### PR TITLE
fix(goal-loop): fail closed governance judge fallback

### DIFF
--- a/lib/dashboard/dashboard_governance_judge.ml
+++ b/lib/dashboard/dashboard_governance_judge.ml
@@ -172,6 +172,7 @@ let degraded_reason_of_error message =
   if
     contains_substring lower "unparseable"
     || contains_substring lower "structurally invalid"
+    || contains_substring lower "invalid json"
     || contains_substring lower "guardrail_state"
   then
     "judge_output_invalid"
@@ -504,7 +505,11 @@ let parse_lenient_governance_json raw_text =
   | `Assoc [("raw", `String raw)] -> (
       match Judge_json_recovery.extract_balanced_object raw with
       | Some block -> (
-          try Ok (Llm_provider.Lenient_json.parse block)
+          try
+            match Llm_provider.Lenient_json.parse block with
+            | `Assoc [ ("raw", `String recovered_raw) ] ->
+                Error (Lenient_fallback recovered_raw)
+            | parsed -> Ok parsed
           with
           | Yojson.Json_error _ -> Error (Lenient_fallback raw)
           | Failure _ -> Error (Lenient_fallback raw))

--- a/lib/dashboard/dashboard_governance_judge.ml
+++ b/lib/dashboard/dashboard_governance_judge.ml
@@ -170,6 +170,12 @@ let contains_substring haystack needle =
 let degraded_reason_of_error message =
   let lower = String.lowercase_ascii message in
   if
+    contains_substring lower "unparseable"
+    || contains_substring lower "structurally invalid"
+    || contains_substring lower "guardrail_state"
+  then
+    "judge_output_invalid"
+  else if
     contains_substring lower "timeout"
     || contains_substring lower "timed out"
     || contains_substring lower "deadline"
@@ -488,18 +494,66 @@ let parse_recommended_action json =
           ])
   | _ -> None
 
+type governance_response_parse_failure =
+  | Lenient_fallback of string
+  | Structural_error of string
+
+let parse_lenient_governance_json raw_text =
+  let parsed = Llm_provider.Lenient_json.parse raw_text in
+  match parsed with
+  | `Assoc [("raw", `String raw)] -> (
+      match Judge_json_recovery.extract_balanced_object raw with
+      | Some block -> (
+          try Ok (Llm_provider.Lenient_json.parse block)
+          with
+          | Yojson.Json_error _ -> Error (Lenient_fallback raw)
+          | Failure _ -> Error (Lenient_fallback raw))
+      | None -> Error (Lenient_fallback raw))
+  | _ -> Ok parsed
+
+let parse_required_guardrail_state json =
+  match json |> member "guardrail_state" with
+  | `Assoc fields ->
+      let required_field name =
+        match List.assoc_opt name fields with
+        | Some value -> Ok value
+        | None -> Error (Printf.sprintf "missing guardrail_state.%s" name)
+      in
+      let requires_human_gate = required_field "requires_human_gate" in
+      let pending_confirm_token = required_field "pending_confirm_token" in
+      let ready_to_execute = required_field "ready_to_execute" in
+      (match requires_human_gate, pending_confirm_token, ready_to_execute with
+       | Ok (`Bool _ as requires_human_gate),
+         Ok ((`String _ | `Null) as pending_confirm_token),
+         Ok (`Bool _ as ready_to_execute) ->
+           Ok
+             (`Assoc
+               [
+                 ("requires_human_gate", requires_human_gate);
+                 ("pending_confirm_token", pending_confirm_token);
+                 ("ready_to_execute", ready_to_execute);
+               ])
+       | Error reason, _, _ | _, Error reason, _ | _, _, Error reason ->
+           Error reason
+       | _ ->
+           Error
+             "invalid guardrail_state: expected requires_human_gate bool, \
+              pending_confirm_token string|null, ready_to_execute bool")
+  | `Null -> Error "missing guardrail_state"
+  | _ -> Error "invalid guardrail_state: expected object"
+
 let parse_item_judgment ~generated_at ~expires_at ~model_used json =
   let target_kind =
     json |> member "kind" |> to_string_option |> Option.value ~default:""
     |> String.lowercase_ascii
   in
   let target_id = json |> member "id" |> to_string_option |> Option.value ~default:"" in
-  if target_kind = "" || target_id = "" then None
+  if target_kind = "" || target_id = "" then Ok None
   else
     let summary =
       normalize_text (json |> member "summary" |> to_string_option |> Option.value ~default:"")
     in
-    if summary = "" then None
+    if summary = "" then Ok None
     else
       let confidence =
         match json |> member "confidence" with
@@ -509,35 +563,65 @@ let parse_item_judgment ~generated_at ~expires_at ~model_used json =
       in
       let evidence_refs = parse_string_list json "evidence_refs" in
       let recommended_action = parse_recommended_action json in
-      let guardrail_state =
-        match json |> member "guardrail_state" with
-        | `Assoc _ as state_json ->
-            Some
-              (`Assoc
-                [
-                  ("requires_human_gate", state_json |> member "requires_human_gate");
-                  ("pending_confirm_token", state_json |> member "pending_confirm_token");
-                  ("ready_to_execute", state_json |> member "ready_to_execute");
-                ])
-        | _ -> None
-      in
-      Some
-        (`Assoc
-          [
-            ("judgment_id", `String (Uuidm.to_string (Uuidm.v4_gen (Random.State.make_self_init ()) ())));
-            ("target_kind", `String target_kind);
-            ("target_id", `String target_id);
-            ("status", `String "active");
-            ("summary", `String summary);
-            ("confidence", `Float confidence);
-            ("generated_at", `String generated_at);
-            ("expires_at", `String expires_at);
-            ("model_used", `String model_used);
-            ("keeper_name", `String keeper_name);
-            ("evidence_refs", `List (List.map (fun item -> `String item) evidence_refs));
-            ("recommended_action", option_to_yojson (fun value -> value) recommended_action);
-            ("guardrail_state", option_to_yojson (fun value -> value) guardrail_state);
-          ])
+      match parse_required_guardrail_state json with
+      | Error reason ->
+          Error
+            (Printf.sprintf "item %s:%s %s" target_kind target_id reason)
+      | Ok guardrail_state ->
+          Ok
+            (Some
+               (`Assoc
+                 [
+                   ( "judgment_id",
+                     `String
+                       (Uuidm.to_string
+                          (Uuidm.v4_gen (Random.State.make_self_init ()) ())) );
+                   ("target_kind", `String target_kind);
+                   ("target_id", `String target_id);
+                   ("status", `String "active");
+                   ("summary", `String summary);
+                   ("confidence", `Float confidence);
+                   ("generated_at", `String generated_at);
+                   ("expires_at", `String expires_at);
+                   ("model_used", `String model_used);
+                   ("keeper_name", `String keeper_name);
+                   ( "evidence_refs",
+                     `List (List.map (fun item -> `String item) evidence_refs) );
+                   ( "recommended_action",
+                     option_to_yojson (fun value -> value) recommended_action );
+                   ("guardrail_state", guardrail_state);
+                 ]))
+
+let parse_governance_response ~raw_text ~generated_at ~expires_at ~model_used =
+  match parse_lenient_governance_json raw_text with
+  | Error _ as error -> error
+  | Ok parsed -> (
+      match parsed with
+      | `Assoc _ -> (
+          match parsed |> member "items" with
+          | `List rows ->
+              let rec loop acc = function
+                | [] -> Ok (List.rev acc)
+                | row :: rest -> (
+                    match
+                      parse_item_judgment ~generated_at ~expires_at ~model_used row
+                    with
+                    | Error reason -> Error (Structural_error reason)
+                    | Ok None -> loop acc rest
+                    | Ok (Some judgment) -> loop (judgment :: acc) rest)
+              in
+              loop [] rows
+          | _ ->
+              Error
+                (Structural_error
+                   "expected top-level items array in judge response"))
+      | _ ->
+          Error
+            (Structural_error
+               "expected top-level JSON object in judge response"))
+
+let parse_governance_response_for_testing =
+  parse_governance_response
 
 let prompt_for_facts facts_json =
   match
@@ -576,91 +660,65 @@ let compute_judgments
   | Ok result -> (
       let response = result.Oas_worker.response in
       try
-        (* LLMs frequently wrap JSON in ```json … ``` markdown fences despite
-           explicit prompt instructions. Lenient_json strips fences, repairs
-           trailing commas, unwraps double-stringified JSON, and falls back
-           to {raw: string} only after all recovery transforms fail. *)
         let raw_text = Oas_response.text_of_response response in
-        let parsed = Llm_provider.Lenient_json.parse raw_text in
-        let parsed =
-          (* #9851: when the model prefixes prose before the JSON object
-             ("Here is the judgment: {...}"), Lenient_json's fence/comma
-             recovery does not strip the prose and falls through to the
-             {raw: <text>} sentinel. Try one more recovery: locate the
-             first balanced {...} block in the raw text and re-parse. *)
-          match parsed with
-          | `Assoc [("raw", `String raw)] -> (
-              match Judge_json_recovery.extract_balanced_object raw with
-              | Some block -> (
-                  try Llm_provider.Lenient_json.parse block
-                  with
-                  | Yojson.Json_error _ -> parsed
-                  | Failure _ -> parsed)
-              | None -> parsed)
-          | _ -> parsed
+        let generated_at = now_iso () in
+        let expires_at = iso_of_unix (Unix.gettimeofday () +. cache_ttl_sec ()) in
+        (* #9880 facet 4: 17% of yesterday's judgment records had
+           [model_used = ""] because OAS transports occasionally
+           return [response.model = ""] (Kimi/Codex CLI silent
+           failure path; CompletionContractViolation
+           retry-exhausted synthetic responses).  An empty
+           [model_used] field destroys attribution downstream
+           (cost rollups, per-model latency p50/p99, daily
+           judgments-by-model breakdown).
+
+           Same shape as keeper-side fix #10083: layered
+           fallback (raw → telemetry canonical_model_id → named
+           sentinel) plus a counter so the operator can see WHICH
+           transport leaked.  Sentinel matches the keeper-side
+           string [unknown_provider] so dashboards can
+           union-aggregate empty-model events across both callers. *)
+        let canonical_model_id =
+          match response.telemetry with
+          | Some { canonical_model_id = Some id; _ } -> Some id
+          | _ -> None
         in
-        match parsed with
-        | `Assoc [("raw", `String raw)] ->
-            (* #9774: surface a preview of the raw text so the next
-               diagnostic pass can see what shape the LLM is producing
-               without having to enable raw provider logging. *)
+        let resolved_model, model_source =
+          resolve_governance_model_used ~raw_model:response.model
+            ~canonical_model_id
+        in
+        begin
+          match model_source with
+          | Response_model -> ()
+          | Telemetry_resolved | Unknown_sentinel ->
+              let source = governance_model_source_to_string model_source in
+              Prometheus.inc_counter
+                governance_response_model_empty_metric
+                ~labels:[ ("source", source) ]
+                ();
+              Log.Governance.warn
+                "compute_judgments: response.model empty → fallback=%s resolved=%s (#9880)"
+                source resolved_model;
+        end;
+        match
+          parse_governance_response ~raw_text ~generated_at ~expires_at
+            ~model_used:resolved_model
+        with
+        | Ok judgments -> Ok (resolved_model, generated_at, expires_at, judgments)
+        | Error (Lenient_fallback raw) ->
             let msg =
-              Judge_diagnostics.record_lenient_fallback ~judge_label:"Governance" raw
+              Judge_diagnostics.record_lenient_fallback
+                ~judge_label:"Governance" raw
             in
             Log.Governance.warn "%s" msg;
             Error msg
-        | _ ->
-            let generated_at = now_iso () in
-            let expires_at = iso_of_unix (Unix.gettimeofday () +. cache_ttl_sec ()) in
-            let items =
-              match parsed |> member "items" with
-              | `List rows -> rows
-              | _ -> []
+        | Error (Structural_error reason) ->
+            let msg =
+              Judge_diagnostics.record_unparseable_response
+                ~judge_label:"Governance" ~reason raw_text
             in
-            (* #9880 facet 4: 17% of yesterday's judgment records had
-               [model_used = ""] because OAS transports occasionally
-               return [response.model = ""] (Kimi/Codex CLI silent
-               failure path; CompletionContractViolation
-               retry-exhausted synthetic responses).  An empty
-               [model_used] field destroys attribution downstream
-               (cost rollups, per-model latency p50/p99, daily
-               judgments-by-model breakdown).
-
-               Same shape as keeper-side fix #10083: layered
-               fallback (raw → telemetry canonical_model_id → named
-               sentinel) plus a counter so the operator can see
-               WHICH transport leaked.  Sentinel matches the
-               keeper-side string [unknown_provider] so dashboards
-               can union-aggregate empty-model events across both
-               callers. *)
-            let canonical_model_id =
-              match response.telemetry with
-              | Some { canonical_model_id = Some id; _ } -> Some id
-              | _ -> None
-            in
-            let resolved_model, model_source =
-              resolve_governance_model_used ~raw_model:response.model ~canonical_model_id
-            in
-            begin
-              match model_source with
-              | Response_model -> ()
-              | Telemetry_resolved | Unknown_sentinel ->
-                let source = governance_model_source_to_string model_source in
-                Prometheus.inc_counter
-                  governance_response_model_empty_metric
-                  ~labels:[ ("source", source) ]
-                  ();
-                Log.Governance.warn
-                  "compute_judgments: response.model empty → fallback=%s resolved=%s (#9880)"
-                  source resolved_model;
-            end;
-            let judgments =
-              items
-              |> List.filter_map
-                   (parse_item_judgment ~generated_at ~expires_at
-                      ~model_used:resolved_model)
-            in
-            Ok (resolved_model, generated_at, expires_at, judgments)
+            Log.Governance.warn "%s" msg;
+            Error msg
       with
       | Yojson.Json_error msg ->
           Error (Printf.sprintf "Governance judge returned invalid JSON: %s" msg)

--- a/lib/dashboard/dashboard_governance_judge.mli
+++ b/lib/dashboard/dashboard_governance_judge.mli
@@ -141,6 +141,25 @@ val resolve_governance_model_used :
     [unknown_provider] sentinel.  Returned tag is the
     classification that fired. *)
 
+type governance_response_parse_failure =
+  | Lenient_fallback of string
+  | Structural_error of string
+(** Failure class for governance judge response parsing.
+    [Lenient_fallback raw] means all deterministic JSON recovery
+    failed. [Structural_error reason] means JSON parsed but
+    violated the judge output contract. *)
+
+val parse_governance_response_for_testing :
+  raw_text:string ->
+  generated_at:string ->
+  expires_at:string ->
+  model_used:string ->
+  (Yojson.Safe.t list, governance_response_parse_failure) result
+(** Parses and validates a governance judge response without
+    mutating metrics or daemon state.  Exposed so regression
+    tests can prove malformed [guardrail_state] output fails
+    closed instead of silently producing a distorted judgment. *)
+
 (** {1 Daemon identity} *)
 
 val keeper_name : string

--- a/lib/dashboard/judge_diagnostics.ml
+++ b/lib/dashboard/judge_diagnostics.ml
@@ -23,6 +23,14 @@ let format_lenient_fallback ~judge_label raw =
     (String.length raw)
     (truncate_with_marker raw)
 
+let format_unparseable_response ~judge_label ~reason raw =
+  Printf.sprintf
+    "%s judge returned structurally invalid response (%s; %d chars; preview: %s)"
+    judge_label
+    reason
+    (String.length raw)
+    (truncate_with_marker raw)
+
 let record_lenient_fallback ~judge_label raw =
   let labels = [("judge", String.lowercase_ascii judge_label)] in
   Prometheus.inc_counter
@@ -34,6 +42,14 @@ let record_lenient_fallback ~judge_label raw =
     ~labels
     ();
   format_lenient_fallback ~judge_label raw
+
+let record_unparseable_response ~judge_label ~reason raw =
+  let labels = [("judge", String.lowercase_ascii judge_label)] in
+  Prometheus.inc_counter
+    Prometheus.metric_governance_judge_unparseable
+    ~labels
+    ();
+  format_unparseable_response ~judge_label ~reason raw
 
 let int_metric_value metric_name ~labels =
   int_of_float (Prometheus.metric_value_or_zero metric_name ~labels ())

--- a/lib/dashboard/judge_diagnostics.mli
+++ b/lib/dashboard/judge_diagnostics.mli
@@ -10,9 +10,19 @@ val format_lenient_fallback : judge_label:string -> string -> string
     output is consumed both as the warn log payload and as the [Error]
     returned upstream. *)
 
+val format_unparseable_response :
+  judge_label:string -> reason:string -> string -> string
+(** Format a structurally-invalid judge response diagnostic. This path is
+    for JSON that parsed but violated the judge output contract. *)
+
 val record_lenient_fallback : judge_label:string -> string -> string
 (** Increment the judge fallback metrics and return
     {!format_lenient_fallback}. *)
+
+val record_unparseable_response :
+  judge_label:string -> reason:string -> string -> string
+(** Increment the judge unparseable metric and return
+    {!format_unparseable_response}. *)
 
 val lenient_fallback_metrics_json : judge_label:string -> Yojson.Safe.t
 (** Current Prometheus counter values for a judge label, formatted for

--- a/test/test_dashboard_governance.ml
+++ b/test/test_dashboard_governance.ml
@@ -23,6 +23,18 @@ let cleanup_dir dir =
   in
   rm dir
 
+let string_contains s sub =
+  let len_s = String.length s in
+  let len_sub = String.length sub in
+  if len_sub > len_s then false
+  else
+    let rec loop i =
+      if i + len_sub > len_s then false
+      else if String.sub s i len_sub = sub then true
+      else loop (i + 1)
+    in
+    loop 0
+
 let iso8601_of_unix ts =
   Masc_domain.iso8601_of_unix_seconds ts
 
@@ -362,6 +374,131 @@ let test_dashboard_surfaces_compute_telemetry () =
       check string "dashboard exposes compute reason" "timeout"
         (judge |> member "last_compute_reason" |> to_string))
 
+let test_parse_governance_response_requires_guardrail_state () =
+  let raw =
+    Yojson.Safe.to_string
+      (`Assoc
+        [
+          ( "items",
+            `List
+              [
+                `Assoc
+                  [
+                    ("kind", `String "agent_health");
+                    ("id", `String "dreamer");
+                    ("summary", `String "dreamer is stuck");
+                    ("confidence", `Float 0.9);
+                    ("evidence_refs", `List []);
+                  ];
+              ] );
+        ])
+  in
+  match
+    Lib.Dashboard_governance_judge.parse_governance_response_for_testing
+      ~raw_text:raw ~generated_at:"2026-05-06T00:00:00Z"
+      ~expires_at:"2026-05-06T00:10:00Z" ~model_used:"glm:test"
+  with
+  | Error (Lib.Dashboard_governance_judge.Structural_error reason) ->
+      check bool "reason names guardrail_state" true
+        (string_contains reason "missing guardrail_state")
+  | Error (Lib.Dashboard_governance_judge.Lenient_fallback _) ->
+      fail "expected structural error, got lenient fallback"
+  | Ok _ -> fail "missing guardrail_state must fail closed"
+
+let test_parse_governance_response_preserves_guardrail_state () =
+  let raw =
+    Yojson.Safe.to_string
+      (`Assoc
+        [
+          ( "items",
+            `List
+              [
+                `Assoc
+                  [
+                    ("kind", `String "agent_health");
+                    ("id", `String "dreamer");
+                    ("summary", `String "dreamer is stuck");
+                    ("confidence", `Float 0.9);
+                    ("evidence_refs", `List [ `String "agent:dreamer" ]);
+                    ( "guardrail_state",
+                      `Assoc
+                        [
+                          ("requires_human_gate", `Bool true);
+                          ("pending_confirm_token", `String "confirm-1");
+                          ("ready_to_execute", `Bool false);
+                        ] );
+                  ];
+              ] );
+        ])
+  in
+  match
+    Lib.Dashboard_governance_judge.parse_governance_response_for_testing
+      ~raw_text:raw ~generated_at:"2026-05-06T00:00:00Z"
+      ~expires_at:"2026-05-06T00:10:00Z" ~model_used:"glm:test"
+  with
+  | Error _ -> fail "valid guardrail_state should parse"
+  | Ok [ judgment ] ->
+      let open Yojson.Safe.Util in
+      let guardrail = judgment |> member "guardrail_state" in
+      check bool "requires_human_gate preserved" true
+        (guardrail |> member "requires_human_gate" |> to_bool);
+      check string "pending_confirm_token preserved" "confirm-1"
+        (guardrail |> member "pending_confirm_token" |> to_string);
+      check bool "ready_to_execute preserved" false
+        (guardrail |> member "ready_to_execute" |> to_bool)
+  | Ok rows -> fail (Printf.sprintf "expected one row, got %d" (List.length rows))
+
+let test_parse_governance_response_requires_guardrail_fields () =
+  let raw =
+    Yojson.Safe.to_string
+      (`Assoc
+        [
+          ( "items",
+            `List
+              [
+                `Assoc
+                  [
+                    ("kind", `String "agent_health");
+                    ("id", `String "dreamer");
+                    ("summary", `String "dreamer is stuck");
+                    ("confidence", `Float 0.9);
+                    ("evidence_refs", `List [ `String "agent:dreamer" ]);
+                    ( "guardrail_state",
+                      `Assoc
+                        [
+                          ("requires_human_gate", `Bool true);
+                          ("ready_to_execute", `Bool false);
+                        ] );
+                  ];
+              ] );
+        ])
+  in
+  match
+    Lib.Dashboard_governance_judge.parse_governance_response_for_testing
+      ~raw_text:raw ~generated_at:"2026-05-06T00:00:00Z"
+      ~expires_at:"2026-05-06T00:10:00Z" ~model_used:"glm:test"
+  with
+  | Error (Lib.Dashboard_governance_judge.Structural_error reason) ->
+      check bool "reason names missing field" true
+        (string_contains reason "missing guardrail_state.pending_confirm_token")
+  | Error (Lib.Dashboard_governance_judge.Lenient_fallback _) ->
+      fail "expected structural error, got lenient fallback"
+  | Ok _ -> fail "incomplete guardrail_state must fail closed"
+
+let test_parse_governance_response_requires_items_array () =
+  let raw = "{\"judgments\": []}" in
+  match
+    Lib.Dashboard_governance_judge.parse_governance_response_for_testing
+      ~raw_text:raw ~generated_at:"2026-05-06T00:00:00Z"
+      ~expires_at:"2026-05-06T00:10:00Z" ~model_used:"glm:test"
+  with
+  | Error (Lib.Dashboard_governance_judge.Structural_error reason) ->
+      check bool "reason names items array" true
+        (string_contains reason "items array")
+  | Error (Lib.Dashboard_governance_judge.Lenient_fallback _) ->
+      fail "expected structural error, got lenient fallback"
+  | Ok _ -> fail "missing items array must fail closed"
+
 let test_refresh_failure_keeps_fresh_cache_online () =
   let dir = test_dir () in
   Fun.protect
@@ -430,6 +567,34 @@ let test_refresh_failure_marks_expired_cache_offline () =
         status.cached_judgments_visible;
       check (option string) "last_error recorded"
         (Some "Execution timed out after 60.0s") status.last_error)
+
+let test_refresh_failure_marks_judge_output_invalid () =
+  let dir = test_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir dir)
+    (fun () ->
+      Eio_main.run @@ fun env ->
+      with_test_fs env @@ fun () ->
+      let st = Lib.Dashboard_governance_judge.get_state dir in
+      let now = Unix.gettimeofday () in
+      let message =
+        "Governance judge returned structurally invalid response \
+         (item agent_health:dreamer missing guardrail_state)"
+      in
+      Lib.Dashboard_governance_judge.with_lock st (fun () ->
+        st.refreshing <- true;
+        st.judge_online <- false;
+        st.last_error <- None;
+        Lib.Dashboard_governance_judge.mark_refresh_failure
+          ~now_ts:now st ~message);
+      let status =
+        Lib.Dashboard_governance_judge.runtime_status_at ~now_ts:now dir
+      in
+      check string "runtime status is offline" "offline" status.status;
+      check (option string) "degraded_reason is judge_output_invalid"
+        (Some "judge_output_invalid") status.degraded_reason;
+      check (option string) "last_error recorded" (Some message)
+        status.last_error)
 
 let test_refresh_once_skips_fresh_cached_result () =
   let dir = test_dir () in
@@ -773,10 +938,20 @@ let () =
             test_runtime_timestamps_fallback_to_unix_values;
           test_case "dashboard surfaces compute telemetry" `Quick
             test_dashboard_surfaces_compute_telemetry;
+          test_case "parser requires guardrail_state" `Quick
+            test_parse_governance_response_requires_guardrail_state;
+          test_case "parser preserves guardrail_state" `Quick
+            test_parse_governance_response_preserves_guardrail_state;
+          test_case "parser requires guardrail fields" `Quick
+            test_parse_governance_response_requires_guardrail_fields;
+          test_case "parser requires items array" `Quick
+            test_parse_governance_response_requires_items_array;
           test_case "refresh failure keeps fresh cache online" `Quick
             test_refresh_failure_keeps_fresh_cache_online;
           test_case "refresh failure marks expired cache offline" `Quick
             test_refresh_failure_marks_expired_cache_offline;
+          test_case "refresh failure marks judge output invalid" `Quick
+            test_refresh_failure_marks_judge_output_invalid;
           test_case "refresh_once skips fresh cached result" `Quick
             test_refresh_once_skips_fresh_cached_result;
           test_case "backoff runtime status is structured" `Quick

--- a/test/test_dashboard_governance.ml
+++ b/test/test_dashboard_governance.ml
@@ -499,6 +499,20 @@ let test_parse_governance_response_requires_items_array () =
       fail "expected structural error, got lenient fallback"
   | Ok _ -> fail "missing items array must fail closed"
 
+let test_parse_governance_response_rejects_unparseable_recovered_block () =
+  let raw = "prefix {\"items\": [} suffix" in
+  match
+    Lib.Dashboard_governance_judge.parse_governance_response_for_testing
+      ~raw_text:raw ~generated_at:"2026-05-06T00:00:00Z"
+      ~expires_at:"2026-05-06T00:10:00Z" ~model_used:"glm:test"
+  with
+  | Error (Lib.Dashboard_governance_judge.Lenient_fallback recovered) ->
+      check bool "fallback keeps recovered fragment" true
+        (string_contains recovered "items")
+  | Error (Lib.Dashboard_governance_judge.Structural_error reason) ->
+      fail ("expected lenient fallback, got structural error: " ^ reason)
+  | Ok _ -> fail "unparseable recovered JSON must stay lenient fallback"
+
 let test_refresh_failure_keeps_fresh_cache_online () =
   let dir = test_dir () in
   Fun.protect
@@ -581,6 +595,31 @@ let test_refresh_failure_marks_judge_output_invalid () =
         "Governance judge returned structurally invalid response \
          (item agent_health:dreamer missing guardrail_state)"
       in
+      Lib.Dashboard_governance_judge.with_lock st (fun () ->
+        st.refreshing <- true;
+        st.judge_online <- false;
+        st.last_error <- None;
+        Lib.Dashboard_governance_judge.mark_refresh_failure
+          ~now_ts:now st ~message);
+      let status =
+        Lib.Dashboard_governance_judge.runtime_status_at ~now_ts:now dir
+      in
+      check string "runtime status is offline" "offline" status.status;
+      check (option string) "degraded_reason is judge_output_invalid"
+        (Some "judge_output_invalid") status.degraded_reason;
+      check (option string) "last_error recorded" (Some message)
+        status.last_error)
+
+let test_refresh_failure_marks_invalid_json_as_judge_output_invalid () =
+  let dir = test_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir dir)
+    (fun () ->
+      Eio_main.run @@ fun env ->
+      with_test_fs env @@ fun () ->
+      let st = Lib.Dashboard_governance_judge.get_state dir in
+      let now = Unix.gettimeofday () in
+      let message = "Governance judge returned invalid JSON: malformed items" in
       Lib.Dashboard_governance_judge.with_lock st (fun () ->
         st.refreshing <- true;
         st.judge_online <- false;
@@ -946,12 +985,16 @@ let () =
             test_parse_governance_response_requires_guardrail_fields;
           test_case "parser requires items array" `Quick
             test_parse_governance_response_requires_items_array;
+          test_case "parser rejects unparseable recovered block" `Quick
+            test_parse_governance_response_rejects_unparseable_recovered_block;
           test_case "refresh failure keeps fresh cache online" `Quick
             test_refresh_failure_keeps_fresh_cache_online;
           test_case "refresh failure marks expired cache offline" `Quick
             test_refresh_failure_marks_expired_cache_offline;
           test_case "refresh failure marks judge output invalid" `Quick
             test_refresh_failure_marks_judge_output_invalid;
+          test_case "refresh failure marks invalid JSON invalid" `Quick
+            test_refresh_failure_marks_invalid_json_as_judge_output_invalid;
           test_case "refresh_once skips fresh cached result" `Quick
             test_refresh_once_skips_fresh_cached_result;
           test_case "backoff runtime status is structured" `Quick

--- a/test/test_judge_diagnostics.ml
+++ b/test/test_judge_diagnostics.ml
@@ -51,6 +51,26 @@ let test_format_lenient_fallback_truncates_huge_raw () =
   check bool "preview is bounded" true
     (String.length out < 1500)
 
+let test_format_unparseable_response_includes_reason () =
+  let raw = "{\"items\":[{\"guardrail_state\":null}]}" in
+  let out =
+    Judge_diagnostics.format_unparseable_response ~judge_label:"Governance"
+      ~reason:"item agent_health:k1 missing guardrail_state"
+      raw
+  in
+  let contains needle =
+    try
+      let re = Re.Pcre.re (Re.Pcre.quote needle) |> Re.compile in
+      ignore (Re.exec re out); true
+    with Not_found -> false
+  in
+  check bool "names structural invalid class" true
+    (contains "structurally invalid response");
+  check bool "includes reason" true
+    (contains "missing guardrail_state");
+  check bool "includes raw preview" true
+    (contains raw)
+
 let test_record_lenient_fallback_increments_metrics () =
   let raw = "not-json" in
   let labels = [("judge", "governance")] in
@@ -84,6 +104,45 @@ let test_record_lenient_fallback_increments_metrics () =
        ());
   check (float 0.0001) "fallback counter increments"
     (fallback_before +. 1.0)
+    (Prometheus.metric_value_or_zero
+       Prometheus.metric_governance_lenient_json_fallback_hit
+       ~labels
+       ())
+
+let test_record_unparseable_response_increments_unparseable_only () =
+  let raw = "{\"items\":[{\"guardrail_state\":null}]}" in
+  let labels = [("judge", "governance")] in
+  let unparseable_before =
+    Prometheus.metric_value_or_zero
+      Prometheus.metric_governance_judge_unparseable
+      ~labels
+      ()
+  in
+  let fallback_before =
+    Prometheus.metric_value_or_zero
+      Prometheus.metric_governance_lenient_json_fallback_hit
+      ~labels
+      ()
+  in
+  let out =
+    Judge_diagnostics.record_unparseable_response
+      ~judge_label:"Governance"
+      ~reason:"item agent_health:k1 missing guardrail_state"
+      raw
+  in
+  check bool "returns structural diagnostic" true
+    (try
+       let re = Re.Pcre.re "structurally invalid response" |> Re.compile in
+       ignore (Re.exec re out); true
+     with Not_found -> false);
+  check (float 0.0001) "unparseable counter increments"
+    (unparseable_before +. 1.0)
+    (Prometheus.metric_value_or_zero
+       Prometheus.metric_governance_judge_unparseable
+       ~labels
+       ());
+  check (float 0.0001) "lenient fallback counter unchanged"
+    fallback_before
     (Prometheus.metric_value_or_zero
        Prometheus.metric_governance_lenient_json_fallback_hit
        ~labels
@@ -139,8 +198,12 @@ let () =
             test_format_lenient_fallback_includes_label;
           test_case "preview is bounded for huge raw" `Quick
             test_format_lenient_fallback_truncates_huge_raw;
+          test_case "structural invalid includes reason" `Quick
+            test_format_unparseable_response_includes_reason;
           test_case "record increments metrics" `Quick
             test_record_lenient_fallback_increments_metrics;
+          test_case "structural invalid increments unparseable only" `Quick
+            test_record_unparseable_response_increments_unparseable_only;
           test_case "metrics JSON reads counters" `Quick
             test_lenient_fallback_metrics_json_reads_counters;
         ] );


### PR DESCRIPTION
## Summary
- Fail closed when governance judge output is structurally invalid instead of falling back leniently.
- Require top-level `items` and complete `guardrail_state` fields for dashboard governance JSON.
- Record structural-invalid output as `governance_judge_unparseable` / `judge_output_invalid` without incrementing lenient fallback counters.
- Keep lenient JSON recovery for recoverable JSON envelopes only.

Closes #13688

## Verification
- `git diff --check origin/main...HEAD`
- `scripts/check-oas-pin.sh --local-only`
- `env MASC_OPAM_LOCK=0 scripts/dune-local.sh build test/test_dashboard_governance.exe test/test_judge_diagnostics.exe test/test_judge_json_recovery.exe test/test_governance_response_model_empty_9880.exe test/test_tool_coord_coverage.exe`
- `./_build/default/test/test_dashboard_governance.exe` (22/22)
- `./_build/default/test/test_judge_diagnostics.exe` (9/9)
- `./_build/default/test/test_judge_json_recovery.exe` (6/6)
- `./_build/default/test/test_governance_response_model_empty_9880.exe` (9/9)
- `./_build/default/test/test_tool_coord_coverage.exe` (37/37)

## Review Notes
- Copilot review threads were already resolved before this rebase.
- Remaining red checks are expected agent policy until a human adds `human-approved-ready`.