### PR TITLE
fix: repair keeper source hardening guard

### DIFF
--- a/lib/keeper/keeper_execution_receipt.ml
+++ b/lib/keeper/keeper_execution_receipt.ml
@@ -715,6 +715,7 @@ let stale_terminal_reason_code = function
   | Some (Keeper_registry.Stale_turn_timeout _) -> "stale_turn_timeout"
   | Some (Keeper_registry.Stale_termination_storm _) ->
       "stale_termination_storm"
+  | Some (Keeper_registry.Stale_fleet_batch _) -> "stale_fleet_batch"
   | Some (Keeper_registry.Heartbeat_consecutive_failures _) ->
       "heartbeat_failures"
   | Some (Keeper_registry.Turn_consecutive_failures _) -> "turn_failures"

--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -670,4 +670,4 @@ let handle_keeper_msg ?on_text_delta ctx args : tool_result =
               in
               (true, Yojson.Safe.to_string reply_json)
 
-))))))
+)))))

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -1114,10 +1114,10 @@ let test_keeper_required_tool_contracts () =
       ~anchor:tool_choice_anchor
       "if computed_surface.required_tool_names <> []"
   in
-  let any_tool_after =
+  let preferred_required_after =
     file_pattern_position_after "lib/keeper/keeper_run_tools.ml"
       ~anchor:tool_choice_anchor
-      "then Some Agent_sdk.Types.Any"
+      "preferred_tool_choice_for_required_tool_names"
   in
   let last_turn_after =
     file_pattern_position_after "lib/keeper/keeper_run_tools.ml"
@@ -1125,9 +1125,9 @@ let test_keeper_required_tool_contracts () =
       "else if computed_surface.is_last_turn"
   in
   check bool "required_tools force tool_choice before last-turn relaxation" true
-    (match required_first, any_tool_after, last_turn_after with
-     | Some required_pos, Some any_pos, Some last_turn_pos ->
-         required_pos < any_pos && any_pos < last_turn_pos
+    (match required_first, preferred_required_after, last_turn_after with
+     | Some required_pos, Some preferred_pos, Some last_turn_pos ->
+         required_pos < preferred_pos && preferred_pos < last_turn_pos
      | _ -> false);
   check bool "last-turn relaxation no longer bypasses required_tools" true
     (file_not_contains_pattern "lib/keeper/keeper_run_tools.ml"


### PR DESCRIPTION
## Summary
- update the keeper required-tool source guard to assert the preferred required-tool choice helper instead of the removed Any fallback
- carry current-main compile unblocks for keeper_turn.ml and Stale_fleet_batch receipt reason codes so the source guard binary can run on current main

Closes #13791.

## Validation
- git diff --check
- env DUNE_BUILD_DIR=_build_codex_ci_source_13791 dune build --root . --display short -j 1 test/test_ci_hardening_source.exe
- ./_build_codex_ci_source_13791/default/test/test_ci_hardening_source.exe (53 tests)