### PR TITLE
fix(main): restore keeper compile gates

### DIFF
--- a/lib/keeper/keeper_execution_receipt.ml
+++ b/lib/keeper/keeper_execution_receipt.ml
@@ -713,6 +713,7 @@ let stale_terminal_reason_code = function
   | Some (Keeper_registry.Tool_required_unsatisfied { code; _ }) -> code
   | Some (Keeper_registry.Oas_timeout_budget_loop _) -> "oas_timeout_budget"
   | Some (Keeper_registry.Stale_turn_timeout _) -> "stale_turn_timeout"
+  | Some (Keeper_registry.Stale_fleet_batch _) -> "stale_fleet_batch"
   | Some (Keeper_registry.Stale_termination_storm _) ->
       "stale_termination_storm"
   | Some (Keeper_registry.Heartbeat_consecutive_failures _) ->

--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -190,7 +190,7 @@ let handle_keeper_msg ?on_text_delta ctx args : tool_result =
       |> List.filter (fun name -> name <> "")
       |> Keeper_types.dedupe_keep_order
     in
-    match keeper_msg_timeout_override args with
+    (match keeper_msg_timeout_override args with
     | Error e -> (false, e)
     | Ok keeper_msg_oas_timeout_s ->
     (match reject_legacy_model_args ~tool_name:"masc_keeper_msg" args with


### PR DESCRIPTION
## What changed

- Restores the missing opening parenthesis around `keeper_msg_timeout_override` in `keeper_turn.ml` after the merged #13692 diff removed it but left the closing delimiter.
- Adds the missing `Stale_fleet_batch` arm to `stale_terminal_reason_code` so the stale-receipt terminal reason classifier remains exhaustive.

## Why

Current `origin/main` fails focused OCaml compilation before downstream dashboard/metrics tests can run. These are compile-gate fixes only; no behavior is widened beyond preserving the existing terminal reason label for stale fleet batches.

## Validation

- `dune build --root . test/test_dashboard_keeper_cost_aggregates.exe`
- `./_build/default/test/test_dashboard_keeper_cost_aggregates.exe`
- `git diff --check`