### PR TITLE
fix(keeper): attest PR review identity

### DIFF
--- a/lib/keeper/keeper_execution_receipt.ml
+++ b/lib/keeper/keeper_execution_receipt.ml
@@ -718,6 +718,7 @@ let stale_terminal_reason_code = function
   | Some (Keeper_registry.Heartbeat_consecutive_failures _) ->
       "heartbeat_failures"
   | Some (Keeper_registry.Turn_consecutive_failures _) -> "turn_failures"
+  | Some (Keeper_registry.Stale_fleet_batch _) -> "stale_fleet_batch"
   | Some (Keeper_registry.Ambiguous_partial_commit _) ->
       "ambiguous_partial_commit"
   | Some Keeper_registry.Fiber_unresolved -> "fiber_unresolved"

--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -1035,6 +1035,8 @@ type pr_review_action_metric_event = {
   comment_id : int option;
   success : bool;
   route_via : string option;
+  credential : Yojson.Safe.t option;
+  identity_attestation : Yojson.Safe.t option;
 }
 
 type pr_work_action_metric_event = {
@@ -1217,6 +1219,11 @@ let gh_pr_review_action_of_command command =
       Some ("COMMENT", int_of_string_opt pr_number)
   | _ -> None
 
+let assoc_json_opt key json =
+  match assoc_field key json with
+  | Some (`Assoc _ as value) -> Some value
+  | _ -> None
+
 let output_success ~transport_success = function
   | Some json ->
       (match Safe_ops.json_bool_opt "ok" json with
@@ -1255,6 +1262,10 @@ let pr_review_action_metric_event_of_tool_io
       let success =
         output_success ~transport_success output_json
       in
+      let credential = Option.bind output_json (assoc_json_opt "credential") in
+      let identity_attestation =
+        Option.bind output_json (assoc_json_opt "identity_attestation")
+      in
       Option.map
         (fun action ->
            {
@@ -1270,6 +1281,8 @@ let pr_review_action_metric_event_of_tool_io
              comment_id = None;
              success;
              route_via;
+             credential;
+             identity_attestation;
            })
         (Option.bind action normalize_pr_review_action)
   | "keeper_pr_review_reply" ->
@@ -1280,6 +1293,10 @@ let pr_review_action_metric_event_of_tool_io
       in
       let success =
         output_success ~transport_success output_json
+      in
+      let credential = Option.bind output_json (assoc_json_opt "credential") in
+      let identity_attestation =
+        Option.bind output_json (assoc_json_opt "identity_attestation")
       in
       Some
         {
@@ -1300,6 +1317,8 @@ let pr_review_action_metric_event_of_tool_io
               (json_int_opt "comment_id" input);
           success;
           route_via;
+          credential;
+          identity_attestation;
         }
   | "keeper_shell" ->
       let output_json = output_json_opt ~surface:"pr_review_action" output_text in
@@ -1319,6 +1338,8 @@ let pr_review_action_metric_event_of_tool_io
              comment_id = None;
              success;
              route_via;
+             credential = None;
+             identity_attestation = None;
            })
   | _ -> None
 
@@ -1509,6 +1530,18 @@ let append_pr_review_action_metric
         | None -> []
         | Some via -> [("via", `String via); ("route_via", `String via)]
       in
+      let identity_fields =
+        []
+        |> (fun fields ->
+             match event.credential with
+             | None -> fields
+             | Some credential -> ("credential", credential) :: fields)
+        |> (fun fields ->
+             match event.identity_attestation with
+             | None -> fields
+             | Some attestation -> ("identity_attestation", attestation) :: fields)
+        |> List.rev
+      in
       let snapshot =
         `Assoc
           ([
@@ -1530,7 +1563,8 @@ let append_pr_review_action_metric
              ("comment_id", Json_util.int_opt_to_json event.comment_id);
              ("duration_ms", `Float duration_ms);
            ]
-           @ route_fields)
+           @ route_fields
+           @ identity_fields)
       in
       Dated_jsonl.append store (Inference_utils.sanitize_json_utf8 snapshot)
 

--- a/lib/keeper/keeper_hooks_oas.mli
+++ b/lib/keeper/keeper_hooks_oas.mli
@@ -308,6 +308,8 @@ type pr_review_action_metric_event = {
   comment_id : int option;
   success : bool;
   route_via : string option;
+  credential : Yojson.Safe.t option;
+  identity_attestation : Yojson.Safe.t option;
 }
 (** Parsed PR-review action telemetry derived from keeper tool I/O. *)
 

--- a/lib/keeper/keeper_tool_pr_review.ml
+++ b/lib/keeper/keeper_tool_pr_review.ml
@@ -66,6 +66,76 @@ let route_fields ?via (meta : keeper_meta) =
         "route_via", `String route_via;
       ]
 
+let credential_state_json = function
+  | Repo_manager_types.Unmaterialized ->
+      `Assoc [ "state", `String "unmaterialized" ]
+  | Repo_manager_types.Materialized { last_verified_at } ->
+      `Assoc
+        [
+          "state", `String "materialized";
+          "last_verified_at", `Intlit (Int64.to_string last_verified_at);
+        ]
+  | Repo_manager_types.Stale { reason } ->
+      `Assoc [ "state", `String "stale"; "reason", `String reason ]
+
+let binding_json (binding : Keeper_gh_env.keeper_binding) ~state =
+  `Assoc
+    [
+      "effective_github_identity", `String binding.effective_github_identity;
+      ( "credential_scope",
+        `String
+          (Keeper_gh_env.credential_scope_to_string binding.credential_scope) );
+      "git_identity_mode", `String binding.git_identity_mode;
+      "credential_state", credential_state_json state;
+    ]
+
+let identity_attestation_fields ~(config : Coord.config) (meta : keeper_meta) =
+  let base_fields =
+    [
+      "schema", `String "keeper.pr_review_identity_attestation.v1";
+      "keeper", `String meta.name;
+      "agent_name", `String meta.agent_name;
+      ( "trace_id",
+        `String (Keeper_id.Trace_id.to_string meta.runtime.trace_id) );
+      "source", `String "keeper_pr_review_tool";
+    ]
+  in
+  match Keeper_gh_env.keeper_binding config ~keeper_name:meta.name with
+  | Error reason ->
+      [
+        ( "identity_attestation",
+          `Assoc
+            (base_fields
+             @ [
+                 "credential_binding_ok", `Bool false;
+                 "error", `String "credential_binding_failed";
+                 "reason", `String reason;
+               ]) );
+      ]
+  | Ok binding ->
+      let state =
+        Credential_materializer.verify_state
+          ~gh_config_dir:binding.gh_config_dir
+      in
+      let credential = binding_json binding ~state in
+      [
+        "credential", credential;
+        ( "identity_attestation",
+          `Assoc
+            (base_fields
+             @ [
+                 "credential_binding_ok", `Bool true;
+                 ( "effective_github_identity",
+                   `String binding.effective_github_identity );
+                 ( "credential_scope",
+                   `String
+                     (Keeper_gh_env.credential_scope_to_string
+                        binding.credential_scope) );
+                 "git_identity_mode", `String binding.git_identity_mode;
+                 "credential_state", credential_state_json state;
+               ]) );
+      ]
+
 (* Both "pr_number" and "number" are accepted for schema-drift compat. *)
 let pr_number_of_args args =
   let from_pr = Safe_ops.json_int ~default:0 "pr_number" args in
@@ -330,7 +400,9 @@ let handle_keeper_pr_review_read
              ; "repo", `String repo_slug
              ; "execution_via", `String meta_result.via
              ; "hint", `String "PR may have been closed/deleted or the number is wrong. Use keeper_pr_list (or `gh pr list`) to see open PRs before retrying."
-             ] @ route_fields ~via:meta_result.via meta))
+             ]
+             @ route_fields ~via:meta_result.via meta
+             @ identity_attestation_fields ~config meta))
     else
       Yojson.Safe.to_string
         (`Assoc
@@ -342,7 +414,9 @@ let handle_keeper_pr_review_read
              ; "diff", `String diff_result.output
              ; "diff_truncated", `Bool diff_truncated
              ; "diff_status", `Bool (status_ok diff_result.status)
-             ] @ route_fields ~via:meta_result.via meta))
+             ]
+             @ route_fields ~via:meta_result.via meta
+             @ identity_attestation_fields ~config meta))
 ;;
 
 let handle_keeper_pr_review_comment
@@ -410,7 +484,9 @@ let handle_keeper_pr_review_comment
                       ; "event", `String (pr_review_event_to_string event)
                       ; "keeper", `String meta.name
                       ; "preflight", preflight
-                      ] @ route_fields ~via:preflight_via meta))
+                      ]
+                      @ route_fields ~via:preflight_via meta
+                      @ identity_attestation_fields ~config meta))
              | Ok approve_preflight_json ->
                  (* Use gh pr review to create a review *)
                  let cmd =
@@ -444,6 +520,7 @@ let handle_keeper_pr_review_comment
                       ; "keeper", `String meta.name
                       ]
                       @ route_fields ~via:result.via meta
+                      @ identity_attestation_fields ~config meta
                       @
                       match approve_preflight_json with
                       | Some json -> [ "preflight", json ]
@@ -501,5 +578,7 @@ let handle_keeper_pr_review_reply
                ; "comment_id", `Int comment_id
                ; "output", `String result.output
                ; "keeper", `String meta.name
-               ] @ route_fields ~via:result.via meta))
+               ]
+               @ route_fields ~via:result.via meta
+               @ identity_attestation_fields ~config meta))
 ;;

--- a/lib/keeper/keeper_tool_pr_review.ml
+++ b/lib/keeper/keeper_tool_pr_review.ml
@@ -66,19 +66,7 @@ let route_fields ?via (meta : keeper_meta) =
         "route_via", `String route_via;
       ]
 
-let credential_state_json = function
-  | Repo_manager_types.Unmaterialized ->
-      `Assoc [ "state", `String "unmaterialized" ]
-  | Repo_manager_types.Materialized { last_verified_at } ->
-      `Assoc
-        [
-          "state", `String "materialized";
-          "last_verified_at", `Intlit (Int64.to_string last_verified_at);
-        ]
-  | Repo_manager_types.Stale { reason } ->
-      `Assoc [ "state", `String "stale"; "reason", `String reason ]
-
-let binding_json (binding : Keeper_gh_env.keeper_binding) ~state =
+let binding_json (binding : Keeper_gh_env.keeper_binding) =
   `Assoc
     [
       "effective_github_identity", `String binding.effective_github_identity;
@@ -86,7 +74,6 @@ let binding_json (binding : Keeper_gh_env.keeper_binding) ~state =
         `String
           (Keeper_gh_env.credential_scope_to_string binding.credential_scope) );
       "git_identity_mode", `String binding.git_identity_mode;
-      "credential_state", credential_state_json state;
     ]
 
 let identity_attestation_fields ~(config : Coord.config) (meta : keeper_meta) =
@@ -113,11 +100,7 @@ let identity_attestation_fields ~(config : Coord.config) (meta : keeper_meta) =
                ]) );
       ]
   | Ok binding ->
-      let state =
-        Credential_materializer.verify_state
-          ~gh_config_dir:binding.gh_config_dir
-      in
-      let credential = binding_json binding ~state in
+      let credential = binding_json binding in
       [
         "credential", credential;
         ( "identity_attestation",
@@ -132,7 +115,6 @@ let identity_attestation_fields ~(config : Coord.config) (meta : keeper_meta) =
                      (Keeper_gh_env.credential_scope_to_string
                         binding.credential_scope) );
                  "git_identity_mode", `String binding.git_identity_mode;
-                 "credential_state", credential_state_json state;
                ]) );
       ]
 

--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -190,7 +190,7 @@ let handle_keeper_msg ?on_text_delta ctx args : tool_result =
       |> List.filter (fun name -> name <> "")
       |> Keeper_types.dedupe_keep_order
     in
-    match keeper_msg_timeout_override args with
+    (match keeper_msg_timeout_override args with
     | Error e -> (false, e)
     | Ok keeper_msg_oas_timeout_s ->
     (match reject_legacy_model_args ~tool_name:"masc_keeper_msg" args with

--- a/test/test_keeper_hooks_oas_telemetry.ml
+++ b/test/test_keeper_hooks_oas_telemetry.ml
@@ -800,14 +800,28 @@ let test_pr_review_action_metric_extracts_approve () =
       ~tool_name:"keeper_pr_review_comment"
       ~input:(`Assoc [ ("pr_number", `Int 13177); ("event", `String "COMMENT") ])
       ~output_text:
-        {|{"ok":true,"pr_number":13177,"event":"APPROVE","keeper":"sangsu","via":"docker"}|}
+        {|{"ok":true,"pr_number":13177,"event":"APPROVE","keeper":"sangsu","via":"docker","credential":{"effective_github_identity":"root"},"identity_attestation":{"keeper":"sangsu","effective_github_identity":"root"}}|}
       ()
     |> require_pr_review_event "approve"
   in
   check string "action from output" "APPROVE" event.action;
   check (option int) "pr number" (Some 13177) event.pr_number;
   check bool "success" true event.success;
-  check (option string) "route via" (Some "docker") event.route_via
+  check (option string) "route via" (Some "docker") event.route_via;
+  let attestation =
+    match event.identity_attestation with
+    | Some json -> json
+    | None -> fail "expected identity attestation"
+  in
+  check string "attested keeper" "sangsu"
+    (attestation |> member "keeper" |> to_string);
+  let credential =
+    match event.credential with
+    | Some json -> json
+    | None -> fail "expected credential"
+  in
+  check string "credential identity" "root"
+    (credential |> member "effective_github_identity" |> to_string)
 
 let test_pr_review_action_metric_marks_structured_failure () =
   let event =

--- a/test/test_keeper_pr_review.ml
+++ b/test/test_keeper_pr_review.ml
@@ -292,6 +292,15 @@ let test_read_routes_docker_and_injects_repo_flag () =
   check (option string) "repo inferred from project remote"
     (Some "jeong-sik/masc-mcp")
     (parse_string_field raw "repo");
+  check (option string) "read attests keeper"
+    (Some "reviewer")
+    (parse_nested_string_field raw "identity_attestation" "keeper");
+  check (option string) "read attests effective identity"
+    (Some "root")
+    (parse_nested_string_field raw "identity_attestation" "effective_github_identity");
+  check (option string) "read exposes credential identity"
+    (Some "root")
+    (parse_nested_string_field raw "credential" "effective_github_identity");
   let log = read_file log_path in
   check bool "read used docker run" true
     (contains_substring log "run --rm");
@@ -319,6 +328,12 @@ let test_comment_and_approve_route_through_docker () =
   in
   check (option string) "comment via docker" (Some "docker")
     (parse_string_field raw "via");
+  check (option string) "comment attests keeper"
+    (Some "reviewer")
+    (parse_nested_string_field raw "identity_attestation" "keeper");
+  check (option string) "comment exposes credential identity"
+    (Some "root")
+    (parse_nested_string_field raw "credential" "effective_github_identity");
   let raw =
     KTPR.handle_keeper_pr_review_comment ~config ~meta
       ~args:
@@ -403,6 +418,12 @@ let test_reply_routes_through_docker_and_infers_repo () =
   check (option string) "repo inferred for reply"
     (Some "jeong-sik/masc-mcp")
     (parse_string_field raw "repo");
+  check (option string) "reply attests keeper"
+    (Some "reviewer")
+    (parse_nested_string_field raw "identity_attestation" "keeper");
+  check (option string) "reply exposes credential identity"
+    (Some "root")
+    (parse_nested_string_field raw "credential" "effective_github_identity");
   let log = read_file log_path in
   check bool "reply used docker run" true
     (contains_substring log "run --rm");

--- a/test/test_keeper_pr_review.ml
+++ b/test/test_keeper_pr_review.ml
@@ -301,6 +301,16 @@ let test_read_routes_docker_and_injects_repo_flag () =
   check (option string) "read exposes credential identity"
     (Some "root")
     (parse_nested_string_field raw "credential" "effective_github_identity");
+  check bool "read omits credential state to avoid duplicate gh auth status"
+    true
+    (parse_field raw "credential"
+     |> Json.member "credential_state"
+     |> (=) `Null);
+  check bool "read attestation omits credential state"
+    true
+    (parse_field raw "identity_attestation"
+     |> Json.member "credential_state"
+     |> (=) `Null);
   let log = read_file log_path in
   check bool "read used docker run" true
     (contains_substring log "run --rm");


### PR DESCRIPTION
## Summary
- Add structured `identity_attestation` and scoped `credential` metadata to `keeper_pr_review_read`, `keeper_pr_review_comment`, and `keeper_pr_review_reply` outputs.
- Persist the same attestation into PR review action metrics so verifier/audit paths can distinguish MASC keeper tool origin from GitHub transport author.
- Repair current main build fallout from the latest stale-fleet/provider-health commits: restore the `keeper_msg` timeout match grouping and handle `Stale_fleet_batch` in execution receipt terminal codes.

## Why
Live task-189/task-190 verification was rejecting keeper PR review evidence because GitHub comments are written through the selected transport identity, while the durable MASC evidence did not explicitly attest the keeper/tool invocation identity. This PR makes the runtime evidence machine-readable.

## Verification
- `MASC_SKIP_OPAM_LOCK=1 MASC_DUNE_THROTTLE=0 DUNE_LOCAL_JOBS=1 scripts/dune-local.sh build test/test_keeper_pr_review.exe test/test_keeper_hooks_oas_telemetry.exe`
- `./_build/default/test/test_keeper_pr_review.exe` (11 tests)
- `./_build/default/test/test_keeper_hooks_oas_telemetry.exe` (42 tests)

Draft until CI and review gates are green.