### PR TITLE
fix(audit): separate keeper and global tool-call paths

### DIFF
--- a/scripts/audit-keeper-fleet-readiness.py
+++ b/scripts/audit-keeper-fleet-readiness.py
@@ -957,7 +957,7 @@ def scan_keeper_board_posts(
     return latest_ts, board_post_evidence, product_evidence, design_evidence
 
 
-def tool_call_paths(base_path: Path) -> list[Path]:
+def global_tool_call_paths(base_path: Path) -> list[Path]:
     calls_dir = base_path / ".masc" / "tool_calls"
     if not calls_dir.exists():
         return []
@@ -1020,7 +1020,7 @@ def scan_keeper_evidence(
         complete_lifecycle_evidence(pr_lifecycle_evidence)
         and complete_lifecycle_evidence(docker_pr_lifecycle_evidence)
     ):
-        for calls in tool_call_paths(base_path):
+        for calls in global_tool_call_paths(base_path):
             for row in iter_jsonl(calls):
                 if row.get("keeper") != name:
                     continue

--- a/test/test_audit_keeper_fleet_readiness.py
+++ b/test/test_audit_keeper_fleet_readiness.py
@@ -227,6 +227,41 @@ class AuditKeeperFleetReadinessTest(unittest.TestCase):
         self.assertEqual(refs, set())
         self.assertEqual(sources, set())
 
+    def test_scan_pr_creation_evidence_reads_keeper_scoped_paths(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            keepers_dir = root / ".masc" / "keepers"
+            keepers_dir.mkdir(parents=True)
+            (keepers_dir / "alpha.decisions.jsonl").write_text(
+                json.dumps(
+                    {
+                        "tool": "keeper_pr_create",
+                        "ok": True,
+                        "output": {
+                            "pr_url": "https://github.com/acme/repo/pull/125",
+                            "number": 125,
+                        },
+                    }
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+
+            evidence = audit.scan_pr_creation_evidence(root, "alpha")
+
+        self.assertEqual(
+            evidence.refs,
+            {
+                "keeper_pr_create",
+                "https://github.com/acme/repo/pull/125",
+                "PR#125",
+            },
+        )
+        self.assertEqual(
+            evidence.sources,
+            {str(keepers_dir / "alpha.decisions.jsonl")},
+        )
+
     def test_pr_action_metric_paths_returns_newest_date_split_first(self):
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)


### PR DESCRIPTION
## Summary
- split keeper-scoped and global tool-call path discovery in the fleet readiness audit
- add a regression test for scan_pr_creation_evidence so duplicate helper names cannot reintroduce the crash

## Verification
- ruff check scripts/audit-keeper-fleet-readiness.py test/test_audit_keeper_fleet_readiness.py
- pytest -q test/test_audit_keeper_fleet_readiness.py
- python3 scripts/audit-keeper-fleet-readiness.py --base-path /Users/dancer/me --expected-keepers 14 --require-docker-pr-lifecycle-evidence --forbid-github-identity jeong-sik --json > /tmp/keeper-audit-fixed2.json

## Operator impact
- unblocks Docker PR lifecycle audit runs that currently crash after keeper smoke results with TypeError: tool_call_paths() takes 1 positional argument but 2 were given
- audit now returns the real missing evidence set instead of hiding it behind a script exception