### PR TITLE
feat(dashboard): add event stream intent projection

### DIFF
--- a/dashboard/src/components/common/event-stream.test.ts
+++ b/dashboard/src/components/common/event-stream.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 import { h } from 'preact'
 import { render } from 'preact'
 import {
+  buildIntentProjectionRows,
   buildSemanticGravityRows,
   buildTemporalSyncRows,
   DEFAULT_TEMPORAL_SYNC_WINDOW_MS,
@@ -17,6 +18,15 @@ const baseEvents = [
   { id: 'e1', timestamp: new Date('2024-01-01T09:30:00').getTime(), level: 'info' as const, message: 'started', source: 'agent-a' },
   { id: 'e2', timestamp: new Date('2024-01-01T09:31:00').getTime(), level: 'warn' as const, message: 'slow', source: 'agent-b' },
   { id: 'e3', timestamp: new Date('2024-01-01T09:32:00').getTime(), level: 'error' as const, message: 'failed' },
+]
+
+const projectionEvents = [
+  { id: 'p1', timestamp: new Date('2024-01-01T10:00:00').getTime(), level: 'info' as const, message: 'edit app.ts', source: 'editor' },
+  { id: 'p2', timestamp: new Date('2024-01-01T10:01:00').getTime(), level: 'error' as const, message: 'test failed', source: 'test' },
+  { id: 'p3', timestamp: new Date('2024-01-01T10:02:00').getTime(), level: 'info' as const, message: 'edit app.ts', source: 'editor' },
+  { id: 'p4', timestamp: new Date('2024-01-01T10:03:00').getTime(), level: 'info' as const, message: 'test passed', source: 'test' },
+  { id: 'p5', timestamp: new Date('2024-01-01T10:04:00').getTime(), level: 'info' as const, message: 'edit app.ts', source: 'editor' },
+  { id: 'p6', timestamp: new Date('2024-01-01T10:05:00').getTime(), level: 'info' as const, message: 'update docs', source: 'docs' },
 ]
 
 describe('EventStream', () => {
@@ -292,6 +302,51 @@ describe('EventStream', () => {
     expect(items[0]?.getAttribute('data-stream-event-id')).toBe('e1')
     expect(focused.dataset.streamEventSemanticGravityScore).toBe('0.85')
     expect(focused.dataset.streamEventSemanticGravityRank).toBe('1')
+  })
+
+  it('projects likely next intent from focused event history', () => {
+    const rows = buildIntentProjectionRows(projectionEvents, 'editor')
+
+    expect(rows.map(row => row.key)).toEqual(['source:test', 'source:docs'])
+    expect(rows[0]).toMatchObject({
+      label: 'test',
+      targetKind: 'source',
+      probability: 0.67,
+      evidenceCount: 2,
+    })
+    expect(rows[1]).toMatchObject({
+      label: 'docs',
+      probability: 0.33,
+      evidenceCount: 1,
+    })
+    expect(summarizeEventStream(projectionEvents, 100, DEFAULT_TEMPORAL_SYNC_WINDOW_MS, 'editor')).toMatchObject({
+      intentProjectionCount: 2,
+      topIntentProjectionProbability: 0.67,
+    })
+  })
+
+  it('renders intentional projection metadata and suggestion chips', () => {
+    const container = document.createElement('div')
+    render(h(EventStream, { events: projectionEvents, semanticFocus: 'editor' }), container)
+    const root = container.querySelector('[data-event-stream]') as HTMLElement
+    const projections = container.querySelectorAll('[data-intent-projection-key]')
+    const top = projections[0] as HTMLElement
+
+    expect(root.dataset.eventStreamIntentProjectionCount).toBe('2')
+    expect(root.dataset.eventStreamTopIntentProjectionProbability).toBe('0.67')
+    expect(top.dataset.intentProjectionKey).toBe('source:test')
+    expect(top.dataset.intentProjectionTargetKind).toBe('source')
+    expect(top.dataset.intentProjectionProbability).toBe('0.67')
+    expect(top.dataset.intentProjectionEvidenceCount).toBe('2')
+    expect(container.textContent).toContain('test')
+    expect(container.textContent).toContain('67%')
+  })
+
+  it('limits intentional projections', () => {
+    const rows = buildIntentProjectionRows(projectionEvents, 'editor', 1)
+
+    expect(rows).toHaveLength(1)
+    expect(rows[0]?.key).toBe('source:test')
   })
 
   it('treats maxItems zero as an empty visible window', () => {

--- a/dashboard/src/components/common/event-stream.ts
+++ b/dashboard/src/components/common/event-stream.ts
@@ -17,6 +17,7 @@ export interface StreamEvent {
 export type EventStreamStatus = 'empty' | 'ok' | 'warning' | 'error'
 export type EventStreamAttractionBand = 'high' | 'medium' | 'low'
 export type EventStreamSemanticFocus = string | readonly string[]
+export type IntentProjectionTargetKind = 'source' | 'level'
 
 export interface EventStreamSummary {
   totalCount: number
@@ -34,6 +35,8 @@ export interface EventStreamSummary {
   semanticGravityTermCount: number
   semanticGravityMatchCount: number
   maxSemanticGravityScore: number
+  intentProjectionCount: number
+  topIntentProjectionProbability: number
   status: EventStreamStatus
 }
 
@@ -49,11 +52,20 @@ export interface SemanticGravityStreamRow extends TemporalSyncStreamRow {
   semanticGravityRank: number
 }
 
+export interface IntentProjectionRow {
+  key: string
+  label: string
+  targetKind: IntentProjectionTargetKind
+  probability: number
+  evidenceCount: number
+}
+
 interface EventStreamProps {
   events: StreamEvent[]
   maxItems?: number
   temporalSyncWindowMs?: number
   semanticFocus?: EventStreamSemanticFocus
+  maxIntentProjections?: number
   testId?: string
 }
 
@@ -132,8 +144,26 @@ function normalizedSemanticTerms(focus: EventStreamSemanticFocus | undefined): s
   return Array.from(new Set(terms)).slice(0, 16)
 }
 
+function intentTermsForEvent(event: StreamEvent): string[] {
+  return normalizedSemanticTerms([
+    event.source ?? '',
+    event.message,
+    event.id,
+    event.level,
+  ])
+}
+
 function fieldIncludes(value: string | undefined, term: string): boolean {
   return value?.toLowerCase().includes(term) ?? false
+}
+
+function eventMatchesTerms(event: StreamEvent, terms: readonly string[]): boolean {
+  return terms.some(term =>
+    fieldIncludes(event.source, term)
+    || fieldIncludes(event.message, term)
+    || fieldIncludes(event.id, term)
+    || event.level === term,
+  )
 }
 
 export function streamEventSemanticGravityScore(
@@ -175,6 +205,60 @@ export function buildSemanticGravityRows(
     semanticGravityScore: item.score,
     semanticGravityRank: index + 1,
   }))
+}
+
+function projectionTargetForEvent(event: StreamEvent): Pick<IntentProjectionRow, 'key' | 'label' | 'targetKind'> {
+  if (event.source?.trim()) {
+    const source = event.source.trim()
+    return { key: `source:${source}`, label: source, targetKind: 'source' }
+  }
+  return { key: `level:${event.level}`, label: levelLabel(event.level), targetKind: 'level' }
+}
+
+export function buildIntentProjectionRows(
+  events: StreamEvent[],
+  semanticFocus?: EventStreamSemanticFocus,
+  maxIntentProjections = 3,
+): IntentProjectionRow[] {
+  const limit = Number.isFinite(maxIntentProjections)
+    ? Math.max(0, Math.floor(maxIntentProjections))
+    : 0
+  if (limit === 0 || events.length < 2) return []
+
+  const explicitTerms = normalizedSemanticTerms(semanticFocus)
+  const latestEvent = events[events.length - 1]
+  const terms = explicitTerms.length > 0 || latestEvent == null
+    ? explicitTerms
+    : intentTermsForEvent(latestEvent)
+  if (terms.length === 0) return []
+
+  const counts = new Map<string, IntentProjectionRow>()
+  let evidenceTotal = 0
+
+  for (let index = 0; index < events.length - 1; index += 1) {
+    const event = events[index]!
+    const next = events[index + 1]!
+    if (!eventMatchesTerms(event, terms)) continue
+
+    const target = projectionTargetForEvent(next)
+    const current = counts.get(target.key)
+    counts.set(target.key, {
+      ...target,
+      probability: 0,
+      evidenceCount: (current?.evidenceCount ?? 0) + 1,
+    })
+    evidenceTotal += 1
+  }
+
+  if (evidenceTotal === 0) return []
+
+  return Array.from(counts.values())
+    .map(row => ({
+      ...row,
+      probability: roundedScore(row.evidenceCount / evidenceTotal),
+    }))
+    .sort((a, b) => (b.probability - a.probability) || (b.evidenceCount - a.evidenceCount) || a.label.localeCompare(b.label))
+    .slice(0, limit)
 }
 
 export function streamEventAttractionScore(
@@ -251,10 +335,12 @@ export function summarizeEventStream(
   maxItems: number,
   temporalSyncWindowMs = DEFAULT_TEMPORAL_SYNC_WINDOW_MS,
   semanticFocus?: EventStreamSemanticFocus,
+  maxIntentProjections = 3,
 ): EventStreamSummary {
   const visible = getVisibleStreamEvents(events, maxItems)
   const syncRows = buildTemporalSyncRows(visible, temporalSyncWindowMs)
   const semanticRows = buildSemanticGravityRows(syncRows, semanticFocus)
+  const intentProjections = buildIntentProjectionRows(events, semanticFocus, maxIntentProjections)
   const latestTimestamp = visible.length > 0 ? finiteTimestamp(visible[0]!.timestamp) : null
   const oldestVisibleTimestamp = visible.length > 0
     ? finiteTimestamp(visible[visible.length - 1]!.timestamp)
@@ -298,6 +384,8 @@ export function summarizeEventStream(
     semanticGravityTermCount: normalizedSemanticTerms(semanticFocus).length,
     semanticGravityMatchCount: semanticMatchCount,
     maxSemanticGravityScore: semanticScores.reduce((max, score) => Math.max(max, score), 0),
+    intentProjectionCount: intentProjections.length,
+    topIntentProjectionProbability: intentProjections[0]?.probability ?? 0,
     status,
   }
 }
@@ -323,6 +411,7 @@ export function EventStream({
   maxItems = 100,
   temporalSyncWindowMs = DEFAULT_TEMPORAL_SYNC_WINDOW_MS,
   semanticFocus,
+  maxIntentProjections = 3,
   testId,
 }: EventStreamProps) {
   const visible = useMemo(() => getVisibleStreamEvents(events, maxItems), [events, maxItems])
@@ -334,9 +423,13 @@ export function EventStream({
     () => buildSemanticGravityRows(syncRows, semanticFocus),
     [syncRows, semanticFocus],
   )
+  const intentProjections = useMemo(
+    () => buildIntentProjectionRows(events, semanticFocus, maxIntentProjections),
+    [events, semanticFocus, maxIntentProjections],
+  )
   const summary = useMemo(
-    () => summarizeEventStream(events, maxItems, temporalSyncWindowMs, semanticFocus),
-    [events, maxItems, temporalSyncWindowMs, semanticFocus],
+    () => summarizeEventStream(events, maxItems, temporalSyncWindowMs, semanticFocus, maxIntentProjections),
+    [events, maxItems, temporalSyncWindowMs, semanticFocus, maxIntentProjections],
   )
 
   return html`
@@ -360,6 +453,8 @@ export function EventStream({
       data-event-stream-semantic-gravity-term-count=${summary.semanticGravityTermCount}
       data-event-stream-semantic-gravity-match-count=${summary.semanticGravityMatchCount}
       data-event-stream-max-semantic-gravity-score=${summary.maxSemanticGravityScore.toFixed(2)}
+      data-event-stream-intent-projection-count=${summary.intentProjectionCount}
+      data-event-stream-top-intent-projection-probability=${summary.topIntentProjectionProbability.toFixed(2)}
       data-testid=${testId}
     >
       <div
@@ -381,6 +476,29 @@ export function EventStream({
           <div class="font-mono text-sm text-[var(--color-status-err)]">${summary.errorCount}</div>
         </div>
       </div>
+      ${intentProjections.length > 0
+        ? html`
+          <div
+            class="flex min-w-0 flex-wrap gap-1"
+            aria-label="의도 예측"
+            data-event-stream-intent-projections
+          >
+            ${intentProjections.map(projection => html`
+              <div
+                key=${projection.key}
+                class="inline-flex min-w-0 items-center gap-1 rounded-[var(--r-0)] border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] px-1.5 py-0.5 text-3xs text-[var(--color-fg-secondary)]"
+                data-intent-projection-key=${projection.key}
+                data-intent-projection-target-kind=${projection.targetKind}
+                data-intent-projection-probability=${projection.probability.toFixed(2)}
+                data-intent-projection-evidence-count=${projection.evidenceCount}
+              >
+                <span class="max-w-28 truncate" title=${projection.label}>${projection.label}</span>
+                <span class="font-mono text-[var(--color-fg-muted)]">${Math.round(projection.probability * 100)}%</span>
+              </div>
+            `)}
+          </div>
+        `
+        : null}
       <div
         role="log"
         aria-label="이벤트 스트림, 이벤트 ${summary.visibleCount}개, 에러 ${summary.errorCount}개"


### PR DESCRIPTION
## Summary
- add history-based intent projection for event stream transitions
- expose projection counts/probability metadata on the stream root and chips
- render compact projection chips for likely next source/level targets

## Stack
- base: #13800 (Semantic Gravity)
- implements P0 Convergence Flow: Intentional Projection

## Verification
- pnpm install --offline --frozen-lockfile
- pnpm exec vitest run --config vitest.config.ts src/components/common/event-stream.test.ts src/components/common/event-stream.a11y.test.ts --no-file-parallelism --maxWorkers=1
- pnpm exec tsc --noEmit --pretty false
- pnpm exec eslint src (passes with existing unrelated warnings in virtual-list.ts and fsm-hub.ts)
- git diff --check