### PR TITLE
fix(dashboard): count nested keeper usage tokens

### DIFF
--- a/lib/dashboard/dashboard_http_keeper.ml
+++ b/lib/dashboard/dashboard_http_keeper.ml
@@ -1933,16 +1933,13 @@ let keeper_cost_aggregates_json
             in
             let latency_ms = Safe_ops.json_int ~default:0 "latency_ms" j in
             let input_t =
-              Safe_ops.json_int_opt "input_tokens" j
-              |> Option.value ~default:0
+              int_member_fallback "input_tokens" j |> Option.value ~default:0
             in
             let output_t =
-              Safe_ops.json_int_opt "output_tokens" j
-              |> Option.value ~default:0
+              int_member_fallback "output_tokens" j |> Option.value ~default:0
             in
             let total_t =
-              Safe_ops.json_int_opt "total_tokens" j
-              |> Option.value ~default:0
+              int_member_fallback "total_tokens" j |> Option.value ~default:0
             in
             let model_used =
               Safe_ops.json_string ~default:"" "model_used" j

--- a/test/test_dashboard_keeper_cost_aggregates.ml
+++ b/test/test_dashboard_keeper_cost_aggregates.ml
@@ -129,19 +129,34 @@ let test_heartbeat_snapshots_do_not_count_as_cost_samples () =
       ("total_tokens", `Int 15);
       ("model_used", `String "test-model");
     ];
+  append_metric config keeper_name
+    [
+      ("ts_unix", `Float ts);
+      ("channel", `String "turn");
+      ("cost_usd", `Float 0.25);
+      ("latency_ms", `Int 100);
+      ("usage",
+       `Assoc
+         [
+           ("input_tokens", `Int 7);
+           ("output_tokens", `Int 3);
+           ("total_tokens", `Int 10);
+         ]);
+      ("model_used", `String "test-model");
+    ];
   let aggregate =
     Dashboard_http_keeper.keeper_cost_aggregates_json
       ~config ~keepers:[ meta ] ~window_minutes:60
     |> keeper_item
   in
-  check int "only real call counted" 1 (int_field "sample_count" aggregate);
-  check (float 0.0001) "total cost excludes snapshots" 0.25
+  check int "only real calls counted" 2 (int_field "sample_count" aggregate);
+  check (float 0.0001) "total cost excludes snapshots" 0.5
     (float_field "total_cost_usd" aggregate);
-  check int "input tokens exclude snapshots" 10
+  check int "input tokens include nested current schema" 17
     (int_field "total_input_tokens" aggregate);
-  check int "output tokens exclude snapshots" 5
+  check int "output tokens include nested current schema" 8
     (int_field "total_output_tokens" aggregate);
-  check int "total tokens exclude snapshots" 15
+  check int "total tokens include nested current schema" 25
     (int_field "total_tokens" aggregate);
   check (float 0.0001) "p50 latency excludes snapshots" 100.0
     (float_field "p50_latency_ms" aggregate);
@@ -151,7 +166,7 @@ let test_heartbeat_snapshots_do_not_count_as_cost_samples () =
   | [ item ] ->
       check string "model breakdown model" "test-model"
         Yojson.Safe.Util.(item |> member "model" |> to_string);
-      check (float 0.0001) "model breakdown cost" 0.25
+      check (float 0.0001) "model breakdown cost" 0.5
         (float_field "cost_usd" item)
   | other ->
       fail


### PR DESCRIPTION
## What changed

- Makes provider cost aggregates read keeper token counts from the current metrics schema under `usage.{input_tokens,output_tokens,total_tokens}`.
- Keeps legacy top-level token fields supported through the existing fallback helper.
- Extends the aggregate regression test with a current-shape turn row so cost/latency samples no longer count with zero tokens.

## Why

Issue #11342's A6/A9 baseline found sparse turn metrics and blocked cost/token validation. Current keeper snapshots already emit token data under `usage`, but the provider dashboard aggregate only read top-level token fields. That meant current-format turn rows could contribute latency/cost samples while adding zero tokens, making A9 cost/token measurement look empty even when the JSONL row carried usage.

This does not fabricate usage when providers omit it; unreported usage remains null and is still surfaced via `usage_trust`/coverage fields.

## Validation

- `dune build --root . test/test_dashboard_keeper_cost_aggregates.exe`
- `./_build/default/test/test_dashboard_keeper_cost_aggregates.exe`
- `git diff --check origin/main..HEAD`