### PR TITLE
fix(dashboard): recover stalled ws parse worker jobs

### DIFF
--- a/dashboard/src/dashboard-ws.test.ts
+++ b/dashboard/src/dashboard-ws.test.ts
@@ -72,6 +72,31 @@ class MockWebSocket {
   }
 }
 
+class MockParseWorker {
+  static holdResponses = false
+
+  onmessage: ((event: MessageEvent) => void) | null = null
+  onerror: ((event: ErrorEvent) => void) | null = null
+  onmessageerror: ((event: MessageEvent) => void) | null = null
+  terminated = false
+
+  constructor(readonly url: URL) {}
+
+  postMessage(message: { id: number; data: string }): void {
+    if (MockParseWorker.holdResponses) return
+    this.onmessage?.({
+      data: {
+        id: message.id,
+        payloads: [JSON.parse(message.data) as unknown],
+      },
+    } as MessageEvent)
+  }
+
+  terminate(): void {
+    this.terminated = true
+  }
+}
+
 function installWebSocketMocks(): void {
   mockSockets.length = 0
   vi.stubGlobal('WebSocket', MockWebSocket)
@@ -128,6 +153,7 @@ beforeEach(() => {
 
 afterEach(() => {
   disconnectDashboardWS()
+  MockParseWorker.holdResponses = false
   dashboardWsConnected.value = false
   dashboardWsLastError.value = null
   dashboardWsLastSeq.value = 0
@@ -375,6 +401,46 @@ describe('dashboard websocket route subscriptions', () => {
     })
     expect(ack).not.toHaveProperty('id')
     expect(dashboardWsLastSeq.value).toBe(42)
+  })
+
+  it('falls back to main-thread parsing when the parse worker stops responding', async () => {
+    vi.useFakeTimers()
+    installWebSocketMocks()
+    vi.stubGlobal('Worker', MockParseWorker)
+
+    await connectDashboardWS({ tab: 'overview', params: {} })
+    const socket = mockSockets[0]!
+    socket.open()
+    const hello = parseRpc(socket, 0)
+    socket.receive({ jsonrpc: '2.0', id: hello.id, result: {} })
+    await flushPromises()
+
+    const subscribe = parseRpc(socket, 1)
+    socket.receive({
+      jsonrpc: '2.0',
+      id: subscribe.id,
+      result: { snapshot: { seq: 1, slices: {} } },
+    })
+    await flushPromises()
+    sseStoreMocks.hydrateDashboardSlice.mockClear()
+
+    MockParseWorker.holdResponses = true
+    socket.receive({
+      jsonrpc: '2.0',
+      method: 'dashboard/delta',
+      params: { seq: 43, slice: 'execution', payload: { agents: [] } },
+    })
+    expect(sseStoreMocks.hydrateDashboardSlice).not.toHaveBeenCalled()
+
+    await vi.advanceTimersByTimeAsync(5_000)
+    flushPendingInbound()
+
+    expect(dashboardWsLastSeq.value).toBe(43)
+    expect(sseStoreMocks.hydrateDashboardSlice).toHaveBeenCalledWith(
+      'execution',
+      { agents: [] },
+      undefined,
+    )
   })
 
   it('ignores stale subscribe snapshots that arrive after a newer route subscription', async () => {

--- a/dashboard/src/dashboard-ws.ts
+++ b/dashboard/src/dashboard-ws.ts
@@ -20,6 +20,10 @@ type PendingRpc = {
   reject: (err: Error) => void
   timeout: ReturnType<typeof setTimeout>
 }
+type ParseWorkerJob = {
+  data: string
+  timeout: ReturnType<typeof setTimeout>
+}
 type DashboardRouteState = Pick<RouteState, 'tab' | 'params'>
 
 interface DashboardWsDiscovery {
@@ -34,6 +38,7 @@ interface DashboardWsDiscoveryResult {
 }
 
 const DASHBOARD_WS_RPC_TIMEOUT_MS = 15_000
+const DASHBOARD_WS_PARSE_TIMEOUT_MS = 5_000
 
 let socket: WebSocket | null = null
 let rpcId = 0
@@ -57,7 +62,31 @@ let flushHandle = 0
 // main thread never blocks on large payloads.
 let parseWorker: Worker | null = null
 let workerJobId = 0
-const workerJobs = new Map<number, (payloads: unknown[]) => void>()
+const workerJobs = new Map<number, ParseWorkerJob>()
+
+function deliverParsedPayloads(payloads: unknown[]): void {
+  for (const payload of payloads) {
+    pendingInbound.push(payload)
+  }
+  scheduleFlush()
+}
+
+function fallbackParseWorkerJob(id: number): void {
+  const job = workerJobs.get(id)
+  if (!job) return
+  workerJobs.delete(id)
+  clearTimeout(job.timeout)
+  pendingInbound.push(job.data)
+  scheduleFlush()
+}
+
+function fallbackAllParseWorkerJobs(): void {
+  for (const id of Array.from(workerJobs.keys())) {
+    fallbackParseWorkerJob(id)
+  }
+  parseWorker?.terminate()
+  parseWorker = null
+}
 
 function initParseWorker(): Worker | null {
   if (parseWorker) return parseWorker
@@ -71,12 +100,14 @@ function initParseWorker(): Worker | null {
         id: number
         payloads: unknown[]
       }
-      const cb = workerJobs.get(id)
-      if (cb) {
-        cb(payloads)
-        workerJobs.delete(id)
-      }
+      const job = workerJobs.get(id)
+      if (!job) return
+      workerJobs.delete(id)
+      clearTimeout(job.timeout)
+      deliverParsedPayloads(Array.isArray(payloads) ? payloads : [])
     }
+    parseWorker.onerror = fallbackAllParseWorkerJobs
+    parseWorker.onmessageerror = fallbackAllParseWorkerJobs
     return parseWorker
   } catch {
     return null
@@ -417,13 +448,18 @@ function handleMessage(data: unknown): void {
   const worker = initParseWorker()
   if (worker) {
     const id = ++workerJobId
-    workerJobs.set(id, (payloads) => {
-      for (const p of payloads) {
-        pendingInbound.push(p)
-      }
-      scheduleFlush()
+    workerJobs.set(id, {
+      data,
+      timeout: setTimeout(() => {
+        fallbackParseWorkerJob(id)
+      }, DASHBOARD_WS_PARSE_TIMEOUT_MS),
     })
-    worker.postMessage({ id, data })
+    try {
+      worker.postMessage({ id, data })
+    } catch {
+      fallbackParseWorkerJob(id)
+      parseWorker = null
+    }
     return
   }
   pendingInbound.push(data)


### PR DESCRIPTION
## Summary
- Add timeout cleanup for dashboard WebSocket parse-worker jobs so a stalled worker cannot retain jobs indefinitely or drop inbound dashboard updates.
- Fall back to the existing main-thread parser path only when the worker fails to respond, preserving the normal off-main-thread parse path for large payloads.
- Cover the stalled-worker path with a route subscription regression test.

## Why this matters
This addresses the dashboard performance plan's WebSocket hydration concern in the failure path around large payload parsing: the parser is already worker-backed, but a dead worker left messages stuck. Operators should get eventual dashboard updates instead of silent parse-job retention.

## Verification
- pnpm exec vitest run --config vitest.config.ts src/dashboard-ws.test.ts src/dashboard-ws-parse.test.ts --no-file-parallelism --maxWorkers=1
- pnpm exec tsc --noEmit --pretty
- git diff --check origin/main...HEAD

Note: this worktree uses the root dashboard node_modules via a temporary symlink during local verification only; the symlink was removed before commit.