### PR TITLE
chore(oas): refresh API surface fingerprint

### DIFF
--- a/scripts/oas-api-surface.json
+++ b/scripts/oas-api-surface.json
@@ -1,5 +1,5 @@
 {
-  "pinned_sha": "52515168760a716d73400c2bb398194452f8103c",
+  "pinned_sha": "0cfb68c620ccd385f16fd6344b2cb003077c73c3",
   "pinned_version": "v0.190.26",
   "surfaces": {
     "event_bus_payload_variants": [


### PR DESCRIPTION
Summary:
- Refresh scripts/oas-api-surface.json pinned_sha to the current OAS main SHA 0cfb68c620ccd385f16fd6344b2cb003077c73c3.
- Keep the pinned version at v0.190.26; API surface content is unchanged.

Verification:
- scripts/oas-drift-check.sh: OAS API surface matches fingerprint (pinned_sha=0cfb68c620ccd385f16fd6344b2cb003077c73c3)
- scripts/check-oas-pin.sh --local-only: OAS pin verified main@0cfb68c620ccd385f16fd6344b2cb003077c73c3 (base version v0.190.26)
- git diff --check origin/main...HEAD