### PR TITLE
perf(dashboard): jittered 60s reconnect cap + 30s WS RPC timeout

### DIFF
--- a/dashboard/src/config/constants.ts
+++ b/dashboard/src/config/constants.ts
@@ -13,10 +13,18 @@ export const ACTIVITY_TIMEOUT_MS = 10_000
 export const MCP_INITIALIZE_TIMEOUT_MS = 10_000
 export const MCP_INITIALIZED_NOTIFY_TIMEOUT_MS = 5_000
 export const MCP_INIT_COOLDOWN_MS = 2_000
+// Dashboard WS JSON-RPC timeout. Matches the backend dashboard handler budget
+// so a slow first response under Executor_pool contention is not turned into
+// a reconnect by the client side.
+export const DASHBOARD_WS_RPC_TIMEOUT_MS = 30_000
 
-// --- SSE reconnection ---
+// --- Reconnect backoff (shared by SSE and dashboard WS) ---
+// Cap at 60s with plus/minus 1s jitter to break reconnect storms when the server is
+// degraded; fleets of dashboards retrying every 15s synchronously was
+// observed to amplify Executor_pool starvation on cold start.
 export const RECONNECT_BASE_MS = 1_000
-export const RECONNECT_MAX_MS = 15_000
+export const RECONNECT_MAX_MS = 60_000
+export const RECONNECT_JITTER_MS = 1_000
 
 // --- Refresh & debounce (milliseconds) ---
 export const SHELL_TTL_MS = 5_000

--- a/dashboard/src/dashboard-ws.test.ts
+++ b/dashboard/src/dashboard-ws.test.ts
@@ -15,6 +15,7 @@ import {
   parseWebSocketSseFrames,
   subscribeDashboardRoute,
 } from './dashboard-ws'
+import { DASHBOARD_WS_RPC_TIMEOUT_MS } from './config/constants'
 import {
   dashboardWsConnected,
   dashboardWsLastError,
@@ -149,6 +150,8 @@ beforeEach(() => {
     return 0
   })
   vi.stubGlobal('cancelAnimationFrame', vi.fn())
+  // Deterministic reconnect-jitter so timer-advance assertions are stable.
+  vi.spyOn(Math, 'random').mockReturnValue(0)
 })
 
 afterEach(() => {
@@ -322,7 +325,7 @@ describe('dashboard websocket route subscriptions', () => {
     expect(hello.method).toBe('dashboard/hello')
     expect(dashboardWsConnected.value).toBe(true)
 
-    await vi.advanceTimersByTimeAsync(15_000)
+    await vi.advanceTimersByTimeAsync(DASHBOARD_WS_RPC_TIMEOUT_MS)
     await flushPromises()
 
     expect(firstSocket.readyState).toBe(MockWebSocket.CLOSED)
@@ -352,7 +355,7 @@ describe('dashboard websocket route subscriptions', () => {
     expect(subscribe.method).toBe('dashboard/subscribe')
     expect(dashboardWsReady.value).toBe(true)
 
-    await vi.advanceTimersByTimeAsync(15_000)
+    await vi.advanceTimersByTimeAsync(DASHBOARD_WS_RPC_TIMEOUT_MS)
     await flushPromises()
 
     expect(firstSocket.readyState).toBe(MockWebSocket.CLOSED)
@@ -583,7 +586,7 @@ describe('dashboard websocket route subscriptions', () => {
     const rejection = expect(subscribePromise).rejects.toThrow(
       'dashboard websocket rpc timed out: dashboard/subscribe',
     )
-    await vi.advanceTimersByTimeAsync(15_000)
+    await vi.advanceTimersByTimeAsync(DASHBOARD_WS_RPC_TIMEOUT_MS)
     await rejection
 
     socket.receive({

--- a/dashboard/src/dashboard-ws.ts
+++ b/dashboard/src/dashboard-ws.ts
@@ -3,6 +3,11 @@ import { parseSSEMessage } from './schemas/sse'
 import { hydrateDashboardSlice, routeServerPushEvent } from './sse-store'
 import { batch } from '@preact/signals'
 import { parseWebSocketSseFrames as parseWebSocketSseFramesImpl } from './dashboard-ws-parse'
+import {
+  DASHBOARD_WS_RPC_TIMEOUT_MS,
+  RECONNECT_JITTER_MS,
+  RECONNECT_MAX_MS,
+} from './config/constants'
 
 // Re-export for test consumers that assert on frame parsing.
 export const parseWebSocketSseFrames = parseWebSocketSseFramesImpl
@@ -37,7 +42,6 @@ interface DashboardWsDiscoveryResult {
   retry: boolean
 }
 
-const DASHBOARD_WS_RPC_TIMEOUT_MS = 15_000
 const DASHBOARD_WS_PARSE_TIMEOUT_MS = 5_000
 
 let socket: WebSocket | null = null
@@ -245,7 +249,10 @@ function scheduleReconnect(): void {
   if (!shouldReconnect) return
   if (reconnectTimer) return
   reconnectAttempts += 1
-  const delay = Math.min(15_000, 500 * Math.pow(2, Math.min(reconnectAttempts, 5)))
+  const exp = Math.min(reconnectAttempts, 5)
+  const backoff = Math.min(RECONNECT_MAX_MS, 500 * Math.pow(2, exp))
+  const jitter = Math.random() * RECONNECT_JITTER_MS
+  const delay = backoff + jitter
   reconnectTimer = setTimeout(() => {
     reconnectTimer = null
     void connectDashboardWS()

--- a/dashboard/src/dashboard-ws.ts
+++ b/dashboard/src/dashboard-ws.ts
@@ -245,12 +245,22 @@ function formatCloseEventError(event: CloseEvent): string {
   return `dashboard websocket closed (${parts.join(', ')})`
 }
 
+// WebSocket reconnect uses an explicit 500ms base (half of the SSE
+// RECONNECT_BASE_MS) so transient socket churn recovers faster. Derive the
+// exp clamp from the configured cap so a future operator bump of
+// RECONNECT_MAX_MS actually grows the achievable backoff.
+const WS_RECONNECT_BASE_MS = 500
+const WS_RECONNECT_MAX_EXP = Math.max(
+  1,
+  Math.ceil(Math.log2(RECONNECT_MAX_MS / WS_RECONNECT_BASE_MS)),
+)
+
 function scheduleReconnect(): void {
   if (!shouldReconnect) return
   if (reconnectTimer) return
   reconnectAttempts += 1
-  const exp = Math.min(reconnectAttempts, 5)
-  const backoff = Math.min(RECONNECT_MAX_MS, 500 * Math.pow(2, exp))
+  const exp = Math.min(reconnectAttempts, WS_RECONNECT_MAX_EXP)
+  const backoff = Math.min(RECONNECT_MAX_MS, WS_RECONNECT_BASE_MS * Math.pow(2, exp))
   const jitter = Math.random() * RECONNECT_JITTER_MS
   const delay = backoff + jitter
   reconnectTimer = setTimeout(() => {

--- a/dashboard/src/sse.ts
+++ b/dashboard/src/sse.ts
@@ -19,6 +19,7 @@ import { RingBuffer } from './lib/ring-buffer'
 
 import {
   RECONNECT_BASE_MS,
+  RECONNECT_JITTER_MS,
   RECONNECT_MAX_MS,
   MAX_JOURNAL_ENTRIES,
 } from './config/constants'
@@ -231,7 +232,9 @@ function scheduleReconnect(): void {
   if (reconnectTimer) return
   reconnectAttempts++
   const exp = Math.min(reconnectAttempts, 5)
-  const delay = Math.min(RECONNECT_MAX_MS, RECONNECT_BASE_MS * Math.pow(2, exp))
+  const backoff = Math.min(RECONNECT_MAX_MS, RECONNECT_BASE_MS * Math.pow(2, exp))
+  const jitter = Math.random() * RECONNECT_JITTER_MS
+  const delay = backoff + jitter
   console.debug(`[SSE] reconnect #${reconnectAttempts} in ${delay}ms`)
   reconnectTimer = setTimeout(() => {
     reconnectTimer = null

--- a/dashboard/src/sse.ts
+++ b/dashboard/src/sse.ts
@@ -228,10 +228,19 @@ function clearReconnectTimer(): void {
   }
 }
 
+// Smallest exponent at which RECONNECT_BASE_MS * 2^exp meets or exceeds the
+// configured RECONNECT_MAX_MS cap. Clamping the attempt counter to this value
+// (rather than the previous hard-coded 5) keeps the backoff growth-bounded
+// while still letting Math.min reach the documented 60s cap.
+const RECONNECT_MAX_EXP = Math.max(
+  1,
+  Math.ceil(Math.log2(RECONNECT_MAX_MS / RECONNECT_BASE_MS)),
+)
+
 function scheduleReconnect(): void {
   if (reconnectTimer) return
   reconnectAttempts++
-  const exp = Math.min(reconnectAttempts, 5)
+  const exp = Math.min(reconnectAttempts, RECONNECT_MAX_EXP)
   const backoff = Math.min(RECONNECT_MAX_MS, RECONNECT_BASE_MS * Math.pow(2, exp))
   const jitter = Math.random() * RECONNECT_JITTER_MS
   const delay = backoff + jitter


### PR DESCRIPTION
## Summary
- WS reconnect backoff cap 15s -> 60s with up to 1s jitter for dashboard WS and SSE reconnects.
- `DASHBOARD_WS_RPC_TIMEOUT_MS` 15s -> 30s, moved to `config/constants.ts` as the dashboard SSOT.
- Rebased onto current `main` and preserved the new WS parse-worker timeout path from main.
- Test scaffolding stubs `Math.random=0` so timer-advance assertions stay deterministic with jitter present.

## Why
Source: local diagnosis at `~/me/planning/masc-mcp-loop-diagnosis/audit.md` (run via `/loop` against `masc_mcp_final_diagnosis (1).md`).

The 15s cap with no jitter caused fleets of dashboards to retry in lockstep during keeper bring-up, amplifying Executor_pool starvation. A 60s cap with jitter desynchronizes reconnect attempts under degraded server conditions.

The 15s `dashboard/hello` JSON-RPC timeout was also smaller than the backend dashboard handler budget (30s, see `lib/server/server_dashboard_http_core.ml`), so a slow first response could become a client-side reconnect before the server gave up. The new 30s matches the backend budget.

## Why not the diagnosis other recommendations
Audited (see `~/me/planning/masc-mcp-loop-diagnosis/audit.md`):
- Step 1 (default `mode = Inline_shared`): NO-OP. `server_dashboard_http_core.ml:421` already does `if lightweight_summary then Inline_shared else Offloaded_readonly`, and 14 callsites pass `mode` explicitly. Default change would not reach a user-visible path.
- Step 3 (`VITE_DASHBOARD_WS_ONLY=false`): explicitly reverses the WS-only cutover (#10102, #10657, #10669, #12708, finalized in #13754). Not done.

## Changes
- `dashboard/src/config/constants.ts` - add `DASHBOARD_WS_RPC_TIMEOUT_MS = 30_000`, `RECONNECT_JITTER_MS = 1_000`, bump `RECONNECT_MAX_MS` 15s -> 60s.
- `dashboard/src/dashboard-ws.ts` - import constants, keep current-main parse timeout, add jitter to `scheduleReconnect`.
- `dashboard/src/sse.ts` - apply the same jitter pattern.
- `dashboard/src/dashboard-ws.test.ts` - import timeout constant and stub `Math.random=0` in `beforeEach` for deterministic timer assertions.

## Test plan
- [x] `git diff --check origin/main...HEAD` - clean.
- [x] `pnpm typecheck` - clean.
- [x] `pnpm vitest run src/dashboard-ws.test.ts src/sse.test.ts --no-file-parallelism --maxWorkers=1` - 24/24 passed.
- [ ] Reviewer should sanity-check on a live cold start: WS reconnect spacing should now scatter rather than land on the same second.

## Risk
- Behavior change: reconnect-after-failure waits up to 60s now (was 15s). Single-user latency on transient disconnect is worse by design; the trade is fleet stability under degraded server.
- `Math.random` stub in `beforeEach` is scoped per test and cleared by `restoreAllMocks` in `afterEach`, so it does not leak across files.
