### PR TITLE
fix: restore keeper source contract checks

### DIFF
--- a/scripts/audit-keeper-fleet-readiness.py
+++ b/scripts/audit-keeper-fleet-readiness.py
@@ -957,7 +957,7 @@ def scan_keeper_board_posts(
     return latest_ts, board_post_evidence, product_evidence, design_evidence
 
 
-def tool_call_paths(base_path: Path) -> list[Path]:
+def global_tool_call_paths(base_path: Path) -> list[Path]:
     calls_dir = base_path / ".masc" / "tool_calls"
     if not calls_dir.exists():
         return []
@@ -1020,7 +1020,7 @@ def scan_keeper_evidence(
         complete_lifecycle_evidence(pr_lifecycle_evidence)
         and complete_lifecycle_evidence(docker_pr_lifecycle_evidence)
     ):
-        for calls in tool_call_paths(base_path):
+        for calls in global_tool_call_paths(base_path):
             for row in iter_jsonl(calls):
                 if row.get("keeper") != name:
                     continue

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -1114,10 +1114,10 @@ let test_keeper_required_tool_contracts () =
       ~anchor:tool_choice_anchor
       "if computed_surface.required_tool_names <> []"
   in
-  let any_tool_after =
+  let preferred_required_after =
     file_pattern_position_after "lib/keeper/keeper_run_tools.ml"
       ~anchor:tool_choice_anchor
-      "then Some Agent_sdk.Types.Any"
+      "preferred_tool_choice_for_required_tool_names"
   in
   let last_turn_after =
     file_pattern_position_after "lib/keeper/keeper_run_tools.ml"
@@ -1125,9 +1125,9 @@ let test_keeper_required_tool_contracts () =
       "else if computed_surface.is_last_turn"
   in
   check bool "required_tools force tool_choice before last-turn relaxation" true
-    (match required_first, any_tool_after, last_turn_after with
-     | Some required_pos, Some any_pos, Some last_turn_pos ->
-         required_pos < any_pos && any_pos < last_turn_pos
+    (match required_first, preferred_required_after, last_turn_after with
+     | Some required_pos, Some preferred_pos, Some last_turn_pos ->
+         required_pos < preferred_pos && preferred_pos < last_turn_pos
      | _ -> false);
   check bool "last-turn relaxation no longer bypasses required_tools" true
     (file_not_contains_pattern "lib/keeper/keeper_run_tools.ml"


### PR DESCRIPTION
## Summary
- Update keeper required-tool source guard to match the current preferred required-tool selection path.
- Keep keeper PR audit contract pointed at keeper-scoped tool_call_paths while renaming the global fallback scanner helper to avoid duplicate Python definitions.

## Verification
- git diff --check origin/main...HEAD
- python3 -m py_compile scripts/audit-keeper-fleet-readiness.py
- ruff check scripts/audit-keeper-fleet-readiness.py
- scripts/check-oas-pin.sh --local-only
- env MASC_OPAM_LOCK=0 scripts/dune-local.sh build test/test_ci_hardening_source.exe
- ./_build/default/test/test_ci_hardening_source.exe: 53 tests passed

pyright --outputjson scripts/audit-keeper-fleet-readiness.py could not run because pyright is not installed in this environment.

Closes #13791.