### PR TITLE
fix(main): repair keeper turn match stack

### DIFF
--- a/lib/keeper/keeper_execution_receipt.ml
+++ b/lib/keeper/keeper_execution_receipt.ml
@@ -716,7 +716,6 @@ let stale_terminal_reason_code = function
   | Some (Keeper_registry.Stale_fleet_batch _) -> "stale_fleet_batch"
   | Some (Keeper_registry.Stale_termination_storm _) ->
       "stale_termination_storm"
-  | Some (Keeper_registry.Stale_fleet_batch _) -> "stale_fleet_batch"
   | Some (Keeper_registry.Heartbeat_consecutive_failures _) ->
       "heartbeat_failures"
   | Some (Keeper_registry.Turn_consecutive_failures _) -> "turn_failures"

--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -670,4 +670,4 @@ let handle_keeper_msg ?on_text_delta ctx args : tool_result =
               in
               (true, Yojson.Safe.to_string reply_json)
 
-)))))
+))))))


### PR DESCRIPTION
## What changed

- Restores the missing closing parenthesis at the end of `handle_keeper_msg` after the latest merged stack left the `keeper_msg_timeout_override` match open.
- Removes the duplicate `Stale_fleet_batch` arm in `stale_terminal_reason_code` that made the second arm unreachable under warnings-as-errors.

## Why

Current `main` fails focused OCaml compilation before unrelated dashboard tests can build. These are merge-artifact repairs only.

## Validation

- `dune build --root . test/test_dashboard_safe_autonomy.exe`
- `git diff --check`
- CI Gate: pass on head `d1bec98f4034ec7a52a9f56a682ccbfd18accf3e`
- PR Live Gate: pass
- PR Sync Check: pass

Note: running `./_build/default/test/test_dashboard_safe_autonomy.exe` currently exposes an unrelated pre-existing assertion failure in `artifact history dedupes identical payloads` (`history lines stay deduped`: expected 1, got 2). This PR is scoped to the compile gate repair.

Closes #13806.