### PR TITLE
Recover Docker PR lifecycle proof gates

### DIFF
--- a/docs/KEEPER-DOCKER-PR-LIFECYCLE-REPROBE.md
+++ b/docs/KEEPER-DOCKER-PR-LIFECYCLE-REPROBE.md
@@ -46,17 +46,17 @@ status records pending requests as lost; the other two log a transient
 notice and the next poll iteration retries.
 When mutation is enabled, the harness sends `required_tools` with each
 `masc_keeper_msg` call. By default that one-turn contract requires
-`keeper_shell`, `keeper_bash`, `masc_code_git`, `keeper_pr_create`, and
+`keeper_shell`, `keeper_bash`, `keeper_pr_create`, and
 `keeper_pr_review_comment`, so the runtime records `tool_surface_mismatch` if
 those tools are not visible and `missing_required_tool_use` if the keeper
 replies without exercising them.
-The prompt reserves `keeper_shell` and `keeper_bash` for read-only inspection.
-Mutating git operations must go through `masc_code_git`; otherwise the shell
-guard can correctly reject `git commit`/`git push` with `write_operation_gated`
-and the run will not produce Docker push evidence.
-Likewise, proof-file writes should use `keeper_fs_edit`, and PR create/review
-mutations should use `keeper_pr_create` / `keeper_pr_review_comment` rather
-than `gh pr ...` through shell tools.
+The prompt reserves `keeper_shell` for read-only GitHub inspection.
+Proof-file creation and git add/commit/push should use `keeper_bash` from
+inside the Docker playground so the route evidence is tied to the keeper
+container path. If the shell guard rejects the git mutation, the keeper must
+stop and report that blocker instead of falling back to host-local credentials.
+PR create/review mutations should use `keeper_pr_create` /
+`keeper_pr_review_comment` rather than `gh pr ...` through shell tools.
 Override the CSV with `REQUIRED_TOOLS=...` for a narrower or broader proof
 lane.
 `MSG_TIMEOUT_SEC` only bounds the harness HTTP request to the MCP server.

--- a/lib/keeper/keeper_execution_receipt.ml
+++ b/lib/keeper/keeper_execution_receipt.ml
@@ -722,6 +722,7 @@ let stale_terminal_reason_code = function
   | Some (Keeper_registry.Turn_consecutive_failures _) -> "turn_failures"
   | Some (Keeper_registry.Ambiguous_partial_commit _) ->
       "ambiguous_partial_commit"
+  | Some (Keeper_registry.Stale_fleet_batch _) -> "stale_fleet_batch"
   | Some Keeper_registry.Fiber_unresolved -> "fiber_unresolved"
   | Some (Keeper_registry.Exception _) -> "exception"
   | None -> "stale_turn_timeout"

--- a/lib/keeper/keeper_tool_github_pr.ml
+++ b/lib/keeper/keeper_tool_github_pr.ml
@@ -72,6 +72,12 @@ let build_pr_status_argv ~repo ~pr_number =
   |> with_repo_arg repo
   |> fun argv -> argv @ [ "--json"; pr_json_fields ^ ",body,files,reviews,comments" ]
 
+let build_pr_view_recovery_argv ~repo ~head =
+  let head = Option.map String.trim head |> Option.value ~default:"" in
+  (if head = "" then [ "gh"; "pr"; "view" ] else [ "gh"; "pr"; "view"; head ])
+  |> with_repo_arg repo
+  |> fun argv -> argv @ [ "--json"; pr_json_fields ^ ",body" ]
+
 let build_pr_create_argv ~repo ~title ~body ~base ~head =
   [ "gh"; "pr"; "create" ]
   |> with_repo_arg repo
@@ -140,6 +146,29 @@ let status_ok = function
   | Unix.WEXITED 0 -> true
   | _ -> false
 
+let contains_substring haystack needle =
+  let needle_len = String.length needle in
+  let haystack_len = String.length haystack in
+  let rec loop idx =
+    if needle_len = 0 then true
+    else if idx + needle_len > haystack_len then false
+    else if String.sub haystack idx needle_len = needle then true
+    else loop (idx + 1)
+  in
+  loop 0
+
+let pr_create_failure_may_have_created_pr output =
+  let output = String.lowercase_ascii output in
+  List.exists
+    (contains_substring output)
+    [
+      "http 504";
+      "504 gateway timeout";
+      "gateway timeout";
+      "context deadline exceeded";
+      "i/o timeout";
+    ]
+
 type gh_exec_result =
   { status : Unix.process_status
   ; output : string
@@ -183,23 +212,25 @@ let sandbox_profile_string (meta : keeper_meta) =
   | Docker -> "docker"
   | Local -> "local"
 
-let output_json ~ok ~tool ~operation ~meta ~binding ~state ~cwd ~via ~output =
+let output_json ?(extra_fields = []) ~ok ~tool ~operation ~meta ~binding
+    ~state ~cwd ~via ~output () =
   Yojson.Safe.to_string
     (`Assoc
-      [
-        "ok", `Bool ok;
-        "tool", `String tool;
-        "operation", `String operation;
-        "keeper", `String meta.name;
-        "sandbox_profile", `String (sandbox_profile_string meta);
-        "via", `String via;
-        "route_via", `String via;
-        "credential", binding_json binding ~state;
-        "cwd", `String cwd;
-        "output", `String output;
-      ])
+      ([
+         "ok", `Bool ok;
+         "tool", `String tool;
+         "operation", `String operation;
+         "keeper", `String meta.name;
+         "sandbox_profile", `String (sandbox_profile_string meta);
+         "via", `String via;
+         "route_via", `String via;
+         "credential", binding_json binding ~state;
+         "cwd", `String cwd;
+         "output", `String output;
+       ]
+       @ extra_fields))
 
-let run_gh ~tool ~operation ~config ~meta ~args ~write argv =
+let run_gh ?recover_pr_create ~tool ~operation ~config ~meta ~args ~write argv =
   match scoped_credential_or_error ~config ~meta with
   | Error json -> Yojson.Safe.to_string json
   | Ok (binding, state, env) -> (
@@ -229,8 +260,35 @@ let run_gh ~tool ~operation ~config ~meta ~args ~write argv =
           let result =
             run_gh_argv ~config ~meta ~env ~cwd ~timeout_sec argv
           in
-          output_json ~ok:(status_ok result.status) ~tool ~operation ~meta
-            ~binding ~state ~cwd ~via:result.via ~output:result.output)
+          let result_ok = status_ok result.status in
+          let recovered =
+            match recover_pr_create with
+            | Some (repo, head)
+              when (not result_ok)
+                   && pr_create_failure_may_have_created_pr result.output ->
+                let recovery =
+                  run_gh_argv ~config ~meta ~env ~cwd ~timeout_sec
+                    (build_pr_view_recovery_argv ~repo ~head)
+                in
+                if status_ok recovery.status then Some recovery else None
+            | _ -> None
+          in
+          (match recovered with
+           | Some recovery ->
+               output_json ~ok:true ~tool ~operation ~meta ~binding ~state
+                 ~cwd ~via:recovery.via ~output:recovery.output
+                 ~extra_fields:
+                   [
+                     ( "recovered_from_error",
+                       `String "pr_create_transient_failure" );
+                     "original_ok", `Bool false;
+                     "original_output", `String result.output;
+                     "recovery_tool", `String "gh pr view";
+                   ]
+                 ()
+           | None ->
+               output_json ~ok:result_ok ~tool ~operation ~meta ~binding
+                 ~state ~cwd ~via:result.via ~output:result.output ()))
 
 let handle_keeper_pr_list ~(config : Coord.config) ~(meta : keeper_meta)
     ~(args : Yojson.Safe.t) =
@@ -275,14 +333,18 @@ let handle_keeper_pr_create ~(config : Coord.config) ~(meta : keeper_meta)
         ])
   else
     run_gh ~tool:"keeper_pr_create" ~operation:"pr_create" ~config ~meta
-      ~args ~write:true
+      ~args ~write:true ~recover_pr_create:(repo, head)
       (build_pr_create_argv ~repo ~title ~body ~base ~head)
 
 module For_testing = struct
   let build_pr_list_argv = build_pr_list_argv
   let build_pr_status_argv = build_pr_status_argv
+  let build_pr_view_recovery_argv = build_pr_view_recovery_argv
   let build_pr_create_argv = build_pr_create_argv
   let draft_request_allowed = draft_request_allowed
+  let pr_create_failure_may_have_created_pr =
+    pr_create_failure_may_have_created_pr
+
   let quote_argv = quote_argv
   let mutation_preset_ok = mutation_preset_ok
 end

--- a/scripts/audit-keeper-fleet-readiness.py
+++ b/scripts/audit-keeper-fleet-readiness.py
@@ -445,6 +445,7 @@ MARKER_OBJECT_FIELDS = (
     "evidence",
     "metadata",
     "route",
+    "route_evidence",
     "tool_metadata",
 )
 
@@ -556,6 +557,12 @@ def has_docker_execution_marker(row: dict[str, Any]) -> bool:
         "route.route_via=brokered",
         "route.via=docker",
         "route.via=brokered",
+        "route_evidence.execution_via=docker",
+        "route_evidence.execution_via=brokered",
+        "route_evidence.route_via=docker",
+        "route_evidence.route_via=brokered",
+        "route_evidence.via=docker",
+        "route_evidence.via=brokered",
         "route_via=docker",
         "route_via=brokered",
         "tool_metadata.execution_via=docker",
@@ -806,9 +813,9 @@ def pr_action_metric_paths(
     return [path for _, _, path in sorted(candidates, reverse=True)]
 
 
-def tool_call_paths(base_path: Path, name: str) -> list[Path]:
+def pr_creation_scan_paths(base_path: Path, name: str) -> list[Path]:
     root = base_path / ".masc"
-    paths = decision_log_paths(base_path, name)
+    paths: list[Path] = decision_log_paths(base_path, name)
     history = root / "keepers" / name / ".playground_pr_history.jsonl"
     if history.exists():
         paths.append(history)
@@ -823,15 +830,23 @@ def tool_call_paths(base_path: Path, name: str) -> list[Path]:
         paths.extend(
             sorted(path for path in trajectories.glob("*.jsonl") if path.is_file())
         )
+    calls_dir = root / "tool_calls"
+    if calls_dir.exists():
+        paths.extend(
+            sorted(path for path in calls_dir.rglob("*.jsonl") if path.is_file())
+        )
     return paths
 
 
 def scan_pr_creation_evidence(base_path: Path, name: str) -> PrCreationEvidence:
     refs: set[str] = set()
     sources: set[str] = set()
-    for path in tool_call_paths(base_path, name):
+    for path in pr_creation_scan_paths(base_path, name):
         for row in iter_jsonl(path):
             row = dict(row)
+            row_keeper = row.get("keeper") or row.get("keeper_name") or row.get("name")
+            if isinstance(row_keeper, str) and row_keeper != name:
+                continue
             row["_source_path"] = str(path)
             row_refs, row_sources = pr_evidence_from_row(row)
             refs.update(row_refs)

--- a/scripts/harness/workload/keeper_docker_pr_lifecycle_reprobe.sh
+++ b/scripts/harness/workload/keeper_docker_pr_lifecycle_reprobe.sh
@@ -36,7 +36,7 @@ KEEPER_TURN_TIMEOUT_SEC="${KEEPER_TURN_TIMEOUT_SEC:-900}"
 INIT_TIMEOUT_SEC="${INIT_TIMEOUT_SEC:-60}"
 POLL_TIMEOUT_SEC="${POLL_TIMEOUT_SEC:-1200}"
 POLL_INTERVAL_SEC="${POLL_INTERVAL_SEC:-10}"
-REQUIRED_TOOLS="${REQUIRED_TOOLS:-keeper_shell,keeper_bash,masc_code_git,keeper_pr_create,keeper_pr_review_comment}"
+REQUIRED_TOOLS="${REQUIRED_TOOLS:-keeper_shell,keeper_bash,keeper_pr_create,keeper_pr_review_comment}"
 MCP_URL="${MCP_URL:-http://127.0.0.1:8935/mcp}"
 MCP_TOKEN="${MASC_MCP_TOKEN:-}"
 MCP_CLIENT_NAME="${MCP_CLIENT_NAME:-keeper-docker-pr-lifecycle-reprobe}"
@@ -803,18 +803,18 @@ Keeper: $keeper
 Goal: produce direct, auditable Docker-backed evidence for PR create, git push, PR review/comment, and PR APPROVE. Use native keeper tools where available; do not use host-local ambient GitHub credentials.
 
 Tool route rules:
-- Use keeper_shell or keeper_bash only for read-only inspection.
-- Do not run git commit, git push, or other mutating git commands through keeper_bash.
+- Use keeper_shell for read-only GitHub inspection.
+- Use keeper_bash inside your Docker playground for proof-file creation and git add/commit/push on the proof branch.
 - Do not run gh pr create, gh pr review, or other mutating GitHub commands through keeper_shell or keeper_bash.
-- Use keeper_fs_edit for the minimal proof-file edit inside the Docker playground; do not use approval-requiring host code-write paths for this proof file.
-- Use masc_code_git for git commit and git push so the runtime can attach Docker route evidence and avoid write_operation_gated shell denials.
+- Do not use approval-requiring host code-write paths such as masc_code_write for this proof file.
+- If keeper_bash rejects mutating git as policy-blocked, stop and report the exact blocker instead of switching to host-local credentials.
 - Use keeper_pr_create and keeper_pr_review_comment for PR mutation/review actions.
 
 Required proof lane:
 1. Confirm your runtime is sandbox_profile=docker before mutating.
 2. Create a unique proof branch named: keeper/$keeper-docker-pr-proof-$RUN_ID
-3. Make a minimal, non-product proof edit under docs/runtime-proof/keepers/$keeper-$RUN_ID.md with keeper_fs_edit.
-4. Commit and git push that branch with masc_code_git. The tool result must show explicit Docker-backed route evidence such as via=docker, route_via=docker, via=brokered, or route_via=brokered.
+3. Make a minimal, non-product proof edit under docs/runtime-proof/keepers/$keeper-$RUN_ID.md with keeper_bash from inside the Docker playground.
+4. Commit and git push that branch with keeper_bash. The tool result must show explicit Docker-backed route evidence such as via=docker, route_via=docker, via=brokered, or route_via=brokered.
 5. Create a draft PR for that branch with keeper_pr_create or the native PR-create tool path. Do not mark ready, do not merge, do not add human-approved-ready.
 6. Use keeper_pr_review_read and keeper_pr_review_comment for review evidence. COMMENT is allowed on your own proof PR. APPROVE must target the cross-keeper PR below, not your own PR.
 

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -1141,10 +1141,10 @@ let test_keeper_required_tool_contracts () =
   check bool "docker PR lifecycle harness default matches runbook" true
     (file_contains_pattern
        "scripts/harness/workload/keeper_docker_pr_lifecycle_reprobe.sh"
-       {|REQUIRED_TOOLS="${REQUIRED_TOOLS:-keeper_shell,keeper_bash,masc_code_git,keeper_pr_create,keeper_pr_review_comment}"|});
+       {|REQUIRED_TOOLS="${REQUIRED_TOOLS:-keeper_shell,keeper_bash,keeper_pr_create,keeper_pr_review_comment}"|});
   check bool "runbook documents docker PR lifecycle required tool default" true
     (file_contains_pattern "docs/KEEPER-DOCKER-PR-LIFECYCLE-REPROBE.md"
-       "`keeper_shell`, `keeper_bash`, `masc_code_git`, `keeper_pr_create`, and");
+       "`keeper_shell`, `keeper_bash`, `keeper_pr_create`, and");
   check bool "docker PR lifecycle prompt accepts brokered route proof" true
     (file_contains_pattern
        "scripts/harness/workload/keeper_docker_pr_lifecycle_reprobe.sh"
@@ -1195,18 +1195,18 @@ let test_keeper_msg_timeout_contracts () =
     (file_contains_pattern
        "scripts/harness/workload/keeper_docker_pr_lifecycle_reprobe.sh"
        "server_incarnation_changed");
-  check bool "docker PR lifecycle prompt routes mutating git through masc_code_git" true
+  check bool "docker PR lifecycle prompt routes mutating git through docker bash" true
     (file_contains_pattern
        "scripts/harness/workload/keeper_docker_pr_lifecycle_reprobe.sh"
-       "Do not run git commit, git push, or other mutating git commands through keeper_bash");
-  check bool "docker PR lifecycle prompt names masc_code_git for push" true
+       "Use keeper_bash inside your Docker playground for proof-file creation and git add/commit/push");
+  check bool "docker PR lifecycle prompt names keeper_bash for push" true
     (file_contains_pattern
        "scripts/harness/workload/keeper_docker_pr_lifecycle_reprobe.sh"
-       "Commit and git push that branch with masc_code_git");
-  check bool "docker PR lifecycle prompt uses keeper_fs_edit for proof edit" true
+       "Commit and git push that branch with keeper_bash");
+  check bool "docker PR lifecycle prompt uses docker bash for proof edit" true
     (file_contains_pattern
        "scripts/harness/workload/keeper_docker_pr_lifecycle_reprobe.sh"
-       "with keeper_fs_edit");
+       "with keeper_bash from inside the Docker playground");
   check bool "docker PR lifecycle prompt forbids gh pr shell mutation" true
     (file_contains_pattern
        "scripts/harness/workload/keeper_docker_pr_lifecycle_reprobe.sh"
@@ -1312,6 +1312,11 @@ let test_keeper_pr_audit_contracts () =
        "pr_action_metric_paths"
      && file_contains_pattern "scripts/audit-keeper-fleet-readiness.py"
           "tool_call_paths");
+  check bool "keeper fleet audit recognizes route_evidence docker markers" true
+    (file_contains_pattern "scripts/audit-keeper-fleet-readiness.py"
+       "route_evidence"
+     && file_contains_pattern "scripts/audit-keeper-fleet-readiness.py"
+          "route_evidence.via=docker");
   check bool "keeper fleet audit survives live invalid utf8 rows" true
     (file_contains_pattern "scripts/audit-keeper-fleet-readiness.py"
        {|errors="replace"|})

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -1311,7 +1311,9 @@ let test_keeper_pr_audit_contracts () =
     (file_contains_pattern "scripts/audit-keeper-fleet-readiness.py"
        "pr_action_metric_paths"
      && file_contains_pattern "scripts/audit-keeper-fleet-readiness.py"
-          "tool_call_paths");
+          "pr_creation_scan_paths"
+     && file_contains_pattern "scripts/audit-keeper-fleet-readiness.py"
+          {|root / "tool_calls"|});
   check bool "keeper fleet audit recognizes route_evidence docker markers" true
     (file_contains_pattern "scripts/audit-keeper-fleet-readiness.py"
        "route_evidence"

--- a/test/test_keeper_github_pr.ml
+++ b/test/test_keeper_github_pr.ml
@@ -144,10 +144,23 @@ let fake_gh_echo_script =
    printf 'gh:%s\\n' \"$*\"\n\
    exit 0\n"
 
-let with_fake_gh f =
+let fake_gh_pr_create_504_then_view_script =
+  "#!/bin/sh\n\
+   if [ \"$1\" = \"pr\" ] && [ \"$2\" = \"create\" ]; then\n\
+   \  printf 'pull request create failed: HTTP 504: 504 Gateway Timeout (https://api.github.com/graphql)\\n' >&2\n\
+   \  exit 1\n\
+   fi\n\
+   if [ \"$1\" = \"pr\" ] && [ \"$2\" = \"view\" ]; then\n\
+   \  printf '{\"number\":13799,\"url\":\"https://github.com/jeong-sik/masc-mcp/pull/13799\",\"headRefName\":\"feature/recovered\",\"state\":\"OPEN\",\"isDraft\":true}\\n'\n\
+   \  exit 0\n\
+   fi\n\
+   printf 'unexpected gh invocation: %s\\n' \"$*\" >&2\n\
+   exit 2\n"
+
+let with_fake_gh_script script f =
   let dir = temp_dir () in
   let gh_path = Filename.concat dir "gh" in
-  write_file gh_path fake_gh_echo_script;
+  write_file gh_path script;
   Unix.chmod gh_path 0o755;
   let path =
     match Sys.getenv_opt "PATH" with
@@ -156,6 +169,8 @@ let with_fake_gh f =
   in
   Fun.protect ~finally:(fun () -> cleanup_dir dir) @@ fun () ->
   with_env "PATH" path f
+
+let with_fake_gh f = with_fake_gh_script fake_gh_echo_script f
 
 let with_fake_docker f =
   let dir = temp_dir () in
@@ -202,6 +217,9 @@ let setup_docker_pr_tool f =
 
 let parse_string_field raw field =
   Yojson.Safe.from_string raw |> Json.member field |> Json.to_string_option
+
+let parse_bool_field raw field =
+  Yojson.Safe.from_string raw |> Json.member field |> Json.to_bool_option
 
 let test_pr_list_argv_uses_repo_state_limit_json () =
   check (list string) "argv"
@@ -327,6 +345,32 @@ let test_pr_create_hard_mode_routes_through_broker () =
     || contains_substring raw "gh:pr create");
   check bool "keeps draft flag" true (contains_substring raw "--draft")
 
+let test_pr_create_recovers_visible_pr_after_transient_504 () =
+  with_fake_gh_script fake_gh_pr_create_504_then_view_script @@ fun () ->
+  with_env "MASC_KEEPER_SANDBOX_HARD_MODE" "true" @@ fun () ->
+  setup_docker_pr_tool @@ fun ~config ~meta ->
+  let raw =
+    K.handle_keeper_pr_create ~config ~meta
+      ~args:
+        (`Assoc
+          [
+            ("repo", `String "jeong-sik/masc-mcp");
+            ("title", `String "recovered draft PR");
+            ("body", `String "recovered draft PR body");
+            ("head", `String "feature/recovered");
+            ("cwd", `String "repos/masc-mcp");
+          ])
+  in
+  check (option bool) "recovered pr create ok" (Some true)
+    (parse_bool_field raw "ok");
+  check (option string) "recovery marker"
+    (Some "pr_create_transient_failure")
+    (parse_string_field raw "recovered_from_error");
+  check bool "keeps original 504 evidence" true
+    (contains_substring raw "HTTP 504");
+  check bool "returns recovered PR metadata" true
+    (contains_substring raw "https://github.com/jeong-sik/masc-mcp/pull/13799")
+
 (* Regression: any preset that grants the [github] group in
    config/tool_policy.toml must satisfy [mutation_preset_ok]. Without
    this, [keeper_pr_create] is visible in the keeper tool surface but
@@ -379,6 +423,8 @@ let () =
             test_pr_create_routes_through_docker;
           test_case "pr create hard mode routes through broker" `Quick
             test_pr_create_hard_mode_routes_through_broker;
+          test_case "pr create recovers visible PR after transient 504" `Quick
+            test_pr_create_recovers_visible_pr_after_transient_504;
         ] );
       ( "preset_gate",
         [


### PR DESCRIPTION
## Summary

- recover `keeper_pr_create` when GitHub returns a transient 504 but the draft PR is visible via `gh pr view <head>`
- make the Docker PR lifecycle harness use Docker `keeper_bash` for proof-file and git push evidence, while keeping PR create/review on native keeper PR tools
- fix the fleet audit evidence paths so global tool-call route evidence and keeper-local PR creation evidence are both scanned
- add the missing `Stale_fleet_batch` receipt label case that currently blocks focused builds on current main

## Why This Matters

Live run `docker-pr-lifecycle-smoke-0506f` produced a real analyst draft PR (#13799) and Docker git push evidence, but the harness/audit still failed because:

- GitHub returned `HTTP 504` from `keeper_pr_create` even though the PR was created.
- Audit ignored `route_evidence.via=docker` on tool-call rows, so Docker git push evidence stayed invisible.
- The prompt pushed verifier toward `masc_code_git` / host code-write paths that do not match Docker playground paths and can hit approval gates.

## Verification

- `python3 -m py_compile scripts/audit-keeper-fleet-readiness.py`
- `bash -n scripts/harness/workload/keeper_docker_pr_lifecycle_reprobe.sh scripts/harness_keeper_docker_pr_lifecycle_reprobe.sh`
- `git diff --check origin/main...HEAD`
- `python3 scripts/audit-keeper-fleet-readiness.py --base-path /Users/dancer/me --expected-keepers 14 --require-docker-pr-lifecycle-evidence --forbid-github-identity jeong-sik --json`
  - expected nonzero: objective still incomplete
  - analyst now shows `docker_pr_create_action=true`, `docker_git_push_action=true`, `docker_pr_approve_mutation=false`
  - verifier still lacks PR create / push / approve evidence from the old 0506f prompt

Local focused Dune was attempted but blocked behind the shared opam/dune locks; CI should be treated as the full build gate for this branch.
