### PR TITLE
fix(dashboard): stabilize safe autonomy history

### DIFF
--- a/lib/dashboard/dashboard_safe_autonomy.ml
+++ b/lib/dashboard/dashboard_safe_autonomy.ml
@@ -1020,7 +1020,7 @@ let normalize_for_hash (json : Yojson.Safe.t) =
         `Assoc
           (fields
           |> List.filter_map (fun (key, value) ->
-                 if List.mem key [ "generated_at"; "generated_at_unix" ] then None
+                 if List.mem key [ "generated_at"; "generated_at_unix"; "history" ] then None
                  else Some (key, aux value)))
     | `List values -> `List (List.map aux values)
     | other -> other

--- a/lib/keeper/keeper_execution_receipt.ml
+++ b/lib/keeper/keeper_execution_receipt.ml
@@ -716,7 +716,6 @@ let stale_terminal_reason_code = function
   | Some (Keeper_registry.Stale_fleet_batch _) -> "stale_fleet_batch"
   | Some (Keeper_registry.Stale_termination_storm _) ->
       "stale_termination_storm"
-  | Some (Keeper_registry.Stale_fleet_batch _) -> "stale_fleet_batch"
   | Some (Keeper_registry.Heartbeat_consecutive_failures _) ->
       "heartbeat_failures"
   | Some (Keeper_registry.Turn_consecutive_failures _) -> "turn_failures"

--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -670,4 +670,4 @@ let handle_keeper_msg ?on_text_delta ctx args : tool_result =
               in
               (true, Yojson.Safe.to_string reply_json)
 
-)))))
+))))))

--- a/test/test_dashboard_safe_autonomy.ml
+++ b/test/test_dashboard_safe_autonomy.ml
@@ -214,6 +214,31 @@ let test_history_dedupes_identical_payloads () =
       check bool "latest file is valid json" true
         (match latest_json with `Assoc _ -> true | _ -> false)))
 
+let test_history_field_returns_last_15_scores () =
+  with_safe_autonomy_store @@ fun config ->
+  ignore (persist_keeper config);
+  let history_dir =
+    Filename.concat (Coord.masc_root_dir config) "audits/safe_autonomy"
+  in
+  Fs_compat.mkdir_p history_dir;
+  let history_path = Filename.concat history_dir "history.jsonl" in
+  for i = 1 to 20 do
+    Fs_compat.append_jsonl history_path
+      (`Assoc
+        [
+          ( "summary",
+            `Assoc [ ("global_score", `Float (float_of_int i)) ] );
+        ])
+  done;
+  let json = Dashboard_safe_autonomy.json ~config () in
+  let history =
+    Yojson.Safe.Util.(json |> member "history" |> to_list |> List.map to_float)
+  in
+  check int "history length capped" 15 (List.length history);
+  check (list (float 0.001)) "history keeps newest 15 scores"
+    (List.init 15 (fun idx -> float_of_int (idx + 6)))
+    history
+
 let test_sandbox_live_probe_is_bounded_per_keeper () =
   with_safe_autonomy_store @@ fun config ->
   ignore (persist_docker_keeper config ~name:"docker-a");
@@ -243,6 +268,8 @@ let () =
             test_json_emits_scorecard_and_artifacts;
           test_case "artifact history dedupes identical payloads" `Quick
             test_history_dedupes_identical_payloads;
+          test_case "history field returns last 15 scores" `Quick
+            test_history_field_returns_last_15_scores;
           test_case "sandbox live probe is bounded per keeper" `Quick
             test_sandbox_live_probe_is_bounded_per_keeper;
         ] );


### PR DESCRIPTION
## What changed

- Excludes the top-level `history` field from the safe-autonomy artifact fingerprint.
- Adds regression coverage that `/api/v1/dashboard/safe-autonomy` returns the last 15 score samples in `history`.

## Why

Issue #11570's backend field already exists, but including `history` in the payload hash made the audit artifact self-referential: the first request writes `history=[]`, the next request reads that score into `history=[...]`, changes the fingerprint, and appends a duplicate history line for an otherwise identical payload.

The trend field should be observable in the response, but it must not make the artifact history append on every read.

## Stack

- Stacked on #13814 (`fix/main-keeper-turn-stack-0506`) because current main needs that compile-gate repair for this focused test target.

## Validation

- `dune build --root . test/test_dashboard_safe_autonomy.exe`
- `./_build/default/test/test_dashboard_safe_autonomy.exe`
- `git diff --check fix/main-keeper-turn-stack-0506..HEAD`