### PR TITLE
fix(dashboard): sync navigation.test.ts with goal-loop section

### DIFF
--- a/dashboard/src/config/navigation.test.ts
+++ b/dashboard/src/config/navigation.test.ts
@@ -114,12 +114,13 @@ describe('monitoring navigation labels', () => {
     const sections = visibleSectionItemsForTab('monitoring')
     const ids = sections.map(item => item.id)
 
-    expect(ids).toEqual(['journey', 'agents', 'cognition', 'runtime', 'fleet-health'])
+    expect(ids).toEqual(['journey', 'agents', 'cognition', 'runtime', 'goal-loop', 'fleet-health'])
     expect(ids).toContain('journey')
     expect(ids).toContain('cognition')
     expect(ids).toContain('fleet-health')
     expect(ids).toContain('runtime')
     expect(ids).toContain('agents')
+    expect(ids).toContain('goal-loop')
     // Legacy sections removed in Phase 1
     expect(ids).not.toContain('live')
     expect(ids).not.toContain('observatory')
@@ -142,7 +143,8 @@ describe('monitoring navigation labels', () => {
     expect(sections[1]?.id).toBe('agents')
     expect(sections[2]?.id).toBe('cognition')
     expect(sections[3]?.id).toBe('runtime')
-    expect(sections[4]?.id).toBe('fleet-health')
+    expect(sections[4]?.id).toBe('goal-loop')
+    expect(sections[5]?.id).toBe('fleet-health')
   })
 
   it('keeps diagnostic monitoring routes available but hidden from the sidebar', () => {


### PR DESCRIPTION
## Summary
PR #13655 (feat(goal-loop): wire operator dashboard panel)이 monitoring sidebar에 \`goal-loop\` section을 index 4 (runtime ↔ fleet-health 사이)에 추가했으나 \`navigation.test.ts\`를 함께 update하지 않아 main이 깨진 상태입니다.

## 실패 중인 expectation (2건)
- **L117 toEqual**: 5개 ID 기대(\`['journey','agents','cognition','runtime','fleet-health']\`), 실제 6개
- **L145 toBe**: sections[4] === 'fleet-health' 기대, 실제 'goal-loop'

## Fix
실제 visible 순서에 맞춰 expectation 동기화:
\`['journey', 'agents', 'cognition', 'runtime', 'goal-loop', 'fleet-health']\`

## Verification
- \`pnpm exec vitest run src/config/navigation.test.ts\` → **43/43 pass** (이전 41/43)

## Why Draft
AI agent 작성 PR. 사용자 검토 후 \`human-approved-ready\` 라벨 + ready 전환 권장.

## 참고
- 사용자 in-flight PR (#13481/#13787/#13777) opam-pin/structure-ratchet 영역과 분리되어 split-brain 위험 없음 확인.
- 변경 1 파일 / 4+ 2- lines.