### PR TITLE
fix(oas): preserve agent completed result

### DIFF
--- a/lib/keeper/keeper_execution_receipt.ml
+++ b/lib/keeper/keeper_execution_receipt.ml
@@ -716,7 +716,6 @@ let stale_terminal_reason_code = function
   | Some (Keeper_registry.Stale_fleet_batch _) -> "stale_fleet_batch"
   | Some (Keeper_registry.Stale_termination_storm _) ->
       "stale_termination_storm"
-  | Some (Keeper_registry.Stale_fleet_batch _) -> "stale_fleet_batch"
   | Some (Keeper_registry.Heartbeat_consecutive_failures _) ->
       "heartbeat_failures"
   | Some (Keeper_registry.Turn_consecutive_failures _) -> "turn_failures"

--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -670,4 +670,4 @@ let handle_keeper_msg ?on_text_delta ctx args : tool_result =
               in
               (true, Yojson.Safe.to_string reply_json)
 
-)))))
+))))))

--- a/lib/oas_event_bridge.ml
+++ b/lib/oas_event_bridge.ml
@@ -41,6 +41,49 @@ let payload_int_opt key = function
       | _ -> None)
   | _ -> None
 
+let stop_reason_to_wire = function
+  | Agent_sdk.Types.EndTurn -> "end_turn"
+  | Agent_sdk.Types.StopToolUse -> "tool_use"
+  | Agent_sdk.Types.MaxTokens -> "max_tokens"
+  | Agent_sdk.Types.StopSequence -> "stop_sequence"
+  | Agent_sdk.Types.Unknown value -> value
+
+let agent_completed_usage_fields (response : Agent_sdk.Types.api_response) =
+  match response.usage with
+  | None -> [ ("usage_reported", `Bool false) ]
+  | Some usage ->
+      [
+        ("usage_reported", `Bool true);
+        ("input_tokens", `Int usage.input_tokens);
+        ("output_tokens", `Int usage.output_tokens);
+        ( "cache_creation_input_tokens",
+          `Int usage.cache_creation_input_tokens );
+        ("cache_read_input_tokens", `Int usage.cache_read_input_tokens);
+        ("total_tokens", `Int (usage.input_tokens + usage.output_tokens));
+        ( "cost_usd",
+          match usage.cost_usd with
+          | Some cost -> `Float cost
+          | None -> `Null );
+      ]
+
+let agent_completed_result_fields = function
+  | Ok (response : Agent_sdk.Types.api_response) ->
+      [
+        ("success", `Bool true);
+        ("result", `String "ok");
+        ("response_id", `String response.id);
+        ("model", `String response.model);
+        ("stop_reason", `String (stop_reason_to_wire response.stop_reason));
+      ]
+      @ agent_completed_usage_fields response
+  | Error error ->
+      [
+        ("success", `Bool false);
+        ("result", `String "error");
+        ("error", `String (Agent_sdk.Error.to_string error));
+        ("usage_reported", `Bool false);
+      ]
+
 let payload_agent_name payload =
   (* Check [agent_name], [agent], then [keeper_name] for Custom events
      whose publisher stores the per-agent attribution under the
@@ -171,7 +214,6 @@ let native_event_to_json (evt : Agent_sdk.Event_bus.event) : Yojson.Safe.t optio
       in
       Some (wrap ~event_type:"agent_started" ~payload ~agent_name ~task_id ())
   | Agent_sdk.Event_bus.AgentCompleted { agent_name; task_id; elapsed; result } ->
-      let usage_fields = match result with Ok _ -> [] | Error _ -> [] in
       let payload =
         `Assoc
           ([
@@ -179,7 +221,7 @@ let native_event_to_json (evt : Agent_sdk.Event_bus.event) : Yojson.Safe.t optio
              ("task_id", `String task_id);
              ("elapsed_s", `Float elapsed);
            ]
-          @ usage_fields)
+          @ agent_completed_result_fields result)
       in
       Some (wrap ~event_type:"agent_completed" ~payload ~agent_name ~task_id ())
   | Agent_sdk.Event_bus.AgentFailed { agent_name; task_id; error; elapsed } ->

--- a/test/test_oas_integration.ml
+++ b/test/test_oas_integration.ml
@@ -610,6 +610,54 @@ let test_agent_completed_includes_usage () =
          | _ -> "")
   | Some _ -> Alcotest.fail "expected assoc"
 
+let test_agent_completed_omits_usage_fields_when_success_has_no_usage () =
+  let open Agent_sdk in
+  let resp : Llm_provider.Types.api_response =
+    {
+      id = "msg-no-usage";
+      model = "test-model";
+      stop_reason = EndTurn;
+      content = [];
+      usage = None;
+      telemetry = None;
+    }
+  in
+  let evt =
+    Event_bus.mk_event ~correlation_id:"sess-no-usage" ~run_id:"run-no-usage"
+      (AgentCompleted
+         {
+           agent_name = "no-usage-agent";
+           task_id = "task-no-usage";
+           result = Ok resp;
+           elapsed = 0.25;
+         })
+  in
+  match Oas_event_bridge.native_event_to_json evt with
+  | None -> Alcotest.fail "expected Some for AgentCompleted without usage"
+  | Some (`Assoc fields) ->
+      let payload_fields =
+        match List.assoc_opt "payload" fields with
+        | Some (`Assoc p) -> p
+        | _ -> Alcotest.failf "expected payload assoc"
+      in
+      let absent name =
+        Option.is_none (List.assoc_opt name payload_fields)
+      in
+      Alcotest.(check bool) "success" true
+        (match List.assoc_opt "success" payload_fields with
+         | Some (`Bool v) -> v
+         | _ -> false);
+      Alcotest.(check bool) "usage_reported" false
+        (match List.assoc_opt "usage_reported" payload_fields with
+         | Some (`Bool v) -> v
+         | _ -> true);
+      Alcotest.(check bool) "input_tokens absent" true (absent "input_tokens");
+      Alcotest.(check bool) "output_tokens absent" true
+        (absent "output_tokens");
+      Alcotest.(check bool) "total_tokens absent" true (absent "total_tokens");
+      Alcotest.(check bool) "cost_usd absent" true (absent "cost_usd")
+  | Some _ -> Alcotest.fail "expected assoc"
+
 let test_agent_completed_no_usage_on_error () =
   let open Agent_sdk in
   let evt =
@@ -901,6 +949,9 @@ let () =
         test_oas_event_bridge_broadcast_retry_does_not_duplicate_append;
       Alcotest.test_case "agent_completed includes usage" `Quick
         test_agent_completed_includes_usage;
+      Alcotest.test_case "agent_completed success without usage omits usage fields"
+        `Quick
+        test_agent_completed_omits_usage_fields_when_success_has_no_usage;
       Alcotest.test_case "agent_completed no usage on error" `Quick
         test_agent_completed_no_usage_on_error;
       Alcotest.test_case "oas log bridge adds turn completed summary" `Quick

--- a/test/test_oas_integration.ml
+++ b/test/test_oas_integration.ml
@@ -581,8 +581,25 @@ let test_agent_completed_includes_usage () =
         | Some (`Int v) -> v
         | _ -> -1
       in
+      let string_field name =
+        match List.assoc_opt name payload_fields with
+        | Some (`String v) -> v
+        | _ -> ""
+      in
+      let bool_field name =
+        match List.assoc_opt name payload_fields with
+        | Some (`Bool v) -> v
+        | _ -> false
+      in
+      Alcotest.(check bool) "success" true (bool_field "success");
+      Alcotest.(check string) "result" "ok" (string_field "result");
+      Alcotest.(check string) "response_id" "msg-test" (string_field "response_id");
+      Alcotest.(check string) "model" "test-model" (string_field "model");
+      Alcotest.(check string) "stop_reason" "end_turn" (string_field "stop_reason");
+      Alcotest.(check bool) "usage_reported" true (bool_field "usage_reported");
       Alcotest.(check int) "input_tokens" 500 (int_field "input_tokens");
       Alcotest.(check int) "output_tokens" 150 (int_field "output_tokens");
+      Alcotest.(check int) "total_tokens" 650 (int_field "total_tokens");
       (match List.assoc_opt "cost_usd" payload_fields with
        | Some (`Float f) ->
            Alcotest.(check (float 0.001)) "cost_usd" 0.003 f
@@ -615,7 +632,24 @@ let test_agent_completed_no_usage_on_error () =
         | None -> Alcotest.fail "expected payload field"
       in
       Alcotest.(check bool) "no input_tokens on error" true
-        (Option.is_none (List.assoc_opt "input_tokens" payload_fields))
+        (Option.is_none (List.assoc_opt "input_tokens" payload_fields));
+      Alcotest.(check bool) "success" false
+        (match List.assoc_opt "success" payload_fields with
+         | Some (`Bool v) -> v
+         | _ -> true);
+      Alcotest.(check string) "result" "error"
+        (match List.assoc_opt "result" payload_fields with
+         | Some (`String v) -> v
+         | _ -> "");
+      Alcotest.(check bool) "usage_reported" false
+        (match List.assoc_opt "usage_reported" payload_fields with
+         | Some (`Bool v) -> v
+         | _ -> true);
+      (match List.assoc_opt "error" payload_fields with
+       | Some (`String value) ->
+           Alcotest.(check bool) "error includes message" true
+             (contains_substring value "test failure")
+       | _ -> Alcotest.fail "expected error string")
   | Some _ -> Alcotest.fail "expected assoc"
 
 let test_oas_log_bridge_turn_completed_summary () =


### PR DESCRIPTION
## Summary
- restore current-main keeper compile gates: close the `keeper_turn.ml` match stack and remove a duplicated `Stale_fleet_batch` match arm
- serialize `AgentCompleted.result` into the OAS SSE/durable event payload with `success`, `result`, error text on failures, and bounded response metadata on success
- preserve response usage truth with `usage_reported`, token counters, total tokens, and nullable `cost_usd` only when usage exists

## Why it matters
This addresses the Kimi cleanup P0 `AgentCompleted.result` drop. Operators need the durable `oas:agent_completed` stream to distinguish Ok/Error and avoid treating a completion envelope as an unqualified success.

## Validation
- `git diff --check`
- `scripts/dune-local.sh build test/test_oas_integration.exe`
- `./_build/default/test/test_oas_integration.exe test oas_events 12,13` (2 targeted AgentCompleted tests passed)

## Known baseline issue
The full `./_build/default/test/test_oas_integration.exe` run still fails existing bridge lifecycle/retry cases 8 and 9. The AgentCompleted cases pass, and I filed follow-up issue #13819 with the exact failure and reproduction.