### PR TITLE
feat(lib): add intentional_projection bigram ranker (RFC-0035 PR-2)

### DIFF
--- a/lib/intentional_projection.ml
+++ b/lib/intentional_projection.ml
@@ -1,0 +1,68 @@
+(* Intentional Projection — implementation.
+
+   See intentional_projection.mli for the interface contract and
+   docs/rfc/RFC-0035-cognitive-ide-roadmap.md for the integration plan. *)
+
+type transition = {
+  prev : string;
+  next : string;
+}
+
+(* Sparse representation: an association list of (prev, next, count).
+   Suitable for the small models we expect (a few hundred transitions
+   per session). Conversion to a Hashtbl is a follow-up if profiling
+   ever shows it matters. *)
+type model = (string * string * int) list
+
+let empty : model = []
+
+let pairs_of_sequence actions =
+  let rec aux = function
+    | [] | [ _ ] -> []
+    | a :: (b :: _ as rest) -> { prev = a; next = b } :: aux rest
+  in
+  aux actions
+
+let bump (m : model) ~prev ~next : model =
+  let rec aux acc = function
+    | [] -> List.rev_append acc [ (prev, next, 1) ]
+    | (p, n, c) :: rest when p = prev && n = next ->
+      List.rev_append acc ((p, n, c + 1) :: rest)
+    | head :: rest -> aux (head :: acc) rest
+  in
+  aux [] m
+
+let observe_pairs (m : model) (pairs : transition list) : model =
+  List.fold_left
+    (fun acc { prev; next } -> bump acc ~prev ~next)
+    m pairs
+
+let count_after (m : model) ~prev ~next =
+  List.fold_left
+    (fun acc (p, n, c) -> if p = prev && n = next then acc + c else acc)
+    0 m
+
+let total_after (m : model) prev =
+  List.fold_left (fun acc (p, _, c) -> if p = prev then acc + c else acc) 0 m
+
+let score (m : model) ~smoothing ~prev ~candidates ~next =
+  match candidates with
+  | [] -> 0.0
+  | _ ->
+    let total = total_after m prev in
+    let count = count_after m ~prev ~next in
+    let n_cands = List.length candidates in
+    let denom =
+      float_of_int total +. (smoothing *. float_of_int n_cands)
+    in
+    if denom <= 0.0 then 0.0
+    else (float_of_int count +. smoothing) /. denom
+
+let rank (m : model) ~smoothing ~prev ~candidates =
+  let scored =
+    List.map
+      (fun cand ->
+        (cand, score m ~smoothing ~prev ~candidates ~next:cand))
+      candidates
+  in
+  List.stable_sort (fun (_, a) (_, b) -> Float.compare b a) scored

--- a/lib/intentional_projection.ml
+++ b/lib/intentional_projection.ml
@@ -1,12 +1,11 @@
 (* Intentional Projection — implementation.
 
-   See intentional_projection.mli for the interface contract and
-   docs/rfc/RFC-0035-cognitive-ide-roadmap.md for the integration plan. *)
+   See intentional_projection.mli for the interface contract. *)
 
-type transition = {
-  prev : string;
-  next : string;
-}
+type transition =
+  { prev : string
+  ; next : string
+  }
 
 (* Sparse representation: an association list of (prev, next, count).
    Suitable for the small models we expect (a few hundred transitions
@@ -22,47 +21,97 @@ let pairs_of_sequence actions =
     | a :: (b :: _ as rest) -> { prev = a; next = b } :: aux rest
   in
   aux actions
+;;
 
 let bump (m : model) ~prev ~next : model =
   let rec aux acc = function
-    | [] -> List.rev_append acc [ (prev, next, 1) ]
+    | [] -> List.rev_append acc [ prev, next, 1 ]
     | (p, n, c) :: rest when p = prev && n = next ->
       List.rev_append acc ((p, n, c + 1) :: rest)
     | head :: rest -> aux (head :: acc) rest
   in
   aux [] m
+;;
 
 let observe_pairs (m : model) (pairs : transition list) : model =
-  List.fold_left
-    (fun acc { prev; next } -> bump acc ~prev ~next)
-    m pairs
-
-let count_after (m : model) ~prev ~next =
-  List.fold_left
-    (fun acc (p, n, c) -> if p = prev && n = next then acc + c else acc)
-    0 m
+  List.fold_left (fun acc { prev; next } -> bump acc ~prev ~next) m pairs
+;;
 
 let total_after (m : model) prev =
   List.fold_left (fun acc (p, _, c) -> if p = prev then acc + c else acc) 0 m
+;;
+
+let validate_smoothing ~caller smoothing =
+  let finite =
+    match classify_float smoothing with
+    | FP_normal | FP_zero | FP_subnormal -> true
+    | FP_infinite | FP_nan -> false
+  in
+  if smoothing < 0.0 || not finite
+  then invalid_arg (caller ^ ": smoothing must be finite and non-negative")
+;;
+
+let unique_candidates candidates =
+  let seen = Hashtbl.create (List.length candidates) in
+  List.filter
+    (fun candidate ->
+       if Hashtbl.mem seen candidate
+       then false
+       else (
+         Hashtbl.add seen candidate ();
+         true))
+    candidates
+;;
+
+let candidate_counts (m : model) ~prev ~candidates =
+  let candidates = unique_candidates candidates in
+  let counts = Hashtbl.create (List.length candidates) in
+  let unique_count = ref 0 in
+  List.iter
+    (fun candidate ->
+       if not (Hashtbl.mem counts candidate)
+       then (
+         Hashtbl.add counts candidate 0;
+         incr unique_count))
+    candidates;
+  let total = ref 0 in
+  List.iter
+    (fun (p, n, c) ->
+       if p = prev && Hashtbl.mem counts n
+       then (
+         let next_count = Option.value ~default:0 (Hashtbl.find_opt counts n) + c in
+         Hashtbl.replace counts n next_count;
+         total := !total + c))
+    m;
+  counts, !total, !unique_count
+;;
+
+let score_from_counts counts ~total ~unique_count ~smoothing ~next =
+  match Hashtbl.find_opt counts next with
+  | None -> 0.0
+  | Some count ->
+    let denom = float_of_int total +. (smoothing *. float_of_int unique_count) in
+    if denom <= 0.0 then 0.0 else (float_of_int count +. smoothing) /. denom
+;;
 
 let score (m : model) ~smoothing ~prev ~candidates ~next =
+  validate_smoothing ~caller:"Intentional_projection.score" smoothing;
   match candidates with
   | [] -> 0.0
   | _ ->
-    let total = total_after m prev in
-    let count = count_after m ~prev ~next in
-    let n_cands = List.length candidates in
-    let denom =
-      float_of_int total +. (smoothing *. float_of_int n_cands)
-    in
-    if denom <= 0.0 then 0.0
-    else (float_of_int count +. smoothing) /. denom
+    let counts, total, unique_count = candidate_counts m ~prev ~candidates in
+    score_from_counts counts ~total ~unique_count ~smoothing ~next
+;;
 
 let rank (m : model) ~smoothing ~prev ~candidates =
+  validate_smoothing ~caller:"Intentional_projection.rank" smoothing;
+  let candidates = unique_candidates candidates in
+  let counts, total, unique_count = candidate_counts m ~prev ~candidates in
   let scored =
     List.map
       (fun cand ->
-        (cand, score m ~smoothing ~prev ~candidates ~next:cand))
+         cand, score_from_counts counts ~total ~unique_count ~smoothing ~next:cand)
       candidates
   in
   List.stable_sort (fun (_, a) (_, b) -> Float.compare b a) scored
+;;

--- a/lib/intentional_projection.mli
+++ b/lib/intentional_projection.mli
@@ -1,0 +1,69 @@
+(** Intentional Projection — Master Report Dim01 / P0 #6.
+
+    Given a sequence of past actions and a list of candidate next actions,
+    rank the candidates by how likely each is to be the user's intended
+    next action. The default predictor is a 1st-order Markov / bigram
+    model with additive Laplace smoothing — deliberately small and
+    deterministic so that the cockpit can call it on every focus change
+    without a budget concern.
+
+    Like {!Cognitive_gravity} this module is intentionally pure: no I/O,
+    no Eio, no global state. Sequences come from the caller (typically
+    the dashboard or a keeper turn log); the model returns a fresh value
+    on every observation. See `docs/rfc/RFC-0035-cognitive-ide-roadmap.md`
+    (PR-2) for the integration plan. *)
+
+(** A single observed transition: action [prev] was followed by [next]. *)
+type transition = {
+  prev : string;
+  next : string;
+}
+
+(** Opaque bigram model. Build it with {!empty} and {!observe_pairs}; the
+    only way to read it is via {!score} and {!rank}. *)
+type model
+
+(** Empty model with no observations. *)
+val empty : model
+
+(** Convert a sequence of actions [a_0; a_1; ...; a_n] to its bigram
+    pairs [{prev=a_0; next=a_1}; {prev=a_1; next=a_2}; ...]. Lists
+    shorter than two elements yield the empty list. *)
+val pairs_of_sequence : string list -> transition list
+
+(** Add observed transitions to the model and return the new model. *)
+val observe_pairs : model -> transition list -> model
+
+(** Total observations recorded with [prev]. Useful for tests and for
+    ratio-based confidence reporting; not part of the ranking path. *)
+val total_after : model -> string -> int
+
+(** [score model ~smoothing ~prev ~candidates ~next] returns the smoothed
+    conditional probability that [next] follows [prev], normalised over
+    the supplied [candidates] set.
+
+    With [smoothing = 0.0] the score reduces to the maximum-likelihood
+    estimate, which is [0.0] for unseen [prev] or unseen [(prev, next)]
+    pairs. With [smoothing > 0.0] every candidate receives at least
+    [smoothing / (smoothing * |candidates|)] mass, so the function never
+    returns [0.0] when [smoothing > 0.0] and [candidates] is non-empty.
+
+    The function returns [0.0] when [candidates] is empty. *)
+val score :
+  model ->
+  smoothing:float ->
+  prev:string ->
+  candidates:string list ->
+  next:string ->
+  float
+
+(** [rank model ~smoothing ~prev ~candidates] applies {!score} to every
+    candidate and returns them paired with their scores, sorted by
+    descending score. The sort is stable: candidates with equal scores
+    retain their input order. *)
+val rank :
+  model ->
+  smoothing:float ->
+  prev:string ->
+  candidates:string list ->
+  (string * float) list

--- a/lib/intentional_projection.mli
+++ b/lib/intentional_projection.mli
@@ -10,14 +10,14 @@
     Like {!Cognitive_gravity} this module is intentionally pure: no I/O,
     no Eio, no global state. Sequences come from the caller (typically
     the dashboard or a keeper turn log); the model returns a fresh value
-    on every observation. See `docs/rfc/RFC-0035-cognitive-ide-roadmap.md`
-    (PR-2) for the integration plan. *)
+    on every observation. The RFC-0035 integration plan is tracked by the
+    PR series that introduces this module and its dashboard consumers. *)
 
 (** A single observed transition: action [prev] was followed by [next]. *)
-type transition = {
-  prev : string;
-  next : string;
-}
+type transition =
+  { prev : string
+  ; next : string
+  }
 
 (** Opaque bigram model. Build it with {!empty} and {!observe_pairs}; the
     only way to read it is via {!score} and {!rank}. *)
@@ -40,30 +40,37 @@ val total_after : model -> string -> int
 
 (** [score model ~smoothing ~prev ~candidates ~next] returns the smoothed
     conditional probability that [next] follows [prev], normalised over
-    the supplied [candidates] set.
+    the supplied unique [candidates] set. Observed transitions to actions
+    outside [candidates] are ignored, and [next] outside [candidates]
+    scores [0.0].
 
     With [smoothing = 0.0] the score reduces to the maximum-likelihood
     estimate, which is [0.0] for unseen [prev] or unseen [(prev, next)]
     pairs. With [smoothing > 0.0] every candidate receives at least
-    [smoothing / (smoothing * |candidates|)] mass, so the function never
-    returns [0.0] when [smoothing > 0.0] and [candidates] is non-empty.
+    [smoothing / (total_observations_among_candidates + smoothing *
+    |unique candidates|)] mass (which is [1.0 / |unique candidates|]
+    when the model has no observations for the supplied set), so the
+    function never returns [0.0] for a candidate when [smoothing > 0.0]
+    and [candidates] is non-empty.
 
-    The function returns [0.0] when [candidates] is empty. *)
-val score :
-  model ->
-  smoothing:float ->
-  prev:string ->
-  candidates:string list ->
-  next:string ->
-  float
+    The function returns [0.0] when [candidates] is empty. [smoothing]
+    must be finite and non-negative. *)
+val score
+  :  model
+  -> smoothing:float
+  -> prev:string
+  -> candidates:string list
+  -> next:string
+  -> float
 
-(** [rank model ~smoothing ~prev ~candidates] applies {!score} to every
-    candidate and returns them paired with their scores, sorted by
+(** [rank model ~smoothing ~prev ~candidates] deduplicates candidates while
+    preserving first-occurrence order, applies {!score} to each unique
+    candidate, and returns them paired with their scores, sorted by
     descending score. The sort is stable: candidates with equal scores
-    retain their input order. *)
-val rank :
-  model ->
-  smoothing:float ->
-  prev:string ->
-  candidates:string list ->
-  (string * float) list
+    retain their first-occurrence input order. *)
+val rank
+  :  model
+  -> smoothing:float
+  -> prev:string
+  -> candidates:string list
+  -> (string * float) list

--- a/test/dune
+++ b/test/dune
@@ -241,6 +241,7 @@
         test_workspace_routes_keeper
         test_effect_evidence_source_path
         test_cognitive_gravity
+        test_intentional_projection
         )
  (modules test_attribution test_attribution_tagged test_autoresearch_result_bridge test_dashboard_attribution test_dashboard_oas_bridge test_masc_runtime_events test_room test_room_state_recovery test_types test_exec_tap test_auth test_auth_doctor test_auth_error_kind test_auth_login test_audit_log test_governance_anomaly test_http_negotiation
           test_attempt_state
@@ -461,6 +462,7 @@
           test_workspace_routes_keeper
           test_effect_evidence_source_path
           test_cognitive_gravity
+          test_intentional_projection
           )
  (libraries masc_test_deps multimodal))
 

--- a/test/test_intentional_projection.ml
+++ b/test/test_intentional_projection.ml
@@ -1,0 +1,138 @@
+(** Unit tests for Intentional_projection (RFC-0035 PR-2,
+    Master Report Dim01 #6). *)
+
+open Masc_mcp.Intentional_projection
+
+let approx_eq a b = Float.abs (a -. b) <= 0.0001
+
+let test_pairs_of_short_sequences () =
+  Alcotest.(check int) "empty sequence → 0 pairs" 0
+    (List.length (pairs_of_sequence []));
+  Alcotest.(check int) "single element → 0 pairs" 0
+    (List.length (pairs_of_sequence [ "a" ]));
+  let pairs = pairs_of_sequence [ "a"; "b"; "c" ] in
+  Alcotest.(check int) "three elements → 2 pairs" 2 (List.length pairs);
+  match pairs with
+  | [ p1; p2 ] ->
+    Alcotest.(check string) "first prev" "a" p1.prev;
+    Alcotest.(check string) "first next" "b" p1.next;
+    Alcotest.(check string) "second prev" "b" p2.prev;
+    Alcotest.(check string) "second next" "c" p2.next
+  | _ -> Alcotest.fail "expected exactly 2 pairs"
+
+let test_observe_increments_total () =
+  let m =
+    empty
+    |> Fun.flip observe_pairs (pairs_of_sequence [ "open"; "edit"; "save" ])
+  in
+  Alcotest.(check int) "total after 'open'" 1 (total_after m "open");
+  Alcotest.(check int) "total after 'edit'" 1 (total_after m "edit");
+  Alcotest.(check int) "total after 'save'" 0 (total_after m "save");
+  let m2 =
+    observe_pairs m (pairs_of_sequence [ "open"; "edit"; "edit"; "save" ])
+  in
+  Alcotest.(check int) "total after 'open' increases" 2 (total_after m2 "open");
+  Alcotest.(check int) "total after 'edit' counts both edits" 3
+    (total_after m2 "edit")
+
+let test_zero_smoothing_unseen_returns_zero () =
+  let m =
+    observe_pairs empty (pairs_of_sequence [ "open"; "edit"; "save" ])
+  in
+  let s_unseen =
+    score m ~smoothing:0.0 ~prev:"never" ~candidates:[ "edit"; "save" ]
+      ~next:"edit"
+  in
+  Alcotest.(check bool)
+    "unseen prev with smoothing=0 → score 0.0" true
+    (approx_eq s_unseen 0.0);
+  let s_seen_unseen_pair =
+    score m ~smoothing:0.0 ~prev:"open"
+      ~candidates:[ "edit"; "save" ]
+      ~next:"save"
+  in
+  Alcotest.(check bool)
+    "seen prev but unseen pair with smoothing=0 → 0.0" true
+    (approx_eq s_seen_unseen_pair 0.0)
+
+let test_smoothing_makes_every_candidate_positive () =
+  let m =
+    observe_pairs empty (pairs_of_sequence [ "open"; "edit"; "save" ])
+  in
+  let smoothing = 0.5 in
+  let candidates = [ "edit"; "save"; "exit" ] in
+  let positive_for c =
+    score m ~smoothing ~prev:"open" ~candidates ~next:c > 0.0
+  in
+  Alcotest.(check bool)
+    "edit (seen) is positive" true (positive_for "edit");
+  Alcotest.(check bool)
+    "save (unseen pair) becomes positive with smoothing" true
+    (positive_for "save");
+  Alcotest.(check bool)
+    "exit (unseen pair) becomes positive with smoothing" true
+    (positive_for "exit")
+
+let test_rank_orders_by_frequency () =
+  let actions =
+    [ "open"; "edit"; "open"; "edit"; "open"; "save"; "open"; "edit" ]
+  in
+  let m = observe_pairs empty (pairs_of_sequence actions) in
+  let result =
+    rank m ~smoothing:0.0 ~prev:"open"
+      ~candidates:[ "save"; "exit"; "edit" ]
+  in
+  let order = List.map fst result in
+  Alcotest.(check (list string))
+    "edit (seen 3x) ranks above save (1x), exit (0x) last"
+    [ "edit"; "save"; "exit" ]
+    order
+
+let test_rank_empty_candidates () =
+  let m = observe_pairs empty (pairs_of_sequence [ "a"; "b" ]) in
+  let result = rank m ~smoothing:1.0 ~prev:"a" ~candidates:[] in
+  Alcotest.(check int) "empty candidates → empty ranking" 0
+    (List.length result)
+
+let test_rank_stable_for_ties () =
+  let m = empty in
+  (* No observations → all candidates score equally with smoothing > 0;
+     stable sort must preserve input order. *)
+  let result =
+    rank m ~smoothing:1.0 ~prev:"x" ~candidates:[ "c"; "a"; "b" ]
+  in
+  let order = List.map fst result in
+  Alcotest.(check (list string))
+    "tie order matches input order under stable sort"
+    [ "c"; "a"; "b" ]
+    order
+
+let () =
+  Alcotest.run "intentional_projection"
+    [
+      ( "pairs",
+        [
+          Alcotest.test_case "short sequences" `Quick
+            test_pairs_of_short_sequences;
+        ] );
+      ( "observe",
+        [
+          Alcotest.test_case "increments totals" `Quick
+            test_observe_increments_total;
+        ] );
+      ( "score",
+        [
+          Alcotest.test_case "zero smoothing unseen → 0.0" `Quick
+            test_zero_smoothing_unseen_returns_zero;
+          Alcotest.test_case "smoothing positive everywhere" `Quick
+            test_smoothing_makes_every_candidate_positive;
+        ] );
+      ( "rank",
+        [
+          Alcotest.test_case "orders by frequency" `Quick
+            test_rank_orders_by_frequency;
+          Alcotest.test_case "empty candidates" `Quick
+            test_rank_empty_candidates;
+          Alcotest.test_case "stable for ties" `Quick test_rank_stable_for_ties;
+        ] );
+    ]

--- a/test/test_intentional_projection.ml
+++ b/test/test_intentional_projection.ml
@@ -6,9 +6,10 @@ open Masc_mcp.Intentional_projection
 let approx_eq a b = Float.abs (a -. b) <= 0.0001
 
 let test_pairs_of_short_sequences () =
-  Alcotest.(check int) "empty sequence → 0 pairs" 0
-    (List.length (pairs_of_sequence []));
-  Alcotest.(check int) "single element → 0 pairs" 0
+  Alcotest.(check int) "empty sequence → 0 pairs" 0 (List.length (pairs_of_sequence []));
+  Alcotest.(check int)
+    "single element → 0 pairs"
+    0
     (List.length (pairs_of_sequence [ "a" ]));
   let pairs = pairs_of_sequence [ "a"; "b"; "c" ] in
   Alcotest.(check int) "three elements → 2 pairs" 2 (List.length pairs);
@@ -19,120 +20,163 @@ let test_pairs_of_short_sequences () =
     Alcotest.(check string) "second prev" "b" p2.prev;
     Alcotest.(check string) "second next" "c" p2.next
   | _ -> Alcotest.fail "expected exactly 2 pairs"
+;;
 
 let test_observe_increments_total () =
   let m =
-    empty
-    |> Fun.flip observe_pairs (pairs_of_sequence [ "open"; "edit"; "save" ])
+    empty |> Fun.flip observe_pairs (pairs_of_sequence [ "open"; "edit"; "save" ])
   in
   Alcotest.(check int) "total after 'open'" 1 (total_after m "open");
   Alcotest.(check int) "total after 'edit'" 1 (total_after m "edit");
   Alcotest.(check int) "total after 'save'" 0 (total_after m "save");
-  let m2 =
-    observe_pairs m (pairs_of_sequence [ "open"; "edit"; "edit"; "save" ])
-  in
+  let m2 = observe_pairs m (pairs_of_sequence [ "open"; "edit"; "edit"; "save" ]) in
   Alcotest.(check int) "total after 'open' increases" 2 (total_after m2 "open");
-  Alcotest.(check int) "total after 'edit' counts both edits" 3
-    (total_after m2 "edit")
+  Alcotest.(check int) "total after 'edit' counts both edits" 3 (total_after m2 "edit")
+;;
 
 let test_zero_smoothing_unseen_returns_zero () =
-  let m =
-    observe_pairs empty (pairs_of_sequence [ "open"; "edit"; "save" ])
-  in
+  let m = observe_pairs empty (pairs_of_sequence [ "open"; "edit"; "save" ]) in
   let s_unseen =
-    score m ~smoothing:0.0 ~prev:"never" ~candidates:[ "edit"; "save" ]
-      ~next:"edit"
+    score m ~smoothing:0.0 ~prev:"never" ~candidates:[ "edit"; "save" ] ~next:"edit"
   in
   Alcotest.(check bool)
-    "unseen prev with smoothing=0 → score 0.0" true
+    "unseen prev with smoothing=0 → score 0.0"
+    true
     (approx_eq s_unseen 0.0);
   let s_seen_unseen_pair =
-    score m ~smoothing:0.0 ~prev:"open"
-      ~candidates:[ "edit"; "save" ]
-      ~next:"save"
+    score m ~smoothing:0.0 ~prev:"open" ~candidates:[ "edit"; "save" ] ~next:"save"
   in
   Alcotest.(check bool)
-    "seen prev but unseen pair with smoothing=0 → 0.0" true
+    "seen prev but unseen pair with smoothing=0 → 0.0"
+    true
     (approx_eq s_seen_unseen_pair 0.0)
+;;
 
 let test_smoothing_makes_every_candidate_positive () =
-  let m =
-    observe_pairs empty (pairs_of_sequence [ "open"; "edit"; "save" ])
-  in
+  let m = observe_pairs empty (pairs_of_sequence [ "open"; "edit"; "save" ]) in
   let smoothing = 0.5 in
   let candidates = [ "edit"; "save"; "exit" ] in
-  let positive_for c =
-    score m ~smoothing ~prev:"open" ~candidates ~next:c > 0.0
-  in
+  let positive_for c = score m ~smoothing ~prev:"open" ~candidates ~next:c > 0.0 in
+  Alcotest.(check bool) "edit (seen) is positive" true (positive_for "edit");
   Alcotest.(check bool)
-    "edit (seen) is positive" true (positive_for "edit");
-  Alcotest.(check bool)
-    "save (unseen pair) becomes positive with smoothing" true
+    "save (unseen pair) becomes positive with smoothing"
+    true
     (positive_for "save");
   Alcotest.(check bool)
-    "exit (unseen pair) becomes positive with smoothing" true
+    "exit (unseen pair) becomes positive with smoothing"
+    true
     (positive_for "exit")
+;;
+
+let test_score_normalizes_over_supplied_candidates () =
+  let actions = [ "open"; "edit"; "open"; "debug"; "open"; "debug"; "open"; "debug" ] in
+  let m = observe_pairs empty (pairs_of_sequence actions) in
+  let candidates = [ "edit"; "save" ] in
+  let edit_score = score m ~smoothing:0.0 ~prev:"open" ~candidates ~next:"edit" in
+  let save_score = score m ~smoothing:0.0 ~prev:"open" ~candidates ~next:"save" in
+  let outside_score = score m ~smoothing:0.0 ~prev:"open" ~candidates ~next:"debug" in
+  Alcotest.(check bool)
+    "candidate-restricted scores sum to 1.0"
+    true
+    (approx_eq (edit_score +. save_score) 1.0);
+  Alcotest.(check bool) "outside candidate scores 0.0" true (approx_eq outside_score 0.0)
+;;
+
+let test_score_rejects_invalid_smoothing () =
+  let m = observe_pairs empty (pairs_of_sequence [ "open"; "edit" ]) in
+  let call smoothing () =
+    ignore (score m ~smoothing ~prev:"open" ~candidates:[ "edit" ] ~next:"edit")
+  in
+  Alcotest.check_raises
+    "negative smoothing rejected"
+    (Invalid_argument
+       "Intentional_projection.score: smoothing must be finite and non-negative")
+    (call (-0.1));
+  Alcotest.check_raises
+    "nan smoothing rejected"
+    (Invalid_argument
+       "Intentional_projection.score: smoothing must be finite and non-negative")
+    (call Float.nan);
+  Alcotest.check_raises
+    "infinite smoothing rejected"
+    (Invalid_argument
+       "Intentional_projection.score: smoothing must be finite and non-negative")
+    (call Float.infinity)
+;;
 
 let test_rank_orders_by_frequency () =
-  let actions =
-    [ "open"; "edit"; "open"; "edit"; "open"; "save"; "open"; "edit" ]
-  in
+  let actions = [ "open"; "edit"; "open"; "edit"; "open"; "save"; "open"; "edit" ] in
   let m = observe_pairs empty (pairs_of_sequence actions) in
   let result =
-    rank m ~smoothing:0.0 ~prev:"open"
-      ~candidates:[ "save"; "exit"; "edit" ]
+    rank m ~smoothing:0.0 ~prev:"open" ~candidates:[ "save"; "exit"; "edit" ]
   in
   let order = List.map fst result in
   Alcotest.(check (list string))
     "edit (seen 3x) ranks above save (1x), exit (0x) last"
     [ "edit"; "save"; "exit" ]
     order
+;;
 
 let test_rank_empty_candidates () =
   let m = observe_pairs empty (pairs_of_sequence [ "a"; "b" ]) in
   let result = rank m ~smoothing:1.0 ~prev:"a" ~candidates:[] in
-  Alcotest.(check int) "empty candidates → empty ranking" 0
-    (List.length result)
+  Alcotest.(check int) "empty candidates → empty ranking" 0 (List.length result)
+;;
 
 let test_rank_stable_for_ties () =
   let m = empty in
   (* No observations → all candidates score equally with smoothing > 0;
      stable sort must preserve input order. *)
-  let result =
-    rank m ~smoothing:1.0 ~prev:"x" ~candidates:[ "c"; "a"; "b" ]
-  in
+  let result = rank m ~smoothing:1.0 ~prev:"x" ~candidates:[ "c"; "a"; "b" ] in
   let order = List.map fst result in
   Alcotest.(check (list string))
     "tie order matches input order under stable sort"
     [ "c"; "a"; "b" ]
     order
+;;
+
+let test_rank_deduplicates_candidates () =
+  let m = observe_pairs empty (pairs_of_sequence [ "open"; "edit"; "open"; "save" ]) in
+  let result =
+    rank m ~smoothing:1.0 ~prev:"open" ~candidates:[ "edit"; "save"; "edit" ]
+  in
+  let order = List.map fst result in
+  Alcotest.(check (list string))
+    "duplicates are removed before scoring"
+    [ "edit"; "save" ]
+    order
+;;
 
 let () =
-  Alcotest.run "intentional_projection"
-    [
-      ( "pairs",
-        [
-          Alcotest.test_case "short sequences" `Quick
-            test_pairs_of_short_sequences;
-        ] );
-      ( "observe",
-        [
-          Alcotest.test_case "increments totals" `Quick
-            test_observe_increments_total;
-        ] );
-      ( "score",
-        [
-          Alcotest.test_case "zero smoothing unseen → 0.0" `Quick
-            test_zero_smoothing_unseen_returns_zero;
-          Alcotest.test_case "smoothing positive everywhere" `Quick
-            test_smoothing_makes_every_candidate_positive;
-        ] );
-      ( "rank",
-        [
-          Alcotest.test_case "orders by frequency" `Quick
-            test_rank_orders_by_frequency;
-          Alcotest.test_case "empty candidates" `Quick
-            test_rank_empty_candidates;
-          Alcotest.test_case "stable for ties" `Quick test_rank_stable_for_ties;
-        ] );
+  Alcotest.run
+    "intentional_projection"
+    [ ( "pairs"
+      , [ Alcotest.test_case "short sequences" `Quick test_pairs_of_short_sequences ] )
+    ; ( "observe"
+      , [ Alcotest.test_case "increments totals" `Quick test_observe_increments_total ] )
+    ; ( "score"
+      , [ Alcotest.test_case
+            "zero smoothing unseen → 0.0"
+            `Quick
+            test_zero_smoothing_unseen_returns_zero
+        ; Alcotest.test_case
+            "smoothing positive everywhere"
+            `Quick
+            test_smoothing_makes_every_candidate_positive
+        ; Alcotest.test_case
+            "normalizes over supplied candidates"
+            `Quick
+            test_score_normalizes_over_supplied_candidates
+        ; Alcotest.test_case
+            "rejects invalid smoothing"
+            `Quick
+            test_score_rejects_invalid_smoothing
+        ] )
+    ; ( "rank"
+      , [ Alcotest.test_case "orders by frequency" `Quick test_rank_orders_by_frequency
+        ; Alcotest.test_case "empty candidates" `Quick test_rank_empty_candidates
+        ; Alcotest.test_case "stable for ties" `Quick test_rank_stable_for_ties
+        ; Alcotest.test_case "deduplicates candidates" `Quick test_rank_deduplicates_candidates
+        ] )
     ]
+;;


### PR DESCRIPTION
## Summary

- Adds `Intentional_projection`, the RFC-0035 PR-2 bigram ranker.
- Keeps the module pure OCaml with no I/O or runtime wiring.
- Rebased onto current `origin/main` after PR-1 (#13797) merged.
- Tightens candidate handling by deduplicating rank candidates while preserving first occurrence order.

## Why

This fills the Master Report Dim01 P0 #6 slot:

- PR-1 (#13797) added `cognitive_gravity` and has merged.
- This PR adds the companion projection primitive: gravity decides what deserves attention, projection ranks likely next actions.
- PR-3 (#13841) owns the version bump and RFC mapping refresh.

## Changes

| File | Change |
|---|---|
| `lib/intentional_projection.ml` | new bigram model, pair observation, smoothing-aware score/rank |
| `lib/intentional_projection.mli` | public API and scoring contract |
| `test/test_intentional_projection.ml` | Alcotest coverage for pairs, observe, score, invalid smoothing, ranking, dedup |
| `test/dune` | registers `test_intentional_projection` alongside existing RFC-0035 tests |

## Verification

Head: `a7e56590fd9fca069cf86325b290fd46f288c87f`

```text
git diff --check origin/main...HEAD
scripts/check-oas-pin.sh --local-only
env MASC_OPAM_LOCK=0 scripts/dune-local.sh build test/test_intentional_projection.exe
./_build/default/test/test_intentional_projection.exe
```

Result:

- Diff check passed.
- OAS pin verified: `main@0cfb68c620ccd385f16fd6344b2cb003077c73c3` / base `v0.190.26`.
- Focused Dune build passed.
- Direct Alcotest run passed: 10 tests.

## Out of Scope

- Runtime wiring into cockpit/dashboard flows.
- Version bump and RFC mapping table refresh; that is tracked in PR-3 (#13841).
- Full suite/local `dune build`; CI remains the broad verification surface for this stack.

## Ready Criteria

- Draft remains intentional.
- Human review is still required before ready/merge.
