### PR TITLE
feat(dashboard): add chronicle navigator read model

### DIFF
--- a/dashboard/src/components/chronicle/chronicle-model.test.ts
+++ b/dashboard/src/components/chronicle/chronicle-model.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildChronicleViewModel,
+  chronicleLaneForEvent,
+  gitCommitToChronicleEvent,
+  keeperStepToChronicleEvent,
+  planProgressToChronicleEvent,
+  sortChronicleEvents,
+  summarizeChronicleEvents,
+} from './chronicle-model'
+
+const planEvent = planProgressToChronicleEvent({
+  id: 'plan-1',
+  timestamp: Date.parse('2026-05-06T09:00:00Z'),
+  planId: 'goal:p1',
+  stepId: 'chronicle-ui',
+  eventType: 'plan.step.completed',
+  summary: 'Chronicle UI planned',
+  statedGoal: 'restore work history context',
+  relatedEventIds: ['keeper-1'],
+  sessionId: 'session-a',
+})
+
+const keeperEvent = keeperStepToChronicleEvent({
+  id: 'keeper-1',
+  timestamp: Date.parse('2026-05-06T09:02:00Z'),
+  keeperId: 'keeper:sigma',
+  keeperName: 'sigma',
+  summary: 'Mapped keeper trace into chronicle event',
+  targetUri: 'keeper:sigma/trace',
+  relatedEventIds: ['plan-1', 'git-1'],
+  sessionId: 'session-a',
+  intent: { inferredIntent: 'connect trace and plan progress', confidence: 0.82 },
+})
+
+const gitEvent = gitCommitToChronicleEvent({
+  id: 'git-1',
+  timestamp: Date.parse('2026-05-06T09:04:00Z'),
+  commitSha: 'abc1234',
+  branch: 'feat/chronicle',
+  summary: 'Add chronicle read model',
+  author: 'codex',
+  filesChanged: 3,
+  relatedEventIds: ['keeper-1'],
+  sessionId: 'session-a',
+})
+
+describe('chronicle model', () => {
+  it('normalizes Git, Keeper, and Plan sources into lanes', () => {
+    expect(chronicleLaneForEvent(gitEvent)).toBe('git')
+    expect(chronicleLaneForEvent(keeperEvent)).toBe('keeper')
+    expect(chronicleLaneForEvent(planEvent)).toBe('plan')
+  })
+
+  it('sorts newest first and summarizes source coverage', () => {
+    const events = [planEvent, gitEvent, keeperEvent]
+    const sorted = sortChronicleEvents(events)
+    const summary = summarizeChronicleEvents(events)
+
+    expect(sorted.map(event => event.id)).toEqual(['git-1', 'keeper-1', 'plan-1'])
+    expect(summary).toMatchObject({
+      totalCount: 3,
+      visibleCount: 3,
+      sessionCount: 1,
+      relatedLinkCount: 4,
+      intentCount: 2,
+      laneCounts: {
+        git: 1,
+        keeper: 1,
+        plan: 1,
+        system: 0,
+        conversation: 0,
+      },
+    })
+    expect(summary.latestTimestamp).toBe(gitEvent.timestamp)
+    expect(summary.oldestTimestamp).toBe(planEvent.timestamp)
+  })
+
+  it('builds selected context with related events and linked targets', () => {
+    const model = buildChronicleViewModel([planEvent, gitEvent, keeperEvent], 'keeper-1')
+
+    expect(model.selectedEvent?.id).toBe('keeper-1')
+    expect(model.relatedEvents.map(event => event.id)).toEqual(['git-1', 'plan-1'])
+    expect(model.linkedTargets.map(target => target.key)).toEqual([
+      'command:git:abc1234',
+      'plan:goal:p1#chronicle-ui',
+      'command:keeper:sigma/trace',
+    ])
+  })
+})

--- a/dashboard/src/components/chronicle/chronicle-model.test.ts
+++ b/dashboard/src/components/chronicle/chronicle-model.test.ts
@@ -76,6 +76,25 @@ describe('chronicle model', () => {
     expect(summary.oldestTimestamp).toBe(planEvent.timestamp)
   })
 
+  it('sorts invalid timestamps deterministically after finite events', () => {
+    const invalidB = { ...keeperEvent, id: 'invalid-b', timestamp: Number.NaN }
+    const invalidA = { ...planEvent, id: 'invalid-a', timestamp: Number.POSITIVE_INFINITY }
+
+    expect(sortChronicleEvents([invalidB, gitEvent, invalidA]).map(event => event.id)).toEqual([
+      'git-1',
+      'invalid-a',
+      'invalid-b',
+    ])
+  })
+
+  it('preserves total count when the view is truncated', () => {
+    const model = buildChronicleViewModel([planEvent, gitEvent, keeperEvent], undefined, 2)
+
+    expect(model.events.map(event => event.id)).toEqual(['git-1', 'keeper-1'])
+    expect(model.summary.totalCount).toBe(3)
+    expect(model.summary.visibleCount).toBe(2)
+  })
+
   it('builds selected context with related events and linked targets', () => {
     const model = buildChronicleViewModel([planEvent, gitEvent, keeperEvent], 'keeper-1')
 

--- a/dashboard/src/components/chronicle/chronicle-model.ts
+++ b/dashboard/src/components/chronicle/chronicle-model.ts
@@ -1,0 +1,230 @@
+import type {
+  ChronicleEvent,
+  ChronicleLane,
+  ChronicleLinkedTarget,
+  ChronicleSummary,
+  ChronicleViewModel,
+  GitCommitChronicleInput,
+  KeeperChronicleInput,
+  PlanChronicleInput,
+} from './chronicle-types'
+
+const EMPTY_LANE_COUNTS: Record<ChronicleLane, number> = {
+  git: 0,
+  keeper: 0,
+  plan: 0,
+  system: 0,
+  conversation: 0,
+}
+
+function finiteTimestamp(value: number): number | null {
+  return Number.isFinite(value) ? value : null
+}
+
+function stableEventId(prefix: string, timestamp: number, id: string): string {
+  return `${prefix}:${timestamp}:${id}`
+}
+
+export function chronicleLaneForEvent(event: ChronicleEvent): ChronicleLane {
+  if (event.eventType.startsWith('git.')) return 'git'
+  if (event.eventType.startsWith('keeper.') || event.actor.type === 'keeper') return 'keeper'
+  if (event.eventType.startsWith('plan.') || event.target.type === 'plan') return 'plan'
+  if (event.eventType === 'conversation' || event.target.type === 'conversation') return 'conversation'
+  return 'system'
+}
+
+export function chronicleLaneLabel(lane: ChronicleLane): string {
+  switch (lane) {
+    case 'git':
+      return 'Git'
+    case 'keeper':
+      return 'Keeper'
+    case 'plan':
+      return 'Plan'
+    case 'conversation':
+      return 'Conversation'
+    case 'system':
+      return 'System'
+  }
+}
+
+export function sortChronicleEvents(events: readonly ChronicleEvent[]): ChronicleEvent[] {
+  return [...events].sort((a, b) => {
+    const timeDelta = (finiteTimestamp(b.timestamp) ?? -Infinity) - (finiteTimestamp(a.timestamp) ?? -Infinity)
+    if (timeDelta !== 0) return timeDelta
+    return a.id.localeCompare(b.id)
+  })
+}
+
+export function summarizeChronicleEvents(events: readonly ChronicleEvent[]): ChronicleSummary {
+  const sorted = sortChronicleEvents(events)
+  const sessionIds = new Set<string>()
+  const laneCounts = { ...EMPTY_LANE_COUNTS }
+  let relatedLinkCount = 0
+  let intentCount = 0
+
+  for (const event of sorted) {
+    sessionIds.add(event.context.sessionId)
+    laneCounts[chronicleLaneForEvent(event)] += 1
+    relatedLinkCount += event.context.relatedEventIds.length
+    if (event.intent) intentCount += 1
+  }
+
+  return {
+    totalCount: events.length,
+    visibleCount: sorted.length,
+    latestTimestamp: sorted.length > 0 ? finiteTimestamp(sorted[0]!.timestamp) : null,
+    oldestTimestamp: sorted.length > 0 ? finiteTimestamp(sorted[sorted.length - 1]!.timestamp) : null,
+    sessionCount: sessionIds.size,
+    relatedLinkCount,
+    laneCounts,
+    intentCount,
+  }
+}
+
+export function relatedChronicleEvents(
+  events: readonly ChronicleEvent[],
+  selected: ChronicleEvent | null,
+): ChronicleEvent[] {
+  if (!selected) return []
+  const relatedIds = new Set(selected.context.relatedEventIds)
+  return sortChronicleEvents(events).filter(event => {
+    if (event.id === selected.id) return false
+    return relatedIds.has(event.id)
+      || event.context.relatedEventIds.includes(selected.id)
+      || event.context.parentEventId === selected.id
+      || selected.context.parentEventId === event.id
+  })
+}
+
+export function linkedChronicleTargets(events: readonly ChronicleEvent[]): ChronicleLinkedTarget[] {
+  const counts = new Map<string, ChronicleLinkedTarget>()
+  for (const event of events) {
+    const key = `${event.target.type}:${event.target.uri}`
+    const prev = counts.get(key)
+    counts.set(key, {
+      key,
+      type: event.target.type,
+      uri: event.target.uri,
+      eventCount: (prev?.eventCount ?? 0) + 1,
+    })
+  }
+  return Array.from(counts.values())
+    .sort((a, b) => (b.eventCount - a.eventCount) || a.uri.localeCompare(b.uri))
+}
+
+export function buildChronicleViewModel(
+  events: readonly ChronicleEvent[],
+  selectedEventId?: string | null,
+  maxEvents = 100,
+): ChronicleViewModel {
+  const limit = Number.isFinite(maxEvents) ? Math.max(0, Math.floor(maxEvents)) : 0
+  const sorted = sortChronicleEvents(events).slice(0, limit)
+  const selectedEvent = sorted.find(event => event.id === selectedEventId) ?? sorted[0] ?? null
+  const relatedEvents = relatedChronicleEvents(sorted, selectedEvent)
+  const linkedTargets = linkedChronicleTargets(selectedEvent ? [selectedEvent, ...relatedEvents] : [])
+  return {
+    events: sorted,
+    selectedEvent,
+    relatedEvents,
+    linkedTargets,
+    summary: summarizeChronicleEvents(sorted),
+  }
+}
+
+export function gitCommitToChronicleEvent(input: GitCommitChronicleInput): ChronicleEvent {
+  return {
+    id: input.id ?? stableEventId('git.commit', input.timestamp, input.commitSha),
+    eventType: 'git.commit',
+    timestamp: input.timestamp,
+    actor: {
+      type: 'system',
+      id: input.author ?? 'git',
+      displayName: input.author ?? 'Git',
+    },
+    target: {
+      type: 'command',
+      uri: `git:${input.commitSha}`,
+    },
+    content: {
+      summary: input.summary,
+      detail: input.detail,
+      metadata: {
+        commitSha: input.commitSha,
+        branch: input.branch,
+        filesChanged: input.filesChanged,
+      },
+    },
+    context: {
+      sessionId: input.sessionId ?? 'git',
+      relatedEventIds: input.relatedEventIds ?? [],
+      tags: input.tags ?? ['git'],
+      projectState: {
+        branch: input.branch,
+        commit: input.commitSha,
+        filesChanged: input.filesChanged,
+      },
+    },
+  }
+}
+
+export function keeperStepToChronicleEvent(input: KeeperChronicleInput): ChronicleEvent {
+  return {
+    id: input.id ?? stableEventId(input.eventType ?? 'keeper.step', input.timestamp, input.keeperId),
+    eventType: input.eventType ?? 'keeper.step',
+    timestamp: input.timestamp,
+    actor: {
+      type: 'keeper',
+      id: input.keeperId,
+      displayName: input.keeperName,
+    },
+    target: {
+      type: 'command',
+      uri: input.targetUri ?? `keeper:${input.keeperName}`,
+    },
+    content: {
+      summary: input.summary,
+      detail: input.detail,
+      metadata: input.metadata,
+    },
+    context: {
+      sessionId: input.sessionId ?? input.keeperId,
+      parentEventId: input.parentEventId,
+      relatedEventIds: input.relatedEventIds ?? [],
+      tags: input.tags ?? ['keeper'],
+    },
+    intent: input.intent,
+  }
+}
+
+export function planProgressToChronicleEvent(input: PlanChronicleInput): ChronicleEvent {
+  return {
+    id: input.id ?? stableEventId(input.eventType ?? 'plan.updated', input.timestamp, input.stepId ?? input.planId),
+    eventType: input.eventType ?? 'plan.updated',
+    timestamp: input.timestamp,
+    actor: {
+      type: 'system',
+      id: 'plan',
+      displayName: 'Plan',
+    },
+    target: {
+      type: 'plan',
+      uri: input.stepId ? `${input.planId}#${input.stepId}` : input.planId,
+    },
+    content: {
+      summary: input.summary,
+      detail: input.detail,
+    },
+    context: {
+      sessionId: input.sessionId ?? input.planId,
+      relatedEventIds: input.relatedEventIds ?? [],
+      tags: input.tags ?? ['plan'],
+    },
+    intent: input.statedGoal
+      ? {
+          statedGoal: input.statedGoal,
+          confidence: 1,
+        }
+      : undefined,
+  }
+}

--- a/dashboard/src/components/chronicle/chronicle-model.ts
+++ b/dashboard/src/components/chronicle/chronicle-model.ts
@@ -50,13 +50,21 @@ export function chronicleLaneLabel(lane: ChronicleLane): string {
 
 export function sortChronicleEvents(events: readonly ChronicleEvent[]): ChronicleEvent[] {
   return [...events].sort((a, b) => {
-    const timeDelta = (finiteTimestamp(b.timestamp) ?? -Infinity) - (finiteTimestamp(a.timestamp) ?? -Infinity)
+    const aTimestamp = finiteTimestamp(a.timestamp)
+    const bTimestamp = finiteTimestamp(b.timestamp)
+    if (aTimestamp == null && bTimestamp == null) return a.id.localeCompare(b.id)
+    if (aTimestamp == null) return 1
+    if (bTimestamp == null) return -1
+    const timeDelta = bTimestamp - aTimestamp
     if (timeDelta !== 0) return timeDelta
     return a.id.localeCompare(b.id)
   })
 }
 
-export function summarizeChronicleEvents(events: readonly ChronicleEvent[]): ChronicleSummary {
+export function summarizeChronicleEvents(
+  events: readonly ChronicleEvent[],
+  totalCount = events.length,
+): ChronicleSummary {
   const sorted = sortChronicleEvents(events)
   const sessionIds = new Set<string>()
   const laneCounts = { ...EMPTY_LANE_COUNTS }
@@ -71,7 +79,7 @@ export function summarizeChronicleEvents(events: readonly ChronicleEvent[]): Chr
   }
 
   return {
-    totalCount: events.length,
+    totalCount,
     visibleCount: sorted.length,
     latestTimestamp: sorted.length > 0 ? finiteTimestamp(sorted[0]!.timestamp) : null,
     oldestTimestamp: sorted.length > 0 ? finiteTimestamp(sorted[sorted.length - 1]!.timestamp) : null,
@@ -120,7 +128,12 @@ export function buildChronicleViewModel(
 ): ChronicleViewModel {
   const limit = Number.isFinite(maxEvents) ? Math.max(0, Math.floor(maxEvents)) : 0
   const sorted = sortChronicleEvents(events).slice(0, limit)
-  const selectedEvent = sorted.find(event => event.id === selectedEventId) ?? sorted[0] ?? null
+  const selectedEvent =
+    selectedEventId === null
+      ? null
+      : selectedEventId === undefined
+        ? sorted[0] ?? null
+        : sorted.find(event => event.id === selectedEventId) ?? sorted[0] ?? null
   const relatedEvents = relatedChronicleEvents(sorted, selectedEvent)
   const linkedTargets = linkedChronicleTargets(selectedEvent ? [selectedEvent, ...relatedEvents] : [])
   return {
@@ -128,7 +141,7 @@ export function buildChronicleViewModel(
     selectedEvent,
     relatedEvents,
     linkedTargets,
-    summary: summarizeChronicleEvents(sorted),
+    summary: summarizeChronicleEvents(sorted, events.length),
   }
 }
 

--- a/dashboard/src/components/chronicle/chronicle-navigator.test.ts
+++ b/dashboard/src/components/chronicle/chronicle-navigator.test.ts
@@ -84,4 +84,36 @@ describe('ChronicleNavigator', () => {
     expect(container.querySelector('[data-chronicle-navigator]')?.getAttribute('data-chronicle-selected-id')).toBe('plan-1')
     expect(container.textContent).toContain('3-panel navigator becomes the first P1 surface.')
   })
+
+  it('honors explicit null selection in controlled mode', async () => {
+    const container = document.createElement('div')
+    render(h(ChronicleNavigator, { events, selectedEventId: 'keeper-1' }), container)
+    expect(container.querySelector('[data-chronicle-navigator]')?.getAttribute('data-chronicle-selected-id')).toBe('keeper-1')
+
+    render(h(ChronicleNavigator, { events, selectedEventId: null }), container)
+    await Promise.resolve()
+
+    expect(container.querySelector('[data-chronicle-navigator]')?.getAttribute('data-chronicle-selected-id')).toBe('')
+    expect(container.textContent).toContain('No selection')
+  })
+
+  it('reports clicks without mutating controlled null selection', async () => {
+    const selected: Array<string | null> = []
+    const container = document.createElement('div')
+    render(
+      h(ChronicleNavigator, {
+        events,
+        selectedEventId: null,
+        onSelectedEventChange: eventId => selected.push(eventId),
+      }),
+      container,
+    )
+    const planButton = container.querySelector('[data-chronicle-event-id="plan-1"] button') as HTMLButtonElement
+
+    planButton.click()
+    await Promise.resolve()
+
+    expect(selected).toEqual(['plan-1'])
+    expect(container.querySelector('[data-chronicle-navigator]')?.getAttribute('data-chronicle-selected-id')).toBe('')
+  })
 })

--- a/dashboard/src/components/chronicle/chronicle-navigator.test.ts
+++ b/dashboard/src/components/chronicle/chronicle-navigator.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest'
+import { h } from 'preact'
+import { render } from 'preact'
+import { ChronicleNavigator } from './chronicle-navigator'
+import {
+  gitCommitToChronicleEvent,
+  keeperStepToChronicleEvent,
+  planProgressToChronicleEvent,
+} from './chronicle-model'
+
+const events = [
+  planProgressToChronicleEvent({
+    id: 'plan-1',
+    timestamp: Date.parse('2026-05-06T09:00:00Z'),
+    planId: 'goal:p1',
+    stepId: 'chronicle-ui',
+    eventType: 'plan.step.completed',
+    summary: 'Chronicle UI planned',
+    detail: '3-panel navigator becomes the first P1 surface.',
+    statedGoal: 'restore work history context',
+    relatedEventIds: ['keeper-1'],
+    sessionId: 'session-a',
+  }),
+  keeperStepToChronicleEvent({
+    id: 'keeper-1',
+    timestamp: Date.parse('2026-05-06T09:02:00Z'),
+    keeperId: 'keeper:sigma',
+    keeperName: 'sigma',
+    summary: 'Mapped keeper trace into chronicle event',
+    targetUri: 'keeper:sigma/trace',
+    relatedEventIds: ['plan-1', 'git-1'],
+    sessionId: 'session-a',
+    metadata: { traceId: 'trace-123' },
+    intent: { inferredIntent: 'connect trace and plan progress', confidence: 0.82 },
+  }),
+  gitCommitToChronicleEvent({
+    id: 'git-1',
+    timestamp: Date.parse('2026-05-06T09:04:00Z'),
+    commitSha: 'abc1234',
+    branch: 'feat/chronicle',
+    summary: 'Add chronicle read model',
+    author: 'codex',
+    filesChanged: 3,
+    relatedEventIds: ['keeper-1'],
+    sessionId: 'session-a',
+  }),
+]
+
+describe('ChronicleNavigator', () => {
+  it('renders the three chronicle panels and summary metadata', () => {
+    const container = document.createElement('div')
+    render(h(ChronicleNavigator, { events, selectedEventId: 'keeper-1', testId: 'chronicle' }), container)
+    const root = container.querySelector('[data-chronicle-navigator]') as HTMLElement
+
+    expect(root.dataset.chronicleTotalCount).toBe('3')
+    expect(root.dataset.chronicleVisibleCount).toBe('3')
+    expect(root.dataset.chronicleSelectedId).toBe('keeper-1')
+    expect(container.querySelector('[data-chronicle-panel="timeline"]')).not.toBeNull()
+    expect(container.querySelector('[data-chronicle-panel="context"]')).not.toBeNull()
+    expect(container.querySelector('[data-chronicle-panel="detail"]')).not.toBeNull()
+    expect(container.querySelectorAll('[data-chronicle-event-id]')).toHaveLength(3)
+  })
+
+  it('shows related events, linked targets, metadata, and intent for the selected event', () => {
+    const container = document.createElement('div')
+    render(h(ChronicleNavigator, { events, selectedEventId: 'keeper-1' }), container)
+
+    expect(container.textContent).toContain('Add chronicle read model')
+    expect(container.textContent).toContain('Chronicle UI planned')
+    expect(container.textContent).toContain('keeper:sigma/trace')
+    expect(container.textContent).toContain('traceId')
+    expect(container.textContent).toContain('trace-123')
+    expect(container.querySelector('[data-chronicle-intent]')?.textContent).toContain('82%')
+  })
+
+  it('updates detail selection when an event row is clicked', async () => {
+    const container = document.createElement('div')
+    render(h(ChronicleNavigator, { events }), container)
+    const planButton = container.querySelector('[data-chronicle-event-id="plan-1"] button') as HTMLButtonElement
+
+    expect(container.querySelector('[data-chronicle-navigator]')?.getAttribute('data-chronicle-selected-id')).toBe('git-1')
+    planButton.click()
+    await Promise.resolve()
+    expect(container.querySelector('[data-chronicle-navigator]')?.getAttribute('data-chronicle-selected-id')).toBe('plan-1')
+    expect(container.textContent).toContain('3-panel navigator becomes the first P1 surface.')
+  })
+})

--- a/dashboard/src/components/chronicle/chronicle-navigator.ts
+++ b/dashboard/src/components/chronicle/chronicle-navigator.ts
@@ -1,5 +1,5 @@
 import { html } from 'htm/preact'
-import { useMemo, useState } from 'preact/hooks'
+import { useEffect, useMemo, useState } from 'preact/hooks'
 import {
   buildChronicleViewModel,
   chronicleLaneForEvent,
@@ -12,7 +12,7 @@ interface ChronicleNavigatorProps {
   selectedEventId?: string | null
   maxEvents?: number
   testId?: string
-  onSelectedEventChange?: (eventId: string) => void
+  onSelectedEventChange?: (eventId: string | null) => void
 }
 
 const LANE_TONE: Record<ChronicleLane, string> = {
@@ -55,8 +55,13 @@ export function ChronicleNavigator({
   testId,
   onSelectedEventChange,
 }: ChronicleNavigatorProps) {
-  const [internalSelectedId, setInternalSelectedId] = useState<string | null>(selectedEventId ?? null)
-  const effectiveSelectedId = selectedEventId ?? internalSelectedId
+  const [internalSelectedId, setInternalSelectedId] = useState<string | null | undefined>(
+    selectedEventId,
+  )
+  useEffect(() => {
+    if (selectedEventId !== undefined) setInternalSelectedId(selectedEventId)
+  }, [selectedEventId])
+  const effectiveSelectedId = selectedEventId !== undefined ? selectedEventId : internalSelectedId
   const model = useMemo(
     () => buildChronicleViewModel(events, effectiveSelectedId, maxEvents),
     [events, effectiveSelectedId, maxEvents],
@@ -66,7 +71,7 @@ export function ChronicleNavigator({
   const metadata = metadataEntries(selected)
 
   const selectEvent = (eventId: string) => {
-    setInternalSelectedId(eventId)
+    if (selectedEventId === undefined) setInternalSelectedId(eventId)
     onSelectedEventChange?.(eventId)
   }
 

--- a/dashboard/src/components/chronicle/chronicle-navigator.ts
+++ b/dashboard/src/components/chronicle/chronicle-navigator.ts
@@ -1,0 +1,233 @@
+import { html } from 'htm/preact'
+import { useMemo, useState } from 'preact/hooks'
+import {
+  buildChronicleViewModel,
+  chronicleLaneForEvent,
+  chronicleLaneLabel,
+} from './chronicle-model'
+import type { ChronicleEvent, ChronicleLane } from './chronicle-types'
+
+interface ChronicleNavigatorProps {
+  events: readonly ChronicleEvent[]
+  selectedEventId?: string | null
+  maxEvents?: number
+  testId?: string
+  onSelectedEventChange?: (eventId: string) => void
+}
+
+const LANE_TONE: Record<ChronicleLane, string> = {
+  git: 'border-[var(--color-status-ok)]',
+  keeper: 'border-[var(--color-accent)]',
+  plan: 'border-[var(--color-status-info)]',
+  system: 'border-[var(--color-border-strong)]',
+  conversation: 'border-[var(--color-status-warn)]',
+}
+
+function formatTime(timestamp: number): string {
+  const date = new Date(timestamp)
+  if (!Number.isFinite(date.getTime())) return '--:--:--'
+  return `${date.getHours().toString().padStart(2, '0')}:${date.getMinutes().toString().padStart(2, '0')}:${date.getSeconds().toString().padStart(2, '0')}`
+}
+
+function formatMetadataValue(value: unknown): string {
+  if (value == null) return ''
+  if (typeof value === 'string') return value
+  if (typeof value === 'number' || typeof value === 'boolean') return String(value)
+  if (Array.isArray(value)) return value.map(item => formatMetadataValue(item)).filter(Boolean).join(', ')
+  try {
+    return JSON.stringify(value)
+  } catch {
+    return String(value)
+  }
+}
+
+function metadataEntries(event: ChronicleEvent | null): Array<[string, string]> {
+  if (!event?.content.metadata) return []
+  return Object.entries(event.content.metadata)
+    .map(([key, value]): [string, string] => [key, formatMetadataValue(value)])
+    .filter(([, value]) => value !== '')
+}
+
+export function ChronicleNavigator({
+  events,
+  selectedEventId,
+  maxEvents = 100,
+  testId,
+  onSelectedEventChange,
+}: ChronicleNavigatorProps) {
+  const [internalSelectedId, setInternalSelectedId] = useState<string | null>(selectedEventId ?? null)
+  const effectiveSelectedId = selectedEventId ?? internalSelectedId
+  const model = useMemo(
+    () => buildChronicleViewModel(events, effectiveSelectedId, maxEvents),
+    [events, effectiveSelectedId, maxEvents],
+  )
+  const selected = model.selectedEvent
+  const selectedLane = selected ? chronicleLaneForEvent(selected) : null
+  const metadata = metadataEntries(selected)
+
+  const selectEvent = (eventId: string) => {
+    setInternalSelectedId(eventId)
+    onSelectedEventChange?.(eventId)
+  }
+
+  return html`
+    <section
+      class="grid min-h-0 gap-3 lg:grid-cols-[minmax(220px,0.9fr)_minmax(220px,1fr)_minmax(260px,1.2fr)]"
+      aria-label="Chronicle navigator"
+      data-chronicle-navigator
+      data-chronicle-total-count=${model.summary.totalCount}
+      data-chronicle-visible-count=${model.summary.visibleCount}
+      data-chronicle-selected-id=${selected?.id ?? ''}
+      data-chronicle-session-count=${model.summary.sessionCount}
+      data-chronicle-related-link-count=${model.summary.relatedLinkCount}
+      data-testid=${testId}
+    >
+      <div
+        class="min-h-0 rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)]"
+        data-chronicle-panel="timeline"
+      >
+        <div class="border-b border-[var(--color-border-default)] px-3 py-2">
+          <div class="text-2xs font-semibold text-[var(--color-fg-primary)]">Chronicle</div>
+          <div class="text-3xs text-[var(--color-fg-muted)]">
+            ${model.summary.visibleCount}/${model.summary.totalCount} events · ${model.summary.sessionCount} sessions
+          </div>
+        </div>
+        <div class="max-h-[520px] overflow-auto p-2" role="list" aria-label="Chronicle events">
+          ${model.events.length === 0
+            ? html`<div class="px-1 py-2 text-3xs text-[var(--color-fg-muted)]">No chronicle events</div>`
+            : model.events.map(event => {
+                const lane = chronicleLaneForEvent(event)
+                const selectedRow = selected?.id === event.id
+                return html`
+                  <div role="listitem" data-chronicle-event-id=${event.id}>
+                    <button
+                      type="button"
+                      class=${`mb-1 grid w-full grid-cols-[3.5rem_minmax(0,1fr)] gap-2 rounded-[var(--r-1)] border-l-2 ${LANE_TONE[lane]} px-2 py-1.5 text-left hover:bg-[var(--color-bg-hover)] aria-pressed:bg-[var(--color-state-active-bg)]`}
+                      aria-pressed=${selectedRow}
+                      onClick=${() => selectEvent(event.id)}
+                    >
+                      <span class="font-mono text-3xs text-[var(--color-fg-muted)]">${formatTime(event.timestamp)}</span>
+                      <span class="min-w-0">
+                        <span class="block truncate text-xs text-[var(--color-fg-primary)]">${event.content.summary}</span>
+                        <span class="block truncate text-3xs text-[var(--color-fg-muted)]">
+                          ${chronicleLaneLabel(lane)} · ${event.actor.displayName}
+                        </span>
+                      </span>
+                    </button>
+                  </div>
+                `
+              })}
+        </div>
+      </div>
+
+      <div
+        class="min-h-0 rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)]"
+        data-chronicle-panel="context"
+      >
+        <div class="border-b border-[var(--color-border-default)] px-3 py-2">
+          <div class="text-2xs font-semibold text-[var(--color-fg-primary)]">Context</div>
+          <div class="text-3xs text-[var(--color-fg-muted)]">
+            ${selected ? `${chronicleLaneLabel(selectedLane!)} · ${selected.context.sessionId}` : 'No selection'}
+          </div>
+        </div>
+        <div class="grid gap-3 p-3">
+          <div>
+            <div class="mb-1 text-3xs font-semibold uppercase text-[var(--color-fg-muted)]">Related Events</div>
+            ${model.relatedEvents.length === 0
+              ? html`<div class="text-3xs text-[var(--color-fg-muted)]">No related events</div>`
+              : html`
+                <ul class="grid gap-1" aria-label="Related chronicle events">
+                  ${model.relatedEvents.map(event => html`
+                    <li class="rounded-[var(--r-0)] bg-[var(--color-bg-elevated)] px-2 py-1 text-3xs text-[var(--color-fg-secondary)]">
+                      ${formatTime(event.timestamp)} · ${event.content.summary}
+                    </li>
+                  `)}
+                </ul>
+              `}
+          </div>
+          <div>
+            <div class="mb-1 text-3xs font-semibold uppercase text-[var(--color-fg-muted)]">Linked Targets</div>
+            ${model.linkedTargets.length === 0
+              ? html`<div class="text-3xs text-[var(--color-fg-muted)]">No linked targets</div>`
+              : html`
+                <ul class="grid gap-1" aria-label="Linked chronicle targets">
+                  ${model.linkedTargets.map(target => html`
+                    <li
+                      class="flex min-w-0 items-center justify-between gap-2 rounded-[var(--r-0)] bg-[var(--color-bg-elevated)] px-2 py-1 text-3xs"
+                      data-chronicle-target=${target.key}
+                    >
+                      <span class="min-w-0 truncate text-[var(--color-fg-secondary)]">${target.uri}</span>
+                      <span class="shrink-0 font-mono text-[var(--color-fg-muted)]">${target.eventCount}</span>
+                    </li>
+                  `)}
+                </ul>
+              `}
+          </div>
+          <div>
+            <div class="mb-1 text-3xs font-semibold uppercase text-[var(--color-fg-muted)]">Project State</div>
+            ${selected?.context.projectState
+              ? html`
+                <dl class="grid grid-cols-[5rem_minmax(0,1fr)] gap-x-2 gap-y-1 text-3xs">
+                  <dt class="text-[var(--color-fg-muted)]">branch</dt>
+                  <dd class="truncate text-[var(--color-fg-secondary)]">${selected.context.projectState.branch ?? '-'}</dd>
+                  <dt class="text-[var(--color-fg-muted)]">commit</dt>
+                  <dd class="truncate font-mono text-[var(--color-fg-secondary)]">${selected.context.projectState.commit ?? '-'}</dd>
+                  <dt class="text-[var(--color-fg-muted)]">files</dt>
+                  <dd class="text-[var(--color-fg-secondary)]">${selected.context.projectState.filesChanged ?? 0}</dd>
+                </dl>
+              `
+              : html`<div class="text-3xs text-[var(--color-fg-muted)]">No project snapshot</div>`}
+          </div>
+        </div>
+      </div>
+
+      <div
+        class="min-h-0 rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)]"
+        data-chronicle-panel="detail"
+      >
+        <div class="border-b border-[var(--color-border-default)] px-3 py-2">
+          <div class="text-2xs font-semibold text-[var(--color-fg-primary)]">Action Detail</div>
+          <div class="text-3xs text-[var(--color-fg-muted)]">${selected?.target.uri ?? 'No selection'}</div>
+        </div>
+        ${selected
+          ? html`
+            <div class="grid gap-3 p-3">
+              <div>
+                <div class="text-sm font-semibold text-[var(--color-fg-primary)]">${selected.content.summary}</div>
+                ${selected.content.detail
+                  ? html`<p class="mt-1 text-xs text-[var(--color-fg-secondary)]">${selected.content.detail}</p>`
+                  : null}
+              </div>
+              ${selected.content.diff
+                ? html`
+                  <pre class="max-h-48 overflow-auto rounded-[var(--r-1)] bg-[var(--color-bg-elevated)] p-2 text-3xs text-[var(--color-fg-secondary)]">${selected.content.diff}</pre>
+                `
+                : null}
+              ${metadata.length > 0
+                ? html`
+                  <dl class="grid grid-cols-[7rem_minmax(0,1fr)] gap-x-2 gap-y-1 text-3xs">
+                    ${metadata.map(([key, value]) => html`
+                      <dt class="text-[var(--color-fg-muted)]">${key}</dt>
+                      <dd class="min-w-0 truncate text-[var(--color-fg-secondary)]">${value}</dd>
+                    `)}
+                  </dl>
+                `
+                : null}
+              ${selected.intent
+                ? html`
+                  <div
+                    class="rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] px-2 py-1.5 text-3xs text-[var(--color-fg-secondary)]"
+                    data-chronicle-intent
+                  >
+                    ${selected.intent.statedGoal ?? selected.intent.inferredIntent ?? 'Intent recorded'}
+                    <span class="font-mono text-[var(--color-fg-muted)]">${Math.round(selected.intent.confidence * 100)}%</span>
+                  </div>
+                `
+                : null}
+            </div>
+          `
+          : html`<div class="p-3 text-3xs text-[var(--color-fg-muted)]">Select an event to inspect details</div>`}
+      </div>
+    </section>
+  `
+}

--- a/dashboard/src/components/chronicle/chronicle-types.ts
+++ b/dashboard/src/components/chronicle/chronicle-types.ts
@@ -1,0 +1,157 @@
+export type ChronicleActorType = 'user' | 'keeper' | 'agent' | 'system'
+
+export type ChronicleTargetType =
+  | 'file'
+  | 'module'
+  | 'plan'
+  | 'issue'
+  | 'command'
+  | 'test'
+  | 'conversation'
+
+export type ChronicleEventType =
+  | 'file.opened'
+  | 'file.edited'
+  | 'file.saved'
+  | 'command.executed'
+  | 'keeper.started'
+  | 'keeper.step'
+  | 'keeper.decision'
+  | 'keeper.completed'
+  | 'keeper.error'
+  | 'plan.created'
+  | 'plan.updated'
+  | 'plan.step.completed'
+  | 'plan.blocked'
+  | 'build.completed'
+  | 'test.passed'
+  | 'test.failed'
+  | 'git.commit'
+  | 'git.merge'
+  | 'conversation'
+  | 'suggestion.accepted'
+  | 'suggestion.rejected'
+
+export type ChronicleLane = 'git' | 'keeper' | 'plan' | 'system' | 'conversation'
+
+export interface ChronicleActor {
+  type: ChronicleActorType
+  id: string
+  displayName: string
+}
+
+export interface ChronicleTarget {
+  type: ChronicleTargetType
+  uri: string
+  range?: readonly [number, number]
+}
+
+export interface ChronicleProjectSnapshot {
+  branch?: string
+  commit?: string
+  filesChanged?: number
+  dirty?: boolean
+}
+
+export interface ChronicleContent {
+  summary: string
+  detail?: string
+  diff?: string
+  metadata?: Record<string, unknown>
+}
+
+export interface ChronicleContext {
+  sessionId: string
+  parentEventId?: string
+  relatedEventIds: readonly string[]
+  tags: readonly string[]
+  projectState?: ChronicleProjectSnapshot
+}
+
+export interface ChronicleIntent {
+  statedGoal?: string
+  inferredIntent?: string
+  confidence: number
+}
+
+export interface ChronicleEvent {
+  id: string
+  eventType: ChronicleEventType
+  timestamp: number
+  actor: ChronicleActor
+  target: ChronicleTarget
+  content: ChronicleContent
+  context: ChronicleContext
+  intent?: ChronicleIntent
+}
+
+export interface ChronicleSummary {
+  totalCount: number
+  visibleCount: number
+  latestTimestamp: number | null
+  oldestTimestamp: number | null
+  sessionCount: number
+  relatedLinkCount: number
+  laneCounts: Record<ChronicleLane, number>
+  intentCount: number
+}
+
+export interface ChronicleLinkedTarget {
+  key: string
+  type: ChronicleTargetType
+  uri: string
+  eventCount: number
+}
+
+export interface ChronicleViewModel {
+  events: ChronicleEvent[]
+  selectedEvent: ChronicleEvent | null
+  relatedEvents: ChronicleEvent[]
+  linkedTargets: ChronicleLinkedTarget[]
+  summary: ChronicleSummary
+}
+
+export interface GitCommitChronicleInput {
+  id?: string
+  timestamp: number
+  commitSha: string
+  branch?: string
+  author?: string
+  summary: string
+  detail?: string
+  filesChanged?: number
+  sessionId?: string
+  relatedEventIds?: readonly string[]
+  tags?: readonly string[]
+}
+
+export interface KeeperChronicleInput {
+  id?: string
+  timestamp: number
+  keeperId: string
+  keeperName: string
+  eventType?: Extract<ChronicleEventType, `keeper.${string}`>
+  summary: string
+  detail?: string
+  targetUri?: string
+  sessionId?: string
+  parentEventId?: string
+  relatedEventIds?: readonly string[]
+  tags?: readonly string[]
+  metadata?: Record<string, unknown>
+  intent?: ChronicleIntent
+}
+
+export interface PlanChronicleInput {
+  id?: string
+  timestamp: number
+  planId: string
+  stepId?: string
+  eventType?: Extract<ChronicleEventType, `plan.${string}`>
+  summary: string
+  detail?: string
+  statedGoal?: string
+  sessionId?: string
+  relatedEventIds?: readonly string[]
+  tags?: readonly string[]
+}

--- a/dashboard/src/components/chronicle/index.ts
+++ b/dashboard/src/components/chronicle/index.ts
@@ -1,0 +1,3 @@
+export * from './chronicle-model'
+export * from './chronicle-navigator'
+export * from './chronicle-types'


### PR DESCRIPTION
## Summary
- add ChronicleEvent contracts for Git, Keeper, Plan, and system history rows
- add pure Chronicle view-model helpers for newest-first ordering, lane summaries, related events, linked targets, and source adapters
- add a reusable 3-panel ChronicleNavigator surface with focused tests

## Master Report
- implements the first P1 Chronicle UI + Librarian foundation slice from /Users/dancer/Downloads/masc-cognitive-ide-master.md
- intentionally dashboard-local; backend EventStore/RAG wiring stays for the next P1 slice

## Verification
- pnpm install --offline --frozen-lockfile
- pnpm exec vitest run --config vitest.config.ts src/components/chronicle/chronicle-model.test.ts src/components/chronicle/chronicle-navigator.test.ts --no-file-parallelism --maxWorkers=1
- pnpm exec tsc --noEmit --pretty false
- pnpm exec eslint src (passes with existing unrelated warnings in virtual-list.ts and fsm-hub.ts)
- git diff --check