### PR TITLE
feat(dashboard): expose board curation snapshot

### DIFF
--- a/dashboard/src/components/board/board-curation-panel.test.ts
+++ b/dashboard/src/components/board/board-curation-panel.test.ts
@@ -70,4 +70,13 @@ describe('BoardCurationPanel', () => {
     await waitFor(() => expect(fetchBoardCurationMock).toHaveBeenCalledTimes(1))
     expect(await screen.findByText('No curation snapshot yet.')).toBeTruthy()
   })
+
+  it('renders the fetch error instead of the empty state when loading fails', async () => {
+    fetchBoardCurationMock.mockRejectedValue(new Error('network unavailable'))
+
+    render(h(BoardCurationPanel, null))
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('network unavailable')
+    expect(screen.queryByText('No curation snapshot yet.')).toBeNull()
+  })
 })

--- a/dashboard/src/components/board/board-curation-panel.test.ts
+++ b/dashboard/src/components/board/board-curation-panel.test.ts
@@ -1,0 +1,73 @@
+import { h } from 'preact'
+import { cleanup, render, screen, waitFor } from '@testing-library/preact'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import '@testing-library/jest-dom'
+import { BoardCurationPanel } from './board-curation-panel'
+import { fetchBoardCuration } from '../../api/board'
+
+vi.mock('../../api/board', () => ({
+  fetchBoardCuration: vi.fn(),
+}))
+
+vi.mock('../../router', () => ({
+  navigate: vi.fn(),
+}))
+
+const fetchBoardCurationMock = vi.mocked(fetchBoardCuration)
+
+describe('BoardCurationPanel', () => {
+  beforeEach(() => {
+    fetchBoardCurationMock.mockResolvedValue({
+      id: 'cu-1',
+      generated_at: '2026-05-06T10:00:00.000Z',
+      submitted_by: 'keeper-curator',
+      model: 'gpt-5',
+      summary: 'Two active incidents need review.',
+      ordering: ['post-a', 'post-b'],
+      highlights: ['post-a'],
+      tag_suggestions: [
+        { post_id: 'post-a', tags: ['incident', 'ops'], rationale: 'Incident thread' },
+      ],
+      answer_matches: [
+        {
+          question_post_id: 'post-question',
+          answer_post_id: 'post-answer',
+          score: 0.86,
+          rationale: 'Same stack trace',
+        },
+      ],
+      health_score: 0.74,
+      health_components: [
+        { name: 'answer_rate', score: 0.8, weight: 0.25, rationale: 'Most questions have replies' },
+      ],
+      rationale: 'Prioritize incidents before planning threads.',
+      provenance: { run_id: 'curation-run-1' },
+    })
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.clearAllMocks()
+  })
+
+  it('renders the latest curation snapshot details', async () => {
+    render(h(BoardCurationPanel, null))
+
+    expect(await screen.findByText('Two active incidents need review.')).toBeTruthy()
+    expect(screen.getByText(/keeper-curator/)).toBeTruthy()
+    expect(screen.getByText('74%')).toBeTruthy()
+    expect(screen.getAllByText('post-a').length).toBeGreaterThan(0)
+    expect(screen.getByText('incident')).toBeTruthy()
+    expect(screen.getByText('post-question')).toBeTruthy()
+    expect(screen.getByText('answer_rate')).toBeTruthy()
+  })
+
+  it('renders an empty state when no curation snapshot exists', async () => {
+    fetchBoardCurationMock.mockResolvedValue(null)
+
+    render(h(BoardCurationPanel, null))
+
+    await waitFor(() => expect(fetchBoardCurationMock).toHaveBeenCalledTimes(1))
+    expect(await screen.findByText('No curation snapshot yet.')).toBeTruthy()
+  })
+})

--- a/dashboard/src/components/board/board-curation-panel.ts
+++ b/dashboard/src/components/board/board-curation-panel.ts
@@ -5,7 +5,7 @@ import { fetchBoardCuration } from '../../api/board'
 import type { BoardCurationSnapshot } from '../../types'
 import { navigate } from '../../router'
 import { ActionButton } from '../common/button'
-import { EmptyState, LoadingState } from '../common/feedback-state'
+import { EmptyState, ErrorState, LoadingState } from '../common/feedback-state'
 import { SurfaceCard } from '../common/card'
 import { TimeAgo } from '../common/time-ago'
 
@@ -157,14 +157,16 @@ export function BoardCurationPanel() {
         </div>
       </div>
 
-      ${error ? html`
+      ${error && snapshot ? html`
         <div class="rounded-[var(--r-1)] border border-[var(--color-status-err)]/40 bg-[var(--color-status-err)]/10 px-3 py-2 text-xs text-[var(--color-status-err)]" role="alert">${error}</div>
       ` : null}
       ${loading
         ? html`<${LoadingState}>Loading board curation...<//>`
-        : snapshot
-          ? html`<${CurationSnapshot} snapshot=${snapshot} />`
-          : html`<${EmptyState} message="No curation snapshot yet." compact />`}
+        : error && !snapshot
+          ? html`<${ErrorState} message=${error} />`
+          : snapshot
+            ? html`<${CurationSnapshot} snapshot=${snapshot} />`
+            : html`<${EmptyState} message="No curation snapshot yet." compact />`}
     </section>
   `
 }

--- a/dashboard/src/components/board/board-curation-panel.ts
+++ b/dashboard/src/components/board/board-curation-panel.ts
@@ -1,0 +1,170 @@
+import { html } from 'htm/preact'
+import { useCallback, useEffect, useState } from 'preact/hooks'
+import { ArrowLeft, RefreshCw, Sparkles } from 'lucide-preact'
+import { fetchBoardCuration } from '../../api/board'
+import type { BoardCurationSnapshot } from '../../types'
+import { navigate } from '../../router'
+import { ActionButton } from '../common/button'
+import { EmptyState, LoadingState } from '../common/feedback-state'
+import { SurfaceCard } from '../common/card'
+import { TimeAgo } from '../common/time-ago'
+
+function percent(value: number | null | undefined): string {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return '--'
+  return `${Math.round(Math.max(0, Math.min(1, value)) * 100)}%`
+}
+
+function postIdList(ids: readonly string[]) {
+  if (ids.length === 0) return null
+  return html`
+    <div class="flex flex-wrap gap-1.5">
+      ${ids.map(id => html`
+        <span key=${id} class="rounded-[var(--r-1)] border border-[var(--color-border-default)] px-1.5 py-0.5 font-mono text-2xs text-[var(--color-fg-muted)]">${id}</span>
+      `)}
+    </div>
+  `
+}
+
+function CurationSnapshot({ snapshot }: { snapshot: BoardCurationSnapshot }) {
+  return html`
+    <div class="grid gap-3">
+      <${SurfaceCard} variant="compact">
+        <div class="grid gap-3 lg:grid-cols-[1fr_auto] lg:items-start">
+          <div class="min-w-0">
+            <div class="flex flex-wrap items-center gap-2 text-2xs text-[var(--color-fg-muted)]">
+              <span class="font-mono">${snapshot.id}</span>
+              <span>submitted by ${snapshot.submitted_by}</span>
+              ${snapshot.model ? html`<span>${snapshot.model}</span>` : null}
+            </div>
+            ${snapshot.summary ? html`
+              <p class="mt-2 text-sm leading-relaxed text-[var(--color-fg-primary)]">${snapshot.summary}</p>
+            ` : null}
+            ${snapshot.rationale ? html`
+              <p class="mt-2 text-xs leading-relaxed text-[var(--color-fg-muted)]">${snapshot.rationale}</p>
+            ` : null}
+          </div>
+          <div class="grid gap-1 text-right text-2xs text-[var(--color-fg-muted)]">
+            <span class="text-lg font-semibold tabular-nums text-[var(--color-fg-primary)]">${percent(snapshot.health_score)}</span>
+            <span>health</span>
+            <${TimeAgo} timestamp=${snapshot.generated_at} />
+          </div>
+        </div>
+      <//>
+
+      <div class="grid gap-3 lg:grid-cols-2">
+        <${SurfaceCard} variant="compact">
+          <h3 class="mb-2 text-xs font-semibold uppercase text-[var(--color-fg-muted)]">Recommended order</h3>
+          ${snapshot.ordering.length > 0 ? postIdList(snapshot.ordering) : html`<span class="text-xs text-[var(--color-fg-disabled)]">No ordering</span>`}
+        <//>
+        <${SurfaceCard} variant="compact">
+          <h3 class="mb-2 text-xs font-semibold uppercase text-[var(--color-fg-muted)]">Highlights</h3>
+          ${snapshot.highlights.length > 0 ? postIdList(snapshot.highlights) : html`<span class="text-xs text-[var(--color-fg-disabled)]">No highlights</span>`}
+        <//>
+      </div>
+
+      ${snapshot.tag_suggestions.length > 0 ? html`
+        <${SurfaceCard} variant="compact">
+          <h3 class="mb-2 text-xs font-semibold uppercase text-[var(--color-fg-muted)]">Tag suggestions</h3>
+          <div class="grid gap-2">
+            ${snapshot.tag_suggestions.map(item => html`
+              <div key=${item.post_id} class="grid gap-1 border-b border-[var(--color-border-subtle)] pb-2 last:border-b-0 last:pb-0">
+                <div class="font-mono text-2xs text-[var(--color-fg-muted)]">${item.post_id}</div>
+                <div class="flex flex-wrap gap-1">${item.tags.map(tag => html`<span key=${tag} class="rounded-[var(--r-1)] bg-[var(--color-bg-elevated)] px-1.5 py-0.5 text-2xs">${tag}</span>`)}</div>
+                ${item.rationale ? html`<p class="text-xs text-[var(--color-fg-muted)]">${item.rationale}</p>` : null}
+              </div>
+            `)}
+          </div>
+        <//>
+      ` : null}
+
+      ${snapshot.answer_matches.length > 0 ? html`
+        <${SurfaceCard} variant="compact">
+          <h3 class="mb-2 text-xs font-semibold uppercase text-[var(--color-fg-muted)]">Answer matches</h3>
+          <div class="grid gap-2">
+            ${snapshot.answer_matches.map(item => html`
+              <div key=${`${item.question_post_id}:${item.answer_post_id}`} class="grid gap-1 border-b border-[var(--color-border-subtle)] pb-2 last:border-b-0 last:pb-0">
+                <div class="flex flex-wrap items-center gap-2 font-mono text-2xs text-[var(--color-fg-muted)]">
+                  <span>${item.question_post_id}</span>
+                  <span aria-hidden="true">-></span>
+                  <span>${item.answer_post_id}</span>
+                  <span class="tabular-nums">${percent(item.score)}</span>
+                </div>
+                ${item.rationale ? html`<p class="text-xs text-[var(--color-fg-muted)]">${item.rationale}</p>` : null}
+              </div>
+            `)}
+          </div>
+        <//>
+      ` : null}
+
+      ${snapshot.health_components.length > 0 ? html`
+        <${SurfaceCard} variant="compact">
+          <h3 class="mb-2 text-xs font-semibold uppercase text-[var(--color-fg-muted)]">Health components</h3>
+          <div class="grid gap-2">
+            ${snapshot.health_components.map(item => html`
+              <div key=${item.name} class="grid gap-1 border-b border-[var(--color-border-subtle)] pb-2 last:border-b-0 last:pb-0">
+                <div class="flex items-center justify-between gap-2 text-xs">
+                  <span class="font-medium text-[var(--color-fg-secondary)]">${item.name}</span>
+                  <span class="font-mono tabular-nums text-[var(--color-fg-muted)]">${percent(item.score)} / weight ${item.weight}</span>
+                </div>
+                ${item.rationale ? html`<p class="text-xs text-[var(--color-fg-muted)]">${item.rationale}</p>` : null}
+              </div>
+            `)}
+          </div>
+        <//>
+      ` : null}
+    </div>
+  `
+}
+
+export function BoardCurationPanel() {
+  const [snapshot, setSnapshot] = useState<BoardCurationSnapshot | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  const load = useCallback(async () => {
+    setLoading(true)
+    setError(null)
+    try {
+      setSnapshot(await fetchBoardCuration())
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load board curation')
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    void load()
+  }, [load])
+
+  return html`
+    <section class="grid gap-4" aria-labelledby="board-curation-heading">
+      <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div class="min-w-0">
+          <div class="flex items-center gap-2 text-2xs uppercase text-[var(--color-fg-muted)]">
+            <${Sparkles} size=${13} aria-hidden="true" />
+            Board curation
+          </div>
+          <h2 id="board-curation-heading" class="mt-1 text-xl font-semibold text-[var(--color-fg-primary)]">AI curation snapshot</h2>
+        </div>
+        <div class="flex flex-wrap items-center gap-2">
+          <${ActionButton} variant="ghost" size="sm" onClick=${() => navigate('workspace', { section: 'board' })} ariaLabel="Back to board">
+            <span class="inline-flex items-center gap-1.5"><${ArrowLeft} size=${14} aria-hidden="true" />Board<//>
+          <//>
+          <${ActionButton} variant="ghost" size="sm" onClick=${() => { void load() }} disabled=${loading} ariaLabel="Refresh board curation">
+            <span class="inline-flex items-center gap-1.5"><${RefreshCw} size=${14} aria-hidden="true" />Refresh<//>
+          <//>
+        </div>
+      </div>
+
+      ${error ? html`
+        <div class="rounded-[var(--r-1)] border border-[var(--color-status-err)]/40 bg-[var(--color-status-err)]/10 px-3 py-2 text-xs text-[var(--color-status-err)]" role="alert">${error}</div>
+      ` : null}
+      ${loading
+        ? html`<${LoadingState}>Loading board curation...<//>`
+        : snapshot
+          ? html`<${CurationSnapshot} snapshot=${snapshot} />`
+          : html`<${EmptyState} message="No curation snapshot yet." compact />`}
+    </section>
+  `
+}

--- a/dashboard/src/components/board/board-surface.test.ts
+++ b/dashboard/src/components/board/board-surface.test.ts
@@ -267,6 +267,21 @@ describe('BoardSurface Component', () => {
     expect(screen.queryByText('+ 새 글 작성')).not.toBeInTheDocument()
   })
 
+  it('routes the curation focus to the board curation surface', async () => {
+    route.value = { params: { focus: 'curation' } } as any
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ snapshot: null }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    ))
+
+    render(h(BoardSurface, null))
+
+    expect(await screen.findByRole('heading', { name: 'AI curation snapshot' })).toBeInTheDocument()
+    expect(screen.queryByText('+ 새 글 작성')).not.toBeInTheDocument()
+  })
+
   it('renders compact board latency metrics when samples exist', () => {
     boardPosts.value = [
       makePost({

--- a/dashboard/src/components/board/board-surface.ts
+++ b/dashboard/src/components/board/board-surface.ts
@@ -546,11 +546,11 @@ function BoardSummary() {
         size="sm"
         class="${lastBoardRefreshAt.value ? '' : 'ml-auto'} !px-2"
         onClick=${() => navigate('workspace', { section: 'board', focus: 'curation' })}
-        ariaLabel="Open board curation"
+        ariaLabel="보드 큐레이션 열기"
       >
         <span class="inline-flex items-center gap-1">
           <${Sparkles} size=${12} aria-hidden="true" />
-          Curation
+          큐레이션
         </span>
       <//>
     </div>

--- a/dashboard/src/components/board/board-surface.ts
+++ b/dashboard/src/components/board/board-surface.ts
@@ -1,6 +1,6 @@
 import { html } from 'htm/preact'
 import { useEffect, useRef, useCallback, useMemo, useState } from 'preact/hooks'
-import { RefreshCw } from 'lucide-preact'
+import { RefreshCw, Sparkles } from 'lucide-preact'
 import { ActionButton } from '../common/button'
 import { Card } from '../common/card'
 import { TimeAgo } from '../common/time-ago'
@@ -18,6 +18,7 @@ import { navigate, navigateToPost, route } from '../../router'
 import { registerBoardHearthsRefresh } from '../../sse-store'
 import { boardLatencyMetrics, type BoardLatencyMetric } from '../../board-metrics'
 import { MessageRoomTimeline } from './message-room-timeline'
+import { BoardCurationPanel } from './board-curation-panel'
 import { MentionInbox } from './mention-inbox'
 import { PostDetail } from './post-detail'
 import { ReactionBar } from './reaction-bar'
@@ -540,6 +541,18 @@ function BoardSummary() {
       ${lastBoardRefreshAt.value ? html`
         <span class="ml-auto text-2xs">갱신 <${TimeAgo} timestamp=${lastBoardRefreshAt.value} /></span>
       ` : null}
+      <${ActionButton}
+        variant="ghost"
+        size="sm"
+        class="${lastBoardRefreshAt.value ? '' : 'ml-auto'} !px-2"
+        onClick=${() => navigate('workspace', { section: 'board', focus: 'curation' })}
+        ariaLabel="Open board curation"
+      >
+        <span class="inline-flex items-center gap-1">
+          <${Sparkles} size=${12} aria-hidden="true" />
+          Curation
+        </span>
+      <//>
     </div>
   `
 }
@@ -776,6 +789,15 @@ export function BoardSurface() {
       <div>
         <${BoardSummary} />
         <${StateBlockMessages} />
+      </div>
+    `
+  }
+
+  if (focus === 'curation') {
+    return html`
+      <div>
+        <${BoardSummary} />
+        <${BoardCurationPanel} />
       </div>
     `
   }


### PR DESCRIPTION
## Summary
- add a read-only board curation panel backed by the existing /api/v1/board/curation endpoint
- add a Board summary action and focus route for workspace?section=board&focus=curation
- cover snapshot rendering, empty state, and BoardSurface focus routing

## Why it matters
The plan files still classify AI curation as missing, but current main already has the curation store, tool path, type normalization, and endpoint. The missing part was operator visibility in the dashboard. This PR exposes the existing runtime truth without expanding write permissions or adding a new model path.

## Verification
- pnpm exec vitest run --config vitest.config.ts src/components/board/board-curation-panel.test.ts src/components/board/board-surface.test.ts --no-file-parallelism --maxWorkers=1
- pnpm exec tsc --noEmit --pretty
- pnpm exec eslint src/components/board/board-curation-panel.ts src/components/board/board-curation-panel.test.ts src/components/board/board-surface.ts src/components/board/board-surface.test.ts
- git diff --cached --check