### PR TITLE
fix(keeper): surface unloaded git policy in prompt

### DIFF
--- a/lib/dashboard/dashboard_http_keeper.ml
+++ b/lib/dashboard/dashboard_http_keeper.ml
@@ -1595,14 +1595,25 @@ let keeper_config_json (config : Coord.config) (name : string)
       let runtime_trust =
         Keeper_runtime_trust_snapshot.snapshot_json ~config ~meta:m
       in
+      let git_clone_allowed_orgs =
+        Keeper_tool_policy.git_clone_allowed_orgs ()
+      in
+      let git_clone_denied_repos =
+        Keeper_tool_policy.git_clone_denied_repos ()
+      in
+      let git_clone_policy_loaded =
+        Option.is_some git_clone_allowed_orgs
+        && Option.is_some git_clone_denied_repos
+      in
       let effective_system_prompt =
         Keeper_prompt.build_keeper_system_prompt
           ~goal:m.goal ~short_goal:m.short_goal ~mid_goal:m.mid_goal
           ~long_goal:m.long_goal ~will:m.will
           ~needs:m.needs ~desires:m.desires ~instructions:m.instructions
           ~persona_extended ~keeper_name:m.name
-          ~allowed_orgs:(Option.value (Keeper_tool_policy.git_clone_allowed_orgs ()) ~default:[])
-          ~denied_repos:(Option.value (Keeper_tool_policy.git_clone_denied_repos ()) ~default:[])
+          ~allowed_orgs:(Option.value git_clone_allowed_orgs ~default:[])
+          ~denied_repos:(Option.value git_clone_denied_repos ~default:[])
+          ~git_clone_policy_loaded
           ~active_goals
           ()
       in

--- a/lib/keeper/keeper_exec_context.mli
+++ b/lib/keeper/keeper_exec_context.mli
@@ -350,6 +350,7 @@ val build_keeper_system_prompt :
   ?keeper_name:string ->
   ?allowed_orgs:string list ->
   ?denied_repos:string list ->
+  ?git_clone_policy_loaded:bool ->
   ?active_goals:(string * string * string) list ->
   unit ->
   string

--- a/lib/keeper/keeper_execution.mli
+++ b/lib/keeper/keeper_execution.mli
@@ -91,6 +91,7 @@ val build_keeper_system_prompt :
   ?keeper_name:string ->
   ?allowed_orgs:string list ->
   ?denied_repos:string list ->
+  ?git_clone_policy_loaded:bool ->
   ?active_goals:(string * string * string) list ->
   unit ->
   string
@@ -108,4 +109,3 @@ val user_visible_reply_text : ?fallback:string -> string -> string
 
 (** Check if text appears fragmentary (incomplete sentence fragments). *)
 val looks_fragmentary_history_text : string -> bool
-

--- a/lib/keeper/keeper_execution_receipt.ml
+++ b/lib/keeper/keeper_execution_receipt.ml
@@ -721,7 +721,6 @@ let stale_terminal_reason_code = function
   | Some (Keeper_registry.Turn_consecutive_failures _) -> "turn_failures"
   | Some (Keeper_registry.Ambiguous_partial_commit _) ->
       "ambiguous_partial_commit"
-  | Some (Keeper_registry.Stale_fleet_batch _) -> "stale_fleet_batch"
   | Some Keeper_registry.Fiber_unresolved -> "fiber_unresolved"
   | Some (Keeper_registry.Exception _) -> "exception"
   | None -> "stale_turn_timeout"

--- a/lib/keeper/keeper_prompt.ml
+++ b/lib/keeper/keeper_prompt.ml
@@ -70,10 +70,14 @@ let ensure_critical_prompt_anchors prompt =
 
     Replaces the earlier [format_list_for_prompt] which collapsed both
     semantics to "(none)". *)
-let format_allowlist_for_prompt (items : string list) : string =
-  match items with
-  | [] -> "(any — allowlist gate is OFF, the operator's gh credential surface is the only repo boundary)"
-  | xs -> String.concat ", " xs
+let format_allowlist_for_prompt ?(policy_loaded = true) (items : string list) :
+    string =
+  if not policy_loaded then
+    "(unavailable — tool_policy.toml is not loaded; git/gh operations fail closed until policy init completes)"
+  else
+    match items with
+    | [] -> "(any — allowlist gate is OFF, the operator's gh credential surface is the only repo boundary)"
+    | xs -> String.concat ", " xs
 
 (** Format a *denylist* for prompt rendering.  An empty denylist means
     no repo is explicitly blocked, so "(none)" reads correctly here. *)
@@ -89,10 +93,13 @@ let format_denylist_for_prompt (items : string list) : string =
     to the raw template text if rendering fails so that prompt wiring
     bugs do not brick keepers — but the fallback is now logged loudly so
     the silent-degradation case documented in #9893 becomes observable. *)
-let render_world_prompt ~allowed_orgs ~denied_repos : string =
+let render_world_prompt ~git_clone_policy_loaded ~allowed_orgs ~denied_repos :
+    string =
   let vars =
     [
-      ("allowed_orgs", format_allowlist_for_prompt allowed_orgs);
+      ( "allowed_orgs",
+        format_allowlist_for_prompt ~policy_loaded:git_clone_policy_loaded
+          allowed_orgs );
       ("denied_repos", format_denylist_for_prompt denied_repos);
     ]
   in
@@ -119,6 +126,7 @@ let build_keeper_system_prompt
     ~goal ~short_goal ~mid_goal ~long_goal ~will ~needs ~desires
     ~instructions ?(persona_extended = "") ?(keeper_name = "")
     ?(allowed_orgs = []) ?(denied_repos = [])
+    ?(git_clone_policy_loaded = true)
     ?(active_goals = []) () =
   let goal = normalize_goal_horizon_text goal in
   let short_goal, mid_goal, long_goal =
@@ -222,7 +230,8 @@ let build_keeper_system_prompt
        \n\
        <world>\n";
       substitute_keeper_name
-        (render_world_prompt ~allowed_orgs ~denied_repos);
+        (render_world_prompt ~git_clone_policy_loaded ~allowed_orgs
+           ~denied_repos);
       "\n</world>\n\
        \n\
        <capabilities>\n";

--- a/lib/keeper/keeper_prompt.mli
+++ b/lib/keeper/keeper_prompt.mli
@@ -37,7 +37,7 @@ val build_keeper_system_prompt :
     the keeper sees the live git_clone allow/deny lists without having
     to query [tool_policy.toml].  Callers should pass the values from
     [Keeper_tool_policy.git_clone_allowed_orgs] /
-    [git_clone_denied_repos].
+    [Keeper_tool_policy.git_clone_denied_repos].
 
     [git_clone_policy_loaded=false] means the caller could not read
     [tool_policy.toml] yet; the prompt should say git/gh operations fail

--- a/lib/keeper/keeper_prompt.mli
+++ b/lib/keeper/keeper_prompt.mli
@@ -29,6 +29,7 @@ val build_keeper_system_prompt :
   ?keeper_name:string ->
   ?allowed_orgs:string list ->
   ?denied_repos:string list ->
+  ?git_clone_policy_loaded:bool ->
   ?active_goals:(string * string * string) list ->
   unit ->
   string
@@ -38,7 +39,12 @@ val build_keeper_system_prompt :
     [Keeper_tool_policy.git_clone_allowed_orgs] /
     [git_clone_denied_repos].
 
-    Empty-list semantics differ between the two:
+    [git_clone_policy_loaded=false] means the caller could not read
+    [tool_policy.toml] yet; the prompt should say git/gh operations fail
+    closed instead of treating an unavailable allowlist as an explicitly empty
+    one.
+
+    Empty-list semantics differ between the two once policy is loaded:
     - Empty [allowed_orgs] = "gate OFF, any account-accessible repo is
       permitted" (matches [validate_gh_command]'s skip-check behaviour).
     - Empty [denied_repos] = "no repos blocked" (renders as "(none)").

--- a/lib/keeper/keeper_run_context.ml
+++ b/lib/keeper/keeper_run_context.ml
@@ -122,6 +122,16 @@ let prepare_run_context
          | None -> None)
       meta.active_goal_ids
   in
+  let git_clone_allowed_orgs =
+    Keeper_tool_policy.git_clone_allowed_orgs ()
+  in
+  let git_clone_denied_repos =
+    Keeper_tool_policy.git_clone_denied_repos ()
+  in
+  let git_clone_policy_loaded =
+    Option.is_some git_clone_allowed_orgs
+    && Option.is_some git_clone_denied_repos
+  in
   let base_system_prompt =
     Keeper_prompt.build_keeper_system_prompt
       ~goal:meta.goal
@@ -134,8 +144,9 @@ let prepare_run_context
       ~instructions:meta.instructions
       ~persona_extended
       ~keeper_name:meta.name
-      ~allowed_orgs:(Option.value (Keeper_tool_policy.git_clone_allowed_orgs ()) ~default:[])
-      ~denied_repos:(Option.value (Keeper_tool_policy.git_clone_denied_repos ()) ~default:[])
+      ~allowed_orgs:(Option.value git_clone_allowed_orgs ~default:[])
+      ~denied_repos:(Option.value git_clone_denied_repos ~default:[])
+      ~git_clone_policy_loaded
       ~active_goals
       ()
   in

--- a/lib/keeper/keeper_turn_up_create.ml
+++ b/lib/keeper/keeper_turn_up_create.ml
@@ -413,6 +413,16 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
                | None -> None)
             active_goal_ids
         in
+        let git_clone_allowed_orgs =
+          Keeper_tool_policy.git_clone_allowed_orgs ()
+        in
+        let git_clone_denied_repos =
+          Keeper_tool_policy.git_clone_denied_repos ()
+        in
+        let git_clone_policy_loaded =
+          Option.is_some git_clone_allowed_orgs
+          && Option.is_some git_clone_denied_repos
+        in
         let system_prompt =
           build_keeper_system_prompt
             ~goal
@@ -425,8 +435,9 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
             ~instructions
             ~persona_extended
             ~keeper_name:p.name
-            ~allowed_orgs:(Option.value (Keeper_tool_policy.git_clone_allowed_orgs ()) ~default:[])
-            ~denied_repos:(Option.value (Keeper_tool_policy.git_clone_denied_repos ()) ~default:[])
+            ~allowed_orgs:(Option.value git_clone_allowed_orgs ~default:[])
+            ~denied_repos:(Option.value git_clone_denied_repos ~default:[])
+            ~git_clone_policy_loaded
             ~active_goals
             ()
       in

--- a/test/test_keeper_prompt_metrics.ml
+++ b/test/test_keeper_prompt_metrics.ml
@@ -283,6 +283,29 @@ let test_prompt_mentions_runtime_operator_approval_for_risky_actions () =
   check bool "does not claim no permission is needed" false
     (has_in prompt "You do not need permission to act")
 
+let test_prompt_marks_git_clone_policy_unavailable () =
+  let prompt =
+    KP.build_keeper_system_prompt
+      ~goal:"Keep keeper policy truth explicit"
+      ~short_goal:"avoid silent-empty git policy"
+      ~mid_goal:"ship coherent keeper guidance"
+      ~long_goal:"prevent policy-load stalls"
+      ~will:"maintain coherent identity"
+      ~needs:"factual grounding"
+      ~desires:"safe execution"
+      ~instructions:""
+      ~allowed_orgs:[]
+      ~denied_repos:[]
+      ~git_clone_policy_loaded:false
+      ()
+  in
+  check bool "marks policy unavailable" true
+    (has_in prompt "tool_policy.toml is not loaded");
+  check bool "names fail-closed behavior" true
+    (has_in prompt "git/gh operations fail closed");
+  check bool "does not render unloaded policy as gate off" false
+    (has_in prompt "allowlist gate is OFF")
+
 let test_token_report () =
   (* Emit a structured report for A/B comparison *)
   let tp = build_separated () in
@@ -413,6 +436,8 @@ let () =
             test_unified_state_instruction_respects_turn_level_guard;
           test_case "prompt mentions runtime operator approval for risky actions" `Quick
             test_prompt_mentions_runtime_operator_approval_for_risky_actions;
+          test_case "prompt marks git clone policy unavailable" `Quick
+            test_prompt_marks_git_clone_policy_unavailable;
         ] );
       ( "metrics_report",
         [


### PR DESCRIPTION
## Summary
- stop treating an unloaded git_clone tool policy as an explicitly empty allowlist in keeper prompts
- pass policy-loaded state through keeper creation, run context, and dashboard prompt rendering
- add a prompt regression test for fail-closed policy guidance
- remove a duplicate Stale_fleet_batch receipt match that blocks focused builds on current main

## Verification
- git diff --check --cached
- DUNE_BUILD_DIR=/private/tmp/masc-policy-prompt-build-0506 DUNE_CACHE=disabled dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-keeper-policy-prompt-fail-closed-0506 --display=short test/test_keeper_prompt_metrics.exe
- /private/tmp/masc-policy-prompt-build-0506/default/test/test_keeper_prompt_metrics.exe