### PR TITLE
feat(board): expose karma ledger api

### DIFF
--- a/dashboard/src/api/board.test.ts
+++ b/dashboard/src/api/board.test.ts
@@ -6,8 +6,10 @@ import {
   fetchBoard,
   fetchBoardCuration,
   fetchBoardHearths,
+  fetchBoardKarmaLedger,
   fetchBoardPost,
   fetchBoardReactions,
+  normalizeBoardKarmaLedger,
   sanitizeBoardTitle,
   toggleReaction,
   voteComment,
@@ -781,6 +783,79 @@ describe('SubBoard API helpers', () => {
       description: 'Operations',
       access: 'members_only',
       members: ['agent-a', 'agent-b'],
+    })
+  })
+})
+
+describe('fetchBoardKarmaLedger', () => {
+  it('normalizes ledger events, totals, and scoring rule', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({
+        events: [
+          {
+            recipient: 'keeper-a',
+            voter: 'operator',
+            target_kind: 'post',
+            target_id: 'post-1',
+            delta: 1,
+            ts: 1_748_779_200,
+            ts_iso: '2025-06-01T12:00:00Z',
+          },
+          { recipient: '', voter: 'ignored', target_kind: 'post', target_id: 'post-x' },
+        ],
+        count: 2,
+        scoring_rule: 'up=+1,down=0',
+        totals: [
+          { agent: 'keeper-a', karma: 3 },
+          { agent: '', karma: 9 },
+        ],
+      }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await fetchBoardKarmaLedger({ agent: ' keeper-a ', limit: 25.9 })
+
+    expect(result).toEqual({
+      events: [
+        {
+          recipient: 'keeper-a',
+          voter: 'operator',
+          target_kind: 'post',
+          target_id: 'post-1',
+          delta: 1,
+          ts: 1_748_779_200,
+          ts_iso: '2025-06-01T12:00:00Z',
+        },
+      ],
+      count: 2,
+      scoring_rule: 'up=+1,down=0',
+      totals: [{ agent: 'keeper-a', karma: 3 }],
+    })
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/v1/board/karma/ledger?agent=keeper-a&limit=25',
+      expect.any(Object),
+    )
+  })
+
+  it('falls back to event length when the ledger count is absent', () => {
+    expect(normalizeBoardKarmaLedger({
+      events: [
+        {
+          recipient: 'keeper-a',
+          voter: 'operator',
+          target_kind: 'comment',
+          target_id: 'comment-1',
+          delta: 1,
+          ts: 1_748_779_200,
+        },
+      ],
+    })).toMatchObject({
+      count: 1,
+      events: [{ ts_iso: '2025-06-01T12:00:00.000Z' }],
+      totals: [],
     })
   })
 })

--- a/dashboard/src/api/board.ts
+++ b/dashboard/src/api/board.ts
@@ -5,7 +5,7 @@ import type {
   BoardActorIdentity, BoardPost, BoardComment, BoardReactionSummary,
   BoardReactionTargetType, BoardReactionToggleResult, BoardSortMode,
   BoardVoteDirection,
-  BoardCurationSnapshot,
+  BoardCurationSnapshot, BoardKarmaLedger, BoardKarmaLedgerEvent, BoardKarmaTotal,
   GovernanceContextRef,
   GovernanceDecisionItem, GovernanceExecutedRoute,
   GovernanceGuardrailState, GovernanceJudgeSummary, GovernanceJudgment,
@@ -544,6 +544,53 @@ function normalizeBoardCurationHealthComponents(raw: unknown): BoardCurationSnap
   })
 }
 
+function normalizeBoardKarmaLedgerEvent(raw: unknown): BoardKarmaLedgerEvent | null {
+  if (!isRecord(raw)) return null
+  const recipient = asString(raw.recipient, '').trim()
+  const voter = asString(raw.voter, '').trim()
+  const targetKind = asString(raw.target_kind, '').trim()
+  const targetId = asString(raw.target_id, '').trim()
+  const tsIso = asNullableIsoTimestamp(raw.ts_iso ?? raw.ts)
+  if (!recipient || !voter || !targetKind || !targetId || !tsIso) return null
+  return {
+    recipient,
+    voter,
+    target_kind: targetKind,
+    target_id: targetId,
+    delta: asNumber(raw.delta, 0),
+    ts: asNumber(raw.ts, 0),
+    ts_iso: tsIso,
+  }
+}
+
+function normalizeBoardKarmaTotal(raw: unknown): BoardKarmaTotal | null {
+  if (!isRecord(raw)) return null
+  const agent = asString(raw.agent, '').trim()
+  if (!agent) return null
+  return {
+    agent,
+    karma: asNumber(raw.karma, 0),
+  }
+}
+
+export function normalizeBoardKarmaLedger(raw: unknown): BoardKarmaLedger {
+  if (!isRecord(raw)) {
+    return { events: [], count: 0, scoring_rule: '', totals: [] }
+  }
+  const events = Array.isArray(raw.events)
+    ? raw.events.map(normalizeBoardKarmaLedgerEvent).filter((row): row is BoardKarmaLedgerEvent => row !== null)
+    : []
+  const totals = Array.isArray(raw.totals)
+    ? raw.totals.map(normalizeBoardKarmaTotal).filter((row): row is BoardKarmaTotal => row !== null)
+    : []
+  return {
+    events,
+    count: asInt(raw.count) ?? events.length,
+    scoring_rule: asString(raw.scoring_rule, ''),
+    totals,
+  }
+}
+
 function normalizeBoardReactionSummary(raw: unknown): BoardReactionSummary | null {
   if (!isRecord(raw)) return null
   const emoji = asString(raw.emoji, '').trim()
@@ -620,6 +667,20 @@ export async function fetchBoardCuration(): Promise<BoardCurationSnapshot | null
   return withRetries('fetchBoardCuration', async () => {
     const raw = await get<{ snapshot?: unknown }>('/api/v1/board/curation')
     return raw.snapshot != null ? normalizeBoardCurationSnapshot(raw.snapshot) : null
+  })
+}
+
+export async function fetchBoardKarmaLedger(options: { agent?: string; limit?: number } = {}): Promise<BoardKarmaLedger> {
+  return withRetries('fetchBoardKarmaLedger', async () => {
+    const params = new URLSearchParams()
+    const agent = options.agent?.trim()
+    if (agent) params.set('agent', agent)
+    if (typeof options.limit === 'number' && Number.isFinite(options.limit)) {
+      params.set('limit', String(Math.trunc(options.limit)))
+    }
+    const qs = params.toString()
+    const raw = await get<unknown>(`/api/v1/board/karma/ledger${qs ? `?${qs}` : ''}`)
+    return normalizeBoardKarmaLedger(raw)
   })
 }
 

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -227,6 +227,28 @@ export interface BoardCurationHealthComponent {
   rationale: string
 }
 
+export interface BoardKarmaLedgerEvent {
+  recipient: string
+  voter: string
+  target_kind: 'post' | 'comment' | string
+  target_id: string
+  delta: number
+  ts: number
+  ts_iso: string
+}
+
+export interface BoardKarmaTotal {
+  agent: string
+  karma: number
+}
+
+export interface BoardKarmaLedger {
+  events: BoardKarmaLedgerEvent[]
+  count: number
+  scoring_rule: string
+  totals: BoardKarmaTotal[]
+}
+
 // --- SubBoard ---
 
 export type SubBoardAccess = 'open' | 'members_only' | 'owner_only'

--- a/lib/server/server_routes_http_routes_activity.ml
+++ b/lib/server/server_routes_http_routes_activity.ml
@@ -497,6 +497,31 @@ let add_routes ~sw ~clock router =
          Http.Response.json (Yojson.Safe.to_string json) reqd
        ) request reqd)
 
+  |> Http.Router.get "/api/v1/board/karma/ledger" (fun request reqd ->
+       with_public_read (fun _state req reqd ->
+         let agent = query_param req "agent" in
+         let limit =
+           int_query_param req "limit" ~default:500
+           |> clamp ~min_v:1 ~max_v:5000
+         in
+         let events = Board_dispatch.get_karma_ledger ?agent ~limit () in
+         let totals =
+           Board_dispatch.get_all_karma ()
+           |> List.sort (fun (_, a) (_, b) -> compare b a)
+         in
+         let json =
+           `Assoc [
+             ("events", `List (List.map Board.karma_event_to_yojson events));
+             ("count", `Int (List.length events));
+             ("scoring_rule", `String "up=+1,down=0");
+             ("totals", `List (List.map (fun (agent_name, k) ->
+               `Assoc [("agent", `String agent_name); ("karma", `Int k)])
+               totals));
+           ]
+         in
+         Http.Response.json (Yojson.Safe.to_string json) reqd
+       ) request reqd)
+
   (* Mention Inbox API *)
   |> Http.Router.prefix_get "/api/v1/mentions/" (fun request reqd ->
        with_public_read (fun state _req reqd ->


### PR DESCRIPTION
## Summary
- expose the board karma ledger on the normal HTTP activity router at /api/v1/board/karma/ledger
- add dashboard BoardKarmaLedger types plus a fetch/normalization helper for events and totals
- cover query construction, event filtering, count fallback, scoring rule, and totals normalization

## Why it matters
implementation_status.md still lists Karma Ledger as a Phase 2 gap. Current main already has the core ledger projection and H2 gateway route, but the dashboard HTTP path and TS client contract were missing. This PR makes the existing ledger reachable from the dashboard API surface without changing scoring semantics.

## Verification
- pnpm exec vitest run --config vitest.config.ts src/api/board.test.ts --no-file-parallelism --maxWorkers=1
- pnpm exec tsc --noEmit --pretty
- pnpm exec eslint src/api/board.ts src/api/board.test.ts src/types/core.ts (0 errors; files ignored by current eslint config)
- git diff --check
- scripts/dune-local.sh build bin/main_eio.exe attempted but blocked by host opam/dune lock contention; waiting command was stopped after confirming another worktree held /tmp/me-opam-switch.lock