### PR TITLE
fix(main): remove duplicate stale fleet receipt arm

### DIFF
--- a/lib/keeper/keeper_execution_receipt.ml
+++ b/lib/keeper/keeper_execution_receipt.ml
@@ -721,7 +721,6 @@ let stale_terminal_reason_code = function
   | Some (Keeper_registry.Turn_consecutive_failures _) -> "turn_failures"
   | Some (Keeper_registry.Ambiguous_partial_commit _) ->
       "ambiguous_partial_commit"
-  | Some (Keeper_registry.Stale_fleet_batch _) -> "stale_fleet_batch"
   | Some Keeper_registry.Fiber_unresolved -> "fiber_unresolved"
   | Some (Keeper_registry.Exception _) -> "exception"
   | None -> "stale_turn_timeout"


### PR DESCRIPTION
## Summary
- remove the duplicate `Stale_fleet_batch` match arm reintroduced in `stale_terminal_reason_code`
- restore focused OCaml builds that fail under warning 11 as error

## Why this matters
Current `origin/main` fails focused Dune validation because the duplicate match arm is unreachable. This keeps unrelated PRs, including #13793, from proving their own diffs cleanly.

Closes #13827

## Verification
- `git diff --check`
- `env MASC_OPAM_LOCK=0 scripts/dune-local.sh build test/test_dune_local_script.exe test/test_ci_hardening_source.exe`
- `./_build/default/test/test_dune_local_script.exe` (20/20)
- `./_build/default/test/test_ci_hardening_source.exe` (53/53)