### PR TITLE
fix(oas): preserve missing response usage

### DIFF
--- a/lib/dashboard/dashboard_oas_bridge.ml
+++ b/lib/dashboard/dashboard_oas_bridge.ml
@@ -14,11 +14,12 @@ type sample = {
   ttfb_ms : float;
   total_duration_ms : float;
   serialization_ms : float;
-  input_tokens : int;
-  output_tokens : int;
-  throughput_tokens_per_s : float;
-  cost_usd : float;
-  cache_hit : bool;
+  usage_reported : bool;
+  input_tokens : int option;
+  output_tokens : int option;
+  throughput_tokens_per_s : float option;
+  cost_usd : float option;
+  cache_hit : bool option;
   status : status;
   retry_count : int;
 }
@@ -64,6 +65,10 @@ let status_to_yojson = function
         ]
   | Timeout -> `Assoc [ ("kind", `String "timeout") ]
 
+let int_opt_to_yojson = function Some value -> `Int value | None -> `Null
+let float_opt_to_yojson = function Some value -> `Float value | None -> `Null
+let bool_opt_to_yojson = function Some value -> `Bool value | None -> `Null
+
 let sample_to_yojson (s : sample) =
   `Assoc
     [
@@ -72,11 +77,13 @@ let sample_to_yojson (s : sample) =
       ("ttfb_ms", `Float s.ttfb_ms);
       ("total_duration_ms", `Float s.total_duration_ms);
       ("serialization_ms", `Float s.serialization_ms);
-      ("input_tokens", `Int s.input_tokens);
-      ("output_tokens", `Int s.output_tokens);
-      ("throughput_tokens_per_s", `Float s.throughput_tokens_per_s);
-      ("cost_usd", `Float s.cost_usd);
-      ("cache_hit", `Bool s.cache_hit);
+      ("usage_reported", `Bool s.usage_reported);
+      ("input_tokens", int_opt_to_yojson s.input_tokens);
+      ("output_tokens", int_opt_to_yojson s.output_tokens);
+      ( "throughput_tokens_per_s",
+        float_opt_to_yojson s.throughput_tokens_per_s );
+      ("cost_usd", float_opt_to_yojson s.cost_usd);
+      ("cache_hit", bool_opt_to_yojson s.cache_hit);
       ("status", status_to_yojson s.status);
       ("retry_count", `Int s.retry_count);
     ]
@@ -154,29 +161,43 @@ let ttfb_from_response (response : Agent_sdk.Types.api_response) =
       ms
   | _ -> 0.0
 
-let cache_hit_from_response ~(usage : Agent_sdk.Types.api_usage)
+let cache_hit_from_response ~(usage : Agent_sdk.Types.api_usage option)
     (response : Agent_sdk.Types.api_response) =
-  usage.cache_read_input_tokens > 0
-  ||
-  match response.telemetry with
-  | Some { timings = Some { cache_n = Some n; _ }; _ } -> n > 0
-  | _ -> false
+  let usage_cache_hit =
+    Option.map
+      (fun (usage : Agent_sdk.Types.api_usage) ->
+        usage.cache_read_input_tokens > 0)
+      usage
+  in
+  let telemetry_cache_hit =
+    match response.telemetry with
+    | Some { timings = Some { cache_n = Some n; _ }; _ } -> Some (n > 0)
+    | _ -> None
+  in
+  match usage_cache_hit, telemetry_cache_hit with
+  | Some true, _ | _, Some true -> Some true
+  | Some false, _ | _, Some false -> Some false
+  | None, None -> None
 
-let throughput_from_response ~(usage : Agent_sdk.Types.api_usage) ~ttfb_ms
+let throughput_from_response ~(usage : Agent_sdk.Types.api_usage option)
+    ~ttfb_ms
     ~total_duration_ms (response : Agent_sdk.Types.api_response) =
   match response.telemetry with
   | Some { timings = Some { predicted_per_second = Some v; _ }; _ }
-    when v > 0.0 -> v
+    when v > 0.0 -> Some v
   | _ ->
-      if usage.output_tokens <= 0 then 0.0
-      else
-        let decode_ms = Float.max 1.0 (total_duration_ms -. ttfb_ms) in
-        Float.of_int usage.output_tokens /. (decode_ms /. 1000.0)
+      Option.map
+        (fun (usage : Agent_sdk.Types.api_usage) ->
+          if usage.output_tokens <= 0 then 0.0
+          else
+            let decode_ms = Float.max 1.0 (total_duration_ms -. ttfb_ms) in
+            Float.of_int usage.output_tokens /. (decode_ms /. 1000.0))
+        usage
 
 let sample_of_response ~provider_id ~model_id ?total_duration_ms
     ?(serialization_ms = 0.0) ?(retry_count = 0) ~status
     (response : Agent_sdk.Types.api_response) =
-  let usage = Oas_response.usage_or_zero response in
+  let usage = Oas_response.usage response in
   let total_duration_ms =
     duration_from_response ?total_duration_ms response
   in
@@ -187,11 +208,20 @@ let sample_of_response ~provider_id ~model_id ?total_duration_ms
     ttfb_ms;
     total_duration_ms;
     serialization_ms;
-    input_tokens = usage.input_tokens;
-    output_tokens = usage.output_tokens;
+    usage_reported = Option.is_some usage;
+    input_tokens =
+      Option.map
+        (fun (usage : Agent_sdk.Types.api_usage) -> usage.input_tokens)
+        usage;
+    output_tokens =
+      Option.map
+        (fun (usage : Agent_sdk.Types.api_usage) -> usage.output_tokens)
+        usage;
     throughput_tokens_per_s =
       throughput_from_response ~usage ~ttfb_ms ~total_duration_ms response;
-    cost_usd = Option.value ~default:0.0 usage.cost_usd;
+    cost_usd =
+      Option.bind usage (fun (usage : Agent_sdk.Types.api_usage) ->
+          usage.cost_usd);
     cache_hit = cache_hit_from_response ~usage response;
     status;
     retry_count;
@@ -345,13 +375,17 @@ let summary ?provider ?limit () =
         List.map (fun (s, _) -> s.total_duration_ms) xs |> Array.of_list
       in
       Array.sort Float.compare durs;
+      let cache_values = List.filter_map (fun (s, _) -> s.cache_hit) xs in
       let cache_hits =
         List.fold_left
-          (fun acc (s, _) -> if s.cache_hit then acc + 1 else acc)
-          0 xs
+          (fun acc cache_hit -> if cache_hit then acc + 1 else acc)
+          0 cache_values
       in
       let total_cost =
-        List.fold_left (fun acc (s, _) -> acc +. s.cost_usd) 0.0 xs
+        List.fold_left
+          (fun acc (s, _) ->
+            match s.cost_usd with Some cost -> acc +. cost | None -> acc)
+          0.0 xs
       in
       let errors =
         List.fold_left
@@ -374,7 +408,11 @@ let summary ?provider ?limit () =
         total_duration_p50_ms = percentile durs 0.50;
         total_duration_p95_ms = percentile durs 0.95;
         total_duration_p99_ms = percentile durs 0.99;
-        cache_hit_ratio = float_of_int cache_hits /. float_of_int n;
+        cache_hit_ratio =
+          (match cache_values with
+          | [] -> 0.0
+          | values ->
+              float_of_int cache_hits /. float_of_int (List.length values));
         total_cost_usd = total_cost;
         error_ratio = float_of_int errors /. float_of_int n;
         cancelled_count = cancels;

--- a/lib/dashboard/dashboard_oas_bridge.mli
+++ b/lib/dashboard/dashboard_oas_bridge.mli
@@ -3,8 +3,8 @@
     Layer 4 collector for {b I1 Telemetry pipeline} (#11924, Phase 1, Track T1)
     of the [Meta] MASC-MCP × OAS root improvement plan (#11923).
 
-    Twelve signals are recorded per LLM call so the dashboard can derive
-    TTFB distribution, throughput, cost, cache-hit ratio, and the bimodal
+    Per-call signals are recorded so the dashboard can derive TTFB
+    distribution, throughput, cost, cache-hit ratio, and the bimodal
     hang signature (100–200s normal vs 2,000–3,000s zombie tail). The
     collector is intentionally additive — existing metric paths remain
     untouched until I7 (string elimination) and I2 (provider_error variant)
@@ -35,7 +35,7 @@ type status =
   | Cancelled of { reason : string }
   | Timeout
 
-(** Twelve-signal telemetry sample for a single OAS LLM call.
+(** Telemetry sample for a single OAS LLM call.
 
     Naming follows OpenTelemetry GenAI semantic convention [gen_ai.*]. The
     bridge does not commit to that namespace at the OCaml type level — the
@@ -51,14 +51,18 @@ type sample = {
   serialization_ms : float;
       (** Request serialize + response parse overhead in milliseconds.
           Captures the adapter cost the docx flagged as currently invisible. *)
-  input_tokens : int;  (** Prompt tokens consumed. *)
-  output_tokens : int;  (** Completion tokens produced. *)
-  throughput_tokens_per_s : float;
+  usage_reported : bool;
+      (** [true] when OAS supplied provider usage. Missing usage remains
+          distinct from real zero-token usage. *)
+  input_tokens : int option;  (** Prompt tokens consumed, when reported. *)
+  output_tokens : int option;
+      (** Completion tokens produced, when reported. *)
+  throughput_tokens_per_s : float option;
       (** [output_tokens / max(total_duration_ms - ttfb_ms, 1.0) * 1000.0]. *)
-  cost_usd : float;
-      (** Dollar cost; [0.0] when unknown — CLI providers (codex_cli,
-          gemini_cli, kimi_cli) intentionally strip usage metadata. *)
-  cache_hit : bool;
+  cost_usd : float option;
+      (** Dollar cost, when reported — CLI providers (codex_cli, gemini_cli,
+          kimi_cli) intentionally strip usage metadata. *)
+  cache_hit : bool option;
       (** Prefix or implicit cache hit detected by the provider. *)
   status : status;  (** Outcome of the call. *)
   retry_count : int;
@@ -92,8 +96,9 @@ val sample_of_response :
     - [serialization_ms] carries request-serialize + response-parse overhead
       measured at the adapter boundary; defaults to [0.0] when not provided.
 
-    Missing OAS usage or telemetry is represented as zero-valued additive
-    data rather than dropping the sample, so coverage gaps stay visible. *)
+    Missing OAS usage is represented with [usage_reported = false] and
+    nullable usage-derived fields rather than synthetic zeroes. Missing
+    telemetry remains nullable where the signal cannot be derived. *)
 
 val record_response :
   provider_id:string ->

--- a/lib/keeper/keeper_execution_receipt.ml
+++ b/lib/keeper/keeper_execution_receipt.ml
@@ -721,7 +721,6 @@ let stale_terminal_reason_code = function
   | Some (Keeper_registry.Turn_consecutive_failures _) -> "turn_failures"
   | Some (Keeper_registry.Ambiguous_partial_commit _) ->
       "ambiguous_partial_commit"
-  | Some (Keeper_registry.Stale_fleet_batch _) -> "stale_fleet_batch"
   | Some Keeper_registry.Fiber_unresolved -> "fiber_unresolved"
   | Some (Keeper_registry.Exception _) -> "exception"
   | None -> "stale_turn_timeout"

--- a/lib/oas_response.ml
+++ b/lib/oas_response.ml
@@ -11,14 +11,4 @@ let text_of_response (response : api_response) =
 let model_used (response : api_response) =
   response.model
 
-let usage_or_zero (response : api_response) =
-  match response.usage with
-  | Some usage -> usage
-  | None ->
-      {
-        Agent_sdk.Types.input_tokens = 0;
-        output_tokens = 0;
-        cache_creation_input_tokens = 0;
-        cache_read_input_tokens = 0;
-        cost_usd = None;
-      }
+let usage (response : api_response) = response.usage

--- a/lib/oas_response.mli
+++ b/lib/oas_response.mli
@@ -11,5 +11,6 @@ val text_of_response : api_response -> string
 val model_used : api_response -> string
 (** Return the model identifier used for the response. *)
 
-val usage_or_zero : api_response -> Agent_sdk.Types.api_usage
-(** Return usage stats, defaulting to zero when absent. *)
+val usage : api_response -> Agent_sdk.Types.api_usage option
+(** Return provider-reported usage stats, if present. [None] means the
+    provider did not report usage; callers must not treat it as zero. *)

--- a/test/test_dashboard_oas_bridge.ml
+++ b/test/test_dashboard_oas_bridge.ml
@@ -1,6 +1,6 @@
 (** Tests for [Dashboard_oas_bridge].
 
-    Twelve-signal collector for I1 telemetry pipeline (#11924). Covers
+    Per-call telemetry collector for I1 telemetry pipeline (#11924). Covers
     ring-buffer semantics (record/recent/clear), provider filter, and
     the nearest-rank percentile in {!Dashboard_oas_bridge.summary}, plus
     provider-error count aggregation for I2 (#11925). *)
@@ -15,6 +15,7 @@ let make_sample
     ?(ttfb = 100.0)
     ?(dur = 200.0)
     ?(serialization = 5.0)
+    ?(usage_reported = true)
     ?(input = 100)
     ?(output = 200)
     ?(throughput = 1000.0)
@@ -29,11 +30,13 @@ let make_sample
     ttfb_ms = ttfb;
     total_duration_ms = dur;
     serialization_ms = serialization;
-    input_tokens = input;
-    output_tokens = output;
-    throughput_tokens_per_s = throughput;
-    cost_usd = cost;
-    cache_hit = cache;
+    usage_reported;
+    input_tokens = (if usage_reported then Some input else None);
+    output_tokens = (if usage_reported then Some output else None);
+    throughput_tokens_per_s =
+      (if usage_reported then Some throughput else None);
+    cost_usd = (if usage_reported then Some cost else None);
+    cache_hit = (if usage_reported then Some cache else None);
     status;
     retry_count = retry;
   }
@@ -165,6 +168,8 @@ let test_sample_json_preserves_signal_fields () =
     (json |> Json.member "total_duration_ms" |> Json.to_float);
   Alcotest.(check (float 1e-9)) "serialization" 2.0
     (json |> Json.member "serialization_ms" |> Json.to_float);
+  Alcotest.(check bool) "usage reported" true
+    (json |> Json.member "usage_reported" |> Json.to_bool);
   Alcotest.(check int) "input" 123
     (json |> Json.member "input_tokens" |> Json.to_int);
   Alcotest.(check int) "output" 45
@@ -343,15 +348,18 @@ let test_sample_of_response_uses_usage_and_native_telemetry () =
   in
   Alcotest.(check string) "provider" "openai_compat" sample.provider_id;
   Alcotest.(check string) "model" "gpt-4" sample.model_id;
-  Alcotest.(check int) "input tokens" 11 sample.input_tokens;
-  Alcotest.(check int) "output tokens" 5 sample.output_tokens;
+  Alcotest.(check bool) "usage reported" true sample.usage_reported;
+  Alcotest.(check bool) "input tokens" true
+    (sample.input_tokens = Some 11);
+  Alcotest.(check bool) "output tokens" true
+    (sample.output_tokens = Some 5);
   Alcotest.(check (float 1e-9)) "ttfb" 510.0 sample.ttfb_ms;
   Alcotest.(check (float 1e-9)) "duration" 620.0
     sample.total_duration_ms;
-  Alcotest.(check (float 1e-9)) "native throughput" 81.56
-    sample.throughput_tokens_per_s;
-  Alcotest.(check (float 1e-9)) "cost" 0.12 sample.cost_usd;
-  Alcotest.(check bool) "cache hit" true sample.cache_hit
+  Alcotest.(check bool) "native throughput" true
+    (sample.throughput_tokens_per_s = Some 81.56);
+  Alcotest.(check bool) "cost" true (sample.cost_usd = Some 0.12);
+  Alcotest.(check bool) "cache hit" true (sample.cache_hit = Some true)
 
 let test_sample_of_response_derives_wall_throughput () =
   let usage = make_usage ~input:100 ~output:50 () in
@@ -363,10 +371,10 @@ let test_sample_of_response_derives_wall_throughput () =
   in
   Alcotest.(check (float 1e-9)) "duration" 250.0
     sample.total_duration_ms;
-  Alcotest.(check (float 1e-9)) "wall throughput" 200.0
-    sample.throughput_tokens_per_s
+  Alcotest.(check bool) "wall throughput" true
+    (sample.throughput_tokens_per_s = Some 200.0)
 
-let test_record_response_records_missing_usage_as_zero_sample () =
+let test_record_response_records_missing_usage_as_unknown_sample () =
   setup ();
   let response =
     make_response ~telemetry:(make_telemetry ~request_latency_ms:33 ())
@@ -376,17 +384,25 @@ let test_record_response_records_missing_usage_as_zero_sample () =
     ~status:(DOB.Error { transient = false }) response;
   match DOB.recent ~provider:"kimi_cli" () with
   | [ (sample, _) ] ->
-      Alcotest.(check int) "input tokens" 0 sample.input_tokens;
-      Alcotest.(check int) "output tokens" 0 sample.output_tokens;
+      Alcotest.(check bool) "usage reported" false
+        sample.usage_reported;
+      Alcotest.(check bool) "input tokens unknown" true
+        (sample.input_tokens = None);
+      Alcotest.(check bool) "output tokens unknown" true
+        (sample.output_tokens = None);
+      Alcotest.(check bool) "throughput unknown" true
+        (sample.throughput_tokens_per_s = None);
+      Alcotest.(check bool) "cost unknown" true (sample.cost_usd = None);
       Alcotest.(check (float 1e-9)) "duration" 33.0
         sample.total_duration_ms;
-      Alcotest.(check bool) "cache hit" false sample.cache_hit
+      Alcotest.(check bool) "cache hit unknown" true
+        (sample.cache_hit = None)
   | xs ->
       Alcotest.failf "expected one sample, got %d" (List.length xs)
 
-(* --- 12-signal coverage ratchet --- *)
+(* --- signal coverage ratchet --- *)
 
-(** Verify that all 12 telemetry signals are present as keys in the JSON output
+(** Verify that all telemetry signals are present as keys in the JSON output
     of [sample_to_yojson].  This ratchet fails CI if any signal is dropped from
     the serialization layer. *)
 let expected_signal_keys =
@@ -396,6 +412,7 @@ let expected_signal_keys =
     "ttfb_ms";
     "total_duration_ms";
     "serialization_ms";
+    "usage_reported";
     "input_tokens";
     "output_tokens";
     "throughput_tokens_per_s";
@@ -405,7 +422,7 @@ let expected_signal_keys =
     "retry_count";
   ]
 
-let test_twelve_signal_json_keys_all_present () =
+let test_signal_json_keys_all_present () =
   let json = DOB.sample_to_yojson (make_sample ()) in
   let keys =
     match json with
@@ -418,7 +435,7 @@ let test_twelve_signal_json_keys_all_present () =
         (Printf.sprintf "signal key '%s' present" expected_key)
         true (List.mem expected_key keys))
     expected_signal_keys;
-  Alcotest.(check int) "exactly 12 signal keys" 12 (List.length keys)
+  Alcotest.(check int) "exactly 13 signal keys" 13 (List.length keys)
 
 let test_serialization_ms_propagates_through_sample_of_response () =
   let usage = make_usage ~input:10 ~output:5 () in
@@ -501,13 +518,13 @@ let () =
             test_sample_of_response_uses_usage_and_native_telemetry;
           Alcotest.test_case "wall throughput fallback" `Quick
             test_sample_of_response_derives_wall_throughput;
-          Alcotest.test_case "missing usage records zero sample" `Quick
-            test_record_response_records_missing_usage_as_zero_sample;
+          Alcotest.test_case "missing usage records unknown sample" `Quick
+            test_record_response_records_missing_usage_as_unknown_sample;
         ] );
-      ( "twelve_signal_ratchet",
+      ( "signal_ratchet",
         [
-          Alcotest.test_case "all 12 JSON keys present" `Quick
-            test_twelve_signal_json_keys_all_present;
+          Alcotest.test_case "all 13 JSON keys present" `Quick
+            test_signal_json_keys_all_present;
           Alcotest.test_case "serialization_ms via sample_of_response" `Quick
             test_serialization_ms_propagates_through_sample_of_response;
           Alcotest.test_case "serialization_ms defaults to zero" `Quick


### PR DESCRIPTION
## What changed

- Replaced `Oas_response.usage_or_zero` with `Oas_response.usage`, preserving `None` when OAS/provider usage is absent.
- Changed dashboard OAS telemetry samples to emit `usage_reported` and nullable usage-derived fields instead of synthetic zero token/cost/cache values.
- Updated the dashboard bridge regression test so missing Kimi-style usage records as unknown, while real provider usage still serializes normally.
- Included a one-line current-main buildability fix removing a duplicate `Stale_fleet_batch` receipt match case that trips `-warn-error` during focused builds.

## Why

The previous helper erased the difference between "provider reported zero usage" and "provider did not report usage." That made Kimi/CLI provider gaps look like real zero-token calls in the dashboard surface.

## Validation

- `git diff --check origin/main..HEAD`
- `scripts/dune-local.sh build test/test_dashboard_oas_bridge.exe`
- `./_build/default/test/test_dashboard_oas_bridge.exe` (21 tests)

`ocamlformat --check` still exits nonzero with no diagnostic on the touched files; applying `ocamlformat --inplace` produced broad pre-existing style churn, so that formatting churn is intentionally not included.