### PR TITLE
Scope keeper lifecycle proof evidence by run id

### DIFF
--- a/docs/KEEPER-DOCKER-PR-LIFECYCLE-REPROBE.md
+++ b/docs/KEEPER-DOCKER-PR-LIFECYCLE-REPROBE.md
@@ -17,7 +17,7 @@ adds the operator action loop:
 2. render a per-keeper proof prompt,
 3. optionally send the prompt through `masc_keeper_msg`,
 4. poll `masc_keeper_msg_result`,
-5. run `audit-keeper-fleet-readiness.py --require-docker-pr-lifecycle-evidence`,
+5. run `audit-keeper-fleet-readiness.py --require-docker-pr-lifecycle-evidence --evidence-run-id <run_id>`,
 6. save artifacts under `logs/keeper_docker_pr_lifecycle/<run_id>/`.
 
 Default mode is dry-run. It writes prompts and runs the read-only audit, but it
@@ -51,10 +51,14 @@ When mutation is enabled, the harness sends `required_tools` with each
 those tools are not visible and `missing_required_tool_use` if the keeper
 replies without exercising them.
 The prompt reserves `keeper_shell` for read-only GitHub inspection.
-Proof-file creation and git add/commit/push should use `keeper_bash` from
-inside the Docker playground so the route evidence is tied to the keeper
-container path. If the shell guard rejects the git mutation, the keeper must
-stop and report that blocker instead of falling back to host-local credentials.
+Keepers must create/use the exact run-scoped branch
+`keeper/<keeper>-docker-pr-proof-<run_id>` and proof file
+`docs/runtime-proof/keepers/<keeper>-<run_id>.md`; older proof branches or
+worktrees do not count. Proof-file creation and git add/commit/push should use
+`keeper_bash` from inside the Docker playground so the route evidence is tied to
+the keeper container path. If the shell guard rejects the git mutation, the
+keeper must stop and report that blocker instead of falling back to host-local
+credentials.
 PR create/review mutations should use `keeper_pr_create` /
 `keeper_pr_review_comment` rather than `gh pr ...` through shell tools.
 Override the CSV with `REQUIRED_TOOLS=...` for a narrower or broader proof
@@ -104,4 +108,6 @@ The prompt requires keepers to stay on draft proof PRs:
 
 The final audit remains the truth source. A successful keeper reply is useful
 operator evidence, but it is not completion unless the Docker lifecycle audit
-also passes for the expected fleet.
+also passes for the expected fleet. The reprobe audit is run-id scoped, so stale
+PR lifecycle evidence from earlier keeper proof runs cannot satisfy a fresh
+run.

--- a/scripts/audit-keeper-fleet-readiness.py
+++ b/scripts/audit-keeper-fleet-readiness.py
@@ -354,6 +354,18 @@ def command_texts_from_structured_input(row: dict[str, Any]) -> list[str]:
     return [text for text in texts if text]
 
 
+def row_mentions_evidence_run_id(
+    row: dict[str, Any], evidence_run_id: str | None
+) -> bool:
+    if not evidence_run_id:
+        return True
+    try:
+        haystack = json.dumps(row, ensure_ascii=False, sort_keys=True)
+    except (TypeError, ValueError):
+        haystack = str(row)
+    return evidence_run_id.lower() in haystack.lower()
+
+
 def add_pr_refs_from_structured_output(
     *,
     refs: set[str],
@@ -990,6 +1002,7 @@ def scan_keeper_evidence(
     name: str,
     *,
     max_silence_hours: float | None = None,
+    evidence_run_id: str | None = None,
     now: float | None = None,
 ) -> tuple[float | None, set[str], set[str], set[str]]:
     latest_ts: float | None = None
@@ -1009,9 +1022,12 @@ def scan_keeper_evidence(
             if ts is not None:
                 latest_ts = ts if latest_ts is None else max(latest_ts, ts)
             tools.update(tools_from_decision(row))
-            row_evidence, row_docker_evidence = pr_lifecycle_evidence_from_decision(row)
-            pr_lifecycle_evidence.update(row_evidence)
-            docker_pr_lifecycle_evidence.update(row_docker_evidence)
+            if row_mentions_evidence_run_id(row, evidence_run_id):
+                row_evidence, row_docker_evidence = (
+                    pr_lifecycle_evidence_from_decision(row)
+                )
+                pr_lifecycle_evidence.update(row_evidence)
+                docker_pr_lifecycle_evidence.update(row_docker_evidence)
     for metrics in pr_action_metric_paths(
         base_path, name, min_day_key=min_metric_day_key
     ):
@@ -1022,11 +1038,12 @@ def scan_keeper_evidence(
             if ts is not None:
                 latest_ts = ts if latest_ts is None else max(latest_ts, ts)
             tools.update(tools_from_action_metric(row))
-            row_evidence, row_docker_evidence = (
-                pr_lifecycle_evidence_from_action_metric(row)
-            )
-            pr_lifecycle_evidence.update(row_evidence)
-            docker_pr_lifecycle_evidence.update(row_docker_evidence)
+            if row_mentions_evidence_run_id(row, evidence_run_id):
+                row_evidence, row_docker_evidence = (
+                    pr_lifecycle_evidence_from_action_metric(row)
+                )
+                pr_lifecycle_evidence.update(row_evidence)
+                docker_pr_lifecycle_evidence.update(row_docker_evidence)
         if complete_lifecycle_evidence(
             pr_lifecycle_evidence
         ) and complete_lifecycle_evidence(docker_pr_lifecycle_evidence):
@@ -1047,11 +1064,12 @@ def scan_keeper_evidence(
                 tool = row.get("tool")
                 if isinstance(tool, str):
                     tools.add(tool)
-                row_evidence, row_docker_evidence = (
-                    pr_lifecycle_evidence_from_tool_call(row)
-                )
-                pr_lifecycle_evidence.update(row_evidence)
-                docker_pr_lifecycle_evidence.update(row_docker_evidence)
+                if row_mentions_evidence_run_id(row, evidence_run_id):
+                    row_evidence, row_docker_evidence = (
+                        pr_lifecycle_evidence_from_tool_call(row)
+                    )
+                    pr_lifecycle_evidence.update(row_evidence)
+                    docker_pr_lifecycle_evidence.update(row_docker_evidence)
             if complete_lifecycle_evidence(
                 pr_lifecycle_evidence
             ) and complete_lifecycle_evidence(docker_pr_lifecycle_evidence):
@@ -1077,6 +1095,7 @@ def audit_keeper(
     require_docker_pr_create_evidence: bool,
     require_docker_git_push_evidence: bool,
     require_docker_pr_approve_evidence: bool,
+    evidence_run_id: str | None,
     forbidden_github_identities: set[str] | None = None,
 ) -> KeeperAudit:
     name = config_path.stem
@@ -1132,7 +1151,12 @@ def audit_keeper(
         tools,
         pr_lifecycle_evidence,
         docker_pr_lifecycle_evidence,
-    ) = scan_keeper_evidence(base_path, name, max_silence_hours=max_silence_hours)
+    ) = scan_keeper_evidence(
+        base_path,
+        name,
+        max_silence_hours=max_silence_hours,
+        evidence_run_id=evidence_run_id,
+    )
     pr_creation_evidence = scan_pr_creation_evidence(base_path, name)
     (
         board_post_ts,
@@ -1310,6 +1334,7 @@ def build_report(args: argparse.Namespace) -> dict[str, Any]:
                 args.require_docker_pr_approve_evidence
                 or args.require_docker_pr_lifecycle_evidence
             ),
+            evidence_run_id=args.evidence_run_id,
             forbidden_github_identities=set(args.forbid_github_identity or []),
         )
         for path in config_paths
@@ -1365,6 +1390,7 @@ def build_report(args: argparse.Namespace) -> dict[str, Any]:
             "require_docker_pr_lifecycle_evidence": (
                 args.require_docker_pr_lifecycle_evidence
             ),
+            "evidence_run_id": args.evidence_run_id,
         },
         "fleet_failures": fleet_failures,
         "failed_keepers": [keeper.name for keeper in failed_keepers],
@@ -1551,6 +1577,15 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         help=(
             "Fail unless each keeper has direct PR create, git push, and "
             "PR APPROVE evidence with explicit Docker execution markers."
+        ),
+    )
+    parser.add_argument(
+        "--evidence-run-id",
+        default=None,
+        help=(
+            "When set, count PR lifecycle evidence only from rows that mention "
+            "this run id. This prevents older proof runs from satisfying a "
+            "fresh lifecycle reprobe."
         ),
     )
     parser.add_argument("--json", action="store_true", help="Emit JSON report.")

--- a/scripts/harness/workload/keeper_docker_pr_lifecycle_reprobe.sh
+++ b/scripts/harness/workload/keeper_docker_pr_lifecycle_reprobe.sh
@@ -812,9 +812,15 @@ Tool route rules:
 
 Required proof lane:
 1. Confirm your runtime is sandbox_profile=docker before mutating.
-2. Create a unique proof branch named: keeper/$keeper-docker-pr-proof-$RUN_ID
-3. Make a minimal, non-product proof edit under docs/runtime-proof/keepers/$keeper-$RUN_ID.md with keeper_bash from inside the Docker playground.
-4. Commit and git push that branch with keeper_bash. The tool result must show explicit Docker-backed route evidence such as via=docker, route_via=docker, via=brokered, or route_via=brokered.
+2. Create a unique proof worktree/branch for exactly this run id:
+   - branch: keeper/$keeper-docker-pr-proof-$RUN_ID
+   - preferred tool: masc_worktree_create
+   - use the returned worktree path for every later keeper_bash git/file command.
+   - Do not reuse any branch, worktree, or proof file from another run id.
+   - Do not remove this run's worktree during the proof attempt. If Git says
+     the branch/worktree already exists, stop and report blocker="branch_collision".
+3. Make a minimal, non-product proof edit under docs/runtime-proof/keepers/$keeper-$RUN_ID.md with keeper_bash from inside the Docker playground. The file content must include run_id=$RUN_ID and branch=keeper/$keeper-docker-pr-proof-$RUN_ID.
+4. Commit and git push exactly branch keeper/$keeper-docker-pr-proof-$RUN_ID with keeper_bash. The tool result must show explicit Docker-backed route evidence such as via=docker, route_via=docker, via=brokered, or route_via=brokered.
 5. Create a draft PR for that branch with keeper_pr_create or the native PR-create tool path. Do not mark ready, do not merge, do not add human-approved-ready.
 6. Use keeper_pr_review_read and keeper_pr_review_comment for review evidence. COMMENT is allowed on your own proof PR. APPROVE must target the cross-keeper PR below, not your own PR.
 
@@ -990,6 +996,7 @@ run_audit() {
     --base-path "$BASE_PATH"
     --expected-keepers "$EXPECTED_KEEPERS"
     --require-docker-pr-lifecycle-evidence
+    --evidence-run-id "$RUN_ID"
     --json
   )
   if [[ -n "$FORBID_GITHUB_IDENTITIES" ]]; then

--- a/test/test_audit_keeper_fleet_readiness.py
+++ b/test/test_audit_keeper_fleet_readiness.py
@@ -48,6 +48,7 @@ def audit_args(base_path: Path, expected_keepers: int):
         require_docker_git_push_evidence=False,
         require_docker_pr_approve_evidence=False,
         require_docker_pr_lifecycle_evidence=False,
+        evidence_run_id=None,
         forbid_github_identity=[],
     )
 
@@ -800,6 +801,48 @@ class AuditKeeperFleetReadinessTest(unittest.TestCase):
             evidence,
             {"git_push:keeper_bash", "pr_approve:keeper_shell"},
         )
+        self.assertEqual(docker_evidence, evidence)
+
+    def test_scan_keeper_evidence_filters_pr_lifecycle_by_run_id(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            calls_dir = root / ".masc" / "tool_calls" / "2026-05"
+            calls_dir.mkdir(parents=True)
+            rows = [
+                {
+                    "ts": 50.0,
+                    "keeper": "alpha",
+                    "tool": "keeper_bash",
+                    "input": {"cmd": "git push -u origin keeper/old-run"},
+                    "output": json.dumps({"ok": True, "via": "docker"}),
+                    "success": True,
+                },
+                {
+                    "ts": 60.0,
+                    "keeper": "alpha",
+                    "tool": "keeper_bash",
+                    "input": {
+                        "cmd": (
+                            "git push -u origin "
+                            "keeper/alpha-docker-pr-proof-current-run"
+                        )
+                    },
+                    "output": json.dumps({"ok": True, "via": "docker"}),
+                    "success": True,
+                },
+            ]
+            (calls_dir / "06.jsonl").write_text(
+                "".join(json.dumps(row) + "\n" for row in rows),
+                encoding="utf-8",
+            )
+
+            latest_ts, tools, evidence, docker_evidence = audit.scan_keeper_evidence(
+                root, "alpha", evidence_run_id="current-run"
+            )
+
+        self.assertEqual(latest_ts, 60.0)
+        self.assertEqual(tools, {"keeper_bash"})
+        self.assertEqual(evidence, {"git_push:keeper_bash"})
         self.assertEqual(docker_evidence, evidence)
 
     def test_scan_keeper_evidence_reads_newest_tool_calls_first(self):

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -1319,6 +1319,11 @@ let test_keeper_pr_audit_contracts () =
        "route_evidence"
      && file_contains_pattern "scripts/audit-keeper-fleet-readiness.py"
           "route_evidence.via=docker");
+  check bool "keeper fleet audit can scope lifecycle evidence by run id" true
+    (file_contains_pattern "scripts/audit-keeper-fleet-readiness.py"
+       "--evidence-run-id"
+     && file_contains_pattern "scripts/harness/workload/keeper_docker_pr_lifecycle_reprobe.sh"
+          "--evidence-run-id \"$RUN_ID\"");
   check bool "keeper fleet audit survives live invalid utf8 rows" true
     (file_contains_pattern "scripts/audit-keeper-fleet-readiness.py"
        {|errors="replace"|})


### PR DESCRIPTION
## Summary

- add `--evidence-run-id` to the keeper fleet audit so PR lifecycle proof only counts rows that mention the active reprobe run id
- pass the reprobe `RUN_ID` into the final Docker PR lifecycle audit
- tighten the mutation prompt/docs so keepers must use the exact run-scoped proof branch/worktree/file and stop on branch collisions instead of reusing stale proof state
- add unit/source-contract coverage for the run-id filter and harness wiring

## Why This Matters

The latest pair reprobe (`docker-pr-lifecycle-pair-0506h`) exposed that stale proof branches/worktrees can pollute the audit surface: verifier drifted toward an older `docker-pr-lifecycle-smoke-0506f` lane before timing out. Fresh Docker PR lifecycle proof should not be satisfied by old tool-call rows or old proof branches.

This does not claim the fleet objective is complete. The 0506h run ended with analyst `require_tool_use` contract failure and verifier timeout, so it is evidence for the hardening need, not completion evidence.

## Verification

- `python3 -m py_compile scripts/audit-keeper-fleet-readiness.py test/test_audit_keeper_fleet_readiness.py`
- `python3 test/test_audit_keeper_fleet_readiness.py`
- `bash -n scripts/harness/workload/keeper_docker_pr_lifecycle_reprobe.sh scripts/harness_keeper_docker_pr_lifecycle_reprobe.sh`
- `git diff --check origin/main...HEAD`
- `scripts/dune-local.sh build test/test_ci_hardening_source.exe`