### PR TITLE
fix(build): restore main green — paren + redundant case + Heartbeat path + Option.bind order

### DIFF
--- a/lib/keeper/keeper_execution_receipt.ml
+++ b/lib/keeper/keeper_execution_receipt.ml
@@ -716,7 +716,6 @@ let stale_terminal_reason_code = function
   | Some (Keeper_registry.Stale_fleet_batch _) -> "stale_fleet_batch"
   | Some (Keeper_registry.Stale_termination_storm _) ->
       "stale_termination_storm"
-  | Some (Keeper_registry.Stale_fleet_batch _) -> "stale_fleet_batch"
   | Some (Keeper_registry.Heartbeat_consecutive_failures _) ->
       "heartbeat_failures"
   | Some (Keeper_registry.Turn_consecutive_failures _) -> "turn_failures"

--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -670,4 +670,4 @@ let handle_keeper_msg ?on_text_delta ctx args : tool_result =
               in
               (true, Yojson.Safe.to_string reply_json)
 
-)))))
+))))))

--- a/test/test_dashboard_keeper_routes.ml
+++ b/test/test_dashboard_keeper_routes.ml
@@ -962,7 +962,7 @@ let test_agent_purge_route_removes_plain_agent_artifacts () =
   ignore
     (Masc_mcp.Auth.create_token config.base_path ~agent_name ~role:Masc_domain.Admin);
   ignore
-    (Masc_mcp.Heartbeat.start ~agent_name ~interval:30 ~message:"route-test");
+    (Heartbeat.start ~agent_name ~interval:30 ~message:"route-test");
   let metrics_dir = Masc_mcp.Metrics_store_eio.agent_metrics_dir config agent_name in
   Fs_compat.mkdir_p metrics_dir;
   write_file (Filename.concat metrics_dir "2026-04.jsonl") "{}\n";
@@ -994,7 +994,7 @@ let test_agent_purge_route_removes_plain_agent_artifacts () =
   check string "agent purge reports coord leave" (agent_name ^ " left the namespace")
     (cleanup_row |> member "coord_leave_result" |> to_string);
   check int "agent purge leaves no duplicate heartbeat stop work" 0
-    (Masc_mcp.Heartbeat.stop_by_agent ~agent_name);
+    (Heartbeat.stop_by_agent ~agent_name);
   check bool "agent file removed" false
     (Sys.file_exists
        (Filename.concat (Masc_mcp.Coord.agents_dir config)

--- a/test/test_room.ml
+++ b/test/test_room.ml
@@ -167,10 +167,12 @@ let test_broadcast_replaces_terminal_task_cache_desync () =
 
   let config = room_config tmp_dir in
   let current_task_for agent_name =
-    Coord.get_agents_raw config
-    |> List.find_opt (fun (agent : Masc_domain.agent) ->
-      String.equal agent.name agent_name)
-    |> Option.bind (fun agent -> agent.current_task)
+    let agent_opt =
+      Coord.get_agents_raw config
+      |> List.find_opt (fun (agent : Masc_domain.agent) ->
+        String.equal agent.name agent_name)
+    in
+    Option.bind agent_opt (fun (agent : Masc_domain.agent) -> agent.current_task)
   in
   let _ = Coord.init config ~agent_name:(Some "taskmaster") in
   let _ = Coord.add_task config ~title:"Terminal task" ~priority:1 ~description:"" in


### PR DESCRIPTION
## Summary

PR #13803 머지 이후 `dune build`가 4개 에러로 실패. 4개 파일 surgical fix로 main 빌드를 복구합니다.

```
File "lib/keeper/keeper_turn.ml", line 674, characters 0-0:
Error: Syntax error: ) expected
File "lib/keeper/keeper_execution_receipt.ml", line 719:
Error (warning 11 [redundant-case]): this match case is unused.
File "test/test_dashboard_keeper_routes.ml", line 965:
Error: Unbound module Masc_mcp.Heartbeat
File "test/test_room.ml", line 173:
Error: This expression should not be a function, the expected type is 'a option
```

## Root cause

| # | 파일 | 도입 PR | 변경 |
|---|------|---------|------|
| 1 | `lib/keeper/keeper_turn.ml:673` | #13803 | `)))))` → `))))))` (6중 nested match에 닫는 paren 1개 누락) |
| 2 | `lib/keeper/keeper_execution_receipt.ml:719` | #13803 | 중복 `Stale_fleet_batch` case 제거 (716에 이미 존재) |
| 3 | `test/test_dashboard_keeper_routes.ml:965,997` | #13538 | `Masc_mcp.Heartbeat.*` → `Heartbeat.*` (`masc_coord` `wrapped false`로 top-level 노출) |
| 4 | `test/test_room.ml:169-174` | (origin 미상) | `pipe \|> Option.bind (fun ...)` → let-bind 후 `Option.bind agent_opt (fun ...)` |

#1·#2는 PR #13803(test guard 수정)의 부수 변경으로 함께 들어왔습니다. paren 1개 누락이 OCaml 파서에 의해 480줄 떨어진 EOF에서 보고되는 점, redundant-case가 이 빌드에서 warning-as-error로 차단되는 점이 디버깅을 늦췄습니다.

## Test plan

- [x] `dune build` (exit 0)
- [x] `dune build @check` (exit 0)
- [ ] CI green

## Notes

`Option.bind` 수정에서 `agent_opt` let-binding이 명시적인 `Masc_domain.agent option` 타입을 그대로 보존하므로 의미 변화 없음. fmt drift는 이번 변경 라인에 한정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)