### PR TITLE
fix(test): align test build with module/api drift

### DIFF
--- a/test/test_dashboard_keeper_routes.ml
+++ b/test/test_dashboard_keeper_routes.ml
@@ -962,7 +962,7 @@ let test_agent_purge_route_removes_plain_agent_artifacts () =
   ignore
     (Masc_mcp.Auth.create_token config.base_path ~agent_name ~role:Masc_domain.Admin);
   ignore
-    (Masc_mcp.Heartbeat.start ~agent_name ~interval:30 ~message:"route-test");
+    (Heartbeat.start ~agent_name ~interval:30 ~message:"route-test");
   let metrics_dir = Masc_mcp.Metrics_store_eio.agent_metrics_dir config agent_name in
   Fs_compat.mkdir_p metrics_dir;
   write_file (Filename.concat metrics_dir "2026-04.jsonl") "{}\n";
@@ -994,7 +994,7 @@ let test_agent_purge_route_removes_plain_agent_artifacts () =
   check string "agent purge reports coord leave" (agent_name ^ " left the namespace")
     (cleanup_row |> member "coord_leave_result" |> to_string);
   check int "agent purge leaves no duplicate heartbeat stop work" 0
-    (Masc_mcp.Heartbeat.stop_by_agent ~agent_name);
+    (Heartbeat.stop_by_agent ~agent_name);
   check bool "agent file removed" false
     (Sys.file_exists
        (Filename.concat (Masc_mcp.Coord.agents_dir config)

--- a/test/test_room.ml
+++ b/test/test_room.ml
@@ -170,7 +170,9 @@ let test_broadcast_replaces_terminal_task_cache_desync () =
     Coord.get_agents_raw config
     |> List.find_opt (fun (agent : Masc_domain.agent) ->
       String.equal agent.name agent_name)
-    |> Option.bind (fun agent -> agent.current_task)
+    |> (function
+        | Some (agent : Masc_domain.agent) -> agent.current_task
+        | None -> None)
   in
   let _ = Coord.init config ~agent_name:(Some "taskmaster") in
   let _ = Coord.add_task config ~title:"Terminal task" ~priority:1 ~description:"" in


### PR DESCRIPTION
## Summary

Rebase-only conflict cleanup for stale test build references after main moved. The PR still owns the same two test files:

- `test/test_dashboard_keeper_routes.ml`: `Masc_mcp.Heartbeat` -> `Heartbeat` because `heartbeat.ml` is exposed from `masc_coord` as a top-level module.
- `test/test_room.ml`: replace stale `Option.bind` pipe usage with an explicit `function` over the option.

## Verification

- `git diff --check origin/main...HEAD`
- `scripts/check-oas-pin.sh --local-only`
- `env MASC_OPAM_LOCK=0 scripts/dune-local.sh build test/test_dashboard_keeper_routes.exe test/test_room.exe`

## Direct Test Follow-ups

The compile blocker is fixed, but direct binary execution exposed broader test-harness issues that are not silently folded into this conflict rebase:

- #13844: `test_dashboard_keeper_routes.exe` process-local heartbeat assertion fails (`heartbeats_stopped` expected 1, got 0).
- #13845: `test_room.exe` direct execution fails 30/89 Coord tests.

## Notes

The PR remains draft. CI lightweight gates were green before the rebase; post-rebase checks should be watched before any ready/merge decision.