### PR TITLE
fix(keeper): include persisted keepers in list surface

### DIFF
--- a/lib/tool_keeper.ml
+++ b/lib/tool_keeper.ml
@@ -720,18 +720,21 @@ let handle_keeper_list ctx args : tool_result =
   let body =
     cached_text_by_key _keeper_list_cache ~key:cache_key
       ~ttl_s:(keeper_list_cache_ttl_s ()) (fun () ->
-        let entries =
+        let registry_names =
           Keeper_registry.all ~base_path:ctx.config.base_path ()
-          |> List.sort (fun (a : Keeper_registry.registry_entry)
-                            (b : Keeper_registry.registry_entry) ->
-               String.compare a.name b.name)
+          |> List.map (fun (entry : Keeper_registry.registry_entry) -> entry.name)
+        in
+        let names =
+          registry_names @ keeper_names ctx.config
+          |> List.map String.trim
+          |> List.filter (fun name -> not (String.equal name ""))
+          |> List.sort_uniq String.compare
           |> take limit
         in
-        let names = List.map (fun (e : Keeper_registry.registry_entry) -> e.name) entries in
         let rows =
-          entries
-          |> List.filter_map (fun (e : Keeper_registry.registry_entry) ->
-               keeper_list_row_json ~runtime_class:"keeper" ctx.config e.name)
+          names
+          |> List.filter_map (fun name ->
+               keeper_list_row_json ~runtime_class:"keeper" ctx.config name)
         in
         let json =
           if not detailed then

--- a/test/test_keeper_meta_listing.ml
+++ b/test/test_keeper_meta_listing.ml
@@ -223,7 +223,26 @@ let test_keeper_listing_ignores_sidecar_json_files () =
       check (list string) "status handler filters sidecars"
         [ "dot.name"; "sangsu" ] listed;
       check int "status handler count filters sidecars" 2
-        Yojson.Safe.Util.(json |> member "count" |> to_int))
+        Yojson.Safe.Util.(json |> member "count" |> to_int);
+      let ok, body =
+        match
+          Tool_keeper.dispatch ctx ~name:"masc_keeper_list"
+            ~args:(`Assoc [ ("limit", `Int 10) ])
+        with
+        | Some result -> result
+        | None -> fail "expected masc_keeper_list dispatch"
+      in
+      check bool "tool keeper list ok without registry entries" true ok;
+      let json = parse_json_exn body in
+      let listed =
+        Yojson.Safe.Util.(json |> member "keepers" |> to_list |> filter_string)
+      in
+      check (list string) "tool keeper list includes persisted keepers"
+        [ "dot.name"; "sangsu" ] listed;
+      check int "tool keeper list count includes persisted keepers" 2
+        Yojson.Safe.Util.(json |> member "count" |> to_int);
+      check int "tool keeper list rows include persisted keepers" 2
+        Yojson.Safe.Util.(json |> member "items" |> to_list |> List.length))
 
 let test_bootable_keeper_names_skip_autoboot_disabled_meta () =
   Eio_main.run @@ fun env ->

--- a/test/test_keeper_meta_listing.ml
+++ b/test/test_keeper_meta_listing.ml
@@ -242,7 +242,36 @@ let test_keeper_listing_ignores_sidecar_json_files () =
       check int "tool keeper list count includes persisted keepers" 2
         Yojson.Safe.Util.(json |> member "count" |> to_int);
       check int "tool keeper list rows include persisted keepers" 2
-        Yojson.Safe.Util.(json |> member "items" |> to_list |> List.length))
+        Yojson.Safe.Util.(json |> member "items" |> to_list |> List.length);
+      (* detailed=true is the primary surface for the operator dashboard
+         after a server restart, so pin its behaviour explicitly:
+         masc_keeper_list with detailed=true must include the persisted
+         keepers even when the in-memory registry is empty. *)
+      let ok_detailed, body_detailed =
+        match
+          Tool_keeper.dispatch ctx ~name:"masc_keeper_list"
+            ~args:(`Assoc [ ("limit", `Int 10); ("detailed", `Bool true) ])
+        with
+        | Some result -> result
+        | None -> fail "expected masc_keeper_list dispatch (detailed)"
+      in
+      check bool "tool keeper list (detailed) ok without registry entries" true
+        ok_detailed;
+      let json_detailed = parse_json_exn body_detailed in
+      let listed_detailed =
+        Yojson.Safe.Util.(
+          json_detailed |> member "keepers" |> to_list |> filter_string)
+      in
+      check (list string)
+        "tool keeper list (detailed) includes persisted keepers"
+        [ "dot.name"; "sangsu" ] listed_detailed;
+      check int
+        "tool keeper list (detailed) count includes persisted keepers" 2
+        Yojson.Safe.Util.(json_detailed |> member "count" |> to_int);
+      check int
+        "tool keeper list (detailed) rows include persisted keepers" 2
+        Yojson.Safe.Util.(
+          json_detailed |> member "items" |> to_list |> List.length))
 
 let test_bootable_keeper_names_skip_autoboot_disabled_meta () =
   Eio_main.run @@ fun env ->


### PR DESCRIPTION
## Summary

`masc_keeper_list` claimed to list known keepers from persisted keeper metadata, but the tool was only reading the live `Keeper_registry`. After a restart or partial keepalive recovery, operator surfaces could show only currently registered keepers even though persisted keeper metadata and sandbox status still knew the full fleet.

This changes the tool list source to combine:

- active registry entries for live runtime state
- persisted keeper metadata names from the current base path

The detailed rows still come from persisted metadata, so stale sidecar JSON remains filtered and base-path scoping stays intact.

## Why It Matters

The keeper proof/runtime dashboard depends on `masc_keeper_list(detailed=true)` as an operator-truth surface. Underreporting the fleet makes the 24h keeper continuity and Docker sandbox proof look false even when persisted keeper metadata and sandbox state are present.

## Validation

- `git diff --check origin/main...HEAD` passed.
- Added regression coverage in `test/test_keeper_meta_listing.ml` for persisted keeper metadata without active registry entries.
- Focused OCaml build attempted: `scripts/dune-local.sh build test/test_keeper_meta_listing.exe`.
  - Blocked locally by shared opam switch lock held by another concurrent worktree build.
  - This PR remains draft until the focused build can run or CI covers it.
