### PR TITLE
test(goal-loop): close autoboot warmup fairness evidence

### DIFF
--- a/scripts/goal_loop_completion_audit.py
+++ b/scripts/goal_loop_completion_audit.py
@@ -40,6 +40,23 @@ PROMPT_CHECKLIST_ISSUE_REF_RE = re.compile(
 PROMPT_CHECKLIST_PR_REF_RE = re.compile(
     r"^https://github\.com/jeong-sik/masc-mcp/pull/\d+$"
 )
+AUTOBOOT_WARMUP_FAIRNESS_ALGORITHM = "int32_djb2_bounded_jitter"
+AUTOBOOT_WARMUP_REQUIRED_KEEPERS = (
+    "analyst",
+    "executor",
+    "glm-coding-plan",
+    "issue_king",
+    "janitor",
+    "masc-improver",
+    "nick0cave",
+    "qa-king",
+    "ramarama",
+    "sangsu",
+    "scholar",
+    "taskmaster",
+    "velvet-hammer",
+    "verifier",
+)
 PROMPT_SOURCE_PATH_PREFIX = "prompt_corpus/GOAL_LOOP/"
 REPO_ROOT = Path(__file__).resolve().parents[1]
 REQUIRED_VERIFY_GATE_IDS = frozenset(
@@ -112,6 +129,10 @@ def as_int(value: Any) -> int:
     return value if isinstance(value, int) else 0
 
 
+def as_strict_int(value: Any) -> int | None:
+    return value if type(value) is int else None
+
+
 def as_nonempty_str(value: Any) -> str | None:
     if not isinstance(value, str):
         return None
@@ -125,6 +146,13 @@ def string_list(value: Any) -> list[str]:
     return [
         stripped for item in value if (stripped := as_nonempty_str(item)) is not None
     ]
+
+
+def stable_keeper_name_hash(name: str) -> int:
+    acc = 5381
+    for byte in name.encode("utf-8"):
+        acc = ((acc << 5) + acc + byte) & 0x3FFF_FFFF
+    return acc
 
 
 def prompt_source_list(value: Any) -> tuple[list[str], dict[str, Any]]:
@@ -1159,6 +1187,245 @@ def verify_pipeline_evidence(
     }
 
 
+def autoboot_warmup_fairness_evidence(
+    audit_catalog: dict[str, Any],
+    warmup_fairness: dict[str, Any],
+) -> tuple[bool, dict[str, Any]]:
+    scheduler_raw = warmup_fairness.get("scheduler_decision")
+    scheduler = scheduler_raw if isinstance(scheduler_raw, dict) else {}
+    source_catalog_id = audit_catalog.get("catalog_id")
+    evidence_catalog_id = warmup_fairness.get("source_catalog_id")
+    base_warmup = as_strict_int(scheduler.get("base_warmup_sec"))
+    stagger_window = as_strict_int(scheduler.get("stagger_window_sec"))
+    max_delay = as_strict_int(scheduler.get("max_delay_sec"))
+    algorithm = as_nonempty_str(scheduler.get("algorithm"))
+    rows_raw = warmup_fairness.get("keeper_rows", [])
+    rows = rows_raw if isinstance(rows_raw, list) else []
+
+    invalid_reasons: list[str] = []
+
+    def require(condition: bool, reason: str) -> None:
+        if not condition:
+            invalid_reasons.append(reason)
+
+    require(warmup_fairness.get("schema_version") == 1, "schema_version")
+    require(warmup_fairness.get("status") == "PASS", "status")
+    require(
+        isinstance(source_catalog_id, str) and evidence_catalog_id == source_catalog_id,
+        "source_catalog_id",
+    )
+    require(
+        algorithm == AUTOBOOT_WARMUP_FAIRNESS_ALGORITHM,
+        "scheduler_decision.algorithm",
+    )
+    require(base_warmup is not None and base_warmup >= 0, "base_warmup_sec")
+    require(
+        stagger_window is not None and stagger_window >= 0,
+        "stagger_window_sec",
+    )
+    if base_warmup is not None and stagger_window is not None:
+        require(max_delay == base_warmup + stagger_window, "max_delay_sec")
+    else:
+        require(max_delay is not None, "max_delay_sec")
+    require(scheduler.get("position_independent") is True, "position_independent")
+
+    by_name: dict[str, dict[str, Any]] = {}
+    duplicate_keeper_names: set[str] = set()
+    row_errors: list[str] = []
+    warmups: list[int] = []
+    boot_positions: list[int] = []
+    for index, row in enumerate(rows):
+        if not isinstance(row, dict):
+            row_errors.append(f"#{index}: not_object")
+            continue
+        keeper_name = as_nonempty_str(row.get("keeper_name"))
+        if keeper_name is None:
+            row_errors.append(f"#{index}: keeper_name")
+            continue
+        if keeper_name in by_name:
+            duplicate_keeper_names.add(keeper_name)
+        by_name[keeper_name] = row
+        name_hash = as_strict_int(row.get("name_hash"))
+        jitter_bucket = as_strict_int(row.get("jitter_bucket"))
+        warmup_sec = as_strict_int(row.get("warmup_sec"))
+        boot_position = as_strict_int(row.get("boot_position"))
+        if boot_position is not None:
+            boot_positions.append(boot_position)
+        if warmup_sec is not None:
+            warmups.append(warmup_sec)
+        if base_warmup is None or stagger_window is None or stagger_window < 0:
+            continue
+        expected_hash = stable_keeper_name_hash(keeper_name)
+        expected_jitter = (
+            0 if stagger_window == 0 else expected_hash % (stagger_window + 1)
+        )
+        expected_warmup = base_warmup + expected_jitter
+        if name_hash != expected_hash:
+            row_errors.append(f"{keeper_name}: name_hash")
+        if jitter_bucket != expected_jitter:
+            row_errors.append(f"{keeper_name}: jitter_bucket")
+        if warmup_sec != expected_warmup:
+            row_errors.append(f"{keeper_name}: warmup_sec")
+        if warmup_sec is None or max_delay is None:
+            row_errors.append(f"{keeper_name}: warmup_bound")
+        elif not (base_warmup <= warmup_sec <= max_delay):
+            row_errors.append(f"{keeper_name}: warmup_bound")
+        if row.get("within_bound") is not True:
+            row_errors.append(f"{keeper_name}: within_bound")
+
+    required_names = set(AUTOBOOT_WARMUP_REQUIRED_KEEPERS)
+    present_names = set(by_name)
+    missing_keeper_names = sorted(required_names - present_names)
+    unexpected_keeper_names = sorted(present_names - required_names)
+    require(not duplicate_keeper_names, "duplicate_keeper_names")
+    require(not missing_keeper_names, "missing_keeper_names")
+    require(not unexpected_keeper_names, "unexpected_keeper_names")
+    require(len(rows) == len(AUTOBOOT_WARMUP_REQUIRED_KEEPERS), "keeper_rows_total")
+    require(not row_errors, "keeper_rows")
+    require(
+        sorted(boot_positions) == list(range(len(AUTOBOOT_WARMUP_REQUIRED_KEEPERS))),
+        "boot_positions",
+    )
+
+    max_observed_warmup = max(warmups) if warmups else None
+    distinct_warmups = len(set(warmups))
+    if max_delay is not None:
+        require(
+            max_observed_warmup is not None and max_observed_warmup <= max_delay,
+            "max_observed_warmup_sec",
+        )
+    ordered_rows = [
+        row
+        for row in rows
+        if isinstance(row, dict) and as_strict_int(row.get("boot_position")) is not None
+    ]
+    ordered_rows.sort(key=lambda row: as_strict_int(row.get("boot_position")) or 0)
+    observed_by_position = [
+        as_strict_int(row.get("warmup_sec"))
+        for row in ordered_rows
+        if as_strict_int(row.get("warmup_sec")) is not None
+    ]
+    linear_sequence_detected = False
+    if (
+        base_warmup is not None
+        and stagger_window is not None
+        and len(observed_by_position) == len(AUTOBOOT_WARMUP_REQUIRED_KEEPERS)
+    ):
+        linear_sequence_detected = observed_by_position == [
+            base_warmup + (index * stagger_window)
+            for index in range(len(AUTOBOOT_WARMUP_REQUIRED_KEEPERS))
+        ]
+    require(not linear_sequence_detected, "linear_sequence_detected")
+
+    late_raw = warmup_fairness.get("late_keeper_check")
+    late = late_raw if isinstance(late_raw, dict) else {}
+    late_keeper_name = as_nonempty_str(late.get("keeper_name"))
+    late_row = by_name.get(late_keeper_name or "")
+    late_warmup = (
+        as_strict_int(late_row.get("warmup_sec"))
+        if isinstance(late_row, dict)
+        else None
+    )
+    claimed_linear_warmup = as_strict_int(late.get("claimed_linear_warmup_sec"))
+    expected_linear_warmup = (
+        base_warmup + 13 * stagger_window
+        if base_warmup is not None and stagger_window is not None
+        else None
+    )
+    require(late_keeper_name == "verifier", "late_keeper_check.keeper_name")
+    require(as_strict_int(late.get("boot_position")) == 13, "late_keeper_position")
+    require(
+        as_strict_int(late.get("warmup_sec")) == late_warmup,
+        "late_keeper_warmup_sec",
+    )
+    require(
+        expected_linear_warmup is not None
+        and claimed_linear_warmup == expected_linear_warmup,
+        "late_keeper_claimed_linear_warmup_sec",
+    )
+    if max_delay is not None:
+        require(
+            late_warmup is not None and late_warmup <= max_delay,
+            "late_keeper_bounded",
+        )
+    require(late.get("bounded_by_max_delay") is True, "bounded_by_max_delay")
+    require(late.get("not_position_delay") is True, "not_position_delay")
+
+    ordering_raw = warmup_fairness.get("ordering_replay")
+    ordering = ordering_raw if isinstance(ordering_raw, dict) else {}
+    require(ordering.get("status") == "PASS", "ordering_replay.status")
+    require(
+        ordering.get("forward_reverse_stable") is True,
+        "ordering_replay.forward_reverse_stable",
+    )
+    require(
+        as_strict_int(ordering.get("distinct_warmups_min")) is not None
+        and (as_strict_int(ordering.get("distinct_warmups_min")) or 0) >= 3,
+        "ordering_replay.distinct_warmups_min",
+    )
+    require(
+        as_nonempty_str(ordering.get("evidence_ref")) is not None,
+        "ordering_replay.evidence_ref",
+    )
+
+    turn_raw = warmup_fairness.get("post_warmup_turn_outcome")
+    turn = turn_raw if isinstance(turn_raw, dict) else {}
+    require(turn.get("status") == "PASS", "post_warmup_turn_outcome.status")
+    require(
+        turn.get("board_cursor_blocked_until_warmup") is True,
+        "post_warmup_turn_outcome.board_cursor_blocked_until_warmup",
+    )
+    require(
+        turn.get("turn_dispatch_receives_proactive_warmup_elapsed") is True,
+        "post_warmup_turn_outcome.turn_dispatch_receives_proactive_warmup_elapsed",
+    )
+    require(
+        as_nonempty_str(turn.get("evidence_ref")) is not None,
+        "post_warmup_turn_outcome.evidence_ref",
+    )
+
+    implementation_refs = [
+        item
+        for item in string_list(warmup_fairness.get("implementation_pr_refs"))
+        if PROMPT_CHECKLIST_PR_REF_RE.fullmatch(item) is not None
+    ]
+    require(len(implementation_refs) >= 3, "implementation_pr_refs")
+    local_path_leaks = contains_user_local_path(warmup_fairness)
+    require(not local_path_leaks, "local_path_leaks")
+
+    return not invalid_reasons, {
+        "evidence_id": warmup_fairness.get("evidence_id"),
+        "source_catalog_id": source_catalog_id,
+        "evidence_source_catalog_id": evidence_catalog_id,
+        "source_catalog_id_matches": evidence_catalog_id == source_catalog_id,
+        "schema_version": warmup_fairness.get("schema_version"),
+        "status": warmup_fairness.get("status"),
+        "algorithm": algorithm,
+        "base_warmup_sec": base_warmup,
+        "stagger_window_sec": stagger_window,
+        "max_delay_sec": max_delay,
+        "keeper_rows_total": len(rows),
+        "required_keeper_rows_total": len(AUTOBOOT_WARMUP_REQUIRED_KEEPERS),
+        "missing_keeper_names": missing_keeper_names,
+        "unexpected_keeper_names": unexpected_keeper_names,
+        "duplicate_keeper_names": sorted(duplicate_keeper_names),
+        "row_errors": row_errors,
+        "boot_positions": sorted(boot_positions),
+        "max_observed_warmup_sec": max_observed_warmup,
+        "distinct_warmups": distinct_warmups,
+        "linear_sequence_detected": linear_sequence_detected,
+        "late_keeper_name": late_keeper_name,
+        "late_keeper_warmup_sec": late_warmup,
+        "late_keeper_claimed_linear_warmup_sec": claimed_linear_warmup,
+        "ordering_replay_status": ordering.get("status"),
+        "post_warmup_turn_outcome_status": turn.get("status"),
+        "implementation_pr_refs_total": len(implementation_refs),
+        "local_path_leaks": local_path_leaks,
+        "invalid_reasons": invalid_reasons,
+        "recorded": not invalid_reasons,
+    }
+
+
 def build_completion_audit(
     status: dict[str, Any],
     *,
@@ -1168,6 +1435,7 @@ def build_completion_audit(
     prompt_closeout_checklist: dict[str, Any] | None = None,
     source_row_candidate_inventory: dict[str, Any] | None = None,
     verify_pipeline: dict[str, Any] | None = None,
+    autoboot_warmup_fairness: dict[str, Any] | None = None,
 ) -> CompletionAudit:
     audit_catalog = nested_dict(status, "phases", "orient", "summary", "audit_catalog")
     verify_summary = nested_dict(status, "phases", "verify", "summary")
@@ -1447,6 +1715,19 @@ def build_completion_audit(
             verify_evidence,
         ),
     ]
+    if autoboot_warmup_fairness is not None:
+        warmup_passed, warmup_evidence = autoboot_warmup_fairness_evidence(
+            audit_catalog,
+            autoboot_warmup_fairness,
+        )
+        criteria.append(
+            criterion(
+                "autoboot_warmup_fairness_complete",
+                warmup_passed,
+                "Autoboot warmup scheduling is bounded, order-independent, and verified for late keepers.",
+                warmup_evidence,
+            )
+        )
     if prompt_closeout_checklist is not None:
         checklist_passed, checklist_evidence = prompt_closeout_checklist_evidence(
             audit_catalog,
@@ -1586,6 +1867,10 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         help="Optional GOAL LOOP Verify pipeline result JSON to require for closeout.",
     )
     parser.add_argument(
+        "--autoboot-warmup-fairness",
+        help="Optional bounded autoboot warmup fairness evidence JSON.",
+    )
+    parser.add_argument(
         "--require-complete",
         action="store_true",
         help="Exit non-zero unless every completion criterion passes.",
@@ -1607,6 +1892,7 @@ def main(argv: list[str] | None = None) -> int:
             args.source_row_candidate_inventory
         ),
         verify_pipeline=load_optional_json_file(args.verify_pipeline),
+        autoboot_warmup_fairness=load_optional_json_file(args.autoboot_warmup_fairness),
     )
     if args.format == "json":
         print(audit_to_json(audit))

--- a/test/fixtures/goal_loop/autoboot-warmup-fairness.external-claim.json
+++ b/test/fixtures/goal_loop/autoboot-warmup-fairness.external-claim.json
@@ -1,0 +1,163 @@
+{
+  "schema_version": 1,
+  "evidence_id": "goal-loop-autoboot-warmup-fairness-2026-05-06",
+  "source_catalog_id": "goal-loop-206-audit-external-claim-2026-05-05",
+  "status": "PASS",
+  "claim_ref": "NF-5",
+  "checked_at": "2026-05-06T00:00:00Z",
+  "scheduler_decision": {
+    "algorithm": "int32_djb2_bounded_jitter",
+    "base_warmup_sec": 60,
+    "stagger_window_sec": 15,
+    "max_delay_sec": 75,
+    "position_independent": true,
+    "code_refs": [
+      "lib/server/server_bootstrap_loops.ml#autoboot_proactive_warmup_sec",
+      "lib/server/server_bootstrap_loops.ml#autoboot: calling start_keepalive",
+      "lib/keeper/keeper_config.ml#keeper_bootstrap_stagger_step_sec"
+    ]
+  },
+  "keeper_rows": [
+    {
+      "keeper_name": "analyst",
+      "boot_position": 0,
+      "name_hash": 910207873,
+      "jitter_bucket": 1,
+      "warmup_sec": 61,
+      "within_bound": true
+    },
+    {
+      "keeper_name": "executor",
+      "boot_position": 1,
+      "name_hash": 970155828,
+      "jitter_bucket": 4,
+      "warmup_sec": 64,
+      "within_bound": true
+    },
+    {
+      "keeper_name": "glm-coding-plan",
+      "boot_position": 2,
+      "name_hash": 846962750,
+      "jitter_bucket": 14,
+      "warmup_sec": 74,
+      "within_bound": true
+    },
+    {
+      "keeper_name": "issue_king",
+      "boot_position": 3,
+      "name_hash": 879175606,
+      "jitter_bucket": 6,
+      "warmup_sec": 66,
+      "within_bound": true
+    },
+    {
+      "keeper_name": "janitor",
+      "boot_position": 4,
+      "name_hash": 228803004,
+      "jitter_bucket": 12,
+      "warmup_sec": 72,
+      "within_bound": true
+    },
+    {
+      "keeper_name": "masc-improver",
+      "boot_position": 5,
+      "name_hash": 845147082,
+      "jitter_bucket": 10,
+      "warmup_sec": 70,
+      "within_bound": true
+    },
+    {
+      "keeper_name": "nick0cave",
+      "boot_position": 6,
+      "name_hash": 680489273,
+      "jitter_bucket": 9,
+      "warmup_sec": 69,
+      "within_bound": true
+    },
+    {
+      "keeper_name": "qa-king",
+      "boot_position": 7,
+      "name_hash": 602119181,
+      "jitter_bucket": 13,
+      "warmup_sec": 73,
+      "within_bound": true
+    },
+    {
+      "keeper_name": "ramarama",
+      "boot_position": 8,
+      "name_hash": 556982023,
+      "jitter_bucket": 7,
+      "warmup_sec": 67,
+      "within_bound": true
+    },
+    {
+      "keeper_name": "sangsu",
+      "boot_position": 9,
+      "name_hash": 456762646,
+      "jitter_bucket": 6,
+      "warmup_sec": 66,
+      "within_bound": true
+    },
+    {
+      "keeper_name": "scholar",
+      "boot_position": 10,
+      "name_hash": 112216369,
+      "jitter_bucket": 1,
+      "warmup_sec": 61,
+      "within_bound": true
+    },
+    {
+      "keeper_name": "taskmaster",
+      "boot_position": 11,
+      "name_hash": 19339588,
+      "jitter_bucket": 4,
+      "warmup_sec": 64,
+      "within_bound": true
+    },
+    {
+      "keeper_name": "velvet-hammer",
+      "boot_position": 12,
+      "name_hash": 929304706,
+      "jitter_bucket": 2,
+      "warmup_sec": 62,
+      "within_bound": true
+    },
+    {
+      "keeper_name": "verifier",
+      "boot_position": 13,
+      "name_hash": 307708225,
+      "jitter_bucket": 1,
+      "warmup_sec": 61,
+      "within_bound": true
+    }
+  ],
+  "late_keeper_check": {
+    "keeper_name": "verifier",
+    "boot_position": 13,
+    "warmup_sec": 61,
+    "claimed_linear_warmup_sec": 255,
+    "bounded_by_max_delay": true,
+    "not_position_delay": true
+  },
+  "ordering_replay": {
+    "status": "PASS",
+    "evidence_ref": "test/test_env_config_keeper_bootstrap_intervals.ml#test_autoboot_warmup_is_order_independent",
+    "forward_reverse_stable": true,
+    "distinct_warmups_min": 3
+  },
+  "post_warmup_turn_outcome": {
+    "status": "PASS",
+    "evidence_ref": "lib/keeper/keeper_heartbeat_loop.ml#proactive_warmup_elapsed",
+    "condition": "proactive_warmup_sec <= 0 || now_ts - keepalive_started_ts >= proactive_warmup_sec",
+    "board_cursor_blocked_until_warmup": true,
+    "turn_dispatch_receives_proactive_warmup_elapsed": true
+  },
+  "implementation_pr_refs": [
+    "https://github.com/jeong-sik/masc-mcp/pull/13119",
+    "https://github.com/jeong-sik/masc-mcp/pull/13156",
+    "https://github.com/jeong-sik/masc-mcp/pull/13167"
+  ],
+  "tracking_issue_refs": [
+    "https://github.com/jeong-sik/masc-mcp/issues/13690"
+  ]
+}

--- a/test/fixtures/goal_loop/prompt-closeout-checklist.external-claim.json
+++ b/test/fixtures/goal_loop/prompt-closeout-checklist.external-claim.json
@@ -123,15 +123,18 @@
       "prompt_requirement": "Linear autoboot warmup visibility",
       "artifact_refs": [
         "test/fixtures/goal_loop/audit-corpus.external-claim.json#NF-5",
-        "test/fixtures/goal_loop/orient.startup.json"
+        "test/fixtures/goal_loop/orient.startup.json",
+        "test/fixtures/goal_loop/autoboot-warmup-fairness.external-claim.json",
+        "lib/server/server_bootstrap_loops.ml#autoboot_proactive_warmup_sec",
+        "test/test_env_config_keeper_bootstrap_intervals.ml#test_autoboot_warmup_jitter_is_bounded_not_linear"
       ],
-      "status": "PARTIAL",
-      "criterion_id": "strict_row_level_catalog_complete",
-      "gap": "Source claim is tracked, but no full row-level replay proves the warmup behavior is closed.",
-      "tracking_issue_refs": [
-        "https://github.com/jeong-sik/masc-mcp/issues/13265",
-        "https://github.com/jeong-sik/masc-mcp/issues/13690",
-        "https://github.com/jeong-sik/masc-mcp/issues/13636"
+      "status": "PASS",
+      "criterion_id": "autoboot_warmup_fairness_complete",
+      "gap": null,
+      "implementation_pr_refs": [
+        "https://github.com/jeong-sik/masc-mcp/pull/13119",
+        "https://github.com/jeong-sik/masc-mcp/pull/13156",
+        "https://github.com/jeong-sik/masc-mcp/pull/13167"
       ]
     },
     {

--- a/test/test_goal_loop_completion_audit.py
+++ b/test/test_goal_loop_completion_audit.py
@@ -1150,8 +1150,15 @@ class GoalLoopCompletionAuditTest(unittest.TestCase):
         )
         keeper_rows = warmup_fairness["keeper_rows"]
         assert isinstance(keeper_rows, list)
-        verifier_row = keeper_rows[-1]
-        assert isinstance(verifier_row, dict)
+        # Locate the verifier row by keeper_name rather than positional
+        # index so the test stays correct under any harmless fixture
+        # reordering.
+        verifier_row = next(
+            (row for row in keeper_rows
+             if isinstance(row, dict) and row.get("keeper_name") == "verifier"),
+            None,
+        )
+        assert verifier_row is not None, "fixture must contain a verifier row"
         verifier_row["warmup_sec"] = 255
         verifier_row["within_bound"] = False
         late_check = warmup_fairness["late_keeper_check"]

--- a/test/test_goal_loop_completion_audit.py
+++ b/test/test_goal_loop_completion_audit.py
@@ -34,6 +34,13 @@ PROMPT_CHECKLIST_FIXTURE = (
     / "goal_loop"
     / "prompt-closeout-checklist.external-claim.json"
 )
+AUTOBOOT_WARMUP_FAIRNESS_FIXTURE = (
+    REPO_ROOT
+    / "test"
+    / "fixtures"
+    / "goal_loop"
+    / "autoboot-warmup-fairness.external-claim.json"
+)
 SOURCE_ROW_CANDIDATE_INVENTORY_FIXTURE = (
     REPO_ROOT
     / "test"
@@ -1060,9 +1067,13 @@ class GoalLoopCompletionAuditTest(unittest.TestCase):
 
     def test_completion_audit_attaches_prompt_closeout_checklist(self) -> None:
         checklist = json.loads(PROMPT_CHECKLIST_FIXTURE.read_text(encoding="utf-8"))
+        warmup_fairness = json.loads(
+            AUTOBOOT_WARMUP_FAIRNESS_FIXTURE.read_text(encoding="utf-8")
+        )
         audit = goal_loop_completion_audit.build_completion_audit(
             strict_catalog_only_blocked_status(),
             prompt_closeout_checklist=checklist,
+            autoboot_warmup_fairness=warmup_fairness,
         )
 
         self.assertEqual(audit.status, "BLOCKED")
@@ -1080,46 +1091,86 @@ class GoalLoopCompletionAuditTest(unittest.TestCase):
         self.assertTrue(checklist_evidence["has_strict_corpus_blocker"])
         self.assertFalse(checklist_evidence["local_path_leaks"])
         self.assertEqual(checklist_evidence["requirements_total"], 21)
-        self.assertEqual(checklist_evidence["status_counts"]["PASS"], 5)
-        self.assertEqual(checklist_evidence["status_counts"]["PARTIAL"], 14)
+        self.assertEqual(checklist_evidence["status_counts"]["PASS"], 6)
+        self.assertEqual(checklist_evidence["status_counts"]["PARTIAL"], 13)
         self.assertEqual(checklist_evidence["status_counts"]["BLOCKED"], 2)
-        self.assertEqual(checklist_evidence["non_pass_requirements"], 16)
+        self.assertEqual(checklist_evidence["non_pass_requirements"], 15)
         self.assertEqual(
             checklist_evidence["requirements_with_tracking_issue_refs"],
-            16,
+            15,
         )
-        self.assertEqual(checklist_evidence["tracking_issue_refs_total"], 12)
+        self.assertEqual(checklist_evidence["tracking_issue_refs_total"], 11)
         self.assertEqual(checklist_evidence["missing_tracking_issue_refs"], [])
         self.assertEqual(checklist_evidence["invalid_tracking_issue_refs"], [])
         self.assertEqual(
             checklist_evidence["requirements_with_implementation_pr_refs"],
-            9,
+            10,
         )
-        self.assertEqual(checklist_evidence["implementation_pr_refs_total"], 6)
+        self.assertEqual(checklist_evidence["implementation_pr_refs_total"], 9)
         self.assertEqual(checklist_evidence["invalid_implementation_pr_refs"], [])
-        self.assertEqual(checklist_evidence["artifact_refs_total"], 72)
-        self.assertEqual(checklist_evidence["artifact_refs_resolved"], 72)
-        self.assertEqual(checklist_evidence["artifact_ref_anchors_total"], 7)
-        self.assertEqual(checklist_evidence["artifact_ref_anchors_resolved"], 7)
+        self.assertEqual(checklist_evidence["artifact_refs_total"], 75)
+        self.assertEqual(checklist_evidence["artifact_refs_resolved"], 75)
+        self.assertEqual(checklist_evidence["artifact_ref_anchors_total"], 9)
+        self.assertEqual(checklist_evidence["artifact_ref_anchors_resolved"], 9)
         self.assertTrue(checklist_evidence["artifact_refs_all_resolved"])
         self.assertEqual(checklist_evidence["missing_artifact_refs"], [])
         self.assertEqual(checklist_evidence["missing_artifact_ref_anchors"], [])
         self.assertEqual(checklist_evidence["invalid_artifact_refs"], [])
+        warmup_evidence = by_id["autoboot_warmup_fairness_complete"].evidence
+        self.assertEqual(by_id["autoboot_warmup_fairness_complete"].status, "PASS")
+        self.assertEqual(warmup_evidence["late_keeper_name"], "verifier")
+        self.assertEqual(warmup_evidence["late_keeper_warmup_sec"], 61)
+        self.assertEqual(
+            warmup_evidence["late_keeper_claimed_linear_warmup_sec"],
+            255,
+        )
+        self.assertFalse(warmup_evidence["linear_sequence_detected"])
+        self.assertEqual(warmup_evidence["max_observed_warmup_sec"], 74)
         closeout_evidence = by_id["prompt_requirements_closeout_complete"].evidence
         self.assertEqual(by_id["prompt_requirements_closeout_complete"].status, "FAIL")
-        self.assertEqual(closeout_evidence["incomplete_requirements"], 16)
-        self.assertEqual(closeout_evidence["non_pass_requirements"], 16)
+        self.assertEqual(closeout_evidence["incomplete_requirements"], 15)
+        self.assertEqual(closeout_evidence["non_pass_requirements"], 15)
         self.assertEqual(
             closeout_evidence["requirements_with_tracking_issue_refs"],
-            16,
+            15,
         )
         self.assertEqual(
             closeout_evidence["requirements_with_implementation_pr_refs"],
-            9,
+            10,
         )
-        self.assertEqual(closeout_evidence["implementation_pr_refs_total"], 6)
+        self.assertEqual(closeout_evidence["implementation_pr_refs_total"], 9)
         self.assertEqual(closeout_evidence["invalid_implementation_pr_refs"], [])
         self.assertTrue(closeout_evidence["has_strict_corpus_blocker"])
+
+    def test_completion_audit_rejects_unbounded_autoboot_warmup_fairness(
+        self,
+    ) -> None:
+        warmup_fairness = json.loads(
+            AUTOBOOT_WARMUP_FAIRNESS_FIXTURE.read_text(encoding="utf-8")
+        )
+        keeper_rows = warmup_fairness["keeper_rows"]
+        assert isinstance(keeper_rows, list)
+        verifier_row = keeper_rows[-1]
+        assert isinstance(verifier_row, dict)
+        verifier_row["warmup_sec"] = 255
+        verifier_row["within_bound"] = False
+        late_check = warmup_fairness["late_keeper_check"]
+        assert isinstance(late_check, dict)
+        late_check["warmup_sec"] = 255
+        late_check["bounded_by_max_delay"] = False
+
+        audit = goal_loop_completion_audit.build_completion_audit(
+            complete_status(),
+            autoboot_warmup_fairness=warmup_fairness,
+        )
+
+        self.assertEqual(audit.status, "BLOCKED")
+        self.assertIn("autoboot_warmup_fairness_complete", audit.blockers)
+        by_id = {item.criterion_id: item for item in audit.criteria}
+        warmup_evidence = by_id["autoboot_warmup_fairness_complete"].evidence
+        self.assertIn("keeper_rows", warmup_evidence["invalid_reasons"])
+        self.assertIn("max_observed_warmup_sec", warmup_evidence["invalid_reasons"])
+        self.assertIn("bounded_by_max_delay", warmup_evidence["invalid_reasons"])
 
     def test_completion_audit_rejects_invalid_closeout_prompt_sources(
         self,
@@ -1306,8 +1357,8 @@ class GoalLoopCompletionAuditTest(unittest.TestCase):
         checklist_evidence = by_id["prompt_to_artifact_checklist_recorded"].evidence
         self.assertFalse(checklist_evidence["recorded"])
         self.assertFalse(checklist_evidence["artifact_refs_all_resolved"])
-        self.assertEqual(checklist_evidence["artifact_refs_total"], 71)
-        self.assertEqual(checklist_evidence["artifact_refs_resolved"], 70)
+        self.assertEqual(checklist_evidence["artifact_refs_total"], 74)
+        self.assertEqual(checklist_evidence["artifact_refs_resolved"], 73)
         self.assertEqual(
             checklist_evidence["missing_artifact_refs"],
             [
@@ -1341,10 +1392,10 @@ class GoalLoopCompletionAuditTest(unittest.TestCase):
         checklist_evidence = by_id["prompt_to_artifact_checklist_recorded"].evidence
         self.assertFalse(checklist_evidence["recorded"])
         self.assertFalse(checklist_evidence["artifact_refs_all_resolved"])
-        self.assertEqual(checklist_evidence["artifact_refs_total"], 70)
-        self.assertEqual(checklist_evidence["artifact_refs_resolved"], 69)
-        self.assertEqual(checklist_evidence["artifact_ref_anchors_total"], 7)
-        self.assertEqual(checklist_evidence["artifact_ref_anchors_resolved"], 6)
+        self.assertEqual(checklist_evidence["artifact_refs_total"], 73)
+        self.assertEqual(checklist_evidence["artifact_refs_resolved"], 72)
+        self.assertEqual(checklist_evidence["artifact_ref_anchors_total"], 9)
+        self.assertEqual(checklist_evidence["artifact_ref_anchors_resolved"], 8)
         self.assertEqual(
             checklist_evidence["missing_artifact_ref_anchors"],
             [
@@ -1393,8 +1444,8 @@ class GoalLoopCompletionAuditTest(unittest.TestCase):
         checklist_evidence = by_id["prompt_to_artifact_checklist_recorded"].evidence
         self.assertFalse(checklist_evidence["recorded"])
         self.assertFalse(checklist_evidence["artifact_refs_all_resolved"])
-        self.assertEqual(checklist_evidence["artifact_ref_anchors_total"], 7)
-        self.assertEqual(checklist_evidence["artifact_ref_anchors_resolved"], 6)
+        self.assertEqual(checklist_evidence["artifact_ref_anchors_total"], 9)
+        self.assertEqual(checklist_evidence["artifact_ref_anchors_resolved"], 8)
         self.assertEqual(
             checklist_evidence["artifact_ref_read_errors"],
             [
@@ -1532,6 +1583,8 @@ class GoalLoopCompletionAuditTest(unittest.TestCase):
                     str(SOURCE_ROW_CANDIDATE_INVENTORY_FIXTURE),
                     "--verify-pipeline",
                     str(pipeline_path),
+                    "--autoboot-warmup-fairness",
+                    str(AUTOBOOT_WARMUP_FAIRNESS_FIXTURE),
                     "--require-complete",
                 ],
                 text=True,
@@ -1571,7 +1624,10 @@ class GoalLoopCompletionAuditTest(unittest.TestCase):
         self.assertEqual(prompt_checklist["status"], "PASS")
         prompt_closeout = by_id["prompt_requirements_closeout_complete"]
         self.assertEqual(prompt_closeout["status"], "FAIL")
-        self.assertEqual(prompt_closeout["evidence"]["incomplete_requirements"], 16)
+        self.assertEqual(prompt_closeout["evidence"]["incomplete_requirements"], 15)
+        warmup_fairness = by_id["autoboot_warmup_fairness_complete"]
+        self.assertEqual(warmup_fairness["status"], "PASS")
+        self.assertEqual(warmup_fairness["evidence"]["late_keeper_warmup_sec"], 61)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- add a machine-validated autoboot warmup fairness evidence fixture for NF-5 / #13690
- teach `goal_loop_completion_audit.py` to recompute the Int32 djb2 bounded-jitter schedule and fail unbounded or linear warmup evidence
- move `linear-autoboot-warmup` from PARTIAL to PASS in the prompt closeout checklist, backed by the new fixture and existing warmup regression tests

## Why

The prompt closeout row was stuck on umbrella blockers even though current runtime code no longer uses the logged linear 60s -> 255s schedule. This PR makes that closure auditable: the evidence records all 14 keeper warmups, checks `verifier` specifically, and ties post-warmup turn dispatch to the existing `proactive_warmup_elapsed` gate.

Closes #13690.

## Validation

- `ruff check scripts/goal_loop_completion_audit.py test/test_goal_loop_completion_audit.py`
- `ruff format --check scripts/goal_loop_completion_audit.py test/test_goal_loop_completion_audit.py`
- `python3 -m py_compile scripts/goal_loop_completion_audit.py test/test_goal_loop_completion_audit.py`
- `python3 test/test_goal_loop_completion_audit.py`
- `git diff --check`
- `scripts/dune-local.sh build test/test_env_config_keeper_bootstrap_intervals.exe` attempted after rebasing to `origin/main` 91316e2f7c, but it is blocked by unrelated current-main keeper compile errors now tracked in #13817.
