### PR TITLE
feat(dashboard): expose branch selector feed

### DIFF
--- a/lib/dashboard/dashboard_branches.ml
+++ b/lib/dashboard/dashboard_branches.ml
@@ -1,0 +1,205 @@
+(** Dashboard_branches — live git branch selector data.
+
+    This backs [/api/v1/dashboard/branches] with repo-local git state instead of
+    CI-time branch environment variables. *)
+
+type branch_status =
+  | Clean
+  | Ahead
+  | Behind
+  | Diverged
+  | Untracked
+
+type branch_entry =
+  { name : string
+  ; tag : string option
+  ; status : branch_status
+  ; ahead : int
+  ; behind : int
+  ; head : string
+  ; keepers : string list
+  }
+
+let exec_gate_raw_source argv = String.concat " " (List.map Filename.quote argv)
+
+let run_git ~repo args =
+  let argv = [ "git"; "-C"; repo; "--no-optional-locks" ] @ args in
+  Masc_exec.Exec_gate.run_argv
+    ~actor:"dashboard/branches"
+    ~raw_source:(exec_gate_raw_source argv)
+    ~summary:"dashboard branches git"
+    ~timeout_sec:Env_config_runtime.Coord_git.local_op_timeout_sec
+    argv
+;;
+
+let first_nonempty_line output =
+  output
+  |> String.split_on_char '\n'
+  |> List.map String.trim
+  |> List.find_opt (fun s -> s <> "")
+;;
+
+let parse_branch_ref_line line =
+  match String.split_on_char '\t' line with
+  | [ name; head ] ->
+    let name = String.trim name in
+    let head = String.trim head in
+    if name = "" || head = "" then None else Some (name, head)
+  | _ -> None
+;;
+
+let parse_branch_refs output =
+  output |> String.split_on_char '\n' |> List.filter_map parse_branch_ref_line
+;;
+
+let parse_ahead_behind output =
+  match String.split_on_char '\t' (String.trim output) with
+  | [ ahead; behind ] ->
+    (match int_of_string_opt ahead, int_of_string_opt behind with
+     | Some ahead, Some behind -> Some (ahead, behind)
+     | _ -> None)
+  | _ -> None
+;;
+
+let status_of_counts ~has_upstream ~ahead ~behind =
+  if not has_upstream
+  then Untracked
+  else (
+    match ahead, behind with
+    | 0, 0 -> Clean
+    | _, 0 when ahead > 0 -> Ahead
+    | 0, _ when behind > 0 -> Behind
+    | _ -> Diverged)
+;;
+
+let status_to_string = function
+  | Clean -> "clean"
+  | Ahead -> "ahead"
+  | Behind -> "behind"
+  | Diverged -> "diverged"
+  | Untracked -> "untracked"
+;;
+
+let current_branch ~repo =
+  try first_nonempty_line (run_git ~repo [ "branch"; "--show-current" ]) with
+  | _ -> None
+;;
+
+let upstream_for_branch ~repo branch =
+  try
+    run_git ~repo [ "rev-parse"; "--abbrev-ref"; branch ^ "@{upstream}" ]
+    |> first_nonempty_line
+  with
+  | _ -> None
+;;
+
+let ahead_behind_for_branch ~repo branch upstream =
+  try
+    run_git ~repo [ "rev-list"; "--left-right"; "--count"; branch ^ "..." ^ upstream ]
+    |> parse_ahead_behind
+  with
+  | _ -> None
+;;
+
+let keepers_by_branch ~config =
+  let tasks = if Coord.is_initialized config then Coord.get_tasks_safe config else [] in
+  let branch_by_task_id =
+    tasks
+    |> List.filter_map (fun (task : Masc_domain.task) ->
+      match task.worktree with
+      | Some worktree when String.trim worktree.branch <> "" ->
+        Some (task.id, String.trim worktree.branch)
+      | _ -> None)
+  in
+  let add_keeper acc branch keeper =
+    let existing =
+      match List.assoc_opt branch acc with
+      | Some keepers -> keepers
+      | None -> []
+    in
+    let updated = if List.mem keeper existing then existing else keeper :: existing in
+    (branch, updated) :: List.remove_assoc branch acc
+  in
+  Keeper_registry.all ()
+  |> List.fold_left
+       (fun acc (entry : Keeper_registry.registry_entry) ->
+          match entry.meta.current_task_id with
+          | None -> acc
+          | Some task_id ->
+            let task_id = Keeper_id.Task_id.to_string task_id in
+            (match List.assoc_opt task_id branch_by_task_id with
+             | None -> acc
+             | Some branch -> add_keeper acc branch entry.meta.name))
+       []
+  |> List.map (fun (branch, keepers) -> branch, List.sort String.compare keepers)
+;;
+
+let build_entry ~repo ~current ~keepers_by_branch (name, head) =
+  let upstream = upstream_for_branch ~repo name in
+  let ahead, behind =
+    match upstream with
+    | None -> 0, 0
+    | Some upstream ->
+      Option.value ~default:(0, 0) (ahead_behind_for_branch ~repo name upstream)
+  in
+  let tag =
+    match current with
+    | Some branch when String.equal branch name -> Some "current"
+    | _ -> None
+  in
+  { name
+  ; tag
+  ; status = status_of_counts ~has_upstream:(Option.is_some upstream) ~ahead ~behind
+  ; ahead
+  ; behind
+  ; head
+  ; keepers = Option.value ~default:[] (List.assoc_opt name keepers_by_branch)
+  }
+;;
+
+let list_entries ~config =
+  let repo = Keeper_alerting_path.project_root_of_config config in
+  let refs =
+    run_git
+      ~repo
+      [ "for-each-ref"; "--format=%(refname:short)%09%(objectname)"; "refs/heads" ]
+    |> parse_branch_refs
+  in
+  let current = current_branch ~repo in
+  let keepers_by_branch = keepers_by_branch ~config in
+  refs
+  |> List.map (build_entry ~repo ~current ~keepers_by_branch)
+  |> List.sort (fun a b -> String.compare a.name b.name)
+;;
+
+let entry_to_json entry =
+  `Assoc
+    [ "name", `String entry.name
+    ; "tag", Json_util.string_opt_to_json entry.tag
+    ; "status", `String (status_to_string entry.status)
+    ; "ahead", `Int entry.ahead
+    ; "behind", `Int entry.behind
+    ; "head", `String entry.head
+    ; "keepers", `List (List.map (fun keeper -> `String keeper) entry.keepers)
+    ]
+;;
+
+let json ~config =
+  try
+    let branches = list_entries ~config in
+    `Assoc
+      [ "generated_at", `String (Masc_domain.now_iso ())
+      ; "repo", `String (Keeper_alerting_path.project_root_of_config config)
+      ; "count", `Int (List.length branches)
+      ; "branches", `List (List.map entry_to_json branches)
+      ]
+  with
+  | exn ->
+    `Assoc
+      [ "generated_at", `String (Masc_domain.now_iso ())
+      ; "repo", `String (Keeper_alerting_path.project_root_of_config config)
+      ; "count", `Int 0
+      ; "branches", `List []
+      ; "error", `String (Printexc.to_string exn)
+      ]
+;;

--- a/lib/dashboard/dashboard_branches.mli
+++ b/lib/dashboard/dashboard_branches.mli
@@ -1,0 +1,26 @@
+type branch_status =
+  | Clean
+  | Ahead
+  | Behind
+  | Diverged
+  | Untracked
+
+type branch_entry =
+  { name : string
+  ; tag : string option
+  ; status : branch_status
+  ; ahead : int
+  ; behind : int
+  ; head : string
+  ; keepers : string list
+  }
+
+val parse_branch_ref_line : string -> (string * string) option
+val parse_branch_refs : string -> (string * string) list
+val parse_ahead_behind : string -> (int * int) option
+val status_of_counts : has_upstream:bool -> ahead:int -> behind:int -> branch_status
+val status_to_string : branch_status -> string
+val keepers_by_branch : config:Coord.config -> (string * string list) list
+val list_entries : config:Coord.config -> branch_entry list
+val entry_to_json : branch_entry -> Yojson.Safe.t
+val json : config:Coord.config -> Yojson.Safe.t

--- a/lib/server/server_h2_gateway.ml
+++ b/lib/server/server_h2_gateway.ml
@@ -562,6 +562,13 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
             in
             h2_respond_json h2_reqd (Yojson.Safe.to_string json) ~extra_headers:cors)
 
+      | `GET, "/api/v1/dashboard/branches" ->
+          with_server_state h2_reqd (fun state ->
+            let json =
+              Dashboard_branches.json ~config:state.Mcp_server.room_config
+            in
+            h2_respond_json h2_reqd (Yojson.Safe.to_string json) ~extra_headers:cors)
+
       | `GET, "/api/v1/dashboard/config" ->
           let json = Env_config_introspect.to_json () in
           h2_respond_json h2_reqd (Yojson.Safe.to_string json) ~extra_headers:cors

--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -339,6 +339,11 @@ let rec add_routes ~sw ~clock router =
          in
          Http.Response.json ~compress:true ~request:req (Yojson.Safe.to_string json) reqd
        ) request reqd)
+  |> Http.Router.get "/api/v1/dashboard/branches" (fun request reqd ->
+       with_public_read (fun state req reqd ->
+         let json = Dashboard_branches.json ~config:state.Mcp_server.room_config in
+         Http.Response.json ~compress:true ~request:req (Yojson.Safe.to_string json) reqd
+       ) request reqd)
   (* Dev-only shared bearer for the dashboard UI. Served exclusively when the
      server binds to loopback and strict-auth env overrides are disabled, so
      that a LAN deployment never hands out a token over the wire. The token is

--- a/test/dune
+++ b/test/dune
@@ -35,6 +35,7 @@
         test_sidecar_lifecycle_routes
         test_channel_gate_imessage_state
         test_dashboard
+        test_dashboard_branches
         test_dashboard_perf
         test_dashboard_tool_host_events
         test_tool_assignment_telemetry
@@ -252,6 +253,7 @@
         test_sidecar_lifecycle_routes
           test_channel_gate_imessage_state
           test_dashboard
+          test_dashboard_branches
           test_dashboard_perf
           test_dashboard_tool_host_events
           test_tool_assignment_telemetry

--- a/test/test_dashboard_branches.ml
+++ b/test/test_dashboard_branches.ml
@@ -1,0 +1,86 @@
+module DB = Masc_mcp.Dashboard_branches
+
+let check = Alcotest.check
+
+let test_parse_branch_refs () =
+  let refs =
+    DB.parse_branch_refs "main\t0123456789abcdef\nfeature/a\tabcdef0123456789\n\nbad\n"
+  in
+  check
+    Alcotest.(list (pair string string))
+    "refs"
+    [ "main", "0123456789abcdef"; "feature/a", "abcdef0123456789" ]
+    refs
+;;
+
+let test_parse_ahead_behind () =
+  check
+    Alcotest.(option (pair int int))
+    "ahead behind"
+    (Some (2, 5))
+    (DB.parse_ahead_behind "2\t5\n");
+  check Alcotest.(option (pair int int)) "malformed" None (DB.parse_ahead_behind "x\t5\n")
+;;
+
+let test_status_of_counts () =
+  check
+    Alcotest.string
+    "no upstream"
+    "untracked"
+    (DB.status_to_string (DB.status_of_counts ~has_upstream:false ~ahead:0 ~behind:0));
+  check
+    Alcotest.string
+    "clean"
+    "clean"
+    (DB.status_to_string (DB.status_of_counts ~has_upstream:true ~ahead:0 ~behind:0));
+  check
+    Alcotest.string
+    "ahead"
+    "ahead"
+    (DB.status_to_string (DB.status_of_counts ~has_upstream:true ~ahead:2 ~behind:0));
+  check
+    Alcotest.string
+    "behind"
+    "behind"
+    (DB.status_to_string (DB.status_of_counts ~has_upstream:true ~ahead:0 ~behind:3));
+  check
+    Alcotest.string
+    "diverged"
+    "diverged"
+    (DB.status_to_string (DB.status_of_counts ~has_upstream:true ~ahead:2 ~behind:3))
+;;
+
+let test_entry_to_json () =
+  let json =
+    DB.entry_to_json
+      { DB.name = "feature/x"
+      ; tag = Some "current"
+      ; status = DB.Ahead
+      ; ahead = 2
+      ; behind = 0
+      ; head = "abc123"
+      ; keepers = [ "sangsu"; "younghee" ]
+      }
+  in
+  let open Yojson.Safe.Util in
+  check Alcotest.string "name" "feature/x" (json |> member "name" |> to_string);
+  check Alcotest.string "status" "ahead" (json |> member "status" |> to_string);
+  check Alcotest.int "ahead" 2 (json |> member "ahead" |> to_int);
+  check
+    Alcotest.(list string)
+    "keepers"
+    [ "sangsu"; "younghee" ]
+    (json |> member "keepers" |> to_list |> List.map to_string)
+;;
+
+let () =
+  Alcotest.run
+    "dashboard_branches"
+    [ ( "branches"
+      , [ Alcotest.test_case "parse branch refs" `Quick test_parse_branch_refs
+        ; Alcotest.test_case "parse ahead behind" `Quick test_parse_ahead_behind
+        ; Alcotest.test_case "status of counts" `Quick test_status_of_counts
+        ; Alcotest.test_case "entry json" `Quick test_entry_to_json
+        ] )
+    ]
+;;


### PR DESCRIPTION
## Summary

- add `/api/v1/dashboard/branches` for the Phase 2 I0-A branch selector backend
- return live local branch rows with `name`, `tag`, `status`, `ahead`, `behind`, `head`, and assigned `keepers`
- wire the route through both HTTP/1 dashboard routes and the H2 gateway

## Product impact

The dashboard can now mount a branch selector from live repo state instead of CI-time or mock branch assumptions. This keeps branch status and keeper assignment visible as an operator-facing read model.

## Evidence

- `dune build --root . test/test_dashboard_branches.exe`
- `./_build/default/test/test_dashboard_branches.exe`
- `ocamlformat --check lib/dashboard/dashboard_branches.ml lib/dashboard/dashboard_branches.mli test/test_dashboard_branches.ml`
- `git diff --check origin/main..HEAD`

## Review evidence

Focused tests cover branch ref parsing, ahead/behind parsing, status mapping, and the JSON row contract used by `/api/v1/dashboard/branches`.

## Linked issue

Fixes #11577.

## Notes

Based directly on current `main`; the earlier compile-repair stack has landed.
