### PR TITLE
Split keeper lifecycle reprobe into create and review phases

### DIFF
--- a/docs/KEEPER-DOCKER-PR-LIFECYCLE-REPROBE.md
+++ b/docs/KEEPER-DOCKER-PR-LIFECYCLE-REPROBE.md
@@ -14,7 +14,7 @@ audit gates. The audit script can detect missing evidence; this reprobe runner
 adds the operator action loop:
 
 1. discover Docker keepers,
-2. render a per-keeper proof prompt,
+2. render per-keeper create/review phase prompts,
 3. optionally send the prompt through `masc_keeper_msg`,
 4. poll `masc_keeper_msg_result`,
 5. run `audit-keeper-fleet-readiness.py --require-docker-pr-lifecycle-evidence --evidence-run-id <run_id>`,
@@ -44,13 +44,14 @@ continues), and `server_health_missing_commit` (the response was reachable
 but lacked `build.commit`, also treated as transient). Only the first
 status records pending requests as lost; the other two log a transient
 notice and the next poll iteration retries.
-When mutation is enabled, the harness sends `required_tools` with each
-`masc_keeper_msg` call. By default that one-turn contract requires
-`keeper_shell`, `keeper_bash`, `keeper_pr_create`, and
-`keeper_pr_review_comment`, so the runtime records `tool_surface_mismatch` if
-those tools are not visible and `missing_required_tool_use` if the keeper
-replies without exercising them.
-The prompt reserves `keeper_shell` for read-only GitHub inspection.
+When mutation is enabled, the harness sends two sequential phases. The create phase
+requires `keeper_bash` and `keeper_pr_create`. After all create requests
+reach terminal status, the review phase requires `keeper_shell` and
+`keeper_pr_review_comment`. This avoids the old single-turn shape where one
+keeper could wait on another keeper's missing PR until the Agent.run timeout.
+The review prompt reserves `keeper_shell` for read-only GitHub inspection and
+instructs keepers to report `target_pr_missing` after one failed branch lookup
+instead of polling in a loop.
 Keepers must create/use the exact run-scoped branch
 `keeper/<keeper>-docker-pr-proof-<run_id>` and proof file
 `docs/runtime-proof/keepers/<keeper>-<run_id>.md`; older proof branches or
@@ -61,8 +62,10 @@ keeper must stop and report that blocker instead of falling back to host-local
 credentials.
 PR create/review mutations should use `keeper_pr_create` /
 `keeper_pr_review_comment` rather than `gh pr ...` through shell tools.
-Override the CSV with `REQUIRED_TOOLS=...` for a narrower or broader proof
-lane.
+Override the phase CSVs with `CREATE_REQUIRED_TOOLS=...` and
+`REVIEW_REQUIRED_TOOLS=...` when debugging a narrower or broader proof lane.
+The older `REQUIRED_TOOLS=...` override is still accepted as a legacy shortcut
+and is applied to both phases only when the phase-specific variables are unset.
 `MSG_TIMEOUT_SEC` only bounds the harness HTTP request to the MCP server.
 The keeper's actual Agent.run budget is sent separately as
 `masc_keeper_msg.timeout_sec` through `KEEPER_TURN_TIMEOUT_SEC`, which defaults

--- a/scripts/harness/workload/keeper_docker_pr_lifecycle_reprobe.sh
+++ b/scripts/harness/workload/keeper_docker_pr_lifecycle_reprobe.sh
@@ -970,8 +970,16 @@ result_is_terminal() {
 
 poll_results() {
   local phase="$1"
+  # Honor MUTATE_POLL_DEADLINE_TS when the caller has already opened the
+  # phase loop with a shared overall budget (split keeper lifecycle PR
+  # #13842). Falling back to the per-call POLL_TIMEOUT_SEC keeps
+  # backwards compatibility for direct invocations of this function.
   local deadline
-  deadline=$(( $(date +%s) + POLL_TIMEOUT_SEC ))
+  if [[ -n "${MUTATE_POLL_DEADLINE_TS:-}" ]]; then
+    deadline="$MUTATE_POLL_DEADLINE_TS"
+  else
+    deadline=$(( $(date +%s) + POLL_TIMEOUT_SEC ))
+  fi
   local pending_file="$RUN_DIR/pending-$phase.txt"
   jq -r --arg phase "$phase" \
     'select(.phase == $phase) | .request_id + "\t" + .keeper' \
@@ -1168,10 +1176,16 @@ build_review_targets
 render_prompts
 
 if [[ "$MUTATE" == "1" ]]; then
+  # Share one POLL_TIMEOUT_SEC budget across both phases so the overall
+  # mutate window remains the single configured value rather than
+  # silently doubling when create + review each compute their own
+  # deadline (PR #13842 review).
+  export MUTATE_POLL_DEADLINE_TS=$(( $(date +%s) + POLL_TIMEOUT_SEC ))
   send_phase_prompts "create" "$CREATE_REQUIRED_TOOLS"
   poll_results "create"
   send_phase_prompts "review" "$REVIEW_REQUIRED_TOOLS"
   poll_results "review"
+  unset MUTATE_POLL_DEADLINE_TS
 else
   log "dry-run mode: prompts rendered under $PROMPT_DIR; no keeper messages sent"
 fi

--- a/scripts/harness/workload/keeper_docker_pr_lifecycle_reprobe.sh
+++ b/scripts/harness/workload/keeper_docker_pr_lifecycle_reprobe.sh
@@ -36,7 +36,10 @@ KEEPER_TURN_TIMEOUT_SEC="${KEEPER_TURN_TIMEOUT_SEC:-900}"
 INIT_TIMEOUT_SEC="${INIT_TIMEOUT_SEC:-60}"
 POLL_TIMEOUT_SEC="${POLL_TIMEOUT_SEC:-1200}"
 POLL_INTERVAL_SEC="${POLL_INTERVAL_SEC:-10}"
-REQUIRED_TOOLS="${REQUIRED_TOOLS:-keeper_shell,keeper_bash,keeper_pr_create,keeper_pr_review_comment}"
+LIFECYCLE_MUTATION_MODE="split"
+REQUIRED_TOOLS_LEGACY="${REQUIRED_TOOLS:-}"
+CREATE_REQUIRED_TOOLS="${CREATE_REQUIRED_TOOLS:-${REQUIRED_TOOLS_LEGACY:-keeper_bash,keeper_pr_create}}"
+REVIEW_REQUIRED_TOOLS="${REVIEW_REQUIRED_TOOLS:-${REQUIRED_TOOLS_LEGACY:-keeper_shell,keeper_pr_review_comment}}"
 MCP_URL="${MCP_URL:-http://127.0.0.1:8935/mcp}"
 MCP_TOKEN="${MASC_MCP_TOKEN:-}"
 MCP_CLIENT_NAME="${MCP_CLIENT_NAME:-keeper-docker-pr-lifecycle-reprobe}"
@@ -87,7 +90,10 @@ Environment:
   POLL_INTERVAL_SEC        Poll interval in seconds.
   MSG_TIMEOUT_SEC          HTTP request timeout for MCP tool calls.
   KEEPER_TURN_TIMEOUT_SEC  Per-keeper Agent.run timeout_sec sent to masc_keeper_msg.
-  REQUIRED_TOOLS           CSV required_tools sent to masc_keeper_msg when mutating.
+  REQUIRED_TOOLS           Legacy CSV applied to both split phases when
+                           phase-specific overrides are unset.
+  CREATE_REQUIRED_TOOLS    CSV required_tools for split create phase.
+  REVIEW_REQUIRED_TOOLS    CSV required_tools for split review phase.
   RUN_AUDIT=0              Skip final audit.
   EXPECTED_SERVER_COMMIT   Optional expected /health build.commit prefix.
   FORBID_GITHUB_IDENTITIES Optional CSV of forbidden keeper GitHub identities.
@@ -318,16 +324,18 @@ record_pending_server_incarnation_loss() {
   local pending_file="$1"
   local status="$2"
   local raw_file="$3"
+  local phase="${4:-}"
   while IFS=$'\t' read -r request_id keeper; do
     [[ -n "$request_id" ]] || continue
     jq -nc \
       --arg keeper "$keeper" \
+      --arg phase "$phase" \
       --arg request_id "$request_id" \
       --arg status "$status" \
       --arg expected_incarnation "$SERVER_INCARNATION_ACTUAL" \
       --arg actual_incarnation "$SERVER_INCARNATION_LAST_ACTUAL" \
       --arg raw_file "$raw_file" \
-      '{keeper:$keeper, request_id:$request_id, status:$status, server_expected_incarnation:$expected_incarnation, server_actual_incarnation:$actual_incarnation, raw_file:$raw_file}' \
+      '{keeper:$keeper, phase:$phase, request_id:$request_id, status:$status, server_expected_incarnation:$expected_incarnation, server_actual_incarnation:$actual_incarnation, raw_file:$raw_file}' \
       >>"$RESULTS_FILE"
   done <"$pending_file"
 }
@@ -766,7 +774,63 @@ review_target_for_keeper() {
   ' "$REVIEW_TARGETS_FILE" | head -n 1
 }
 
-prompt_for_keeper() {
+prompt_for_keeper_create() {
+  local keeper="$1"
+  cat <<EOF
+Docker PR lifecycle proof run: $RUN_ID
+Phase: create
+
+Target repo: $REPO_SLUG
+Keeper: $keeper
+
+Goal: create a fresh, auditable Docker-backed proof branch and draft PR. Do
+not review or approve another keeper's PR in this phase.
+
+Tool route rules:
+- Use keeper_bash inside your Docker playground for proof-file creation and git add/commit/push on the proof branch.
+- Do not run gh pr create, gh pr review, or other mutating GitHub commands through keeper_shell or keeper_bash.
+- Do not use approval-requiring host code-write paths such as masc_code_write for this proof file.
+- If keeper_bash rejects mutating git as policy-blocked, stop and report the exact blocker instead of switching to host-local credentials.
+- Use keeper_pr_create for PR creation.
+
+Required create lane:
+1. Confirm your runtime is sandbox_profile=docker before mutating.
+2. Create a unique proof worktree/branch for exactly this run id:
+   - branch: keeper/$keeper-docker-pr-proof-$RUN_ID
+   - preferred tool: masc_worktree_create
+   - use the returned worktree path for every later keeper_bash git/file command.
+   - Do not reuse any branch, worktree, or proof file from another run id.
+   - Do not remove this run's worktree during the proof attempt. If Git says
+     the branch/worktree already exists, stop and report blocker="branch_collision".
+3. Make a minimal, non-product proof edit under docs/runtime-proof/keepers/$keeper-$RUN_ID.md with keeper_bash from inside the Docker playground. The file content must include run_id=$RUN_ID and branch=keeper/$keeper-docker-pr-proof-$RUN_ID.
+4. Commit and git push exactly branch keeper/$keeper-docker-pr-proof-$RUN_ID with keeper_bash. The tool result must show explicit Docker-backed route evidence such as via=docker, route_via=docker, via=brokered, or route_via=brokered.
+5. Create a draft PR for that branch with keeper_pr_create. Do not mark ready, do not merge, do not add human-approved-ready.
+6. Reply with one compact JSON object:
+   {
+     "run_id": "$RUN_ID",
+     "phase": "create",
+     "keeper": "$keeper",
+     "branch": "keeper/$keeper-docker-pr-proof-$RUN_ID",
+     "pr_url": "...",
+     "docker_pr_create": true,
+     "docker_git_push": true,
+     "blocker": null
+   }
+
+Safety rules:
+- No protected branches.
+- No force push.
+- No ready/merge.
+- No human-approved-ready label.
+- If a tool is missing or policy-blocked, stop and reply with blocker plus exact structured tool output.
+
+This prompt is sent with create-phase masc_keeper_msg.required_tools so the
+runtime records tool_surface_mismatch or missing_required_tool_use when
+keeper_bash/keeper_pr_create are not visible or not used.
+EOF
+}
+
+prompt_for_keeper_review() {
   local keeper="$1"
   local review_target="${2:-}"
   local review_branch=""
@@ -782,96 +846,82 @@ Cross-keeper approval target:
 - You must review and APPROVE the draft PR whose head branch is: $review_branch
 - This target belongs to keeper: $review_target
 - Do not approve your own PR or your own branch.
-- If the target PR is not visible yet, wait/retry briefly by listing PRs for that head branch before declaring a blocker.
+- First use keeper_shell once to resolve the target PR number:
+  gh pr view $review_branch -R $REPO_SLUG --json number,url,isDraft,headRefName
+- If that command reports no PR or cannot resolve the branch, do not wait in a loop. Reply with blocker="target_pr_missing" and the exact tool output.
 - If GitHub reports the target PR has the same author identity as your current credential and rejects approval as self-approval, stop and report blocker="github_self_approve_policy" with the exact tool output.
+- Once the PR number is known, call keeper_pr_review_comment with event="APPROVE" and a body that includes run_id=$RUN_ID, reviewer=$keeper, and target_branch=$review_branch.
 EOF
 )"
   else
     review_instruction="$(cat <<'EOF'
 Cross-keeper approval target:
-- No distinct review target was available. You can create/push/comment on your own draft PR, but this run cannot satisfy PR APPROVE evidence.
-- Stop before approval and report blocker="insufficient_review_targets".
+- No distinct review target was available. This phase cannot satisfy PR APPROVE evidence.
+- Stop immediately and report blocker="insufficient_review_targets".
 EOF
 )"
   fi
   cat <<EOF
 Docker PR lifecycle proof run: $RUN_ID
+Phase: review
 
 Target repo: $REPO_SLUG
 Keeper: $keeper
 
-Goal: produce direct, auditable Docker-backed evidence for PR create, git push, PR review/comment, and PR APPROVE. Use native keeper tools where available; do not use host-local ambient GitHub credentials.
+Goal: produce direct, auditable Docker-backed PR review and APPROVE evidence
+for another keeper's draft proof PR. Do not create a new branch or PR in this
+phase.
 
 Tool route rules:
 - Use keeper_shell for read-only GitHub inspection.
-- Use keeper_bash inside your Docker playground for proof-file creation and git add/commit/push on the proof branch.
-- Do not run gh pr create, gh pr review, or other mutating GitHub commands through keeper_shell or keeper_bash.
-- Do not use approval-requiring host code-write paths such as masc_code_write for this proof file.
-- If keeper_bash rejects mutating git as policy-blocked, stop and report the exact blocker instead of switching to host-local credentials.
-- Use keeper_pr_create and keeper_pr_review_comment for PR mutation/review actions.
-
-Required proof lane:
-1. Confirm your runtime is sandbox_profile=docker before mutating.
-2. Create a unique proof worktree/branch for exactly this run id:
-   - branch: keeper/$keeper-docker-pr-proof-$RUN_ID
-   - preferred tool: masc_worktree_create
-   - use the returned worktree path for every later keeper_bash git/file command.
-   - Do not reuse any branch, worktree, or proof file from another run id.
-   - Do not remove this run's worktree during the proof attempt. If Git says
-     the branch/worktree already exists, stop and report blocker="branch_collision".
-3. Make a minimal, non-product proof edit under docs/runtime-proof/keepers/$keeper-$RUN_ID.md with keeper_bash from inside the Docker playground. The file content must include run_id=$RUN_ID and branch=keeper/$keeper-docker-pr-proof-$RUN_ID.
-4. Commit and git push exactly branch keeper/$keeper-docker-pr-proof-$RUN_ID with keeper_bash. The tool result must show explicit Docker-backed route evidence such as via=docker, route_via=docker, via=brokered, or route_via=brokered.
-5. Create a draft PR for that branch with keeper_pr_create or the native PR-create tool path. Do not mark ready, do not merge, do not add human-approved-ready.
-6. Use keeper_pr_review_read and keeper_pr_review_comment for review evidence. COMMENT is allowed on your own proof PR. APPROVE must target the cross-keeper PR below, not your own PR.
+- Do not run mutating gh review commands through keeper_shell or keeper_bash.
+- Use keeper_pr_review_comment for the APPROVE mutation.
 
 $review_instruction
 
-7. Reply with one compact JSON object:
+Reply with one compact JSON object:
    {
      "run_id": "$RUN_ID",
+     "phase": "review",
      "keeper": "$keeper",
-     "branch": "keeper/$keeper-docker-pr-proof-$RUN_ID",
      "review_target_keeper": $review_target_json,
      "review_target_branch": $review_branch_json,
-     "pr_url": "...",
      "approved_pr_url": "...",
-     "docker_pr_create": true,
-     "docker_git_push": true,
-     "docker_pr_review": true,
      "docker_pr_approve": true,
      "blocker": null
    }
 
 Safety rules:
-- No protected branches.
-- No force push.
 - No ready/merge.
 - No human-approved-ready label.
 - If a tool is missing or policy-blocked, stop and reply with blocker plus exact structured tool output.
 
-This prompt is sent with masc_keeper_msg.required_tools so the runtime records
-tool_surface_mismatch or missing_required_tool_use when the Docker PR lifecycle
-tools are not visible or not used.
+This prompt is sent with review-phase masc_keeper_msg.required_tools so the
+runtime records tool_surface_mismatch or missing_required_tool_use when
+keeper_shell/keeper_pr_review_comment are not visible or not used.
 EOF
 }
 
 render_prompts() {
   while IFS= read -r keeper; do
     [[ -n "$keeper" ]] || continue
-    prompt_for_keeper "$keeper" "$(review_target_for_keeper "$keeper")" >"$PROMPT_DIR/$keeper.txt"
+    prompt_for_keeper_create "$keeper" >"$PROMPT_DIR/$keeper-create.txt"
+    prompt_for_keeper_review "$keeper" "$(review_target_for_keeper "$keeper")" >"$PROMPT_DIR/$keeper-review.txt"
   done <"$RUN_DIR/keepers.txt"
 }
 
-send_prompts() {
+send_phase_prompts() {
+  local phase="$1"
+  local required_tools_csv="$2"
   while IFS= read -r keeper; do
     [[ -n "$keeper" ]] || continue
     local prompt args payload text request_id
-    prompt="$(cat "$PROMPT_DIR/$keeper.txt")"
+    prompt="$(cat "$PROMPT_DIR/$keeper-$phase.txt")"
     args="$(
       jq -cn \
         --arg name "$keeper" \
         --arg message "$prompt" \
-        --arg required_tools_csv "$REQUIRED_TOOLS" \
+        --arg required_tools_csv "$required_tools_csv" \
         --argjson timeout "$KEEPER_TURN_TIMEOUT_SEC" \
         '{
           name:$name,
@@ -885,12 +935,12 @@ send_prompts() {
           )
         }'
     )"
-    log "sending proof prompt to $keeper"
-    payload="$(tool_call "keeper-msg-$keeper-$RUN_ID" "masc_keeper_msg" "$args" "$MSG_TIMEOUT_SEC")"
-    printf '%s' "$payload" >"$RAW_DIR/msg-$keeper.jsonrpc.json"
+    log "sending $phase proof prompt to $keeper"
+    payload="$(tool_call "keeper-msg-$phase-$keeper-$RUN_ID" "masc_keeper_msg" "$args" "$MSG_TIMEOUT_SEC")"
+    printf '%s' "$payload" >"$RAW_DIR/msg-$phase-$keeper.jsonrpc.json"
     mcp_require_tool_ok "$payload" "masc_keeper_msg:$keeper"
     text="$(tool_text_or_empty "$payload")"
-    printf '%s' "$text" >"$RAW_DIR/msg-$keeper.text"
+    printf '%s' "$text" >"$RAW_DIR/msg-$phase-$keeper.text"
     request_id="$(printf '%s' "$text" | jq -r '.request_id // .id // empty' 2>/dev/null || true)"
     if [[ -z "$request_id" ]]; then
       echo "masc_keeper_msg did not return request_id for $keeper" >&2
@@ -899,10 +949,11 @@ send_prompts() {
     fi
     jq -nc \
       --arg keeper "$keeper" \
+      --arg phase "$phase" \
       --arg request_id "$request_id" \
-      --arg prompt_file "$PROMPT_DIR/$keeper.txt" \
+      --arg prompt_file "$PROMPT_DIR/$keeper-$phase.txt" \
       --arg review_target "$(review_target_for_keeper "$keeper")" \
-      '{keeper:$keeper, request_id:$request_id, prompt_file:$prompt_file, review_target:$review_target, status:"pending"}' \
+      '{keeper:$keeper, phase:$phase, request_id:$request_id, prompt_file:$prompt_file, review_target:$review_target, status:"pending"}' \
       >>"$REQUESTS_FILE"
   done <"$RUN_DIR/keepers.txt"
 }
@@ -918,10 +969,13 @@ result_is_terminal() {
 }
 
 poll_results() {
+  local phase="$1"
   local deadline
   deadline=$(( $(date +%s) + POLL_TIMEOUT_SEC ))
-  local pending_file="$RUN_DIR/pending.txt"
-  jq -r '.request_id + "\t" + .keeper' "$REQUESTS_FILE" >"$pending_file"
+  local pending_file="$RUN_DIR/pending-$phase.txt"
+  jq -r --arg phase "$phase" \
+    'select(.phase == $phase) | .request_id + "\t" + .keeper' \
+    "$REQUESTS_FILE" >"$pending_file"
 
   while [[ -s "$pending_file" && "$(date +%s)" -lt "$deadline" ]]; do
     if ! assert_server_incarnation_unchanged; then
@@ -934,7 +988,8 @@ poll_results() {
         log "server incarnation changed while polling keeper results: expected=$SERVER_INCARNATION_ACTUAL actual=${SERVER_INCARNATION_LAST_ACTUAL:-unknown}"
         record_pending_server_incarnation_loss "$pending_file" \
           "$SERVER_INCARNATION_LAST_REASON" \
-          "$SERVER_INCARNATION_LAST_FILE"
+          "$SERVER_INCARNATION_LAST_FILE" \
+          "$phase"
         : >"$pending_file"
         break
       fi
@@ -949,23 +1004,23 @@ poll_results() {
       local args payload text status
       args="$(jq -cn --arg request_id "$request_id" '{request_id:$request_id}')"
       payload="$(tool_call "keeper-msg-result-$request_id" "masc_keeper_msg_result" "$args" 30)"
-      printf '%s' "$payload" >"$RAW_DIR/result-$keeper-$request_id.jsonrpc.json"
+      printf '%s' "$payload" >"$RAW_DIR/result-$phase-$keeper-$request_id.jsonrpc.json"
       if ! mcp_require_tool_ok "$payload" "masc_keeper_msg_result:$keeper" >/dev/null 2>&1; then
-        jq -nc --arg keeper "$keeper" --arg request_id "$request_id" \
+        jq -nc --arg keeper "$keeper" --arg phase "$phase" --arg request_id "$request_id" \
           --arg status "poll_error" \
-          --arg raw_file "$RAW_DIR/result-$keeper-$request_id.jsonrpc.json" \
-          '{keeper:$keeper, request_id:$request_id, status:$status, raw_file:$raw_file}' \
+          --arg raw_file "$RAW_DIR/result-$phase-$keeper-$request_id.jsonrpc.json" \
+          '{keeper:$keeper, phase:$phase, request_id:$request_id, status:$status, raw_file:$raw_file}' \
           >>"$POLL_ERRORS_FILE"
         printf '%s\t%s\n' "$request_id" "$keeper" >>"$next_pending"
         continue
       fi
       text="$(tool_text_or_empty "$payload")"
-      printf '%s' "$text" >"$RAW_DIR/result-$keeper-$request_id.text"
+      printf '%s' "$text" >"$RAW_DIR/result-$phase-$keeper-$request_id.text"
       if result_is_terminal "$text"; then
         status="$(printf '%s' "$text" | jq -r '.status // (if .reply then "completed" else "unknown" end)' 2>/dev/null || echo completed)"
-        jq -nc --arg keeper "$keeper" --arg request_id "$request_id" --arg status "$status" \
-          --arg text_file "$RAW_DIR/result-$keeper-$request_id.text" \
-          '{keeper:$keeper, request_id:$request_id, status:$status, text_file:$text_file}' \
+        jq -nc --arg keeper "$keeper" --arg phase "$phase" --arg request_id "$request_id" --arg status "$status" \
+          --arg text_file "$RAW_DIR/result-$phase-$keeper-$request_id.text" \
+          '{keeper:$keeper, phase:$phase, request_id:$request_id, status:$status, text_file:$text_file}' \
           >>"$RESULTS_FILE"
       else
         printf '%s\t%s\n' "$request_id" "$keeper" >>"$next_pending"
@@ -978,8 +1033,8 @@ poll_results() {
 
   if [[ -s "$pending_file" ]]; then
     while IFS=$'\t' read -r request_id keeper; do
-      jq -nc --arg keeper "$keeper" --arg request_id "$request_id" \
-        '{keeper:$keeper, request_id:$request_id, status:"poll_timeout"}' \
+      jq -nc --arg keeper "$keeper" --arg phase "$phase" --arg request_id "$request_id" \
+        '{keeper:$keeper, phase:$phase, request_id:$request_id, status:"poll_timeout"}' \
         >>"$RESULTS_FILE"
     done <"$pending_file"
   fi
@@ -1031,6 +1086,9 @@ write_summary() {
     --arg run_dir "$RUN_DIR" \
     --arg repo "$REPO_SLUG" \
     --arg base_path "$BASE_PATH" \
+    --arg lifecycle_mutation_mode "$LIFECYCLE_MUTATION_MODE" \
+    --arg create_required_tools "$CREATE_REQUIRED_TOOLS" \
+    --arg review_required_tools "$REVIEW_REQUIRED_TOOLS" \
     --arg expected_server_commit "$EXPECTED_SERVER_COMMIT" \
     --arg forbid_github_identities "$FORBID_GITHUB_IDENTITIES" \
     --arg server_commit "$SERVER_COMMIT_ACTUAL" \
@@ -1052,6 +1110,9 @@ write_summary() {
       run_dir:$run_dir,
       repo:$repo,
       base_path:$base_path,
+      lifecycle_mutation_mode:$lifecycle_mutation_mode,
+      create_required_tools:$create_required_tools,
+      review_required_tools:$review_required_tools,
       expected_server_commit:$expected_server_commit,
       forbid_github_identities:$forbid_github_identities,
       server_commit:$server_commit,
@@ -1107,8 +1168,10 @@ build_review_targets
 render_prompts
 
 if [[ "$MUTATE" == "1" ]]; then
-  send_prompts
-  poll_results
+  send_phase_prompts "create" "$CREATE_REQUIRED_TOOLS"
+  poll_results "create"
+  send_phase_prompts "review" "$REVIEW_REQUIRED_TOOLS"
+  poll_results "review"
 else
   log "dry-run mode: prompts rendered under $PROMPT_DIR; no keeper messages sent"
 fi

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -1138,13 +1138,23 @@ let test_keeper_required_tool_contracts () =
   check bool "final-turn required tool prompt does not allow one-tool partial success" true
     (file_not_contains_pattern "lib/keeper/keeper_run_tools.ml"
        "call at least one");
-  check bool "docker PR lifecycle harness default matches runbook" true
+  check bool "docker PR lifecycle harness default splits create/review tools" true
     (file_contains_pattern
        "scripts/harness/workload/keeper_docker_pr_lifecycle_reprobe.sh"
-       {|REQUIRED_TOOLS="${REQUIRED_TOOLS:-keeper_shell,keeper_bash,keeper_pr_create,keeper_pr_review_comment}"|});
-  check bool "runbook documents docker PR lifecycle required tool default" true
+       {|REQUIRED_TOOLS_LEGACY="${REQUIRED_TOOLS:-}"|}
+     && file_contains_pattern
+          "scripts/harness/workload/keeper_docker_pr_lifecycle_reprobe.sh"
+          {|CREATE_REQUIRED_TOOLS="${CREATE_REQUIRED_TOOLS:-${REQUIRED_TOOLS_LEGACY:-keeper_bash,keeper_pr_create}}"|}
+     && file_contains_pattern
+          "scripts/harness/workload/keeper_docker_pr_lifecycle_reprobe.sh"
+          {|REVIEW_REQUIRED_TOOLS="${REVIEW_REQUIRED_TOOLS:-${REQUIRED_TOOLS_LEGACY:-keeper_shell,keeper_pr_review_comment}}"|});
+  check bool "runbook documents docker PR lifecycle split phases" true
     (file_contains_pattern "docs/KEEPER-DOCKER-PR-LIFECYCLE-REPROBE.md"
-       "`keeper_shell`, `keeper_bash`, `keeper_pr_create`, and");
+       "The create phase"
+     && file_contains_pattern "docs/KEEPER-DOCKER-PR-LIFECYCLE-REPROBE.md"
+          "requires `keeper_bash` and `keeper_pr_create`"
+     && file_contains_pattern "docs/KEEPER-DOCKER-PR-LIFECYCLE-REPROBE.md"
+          "the review phase requires `keeper_shell` and");
   check bool "docker PR lifecycle prompt accepts brokered route proof" true
     (file_contains_pattern
        "scripts/harness/workload/keeper_docker_pr_lifecycle_reprobe.sh"
@@ -1202,7 +1212,7 @@ let test_keeper_msg_timeout_contracts () =
   check bool "docker PR lifecycle prompt names keeper_bash for push" true
     (file_contains_pattern
        "scripts/harness/workload/keeper_docker_pr_lifecycle_reprobe.sh"
-       "Commit and git push that branch with keeper_bash");
+       "Commit and git push exactly branch");
   check bool "docker PR lifecycle prompt uses docker bash for proof edit" true
     (file_contains_pattern
        "scripts/harness/workload/keeper_docker_pr_lifecycle_reprobe.sh"


### PR DESCRIPTION
## Summary

- split the Docker PR lifecycle reprobe mutation path into sequential `create` and `review` keeper turns
- narrow create-phase required tools to `keeper_bash,keeper_pr_create`
- narrow review-phase required tools to `keeper_shell,keeper_pr_review_comment`
- make review prompts resolve the target PR once and report `target_pr_missing` instead of waiting in a loop
- update the reprobe runbook and source-contract coverage for the split phase defaults

## Why This Matters

The 0506h pair reprobe showed two distinct failure classes after stale evidence was blocked: analyst returned no ToolUse under the required-tool contract, and verifier timed out while the cross-keeper target was not reliably available. Asking each keeper to create its own PR and approve the peer PR in one Agent.run lets a single failed create phase cascade into another keeper burning the full timeout.

This change makes the proof shape more debuggable: create/push/PR-create evidence is produced first, then review/approve evidence is attempted only in the second phase with explicit no-loop target-missing behavior.

This does not claim the 14-keeper lifecycle objective is complete.

## Verification

- `bash -n scripts/harness/workload/keeper_docker_pr_lifecycle_reprobe.sh scripts/harness_keeper_docker_pr_lifecycle_reprobe.sh`
- `env RUN_AUDIT=0 scripts/harness/workload/keeper_docker_pr_lifecycle_reprobe.sh --dry-run --keeper-names analyst,verifier --expected-keepers 14 --run-id dry-phase-smoke-0506d --run-dir /private/tmp/keeper-docker-pr-phase-smoke-d`
- `python3 -m py_compile scripts/audit-keeper-fleet-readiness.py test/test_audit_keeper_fleet_readiness.py`
- `git diff --check origin/main...HEAD`
- GitHub PR checks on `43364d22a9ae4f9342f4790b46aac0c6c9b4bb6a`: `CI Gate`, `PR Live Gate`, `PR Sync Check`, `Draft Auto-Merge Guard` after rerun, `Fundamental Check`, and `Fun.protect Finalizer Check` passed.

Focused Dune source-contract build was attempted but stopped after waiting behind other long-running Dune locks; PR CI should be treated as the build gate for this follow-up.