### PR TITLE
feat(dashboard): add board moderation surface

### DIFF
--- a/dashboard/src/api/board-moderation.test.ts
+++ b/dashboard/src/api/board-moderation.test.ts
@@ -1,0 +1,152 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  fetchBoardModerationQueue,
+  flagBoardModerationTarget,
+  normalizeBoardModerationAuditEntry,
+  normalizeBoardModerationQueueEntry,
+  submitBoardModerationAction,
+} from './board-moderation'
+
+function jsonResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  vi.unstubAllGlobals()
+})
+
+describe('board moderation api', () => {
+  it('fetches the queue with resolved filter and drops malformed entries', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse({
+      ok: true,
+      entries: [
+        {
+          entry_id: 'flag-1',
+          target_kind: 'post',
+          target_id: 'post-1',
+          reporter: 'keeper-a',
+          reason: 'spam',
+          flagged_at: 1_779_000_000,
+          resolved: false,
+        },
+        {
+          entry_id: 'bad',
+          target_kind: 'post',
+          reporter: 'keeper-a',
+          reason: 'spam',
+          flagged_at: 1_779_000_000,
+          resolved: false,
+        },
+      ],
+      count: 2,
+    }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await fetchBoardModerationQueue({ resolved: false })
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(fetchMock.mock.calls[0]?.[0]).toBe('/api/v1/dashboard/board/moderation/queue?resolved=false')
+    expect(result.count).toBe(2)
+    expect(result.entries).toHaveLength(1)
+    expect(result.entries[0]?.entry_id).toBe('flag-1')
+    expect(result.entries[0]?.flagged_at_iso).toBe('2026-05-17T06:40:00.000Z')
+  })
+
+  it('flags a target through the dashboard moderation route', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse({
+      ok: true,
+      entry: {
+        entry_id: 'flag-2',
+        target_kind: 'post',
+        target_id: 'post-2',
+        reporter: 'keeper-b',
+        reason: 'policy:duplicate',
+        flagged_at: 1_779_000_100,
+        resolved: false,
+      },
+    }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const entry = await flagBoardModerationTarget({
+      target_id: ' post-2 ',
+      reporter: ' keeper-b ',
+      reason: 'policy:duplicate',
+    })
+
+    expect(entry.entry_id).toBe('flag-2')
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect(url).toBe('/api/v1/dashboard/board/moderation/flag')
+    expect(init.method).toBe('POST')
+    expect(JSON.parse(String(init.body))).toEqual({
+      target_kind: 'post',
+      target_id: 'post-2',
+      reporter: 'keeper-b',
+      reason: 'policy:duplicate',
+    })
+  })
+
+  it('submits a moderation action and preserves delete warnings', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse({
+      ok: true,
+      entry: {
+        audit_id: 'audit-1',
+        target_kind: 'comment',
+        target_id: 'comment-1',
+        actor: 'operator-a',
+        action: 'remove',
+        reason: 'harassment',
+        note: 'remove offensive comment',
+        acted_at: 1_779_000_200,
+      },
+      delete_warning: 'comment removal is audit-only',
+    }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await submitBoardModerationAction({
+      target_kind: 'comment',
+      target_id: ' comment-1 ',
+      action: 'remove',
+      actor: ' operator-a ',
+      reason: 'harassment',
+      note: ' remove offensive comment ',
+    })
+
+    expect(result.entry.audit_id).toBe('audit-1')
+    expect(result.delete_warning).toBe('comment removal is audit-only')
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect(url).toBe('/api/v1/dashboard/board/moderation/action')
+    expect(JSON.parse(String(init.body))).toEqual({
+      target_kind: 'comment',
+      target_id: 'comment-1',
+      action: 'remove',
+      actor: 'operator-a',
+      reason: 'harassment',
+      note: 'remove offensive comment',
+    })
+  })
+
+  it('returns null for malformed queue and audit entries', () => {
+    expect(normalizeBoardModerationQueueEntry({
+      entry_id: 'flag-1',
+      target_kind: 'post',
+      reporter: 'keeper-a',
+      reason: 'spam',
+      flagged_at: 1,
+      resolved: false,
+    })).toBeNull()
+
+    expect(normalizeBoardModerationAuditEntry({
+      audit_id: 'audit-1',
+      target_kind: 'post',
+      target_id: 'post-1',
+      actor: 'operator-a',
+      action: 'delete',
+      acted_at: 1,
+    })).toBeNull()
+  })
+})

--- a/dashboard/src/api/board-moderation.test.ts
+++ b/dashboard/src/api/board-moderation.test.ts
@@ -46,10 +46,16 @@ describe('board moderation api', () => {
     }))
     vi.stubGlobal('fetch', fetchMock)
 
-    const result = await fetchBoardModerationQueue({ resolved: false })
+    const controller = new AbortController()
+    controller.abort()
+    const result = await fetchBoardModerationQueue({
+      resolved: false,
+      signal: controller.signal,
+    })
 
     expect(fetchMock).toHaveBeenCalledTimes(1)
     expect(fetchMock.mock.calls[0]?.[0]).toBe('/api/v1/dashboard/board/moderation/queue?resolved=false')
+    expect(((fetchMock.mock.calls[0]?.[1] as RequestInit | undefined)?.signal as AbortSignal | undefined)?.aborted).toBe(true)
     expect(result.count).toBe(2)
     expect(result.entries).toHaveLength(1)
     expect(result.entries[0]?.entry_id).toBe('flag-1')
@@ -192,6 +198,25 @@ describe('board moderation api', () => {
       actor: 'operator-a',
       action: 'delete',
       acted_at: 1,
+    })).toBeNull()
+
+    expect(normalizeBoardModerationQueueEntry({
+      entry_id: 'flag-zero',
+      target_kind: 'post',
+      target_id: 'post-1',
+      reporter: 'keeper-a',
+      reason: 'spam',
+      flagged_at: 0,
+      resolved: false,
+    })).toBeNull()
+
+    expect(normalizeBoardModerationAuditEntry({
+      audit_id: 'audit-negative',
+      target_kind: 'post',
+      target_id: 'post-1',
+      actor: 'operator-a',
+      action: 'approve',
+      acted_at: -1,
     })).toBeNull()
   })
 })

--- a/dashboard/src/api/board-moderation.test.ts
+++ b/dashboard/src/api/board-moderation.test.ts
@@ -46,20 +46,39 @@ describe('board moderation api', () => {
     }))
     vi.stubGlobal('fetch', fetchMock)
 
-    const controller = new AbortController()
-    controller.abort()
     const result = await fetchBoardModerationQueue({
       resolved: false,
-      signal: controller.signal,
+      signal: new AbortController().signal,
     })
 
     expect(fetchMock).toHaveBeenCalledTimes(1)
     expect(fetchMock.mock.calls[0]?.[0]).toBe('/api/v1/dashboard/board/moderation/queue?resolved=false')
-    expect(((fetchMock.mock.calls[0]?.[1] as RequestInit | undefined)?.signal as AbortSignal | undefined)?.aborted).toBe(true)
+    const fetchSignal = (fetchMock.mock.calls[0]?.[1] as RequestInit | undefined)?.signal as AbortSignal | undefined
+    expect(fetchSignal).toBeInstanceOf(AbortSignal)
+    expect(fetchSignal?.aborted).toBe(false)
     expect(result.count).toBe(2)
     expect(result.entries).toHaveLength(1)
     expect(result.entries[0]?.entry_id).toBe('flag-1')
     expect(result.entries[0]?.flagged_at_iso).toBe('2026-05-17T06:40:00.000Z')
+  })
+
+  it('rejects when a queue fetch is aborted in flight', async () => {
+    const controller = new AbortController()
+    const fetchMock = vi.fn((_url: string, init?: RequestInit) => new Promise<Response>((_, reject) => {
+      const signal = init?.signal as AbortSignal | undefined
+      signal?.addEventListener(
+        'abort',
+        () => reject(new DOMException('aborted', 'AbortError')),
+        { once: true },
+      )
+      controller.abort()
+    }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(fetchBoardModerationQueue({ signal: controller.signal })).rejects.toMatchObject({
+      name: 'AbortError',
+    })
+    expect(fetchMock).toHaveBeenCalledTimes(1)
   })
 
   it('flags a target through the dashboard moderation route', async () => {

--- a/dashboard/src/api/board-moderation.test.ts
+++ b/dashboard/src/api/board-moderation.test.ts
@@ -130,6 +130,51 @@ describe('board moderation api', () => {
     })
   })
 
+  it('rejects invalid target kinds instead of falling back to posts', async () => {
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(flagBoardModerationTarget({
+      target_kind: 'message' as never,
+      target_id: 'post-1',
+    })).rejects.toThrow('unknown board moderation target_kind: message; valid: post, comment')
+
+    await expect(submitBoardModerationAction({
+      target_kind: 'message' as never,
+      target_id: 'post-1',
+      action: 'approve',
+    })).rejects.toThrow('unknown board moderation target_kind: message; valid: post, comment')
+
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('names rejected moderation actions and reasons with valid options', async () => {
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(submitBoardModerationAction({
+      target_id: 'post-1',
+      action: 'delete' as never,
+    })).rejects.toThrow('unknown board moderation action: delete; valid: approve, remove, hide, warn')
+
+    await expect(flagBoardModerationTarget({
+      target_id: 'post-1',
+      reason: 'duplicate' as never,
+    })).rejects.toThrow(
+      'unknown board moderation reason: duplicate; valid: spam, harassment, off_topic, policy:<non-empty>',
+    )
+
+    await expect(submitBoardModerationAction({
+      target_id: 'post-1',
+      action: 'approve',
+      reason: 'duplicate' as never,
+    })).rejects.toThrow(
+      'unknown board moderation reason: duplicate; valid: spam, harassment, off_topic, policy:<non-empty>',
+    )
+
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
   it('returns null for malformed queue and audit entries', () => {
     expect(normalizeBoardModerationQueueEntry({
       entry_id: 'flag-1',

--- a/dashboard/src/api/board-moderation.ts
+++ b/dashboard/src/api/board-moderation.ts
@@ -71,7 +71,9 @@ function describeInvalid(value: unknown): string {
 
 function normalizeTargetKind(value: unknown): BoardModerationTargetKind | null {
   const kind = asString(value, '').trim()
-  if (kind === 'post' || kind === 'comment') return kind
+  if ((VALID_TARGET_KINDS as readonly string[]).includes(kind)) {
+    return kind as BoardModerationTargetKind
+  }
   return null
 }
 
@@ -96,15 +98,15 @@ function normalizeFlagReason(value: unknown): BoardModerationFlagReason | null {
 
 function normalizeActionKind(value: unknown): BoardModerationActionKind | null {
   const action = asString(value, '').trim()
-  if (action === 'approve' || action === 'remove' || action === 'hide' || action === 'warn') {
-    return action
+  if ((VALID_ACTION_KINDS as readonly string[]).includes(action)) {
+    return action as BoardModerationActionKind
   }
   return null
 }
 
 function requiredTimestamp(value: unknown): number | null {
   const timestamp = asNumber(value)
-  return timestamp === undefined ? null : timestamp
+  return timestamp === undefined || timestamp <= 0 ? null : timestamp
 }
 
 export function normalizeBoardModerationQueueEntry(raw: unknown): BoardModerationQueueEntry | null {
@@ -155,7 +157,7 @@ export function normalizeBoardModerationAuditEntry(raw: unknown): BoardModeratio
 }
 
 export async function fetchBoardModerationQueue(
-  options: { resolved?: boolean } = {},
+  options: { resolved?: boolean; signal?: AbortSignal } = {},
 ): Promise<BoardModerationQueue> {
   return withRetries('fetchBoardModerationQueue', async () => {
     const params = new URLSearchParams()
@@ -163,7 +165,9 @@ export async function fetchBoardModerationQueue(
       params.set('resolved', options.resolved ? 'true' : 'false')
     }
     const qs = params.toString()
-    const raw = await get<unknown>(`${MODERATION_QUEUE_PATH}${qs ? `?${qs}` : ''}`)
+    const raw = await get<unknown>(`${MODERATION_QUEUE_PATH}${qs ? `?${qs}` : ''}`, {
+      signal: options.signal,
+    })
     if (!isRecord(raw)) return { entries: [], count: 0 }
     const entries = Array.isArray(raw.entries)
       ? raw.entries

--- a/dashboard/src/api/board-moderation.ts
+++ b/dashboard/src/api/board-moderation.ts
@@ -1,0 +1,228 @@
+import { get, post, withRetries } from './core'
+import {
+  asBoolean,
+  asInt,
+  asNullableString,
+  asNumber,
+  asString,
+  isRecord,
+  toIsoTimestamp,
+} from '../components/common/normalize'
+
+const MODERATION_QUEUE_PATH = '/api/v1/dashboard/board/moderation/queue'
+const MODERATION_FLAG_PATH = '/api/v1/dashboard/board/moderation/flag'
+const MODERATION_ACTION_PATH = '/api/v1/dashboard/board/moderation/action'
+
+export type BoardModerationTargetKind = 'post' | 'comment'
+export type BoardModerationFlagReason =
+  | 'spam'
+  | 'harassment'
+  | 'off_topic'
+  | `policy:${string}`
+export type BoardModerationActionKind = 'approve' | 'remove' | 'hide' | 'warn'
+
+export interface BoardModerationQueueEntry {
+  entry_id: string
+  target_kind: BoardModerationTargetKind
+  target_id: string
+  reporter: string
+  reason: BoardModerationFlagReason
+  flagged_at: number
+  flagged_at_iso: string | null
+  resolved: boolean
+}
+
+export interface BoardModerationAuditEntry {
+  audit_id: string
+  target_kind: BoardModerationTargetKind
+  target_id: string
+  actor: string
+  action: BoardModerationActionKind
+  reason: BoardModerationFlagReason | null
+  note: string | null
+  acted_at: number
+  acted_at_iso: string | null
+}
+
+export interface BoardModerationQueue {
+  entries: BoardModerationQueueEntry[]
+  count: number
+}
+
+export interface BoardModerationActionResult {
+  entry: BoardModerationAuditEntry
+  delete_warning: string | null
+}
+
+function trimNonEmpty(value: string | null | undefined): string | null {
+  const trimmed = value?.trim() ?? ''
+  return trimmed ? trimmed : null
+}
+
+function normalizeTargetKind(value: unknown): BoardModerationTargetKind | null {
+  const kind = asString(value, '').trim()
+  if (kind === 'post' || kind === 'comment') return kind
+  return null
+}
+
+function normalizeFlagReason(value: unknown): BoardModerationFlagReason | null {
+  const reason = asString(value, '').trim()
+  if (reason === 'spam' || reason === 'harassment' || reason === 'off_topic') {
+    return reason
+  }
+  if (reason.startsWith('policy:') && reason.length > 'policy:'.length) {
+    return reason as `policy:${string}`
+  }
+  return null
+}
+
+function normalizeActionKind(value: unknown): BoardModerationActionKind | null {
+  const action = asString(value, '').trim()
+  if (action === 'approve' || action === 'remove' || action === 'hide' || action === 'warn') {
+    return action
+  }
+  return null
+}
+
+function requiredTimestamp(value: unknown): number | null {
+  const timestamp = asNumber(value)
+  return timestamp === undefined ? null : timestamp
+}
+
+export function normalizeBoardModerationQueueEntry(raw: unknown): BoardModerationQueueEntry | null {
+  if (!isRecord(raw)) return null
+  const entryId = asString(raw.entry_id, '').trim()
+  const targetKind = normalizeTargetKind(raw.target_kind)
+  const targetId = asString(raw.target_id, '').trim()
+  const reporter = asString(raw.reporter, '').trim()
+  const reason = normalizeFlagReason(raw.reason)
+  const flaggedAt = requiredTimestamp(raw.flagged_at)
+  if (!entryId || !targetKind || !targetId || !reporter || !reason || flaggedAt === null) {
+    return null
+  }
+  return {
+    entry_id: entryId,
+    target_kind: targetKind,
+    target_id: targetId,
+    reporter,
+    reason,
+    flagged_at: flaggedAt,
+    flagged_at_iso: toIsoTimestamp(flaggedAt) ?? null,
+    resolved: asBoolean(raw.resolved, false),
+  }
+}
+
+export function normalizeBoardModerationAuditEntry(raw: unknown): BoardModerationAuditEntry | null {
+  if (!isRecord(raw)) return null
+  const auditId = asString(raw.audit_id, '').trim()
+  const targetKind = normalizeTargetKind(raw.target_kind)
+  const targetId = asString(raw.target_id, '').trim()
+  const actor = asString(raw.actor, '').trim()
+  const action = normalizeActionKind(raw.action)
+  const actedAt = requiredTimestamp(raw.acted_at)
+  if (!auditId || !targetKind || !targetId || !actor || !action || actedAt === null) {
+    return null
+  }
+  return {
+    audit_id: auditId,
+    target_kind: targetKind,
+    target_id: targetId,
+    actor,
+    action,
+    reason: normalizeFlagReason(raw.reason),
+    note: asNullableString(raw.note),
+    acted_at: actedAt,
+    acted_at_iso: toIsoTimestamp(actedAt) ?? null,
+  }
+}
+
+export async function fetchBoardModerationQueue(
+  options: { resolved?: boolean } = {},
+): Promise<BoardModerationQueue> {
+  return withRetries('fetchBoardModerationQueue', async () => {
+    const params = new URLSearchParams()
+    if (typeof options.resolved === 'boolean') {
+      params.set('resolved', options.resolved ? 'true' : 'false')
+    }
+    const qs = params.toString()
+    const raw = await get<unknown>(`${MODERATION_QUEUE_PATH}${qs ? `?${qs}` : ''}`)
+    if (!isRecord(raw)) return { entries: [], count: 0 }
+    const entries = Array.isArray(raw.entries)
+      ? raw.entries
+          .map(normalizeBoardModerationQueueEntry)
+          .filter((row): row is BoardModerationQueueEntry => row !== null)
+      : []
+    return {
+      entries,
+      count: asInt(raw.count) ?? entries.length,
+    }
+  })
+}
+
+export async function flagBoardModerationTarget(args: {
+  target_kind?: BoardModerationTargetKind
+  target_id: string
+  reporter?: string
+  reason?: BoardModerationFlagReason
+}): Promise<BoardModerationQueueEntry> {
+  const targetId = trimNonEmpty(args.target_id)
+  if (!targetId) throw new Error('target_id is required')
+  const targetKind = normalizeTargetKind(args.target_kind) ?? 'post'
+  const reason = args.reason === undefined ? 'spam' : normalizeFlagReason(args.reason)
+  if (!reason) throw new Error('unknown board moderation reason')
+  const reporter = trimNonEmpty(args.reporter)
+
+  const body: Record<string, string> = {
+    target_kind: targetKind,
+    target_id: targetId,
+    reason,
+  }
+  if (reporter) body.reporter = reporter
+
+  const raw = await post<unknown>(MODERATION_FLAG_PATH, body)
+  const entry = isRecord(raw) ? normalizeBoardModerationQueueEntry(raw.entry) : null
+  if (!entry) {
+    throw new Error('Malformed board moderation flag response')
+  }
+  return entry
+}
+
+export async function submitBoardModerationAction(args: {
+  target_kind?: BoardModerationTargetKind
+  target_id: string
+  action: BoardModerationActionKind
+  actor?: string
+  reason?: BoardModerationFlagReason
+  note?: string
+}): Promise<BoardModerationActionResult> {
+  const targetId = trimNonEmpty(args.target_id)
+  if (!targetId) throw new Error('target_id is required')
+  const targetKind = normalizeTargetKind(args.target_kind) ?? 'post'
+  const action = normalizeActionKind(args.action)
+  if (!action) throw new Error('unknown board moderation action')
+  const reason = args.reason === undefined ? null : normalizeFlagReason(args.reason)
+  if (args.reason !== undefined && !reason) {
+    throw new Error('unknown board moderation reason')
+  }
+
+  const body: Record<string, string> = {
+    target_kind: targetKind,
+    target_id: targetId,
+    action,
+  }
+  const actor = trimNonEmpty(args.actor)
+  const note = trimNonEmpty(args.note)
+  if (actor) body.actor = actor
+  if (reason) body.reason = reason
+  if (note) body.note = note
+
+  const raw = await post<unknown>(MODERATION_ACTION_PATH, body)
+  const entry = isRecord(raw) ? normalizeBoardModerationAuditEntry(raw.entry) : null
+  if (!entry) {
+    throw new Error('Malformed board moderation action response')
+  }
+  return {
+    entry,
+    delete_warning: isRecord(raw) ? asNullableString(raw.delete_warning) : null,
+  }
+}

--- a/dashboard/src/api/board-moderation.ts
+++ b/dashboard/src/api/board-moderation.ts
@@ -12,6 +12,9 @@ import {
 const MODERATION_QUEUE_PATH = '/api/v1/dashboard/board/moderation/queue'
 const MODERATION_FLAG_PATH = '/api/v1/dashboard/board/moderation/flag'
 const MODERATION_ACTION_PATH = '/api/v1/dashboard/board/moderation/action'
+const VALID_TARGET_KINDS = ['post', 'comment'] as const
+const VALID_ACTION_KINDS = ['approve', 'remove', 'hide', 'warn'] as const
+const VALID_REASON_HINT = 'spam, harassment, off_topic, policy:<non-empty>'
 
 export type BoardModerationTargetKind = 'post' | 'comment'
 export type BoardModerationFlagReason =
@@ -59,10 +62,25 @@ function trimNonEmpty(value: string | null | undefined): string | null {
   return trimmed ? trimmed : null
 }
 
+function describeInvalid(value: unknown): string {
+  if (typeof value === 'string') return value.trim() || '<blank>'
+  if (value === undefined) return '<undefined>'
+  if (value === null) return '<null>'
+  return String(value)
+}
+
 function normalizeTargetKind(value: unknown): BoardModerationTargetKind | null {
   const kind = asString(value, '').trim()
   if (kind === 'post' || kind === 'comment') return kind
   return null
+}
+
+function requireTargetKind(value: unknown): BoardModerationTargetKind {
+  const kind = normalizeTargetKind(value)
+  if (kind) return kind
+  throw new Error(
+    `unknown board moderation target_kind: ${describeInvalid(value)}; valid: ${VALID_TARGET_KINDS.join(', ')}`,
+  )
 }
 
 function normalizeFlagReason(value: unknown): BoardModerationFlagReason | null {
@@ -167,9 +185,13 @@ export async function flagBoardModerationTarget(args: {
 }): Promise<BoardModerationQueueEntry> {
   const targetId = trimNonEmpty(args.target_id)
   if (!targetId) throw new Error('target_id is required')
-  const targetKind = normalizeTargetKind(args.target_kind) ?? 'post'
+  const targetKind = args.target_kind === undefined ? 'post' : requireTargetKind(args.target_kind)
   const reason = args.reason === undefined ? 'spam' : normalizeFlagReason(args.reason)
-  if (!reason) throw new Error('unknown board moderation reason')
+  if (!reason) {
+    throw new Error(
+      `unknown board moderation reason: ${describeInvalid(args.reason)}; valid: ${VALID_REASON_HINT}`,
+    )
+  }
   const reporter = trimNonEmpty(args.reporter)
 
   const body: Record<string, string> = {
@@ -197,12 +219,18 @@ export async function submitBoardModerationAction(args: {
 }): Promise<BoardModerationActionResult> {
   const targetId = trimNonEmpty(args.target_id)
   if (!targetId) throw new Error('target_id is required')
-  const targetKind = normalizeTargetKind(args.target_kind) ?? 'post'
+  const targetKind = args.target_kind === undefined ? 'post' : requireTargetKind(args.target_kind)
   const action = normalizeActionKind(args.action)
-  if (!action) throw new Error('unknown board moderation action')
+  if (!action) {
+    throw new Error(
+      `unknown board moderation action: ${describeInvalid(args.action)}; valid: ${VALID_ACTION_KINDS.join(', ')}`,
+    )
+  }
   const reason = args.reason === undefined ? null : normalizeFlagReason(args.reason)
   if (args.reason !== undefined && !reason) {
-    throw new Error('unknown board moderation reason')
+    throw new Error(
+      `unknown board moderation reason: ${describeInvalid(args.reason)}; valid: ${VALID_REASON_HINT}`,
+    )
   }
 
   const body: Record<string, string> = {

--- a/dashboard/src/components/board/board-moderation-surface.test.ts
+++ b/dashboard/src/components/board/board-moderation-surface.test.ts
@@ -8,6 +8,10 @@ import {
   flagBoardModerationTarget,
   submitBoardModerationAction,
 } from '../../api/board-moderation'
+import {
+  resetDashboardSessionActorForTests,
+  setCanonicalDashboardActor,
+} from '../../lib/dashboard-session-actor'
 
 vi.mock('../../api/board-moderation', () => ({
   fetchBoardModerationQueue: vi.fn(),
@@ -69,6 +73,7 @@ describe('BoardModerationSurface', () => {
   afterEach(() => {
     cleanup()
     vi.clearAllMocks()
+    resetDashboardSessionActorForTests()
   })
 
   it('renders queue entries with moderation state', async () => {
@@ -136,6 +141,24 @@ describe('BoardModerationSurface', () => {
       reason: 'harassment',
     }))
     expect(fetchQueueMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('defaults the reporter to the current dashboard actor', async () => {
+    setCanonicalDashboardActor('codex')
+    fetchQueueMock.mockResolvedValueOnce({ count: 0, entries: [] })
+    render(h(BoardModerationSurface, null))
+
+    await waitFor(() => expect(fetchQueueMock).toHaveBeenCalledTimes(1))
+    expect(screen.getByTestId('moderation-reporter')).toHaveValue('codex')
+    fireEvent.input(screen.getByTestId('moderation-target-id'), { target: { value: 'post-2' } })
+    fireEvent.click(screen.getByTestId('moderation-flag-submit'))
+
+    await waitFor(() => expect(flagTargetMock).toHaveBeenCalledWith({
+      target_kind: 'post',
+      target_id: 'post-2',
+      reporter: 'codex',
+      reason: 'spam',
+    }))
   })
 
   it('locks queue controls while a flag submission is in flight', async () => {

--- a/dashboard/src/components/board/board-moderation-surface.test.ts
+++ b/dashboard/src/components/board/board-moderation-surface.test.ts
@@ -78,7 +78,44 @@ describe('BoardModerationSurface', () => {
     expect(screen.getByText('spam')).toBeTruthy()
     expect(screen.getByText('keeper-a')).toBeTruthy()
     expect(screen.getByText('open')).toBeTruthy()
-    expect(fetchQueueMock).toHaveBeenCalledWith({ resolved: false })
+    expect(fetchQueueMock).toHaveBeenCalledWith(expect.objectContaining({
+      resolved: false,
+      signal: expect.any(AbortSignal),
+    }))
+  })
+
+  it('ignores aborted stale queue loads', async () => {
+    let rejectFirst: ((reason?: unknown) => void) | null = null
+    fetchQueueMock
+      .mockImplementationOnce((options = {}) => new Promise((_, reject) => {
+        const { signal } = options
+        rejectFirst = reject
+        signal?.addEventListener('abort', () => reject(new DOMException('aborted', 'AbortError')))
+      }))
+      .mockResolvedValueOnce({
+        count: 1,
+        entries: [
+          {
+            entry_id: 'flag-resolved',
+            target_kind: 'post',
+            target_id: 'post-resolved',
+            reporter: 'keeper-b',
+            reason: 'spam',
+            flagged_at: 1_779_000_010,
+            flagged_at_iso: '2026-05-17T06:40:10.000Z',
+            resolved: true,
+          },
+        ],
+      })
+
+    render(h(BoardModerationSurface, null))
+    await waitFor(() => expect(fetchQueueMock).toHaveBeenCalledTimes(1))
+    fireEvent.change(screen.getByTestId('moderation-filter'), { target: { value: 'resolved' } })
+
+    expect(rejectFirst).not.toBeNull()
+    await screen.findByText('post-resolved')
+    expect(screen.queryByText('post-1')).toBeNull()
+    expect(fetchQueueMock.mock.calls[0]?.[0]?.signal?.aborted).toBe(true)
   })
 
   it('flags a target and reloads the queue', async () => {

--- a/dashboard/src/components/board/board-moderation-surface.test.ts
+++ b/dashboard/src/components/board/board-moderation-surface.test.ts
@@ -138,6 +138,38 @@ describe('BoardModerationSurface', () => {
     expect(fetchQueueMock).toHaveBeenCalledTimes(2)
   })
 
+  it('locks queue controls while a flag submission is in flight', async () => {
+    const queuedEntry = {
+      entry_id: 'flag-2',
+      target_kind: 'comment',
+      target_id: 'comment-2',
+      reporter: 'operator',
+      reason: 'harassment',
+      flagged_at: 1_779_000_100,
+      flagged_at_iso: '2026-05-17T06:41:40.000Z',
+      resolved: false,
+    } satisfies Awaited<ReturnType<typeof flagBoardModerationTarget>>
+    let resolveFlag: (() => void) | null = null
+    flagTargetMock.mockImplementationOnce(() => new Promise(resolve => {
+      resolveFlag = () => resolve(queuedEntry)
+    }))
+    render(h(BoardModerationSurface, null))
+
+    await screen.findByText('post-1')
+    fireEvent.change(screen.getByTestId('moderation-target-kind'), { target: { value: 'comment' } })
+    fireEvent.input(screen.getByTestId('moderation-target-id'), { target: { value: ' comment-2 ' } })
+    fireEvent.change(screen.getByTestId('moderation-reason'), { target: { value: 'harassment' } })
+    fireEvent.click(screen.getByTestId('moderation-flag-submit'))
+
+    await waitFor(() => expect(flagTargetMock).toHaveBeenCalledTimes(1))
+    expect(screen.getByTestId('moderation-filter')).toBeDisabled()
+    expect(screen.getByLabelText('Refresh moderation queue')).toBeDisabled()
+    const completeFlag = resolveFlag as (() => void) | null
+    expect(completeFlag).not.toBeNull()
+    completeFlag?.()
+    await waitFor(() => expect(fetchQueueMock).toHaveBeenCalledTimes(2))
+  })
+
   it('submits an action for an unresolved queue entry', async () => {
     render(h(BoardModerationSurface, null))
 
@@ -151,5 +183,38 @@ describe('BoardModerationSurface', () => {
       reason: 'spam',
     }))
     expect(fetchQueueMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('locks queue controls while a moderation action is in flight', async () => {
+    const actionResult = {
+      entry: {
+        audit_id: 'audit-1',
+        target_kind: 'post',
+        target_id: 'post-1',
+        actor: 'operator',
+        action: 'hide',
+        reason: 'spam',
+        note: null,
+        acted_at: 1_779_000_200,
+        acted_at_iso: '2026-05-17T06:43:20.000Z',
+      },
+      delete_warning: null,
+    } satisfies Awaited<ReturnType<typeof submitBoardModerationAction>>
+    let resolveAction: (() => void) | null = null
+    submitActionMock.mockImplementationOnce(() => new Promise(resolve => {
+      resolveAction = () => resolve(actionResult)
+    }))
+    render(h(BoardModerationSurface, null))
+
+    await screen.findByText('post-1')
+    fireEvent.click(screen.getByTestId('moderation-action-flag-1-hide'))
+
+    await waitFor(() => expect(submitActionMock).toHaveBeenCalledTimes(1))
+    expect(screen.getByTestId('moderation-filter')).toBeDisabled()
+    expect(screen.getByLabelText('Refresh moderation queue')).toBeDisabled()
+    const completeAction = resolveAction as (() => void) | null
+    expect(completeAction).not.toBeNull()
+    completeAction?.()
+    await waitFor(() => expect(fetchQueueMock).toHaveBeenCalledTimes(2))
   })
 })

--- a/dashboard/src/components/board/board-moderation-surface.test.ts
+++ b/dashboard/src/components/board/board-moderation-surface.test.ts
@@ -1,0 +1,118 @@
+import { h } from 'preact'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/preact'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import '@testing-library/jest-dom'
+import { BoardModerationSurface } from './board-moderation-surface'
+import {
+  fetchBoardModerationQueue,
+  flagBoardModerationTarget,
+  submitBoardModerationAction,
+} from '../../api/board-moderation'
+
+vi.mock('../../api/board-moderation', () => ({
+  fetchBoardModerationQueue: vi.fn(),
+  flagBoardModerationTarget: vi.fn(),
+  submitBoardModerationAction: vi.fn(),
+}))
+
+vi.mock('../common/toast', () => ({
+  showToast: vi.fn(),
+}))
+
+const fetchQueueMock = vi.mocked(fetchBoardModerationQueue)
+const flagTargetMock = vi.mocked(flagBoardModerationTarget)
+const submitActionMock = vi.mocked(submitBoardModerationAction)
+
+describe('BoardModerationSurface', () => {
+  beforeEach(() => {
+    fetchQueueMock.mockResolvedValue({
+      count: 1,
+      entries: [
+        {
+          entry_id: 'flag-1',
+          target_kind: 'post',
+          target_id: 'post-1',
+          reporter: 'keeper-a',
+          reason: 'spam',
+          flagged_at: 1_779_000_000,
+          flagged_at_iso: '2026-05-17T06:40:00.000Z',
+          resolved: false,
+        },
+      ],
+    })
+    flagTargetMock.mockResolvedValue({
+      entry_id: 'flag-2',
+      target_kind: 'comment',
+      target_id: 'comment-2',
+      reporter: 'operator',
+      reason: 'harassment',
+      flagged_at: 1_779_000_100,
+      flagged_at_iso: '2026-05-17T06:41:40.000Z',
+      resolved: false,
+    })
+    submitActionMock.mockResolvedValue({
+      entry: {
+        audit_id: 'audit-1',
+        target_kind: 'post',
+        target_id: 'post-1',
+        actor: 'operator',
+        action: 'hide',
+        reason: 'spam',
+        note: null,
+        acted_at: 1_779_000_200,
+        acted_at_iso: '2026-05-17T06:43:20.000Z',
+      },
+      delete_warning: null,
+    })
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.clearAllMocks()
+  })
+
+  it('renders queue entries with moderation state', async () => {
+    render(h(BoardModerationSurface, null))
+
+    expect(await screen.findByText('post-1')).toBeTruthy()
+    expect(screen.getByText('spam')).toBeTruthy()
+    expect(screen.getByText('keeper-a')).toBeTruthy()
+    expect(screen.getByText('open')).toBeTruthy()
+    expect(fetchQueueMock).toHaveBeenCalledWith({ resolved: false })
+  })
+
+  it('flags a target and reloads the queue', async () => {
+    fetchQueueMock.mockResolvedValueOnce({ count: 0, entries: [] })
+    render(h(BoardModerationSurface, null))
+
+    await waitFor(() => expect(fetchQueueMock).toHaveBeenCalledTimes(1))
+    fireEvent.change(screen.getByTestId('moderation-target-kind'), { target: { value: 'comment' } })
+    fireEvent.input(screen.getByTestId('moderation-target-id'), { target: { value: ' comment-2 ' } })
+    fireEvent.change(screen.getByTestId('moderation-reason'), { target: { value: 'harassment' } })
+    fireEvent.input(screen.getByTestId('moderation-reporter'), { target: { value: ' operator ' } })
+    fireEvent.click(screen.getByTestId('moderation-flag-submit'))
+
+    await waitFor(() => expect(flagTargetMock).toHaveBeenCalledWith({
+      target_kind: 'comment',
+      target_id: ' comment-2 ',
+      reporter: ' operator ',
+      reason: 'harassment',
+    }))
+    expect(fetchQueueMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('submits an action for an unresolved queue entry', async () => {
+    render(h(BoardModerationSurface, null))
+
+    await screen.findByText('post-1')
+    fireEvent.click(screen.getByTestId('moderation-action-flag-1-hide'))
+
+    await waitFor(() => expect(submitActionMock).toHaveBeenCalledWith({
+      target_kind: 'post',
+      target_id: 'post-1',
+      action: 'hide',
+      reason: 'spam',
+    }))
+    expect(fetchQueueMock).toHaveBeenCalledTimes(2)
+  })
+})

--- a/dashboard/src/components/board/board-moderation-surface.ts
+++ b/dashboard/src/components/board/board-moderation-surface.ts
@@ -1,0 +1,330 @@
+import { html } from 'htm/preact'
+import { useCallback, useEffect, useMemo, useState } from 'preact/hooks'
+import { CheckCircle2, EyeOff, RefreshCw, ShieldAlert, Trash2 } from 'lucide-preact'
+import {
+  fetchBoardModerationQueue,
+  flagBoardModerationTarget,
+  submitBoardModerationAction,
+  type BoardModerationActionKind,
+  type BoardModerationFlagReason,
+  type BoardModerationQueueEntry,
+  type BoardModerationTargetKind,
+} from '../../api/board-moderation'
+import { ActionButton } from '../common/button'
+import { EmptyState, LoadingState } from '../common/feedback-state'
+import { TextInput } from '../common/input'
+import { Select } from '../common/select'
+import { SurfaceCard } from '../common/card'
+import { TimeAgo } from '../common/time-ago'
+import { showToast } from '../common/toast'
+
+type QueueFilter = 'open' | 'resolved' | 'all'
+
+const TARGET_OPTIONS: Array<{ value: BoardModerationTargetKind; label: string }> = [
+  { value: 'post', label: 'Post' },
+  { value: 'comment', label: 'Comment' },
+]
+
+const REASON_OPTIONS: Array<{ value: BoardModerationFlagReason; label: string }> = [
+  { value: 'spam', label: 'Spam' },
+  { value: 'harassment', label: 'Harassment' },
+  { value: 'off_topic', label: 'Off topic' },
+  { value: 'policy:operator', label: 'Policy' },
+]
+
+const FILTER_OPTIONS: Array<{ value: QueueFilter; label: string }> = [
+  { value: 'open', label: 'Open' },
+  { value: 'resolved', label: 'Resolved' },
+  { value: 'all', label: 'All' },
+]
+
+const ACTION_META: Record<BoardModerationActionKind, {
+  label: string
+  variant: 'ghost' | 'danger' | 'warn' | 'ok'
+  icon: typeof CheckCircle2
+}> = {
+  approve: { label: 'Approve', variant: 'ok', icon: CheckCircle2 },
+  hide: { label: 'Hide', variant: 'warn', icon: EyeOff },
+  remove: { label: 'Remove', variant: 'danger', icon: Trash2 },
+  warn: { label: 'Warn', variant: 'ghost', icon: ShieldAlert },
+}
+
+function resolvedQuery(filter: QueueFilter): boolean | undefined {
+  if (filter === 'open') return false
+  if (filter === 'resolved') return true
+  return undefined
+}
+
+function queueTimestamp(entry: BoardModerationQueueEntry): string {
+  return entry.flagged_at_iso ?? new Date(entry.flagged_at * 1000).toISOString()
+}
+
+function QueueRow({
+  entry,
+  busyAction,
+  onAction,
+}: {
+  entry: BoardModerationQueueEntry
+  busyAction: string | null
+  onAction: (entry: BoardModerationQueueEntry, action: BoardModerationActionKind) => void
+}) {
+  return html`
+    <${SurfaceCard} variant="compact" testId=${`moderation-row-${entry.entry_id}`}>
+      <div class="grid gap-3 lg:grid-cols-[1fr_auto] lg:items-start">
+        <div class="min-w-0 space-y-2">
+          <div class="flex min-w-0 flex-wrap items-center gap-2">
+            <span class="inline-flex size-7 items-center justify-center rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] text-[var(--color-fg-muted)]" aria-hidden="true">
+              <${ShieldAlert} size=${15} />
+            </span>
+            <div class="min-w-0">
+              <h3 class="truncate font-mono text-sm font-semibold text-[var(--color-fg-primary)]">${entry.target_id}</h3>
+              <div class="flex flex-wrap items-center gap-2 text-2xs text-[var(--color-fg-muted)]">
+                <span>${entry.target_kind}</span>
+                <span>${entry.reason}</span>
+                <span>${entry.reporter}</span>
+                <span><${TimeAgo} timestamp=${queueTimestamp(entry)} /></span>
+              </div>
+            </div>
+          </div>
+          <div class="flex flex-wrap items-center gap-2 text-2xs text-[var(--color-fg-muted)]">
+            <span class=${`inline-flex rounded-[var(--r-1)] border px-1.5 py-0.5 ${
+              entry.resolved
+                ? 'border-[var(--ok-30)] bg-[var(--ok-10)] text-[var(--ok-bright)]'
+                : 'border-[var(--warn-30)] bg-[var(--warn-10)] text-[var(--warn-bright)]'
+            }`}>
+              ${entry.resolved ? 'resolved' : 'open'}
+            </span>
+            <span class="font-mono">${entry.entry_id}</span>
+          </div>
+        </div>
+        <div class="flex flex-wrap gap-2 lg:justify-end">
+          ${(['approve', 'hide', 'warn', 'remove'] as const).map(action => {
+            const meta = ACTION_META[action]
+            const Icon = meta.icon
+            const busy = busyAction === `${entry.entry_id}:${action}`
+            return html`
+              <${ActionButton}
+                key=${action}
+                variant=${meta.variant}
+                size="sm"
+                disabled=${entry.resolved || busyAction !== null}
+                ariaBusy=${busy}
+                ariaLabel=${`${meta.label} moderation flag ${entry.entry_id}`}
+                testId=${`moderation-action-${entry.entry_id}-${action}`}
+                onClick=${() => onAction(entry, action)}
+              >
+                <span class="inline-flex items-center gap-1.5">
+                  <${Icon} size=${13} aria-hidden="true" />
+                  ${busy ? 'Working' : meta.label}
+                </span>
+              <//>
+            `
+          })}
+        </div>
+      </div>
+    <//>
+  `
+}
+
+export function BoardModerationSurface() {
+  const [entries, setEntries] = useState<BoardModerationQueueEntry[]>([])
+  const [serverCount, setServerCount] = useState(0)
+  const [filter, setFilter] = useState<QueueFilter>('open')
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [targetKind, setTargetKind] = useState<BoardModerationTargetKind>('post')
+  const [targetId, setTargetId] = useState('')
+  const [reporter, setReporter] = useState('dashboard')
+  const [reason, setReason] = useState<BoardModerationFlagReason>('spam')
+  const [submitting, setSubmitting] = useState(false)
+  const [busyAction, setBusyAction] = useState<string | null>(null)
+
+  const load = useCallback(async () => {
+    setLoading(true)
+    setError(null)
+    try {
+      const queue = await fetchBoardModerationQueue({ resolved: resolvedQuery(filter) })
+      setEntries(queue.entries)
+      setServerCount(queue.count)
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to load moderation queue'
+      setError(message)
+    } finally {
+      setLoading(false)
+    }
+  }, [filter])
+
+  useEffect(() => {
+    void load()
+  }, [load])
+
+  const openCount = useMemo(() => entries.filter(entry => !entry.resolved).length, [entries])
+  const canSubmit = targetId.trim() !== '' && !submitting
+
+  const submitFlag = async (event: Event) => {
+    event.preventDefault()
+    if (!canSubmit) return
+    setSubmitting(true)
+    setError(null)
+    try {
+      await flagBoardModerationTarget({
+        target_kind: targetKind,
+        target_id: targetId,
+        reporter,
+        reason,
+      })
+      setTargetId('')
+      showToast('Moderation flag queued', 'success')
+      await load()
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to flag target'
+      setError(message)
+      showToast(`Moderation flag failed: ${message}`, 'error')
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  const handleAction = async (
+    entry: BoardModerationQueueEntry,
+    action: BoardModerationActionKind,
+  ) => {
+    const key = `${entry.entry_id}:${action}`
+    setBusyAction(key)
+    setError(null)
+    try {
+      const result = await submitBoardModerationAction({
+        target_kind: entry.target_kind,
+        target_id: entry.target_id,
+        action,
+        reason: entry.reason,
+      })
+      showToast(result.delete_warning ?? `Moderation action recorded: ${action}`, result.delete_warning ? 'warning' : 'success')
+      await load()
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to record moderation action'
+      setError(message)
+      showToast(`Moderation action failed: ${message}`, 'error')
+    } finally {
+      setBusyAction(null)
+    }
+  }
+
+  return html`
+    <section class="flex min-w-0 flex-col gap-4" aria-label="Board moderation">
+      <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div class="min-w-0">
+          <h2 class="text-base font-semibold text-[var(--color-fg-primary)]">Board Moderation</h2>
+          <p class="mt-1 text-xs text-[var(--color-fg-muted)]">${openCount} open / ${serverCount} returned</p>
+        </div>
+        <div class="flex flex-wrap items-center gap-2">
+          <${Select}
+            value=${filter}
+            options=${FILTER_OPTIONS}
+            ariaLabel="Moderation queue filter"
+            testId="moderation-filter"
+            class="!w-32 !py-1 !text-xs"
+            disabled=${loading}
+            onInput=${(value: string) => setFilter(value as QueueFilter)}
+          />
+          <${ActionButton}
+            variant="ghost"
+            size="sm"
+            onClick=${() => { void load() }}
+            disabled=${loading}
+            ariaLabel="Refresh moderation queue"
+          >
+            <span class="inline-flex items-center gap-1.5">
+              <${RefreshCw} size=${14} aria-hidden="true" />
+              Refresh
+            </span>
+          <//>
+        </div>
+      </div>
+
+      <form class="grid gap-3 rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] p-3" onSubmit=${submitFlag}>
+        <div class="grid gap-3 lg:grid-cols-[0.7fr_1fr_0.8fr_0.8fr_auto] lg:items-end">
+          <label class="grid gap-1 text-2xs font-medium uppercase text-[var(--color-fg-muted)]">
+            Target
+            <${Select}
+              value=${targetKind}
+              options=${TARGET_OPTIONS}
+              disabled=${submitting}
+              ariaLabel="Moderation target kind"
+              testId="moderation-target-kind"
+              onInput=${(value: string) => setTargetKind(value as BoardModerationTargetKind)}
+            />
+          </label>
+          <label class="grid gap-1 text-2xs font-medium uppercase text-[var(--color-fg-muted)]">
+            Target ID
+            <${TextInput}
+              value=${targetId}
+              required
+              disabled=${submitting}
+              placeholder="post-id"
+              ariaLabel="Moderation target id"
+              testId="moderation-target-id"
+              onInput=${(event: Event) => setTargetId((event.target as HTMLInputElement).value)}
+            />
+          </label>
+          <label class="grid gap-1 text-2xs font-medium uppercase text-[var(--color-fg-muted)]">
+            Reason
+            <${Select}
+              value=${reason}
+              options=${REASON_OPTIONS}
+              disabled=${submitting}
+              ariaLabel="Moderation reason"
+              testId="moderation-reason"
+              onInput=${(value: string) => setReason(value as BoardModerationFlagReason)}
+            />
+          </label>
+          <label class="grid gap-1 text-2xs font-medium uppercase text-[var(--color-fg-muted)]">
+            Reporter
+            <${TextInput}
+              value=${reporter}
+              disabled=${submitting}
+              placeholder="dashboard"
+              ariaLabel="Moderation reporter"
+              testId="moderation-reporter"
+              onInput=${(event: Event) => setReporter((event.target as HTMLInputElement).value)}
+            />
+          </label>
+          <${ActionButton}
+            type="submit"
+            variant="primary"
+            size="md"
+            disabled=${!canSubmit}
+            ariaBusy=${submitting}
+            testId="moderation-flag-submit"
+          >
+            <span class="inline-flex items-center gap-1.5">
+              <${ShieldAlert} size=${14} aria-hidden="true" />
+              Flag
+            </span>
+          <//>
+        </div>
+      </form>
+
+      ${error ? html`
+        <div class="rounded-[var(--r-1)] border border-[var(--color-status-err)]/40 bg-[var(--color-status-err)]/10 px-3 py-2 text-xs text-[var(--color-status-err)]" role="alert">${error}</div>
+      ` : null}
+
+      ${loading
+        ? html`<${LoadingState}>Loading moderation queue...<//>`
+        : entries.length === 0
+          ? html`<${EmptyState} message="No moderation queue entries." compact />`
+          : html`
+            <div class="grid gap-3" data-testid="moderation-queue">
+              ${entries.map(entry => html`
+                <${QueueRow}
+                  key=${entry.entry_id}
+                  entry=${entry}
+                  busyAction=${busyAction}
+                  onAction=${handleAction}
+                />
+              `)}
+            </div>
+          `}
+    </section>
+  `
+}

--- a/dashboard/src/components/board/board-moderation-surface.ts
+++ b/dashboard/src/components/board/board-moderation-surface.ts
@@ -17,6 +17,7 @@ import { Select } from '../common/select'
 import { SurfaceCard } from '../common/card'
 import { TimeAgo } from '../common/time-ago'
 import { showToast } from '../common/toast'
+import { currentCanonicalDashboardActor } from '../../lib/dashboard-session-actor'
 
 type QueueFilter = 'open' | 'resolved' | 'all'
 
@@ -134,7 +135,7 @@ export function BoardModerationSurface() {
   const [error, setError] = useState<string | null>(null)
   const [targetKind, setTargetKind] = useState<BoardModerationTargetKind>('post')
   const [targetId, setTargetId] = useState('')
-  const [reporter, setReporter] = useState('dashboard')
+  const [reporter, setReporter] = useState(() => currentCanonicalDashboardActor() ?? '')
   const [reason, setReason] = useState<BoardModerationFlagReason>('spam')
   const [submitting, setSubmitting] = useState(false)
   const [busyAction, setBusyAction] = useState<string | null>(null)
@@ -304,7 +305,7 @@ export function BoardModerationSurface() {
             <${TextInput}
               value=${reporter}
               disabled=${submitting}
-              placeholder="dashboard"
+              placeholder="operator"
               ariaLabel="Moderation reporter"
               testId="moderation-reporter"
               onInput=${(event: Event) => setReporter((event.target as HTMLInputElement).value)}

--- a/dashboard/src/components/board/board-moderation-surface.ts
+++ b/dashboard/src/components/board/board-moderation-surface.ts
@@ -180,6 +180,7 @@ export function BoardModerationSurface() {
 
   const openCount = useMemo(() => entries.filter(entry => !entry.resolved).length, [entries])
   const canSubmit = targetId.trim() !== '' && !submitting
+  const queueControlsDisabled = loading || submitting || busyAction !== null
 
   const submitFlag = async (event: Event) => {
     event.preventDefault()
@@ -244,14 +245,14 @@ export function BoardModerationSurface() {
             ariaLabel="Moderation queue filter"
             testId="moderation-filter"
             class="!w-32 !py-1 !text-xs"
-            disabled=${loading}
+            disabled=${queueControlsDisabled}
             onInput=${(value: string) => setFilter(value as QueueFilter)}
           />
           <${ActionButton}
             variant="ghost"
             size="sm"
             onClick=${() => { void load() }}
-            disabled=${loading}
+            disabled=${queueControlsDisabled}
             ariaLabel="Refresh moderation queue"
           >
             <span class="inline-flex items-center gap-1.5">

--- a/dashboard/src/components/board/board-moderation-surface.ts
+++ b/dashboard/src/components/board/board-moderation-surface.ts
@@ -1,5 +1,5 @@
 import { html } from 'htm/preact'
-import { useCallback, useEffect, useMemo, useState } from 'preact/hooks'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'preact/hooks'
 import { CheckCircle2, EyeOff, RefreshCw, ShieldAlert, Trash2 } from 'lucide-preact'
 import {
   fetchBoardModerationQueue,
@@ -138,24 +138,44 @@ export function BoardModerationSurface() {
   const [reason, setReason] = useState<BoardModerationFlagReason>('spam')
   const [submitting, setSubmitting] = useState(false)
   const [busyAction, setBusyAction] = useState<string | null>(null)
+  const activeLoad = useRef<{ id: number; controller: AbortController } | null>(null)
+  const nextLoadId = useRef(0)
 
   const load = useCallback(async () => {
+    activeLoad.current?.controller.abort()
+    const controller = new AbortController()
+    const id = nextLoadId.current + 1
+    nextLoadId.current = id
+    activeLoad.current = { id, controller }
     setLoading(true)
     setError(null)
     try {
-      const queue = await fetchBoardModerationQueue({ resolved: resolvedQuery(filter) })
+      const queue = await fetchBoardModerationQueue({
+        resolved: resolvedQuery(filter),
+        signal: controller.signal,
+      })
+      if (activeLoad.current?.id !== id || controller.signal.aborted) return
       setEntries(queue.entries)
       setServerCount(queue.count)
     } catch (err) {
+      if (activeLoad.current?.id !== id || controller.signal.aborted) return
       const message = err instanceof Error ? err.message : 'Failed to load moderation queue'
       setError(message)
     } finally {
-      setLoading(false)
+      if (activeLoad.current?.id === id) {
+        activeLoad.current = null
+        setLoading(false)
+      }
     }
   }, [filter])
 
   useEffect(() => {
     void load()
+    return () => {
+      activeLoad.current?.controller.abort()
+      activeLoad.current = null
+      nextLoadId.current += 1
+    }
   }, [load])
 
   const openCount = useMemo(() => entries.filter(entry => !entry.resolved).length, [entries])

--- a/dashboard/src/components/board/index.ts
+++ b/dashboard/src/components/board/index.ts
@@ -1,4 +1,5 @@
 export { BoardSurface } from './board-surface'
+export { BoardModerationSurface } from './board-moderation-surface'
 export { SubBoardSurface } from './sub-board-surface'
 export * from './board-state'
 export {

--- a/dashboard/src/components/work.test.ts
+++ b/dashboard/src/components/work.test.ts
@@ -16,6 +16,7 @@ vi.mock('../router', () => ({
 
 vi.mock('./board', () => ({
   BoardSurface: () => html`<div data-testid="board-surface">Board</div>`,
+  BoardModerationSurface: () => html`<div data-testid="board-moderation-surface">Moderation</div>`,
   SubBoardSurface: () => html`<div data-testid="sub-board-surface">Sub-Boards</div>`,
 }))
 
@@ -46,6 +47,19 @@ describe('Work', () => {
     render(html`<${Work} />`)
 
     expect(screen.getByTestId('sub-board-surface')).toBeTruthy()
+    expect(screen.queryByTestId('board-surface')).toBeNull()
+  })
+
+  it('renders the board moderation surface for the workspace moderation section', () => {
+    routeSignal.value = {
+      tab: 'workspace',
+      params: { section: 'moderation' },
+      postId: null,
+    }
+
+    render(html`<${Work} />`)
+
+    expect(screen.getByTestId('board-moderation-surface')).toBeTruthy()
     expect(screen.queryByTestId('board-surface')).toBeNull()
   })
 

--- a/dashboard/src/components/work.ts
+++ b/dashboard/src/components/work.ts
@@ -4,20 +4,20 @@
 import { html } from 'htm/preact'
 import { lazy, Suspense } from 'preact/compat'
 import { route } from '../router'
-import { BoardSurface, SubBoardSurface } from './board'
+import { BoardModerationSurface, BoardSurface, SubBoardSurface } from './board'
 import { PlanningPanel } from './planning-panel'
 import { VerificationRequestsPanel } from './verification-requests-panel'
 import { ErrorBoundary } from './common/error-boundary'
 import { LoadingState } from './common/feedback-state'
 
-type WorkSection = 'board' | 'sub-boards' | 'planning' | 'repositories' | 'verification'
+type WorkSection = 'board' | 'sub-boards' | 'moderation' | 'planning' | 'repositories' | 'verification'
 
 const LazyRepositoryManagement = lazy(async () => ({
   default: (await import('./repository-management')).RepositoryManagement,
 }))
 
 function isWorkSection(v: string | undefined): v is WorkSection {
-  return v === 'board' || v === 'sub-boards' || v === 'planning' || v === 'repositories' || v === 'verification'
+  return v === 'board' || v === 'sub-boards' || v === 'moderation' || v === 'planning' || v === 'repositories' || v === 'verification'
 }
 
 export function Work() {
@@ -31,6 +31,7 @@ export function Work() {
         <${ErrorBoundary} label=${current}>
           ${current === 'board' ? html`<${BoardSurface} />`
             : current === 'sub-boards' ? html`<${SubBoardSurface} />`
+            : current === 'moderation' ? html`<${BoardModerationSurface} />`
             : current === 'planning' ? html`<${PlanningPanel} />`
             : current === 'repositories' ? html`
               <${Suspense} fallback=${html`<${LoadingState}>저장소 화면 불러오는 중...<//>`}>


### PR DESCRIPTION
## Summary

- Add a dashboard moderation API client for the existing admin routes:
  `/api/v1/dashboard/board/moderation/queue`, `/flag`, and `/action`.
- Normalize queue and audit entries from the backend JSON contract, including
  typed target/action/reason values and ISO timestamps for display consumers.
- Add a `section=moderation` dashboard surface for queue inspection, flag
  creation, and approve/hide/warn/remove actions.
- Add focused contract and component tests for queue filtering, request bodies,
  delete warnings, malformed row handling, and `Work` route selection.

## Why

The Phase 2 board moderation backend was already wired, but the dashboard had no
typed client or operator-visible surface for consuming it. This gives the
operator UI a narrow, tested moderation lane without touching the broader board
client files currently involved in other PRs.

## Validation

- `pnpm exec vitest run --config vitest.config.ts src/api/board-moderation.test.ts src/components/board/board-moderation-surface.test.ts src/components/work.test.ts --no-file-parallelism --maxWorkers=1`
- `pnpm exec tsc --noEmit --pretty`
- `pnpm exec eslint src/api/board-moderation.ts src/api/board-moderation.test.ts src/components/board/board-moderation-surface.ts src/components/board/board-moderation-surface.test.ts src/components/board/index.ts src/components/work.ts src/components/work.test.ts`
  - 0 errors; current config reports some dashboard API/test files as ignored
- `git diff --check HEAD~1..HEAD`
