### PR TITLE
fix(oas): measure kimi error latency

### DIFF
--- a/lib/oas_worker_exec_transport.ml
+++ b/lib/oas_worker_exec_transport.ml
@@ -1228,15 +1228,20 @@ module Kimi_cli_transport_local = struct
           let on_line line =
             if String.trim line <> "" then seen_lines := line :: !seen_lines
           in
-          match
-            Llm_provider.Cli_common_subprocess.run_stream_lines ~sw ~mgr
-              ~name:"kimi" ~cwd:config.cwd ~extra_env:config.extra_env
-              ~on_stderr_line
-              ?stdin_content:(stdin_for_prompt prompt)
-              ~on_line ?cancel:config.cancel argv
-          with
+          let run_result, measured_latency_ms =
+            Inference_utils.timed (fun () ->
+                Llm_provider.Cli_common_subprocess.run_stream_lines ~sw ~mgr
+                  ~name:"kimi" ~cwd:config.cwd ~extra_env:config.extra_env
+                  ~on_stderr_line
+                  ?stdin_content:(stdin_for_prompt prompt)
+                  ~on_line ?cancel:config.cancel argv)
+          in
+          match run_result with
           | Error _ as err ->
-              { Llm_provider.Llm_transport.response = classify_cli_error err; latency_ms = 0 }
+              {
+                Llm_provider.Llm_transport.response = classify_cli_error err;
+                latency_ms = measured_latency_ms;
+              }
           | Ok { latency_ms; _ } ->
               let response =
                 parse_jsonl_result ~model_id (List.rev !seen_lines)

--- a/test/test_oas_worker.ml
+++ b/test/test_oas_worker.ml
@@ -104,6 +104,13 @@ let cleanup_dir dir =
   in
   try rm dir with _ -> ()
 
+let write_executable_file path contents =
+  let oc = open_out path in
+  Fun.protect
+    ~finally:(fun () -> close_out_noerr oc)
+    (fun () -> output_string oc contents);
+  Unix.chmod path 0o755
+
 let test_process_base_path = ref None
 
 let configure_direct_test_environment () =
@@ -3472,6 +3479,47 @@ let test_kimi_cli_should_log_stderr_line_filters_resume_noise () =
   Alcotest.(check bool) "other stderr guidance remains visible" true
     (should_log "warning: upstream endpoint is slow")
 
+let test_kimi_cli_error_completion_uses_measured_latency () =
+  let dir = temp_dir "kimi_cli_error_latency" in
+  let fake_kimi_path = Filename.concat dir "fake-kimi" in
+  write_executable_file fake_kimi_path
+    "#!/bin/sh\nsleep 0.05\nprintf '%s\\n' 'simulated failure' >&2\nexit 7\n";
+  let config =
+    {
+      Oas_worker_exec.Kimi_cli_transport_local.default_config with
+      kimi_path = fake_kimi_path;
+    }
+  in
+  let req =
+    {
+      (mock_completion_request ()) with
+      config = make_kimi_cli_provider_cfg ();
+      messages =
+        [
+          {
+            Agent_sdk.Types.role = Agent_sdk.Types.User;
+            content = [ Agent_sdk.Types.Text "hello" ];
+            name = None;
+            tool_call_id = None;
+            metadata = [];
+          };
+        ];
+    }
+  in
+  Eio.Switch.run @@ fun sw ->
+  let transport =
+    Oas_worker_exec.Kimi_cli_transport_local.create ~sw
+      ~mgr:(require_test_proc_mgr ()) ~config
+  in
+  let { Llm_provider.Llm_transport.response; latency_ms } =
+    transport.complete_sync req
+  in
+  Alcotest.(check bool) "failed subprocess latency is measured" true
+    (latency_ms > 0);
+  match response with
+  | Error _ -> ()
+  | Ok _ -> Alcotest.fail "expected fake kimi subprocess to fail"
+
 let test_kimi_cli_classify_cli_error_redacts_resumable_session_detail () =
   let raw_message =
     "kimi exited with code 75: \nTo resume this session: kimi -r ff37febe-2adb-4ac6-9dc6-cae23e672fbc"
@@ -5308,6 +5356,8 @@ let () =
         test_kimi_cli_config_uses_oas_context_ssot;
       Alcotest.test_case "kimi stderr resume noise is filtered" `Quick
         test_kimi_cli_should_log_stderr_line_filters_resume_noise;
+      Alcotest.test_case "kimi error completion measures latency" `Quick
+        test_kimi_cli_error_completion_uses_measured_latency;
       Alcotest.test_case "kimi exit 75 detail is redacted" `Quick
         test_kimi_cli_classify_cli_error_redacts_resumable_session_detail;
       Alcotest.test_case "kimi exit 1 resume hint is resumable" `Quick


### PR DESCRIPTION
## Summary

- measure wall-clock latency around the Kimi CLI `run_stream_lines` call
- use the measured latency for Kimi CLI subprocess error results instead of returning a synthetic `0`
- add a focused regression test with a fake Kimi executable that exits nonzero and verifies the error result still carries positive measured latency

## Why

Kimi CLI failures previously looked like zero-millisecond completions, which made transport telemetry ambiguous and hid the real time spent waiting on a failing subprocess. This keeps the current OAS/agent_sdk `latency_ms : int` contract intact while removing the fake-zero fallback for this MASC path.

True nullable/unavailable latency needs an upstream OAS contract change; recorded separately as https://github.com/jeong-sik/oas/issues/1450.

## Validation

- `git diff --check origin/main..HEAD`
- `ocamlformat --check lib/oas_worker_exec_transport.ml test/test_oas_worker.ml` (repo-baseline nonzero/no-output behavior)
- `scripts/dune-local.sh build test/test_oas_worker.exe`
- `./_build/default/test/test_oas_worker.exe test resume_config 65`