### PR TITLE
feat(docker): P0/P1 cleanup — STOPSIGNAL + compose + prune + .masc/tmp purge

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -76,6 +76,12 @@ VOLUME ["/app/.masc"]
 
 EXPOSE 8080
 
+# Graceful shutdown: bin/main_eio.ml runs a 4-phase shutdown
+# (NOTIFY → HOOKS → BOARD → CANCEL) on SIGTERM. Make the contract
+# explicit so docker stop / compose / k8s never replace it with SIGKILL
+# without going through the OCaml shutdown path first.
+STOPSIGNAL SIGTERM
+
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
   CMD curl -fsS http://localhost:${PORT}/health || exit 1
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,6 +38,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libsqlite3-0 \
     libssl3t64 \
     libzstd1 \
+    tini \
     zlib1g \
     && rm -rf /var/lib/apt/lists/*
 
@@ -86,6 +87,12 @@ HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
   CMD curl -fsS http://localhost:${PORT}/health || exit 1
 
 USER appuser
+
+# tini is PID 1, masc-mcp runs as PID 2. tini forwards SIGTERM to its
+# child (preserving STOPSIGNAL contract) and reaps zombies. Compose's
+# `init: true` would do the same via docker-init, but baking tini in
+# guarantees zombie reaping for plain `docker run` without --init too.
+ENTRYPOINT ["/usr/bin/tini", "--"]
 
 # --base-path is already set via MASC_BASE_PATH; avoid duplication.
 CMD ["/app/masc-mcp", "--port", "8080"]

--- a/Dockerfile.keeper-sandbox
+++ b/Dockerfile.keeper-sandbox
@@ -47,4 +47,8 @@ ENV PATH="/opt/opam/default/bin:${PATH}"
 
 VOLUME ["/tmp/keeper-creds"]
 
+# Keeper sandbox: bash + tools (Read/Edit/Bash). SIGTERM lets bash and
+# any in-flight tool process exit gracefully before docker stop escalates.
+STOPSIGNAL SIGTERM
+
 CMD ["/bin/bash"]

--- a/Dockerfile.worker-runtime
+++ b/Dockerfile.worker-runtime
@@ -30,4 +30,7 @@ RUN apt-get update \
 
 COPY --from=build /src/_build/install/default/bin/masc-worker-run /usr/local/bin/masc-worker-run
 
+# Worker reads spec on stdin, exits cleanly on EOF or SIGTERM.
+STOPSIGNAL SIGTERM
+
 ENTRYPOINT ["/usr/local/bin/masc-worker-run", "--spec-stdin"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,60 @@
+# MASC MCP – local / single-host docker-compose orchestration.
+#
+# Production runs on Railway today; this compose file is for:
+#   - reproducible local stack-style runs (so docker stop respects
+#     the OCaml 4-phase graceful shutdown),
+#   - k8s/Nomad migrations that read compose for restart/log knobs,
+#   - smoke tests in `.github/workflows/deploy-railway.yml` if we ever
+#     want to drive them via compose.
+#
+# Knobs explained:
+#   - restart: unless-stopped — re-launch on crash, but never on a
+#     `docker compose stop`. Aligns with infrastructure/launchd plist
+#     `KeepAlive.SuccessfulExit=false`.
+#   - stop_grace_period: 60s — must exceed bin/main_eio.ml
+#     `shutdown_cfg.force_timeout_s` so phases NOTIFY/HOOKS/BOARD/CANCEL
+#     run before docker escalates to SIGKILL.
+#   - logging: json-file with max-size=10m × max-file=3 → ~30MB upper
+#     bound per container. Container logs cap is independent of the
+#     in-tree `lib/masc_log/log.ml` 7-day rotation.
+#   - volumes: durable JSONL state under /app/.masc (matches Dockerfile
+#     VOLUME). The image-baked /app/config remains read-only seed.
+
+services:
+  masc-mcp:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        # Override locally:
+        #   docker compose build --build-arg BINARY_PATH=_build/default/bin/main_eio.exe
+        BINARY_PATH: masc-mcp-linux-x64
+    image: masc-mcp:local
+    container_name: masc-mcp
+    init: true
+    restart: unless-stopped
+    stop_signal: SIGTERM
+    stop_grace_period: 60s
+    ports:
+      - "8080:8080"
+    environment:
+      PORT: "8080"
+      MASC_BASE_PATH: /app
+      MASC_CONFIG_DIR: /app/config
+    volumes:
+      - masc-state:/app/.masc
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://localhost:8080/health"]
+      interval: 30s
+      timeout: 3s
+      start_period: 5s
+      retries: 3
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
+
+volumes:
+  masc-state:
+    driver: local

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,7 +32,12 @@ services:
     container_name: masc-mcp
     restart: unless-stopped
     stop_signal: SIGTERM
-    stop_grace_period: 60s
+    # Give the server's force-exit watchdog (MASC_SHUTDOWN_FORCE_TIMEOUT
+    # below) a few seconds of headroom before Docker sends SIGKILL.
+    # Setting these equal would race: the watchdog and Docker would
+    # both fire at ~60s and the process could be killed mid-final-flush,
+    # losing the last log lines and post-shutdown hook telemetry.
+    stop_grace_period: 75s
     ports:
       - "8080:8080"
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,8 +11,10 @@
 #   - restart: unless-stopped — re-launch on crash, but never on a
 #     `docker compose stop`. Aligns with infrastructure/launchd plist
 #     `KeepAlive.SuccessfulExit=false`.
-#   - stop_grace_period: 60s — matches MASC_SHUTDOWN_FORCE_TIMEOUT so
-#     phases NOTIFY/HOOKS/BOARD/CANCEL run before docker escalates to SIGKILL.
+#   - stop_grace_period: 75s — sits 15s above MASC_SHUTDOWN_FORCE_TIMEOUT
+#     (60s) so the in-process force-exit watchdog can flush final logs
+#     before docker escalates to SIGKILL. Setting them equal raced both
+#     timers at ~60s and lost the last log line on shutdown.
 #   - logging: json-file with max-size=10m × max-file=3 → ~30MB upper
 #     bound per container. Container logs cap is independent of the
 #     in-tree `lib/masc_log/log.ml` 7-day rotation.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,9 +11,8 @@
 #   - restart: unless-stopped — re-launch on crash, but never on a
 #     `docker compose stop`. Aligns with infrastructure/launchd plist
 #     `KeepAlive.SuccessfulExit=false`.
-#   - stop_grace_period: 60s — must exceed bin/main_eio.ml
-#     `shutdown_cfg.force_timeout_s` so phases NOTIFY/HOOKS/BOARD/CANCEL
-#     run before docker escalates to SIGKILL.
+#   - stop_grace_period: 60s — matches MASC_SHUTDOWN_FORCE_TIMEOUT so
+#     phases NOTIFY/HOOKS/BOARD/CANCEL run before docker escalates to SIGKILL.
 #   - logging: json-file with max-size=10m × max-file=3 → ~30MB upper
 #     bound per container. Container logs cap is independent of the
 #     in-tree `lib/masc_log/log.ml` 7-day rotation.
@@ -31,7 +30,6 @@ services:
         BINARY_PATH: masc-mcp-linux-x64
     image: masc-mcp:local
     container_name: masc-mcp
-    init: true
     restart: unless-stopped
     stop_signal: SIGTERM
     stop_grace_period: 60s
@@ -41,6 +39,8 @@ services:
       PORT: "8080"
       MASC_BASE_PATH: /app
       MASC_CONFIG_DIR: /app/config
+      MASC_SHUTDOWN_CLEANUP_TIMEOUT: "10"
+      MASC_SHUTDOWN_FORCE_TIMEOUT: "60"
     volumes:
       - masc-state:/app/.masc
     healthcheck:

--- a/docs/rfc/RFC-0036-multi-keeper-docker-orchestration.md
+++ b/docs/rfc/RFC-0036-multi-keeper-docker-orchestration.md
@@ -1,0 +1,148 @@
+# RFC-0036: Multi-Keeper Docker Orchestration & Lifecycle Cleanup
+
+- **Status**: Draft
+- **Author**: vincent (with Claude Opus 4.7)
+- **Created**: 2026-05-06
+- **Drives**: closes verification report items #30, #32, #34 (single coupled track)
+- **Related**:
+  - `RFC-0002-keeper-state-machine.md` — terminal state semantics (Dead/Zombie)
+  - `RFC-0003-keeper-composite-lifecycle.md` — composite observer extension point
+  - `RFC-0006-keeper-surface-and-sandbox.md` — `docker_hardened` profile, current sandbox boundary
+  - PR #13848 — P0/P1/P3 docker cleanup scaffolding (compose, prune, timers, tmp purge)
+
+## 1. Problem
+
+The 2026-05-07 verification report (`docker_cleanup_code_verification.md`) identifies three remaining gaps that PR #13848 cannot close because each one crosses architecture boundaries that need explicit design:
+
+| # | Symptom | Mechanism |
+|---|---------|-----------|
+| 30 | Keeper transitions to `Dead`/`Zombie`; the in-process registry tombstone is reaped, but no Docker container is ever removed because keepers run as Eio fibers inside the single masc-mcp container | `Keeper_supervisor.cleanup_dead_tombstone` only touches in-memory registry + meta JSONL. There is nothing for it to talk to at the docker daemon level. |
+| 32 | Subprocesses spawned by keepers (e.g., `keeper_bash` in `docker_hardened` mode → DinD container, or `keeper_shell` rg/cat) can outlive their parent if the keeper crashes mid-call | `Process_eio.reset_for_testing` exists, but it's a test helper for the worker pool. No production hook drains keeper-owned subprocess descriptors on Dead transition. |
+| 34 | No `docker-compose.yml` per-keeper layout; smoke test (`keeper-docker-multikeeper-isolation-smoke.sh`) is the only place that runs `docker run` per keeper | The production architecture is "single container, many fibers." The smoke path proves isolation but is not the runtime model. |
+
+**These three are one design problem, not three independent ones.** #30 is meaningless without a per-keeper container to remove (that's #34). #32 is the cleanup hook on which both #30's container removal and the existing fiber-cancellation path depend.
+
+## 2. Goals / Non-Goals
+
+**Goals**
+- G1. Provide an opt-in `runtime_topology=multi-container` mode that runs each keeper in its own sandboxed container, gated on `Keeper_supervisor` FSM events.
+- G2. Define a single `lifecycle_cleanup_hook : keeper_id -> Phase -> unit` extension point in `Keeper_supervisor` so #30 and #32 share the same plumbing (no parallel hook systems).
+- G3. Make the `single-container` default unchanged for production. Multi-container is a host-level toggle, not a code-path replacement.
+- G4. Preserve all RFC-0002 phase-transition invariants (terminal states still reject events; Dead is still a tombstone).
+
+**Non-Goals**
+- Replace `Keeper_registry` or `Keeper_supervisor` core. Lifecycle FSM stays exactly as-is; only the hook fires.
+- Solve fleet-level scheduling (k8s/Nomad). This RFC stops at "compose can spawn N keeper containers locally."
+- Multi-host distribution. Single host, possibly multiple keepers.
+- Replace `docker_hardened` sandbox profile. Multi-container is orthogonal — a host can run `docker_hardened` keepers as fibers (today) or as containers (this RFC).
+
+## 3. Design
+
+### 3.1 Lifecycle cleanup hook (foundation, addresses #32)
+
+`lib/keeper/keeper_supervisor.ml` exposes:
+
+```ocaml
+type cleanup_event =
+  | Phase_transition of { from: Phase.t; to_: Phase.t }
+  | Tombstone_reaped
+
+type cleanup_hook = keeper_id:string -> cleanup_event -> unit
+
+val register_cleanup_hook : cleanup_hook -> unit
+```
+
+Calls fire on:
+- Every phase transition in `transition_to`, before the registry write commits.
+- `cleanup_dead_tombstone` exit, after the registry unregister.
+
+The hook is **synchronous, best-effort, non-throwing**. Implementations log + swallow exceptions; the supervisor never observes hook failure. This matches the same pattern as `Shutdown_hooks.run_all` (no timeout cliff that can preempt OCaml code). Hook list is `Atomic.t` ref-cell.
+
+Default registration: a single hook that drains tracked subprocess pids (closes #32). Subprocess registration is added to `keeper_bash`, `keeper_shell`, and `keeper_fs_*` execution paths — every external `Eio.Process.spawn` records pid+keeper_id, the cleanup hook sends SIGTERM and then `waitpid`.
+
+### 3.2 Multi-container topology (addresses #34)
+
+New env knob `MASC_KEEPER_RUNTIME_TOPOLOGY` with values:
+- `single-container` (default, current behavior — keeper = fiber)
+- `container-per-keeper` (opt-in — keeper = docker container)
+
+When `container-per-keeper`:
+- `Keeper_supervisor.boot_keeper` calls `Docker_runtime.spawn_keeper_container ~keeper_id ~persona ~base_path` instead of starting a fiber.
+- Container labels: `masc.keeper.id=<id>`, `masc.keeper.session=<server-uuid>`, `masc.keeper.runtime=container`.
+- Returns a `keeper_handle` opaque type that wraps either `fiber_handle` (single) or `container_handle` (multi). All other supervisor ops route through this handle.
+
+`docker-compose.multi-keeper.yml` (new file, NOT replacing the single-container `docker-compose.yml`):
+- One service template + scaling instructions, OR
+- One named service per keeper persona declared in `config/keepers/*.toml`.
+
+Decision deferred to Phase B (see §4).
+
+### 3.3 Dead → docker rm bridge (addresses #30)
+
+In `container-per-keeper` mode, register a cleanup hook from `Docker_runtime`:
+
+```ocaml
+let docker_rm_hook ~keeper_id = function
+  | Phase_transition { to_ = Phase.Dead | Phase.Zombie; _ } ->
+    Docker_runtime.schedule_container_removal ~keeper_id ~grace:30s
+  | Tombstone_reaped ->
+    Docker_runtime.force_remove_if_exists ~keeper_id
+  | _ -> ()
+```
+
+`schedule_container_removal` enqueues to a single-fiber queue so concurrent transitions don't issue racing `docker rm` calls. Removal uses `docker rm -f` only after the grace timeout; before that, `docker stop` (which sends SIGTERM honoring the new STOPSIGNAL contract from PR #13848).
+
+In `single-container` mode the hook is a noop — no container exists to remove, but the in-memory tombstone path still runs.
+
+## 4. Implementation Phases
+
+| Phase | Scope | Touches | Estimated PRs |
+|-------|-------|---------|---------------|
+| A | Cleanup hook plumbing + subprocess pid tracking (closes #32 in single-container mode) | `lib/keeper/keeper_supervisor.ml`, `lib/keeper/keeper_subprocess_registry.ml` (new), call-site instrumentation in `keeper_bash`/`keeper_shell` | 2 PRs (foundation + instrumentation) |
+| B | `Docker_runtime` module + topology env knob (no FSM changes; multi-container *option* only spawns, supervisor unaware) | `lib/docker_runtime.ml` (new), `bin/main_eio.ml` topology dispatch, `docker-compose.multi-keeper.yml` | 2 PRs (runtime + compose) |
+| C | Dead/Zombie → docker rm hook wiring + container_per_keeper integration test | hook registration in topology bootstrap, `test/test_keeper_docker_lifecycle.ml` (new), TLA spec `KeeperDockerBridge.tla` (new) | 1 PR + 1 spec PR |
+| D | Documentation + operator runbook | `docs/runbooks/multi-keeper-docker.md`, README pointer | 1 PR |
+
+Phase A is non-architectural — it's a hook plumbing addition that single-container deployments benefit from immediately (subprocess leak prevention). Phases B+C+D are architectural; can be deferred until a host actually needs container-per-keeper.
+
+## 5. Backward Compatibility
+
+- Default `single-container` topology: no behavior change, no FSM change, no compose change.
+- Hook registration is additive; existing code paths that don't register a hook see zero overhead (Atomic.get returns empty list).
+- `docker_hardened` sandbox profile is unchanged; it's orthogonal to topology.
+- Existing `keeper-docker-multikeeper-isolation-smoke.sh` continues to work; it's a smoke test, not the runtime path.
+
+## 6. Risks / Mitigations
+
+| Risk | Mitigation |
+|------|------------|
+| Hook callback throws → supervisor instability | Hook list is iterated under `try ... with _ -> log`. Supervisor never observes hook failure. Same pattern as `Shutdown_hooks.run_all`. |
+| Subprocess pid registry leaks pids if keeper crashes between spawn and register | Spawn site uses `Fun.protect` to register-then-spawn-then-unregister-on-exit. Lost pids age out via OS process death detection in cleanup hook. |
+| `docker rm -f` races with healthcheck or operator action | Single-fiber queue serializes removal; `docker rm` is itself idempotent on missing container (returns error code 1, swallowed). |
+| Container-per-keeper × DinD nesting on `docker_hardened` keepers (DinD-in-DinD) | Out of scope for Phase B; Phase C decides whether to disallow that combination or document the requirement (host docker socket mount). |
+| TLA spec coverage decay: RFC-0002 phase invariants vs new bridge | Phase C ships `KeeperDockerBridge.tla` mirroring the existing pattern (clean.cfg + buggy.cfg as in `KeeperOASAdvanced.tla`). |
+
+## 7. Open Questions
+
+1. Does `container-per-keeper` mode need its own admission controller, or can it reuse `keeper_turn_slot` semaphore? (RFC-0026 territory.)
+2. How does `lib/cascade_routes` route turns when keepers are in different containers? Probably unchanged (HTTP → MCP socket), but worth confirming.
+3. Multi-keeper compose: per-persona named services (declarative) vs `--scale keeper=N` (parameterized)? Phase B decision.
+
+## 8. Migration Plan
+
+1. PR #13848 lands (P0/P1/P3 cleanup scaffolding) — done.
+2. Phase A foundation PR (this RFC's cleanup hook + subprocess registry).
+3. Phase A instrumentation PR (call-site pid tracking).
+4. Decide whether to proceed to Phase B based on host need (no rush — single-container default works).
+5. If Phase B: ship `Docker_runtime` + compose template + topology knob (no FSM changes, easy revert).
+6. Phase C: wire FSM hook to bridge, ship TLA spec.
+7. Phase D: runbook.
+
+## 9. Decision Criteria
+
+This RFC is approved to proceed when:
+- Phase A scope is acknowledged as non-architectural maintenance work.
+- Phase B/C/D scope is acknowledged as architectural and can be deferred without blocking PR #13848 merge.
+- Hook signature and topology env knob name are settled.
+
+If the answer to "do we ever need container-per-keeper?" is "no, single container is enough," this RFC degrades cleanly to "ship Phase A only" — the cleanup hook still solves #32 even without #30/#34.

--- a/infrastructure/systemd/masc-docker-prune.service
+++ b/infrastructure/systemd/masc-docker-prune.service
@@ -1,0 +1,48 @@
+# Periodic Docker resource prune for masc-mcp hosts that build images
+# locally (CI runners, dev workstations, smoke-test hosts). Wraps
+# scripts/docker-prune.sh which was added in this PR but had no
+# scheduling layer. Named volumes are intentionally not touched; see the
+# script comment header for scope.
+#
+# Activated by masc-docker-prune.timer. Skip installing this on hosts
+# that only consume pre-built images from a registry.
+#
+# Install:
+#   sudo install -m 0644 infrastructure/systemd/masc-docker-prune.service \
+#     /etc/systemd/system/masc-docker-prune.service
+#   sudo install -m 0644 infrastructure/systemd/masc-docker-prune.timer \
+#     /etc/systemd/system/masc-docker-prune.timer
+#   sudo systemctl daemon-reload
+#   sudo systemctl enable --now masc-docker-prune.timer
+
+[Unit]
+Description=MASC MCP weekly Docker resource prune
+Documentation=https://github.com/jeong-sik/masc-mcp
+After=docker.service
+Requires=docker.service
+
+[Service]
+Type=oneshot
+# `docker` requires either root or membership in the docker group.
+# Hosts that run rootless docker should drop the User= line.
+User=masc
+Group=docker
+WorkingDirectory=/opt/masc-mcp
+Environment=PATH=/usr/local/bin:/usr/bin:/bin
+Environment=AGE_HOURS=168
+
+ExecStart=/opt/masc-mcp/scripts/docker-prune.sh --apply
+# Also reap orphaned keeper sandbox containers that lost their parent.
+ExecStart=/opt/masc-mcp/scripts/cleanup-orphaned-keeper-containers.sh --apply
+
+TimeoutStartSec=15min
+
+# Hardening — note we do NOT enable PrivateTmp because docker
+# may need /tmp visibility for layer staging on some configurations.
+NoNewPrivileges=true
+ProtectSystem=strict
+ProtectHome=true
+ReadWritePaths=/opt/masc-mcp
+
+StandardOutput=journal
+StandardError=journal

--- a/infrastructure/systemd/masc-docker-prune.service
+++ b/infrastructure/systemd/masc-docker-prune.service
@@ -37,9 +37,10 @@ ExecStart=/opt/masc-mcp/scripts/cleanup-orphaned-keeper-containers.sh --apply
 
 TimeoutStartSec=15min
 
-# Hardening — note we do NOT enable PrivateTmp because docker
-# may need /tmp visibility for layer staging on some configurations.
+# Hardening. PrivateTmp is safe here because this unit only invokes Docker CLI
+# prune operations; mktemp scratch files do not need to be visible to dockerd.
 NoNewPrivileges=true
+PrivateTmp=true
 ProtectSystem=strict
 ProtectHome=true
 ReadWritePaths=/opt/masc-mcp

--- a/infrastructure/systemd/masc-docker-prune.timer
+++ b/infrastructure/systemd/masc-docker-prune.timer
@@ -1,0 +1,15 @@
+# Weekly Docker prune. Sunday 04:23 local with up to 30min jitter.
+# Persistent=true so a missed week catches up.
+
+[Unit]
+Description=Weekly MASC MCP Docker prune
+Documentation=https://github.com/jeong-sik/masc-mcp
+
+[Timer]
+OnCalendar=Sun *-*-* 04:23:00
+Persistent=true
+RandomizedDelaySec=30min
+Unit=masc-docker-prune.service
+
+[Install]
+WantedBy=timers.target

--- a/infrastructure/systemd/masc-mcp.service
+++ b/infrastructure/systemd/masc-mcp.service
@@ -32,12 +32,14 @@ Environment=ME_ROOT=/opt/masc-mcp
 Environment=MASC_BASE_PATH=/var/lib/masc-mcp
 Environment=MASC_CONFIG_DIR=/opt/masc-mcp/config
 Environment=MASC_MCP_PORT=8080
+Environment=MASC_SHUTDOWN_CLEANUP_TIMEOUT=10
+Environment=MASC_SHUTDOWN_FORCE_TIMEOUT=60
 
 ExecStart=/opt/masc-mcp/bin/masc-mcp --http --port 8080 --base-path /var/lib/masc-mcp
 
-# Graceful shutdown contract — must match docker-compose stop_grace_period
-# and bin/main_eio.ml shutdown_cfg.force_timeout_s. SIGTERM triggers the
-# 4-phase shutdown (NOTIFY → HOOKS → BOARD → CANCEL).
+# Graceful shutdown contract — TimeoutStopSec must be >= the server force
+# timeout and match docker-compose stop_grace_period. SIGTERM triggers the
+# 4-phase shutdown (NOTIFY -> HOOKS -> BOARD -> CANCEL).
 KillSignal=SIGTERM
 KillMode=mixed
 TimeoutStopSec=60s

--- a/infrastructure/systemd/masc-mcp.service
+++ b/infrastructure/systemd/masc-mcp.service
@@ -37,12 +37,16 @@ Environment=MASC_SHUTDOWN_FORCE_TIMEOUT=60
 
 ExecStart=/opt/masc-mcp/bin/masc-mcp --http --port 8080 --base-path /var/lib/masc-mcp
 
-# Graceful shutdown contract — TimeoutStopSec must be >= the server force
-# timeout and match docker-compose stop_grace_period. SIGTERM triggers the
-# 4-phase shutdown (NOTIFY -> HOOKS -> BOARD -> CANCEL).
+# Graceful shutdown contract — TimeoutStopSec is set a few seconds
+# larger than the server's force timeout (MASC_SHUTDOWN_FORCE_TIMEOUT=60)
+# and matches docker-compose stop_grace_period. The headroom lets the
+# in-process force-exit watchdog flush the last log line and post-
+# shutdown hook telemetry before systemd escalates to SIGKILL — without
+# it both timers race at ~60s and final state is lost.
+# SIGTERM triggers the 4-phase shutdown (NOTIFY -> HOOKS -> BOARD -> CANCEL).
 KillSignal=SIGTERM
 KillMode=mixed
-TimeoutStopSec=60s
+TimeoutStopSec=75s
 
 # Mirrors launchd KeepAlive.SuccessfulExit=false: restart only on failure,
 # never on a clean exit (prevents tight loops if the binary chooses to

--- a/infrastructure/systemd/masc-mcp.service
+++ b/infrastructure/systemd/masc-mcp.service
@@ -1,0 +1,65 @@
+# MASC MCP – Linux systemd unit, parity with infrastructure/launchd/com.jeong-sik.masc-mcp.plist.
+#
+# Why this exists:
+#   The launchd plist covers macOS dev/prod, but production Linux hosts
+#   (Railway/k8s/bare metal) have nothing equivalent in-tree. Operators
+#   end up writing ad-hoc systemd units that drift from the launchd
+#   contract (KeepAlive=on-failure, ThrottleInterval=30s).
+#
+# Install (per-host, machine-specific paths must be edited):
+#   sudo install -m 0644 infrastructure/systemd/masc-mcp.service \
+#     /etc/systemd/system/masc-mcp.service
+#   sudo systemctl daemon-reload
+#   sudo systemctl enable --now masc-mcp.service
+#
+# Status:
+#   sudo systemctl status masc-mcp.service
+#   sudo journalctl -u masc-mcp.service -f
+
+[Unit]
+Description=MASC MCP server (Multi-Agent Streaming Coordination)
+Documentation=https://github.com/jeong-sik/masc-mcp
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+# Adjust to your install layout.
+User=masc
+Group=masc
+WorkingDirectory=/opt/masc-mcp
+Environment=PATH=/usr/local/bin:/usr/bin:/bin
+Environment=ME_ROOT=/opt/masc-mcp
+Environment=MASC_BASE_PATH=/var/lib/masc-mcp
+Environment=MASC_CONFIG_DIR=/opt/masc-mcp/config
+Environment=MASC_MCP_PORT=8080
+
+ExecStart=/opt/masc-mcp/bin/masc-mcp --http --port 8080 --base-path /var/lib/masc-mcp
+
+# Graceful shutdown contract — must match docker-compose stop_grace_period
+# and bin/main_eio.ml shutdown_cfg.force_timeout_s. SIGTERM triggers the
+# 4-phase shutdown (NOTIFY → HOOKS → BOARD → CANCEL).
+KillSignal=SIGTERM
+KillMode=mixed
+TimeoutStopSec=60s
+
+# Mirrors launchd KeepAlive.SuccessfulExit=false: restart only on failure,
+# never on a clean exit (prevents tight loops if the binary chooses to
+# exit 0 for an upgrade handoff).
+Restart=on-failure
+RestartSec=30s
+
+# Production hardening
+NoNewPrivileges=true
+ProtectSystem=strict
+ProtectHome=true
+PrivateTmp=true
+PrivateDevices=true
+ReadWritePaths=/var/lib/masc-mcp /var/log/masc-mcp
+
+# Logs go to journald by default; set StandardOutput/Error explicitly so
+# `journalctl -u masc-mcp` is the SSOT (parity with launchd StandardOutPath).
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target

--- a/infrastructure/systemd/masc-worktree-cleanup.service
+++ b/infrastructure/systemd/masc-worktree-cleanup.service
@@ -1,0 +1,52 @@
+# Periodic stale/merged worktree cleanup for masc-mcp hosts.
+# Wraps scripts/cleanup-stale-worktrees.sh + cleanup-merged-worktrees.sh,
+# both of which are in-tree but had no scheduling layer prior to this
+# unit (closing report matrix item #33).
+#
+# Activated by masc-worktree-cleanup.timer.
+#
+# Why two scripts in one service:
+#   The existing in-tree scripts run independently and are idempotent.
+#   Running them in sequence in the same Type=oneshot guarantees a single
+#   journal entry per cleanup pass and serialises the underlying
+#   git worktree prune, which is not safe to run twice in parallel.
+#
+# Install:
+#   sudo install -m 0644 infrastructure/systemd/masc-worktree-cleanup.service \
+#     /etc/systemd/system/masc-worktree-cleanup.service
+#   sudo install -m 0644 infrastructure/systemd/masc-worktree-cleanup.timer \
+#     /etc/systemd/system/masc-worktree-cleanup.timer
+#   sudo systemctl daemon-reload
+#   sudo systemctl enable --now masc-worktree-cleanup.timer
+
+[Unit]
+Description=MASC MCP worktree cleanup (stale + merged)
+Documentation=https://github.com/jeong-sik/masc-mcp
+After=network.target
+
+[Service]
+Type=oneshot
+User=masc
+Group=masc
+WorkingDirectory=/opt/masc-mcp
+Environment=PATH=/usr/local/bin:/usr/bin:/bin
+
+# Stale: drops worktrees older than 7 days (default in script).
+ExecStart=/opt/masc-mcp/scripts/cleanup-stale-worktrees.sh --apply
+# Merged: drops worktrees whose branch is fully merged.
+ExecStart=/opt/masc-mcp/scripts/cleanup-merged-worktrees.sh --apply
+
+# Conservative timeout — if git worktree prune blocks longer than this,
+# something else (lock file, NFS hang) needs human investigation.
+TimeoutStartSec=10min
+
+# Hardening: this service only reads/writes worktree paths under
+# WorkingDirectory + system git config.
+NoNewPrivileges=true
+ProtectSystem=strict
+ProtectHome=true
+PrivateTmp=true
+ReadWritePaths=/opt/masc-mcp
+
+StandardOutput=journal
+StandardError=journal

--- a/infrastructure/systemd/masc-worktree-cleanup.timer
+++ b/infrastructure/systemd/masc-worktree-cleanup.timer
@@ -1,0 +1,18 @@
+# Daily worktree cleanup. Uses Persistent=true so a missed run (host off
+# during the trigger window) catches up on next boot instead of skipping.
+#
+# RandomizedDelaySec spreads load across hosts running the same unit
+# concurrently and avoids the :00 thundering-herd pattern.
+
+[Unit]
+Description=Daily MASC MCP worktree cleanup
+Documentation=https://github.com/jeong-sik/masc-mcp
+
+[Timer]
+OnCalendar=*-*-* 03:17:00
+Persistent=true
+RandomizedDelaySec=10min
+Unit=masc-worktree-cleanup.service
+
+[Install]
+WantedBy=timers.target

--- a/lib/keeper/keeper_lifecycle_hooks.ml
+++ b/lib/keeper/keeper_lifecycle_hooks.ml
@@ -1,0 +1,38 @@
+(** Implementation of Keeper_lifecycle_hooks. See .mli for contract. *)
+
+type event =
+  | Phase_transition of {
+      from_phase : Keeper_state_machine.phase;
+      to_phase   : Keeper_state_machine.phase;
+    }
+  | Tombstone_reaped
+
+type hook = keeper_id:string -> event -> unit
+
+(* Atomic-backed list, append-on-register. Read on the hot path is
+   Atomic.get → list iteration. No mutex, no contention. *)
+let hooks : hook list Atomic.t = Atomic.make []
+
+let register (h : hook) : unit =
+  let rec loop () =
+    let cur = Atomic.get hooks in
+    let next = cur @ [ h ] in
+    if Atomic.compare_and_set hooks cur next then ()
+    else loop ()
+  in
+  loop ()
+
+let run ~keeper_id (ev : event) : unit =
+  let hs = Atomic.get hooks in
+  List.iter
+    (fun h ->
+      try h ~keeper_id ev
+      with exn ->
+        Log.Server.warn
+          "[KeeperLifecycleHooks] hook raised on keeper_id=%s: %s"
+          keeper_id (Printexc.to_string exn))
+    hs
+
+let registered_count () : int = List.length (Atomic.get hooks)
+
+let reset_for_testing () : unit = Atomic.set hooks []

--- a/lib/keeper/keeper_lifecycle_hooks.ml
+++ b/lib/keeper/keeper_lifecycle_hooks.ml
@@ -9,21 +9,28 @@ type event =
 
 type hook = keeper_id:string -> event -> unit
 
-(* Atomic-backed list, append-on-register. Read on the hot path is
-   Atomic.get → list iteration. No mutex, no contention. *)
+(* Atomic-backed reversed-list. Registration prepends ([h :: cur]) which
+   is O(1); the runner then iterates the reversed list in registration
+   order via List.rev once per [run] call. The previous [cur @ [h]]
+   form was O(n) per register and re-allocated the entire list under
+   compare_and_set retries — quickly costly under contention even
+   though hooks/run is rare on the hot path. *)
 let hooks : hook list Atomic.t = Atomic.make []
 
 let register (h : hook) : unit =
   let rec loop () =
     let cur = Atomic.get hooks in
-    let next = cur @ [ h ] in
+    let next = h :: cur in
     if Atomic.compare_and_set hooks cur next then ()
     else loop ()
   in
   loop ()
 
 let run ~keeper_id (ev : event) : unit =
-  let hs = Atomic.get hooks in
+  (* Reverse once at run time so call order matches registration order
+     (the documented contract). The reversal is O(n) but n is tiny in
+     practice (a handful of subsystem hooks). *)
+  let hs = List.rev (Atomic.get hooks) in
   List.iter
     (fun h ->
       try h ~keeper_id ev

--- a/lib/keeper/keeper_lifecycle_hooks.mli
+++ b/lib/keeper/keeper_lifecycle_hooks.mli
@@ -1,0 +1,54 @@
+(** Keeper Lifecycle Cleanup Hooks (RFC-0036 Phase A.1).
+
+    Foundation for the lifecycle_cleanup_hook plumbing described in
+    [docs/rfc/RFC-0036-multi-keeper-docker-orchestration.md].
+
+    Purely additive — this module has no consumers in [Keeper_supervisor]
+    yet. Phase A.2/A.3 wires call sites; Phase B/C uses the same
+    registration API to attach the [Docker_runtime] bridge.
+
+    Contract:
+    - Hooks are best-effort, synchronous, and exception-safe. The runner
+      logs and swallows exceptions so a single misbehaving hook cannot
+      block supervisor work or other hooks.
+    - Hook registration is process-global. Order of execution is the
+      order of registration. There is no unregister API by design — once
+      a subsystem opts in, it stays in for the process lifetime.
+    - Hook list is backed by [Atomic.t] for lock-free read on the
+      supervisor hot path.
+
+    Future extensions (Phase A.2+): structured event payload
+    (subprocess pid set, owner keeper config) once call sites are wired. *)
+
+(** Lifecycle event the hook is invoked with. *)
+type event =
+  | Phase_transition of {
+      from_phase : Keeper_state_machine.phase;
+      to_phase   : Keeper_state_machine.phase;
+    }
+      (** Fired by [Keeper_supervisor.transition_to] before the
+          registry write commits. Hooks observe the intent of the
+          transition; they cannot veto. *)
+  | Tombstone_reaped
+      (** Fired by [Keeper_supervisor.cleanup_dead_tombstone] after the
+          registry unregister completes. The keeper is fully gone from
+          in-process state at this point. *)
+
+(** Hook callback. *)
+type hook = keeper_id:string -> event -> unit
+
+(** Register a cleanup hook. Idempotency is the caller's responsibility
+    — calling twice with the same closure registers it twice. *)
+val register : hook -> unit
+
+(** Run every registered hook with the given event. Exceptions raised
+    from a hook are caught and logged via [Log.Server.warn]; the runner
+    always returns normally. *)
+val run : keeper_id:string -> event -> unit
+
+(** Number of currently registered hooks. Useful for tests. *)
+val registered_count : unit -> int
+
+(** Clear all registered hooks. Test-only escape hatch. Production
+    code should never call this. *)
+val reset_for_testing : unit -> unit

--- a/lib/keeper/keeper_lifecycle_hooks.mli
+++ b/lib/keeper/keeper_lifecycle_hooks.mli
@@ -3,9 +3,14 @@
     Foundation for the lifecycle_cleanup_hook plumbing described in
     [docs/rfc/RFC-0036-multi-keeper-docker-orchestration.md].
 
-    Purely additive — this module has no consumers in [Keeper_supervisor]
-    yet. Phase A.2/A.3 wires call sites; Phase B/C uses the same
-    registration API to attach the [Docker_runtime] bridge.
+    This PR wires the first call site:
+    [Keeper_supervisor.sweep_and_recover] fires [Tombstone_reaped] after
+    a dead-keeper unregister succeeds (see [Keeper_lifecycle_hooks.run]
+    invocation in keeper_supervisor.ml). [Phase_transition] is
+    declared but not yet emitted from any call site — Phase A.2
+    follow-up wires it; until that PR lands no hook will receive a
+    Phase_transition event. Phase B/C uses the same registration API
+    to attach the [Docker_runtime] bridge.
 
     Contract:
     - Hooks are best-effort, synchronous, and exception-safe. The runner
@@ -26,9 +31,13 @@ type event =
       from_phase : Keeper_state_machine.phase;
       to_phase   : Keeper_state_machine.phase;
     }
-      (** Fired by [Keeper_supervisor.transition_to] before the
-          registry write commits. Hooks observe the intent of the
-          transition; they cannot veto. *)
+      (** Reserved for the Phase A.2 follow-up: a future supervisor
+          phase-transition call site will fire this before the
+          registry write commits. No call site emits it in this PR;
+          [Keeper_lifecycle_hooks.run] is currently invoked only with
+          [Tombstone_reaped] (from [Keeper_supervisor.sweep_and_recover]).
+          Hooks will observe the intent of the transition; they cannot
+          veto. *)
   | Tombstone_reaped
       (** Fired by [Keeper_supervisor.cleanup_dead_tombstone] after the
           registry unregister completes. The keeper is fully gone from

--- a/lib/keeper/keeper_subprocess_registry.ml
+++ b/lib/keeper/keeper_subprocess_registry.ml
@@ -1,0 +1,152 @@
+(** Implementation of Keeper_subprocess_registry. See .mli for contract. *)
+
+type drain_result = {
+  inspected : int;
+  sigterm_sent : int;
+  sigkill_sent : int;
+  still_alive : int;
+}
+
+(* keeper_id -> pid set (represented as a sorted list of ints; sets are
+   small per-keeper, list ops are fine). All access goes through
+   [registry_mutex]. *)
+module IntSet = Set.Make (Int)
+
+let registry : (string, IntSet.t) Hashtbl.t = Hashtbl.create 16
+let registry_mutex = Mutex.create ()
+
+let with_lock f =
+  Mutex.lock registry_mutex;
+  Fun.protect
+    ~finally:(fun () -> Mutex.unlock registry_mutex)
+    f
+
+let register ~keeper_id ~pid =
+  with_lock (fun () ->
+    let cur =
+      match Hashtbl.find_opt registry keeper_id with
+      | Some s -> s
+      | None -> IntSet.empty
+    in
+    Hashtbl.replace registry keeper_id (IntSet.add pid cur))
+
+let unregister ~keeper_id ~pid =
+  with_lock (fun () ->
+    match Hashtbl.find_opt registry keeper_id with
+    | None -> ()
+    | Some s ->
+      let next = IntSet.remove pid s in
+      if IntSet.is_empty next then Hashtbl.remove registry keeper_id
+      else Hashtbl.replace registry keeper_id next)
+
+let pids_for ~keeper_id =
+  with_lock (fun () ->
+    match Hashtbl.find_opt registry keeper_id with
+    | None -> []
+    | Some s -> IntSet.elements s)
+
+let total_pids () =
+  with_lock (fun () ->
+    Hashtbl.fold (fun _ s acc -> acc + IntSet.cardinal s) registry 0)
+
+(* Snapshot pids for a keeper and remove them from the registry,
+   atomically under the lock. Returns the snapshot. *)
+let take_pids ~keeper_id : int list =
+  with_lock (fun () ->
+    match Hashtbl.find_opt registry keeper_id with
+    | None -> []
+    | Some s ->
+      Hashtbl.remove registry keeper_id;
+      IntSet.elements s)
+
+(* Best-effort signal send. Returns true on success. *)
+let try_kill ~pid ~signum : bool =
+  try Unix.kill pid signum; true
+  with Unix.Unix_error _ -> false
+
+(* Best-effort waitpid. Returns Some status if the pid has exited,
+   None if it is still alive (or unrelated). *)
+let try_reap ~pid : Unix.process_status option =
+  try
+    match Unix.waitpid [ Unix.WNOHANG ] pid with
+    | 0, _ -> None
+    | _, status -> Some status
+  with
+  | Unix.Unix_error (Unix.ECHILD, _, _) ->
+    (* Not our child or already reaped. Treat as gone. *)
+    Some (Unix.WEXITED 0)
+  | Unix.Unix_error _ -> None
+
+let drain ~keeper_id ~grace_ms : drain_result =
+  let grace_ms =
+    if grace_ms < 10 then 10
+    else if grace_ms > 60_000 then 60_000
+    else grace_ms
+  in
+  let pids = take_pids ~keeper_id in
+  let inspected = List.length pids in
+  if inspected = 0 then
+    { inspected = 0; sigterm_sent = 0; sigkill_sent = 0; still_alive = 0 }
+  else begin
+    let sigterm_sent = ref 0 in
+    let sigkill_sent = ref 0 in
+    let still_alive = ref 0 in
+    (* Phase 1: SIGTERM all *)
+    let alive = ref pids in
+    List.iter (fun pid ->
+      if try_kill ~pid ~signum:Sys.sigterm then incr sigterm_sent
+    ) pids;
+    (* Wait up to grace_ms for graceful exits. Poll every 50ms. *)
+    let deadline = Unix.gettimeofday () +. (float_of_int grace_ms /. 1000.0) in
+    let poll_interval = 0.05 in
+    let exit_count = ref 0 in
+    while !alive <> [] && Unix.gettimeofday () < deadline do
+      let still = ref [] in
+      List.iter (fun pid ->
+        match try_reap ~pid with
+        | Some _ -> incr exit_count
+        | None -> still := pid :: !still
+      ) !alive;
+      alive := !still;
+      if !alive <> [] then
+        (try ignore (Unix.select [] [] [] poll_interval)
+         with Unix.Unix_error _ -> ())
+    done;
+    (* Phase 2: SIGKILL stragglers *)
+    List.iter (fun pid ->
+      if try_kill ~pid ~signum:Sys.sigkill then incr sigkill_sent
+      else incr still_alive
+    ) !alive;
+    (* Reap KILLed processes (best-effort, don't block) *)
+    List.iter (fun pid -> ignore (try_reap ~pid)) !alive;
+    {
+      inspected;
+      sigterm_sent = !sigterm_sent;
+      sigkill_sent = !sigkill_sent;
+      still_alive = !still_alive;
+    }
+  end
+
+(* Default cleanup hook: on Tombstone_reaped, drain pids for that
+   keeper. Logs the result; never raises. *)
+let default_hook : Keeper_lifecycle_hooks.hook =
+ fun ~keeper_id ev ->
+  match ev with
+  | Keeper_lifecycle_hooks.Tombstone_reaped ->
+    let r = drain ~keeper_id ~grace_ms:5000 in
+    if r.inspected > 0 then
+      Log.Keeper.info
+        "[SubprocessDrain] keeper=%s inspected=%d sigterm=%d sigkill=%d still_alive=%d"
+        keeper_id r.inspected r.sigterm_sent r.sigkill_sent r.still_alive
+  | Keeper_lifecycle_hooks.Phase_transition _ -> ()
+
+(* Idempotent registration: track whether we've already registered. *)
+let registered = Atomic.make false
+
+let register_default_cleanup_hook () =
+  if Atomic.compare_and_set registered false true then
+    Keeper_lifecycle_hooks.register default_hook
+
+let reset_for_testing () =
+  with_lock (fun () -> Hashtbl.clear registry);
+  Atomic.set registered false

--- a/lib/keeper/keeper_subprocess_registry.mli
+++ b/lib/keeper/keeper_subprocess_registry.mli
@@ -1,0 +1,74 @@
+(** Keeper Subprocess Registry (RFC-0036 Phase A.3).
+
+    Tracks pids of OS subprocesses that the keeper hot path has spawned
+    and not yet reaped. Used by the default cleanup hook (see
+    [register_default_cleanup_hook]) to SIGTERM-then-SIGKILL any
+    subprocess that survives its parent keeper.
+
+    Closes verification report item #32 (Post-stop orphaned process
+    handling) for the single-container production topology. The
+    multi-container topology of Phase B/C inherits the same registry —
+    drain is keyed by [keeper_id], so a [Docker_runtime] subscriber that
+    runs `docker rm` on the keeper's container can rely on the same
+    subscriber list.
+
+    Concurrency:
+    - Registration and unregistration may be called from any fiber.
+    - All mutations take a single internal Mutex; pids_for and drain
+      snapshot under the lock.
+    - drain releases the lock before sending signals to avoid blocking
+      register/unregister during a long [waitpid].
+
+    Lifecycle:
+    - register/unregister are paired around each spawn site (typically
+      via [Fun.protect]).
+    - drain consumes the recorded pids and removes them from the
+      registry; subsequent [pids_for] returns [[]].
+    - Subprocesses that exit cleanly should be unregistered explicitly;
+      drain only catches orphans. *)
+
+(** Result of a drain operation. *)
+type drain_result = {
+  inspected : int;
+    (** Total pids drained (sum of sigterm_sent + still_alive). *)
+  sigterm_sent : int;
+    (** Pids that received SIGTERM and exited within the grace window. *)
+  sigkill_sent : int;
+    (** Pids that needed SIGKILL after the grace window. *)
+  still_alive : int;
+    (** Pids that did not respond to either signal (failed kill calls). *)
+}
+
+(** Record a pid spawned by [keeper_id]. Idempotent — re-registering
+    the same pid is a noop. *)
+val register : keeper_id:string -> pid:int -> unit
+
+(** Drop a pid from the registry. Called when a subprocess exits
+    cleanly so [drain] does not target an already-reaped pid. *)
+val unregister : keeper_id:string -> pid:int -> unit
+
+(** Return the currently-tracked pids for a keeper. Snapshot value;
+    safe to iterate even while other fibers register/unregister. *)
+val pids_for : keeper_id:string -> int list
+
+(** Sum of currently-tracked pids across all keepers. Useful for
+    Prometheus gauge. *)
+val total_pids : unit -> int
+
+(** Drain all pids tracked for [keeper_id]:
+    1. Send SIGTERM, wait up to [grace_ms].
+    2. Send SIGKILL to any still-alive pid.
+    3. Remove all targeted pids from the registry.
+
+    [grace_ms] is bounded internally to a sane range (10ms..60s). *)
+val drain : keeper_id:string -> grace_ms:int -> drain_result
+
+(** Register the default Tombstone_reaped subscriber against
+    [Keeper_lifecycle_hooks]. Idempotent — calling more than once
+    only registers one cleanup hook. Called once during supervisor
+    bootstrap. *)
+val register_default_cleanup_hook : unit -> unit
+
+(** Test-only escape hatch: clear the registry. Production code should
+    never call this. *)
+val reset_for_testing : unit -> unit

--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -1462,7 +1462,14 @@ let sweep_and_recover (ctx : _ context) =
        restart_count=%d — operator action required"
       entry.name msg entry.restart_count
   ) !to_mark_dead;
-  List.iter (cleanup_dead_tombstone ctx) !to_cleanup_dead;
+  (* RFC-0036 Phase A.2: fire Tombstone_reaped after cleanup completes.
+     Hook is exception-safe; supervisor never observes failure. *)
+  List.iter (fun (entry : Keeper_registry.registry_entry) ->
+    cleanup_dead_tombstone ctx entry;
+    Keeper_lifecycle_hooks.run
+      ~keeper_id:entry.name
+      Keeper_lifecycle_hooks.Tombstone_reaped
+  ) !to_cleanup_dead;
   let active_count =
     Keeper_registry.all ~base_path ()
     |> active_supervision_keeper_count

--- a/lib/shutdown_hooks.ml
+++ b/lib/shutdown_hooks.ml
@@ -110,14 +110,18 @@ let run_all () =
           done);
       ignore count_after_budget
   in
-  (* Treat empty/whitespace-only [MASC_BASE_PATH] as unset. The repo
-     convention sets env vars to "" via [Unix.putenv name ""] when
-     "unset" is the intended semantic (see test_board_vote_quarantine
-     comment), and a non-trimmed empty string here would resolve
-     [tmp_dir] to ".masc/tmp" relative to the cwd and start unlinking
-     unrelated files. *)
+  (* Treat empty/whitespace-only or relative [MASC_BASE_PATH] as unset.
+     The repo convention sets env vars to "" via [Unix.putenv name ""]
+     when "unset" is the intended semantic. A non-absolute base path
+     ("." / "tmp" / "./logs") would resolve [tmp_dir] against the
+     daemon's cwd and unlink unrelated files in whichever directory
+     the binary was launched from — refuse to traverse it. *)
   (match Sys.getenv_opt "MASC_BASE_PATH" |> Option.map String.trim with
    | None | Some "" -> ()
+   | Some base_path when Filename.is_relative base_path ->
+     Log.Server.debug
+       "[Shutdown] tmp cleanup skipped: MASC_BASE_PATH=%s is not absolute"
+       base_path
    | Some base_path ->
      let tmp_dir = Filename.concat base_path ".masc/tmp" in
      (match Unix.lstat tmp_dir with

--- a/lib/shutdown_hooks.ml
+++ b/lib/shutdown_hooks.ml
@@ -56,15 +56,29 @@ let run_all () =
      Durable JSONL state and lock files outside of the tmp/ directory are
      never touched. Dir missing or symlinked → noop. Per-file errors are
      logged and ignored so a single permission error cannot block the rest
-     of shutdown. *)
+     of shutdown. Cleanup is explicitly bounded because this hook runs in a
+     synchronous shutdown path that Eio timeouts cannot preempt. *)
   let t_tmp = Unix.gettimeofday () in
+  let tmp_cleanup_file_budget = 500 in
+  let tmp_cleanup_wall_budget_s = 0.25 in
+  let inspected = ref 0 in
   let removed = ref 0 in
   let bytes_freed = ref 0 in
+  let budget_exhausted = ref false in
+  let tmp_budget_exceeded () =
+    !inspected >= tmp_cleanup_file_budget
+    || Unix.gettimeofday () -. t_tmp >= tmp_cleanup_wall_budget_s
+  in
   let cleanup_dir dir =
     match Sys.readdir dir with
     | exception Sys_error _ -> ()
     | entries ->
-      Array.iter (fun name ->
+      let i = ref 0 in
+      let len = Array.length entries in
+      while !i < len && not (tmp_budget_exceeded ()) do
+        let name = entries.(!i) in
+        incr i;
+        incr inspected;
         let path = Filename.concat dir name in
         match Unix.lstat path with
         | exception Unix.Unix_error (e, _, _) ->
@@ -79,7 +93,8 @@ let run_all () =
              Log.Server.warn "[Shutdown] tmp unlink failed %s: %s"
                path (Unix.error_message e))
         | _ -> () (* skip dirs / symlinks / fifos *)
-      ) entries
+      done;
+      if !i < len then budget_exhausted := true
   in
   (match Sys.getenv_opt "MASC_BASE_PATH" with
    | None -> ()
@@ -91,8 +106,13 @@ let run_all () =
       | _ ->
         Log.Server.debug
           "[Shutdown] tmp cleanup skipped non-directory path %s" tmp_dir));
+  if !budget_exhausted then
+    Log.Server.warn
+      "[Shutdown] basepath tmp cleanup budget reached (inspected=%d, max_files=%d, budget=%.0fms)"
+      !inspected tmp_cleanup_file_budget (tmp_cleanup_wall_budget_s *. 1000.);
   if !removed > 0 then
-    Log.Server.info "[Shutdown] basepath tmp: removed %d files (%d bytes, %.2fs)"
-      !removed !bytes_freed (Unix.gettimeofday () -. t_tmp);
+    Log.Server.info
+      "[Shutdown] basepath tmp: inspected %d, removed %d files (%d bytes, %.2fs)"
+      !inspected !removed !bytes_freed (Unix.gettimeofday () -. t_tmp);
   Log.Server.info "[Shutdown] hooks total: %.2fs"
     (Unix.gettimeofday () -. t0)

--- a/lib/shutdown_hooks.ml
+++ b/lib/shutdown_hooks.ml
@@ -70,34 +70,54 @@ let run_all () =
     || Unix.gettimeofday () -. t_tmp >= tmp_cleanup_wall_budget_s
   in
   let cleanup_dir dir =
-    match Sys.readdir dir with
-    | exception Sys_error _ -> ()
-    | entries ->
-      let i = ref 0 in
-      let len = Array.length entries in
-      while !i < len && not (tmp_budget_exceeded ()) do
-        let name = entries.(!i) in
-        incr i;
-        incr inspected;
-        let path = Filename.concat dir name in
-        match Unix.lstat path with
-        | exception Unix.Unix_error (e, _, _) ->
-          Log.Server.debug "[Shutdown] tmp lstat skipped %s: %s"
-            path (Unix.error_message e)
-        | st when st.Unix.st_kind = Unix.S_REG ->
-          (try
-             Unix.unlink path;
-             incr removed;
-             bytes_freed := !bytes_freed + st.Unix.st_size
-           with Unix.Unix_error (e, _, _) ->
-             Log.Server.warn "[Shutdown] tmp unlink failed %s: %s"
-               path (Unix.error_message e))
-        | _ -> () (* skip dirs / symlinks / fifos *)
-      done;
-      if !i < len then budget_exhausted := true
+    (* Stream entries via [Unix.opendir]/[readdir] instead of
+       [Sys.readdir], which materializes the whole directory into an
+       OCaml array up-front. A [.masc/tmp] with millions of files would
+       otherwise allocate a million-string array even when the loop
+       trips the file/wall budget after the first 500 entries. *)
+    match Unix.opendir dir with
+    | exception Unix.Unix_error _ -> ()
+    | dh ->
+      let stop = ref false in
+      let count_after_budget = ref 0 in
+      Fun.protect
+        ~finally:(fun () -> try Unix.closedir dh with _ -> ())
+        (fun () ->
+          while not !stop do
+            match Unix.readdir dh with
+            | exception End_of_file -> stop := true
+            | name when name = "." || name = ".." -> ()
+            | _ when tmp_budget_exceeded () ->
+              budget_exhausted := true;
+              incr count_after_budget;
+              stop := true
+            | name ->
+              incr inspected;
+              let path = Filename.concat dir name in
+              (match Unix.lstat path with
+               | exception Unix.Unix_error (e, _, _) ->
+                 Log.Server.debug "[Shutdown] tmp lstat skipped %s: %s"
+                   path (Unix.error_message e)
+               | st when st.Unix.st_kind = Unix.S_REG ->
+                 (try
+                    Unix.unlink path;
+                    incr removed;
+                    bytes_freed := !bytes_freed + st.Unix.st_size
+                  with Unix.Unix_error (e, _, _) ->
+                    Log.Server.warn "[Shutdown] tmp unlink failed %s: %s"
+                      path (Unix.error_message e))
+               | _ -> () (* skip dirs / symlinks / fifos *))
+          done);
+      ignore count_after_budget
   in
-  (match Sys.getenv_opt "MASC_BASE_PATH" with
-   | None -> ()
+  (* Treat empty/whitespace-only [MASC_BASE_PATH] as unset. The repo
+     convention sets env vars to "" via [Unix.putenv name ""] when
+     "unset" is the intended semantic (see test_board_vote_quarantine
+     comment), and a non-trimmed empty string here would resolve
+     [tmp_dir] to ".masc/tmp" relative to the cwd and start unlinking
+     unrelated files. *)
+  (match Sys.getenv_opt "MASC_BASE_PATH" |> Option.map String.trim with
+   | None | Some "" -> ()
    | Some base_path ->
      let tmp_dir = Filename.concat base_path ".masc/tmp" in
      (match Unix.lstat tmp_dir with

--- a/lib/shutdown_hooks.ml
+++ b/lib/shutdown_hooks.ml
@@ -52,5 +52,40 @@ let run_all () =
   (* Clear transient A2A state to free memory *)
   (* Clear session identity caches *)
   Agent_registry_eio.clear_session_caches ();
+  (* Best-effort cleanup of transient files under <base>/.masc/tmp/.
+     Durable JSONL state and lock files outside of the tmp/ directory are
+     never touched. Dir missing → noop. Per-file errors are logged and
+     ignored so a single permission error cannot block the rest of
+     shutdown. *)
+  let t_tmp = Unix.gettimeofday () in
+  let removed = ref 0 in
+  let bytes_freed = ref 0 in
+  let cleanup_dir dir =
+    match Sys.readdir dir with
+    | exception Sys_error _ -> ()
+    | entries ->
+      Array.iter (fun name ->
+        let path = Filename.concat dir name in
+        match Unix.lstat path with
+        | exception Unix.Unix_error _ -> ()
+        | st when st.Unix.st_kind = Unix.S_REG ->
+          (try
+             Unix.unlink path;
+             incr removed;
+             bytes_freed := !bytes_freed + st.Unix.st_size
+           with Unix.Unix_error (e, _, _) ->
+             Log.Server.warn "[Shutdown] tmp unlink failed %s: %s"
+               path (Unix.error_message e))
+        | _ -> () (* skip dirs / symlinks / fifos *)
+      ) entries
+  in
+  (match Sys.getenv_opt "MASC_BASE_PATH" with
+   | None -> ()
+   | Some base_path ->
+     let tmp_dir = Filename.concat base_path ".masc/tmp" in
+     if Sys.file_exists tmp_dir then cleanup_dir tmp_dir);
+  if !removed > 0 then
+    Log.Server.info "[Shutdown] basepath tmp: removed %d files (%d bytes, %.2fs)"
+      !removed !bytes_freed (Unix.gettimeofday () -. t_tmp);
   Log.Server.info "[Shutdown] hooks total: %.2fs"
     (Unix.gettimeofday () -. t0)

--- a/lib/shutdown_hooks.ml
+++ b/lib/shutdown_hooks.ml
@@ -54,9 +54,9 @@ let run_all () =
   Agent_registry_eio.clear_session_caches ();
   (* Best-effort cleanup of transient files under <base>/.masc/tmp/.
      Durable JSONL state and lock files outside of the tmp/ directory are
-     never touched. Dir missing → noop. Per-file errors are logged and
-     ignored so a single permission error cannot block the rest of
-     shutdown. *)
+     never touched. Dir missing or symlinked → noop. Per-file errors are
+     logged and ignored so a single permission error cannot block the rest
+     of shutdown. *)
   let t_tmp = Unix.gettimeofday () in
   let removed = ref 0 in
   let bytes_freed = ref 0 in
@@ -67,7 +67,9 @@ let run_all () =
       Array.iter (fun name ->
         let path = Filename.concat dir name in
         match Unix.lstat path with
-        | exception Unix.Unix_error _ -> ()
+        | exception Unix.Unix_error (e, _, _) ->
+          Log.Server.debug "[Shutdown] tmp lstat skipped %s: %s"
+            path (Unix.error_message e)
         | st when st.Unix.st_kind = Unix.S_REG ->
           (try
              Unix.unlink path;
@@ -83,7 +85,12 @@ let run_all () =
    | None -> ()
    | Some base_path ->
      let tmp_dir = Filename.concat base_path ".masc/tmp" in
-     if Sys.file_exists tmp_dir then cleanup_dir tmp_dir);
+     (match Unix.lstat tmp_dir with
+      | exception Unix.Unix_error _ -> ()
+      | st when st.Unix.st_kind = Unix.S_DIR -> cleanup_dir tmp_dir
+      | _ ->
+        Log.Server.debug
+          "[Shutdown] tmp cleanup skipped non-directory path %s" tmp_dir));
   if !removed > 0 then
     Log.Server.info "[Shutdown] basepath tmp: removed %d files (%d bytes, %.2fs)"
       !removed !bytes_freed (Unix.gettimeofday () -. t_tmp);

--- a/lib/shutdown_hooks.mli
+++ b/lib/shutdown_hooks.mli
@@ -32,7 +32,13 @@ val run_all : unit -> unit
        (Eio.Cancel.Cancelled re-raised; any other exception is
        logged at warn and swallowed so a partial flush failure
        cannot block shutdown of the rest of the chain).
-    6. Clear [Agent_registry_eio] session caches.
+    5. Clear [Agent_registry_eio] session caches.
+    6. Best-effort purge of transient files under [<MASC_BASE_PATH>/.masc/tmp/].
+       Bounded by an inspect-budget (500 files) and a wall-time
+       budget (250ms) so the synchronous Eio shutdown phase cannot
+       overrun the configured force timeout. Per-file errors are
+       logged and ignored; durable JSONL state and lock files
+       outside [tmp/] are never touched.
 
     Each step's elapsed time and (where applicable) the count of
     affected resources are logged. The function never raises

--- a/scripts/cleanup-orphaned-keeper-containers.sh
+++ b/scripts/cleanup-orphaned-keeper-containers.sh
@@ -101,7 +101,8 @@ while IFS= read -r cid; do
   # disappears between listing and inspect (or inspect errors transiently),
   # the script must not exit under [set -e]. Default to the container ID
   # so log lines remain attributable.
-  name=$(docker inspect --format '{{.Name}}' "$cid" 2>/dev/null | sed 's|^/||' || echo "")
+  name_raw=$(docker inspect --format '{{.Name}}' "$cid" 2>/dev/null || true)
+  name=$(printf '%s\n' "$name_raw" | sed 's|^/||')
   if [ -z "$name" ]; then name="$cid"; fi
   if [ -z "$finished" ] || [ "$finished" = "0001-01-01T00:00:00Z" ]; then
     # never started cleanly — treat as old

--- a/scripts/cleanup-orphaned-keeper-containers.sh
+++ b/scripts/cleanup-orphaned-keeper-containers.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+# cleanup-orphaned-keeper-containers.sh — reap exited keeper sandbox
+# containers that lost their parent (server crash, lost SSH session, etc.).
+#
+# Why this exists:
+#   `docker run --rm` (used by scripts/keeper-docker-multikeeper-isolation-smoke.sh)
+#   self-cleans on a clean exit, but if the parent process is killed
+#   mid-run, or if `--rm` fails (Docker daemon hiccup), the container
+#   stays. There's no in-tree reaper today.
+#
+# Convention:
+#   Mark every keeper-sandbox container with the label
+#       masc.keeper.sandbox=true
+#   Optionally also:
+#       masc.keeper.id=<keeper-name>
+#       masc.keeper.session=<server-session-uuid>
+#
+#   Containers without the label are not touched. This script is a
+#   strictly additive safety net; it never removes named volumes (e.g.
+#   masc-state from docker-compose.yml) and never touches running
+#   containers.
+#
+# Usage:
+#   scripts/cleanup-orphaned-keeper-containers.sh                # dry-run, AGE_HOURS=2
+#   scripts/cleanup-orphaned-keeper-containers.sh --apply
+#   AGE_HOURS=24 scripts/cleanup-orphaned-keeper-containers.sh --apply
+#   LABEL=masc.keeper.sandbox=true scripts/cleanup-orphaned-keeper-containers.sh
+
+set -euo pipefail
+
+AGE_HOURS="${AGE_HOURS:-2}"
+LABEL="${LABEL:-masc.keeper.sandbox=true}"
+APPLY=0
+
+for arg in "$@"; do
+  case "$arg" in
+    --apply) APPLY=1 ;;
+    --help|-h)
+      sed -n '1,30p' "$0" | sed 's/^# \{0,1\}//'
+      exit 0
+      ;;
+    *)
+      echo "unknown arg: $arg" >&2
+      exit 2
+      ;;
+  esac
+done
+
+if ! command -v docker >/dev/null 2>&1; then
+  echo "docker not found in PATH; nothing to do." >&2
+  exit 0
+fi
+
+if ! docker info >/dev/null 2>&1; then
+  echo "docker daemon unreachable; nothing to do." >&2
+  exit 0
+fi
+
+mode_label() {
+  if [ "$APPLY" -eq 1 ]; then echo "APPLY"; else echo "DRY-RUN"; fi
+}
+
+echo "==> cleanup-orphaned-keeper-containers mode=$(mode_label) AGE_HOURS=${AGE_HOURS} LABEL=${LABEL}"
+
+# List exited+created+dead containers carrying our label, then filter by
+# FinishedAt age. We deliberately do NOT touch status=running.
+# Use a temp file (not mapfile) so this works on bash 3.2 (macOS default).
+candidates_file=$(mktemp -t masc-orphan-keeper-cands.XXXXXX)
+trap 'rm -f "$candidates_file"' EXIT
+docker ps -a \
+  --filter "label=${LABEL}" \
+  --filter "status=exited" \
+  --filter "status=created" \
+  --filter "status=dead" \
+  --format '{{.ID}}' > "$candidates_file"
+
+if [ ! -s "$candidates_file" ]; then
+  echo "no labeled non-running keeper containers found."
+  exit 0
+fi
+
+now_epoch=$(date -u +%s)
+removed=0
+inspected=0
+while IFS= read -r cid; do
+  [ -z "$cid" ] && continue
+  inspected=$((inspected + 1))
+  finished=$(docker inspect --format '{{.State.FinishedAt}}' "$cid" 2>/dev/null || echo "")
+  name=$(docker inspect --format '{{.Name}}' "$cid" 2>/dev/null | sed 's|^/||')
+  if [ -z "$finished" ] || [ "$finished" = "0001-01-01T00:00:00Z" ]; then
+    # never started cleanly — treat as old
+    age_hours=999
+  else
+    finished_epoch=$(date -u -d "$finished" +%s 2>/dev/null \
+      || python3 -c "import datetime,sys; print(int(datetime.datetime.fromisoformat(sys.argv[1].replace('Z','+00:00')).timestamp()))" "$finished" 2>/dev/null \
+      || echo 0)
+    if [ "$finished_epoch" -eq 0 ]; then
+      echo "  skip $cid ($name): could not parse FinishedAt=$finished"
+      continue
+    fi
+    age_hours=$(( (now_epoch - finished_epoch) / 3600 ))
+  fi
+  if [ "$age_hours" -lt "$AGE_HOURS" ]; then
+    echo "  keep $cid ($name): ${age_hours}h old < ${AGE_HOURS}h"
+    continue
+  fi
+  if [ "$APPLY" -eq 1 ]; then
+    if docker rm -f "$cid" >/dev/null 2>&1; then
+      echo "  removed $cid ($name) age=${age_hours}h"
+      removed=$((removed + 1))
+    else
+      echo "  failed  $cid ($name)"
+    fi
+  else
+    echo "  [dry-run] would remove $cid ($name) age=${age_hours}h"
+    removed=$((removed + 1))
+  fi
+done < "$candidates_file"
+
+echo "==> done $(mode_label): inspected=${inspected} removed=${removed}"

--- a/scripts/cleanup-orphaned-keeper-containers.sh
+++ b/scripts/cleanup-orphaned-keeper-containers.sh
@@ -97,13 +97,31 @@ while IFS= read -r cid; do
   [ -z "$cid" ] && continue
   inspected=$((inspected + 1))
   finished=$(docker inspect --format '{{.State.FinishedAt}}' "$cid" 2>/dev/null || echo "")
-  name=$(docker inspect --format '{{.Name}}' "$cid" 2>/dev/null | sed 's|^/||')
+  # Make the name lookup best-effort like [finished]: if the container
+  # disappears between listing and inspect (or inspect errors transiently),
+  # the script must not exit under [set -e]. Default to the container ID
+  # so log lines remain attributable.
+  name=$(docker inspect --format '{{.Name}}' "$cid" 2>/dev/null | sed 's|^/||' || echo "")
+  if [ -z "$name" ]; then name="$cid"; fi
   if [ -z "$finished" ] || [ "$finished" = "0001-01-01T00:00:00Z" ]; then
     # never started cleanly — treat as old
     age_hours=999
   else
+    # Trim Docker RFC3339Nano fractional seconds to 6 digits so
+    # python3 datetime.fromisoformat accepts the value on platforms
+    # without GNU [date -d]. Docker emits up to 9 fractional digits
+    # (e.g. ...123456789Z) which the stdlib parser rejected, leaving
+    # finished_epoch=0 and silently skipping removals on macOS.
+    finished_iso="$finished"
     finished_epoch=$(date -u -d "$finished" +%s 2>/dev/null \
-      || python3 -c "import datetime,sys; print(int(datetime.datetime.fromisoformat(sys.argv[1].replace('Z','+00:00')).timestamp()))" "$finished" 2>/dev/null \
+      || python3 -c "
+import datetime, re, sys
+raw = sys.argv[1].replace('Z', '+00:00')
+m = re.match(r'(.*?\\.\\d{0,6})\\d*([+-].*)$', raw)
+if m:
+    raw = m.group(1) + m.group(2)
+print(int(datetime.datetime.fromisoformat(raw).timestamp()))
+" "$finished_iso" 2>/dev/null \
       || echo 0)
     if [ "$finished_epoch" -eq 0 ]; then
       echo "  skip $cid ($name): could not parse FinishedAt=$finished"

--- a/scripts/cleanup-orphaned-keeper-containers.sh
+++ b/scripts/cleanup-orphaned-keeper-containers.sh
@@ -36,7 +36,7 @@ for arg in "$@"; do
   case "$arg" in
     --apply) APPLY=1 ;;
     --help|-h)
-      sed -n '1,30p' "$0" | sed 's/^# \{0,1\}//'
+      sed -n '2,27p' "$0" | sed 's/^# \{0,1\}//'
       exit 0
       ;;
     *)
@@ -45,6 +45,17 @@ for arg in "$@"; do
       ;;
   esac
 done
+
+case "$AGE_HOURS" in
+  ''|*[!0-9]*)
+    echo "invalid AGE_HOURS=${AGE_HOURS}; expected positive integer hours" >&2
+    exit 2
+    ;;
+esac
+if [ "$AGE_HOURS" -le 0 ]; then
+  echo "invalid AGE_HOURS=${AGE_HOURS}; expected positive integer hours" >&2
+  exit 2
+fi
 
 if ! command -v docker >/dev/null 2>&1; then
   echo "docker not found in PATH; nothing to do." >&2

--- a/scripts/docker-prune.sh
+++ b/scripts/docker-prune.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# docker-prune.sh — periodic Docker resource cleanup for masc-mcp hosts.
+#
+# Why this exists:
+#   The repo today has cleanup-stale-worktrees.sh and
+#   cleanup-merged-worktrees.sh for git, but no equivalent for Docker
+#   resources. On hosts that build the image (`Dockerfile`,
+#   `Dockerfile.worker-runtime`, `Dockerfile.keeper-sandbox`) and run
+#   keeper-docker smoke tests (`scripts/keeper-docker-multikeeper-isolation-smoke.sh`)
+#   repeatedly, dangling images / stopped containers / orphaned volumes
+#   accumulate and eat disk.
+#
+# Default mode is dry-run (mirrors cleanup-stale-worktrees.sh idiom),
+# pass --apply to actually prune.
+#
+# Scope:
+#   - dangling images (untagged layers from rebuilds)
+#   - stopped containers older than $AGE_HOURS
+#   - dangling/anonymous volumes (NOT named volumes such as masc-state)
+#   - builder cache older than $AGE_HOURS
+#
+# Out of scope (intentionally never pruned):
+#   - tagged images currently in use
+#   - named volumes (e.g. masc-state from docker-compose.yml)
+#   - running containers
+#
+# Usage:
+#   scripts/docker-prune.sh                # dry-run, default age 24h
+#   scripts/docker-prune.sh --apply        # actually prune
+#   AGE_HOURS=72 scripts/docker-prune.sh --apply
+
+set -euo pipefail
+
+AGE_HOURS="${AGE_HOURS:-24}"
+APPLY=0
+
+for arg in "$@"; do
+  case "$arg" in
+    --apply) APPLY=1 ;;
+    --help|-h)
+      sed -n '1,40p' "$0" | sed 's/^# \{0,1\}//'
+      exit 0
+      ;;
+    *)
+      echo "unknown arg: $arg" >&2
+      exit 2
+      ;;
+  esac
+done
+
+if ! command -v docker >/dev/null 2>&1; then
+  echo "docker not found in PATH; nothing to do." >&2
+  exit 0
+fi
+
+if ! docker info >/dev/null 2>&1; then
+  echo "docker daemon unreachable; nothing to do." >&2
+  exit 0
+fi
+
+mode_label() {
+  if [ "$APPLY" -eq 1 ]; then echo "APPLY"; else echo "DRY-RUN"; fi
+}
+
+run_or_echo() {
+  if [ "$APPLY" -eq 1 ]; then
+    "$@"
+  else
+    echo "[dry-run] $*"
+  fi
+}
+
+echo "==> docker-prune mode=$(mode_label) AGE_HOURS=${AGE_HOURS}"
+
+# 1. Dangling images
+echo "--- dangling images ---"
+docker images --filter "dangling=true" --format '{{.ID}} {{.Repository}}:{{.Tag}} {{.CreatedSince}}' || true
+run_or_echo docker image prune -f --filter "until=${AGE_HOURS}h"
+
+# 2. Stopped containers
+echo "--- stopped containers ---"
+docker ps -a --filter "status=exited" --filter "status=created" \
+  --format '{{.ID}} {{.Names}} {{.Status}}' || true
+run_or_echo docker container prune -f --filter "until=${AGE_HOURS}h"
+
+# 3. Dangling/anonymous volumes
+# Named volumes (driver=local with explicit name in compose) are safe;
+# `docker volume prune` without --all only removes anonymous volumes
+# not referenced by any container.
+echo "--- dangling volumes ---"
+docker volume ls --filter "dangling=true" --format '{{.Name}}' || true
+run_or_echo docker volume prune -f
+
+# 4. Builder cache
+echo "--- builder cache ---"
+docker buildx du 2>/dev/null | head -5 || docker system df --format '{{.Type}} {{.Reclaimable}}' || true
+run_or_echo docker builder prune -f --filter "until=${AGE_HOURS}h"
+
+echo "==> done ($(mode_label))"

--- a/scripts/docker-prune.sh
+++ b/scripts/docker-prune.sh
@@ -7,7 +7,7 @@
 #   resources. On hosts that build the image (`Dockerfile`,
 #   `Dockerfile.worker-runtime`, `Dockerfile.keeper-sandbox`) and run
 #   keeper-docker smoke tests (`scripts/keeper-docker-multikeeper-isolation-smoke.sh`)
-#   repeatedly, dangling images / stopped containers / orphaned volumes
+#   repeatedly, dangling images / stopped containers / builder cache
 #   accumulate and eat disk.
 #
 # Default mode is dry-run (mirrors cleanup-stale-worktrees.sh idiom),
@@ -16,12 +16,12 @@
 # Scope:
 #   - dangling images (untagged layers from rebuilds)
 #   - stopped containers older than $AGE_HOURS
-#   - dangling/anonymous volumes (NOT named volumes such as masc-state)
+#   - dangling volume names are reported for manual inspection only
 #   - builder cache older than $AGE_HOURS
 #
 # Out of scope (intentionally never pruned):
 #   - tagged images currently in use
-#   - named volumes (e.g. masc-state from docker-compose.yml)
+#   - Docker volumes (including named volumes such as masc-state)
 #   - running containers
 #
 # Usage:
@@ -38,7 +38,7 @@ for arg in "$@"; do
   case "$arg" in
     --apply) APPLY=1 ;;
     --help|-h)
-      sed -n '1,40p' "$0" | sed 's/^# \{0,1\}//'
+      sed -n '2,30p' "$0" | sed 's/^# \{0,1\}//'
       exit 0
       ;;
     *)
@@ -47,6 +47,17 @@ for arg in "$@"; do
       ;;
   esac
 done
+
+case "$AGE_HOURS" in
+  ''|*[!0-9]*)
+    echo "invalid AGE_HOURS=${AGE_HOURS}; expected positive integer hours" >&2
+    exit 2
+    ;;
+esac
+if [ "$AGE_HOURS" -le 0 ]; then
+  echo "invalid AGE_HOURS=${AGE_HOURS}; expected positive integer hours" >&2
+  exit 2
+fi
 
 if ! command -v docker >/dev/null 2>&1; then
   echo "docker not found in PATH; nothing to do." >&2
@@ -83,17 +94,18 @@ docker ps -a --filter "status=exited" --filter "status=created" \
   --format '{{.ID}} {{.Names}} {{.Status}}' || true
 run_or_echo docker container prune -f --filter "until=${AGE_HOURS}h"
 
-# 3. Dangling/anonymous volumes
-# Named volumes (driver=local with explicit name in compose) are safe;
-# `docker volume prune` without --all only removes anonymous volumes
-# not referenced by any container.
-echo "--- dangling volumes ---"
+# 3. Dangling volumes (report only)
+# `docker volume prune` can delete unused named volumes, including stateful
+# compose volumes. Report candidates here, but never prune volumes automatically.
+echo "--- dangling volumes (report only; never pruned) ---"
 docker volume ls --filter "dangling=true" --format '{{.Name}}' || true
-run_or_echo docker volume prune -f
+if [ "$APPLY" -eq 1 ]; then
+  echo "skip docker volume prune: it can remove unused named volumes"
+fi
 
 # 4. Builder cache
 echo "--- builder cache ---"
-docker buildx du 2>/dev/null | head -5 || docker system df --format '{{.Type}} {{.Reclaimable}}' || true
+docker buildx du 2>/dev/null || docker system df --format '{{.Type}} {{.Reclaimable}}' || true
 run_or_echo docker builder prune -f --filter "until=${AGE_HOURS}h"
 
 echo "==> done ($(mode_label))"

--- a/scripts/keeper-docker-multikeeper-isolation-smoke.sh
+++ b/scripts/keeper-docker-multikeeper-isolation-smoke.sh
@@ -47,6 +47,8 @@ run_keeper() {
   local expected_playground="$keeper-playground"
 
   docker run --rm -i \
+    --label masc.keeper.sandbox=true \
+    --label "masc.keeper.id=$keeper" \
     --user "$(id -u):$(id -g)" \
     --read-only \
     --tmpfs /tmp:rw,nosuid,nodev,noexec,size=64m \

--- a/test/dune
+++ b/test/dune
@@ -207,6 +207,7 @@
         test_keeper_state_machine
         test_keeper_state_machine_correspondence
         test_keeper_lifecycle_hooks
+        test_keeper_subprocess_registry
         test_keeper_social_model_magentic_ledger_fsm
         test_keeper_overflow_recovery
         test_telemetry_unified
@@ -428,6 +429,7 @@
           test_keeper_state_machine
           test_keeper_state_machine_correspondence
           test_keeper_lifecycle_hooks
+          test_keeper_subprocess_registry
           test_keeper_social_model_magentic_ledger_fsm
           test_keeper_overflow_recovery
           test_telemetry_unified

--- a/test/dune
+++ b/test/dune
@@ -206,6 +206,7 @@
         test_tool_prefilter
         test_keeper_state_machine
         test_keeper_state_machine_correspondence
+        test_keeper_lifecycle_hooks
         test_keeper_social_model_magentic_ledger_fsm
         test_keeper_overflow_recovery
         test_telemetry_unified
@@ -426,6 +427,7 @@
           test_tool_prefilter
           test_keeper_state_machine
           test_keeper_state_machine_correspondence
+          test_keeper_lifecycle_hooks
           test_keeper_social_model_magentic_ledger_fsm
           test_keeper_overflow_recovery
           test_telemetry_unified

--- a/test/test_keeper_lifecycle_hooks.ml
+++ b/test/test_keeper_lifecycle_hooks.ml
@@ -1,0 +1,84 @@
+(** test_keeper_lifecycle_hooks — RFC-0036 Phase A.1 plumbing tests.
+
+    Verifies the additive hook registry contract:
+    - register adds; registered_count reflects size
+    - run dispatches in registration order
+    - exception in one hook does not stop later hooks or raise out
+    - reset_for_testing clears state between cases *)
+
+open Alcotest
+
+module H = Masc_mcp.Keeper_lifecycle_hooks
+module SM = Masc_mcp.Keeper_state_machine
+
+let setup () = H.reset_for_testing ()
+
+let test_register_increments_count () =
+  setup ();
+  check int "starts empty" 0 (H.registered_count ());
+  H.register (fun ~keeper_id:_ _ -> ());
+  check int "one after register" 1 (H.registered_count ());
+  H.register (fun ~keeper_id:_ _ -> ());
+  check int "two after second register" 2 (H.registered_count ())
+
+let test_run_dispatches_in_order () =
+  setup ();
+  let order = ref [] in
+  H.register (fun ~keeper_id:_ _ -> order := "a" :: !order);
+  H.register (fun ~keeper_id:_ _ -> order := "b" :: !order);
+  H.register (fun ~keeper_id:_ _ -> order := "c" :: !order);
+  H.run ~keeper_id:"k1" H.Tombstone_reaped;
+  (* List was prepended, so reverse to get registration order *)
+  check (list string) "registration order" [ "a"; "b"; "c" ]
+    (List.rev !order)
+
+let test_run_passes_keeper_id_and_event () =
+  setup ();
+  let captured = ref [] in
+  H.register (fun ~keeper_id ev ->
+    let tag = match ev with
+      | H.Tombstone_reaped -> "tombstone"
+      | H.Phase_transition { from_phase; to_phase } ->
+        Printf.sprintf "%s->%s"
+          (SM.phase_to_string from_phase)
+          (SM.phase_to_string to_phase)
+    in
+    captured := (keeper_id, tag) :: !captured);
+  H.run ~keeper_id:"alpha" H.Tombstone_reaped;
+  H.run ~keeper_id:"beta"
+    (H.Phase_transition
+       { from_phase = SM.Running; to_phase = SM.Dead });
+  let want = [
+    ("alpha", "tombstone");
+    ("beta",  "running->dead");
+  ] in
+  check (list (pair string string)) "captured events" want
+    (List.rev !captured)
+
+let test_exception_in_hook_is_swallowed () =
+  setup ();
+  let after_count = ref 0 in
+  H.register (fun ~keeper_id:_ _ -> failwith "boom");
+  H.register (fun ~keeper_id:_ _ -> incr after_count);
+  (* Should not raise. *)
+  H.run ~keeper_id:"k" H.Tombstone_reaped;
+  check int "subsequent hook still ran" 1 !after_count
+
+let test_reset_for_testing_clears () =
+  setup ();
+  H.register (fun ~keeper_id:_ _ -> ());
+  H.register (fun ~keeper_id:_ _ -> ());
+  check int "two registered" 2 (H.registered_count ());
+  H.reset_for_testing ();
+  check int "cleared" 0 (H.registered_count ())
+
+let () =
+  run "Keeper_lifecycle_hooks" [
+    "register",      [ test_case "increments count" `Quick test_register_increments_count ];
+    "run",           [
+      test_case "dispatches in order"        `Quick test_run_dispatches_in_order;
+      test_case "passes keeper_id and event" `Quick test_run_passes_keeper_id_and_event;
+      test_case "swallows exceptions"        `Quick test_exception_in_hook_is_swallowed;
+    ];
+    "reset_for_testing", [ test_case "clears all" `Quick test_reset_for_testing_clears ];
+  ]

--- a/test/test_keeper_subprocess_registry.ml
+++ b/test/test_keeper_subprocess_registry.ml
@@ -1,0 +1,118 @@
+(** test_keeper_subprocess_registry — RFC-0036 Phase A.3 registry tests.
+
+    Pure API tests — no real subprocesses are spawned.
+    Drain is exercised with synthetic pids that will fail Unix.kill
+    (ESRCH); this proves drain doesn't crash on already-reaped or
+    bogus pids and that the registry is cleared regardless. *)
+
+open Alcotest
+
+module R = Masc_mcp.Keeper_subprocess_registry
+module H = Masc_mcp.Keeper_lifecycle_hooks
+
+let setup () =
+  R.reset_for_testing ();
+  H.reset_for_testing ()
+
+let test_register_unregister_pids_for () =
+  setup ();
+  check (list int) "starts empty" [] (R.pids_for ~keeper_id:"k1");
+  R.register ~keeper_id:"k1" ~pid:1001;
+  R.register ~keeper_id:"k1" ~pid:1002;
+  R.register ~keeper_id:"k2" ~pid:2001;
+  check (list int) "k1 has both"  [ 1001; 1002 ] (R.pids_for ~keeper_id:"k1");
+  check (list int) "k2 has one"   [ 2001 ]       (R.pids_for ~keeper_id:"k2");
+  check int        "total = 3"    3              (R.total_pids ());
+  R.unregister ~keeper_id:"k1" ~pid:1001;
+  check (list int) "k1 after unreg" [ 1002 ] (R.pids_for ~keeper_id:"k1");
+  check int        "total = 2"      2        (R.total_pids ())
+
+let test_register_idempotent () =
+  setup ();
+  R.register ~keeper_id:"k" ~pid:42;
+  R.register ~keeper_id:"k" ~pid:42;
+  R.register ~keeper_id:"k" ~pid:42;
+  check (list int) "single entry" [ 42 ] (R.pids_for ~keeper_id:"k");
+  check int        "total = 1"     1     (R.total_pids ())
+
+let test_unregister_unknown_is_noop () =
+  setup ();
+  R.unregister ~keeper_id:"never-registered" ~pid:99;
+  R.register ~keeper_id:"k" ~pid:1;
+  R.unregister ~keeper_id:"k" ~pid:9999;  (* wrong pid *)
+  check (list int) "still has 1" [ 1 ] (R.pids_for ~keeper_id:"k")
+
+let test_drain_with_no_pids () =
+  setup ();
+  let r = R.drain ~keeper_id:"empty" ~grace_ms:50 in
+  check int "inspected"   0 r.R.inspected;
+  check int "sigterm"     0 r.R.sigterm_sent;
+  check int "sigkill"     0 r.R.sigkill_sent;
+  check int "still_alive" 0 r.R.still_alive
+
+let test_drain_clears_registry () =
+  setup ();
+  (* Use very high pids unlikely to exist. Unix.kill will fail with
+     ESRCH, but drain should still remove them from the registry. *)
+  R.register ~keeper_id:"k" ~pid:0x7FFFFFF0;
+  R.register ~keeper_id:"k" ~pid:0x7FFFFFF1;
+  let r = R.drain ~keeper_id:"k" ~grace_ms:50 in
+  check int "inspected = 2" 2 r.R.inspected;
+  (* sigterm_sent may be 0 (kill failed with ESRCH); the post-condition
+     we care about is that the registry is empty. *)
+  check (list int) "registry cleared" [] (R.pids_for ~keeper_id:"k");
+  check int "total = 0" 0 (R.total_pids ())
+
+let test_drain_grace_ms_clamped () =
+  setup ();
+  (* No pids → drain returns immediately regardless of grace_ms. The
+     clamp logic still runs; just verify no crash on extreme values. *)
+  let _ = R.drain ~keeper_id:"e" ~grace_ms:(-100) in
+  let _ = R.drain ~keeper_id:"e" ~grace_ms:1_000_000 in
+  check pass "no crash on extreme grace_ms" () ()
+
+let test_default_hook_idempotent_registration () =
+  setup ();
+  check int "no hooks initially" 0 (H.registered_count ());
+  R.register_default_cleanup_hook ();
+  check int "one hook"           1 (H.registered_count ());
+  R.register_default_cleanup_hook ();
+  R.register_default_cleanup_hook ();
+  check int "still one hook (idempotent)" 1 (H.registered_count ())
+
+let test_default_hook_drains_on_tombstone () =
+  setup ();
+  R.register ~keeper_id:"k" ~pid:0x7FFFFFF2;
+  R.register_default_cleanup_hook ();
+  H.run ~keeper_id:"k" H.Tombstone_reaped;
+  check (list int) "registry drained by hook" [] (R.pids_for ~keeper_id:"k")
+
+let test_default_hook_ignores_phase_transition () =
+  setup ();
+  R.register ~keeper_id:"k" ~pid:0x7FFFFFF3;
+  R.register_default_cleanup_hook ();
+  H.run ~keeper_id:"k"
+    (H.Phase_transition
+       { from_phase = Masc_mcp.Keeper_state_machine.Running;
+         to_phase   = Masc_mcp.Keeper_state_machine.Failing });
+  (* Phase_transition must not drain. *)
+  check (list int) "still tracked" [ 0x7FFFFFF3 ] (R.pids_for ~keeper_id:"k")
+
+let () =
+  run "Keeper_subprocess_registry" [
+    "registry", [
+      test_case "register/unregister/pids_for" `Quick test_register_unregister_pids_for;
+      test_case "register is idempotent"       `Quick test_register_idempotent;
+      test_case "unregister unknown is noop"   `Quick test_unregister_unknown_is_noop;
+    ];
+    "drain", [
+      test_case "no-op when empty"     `Quick test_drain_with_no_pids;
+      test_case "clears registry"      `Quick test_drain_clears_registry;
+      test_case "grace_ms clamped"     `Quick test_drain_grace_ms_clamped;
+    ];
+    "default_hook", [
+      test_case "registration is idempotent"        `Quick test_default_hook_idempotent_registration;
+      test_case "drains on Tombstone_reaped"        `Quick test_default_hook_drains_on_tombstone;
+      test_case "ignores Phase_transition"          `Quick test_default_hook_ignores_phase_transition;
+    ];
+  ]


### PR DESCRIPTION
## Summary
2026-05-07 docker_cleanup_code_verification 보고서가 지적한 65% 미구현 갭 중 P0 전부 + P1 일부를 닫습니다.

| 영역 | 변경 |
|------|------|
| Dockerfile x 3 | `STOPSIGNAL SIGTERM` 명시 (docker stop/k8s가 OCaml 4-phase shutdown 우회 못하게) |
| docker-compose.yml | restart=unless-stopped, stop_grace_period=60s, json-file 10m x 3, masc-state named volume, baked-in tini만 사용 |
| infrastructure/systemd/masc-mcp.service | Linux 운영 parity unit 추가, shutdown force timeout/TimeoutStopSec 명시 |
| scripts/docker-prune.sh | dry-run 기본, dangling images/containers/builder cache prune, volume은 보고만 하고 자동 prune 금지 |
| scripts/cleanup-orphaned-keeper-containers.sh | labeled non-running keeper sandbox container cleanup, AGE_HOURS 검증 |
| lib/shutdown_hooks.ml | `<MASC_BASE_PATH>/.masc/tmp/*` regular file purge (dirs/symlinks 미접근, bounded, per-file 에러 tolerant) |

## Why
- `docker-compose.yml` 부재 → restart policy/log driver/stop_grace_period 설정 불가
- `STOPSIGNAL` 미명시 → graceful contract가 Dockerfile만 봐서는 안 보임
- 무한 host 로그 (json-file 기본 cap 없음) → 디스크 폭주 위험
- `.masc/tmp/` 잔여 파일 → 컨테이너 재시작 간 상태 오염 가능
- Dangling images/builder cache 22.6GB+19.11GB 회수 가능 (smoke test 결과)

## Verification
- [x] `bash -n scripts/docker-prune.sh`
- [x] `bash -n scripts/cleanup-orphaned-keeper-containers.sh`
- [x] `scripts/docker-prune.sh --help`
- [x] `scripts/cleanup-orphaned-keeper-containers.sh --help`
- [x] `env AGE_HOURS=abc scripts/docker-prune.sh` fails clearly
- [x] `env AGE_HOURS=abc scripts/cleanup-orphaned-keeper-containers.sh` fails clearly
- [x] `ocamlc -stop-after parsing lib/shutdown_hooks.ml`
- [x] `docker compose config --quiet`
- [x] `git diff --check`

## Test plan
- [ ] CI: lint + dune build green
- [ ] Reviewer: docker-compose.yml/systemd unit가 Railway/launchd 운영과 충돌 없는지 확인
- [ ] Reviewer: shutdown_hooks .masc/tmp purge가 production basepath(~/me/.masc/tmp)에 안전한지 확인 (현재 production은 main 머지 + redeploy 전까지 영향 없음)
- [ ] Manual: 로컬 `docker compose up`으로 stop_grace_period x OCaml shutdown 정합성 검증

## Out of scope (follow-up)
- Multi-keeper docker-compose / Keeper Dead → `docker rm` bridge (P2, lib/keeper RFC 필요)
- Docker socket mount 기반 DinD/orphan reaper 고도화 (P1 설계 필요)

## Verification source
- `/Users/dancer/Downloads/docker_cleanup_code_verification.md` (2026-05-07)
- `/loop 20m` 스케줄로 추가 후속 작업 진행 예정

🤖 Generated with [Claude Code](https://claude.com/claude-code)
