### PR TITLE
fix(ci): restore main opam pin and spec refs

### DIFF
--- a/scripts/opam-pin-external-deps.sh
+++ b/scripts/opam-pin-external-deps.sh
@@ -152,7 +152,7 @@ installed_agent_sdk_version() {
   # qualifies. This mirrors PR #13787 which closed the same family of
   # bypass on the sibling installed_agent_sdk_version() implementation.
   if [[ "${show_status}" -ne 0 ]] \
-    && grep -Eiq 'No package named (agent_sdk|"agent_sdk")|no packages matching .*agent_sdk|unknown package .*agent_sdk' <<<"${show_output}"; then
+    && grep -Eiq 'No package named (agent_sdk|"agent_sdk")|No package matching .*agent_sdk|no packages matching .*agent_sdk|unknown package .*agent_sdk' <<<"${show_output}"; then
     return 1
   fi
 

--- a/specs/INDEX.md
+++ b/specs/INDEX.md
@@ -77,7 +77,7 @@ Source of truth: `specs/`. Run `scripts/gen-tla-index.sh > specs/INDEX.md` to re
 | CascadeCrossFallback.tla | CascadeCrossFallback | manual | 2 | 1 | clean={inv:TypeOK, inv:AtMostOneCrossCascadePerTurn, inv:PromotionRequiresExhaustion, inv:PromotionFrozenAfterFinish} buggy={inv:TypeOK, inv:AtMostOneCrossCascadePerTurn} | b3f6de56fd84 |
 | CascadeExhaustion.tla | CascadeExhaustion | manual | 2 | 1 | clean={inv:TypeOK, inv:ExhaustionSafetyLastOk} buggy={inv:TypeOK, inv:ExhaustionDiagnosticConsistency} | 20f49d7b2536 |
 | CascadeLiveness.tla | CascadeLiveness | manual | 3 | 1 | clean={inv:TypeOK, inv:SlotCapacity, inv:SlotNonNeg, inv:NoPhantomSlots, inv:AdmittedOK} buggy={inv:TypeOK, inv:NoPhantomSlots} liveness={inv:TypeOK, inv:SlotCapacity, inv:SlotNonNeg, inv:NoPhantomSlots, inv:AdmittedOK} | 47df51e8fce8 |
-| DashboardCacheStampede.tla | DashboardCacheStampede | manual | 2 | 1 | clean={inv:TypeOK, inv:NoZombieSlot} buggy={inv:TypeOK, inv:NoZombieSlot} | 0faf264fec4b |
+| DashboardCacheStampede.tla | DashboardCacheStampede | manual | 2 | 1 | clean={inv:TypeOK, inv:NoZombieSlot} buggy={inv:TypeOK, inv:NoZombieSlot} | 30257cba3584 |
 | DiscoveryCacheTTL.tla | DiscoveryCacheTTL | manual | 2 | 1 | clean={inv:TypeOK, inv:ConsistentRead} buggy={inv:TypeOK, inv:ConsistentRead} | 67b6a98c6628 |
 | DispatchCoverage.tla | DispatchCoverage | manual | 2 | 1 | clean={inv:TypeOK, inv:DataFsmConsistent, inv:PhaseConsistent, inv:NeverStuckFailing} buggy={inv:TypeOK, inv:DataFsmConsistent, inv:PhaseConsistent, inv:NeverStuckFailing} | 27f7463c8e91 |
 | DispatchHookChain.tla | DispatchHookChain | manual | 2 | 1 | clean={inv:ShortCircuitSkipsHandler, inv:PostHooksAfterHandler, inv:HandlerRequiresNoReject} buggy={inv:ShortCircuitSkipsHandler} | be2fa471842f |

--- a/specs/INDEX.md
+++ b/specs/INDEX.md
@@ -77,7 +77,7 @@ Source of truth: `specs/`. Run `scripts/gen-tla-index.sh > specs/INDEX.md` to re
 | CascadeCrossFallback.tla | CascadeCrossFallback | manual | 2 | 1 | clean={inv:TypeOK, inv:AtMostOneCrossCascadePerTurn, inv:PromotionRequiresExhaustion, inv:PromotionFrozenAfterFinish} buggy={inv:TypeOK, inv:AtMostOneCrossCascadePerTurn} | b3f6de56fd84 |
 | CascadeExhaustion.tla | CascadeExhaustion | manual | 2 | 1 | clean={inv:TypeOK, inv:ExhaustionSafetyLastOk} buggy={inv:TypeOK, inv:ExhaustionDiagnosticConsistency} | 20f49d7b2536 |
 | CascadeLiveness.tla | CascadeLiveness | manual | 3 | 1 | clean={inv:TypeOK, inv:SlotCapacity, inv:SlotNonNeg, inv:NoPhantomSlots, inv:AdmittedOK} buggy={inv:TypeOK, inv:NoPhantomSlots} liveness={inv:TypeOK, inv:SlotCapacity, inv:SlotNonNeg, inv:NoPhantomSlots, inv:AdmittedOK} | 47df51e8fce8 |
-| DashboardCacheStampede.tla | DashboardCacheStampede | manual | 2 | 1 | clean={inv:TypeOK, inv:NoZombieSlot} buggy={inv:TypeOK, inv:NoZombieSlot} | 30257cba3584 |
+| DashboardCacheStampede.tla | DashboardCacheStampede | manual | 2 | 1 | clean={inv:TypeOK, inv:NoZombieSlot} buggy={inv:TypeOK, inv:NoZombieSlot} | ab492d475875 |
 | DiscoveryCacheTTL.tla | DiscoveryCacheTTL | manual | 2 | 1 | clean={inv:TypeOK, inv:ConsistentRead} buggy={inv:TypeOK, inv:ConsistentRead} | 67b6a98c6628 |
 | DispatchCoverage.tla | DispatchCoverage | manual | 2 | 1 | clean={inv:TypeOK, inv:DataFsmConsistent, inv:PhaseConsistent, inv:NeverStuckFailing} buggy={inv:TypeOK, inv:DataFsmConsistent, inv:PhaseConsistent, inv:NeverStuckFailing} | 27f7463c8e91 |
 | DispatchHookChain.tla | DispatchHookChain | manual | 2 | 1 | clean={inv:ShortCircuitSkipsHandler, inv:PostHooksAfterHandler, inv:HandlerRequiresNoReject} buggy={inv:ShortCircuitSkipsHandler} | be2fa471842f |

--- a/specs/bug-models/DashboardCacheStampede.tla
+++ b/specs/bug-models/DashboardCacheStampede.tla
@@ -10,11 +10,11 @@
 \*
 \* Actual code (verified 2026-04-20):
 \*   lib/dashboard/dashboard_cache.ml:60   let maybe_evict map
-\*   lib/dashboard/dashboard_cache.ml:161  let get_or_compute_eio
-\*   lib/dashboard/dashboard_cache.ml:262  | Eio.Cancel.Cancelled _ as e -> ...
+\*   lib/dashboard/dashboard_cache.ml:219  let get_or_compute_eio
+\*   lib/dashboard/dashboard_cache.ml:159  | Eio.Cancel.Cancelled _ -> ...
 \*
 \* (Path drift: lib/dashboard_cache.ml -> lib/dashboard/dashboard_cache.ml.
-\*  Line drift: 265 -> 216 -> 161/262. Recorded for cross-reference.)
+\*  Line drift: 265 -> 216 -> 161/262 -> 219/159. Recorded for cross-reference.)
 
 EXTENDS Naturals
 

--- a/specs/bug-models/DashboardCacheStampede.tla
+++ b/specs/bug-models/DashboardCacheStampede.tla
@@ -11,10 +11,10 @@
 \* Actual code (verified 2026-04-20):
 \*   lib/dashboard/dashboard_cache.ml:60   let maybe_evict map
 \*   lib/dashboard/dashboard_cache.ml:219  let get_or_compute_eio
-\*   lib/dashboard/dashboard_cache.ml:159  | Eio.Cancel.Cancelled _ -> ...
+\*   lib/dashboard/dashboard_cache.ml:326  | Eio.Cancel.Cancelled _ -> ...
 \*
 \* (Path drift: lib/dashboard_cache.ml -> lib/dashboard/dashboard_cache.ml.
-\*  Line drift: 265 -> 216 -> 161/262 -> 219/159. Recorded for cross-reference.)
+\*  Line drift: 265 -> 216 -> 161/262 -> 219/326. Recorded for cross-reference.)
 
 EXTENDS Naturals
 

--- a/test/test_opam_pin_downgrade_guard.sh
+++ b/test/test_opam_pin_downgrade_guard.sh
@@ -45,7 +45,7 @@ case "$1" in
     shift
     if [[ "${1:-}" == "agent_sdk" && "${2:-}" == "--field=version" ]]; then
       if [[ "${FAKE_OPAM_SHOW_MISSING:-0}" == "1" ]]; then
-        echo "No package named agent_sdk found" >&2
+        echo "[ERROR] No package matching agent_sdk found" >&2
         exit 1
       fi
       [[ "${FAKE_OPAM_SHOW_FAIL:-0}" == "1" ]] && exit 43


### PR DESCRIPTION
## Summary
- Treat CI's singular opam missing-package output as the fresh-switch path for agent_sdk initial pinning
- Update the opam downgrade guard regression fixture to use the CI failure string
- Refresh DashboardCacheStampede spec line refs after dashboard_cache.ml drift

## Validation
- bash -n scripts/opam-pin-external-deps.sh test/test_opam_pin_downgrade_guard.sh
- git diff --check
- bash scripts/lint/spec-line-refs.sh
- bash test/test_opam_pin_downgrade_guard.sh