### PR TITLE
obs(backend): export mutex acquire/held histograms to Prometheus

### DIFF
--- a/lib/backend/backend.ml
+++ b/lib/backend/backend.ml
@@ -65,6 +65,14 @@ module FileSystem = struct
     mutex_acquire_observer := acquire;
     mutex_held_observer := held
 
+  let notify_mutex_observer ~kind observer ~op ~seconds =
+    try observer ~op ~seconds
+    with exn ->
+      Log.legacy_traceln ~level:Log.Debug ~module_name:"Backend"
+        (Printf.sprintf
+           "[DEBUG] backend mutex %s observer failed for op=%s: %s"
+           kind op (Printexc.to_string exn))
+
   (** Wrap a write critical section with acquire/held observers.
 
       Acquire latency is measured as [now - call_start]; held latency
@@ -74,19 +82,25 @@ module FileSystem = struct
       mutex. *)
   let with_observed_mutex ~op t f =
     let started = Time_compat.now () in
+    let acquired = ref false in
     let acquire_seconds = ref 0.0 in
     let held_seconds = ref 0.0 in
-    let result =
-      Eio.Mutex.use_rw ~protect:true t.mutex (fun () ->
-        let acquired = Time_compat.now () in
-        acquire_seconds := acquired -. started;
-        let value = f () in
-        held_seconds := Time_compat.now () -. acquired;
-        value)
-    in
-    !mutex_acquire_observer ~op ~seconds:!acquire_seconds;
-    !mutex_held_observer ~op ~seconds:!held_seconds;
-    result
+    Fun.protect
+      ~finally:(fun () ->
+        if not !acquired then acquire_seconds := Time_compat.now () -. started;
+        notify_mutex_observer ~kind:"acquire" !mutex_acquire_observer
+          ~op ~seconds:!acquire_seconds;
+        notify_mutex_observer ~kind:"held" !mutex_held_observer
+          ~op ~seconds:!held_seconds)
+      (fun () ->
+        Eio.Mutex.use_rw ~protect:true t.mutex (fun () ->
+          let acquired_at = Time_compat.now () in
+          acquired := true;
+          acquire_seconds := acquired_at -. started;
+          Fun.protect
+            ~finally:(fun () ->
+              held_seconds := Time_compat.now () -. acquired_at)
+            f))
 
   (** Create a new FileSystem backend *)
   let create ~fs ?clock config =

--- a/lib/backend/backend.ml
+++ b/lib/backend/backend.ml
@@ -43,6 +43,51 @@ module FileSystem = struct
     clock: float Eio.Time.clock_ty Eio.Resource.t option;
   }
 
+  (** {2 Mutex contention observers}
+
+      Hooks for write-mutex contention metrics.  Default is a no-op
+      so [masc_backend] does not depend on [Prometheus] at link time;
+      the main library wires Prometheus histograms via
+      [set_mutex_observers] at startup.
+
+      Observers run *outside* the critical section to avoid nested
+      locking against [Prometheus]'s internal Stdlib.Mutex. *)
+
+  let mutex_acquire_observer
+    : (op:string -> seconds:float -> unit) ref =
+    ref (fun ~op:_ ~seconds:_ -> ())
+
+  let mutex_held_observer
+    : (op:string -> seconds:float -> unit) ref =
+    ref (fun ~op:_ ~seconds:_ -> ())
+
+  let set_mutex_observers ~acquire ~held =
+    mutex_acquire_observer := acquire;
+    mutex_held_observer := held
+
+  (** Wrap a write critical section with acquire/held observers.
+
+      Acquire latency is measured as [now - call_start]; held latency
+      as [now - mutex_acquired].  Observers run after the lock is
+      released, so they cannot extend the critical section even if
+      the underlying Prometheus implementation contends on its own
+      mutex. *)
+  let with_observed_mutex ~op t f =
+    let started = Time_compat.now () in
+    let acquire_seconds = ref 0.0 in
+    let held_seconds = ref 0.0 in
+    let result =
+      Eio.Mutex.use_rw ~protect:true t.mutex (fun () ->
+        let acquired = Time_compat.now () in
+        acquire_seconds := acquired -. started;
+        let value = f () in
+        held_seconds := Time_compat.now () -. acquired;
+        value)
+    in
+    !mutex_acquire_observer ~op ~seconds:!acquire_seconds;
+    !mutex_held_observer ~op ~seconds:!held_seconds;
+    result
+
   (** Create a new FileSystem backend *)
   let create ~fs ?clock config =
     let path = Eio.Path.(fs / config.base_path) in
@@ -239,7 +284,7 @@ module FileSystem = struct
       The mutex inside [t] already serialises writers against each
       other; this change adds atomicity against concurrent readers. *)
   let set t key value =
-    Eio.Mutex.use_rw ~protect:true t.mutex (fun () ->
+    with_observed_mutex ~op:"set" t (fun () ->
       match validate_key key with
       | Error e -> Error e
       | Ok safe_key ->
@@ -268,7 +313,7 @@ module FileSystem = struct
 
   (** Delete key *)
   let delete t key =
-    Eio.Mutex.use_rw ~protect:true t.mutex (fun () ->
+    with_observed_mutex ~op:"delete" t (fun () ->
       match key_to_path t key with
       | Error e -> Error e
       | Ok path ->
@@ -481,7 +526,7 @@ module FileSystem = struct
   let set_if_not_exists t key value =
     (* Compact Protocol v4: Compress before saving *)
     let compressed = _compress value in
-    Eio.Mutex.use_rw ~protect:true t.mutex (fun () ->
+    with_observed_mutex ~op:"set_if_not_exists" t (fun () ->
       match key_to_path t key with
       | Error e -> Error e
       | Ok path ->

--- a/lib/backend/backend.mli
+++ b/lib/backend/backend.mli
@@ -21,12 +21,12 @@ module FileSystem : sig
       [Prometheus] at link time.
 
       [acquire] receives the seconds a fiber waited before entering
-      the lock; [held] receives the seconds the lock was held during
-      compress + rename / unlink.  Both run *outside* the mutex
-      critical section to avoid nested locking.
+      the lock; [held] receives the seconds spent in the write critical
+      section. Both run *outside* the mutex critical section to avoid
+      nested locking.
 
-      [op] is one of [set | delete | set_if_not_exists]; read paths
-      ([get], [atomic_get]) run lock-free and are not measured. *)
+      [op] is one of [set | delete | set_if_not_exists]. Read paths
+      are not measured by these histograms. *)
   val set_mutex_observers :
     acquire:(op:string -> seconds:float -> unit) ->
     held:(op:string -> seconds:float -> unit) ->

--- a/lib/backend/backend.mli
+++ b/lib/backend/backend.mli
@@ -13,6 +13,25 @@ include module type of struct include Backend_types end
 module FileSystem : sig
   type t
 
+  (** Install observers for write-mutex contention.
+
+      Called once at startup from the main library to wire mutex
+      acquire/hold timings into Prometheus histograms.  The default
+      observers are no-ops, so [masc_backend] does not depend on
+      [Prometheus] at link time.
+
+      [acquire] receives the seconds a fiber waited before entering
+      the lock; [held] receives the seconds the lock was held during
+      compress + rename / unlink.  Both run *outside* the mutex
+      critical section to avoid nested locking.
+
+      [op] is one of [set | delete | set_if_not_exists]; read paths
+      ([get], [atomic_get]) run lock-free and are not measured. *)
+  val set_mutex_observers :
+    acquire:(op:string -> seconds:float -> unit) ->
+    held:(op:string -> seconds:float -> unit) ->
+    unit
+
   val create :
     fs:Eio.Fs.dir_ty Eio.Path.t ->
     ?clock:float Eio.Time.clock_ty Eio.Resource.t ->

--- a/lib/coord/coord_eio.ml
+++ b/lib/coord/coord_eio.ml
@@ -82,6 +82,17 @@ let create_config ~fs ?clock base_path =
     pubsub_max_messages = Backend.pubsub_max_messages;
   } in
   let backend = Backend.FileSystem.create ~fs ?clock backend_config in
+  Backend.FileSystem.set_mutex_observers
+    ~acquire:(fun ~op ~seconds ->
+      Prometheus.observe_histogram
+        Prometheus.metric_backend_mutex_acquire_sec
+        ~labels:[("op", op)]
+        seconds)
+    ~held:(fun ~op ~seconds ->
+      Prometheus.observe_histogram
+        Prometheus.metric_backend_mutex_held_sec
+        ~labels:[("op", op)]
+        seconds);
   {
     base_path;
     lock_expiry_minutes = 30;

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -363,8 +363,8 @@ let metric_board_persist_lock_held_sec =
    [Backend.FileSystem.with_observed_mutex] via
    [Backend.FileSystem.set_mutex_observers] (installed once from the
    main library at startup).  Scoped to writer paths
-   (set / delete / set_if_not_exists); read paths are lock-free and
-   are not measured.  Labels: [op]. *)
+   (set / delete / set_if_not_exists). Read paths are not measured by
+   these histograms. Labels: [op]. *)
 let metric_backend_mutex_acquire_sec =
   "masc_backend_mutex_acquire_sec"
 
@@ -1448,18 +1448,17 @@ let init () =
     ~help:"Seconds the board persist mutex is held by one fiber, \
            covering the disk I/O performed inside the lock." ();
   (* Backend filesystem mutex diagnostic histograms.  acquire =
-     wait-for-write-lock, held = inside-lock compress + rename/unlink
-     syscalls.  Together they let operators decide whether keeper
-     storage I/O latency is queueing (acquire high) or syscall stall
-     (held high), without inferring from external symptoms.
+     wait-for-write-lock, held = time spent in the write critical
+     section. Together they let operators decide whether keeper storage
+     I/O latency is queueing (acquire high) or filesystem work while
+     holding the mutex (held high), without inferring from external symptoms.
      Labels: op in {set, delete, set_if_not_exists}. *)
   register_histogram ~name:metric_backend_mutex_acquire_sec
     ~help:"Seconds spent waiting to acquire the backend filesystem \
            write mutex.  Labels: op." ();
   register_histogram ~name:metric_backend_mutex_held_sec
     ~help:"Seconds the backend filesystem mutex is held by one fiber, \
-           covering compress + atomic-rename / unlink syscalls. \
-           Labels: op." ();
+           covering the write critical section. Labels: op." ();
   add metric_keeper_slot_yield_total
     "Total autonomous turn slot yields (successfully yielded and reacquired). \
      Labels: keeper."

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -359,6 +359,18 @@ let metric_board_persist_lock_acquire_sec =
 let metric_board_persist_lock_held_sec =
   "masc_board_persist_lock_held_sec"
 
+(* Backend filesystem mutex contention diagnostic.  Recorded by
+   [Backend.FileSystem.with_observed_mutex] via
+   [Backend.FileSystem.set_mutex_observers] (installed once from the
+   main library at startup).  Scoped to writer paths
+   (set / delete / set_if_not_exists); read paths are lock-free and
+   are not measured.  Labels: [op]. *)
+let metric_backend_mutex_acquire_sec =
+  "masc_backend_mutex_acquire_sec"
+
+let metric_backend_mutex_held_sec =
+  "masc_backend_mutex_held_sec"
+
 (* P-DASH-02: turn queue depth gauge.  Semaphore waiters are
    observable via [autonomous_waiter_snapshot_for_test] but were
    only emitted as a debug log line.  Surfacing as a gauge lets
@@ -1435,6 +1447,19 @@ let init () =
   register_histogram ~name:metric_board_persist_lock_held_sec
     ~help:"Seconds the board persist mutex is held by one fiber, \
            covering the disk I/O performed inside the lock." ();
+  (* Backend filesystem mutex diagnostic histograms.  acquire =
+     wait-for-write-lock, held = inside-lock compress + rename/unlink
+     syscalls.  Together they let operators decide whether keeper
+     storage I/O latency is queueing (acquire high) or syscall stall
+     (held high), without inferring from external symptoms.
+     Labels: op in {set, delete, set_if_not_exists}. *)
+  register_histogram ~name:metric_backend_mutex_acquire_sec
+    ~help:"Seconds spent waiting to acquire the backend filesystem \
+           write mutex.  Labels: op." ();
+  register_histogram ~name:metric_backend_mutex_held_sec
+    ~help:"Seconds the backend filesystem mutex is held by one fiber, \
+           covering compress + atomic-rename / unlink syscalls. \
+           Labels: op." ();
   add metric_keeper_slot_yield_total
     "Total autonomous turn slot yields (successfully yielded and reacquired). \
      Labels: keeper."

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -158,6 +158,28 @@ val metric_board_persist_lock_held_sec : string
     or (c) leaving the path synchronous when held time is already
     sub-second. *)
 
+val metric_backend_mutex_acquire_sec : string
+(** Time spent waiting to acquire [Backend.FileSystem.t.mutex] before
+    a write/delete operation.  Labels: [op] in
+    {[set | delete | set_if_not_exists]}.
+
+    Combined with [metric_backend_mutex_held_sec] this distinguishes
+    keeper write contention (acquire high) from disk I/O stall (held
+    high) inside the storage layer.  Read paths ([get], [atomic_get])
+    run lock-free and are not measured.
+
+    Wired by [Backend.FileSystem.set_mutex_observers] from the main
+    library at startup so that [masc_backend] does not depend on
+    [Prometheus]. *)
+
+val metric_backend_mutex_held_sec : string
+(** Time spent inside the backend persist lock, from acquisition to
+    release.  Labels: [op] in {[set | delete | set_if_not_exists]}.
+
+    Captures the actual compress + atomic-rename / unlink syscall
+    latency per write call, used together with
+    [metric_backend_mutex_acquire_sec]. *)
+
 val metric_keeper_turn_queue_depth : string
 (** P-DASH-02: turn queue depth gauge.  Semaphore waiter count
     surfaced so operators can alert on queue pressure without log

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -165,8 +165,8 @@ val metric_backend_mutex_acquire_sec : string
 
     Combined with [metric_backend_mutex_held_sec] this distinguishes
     keeper write contention (acquire high) from disk I/O stall (held
-    high) inside the storage layer.  Read paths ([get], [atomic_get])
-    run lock-free and are not measured.
+    high) inside the storage layer. Read paths are not measured by
+    these histograms.
 
     Wired by [Backend.FileSystem.set_mutex_observers] from the main
     library at startup so that [masc_backend] does not depend on
@@ -174,11 +174,10 @@ val metric_backend_mutex_acquire_sec : string
 
 val metric_backend_mutex_held_sec : string
 (** Time spent inside the backend persist lock, from acquisition to
-    release.  Labels: [op] in {[set | delete | set_if_not_exists]}.
+    release. Labels: [op] in {[set | delete | set_if_not_exists]}.
 
-    Captures the actual compress + atomic-rename / unlink syscall
-    latency per write call, used together with
-    [metric_backend_mutex_acquire_sec]. *)
+    Captures time spent in the write critical section, used together
+    with [metric_backend_mutex_acquire_sec]. *)
 
 val metric_keeper_turn_queue_depth : string
 (** P-DASH-02: turn queue depth gauge.  Semaphore waiter count


### PR DESCRIPTION
## 목적

backend 저장소의 `t.mutex` write contention을 Prometheus histogram으로 export. 외부 진단(2026-05-06)이 "28초 지연 60% = 락"이라 추정했지만 실측 데이터 부재. 이 PR은 측정 인프라를 먼저 구축해 추정에서 실증으로 전환한다.

## 보고서 배경 (Kimi 시리즈)

| 파일 | 핵심 클레임 | 판정 |
|---|---|---|
| `masc_mcp_final_report.md` | `dir_lock` 전역 단일 락이 18 keeper를 직렬화 | 이름 stale, 실체 valid |
| `masc_mcp_revised_diagnosis.md` | 동일한 진단 (더 자세한 다이어그램) | 동일 |
| `masc-dashboard-websocket-analysis.md` | `/shell?light=true` 27.52s 측정값 | DevTools 실측 |
| `masc_mcp_concurrency_analysis.md` | 28s = 18× 락 대기 시간 + 파일 I/O | 추정, 근거 미확인 |

## 구현

`board_core.ml`의 #10569 진단 패턴(`with_persist_lock`)을 그대로 확장.

### 아키텍처: 의존성 역전

`masc_backend`(sub-lib)는 `Prometheus`(메인 lib)에 의존 불가. 따라서:

1. `backend.ml` — `ref` 기반 hook + `with_observed_mutex` helper (default no-op)
2. `coord_eio.ml`(`masc_mcp`) — startup 시 hook에 Prometheus histogram wiring

```
masc_backend               masc_mcp
backend.ml --------------
  with_observed_mutex      Prometheus.ml
      |                        |
      v                        v
  mutex hook  <-------   wiring at startup
```

### 신규 metric

| 이름 | type | labels | 의미 |
|---|---|---|---|
| `masc_backend_mutex_acquire_sec` | Histogram | `op={set,delete,set_if_not_exists}` | write lock 획득 대기 시간 |
| `masc_backend_mutex_held_sec` | Histogram | `op={set,delete,set_if_not_exists}` | critical section 내 compress + rename/unlink 시간 |

`get`과 `atomic_get`은 lock-free로 동작(읽기는 measure 안 함). `atomic_increment`/`atomic_update`는 별도 file-locking 메커니즘 사용(이 PR 범위 밖).

### 변경 파일

- `lib/backend/backend.ml` (+51/-3): hook ref, `with_observed_mutex`, 3 op site 변경
- `lib/backend/backend.mli` (+19): `set_mutex_observers` 시그니처
- `lib/prometheus.mli` (+22): `metric_backend_mutex_acquire_sec` / `metric_backend_mutex_held_sec` 상수 + 문서
- `lib/prometheus.ml` (+25): 상수 정의 + `register_histogram`
- `lib/coord/coord_eio.ml` (+11): startup wiring

### 안전성

- **default no-op**: hook ref 초기값은 아무것도 안 함. wiring 전이라도 모든 동작 동일
- **observer는 critical section 밖**: `with_observed_mutex`에서 Prometheus.observe_histogram은 `Eio.Mutex.use_rw` 종료 *후* 호출 → nested locking 불가
- **read 경로 영향 없음**: `get`은 여전히 mutex 안(이 PR는 measure 안 함). lock-free 전환은 PR #13836에서 처리
- **caller signature 변경 없음**: `set`/`delete`/`set_if_not_exists`의 시그니처 물결

### 향후

- 이 metric 기반으로 48시간치 추정: `acquire_sec` vs `held_sec` 비율이 `acquire >>> held` 이면 queueing(샤딩 효과 있음). `held >>> acquire` 이면 disk stall(샤딩이 의미 없음).
- PR #13836(`get` lock-free) 머지 후 `masc_dashboard_shell_latency_seconds`와 cross-correlation 가능

## Self-review checklist

- [x] 목표: backend write mutex contention 측정 인프라 추가
- [x] 변경 파일: 5개 (+125/-3)
- [x] 로컬 검증: type-check (`dune build @check`) 통과
- [x] 아키텍처: 의존성 역전으로 sub-lib 순환 의존 방지
- [x] 미검증: 실제 18 keeper 환경에서의 metric emission (production deploy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)