### PR TITLE
Fix keeper review required tool contract

### DIFF
--- a/docs/KEEPER-DOCKER-PR-LIFECYCLE-REPROBE.md
+++ b/docs/KEEPER-DOCKER-PR-LIFECYCLE-REPROBE.md
@@ -46,12 +46,13 @@ status records pending requests as lost; the other two log a transient
 notice and the next poll iteration retries.
 When mutation is enabled, the harness sends two sequential phases. The create phase
 requires `keeper_bash` and `keeper_pr_create`. After all create requests
-reach terminal status, the review phase requires `keeper_shell` and
-`keeper_pr_review_comment`. This avoids the old single-turn shape where one
-keeper could wait on another keeper's missing PR until the Agent.run timeout.
-The review prompt reserves `keeper_shell` for read-only GitHub inspection and
-instructs keepers to report `target_pr_missing` after one failed branch lookup
-instead of polling in a loop.
+reach terminal status, the review phase requires `keeper_pr_review_comment`.
+This avoids the old single-turn shape where one keeper could wait on another
+keeper's missing PR until the Agent.run timeout. The review prompt reserves
+`keeper_shell` for read-only GitHub inspection, but does not put it in
+`required_tools` because passive read-only tools cannot satisfy the runtime
+required-tool predicate. Keepers are instructed to report `target_pr_missing`
+after one failed branch lookup instead of polling in a loop.
 Keepers must create/use the exact run-scoped branch
 `keeper/<keeper>-docker-pr-proof-<run_id>` and proof file
 `docs/runtime-proof/keepers/<keeper>-<run_id>.md`; older proof branches or

--- a/scripts/harness/workload/keeper_docker_pr_lifecycle_reprobe.sh
+++ b/scripts/harness/workload/keeper_docker_pr_lifecycle_reprobe.sh
@@ -39,7 +39,7 @@ POLL_INTERVAL_SEC="${POLL_INTERVAL_SEC:-10}"
 LIFECYCLE_MUTATION_MODE="split"
 REQUIRED_TOOLS_LEGACY="${REQUIRED_TOOLS:-}"
 CREATE_REQUIRED_TOOLS="${CREATE_REQUIRED_TOOLS:-${REQUIRED_TOOLS_LEGACY:-keeper_bash,keeper_pr_create}}"
-REVIEW_REQUIRED_TOOLS="${REVIEW_REQUIRED_TOOLS:-${REQUIRED_TOOLS_LEGACY:-keeper_shell,keeper_pr_review_comment}}"
+REVIEW_REQUIRED_TOOLS="${REVIEW_REQUIRED_TOOLS:-${REQUIRED_TOOLS_LEGACY:-keeper_pr_review_comment}}"
 MCP_URL="${MCP_URL:-http://127.0.0.1:8935/mcp}"
 MCP_TOKEN="${MASC_MCP_TOKEN:-}"
 MCP_CLIENT_NAME="${MCP_CLIENT_NAME:-keeper-docker-pr-lifecycle-reprobe}"
@@ -898,7 +898,8 @@ Safety rules:
 
 This prompt is sent with review-phase masc_keeper_msg.required_tools so the
 runtime records tool_surface_mismatch or missing_required_tool_use when
-keeper_shell/keeper_pr_review_comment are not visible or not used.
+keeper_pr_review_comment is not visible or not used. keeper_shell is read-only
+inspection and intentionally not part of the required-tool contract.
 EOF
 }
 

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -1147,14 +1147,14 @@ let test_keeper_required_tool_contracts () =
           {|CREATE_REQUIRED_TOOLS="${CREATE_REQUIRED_TOOLS:-${REQUIRED_TOOLS_LEGACY:-keeper_bash,keeper_pr_create}}"|}
      && file_contains_pattern
           "scripts/harness/workload/keeper_docker_pr_lifecycle_reprobe.sh"
-          {|REVIEW_REQUIRED_TOOLS="${REVIEW_REQUIRED_TOOLS:-${REQUIRED_TOOLS_LEGACY:-keeper_shell,keeper_pr_review_comment}}"|});
+          {|REVIEW_REQUIRED_TOOLS="${REVIEW_REQUIRED_TOOLS:-${REQUIRED_TOOLS_LEGACY:-keeper_pr_review_comment}}"|});
   check bool "runbook documents docker PR lifecycle split phases" true
     (file_contains_pattern "docs/KEEPER-DOCKER-PR-LIFECYCLE-REPROBE.md"
        "The create phase"
      && file_contains_pattern "docs/KEEPER-DOCKER-PR-LIFECYCLE-REPROBE.md"
           "requires `keeper_bash` and `keeper_pr_create`"
      && file_contains_pattern "docs/KEEPER-DOCKER-PR-LIFECYCLE-REPROBE.md"
-          "the review phase requires `keeper_shell` and");
+          "the review phase requires `keeper_pr_review_comment`");
   check bool "docker PR lifecycle prompt accepts brokered route proof" true
     (file_contains_pattern
        "scripts/harness/workload/keeper_docker_pr_lifecycle_reprobe.sh"


### PR DESCRIPTION
## Summary

- remove read-only `keeper_shell` from the Docker lifecycle review phase `required_tools` default
- keep `keeper_shell` in the prompt as one-shot read-only PR lookup guidance
- document why only mutating `keeper_pr_review_comment` can satisfy the review required-tool contract
- update the source-contract test to match the runtime required-tool predicate

## Why This Matters

A live split-phase reprobe after #13842 showed the review phase can fail before approval with:

`tool 'keeper_shell' is read-only/passive and cannot satisfy a required-tool contract`

The review phase still needs a read-only GitHub lookup, but the runtime required-tool contract must be satisfied by the mutating approval evidence tool. This keeps the proof lane aligned with the required-tool predicate while preserving the no-loop `target_pr_missing` behavior.

This does not claim the 14-keeper lifecycle objective is complete.

## Verification

- `bash -n scripts/harness/workload/keeper_docker_pr_lifecycle_reprobe.sh scripts/harness_keeper_docker_pr_lifecycle_reprobe.sh`
- `git diff --check origin/main...HEAD`
- `env RUN_AUDIT=0 scripts/harness/workload/keeper_docker_pr_lifecycle_reprobe.sh --dry-run --keeper-names analyst,verifier --expected-keepers 14 --run-id dry-phase-smoke-0506f --run-dir /private/tmp/keeper-docker-pr-phase-smoke-f`
- `/private/tmp/keeper-docker-pr-phase-smoke-f/summary.json` records `review_required_tools: keeper_pr_review_comment`.

Focused Dune was not rerun because the shared opam/Dune lock is still occupied by other sessions; PR CI is the build gate for this narrow source-contract follow-up.