### PR TITLE
fix: emit keeper semaphore wait buckets

### DIFF
--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -661,7 +661,9 @@ let run_keepalive_unified_turn
             ~keeper_id:meta_after_triage.name
         in
         match
-          Keeper_turn_slot.with_keeper_turn_slot_control ~keeper_name:meta_after_triage.name
+          Keeper_turn_slot.with_keeper_turn_slot_control
+            ~cascade_profile:meta_after_triage.cascade_name
+            ~keeper_name:meta_after_triage.name
             ~channel:turn_decision.channel (fun ~semaphore_wait_ms ~slot_control ->
             match
               with_in_turn_liveness_pulse ~ctx ~meta:meta_after_cursor_persist ~stop

--- a/lib/keeper/keeper_keepalive.mli
+++ b/lib/keeper/keeper_keepalive.mli
@@ -227,6 +227,7 @@ type keeper_turn_slot_control = Keeper_turn_slot.keeper_turn_slot_control = {
 (** Test-only wrapper around the keeper turn slot acquisition path with
     explicit in-turn release/reacquire controls. *)
 val with_keeper_turn_slot_control_for_test :
+  ?cascade_profile:string ->
   keeper_name:string ->
   channel:Keeper_world_observation.keeper_cycle_channel ->
   (semaphore_wait_ms:int -> slot_control:keeper_turn_slot_control -> 'a) ->
@@ -234,6 +235,7 @@ val with_keeper_turn_slot_control_for_test :
 
 (** Test-only wrapper around the keeper turn slot acquisition path. *)
 val with_keeper_turn_slot_for_test :
+  ?cascade_profile:string ->
   keeper_name:string ->
   channel:Keeper_world_observation.keeper_cycle_channel ->
   (semaphore_wait_ms:int -> 'a) ->

--- a/lib/keeper/keeper_turn_slot.ml
+++ b/lib/keeper/keeper_turn_slot.ml
@@ -875,7 +875,36 @@ let rec wait_for_autonomous_queue_head ~(keeper_name : string) ~(ticket : int)
            Eio.Fiber.yield ());
       wait_for_autonomous_queue_head ~keeper_name ~ticket ~started_at)
 
-let with_keeper_turn_slot_control ~keeper_name ~channel f =
+let semaphore_wait_seconds_buckets =
+  [ 0.001; 0.005; 0.01; 0.025; 0.05; 0.1; 0.25; 0.5; 1.0; 2.5; 5.0; 10.0;
+    30.0; 60.0 ]
+
+let observe_semaphore_wait_seconds ~keeper_name ~cascade_profile ~channel seconds =
+  let seconds = if seconds < 0.0 then 0.0 else seconds in
+  let labels =
+    [ ("keeper_name", keeper_name);
+      ("cascade_profile", cascade_profile);
+      ("channel", channel) ]
+  in
+  Prometheus.observe_histogram
+    Prometheus.metric_keeper_semaphore_wait_seconds
+    ~labels
+    seconds;
+  let inc_bucket le =
+    Prometheus.inc_counter
+      Prometheus.metric_keeper_semaphore_wait_seconds_bucket
+      ~labels:(labels @ [ ("le", le) ])
+      ()
+  in
+  List.iter
+    (fun upper ->
+      if seconds <= upper then
+        inc_bucket (Printf.sprintf "%g" upper))
+    semaphore_wait_seconds_buckets;
+  inc_bucket "+Inf"
+
+let with_keeper_turn_slot_control ?(cascade_profile = "unknown") ~keeper_name
+    ~channel f =
   let is_autonomous =
     match channel with
     | Keeper_world_observation.Scheduled_autonomous -> true
@@ -1062,8 +1091,14 @@ let with_keeper_turn_slot_control ~keeper_name ~channel f =
               ~acquired_at:(Time_compat.now ())
           in
               slot_state.turn_acquisition_id := Some acquisition_id;
+              let semaphore_wait_sec = Time_compat.now () -. t0 in
+              observe_semaphore_wait_seconds ~keeper_name ~cascade_profile
+                ~channel:channel_label semaphore_wait_sec;
               let semaphore_wait_ms =
-                int_of_float ((Time_compat.now () -. t0) *. 1000.0) in
+                int_of_float
+                  ((if semaphore_wait_sec < 0.0 then 0.0 else semaphore_wait_sec)
+                   *. 1000.0)
+              in
               Ok semaphore_wait_ms
   in
   let slot_control =
@@ -1096,17 +1131,17 @@ let with_keeper_turn_slot_control ~keeper_name ~channel f =
           Ok (f ~semaphore_wait_ms ~slot_control))
 ;;
 
-let with_keeper_turn_slot ~keeper_name ~channel f =
-  with_keeper_turn_slot_control ~keeper_name ~channel
+let with_keeper_turn_slot ?cascade_profile ~keeper_name ~channel f =
+  with_keeper_turn_slot_control ?cascade_profile ~keeper_name ~channel
     (fun ~semaphore_wait_ms ~slot_control:_ -> f ~semaphore_wait_ms)
 ;;
 
-let with_keeper_turn_slot_control_for_test ~keeper_name ~channel f =
-  with_keeper_turn_slot_control ~keeper_name ~channel f
+let with_keeper_turn_slot_control_for_test ?cascade_profile ~keeper_name ~channel f =
+  with_keeper_turn_slot_control ?cascade_profile ~keeper_name ~channel f
 ;;
 
-let with_keeper_turn_slot_for_test ~keeper_name ~channel f =
-  with_keeper_turn_slot ~keeper_name ~channel f
+let with_keeper_turn_slot_for_test ?cascade_profile ~keeper_name ~channel f =
+  with_keeper_turn_slot ?cascade_profile ~keeper_name ~channel f
 ;;
 
 let wait_for_autonomous_queue_head_for_test ~keeper_name ~ticket ~started_at =

--- a/lib/keeper/keeper_turn_slot.mli
+++ b/lib/keeper/keeper_turn_slot.mli
@@ -182,12 +182,14 @@ type keeper_turn_slot_control = {
 }
 
 val with_keeper_turn_slot_control :
+  ?cascade_profile:string ->
   keeper_name:string ->
   channel:Keeper_world_observation.keeper_cycle_channel ->
   (semaphore_wait_ms:int -> slot_control:keeper_turn_slot_control -> 'a) ->
   ('a, [> `Semaphore_wait_timeout of semaphore_wait_timeout ]) result
 
 val with_keeper_turn_slot :
+  ?cascade_profile:string ->
   keeper_name:string ->
   channel:Keeper_world_observation.keeper_cycle_channel ->
   (semaphore_wait_ms:int -> 'a) ->
@@ -196,6 +198,7 @@ val with_keeper_turn_slot :
 (** Test-only wrapper around the keeper turn slot acquisition path with
     explicit in-turn release/reacquire controls. *)
 val with_keeper_turn_slot_control_for_test :
+  ?cascade_profile:string ->
   keeper_name:string ->
   channel:Keeper_world_observation.keeper_cycle_channel ->
   (semaphore_wait_ms:int -> slot_control:keeper_turn_slot_control -> 'a) ->
@@ -203,6 +206,7 @@ val with_keeper_turn_slot_control_for_test :
 
 (** Test-only wrapper around the keeper turn slot acquisition path. *)
 val with_keeper_turn_slot_for_test :
+  ?cascade_profile:string ->
   keeper_name:string ->
   channel:Keeper_world_observation.keeper_cycle_channel ->
   (semaphore_wait_ms:int -> 'a) ->

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -426,6 +426,15 @@ let metric_tool_join_required_guard =
 let metric_keeper_semaphore_wait_timeout =
   "masc_keeper_semaphore_wait_timeout_total"
 
+(* Goal-loop Observe contract: the Grafana p99 query consumes
+   [masc_keeper_semaphore_wait_seconds_bucket] grouped by keeper and cascade.
+   The generic [register_histogram] exporter currently exposes summaries, so
+   keeper_turn_slot emits the cumulative bucket companion explicitly. *)
+let metric_keeper_semaphore_wait_seconds =
+  "masc_keeper_semaphore_wait_seconds"
+let metric_keeper_semaphore_wait_seconds_bucket =
+  "masc_keeper_semaphore_wait_seconds_bucket"
+
 let metric_keeper_slot_yield_total =
   "masc_keeper_slot_yield_total"
 
@@ -1419,6 +1428,9 @@ let init () =
   add metric_keeper_turn_queue_depth
     "Current keeper turn wait queue depth (labels: channel=autonomous_queue)"
     Gauge;
+  register_histogram ~name:metric_keeper_semaphore_wait_seconds
+    ~help:"Seconds spent waiting to acquire keeper turn semaphores \
+           (labels: keeper_name, cascade_profile, channel)." ();
   (* P-DASH-13: provider block duration histogram.
      Records the duration (in seconds) for which a provider is placed in
      cooldown each time a cooldown is applied or extended.  Labels: provider. *)

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -180,6 +180,14 @@ val metric_keeper_semaphore_wait_timeout : string
     Labels: [keeper, channel] with channel in
     [autonomous_queue_head | autonomous | turn]. *)
 
+val metric_keeper_semaphore_wait_seconds : string
+(** Cumulative keeper turn-slot semaphore wait seconds. Labels:
+    [keeper_name, cascade_profile, channel]. *)
+
+val metric_keeper_semaphore_wait_seconds_bucket : string
+(** Cumulative bucket counter for keeper turn-slot semaphore wait seconds.
+    Labels: [keeper_name, cascade_profile, channel, le]. *)
+
 val metric_keeper_turn_queue_depth : string
 (** P-DASH-02: gauge for keeper turn wait queue depth.
     Labels: [channel] with [autonomous_queue] for the explicit autonomous

--- a/test/test_keeper_semaphore_wait_counter.ml
+++ b/test/test_keeper_semaphore_wait_counter.ml
@@ -24,6 +24,17 @@ let queue_depth_for ~channel =
     ~labels:[ ("channel", channel) ]
     ()
 
+let semaphore_wait_bucket_for ~keeper_name ~cascade_profile ~channel ~le =
+  Masc_mcp.Prometheus.metric_value_or_zero
+    Masc_mcp.Prometheus.metric_keeper_semaphore_wait_seconds_bucket
+    ~labels:[
+      ("keeper_name", keeper_name);
+      ("cascade_profile", cascade_profile);
+      ("channel", channel);
+      ("le", le);
+    ]
+    ()
+
 let make_meta name =
   match
     Masc_test_deps.meta_of_json_fixture
@@ -44,7 +55,15 @@ let test_metric_name_stable () =
   Alcotest.(check string)
     "turn queue depth canonical metric name"
     "masc_keeper_turn_queue_depth"
-    Masc_mcp.Prometheus.metric_keeper_turn_queue_depth
+    Masc_mcp.Prometheus.metric_keeper_turn_queue_depth;
+  Alcotest.(check string)
+    "semaphore wait seconds canonical metric name"
+    "masc_keeper_semaphore_wait_seconds"
+    Masc_mcp.Prometheus.metric_keeper_semaphore_wait_seconds;
+  Alcotest.(check string)
+    "semaphore wait seconds bucket canonical metric name"
+    "masc_keeper_semaphore_wait_seconds_bucket"
+    Masc_mcp.Prometheus.metric_keeper_semaphore_wait_seconds_bucket
 
 let test_autonomous_queue_depth_gauge_tracks_fifo () =
   Eio_main.run @@ fun _env ->
@@ -74,6 +93,39 @@ let test_autonomous_queue_depth_gauge_tracks_fifo () =
     "final drop records zero depth"
     0.0
     (queue_depth_for ~channel:"autonomous_queue")
+
+let test_successful_acquire_emits_wait_seconds_buckets () =
+  Eio_main.run @@ fun _env ->
+  let module KK = Masc_mcp.Keeper_keepalive in
+  let keeper_name = "wait-histogram-keeper-0506" in
+  let cascade_profile = "wait-histogram-cascade-0506" in
+  let channel = "scheduled_autonomous" in
+  KK.reset_autonomous_completion_for_test ();
+  KK.reset_autonomous_turn_queue_for_test ();
+  let before_inf =
+    semaphore_wait_bucket_for ~keeper_name ~cascade_profile ~channel ~le:"+Inf"
+  in
+  let before_60 =
+    semaphore_wait_bucket_for ~keeper_name ~cascade_profile ~channel ~le:"60"
+  in
+  (match
+     KK.with_keeper_turn_slot_for_test
+       ~cascade_profile
+       ~keeper_name
+       ~channel:Masc_mcp.Keeper_world_observation.Scheduled_autonomous
+       (fun ~semaphore_wait_ms:_ -> ())
+   with
+   | Ok () -> ()
+   | Error (`Semaphore_wait_timeout _) ->
+       Alcotest.fail "unexpected semaphore wait timeout");
+  Alcotest.(check (float 0.0001))
+    "+Inf bucket increments"
+    (before_inf +. 1.0)
+    (semaphore_wait_bucket_for ~keeper_name ~cascade_profile ~channel ~le:"+Inf");
+  Alcotest.(check (float 0.0001))
+    "60s bucket increments"
+    (before_60 +. 1.0)
+    (semaphore_wait_bucket_for ~keeper_name ~cascade_profile ~channel ~le:"60")
 
 let test_increments_per_channel () =
   let keeper = "sangsu-test-9771" in
@@ -235,6 +287,10 @@ let () =
     "queue_depth", [
       Alcotest.test_case "autonomous FIFO depth gauge tracks queue" `Quick
         test_autonomous_queue_depth_gauge_tracks_fifo;
+    ];
+    "histogram", [
+      Alcotest.test_case "successful acquire emits wait buckets" `Quick
+        test_successful_acquire_emits_wait_seconds_buckets;
     ];
     "counter", [
       Alcotest.test_case "all 3 channels increment" `Quick


### PR DESCRIPTION
## Summary
- Emit `masc_keeper_semaphore_wait_seconds` from successful keeper turn-slot acquisitions.
- Emit cumulative `masc_keeper_semaphore_wait_seconds_bucket` series with `keeper_name`, `cascade_profile`, `channel`, and `le` labels so the existing goal-loop Observe Grafana p99 query has runtime data.
- Thread the keeper cascade profile from the heartbeat loop into turn-slot acquisition, defaulting test-only callers to `unknown`.
- Add a regression that acquires a real test turn slot and asserts the bucket counters increment.

## Why
The goal-loop Observe contract and dashboard already query `masc_keeper_semaphore_wait_seconds_bucket`, but the turn-slot runtime only exposed timeout counters. That left p99 semaphore wait and starvation diagnosis blind for successful-but-slow acquisitions.

## Validation
- `git diff --check origin/main..HEAD`
- `env MASC_SKIP_OPAM_LOCK=1 DUNE_JOBS=1 DUNE_CACHE=disabled scripts/dune-local.sh build test/test_keeper_semaphore_wait_counter.exe`
- `./_build/default/test/test_keeper_semaphore_wait_counter.exe` (10 tests)

Note: after rebasing onto current `origin/main`, a repeat focused build was queued behind an unrelated long-running `/tmp/me-dune-local.lock` holder and was stopped to avoid blocking on another agent's Dune job. The pre-rebase focused build/test passed, and the rebase applied cleanly with diff-check clean.