### PR TITLE
feat(dashboard): add board karma ledger surface

### DIFF
--- a/dashboard/src/components/board/board-karma-panel.test.ts
+++ b/dashboard/src/components/board/board-karma-panel.test.ts
@@ -1,0 +1,84 @@
+import { h } from 'preact'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/preact'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import '@testing-library/jest-dom'
+import { BoardKarmaPanel } from './board-karma-panel'
+import { fetchBoardKarmaLedger } from '../../api/board'
+
+vi.mock('../../api/board', () => ({
+  fetchBoardKarmaLedger: vi.fn(),
+}))
+
+vi.mock('../../router', () => ({
+  navigate: vi.fn(),
+}))
+
+const fetchKarmaMock = vi.mocked(fetchBoardKarmaLedger)
+
+describe('BoardKarmaPanel', () => {
+  beforeEach(() => {
+    fetchKarmaMock.mockResolvedValue({
+      count: 2,
+      scoring_rule: 'upvote=+1',
+      totals: [
+        { agent: 'alice', karma: 3 },
+        { agent: 'bob', karma: 1 },
+      ],
+      events: [
+        {
+          recipient: 'alice',
+          voter: 'bob',
+          target_kind: 'post',
+          target_id: 'post-1',
+          delta: 1,
+          ts: 1_779_000_000,
+          ts_iso: '2026-05-17T06:40:00.000Z',
+        },
+      ],
+    })
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.clearAllMocks()
+  })
+
+  it('renders karma totals and ledger events', async () => {
+    render(h(BoardKarmaPanel, null))
+
+    expect(await screen.findByRole('heading', { name: 'Karma ledger' })).toBeInTheDocument()
+    expect(screen.getAllByText('alice').length).toBeGreaterThan(0)
+    expect(screen.getByText('3')).toBeInTheDocument()
+    expect(screen.getByText('post:post-1')).toBeInTheDocument()
+    expect(screen.getByText('upvote=+1')).toBeInTheDocument()
+    expect(fetchKarmaMock).toHaveBeenCalledWith({ agent: undefined, limit: 50 })
+  })
+
+  it('applies agent and limit filters', async () => {
+    render(h(BoardKarmaPanel, null))
+
+    await waitFor(() => expect(fetchKarmaMock).toHaveBeenCalledTimes(1))
+    fireEvent.input(screen.getByTestId('karma-agent-filter'), { target: { value: ' alice ' } })
+    fireEvent.change(screen.getByTestId('karma-event-limit'), { target: { value: '25' } })
+    fireEvent.submit(screen.getByTestId('karma-filter-form'))
+
+    await waitFor(() => expect(fetchKarmaMock).toHaveBeenLastCalledWith({
+      agent: 'alice',
+      limit: 25,
+    }))
+  })
+
+  it('renders an empty state when the ledger has no rows', async () => {
+    fetchKarmaMock.mockResolvedValueOnce({
+      count: 0,
+      scoring_rule: '',
+      totals: [],
+      events: [],
+    })
+
+    render(h(BoardKarmaPanel, null))
+
+    expect(await screen.findByText('No karma totals.')).toBeInTheDocument()
+    expect(screen.getByText('No karma events.')).toBeInTheDocument()
+  })
+})

--- a/dashboard/src/components/board/board-karma-panel.ts
+++ b/dashboard/src/components/board/board-karma-panel.ts
@@ -1,0 +1,186 @@
+import { html } from 'htm/preact'
+import { useCallback, useEffect, useState } from 'preact/hooks'
+import { ArrowLeft, RefreshCw, Trophy } from 'lucide-preact'
+import { fetchBoardKarmaLedger } from '../../api/board'
+import type { BoardKarmaLedger, BoardKarmaLedgerEvent } from '../../types'
+import { navigate } from '../../router'
+import { ActionButton } from '../common/button'
+import { EmptyState, ErrorState, LoadingState } from '../common/feedback-state'
+import { TextInput } from '../common/input'
+import { Select } from '../common/select'
+import { SurfaceCard } from '../common/card'
+import { TimeAgo } from '../common/time-ago'
+
+const LIMIT_OPTIONS = [
+  { value: '25', label: '25 events' },
+  { value: '50', label: '50 events' },
+  { value: '100', label: '100 events' },
+]
+
+function signedDelta(delta: number): string {
+  return delta > 0 ? `+${delta}` : String(delta)
+}
+
+function targetLabel(event: BoardKarmaLedgerEvent): string {
+  return `${event.target_kind}:${event.target_id}`
+}
+
+function emptyLedger(): BoardKarmaLedger {
+  return { events: [], count: 0, scoring_rule: '', totals: [] }
+}
+
+export function BoardKarmaPanel() {
+  const [ledger, setLedger] = useState<BoardKarmaLedger>(emptyLedger)
+  const [agentInput, setAgentInput] = useState('')
+  const [agentFilter, setAgentFilter] = useState('')
+  const [limit, setLimit] = useState(50)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  const load = useCallback(async () => {
+    setLoading(true)
+    setError(null)
+    try {
+      setLedger(await fetchBoardKarmaLedger({
+        agent: agentFilter || undefined,
+        limit,
+      }))
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load board karma ledger')
+    } finally {
+      setLoading(false)
+    }
+  }, [agentFilter, limit])
+
+  useEffect(() => {
+    void load()
+  }, [load])
+
+  const submitFilter = (event: Event) => {
+    event.preventDefault()
+    setAgentFilter(agentInput.trim())
+  }
+
+  return html`
+    <section class="grid gap-4" aria-labelledby="board-karma-heading">
+      <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div class="min-w-0">
+          <div class="flex items-center gap-2 text-2xs uppercase text-[var(--color-fg-muted)]">
+            <${Trophy} size=${13} aria-hidden="true" />
+            Board karma
+          </div>
+          <h2 id="board-karma-heading" class="mt-1 text-xl font-semibold text-[var(--color-fg-primary)]">Karma ledger</h2>
+        </div>
+        <div class="flex flex-wrap items-center gap-2">
+          <${ActionButton} variant="ghost" size="sm" onClick=${() => navigate('workspace', { section: 'board' })} ariaLabel="Back to board">
+            <span class="inline-flex items-center gap-1.5"><${ArrowLeft} size=${14} aria-hidden="true" />Board<//>
+          <//>
+          <${ActionButton} variant="ghost" size="sm" onClick=${() => { void load() }} disabled=${loading} ariaLabel="Refresh board karma">
+            <span class="inline-flex items-center gap-1.5"><${RefreshCw} size=${14} aria-hidden="true" />Refresh<//>
+          <//>
+        </div>
+      </div>
+
+      <form
+        class="flex flex-col gap-2 rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] p-3 sm:flex-row sm:items-end"
+        data-testid="karma-filter-form"
+        onSubmit=${submitFilter}
+      >
+        <label class="grid min-w-0 flex-1 gap-1 text-2xs font-medium uppercase text-[var(--color-fg-muted)]">
+          Agent
+          <${TextInput}
+            value=${agentInput}
+            placeholder="all agents"
+            ariaLabel="Karma agent filter"
+            testId="karma-agent-filter"
+            disabled=${loading}
+            onInput=${(event: Event) => setAgentInput((event.target as HTMLInputElement).value)}
+          />
+        </label>
+        <label class="grid gap-1 text-2xs font-medium uppercase text-[var(--color-fg-muted)]">
+          Limit
+          <${Select}
+            value=${String(limit)}
+            options=${LIMIT_OPTIONS}
+            ariaLabel="Karma event limit"
+            testId="karma-event-limit"
+            disabled=${loading}
+            class="!min-w-32"
+            onInput=${(value: string) => setLimit(Number.parseInt(value, 10))}
+          />
+        </label>
+        <${ActionButton}
+          type="submit"
+          variant="primary"
+          size="md"
+          disabled=${loading}
+          testId="karma-filter-apply"
+        >
+          Apply
+        <//>
+      </form>
+
+      ${error && ledger.events.length > 0 ? html`
+        <div class="rounded-[var(--r-1)] border border-[var(--color-status-err)]/40 bg-[var(--color-status-err)]/10 px-3 py-2 text-xs text-[var(--color-status-err)]" role="alert">${error}</div>
+      ` : null}
+      ${loading
+        ? html`<${LoadingState}>Loading board karma...<//>`
+        : error && ledger.events.length === 0
+          ? html`<${ErrorState} message=${error} />`
+          : html`
+            <div class="grid gap-3 lg:grid-cols-[0.8fr_1.2fr]">
+              <${SurfaceCard} variant="compact">
+                <div class="mb-3 flex items-center justify-between gap-2">
+                  <h3 class="text-xs font-semibold uppercase text-[var(--color-fg-muted)]">Totals</h3>
+                  <span class="font-mono text-2xs text-[var(--color-fg-muted)]">${ledger.totals.length} agents</span>
+                </div>
+                ${ledger.totals.length === 0
+                  ? html`<${EmptyState} message="No karma totals." compact />`
+                  : html`
+                    <div class="grid gap-2">
+                      ${ledger.totals.map((row, index) => html`
+                        <div key=${row.agent} class="flex items-center justify-between gap-3 rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] px-2.5 py-2">
+                          <div class="min-w-0">
+                            <div class="truncate text-sm font-medium text-[var(--color-fg-primary)]">${row.agent}</div>
+                            <div class="font-mono text-2xs text-[var(--color-fg-muted)]">#${index + 1}</div>
+                          </div>
+                          <div class="font-mono text-lg font-semibold tabular-nums text-[var(--color-fg-primary)]">${row.karma}</div>
+                        </div>
+                      `)}
+                    </div>
+                  `}
+              <//>
+
+              <${SurfaceCard} variant="compact">
+                <div class="mb-3 flex flex-wrap items-center justify-between gap-2">
+                  <h3 class="text-xs font-semibold uppercase text-[var(--color-fg-muted)]">Ledger events</h3>
+                  <div class="flex flex-wrap items-center gap-2 font-mono text-2xs text-[var(--color-fg-muted)]">
+                    <span>${ledger.count} events</span>
+                    ${ledger.scoring_rule ? html`<span>${ledger.scoring_rule}</span>` : null}
+                  </div>
+                </div>
+                ${ledger.events.length === 0
+                  ? html`<${EmptyState} message="No karma events." compact />`
+                  : html`
+                    <div class="grid gap-2">
+                      ${ledger.events.map((event, index) => html`
+                        <div key=${`${event.ts}:${event.recipient}:${event.voter}:${event.target_id}:${index}`} class="grid gap-1 border-b border-[var(--color-border-subtle)] pb-2 last:border-b-0 last:pb-0">
+                          <div class="flex flex-wrap items-center gap-2 text-xs">
+                            <span class="font-medium text-[var(--color-fg-primary)]">${event.recipient}</span>
+                            <span class="font-mono tabular-nums text-[var(--ok-bright)]">${signedDelta(event.delta)}</span>
+                            <span class="text-[var(--color-fg-muted)]">from ${event.voter}</span>
+                          </div>
+                          <div class="flex flex-wrap items-center gap-2 font-mono text-2xs text-[var(--color-fg-muted)]">
+                            <span>${targetLabel(event)}</span>
+                            <span><${TimeAgo} timestamp=${event.ts_iso} /></span>
+                          </div>
+                        </div>
+                      `)}
+                    </div>
+                  `}
+              <//>
+            </div>
+          `}
+    </section>
+  `
+}

--- a/dashboard/src/components/board/board-surface.test.ts
+++ b/dashboard/src/components/board/board-surface.test.ts
@@ -282,6 +282,26 @@ describe('BoardSurface Component', () => {
     expect(screen.queryByText('+ 새 글 작성')).not.toBeInTheDocument()
   })
 
+  it('routes the karma focus to the board karma surface', async () => {
+    route.value = { params: { focus: 'karma' } } as any
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({
+        events: [],
+        count: 0,
+        scoring_rule: '',
+        totals: [],
+      }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    ))
+
+    render(h(BoardSurface, null))
+
+    expect(await screen.findByRole('heading', { name: 'Karma ledger' })).toBeInTheDocument()
+    expect(screen.queryByText('+ 새 글 작성')).not.toBeInTheDocument()
+  })
+
   it('renders compact board latency metrics when samples exist', () => {
     boardPosts.value = [
       makePost({

--- a/dashboard/src/components/board/board-surface.ts
+++ b/dashboard/src/components/board/board-surface.ts
@@ -1,6 +1,6 @@
 import { html } from 'htm/preact'
 import { useEffect, useRef, useCallback, useMemo, useState } from 'preact/hooks'
-import { RefreshCw, Sparkles } from 'lucide-preact'
+import { RefreshCw, Sparkles, Trophy } from 'lucide-preact'
 import { ActionButton } from '../common/button'
 import { Card } from '../common/card'
 import { TimeAgo } from '../common/time-ago'
@@ -19,6 +19,7 @@ import { registerBoardHearthsRefresh } from '../../sse-store'
 import { boardLatencyMetrics, type BoardLatencyMetric } from '../../board-metrics'
 import { MessageRoomTimeline } from './message-room-timeline'
 import { BoardCurationPanel } from './board-curation-panel'
+import { BoardKarmaPanel } from './board-karma-panel'
 import { MentionInbox } from './mention-inbox'
 import { PostDetail } from './post-detail'
 import { ReactionBar } from './reaction-bar'
@@ -553,6 +554,18 @@ function BoardSummary() {
           큐레이션
         </span>
       <//>
+      <${ActionButton}
+        variant="ghost"
+        size="sm"
+        class="!px-2"
+        onClick=${() => navigate('workspace', { section: 'board', focus: 'karma' })}
+        ariaLabel="보드 카르마 열기"
+      >
+        <span class="inline-flex items-center gap-1">
+          <${Trophy} size=${12} aria-hidden="true" />
+          Karma
+        </span>
+      <//>
     </div>
   `
 }
@@ -798,6 +811,15 @@ export function BoardSurface() {
       <div>
         <${BoardSummary} />
         <${BoardCurationPanel} />
+      </div>
+    `
+  }
+
+  if (focus === 'karma') {
+    return html`
+      <div>
+        <${BoardSummary} />
+        <${BoardKarmaPanel} />
       </div>
     `
   }


### PR DESCRIPTION
## Summary

- Add a dashboard `focus=karma` board surface for the merged karma ledger API.
- Show agent totals, attributed ledger events, scoring rule metadata, event limits, and an agent filter.
- Add route coverage through `BoardSurface` and focused component tests for totals, events, filters, and empty states.

## Why

The board karma ledger backend/API is merged, but operators still need a dashboard surface to inspect the projection and audit attributed karma events without reading raw JSON.

## Validation

- `pnpm exec vitest run --config vitest.config.ts src/components/board/board-karma-panel.test.ts src/components/board/board-surface.test.ts --no-file-parallelism --maxWorkers=1`
- `pnpm exec tsc --noEmit --pretty`
- `pnpm exec eslint src/components/board/board-karma-panel.ts src/components/board/board-karma-panel.test.ts src/components/board/board-surface.ts src/components/board/board-surface.test.ts`
- `git diff --check`
