### PR TITLE
Align Docker lifecycle proof branch with worktree contract

### DIFF
--- a/docs/KEEPER-DOCKER-PR-LIFECYCLE-REPROBE.md
+++ b/docs/KEEPER-DOCKER-PR-LIFECYCLE-REPROBE.md
@@ -53,12 +53,15 @@ keeper's missing PR until the Agent.run timeout. The review prompt reserves
 `required_tools` because passive read-only tools cannot satisfy the runtime
 required-tool predicate. Keepers are instructed to report `target_pr_missing`
 after one failed branch lookup instead of polling in a loop.
-Keepers must create/use the exact run-scoped branch
-`keeper/<keeper>-docker-pr-proof-<run_id>` and proof file
+Keepers must create/use the exact run-scoped branch produced by
+`masc_worktree_create task_id=<run_id>`:
+`keeper-<keeper>-agent/<run_id>`. They must write the proof file
 `docs/runtime-proof/keepers/<keeper>-<run_id>.md`; older proof branches or
-worktrees do not count. Proof-file creation and git add/commit/push should use
-`keeper_bash` from inside the Docker playground so the route evidence is tied to
-the keeper container path. If the shell guard rejects the git mutation, the
+worktrees do not count. This branch convention matches the runtime worktree
+tool contract (`{agent_name}/{task_id}`) while still keeping stale evidence
+out via the run id. Proof-file creation and git add/commit/push should use
+`keeper_bash` from inside the Docker playground so the route evidence is tied
+to the keeper container path. If the shell guard rejects the git mutation, the
 keeper must stop and report that blocker instead of falling back to host-local
 credentials.
 PR create/review mutations should use `keeper_pr_create` /

--- a/scripts/harness/workload/keeper_docker_pr_lifecycle_reprobe.sh
+++ b/scripts/harness/workload/keeper_docker_pr_lifecycle_reprobe.sh
@@ -774,8 +774,15 @@ review_target_for_keeper() {
   ' "$REVIEW_TARGETS_FILE" | head -n 1
 }
 
+proof_branch_for_keeper() {
+  local keeper="$1"
+  printf 'keeper-%s-agent/%s' "$keeper" "$RUN_ID"
+}
+
 prompt_for_keeper_create() {
   local keeper="$1"
+  local branch
+  branch="$(proof_branch_for_keeper "$keeper")"
   cat <<EOF
 Docker PR lifecycle proof run: $RUN_ID
 Phase: create
@@ -796,21 +803,22 @@ Tool route rules:
 Required create lane:
 1. Confirm your runtime is sandbox_profile=docker before mutating.
 2. Create a unique proof worktree/branch for exactly this run id:
-   - branch: keeper/$keeper-docker-pr-proof-$RUN_ID
-   - preferred tool: masc_worktree_create
+   - branch: $branch
+   - preferred tool: masc_worktree_create with task_id=$RUN_ID
    - use the returned worktree path for every later keeper_bash git/file command.
+   - the returned branch must be $branch. If it is different, stop and report blocker="branch_mismatch".
    - Do not reuse any branch, worktree, or proof file from another run id.
    - Do not remove this run's worktree during the proof attempt. If Git says
      the branch/worktree already exists, stop and report blocker="branch_collision".
-3. Make a minimal, non-product proof edit under docs/runtime-proof/keepers/$keeper-$RUN_ID.md with keeper_bash from inside the Docker playground. The file content must include run_id=$RUN_ID and branch=keeper/$keeper-docker-pr-proof-$RUN_ID.
-4. Commit and git push exactly branch keeper/$keeper-docker-pr-proof-$RUN_ID with keeper_bash. The tool result must show explicit Docker-backed route evidence such as via=docker, route_via=docker, via=brokered, or route_via=brokered.
+3. Make a minimal, non-product proof edit under docs/runtime-proof/keepers/$keeper-$RUN_ID.md with keeper_bash from inside the Docker playground. The file content must include run_id=$RUN_ID and branch=$branch.
+4. Commit and git push exactly branch $branch with keeper_bash. The tool result must show explicit Docker-backed route evidence such as via=docker, route_via=docker, via=brokered, or route_via=brokered.
 5. Create a draft PR for that branch with keeper_pr_create. Do not mark ready, do not merge, do not add human-approved-ready.
 6. Reply with one compact JSON object:
    {
      "run_id": "$RUN_ID",
      "phase": "create",
      "keeper": "$keeper",
-     "branch": "keeper/$keeper-docker-pr-proof-$RUN_ID",
+     "branch": "$branch",
      "pr_url": "...",
      "docker_pr_create": true,
      "docker_git_push": true,
@@ -838,7 +846,7 @@ prompt_for_keeper_review() {
   local review_branch_json="null"
   local review_instruction=""
   if [[ -n "$review_target" ]]; then
-    review_branch="keeper/$review_target-docker-pr-proof-$RUN_ID"
+    review_branch="$(proof_branch_for_keeper "$review_target")"
     review_target_json="\"$review_target\""
     review_branch_json="\"$review_branch\""
     review_instruction="$(cat <<EOF

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -1160,6 +1160,13 @@ let test_keeper_required_tool_contracts () =
        "scripts/harness/workload/keeper_docker_pr_lifecycle_reprobe.sh"
        "via=docker, route_via=docker, via=brokered, or route_via=brokered")
   ;
+  check bool "docker PR lifecycle branch matches worktree tool contract" true
+    (file_contains_pattern
+       "scripts/harness/workload/keeper_docker_pr_lifecycle_reprobe.sh"
+       {|printf 'keeper-%s-agent/%s' "$keeper" "$RUN_ID"|}
+     && file_contains_pattern
+          "docs/KEEPER-DOCKER-PR-LIFECYCLE-REPROBE.md"
+          "`keeper-<keeper>-agent/<run_id>`");
   check bool "keeper msg schema documents required_tool_names alias" true
     (file_contains_pattern "lib/keeper/keeper_schema.ml"
        "required_tool_names")


### PR DESCRIPTION
## Summary

- align the Docker PR lifecycle reprobe proof branch with `masc_worktree_create`'s runtime branch contract
- render create-phase expected branches as `keeper-<keeper>-agent/<run_id>`
- render review target lookups against that same branch shape
- document that the run id, not an impossible custom branch prefix, is the stale-evidence boundary
- add source-contract coverage for the branch convention

## Why This Matters

A live `docker-pr-lifecycle-pair-0506i` create proof showed `verifier` could create, push, and open draft PR #13854 through the Docker route, but `masc_worktree_create` produced branch `keeper-verifier-agent/docker-pr-lifecycle-pair-0506i` while the harness prompt demanded `keeper/verifier-docker-pr-proof-docker-pr-lifecycle-pair-0506i`.

That mismatch makes successful keeper behavior look invalid and makes the review phase look for the wrong head branch. The harness should match the actual runtime worktree contract (`{agent_name}/{task_id}`) and use the run id to prevent stale evidence.

This does not claim the 14-keeper lifecycle objective is complete.

## Verification

- `bash -n scripts/harness/workload/keeper_docker_pr_lifecycle_reprobe.sh scripts/harness_keeper_docker_pr_lifecycle_reprobe.sh`
- `git diff --check origin/main...HEAD`
- `env RUN_AUDIT=0 scripts/harness/workload/keeper_docker_pr_lifecycle_reprobe.sh --dry-run --keeper-names analyst,verifier --expected-keepers 14 --run-id dry-phase-smoke-0506h --run-dir /private/tmp/keeper-docker-pr-phase-smoke-h`
- `/private/tmp/keeper-docker-pr-phase-smoke-h/prompts/analyst-create.txt` renders `branch: keeper-analyst-agent/dry-phase-smoke-0506h`
- `/private/tmp/keeper-docker-pr-phase-smoke-h/prompts/verifier-review.txt` looks up `keeper-analyst-agent/dry-phase-smoke-0506h`
- `python3 -m py_compile scripts/audit-keeper-fleet-readiness.py test/test_audit_keeper_fleet_readiness.py`

Focused Dune was not run because shared opam/Dune lock contention is still present; PR CI is the build gate for this narrow harness contract follow-up.