### PR TITLE
fix(dated-jsonl): switch append to Eio.Mutex.use_ro to keep no-poison contract

### DIFF
--- a/lib/dated_jsonl/dated_jsonl.ml
+++ b/lib/dated_jsonl/dated_jsonl.ml
@@ -202,9 +202,10 @@ let load_tail_lines path ~max_lines =
 
 let append t json =
   let mutex = Atomic.get t.mutex in
-  (* This exclusive lock serializes file appends without using ~protect:false,
-     so retry paths do not poison the shared mutex after IO failures. *)
-  Eio.Mutex.use_rw mutex (fun () ->
+  (* [use_ro] serializes file appends without poisoning the shared mutex on
+     IO failure, so retry paths can keep using the same registry entry.
+     [use_rw] would poison on any exception regardless of [~protect]. *)
+  Eio.Mutex.use_ro mutex (fun () ->
     let path = today_path t in
     Fs_compat.append_jsonl path json)
 


### PR DESCRIPTION
## Summary

PR #13843 머지 후 `dune build`가 `lib/dated_jsonl/dated_jsonl.ml` 의 `.ml`/`.mli` 시그니처 mismatch로 실패합니다.

```
File "lib/dated_jsonl/dated_jsonl.ml", line 1:
Error: The implementation lib/dated_jsonl/dated_jsonl.ml
       does not match the interface lib/dated_jsonl/dated_jsonl.mli:
       Values do not match:
         val append : t -> Yojson.Safe.t -> protect:bool -> unit
       is not included in
         val append : t -> Yojson.Safe.t -> unit
```

## Root cause

`Eio.Mutex.use_rw : ~protect:bool -> t -> (unit -> 'a) -> 'a` 의 `~protect`는 **required labelled arg** (optional `?`가 아님). PR #13843은 `~protect:false`를 떼어내면서 함수가 partially apply되어 `append`의 inferred type이 `t -> Yojson.Safe.t -> protect:bool -> unit`로 바뀌었습니다.

게다가 PR #13843이 commit message에 명시한 의도("retry paths do not poison the shared mutex after IO failures")는 `~protect` 라벨을 빼는 것으로는 달성되지 않습니다 — `use_rw`는 `~protect` 값과 무관하게 예외 발생 시 항상 mutex를 poison합니다 (eio_mutex.ml):

```ocaml
let use_rw ~protect t fn =
  lock t;
  match if protect then Cancel.protect fn else fn () with
  | x -> unlock t; x
  | exception ex -> poison t ex; raise ex   (* always poisons *)
```

`~protect`는 단지 fn이 `Cancel.protect` 아래서 실행될지 여부만 결정합니다.

예외 시 poison하지 않는 variant는 `use_ro`입니다:

```ocaml
let use_ro t fn =
  lock t;
  match fn () with
  | x -> unlock t; x
  | exception ex -> unlock t; raise ex   (* no poison *)
```

이름이 misleading하지만 — `use_ro` 도 mutex를 exclusive하게 acquire하고 concurrent caller를 serialize합니다. "ro"가 구분하는 건 access mode가 아니라 no-poison-on-exception contract입니다.

## Change

`Eio.Mutex.use_rw mutex (fun () -> ...)` → `Eio.Mutex.use_ro mutex (fun () -> ...)` + 정확한 주석.

## Test plan

- [x] `dune build` (exit 0)
- [x] `dune build @check` (exit 0)
- [x] `test_dated_jsonl_mutex_registry_10372` 6/6 PASS — 특히 PR #13843이 추가한 "append failure does not poison the shared mutex" 케이스가 직접 no-poison 동작을 검증
- [ ] CI green

## Why this is the correct fix (not a `~protect:true` revert)

`~protect:true`로 라벨만 채우는 minimal fix는 build를 통과시키지만:
1. PR #13843 commit message의 stated intent (no poisoning) 와 모순
2. `test_dated_jsonl_mutex_registry_10372` 의 "append failure does not poison" 케이스를 통과 못 시킴 — 이 PR 본인이 추가한 테스트인데 자기 fix로 깨지는 모양새

`use_ro` 는 위 두 조건을 동시에 만족합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)