### PR TITLE
docs(rfc): permit per-cascade turn_timeout_sec override (RFC-0012/0022)

### DIFF
--- a/docs/rfc/RFC-0012-mid-turn-progress-probe.md
+++ b/docs/rfc/RFC-0012-mid-turn-progress-probe.md
@@ -57,15 +57,18 @@ progress" from "hung turn that will never complete".
   resolved separately by per-cascade override (Step 2 of goal
   `oas-bridge-stabilization`). What remains rejected is **flat
   global reduction** that ignores the legitimate 27 B `900 s+`
-  floor (`keeper_stale_watchdog.ml:194-207`).
+  floor (`keeper_stale_watchdog.ml:405-418`).
 - **Permitted (per-cascade override, added 2026-05-06)**: a cascade
   profile in `config/cascade.toml` may declare its own
-  `turn_timeout_sec`. Remote tiers (`big_three`, `tier_small`,
-  `tier_medium`, `tier_fast`) run at 600 s; local tiers
-  (`local_recovery`, the local-leaning sub-profiles of
-  `keeper_diverse`) run at 900 s. The 1 800 s tier is gated behind a
-  follow-up RFC after one week of Prometheus data demonstrates a
-  900 s ceiling hit. Implementation: see
+  `turn_timeout_sec`. Checked-in remote/CLI profiles (`big_three`,
+  `keeper_diverse`, `tier_fast`, `tier_medium`) run at 600 s.
+  Explicit local-model profiles run at 900 s when operators configure
+  them (for example, an operator-populated `tier_small` or a
+  runtime-local recovery profile). This is not modeled as
+  sub-profiles of `keeper_diverse`; `keeper_diverse` is a single
+  checked-in profile. The 1 800 s tier is gated behind a follow-up
+  RFC after one week of Prometheus data demonstrates a 900 s ceiling
+  hit. Implementation: see
   `feature/cascade-tiered-turn-timeout`.
 - Changing OAS execution to use chunked reads. That is an OAS-level
   change; the user explicitly noted in

--- a/docs/rfc/RFC-0012-mid-turn-progress-probe.md
+++ b/docs/rfc/RFC-0012-mid-turn-progress-probe.md
@@ -57,18 +57,17 @@ progress" from "hung turn that will never complete".
   resolved separately by per-cascade override (Step 2 of goal
   `oas-bridge-stabilization`). What remains rejected is **flat
   global reduction** that ignores the legitimate 27 B `900 s+`
-  floor (`keeper_stale_watchdog.ml:405-418`).
+  floor (`lib/keeper/keeper_stale_watchdog.ml:405-418`).
 - **Permitted (per-cascade override, added 2026-05-06)**: a cascade
   profile in `config/cascade.toml` may declare its own
   `turn_timeout_sec`. Checked-in remote/CLI profiles (`big_three`,
   `keeper_diverse`, `tier_fast`, `tier_medium`) run at 600 s.
-  Explicit local-model profiles run at 900 s when operators configure
-  them (for example, an operator-populated `tier_small` or a
-  runtime-local recovery profile). This is not modeled as
-  sub-profiles of `keeper_diverse`; `keeper_diverse` is a single
-  checked-in profile. The 1 800 s tier is gated behind a follow-up
-  RFC after one week of Prometheus data demonstrates a 900 s ceiling
-  hit. Implementation: see
+  Operator-populated local-model profiles run at 900 s when they
+  declare local providers (for example, `tier_small` with its Ollama
+  entries enabled). `keeper_diverse` remains a single checked-in
+  profile, not a family of implicit local variants. The 1 800 s tier
+  is gated behind a follow-up RFC after one week of Prometheus data
+  demonstrates a 900 s ceiling hit. Implementation: see
   `feature/cascade-tiered-turn-timeout`.
 - Changing OAS execution to use chunked reads. That is an OAS-level
   change; the user explicitly noted in

--- a/docs/rfc/RFC-0012-mid-turn-progress-probe.md
+++ b/docs/rfc/RFC-0012-mid-turn-progress-probe.md
@@ -26,8 +26,9 @@ The keeper stale-watchdog has three stale-detection paths
 `active_turn_timeout_sec` is `max(turn_timeout_sec, threshold)`.
 Historically, this RFC assumed the design default was
 `Keeper_runtime_resolved.turn_timeout_sec () = 3600 s`; the current
-runtime default is 600 s because `keeper_runtime_resolved.ml:73-79`
-clamps the env-driven value to `[60, 600]`.
+runtime default is 600 s because
+`lib/keeper/keeper_runtime_resolved.ml:73-79` clamps the
+env-driven value to `[60, 600]`.
 `consecutive_noop_count` is updated only at turn end.
 
 Consequence: a turn that hangs in the middle — for example, an
@@ -55,12 +56,12 @@ progress" from "hung turn that will never complete".
 - Flat global lowering of `turn_timeout_sec` to a single value
   below the per-cascade design floor. Note the historical drift:
   this RFC was authored assuming `turn_timeout_sec () = 3600 s`,
-  but `keeper_runtime_resolved.ml:73-79` currently clamps the
-  env-driven value to `[60, 600]`. The desync is a code regression
-  resolved separately by per-cascade override (Step 2 of goal
-  `oas-bridge-stabilization`). What remains rejected is **flat
-  global reduction** that ignores the legitimate 27 B `900 s+`
-  floor (`lib/keeper/keeper_stale_watchdog.ml:405-418`).
+  but `lib/keeper/keeper_runtime_resolved.ml:73-79` currently
+  clamps the env-driven value to `[60, 600]`. The desync is a code
+  regression resolved separately by per-cascade override (Step 2 of
+  goal `oas-bridge-stabilization`). What remains rejected is
+  **flat global reduction** that ignores the legitimate 27 B
+  `900 s+` floor (`lib/keeper/keeper_stale_watchdog.ml:405-418`).
 - **Permitted (per-cascade override, added 2026-05-06)**: a cascade
   profile in `config/cascade.toml` may declare its own
   `turn_timeout_sec`. Checked-in remote/CLI profiles (`big_three`,

--- a/docs/rfc/RFC-0012-mid-turn-progress-probe.md
+++ b/docs/rfc/RFC-0012-mid-turn-progress-probe.md
@@ -49,9 +49,24 @@ progress" from "hung turn that will never complete".
 
 ## Out of scope
 
-- Lowering `turn_timeout_sec`. It was deliberately raised to 3600 s
-  because local 27 B models legitimately take 900 s+ per turn
-  (`keeper_stale_watchdog.ml:194-207`).
+- Flat global lowering of `turn_timeout_sec` to a single value
+  below the per-cascade design floor. Note the historical drift:
+  this RFC was authored assuming `turn_timeout_sec () = 3600 s`,
+  but `keeper_runtime_resolved.ml:73-79` currently clamps the
+  env-driven value to `[60, 600]`. The desync is a code regression
+  resolved separately by per-cascade override (Step 2 of goal
+  `oas-bridge-stabilization`). What remains rejected is **flat
+  global reduction** that ignores the legitimate 27 B `900 s+`
+  floor (`keeper_stale_watchdog.ml:194-207`).
+- **Permitted (per-cascade override, added 2026-05-06)**: a cascade
+  profile in `config/cascade.toml` may declare its own
+  `turn_timeout_sec`. Remote tiers (`big_three`, `tier_small`,
+  `tier_medium`, `tier_fast`) run at 600 s; local tiers
+  (`local_recovery`, the local-leaning sub-profiles of
+  `keeper_diverse`) run at 900 s. The 1 800 s tier is gated behind a
+  follow-up RFC after one week of Prometheus data demonstrates a
+  900 s ceiling hit. Implementation: see
+  `feature/cascade-tiered-turn-timeout`.
 - Changing OAS execution to use chunked reads. That is an OAS-level
   change; the user explicitly noted in
   `feedback_oas_execution_uncancellable_mid_turn` that

--- a/docs/rfc/RFC-0012-mid-turn-progress-probe.md
+++ b/docs/rfc/RFC-0012-mid-turn-progress-probe.md
@@ -23,8 +23,11 @@ The keeper stale-watchdog has three stale-detection paths
    when a turn is running.
 3. `failure_loop` — `consecutive_noop_count >= noop_threshold`.
 
-`active_turn_timeout_sec` is `max(turn_timeout_sec, threshold)` and
-defaults to `Keeper_runtime_resolved.turn_timeout_sec () = 3600 s`.
+`active_turn_timeout_sec` is `max(turn_timeout_sec, threshold)`.
+Historically, this RFC assumed the design default was
+`Keeper_runtime_resolved.turn_timeout_sec () = 3600 s`; the current
+runtime default is 600 s because `keeper_runtime_resolved.ml:73-79`
+clamps the env-driven value to `[60, 600]`.
 `consecutive_noop_count` is updated only at turn end.
 
 Consequence: a turn that hangs in the middle — for example, an

--- a/docs/rfc/RFC-0022-cascade-attempt-liveness.md
+++ b/docs/rfc/RFC-0022-cascade-attempt-liveness.md
@@ -429,7 +429,22 @@ Phase C (default `enforce` everywhere):
 
 ## 10. Out of scope
 
-- Lowering `MASC_KEEPER_TURN_TIMEOUT_SEC` below 3600. RFC-0012 §Out-of-scope already explains why turn-cap reduction is rejected (legitimate 27B 900s+ turns).
+- Flat global lowering of `MASC_KEEPER_TURN_TIMEOUT_SEC` to a single
+  value below the per-cascade design floor. RFC-0012 §Out of scope
+  explains why a global reduction is rejected (legitimate 27 B
+  `900 s+` turns). Note that the env clamp in
+  `keeper_runtime_resolved.ml:73-79` currently caps the env value at
+  600 s — that is a code regression versus the original 3 600 s
+  design and is resolved separately by per-cascade override (Step 2
+  of goal `oas-bridge-stabilization`).
+- **Permitted (per-cascade override, added 2026-05-06)**: a cascade
+  profile in `config/cascade.toml` may set its own
+  `turn_timeout_sec`. Remote tiers run at 600 s; local tiers run at
+  900 s. Promotion to 1 800 s requires a follow-up RFC backed by
+  one week of `masc_keeper_turns_total{terminated_by="turn_timeout"}`
+  + p95 turn-duration data. The budget invariant
+  `turn_timeout - oas_guard >= admission_wait + min_useful_run`
+  remains a hard regression test (root cause of #10388).
 - Provider-side cost metrics (covered by RFC-0009 Phase 3).
 - Wholesale replacement of OAS HTTP single-bulk-read with chunked. That is `feedback_oas_execution_uncancellable_mid_turn` ("masc-mcp 단독 fix 영역 zero").
 - Per-keeper liveness override (deferred — start with per-profile).

--- a/docs/rfc/RFC-0022-cascade-attempt-liveness.md
+++ b/docs/rfc/RFC-0022-cascade-attempt-liveness.md
@@ -441,14 +441,22 @@ Phase C (default `enforce` everywhere):
   profile in `config/cascade.toml` may set its own
   `turn_timeout_sec`. Checked-in remote/CLI profiles (`big_three`,
   `keeper_diverse`, `tier_fast`, `tier_medium`) run at 600 s.
-  Operator-populated local-model profiles run at 900 s when they
-  declare local providers (for example, `tier_small` with its Ollama
-  entries enabled). Promotion to 1 800 s requires a follow-up RFC
+  Operator-populated local-model profiles (not the checked-in
+  `[local_recovery]` fallback profile) run at 900 s when they declare
+  local providers (for example, `tier_small` with its Ollama entries
+  enabled). Promotion to 1 800 s requires a follow-up RFC
   backed by one week of
   `masc_cascade_attempt_liveness_kill_total{mode="observe",kind="wall_exceeded"}`
   + p95 turn-duration data. The budget invariant
   `turn_timeout - oas_guard >= admission_wait + min_useful_run`
-  remains a hard regression test (root cause of #10388).
+  remains a hard regression test (root cause of #10388), with terms
+  mapped as follows: `turn_timeout` is the resolved cascade
+  `turn_timeout_sec` (or `MASC_KEEPER_TURN_TIMEOUT_SEC` fallback);
+  `oas_guard` is `Keeper_turn_cascade_budget.oas_timeout_guard_sec`;
+  `admission_wait` is
+  `Keeper_runtime_resolved.admission_wait_timeout_sec`
+  / `MASC_KEEPER_ADMISSION_WAIT_TIMEOUT_SEC`; `min_useful_run` is the
+  RFC/test minimum useful post-admission provider run window.
 - Provider-side cost metrics (covered by RFC-0009 Phase 3).
 - Wholesale replacement of OAS HTTP single-bulk-read with chunked. That is `feedback_oas_execution_uncancellable_mid_turn` ("masc-mcp 단독 fix 영역 zero").
 - Per-keeper liveness override (deferred — start with per-profile).

--- a/docs/rfc/RFC-0022-cascade-attempt-liveness.md
+++ b/docs/rfc/RFC-0022-cascade-attempt-liveness.md
@@ -433,10 +433,10 @@ Phase C (default `enforce` everywhere):
   value below the per-cascade design floor. RFC-0012 §Out of scope
   explains why a global reduction is rejected (legitimate 27 B
   `900 s+` turns). Note that the env clamp in
-  `keeper_runtime_resolved.ml:73-79` currently caps the env value at
-  600 s — that is a code regression versus the original 3 600 s
-  design and is resolved separately by per-cascade override (Step 2
-  of goal `oas-bridge-stabilization`).
+  `lib/keeper/keeper_runtime_resolved.ml:73-79` currently caps the
+  env value at 600 s — that is a code regression versus the original
+  3 600 s design and is resolved separately by per-cascade override
+  (Step 2 of goal `oas-bridge-stabilization`).
 - **Permitted (per-cascade override, added 2026-05-06)**: a cascade
   profile in `config/cascade.toml` may set its own
   `turn_timeout_sec`. Checked-in remote/CLI profiles (`big_three`,
@@ -454,7 +454,7 @@ Phase C (default `enforce` everywhere):
   `turn_timeout_sec` (or `MASC_KEEPER_TURN_TIMEOUT_SEC` fallback);
   `oas_guard` is `Keeper_turn_cascade_budget.oas_timeout_guard_sec`;
   `admission_wait` is
-  `Keeper_runtime_resolved.admission_wait_timeout_sec`
+  `Keeper_runtime_resolved.admission_wait_timeout_sec ()`
   / `MASC_KEEPER_ADMISSION_WAIT_TIMEOUT_SEC`; `min_useful_run` is the
   RFC/test minimum useful post-admission provider run window.
 - Provider-side cost metrics (covered by RFC-0009 Phase 3).

--- a/docs/rfc/RFC-0022-cascade-attempt-liveness.md
+++ b/docs/rfc/RFC-0022-cascade-attempt-liveness.md
@@ -441,10 +441,10 @@ Phase C (default `enforce` everywhere):
   profile in `config/cascade.toml` may set its own
   `turn_timeout_sec`. Checked-in remote/CLI profiles (`big_three`,
   `keeper_diverse`, `tier_fast`, `tier_medium`) run at 600 s.
-  Explicit local-model profiles run at 900 s when operators configure
-  them (for example, an operator-populated `tier_small` or a
-  runtime-local recovery profile). Promotion to 1 800 s requires a
-  follow-up RFC backed by one week of
+  Operator-populated local-model profiles run at 900 s when they
+  declare local providers (for example, `tier_small` with its Ollama
+  entries enabled). Promotion to 1 800 s requires a follow-up RFC
+  backed by one week of
   `masc_cascade_attempt_liveness_kill_total{mode="observe",kind="wall_exceeded"}`
   + p95 turn-duration data. The budget invariant
   `turn_timeout - oas_guard >= admission_wait + min_useful_run`

--- a/docs/rfc/RFC-0022-cascade-attempt-liveness.md
+++ b/docs/rfc/RFC-0022-cascade-attempt-liveness.md
@@ -439,9 +439,13 @@ Phase C (default `enforce` everywhere):
   of goal `oas-bridge-stabilization`).
 - **Permitted (per-cascade override, added 2026-05-06)**: a cascade
   profile in `config/cascade.toml` may set its own
-  `turn_timeout_sec`. Remote tiers run at 600 s; local tiers run at
-  900 s. Promotion to 1 800 s requires a follow-up RFC backed by
-  one week of `masc_keeper_turns_total{terminated_by="turn_timeout"}`
+  `turn_timeout_sec`. Checked-in remote/CLI profiles (`big_three`,
+  `keeper_diverse`, `tier_fast`, `tier_medium`) run at 600 s.
+  Explicit local-model profiles run at 900 s when operators configure
+  them (for example, an operator-populated `tier_small` or a
+  runtime-local recovery profile). Promotion to 1 800 s requires a
+  follow-up RFC backed by one week of
+  `masc_cascade_attempt_liveness_kill_total{mode="observe",kind="wall_exceeded"}`
   + p95 turn-duration data. The budget invariant
   `turn_timeout - oas_guard >= admission_wait + min_useful_run`
   remains a hard regression test (root cause of #10388).


### PR DESCRIPTION
## Summary

`docs/rfc/RFC-0012` §Out of scope and `docs/rfc/RFC-0022` §10 are updated to permit a per-cascade `turn_timeout_sec` override, resolving a documented vs. implemented divergence and unblocking the Step 2 code change in goal `oas-bridge-stabilization`.

## Why this change

- **RFC ↔ code desync**: RFC-0012 was authored assuming `turn_timeout_sec () = 3600 s`, but `keeper_runtime_resolved.ml:73-79` currently clamps the env-driven value to `[60, 600]`. The RFC text and the runtime no longer match.
- **27 B local-LLM workload still real**: `keeper_stale_watchdog.ml:194-207` continues to reference legitimate 900 s+ turns. A flat global reduction is still the wrong answer — but a per-cascade override is the right answer.
- **Step 2 unblock**: `feature/cascade-tiered-turn-timeout` (Step 2) needs an RFC blessing to land the per-tier `turn_timeout_sec` field in `config/cascade.toml` without contradicting RFC-0012/0022.

## What changes

- `RFC-0012-mid-turn-progress-probe.md` §Out of scope: rewritten to (1) acknowledge the 3600 → 600 clamp regression, (2) permit per-cascade override at the documented tiers (remote = 600 s, local = 900 s), (3) gate the 1 800 s tier behind a follow-up RFC with Prometheus evidence.
- `RFC-0022-cascade-attempt-liveness.md` §10: same per-cascade override allowance, plus an explicit reaffirmation of the #10388 budget invariant `turn_timeout - oas_guard >= admission_wait + min_useful_run` as a hard regression test for the Step 2 implementation.

## Out of scope

- No code change in this PR. The clamp lift, `cascade.toml` schema field, and budget-invariant test land in `feature/cascade-tiered-turn-timeout` (separate PR).
- No promotion to 1 800 s. That requires one week of Prometheus data after Step 2 merges.

## Refs

- Goal: `oas-bridge-stabilization`
- Plan: `~/me/planning/claude-plans/20m-me-workspace-yousleepwhen-masc-mcp-o-recursive-mountain.md`
- Cited RFCs: RFC-0012 (mid-turn progress probe), RFC-0022 (cascade attempt liveness), #10388 (budget drift incident)

## Test plan

- [ ] `git diff origin/main...HEAD docs/rfc/` reviewed manually for tone/scope.
- [ ] No code files modified — `git diff --stat` shows only two `docs/rfc/*.md`.
- [ ] Step 2 PR (`feature/cascade-tiered-turn-timeout`) cites this RFC PR's commit hash before push.