### PR TITLE
Docker PR lifecycle pair proof — analyst keeper 0506j

### DIFF
--- a/docs/runtime-proof/keepers/analyst-docker-pr-lifecycle-pair-0506j.md
+++ b/docs/runtime-proof/keepers/analyst-docker-pr-lifecycle-pair-0506j.md
@@ -1,0 +1,9 @@
+# Docker PR Lifecycle Pair Proof — analyst keeper
+
+- run_id: docker-pr-lifecycle-pair-0506j
+- phase: create
+- keeper: analyst
+- branch: keeper-analyst-agent/docker-pr-lifecycle-pair-0506j
+- sandbox_profile: docker
+- timestamp: 2026-05-06T14:06Z
+- purpose: Non-product proof edit for Docker-backed PR lifecycle create-phase validation


### PR DESCRIPTION
## Docker PR Lifecycle Pair Proof — analyst keeper

- **run_id**: docker-pr-lifecycle-pair-0506j
- **phase**: create
- **keeper**: analyst
- **branch**: keeper-analyst-agent/docker-pr-lifecycle-pair-0506j
- **sandbox_profile**: docker
- **purpose**: Non-product proof edit for Docker-backed PR lifecycle create-phase validation
- **safety**: draft only, no merge, no ready label