### PR TITLE
fix: emit dashboard observe metrics

### DIFF
--- a/lib/dashboard/dashboard_execution.ml
+++ b/lib/dashboard/dashboard_execution.ml
@@ -113,9 +113,52 @@ let observe_render_phase phase ms =
     ~labels:[("phase", phase)]
     (render_phase_seconds ms)
 
+let dashboard_snapshot_latency_seconds_buckets =
+  [ 0.05; 0.1; 0.25; 0.5; 1.0; 2.5; 5.0; 10.0; 30.0; 60.0 ]
+
+let observe_dashboard_snapshot_latency ms =
+  let seconds = render_phase_seconds ms in
+  Prometheus.observe_histogram
+    Prometheus.metric_dashboard_snapshot_latency_seconds
+    seconds;
+  let inc_bucket le =
+    Prometheus.inc_counter
+      Prometheus.metric_dashboard_snapshot_latency_seconds_bucket
+      ~labels:[("le", le)]
+      ()
+  in
+  List.iter
+    (fun upper ->
+      if seconds <= upper then
+        inc_bucket (Printf.sprintf "%g" upper))
+    dashboard_snapshot_latency_seconds_buckets;
+  inc_bucket "+Inf"
+
+let dashboard_all_zero_labels = [("keeper_name", "__dashboard__")]
+
+let render_sub_operation_timings_all_zero (t : render_phase_timings_ms) =
+  t.n_keepers > 0
+  && t.snapshot_ms <= 0.0
+  && t.operations_ms <= 0.0
+  && t.enrich_ms <= 0.0
+  && t.data_load_ms <= 0.0
+  && t.assemble_ms <= 0.0
+
+let record_dashboard_all_zero_metric t =
+  let value =
+    if render_sub_operation_timings_all_zero t then 1.0 else 0.0
+  in
+  Prometheus.set_gauge
+    Prometheus.metric_dashboard_metric_all_zeros
+    ~labels:dashboard_all_zero_labels
+    value
+
 let record_render_phase_timings (t : render_phase_timings_ms) =
+  record_dashboard_all_zero_metric t;
   observe_render_phase "total" t.total_ms;
   observe_render_phase "snapshot" t.snapshot_ms;
+  if t.snapshot_ms > 0.0 then
+    observe_dashboard_snapshot_latency t.snapshot_ms;
   observe_render_phase "operations" t.operations_ms;
   observe_render_phase "enrich" t.enrich_ms;
   (* Idle renders (n_keepers = 0) would otherwise inject a fake 0s sample

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -839,6 +839,12 @@ let metric_ws_bytes_cache_hits = "masc_ws_bytes_cache_hits_total"
 let metric_ws_bytes_cache_misses = "masc_ws_bytes_cache_misses_total"
 let metric_dashboard_execution_render_phase_sec =
   "masc_dashboard_execution_render_phase_seconds"
+let metric_dashboard_snapshot_latency_seconds =
+  "masc_dashboard_snapshot_latency_seconds"
+let metric_dashboard_snapshot_latency_seconds_bucket =
+  "masc_dashboard_snapshot_latency_seconds_bucket"
+let metric_dashboard_metric_all_zeros =
+  "masc_dashboard_metric_all_zeros"
 (* PR-0.2.A (RFC 2026-04-masc-ide-strategy): generic cache hit/miss
    counters, labelled by [cache] = "eio" | "dashboard".  Distinct from
    the WS-specific parse/bytes cache counters above; these track the
@@ -2465,6 +2471,16 @@ let init () =
     ~help:
       "Dashboard execution render phase latency in seconds. Labels: \
        phase=total|snapshot|operations|enrich|enrich_per_keeper|data_load|assemble."
+    ();
+  register_histogram ~name:metric_dashboard_snapshot_latency_seconds
+    ~help:"Dashboard snapshot phase latency in seconds." ();
+  register_gauge ~name:metric_dashboard_metric_all_zeros
+    ~help:
+      "Dashboard render sub-operation timing all-zero diagnostic. 1 means \
+       snapshot/operations/enrich/data_load/assemble were all zero for a \
+       non-empty render. Labels: keeper_name, with keeper_name=__dashboard__ \
+       for this render-level singleton."
+    ~labels:[("keeper_name", "__dashboard__")]
     ();
   (* PR-0.2.A: generic cache hit/miss counters.  Labels: cache=eio|dashboard.
      [eio] tracks Cache_eio.get; [dashboard] tracks Dashboard_cache.get_or_compute.

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -913,6 +913,18 @@ val metric_ws_bytes_cache_misses : string
     enrichment cost from unrelated snapshot or assembly latency. *)
 val metric_dashboard_execution_render_phase_sec : string
 
+val metric_dashboard_snapshot_latency_seconds : string
+(** Dashboard snapshot phase latency in seconds. *)
+
+val metric_dashboard_snapshot_latency_seconds_bucket : string
+(** Cumulative bucket counter for dashboard snapshot phase latency.
+    Labels: [le]. *)
+
+val metric_dashboard_metric_all_zeros : string
+(** Dashboard render sub-operation timing all-zero diagnostic.
+    Labels: [keeper_name], using [__dashboard__] for the render-level
+    singleton required by the Observe dashboard contract. *)
+
 (** PR-0.2.A (RFC 2026-04-masc-ide-strategy): cache lookup hit/miss
     counters. Labels: [cache] with values
     - ["eio"]      — [Cache_eio.get] (filesystem-backed key/value cache).

--- a/test/test_dashboard_render_timing_9766.ml
+++ b/test/test_dashboard_render_timing_9766.ml
@@ -64,6 +64,18 @@ let phase_count phase =
     ~labels:[("phase", phase)]
     ()
 
+let snapshot_latency_bucket le =
+  Prom.metric_value_or_zero
+    Prom.metric_dashboard_snapshot_latency_seconds_bucket
+    ~labels:[("le", le)]
+    ()
+
+let dashboard_all_zero_value () =
+  Prom.metric_value_or_zero
+    Prom.metric_dashboard_metric_all_zeros
+    ~labels:[("keeper_name", "__dashboard__")]
+    ()
+
 let test_record_timings_observes_prometheus () =
   let phases = [
     "total"; "snapshot"; "operations"; "enrich";
@@ -72,10 +84,15 @@ let test_record_timings_observes_prometheus () =
   let snapshot_before =
     List.map (fun p -> p, phase_sum p, phase_count p) phases
   in
+  let snapshot_bucket_5_before = snapshot_latency_bucket "5" in
+  let snapshot_bucket_inf_before = snapshot_latency_bucket "+Inf" in
   let per_keeper_sum_before = phase_sum "enrich_per_keeper" in
   let per_keeper_count_before = phase_count "enrich_per_keeper" in
   let t = sample_timings () in
   DE.record_render_phase_timings t;
+  check (float 1e-9) "normal render clears all-zero diagnostic"
+    0.0
+    (dashboard_all_zero_value ());
   let expected_increment = function
     | "total" -> t.total_ms /. 1000.0
     | "snapshot" -> t.snapshot_ms /. 1000.0
@@ -96,6 +113,12 @@ let test_record_timings_observes_prometheus () =
       (count_before +. 1.0)
       (phase_count phase)
   ) snapshot_before;
+  check (float 1e-6) "dashboard snapshot latency 5s bucket +1"
+    (snapshot_bucket_5_before +. 1.0)
+    (snapshot_latency_bucket "5");
+  check (float 1e-6) "dashboard snapshot latency +Inf bucket +1"
+    (snapshot_bucket_inf_before +. 1.0)
+    (snapshot_latency_bucket "+Inf");
   (* enrich_per_keeper is observed once per keeper (n_keepers=9) so that
      Prometheus [sum / count] gives the actual average per-keeper enrich
      time weighted by fleet size, instead of averaging render-level
@@ -123,6 +146,26 @@ let test_record_timings_skips_per_keeper_when_idle () =
     (total_count_before +. 1.0)
     (phase_count "total")
 
+let test_record_timings_flags_all_zero_suboperations () =
+  let all_zero : DE.render_phase_timings_ms = {
+    total_ms = 1200.0;
+    snapshot_ms = 0.0;
+    operations_ms = 0.0;
+    enrich_ms = 0.0;
+    data_load_ms = 0.0;
+    assemble_ms = 0.0;
+    n_keepers = 3;
+  } in
+  DE.record_render_phase_timings all_zero;
+  check (float 1e-9) "non-empty all-zero render raises diagnostic"
+    1.0
+    (dashboard_all_zero_value ());
+  let idle = { all_zero with n_keepers = 0 } in
+  DE.record_render_phase_timings idle;
+  check (float 1e-9) "idle all-zero render clears diagnostic"
+    0.0
+    (dashboard_all_zero_value ())
+
 let () =
   run "dashboard_render_timing_9766" [
     ("phase_timing", [
@@ -138,5 +181,7 @@ let () =
           test_record_timings_observes_prometheus;
         test_case "idle render skips enrich_per_keeper observation" `Quick
           test_record_timings_skips_per_keeper_when_idle;
+        test_case "record timings flags all-zero sub-operation metrics" `Quick
+          test_record_timings_flags_all_zero_suboperations;
       ]);
   ]


### PR DESCRIPTION
## Summary
- Add `masc_dashboard_snapshot_latency_seconds` and `masc_dashboard_snapshot_latency_seconds_bucket` metric constants.
- Emit cumulative dashboard snapshot latency buckets from the existing dashboard render timing path, while skipping fake `0ms` snapshot fallback samples.
- Add the contracted `masc_dashboard_metric_all_zeros` diagnostic gauge with `keeper_name="__dashboard__"` for render-level bridge health.
- Extend `test_dashboard_render_timing_9766` to assert snapshot bucket increments and all-zero diagnostic set/clear behavior.

## Why
The goal-loop Observe contract, alert rules, and Grafana dashboard already query both dashboard snapshot latency buckets and the all-zero metric bridge diagnostic. Runtime only emitted the generic dashboard render phase summary metric, so those Observe dashboard signals could be absent even when the render timing code had the source data.

## Operator impact
Operators can now alert on dashboard snapshot p99 from a real bucket series and distinguish a disconnected/all-zero dashboard timing bridge from a merely idle dashboard render. The all-zero gauge only flips to `1` for non-empty renders where every sub-operation timing is zero, avoiding fresh-room false positives.

## Validation
- `git diff --check`
- `env MASC_SKIP_OPAM_LOCK=1 DUNE_JOBS=1 DUNE_CACHE=disabled scripts/dune-local.sh build test/test_dashboard_render_timing_9766.exe`
- `./_build/default/test/test_dashboard_render_timing_9766.exe` (7 tests)