### PR TITLE
fix(oas): reject invalid kimi tool arguments

### DIFF
--- a/lib/oas_worker_exec_transport.ml
+++ b/lib/oas_worker_exec_transport.ml
@@ -854,9 +854,10 @@ module Kimi_cli_transport_local = struct
     !args
 
   let json_of_argument_string = function
-    | None | Some "" -> `Assoc []
+    | None | Some "" -> Ok (`Assoc [])
     | Some raw -> (
-        try Yojson.Safe.from_string raw with Yojson.Json_error _ -> `Assoc [])
+        try Ok (Yojson.Safe.from_string raw) with
+        | Yojson.Json_error msg -> Error msg)
 
   let blocks_of_message_content json =
     match json with
@@ -873,11 +874,26 @@ module Kimi_cli_transport_local = struct
       let fn = json |> member "function" in
       let id = Llm_provider.Cli_common_json.member_str "id" json in
       let name = Llm_provider.Cli_common_json.member_str "name" fn in
-      let args =
+      match
         fn |> member "arguments" |> to_string_option |> json_of_argument_string
-      in
-      Some (Agent_sdk.Types.ToolUse { id; name; input = args })
-    with Type_error _ -> None
+      with
+      | Ok args -> Ok (Some (Agent_sdk.Types.ToolUse { id; name; input = args }))
+      | Error msg ->
+          Error
+            (Printf.sprintf
+               "invalid kimi tool arguments JSON for tool %S: %s" name msg)
+    with Type_error _ -> Ok None
+
+  let tool_uses_of_json calls =
+    let rec loop acc = function
+      | [] -> Ok (List.rev acc)
+      | call :: rest -> (
+          match tool_use_of_json call with
+          | Ok (Some block) -> loop (block :: acc) rest
+          | Ok None -> loop acc rest
+          | Error _ as err -> err)
+    in
+    loop [] calls
 
   let tool_result_of_json json =
     let open Yojson.Safe.Util in
@@ -905,18 +921,18 @@ module Kimi_cli_transport_local = struct
       match json |> member "role" |> to_string_option with
       | Some "assistant" ->
           let content = blocks_of_message_content (json |> member "content") in
-          let tool_uses =
+          let tool_uses_result =
             match json |> member "tool_calls" with
-            | `List calls -> List.filter_map tool_use_of_json calls
-            | _ -> []
+            | `List calls -> tool_uses_of_json calls
+            | _ -> Ok []
           in
-          content @ tool_uses
+          Result.map (fun tool_uses -> content @ tool_uses) tool_uses_result
       | Some "tool" -> (
           match tool_result_of_json json with
-          | Some block -> [ block ]
-          | None -> [])
-      | _ -> []
-    with Yojson.Json_error _ | Type_error _ -> []
+          | Some block -> Ok [ block ]
+          | None -> Ok [])
+      | _ -> Ok []
+    with Yojson.Json_error _ | Type_error _ -> Ok []
 
   let response_id_of_lines lines =
     let open Yojson.Safe.Util in
@@ -946,12 +962,26 @@ module Kimi_cli_transport_local = struct
     List.find_map find_model lines |> Option.value ~default:model_id
 
   let parse_jsonl_result ~model_id lines =
-    let content = List.concat_map blocks_of_output_line lines in
-    if content = [] then
+    let content_result =
+      let rec loop acc = function
+        | [] -> Ok (List.concat (List.rev acc))
+        | line :: rest -> (
+            match blocks_of_output_line line with
+            | Ok blocks -> loop (blocks :: acc) rest
+            | Error _ as err -> err)
+      in
+      loop [] lines
+    in
+    match content_result with
+    | Error message ->
+        Error
+          (Llm_provider.Http_client.NetworkError
+             { message; kind = Unknown })
+    | Ok [] ->
       Error
         (Llm_provider.Http_client.NetworkError
            { message = "no messages parsed from kimi output"; kind = Unknown })
-    else
+    | Ok content ->
       Ok
         {
           Agent_sdk.Types.id = response_id_of_lines lines;
@@ -1279,6 +1309,7 @@ module Kimi_cli_transport_local = struct
           let seen_lines = ref [] in
           let next_index = ref 0 in
           let started = ref false in
+          let parse_error = ref None in
           let ensure_started () =
             if not !started then (
               started := true;
@@ -1289,11 +1320,13 @@ module Kimi_cli_transport_local = struct
           let on_line line =
             if String.trim line <> "" then (
               seen_lines := line :: !seen_lines;
-              let blocks = blocks_of_output_line line in
-              if blocks <> [] then (
-                ensure_started ();
-                next_index :=
-                  emit_blocks ~on_event ~start_index:!next_index blocks))
+              match blocks_of_output_line line with
+              | Error message -> parse_error := Some message
+              | Ok blocks ->
+                  if blocks <> [] then (
+                    ensure_started ();
+                    next_index :=
+                      emit_blocks ~on_event ~start_index:!next_index blocks))
           in
           match
             classify_cli_error
@@ -1305,18 +1338,27 @@ module Kimi_cli_transport_local = struct
           with
           | Error _ as err -> err
           | Ok _ -> (
-              match parse_jsonl_result ~model_id (List.rev !seen_lines) with
-              | Error _ as err -> err
-              | Ok resp as ok ->
-                  if !started then (
-                    on_event
-                      (Agent_sdk.Types.MessageDelta
-                         { stop_reason = Some resp.stop_reason; usage = resp.usage });
-                    on_event Agent_sdk.Types.MessageStop)
-                  else
-                    Llm_provider.Cli_common_synthetic_events.replay ~on_event
-                      resp;
-                  ok));
+              match !parse_error with
+              | Some message ->
+                  Error
+                    (Llm_provider.Http_client.NetworkError
+                       { message; kind = Unknown })
+              | None -> (
+                  match parse_jsonl_result ~model_id (List.rev !seen_lines) with
+                  | Error _ as err -> err
+                  | Ok resp as ok ->
+                      if !started then (
+                        on_event
+                          (Agent_sdk.Types.MessageDelta
+                             {
+                               stop_reason = Some resp.stop_reason;
+                               usage = resp.usage;
+                             });
+                        on_event Agent_sdk.Types.MessageStop)
+                      else
+                        Llm_provider.Cli_common_synthetic_events.replay ~on_event
+                          resp;
+                      ok)));
     }
 end
 

--- a/lib/oas_worker_exec_transport.ml
+++ b/lib/oas_worker_exec_transport.ml
@@ -856,8 +856,11 @@ module Kimi_cli_transport_local = struct
   let json_of_argument_string = function
     | None | Some "" -> Ok (`Assoc [])
     | Some raw -> (
-        try Ok (Yojson.Safe.from_string raw) with
-        | Yojson.Json_error msg -> Error msg)
+        let raw = String.trim raw in
+        if raw = "" then Ok (`Assoc [])
+        else
+          try Ok (Yojson.Safe.from_string raw) with
+          | Yojson.Json_error msg -> Error msg)
 
   let blocks_of_message_content json =
     match json with
@@ -1318,15 +1321,19 @@ module Kimi_cli_transport_local = struct
                    { id = "kimi-print"; model = model_id; usage = None }))
           in
           let on_line line =
-            if String.trim line <> "" then (
-              seen_lines := line :: !seen_lines;
-              match blocks_of_output_line line with
-              | Error message -> parse_error := Some message
-              | Ok blocks ->
-                  if blocks <> [] then (
-                    ensure_started ();
-                    next_index :=
-                      emit_blocks ~on_event ~start_index:!next_index blocks))
+            match !parse_error with
+            | Some _ -> ()
+            | None ->
+                if String.trim line <> "" then (
+                  seen_lines := line :: !seen_lines;
+                  match blocks_of_output_line line with
+                  | Error message -> parse_error := Some message
+                  | Ok blocks ->
+                      if blocks <> [] then (
+                        ensure_started ();
+                        next_index :=
+                          emit_blocks ~on_event ~start_index:!next_index
+                            blocks))
           in
           match
             classify_cli_error

--- a/test/test_oas_worker.ml
+++ b/test/test_oas_worker.ml
@@ -3463,6 +3463,75 @@ let test_kimi_cli_config_uses_oas_context_ssot () =
       Alcotest.(check int) "max_context_size from OAS capabilities SSOT"
         expected actual
 
+let test_kimi_cli_rejects_invalid_tool_argument_json () =
+  let dir = temp_dir "kimi_cli_bad_tool_args" in
+  let fake_kimi_path = Filename.concat dir "fake-kimi" in
+  let invalid_tool_line =
+    Yojson.Safe.to_string
+      (`Assoc
+        [
+          ("role", `String "assistant");
+          ( "tool_calls",
+            `List
+              [
+                `Assoc
+                  [
+                    ("id", `String "call-1");
+                    ( "function",
+                      `Assoc
+                        [
+                          ("name", `String "bad_tool");
+                          ("arguments", `String "{\"unterminated\"");
+                        ] );
+                  ];
+              ] );
+        ])
+  in
+  let oc = open_out fake_kimi_path in
+  output_string oc ("#!/bin/sh\ncat <<'JSON'\n" ^ invalid_tool_line ^ "\nJSON\n");
+  close_out oc;
+  Unix.chmod fake_kimi_path 0o755;
+  let config =
+    {
+      Oas_worker_exec.Kimi_cli_transport_local.default_config with
+      kimi_path = fake_kimi_path;
+    }
+  in
+  let req =
+    {
+      (mock_completion_request ()) with
+      config = make_kimi_cli_provider_cfg ();
+      messages =
+        [
+          {
+            Agent_sdk.Types.role = Agent_sdk.Types.User;
+            content = [ Agent_sdk.Types.Text "hello" ];
+            name = None;
+            tool_call_id = None;
+            metadata = [];
+          };
+        ];
+    }
+  in
+  Eio.Switch.run @@ fun sw ->
+  let transport =
+    Oas_worker_exec.Kimi_cli_transport_local.create ~sw
+      ~mgr:(require_test_proc_mgr ()) ~config
+  in
+  let { Llm_provider.Llm_transport.response; latency_ms = _ } =
+    transport.complete_sync req
+  in
+  match response with
+  | Error (Llm_provider.Http_client.NetworkError { message; kind }) ->
+      Alcotest.(check bool) "network kind is unknown" true
+        (kind = Llm_provider.Http_client.Unknown);
+      Alcotest.(check bool) "invalid arguments rejected" true
+        (contains_substring ~needle:"invalid kimi tool arguments JSON" message);
+      Alcotest.(check bool) "tool name included" true
+        (contains_substring ~needle:"bad_tool" message)
+  | Error _ -> Alcotest.fail "expected NetworkError for invalid tool arguments"
+  | Ok _ -> Alcotest.fail "expected invalid tool arguments to fail parsing"
+
 let test_kimi_cli_should_log_stderr_line_filters_resume_noise () =
   let should_log =
     Oas_worker_exec.Kimi_cli_transport_local.should_log_stderr_line
@@ -5354,6 +5423,8 @@ let () =
         test_kimi_cli_model_for_provider_keeps_explicit_model;
       Alcotest.test_case "kimi config max context uses OAS SSOT" `Quick
         test_kimi_cli_config_uses_oas_context_ssot;
+      Alcotest.test_case "kimi invalid tool argument JSON is rejected" `Quick
+        test_kimi_cli_rejects_invalid_tool_argument_json;
       Alcotest.test_case "kimi stderr resume noise is filtered" `Quick
         test_kimi_cli_should_log_stderr_line_filters_resume_noise;
       Alcotest.test_case "kimi error completion measures latency" `Quick

--- a/test/test_oas_worker.ml
+++ b/test/test_oas_worker.ml
@@ -3532,6 +3532,171 @@ let test_kimi_cli_rejects_invalid_tool_argument_json () =
   | Error _ -> Alcotest.fail "expected NetworkError for invalid tool arguments"
   | Ok _ -> Alcotest.fail "expected invalid tool arguments to fail parsing"
 
+let test_kimi_cli_treats_whitespace_tool_arguments_as_empty_json () =
+  let dir = temp_dir "kimi_cli_whitespace_tool_args" in
+  let fake_kimi_path = Filename.concat dir "fake-kimi" in
+  let whitespace_tool_line =
+    Yojson.Safe.to_string
+      (`Assoc
+        [
+          ("role", `String "assistant");
+          ( "tool_calls",
+            `List
+              [
+                `Assoc
+                  [
+                    ("id", `String "call-empty");
+                    ( "function",
+                      `Assoc
+                        [
+                          ("name", `String "empty_tool");
+                          ("arguments", `String "  \n\t  ");
+                        ] );
+                  ];
+              ] );
+        ])
+  in
+  write_executable_file fake_kimi_path
+    ("#!/bin/sh\ncat <<'JSON'\n" ^ whitespace_tool_line ^ "\nJSON\n");
+  let config =
+    {
+      Oas_worker_exec.Kimi_cli_transport_local.default_config with
+      kimi_path = fake_kimi_path;
+    }
+  in
+  let req =
+    {
+      (mock_completion_request ()) with
+      config = make_kimi_cli_provider_cfg ();
+      messages =
+        [
+          {
+            Agent_sdk.Types.role = Agent_sdk.Types.User;
+            content = [ Agent_sdk.Types.Text "hello" ];
+            name = None;
+            tool_call_id = None;
+            metadata = [];
+          };
+        ];
+    }
+  in
+  Eio.Switch.run @@ fun sw ->
+  let transport =
+    Oas_worker_exec.Kimi_cli_transport_local.create ~sw
+      ~mgr:(require_test_proc_mgr ()) ~config
+  in
+  let { Llm_provider.Llm_transport.response; latency_ms = _ } =
+    transport.complete_sync req
+  in
+  match response with
+  | Ok
+      {
+        Agent_sdk.Types.content =
+          [ Agent_sdk.Types.ToolUse { name; input; _ } ];
+        _;
+      } ->
+      Alcotest.(check string) "tool name" "empty_tool" name;
+      Alcotest.(check string) "whitespace args become empty object" "{}"
+        (Yojson.Safe.to_string input)
+  | Ok _ -> Alcotest.fail "expected one tool use"
+  | Error _ -> Alcotest.fail "expected whitespace arguments to parse as {}"
+
+let test_kimi_cli_stream_rejects_invalid_tool_argument_json () =
+  let dir = temp_dir "kimi_cli_stream_bad_tool_args" in
+  let fake_kimi_path = Filename.concat dir "fake-kimi" in
+  let assistant_text text =
+    Yojson.Safe.to_string
+      (`Assoc [ ("role", `String "assistant"); ("content", `String text) ])
+  in
+  let invalid_tool_line =
+    Yojson.Safe.to_string
+      (`Assoc
+        [
+          ("role", `String "assistant");
+          ( "tool_calls",
+            `List
+              [
+                `Assoc
+                  [
+                    ("id", `String "call-1");
+                    ( "function",
+                      `Assoc
+                        [
+                          ("name", `String "bad_tool");
+                          ("arguments", `String "{\"unterminated\"");
+                        ] );
+                  ];
+              ] );
+        ])
+  in
+  write_executable_file fake_kimi_path
+    (String.concat "\n"
+       [
+         "#!/bin/sh";
+         "cat <<'JSON'";
+         assistant_text "before";
+         invalid_tool_line;
+         assistant_text "after";
+         "JSON";
+       ]
+    ^ "\n");
+  let config =
+    {
+      Oas_worker_exec.Kimi_cli_transport_local.default_config with
+      kimi_path = fake_kimi_path;
+    }
+  in
+  let req =
+    {
+      (mock_completion_request ()) with
+      config = make_kimi_cli_provider_cfg ();
+      messages =
+        [
+          {
+            Agent_sdk.Types.role = Agent_sdk.Types.User;
+            content = [ Agent_sdk.Types.Text "hello" ];
+            name = None;
+            tool_call_id = None;
+            metadata = [];
+          };
+        ];
+    }
+  in
+  Eio.Switch.run @@ fun sw ->
+  let transport =
+    Oas_worker_exec.Kimi_cli_transport_local.create ~sw
+      ~mgr:(require_test_proc_mgr ()) ~config
+  in
+  let events = ref [] in
+  let response =
+    transport.complete_stream
+      ~on_event:(fun event -> events := event :: !events)
+      req
+  in
+  let text_deltas =
+    List.filter_map
+      (function
+        | Agent_sdk.Types.ContentBlockDelta
+            { delta = Agent_sdk.Types.TextDelta text; _ } ->
+            Some text
+        | _ -> None)
+      (List.rev !events)
+  in
+  Alcotest.(check bool) "pre-error text emitted" true
+    (List.mem "before" text_deltas);
+  Alcotest.(check bool) "post-error text suppressed" false
+    (List.mem "after" text_deltas);
+  match response with
+  | Error (Llm_provider.Http_client.NetworkError { message; kind }) ->
+      Alcotest.(check bool) "network kind is unknown" true
+        (kind = Llm_provider.Http_client.Unknown);
+      Alcotest.(check bool) "invalid arguments rejected" true
+        (contains_substring ~needle:"invalid kimi tool arguments JSON" message);
+      Alcotest.(check bool) "tool name included" true
+        (contains_substring ~needle:"bad_tool" message)
+  | Error _ -> Alcotest.fail "expected NetworkError for invalid tool arguments"
+  | Ok _ -> Alcotest.fail "expected invalid tool arguments to fail streaming"
+
 let test_kimi_cli_should_log_stderr_line_filters_resume_noise () =
   let should_log =
     Oas_worker_exec.Kimi_cli_transport_local.should_log_stderr_line
@@ -5425,6 +5590,10 @@ let () =
         test_kimi_cli_config_uses_oas_context_ssot;
       Alcotest.test_case "kimi invalid tool argument JSON is rejected" `Quick
         test_kimi_cli_rejects_invalid_tool_argument_json;
+      Alcotest.test_case "kimi whitespace tool arguments become empty JSON" `Quick
+        test_kimi_cli_treats_whitespace_tool_arguments_as_empty_json;
+      Alcotest.test_case "kimi stream invalid tool argument JSON is rejected" `Quick
+        test_kimi_cli_stream_rejects_invalid_tool_argument_json;
       Alcotest.test_case "kimi stderr resume noise is filtered" `Quick
         test_kimi_cli_should_log_stderr_line_filters_resume_noise;
       Alcotest.test_case "kimi error completion measures latency" `Quick


### PR DESCRIPTION
## Summary

- stop converting malformed Kimi CLI `function.arguments` JSON into an empty `{}` input
- propagate invalid tool-argument JSON as a transport `NetworkError` parse failure in both sync and stream parsing paths
- add a focused regression test using a fake Kimi executable that emits a tool call with malformed argument JSON

## Why

The old parser made a malformed provider tool-call payload look like a real tool call with empty input. That loses the original failure and can drive keepers down an incorrect execution path. Missing or empty arguments still map to `{}`; only explicitly malformed JSON is rejected.

## Validation

- `git diff --check origin/main..HEAD` after final rebase
- `ocamlformat --check lib/oas_worker_exec_transport.ml test/test_oas_worker.ml` (repo-baseline nonzero/no-output behavior)
- `scripts/dune-local.sh build test/test_oas_worker.exe` passed before final rebase
- `./_build/default/test/test_oas_worker.exe test resume_config 64` passed before final rebase

Note: after the final rebase, a repeat focused build was queued behind several shared `dune-local.sh` jobs for multiple minutes and was stopped to avoid keeping another lock waiter alive; this PR is draft and GitHub checks are the fresh verification surface.