### PR TITLE
Harden Docker lifecycle reprobe gating

### DIFF
--- a/docs/KEEPER-DOCKER-PR-LIFECYCLE-REPROBE.md
+++ b/docs/KEEPER-DOCKER-PR-LIFECYCLE-REPROBE.md
@@ -45,8 +45,17 @@ but lacked `build.commit`, also treated as transient). Only the first
 status records pending requests as lost; the other two log a transient
 notice and the next poll iteration retries.
 When mutation is enabled, the harness sends two sequential phases. The create phase
-requires `keeper_bash` and `keeper_pr_create`. After all create requests
-reach terminal status, the review phase requires `keeper_pr_review_comment`.
+requires `keeper_bash` and `keeper_pr_create`. Before it sends any mutation
+prompt, the harness checks the run-scoped proof branches and fails closed with
+`branch_collision_preflight` if a local branch, remote-tracking branch, remote
+head, or local worktree already exists for the selected `--run-id`. After the
+create phase, the review phase only starts when every keeper produced create
+success markers for the same run id: `docker_pr_create=true`,
+`docker_git_push=true`, `blocker=null`, the exact branch, and a PR URL. If a
+keeper returns an error or blocker, the harness writes
+`create-readiness-failures.jsonl` and skips review prompts instead of approving
+stale or partially-created PRs. The review phase requires
+`keeper_pr_review_comment`.
 This avoids the old single-turn shape where one keeper could wait on another
 keeper's missing PR until the Agent.run timeout. The review prompt reserves
 `keeper_shell` for read-only GitHub inspection, but does not put it in

--- a/docs/KEEPER-DOCKER-PR-LIFECYCLE-REPROBE.md
+++ b/docs/KEEPER-DOCKER-PR-LIFECYCLE-REPROBE.md
@@ -61,7 +61,9 @@ the offending branch ref(s) so operators can clean up stale local/remote
 branches before re-running. An empty file means no collisions; rows look like:
 ```json
 {"keeper":"executor","branch":"keeper-executor-agent/<run_id>",
- "kinds":["local","remote_tracking"]}
+ "local_branch":true,"remote_tracking_branch":true,
+ "remote_head":false,"worktree_branch":false,
+ "blocker":"branch_collision_preflight"}
 ```
 After collision evidence is clear, the review phase requires `keeper_pr_review_comment`.
 This avoids the old single-turn shape where one keeper could wait on another

--- a/docs/KEEPER-DOCKER-PR-LIFECYCLE-REPROBE.md
+++ b/docs/KEEPER-DOCKER-PR-LIFECYCLE-REPROBE.md
@@ -54,7 +54,15 @@ success markers for the same run id: `docker_pr_create=true`,
 `docker_git_push=true`, `blocker=null`, the exact branch, and a PR URL. If a
 keeper returns an error or blocker, the harness writes
 `create-readiness-failures.jsonl` and skips review prompts instead of approving
-stale or partially-created PRs. The review phase requires
+stale or partially-created PRs. Per-keeper branch-collision evidence detected
+upfront by `assert_no_proof_branch_collisions_for_mutate` is written to
+`proof-branch-collisions.jsonl` (under the run dir) — one row per keeper with
+the offending branch ref(s) so operators can clean up stale local/remote
+branches before re-running. An empty file means no collisions; rows look like:
+```json
+{"keeper":"executor","branch":"keeper-executor-agent/<run_id>",
+ "kinds":["local","remote_tracking"]}
+``` The review phase requires
 `keeper_pr_review_comment`.
 This avoids the old single-turn shape where one keeper could wait on another
 keeper's missing PR until the Agent.run timeout. The review prompt reserves

--- a/docs/KEEPER-DOCKER-PR-LIFECYCLE-REPROBE.md
+++ b/docs/KEEPER-DOCKER-PR-LIFECYCLE-REPROBE.md
@@ -62,8 +62,8 @@ branches before re-running. An empty file means no collisions; rows look like:
 ```json
 {"keeper":"executor","branch":"keeper-executor-agent/<run_id>",
  "kinds":["local","remote_tracking"]}
-``` The review phase requires
-`keeper_pr_review_comment`.
+```
+After collision evidence is clear, the review phase requires `keeper_pr_review_comment`.
 This avoids the old single-turn shape where one keeper could wait on another
 keeper's missing PR until the Agent.run timeout. The review prompt reserves
 `keeper_shell` for read-only GitHub inspection, but does not put it in

--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -1066,6 +1066,8 @@ type pr_review_action_metric_event = {
 type pr_work_action_metric_event = {
   work_action : string;
   work_source : string;
+  work_ref : string option;
+  pr_url : string option;
   command : string option;
   success : bool;
   route_via : string option;
@@ -1141,6 +1143,62 @@ let route_via_of_json json =
     nested "tool_metadata" "via";
     nested "tool_metadata" "execution_via";
     nested "tool_metadata" "route_via";
+  ]
+  |> List.find_map Fun.id
+
+let non_empty_string_opt = function
+  | Some value ->
+      let value = String.trim value in
+      if String.equal value "" then None else Some value
+  | None -> None
+
+let string_field_opt key json = Safe_ops.json_string_opt key json |> non_empty_string_opt
+
+let nested_string_field_opt parent key json =
+  match assoc_field parent json with
+  | Some nested_json -> string_field_opt key nested_json
+  | None -> None
+
+let github_pr_url_from_text raw =
+  let normalized =
+    raw
+    |> String.map (function
+         | '\n' | '\r' | '\t' | '"' | '\'' -> ' '
+         | ch -> ch)
+  in
+  normalized
+  |> String.split_on_char ' '
+  |> List.find_map (fun token ->
+       let token = String.trim token in
+       if
+         String.starts_with ~prefix:"https://github.com/" token
+         && String_util.contains_substring token "/pull/"
+       then Some token
+       else None)
+
+let pr_url_of_json json =
+  [
+    string_field_opt "pr_url" json;
+    string_field_opt "pull_request_url" json;
+    string_field_opt "url" json;
+    string_field_opt "html_url" json;
+    string_field_opt "output" json;
+    nested_string_field_opt "result" "pr_url" json;
+    nested_string_field_opt "result" "pull_request_url" json;
+    nested_string_field_opt "result" "url" json;
+    nested_string_field_opt "result" "html_url" json;
+    nested_string_field_opt "result" "output" json;
+    nested_string_field_opt "route_evidence" "pr_url" json;
+  ]
+  |> List.find_map (function
+       | None -> None
+       | Some value -> github_pr_url_from_text value)
+
+let pr_create_ref_of_input input =
+  [
+    string_field_opt "head" input;
+    string_field_opt "branch" input;
+    string_field_opt "head_ref" input;
   ]
   |> List.find_map Fun.id
 
@@ -1466,16 +1524,22 @@ let pr_work_action_metric_events_of_tool_io
              {
                work_action;
                work_source = "masc_code_git";
+               work_ref = None;
+               pr_url = None;
                command = None;
                success;
                route_via;
              };
            ])
   | "keeper_pr_create" ->
+      let work_ref = pr_create_ref_of_input input in
+      let pr_url = Option.bind output_json pr_url_of_json in
       [
         {
           work_action = "PR_CREATE";
           work_source = "keeper_pr_create";
+          work_ref;
+          pr_url;
           command = None;
           success;
           route_via;
@@ -1490,6 +1554,8 @@ let pr_work_action_metric_events_of_tool_io
                   {
                     work_action;
                     work_source = tool_name;
+                    work_ref = None;
+                    pr_url = None;
                     command = Some command;
                     success;
                     route_via;
@@ -1615,6 +1681,9 @@ let append_pr_work_action_metrics
                   ("pr_work_action", `String event.work_action);
                   ("pr_work_action_source", `String event.work_source);
                   ("pr_work_action_success", `Bool event.success);
+                  ( "pr_work_ref",
+                    Json_util.string_opt_to_json event.work_ref );
+                  ("pr_url", Json_util.string_opt_to_json event.pr_url);
                   ( "pr_work_command",
                     Json_util.string_opt_to_json event.command );
                   ("tool_call_count", `Int 0);

--- a/lib/keeper/keeper_hooks_oas.mli
+++ b/lib/keeper/keeper_hooks_oas.mli
@@ -318,6 +318,8 @@ type pr_review_action_metric_event = {
 type pr_work_action_metric_event = {
   work_action : string;
   work_source : string;
+  work_ref : string option;
+  pr_url : string option;
   command : string option;
   success : bool;
   route_via : string option;

--- a/scripts/harness/workload/keeper_docker_pr_lifecycle_reprobe.sh
+++ b/scripts/harness/workload/keeper_docker_pr_lifecycle_reprobe.sh
@@ -1146,15 +1146,25 @@ poll_results() {
   fi
 }
 
+ere_escape() {
+  # Escape ERE metacharacters in a literal value before splicing it
+  # into a [grep -Eq] pattern. Without this, an operator-supplied
+  # --run-id like "post-act.live" or a branch name carrying a literal
+  # "+" would produce false matches/false failures.
+  printf '%s' "$1" | sed -e 's/[][\\^$.|?*+(){}]/\\&/g'
+}
+
 create_result_has_success_markers() {
   local keeper="$1"
   local text_file="$2"
-  local branch reply
+  local branch reply run_id_re branch_re
   branch="$(proof_branch_for_keeper "$keeper")"
+  run_id_re="$(ere_escape "$RUN_ID")"
+  branch_re="$(ere_escape "$branch")"
   reply="$(jq -r '.result.reply // .reply // empty' "$text_file" 2>/dev/null || true)"
 
-  printf '%s' "$reply" | grep -Eq '"run_id"[[:space:]]*:[[:space:]]*"'"$RUN_ID"'"' \
-    && printf '%s' "$reply" | grep -Eq '"branch"[[:space:]]*:[[:space:]]*"'"$branch"'"' \
+  printf '%s' "$reply" | grep -Eq '"run_id"[[:space:]]*:[[:space:]]*"'"$run_id_re"'"' \
+    && printf '%s' "$reply" | grep -Eq '"branch"[[:space:]]*:[[:space:]]*"'"$branch_re"'"' \
     && printf '%s' "$reply" | grep -Eq '"docker_pr_create"[[:space:]]*:[[:space:]]*true' \
     && printf '%s' "$reply" | grep -Eq '"docker_git_push"[[:space:]]*:[[:space:]]*true' \
     && printf '%s' "$reply" | grep -Eq '"blocker"[[:space:]]*:[[:space:]]*null' \
@@ -1323,6 +1333,12 @@ post_board_summary() {
 require_cmd jq
 require_cmd python3
 require_cmd curl
+# git is used by assert_no_proof_branch_collisions_for_mutate
+# (ls-remote/show-ref/worktree). Surface it up-front so a missing
+# git binary fails immediately at startup with a consistent
+# "required command not found" message rather than partway through
+# the run with a less obvious git-not-found error.
+require_cmd git
 
 if [[ "$MUTATE" == "1" || -n "$EXPECTED_SERVER_COMMIT" ]]; then
   assert_expected_server_commit

--- a/scripts/harness/workload/keeper_docker_pr_lifecycle_reprobe.sh
+++ b/scripts/harness/workload/keeper_docker_pr_lifecycle_reprobe.sh
@@ -18,6 +18,8 @@ RESULTS_FILE="$RUN_DIR/results.jsonl"
 POLL_ERRORS_FILE="$RUN_DIR/poll_errors.jsonl"
 REVIEW_TARGETS_FILE="$RUN_DIR/review-targets.jsonl"
 GITHUB_IDENTITY_COUNTS_FILE="$RUN_DIR/github-identity-counts.json"
+PROOF_BRANCH_COLLISIONS_FILE="$RUN_DIR/proof-branch-collisions.jsonl"
+CREATE_READINESS_FAILURES_FILE="$RUN_DIR/create-readiness-failures.jsonl"
 SUMMARY_FILE="$RUN_DIR/summary.json"
 AUDIT_FILE="$RUN_DIR/audit-docker-pr-lifecycle.json"
 AUDIT_STATUS_RESULT=0
@@ -165,6 +167,8 @@ while [[ $# -gt 0 ]]; do
         POLL_ERRORS_FILE="$RUN_DIR/poll_errors.jsonl"
         REVIEW_TARGETS_FILE="$RUN_DIR/review-targets.jsonl"
         GITHUB_IDENTITY_COUNTS_FILE="$RUN_DIR/github-identity-counts.json"
+        PROOF_BRANCH_COLLISIONS_FILE="$RUN_DIR/proof-branch-collisions.jsonl"
+        CREATE_READINESS_FAILURES_FILE="$RUN_DIR/create-readiness-failures.jsonl"
         SUMMARY_FILE="$RUN_DIR/summary.json"
         AUDIT_FILE="$RUN_DIR/audit-docker-pr-lifecycle.json"
       fi
@@ -180,6 +184,8 @@ while [[ $# -gt 0 ]]; do
       POLL_ERRORS_FILE="$RUN_DIR/poll_errors.jsonl"
       REVIEW_TARGETS_FILE="$RUN_DIR/review-targets.jsonl"
       GITHUB_IDENTITY_COUNTS_FILE="$RUN_DIR/github-identity-counts.json"
+      PROOF_BRANCH_COLLISIONS_FILE="$RUN_DIR/proof-branch-collisions.jsonl"
+      CREATE_READINESS_FAILURES_FILE="$RUN_DIR/create-readiness-failures.jsonl"
       SUMMARY_FILE="$RUN_DIR/summary.json"
       AUDIT_FILE="$RUN_DIR/audit-docker-pr-lifecycle.json"
       shift 2
@@ -205,6 +211,8 @@ mkdir -p "$RUN_DIR" "$RAW_DIR" "$PROMPT_DIR"
 : >"$RESULTS_FILE"
 : >"$POLL_ERRORS_FILE"
 : >"$REVIEW_TARGETS_FILE"
+: >"$PROOF_BRANCH_COLLISIONS_FILE"
+: >"$CREATE_READINESS_FAILURES_FILE"
 
 log() {
   printf '[%s] %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$*" >&2
@@ -779,6 +787,87 @@ proof_branch_for_keeper() {
   printf 'keeper-%s-agent/%s' "$keeper" "$RUN_ID"
 }
 
+assert_no_proof_branch_collisions_for_mutate() {
+  [[ "$MUTATE" == "1" ]] || return 0
+
+  local branches_file remote_heads_file
+  branches_file="$RUN_DIR/proof-branches.txt"
+  remote_heads_file="$RUN_DIR/proof-branch-remote-heads.txt"
+  : >"$branches_file"
+  : >"$remote_heads_file"
+  : >"$PROOF_BRANCH_COLLISIONS_FILE"
+
+  local keeper branch
+  while IFS= read -r keeper; do
+    [[ -n "$keeper" ]] || continue
+    branch="$(proof_branch_for_keeper "$keeper")"
+    printf '%s\t%s\n' "$keeper" "$branch" >>"$branches_file"
+  done <"$RUN_DIR/keepers.txt"
+
+  local proof_branches=()
+  while IFS=$'\t' read -r _ branch; do
+    [[ -n "$branch" ]] || continue
+    proof_branches+=( "$branch" )
+  done <"$branches_file"
+  if [[ "${#proof_branches[@]}" -gt 0 ]]; then
+    if ! git -C "$REPO_ROOT" ls-remote --heads origin "${proof_branches[@]}" \
+        >"$remote_heads_file"; then
+      echo "failed to check remote proof branch uniqueness before mutate" >&2
+      exit 1
+    fi
+  fi
+
+  while IFS=$'\t' read -r keeper branch; do
+    [[ -n "$keeper" && -n "$branch" ]] || continue
+    local local_branch remote_tracking_branch remote_head worktree_branch
+    local_branch=false
+    remote_tracking_branch=false
+    remote_head=false
+    worktree_branch=false
+
+    if git -C "$REPO_ROOT" show-ref --verify --quiet "refs/heads/$branch"; then
+      local_branch=true
+    fi
+    if git -C "$REPO_ROOT" show-ref --verify --quiet "refs/remotes/origin/$branch"; then
+      remote_tracking_branch=true
+    fi
+    if awk -v ref="refs/heads/$branch" '$2 == ref { found = 1 } END { exit(found ? 0 : 1) }' \
+        "$remote_heads_file"; then
+      remote_head=true
+    fi
+    if git -C "$REPO_ROOT" worktree list --porcelain \
+        | awk -v ref="refs/heads/$branch" '$1 == "branch" && $2 == ref { found = 1 } END { exit(found ? 0 : 1) }'; then
+      worktree_branch=true
+    fi
+
+    if [[ "$local_branch" == "true" || "$remote_tracking_branch" == "true" \
+        || "$remote_head" == "true" || "$worktree_branch" == "true" ]]; then
+      jq -nc \
+        --arg keeper "$keeper" \
+        --arg branch "$branch" \
+        --argjson local_branch "$local_branch" \
+        --argjson remote_tracking_branch "$remote_tracking_branch" \
+        --argjson remote_head "$remote_head" \
+        --argjson worktree_branch "$worktree_branch" \
+        '{
+          keeper:$keeper,
+          branch:$branch,
+          local_branch:$local_branch,
+          remote_tracking_branch:$remote_tracking_branch,
+          remote_head:$remote_head,
+          worktree_branch:$worktree_branch,
+          blocker:"branch_collision_preflight"
+        }' >>"$PROOF_BRANCH_COLLISIONS_FILE"
+    fi
+  done <"$branches_file"
+
+  if [[ -s "$PROOF_BRANCH_COLLISIONS_FILE" ]]; then
+    echo "proof branch collision preflight failed; choose a fresh --run-id" >&2
+    cat "$PROOF_BRANCH_COLLISIONS_FILE" >&2
+    exit 1
+  fi
+}
+
 prompt_for_keeper_create() {
   local keeper="$1"
   local branch
@@ -1057,6 +1146,62 @@ poll_results() {
   fi
 }
 
+create_result_has_success_markers() {
+  local keeper="$1"
+  local text_file="$2"
+  local branch reply
+  branch="$(proof_branch_for_keeper "$keeper")"
+  reply="$(jq -r '.result.reply // .reply // empty' "$text_file" 2>/dev/null || true)"
+
+  printf '%s' "$reply" | grep -Eq '"run_id"[[:space:]]*:[[:space:]]*"'"$RUN_ID"'"' \
+    && printf '%s' "$reply" | grep -Eq '"branch"[[:space:]]*:[[:space:]]*"'"$branch"'"' \
+    && printf '%s' "$reply" | grep -Eq '"docker_pr_create"[[:space:]]*:[[:space:]]*true' \
+    && printf '%s' "$reply" | grep -Eq '"docker_git_push"[[:space:]]*:[[:space:]]*true' \
+    && printf '%s' "$reply" | grep -Eq '"blocker"[[:space:]]*:[[:space:]]*null' \
+    && printf '%s' "$reply" | grep -Eq 'https://github\.com/[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+/pull/[0-9]+'
+}
+
+all_create_results_ready_for_review() {
+  : >"$CREATE_READINESS_FAILURES_FILE"
+
+  local keeper status text_file
+  while IFS= read -r keeper; do
+    [[ -n "$keeper" ]] || continue
+    status="$(
+      jq -r --arg keeper "$keeper" '
+        select(.phase == "create" and .keeper == $keeper)
+        | .status // empty
+      ' "$RESULTS_FILE" | tail -n 1
+    )"
+    text_file="$(
+      jq -r --arg keeper "$keeper" '
+        select(.phase == "create" and .keeper == $keeper)
+        | .text_file // empty
+      ' "$RESULTS_FILE" | tail -n 1
+    )"
+
+    if [[ -z "$status" || -z "$text_file" ]]; then
+      jq -nc --arg keeper "$keeper" \
+        '{keeper:$keeper, blocker:"create_result_missing"}' \
+        >>"$CREATE_READINESS_FAILURES_FILE"
+      continue
+    fi
+    if [[ "$status" != "done" && "$status" != "completed" && "$status" != "complete" ]]; then
+      jq -nc --arg keeper "$keeper" --arg status "$status" \
+        '{keeper:$keeper, status:$status, blocker:"create_status_not_success"}' \
+        >>"$CREATE_READINESS_FAILURES_FILE"
+      continue
+    fi
+    if ! create_result_has_success_markers "$keeper" "$text_file"; then
+      jq -nc --arg keeper "$keeper" --arg status "$status" --arg text_file "$text_file" \
+        '{keeper:$keeper, status:$status, text_file:$text_file, blocker:"create_success_markers_missing"}' \
+        >>"$CREATE_READINESS_FAILURES_FILE"
+    fi
+  done <"$RUN_DIR/keepers.txt"
+
+  [[ ! -s "$CREATE_READINESS_FAILURES_FILE" ]]
+}
+
 run_audit() {
   if [[ "$RUN_AUDIT" != "1" ]]; then
     AUDIT_STATUS_RESULT=0
@@ -1114,6 +1259,8 @@ write_summary() {
     --arg server_health_file "$SERVER_HEALTH_CHECK_FILE" \
     --arg review_targets_file "$REVIEW_TARGETS_FILE" \
     --arg github_identity_counts_file "$GITHUB_IDENTITY_COUNTS_FILE" \
+    --arg proof_branch_collisions_file "$PROOF_BRANCH_COLLISIONS_FILE" \
+    --arg create_readiness_failures_file "$CREATE_READINESS_FAILURES_FILE" \
     --argjson mutate "$MUTATE" \
     --argjson keeper_count "$keeper_count" \
     --argjson request_count "$request_count" \
@@ -1138,6 +1285,8 @@ write_summary() {
       server_health_file:$server_health_file,
       review_targets_file:$review_targets_file,
       github_identity_counts_file:$github_identity_counts_file,
+      proof_branch_collisions_file:$proof_branch_collisions_file,
+      create_readiness_failures_file:$create_readiness_failures_file,
       mutate:$mutate,
       keeper_count:$keeper_count,
       request_count:$request_count,
@@ -1183,6 +1332,7 @@ discover_keepers
 assert_github_identity_pool_for_mutate
 build_review_targets
 render_prompts
+assert_no_proof_branch_collisions_for_mutate
 
 if [[ "$MUTATE" == "1" ]]; then
   # Share one POLL_TIMEOUT_SEC budget across both phases so the overall
@@ -1192,8 +1342,12 @@ if [[ "$MUTATE" == "1" ]]; then
   export MUTATE_POLL_DEADLINE_TS=$(( $(date +%s) + POLL_TIMEOUT_SEC ))
   send_phase_prompts "create" "$CREATE_REQUIRED_TOOLS"
   poll_results "create"
-  send_phase_prompts "review" "$REVIEW_REQUIRED_TOOLS"
-  poll_results "review"
+  if all_create_results_ready_for_review; then
+    send_phase_prompts "review" "$REVIEW_REQUIRED_TOOLS"
+    poll_results "review"
+  else
+    log "skipping review phase because create phase did not produce complete success evidence"
+  fi
   unset MUTATE_POLL_DEADLINE_TS
 else
   log "dry-run mode: prompts rendered under $PROMPT_DIR; no keeper messages sent"

--- a/test/test_audit_keeper_fleet_readiness.py
+++ b/test/test_audit_keeper_fleet_readiness.py
@@ -808,6 +808,10 @@ class AuditKeeperFleetReadinessTest(unittest.TestCase):
             root = Path(tmp)
             calls_dir = root / ".masc" / "tool_calls" / "2026-05"
             calls_dir.mkdir(parents=True)
+            metrics_dir = (
+                root / ".masc" / "keepers" / "alpha" / "pr-action-metrics" / "2026-05"
+            )
+            metrics_dir.mkdir(parents=True)
             rows = [
                 {
                     "ts": 50.0,
@@ -835,14 +839,43 @@ class AuditKeeperFleetReadinessTest(unittest.TestCase):
                 "".join(json.dumps(row) + "\n" for row in rows),
                 encoding="utf-8",
             )
+            metric_rows = [
+                {
+                    "ts_unix": 55.0,
+                    "metric_event": "keeper_pr_work_action",
+                    "tool_name": "keeper_pr_create",
+                    "pr_work_action": "PR_CREATE",
+                    "pr_work_action_source": "keeper_pr_create",
+                    "pr_work_action_success": True,
+                    "pr_work_ref": "keeper/alpha-docker-pr-proof-old-run",
+                    "route_via": "docker",
+                },
+                {
+                    "ts_unix": 65.0,
+                    "metric_event": "keeper_pr_work_action",
+                    "tool_name": "keeper_pr_create",
+                    "pr_work_action": "PR_CREATE",
+                    "pr_work_action_source": "keeper_pr_create",
+                    "pr_work_action_success": True,
+                    "pr_work_ref": "keeper/alpha-docker-pr-proof-current-run",
+                    "pr_url": "https://github.com/acme/repo/pull/42",
+                    "route_via": "docker",
+                },
+            ]
+            (metrics_dir / "06.jsonl").write_text(
+                "".join(json.dumps(row) + "\n" for row in metric_rows),
+                encoding="utf-8",
+            )
 
             latest_ts, tools, evidence, docker_evidence = audit.scan_keeper_evidence(
                 root, "alpha", evidence_run_id="current-run"
             )
 
-        self.assertEqual(latest_ts, 60.0)
-        self.assertEqual(tools, {"keeper_bash"})
-        self.assertEqual(evidence, {"git_push:keeper_bash"})
+        self.assertEqual(latest_ts, 65.0)
+        self.assertEqual(tools, {"keeper_bash", "keeper_pr_create"})
+        self.assertEqual(
+            evidence, {"git_push:keeper_bash", "pr_create:keeper_pr_create"}
+        )
         self.assertEqual(docker_evidence, evidence)
 
     def test_scan_keeper_evidence_reads_newest_tool_calls_first(self):

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -1167,6 +1167,27 @@ let test_keeper_required_tool_contracts () =
      && file_contains_pattern
           "docs/KEEPER-DOCKER-PR-LIFECYCLE-REPROBE.md"
           "`keeper-<keeper>-agent/<run_id>`");
+  check bool "docker PR lifecycle rejects stale proof branches before mutate" true
+    (file_contains_pattern
+       "scripts/harness/workload/keeper_docker_pr_lifecycle_reprobe.sh"
+       "assert_no_proof_branch_collisions_for_mutate"
+     && file_contains_pattern
+          "scripts/harness/workload/keeper_docker_pr_lifecycle_reprobe.sh"
+          "branch_collision_preflight"
+     && file_contains_pattern "docs/KEEPER-DOCKER-PR-LIFECYCLE-REPROBE.md"
+          "`branch_collision_preflight`");
+  check bool "docker PR lifecycle gates review on create success evidence" true
+    (file_contains_pattern
+       "scripts/harness/workload/keeper_docker_pr_lifecycle_reprobe.sh"
+       "all_create_results_ready_for_review"
+     && file_contains_pattern
+          "scripts/harness/workload/keeper_docker_pr_lifecycle_reprobe.sh"
+          "create_success_markers_missing"
+     && file_contains_pattern
+          "scripts/harness/workload/keeper_docker_pr_lifecycle_reprobe.sh"
+          "skipping review phase because create phase did not produce complete success evidence"
+     && file_contains_pattern "docs/KEEPER-DOCKER-PR-LIFECYCLE-REPROBE.md"
+          "`create-readiness-failures.jsonl`");
   check bool "keeper msg schema documents required_tool_names alias" true
     (file_contains_pattern "lib/keeper/keeper_schema.ml"
        "required_tool_names")

--- a/test/test_keeper_hooks_oas_telemetry.ml
+++ b/test/test_keeper_hooks_oas_telemetry.ml
@@ -962,7 +962,7 @@ let test_pr_work_action_metric_extracts_keeper_pr_create () =
             ("head", `String "proof/keeper-docker");
           ])
       ~output_text:
-        {|{"ok":true,"tool":"keeper_pr_create","operation":"pr_create","via":"brokered"}|}
+        {|{"ok":true,"tool":"keeper_pr_create","operation":"pr_create","via":"brokered","result":{"output":"https://github.com/acme/repo/pull/42\n"}}|}
       ()
   in
   check (list string) "pr create action" [ "PR_CREATE" ]
@@ -970,6 +970,11 @@ let test_pr_work_action_metric_extracts_keeper_pr_create () =
   match events with
   | [ event ] ->
       check string "source" "keeper_pr_create" event.work_source;
+      check (option string) "head ref" (Some "proof/keeper-docker")
+        event.work_ref;
+      check (option string) "pr url"
+        (Some "https://github.com/acme/repo/pull/42")
+        event.pr_url;
       check (option string) "route via" (Some "brokered") event.route_via
   | _ -> failf "expected one keeper_pr_create event"
 
@@ -991,6 +996,8 @@ let test_pr_work_action_metric_uses_native_pr_create_route_fallback () =
     (work_actions events);
   match events with
   | [ event ] ->
+      check (option string) "head ref" (Some "proof/keeper-docker")
+        event.work_ref;
       check (option string) "route fallback" (Some "brokered")
         event.route_via
   | _ -> failf "expected one keeper_pr_create event"


### PR DESCRIPTION
## Summary
- add a mutate preflight that fails before keeper prompts when run-scoped proof branches already exist
- require create-phase success markers before sending review prompts
- record `keeper_pr_create` head refs and PR URLs into durable PR-action metrics so run-id scoped audits can count PR create evidence
- document the new branch-collision and create-readiness artifact files

## Why
Live reprobe attempts showed code-level gaps: stale run ids could reuse existing proof branches, the harness could still send review prompts after create returned an error or blocker, and successful `keeper_pr_create` rows did not retain the run-scoped branch/PR URL needed by `--evidence-run-id` audits. That polluted the Docker PR lifecycle evidence surface and made real create evidence invisible to the fleet audit.

## Live Evidence
- clean run: `docker-pr-lifecycle-pair-20260506-1427-codex`
- artifacts: `logs/keeper_docker_pr_lifecycle/docker-pr-lifecycle-pair-20260506-1427-codex/`
- analyst create succeeded via Docker: PR #13869, branch `keeper-analyst-agent/docker-pr-lifecycle-pair-20260506-1427-codex`
- verifier create succeeded via Docker: PR #13868, branch `keeper-verifier-agent/docker-pr-lifecycle-pair-20260506-1427-codex`
- review phase reached Docker `keeper_pr_review_comment`, but GitHub rejected APPROVE with self-approval policy because effective credentials are shared (`anyang-keepers`); analyst posted a Docker COMMENT on #13868 documenting the blocker

## Verification
- current head: `16e5727ff6e292eea0d92a13f5192bdce07c5133`
- `bash -n scripts/harness/workload/keeper_docker_pr_lifecycle_reprobe.sh scripts/harness_keeper_docker_pr_lifecycle_reprobe.sh`
- `git diff --check origin/main...HEAD`
- `ruff check test/test_audit_keeper_fleet_readiness.py`
- `ruff format --check test/test_audit_keeper_fleet_readiness.py`
- `python3 -B -m py_compile test/test_audit_keeper_fleet_readiness.py`
- `python3 test/test_audit_keeper_fleet_readiness.py` (33 tests pass)
- `scripts/check-oas-pin.sh --local-only`
- `env MASC_OPAM_LOCK=0 scripts/dune-local.sh build test/test_ci_hardening_source.exe` (passed on prior head `26b7a5e`; final `16e5727` is doc-only on top)
- `./_build/default/test/test_ci_hardening_source.exe` on `16e5727` (53 tests pass)
- `RUN_AUDIT=0 scripts/harness/workload/keeper_docker_pr_lifecycle_reprobe.sh --dry-run --keeper-names analyst,verifier --expected-keepers 14 --run-id dry-phase-smoke-0506-preflight-gate2 --run-dir /private/tmp/keeper-docker-pr-preflight-gate-smoke2`
- collision preflight: `RUN_AUDIT=0 EXIT_ON_AUDIT_FAIL=0 scripts/harness/workload/keeper_docker_pr_lifecycle_reprobe.sh --mutate --keeper-names analyst,verifier --expected-keepers 14 --base-path /Users/dancer/me --run-id docker-pr-lifecycle-pair-0506j --run-dir /private/tmp/keeper-docker-pr-preflight-collision-0506j-pair2 --forbid-github-identity jeong-sik` failed before prompts with `branch_collision_preflight` for both proof branches
