### PR TITLE
feat(board): surface moderation projection fields

### DIFF
--- a/dashboard/src/api/board.test.ts
+++ b/dashboard/src/api/board.test.ts
@@ -453,6 +453,8 @@ describe('fetchBoard', () => {
           updated_at: 1_713_000_000,
           current_vote: 'up',
           has_voted: true,
+          report_count: 2,
+          moderation_status: 'flagged',
           reactions: [
             {
               emoji: '🔥',
@@ -486,6 +488,8 @@ describe('fetchBoard', () => {
     expect(result.posts[0]).toMatchObject({
       current_vote: 'up',
       has_voted: true,
+      report_count: 2,
+      moderation_status: 'flagged',
       reactions: [
         {
           emoji: '🔥',
@@ -663,6 +667,8 @@ describe('fetchBoardPost', () => {
           score: 3,
           current_vote: 'up',
           has_voted: true,
+          report_count: 1,
+          moderation_status: 'hidden',
           reactions: [
             {
               emoji: '🚀',
@@ -692,6 +698,8 @@ describe('fetchBoardPost', () => {
       votes_down: 2,
       current_vote: 'up',
       has_voted: true,
+      report_count: 1,
+      moderation_status: 'hidden',
       reactions: [
         {
           emoji: '🚀',

--- a/dashboard/src/api/board.ts
+++ b/dashboard/src/api/board.ts
@@ -4,7 +4,7 @@ import { timeBoardRequest } from '../board-metrics'
 import type {
   BoardActorIdentity, BoardPost, BoardComment, BoardReactionSummary,
   BoardReactionTargetType, BoardReactionToggleResult, BoardSortMode,
-  BoardVoteDirection,
+  BoardVoteDirection, BoardModerationStatus,
   BoardCurationSnapshot, BoardKarmaLedger, BoardKarmaLedgerEvent, BoardKarmaTotal,
   GovernanceContextRef,
   GovernanceDecisionItem, GovernanceExecutedRoute,
@@ -339,6 +339,20 @@ function normalizeBoardVoteDirection(raw: unknown): BoardVoteDirection | null {
   return direction === 'up' || direction === 'down' ? direction : null
 }
 
+function normalizeBoardModerationStatus(raw: unknown): BoardModerationStatus {
+  const status = asString(raw, '').trim().toLowerCase()
+  switch (status) {
+    case 'flagged':
+    case 'approved':
+    case 'removed':
+    case 'hidden':
+    case 'warned':
+      return status
+    default:
+      return 'none'
+  }
+}
+
 function normalizeBoardPost(raw: unknown): BoardPost | null {
   if (!isRecord(raw)) return null
   const id = asString(raw.id, '').trim()
@@ -413,6 +427,8 @@ function normalizeBoardPost(raw: unknown): BoardPost | null {
         : '')
       || null,
     hearth_count: asNumber(raw.hearth_count, 0),
+    report_count: Math.max(0, Math.trunc(asNumber(raw.report_count, 0))),
+    moderation_status: normalizeBoardModerationStatus(raw.moderation_status),
     ...(reactions !== undefined ? { reactions } : {}),
   }
 }
@@ -449,6 +465,8 @@ function normalizeBoardComment(raw: unknown): BoardComment | null {
     votes_down: votesDown,
     current_vote: currentVote,
     has_voted: hasVoted,
+    report_count: Math.max(0, Math.trunc(asNumber(raw.report_count, 0))),
+    moderation_status: normalizeBoardModerationStatus(raw.moderation_status),
     ...(reactions !== undefined ? { reactions } : {}),
   }
 }

--- a/dashboard/src/components/board/board-surface.test.ts
+++ b/dashboard/src/components/board/board-surface.test.ts
@@ -237,6 +237,23 @@ describe('BoardSurface Component', () => {
     expect(screen.getByRole('button', { name: '🔥 리액션 2개' })).toHaveAttribute('aria-pressed', 'true')
   })
 
+  it('renders post moderation projection badges', () => {
+    boardPosts.value = [
+      makePost({
+        id: 'post-flagged',
+        title: 'Needs moderation',
+        body: 'content',
+        author: 'ani1999',
+        report_count: 2,
+        moderation_status: 'flagged',
+      }),
+    ]
+
+    render(h(BoardSurface, null))
+
+    expect(screen.getByLabelText('게시글 moderation 신고됨 2건')).toHaveTextContent('신고됨 2')
+  })
+
   it('routes the mention inbox focus to the message surface', () => {
     route.value = { params: { focus: 'mention-inbox' } } as any
     messages.value = [{ id: 'm-1', from: 'sojin', content: '@dashboard needs review' }]

--- a/dashboard/src/components/board/board-surface.ts
+++ b/dashboard/src/components/board/board-surface.ts
@@ -21,6 +21,7 @@ import { MessageRoomTimeline } from './message-room-timeline'
 import { BoardCurationPanel } from './board-curation-panel'
 import { BoardKarmaPanel } from './board-karma-panel'
 import { MentionInbox } from './mention-inbox'
+import { ModerationBadge } from './moderation-badge'
 import { PostDetail } from './post-detail'
 import { ReactionBar } from './reaction-bar'
 import { StateBlockMessages } from './state-block-messages'
@@ -697,6 +698,7 @@ function PostCard({ post }: { post: BoardPost }) {
           <span class="inline-flex items-center px-1.5 py-0.5 rounded-[var(--r-1)] text-3xs font-medium border ${categoryBadgeColor(cat)}">${categoryLabel(cat)}</span>
           ${post.hearth ? html`<span class="inline-flex items-center px-1.5 py-0.5 rounded-[var(--r-1)] text-3xs font-medium border bg-[var(--ff-gold-10)] text-[var(--ff-gold-bright)] border-[var(--ff-gold-20)]">${post.hearth}</span>` : null}
           ${post.visibility && visibilityLabel(post.visibility) ? html`<span class="inline-flex items-center px-1.5 py-0.5 rounded-[var(--r-1)] text-3xs font-medium border ${visibilityBadgeColor(post.visibility)}">${visibilityLabel(post.visibility)}</span>` : null}
+          <${ModerationBadge} status=${post.moderation_status} reportCount=${post.report_count} targetLabel="게시글" />
 
           <!-- Delete button — reveal on row hover via opacity utilities -->
           <${ActionButton}

--- a/dashboard/src/components/board/moderation-badge.ts
+++ b/dashboard/src/components/board/moderation-badge.ts
@@ -1,0 +1,88 @@
+import { html } from 'htm/preact'
+import type { BoardModerationStatus } from '../../types'
+
+type ModerationTone = 'muted' | 'warn' | 'bad' | 'ok'
+
+function normalizeStatus(status: BoardModerationStatus | string | null | undefined): BoardModerationStatus | null {
+  const normalized = (status ?? '').trim().toLowerCase()
+  if (
+    normalized === 'flagged'
+    || normalized === 'approved'
+    || normalized === 'removed'
+    || normalized === 'hidden'
+    || normalized === 'warned'
+  ) {
+    return normalized
+  }
+  return null
+}
+
+function statusLabel(status: BoardModerationStatus | null): string {
+  switch (status) {
+    case 'flagged':
+      return '신고됨'
+    case 'approved':
+      return '승인됨'
+    case 'removed':
+      return '삭제됨'
+    case 'hidden':
+      return '숨김'
+    case 'warned':
+      return '경고됨'
+    default:
+      return '신고'
+  }
+}
+
+function statusTone(status: BoardModerationStatus | null): ModerationTone {
+  switch (status) {
+    case 'flagged':
+    case 'warned':
+      return 'warn'
+    case 'removed':
+    case 'hidden':
+      return 'bad'
+    case 'approved':
+      return 'ok'
+    default:
+      return 'muted'
+  }
+}
+
+function toneClass(tone: ModerationTone): string {
+  switch (tone) {
+    case 'warn':
+      return 'bg-[var(--warn-15)] text-[var(--color-status-warn)] border-[var(--warn-30)]'
+    case 'bad':
+      return 'bg-[var(--bad-10)] text-[var(--color-status-err)] border-[var(--bad-30)]'
+    case 'ok':
+      return 'bg-[var(--ok-soft)] text-[var(--color-status-ok)] border-[var(--ok-30)]'
+    default:
+      return 'bg-[var(--color-bg-hover)] text-[var(--color-fg-muted)] border-[var(--color-border-divider)]'
+  }
+}
+
+export function ModerationBadge({
+  status,
+  reportCount = 0,
+  targetLabel = '콘텐츠',
+}: {
+  status?: BoardModerationStatus | string | null
+  reportCount?: number | null
+  targetLabel?: string
+}) {
+  const normalizedStatus = normalizeStatus(status)
+  const normalizedCount = Math.max(0, Math.trunc(reportCount ?? 0))
+  if (normalizedStatus === null && normalizedCount === 0) return null
+  const label = statusLabel(normalizedStatus)
+  const countLabel = normalizedCount > 0 ? ` ${normalizedCount}` : ''
+  return html`
+    <span
+      class=${`inline-flex items-center px-1.5 py-0.5 rounded-[var(--r-1)] text-3xs font-medium border ${toneClass(statusTone(normalizedStatus))}`}
+      aria-label=${`${targetLabel} moderation ${label}${normalizedCount > 0 ? ` ${normalizedCount}건` : ''}`}
+      title=${`${label}${normalizedCount > 0 ? ` · 신고 ${normalizedCount}건` : ''}`}
+    >
+      ${label}${countLabel}
+    </span>
+  `
+}

--- a/dashboard/src/components/board/moderation-badge.ts
+++ b/dashboard/src/components/board/moderation-badge.ts
@@ -80,7 +80,13 @@ export function ModerationBadge({
     <span
       class=${`inline-flex items-center px-1.5 py-0.5 rounded-[var(--r-1)] text-3xs font-medium border ${toneClass(statusTone(normalizedStatus))}`}
       aria-label=${`${targetLabel} moderation ${label}${normalizedCount > 0 ? ` ${normalizedCount}건` : ''}`}
-      title=${`${label}${normalizedCount > 0 ? ` · 신고 ${normalizedCount}건` : ''}`}
+      title=${
+        normalizedCount > 0
+          ? (label === '신고'
+              ? `신고 ${normalizedCount}건`
+              : `${label} · 신고 ${normalizedCount}건`)
+          : label
+      }
     >
       ${label}${countLabel}
     </span>

--- a/dashboard/src/components/board/post-detail.test.ts
+++ b/dashboard/src/components/board/post-detail.test.ts
@@ -249,6 +249,25 @@ describe('CommentThread', () => {
     expect(screen.getByText('4')).toBeInTheDocument()
   })
 
+  it('renders comment moderation projection badges', () => {
+    const comments = [
+      {
+        id: 'c1',
+        post_id: 'post-1',
+        parent_id: null,
+        author: 'agent',
+        content: 'review me',
+        created_at: '2026-04-02T00:00:00Z',
+        report_count: 1,
+        moderation_status: 'hidden',
+      },
+    ] as any
+
+    render(h(CommentThread, { comments, postId: 'post-1' }))
+
+    expect(screen.getByLabelText('댓글 moderation 숨김 1건')).toHaveTextContent('숨김 1')
+  })
+
   it('marks the current comment vote as pressed', () => {
     const comments = [
       {
@@ -417,6 +436,8 @@ describe('PostDetail', () => {
       comment_count: 0,
       post_kind: 'direct',
       classification_reason: 'Direct board post without automation provenance.',
+      report_count: 1,
+      moderation_status: 'approved',
       comments: [],
     } as any
 
@@ -425,6 +446,7 @@ describe('PostDetail', () => {
     expect(screen.getByText(/분류 근거:/)).toBeInTheDocument()
     expect(screen.getByText(/Direct board post without automation provenance/)).toBeInTheDocument()
     expect(screen.getByText('직접')).toBeInTheDocument()
+    expect(screen.getByLabelText('게시글 moderation 승인됨 1건')).toHaveTextContent('승인됨 1')
   })
 
   it('marks the current post vote as pressed', async () => {

--- a/dashboard/src/components/board/post-detail.ts
+++ b/dashboard/src/components/board/post-detail.ts
@@ -12,6 +12,7 @@ import { RichContent } from '../common/rich-content'
 import { TextInput } from '../common/input'
 import { stripStateBlocks } from '../../keeper-message'
 import { navigate } from '../../router'
+import { ModerationBadge } from './moderation-badge'
 import { ReactionBar } from './reaction-bar'
 import {
   boardActorAvatarKey,
@@ -238,6 +239,7 @@ function CommentItem({
           <span class="text-xs">${authorAvatar(authorAvatarKey)}</span>
           <${ActionButton} variant="subtle" size="sm" class="text-xs font-medium text-[var(--color-fg-primary)] hover:text-[var(--color-accent-fg)] bg-transparent border-none p-0" title=${authorTitle} ariaLabel=${`작성자 ${authorLabel} 프로필로 이동`} onClick=${() => navigateToAuthor(comment.author, undefined, comment.author_identity)}>${authorLabel}<//>
           <span class="text-2xs text-[var(--color-fg-muted)] opacity-60"><${TimeAgo} timestamp=${comment.created_at} /></span>
+          <${ModerationBadge} status=${comment.moderation_status} reportCount=${comment.report_count} targetLabel="댓글" />
           <div class="ml-auto flex items-center gap-1">
             <button
               type="button"
@@ -470,7 +472,7 @@ export function PostDetail({ post }: { post: BoardPost }) {
           </div>
 
           <!-- Badges -->
-          ${(post.hearth || post.visibility || post.expires_at || post.classification_reason)
+          ${(post.hearth || post.visibility || post.expires_at || post.classification_reason || (post.moderation_status && post.moderation_status !== 'none') || (post.report_count ?? 0) > 0)
             ? html`
                 <div class="flex flex-col gap-2">
                   <div class="flex gap-1.5 flex-wrap">
@@ -478,6 +480,7 @@ export function PostDetail({ post }: { post: BoardPost }) {
                     ${post.visibility && visibilityLabel(post.visibility) ? html`<span class="inline-flex items-center px-2 py-0.5 rounded-[var(--r-1)] text-3xs font-medium border ${visibilityBadgeColor(post.visibility)}">${visibilityLabel(post.visibility)}</span>` : null}
                     <span class="inline-flex items-center px-2 py-0.5 rounded-[var(--r-1)] text-3xs font-medium border ${kindBadgeColor(boardPostKind(post))}">${kindLabel(boardPostKind(post))}</span>
                     ${expiryChip(post)}
+                    <${ModerationBadge} status=${post.moderation_status} reportCount=${post.report_count} targetLabel="게시글" />
                   </div>
                   ${post.classification_reason
                     ? html`<div class="text-2xs text-[var(--color-fg-muted)]">분류 근거: ${post.classification_reason}</div>`

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -118,6 +118,7 @@ type BoardPostMeta = Record<string, unknown> & {
 }
 
 export type BoardVoteDirection = 'up' | 'down'
+export type BoardModerationStatus = 'none' | 'flagged' | 'approved' | 'removed' | 'hidden' | 'warned'
 
 export interface BoardActorIdentity {
   kind: 'keeper' | 'agent'
@@ -152,6 +153,8 @@ export interface BoardPost {
   visibility?: string
   expires_at?: string | null
   hearth_count?: number
+  report_count?: number
+  moderation_status?: BoardModerationStatus
   reactions?: BoardReactionSummary[]
 }
 
@@ -169,6 +172,8 @@ export interface BoardComment {
   votes_down?: number
   current_vote?: BoardVoteDirection | null
   has_voted?: boolean
+  report_count?: number
+  moderation_status?: BoardModerationStatus
   reactions?: BoardReactionSummary[]
 }
 

--- a/lib/board_moderation.ml
+++ b/lib/board_moderation.ml
@@ -88,6 +88,11 @@ type audit_entry = {
   acted_at    : float;
 }
 
+type target_summary = {
+  report_count : int;
+  moderation_status : string;
+}
+
 (** {1 In-memory store} *)
 
 type store = {
@@ -271,6 +276,49 @@ let get_audit_trail ?target_id ?actor ?(limit = 100) () =
       | x :: xs -> take (x :: acc) (i + 1) xs
     in
     take [] 0 sorted
+
+(** {1 Target projection} *)
+
+let moderation_status_of_action = function
+  | Approve -> "approved"
+  | Remove  -> "removed"
+  | Hide    -> "hidden"
+  | Warn    -> "warned"
+
+let target_summary ~target_kind ~target_id =
+  let s = store () in
+  let matches_target target_kind' target_id' =
+    target_kind = target_kind' && String.equal target_id target_id'
+  in
+  let report_count =
+    Hashtbl.fold
+      (fun _ (entry : queue_entry) acc ->
+         if matches_target entry.target_kind entry.target_id then acc + 1 else acc)
+      s.queue 0
+  in
+  let has_unresolved =
+    match Hashtbl.find_opt s.unresolved_by_target (target_key target_kind target_id) with
+    | None -> false
+    | Some entry_id -> (
+        match Hashtbl.find_opt s.queue entry_id with
+        | Some entry when not entry.resolved -> true
+        | _ -> false)
+  in
+  let moderation_status =
+    if has_unresolved then
+      "flagged"
+    else
+      match
+        !(s.audit)
+        |> List.filter
+             (fun (entry : audit_entry) ->
+                matches_target entry.target_kind entry.target_id)
+        |> List.sort (fun a b -> Float.compare b.acted_at a.acted_at)
+      with
+      | [] -> "none"
+      | entry :: _ -> moderation_status_of_action entry.action
+  in
+  { report_count; moderation_status }
 
 (** {1 JSON projection} *)
 

--- a/lib/board_moderation.mli
+++ b/lib/board_moderation.mli
@@ -96,6 +96,16 @@ type audit_entry = {
   acted_at : float;
 }
 
+(** {1 Target projection — board/dashboard summary} *)
+
+type target_summary = {
+  report_count : int;
+      (** Number of flag queue entries ever recorded for this target. *)
+  moderation_status : string;
+      (** Operator-facing status. One of ["none"], ["flagged"],
+          ["approved"], ["removed"], ["hidden"], or ["warned"]. *)
+}
+
 (** {1 Store lifecycle} *)
 
 val init : unit -> unit
@@ -153,6 +163,14 @@ val get_audit_trail :
     Optional filters: [~target_id] restricts to one content item;
     [~actor] restricts to one operator. [~limit] caps the result
     (default 100, max 500). *)
+
+val target_summary :
+  target_kind:target_kind ->
+  target_id:string ->
+  target_summary
+(** Return the board/dashboard moderation projection for a post or comment.
+    An unresolved queue entry wins over older audit decisions, so a re-flagged
+    target reports ["flagged"] until an operator action resolves it. *)
 
 (** {1 JSON serialisation — dashboard API projection} *)
 

--- a/lib/server/server_utils.ml
+++ b/lib/server/server_utils.ml
@@ -188,19 +188,30 @@ let board_reaction_fields = function
   | Some summaries ->
       [ ("reactions", `List (List.map Board.reaction_summary_to_yojson summaries)) ]
 
+let board_moderation_fields ~target_kind ~target_id =
+  let summary = Board_moderation.target_summary ~target_kind ~target_id in
+  [
+    ("report_count", `Int summary.Board_moderation.report_count);
+    ("moderation_status", `String summary.Board_moderation.moderation_status);
+  ]
+
 let board_comment_dashboard_json ?current_vote ?reactions (c : Board.comment) : Yojson.Safe.t =
   let author = Board.Agent_id.to_string c.author in
+  let comment_id = Board.Comment_id.to_string c.id in
   match Board.comment_to_yojson c with
   | `Assoc fields ->
       `Assoc
         (fields
          @ [ ("author_identity", board_actor_identity_json author) ]
+         @ board_moderation_fields ~target_kind:Board_moderation.Target_comment
+             ~target_id:comment_id
          @ board_vote_state_fields current_vote
          @ board_reaction_fields reactions)
   | other -> other
 
 let board_post_dashboard_json ?current_vote ?reactions ~author_karma (p : Board.post) : Yojson.Safe.t =
   let author = Board.Agent_id.to_string p.author in
+  let post_id = Board.Post_id.to_string p.id in
   let base_fields =
     match Board_dispatch.post_to_yojson_with_karma p ~author_karma with
     | `Assoc fields -> fields
@@ -228,6 +239,8 @@ let board_post_dashboard_json ?current_vote ?reactions ~author_karma (p : Board.
           ("hearth_count", `Int (match p.hearth with Some _ -> 1 | None -> 0));
           ("author_identity", board_actor_identity_json author);
         ]
+      @ board_moderation_fields ~target_kind:Board_moderation.Target_post
+          ~target_id:post_id
       @ board_vote_state_fields current_vote
       @ board_reaction_fields reactions )
 

--- a/lib/server/server_utils.mli
+++ b/lib/server/server_utils.mli
@@ -179,8 +179,8 @@ val board_comment_dashboard_json :
   Board.comment ->
   Yojson.Safe.t
 (** [board_comment_dashboard_json c] renders a comment with the
-    [author_identity] field appended via
-    {!board_actor_identity_json}. *)
+    [author_identity], [report_count], and [moderation_status] fields
+    appended for dashboard inspection. *)
 
 val board_post_dashboard_json :
   ?current_vote:Board.vote_direction option ->
@@ -199,6 +199,7 @@ val board_post_dashboard_json :
     - [hearth_count] = 0 or 1 (boolean-as-int for the dashboard's
       column that aggregates across multiple hearths).
     - [author_identity] from {!board_actor_identity_json}.
+    - [report_count] / [moderation_status] from {!Board_moderation}.
 
     The base fields [title] / [votes] / [comment_count] /
     [created_at_iso] / [updated_at_iso] / [hearth_count] are

--- a/test/test_board_moderation.ml
+++ b/test/test_board_moderation.ml
@@ -7,6 +7,7 @@
     - resolve_entry: happy path and not-found error
     - record_action: happy path, note capping, auto-resolve of queue entry
     - get_audit_trail: actor/target filters and limit cap
+    - target_summary: report count and moderation status projection
     - JSON projection shapes for queue_entry_to_json and audit_entry_to_json
 *)
 
@@ -347,6 +348,65 @@ let test_audit_trail_limit () =
   let limited = BM.get_audit_trail ~limit:3 () in
   check int "limit=3 returns 3" 3 (List.length limited)
 
+(* ── target_summary ─────────────────────────────────────────────── *)
+
+let test_target_summary_none () =
+  reset ();
+  let summary =
+    BM.target_summary ~target_kind:BM.Target_post ~target_id:"summary-none"
+  in
+  check int "no reports" 0 summary.BM.report_count;
+  check string "status none" "none" summary.BM.moderation_status
+
+let test_target_summary_flagged () =
+  reset ();
+  (match BM.flag ~target_kind:BM.Target_comment ~target_id:"summary-flagged"
+           ~reporter:"reporter" ~reason:BM.Harassment with
+   | Ok _ -> ()
+   | Error m -> fail m);
+  let summary =
+    BM.target_summary ~target_kind:BM.Target_comment ~target_id:"summary-flagged"
+  in
+  check int "one report" 1 summary.BM.report_count;
+  check string "status flagged" "flagged" summary.BM.moderation_status
+
+let test_target_summary_action_status () =
+  reset ();
+  (match BM.flag ~target_kind:BM.Target_post ~target_id:"summary-hidden"
+           ~reporter:"reporter" ~reason:BM.Spam with
+   | Ok _ -> ()
+   | Error m -> fail m);
+  (match BM.record_action ~target_kind:BM.Target_post ~target_id:"summary-hidden"
+           ~actor:"operator" ~action:BM.Hide () with
+   | Ok _ -> ()
+   | Error m -> fail m);
+  let summary =
+    BM.target_summary ~target_kind:BM.Target_post ~target_id:"summary-hidden"
+  in
+  check int "report retained after action" 1 summary.BM.report_count;
+  check string "status hidden" "hidden" summary.BM.moderation_status
+
+let test_target_summary_reflagged_wins_over_audit () =
+  reset ();
+  with_flag_rate_limit "0" (fun () ->
+    (match BM.flag ~target_kind:BM.Target_post ~target_id:"summary-reflag"
+             ~reporter:"reporter-a" ~reason:BM.Spam with
+     | Ok _ -> ()
+     | Error m -> fail m);
+    (match BM.record_action ~target_kind:BM.Target_post ~target_id:"summary-reflag"
+             ~actor:"operator" ~action:BM.Approve () with
+     | Ok _ -> ()
+     | Error m -> fail m);
+    (match BM.flag ~target_kind:BM.Target_post ~target_id:"summary-reflag"
+             ~reporter:"reporter-b" ~reason:BM.Harassment with
+     | Ok _ -> ()
+     | Error m -> fail m);
+    let summary =
+      BM.target_summary ~target_kind:BM.Target_post ~target_id:"summary-reflag"
+    in
+    check int "two reports" 2 summary.BM.report_count;
+    check string "unresolved reflag wins" "flagged" summary.BM.moderation_status)
+
 (* ── JSON projections ────────────────────────────────────────────── *)
 
 let test_queue_entry_to_json () =
@@ -452,6 +512,12 @@ let () =
         [ test_case "actor filter"           `Quick test_audit_trail_actor_filter;
           test_case "target filter"          `Quick test_audit_trail_target_filter;
           test_case "limit cap"              `Quick test_audit_trail_limit ] );
+      ( "target_summary",
+        [ test_case "none"                   `Quick test_target_summary_none;
+          test_case "flagged"                `Quick test_target_summary_flagged;
+          test_case "action status"          `Quick test_target_summary_action_status;
+          test_case "reflag wins over audit" `Quick
+            test_target_summary_reflagged_wins_over_audit ] );
       ( "json_projection",
         [ test_case "queue_entry shape"      `Quick test_queue_entry_to_json;
           test_case "audit_entry shape"      `Quick test_audit_entry_to_json;

--- a/test/test_tool_board_coverage.ml
+++ b/test/test_tool_board_coverage.ml
@@ -31,6 +31,7 @@ let cleanup () =
   Board.reset_global_for_test ();
   Board_dispatch.reset_for_test ();
   Board_curation.reset_for_test ();
+  Board_moderation.reset_for_test ();
   remove_path (Filename.concat _test_base_path Common.masc_dirname);
   Board_dispatch.init_jsonl ()
 
@@ -270,6 +271,54 @@ let test_board_dashboard_json_embeds_reaction_summaries () =
     (json_member_string comment_summary "emoji");
   Alcotest.(check bool) "comment reaction selected" true
     (json_member_bool comment_summary "has_reacted")
+
+let test_board_dashboard_json_embeds_moderation_projection () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  cleanup ();
+  let post =
+    match
+      Board_dispatch.create_post ~author:"moderated-author"
+        ~content:"moderation projection post" ~post_kind:Board.Human_post ()
+    with
+    | Ok post -> post
+    | Error e -> Alcotest.fail (Board.show_board_error e)
+  in
+  let post_id = Board.Post_id.to_string post.id in
+  let comment =
+    match
+      Board_dispatch.add_comment ~post_id ~author:"moderated-commenter"
+        ~content:"moderation projection comment" ()
+    with
+    | Ok comment -> comment
+    | Error e -> Alcotest.fail (Board.show_board_error e)
+  in
+  let comment_id = Board.Comment_id.to_string comment.id in
+  (match
+     Board_moderation.flag ~target_kind:Board_moderation.Target_post
+       ~target_id:post_id ~reporter:"reporter-a" ~reason:Board_moderation.Spam
+   with
+   | Ok _ -> ()
+   | Error e -> Alcotest.fail e);
+  (match
+     Board_moderation.flag ~target_kind:Board_moderation.Target_comment
+       ~target_id:comment_id ~reporter:"reporter-b"
+       ~reason:Board_moderation.Harassment
+   with
+   | Ok _ -> ()
+   | Error e -> Alcotest.fail e);
+  let post_json =
+    Server_utils.board_post_dashboard_json ~author_karma:0 post
+  in
+  let comment_json = Server_utils.board_comment_dashboard_json comment in
+  Alcotest.(check int) "post report count" 1
+    (json_member_int post_json "report_count");
+  Alcotest.(check string) "post moderation status" "flagged"
+    (json_member_string post_json "moderation_status");
+  Alcotest.(check int) "comment report count" 1
+    (json_member_int comment_json "report_count");
+  Alcotest.(check string) "comment moderation status" "flagged"
+    (json_member_string comment_json "moderation_status")
 
 let test_inline_board_post_author_rewrites_caller_claim () =
   let args =
@@ -1346,6 +1395,8 @@ let () =
             `Quick test_board_actor_identity_keeps_non_keeper_agent;
           Alcotest.test_case "board dashboard json embeds reaction summaries"
             `Quick test_board_dashboard_json_embeds_reaction_summaries;
+          Alcotest.test_case "board dashboard json embeds moderation projection"
+            `Quick test_board_dashboard_json_embeds_moderation_projection;
           Alcotest.test_case "inline board post author rewrites caller claim"
             `Quick test_inline_board_post_author_rewrites_caller_claim;
           Alcotest.test_case "inline board post author accepts matching alias"


### PR DESCRIPTION
## Summary

Adds the Phase 2 board moderation projection to the board/dashboard data path:

- `Board_moderation.target_summary` now exposes per-target `report_count` and `moderation_status`.
- Dashboard board post/comment JSON includes those fields for `/api/v1/board` and post detail responses.
- Dashboard types/normalizers preserve the fields and render compact moderation badges on board cards, post detail, and comment threads.

## Why it matters

Operators can now see whether a post or comment has been flagged, approved, hidden, removed, or warned without jumping into the moderation queue API. This closes the projection gap between the moderation backend and the dashboard board surface.

## Validation

- `pnpm exec tsc --noEmit --pretty`
- `pnpm exec vitest run --config vitest.config.ts src/api/board.test.ts src/components/board/board-surface.test.ts src/components/board/post-detail.test.ts --no-file-parallelism --maxWorkers=1` (123 tests)
- `pnpm exec eslint src/api/board.ts src/api/board.test.ts src/types/core.ts src/components/board/board-surface.ts src/components/board/board-surface.test.ts src/components/board/post-detail.ts src/components/board/post-detail.test.ts src/components/board/moderation-badge.ts` (0 errors; existing ignored-file warnings for api/types entries)
- `ocamlc -stop-after parsing` on changed OCaml impl/intf/test files
- `git diff --check HEAD~1..HEAD`
- `scripts/check-oas-pin.sh --local-only`

Note: `scripts/dune-local.sh build test/test_board_moderation.exe test/test_tool_board_coverage.exe` was attempted. The first run reached OCaml compilation and surfaced two compatibility issues, which this PR fixed. The final rerun was blocked by `/tmp/me-opam-switch.lock` contention from other active worktrees, so CI should be the full OCaml build gate here.