### PR TITLE
fix: emit keeper observe metrics

### DIFF
--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -1944,6 +1944,18 @@ let alive_but_stuck_threshold ~stall_multiplier ~stall_floor_sec
     (float_of_int entry.meta.proactive.cooldown_sec
      *. float_of_int stall_multiplier)
 
+let set_alive_but_stuck_gauges ~(entry : Keeper_registry.registry_entry)
+    ~threshold ~elapsed =
+  let labels = [("keeper_name", entry.name)] in
+  Prometheus.set_gauge
+    Prometheus.metric_keeper_alive_but_stuck_seconds
+    ~labels
+    (Option.value elapsed ~default:0.0);
+  Prometheus.set_gauge
+    Prometheus.metric_keeper_alive_but_stuck_threshold_seconds
+    ~labels
+    threshold
+
 let alive_but_stuck_recovery_stimulus ~now ~elapsed ~threshold
     (entry : Keeper_registry.registry_entry) : Keeper_event_queue.stimulus =
   let payload =
@@ -2068,15 +2080,17 @@ let alive_but_stuck_scan (ctx : _ context) =
     let entries = Keeper_registry.all ~base_path () in
     let abs_ym = Eio_guard.create_yield_meter () in
     List.iter (fun (entry : Keeper_registry.registry_entry) ->
-      (match
+      let threshold =
+        alive_but_stuck_threshold ~stall_multiplier ~stall_floor_sec entry
+      in
+      let elapsed =
         detect_alive_but_stuck ~now ~stall_multiplier ~stall_floor_sec entry
-      with
+      in
+      set_alive_but_stuck_gauges ~entry ~threshold ~elapsed;
+      (match elapsed with
       | None -> ()
       | Some elapsed ->
         if alive_but_stuck_should_emit ~now ~dedup_ttl_sec entry.name then begin
-          let threshold =
-            alive_but_stuck_threshold ~stall_multiplier ~stall_floor_sec entry
-          in
           let recovery =
             queue_alive_but_stuck_recovery ~base_path ~now ~elapsed
               ~threshold entry

--- a/lib/keeper/keeper_turn_livelock.ml
+++ b/lib/keeper/keeper_turn_livelock.ml
@@ -78,6 +78,9 @@ let record_started_metrics ~keeper outcome =
   Prometheus.inc_counter
     Prometheus.metric_keeper_turn_starts
     ~labels:[ ("keeper", keeper) ] ();
+  Prometheus.inc_counter
+    Prometheus.metric_keeper_turn_scheduled
+    ~labels:[ ("keeper_name", keeper) ] ();
   (match outcome with
    | Fresh -> ()
    | Reattempt _ ->

--- a/lib/keeper/keeper_unified_metrics.ml
+++ b/lib/keeper/keeper_unified_metrics.ml
@@ -1380,6 +1380,10 @@ let append_metrics_snapshot ~(config : Coord.config) ~(meta : keeper_meta)
     ~resolved_model_id
     ~cascade_profile
     ~latency_ms;
+  Prometheus.inc_counter
+    Prometheus.metric_keeper_turn_completed
+    ~labels:[("keeper_name", meta.name)]
+    ();
   let snapshot =
     `Assoc
       [

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -233,6 +233,10 @@ let metric_keeper_usage_anomalies =
   "masc_keeper_usage_anomalies_total"
 let metric_keeper_total_cost_usd =
   "masc_keeper_total_cost_usd"
+let metric_keeper_turn_scheduled =
+  "masc_keeper_turn_scheduled_total"
+let metric_keeper_turn_completed =
+  "masc_keeper_turn_completed_total"
 
 (** #10530: keeper required-tool-contract violations (passive-only or
     text-only turns rejected by the keeper agent loop).
@@ -248,6 +252,10 @@ let metric_keeper_contract_violations =
     Labels: keeper. *)
 let metric_keeper_alive_but_stuck =
   "masc_keeper_alive_but_stuck_total"
+let metric_keeper_alive_but_stuck_seconds =
+  "masc_keeper_alive_but_stuck_seconds"
+let metric_keeper_alive_but_stuck_threshold_seconds =
+  "masc_keeper_alive_but_stuck_threshold_seconds"
 
 (** #12838 follow-up: supervisor recovery requests emitted after an
     alive-but-stuck detection.  Each increment means the supervisor set
@@ -2101,6 +2109,13 @@ let init () =
   add metric_keeper_turns
     "Total keeper turns by outcome (labels: keeper_name, outcome=success|failure|budget_exhausted|mutation_boundary)"
     Counter;
+  add metric_keeper_turn_scheduled
+    "Total keeper turns accepted for dispatch by keeper_name."
+    Counter;
+  add metric_keeper_turn_completed
+    "Total keeper turns that completed and emitted a metrics snapshot by \
+     keeper_name."
+    Counter;
   add metric_keeper_input_tokens
     "Cumulative input tokens per keeper turn (labels: keeper_name, model)"
     Counter;
@@ -2135,6 +2150,13 @@ let init () =
      keepalive-running, but proactive_rt.last_ts has been frozen while \
      autonomous turns kept advancing. Labels: keeper."
     Counter;
+  add metric_keeper_alive_but_stuck_seconds
+    "Current alive-but-stuck elapsed seconds by keeper_name. Set to 0 when \
+     the keeper is not currently detected as alive-but-stuck."
+    Gauge;
+  add metric_keeper_alive_but_stuck_threshold_seconds
+    "Current alive-but-stuck detector threshold seconds by keeper_name."
+    Gauge;
   add metric_keeper_alive_but_stuck_recovery
     "Bounded recovery wakeups queued by alive_but_stuck_scan. \
      Labels: keeper, outcome."

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -75,6 +75,11 @@ val metric_keeper_cache_creation_tokens : string
 val metric_keeper_cache_read_tokens : string
 val metric_keeper_usage_anomalies : string
 val metric_keeper_total_cost_usd : string
+val metric_keeper_turn_scheduled : string
+(** Goal-loop Observe turn-success denominator. Labels: [keeper_name]. *)
+
+val metric_keeper_turn_completed : string
+(** Goal-loop Observe turn-success numerator. Labels: [keeper_name]. *)
 
 (** #10530: keeper required-tool-contract violations.
     Labels: keeper_name, kind \in \{passive,text_only\}. *)
@@ -83,6 +88,12 @@ val metric_keeper_contract_violations : string
 (** #12838: keepers detected as alive-but-stuck.  Bounded to one
     increment per dedup window per keeper. Labels: keeper. *)
 val metric_keeper_alive_but_stuck : string
+
+val metric_keeper_alive_but_stuck_seconds : string
+(** Current alive-but-stuck elapsed seconds. Labels: [keeper_name]. *)
+
+val metric_keeper_alive_but_stuck_threshold_seconds : string
+(** Alive-but-stuck detector threshold seconds. Labels: [keeper_name]. *)
 
 (** #12838 follow-up: alive-but-stuck recovery requests.  Each increment
     means the supervisor requested a supervised restart via

--- a/test/test_keeper_supervisor.ml
+++ b/test/test_keeper_supervisor.ml
@@ -1822,6 +1822,23 @@ let () =
                   }
                 in
                 Sup.alive_but_stuck_scan ctx;
+                let labels = [("keeper_name", name)] in
+                let stuck_seconds =
+                  Masc_mcp.Prometheus.metric_value_or_zero
+                    Masc_mcp.Prometheus.metric_keeper_alive_but_stuck_seconds
+                    ~labels
+                    ()
+                in
+                let threshold_seconds =
+                  Masc_mcp.Prometheus.metric_value_or_zero
+                    Masc_mcp.Prometheus.metric_keeper_alive_but_stuck_threshold_seconds
+                    ~labels
+                    ()
+                in
+                check bool "alive-but-stuck seconds crosses threshold" true
+                  (stuck_seconds > threshold_seconds);
+                check bool "alive-but-stuck threshold exported" true
+                  (threshold_seconds > 0.0);
                 let queue =
                   Reg.event_queue_snapshot ~base_path:config.base_path name
                 in

--- a/test/test_keeper_turn_livelock_10121.ml
+++ b/test/test_keeper_turn_livelock_10121.ml
@@ -47,6 +47,10 @@ let starts_for ~keeper =
   Prom.metric_value_or_zero Prom.metric_keeper_turn_starts
     ~labels:[ ("keeper", keeper) ] ()
 
+let scheduled_for ~keeper =
+  Prom.metric_value_or_zero Prom.metric_keeper_turn_scheduled
+    ~labels:[ ("keeper_name", keeper) ] ()
+
 let reattempts_for ~keeper =
   Prom.metric_value_or_zero Prom.metric_keeper_turn_reattempts
     ~labels:[ ("keeper", keeper) ] ()
@@ -65,12 +69,16 @@ let test_fresh_first_start () =
   L.reset_for_tests ();
   let keeper = "test-keeper-fresh-10121" in
   let before_starts = starts_for ~keeper in
+  let before_scheduled = scheduled_for ~keeper in
   let before_reattempts = reattempts_for ~keeper in
   let outcome = L.record_turn_start ~keeper ~turn_id:1 in
   Alcotest.(check bool) "outcome is Fresh" true (outcome = L.Fresh);
   Alcotest.(check (float 0.0001))
     "starts +1"
     (before_starts +. 1.0) (starts_for ~keeper);
+  Alcotest.(check (float 0.0001))
+    "scheduled +1"
+    (before_scheduled +. 1.0) (scheduled_for ~keeper);
   Alcotest.(check (float 0.0001))
     "reattempts unchanged"
     before_reattempts (reattempts_for ~keeper)

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -3080,6 +3080,12 @@ let test_append_metrics_snapshot_includes_cascade_observation () =
         KD.baseline_execution_result
           (KD.empty_world_observation ~keeper_name:minimal_meta.name)
       in
+      let completed_before =
+        Masc_mcp.Prometheus.metric_value_or_zero
+          Masc_mcp.Prometheus.metric_keeper_turn_completed
+          ~labels:[("keeper_name", minimal_meta.name)]
+          ()
+      in
       UM.append_metrics_snapshot
         ~config
         ~meta:minimal_meta
@@ -3108,6 +3114,15 @@ let test_append_metrics_snapshot_includes_cascade_observation () =
         ~handoff_json:None
         ~deliberation_execution
         ();
+      let completed_after =
+        Masc_mcp.Prometheus.metric_value_or_zero
+          Masc_mcp.Prometheus.metric_keeper_turn_completed
+          ~labels:[("keeper_name", minimal_meta.name)]
+          ()
+      in
+      check (float 0.0001) "turn completed counter increments"
+        (completed_before +. 1.0)
+        completed_after;
       let metrics_store =
         Masc_mcp.Keeper_types.keeper_metrics_store config minimal_meta.name
       in


### PR DESCRIPTION
## Summary
- Add the goal-loop Observe turn-success counters `masc_keeper_turn_scheduled_total` and `masc_keeper_turn_completed_total`.
- Increment scheduled turns from the existing keeper turn-start/livelock gate, using the contract label `keeper_name`.
- Increment completed turns when a successful keeper metrics snapshot is emitted.
- Add `masc_keeper_alive_but_stuck_seconds` and `masc_keeper_alive_but_stuck_threshold_seconds` gauges from the existing `alive_but_stuck_scan` path.
- Set alive-but-stuck elapsed seconds to `0` when a scanned keeper is not currently detected as stuck, so stale stuck values are cleared.

## Why
The goal-loop Observe contract, alerts, and Grafana dashboard already query keeper turn success-rate counters and alive-but-stuck elapsed/threshold gauges. Runtime had adjacent older counters and one-shot detection counters, but these exact Observe signals could be absent or stale even though the keeper lifecycle already computed the source data.

## Operator impact
Operators can now alert on keeper turn success rate and current alive-but-stuck ratio directly from runtime state. Existing legacy counters and labels remain unchanged; the new contract series use `keeper_name` where the dashboard expects it.

## Validation
- `git diff --check`
- `env MASC_SKIP_OPAM_LOCK=1 DUNE_JOBS=1 DUNE_CACHE=disabled scripts/dune-local.sh build test/test_keeper_supervisor.exe`
- `./_build/default/test/test_keeper_supervisor.exe` (68 tests)
- `env MASC_SKIP_OPAM_LOCK=1 DUNE_JOBS=1 DUNE_CACHE=disabled scripts/dune-local.sh build test/test_keeper_turn_livelock_10121.exe test/test_keeper_unified.exe`
- `./_build/default/test/test_keeper_turn_livelock_10121.exe` (10 tests)
- `./_build/default/test/test_keeper_unified.exe test metrics_observation 17` (1 targeted test)

## Note
A full `./_build/default/test/test_keeper_unified.exe` run still fails in the unrelated `world_observation.007` case (`auto-goal fallback claimable backlog`: expected 1, got 0). The targeted metrics snapshot case touched by this PR passes.