### PR TITLE
fix(oas): aggregate inference telemetry

### DIFF
--- a/lib/oas_event_bridge.ml
+++ b/lib/oas_event_bridge.ml
@@ -41,20 +41,11 @@ let payload_int_opt key = function
       | _ -> None)
   | _ -> None
 
-let string_contains haystack needle =
-  let haystack_len = String.length haystack in
-  let needle_len = String.length needle in
-  let rec loop index =
-    if needle_len = 0 then true
-    else if index + needle_len > haystack_len then false
-    else if String.sub haystack index needle_len = needle then true
-    else loop (index + 1)
-  in
-  loop 0
-
 let inference_model_bucket ~provider ~model =
-  let text = String.lowercase_ascii (provider ^ " " ^ model) in
-  let has needle = string_contains text needle in
+  let has needle =
+    String_util.contains_substring_ci provider needle
+    || String_util.contains_substring_ci model needle
+  in
   if has "kimi" then "kimi"
   else if has "claude" || has "anthropic" then "anthropic"
   else if has "openai" || has "gpt" || has "codex" then "openai"

--- a/lib/oas_event_bridge.ml
+++ b/lib/oas_event_bridge.ml
@@ -41,6 +41,92 @@ let payload_int_opt key = function
       | _ -> None)
   | _ -> None
 
+let string_contains haystack needle =
+  let haystack_len = String.length haystack in
+  let needle_len = String.length needle in
+  let rec loop index =
+    if needle_len = 0 then true
+    else if index + needle_len > haystack_len then false
+    else if String.sub haystack index needle_len = needle then true
+    else loop (index + 1)
+  in
+  loop 0
+
+let inference_model_bucket ~provider ~model =
+  let text = String.lowercase_ascii (provider ^ " " ^ model) in
+  let has needle = string_contains text needle in
+  if has "kimi" then "kimi"
+  else if has "claude" || has "anthropic" then "anthropic"
+  else if has "openai" || has "gpt" || has "codex" then "openai"
+  else if has "gemini" || has "google" then "gemini"
+  else if has "glm" || has "zai" then "glm"
+  else if has "qwen" then "qwen"
+  else if has "llama" then "llama"
+  else "other"
+
+let inference_token_bucket = function
+  | None -> "missing"
+  | Some tokens when tokens <= 0 -> "0"
+  | Some tokens when tokens <= 1024 -> "1_1k"
+  | Some tokens when tokens <= 8192 -> "1k_8k"
+  | Some _ -> "over_8k"
+
+let positive_finite value =
+  value > 0.0
+  && match classify_float value with
+  | FP_nan | FP_infinite -> false
+  | FP_normal | FP_subnormal | FP_zero -> true
+
+let observe_inference_tokens ~model_bucket ~phase tokens =
+  let labels =
+    [
+      ("model_bucket", model_bucket);
+      ("phase", phase);
+      ("token_bucket", inference_token_bucket tokens);
+    ]
+  in
+  let value =
+    match tokens with
+    | Some tokens when tokens > 0 -> float_of_int tokens
+    | _ -> 0.0
+  in
+  Prometheus.observe_histogram Prometheus.metric_oas_inference_telemetry_tokens
+    ~labels value
+
+let tok_per_sec_from_ms ~tokens ~ms =
+  match (tokens, ms) with
+  | Some tokens, Some ms when tokens > 0 && positive_finite ms ->
+      Some (float_of_int tokens /. (ms /. 1000.0))
+  | _ -> None
+
+let observe_inference_rate metric ~model_bucket = function
+  | Some rate when positive_finite rate ->
+      Prometheus.observe_histogram metric
+        ~labels:[ ("model_bucket", model_bucket) ]
+        rate
+  | _ -> ()
+
+let observe_inference_telemetry ~provider ~model ~prompt_tokens
+    ~completion_tokens ~prompt_ms ~decode_ms ~decode_tok_s =
+  let model_bucket =
+    inference_model_bucket ~provider ~model
+  in
+  observe_inference_tokens ~model_bucket ~phase:"prompt"
+    prompt_tokens;
+  observe_inference_tokens ~model_bucket ~phase:"completion"
+    completion_tokens;
+  observe_inference_rate Prometheus.metric_oas_inference_prompt_tok_per_sec
+    ~model_bucket
+    (tok_per_sec_from_ms ~tokens:prompt_tokens ~ms:prompt_ms);
+  let decode_tok_s =
+    match decode_tok_s with
+    | Some rate when positive_finite rate -> Some rate
+    | _ ->
+        tok_per_sec_from_ms ~tokens:completion_tokens ~ms:decode_ms
+  in
+  observe_inference_rate Prometheus.metric_oas_inference_decode_tok_per_sec
+    ~model_bucket decode_tok_s
+
 let stop_reason_to_wire = function
   | Agent_sdk.Types.EndTurn -> "end_turn"
   | Agent_sdk.Types.StopToolUse -> "tool_use"
@@ -413,11 +499,23 @@ let native_event_to_json (evt : Agent_sdk.Event_bus.event) : Yojson.Safe.t optio
            ?turn:(payload_int_opt "turn" payload)
            ?tool_name:(payload_string_opt "tool_name" payload)
            ())
-  | Agent_sdk.Event_bus.InferenceTelemetry _ ->
-      (* Per-token telemetry from OAS#1202; not surfaced over SSE — the
-         dashboard receives token usage via the existing AgentCompleted
-         payload aggregate. Skip the relay to avoid flooding SSE
-         consumers with high-frequency low-value events. *)
+  | Agent_sdk.Event_bus.InferenceTelemetry
+      {
+        provider;
+        model;
+        prompt_tokens;
+        completion_tokens;
+        prompt_ms;
+        decode_ms;
+        decode_tok_s;
+        _;
+      } ->
+      (* Per-token telemetry from OAS#1202; not surfaced over SSE. Preserve
+         the aggregate signal with bounded Prometheus labels so operators can
+         see model-family/token-bin trends without flooding SSE consumers or
+         creating raw-model cardinality. *)
+      observe_inference_telemetry ~provider ~model ~prompt_tokens
+        ~completion_tokens ~prompt_ms ~decode_ms ~decode_tok_s;
       None
   | other ->
       (* Graceful fallback for OAS variants that ship before this consumer

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -807,6 +807,12 @@ let metric_oas_sse_relay_drops =
   "masc_oas_sse_relay_drops_total"
 let metric_oas_sse_relay_queue_depth =
   "masc_oas_sse_relay_queue_depth"
+let metric_oas_inference_telemetry_tokens =
+  "masc_oas_inference_telemetry_tokens"
+let metric_oas_inference_prompt_tok_per_sec =
+  "masc_oas_inference_prompt_tok_per_sec"
+let metric_oas_inference_decode_tok_per_sec =
+  "masc_oas_inference_decode_tok_per_sec"
 
 (* MCP tool schema budget (set once at boot from mcp_server_eio.ml
    via [set_tool_schema_stats]). *)
@@ -1325,6 +1331,16 @@ let init () =
     "AfterTurn responses where response.telemetry was None." Counter;
   add metric_after_turn_telemetry_zero_latency
     "AfterTurn responses where telemetry was present but request_latency_ms was 0." Counter;
+  add metric_oas_inference_telemetry_tokens
+    "OAS InferenceTelemetry token histogram for events suppressed from SSE. \
+     Labels are bounded to model_bucket, phase, and token_bucket; max token \
+     histogram cardinality is 8 * 2 * 5 = 80 labelled series." Histogram;
+  add metric_oas_inference_prompt_tok_per_sec
+    "OAS InferenceTelemetry prompt throughput histogram for events suppressed \
+     from SSE. Labelled only by bounded model_bucket." Histogram;
+  add metric_oas_inference_decode_tok_per_sec
+    "OAS InferenceTelemetry decode throughput histogram for events suppressed \
+     from SSE. Labelled only by bounded model_bucket." Histogram;
   add metric_tasks "Total tasks processed" Counter;
   add metric_errors "Total errors" Counter;
   add metric_error_events

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -453,6 +453,20 @@ val metric_oas_bridge_cancel : string
 val metric_oas_sse_relay_retries : string
 val metric_oas_sse_relay_drops : string
 val metric_oas_sse_relay_queue_depth : string
+(** Histogram populated from OAS [InferenceTelemetry] events that are
+    intentionally not relayed over SSE. Labels: [model_bucket], [phase],
+    and [token_bucket]. Cardinality bound: 8 model buckets * 2 phases *
+    5 token buckets = 80 labelled series. *)
+val metric_oas_inference_telemetry_tokens : string
+
+(** Histogram populated from OAS [InferenceTelemetry.prompt_ms] and
+    [prompt_tokens]. Labels: [model_bucket] only. *)
+val metric_oas_inference_prompt_tok_per_sec : string
+
+(** Histogram populated from OAS [InferenceTelemetry.decode_tok_s] or
+    [decode_ms] plus [completion_tokens]. Labels: [model_bucket] only. *)
+val metric_oas_inference_decode_tok_per_sec : string
+
 val metric_mcp_tool_schema_count : string
 val metric_mcp_tool_schema_tokens_approx : string
 

--- a/test/test_oas_integration.ml
+++ b/test/test_oas_integration.ml
@@ -866,7 +866,46 @@ let test_oas_event_bridge_logs_tool_completed_with_agent_name () =
    relaying per-token telemetry over SSE (high-frequency flood path that
    was deliberately suppressed in #10590).  Pin both invariants. *)
 
-let test_inference_telemetry_stays_none_after_fallback () =
+let inference_token_labels ~model_bucket ~phase ~token_bucket =
+  [
+    ("model_bucket", model_bucket);
+    ("phase", phase);
+    ("token_bucket", token_bucket);
+  ]
+
+let test_inference_telemetry_aggregates_without_sse_relay () =
+  let prompt_labels =
+    inference_token_labels ~model_bucket:"openai" ~phase:"prompt"
+      ~token_bucket:"1_1k"
+  in
+  let completion_labels =
+    inference_token_labels ~model_bucket:"openai" ~phase:"completion"
+      ~token_bucket:"over_8k"
+  in
+  let rate_labels = [ ("model_bucket", "openai") ] in
+  let token_metric = Prometheus.metric_oas_inference_telemetry_tokens in
+  let prompt_rate_metric = Prometheus.metric_oas_inference_prompt_tok_per_sec in
+  let decode_rate_metric = Prometheus.metric_oas_inference_decode_tok_per_sec in
+  let before_prompt_tokens =
+    Prometheus.metric_value_or_zero token_metric ~labels:prompt_labels ()
+  in
+  let before_prompt_count =
+    Prometheus.metric_value_or_zero (token_metric ^ "_count")
+      ~labels:prompt_labels ()
+  in
+  let before_completion_tokens =
+    Prometheus.metric_value_or_zero token_metric ~labels:completion_labels ()
+  in
+  let before_prompt_rate =
+    Prometheus.metric_value_or_zero prompt_rate_metric ~labels:rate_labels ()
+  in
+  let before_decode_rate =
+    Prometheus.metric_value_or_zero decode_rate_metric ~labels:rate_labels ()
+  in
+  let before_decode_count =
+    Prometheus.metric_value_or_zero (decode_rate_metric ^ "_count")
+      ~labels:rate_labels ()
+  in
   let evt : Event_bus.event =
     Event_bus.mk_event
       ~correlation_id:"test-corr"
@@ -875,21 +914,47 @@ let test_inference_telemetry_stays_none_after_fallback () =
          {
            agent_name = "test-agent";
            turn = 1;
-           provider = "test-provider";
-           model = "test-model";
+           provider = "openai";
+           model = "gpt-5";
            prompt_tokens = Some 10;
-           completion_tokens = Some 20;
+           completion_tokens = Some 9000;
            prompt_ms = Some 5.0;
            decode_ms = Some 50.0;
            decode_tok_s = Some 100.0;
          })
   in
-  match Oas_event_bridge.native_event_to_json evt with
-  | None -> ()
-  | Some _ ->
-      Alcotest.fail
-        "InferenceTelemetry must remain None — catch-all fallback \
-         must not absorb the high-frequency suppression case"
+  (match Oas_event_bridge.native_event_to_json evt with
+   | None -> ()
+   | Some _ ->
+       Alcotest.fail
+         "InferenceTelemetry must remain None — catch-all fallback \
+          must not absorb the high-frequency suppression case");
+  Alcotest.(check (float 0.0001))
+    "prompt token histogram sum"
+    (before_prompt_tokens +. 10.0)
+    (Prometheus.metric_value_or_zero token_metric ~labels:prompt_labels ());
+  Alcotest.(check (float 0.0001))
+    "prompt token histogram count"
+    (before_prompt_count +. 1.0)
+    (Prometheus.metric_value_or_zero (token_metric ^ "_count")
+       ~labels:prompt_labels ());
+  Alcotest.(check (float 0.0001))
+    "completion token histogram sum"
+    (before_completion_tokens +. 9000.0)
+    (Prometheus.metric_value_or_zero token_metric ~labels:completion_labels ());
+  Alcotest.(check (float 0.0001))
+    "prompt throughput histogram sum"
+    (before_prompt_rate +. 2000.0)
+    (Prometheus.metric_value_or_zero prompt_rate_metric ~labels:rate_labels ());
+  Alcotest.(check (float 0.0001))
+    "decode throughput histogram sum"
+    (before_decode_rate +. 100.0)
+    (Prometheus.metric_value_or_zero decode_rate_metric ~labels:rate_labels ());
+  Alcotest.(check (float 0.0001))
+    "decode throughput histogram count"
+    (before_decode_count +. 1.0)
+    (Prometheus.metric_value_or_zero (decode_rate_metric ^ "_count")
+       ~labels:rate_labels ())
 
 let test_payload_kind_labels_match_envelope_event_type () =
   (* For the explicit-arm path, the [event_type] embedded in the wrap
@@ -960,8 +1025,9 @@ let () =
         test_oas_event_bridge_logs_turn_completed_with_agent_name;
       Alcotest.test_case "sse bridge logs tool completed with agent name" `Quick
         test_oas_event_bridge_logs_tool_completed_with_agent_name;
-      Alcotest.test_case "inference telemetry stays None after fallback added (#10584)" `Quick
-        test_inference_telemetry_stays_none_after_fallback;
+      Alcotest.test_case
+        "inference telemetry aggregates without sse relay (#10584)" `Quick
+        test_inference_telemetry_aggregates_without_sse_relay;
       Alcotest.test_case "payload_kind labels match wrap envelope event_type" `Quick
         test_payload_kind_labels_match_envelope_event_type;
     ];


### PR DESCRIPTION
## What changed

- Keeps OAS `InferenceTelemetry` suppressed from SSE, preserving the existing flood guard.
- Adds bounded Prometheus aggregation for suppressed telemetry:
  - `masc_oas_inference_telemetry_tokens` histogram labelled by `model_bucket`, `phase`, and `token_bucket`.
  - `masc_oas_inference_prompt_tok_per_sec` histogram labelled by `model_bucket`.
  - `masc_oas_inference_decode_tok_per_sec` histogram labelled by `model_bucket`.
- Buckets raw provider/model names into 8 model families, so the token histogram is bounded at `8 * 2 * 5 = 80` labelled series.
- Updates the bridge regression test so `InferenceTelemetry` still returns `None` while metrics are emitted.

## Why it matters

The Kimi audit flagged this path as a silent telemetry drop: the bridge intentionally avoided relaying high-frequency token events over SSE, but that also erased useful operator signal. This preserves the SSE behavior while making aggregate token and throughput trends visible in Prometheus without raw-model cardinality growth.

## Validation

- `git diff --check`
- `scripts/dune-local.sh build test/test_oas_integration.exe`
- `./_build/default/test/test_oas_integration.exe test oas_events 18`
- `./_build/default/test/test_oas_integration.exe`

Note: `ocamlformat --check` on the changed legacy files also exits 1 on clean `HEAD` with no output; I avoided applying formatter churn to whole files.