### PR TITLE
feat(dashboard): add rooms message feed

### DIFF
--- a/lib/dashboard/dashboard_rooms.ml
+++ b/lib/dashboard/dashboard_rooms.ml
@@ -45,23 +45,41 @@ let words s =
   take_word [] 0
 ;;
 
-let strip_target_punct s =
+let is_mention_punct = function
+  | ',' | ';' | ':' | '.' | '!' | '?'
+  | ')' | ']' | '}' | '>'
+  | '(' | '[' | '{' | '<'
+  | '"' | '\'' | '`' -> true
+  | _ -> false
+;;
+
+let strip_mention_punct s =
+  (* Strip both leading and trailing punctuation so common shapes like
+     "(@bob)", "@bob!", '"@bob"' resolve to the same target. The
+     previous helper trimmed only the trailing side and a smaller set
+     of characters, dropping otherwise-valid mentions or polluting
+     extracted targets with punctuation. *)
+  let len = String.length s in
+  let rec left i = if i < len && is_mention_punct s.[i] then left (i + 1) else i in
+  let lo = left 0 in
   let rec right i =
-    if i < 0
-    then ""
-    else (
-      match s.[i] with
-      | ',' | ';' | ':' | '.' | ')' | ']' -> right (i - 1)
-      | _ -> String.sub s 0 (i + 1))
+    if i < lo then lo - 1
+    else if is_mention_punct s.[i] then right (i - 1)
+    else i
   in
-  right (String.length s - 1)
+  let hi = right (len - 1) in
+  if hi < lo then "" else String.sub s lo (hi - lo + 1)
 ;;
 
 let mention_of_word word =
-  if String.length word <= 1 || word.[0] <> '@'
+  let trimmed_word = strip_mention_punct word in
+  if String.length trimmed_word <= 1 || trimmed_word.[0] <> '@'
   then None
   else (
-    let target = String.sub word 1 (String.length word - 1) |> strip_target_punct in
+    let target =
+      String.sub trimmed_word 1 (String.length trimmed_word - 1)
+      |> strip_mention_punct
+    in
     if target = "" then None else Some target)
 ;;
 
@@ -94,23 +112,28 @@ let is_room_message (msg : Masc_domain.message) =
 ;;
 
 let block_kind_of_message (msg : Masc_domain.message) =
+  (* Restrict block_kind to messages whose msg_type explicitly carries
+     a [state_block:<kind>] / [state-block:<kind>] discriminator. The
+     previous fall-through (`else Some lower`) surfaced operational
+     msg_types like "cache_invalidated" as block_kind, which clients
+     interpreted as a structural state-block name and rendered as a
+     fake panel. An empty suffix (e.g. "state_block:") returns None
+     too — a missing discriminator is no signal at all, not a
+     [block_kind: ""] field that downstream consumers cannot decode. *)
   let msg_type = String.trim msg.msg_type in
   let lower = String.lowercase_ascii msg_type in
-  if lower = "" || lower = "broadcast"
-  then None
-  else if String.starts_with ~prefix:"state_block:" lower
-  then
-    Some
-      (String.sub msg_type 12 (String.length msg_type - 12)
-       |> String.trim
-       |> String.lowercase_ascii)
-  else if String.starts_with ~prefix:"state-block:" lower
-  then
-    Some
-      (String.sub msg_type 12 (String.length msg_type - 12)
-       |> String.trim
-       |> String.lowercase_ascii)
-  else Some lower
+  let extract_suffix prefix =
+    let n = String.length prefix in
+    String.sub msg_type n (String.length msg_type - n)
+    |> String.trim
+    |> String.lowercase_ascii
+  in
+  let prefixes = [ "state_block:"; "state-block:" ] in
+  match List.find_opt (fun p -> String.starts_with ~prefix:p lower) prefixes with
+  | None -> None
+  | Some prefix ->
+    let suffix = extract_suffix prefix in
+    if suffix = "" then None else Some suffix
 ;;
 
 let message_json (msg : Masc_domain.message) =
@@ -166,7 +189,11 @@ let active_agent_names config =
   then []
   else (
     try
-      Coord.get_agents_raw config
+      (* Use [get_active_agents] (filtered to currently-active agents)
+         instead of [get_agents_raw] which also returned tombstones /
+         left agents. The function name and the rooms participants
+         contract both expect "active only". *)
+      Coord.get_active_agents config
       |> List.map (fun (agent : Masc_domain.agent) -> agent.name)
     with
     | Eio.Cancel.Cancelled _ as exn -> raise exn

--- a/lib/dashboard/dashboard_rooms.ml
+++ b/lib/dashboard/dashboard_rooms.ml
@@ -1,0 +1,218 @@
+let clamp ~min_v ~max_v value = max min_v (min max_v value)
+let clamp_limit limit = clamp ~min_v:1 ~max_v:200 limit
+let fetch_limit limit = clamp ~min_v:limit ~max_v:1000 (limit * 5)
+let default_room_id = "default"
+let default_room_name = "Room timeline"
+
+let take n xs =
+  let rec loop acc remaining = function
+    | [] -> List.rev acc
+    | _ when remaining <= 0 -> List.rev acc
+    | x :: rest -> loop (x :: acc) (remaining - 1) rest
+  in
+  loop [] n xs
+;;
+
+let decode_message_entities content =
+  content
+  |> String_util.replace_substring ~needle:"&quot;" ~by:"\""
+  |> String_util.replace_substring ~needle:"&#x27;" ~by:"'"
+  |> String_util.replace_substring ~needle:"&apos;" ~by:"'"
+  |> String_util.replace_substring ~needle:"&lt;" ~by:"<"
+  |> String_util.replace_substring ~needle:"&gt;" ~by:">"
+  |> String_util.replace_substring ~needle:"&amp;" ~by:"&"
+;;
+
+let is_space = function
+  | ' ' | '\t' | '\r' | '\n' -> true
+  | _ -> false
+;;
+
+let words s =
+  let len = String.length s in
+  let rec skip i = if i < len && is_space s.[i] then skip (i + 1) else i in
+  let rec take_word acc i =
+    let i = skip i in
+    if i >= len
+    then List.rev acc
+    else (
+      let j = ref i in
+      while !j < len && not (is_space s.[!j]) do
+        incr j
+      done;
+      take_word (String.sub s i (!j - i) :: acc) !j)
+  in
+  take_word [] 0
+;;
+
+let strip_target_punct s =
+  let rec right i =
+    if i < 0
+    then ""
+    else (
+      match s.[i] with
+      | ',' | ';' | ':' | '.' | ')' | ']' -> right (i - 1)
+      | _ -> String.sub s 0 (i + 1))
+  in
+  right (String.length s - 1)
+;;
+
+let mention_of_word word =
+  if String.length word <= 1 || word.[0] <> '@'
+  then None
+  else (
+    let target = String.sub word 1 (String.length word - 1) |> strip_target_punct in
+    if target = "" then None else Some target)
+;;
+
+let unique_preserving_order xs =
+  let rec loop seen acc = function
+    | [] -> List.rev acc
+    | x :: rest when List.mem x seen -> loop seen acc rest
+    | x :: rest -> loop (x :: seen) (x :: acc) rest
+  in
+  loop [] [] xs
+;;
+
+let mentions_of_message (msg : Masc_domain.message) =
+  let body_mentions =
+    decode_message_entities msg.content |> words |> List.filter_map mention_of_word
+  in
+  let direct =
+    match msg.mention with
+    | Some value when String.trim value <> "" -> [ String.trim value ]
+    | _ -> []
+  in
+  unique_preserving_order (direct @ body_mentions)
+;;
+
+let message_id (msg : Masc_domain.message) = Printf.sprintf "msg-%09d" msg.seq
+
+let is_room_message (msg : Masc_domain.message) =
+  let msg_type = String.lowercase_ascii (String.trim msg.msg_type) in
+  not (String.starts_with ~prefix:"lifecycle_" msg_type)
+;;
+
+let block_kind_of_message (msg : Masc_domain.message) =
+  let msg_type = String.trim msg.msg_type in
+  let lower = String.lowercase_ascii msg_type in
+  if lower = "" || lower = "broadcast"
+  then None
+  else if String.starts_with ~prefix:"state_block:" lower
+  then
+    Some
+      (String.sub msg_type 12 (String.length msg_type - 12)
+       |> String.trim
+       |> String.lowercase_ascii)
+  else if String.starts_with ~prefix:"state-block:" lower
+  then
+    Some
+      (String.sub msg_type 12 (String.length msg_type - 12)
+       |> String.trim
+       |> String.lowercase_ascii)
+  else Some lower
+;;
+
+let message_json (msg : Masc_domain.message) =
+  let body = decode_message_entities msg.content in
+  let mentions = mentions_of_message msg in
+  let base =
+    [ "id", `String (message_id msg)
+    ; "room_id", `String default_room_id
+    ; "ts", `String msg.timestamp
+    ; "sender", `String msg.from_agent
+    ; "body", `String body
+    ; "mentions", `List (List.map (fun target -> `String target) mentions)
+    ]
+  in
+  let fields =
+    match block_kind_of_message msg with
+    | None -> base
+    | Some kind -> base @ [ "block_kind", `String kind ]
+  in
+  `Assoc fields
+;;
+
+let snippet text =
+  let text = String.trim text in
+  let max_len = 160 in
+  if String.length text <= max_len then text else String.sub text 0 (max_len - 3) ^ "..."
+;;
+
+let mention_matches ?me mentions =
+  match Option.map String.trim me with
+  | Some target when target <> "" -> List.exists (String.equal target) mentions
+  | _ -> mentions <> []
+;;
+
+let mention_inbox_json ?me (msg : Masc_domain.message) =
+  let mentions = mentions_of_message msg in
+  if not (mention_matches ?me mentions)
+  then None
+  else
+    Some
+      (`Assoc
+          [ "message_id", `String (message_id msg)
+          ; "room_id", `String default_room_id
+          ; "ts", `String msg.timestamp
+          ; "sender", `String msg.from_agent
+          ; "snippet", `String (decode_message_entities msg.content |> snippet)
+          ; "ack_at", `Null
+          ])
+;;
+
+let active_agent_names config =
+  if not (Coord.is_initialized config)
+  then []
+  else (
+    try
+      Coord.get_agents_raw config
+      |> List.map (fun (agent : Masc_domain.agent) -> agent.name)
+    with
+    | Eio.Cancel.Cancelled _ as exn -> raise exn
+    | _ -> [])
+;;
+
+let room_json ~config messages =
+  let participants =
+    let senders = List.map (fun (msg : Masc_domain.message) -> msg.from_agent) messages in
+    let mentions = messages |> List.concat_map mentions_of_message in
+    active_agent_names config @ senders @ mentions |> unique_preserving_order
+  in
+  let last_message_at =
+    match messages with
+    | latest :: _ -> `String latest.timestamp
+    | [] -> `Null
+  in
+  `Assoc
+    [ "id", `String default_room_id
+    ; "name", `String default_room_name
+    ; "participants", `List (List.map (fun name -> `String name) participants)
+    ; "last_message_at", last_message_at
+    ]
+;;
+
+let json ~config ?me ~limit () =
+  let limit = clamp_limit limit in
+  let recent_desc =
+    Coord.get_messages_raw config ~since_seq:0 ~limit:(fetch_limit limit)
+    |> List.filter is_room_message
+    |> take limit
+  in
+  let timeline = List.rev recent_desc in
+  let messages_json = List.map message_json timeline in
+  let mentions_inbox =
+    recent_desc |> List.filter_map (mention_inbox_json ?me) |> take limit
+  in
+  `Assoc
+    [ "generated_at", `String (Masc_domain.now_iso ())
+    ; "limit", `Int limit
+    ; ( "me"
+      , match me with
+        | Some value -> `String value
+        | None -> `Null )
+    ; "rooms", `List [ room_json ~config recent_desc ]
+    ; "messages", `List messages_json
+    ; "mentions_inbox", `List mentions_inbox
+    ]
+;;

--- a/lib/dashboard/dashboard_rooms.mli
+++ b/lib/dashboard/dashboard_rooms.mli
@@ -1,0 +1,1 @@
+val json : config:Coord.config -> ?me:string -> limit:int -> unit -> Yojson.Safe.t

--- a/lib/server/server_h2_gateway.ml
+++ b/lib/server/server_h2_gateway.ml
@@ -582,6 +582,25 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
             h2_respond_json h2_reqd (Yojson.Safe.to_string json)
               ~extra_headers:cors)
 
+      | `GET, "/api/v1/dashboard/rooms"
+      | `GET, "/api/v1/rooms" ->
+          with_server_state h2_reqd (fun state ->
+            let limit =
+              Server_utils.int_query_param httpun_request "limit" ~default:50
+              |> Server_utils.clamp ~min_v:1 ~max_v:200
+            in
+            let me =
+              match trimmed_query_param httpun_request "me" with
+              | Some _ as value -> value
+              | None -> trimmed_query_param httpun_request "agent"
+            in
+            let json =
+              Dashboard_rooms.json ~config:state.Mcp_server.room_config ?me
+                ~limit ()
+            in
+            h2_respond_json h2_reqd (Yojson.Safe.to_string json)
+              ~extra_headers:cors)
+
       | `GET, "/api/v1/dashboard/config" ->
           let json = Env_config_introspect.to_json () in
           h2_respond_json h2_reqd (Yojson.Safe.to_string json) ~extra_headers:cors

--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -290,6 +290,20 @@ let handle_dashboard_task_history state req reqd =
       Tool_task.task_history_events_json state.Mcp_server.room_config ~task_id ~limit
     in
     Http.Response.json ~compress:true ~request:req (Yojson.Safe.to_string json) reqd
+
+let handle_dashboard_rooms state req reqd =
+  let limit =
+    Server_utils.int_query_param req "limit" ~default:50
+    |> Server_utils.clamp ~min_v:1 ~max_v:200
+  in
+  let me =
+    match trimmed_query_param req "me" with
+    | Some _ as value -> value
+    | None -> trimmed_query_param req "agent"
+  in
+  let json = Dashboard_rooms.json ~config:state.Mcp_server.room_config ?me ~limit () in
+  Http.Response.json ~compress:true ~request:req (Yojson.Safe.to_string json) reqd
+
 let rec add_routes ~sw ~clock router =
   router
   |> Http.Router.post "/api/v1/broadcast" (fun request reqd ->
@@ -357,6 +371,10 @@ let rec add_routes ~sw ~clock router =
          let json = Dashboard_branches.json ~config:state.Mcp_server.room_config in
          Http.Response.json ~compress:true ~request:req (Yojson.Safe.to_string json) reqd
        ) request reqd)
+  |> Http.Router.get "/api/v1/dashboard/rooms" (fun request reqd ->
+       with_public_read handle_dashboard_rooms request reqd)
+  |> Http.Router.get "/api/v1/rooms" (fun request reqd ->
+       with_public_read handle_dashboard_rooms request reqd)
   (* Dev-only shared bearer for the dashboard UI. Served exclusively when the
      server binds to loopback and strict-auth env overrides are disabled, so
      that a LAN deployment never hands out a token over the wire. The token is

--- a/test/dune
+++ b/test/dune
@@ -494,6 +494,7 @@
         test_config_dir_resolver
         test_room_coverage
         test_streamable_http
+        test_dashboard_rooms
         test_dashboard_mission
         test_dashboard_mission_briefing
         ; test_command_plane_help removed (CP purge)
@@ -697,6 +698,7 @@
         test_config_dir_resolver
         test_room_coverage
         test_streamable_http
+        test_dashboard_rooms
         test_dashboard_mission
         test_dashboard_mission_briefing
         ; test_command_plane_help removed (CP purge)

--- a/test/test_dashboard_rooms.ml
+++ b/test/test_dashboard_rooms.ml
@@ -1,0 +1,100 @@
+open Masc_mcp
+
+let temp_dir prefix =
+  let dir =
+    Filename.concat
+      (Filename.get_temp_dir_name ())
+      (Printf.sprintf
+         "%s_%d_%d"
+         prefix
+         (Unix.getpid ())
+         (int_of_float (Unix.gettimeofday () *. 1000.)))
+  in
+  Unix.mkdir dir 0o755;
+  dir
+;;
+
+let with_room f =
+  Eio_main.run
+  @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let dir = temp_dir "masc_rooms" in
+  Fun.protect
+    ~finally:(fun () ->
+      let config = Coord.default_config dir in
+      ignore (Coord.reset config);
+      try Unix.rmdir dir with
+      | _ -> ())
+    (fun () ->
+       let config = Coord.default_config dir in
+       ignore (Coord.init config ~agent_name:(Some "operator"));
+       f config)
+;;
+
+let list_field key json = Yojson.Safe.Util.(json |> member key |> to_list)
+let string_field key json = Yojson.Safe.Util.(json |> member key |> to_string)
+
+let string_list_field key json =
+  Yojson.Safe.Util.(json |> member key |> to_list |> List.map to_string)
+;;
+
+let test_rooms_projection_includes_messages_and_mentions () =
+  with_room
+  @@ fun config ->
+  ignore (Coord.join config ~agent_name:"sangsu" ~capabilities:[] ());
+  ignore (Coord.broadcast config ~from_agent:"operator" ~content:"hello @sangsu");
+  ignore
+    (Coord.broadcast
+       config
+       ~from_agent:"sangsu"
+       ~msg_type:"state_block:plan"
+       ~content:"{\"phase\":\"next\"}");
+  let json = Dashboard_rooms.json ~config ~me:"sangsu" ~limit:10 () in
+  let rooms = list_field "rooms" json in
+  let messages = list_field "messages" json in
+  let inbox = list_field "mentions_inbox" json in
+  Alcotest.(check int) "one default room" 1 (List.length rooms);
+  Alcotest.(check int) "two messages" 2 (List.length messages);
+  Alcotest.(check int) "one mention" 1 (List.length inbox);
+  let room = List.hd rooms in
+  Alcotest.(check string) "room id" "default" (string_field "id" room);
+  Alcotest.(check bool)
+    "participants include sangsu"
+    true
+    (List.mem "sangsu" (string_list_field "participants" room));
+  let first = List.hd messages in
+  Alcotest.(check string) "first sender" "operator" (string_field "sender" first);
+  Alcotest.(check (list string))
+    "mentions"
+    [ "sangsu" ]
+    (string_list_field "mentions" first);
+  let second = List.nth messages 1 in
+  Alcotest.(check string) "block kind" "plan" (string_field "block_kind" second);
+  let inbox_item = List.hd inbox in
+  Alcotest.(check string) "inbox sender" "operator" (string_field "sender" inbox_item)
+;;
+
+let test_mentions_without_me_returns_all_mentions () =
+  with_room
+  @@ fun config ->
+  ignore (Coord.broadcast config ~from_agent:"operator" ~content:"hello @rama");
+  ignore (Coord.broadcast config ~from_agent:"operator" ~content:"plain broadcast");
+  let json = Dashboard_rooms.json ~config ~limit:10 () in
+  Alcotest.(check int) "all mentions" 1 (List.length (list_field "mentions_inbox" json))
+;;
+
+let () =
+  Alcotest.run
+    "Dashboard_rooms"
+    [ ( "projection"
+      , [ Alcotest.test_case
+            "rooms projection includes messages and mentions"
+            `Quick
+            test_rooms_projection_includes_messages_and_mentions
+        ; Alcotest.test_case
+            "mentions without me returns all mentions"
+            `Quick
+            test_mentions_without_me_returns_all_mentions
+        ] )
+    ]
+;;


### PR DESCRIPTION
## Summary

- Add `Dashboard_rooms` as a derived read model over the existing Coord broadcast store.
- Expose room timeline data, message rows, mention arrays, optional `block_kind`, and an `@me` mention inbox.
- Wire `GET /api/v1/dashboard/rooms` and compatibility alias `GET /api/v1/rooms` through both HTTP/1 and H2 routes.

## Notes

- This keeps C2 backend conservative: the first room is the existing namespace-wide broadcast room rather than a new chat persistence layer.
- Lifecycle join/rejoin messages are filtered out so the feed behaves like a chat room timeline.

## Verification

- `dune build --root . test/test_dashboard_rooms.exe`
- `./_build/default/test/test_dashboard_rooms.exe`
- `ocamlformat --check lib/dashboard/dashboard_rooms.ml lib/dashboard/dashboard_rooms.mli test/test_dashboard_rooms.ml`
- `git diff --check`

Fixes #11575
