### PR TITLE
fix(safe-ops): preserve raw utf8 sanitization

### DIFF
--- a/lib/core/safe_ops.ml
+++ b/lib/core/safe_ops.ml
@@ -226,6 +226,12 @@ let sanitize_text_utf8 (s : string) : string =
     loop 0;
     Buffer.contents buf
 
+type sanitized_json_utf8 =
+  { raw : Yojson.Safe.t
+  ; sanitized : Yojson.Safe.t
+  ; changed : bool
+  }
+
 let rec sanitize_json_utf8 (json : Yojson.Safe.t) : Yojson.Safe.t =
   match json with
   | `String s ->
@@ -256,6 +262,10 @@ let rec sanitize_json_utf8 (json : Yojson.Safe.t) : Yojson.Safe.t =
       in
       if !changed then `List sanitized_items else json
   | (`Null | `Bool _ | `Int _ | `Intlit _ | `Float _) as other -> other
+
+let sanitize_json_utf8_with_raw raw =
+  let sanitized = sanitize_json_utf8 raw in
+  { raw; sanitized; changed = sanitized != raw }
 
 let count_invalid_utf8_bytes s =
   let len = String.length s in

--- a/lib/core/safe_ops.mli
+++ b/lib/core/safe_ops.mli
@@ -55,9 +55,20 @@ val sanitize_text_utf8 : string -> string
     control characters with spaces (except LF/CR/TAB), without recording a
     read-path persistence repair. *)
 
+type sanitized_json_utf8 =
+  { raw : Yojson.Safe.t
+  ; sanitized : Yojson.Safe.t
+  ; changed : bool
+  }
+(** Raw and sanitized views of the same JSON payload. *)
+
 val sanitize_json_utf8 : Yojson.Safe.t -> Yojson.Safe.t
 (** Recursively scrub every JSON string node through {!sanitize_text_utf8}.
     Intended for writer-side sanitization before persistence or broadcast. *)
+
+val sanitize_json_utf8_with_raw : Yojson.Safe.t -> sanitized_json_utf8
+(** Preserve the original JSON payload while also returning the sanitized
+    writer-side view. *)
 
 val parse_json_safe : context:string -> string -> (Yojson.Safe.t, string) result
 (** Parse JSON with detailed error reporting. *)

--- a/test/test_safe_ops.ml
+++ b/test/test_safe_ops.ml
@@ -110,6 +110,32 @@ let test_sanitize_json_utf8_covers_safe_constructors () =
         (Yojson.Safe.Util.to_string value)
   | _ -> fail "unexpected sanitized JSON shape"
 
+let test_sanitize_json_utf8_with_raw_preserves_original () =
+  let open Safe_ops in
+  let raw = `Assoc [ ("bad\xffkey", `String "bad\xffvalue") ] in
+  let replacement = "\xEF\xBF\xBD" in
+  let result = sanitize_json_utf8_with_raw raw in
+  check bool "changed when utf8 repair needed" true result.changed;
+  check bool "raw points at original payload" true (result.raw == raw);
+  (match result.raw with
+   | `Assoc [ (key, `String value) ] ->
+       check string "raw key unchanged" "bad\xffkey" key;
+       check string "raw value unchanged" "bad\xffvalue" value
+   | _ -> fail "unexpected raw JSON shape");
+  match result.sanitized with
+  | `Assoc [ (key, `String value) ] ->
+      check string "sanitized key repaired" ("bad" ^ replacement ^ "key") key;
+      check string "sanitized value repaired" ("bad" ^ replacement ^ "value") value
+  | _ -> fail "unexpected sanitized JSON shape"
+
+let test_sanitize_json_utf8_with_raw_marks_clean_payload_unchanged () =
+  let open Safe_ops in
+  let raw = `Assoc [ ("ok", `String "value") ] in
+  let result = sanitize_json_utf8_with_raw raw in
+  check bool "clean payload not changed" false result.changed;
+  check bool "raw points at original payload" true (result.raw == raw);
+  check bool "sanitized reuses original payload" true (result.sanitized == raw)
+
 let test_utf8_repair_log_rate_limit_table_is_bounded () =
   let open Safe_ops in
   reset_persistence_utf8_repair_stats_for_tests ();
@@ -474,6 +500,10 @@ let () =
         test_parse_json_safe_rate_limits_repeated_utf8_repair_logs;
       test_case "sanitizes safe constructors" `Quick
         test_sanitize_json_utf8_covers_safe_constructors;
+      test_case "sanitizes with raw preserved" `Quick
+        test_sanitize_json_utf8_with_raw_preserves_original;
+      test_case "sanitizes with raw unchanged marker" `Quick
+        test_sanitize_json_utf8_with_raw_marks_clean_payload_unchanged;
       test_case "bounds utf8 repair log rate-limit table" `Quick
         test_utf8_repair_log_rate_limit_table_is_bounded;
       test_case "long invalid" `Quick test_parse_json_safe_long_invalid;


### PR DESCRIPTION
## Summary
- Add a raw-preserving `Safe_ops.sanitized_json_utf8` result shape with `raw`, `sanitized`, and `changed` fields.
- Keep existing `sanitize_json_utf8` callers compatible while exposing `sanitize_json_utf8_with_raw` for callers that need both views.
- Cover invalid UTF-8 and clean-payload cases in `test_safe_ops`.

## Why
The Kimi cleanup roadmap flagged writer-side UTF-8 sanitization as losing the original payload view. This keeps the sanitized writer path intact while making the raw payload explicitly available for forensic or audit-sensitive callers.

## Validation
- `git diff --check origin/main..HEAD`
- `scripts/dune-local.sh build test/test_safe_ops.exe`
- `./_build/default/test/test_safe_ops.exe` (70 tests)
- Note: `ocamlformat --check` exits 1 with no diagnostics on these files even for clean `HEAD`, so I avoided whole-file formatter churn.