### PR TITLE
fix(board): gate moderation projection fields

### DIFF
--- a/bin/main_eio.ml
+++ b/bin/main_eio.ml
@@ -393,7 +393,10 @@ let dispatch_route ~routes ~request ~path reqd =
       let post_id = String.sub p 14 (String.length p - 14) in
       let format = Option.value ~default:"nested" (query_param request "format") in
       let voter = board_voter_query request in
-      let (status, body) = board_post_detail_json ~voter ~response_format:format ~post_id in
+      let (status, body) =
+        board_post_detail_json ~include_moderation:false ~voter
+          ~response_format:format ~post_id
+      in
       Http.Response.json ~status body reqd
   | _ -> Http.Router.dispatch routes request reqd
 

--- a/lib/board_moderation.ml
+++ b/lib/board_moderation.ml
@@ -99,6 +99,8 @@ type store = {
   queue : (string, queue_entry) Hashtbl.t;  (* entry_id -> entry *)
   audit : audit_entry list ref;
   unresolved_by_target : (target_kind * string, string) Hashtbl.t;
+  report_count_by_target : (target_kind * string, int) Hashtbl.t;
+  latest_action_by_target : (target_kind * string, action_kind * float) Hashtbl.t;
   last_flag_by_reporter : (string, float) Hashtbl.t;
 }
 
@@ -122,10 +124,23 @@ let make_store () : store =
     queue = Hashtbl.create 64;
     audit = ref [];
     unresolved_by_target = Hashtbl.create 64;
+    report_count_by_target = Hashtbl.create 64;
+    latest_action_by_target = Hashtbl.create 64;
     last_flag_by_reporter = Hashtbl.create 64;
   }
 
 let target_key target_kind target_id = (target_kind, target_id)
+
+let increment_report_count s target_key =
+  let current =
+    Hashtbl.find_opt s.report_count_by_target target_key |> Option.value ~default:0
+  in
+  Hashtbl.replace s.report_count_by_target target_key (current + 1)
+
+let update_latest_action s target_key action acted_at =
+  match Hashtbl.find_opt s.latest_action_by_target target_key with
+  | Some (_existing_action, existing_at) when Float.compare existing_at acted_at > 0 -> ()
+  | _ -> Hashtbl.replace s.latest_action_by_target target_key (action, acted_at)
 
 let retry_after_for_reporter s ~reporter ~now ~window_sec =
   if Float.compare window_sec 0.0 <= 0 then None
@@ -191,6 +206,7 @@ let flag ~target_kind ~target_id ~reporter ~reason =
         } in
         Hashtbl.replace s.queue entry_id entry;
         Hashtbl.replace s.unresolved_by_target target_key entry_id;
+        increment_report_count s target_key;
         Hashtbl.replace s.last_flag_by_reporter reporter now;
         Ok entry
 
@@ -230,6 +246,7 @@ let record_action ~target_kind ~target_id ~actor ~action ?reason ?note () =
       note
   in
   let audit_id = Random_id.prefixed ~prefix:"ma-" ~bytes:16 in
+  let acted_at = Time_compat.now () in
   let entry = {
     audit_id;
     target_kind;
@@ -238,7 +255,7 @@ let record_action ~target_kind ~target_id ~actor ~action ?reason ?note () =
     action;
     reason;
     note = note_trimmed;
-    acted_at = Time_compat.now ();
+    acted_at;
   } in
   let target_key = target_key target_kind target_id in
   (match Hashtbl.find_opt s.unresolved_by_target target_key with
@@ -249,6 +266,7 @@ let record_action ~target_kind ~target_id ~actor ~action ?reason ?note () =
         | Some qe when not qe.resolved ->
             Hashtbl.replace s.queue entry_id { qe with resolved = true }
         | _ -> ()));
+  update_latest_action s target_key action acted_at;
   s.audit := entry :: !(s.audit);
   Ok entry
 
@@ -287,17 +305,12 @@ let moderation_status_of_action = function
 
 let target_summary ~target_kind ~target_id =
   let s = store () in
-  let matches_target target_kind' target_id' =
-    target_kind = target_kind' && String.equal target_id target_id'
-  in
+  let target_key = target_key target_kind target_id in
   let report_count =
-    Hashtbl.fold
-      (fun _ (entry : queue_entry) acc ->
-         if matches_target entry.target_kind entry.target_id then acc + 1 else acc)
-      s.queue 0
+    Hashtbl.find_opt s.report_count_by_target target_key |> Option.value ~default:0
   in
   let has_unresolved =
-    match Hashtbl.find_opt s.unresolved_by_target (target_key target_kind target_id) with
+    match Hashtbl.find_opt s.unresolved_by_target target_key with
     | None -> false
     | Some entry_id -> (
         match Hashtbl.find_opt s.queue entry_id with
@@ -308,15 +321,9 @@ let target_summary ~target_kind ~target_id =
     if has_unresolved then
       "flagged"
     else
-      match
-        !(s.audit)
-        |> List.filter
-             (fun (entry : audit_entry) ->
-                matches_target entry.target_kind entry.target_id)
-        |> List.sort (fun a b -> Float.compare b.acted_at a.acted_at)
-      with
-      | [] -> "none"
-      | entry :: _ -> moderation_status_of_action entry.action
+      match Hashtbl.find_opt s.latest_action_by_target target_key with
+      | None -> "none"
+      | Some (action, _acted_at) -> moderation_status_of_action action
   in
   { report_count; moderation_status }
 

--- a/lib/board_moderation.mli
+++ b/lib/board_moderation.mli
@@ -170,7 +170,9 @@ val target_summary :
   target_summary
 (** Return the board/dashboard moderation projection for a post or comment.
     An unresolved queue entry wins over older audit decisions, so a re-flagged
-    target reports ["flagged"] until an operator action resolves it. *)
+    target reports ["flagged"] until an operator action resolves it.  The
+    projection is served from per-target aggregates maintained on mutation, so
+    board response rendering does not scan the full queue or audit log per row. *)
 
 (** {1 JSON serialisation — dashboard API projection} *)
 

--- a/lib/server/server_h2_gateway_routes_extra.ml
+++ b/lib/server/server_h2_gateway_routes_extra.ml
@@ -106,7 +106,8 @@ let dispatch ~h2_reqd ~httpun_request ~cors ~path
       let format = Option.value ~default:"nested" (query_param httpun_request "format") in
       let voter = board_voter_query httpun_request in
       let (status, body) =
-        board_post_detail_json ~voter ~response_format:format ~post_id
+        board_post_detail_json ~include_moderation:false ~voter
+          ~response_format:format ~post_id
       in
       h2_respond_json h2_reqd body ~status ~extra_headers:cors;
       true

--- a/lib/server/server_routes_http_routes_activity.ml
+++ b/lib/server/server_routes_http_routes_activity.ml
@@ -12,6 +12,19 @@ module Pages = Server_routes_http_pages
 module Runtime = Server_routes_http_runtime
 module Keeper_stream = Server_routes_http_keeper_stream
 
+let include_moderation_projection ~base_path request =
+  match auth_token_from_request request with
+  | None -> false
+  | Some _ -> (
+      match
+        authorize_token_bound_permission_request
+          ~base_path
+          ~permission:Masc_domain.CanReadState
+          request
+      with
+      | Ok _ -> true
+      | Error _ -> false)
+
 let activity_http_deps ~sw ~clock : Server_activity_http.deps =
   {
     query_param;
@@ -197,7 +210,7 @@ let add_routes ~sw ~clock router =
        ) request reqd)
 
   |> Http.Router.get "/api/v1/board" (fun request reqd ->
-       with_public_read (fun _state req reqd ->
+       with_public_read (fun state req reqd ->
          let hearth = query_param req "hearth" in
          let sort_by = board_sort_order_of_request req in
          let exclude_system = bool_query_param req "exclude_system" ~default:false in
@@ -214,6 +227,11 @@ let add_routes ~sw ~clock router =
          let offset = int_query_param req "offset" ~default:0 |> clamp ~min_v:0 ~max_v:5000 in
          let base_fetch = board_fetch_limit ~exclude_system ~exclude_automation ~limit ~offset in
          let voter = board_voter_query req in
+         let include_moderation =
+           include_moderation_projection
+             ~base_path:state.Mcp_server.room_config.base_path
+             req
+         in
          let posts =
            Board_dispatch.list_posts ?hearth ~sort_by ~exclude_system
              ~exclude_automation ?author_filter ~limit:base_fetch ()
@@ -240,7 +258,7 @@ let add_routes ~sw ~clock router =
                let post_id = Board.Post_id.to_string p.id in
                let current_vote = board_current_vote_for_post ~voter ~post_id in
                let reactions = reactions_for (Board.Reaction_post, post_id) in
-               board_post_dashboard_json ?current_vote
+               board_post_dashboard_json ~include_moderation ?current_vote
                  ~reactions
                  ~author_karma:(get_karma author) p)
              paged
@@ -343,7 +361,7 @@ let add_routes ~sw ~clock router =
                    reqd)))
 
   |> Http.Router.prefix_get "/api/v1/board/" (fun request reqd ->
-       with_public_read (fun _state req reqd ->
+       with_public_read (fun state req reqd ->
          let path = Http.Request.path request in
          (match extract_path_param ~prefix:"/api/v1/board/" path with
           | None ->
@@ -355,8 +373,14 @@ let add_routes ~sw ~clock router =
                 query_param req "format" |> Option.value ~default:"nested"
               in
               let voter = board_voter_query req in
+              let include_moderation =
+                include_moderation_projection
+                  ~base_path:state.Mcp_server.room_config.base_path
+                  req
+              in
               let (status, body) =
-                board_post_detail_json ~voter ~response_format:format ~post_id
+                board_post_detail_json ~include_moderation ~voter
+                  ~response_format:format ~post_id
               in
               respond_json_with_cors ~status request reqd body)
        ) request reqd)

--- a/lib/server/server_routes_http_runtime.ml
+++ b/lib/server/server_routes_http_runtime.ml
@@ -294,7 +294,8 @@ let readiness_handler _request reqd =
             ]))
       reqd
 
-let board_post_detail_json ~voter ~response_format ~post_id =
+let board_post_detail_json ~include_moderation ~voter ~response_format
+    ~post_id =
   match Board_dispatch.get_post ~post_id with
   | Error err ->
       (`Not_found, Printf.sprintf {|{"error":"%s"}|}
@@ -321,13 +322,17 @@ let board_post_detail_json ~voter ~response_format ~post_id =
       let reaction_rows = board_reactions_batch ~targets:reaction_targets ~voter in
       let reactions_for = board_reactions_lookup reaction_rows in
       let reactions = reactions_for (Board.Reaction_post, post_id) in
-      let post_json = board_post_dashboard_json ?current_vote ~reactions ~author_karma post in
+      let post_json =
+        board_post_dashboard_json ~include_moderation ?current_vote ~reactions
+          ~author_karma post
+      in
       let comments_json =
         `List (List.map (fun (comment : Board.comment) ->
           let comment_id = Board.Comment_id.to_string comment.id in
           let current_vote = board_current_vote_for_comment ~voter ~comment_id in
           let reactions = reactions_for (Board.Reaction_comment, comment_id) in
-          board_comment_dashboard_json ?current_vote ~reactions comment
+          board_comment_dashboard_json ~include_moderation ?current_vote ~reactions
+            comment
         ) comments)
       in
       let json =

--- a/lib/server/server_routes_http_runtime.mli
+++ b/lib/server/server_routes_http_runtime.mli
@@ -161,6 +161,7 @@ val readiness_handler : Httpun.Request.t -> Httpun.Reqd.t -> unit
 (** {1 Board} *)
 
 val board_post_detail_json :
+  include_moderation:bool ->
   voter:string option ->
   response_format:string ->
   post_id:string ->
@@ -168,7 +169,8 @@ val board_post_detail_json :
 (** [board_post_detail_json ~voter ~response_format ~post_id] returns
     [(status, json_string)] for [GET /api/v1/board/<post_id>].
     When [voter] is supplied, post/comment rows include vote state for
-    that voter.
+    that voter.  When [include_moderation] is [true], rows also include
+    operator-only moderation projection fields.
 
     {2 response_format values (case-insensitive, trimmed)}
 

--- a/lib/server/server_utils.ml
+++ b/lib/server/server_utils.ml
@@ -188,14 +188,17 @@ let board_reaction_fields = function
   | Some summaries ->
       [ ("reactions", `List (List.map Board.reaction_summary_to_yojson summaries)) ]
 
-let board_moderation_fields ~target_kind ~target_id =
-  let summary = Board_moderation.target_summary ~target_kind ~target_id in
-  [
-    ("report_count", `Int summary.Board_moderation.report_count);
-    ("moderation_status", `String summary.Board_moderation.moderation_status);
-  ]
+let board_moderation_fields ~include_moderation ~target_kind ~target_id =
+  if not include_moderation then []
+  else
+    let summary = Board_moderation.target_summary ~target_kind ~target_id in
+    [
+      ("report_count", `Int summary.Board_moderation.report_count);
+      ("moderation_status", `String summary.Board_moderation.moderation_status);
+    ]
 
-let board_comment_dashboard_json ?current_vote ?reactions (c : Board.comment) : Yojson.Safe.t =
+let board_comment_dashboard_json ?(include_moderation = false) ?current_vote
+    ?reactions (c : Board.comment) : Yojson.Safe.t =
   let author = Board.Agent_id.to_string c.author in
   let comment_id = Board.Comment_id.to_string c.id in
   match Board.comment_to_yojson c with
@@ -203,13 +206,15 @@ let board_comment_dashboard_json ?current_vote ?reactions (c : Board.comment) : 
       `Assoc
         (fields
          @ [ ("author_identity", board_actor_identity_json author) ]
-         @ board_moderation_fields ~target_kind:Board_moderation.Target_comment
+         @ board_moderation_fields ~include_moderation
+             ~target_kind:Board_moderation.Target_comment
              ~target_id:comment_id
          @ board_vote_state_fields current_vote
          @ board_reaction_fields reactions)
   | other -> other
 
-let board_post_dashboard_json ?current_vote ?reactions ~author_karma (p : Board.post) : Yojson.Safe.t =
+let board_post_dashboard_json ?(include_moderation = false) ?current_vote
+    ?reactions ~author_karma (p : Board.post) : Yojson.Safe.t =
   let author = Board.Agent_id.to_string p.author in
   let post_id = Board.Post_id.to_string p.id in
   let base_fields =
@@ -239,7 +244,8 @@ let board_post_dashboard_json ?current_vote ?reactions ~author_karma (p : Board.
           ("hearth_count", `Int (match p.hearth with Some _ -> 1 | None -> 0));
           ("author_identity", board_actor_identity_json author);
         ]
-      @ board_moderation_fields ~target_kind:Board_moderation.Target_post
+      @ board_moderation_fields ~include_moderation
+          ~target_kind:Board_moderation.Target_post
           ~target_id:post_id
       @ board_vote_state_fields current_vote
       @ board_reaction_fields reactions )

--- a/lib/server/server_utils.mli
+++ b/lib/server/server_utils.mli
@@ -174,15 +174,18 @@ val board_reactions_lookup :
 (** {1 Dashboard helpers} *)
 
 val board_comment_dashboard_json :
+  ?include_moderation:bool ->
   ?current_vote:Board.vote_direction option ->
   ?reactions:Board.reaction_summary list ->
   Board.comment ->
   Yojson.Safe.t
 (** [board_comment_dashboard_json c] renders a comment with the
-    [author_identity], [report_count], and [moderation_status] fields
-    appended for dashboard inspection. *)
+    [author_identity] field appended for dashboard inspection.  When
+    [include_moderation] is [true], it also appends operator-only
+    [report_count] and [moderation_status] fields. *)
 
 val board_post_dashboard_json :
+  ?include_moderation:bool ->
   ?current_vote:Board.vote_direction option ->
   ?reactions:Board.reaction_summary list ->
   author_karma:int ->
@@ -199,7 +202,8 @@ val board_post_dashboard_json :
     - [hearth_count] = 0 or 1 (boolean-as-int for the dashboard's
       column that aggregates across multiple hearths).
     - [author_identity] from {!board_actor_identity_json}.
-    - [report_count] / [moderation_status] from {!Board_moderation}.
+    - [report_count] / [moderation_status] from {!Board_moderation}
+      only when [include_moderation] is [true].
 
     The base fields [title] / [votes] / [comment_count] /
     [created_at_iso] / [updated_at_iso] / [hearth_count] are

--- a/test/test_tool_board_coverage.ml
+++ b/test/test_tool_board_coverage.ml
@@ -178,6 +178,11 @@ let json_member_list json key =
   | `List values -> values
   | _ -> Alcotest.failf "expected list field %s" key
 
+let json_has_member json key =
+  match Yojson.Safe.Util.member key json with
+  | `Null -> false
+  | _ -> true
+
 let test_board_actor_identity_canonicalizes_keeper_alias () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
@@ -307,10 +312,24 @@ let test_board_dashboard_json_embeds_moderation_projection () =
    with
    | Ok _ -> ()
    | Error e -> Alcotest.fail e);
-  let post_json =
+  let public_post_json =
     Server_utils.board_post_dashboard_json ~author_karma:0 post
   in
-  let comment_json = Server_utils.board_comment_dashboard_json comment in
+  let public_comment_json = Server_utils.board_comment_dashboard_json comment in
+  Alcotest.(check bool) "public post omits report count" false
+    (json_has_member public_post_json "report_count");
+  Alcotest.(check bool) "public post omits moderation status" false
+    (json_has_member public_post_json "moderation_status");
+  Alcotest.(check bool) "public comment omits report count" false
+    (json_has_member public_comment_json "report_count");
+  Alcotest.(check bool) "public comment omits moderation status" false
+    (json_has_member public_comment_json "moderation_status");
+  let post_json =
+    Server_utils.board_post_dashboard_json ~include_moderation:true ~author_karma:0 post
+  in
+  let comment_json =
+    Server_utils.board_comment_dashboard_json ~include_moderation:true comment
+  in
   Alcotest.(check int) "post report count" 1
     (json_member_int post_json "report_count");
   Alcotest.(check string) "post moderation status" "flagged"


### PR DESCRIPTION
Follow-up to #13870 review. Keeps moderation target summaries in per-target aggregates, gates report_count/moderation_status behind token-bound read auth for /api/v1/board, and preserves public board reads without operator-only fields. Validation: scripts/dune-local.sh build bin/main_eio.exe test/test_board_moderation.exe test/test_tool_board_coverage.exe; test_board_moderation.exe; test_tool_board_coverage.exe helpers case 8; dashboard tsc; board-surface/post-detail vitest.