### PR TITLE
fix: emit persistence utf8 repair metric

### DIFF
--- a/lib/core/safe_ops.ml
+++ b/lib/core/safe_ops.ml
@@ -69,6 +69,8 @@ let utf8_repair_mu = Stdlib.Mutex.create ()
 let utf8_repaired_reads = ref 0
 let utf8_repaired_bytes = ref 0
 let utf8_repair_path_samples = ref []
+let persistence_utf8_repair_metric_hook : (unit -> unit) option Atomic.t =
+  Atomic.make None
 let utf8_repair_path_sample_limit = 8
 let utf8_repair_log_restate_sec = 60.0
 let utf8_repair_log_entry_limit = 1024
@@ -88,6 +90,19 @@ let utf8_repair_log_seen : (string, utf8_repair_log_entry) Hashtbl.t =
   Hashtbl.create 16
 
 let utf8_repair_log_key ~surface ~path = surface ^ "\x00" ^ path
+
+let set_persistence_utf8_repair_metric_hook hook =
+  Atomic.set persistence_utf8_repair_metric_hook (Some hook)
+
+let emit_persistence_utf8_repair_metric () =
+  match Atomic.get persistence_utf8_repair_metric_hook with
+  | None -> ()
+  | Some hook ->
+      (try hook ()
+       with exn ->
+         Log.Misc.warn
+           "persistence UTF-8 repair metric hook failed: %s"
+           (Printexc.to_string exn))
 
 let prune_utf8_repair_log_seen_if_needed ~now =
   (* Sweep first: drop any entry whose [last_seen] is older than
@@ -158,6 +173,7 @@ let record_utf8_repair ~surface ~path ~invalid_bytes =
             { entry with last_seen = now; suppressed = entry.suppressed + 1 };
           None)
   in
+  emit_persistence_utf8_repair_metric ();
   match log_decision with
   | None -> ()
   | Some 0 ->

--- a/lib/core/safe_ops.mli
+++ b/lib/core/safe_ops.mli
@@ -41,6 +41,11 @@ val persistence_utf8_repair_stats : unit -> utf8_repair_stats
 (** Process-local cumulative count of malformed UTF-8 repairs seen by
     persistence read helpers. *)
 
+val set_persistence_utf8_repair_metric_hook : (unit -> unit) -> unit
+(** Install the higher-level metrics hook called once for each persistence
+    UTF-8 repair. Safe_ops lives below Prometheus, so the hook keeps the
+    dependency direction one-way. *)
+
 val reset_persistence_utf8_repair_stats_for_tests : unit -> unit
 (** Reset {!persistence_utf8_repair_stats}. Test-only. *)
 

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -737,6 +737,8 @@ let metric_keeper_observation_query_failures =
   "masc_keeper_observation_query_failures_total"
 let metric_persistence_read_drops =
   "masc_persistence_read_drops_total"
+let metric_persistence_utf8_repair =
+  "masc_persistence_utf8_repair_total"
 let metric_discovery_history_failures =
   "masc_discovery_history_failures_total"
 
@@ -2102,6 +2104,11 @@ let init () =
     "Total persisted read-model entries dropped during filesystem scans, \
      labeled by surface and reason"
     Counter;
+  add metric_persistence_utf8_repair
+    "Total persistence JSON reads repaired after invalid UTF-8 was detected."
+    Counter;
+  Safe_ops.set_persistence_utf8_repair_metric_hook (fun () ->
+    inc_counter metric_persistence_utf8_repair ());
   add metric_discovery_history_failures
     "Total discovery history JSONL persistence/read/prune failures, \
      labeled by site"

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -425,6 +425,9 @@ val metric_keeper_ollama_saturation_skip : string
     by [keeper] and [cascade] so dashboards can attribute starvation
     to specific cascade profiles. *)
 val metric_persistence_read_drops : string
+val metric_persistence_utf8_repair : string
+(** Goal-loop Observe counter for persistence UTF-8 repairs. No labels. *)
+
 val metric_discovery_history_failures : string
 val metric_codex_cli_mcp_tool_omission : string
 (** #10097: per-tool counter for codex_cli keeper-bound runtime

--- a/test/test_safe_ops.ml
+++ b/test/test_safe_ops.ml
@@ -35,6 +35,11 @@ let test_parse_json_safe_invalid () =
 let test_parse_json_safe_repairs_invalid_utf8_inside_string () =
   let open Safe_ops in
   reset_persistence_utf8_repair_stats_for_tests ();
+  let metric_before =
+    Masc_mcp.Prometheus.metric_value_or_zero
+      Masc_mcp.Prometheus.metric_persistence_utf8_repair
+      ()
+  in
   let replacement = "\xEF\xBF\xBD" in
   let result = parse_json_safe ~context:"utf8-fixture" "{\"msg\":\"ok\xffbad\"}" in
   match result with
@@ -44,7 +49,15 @@ let test_parse_json_safe_repairs_invalid_utf8_inside_string () =
     check string "invalid byte replaced" ("ok" ^ replacement ^ "bad") msg;
     let stats = persistence_utf8_repair_stats () in
     check int "one repaired read" 1 stats.repaired_reads;
-    check int "one invalid byte" 1 stats.repaired_bytes
+    check int "one invalid byte" 1 stats.repaired_bytes;
+    let metric_after =
+      Masc_mcp.Prometheus.metric_value_or_zero
+        Masc_mcp.Prometheus.metric_persistence_utf8_repair
+        ()
+    in
+    check (float 0.0001) "UTF-8 repair counter +1"
+      (metric_before +. 1.0)
+      metric_after
 
 let test_parse_json_safe_still_rejects_malformed_json_after_utf8_repair () =
   let open Safe_ops in


### PR DESCRIPTION
## Summary
- Add the goal-loop Observe counter `masc_persistence_utf8_repair_total`.
- Keep `Safe_ops` independent from `Prometheus` by installing a higher-level metric hook from `Prometheus.init`.
- Increment the counter once per invalid-UTF-8 persistence repair, independent of warning log rate limiting.
- Extend `test_safe_ops` to assert the counter increments when invalid bytes are repaired.

## Why
The goal-loop Observe contract, alerts, and Grafana dashboard already query `masc_persistence_utf8_repair_total`, but runtime only tracked process-local SafeOps repair stats. The alert could therefore see absent data even when SafeOps repaired malformed persistence JSON reads.

## Operator impact
Operators can now alert on UTF-8 repair events from the Prometheus surface while preserving the existing SafeOps stats and warning suppression behavior.

## Validation
- `git diff --check origin/main..HEAD`
- `env MASC_SKIP_OPAM_LOCK=1 DUNE_JOBS=1 DUNE_CACHE=disabled scripts/dune-local.sh build test/test_safe_ops.exe`
- `./_build/default/test/test_safe_ops.exe` (68 tests)

## Note
After a clean rebase onto current `origin/main`, repeating the focused build was queued behind an unrelated long-running `feat-dashboard-rooms-11575` Dune lock holder for ~10 minutes. I stopped only my queued wait; the pre-rebase focused build/test above passed and the rebase had no conflicts.