### PR TITLE
fix(keeper): log subprocess drain poll failures

### DIFF
--- a/lib/keeper/keeper_subprocess_registry.ml
+++ b/lib/keeper/keeper_subprocess_registry.ml
@@ -109,8 +109,13 @@ let drain ~keeper_id ~grace_ms : drain_result =
       ) !alive;
       alive := !still;
       if !alive <> [] then
-        (try ignore (Unix.select [] [] [] poll_interval)
-         with Unix.Unix_error _ -> ())
+        match Unix.select [] [] [] poll_interval with
+        | _, _, _ -> ()
+        | exception Unix.Unix_error (Unix.EINTR, _, _) -> ()
+        | exception Unix.Unix_error (err, fn, arg) ->
+            Log.Keeper.warn
+              "[SubprocessDrain] poll failed fn=%s arg=%s error=%s"
+              fn arg (Unix.error_message err)
     done;
     (* Phase 2: SIGKILL stragglers *)
     List.iter (fun pid ->


### PR DESCRIPTION
## Summary
- Replace the subprocess-drain `try ignore (Unix.select ...)` sleep with explicit exception handling.
- Keep `EINTR` as a harmless retry path and log unexpected `Unix.select` failures through `Log.Keeper.warn`.

## Why
The current Meta Guards SIL gate fails on the whole-repo `try ignore` pattern in `keeper_subprocess_registry.ml`. This makes the best-effort cleanup path noisy for unexpected errors without changing the drain semantics.

## Validation
- `git diff --check origin/main...HEAD`
- `bash scripts/ci/check-silent-failure-patterns.sh`
- `ocamlformat --check lib/keeper/keeper_subprocess_registry.ml` still exits 1 with no diagnostics on clean `HEAD`, so I avoided whole-file formatter churn.
- Focused Dune validation was attempted, but the shared local Dune lock was held by another worktree build for several minutes; CI is the active compile surface for this small OCaml change.