### PR TITLE
fix(coord): remove unbound Prometheus ref in coord_eio.create_config (main blocker)

### DIFF
--- a/lib/coord/coord_eio.ml
+++ b/lib/coord/coord_eio.ml
@@ -82,17 +82,12 @@ let create_config ~fs ?clock base_path =
     pubsub_max_messages = Backend.pubsub_max_messages;
   } in
   let backend = Backend.FileSystem.create ~fs ?clock backend_config in
-  Backend.FileSystem.set_mutex_observers
-    ~acquire:(fun ~op ~seconds ->
-      Prometheus.observe_histogram
-        Prometheus.metric_backend_mutex_acquire_sec
-        ~labels:[("op", op)]
-        seconds)
-    ~held:(fun ~op ~seconds ->
-      Prometheus.observe_histogram
-        Prometheus.metric_backend_mutex_held_sec
-        ~labels:[("op", op)]
-        seconds);
+  (* Prometheus mutex observers were wired here by PR #13851, but this
+     library (masc_coord) cannot depend on Prometheus (which lives in the
+     masc_mcp top-level lib) without a dependency cycle. The wiring
+     therefore failed to compile.  Removed pending follow-up that installs
+     Backend.FileSystem.set_mutex_observers from a masc_mcp startup site
+     where Prometheus is in scope. See follow-up issue. *)
   {
     base_path;
     lock_expiry_minutes = 30;


### PR DESCRIPTION
## 증상

main 브랜치를 빌드하면 다음 에러로 실패합니다.

```
File \"lib/coord/coord_eio.ml\", line 87, characters 6-34:
87 |       Prometheus.observe_histogram
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Error: Unbound module Prometheus
```

## 근본 원인

PR #13851 (\`obs(backend): export mutex acquire/held histograms to Prometheus\`)이 \`Coord_eio.create_config\` 안에 다음 호출을 추가했습니다:

\`\`\`ocaml
Backend.FileSystem.set_mutex_observers
  ~acquire:(fun ~op ~seconds ->
    Prometheus.observe_histogram
      Prometheus.metric_backend_mutex_acquire_sec ...)
  ~held:(fun ~op ~seconds ->
    Prometheus.observe_histogram
      Prometheus.metric_backend_mutex_held_sec ...)
\`\`\`

\`lib/coord/\` 는 \`masc_coord\` library 입니다. \`Prometheus\` 모듈은 최상위 \`masc_mcp\` lib 에 있습니다. \`masc_mcp\` 는 이미 \`masc_coord\` 에 의존하므로, 반대 방향 edge 를 추가하면 cycle 입니다. \`lib/coord/dune\` 의 \`(libraries ...)\` 는 의도적으로 \`masc_mcp\` 를 포함하지 않습니다.

PR 본문은 \"의존성 역전\" 아키텍처 (\`backend.ml\` 의 \`ref\` 기반 hook + \`coord_eio.ml\` 의 wiring) 를 명시했지만, 본문이 \"\`coord_eio.ml\`(\`masc_mcp\`)\" 라고 잘못 적었습니다. 실제로 \`coord_eio.ml\` 은 \`masc_coord\` 에 속합니다.

## 왜 CI 가 못 잡았나

#13851 의 status check 를 보면 \`Build and Test\` 가 **SKIPPED** 입니다 (path-filtered conditional CI). \`lib/coord/*\` 변경에 대해 dune build 가 실제로 안 돌았습니다. 별도 메타 이슈로 기록 예정 (path-filter gate gap).

메모리 패턴 \`feedback_pre_merge_typecheck_drag_in_blocker\` (2026-05-05 #12957→#12978) 와 동일한 회귀.

## 왜 \"제거\" 인가, 왜 \"재배치\" 가 아닌가

\`Coord_eio.create_config\` 는 repo 전체에서 caller 가 0건입니다.

\`\`\`bash
$ rg -n create_config lib/ bin/ | grep -v 'lib/coord/coord_eio'
(no output)
\`\`\`

따라서 PR #13851 이 wiring 한 observer 들은 **dead path 안의 dead wiring** 입니다 — production 에서 metric 이 한 번도 emit 되지 않았습니다 (\`backend.ml\` hook ref 의 default no-op 가 그대로 유지됨). \`Backend.FileSystem.create\` 의 실제 production caller 는 \`lib/coord/coord_utils_backend_setup.ml:323\` 인데 거기엔 wiring 이 없습니다.

이 PR 은 11줄을 단순 제거합니다. Runtime regression 은 0 입니다 (애초 emit 되지 않았으므로).

## 후속 작업 (별도 PR)

#13851 의 *의도* (mutex contention 측정) 를 살리려면:

1. \`masc_mcp\` lib startup 지점 (예: \`bin/main_eio.ml\` 또는 \`lib/server/server_bootstrap_loops.ml\`) 에 \`Backend.FileSystem.set_mutex_observers\` 호출을 설치
2. 그 호출은 \`Prometheus\` closure 를 직접 전달
3. Production backend 생성 경로 (\`coord_utils_backend_setup.ml:323\`) 가 observer 설치 *이후* 실행되도록 ordering 보장

이 재배치는 multi-file 결정이라 별도 PR 로 분리합니다. 본 PR 의 우선순위는 main blocker 해소.

## 변경

\`\`\`
lib/coord/coord_eio.ml | 17 ++++++-----------
1 file changed, 6 insertions(+), 11 deletions(-)
\`\`\`

11 줄 제거 + 6 줄 주석 (제거 사유와 follow-up 안내). \`Coord_eio.create_config\` 의 시그니처 변경 없음, .mli 변경 없음.

## 검증

- \`dune build @check --root=.\` → exit 0
- \`dune build lib/coord/.masc_coord.objs/byte/coord_eio.cmo --root=.\` → exit 0
- 기존 \`Coord_eio.create_config\` API 시그니처 유지 (\`fs:... -> ?clock:... -> string -> config\`)

## Best Programmer self-review

- 목표: main 빌드 차단 해소
- 변경 파일: 1 (\`lib/coord/coord_eio.ml\`)
- 로컬 검증: \`dune build @check\` 통과
- 미검증: 전체 테스트 스위트 (\`dune test\`) — 본 변경은 dead-path 제거이므로 테스트 영향 없음 추정. CI 가 검증할 영역.
- 아키텍처: dead-code 제거. observability follow-up 별도 분리.

🤖 Generated with [Claude Code](https://claude.com/claude-code)