### PR TITLE
feat(dashboard): expose O5 heuristic and stress feeds

### DIFF
--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -997,10 +997,20 @@ export interface HeuristicEvent {
   detail?: string
 }
 
+export interface HeuristicFiring {
+  id: string
+  ts: number
+  rule_id: string
+  agent?: string
+  action: string
+  cooldown_remaining_ms?: number
+}
+
 export interface HeuristicsResponse {
   limit: number
   count: number
   events: HeuristicEvent[]
+  heuristics: HeuristicFiring[]
 }
 
 function decodeHeuristicEvent(raw: unknown): HeuristicEvent | null {
@@ -1020,6 +1030,20 @@ function decodeHeuristicEvent(raw: unknown): HeuristicEvent | null {
   }
 }
 
+function decodeHeuristicFiring(raw: unknown): HeuristicFiring | null {
+  if (!isRecord(raw)) return null
+  return {
+    id: asString(raw.id) ?? '',
+    ts: asNumber(raw.ts) ?? 0,
+    rule_id: asString(raw.rule_id) ?? '',
+    agent: asNullableString(raw.agent) ?? undefined,
+    action: asString(raw.action) ?? '',
+    cooldown_remaining_ms: raw.cooldown_remaining_ms === undefined
+      ? undefined
+      : (asInt(raw.cooldown_remaining_ms) ?? 0),
+  }
+}
+
 function decodeHeuristicsResponse(raw: unknown): HeuristicsResponse | null {
   if (!isRecord(raw)) return null
   return {
@@ -1028,6 +1052,9 @@ function decodeHeuristicsResponse(raw: unknown): HeuristicsResponse | null {
     events: asRecordArray(raw.events)
       .map(decodeHeuristicEvent)
       .filter((e): e is HeuristicEvent => e !== null),
+    heuristics: asRecordArray(raw.heuristics)
+      .map(decodeHeuristicFiring)
+      .filter((e): e is HeuristicFiring => e !== null),
   }
 }
 
@@ -1062,6 +1089,19 @@ export interface StressResponse {
   limit: number
   count: number
   events: StressEvent[]
+  agent_stress: AgentStressRow[]
+}
+
+export interface AgentStressRow {
+  agent: string
+  budget_pressure: number
+  ctx_pressure: number
+  queue_depth: number
+  blocked_on?: string
+  ts: number
+  budget_pressure_source?: string
+  ctx_pressure_source?: string
+  queue_depth_source?: string
 }
 
 function decodeStressKind(raw: unknown): StressKind | null {
@@ -1089,6 +1129,21 @@ function decodeStressEvent(raw: unknown): StressEvent | null {
   }
 }
 
+function decodeAgentStressRow(raw: unknown): AgentStressRow | null {
+  if (!isRecord(raw)) return null
+  return {
+    agent: asString(raw.agent) ?? '',
+    budget_pressure: asNumber(raw.budget_pressure) ?? 0,
+    ctx_pressure: asNumber(raw.ctx_pressure) ?? 0,
+    queue_depth: asInt(raw.queue_depth) ?? 0,
+    blocked_on: asNullableString(raw.blocked_on) ?? undefined,
+    ts: asNumber(raw.ts) ?? 0,
+    budget_pressure_source: asNullableString(raw.budget_pressure_source) ?? undefined,
+    ctx_pressure_source: asNullableString(raw.ctx_pressure_source) ?? undefined,
+    queue_depth_source: asNullableString(raw.queue_depth_source) ?? undefined,
+  }
+}
+
 function decodeStressResponse(raw: unknown): StressResponse | null {
   if (!isRecord(raw)) return null
   return {
@@ -1097,6 +1152,9 @@ function decodeStressResponse(raw: unknown): StressResponse | null {
     events: asRecordArray(raw.events)
       .map(decodeStressEvent)
       .filter((e): e is StressEvent => e !== null),
+    agent_stress: asRecordArray(raw.agent_stress)
+      .map(decodeAgentStressRow)
+      .filter((row): row is AgentStressRow => row !== null),
   }
 }
 

--- a/dashboard/src/components/cost-dashboard.ts
+++ b/dashboard/src/components/cost-dashboard.ts
@@ -28,6 +28,7 @@ import {
   type HeuristicCoverage,
   type CoverageSite,
   type StressEvent,
+  type AgentStressRow,
   type AuditEntry,
   type AuditLedgerResponse,
   type KeeperDecision,
@@ -92,7 +93,7 @@ type HeuristicLoadState =
 type StressLoadState =
   | { status: 'idle' }
   | { status: 'loading' }
-  | { status: 'loaded'; data: StressEvent[]; limit: number }
+  | { status: 'loaded'; events: StressEvent[]; board: AgentStressRow[]; limit: number }
   | { status: 'error'; message: string }
 
 type CoverageLoadState =
@@ -245,7 +246,7 @@ async function loadStress(limit = 100) {
   stressState.value = { status: 'loading' }
   try {
     const resp = await fetchStress(limit)
-    stressState.value = { status: 'loaded', data: resp.events, limit: resp.limit }
+    stressState.value = { status: 'loaded', events: resp.events, board: resp.agent_stress, limit: resp.limit }
   } catch (err) {
     const message = err instanceof Error ? err.message : 'stress events 불러오기 실패'
     stressState.value = { status: 'error', message }
@@ -662,7 +663,7 @@ function HeuristicLog({ events, limit }: { events: HeuristicEvent[]; limit: numb
   `
 }
 
-function StressBoard({ events, limit }: { events: StressEvent[]; limit: number }) {
+function StressBoard({ rows, events, limit }: { rows: AgentStressRow[]; events: StressEvent[]; limit: number }) {
   const fmtTime = (ts: number): string => {
     const d = new Date(ts * 1000)
     return d.toLocaleTimeString('ko-KR', { hour: '2-digit', minute: '2-digit', second: '2-digit', hour12: false })
@@ -693,14 +694,56 @@ function StressBoard({ events, limit }: { events: StressEvent[]; limit: number }
     }
   }
 
+  const pressureTone = (value: number): string => {
+    if (value >= 0.75) return 'text-[var(--color-status-err)]'
+    if (value >= 0.45) return 'text-[var(--color-status-warn)]'
+    return 'text-[var(--color-status-ok)]'
+  }
+
+  const sourceHint = (row: AgentStressRow): string => {
+    return [
+      row.budget_pressure_source ? `budget=${row.budget_pressure_source}` : '',
+      row.ctx_pressure_source ? `ctx=${row.ctx_pressure_source}` : '',
+      row.queue_depth_source ? `queue=${row.queue_depth_source}` : '',
+    ].filter(Boolean).join(' · ')
+  }
+
   return html`
-    <section class="flex flex-col gap-2" aria-label=${`Stress board · ${events.length} events`}>
+    <section class="flex flex-col gap-2" aria-label=${`Stress board · ${rows.length} agents · ${events.length} events`}>
       <div class="flex items-center justify-between rounded-[var(--r-1)] border border-card-border/60 bg-[var(--backdrop-deep)] px-3 py-2">
-        <span class="font-mono text-2xs uppercase tracking-[var(--track-caps)] text-text-muted">stress board · ${events.length} events</span>
+        <span class="font-mono text-2xs uppercase tracking-[var(--track-caps)] text-text-muted">stress board · ${rows.length} agents · ${events.length} events</span>
         <span class="font-mono text-2xs text-text-muted">limit ${limit}</span>
       </div>
       <div class="overflow-x-auto rounded-[var(--r-1)] border border-card-border/60 bg-[var(--backdrop-deep)]">
-        <table class="w-full" aria-label="Stress events">
+        <table class="w-full" aria-label="Agent stress board">
+          <thead>
+            <tr class="border-b border-[var(--color-border-default)] text-2xs uppercase tracking-[var(--track-caps)] text-text-muted">
+              <th scope="col" class="px-2 py-1.5 text-left">agent</th>
+              <th scope="col" class="px-2 py-1.5 text-right">budget</th>
+              <th scope="col" class="px-2 py-1.5 text-right">context</th>
+              <th scope="col" class="px-2 py-1.5 text-right">queue</th>
+              <th scope="col" class="px-2 py-1.5 text-left">blocked</th>
+              <th scope="col" class="px-2 py-1.5 text-left">source</th>
+              <th scope="col" class="px-2 py-1.5 text-left">time</th>
+            </tr>
+          </thead>
+          <tbody>
+            ${rows.map((row, i) => html`
+              <tr key=${i} class="border-b border-[var(--color-border-default)]/50 text-2xs">
+                <td class="px-2 py-1.5 text-text-strong">${row.agent}</td>
+                <td class=${`px-2 py-1.5 text-right font-mono ${pressureTone(row.budget_pressure)}`}>${formatPct1(row.budget_pressure)}</td>
+                <td class=${`px-2 py-1.5 text-right font-mono ${pressureTone(row.ctx_pressure)}`}>${formatPct1(row.ctx_pressure)}</td>
+                <td class="px-2 py-1.5 text-right font-mono text-text-muted">${row.queue_depth}</td>
+                <td class="px-2 py-1.5 text-text-muted">${row.blocked_on ?? '—'}</td>
+                <td class="px-2 py-1.5 text-text-muted">${sourceHint(row)}</td>
+                <td class="px-2 py-1.5 font-mono text-text-muted">${row.ts > 0 ? fmtTime(row.ts) : '—'}</td>
+              </tr>
+            `)}
+          </tbody>
+        </table>
+      </div>
+      <div class="overflow-x-auto rounded-[var(--r-1)] border border-card-border/60 bg-[var(--backdrop-deep)]">
+        <table class="w-full" aria-label="Recent stress events">
           <thead>
             <tr class="border-b border-[var(--color-border-default)] text-2xs uppercase tracking-[var(--track-caps)] text-text-muted">
               <th scope="col" class="px-2 py-1.5 text-left">time</th>
@@ -1330,7 +1373,7 @@ function CostDashboardContent({ view }: { view: CostView }) {
           <h2 class="text-base font-semibold text-text-strong">스트레스 이벤트</h2>
         </header>
         ${stressState.value.status === 'loaded'
-          ? html`<${StressBoard} events=${stressState.value.data} limit=${stressState.value.limit} />`
+          ? html`<${StressBoard} rows=${stressState.value.board} events=${stressState.value.events} limit=${stressState.value.limit} />`
           : stressState.value.status === 'error'
             ? html`<${ErrorState} message=${stressState.value.message} onRetry=${() => void loadStress()} />`
             : html`<${LoadingState} />`}

--- a/lib/agent_stress.ml
+++ b/lib/agent_stress.ml
@@ -90,6 +90,162 @@ let event_to_json (e : event) : Yojson.Safe.t =
     ("timestamp", `Float e.timestamp);
   ]
 
+type board_agent = {
+  agent : string;
+  ctx_pressure : float option;
+  queue_depth : int option;
+  blocked_on : string option;
+  ts : float option;
+}
+
+type board_acc = {
+  agent : string;
+  mutable budget_pressure : float;
+  mutable ctx_pressure : float option;
+  mutable queue_depth : int option;
+  mutable blocked_on : string option;
+  mutable ts : float;
+  mutable saw_event : bool;
+}
+
+let clamp01 value =
+  if value < 0.0 then 0.0 else if value > 1.0 then 1.0 else value
+
+let string_field name fields =
+  match List.assoc_opt name fields with
+  | Some (`String s) -> Some s
+  | _ -> None
+
+let int_field name fields =
+  match List.assoc_opt name fields with
+  | Some (`Int n) -> Some n
+  | Some (`Float f) -> Some (int_of_float f)
+  | _ -> None
+
+let float_field name fields =
+  match List.assoc_opt name fields with
+  | Some (`Float f) -> Some f
+  | Some (`Int n) -> Some (float_of_int n)
+  | _ -> None
+
+let pressure_of_kind_fields fields =
+  match string_field "type" fields with
+  | Some "failure_streak" ->
+      let count = int_field "count" fields |> Option.value ~default:0 in
+      clamp01 (float_of_int count /. 3.0)
+  | Some "turn_failure" ->
+      let consecutive =
+        int_field "consecutive" fields |> Option.value ~default:0
+      in
+      let threshold = int_field "threshold" fields |> Option.value ~default:3 in
+      if threshold <= 0 then 0.0
+      else clamp01 (float_of_int consecutive /. float_of_int threshold)
+  | Some "timeout" -> 0.65
+  | Some "task_released" -> 0.60
+  | Some "parse_degraded" -> 0.40
+  | Some "fallback_approval" -> 0.30
+  | Some _ | None -> 0.0
+
+let blocker_of_kind_fields fields =
+  match string_field "type" fields with
+  | Some ("failure_streak" | "turn_failure" | "timeout" | "task_released") as kind ->
+      kind
+  | Some _ | None -> None
+
+let ensure_acc table agent =
+  match Hashtbl.find_opt table agent with
+  | Some acc -> acc
+  | None ->
+      let acc = {
+        agent;
+        budget_pressure = 0.0;
+        ctx_pressure = None;
+        queue_depth = None;
+        blocked_on = None;
+        ts = 0.0;
+        saw_event = false;
+      } in
+      Hashtbl.add table agent acc;
+      acc
+
+let merge_board_agent table (agent : board_agent) =
+  let name = String.trim agent.agent in
+  if name <> "" then begin
+    let acc = ensure_acc table name in
+    acc.ctx_pressure <- agent.ctx_pressure;
+    acc.queue_depth <- agent.queue_depth;
+    (match agent.blocked_on with
+     | Some value when String.trim value <> "" ->
+         acc.blocked_on <- Some (String.trim value)
+     | _ -> ());
+    (match agent.ts with
+     | Some ts when ts > acc.ts -> acc.ts <- ts
+     | _ -> ())
+  end
+
+let merge_event table (json : Yojson.Safe.t) =
+  match json with
+  | `Assoc fields -> (
+      match string_field "agent_name" fields with
+      | None | Some "" -> ()
+      | Some agent ->
+          let acc = ensure_acc table agent in
+          acc.saw_event <- true;
+          let ts = float_field "timestamp" fields |> Option.value ~default:0.0 in
+          if ts > acc.ts then acc.ts <- ts;
+          (match List.assoc_opt "kind" fields with
+           | Some (`Assoc kind_fields) ->
+               acc.budget_pressure <-
+                 max acc.budget_pressure (pressure_of_kind_fields kind_fields);
+               (match acc.blocked_on, blocker_of_kind_fields kind_fields with
+                | None, Some blocker -> acc.blocked_on <- Some blocker
+                | _ -> ())
+           | _ -> ()))
+  | _ -> ()
+
+let board_row_to_json acc =
+  let base = [
+    ("agent", `String acc.agent);
+    ("budget_pressure", `Float (clamp01 acc.budget_pressure));
+    ("ctx_pressure",
+     `Float (acc.ctx_pressure |> Option.value ~default:0.0 |> clamp01));
+    ("queue_depth", `Int (acc.queue_depth |> Option.value ~default:0));
+    ("ts", `Float acc.ts);
+    ("ctx_pressure_source",
+     `String (if Option.is_some acc.ctx_pressure then "keeper_meta" else "unavailable"));
+    ("queue_depth_source",
+     `String (if Option.is_some acc.queue_depth then "autonomous_queue_metric" else "unavailable"));
+    ("budget_pressure_source",
+     `String (if acc.saw_event then "agent_stress_events" else "unavailable"));
+  ] in
+  let fields =
+    match acc.blocked_on with
+    | None -> base
+    | Some blocker -> base @ [("blocked_on", `String blocker)]
+  in
+  `Assoc fields
+
+let board_rows_json ?(agents = []) events =
+  let table = Hashtbl.create 16 in
+  List.iter (merge_board_agent table) agents;
+  List.iter (merge_event table) events;
+  Hashtbl.fold (fun _ acc rows -> board_row_to_json acc :: rows) table []
+  |> List.sort (fun left right ->
+       match left, right with
+       | `Assoc lf, `Assoc rf ->
+           let la = string_field "agent" lf |> Option.value ~default:"" in
+           let ra = string_field "agent" rf |> Option.value ~default:"" in
+           String.compare la ra
+       | _ -> 0)
+
+let dashboard_feed_json ~limit ?(agents = []) events =
+  `Assoc [
+    ("limit", `Int limit);
+    ("count", `Int (List.length events));
+    ("events", `List events);
+    ("agent_stress", `List (board_rows_json ~agents events));
+  ]
+
 (* ================================================================ *)
 (* Storage (same pattern as Heuristic_metrics)                      *)
 (* ================================================================ *)

--- a/lib/agent_stress.mli
+++ b/lib/agent_stress.mli
@@ -76,3 +76,28 @@ val recent : int -> Yojson.Safe.t list
 
 val event_to_json : event -> Yojson.Safe.t
 (** Serialize an event for external consumption. *)
+
+type board_agent = {
+  agent : string;
+  ctx_pressure : float option;
+  queue_depth : int option;
+  blocked_on : string option;
+  ts : float option;
+}
+(** Optional live keeper metadata used to enrich the Phase 2 O5
+    [agent_stress] board projection.  Missing fields are surfaced with
+    explicit *_source markers instead of inventing hidden data. *)
+
+val board_rows_json :
+  ?agents:board_agent list -> Yojson.Safe.t list -> Yojson.Safe.t list
+(** Project raw stress events into the O5
+    [agent_stress: {agent, budget_pressure, ctx_pressure, queue_depth,
+    blocked_on?, ts}[]] board shape. *)
+
+val dashboard_feed_json :
+  limit:int ->
+  ?agents:board_agent list ->
+  Yojson.Safe.t list ->
+  Yojson.Safe.t
+(** Build the dashboard response carrying both the existing [events] array
+    and the O5 compatibility [agent_stress] board rows. *)

--- a/lib/heuristic_metrics.ml
+++ b/lib/heuristic_metrics.ml
@@ -79,6 +79,66 @@ let event_to_json (e : event) : Yojson.Safe.t =
     ("timestamp", `Float e.timestamp);
   ]
 
+let string_field name fields =
+  match List.assoc_opt name fields with
+  | Some (`String s) -> Some s
+  | _ -> None
+
+let float_field name fields =
+  match List.assoc_opt name fields with
+  | Some (`Float f) -> Some f
+  | Some (`Int n) -> Some (float_of_int n)
+  | _ -> None
+
+let bool_field name fields =
+  match List.assoc_opt name fields with
+  | Some (`Bool b) -> Some b
+  | _ -> None
+
+let non_empty_or fallback value =
+  let trimmed = String.trim value in
+  if trimmed = "" then fallback else trimmed
+
+let rule_id_of_fields fields =
+  let module_name =
+    string_field "module" fields |> Option.value ~default:""
+    |> non_empty_or "unknown"
+  in
+  let site =
+    string_field "site" fields |> Option.value ~default:""
+    |> non_empty_or "unknown"
+  in
+  if String.equal module_name "unknown" then site
+  else module_name ^ "." ^ site
+
+let dashboard_issue_event_to_json (json : Yojson.Safe.t) : Yojson.Safe.t option =
+  match json with
+  | `Assoc fields ->
+      let rule_id = rule_id_of_fields fields in
+      let timestamp = float_field "timestamp" fields |> Option.value ~default:0.0 in
+      let triggered = bool_field "triggered" fields |> Option.value ~default:false in
+      let id = Printf.sprintf "%s:%.3f" rule_id timestamp in
+      Some (`Assoc [
+        ("id", `String id);
+        ("ts", `Float timestamp);
+        ("rule_id", `String rule_id);
+        ("action", `String (if triggered then "triggered" else "observed"));
+        ("cooldown_remaining_ms", `Int 0);
+        ("source", `String "heuristic_metrics");
+      ])
+  | _ -> None
+
+let dashboard_issue_events events =
+  List.filter_map dashboard_issue_event_to_json events
+
+let dashboard_feed_json ~limit events =
+  `Assoc [
+    ("limit", `Int limit);
+    ("count", `Int (List.length events));
+    ("events", `List events);
+    ("heuristics", `List (dashboard_issue_events events));
+  ]
+
 (* ================================================================ *)
 (* Storage                                                          *)
 (* ================================================================ *)

--- a/lib/heuristic_metrics.mli
+++ b/lib/heuristic_metrics.mli
@@ -96,3 +96,13 @@ val coverage_report_to_json : coverage_report -> Yojson.Safe.t
 
 val event_to_json : event -> Yojson.Safe.t
 (** Serialize an event for external consumption (dashboard, tests). *)
+
+val dashboard_issue_events : Yojson.Safe.t list -> Yojson.Safe.t list
+(** Project raw heuristic metric events into the Phase 2 O5
+    [heuristics: {id, ts, rule_id, action, cooldown_remaining_ms?}[]]
+    compatibility shape.  The raw [events] stream remains the canonical
+    diagnostics payload. *)
+
+val dashboard_feed_json : limit:int -> Yojson.Safe.t list -> Yojson.Safe.t
+(** Build the dashboard response carrying both the existing [events] array
+    and the O5 compatibility [heuristics] array. *)

--- a/lib/server/server_h2_gateway.ml
+++ b/lib/server/server_h2_gateway.ml
@@ -645,6 +645,34 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
             h2_respond_json h2_reqd (Yojson.Safe.to_string json)
               ~extra_headers:cors)
 
+      | `GET, "/api/v1/dashboard/heuristics"
+      | `GET, "/api/v1/heuristics" ->
+          let json =
+            Server_routes_http_routes_provider_runs.dashboard_heuristics_json
+              httpun_request
+          in
+          h2_respond_json h2_reqd (Yojson.Safe.to_string json)
+            ~extra_headers:cors
+
+      | `GET, "/api/v1/dashboard/heuristics/coverage"
+      | `GET, "/api/v1/heuristics/coverage" ->
+          let json =
+            Server_routes_http_routes_provider_runs.dashboard_heuristics_coverage_json
+              httpun_request
+          in
+          h2_respond_json h2_reqd (Yojson.Safe.to_string json)
+            ~extra_headers:cors
+
+      | `GET, "/api/v1/dashboard/stress"
+      | `GET, "/api/v1/agent_stress" ->
+          with_server_state h2_reqd (fun state ->
+            let json =
+              Server_routes_http_routes_provider_runs.dashboard_stress_json
+                ~config:state.Mcp_server.room_config httpun_request
+            in
+            h2_respond_json h2_reqd (Yojson.Safe.to_string json)
+              ~extra_headers:cors)
+
       | `GET, "/api/v1/dashboard/config" ->
           with_h2_public_read h2_reqd (fun _state ->
             let json = Env_config_introspect.to_json () in

--- a/lib/server/server_routes_http_routes_provider_runs.ml
+++ b/lib/server/server_routes_http_routes_provider_runs.ml
@@ -7,6 +7,69 @@ module Http = Http_server_eio
 let dashboard_feed_limit req =
   int_query_param req "limit" ~default:200 |> clamp ~min_v:1 ~max_v:200
 
+let o5_agent_board_inputs (config : Coord.config) =
+  let queue_depth =
+    Prometheus.metric_value_or_zero Prometheus.metric_keeper_turn_queue_depth
+      ~labels:[("channel", "autonomous_queue")] ()
+    |> int_of_float
+    |> max 0
+  in
+  let now = Unix.gettimeofday () in
+  Keeper_types.keeper_names config
+  |> List.filter_map (fun name ->
+       match Keeper_types.read_meta config name with
+       | Ok (Some meta) ->
+           let blocked_on =
+             let value = String.trim meta.runtime.last_blocker in
+             if value = "" then None else Some value
+           in
+           Some {
+             Agent_stress.agent = meta.name;
+             ctx_pressure = Operator_control_snapshot.compute_context_ratio meta;
+             queue_depth = Some queue_depth;
+             blocked_on;
+             ts = Some now;
+           }
+       | Ok None | Error _ -> None)
+
+let dashboard_heuristics_json req =
+  let limit = int_query_param req "limit" ~default:100 in
+  let events = Heuristic_metrics.recent limit in
+  Heuristic_metrics.dashboard_feed_json ~limit events
+
+let dashboard_heuristics_coverage_json req =
+  let limit = int_query_param req "limit" ~default:100 in
+  Heuristic_metrics.recent_coverage limit
+  |> Heuristic_metrics.coverage_report_to_json
+
+let dashboard_stress_json ~config req =
+  let limit = int_query_param req "limit" ~default:100 in
+  let events = Agent_stress.recent limit in
+  let agents = o5_agent_board_inputs config in
+  Agent_stress.dashboard_feed_json ~limit ~agents events
+
+let respond_dashboard_heuristics request reqd =
+  with_public_read (fun _state req reqd ->
+    let json = dashboard_heuristics_json req in
+    Http.Response.json ~compress:true ~request:req
+      (Yojson.Safe.to_string json) reqd
+  ) request reqd
+
+let respond_dashboard_heuristics_coverage request reqd =
+  with_public_read (fun _state req reqd ->
+    let json = dashboard_heuristics_coverage_json req in
+    Http.Response.json ~compress:true ~request:req
+      (Yojson.Safe.to_string json) reqd
+  ) request reqd
+
+let respond_dashboard_stress request reqd =
+  with_public_read (fun state req reqd ->
+    let config = state.Mcp_server.room_config in
+    let json = dashboard_stress_json ~config req in
+    Http.Response.json ~compress:true ~request:req
+      (Yojson.Safe.to_string json) reqd
+  ) request reqd
+
 let add_routes ~sw router =
   router
   |> Http.Router.get "/api/v1/providers" (fun request reqd ->
@@ -176,40 +239,11 @@ let add_routes ~sw router =
          Http.Response.json ~compress:true ~request:req
            (Yojson.Safe.to_string json) reqd
        ) request reqd)
-  |> Http.Router.get "/api/v1/dashboard/heuristics" (fun request reqd ->
-       with_public_read (fun _state req reqd ->
-         let limit = int_query_param req "limit" ~default:100 in
-         let events = Heuristic_metrics.recent limit in
-         let json =
-           `Assoc [
-             ("limit", `Int limit);
-             ("count", `Int (List.length events));
-             ("events", `List events);
-           ]
-         in
-         Http.Response.json ~compress:true ~request:req
-           (Yojson.Safe.to_string json) reqd
-       ) request reqd)
-  |> Http.Router.get "/api/v1/dashboard/heuristics/coverage" (fun request reqd ->
-       with_public_read (fun _state req reqd ->
-         let limit = int_query_param req "limit" ~default:100 in
-         let report = Heuristic_metrics.recent_coverage limit in
-         Http.Response.json ~compress:true ~request:req
-           (Yojson.Safe.to_string
-              (Heuristic_metrics.coverage_report_to_json report))
-           reqd
-       ) request reqd)
-  |> Http.Router.get "/api/v1/dashboard/stress" (fun request reqd ->
-       with_public_read (fun _state req reqd ->
-         let limit = int_query_param req "limit" ~default:100 in
-         let events = Agent_stress.recent limit in
-         let json =
-           `Assoc [
-             ("limit", `Int limit);
-             ("count", `Int (List.length events));
-             ("events", `List events);
-           ]
-         in
-         Http.Response.json ~compress:true ~request:req
-           (Yojson.Safe.to_string json) reqd
-       ) request reqd)
+  |> Http.Router.get "/api/v1/dashboard/heuristics" respond_dashboard_heuristics
+  |> Http.Router.get "/api/v1/heuristics" respond_dashboard_heuristics
+  |> Http.Router.get "/api/v1/dashboard/heuristics/coverage"
+       respond_dashboard_heuristics_coverage
+  |> Http.Router.get "/api/v1/heuristics/coverage"
+       respond_dashboard_heuristics_coverage
+  |> Http.Router.get "/api/v1/dashboard/stress" respond_dashboard_stress
+  |> Http.Router.get "/api/v1/agent_stress" respond_dashboard_stress

--- a/lib/server/server_routes_http_routes_provider_runs.mli
+++ b/lib/server/server_routes_http_routes_provider_runs.mli
@@ -7,3 +7,13 @@
 val add_routes :
   sw:Eio.Switch.t ->
   Http_server_eio.Router.t -> Http_server_eio.Router.t
+
+val dashboard_heuristics_json : Httpun.Request.t -> Yojson.Safe.t
+(** Shared HTTP/1 + H2 response builder for O5 heuristic feeds. *)
+
+val dashboard_heuristics_coverage_json : Httpun.Request.t -> Yojson.Safe.t
+(** Shared HTTP/1 + H2 response builder for heuristic coverage. *)
+
+val dashboard_stress_json :
+  config:Coord.config -> Httpun.Request.t -> Yojson.Safe.t
+(** Shared HTTP/1 + H2 response builder for O5 agent stress feeds. *)

--- a/test/dune
+++ b/test/dune
@@ -1259,6 +1259,11 @@
  (libraries masc_test_deps))
 
 (test
+ (name test_dashboard_o5_feeds)
+ (modules test_dashboard_o5_feeds)
+ (libraries masc_test_deps))
+
+(test
  (name test_masc_contract_catalog)
  (modules test_masc_contract_catalog)
  (libraries masc_test_deps))

--- a/test/test_dashboard_o5_feeds.ml
+++ b/test/test_dashboard_o5_feeds.ml
@@ -1,0 +1,91 @@
+open Masc_mcp
+module U = Yojson.Safe.Util
+
+let first_list_item name json =
+  match json |> U.member name |> U.to_list with
+  | x :: _ -> x
+  | [] -> Alcotest.failf "expected %s to contain at least one item" name
+;;
+
+let test_heuristics_feed_exposes_o5_shape () =
+  let event =
+    Heuristic_metrics.event_to_json
+      { module_name = "keeper"
+      ; site = "guard"
+      ; raw_value = 0.91
+      ; threshold = 0.80
+      ; triggered = true
+      ; provenance = Heuristic_metrics.Drift_guard "ctx"
+      ; timestamp = 1_777_120_045.0
+      }
+  in
+  let feed = Heuristic_metrics.dashboard_feed_json ~limit:50 [ event ] in
+  let item = first_list_item "heuristics" feed in
+  Alcotest.(check int) "raw event count" 1 (feed |> U.member "count" |> U.to_int);
+  Alcotest.(check string)
+    "rule id"
+    "keeper.guard"
+    (item |> U.member "rule_id" |> U.to_string);
+  Alcotest.(check string) "action" "triggered" (item |> U.member "action" |> U.to_string);
+  Alcotest.(check int) "cooldown" 0 (item |> U.member "cooldown_remaining_ms" |> U.to_int)
+;;
+
+let test_agent_stress_feed_exposes_board_rows () =
+  let event =
+    Agent_stress.event_to_json
+      { agent_name = "sangsu"
+      ; room_id = "default"
+      ; kind =
+          Agent_stress.Turn_failure
+            { consecutive = 2
+            ; threshold = 4
+            ; counted_toward_crash = true
+            ; recoverable = false
+            ; error_kind = Some (Agent_stress.error_kind_of_string "api")
+            }
+      ; timestamp = 99.0
+      }
+  in
+  let agents =
+    [ { Agent_stress.agent = "sangsu"
+      ; ctx_pressure = Some 0.80
+      ; queue_depth = Some 2
+      ; blocked_on = Some "Admission_queue_wait_timeout"
+      ; ts = Some 100.0
+      }
+    ]
+  in
+  let feed = Agent_stress.dashboard_feed_json ~limit:25 ~agents [ event ] in
+  let row = first_list_item "agent_stress" feed in
+  Alcotest.(check int) "raw event count" 1 (feed |> U.member "count" |> U.to_int);
+  Alcotest.(check string) "agent" "sangsu" (row |> U.member "agent" |> U.to_string);
+  Alcotest.(check (float 0.001))
+    "budget pressure"
+    0.50
+    (row |> U.member "budget_pressure" |> U.to_float);
+  Alcotest.(check (float 0.001))
+    "context pressure"
+    0.80
+    (row |> U.member "ctx_pressure" |> U.to_float);
+  Alcotest.(check int) "queue depth" 2 (row |> U.member "queue_depth" |> U.to_int);
+  Alcotest.(check string)
+    "blocked on"
+    "Admission_queue_wait_timeout"
+    (row |> U.member "blocked_on" |> U.to_string)
+;;
+
+let () =
+  Alcotest.run
+    "dashboard_o5_feeds"
+    [ ( "o5"
+      , [ Alcotest.test_case
+            "heuristics response carries issue-shape array"
+            `Quick
+            test_heuristics_feed_exposes_o5_shape
+        ; Alcotest.test_case
+            "stress response carries agent board rows"
+            `Quick
+            test_agent_stress_feed_exposes_board_rows
+        ] )
+    ]
+;;


### PR DESCRIPTION
## Summary

- Implements #11572 O5 feed compatibility for heuristic firing logs and the fleet agent stress board.
- Preserves existing raw `events` arrays while adding `heuristics` and `agent_stress` projections in the issue-requested shapes.
- Adds top-level aliases for the dashboard feeds: `/api/v1/heuristics`, `/api/v1/heuristics/coverage`, and `/api/v1/agent_stress`, with HTTP/1 and H2 parity.
- Updates the dashboard decoder and stress view to render board rows before the raw recent event log.

## Operator Impact

- Operators can now inspect heuristic firing state and agent stress from stable API contracts instead of reverse-engineering raw event rows.
- Missing or derived stress fields carry explicit `*_source` markers, so the board does not silently fabricate budget/context/queue signals.
- The existing `/api/v1/dashboard/heuristics`, `/api/v1/dashboard/heuristics/coverage`, and `/api/v1/dashboard/stress` responses remain backward-compatible via the unchanged `events` payloads.

## Verification

- `pnpm install --frozen-lockfile --offline`
- `pnpm run typecheck`
- `git diff --check origin/main...HEAD`
- Attempted `scripts/dune-local.sh build test/test_dashboard_o5_feeds.exe`, but local backend verification stayed queued behind `/tmp/me-opam-switch.lock` / `/tmp/me-dune-local.lock` held by other active worktrees. CI is the backend compile/test gate for this draft.

Fixes #11572
