### PR TITLE
fix(oas): backpressure sse relay retries

### DIFF
--- a/lib/oas_event_bridge.ml
+++ b/lib/oas_event_bridge.ml
@@ -722,13 +722,15 @@ let deliver_pending ?store_ref (pending : pending_relay) =
   | Eio.Cancel.Cancelled _ as e -> raise e
   | exn -> Retryable_failure (pending, Append, exn)
 
-let enqueue_pending pending item =
-  if List.length pending < relay_max_queue_depth then
-    (pending @ [ item ], None)
-  else
-    match pending with
-    | dropped :: rest -> (rest @ [ item ], Some dropped)
-    | [] -> ([ item ], None)
+let should_drain_subscription pending =
+  (* Do not move new OAS bus events into the local retry queue while
+     failed relays are still pending.  The OAS subscriber stream is
+     bounded, so leaving it undrained applies publisher backpressure
+     instead of dropping the oldest local relay event. *)
+  pending = []
+
+let prepare_pending_events events =
+  List.filter_map prepare_pending_event events
 
 let rec process_pending ?store_ref acc = function
   | [] -> List.rev acc
@@ -780,6 +782,8 @@ module For_testing = struct
 
   let make_pending json = { json; attempts = 0; appended = false; }
 
+  let relay_max_queue_depth = relay_max_queue_depth
+
   let to_pending (pending : pending_relay) : bridge_pending_relay =
     { json = pending.json;
       attempts = pending.attempts;
@@ -812,6 +816,9 @@ module For_testing = struct
       ~broadcast_json
       (to_pending pending)
     |> of_result
+
+  let should_drain_subscription pending =
+    should_drain_subscription (List.map to_pending pending)
 end
 
 let start_impl ~interval_s ~sw ~clock ~(config : Coord.config) ~bus =
@@ -834,27 +841,12 @@ let start_impl ~interval_s ~sw ~clock ~(config : Coord.config) ~bus =
   Eio.Fiber.fork ~sw (fun () ->
     let rec loop () =
       (try
-         let events = Oas_bus_instrument.drain sub in
-         List.iter
-           (fun evt ->
-              match prepare_pending_event evt with
-              | None -> ()
-              | Some item ->
-                  let next_pending, dropped = enqueue_pending !pending item in
-                  pending := next_pending;
-                  (match dropped with
-                   | None -> ()
-                   | Some dropped ->
-                       Prometheus.inc_counter Prometheus.metric_oas_sse_relay_drops
-                         ~labels:[ ("stage", "queue") ] ();
-                       emit_relay_drop_log ~pending:dropped
-                         ~stage_label:"queue"
-                         ~attempts:dropped.attempts;
-                       broadcast_drop_marker ~pending:dropped
-                         ~stage_label:"queue"
-                         ~attempts:dropped.attempts))
-           events;
          pending := process_pending ~store_ref:store [] !pending;
+         if should_drain_subscription !pending then begin
+           let events = Oas_bus_instrument.drain sub in
+           pending := prepare_pending_events events;
+           pending := process_pending ~store_ref:store [] !pending
+         end;
          update_relay_queue_depth !pending
        with
        | Eio.Cancel.Cancelled _ as e -> raise e

--- a/lib/oas_event_bridge.mli
+++ b/lib/oas_event_bridge.mli
@@ -51,6 +51,10 @@ module For_testing : sig
 
   val make_pending : Yojson.Safe.t -> pending_relay
 
+  val relay_max_queue_depth : int
+
+  val should_drain_subscription : pending_relay list -> bool
+
   val deliver_pending_with :
     append_json:(Yojson.Safe.t -> unit) ->
     broadcast_json:(Yojson.Safe.t -> unit) ->

--- a/test/test_oas_integration.ml
+++ b/test/test_oas_integration.ml
@@ -455,6 +455,25 @@ let test_oas_event_bridge_broadcast_retry_does_not_duplicate_append () =
   Alcotest.(check int) "retry does not duplicate durable append" 1 !append_count;
   Alcotest.(check int) "broadcast retried once" 2 !broadcast_count
 
+let test_oas_event_bridge_backpressures_when_retry_queue_full () =
+  let json =
+    `Assoc
+      [
+        ("type", `String "oas:tool_called");
+        ("event_type", `String "tool_called");
+        ("correlation_id", `String "sess-backpressure");
+        ("run_id", `String "run-backpressure");
+      ]
+  in
+  let pending =
+    List.init Oas_event_bridge.For_testing.relay_max_queue_depth
+      (fun _ -> Oas_event_bridge.For_testing.make_pending json)
+  in
+  Alcotest.(check bool) "empty queue drains subscription" true
+    (Oas_event_bridge.For_testing.should_drain_subscription []);
+  Alcotest.(check bool) "full retry queue blocks subscription drain" false
+    (Oas_event_bridge.For_testing.should_drain_subscription pending)
+
 (* ================================================================ *)
 (* Message conversion tests (formerly oas_checkpoint_bridge)         *)
 (* ================================================================ *)
@@ -1012,6 +1031,9 @@ let () =
         test_oas_event_bridge_drop_marker_on_exhausted_append_failure;
       Alcotest.test_case "sse bridge retry avoids duplicate append after broadcast failure" `Quick
         test_oas_event_bridge_broadcast_retry_does_not_duplicate_append;
+      Alcotest.test_case "sse bridge retry queue backpressures instead of dropping head"
+        `Quick
+        test_oas_event_bridge_backpressures_when_retry_queue_full;
       Alcotest.test_case "agent_completed includes usage" `Quick
         test_agent_completed_includes_usage;
       Alcotest.test_case "agent_completed success without usage omits usage fields"


### PR DESCRIPTION
## Summary
- Remove the SSE relay retry queue's head-drop overflow path.
- Stop draining the bounded OAS Event_bus subscription while relay retries remain pending, so publisher backpressure applies instead of losing the oldest local event.
- Add a focused test hook and regression case that a full retry queue blocks subscription draining.

## Why
The Kimi cleanup roadmap flagged `oas_event_bridge` queue overflow as unsafe because the oldest event was dropped once the retry queue exceeded 256. This preserves event order and losslessness under relay failure: retries are exhausted through the existing retry/drop-marker path, while new bus events stay in the bounded subscription stream until the bridge is ready to drain again.

## Validation
- `git diff --check origin/main...HEAD`
- `bash scripts/ci/check-silent-failure-patterns.sh`
- `ocamlformat --check` has the repo's existing no-output baseline failure on the changed OCaml files, so no formatter churn was included.
- Focused Dune build for `test/test_oas_integration.exe` was attempted twice but stayed blocked behind long-running shared local Dune locks; CI is the active compile/test surface for this draft.