### PR TITLE
fix: emit write_meta CAS retry metric

### DIFF
--- a/lib/keeper/keeper_meta_store.ml
+++ b/lib/keeper/keeper_meta_store.ml
@@ -383,6 +383,10 @@ let write_meta_with_retry ?(max_retries = 3) config (m : keeper_meta)
            Prometheus.metric_keeper_write_meta_failures
            ~labels:[("keeper", m.name); ("phase", "cas_retry")]
            ();
+         Prometheus.inc_counter
+           Prometheus.metric_write_meta_cas_retry_total
+           ~labels:[("keeper_name", m.name)]
+           ();
          Log.Keeper.warn
            "write_meta CAS retry %d/%d for %s (caller had %d, disk %d)"
            (n + 1)
@@ -424,6 +428,10 @@ let write_meta_with_merge
          Prometheus.inc_counter
            Prometheus.metric_keeper_write_meta_failures
            ~labels:[("keeper", caller.name); ("phase", "cas_retry_merge")]
+           ();
+         Prometheus.inc_counter
+           Prometheus.metric_write_meta_cas_retry_total
+           ~labels:[("keeper_name", caller.name)]
            ();
          Log.Keeper.warn
            "write_meta CAS retry %d/%d for %s (caller had %d, disk %d; field-level merge)"

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -548,6 +548,8 @@ let metric_keeper_tool_call_duration =
   "masc_keeper_tool_call_duration_seconds"
 let metric_keeper_write_meta_failures =
   "masc_keeper_write_meta_failures_total"
+let metric_write_meta_cas_retry_total =
+  "masc_write_meta_cas_retry_total"
 let metric_keeper_meta_read_failures =
   "masc_keeper_meta_read_failures_total"
 let metric_keeper_approval_queue_failures =
@@ -1642,6 +1644,9 @@ let init () =
      first observation. *)
   add metric_keeper_write_meta_failures
     "Total keeper meta-file write failures, labeled by keeper and phase"
+    Counter;
+  add metric_write_meta_cas_retry_total
+    "Total keeper meta write CAS retries, labeled by keeper_name"
     Counter;
   add metric_keeper_meta_read_failures
     "Total keeper meta-file read/parse failures, labeled by keeper and site"

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -278,6 +278,7 @@ val metric_keeper_heartbeat_failures : string
 val metric_keeper_cleanup_tracking_failures : string
 val metric_keeper_tool_call_duration : string
 val metric_keeper_write_meta_failures : string
+val metric_write_meta_cas_retry_total : string
 val metric_keeper_meta_read_failures : string
 val metric_keeper_approval_queue_failures : string
 val metric_keeper_guards_failures : string

--- a/test/test_keeper_meta_cas_retry.ml
+++ b/test/test_keeper_meta_cas_retry.ml
@@ -101,16 +101,30 @@ let test_retry_succeeds_after_concurrent_bump () =
        once; write_meta_with_retry must lift the payload onto the new
        disk version and succeed. *)
     let cycle_payload = { caller_view with goal = "cycle payload" } in
+    let before_retry_metric =
+      Prometheus.metric_value_or_zero
+        Prometheus.metric_write_meta_cas_retry_total
+        ~labels:[("keeper_name", "beta")]
+        ()
+    in
     (match Keeper_types.write_meta_with_retry config cycle_payload with
      | Ok () -> ()
      | Error e -> fail ("retry write failed: " ^ e));
+    let after_retry_metric =
+      Prometheus.metric_value_or_zero
+        Prometheus.metric_write_meta_cas_retry_total
+        ~labels:[("keeper_name", "beta")]
+        ()
+    in
     let final = match Keeper_types.read_meta config "beta" with
       | Ok (Some m) -> m
       | _ -> fail "final read failed"
     in
     check string "cycle payload wins (last writer)" "cycle payload" final.goal;
     check bool "version moved past racing write" true
-      (final.meta_version > racing.meta_version + 1))
+      (final.meta_version > racing.meta_version + 1);
+    check (float 0.001) "CAS retry metric increments" 1.0
+      (after_retry_metric -. before_retry_metric))
 
 let test_is_version_conflict_error_classifies () =
   let conflict_msg = "meta version conflict for foo: expected 3, disk has 4" in

--- a/test/test_keeper_meta_heartbeat_retain_9733.ml
+++ b/test/test_keeper_meta_heartbeat_retain_9733.ml
@@ -114,6 +114,12 @@ let test_caller_wins_cycle_disk_wins_heartbeat () =
     let cycle_payload =
       { caller_view with goal = "cycle done" }
     in
+    let before_retry_metric =
+      Prometheus.metric_value_or_zero
+        Prometheus.metric_write_meta_cas_retry_total
+        ~labels:[("keeper_name", name)]
+        ()
+    in
     (match
        Keeper_types.write_meta_with_merge
          ~merge:Keeper_meta_merge.heartbeat_fields_from_disk
@@ -121,6 +127,12 @@ let test_caller_wins_cycle_disk_wins_heartbeat () =
      with
      | Ok () -> ()
      | Error e -> fail ("merged retry failed: " ^ e));
+    let after_retry_metric =
+      Prometheus.metric_value_or_zero
+        Prometheus.metric_write_meta_cas_retry_total
+        ~labels:[("keeper_name", name)]
+        ()
+    in
     let final = match Keeper_types.read_meta config name with
       | Ok (Some m) -> m
       | _ -> fail "final read failed"
@@ -130,7 +142,9 @@ let test_caller_wins_cycle_disk_wins_heartbeat () =
       "disk wins: joined_room_ids preserved heartbeat update"
       ["r1"; "r2"] final.joined_room_ids;
     check bool "version moved past heartbeat write" true
-      (final.meta_version > heartbeat_payload.meta_version))
+      (final.meta_version > heartbeat_payload.meta_version);
+    check (float 0.001) "CAS retry metric increments for merge" 1.0
+      (after_retry_metric -. before_retry_metric))
 
 (* Sanity: when no concurrent writer interferes, the merge function
    is never called and behaviour matches plain

--- a/test/test_prometheus_coverage.ml
+++ b/test/test_prometheus_coverage.ml
@@ -268,7 +268,8 @@ let test_new_issue_metrics_registered () =
   check_metric_name Prometheus.metric_keeper_liveness_recovery_attempts;
   check_metric_name Prometheus.metric_keeper_liveness_recovery_outcomes;
   check_metric_name Prometheus.metric_cascade_server_error_skip_total;
-  check_metric_name Prometheus.metric_keeper_passive_loop_detected_total
+  check_metric_name Prometheus.metric_keeper_passive_loop_detected_total;
+  check_metric_name Prometheus.metric_write_meta_cas_retry_total
 
 let test_review_blocker_metrics_registered () =
   let text = Prometheus.to_prometheus_text () in


### PR DESCRIPTION
## Summary
- register `masc_write_meta_cas_retry_total` in Prometheus with `keeper_name` labels matching the Observe alert/dashboard contract
- increment it from the two centralized keeper meta CAS retry helpers, while preserving the existing generic `masc_keeper_write_meta_failures_total` behavior
- pin both plain retry and merge retry paths with counter assertions, plus Prometheus HELP registration coverage

## Why
The Observe contract, dashboard, and alert already referenced `masc_write_meta_cas_retry_total`, but runtime only recorded CAS retries under the generic keeper write-meta failure metric. Operators could see alert/dashboard queries for a metric the exporter never emitted.

## Validation
- `git diff --check`
- `python3 scripts/validate_goal_loop_observe_metrics.py infrastructure/monitoring/goal-loop-observe-metrics.contract.json --alerts-yml infrastructure/monitoring/goal-loop-observe-alerts.yml --dashboard-json infrastructure/monitoring/grafana-goal-loop-observe-dashboard.json --require-complete` -> PASS, 18/18 signals
- Focused Dune validation attempted with `lockf -k -t 30 /tmp/me-dune-local.lock env MASC_DUNE_LOCK_HELD=1 MASC_SKIP_OPAM_LOCK=1 DUNE_JOBS=1 DUNE_CACHE=disabled scripts/dune-local.sh build test/test_keeper_meta_cas_retry.exe test/test_keeper_meta_heartbeat_retain_9733.exe test/test_prometheus_coverage.exe`; blocked by unrelated local Dune lock holders (`lockf: /tmp/me-dune-local.lock: already locked`). CI is the build surface for this draft until the local lock clears.