### PR TITLE
obs(backend): wire mutex metrics at startup

### DIFF
--- a/lib/backend_mutex_metrics.ml
+++ b/lib/backend_mutex_metrics.ml
@@ -1,0 +1,14 @@
+(** Prometheus bridge for backend filesystem mutex contention metrics. *)
+
+let install () =
+  Backend.FileSystem.set_mutex_observers
+    ~acquire:(fun ~op ~seconds ->
+      Prometheus.observe_histogram
+        Prometheus.metric_backend_mutex_acquire_sec
+        ~labels:[ ("op", op) ]
+        seconds)
+    ~held:(fun ~op ~seconds ->
+      Prometheus.observe_histogram
+        Prometheus.metric_backend_mutex_held_sec
+        ~labels:[ ("op", op) ]
+        seconds)

--- a/lib/backend_mutex_metrics.mli
+++ b/lib/backend_mutex_metrics.mli
@@ -1,0 +1,9 @@
+(** Prometheus bridge for backend filesystem mutex contention metrics. *)
+
+val install : unit -> unit
+(** Install Prometheus-backed observers for {!Backend.FileSystem} write
+    mutex acquire/held timings.
+
+    The backend sub-library intentionally has no dependency on Prometheus.
+    Calling [install] from the top-level runtime wires that dependency from
+    [masc_mcp], where both modules are already available. *)

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -1466,6 +1466,12 @@ let run ~sw ~env ~host ~port ~base_path ~make_routes ~make_request_handler
          the default noop sink instead of the Prometheus-backed one. *)
       Llm_metric_bridge.install ();
       Log.Server.info "Llm_metric_bridge installed (masc_llm_provider_http_status_total)";
+      (* #13885: install backend mutex observers from the top-level
+         masc_mcp layer.  Backend/coord sub-libraries cannot depend on
+         Prometheus without creating dependency cycles, but the global
+         observer refs can be wired before any FileSystem backend writes. *)
+      Backend_mutex_metrics.install ();
+      Log.Server.info "Backend_mutex_metrics installed (masc_backend_mutex_*)";
       (* Forward Agent_sdk.Log records (per-turn timing from oas#816 and
          any subsequent structured emits) into the masc-mcp log ring so
          they land in ~/.masc/logs/system_log_*.jsonl alongside

--- a/test/test_prometheus_coverage.ml
+++ b/test/test_prometheus_coverage.ml
@@ -12,6 +12,8 @@
 
 open Alcotest
 
+module Backend = Backend
+module Backend_mutex_metrics = Masc_mcp.Backend_mutex_metrics
 module Prometheus = Masc_mcp.Prometheus
 
 (* ============================================================
@@ -219,10 +221,51 @@ let text_has_literal text literal =
     true
   with Not_found -> false
 
+let sample_value text prefix =
+  String.split_on_char '\n' text
+  |> List.find_map (fun line ->
+         if String.starts_with ~prefix line then
+           match List.rev (String.split_on_char ' ' line) with
+           | raw :: _ -> float_of_string_opt raw
+           | [] -> None
+         else None)
+
 let count_lines_with_prefix text prefix =
   String.split_on_char '\n' text
   |> List.filter (fun line -> String.starts_with ~prefix line)
   |> List.length
+
+let rec rm_rf path =
+  if Sys.file_exists path then
+    if Sys.is_directory path then begin
+      Sys.readdir path
+      |> Array.iter (fun entry -> rm_rf (Filename.concat path entry));
+      Unix.rmdir path
+    end else
+      Sys.remove path
+
+let with_eio_backend f =
+  Eio_main.run @@ fun env ->
+  let fs = Eio.Stdenv.fs env in
+  let dir =
+    Filename.concat (Filename.get_temp_dir_name ())
+      (Printf.sprintf "backend-mutex-metrics-%d-%0.f" (Unix.getpid ())
+         (Unix.gettimeofday () *. 1000000.))
+  in
+  Unix.mkdir dir 0o755;
+  Fun.protect
+    ~finally:(fun () -> rm_rf dir)
+    (fun () ->
+      let config =
+        {
+          Backend.default_config with
+          base_path = dir;
+          node_id = "prometheus-test";
+          cluster_name = "prometheus-test";
+        }
+      in
+      let backend = Backend.FileSystem.create ~fs config in
+      f backend)
 
 let test_keeper_metrics_registered () =
   let text = Prometheus.to_prometheus_text () in
@@ -390,6 +433,28 @@ let test_histogram_exported_as_summary () =
     (has (Printf.sprintf "%s_count" name));
   check bool "no standalone _count TYPE" false
     (has (Printf.sprintf "# TYPE %s_count" name))
+
+let test_backend_mutex_metrics_emit_after_install () =
+  Backend_mutex_metrics.install ();
+  with_eio_backend (fun backend ->
+      match Backend.FileSystem.set backend "mutex-metric-test" "value" with
+      | Ok () -> ()
+      | Error _ -> fail "backend set failed");
+  let text = Prometheus.to_prometheus_text () in
+  let acquire_count_prefix =
+    Prometheus.metric_backend_mutex_acquire_sec ^ "_count{op=\"set\"} "
+  in
+  let held_count_prefix =
+    Prometheus.metric_backend_mutex_held_sec ^ "_count{op=\"set\"} "
+  in
+  check bool "backend acquire mutex sample emitted" true
+    (match sample_value text acquire_count_prefix with
+     | Some value -> Float.compare value 0.0 > 0
+     | None -> false);
+  check bool "backend held mutex sample emitted" true
+    (match sample_value text held_count_prefix with
+     | Some value -> Float.compare value 0.0 > 0
+     | None -> false)
 
 (* ============================================================
    Convenience Functions Tests
@@ -559,6 +624,8 @@ let () =
         test_goal_attainment_metrics_registered;
       test_case "histogram exported as summary with _sum/_count"
         `Quick test_histogram_exported_as_summary;
+      test_case "backend mutex observers emit histogram samples" `Quick
+        test_backend_mutex_metrics_emit_after_install;
     ];
     "convenience", [
       test_case "record_request" `Quick test_record_request;


### PR DESCRIPTION
## Summary

- Install backend filesystem mutex observers from top-level `masc_mcp` startup instead of the backend/coord libraries.
- Add a small `Backend_mutex_metrics` bridge so the backend library stays Prometheus-free while startup wires the live metric callbacks.
- Add a regression test proving `masc_backend_mutex_acquire_sec` and `masc_backend_mutex_held_sec` emit samples after an Eio filesystem write.

Fixes #13885

## Validation

- `git diff --check origin/main...HEAD`
- Attempted `env DUNE_BUILD_DIR=_build_codex_13885_backend_mutex scripts/dune-local.sh build bin/main_eio.exe test/test_prometheus_coverage.exe`; local wrapper was queued behind `/tmp/me-dune-local.lock` held by another active agent build, so I stopped the queued invocation without bypassing the shared lock. CI is the compile/test validation surface for this draft.
