### PR TITLE
fix: emit keeper zombie loop observe metric

### DIFF
--- a/lib/keeper/keeper_passive_loop_detector.ml
+++ b/lib/keeper/keeper_passive_loop_detector.ml
@@ -111,6 +111,16 @@ let detect_labels_for_progress_class keeper_name progress_class =
   then [("keeper", keeper_name); ("kind", progress_class)]
   else [("keeper", keeper_name)]
 
+let emit_detected_loop_metrics keeper_name progress_class =
+  Prometheus.inc_counter
+    (detect_counter_for_progress_class progress_class)
+    ~labels:(detect_labels_for_progress_class keeper_name progress_class)
+    ();
+  Prometheus.inc_counter
+    Prometheus.metric_keeper_zombie_loop_detected_total
+    ~labels:[("keeper_name", keeper_name)]
+    ()
+
 let log_detected_loop keeper_name progress_class streak threshold =
   if is_required_tool_progress_class progress_class then
     Log.Keeper.warn
@@ -148,10 +158,7 @@ let record_turn ~keeper_name ~progress_class =
         let t = threshold_for_progress_class progress_class in
         if s.streak >= t && not s.detected_latched then begin
           s.detected_latched <- true;
-          Prometheus.inc_counter
-            (detect_counter_for_progress_class progress_class)
-            ~labels:(detect_labels_for_progress_class keeper_name progress_class)
-            ();
+          emit_detected_loop_metrics keeper_name progress_class;
           log_detected_loop keeper_name progress_class s.streak t
         end
       end

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -1116,6 +1116,8 @@ let metric_keeper_passive_loop_detected_total =
   "masc_keeper_passive_loop_detected_total"
 let metric_keeper_required_tool_loop_detected_total =
   "masc_keeper_required_tool_loop_detected_total"
+let metric_keeper_zombie_loop_detected_total =
+  "masc_keeper_zombie_loop_detected_total"
 let metric_keeper_required_tool_gate_suppressed_total =
   "masc_keeper_required_tool_gate_suppressed_total"
 
@@ -1867,6 +1869,11 @@ let init () =
     "#13362 Total required-tool contract loops: keeper hit N consecutive \
      actionable required-tool failures before making execution/completion \
      progress. Labeled by keeper and kind."
+    Counter;
+  add metric_keeper_zombie_loop_detected_total
+    "Goal-loop Observe counter for no-progress keeper loops. Emitted by the \
+     passive/required-tool loop detector when progress-signalling turns make \
+     no execution or completion progress. Labeled by keeper_name."
     Counter;
   add metric_keeper_required_tool_gate_suppressed_total
     "#13631 Total Require_tool_use gate suppressions caused by actionable \

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -403,6 +403,12 @@ val metric_keeper_required_tool_loop_detected_total : string
     actionable required-tool failures before making execution/completion
     progress.  Incremented once per loop episode. Labels: [keeper, kind]. *)
 
+val metric_keeper_zombie_loop_detected_total : string
+(** Goal-loop Observe counter for no-progress keeper loops. Emitted by the
+    passive/required-tool loop detector when progress-signalling turns make no
+    execution or completion progress. Incremented once per loop episode.
+    Labels: [keeper_name]. *)
+
 val metric_keeper_required_tool_gate_suppressed_total : string
 (** #13631 Total Require_tool_use gate suppressions caused by actionable
     affordances whose visible keeper tool surface contains no

--- a/test/test_keeper_passive_loop_detector.ml
+++ b/test/test_keeper_passive_loop_detector.ml
@@ -59,6 +59,12 @@ let test_required_tool_no_call_fires_metric_at_three () =
       P.metric_keeper_required_tool_loop_detected_total
       ~labels ()
   in
+  let zombie_before =
+    P.metric_value_or_zero
+      P.metric_keeper_zombie_loop_detected_total
+      ~labels:[("keeper_name", "k-required-no-call")]
+      ()
+  in
   PLD.record_turn ~keeper_name:"k-required-no-call"
     ~progress_class:"required_tool_no_call";
   PLD.record_turn ~keeper_name:"k-required-no-call"
@@ -77,7 +83,13 @@ let test_required_tool_no_call_fires_metric_at_three () =
     (before +. 1.0)
     (P.metric_value_or_zero
        P.metric_keeper_required_tool_loop_detected_total
-       ~labels ())
+       ~labels ());
+  check (float 0.001) "Observe zombie-loop metric increments once"
+    (zombie_before +. 1.0)
+    (P.metric_value_or_zero
+       P.metric_keeper_zombie_loop_detected_total
+       ~labels:[("keeper_name", "k-required-no-call")]
+       ())
 
 let test_required_tool_streak_does_not_inherit_passive_streak () =
   Eio_main.run @@ fun _env ->
@@ -132,6 +144,11 @@ let test_detection_fires_metric_at_threshold () =
       P.metric_keeper_passive_loop_detected_total
       ~labels:[("keeper", "k-metric")] ()
   in
+  let zombie_before =
+    P.metric_value_or_zero
+      P.metric_keeper_zombie_loop_detected_total
+      ~labels:[("keeper_name", "k-metric")] ()
+  in
   for _ = 1 to 5 do
     PLD.record_turn ~keeper_name:"k-metric" ~progress_class:"passive_status"
   done;
@@ -140,7 +157,14 @@ let test_detection_fires_metric_at_threshold () =
       P.metric_keeper_passive_loop_detected_total
       ~labels:[("keeper", "k-metric")] ()
   in
-  check bool "metric incremented at threshold" true (after > before)
+  let zombie_after =
+    P.metric_value_or_zero
+      P.metric_keeper_zombie_loop_detected_total
+      ~labels:[("keeper_name", "k-metric")] ()
+  in
+  check bool "metric incremented at threshold" true (after > before);
+  check (float 0.001) "Observe zombie-loop metric increments"
+    (zombie_before +. 1.0) zombie_after
 
 let test_detection_latch_does_not_double_fire () =
   Eio_main.run @@ fun _env ->
@@ -149,6 +173,11 @@ let test_detection_latch_does_not_double_fire () =
     P.metric_value_or_zero
       P.metric_keeper_passive_loop_detected_total
       ~labels:[("keeper", "k-latch")] ()
+  in
+  let zombie_before =
+    P.metric_value_or_zero
+      P.metric_keeper_zombie_loop_detected_total
+      ~labels:[("keeper_name", "k-latch")] ()
   in
   (* Fire well above threshold — latch should prevent repeated increments *)
   for _ = 1 to 20 do
@@ -160,7 +189,13 @@ let test_detection_latch_does_not_double_fire () =
       ~labels:[("keeper", "k-latch")] ()
   in
   check (float 0.001) "latch: counter increments exactly once per episode"
-    (before +. 1.0) after
+    (before +. 1.0) after;
+  check (float 0.001)
+    "latch: Observe zombie-loop counter increments exactly once per episode"
+    (zombie_before +. 1.0)
+    (P.metric_value_or_zero
+       P.metric_keeper_zombie_loop_detected_total
+       ~labels:[("keeper_name", "k-latch")] ())
 
 let test_reset_clears_state () =
   Eio_main.run @@ fun _env ->

--- a/test/test_prometheus_coverage.ml
+++ b/test/test_prometheus_coverage.ml
@@ -269,7 +269,8 @@ let test_new_issue_metrics_registered () =
   check_metric_name Prometheus.metric_keeper_liveness_recovery_outcomes;
   check_metric_name Prometheus.metric_cascade_server_error_skip_total;
   check_metric_name Prometheus.metric_keeper_passive_loop_detected_total;
-  check_metric_name Prometheus.metric_write_meta_cas_retry_total
+  check_metric_name Prometheus.metric_write_meta_cas_retry_total;
+  check_metric_name Prometheus.metric_keeper_zombie_loop_detected_total
 
 let test_review_blocker_metrics_registered () =
   let text = Prometheus.to_prometheus_text () in


### PR DESCRIPTION
## Summary
- register `masc_keeper_zombie_loop_detected_total` in Prometheus with the `keeper_name` label expected by the Observe alert/dashboard contract
- emit the Observe zombie-loop counter from `Keeper_passive_loop_detector` when passive or required-tool no-progress loop episodes latch
- keep the existing detailed counters (`masc_keeper_passive_loop_detected_total`, `masc_keeper_required_tool_loop_detected_total`) unchanged and add tests for the alias metric

## Why
The Observe alert describes zombie loops as progress-signalling noise without real task progress. Runtime already detects that condition in the passive/required-tool loop detector, but the contract metric existed only in monitoring config. This wires the contract metric without redefining stale-agent or fiber-zombie semantics.

## Validation
- `git diff --check origin/main..HEAD`
- `python3 scripts/validate_goal_loop_observe_metrics.py infrastructure/monitoring/goal-loop-observe-metrics.contract.json --alerts-yml infrastructure/monitoring/goal-loop-observe-alerts.yml --dashboard-json infrastructure/monitoring/grafana-goal-loop-observe-dashboard.json --require-complete` -> PASS, 18/18 signals
- Focused Dune validation attempted with `lockf -k -t 30 /tmp/me-dune-local.lock env MASC_DUNE_LOCK_HELD=1 MASC_SKIP_OPAM_LOCK=1 DUNE_JOBS=1 DUNE_CACHE=disabled scripts/dune-local.sh build test/test_keeper_passive_loop_detector.exe test/test_prometheus_coverage.exe`; blocked by unrelated local Dune lock holders (`lockf: /tmp/me-dune-local.lock: already locked`). CI is the build surface for this draft until the local lock clears.