### PR TITLE
fix(keeper): expose underused tool telemetry

### DIFF
--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -593,24 +593,28 @@ let run_keepalive_unified_turn
           "keepalive turn scheduled for %s: channel=%s reasons=%s"
           meta_after_triage.name channel_str
           (String.concat "," verdict_strs);
+      let tool_usage_entries =
+        Keeper_registry.tool_usage_of
+          ~base_path:ctx.config.base_path meta_after_triage.name
+      in
+      let available_tools =
+        Keeper_tool_policy.keeper_allowed_tool_names meta_after_triage
+      in
+      let tool_diversity_summary =
+        let stats =
+          Keeper_tool_diversity.stats_of_registry_entries tool_usage_entries
+        in
+        Keeper_tool_diversity.compute_diversity ~available_tools stats
+      in
+      Keeper_tool_diversity.record_underused_tool_metrics
+        ~keeper_name:meta_after_triage.name ~available_tools
+        tool_diversity_summary;
       (* Phase A2: record decision in audit trail (skip all work when disabled) *)
       if Keeper_decision_audit.audit_enabled () then begin
         let audit_wall_clock = Time_compat.now () in
         let tool_diversity_entropy =
-          let entries =
-            Keeper_registry.tool_usage_of
-              ~base_path:ctx.config.base_path meta_after_triage.name
-          in
-          if entries = [] then None
-          else
-            let stats = Keeper_tool_diversity.stats_of_registry_entries entries in
-            let available_tools =
-              Keeper_tool_policy.keeper_allowed_tool_names meta_after_triage
-            in
-            let summary =
-              Keeper_tool_diversity.compute_diversity ~available_tools stats
-            in
-            Some summary.normalized_entropy
+          if tool_usage_entries = [] then None
+          else Some tool_diversity_summary.normalized_entropy
         in
         Keeper_decision_audit.append
           ~keeper_name:meta_after_triage.name

--- a/lib/keeper/keeper_tool_diversity.ml
+++ b/lib/keeper/keeper_tool_diversity.ml
@@ -109,6 +109,26 @@ let compute_diversity ~(available_tools : string list)
     entropy = raw_h; normalized_entropy = norm_h;
     underused_tools = underused; overused_tools = overused }
 
+let record_underused_tool_metrics ~keeper_name ~available_tools summary =
+  let available_tools = List.sort_uniq String.compare available_tools in
+  let underused_tools =
+    List.sort_uniq String.compare summary.underused_tools
+  in
+  Prometheus.set_gauge
+    Prometheus.metric_keeper_tool_underused_allowed_count
+    ~labels:[ ("keeper", keeper_name) ]
+    (float_of_int (List.length underused_tools));
+  List.iter
+    (fun tool ->
+       let value =
+         if List.mem tool underused_tools then 1.0 else 0.0
+       in
+       Prometheus.set_gauge
+         Prometheus.metric_keeper_tool_underused_allowed
+         ~labels:[ ("keeper", keeper_name); ("tool", tool) ]
+         value)
+    available_tools
+
 (** Default normalized entropy threshold.  Below this, the keeper is
     considered to be in an exploitation-only pattern.
     Empirical: a keeper using 5 of 25 tools at roughly equal rates

--- a/lib/keeper/keeper_tool_diversity.mli
+++ b/lib/keeper/keeper_tool_diversity.mli
@@ -27,5 +27,10 @@ val parse_tool_usage_json : Yojson.Safe.t -> tool_stat list
 val shannon_entropy : int list -> float
 val normalized_entropy : n_categories:int -> float -> float
 val compute_diversity : available_tools:string list -> tool_stat list -> diversity_summary
+val record_underused_tool_metrics :
+  keeper_name:string ->
+  available_tools:string list ->
+  diversity_summary ->
+  unit
 val default_entropy_threshold : float
 val stats_of_registry_entries : (string * Keeper_types.tool_call_entry) list -> tool_stat list

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -505,6 +505,18 @@ let metric_keeper_tool_emission_registry_size =
 let metric_keeper_tool_emission_pushes =
   "masc_keeper_tool_emission_pushes_total"
 
+(* #13387: keeper tool diversity gauges. The count gauge gives
+   dashboard/operator summaries a cheap per-keeper signal; the per-tool
+   gauge identifies exactly which allowed tools are available but unused
+   or below the diversity threshold. Labels:
+   - [keeper] for the count gauge
+   - [keeper, tool] for the per-tool gauge *)
+let metric_keeper_tool_underused_allowed_count =
+  "masc_keeper_tool_underused_allowed_count"
+
+let metric_keeper_tool_underused_allowed =
+  "masc_keeper_tool_underused_allowed"
+
 (* #10349: keeper FS path rejection counter.  Pre-fix the
    user-facing read-path rejection strings carried the resolver's
    view of allowed sandbox roots (for example [(roots=[<list>])]
@@ -1538,6 +1550,14 @@ let init () =
     "Total tagged tool results captured into the K4c per-keeper \
      accumulator (labels: keeper)"
     Counter;
+  add metric_keeper_tool_underused_allowed_count
+    "Number of keeper-allowed tools that have no calls or are below \
+     the diversity threshold (labels: keeper)"
+    Gauge;
+  add metric_keeper_tool_underused_allowed
+    "Whether an allowed keeper tool is unused or below the diversity \
+     threshold (1=yes, 0=no; labels: keeper, tool)"
+    Gauge;
   (* Operator-initiated overflow recovery — emitted by tool_keeper.ml *)
   add metric_keeper_operator_compact
     "Total operator-invoked masc_keeper_compact calls (labels: result=ok|no_checkpoint|precondition|not_found)" Counter;

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -256,6 +256,16 @@ val metric_keeper_tool_emission_registry_size : string
     into the keeper's accumulator. *)
 val metric_keeper_tool_emission_pushes : string
 
+(** #13387: per-keeper count of allowed tools that the diversity
+    analyzer classifies as unused or below threshold. Labels:
+    [keeper]. *)
+val metric_keeper_tool_underused_allowed_count : string
+
+(** #13387: per-tool gauge for allowed keeper tools that are unused
+    or below threshold. Value is [1.0] when underused and [0.0]
+    otherwise. Labels: [keeper], [tool]. *)
+val metric_keeper_tool_underused_allowed : string
+
 val metric_keeper_operator_compact : string
 val metric_keeper_operator_clear : string
 

--- a/test/test_prometheus_coverage.ml
+++ b/test/test_prometheus_coverage.ml
@@ -247,6 +247,10 @@ let test_keeper_metrics_registered () =
        ("# TYPE " ^ Prometheus.metric_keeper_total_cost_usd ^ " gauge"));
   check bool "has keeper tool duration histogram" true
     (has "masc_keeper_tool_call_duration_seconds");
+  check bool "has keeper underused allowed tool count gauge" true
+    (has "masc_keeper_tool_underused_allowed_count");
+  check bool "has keeper underused allowed tool gauge" true
+    (has "masc_keeper_tool_underused_allowed");
   check bool "has operator compact counter" true
     (has "masc_keeper_operator_compact_total");
   check bool "has operator clear counter" true

--- a/test/test_tool_diversity.ml
+++ b/test/test_tool_diversity.ml
@@ -39,6 +39,40 @@ let test_stats_of_registry () =
   check string "first name" "tool_a" first.name;
   check int "first count" 50 first.count
 
+let test_underused_tool_metrics_flag_unused_web_search () =
+  let keeper_name = "test-underused-tool-metrics" in
+  let available_tools = [ "keeper_board_post"; "masc_web_search" ] in
+  let stats =
+    [
+      {
+        Masc_mcp.Keeper_tool_diversity.name = "keeper_board_post";
+        count = 100;
+        successes = 100;
+        failures = 0;
+      };
+    ]
+  in
+  let summary =
+    Masc_mcp.Keeper_tool_diversity.compute_diversity
+      ~available_tools stats
+  in
+  Masc_mcp.Keeper_tool_diversity.record_underused_tool_metrics
+    ~keeper_name ~available_tools summary;
+  check (float 0.001) "one underused allowed tool" 1.0
+    (Masc_mcp.Prometheus.metric_value_or_zero
+       Masc_mcp.Prometheus.metric_keeper_tool_underused_allowed_count
+       ~labels:[ ("keeper", keeper_name) ] ());
+  check (float 0.001) "web search flagged underused" 1.0
+    (Masc_mcp.Prometheus.metric_value_or_zero
+       Masc_mcp.Prometheus.metric_keeper_tool_underused_allowed
+       ~labels:[ ("keeper", keeper_name); ("tool", "masc_web_search") ]
+       ());
+  check (float 0.001) "used board post cleared" 0.0
+    (Masc_mcp.Prometheus.metric_value_or_zero
+       Masc_mcp.Prometheus.metric_keeper_tool_underused_allowed
+       ~labels:[ ("keeper", keeper_name); ("tool", "keeper_board_post") ]
+       ())
+
 (* ── QCheck properties ───────────────────────────────────── *)
 
 let int_list_gen ~min_len ~max_len ~min_val ~max_val =
@@ -84,6 +118,8 @@ let () =
           test_case "shannon_entropy empty" `Quick test_shannon_entropy_empty;
           test_case "normalized uniform" `Quick test_normalized_uniform;
           test_case "stats_of_registry" `Quick test_stats_of_registry;
+          test_case "underused tool metrics flag unused web search" `Quick
+            test_underused_tool_metrics_flag_unused_web_search;
         ] );
       ( "qcheck",
         List.map QCheck_alcotest.to_alcotest


### PR DESCRIPTION
## Summary
- add Prometheus gauges for underused allowed keeper tools
- emit per-keeper and per-tool values from the existing tool diversity heartbeat path
- add regression coverage for unused `masc_web_search` telemetry and metric registration

## Why
Closes #13387. Current main already has the research prompt contract and board `sources` support from that issue; this PR covers the remaining telemetry surface so operators can see when an allowed tool stays unused.

## Validation
- `git diff --check`
- `scripts/dune-local.sh build test/test_tool_diversity.exe test/test_prometheus_coverage.exe` attempted twice, but both attempts were blocked behind other long-running `/tmp/me-dune-local.lock` holders; I stopped only my queued wrapper processes. CI should be treated as the build proof for this draft.