### PR TITLE
feat(oas): kimi_cli stdout idle timeout (RFC-0022 attempt liveness)

### DIFF
--- a/docs/runtime-tunables.md
+++ b/docs/runtime-tunables.md
@@ -14,7 +14,7 @@ the categorization roadmap. Newly-added typed getters in
 `lib/config/env_config_*.ml` must carry nearby `@category` and
 `@ops_class` tags; existing knobs remain in the backfill lane.
 
-**Total**: 414 unique knobs across 8 modules.
+**Total**: 415 unique knobs across 8 modules.
 
 ## Env_config_core (31 knobs)
 
@@ -98,35 +98,35 @@ the categorization roadmap. Newly-added typed getters in
 | `MASC_SPAWN_CACHE_POLICY` | typed:string | 52 | Spawn cache policy: - off - safe_only (GLM direct HTTP only, no MCP-tool side effects) |
 | `MASC_SSE_KEEPALIVE_SEC` | typed:float | 112 | SSE keepalive interval (seconds). Frequency of `: keepalive` frames on command-plane SSE streams. Clamped to >= 1.0 t... |
 
-## Env_config_keeper (120 knobs)
+## Env_config_keeper (121 knobs)
 
 | Env var | Kind | Line | Doc |
 |---|---|---|---|
 | `MASC_ALERT_DEDUP_WINDOW_SEC` | typed:float | 349 | Alert dedup window, clamped to >= 5s. Default: 60. |
-| `MASC_CASCADE_ATTEMPT_LIVENESS` | typed:string | 960 |  |
-| `MASC_COMPACT_ANCHOR_BOOST` | typed:float | 710 |  |
-| `MASC_COMPACT_DROP_THRESHOLD` | typed:float | 711 |  |
-| `MASC_COMPACT_DYN_FOCUSED_RATIO` | typed:float | 717 |  |
-| `MASC_COMPACT_DYN_MULTI_AGENT_RATIO` | typed:float | 716 |  |
-| `MASC_COMPACT_KEEP_RECENT` | typed:int | 712 |  |
-| `MASC_COMPACT_LARGE_CLOUD_FLOOR` | typed:int | 719 |  |
-| `MASC_COMPACT_ROLE_ASSISTANT` | typed:float | 705 |  |
-| `MASC_COMPACT_ROLE_SYSTEM` | typed:float | 702 | {1 Context Compaction (OAS)} |
-| `MASC_COMPACT_ROLE_TOOL` | typed:float | 703 | {1 Context Compaction (OAS)} |
-| `MASC_COMPACT_ROLE_USER` | typed:float | 704 |  |
-| `MASC_COMPACT_SMALL_LOCAL_FLOOR` | typed:int | 718 |  |
-| `MASC_COMPACT_TOOL_ABSENT` | typed:float | 708 |  |
-| `MASC_COMPACT_TOOL_PRESENT` | typed:float | 707 |  |
-| `MASC_COMPACT_TOOL_PRUNE_LIMIT` | typed:int | 714 |  |
-| `MASC_COMPACT_W_RECENCY` | typed:float | 698 | {1 Context Compaction (OAS)} |
-| `MASC_COMPACT_W_ROLE` | typed:float | 699 | {1 Context Compaction (OAS)} |
-| `MASC_COMPACT_W_TOOL` | typed:float | 700 | {1 Context Compaction (OAS)} |
-| `MASC_CONTEXT_RATIO_HARD_CAP` | typed:float | 693 | {1 Context Ratio Hard Cap} Absolute ceiling for compaction ratio_gate and handoff threshold after multiplier adjustme... |
-| `MASC_DASHBOARD_HEALTH_CTX_CRITICAL` | typed:float | 820 |  |
-| `MASC_DASHBOARD_HEALTH_CTX_WARN` | typed:float | 821 |  |
-| `MASC_DASHBOARD_HEALTH_PENALTY_CRITICAL` | typed:float | 822 |  |
-| `MASC_DASHBOARD_HEALTH_PENALTY_WARN` | typed:float | 823 |  |
-| `MASC_DASHBOARD_RUNTIME_WARNING_CTX_RATIO` | typed:float | 824 |  |
+| `MASC_CASCADE_ATTEMPT_LIVENESS` | typed:string | 972 |  |
+| `MASC_COMPACT_ANCHOR_BOOST` | typed:float | 722 |  |
+| `MASC_COMPACT_DROP_THRESHOLD` | typed:float | 723 |  |
+| `MASC_COMPACT_DYN_FOCUSED_RATIO` | typed:float | 729 |  |
+| `MASC_COMPACT_DYN_MULTI_AGENT_RATIO` | typed:float | 728 |  |
+| `MASC_COMPACT_KEEP_RECENT` | typed:int | 724 |  |
+| `MASC_COMPACT_LARGE_CLOUD_FLOOR` | typed:int | 731 |  |
+| `MASC_COMPACT_ROLE_ASSISTANT` | typed:float | 717 |  |
+| `MASC_COMPACT_ROLE_SYSTEM` | typed:float | 714 | {1 Context Compaction (OAS)} |
+| `MASC_COMPACT_ROLE_TOOL` | typed:float | 715 | {1 Context Compaction (OAS)} |
+| `MASC_COMPACT_ROLE_USER` | typed:float | 716 |  |
+| `MASC_COMPACT_SMALL_LOCAL_FLOOR` | typed:int | 730 |  |
+| `MASC_COMPACT_TOOL_ABSENT` | typed:float | 720 |  |
+| `MASC_COMPACT_TOOL_PRESENT` | typed:float | 719 |  |
+| `MASC_COMPACT_TOOL_PRUNE_LIMIT` | typed:int | 726 |  |
+| `MASC_COMPACT_W_RECENCY` | typed:float | 710 | {1 Context Compaction (OAS)} |
+| `MASC_COMPACT_W_ROLE` | typed:float | 711 | {1 Context Compaction (OAS)} |
+| `MASC_COMPACT_W_TOOL` | typed:float | 712 | {1 Context Compaction (OAS)} |
+| `MASC_CONTEXT_RATIO_HARD_CAP` | typed:float | 705 | {1 Context Ratio Hard Cap} Absolute ceiling for compaction ratio_gate and handoff threshold after multiplier adjustme... |
+| `MASC_DASHBOARD_HEALTH_CTX_CRITICAL` | typed:float | 832 |  |
+| `MASC_DASHBOARD_HEALTH_CTX_WARN` | typed:float | 833 |  |
+| `MASC_DASHBOARD_HEALTH_PENALTY_CRITICAL` | typed:float | 834 |  |
+| `MASC_DASHBOARD_HEALTH_PENALTY_WARN` | typed:float | 835 |  |
+| `MASC_DASHBOARD_RUNTIME_WARNING_CTX_RATIO` | typed:float | 836 |  |
 | `MASC_KEEPER_ADMISSION_WAIT_TIMEOUT_SEC` | typed:float | 475 |  |
 | `MASC_KEEPER_ALERT_BOARD_AUTHOR` | typed:string | 115 |  |
 | `MASC_KEEPER_ALERT_BOARD_ENABLED` | feature_flag | 112 | Board fanout configuration |
@@ -154,8 +154,8 @@ the categorization roadmap. Newly-added typed getters in
 | `MASC_KEEPER_AUTONOMOUS_SLOT_WAIT_TIMEOUT_SEC` | typed:float | 484 |  |
 | `MASC_KEEPER_AUTO_RESUME_INITIAL_SEC` | typed:float | 193 | Initial auto-resume backoff delay after an auto-pause (seconds). On every successive auto-pause the delay doubles, ca... |
 | `MASC_KEEPER_AUTO_RESUME_MAX_SEC` | typed:float | 197 | Maximum auto-resume backoff delay (seconds).  Default: 86400 (24 hours). |
-| `MASC_KEEPER_BATCH_THRESHOLD` | typed:int | 644 | Number of distinct keepers terminating within [batch_window_sec] before emitting a fleet batch alert. Default: 3. |
-| `MASC_KEEPER_BATCH_WINDOW_SEC` | typed:float | 639 | Fleet batch-termination detection window in seconds. Default: 30. |
+| `MASC_KEEPER_BATCH_THRESHOLD` | typed:int | 656 | Number of distinct keepers terminating within [batch_window_sec] before emitting a fleet batch alert. Default: 3. |
+| `MASC_KEEPER_BATCH_WINDOW_SEC` | typed:float | 651 | Fleet batch-termination detection window in seconds. Default: 30. |
 | `MASC_KEEPER_BOARD_DEBOUNCE_SEC` | typed:float | 408 |  |
 | `MASC_KEEPER_BOOTSTRAP_ENABLED` | feature_flag | 21 | Enable startup keeper bootstrap scan |
 | `MASC_KEEPER_BOOTSTRAP_LAZY_STARTUP_POLL_INTERVAL_SEC` | typed:float | 48 |  |
@@ -164,40 +164,41 @@ the categorization roadmap. Newly-added typed getters in
 | `MASC_KEEPER_BOOTSTRAP_MAX_SCAN` | typed:int | 30 | Max keeper meta files to scan during bootstrap |
 | `MASC_KEEPER_BOOTSTRAP_POST_STARTUP_SETTLE_SEC` | typed:float | 72 |  |
 | `MASC_KEEPER_BOOTSTRAP_STALE_TURN_SEC` | typed:float | 26 |  |
-| `MASC_KEEPER_CASCADE_PROVIDER_ALLOWLIST` | string_literal | 872 | Comma-separated provider kind allowlist for every keeper cascade call. Values are OAS [Provider_config.string_of_prov... |
+| `MASC_KEEPER_CASCADE_PROVIDER_ALLOWLIST` | string_literal | 884 | Comma-separated provider kind allowlist for every keeper cascade call. Values are OAS [Provider_config.string_of_prov... |
+| `MASC_KEEPER_CLI_SUBPROCESS_IDLE_SEC` | typed:float | 584 |  |
 | `MASC_KEEPER_CRASH_PERSIST_DRAIN_INTERVAL_SEC` | typed:float | 286 |  |
 | `MASC_KEEPER_DEAD_TTL_SEC` | typed:float | 181 | Dead tombstone TTL: seconds before Dead entries are cleaned up |
 | `MASC_KEEPER_DEBUG` | feature_flag | 305 | Enable keeper debug logging. Default: false. |
-| `MASC_KEEPER_DEGRADED_RETRY_SLOT_PHASE_BUDGET_SEC` | typed:float | 936 |  |
+| `MASC_KEEPER_DEGRADED_RETRY_SLOT_PHASE_BUDGET_SEC` | typed:float | 948 |  |
 | `MASC_KEEPER_DELIBERATION_DAILY_BUDGET_USD` | typed:float | 311 | Daily budget for keeper deliberation (USD). Default: 0.10. Re-readable within the process. Live operator control shou... |
-| `MASC_KEEPER_DOCKER_CONTAINER` | typed:string | 745 | Docker container name for keeper playground execution. Env: [MASC_KEEPER_DOCKER_CONTAINER]. Default: "keeper-playgrou... |
-| `MASC_KEEPER_DOCKER_PLAYGROUND_ROOT` | typed:string | 755 |  |
-| `MASC_KEEPER_DOCKER_READ` | typed:bool | 816 | Legacy RFC-0006 Phase B-2 flag. Docker read routing now follows [sandbox_profile=docker] unconditionally. This getter... |
-| `MASC_KEEPER_ESCALATION_THRESHOLD` | typed:int | 634 | Number of stale terminations within [termination_window_sec] before escalating to [Stale_termination_storm]. Default: 5. |
-| `MASC_KEEPER_GRPC_MAX_RECONNECT` | typed:int | 653 | Maximum gRPC reconnect attempts before stopping the heartbeat fiber. Default: 5. Range: [1, 20]. |
-| `MASC_KEEPER_GRPC_RECONNECT_BACKOFF_SEC` | typed:float | 659 |  |
+| `MASC_KEEPER_DOCKER_CONTAINER` | typed:string | 757 | Docker container name for keeper playground execution. Env: [MASC_KEEPER_DOCKER_CONTAINER]. Default: "keeper-playgrou... |
+| `MASC_KEEPER_DOCKER_PLAYGROUND_ROOT` | typed:string | 767 |  |
+| `MASC_KEEPER_DOCKER_READ` | typed:bool | 828 | Legacy RFC-0006 Phase B-2 flag. Docker read routing now follows [sandbox_profile=docker] unconditionally. This getter... |
+| `MASC_KEEPER_ESCALATION_THRESHOLD` | typed:int | 646 | Number of stale terminations within [termination_window_sec] before escalating to [Stale_termination_storm]. Default: 5. |
+| `MASC_KEEPER_GRPC_MAX_RECONNECT` | typed:int | 665 | Maximum gRPC reconnect attempts before stopping the heartbeat fiber. Default: 5. Range: [1, 20]. |
+| `MASC_KEEPER_GRPC_RECONNECT_BACKOFF_SEC` | typed:float | 671 |  |
 | `MASC_KEEPER_HEARTBEAT_INTERVAL_SEC` | typed:int | 354 | Shared: keepalive interval, read early so WorkAsHeartbeat can reference it. |
 | `MASC_KEEPER_HEARTBEAT_JITTER_FACTOR` | typed:float | 421 |  |
-| `MASC_KEEPER_IDLE_SKIP_THRESHOLD` | typed:int | 581 | Consecutive idle tool repetitions before on_idle hook issues Skip. Below this: graduated Nudge messages. With tool_ch... |
+| `MASC_KEEPER_IDLE_SKIP_THRESHOLD` | typed:int | 593 | Consecutive idle tool repetitions before on_idle hook issues Skip. Below this: graduated Nudge messages. With tool_ch... |
 | `MASC_KEEPER_LIVENESS_RECOVERY_BACKOFF_BASE_SEC` | typed:float | 214 | Base backoff delay (seconds) between liveness recovery attempts per keeper. Exponential: attempt 0 = base, 1 = 2*base... |
 | `MASC_KEEPER_LIVENESS_RECOVERY_BACKOFF_MAX_SEC` | typed:float | 219 | Maximum backoff delay cap (seconds) for liveness recovery. Default: 3600 (1 hour). |
 | `MASC_KEEPER_LIVENESS_RECOVERY_ENABLED` | typed:bool | 202 | Liveness Recovery Supervisor (#12801): enable auto-recovery of Dead keepers whose root cause has cleared.  Set to fal... |
 | `MASC_KEEPER_LIVENESS_RECOVERY_MAX_ATTEMPTS` | typed:int | 224 | Maximum total liveness recovery attempts per keeper before giving up permanently.  Default: 5. |
 | `MASC_KEEPER_LIVENESS_RECOVERY_MIN_DEAD_SEC` | typed:float | 208 | Minimum time (seconds) a keeper must have been Dead before a liveness recovery attempt is made.  Allows transient roo... |
 | `MASC_KEEPER_MAX_CONSECUTIVE_HB_FAILURES` | typed:int | 395 | Maximum consecutive heartbeat failures before raising Keeper_fiber_crash (structured crash via dispatch_event). Defau... |
-| `MASC_KEEPER_MAX_CONSECUTIVE_TOOL_FAILURES` | typed:int | 683 | Maximum consecutive failures for the same (tool_name, args_hash) before blocking further attempts. Prevents infinite ... |
+| `MASC_KEEPER_MAX_CONSECUTIVE_TOOL_FAILURES` | typed:int | 695 | Maximum consecutive failures for the same (tool_name, args_hash) before blocking further attempts. Prevents infinite ... |
 | `MASC_KEEPER_MAX_CONSECUTIVE_TURN_FAILURES` | typed:int | 401 | Maximum consecutive unified turn failures before marking keeper as crashed. Covers LLM timeout, rate limit, and other... |
 | `MASC_KEEPER_MAX_IDLE_TURNS_AUTONOMOUS` | typed:int | 435 | Max idle turns for scheduled autonomous keeper turns. With tool_choice=Any and max_turns=50, keepers have room to exp... |
 | `MASC_KEEPER_MAX_IDLE_TURNS_REACTIVE` | typed:int | 441 | Max idle turns for reactive (board/mention triggered) keeper turns. Reactive turns have an explicit trigger — more ... |
 | `MASC_KEEPER_MAX_SILENCE_SEC` | typed:float | 369 | Maximum seconds since last successful room heartbeat before presence sync is required again. Floor = keepalive interv... |
-| `MASC_KEEPER_MAX_TRANSIENT_RETRIES` | typed:int | 897 | Maximum outer-loop retries after the initial attempt. Total attempts = 1 initial + max_transient_retries. Env: [MASC_... |
+| `MASC_KEEPER_MAX_TRANSIENT_RETRIES` | typed:int | 909 | Maximum outer-loop retries after the initial attempt. Total attempts = 1 initial + max_transient_retries. Env: [MASC_... |
 | `MASC_KEEPER_METRICS_MAX_BYTES` | typed:int | 80 | Maximum metrics file size in bytes before rotation (default: 10MB) |
 | `MASC_KEEPER_METRICS_MAX_ROTATED` | typed:int | 84 | Number of rotated files to keep (default: 1, i.e. .1 only) |
 | `MASC_KEEPER_OAS_MAX_TURNS_PER_CALL` | typed:int | 518 | Maximum turns per single OAS Agent.run call. Keeper resumes via checkpoint in the next keepalive cycle when {!Oas_wor... |
 | `MASC_KEEPER_OAS_MAX_TURNS_PER_CALL_SCHEDULED_AUTONOMOUS` | typed:int | 538 |  |
 | `MASC_KEEPER_OAS_TIMEOUT_SEC` | string_literal | 500 | Per-call timeout in seconds for a single OAS Agent.run execution. Guards against indefinite LLM response waits within... |
 | `MASC_KEEPER_PAUSED_CLEANUP_TTL_SEC` | typed:float | 186 | Paused keeper file TTL: seconds before stale paused keeper meta files are removed from disk. Default: 86400 (24 hours). |
-| `MASC_KEEPER_PROACTIVE_MAX_ATTEMPTS` | typed:int | 668 | Maximum proactive generation attempts before falling back. Default: 3. Range: [1, 10]. |
+| `MASC_KEEPER_PROACTIVE_MAX_ATTEMPTS` | typed:int | 680 | Maximum proactive generation attempts before falling back. Default: 3. Range: [1, 10]. |
 | `MASC_KEEPER_REDUCER_CAP_TOKENS` | typed:int | 333 | Max message tokens retained by {!Agent_sdk.Context_reducer.cap_message_tokens} in the keeper run reducer pipeline.  D... |
 | `MASC_KEEPER_REDUCER_KEEP_RECENT` | typed:int | 341 | Recent messages kept verbatim by {!Agent_sdk.Context_reducer.cap_message_tokens}.  Default: 3. Range: [1, 20]. Env: [... |
 | `MASC_KEEPER_SELF_PRESERVATION_MIN_CANDIDATES` | typed:int | 177 | Self-preservation: minimum crashed candidates to trigger |
@@ -205,23 +206,23 @@ the categorization roadmap. Newly-added typed getters in
 | `MASC_KEEPER_SLEEP_CHUNK_SEC` | typed:float | 415 |  |
 | `MASC_KEEPER_SMART_HEARTBEAT` | feature_flag | 379 | Master switch for adaptive heartbeat scheduling in the keepalive loop. When true, Heartbeat_smart.should_emit gates p... |
 | `MASC_KEEPER_SNAPSHOT_SEC` | typed:int | 315 | Keeper keepalive snapshot interval, clamped to [15, 3600]. Default: 300. |
-| `MASC_KEEPER_STAGE_TIMING_RING_SIZE` | typed:int | 673 | Stage timing ring buffer size for Phase 0 profiling. Default: 100. Range: [10, 1000]. |
+| `MASC_KEEPER_STAGE_TIMING_RING_SIZE` | typed:int | 685 | Stage timing ring buffer size for Phase 0 profiling. Default: 100. Range: [10, 1000]. |
 | `MASC_KEEPER_STREAM_IDLE_TIMEOUT_SEC` | typed:float | 572 |  |
 | `MASC_KEEPER_SUPERVISOR_BACKOFF_BASE_S` | typed:float | 160 | Base delay for exponential backoff between restarts (seconds) |
 | `MASC_KEEPER_SUPERVISOR_BACKOFF_MAX_S` | typed:float | 164 | Maximum backoff delay cap (seconds) |
 | `MASC_KEEPER_SUPERVISOR_MAX_RESTARTS` | typed:int | 156 | Maximum restart attempts before declaring a keeper dead |
 | `MASC_KEEPER_SUPERVISOR_SWEEP_SEC` | typed:float | 168 | Interval between supervisor sweep runs (seconds) |
-| `MASC_KEEPER_SYMMETRIC_SANDBOX` | typed:bool | 808 | Legacy RFC-0006 Phase B-1 flag. Read-side containment now follows [sandbox_profile=docker] unconditionally. This gett... |
-| `MASC_KEEPER_TERMINATION_WINDOW_SEC` | typed:float | 629 | Sliding window for stale-termination escalation tracking. Default: 21600 (6 hours). |
-| `MASC_KEEPER_TRANSIENT_BACKOFF_BASE_SEC` | typed:float | 902 | Base delay (seconds) for exponential backoff. Delay at attempt [n] is [base * 2^(n-1)]. Env: [MASC_KEEPER_TRANSIENT_B... |
-| `MASC_KEEPER_TRANSIENT_BACKOFF_CAP_SEC` | typed:float | 906 | Hard cap on backoff delay (seconds). Env: [MASC_KEEPER_TRANSIENT_BACKOFF_CAP_SEC].  Default: 4.0. |
+| `MASC_KEEPER_SYMMETRIC_SANDBOX` | typed:bool | 820 | Legacy RFC-0006 Phase B-1 flag. Read-side containment now follows [sandbox_profile=docker] unconditionally. This gett... |
+| `MASC_KEEPER_TERMINATION_WINDOW_SEC` | typed:float | 641 | Sliding window for stale-termination escalation tracking. Default: 21600 (6 hours). |
+| `MASC_KEEPER_TRANSIENT_BACKOFF_BASE_SEC` | typed:float | 914 | Base delay (seconds) for exponential backoff. Delay at attempt [n] is [base * 2^(n-1)]. Env: [MASC_KEEPER_TRANSIENT_B... |
+| `MASC_KEEPER_TRANSIENT_BACKOFF_CAP_SEC` | typed:float | 918 | Hard cap on backoff delay (seconds). Env: [MASC_KEEPER_TRANSIENT_BACKOFF_CAP_SEC].  Default: 4.0. |
 | `MASC_KEEPER_TURN_TIMEOUT_SEC` | typed:float | 459 |  |
-| `MASC_KEEPER_WATCHDOG_GRACE_SEC` | typed:float | 624 | Grace period after fiber start before idle-stale detection activates. Prevents false positives on server restart when... |
-| `MASC_KEEPER_WATCHDOG_NOOP_THRESHOLD` | typed:int | 616 | Consecutive noop turns before considering the keeper stuck in a failure loop. Must be >= 2. Default: 3. |
-| `MASC_KEEPER_WATCHDOG_POLL_SEC` | typed:float | 611 | Watchdog poll interval in seconds. Must be >= 5. Default: 30. |
-| `MASC_KEEPER_WATCHDOG_STALE_SEC` | typed:float | 601 | Seconds since last turn before a Running keeper is considered idle-stale. Must be >= 60. Default: 300 (5 minutes). In... |
+| `MASC_KEEPER_WATCHDOG_GRACE_SEC` | typed:float | 636 | Grace period after fiber start before idle-stale detection activates. Prevents false positives on server restart when... |
+| `MASC_KEEPER_WATCHDOG_NOOP_THRESHOLD` | typed:int | 628 | Consecutive noop turns before considering the keeper stuck in a failure loop. Must be >= 2. Default: 3. |
+| `MASC_KEEPER_WATCHDOG_POLL_SEC` | typed:float | 623 | Watchdog poll interval in seconds. Must be >= 5. Default: 30. |
+| `MASC_KEEPER_WATCHDOG_STALE_SEC` | typed:float | 613 | Seconds since last turn before a Running keeper is considered idle-stale. Must be >= 60. Default: 300 (5 minutes). In... |
 | `MASC_KEEPER_WORK_AS_HEARTBEAT` | feature_flag | 363 | Master switch. When true, successful Coord.heartbeat after a unified turn counts as presence proof, allowing the next... |
-| `MASC_PAYLOAD_TELEMETRY` | typed:bool | 842 | Master switch for wake-payload measurement. Default off so the hot path is untouched until a baseline sweep is explic... |
+| `MASC_PAYLOAD_TELEMETRY` | typed:bool | 854 | Master switch for wake-payload measurement. Default off so the hot path is untouched until a baseline sweep is explic... |
 
 ## Env_config_oas_bridge (3 knobs)
 

--- a/lib/config/env_config_keeper.ml
+++ b/lib/config/env_config_keeper.ml
@@ -577,7 +577,9 @@ module KeeperKeepalive = struct
       The CLI subprocess is aborted via SIGINT if no stdout line arrives
       within this many seconds. Read fresh per-turn via
       {!Keeper_runtime_resolved.cli_subprocess_idle_sec}.
-      Env: [MASC_KEEPER_CLI_SUBPROCESS_IDLE_SEC]. Default: 120. Range: [10, 600]. *)
+      Env: [MASC_KEEPER_CLI_SUBPROCESS_IDLE_SEC]. Default: 120. Range: [10, 600].
+      @category Timeouts
+      @ops_class operator *)
   let cli_subprocess_idle_sec =
     Float.max 10.0
       (Float.min 600.0

--- a/lib/config/env_config_keeper.ml
+++ b/lib/config/env_config_keeper.ml
@@ -571,6 +571,18 @@ module KeeperKeepalive = struct
       (Float.min 600.0
          (get_float ~default:120.0 "MASC_KEEPER_STREAM_IDLE_TIMEOUT_SEC"))
 
+  (** Stdout-idle timeout for CLI subprocess transports (Kimi CLI today;
+      Claude Code / Gemini CLI / Codex CLI need an OAS upstream change to
+      expose [stdout_idle_timeout_s] in their transport configs).
+      The CLI subprocess is aborted via SIGINT if no stdout line arrives
+      within this many seconds. Read fresh per-turn via
+      {!Keeper_runtime_resolved.cli_subprocess_idle_sec}.
+      Env: [MASC_KEEPER_CLI_SUBPROCESS_IDLE_SEC]. Default: 120. Range: [10, 600]. *)
+  let cli_subprocess_idle_sec =
+    Float.max 10.0
+      (Float.min 600.0
+         (get_float ~default:120.0 "MASC_KEEPER_CLI_SUBPROCESS_IDLE_SEC"))
+
   (** Consecutive idle tool repetitions before on_idle hook issues Skip.
       Below this: graduated Nudge messages.
       With tool_choice=Any, the model always calls tools, so idle

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -272,11 +272,18 @@ let run_turn
     (* OAS [stream_idle_timeout_s] bounds inter-line idle on HTTP streams
        (Anthropic/OpenAI/Gemini/GLM/Ollama). The deadline resets after each
        successful line, so this is gap detection, not total run cap.
-       (CLI subprocess transports ignore it; bounded separately by OAS
-       cli_common_subprocess idle.) Default 120s catches real network/stream
-       hangs while preserving legitimate reasoning pauses + provider
-       keepalives. If the total OAS timeout is shorter, the idle gap is
-       clamped to that total cap so the nested timeout envelope is explicit. *)
+
+       CLI subprocess transports use a separate envelope:
+       [cli_subprocess_idle_sec], wired into [cli_transport_overrides]
+       below and forwarded to [Cli_common_subprocess.run_stream_lines]
+       via [stdout_idle_timeout_s] (Kimi CLI today; Claude Code / Gemini
+       CLI / Codex CLI need an OAS upstream change to expose the same
+       parameter in their transport configs).
+
+       Default 120 s catches real network/stream hangs while preserving
+       legitimate reasoning pauses + provider keepalives. If the total
+       OAS timeout is shorter, the idle gap is clamped to that total cap
+       so the nested timeout envelope is explicit. *)
     let stream_idle_timeout_s =
       Some
         (Keeper_runtime_resolved.stream_idle_timeout_for_total_timeout
@@ -315,6 +322,9 @@ let run_turn
               ~base_path:config.base_path
               ~agent_name:meta.agent_name
       in
+      let cli_subprocess_idle_sec =
+        Some (Keeper_runtime_resolved.cli_subprocess_idle_sec ())
+      in
       Some
         ({
           cwd = Some keeper_sandbox_root;
@@ -327,6 +337,7 @@ let run_turn
              | Some mode ->
                Some (String.equal (String.lowercase_ascii mode) "yolo")
              | None -> None);
+          cli_subprocess_idle_sec;
         } : Oas_worker.cli_transport_overrides)
     in
     (* Phase 0: wake-time payload telemetry (Option C baseline).

--- a/lib/keeper/keeper_runtime_config.ml
+++ b/lib/keeper/keeper_runtime_config.ml
@@ -40,6 +40,7 @@ let key_to_env =
     "turn.timeout_sec",                 "MASC_KEEPER_TURN_TIMEOUT_SEC";
     "turn.oas_timeout_sec",             "MASC_KEEPER_OAS_TIMEOUT_SEC";
     "turn.stream_idle_timeout_sec",     "MASC_KEEPER_STREAM_IDLE_TIMEOUT_SEC";
+    "turn.cli_subprocess_idle_sec",     "MASC_KEEPER_CLI_SUBPROCESS_IDLE_SEC";
     "turn.admission_wait_timeout_sec",  "MASC_KEEPER_ADMISSION_WAIT_TIMEOUT_SEC";
     "turn.max_consecutive_hb_failures", "MASC_KEEPER_MAX_CONSECUTIVE_HB_FAILURES";
     "turn.max_consecutive_turn_failures", "MASC_KEEPER_MAX_CONSECUTIVE_TURN_FAILURES";

--- a/lib/keeper/keeper_runtime_resolved.ml
+++ b/lib/keeper/keeper_runtime_resolved.ml
@@ -90,6 +90,21 @@ let stream_idle_timeout_sec_live () =
     (Float.min 600.0
        (get_float ~default:120.0 "MASC_KEEPER_STREAM_IDLE_TIMEOUT_SEC"))
 
+(* Per-call CLI subprocess idle timeout. Read fresh each turn rather than
+   frozen at server boot — the value sits outside the keepalive budget
+   contract enforced by the [t] snapshot. Range [10, 600] mirrors
+   [stream_idle_timeout_sec_live] but allows lower floors for CLI
+   transports that should fail faster than HTTP streaming providers.
+
+   SSOT: must match Env_config_keeper.KeeperKeepalive.cli_subprocess_idle_sec
+   (same default 120, same range [10, 600]). *)
+let cli_subprocess_idle_sec_live () =
+  Float.max 10.0
+    (Float.min 600.0
+       (get_float ~default:120.0 "MASC_KEEPER_CLI_SUBPROCESS_IDLE_SEC"))
+
+let cli_subprocess_idle_sec = cli_subprocess_idle_sec_live
+
 let oas_timeout_override_sec_live ~turn_timeout_sec =
   match Env_config_core.raw_value_opt "MASC_KEEPER_OAS_TIMEOUT_SEC" with
   | Some raw ->

--- a/lib/keeper/keeper_runtime_resolved.mli
+++ b/lib/keeper/keeper_runtime_resolved.mli
@@ -51,6 +51,13 @@ val turn_timeout_sec : unit -> float
 val admission_wait_timeout_sec : unit -> float
 val stream_idle_timeout_sec : unit -> float
 val stream_idle_timeout_for_total_timeout : total_timeout_s:float -> float
+
+(** CLI subprocess stdout-idle timeout, read fresh per turn from
+    [MASC_KEEPER_CLI_SUBPROCESS_IDLE_SEC] and clamped to [10, 600].
+    Default 120 s. Honoured by [Kimi_cli_transport_local]; other CLI
+    transports require an OAS upstream change to expose
+    [stdout_idle_timeout_s]. *)
+val cli_subprocess_idle_sec : unit -> float
 val oas_timeout_for_estimated_input_tokens_with_turn_budget :
   estimated_input_tokens:int ->
   max_turns:int ->

--- a/lib/oas_worker.mli
+++ b/lib/oas_worker.mli
@@ -61,6 +61,7 @@ type cli_transport_overrides = Oas_worker_exec.cli_transport_overrides = {
   claude_permission_mode : string option;
   claude_max_turns : int option;
   gemini_yolo : bool option;
+  cli_subprocess_idle_sec : float option;
 }
 
 type run_result = {

--- a/lib/oas_worker_exec.ml
+++ b/lib/oas_worker_exec.ml
@@ -24,6 +24,7 @@ type cli_transport_overrides =
   claude_permission_mode : string option;
   claude_max_turns : int option;
   gemini_yolo : bool option;
+  cli_subprocess_idle_sec : float option;
 }
 
 type config =

--- a/lib/oas_worker_exec.mli
+++ b/lib/oas_worker_exec.mli
@@ -56,9 +56,12 @@ type cli_transport_overrides =
   claude_permission_mode : string option;
   claude_max_turns : int option;
   gemini_yolo : bool option;
+  cli_subprocess_idle_sec : float option;
 }
-(** Per-call overrides threaded into the local CLI
-    transports (Claude Code, Gemini CLI, Kimi CLI). *)
+(** Per-call overrides threaded into the local CLI transports
+    (Claude Code, Gemini CLI, Kimi CLI).
+    [cli_subprocess_idle_sec] is currently honoured only by Kimi CLI;
+    see {!Oas_worker_exec_transport.cli_transport_overrides}. *)
 
 (** {1 Config} *)
 

--- a/lib/oas_worker_exec_transport.ml
+++ b/lib/oas_worker_exec_transport.ml
@@ -11,6 +11,15 @@ type cli_transport_overrides = {
   claude_permission_mode : string option;
   claude_max_turns : int option;
   gemini_yolo : bool option;
+  cli_subprocess_idle_sec : float option;
+  (* When [Some s], the CLI subprocess is aborted via SIGINT if no
+     stdout line arrives within [s] seconds. Currently honoured only
+     by [Kimi_cli_transport_local], which calls
+     [Cli_common_subprocess.run_stream_lines] directly. The other CLI
+     transports (claude_code, gemini_cli, codex_cli) route through
+     agent_sdk [Transport_*_cli.create] whose configs do not yet
+     expose [stdout_idle_timeout_s]; an OAS upstream change is needed
+     to honour this field there. *)
 }
 
 let claude_code_max_turns_hard_cap = 30
@@ -774,6 +783,7 @@ module Kimi_cli_transport_local = struct
     mcp_config_json : string list;
     extra_env : (string * string) list;
     cancel : unit Eio.Promise.t option;
+    stdout_idle_timeout_s : float option;
   }
 
   let default_config =
@@ -785,6 +795,7 @@ module Kimi_cli_transport_local = struct
       mcp_config_json = [];
       extra_env = [];
       cancel = None;
+      stdout_idle_timeout_s = None;
     }
 
   (* Kimi CLI imports [setproctitle] on macOS before processing the
@@ -1261,9 +1272,19 @@ module Kimi_cli_transport_local = struct
           let on_line line =
             if String.trim line <> "" then seen_lines := line :: !seen_lines
           in
+          let stdout_idle_timeout_s = config.stdout_idle_timeout_s in
+          let clock_opt =
+            match stdout_idle_timeout_s with
+            | None -> None
+            | Some _ -> (
+                match Process_eio.get_clock () with
+                | Ok c -> Some c
+                | Error _ -> None)
+          in
           let run_result, measured_latency_ms =
             Inference_utils.timed (fun () ->
                 Llm_provider.Cli_common_subprocess.run_stream_lines ~sw ~mgr
+                  ?clock:clock_opt ?stdout_idle_timeout_s
                   ~name:"kimi" ~cwd:config.cwd ~extra_env:config.extra_env
                   ~on_stderr_line
                   ?stdin_content:(stdin_for_prompt prompt)
@@ -1335,9 +1356,19 @@ module Kimi_cli_transport_local = struct
                           emit_blocks ~on_event ~start_index:!next_index
                             blocks))
           in
+          let stdout_idle_timeout_s = config.stdout_idle_timeout_s in
+          let clock_opt =
+            match stdout_idle_timeout_s with
+            | None -> None
+            | Some _ -> (
+                match Process_eio.get_clock () with
+                | Ok c -> Some c
+                | Error _ -> None)
+          in
           match
             classify_cli_error
               (Llm_provider.Cli_common_subprocess.run_stream_lines ~sw ~mgr
+                 ?clock:clock_opt ?stdout_idle_timeout_s
                  ~name:"kimi" ~cwd:config.cwd ~extra_env:config.extra_env
                  ~on_stderr_line
                  ?stdin_content:(stdin_for_prompt prompt)
@@ -1488,6 +1519,7 @@ let non_http_transport_of_provider
                   claude_permission_mode = None;
                   claude_max_turns = None;
                   gemini_yolo = None;
+                  cli_subprocess_idle_sec = None;
                 }
               cli_transport_overrides
           in
@@ -1525,6 +1557,7 @@ let non_http_transport_of_provider
                   claude_permission_mode = None;
                   claude_max_turns = None;
                   gemini_yolo = None;
+                  cli_subprocess_idle_sec = None;
                 }
               cli_transport_overrides
           in
@@ -1548,6 +1581,10 @@ let non_http_transport_of_provider
           let cwd =
             Option.bind cli_transport_overrides (fun overrides -> overrides.cwd)
           in
+          let stdout_idle_timeout_s =
+            Option.bind cli_transport_overrides (fun overrides ->
+              overrides.cli_subprocess_idle_sec)
+          in
           let mcp_config_json =
             kimi_cli_runtime_mcp_jsons ~base:[] runtime_mcp_policy
           in
@@ -1562,6 +1599,7 @@ let non_http_transport_of_provider
               config_json;
               mcp_config_json;
               extra_env;
+              stdout_idle_timeout_s;
             }
           in
           Ok

--- a/lib/oas_worker_exec_transport.mli
+++ b/lib/oas_worker_exec_transport.mli
@@ -14,6 +14,14 @@ type cli_transport_overrides = {
   claude_permission_mode : string option;
   claude_max_turns : int option;
   gemini_yolo : bool option;
+  cli_subprocess_idle_sec : float option;
+      (** When [Some s], the CLI subprocess is aborted via SIGINT if no
+          stdout line arrives within [s] seconds.  Currently honoured
+          only by [Kimi_cli_transport_local], which calls
+          [Cli_common_subprocess.run_stream_lines] directly.  Other CLI
+          transports route through agent_sdk [Transport_*_cli.create]
+          configs that do not yet expose [stdout_idle_timeout_s]; an
+          OAS upstream change is needed to honour this field there. *)
 }
 
 (** Hard cap for Claude Code's internal agent loop.  MASC may run a keeper
@@ -249,6 +257,13 @@ module Kimi_cli_transport_local : sig
     mcp_config_json : string list;
     extra_env : (string * string) list;
     cancel : unit Eio.Promise.t option;
+    stdout_idle_timeout_s : float option;
+        (** When [Some s], the kimi subprocess is aborted via SIGINT if no
+            stdout line arrives within [s] seconds.  Forwarded to
+            [Llm_provider.Cli_common_subprocess.run_stream_lines] together
+            with the process clock obtained from [Process_eio.get_clock].
+            Defaults to [None] (no idle bound; rely on the outer keeper
+            turn timeout). *)
   }
 
   val default_config : config

--- a/test/test_keeper_runtime_toml.ml
+++ b/test/test_keeper_runtime_toml.ml
@@ -516,6 +516,37 @@ let test_resolved_runtime_prefers_env_over_toml () =
     "env"
     (Keeper_runtime_resolved.source_to_string runtime.turn_timeout_sec.source)
 
+let test_resolved_cli_subprocess_idle_default_120s () =
+  with_clean_boot_overrides @@ fun () ->
+  Keeper_runtime_resolved.init ();
+  check (float 0.0001) "cli_subprocess_idle default 120s"
+    120.0 (Keeper_runtime_resolved.cli_subprocess_idle_sec ())
+
+let test_resolved_cli_subprocess_idle_clamps_low () =
+  with_clean_boot_overrides @@ fun () ->
+  with_env "MASC_KEEPER_CLI_SUBPROCESS_IDLE_SEC" (Some "1") @@ fun () ->
+  Keeper_runtime_resolved.init ();
+  check (float 0.0001) "cli_subprocess_idle clamps to 10s floor"
+    10.0 (Keeper_runtime_resolved.cli_subprocess_idle_sec ())
+
+let test_resolved_cli_subprocess_idle_clamps_high () =
+  with_clean_boot_overrides @@ fun () ->
+  with_env "MASC_KEEPER_CLI_SUBPROCESS_IDLE_SEC" (Some "9999") @@ fun () ->
+  Keeper_runtime_resolved.init ();
+  check (float 0.0001) "cli_subprocess_idle clamps to 600s ceiling"
+    600.0 (Keeper_runtime_resolved.cli_subprocess_idle_sec ())
+
+let test_resolved_cli_subprocess_idle_from_toml () =
+  with_clean_boot_overrides @@ fun () ->
+  with_base_path @@ fun base_path ->
+  write_toml base_path "[turn]\ncli_subprocess_idle_sec = 45\n";
+  (match Keeper_runtime_config.load_and_apply ~base_path with
+   | Error msg -> failf "unexpected error: %s" msg
+   | Ok _ -> ());
+  Keeper_runtime_resolved.init ();
+  check (float 0.0001) "cli_subprocess_idle from toml"
+    45.0 (Keeper_runtime_resolved.cli_subprocess_idle_sec ())
+
 let () =
   run "keeper_runtime_toml"
     [ ( "resolve_overrides"
@@ -543,5 +574,9 @@ let () =
         ; test_case "resolved stream idle timeout defaults and clamps to total" `Quick test_resolved_stream_idle_timeout_defaults_and_clamps_to_total
         ; test_case "resolved stream idle timeout uses toml" `Quick test_resolved_stream_idle_timeout_uses_toml
         ; test_case "resolved runtime prefers env over toml" `Quick test_resolved_runtime_prefers_env_over_toml
+        ; test_case "cli subprocess idle default 120s" `Quick test_resolved_cli_subprocess_idle_default_120s
+        ; test_case "cli subprocess idle from toml" `Quick test_resolved_cli_subprocess_idle_from_toml
+        ; test_case "cli subprocess idle clamps to 10s floor" `Quick test_resolved_cli_subprocess_idle_clamps_low
+        ; test_case "cli subprocess idle clamps to 600s ceiling" `Quick test_resolved_cli_subprocess_idle_clamps_high
         ] )
     ]


### PR DESCRIPTION
## Summary

Adds a `cli_subprocess_idle_sec` field to OAS `cli_transport_overrides` and plumbs `?stdout_idle_timeout_s` + `?clock` to the kimi_cli subprocess so the kimi CLI can be aborted via SIGINT when stdout falls silent for the configured duration. Default 120 s, range [10, 600], env `MASC_KEEPER_CLI_SUBPROCESS_IDLE_SEC`, TOML `turn.cli_subprocess_idle_sec`. Closes the masc-mcp portion of OAS goal `oas-bridge-stabilization` Step 1.

## Why this change

Keeper "살았다 죽었다" symptom: the OAS HTTP path is bounded by `stream_idle_timeout_s` (default 120 s) but the CLI subprocess path was unbounded — when a kimi/codex/gemini child went silent on stdout, the keeper waited the full `MASC_KEEPER_TURN_TIMEOUT_SEC` budget (clamped 600 s today, longer historically). The agent_sdk `Cli_common_subprocess.run_stream_lines` already exposes `?stdout_idle_timeout_s` and `?clock`, but masc-mcp's kimi call sites (`oas_worker_exec_transport.ml:1244` and `:1311`) never passed them — so the parameter was effectively dead for masc keepers.

## Scope (honest about partial coverage)

| Transport | Status after this PR |
|---|---|
| `Kimi_cli_transport_local` (masc-mcp local) | **Wired** — passes `?stdout_idle_timeout_s` + `?clock` to `Cli_common_subprocess.run_stream_lines`. |
| `Transport_codex_cli` (agent_sdk) | **Not wired** — the agent_sdk `config` record does not expose `stdout_idle_timeout_s`. Needs an OAS upstream PR before masc-mcp can plumb it. |
| `Transport_gemini_cli` (agent_sdk) | Same — upstream change needed. |
| `Transport_claude_code` (agent_sdk) | Same — upstream change needed. |

The new `cli_transport_overrides.cli_subprocess_idle_sec` field is added now so that when the upstream change lands, plumbing is one-line at each call site instead of a refactor.

## Files changed

| File | Change |
|---|---|
| `lib/oas_worker_exec_transport.ml` (and `.mli`) | Add `cli_subprocess_idle_sec : float option` to `cli_transport_overrides`; add `stdout_idle_timeout_s : float option` to `Kimi_cli_transport_local.config`; thread to both `Cli_common_subprocess.run_stream_lines` callsites. |
| `lib/oas_worker_exec.ml`, `lib/oas_worker_exec.mli`, `lib/oas_worker.mli` | Re-export updated record (3 mirrored definitions). |
| `lib/keeper/keeper_runtime_resolved.ml` (and `.mli`) | Add `cli_subprocess_idle_sec_live` + public `cli_subprocess_idle_sec`. |
| `lib/keeper/keeper_runtime_config.ml` | Add `turn.cli_subprocess_idle_sec` → `MASC_KEEPER_CLI_SUBPROCESS_IDLE_SEC` mapping. |
| `lib/config/env_config_keeper.ml` | SSOT mirror for the catalog generator. |
| `lib/keeper/keeper_agent_run.ml` | Construct `cli_subprocess_idle_sec` from runtime resolved; update outdated comment that claimed CLI transports were "bounded separately by OAS cli_common_subprocess idle". |
| `docs/runtime-tunables.md` | Regenerated via `dune exec ./bin/env_knob_catalog.exe`. |
| `test/test_keeper_runtime_toml.ml` | Add 4 tests: default 120 s, low/high clamp, TOML override. |

## Why "kimi only" is still useful

The kimi-coding-plan path is the chronic offender in the user-reported symptom; the production cascade routes most local-LLM coding work through it. Wiring just kimi today closes the most common root cause and makes the agent_sdk upstream PR a strict refactor instead of a feature change.

## Refs

- Goal: `oas-bridge-stabilization` (Step 1 of 7)
- Plan: `~/me/planning/claude-plans/20m-me-workspace-yousleepwhen-masc-mcp-o-recursive-mountain.md`
- Related RFCs: RFC-0022 (cascade attempt liveness), RFC-0012 (mid-turn progress probe)
- Companion PR: #13861 (RFC-0012/0022 update permitting per-cascade timeout override)
- Follow-up (out of scope): OAS upstream PR exposing `stdout_idle_timeout_s` in `Transport_codex_cli`, `Transport_gemini_cli`, `Transport_claude_code` config records.

## Test plan

- [x] `dune build` (full project) green.
- [x] `dune runtest` for `test_keeper_runtime_toml.ml` — 4 new test cases pass (default, low clamp, high clamp, TOML override).
- [ ] Manual: set `MASC_KEEPER_CLI_SUBPROCESS_IDLE_SEC=15` and run a keeper through the kimi cascade with a stalled prompt; observe SIGINT abort within ≤16 s instead of waiting the full turn budget.
- [ ] Production probe (post-merge): grep `keeper_llm_bridge: OAS execution cancelled after [0-9]+\.` for kimi runs; durations should cluster under the configured idle bound.

## Out of scope

- Codex CLI / Gemini CLI / Claude Code idle bounding (requires agent_sdk upstream).
- Cascade-level `cli_subprocess_idle_sec` override (would need cascade.toml schema; track separately under Step 2 / `feature/cascade-tiered-turn-timeout`).
- TLA+ spec for kimi idle invariant — defer to Step 3a (empty-response diagnosis).

## Pre-existing issue not addressed here

- `pr-rfc-check.sh` still requires bash 4+ (macOS default ships bash 3.2). The keeper subsystem files this PR touches make RFC discovery mandatory; the body cites RFC-0022 (Cascade Attempt Liveness) by name and the SSOT comment in `keeper_runtime_resolved.ml` so the spirit of the gate is satisfied even though the script itself can't run locally.