### PR TITLE
feat(dashboard): expose cascade inspector audit runs

### DIFF
--- a/dashboard/src/api/dashboard-cascade.test.ts
+++ b/dashboard/src/api/dashboard-cascade.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
+  fetchCascadeAuditRuns,
   fetchCascadeClientCapacityHistory,
   fetchCascadeConfig as fetchCascadeConfigFromCascade,
   fetchCascadeStrategyTrace,
@@ -55,6 +56,26 @@ describe('dashboard cascade split', () => {
     expect(fetchMock).toHaveBeenCalledTimes(1)
     expect(fetchMock.mock.calls[0]?.[0]).toBe('/api/v1/cascade/strategy_trace?limit=25&cascade=big_three')
     expect(result.events).toEqual([])
+  })
+
+  it('builds cascade audit runs query params', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({
+        updated_at: '2026-04-22T00:00:00Z',
+        total_runs: 0,
+        audit_runs: [],
+      }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await fetchCascadeAuditRuns({ limit: 10, cascade: 'keeper_unified' })
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(fetchMock.mock.calls[0]?.[0]).toBe('/api/v1/cascade/audit_runs?limit=10&cascade=keeper_unified')
+    expect(result.audit_runs).toEqual([])
   })
 
   it('posts keeper cascade updates unchanged', async () => {

--- a/dashboard/src/api/dashboard-cascade.ts
+++ b/dashboard/src/api/dashboard-cascade.ts
@@ -276,6 +276,55 @@ export function fetchCascadeStrategyTrace(opts?: {
   )
 }
 
+export type CascadeAuditHopStatus = 'success' | 'fallback' | 'error' | 'attempted'
+
+export interface CascadeAuditHop {
+  i: number
+  model: string
+  status: CascadeAuditHopStatus
+  ms: number
+  reason?: string
+  ms_source?: string
+}
+
+export interface CascadeAuditRun {
+  id: string
+  cascade: string
+  trigger: string
+  at: number
+  outcome: string
+  error_category?: string
+  configured: string[]
+  primary: string | null
+  selected: string | null
+  total_ms: number
+  total_ms_source?: string
+  hops: CascadeAuditHop[]
+}
+
+export interface CascadeAuditRunsResponse {
+  updated_at: string
+  total_runs: number
+  audit_runs: CascadeAuditRun[]
+}
+
+export function fetchCascadeAuditRuns(opts?: {
+  limit?: number
+  cascade?: string
+  signal?: AbortSignal
+}): Promise<CascadeAuditRunsResponse> {
+  const params = new URLSearchParams()
+  if (typeof opts?.limit === 'number' && opts.limit > 0) {
+    params.set('limit', String(opts.limit))
+  }
+  if (opts?.cascade) params.set('cascade', opts.cascade)
+  const qs = params.toString()
+  return get<CascadeAuditRunsResponse>(
+    `/api/v1/cascade/audit_runs${qs ? `?${qs}` : ''}`,
+    { signal: opts?.signal },
+  )
+}
+
 export type CascadeSloStatus = 'ok' | 'warn' | 'violated'
 
 interface CascadeSloTargets {

--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -62,6 +62,7 @@ import type {
   DashboardRuntimeResolution,
 } from '../types'
 export {
+  fetchCascadeAuditRuns,
   fetchCascadeClientCapacity,
   fetchCascadeClientCapacityHistory,
   fetchCascadeConfig,
@@ -74,6 +75,10 @@ export {
   updateKeeperCascade,
 } from './dashboard-cascade'
 export type {
+  CascadeAuditHop,
+  CascadeAuditHopStatus,
+  CascadeAuditRun,
+  CascadeAuditRunsResponse,
   CascadeCandidate,
   CascadeCapacityEventKind,
   CascadeClientCapacityEntry,

--- a/lib/dashboard_cascade.ml
+++ b/lib/dashboard_cascade.ml
@@ -911,6 +911,237 @@ let strategy_trace_json ?limit ?cascade () =
     ("events", `List (List.map strategy_trace_event_to_json events));
   ]
 
+(* ── Cascade inspector projection (O1) ─────────────────────────────
+
+   The runtime writer already persists per-call observations under
+   [.masc/cascade_audit/YYYY-MM/DD.jsonl].  This projection keeps that
+   durable SSOT and reshapes each record into the O1 inspector contract:
+   one cascade run with configured pool, selected model, aggregate
+   duration, and ordered hop rows. *)
+
+let json_string_member key json =
+  match json_assoc_member key json with
+  | `String value -> Some value
+  | _ -> None
+
+let json_float_member key json =
+  match json_assoc_member key json with
+  | `Float value -> Some value
+  | `Int value -> Some (float_of_int value)
+  | _ -> None
+
+let json_int_member key json =
+  match json_assoc_member key json with
+  | `Int value -> Some value
+  | `Float value -> Some (int_of_float value)
+  | _ -> None
+
+let json_list_member key json =
+  match json_assoc_member key json with
+  | `List values -> values
+  | _ -> []
+
+let nonempty_string value =
+  match value with
+  | Some raw ->
+      let trimmed = String.trim raw in
+      if String.equal trimmed "" then None else Some trimmed
+  | None -> None
+
+let first_nonempty values =
+  List.find_map nonempty_string values
+
+let json_string_opt_member key json =
+  json_string_member key json |> nonempty_string
+
+let audit_store_dir ~base_path =
+  Filename.concat
+    (Common.masc_dir_from_base_path ~base_path)
+    "cascade_audit"
+
+let cascade_audit_store ~base_path =
+  Dated_jsonl.create ~base_dir:(audit_store_dir ~base_path) ()
+
+let stable_audit_run_id json =
+  "cascade-audit-" ^ String.sub (Digest.to_hex (Digest.string (Yojson.Safe.to_string json))) 0 16
+
+let model_display_of_attempt attempt =
+  first_nonempty
+    [
+      json_string_member "model_label" attempt;
+      json_string_member "model_id" attempt;
+    ]
+  |> Option.value ~default:"unknown"
+
+let fallback_reason_for_model ~model_id ~model_label fallback_events =
+  let matches value =
+    match nonempty_string value with
+    | None -> false
+    | Some value ->
+        (match model_id with Some id -> String.equal value id | None -> false)
+        || (match model_label with Some label -> String.equal value label | None -> false)
+  in
+  List.find_map
+    (fun event ->
+      if matches (json_string_member "from_model_id" event)
+         || matches (json_string_member "from_model_label" event)
+      then json_string_opt_member "reason" event
+      else None)
+    fallback_events
+
+let audit_hop_json ~selected_model ~fallback_events attempt =
+  let model_id = json_string_opt_member "model_id" attempt in
+  let model_label = json_string_opt_member "model_label" attempt in
+  let model = model_display_of_attempt attempt in
+  let latency_ms = json_int_member "latency_ms" attempt in
+  let error = json_string_opt_member "error" attempt in
+  let reason =
+    match error with
+    | Some _ as value -> value
+    | None -> fallback_reason_for_model ~model_id ~model_label fallback_events
+  in
+  let selected =
+    match selected_model with
+    | Some selected ->
+        String.equal selected model
+        || (match model_id with Some id -> String.equal selected id | None -> false)
+        || (match model_label with Some label -> String.equal selected label | None -> false)
+    | None -> false
+  in
+  let status =
+    match error, reason, selected with
+    | Some _, _, _ -> "error"
+    | None, _, true -> "success"
+    | None, Some _, false -> "fallback"
+    | None, None, _ -> "attempted"
+  in
+  let base =
+    [
+      ("i", `Int (Option.value ~default:0 (json_int_member "attempt_index" attempt)));
+      ("model", `String model);
+      ("status", `String status);
+      ("ms", `Int (Option.value ~default:0 latency_ms));
+      ("ms_source",
+       `String (if Option.is_some latency_ms then "oas_metrics_callbacks" else "unavailable"));
+    ]
+  in
+  let fields =
+    match reason with
+    | Some value -> base @ [("reason", `String value)]
+    | None -> base
+  in
+  `Assoc fields
+
+let attempt_latency_total attempts =
+  List.fold_left
+    (fun acc attempt ->
+      acc + Option.value ~default:0 (json_int_member "latency_ms" attempt))
+    0 attempts
+
+let last_attempt_error attempts =
+  List.rev attempts |> List.find_map (json_string_opt_member "error")
+
+let audit_run_json_of_record json =
+  let observation = json_assoc_member "observation" json in
+  let configured_labels = json_string_list (json_assoc_member "configured_labels" observation) in
+  let candidate_models = json_string_list (json_assoc_member "candidate_models" observation) in
+  let configured =
+    match configured_labels with
+    | [] -> candidate_models
+    | labels -> labels
+  in
+  let attempts = json_list_member "attempts" observation in
+  let fallback_events = json_list_member "fallback_events" observation in
+  let selected =
+    first_nonempty
+      [
+        json_string_member "selected_model" observation;
+        json_string_member "selected_model_raw" observation;
+      ]
+  in
+  let primary =
+    first_nonempty
+      [
+        json_string_member "primary_model" observation;
+        List.nth_opt configured 0;
+        List.nth_opt candidate_models 0;
+      ]
+  in
+  let cascade =
+    first_nonempty
+      [
+        json_string_member "cascade_name" json;
+        json_string_member "cascade_name" observation;
+      ]
+    |> Option.value ~default:"unknown"
+  in
+  let ts = Option.value ~default:0.0 (json_float_member "ts" json) in
+  let top_level_reason = json_string_opt_member "top_level_reason" json in
+  let error_category =
+    match top_level_reason with
+    | Some _ as value -> value
+    | None -> last_attempt_error attempts
+  in
+  let base =
+    [
+      ("id", `String (stable_audit_run_id json));
+      ("cascade", `String cascade);
+      ( "trigger",
+        `String
+          (json_string_opt_member "keeper_name" json
+           |> Option.value ~default:"unknown") );
+      ("at", `Float ts);
+      ( "outcome",
+        `String
+          (json_string_member "outcome" json |> Option.value ~default:"unknown") );
+      ("configured", `List (List.map (fun value -> `String value) configured));
+      ("primary", Json_util.string_opt_to_json primary);
+      ("selected", Json_util.string_opt_to_json selected);
+      ("total_ms", `Int (attempt_latency_total attempts));
+      ( "total_ms_source",
+        `String
+          (if List.exists (fun attempt -> Option.is_some (json_int_member "latency_ms" attempt)) attempts
+           then "attempt_latency_sum"
+           else "unavailable") );
+      ("hops", `List (List.map (audit_hop_json ~selected_model:selected ~fallback_events) attempts));
+    ]
+  in
+  let fields =
+    match error_category with
+    | Some value -> base @ [("error_category", `String value)]
+    | None -> base
+  in
+  `Assoc fields
+
+let audit_run_cascade_matches cascade_filter run =
+  match cascade_filter with
+  | None -> true
+  | Some expected ->
+      (match json_string_member "cascade" run with
+      | Some actual -> String.equal actual expected
+      | None -> false)
+
+let audit_runs_json ~base_path ?limit ?cascade () =
+  let limit = Option.value ~default:100 limit |> max 1 |> min 1024 in
+  let read_limit = if Option.is_some cascade then min 4096 (limit * 4) else limit in
+  let runs =
+    Dated_jsonl.read_recent (cascade_audit_store ~base_path) read_limit
+    |> List.rev
+    |> List.map audit_run_json_of_record
+    |> List.filter (audit_run_cascade_matches cascade)
+  in
+  let rec take n = function
+    | _ when n <= 0 -> []
+    | [] -> []
+    | x :: xs -> x :: take (n - 1) xs
+  in
+  let runs = take limit runs in
+  `Assoc [
+    ("updated_at", `String (now_iso ()));
+    ("total_runs", `Int (List.length runs));
+    ("audit_runs", `List runs);
+  ]
+
 (* ── SLO projection (LT-11) ─────────────────────────────────
 
    Targets mirror infrastructure/monitoring/cascade-slo.yml.  Computed

--- a/lib/dashboard_cascade.mli
+++ b/lib/dashboard_cascade.mli
@@ -387,6 +387,49 @@ val strategy_trace_json :
   ?cascade:string ->
   unit -> Yojson.Safe.t
 
+(** JSON projection of durable cascade audit records for the O1 Cascade
+    Inspector.
+
+    Reads [base_path/.masc/cascade_audit/YYYY-MM/DD.jsonl] and reshapes each
+    runtime audit record into one run row:
+    {[
+      {
+        "updated_at": "ISO-8601",
+        "total_runs": <int>,
+        "audit_runs": [
+          { "id": "cascade-audit-...",
+            "cascade": "keeper_unified",
+            "trigger": "sangsu",
+            "at": <unix seconds>,
+            "outcome": "success" | "failure" | "rejected",
+            "error_category": "..."?,
+            "configured": ["glm-coding:auto", ...],
+            "primary": "glm-coding:auto" | null,
+            "selected": "glm-coding:auto" | null,
+            "total_ms": <int>,
+            "hops": [
+              { "i": 0,
+                "model": "glm-coding:auto",
+                "status": "success" | "fallback" | "error" | "attempted",
+                "ms": <int>,
+                "reason": "..."? }, ...
+            ] }, ...
+        ]
+      }
+    ]}
+
+    [total_ms_source] and per-hop [ms_source] are also emitted so missing
+    callback timings are explicit instead of hidden behind fake numbers.
+
+    @param limit    max runs returned (default 100, clamped to [1, 1024]).
+    @param cascade  filter by projected [cascade]; omit to include every
+                    cascade. *)
+val audit_runs_json :
+  base_path:string ->
+  ?limit:int ->
+  ?cascade:string ->
+  unit -> Yojson.Safe.t
+
 (** Instantaneous SLO snapshot computed from the live
     {!Cascade_strategy_trace} ring buffer.
 

--- a/lib/server/server_routes_http_routes_cascade.ml
+++ b/lib/server/server_routes_http_routes_cascade.ml
@@ -114,6 +114,32 @@ let add_routes router =
          Http.Response.json ~compress:true ~request:req
            (Yojson.Safe.to_string json) reqd
        ) request reqd)
+  |> Http.Router.get "/api/v1/cascade/audit_runs" (fun request reqd ->
+       with_public_read (fun state req reqd ->
+         let limit =
+           clamp_history_limit (int_query_param req "limit" ~default:100)
+         in
+         let cascade = query_param req "cascade" in
+         let base_path = state.Mcp_server.room_config.base_path in
+         let json =
+           Dashboard_cascade.audit_runs_json ~base_path ~limit ?cascade ()
+         in
+         Http.Response.json ~compress:true ~request:req
+           (Yojson.Safe.to_string json) reqd
+       ) request reqd)
+  |> Http.Router.get "/api/v1/cascade/inspector" (fun request reqd ->
+       with_public_read (fun state req reqd ->
+         let limit =
+           clamp_history_limit (int_query_param req "limit" ~default:100)
+         in
+         let cascade = query_param req "cascade" in
+         let base_path = state.Mcp_server.room_config.base_path in
+         let json =
+           Dashboard_cascade.audit_runs_json ~base_path ~limit ?cascade ()
+         in
+         Http.Response.json ~compress:true ~request:req
+           (Yojson.Safe.to_string json) reqd
+       ) request reqd)
   |> Http.Router.get "/api/v1/cascade/slo" (fun request reqd ->
        with_public_read (fun _state req reqd ->
          let json = Dashboard_cascade.slo_json () in

--- a/test/test_dashboard_cascade.ml
+++ b/test/test_dashboard_cascade.ml
@@ -754,6 +754,107 @@ let test_slo_top_level_shape () =
   check bool "has status" true (List.mem_assoc "status" fs);
   check bool "has violations" true (List.mem_assoc "violations" fs)
 
+(* ── O1 cascade inspector audit runs ───────────────────────────── *)
+
+let test_audit_runs_json_projects_o1_shape () =
+  with_temp_config_root_setup
+    (fun _dir -> ())
+    (fun base_path ->
+       let audit_dir =
+         Filename.concat
+           (Masc_mcp.Coord_utils.masc_dir_from_base_path ~base_path)
+           "cascade_audit"
+       in
+       let store = Dated_jsonl.create ~base_dir:audit_dir () in
+       Dated_jsonl.append store
+         (`Assoc
+            [
+              ("ts", `Float 123.4);
+              ("keeper_name", `String "sangsu");
+              ("cascade_name", `String "keeper_unified");
+              ("outcome", `String "success");
+              ("top_level_reason", `Null);
+              ( "observation",
+                `Assoc
+                  [
+                    ("cascade_name", `String "keeper_unified");
+                    ("strategy", `String "failover");
+                    ("configured_labels", `List [`String "glm"; `String "kimi"]);
+                    ("candidate_models", `List [`String "glm"; `String "kimi"]);
+                    ("primary_model", `String "glm");
+                    ("selected_model", `String "kimi");
+                    ("selected_model_raw", `String "kimi-model");
+                    ( "attempts",
+                      `List
+                        [
+                          `Assoc
+                            [
+                              ("attempt_index", `Int 0);
+                              ("model_id", `String "glm-model");
+                              ("model_label", `String "glm");
+                              ("latency_ms", `Int 120);
+                              ("error", `String "timeout");
+                            ];
+                          `Assoc
+                            [
+                              ("attempt_index", `Int 1);
+                              ("model_id", `String "kimi-model");
+                              ("model_label", `String "kimi");
+                              ("latency_ms", `Int 80);
+                              ("error", `Null);
+                            ];
+                        ] );
+                    ( "fallback_events",
+                      `List
+                        [
+                          `Assoc
+                            [
+                              ("from_model_id", `String "glm-model");
+                              ("from_model_label", `String "glm");
+                              ("to_model_id", `String "kimi-model");
+                              ("to_model_label", `String "kimi");
+                              ("reason", `String "timeout");
+                            ];
+                        ] );
+                    ("attempt_details_available", `Bool true);
+                    ("attempt_details_source", `String "oas_metrics_callbacks");
+                  ] );
+            ]);
+       let json =
+         Masc_mcp.Dashboard_cascade.audit_runs_json ~base_path ~limit:10 ()
+       in
+       let runs = Yojson.Safe.Util.(json |> member "audit_runs" |> to_list) in
+       check int "one run" 1 (List.length runs);
+       match runs with
+       | [] -> fail "missing audit run"
+       | run :: _ ->
+           check string "cascade" "keeper_unified"
+             Yojson.Safe.Util.(run |> member "cascade" |> to_string);
+           check string "trigger" "sangsu"
+             Yojson.Safe.Util.(run |> member "trigger" |> to_string);
+           check string "selected" "kimi"
+             Yojson.Safe.Util.(run |> member "selected" |> to_string);
+           check int "total_ms" 200
+             Yojson.Safe.Util.(run |> member "total_ms" |> to_int);
+           let hops = Yojson.Safe.Util.(run |> member "hops" |> to_list) in
+           check int "two hops" 2 (List.length hops);
+           (match hops with
+            | first :: second :: _ ->
+                check string "first status" "error"
+                  Yojson.Safe.Util.(first |> member "status" |> to_string);
+                check string "first reason" "timeout"
+                  Yojson.Safe.Util.(first |> member "reason" |> to_string);
+                check string "second status" "success"
+                  Yojson.Safe.Util.(second |> member "status" |> to_string)
+            | _ -> fail "expected two hops");
+           let filtered =
+             Masc_mcp.Dashboard_cascade.audit_runs_json ~base_path ~limit:10
+               ~cascade:"other" ()
+           in
+           check int "cascade filter excludes other" 0
+             Yojson.Safe.Util.(
+               filtered |> member "audit_runs" |> to_list |> List.length))
+
 (* ── keeper_profile_json: raw vs canonical contract ──────────────── *)
 
 (* These tests exercise the pure [keeper_profile_json] projection directly
@@ -1008,6 +1109,10 @@ let () =
       test_case "partial filtered drops ratio" `Quick test_slo_partial_filtered;
       test_case "exhaustion > 10 → violated" `Quick test_slo_exhaustion_breach;
       test_case "burn_rate math" `Quick test_slo_burn_rate_math;
+    ];
+    "audit_runs", [
+      test_case "projects cascade_audit records into O1 run shape" `Quick
+        test_audit_runs_json_projects_o1_shape;
     ];
     "keeper_profile_json", [
       test_case "unknown cascade preserves raw, canonical shows drift"


### PR DESCRIPTION
## Summary

- Implements #11574 backend/read-model support for the O1 Cascade Inspector.
- Adds `/api/v1/cascade/audit_runs` plus `/api/v1/cascade/inspector` as a route alias.
- Projects durable `.masc/cascade_audit/YYYY-MM/DD.jsonl` records into `audit_runs[]` with configured pool, primary/selected model, outcome, total latency, and ordered hop rows.
- Adds typed dashboard client support and API query tests for the new audit-run feed.

## Operator Impact

- Operators can inspect actual cascade executions from the durable audit log instead of the flat strategy-trace ring.
- Hop timing uses existing OAS metrics callback data; when timing is unavailable, `total_ms_source` / `ms_source` explicitly say `unavailable` rather than hiding fake timing.
- Existing `/api/v1/cascade/strategy_trace` remains unchanged for strategy-cycle diagnostics.

## Verification

- `pnpm install --frozen-lockfile --offline`
- `pnpm run typecheck`
- `pnpm exec vitest run src/api/dashboard-cascade.test.ts`
- `git diff --check origin/main...HEAD`
- Attempted `scripts/dune-local.sh build test/test_dashboard_cascade.exe`, but the target remained queued behind `/tmp/me-dune-local.lock` held by other worktrees. Backend compile/test remains on PR CI for this draft.

Fixes #11574
