### PR TITLE
feat(board): RFC-0037 PR-1 — Board_attachment_meta carrier on post.meta_json

### DIFF
--- a/lib/board_attachment_meta.ml
+++ b/lib/board_attachment_meta.ml
@@ -1,0 +1,173 @@
+(* Board_attachment_meta — pure-data attachment carrier.
+   See lib/board_attachment_meta.mli for the contract. *)
+
+(* Errors *)
+
+type error =
+  | Invalid_id of string
+  | Invalid_kind of string
+  | Invalid_payload of string
+  | Missing_field of string
+[@@deriving show]
+
+let error_to_string = function
+  | Invalid_id s -> Printf.sprintf "Invalid attachment id: %s" s
+  | Invalid_kind s -> Printf.sprintf "Invalid attachment kind: %s" s
+  | Invalid_payload s -> Printf.sprintf "Invalid attachment payload: %s" s
+  | Missing_field s -> Printf.sprintf "Missing field: %s" s
+
+(* Kind *)
+
+type kind =
+  | Image
+  | Video
+  | Youtube
+  | External_link
+
+let kind_to_string = function
+  | Image -> "image"
+  | Video -> "video"
+  | Youtube -> "youtube"
+  | External_link -> "external_link"
+
+let kind_of_string = function
+  | "image" -> Ok Image
+  | "video" -> Ok Video
+  | "youtube" -> Ok Youtube
+  | "external_link" -> Ok External_link
+  | s -> Error (Invalid_kind s)
+
+(* Id — same character class + length envelope as Board_types.Post_id *)
+
+module Id = struct
+  type t = string
+
+  let valid_pattern = Re.Pcre.re {|^[a-zA-Z0-9_-]+$|} |> Re.compile
+
+  let of_string s =
+    let s = String.trim s in
+    let len = String.length s in
+    if len >= 1 && len <= 64 && Re.execp valid_pattern s then Ok s
+    else Error (Invalid_id (Printf.sprintf "Invalid attachment id: %s" s))
+
+  let to_string t = t
+
+  let generate () = Random_id.prefixed ~prefix:"a-" ~bytes:16
+
+  let equal = String.equal
+end
+
+(* Record *)
+
+type t = {
+  id : Id.t;
+  kind : kind;
+  origin_url : string;
+  origin_name : string;
+  origin_size_bytes : int;
+  mime_type : string;
+  width : int option;
+  height : int option;
+  created_at : float;
+}
+
+(* JSON encoding — explicit, no ppx_deriving_yojson dependency. *)
+
+let opt_int_to_yojson = function
+  | None -> `Null
+  | Some i -> `Int i
+
+let to_yojson (t : t) : Yojson.Safe.t =
+  `Assoc [
+    "id", `String (Id.to_string t.id);
+    "kind", `String (kind_to_string t.kind);
+    "origin_url", `String t.origin_url;
+    "origin_name", `String t.origin_name;
+    "origin_size_bytes", `Int t.origin_size_bytes;
+    "mime_type", `String t.mime_type;
+    "width", opt_int_to_yojson t.width;
+    "height", opt_int_to_yojson t.height;
+    "created_at", `Float t.created_at;
+  ]
+
+let opt_int_of_yojson = function
+  | `Null -> Ok None
+  | `Int i -> Ok (Some i)
+  | _ -> Error (Invalid_payload "expected null or int")
+
+let assoc_get key = function
+  | `Assoc kvs -> (
+      match List.assoc_opt key kvs with
+      | Some v -> Ok v
+      | None -> Error (Missing_field key))
+  | _ -> Error (Invalid_payload "expected JSON object")
+
+let string_of_yojson key json =
+  match assoc_get key json with
+  | Ok (`String s) -> Ok s
+  | Ok _ -> Error (Invalid_payload (Printf.sprintf "%s: expected string" key))
+  | Error e -> Error e
+
+let int_of_yojson key json =
+  match assoc_get key json with
+  | Ok (`Int i) -> Ok i
+  | Ok _ -> Error (Invalid_payload (Printf.sprintf "%s: expected int" key))
+  | Error e -> Error e
+
+let float_of_yojson key json =
+  match assoc_get key json with
+  | Ok (`Float f) -> Ok f
+  | Ok (`Int i) -> Ok (float_of_int i)
+  | Ok _ -> Error (Invalid_payload (Printf.sprintf "%s: expected float" key))
+  | Error e -> Error e
+
+let opt_int_field key json =
+  match assoc_get key json with
+  | Ok v -> opt_int_of_yojson v
+  | Error _ -> Ok None  (* missing optional => None *)
+
+let ( let* ) = Result.bind
+
+let of_yojson (json : Yojson.Safe.t) : (t, error) result =
+  let* id_str = string_of_yojson "id" json in
+  let* id = Id.of_string id_str in
+  let* kind_str = string_of_yojson "kind" json in
+  let* kind = kind_of_string kind_str in
+  let* origin_url = string_of_yojson "origin_url" json in
+  let* origin_name = string_of_yojson "origin_name" json in
+  let* origin_size_bytes = int_of_yojson "origin_size_bytes" json in
+  let* mime_type = string_of_yojson "mime_type" json in
+  let* width = opt_int_field "width" json in
+  let* height = opt_int_field "height" json in
+  let* created_at = float_of_yojson "created_at" json in
+  Ok {
+    id; kind; origin_url; origin_name;
+    origin_size_bytes; mime_type; width; height; created_at;
+  }
+
+(* meta_json embedding *)
+
+let meta_json_key = "attachments"
+
+let attach_to_post_meta ~existing (attachments : t list) : Yojson.Safe.t =
+  let attachments_json = `List (List.map to_yojson attachments) in
+  let other_keys =
+    match existing with
+    | Some (`Assoc kvs) ->
+      List.filter (fun (k, _) -> not (String.equal k meta_json_key)) kvs
+    | _ -> []
+  in
+  `Assoc (other_keys @ [meta_json_key, attachments_json])
+
+let attachments_of_post_meta (meta : Yojson.Safe.t option) : t list =
+  match meta with
+  | Some (`Assoc kvs) -> (
+      match List.assoc_opt meta_json_key kvs with
+      | Some (`List items) ->
+        List.filter_map (fun j ->
+          match of_yojson j with
+          | Ok a -> Some a
+          | Error _ -> None
+        ) items
+      | _ -> [])
+  | _ -> []

--- a/lib/board_attachment_meta.mli
+++ b/lib/board_attachment_meta.mli
@@ -1,0 +1,108 @@
+(** Board_attachment_meta — pure-data carrier for board post attachments.
+
+    Attachments are referenced from a [Board_types.post] via the existing
+    [meta_json : Yojson.Safe.t option] field — no struct change to the
+    post type.  This module owns the JSON shape under the
+    ["attachments"] key.
+
+    No I/O.  No Eio.  No network.  Round-trippable JSON.
+
+    See [docs/rfc/RFC-0037-board-multimedia-vision-adapted.md] §4.1 for
+    the design rationale.  This is RFC-0037 PR-1.
+
+    Properties enforced:
+    - [Id] is opaque + parsed (Parse, don't validate), mirroring the
+      discipline used by [Board_types.Post_id] / [Board_types.Comment_id].
+    - [of_yojson] is total: an unknown JSON shape returns [Error] rather
+      than throwing.
+    - [attach_to_post_meta] preserves any keys in [meta_json] other than
+      the ["attachments"] slot, so this module can coexist with future
+      [meta_json] users. *)
+
+(** {1 Errors} *)
+
+type error =
+  | Invalid_id of string
+  | Invalid_kind of string
+  | Invalid_payload of string
+  | Missing_field of string
+[@@deriving show]
+
+val error_to_string : error -> string
+
+(** {1 Attachment kind — closed sum} *)
+
+type kind =
+  | Image
+  | Video
+  | Youtube
+  | External_link
+
+val kind_to_string : kind -> string
+val kind_of_string : string -> (kind, error) result
+
+(** {1 Attachment id — opaque, parsed} *)
+
+module Id : sig
+  type t
+
+  val of_string : string -> (t, error) result
+  (** Validates [a-zA-Z0-9_-]+ and length 1..64.  Same character class as
+      [Board_types.Post_id]. *)
+
+  val to_string : t -> string
+
+  val generate : unit -> t
+  (** Cryptographic random id, prefix ["a-"]. *)
+
+  val equal : t -> t -> bool
+end
+
+(** {1 Attachment record} *)
+
+type t = {
+  id : Id.t;
+  kind : kind;
+  origin_url : string;
+  origin_name : string;
+  origin_size_bytes : int;
+  mime_type : string;
+  width : int option;
+  height : int option;
+  created_at : float;
+}
+
+(** {1 JSON encoding} *)
+
+val to_yojson : t -> Yojson.Safe.t
+val of_yojson : Yojson.Safe.t -> (t, error) result
+
+(** {1 [meta_json] embedding}
+
+    These helpers pack/unpack a list of attachments under the
+    ["attachments"] key of a post's [meta_json] field. *)
+
+val meta_json_key : string
+(** ["attachments"] — single-source-of-truth for the JSON key. *)
+
+val attach_to_post_meta :
+  existing:Yojson.Safe.t option ->
+  t list ->
+  Yojson.Safe.t
+(** [attach_to_post_meta ~existing attachments] returns a JSON object
+    that:
+    - preserves every key in [existing] (when it is a [`Assoc]) other
+      than [meta_json_key]
+    - sets [meta_json_key] to a JSON array of [attachments]
+
+    If [existing] is [None] or not a [`Assoc], the returned object has
+    only the [meta_json_key] entry.  The returned value is suitable to
+    drop into [post.meta_json]. *)
+
+val attachments_of_post_meta : Yojson.Safe.t option -> t list
+(** [attachments_of_post_meta meta] returns the attachments encoded under
+    [meta_json_key].  Total: any shape that does not match returns the
+    empty list, including [None], non-[`Assoc], missing key, or invalid
+    items.  Invalid items are silently dropped — readers that need
+    strict validation should iterate the array themselves with
+    [of_yojson]. *)

--- a/test/dune
+++ b/test/dune
@@ -691,6 +691,7 @@
         test_goal_verification
         test_string_util
         test_board_core_payload
+        test_board_attachment_meta
         test_board_moderation
         test_voice_config)
  (modules
@@ -894,6 +895,7 @@
         test_goal_verification
         test_string_util
         test_board_core_payload
+        test_board_attachment_meta
         test_board_moderation
         test_voice_config)
  (libraries masc_test_deps)

--- a/test/test_board_attachment_meta.ml
+++ b/test/test_board_attachment_meta.ml
@@ -1,0 +1,292 @@
+(** Tests for Board_attachment_meta — RFC-0037 PR-1.
+
+    Pure-data round-trip + meta_json embedding.  No I/O. *)
+
+open Alcotest
+open Masc_mcp
+module BAM = Board_attachment_meta
+
+(* Initialize crypto RNG once — required by Random_id.prefixed via
+   Mirage_crypto_rng. Same pattern as test_board_karma_ledger,
+   test_board_moderation, test_board_curation, etc. *)
+let () = Mirage_crypto_rng_unix.use_default ()
+
+let sample_attachment ?(kind = BAM.Image) ?(width = Some 1920)
+    ?(height = Some 1080) ?(name = "diagram.png") () : BAM.t =
+  {
+    id = BAM.Id.generate ();
+    kind;
+    origin_url = "https://example.com/upload/diagram.png";
+    origin_name = name;
+    origin_size_bytes = 524288;
+    mime_type = "image/png";
+    width;
+    height;
+    created_at = 1714989600.0;
+  }
+
+let attachment_eq (a : BAM.t) (b : BAM.t) : bool =
+  BAM.Id.equal a.id b.id
+  && a.kind = b.kind
+  && String.equal a.origin_url b.origin_url
+  && String.equal a.origin_name b.origin_name
+  && a.origin_size_bytes = b.origin_size_bytes
+  && String.equal a.mime_type b.mime_type
+  && a.width = b.width
+  && a.height = b.height
+  && Float.equal a.created_at b.created_at
+
+let attachment_pp fmt (t : BAM.t) =
+  Format.fprintf fmt
+    "{id=%s; kind=%s; origin_url=%s; origin_size_bytes=%d}"
+    (BAM.Id.to_string t.id)
+    (BAM.kind_to_string t.kind)
+    t.origin_url
+    t.origin_size_bytes
+
+let attachment_testable = testable attachment_pp attachment_eq
+
+(* --- Id discipline --- *)
+
+let test_id_generate_prefix () =
+  let id = BAM.Id.generate () in
+  let s = BAM.Id.to_string id in
+  check bool "generated id has 'a-' prefix" true
+    (String.length s > 2 && String.sub s 0 2 = "a-")
+
+let test_id_of_string_valid () =
+  match BAM.Id.of_string "a-abcdef0123" with
+  | Ok _ -> ()
+  | Error _ -> fail "valid id rejected"
+
+let test_id_of_string_rejects_path_traversal () =
+  match BAM.Id.of_string "../etc/passwd" with
+  | Ok _ -> fail "path traversal accepted"
+  | Error _ -> ()
+
+let test_id_of_string_rejects_slash () =
+  match BAM.Id.of_string "a/b" with
+  | Ok _ -> fail "slash accepted"
+  | Error _ -> ()
+
+let test_id_of_string_rejects_too_long () =
+  let s = String.make 65 'x' in
+  match BAM.Id.of_string s with
+  | Ok _ -> fail "65-char id accepted"
+  | Error _ -> ()
+
+let test_id_of_string_rejects_empty () =
+  match BAM.Id.of_string "" with
+  | Ok _ -> fail "empty id accepted"
+  | Error _ -> ()
+
+(* --- Kind round-trip --- *)
+
+let test_kind_round_trip () =
+  let all = [BAM.Image; BAM.Video; BAM.Youtube; BAM.External_link] in
+  List.iter (fun k ->
+    let s = BAM.kind_to_string k in
+    match BAM.kind_of_string s with
+    | Ok k' when k = k' -> ()
+    | Ok _ -> failf "kind drift: %s" s
+    | Error _ -> failf "rejected own output: %s" s
+  ) all
+
+let test_kind_unknown () =
+  match BAM.kind_of_string "audio" with
+  | Ok _ -> fail "unknown kind accepted"
+  | Error _ -> ()
+
+(* --- to_yojson / of_yojson round-trip --- *)
+
+let test_yojson_round_trip_image () =
+  let a = sample_attachment () in
+  let json = BAM.to_yojson a in
+  match BAM.of_yojson json with
+  | Ok a' -> check attachment_testable "round-trip image" a a'
+  | Error e -> failf "round-trip failed: %s" (BAM.error_to_string e)
+
+let test_yojson_round_trip_each_kind () =
+  List.iter (fun kind ->
+    let a = sample_attachment ~kind () in
+    let json = BAM.to_yojson a in
+    match BAM.of_yojson json with
+    | Ok a' -> check attachment_testable
+                 (Printf.sprintf "round-trip %s" (BAM.kind_to_string kind)) a a'
+    | Error e -> failf "round-trip %s failed: %s"
+                   (BAM.kind_to_string kind) (BAM.error_to_string e)
+  ) [BAM.Image; BAM.Video; BAM.Youtube; BAM.External_link]
+
+let test_yojson_optional_dimensions_absent () =
+  let a = sample_attachment ~width:None ~height:None () in
+  let json = BAM.to_yojson a in
+  match BAM.of_yojson json with
+  | Ok a' ->
+    check (option int) "width None" None a'.width;
+    check (option int) "height None" None a'.height
+  | Error e -> failf "round-trip None dims: %s" (BAM.error_to_string e)
+
+let test_yojson_rejects_unknown_shape () =
+  let bogus : Yojson.Safe.t = `Int 42 in
+  match BAM.of_yojson bogus with
+  | Ok _ -> fail "non-object accepted"
+  | Error _ -> ()
+
+let test_yojson_rejects_missing_field () =
+  let json : Yojson.Safe.t = `Assoc [("id", `String "a-x")] in
+  match BAM.of_yojson json with
+  | Ok _ -> fail "missing-field accepted"
+  | Error _ -> ()
+
+let test_yojson_rejects_invalid_id () =
+  let a = sample_attachment () in
+  let json = BAM.to_yojson a in
+  let json' = match json with
+    | `Assoc kvs ->
+      `Assoc (List.map (fun (k, v) ->
+        if k = "id" then (k, `String "../oops") else (k, v)
+      ) kvs)
+    | _ -> json
+  in
+  match BAM.of_yojson json' with
+  | Ok _ -> fail "invalid id accepted"
+  | Error _ -> ()
+
+let test_yojson_rejects_invalid_kind () =
+  let a = sample_attachment () in
+  let json = BAM.to_yojson a in
+  let json' = match json with
+    | `Assoc kvs ->
+      `Assoc (List.map (fun (k, v) ->
+        if k = "kind" then (k, `String "audio") else (k, v)
+      ) kvs)
+    | _ -> json
+  in
+  match BAM.of_yojson json' with
+  | Ok _ -> fail "invalid kind accepted"
+  | Error _ -> ()
+
+(* --- meta_json embedding --- *)
+
+let test_meta_attach_from_none () =
+  let a = sample_attachment () in
+  let meta = BAM.attach_to_post_meta ~existing:None [a] in
+  match meta with
+  | `Assoc kvs ->
+    check int "single key" 1 (List.length kvs);
+    check string "key name" BAM.meta_json_key (fst (List.hd kvs))
+  | _ -> fail "attach returned non-object"
+
+let test_meta_preserves_other_keys () =
+  let existing : Yojson.Safe.t = `Assoc [
+    ("foo", `String "bar");
+    ("count", `Int 7);
+  ] in
+  let a = sample_attachment () in
+  let meta = BAM.attach_to_post_meta ~existing:(Some existing) [a] in
+  match meta with
+  | `Assoc kvs ->
+    let has key = List.mem_assoc key kvs in
+    check bool "foo preserved" true (has "foo");
+    check bool "count preserved" true (has "count");
+    check bool "attachments added" true (has BAM.meta_json_key)
+  | _ -> fail "attach returned non-object"
+
+let test_meta_overwrites_attachments_slot () =
+  let existing : Yojson.Safe.t = `Assoc [
+    (BAM.meta_json_key, `List [`String "old garbage"]);
+    ("other", `String "kept");
+  ] in
+  let a = sample_attachment () in
+  let meta = BAM.attach_to_post_meta ~existing:(Some existing) [a] in
+  let parsed = BAM.attachments_of_post_meta (Some meta) in
+  check int "slot replaced, not appended" 1 (List.length parsed);
+  match meta with
+  | `Assoc kvs ->
+    check bool "other key preserved" true (List.mem_assoc "other" kvs)
+  | _ -> fail "attach returned non-object"
+
+let test_meta_round_trip_multiple () =
+  let attachments = [
+    sample_attachment ~kind:BAM.Image ~name:"a.png" ();
+    sample_attachment ~kind:BAM.Video ~name:"b.mp4" ();
+    sample_attachment ~kind:BAM.Youtube ~name:"c.url"
+      ~width:None ~height:None ();
+  ] in
+  let meta = BAM.attach_to_post_meta ~existing:None attachments in
+  let parsed = BAM.attachments_of_post_meta (Some meta) in
+  check int "count preserved" (List.length attachments) (List.length parsed);
+  List.iter2 (fun original recovered ->
+    check attachment_testable "round-trip preserves attachment"
+      original recovered
+  ) attachments parsed
+
+let test_meta_total_on_none () =
+  check int "None => []" 0 (List.length (BAM.attachments_of_post_meta None))
+
+let test_meta_total_on_non_object () =
+  let bogus : Yojson.Safe.t = `String "not an object" in
+  check int "non-object => []"
+    0 (List.length (BAM.attachments_of_post_meta (Some bogus)))
+
+let test_meta_total_on_missing_key () =
+  let no_attachments : Yojson.Safe.t = `Assoc [("foo", `String "bar")] in
+  check int "missing key => []"
+    0 (List.length (BAM.attachments_of_post_meta (Some no_attachments)))
+
+let test_meta_drops_invalid_items () =
+  let valid = sample_attachment () in
+  let meta : Yojson.Safe.t = `Assoc [
+    (BAM.meta_json_key, `List [
+      BAM.to_yojson valid;
+      `String "garbage";
+      `Assoc [("id", `String "a-x")];  (* missing fields *)
+    ]);
+  ] in
+  let parsed = BAM.attachments_of_post_meta (Some meta) in
+  check int "invalid items dropped, valid kept" 1 (List.length parsed)
+
+(* --- registration --- *)
+
+let () =
+  run "Board_attachment_meta" [
+    "id discipline", [
+      test_case "generate has 'a-' prefix" `Quick test_id_generate_prefix;
+      test_case "valid id accepted" `Quick test_id_of_string_valid;
+      test_case "rejects path traversal" `Quick
+        test_id_of_string_rejects_path_traversal;
+      test_case "rejects slash" `Quick test_id_of_string_rejects_slash;
+      test_case "rejects > 64 chars" `Quick
+        test_id_of_string_rejects_too_long;
+      test_case "rejects empty" `Quick test_id_of_string_rejects_empty;
+    ];
+    "kind", [
+      test_case "round-trip all kinds" `Quick test_kind_round_trip;
+      test_case "rejects unknown kind" `Quick test_kind_unknown;
+    ];
+    "yojson", [
+      test_case "round-trip image" `Quick test_yojson_round_trip_image;
+      test_case "round-trip every kind" `Quick test_yojson_round_trip_each_kind;
+      test_case "optional width/height absent" `Quick
+        test_yojson_optional_dimensions_absent;
+      test_case "rejects unknown JSON shape" `Quick
+        test_yojson_rejects_unknown_shape;
+      test_case "rejects missing field" `Quick
+        test_yojson_rejects_missing_field;
+      test_case "rejects invalid id payload" `Quick
+        test_yojson_rejects_invalid_id;
+      test_case "rejects invalid kind payload" `Quick
+        test_yojson_rejects_invalid_kind;
+    ];
+    "meta_json embedding", [
+      test_case "attach from None existing" `Quick test_meta_attach_from_none;
+      test_case "preserves other keys" `Quick test_meta_preserves_other_keys;
+      test_case "overwrites attachments slot" `Quick
+        test_meta_overwrites_attachments_slot;
+      test_case "round-trip multiple" `Quick test_meta_round_trip_multiple;
+      test_case "total on None" `Quick test_meta_total_on_none;
+      test_case "total on non-object" `Quick test_meta_total_on_non_object;
+      test_case "total on missing key" `Quick test_meta_total_on_missing_key;
+      test_case "drops invalid items" `Quick test_meta_drops_invalid_items;
+    ];
+  ]

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -2150,6 +2150,45 @@ let test_dashboard_bootstrap_contracts () =
     (file_not_contains_pattern "lib/server/server_dashboard_http.ml"
        "(\"error\", `String (Printexc.to_string exn))")
 
+(* RFC-0037 PR-1 — Board_attachment_meta carrier on post.meta_json.
+
+   These guards capture the contract that ties the carrier module to the
+   post type:
+   - the carrier module + .mli exist with the agreed surface
+   - Board_types.post still carries meta_json (the carrier's storage slot)
+   - the JSON key SSOT is "attachments"
+   - of_yojson returns a result type (total, no silent raises)
+   - id generator uses the "a-" prefix (RFC §6 Q2 default)
+
+   If any of these breaks, the carrier mechanism's load-bearing assumption
+   is gone and the next reader will silently get [] instead of a parse
+   error.  See loop iter 5 / 6 for the rationale. *)
+let test_board_attachment_meta_contracts () =
+  check bool "carrier mli exists with attach helper" true
+    (file_contains_pattern "lib/board_attachment_meta.mli"
+       "val attach_to_post_meta");
+  check bool "carrier mli exposes parse total" true
+    (file_contains_pattern "lib/board_attachment_meta.mli"
+       "val of_yojson : Yojson.Safe.t -> (t, error) result");
+  check bool "carrier mli exposes meta_json_key SSOT" true
+    (file_contains_pattern "lib/board_attachment_meta.mli"
+       "val meta_json_key : string");
+  check bool "carrier ml binds meta_json_key to \"attachments\"" true
+    (file_contains_pattern "lib/board_attachment_meta.ml"
+       "let meta_json_key = \"attachments\"");
+  check bool "carrier ml uses 'a-' id prefix (RFC-0037 Q2 default)" true
+    (file_contains_pattern "lib/board_attachment_meta.ml"
+       "Random_id.prefixed ~prefix:\"a-\"");
+  check bool "carrier kind union has all 4 variants" true
+    (file_contains_pattern "lib/board_attachment_meta.mli"
+       "| Image\n  | Video\n  | Youtube\n  | External_link");
+  check bool "Board_types.post still has meta_json carrier slot" true
+    (file_contains_pattern "lib/board_types/board_types.mli"
+       "meta_json : Yojson.Safe.t option");
+  check bool "carrier test registered in test/dune" true
+    (file_contains_pattern "test/dune"
+       "test_board_attachment_meta")
+
 let () =
   run "ci_hardening_source"
     [
@@ -2248,5 +2287,7 @@ let () =
              test_copilot_zero_diff_cleanup_contracts;
            test_case "dashboard bootstrap contracts (loop #7)" `Quick
              test_dashboard_bootstrap_contracts;
+           test_case "board attachment meta contracts (RFC-0037 PR-1)" `Quick
+             test_board_attachment_meta_contracts;
          ]);
     ]


### PR DESCRIPTION
## 요약

[RFC-0037](https://github.com/jeong-sik/masc-mcp/pull/13887) (\`board multimedia & vision — eio/file-based adaptation\`) PR-1.

\`Board_attachment_meta\` 순수-data 모듈을 추가합니다. 이미지/비디오/유튜브/외부링크 첨부 메타를 기존 \`Board_types.post.meta_json : Yojson.Safe.t option\` 필드 위에 직렬화 — **post struct 변경 없음**.

| 변경량 |
|---|
| \`lib/board_attachment_meta.ml\` (+173 LOC) |
| \`lib/board_attachment_meta.mli\` (+108 LOC) |
| \`test/test_board_attachment_meta.ml\` (+292 LOC, **23 cases / 4 groups**) |
| \`test/dune\` (+2 lines, 2 곳 등록) |
| **Total**: +575 / -0, 4 files |

## RFC-0037 §6 open questions — 이 PR이 commit 한 default

| Q | RFC 제안 | 이 PR default | 변경 비용 |
|---|---|---|---|
| Q1 module placement | top-level vs sub-module | **top-level** \`lib/board_attachment_meta.ml\` | \`git mv\` + dune 수정 (~5 lines, 0 caller 영향) |
| Q2 id prefix | \`a-\` vs \`att-\` | **\`a-\`** (post \`p-\`/comment \`c-\` 일관) | 단일 상수 변경 (~1 line) |
| Q3 Phase B 모델 | — | N/A (Phase B PR) | — |
| Q4 frontend 통합 | — | N/A (Phase C PR) | — |

사용자가 Q1/Q2 를 다르게 결정하면 follow-up commit 으로 빠르게 조정 가능합니다 (현재는 0 caller 라 깨질 곳 없음).

## 설계 properties

- **Id** opaque + parsed (\`Board_types.Post_id\` 패턴 정확히 미러링)
- **of_yojson total**: unknown JSON shape → \`Error\`, 절대 throw 안 함
- **attach_to_post_meta**: 기존 \`meta_json\` 의 \"attachments\" 외 모든 키 보존 → 미래 \`meta_json\` 사용자와 공존 가능
- **No I/O / Eio / network** — 순수 데이터, trivial 테스트
- 명시적 JSON 인코딩 (ppx_deriving_yojson 의존성 없음 → 디버깅 단순)

## 검증

- \`dune build @check --root=.\` → exit 0
- \`dune exec test/test_board_attachment_meta.exe\` → **23 / 23 pass** in 2ms
- 4 group: id discipline (6) / kind (2) / yojson (7) / meta_json embedding (8)

## Migration impact

**Zero** on \`Board_types.post\` struct. 기존 serializer 는 \`meta_json\` 을 그대로 통과시킵니다. attachment 를 모르는 readers 는 unknown JSON key 로 취급 — 현재 동작 그대로.

## Phase 외 NOT in this PR

- 파일 스토어 (Phase A1, 별도 PR)
- Vision API 통합 (Phase B, RFC-0037 §4.3)
- 프론트엔드 렌더링 (Phase C)
- PostgreSQL / MinIO / S3 / Redis (RFC §2 N1-N6, 영구 out-of-scope)

## Best Programmer self-review

- 목표: RFC-0037 PR-1 구현 — meta_json 위 attachment carrier
- 변경 파일: 4 (1 module + 1 mli + 1 test + 1 test/dune 라인)
- 로컬 검증: \`dune build @check\` 0, 테스트 23/23 pass
- 미검증: 통합 시나리오 — 실제 post 에 attachment 직렬화 → 디스크 → 재로드. Phase A1 의 file-based store PR 가 그 검증을 담당
- 아키텍처: \`agent_delegation\` 룰의 RFC 인용 충족 (RFC-0037 \[#13887\] 참조). \`pr-rfc-check.sh\` 통과 가능

## Related

- RFC-0037: #13887 (이 PR 의 motivation + acceptance criteria)
- Plan audit artefacts (user-local): \`~/me/planning/media-vision-loop/iter1-3.md\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)