### PR TITLE
Block keeper GitHub PR bypasses and identity conflicts

### DIFF
--- a/lib/keeper/host_config_provider.ml
+++ b/lib/keeper/host_config_provider.ml
@@ -357,6 +357,51 @@ let bind_from_credential ~keeper_name (cred : Repo_manager_types.credential) =
               | None -> []
               | Some path -> [ ("ssh_key_path", path) ]))
 
+let gh_config_dir_matches_identity ~expected gh_config_dir =
+  String.equal (Filename.basename gh_config_dir) "gh"
+  && String.equal (Filename.basename (Filename.dirname gh_config_dir)) expected
+
+let credential_matches_explicit_github_identity ~expected
+    (cred : Repo_manager_types.credential) =
+  let expected = String.trim expected in
+  expected <> ""
+  && (String.equal cred.id expected
+      || String.equal cred.username expected
+      ||
+      match cred.gh_config_dir with
+      | Some gh_config_dir ->
+          gh_config_dir_matches_identity ~expected (String.trim gh_config_dir)
+      | None -> false)
+
+let explicit_github_identity_conflict ~keeper_name
+    (cred : Repo_manager_types.credential) =
+  let defaults = Keeper_types_profile.load_keeper_profile_defaults keeper_name in
+  match defaults.github_identity, defaults.git_identity_mode with
+  | Some expected, Some "github_identity"
+    when not (credential_matches_explicit_github_identity ~expected cred) ->
+      Some expected
+  | _ -> None
+
+let bind_from_credential_checked ~keeper_name cred =
+  match explicit_github_identity_conflict ~keeper_name cred with
+  | Some expected ->
+      let gh_config_dir =
+        Option.value ~default:"<none>" cred.Repo_manager_types.gh_config_dir
+      in
+      Error
+        (Credential_provider.Missing_bundle
+           { identity = keeper_name
+           ; path =
+               Printf.sprintf
+                 "keeper %s declares github_identity %s but credential \
+                  mapping selected credential_id=%s username=%s \
+                  gh_config_dir=%s. Update keeper_repo_mappings.toml to \
+                  select the declared identity bundle or remove the \
+                  conflicting mapping."
+                 keeper_name expected cred.id cred.username gh_config_dir
+           })
+  | None -> bind_from_credential ~keeper_name cred
+
 let resolve ~config ~identity:keeper_name =
   match
     Keeper_repo_mapping.credentials_for_keeper
@@ -381,7 +426,7 @@ let resolve ~config ~identity:keeper_name =
   | Ok [cred] ->
       count_resolve_outcome ~keeper_name ~source:"credential_store"
         ~reason:"single_mapping";
-      bind_from_credential ~keeper_name cred
+      bind_from_credential_checked ~keeper_name cred
   | Ok many ->
       count_resolve_outcome ~keeper_name ~source:"ambiguous"
         ~reason:"multi_mapping";

--- a/lib/keeper/keeper_gh_shared.ml
+++ b/lib/keeper/keeper_gh_shared.ml
@@ -442,6 +442,27 @@ let gh_mutates_entity (cmd : string) : entity_kind option =
     Some Issue
   | _ -> None
 
+let dedicated_pr_tool_required (cmd : string) :
+    (string * string * string) option =
+  let parts =
+    cmd
+    |> normalize_gh_command
+    |> gh_words
+    |> skip_gh_leading_global_options
+  in
+  match parts with
+  | "pr" :: "create" :: _ ->
+    Some
+      ( "gh_pr_create_requires_keeper_pr_create"
+      , "keeper_pr_create"
+      , "Use keeper_pr_create with draft=true so governance approval and PR lifecycle markers are enforced." )
+  | "pr" :: "review" :: _ ->
+    Some
+      ( "gh_pr_review_requires_keeper_pr_review_comment"
+      , "keeper_pr_review_comment"
+      , "Use keeper_pr_review_comment for PR review COMMENT/APPROVE/REQUEST_CHANGES mutations." )
+  | _ -> None
+
 (** Deterministic blocklist for obviously destructive or credential-sensitive
     gh commands. Unlike prefix matching on the raw string, this ignores
     leading global options before inspecting the command group/action pair. *)

--- a/lib/keeper/keeper_gh_shared.mli
+++ b/lib/keeper/keeper_gh_shared.mli
@@ -109,6 +109,12 @@ val extract_gh_target_number :
 val gh_mutates_entity :
   string -> entity_kind option
 
+(** Return [Some (error, required_tool, hint)] when a [keeper_shell op=gh]
+    command targets PR mutations that must go through dedicated keeper PR
+    tools rather than raw gh. *)
+val dedicated_pr_tool_required :
+  string -> (string * string * string) option
+
 (** Deterministic safety classifier for destructive or credential-sensitive
     gh CLI commands. Ignores leading global flags like [--repo owner/name]
     before matching the command shape. Returns the canonical blocked pattern

--- a/lib/keeper/keeper_shell_ops.ml
+++ b/lib/keeper/keeper_shell_ops.ml
@@ -1156,6 +1156,22 @@ let handle_keeper_shell
                  ; "reversibility", `String rev_tag
                  ] @ route_fields @ extras))
         in
+        let dedicated_pr_tool_block ~error ~required_tool ~hint =
+          Prometheus.inc_counter
+            Prometheus.metric_keeper_shell_ops_failures
+            ~labels:[("keeper", meta.name)]
+            ();
+          Log.Keeper.warn
+            "keeper_shell op=gh dedicated PR tool required: keeper=%s cmd=%s tool=%s"
+            meta.name canonical_cmd_str required_tool;
+          gh_base ~ok:false ~cwd:"" ~command:(gh_cmd_display parsed_cmd)
+            [ "error", `String error
+            ; "reason", `String
+                "keeper_shell op=gh cannot bypass the dedicated PR workflow tools"
+            ; "required_tool", `String required_tool
+            ; "hint", `String hint
+            ]
+        in
         let run_gh_command ~display_command ~parsed_command ~cwd
             ~(ctx : Keeper_shell_gh_context.gh_repo_context option) =
           if reversibility = Worker_dev_tools.R1_Reversible then
@@ -1238,6 +1254,10 @@ let handle_keeper_shell
               in
               gh_base ~command:display_command ~ok ~cwd hinted_fields
         in
+        (match Keeper_gh_shared.dedicated_pr_tool_required canonical_cmd_str with
+         | Some (error, required_tool, hint) ->
+           dedicated_pr_tool_block ~error ~required_tool ~hint
+         | None ->
         (match reversibility with
          | Worker_dev_tools.R2_Irreversible ->
            let hint =
@@ -1341,7 +1361,7 @@ let handle_keeper_shell
                              ~parsed_command:cmd_to_run
                              ~cwd:ctx.worktree_cwd
                              ~ctx:(Some ctx)))
-           end))
+           end)))
   | _ ->
     Yojson.Safe.to_string
       (`Assoc

--- a/test/test_credential_provider.ml
+++ b/test/test_credential_provider.ml
@@ -72,6 +72,31 @@ let write_mapping base_path keeper_id repo_ids =
     ~finally:(fun () -> close_out_noerr oc)
     (fun () -> output_string oc content)
 
+let with_config_dir_env config_dir f =
+  let key = "MASC_CONFIG_DIR" in
+  let old = Sys.getenv_opt key in
+  Unix.putenv key config_dir;
+  Masc_mcp.Config_dir_resolver.reset ();
+  Fun.protect
+    ~finally:(fun () ->
+      (match old with
+       | Some value -> Unix.putenv key value
+       | None -> Unix.putenv key "");
+      Masc_mcp.Config_dir_resolver.reset ())
+    f
+
+let write_keeper_identity_toml ~base_path ~keeper_name ~github_identity =
+  let keepers_dir = Filename.concat base_path ".masc/config/keepers" in
+  mkdir_p keepers_dir;
+  let path = Filename.concat keepers_dir (keeper_name ^ ".toml") in
+  let oc = open_out path in
+  Fun.protect
+    ~finally:(fun () -> close_out_noerr oc)
+    (fun () ->
+      Printf.fprintf oc
+        "[keeper]\nname = %S\ngithub_identity = %S\ngit_identity_mode = \"github_identity\"\n"
+        keeper_name github_identity)
+
 let seed_credential ~base_path cred =
   match Credential_store.add ~base_path cred with
   | Ok _ -> ()
@@ -364,6 +389,52 @@ let test_resolve_credential_store_mounts_explicit_ssh_key () =
                       "/tmp/keeper-creds/.ssh/id_credential")
                binding.ro_mounts))
 
+let test_credential_store_mapping_conflicting_github_identity_fails_closed
+    () =
+  with_temp_base_path (fun base_path ->
+      let config = Masc_mcp.Coord.default_config base_path in
+      let config_dir = Filename.concat base_path ".masc/config" in
+      let keeper_name = "keeper-conflict" in
+      let declared_identity = "declared-reviewer" in
+      write_keeper_identity_toml ~base_path ~keeper_name
+        ~github_identity:declared_identity;
+      with_config_dir_env config_dir (fun () ->
+          let gh_config_dir =
+            Filename.concat base_path ".masc/github-identities/other/gh"
+          in
+          seed_credential ~base_path
+            (make_credential ~id:"other-credential" ~username:"other-user"
+               ~gh_config_dir ());
+          seed_repo ~base_path
+            (make_repo ~id:"repo-conflict"
+               ~credential_id:"other-credential");
+          write_mapping base_path keeper_name [ "repo-conflict" ];
+          match HCP.resolve ~config ~identity:keeper_name with
+          | Error (CP.Missing_bundle { identity; path }) ->
+              check string "identity" keeper_name identity;
+              check bool "mentions declared identity" true
+                (try
+                   ignore
+                     (Str.search_forward
+                        (Str.regexp_string declared_identity)
+                        path 0);
+                   true
+                 with Not_found -> false);
+              check bool "mentions mapped credential" true
+                (try
+                   ignore
+                     (Str.search_forward
+                        (Str.regexp_string "other-credential")
+                        path 0);
+                   true
+                 with Not_found -> false)
+          | Ok _ ->
+              fail
+                "conflicting credential-store mapping should fail closed \
+                 before materializing Docker credentials"
+          | Error other ->
+              failf "expected Missing_bundle, got %s" (CP.pp_error other)))
+
 (* --- 4. finalize / tear_down noop semantics --- *)
 
 let dummy_binding () : CP.binding =
@@ -562,6 +633,8 @@ let () =
         [
           test_case "explicit ssh key is mounted" `Quick
             test_resolve_credential_store_mounts_explicit_ssh_key;
+          test_case "conflicting keeper github_identity fails closed" `Quick
+            test_credential_store_mapping_conflicting_github_identity_fails_closed;
         ] );
       ( "lifecycle (PR-1 noop)",
         [

--- a/test/test_keeper_shell_docker_route.ml
+++ b/test/test_keeper_shell_docker_route.ml
@@ -774,6 +774,52 @@ let test_hard_mode_blocks_raw_gh_bash () =
   Alcotest.(check bool) "hint mentions structured op=gh" true
     (response_mentions raw "hint" "keeper_shell op=gh")
 
+let test_keeper_shell_gh_pr_create_requires_dedicated_tool () =
+  with_tool_policy_config @@ fun () ->
+  setup ~sandbox:Keeper_types.Docker
+  @@ fun ~config ~meta ~playground ->
+  let raw =
+    Keeper_exec_shell.handle_keeper_shell
+      ~turn_sandbox_factory:None ~exec_cache:None ~config ~meta
+      ~args:
+        (`Assoc
+           [ ("op", `String "gh")
+           ; ("cmd", `String "pr create --draft --title proof")
+           ; ("cwd", `String playground)
+           ])
+  in
+  Alcotest.(check (option bool)) "blocked" (Some false)
+    (parse_bool_field raw "ok");
+  Alcotest.(check (option string)) "error"
+    (Some "gh_pr_create_requires_keeper_pr_create")
+    (parse_string_field raw "error");
+  Alcotest.(check (option string)) "required tool"
+    (Some "keeper_pr_create")
+    (parse_string_field raw "required_tool")
+
+let test_keeper_shell_gh_pr_review_requires_dedicated_tool () =
+  with_tool_policy_config @@ fun () ->
+  setup ~sandbox:Keeper_types.Docker
+  @@ fun ~config ~meta ~playground ->
+  let raw =
+    Keeper_exec_shell.handle_keeper_shell
+      ~turn_sandbox_factory:None ~exec_cache:None ~config ~meta
+      ~args:
+        (`Assoc
+           [ ("op", `String "gh")
+           ; ("cmd", `String "pr review 123 --approve --body ok")
+           ; ("cwd", `String playground)
+           ])
+  in
+  Alcotest.(check (option bool)) "blocked" (Some false)
+    (parse_bool_field raw "ok");
+  Alcotest.(check (option string)) "error"
+    (Some "gh_pr_review_requires_keeper_pr_review_comment")
+    (parse_string_field raw "error");
+  Alcotest.(check (option string)) "required tool"
+    (Some "keeper_pr_review_comment")
+    (parse_string_field raw "required_tool")
+
 let docker_run_line log_path =
   read_file log_path
   |> String.split_on_char '\n'
@@ -1175,9 +1221,15 @@ let () =
           Alcotest.test_case
             "docker keeper git push routes through git-creds docker"
             `Quick test_bash_git_push_routes_through_git_creds_docker;
-	          Alcotest.test_case
-	            "hard mode blocks raw gh keeper_bash"
-	            `Quick test_hard_mode_blocks_raw_gh_bash;
+          Alcotest.test_case
+            "hard mode blocks raw gh keeper_bash"
+            `Quick test_hard_mode_blocks_raw_gh_bash;
+          Alcotest.test_case
+            "keeper_shell gh pr create requires keeper_pr_create"
+            `Quick test_keeper_shell_gh_pr_create_requires_dedicated_tool;
+          Alcotest.test_case
+            "keeper_shell gh pr review requires keeper_pr_review_comment"
+            `Quick test_keeper_shell_gh_pr_review_requires_dedicated_tool;
           Alcotest.test_case
             "docker keeper bash executes through fake docker"
             `Quick test_bash_fake_docker_executes;


### PR DESCRIPTION
## Summary

- fail-close `keeper_shell op=gh` for raw `gh pr create` and `gh pr review`
- require the dedicated `keeper_pr_create` / `keeper_pr_review_comment` tools for keeper PR lifecycle mutations
- fail-close credential-store mappings when a keeper declares `git_identity_mode = "github_identity"` but the selected credential does not match that declared identity

## Why

The Docker PR lifecycle reprobe showed that a keeper could still create a PR through raw `keeper_shell op=gh` instead of the dedicated keeper PR tool. That makes the proof weak because the lifecycle bypasses the typed PR path that should enforce keeper identity and review constraints.

The same reprobe also depended on `keeper_repo_mappings.toml` selecting the correct GitHub identity bundle. If a mapping points at a conflicting credential, the resolver must stop before materializing Docker credentials, not silently run with the wrong GitHub actor.

## Operator Impact

Keepers can still run safe shell/git commands, but raw GitHub PR lifecycle mutations now return structured errors that point to the required typed keeper tools. Credential mapping mistakes now fail before Docker credential projection, with an actionable message that names the declared identity and selected credential.

## Validation

- `scripts/dune-local.sh build test/test_credential_provider.exe`
- `./_build/default/test/test_credential_provider.exe` (21 tests)
- `scripts/dune-local.sh build test/test_keeper_shell_docker_route.exe`
- `./_build/default/test/test_keeper_shell_docker_route.exe` (29 tests)
