### PR TITLE
fix(keeper): verify GitHub account proof pool

### DIFF
--- a/docs/KEEPER-DOCKER-PR-LIFECYCLE-REPROBE.md
+++ b/docs/KEEPER-DOCKER-PR-LIFECYCLE-REPROBE.md
@@ -65,6 +65,12 @@ branches before re-running. An empty file means no collisions; rows look like:
  "remote_head":false,"worktree_branch":false,
  "blocker":"branch_collision_preflight"}
 ```
+By default, mutation preflight also requires every selected keeper account to
+have upstream `WRITE`, `MAINTAIN`, or `ADMIN` permission for the target repo. For
+PUBLIC repositories, `--allow-fork-pr-for-readonly` permits `READ`/`TRIAGE`
+credential lanes to push their proof branch to the keeper account's fork and
+open the draft PR with `head=OWNER:BRANCH`; PR creation still goes through
+`keeper_pr_create`, not raw `gh pr create`.
 After collision evidence is clear, the review phase requires `keeper_pr_review_comment`.
 This avoids the old single-turn shape where one keeper could wait on another
 keeper's missing PR until the Agent.run timeout. The review prompt reserves

--- a/scripts/audit-keeper-fleet-readiness.py
+++ b/scripts/audit-keeper-fleet-readiness.py
@@ -82,6 +82,7 @@ PR_CREATED_NUMBER_RE = re.compile(
     re.IGNORECASE,
 )
 GH_PR_CREATE_RE = re.compile(r"\bgh\s+pr\s+create\b", re.IGNORECASE)
+GH_HOSTS_USER_RE = re.compile(r"^\s*user:\s*['\"]?([^'\"\s#]+)")
 
 
 @dataclass
@@ -93,6 +94,7 @@ class KeeperAudit:
     network_mode: str | None
     tool_preset: str | None
     github_identity: str | None
+    github_account_login: str | None
     git_identity_mode: str | None
     credential_dir: str | None
     credential_dir_exists: bool
@@ -170,6 +172,19 @@ def load_toml(path: Path) -> dict[str, Any]:
     if not isinstance(data, dict):
         raise ValueError(f"{path}: expected TOML object")
     return data
+
+
+def read_github_account_login(gh_config_dir: Path | None) -> str | None:
+    if gh_config_dir is None:
+        return None
+    hosts_path = gh_config_dir / "hosts.yml"
+    if not hosts_path.is_file():
+        return None
+    for line in hosts_path.read_text(encoding="utf-8", errors="replace").splitlines():
+        match = GH_HOSTS_USER_RE.match(line)
+        if match:
+            return match.group(1).strip()
+    return None
 
 
 def merge_dicts(base: dict[str, Any], overlay: dict[str, Any]) -> dict[str, Any]:
@@ -1138,6 +1153,7 @@ def audit_keeper(
 
     credential_dir: Path | None = None
     credential_dir_exists = False
+    github_account_login: str | None = None
     if github_identity:
         credential_dir = (
             base_path / ".masc" / "github-identities" / github_identity / "gh"
@@ -1145,6 +1161,14 @@ def audit_keeper(
         credential_dir_exists = credential_dir.is_dir()
         if not credential_dir_exists:
             failures.append("github_credential_dir_missing")
+        else:
+            github_account_login = read_github_account_login(credential_dir)
+            if (
+                forbidden_github_identities
+                and github_account_login in forbidden_github_identities
+                and github_account_login != github_identity
+            ):
+                failures.append(f"github_account_forbidden_{github_account_login}")
 
     (
         evidence_ts,
@@ -1258,6 +1282,7 @@ def audit_keeper(
         network_mode=network_mode,
         tool_preset=tool_preset,
         github_identity=github_identity,
+        github_account_login=github_account_login,
         git_identity_mode=git_identity_mode,
         credential_dir=str(credential_dir) if credential_dir else None,
         credential_dir_exists=credential_dir_exists,
@@ -1348,6 +1373,11 @@ def build_report(args: argparse.Namespace) -> dict[str, Any]:
     github_identity_counts = Counter(
         keeper.github_identity for keeper in keepers if keeper.github_identity
     )
+    github_account_counts = Counter(
+        keeper.github_account_login
+        for keeper in keepers
+        if keeper.github_account_login
+    )
     requires_docker_approve = (
         args.require_docker_pr_approve_evidence
         or args.require_docker_pr_lifecycle_evidence
@@ -1357,6 +1387,24 @@ def build_report(args: argparse.Namespace) -> dict[str, Any]:
             "docker_pr_approve_identity_pool_insufficient"
             f"_unique_github_identities_{len(github_identity_counts)}"
         )
+    if requires_docker_approve:
+        unresolved_account_identities = sorted(
+            {
+                keeper.github_identity
+                for keeper in keepers
+                if keeper.github_identity and not keeper.github_account_login
+            }
+        )
+        if unresolved_account_identities:
+            fleet_failures.append(
+                "docker_pr_approve_identity_pool_unresolved_github_accounts_"
+                f"{len(unresolved_account_identities)}"
+            )
+        elif len(github_account_counts) < 2:
+            fleet_failures.append(
+                "docker_pr_approve_account_pool_insufficient"
+                f"_unique_accounts_{len(github_account_counts)}"
+            )
     failed_keepers = [keeper for keeper in keepers if keeper.failures]
     ok = not fleet_failures and not failed_keepers
     return {
@@ -1367,6 +1415,7 @@ def build_report(args: argparse.Namespace) -> dict[str, Any]:
         "configured_keepers": len(config_paths),
         "max_silence_hours": args.max_silence_hours,
         "github_identity_counts": dict(sorted(github_identity_counts.items())),
+        "github_account_counts": dict(sorted(github_account_counts.items())),
         "requirements": {
             "require_board_evidence": args.require_board_evidence,
             "require_product_evidence": args.require_product_evidence,
@@ -1420,6 +1469,7 @@ def print_text(report: dict[str, Any]) -> None:
         print(
             "- {name}: {marker} preset={preset} sandbox={sandbox}/{network} "
             "gh={github} recent={recent} age={age} board={board} "
+            "gh_account={github_account} "
             "product={product} design={design} "
             "pr_surface={pr_surface} pr_review={pr_review} "
             "pr_create={pr_create} git_push={git_push} "
@@ -1433,6 +1483,7 @@ def print_text(report: dict[str, Any]) -> None:
                 sandbox=keeper["sandbox_profile"],
                 network=keeper["network_mode"],
                 github=keeper["github_identity"],
+                github_account=keeper["github_account_login"],
                 recent=str(keeper["recent_action"]).lower(),
                 age=age_label,
                 board=str(keeper["board_action"]).lower(),

--- a/scripts/harness/workload/keeper_docker_pr_lifecycle_reprobe.sh
+++ b/scripts/harness/workload/keeper_docker_pr_lifecycle_reprobe.sh
@@ -606,6 +606,9 @@ except Exception:
 identities = identity_payload.get("keepers")
 if not isinstance(identities, dict):
     identities = {}
+accounts = identity_payload.get("keeper_accounts")
+if not isinstance(accounts, dict):
+    accounts = {}
 
 
 def fallback_target(index):
@@ -617,20 +620,32 @@ def fallback_target(index):
 with review_targets_file.open("w", encoding="utf-8") as handle:
     for index, keeper in enumerate(keepers):
         keeper_identity = identities.get(keeper)
+        keeper_account = accounts.get(keeper)
         review_target = None
         mode = "insufficient_targets"
 
-        if len(keepers) >= 2 and isinstance(keeper_identity, str):
+        if len(keepers) >= 2 and isinstance(keeper_account, str):
+            for candidate in keepers:
+                if candidate == keeper:
+                    continue
+                candidate_account = accounts.get(candidate)
+                if isinstance(candidate_account, str) and candidate_account != keeper_account:
+                    review_target = candidate
+                    mode = "account_aware"
+                    break
+            if review_target is None:
+                mode = "account_pool_insufficient"
+        elif len(keepers) >= 2 and isinstance(keeper_identity, str):
             for candidate in keepers:
                 if candidate == keeper:
                     continue
                 candidate_identity = identities.get(candidate)
                 if isinstance(candidate_identity, str) and candidate_identity != keeper_identity:
                     review_target = candidate
-                    mode = "identity_aware"
+                    mode = "identity_name_aware_unresolved_account"
                     break
             if review_target is None:
-                mode = "identity_pool_insufficient"
+                mode = "identity_name_pool_insufficient"
         elif len(keepers) >= 2:
             review_target = fallback_target(index)
             mode = "ring_unverified_identity"
@@ -638,8 +653,10 @@ with review_targets_file.open("w", encoding="utf-8") as handle:
         row = {
             "keeper": keeper,
             "keeper_identity": keeper_identity,
+            "keeper_account_login": keeper_account,
             "review_target": review_target,
             "review_target_identity": identities.get(review_target) if review_target else None,
+            "review_target_account_login": accounts.get(review_target) if review_target else None,
             "mode": mode,
         }
         handle.write(json.dumps(row, sort_keys=True, separators=(",", ":")) + "\n")
@@ -712,9 +729,28 @@ def string_field(data, key):
     return value if isinstance(value, str) and value else None
 
 
+def read_account_login(identity):
+    hosts_path = base_path / ".masc" / "github-identities" / identity / "gh" / "hosts.yml"
+    if not hosts_path.is_file():
+        return None
+    try:
+        lines = hosts_path.read_text(encoding="utf-8", errors="replace").splitlines()
+    except Exception:
+        return None
+    for line in lines:
+        stripped = line.strip()
+        if not stripped.startswith("user:"):
+            continue
+        value = stripped.split(":", 1)[1].split("#", 1)[0].strip().strip("'\"")
+        return value or None
+    return None
+
+
 keepers = [line.strip() for line in keepers_file.read_text().splitlines() if line.strip()]
 identities = {}
+accounts = {}
 missing = []
+unresolved_accounts = []
 forbidden_keepers = []
 for keeper in keepers:
     config = load_keeper_config(config_dir / f"{keeper}.toml")
@@ -732,21 +768,46 @@ for keeper in keepers:
     )
     if identity:
         identities[keeper] = identity
+        account_login = read_account_login(identity)
+        if account_login:
+            accounts[keeper] = account_login
+        else:
+            unresolved_accounts.append({"keeper": keeper, "github_identity": identity})
         if identity in forbidden:
-            forbidden_keepers.append({"keeper": keeper, "github_identity": identity})
+            forbidden_keepers.append(
+                {
+                    "keeper": keeper,
+                    "github_identity": identity,
+                    "matched": "github_identity",
+                }
+            )
+        if account_login and account_login in forbidden and account_login != identity:
+            forbidden_keepers.append(
+                {
+                    "keeper": keeper,
+                    "github_identity": identity,
+                    "github_account_login": account_login,
+                    "matched": "github_account_login",
+                }
+            )
     else:
         missing.append(keeper)
 
 counts = Counter(identities.values())
+account_counts = Counter(accounts.values())
 out_file.write_text(
     json.dumps(
         {
             "base_path": str(base_path),
             "keeper_count": len(keepers),
             "unique_count": len(counts),
+            "account_unique_count": len(account_counts),
             "counts": dict(sorted(counts.items())),
+            "account_counts": dict(sorted(account_counts.items())),
             "keepers": identities,
+            "keeper_accounts": accounts,
             "missing": missing,
+            "unresolved_accounts": unresolved_accounts,
             "forbidden_identities": sorted(forbidden),
             "forbidden_keepers": forbidden_keepers,
         },
@@ -762,9 +823,23 @@ assert_github_identity_pool_for_mutate() {
   build_github_identity_counts
   local unique_count
   unique_count="$(jq -r '.unique_count // 0' "$GITHUB_IDENTITY_COUNTS_FILE")"
+  local unresolved_accounts_count
+  unresolved_accounts_count="$(jq -r '(.unresolved_accounts // []) | length' "$GITHUB_IDENTITY_COUNTS_FILE")"
   if [[ "$MUTATE" == "1" && "$unique_count" -lt 2 ]]; then
     echo "at least two unique github_identity values are required for cross-keeper approval proof" >&2
     jq -c '{unique_count, counts, missing}' "$GITHUB_IDENTITY_COUNTS_FILE" >&2 || true
+    exit 1
+  fi
+  if [[ "$MUTATE" == "1" && "$unresolved_accounts_count" -gt 0 ]]; then
+    echo "target keeper set has unresolved GitHub account logins" >&2
+    jq -c '{unresolved_accounts}' "$GITHUB_IDENTITY_COUNTS_FILE" >&2 || true
+    exit 1
+  fi
+  local account_unique_count
+  account_unique_count="$(jq -r '.account_unique_count // 0' "$GITHUB_IDENTITY_COUNTS_FILE")"
+  if [[ "$MUTATE" == "1" && "$account_unique_count" -lt 2 ]]; then
+    echo "at least two unique authenticated GitHub accounts are required for cross-keeper approval proof" >&2
+    jq -c '{account_unique_count, account_counts, keeper_accounts}' "$GITHUB_IDENTITY_COUNTS_FILE" >&2 || true
     exit 1
   fi
   if [[ "$MUTATE" == "1" ]] \

--- a/scripts/harness/workload/keeper_docker_pr_lifecycle_reprobe.sh
+++ b/scripts/harness/workload/keeper_docker_pr_lifecycle_reprobe.sh
@@ -671,9 +671,11 @@ PY
 }
 
 build_github_identity_counts() {
-  python3 - "$BASE_PATH" "$RUN_DIR/keepers.txt" "$GITHUB_IDENTITY_COUNTS_FILE" "$FORBID_GITHUB_IDENTITIES" <<'PY'
+  python3 - "$BASE_PATH" "$RUN_DIR/keepers.txt" "$GITHUB_IDENTITY_COUNTS_FILE" "$FORBID_GITHUB_IDENTITIES" "$REPO_SLUG" <<'PY'
 import json
+import os
 import pathlib
+import subprocess
 import sys
 from collections import Counter
 
@@ -691,6 +693,7 @@ forbidden = {
     for item in sys.argv[4].split(",")
     if item.strip()
 }
+repo_slug = sys.argv[5]
 config_dir = base_path / ".masc" / "config" / "keepers"
 runtime_dir = base_path / ".masc" / "keepers"
 
@@ -746,11 +749,48 @@ def read_account_login(identity):
     return None
 
 
+def read_repo_permission(identity):
+    gh_config_dir = base_path / ".masc" / "github-identities" / identity / "gh"
+    if not gh_config_dir.is_dir():
+        return None, "gh_config_dir_missing"
+    env = os.environ.copy()
+    env["GH_CONFIG_DIR"] = str(gh_config_dir)
+    try:
+        completed = subprocess.run(
+            [
+                "gh",
+                "repo",
+                "view",
+                repo_slug,
+                "--json",
+                "viewerPermission",
+                "--jq",
+                ".viewerPermission",
+            ],
+            check=False,
+            env=env,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            timeout=20,
+        )
+    except Exception as exc:
+        return None, f"repo_permission_probe_exception:{exc}"
+    if completed.returncode != 0:
+        detail = (completed.stderr or completed.stdout).strip().splitlines()
+        preview = detail[0] if detail else f"gh_exit_{completed.returncode}"
+        return None, preview[:200]
+    permission = completed.stdout.strip()
+    return permission or None, None
+
+
 keepers = [line.strip() for line in keepers_file.read_text().splitlines() if line.strip()]
 identities = {}
 accounts = {}
+permissions = {}
 missing = []
 unresolved_accounts = []
+permission_errors = []
 forbidden_keepers = []
 for keeper in keepers:
     config = load_keeper_config(config_dir / f"{keeper}.toml")
@@ -773,6 +813,17 @@ for keeper in keepers:
             accounts[keeper] = account_login
         else:
             unresolved_accounts.append({"keeper": keeper, "github_identity": identity})
+        permission, permission_error = read_repo_permission(identity)
+        if permission:
+            permissions[keeper] = permission
+        else:
+            permission_errors.append(
+                {
+                    "keeper": keeper,
+                    "github_identity": identity,
+                    "error": permission_error or "permission_unresolved",
+                }
+            )
         if identity in forbidden:
             forbidden_keepers.append(
                 {
@@ -795,6 +846,7 @@ for keeper in keepers:
 
 counts = Counter(identities.values())
 account_counts = Counter(accounts.values())
+permission_counts = Counter(permissions.values())
 out_file.write_text(
     json.dumps(
         {
@@ -804,10 +856,13 @@ out_file.write_text(
             "account_unique_count": len(account_counts),
             "counts": dict(sorted(counts.items())),
             "account_counts": dict(sorted(account_counts.items())),
+            "repo_permission_counts": dict(sorted(permission_counts.items())),
             "keepers": identities,
             "keeper_accounts": accounts,
+            "keeper_repo_permissions": permissions,
             "missing": missing,
             "unresolved_accounts": unresolved_accounts,
+            "repo_permission_errors": permission_errors,
             "forbidden_identities": sorted(forbidden),
             "forbidden_keepers": forbidden_keepers,
         },
@@ -840,6 +895,31 @@ assert_github_identity_pool_for_mutate() {
   if [[ "$MUTATE" == "1" && "$account_unique_count" -lt 2 ]]; then
     echo "at least two unique authenticated GitHub accounts are required for cross-keeper approval proof" >&2
     jq -c '{account_unique_count, account_counts, keeper_accounts}' "$GITHUB_IDENTITY_COUNTS_FILE" >&2 || true
+    exit 1
+  fi
+  local repo_permission_error_count
+  repo_permission_error_count="$(jq -r '(.repo_permission_errors // []) | length' "$GITHUB_IDENTITY_COUNTS_FILE")"
+  if [[ "$MUTATE" == "1" && "$repo_permission_error_count" -gt 0 ]]; then
+    echo "target keeper set has unresolved GitHub repository permissions" >&2
+    jq -c '{repo_permission_errors}' "$GITHUB_IDENTITY_COUNTS_FILE" >&2 || true
+    exit 1
+  fi
+  if [[ "$MUTATE" == "1" ]] \
+    && jq -e '
+      (.keeper_repo_permissions // {})
+      | to_entries
+      | map(select(.value as $p | ["ADMIN", "MAINTAIN", "WRITE"] | index($p) | not))
+      | length > 0
+    ' "$GITHUB_IDENTITY_COUNTS_FILE" >/dev/null; then
+    echo "target keeper set includes accounts without upstream write permission" >&2
+    jq -c '{
+      keeper_repo_permissions,
+      non_writable_keepers: (
+        (.keeper_repo_permissions // {})
+        | to_entries
+        | map(select(.value as $p | ["ADMIN", "MAINTAIN", "WRITE"] | index($p) | not))
+      )
+    }' "$GITHUB_IDENTITY_COUNTS_FILE" >&2 || true
     exit 1
   fi
   if [[ "$MUTATE" == "1" ]] \
@@ -976,7 +1056,11 @@ Required create lane:
      the branch/worktree already exists, stop and report blocker="branch_collision".
 3. Make a minimal, non-product proof edit under docs/runtime-proof/keepers/$keeper-$RUN_ID.md with keeper_bash from inside the Docker playground. The file content must include run_id=$RUN_ID and branch=$branch.
 4. Commit and git push exactly branch $branch with keeper_bash. The tool result must show explicit Docker-backed route evidence such as via=docker, route_via=docker, via=brokered, or route_via=brokered.
-5. Create a draft PR for that branch with keeper_pr_create. Do not mark ready, do not merge, do not add human-approved-ready.
+5. Create a draft PR for that branch with keeper_pr_create. The call must include
+   repo="$REPO_SLUG", head="$branch", base="main", draft=true, and cwd set to
+   the returned proof worktree path. Do not leave head/base empty and do not use
+   the base repo path if the proof branch lives in a separate worktree. Do not
+   mark ready, do not merge, do not add human-approved-ready.
 6. Reply with one compact JSON object:
    {
      "run_id": "$RUN_ID",

--- a/scripts/harness/workload/keeper_docker_pr_lifecycle_reprobe.sh
+++ b/scripts/harness/workload/keeper_docker_pr_lifecycle_reprobe.sh
@@ -47,6 +47,7 @@ MCP_TOKEN="${MASC_MCP_TOKEN:-}"
 MCP_CLIENT_NAME="${MCP_CLIENT_NAME:-keeper-docker-pr-lifecycle-reprobe}"
 EXPECTED_SERVER_COMMIT="${EXPECTED_SERVER_COMMIT:-}"
 FORBID_GITHUB_IDENTITIES="${FORBID_GITHUB_IDENTITIES:-}"
+ALLOW_FORK_PR_FOR_READONLY="${ALLOW_FORK_PR_FOR_READONLY:-0}"
 SERVER_HEALTH_URL="${SERVER_HEALTH_URL:-}"
 SERVER_COMMIT_ACTUAL=""
 SERVER_STARTED_AT_ACTUAL=""
@@ -80,6 +81,10 @@ Options:
   --forbid-github-identity NAME
                            Fail --mutate preflight when a target keeper uses
                            this GitHub identity. Repeat or pass comma-separated.
+  --allow-fork-pr-for-readonly
+                           Permit PUBLIC repo READ/TRIAGE credentials to satisfy
+                           create proof by pushing to their own fork and opening
+                           a draft PR with head OWNER:BRANCH.
   --server-health-url URL  Health endpoint for commit verification.
   --board-post-id ID       Post a final board comment to this thread.
   --run-id ID              Stable run id for prompts and artifacts.
@@ -99,6 +104,8 @@ Environment:
   RUN_AUDIT=0              Skip final audit.
   EXPECTED_SERVER_COMMIT   Optional expected /health build.commit prefix.
   FORBID_GITHUB_IDENTITIES Optional CSV of forbidden keeper GitHub identities.
+  ALLOW_FORK_PR_FOR_READONLY=1
+                           Same as --allow-fork-pr-for-readonly.
 EOF
 }
 
@@ -147,6 +154,10 @@ while [[ $# -gt 0 ]]; do
         FORBID_GITHUB_IDENTITIES="$2"
       fi
       shift 2
+      ;;
+    --allow-fork-pr-for-readonly)
+      ALLOW_FORK_PR_FOR_READONLY=1
+      shift
       ;;
     --server-health-url)
       SERVER_HEALTH_URL="$2"
@@ -749,10 +760,10 @@ def read_account_login(identity):
     return None
 
 
-def read_repo_permission(identity):
+def read_repo_info(identity):
     gh_config_dir = base_path / ".masc" / "github-identities" / identity / "gh"
     if not gh_config_dir.is_dir():
-        return None, "gh_config_dir_missing"
+        return None, None, "gh_config_dir_missing"
     env = os.environ.copy()
     env["GH_CONFIG_DIR"] = str(gh_config_dir)
     try:
@@ -763,9 +774,7 @@ def read_repo_permission(identity):
                 "view",
                 repo_slug,
                 "--json",
-                "viewerPermission",
-                "--jq",
-                ".viewerPermission",
+                "viewerPermission,visibility",
             ],
             check=False,
             env=env,
@@ -775,19 +784,27 @@ def read_repo_permission(identity):
             timeout=20,
         )
     except Exception as exc:
-        return None, f"repo_permission_probe_exception:{exc}"
+        return None, None, f"repo_permission_probe_exception:{exc}"
     if completed.returncode != 0:
         detail = (completed.stderr or completed.stdout).strip().splitlines()
         preview = detail[0] if detail else f"gh_exit_{completed.returncode}"
-        return None, preview[:200]
-    permission = completed.stdout.strip()
-    return permission or None, None
+        return None, None, preview[:200]
+    try:
+        payload = json.loads(completed.stdout)
+    except Exception as exc:
+        return None, None, f"repo_permission_probe_json_error:{exc}"
+    permission = payload.get("viewerPermission")
+    visibility = payload.get("visibility")
+    permission = permission if isinstance(permission, str) and permission else None
+    visibility = visibility if isinstance(visibility, str) and visibility else None
+    return permission, visibility, None
 
 
 keepers = [line.strip() for line in keepers_file.read_text().splitlines() if line.strip()]
 identities = {}
 accounts = {}
 permissions = {}
+visibilities = {}
 missing = []
 unresolved_accounts = []
 permission_errors = []
@@ -813,9 +830,11 @@ for keeper in keepers:
             accounts[keeper] = account_login
         else:
             unresolved_accounts.append({"keeper": keeper, "github_identity": identity})
-        permission, permission_error = read_repo_permission(identity)
+        permission, visibility, permission_error = read_repo_info(identity)
         if permission:
             permissions[keeper] = permission
+            if visibility:
+                visibilities[keeper] = visibility
         else:
             permission_errors.append(
                 {
@@ -847,6 +866,7 @@ for keeper in keepers:
 counts = Counter(identities.values())
 account_counts = Counter(accounts.values())
 permission_counts = Counter(permissions.values())
+visibility_counts = Counter(visibilities.values())
 out_file.write_text(
     json.dumps(
         {
@@ -857,9 +877,11 @@ out_file.write_text(
             "counts": dict(sorted(counts.items())),
             "account_counts": dict(sorted(account_counts.items())),
             "repo_permission_counts": dict(sorted(permission_counts.items())),
+            "repo_visibility_counts": dict(sorted(visibility_counts.items())),
             "keepers": identities,
             "keeper_accounts": accounts,
             "keeper_repo_permissions": permissions,
+            "keeper_repo_visibilities": visibilities,
             "missing": missing,
             "unresolved_accounts": unresolved_accounts,
             "repo_permission_errors": permission_errors,
@@ -904,22 +926,48 @@ assert_github_identity_pool_for_mutate() {
     jq -c '{repo_permission_errors}' "$GITHUB_IDENTITY_COUNTS_FILE" >&2 || true
     exit 1
   fi
-  if [[ "$MUTATE" == "1" ]] \
-    && jq -e '
-      (.keeper_repo_permissions // {})
-      | to_entries
-      | map(select(.value as $p | ["ADMIN", "MAINTAIN", "WRITE"] | index($p) | not))
-      | length > 0
-    ' "$GITHUB_IDENTITY_COUNTS_FILE" >/dev/null; then
+  local non_writable_file
+  non_writable_file="$RUN_DIR/non-writable-keepers.json"
+  python3 - "$GITHUB_IDENTITY_COUNTS_FILE" "$ALLOW_FORK_PR_FOR_READONLY" >"$non_writable_file" <<'PY'
+import json
+import pathlib
+import sys
+
+payload = json.loads(pathlib.Path(sys.argv[1]).read_text())
+allow_fork = sys.argv[2] == "1"
+permissions = payload.get("keeper_repo_permissions")
+if not isinstance(permissions, dict):
+    permissions = {}
+visibilities = payload.get("keeper_repo_visibilities")
+if not isinstance(visibilities, dict):
+    visibilities = {}
+
+writable = {"ADMIN", "MAINTAIN", "WRITE"}
+forkable_read = {"READ", "TRIAGE"}
+non_writable = []
+for keeper, permission in sorted(permissions.items()):
+    visibility = visibilities.get(keeper)
+    if permission in writable:
+        continue
+    if allow_fork and permission in forkable_read and visibility == "PUBLIC":
+        continue
+    non_writable.append(
+        {"keeper": keeper, "permission": permission, "visibility": visibility}
+    )
+
+print(json.dumps({"non_writable_keepers": non_writable}, sort_keys=True))
+PY
+  if [[ "$MUTATE" == "1" && -s "$non_writable_file" ]] \
+    && jq -e '(.non_writable_keepers // []) | length > 0' "$non_writable_file" >/dev/null; then
     echo "target keeper set includes accounts without upstream write permission" >&2
-    jq -c '{
+    jq -c --arg allow_fork "$ALLOW_FORK_PR_FOR_READONLY" '{
       keeper_repo_permissions,
+      keeper_repo_visibilities,
       non_writable_keepers: (
-        (.keeper_repo_permissions // {})
-        | to_entries
-        | map(select(.value as $p | ["ADMIN", "MAINTAIN", "WRITE"] | index($p) | not))
-      )
-    }' "$GITHUB_IDENTITY_COUNTS_FILE" >&2 || true
+        input.non_writable_keepers
+      ),
+      allow_fork_pr_for_readonly: $allow_fork
+    }' "$GITHUB_IDENTITY_COUNTS_FILE" "$non_writable_file" >&2 || true
     exit 1
   fi
   if [[ "$MUTATE" == "1" ]] \
@@ -940,6 +988,31 @@ review_target_for_keeper() {
 proof_branch_for_keeper() {
   local keeper="$1"
   printf 'keeper-%s-agent/%s' "$keeper" "$RUN_ID"
+}
+
+github_account_for_keeper() {
+  local keeper="$1"
+  jq -r --arg keeper "$keeper" '.keeper_accounts[$keeper] // empty' "$GITHUB_IDENTITY_COUNTS_FILE"
+}
+
+repo_permission_for_keeper() {
+  local keeper="$1"
+  jq -r --arg keeper "$keeper" '.keeper_repo_permissions[$keeper] // empty' "$GITHUB_IDENTITY_COUNTS_FILE"
+}
+
+repo_visibility_for_keeper() {
+  local keeper="$1"
+  jq -r --arg keeper "$keeper" '.keeper_repo_visibilities[$keeper] // empty' "$GITHUB_IDENTITY_COUNTS_FILE"
+}
+
+keeper_uses_fork_pr_route() {
+  local keeper="$1"
+  local permission visibility
+  permission="$(repo_permission_for_keeper "$keeper")"
+  visibility="$(repo_visibility_for_keeper "$keeper")"
+  [[ "$ALLOW_FORK_PR_FOR_READONLY" == "1" \
+    && "$visibility" == "PUBLIC" \
+    && ( "$permission" == "READ" || "$permission" == "TRIAGE" ) ]]
 }
 
 assert_no_proof_branch_collisions_for_mutate() {
@@ -1027,19 +1100,62 @@ prompt_for_keeper_create() {
   local keeper="$1"
   local branch
   branch="$(proof_branch_for_keeper "$keeper")"
+  local account permission visibility head_ref git_route_rule push_step pr_step
+  account="$(github_account_for_keeper "$keeper")"
+  permission="$(repo_permission_for_keeper "$keeper")"
+  visibility="$(repo_visibility_for_keeper "$keeper")"
+  if keeper_uses_fork_pr_route "$keeper"; then
+    head_ref="$account:$branch"
+    git_route_rule="- You may use keeper_bash for gh repo fork / git remote setup only to prepare your own fork branch for this proof. Do not run gh pr create, gh pr review, or other PR mutations through keeper_shell or keeper_bash."
+    push_step="$(cat <<EOF
+4. Commit and push exactly branch $branch with keeper_bash using the fork PR route because your upstream repo permission is $permission:
+   - Confirm your GitHub account login is $account.
+   - Ensure the fork $account/${REPO_SLUG#*/} exists. If needed, run gh repo fork $REPO_SLUG --remote=false from keeper_bash; if GitHub blocks fork creation, stop and report blocker="fork_create_blocked" with the exact output.
+   - Add or update a remote named keeper-fork pointing at https://github.com/$account/${REPO_SLUG#*/}.git in the returned proof worktree.
+   - Push with git push keeper-fork HEAD:$branch.
+   - The tool result must show explicit Docker-backed route evidence such as via=docker, route_via=docker, via=brokered, or route_via=brokered.
+EOF
+)"
+    pr_step="$(cat <<EOF
+5. Create a draft PR from your fork branch with keeper_pr_create. The call must include
+   repo="$REPO_SLUG", head="$head_ref", base="main", draft=true, and cwd set to
+   the returned proof worktree path. Do not leave head/base empty and do not use
+   the base repo path if the proof branch lives in a separate worktree. Do not
+   mark ready, do not merge, do not add human-approved-ready.
+EOF
+)"
+  else
+    head_ref="$branch"
+    git_route_rule="- Do not run gh pr create, gh pr review, or other mutating GitHub commands through keeper_shell or keeper_bash."
+    push_step="$(cat <<EOF
+4. Commit and git push exactly branch $branch with keeper_bash. The tool result must show explicit Docker-backed route evidence such as via=docker, route_via=docker, via=brokered, or route_via=brokered.
+EOF
+)"
+    pr_step="$(cat <<EOF
+5. Create a draft PR for that branch with keeper_pr_create. The call must include
+   repo="$REPO_SLUG", head="$head_ref", base="main", draft=true, and cwd set to
+   the returned proof worktree path. Do not leave head/base empty and do not use
+   the base repo path if the proof branch lives in a separate worktree. Do not
+   mark ready, do not merge, do not add human-approved-ready.
+EOF
+)"
+  fi
   cat <<EOF
 Docker PR lifecycle proof run: $RUN_ID
 Phase: create
 
 Target repo: $REPO_SLUG
 Keeper: $keeper
+GitHub account: ${account:-unknown}
+Repo permission: ${permission:-unknown}
+Repo visibility: ${visibility:-unknown}
 
 Goal: create a fresh, auditable Docker-backed proof branch and draft PR. Do
 not review or approve another keeper's PR in this phase.
 
 Tool route rules:
 - Use keeper_bash inside your Docker playground for proof-file creation and git add/commit/push on the proof branch.
-- Do not run gh pr create, gh pr review, or other mutating GitHub commands through keeper_shell or keeper_bash.
+$git_route_rule
 - Do not use approval-requiring host code-write paths such as masc_code_write for this proof file.
 - If keeper_bash rejects mutating git as policy-blocked, stop and report the exact blocker instead of switching to host-local credentials.
 - Use keeper_pr_create for PR creation.
@@ -1055,18 +1171,15 @@ Required create lane:
    - Do not remove this run's worktree during the proof attempt. If Git says
      the branch/worktree already exists, stop and report blocker="branch_collision".
 3. Make a minimal, non-product proof edit under docs/runtime-proof/keepers/$keeper-$RUN_ID.md with keeper_bash from inside the Docker playground. The file content must include run_id=$RUN_ID and branch=$branch.
-4. Commit and git push exactly branch $branch with keeper_bash. The tool result must show explicit Docker-backed route evidence such as via=docker, route_via=docker, via=brokered, or route_via=brokered.
-5. Create a draft PR for that branch with keeper_pr_create. The call must include
-   repo="$REPO_SLUG", head="$branch", base="main", draft=true, and cwd set to
-   the returned proof worktree path. Do not leave head/base empty and do not use
-   the base repo path if the proof branch lives in a separate worktree. Do not
-   mark ready, do not merge, do not add human-approved-ready.
+$push_step
+$pr_step
 6. Reply with one compact JSON object:
    {
      "run_id": "$RUN_ID",
      "phase": "create",
      "keeper": "$keeper",
      "branch": "$branch",
+     "head": "$head_ref",
      "pr_url": "...",
      "docker_pr_create": true,
      "docker_git_push": true,
@@ -1422,6 +1535,7 @@ write_summary() {
     --arg review_required_tools "$REVIEW_REQUIRED_TOOLS" \
     --arg expected_server_commit "$EXPECTED_SERVER_COMMIT" \
     --arg forbid_github_identities "$FORBID_GITHUB_IDENTITIES" \
+    --arg allow_fork_pr_for_readonly "$ALLOW_FORK_PR_FOR_READONLY" \
     --arg server_commit "$SERVER_COMMIT_ACTUAL" \
     --arg server_started_at "$SERVER_STARTED_AT_ACTUAL" \
     --arg server_incarnation "$SERVER_INCARNATION_ACTUAL" \
@@ -1448,6 +1562,7 @@ write_summary() {
       review_required_tools:$review_required_tools,
       expected_server_commit:$expected_server_commit,
       forbid_github_identities:$forbid_github_identities,
+      allow_fork_pr_for_readonly:$allow_fork_pr_for_readonly,
       server_commit:$server_commit,
       server_started_at:$server_started_at,
       server_incarnation:$server_incarnation,

--- a/test/test_audit_keeper_fleet_readiness.py
+++ b/test/test_audit_keeper_fleet_readiness.py
@@ -54,7 +54,11 @@ def audit_args(base_path: Path, expected_keepers: int):
 
 
 def write_ready_keeper(
-    root: Path, name: str, *, github_identity: str = "anyang-keepers"
+    root: Path,
+    name: str,
+    *,
+    github_identity: str = "anyang-keepers",
+    github_account_login: str | None = None,
 ) -> None:
     config_dir = root / ".masc" / "config" / "keepers"
     runtime_dir = root / ".masc" / "keepers"
@@ -62,6 +66,18 @@ def write_ready_keeper(
     config_dir.mkdir(parents=True, exist_ok=True)
     runtime_dir.mkdir(parents=True, exist_ok=True)
     credential_dir.mkdir(parents=True, exist_ok=True)
+    account_login = github_account_login or github_identity
+    (credential_dir / "hosts.yml").write_text(
+        "\n".join(
+            [
+                "github.com:",
+                "    git_protocol: https",
+                f"    user: {account_login}",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
     (config_dir / f"{name}.toml").write_text(
         "\n".join(
             [
@@ -713,6 +729,26 @@ class AuditKeeperFleetReadinessTest(unittest.TestCase):
             ["github_identity_forbidden_operator"],
         )
 
+    def test_forbid_github_identity_fails_matching_account_login(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            write_ready_keeper(
+                root,
+                "alpha",
+                github_identity="reviewer-keepers",
+                github_account_login="operator",
+            )
+            args = audit_args(root, expected_keepers=1)
+            args.forbid_github_identity = ["operator"]
+
+            report = audit.build_report(args)
+
+        self.assertFalse(report["ok"])
+        self.assertEqual(
+            report["keepers"][0]["failures"],
+            ["github_account_forbidden_operator"],
+        )
+
     def test_docker_pr_approve_requirement_fails_with_single_identity_pool(self):
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
@@ -725,8 +761,44 @@ class AuditKeeperFleetReadinessTest(unittest.TestCase):
 
         self.assertFalse(report["ok"])
         self.assertEqual(report["github_identity_counts"], {"anyang-keepers": 2})
+        self.assertEqual(report["github_account_counts"], {"anyang-keepers": 2})
         self.assertIn(
             "docker_pr_approve_identity_pool_insufficient_unique_github_identities_1",
+            report["fleet_failures"],
+        )
+        self.assertIn(
+            "docker_pr_approve_account_pool_insufficient_unique_accounts_1",
+            report["fleet_failures"],
+        )
+
+    def test_docker_pr_approve_requirement_fails_aliases_to_same_account(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            write_ready_keeper(
+                root,
+                "alpha",
+                github_identity="anyang-keepers",
+                github_account_login="anyang-keepers",
+            )
+            write_ready_keeper(
+                root,
+                "bravo",
+                github_identity="reviewer-keepers",
+                github_account_login="anyang-keepers",
+            )
+            args = audit_args(root, expected_keepers=2)
+            args.require_docker_pr_approve_evidence = True
+
+            report = audit.build_report(args)
+
+        self.assertFalse(report["ok"])
+        self.assertEqual(
+            report["github_identity_counts"],
+            {"anyang-keepers": 1, "reviewer-keepers": 1},
+        )
+        self.assertEqual(report["github_account_counts"], {"anyang-keepers": 2})
+        self.assertIn(
+            "docker_pr_approve_account_pool_insufficient_unique_accounts_1",
             report["fleet_failures"],
         )
 
@@ -744,8 +816,16 @@ class AuditKeeperFleetReadinessTest(unittest.TestCase):
             report["github_identity_counts"],
             {"anyang-keepers": 1, "reviewer-keepers": 1},
         )
+        self.assertEqual(
+            report["github_account_counts"],
+            {"anyang-keepers": 1, "reviewer-keepers": 1},
+        )
         self.assertNotIn(
             "docker_pr_approve_identity_pool_insufficient_unique_github_identities_1",
+            report["fleet_failures"],
+        )
+        self.assertNotIn(
+            "docker_pr_approve_account_pool_insufficient_unique_accounts_1",
             report["fleet_failures"],
         )
 


### PR DESCRIPTION
## Summary
- resolve each keeper GitHub identity bundle to the authenticated account login from gh hosts.yml
- require at least two unique authenticated GitHub accounts, not only two bundle names, before Docker PR approval proof can pass
- make the Docker PR lifecycle reprobe assign review targets by account login and fail mutate preflight on unresolved or impossible permission pools
- fail closed by default when selected keepers lack upstream write permission, while allowing an explicit PUBLIC repo fork lane with `--allow-fork-pr-for-readonly`
- tighten the keeper create-lane prompt so `keeper_pr_create` must pass explicit `repo`, `head`, `base`, `draft`, and proof-worktree `cwd`; READ/TRIAGE fork lanes use `head=OWNER:BRANCH`

## Why
Issue #13728 showed that a second bundle name can still authenticate as the same real GitHub account. Name-only checks can route a keeper to approve a PR authored by the same underlying account, which GitHub rejects as self-approval and which should not count as proof.

The live mutate reprobe also exposed a second failure class: the current distinct reviewer account resolves to `yousleepwhen`, but only has READ permission on `jeong-sik/masc-mcp`. That account cannot push an upstream proof branch. For PUBLIC repositories, this PR adds an explicit fork proof path: the READ/TRIAGE keeper pushes to its own fork and still opens the target draft PR through `keeper_pr_create` with `head=OWNER:BRANCH`.

This PR does not provision credentials or claim Docker lifecycle proof is complete. It makes the proof guard distinguish same-account, no-write, and fork-capable READ lanes so the next live proof run can produce concrete evidence instead of failing ambiguously.

Refs #13728.

## Validation
- `python3 test/test_audit_keeper_fleet_readiness.py`
- `ruff check scripts/audit-keeper-fleet-readiness.py test/test_audit_keeper_fleet_readiness.py`
- `npx pyright --outputjson scripts/audit-keeper-fleet-readiness.py test/test_audit_keeper_fleet_readiness.py`
- `bash -n scripts/harness/workload/keeper_docker_pr_lifecycle_reprobe.sh`
- `git diff --check`
- live read-only audit against `/Users/dancer/me` with `--require-docker-pr-lifecycle-evidence` and `--forbid-github-identity jeong-sik`
- harness dry-run for `sangsu,verifier` wrote account-aware review targets under `/private/tmp/keeper-gh-account-proof-13728-harness`
- live mutate attempt `keeper-docker-pr-lifecycle-account-proof-20260507-0054`: generated Docker push evidence for `sangsu`, but failed strict create readiness because PR creation used empty `head`/wrong `cwd` and `verifier` lacked upstream write permission
- mutate preflight after the permission patch exits before keeper messaging when selected accounts include READ-only `verifier`: `/private/tmp/keeper-docker-pr-lifecycle-permission-preflight-20260507-0109`
- fork-lane dry-run `keeper-docker-pr-lifecycle-fork-dryrun-20260507-0128`: `sangsu` prompt uses upstream `head=branch`; `verifier` prompt uses `head=yousleepwhen:branch` and fork remote push instructions
- fork-lane mutate preflight collision check `keeper-docker-pr-lifecycle-fork-preflight-collision-20260507-0129`: permission gates pass with READ `verifier`, then execution stops before messaging on the expected stale `sangsu` proof branch collision
