### PR TITLE
feat(board): add vote-blind score projection

### DIFF
--- a/dashboard/src/api/board.test.ts
+++ b/dashboard/src/api/board.test.ts
@@ -527,6 +527,43 @@ describe('fetchBoard', () => {
     expect(url).toContain('hearth=ops')
     expect(url).toContain('limit=150')
   })
+
+  it('normalizes vote-blind rows and opts into the board projection when requested', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({
+        posts: [
+          {
+            id: 'post-blind',
+            author: 'analyst',
+            title: 'Blind score',
+            body: 'Working',
+            created_at: 1_713_000_000,
+            updated_at: 1_713_000_000,
+            votes: null,
+            score: null,
+            votes_up: null,
+            votes_down: null,
+            vote_blind: true,
+            vote_blind_reason: 'vote_before_score',
+          },
+        ],
+      }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await fetchBoard('hot', { blindVotes: true })
+
+    expect(result.posts[0]).toMatchObject({
+      id: 'post-blind',
+      vote_blind: true,
+      vote_blind_reason: 'vote_before_score',
+    })
+    const [url] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect(url).toContain('blind_votes=true')
+  })
 })
 
 describe('fetchBoardHearths', () => {
@@ -723,6 +760,7 @@ describe('fetchBoardPost', () => {
     const [url] = fetchMock.mock.calls[0] as [string, RequestInit]
     expect(url).toContain('format=flat')
     expect(url).toContain('voter=')
+    expect(url).toContain('blind_votes=true')
   })
 })
 

--- a/dashboard/src/api/board.ts
+++ b/dashboard/src/api/board.ts
@@ -367,6 +367,8 @@ function normalizeBoardPost(raw: unknown): BoardPost | null {
   const votes = asNumber(raw.votes, score || (votesUp - votesDown))
   const currentVote = normalizeBoardVoteDirection(raw.current_vote)
   const hasVoted = typeof raw.has_voted === 'boolean' ? raw.has_voted : currentVote !== null
+  const voteBlind = raw.vote_blind === true
+  const voteBlindReason = asString(raw.vote_blind_reason, '').trim() || undefined
   const commentCount = asNumber(raw.comment_count, asNumber(raw.reply_count, 0))
   const flairValue = (() => {
     const flair = raw.flair
@@ -412,6 +414,8 @@ function normalizeBoardPost(raw: unknown): BoardPost | null {
     tags,
     votes,
     vote_balance: score,
+    vote_blind: voteBlind,
+    ...(voteBlindReason ? { vote_blind_reason: voteBlindReason } : {}),
     current_vote: currentVote,
     has_voted: hasVoted,
     comment_count: commentCount,
@@ -446,6 +450,8 @@ function normalizeBoardComment(raw: unknown): BoardComment | null {
   const votes = asNumber(raw.votes, score)
   const currentVote = normalizeBoardVoteDirection(raw.current_vote)
   const hasVoted = typeof raw.has_voted === 'boolean' ? raw.has_voted : currentVote !== null
+  const voteBlind = raw.vote_blind === true
+  const voteBlindReason = asString(raw.vote_blind_reason, '').trim() || undefined
   const reactions = Array.isArray(raw.reactions)
     ? raw.reactions
         .map(normalizeBoardReactionSummary)
@@ -463,6 +469,8 @@ function normalizeBoardComment(raw: unknown): BoardComment | null {
     vote_balance: score,
     votes_up: votesUp,
     votes_down: votesDown,
+    vote_blind: voteBlind,
+    ...(voteBlindReason ? { vote_blind_reason: voteBlindReason } : {}),
     current_vote: currentVote,
     has_voted: hasVoted,
     report_count: Math.max(0, Math.trunc(asNumber(raw.report_count, 0))),
@@ -652,7 +660,13 @@ function normalizeBoardReactionToggleResult(raw: unknown): BoardReactionToggleRe
 
 export async function fetchBoard(
   sortBy?: BoardSortMode,
-  options?: { excludeSystem?: boolean; excludeAutomation?: boolean; author?: string; hearth?: string },
+  options?: {
+    excludeSystem?: boolean
+    excludeAutomation?: boolean
+    author?: string
+    hearth?: string
+    blindVotes?: boolean
+  },
 ): Promise<{ posts: BoardPost[] }> {
   return timeBoardRequest('list', () => withRetries('fetchBoard', async () => {
     const params = new URLSearchParams()
@@ -662,6 +676,7 @@ export async function fetchBoard(
     if (options?.author) params.set('author', options.author)
     if (options?.hearth) params.set('hearth', options.hearth)
     params.set('voter', currentDashboardActor())
+    if (options?.blindVotes) params.set('blind_votes', 'true')
     params.set('limit', options?.excludeSystem || options?.excludeAutomation || options?.author || options?.hearth ? '150' : '100')
     const qs = params.toString()
     const raw = await get<{ posts?: unknown[] }>(`/api/v1/board${qs ? `?${qs}` : ''}`)
@@ -724,6 +739,7 @@ export async function fetchBoardPost(postId: string): Promise<BoardPost & { comm
     const params = new URLSearchParams({
       format: 'flat',
       voter: currentDashboardActor(),
+      blind_votes: 'true',
     })
     const raw = await get<Record<string, unknown>>(`/api/v1/board/${postId}?${params}`)
     const postRaw = isRecord(raw.post) ? raw.post : raw

--- a/dashboard/src/api/dashboard.test.ts
+++ b/dashboard/src/api/dashboard.test.ts
@@ -5,6 +5,7 @@ import {
   fetchDashboardGoalDetail,
   fetchDashboardGoalsTree,
   fetchDashboardTools,
+  fetchDashboardMemory,
   fetchCostLatency,
   fetchKeeperConfig,
   fetchMemorySubsystems,
@@ -274,6 +275,25 @@ describe('fetchToolQuality', () => {
     expect(fetchMock.mock.calls[0]?.[0]).toBe('/api/v1/dashboard/tool-quality?window_hours=24')
     expect(result.window_hours).toBe(24)
     expect(result.sampling_mode).toBe('window_hours')
+  })
+})
+
+describe('fetchDashboardMemory', () => {
+  it('requests vote-blind dashboard board rows for the current actor', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ posts: [] }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    await fetchDashboardMemory('hot')
+
+    const [url] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect(url).toContain('/api/v1/dashboard/board?')
+    expect(url).toContain('voter=')
+    expect(url).toContain('blind_votes=true')
   })
 })
 

--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -11,7 +11,7 @@ import {
   normalizePendingConfirmation,
 } from './board'
 import { normalizeKeeperTrustTerminalReason } from '../keeper-store-normalize'
-import { get, post, patch, withRetries, NAMESPACE_TRUTH_GET_TIMEOUT_MS } from './core'
+import { currentDashboardActor, get, post, patch, withRetries, NAMESPACE_TRUTH_GET_TIMEOUT_MS } from './core'
 import {
   parseAgentRelationsResponse,
   type AgentRelationsResponse,
@@ -374,6 +374,8 @@ export function fetchDashboardMemory(
   const offset = Math.max(0, Math.min(5000, opts?.offset ?? 0))
   params.set('limit', String(limit))
   if (offset > 0) params.set('offset', String(offset))
+  params.set('voter', currentDashboardActor())
+  params.set('blind_votes', 'true')
   if (opts?.excludeSystem) params.set('exclude_system', 'true')
   if (opts?.excludeAutomation) params.set('exclude_automation', 'true')
   if (opts?.author) params.set('author', opts.author)

--- a/dashboard/src/components/board/board-surface.test.ts
+++ b/dashboard/src/components/board/board-surface.test.ts
@@ -254,6 +254,25 @@ describe('BoardSurface Component', () => {
     expect(screen.getByLabelText('게시글 moderation 신고됨 2건')).toHaveTextContent('신고됨 2')
   })
 
+  it('renders vote-blind post scores as hidden until voting', () => {
+    boardPosts.value = [
+      makePost({
+        id: 'post-blind',
+        title: 'Blind score',
+        body: 'content',
+        author: 'ani1999',
+        votes: null,
+        vote_balance: null,
+        vote_blind: true,
+        vote_blind_reason: 'vote_before_score',
+      }),
+    ]
+
+    render(h(BoardSurface, null))
+
+    expect(screen.getByLabelText('점수 투표 후 공개')).toHaveTextContent('투표 후 공개')
+  })
+
   it('routes the mention inbox focus to the message surface', () => {
     route.value = { params: { focus: 'mention-inbox' } } as any
     messages.value = [{ id: 'm-1', from: 'sojin', content: '@dashboard needs review' }]

--- a/dashboard/src/components/board/board-surface.ts
+++ b/dashboard/src/components/board/board-surface.ts
@@ -582,6 +582,8 @@ function PostCard({ post }: { post: BoardPost }) {
   const authorTitle = boardActorTitle(post.author, post.author_identity)
   const upvoteActive = post.current_vote === 'up'
   const downvoteActive = post.current_vote === 'down'
+  const voteScoreLabel = post.vote_blind ? '투표 후 공개' : String(post.votes ?? 0)
+  const voteScoreAria = post.vote_blind ? '점수 투표 후 공개' : `점수 ${post.votes ?? 0}`
   const reactionPreview = post.reactions?.some(summary => summary.count > 0 || summary.reacted || summary.has_reacted)
 
   const handleVote = async (dir: 'up' | 'down', event: Event) => {
@@ -643,7 +645,7 @@ function PostCard({ post }: { post: BoardPost }) {
       </div>
 
       <!-- Vote column -->
-      <div class="flex flex-col items-center gap-0.5 pt-0.5 min-w-9">
+      <div class="flex flex-col items-center gap-0.5 pt-0.5 min-w-14">
         <button type="button"
           aria-label="추천"
           aria-pressed=${upvoteActive ? 'true' : 'false'}
@@ -651,7 +653,13 @@ function PostCard({ post }: { post: BoardPost }) {
           class=${`vote-btn upvote w-7 h-5 flex items-center justify-center rounded-[var(--r-1)] text-2xs transition-colors border-0 bg-transparent ${upvoteActive ? 'active text-[var(--warn-bright)] bg-[var(--warn-10)] cursor-default' : 'text-[var(--color-fg-muted)] hover:text-[var(--warn-bright)] hover:bg-[var(--warn-10)] cursor-pointer'}`}
           onClick=${(event: Event) => handleVote('up', event)}
         ><span aria-hidden="true">▲</span></button>
-        <span class="text-sm font-semibold tabular-nums text-[var(--color-fg-secondary)]">${post.votes ?? 0}</span>
+        <span
+          class=${post.vote_blind
+            ? 'max-w-14 text-center text-[10px] font-medium leading-tight text-[var(--color-fg-muted)]'
+            : 'text-sm font-semibold tabular-nums text-[var(--color-fg-secondary)]'}
+          aria-label=${voteScoreAria}
+          title=${voteScoreLabel}
+        >${voteScoreLabel}</span>
         <button type="button"
           aria-label="비추천"
           aria-pressed=${downvoteActive ? 'true' : 'false'}

--- a/dashboard/src/components/board/post-detail.test.ts
+++ b/dashboard/src/components/board/post-detail.test.ts
@@ -268,6 +268,27 @@ describe('CommentThread', () => {
     expect(screen.getByLabelText('댓글 moderation 숨김 1건')).toHaveTextContent('숨김 1')
   })
 
+  it('renders vote-blind comment scores as hidden until voting', () => {
+    const comments = [
+      {
+        id: 'c1',
+        post_id: 'post-1',
+        parent_id: null,
+        author: 'agent',
+        content: 'review me',
+        created_at: '2026-04-02T00:00:00Z',
+        votes: null,
+        vote_balance: null,
+        vote_blind: true,
+        vote_blind_reason: 'vote_before_score',
+      },
+    ] as any
+
+    render(h(CommentThread, { comments, postId: 'post-1' }))
+
+    expect(screen.getByLabelText('댓글 점수 투표 후 공개')).toHaveTextContent('투표 후 공개')
+  })
+
   it('marks the current comment vote as pressed', () => {
     const comments = [
       {
@@ -478,5 +499,28 @@ describe('PostDetail', () => {
     await waitFor(() => {
       expect(votePost).toHaveBeenCalledWith('post-1', 'up')
     })
+  })
+
+  it('renders vote-blind post scores as hidden until voting', () => {
+    const post = {
+      id: 'post-1',
+      author: 'sleepers',
+      title: 'Post',
+      body: 'Body',
+      content: 'Body',
+      created_at: '2026-04-02T00:00:00Z',
+      updated_at: '2026-04-02T00:00:00Z',
+      votes: null,
+      vote_balance: null,
+      vote_blind: true,
+      vote_blind_reason: 'vote_before_score',
+      comment_count: 0,
+      post_kind: 'direct',
+      comments: [],
+    } as any
+
+    render(h(PostDetail, { post }))
+
+    expect(screen.getByLabelText('게시글 점수 투표 후 공개')).toHaveTextContent('투표 후 공개')
   })
 })

--- a/dashboard/src/components/board/post-detail.ts
+++ b/dashboard/src/components/board/post-detail.ts
@@ -206,6 +206,8 @@ function CommentItem({
   const hiddenSiblingReplyCount = Math.max(0, replies.length - visibleReplies.length)
   const canLoadMoreSiblingReplies = showReplies && !forceThreadExpanded && hiddenSiblingReplyCount > 0
   const score = comment.vote_balance ?? comment.votes ?? ((comment.votes_up ?? 0) - (comment.votes_down ?? 0))
+  const scoreLabel = comment.vote_blind ? '투표 후 공개' : String(score)
+  const scoreAria = comment.vote_blind ? '댓글 점수 투표 후 공개' : `댓글 점수 ${score}`
   const authorLabel = boardActorDisplayName(comment.author, comment.author_identity)
   const authorAvatarKey = boardActorAvatarKey(comment.author, comment.author_identity)
   const authorTitle = boardActorTitle(comment.author, comment.author_identity)
@@ -249,7 +251,13 @@ function CommentItem({
               disabled=${upvoteActive}
               onClick=${() => handleCommentVote('up')}
             >▲</button>
-            <span class="min-w-5 text-center text-2xs font-semibold tabular-nums text-[var(--color-fg-secondary)]">${score}</span>
+            <span
+              class=${comment.vote_blind
+                ? 'min-w-14 text-center text-[10px] font-medium leading-tight text-[var(--color-fg-muted)]'
+                : 'min-w-5 text-center text-2xs font-semibold tabular-nums text-[var(--color-fg-secondary)]'}
+              aria-label=${scoreAria}
+              title=${scoreLabel}
+            >${scoreLabel}</span>
             <button
               type="button"
               class=${`h-5 w-6 rounded-[var(--r-1)] border-0 bg-transparent text-2xs ${downvoteActive ? 'active text-[var(--color-accent-fg)] bg-[var(--accent-10)] cursor-default' : 'text-[var(--color-fg-muted)] hover:bg-[var(--accent-10)] hover:text-[var(--color-accent-fg)]'}`}
@@ -443,6 +451,8 @@ export function PostDetail({ post }: { post: BoardPost }) {
   const authorTitle = boardActorTitle(post.author, post.author_identity)
   const upvoteActive = post.current_vote === 'up'
   const downvoteActive = post.current_vote === 'down'
+  const postVoteLabel = post.vote_blind ? '투표 후 공개' : `${post.votes ?? 0} votes`
+  const postVoteAria = post.vote_blind ? '게시글 점수 투표 후 공개' : `게시글 점수 ${post.votes ?? 0}`
 
   return html`
     <div>
@@ -468,7 +478,11 @@ export function PostDetail({ post }: { post: BoardPost }) {
             <span class="text-sm">${authorAvatar(authorAvatarKey)}</span>
             <${ActionButton} variant="subtle" size="sm" class="text-xs text-[var(--color-fg-primary)] hover:text-[var(--color-accent-fg)] bg-transparent border-none p-0" title=${authorTitle} ariaLabel=${`작성자 ${authorLabel} 프로필로 이동`} onClick=${() => navigateToAuthor(post.author, undefined, post.author_identity)}>${authorLabel}<//>
             <span class="text-2xs text-[var(--color-fg-muted)]"><${TimeAgo} timestamp=${post.created_at} /></span>
-            <span class="text-2xs text-[var(--color-fg-muted)]">${post.votes ?? 0} votes</span>
+            <span
+              class="text-2xs text-[var(--color-fg-muted)]"
+              aria-label=${postVoteAria}
+              title=${postVoteLabel}
+            >${postVoteLabel}</span>
           </div>
 
           <!-- Badges -->

--- a/dashboard/src/components/ide/ide-conversation-rail-mock.ts
+++ b/dashboard/src/components/ide/ide-conversation-rail-mock.ts
@@ -298,7 +298,7 @@ function PostCard(post: BoardPost, focused: boolean, onFocus: () => void) {
         ` : null}
         <p class="ide-conversation-body">${bodyText}</p>
         <div style=${{ fontSize: 'var(--fs-11)', color: 'var(--color-fg-muted)' }}>
-          ${post.comment_count > 0 ? `${post.comment_count} replies · ` : ''}${post.votes > 0 ? `${post.votes} votes` : ''}
+          ${post.comment_count > 0 ? `${post.comment_count} replies · ` : ''}${(post.votes ?? 0) > 0 ? `${post.votes ?? 0} votes` : ''}
         </div>
       </button>
     </li>

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -141,8 +141,10 @@ export interface BoardPost {
   content: string
   meta?: BoardPostMeta | null
   tags: string[]
-  votes: number
-  vote_balance?: number
+  votes: number | null
+  vote_balance?: number | null
+  vote_blind?: boolean
+  vote_blind_reason?: string
   current_vote?: BoardVoteDirection | null
   has_voted?: boolean
   comment_count: number
@@ -166,10 +168,12 @@ export interface BoardComment {
   author_identity?: BoardActorIdentity | null
   content: string
   created_at: string
-  votes?: number
-  vote_balance?: number
-  votes_up?: number
-  votes_down?: number
+  votes?: number | null
+  vote_balance?: number | null
+  votes_up?: number | null
+  votes_down?: number | null
+  vote_blind?: boolean
+  vote_blind_reason?: string
   current_vote?: BoardVoteDirection | null
   has_voted?: boolean
   report_count?: number

--- a/docs/spec/11-board.md
+++ b/docs/spec/11-board.md
@@ -319,6 +319,28 @@ truth.  `build_karma_ledger` replays it deterministically.  Rows whose
 post/comment has been deleted are silently dropped; the vote file is
 never modified by the replay path.
 
+### 9a.6 Vote-Blind Projection
+
+Board read endpoints may opt into vote-blind scoring with
+`blind_votes=true` and a canonical `voter`.  When the viewer has not
+voted on a post or comment, the response emits:
+
+```json
+{
+  "vote_blind": true,
+  "vote_blind_reason": "vote_before_score",
+  "votes": null,
+  "vote_balance": null,
+  "score": null,
+  "votes_up": null,
+  "votes_down": null
+}
+```
+
+After that viewer votes, the same row emits `vote_blind: false` and the
+normal score fields.  This is a read-time projection only: it does not
+change storage, sorting, karma ledger replay, or moderation state.
+
 
 
 ## 10. MCP Tool Surface

--- a/lib/server/server_dashboard_http.ml
+++ b/lib/server/server_dashboard_http.ml
@@ -21,17 +21,19 @@ let dashboard_namespace_truth_http_json =
 
 let dashboard_board_json ?hearth ?author_filter
     ?(sort_by = Board_dispatch.Hot) ?(exclude_system = false)
-    ?(exclude_automation = false) ?(limit = 100) ?(offset = 0) () :
-    Yojson.Safe.t =
+    ?(exclude_automation = false) ?(limit = 100) ?(offset = 0) ?voter
+    ?(blind_votes = false) () : Yojson.Safe.t =
   let limit = clamp ~min_v:1 ~max_v:500 limit in
   let offset = clamp ~min_v:0 ~max_v:5000 offset in
   let author_filter = Option.map board_actor_author_for_write author_filter in
   let cache_key =
-    Printf.sprintf "board:memory:%s;%s;%s;%b;%b;%d;%d"
+    Printf.sprintf "board:memory:%s;%s;%s;%b;%b;%d;%d;%s;%b"
       (Option.value ~default:"-" hearth)
       (Option.value ~default:"-" author_filter)
       (board_sort_label sort_by)
       exclude_system exclude_automation limit offset
+      (Option.value ~default:"-" voter)
+      blind_votes
   in
   Dashboard_cache.get_or_compute cache_key ~ttl:10.0 (fun () ->
     let base_fetch = board_fetch_limit ~exclude_system ~exclude_automation ~limit ~offset in
@@ -58,7 +60,10 @@ let dashboard_board_json ?hearth ?author_filter
       List.map
         (fun (post : Board.post) ->
           let author = Board.Agent_id.to_string post.author in
-          board_post_dashboard_json ~author_karma:(get_karma author) post)
+          let post_id = Board.Post_id.to_string post.id in
+          let current_vote = board_current_vote_for_post ~voter ~post_id in
+          board_post_dashboard_json ~blind_votes ?current_vote
+            ~author_karma:(get_karma author) post)
         paged
     in
     `Assoc
@@ -100,8 +105,10 @@ let dashboard_memory_http_json request : Yojson.Safe.t =
   let offset =
     int_query_param request "offset" ~default:0 |> clamp ~min_v:0 ~max_v:5000
   in
+  let voter = board_voter_query request in
+  let blind_votes = bool_query_param request "blind_votes" ~default:false in
   dashboard_board_json ?hearth ?author_filter ~sort_by ~exclude_system
-    ~exclude_automation ~limit ~offset ()
+    ~exclude_automation ~limit ~offset ?voter ~blind_votes ()
 
 let memory_subsystems_entry_cache_ttl_sec = 30.0
 

--- a/lib/server/server_dashboard_http.mli
+++ b/lib/server/server_dashboard_http.mli
@@ -54,6 +54,8 @@ val dashboard_board_json :
   ?exclude_automation:bool ->
   ?limit:int ->
   ?offset:int ->
+  ?voter:string ->
+  ?blind_votes:bool ->
   unit ->
   Yojson.Safe.t
 

--- a/lib/server/server_h2_gateway_routes_extra.ml
+++ b/lib/server/server_h2_gateway_routes_extra.ml
@@ -36,6 +36,7 @@ let dispatch ~h2_reqd ~httpun_request ~cors ~path
       let offset = int_query_param httpun_request "offset" ~default:0 |> clamp ~min_v:0 ~max_v:5000 in
       let base_fetch = board_fetch_limit ~exclude_system ~exclude_automation ~limit ~offset in
       let voter = board_voter_query httpun_request in
+      let blind_votes = bool_query_param httpun_request "blind_votes" ~default:false in
       let posts =
         Board_dispatch.list_posts ?hearth ~sort_by ~exclude_system
           ~exclude_automation ?author_filter ~limit:base_fetch ()
@@ -60,7 +61,7 @@ let dispatch ~h2_reqd ~httpun_request ~cors ~path
         let post_id = Board.Post_id.to_string p.id in
         let current_vote = board_current_vote_for_post ~voter ~post_id in
         let reactions = reactions_for (Board.Reaction_post, post_id) in
-        board_post_dashboard_json ?current_vote ~reactions
+        board_post_dashboard_json ~blind_votes ?current_vote ~reactions
           ~author_karma:(get_karma author) p
       ) paged in
       let json = `Assoc [
@@ -105,8 +106,11 @@ let dispatch ~h2_reqd ~httpun_request ~cors ~path
       let post_id = String.sub p 14 (String.length p - 14) in
       let format = Option.value ~default:"nested" (query_param httpun_request "format") in
       let voter = board_voter_query httpun_request in
+      let blind_votes =
+        bool_query_param httpun_request "blind_votes" ~default:false
+      in
       let (status, body) =
-        board_post_detail_json ~include_moderation:false ~voter
+        board_post_detail_json ~include_moderation:false ~blind_votes ~voter
           ~response_format:format ~post_id
       in
       h2_respond_json h2_reqd body ~status ~extra_headers:cors;

--- a/lib/server/server_routes_http_routes_activity.ml
+++ b/lib/server/server_routes_http_routes_activity.ml
@@ -227,6 +227,7 @@ let add_routes ~sw ~clock router =
          let offset = int_query_param req "offset" ~default:0 |> clamp ~min_v:0 ~max_v:5000 in
          let base_fetch = board_fetch_limit ~exclude_system ~exclude_automation ~limit ~offset in
          let voter = board_voter_query req in
+         let blind_votes = bool_query_param req "blind_votes" ~default:false in
          let include_moderation =
            include_moderation_projection
              ~base_path:state.Mcp_server.room_config.base_path
@@ -258,8 +259,8 @@ let add_routes ~sw ~clock router =
                let post_id = Board.Post_id.to_string p.id in
                let current_vote = board_current_vote_for_post ~voter ~post_id in
                let reactions = reactions_for (Board.Reaction_post, post_id) in
-               board_post_dashboard_json ~include_moderation ?current_vote
-                 ~reactions
+               board_post_dashboard_json ~include_moderation ~blind_votes
+                 ?current_vote ~reactions
                  ~author_karma:(get_karma author) p)
              paged
          in
@@ -373,13 +374,16 @@ let add_routes ~sw ~clock router =
                 query_param req "format" |> Option.value ~default:"nested"
               in
               let voter = board_voter_query req in
+              let blind_votes =
+                bool_query_param req "blind_votes" ~default:false
+              in
               let include_moderation =
                 include_moderation_projection
                   ~base_path:state.Mcp_server.room_config.base_path
                   req
               in
               let (status, body) =
-                board_post_detail_json ~include_moderation ~voter
+                board_post_detail_json ~include_moderation ~blind_votes ~voter
                   ~response_format:format ~post_id
               in
               respond_json_with_cors ~status request reqd body)

--- a/lib/server/server_routes_http_runtime.ml
+++ b/lib/server/server_routes_http_runtime.ml
@@ -294,8 +294,8 @@ let readiness_handler _request reqd =
             ]))
       reqd
 
-let board_post_detail_json ~include_moderation ~voter ~response_format
-    ~post_id =
+let board_post_detail_json ~include_moderation ~blind_votes ~voter
+    ~response_format ~post_id =
   match Board_dispatch.get_post ~post_id with
   | Error err ->
       (`Not_found, Printf.sprintf {|{"error":"%s"}|}
@@ -323,16 +323,16 @@ let board_post_detail_json ~include_moderation ~voter ~response_format
       let reactions_for = board_reactions_lookup reaction_rows in
       let reactions = reactions_for (Board.Reaction_post, post_id) in
       let post_json =
-        board_post_dashboard_json ~include_moderation ?current_vote ~reactions
-          ~author_karma post
+        board_post_dashboard_json ~include_moderation ~blind_votes ?current_vote
+          ~reactions ~author_karma post
       in
       let comments_json =
         `List (List.map (fun (comment : Board.comment) ->
           let comment_id = Board.Comment_id.to_string comment.id in
           let current_vote = board_current_vote_for_comment ~voter ~comment_id in
           let reactions = reactions_for (Board.Reaction_comment, comment_id) in
-          board_comment_dashboard_json ~include_moderation ?current_vote ~reactions
-            comment
+          board_comment_dashboard_json ~include_moderation ~blind_votes
+            ?current_vote ~reactions comment
         ) comments)
       in
       let json =

--- a/lib/server/server_routes_http_runtime.mli
+++ b/lib/server/server_routes_http_runtime.mli
@@ -162,6 +162,7 @@ val readiness_handler : Httpun.Request.t -> Httpun.Reqd.t -> unit
 
 val board_post_detail_json :
   include_moderation:bool ->
+  blind_votes:bool ->
   voter:string option ->
   response_format:string ->
   post_id:string ->
@@ -170,7 +171,8 @@ val board_post_detail_json :
     [(status, json_string)] for [GET /api/v1/board/<post_id>].
     When [voter] is supplied, post/comment rows include vote state for
     that voter.  When [include_moderation] is [true], rows also include
-    operator-only moderation projection fields.
+    operator-only moderation projection fields.  When [blind_votes] is
+    [true], rows hide score fields until that voter has voted.
 
     {2 response_format values (case-insensitive, trimmed)}
 

--- a/lib/server/server_utils.ml
+++ b/lib/server/server_utils.ml
@@ -149,6 +149,22 @@ let board_vote_state_fields = function
         ("has_voted", `Bool true);
       ]
 
+let board_vote_blind_active ~blind_votes = function
+  | Some (Some _) -> false
+  | _ -> blind_votes
+
+let board_vote_blind_fields ~blind_active =
+  if blind_active then
+    [
+      ("vote_blind", `Bool true);
+      ("vote_blind_reason", `String "vote_before_score");
+      ("vote_balance", `Null);
+      ("score", `Null);
+      ("votes_up", `Null);
+      ("votes_down", `Null);
+    ]
+  else [ ("vote_blind", `Bool false) ]
+
 let board_reactions_for_post ~voter ~post_id =
   match
     Board_dispatch.list_reactions ~target_type:Board.Reaction_post
@@ -197,24 +213,39 @@ let board_moderation_fields ~include_moderation ~target_kind ~target_id =
       ("moderation_status", `String summary.Board_moderation.moderation_status);
     ]
 
-let board_comment_dashboard_json ?(include_moderation = false) ?current_vote
-    ?reactions (c : Board.comment) : Yojson.Safe.t =
+let board_comment_dashboard_json ?(include_moderation = false)
+    ?(blind_votes = false) ?current_vote ?reactions (c : Board.comment) :
+    Yojson.Safe.t =
   let author = Board.Agent_id.to_string c.author in
   let comment_id = Board.Comment_id.to_string c.id in
   match Board.comment_to_yojson c with
   | `Assoc fields ->
+      let blind_active = board_vote_blind_active ~blind_votes current_vote in
+      let fields =
+        if blind_active then
+          fields
+          |> List.remove_assoc "votes"
+          |> List.remove_assoc "vote_balance"
+          |> List.remove_assoc "score"
+          |> List.remove_assoc "votes_up"
+          |> List.remove_assoc "votes_down"
+        else fields
+      in
       `Assoc
         (fields
          @ [ ("author_identity", board_actor_identity_json author) ]
          @ board_moderation_fields ~include_moderation
              ~target_kind:Board_moderation.Target_comment
              ~target_id:comment_id
+         @ (if blind_active then [ ("votes", `Null) ] else [])
+         @ board_vote_blind_fields ~blind_active
          @ board_vote_state_fields current_vote
          @ board_reaction_fields reactions)
   | other -> other
 
-let board_post_dashboard_json ?(include_moderation = false) ?current_vote
-    ?reactions ~author_karma (p : Board.post) : Yojson.Safe.t =
+let board_post_dashboard_json ?(include_moderation = false)
+    ?(blind_votes = false) ?current_vote ?reactions ~author_karma
+    (p : Board.post) : Yojson.Safe.t =
   let author = Board.Agent_id.to_string p.author in
   let post_id = Board.Post_id.to_string p.id in
   let base_fields =
@@ -231,13 +262,23 @@ let board_post_dashboard_json ?(include_moderation = false) ?current_vote
     |> List.remove_assoc "updated_at_iso"
     |> List.remove_assoc "hearth_count"
   in
+  let blind_active = board_vote_blind_active ~blind_votes current_vote in
+  let fields =
+    if blind_active then
+      fields
+      |> List.remove_assoc "vote_balance"
+      |> List.remove_assoc "score"
+      |> List.remove_assoc "votes_up"
+      |> List.remove_assoc "votes_down"
+    else fields
+  in
   let score = p.votes_up - p.votes_down in
   `Assoc
     ( fields
       @ [
           ("title", `String p.title);
           ("body", `String p.body);
-          ("votes", `Int score);
+          ("votes", if blind_active then `Null else `Int score);
           ("comment_count", `Int p.reply_count);
           ("created_at_iso", `String (iso8601_of_unix p.created_at));
           ("updated_at_iso", `String (iso8601_of_unix p.updated_at));
@@ -247,6 +288,7 @@ let board_post_dashboard_json ?(include_moderation = false) ?current_vote
       @ board_moderation_fields ~include_moderation
           ~target_kind:Board_moderation.Target_post
           ~target_id:post_id
+      @ board_vote_blind_fields ~blind_active
       @ board_vote_state_fields current_vote
       @ board_reaction_fields reactions )
 

--- a/lib/server/server_utils.mli
+++ b/lib/server/server_utils.mli
@@ -175,6 +175,7 @@ val board_reactions_lookup :
 
 val board_comment_dashboard_json :
   ?include_moderation:bool ->
+  ?blind_votes:bool ->
   ?current_vote:Board.vote_direction option ->
   ?reactions:Board.reaction_summary list ->
   Board.comment ->
@@ -182,10 +183,13 @@ val board_comment_dashboard_json :
 (** [board_comment_dashboard_json c] renders a comment with the
     [author_identity] field appended for dashboard inspection.  When
     [include_moderation] is [true], it also appends operator-only
-    [report_count] and [moderation_status] fields. *)
+    [report_count] and [moderation_status] fields.  When [blind_votes]
+    is [true], score fields are hidden until [current_vote] records a
+    viewer vote. *)
 
 val board_post_dashboard_json :
   ?include_moderation:bool ->
+  ?blind_votes:bool ->
   ?current_vote:Board.vote_direction option ->
   ?reactions:Board.reaction_summary list ->
   author_karma:int ->
@@ -204,6 +208,8 @@ val board_post_dashboard_json :
     - [author_identity] from {!board_actor_identity_json}.
     - [report_count] / [moderation_status] from {!Board_moderation}
       only when [include_moderation] is [true].
+    - [vote_blind] / [vote_blind_reason] and null score fields when
+      [blind_votes] is [true] and the viewer has not voted yet.
 
     The base fields [title] / [votes] / [comment_count] /
     [created_at_iso] / [updated_at_iso] / [hearth_count] are

--- a/test/test_tool_board_coverage.ml
+++ b/test/test_tool_board_coverage.ml
@@ -173,6 +173,11 @@ let json_member_bool json key =
   | `Bool value -> value
   | _ -> Alcotest.failf "expected bool field %s" key
 
+let json_member_null json key =
+  match Yojson.Safe.Util.member key json with
+  | `Null -> ()
+  | _ -> Alcotest.failf "expected null field %s" key
+
 let json_member_list json key =
   match Yojson.Safe.Util.member key json with
   | `List values -> values
@@ -338,6 +343,87 @@ let test_board_dashboard_json_embeds_moderation_projection () =
     (json_member_int comment_json "report_count");
   Alcotest.(check string) "comment moderation status" "flagged"
     (json_member_string comment_json "moderation_status")
+
+let test_board_dashboard_json_hides_unvoted_scores_when_blind () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  cleanup ();
+  let post =
+    match
+      Board_dispatch.create_post ~author:"blind-author"
+        ~content:"vote blind post" ~post_kind:Board.Human_post ()
+    with
+    | Ok post -> post
+    | Error e -> Alcotest.fail (Board.show_board_error e)
+  in
+  let post_id = Board.Post_id.to_string post.id in
+  (match Board_dispatch.vote ~voter:"peer" ~post_id ~direction:Board.Up with
+  | Ok _ -> ()
+  | Error e -> Alcotest.fail (Board.show_board_error e));
+  let post =
+    match Board_dispatch.get_post ~post_id with
+    | Ok post -> post
+    | Error e -> Alcotest.fail (Board.show_board_error e)
+  in
+  let comment =
+    match
+      Board_dispatch.add_comment ~post_id ~author:"blind-commenter"
+        ~content:"vote blind comment" ()
+    with
+    | Ok comment -> comment
+    | Error e -> Alcotest.fail (Board.show_board_error e)
+  in
+  let comment_id = Board.Comment_id.to_string comment.id in
+  (match
+     Board_dispatch.vote_comment ~voter:"peer" ~comment_id
+       ~direction:Board.Up
+   with
+   | Ok _ -> ()
+   | Error e -> Alcotest.fail (Board.show_board_error e));
+  let comment =
+    match Board_dispatch.get_comments ~post_id with
+    | Ok (comment :: _) -> comment
+    | Ok [] -> Alcotest.fail "expected comment"
+    | Error e -> Alcotest.fail (Board.show_board_error e)
+  in
+  let hidden_post_json =
+    Server_utils.board_post_dashboard_json ~blind_votes:true
+      ~current_vote:None ~author_karma:0 post
+  in
+  Alcotest.(check bool) "post vote blind" true
+    (json_member_bool hidden_post_json "vote_blind");
+  json_member_null hidden_post_json "votes";
+  json_member_null hidden_post_json "score";
+  json_member_null hidden_post_json "votes_up";
+  json_member_null hidden_post_json "votes_down";
+  Alcotest.(check string) "post blind reason" "vote_before_score"
+    (json_member_string hidden_post_json "vote_blind_reason");
+  let revealed_post_json =
+    Server_utils.board_post_dashboard_json ~blind_votes:true
+      ~current_vote:(Some Board.Up) ~author_karma:0 post
+  in
+  Alcotest.(check bool) "post vote revealed" false
+    (json_member_bool revealed_post_json "vote_blind");
+  Alcotest.(check int) "post revealed votes" 1
+    (json_member_int revealed_post_json "votes");
+  let hidden_comment_json =
+    Server_utils.board_comment_dashboard_json ~blind_votes:true
+      ~current_vote:None comment
+  in
+  Alcotest.(check bool) "comment vote blind" true
+    (json_member_bool hidden_comment_json "vote_blind");
+  json_member_null hidden_comment_json "votes";
+  json_member_null hidden_comment_json "score";
+  json_member_null hidden_comment_json "votes_up";
+  json_member_null hidden_comment_json "votes_down";
+  let revealed_comment_json =
+    Server_utils.board_comment_dashboard_json ~blind_votes:true
+      ~current_vote:(Some Board.Up) comment
+  in
+  Alcotest.(check bool) "comment vote revealed" false
+    (json_member_bool revealed_comment_json "vote_blind");
+  Alcotest.(check int) "comment revealed score" 1
+    (json_member_int revealed_comment_json "score")
 
 let test_inline_board_post_author_rewrites_caller_claim () =
   let args =
@@ -1416,6 +1502,8 @@ let () =
             `Quick test_board_dashboard_json_embeds_reaction_summaries;
           Alcotest.test_case "board dashboard json embeds moderation projection"
             `Quick test_board_dashboard_json_embeds_moderation_projection;
+          Alcotest.test_case "board dashboard json hides blind vote scores"
+            `Quick test_board_dashboard_json_hides_unvoted_scores_when_blind;
           Alcotest.test_case "inline board post author rewrites caller claim"
             `Quick test_inline_board_post_author_rewrites_caller_claim;
           Alcotest.test_case "inline board post author accepts matching alias"


### PR DESCRIPTION
## Summary

Adds a vote-blind board projection so dashboard readers do not see aggregate scores for posts/comments until the current viewer has voted.

## What changed

- Adds `blind_votes=true` support to board list/detail JSON helpers and HTTP/H2 routes.
- Wires dashboard board reads with `voter=<current actor>&blind_votes=true` and includes voter in the dashboard board cache key.
- Adds dashboard types/UI rendering for hidden vote scores as `투표 후 공개`.
- Documents the read-time projection contract in `docs/spec/11-board.md`.

## Operator impact

This is projection-only: storage, sorting, karma ledger replay, and moderation state are unchanged. The dashboard can still show the viewer's current vote state, but score fields are nulled until that viewer has voted.

## Validation

- `pnpm exec tsc --noEmit --pretty`
- `pnpm exec vitest run --config vitest.config.ts src/api/board.test.ts src/api/dashboard.test.ts src/components/board/board-surface.test.ts src/components/board/post-detail.test.ts --no-file-parallelism --maxWorkers=1` (151 tests)
- `pnpm exec eslint src/api/board.ts src/api/dashboard.ts src/components/board/board-surface.ts src/components/board/post-detail.ts src/components/ide/ide-conversation-rail-mock.ts src/api/board.test.ts src/api/dashboard.test.ts src/components/board/board-surface.test.ts src/components/board/post-detail.test.ts` (0 errors, 4 existing ignored-file warnings)
- `ocamlc -stop-after parsing ...`
- `scripts/dune-local.sh build test/test_tool_board_coverage.exe`
- `./_build/default/test/test_tool_board_coverage.exe` (74 tests)
- `git diff --cached --check`
- `scripts/check-oas-pin.sh --local-only`