### PR TITLE
feat(keeper): lift turn_timeout_sec ceiling 600 → 900s (RFC-0012/0022)

### DIFF
--- a/lib/config/env_config_keeper.ml
+++ b/lib/config/env_config_keeper.ml
@@ -442,18 +442,30 @@ module KeeperKeepalive = struct
 
   (** Hard ceiling for all keeper timeout constants (seconds).
       No timeout may exceed this value regardless of env override.
-      Default: 600 (10 minutes). *)
-  let timeout_hard_ceiling_sec = 600.0
+
+      Default: 900 (15 minutes), lifted from 600 in PR #13861's
+      RFC-0012/0022 update permitting per-cascade turn_timeout_sec
+      overrides. Local-LLM cascades that legitimately run 27 B turns
+      ≥600 s can now opt in via env or the upcoming cascade.toml
+      override; remote cascades stay at the global default 600.
+
+      Promotion to 1 800 s requires a follow-up RFC plus one week of
+      [masc_keeper_turns_total{terminated_by="turn_timeout"}] and p95
+      duration data — see RFC-0012 §Out of scope. *)
+  let timeout_hard_ceiling_sec = 900.0
 
   (** Wall-clock timeout in seconds for a single unified turn (including all
       retries and cascade fallbacks). Prevents indefinite blocking when an
       upstream LLM hangs at the TCP level.
-      Env: [MASC_KEEPER_TURN_TIMEOUT_SEC]. Default: 600. Range: [60, 600].
+      Env: [MASC_KEEPER_TURN_TIMEOUT_SEC]. Default: 600. Range: [60, 900].
 
-      The default is deliberately the global hard ceiling. Individual OAS
-      provider attempts are capped by [oas_timeout_default_sec] and
-      provider-specific bounds below, so the full turn budget remains a
-      container for fallback/retry work rather than one provider's spend. *)
+      The default stays at 600 (the prior hard ceiling) so existing
+      remote cascades keep their budget unchanged; the lifted ceiling
+      only fires when an operator opts in via env or cascade override.
+      Individual OAS provider attempts are still capped by
+      [oas_timeout_default_sec] and provider-specific bounds below, so
+      the full turn budget remains a container for fallback/retry work
+      rather than one provider's spend. *)
   let turn_timeout_sec =
     Float.max 60.0 (Float.min timeout_hard_ceiling_sec
       (get_float ~default:600.0 "MASC_KEEPER_TURN_TIMEOUT_SEC"))

--- a/lib/config/env_config_snapshot.ml
+++ b/lib/config/env_config_snapshot.ml
@@ -736,7 +736,7 @@ let keeper_keepalive_entries =
     entry ~default:"1800.0" "MASC_KEEPER_TURN_LIVELOCK_STUCK_AFTER_SEC"
       "Max seconds a keeper turn id may stay active before livelock guard blocks";
     entry ~default:"600.0" "MASC_KEEPER_TURN_TIMEOUT_SEC"
-      "Wall-clock timeout for a single unified turn (clamped 60-600 seconds)";
+      "Wall-clock timeout for a single unified turn (clamped 60-900 seconds)";
     entry ~default:"(none)" "MASC_KEEPER_WORK_AS_HEARTBEAT"
       "Successful room heartbeat after turn counts as presence proof (feature flag)";
   ]

--- a/lib/keeper/keeper_runtime_resolved.ml
+++ b/lib/keeper/keeper_runtime_resolved.ml
@@ -72,10 +72,12 @@ let autonomous_max_idle_turns_live () =
 
 let turn_timeout_sec_live () =
   (* SSOT: must match Env_config_keeper.KeeperKeepalive.turn_timeout_sec
-     (range [60, timeout_hard_ceiling_sec], default 600). Drift here was
-     the mathematical root of #10388 (1200 - 30 oas_guard = 1170s budget). *)
+     (range [60, timeout_hard_ceiling_sec=900], default 600). Drift here
+     was the mathematical root of #10388 (1200 - 30 oas_guard = 1170 s
+     budget). The 900 s ceiling was lifted from 600 in PR #13861 along
+     with the RFC-0012/0022 permission for per-cascade overrides. *)
   Float.max 60.0
-    (Float.min 600.0
+    (Float.min 900.0
        (get_float ~default:600.0 "MASC_KEEPER_TURN_TIMEOUT_SEC"))
 
 let oas_timeout_default_sec = 300.0

--- a/test/test_keeper_runtime_toml.ml
+++ b/test/test_keeper_runtime_toml.ml
@@ -547,6 +547,59 @@ let test_resolved_cli_subprocess_idle_from_toml () =
   check (float 0.0001) "cli_subprocess_idle from toml"
     45.0 (Keeper_runtime_resolved.cli_subprocess_idle_sec ())
 
+(* Step 2 (PR #13861 / RFC-0012/0022): the hard ceiling for
+   turn_timeout_sec is lifted from 600 s to 900 s so cascades that
+   legitimately run 27 B local-LLM turns can opt in via env override.
+   The default stays at 600 s so existing remote cascades keep their
+   budget unchanged. *)
+
+let test_resolved_turn_timeout_default_stays_600s () =
+  with_clean_boot_overrides @@ fun () ->
+  Keeper_runtime_resolved.init ();
+  let runtime = Keeper_runtime_resolved.current () in
+  check (float 0.0001) "turn_timeout default 600s post-lift"
+    600.0 runtime.turn_timeout_sec.value
+
+let test_resolved_turn_timeout_accepts_900s_env_override () =
+  with_clean_boot_overrides @@ fun () ->
+  with_env "MASC_KEEPER_TURN_TIMEOUT_SEC" (Some "900") @@ fun () ->
+  Keeper_runtime_resolved.init ();
+  let runtime = Keeper_runtime_resolved.current () in
+  check (float 0.0001) "env override of 900s passes new ceiling"
+    900.0 runtime.turn_timeout_sec.value
+
+let test_resolved_turn_timeout_clamps_above_900s () =
+  with_clean_boot_overrides @@ fun () ->
+  with_env "MASC_KEEPER_TURN_TIMEOUT_SEC" (Some "1800") @@ fun () ->
+  Keeper_runtime_resolved.init ();
+  let runtime = Keeper_runtime_resolved.current () in
+  check (float 0.0001) "1800s env input clamps to new 900s ceiling"
+    900.0 runtime.turn_timeout_sec.value
+
+(* #10388 budget invariant guard: with the lifted 900s ceiling, even
+   the maximum permitted turn timeout must still leave room for an
+   admission wait (default 180s) plus a minimum useful run (30s). The
+   plan-level invariant is
+     [turn_timeout - oas_guard >= admission_wait + min_useful_run]
+   with [oas_guard = 30] (#10388 origin), [admission_wait = 180] and
+   [min_useful_run = 30]. The test fails if a future change shrinks
+   the ceiling below 240s (180 + 30 + 30) or expands the admission
+   wait default past the budget. *)
+let test_budget_invariant_at_minimum_turn_timeout () =
+  with_clean_boot_overrides @@ fun () ->
+  with_env "MASC_KEEPER_TURN_TIMEOUT_SEC" (Some "240") @@ fun () ->
+  Keeper_runtime_resolved.init ();
+  let runtime = Keeper_runtime_resolved.current () in
+  let oas_guard = 30.0 in
+  let min_useful_run = 30.0 in
+  let admission_wait = runtime.admission_wait_timeout_sec.value in
+  let turn_timeout = runtime.turn_timeout_sec.value in
+  let budget_remaining =
+    turn_timeout -. oas_guard -. admission_wait -. min_useful_run
+  in
+  check bool "budget invariant holds at 240s lower bound"
+    true (budget_remaining >= 0.0)
+
 let () =
   run "keeper_runtime_toml"
     [ ( "resolve_overrides"
@@ -578,5 +631,9 @@ let () =
         ; test_case "cli subprocess idle from toml" `Quick test_resolved_cli_subprocess_idle_from_toml
         ; test_case "cli subprocess idle clamps to 10s floor" `Quick test_resolved_cli_subprocess_idle_clamps_low
         ; test_case "cli subprocess idle clamps to 600s ceiling" `Quick test_resolved_cli_subprocess_idle_clamps_high
+        ; test_case "turn_timeout default stays 600s post-lift" `Quick test_resolved_turn_timeout_default_stays_600s
+        ; test_case "turn_timeout accepts 900s env override" `Quick test_resolved_turn_timeout_accepts_900s_env_override
+        ; test_case "turn_timeout clamps above 900s ceiling" `Quick test_resolved_turn_timeout_clamps_above_900s
+        ; test_case "#10388 budget invariant holds at 240s minimum" `Quick test_budget_invariant_at_minimum_turn_timeout
         ] )
     ]

--- a/test/test_keeper_turn_timeout_default_10456.ml
+++ b/test/test_keeper_turn_timeout_default_10456.ml
@@ -1,5 +1,5 @@
 (** #10456/#10716 — pin {!Env_config_keeper.KeeperKeepalive.turn_timeout_sec}
-    SSOT default (600) and the source literal in
+    SSOT default (600) and opt-in ceiling (900) source literals in
     {!Keeper_runtime_resolved.turn_timeout_sec_live}.
 
     Original pre-fix drift was:
@@ -10,7 +10,9 @@
     #10388 cascade ollama timeout walls.
 
     The audit hard-ceiling pass later lowered the SSOT default to 600 so the
-    keeper turn envelope cannot hide long OAS provider stalls.
+    keeper turn envelope cannot hide long OAS provider stalls. RFC-0012/0022
+    then lifted only the opt-in hard ceiling to 900 so local-LLM cascades can
+    opt in without changing the checked-in remote default.
 
     This test pins the SSOT, source-level literal, and generated env snapshot
     so silent re-divergence shows up as a test failure. *)
@@ -92,10 +94,11 @@ let test_resolver_upper_matches_ssot () =
   | None -> skip ()
   | Some p ->
       let body = read_file p in
-      (* The resolver must keep the same 600s hard ceiling as
-         Env_config_keeper.KeeperKeepalive.turn_timeout_sec. *)
-      let canonical_upper = "Float.min 600.0" in
-      check bool "canonical 600 upper bound in resolver" true
+      (* The resolver must keep the same 900s opt-in hard ceiling as
+         Env_config_keeper.KeeperKeepalive.timeout_hard_ceiling_sec while
+         preserving the 600s default checked above. *)
+      let canonical_upper = "Float.min 900.0" in
+      check bool "canonical 900 upper bound in resolver" true
         (contains body canonical_upper)
 
 let test_snapshot_default_matches_ssot () =
@@ -113,7 +116,7 @@ let test_snapshot_default_matches_ssot () =
         "entry ~default:\"600.0\" \"MASC_KEEPER_TURN_TIMEOUT_SEC\""
       in
       let canonical_range =
-        "Wall-clock timeout for a single unified turn (clamped 60-600 seconds)"
+        "Wall-clock timeout for a single unified turn (clamped 60-900 seconds)"
       in
       check bool "no stale 3600 default in env snapshot" false
         (contains body stale_default);
@@ -121,7 +124,7 @@ let test_snapshot_default_matches_ssot () =
         (contains body stale_range);
       check bool "canonical 600 default in env snapshot" true
         (contains body canonical_default);
-      check bool "canonical 60-600 range in env snapshot" true
+      check bool "canonical 60-900 range in env snapshot" true
         (contains body canonical_range)
 
 let () =
@@ -136,7 +139,7 @@ let () =
         [
           test_case "resolver default literal matches SSOT (no 1200 drift)"
             `Quick test_resolver_default_matches_ssot;
-          test_case "resolver upper bound literal matches SSOT (600)" `Quick
+          test_case "resolver upper bound literal matches SSOT (900)" `Quick
             test_resolver_upper_matches_ssot;
         ] );
       ( "snapshot-drift-gate",


### PR DESCRIPTION
## Summary

Lifts the hard ceiling for `MASC_KEEPER_TURN_TIMEOUT_SEC` from 600 s to 900 s while keeping the default at 600 s. Operators can opt local/slow cascades into the extra headroom without changing checked-in remote cascade behavior.

Rebased on current `origin/main` at `e79b358e23`; head is `78a71bfdca`.

## Why

Live keeper evidence on 2026-05-06 showed repeated `stale_turn_timeout(in_turn_hung(active≈600s threshold=600s))` restarts, and the current task queue already names this as Step 2: `cascade tiered turn_timeout (clamp 600→900, per-cascade override)`. The existing `Float.min 600.0` resolver made a 900 s operator override impossible.

This PR lands the smallest runtime-safe part: lift the process/env ceiling to 900 s. It does not add a new `cascade.toml` schema yet.

## What Changed

- `lib/config/env_config_keeper.ml`: `timeout_hard_ceiling_sec` is now `900.0`; `turn_timeout_sec` default remains `600.0`.
- `lib/keeper/keeper_runtime_resolved.ml`: mirrors the same `Float.min 900.0` ceiling.
- `lib/config/env_config_snapshot.ml`: updates the generated env snapshot text to `clamped 60-900 seconds`.
- `test/test_keeper_runtime_toml.ml`: covers 600 s default, 900 s accepted, 1800 s clamped to 900 s, and the #10388 budget invariant.
- `test/test_keeper_turn_timeout_default_10456.ml`: pins 600 s as the default, 900 s as the opt-in ceiling, and the env snapshot range.

## Validation

- `ocamlc -stop-after parsing lib/config/env_config_keeper.ml`
- `ocamlc -stop-after parsing lib/keeper/keeper_runtime_resolved.ml`
- `ocamlc -stop-after parsing lib/config/env_config_snapshot.ml`
- `ocamlc -stop-after parsing test/test_keeper_runtime_toml.ml`
- `ocamlc -stop-after parsing test/test_keeper_turn_timeout_default_10456.ml`
- `git diff --check`
- `git diff --check origin/main...HEAD`
- `scripts/check-oas-pin.sh --local-only` -> `main@0cfb68c620ccd385f16fd6344b2cb003077c73c3` (`v0.190.26`)
- `scripts/oas-drift-check.sh` -> OAS API surface matches fingerprint
- `scripts/dune-local.sh build test/test_keeper_runtime_toml.exe test/test_keeper_turn_timeout_default_10456.exe`
- `./_build/default/test/test_keeper_runtime_toml.exe` (31 tests)
- `./_build/default/test/test_keeper_turn_timeout_default_10456.exe` (4 tests)

Note: the focused Dune build waited behind another repo-local lock holder before running; it completed successfully after the lock cleared.

## Out Of Scope

- `config/cascade.toml` per-cascade `turn_timeout_sec` schema/parser.
- Cascade-specific resolver plumbing.
- Raising the ceiling beyond 900 s; that still needs runtime evidence and a follow-up RFC/PR.
