### PR TITLE
fix: record work discovery nudge failures

### DIFF
--- a/lib/keeper/keeper_run_tools.ml
+++ b/lib/keeper/keeper_run_tools.ml
@@ -991,7 +991,13 @@ let prepare_agent_setup
                         (List.length tasks) n preview)
                   with
                   | Eio.Cancel.Cancelled _ as e -> raise e
-                  | _ -> None)
+                  | exn ->
+                    Keeper_callback_failure.record
+                      ~base_dir:config.base_path
+                      ~meta
+                      ~callback:"work_discovery_nudge"
+                      exn;
+                    None)
                | _ -> None)
             sources
         in

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -700,11 +700,13 @@ val metric_fsm_guard_violation : string
     row through [Keeper_callback_failure.record]. Labels: [callback]
     plus optional [keeper] at per-keeper OAS hook sites.
 
-    Lifecycle-only labels:
+    Callback-only labels:
     - [on_compaction_started] — fired from
       [Keeper_post_turn.apply_post_turn_lifecycle]
     - [on_handoff_started] — fired from
       [Keeper_rollover.maybe_rollover_oas_handoff]
+    - [work_discovery_nudge] — fired from
+      [Keeper_run_tools.prepare_agent_setup] before-turn work discovery
 
     Per-keeper hook labels:
     - [gate_tool_call_log]

--- a/test/test_keeper_callback_hardening.ml
+++ b/test/test_keeper_callback_hardening.ml
@@ -133,6 +133,7 @@ let test_documented_callback_label_vocabulary () =
       "on_tool_executed";
       "on_error";
       "on_tool_error";
+      "work_discovery_nudge";
     ]
   in
   List.iter (fun label ->


### PR DESCRIPTION
## What

- Route `discover_work_nudge` backlog-read exceptions through `Keeper_callback_failure.record` with the bounded callback label `work_discovery_nudge`.
- Preserve the existing runtime behavior: cancellation still re-raises, and non-cancellation failures still suppress the nudge by returning `None`.
- Document and pin the new callback label in the callback-hardening vocabulary test.

## Why

Before this change, a before-turn work-discovery nudge could fail while reading backlog state and disappear as a silent `None`. That made the keeper look idle/no-op even though the callback path had failed. This puts the failure on the existing lifecycle-callback counter and durable telemetry coverage-gap path.

## Validation

- `git diff --check`
- `lockf -k -t 30 /tmp/me-dune-local.lock env MASC_DUNE_LOCK_HELD=1 MASC_SKIP_OPAM_LOCK=1 DUNE_JOBS=1 DUNE_CACHE=disabled scripts/dune-local.sh build test/test_keeper_callback_hardening.exe`
- `_build/default/test/test_keeper_callback_hardening.exe`