### PR TITLE
feat(board): surface contributor quality

### DIFF
--- a/dashboard/src/api/board.test.ts
+++ b/dashboard/src/api/board.test.ts
@@ -455,6 +455,18 @@ describe('fetchBoard', () => {
           has_voted: true,
           report_count: 2,
           moderation_status: 'flagged',
+          contributor_quality: {
+            score: 0.72,
+            band: 'strong',
+            source: 'agent_reputation',
+            completion_rate: 0.8,
+            response_rate: 0.6,
+            board_posts: 3,
+            board_comments: 5,
+            accountability_score: 0.9,
+            autonomy_level: 'elevated',
+            thompson_confidence: 0.7,
+          },
           reactions: [
             {
               emoji: '🔥',
@@ -490,6 +502,18 @@ describe('fetchBoard', () => {
       has_voted: true,
       report_count: 2,
       moderation_status: 'flagged',
+      contributor_quality: {
+        score: 0.72,
+        band: 'strong',
+        source: 'agent_reputation',
+        completion_rate: 0.8,
+        response_rate: 0.6,
+        board_posts: 3,
+        board_comments: 5,
+        accountability_score: 0.9,
+        autonomy_level: 'elevated',
+        thompson_confidence: 0.7,
+      },
       reactions: [
         {
           emoji: '🔥',

--- a/dashboard/src/api/board.ts
+++ b/dashboard/src/api/board.ts
@@ -4,7 +4,7 @@ import { timeBoardRequest } from '../board-metrics'
 import type {
   BoardActorIdentity, BoardPost, BoardComment, BoardReactionSummary,
   BoardReactionTargetType, BoardReactionToggleResult, BoardSortMode,
-  BoardVoteDirection, BoardModerationStatus,
+  BoardVoteDirection, BoardModerationStatus, BoardContributorQuality,
   BoardCurationSnapshot, BoardKarmaLedger, BoardKarmaLedgerEvent, BoardKarmaTotal,
   GovernanceContextRef,
   GovernanceDecisionItem, GovernanceExecutedRoute,
@@ -353,6 +353,24 @@ function normalizeBoardModerationStatus(raw: unknown): BoardModerationStatus {
   }
 }
 
+function normalizeBoardContributorQuality(raw: unknown): BoardContributorQuality | null {
+  if (!isRecord(raw)) return null
+  const score = asNumber(raw.score)
+  if (score === undefined) return null
+  return {
+    score,
+    band: asString(raw.band, '').trim() || undefined,
+    source: asString(raw.source, '').trim() || undefined,
+    completion_rate: asNumber(raw.completion_rate),
+    response_rate: asNumber(raw.response_rate),
+    board_posts: asNumber(raw.board_posts),
+    board_comments: asNumber(raw.board_comments),
+    accountability_score: asNumber(raw.accountability_score),
+    autonomy_level: asString(raw.autonomy_level, '').trim() || undefined,
+    thompson_confidence: asNumber(raw.thompson_confidence),
+  }
+}
+
 function normalizeBoardPost(raw: unknown): BoardPost | null {
   if (!isRecord(raw)) return null
   const id = asString(raw.id, '').trim()
@@ -433,6 +451,7 @@ function normalizeBoardPost(raw: unknown): BoardPost | null {
     hearth_count: asNumber(raw.hearth_count, 0),
     report_count: Math.max(0, Math.trunc(asNumber(raw.report_count, 0))),
     moderation_status: normalizeBoardModerationStatus(raw.moderation_status),
+    contributor_quality: normalizeBoardContributorQuality(raw.contributor_quality),
     ...(reactions !== undefined ? { reactions } : {}),
   }
 }

--- a/dashboard/src/components/board/board-surface.test.ts
+++ b/dashboard/src/components/board/board-surface.test.ts
@@ -273,6 +273,26 @@ describe('BoardSurface Component', () => {
     expect(screen.getByLabelText('점수 투표 후 공개')).toHaveTextContent('투표 후 공개')
   })
 
+  it('renders contributor quality badges on post cards', () => {
+    boardPosts.value = [
+      makePost({
+        id: 'post-quality',
+        title: 'Quality signal',
+        body: 'content',
+        author: 'ani1999',
+        contributor_quality: {
+          score: 0.72,
+          band: 'strong',
+          source: 'agent_reputation',
+        },
+      }),
+    ]
+
+    render(h(BoardSurface, null))
+
+    expect(screen.getByLabelText('기여자 품질 72점 · 강함')).toHaveTextContent('품질 72')
+  })
+
   it('routes the mention inbox focus to the message surface', () => {
     route.value = { params: { focus: 'mention-inbox' } } as any
     messages.value = [{ id: 'm-1', from: 'sojin', content: '@dashboard needs review' }]

--- a/dashboard/src/components/board/board-surface.ts
+++ b/dashboard/src/components/board/board-surface.ts
@@ -29,6 +29,9 @@ import {
   boardActorAvatarKey,
   boardActorDisplayName,
   boardActorTitle,
+  contributorQualityBadgeClass,
+  contributorQualityBandLabel,
+  contributorQualityPercent,
   navigateToAuthor,
   stripInlineMarkdown,
 } from '../../lib/board-utils'
@@ -580,6 +583,11 @@ function PostCard({ post }: { post: BoardPost }) {
   const authorLabel = boardActorDisplayName(post.author, post.author_identity)
   const authorAvatarKey = boardActorAvatarKey(post.author, post.author_identity)
   const authorTitle = boardActorTitle(post.author, post.author_identity)
+  const qualityPercent = contributorQualityPercent(post.contributor_quality)
+  const qualityBand = contributorQualityBandLabel(post.contributor_quality)
+  const qualityTitle = qualityPercent === null
+    ? undefined
+    : `기여자 품질 ${qualityPercent}점 · ${qualityBand}`
   const upvoteActive = post.current_vote === 'up'
   const downvoteActive = post.current_vote === 'down'
   const voteScoreLabel = post.vote_blind ? '투표 후 공개' : String(post.votes ?? 0)
@@ -704,6 +712,13 @@ function PostCard({ post }: { post: BoardPost }) {
 
           <!-- Category badges -->
           <span class="inline-flex items-center px-1.5 py-0.5 rounded-[var(--r-1)] text-3xs font-medium border ${categoryBadgeColor(cat)}">${categoryLabel(cat)}</span>
+          ${qualityPercent !== null ? html`
+            <span
+              class=${`inline-flex items-center px-1.5 py-0.5 rounded-[var(--r-1)] text-3xs font-medium border ${contributorQualityBadgeClass(post.contributor_quality)}`}
+              aria-label=${qualityTitle}
+              title=${qualityTitle}
+            >품질 ${qualityPercent}</span>
+          ` : null}
           ${post.hearth ? html`<span class="inline-flex items-center px-1.5 py-0.5 rounded-[var(--r-1)] text-3xs font-medium border bg-[var(--ff-gold-10)] text-[var(--ff-gold-bright)] border-[var(--ff-gold-20)]">${post.hearth}</span>` : null}
           ${post.visibility && visibilityLabel(post.visibility) ? html`<span class="inline-flex items-center px-1.5 py-0.5 rounded-[var(--r-1)] text-3xs font-medium border ${visibilityBadgeColor(post.visibility)}">${visibilityLabel(post.visibility)}</span>` : null}
           <${ModerationBadge} status=${post.moderation_status} reportCount=${post.report_count} targetLabel="게시글" />

--- a/dashboard/src/components/board/post-detail.test.ts
+++ b/dashboard/src/components/board/post-detail.test.ts
@@ -459,6 +459,11 @@ describe('PostDetail', () => {
       classification_reason: 'Direct board post without automation provenance.',
       report_count: 1,
       moderation_status: 'approved',
+      contributor_quality: {
+        score: 0.91,
+        band: 'excellent',
+        source: 'agent_reputation',
+      },
       comments: [],
     } as any
 
@@ -468,6 +473,7 @@ describe('PostDetail', () => {
     expect(screen.getByText(/Direct board post without automation provenance/)).toBeInTheDocument()
     expect(screen.getByText('직접')).toBeInTheDocument()
     expect(screen.getByLabelText('게시글 moderation 승인됨 1건')).toHaveTextContent('승인됨 1')
+    expect(screen.getByLabelText('기여자 품질 91점 · 우수')).toHaveTextContent('품질 91')
   })
 
   it('marks the current post vote as pressed', async () => {

--- a/dashboard/src/components/board/post-detail.test.ts
+++ b/dashboard/src/components/board/post-detail.test.ts
@@ -476,6 +476,32 @@ describe('PostDetail', () => {
     expect(screen.getByLabelText('기여자 품질 91점 · 우수')).toHaveTextContent('품질 91')
   })
 
+  it('renders contributor quality when it is the only detail badge', () => {
+    const post = {
+      id: 'post-quality',
+      author: 'sleepers',
+      title: 'Post',
+      body: 'Body',
+      content: 'Body',
+      created_at: '2026-04-02T00:00:00Z',
+      updated_at: '2026-04-02T00:00:00Z',
+      votes: 0,
+      comment_count: 0,
+      post_kind: 'direct',
+      moderation_status: 'none',
+      contributor_quality: {
+        score: 0.42,
+        band: 'watch',
+        source: 'agent_reputation',
+      },
+      comments: [],
+    } as any
+
+    render(h(PostDetail, { post }))
+
+    expect(screen.getByLabelText('기여자 품질 42점 · 관찰')).toHaveTextContent('품질 42')
+  })
+
   it('marks the current post vote as pressed', async () => {
     const post = {
       id: 'post-1',

--- a/dashboard/src/components/board/post-detail.ts
+++ b/dashboard/src/components/board/post-detail.ts
@@ -494,7 +494,7 @@ export function PostDetail({ post }: { post: BoardPost }) {
           </div>
 
           <!-- Badges -->
-          ${(post.hearth || post.visibility || post.expires_at || post.classification_reason || (post.moderation_status && post.moderation_status !== 'none') || (post.report_count ?? 0) > 0)
+          ${(post.hearth || post.visibility || post.expires_at || post.classification_reason || qualityPercent !== null || (post.moderation_status && post.moderation_status !== 'none') || (post.report_count ?? 0) > 0)
             ? html`
                 <div class="flex flex-col gap-2">
                   <div class="flex gap-1.5 flex-wrap">

--- a/dashboard/src/components/board/post-detail.ts
+++ b/dashboard/src/components/board/post-detail.ts
@@ -18,6 +18,9 @@ import {
   boardActorAvatarKey,
   boardActorDisplayName,
   boardActorTitle,
+  contributorQualityBadgeClass,
+  contributorQualityBandLabel,
+  contributorQualityPercent,
   navigateToAuthor,
 } from '../../lib/board-utils'
 import {
@@ -449,6 +452,11 @@ export function PostDetail({ post }: { post: BoardPost }) {
   const authorLabel = boardActorDisplayName(post.author, post.author_identity)
   const authorAvatarKey = boardActorAvatarKey(post.author, post.author_identity)
   const authorTitle = boardActorTitle(post.author, post.author_identity)
+  const qualityPercent = contributorQualityPercent(post.contributor_quality)
+  const qualityBand = contributorQualityBandLabel(post.contributor_quality)
+  const qualityTitle = qualityPercent === null
+    ? undefined
+    : `기여자 품질 ${qualityPercent}점 · ${qualityBand}`
   const upvoteActive = post.current_vote === 'up'
   const downvoteActive = post.current_vote === 'down'
   const postVoteLabel = post.vote_blind ? '투표 후 공개' : `${post.votes ?? 0} votes`
@@ -493,6 +501,13 @@ export function PostDetail({ post }: { post: BoardPost }) {
                     ${post.hearth ? html`<span class="inline-flex items-center px-2 py-0.5 rounded-[var(--r-1)] text-3xs font-medium border bg-[var(--ff-gold-10)] text-[var(--ff-gold-bright)] border-[var(--ff-gold-20)]">${post.hearth}</span>` : null}
                     ${post.visibility && visibilityLabel(post.visibility) ? html`<span class="inline-flex items-center px-2 py-0.5 rounded-[var(--r-1)] text-3xs font-medium border ${visibilityBadgeColor(post.visibility)}">${visibilityLabel(post.visibility)}</span>` : null}
                     <span class="inline-flex items-center px-2 py-0.5 rounded-[var(--r-1)] text-3xs font-medium border ${kindBadgeColor(boardPostKind(post))}">${kindLabel(boardPostKind(post))}</span>
+                    ${qualityPercent !== null ? html`
+                      <span
+                        class=${`inline-flex items-center px-2 py-0.5 rounded-[var(--r-1)] text-3xs font-medium border ${contributorQualityBadgeClass(post.contributor_quality)}`}
+                        aria-label=${qualityTitle}
+                        title=${qualityTitle}
+                      >품질 ${qualityPercent}</span>
+                    ` : null}
                     ${expiryChip(post)}
                     <${ModerationBadge} status=${post.moderation_status} reportCount=${post.report_count} targetLabel="게시글" />
                   </div>

--- a/dashboard/src/lib/board-utils.ts
+++ b/dashboard/src/lib/board-utils.ts
@@ -3,7 +3,7 @@
 import { navigate } from '../router'
 import { findKeeper } from './keeper-utils'
 import { openKeeperDetail } from '../components/keeper-detail'
-import type { BoardActorIdentity } from '../types'
+import type { BoardActorIdentity, BoardContributorQuality } from '../types'
 
 /** Strip inline markdown formatting from title text (bold, italic, code). */
 export function stripInlineMarkdown(text: string): string {
@@ -48,6 +48,40 @@ export function boardActorTitle(
   const runtime = boardActorRuntimeName(authorName, identity)
   const display = boardActorDisplayName(authorName, identity)
   return runtime && runtime !== display ? `런타임 ${runtime}` : undefined
+}
+
+export function contributorQualityPercent(quality?: BoardContributorQuality | null): number | null {
+  if (!quality || !Number.isFinite(quality.score)) return null
+  return Math.max(0, Math.min(100, Math.round(quality.score * 100)))
+}
+
+export function contributorQualityBandLabel(quality?: BoardContributorQuality | null): string {
+  switch (quality?.band) {
+    case 'excellent':
+      return '우수'
+    case 'strong':
+      return '강함'
+    case 'watch':
+      return '관찰'
+    case 'low':
+      return '낮음'
+    default:
+      return '품질'
+  }
+}
+
+export function contributorQualityBadgeClass(quality?: BoardContributorQuality | null): string {
+  switch (quality?.band) {
+    case 'excellent':
+    case 'strong':
+      return 'bg-[var(--ok-10)] text-[var(--ok-fg)] border-[var(--ok-20)]'
+    case 'watch':
+      return 'bg-[var(--warn-10)] text-[var(--warn-bright)] border-[var(--warn-20)]'
+    case 'low':
+      return 'bg-[var(--bad-10)] text-[var(--bad-light)] border-[var(--bad-20)]'
+    default:
+      return 'bg-[var(--color-bg-muted)] text-[var(--color-fg-muted)] border-[var(--color-border-divider)]'
+  }
 }
 
 /** Navigate to keeper detail if author is a keeper, otherwise agent profile. */

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -120,6 +120,19 @@ type BoardPostMeta = Record<string, unknown> & {
 export type BoardVoteDirection = 'up' | 'down'
 export type BoardModerationStatus = 'none' | 'flagged' | 'approved' | 'removed' | 'hidden' | 'warned'
 
+export interface BoardContributorQuality {
+  score: number
+  band?: 'low' | 'watch' | 'strong' | 'excellent' | string
+  source?: string
+  completion_rate?: number
+  response_rate?: number
+  board_posts?: number
+  board_comments?: number
+  accountability_score?: number
+  autonomy_level?: string
+  thompson_confidence?: number
+}
+
 export interface BoardActorIdentity {
   kind: 'keeper' | 'agent'
   id: string
@@ -157,6 +170,7 @@ export interface BoardPost {
   hearth_count?: number
   report_count?: number
   moderation_status?: BoardModerationStatus
+  contributor_quality?: BoardContributorQuality | null
   reactions?: BoardReactionSummary[]
 }
 

--- a/docs/spec/11-board.md
+++ b/docs/spec/11-board.md
@@ -341,6 +341,33 @@ After that viewer votes, the same row emits `vote_blind: false` and the
 normal score fields.  This is a read-time projection only: it does not
 change storage, sorting, karma ledger replay, or moderation state.
 
+### 9a.7 Contributor Quality Projection
+
+Board post read paths may include `contributor_quality`, a compact
+projection of the existing `Agent_reputation` score for the post author.
+It is request-time derived data and does not create new board storage.
+
+```json
+{
+  "contributor_quality": {
+    "score": 0.72,
+    "band": "strong",
+    "source": "agent_reputation",
+    "completion_rate": 0.8,
+    "response_rate": 0.6,
+    "board_posts": 3,
+    "board_comments": 5,
+    "accountability_score": 0.9,
+    "autonomy_level": "elevated",
+    "thompson_confidence": 0.7
+  }
+}
+```
+
+`band` is a UI hint derived from `score`: `excellent` (>= 0.85),
+`strong` (>= 0.65), `watch` (>= 0.35), otherwise `low`. This projection
+is advisory only; sorting, moderation, karma ledger replay, and author
+permissions remain unchanged.
 
 
 ## 10. MCP Tool Surface

--- a/lib/server/server_dashboard_http.ml
+++ b/lib/server/server_dashboard_http.ml
@@ -19,19 +19,25 @@ let dashboard_namespace_truth_focus_json =
 let dashboard_namespace_truth_http_json =
   Server_dashboard_http_namespace_truth.dashboard_namespace_truth_http_json
 
-let dashboard_board_json ?hearth ?author_filter
+let dashboard_board_json ?config ?hearth ?author_filter
     ?(sort_by = Board_dispatch.Hot) ?(exclude_system = false)
     ?(exclude_automation = false) ?(limit = 100) ?(offset = 0) ?voter
     ?(blind_votes = false) () : Yojson.Safe.t =
   let limit = clamp ~min_v:1 ~max_v:500 limit in
   let offset = clamp ~min_v:0 ~max_v:5000 offset in
   let author_filter = Option.map board_actor_author_for_write author_filter in
+  let config_key =
+    match config with
+    | None -> "-"
+    | Some config -> config.Coord.base_path
+  in
   let cache_key =
-    Printf.sprintf "board:memory:%s;%s;%s;%b;%b;%d;%d;%s;%b"
+    Printf.sprintf "board:memory:%s;%s;%s;%b;%b;%d;%d;%s;%s;%b"
       (Option.value ~default:"-" hearth)
       (Option.value ~default:"-" author_filter)
       (board_sort_label sort_by)
       exclude_system exclude_automation limit offset
+      config_key
       (Option.value ~default:"-" voter)
       blind_votes
   in
@@ -56,13 +62,16 @@ let dashboard_board_json ?hearth ?author_filter
       if has_more then `Null else `Int fetched_len
     in
     let paged = posts |> drop offset |> take limit in
+    let contributor_quality_for = board_contributor_quality_lookup ?config () in
     let posts_json =
       List.map
         (fun (post : Board.post) ->
           let author = Board.Agent_id.to_string post.author in
           let post_id = Board.Post_id.to_string post.id in
           let current_vote = board_current_vote_for_post ~voter ~post_id in
+          let contributor_quality = contributor_quality_for author in
           board_post_dashboard_json ~blind_votes ?current_vote
+            ?contributor_quality
             ~author_karma:(get_karma author) post)
         paged
     in
@@ -86,7 +95,7 @@ let dashboard_board_json ?hearth ?author_filter
         ("sort_by", `String (board_sort_label sort_by));
       ])
 
-let dashboard_memory_http_json request : Yojson.Safe.t =
+let dashboard_memory_http_json ?config request : Yojson.Safe.t =
   let hearth = query_param request "hearth" in
   let author_filter =
     query_param request "author"
@@ -107,7 +116,7 @@ let dashboard_memory_http_json request : Yojson.Safe.t =
   in
   let voter = board_voter_query request in
   let blind_votes = bool_query_param request "blind_votes" ~default:false in
-  dashboard_board_json ?hearth ?author_filter ~sort_by ~exclude_system
+  dashboard_board_json ?config ?hearth ?author_filter ~sort_by ~exclude_system
     ~exclude_automation ~limit ~offset ?voter ~blind_votes ()
 
 let memory_subsystems_entry_cache_ttl_sec = 30.0

--- a/lib/server/server_dashboard_http.mli
+++ b/lib/server/server_dashboard_http.mli
@@ -47,6 +47,7 @@ val approval_resolve_http_error_to_string :
 (** {1 Board / memory / governance HTTP entries} *)
 
 val dashboard_board_json :
+  ?config:Coord.config ->
   ?hearth:string ->
   ?author_filter:string ->
   ?sort_by:Board_dispatch.sort_order ->
@@ -60,7 +61,7 @@ val dashboard_board_json :
   Yojson.Safe.t
 
 val dashboard_memory_http_json :
-  Httpun.Request.t -> Yojson.Safe.t
+  ?config:Coord.config -> Httpun.Request.t -> Yojson.Safe.t
 
 val dashboard_memory_subsystems_include_entries :
   Httpun.Request.t -> bool

--- a/lib/server/server_h2_gateway.ml
+++ b/lib/server/server_h2_gateway.ml
@@ -975,7 +975,9 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
       (* ═══════════════════════════════════════════════════════════════════════
          Delegated route groups
          ═══════════════════════════════════════════════════════════════════════ *)
-      | _ when Server_h2_gateway_routes_extra.dispatch ~h2_reqd ~httpun_request ~cors ~path httpun_meth -> ()
+      | _ when Server_h2_gateway_routes_extra.dispatch ~h2_reqd ~httpun_request
+                 ~cors ~path ~config:state.Mcp_server.room_config httpun_meth ->
+          ()
 
       (* ─────────────────────────────────────────────────────────────────────
          Fallback

--- a/lib/server/server_h2_gateway.ml
+++ b/lib/server/server_h2_gateway.ml
@@ -975,8 +975,14 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
       (* ═══════════════════════════════════════════════════════════════════════
          Delegated route groups
          ═══════════════════════════════════════════════════════════════════════ *)
-      | _ when Server_h2_gateway_routes_extra.dispatch ~h2_reqd ~httpun_request
-                 ~cors ~path ~config:state.Mcp_server.room_config httpun_meth ->
+      | _
+        when Server_h2_gateway_routes_extra.dispatch ~h2_reqd ~httpun_request
+               ~cors ~path
+               ~config:
+                 (Option.map
+                    (fun state -> state.Mcp_server.room_config)
+                    !server_state)
+               httpun_meth ->
           ()
 
       (* ─────────────────────────────────────────────────────────────────────

--- a/lib/server/server_h2_gateway_routes_extra.ml
+++ b/lib/server/server_h2_gateway_routes_extra.ml
@@ -6,7 +6,7 @@ open Server_h2_gateway_helpers
 
 (* Dispatch board, governance, voice, karma, and static asset routes.
    Returns [true] if the route was handled, [false] otherwise. *)
-let dispatch ~h2_reqd ~httpun_request ~cors ~path
+let dispatch ~h2_reqd ~httpun_request ~cors ~path ~config
     (httpun_meth : [ `GET | `POST | `DELETE | `OPTIONS | `PUT | `HEAD
                     | `CONNECT | `TRACE | `Other of string ]) =
   match httpun_meth, path with
@@ -56,13 +56,17 @@ let dispatch ~h2_reqd ~httpun_request ~cors ~path
           ~voter
       in
       let reactions_for = board_reactions_lookup reaction_rows in
+      let contributor_quality_for =
+        board_contributor_quality_lookup ~config ()
+      in
       let posts_json = List.map (fun (p : Board.post) ->
         let author = Board.Agent_id.to_string p.author in
         let post_id = Board.Post_id.to_string p.id in
         let current_vote = board_current_vote_for_post ~voter ~post_id in
         let reactions = reactions_for (Board.Reaction_post, post_id) in
+        let contributor_quality = contributor_quality_for author in
         board_post_dashboard_json ~blind_votes ?current_vote ~reactions
-          ~author_karma:(get_karma author) p
+          ?contributor_quality ~author_karma:(get_karma author) p
       ) paged in
       let json = `Assoc [
         ("posts", `List posts_json);
@@ -111,6 +115,7 @@ let dispatch ~h2_reqd ~httpun_request ~cors ~path
       in
       let (status, body) =
         board_post_detail_json ~include_moderation:false ~blind_votes ~voter
+          ~config:(Some config)
           ~response_format:format ~post_id
       in
       h2_respond_json h2_reqd body ~status ~extra_headers:cors;

--- a/lib/server/server_h2_gateway_routes_extra.ml
+++ b/lib/server/server_h2_gateway_routes_extra.ml
@@ -56,9 +56,7 @@ let dispatch ~h2_reqd ~httpun_request ~cors ~path ~config
           ~voter
       in
       let reactions_for = board_reactions_lookup reaction_rows in
-      let contributor_quality_for =
-        board_contributor_quality_lookup ~config ()
-      in
+      let contributor_quality_for = board_contributor_quality_lookup ?config () in
       let posts_json = List.map (fun (p : Board.post) ->
         let author = Board.Agent_id.to_string p.author in
         let post_id = Board.Post_id.to_string p.id in
@@ -115,7 +113,7 @@ let dispatch ~h2_reqd ~httpun_request ~cors ~path ~config
       in
       let (status, body) =
         board_post_detail_json ~include_moderation:false ~blind_votes ~voter
-          ~config:(Some config)
+          ~config
           ~response_format:format ~post_id
       in
       h2_respond_json h2_reqd body ~status ~extra_headers:cors;

--- a/lib/server/server_h2_gateway_routes_extra.mli
+++ b/lib/server/server_h2_gateway_routes_extra.mli
@@ -11,10 +11,11 @@ val dispatch :
   httpun_request:Httpun.Request.t ->
   cors:(string * string) list ->
   path:string ->
+  config:Coord.config ->
   [ `GET | `POST | `DELETE | `OPTIONS | `PUT | `HEAD
   | `CONNECT | `TRACE | `Other of string ] ->
   bool
-(** [dispatch ~h2_reqd ~httpun_request ~cors ~path method_]
+(** [dispatch ~h2_reqd ~httpun_request ~cors ~path ~config method_]
     handles the following routes:
 
     {2 Voice config}

--- a/lib/server/server_h2_gateway_routes_extra.mli
+++ b/lib/server/server_h2_gateway_routes_extra.mli
@@ -11,7 +11,7 @@ val dispatch :
   httpun_request:Httpun.Request.t ->
   cors:(string * string) list ->
   path:string ->
-  config:Coord.config ->
+  config:Coord.config option ->
   [ `GET | `POST | `DELETE | `OPTIONS | `PUT | `HEAD
   | `CONNECT | `TRACE | `Other of string ] ->
   bool

--- a/lib/server/server_routes_http_routes_activity.ml
+++ b/lib/server/server_routes_http_routes_activity.ml
@@ -252,6 +252,10 @@ let add_routes ~sw ~clock router =
              ~voter
          in
          let reactions_for = board_reactions_lookup reaction_rows in
+         let contributor_quality_for =
+           board_contributor_quality_lookup
+             ~config:state.Mcp_server.room_config ()
+         in
          let posts_json =
            List.map
              (fun (p : Board.post) ->
@@ -259,8 +263,10 @@ let add_routes ~sw ~clock router =
                let post_id = Board.Post_id.to_string p.id in
                let current_vote = board_current_vote_for_post ~voter ~post_id in
                let reactions = reactions_for (Board.Reaction_post, post_id) in
+               let contributor_quality = contributor_quality_for author in
                board_post_dashboard_json ~include_moderation ~blind_votes
-                 ?current_vote ~reactions
+                 ?contributor_quality ~reactions
+                 ?current_vote
                  ~author_karma:(get_karma author) p)
              paged
          in
@@ -384,6 +390,7 @@ let add_routes ~sw ~clock router =
               in
               let (status, body) =
                 board_post_detail_json ~include_moderation ~blind_votes ~voter
+                  ~config:(Some state.Mcp_server.room_config)
                   ~response_format:format ~post_id
               in
               respond_json_with_cors ~status request reqd body)

--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -534,8 +534,10 @@ let rec add_routes ~sw ~clock router =
            (Yojson.Safe.to_string json) reqd
        ) request reqd)
   |> Http.Router.get "/api/v1/dashboard/board" (fun request reqd ->
-       with_public_read (fun _state req reqd ->
-         let json = dashboard_memory_http_json req in
+       with_public_read (fun state req reqd ->
+         let json =
+           dashboard_memory_http_json ~config:state.Mcp_server.room_config req
+         in
          Http.Response.json ~compress:true ~request:req (Yojson.Safe.to_string json) reqd
        ) request reqd)
   |> Http.Router.post "/api/v1/dashboard/link-previews" (fun request reqd ->

--- a/lib/server/server_routes_http_runtime.ml
+++ b/lib/server/server_routes_http_runtime.ml
@@ -294,7 +294,7 @@ let readiness_handler _request reqd =
             ]))
       reqd
 
-let board_post_detail_json ~include_moderation ~blind_votes ~voter
+let board_post_detail_json ~include_moderation ~blind_votes ~config ~voter
     ~response_format ~post_id =
   match Board_dispatch.get_post ~post_id with
   | Error err ->
@@ -322,9 +322,12 @@ let board_post_detail_json ~include_moderation ~blind_votes ~voter
       let reaction_rows = board_reactions_batch ~targets:reaction_targets ~voter in
       let reactions_for = board_reactions_lookup reaction_rows in
       let reactions = reactions_for (Board.Reaction_post, post_id) in
+      let contributor_quality =
+        board_contributor_quality_lookup ?config () author
+      in
       let post_json =
         board_post_dashboard_json ~include_moderation ~blind_votes ?current_vote
-          ~reactions ~author_karma post
+          ?contributor_quality ~reactions ~author_karma post
       in
       let comments_json =
         `List (List.map (fun (comment : Board.comment) ->

--- a/lib/server/server_routes_http_runtime.mli
+++ b/lib/server/server_routes_http_runtime.mli
@@ -163,6 +163,7 @@ val readiness_handler : Httpun.Request.t -> Httpun.Reqd.t -> unit
 val board_post_detail_json :
   include_moderation:bool ->
   blind_votes:bool ->
+  config:Coord.config option ->
   voter:string option ->
   response_format:string ->
   post_id:string ->
@@ -173,6 +174,10 @@ val board_post_detail_json :
     that voter.  When [include_moderation] is [true], rows also include
     operator-only moderation projection fields.  When [blind_votes] is
     [true], rows hide score fields until that voter has voted.
+    operator-only moderation projection fields.  When [config] is
+    supplied, post rows include contributor-quality projection fields.
+    When [blind_votes] is [true], rows hide score fields until that
+    voter has voted.
 
     {2 response_format values (case-insensitive, trimmed)}
 

--- a/lib/server/server_utils.ml
+++ b/lib/server/server_utils.ml
@@ -266,8 +266,9 @@ let board_contributor_quality_fields = function
   | None -> []
   | Some quality -> [ ("contributor_quality", quality) ]
 
-let board_comment_dashboard_json ?(include_moderation = false) ?current_vote
-    ?(blind_votes = false) ?reactions (c : Board.comment) : Yojson.Safe.t =
+let board_comment_dashboard_json ?(include_moderation = false)
+    ?(blind_votes = false) ?current_vote ?reactions (c : Board.comment) :
+    Yojson.Safe.t =
   let author = Board.Agent_id.to_string c.author in
   let comment_id = Board.Comment_id.to_string c.id in
   match Board.comment_to_yojson c with

--- a/lib/server/server_utils.ml
+++ b/lib/server/server_utils.ml
@@ -213,9 +213,61 @@ let board_moderation_fields ~include_moderation ~target_kind ~target_id =
       ("moderation_status", `String summary.Board_moderation.moderation_status);
     ]
 
-let board_comment_dashboard_json ?(include_moderation = false)
-    ?(blind_votes = false) ?current_vote ?reactions (c : Board.comment) :
-    Yojson.Safe.t =
+let board_contributor_quality_band score =
+  if score >= 0.85 then "excellent"
+  else if score >= 0.65 then "strong"
+  else if score >= 0.35 then "watch"
+  else "low"
+
+let board_contributor_quality_json
+    (rep : Agent_reputation.agent_reputation) : Yojson.Safe.t =
+  `Assoc
+    [
+      ("score", `Float rep.overall_score);
+      ("band", `String (board_contributor_quality_band rep.overall_score));
+      ("source", `String "agent_reputation");
+      ("completion_rate", `Float rep.completion_rate);
+      ("response_rate", `Float rep.response_rate);
+      ("board_posts", `Int rep.board_posts);
+      ("board_comments", `Int rep.board_comments);
+      ("accountability_score", `Float rep.accountability_score);
+      ("autonomy_level", `String rep.autonomy_level);
+      ("thompson_confidence", `Float rep.thompson_confidence);
+    ]
+
+let board_contributor_quality_lookup ?config () =
+  match config with
+  | None -> fun _author -> None
+  | Some config ->
+      let cache = Hashtbl.create 16 in
+      fun author ->
+        match Hashtbl.find_opt cache author with
+        | Some value -> value
+        | None ->
+            let value =
+              try
+                let rep =
+                  Agent_reputation.compute_reputation config
+                    ~agent_name:author
+                in
+                Some (board_contributor_quality_json rep)
+              with
+              | Eio.Cancel.Cancelled _ as e -> raise e
+              | exn ->
+                  Log.Server.warn
+                    "board contributor quality failed for %s: %s" author
+                    (Printexc.to_string exn);
+                  None
+            in
+            Hashtbl.replace cache author value;
+            value
+
+let board_contributor_quality_fields = function
+  | None -> []
+  | Some quality -> [ ("contributor_quality", quality) ]
+
+let board_comment_dashboard_json ?(include_moderation = false) ?current_vote
+    ?(blind_votes = false) ?reactions (c : Board.comment) : Yojson.Safe.t =
   let author = Board.Agent_id.to_string c.author in
   let comment_id = Board.Comment_id.to_string c.id in
   match Board.comment_to_yojson c with
@@ -244,7 +296,8 @@ let board_comment_dashboard_json ?(include_moderation = false)
   | other -> other
 
 let board_post_dashboard_json ?(include_moderation = false)
-    ?(blind_votes = false) ?current_vote ?reactions ~author_karma
+    ?(blind_votes = false) ?contributor_quality ?current_vote ?reactions
+    ~author_karma
     (p : Board.post) : Yojson.Safe.t =
   let author = Board.Agent_id.to_string p.author in
   let post_id = Board.Post_id.to_string p.id in
@@ -288,6 +341,7 @@ let board_post_dashboard_json ?(include_moderation = false)
       @ board_moderation_fields ~include_moderation
           ~target_kind:Board_moderation.Target_post
           ~target_id:post_id
+      @ board_contributor_quality_fields contributor_quality
       @ board_vote_blind_fields ~blind_active
       @ board_vote_state_fields current_vote
       @ board_reaction_fields reactions )

--- a/lib/server/server_utils.mli
+++ b/lib/server/server_utils.mli
@@ -171,6 +171,16 @@ val board_reactions_lookup :
   Board.reaction_target_type * string ->
   Board.reaction_summary list
 
+val board_contributor_quality_json :
+  Agent_reputation.agent_reputation -> Yojson.Safe.t
+(** [board_contributor_quality_json rep] projects the existing agent
+    reputation record into the compact board contributor-quality contract. *)
+
+val board_contributor_quality_lookup :
+  ?config:Coord.config -> unit -> string -> Yojson.Safe.t option
+(** [board_contributor_quality_lookup ?config ()] returns a request-local
+    memoized lookup by author.  Without [config], it returns [None]. *)
+
 (** {1 Dashboard helpers} *)
 
 val board_comment_dashboard_json :
@@ -190,6 +200,7 @@ val board_comment_dashboard_json :
 val board_post_dashboard_json :
   ?include_moderation:bool ->
   ?blind_votes:bool ->
+  ?contributor_quality:Yojson.Safe.t ->
   ?current_vote:Board.vote_direction option ->
   ?reactions:Board.reaction_summary list ->
   author_karma:int ->
@@ -210,6 +221,8 @@ val board_post_dashboard_json :
       only when [include_moderation] is [true].
     - [vote_blind] / [vote_blind_reason] and null score fields when
       [blind_votes] is [true] and the viewer has not voted yet.
+    - [contributor_quality] when supplied by the route layer from
+      {!Agent_reputation}.
 
     The base fields [title] / [votes] / [comment_count] /
     [created_at_iso] / [updated_at_iso] / [hearth_count] are

--- a/test/test_tool_board_coverage.ml
+++ b/test/test_tool_board_coverage.ml
@@ -425,6 +425,50 @@ let test_board_dashboard_json_hides_unvoted_scores_when_blind () =
   Alcotest.(check int) "comment revealed score" 1
     (json_member_int revealed_comment_json "score")
 
+let test_board_dashboard_json_embeds_contributor_quality () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  cleanup ();
+  let post =
+    match
+      Board_dispatch.create_post ~author:"quality-author"
+        ~content:"quality projection post" ~post_kind:Board.Human_post ()
+    with
+    | Ok post -> post
+    | Error e -> Alcotest.fail (Board.show_board_error e)
+  in
+  let rep =
+    {
+      (Agent_reputation.default_reputation ~agent_name:"quality-author") with
+      overall_score = 0.72;
+      completion_rate = 0.8;
+      response_rate = 0.6;
+      board_posts = 3;
+      board_comments = 5;
+      accountability_score = 0.9;
+      autonomy_level = "elevated";
+      thompson_confidence = 0.7;
+    }
+  in
+  let contributor_quality =
+    Server_utils.board_contributor_quality_json rep
+  in
+  let post_json =
+    Server_utils.board_post_dashboard_json ~contributor_quality
+      ~author_karma:0 post
+  in
+  let quality =
+    match Yojson.Safe.Util.member "contributor_quality" post_json with
+    | `Assoc _ as quality -> quality
+    | _ -> Alcotest.fail "expected contributor_quality object"
+  in
+  Alcotest.(check string) "quality source" "agent_reputation"
+    (json_member_string quality "source");
+  Alcotest.(check string) "quality band" "strong"
+    (json_member_string quality "band");
+  Alcotest.(check int) "quality board posts" 3
+    (json_member_int quality "board_posts")
+
 let test_inline_board_post_author_rewrites_caller_claim () =
   let args =
     make_args
@@ -1504,6 +1548,8 @@ let () =
             `Quick test_board_dashboard_json_embeds_moderation_projection;
           Alcotest.test_case "board dashboard json hides blind vote scores"
             `Quick test_board_dashboard_json_hides_unvoted_scores_when_blind;
+          Alcotest.test_case "board dashboard json embeds contributor quality"
+            `Quick test_board_dashboard_json_embeds_contributor_quality;
           Alcotest.test_case "inline board post author rewrites caller claim"
             `Quick test_inline_board_post_author_rewrites_caller_claim;
           Alcotest.test_case "inline board post author accepts matching alias"


### PR DESCRIPTION
## Summary

Surfaces the existing `Agent_reputation` signal as a compact board contributor-quality projection for post authors.

## What changed

- Adds request-local contributor-quality lookup helpers over `Agent_reputation`.
- Adds `contributor_quality` to board post JSON when the route has runtime config.
- Wires `/api/v1/board`, `/api/v1/board/<post_id>`, and `/api/v1/dashboard/board` to include the projection.
- Adds dashboard types, normalizers, and quality badges on board cards and post detail.
- Keeps the post-detail quality badge visible even when it is the only detail badge.
- Documents the projection contract in `docs/spec/11-board.md`.

## Operator impact

This is read-time advisory data only. It does not change board storage, sorting, moderation, karma ledger replay, or author permissions.

## Validation

- `pnpm exec tsc --noEmit --pretty`
- `pnpm exec vitest run --config vitest.config.ts src/api/board.test.ts src/components/board/board-surface.test.ts src/components/board/post-detail.test.ts --no-file-parallelism --maxWorkers=1` (129 tests)
- `pnpm exec eslint src/api/board.ts src/components/board/board-surface.ts src/components/board/post-detail.ts src/lib/board-utils.ts src/types/core.ts src/api/board.test.ts src/components/board/board-surface.test.ts src/components/board/post-detail.test.ts` (0 errors, 4 existing ignored-file warnings)
- `./_build/default/test/test_tool_board_coverage.exe` (75 tests)
- `git diff --check`
- `scripts/check-oas-pin.sh --local-only`
- `scripts/oas-drift-check.sh`

## Review focus

- Verify the projection remains advisory-only and does not affect board ordering, write paths, or moderation decisions.
- Check that config-scoped routes pass runtime config consistently so `Agent_reputation` reads from the active base path.
