### PR TITLE
fix(oas): preserve zero-turn checkpoints

### DIFF
--- a/lib/oas_worker_named.ml
+++ b/lib/oas_worker_named.ml
@@ -104,6 +104,12 @@ let apply_stream_idle_timeout_default = function
   | Some _ as v -> v
   | None -> Some Env_config_keeper.KeeperKeepalive.stream_idle_timeout_sec
 
+let checkpoint_after_attempt ?agent_ref = function
+  | Some agent ->
+      (match agent_ref with Some r -> r := Some agent | None -> ());
+      Some (Agent_sdk.Agent.checkpoint agent)
+  | None -> None
+
 (* ================================================================ *)
 (* Facade-only: run_named, run_model_by_label, and MASC tool bridges  *)
 (* ================================================================ *)
@@ -588,17 +594,11 @@ let run_named
           (enrich_sdk_error ~cascade_name:error_cascade_name ~provider_cfg)
           result
       in
-      (* Extract checkpoint from the agent if it made progress.
-         The agent's mutable state reflects all completed turns even on Error. *)
-      let checkpoint_after = match !local_agent_ref with
-        | Some agent when (Agent_sdk.Agent.state agent).turn_count > 0 ->
-          (* Also propagate to caller's agent_ref for final result *)
-          (match agent_ref with Some r -> r := Some agent | None -> ());
-          Some (Agent_sdk.Agent.checkpoint agent)
-        | Some agent ->
-          (match agent_ref with Some r -> r := Some agent | None -> ());
-          None
-        | None -> None
+      (* Extract checkpoint from the agent even when no turn completed.
+         A zero-turn agent still carries built context, initial messages,
+         and sidecar state needed by cancel-before-start recovery. *)
+      let checkpoint_after =
+        checkpoint_after_attempt ?agent_ref !local_agent_ref
       in
       (result, checkpoint_after)
   in
@@ -1406,3 +1406,7 @@ let run_model_with_masc_tools
           Error
             (sdk_error_of_masc_internal_error
                (Admission_queue_rejected { keeper_name = "oas-explicit-model"; reason }))
+
+module For_testing = struct
+  let checkpoint_after_attempt = checkpoint_after_attempt
+end

--- a/lib/oas_worker_named.mli
+++ b/lib/oas_worker_named.mli
@@ -202,3 +202,10 @@ val run_model_with_masc_tools :
   unit ->
   (Oas_worker_exec.run_result, Agent_sdk.Error.sdk_error) result
 (** [run_model_by_label] variant that bridges MASC tool schemas into OAS tools. *)
+
+module For_testing : sig
+  val checkpoint_after_attempt :
+    ?agent_ref:Agent_sdk.Agent.t option ref ->
+    Agent_sdk.Agent.t option ->
+    Agent_sdk.Checkpoint.t option
+end

--- a/lib/provider_adapter.ml
+++ b/lib/provider_adapter.ml
@@ -1473,8 +1473,16 @@ let provider_label_of_config (cfg : Llm_provider.Provider_config.t) =
   | Some adapter -> adapter.cascade_prefix
   | None -> provider_label_from_registry cfg
 
-let provider_health_key_of_config cfg =
-  provider_label_of_config cfg
+let provider_health_key_of_config (cfg : Llm_provider.Provider_config.t) =
+  match cfg.kind with
+  | Llm_provider.Provider_config.OpenAI_compat
+    when Llm_provider.Provider_config.is_local cfg ->
+      let base_url = String.trim cfg.base_url in
+      if base_url = "" then provider_label_of_config cfg
+      else
+        Printf.sprintf "%s:%s@%s" (provider_label_of_config cfg)
+          cfg.model_id base_url
+  | _ -> provider_label_of_config cfg
 
 let display_provider_name_of_config (cfg : Llm_provider.Provider_config.t) =
   display_provider_name (provider_label_of_config cfg)

--- a/lib/provider_adapter.mli
+++ b/lib/provider_adapter.mli
@@ -370,7 +370,10 @@ val adapter_of_provider_config :
 val provider_label_of_config :
   Llm_provider.Provider_config.t -> string
 
-(** Stable provider-level key for cascade health and circuit-breaker state. *)
+(** Stable key for cascade health and circuit-breaker state.
+    Most providers are keyed at provider level. Local OpenAI-compatible
+    endpoints include model and base URL so independent loopback runtimes can
+    fail over without sharing cooldown state. *)
 val provider_health_key_of_config :
   Llm_provider.Provider_config.t -> string
 

--- a/test/test_oas_worker.ml
+++ b/test/test_oas_worker.ml
@@ -1421,21 +1421,25 @@ let test_run_named_skips_cooldown_primary_and_falls_back () =
       | Ok providers -> providers
       | Error err -> Alcotest.fail err
     in
-    (match resolved with
-     | [ primary; fallback ] ->
+    let primary_health_key, fallback_health_key =
+      match resolved with
+      | [ primary; fallback ] ->
          Alcotest.(check string) "primary model id"
            primary_key primary.Llm_provider.Provider_config.model_id;
          Alcotest.(check string) "fallback model id"
            fallback_key fallback.model_id;
          Alcotest.(check string) "primary base url" primary_url primary.base_url;
-         Alcotest.(check string) "fallback base url" fallback_url fallback.base_url
-     | providers ->
+         Alcotest.(check string) "fallback base url" fallback_url fallback.base_url;
+         ( Masc_mcp.Provider_adapter.provider_health_key_of_config primary,
+           Masc_mcp.Provider_adapter.provider_health_key_of_config fallback )
+      | providers ->
          Alcotest.failf "expected 2 resolved providers, got %d"
-           (List.length providers));
+           (List.length providers)
+    in
     for _ = 1 to Masc_mcp.Cascade_health_tracker.cooldown_threshold do
       Masc_mcp.Cascade_health_tracker.record_failure
         Masc_mcp.Cascade_health_tracker.global
-        ~provider_key:primary_key
+        ~provider_key:primary_health_key
         ()
     done;
     reset_primary_calls ();
@@ -1443,7 +1447,7 @@ let test_run_named_skips_cooldown_primary_and_falls_back () =
     (match
        Masc_mcp.Cascade_health_tracker.check_circuit_breaker
          Masc_mcp.Cascade_health_tracker.global
-         ~provider_key:primary_key
+         ~provider_key:primary_health_key
      with
      | Ok () -> Alcotest.fail "primary provider should be OPEN before run_named"
      | Error _ -> ());
@@ -1472,7 +1476,7 @@ let test_run_named_skips_cooldown_primary_and_falls_back () =
         (match
            Masc_mcp.Cascade_health_tracker.provider_info
              Masc_mcp.Cascade_health_tracker.global
-             ~provider_key:fallback_key
+             ~provider_key:fallback_health_key
          with
          | None -> Alcotest.fail "fallback provider should have health info"
          | Some info ->
@@ -1584,6 +1588,45 @@ let test_run_named_accept_rejected_does_not_replay_rejected_checkpoint () =
         Eio.Switch.fail sw Exit
     | Error err -> Alcotest.fail (Agent_sdk.Error.to_string err)
   with Exit -> ()
+
+let test_zero_turn_attempt_preserves_checkpoint () =
+  let initial_messages =
+    [
+      {
+        Agent_sdk.Types.role = Agent_sdk.Types.User;
+        content = [ Agent_sdk.Types.Text "pre-start recovery seed" ];
+        name = None;
+        tool_call_id = None;
+        metadata = [];
+      };
+    ]
+  in
+  let config =
+    {
+      Agent_sdk.Types.default_config with
+      name = "zero-turn-agent";
+      model = "mock-model";
+      system_prompt = Some "system";
+      initial_messages;
+    }
+  in
+  let agent = Agent_sdk.Agent.create ~net:(require_test_net ()) ~config () in
+  let agent_ref = ref None in
+  Fun.protect
+    ~finally:(fun () -> Agent_sdk.Agent.close agent)
+    (fun () ->
+      match
+        Oas_worker_named.For_testing.checkpoint_after_attempt ~agent_ref
+          (Some agent)
+      with
+      | Some checkpoint ->
+          Alcotest.(check int) "zero turns preserved" 0
+            checkpoint.Agent_sdk.Checkpoint.turn_count;
+          Alcotest.(check int) "initial messages preserved" 1
+            (List.length checkpoint.messages);
+          Alcotest.(check bool) "agent_ref propagated" true
+            (Option.is_some !agent_ref)
+      | None -> Alcotest.fail "expected zero-turn checkpoint")
 
 let make_worker_meta ?(effective_model = "local-qwen") () :
     Worker_container_types.worker_container_meta =
@@ -5422,6 +5465,8 @@ let () =
         test_run_named_default_accept_allows_empty_content;
       Alcotest.test_case "accept-rejected fallback skips rejected checkpoint" `Quick
         test_run_named_accept_rejected_does_not_replay_rejected_checkpoint;
+      Alcotest.test_case "zero-turn attempt preserves checkpoint" `Quick
+        test_zero_turn_attempt_preserves_checkpoint;
     ];
     "resume_config", [
       Alcotest.test_case "checkpoint model wins" `Quick

--- a/test/test_provider_adapter.ml
+++ b/test/test_provider_adapter.ml
@@ -367,6 +367,18 @@ let test_provider_health_key_is_provider_scoped () =
     (Adapter.provider_health_key_of_config claude_auto
      <> Adapter.provider_health_key_of_config gemini_auto)
 
+let test_local_openai_compat_health_key_is_endpoint_scoped () =
+  let cfg label =
+    match Masc_mcp.Cascade_config.parse_model_string label with
+    | Some cfg -> cfg
+    | None -> fail ("expected model label to parse: " ^ label)
+  in
+  let primary = cfg "custom:primary@http://127.0.0.1:11111" in
+  let fallback = cfg "custom:primary@http://127.0.0.1:22222" in
+  check bool "same local model on different endpoints is isolated" true
+    (Adapter.provider_health_key_of_config primary
+     <> Adapter.provider_health_key_of_config fallback)
+
 let test_provider_of_model_label_uses_typed_boundaries () =
   check string "explicit prefix wins over coarse kind" "glm-coding"
     (Adapter.provider_of_model_label
@@ -455,6 +467,8 @@ let () =
             test_provider_label_of_config_preserves_cli_vs_api_identity;
           test_case "provider health key is provider scoped" `Quick
             test_provider_health_key_is_provider_scoped;
+          test_case "local openai compat health key is endpoint scoped" `Quick
+            test_local_openai_compat_health_key_is_endpoint_scoped;
           test_case "provider model label uses typed boundaries" `Quick
             test_provider_of_model_label_uses_typed_boundaries;
           test_case "unmetered provider uses telemetry policy" `Quick


### PR DESCRIPTION
Summary:
- Preserve OAS Agent checkpoints even when an attempt ends before completing turn 1, so cancel-before-start recovery keeps built context and initial messages.
- Expose a small For_testing checkpoint helper and add a zero-turn regression test.
- Key local OpenAI-compatible provider health by model and base URL so one loopback runtime opening its circuit does not suppress an independent fallback endpoint.

Validation:
- git diff --check
- ocamlc -stop-after parsing lib/provider_adapter.ml lib/oas_worker_named.ml test/test_provider_adapter.ml test/test_oas_worker.ml
- scripts/dune-local.sh build test/test_oas_worker.exe test/test_provider_adapter.exe
- ./_build/default/test/test_provider_adapter.exe
- ./_build/default/test/test_oas_worker.exe test cascade_config 42
- ./_build/default/test/test_oas_worker.exe test cascade_config 45
- ./_build/default/test/test_oas_worker.exe (162 tests)
- bash scripts/ci/check-silent-failure-patterns.sh

Review focus:
- Confirm zero-turn checkpoint retention is acceptable for cancellation/recovery semantics.
- Confirm local OpenAI-compatible health-key granularity should be endpoint/model scoped while normal providers stay provider scoped.