### PR TITLE
fix: emit keeper on_stop telemetry

### DIFF
--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -64,6 +64,13 @@ let current_keeper_model meta =
   let m = meta.Keeper_types.runtime.usage.last_model_used in
   if m = "" then meta.Keeper_types.cascade_name else m
 
+let stop_reason_to_label = function
+  | Agent_sdk.Types.EndTurn -> "end_turn"
+  | Agent_sdk.Types.StopToolUse -> "tool_use"
+  | Agent_sdk.Types.MaxTokens -> "max_tokens"
+  | Agent_sdk.Types.StopSequence -> "stop_sequence"
+  | Agent_sdk.Types.Unknown _ -> "unknown"
+
 let render_pre_tool_gate_source_hint
     (event : Keeper_guards.gate_decision_event) =
   match event.source_path, event.source_line with
@@ -2193,6 +2200,19 @@ let make_hooks
        destructive + governance_approval) is composed with these
        non-gate hooks at the end of [make_hooks]. *)
 
+    on_stop = Some (fun event ->
+      match event with
+      | Agent_sdk.Hooks.OnStop { reason; _ } ->
+        Prometheus.inc_counter Prometheus.metric_keeper_oas_on_stop
+          ~labels:
+            [
+              ("keeper", (!meta_ref).name);
+              ("stop_reason", stop_reason_to_label reason);
+            ]
+          ();
+        Agent_sdk.Hooks.Continue
+      | _ -> Agent_sdk.Hooks.Continue);
+
     on_idle = Some (fun event ->
       match event with
       | Agent_sdk.Hooks.OnIdle { consecutive_idle_turns; tool_names; _ } ->
@@ -2383,9 +2403,9 @@ let hook_introspection_json
         ~effects:[ "tool_use_failure_metric" ]
         "post_tool_use_failure";
       slot
-        ~active:false
-        ~source:"not_registered"
-        ~reason:"keeper runtime has no stop hook"
+        ~active:true
+        ~source:"keeper_hooks_oas"
+        ~effects:[ "stop_reason_metric" ]
         "on_stop";
       slot
         ~active:true

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -929,6 +929,7 @@ let metric_llm_inference_duration = "masc_llm_inference_duration_seconds"
 let metric_llm_prompt_tok_per_sec = "masc_llm_prompt_tok_per_sec"
 let metric_llm_decode_tok_per_sec = "masc_llm_decode_tok_per_sec"
 let metric_after_turn_hook = "masc_after_turn_hook_total"
+let metric_keeper_oas_on_stop = "masc_keeper_oas_on_stop_total"
 let metric_after_turn_telemetry_missing =
   "masc_after_turn_telemetry_missing_total"
 let metric_after_turn_telemetry_zero_latency =
@@ -1357,6 +1358,9 @@ let init () =
   add metric_after_turn_hook
     "Times the keeper AfterTurn hook ran (labeled by model). Divergence from \
      masc_llm_inference_duration_seconds_count identifies missing telemetry." Counter;
+  add metric_keeper_oas_on_stop
+    "Times the keeper OnStop hook ran after an OAS response terminated. \
+     Labels: keeper, stop_reason." Counter;
   add metric_after_turn_telemetry_missing
     "AfterTurn responses where response.telemetry was None." Counter;
   add metric_after_turn_telemetry_zero_latency

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -524,6 +524,7 @@ val metric_llm_decode_tok_per_sec : string
     tell absence apart from zero. *)
 
 val metric_after_turn_hook : string
+val metric_keeper_oas_on_stop : string
 val metric_after_turn_telemetry_missing : string
 val metric_after_turn_telemetry_zero_latency : string
 val metric_tasks : string

--- a/test/test_keeper_hooks_oas_telemetry.ml
+++ b/test/test_keeper_hooks_oas_telemetry.ml
@@ -55,6 +55,12 @@ let lifecycle_callback_failure_count ~keeper ~callback =
     ~labels:[ ("keeper", keeper); ("callback", callback) ]
     ()
 
+let on_stop_count ~keeper ~stop_reason =
+  Masc_mcp.Prometheus.metric_value_or_zero
+    Masc_mcp.Prometheus.metric_keeper_oas_on_stop
+    ~labels:[ ("keeper", keeper); ("stop_reason", stop_reason) ]
+    ()
+
 let require_hook label = function
   | Some hook -> hook
   | None -> failf "expected active hook: %s" label
@@ -447,6 +453,16 @@ let make_telemetry
     provider_internal_action_count = None;
   }
 
+let make_response ?(stop_reason = Agent_sdk.Types.EndTurn) ?telemetry () =
+  {
+    Agent_sdk.Types.id = "response-test";
+    model = "test-model";
+    stop_reason;
+    content = [];
+    usage = None;
+    telemetry;
+  }
+
 let histogram_snapshot metric ~labels =
   let sum =
     Masc_mcp.Prometheus.metric_value_or_zero metric ~labels ()
@@ -693,9 +709,9 @@ let test_hook_introspection_reports_current_runtime_slots () =
   check string "scope" "keeper_runtime_composite"
     (json |> member "scope" |> to_string);
   check int "slot_count" 14 (json |> member "slot_count" |> to_int);
-  check int "active slots" 9
+  check int "active slots" 10
     (json |> member "active_slot_count" |> to_int);
-  check int "inactive slots" 5
+  check int "inactive slots" 4
     (json |> member "inactive_slot_count" |> to_int);
   check bool "before_turn active" true
     (slot json "before_turn" |> member "active" |> to_bool);
@@ -726,6 +742,11 @@ let test_hook_introspection_reports_current_runtime_slots () =
     "tool_use_failure_metric" failure_effects;
   check_string_list_not_contains "failure hook no stale heuristic label"
     "heuristic_metrics" failure_effects;
+  check bool "on_stop active" true
+    (slot json "on_stop" |> member "active" |> to_bool);
+  check_string_list_contains "on_stop records stop reason"
+    "stop_reason_metric"
+    (string_list_field (slot json "on_stop") "effects");
   check bool "on_idle_escalated inactive" false
     (slot json "on_idle_escalated" |> member "active" |> to_bool);
   check bool "pre_compact inactive" false
@@ -767,6 +788,36 @@ let test_on_tool_error_hook_records_callback_failure_metric () =
   in
   check (float 0.001) "on_tool_error counter increments" 1.0
     (after -. before)
+
+let test_on_stop_hook_records_stop_reason_metric () =
+  let keeper = "callback-on-stop-keeper" in
+  let hooks = make_test_hooks keeper in
+  let hook = require_hook "on_stop" hooks.on_stop in
+  let before = on_stop_count ~keeper ~stop_reason:"end_turn" in
+  check_continue "on_stop"
+    (hook
+       (Agent_sdk.Hooks.OnStop
+          {
+            reason = Agent_sdk.Types.EndTurn;
+            response = make_response ();
+          }));
+  let after = on_stop_count ~keeper ~stop_reason:"end_turn" in
+  check (float 0.001) "on_stop counter increments" 1.0
+    (after -. before);
+  let unknown_before = on_stop_count ~keeper ~stop_reason:"unknown" in
+  check_continue "on_stop unknown"
+    (hook
+       (Agent_sdk.Hooks.OnStop
+          {
+            reason = Agent_sdk.Types.Unknown "provider raw detail";
+            response =
+              make_response
+                ~stop_reason:(Agent_sdk.Types.Unknown "provider raw detail")
+                ();
+          }));
+  let unknown_after = on_stop_count ~keeper ~stop_reason:"unknown" in
+  check (float 0.001) "unknown stop reason is bounded" 1.0
+    (unknown_after -. unknown_before)
 
 let test_on_idle_hook_returns_runtime_nudge () =
   let hooks = make_test_hooks "callback-on-idle-keeper" in
@@ -1161,6 +1212,8 @@ let () =
             test_on_error_hook_records_callback_failure_metric
         ; test_case "on_tool_error records callback metric" `Quick
             test_on_tool_error_hook_records_callback_failure_metric
+        ; test_case "on_stop records stop reason metric" `Quick
+            test_on_stop_hook_records_stop_reason_metric
         ; test_case "on_idle returns runtime nudge" `Quick
             test_on_idle_hook_returns_runtime_nudge
         ] )

--- a/test/test_prometheus_coverage.ml
+++ b/test/test_prometheus_coverage.ml
@@ -292,6 +292,7 @@ let test_review_blocker_metrics_registered () =
   check_registered Prometheus.metric_coord_telemetry_drop;
   check_registered Prometheus.metric_coord_claim_post_provision_failures;
   check_registered Prometheus.metric_keeper_lifecycle_callback_failures;
+  check_registered Prometheus.metric_keeper_oas_on_stop;
   check_registered Prometheus.metric_keeper_event_bus_drain
 
 let test_distributed_lock_metric_registered () =


### PR DESCRIPTION
## What

- Register the keeper OAS `on_stop` hook instead of leaving that slot inactive.
- Emit `masc_keeper_oas_on_stop_total{keeper,stop_reason}` when OAS reports a terminal response stop reason.
- Bound raw `Unknown _` provider stop reasons to the `unknown` label to avoid unbounded Prometheus cardinality.
- Update hook introspection and metric registration tests.

## Why

The OAS runtime already calls `on_stop` for terminal response stop reasons, but MASC did not register a hook. That left one lifecycle callback slot as an intentional no-op and made stop-reason observation dependent on later receipt plumbing only. This gives operators a direct hook-fired signal for the OAS termination path.

## Validation

- `git diff --check`
- `lockf -k -t 30 /tmp/me-dune-local.lock env MASC_DUNE_LOCK_HELD=1 MASC_SKIP_OPAM_LOCK=1 DUNE_JOBS=1 DUNE_CACHE=disabled scripts/dune-local.sh build test/test_keeper_hooks_oas_telemetry.exe test/test_prometheus_coverage.exe`
- `_build/default/test/test_keeper_hooks_oas_telemetry.exe`
- `_build/default/test/test_prometheus_coverage.exe`