### PR TITLE
test(cascade): guard TOML/JSON seed drift

### DIFF
--- a/test/stanzas/test_cascade_config_validity.inc
+++ b/test/stanzas/test_cascade_config_validity.inc
@@ -1,8 +1,11 @@
-; Static validity check for the committed config/cascade.json.
-; Feeds every profile's model string list through the OAS parser
+; Static validity check for the committed cascade seed.
+; Feeds every materialized profile's model string list through the OAS parser
 ; (parse_model_string_exn) so unknown provider names fail at test time
 ; rather than when a keeper actually tries to resolve the cascade at
 ; runtime. Path is injected via env var, not hardcoded.
+; Also asserts that committed config/cascade.json exactly matches the
+; materialized output of config/cascade.toml, keeping TOML as the
+; human-authored SSOT.
 ;
 ; The test uses parse_model_string_exn and explicitly accepts the
 ; "provider unavailable" error path, so the file-level (ZAI_API_KEY "")
@@ -12,7 +15,9 @@
 (test
  (name test_cascade_config_validity)
  (modules test_cascade_config_validity)
- (deps %{workspace_root}/config/cascade.json)
+ (deps
+  %{workspace_root}/config/cascade.json
+  %{workspace_root}/config/cascade.toml)
  (action
   (setenv MASC_CASCADE_JSON_PATH %{workspace_root}/config/cascade.json
    (run %{test})))

--- a/test/test_cascade_config_validity.ml
+++ b/test/test_cascade_config_validity.ml
@@ -200,6 +200,38 @@ let test_unknown_provider_is_dropped () =
         true
         (List.length parsed < List.length strings))
 
+let test_committed_json_matches_toml_materializer () =
+  let path = cascade_path () in
+  let source =
+    Masc_mcp.Cascade_toml_materializer.source_info ~config_path:path
+  in
+  check string "repo cascade source kind" "toml"
+    (Masc_mcp.Cascade_toml_materializer.source_kind_to_string source.kind);
+  match source.kind with
+  | Masc_mcp.Cascade_toml_materializer.Json ->
+      fail "config/cascade.toml must remain the committed cascade SSOT"
+  | Masc_mcp.Cascade_toml_materializer.Toml -> (
+      match
+        Masc_mcp.Cascade_toml_materializer.render_toml_file_to_json_string
+          source.source_path
+      with
+      | Error msg -> fail ("cascade.toml failed to materialize: " ^ msg)
+      | Ok rendered_json ->
+          let ic = open_in source.json_path in
+          let committed_json =
+            Fun.protect
+              ~finally:(fun () -> close_in_noerr ic)
+              (fun () ->
+                let len = in_channel_length ic in
+                let buf = Bytes.create len in
+                really_input ic buf 0 len;
+                Bytes.to_string buf)
+          in
+          check bool
+            "committed cascade.json matches cascade.toml materialization"
+            true
+            (String.equal rendered_json committed_json))
+
 let with_temp_cascade_json body =
   let tmp = Filename.temp_file "cascade-strategy-" ".json" in
   Fun.protect
@@ -325,6 +357,10 @@ let () =
             "unknown provider dropped (meta-guard)"
             `Quick
             test_unknown_provider_is_dropped;
+          test_case
+            "committed json matches toml materializer"
+            `Quick
+            test_committed_json_matches_toml_materializer;
           test_case
             "priority_tier label tiers normalize to model ids"
             `Quick


### PR DESCRIPTION
## What changed

- Added a regression case to `test_cascade_config_validity` that renders the committed `config/cascade.toml` through the strict materializer and compares it against committed `config/cascade.json`.
- Declared both seed files as Dune dependencies for the validity test.

## Why

`config/cascade.toml` is the supported human-authored cascade source, while `config/cascade.json` is the materialized runtime artifact. The old gate validated only the JSON provider strings, so TOML/JSON seed drift could pass unnoticed.

## Validation

- `scripts/dune-local.sh build test/test_cascade_config_validity.exe`
- `env MASC_CASCADE_JSON_PATH=/Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-cascade-toml-json-drift-gate/config/cascade.json ./_build/default/test/test_cascade_config_validity.exe`
- `git diff --check`

Closes #13907
