### PR TITLE
feat(keeper): expose idle seconds metric

### DIFF
--- a/docs/spec/05-keeper-agent.md
+++ b/docs/spec/05-keeper-agent.md
@@ -192,7 +192,7 @@ stateDiagram-v2
 2. **BuildPrompt**: `keeper_unified_prompt.build_prompt`로 keeper identity + observation을 단일 (system_prompt, user_message) 쌍으로 조립
 3. **AgentRun**: `keeper_agent_run.run_turn`이 OAS `Agent.run`에 위임. tools + hooks + context_reducer + memory 전달
 4. **ToolExecution**: Agent가 tool을 호출하면 `keeper_tools_oas`가 `keeper_exec_tools.execute_keeper_tool_call`로 디스패치
-5. **UpdateMetrics**: `keeper_unified_turn.update_metrics_from_result`가 turn count, token 사용량, cost 등을 keeper_meta에 반영
+5. **UpdateMetrics**: `keeper_unified_turn.update_metrics_from_result`가 turn count, token 사용량, cost 등을 keeper_meta에 반영하고 `observation.idle_seconds`를 `masc_keeper_idle_seconds{keeper_name}` Prometheus gauge로 노출
 6. **PostTurnLifecycle**: `keeper_post_turn.apply_post_turn_lifecycle`가 compaction, handoff rollover, continuity summary를 single-writer로 처리
 7. **Checkpoint / Compact / Handoff**: checkpoint 저장 후 gate에 따라 compaction 또는 handoff rollover를 실행
 8. **MemoryWrite**: `keeper_agent_run` tail에서 memory bank note append와 episodic flush를 수행. hebbian은 task lifecycle에서만 기록

--- a/lib/keeper/keeper_unified_metrics.ml
+++ b/lib/keeper/keeper_unified_metrics.ml
@@ -285,6 +285,12 @@ let record_keeper_total_cost_usd ~keeper_name ~total_cost_usd =
     ~labels
     total_cost_usd
 
+let record_keeper_idle_seconds ~keeper_name ~idle_seconds =
+  Prometheus.set_gauge
+    Prometheus.metric_keeper_idle_seconds
+    ~labels:[ ("keeper_name", keeper_name) ]
+    (float_of_int (max 0 idle_seconds))
+
 let turn_mode_to_string = function
   | Tool_use -> "tool_use"
   | Text_response -> "text_response"
@@ -1069,6 +1075,9 @@ let update_metrics_from_result (meta : keeper_meta) ~(latency_ms : int)
      turn. Other [classify_usage_trust] call sites serialize the
      trust into JSONL but do not bump the counter. *)
   record_usage_trust ~keeper_name:meta.name ~trust:usage_trust;
+  record_keeper_idle_seconds
+    ~keeper_name:meta.name
+    ~idle_seconds:observation.idle_seconds;
   let usage_trusted = usage_trust_is_trusted usage_trust in
   let trusted_input_tokens =
     if usage_trusted then result.usage.input_tokens else 0
@@ -1590,6 +1599,9 @@ let update_metrics_from_failure (meta : keeper_meta) ~(latency_ms : int)
   ignore is_transient; (* Param retained for caller compatibility; no longer
                           used internally after zombie-fix #5594. *)
   let now_ts = Time_compat.now () in
+  record_keeper_idle_seconds
+    ~keeper_name:meta.name
+    ~idle_seconds:observation.idle_seconds;
   let is_scheduled_autonomous_cycle =
     is_scheduled_autonomous_cycle_of_observation observation
   in

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -237,6 +237,7 @@ let metric_keeper_turn_scheduled =
   "masc_keeper_turn_scheduled_total"
 let metric_keeper_turn_completed =
   "masc_keeper_turn_completed_total"
+let metric_keeper_idle_seconds = "masc_keeper_idle_seconds"
 
 (** #10530: keeper required-tool-contract violations (passive-only or
     text-only turns rejected by the keeper agent loop).
@@ -2199,6 +2200,11 @@ let init () =
     Counter;
   add metric_keeper_total_cost_usd
     "Accumulated trusted USD cost per keeper (labels: keeper_name)"
+    Gauge;
+  add metric_keeper_idle_seconds
+    "Current keeper world-observation idle seconds by keeper_name. Updated \
+     from observation.idle_seconds during keeper metrics emission so long \
+     idle gaps are visible as Prometheus data, not only in message text."
     Gauge;
   add metric_keeper_contract_violations
     "Keeper turns rejected for required-tool-contract violations (labels: keeper_name, kind={passive|text_only}). #10530."

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -81,6 +81,12 @@ val metric_keeper_turn_scheduled : string
 val metric_keeper_turn_completed : string
 (** Goal-loop Observe turn-success numerator. Labels: [keeper_name]. *)
 
+val metric_keeper_idle_seconds : string
+(** Current keeper world-observation idle seconds. Updated from
+    [observation.idle_seconds] during keeper metrics emission so long idle
+    gaps are visible as a scrapeable gauge, not only in message text.
+    Labels: [keeper_name]. *)
+
 (** #10530: keeper required-tool-contract violations.
     Labels: keeper_name, kind \in \{passive,text_only\}. *)
 val metric_keeper_contract_violations : string

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -2547,6 +2547,36 @@ let test_metrics_text_response () =
   check int "input tokens" (minimal_meta.runtime.usage.total_input_tokens + 100) updated.runtime.usage.total_input_tokens;
   check int "output tokens" (minimal_meta.runtime.usage.total_output_tokens + 50) updated.runtime.usage.total_output_tokens
 
+let test_metrics_idle_seconds_gauge_records_observation () =
+  let idle_seconds = 19_006 in
+  let result =
+    make_run_result ~text:"I checked the board." ~tools:[]
+      ~model:"test-model" ~input_tok:100 ~output_tok:50 ()
+  in
+  let observation = { base_observation with idle_seconds = idle_seconds } in
+  ignore
+    (UM.update_metrics_from_result minimal_meta ~latency_ms:200
+       ~observation result);
+  check (option (float 0.001)) "success idle seconds gauge"
+    (Some (float_of_int idle_seconds))
+    (Masc_mcp.Prometheus.get_metric_value
+       Masc_mcp.Prometheus.metric_keeper_idle_seconds
+       ~labels:[ ("keeper_name", minimal_meta.name) ]
+       ());
+  let failure_idle_seconds = idle_seconds + 1 in
+  let failure_observation =
+    { base_observation with idle_seconds = failure_idle_seconds }
+  in
+  ignore
+    (UM.update_metrics_from_failure minimal_meta ~latency_ms:100
+       ~observation:failure_observation ~reason:"synthetic failure" ());
+  check (option (float 0.001)) "failure idle seconds gauge"
+    (Some (float_of_int failure_idle_seconds))
+    (Masc_mcp.Prometheus.get_metric_value
+       Masc_mcp.Prometheus.metric_keeper_idle_seconds
+       ~labels:[ ("keeper_name", minimal_meta.name) ]
+       ())
+
 let test_metrics_surface_model_prefers_successful_cascade_label () =
   let selected_label = "llama:qwen3.5-3b-a3b-ud-q8-xl" in
   let result =
@@ -8049,6 +8079,8 @@ let () =
           test_case "prompt metrics fingerprint" `Quick
             test_prompt_metrics_fingerprint_is_deterministic;
           test_case "text response" `Quick test_metrics_text_response;
+          test_case "idle seconds gauge records observation" `Quick
+            test_metrics_idle_seconds_gauge_records_observation;
           test_case "surface model prefers successful cascade label" `Quick
             test_metrics_surface_model_prefers_successful_cascade_label;
           test_case "resolved_model_id prefers last attempt id (#9953)"

--- a/test/test_prometheus_coverage.ml
+++ b/test/test_prometheus_coverage.ml
@@ -245,6 +245,9 @@ let test_keeper_metrics_registered () =
   check bool "has keeper total cost gauge" true
     (text_has_literal text
        ("# TYPE " ^ Prometheus.metric_keeper_total_cost_usd ^ " gauge"));
+  check bool "has keeper idle seconds gauge" true
+    (text_has_literal text
+       ("# TYPE " ^ Prometheus.metric_keeper_idle_seconds ^ " gauge"));
   check bool "has keeper tool duration histogram" true
     (has "masc_keeper_tool_call_duration_seconds");
   check bool "has operator compact counter" true


### PR DESCRIPTION
## What changed
- Added `masc_keeper_idle_seconds{keeper_name}` as a registered Prometheus gauge.
- Emit the gauge from keeper success and failure metrics paths using `observation.idle_seconds`.
- Added focused coverage for registration plus the 19006s-style idle value projection.
- Documented the UpdateMetrics surface in the keeper agent spec.

## Why
`live_snapshot_delta_analysis.md` called out a zombie-idle gap where `Idle=19006s` was only visible in assistant/message text. Operators need the same wall-clock idle duration as scrapeable numeric telemetry, separate from passive-loop streak counters or alive-but-stuck detector state.

## Validation
- `ocamlc -stop-after parsing test/test_keeper_unified.ml lib/keeper/keeper_unified_metrics.ml lib/prometheus.ml lib/prometheus.mli`
- `scripts/dune-local.sh build test/test_keeper_unified.exe test/test_prometheus_coverage.exe`
- `./_build/default/test/test_keeper_unified.exe test metrics_observation 2 --show-errors`
- `./_build/default/test/test_prometheus_coverage.exe test to_prometheus_text 5 --show-errors`
- `scripts/check-oas-pin.sh --local-only`
- `git diff --check`