### PR TITLE
docs(rfc): RFC-0036 oas cognitive mapping (companion to RFC-0035)

### DIFF
--- a/docs/rfc/RFC-0036-oas-cognitive-mapping.md
+++ b/docs/rfc/RFC-0036-oas-cognitive-mapping.md
@@ -1,0 +1,204 @@
+# RFC-0036: oas Cognitive Mapping (companion to RFC-0035)
+
+- **Status**: Draft
+- **Author**: Claude (autonomous, /loop iteration 5)
+- **Created**: 2026-05-07
+- **Companion to**: RFC-0035 (Cognitive IDE Master Plan Integration)
+- **Repos affected**: `jeong-sik/oas` (agent_sdk) and the masc-mcp ↔ oas
+  contract surface
+- **Out of scope**: changing `agent_sdk`'s public-API contract, breaking
+  semver promises, anything that requires consumers to re-pin
+
+## Problem
+
+RFC-0035 covers the masc-mcp side of the Master Report's 11 cognitive
+dimensions. It deliberately marked `agent_sdk` (oas) as "out of scope"
+on the assumption that the cognitive layer lives entirely in the host.
+
+That assumption was wrong. A re-read of `oas/lib/` shows that the SDK
+already carries the *SDK-side* primitives that pair with the host-side
+cognitive layer:
+
+| Master Report dim / item | Host (masc-mcp) surface | oas surface |
+|---|---|---|
+| Dim01 #5 Semantic Gravity | `lib/cognitive_gravity.ml` (PR-1, #13797) | — (genuinely host-only) |
+| Dim01 #6 Intentional Projection | `lib/intentional_projection.ml` (PR-2, #13821) | **`lib/context_intent.{ml,mli}`** (`intent` enum + heuristic + model-assisted classify) |
+| Dim06 FSM-based Tools / Structured Bash | `lib/keeper_shell_*`, `lib/tool_*` | **`lib/agent_tool.mli` (agent-as-tool)**, **`lib/typed_tool.{ml,mli}` (strong-typed tools)** |
+| Dim09 Goal-driven design — execution gate | `lib/goal_loop` etc | **`lib/autonomy_exec.ml` (orchestration-agnostic exec primitive)** |
+| Dim03 Code-Plan Alignment — diff guard | (none yet) | **`lib/autonomy_diff_guard.ml` (banned-pattern + path filter on unified-diff)** |
+| Dim01 #1~#4 (cognitive UI flow) | dashboard PRs | — (UI is genuinely host-only) |
+| Dim02 Chronicle / Librarian | `lib/chronicle_event.ml` (TBD), dashboard read model | — (event source is host-side) |
+
+The oas surfaces in the right column are *not* recent additions — they
+predate the Master Report. Treating oas as a passive transport in
+RFC-0035 misses that the SDK has been quietly carrying a coherent
+SDK-side cognitive layer.
+
+This RFC corrects the omission by:
+
+1. recording the host ↔ oas mapping above as the working manifest;
+2. proposing two small, additive oas extensions that close the
+   remaining gaps without breaking the SDK's public API;
+3. listing what we are *not* changing on the oas side (most things).
+
+## Why this matters now
+
+Without an explicit mapping, future cognitive PRs will:
+
+- Re-implement on the host what oas already has (e.g. a host-side intent
+  taxonomy that conflicts with `oas/lib/context_intent.ml`'s 5-variant
+  enum). Wasteful and a source of drift.
+- Touch oas opportunistically without a manifest, which is dangerous
+  because oas is a pinned hot dependency: every push triggers a
+  downstream re-pin in masc-mcp's `chore(oas) bump agent sdk pin`
+  workflow (#13785, #13625, #13554, #13494, #13458 — five within a
+  week prior to 2026-05-07).
+- Leave Dim03 / Dim09 work in the host-only column even though
+  `autonomy_diff_guard` already enforces the same family of constraints
+  one layer down.
+
+## Goals
+
+- Make the host-side / oas-side pairing explicit. Future PRs cite this
+  table in their bodies.
+- Identify the *minimum* oas surface additions needed to close cognitive
+  gaps. The bias is toward additive type-only or doc-only changes.
+- Define the boundary: what stays on the host, what stays on oas, and
+  what is genuinely shared.
+
+## Non-goals
+
+- Reproducing RFC-0035 or the Master Report.
+- Changing existing oas public API. The two proposed extensions below
+  add new types / new module — no rename, no signature change.
+- Touching the cascade / provider / hooks layers (those already have
+  their own RFCs in masc-mcp space).
+- Centralising version policy. oas already has
+  `scripts/sync-version-truth.sh` (3-surface sync) and
+  `scripts/check-tag-drift.sh` (CHANGELOG ↔ tag); both work and do not
+  need re-design.
+
+## Boundary discipline
+
+A PR that touches both the host cognitive layer and oas:
+
+- **must** cite this RFC and the matching RFC-0035 row.
+- **must** split if the change is more than additive (dual PRs, masc-mcp
+  side first, oas side second, oas pin bump third).
+- **must not** change oas public API in the same week as a host-side
+  cognitive PR that depends on it (let the pin lifecycle absorb one
+  change at a time).
+
+A PR that touches only oas cognitive surfaces (`context_intent`,
+`agent_tool`, `typed_tool`, `autonomy_*`):
+
+- should still cite this RFC for traceability.
+- can ship without a host-side companion if the change is a strict
+  internal refactor / docstring strengthening / test coverage.
+
+## Proposed extensions (oas)
+
+The following two extensions are the minimum to close the remaining
+gaps. Both are **additive** — no public-API break.
+
+### Extension A: `Context_intent.intent` adds a `Cognitive_op` variant
+
+**Status**: proposed, **not** yet implemented.
+
+`Context_intent.intent` currently has 5 variants:
+`Conversational | Task_command | Status_check | Knowledge_query | Coordination`.
+
+The host-side cognitive layer fires queries that don't fit any of these
+cleanly — e.g. "rank these candidates by gravity", "predict next action".
+A new variant `Cognitive_op` would let the host route those through
+`context_intent` without misclassifying them as `Task_command` (which
+triggers `Full` retrieval depth — wasteful for a pure ranking call).
+
+This is a non-trivial change because `intent` is `[@@deriving yojson, show]`
+and consumers may pattern-match it without a wildcard. Concrete steps:
+
+1. Add the variant in `lib/context_intent.ml(.mli)`.
+2. Update `intent_of_string` / `depth_for_intent` (default to `Skip`).
+3. Update structured-output schema in `Context_intent.schema`.
+4. Add 2 unit tests: round-trip, depth mapping.
+5. Bump `0.190.x → 0.190.y` (minor — additive variant).
+
+Risks: any downstream pattern-match without a wildcard breaks at the
+type level. Search masc-mcp first for `Context_intent.intent` patterns
+before opening this PR.
+
+### Extension B: `Cognitive_event` SDK-side type
+
+**Status**: proposed, **not** yet implemented.
+
+The host-side `chronicle_event` (RFC-0035 PR-4) needs a transport-stable
+event type. Today the host invents its own JSON; tomorrow if the SDK
+itself wants to emit cognitive events (gravity rank, intent prediction,
+mode transition), it has nowhere to put them.
+
+Adding `lib/cognitive_event.{ml,mli}` to oas as a small typed module
+gives both sides a shared schema:
+
+```ocaml
+(* sketch only — final shape per Extension B's PR *)
+type cognitive_event =
+  | Gravity_ranked of { ranked_count : int; query_terms : int }
+  | Intent_predicted of { intent : Context_intent.intent; confidence : float }
+  | Mode_transitioned of { from_ : string; to_ : string }
+  | Disclosure_level of { level : int }
+  [@@deriving yojson, show]
+```
+
+The host writes it, the SDK can later consume it via Hooks. No
+behavioural change in this PR — purely a type definition and JSON
+codec.
+
+### Extensions explicitly NOT proposed
+
+- Changing `Provider.config` to carry cognitive metadata. Out of scope;
+  the cognitive surface should not leak into provider routing.
+- Adding a `Cognitive_hook` to `Hooks`. Use the existing `Hooks` event
+  shape; if expressivity is missing, a separate RFC covers it.
+- Centralising version SSOT into one file. Both
+  `scripts/sync-version-truth.sh` and `scripts/check-tag-drift.sh`
+  already cover this; adding a third surface dilutes responsibility.
+
+## Risks
+
+1. **Hot-dep churn.** oas has been re-pinned ~5×/week through 2026-04
+   into 2026-05. Every oas PR triggers a downstream chore(oas) bump.
+   Both proposed extensions are additive precisely to keep the pin
+   bump trivial.
+2. **Master Report's confidence ladder is the author's.** This RFC
+   adopts the routing manifest, not the prescription. Each oas PR
+   stands on its own evidence gate, the same as RFC-0035.
+3. **Extension A risks pattern-match drift on the host.** Mitigation:
+   open a separate masc-mcp PR first that adds `| _ -> ...` wildcards
+   in any host-side `Context_intent.intent` matches that don't already
+   have one. Land that PR before Extension A's oas PR.
+
+## Implementation plan (this RFC stack)
+
+| PR | Repo | Topic | Status |
+|----|------|-------|--------|
+| RFC-0036 (this PR) | masc-mcp | docs only — record the manifest | this PR |
+| RFC-0036 PR-A1 | masc-mcp | wildcard guard on `Context_intent.intent` matches (defensive prep for Extension A) | not started |
+| RFC-0036 PR-A2 | oas | Extension A — `Cognitive_op` variant + tests + bump | not started |
+| RFC-0036 PR-B | oas | Extension B — `Cognitive_event` type + JSON codec + bump | not started, can run independently |
+
+PR-A1 must merge before PR-A2 lands in oas.
+PR-B has no host-side dependency.
+
+## Verification gates
+
+This RFC is mergeable on docs-only criteria:
+
+- The mapping table reflects what is actually in the listed files
+  (verified by `bash scripts/verify_audit_claim.sh 1 'context_intent' .`
+  and similar for the other modules — exactly one module surface per
+  named file).
+- No code change. No build change. No CI change.
+- Self-review against `~/me/agents/best-programmer/AGENT.md` posted
+  in the PR body.
+
+Future PRs (PR-A1 / PR-A2 / PR-B) carry their own verification gates.


### PR DESCRIPTION
## Summary

- RFC-0036을 추가. RFC-0035의 동반 문서로 **oas (agent_sdk) 측 cognitive primitives 매핑**을 기록.
- 코드 변경 0건, 빌드/테스트 변경 0건. **순수 docs-only**.

## Why

RFC-0035는 oas를 "out of scope"로 표시했지만, oas/lib/ 재독 결과 **oas는 이미 cognitive layer의 SDK-side 짝꿍을 가지고 있습니다**:

| Master Report 차원 | host 측 (masc-mcp) | oas 측 |
|---|---|---|
| Dim01 #6 Intentional Projection | `lib/intentional_projection.ml` (PR-2 #13821) | **`lib/context_intent.{ml,mli}`** (intent enum + heuristic + model classify) |
| Dim06 FSM-based Tools | `lib/keeper_shell_*`, `lib/tool_*` | **`lib/agent_tool.mli`**, **`lib/typed_tool.{ml,mli}`** |
| Dim09 Goal-driven design (execution) | `lib/goal_loop` etc | **`lib/autonomy_exec.ml`** |
| Dim03 Code-Plan Alignment (diff guard) | (없음) | **`lib/autonomy_diff_guard.ml`** |

이 oas 모듈들은 모두 Master Report 이전부터 존재한 것들이라, oas를 passive transport로만 본 RFC-0035의 가정이 틀렸음을 의미합니다.

## What this RFC delivers

1. **호스트 ↔ oas 매핑 매니페스트**. 향후 cognitive PR이 RFC-0036의 행을 인용해 작업 위치를 명확히 함.
2. **두 개의 작은 additive 확장 제안** (이 PR에서는 코드 미실행, 별도 PR로 진행):
   - **PR-A2**: `Context_intent.intent`에 `Cognitive_op` 변형 추가 (host-side wildcard guard PR-A1 선행 필수)
   - **PR-B**: `oas/lib/cognitive_event.{ml,mli}` 타입 모듈 신규 추가 (JSON codec, 동작 변경 0)
3. **명시적 NOT-proposed**: `Provider.config` 변경 X, `Hooks`에 Cognitive_hook 추가 X, 세 번째 version SSOT X. 모두 기존 infra와 중복/위험.

## Why now

oas는 hot dependency라 매주 ~5회 pin bump (#13785, #13625, #13554, #13494, #13458). cognitive PR이 oas에 무계획으로 박히면 다운스트림 chore(oas) bump 비용이 증폭됩니다. 매핑 매니페스트로 사전 조율.

## Changes

| File | Δ |
|---|---|
| `docs/rfc/RFC-0036-oas-cognitive-mapping.md` | new — 204 lines |

총 **+204 / -0**, 1 파일.

## Best Programmer self-review

- **목표**: Master Report ↔ oas 매핑 누락을 메우고, 향후 oas 변경 디시플린(기준선) 확립.
- **변경 파일**: 1개 신규 RFC. 코드 0.
- **로컬 검증**: docs-only이므로 빌드/테스트 영향 0. 매핑 표의 파일 이름은 직접 `head` / `wc -l`로 검증한 것 (`lib/context_intent.mli` 74줄, `lib/typed_tool.mli` 104줄, `lib/autonomy_diff_guard.ml` 24줄+ 등).
- **남은 미검증**: 없음 (실제 변경 없음).
- **회귀 가능성**: 0.

## Out of scope (이 PR)

- Extension A / Extension B의 실제 구현은 별도 PR로:
  - **PR-A1** (masc-mcp): `Context_intent.intent` 패턴 매치에 wildcard 가드 추가 (defensive prep)
  - **PR-A2** (oas): `Cognitive_op` 변형 추가 + 테스트 + bump
  - **PR-B** (oas): `cognitive_event.{ml,mli}` 신규 + bump
- oas pin bump 자체는 별도 chore PR (`chore(oas): bump agent sdk pin to ...`) 흐름.

## RFC compliance

- RFC: `docs/rfc/RFC-0036-oas-cognitive-mapping.md` (이 PR에 포함).
- `scripts/pr-rfc-check.sh` 강제 영역(credential / repo_manager / operator / dashboard credential / hooks / workflow) 0건 변경. RFC waiver 불필요.

## Test plan

- [x] 매핑 표의 oas 파일 이름이 실제 oas/lib/에 존재함 직접 확인 (head/wc로 5개 파일 검증)
- [x] 코드 변경 0
- [ ] CI 19개 체크 — docs-only이므로 모두 SKIP/PASS 예상
- [ ] Ready 전환 전 사람 리뷰 + `human-approved-ready` 라벨 (Draft Auto-Merge Guard 대응)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>