### PR TITLE
chore: unblock main build (3 small fixes)

### DIFF
--- a/bin/main_eio.ml
+++ b/bin/main_eio.ml
@@ -394,8 +394,8 @@ let dispatch_route ~routes ~request ~path reqd =
       let format = Option.value ~default:"nested" (query_param request "format") in
       let voter = board_voter_query request in
       let (status, body) =
-        board_post_detail_json ~include_moderation:false ~voter
-          ~response_format:format ~post_id
+        board_post_detail_json ~include_moderation:false ~blind_votes:false
+          ~voter ~response_format:format ~post_id
       in
       Http.Response.json ~status body reqd
   | _ -> Http.Router.dispatch routes request reqd

--- a/test/test_dashboard_cascade.ml
+++ b/test/test_dashboard_cascade.ml
@@ -762,7 +762,7 @@ let test_audit_runs_json_projects_o1_shape () =
     (fun base_path ->
        let audit_dir =
          Filename.concat
-           (Masc_mcp.Coord_utils.masc_dir_from_base_path ~base_path)
+           (Coord_utils.masc_dir_from_base_path ~base_path)
            "cascade_audit"
        in
        let store = Dated_jsonl.create ~base_dir:audit_dir () in

--- a/test/test_prometheus_coverage.ml
+++ b/test/test_prometheus_coverage.ml
@@ -249,7 +249,7 @@ let with_eio_backend f =
   let fs = Eio.Stdenv.fs env in
   let dir =
     Filename.concat (Filename.get_temp_dir_name ())
-      (Printf.sprintf "backend-mutex-metrics-%d-%0.f" (Unix.getpid ())
+      (Printf.sprintf "backend-mutex-metrics-%d-%.0f" (Unix.getpid ())
          (Unix.gettimeofday () *. 1000000.))
   in
   Unix.mkdir dir 0o755;


### PR DESCRIPTION
## Summary

main 빌드가 깨진 상태에서 발견. 세 개 독립 build error 를 단일 chore PR 로 unblock.

| # | File:Line | Error | Fix |
|---|-----------|-------|-----|
| 1 | bin/main_eio.ml:397 | \`board_post_detail_json\` partial application (\`~blind_votes:bool\` 누락) | \`~blind_votes:false\` 추가 |
| 2 | test/test_dashboard_cascade.ml:765 | \`Masc_mcp.Coord_utils\` unbound | \`Masc_mcp.\` prefix 제거 |
| 3 | test/test_prometheus_coverage.ml:252 | \`Printf.sprintf\` invalid format \`%0.f\` | \`%.0f\` 로 정정 |

## Why each fix

**1. board_post_detail_json**: 함수 정의 (lib/server/server_routes_http_runtime.ml:297) signature 가 \`~include_moderation ~blind_votes ~voter\` 인데 main_eio.ml:397 만 caller 미업데이트. 다른 두 caller (server_routes_http_routes_activity.ml:386, server_h2_gateway_routes_extra.ml:113) 는 이미 \`~blind_votes\` 전달.

**2. Coord_utils**: \`Masc_mcp\` wrapped module 에서 \`Coord_utils\` 가 노출 안 됨 (\`Coord_goals\` 등 일부만 노출). test_verification.ml:8 의 \`module CU = Coord_utils\` 처럼 unwrapped 직접 access. 같은 lib 의 다른 이름으로 변경한 것 아니라 wrap convention 차이.

**3. Printf format**: \`%0.f\` 는 OCaml Printf 에서 invalid (precision 표기는 dot 다음에 옴). 의도는 \`Unix.gettimeofday () *. 1000000.\` 의 precision 0 인쇄.

## Verification

- \`dune build --root .\` from worktree 통과 (모든 21,048 jobs, 0 failed)
- 의미 변경 없음 — 모두 mechanical fix

## RFC-WAIVED

agent_delegation 가드 path 미해당 (lib/keeper/credential_*, lib/repo_manager/, lib/operator/operator_control*, dashboard credential*, .claude/hooks/, instructions/workflow* 모두 X). chore 빌드 unblock.

## Best Programmer self-review

- **목표**: main 빌드 즉시 복구 (다른 PR 의 dashboard auto-disable 영향 차단)
- **변경 파일**: 3 (bin/main_eio.ml, test/test_dashboard_cascade.ml, test/test_prometheus_coverage.ml)
- **로컬 검증**: dune build 통과
- **미검증**: dashboard typecheck (\`dashboard/\` 미수정이지만 이전 PR memory \`feedback_pre_merge_typecheck_drag_in_blocker\` 권고대로 main 머지 후 dashboard 영향 모니터링 필요)

## Test plan

- [ ] CI \`gh pr checks --watch\`
- [ ] Pre-existing memory \`feedback_check_open_prs_before_fixing_pasted_build_error\` 적용 확인 — open PR 검색 (#13909/#13856/#13805 모두 다른 axis 이라 중복 없음 확인)
- [ ] 머지 후 main \`dune build\` 재확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)