### PR TITLE
fix(keeper): guard tool failure counters

### DIFF
--- a/lib/keeper/keeper_tools_oas.ml
+++ b/lib/keeper/keeper_tools_oas.ml
@@ -54,21 +54,47 @@ let recent_tools_for_keeper ?(limit = 5) keeper_name : string list =
 
 (* ── end tracking ────────────────────────────────────────────── *)
 
-(** Build OAS Tool.t list from keeper's allowed tools.
+(* Build OAS Tool.t list from keeper's allowed tools.
 
-    Each tool delegates to [execute_keeper_tool_call] with the current
-    [ctx_snapshot] value. Tools that raise exceptions return error results
-    instead of crashing the agent loop.
+   Each tool delegates to [execute_keeper_tool_call] with the current
+   [ctx_snapshot] value. Tools that raise exceptions return error results
+   instead of crashing the agent loop.
 
-    @param config Coord configuration for tool dispatch
-    @param meta Keeper metadata (determines which tools are allowed)
-    @param ctx_snapshot Immutable snapshot of current working context *)
+   @param config Coord configuration for tool dispatch
+   @param meta Keeper metadata (determines which tools are allowed)
+   @param ctx_snapshot Immutable snapshot of current working context *)
 (** Repeated-failure guardrail: blocks a tool after [max_consecutive]
     consecutive failures with the same (tool_name, args_hash) key.
     Resets on success. Prevents infinite retry loops (e.g. keeper
     reading a non-existent file 400+ times). *)
 let max_consecutive_failures =
   Env_config.KeeperToolExec.max_consecutive_tool_failures
+
+type failure_counts =
+  {
+    table : (string, int) Hashtbl.t;
+    mutex : Mutex.t;
+  }
+
+let create_failure_counts () =
+  { table = Hashtbl.create 16; mutex = Mutex.create () }
+
+let failure_count_get counts key =
+  Mutex.protect counts.mutex (fun () ->
+      Option.value ~default:0 (Hashtbl.find_opt counts.table key))
+
+let failure_count_record_failure counts key =
+  Mutex.protect counts.mutex (fun () ->
+      let next =
+        match Hashtbl.find_opt counts.table key with
+        | Some n -> n + 1
+        | None -> 1
+      in
+      Hashtbl.replace counts.table key next;
+      next)
+
+let failure_count_reset counts key =
+  Mutex.protect counts.mutex (fun () -> Hashtbl.remove counts.table key)
 
 (** Normalize a raw tool result string into a consistent JSON envelope.
 
@@ -365,7 +391,7 @@ let make_keeper_tool_handler
     ?search_fn
     ?on_tool_called
     ?(translate_input = fun j -> j)
-    ~(failure_counts : (string, int) Hashtbl.t)
+    ~(failure_counts : failure_counts)
     ()
   : Yojson.Safe.t -> bool * string =
   let args_key input =
@@ -375,10 +401,7 @@ let make_keeper_tool_handler
   fun raw_input ->
     let input = translate_input raw_input in
     let key = args_key input in
-    let prior_fails =
-      (match Hashtbl.find_opt failure_counts key with
-        | Some n -> n | None -> 0)
-    in
+    let prior_fails = failure_count_get failure_counts key in
     if prior_fails >= max_consecutive_failures then begin
       Prometheus.inc_counter
         Prometheus.metric_keeper_tools_oas_failures
@@ -410,8 +433,7 @@ let make_keeper_tool_handler
           | `Success -> false
         in
         if is_failure then begin
-          let count = prior_fails + 1 in
-          Hashtbl.replace failure_counts key count;
+          let count = failure_count_record_failure failure_counts key in
           Keeper_registry.record_tool_use ~base_path:config.base_path meta.name ~tool_name:name ~success:false;
           !Keeper_exec_tools.on_keeper_tool_call ~tool_name:name ~success:false ~duration_ms;
           (* Tool-call observability flows through the OAS Event_bus
@@ -456,7 +478,7 @@ let make_keeper_tool_handler
             ~original_bytes:(String.length normalized_error) ();
           (false, Tool_output_validation.cap normalized_error)
         end else begin
-          Hashtbl.remove failure_counts key;
+          failure_count_reset failure_counts key;
           Keeper_registry.record_tool_use ~base_path:config.base_path meta.name ~tool_name:name ~success:true;
           !Keeper_exec_tools.on_keeper_tool_call ~tool_name:name ~success:true ~duration_ms;
           (* Tool-call observability via OAS Event_bus. See above. *)
@@ -571,9 +593,10 @@ let make_keeper_tool_handler
            warn so dashboards don't conflate transient EDEADLK with real
            tool errors. The #10682 EDEADLK backtrace logging stays so the
            underlying Stdlib.Mutex site can still be pinpointed. *)
-        let count = if is_edeadlk then prior_fails else prior_fails + 1 in
-        if not is_edeadlk then
-          Hashtbl.replace failure_counts key count;
+        let count =
+          if is_edeadlk then failure_count_get failure_counts key
+          else failure_count_record_failure failure_counts key
+        in
         Keeper_registry.record_tool_use ~base_path:config.base_path meta.name ~tool_name:name ~success:false;
         !Keeper_exec_tools.on_keeper_tool_call ~tool_name:name ~success:false ~duration_ms;
         (* Tool-call observability via OAS Event_bus. See above. *)
@@ -699,8 +722,7 @@ let make_tool_bundle
       ~reason:"keeper tool bundle assembly"
       ()
   in
-  let failure_counts : (string, int) Hashtbl.t = Hashtbl.create 16 in
-  (* No mutex: Hashtbl ops are non-yielding, single domain. *)
+  let failure_counts = create_failure_counts () in
   (* Pass A: existing internal tools. Behavior unchanged from pre-A.2. *)
   let internal_tools =
     List.filter_map (fun (td : Masc_domain.tool_schema) ->

--- a/lib/keeper/keeper_tools_oas.mli
+++ b/lib/keeper/keeper_tools_oas.mli
@@ -41,6 +41,12 @@ val recent_tools_for_keeper : ?limit:int -> string -> string list
     same (tool_name, args_hash) key; resets on success. *)
 val max_consecutive_failures : int
 
+(** Thread-safe per-tool consecutive-failure counters shared by the
+    handler closures in one tool bundle. *)
+type failure_counts
+
+val create_failure_counts : unit -> failure_counts
+
 (** Normalize a raw tool result string into the canonical JSON
     envelope. Success → [{"ok":true,"result":...}]; failure →
     [{"ok":false,"error":...,"detail":...}]. Plain text is wrapped
@@ -85,7 +91,7 @@ val make_keeper_tool_handler :
   ?search_fn:(query:string -> max_results:int -> Yojson.Safe.t) ->
   ?on_tool_called:(string -> unit) ->
   ?translate_input:(Yojson.Safe.t -> Yojson.Safe.t) ->
-  failure_counts:(string, int) Hashtbl.t ->
+  failure_counts:failure_counts ->
   unit ->
   Yojson.Safe.t -> bool * string
 

--- a/test/test_keeper_tools_oas.ml
+++ b/test/test_keeper_tools_oas.ml
@@ -115,23 +115,34 @@ let string_contains ~sub text =
   in
   sub_len = 0 || loop 0
 
+let rec rm_rf path =
+  match Unix.lstat path with
+  | exception Unix.Unix_error (Unix.ENOENT, _, _) -> ()
+  | stat ->
+      match stat.Unix.st_kind with
+      | Unix.S_DIR ->
+          Sys.readdir path
+          |> Array.iter (fun name -> rm_rf (Filename.concat path name));
+          Unix.rmdir path
+      | _ -> Sys.remove path
+
 let test_tool_side_effect_failures_are_observed () =
   let meta = make_test_meta ~name:"test-keeper-side-effects" () in
   let ctx_snapshot = make_test_ctx () in
-  let dir =
-    Filename.concat (Filename.get_temp_dir_name ())
-      (Printf.sprintf "test_keeper_tools_side_effects_%d" (Random.int 100000))
-  in
-  (try Unix.mkdir dir 0o755 with Unix.Unix_error (Unix.EEXIST, _, _) -> ());
+  let dir = Filename.temp_file "test_keeper_tools_side_effects_" "" in
+  Sys.remove dir;
+  Unix.mkdir dir 0o755;
   Fun.protect
-    ~finally:(fun () ->
-      (try Sys.readdir dir |> Array.iter (fun f ->
-        Sys.remove (Filename.concat dir f));
-        Unix.rmdir dir with _ -> ()))
+    ~finally:(fun () -> rm_rf dir)
     (fun () ->
       Eio_main.run @@ fun env ->
       Fs_compat.set_fs (Eio.Stdenv.fs env);
       let config = Coord.default_config dir in
+      let decision_path =
+        Keeper_types_support.keeper_decision_log_path config meta.name
+      in
+      Fs_compat.mkdir_p (Filename.dirname decision_path);
+      Unix.mkdir decision_path 0o755;
       let tools = Keeper_tools_oas.make_tools ~config ~meta ~ctx_snapshot () in
       let tool = find_tool "keeper_fs_read" tools in
       let keeper_labels = [("keeper", meta.name)] in


### PR DESCRIPTION
## Summary

- Replaced the shared keeper tool failure-count Hashtbl with an abstract mutex-protected counter.
- Kept repeated-failure guard semantics unchanged for failure, success reset, and transient EDEADLK handling.
- Made the side-effect failure test force decision-log append failure deterministically and clean nested temp state.

## Product impact

- User-visible change: none expected. This hardens keeper tool execution under concurrent handler use and preserves the existing operator-facing guardrail behavior.

## Evidence

- `scripts/dune-local.sh build test/test_keeper_tools_oas.exe`
- `./_build/default/test/test_keeper_tools_oas.exe` PASS, 35 tests
- `bash scripts/ci/check-silent-failure-patterns.sh` PASS, no critical silent failures detected
- `git diff --check HEAD~1 HEAD` PASS
- `ocamlc -stop-after parsing lib/keeper/keeper_tools_oas.ml && ocamlc -stop-after parsing lib/keeper/keeper_tools_oas.mli && ocamlc -stop-after parsing test/test_keeper_tools_oas.ml` PASS

## GOAL LOOP ACT checklist

- [x] Observe — Kimi audit item identified keeper_tools_oas failure_counts as a raw shared Hashtbl used by tool handler closures.
- [x] Orient — mapped to keeper tool repeated-failure guard state shared across bundled handlers.
- [x] Decide — bounded fix protects the shared table without changing tool execution or guard thresholds.
- [x] Act — code changed only in keeper_tools_oas and the focused regression test.
- [x] Verify — focused Dune build, focused test executable, silent-failure scan, diff check, and parser checks passed locally.
- [x] Loop — no follow-up required for this narrow race hardening slice.

## Review evidence

- Not run: no cross-model review for this bounded concurrency patch.

## Linked issue

- Relates: Kimi audit follow-up; no GitHub issue number.

## Variant addition checklist

- [ ] **OCaml** — N/A: no variant added, removed, or renamed.
- [ ] **TypeScript** — N/A: no TypeScript union member changed.
- [ ] **TLA+ spec** — N/A: no TLA+ domain literal changed.
- [ ] **Event / JSON schema** — N/A: no event or JSON schema enum changed.
- [ ] **`make check-variants` passes** — N/A: no variant surface changed.
