### PR TITLE
Count hook-observed keeper tool calls in contract checks

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -557,8 +557,18 @@ let run_turn
        let tool_usage_after =
          Keeper_tool_disclosure.keeper_tool_usage_snapshot ~base_path:config.base_path ~keeper_name:meta.name
        in
-       let observed_tool_names =
+       let registry_observed_tool_names =
          Keeper_tool_disclosure.tool_usage_delta ~before:tool_usage_before ~after:tool_usage_after
+       in
+       let hook_observed_tool_names =
+         List.rev_map
+           (fun (detail : tool_call_detail) -> detail.tool_name)
+           acc.tool_calls
+       in
+       let observed_tool_names =
+         Keeper_tool_disclosure.merge_observed_tool_names
+           ~registry_observed_tool_names
+           ~hook_observed_tool_names
        in
        observed_tool_names_ref := observed_tool_names;
        let tool_names =

--- a/lib/keeper/keeper_tool_disclosure.ml
+++ b/lib/keeper/keeper_tool_disclosure.ml
@@ -25,6 +25,34 @@ let tool_usage_delta ~(before : (string * int) list) ~(after : (string * int) li
     List.init (max 0 (after_count - before_count)) (fun _ -> tool_name))
 ;;
 
+let merge_observed_tool_names
+      ~(registry_observed_tool_names : string list)
+      ~(hook_observed_tool_names : string list)
+  : string list
+  =
+  let hook_counts = Hashtbl.create 16 in
+  List.iter
+    (fun tool_name ->
+      let count = Option.value ~default:0 (Hashtbl.find_opt hook_counts tool_name) in
+      Hashtbl.replace hook_counts tool_name (count + 1))
+    hook_observed_tool_names;
+  let emitted_extra = Hashtbl.create 16 in
+  hook_observed_tool_names
+  @ List.filter
+      (fun tool_name ->
+        let hook_count =
+          Option.value ~default:0 (Hashtbl.find_opt hook_counts tool_name)
+        in
+        let already_emitted =
+          Option.value ~default:0 (Hashtbl.find_opt emitted_extra tool_name)
+        in
+        if already_emitted < hook_count then (
+          Hashtbl.replace emitted_extra tool_name (already_emitted + 1);
+          false)
+        else true)
+      registry_observed_tool_names
+;;
+
 let merge_reported_and_observed_tool_names
       ~(reported_tool_names : string list)
       ~(observed_tool_names : string list)

--- a/lib/keeper/keeper_tool_disclosure.mli
+++ b/lib/keeper/keeper_tool_disclosure.mli
@@ -19,6 +19,16 @@ val tool_usage_delta :
   after:(string * int) list ->
   string list
 
+(** Merge provider hook-observed tool names with registry-observed
+    deltas. The hook path is the most direct runtime signal, while
+    registry deltas are retained for tools that only update the
+    keeper registry. Duplicate sources are combined by max count per
+    tool instead of double-counting the same execution. *)
+val merge_observed_tool_names :
+  registry_observed_tool_names:string list ->
+  hook_observed_tool_names:string list ->
+  string list
+
 (** Merge model-reported tool names with provider-observed ones.
     When [observed_tool_names] is non-empty it dominates the head
     of the result; reported-only tails are appended. *)

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -6653,6 +6653,27 @@ let test_tool_usage_delta_ignores_removed_tools () =
     []
     (KTD.tool_usage_delta ~before ~after)
 
+let test_merge_observed_tool_names_prefers_hook_without_double_counting () =
+  let merged =
+    KTD.merge_observed_tool_names
+      ~hook_observed_tool_names:[ "keeper_bash"; "keeper_pr_create" ]
+      ~registry_observed_tool_names:
+        [ "keeper_bash"; "keeper_pr_create"; "keeper_board_post" ]
+  in
+  check (list string) "hook evidence plus registry-only tail"
+    [ "keeper_bash"; "keeper_pr_create"; "keeper_board_post" ]
+    merged
+
+let test_merge_observed_tool_names_preserves_extra_registry_repeats () =
+  let merged =
+    KTD.merge_observed_tool_names
+      ~hook_observed_tool_names:[ "keeper_bash" ]
+      ~registry_observed_tool_names:[ "keeper_bash"; "keeper_bash" ]
+  in
+  check (list string) "max count per observed source"
+    [ "keeper_bash"; "keeper_bash" ]
+    merged
+
 let test_merge_reported_and_observed_tool_names_preserves_synthetic_tools () =
   let merged =
     KTD.merge_reported_and_observed_tool_names
@@ -8194,6 +8215,10 @@ let () =
             test_tool_usage_delta_uses_registry_counts;
           test_case "tool usage delta ignores removed tools" `Quick
             test_tool_usage_delta_ignores_removed_tools;
+          test_case "merge observed tool names uses hook evidence" `Quick
+            test_merge_observed_tool_names_prefers_hook_without_double_counting;
+          test_case "merge observed tool names keeps extra registry repeats" `Quick
+            test_merge_observed_tool_names_preserves_extra_registry_repeats;
           test_case "merge observed and synthetic tool names" `Quick
             test_merge_reported_and_observed_tool_names_preserves_synthetic_tools;
           test_case "final keeper tool names fall back to reported tools"


### PR DESCRIPTION
## Summary

- include OAS hook-observed keeper tool calls when computing observed tools for a keeper turn
- keep registry deltas as a fallback/tail so registry-only tool signals are still counted
- add unit coverage for merging hook-observed and registry-observed tool names without double-counting the same execution

## Why

The Docker keeper PR lifecycle reprobe showed a false negative: a keeper executed real Docker-backed tools, but the required-tool contract failed with `no keeper-surface tools were called`. The existing contract path only trusted model-reported tool use and `Keeper_registry` usage deltas. Runtime MCP/OAS hook evidence already records the actual executed tool calls in `acc.tool_calls`, so the contract should count that direct execution signal.

This does not resolve the separate invalid nonoperator GitHub credential blocker tracked in #13920. It prevents successful tool executions from being misclassified as no-tool turns.

## Operator Impact

Keeper turns that actually execute keeper-surface tools should no longer be marked as required-tool no-call solely because the registry delta missed the runtime MCP call. Receipts should preserve hook-observed tools in `observed_tools`, `tools_used`, and downstream contract status.

## Validation

- `git diff --check`
- Draft PR gates passed: CI Gate, Draft Auto-Merge Guard, Env knob classification, Fun.protect finalizer guard, Godfile size, Hardcoded model prefix, Math.random in components, PR Live Gate, PR Sync Check, Workflow YAML syntax
- Attempted `scripts/dune-local.sh build test/test_keeper_unified.exe`; local verification is still blocked by the shared `/tmp/me-dune-local.lock` held by other active worktree builds. Full build/test jobs are skipped while the PR remains draft.