### PR TITLE
fix(keeper): reject keyring-only github bundles

### DIFF
--- a/lib/repo_manager/credential_materializer.ml
+++ b/lib/repo_manager/credential_materializer.ml
@@ -6,7 +6,8 @@
     |---------------------|--------|-----------------|
     | None / empty | none | [Unmaterialized] |
     | non-empty dir, missing on disk | none | [Unmaterialized] |
-    | exists + [gh auth status] = 0 | record verify timestamp | [Materialized {last_verified_at}] |
+    | exists + missing [hosts.yml] [oauth_token] | none | [Stale {reason}] |
+    | exists + [hosts.yml] [oauth_token] + [gh auth status] = 0 | record verify timestamp | [Materialized {last_verified_at}] |
     | exists + [gh auth status] != 0 | record reason | [Stale {reason}] |
 
     PR-B Slice 1 ships this **verify-only** path.  The two [oauth_method]
@@ -89,6 +90,34 @@ let gh_auth_status_ok ~gh_config_dir =
       | Unix.WEXITED 0 -> true
       | _ -> false)
 
+let hosts_yml_has_oauth_token ~gh_config_dir =
+  let path = Filename.concat gh_config_dir gh_hosts_yml in
+  if not (Sys.file_exists path) then false
+  else
+    try
+      let ic = open_in path in
+      Fun.protect
+        ~finally:(fun () -> close_in_noerr ic)
+        (fun () ->
+          let found = ref false in
+          (try
+             while not !found do
+               let line = input_line ic in
+               let trimmed = String.trim line in
+               let prefix = "oauth_token:" in
+               let plen = String.length prefix in
+               if String.length trimmed > plen
+                  && String.equal (String.sub trimmed 0 plen) prefix
+                  && String.trim
+                       (String.sub trimmed plen
+                          (String.length trimmed - plen))
+                     <> ""
+               then found := true
+             done
+           with End_of_file -> ());
+          !found)
+    with Sys_error _ -> false
+
 (** Compute the new state for [gh_config_dir] without writing anywhere.
     Pure with respect to credential records; reads filesystem + invokes
     [gh] subprocess. *)
@@ -97,6 +126,15 @@ let verify_state ~gh_config_dir : credential_state =
   else if not (Sys.file_exists gh_config_dir) then Unmaterialized
   else if not (Sys.is_directory gh_config_dir) then
     Stale { reason = "gh_config_dir is not a directory" }
+  else if not (hosts_yml_has_oauth_token ~gh_config_dir) then
+    Stale
+      {
+        reason =
+          "gh_config_dir has no hosts.yml oauth_token; keyring-backed \
+           GitHub auth cannot be projected into Docker. Re-materialize \
+           this identity with `gh auth login --with-token \
+           --insecure-storage` into the bundle.";
+      }
   else if gh_auth_status_ok ~gh_config_dir then
     Materialized { last_verified_at = now_unix_ms () }
   else

--- a/lib/repo_manager/credential_materializer.mli
+++ b/lib/repo_manager/credential_materializer.mli
@@ -1,6 +1,9 @@
 (** Decide on-disk materialisation status for a credential record.
     See {!Credential_materializer} module documentation for the full
-    state-derivation table.  RFC-0019 §4.4. *)
+    state-derivation table.  A bundle is materialized only when its
+    [hosts.yml] contains an [oauth_token] that can be projected into a
+    Docker keeper container; host keyring-only gh auth is [Stale].
+    RFC-0019 §4.4. *)
 
 open Repo_manager_types
 

--- a/test/test_credential_materializer.ml
+++ b/test/test_credential_materializer.ml
@@ -2,13 +2,14 @@
     {!Credential_materializer.verify_state} and {!ensure}.
 
     The [Materialized] outcome requires a real [gh] subprocess + a
-    populated bundle and is exercised by the end-to-end test added in
-    PR-B Slice 3.  Here we pin the three branches that do not depend on
-    [gh] being installed:
+    populated, Docker-projectable bundle and is exercised by the
+    end-to-end test added in PR-B Slice 3.  Here we pin the branches
+    that do not depend on [gh] being installed:
 
     1. [None] / empty / missing [gh_config_dir] -> [Unmaterialized].
     2. Path exists but is a file rather than a directory -> [Stale].
-    3. [ensure] mutates only the [state] field; every other field on the
+    3. Path exists but [hosts.yml] has no [oauth_token] -> [Stale].
+    4. [ensure] mutates only the [state] field; every other field on the
        input record is preserved verbatim. *)
 
 open Repo_manager_types
@@ -86,6 +87,43 @@ let test_path_is_file_is_stale () =
              with Not_found -> false)
       | other ->
           Alcotest.failf "expected Stale, got %s"
+            (show_credential_state other))
+
+let test_keyring_backed_bundle_without_oauth_token_is_stale () =
+  with_temp_base_path (fun base ->
+      let gh_config_dir = Filename.concat base "keyring_only_gh" in
+      Unix.mkdir gh_config_dir 0o700;
+      let hosts_yml = Filename.concat gh_config_dir "hosts.yml" in
+      let oc = open_out hosts_yml in
+      output_string oc
+        "github.com:\n\
+        \    git_protocol: https\n\
+        \    users:\n\
+        \        yousleepwhen:\n\
+        \    user: yousleepwhen\n";
+      close_out oc;
+      match
+        Credential_materializer.verify_state ~gh_config_dir
+      with
+      | Stale { reason } ->
+          Alcotest.(check bool)
+            "reason mentions missing oauth_token" true
+            (try
+               ignore
+                 (Str.search_forward
+                    (Str.regexp_string "oauth_token") reason 0);
+               true
+             with Not_found -> false);
+          Alcotest.(check bool)
+            "reason points at insecure-storage rematerialization" true
+            (try
+               ignore
+                 (Str.search_forward
+                    (Str.regexp_string "--insecure-storage") reason 0);
+               true
+             with Not_found -> false)
+      | other ->
+          Alcotest.failf "expected Stale for keyring-only bundle, got %s"
             (show_credential_state other))
 
 (* --- 3. ensure mutates only state, preserves other fields --- *)
@@ -596,6 +634,9 @@ let () =
             test_missing_path_is_unmaterialized;
           Alcotest.test_case "file (not dir) is Stale" `Quick
             test_path_is_file_is_stale;
+          Alcotest.test_case
+            "keyring-only hosts.yml without oauth_token is Stale" `Quick
+            test_keyring_backed_bundle_without_oauth_token_is_stale;
         ] );
       ( "ensure",
         [

--- a/test/test_credential_provider.ml
+++ b/test/test_credential_provider.ml
@@ -529,8 +529,8 @@ let test_f1_gate_resolve_stub () =
 (* --- 6. #12685: credential preflight gate --- *)
 
 let test_preflight_missing_hosts_yml () =
-  (* gh_config_dir exists but has no hosts.yml -> verify_state
-     returns Unmaterialized -> resolve must return Missing_bundle. *)
+  (* gh_config_dir exists but has no hosts.yml/oauth_token ->
+     verify_state returns Stale -> resolve must return Missing_bundle. *)
   with_temp_base_path (fun base_path ->
       let config = Masc_mcp.Coord.default_config base_path in
       let gh_config_dir =


### PR DESCRIPTION
## Summary
- Treat keyring-only GitHub identity bundles as stale unless `hosts.yml` carries an `oauth_token` that Docker can mount.
- Add a regression for `hosts.yml` with `users`/`user` but no token.
- Document that keeper credential materialization requires a Docker-projectable token, not host keyring auth.

## Why
The live Docker fork-lane proof showed the verifier identity passing host-side `gh auth status` through the macOS keyring, while Docker `gh` calls failed with HTTP 401 because the keyring is not projected into the container. This makes preflight/dashboard state look healthy while keeper PR creation fails at runtime.

## Live Evidence
- Before remediation, verifier `hosts.yml` had `user: yousleepwhen` but no `oauth_token`; host `gh auth status` reported `(keyring)` and Docker `gh repo fork`/`keeper_pr_create` returned HTTP 401.
- After re-materializing the verifier identity into `hosts.yml` with `--insecure-storage`, run `keeper-docker-pr-lifecycle-fork-live-20260507-remat` produced Docker git push + Docker PR create evidence for both selected accounts.
- Sangsu / `anyang-keepers`: Docker push + PR create evidence recorded; PR #13926 was created from `keeper-sangsu-agent/keeper-docker-pr-lifecycle-fork-live-20260507-remat`.
- Verifier / `yousleepwhen`: Docker `gh repo fork`, fork push, and `keeper_pr_create` succeeded; open draft PR #13930 exists from fork branch `keeper-verifier-agent/keeper-docker-pr-lifecycle-fork-live-20260507-remat`.
- Read-only audit artifact: `/private/tmp/keeper-docker-pr-lifecycle-fork-live-20260507-remat/audit-create-push-current.json`; selected keepers `sangsu` and `verifier` have no failures for `--require-docker-pr-create-evidence --require-docker-git-push-evidence --evidence-run-id keeper-docker-pr-lifecycle-fork-live-20260507-remat`.

## Validation
- `git diff --check`
- `python3 test/test_audit_keeper_fleet_readiness.py`
- `ruff check scripts/audit-keeper-fleet-readiness.py test/test_audit_keeper_fleet_readiness.py`
- `npx pyright --outputjson scripts/audit-keeper-fleet-readiness.py test/test_audit_keeper_fleet_readiness.py`
- `bash -n scripts/harness/workload/keeper_docker_pr_lifecycle_reprobe.sh`
- GitHub checks on this draft: `CI Gate`, `PR Live Gate`, `PR Sync Check`, `Draft Auto-Merge Guard`, and fundamental checks pass/skipped under draft policy.
- Attempted `scripts/dune-local.sh build ./_build/default/test/test_credential_materializer.exe`; local Dune wrapper did not complete because `/tmp/me-dune-local.lock` was held by another worktree build.
