### PR TITLE
feat(oas): wire max_execution_time + clock to Agent.run_stream/run

### DIFF
--- a/lib/oas_worker_exec.ml
+++ b/lib/oas_worker_exec.ml
@@ -41,6 +41,7 @@ type config =
   max_turns : int;
   max_idle_turns : int;
   stream_idle_timeout_s : float option;
+  max_execution_time_s : float option;
   max_tokens : int;
   max_input_tokens : int option;
   max_cost_usd : float option;
@@ -422,9 +423,19 @@ let run
         let cr = Agent_sdk.Contract_runner.run ~sw ~contract:c agent goal in
         (cr.response, Some cr.proof)
       | None ->
+        (* Pass the process-level Eio clock when available so agent_sdk's
+           [with_optional_timeout] can fire on hang when the caller has
+           also set [config.max_execution_time_s]. Both inputs must be
+           [Some] for the timeout to engage; absent either, behaviour is
+           historical (block until provider closes). *)
+        let clock =
+          match Process_eio.get_clock () with
+          | Ok c -> Some c
+          | Error _ -> None
+        in
         let r = match on_event with
-          | Some cb -> Agent_sdk.Agent.run_stream ~sw ?on_yield ?on_resume ~on_event:cb agent goal
-          | None -> Agent_sdk.Agent.run ~sw ?on_yield ?on_resume agent goal
+          | Some cb -> Agent_sdk.Agent.run_stream ~sw ?clock ?on_yield ?on_resume ~on_event:cb agent goal
+          | None -> Agent_sdk.Agent.run ~sw ?clock ?on_yield ?on_resume agent goal
         in
         (r, None)
     in

--- a/lib/oas_worker_exec.mli
+++ b/lib/oas_worker_exec.mli
@@ -78,6 +78,7 @@ type config = Oas_worker_exec_agent.config = {
   max_turns : int;
   max_idle_turns : int;
   stream_idle_timeout_s : float option;
+  max_execution_time_s : float option;
   max_tokens : int;
   max_input_tokens : int option;
   max_cost_usd : float option;

--- a/lib/oas_worker_exec_agent.ml
+++ b/lib/oas_worker_exec_agent.ml
@@ -23,6 +23,16 @@ type config = {
   max_turns : int;
   max_idle_turns : int;
   stream_idle_timeout_s : float option;
+  max_execution_time_s : float option;
+      (** Wall-clock ceiling for one [Agent_sdk.Agent.run] / [run_stream]
+          call. When [Some s] AND a clock is available at the call site,
+          agent_sdk's [with_optional_timeout] returns
+          [Error (Api (Retry.Timeout {...}))] after [s] seconds — the
+          cascade FSM already maps [Retry.Timeout] to a fallback signal,
+          so this is the canonical knob to bound a hung [run_stream]
+          when a provider closes the connection without [end_turn].
+          Default [None] preserves the historical behaviour
+          (block indefinitely on stream-parser hang). *)
   max_tokens : int;
   max_input_tokens : int option;
   max_cost_usd : float option;
@@ -109,6 +119,7 @@ let default_config
     max_turns = 20;
     max_idle_turns = 3;
     stream_idle_timeout_s = None;
+    max_execution_time_s = None;
     max_tokens = Oas_worker_cascade.default_max_tokens;
     max_input_tokens = None;
     max_cost_usd = None;
@@ -180,6 +191,11 @@ let builder_without_approval
   let builder =
     match config.stream_idle_timeout_s with
     | Some timeout_s -> Agent_sdk.Builder.with_stream_idle_timeout timeout_s builder
+    | None -> builder
+  in
+  let builder =
+    match config.max_execution_time_s with
+    | Some s -> Agent_sdk.Builder.with_max_execution_time s builder
     | None -> builder
   in
   let builder =
@@ -359,6 +375,7 @@ let prepare_resume ~(config : config) ~(checkpoint : Agent_sdk.Checkpoint.t) :
       hooks = Option.value ~default:Agent_sdk.Hooks.empty config.hooks;
       max_idle_turns = config.max_idle_turns;
       stream_idle_timeout_s = config.stream_idle_timeout_s;
+      max_execution_time_s = config.max_execution_time_s;
       guardrails = guardrails_of_config config;
       context_reducer = config.context_reducer;
       context_injector = config.context_injector;

--- a/lib/oas_worker_exec_agent.mli
+++ b/lib/oas_worker_exec_agent.mli
@@ -39,6 +39,11 @@ type config = {
   max_turns : int;
   max_idle_turns : int;
   stream_idle_timeout_s : float option;
+  max_execution_time_s : float option;
+      (** Wall-clock ceiling for one [Agent.run] / [run_stream] call.
+          When [Some] AND a clock is available, agent_sdk returns
+          [Retry.Timeout] after [s] seconds. Default [None] preserves
+          historical block-on-hang behaviour. *)
   max_tokens : int;
   max_input_tokens : int option;
   max_cost_usd : float option;


### PR DESCRIPTION
## Summary

Activates `agent_sdk`'s pre-existing `with_optional_timeout` mechanism that has been dormant in masc-mcp. This PR is the wiring layer; a follow-up populates the field with a concrete value.

## Problem

`agent_sdk/agent/agent.ml:246-260` wraps `Agent.run` and `Agent.run_stream` with `with_optional_timeout`. The wrapper converts a hung `run_stream` into `Error.Api (Retry.Timeout {...})` — but **only when both** `agent.options.max_execution_time_s` AND `?clock` are set. masc-mcp set neither:

- `rg "with_max_execution_time" lib/` → 0 hits before this PR.
- `oas_worker_exec.ml:425-427`'s `Agent.run` / `run_stream` calls passed no `?clock`.

So `with_optional_timeout` fell through to `f ()` unchanged in every production code path. Any `Eio.Stream.take` inside agent_sdk's stream parser then blocked indefinitely when an upstream provider closed the connection without an `end_turn` event — exactly the empty-response hang Step 3a identified.

Direct evidence at `~/me/memory/procedural-memory/2026-05-07-oas-run-stream-hang-root-cause-evidence.md`.

## What changes

| File | Change |
|------|--------|
| `lib/oas_worker_exec_agent.ml` | Add `max_execution_time_s : float option` to `config`; default to `None` in `default_config`; wire builder via `Agent_sdk.Builder.with_max_execution_time` when `Some`; thread the value into the resume options record. |
| `lib/oas_worker_exec_agent.mli` | Mirror the new field. |
| `lib/oas_worker_exec.ml` | Add the `max_execution_time_s` field to the re-exported `config` record. In `run`, source a process-level Eio clock via `Process_eio.get_clock ()` and pass `?clock` to both `Agent.run_stream` and `Agent.run`. |
| `lib/oas_worker_exec.mli` | Mirror the new field. |

Net diff: 4 files / +36 / -2.

## Why this shape

| Alternative | Why not |
|-------------|---------|
| New post-`run_stream` empty-response detector in `oas_worker_exec.ml` | Hang is inside `Eio.Stream.take` — control never reaches the post-detection code. |
| Force-short `stream_idle_timeout_s` to throw on EOF | Couples HTTP idle path with stream-parser hang, two distinct concerns. |
| New `Agent_sdk.Error` variant + cascade FSM mapping | Cascade FSM already maps `Retry.Timeout` to fallback. Adding a variant is duplicate work. |

The shape used here matches the `stream_idle_timeout_s` pattern that already exists at `oas_worker_exec_agent.ml:181-184` (single `match … with Some s -> Builder.with_X s b | None -> b`). One precedent, one knob.

## Out of scope (deferred)

- **Caller wiring**: no caller in `lib/oas_worker_named.ml` yet populates `max_execution_time_s`. Production behaviour is byte-for-byte unchanged. A follow-up PR will source the value from `Keeper_runtime_resolved.oas_timeout_sec_live ()` (one-OAS-call scale, ~300 s default) so cascade fallback engages on hang.
- **Regression test of `Retry.Timeout` path**: depends on caller wire being live; would otherwise be a no-op test.
- **`Process_eio.get_clock` failure observability**: when `Error _`, we silently fall to `None` (i.e. timeout disabled). Reasonable because `Process_eio` is initialised at server boot in `bin/masc_worker_run.ml:50` and `bin/main_eio.ml:657`; failure means we are not running under Eio at all.

## Test plan

- [x] `dune build --root .` against my four files — type-check passes.
- [ ] CI green — see "Pre-existing items" below.
- [ ] Manual probe: planned for follow-up PR after caller wires the field.

## Pre-existing items not addressed here

`lib/keeper/keeper_execution_receipt.ml:716` and `:722` both contain `| Some (Keeper_registry.Stale_fleet_batch _) -> "stale_fleet_batch"` — duplicate match arm, warning 11, treated as error under `-W +11`. This is a regression from PR #13805 of a fix previously landed in #13830 (`fix(main): remove duplicate stale fleet receipt arm`). My diff does not touch that file. CI may show that error until a separate unblock PR lands.

## Refs

- Goal: `oas-bridge-stabilization` Step 3b (wiring half)
- Plan: `~/me/planning/claude-plans/20m-me-workspace-yousleepwhen-masc-mcp-o-recursive-mountain.md`
- Companion PRs: #13894 (kimi_cli idle, **MERGED** as `15b6c37f55`), #13901 (turn_timeout ceiling 600→900s, MERGEABLE awaiting `human-approved-ready` label)
- Evidence: `~/me/memory/procedural-memory/2026-05-07-oas-run-stream-hang-root-cause-evidence.md`

RFC-WAIVED: this PR touches only `lib/oas_worker_exec*.ml{,i}` and `lib/oas_worker_exec_agent*.ml{,i}`. No credential / identity / auth / sandbox / dashboard-credential / hooks / workflow paths from the RFC discovery list are touched.
