### PR TITLE
fix(keeper): remove duplicate stale batch receipt case

### DIFF
--- a/lib/keeper/keeper_execution_receipt.ml
+++ b/lib/keeper/keeper_execution_receipt.ml
@@ -719,7 +719,6 @@ let stale_terminal_reason_code = function
   | Some (Keeper_registry.Heartbeat_consecutive_failures _) ->
       "heartbeat_failures"
   | Some (Keeper_registry.Turn_consecutive_failures _) -> "turn_failures"
-  | Some (Keeper_registry.Stale_fleet_batch _) -> "stale_fleet_batch"
   | Some (Keeper_registry.Ambiguous_partial_commit _) ->
       "ambiguous_partial_commit"
   | Some Keeper_registry.Fiber_unresolved -> "fiber_unresolved"


### PR DESCRIPTION
Summary: remove the duplicate Stale_fleet_batch branch in keeper_execution_receipt.stale_terminal_reason_code that fails main CI under -warn-error +a warning 11. Validation: git diff --check passed; focused Dune validation was attempted but skipped due shared dune-local lock saturation, so PR CI is the compile proof.