### PR TITLE
Improve keeper OAS timeout budget receipts

### DIFF
--- a/lib/keeper/keeper_turn_cascade_budget.ml
+++ b/lib/keeper/keeper_turn_cascade_budget.ml
@@ -324,6 +324,10 @@ let reclassify_oas_timeout_for_attempt
                timeout_budget.keeper_turn_timeout_sec;
              estimated_input_tokens = timeout_budget.estimated_input_tokens;
              source = timeout_budget.source;
+             remaining_turn_budget_sec =
+               Some timeout_budget.remaining_turn_budget_sec;
+             min_required_sec = min_oas_timeout_budget_sec;
+             phase = "cascade_attempt_watchdog";
            })
   | _ -> err
 

--- a/lib/keeper/keeper_unified_metrics.ml
+++ b/lib/keeper/keeper_unified_metrics.ml
@@ -1602,15 +1602,10 @@ let update_metrics_from_failure (meta : keeper_meta) ~(latency_ms : int)
             if trimmed = "" then reason else trimmed
         | Some
             (Oas_worker_named.Oas_timeout_budget
-               {
-                 budget_sec;
-                 keeper_turn_timeout_sec;
-                 estimated_input_tokens;
-                 source;
-               }) ->
-            Printf.sprintf
-              "OAS budget timeout after %.1fs (%s, estimated input %d tokens, keeper hard cap %.1fs)"
-              budget_sec source estimated_input_tokens keeper_turn_timeout_sec
+               _ as err) ->
+            Option.value
+              ~default:reason
+              (Oas_worker_named.summary_of_masc_internal_error err)
         | Some (Oas_worker_named.No_tool_capable_provider _ as err) -> (
             match Oas_worker_named.summary_of_masc_internal_error err with
             | Some summary -> summary

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -1089,13 +1089,22 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
               with
               | None ->
                   Error
-                    (Agent_sdk.Error.Api
-                       (Timeout
+                    (Oas_worker_named.sdk_error_of_masc_internal_error
+                       (Oas_worker_named.Oas_timeout_budget
                           {
-                            message =
-                              Printf.sprintf
-                                "Turn wall-clock budget exhausted before retry (remaining=%.1fs)"
-                                (remaining_turn_budget_s ());
+                            budget_sec = 0.0;
+                            keeper_turn_timeout_sec = timeout_sec;
+                            estimated_input_tokens =
+                              prompt_timeout_estimate_tokens;
+                            source =
+                              (if is_retry then "pre_retry_budget_unavailable"
+                               else "pre_attempt_budget_unavailable");
+                            remaining_turn_budget_sec =
+                              Some (remaining_turn_budget_s ());
+                            min_required_sec = min_oas_timeout_budget_sec;
+                            phase =
+                              (if is_retry then "pre_retry_budget_gate"
+                               else "pre_attempt_budget_gate");
                           }))
               | Some timeout_budget ->
                   attempt_timeout_budget := Some timeout_budget;

--- a/lib/oas_worker_named_error.ml
+++ b/lib/oas_worker_named_error.ml
@@ -58,6 +58,9 @@ type masc_internal_error =
       keeper_turn_timeout_sec : float;
       estimated_input_tokens : int;
       source : string;
+      remaining_turn_budget_sec : float option;
+      min_required_sec : float;
+      phase : string;
     }
   | Ambiguous_post_commit of {
       is_timeout : bool;
@@ -187,6 +190,9 @@ let masc_internal_error_to_json = function
         keeper_turn_timeout_sec;
         estimated_input_tokens;
         source;
+        remaining_turn_budget_sec;
+        min_required_sec;
+        phase;
       } ->
     `Assoc
       [
@@ -195,6 +201,10 @@ let masc_internal_error_to_json = function
         ("keeper_turn_timeout_sec", `Float keeper_turn_timeout_sec);
         ("estimated_input_tokens", `Int estimated_input_tokens);
         ("source", `String source);
+        ( "remaining_turn_budget_sec",
+          Json_util.float_opt_to_json remaining_turn_budget_sec );
+        ("min_required_sec", `Float min_required_sec);
+        ("phase", `String phase);
       ]
   | Ambiguous_post_commit { is_timeout; tools; original_error } ->
     `Assoc
@@ -235,6 +245,26 @@ let summary_of_masc_internal_error = function
            (summarize_list required_tool_names)
            (summarize_provider_rejections provider_rejections)
            (summarize_list configured_labels))
+  | Oas_timeout_budget
+      {
+        budget_sec;
+        keeper_turn_timeout_sec;
+        estimated_input_tokens;
+        source;
+        remaining_turn_budget_sec;
+        min_required_sec;
+        phase;
+      } ->
+      let remaining =
+        match remaining_turn_budget_sec with
+        | Some value -> Printf.sprintf "%.1fs" value
+        | None -> "unknown"
+      in
+      Some
+        (Printf.sprintf
+           "OAS timeout budget exhausted; phase=%s; source=%s; budget=%.1fs; remaining=%s; min_required=%.1fs; estimated_input_tokens=%d; keeper_turn_timeout=%.1fs"
+           phase source budget_sec remaining min_required_sec
+           estimated_input_tokens keeper_turn_timeout_sec)
   | _ -> None
 
 (* #9933: classify emitted [masc_oas_error] payloads by kind so
@@ -336,6 +366,16 @@ let classify_masc_internal_error (err : Agent_sdk.Error.sdk_error) :
         match List.assoc_opt key fields with
         | Some (`Int value) -> Some value
         | Some (`Intlit value) -> int_of_string_opt value
+        | _ -> None)
+    | _ -> None
+  in
+  let float_opt_of_assoc key = function
+    | `Assoc fields -> (
+        match List.assoc_opt key fields with
+        | Some (`Float value) -> Some value
+        | Some (`Int value) -> Some (float_of_int value)
+        | Some (`Intlit value) ->
+            Option.map float_of_int (int_of_string_opt value)
         | _ -> None)
     | _ -> None
   in
@@ -462,6 +502,15 @@ let classify_masc_internal_error (err : Agent_sdk.Error.sdk_error) :
                               keeper_turn_timeout_sec;
                               estimated_input_tokens;
                               source;
+                              remaining_turn_budget_sec =
+                                float_opt_of_assoc
+                                  "remaining_turn_budget_sec" json;
+                              min_required_sec =
+                                Option.value ~default:0.0
+                                  (float_opt_of_assoc "min_required_sec" json);
+                              phase =
+                                Option.value ~default:"unknown"
+                                  (string_opt_of_assoc "phase" json);
                             })
                    | _ -> None)
                | _ -> None)

--- a/lib/oas_worker_named_error.mli
+++ b/lib/oas_worker_named_error.mli
@@ -59,6 +59,9 @@ type masc_internal_error =
       keeper_turn_timeout_sec : float;
       estimated_input_tokens : int;
       source : string;
+      remaining_turn_budget_sec : float option;
+      min_required_sec : float;
+      phase : string;
     }
   | Ambiguous_post_commit of {
       is_timeout : bool;

--- a/test/test_keeper_cascade_auto_pause_task074.ml
+++ b/test/test_keeper_cascade_auto_pause_task074.ml
@@ -81,7 +81,10 @@ let mk_oas_timeout_budget () =
        { budget_sec = 30.0;
          keeper_turn_timeout_sec = 60.0;
          estimated_input_tokens = 1000;
-         source = "test" })
+         source = "test";
+         remaining_turn_budget_sec = Some 10.0;
+         min_required_sec = 15.0;
+         phase = "test_phase" })
 
 let mk_turn_timeout () =
   Owne.sdk_error_of_masc_internal_error

--- a/test/test_keeper_terminal_reason.ml
+++ b/test/test_keeper_terminal_reason.ml
@@ -271,6 +271,9 @@ let test_structured_oas_timeout_budget () =
            keeper_turn_timeout_sec = 1200.0;
            estimated_input_tokens = 10_000;
            source = "test";
+           remaining_turn_budget_sec = Some 42.0;
+           min_required_sec = 15.0;
+           phase = "test_phase";
          })
   in
   let terminal =

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -4570,6 +4570,9 @@ let test_degraded_retry_after_recoverable_error_includes_oas_timeout_budget () =
               keeper_turn_timeout_sec = 1200.0;
               estimated_input_tokens = 2_000;
               source = "adaptive_estimated_input_tokens";
+              remaining_turn_budget_sec = Some 600.0;
+              min_required_sec = 15.0;
+              phase = "test_phase";
             }))
   in
   expect_degraded_retry "oas timeout budget degraded retry"
@@ -5115,6 +5118,9 @@ let test_metrics_failure_timeout_increments_proactive_backoff () =
            keeper_turn_timeout_sec = 90.0;
            estimated_input_tokens = 42_000;
            source = "test";
+           remaining_turn_budget_sec = Some 0.0;
+           min_required_sec = 15.0;
+           phase = "test_phase";
          })
   in
   let updated =
@@ -5890,10 +5896,14 @@ let test_oas_timeout_reclassifies_only_current_attempt_budget () =
        | Some (Masc_mcp.Oas_worker_named.Oas_timeout_budget budget) ->
            check int "estimated tokens preserved" 2_000
              budget.estimated_input_tokens;
-           check string "source preserved" timeout_budget.source budget.source
+           check string "source preserved" timeout_budget.source budget.source;
+           check (option (float 0.001)) "remaining budget preserved"
+             (Some timeout_budget.remaining_turn_budget_sec)
+             budget.remaining_turn_budget_sec;
+           check string "phase" "cascade_attempt_watchdog" budget.phase
        | _ -> fail "expected OAS timeout budget classification")
 
-let test_pre_retry_budget_exhaustion_not_reclassified_with_stale_budget () =
+let test_pre_retry_timeout_helper_does_not_reuse_stale_budget () =
   let err =
     Agent_sdk.Error.Api
       (Timeout
@@ -5905,7 +5915,7 @@ let test_pre_retry_budget_exhaustion_not_reclassified_with_stale_budget () =
   let classified =
     UT.reclassify_oas_timeout_for_attempt ~timeout_budget:None err
   in
-  check bool "pre-dispatch exhaustion remains raw timeout" true
+  check bool "plain helper call without budget stays raw timeout" true
     (Option.is_none
        (Masc_mcp.Oas_worker_named.classify_masc_internal_error classified))
 
@@ -5917,6 +5927,9 @@ let oas_timeout_budget_error () =
          keeper_turn_timeout_sec = 1200.0;
          estimated_input_tokens = 2_000;
          source = "adaptive_estimated_input_tokens";
+         remaining_turn_budget_sec = Some 600.0;
+         min_required_sec = 15.0;
+         phase = "test_phase";
        })
 
 let test_degraded_retry_budget_gate_allows_remaining_budget () =
@@ -8372,8 +8385,8 @@ let () =
             test_bounded_oas_timeout_refuses_too_little_budget;
           test_case "OAS timeout classification uses current attempt budget" `Quick
             test_oas_timeout_reclassifies_only_current_attempt_budget;
-          test_case "pre-retry budget exhaustion does not reuse stale budget" `Quick
-            test_pre_retry_budget_exhaustion_not_reclassified_with_stale_budget;
+          test_case "plain pre-retry timeout helper does not reuse stale budget" `Quick
+            test_pre_retry_timeout_helper_does_not_reuse_stale_budget;
           test_case "degraded retry is allowed when turn budget remains" `Quick
             test_degraded_retry_budget_gate_allows_remaining_budget;
           test_case "degraded retry is blocked when turn budget is exhausted" `Quick

--- a/test/test_oas_error_kind_counter.ml
+++ b/test/test_oas_error_kind_counter.ml
@@ -38,6 +38,9 @@ let test_oas_timeout_budget_kind () =
            keeper_turn_timeout_sec = 1200.0;
            estimated_input_tokens = 2519;
            source = "adaptive_estimated_input_tokens";
+           remaining_turn_budget_sec = Some 300.0;
+           min_required_sec = 15.0;
+           phase = "test_phase";
          })
   in
   Alcotest.(check (float 0.0001))


### PR DESCRIPTION
## Summary
- Extend structured `Oas_timeout_budget` with `phase`, `remaining_turn_budget_sec`, and `min_required_sec`.
- Emit typed `Oas_timeout_budget` when the turn reaches the pre-attempt/pre-retry budget gate instead of falling back to a generic API timeout.
- Use the structured timeout summary in keeper failure metrics so operator surfaces keep the phase and remaining-budget context.

## Why
Kimi FSM/log review plus live `~/me/.masc` receipts showed timeout-budget rows where provider/model were null and `attempt_count=0`. Operators need to distinguish “provider attempt timed out” from “no provider attempt was scheduled because the remaining turn budget was below the guard.”

## Tests
- `env MASC_DUNE_THROTTLE=0 MASC_SKIP_OPAM_LOCK=1 DUNE_LOCAL_JOBS=1 DUNE_CACHE=disabled scripts/dune-local.sh build test/test_keeper_unified.exe test/test_keeper_terminal_reason.exe test/test_oas_error_kind_counter.exe test/test_keeper_cascade_auto_pause_task074.exe`
- `./_build/default/test/test_oas_error_kind_counter.exe`
- `./_build/default/test/test_keeper_terminal_reason.exe`
- `./_build/default/test/test_keeper_cascade_auto_pause_task074.exe`
- `./_build/default/test/test_keeper_unified.exe test transient_network_error`
- `./_build/default/test/test_keeper_unified.exe test phase_gate`