### PR TITLE
fix: emit keeper idle escalation telemetry

### DIFF
--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -71,6 +71,20 @@ let stop_reason_to_label = function
   | Agent_sdk.Types.StopSequence -> "stop_sequence"
   | Agent_sdk.Types.Unknown _ -> "unknown"
 
+let idle_severity_to_label = function
+  | Agent_sdk.Hooks.Idle_severity.Nudge -> "nudge"
+  | Agent_sdk.Hooks.Idle_severity.Final_warning -> "final_warning"
+  | Agent_sdk.Hooks.Idle_severity.Skip -> "skip"
+
+let idle_decision_to_label = function
+  | Agent_sdk.Hooks.Continue -> "continue"
+  | Agent_sdk.Hooks.Skip -> "skip"
+  | Agent_sdk.Hooks.Nudge _ -> "nudge"
+  | Agent_sdk.Hooks.Override _ -> "override"
+  | Agent_sdk.Hooks.ApprovalRequired -> "approval_required"
+  | Agent_sdk.Hooks.AdjustParams _ -> "adjust_params"
+  | Agent_sdk.Hooks.ElicitInput _ -> "elicit_input"
+
 let render_pre_tool_gate_source_hint
     (event : Keeper_guards.gate_decision_event) =
   match event.source_path, event.source_line with
@@ -1046,6 +1060,24 @@ let on_idle_decision ~consecutive_idle_turns ~allowed_tools ~tool_names
   let skip_at = Env_config_keeper.KeeperKeepalive.idle_skip_threshold in
   on_idle_decision_with_threshold ~skip_at ~consecutive_idle_turns
     ~allowed_tools ~tool_names
+
+let keeper_idle_decision ~meta_ref ~consecutive_idle_turns ~tool_names =
+  let allowed_tools =
+    Keeper_tool_policy.keeper_allowed_tool_names !meta_ref in
+  let decision =
+    on_idle_decision ~consecutive_idle_turns ~tool_names
+      ~allowed_tools in
+  let tools_str = match tool_names with
+    | [] -> "<none>" | names -> String.concat ", " names in
+  (match decision with
+   | Agent_sdk.Hooks.Skip ->
+     Log.Keeper.warn "keeper:%s idle_turns=%d repeated_tools=[%s] — requesting stop"
+       (!meta_ref).name consecutive_idle_turns tools_str
+   | Agent_sdk.Hooks.Nudge _ ->
+     Log.Keeper.info "keeper:%s idle_turns=%d tools=[%s] — nudging LLM via Nudge"
+       (!meta_ref).name consecutive_idle_turns tools_str
+   | _ -> ());
+  decision
 
 let recent_tool_streak_count ?(within_sec = 900.0) ~(tool_name : string)
     (entries : Yojson.Safe.t list) : int =
@@ -2250,21 +2282,24 @@ let make_hooks
     on_idle = Some (fun event ->
       match event with
       | Agent_sdk.Hooks.OnIdle { consecutive_idle_turns; tool_names; _ } ->
-        let allowed_tools =
-          Keeper_tool_policy.keeper_allowed_tool_names !meta_ref in
+        keeper_idle_decision ~meta_ref ~consecutive_idle_turns ~tool_names
+      | _ -> Agent_sdk.Hooks.Continue);
+
+    on_idle_escalated = Some (fun event ->
+      match event with
+      | Agent_sdk.Hooks.OnIdleEscalated
+          { severity; consecutive_idle_turns; tool_names; _ } ->
         let decision =
-          on_idle_decision ~consecutive_idle_turns ~tool_names
-            ~allowed_tools in
-        let tools_str = match tool_names with
-          | [] -> "<none>" | names -> String.concat ", " names in
-        (match decision with
-         | Agent_sdk.Hooks.Skip ->
-           Log.Keeper.warn "keeper:%s idle_turns=%d repeated_tools=[%s] — requesting stop"
-             (!meta_ref).name consecutive_idle_turns tools_str
-         | Agent_sdk.Hooks.Nudge _ ->
-           Log.Keeper.info "keeper:%s idle_turns=%d tools=[%s] — nudging LLM via Nudge"
-             (!meta_ref).name consecutive_idle_turns tools_str
-         | _ -> ());
+          keeper_idle_decision ~meta_ref ~consecutive_idle_turns ~tool_names in
+        Prometheus.inc_counter
+          Prometheus.metric_keeper_oas_on_idle_escalated
+          ~labels:
+            [
+              ("keeper", (!meta_ref).name);
+              ("severity", idle_severity_to_label severity);
+              ("decision", idle_decision_to_label decision);
+            ]
+          ();
         decision
       | _ -> Agent_sdk.Hooks.Continue);
 
@@ -2447,9 +2482,9 @@ let hook_introspection_json
         ~features:[ "repeated_tool_nudge"; "stay_silent_skip" ]
         "on_idle";
       slot
-        ~active:false
-        ~source:"not_registered"
-        ~reason:"keeper runtime uses legacy on_idle hook"
+        ~active:true
+        ~source:"keeper_hooks_oas"
+        ~effects:[ "idle_escalation_metric" ]
         "on_idle_escalated";
       slot
         ~active:true

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -955,6 +955,8 @@ let metric_llm_prompt_tok_per_sec = "masc_llm_prompt_tok_per_sec"
 let metric_llm_decode_tok_per_sec = "masc_llm_decode_tok_per_sec"
 let metric_after_turn_hook = "masc_after_turn_hook_total"
 let metric_keeper_oas_on_stop = "masc_keeper_oas_on_stop_total"
+let metric_keeper_oas_on_idle_escalated =
+  "masc_keeper_oas_on_idle_escalated_total"
 let metric_after_turn_telemetry_missing =
   "masc_after_turn_telemetry_missing_total"
 let metric_after_turn_telemetry_zero_latency =
@@ -1388,6 +1390,9 @@ let init () =
   add metric_keeper_oas_on_stop
     "Times the keeper OnStop hook ran after an OAS response terminated. \
      Labels: keeper, stop_reason." Counter;
+  add metric_keeper_oas_on_idle_escalated
+    "Times the keeper OnIdleEscalated hook ran. Labels: keeper, severity, \
+     decision." Counter;
   add metric_after_turn_telemetry_missing
     "AfterTurn responses where response.telemetry was None." Counter;
   add metric_after_turn_telemetry_zero_latency

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -547,6 +547,7 @@ val metric_llm_decode_tok_per_sec : string
 
 val metric_after_turn_hook : string
 val metric_keeper_oas_on_stop : string
+val metric_keeper_oas_on_idle_escalated : string
 val metric_after_turn_telemetry_missing : string
 val metric_after_turn_telemetry_zero_latency : string
 val metric_tasks : string

--- a/test/test_keeper_hooks_oas_telemetry.ml
+++ b/test/test_keeper_hooks_oas_telemetry.ml
@@ -61,6 +61,17 @@ let on_stop_count ~keeper ~stop_reason =
     ~labels:[ ("keeper", keeper); ("stop_reason", stop_reason) ]
     ()
 
+let on_idle_escalated_count ~keeper ~severity ~decision =
+  Masc_mcp.Prometheus.metric_value_or_zero
+    Masc_mcp.Prometheus.metric_keeper_oas_on_idle_escalated
+    ~labels:
+      [
+        ("keeper", keeper);
+        ("severity", severity);
+        ("decision", decision);
+      ]
+    ()
+
 let require_hook label = function
   | Some hook -> hook
   | None -> failf "expected active hook: %s" label
@@ -709,9 +720,9 @@ let test_hook_introspection_reports_current_runtime_slots () =
   check string "scope" "keeper_runtime_composite"
     (json |> member "scope" |> to_string);
   check int "slot_count" 14 (json |> member "slot_count" |> to_int);
-  check int "active slots" 10
+  check int "active slots" 11
     (json |> member "active_slot_count" |> to_int);
-  check int "inactive slots" 4
+  check int "inactive slots" 3
     (json |> member "inactive_slot_count" |> to_int);
   check bool "before_turn active" true
     (slot json "before_turn" |> member "active" |> to_bool);
@@ -747,8 +758,11 @@ let test_hook_introspection_reports_current_runtime_slots () =
   check_string_list_contains "on_stop records stop reason"
     "stop_reason_metric"
     (string_list_field (slot json "on_stop") "effects");
-  check bool "on_idle_escalated inactive" false
+  check bool "on_idle_escalated active" true
     (slot json "on_idle_escalated" |> member "active" |> to_bool);
+  check_string_list_contains "on_idle_escalated records metric"
+    "idle_escalation_metric"
+    (string_list_field (slot json "on_idle_escalated") "effects");
   check bool "pre_compact inactive" false
     (slot json "pre_compact" |> member "active" |> to_bool);
   check bool "post_compact inactive" false
@@ -818,6 +832,29 @@ let test_on_stop_hook_records_stop_reason_metric () =
   let unknown_after = on_stop_count ~keeper ~stop_reason:"unknown" in
   check (float 0.001) "unknown stop reason is bounded" 1.0
     (unknown_after -. unknown_before)
+
+let test_on_idle_escalated_hook_records_metric () =
+  let keeper = "callback-on-idle-escalated-keeper" in
+  let hooks = make_test_hooks keeper in
+  let hook = require_hook "on_idle_escalated" hooks.on_idle_escalated in
+  let before =
+    on_idle_escalated_count ~keeper ~severity:"final_warning"
+      ~decision:"nudge"
+  in
+  check_nudge "on_idle_escalated"
+    (hook
+       (Agent_sdk.Hooks.OnIdleEscalated
+          {
+            severity = Agent_sdk.Hooks.Idle_severity.Final_warning;
+            consecutive_idle_turns = 1;
+            tool_names = [ "keeper_bash" ];
+          }));
+  let after =
+    on_idle_escalated_count ~keeper ~severity:"final_warning"
+      ~decision:"nudge"
+  in
+  check (float 0.001) "on_idle_escalated counter increments" 1.0
+    (after -. before)
 
 let test_on_idle_hook_returns_runtime_nudge () =
   let hooks = make_test_hooks "callback-on-idle-keeper" in
@@ -1228,6 +1265,8 @@ let () =
             test_on_tool_error_hook_records_callback_failure_metric
         ; test_case "on_stop records stop reason metric" `Quick
             test_on_stop_hook_records_stop_reason_metric
+        ; test_case "on_idle_escalated records metric" `Quick
+            test_on_idle_escalated_hook_records_metric
         ; test_case "on_idle returns runtime nudge" `Quick
             test_on_idle_hook_returns_runtime_nudge
         ] )

--- a/test/test_prometheus_coverage.ml
+++ b/test/test_prometheus_coverage.ml
@@ -344,6 +344,7 @@ let test_review_blocker_metrics_registered () =
   check_registered Prometheus.metric_coord_claim_post_provision_failures;
   check_registered Prometheus.metric_keeper_lifecycle_callback_failures;
   check_registered Prometheus.metric_keeper_oas_on_stop;
+  check_registered Prometheus.metric_keeper_oas_on_idle_escalated;
   check_registered Prometheus.metric_keeper_event_bus_drain
 
 let test_distributed_lock_metric_registered () =


### PR DESCRIPTION
## What

- Register the keeper OAS `on_idle_escalated` hook instead of leaving that slot inactive.
- Reuse the existing MASC idle decision logic used by legacy `on_idle`, preserving current keeper behavior.
- Emit `masc_keeper_oas_on_idle_escalated_total{keeper,severity,decision}` with bounded severity and decision labels.
- Update hook introspection and metric registration tests.

## Why

OAS can dispatch `on_idle_escalated` when the idle path escalates, but MASC was still reporting that hook slot as inactive and relying on the legacy `on_idle` path. This gives operators direct hook-fired telemetry for idle escalation without changing the existing nudge/skip decision policy.

## Validation

- `git diff --check origin/main...HEAD`
- Earlier, before rebasing the same semantic patch onto the latest `origin/main`: `lockf -k -t 600 /tmp/me-dune-local.lock env MASC_DUNE_LOCK_HELD=1 MASC_SKIP_OPAM_LOCK=1 DUNE_JOBS=1 DUNE_CACHE=disabled scripts/dune-local.sh build test/test_keeper_hooks_oas_telemetry.exe test/test_prometheus_coverage.exe`
- Earlier executable checks passed: `_build/default/test/test_keeper_hooks_oas_telemetry.exe` and `_build/default/test/test_prometheus_coverage.exe`
- After rebasing to current `origin/main`, the focused build retry was blocked by the shared `/tmp/me-dune-local.lock` and timed out before starting; draft PR CI is the current-base verification surface.