### PR TITLE
fix(keeper): remove duplicate stale fleet receipt arm

### DIFF
--- a/lib/keeper/keeper_execution_receipt.ml
+++ b/lib/keeper/keeper_execution_receipt.ml
@@ -719,7 +719,6 @@ let stale_terminal_reason_code = function
   | Some (Keeper_registry.Heartbeat_consecutive_failures _) ->
       "heartbeat_failures"
   | Some (Keeper_registry.Turn_consecutive_failures _) -> "turn_failures"
-  | Some (Keeper_registry.Stale_fleet_batch _) -> "stale_fleet_batch"
   | Some (Keeper_registry.Ambiguous_partial_commit _) ->
       "ambiguous_partial_commit"
   | Some Keeper_registry.Fiber_unresolved -> "fiber_unresolved"


### PR DESCRIPTION
Fixes #13817.

## Summary
- Removes the duplicate `Keeper_registry.Stale_fleet_batch` branch from `stale_terminal_reason_code`.
- Leaves the current `keeper_turn.ml` match-stack repair from #13814 intact; current `main` no longer reproduces that parser error.

## Validation
- PASS: git diff --check.
- PASS: env DUNE_BUILD_DIR=_build_codex_13817_keeper_compile scripts/dune-local.sh build test/test_env_config_keeper_bootstrap_intervals.exe.
- PASS: ./_build_codex_13817_keeper_compile/default/test/test_env_config_keeper_bootstrap_intervals.exe: 8 tests run, Test Successful.