### PR TITLE
fix(cascade): cool down denied models by model key

### DIFF
--- a/lib/oas_worker_named.ml
+++ b/lib/oas_worker_named.ml
@@ -16,6 +16,25 @@ include Oas_worker_named_cascade
 include Oas_worker_named_error
 include Oas_worker_named_fsm
 
+let provider_health_keys_of_config provider_cfg =
+  let provider_key = Provider_adapter.provider_health_key_of_config provider_cfg in
+  let model_key =
+    Provider_adapter.provider_model_health_key_of_config provider_cfg
+  in
+  if String.equal provider_key model_key then [ provider_key ]
+  else [ provider_key; model_key ]
+
+let first_health_cooldown provider_cfg =
+  provider_health_keys_of_config provider_cfg
+  |> List.find_map (fun provider_key ->
+         match
+           Cascade_health_tracker.check_circuit_breaker
+             Cascade_health_tracker.global
+             ~provider_key
+         with
+         | Ok () -> None
+         | Error msg -> Some (provider_key, msg))
+
 type provider_attempt_timeout_constraints = {
   min_timeout_s : float option;
   max_timeout_s : float option;
@@ -254,16 +273,9 @@ let run_named
   let candidate_cfgs =
     List.filter
       (fun (provider_cfg : Llm_provider.Provider_config.t) ->
-         let provider_health_key =
-           Provider_adapter.provider_health_key_of_config provider_cfg
-         in
-         match
-           Cascade_health_tracker.check_circuit_breaker
-             Cascade_health_tracker.global
-             ~provider_key:provider_health_key
-         with
-         | Ok () -> true
-         | Error msg ->
+         match first_health_cooldown provider_cfg with
+         | None -> true
+         | Some (provider_health_key, msg) ->
              Log.Misc.debug
                "cascade %s: prefilter skipped %s (provider_key=%s cooldown: %s)"
                cascade_name provider_cfg.model_id provider_health_key msg;
@@ -686,11 +698,16 @@ let run_named
       let provider_health_key =
         Provider_adapter.provider_health_key_of_config provider_cfg
       in
-      match Cascade_health_tracker.check_circuit_breaker Cascade_health_tracker.global ~provider_key:provider_health_key with
-      | Error msg ->
-          Log.Misc.debug "cascade %s: skipping %s (provider_key=%s cooldown: %s)" cascade_name provider_cfg.model_id provider_health_key msg;
+      let provider_model_health_key =
+        Provider_adapter.provider_model_health_key_of_config provider_cfg
+      in
+      match first_health_cooldown provider_cfg with
+      | Some (blocked_health_key, msg) ->
+          Log.Misc.debug
+            "cascade %s: skipping %s (provider_key=%s cooldown: %s)"
+            cascade_name provider_cfg.model_id blocked_health_key msg;
           try_cascade ~on_success ?resume_checkpoint ?per_provider_timeout_s rest last_err
-      | Ok () ->
+      | None ->
       let is_last = rest = [] in
       Log.Misc.debug "cascade %s: trying %s (is_last=%b)" cascade_name provider_cfg.model_id is_last;
       let pp_timeout =
@@ -845,6 +862,11 @@ let run_named
           Cascade_health_tracker.(
             record_hard_quota global ~provider_key:provider_health_key
               ~error_kind:(error_kind_of_string "hard_quota")
+              ~error_reason:err_str ())
+        else if sdk_error_is_model_access_denied sdk_err then
+          Cascade_health_tracker.(
+            record_terminal_failure global ~provider_key:provider_model_health_key
+              ~error_kind:(error_kind_of_string "model_access_denied")
               ~error_reason:err_str ())
         else if sdk_error_is_resumable_cli_session sdk_err
                 || sdk_error_is_terminal_provider_runtime_failure sdk_err

--- a/lib/oas_worker_named_fsm.ml
+++ b/lib/oas_worker_named_fsm.ml
@@ -87,6 +87,20 @@ let sdk_error_to_cascade_outcome (err : Agent_sdk.Error.sdk_error)
          (Llm_provider.Http_client.AcceptRejected { reason = detail }))
   | _ -> None)
 
+let sdk_error_is_model_access_denied (err : Agent_sdk.Error.sdk_error) =
+  match sdk_error_to_cascade_outcome err with
+  | Some
+      (Cascade_fsm.Call_err
+         (Llm_provider.Http_client.ProviderFailure
+            {
+              kind =
+                Llm_provider.Http_client.Capability_mismatch
+                  { capability = Some "model_access" };
+              _;
+            })) ->
+    true
+  | _ -> false
+
 let moonshot_auth_hint_marker = "Moonshot returned 401"
 let openai_compat_not_found_hint_marker =
   "OpenAI-compatible endpoint returned 404"

--- a/lib/oas_worker_named_fsm.mli
+++ b/lib/oas_worker_named_fsm.mli
@@ -71,6 +71,10 @@ val sdk_error_is_terminal_provider_runtime_failure :
     immediate long cooldown lane instead of waiting for generic failure
     thresholding. *)
 
+val sdk_error_is_model_access_denied : Agent_sdk.Error.sdk_error -> bool
+(** [true] for deterministic model-access denials that should cool down the
+    concrete provider/model pair without poisoning sibling models. *)
+
 val sdk_error_is_hard_quota : Agent_sdk.Error.sdk_error -> bool
 (** [true] when the error represents a hard usage quota that will not
     recover within the cascade turn budget. *)

--- a/lib/provider_adapter.ml
+++ b/lib/provider_adapter.ml
@@ -1484,6 +1484,9 @@ let provider_health_key_of_config (cfg : Llm_provider.Provider_config.t) =
           cfg.model_id base_url
   | _ -> provider_label_of_config cfg
 
+let provider_model_health_key_of_config cfg =
+  Printf.sprintf "%s:%s" (provider_health_key_of_config cfg) cfg.model_id
+
 let display_provider_name_of_config (cfg : Llm_provider.Provider_config.t) =
   display_provider_name (provider_label_of_config cfg)
 

--- a/lib/provider_adapter.mli
+++ b/lib/provider_adapter.mli
@@ -377,6 +377,10 @@ val provider_label_of_config :
 val provider_health_key_of_config :
   Llm_provider.Provider_config.t -> string
 
+(** Stable model-level key for model-specific cascade health state. *)
+val provider_model_health_key_of_config :
+  Llm_provider.Provider_config.t -> string
+
 (** User-facing provider label for a provider config. *)
 val display_provider_name_of_config :
   Llm_provider.Provider_config.t -> string

--- a/test/test_oas_worker.ml
+++ b/test/test_oas_worker.ml
@@ -1086,6 +1086,25 @@ let test_sdk_error_to_cascade_outcome_cascades_model_access_denied () =
         "expected model access InvalidRequest to cascade as ProviderFailure Capability_mismatch, got %s"
         (Cascade_fsm.provider_outcome_option_to_string outcome)
 
+let test_sdk_error_is_model_access_denied_predicate () =
+  let denied =
+    Agent_sdk.Error.Api
+      (Llm_provider.Retry.InvalidRequest
+         {
+           message =
+             "Invalid request: You do not have permission to access glm-5-code";
+         })
+  in
+  let ordinary =
+    Agent_sdk.Error.Api
+      (Llm_provider.Retry.InvalidRequest { message = {|{"detail":"Bad Request"}|} })
+  in
+  Alcotest.(check bool) "model access denied is detected" true
+    (Oas_worker_named.sdk_error_is_model_access_denied denied);
+  Alcotest.(check bool) "ordinary invalid request is not model access denial"
+    false
+    (Oas_worker_named.sdk_error_is_model_access_denied ordinary)
+
 let test_sdk_error_to_cascade_outcome_cascades_runtime_mcp_auth_config () =
   let detail = "codex_cli runtime MCP cannot carry keeper-bound auth headers" in
   let err =
@@ -1421,7 +1440,7 @@ let test_run_named_skips_cooldown_primary_and_falls_back () =
       | Ok providers -> providers
       | Error err -> Alcotest.fail err
     in
-    let primary_health_key, fallback_health_key =
+    let primary_model_health_key, fallback_provider_health_key =
       match resolved with
       | [ primary; fallback ] ->
          Alcotest.(check string) "primary model id"
@@ -1430,7 +1449,15 @@ let test_run_named_skips_cooldown_primary_and_falls_back () =
            fallback_key fallback.model_id;
          Alcotest.(check string) "primary base url" primary_url primary.base_url;
          Alcotest.(check string) "fallback base url" fallback_url fallback.base_url;
-         ( Masc_mcp.Provider_adapter.provider_health_key_of_config primary,
+         let primary_model_health_key =
+           Masc_mcp.Provider_adapter.provider_model_health_key_of_config primary
+         in
+         let fallback_model_health_key =
+           Masc_mcp.Provider_adapter.provider_model_health_key_of_config fallback
+         in
+         Alcotest.(check bool) "model health keys are isolated" true
+           (primary_model_health_key <> fallback_model_health_key);
+         ( primary_model_health_key,
            Masc_mcp.Provider_adapter.provider_health_key_of_config fallback )
       | providers ->
          Alcotest.failf "expected 2 resolved providers, got %d"
@@ -1439,7 +1466,7 @@ let test_run_named_skips_cooldown_primary_and_falls_back () =
     for _ = 1 to Masc_mcp.Cascade_health_tracker.cooldown_threshold do
       Masc_mcp.Cascade_health_tracker.record_failure
         Masc_mcp.Cascade_health_tracker.global
-        ~provider_key:primary_health_key
+        ~provider_key:primary_model_health_key
         ()
     done;
     reset_primary_calls ();
@@ -1447,7 +1474,7 @@ let test_run_named_skips_cooldown_primary_and_falls_back () =
     (match
        Masc_mcp.Cascade_health_tracker.check_circuit_breaker
          Masc_mcp.Cascade_health_tracker.global
-         ~provider_key:primary_health_key
+         ~provider_key:primary_model_health_key
      with
      | Ok () -> Alcotest.fail "primary provider should be OPEN before run_named"
      | Error _ -> ());
@@ -1476,7 +1503,7 @@ let test_run_named_skips_cooldown_primary_and_falls_back () =
         (match
            Masc_mcp.Cascade_health_tracker.provider_info
              Masc_mcp.Cascade_health_tracker.global
-             ~provider_key:fallback_health_key
+             ~provider_key:fallback_provider_health_key
          with
          | None -> Alcotest.fail "fallback provider should have health info"
          | Some info ->
@@ -5441,6 +5468,8 @@ let () =
         test_sdk_error_to_cascade_outcome_keeps_invalid_request_as_400;
       Alcotest.test_case "sdk_error_to_cascade_outcome cascades model access denial" `Quick
         test_sdk_error_to_cascade_outcome_cascades_model_access_denied;
+      Alcotest.test_case "sdk_error_is_model_access_denied classifies model access denial" `Quick
+        test_sdk_error_is_model_access_denied_predicate;
       Alcotest.test_case "sdk_error_to_cascade_outcome cascades runtime MCP auth config" `Quick
         test_sdk_error_to_cascade_outcome_cascades_runtime_mcp_auth_config;
       Alcotest.test_case "sdk_error_to_cascade_outcome cascades resumable CLI session" `Quick

--- a/test/test_provider_adapter.ml
+++ b/test/test_provider_adapter.ml
@@ -379,6 +379,25 @@ let test_local_openai_compat_health_key_is_endpoint_scoped () =
     (Adapter.provider_health_key_of_config primary
      <> Adapter.provider_health_key_of_config fallback)
 
+let test_provider_model_health_key_is_model_scoped () =
+  let cfg label =
+    match Masc_mcp.Cascade_config.parse_model_string label with
+    | Some cfg -> cfg
+    | None -> fail ("expected model label to parse: " ^ label)
+  in
+  let glm_code = cfg "glm-coding:glm-5-code" in
+  let glm_51 = cfg "glm-coding:glm-5.1" in
+  check string "provider health key stays provider scoped" "glm-coding"
+    (Adapter.provider_health_key_of_config glm_code);
+  check string "model health key includes concrete model" "glm-coding:glm-5-code"
+    (Adapter.provider_model_health_key_of_config glm_code);
+  check bool "sibling models do not share model health key" true
+    (Adapter.provider_model_health_key_of_config glm_code
+     <> Adapter.provider_model_health_key_of_config glm_51);
+  check string "sibling models still share provider health key"
+    (Adapter.provider_health_key_of_config glm_code)
+    (Adapter.provider_health_key_of_config glm_51)
+
 let test_provider_of_model_label_uses_typed_boundaries () =
   check string "explicit prefix wins over coarse kind" "glm-coding"
     (Adapter.provider_of_model_label
@@ -469,6 +488,8 @@ let () =
             test_provider_health_key_is_provider_scoped;
           test_case "local openai compat health key is endpoint scoped" `Quick
             test_local_openai_compat_health_key_is_endpoint_scoped;
+          test_case "provider model health key is model scoped" `Quick
+            test_provider_model_health_key_is_model_scoped;
           test_case "provider model label uses typed boundaries" `Quick
             test_provider_of_model_label_uses_typed_boundaries;
           test_case "unmetered provider uses telemetry policy" `Quick


### PR DESCRIPTION
## Summary
- Add a stable provider/model health key alongside the existing provider-level key.
- Check both provider-level and model-level cooldowns before selecting a candidate.
- Record model-access denials, such as unavailable glm-5-code, as long terminal cooldowns on only that concrete model key so sibling models can still run.

## Runtime evidence
- /health on 127.0.0.1:8935 reports effective_base_path=/Users/dancer/me, effective_masc_root=/Users/dancer/me/.masc, roots_diverge=false, server commit 8d4647f4bd.
- /Users/dancer/me/.masc/logs/system_log_2026-05-06.jsonl:121826 shows glm-5-code ending with 'Invalid request: You do not have permission to access glm-5-code'.
- /Users/dancer/me/.masc/logs/system_log_2026-05-06.jsonl:121849 shows the cascade falling back after that same denied model.
- Trajectory summaries under /Users/dancer/me/.masc/trajectories also show repeated glm-5-code model-access failures and capability_mismatch:model_access cascade exhaustion.

## Verification
- env MASC_DUNE_THROTTLE=0 MASC_SKIP_OPAM_LOCK=1 DUNE_JOBS=1 scripts/dune-local.sh build test/test_provider_adapter.exe test/test_oas_worker.exe
- ./_build/default/test/test_provider_adapter.exe: 36 tests passed.
- ./_build/default/test/test_oas_worker.exe: 163 tests passed.
- scripts/check-oas-pin.sh --local-only: OAS pin verified at main@0cfb68c620ccd385f16fd6344b2cb003077c73c3, base version v0.190.26.
- scripts/oas-drift-check.sh: OAS API surface matches fingerprint for pinned_sha=0cfb68c620ccd385f16fd6344b2cb003077c73c3.

## Review focus
- Model-access denial should cool down provider:model, not the whole provider.
- Provider-wide failures such as hard quota and terminal runtime failures still use the existing provider-level cooldown path.