### PR TITLE
feat(oas): activate max_execution_time_s in cascade-driven runs

### DIFF
--- a/lib/oas_worker_named.ml
+++ b/lib/oas_worker_named.ml
@@ -404,6 +404,17 @@ let run_named
                                Env_config_keeper.KeeperKeepalive
                                .stream_idle_timeout_sec
                              stream_idle_timeout_s));
+                 max_execution_time_s =
+                   (* Bound a single OAS call (one [Agent.run]/[run_stream])
+                      so a hung provider falls into [Retry.Timeout] instead
+                      of blocking until the whole-keeper [turn_timeout].
+                      Scale = per-OAS-call (default 300 s, env override via
+                      [MASC_KEEPER_OAS_TIMEOUT_SEC]); the input-token arg
+                      is currently ignored by the resolver (#10008 fm2). *)
+                   Some
+                     (Keeper_runtime_resolved
+                      .oas_timeout_for_estimated_input_tokens
+                        ~estimated_input_tokens:0);
                  temperature;
                  max_idle_turns;
                  guardrails;


### PR DESCRIPTION
## Summary

Activates `max_execution_time_s` in the cascade-driven `Agent.run` path. The wire was landed in PR #13923 (merged as `56ced1940a`); this PR populates the field so production behaviour actually changes.

## Effect

Before: a hung `Agent.run_stream` (e.g. Ollama closes the connection without `end_turn`) blocks until the whole-keeper `turn_timeout` (600 s — or 900 s once #13901 lands) expires. Cross-cascade fallback waits the full window.

After: `agent_sdk`'s `with_optional_timeout` engages at the per-OAS-call ceiling (default 300 s, env override `MASC_KEEPER_OAS_TIMEOUT_SEC`) and returns `Error.Api (Retry.Timeout {...})`. The cascade FSM already treats `Retry.Timeout` as a fallback signal, so the next provider gets a turn within the same keeper budget. RFC-0022 §10 was the goal; this PR closes the gap between #13923's wire and the actual control-plane behaviour.

## What changes

`lib/oas_worker_named.ml` — one record-field addition (~11 LOC) inside the cascade config builder at the existing `Oas_worker_exec.default_config { … with stream_idle_timeout_s = … }` site:

```ocaml
max_execution_time_s =
  Some
    (Keeper_runtime_resolved
     .oas_timeout_for_estimated_input_tokens
       ~estimated_input_tokens:0);
```

The resolver already enforces a `min(turn_timeout, 300 s)` ceiling and an env override hook, so callers don't need to repeat the clamp. The `estimated_input_tokens` arg is currently ignored by the resolver (#10008 fm2 dropped per-token scaling); a future RFC can restore it.

## Why this scale, not `turn_timeout_sec`

`turn_timeout_sec` is the whole-keeper budget; it includes cascade fallback. Wiring that scale would let one slow provider eat the entire turn before falling back — exactly what RFC-0022 forbids. `oas_timeout_for_estimated_input_tokens` is per-OAS-call (~1 attempt within a turn), which is the correct shape for `with_optional_timeout`'s "one `run_stream` invocation" semantics.

## Out of scope

- `oas_worker_named_error.ml:527` (recovery branch) still calls `default_config` without setting `max_execution_time_s`. That path is secondary and lower hang-risk; can be wired in a follow-up if production observes hangs there.
- Per-token timeout scaling (#10008 fm2 reversal) — separate RFC.

## Test plan

- [x] `dune build --root . @check` — type-check passes for my files. The only unrelated failure was the duplicate `Stale_fleet_batch` arm, since unblocked by PR #13928 (`a1ce60d197`).
- [ ] CI green — pending after push.
- [ ] Production probe (post-merge): observe `masc_keeper_*_timeout` counter increase + cascade fallback engaging on a no-`end_turn` provider.

## Refs

- Goal: `oas-bridge-stabilization` Step 3b-2 (caller activation half).
- Parent (merged): PR #13923 — wire infra (`Builder.with_max_execution_time` + `?clock` plumbing).
- Companion PR #13901 (turn_timeout 600→900 lift, MERGEABLE).
- Plan: `~/me/planning/claude-plans/20m-me-workspace-yousleepwhen-masc-mcp-o-recursive-mountain.md`.
- Evidence: `~/me/memory/procedural-memory/2026-05-07-oas-run-stream-hang-root-cause-evidence.md`.

RFC-WAIVED: this PR touches only `lib/oas_worker_named.ml` (one record field). No credential / identity / auth / sandbox / dashboard-credential / hooks / workflow paths from the RFC discovery list are touched.
