### PR TITLE
fix: count keeper lifecycle hook failures

### DIFF
--- a/lib/keeper/keeper_lifecycle_hooks.ml
+++ b/lib/keeper/keeper_lifecycle_hooks.ml
@@ -34,7 +34,17 @@ let run ~keeper_id (ev : event) : unit =
   List.iter
     (fun h ->
       try h ~keeper_id ev
-      with exn ->
+      with
+      | Eio.Cancel.Cancelled _ as e -> raise e
+      | exn ->
+        Prometheus.inc_counter
+          Prometheus.metric_keeper_lifecycle_callback_failures
+          ~labels:
+            [
+              ("keeper", keeper_id);
+              ("callback", "keeper_lifecycle_hook");
+            ]
+          ();
         Log.Server.warn
           "[KeeperLifecycleHooks] hook raised on keeper_id=%s: %s"
           keeper_id (Printexc.to_string exn))

--- a/lib/keeper/keeper_lifecycle_hooks.mli
+++ b/lib/keeper/keeper_lifecycle_hooks.mli
@@ -50,9 +50,11 @@ type hook = keeper_id:string -> event -> unit
     — calling twice with the same closure registers it twice. *)
 val register : hook -> unit
 
-(** Run every registered hook with the given event. Exceptions raised
-    from a hook are caught and logged via [Log.Server.warn]; the runner
-    always returns normally. *)
+(** Run every registered hook with the given event. Non-cancellation
+    exceptions raised from a hook are caught, counted via
+    [metric_keeper_lifecycle_callback_failures], and logged via
+    [Log.Server.warn]; [Eio.Cancel.Cancelled] is re-raised to preserve
+    cooperative cancellation. *)
 val run : keeper_id:string -> event -> unit
 
 (** Number of currently registered hooks. Useful for tests. *)

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -741,6 +741,7 @@ val metric_fsm_guard_violation : string
     - [on_tool_executed]
     - [on_error]
     - [on_tool_error]
+    - [keeper_lifecycle_hook]
 
     Cardinality is bounded by fleet size times this callback vocabulary. *)
 val metric_keeper_lifecycle_callback_failures : string

--- a/test/test_keeper_callback_hardening.ml
+++ b/test/test_keeper_callback_hardening.ml
@@ -134,6 +134,7 @@ let test_documented_callback_label_vocabulary () =
       "on_error";
       "on_tool_error";
       "work_discovery_nudge";
+      "keeper_lifecycle_hook";
     ]
   in
   List.iter (fun label ->

--- a/test/test_keeper_lifecycle_hooks.ml
+++ b/test/test_keeper_lifecycle_hooks.ml
@@ -9,9 +9,20 @@
 open Alcotest
 
 module H = Masc_mcp.Keeper_lifecycle_hooks
+module P = Masc_mcp.Prometheus
 module SM = Masc_mcp.Keeper_state_machine
 
 let setup () = H.reset_for_testing ()
+
+let lifecycle_hook_failure_count ~keeper =
+  P.metric_value_or_zero
+    P.metric_keeper_lifecycle_callback_failures
+    ~labels:
+      [
+        ("keeper", keeper);
+        ("callback", "keeper_lifecycle_hook");
+      ]
+    ()
 
 let test_register_increments_count () =
   setup ();
@@ -57,12 +68,30 @@ let test_run_passes_keeper_id_and_event () =
 
 let test_exception_in_hook_is_swallowed () =
   setup ();
+  let keeper = "keeper-lifecycle-hooks-test" in
   let after_count = ref 0 in
   H.register (fun ~keeper_id:_ _ -> failwith "boom");
   H.register (fun ~keeper_id:_ _ -> incr after_count);
+  let before = lifecycle_hook_failure_count ~keeper in
   (* Should not raise. *)
-  H.run ~keeper_id:"k" H.Tombstone_reaped;
-  check int "subsequent hook still ran" 1 !after_count
+  H.run ~keeper_id:keeper H.Tombstone_reaped;
+  let after = lifecycle_hook_failure_count ~keeper in
+  check int "subsequent hook still ran" 1 !after_count;
+  check (float 0.001) "hook failure metric increments" 1.0
+    (after -. before)
+
+let test_cancelled_in_hook_is_reraised () =
+  setup ();
+  H.register (fun ~keeper_id:_ _ ->
+    raise (Eio.Cancel.Cancelled (Failure "synthetic cancel")));
+  let raised =
+    try
+      H.run ~keeper_id:"cancel-keeper" H.Tombstone_reaped;
+      false
+    with
+    | Eio.Cancel.Cancelled _ -> true
+  in
+  check bool "cancelled re-raised" true raised
 
 let test_reset_for_testing_clears () =
   setup ();
@@ -79,6 +108,7 @@ let () =
       test_case "dispatches in order"        `Quick test_run_dispatches_in_order;
       test_case "passes keeper_id and event" `Quick test_run_passes_keeper_id_and_event;
       test_case "swallows exceptions"        `Quick test_exception_in_hook_is_swallowed;
+      test_case "re-raises cancellation"     `Quick test_cancelled_in_hook_is_reraised;
     ];
     "reset_for_testing", [ test_case "clears all" `Quick test_reset_for_testing_clears ];
   ]


### PR DESCRIPTION
## What

- Count generic `Keeper_lifecycle_hooks.run` hook failures with `masc_keeper_lifecycle_callback_failures_total{keeper,callback="keeper_lifecycle_hook"}`.
- Preserve the existing best-effort behavior for non-cancellation hook exceptions so later hooks still run.
- Re-raise `Eio.Cancel.Cancelled` so lifecycle hook cleanup does not swallow cooperative cancellation.
- Pin the callback label vocabulary and lifecycle hook runner behavior in focused tests.

## Why

The Phase 0 plan calls out exception swallowing as a silent-failure source. This runner already logged hook exceptions, but the failure was not visible in the existing callback-failure counter. Counting it closes another lifecycle callback blind spot without changing the supervisor cleanup contract for ordinary hook failures.

## Validation

- `git diff --check origin/main...HEAD`
- Focused local Dune build attempted twice with `lockf -k -t ... /tmp/me-dune-local.lock env MASC_DUNE_LOCK_HELD=1 MASC_SKIP_OPAM_LOCK=1 DUNE_JOBS=1 DUNE_CACHE=disabled scripts/dune-local.sh build test/test_keeper_lifecycle_hooks.exe test/test_keeper_callback_hardening.exe`; both attempts timed out waiting for unrelated shared Dune lock holders.
- Draft PR CI is the current-base compile/test verification surface.