### PR TITLE
fix(credential): verify GitHub GraphQL auth

### DIFF
--- a/lib/repo_manager/credential_materializer.ml
+++ b/lib/repo_manager/credential_materializer.ml
@@ -7,8 +7,8 @@
     | None / empty | none | [Unmaterialized] |
     | non-empty dir, missing on disk | none | [Unmaterialized] |
     | exists + missing [hosts.yml] [oauth_token] | none | [Stale {reason}] |
-    | exists + [hosts.yml] [oauth_token] + [gh auth status] = 0 | record verify timestamp | [Materialized {last_verified_at}] |
-    | exists + [gh auth status] != 0 | record reason | [Stale {reason}] |
+    | exists + [hosts.yml] [oauth_token] + [gh auth status] = 0 + GraphQL viewer succeeds | record verify timestamp | [Materialized {last_verified_at}] |
+    | exists + [gh auth status] / GraphQL viewer fails | record reason | [Stale {reason}] |
 
     PR-B Slice 1 ships this **verify-only** path.  The two [oauth_method]
     materialisation flows (web device-flow, with-token) are layered on
@@ -65,18 +65,17 @@ let gh_bundle_env ~gh_config_dir =
          "GH_PROMPT_DISABLED=1";
        ])
 
-(** Run [gh auth status] against the supplied [GH_CONFIG_DIR] and
-    return whether it succeeded.  The child process receives a
-    bundle-scoped environment only, so ambient GH_TOKEN/GITHUB_TOKEN
-    values cannot make a stale bundle look materialized. *)
-let gh_auth_status_ok ~gh_config_dir =
+(** Run a [gh] command against the supplied [GH_CONFIG_DIR] and return
+    whether it succeeded.  The child process receives a bundle-scoped
+    environment only, so ambient GH_TOKEN/GITHUB_TOKEN values cannot
+    make a stale bundle look materialized. *)
+let gh_command_ok ~gh_config_dir argv =
   let devnull_in = Unix.openfile "/dev/null" [ Unix.O_RDONLY ] 0 in
   let devnull_out = Unix.openfile "/dev/null" [ Unix.O_WRONLY ] 0o644 in
   let pid =
     try
       Some
-        (Unix.create_process_env "gh"
-           [| "gh"; "auth"; "status" |]
+        (Unix.create_process_env "gh" (Array.of_list ("gh" :: argv))
            (gh_bundle_env ~gh_config_dir)
            devnull_in devnull_out devnull_out)
     with Unix.Unix_error _ -> None
@@ -118,6 +117,19 @@ let hosts_yml_has_oauth_token ~gh_config_dir =
           !found)
     with Sys_error _ -> false
 
+let gh_auth_status_ok ~gh_config_dir =
+  gh_command_ok ~gh_config_dir [ "auth"; "status" ]
+
+let gh_graphql_viewer_ok ~gh_config_dir =
+  gh_command_ok ~gh_config_dir
+    [ "api";
+      "graphql";
+      "-f";
+      "query=query { viewer { login } }";
+      "--jq";
+      ".data.viewer.login";
+    ]
+
 (** Compute the new state for [gh_config_dir] without writing anywhere.
     Pure with respect to credential records; reads filesystem + invokes
     [gh] subprocess. *)
@@ -135,10 +147,12 @@ let verify_state ~gh_config_dir : credential_state =
            this identity with `gh auth login --with-token \
            --insecure-storage` into the bundle.";
       }
-  else if gh_auth_status_ok ~gh_config_dir then
-    Materialized { last_verified_at = now_unix_ms () }
-  else
+  else if not (gh_auth_status_ok ~gh_config_dir) then
     Stale { reason = "gh auth status returned non-zero exit code" }
+  else if not (gh_graphql_viewer_ok ~gh_config_dir) then
+    Stale { reason = "gh api graphql viewer returned non-zero exit code" }
+  else
+    Materialized { last_verified_at = now_unix_ms () }
 
 (* RFC-0019 PR-C §3.2 P1 — token-as-boundary invariant requires a
    stable, length-bounded fingerprint of the actual oauth_token so the

--- a/test/test_credential_materializer.ml
+++ b/test/test_credential_materializer.ml
@@ -260,6 +260,48 @@ let with_env_vars vars f =
         saved)
     f
 
+let test_verify_state_rejects_graphql_auth_failure () =
+  with_temp_base_path (fun base ->
+      let bin_dir = Filename.concat base "bin" in
+      Unix.mkdir bin_dir 0o755;
+      let gh_path = Filename.concat bin_dir "gh" in
+      write_file gh_path
+        {|#!/bin/sh
+set -eu
+cmd1="${1:-}"
+cmd2="${2:-}"
+if [ "$cmd1" = "auth" ] && [ "$cmd2" = "status" ]; then
+  exit 0
+fi
+if [ "$cmd1" = "api" ] && [ "$cmd2" = "graphql" ]; then
+  exit 1
+fi
+exit 2
+|};
+      Unix.chmod gh_path 0o755;
+      let gh_config_dir = Filename.concat base "bundle-gh" in
+      Unix.mkdir gh_config_dir 0o700;
+      write_file (Filename.concat gh_config_dir "hosts.yml")
+        "github.com:\n\
+        \    user: keeper-A\n\
+        \    oauth_token: ghp_graphql_failure_canary\n\
+        \    git_protocol: https\n";
+      let path =
+        match Sys.getenv_opt "PATH" with
+        | None | Some "" -> bin_dir
+        | Some current -> bin_dir ^ ":" ^ current
+      in
+      with_env_vars [ ("PATH", path) ] (fun () ->
+          match Credential_materializer.verify_state ~gh_config_dir with
+          | Stale { reason } ->
+              Alcotest.(check bool)
+                "reason mentions graphql viewer"
+                true
+                (contains_substring reason "graphql viewer")
+          | other ->
+              Alcotest.failf "expected Stale, got %s"
+                (show_credential_state other)))
+
 let test_provision_rejects_empty_token () =
   match
     Credential_materializer.provision_via_with_token
@@ -321,6 +363,15 @@ if [ "$cmd1" = "auth" ] && [ "$cmd2" = "status" ]; then
   env | sort > "$GH_CONFIG_DIR/status.env"
   printf '%s\n' "$@" > "$GH_CONFIG_DIR/status.argv"
   if [ -s "$GH_CONFIG_DIR/hosts.yml" ]; then
+    exit 0
+  fi
+  exit 1
+fi
+if [ "$cmd1" = "api" ] && [ "$cmd2" = "graphql" ]; then
+  env | sort > "$GH_CONFIG_DIR/api.env"
+  printf '%s\n' "$@" > "$GH_CONFIG_DIR/api.argv"
+  if [ -s "$GH_CONFIG_DIR/hosts.yml" ]; then
+    printf '%s\n' 'keeper-A'
     exit 0
   fi
   exit 1
@@ -397,6 +448,8 @@ exit 2
         (read_file (Filename.concat gh_config_dir "login.env"));
       assert_clean_env "status env"
         (read_file (Filename.concat gh_config_dir "status.env"));
+      assert_clean_env "api env"
+        (read_file (Filename.concat gh_config_dir "api.env"));
       let hosts_yml =
         read_file (Filename.concat gh_config_dir "hosts.yml")
       in
@@ -637,6 +690,8 @@ let () =
           Alcotest.test_case
             "keyring-only hosts.yml without oauth_token is Stale" `Quick
             test_keyring_backed_bundle_without_oauth_token_is_stale;
+          Alcotest.test_case "GraphQL auth failure is Stale" `Quick
+            test_verify_state_rejects_graphql_auth_failure;
         ] );
       ( "ensure",
         [


### PR DESCRIPTION
## Summary

- require bundle-scoped `gh api graphql` viewer success before a GitHub identity is considered `Materialized`
- keep the existing Docker-projectable `hosts.yml`/`oauth_token` preflight from #13922 before running `gh` checks
- add credential materializer coverage for a bundle where `gh auth status` succeeds but GraphQL viewer fails

## Why

The Docker keeper PR lifecycle work exposed multiple ways a credential can look usable on the host while still failing during keeper PR operations. #13922 closed the keyring-only case where `hosts.yml` had no Docker-projectable `oauth_token`. This patch closes the next preflight gap: a bundle should not be treated as materialized unless the same scrubbed, bundle-scoped environment can authenticate against GitHub's GraphQL API.

This is still only a preflight hardening slice. The broader fleet objective remains tracked by #13920, including nonoperator permission/capability proof for Docker push, PR create, review, and approve.

## Operator Impact

Credential state should fail closed earlier when a keeper identity cannot make the API calls needed for PR lifecycle work. Operators should see a stale credential reason before launching Docker keeper flows that would otherwise fail later inside `keeper_pr_create` or review tooling.

## Validation

- `git diff --check`
- Draft PR checks passed: CI Gate, Draft Auto-Merge Guard, Env knob classification, Fun.protect finalizer guard, Godfile size, Hardcoded model prefix, Math.random in components, PR Live Gate, PR Sync Check, Workflow YAML syntax
- Full Build/Test, Lint, Dashboard, Health, Keeper Cwd Leak Gate, Meta Guards, OCaml Structure Ratchet, and TLA+ jobs are skipped while this remains draft
- Attempted `scripts/dune-local.sh build lib/repo_manager/repo_manager.cma`; blocked waiting on shared `/tmp/me-dune-local.lock`, then stopped the waiting command
- Attempted `scripts/dune-local.sh build test/test_credential_materializer.exe`; blocked waiting on shared `/tmp/me-dune-local.lock`, then stopped the waiting command

Draft until CI/local Dune validates the OCaml targets.