### PR TITLE
fix(coord): hard-stop oscillating task release loops

### DIFF
--- a/lib/coord/coord_task_claim.ml
+++ b/lib/coord/coord_task_claim.ml
@@ -373,6 +373,16 @@ let release_should_block_reclaim handoff_context =
     (release_handoff_texts handoff_context)
 ;;
 
+let release_cycle_oscillation_hard_stop_threshold = 15
+
+let release_cycle_oscillation_hard_stop_reason ~next_cycle =
+  Printf.sprintf
+    "auto: claim-release oscillation threshold reached (cycle=%d >= %d) - \
+     operator review required before reclaim"
+    next_cycle
+    release_cycle_oscillation_hard_stop_threshold
+;;
+
 let derive_release_do_not_reclaim_reason (task : Masc_domain.task) handoff_context =
   match do_not_reclaim_reason_blocks_claim task.do_not_reclaim_reason with
   | Some _ as existing -> existing
@@ -386,5 +396,9 @@ let derive_release_do_not_reclaim_reason (task : Masc_domain.task) handoff_conte
     then
       Some
         (Option.value first_text ~default:"release hard-stop requested")
-    else None
+    else
+      let next_cycle = task.cycle_count + 1 in
+      if next_cycle >= release_cycle_oscillation_hard_stop_threshold
+      then Some (release_cycle_oscillation_hard_stop_reason ~next_cycle)
+      else None
 ;;

--- a/test/test_room_coverage.ml
+++ b/test/test_room_coverage.ml
@@ -677,6 +677,45 @@ let test_release_cycles_do_not_create_auto_do_not_reclaim () =
       Alcotest.fail
         ("retryable task should remain claimable: " ^ Masc_domain.masc_error_to_string e))
 
+let test_release_cycle_15_creates_auto_hard_stop () =
+  with_test_env (fun config ->
+    let claude = find_agent_name_by_prefix config "claude" in
+    let _ =
+      Coord.add_task config ~title:"Oscillating task" ~priority:1 ~description:""
+    in
+    let backlog = Coord.read_backlog config in
+    let tasks =
+      List.map
+        (fun (t : Masc_domain.task) ->
+           if String.equal t.id "task-001"
+           then { t with cycle_count = 14; do_not_reclaim_reason = None }
+           else t)
+        backlog.tasks
+    in
+    write_tasks config tasks;
+    (match Coord.claim_task_r config ~agent_name:claude ~task_id:"task-001" () with
+     | Ok _ -> ()
+     | Error e -> Alcotest.fail (Masc_domain.masc_error_to_string e));
+    (match Coord.release_task_r config ~agent_name:claude ~task_id:"task-001" () with
+     | Ok _ -> ()
+     | Error e -> Alcotest.fail (Masc_domain.masc_error_to_string e));
+    let task = task_by_id config "task-001" in
+    Alcotest.(check int) "cycle count reaches hard-stop threshold" 15
+      task.cycle_count;
+    let reason =
+      match task.do_not_reclaim_reason with
+      | Some reason -> reason
+      | None -> Alcotest.fail "expected auto oscillation hard stop"
+    in
+    Alcotest.(check bool) "reason names oscillation" true
+      (str_contains reason "claim-release oscillation threshold");
+    match Coord.claim_task_r config ~agent_name:claude ~task_id:"task-001" () with
+    | Ok _ -> Alcotest.fail "oscillating task should be blocked from reclaim"
+    | Error e ->
+      let msg = Masc_domain.masc_error_to_string e in
+      Alcotest.(check bool) "claim error carries hard-stop reason" true
+        (str_contains msg "operator review required"))
+
 let test_claim_next_allows_failed_verification_repair () =
   with_test_env (fun config ->
     let claude = find_agent_name_by_prefix config "claude" in
@@ -1531,6 +1570,8 @@ let () =
         test_claim_next_prefers_unblocked_over_legacy_auto_cycle;
       Alcotest.test_case "release cycles do not create auto block" `Quick
         test_release_cycles_do_not_create_auto_do_not_reclaim;
+      Alcotest.test_case "cycle 15 release creates auto hard stop" `Quick
+        test_release_cycle_15_creates_auto_hard_stop;
       Alcotest.test_case "failed verification stays repair-claimable" `Quick
         test_claim_next_allows_failed_verification_repair;
     ];


### PR DESCRIPTION
## Summary
- re-land the #10719 cycle-15 release hard-stop directly on current main
- set a hard do_not_reclaim_reason when release would move a task to cycle_count >= 15
- keep lower retry cycles and legacy soft auto-cycle reasons claimable
- add room coverage for cycle 15 hard-stop blocking direct reclaim

## Root Cause
The earlier hard-stop work was merged only into a stacked branch, not origin/main. Main had WARN-only oscillation threshold handling, so tasks could still continue claim -> release indefinitely after the alert thresholds.

## Validation
- ocamlc -stop-after parsing lib/coord/coord_task_claim.ml test/test_room_coverage.ml
- scripts/dune-local.sh build test/test_room_coverage.exe
- ./_build/default/test/test_room_coverage.exe test ^claim_next 16,17 --show-errors
- scripts/check-oas-pin.sh --local-only
- git diff --check origin/main..HEAD

Fixes #10719