### PR TITLE
fix(keeper): fail closed on no-clock slot waits

### DIFF
--- a/lib/keeper/keeper_turn_slot.ml
+++ b/lib/keeper/keeper_turn_slot.ml
@@ -971,15 +971,33 @@ let with_keeper_turn_slot_control ?(cascade_profile = "unknown") ~keeper_name
       (* No Eio clock available: we are running outside an Eio main loop
          (e.g. Alcotest without [Eio_main.run]). Production masc-mcp
          always provides a clock via [Masc_eio_env.init]; reaching this
-         branch at runtime would indicate an environment-setup drift,
-         so log it prominently before falling back to unbounded acquire. *)
-      Log.Keeper.warn
-        "semaphore_wait: no Eio clock available — %s acquire will be unbounded (environment drift?)"
-        label;
-      Eio.Semaphore.acquire sem;
-      (* Cancel-race fix: see comment in the with-clock branch above.
-         record_holder is the caller's responsibility, after flag set. *)
-      Ok ()
+         branch at runtime would indicate an environment-setup drift.  If
+         the permit is immediately available we can still acquire without
+         waiting; otherwise fail closed rather than blocking forever. *)
+      if Eio.Semaphore.get_value sem > 0 then begin
+        Log.Keeper.warn
+          "semaphore_wait: no Eio clock available — %s acquire is immediate only (environment drift?)"
+          label;
+        Eio.Semaphore.acquire sem;
+        (* Cancel-race fix: see comment in the with-clock branch above.
+           record_holder is the caller's responsibility, after flag set. *)
+        Ok ()
+      end else begin
+        let holders =
+          snapshot_holders ~label ~now:(Time_compat.now ())
+        in
+        Log.Keeper.warn
+          "semaphore_wait: no Eio clock available and %s semaphore has no permits; failing closed instead of waiting unboundedly"
+          label;
+        Prometheus.inc_counter
+          Prometheus.metric_keeper_semaphore_wait_timeout
+          ~labels:[ ("keeper", keeper_name);
+                    ("channel", label) ]
+          ();
+        Error
+          (`Semaphore_wait_timeout
+            (semaphore_wait_timeout_snapshot ~phase ~holders ()))
+      end
   in
   let log_acquire_attempt () =
     let queue_depth = List.length (autonomous_waiter_snapshot_for_test ()) in

--- a/test/test_keeper_turn_slot_holders.ml
+++ b/test/test_keeper_turn_slot_holders.ml
@@ -534,6 +534,49 @@ let test_retry_control_autonomous_release_skips_completion_stamp () =
     ~expected:autonomous_before
     ~actual:(KK.autonomous_turn_semaphore_value_for_test ())
 
+let test_no_clock_exhausted_turn_slot_fails_closed () =
+  match Eio_context.get_clock_opt () with
+  | Some _ ->
+      (* This executable normally runs without a global Eio_context clock.
+         If a wider test runner has installed one, the no-clock branch is
+         not reachable in this process. *)
+      ()
+  | None ->
+      let rec acquire_all acquired =
+        if Eio.Semaphore.get_value KTS.turn_semaphore <= 0 then acquired
+        else begin
+          Eio.Semaphore.acquire KTS.turn_semaphore;
+          acquire_all (acquired + 1)
+        end
+      in
+      let rec release_n = function
+        | n when n <= 0 -> ()
+        | n ->
+            Eio.Semaphore.release KTS.turn_semaphore;
+            release_n (n - 1)
+      in
+      let acquired = acquire_all 0 in
+      Fun.protect
+        ~finally:(fun () -> release_n acquired)
+        (fun () ->
+          let result =
+            KK.with_keeper_turn_slot_for_test
+              ~keeper_name:"diag-no-clock-exhausted"
+              ~channel:Masc_mcp.Keeper_world_observation.Reactive
+              (fun ~semaphore_wait_ms:_ ->
+                failwith "exhausted turn slot should fail before body runs")
+          in
+          match result with
+          | Error (`Semaphore_wait_timeout snapshot) ->
+              if snapshot.timeout_phase <> KK.Turn_slot then
+                failwith
+                  (Printf.sprintf
+                     "expected Turn_slot timeout, got %s"
+                     (KK.semaphore_wait_phase_to_string
+                        snapshot.timeout_phase))
+          | Ok _ ->
+              failwith "exhausted no-clock acquire should fail closed")
+
 let test_force_release_marker_ttl_bounds_unfinalized_fibers () =
   KK.clear_force_released_markers_for_test ();
   let marked_at = 1_000.0 in
@@ -582,6 +625,8 @@ let () =
         test_retry_control_releases_and_reacquires_reactive_slot;
       "retry control autonomous release skips completion stamp",
         test_retry_control_autonomous_release_skips_completion_stamp;
+      "no-clock exhausted turn slot fails closed",
+        test_no_clock_exhausted_turn_slot_fails_closed;
       "force release marker ttl bounds unfinalized fibers",
         test_force_release_marker_ttl_bounds_unfinalized_fibers;
     ]


### PR DESCRIPTION
## Summary

- Fail closed when keeper turn-slot acquisition runs without an Eio clock and the target semaphore has no available permits.
- Preserve the immediate-acquire path for no-clock test contexts when a permit is available.
- Add a holder regression that exhausts the turn semaphore and verifies a `Turn_slot` `Semaphore_wait_timeout` instead of an unbounded wait.

## Product impact

- User-visible change: no normal production change expected because production should have an initialized Eio clock. If that invariant drifts while slots are exhausted, the keeper now skips/fails closed with holder evidence and metrics instead of blocking indefinitely.

## Evidence

- `git diff --check origin/main...HEAD`
- `ocamlc -stop-after parsing lib/keeper/keeper_turn_slot.ml && ocamlc -stop-after parsing test/test_keeper_turn_slot_holders.ml`
- `scripts/dune-local.sh build test/test_keeper_turn_slot_holders.exe`
- `./_build/default/test/test_keeper_turn_slot_holders.exe` PASS
- `bash scripts/ci/check-silent-failure-patterns.sh` PASS, no critical silent failures detected

## GOAL LOOP ACT checklist

- [x] Observe — Kimi audit item identified keeper_turn_slot no-clock semaphore acquire as an unbounded wait path.
- [x] Orient — the risk is only when Eio_context has no clock and the semaphore has no permits.
- [x] Decide — bounded fail-closed branch preserves immediate no-clock test acquires while preventing indefinite waits under contention.
- [x] Act — changed only keeper_turn_slot and its focused holder regression test.
- [x] Verify — focused Dune build, holder executable, parser checks, diff check, and silent-failure scan passed locally.
- [x] Loop — no follow-up required for this narrow no-clock acquire slice.

## Review evidence

- Not run: no cross-model review for this bounded semaphore hardening patch.

## Linked issue

- Relates: Kimi audit follow-up; no GitHub issue number.

## Variant addition checklist

- [ ] **OCaml** — N/A: no variant added, removed, or renamed.
- [ ] **TypeScript** — N/A: no TypeScript union member changed.
- [ ] **TLA+ spec** — N/A: no TLA+ domain literal changed.
- [ ] **Event / JSON schema** — N/A: no event or JSON schema enum changed.
- [ ] **`make check-variants` passes** — N/A: no variant surface changed.
