### PR TITLE
feat(metrics): masc_keeper_oas_run_timeout_total counter for hang attribution

### DIFF
--- a/lib/oas_worker_named_fsm.ml
+++ b/lib/oas_worker_named_fsm.ml
@@ -465,7 +465,38 @@ let emit_provider_error_metric ~cascade_name ~provider error =
       ]
     ()
 
+(* #13923 / #13933: when the agent_sdk [with_optional_timeout] wrapper
+   fires it produces a [Retry.Timeout] whose message starts with
+   "Agent execution exceeded max_execution_time_s". Distinguish that
+   from a transport-level provider timeout by substring so dashboards
+   can tell whether our per-OAS-call ceiling actually engaged versus
+   the upstream socket deadline. *)
+let timeout_source_label (err : Agent_sdk.Error.sdk_error) : string =
+  let is_max_execution_time =
+    match err with
+    | Agent_sdk.Error.Api (Llm_provider.Retry.Timeout { message }) ->
+        String_util.contains_substring_ci message "max_execution_time_s"
+    | _ -> false
+  in
+  if is_max_execution_time then "max_execution_time" else "provider"
+
+let emit_oas_run_timeout_metric ~cascade_name ~provider err =
+  match err with
+  | Agent_sdk.Error.Api (Llm_provider.Retry.Timeout _) ->
+      let cascade_name = provider_label (cascade_name_to_string cascade_name) in
+      let provider = provider_label provider in
+      Prometheus.inc_counter Prometheus.metric_keeper_oas_run_timeout
+        ~labels:
+          [
+            ("cascade", cascade_name);
+            ("provider", provider);
+            ("source", timeout_source_label err);
+          ]
+        ()
+  | _ -> ()
+
 let emit_sdk_provider_error_metric ~cascade_name ~provider err =
+  emit_oas_run_timeout_metric ~cascade_name ~provider err;
   match sdk_error_to_provider_error ~provider err with
   | None -> None
   | Some provider_error ->

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -1295,6 +1295,8 @@ let metric_keeper_stale_termination_batch =
   "masc_keeper_stale_termination_batch_total"
 let metric_keeper_stale_broadcast_emit_failures =
   "masc_keeper_stale_broadcast_emit_failures"
+let metric_keeper_oas_run_timeout =
+  "masc_keeper_oas_run_timeout_total"
 
 
 (* Centralized metric constants for inline string replacement.
@@ -2516,6 +2518,12 @@ let init () =
     "Total fleet-wide batch termination events (multiple keepers terminated      within the batch window). Labels: root_cause." Counter;
   add metric_keeper_stale_broadcast_emit_failures
     "Total failures emitting stale keeper broadcast events. Labels: keeper." Counter;
+  add metric_keeper_oas_run_timeout
+    "Total Agent.run / run_stream invocations that returned Llm_provider.Retry.Timeout. \
+     Pairs with #13923 (max_execution_time wire) and #13933 (cascade activation): \
+     dashboards can attribute hangs to root cause via the source label \
+     (max_execution_time = our wrapper fired; provider = transport-level deadline). \
+     Labels: cascade, provider, source." Counter;
   add metric_keeper_tool_use_failure
     "Total keeper tool use failures during OAS hooks. Labels: keeper, tool." Counter;
   add metric_keeper_tool_not_allowed

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -1093,6 +1093,23 @@ val metric_keeper_oas_timeout_budget_watchdog_termination : string
 val metric_keeper_stale_termination_threshold_breached : string
 val metric_keeper_stale_termination_batch : string
 val metric_keeper_stale_broadcast_emit_failures : string
+
+val metric_keeper_oas_run_timeout : string
+(** [masc_keeper_oas_run_timeout_total] counter incremented in the
+    cascade FSM each time an [Agent.run] / [run_stream] returns
+    [Llm_provider.Retry.Timeout]. The [source] label distinguishes the
+    timeout origin so dashboards can attribute hangs to root cause:
+
+    - [source="max_execution_time"] — agent_sdk's
+      [with_optional_timeout] fired because the per-OAS-call ceiling
+      ([max_execution_time_s], wired in PR #13923/#13933) was reached.
+      This is the canonical signal for cross-cascade fallback on hang.
+    - [source="provider"] — transport-level timeout from the upstream
+      provider (HTTP read deadline, gRPC deadline, etc.). The agent
+      did not have [max_execution_time_s] set, or the timeout fired
+      below the wrapper.
+
+    Labels: cascade, provider, source. *)
   (* Centralized metric constants for inline string replacement. *)
 val metric_keeper_tool_use_failure : string
 val metric_keeper_tool_not_allowed : string


### PR DESCRIPTION
## Summary

Adds a Prometheus counter `masc_keeper_oas_run_timeout_total{cascade, provider, source}` so dashboards can attribute `Agent.run`/`run_stream` timeouts to root cause now that PR #13923 (wire) + #13933 (caller activation) have shipped.

## Why

Until #13923/#13933 merged, `Llm_provider.Retry.Timeout` from agent_sdk was effectively never produced (`max_execution_time_s` was always `None`). Now that the per-OAS-call ceiling fires at ~300 s, we need to know:

1. How often the new wire engages — is the fix actually doing work?
2. Whether residual hangs are from transport-level timeouts (separate root cause).

Without a labelled counter, dashboards lump both into the generic `provider_error_total{kind="...", ...}` (which doesn't even fire for `Retry.Timeout` — see `lib/oas_worker_named_fsm.ml:417`, `Timeout` returns `None` from `retry_api_error_to_provider_error` when capacity is fine). So timeouts have been silently dropping out of the metrics pipeline. This PR closes that gap.

## What changes

| File | Change |
|------|--------|
| `lib/prometheus.mli` | Declare `val metric_keeper_oas_run_timeout : string` with full doc on label semantics. |
| `lib/prometheus.ml` | Define the constant `"masc_keeper_oas_run_timeout_total"`; register it as a Counter with help text in startup. |
| `lib/oas_worker_named_fsm.ml` | Add `timeout_source_label` (substring classification) + `emit_oas_run_timeout_metric` (no-op for non-Timeout errors). Wire it into `emit_sdk_provider_error_metric` so every cascade error pass also fires this counter when applicable. |

Net diff: 3 files / +56 / -0.

## Source label semantics

| Label | When |
|-------|------|
| `source="max_execution_time"` | agent_sdk's `with_optional_timeout` fired. Message contains `"Agent execution exceeded max_execution_time_s"` (literal from agent.ml:255). This is the wire from #13923/#13933 doing its job. |
| `source="provider"` | Transport-level timeout (HTTP read deadline, gRPC deadline, etc.) or the wire was inactive (default `None`) for this call. |

Substring-based classification is brittle but the message format is hardcoded in agent_sdk; if the format changes, the substring guard becomes a soft-fail (everything attributed to `provider`) — no crash.

## Why not extend `metric_keeper_stale_termination_by_class`?

That counter is owned by the watchdog and represents *kills*, not *observed timeouts during a run*. The cascade FSM sees the `Retry.Timeout` directly from `Agent.run_stream`, before any kill decision. Different signal, different counter — separation matches existing precedent (`provider_error_total` is also distinct from stale-termination counters).

## Out of scope

- Grafana dashboard panel — `dashboard/` repo separate; dashboards.json patch is a follow-up.
- Cascade fallback action correlation (which provider got the next attempt) — reuses existing `provider_error_total{cascade_name, provider}` for that question.
- Watchdog-side stream-idle metric originally proposed in plan — superseded; the cascade FSM observation point has cleaner data than the watchdog could derive.

## Test plan

- [x] `dune build --root . @check` — clean (no errors, no warnings on touched files).
- [ ] CI green — pending after push.
- [ ] Production probe (post-merge): expect `source=max_execution_time` counter to start increasing on local-LLM cascades; `source=provider` stays close to baseline.

## Refs

- Goal: `oas-bridge-stabilization` Step 6 (revised scope).
- Companion: PR #13923 (MERGED), PR #13933 (MERGED), PR #13901 (MERGEABLE).
- Plan: `~/me/planning/claude-plans/20m-me-workspace-yousleepwhen-masc-mcp-o-recursive-mountain.md`.

RFC-WAIVED: this PR touches `lib/prometheus.{ml,mli}` (observability registry — no policy gate) and `lib/oas_worker_named_fsm.ml` (cascade FSM, not in the credential / identity / auth / sandbox / hooks / workflow path).
