### PR TITLE
fix: derive dashboard OAS duration from timings

### DIFF
--- a/lib/dashboard/dashboard_oas_bridge.ml
+++ b/lib/dashboard/dashboard_oas_bridge.ml
@@ -149,10 +149,21 @@ let record (s : sample) = record_with_time ~now:(Unix.gettimeofday ()) s
 
 let duration_from_response ?total_duration_ms
     (response : Agent_sdk.Types.api_response) =
+  let positive = function Some ms when ms > 0.0 -> Some ms | _ -> None in
+  let duration_from_timings = function
+    | Some (timings : Agent_sdk.Types.inference_timings) -> (
+        match (positive timings.prompt_ms, positive timings.predicted_ms) with
+        | Some prompt_ms, Some predicted_ms -> prompt_ms +. predicted_ms
+        | Some prompt_ms, None -> prompt_ms
+        | None, Some predicted_ms -> predicted_ms
+        | None, None -> 0.0)
+    | None -> 0.0
+  in
   match total_duration_ms, response.telemetry with
   | Some ms, _ when ms > 0.0 -> ms
   | _, Some telemetry when telemetry.request_latency_ms > 0 ->
       Float.of_int telemetry.request_latency_ms
+  | _, Some telemetry -> duration_from_timings telemetry.timings
   | _ -> 0.0
 
 let ttfb_from_response (response : Agent_sdk.Types.api_response) =

--- a/lib/dashboard/dashboard_oas_bridge.mli
+++ b/lib/dashboard/dashboard_oas_bridge.mli
@@ -89,7 +89,9 @@ val sample_of_response :
 
     - [usage] fields become token, cost, and cache-hit signals.
     - [response.telemetry.request_latency_ms] is used as duration when the
-      caller does not provide [total_duration_ms].
+      caller does not provide [total_duration_ms]. If that aggregate
+      latency is missing/zero, positive [prompt_ms] + [predicted_ms]
+      timing components are used as a non-zero duration instead.
     - native decode throughput is preferred when OAS telemetry exposes it;
       otherwise wall-clock throughput is derived from output tokens and
       duration.

--- a/test/test_dashboard_oas_bridge.ml
+++ b/test/test_dashboard_oas_bridge.ml
@@ -374,6 +374,36 @@ let test_sample_of_response_derives_wall_throughput () =
   Alcotest.(check bool) "wall throughput" true
     (sample.throughput_tokens_per_s = Some 200.0)
 
+let test_sample_of_response_derives_duration_from_timing_components () =
+  let usage = make_usage ~input:100 ~output:88 () in
+  let timings : Agent_sdk.Types.inference_timings =
+    {
+      prompt_n = None;
+      prompt_ms = Some 120.0;
+      prompt_per_second = None;
+      predicted_n = None;
+      predicted_ms = Some 880.0;
+      predicted_per_second = None;
+      cache_n = None;
+    }
+  in
+  let telemetry = make_telemetry ~timings ~request_latency_ms:0 () in
+  let response = make_response ~usage ~telemetry ~model:"ollama:qwen" () in
+  let sample =
+    DOB.sample_of_response ~provider_id:"ollama" ~model_id:"ollama:qwen"
+      ~status:DOB.Success response
+  in
+  Alcotest.(check (float 1e-9))
+    "duration falls back to prompt+decode timings" 1000.0
+    sample.total_duration_ms;
+  Alcotest.(check (float 1e-9)) "ttfb still uses prompt timing" 120.0
+    sample.ttfb_ms;
+  (match sample.throughput_tokens_per_s with
+  | Some throughput ->
+      Alcotest.(check (float 1e-9))
+        "wall throughput uses derived decode time" 100.0 throughput
+  | None -> Alcotest.fail "expected derived throughput")
+
 let test_record_response_records_missing_usage_as_unknown_sample () =
   setup ();
   let response =
@@ -518,6 +548,8 @@ let () =
             test_sample_of_response_uses_usage_and_native_telemetry;
           Alcotest.test_case "wall throughput fallback" `Quick
             test_sample_of_response_derives_wall_throughput;
+          Alcotest.test_case "timing components avoid zero duration" `Quick
+            test_sample_of_response_derives_duration_from_timing_components;
           Alcotest.test_case "missing usage records unknown sample" `Quick
             test_record_response_records_missing_usage_as_unknown_sample;
         ] );


### PR DESCRIPTION
## What

- Derive dashboard OAS `total_duration_ms` from positive `prompt_ms` + `predicted_ms` timing components when aggregate `request_latency_ms` is missing or zero.
- Preserve explicit caller-provided duration and positive aggregate latency precedence.
- Add a regression test proving a zero aggregate latency no longer forces a zero dashboard duration when native timing components are available.

## Why

Phase 0 calls out 0ms telemetry as a measurement-foundation blocker. The dashboard bridge already had useful timing components available in some OAS responses, but `request_latency_ms = 0` collapsed those samples to `total_duration_ms = 0.0`. This keeps those samples measurable without inventing synthetic latency.

## Validation

- `git diff --check origin/main...HEAD`
- `lockf -k -t 300 /tmp/me-dune-local.lock env MASC_DUNE_LOCK_HELD=1 MASC_SKIP_OPAM_LOCK=1 DUNE_JOBS=1 DUNE_CACHE=disabled scripts/dune-local.sh build test/test_dashboard_oas_bridge.exe` passed before the clean final rebase
- `_build/default/test/test_dashboard_oas_bridge.exe` passed: 22 tests
- Post-rebase rerun of the same focused build timed out waiting for an unrelated shared Dune lock holder; draft CI is the current-base verification surface.