### PR TITLE
test(oas): regression guard for masc_keeper_oas_run_timeout source label

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -173,7 +173,6 @@
   oas_worker_named
   oas_worker_named_cascade
   oas_worker_named_error
-  oas_worker_named_fsm
   meta_cognition_types
   meta_cognition_rules
   meta_cognition_snapshot

--- a/lib/oas_worker_named_fsm.ml
+++ b/lib/oas_worker_named_fsm.ml
@@ -468,14 +468,16 @@ let emit_provider_error_metric ~cascade_name ~provider error =
 (* #13923 / #13933: when the agent_sdk [with_optional_timeout] wrapper
    fires it produces a [Retry.Timeout] whose message starts with
    "Agent execution exceeded max_execution_time_s". Distinguish that
-   from a transport-level provider timeout by substring so dashboards
-   can tell whether our per-OAS-call ceiling actually engaged versus
-   the upstream socket deadline. *)
+   from a transport-level provider timeout by prefix so dashboards can
+   tell whether our per-OAS-call ceiling actually engaged versus the
+   upstream socket deadline. *)
 let timeout_source_label (err : Agent_sdk.Error.sdk_error) : string =
   let is_max_execution_time =
     match err with
     | Agent_sdk.Error.Api (Llm_provider.Retry.Timeout { message }) ->
-        String_util.contains_substring_ci message "max_execution_time_s"
+        String.starts_with
+          ~prefix:"agent execution exceeded max_execution_time_s"
+          (String.trim (String.lowercase_ascii message))
     | _ -> false
   in
   if is_max_execution_time then "max_execution_time" else "provider"

--- a/lib/oas_worker_named_fsm.mli
+++ b/lib/oas_worker_named_fsm.mli
@@ -116,12 +116,11 @@ val timeout_source_label : Agent_sdk.Error.sdk_error -> string
 (** Classifier for [masc_keeper_oas_run_timeout_total]'s [source] label.
 
     - ["max_execution_time"] when the error is [Retry.Timeout] and the
-      message contains the literal substring ["max_execution_time_s"]
-      (the wrapper text agent_sdk emits at agent.ml:255).
+      message starts with the wrapper text agent_sdk emits at agent.ml:255.
     - ["provider"] for every other case (transport-level deadlines,
       non-Timeout errors that callers nevertheless pass in).
 
-    Exposed for regression tests against the substring classification —
+    Exposed for regression tests against the prefix classification —
     if agent_sdk changes the wrapper message, the test fails loudly
     before the metric silently misclassifies. *)
 

--- a/lib/oas_worker_named_fsm.mli
+++ b/lib/oas_worker_named_fsm.mli
@@ -112,6 +112,19 @@ val emit_sdk_provider_error_metric :
 (** Convert and emit an SDK provider error. Returns the converted variant
     so callers/tests can assert the same decision without reparsing metrics. *)
 
+val timeout_source_label : Agent_sdk.Error.sdk_error -> string
+(** Classifier for [masc_keeper_oas_run_timeout_total]'s [source] label.
+
+    - ["max_execution_time"] when the error is [Retry.Timeout] and the
+      message contains the literal substring ["max_execution_time_s"]
+      (the wrapper text agent_sdk emits at agent.ml:255).
+    - ["provider"] for every other case (transport-level deadlines,
+      non-Timeout errors that callers nevertheless pass in).
+
+    Exposed for regression tests against the substring classification —
+    if agent_sdk changes the wrapper message, the test fails loudly
+    before the metric silently misclassifies. *)
+
 val sdk_error_soft_rate_limited :
   Agent_sdk.Error.sdk_error -> float option option
 (** [Some (Some retry_after)] for non-quota 429 responses with a parsed

--- a/test/dune
+++ b/test/dune
@@ -1086,6 +1086,7 @@
 (include stanzas/test_cascade_catalog_runtime.inc)
 (include stanzas/test_cascade_config_validity.inc)
 (include stanzas/test_cascade_fsm.inc)
+(include stanzas/test_oas_run_timeout_source_label.inc)
 (include stanzas/test_cascade_health_tracker.inc)
 (include stanzas/test_cascade_inventory.inc)
 (include stanzas/test_cascade_per_candidate_telemetry.inc)

--- a/test/stanzas/test_oas_run_timeout_source_label.inc
+++ b/test/stanzas/test_oas_run_timeout_source_label.inc
@@ -1,0 +1,4 @@
+(test
+ (name test_oas_run_timeout_source_label)
+ (modules test_oas_run_timeout_source_label)
+ (libraries masc_test_deps))

--- a/test/test_oas_run_timeout_source_label.ml
+++ b/test/test_oas_run_timeout_source_label.ml
@@ -1,0 +1,108 @@
+(** Regression test for the [source] label classifier of
+    [masc_keeper_oas_run_timeout_total] (PR #13941).
+
+    The classifier discriminates on a substring of the
+    [Llm_provider.Retry.Timeout] message; the substring is the
+    literal text agent_sdk emits at
+    [agent_sdk/agent/agent.ml:255]:
+      "Agent execution exceeded max_execution_time_s (%f)"
+
+    If agent_sdk changes that format, this test fails loudly *before*
+    the production metric silently misclassifies every wrapper hit as
+    a transport-level timeout. *)
+
+open Masc_mcp
+
+let check_string = Alcotest.(check string)
+
+let timeout_err message =
+  Agent_sdk.Error.Api (Llm_provider.Retry.Timeout { message })
+
+let test_max_execution_time_message_classifies () =
+  let err =
+    timeout_err
+      "Agent execution exceeded max_execution_time_s (300.000000)"
+  in
+  check_string
+    "wrapper message → max_execution_time"
+    "max_execution_time"
+    (Oas_worker_named_fsm.timeout_source_label err)
+
+let test_max_execution_time_substring_anywhere () =
+  (* The classifier should be robust to surrounding text — case
+     insensitivity is part of [String_util.contains_substring_ci],
+     so an upper-cased fragment must still match. *)
+  let err =
+    timeout_err
+      "wrapped: AGENT EXECUTION EXCEEDED MAX_EXECUTION_TIME_S (45.0); cascade fallback engaged"
+  in
+  check_string
+    "uppercase substring still classifies as max_execution_time"
+    "max_execution_time"
+    (Oas_worker_named_fsm.timeout_source_label err)
+
+let test_provider_timeout_without_substring () =
+  (* Generic transport-level timeout — different message, must
+     fall through to the [provider] bucket. *)
+  let err =
+    timeout_err
+      "HTTP read deadline exceeded after 30 seconds"
+  in
+  check_string
+    "transport timeout → provider"
+    "provider"
+    (Oas_worker_named_fsm.timeout_source_label err)
+
+let test_non_timeout_error_classifies_as_provider () =
+  (* Non-Timeout errors should not crash the classifier; they
+     produce the [provider] bucket so callers can pass any error
+     and rely on the no-op for the metric path. *)
+  let err =
+    Agent_sdk.Error.Api
+      (Llm_provider.Retry.NetworkError
+         { message = "DNS lookup failed"
+         ; kind = Llm_provider.Http_client.Dns_failure
+         })
+  in
+  check_string
+    "non-Timeout error → provider"
+    "provider"
+    (Oas_worker_named_fsm.timeout_source_label err)
+
+let test_empty_message_falls_back_to_provider () =
+  (* Defensive: agent_sdk should never produce an empty message
+     for [Retry.Timeout], but if it did the classifier must not
+     mis-attribute it. *)
+  let err = timeout_err "" in
+  check_string
+    "empty message → provider"
+    "provider"
+    (Oas_worker_named_fsm.timeout_source_label err)
+
+let () =
+  Alcotest.run "Oas_run_timeout_source_label"
+    [
+      ( "classification",
+        [
+          Alcotest.test_case
+            "exact wrapper message"
+            `Quick
+            test_max_execution_time_message_classifies;
+          Alcotest.test_case
+            "uppercase substring"
+            `Quick
+            test_max_execution_time_substring_anywhere;
+          Alcotest.test_case
+            "transport timeout"
+            `Quick
+            test_provider_timeout_without_substring;
+          Alcotest.test_case
+            "non-Timeout error"
+            `Quick
+            test_non_timeout_error_classifies_as_provider;
+          Alcotest.test_case
+            "empty message defensive"
+            `Quick
+            test_empty_message_falls_back_to_provider;
+        ] );
+    ]

--- a/test/test_oas_run_timeout_source_label.ml
+++ b/test/test_oas_run_timeout_source_label.ml
@@ -1,15 +1,15 @@
 (** Regression test for the [source] label classifier of
     [masc_keeper_oas_run_timeout_total] (PR #13941).
 
-    The classifier discriminates on a substring of the
-    [Llm_provider.Retry.Timeout] message; the substring is the
-    literal text agent_sdk emits at
+    The classifier discriminates on the prefix of the
+    [Llm_provider.Retry.Timeout] message; the prefix is the literal
+    text agent_sdk emits at
     [agent_sdk/agent/agent.ml:255]:
       "Agent execution exceeded max_execution_time_s (%f)"
 
     If agent_sdk changes that format, this test fails loudly *before*
-    the production metric silently misclassifies every wrapper hit as
-    a transport-level timeout. *)
+    the production metric silently misclassifies wrapper hits as
+    transport-level timeouts or provider messages as wrapper hits. *)
 
 open Masc_mcp
 
@@ -28,17 +28,30 @@ let test_max_execution_time_message_classifies () =
     "max_execution_time"
     (Oas_worker_named_fsm.timeout_source_label err)
 
-let test_max_execution_time_substring_anywhere () =
-  (* The classifier should be robust to surrounding text — case
-     insensitivity is part of [String_util.contains_substring_ci],
-     so an upper-cased fragment must still match. *)
+let test_max_execution_time_prefix_is_case_insensitive () =
+  (* The classifier should be case-insensitive but still require the
+     agent_sdk wrapper prefix, so provider messages that merely mention
+     max_execution_time_s do not get attributed to the wrapper. *)
   let err =
     timeout_err
-      "wrapped: AGENT EXECUTION EXCEEDED MAX_EXECUTION_TIME_S (45.0); cascade fallback engaged"
+      "AGENT EXECUTION EXCEEDED MAX_EXECUTION_TIME_S (45.0); cascade fallback engaged"
   in
   check_string
-    "uppercase substring still classifies as max_execution_time"
+    "uppercase prefix still classifies as max_execution_time"
     "max_execution_time"
+    (Oas_worker_named_fsm.timeout_source_label err)
+
+let test_provider_timeout_with_substring_falls_back_to_provider () =
+  (* A provider/transport timeout can include the same knob name in its
+     diagnostic text. That must remain a provider timeout unless the
+     message starts with agent_sdk's wrapper prefix. *)
+  let err =
+    timeout_err
+      "Provider Ollama rejected max_execution_time_s during request setup"
+  in
+  check_string
+    "provider message mentioning max_execution_time_s → provider"
+    "provider"
     (Oas_worker_named_fsm.timeout_source_label err)
 
 let test_provider_timeout_without_substring () =
@@ -79,6 +92,95 @@ let test_empty_message_falls_back_to_provider () =
     "provider"
     (Oas_worker_named_fsm.timeout_source_label err)
 
+(* ----------------------------------------------------------------
+   Side-effect tests for [emit_sdk_provider_error_metric]
+   ---------------------------------------------------------------- *)
+
+let oas_run_timeout_count ~cascade ~provider ~source =
+  Prometheus.metric_value_or_zero
+    Prometheus.metric_keeper_oas_run_timeout
+    ~labels:
+      [ ("cascade", cascade)
+      ; ("provider", provider)
+      ; ("source", source)
+      ]
+    ()
+
+let cascade_name_for_test name =
+  Oas_worker_named_error.cascade_name_of_string name
+
+let test_emit_increments_max_execution_time_counter () =
+  (* Calling [emit_sdk_provider_error_metric] with a wrapper-message
+     [Retry.Timeout] must increment the counter under the
+     [source="max_execution_time"] label. The function returns
+     [None] for [Timeout] (since the cascade FSM does not map it to
+     a [Provider_error.t] without [capacity_exhausted]) — the
+     side-effect on the new counter is the meaningful observable. *)
+  let cascade = "test-cascade-met" in
+  let provider = "test-provider-met" in
+  let source = "max_execution_time" in
+  let before = oas_run_timeout_count ~cascade ~provider ~source in
+  let err =
+    timeout_err
+      "Agent execution exceeded max_execution_time_s (300.000000)"
+  in
+  let _ =
+    Oas_worker_named_fsm.emit_sdk_provider_error_metric
+      ~cascade_name:(cascade_name_for_test cascade) ~provider err
+  in
+  let after = oas_run_timeout_count ~cascade ~provider ~source in
+  Alcotest.(check (float 0.0001))
+    "max_execution_time counter incremented by 1"
+    1.0 (after -. before)
+
+let test_emit_increments_provider_counter_on_transport_timeout () =
+  let cascade = "test-cascade-prov" in
+  let provider = "test-provider-prov" in
+  let source = "provider" in
+  let before = oas_run_timeout_count ~cascade ~provider ~source in
+  let err = timeout_err "HTTP read deadline exceeded" in
+  let _ =
+    Oas_worker_named_fsm.emit_sdk_provider_error_metric
+      ~cascade_name:(cascade_name_for_test cascade) ~provider err
+  in
+  let after = oas_run_timeout_count ~cascade ~provider ~source in
+  Alcotest.(check (float 0.0001))
+    "provider-source counter incremented by 1"
+    1.0 (after -. before)
+
+let test_emit_does_not_touch_counter_on_non_timeout () =
+  let cascade = "test-cascade-nontmo" in
+  let provider = "test-provider-nontmo" in
+  let before_max =
+    oas_run_timeout_count ~cascade ~provider ~source:"max_execution_time"
+  in
+  let before_prov =
+    oas_run_timeout_count ~cascade ~provider ~source:"provider"
+  in
+  let err =
+    Agent_sdk.Error.Api
+      (Llm_provider.Retry.NetworkError
+         { message = "DNS lookup failed"
+         ; kind = Llm_provider.Http_client.Dns_failure
+         })
+  in
+  let _ =
+    Oas_worker_named_fsm.emit_sdk_provider_error_metric
+      ~cascade_name:(cascade_name_for_test cascade) ~provider err
+  in
+  let after_max =
+    oas_run_timeout_count ~cascade ~provider ~source:"max_execution_time"
+  in
+  let after_prov =
+    oas_run_timeout_count ~cascade ~provider ~source:"provider"
+  in
+  Alcotest.(check (float 0.0001))
+    "no max_execution_time bump on NetworkError"
+    0.0 (after_max -. before_max);
+  Alcotest.(check (float 0.0001))
+    "no provider-source bump on NetworkError"
+    0.0 (after_prov -. before_prov)
+
 let () =
   Alcotest.run "Oas_run_timeout_source_label"
     [
@@ -89,9 +191,13 @@ let () =
             `Quick
             test_max_execution_time_message_classifies;
           Alcotest.test_case
-            "uppercase substring"
+            "uppercase prefix"
             `Quick
-            test_max_execution_time_substring_anywhere;
+            test_max_execution_time_prefix_is_case_insensitive;
+          Alcotest.test_case
+            "provider substring false positive"
+            `Quick
+            test_provider_timeout_with_substring_falls_back_to_provider;
           Alcotest.test_case
             "transport timeout"
             `Quick
@@ -104,5 +210,20 @@ let () =
             "empty message defensive"
             `Quick
             test_empty_message_falls_back_to_provider;
+        ] );
+      ( "side_effect",
+        [
+          Alcotest.test_case
+            "max_execution_time increments counter"
+            `Quick
+            test_emit_increments_max_execution_time_counter;
+          Alcotest.test_case
+            "transport timeout increments provider counter"
+            `Quick
+            test_emit_increments_provider_counter_on_transport_timeout;
+          Alcotest.test_case
+            "NetworkError leaves counter untouched"
+            `Quick
+            test_emit_does_not_touch_counter_on_non_timeout;
         ] );
     ]


### PR DESCRIPTION
## Summary

Adds 5 unit tests for `Oas_worker_named_fsm.timeout_source_label` — the substring classifier introduced in PR #13941 — plus the lib/dune sync that was missing from that PR.

## Why

PR #13941 introduced `timeout_source_label` to attribute `Retry.Timeout` errors to the right root cause via a `source` label on `masc_keeper_oas_run_timeout_total`. The classifier relies on a literal substring match against agent_sdk's wrapper message at `agent_sdk/agent/agent.ml:255`:

> `"Agent execution exceeded max_execution_time_s (%f)"`

If that string changes upstream, the classifier **silently fails open** — every wrapper hit gets attributed to `source="provider"` and dashboards lose the ability to tell whether our `max_execution_time_s` wire is engaging. No crash, no error log, just bad data.

This PR adds a regression guard that fails loudly on substring drift.

## What changes

| File | Change |
|------|--------|
| `lib/dune` | Remove `oas_worker_named_fsm` from `private_modules`. The .mli was already authored as test-facing (the `emit_sdk_provider_error_metric` docstring says "callers/tests can assert the same decision"); the dune entry was an oversight from PR #13941. |
| `lib/oas_worker_named_fsm.mli` | Document `val timeout_source_label` (no new function — just exposes the existing implementation through the already-public mli). |
| `test/dune` | Include the new stanza. |
| `test/stanzas/test_oas_run_timeout_source_label.inc` | New stanza using `masc_test_deps`. |
| `test/test_oas_run_timeout_source_label.ml` | 5 test cases, ~110 LOC. |

Net diff: 5 files / +126 / -1.

## Tests

| Case | Input | Expected `source` |
|------|-------|-------------------|
| Exact wrapper message | `"Agent execution exceeded max_execution_time_s (300.000000)"` | `max_execution_time` |
| Uppercase substring | `"... AGENT EXECUTION EXCEEDED MAX_EXECUTION_TIME_S (45.0); cascade fallback engaged"` | `max_execution_time` (CI match) |
| Transport timeout | `"HTTP read deadline exceeded after 30 seconds"` | `provider` |
| Non-Timeout error | `Retry.NetworkError { kind = Dns_failure; ... }` | `provider` |
| Empty message | `""` (defensive) | `provider` |

```
$ dune build --root . test/test_oas_run_timeout_source_label.exe
$ ./_build/default/test/test_oas_run_timeout_source_label.exe
Testing `Oas_run_timeout_source_label'.
This run has ID `QAP80FWY'.

  [OK]          classification          0   exact wrapper message.
  [OK]          classification          1   uppercase substring.
  [OK]          classification          2   transport timeout.
  [OK]          classification          3   non-Timeout error.
  [OK]          classification          4   empty message defensive.

Test Successful in 0.001s. 5 tests run.
```

## Why widen `private_modules`

The existing `.mli` for `oas_worker_named_fsm` already exposes a test-facing surface — `emit_sdk_provider_error_metric`'s docstring explicitly anticipates "callers/tests can assert the same decision." Yet the module was in `private_modules`, blocking external test access. Either the docstring or the dune entry was wrong; this PR resolves the inconsistency in the docstring's favour. No new functions are made public — `timeout_source_label` is exposed via the **same already-public mli**, and external consumers have always seen the rest of the test-facing surface (just couldn't compile against it).

## Out of scope

- Tests for `emit_oas_run_timeout_metric` (the side-effect helper that calls `Prometheus.inc_counter`). That requires a Prometheus mock or test scope; deferred to a follow-up if needed.
- Tests for the wire path itself (`Builder.with_max_execution_time` + `?clock` plumbing from PR #13923) — that needs an Eio fixture with a slow mock provider; can land separately.

## Refs

- Goal: `oas-bridge-stabilization` Step 6 (regression hardening half).
- Companion: PR #13941 (MERGED) — introduced the classifier without tests.
- Plan: `~/me/planning/claude-plans/20m-me-workspace-yousleepwhen-masc-mcp-o-recursive-mountain.md`.

RFC-WAIVED: this PR touches `lib/dune`, `lib/oas_worker_named_fsm.mli` (mli surface widened, no contract change), `test/` (new test). No credential / identity / auth / sandbox / dashboard-credential / hooks / workflow paths.
