### PR TITLE
fix: treat zero latency as missing in cost aggregates

### DIFF
--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -844,7 +844,8 @@ let assemble_cost_event_payload
            @ float_field "hw_decode_tokens_per_second" tm.predicted_per_second
          | None -> [])
       @ float_field "peak_memory_gb" t.peak_memory_gb
-      @ [("request_latency_ms", `Int t.request_latency_ms)]
+      @ int_field "request_latency_ms"
+          (if t.request_latency_ms > 0 then Some t.request_latency_ms else None)
     | None -> []
   in
   let wall_tok_s_fields =

--- a/lib/model_inference_metrics.ml
+++ b/lib/model_inference_metrics.ml
@@ -174,6 +174,11 @@ let json_float_field_opt key (fields : (string * Yojson.Safe.t) list) =
   | Some (`Int n) -> Some (Float.of_int n)
   | _ -> None
 
+let json_positive_float_field_opt key fields =
+  match json_float_field_opt key fields with
+  | Some v when v > 0.0 -> Some v
+  | _ -> None
+
 let json_int_field_opt key (fields : (string * Yojson.Safe.t) list) =
   match List.assoc_opt key fields with
   | Some (`Int n) -> Some n
@@ -403,7 +408,9 @@ let parse_telemetry_entry (json : Yojson.Safe.t) ~since_unix : raw_entry option 
              | Some _ as v -> v
              | None -> read "peak_memory"
            in
-           let latency_ms = json_float_field_opt "request_latency_ms" tfields in
+           let latency_ms =
+             json_positive_float_field_opt "request_latency_ms" tfields
+           in
            let input_tokens_raw = json_int_field_opt "input_tokens" tfields in
            let output_tokens_raw = json_int_field_opt "output_tokens" tfields in
            let cache_read_tokens_raw =
@@ -573,7 +580,7 @@ let parse_cost_entry (json : Yojson.Safe.t) ~since_unix : raw_entry option =
                 in
                 let usage_untrusted = usage_trust_untrusted usage_trust in
                 let latency_ms =
-                  json_float_field_opt "request_latency_ms" fields
+                  json_positive_float_field_opt "request_latency_ms" fields
                 in
                 let tok_per_sec_raw =
                   match json_float_field_opt "tokens_per_second" fields with

--- a/test/test_keeper_hooks_oas_telemetry.ml
+++ b/test/test_keeper_hooks_oas_telemetry.ml
@@ -160,7 +160,9 @@ let test_emit_cost_event_uses_typed_provider_kind_for_bare_model () =
     ~telemetry ();
   let json = read_jsonl_line (Filename.concat root "costs.jsonl") in
   check string "provider from provider_kind" "kimi_cli"
-    (json |> member "provider" |> to_string)
+    (json |> member "provider" |> to_string);
+  check bool "zero latency is omitted" true
+    (match json |> member "request_latency_ms" with `Null -> true | _ -> false)
 
 let test_emit_cost_event_writes_wall_tok_s_without_provider_timings () =
   let root = temp_dir () in

--- a/test/test_model_inference_metrics.ml
+++ b/test/test_model_inference_metrics.ml
@@ -594,6 +594,35 @@ let test_costs_jsonl_backfills_wall_tok_per_sec () =
     check int "usage sample" 1 s.usage_sample_count;
     check int "telemetry sample" 1 s.telemetry_sample_count)
 
+let test_costs_jsonl_zero_latency_is_missing () =
+  let base = test_dir () in
+  Fun.protect ~finally:(fun () -> cleanup_dir base) (fun () ->
+    let ts = now_unix () in
+    write_costs base [
+      cost_entry ~model:"qwen3.6:27b-coding-nvfp4" ~ts
+        ~input_tokens:100 ~output_tokens:50 ~latency_ms:0 ();
+    ];
+    let agg = M.compute ~base_path:base ~window_minutes:60 in
+    let s = List.hd agg.models in
+    check int "one cost entry" 1 s.entry_count;
+    check (option (float 0.001)) "zero latency not averaged"
+      None s.avg_latency_ms;
+    check (option (float 0.001)) "zero latency not p50"
+      None s.p50_latency_ms;
+    check (option (float 0.001)) "zero latency does not derive tok/sec"
+      None s.avg_tok_per_sec;
+    check int "usage sample preserved" 1 s.usage_sample_count;
+    check int "telemetry sample absent" 0 s.telemetry_sample_count;
+    let recent = List.hd s.recent_entries in
+    check (option (float 0.001)) "recent latency unknown"
+      None recent.re_latency_ms;
+    let bucket_total =
+      List.fold_left
+        (fun acc (bucket : M.latency_bucket) -> acc + bucket.count)
+        0 agg.latency_buckets
+    in
+    check int "zero latency skipped from buckets" 0 bucket_total)
+
 let test_costs_jsonl_dedupes_matching_decision_sample () =
   let base = test_dir () in
   Fun.protect ~finally:(fun () -> cleanup_dir base) (fun () ->
@@ -1069,6 +1098,7 @@ let () =
       test_case "missing usage serializes unknowns" `Quick test_missing_usage_serializes_unknowns;
       test_case "coverage diagnostics survive aggregation" `Quick test_coverage_diagnostics_survive_aggregation;
       test_case "costs.jsonl backfills wall tok/sec" `Quick test_costs_jsonl_backfills_wall_tok_per_sec;
+      test_case "costs.jsonl zero latency stays missing" `Quick test_costs_jsonl_zero_latency_is_missing;
       test_case "costs.jsonl dedupes matching decision sample" `Quick test_costs_jsonl_dedupes_matching_decision_sample;
       test_case "cost latency json composes axes and percentiles" `Quick test_cost_latency_json_composes_axes_and_percentiles;
       test_case "cost latency json preserves missing latency nulls" `Quick test_cost_latency_json_preserves_missing_latency_as_null;


### PR DESCRIPTION
## What

- Stop writing `request_latency_ms` to keeper `costs.jsonl` when OAS telemetry only provides the SDK default/sentinel `0`.
- Treat legacy `request_latency_ms <= 0` rows as missing latency in `Model_inference_metrics` for decision telemetry and cost ledger rows.
- Keep positive latency rows unchanged, including wall-token/sec derivation from cost latency.
- Add focused tests for writer omission and aggregate behavior.

## Why

Phase 0.2 targets 0ms telemetry root causes. The Prometheus path already counts zero latency as a telemetry quality problem and floors histogram observations for continuity, but the JSONL/dashboard aggregate path still promoted `0` into measured latency. This removes that fake measurement while preserving the incident signal elsewhere.

## Validation

- `git diff --check origin/main...HEAD`
- `lockf -k -t 600 /tmp/me-dune-local.lock env MASC_DUNE_LOCK_HELD=1 MASC_SKIP_OPAM_LOCK=1 DUNE_JOBS=1 DUNE_CACHE=disabled scripts/dune-local.sh build test/test_keeper_hooks_oas_telemetry.exe test/test_model_inference_metrics.exe`
- `_build/default/test/test_keeper_hooks_oas_telemetry.exe` passed: 44 tests
- `_build/default/test/test_model_inference_metrics.exe` passed: 32 tests