### PR TITLE
fix(harness): allow keeper review phase resume

### DIFF
--- a/docs/KEEPER-DOCKER-PR-LIFECYCLE-REPROBE.md
+++ b/docs/KEEPER-DOCKER-PR-LIFECYCLE-REPROBE.md
@@ -73,6 +73,9 @@ PUBLIC repositories, `--allow-fork-pr-for-readonly` permits `READ`/`TRIAGE`
 credential lanes to push their proof branch to the keeper account's fork and
 open the draft PR with `head=OWNER:BRANCH`; PR creation still goes through
 `keeper_pr_create`, not raw `gh pr create`.
+The review phase also resolves fork-created target PRs with the same
+owner-qualified `OWNER:BRANCH` head ref so reviewers do not miss valid fork PRs
+by looking up only the bare branch name.
 After collision evidence is clear, the review phase requires `keeper_pr_review_comment`.
 This avoids the old single-turn shape where one keeper could wait on another
 keeper's missing PR until the Agent.run timeout. The review prompt reserves

--- a/docs/KEEPER-DOCKER-PR-LIFECYCLE-REPROBE.md
+++ b/docs/KEEPER-DOCKER-PR-LIFECYCLE-REPROBE.md
@@ -129,6 +129,14 @@ Useful scoped runs:
   --mutate \
   --keeper-names sangsu,executor,verifier \
   --max-keepers 3
+
+./scripts/harness_keeper_docker_pr_lifecycle_reprobe.sh \
+  --mutate \
+  --phase review \
+  --review-resume \
+  --keeper-names sangsu,verifier \
+  --run-id keeper-docker-pr-lifecycle-fork-live-20260507-remat \
+  --run-dir /private/tmp/keeper-docker-pr-lifecycle-fork-live-20260507-remat
 ```
 
 The prompt requires keepers to stay on draft proof PRs:
@@ -145,3 +153,9 @@ operator evidence, but it is not completion unless the Docker lifecycle audit
 also passes for the expected fleet. The reprobe audit is run-id scoped, so stale
 PR lifecycle evidence from earlier keeper proof runs cannot satisfy a fresh
 run.
+
+Use `--phase review --review-resume` only after create proof PRs already exist
+for the run id and should be reviewed without creating another proof branch.
+The resume path intentionally still resolves target PRs keeper-side; if a target
+PR was closed or never existed, the review phase must report a blocker instead
+of manufacturing approve evidence.

--- a/docs/KEEPER-DOCKER-PR-LIFECYCLE-REPROBE.md
+++ b/docs/KEEPER-DOCKER-PR-LIFECYCLE-REPROBE.md
@@ -76,13 +76,14 @@ open the draft PR with `head=OWNER:BRANCH`; PR creation still goes through
 The review phase also resolves fork-created target PRs with the same
 owner-qualified `OWNER:BRANCH` head ref so reviewers do not miss valid fork PRs
 by looking up only the bare branch name.
-After collision evidence is clear, the review phase requires `keeper_pr_review_comment`.
+After collision evidence is clear, the review phase requires `keeper_shell` and
+`keeper_pr_review_comment`, in that order. The first required tool allows the
+prompted read-only PR lookup to satisfy the provider's first-tool contract; the
+second required tool keeps approval mandatory.
 This avoids the old single-turn shape where one keeper could wait on another
 keeper's missing PR until the Agent.run timeout. The review prompt reserves
-`keeper_shell` for read-only GitHub inspection, but does not put it in
-`required_tools` because passive read-only tools cannot satisfy the runtime
-required-tool predicate. Keepers are instructed to report `target_pr_missing`
-after one failed branch lookup instead of polling in a loop.
+`keeper_shell` for read-only GitHub inspection. Keepers are instructed to report
+`target_pr_missing` after one failed branch lookup instead of polling in a loop.
 Keepers must create/use the exact run-scoped branch produced by
 `masc_worktree_create task_id=<run_id>`:
 `keeper-<keeper>-agent/<run_id>`. They must write the proof file

--- a/scripts/harness/workload/keeper_docker_pr_lifecycle_reprobe.sh
+++ b/scripts/harness/workload/keeper_docker_pr_lifecycle_reprobe.sh
@@ -39,6 +39,8 @@ INIT_TIMEOUT_SEC="${INIT_TIMEOUT_SEC:-60}"
 POLL_TIMEOUT_SEC="${POLL_TIMEOUT_SEC:-1200}"
 POLL_INTERVAL_SEC="${POLL_INTERVAL_SEC:-10}"
 LIFECYCLE_MUTATION_MODE="split"
+PHASE_MODE="${PHASE_MODE:-both}"
+REVIEW_RESUME="${REVIEW_RESUME:-0}"
 REQUIRED_TOOLS_LEGACY="${REQUIRED_TOOLS:-}"
 CREATE_REQUIRED_TOOLS="${CREATE_REQUIRED_TOOLS:-${REQUIRED_TOOLS_LEGACY:-masc_web_search,keeper_bash,keeper_pr_create}}"
 REVIEW_REQUIRED_TOOLS="${REVIEW_REQUIRED_TOOLS:-${REQUIRED_TOOLS_LEGACY:-keeper_pr_review_comment}}"
@@ -89,6 +91,11 @@ Options:
   --board-post-id ID       Post a final board comment to this thread.
   --run-id ID              Stable run id for prompts and artifacts.
   --run-dir PATH           Artifact directory.
+  --phase create|review|both
+                           Which lifecycle phase to mutate (default: both).
+  --review-resume          With --phase review, send review prompts even when
+                           create result readiness is incomplete. Keeper-side
+                           target PR resolution still decides success/failure.
   -h, --help               Show this help.
 
 Environment:
@@ -102,6 +109,9 @@ Environment:
   CREATE_REQUIRED_TOOLS    CSV required_tools for split create phase.
   REVIEW_REQUIRED_TOOLS    CSV required_tools for split review phase.
   RUN_AUDIT=0              Skip final audit.
+  PHASE_MODE=create|review|both
+                           Same as --phase.
+  REVIEW_RESUME=1          Same as --review-resume.
   EXPECTED_SERVER_COMMIT   Optional expected /health build.commit prefix.
   FORBID_GITHUB_IDENTITIES Optional CSV of forbidden keeper GitHub identities.
   ALLOW_FORK_PR_FOR_READONLY=1
@@ -200,6 +210,14 @@ while [[ $# -gt 0 ]]; do
       SUMMARY_FILE="$RUN_DIR/summary.json"
       AUDIT_FILE="$RUN_DIR/audit-docker-pr-lifecycle.json"
       shift 2
+      ;;
+    --phase)
+      PHASE_MODE="$2"
+      shift 2
+      ;;
+    --review-resume)
+      REVIEW_RESUME=1
+      shift
       ;;
     -h|--help)
       usage
@@ -1620,6 +1638,14 @@ require_cmd curl
 # the run with a less obvious git-not-found error.
 require_cmd git
 
+case "$PHASE_MODE" in
+  create|review|both) ;;
+  *)
+    echo "invalid --phase: $PHASE_MODE (expected create, review, or both)" >&2
+    exit 2
+    ;;
+esac
+
 if [[ "$MUTATE" == "1" || -n "$EXPECTED_SERVER_COMMIT" ]]; then
   assert_expected_server_commit
 fi
@@ -1628,7 +1654,9 @@ discover_keepers
 assert_github_identity_pool_for_mutate
 build_review_targets
 render_prompts
-assert_no_proof_branch_collisions_for_mutate
+if [[ "$PHASE_MODE" != "review" ]]; then
+  assert_no_proof_branch_collisions_for_mutate
+fi
 
 if [[ "$MUTATE" == "1" ]]; then
   # Share one POLL_TIMEOUT_SEC budget across both phases so the overall
@@ -1636,14 +1664,30 @@ if [[ "$MUTATE" == "1" ]]; then
   # silently doubling when create + review each compute their own
   # deadline (PR #13842 review).
   export MUTATE_POLL_DEADLINE_TS=$(( $(date +%s) + POLL_TIMEOUT_SEC ))
-  send_phase_prompts "create" "$CREATE_REQUIRED_TOOLS"
-  poll_results "create"
-  if all_create_results_ready_for_review; then
-    send_phase_prompts "review" "$REVIEW_REQUIRED_TOOLS"
-    poll_results "review"
-  else
-    log "skipping review phase because create phase did not produce complete success evidence"
-  fi
+  case "$PHASE_MODE" in
+    create)
+      send_phase_prompts "create" "$CREATE_REQUIRED_TOOLS"
+      poll_results "create"
+      ;;
+    review)
+      if [[ "$REVIEW_RESUME" == "1" ]] || all_create_results_ready_for_review; then
+        send_phase_prompts "review" "$REVIEW_REQUIRED_TOOLS"
+        poll_results "review"
+      else
+        log "skipping review phase because create phase did not produce complete success evidence"
+      fi
+      ;;
+    both)
+      send_phase_prompts "create" "$CREATE_REQUIRED_TOOLS"
+      poll_results "create"
+      if all_create_results_ready_for_review; then
+        send_phase_prompts "review" "$REVIEW_REQUIRED_TOOLS"
+        poll_results "review"
+      else
+        log "skipping review phase because create phase did not produce complete success evidence"
+      fi
+      ;;
+  esac
   unset MUTATE_POLL_DEADLINE_TS
 else
   log "dry-run mode: prompts rendered under $PROMPT_DIR; no keeper messages sent"

--- a/scripts/harness/workload/keeper_docker_pr_lifecycle_reprobe.sh
+++ b/scripts/harness/workload/keeper_docker_pr_lifecycle_reprobe.sh
@@ -43,7 +43,7 @@ PHASE_MODE="${PHASE_MODE:-both}"
 REVIEW_RESUME="${REVIEW_RESUME:-0}"
 REQUIRED_TOOLS_LEGACY="${REQUIRED_TOOLS:-}"
 CREATE_REQUIRED_TOOLS="${CREATE_REQUIRED_TOOLS:-${REQUIRED_TOOLS_LEGACY:-masc_web_search,keeper_bash,keeper_pr_create}}"
-REVIEW_REQUIRED_TOOLS="${REVIEW_REQUIRED_TOOLS:-${REQUIRED_TOOLS_LEGACY:-keeper_pr_review_comment}}"
+REVIEW_REQUIRED_TOOLS="${REVIEW_REQUIRED_TOOLS:-${REQUIRED_TOOLS_LEGACY:-keeper_shell,keeper_pr_review_comment}}"
 MCP_URL="${MCP_URL:-http://127.0.0.1:8935/mcp}"
 MCP_TOKEN="${MASC_MCP_TOKEN:-}"
 MCP_CLIENT_NAME="${MCP_CLIENT_NAME:-keeper-docker-pr-lifecycle-reprobe}"
@@ -1309,9 +1309,9 @@ Safety rules:
 - If a tool is missing or policy-blocked, stop and reply with blocker plus exact structured tool output.
 
 This prompt is sent with review-phase masc_keeper_msg.required_tools so the
-runtime records tool_surface_mismatch or missing_required_tool_use when
-keeper_pr_review_comment is not visible or not used. keeper_shell is read-only
-inspection and intentionally not part of the required-tool contract.
+runtime records tool_surface_mismatch or missing_required_tool_use when the
+read-only keeper_shell lookup or keeper_pr_review_comment approval is not
+visible or not used.
 EOF
 }
 

--- a/scripts/harness/workload/keeper_docker_pr_lifecycle_reprobe.sh
+++ b/scripts/harness/workload/keeper_docker_pr_lifecycle_reprobe.sh
@@ -1008,6 +1008,20 @@ proof_branch_for_keeper() {
   printf 'keeper-%s-agent/%s' "$keeper" "$RUN_ID"
 }
 
+proof_head_ref_for_keeper() {
+  local keeper="$1"
+  local branch account
+  branch="$(proof_branch_for_keeper "$keeper")"
+  if keeper_uses_fork_pr_route "$keeper"; then
+    account="$(github_account_for_keeper "$keeper")"
+    if [[ -n "$account" ]]; then
+      printf '%s:%s' "$account" "$branch"
+      return 0
+    fi
+  fi
+  printf '%s' "$branch"
+}
+
 github_account_for_keeper() {
   local keeper="$1"
   jq -r --arg keeper "$keeper" '.keeper_accounts[$keeper] // empty' "$GITHUB_IDENTITY_COUNTS_FILE"
@@ -1226,23 +1240,28 @@ prompt_for_keeper_review() {
   local keeper="$1"
   local review_target="${2:-}"
   local review_branch=""
+  local review_head_ref=""
   local review_target_json="null"
   local review_branch_json="null"
+  local review_head_ref_json="null"
   local review_instruction=""
   if [[ -n "$review_target" ]]; then
     review_branch="$(proof_branch_for_keeper "$review_target")"
+    review_head_ref="$(proof_head_ref_for_keeper "$review_target")"
     review_target_json="\"$review_target\""
     review_branch_json="\"$review_branch\""
+    review_head_ref_json="\"$review_head_ref\""
     review_instruction="$(cat <<EOF
 Cross-keeper approval target:
-- You must review and APPROVE the draft PR whose head branch is: $review_branch
+- You must review and APPROVE the draft PR whose head ref is: $review_head_ref
+- Bare target branch: $review_branch
 - This target belongs to keeper: $review_target
 - Do not approve your own PR or your own branch.
 - First use keeper_shell once to resolve the target PR number:
-  gh pr view $review_branch -R $REPO_SLUG --json number,url,isDraft,headRefName
+  gh pr view $review_head_ref -R $REPO_SLUG --json number,url,isDraft,headRefName
 - If that command reports no PR or cannot resolve the branch, do not wait in a loop. Reply with blocker="target_pr_missing" and the exact tool output.
 - If GitHub reports the target PR has the same author identity as your current credential and rejects approval as self-approval, stop and report blocker="github_self_approve_policy" with the exact tool output.
-- Once the PR number is known, call keeper_pr_review_comment with event="APPROVE" and a body that includes run_id=$RUN_ID, reviewer=$keeper, and target_branch=$review_branch.
+- Once the PR number is known, call keeper_pr_review_comment with event="APPROVE" and a body that includes run_id=$RUN_ID, reviewer=$keeper, target_branch=$review_branch, and target_head=$review_head_ref.
 EOF
 )"
   else
@@ -1278,6 +1297,7 @@ Reply with one compact JSON object:
      "keeper": "$keeper",
      "review_target_keeper": $review_target_json,
      "review_target_branch": $review_branch_json,
+     "review_target_head": $review_head_ref_json,
      "approved_pr_url": "...",
      "docker_pr_approve": true,
      "blocker": null
@@ -1308,7 +1328,12 @@ send_phase_prompts() {
   local required_tools_csv="$2"
   while IFS= read -r keeper; do
     [[ -n "$keeper" ]] || continue
-    local prompt args payload text request_id
+    local prompt args payload text request_id review_target review_target_head
+    review_target="$(review_target_for_keeper "$keeper")"
+    review_target_head=""
+    if [[ -n "$review_target" ]]; then
+      review_target_head="$(proof_head_ref_for_keeper "$review_target")"
+    fi
     prompt="$(cat "$PROMPT_DIR/$keeper-$phase.txt")"
     args="$(
       jq -cn \
@@ -1345,8 +1370,9 @@ send_phase_prompts() {
       --arg phase "$phase" \
       --arg request_id "$request_id" \
       --arg prompt_file "$PROMPT_DIR/$keeper-$phase.txt" \
-      --arg review_target "$(review_target_for_keeper "$keeper")" \
-      '{keeper:$keeper, phase:$phase, request_id:$request_id, prompt_file:$prompt_file, review_target:$review_target, status:"pending"}' \
+      --arg review_target "$review_target" \
+      --arg review_target_head "$review_target_head" \
+      '{keeper:$keeper, phase:$phase, request_id:$request_id, prompt_file:$prompt_file, review_target:$review_target, review_target_head:$review_target_head, status:"pending"}' \
       >>"$REQUESTS_FILE"
   done <"$RUN_DIR/keepers.txt"
 }

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -1220,6 +1220,18 @@ let test_keeper_required_tool_contracts () =
           {|if [[ "$REVIEW_RESUME" == "1" ]] || all_create_results_ready_for_review; then|}
      && file_contains_pattern "docs/KEEPER-DOCKER-PR-LIFECYCLE-REPROBE.md"
           "`--phase review --review-resume`");
+  check bool "docker PR lifecycle review resolves fork head refs" true
+    (file_contains_pattern
+       "scripts/harness/workload/keeper_docker_pr_lifecycle_reprobe.sh"
+       "proof_head_ref_for_keeper"
+     && file_contains_pattern
+          "scripts/harness/workload/keeper_docker_pr_lifecycle_reprobe.sh"
+          {|gh pr view $review_head_ref -R $REPO_SLUG --json number,url,isDraft,headRefName|}
+     && file_contains_pattern
+          "scripts/harness/workload/keeper_docker_pr_lifecycle_reprobe.sh"
+          "review_target_head"
+     && file_contains_pattern "docs/KEEPER-DOCKER-PR-LIFECYCLE-REPROBE.md"
+          "owner-qualified `OWNER:BRANCH` head ref");
   check bool "keeper msg schema documents required_tool_names alias" true
     (file_contains_pattern "lib/keeper/keeper_schema.ml"
        "required_tool_names")

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -1205,6 +1205,21 @@ let test_keeper_required_tool_contracts () =
           "skipping review phase because create phase did not produce complete success evidence"
      && file_contains_pattern "docs/KEEPER-DOCKER-PR-LIFECYCLE-REPROBE.md"
           "`create-readiness-failures.jsonl`");
+  check bool "docker PR lifecycle supports review-only resume" true
+    (file_contains_pattern
+       "scripts/harness/workload/keeper_docker_pr_lifecycle_reprobe.sh"
+       {|PHASE_MODE="${PHASE_MODE:-both}"|}
+     && file_contains_pattern
+          "scripts/harness/workload/keeper_docker_pr_lifecycle_reprobe.sh"
+          {|--phase create|review|both|}
+     && file_contains_pattern
+          "scripts/harness/workload/keeper_docker_pr_lifecycle_reprobe.sh"
+          {|--review-resume|}
+     && file_contains_pattern
+          "scripts/harness/workload/keeper_docker_pr_lifecycle_reprobe.sh"
+          {|if [[ "$REVIEW_RESUME" == "1" ]] || all_create_results_ready_for_review; then|}
+     && file_contains_pattern "docs/KEEPER-DOCKER-PR-LIFECYCLE-REPROBE.md"
+          "`--phase review --review-resume`");
   check bool "keeper msg schema documents required_tool_names alias" true
     (file_contains_pattern "lib/keeper/keeper_schema.ml"
        "required_tool_names")

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -1164,14 +1164,16 @@ let test_keeper_required_tool_contracts () =
           {|CREATE_REQUIRED_TOOLS="${CREATE_REQUIRED_TOOLS:-${REQUIRED_TOOLS_LEGACY:-masc_web_search,keeper_bash,keeper_pr_create}}"|}
      && file_contains_pattern
           "scripts/harness/workload/keeper_docker_pr_lifecycle_reprobe.sh"
-          {|REVIEW_REQUIRED_TOOLS="${REVIEW_REQUIRED_TOOLS:-${REQUIRED_TOOLS_LEGACY:-keeper_pr_review_comment}}"|});
+          {|REVIEW_REQUIRED_TOOLS="${REVIEW_REQUIRED_TOOLS:-${REQUIRED_TOOLS_LEGACY:-keeper_shell,keeper_pr_review_comment}}"|});
   check bool "runbook documents docker PR lifecycle split phases" true
     (file_contains_pattern "docs/KEEPER-DOCKER-PR-LIFECYCLE-REPROBE.md"
        "The create phase"
      && file_contains_pattern "docs/KEEPER-DOCKER-PR-LIFECYCLE-REPROBE.md"
           "requires `masc_web_search`, `keeper_bash`, and `keeper_pr_create`"
      && file_contains_pattern "docs/KEEPER-DOCKER-PR-LIFECYCLE-REPROBE.md"
-          "the review phase requires `keeper_pr_review_comment`");
+          "the review phase requires `keeper_shell` and"
+     && file_contains_pattern "docs/KEEPER-DOCKER-PR-LIFECYCLE-REPROBE.md"
+          "second required tool keeps approval mandatory");
   check bool "docker PR lifecycle prompt accepts brokered route proof" true
     (file_contains_pattern
        "scripts/harness/workload/keeper_docker_pr_lifecycle_reprobe.sh"


### PR DESCRIPTION
## Summary

- add `--phase create|review|both` to the Docker PR lifecycle reprobe harness
- add `--review-resume` so an operator can rerun only the review/approve phase after create proof PRs already exist
- resolve fork proof PR review targets as `OWNER:BRANCH`, so `gh pr view` works for cross-account read-only heads
- require a review lookup before approve by allowing `keeper_shell,keeper_pr_review_comment` in the review phase
- keep current main create-phase evidence requirements, including `masc_web_search,keeper_bash,keeper_pr_create`
- skip stale proof branch collision preflight for review-only runs, since review resume should not create or push proof branches
- document the review resume command and pin source-contract coverage for the new path

## Why

The live approve resume for #13920 showed a real operational gap: `sangsu` and `verifier` had Docker-backed push/create evidence, but review/approve evidence was missing. The original split harness can skip review when create polling times out, and there was no supported way to send only the review prompts later without creating another proof branch.

Two follow-up blockers were found while reproving the path:

- fork proof PRs need an explicit `OWNER:BRANCH` head ref for GitHub lookup from the reviewer container;
- review prompts must be allowed to inspect the PR with `keeper_shell` before calling `keeper_pr_review_comment`, otherwise provider tool-choice ordering can reject a valid lookup-first review.

This PR fixes the harness/resume path. It does not by itself prove the full 14+ keeper fleet objective; it makes the pair-level review/approve blocker reproducible and recoverable.

## Rebase note

Rebased onto current `origin/main` (`f34a94b61b`) and resolved the required-tools conflict by preserving both current main create-phase `masc_web_search` evidence and this PRs review-phase `keeper_shell` lookup requirement.

## Operator Impact

After a create phase has produced proof PRs, operators can run:

```sh
scripts/harness_keeper_docker_pr_lifecycle_reprobe.sh \
  --mutate \
  --phase review \
  --review-resume \
  --keeper-names sangsu,verifier \
  --repo jeong-sik/masc-mcp \
  --run-id keeper-docker-pr-lifecycle-fork-live-20260507-remat \
  --run-dir /private/tmp/keeper-docker-pr-lifecycle-fork-live-20260507-remat
```

The review phase now passes both `review_target_head` and `review_required_tools=keeper_shell,keeper_pr_review_comment` into the prompt. If the target PR is closed or missing, the keeper must report a blocker rather than fabricating approve evidence.

## Validation

- `git diff --check`
- `git diff --check origin/main...HEAD`
- `bash -n scripts/harness/workload/keeper_docker_pr_lifecycle_reprobe.sh`
- `ocamlc -stop-after parsing test/test_ci_hardening_source.ml`
- `scripts/dune-local.sh build test/test_ci_hardening_source.exe`
- `./_build/default/test/test_ci_hardening_source.exe` (55 tests)
- `scripts/check-oas-pin.sh --local-only`

Earlier proof evidence retained from this branch:
- `RUN_AUDIT=0 scripts/harness_keeper_docker_pr_lifecycle_reprobe.sh --dry-run --phase review --review-resume --keeper-names sangsu,verifier --base-path /private/tmp/masc-integration-8975-base-20260507-0419 --mcp-url http://127.0.0.1:8975/mcp --server-health-url http://127.0.0.1:8975/health --expected-server-commit 4dd43bad5a --allow-fork-pr-for-readonly --run-id keeper-docker-pr-lifecycle-fork-live-20260507-remat --run-dir /private/tmp/keeper-docker-pr-lifecycle-fork-live-20260507-remat-toolsverify`
- isolated patched runtime proof: `/private/tmp/keeper-docker-pr-lifecycle-fork-live-20260507-remat-stackverify2` produced `status=done` approve evidence for both `sangsu` and `verifier`
- GitHub live verification: PR #13929 latest review `APPROVED` by `anyang-keepers`; PR #13926 latest review `APPROVED` by `yousleepwhen`

Draft remains intentional until the dependent keeper lifecycle fixes/proofs are ready to land together.
