### PR TITLE
fix(keeper): harden tool hooks and exec cache

### DIFF
--- a/lib/keeper/keeper_exec_tools.ml
+++ b/lib/keeper/keeper_exec_tools.ml
@@ -16,16 +16,44 @@ let has_mutating_side_effect_with_input ~(tool_name : string)
     ~(input : Yojson.Safe.t) : bool =
   not (Keeper_tool_registry.is_read_only_with_input ~tool_name ~input)
 
-let on_keeper_tool_call
-  : (tool_name:string -> success:bool -> duration_ms:int -> unit) ref
-  =
-  ref (fun ~tool_name:_ ~success:_ ~duration_ms:_ -> ())
+type keeper_tool_call_recorder =
+  tool_name:string -> success:bool -> duration_ms:int -> unit
 
-let tool_search_fn
-  : (query:string -> max_results:int -> Yojson.Safe.t) ref
-  =
-  ref (fun ~query:_ ~max_results:_ ->
-    `Assoc [ ("results", `List []) ])
+let default_keeper_tool_call_recorder
+    ~tool_name:_ ~success:_ ~duration_ms:_ =
+  ()
+
+let keeper_tool_call_recorder_mutex = Stdlib.Mutex.create ()
+let keeper_tool_call_recorder = ref default_keeper_tool_call_recorder
+
+let set_on_keeper_tool_call (f : keeper_tool_call_recorder) =
+  Stdlib.Mutex.protect keeper_tool_call_recorder_mutex (fun () ->
+    keeper_tool_call_recorder := f)
+
+let record_keeper_tool_call ~tool_name ~success ~duration_ms =
+  let f =
+    Stdlib.Mutex.protect keeper_tool_call_recorder_mutex (fun () ->
+      !keeper_tool_call_recorder)
+  in
+  f ~tool_name ~success ~duration_ms
+
+type tool_searcher = query:string -> max_results:int -> Yojson.Safe.t
+
+let default_tool_searcher ~query:_ ~max_results:_ =
+  `Assoc [ ("results", `List []) ]
+
+let tool_searcher_mutex = Stdlib.Mutex.create ()
+let tool_searcher = ref default_tool_searcher
+
+let set_tool_search_fn (f : tool_searcher) =
+  Stdlib.Mutex.protect tool_searcher_mutex (fun () ->
+    tool_searcher := f)
+
+let search_tools ~query ~max_results =
+  let f =
+    Stdlib.Mutex.protect tool_searcher_mutex (fun () -> !tool_searcher)
+  in
+  f ~query ~max_results
 
 type tool_result_payload =
   | Structured_success
@@ -217,7 +245,7 @@ let execute_keeper_tool_call_with_outcome
       else
         let fn = match search_fn with
           | Some f -> f
-          | None -> !tool_search_fn
+          | None -> search_tools
         in
         success_tool_result (Yojson.Safe.to_string (fn ~query ~max_results))
     | "keeper_stay_silent" ->

--- a/lib/keeper/keeper_exec_tools.mli
+++ b/lib/keeper/keeper_exec_tools.mli
@@ -96,16 +96,27 @@ val init_policy_config : base_path:string -> (unit, string) result
     and blocked at execution time by the pre_tool_use hook. *)
 val is_keeper_denied : string -> bool
 
-(** Callback for recording keeper-internal tool calls.
-    Set at server initialization to avoid Config dependency cycle. *)
-val on_keeper_tool_call :
-  (tool_name:string -> success:bool -> duration_ms:int -> unit) ref
+type keeper_tool_call_recorder =
+  tool_name:string -> success:bool -> duration_ms:int -> unit
 
-(** Callback for keeper_tool_search BM25 search.
-    Process-global fallback; prefer passing [~search_fn] to
-    [execute_keeper_tool_call] for session-scoped, race-free search. *)
-val tool_search_fn :
-  (query:string -> max_results:int -> Yojson.Safe.t) ref
+(** Set the keeper-internal tool-call recorder.
+    The setter is process-global because server initialization wires around
+    the Config dependency cycle; calls are mutex-protected so runtime readers
+    do not dereference a publicly mutable ref. *)
+val set_on_keeper_tool_call : keeper_tool_call_recorder -> unit
+
+(** Record a keeper-internal tool call through the configured recorder. *)
+val record_keeper_tool_call : keeper_tool_call_recorder
+
+type tool_searcher = query:string -> max_results:int -> Yojson.Safe.t
+
+(** Set the fallback BM25 searcher for [keeper_tool_search].
+    Prefer passing [~search_fn] to [execute_keeper_tool_call] for
+    session-scoped search. *)
+val set_tool_search_fn : tool_searcher -> unit
+
+(** Invoke the fallback BM25 searcher for [keeper_tool_search]. *)
+val search_tools : tool_searcher
 
 (** Classification of a keeper tool result payload for circuit-breaker
     bookkeeping.

--- a/lib/keeper/keeper_shell_bash.ml
+++ b/lib/keeper/keeper_shell_bash.ml
@@ -273,6 +273,83 @@ let handle_keeper_bash
       | Eio.Cancel.Cancelled _ as e -> raise e
       | _ -> None
     in
+    let cached_result_json
+          (entry : Masc_exec.Exec_cache.cache_entry) =
+      let st = Unix.WEXITED entry.exit_code in
+      Yojson.Safe.to_string
+        (Exec_core.process_result_json
+           ~base_path:root
+           ~keeper_name:meta.name
+           ~cmd
+           ~extra:[
+             "cwd", `String cwd;
+             "execution_time_ms", `Int entry.duration_ms;
+             "cached", `Bool true;
+             "cache_age_ms",
+               `Int
+                 (int_of_float
+                    ((Unix.time () -. entry.cached_at) *. 1000.));
+           ]
+           ~status:st
+           ~output:entry.output
+           ~env_snapshot:env_snap
+           ())
+    in
+    let cached_raw_result_json
+          (entry : Masc_exec.Exec_cache.cache_entry) =
+      match
+        Safe_ops.parse_json_safe
+          ~context:"Keeper_shell_bash.cached_raw_result_json"
+          entry.output
+      with
+      | Ok (`Assoc fields) ->
+        let fields =
+          fields
+          |> List.remove_assoc "cached"
+          |> List.remove_assoc "cache_age_ms"
+          |> List.remove_assoc "execution_time_ms"
+        in
+        Yojson.Safe.to_string
+          (`Assoc
+            (fields @ [
+               "cached", `Bool true;
+               "cache_age_ms",
+                 `Int
+                   (int_of_float
+                      ((Unix.time () -. entry.cached_at) *. 1000.));
+               "execution_time_ms", `Int entry.duration_ms;
+             ]))
+      | Ok _ | Error _ -> cached_result_json entry
+    in
+    let with_raw_json_exec_cache run =
+      let cacheable =
+        Masc_exec.Risk_classifier.(is_cacheable (classify cmd))
+      in
+      if not cacheable then run ()
+      else
+        match exec_cache with
+        | None -> run ()
+        | Some cache ->
+          (match Masc_exec.Exec_cache.lookup cache cmd with
+           | Some entry -> cached_raw_result_json entry
+           | None ->
+             let t0 = Unix.gettimeofday () in
+             let raw = run () in
+             let elapsed_ms =
+               elapsed_duration_ms
+                 ~start_time:t0 ~end_time:(Unix.gettimeofday ())
+             in
+             (match
+                Safe_ops.parse_json_safe
+                  ~context:"Keeper_shell_bash.with_raw_json_exec_cache"
+                  raw
+              with
+              | Ok json when Safe_ops.json_bool ~default:false "ok" json ->
+                Masc_exec.Exec_cache.store cache
+                  ~cmd ~exit_code:0 ~output:raw ~duration_ms:elapsed_ms
+              | Ok _ | Error _ -> ());
+             raw)
+    in
     let normalize_path_for_containment path =
       Keeper_alerting_path.normalize_path_for_check path
       |> Keeper_alerting_path.strip_trailing_slashes
@@ -493,12 +570,13 @@ let handle_keeper_bash
       Log.Keeper.info
         "DOCKER_EXEC: keeper=%s cwd=%s cmd=%s network=%s"
         meta.name cwd cmd_for_log (network_mode_to_string sandbox_network_mode);
-      Keeper_shell_shared.run_docker_hardened_bash
-        ~turn_sandbox_runtime:
-          (Keeper_sandbox_factory.resolve_opt
-             turn_sandbox_factory ~cwd)
-        ~config ~meta ~cwd ~timeout_sec ~cmd
-        ~network_mode:sandbox_network_mode)
+      with_raw_json_exec_cache (fun () ->
+        Keeper_shell_shared.run_docker_hardened_bash
+          ~turn_sandbox_runtime:
+            (Keeper_sandbox_factory.resolve_opt
+               turn_sandbox_factory ~cwd)
+          ~config ~meta ~cwd ~timeout_sec ~cmd
+          ~network_mode:sandbox_network_mode))
     else
       let local_reason =
         if Env_config_keeper.KeeperSandbox.hard_mode () then "hard_mode_local"
@@ -676,24 +754,7 @@ let handle_keeper_bash
                     | Some cache ->
                       (match Masc_exec.Exec_cache.lookup cache cmd with
                        | Some entry ->
-                         let st = Unix.WEXITED entry.exit_code in
-                         Yojson.Safe.to_string
-                           (Exec_core.process_result_json
-                              ~base_path:root
-                              ~keeper_name:meta.name
-                              ~cmd
-                              ~extra:[
-                                "cwd", `String cwd;
-                                "execution_time_ms", `Int entry.duration_ms;
-                                "cached", `Bool true;
-                                "cache_age_ms",
-                                  `Int (int_of_float
-                                          ((Unix.time () -. entry.cached_at) *. 1000.));
-                              ]
-                              ~status:st
-                              ~output:entry.output
-                              ~env_snapshot:env_snap
-                              ())
+                         cached_result_json entry
                        | None ->
                          let t0 = Unix.gettimeofday () in
                          let st, out =
@@ -782,101 +843,109 @@ let handle_keeper_bash
                         ~env_snapshot:env_snap
                         ()))
                  | Some clock ->
-                   let budget_ms = Masc_exec.Exec_run.default_budget_ms () in
-                   let t0_bg = Unix.gettimeofday () in
-                   let outcome =
-                     Masc_exec.Exec_run.run_with_auto_bg
-                       ~clock
-                       ~base_path:root
-                       ~budget_ms
-                       ~keeper:meta.name
-                       ~argv:argv_merged
-                       ~cwd
-                       ~envp:(Unix.environment ())
-                       ~timeout_sec
-                       ()
+                   let run_uncached () =
+                     let budget_ms = Masc_exec.Exec_run.default_budget_ms () in
+                     let t0_bg = Unix.gettimeofday () in
+                     let outcome =
+                       Masc_exec.Exec_run.run_with_auto_bg
+                         ~clock
+                         ~base_path:root
+                         ~budget_ms
+                         ~keeper:meta.name
+                         ~argv:argv_merged
+                         ~cwd
+                         ~envp:(Unix.environment ())
+                         ~timeout_sec
+                         ()
+                     in
+                     (match outcome with
+                      | Masc_exec.Exec_run.Completed r ->
+                        let elapsed_ms =
+                          elapsed_duration_ms
+                            ~start_time:t0_bg ~end_time:(Unix.gettimeofday ())
+                        in
+                        (* P21: store in exec cache if not a timeout *)
+                        if not (Keeper_shell_shared.process_status_is_timeout r.status) then
+                          (match exec_cache with
+                           | Some cache ->
+                             let exit_code = match r.status with
+                               | Unix.WEXITED n -> n
+                               | Unix.WSIGNALED n -> 128 + n
+                               | Unix.WSTOPPED n -> 256 + n
+                             in
+                             Masc_exec.Exec_cache.store cache
+                               ~cmd ~exit_code ~output:r.stdout ~duration_ms:elapsed_ms
+                           | None -> ());
+                        Yojson.Safe.to_string
+                          (Exec_core.process_result_json
+                             ~base_path:root
+                             ~keeper_name:meta.name
+                             ~cmd
+                             ~extra:[
+                               "cwd", `String cwd;
+                               "execution_time_ms", `Int elapsed_ms;
+                             ]
+                             ~status:r.status
+                             ~output:r.stdout
+                             ~env_snapshot:env_snap
+                             ())
+                      | Masc_exec.Exec_run.Promoted p ->
+                        let elapsed_ms =
+                          elapsed_duration_ms
+                            ~start_time:t0_bg ~end_time:(Unix.gettimeofday ())
+                        in
+                        Log.Keeper.info
+                          "BG_PROMOTE: keeper=%s task_id=%s budget_ms=%d cmd=%s"
+                          meta.name
+                          (Bg_task.task_id_to_string p.task_id)
+                          budget_ms
+                          cmd_for_log;
+                        Yojson.Safe.to_string
+                          (`Assoc
+                            [
+                              ("ok", `Bool false);
+                              ("promoted", `Bool true);
+                              ( "background_task_id",
+                                `String
+                                  (Bg_task.task_id_to_string p.task_id) );
+                              ("cmd", `String cmd);
+                              ("cwd", `String cwd);
+                              ("partial_output", `String p.partial_stdout);
+                              ( "bytes_dropped",
+                                `Int p.bytes_dropped_stdout );
+                              ("budget_ms", `Int budget_ms);
+                              ("execution_time_ms", `Int elapsed_ms);
+                              ( "hint",
+                                `String
+                                  (Printf.sprintf
+                                     "Command exceeded \
+                                      MASC_BLOCKING_BUDGET_MS=%d. Still \
+                                      running in background; poll with \
+                                      keeper_bash_output or stop with \
+                                      keeper_bash_kill."
+                                     budget_ms) );
+                            ])
+                      | Masc_exec.Exec_run.Spawn_error
+                          (Bg_task.Spawn_failed e) ->
+                        error_json
+                          (Printf.sprintf
+                             "auto-bg spawn failed: %s" e)
+                      | Masc_exec.Exec_run.Spawn_error
+                          (Bg_task.Too_many_tasks { keeper = k; limit }) ->
+                        error_json
+                          (Printf.sprintf
+                             "keeper %s exceeded background task limit (%d)"
+                             k limit)
+                      | Masc_exec.Exec_run.Spawn_error
+                          (Bg_task.Invalid_cwd msg) ->
+                        error_json (Printf.sprintf "invalid cwd: %s" msg))
                    in
-                   (match outcome with
-                    | Masc_exec.Exec_run.Completed r ->
-                      let elapsed_ms =
-                        elapsed_duration_ms
-                          ~start_time:t0_bg ~end_time:(Unix.gettimeofday ())
-                      in
-                      (* P21: store in exec cache if not a timeout *)
-                      if not (Keeper_shell_shared.process_status_is_timeout r.status) then
-                        (match exec_cache with
-                         | Some cache ->
-                           let exit_code = match r.status with
-                             | Unix.WEXITED n -> n
-                             | Unix.WSIGNALED n -> 128 + n
-                             | Unix.WSTOPPED n -> 256 + n
-                           in
-                           Masc_exec.Exec_cache.store cache
-                             ~cmd ~exit_code ~output:r.stdout ~duration_ms:elapsed_ms
-                         | None -> ());
-                      Yojson.Safe.to_string
-                        (Exec_core.process_result_json
-                           ~base_path:root
-                           ~keeper_name:meta.name
-                           ~cmd
-                           ~extra:[
-                             "cwd", `String cwd;
-                             "execution_time_ms", `Int elapsed_ms;
-                           ]
-                           ~status:r.status
-                           ~output:r.stdout
-                           ~env_snapshot:env_snap
-                           ())
-                    | Masc_exec.Exec_run.Promoted p ->
-                      let elapsed_ms =
-                        elapsed_duration_ms
-                          ~start_time:t0_bg ~end_time:(Unix.gettimeofday ())
-                      in
-                      Log.Keeper.info
-                        "BG_PROMOTE: keeper=%s task_id=%s budget_ms=%d cmd=%s"
-                        meta.name
-                        (Bg_task.task_id_to_string p.task_id)
-                        budget_ms
-                        cmd_for_log;
-                      Yojson.Safe.to_string
-                        (`Assoc
-                          [
-                            ("ok", `Bool false);
-                            ("promoted", `Bool true);
-                            ( "background_task_id",
-                              `String
-                                (Bg_task.task_id_to_string p.task_id) );
-                            ("cmd", `String cmd);
-                            ("cwd", `String cwd);
-                            ("partial_output", `String p.partial_stdout);
-                            ( "bytes_dropped",
-                              `Int p.bytes_dropped_stdout );
-                            ("budget_ms", `Int budget_ms);
-                            ("execution_time_ms", `Int elapsed_ms);
-                            ( "hint",
-                              `String
-                                (Printf.sprintf
-                                   "Command exceeded \
-                                    MASC_BLOCKING_BUDGET_MS=%d. Still \
-                                    running in background; poll with \
-                                    keeper_bash_output or stop with \
-                                    keeper_bash_kill."
-                                   budget_ms) );
-                          ])
-                    | Masc_exec.Exec_run.Spawn_error
-                        (Bg_task.Spawn_failed e) ->
-                      error_json
-                        (Printf.sprintf
-                           "auto-bg spawn failed: %s" e)
-                    | Masc_exec.Exec_run.Spawn_error
-                        (Bg_task.Too_many_tasks { keeper = k; limit }) ->
-                      error_json
-                        (Printf.sprintf
-                           "keeper %s exceeded background task limit (%d)"
-                           k limit)
-                    | Masc_exec.Exec_run.Spawn_error
-                        (Bg_task.Invalid_cwd msg) ->
-                      error_json (Printf.sprintf "invalid cwd: %s" msg))
+                   (match exec_cache with
+                    | Some cache ->
+                      (match Masc_exec.Exec_cache.lookup cache cmd with
+                       | Some entry -> cached_result_json entry
+                       | None -> run_uncached ())
+                    | None -> run_uncached ())
                end))
   end
 ;;

--- a/lib/keeper/keeper_tools_oas.ml
+++ b/lib/keeper/keeper_tools_oas.ml
@@ -373,7 +373,7 @@ let append_tool_exec_decision_log ~config ~keeper_name ~site entry =
 
     Telemetry SSOT contract: [~name] flows into every observability
     sink (Keeper_registry.record_tool_use, SSE broadcast tool_name,
-    decision-log "tool" field, on_keeper_tool_call). The LLM-facing
+    decision-log "tool" field, record_keeper_tool_call). The LLM-facing
     public name (Bash/Read/...) only appears as the [Tool.schema.name]
     set by [Tool_bridge.oas_tool_of_masc] above this helper.
 
@@ -435,7 +435,8 @@ let make_keeper_tool_handler
         if is_failure then begin
           let count = failure_count_record_failure failure_counts key in
           Keeper_registry.record_tool_use ~base_path:config.base_path meta.name ~tool_name:name ~success:false;
-          !Keeper_exec_tools.on_keeper_tool_call ~tool_name:name ~success:false ~duration_ms;
+          Keeper_exec_tools.record_keeper_tool_call
+            ~tool_name:name ~success:false ~duration_ms;
           (* Tool-call observability flows through the OAS Event_bus
              (ToolCalled + ToolCompleted). MASC-side observers removed
              in refactor/tool-call-single-source. *)
@@ -480,7 +481,8 @@ let make_keeper_tool_handler
         end else begin
           failure_count_reset failure_counts key;
           Keeper_registry.record_tool_use ~base_path:config.base_path meta.name ~tool_name:name ~success:true;
-          !Keeper_exec_tools.on_keeper_tool_call ~tool_name:name ~success:true ~duration_ms;
+          Keeper_exec_tools.record_keeper_tool_call
+            ~tool_name:name ~success:true ~duration_ms;
           (* Tool-call observability via OAS Event_bus. See above. *)
           (let tr = Tool_result.{ tool_name = name; success = true;
               duration_ms = Float.of_int duration_ms; data = `Null;
@@ -598,7 +600,8 @@ let make_keeper_tool_handler
           else failure_count_record_failure failure_counts key
         in
         Keeper_registry.record_tool_use ~base_path:config.base_path meta.name ~tool_name:name ~success:false;
-        !Keeper_exec_tools.on_keeper_tool_call ~tool_name:name ~success:false ~duration_ms;
+        Keeper_exec_tools.record_keeper_tool_call
+          ~tool_name:name ~success:false ~duration_ms;
         (* Tool-call observability via OAS Event_bus. See above. *)
         broadcast_keeper_tool_call_event
           ~keeper_name:meta.name ~tool_name:name ~duration_ms

--- a/lib/mcp_server_eio.ml
+++ b/lib/mcp_server_eio.ml
@@ -127,7 +127,7 @@ let () =
    Prometheus.set_tool_schema_stats ~count ~approx_tokens:(chars / 4));
   (* Wire keeper-internal tool call recording to break Config dependency cycle.
      keeper_exec_tools cannot reference Tool_registry directly. *)
-  Keeper_exec_tools.on_keeper_tool_call :=
+  Keeper_exec_tools.set_on_keeper_tool_call
     (fun ~tool_name ~success ~duration_ms ->
        Tool_registry.record_call ~source:Keeper_internal
          ~tool_name ~success ~duration_ms ());


### PR DESCRIPTION
## Summary

- Replace exported `Keeper_exec_tools.on_keeper_tool_call` and `tool_search_fn` refs with mutex-protected setter/invocation functions.
- Route OAS tool-call recording and MCP server startup wiring through the new functions.
- Fix keeper bash exec-cache lookup for Docker JSON results and the Eio auto-bg path so identical cacheable commands hit the per-turn cache.

## Product impact

- Removes racy public callback mutation from keeper tool execution while preserving the startup dependency-cycle escape hatch.
- Restores expected cache behavior for Docker-profile keeper bash calls; before this patch, `test_keeper_exec_tools.exe` failed on current `main` because the second identical `echo hello_cache_test` command executed again instead of returning `cached=true`.

## Evidence

- Verified stale-current claim against `origin/main`: direct public refs existed in `lib/keeper/keeper_exec_tools.ml` before this patch.
- Reproduced pre-existing cache failure on clean `main`: `./_build/default/test/test_keeper_exec_tools.exe` failed at `exec_cache / miss then hit` because second call was not cached.
- `ocamlc -stop-after parsing lib/keeper/keeper_exec_tools.mli lib/keeper/keeper_exec_tools.ml lib/keeper/keeper_shell_bash.ml lib/keeper/keeper_tools_oas.ml lib/mcp_server_eio.ml`
- `git diff --check origin/main...HEAD`
- `scripts/dune-local.sh build test/test_keeper_exec_tools.exe test/test_keeper_tools_oas.exe bin/main_eio.exe`
- `./_build/default/test/test_keeper_exec_tools.exe` PASS, 18 tests
- `./_build/default/test/test_keeper_tools_oas.exe` PASS, 35 tests
- `bash scripts/ci/check-silent-failure-patterns.sh` PASS, no critical silent failures detected

## GOAL LOOP ACT checklist

- [x] Observe — Kimi audit item flagged process-global keeper tool callback refs; focused test also exposed a main-branch exec-cache miss.
- [x] Orient — callback mutation was a public `ref` surface; cache misses came from Docker/raw JSON and Eio auto-bg paths not reading the per-turn cache before executing.
- [x] Decide — keep startup wiring global but mutex-protected, and preserve session-scoped search override while hardening the fallback.
- [x] Act — updated keeper tool hook API, OAS/server call sites, and keeper bash cache lookup paths.
- [x] Verify — parser checks, focused Dune build, focused executables, diff check, and silent-failure scan passed locally after rebase.
- [x] Loop — remaining Kimi claims should continue to be verified against current `main` before edits; `masc_schemas_ref` is still a separate raw-ref surface.

## Review evidence

- Not run: no cross-model review for this bounded keeper tool/cache hardening patch.

## Linked issue

- Relates: Kimi audit follow-up; no GitHub issue number.

## Variant addition checklist

- [ ] **OCaml** — N/A: no variant added, removed, or renamed.
- [ ] **TypeScript** — N/A: no TypeScript union member changed.
- [ ] **TLA+ spec** — N/A: no TLA+ domain literal changed.
- [ ] **Event / JSON schema** — N/A: no event or JSON schema enum changed.
- [ ] **`make check-variants` passes** — N/A: no variant surface changed.
