### PR TITLE
fix(keeper): hide passive tools on required gates

### DIFF
--- a/lib/keeper/keeper_agent_tool_surface.ml
+++ b/lib/keeper/keeper_agent_tool_surface.ml
@@ -205,6 +205,27 @@ let turn_affordances_require_tool_gate_with_allowed
       gated_affordances;
   gate_requested
 
+let tool_names_for_required_gate_surface
+    ~(tool_gate_requested : bool)
+    (tool_names : string list) : string list =
+  let is_stay_silent name =
+    match Tool_name.of_string name with
+    | Some (Tool_name.Keeper Tool_name.Keeper.Stay_silent) -> true
+    | _ -> false
+  in
+  if not tool_gate_requested then tool_names
+  else
+    let actionable =
+      tool_names
+      |> List.filter (fun name ->
+        Keeper_tool_disclosure.tool_name_can_satisfy_required_contract name
+        && not (is_stay_silent name))
+      |> Keeper_types.dedupe_keep_order
+    in
+    match actionable with
+    | [] -> tool_names
+    | _ :: _ -> actionable
+
 let should_require_tools_for_initial_turn ~(max_turns : int)
     ~(turn_affordances : string list) =
   let initial_per_call_turn = 1 in

--- a/lib/keeper/keeper_agent_tool_surface.mli
+++ b/lib/keeper/keeper_agent_tool_surface.mli
@@ -104,6 +104,12 @@ val turn_affordances_require_tool_gate_with_allowed :
   -> string list
   -> bool
 
+(** On a required-action turn, trim the visible surface to tools that can make
+    progress when such tools exist. Passive status/read tools remain visible on
+    optional turns and on surfaces that have no actionable alternative. *)
+val tool_names_for_required_gate_surface :
+  tool_gate_requested:bool -> string list -> string list
+
 (** Whether the very first turn of a multi-turn slot should require
     a tool call. *)
 val should_require_tools_for_initial_turn :

--- a/lib/keeper/keeper_run_tools.ml
+++ b/lib/keeper/keeper_run_tools.ml
@@ -792,6 +792,9 @@ let prepare_agent_setup
            ~allowed_tool_names:all_allowed
     in
     let all_allowed =
+      tool_names_for_required_gate_surface ~tool_gate_requested all_allowed
+    in
+    let all_allowed =
       if List.length all_allowed > max_tools then (
         Log.Keeper.info
           "context overflow guard: %d tools > max %d, truncating"

--- a/lib/keeper/keeper_tool_guidance.ml
+++ b/lib/keeper/keeper_tool_guidance.ml
@@ -145,5 +145,7 @@ let render_gh_workflow ~allowed_tool_names =
 let render_unknown_tool_guard () =
   "Do not call tool names that are absent from the active runtime schema list. Heartbeat \
    is server-managed; public lifecycle/status tools such as `masc_join`, `masc_who`, and \
-   `masc_heartbeat` are not keeper action tools unless they are explicitly shown to you."
+   `masc_heartbeat` are not keeper action tools unless they are explicitly shown to you. \
+   Copy active schema names exactly; do not substitute public `masc_*` aliases such as \
+   `masc_board_list` for keeper-scoped tools."
 ;;

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -2333,6 +2333,8 @@ let test_work_discovery_nudge_uses_registered_keeper_tool_schemas () =
        "keeper_shell op=gh` derives repo context from the active task worktree/current_task_id");
   check bool "unknown tool guard names server-managed public lifecycle tools" true
     (contains_substring (Guidance.render_unknown_tool_guard ()) "masc_heartbeat");
+  check bool "unknown tool guard warns against public board alias" true
+    (contains_substring (Guidance.render_unknown_tool_guard ()) "masc_board_list");
   check bool "keeper_shell schema documents gh claim prerequisite" true
     (source_file_contains "lib/tool_shard.ml"
        "Requires an active claimed task/current_task_id");
@@ -7496,6 +7498,28 @@ let test_turn_affordance_gate_suppression_metric () =
     claim_before
     (metric "task_claim")
 
+let test_required_gate_surface_removes_passive_distractions () =
+  let module Surface = Masc_mcp.Keeper_agent_tool_surface in
+  check (list string)
+    "required gate keeps actionable tools only"
+    [ "keeper_task_claim"; "keeper_board_post" ]
+    (Surface.tool_names_for_required_gate_surface
+       ~tool_gate_requested:true
+       [ "keeper_tasks_list"; "keeper_task_claim"; "keeper_stay_silent";
+         "keeper_board_post"; "masc_status" ]);
+  check (list string)
+    "optional turn keeps passive tools visible"
+    [ "keeper_tasks_list"; "keeper_board_post" ]
+    (Surface.tool_names_for_required_gate_surface
+       ~tool_gate_requested:false
+       [ "keeper_tasks_list"; "keeper_board_post" ]);
+  check (list string)
+    "passive-only surface remains unchanged when no action exists"
+    [ "keeper_tasks_list"; "masc_status" ]
+    (Surface.tool_names_for_required_gate_surface
+       ~tool_gate_requested:true
+       [ "keeper_tasks_list"; "masc_status" ])
+
 let test_tools_for_gated_affordance_covers_each_variant () =
   (* Compile-time exhaustiveness already ensures every variant is
      handled; this asserts the runtime mapping is non-empty so a
@@ -8648,6 +8672,8 @@ let () =
             test_turn_affordances_require_tool_gate_with_allowed_filters_by_tool;
           test_case "affordance gate suppression emits metric" `Quick
             test_turn_affordance_gate_suppression_metric;
+          test_case "required gate surface removes passive distractions" `Quick
+            test_required_gate_surface_removes_passive_distractions;
           test_case "tools_for_gated_affordance non-empty for every variant"
             `Quick test_tools_for_gated_affordance_covers_each_variant;
         ] );


### PR DESCRIPTION
## Summary
- trim required-action keeper tool surfaces to contract-satisfying action tools when any are available
- preserve optional/passive-only surfaces so impossible gates are not made worse upstream
- strengthen keeper guidance/tests against substituting public `masc_*` aliases for keeper-scoped tools

Fixes #13762

## Validation
- PASS: `git diff --check HEAD~1 HEAD`
- PASS: `env DUNE_BUILD_DIR=_build_codex_13762_required_surface scripts/dune-local.sh build test/test_keeper_unified.exe`
- PASS: `./_build_codex_13762_required_surface/default/test/test_keeper_unified.exe test tool_classification` (8 tests)
- NOTE: full direct `test_keeper_unified.exe` was previously run during this branch and failed on existing `world_observation 7 claimable backlog mirror` / `auto-goal fallback claimable backlog` (expected 1, got 0); the new `tool_classification` coverage passed.