### PR TITLE
fix(keeper): persist async message requests

### DIFF
--- a/lib/keeper/keeper_msg_async.ml
+++ b/lib/keeper/keeper_msg_async.ml
@@ -4,125 +4,412 @@
     MCP tool returns immediately with a request_id;
     clients poll keeper_msg_result for completion.
 
-    Entries auto-expire after [max_age_sec] to prevent memory leaks. *)
+    Completed entries auto-expire from memory after [max_age_sec] to prevent
+    memory leaks. Non-terminal entries remain queryable until they either
+    complete or are recovered from disk as lost after a process restart. *)
 
 open Keeper_types
 
 type request_status =
   | Queued
   | Running
-  | Done of { ok : bool; body : string }
+  | Lost of { reason : string }
+  | Done of
+      { ok : bool
+      ; body : string
+      }
 
-type entry = {
-  request_id : string;
-  keeper_name : string;
-  status : request_status;
-  submitted_at : float;
-  completed_at : float option;
-}
+type entry =
+  { request_id : string
+  ; keeper_name : string
+  ; base_path : string
+  ; status : request_status
+  ; submitted_at : float
+  ; completed_at : float option
+  }
 
 let mu = Eio.Mutex.create ()
 let pending : (string, entry) Hashtbl.t = Hashtbl.create 16
 let counter = Atomic.make 0
-
 let max_age_sec = 3600.0
+
+let request_dir ~base_path =
+  Filename.concat (Common.masc_dir_from_base_path ~base_path) "keeper_msg_requests"
+;;
+
+let max_request_id_len = 128
+
+let is_safe_request_id request_id =
+  let len = String.length request_id in
+  if len = 0
+  then false
+  else if len > max_request_id_len
+  then false
+  else (
+    let rec loop i =
+      if i = len
+      then true
+      else (
+        match request_id.[i] with
+        | 'a' .. 'z' | 'A' .. 'Z' | '0' .. '9' | '_' | '-' | '.' -> loop (i + 1)
+        | _ -> false)
+    in
+    loop 0)
+;;
+
+let record_path ~base_path ~request_id =
+  if is_safe_request_id request_id
+  then Some (Filename.concat (request_dir ~base_path) (request_id ^ ".json"))
+  else None
+;;
+
+let status_to_string = function
+  | Queued -> "queued"
+  | Running -> "running"
+  | Lost _ -> "lost"
+  | Done { ok = true; _ } -> "done"
+  | Done { ok = false; _ } -> "error"
+;;
+
+let entry_record_to_json (e : entry) : Yojson.Safe.t =
+  let fields =
+    [ "request_id", `String e.request_id
+    ; "keeper_name", `String e.keeper_name
+    ; "base_path", `String e.base_path
+    ; "status", `String (status_to_string e.status)
+    ; "submitted_at", `Float e.submitted_at
+    ]
+  in
+  let fields =
+    match e.completed_at with
+    | Some t -> fields @ [ "completed_at", `Float t ]
+    | None -> fields
+  in
+  let fields =
+    match e.status with
+    | Done { ok; body } -> fields @ [ "ok", `Bool ok; "body", `String body ]
+    | Lost { reason } -> fields @ [ "reason", `String reason ]
+    | Queued | Running -> fields
+  in
+  `Assoc fields
+;;
+
+let string_member name json =
+  match Yojson.Safe.Util.member name json with
+  | `String value -> Some value
+  | _ -> None
+;;
+
+let float_member name json =
+  match Yojson.Safe.Util.member name json with
+  | `Float value -> Some value
+  | `Int value -> Some (float_of_int value)
+  | _ -> None
+;;
+
+let bool_member name json =
+  match Yojson.Safe.Util.member name json with
+  | `Bool value -> Some value
+  | _ -> None
+;;
+
+let entry_of_record_json ~base_path json : entry option =
+  match
+    ( string_member "request_id" json
+    , string_member "keeper_name" json
+    , string_member "status" json
+    , float_member "submitted_at" json )
+  with
+  | Some request_id, Some keeper_name, Some status, Some submitted_at ->
+    let completed_at = float_member "completed_at" json in
+    let status =
+      match status with
+      | "queued" -> Some Queued
+      | "running" -> Some Running
+      | "lost" ->
+        Some
+          (Lost
+             { reason =
+                 string_member "reason" json
+                 |> Option.value
+                      ~default:"keeper_msg request was lost before terminal result"
+             })
+      | "done" | "error" ->
+        let ok =
+          bool_member "ok" json |> Option.value ~default:(String.equal status "done")
+        in
+        let body =
+          string_member "body" json
+          |> Option.value ~default:{|{"error":"result body missing"}|}
+        in
+        Some (Done { ok; body })
+      | _ -> None
+    in
+    Option.map
+      (fun status ->
+         { request_id; keeper_name; base_path; status; submitted_at; completed_at })
+      status
+  | _ -> None
+;;
+
+let persist_entry (entry : entry) =
+  match record_path ~base_path:entry.base_path ~request_id:entry.request_id with
+  | None -> ()
+  | Some path ->
+    (match Keeper_fs.save_json_atomic path (entry_record_to_json entry) with
+     | Ok () -> ()
+     | Error err ->
+       Log.Keeper.warn
+         "keeper_msg_async: persist failed request_id=%s path=%s error=%s"
+         entry.request_id
+         path
+         err)
+;;
+
+let load_record ~base_path ~request_id =
+  match record_path ~base_path ~request_id with
+  | None -> None
+  | Some path ->
+    if not (Fs_compat.file_exists path)
+    then None
+    else (
+      try
+        Fs_compat.load_file path
+        |> Yojson.Safe.from_string
+        |> entry_of_record_json ~base_path
+      with
+      | Eio.Cancel.Cancelled _ as e -> raise e
+      | exn ->
+        Log.Keeper.warn
+          "keeper_msg_async: load failed request_id=%s path=%s error=%s"
+          request_id
+          path
+          (Printexc.to_string exn);
+        None)
+;;
+
+let has_suffix ~suffix value =
+  let value_len = String.length value in
+  let suffix_len = String.length suffix in
+  value_len >= suffix_len
+  && String.equal (String.sub value (value_len - suffix_len) suffix_len) suffix
+;;
+
+let request_id_of_record_filename name =
+  let suffix = ".json" in
+  if has_suffix ~suffix name
+  then Some (String.sub name 0 (String.length name - String.length suffix))
+  else None
+;;
+
+let should_gc_disk_record ~now (entry : entry) =
+  match entry.status with
+  | Done _ | Lost _ -> now -. entry.submitted_at > max_age_sec
+  | Queued | Running -> false
+;;
+
+let remove_record_file path =
+  try
+    Sys.remove path;
+    true
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | exn ->
+    Log.Keeper.warn
+      "keeper_msg_async: gc remove failed path=%s error=%s"
+      path
+      (Printexc.to_string exn);
+    false
+;;
+
+let gc_stale_disk ~base_path =
+  let dir = request_dir ~base_path in
+  let now = Unix.gettimeofday () in
+  try
+    if (not (Sys.file_exists dir)) || not (Sys.is_directory dir)
+    then 0
+    else
+      Sys.readdir dir
+      |> Array.fold_left
+           (fun removed name ->
+              match request_id_of_record_filename name with
+              | None -> removed
+              | Some request_id ->
+                let path = Filename.concat dir name in
+                if Sys.is_directory path
+                then removed
+                else (
+                  match load_record ~base_path ~request_id with
+                  | Some entry when should_gc_disk_record ~now entry ->
+                    if remove_record_file path then removed + 1 else removed
+                  | Some _ | None -> removed))
+           0
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | exn ->
+    Log.Keeper.warn
+      "keeper_msg_async: gc scan failed base_path=%s dir=%s error=%s"
+      base_path
+      dir
+      (Printexc.to_string exn);
+    0
+;;
+
+let mark_lost_after_recovery (entry : entry) =
+  let reason =
+    "keeper_msg request was accepted but no live worker owns it; the server may have \
+     restarted or evicted the request before terminal result"
+  in
+  let lost =
+    { entry with status = Lost { reason }; completed_at = Some (Unix.gettimeofday ()) }
+  in
+  persist_entry lost;
+  lost
+;;
 
 let generate_request_id ~keeper_name =
   let n = Atomic.fetch_and_add counter 1 in
-  Printf.sprintf "kmsg_%s_%d_%d" keeper_name n
+  let safe_keeper_name =
+    Coord_utils_backend_setup.sanitize_namespace_segment keeper_name
+  in
+  Printf.sprintf
+    "kmsg_%s_%d_%d"
+    safe_keeper_name
+    n
     (int_of_float (Unix.gettimeofday () *. 1000.0))
+;;
 
-let with_lock f =
-  Eio.Mutex.use_rw ~protect:true mu (fun () -> f ())
+let with_lock f = Eio.Mutex.use_rw ~protect:true mu (fun () -> f ())
 
 let gc_stale () =
   let now = Unix.gettimeofday () in
   with_lock (fun () ->
-      Hashtbl.fold
-        (fun id entry acc ->
-          if now -. entry.submitted_at > max_age_sec then id :: acc else acc)
-        pending []
-      |> List.iter (fun id -> Hashtbl.remove pending id))
+    Hashtbl.fold
+      (fun id entry acc ->
+         match entry.status with
+         | (Done _ | Lost _) when now -. entry.submitted_at > max_age_sec -> id :: acc
+         | Queued | Running | Done _ | Lost _ -> acc)
+      pending
+      []
+    |> List.iter (fun id -> Hashtbl.remove pending id))
+;;
 
 let set_status request_id status =
   with_lock (fun () ->
     match Hashtbl.find_opt pending request_id with
     | Some entry ->
-      let completed_at = match status with
-        | Done _ -> Some (Unix.gettimeofday ())
+      let completed_at =
+        match status with
+        | Done _ | Lost _ -> Some (Unix.gettimeofday ())
         | _ -> None
       in
-      Hashtbl.replace pending request_id { entry with status; completed_at }
-    | None -> ()
-  )
+      let updated = { entry with status; completed_at } in
+      Hashtbl.replace pending request_id updated;
+      persist_entry updated
+    | None -> ())
+;;
 
 (** Submit a keeper_msg turn for async execution.
     Forks a background fiber on [sw], returns the request_id immediately. *)
-let submit ~sw ~(f : unit -> tool_result) ~keeper_name : string =
+let submit ~sw ~base_path ~(f : unit -> tool_result) ~keeper_name : string =
   gc_stale ();
+  ignore (gc_stale_disk ~base_path);
   let request_id = generate_request_id ~keeper_name in
-  let entry = {
-    request_id;
-    keeper_name;
-    status = Queued;
-    submitted_at = Unix.gettimeofday ();
-    completed_at = None;
-  } in
-  with_lock (fun () -> Hashtbl.replace pending request_id entry);
+  let entry =
+    { request_id
+    ; keeper_name
+    ; base_path
+    ; status = Queued
+    ; submitted_at = Unix.gettimeofday ()
+    ; completed_at = None
+    }
+  in
+  with_lock (fun () ->
+    Hashtbl.replace pending request_id entry;
+    persist_entry entry);
   Eio.Fiber.fork_daemon ~sw (fun () ->
     set_status request_id Running;
     let result =
       try
-        let (ok, body) = f () in
+        let ok, body = f () in
         Done { ok; body }
       with
       | Eio.Cancel.Cancelled _ as e -> raise e
       | exn ->
-        Done { ok = false; body = Printf.sprintf "keeper_msg failed: %s" (Printexc.to_string exn) }
+        Done
+          { ok = false
+          ; body = Printf.sprintf "keeper_msg failed: %s" (Printexc.to_string exn)
+          }
     in
     set_status request_id result;
-    `Stop_daemon
-  );
+    `Stop_daemon);
   request_id
+;;
 
 (** Poll for the result of an async keeper_msg request. *)
-let poll request_id : entry option =
-  Eio.Mutex.use_ro mu (fun () -> Hashtbl.find_opt pending request_id)
+let poll ?base_path request_id : entry option =
+  match Eio.Mutex.use_ro mu (fun () -> Hashtbl.find_opt pending request_id) with
+  | Some _ as found -> found
+  | None ->
+    (match base_path with
+     | None -> None
+     | Some base_path ->
+       ignore (gc_stale_disk ~base_path);
+       (match load_record ~base_path ~request_id with
+        | None -> None
+        | Some ({ status = Queued | Running; _ } as entry) ->
+          Some (mark_lost_after_recovery entry)
+        | Some entry -> Some entry))
+;;
 
 (** List all pending/running requests for a keeper. *)
 let list_for_keeper ~keeper_name : entry list =
   Eio.Mutex.use_ro mu (fun () ->
-      Hashtbl.fold
-        (fun _id entry acc ->
-          if entry.keeper_name = keeper_name then entry :: acc else acc)
-        pending [])
+    Hashtbl.fold
+      (fun _id entry acc -> if entry.keeper_name = keeper_name then entry :: acc else acc)
+      pending
+      [])
   |> List.sort (fun a b -> compare b.submitted_at a.submitted_at)
-
-let status_to_string = function
-  | Queued -> "queued"
-  | Running -> "running"
-  | Done { ok = true; _ } -> "done"
-  | Done { ok = false; _ } -> "error"
+;;
 
 let entry_to_json (e : entry) : Yojson.Safe.t =
-  let fields = [
-    ("request_id", `String e.request_id);
-    ("keeper_name", `String e.keeper_name);
-    ("status", `String (status_to_string e.status));
-    ("submitted_at", `Float e.submitted_at);
-  ] in
-  let fields = match e.completed_at with
-    | Some t -> fields @ [("completed_at", `Float t)]
+  let fields =
+    [ "request_id", `String e.request_id
+    ; "keeper_name", `String e.keeper_name
+    ; "status", `String (status_to_string e.status)
+    ; "submitted_at", `Float e.submitted_at
+    ]
+  in
+  let fields =
+    match e.completed_at with
+    | Some t -> fields @ [ "completed_at", `Float t ]
     | None ->
       let elapsed = Unix.gettimeofday () -. e.submitted_at in
-      fields @ [("elapsed_sec", `Float elapsed)]
+      fields @ [ "elapsed_sec", `Float elapsed ]
   in
-  let fields = match e.status with
+  let fields =
+    match e.status with
     | Done { ok; body } ->
-      fields @ [
-        ("ok", `Bool ok);
-        ("result", (try Yojson.Safe.from_string body with Eio.Cancel.Cancelled _ as e -> raise e | Yojson.Json_error _ -> `String body));
-      ]
+      fields
+      @ [ "ok", `Bool ok
+        ; ( "result"
+          , try Yojson.Safe.from_string body with
+            | Eio.Cancel.Cancelled _ as e -> raise e
+            | Yojson.Json_error _ -> `String body )
+        ]
+    | Lost { reason } ->
+      fields
+      @ [ "ok", `Bool false
+        ; "result", `Assoc [ "error", `String "request_lost"; "reason", `String reason ]
+        ]
     | _ -> fields
   in
   `Assoc fields
+;;
+
+module For_testing = struct
+  let forget request_id = with_lock (fun () -> Hashtbl.remove pending request_id)
+  let clear () = with_lock (fun () -> Hashtbl.clear pending)
+  let record_path = record_path
+  let gc_stale_disk = gc_stale_disk
+end

--- a/lib/keeper/keeper_msg_async.mli
+++ b/lib/keeper/keeper_msg_async.mli
@@ -2,23 +2,30 @@
 
     Background fibers run [keeper_msg] turns. MCP tool returns
     immediately with a [request_id]; clients poll via
-    [masc_keeper_msg_result] for completion. Entries auto-expire
-    after [max_age_sec] (1h) to prevent memory leaks. *)
+    [masc_keeper_msg_result] for completion. Completed entries auto-expire
+    from memory after [max_age_sec] (1h), while accepted request records are
+    persisted under the active [.masc] root for recovery diagnostics. Terminal
+    disk records follow the same age-based cleanup policy. *)
 
 (** {1 Types} *)
 
 type request_status =
   | Queued
   | Running
-  | Done of { ok : bool; body : string }
+  | Lost of { reason : string }
+  | Done of
+      { ok : bool
+      ; body : string
+      }
 
-type entry = {
-  request_id : string;
-  keeper_name : string;
-  status : request_status;
-  submitted_at : float;
-  completed_at : float option;
-}
+type entry =
+  { request_id : string
+  ; keeper_name : string
+  ; base_path : string
+  ; status : request_status
+  ; submitted_at : float
+  ; completed_at : float option
+  }
 
 (** {1 Submit and poll} *)
 
@@ -26,15 +33,18 @@ type entry = {
     [sw] that runs [f] and stores the result. Returns the fresh
     [request_id] synchronously. Cancellation of [sw] cancels the
     fiber. *)
-val submit :
-  sw:Eio.Switch.t ->
-  f:(unit -> Keeper_types.tool_result) ->
-  keeper_name:string ->
-  string
+val submit
+  :  sw:Eio.Switch.t
+  -> base_path:string
+  -> f:(unit -> Keeper_types.tool_result)
+  -> keeper_name:string
+  -> string
 
-(** [poll request_id] returns the current entry, or [None] when the
-    id is unknown or has expired. *)
-val poll : string -> entry option
+(** [poll ?base_path request_id] returns the current entry, or [None] when the
+    id was never seen. If [base_path] is supplied and a persisted non-terminal
+    request exists without an in-memory worker, it is returned as [Lost] and the
+    terminal lost state is persisted. *)
+val poll : ?base_path:string -> string -> entry option
 
 (** [list_for_keeper ~keeper_name] returns all entries for a keeper
     sorted most-recent-first. *)
@@ -48,3 +58,10 @@ val status_to_string : request_status -> string
     [submitted_at], and — depending on state — [completed_at] /
     [elapsed_sec] / [ok] + [result]. *)
 val entry_to_json : entry -> Yojson.Safe.t
+
+module For_testing : sig
+  val forget : string -> unit
+  val clear : unit -> unit
+  val record_path : base_path:string -> request_id:string -> string option
+  val gc_stale_disk : base_path:string -> int
+end

--- a/lib/tool_keeper.ml
+++ b/lib/tool_keeper.ml
@@ -465,6 +465,7 @@ let handle_keeper_msg ctx args : tool_result =
   | Ok name ->
       let resolved_args = with_keeper_name args name in
       let request_id = Keeper_msg_async.submit ~sw:ctx.sw
+        ~base_path:ctx.config.base_path
         ~keeper_name:name
         ~f:(fun () ->
           let ok, body = Turn.handle_keeper_msg ctx resolved_args in
@@ -482,12 +483,12 @@ let handle_keeper_msg ctx args : tool_result =
       ] in
       (true, Yojson.Safe.to_string json)
 
-let handle_keeper_msg_result _ctx args : tool_result =
+let handle_keeper_msg_result ctx args : tool_result =
   let request_id = get_string args "request_id" "" in
   if String.equal request_id "" then
     (false, {|{"error":"request_id is required"}|})
   else
-    match Keeper_msg_async.poll request_id with
+    match Keeper_msg_async.poll ~base_path:ctx.config.base_path request_id with
     | None ->
       (false, Printf.sprintf {|{"error":"request_id not found","request_id":"%s"}|} request_id)
     | Some entry ->

--- a/test/test_keeper_mutex_coverage.ml
+++ b/test/test_keeper_mutex_coverage.ml
@@ -6,15 +6,47 @@ let wait_for_done request_id =
     match Keeper_msg_async.poll request_id with
     | Some ({ status = Done _; _ } as entry) -> entry
     | _ when remaining <= 0 ->
-        failwith (Printf.sprintf "request %s did not complete" request_id)
+      failwith (Printf.sprintf "request %s did not complete" request_id)
     | _ ->
-        Eio.Fiber.yield ();
-        loop (remaining - 1)
+      Eio.Fiber.yield ();
+      loop (remaining - 1)
   in
   loop 200
+;;
+
+let wait_for_running request_id =
+  let rec loop remaining =
+    match Keeper_msg_async.poll request_id with
+    | Some ({ status = Running; _ } as entry) -> entry
+    | _ when remaining <= 0 ->
+      failwith (Printf.sprintf "request %s did not start" request_id)
+    | _ ->
+      Eio.Fiber.yield ();
+      loop (remaining - 1)
+  in
+  loop 200
+;;
+
+let temp_dir prefix =
+  let path = Filename.temp_file prefix "" in
+  Sys.remove path;
+  Unix.mkdir path 0o755;
+  path
+;;
+
+let rec rm_rf path =
+  if Sys.file_exists path
+  then
+    if Sys.is_directory path
+    then (
+      Sys.readdir path |> Array.iter (fun entry -> rm_rf (Filename.concat path entry));
+      Unix.rmdir path)
+    else Sys.remove path
+;;
 
 let with_eio_env f =
-  Eio_main.run @@ fun env ->
+  Eio_main.run
+  @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
   Eio_guard.enable ();
   Fun.protect
@@ -22,53 +54,209 @@ let with_eio_env f =
       Fs_compat.clear_fs ();
       Eio_guard.disable ())
     (fun () -> f env)
+;;
 
 let test_keeper_msg_async_roundtrip () =
-  with_eio_env @@ fun _env ->
-  Eio.Switch.run @@ fun sw ->
+  with_eio_env
+  @@ fun _env ->
+  Eio.Switch.run
+  @@ fun sw ->
+  let base_path = temp_dir "keeper-msg-async-roundtrip-" in
   let request_id =
-    Keeper_msg_async.submit ~sw
-      ~keeper_name:"alpha"
-      ~f:(fun () ->
-        Eio.Fiber.yield ();
-        (true, Yojson.Safe.to_string (`Assoc [ ("kind", `String "done") ])))
+    Keeper_msg_async.submit ~sw ~base_path ~keeper_name:"alpha" ~f:(fun () ->
+      Eio.Fiber.yield ();
+      true, Yojson.Safe.to_string (`Assoc [ "kind", `String "done" ]))
   in
   let entry = wait_for_done request_id in
-  Alcotest.(check bool) "request completed" true
-    (match entry.Keeper_msg_async.status with Done { ok = true; body } ->
-       String.length body > 0
+  Alcotest.(check bool)
+    "request completed"
+    true
+    (match entry.Keeper_msg_async.status with
+     | Done { ok = true; body } -> String.length body > 0
      | _ -> false);
-  Alcotest.(check int) "one pending entry" 1
+  Alcotest.(check int)
+    "one pending entry"
+    1
     (List.length (Keeper_msg_async.list_for_keeper ~keeper_name:"alpha"))
+;;
+
+let test_keeper_msg_async_recovers_done_from_disk () =
+  with_eio_env
+  @@ fun _env ->
+  Eio.Switch.run
+  @@ fun sw ->
+  let base_path = temp_dir "keeper-msg-async-done-" in
+  let request_id =
+    Keeper_msg_async.submit ~sw ~base_path ~keeper_name:"beta" ~f:(fun () ->
+      Eio.Fiber.yield ();
+      true, Yojson.Safe.to_string (`Assoc [ "kind", `String "done" ]))
+  in
+  let entry = wait_for_done request_id in
+  Alcotest.(check bool)
+    "request completed before recovery"
+    true
+    (match entry.Keeper_msg_async.status with
+     | Done { ok = true; _ } -> true
+     | _ -> false);
+  Keeper_msg_async.For_testing.forget request_id;
+  match Keeper_msg_async.poll ~base_path request_id with
+  | Some { Keeper_msg_async.status = Done { ok = true; body }; _ } ->
+    Alcotest.(check bool) "body persisted" true (String.length body > 0)
+  | Some entry ->
+    Alcotest.failf
+      "expected recovered done, got %s"
+      (Keeper_msg_async.status_to_string entry.Keeper_msg_async.status)
+  | None -> Alcotest.fail "expected persisted request"
+;;
+
+let test_keeper_msg_async_marks_recovered_inflight_lost () =
+  with_eio_env
+  @@ fun _env ->
+  Eio.Switch.run
+  @@ fun sw ->
+  let base_path = temp_dir "keeper-msg-async-lost-" in
+  let promise, _resolver = Eio.Promise.create () in
+  let request_id =
+    Keeper_msg_async.submit ~sw ~base_path ~keeper_name:"gamma" ~f:(fun () ->
+      Eio.Promise.await promise;
+      true, "{}")
+  in
+  ignore (wait_for_running request_id : Keeper_msg_async.entry);
+  Keeper_msg_async.For_testing.forget request_id;
+  match Keeper_msg_async.poll ~base_path request_id with
+  | Some { Keeper_msg_async.status = Lost { reason }; _ } ->
+    Alcotest.(check bool) "lost reason retained" true (String.length reason > 0);
+    Keeper_msg_async.For_testing.forget request_id;
+    (match Keeper_msg_async.poll ~base_path request_id with
+     | Some { Keeper_msg_async.status = Lost _; _ } -> ()
+     | Some entry ->
+       Alcotest.failf
+         "expected persisted lost, got %s"
+         (Keeper_msg_async.status_to_string entry.Keeper_msg_async.status)
+     | None -> Alcotest.fail "expected persisted lost request")
+  | Some entry ->
+    Alcotest.failf
+      "expected recovered lost, got %s"
+      (Keeper_msg_async.status_to_string entry.Keeper_msg_async.status)
+  | None -> Alcotest.fail "expected persisted request"
+;;
+
+let test_keeper_msg_async_gc_removes_stale_terminal_disk_record () =
+  with_eio_env
+  @@ fun _env ->
+  Eio.Switch.run
+  @@ fun sw ->
+  let base_path = temp_dir "keeper-msg-async-gc-" in
+  let request_id =
+    Keeper_msg_async.submit ~sw ~base_path ~keeper_name:"delta" ~f:(fun () ->
+      Eio.Fiber.yield ();
+      true, "{}")
+  in
+  let entry = wait_for_done request_id in
+  let path =
+    match Keeper_msg_async.For_testing.record_path ~base_path ~request_id with
+    | Some path -> path
+    | None -> Alcotest.fail "expected safe record path"
+  in
+  let stale_ts = entry.Keeper_msg_async.submitted_at -. 7200.0 in
+  Fs_compat.save_file
+    path
+    (Yojson.Safe.to_string
+       (`Assoc
+           [ "request_id", `String request_id
+           ; "keeper_name", `String entry.keeper_name
+           ; "base_path", `String base_path
+           ; "status", `String "done"
+           ; "submitted_at", `Float stale_ts
+           ; "completed_at", `Float stale_ts
+           ; "ok", `Bool true
+           ; "body", `String "{}"
+           ]));
+  Keeper_msg_async.For_testing.forget request_id;
+  let removed = Keeper_msg_async.For_testing.gc_stale_disk ~base_path in
+  Alcotest.(check int) "removed stale disk record" 1 removed;
+  Alcotest.(check bool) "record file removed" false (Sys.file_exists path);
+  match Keeper_msg_async.poll ~base_path request_id with
+  | None -> ()
+  | Some entry ->
+    Alcotest.failf
+      "expected stale disk record to be gone, got %s"
+      (Keeper_msg_async.status_to_string entry.Keeper_msg_async.status)
+;;
+
+let test_keeper_msg_async_rejects_oversized_request_id () =
+  let base_path = temp_dir "keeper-msg-id-limit-" in
+  Fun.protect
+    ~finally:(fun () -> rm_rf base_path)
+    (fun () ->
+       let max_id = String.make 128 'a' in
+       let too_long = String.make 129 'a' in
+       check
+         bool
+         "128-char request id accepted"
+         true
+         (Option.is_some
+            (Keeper_msg_async.For_testing.record_path ~base_path ~request_id:max_id));
+       check
+         (option string)
+         "129-char request id rejected"
+         None
+         (Keeper_msg_async.For_testing.record_path ~base_path ~request_id:too_long))
+;;
 
 let test_yield_meter_noops_without_runnable_fiber () =
   let meter = Eio_guard.create_yield_meter ~interval:0 () in
   Eio_guard.enable ();
   Fun.protect ~finally:Eio_guard.disable (fun () ->
-      Eio_guard.yield_step meter;
-      Eio_guard.yield_step meter)
+    Eio_guard.yield_step meter;
+    Eio_guard.yield_step meter)
+;;
 
 let test_yield_meter_can_be_shared_across_fibers () =
-  with_eio_env @@ fun _env ->
-  Eio.Switch.run @@ fun sw ->
+  with_eio_env
+  @@ fun _env ->
+  Eio.Switch.run
+  @@ fun sw ->
   let meter = Eio_guard.create_yield_meter ~interval:2 () in
   for _ = 1 to 8 do
     Eio.Fiber.fork ~sw (fun () ->
-        for _ = 1 to 50 do
-          Eio_guard.yield_step meter
-        done)
+      for _ = 1 to 50 do
+        Eio_guard.yield_step meter
+      done)
   done
+;;
 
 let () =
-  run "keeper_mutex_coverage"
-    [
-      "keeper_msg_async", [
-        test_case "submit/poll roundtrip" `Quick test_keeper_msg_async_roundtrip;
-      ];
-      "eio_guard", [
-        test_case "yield meter noops without runnable fiber" `Quick
-          test_yield_meter_noops_without_runnable_fiber;
-        test_case "yield meter can be shared across fibers" `Quick
-          test_yield_meter_can_be_shared_across_fibers;
-      ];
+  run
+    "keeper_mutex_coverage"
+    [ ( "keeper_msg_async"
+      , [ test_case "submit/poll roundtrip" `Quick test_keeper_msg_async_roundtrip
+        ; test_case
+            "recover completed request from disk"
+            `Quick
+            test_keeper_msg_async_recovers_done_from_disk
+        ; test_case
+            "recover in-flight request as lost"
+            `Quick
+            test_keeper_msg_async_marks_recovered_inflight_lost
+        ; test_case
+            "gc removes stale terminal disk record"
+            `Quick
+            test_keeper_msg_async_gc_removes_stale_terminal_disk_record
+        ; test_case
+            "oversized request id rejected"
+            `Quick
+            test_keeper_msg_async_rejects_oversized_request_id
+        ] )
+    ; ( "eio_guard"
+      , [ test_case
+            "yield meter noops without runnable fiber"
+            `Quick
+            test_yield_meter_noops_without_runnable_fiber
+        ; test_case
+            "yield meter can be shared across fibers"
+            `Quick
+            test_yield_meter_can_be_shared_across_fibers
+        ] )
     ]
+;;


### PR DESCRIPTION
## Summary

- persist `masc_keeper_msg` async request records under the active `.masc` root as soon as the request is accepted
- keep non-terminal entries in memory until completion instead of expiring active turns after one hour
- let `masc_keeper_msg_result` recover known request IDs from disk; completed records return their terminal result, while recovered in-flight records become an explicit `lost` terminal result instead of `request_id not found`
- add regression coverage for completed-result recovery and in-flight lost recovery

## Why

Fixes #13951.

During the Docker PR approve resume, `verifier` returned an accepted/running request ID and later polling reported `request_id not found`. That made long-running keeper review/approve evidence unauditable: the operator could not distinguish a never-seen ID from a real accepted turn lost during restart, eviction, or session loss.

## Operator Impact

Accepted keeper message IDs now remain explainable after process loss. If the server can no longer own an in-flight request, polling returns a successful tool response with `status: "lost"`, `ok: false`, and a structured `request_lost` result. Unknown IDs still return `request_id not found`.

This does not replay the lost keeper turn. It preserves terminal observability so the harness can record a real blocker and safely retry the review phase.

## Validation

- `git diff --check`
- `ocamlformat --check lib/keeper/keeper_msg_async.ml lib/keeper/keeper_msg_async.mli test/test_keeper_mutex_coverage.ml`
- `scripts/dune-local.sh build test/test_keeper_mutex_coverage.exe`
- `./_build/default/test/test_keeper_mutex_coverage.exe`