### PR TITLE
test: register goal loop starvation metrics

### DIFF
--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -1230,6 +1230,9 @@ let init () =
      complete while preserving semaphore release (labels: op, \
      kind=cancelled|exception)"
     Counter;
+  add Keeper_metrics.metric_keeper_semaphore_wait_timeout
+    "Total keeper turn semaphore wait timeouts (labels: keeper, channel)"
+    Counter;
   register_histogram ~name:Keeper_metrics.metric_keeper_semaphore_wait_seconds
     ~help:"Seconds spent waiting to acquire keeper turn semaphores \
            (labels: keeper_name, cascade_profile, channel)." ();

--- a/masc_mcp.opam
+++ b/masc_mcp.opam
@@ -25,7 +25,7 @@ depends: [
   "cmdliner" {>= "1.1"}
   "cohttp" {>= "5.0"}
   "cohttp-eio" {>= "6.0"}
-  "agent_sdk" {>= "0.190.26"}
+  "agent_sdk" {>= "0.192.0"}
   "uri" {>= "4.4"}
   "tls" {>= "2.0"}
   "tls-eio" {>= "2.0"}

--- a/test/test_prometheus_coverage.ml
+++ b/test/test_prometheus_coverage.ml
@@ -435,6 +435,48 @@ let test_goal_attainment_metrics_registered () =
     (text_has_literal text
        ("# TYPE " ^ Prometheus.metric_goal_attainment_measured ^ " gauge"))
 
+let test_goal_loop_starvation_metrics_registered () =
+  let text = Prometheus.to_prometheus_text () in
+  check bool "has semaphore wait timeout HELP" true
+    (text_has_literal text
+       ("# HELP " ^ Prometheus.metric_keeper_semaphore_wait_timeout ^ " "));
+  check bool "has semaphore wait timeout TYPE" true
+    (text_has_literal text
+       ("# TYPE " ^ Prometheus.metric_keeper_semaphore_wait_timeout
+        ^ " counter"));
+  check bool "has turn scheduled HELP" true
+    (text_has_literal text
+       ("# HELP " ^ Prometheus.metric_keeper_turn_scheduled ^ " "));
+  check bool "has turn scheduled TYPE" true
+    (text_has_literal text
+       ("# TYPE " ^ Prometheus.metric_keeper_turn_scheduled ^ " counter"))
+
+let test_goal_loop_starvation_counter_emits_labelled_sample () =
+  let labels = [ ("keeper", "qa-king-13960"); ("channel", "autonomous_queue") ] in
+  let before =
+    Prometheus.metric_value_or_zero
+      Prometheus.metric_keeper_semaphore_wait_timeout
+      ~labels
+      ()
+  in
+  Prometheus.inc_counter
+    Prometheus.metric_keeper_semaphore_wait_timeout
+    ~labels
+    ();
+  Alcotest.(check (float 0.0001))
+    "counter incremented"
+    (before +. 1.0)
+    (Prometheus.metric_value_or_zero
+       Prometheus.metric_keeper_semaphore_wait_timeout
+       ~labels
+       ());
+  let text = Prometheus.to_prometheus_text () in
+  check bool "labelled sample exported" true
+    (text_has_literal
+       text
+       (Prometheus.metric_keeper_semaphore_wait_timeout
+        ^ "{keeper=\"qa-king-13960\",channel=\"autonomous_queue\"} "))
+
 let test_histogram_exported_as_summary () =
   let name = "test_hist_export_fmt" in
   Prometheus.register_histogram ~name ~help:"export format test" ();
@@ -642,6 +684,10 @@ let () =
         test_builtin_gauge_update_does_not_duplicate_sample;
       test_case "goal attainment metrics registered" `Quick
         test_goal_attainment_metrics_registered;
+      test_case "goal loop starvation metrics registered" `Quick
+        test_goal_loop_starvation_metrics_registered;
+      test_case "goal loop starvation counter emits labelled sample" `Quick
+        test_goal_loop_starvation_counter_emits_labelled_sample;
       test_case "histogram exported as summary with _sum/_count"
         `Quick test_histogram_exported_as_summary;
       test_case "backend mutex observers emit histogram samples" `Quick


### PR DESCRIPTION
## Summary
- register masc_keeper_semaphore_wait_timeout_total during Prometheus init so the idle exporter exposes HELP/TYPE metadata
- add coverage for the starvation-rate metric pair: semaphore wait timeouts and turn scheduled total

## Validation
- git diff --check
- scripts/dune-local.sh build test/test_prometheus_coverage.exe
- _build/default/test/test_prometheus_coverage.exe (61 tests)