### PR TITLE
fix(keeper): protect injected masc schemas

### DIFF
--- a/lib/keeper/keeper_exec_tools.ml
+++ b/lib/keeper/keeper_exec_tools.ml
@@ -351,7 +351,9 @@ let execute_keeper_tool_call_with_outcome
            in
            scored
          in
-         let masc_schemas = !Keeper_tool_registry.masc_schemas_ref in
+         let masc_schemas =
+           Keeper_tool_registry.masc_schemas_snapshot ()
+         in
          let enrich_suggestion name =
            let schema_opt =
              List.find_opt (fun (s : Masc_domain.tool_schema) -> s.name = name) masc_schemas

--- a/lib/keeper/keeper_exec_tools.mli
+++ b/lib/keeper/keeper_exec_tools.mli
@@ -67,8 +67,17 @@ val has_mutating_side_effect_with_input :
 (** Schema for the keeper_tool_search tool. *)
 val keeper_tool_search_schema : Masc_domain.tool_schema
 
-(** Injected masc_* tool schemas (populated at startup by [inject_masc_schemas]). *)
-val masc_schemas_ref : Masc_domain.tool_schema list ref
+(** Replace injected MASC tool schemas.
+    Startup calls this through [inject_masc_schemas]; runtime readers should
+    use [masc_schemas_snapshot] rather than holding mutable state. *)
+val set_masc_schemas : Masc_domain.tool_schema list -> unit
+
+(** Immutable snapshot of injected MASC tool schemas. *)
+val masc_schemas_snapshot : unit -> Masc_domain.tool_schema list
+
+(** Scoped schema override for tests that need a synthetic MASC surface. *)
+val with_masc_schemas_for_test :
+  Masc_domain.tool_schema list -> (unit -> 'a) -> 'a
 
 (** Injected masc_* tool names (populated at startup by [inject_masc_schemas]). *)
 val injected_masc_tool_names : unit -> string list

--- a/lib/keeper/keeper_run_tools.ml
+++ b/lib/keeper/keeper_run_tools.ml
@@ -344,7 +344,7 @@ let prepare_agent_setup
           acc.discovered
           ~turn:acc.current_turn
           ~names:discovered_names;
-        let masc_schemas = !Keeper_exec_tools.masc_schemas_ref in
+        let masc_schemas = Keeper_exec_tools.masc_schemas_snapshot () in
         let result_json ~already_visible (name, score) =
                let help_opt = Tool_help_registry.find_entry masc_schemas name in
                let desc =

--- a/lib/keeper/keeper_tool_policy.ml
+++ b/lib/keeper/keeper_tool_policy.ml
@@ -297,7 +297,7 @@ let keeper_supported_masc_tool_names_from_schemas schemas =
   |> dedupe_tool_names
 
 let inject_masc_schemas (schemas : Masc_domain.tool_schema list) =
-  masc_schemas_ref := keeper_supported_masc_schemas schemas
+  set_masc_schemas (keeper_supported_masc_schemas schemas)
 
 let select_existing_masc_tool_names names =
   let injected = injected_masc_tool_names () in
@@ -467,7 +467,7 @@ let can_execute ~(lookup : tool_access_lookup) (name : string) : bool =
 
 let keeper_masc_tool_names (meta : keeper_meta) : string list =
   let lookup = tool_access_lookup_of_meta meta in
-  !masc_schemas_ref
+  masc_schemas_snapshot ()
   |> List.filter_map (fun (schema : Masc_domain.tool_schema) ->
     if filter_by_access ~lookup schema.name
     then Some schema.name
@@ -475,7 +475,7 @@ let keeper_masc_tool_names (meta : keeper_meta) : string list =
 
 let keeper_masc_tool_schemas (meta : keeper_meta) : Masc_domain.tool_schema list =
   let lookup = tool_access_lookup_of_meta meta in
-  !masc_schemas_ref
+  masc_schemas_snapshot ()
   |> List.filter (fun (schema : Masc_domain.tool_schema) -> filter_by_access ~lookup schema.name)
 
 (* ── Layer 2: Universe (all executable tools, policy-independent) ── *)
@@ -484,7 +484,7 @@ let keeper_masc_tool_schemas (meta : keeper_meta) : Masc_domain.tool_schema list
     Used by make_tools to build Tool.t for BM25 retrieval scope. *)
 let keeper_universe_masc_tool_schemas (meta : keeper_meta) : Masc_domain.tool_schema list =
   let lookup = tool_access_lookup_of_meta meta in
-  !masc_schemas_ref
+  masc_schemas_snapshot ()
   |> List.filter (fun (schema : Masc_domain.tool_schema) ->
     filter_by_universe ~lookup schema.name)
 
@@ -690,7 +690,7 @@ let tool_hint_of (name : string) : string option =
     @ Keeper_tool_registry.keeper_voice_tool_schemas
     @ [ Keeper_tool_registry.keeper_tool_search_schema ]
     @ Tool_schemas_inline.schemas
-    @ !masc_schemas_ref
+    @ masc_schemas_snapshot ()
     @ Tool_code_write.schemas
   in
   match List.find_opt (fun (s : Masc_domain.tool_schema) -> s.name = name) all_schemas with

--- a/lib/keeper/keeper_tool_registry.ml
+++ b/lib/keeper/keeper_tool_registry.ml
@@ -342,10 +342,27 @@ let all_tools_reconcile_safe (names : string list) : bool =
 
 (* ── Dynamic schema injection (masc_* tools) ──────────────────── *)
 
-let masc_schemas_ref : Masc_domain.tool_schema list ref = ref []
+let masc_schemas_mutex = Stdlib.Mutex.create ()
+let masc_schemas_state : Masc_domain.tool_schema list ref = ref []
+
+let set_masc_schemas (schemas : Masc_domain.tool_schema list) =
+  Stdlib.Mutex.protect masc_schemas_mutex (fun () ->
+    masc_schemas_state := schemas)
+
+let masc_schemas_snapshot () =
+  Stdlib.Mutex.protect masc_schemas_mutex (fun () ->
+    !masc_schemas_state)
+
+let with_masc_schemas_for_test schemas f =
+  let previous = masc_schemas_snapshot () in
+  Fun.protect
+    ~finally:(fun () -> set_masc_schemas previous)
+    (fun () ->
+      set_masc_schemas schemas;
+      f ())
 
 let injected_masc_tool_names () =
-  !masc_schemas_ref
+  masc_schemas_snapshot ()
   |> List.map (fun (schema : Masc_domain.tool_schema) -> schema.name)
 
 (* ── keeper_tool_search schema ───────────────────────────────── *)

--- a/lib/keeper/keeper_tool_registry.mli
+++ b/lib/keeper/keeper_tool_registry.mli
@@ -109,11 +109,19 @@ val is_reconcile_safe_tool : string -> bool
     [reconcile_safe_set]. *)
 val all_tools_reconcile_safe : string list -> bool
 
-(** Mutable ref holding injected MASC tool schemas; populated at
-    boot by the dashboard / tool_registration paths. *)
-val masc_schemas_ref : Masc_domain.tool_schema list ref
+(** Replace injected MASC tool schemas.
+    Startup calls this through [inject_masc_schemas]; runtime readers should
+    use [masc_schemas_snapshot] rather than holding mutable state. *)
+val set_masc_schemas : Masc_domain.tool_schema list -> unit
 
-(** Names extracted from [!masc_schemas_ref] in declaration order. *)
+(** Immutable snapshot of injected MASC tool schemas. *)
+val masc_schemas_snapshot : unit -> Masc_domain.tool_schema list
+
+(** Scoped schema override for tests that need a synthetic MASC surface. *)
+val with_masc_schemas_for_test :
+  Masc_domain.tool_schema list -> (unit -> 'a) -> 'a
+
+(** Names extracted from [masc_schemas_snapshot ()] in declaration order. *)
 val injected_masc_tool_names : unit -> string list
 
 (** SSOT schema for [keeper_tool_search]. Defined here because this

--- a/test/test_keeper_masc_bridge.ml
+++ b/test/test_keeper_masc_bridge.ml
@@ -245,12 +245,7 @@ let test_custom_keeps_registered_inline_board_tool () =
     (List.mem "masc_who" names)
 
 let with_masc_schema_ref schemas f =
-  let previous = !(KET.masc_schemas_ref) in
-  Fun.protect
-    ~finally:(fun () -> KET.masc_schemas_ref := previous)
-    (fun () ->
-      KET.masc_schemas_ref := schemas;
-      f ())
+  KET.with_masc_schemas_for_test schemas f
 
 let test_dashboard_tool_count_uses_schema_ssot () =
   let bridge_name = "mcp__masc__masc_status" in

--- a/test/test_tool_registration_consistency.ml
+++ b/test/test_tool_registration_consistency.ml
@@ -271,11 +271,7 @@ let test_tool_registration_check_does_not_depend_on_injected_masc_schemas () =
   | Error msg ->
       Alcotest.failf "failed to load tool policy config: %s" msg
   | Ok () ->
-      let saved = !(Keeper_exec_tools.masc_schemas_ref) in
-      Fun.protect
-        ~finally:(fun () -> Keeper_exec_tools.masc_schemas_ref := saved)
-        (fun () ->
-          Keeper_exec_tools.masc_schemas_ref := [];
+      Keeper_exec_tools.with_masc_schemas_for_test [] (fun () ->
           let validation = Tool_registration_check.validate () in
           let masc_orphans =
             validation.Tool_registration_check.orphan_toml


### PR DESCRIPTION
## Summary

- Replace the public `masc_schemas_ref` mutation surface with mutex-protected schema setter/snapshot functions.
- Route keeper policy, tool suggestions, run-tool discovery, and tests through immutable schema snapshots.
- Add a scoped schema override helper for tests that need synthetic injected MASC tools.

## Product impact

- Removes a remaining raw shared-state surface from keeper tool registration. Runtime readers no longer dereference a public mutable ref while startup or tests replace the injected `masc_*` schema set.
- Preserves existing startup behavior through `inject_masc_schemas`, but makes the read path snapshot-based and race-resistant.

## Evidence

- Verified current `origin/main` still exposed `masc_schemas_ref` through `keeper_tool_registry.mli` and `keeper_exec_tools.mli` before this patch.
- `rg -n "masc_schemas_ref|val masc_schemas_ref|!.*masc_schemas|masc_schemas.*:=" lib test --glob "!_build/**"` now only finds the protected internal state assignments/read in `keeper_tool_registry.ml`.
- `ocamlc -stop-after parsing lib/keeper/keeper_tool_registry.mli lib/keeper/keeper_tool_registry.ml lib/keeper/keeper_exec_tools.mli lib/keeper/keeper_tool_policy.ml lib/keeper/keeper_exec_tools.ml lib/keeper/keeper_run_tools.ml test/test_tool_registration_consistency.ml test/test_keeper_masc_bridge.ml`
- `scripts/dune-local.sh build test/test_keeper_masc_bridge.exe test/test_tool_registration_consistency.exe test/test_keeper_tool_exposure.exe bin/main_eio.exe`
- `./_build/default/test/test_keeper_masc_bridge.exe` PASS, 30 tests
- `./_build/default/test/test_tool_registration_consistency.exe` PASS, 13 tests
- `./_build/default/test/test_keeper_tool_exposure.exe` PASS, 65 tests
- `scripts/dune-local.sh build test/test_keeper_tools_oas.exe`
- `./_build/default/test/test_keeper_tools_oas.exe` PASS, 35 tests
- `git diff --check origin/main...HEAD`
- `bash scripts/ci/check-silent-failure-patterns.sh` PASS, no critical silent failures detected

## GOAL LOOP ACT checklist

- [x] Observe — Kimi audit item flagged `masc_schemas_ref` as a shared startup/runtime race surface.
- [x] Orient — injected schema writes are startup/test events, while keeper policy and tool discovery read the same state during runtime.
- [x] Decide — keep a global schema store but protect replacement/read with `Stdlib.Mutex` and expose snapshots instead of a mutable ref.
- [x] Act — updated registry API, policy/read sites, run-tool discovery, and tests.
- [x] Verify — parser checks, focused Dune builds, focused executables, diff check, and silent-failure scan passed locally.
- [x] Loop — broader Kimi cleanup remains ongoing; this PR only closes the injected MASC schema raw-ref slice.

## Review evidence

- Not run: no cross-model review for this bounded schema state hardening patch.

## Linked issue

- Relates: Kimi audit follow-up; no GitHub issue number.

## Variant addition checklist

- [ ] **OCaml** — N/A: no variant added, removed, or renamed.
- [ ] **TypeScript** — N/A: no TypeScript union member changed.
- [ ] **TLA+ spec** — N/A: no TLA+ domain literal changed.
- [ ] **Event / JSON schema** — N/A: no event or JSON schema enum changed.
- [ ] **`make check-variants` passes** — N/A: no variant surface changed.
