### PR TITLE
fix(keeper): idempotent recovery on gh pr create "already exists"

### DIFF
--- a/lib/keeper/keeper_tool_github_pr.ml
+++ b/lib/keeper/keeper_tool_github_pr.ml
@@ -169,6 +169,27 @@ let pr_create_failure_may_have_created_pr output =
       "i/o timeout";
     ]
 
+(* gh CLI verbatim prefix when a PR for the same head already exists:
+   "a pull request for branch \"<owner:branch>\" into branch \"<base>\"
+    already exists:\n<url>\n"
+   Match the leading clause case-insensitively so future gh versions with
+   minor wording shifts still classify correctly. *)
+let pr_create_failure_already_exists output =
+  let output = String.lowercase_ascii output in
+  contains_substring output "a pull request for branch"
+  && contains_substring output "already exists"
+
+(* Recovery reason classifier — returned alongside the recovery result so
+   observers can distinguish a transient retry-style recovery (504/timeout)
+   from a deterministic idempotency hit (PR already exists). *)
+let classify_pr_create_recovery output =
+  if pr_create_failure_already_exists output then
+    Some "pr_already_exists"
+  else if pr_create_failure_may_have_created_pr output then
+    Some "pr_create_transient_failure"
+  else
+    None
+
 type gh_exec_result =
   { status : Unix.process_status
   ; output : string
@@ -263,24 +284,25 @@ let run_gh ?recover_pr_create ~tool ~operation ~config ~meta ~args ~write argv =
           let result_ok = status_ok result.status in
           let recovered =
             match recover_pr_create with
-            | Some (repo, head)
-              when (not result_ok)
-                   && pr_create_failure_may_have_created_pr result.output ->
-                let recovery =
-                  run_gh_argv ~config ~meta ~env ~cwd ~timeout_sec
-                    (build_pr_view_recovery_argv ~repo ~head)
-                in
-                if status_ok recovery.status then Some recovery else None
+            | Some (repo, head) when not result_ok -> (
+                match classify_pr_create_recovery result.output with
+                | None -> None
+                | Some reason ->
+                    let recovery =
+                      run_gh_argv ~config ~meta ~env ~cwd ~timeout_sec
+                        (build_pr_view_recovery_argv ~repo ~head)
+                    in
+                    if status_ok recovery.status then Some (recovery, reason)
+                    else None)
             | _ -> None
           in
           (match recovered with
-           | Some recovery ->
+           | Some (recovery, reason) ->
                output_json ~ok:true ~tool ~operation ~meta ~binding ~state
                  ~cwd ~via:recovery.via ~output:recovery.output
                  ~extra_fields:
                    [
-                     ( "recovered_from_error",
-                       `String "pr_create_transient_failure" );
+                     "recovered_from_error", `String reason;
                      "original_ok", `Bool false;
                      "original_output", `String result.output;
                      "recovery_tool", `String "gh pr view";
@@ -344,6 +366,8 @@ module For_testing = struct
   let draft_request_allowed = draft_request_allowed
   let pr_create_failure_may_have_created_pr =
     pr_create_failure_may_have_created_pr
+  let pr_create_failure_already_exists = pr_create_failure_already_exists
+  let classify_pr_create_recovery = classify_pr_create_recovery
 
   let quote_argv = quote_argv
   let mutation_preset_ok = mutation_preset_ok

--- a/lib/keeper/keeper_tool_github_pr.mli
+++ b/lib/keeper/keeper_tool_github_pr.mli
@@ -46,4 +46,17 @@ module For_testing : sig
       regression tests can pin the visible/callable contract: any preset
       that grants the [github] group in [config/tool_policy.toml] must
       return [true] here. *)
+
+  val pr_create_failure_already_exists : string -> bool
+  (** [true] when [output] matches the gh CLI verbatim
+      "a pull request for branch ... already exists" prefix. Exposed so
+      tests can pin the classifier wording independently of the recovery
+      path. *)
+
+  val classify_pr_create_recovery : string -> string option
+  (** Recovery reason classifier. Returns [Some "pr_already_exists"] for
+      idempotent hits, [Some "pr_create_transient_failure"] for 504/timeout
+      patterns, or [None] when the output is not recoverable. The string
+      identifier is what gets emitted as [recovered_from_error] in the
+      keeper_pr_create JSON output. *)
 end

--- a/test/test_keeper_github_pr.ml
+++ b/test/test_keeper_github_pr.ml
@@ -371,6 +371,64 @@ let test_pr_create_recovers_visible_pr_after_transient_504 () =
   check bool "returns recovered PR metadata" true
     (contains_substring raw "https://github.com/jeong-sik/masc-mcp/pull/13799")
 
+(* Classifier-level pin: gh CLI's verbatim "a pull request for branch ...
+   already exists" prefix must classify as the deterministic
+   [pr_already_exists] recovery reason; transient 504/timeout payloads
+   continue to map to [pr_create_transient_failure]; unrelated payloads
+   stay [None]. Verifier loop regression evidence (2026-05-07): keeper
+   keeper_pr_create returned the verbatim payload across 6+ turns,
+   inflating the consecutive-failure counter until the OAS 900s budget
+   tripped and the keeper auto-paused.
+
+   The integration path (handle_keeper_pr_create end-to-end through
+   Process_eio brokered route) is exercised separately by the existing
+   504 test; classifier-only unit tests here pin the wording contract
+   without depending on that path. *)
+let already_exists_payload =
+  "a pull request for branch \"yousleepwhen:feature/dup\" into branch \
+   \"main\" already exists:\n\
+   https://github.com/jeong-sik/masc-mcp/pull/13930\n"
+
+let already_exists_payload_uppercase =
+  "A Pull Request For Branch \"yousleepwhen:feature/dup\" into branch \
+   \"main\" Already Exists:\n\
+   https://github.com/jeong-sik/masc-mcp/pull/13930\n"
+
+let transient_504_payload =
+  "pull request create failed: HTTP 504: 504 Gateway Timeout \
+   (https://api.github.com/graphql)\n"
+
+let unrelated_failure_payload =
+  "pull request create failed: GraphQL: Resource not accessible by \
+   integration (createPullRequest)\n"
+
+let test_classifier_already_exists_matches_verbatim_payload () =
+  check bool "verbatim already-exists matches" true
+    (K.For_testing.pr_create_failure_already_exists already_exists_payload);
+  check bool "case-insensitive already-exists matches" true
+    (K.For_testing.pr_create_failure_already_exists
+       already_exists_payload_uppercase);
+  check bool "504 payload does not match already-exists" false
+    (K.For_testing.pr_create_failure_already_exists transient_504_payload);
+  check bool "unrelated failure does not match already-exists" false
+    (K.For_testing.pr_create_failure_already_exists unrelated_failure_payload);
+  check bool "empty payload does not match already-exists" false
+    (K.For_testing.pr_create_failure_already_exists "")
+
+let test_classifier_recovery_reason_routing () =
+  check (option string) "already-exists routes to pr_already_exists"
+    (Some "pr_already_exists")
+    (K.For_testing.classify_pr_create_recovery already_exists_payload);
+  check (option string) "504 routes to pr_create_transient_failure"
+    (Some "pr_create_transient_failure")
+    (K.For_testing.classify_pr_create_recovery transient_504_payload);
+  check (option string) "unrelated failure does not classify"
+    None
+    (K.For_testing.classify_pr_create_recovery unrelated_failure_payload);
+  check (option string) "empty payload does not classify"
+    None
+    (K.For_testing.classify_pr_create_recovery "")
+
 (* Regression: any preset that grants the [github] group in
    config/tool_policy.toml must satisfy [mutation_preset_ok]. Without
    this, [keeper_pr_create] is visible in the keeper tool surface but
@@ -425,6 +483,13 @@ let () =
             test_pr_create_hard_mode_routes_through_broker;
           test_case "pr create recovers visible PR after transient 504" `Quick
             test_pr_create_recovers_visible_pr_after_transient_504;
+        ] );
+      ( "recovery_classifier",
+        [
+          test_case "already-exists wording matches verbatim" `Quick
+            test_classifier_already_exists_matches_verbatim_payload;
+          test_case "recovery reason routes by payload" `Quick
+            test_classifier_recovery_reason_routing;
         ] );
       ( "preset_gate",
         [

--- a/test/test_keeper_github_pr.ml
+++ b/test/test_keeper_github_pr.ml
@@ -146,6 +146,14 @@ let fake_gh_echo_script =
 
 let fake_gh_pr_create_504_then_view_script =
   "#!/bin/sh\n\
+   if [ \"$1\" = \"auth\" ] && [ \"$2\" = \"status\" ]; then\n\
+   \  printf 'github.com\\n'\n\
+   \  exit 0\n\
+   fi\n\
+   if [ \"$1\" = \"api\" ] && [ \"$2\" = \"graphql\" ]; then\n\
+   \  printf 'test-user\\n'\n\
+   \  exit 0\n\
+   fi\n\
    if [ \"$1\" = \"pr\" ] && [ \"$2\" = \"create\" ]; then\n\
    \  printf 'pull request create failed: HTTP 504: 504 Gateway Timeout (https://api.github.com/graphql)\\n' >&2\n\
    \  exit 1\n\
@@ -402,6 +410,9 @@ let unrelated_failure_payload =
   "pull request create failed: GraphQL: Resource not accessible by \
    integration (createPullRequest)\n"
 
+let non_pr_already_exists_payload =
+  "git push failed: remote ref already exists for refs/heads/feature/dup\n"
+
 let test_classifier_already_exists_matches_verbatim_payload () =
   check bool "verbatim already-exists matches" true
     (K.For_testing.pr_create_failure_already_exists already_exists_payload);
@@ -412,6 +423,9 @@ let test_classifier_already_exists_matches_verbatim_payload () =
     (K.For_testing.pr_create_failure_already_exists transient_504_payload);
   check bool "unrelated failure does not match already-exists" false
     (K.For_testing.pr_create_failure_already_exists unrelated_failure_payload);
+  check bool "non-PR already-exists does not match" false
+    (K.For_testing.pr_create_failure_already_exists
+       non_pr_already_exists_payload);
   check bool "empty payload does not match already-exists" false
     (K.For_testing.pr_create_failure_already_exists "")
 
@@ -425,6 +439,9 @@ let test_classifier_recovery_reason_routing () =
   check (option string) "unrelated failure does not classify"
     None
     (K.For_testing.classify_pr_create_recovery unrelated_failure_payload);
+  check (option string) "non-PR already-exists does not classify"
+    None
+    (K.For_testing.classify_pr_create_recovery non_pr_already_exists_payload);
   check (option string) "empty payload does not classify"
     None
     (K.For_testing.classify_pr_create_recovery "")


### PR DESCRIPTION
## Summary

`gh pr create`가 동일 head ref의 기존 PR로 인해 "already exists" 에러를 반환할 때, 기존 PR을 `gh pr view`로 조회해 idempotent success로 복구합니다. 2026-05-07 verifier 무한 루프(turn=288~296, OAS 900s budget 소진 후 keeper auto-pause)의 직접 원인을 차단합니다.

## 문제

```
[2026-05-07 02:06:53] [ERROR] [Keeper] tool keeper_pr_create returned error result (1/3):
{"ok":false,"error":"a pull request for branch ... already exists:\nhttps://github.com/jeong-sik/masc-mcp/pull/13930\n", ...}
```

이전 turn에 PR을 생성한 뒤, 이후 turn마다 동일 에러로 retry counter (1/3 → 2/3 → 3/3) 누적. 6+ turn 반복 후 `keeper_llm_bridge: OAS execution timed out after 900.0s` 발생, verifier auto-paused.

## 변경

- `pr_create_failure_already_exists output : bool` — gh CLI의 "a pull request for branch ... already exists" prefix를 case-insensitive 매칭
- `classify_pr_create_recovery output : string option` — `pr_already_exists | pr_create_transient_failure | None` 분류기. 504/timeout 복구와 동일한 `gh pr view <head>` 경로 재사용
- `run_gh`의 recovery 분기에서 분류기를 사용해 두 경로 통합. `recovered_from_error` extra field에 분류 결과 그대로 emit (audit-trail로 idempotent vs transient 구분 가능)
- 단위 테스트 2개:
  - `already-exists wording matches verbatim` — case-insensitive 매칭, 504/unrelated/empty 음성 케이스
  - `recovery reason routes by payload` — already-exists / 504 / unrelated / empty payload별 분류 결과 핀

## 왜 이렇게 작은가

기존 504 transient recovery 인프라(`recover_pr_create`, `pr_create_failure_may_have_created_pr`, `build_pr_view_recovery_argv`)가 이미 검증된 path. 새 코드 path 0개, 분기 1개 추가. RFC-0007 §3 PR-2의 `gh_exit_class` 구조화에서 `Pr_already_exists` variant를 미리 enumerate하는 의미도 있음.

## RFC

`RFC-WAIVED: incremental implementation of RFC-0007 §3 PR-2 — enumerates Pr_already_exists ahead of full gh_exit_class carrier`

본 PR이 다루는 영역(`lib/keeper/keeper_tool_github_pr.ml`)은 RFC-0007 §3 PR-2 (gh_exit_class 구조화)의 prior art. PR-2의 핵심 enumerate 작업은 광범위한 type 도입을 동반하므로 별도 PR로 진행, 본 fix는 그 spirit을 유지하며 verifier 루프의 직접 원인만 차단합니다.

## Test plan

- [x] `dune build` 통과
- [x] 신규 단위 테스트 `recovery_classifier` 그룹 (2 케이스, 9개 assertion) 통과
- [x] 기존 `argv` / `docker_route routes through docker` / `hard mode routes through broker` / `preset_gate` 테스트 회귀 없음
- [ ] 기존 `docker_route pr create recovers visible PR after transient 504` 테스트는 main에서도 동일하게 실패 — 본 PR과 무관한 pre-existing 이슈 (Process_eio brokered path의 stderr 캡처 시점 문제로 추정). 별도 이슈로 추적 필요
- [ ] 향후 fleet에서 verifier 류 keeper의 consecutive-failure counter 회복 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)