### PR TITLE
fix(keeper): serialize budget strike updates

### DIFF
--- a/lib/keeper/keeper_turn_slot.ml
+++ b/lib/keeper/keeper_turn_slot.ml
@@ -728,17 +728,19 @@ let oas_timeout_budget_strike_limit = 3
 
 module Budget_strike_map = Map.Make (String)
 
-let budget_exhaustions : int Budget_strike_map.t Atomic.t =
-  Atomic.make Budget_strike_map.empty
+let budget_exhaustions : int Budget_strike_map.t ref =
+  ref Budget_strike_map.empty
+
+(* Stdlib.Mutex: this is a global, pure, non-yielding critical section and
+   the test helpers can run outside an Eio context. *)
+let budget_exhaustions_mutex = Stdlib.Mutex.create ()
 
 let update_budget_exhaustions f =
-  let rec loop () =
-    let current = Atomic.get budget_exhaustions in
+  Stdlib.Mutex.protect budget_exhaustions_mutex (fun () ->
+    let current = !budget_exhaustions in
     let next, result = f current in
-    if Atomic.compare_and_set budget_exhaustions current next then result
-    else loop ()
-  in
-  loop ()
+    budget_exhaustions := next;
+    result)
 
 let bump_budget_exhaustion_seeded ~keeper_name ~prior_strikes : int =
   let prior_strikes = max 0 prior_strikes in
@@ -758,8 +760,9 @@ let reset_budget_exhaustion ~keeper_name : unit =
     (Budget_strike_map.remove keeper_name current, ()))
 
 let peek_budget_exhaustion_for_test ~keeper_name : int =
-  Budget_strike_map.find_opt keeper_name (Atomic.get budget_exhaustions)
-  |> Option.value ~default:0
+  Stdlib.Mutex.protect budget_exhaustions_mutex (fun () ->
+    Budget_strike_map.find_opt keeper_name !budget_exhaustions
+    |> Option.value ~default:0)
 
 let set_budget_exhaustion_for_test ~keeper_name ~strikes : unit =
   if strikes <= 0 then reset_budget_exhaustion ~keeper_name

--- a/test/test_oas_timeout_budget_strike.ml
+++ b/test/test_oas_timeout_budget_strike.ml
@@ -42,6 +42,24 @@ let test_reset_clears () =
   Alcotest.(check int) "reset clears" 0
     (KK.peek_budget_exhaustion_for_test ~keeper_name:"reset")
 
+let test_parallel_bumps_preserve_all_updates () =
+  let keeper_name = "parallel" in
+  let workers = 4 in
+  let bumps_per_worker = 250 in
+  with_reset keeper_name (fun () ->
+    let domains =
+      List.init workers (fun _ ->
+        Domain.spawn (fun () ->
+          for _ = 1 to bumps_per_worker do
+            ignore (KK.bump_budget_exhaustion ~keeper_name : int)
+          done))
+    in
+    List.iter Domain.join domains;
+    Alcotest.(check int)
+      "all domain-local bumps are preserved"
+      (workers * bumps_per_worker)
+      (KK.peek_budget_exhaustion_for_test ~keeper_name))
+
 let () =
   Alcotest.run "oas_timeout_budget_strike"
   [
@@ -54,5 +72,7 @@ let () =
         Alcotest.test_case "seeded bump uses higher persisted count" `Quick
           test_seeded_bump_uses_higher_persisted_count;
         Alcotest.test_case "reset clears" `Quick test_reset_clears;
+        Alcotest.test_case "parallel bumps preserve all updates" `Quick
+          test_parallel_bumps_preserve_all_updates;
       ] );
   ]


### PR DESCRIPTION
## Summary
- replace the budget-exhaustion CAS retry loop with a Stdlib.Mutex-protected map update
- keep the strike API semantics unchanged for seeded bumps, resets, and peeks
- add a multi-domain regression that verifies parallel bumps preserve every update

## Why it matters
The Kimi audit flagged this ledger as a CAS spin point in the keeper turn path. The update is a tiny pure critical section, so a mutex is simpler and avoids retry CPU churn under contention while remaining safe for test helpers that run outside an Eio context.

## Local evidence
- ocamlc -stop-after parsing lib/keeper/keeper_turn_slot.ml test/test_oas_timeout_budget_strike.ml
- scripts/dune-local.sh build test/test_oas_timeout_budget_strike.exe bin/main_eio.exe
- ./_build/default/test/test_oas_timeout_budget_strike.exe (5 tests)
- git diff --check origin/main...HEAD
- bash scripts/ci/check-silent-failure-patterns.sh
