### PR TITLE
fix(keeper): preflight async keeper messages

### DIFF
--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -161,6 +161,45 @@ let keeper_msg_timeout_override args =
       Ok (Some timeout_sec)
   | Some _ -> Error "timeout_sec must be a positive finite number"
 
+let preflight_keeper_msg ctx args : (unit, string) result =
+  let name = get_string args "name" "" in
+  let message = get_string args "message" "" in
+  if not (validate_name name) then
+    Error "invalid keeper name"
+  else if message = "" then
+    Error "message is required"
+  else
+    let direct_reply = get_bool args "direct_reply" false in
+    match keeper_msg_timeout_override args with
+    | Error e -> Error e
+    | Ok _ ->
+    (match reject_legacy_model_args ~tool_name:"masc_keeper_msg" args with
+    | Error e -> Error ("" ^ e)
+    | Ok () ->
+    (match reject_removed_keeper_input_keys ~tool_name:"masc_keeper_msg" args with
+    | Error e -> Error ("" ^ e)
+    | Ok () ->
+    (match reject_removed_keeper_msg_input_keys ~tool_name:"masc_keeper_msg" args with
+    | Error e -> Error ("" ^ e)
+    | Ok () ->
+    match ensure_keeper_exists ~ctx ~name with
+    | Error e -> Error ("" ^ e)
+    | Ok meta ->
+      match resolve_turn_cascade_name meta with
+      | Error e -> Error e
+      | Ok turn_cascade_name ->
+        let effective_models =
+          if direct_reply then
+            Cascade_runtime.models_of_cascade_name
+              (Keeper_cascade_profile.Runtime_name turn_cascade_name)
+          else
+            effective_model_labels_for_turn meta
+        in
+        match ensure_api_keys_for_labels effective_models with
+        | Error e -> Error ("" ^ e)
+        | Ok () ->
+          Keeper_turn_helpers.ensure_local_discovery_ready effective_models)))
+
 (* -- handle_keeper_msg: orchestrator ---------------------------------------- *)
 
 let handle_keeper_msg ?on_text_delta ctx args : tool_result =

--- a/lib/keeper/keeper_turn.mli
+++ b/lib/keeper/keeper_turn.mli
@@ -20,6 +20,11 @@ val handle_keeper_up : _ Keeper_types.context -> Yojson.Safe.t -> tool_result
     If streaming fails, the function falls back to batch automatically.
 
     @since 2.110.0 *)
+val preflight_keeper_msg :
+  _ Keeper_types.context -> Yojson.Safe.t -> (unit, string) result
+(** Run synchronous validation for [handle_keeper_msg] before an async wrapper
+    accepts the turn for later execution. *)
+
 val handle_keeper_msg :
   ?on_text_delta:(string -> unit) ->
   _ Keeper_types.context -> Yojson.Safe.t -> tool_result

--- a/lib/keeper/keeper_turn_helpers.ml
+++ b/lib/keeper/keeper_turn_helpers.ml
@@ -301,16 +301,29 @@ let record_pre_dispatch_terminal_observation
         ~side_effect:(activity_kind ^ " emit")
         (Printexc.to_string exn))
 
+let local_discovery_refresh_for_test :
+    (string list -> bool) option Atomic.t =
+  Atomic.make None
+
 let ensure_local_discovery_ready
     ?refresh
     (labels : string list) : (unit, string) result =
+  let refresh_for_test = Atomic.get local_discovery_refresh_for_test in
   let refresh =
     match refresh with
     | Some f -> f
-    | None -> fun labels ->
-        Cascade_runtime.refresh_local_discovery_if_possible labels
+    | None ->
+        (match refresh_for_test with
+        | Some f -> f
+        | None -> fun labels ->
+            Cascade_runtime.refresh_local_discovery_if_possible labels)
   in
-  if not (Cascade_runtime.labels_require_local_discovery labels)
+  let should_refresh =
+    match refresh_for_test with
+    | Some _ -> true
+    | None -> Cascade_runtime.labels_require_local_discovery labels
+  in
+  if not should_refresh
   then Ok ()
   else
     try
@@ -329,3 +342,13 @@ let ensure_local_discovery_ready
              "local discovery refresh raised for labels [%s]: %s"
              (String.concat ", " labels)
              (Printexc.to_string exn))
+
+module For_testing = struct
+  let with_local_discovery_refresh refresh f =
+    let previous = Atomic.get local_discovery_refresh_for_test in
+    Atomic.set local_discovery_refresh_for_test (Some refresh);
+    Fun.protect
+      ~finally:(fun () ->
+        Atomic.set local_discovery_refresh_for_test previous)
+      f
+end

--- a/lib/keeper/keeper_turn_helpers.mli
+++ b/lib/keeper/keeper_turn_helpers.mli
@@ -87,3 +87,10 @@ val ensure_local_discovery_ready :
   (unit, string) result
 (** Ensure local-provider discovery is refreshed before a turn when the
     selected labels depend on runtime discovery. *)
+
+module For_testing : sig
+  val with_local_discovery_refresh :
+    (string list -> bool) -> (unit -> 'a) -> 'a
+  (** Install a scoped refresh override and force the discovery branch for
+      deterministic preflight tests. *)
+end

--- a/lib/tool_keeper.ml
+++ b/lib/tool_keeper.ml
@@ -464,6 +464,9 @@ let handle_keeper_msg ctx args : tool_result =
   | Error err -> (false, err)
   | Ok name ->
       let resolved_args = with_keeper_name args name in
+      (match Turn.preflight_keeper_msg ctx resolved_args with
+      | Error err -> (false, err)
+      | Ok () ->
       let request_id = Keeper_msg_async.submit ~sw:ctx.sw
         ~keeper_name:name
         ~f:(fun () ->
@@ -480,7 +483,7 @@ let handle_keeper_msg ctx args : tool_result =
         ("status", `String "queued");
         ("message", `String "Keeper turn submitted. Poll with keeper_msg_result.");
       ] in
-      (true, Yojson.Safe.to_string json)
+      (true, Yojson.Safe.to_string json))
 
 let handle_keeper_msg_result _ctx args : tool_result =
   let request_id = get_string args "request_id" "" in

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -4336,6 +4336,7 @@ let test_keeper_msg_async_failure_surface () =
       KR.clear ();
       cleanup_dir base_dir)
     (fun () ->
+      with_test_runtime_roots base_dir @@ fun () ->
       let keeper_name = "msg-preflight" in
       let config = Masc_mcp.Coord.default_config base_dir in
       ignore (Masc_mcp.Coord.init config ~agent_name:(Some "operator"));

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -18,6 +18,7 @@ module KP = Masc_mcp.Keeper_state_machine
 module KD = Masc_mcp.Keeper_deliberation
 module AE = Masc_mcp.Agent_economy
 module KC = Masc_mcp.Keeper_config
+module KTH = Masc_mcp.Keeper_turn_helpers
 module HK = Masc_mcp.Keeper_hooks_oas
 module KG = Masc_mcp.Keeper_guards
 module OMR = Masc_mcp.Oas_model_resolve
@@ -4275,7 +4276,10 @@ let test_run_keeper_cycle_surfaces_side_effect_failures_source_contract () =
        "ensure_local_discovery_ready model_labels");
   check bool "manual keeper_msg discovery helper guards keeper setup" true
     (source_file_contains "lib/keeper/keeper_turn.ml"
-       "ensure_local_discovery_ready effective_models")
+       "ensure_local_discovery_ready effective_models");
+  check bool "manual keeper_msg async facade preflights before submit" true
+    (source_file_contains "lib/tool_keeper.ml"
+       "Turn.preflight_keeper_msg ctx resolved_args")
 
 let test_sync_keeper_paused_state_surfaces_write_failure_without_mutating_registry () =
   let base_dir = temp_dir () in
@@ -4321,6 +4325,54 @@ let test_ensure_local_discovery_ready_surfaces_refresh_failure () =
       check int "refresh called once" 1 !refresh_calls;
       check bool "error includes label" true
         (contains_substring msg "llama:auto")
+
+let test_keeper_msg_async_failure_surface () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  Eio.Switch.run @@ fun sw ->
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () ->
+      KR.clear ();
+      cleanup_dir base_dir)
+    (fun () ->
+      let keeper_name = "msg-preflight" in
+      let config = Masc_mcp.Coord.default_config base_dir in
+      ignore (Masc_mcp.Coord.init config ~agent_name:(Some "operator"));
+      let meta = make_meta keeper_name in
+      (match Masc_mcp.Keeper_types.write_meta ~force:true config meta with
+      | Ok () -> ()
+      | Error err -> fail ("write_meta failed: " ^ err));
+      let ctx : _ Masc_mcp.Tool_keeper.context =
+        {
+          config;
+          agent_name = "operator";
+          sw;
+          clock = Eio.Stdenv.clock env;
+          proc_mgr = Some (Eio.Stdenv.process_mgr env);
+          net = None;
+        }
+      in
+      KTH.For_testing.with_local_discovery_refresh
+        (fun _labels -> false)
+        (fun () ->
+          match
+            Masc_mcp.Tool_keeper.dispatch ctx ~name:"masc_keeper_msg"
+              ~args:
+                (`Assoc
+                   [
+                     ("name", `String keeper_name);
+                     ("message", `String "check discovery failure");
+                   ])
+          with
+          | Some (false, err) ->
+              if not
+                   (contains_substring err "local discovery refresh required"
+                    && contains_substring err "refresh failed")
+              then fail ("unexpected synchronous error: " ^ err)
+          | Some (true, body) ->
+              fail ("expected synchronous failure, got queued body: " ^ body)
+          | None -> fail "masc_keeper_msg dispatch missing"))
 
 let provider_config_of_label label =
   match Masc_mcp.Cascade_config.parse_model_string label with
@@ -8516,6 +8568,8 @@ let () =
             test_sync_keeper_paused_state_surfaces_write_failure_without_mutating_registry;
           test_case "local discovery guard surfaces refresh failure" `Quick
             test_ensure_local_discovery_ready_surfaces_refresh_failure;
+          test_case "async keeper_msg preflight surfaces discovery failure" `Quick
+            test_keeper_msg_async_failure_surface;
           test_case "local_only liveness decision keeps non-local route" `Quick
             test_decide_local_only_liveness_keeps_non_local_effective;
           test_case "local_only liveness decision keeps explicit local base"


### PR DESCRIPTION
## Summary
- add `Keeper_turn.preflight_keeper_msg` for synchronous keeper message validation before async queueing
- call preflight from the public `masc_keeper_msg` facade before `Keeper_msg_async.submit`
- add a scoped discovery-refresh test hook and a public dispatch regression proving discovery failures return `(false, err)` instead of queued JSON

Fixes #13757

## Validation
- PASS: `git diff --check HEAD~1 HEAD`
- PASS: `env DUNE_BUILD_DIR=_build_codex_13757_keeper_msg_preflight scripts/dune-local.sh build test/test_keeper_unified.exe`
- PASS: `./_build_codex_13757_keeper_msg_preflight/default/test/test_keeper_unified.exe test phase_gate` (53 tests)