### PR TITLE
fix: count keeper side-effect failures

### DIFF
--- a/lib/keeper/keeper_turn_helpers.ml
+++ b/lib/keeper/keeper_turn_helpers.ml
@@ -46,6 +46,17 @@ let string_contains_substring_ci ~(needle : string) (haystack : string) : bool =
       ~needle:(String.lowercase_ascii needle)
     (String.lowercase_ascii haystack)
 
+let side_effect_metric_label side_effect =
+  let trimmed = String.trim side_effect in
+  let normalized =
+    String.map
+      (function
+        | ' ' | ':' | '/' -> '_'
+        | c -> c)
+      trimmed
+  in
+  if String.equal normalized "" then "unknown" else normalized
+
 let report_keeper_cycle_side_effect_issue
     ~(config : Coord.config)
     ~(keeper_name : string)
@@ -56,6 +67,13 @@ let report_keeper_cycle_side_effect_issue
     Printf.sprintf "keeper cycle %s failed: %s" side_effect detail
   in
   Keeper_registry.record_error ~base_path:config.base_path keeper_name message;
+  Prometheus.inc_counter
+    Prometheus.metric_keeper_dispatch_event_failures
+    ~labels:[
+      ("keeper", keeper_name);
+      ("site", side_effect_metric_label side_effect);
+    ]
+    ();
   match severity with
   | `Warn -> Log.Keeper.warn "%s: %s" keeper_name message
   | `Error -> Log.Keeper.error "%s: %s" keeper_name message

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -2140,8 +2140,9 @@ let init () =
      Labeled by kind."
     Counter;
   add metric_keeper_dispatch_event_failures
-    "Total keeper state machine dispatch_event failures in supervisor. \
-     Labeled by event type."
+    "Total keeper state-machine dispatch and keeper cycle side-effect \
+     failures. Labels include keeper plus site, event, or reason depending \
+     on the emitting path."
     Counter;
   add metric_keeper_directive_failures
     "Total gRPC directive routing failures — target agent not in registry \

--- a/test/dune
+++ b/test/dune
@@ -1200,6 +1200,7 @@
 (include stanzas/test_keeper_tool_policy_paths.inc)
 (include stanzas/test_keeper_turn_fsm_tla_parity.inc)
 (include stanzas/test_keeper_turn_livelock_10121.inc)
+(include stanzas/test_keeper_turn_helpers_side_effect_metric.inc)
 (include stanzas/test_keeper_turn_slot_force_release.inc)
 (include stanzas/test_keeper_turn_slot_holders.inc)
 (include stanzas/test_keeper_turn_slot_release_cancel_safe.inc)

--- a/test/stanzas/test_keeper_turn_helpers_side_effect_metric.inc
+++ b/test/stanzas/test_keeper_turn_helpers_side_effect_metric.inc
@@ -1,0 +1,4 @@
+(test
+ (name test_keeper_turn_helpers_side_effect_metric)
+ (modules test_keeper_turn_helpers_side_effect_metric)
+ (libraries masc_test_deps))

--- a/test/test_keeper_turn_helpers_side_effect_metric.ml
+++ b/test/test_keeper_turn_helpers_side_effect_metric.ml
@@ -1,0 +1,45 @@
+open Alcotest
+
+module Helpers = Masc_mcp.Keeper_turn_helpers
+module Prometheus = Masc_mcp.Prometheus
+
+let test_side_effect_issue_increments_failure_metric () =
+  let keeper_name = "side-effect-metric-keeper-0507" in
+  let labels =
+    [ ("keeper", keeper_name); ("site", "trajectory_finalize") ]
+  in
+  let before =
+    Prometheus.metric_value_or_zero
+      Prometheus.metric_keeper_dispatch_event_failures
+      ~labels
+      ()
+  in
+  let config =
+    Masc_mcp.Coord.default_config
+      (Filename.concat (Filename.get_temp_dir_name ())
+         "masc-side-effect-metric-0507")
+  in
+  Helpers.report_keeper_cycle_side_effect_issue
+    ~config
+    ~keeper_name
+    ~side_effect:"trajectory finalize"
+    "test failure";
+  let after =
+    Prometheus.metric_value_or_zero
+      Prometheus.metric_keeper_dispatch_event_failures
+      ~labels
+      ()
+  in
+  check (float 0.0001) "side-effect metric increments"
+    (before +. 1.0)
+    after
+
+let () =
+  run "keeper_turn_helpers_side_effect_metric"
+    [
+      ( "side_effect_metric",
+        [
+          test_case "report side-effect issue increments metric" `Quick
+            test_side_effect_issue_increments_failure_metric;
+        ] );
+    ]


### PR DESCRIPTION
## Summary
- count keeper cycle side-effect failures through the existing dispatch failure metric
- normalize side-effect names into bounded site labels
- add a focused test for report_keeper_cycle_side_effect_issue metric visibility

## Validation
- git diff --check
- scripts/dune-local.sh build test/test_keeper_turn_helpers_side_effect_metric.exe
- _build/default/test/test_keeper_turn_helpers_side_effect_metric.exe (1 test)