### PR TITLE
fix(keeper): classify specific tool contract failures

### DIFF
--- a/lib/keeper/keeper_error_classify.ml
+++ b/lib/keeper/keeper_error_classify.ml
@@ -91,8 +91,13 @@ let is_server_rejected_parse_error (err : Agent_sdk.Error.sdk_error) : bool =
 
 let is_required_tool_contract_violation (err : Agent_sdk.Error.sdk_error) : bool =
   match err with
-  | Agent_sdk.Error.Agent (Agent_sdk.Error.CompletionContractViolation { contract; _ }) ->
-      contract = Agent_sdk.Completion_contract_id.Require_tool_use
+  | Agent_sdk.Error.Agent
+      (Agent_sdk.Error.CompletionContractViolation
+         { contract = Agent_sdk.Completion_contract_id.Require_tool_use; _ })
+  | Agent_sdk.Error.Agent
+      (Agent_sdk.Error.CompletionContractViolation
+         { contract = Agent_sdk.Completion_contract_id.Require_specific_tool _; _ }) ->
+      true
   | _ -> false
 
 let is_auto_recoverable_cascade_exhausted_error (err : Agent_sdk.Error.sdk_error) : bool =

--- a/lib/keeper/keeper_error_classify.mli
+++ b/lib/keeper/keeper_error_classify.mli
@@ -20,8 +20,9 @@ val is_structural_oas_timeout_message : string -> bool
     of requiring manual reconcile. *)
 val is_server_rejected_parse_error : Agent_sdk.Error.sdk_error -> bool
 
-(** [true] when the provider/tooling violated a required tool-use contract
-    by returning text/no-op where a ToolUse block was required. *)
+(** [true] when the provider/tooling violated a required tool-use contract,
+    either for any ToolUse block or for one specific ToolUse block, by
+    returning text/no-op where that ToolUse block was required. *)
 val is_required_tool_contract_violation : Agent_sdk.Error.sdk_error -> bool
 
 (** [true] when the keeper should preserve liveness and skip consecutive

--- a/lib/keeper/keeper_runtime_contract.ml
+++ b/lib/keeper/keeper_runtime_contract.ml
@@ -65,7 +65,8 @@ let active_goal_ids_have_eligible_claim_task
             task)
 
 let resolve_claim_goal_scope ?agent_tool_names
-    ?(allow_empty_goal_scope_fallback = false) ~(config : Coord.config)
+    ?(allow_empty_goal_scope_fallback = false)
+    ?(allow_auto_goal_scope_fallback = false) ~(config : Coord.config)
     ~(meta : keeper_meta) () =
   match meta.active_goal_ids with
   | [] ->
@@ -77,6 +78,9 @@ let resolve_claim_goal_scope ?agent_tool_names
       }
   | goal_ids ->
       let scoped_filter task = task_is_linked_to_keeper_goals goal_ids task in
+      let is_auto_goal =
+        active_goal_ids_are_auto_keeper_goals config ~meta goal_ids
+      in
       if
         not
           (active_goal_ids_have_eligible_claim_task
@@ -84,10 +88,8 @@ let resolve_claim_goal_scope ?agent_tool_names
              config
              goal_ids)
       then
-        if allow_empty_goal_scope_fallback then
-          let is_auto_goal =
-            active_goal_ids_are_auto_keeper_goals config ~meta goal_ids
-          in
+        if allow_empty_goal_scope_fallback
+           || (allow_auto_goal_scope_fallback && is_auto_goal) then
           {
             task_filter = (fun (_task : Masc_domain.task) -> true);
             mode =

--- a/lib/keeper/keeper_runtime_contract.mli
+++ b/lib/keeper/keeper_runtime_contract.mli
@@ -14,10 +14,12 @@ type claim_goal_scope = {
 val resolve_claim_goal_scope :
   ?agent_tool_names:string list ->
   (** [allow_empty_goal_scope_fallback] should stay false for normal keeper
-      task claims. Auto-repaired keeper-purpose goals may still fall back to
-      all tasks; explicit persisted [active_goal_ids] stay scoped unless this
-      flag is set. *)
+      task claims. Explicit persisted [active_goal_ids] stay scoped unless
+      this flag is set. *)
   ?allow_empty_goal_scope_fallback:bool ->
+  (** [allow_auto_goal_scope_fallback] allows only auto-repaired
+      keeper-purpose goals to fall back to all tasks. *)
+  ?allow_auto_goal_scope_fallback:bool ->
   config:Coord.config ->
   meta:Keeper_types.keeper_meta ->
   unit ->

--- a/lib/keeper/keeper_turn_terminal.ml
+++ b/lib/keeper/keeper_turn_terminal.ml
@@ -115,7 +115,8 @@ let of_legacy_error_text raw_error =
     make ~source:"legacy_error_text" "oas_timeout_budget"
   else if contains_ci trimmed "Turn wall-clock timeout" then
     make ~source:"legacy_error_text" "turn_wall_clock_timeout"
-  else if contains_ci trimmed "require_tool_use" then
+  else if contains_ci trimmed "require_tool_use"
+          || contains_ci trimmed "require_specific_tool" then
     make ~source:"legacy_error_text" (contract_code_from_error_text trimmed)
   else
     make ~source:"legacy_error_text" "unknown_error"
@@ -134,7 +135,12 @@ let of_failure ?(post_commit_ambiguous = false) ?(tool_call_count = 0)
         (match err with
          | Agent_sdk.Error.Agent
              (Agent_sdk.Error.CompletionContractViolation
-                { contract = Agent_sdk.Completion_contract_id.Require_tool_use; _ }) ->
+                { contract = Agent_sdk.Completion_contract_id.Require_tool_use; _ })
+         | Agent_sdk.Error.Agent
+             (Agent_sdk.Error.CompletionContractViolation
+                { contract =
+                    Agent_sdk.Completion_contract_id.Require_specific_tool _;
+                  _ }) ->
              let code =
                if tool_call_count <= 0 then
                  contract_code_from_error_text raw_error

--- a/lib/keeper/keeper_world_observation.ml
+++ b/lib/keeper/keeper_world_observation.ml
@@ -264,6 +264,7 @@ let claim_goal_scope_filter ?agent_tool_names ~(config : Coord.config)
     Keeper_runtime_contract.resolve_claim_goal_scope
       ?agent_tool_names
       ~allow_empty_goal_scope_fallback:false
+      ~allow_auto_goal_scope_fallback:true
       ~config
       ~meta
       ()

--- a/test/test_keeper_terminal_reason.ml
+++ b/test/test_keeper_terminal_reason.ml
@@ -262,6 +262,26 @@ let test_structured_required_tool_no_tool_call () =
   check (option string) "next action" (Some "inspect_provider_tool_contract")
     (terminal_next_action terminal)
 
+let test_structured_specific_required_tool_no_tool_call () =
+  let err =
+    Agent_sdk.Error.Agent
+      (Agent_sdk.Error.CompletionContractViolation
+         {
+           contract =
+             Agent_sdk.Completion_contract_id.Require_specific_tool
+               "keeper_pr_review_comment";
+           reason =
+             "required tool contract unsatisfied: tool_choice requested tool 'keeper_pr_review_comment', but the model returned no ToolUse block";
+         })
+  in
+  let terminal =
+    KT.of_failure ~raw_error:(Agent_sdk.Error.to_string err) err
+  in
+  check string "code" "required_tool_use_no_tool_call"
+    (terminal_code terminal);
+  check (option string) "next action" (Some "inspect_provider_tool_contract")
+    (terminal_next_action terminal)
+
 let test_structured_oas_timeout_budget () =
   let err =
     Masc_mcp.Oas_worker_named.sdk_error_of_masc_internal_error
@@ -360,6 +380,8 @@ let () =
 	        [
 	          test_case "required tool no tool call" `Quick
 	            test_structured_required_tool_no_tool_call;
+	          test_case "specific required tool no tool call" `Quick
+	            test_structured_specific_required_tool_no_tool_call;
 	          test_case "oas timeout budget" `Quick
 	            test_structured_oas_timeout_budget;
 	          test_case "turn wall-clock timeout" `Quick

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -4528,6 +4528,17 @@ let required_tool_contract_violation_error () =
            "required tool contract unsatisfied: tool_choice requested tool use, but the model returned no ToolUse block";
        })
 
+let required_specific_tool_contract_violation_error () =
+  Agent_sdk.Error.Agent
+    (CompletionContractViolation
+       {
+         contract =
+           Agent_sdk.Completion_contract_id.Require_specific_tool
+             "keeper_pr_review_comment";
+         reason =
+           "required tool contract unsatisfied: tool_choice requested tool 'keeper_pr_review_comment', but the model returned no ToolUse block";
+       })
+
 let expect_degraded_retry label expected_cascade expected_reason = function
   | Some (retry : EC.degraded_retry) ->
       check string (label ^ " cascade") expected_cascade retry.next_cascade;
@@ -5620,6 +5631,11 @@ let test_required_tool_contract_violation_detected () =
   check bool "tool-choice contract violation detected" true
     (EC.is_required_tool_contract_violation err)
 
+let test_required_specific_tool_contract_violation_detected () =
+  let err = required_specific_tool_contract_violation_error () in
+  check bool "specific tool-choice contract violation detected" true
+    (EC.is_required_tool_contract_violation err)
+
 let test_required_tool_contract_violation_ignores_legacy_internal_error () =
   let err =
     Agent_sdk.Error.Internal
@@ -5644,6 +5660,14 @@ let test_should_cap_rotation_does_not_fire_on_first_attempt () =
 let test_should_cap_rotation_fires_after_one_rotation () =
   let err = required_tool_contract_violation_error () in
   check bool "cap fires when one rotation has already been attempted" true
+    (EC.should_cap_rotation_for_contract_violation
+       ~attempted_cascades:[ "strict_exec"; KC.default_cascade_name ]
+       ~fallback_not_yet_tried:false
+       err)
+
+let test_should_cap_rotation_fires_for_specific_tool_after_one_rotation () =
+  let err = required_specific_tool_contract_violation_error () in
+  check bool "cap fires for specific-tool contract after one rotation" true
     (EC.should_cap_rotation_for_contract_violation
        ~attempted_cascades:[ "strict_exec"; KC.default_cascade_name ]
        ~fallback_not_yet_tried:false
@@ -8396,12 +8420,16 @@ let () =
             test_auto_recoverable_turn_error_includes_wrapped_max_turns;
           test_case "required tool contract violation detected from structured error" `Quick
             test_required_tool_contract_violation_detected;
+          test_case "specific required tool contract violation detected from structured error" `Quick
+            test_required_specific_tool_contract_violation_detected;
           test_case "legacy internal contract violation is ignored" `Quick
             test_required_tool_contract_violation_ignores_legacy_internal_error;
           test_case "rotation cap does not fire before first rotation" `Quick
             test_should_cap_rotation_does_not_fire_on_first_attempt;
           test_case "rotation cap fires after one rotation" `Quick
             test_should_cap_rotation_fires_after_one_rotation;
+          test_case "rotation cap fires for specific tool after one rotation" `Quick
+            test_should_cap_rotation_fires_for_specific_tool_after_one_rotation;
           test_case "rotation cap suppressed while fallback available" `Quick
             test_should_cap_rotation_suppressed_while_fallback_available;
           test_case "rotation cap ignores non-contract-violation errors" `Quick


### PR DESCRIPTION
## What changed

- Treat `Require_specific_tool _` completion-contract violations the same as required tool-use violations for keeper error classification and terminal reason mapping.
- Recognize legacy `require_specific_tool(...)` error text so failures like `keeper_pr_review_comment` no-ToolUse responses produce `required_tool_use_no_tool_call` instead of falling through as unknown.
- Split claim-scope fallback policy so world observation can surface auto-repaired keeper-goal fallback work, while `keeper_task_claim` still does not cross active goal scope unless an explicit fallback override is used.

## Why

The Docker keeper PR lifecycle hit a review resume failure for `sangsu`:

`Completion contract [require_specific_tool(keeper_pr_review_comment)] violated ... no ToolUse block`

The existing keeper recovery path only recognized `Require_tool_use`, so the specific-tool contract skipped the same rotation/cap/terminal classification used by required tool-use failures.

## Validation

- `git diff --check`
- `scripts/dune-local.sh build test/test_keeper_unified.exe test/test_keeper_terminal_reason.exe test/test_keeper_task_dispatch.exe`
- `./_build/default/test/test_keeper_unified.exe` (347 tests)
- `./_build/default/test/test_keeper_terminal_reason.exe` (33 tests)
- `./_build/default/test/test_keeper_task_dispatch.exe` (38 tests)
