### PR TITLE
fix(keeper): abort retries on unpaired tool completion

### DIFF
--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -609,8 +609,45 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
       let pending_tool_inputs : (string, Yojson.Safe.t Queue.t) Hashtbl.t =
         Hashtbl.create 8
       in
+      let tool_event_order_violation = ref None in
       let with_turn_event_bus_lock f =
         Eio.Mutex.use_rw ~protect:true turn_event_bus_mu f
+      in
+      let input_sensitive_mutation_tool tool_name =
+        match Tool_name.of_string tool_name with
+        | Some (Keeper Shell)
+        | Some (Masc Code_git) ->
+            true
+        | _ -> false
+      in
+      let mark_mutating_tool_committed tool_name =
+        if not (List.mem tool_name !mutating_tools_committed) then
+          mutating_tools_committed :=
+            tool_name :: !mutating_tools_committed
+      in
+      let record_tool_event_order_violation ~tool_name =
+        let detail =
+          Printf.sprintf
+            "ToolCompleted without matching ToolCalled for tool=%s"
+            tool_name
+        in
+        tool_event_order_violation := Some detail;
+        Log.Keeper.warn
+          "keeper:%s %s; treating tool as post-commit until retry safety can reconcile event order"
+          meta.name detail;
+        if
+          Keeper_exec_tools.has_mutating_side_effect tool_name
+          || input_sensitive_mutation_tool tool_name
+        then
+          mark_mutating_tool_committed tool_name
+      in
+      let tool_event_order_violation_error () =
+        Option.map
+          (fun detail ->
+            Agent_sdk.Error.Internal
+              (Printf.sprintf "keeper:%s event bus order violation: %s"
+                 meta.name detail))
+          !tool_event_order_violation
       in
       let push_pending_input tool_name input =
         let q =
@@ -642,27 +679,18 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
                   match input_opt with
                   | Some i -> i
                   | None ->
-                      (* P2 silent-failure fix: pop_pending_input returns
-                         None either when there's no queue for this tool
-                         name, or when the queue is empty.  Either case
-                         means a ToolCompleted arrived without a matching
-                         ToolCalled — likely a race or an OAS event-bus
-                         ordering bug.  Falling back to `Null` lets
-                         downstream `has_mutating_side_effect_with_input`
-                         continue, but it can undercount mutations.
-                         Logging surfaces the mismatch so it can be
-                         diagnosed instead of silently skewing audit data. *)
-                      Log.Keeper.debug
-                        "keeper:%s tool=%s ToolCompleted without matching ToolCalled — using Null input"
-                        meta.name tool_name;
-                      `Null
+                      record_tool_event_order_violation ~tool_name;
+                      `Assoc
+                        [
+                          ( "event_order_violation",
+                            `String "missing_tool_called" );
+                        ]
                 in
                 if
                   Keeper_exec_tools.has_mutating_side_effect_with_input
                     ~tool_name ~input
                 then
-                  mutating_tools_committed :=
-                    tool_name :: !mutating_tools_committed
+                  mark_mutating_tool_committed tool_name
             | Agent_sdk.Event_bus.ToolCompleted
                 { tool_name; output = Error _; _ } ->
                 (* Failed tool: drop the matching pending input. *)
@@ -1141,6 +1169,15 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
                     ~timeout_budget:!attempt_timeout_budget err
                 in
                 let _ = drain_turn_event_bus ~site:"reconcile_pre_check" () in
+                match tool_event_order_violation_error () with
+                | Some order_err ->
+                  Log.Keeper.error
+                    "%s: event-bus order violation after provider error; aborting retry path to avoid replaying an unpaired tool completion (original_error=%s)"
+                    meta.name
+                    (short_preview (Agent_sdk.Error.to_string err));
+                  mark_terminal_error order_err;
+                  Error order_err
+                | None ->
                 let committed_tools = committed_mutating_tools_snapshot () in
                 if committed_tools <> []
                    && Keeper_tool_registry.all_tools_reconcile_safe
@@ -1599,6 +1636,16 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
               ~labels:[("keeper", meta.name)]
               ();
             let _ = drain_turn_event_bus ~site:"error_path_drain" () in
+            (match tool_event_order_violation_error () with
+             | Some order_err ->
+               Log.Keeper.error
+                 "%s: event-bus order violation during timeout path; treating turn as failed before retry/reconcile decisions"
+                 meta.name;
+               Keeper_registry.set_turn_phase
+                 ~base_path:config.base_path meta.name
+                 Keeper_registry.Turn_finalizing;
+               Error order_err
+             | None ->
             let committed_tools = committed_mutating_tools_snapshot () in
             if committed_tools <> []
                && Keeper_tool_registry.all_tools_reconcile_safe
@@ -1670,7 +1717,7 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
                 (Oas_worker_named.sdk_error_of_masc_internal_error
                    (Oas_worker_named.Turn_timeout
                       { elapsed_sec = timeout_sec }))
-            end))
+            end)))
         with
         | result -> cleanup (); result
         | exception e ->

--- a/test/dune
+++ b/test/dune
@@ -1199,6 +1199,7 @@
 (include stanzas/test_keeper_tool_matrix.inc)
 (include stanzas/test_keeper_tool_policy_paths.inc)
 (include stanzas/test_keeper_turn_fsm_tla_parity.inc)
+(include stanzas/test_keeper_unified_tool_event_order_source.inc)
 (include stanzas/test_keeper_turn_livelock_10121.inc)
 (include stanzas/test_keeper_turn_slot_force_release.inc)
 (include stanzas/test_keeper_turn_slot_holders.inc)

--- a/test/stanzas/test_keeper_unified_tool_event_order_source.inc
+++ b/test/stanzas/test_keeper_unified_tool_event_order_source.inc
@@ -1,0 +1,3 @@
+(test
+ (name test_keeper_unified_tool_event_order_source)
+ (modules test_keeper_unified_tool_event_order_source))

--- a/test/test_keeper_unified_tool_event_order_source.ml
+++ b/test/test_keeper_unified_tool_event_order_source.ml
@@ -1,0 +1,55 @@
+let read_file path =
+  let ic = open_in path in
+  Fun.protect
+    ~finally:(fun () -> close_in_noerr ic)
+    (fun () -> In_channel.input_all ic)
+
+let contains haystack needle =
+  let n = String.length needle in
+  let h = String.length haystack in
+  let rec loop i =
+    if i + n > h then false
+    else if String.sub haystack i n = needle then true
+    else loop (i + 1)
+  in
+  loop 0
+
+let assert_contains ~label src needle =
+  if not (contains src needle) then
+    failwith (Printf.sprintf "%s: expected source to contain %S" label needle)
+
+let assert_not_contains ~label src needle =
+  if contains src needle then
+    failwith
+      (Printf.sprintf "%s: source must not contain %S" label needle)
+
+let source_path () =
+  let parent p = Filename.dirname p in
+  let exe = Sys.executable_name in
+  let project_root = parent (parent (parent (parent exe))) in
+  let candidates =
+    [
+      Filename.concat project_root "lib/keeper/keeper_unified_turn.ml";
+      "lib/keeper/keeper_unified_turn.ml";
+      "../lib/keeper/keeper_unified_turn.ml";
+      "../../lib/keeper/keeper_unified_turn.ml";
+    ]
+  in
+  match List.find_opt Sys.file_exists candidates with
+  | Some path -> path
+  | None ->
+      failwith
+        (Printf.sprintf
+           "keeper_unified_turn source path not found (cwd=%s exe=%s)"
+           (Sys.getcwd ()) exe)
+
+let () =
+  let src = read_file (source_path ()) in
+  assert_not_contains ~label:"no null fallback" src "using Null input";
+  assert_contains ~label:"order violation latch" src
+    "tool_event_order_violation_error";
+  assert_contains ~label:"input-sensitive conservative classification" src
+    "input_sensitive_mutation_tool";
+  assert_contains ~label:"retry abort log" src
+    "aborting retry path to avoid replaying an unpaired tool completion";
+  print_endline "test_keeper_unified_tool_event_order_source: OK"


### PR DESCRIPTION
## Summary
- replace the ToolCompleted-without-ToolCalled Null fallback with an explicit event-order violation latch
- conservatively mark input-sensitive tool completions as committed when their ToolCalled input is missing
- abort provider-error and timeout retry paths on unpaired tool completion so a replay cannot duplicate unknown side effects
- add a source regression test that prevents reintroducing the Null fallback path

## Why it matters
The Kimi audit flagged that the old fallback used Null input for side-effect classification. That can undercount input-sensitive tools such as keeper_shell, making retry logic think no mutating tool committed. This patch fails closed for retry safety when the OAS event stream is out of order.

## Local evidence
- ocamlc -stop-after parsing lib/keeper/keeper_unified_turn.ml test/test_keeper_unified_tool_event_order_source.ml
- scripts/dune-local.sh build test/test_keeper_unified_tool_event_order_source.exe bin/main_eio.exe
- ./_build/default/test/test_keeper_unified_tool_event_order_source.exe
- git diff --check
- bash scripts/ci/check-silent-failure-patterns.sh
