### PR TITLE
fix: record lifecycle hook coverage gaps

### DIFF
--- a/lib/keeper/keeper_lifecycle_hooks.ml
+++ b/lib/keeper/keeper_lifecycle_hooks.ml
@@ -9,6 +9,12 @@ type event =
 
 type hook = keeper_id:string -> event -> unit
 
+let callback_label = "keeper_lifecycle_hook"
+let coverage_source = "keeper_lifecycle_callback"
+let coverage_durable_store = "keeper_lifecycle_events"
+let coverage_dashboard_surface = "keeper_lifecycle"
+let coverage_stale_reason = "callback_exception"
+
 (* Atomic-backed reversed-list. Registration prepends ([h :: cur]) which
    is O(1); the runner then iterates the reversed list in registration
    order via List.rev once per [run] call. The previous [cur @ [h]]
@@ -26,7 +32,30 @@ let register (h : hook) : unit =
   in
   loop ()
 
-let run ~keeper_id (ev : event) : unit =
+let record_coverage_gap ?base_dir ?meta ~callback ~error () =
+  match base_dir, meta with
+  | Some masc_root, Some (meta : Keeper_types.keeper_meta) -> (
+      try
+        Telemetry_coverage_gap.record
+          ~masc_root
+          ~source:coverage_source
+          ~producer:callback
+          ~durable_store:coverage_durable_store
+          ~dashboard_surface:coverage_dashboard_surface
+          ~stale_reason:coverage_stale_reason
+          ~keeper_name:meta.name
+          ~trace_id:(Keeper_id.Trace_id.to_string meta.runtime.trace_id)
+          ~error
+          ()
+      with
+      | Eio.Cancel.Cancelled _ as e -> raise e
+      | gap_exn ->
+        Log.Keeper.warn
+          "keeper:%s lifecycle hook coverage-gap record failed: %s"
+          meta.name (Printexc.to_string gap_exn))
+  | _ -> ()
+
+let run ?base_dir ?meta ~keeper_id (ev : event) : unit =
   (* Reverse once at run time so call order matches registration order
      (the documented contract). The reversal is O(n) but n is tiny in
      practice (a handful of subsystem hooks). *)
@@ -37,17 +66,19 @@ let run ~keeper_id (ev : event) : unit =
       with
       | Eio.Cancel.Cancelled _ as e -> raise e
       | exn ->
+        let error = Printexc.to_string exn in
         Prometheus.inc_counter
           Prometheus.metric_keeper_lifecycle_callback_failures
           ~labels:
             [
               ("keeper", keeper_id);
-              ("callback", "keeper_lifecycle_hook");
+              ("callback", callback_label);
             ]
           ();
         Log.Server.warn
           "[KeeperLifecycleHooks] hook raised on keeper_id=%s: %s"
-          keeper_id (Printexc.to_string exn))
+          keeper_id error;
+        record_coverage_gap ?base_dir ?meta ~callback:callback_label ~error ())
     hs
 
 let registered_count () : int = List.length (Atomic.get hooks)

--- a/lib/keeper/keeper_lifecycle_hooks.mli
+++ b/lib/keeper/keeper_lifecycle_hooks.mli
@@ -53,9 +53,17 @@ val register : hook -> unit
 (** Run every registered hook with the given event. Non-cancellation
     exceptions raised from a hook are caught, counted via
     [metric_keeper_lifecycle_callback_failures], and logged via
-    [Log.Server.warn]; [Eio.Cancel.Cancelled] is re-raised to preserve
-    cooperative cancellation. *)
-val run : keeper_id:string -> event -> unit
+    [Log.Server.warn]. When [base_dir] and [meta] are supplied, the
+    failure also writes a durable telemetry coverage-gap row so the
+    best-effort hook contract is visible outside process-local logs.
+    [Eio.Cancel.Cancelled] is re-raised to preserve cooperative
+    cancellation. *)
+val run :
+  ?base_dir:string ->
+  ?meta:Keeper_types.keeper_meta ->
+  keeper_id:string ->
+  event ->
+  unit
 
 (** Number of currently registered hooks. Useful for tests. *)
 val registered_count : unit -> int

--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -1467,6 +1467,8 @@ let sweep_and_recover (ctx : _ context) =
   List.iter (fun (entry : Keeper_registry.registry_entry) ->
     cleanup_dead_tombstone ctx entry;
     Keeper_lifecycle_hooks.run
+      ~base_dir:(Coord.masc_root_dir ctx.config)
+      ~meta:entry.meta
       ~keeper_id:entry.name
       Keeper_lifecycle_hooks.Tombstone_reaped
   ) !to_cleanup_dead;

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -721,8 +721,10 @@ val metric_fsm_guard_violation : string
 (** Keeper callback failures that would otherwise look like missing
     lifecycle, SSE, tool-call-log, or action-metric rows. Lifecycle
     callback failures also write a durable [telemetry_coverage_gap]
-    row through [Keeper_callback_failure.record]. Labels: [callback]
-    plus optional [keeper] at per-keeper OAS hook sites.
+    row through [Keeper_callback_failure.record] or
+    [Keeper_lifecycle_hooks.run] when runtime context is available.
+    Labels: [callback] plus optional [keeper] at per-keeper OAS hook
+    sites.
 
     Callback-only labels:
     - [on_compaction_started] — fired from

--- a/test/test_keeper_lifecycle_hooks.ml
+++ b/test/test_keeper_lifecycle_hooks.ml
@@ -11,8 +11,40 @@ open Alcotest
 module H = Masc_mcp.Keeper_lifecycle_hooks
 module P = Masc_mcp.Prometheus
 module SM = Masc_mcp.Keeper_state_machine
+module TCG = Masc_mcp.Telemetry_coverage_gap
 
 let setup () = H.reset_for_testing ()
+
+let temp_dir () =
+  let tmp = Filename.temp_file "masc_lifecycle_hooks" "" in
+  Sys.remove tmp;
+  Unix.mkdir tmp 0o755;
+  tmp
+
+let cleanup_dir dir =
+  let rec rm path =
+    if Sys.file_exists path then
+      if Sys.is_directory path then begin
+        Sys.readdir path
+        |> Array.iter (fun name -> rm (Filename.concat path name));
+        Unix.rmdir path
+      end
+      else Sys.remove path
+  in
+  rm dir
+
+let make_keeper_meta ~name ~trace_id =
+  match
+    Masc_test_deps.meta_of_json_fixture
+      (`Assoc
+         [
+           ("name", `String name);
+           ("agent_name", `String name);
+           ("trace_id", `String trace_id);
+         ])
+  with
+  | Ok meta -> meta
+  | Error e -> failwith (Printf.sprintf "make_keeper_meta failed: %s" e)
 
 let lifecycle_hook_failure_count ~keeper =
   P.metric_value_or_zero
@@ -80,6 +112,39 @@ let test_exception_in_hook_is_swallowed () =
   check (float 0.001) "hook failure metric increments" 1.0
     (after -. before)
 
+let test_exception_in_hook_records_coverage_gap_with_context () =
+  setup ();
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_dir)
+    (fun () ->
+      let requested_keeper = "keeper-lifecycle-gap-test" in
+      let trace_id = "trace-lifecycle-gap-test" in
+      let meta = make_keeper_meta ~name:requested_keeper ~trace_id in
+      let keeper = meta.name in
+      H.register (fun ~keeper_id:_ _ ->
+        failwith "synthetic lifecycle hook failure");
+      H.run ~base_dir ~meta ~keeper_id:keeper H.Tombstone_reaped;
+      match TCG.read_recent ~masc_root:base_dir ~n:1 with
+      | [ row ] ->
+        let open Yojson.Safe.Util in
+        check string "gap schema" "masc.telemetry_coverage_gap.v1"
+          (row |> member "schema" |> to_string);
+        check string "gap source" "keeper_lifecycle_callback"
+          (row |> member "source" |> to_string);
+        check string "gap producer" "keeper_lifecycle_hook"
+          (row |> member "producer" |> to_string);
+        check string "gap reason" "callback_exception"
+          (row |> member "stale_reason" |> to_string);
+        check string "gap keeper" keeper
+          (row |> member "keeper_name" |> to_string);
+        check string "gap trace" trace_id
+          (row |> member "trace_id" |> to_string);
+        check string "gap error recorded"
+          "Failure(\"synthetic lifecycle hook failure\")"
+          (row |> member "error" |> to_string)
+      | _ -> fail "expected one telemetry coverage gap row")
+
 let test_cancelled_in_hook_is_reraised () =
   setup ();
   H.register (fun ~keeper_id:_ _ ->
@@ -108,6 +173,8 @@ let () =
       test_case "dispatches in order"        `Quick test_run_dispatches_in_order;
       test_case "passes keeper_id and event" `Quick test_run_passes_keeper_id_and_event;
       test_case "swallows exceptions"        `Quick test_exception_in_hook_is_swallowed;
+      test_case "records coverage gap with context" `Quick
+        test_exception_in_hook_records_coverage_gap_with_context;
       test_case "re-raises cancellation"     `Quick test_cancelled_in_hook_is_reraised;
     ];
     "reset_for_testing", [ test_case "clears all" `Quick test_reset_for_testing_clears ];


### PR DESCRIPTION
## Summary
- add optional runtime context to Keeper_lifecycle_hooks.run so swallowed lifecycle hook failures write telemetry coverage-gap JSONL rows
- pass supervisor keeper meta/base path into Tombstone_reaped hook dispatch
- add regression coverage for the durable coverage-gap row while preserving swallow/cancellation semantics

## Why it matters
The Phase 0 plan calls out swallowed callback failures as an operator-trust gap: logs and counters are not enough when the dashboard/unified telemetry path needs durable evidence. This keeps Tombstone_reaped hooks best-effort, but makes failures visible by keeper and trace.

## Validation
- git diff --check
- lockf -k -t 1200 /tmp/me-dune-local.lock env MASC_DUNE_LOCK_HELD=1 MASC_SKIP_OPAM_LOCK=1 DUNE_JOBS=1 DUNE_CACHE=disabled scripts/dune-local.sh build test/test_keeper_lifecycle_hooks.exe
- _build/default/test/test_keeper_lifecycle_hooks.exe
- lockf -k -t 1200 /tmp/me-dune-local.lock env MASC_DUNE_LOCK_HELD=1 MASC_SKIP_OPAM_LOCK=1 DUNE_JOBS=1 DUNE_CACHE=disabled scripts/dune-local.sh build test/test_keeper_supervisor.exe
- _build/default/test/test_keeper_supervisor.exe