### PR TITLE
fix: align keeper turn timeout snapshot

### DIFF
--- a/lib/config/env_config_snapshot.ml
+++ b/lib/config/env_config_snapshot.ml
@@ -735,8 +735,8 @@ let keeper_keepalive_entries =
       "Max dispatch attempts for the same keeper turn id before livelock guard blocks";
     entry ~default:"1800.0" "MASC_KEEPER_TURN_LIVELOCK_STUCK_AFTER_SEC"
       "Max seconds a keeper turn id may stay active before livelock guard blocks";
-    entry ~default:"3600.0" "MASC_KEEPER_TURN_TIMEOUT_SEC"
-      "Wall-clock timeout for a single unified turn (clamped 60-7200 seconds)";
+    entry ~default:"600.0" "MASC_KEEPER_TURN_TIMEOUT_SEC"
+      "Wall-clock timeout for a single unified turn (clamped 60-600 seconds)";
     entry ~default:"(none)" "MASC_KEEPER_WORK_AS_HEARTBEAT"
       "Successful room heartbeat after turn counts as presence proof (feature flag)";
   ]

--- a/lib/keeper/keeper_stale_watchdog.ml
+++ b/lib/keeper/keeper_stale_watchdog.ml
@@ -409,13 +409,14 @@ let fork_stale_watchdog (ctx : _ context) (meta : keeper_meta)
                 latency=278s.  The previous code looked only at
                 [last_turn_ts] and could fire while a turn was actively
                 running, killing the keeper mid-LLM-call.  Active turns
-                get a separate (larger) threshold so legitimately slow
-                turns aren't mistaken for hangs.  Use
-                [Keeper_runtime_resolved.turn_timeout_sec] as the ceiling
-                so the watchdog never kills a turn still within its
-                configured budget (default 3600s, range [60, 7200]).
-                Previous 600s hardcoded minimum caused fleet-wide
-                termination when local models take 900s+ turns. *)
+                get a separate threshold so legitimately slow turns aren't
+                mistaken for hangs.  Use
+                [Keeper_runtime_resolved.turn_timeout_sec] as the
+                active-turn floor so the watchdog never kills a turn still
+                within its configured budget (default 600s, range [60, 600]).
+                [stale_threshold_sec] may be larger, and the [Float.max]
+                below preserves that deployer patience for watchdog-only
+                stale detection. *)
              let active_turn_timeout_sec =
                let turn_timeout = Keeper_runtime_resolved.turn_timeout_sec () in
                Float.max turn_timeout threshold

--- a/test/test_keeper_turn_timeout_default_10456.ml
+++ b/test/test_keeper_turn_timeout_default_10456.ml
@@ -12,8 +12,8 @@
     The audit hard-ceiling pass later lowered the SSOT default to 600 so the
     keeper turn envelope cannot hide long OAS provider stalls.
 
-    This test pins the SSOT and source-level literal so silent
-    re-divergence shows up as a test failure. *)
+    This test pins the SSOT, source-level literal, and generated env snapshot
+    so silent re-divergence shows up as a test failure. *)
 
 open Alcotest
 
@@ -38,11 +38,32 @@ let resolver_source_path =
   | Some p -> Some p
   | None -> None
 
+let snapshot_source_path =
+  let candidates =
+    [
+      "lib/config/env_config_snapshot.ml";
+      "../lib/config/env_config_snapshot.ml";
+      "../../lib/config/env_config_snapshot.ml";
+    ]
+  in
+  match List.find_opt Sys.file_exists candidates with
+  | Some p -> Some p
+  | None -> None
+
 let read_file path =
   let ic = open_in path in
   Fun.protect
     ~finally:(fun () -> close_in_noerr ic)
     (fun () -> really_input_string ic (in_channel_length ic))
+
+let contains s sub =
+  let n = String.length s and m = String.length sub in
+  let rec loop i =
+    if i + m > n then false
+    else if String.sub s i m = sub then true
+    else loop (i + 1)
+  in
+  loop 0
 
 let test_resolver_default_matches_ssot () =
   match resolver_source_path with
@@ -59,15 +80,6 @@ let test_resolver_default_matches_ssot () =
       let canonical_pattern =
         "~default:600.0 \"MASC_KEEPER_TURN_TIMEOUT_SEC\""
       in
-      let contains s sub =
-        let n = String.length s and m = String.length sub in
-        let rec loop i =
-          if i + m > n then false
-          else if String.sub s i m = sub then true
-          else loop (i + 1)
-        in
-        loop 0
-      in
       let has_stale = contains body stale_pattern in
       let has_stale_3600 = contains body stale_3600_pattern in
       let has_canonical = contains body canonical_pattern in
@@ -83,17 +95,34 @@ let test_resolver_upper_matches_ssot () =
       (* The resolver must keep the same 600s hard ceiling as
          Env_config_keeper.KeeperKeepalive.turn_timeout_sec. *)
       let canonical_upper = "Float.min 600.0" in
-      let contains s sub =
-        let n = String.length s and m = String.length sub in
-        let rec loop i =
-          if i + m > n then false
-          else if String.sub s i m = sub then true
-          else loop (i + 1)
-        in
-        loop 0
-      in
       check bool "canonical 600 upper bound in resolver" true
         (contains body canonical_upper)
+
+let test_snapshot_default_matches_ssot () =
+  match snapshot_source_path with
+  | None -> skip ()
+  | Some p ->
+      let body = read_file p in
+      let stale_default =
+        "entry ~default:\"3600.0\" \"MASC_KEEPER_TURN_TIMEOUT_SEC\""
+      in
+      let stale_range =
+        "Wall-clock timeout for a single unified turn (clamped 60-7200 seconds)"
+      in
+      let canonical_default =
+        "entry ~default:\"600.0\" \"MASC_KEEPER_TURN_TIMEOUT_SEC\""
+      in
+      let canonical_range =
+        "Wall-clock timeout for a single unified turn (clamped 60-600 seconds)"
+      in
+      check bool "no stale 3600 default in env snapshot" false
+        (contains body stale_default);
+      check bool "no stale 7200 range in env snapshot" false
+        (contains body stale_range);
+      check bool "canonical 600 default in env snapshot" true
+        (contains body canonical_default);
+      check bool "canonical 60-600 range in env snapshot" true
+        (contains body canonical_range)
 
 let () =
   run "keeper_turn_timeout_default_10456"
@@ -109,5 +138,10 @@ let () =
             `Quick test_resolver_default_matches_ssot;
           test_case "resolver upper bound literal matches SSOT (600)" `Quick
             test_resolver_upper_matches_ssot;
+        ] );
+      ( "snapshot-drift-gate",
+        [
+          test_case "env config snapshot matches keeper turn timeout SSOT"
+            `Quick test_snapshot_default_matches_ssot;
         ] );
     ]


### PR DESCRIPTION
## Summary
- align the env config snapshot entry for MASC_KEEPER_TURN_TIMEOUT_SEC with the current 600s default and 60-600 clamp
- update the stale watchdog source comment so operator-facing source truth no longer advertises the old 3600/7200 envelope
- extend the keeper timeout regression test to pin the snapshot entry alongside the runtime resolver literal

## Why this matters
The runtime SSOT already enforces a 600s default/hard ceiling, but the generated snapshot still advertised 3600s and a 7200s upper range. That misleads operators reading the config surface and lets the same drift return without a focused guard.

## Validation
- ocamlc -stop-after parsing lib/config/env_config_snapshot.ml
- ocamlc -stop-after parsing lib/keeper/keeper_stale_watchdog.ml
- ocamlc -stop-after parsing test/test_keeper_turn_timeout_default_10456.ml
- scripts/dune-local.sh build test/test_keeper_turn_timeout_default_10456.exe
- ./_build/default/test/test_keeper_turn_timeout_default_10456.exe
- git diff --check

## Review focus
- confirm the env snapshot wording matches Env_config_keeper.KeeperKeepalive.turn_timeout_sec
- confirm the snapshot drift test is narrow enough for this config mismatch