### PR TITLE
test: enforce goal loop absent metric coverage

### DIFF
--- a/docs/observability/goal-loop-observe-metrics.md
+++ b/docs/observability/goal-loop-observe-metrics.md
@@ -66,7 +66,10 @@ failing_signals: 0
 
 The script is intentionally stdlib-only. CI can run it without installing
 YAML tooling because it checks explicit alert names, metric names, and
-threshold fragments from the contract.
+threshold fragments from the contract. It also keeps the aggregate
+`GoalLoopObserveMetricAbsentCritical` rule in sync with every contract
+metric, so a metric cannot silently fall out of the absent-exporter safety
+net while its per-signal alert still passes.
 
 ## Apply
 

--- a/scripts/validate_goal_loop_observe_metrics.py
+++ b/scripts/validate_goal_loop_observe_metrics.py
@@ -12,6 +12,9 @@ from pathlib import Path
 from typing import Any
 
 
+ABSENT_ALERT_NAME = "GoalLoopObserveMetricAbsentCritical"
+
+
 @dataclass
 class SignalCheck:
     signal_id: str
@@ -29,6 +32,7 @@ class ValidationReport:
     checked_signals: int
     passing_signals: int
     failing_signals: int
+    missing_absent_metrics: list[str]
     signal_checks: list[SignalCheck]
 
 
@@ -159,6 +163,29 @@ def required_signals(contract: dict[str, Any]) -> list[dict[str, Any]]:
     return signals
 
 
+def required_metric_names(signals: list[dict[str, Any]]) -> list[str]:
+    seen: set[str] = set()
+    names: list[str] = []
+    for signal in signals:
+        for name in as_string_list(signal.get("metric_names")):
+            if name not in seen:
+                seen.add(name)
+                names.append(name)
+    return names
+
+
+def missing_absent_metrics(
+    metric_names: list[str],
+    alert_expr_map: dict[str, str],
+) -> list[str]:
+    absent_expr = alert_expr_map.get(ABSENT_ALERT_NAME, "")
+    return [
+        name
+        for name in metric_names
+        if not contains_expr_token(absent_expr, name)
+    ]
+
+
 def validate_signal(
     signal: dict[str, Any],
     *,
@@ -214,22 +241,28 @@ def validate_contract(
     schema_version = contract_schema_version(contract)
     alert_expr_map = alert_exprs(alert_text)
     dashboard_query_exprs = dashboard_exprs(dashboard_text)
+    signals = required_signals(contract)
     checks = [
         validate_signal(
             signal,
             alert_expr_map=alert_expr_map,
             dashboard_query_exprs=dashboard_query_exprs,
         )
-        for signal in required_signals(contract)
+        for signal in signals
     ]
     passing = sum(1 for check in checks if check.status == "PASS")
     failing = len(checks) - passing
+    absent_missing = missing_absent_metrics(
+        required_metric_names(signals),
+        alert_expr_map,
+    )
     return ValidationReport(
         schema_version=schema_version,
-        status="PASS" if failing == 0 else "FAIL",
+        status="PASS" if failing == 0 and not absent_missing else "FAIL",
         checked_signals=len(checks),
         passing_signals=passing,
         failing_signals=failing,
+        missing_absent_metrics=absent_missing,
         signal_checks=checks,
     )
 
@@ -245,6 +278,10 @@ def report_to_text(report: ValidationReport) -> str:
         f"passing_signals: {report.passing_signals}",
         f"failing_signals: {report.failing_signals}",
     ]
+    if report.missing_absent_metrics:
+        lines.append(
+            "missing_absent_metrics=" + ",".join(report.missing_absent_metrics)
+        )
     for check in report.signal_checks:
         lines.append(f"- {check.signal_id}: {check.status}")
         if check.status == "FAIL":

--- a/test/test_validate_goal_loop_observe_metrics.py
+++ b/test/test_validate_goal_loop_observe_metrics.py
@@ -69,6 +69,7 @@ class GoalLoopObserveMetricsValidatorTest(unittest.TestCase):
         self.assertEqual(18, report.checked_signals)
         self.assertEqual(18, report.passing_signals)
         self.assertEqual(0, report.failing_signals)
+        self.assertEqual([], report.missing_absent_metrics)
 
     def test_contract_pins_starvation_rate_signal(self) -> None:
         contract = validate_goal_loop_observe_metrics.load_json_object(
@@ -218,6 +219,38 @@ class GoalLoopObserveMetricsValidatorTest(unittest.TestCase):
         self.assertEqual(
             ["masc_write_meta_cas_retry_total"],
             failed["write_meta_cas_retry"].missing_dashboard_metrics,
+        )
+
+    def test_missing_absent_alert_metric_fails_contract(self) -> None:
+        alert_text = ALERTS_PATH.read_text(encoding="utf-8").replace(
+            "or absent(masc_goal_attainment_measured)",
+            "or absent(masc_goal_attainment_measured_shadow)",
+            1,
+        )
+
+        report = load_current_report(alert_text=alert_text)
+
+        self.assertEqual("FAIL", report.status)
+        self.assertEqual(18, report.passing_signals)
+        self.assertEqual(0, report.failing_signals)
+        self.assertEqual(
+            ["masc_goal_attainment_measured"],
+            report.missing_absent_metrics,
+        )
+
+    def test_missing_absent_alert_metric_is_reported_in_text(self) -> None:
+        alert_text = ALERTS_PATH.read_text(encoding="utf-8").replace(
+            "or absent(masc_memory_usage_bytes)",
+            "or absent(masc_memory_usage_bytes_shadow)",
+            1,
+        )
+
+        report = load_current_report(alert_text=alert_text)
+        text = validate_goal_loop_observe_metrics.report_to_text(report)
+
+        self.assertIn(
+            "missing_absent_metrics=masc_memory_usage_bytes",
+            text,
         )
 
     def test_cli_require_complete_fails_when_contract_broken(self) -> None:


### PR DESCRIPTION
## Summary
- require every metric in the GOAL LOOP Observe contract to appear in the aggregate absent-metric alert
- surface missing absent-alert coverage in JSON/text validator reports
- add regression tests where per-signal alerts still pass but the absent-exporter safety net drifts

## Why it matters
Phase 0.5 depends on metric schemas being both dashboard-exposed and alert-visible. Before this change, `GoalLoopObserveMetricAbsentCritical` could silently drop a contract metric while the validator still returned PASS because the per-signal alert and dashboard query remained present.

## Validation
- python3 test/test_validate_goal_loop_observe_metrics.py
- python3 scripts/validate_goal_loop_observe_metrics.py infrastructure/monitoring/goal-loop-observe-metrics.contract.json --alerts-yml infrastructure/monitoring/goal-loop-observe-alerts.yml --dashboard-json infrastructure/monitoring/grafana-goal-loop-observe-dashboard.json --require-complete --format text
- ruff check scripts/validate_goal_loop_observe_metrics.py test/test_validate_goal_loop_observe_metrics.py
- git diff --check

## Notes
- `pyright --outputjson scripts/validate_goal_loop_observe_metrics.py test/test_validate_goal_loop_observe_metrics.py` could not run locally because `pyright` is not installed in this environment.