### PR TITLE
fix: record memory activity coverage gaps

### DIFF
--- a/lib/keeper/keeper_agent_memory_episode.ml
+++ b/lib/keeper/keeper_agent_memory_episode.ml
@@ -3,6 +3,28 @@
     Keeps OAS memory persistence details out of [Keeper_agent_run], preserving
     the keeper runner as a thin orchestration layer. *)
 
+let record_activity_emit_gap ~config ~keeper_name ~outcome_label ~error =
+  let masc_root = Coord_utils.masc_dir config in
+  try
+    Telemetry_coverage_gap.record
+      ~masc_root
+      ~source:"keeper_memory_activity"
+      ~producer:"keeper_agent_memory_episode.emit_flush_activity"
+      ~durable_store:(Filename.concat masc_root "activity-events")
+      ~dashboard_surface:"/api/v1/agent-timeline"
+      ~stale_reason:"episode_flush_activity_emit_failed"
+      ~keeper_name
+      ~error:
+        (Printf.sprintf "outcome=%s error=%s" outcome_label error)
+      ()
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | gap_exn ->
+    Log.Keeper.warn
+      "keeper:%s episode.flush activity coverage-gap record failed \
+       outcome=%s: %s"
+      keeper_name outcome_label (Printexc.to_string gap_exn)
+
 let emit_flush_activity
     ~(config : Coord_utils.config)
     ~(keeper_name : string)
@@ -43,9 +65,11 @@ let emit_flush_activity
         Prometheus.metric_keeper_memory_activity_emit_failures
         ~labels:[("keeper", keeper_name); ("outcome", outcome_label)]
         ();
+      let error = Printexc.to_string exn in
+      record_activity_emit_gap ~config ~keeper_name ~outcome_label ~error;
       Log.Keeper.error
         "keeper:%s episode.flush activity emit failed outcome=%s: %s"
-        keeper_name outcome_label (Printexc.to_string exn)
+        keeper_name outcome_label error
 
 let record_success
     ~(config : Coord_utils.config)

--- a/lib/keeper/keeper_agent_memory_episode.mli
+++ b/lib/keeper/keeper_agent_memory_episode.mli
@@ -5,7 +5,8 @@
 
 (** Emit an [episode.flush] activity payload via [Coord_hooks.activity_emit_fn].
     No-op if both [episodes] and [procedures] are zero. Logs and counts
-    non-cancel exceptions; re-raises [Eio.Cancel.Cancelled]. *)
+    non-cancel exceptions, records a telemetry coverage-gap row, and
+    re-raises [Eio.Cancel.Cancelled]. *)
 val emit_flush_activity :
   config:Coord_utils.config ->
   keeper_name:string ->

--- a/test/test_keeper_agent_memory_episode_activity.ml
+++ b/test/test_keeper_agent_memory_episode_activity.ml
@@ -6,6 +6,7 @@ open Masc_mcp
 module Episode = Keeper_agent_memory_episode
 module Hooks = Coord_hooks
 module P = Prometheus
+module TCG = Telemetry_coverage_gap
 
 let temp_dir () =
   let dir = Filename.temp_file "test_keeper_memory_activity_" "" in
@@ -66,6 +67,15 @@ let failing_emit _config ~actor:_ ?subject ~kind:_ ~payload:_ ~tags:_ () =
   ignore subject;
   failwith "activity graph down"
 
+let contains s sub =
+  let n = String.length s and m = String.length sub in
+  let rec loop i =
+    if i + m > n then false
+    else if String.sub s i m = sub then true
+    else loop (i + 1)
+  in
+  m = 0 || loop 0
+
 let test_activity_emit_failure_increments_success_metric () =
   with_config (fun config ->
     let keeper = "keeper-memory-activity-success" in
@@ -78,6 +88,32 @@ let test_activity_emit_failure_increments_success_metric () =
       check (float 0.0001)
         "activity emit failure increments success-outcome metric"
         (before +. 1.0) after))
+
+let test_activity_emit_failure_records_coverage_gap () =
+  with_config (fun config ->
+    let keeper = "keeper-memory-activity-gap" in
+    with_activity_emit failing_emit (fun () ->
+      Episode.emit_flush_activity ~config ~keeper_name:keeper ~turn:11
+        ~episodes:1 ~procedures:0 ~tags:["memory"; "episode"; "flush"]
+        ();
+      match TCG.read_recent ~masc_root:(Coord_utils.masc_dir config) ~n:1 with
+      | [ row ] ->
+        let open Yojson.Safe.Util in
+        check string "gap source" "keeper_memory_activity"
+          (row |> member "source" |> to_string);
+        check string "gap producer"
+          "keeper_agent_memory_episode.emit_flush_activity"
+          (row |> member "producer" |> to_string);
+        check string "gap reason" "episode_flush_activity_emit_failed"
+          (row |> member "stale_reason" |> to_string);
+        check string "gap keeper" keeper
+          (row |> member "keeper_name" |> to_string);
+        let error = row |> member "error" |> to_string in
+        check bool "gap error includes outcome" true
+          (contains error "outcome=success");
+        check bool "gap error includes activity failure" true
+          (contains error "activity graph down")
+      | _ -> fail "expected one telemetry coverage gap row"))
 
 let test_activity_emit_failure_increments_failure_metric () =
   with_config (fun config ->
@@ -112,6 +148,8 @@ let () =
     "activity emit visibility", [
       test_case "success flush emit failure increments metric" `Quick
         test_activity_emit_failure_increments_success_metric;
+      test_case "activity emit failure records coverage gap" `Quick
+        test_activity_emit_failure_records_coverage_gap;
       test_case "failure flush emit failure increments metric" `Quick
         test_activity_emit_failure_increments_failure_metric;
       test_case "zero flush remains a no-op" `Quick test_zero_flush_is_noop;


### PR DESCRIPTION
## Summary
- write a telemetry coverage-gap row when keeper episode.flush activity emission fails
- keep the existing best-effort behavior: non-cancel failures are counted/logged and swallowed, cancellation still propagates
- add regression coverage for the durable JSONL row

## Why it matters
Phase 0 calls out silent exception accumulation in telemetry and memory paths. `episode.flush` activity emit failures already had a counter, but no durable row for dashboard/unified telemetry readers to explain the missing activity event. This makes the dropped memory activity visible by keeper and stale reason.

## Validation
- git diff --check
- lockf -k -t 1200 /tmp/me-dune-local.lock env MASC_DUNE_LOCK_HELD=1 MASC_SKIP_OPAM_LOCK=1 DUNE_JOBS=1 DUNE_CACHE=disabled scripts/dune-local.sh build test/test_keeper_agent_memory_episode_activity.exe
- _build/default/test/test_keeper_agent_memory_episode_activity.exe