### PR TITLE
fix: label gate observer failures by keeper

### DIFF
--- a/lib/keeper/keeper_guards.ml
+++ b/lib/keeper/keeper_guards.ml
@@ -188,6 +188,7 @@ let gate_decision_is_rejection = function
 
 type gate_decision_event = {
   stage : string;
+  keeper_name : string;
   decision : gate_decision;
   reason_code : string;
   reason_text : string;
@@ -209,11 +210,11 @@ let notify_gate_decision on_gate_decision (event : gate_decision_event) =
   | exn ->
       Prometheus.inc_counter
         Prometheus.metric_keeper_guards_failures
-        ~labels:[("keeper", "aggregate"); ("site", "gate_observer")]
+        ~labels:[("keeper", event.keeper_name); ("site", "gate_observer")]
         ();
       Log.Keeper.warn
-        "keeper_guards: gate observer failed stage=%s tool=%s err=%s"
-        event.stage event.tool_name (Printexc.to_string exn)
+        "keeper_guards: gate observer failed keeper=%s stage=%s tool=%s err=%s"
+        event.keeper_name event.stage event.tool_name (Printexc.to_string exn)
 
 (** Emit a [masc:keeper_gate] Event_bus Custom event.
 
@@ -334,7 +335,7 @@ let report_gate_decision on_gate_decision
     ~agent_name:keeper_name ~turn ~accumulated_cost_usd
     ~stage_latency_ms ~reason_text;
   notify_gate_decision on_gate_decision
-    { stage; decision; reason_code; reason_text; tool_name; input; turn;
+    { stage; keeper_name; decision; reason_code; reason_text; tool_name; input; turn;
       accumulated_cost_usd; stage_latency_ms; source_path; source_line }
 
 (* -------------------------------------------------------------- *)

--- a/lib/keeper/keeper_guards.mli
+++ b/lib/keeper/keeper_guards.mli
@@ -61,6 +61,7 @@ val gate_decision_is_rejection : gate_decision -> bool
 (** Telemetry payload reported to the gate observer. *)
 type gate_decision_event =
   { stage : string
+  ; keeper_name : string
   ; decision : gate_decision
   ; reason_code : string
   ; reason_text : string
@@ -77,7 +78,10 @@ type gate_decision_event =
 val ignore_gate_decision : gate_decision_event -> unit
 
 (** Invoke [on_gate_decision] with [event]; logs and swallows
-    non-cancel exceptions. *)
+    non-cancel exceptions.  Observer-failure warnings include
+    [keeper=<name>] so log readers can attribute failures by keeper;
+    dashboard/microlog integrations should use metric labels or event
+    payloads instead of parsing this warning line. *)
 val notify_gate_decision :
   (gate_decision_event -> unit) -> gate_decision_event -> unit
 

--- a/test/test_keeper_guards.ml
+++ b/test/test_keeper_guards.ml
@@ -10,6 +10,7 @@
 open Alcotest
 module KG = Masc_mcp.Keeper_guards
 module HK = Masc_mcp.Keeper_hooks_oas
+module P = Masc_mcp.Prometheus
 
 (* ----------------------------------------------------------------- *)
 (* Helpers                                                             *)
@@ -129,6 +130,7 @@ let test_render_inline_skip_reason () =
 
 let make_gate_event ?(decision = KG.Gate_override) () =
   { KG.stage = "keeper_deny";
+    keeper_name = "test_keeper";
     decision;
     reason_code = "keeper_deny";
     reason_text = "tool is on the keeper deny list";
@@ -207,6 +209,7 @@ let test_deny_guard_notifies_gate_observer () =
   match !observed with
   | [ event ] ->
     check string "stage" "keeper_deny" event.KG.stage;
+    check string "keeper_name" "test_keeper" event.KG.keeper_name;
     check string "decision" "override"
       (KG.gate_decision_to_string event.KG.decision);
     check string "reason_code" "keeper_deny" event.KG.reason_code;
@@ -225,6 +228,27 @@ let test_deny_guard_notifies_gate_observer () =
        | _ -> false)
   | events ->
     failf "expected one observer event, got %d" (List.length events)
+
+let test_gate_observer_failure_counts_actual_keeper () =
+  let meta_ref = make_meta_ref "keeper_gate_observer_failure" in
+  let keeper = (!meta_ref).name in
+  let labels = [ ("keeper", keeper); ("site", "gate_observer") ] in
+  let before =
+    P.metric_value_or_zero P.metric_keeper_guards_failures ~labels ()
+  in
+  let on_gate_decision _event =
+    raise (Failure "synthetic gate observer failure")
+  in
+  let hook =
+    KG.deny_guard ~meta_ref ~on_gate_decision ~denied:["dangerous_tool"]
+  in
+  let d = invoke hook (pre_tool_use_event ~tool_name:"dangerous_tool" ()) in
+  check string "denied tool still overrides" "Override" (decision_kind d);
+  let after =
+    P.metric_value_or_zero P.metric_keeper_guards_failures ~labels ()
+  in
+  check (float 0.0001) "observer failure counted for keeper"
+    (before +. 1.0) after
 
 let test_deny_guard_continues () =
   let meta_ref = make_meta_ref "test_keeper" in
@@ -479,6 +503,8 @@ let () = run "Keeper_guards" [
     test_case "blocks denied tool" `Quick test_deny_guard_blocks;
     test_case "notifies observer on block" `Quick
       test_deny_guard_notifies_gate_observer;
+    test_case "observer failure counts actual keeper" `Quick
+      test_gate_observer_failure_counts_actual_keeper;
     test_case "continues for allowed tool" `Quick test_deny_guard_continues;
   ];
   "cost_guard", [


### PR DESCRIPTION
## Summary
- carry keeper_name on typed gate_decision_event payloads
- use the real keeper label when gate observer callbacks fail
- add regression coverage that a swallowed observer exception increments `metric_keeper_guards_failures{keeper=<actual>,site=gate_observer}` while the gate still overrides as intended

## Why it matters
Phase 1.1 asks for measurable pre-dispatch/gate decisions by keeper. The observer failure path previously used `keeper=aggregate`, so operator metrics could show that gate observer delivery broke but not which keeper lost the decision signal.

## Validation
- git diff --check
- lockf -k -t 1200 /tmp/me-dune-local.lock env MASC_DUNE_LOCK_HELD=1 MASC_SKIP_OPAM_LOCK=1 DUNE_JOBS=1 DUNE_CACHE=disabled scripts/dune-local.sh build test/test_keeper_guards.exe
- _build/default/test/test_keeper_guards.exe