### PR TITLE
fix: lock task dispatch backlog mutations

### DIFF
--- a/lib/task_dispatch.ml
+++ b/lib/task_dispatch.ml
@@ -93,40 +93,62 @@ let validate_transition ~(current : task_status) ~(next : task_status) ~task_id 
                   (task_status_to_string next))))
   | _ -> Ok ()
 
+let backlog_lock_path config =
+  Filename.concat (Coord.tasks_dir config) ".backlog"
+
+let with_locked_backlog
+    config
+    (f : backlog -> ('a, Masc_error.t) result)
+    : ('a, Masc_error.t) result =
+  Coord.with_file_lock config (backlog_lock_path config) (fun () ->
+    match Coord.read_backlog_r config with
+    | Error msg -> Error (System (System_error.IoError msg))
+    | Ok backlog -> f backlog)
+
 (** Update task status (claim, start, complete, cancel) *)
 let update_status config ~task_id ~status =
   match backend () with
   | Jsonl ->
-      let backlog = Coord.read_backlog config in
-      let task_opt = List.find_opt (fun (t : task) -> t.id = task_id) backlog.tasks in
-      (match task_opt with
-       | None -> Error (Task (Task_error.NotFound task_id))
-       | Some t ->
-          match validate_transition ~current:t.task_status ~next:status ~task_id with
-          | Error e -> Error e
-          | Ok () ->
-            let updated_tasks = List.map (fun (t : task) ->
-              if t.id = task_id then { t with task_status = status } else t
-            ) backlog.tasks in
-            let new_backlog = {
-              tasks = updated_tasks;
-              last_updated = now_iso ();
-              version = backlog.version + 1;
-            } in
-            Coord.write_backlog config new_backlog;
-            Ok ())
+      with_locked_backlog config (fun backlog ->
+        let task_opt =
+          List.find_opt (fun (t : task) -> t.id = task_id) backlog.tasks
+        in
+        match task_opt with
+        | None -> Error (Task (Task_error.NotFound task_id))
+        | Some t -> (
+            match validate_transition ~current:t.task_status ~next:status ~task_id with
+            | Error e -> Error e
+            | Ok () ->
+                let updated_tasks =
+                  List.map
+                    (fun (t : task) ->
+                      if t.id = task_id then { t with task_status = status } else t)
+                    backlog.tasks
+                in
+                let new_backlog =
+                  {
+                    tasks = updated_tasks;
+                    last_updated = now_iso ();
+                    version = backlog.version + 1;
+                  }
+                in
+                Coord.write_backlog config new_backlog;
+                Ok ()))
 
 (** Delete a task *)
 let delete_task config ~task_id =
   match backend () with
   | Jsonl ->
-      let backlog = Coord.read_backlog config in
-      let new_tasks = List.filter (fun (t : task) -> t.id <> task_id) backlog.tasks in
-      let new_backlog = {
-        tasks = new_tasks;
-        last_updated = now_iso ();
-        version = backlog.version + 1;
-      } in
-      Coord.write_backlog config new_backlog;
-      Ok ()
-
+      with_locked_backlog config (fun backlog ->
+        let new_tasks =
+          List.filter (fun (t : task) -> t.id <> task_id) backlog.tasks
+        in
+        let new_backlog =
+          {
+            tasks = new_tasks;
+            last_updated = now_iso ();
+            version = backlog.version + 1;
+          }
+        in
+        Coord.write_backlog config new_backlog;
+        Ok ())

--- a/lib/task_dispatch.mli
+++ b/lib/task_dispatch.mli
@@ -105,19 +105,22 @@ val update_status :
   task_id:string ->
   status:Masc_domain.task_status ->
   (unit, Masc_error.t) result
-(** [update_status config ~task_id ~status] reads the backlog,
+(** [update_status config ~task_id ~status] takes the Coord [.backlog]
+    file lock, reads the backlog,
     runs {!validate_transition}, and on success rewrites the task
     list with the new status, bumping [version] and refreshing
     [last_updated] (ISO 8601 of the current monotonic time).
     Errors:
     - [TaskNotFound task_id] when the task is absent.
-    - [TaskInvalidState <message>] from {!validate_transition}. *)
+    - [TaskInvalidState <message>] from {!validate_transition}.
+    - [System IoError <message>] when the backlog cannot be read. *)
 
 val delete_task :
   Coord.config ->
   task_id:string ->
   (unit, Masc_error.t) result
-(** [delete_task config ~task_id] filters the task out of the
+(** [delete_task config ~task_id] takes the Coord [.backlog] file lock,
+    filters the task out of the
     backlog and writes it back with [version] bumped.  Idempotent
     — deleting a non-existent task is silently a no-op (always
-    returns [Ok ()]).  Always [Ok _] on the JSONL backend. *)
+    returns [Ok ()] when the backlog is readable). *)

--- a/test/test_task_dispatch.ml
+++ b/test/test_task_dispatch.ml
@@ -39,6 +39,125 @@ let test_add_task_in_jsonl_mode () =
           Alcotest.(check bool) "returns success message" true
             (String.length message > 0))
 
+let test_update_status_and_delete_use_locked_jsonl_path () =
+  with_temp_config (fun config ->
+      ignore (Coord.init config ~agent_name:(Some "tester"));
+      Task_dispatch.reset_for_test ();
+      Task_dispatch.init_jsonl ();
+      let task_id =
+        match
+          Task_dispatch.add_task config ~title:"locked dispatch task" ~priority:3
+            ~description:"from task dispatch lock test"
+        with
+        | Error e -> Alcotest.fail (Masc_domain.show_masc_error e)
+        | Ok _ ->
+            let backlog = Coord.read_backlog config in
+            (match backlog.tasks with
+             | [ task ] -> task.Masc_domain.id
+             | tasks ->
+                 Alcotest.failf "expected exactly one task, got %d"
+                   (List.length tasks))
+      in
+      let status =
+        Masc_domain.Claimed
+          { assignee = "tester"; claimed_at = Masc_domain.now_iso () }
+      in
+      (match Task_dispatch.update_status config ~task_id ~status with
+       | Ok () -> ()
+       | Error e -> Alcotest.fail (Masc_domain.show_masc_error e));
+      let updated = Coord.read_backlog config in
+      Alcotest.(check int) "version bumped by update" 3 updated.version;
+      (match updated.tasks with
+       | [ task ] ->
+           Alcotest.(check bool)
+             "task claimed"
+             true
+             (match task.Masc_domain.task_status with
+              | Masc_domain.Claimed { assignee; _ } -> String.equal assignee "tester"
+              | _ -> false)
+       | tasks ->
+           Alcotest.failf "expected exactly one task after update, got %d"
+             (List.length tasks));
+      (match Task_dispatch.delete_task config ~task_id with
+       | Ok () -> ()
+       | Error e -> Alcotest.fail (Masc_domain.show_masc_error e));
+      let deleted = Coord.read_backlog config in
+      Alcotest.(check int) "version bumped by delete" 4 deleted.version;
+      Alcotest.(check int) "task deleted" 0 (List.length deleted.tasks))
+
+let write_string path content =
+  let oc = open_out path in
+  Fun.protect
+    ~finally:(fun () -> close_out_noerr oc)
+    (fun () -> output_string oc content)
+
+let test_update_status_and_delete_return_error_when_backlog_unreadable () =
+  with_temp_config (fun config ->
+      ignore (Coord.init config ~agent_name:(Some "tester"));
+      Task_dispatch.reset_for_test ();
+      Task_dispatch.init_jsonl ();
+      let backlog_path = Filename.concat (Coord.tasks_dir config) "backlog.json" in
+      write_string backlog_path "{not-json";
+      write_string (backlog_path ^ ".last-good") "{not-json";
+      let status =
+        Masc_domain.Claimed
+          { assignee = "tester"; claimed_at = Masc_domain.now_iso () }
+      in
+      let expect_io_error label = function
+        | Error (Masc_domain.System (Masc_domain.System_error.IoError _)) -> ()
+        | Ok () -> Alcotest.failf "%s unexpectedly succeeded" label
+        | Error e ->
+            Alcotest.failf "%s returned unexpected error: %s" label
+              (Masc_domain.show_masc_error e)
+      in
+      expect_io_error "update_status"
+        (Task_dispatch.update_status config ~task_id:"missing" ~status);
+      expect_io_error "delete_task"
+        (Task_dispatch.delete_task config ~task_id:"missing");
+      let ic = open_in backlog_path in
+      let primary =
+        Fun.protect
+          ~finally:(fun () -> close_in_noerr ic)
+          (fun () -> really_input_string ic (in_channel_length ic))
+      in
+      Alcotest.(check string)
+        "primary backlog not rewritten via empty fallback" "{not-json" primary)
+
+let test_task_dispatch_source_pins_backlog_lock () =
+  let candidates =
+    [
+      "lib/task_dispatch.ml";
+      "../lib/task_dispatch.ml";
+      "../../lib/task_dispatch.ml";
+    ]
+  in
+  let source =
+    match List.find_opt Sys.file_exists candidates with
+    | Some path ->
+        let ic = open_in path in
+        Fun.protect
+          ~finally:(fun () -> close_in_noerr ic)
+          (fun () -> really_input_string ic (in_channel_length ic))
+    | None -> Alcotest.skip ()
+  in
+  let contains s sub =
+    let n = String.length s and m = String.length sub in
+    let rec loop i =
+      if i + m > n then false
+      else if String.sub s i m = sub then true
+      else loop (i + 1)
+    in
+    if m = 0 then true else loop 0
+  in
+  Alcotest.(check bool)
+    "Task_dispatch mutations use Coord backlog lock"
+    true
+    (contains source "Coord.with_file_lock config (backlog_lock_path config)");
+  Alcotest.(check bool)
+    "Task_dispatch mutations read backlog as result under lock"
+    true
+    (contains source "Coord.read_backlog_r config")
+
 let test_reset_clears_pg_state_shape () =
   Task_dispatch.reset_for_test ();
   Task_dispatch.init_jsonl ();
@@ -55,5 +174,14 @@ let () =
           Alcotest.test_case "reset clears state" `Quick
             test_reset_clears_pg_state_shape;
         ] );
-      ("jsonl", [ Alcotest.test_case "add task" `Quick test_add_task_in_jsonl_mode ]);
+      ( "jsonl",
+        [
+          Alcotest.test_case "add task" `Quick test_add_task_in_jsonl_mode;
+          Alcotest.test_case "update/delete use locked path" `Quick
+            test_update_status_and_delete_use_locked_jsonl_path;
+          Alcotest.test_case "update/delete fail on unreadable backlog" `Quick
+            test_update_status_and_delete_return_error_when_backlog_unreadable;
+          Alcotest.test_case "source pins backlog lock" `Quick
+            test_task_dispatch_source_pins_backlog_lock;
+        ] );
     ]


### PR DESCRIPTION
## Summary
- wrap Task_dispatch.update_status and Task_dispatch.delete_task in the same Coord .backlog file lock used by the core task paths
- read the backlog through read_backlog_r while holding the lock so decode/storage failures return an error instead of falling back to an empty backlog and rewriting it
- add focused Task_dispatch coverage for update/delete behavior and a source guard that pins the backlog lock wiring

## Audit context
Kimi's audit claim that Task_dispatch.backend_state still used ref is stale; current code already uses Atomic.t. The remaining live issue is the same class of lost-update risk in the JSONL mutation paths: update_status/delete_task performed read-modify-write without the .backlog lock used by Coord claim/schedule/transition paths.

## Why this matters
Keeper task progress depends on durable backlog state. Unlocked helper mutations can race with claim/schedule/transition writes and lose task status changes under concurrent keepers or dashboard actions.

## Validation
- ocamlc -stop-after parsing lib/task_dispatch.ml
- ocamlc -stop-after parsing lib/task_dispatch.mli
- ocamlc -stop-after parsing test/test_task_dispatch.ml
- scripts/dune-local.sh build test/test_task_dispatch.exe
- ./_build/default/test/test_task_dispatch.exe
- git diff --check

## Review focus
- confirm .backlog lock path matches existing Coord task mutation paths
- confirm read_backlog_r error propagation is preferable to read_backlog's empty fallback for mutation paths
- confirm source-level guard is narrow enough for this concurrency invariant