### PR TITLE
feat(oas): activate max_execution_time_s in recovery branch

### DIFF
--- a/lib/oas_worker_named_error.ml
+++ b/lib/oas_worker_named_error.ml
@@ -583,6 +583,18 @@ let config_for_label
       temperature;
       max_idle_turns;
       stream_idle_timeout_s;
+      max_execution_time_s =
+        (* Mirror the cascade-driven activation at
+           [oas_worker_named.ml:389] so recovery-path [Agent.run]
+           calls also engage agent_sdk's [with_optional_timeout]
+           on hang instead of blocking until the whole-keeper
+           [turn_timeout]. Default 300 s, env override via
+           [MASC_KEEPER_OAS_TIMEOUT_SEC] (#10008 fm2 ignores the
+           [estimated_input_tokens] arg, so passing 0 is fine). *)
+        Some
+          (Keeper_runtime_resolved
+           .oas_timeout_for_estimated_input_tokens
+             ~estimated_input_tokens:0);
       guardrails;
       hooks;
       context_reducer;


### PR DESCRIPTION
## Summary

Closes the recovery-path gap explicitly deferred in PR #13933. Mirrors that PR's one-line `max_execution_time_s` activation at the recovery-branch config-build site so every `Agent.run` invocation in masc-mcp now engages agent_sdk's `with_optional_timeout` wrapper.

## Background

PR #13933 wired `max_execution_time_s` for the cascade-FSM-driven `Agent.run` at `oas_worker_named.ml:389`. Its PR body explicitly listed the recovery branch as out of scope:

> `oas_worker_named_error.ml:527` (recovery branch) still calls `default_config` without setting `max_execution_time_s`. That path is secondary and lower hang-risk; can be wired in a follow-up if production observes hangs there.

This PR is that follow-up. It does not wait for production to observe a hang because the marginal cost is one record field; engaging the per-OAS-call ceiling on both paths is the conservative default.

## What changes

`lib/oas_worker_named_error.ml`: one new record-field inside the `Oas_worker_exec.default_config { ... with ... }` expression at the recovery-branch config builder. Value sourced from the same resolver the cascade path uses (`Keeper_runtime_resolved.oas_timeout_for_estimated_input_tokens`), default 300 s, env override `MASC_KEEPER_OAS_TIMEOUT_SEC`.

```ocaml
max_execution_time_s =
  Some
    (Keeper_runtime_resolved
     .oas_timeout_for_estimated_input_tokens
       ~estimated_input_tokens:0);
```

Net diff: 1 file / +12 / 0.

## Why this scale

Same reasoning as PR #13933: per-OAS-call (~300 s default), not whole-keeper-turn (`turn_timeout_sec`, 600 s). One slow provider in the recovery flow shouldn't eat the entire turn before the cascade can fall back. The resolver clamps to `min(turn_timeout, 300)` so it never exceeds the keeper budget.

The `estimated_input_tokens` argument is currently ignored by the resolver (#10008 fm2 dropped per-token scaling), so passing 0 is fine.

## Out of scope

- `oas_worker_named_error.ml`'s recovery flow does not currently emit on `masc_keeper_oas_run_timeout_total` (that counter sits in `oas_worker_named_fsm.emit_sdk_provider_error_metric`, only called from the cascade path). If recovery hangs need observability too, wiring `emit_oas_run_timeout_metric` into the recovery error path is a separate ~10 LOC follow-up.
- Test coverage for the recovery-branch behaviour. The change is structurally identical to PR #13933's cascade-path change; test surface there is sufficient to guard the resolver's contract.

## Test plan

- [x] `dune build --root . @check` — clean.
- [ ] CI green — pending after push.
- [ ] Production probe (post-merge): if recovery-path hangs were occurring, expect them to terminate at ~300 s with `Retry.Timeout` instead of blocking until `turn_timeout`.

## Refs

- Goal: `oas-bridge-stabilization` (recovery-path follow-up).
- Parent (merged): PR #13923 (wire), PR #13933 (cascade-path activation), PR #13941 (counter).
- Companion: PR #13901 (turn_timeout 600→900 ceiling, MERGEABLE), PR #13948 (prefix classifier + tests, MERGEABLE).
- Plan: `~/me/planning/claude-plans/20m-me-workspace-yousleepwhen-masc-mcp-o-recursive-mountain.md`.

RFC-WAIVED: this PR touches only `lib/oas_worker_named_error.ml`. No credential / identity / auth / sandbox / dashboard-credential / hooks / workflow paths from the RFC discovery list are touched.
