### PR TITLE
fix(keeper): make tool search fallback truthful

### DIFF
--- a/lib/keeper/keeper_exec_tools.ml
+++ b/lib/keeper/keeper_exec_tools.ml
@@ -37,10 +37,131 @@ let record_keeper_tool_call ~tool_name ~success ~duration_ms =
   in
   f ~tool_name ~success ~duration_ms
 
+let search_char c =
+  match c with
+  | 'a' .. 'z' | 'A' .. 'Z' | '0' .. '9' | '_' | '-' -> c
+  | _ -> ' '
+
+let normalize_search_text text =
+  String.lowercase_ascii (String.map search_char text)
+
+let contains_substring text needle =
+  let text_len = String.length text in
+  let needle_len = String.length needle in
+  let rec loop idx =
+    idx + needle_len <= text_len
+    && (String.sub text idx needle_len = needle || loop (idx + 1))
+  in
+  needle_len = 0 || loop 0
+
+let search_terms query =
+  normalize_search_text query
+  |> String.split_on_char ' '
+  |> List.map String.trim
+  |> List.filter (fun term -> term <> "")
+  |> List.sort_uniq String.compare
+
+let dedupe_tool_search_schemas schemas =
+  let seen = Hashtbl.create (List.length schemas) in
+  List.filter
+    (fun (schema : Masc_domain.tool_schema) ->
+       if Hashtbl.mem seen schema.name then false
+       else begin
+         Hashtbl.replace seen schema.name ();
+         true
+       end)
+    schemas
+
+let default_tool_search_schemas () =
+  Tool_shard.all_keeper_tool_schemas
+  @ [ keeper_tool_search_schema ]
+  |> List.filter (fun (schema : Masc_domain.tool_schema) ->
+       not (is_keeper_denied schema.name))
+  |> dedupe_tool_search_schemas
+
+let score_tool_schema terms (schema : Masc_domain.tool_schema) =
+  let help = Tool_help_registry.entry_of_schema schema in
+  let name_text = normalize_search_text schema.name in
+  let search_text =
+    normalize_search_text
+      (String.concat " "
+         [ schema.name;
+           schema.description;
+           help.Tool_help_registry.when_to_use;
+           Yojson.Safe.to_string schema.input_schema;
+         ])
+  in
+  List.fold_left
+    (fun score term ->
+       if contains_substring name_text term then score +. 2.0
+       else if contains_substring search_text term then score +. 1.0
+       else score)
+    0.0
+    terms
+
+let default_tool_search_fn ~query ~max_results =
+  let terms = search_terms query in
+  let schemas = default_tool_search_schemas () in
+  let hits =
+    schemas
+    |> List.filter_map
+         (fun schema ->
+            let score = score_tool_schema terms schema in
+            if Float.compare score 0.0 <= 0 then None
+            else Some (schema, score))
+    |> List.sort
+         (fun (left_schema, left_score) (right_schema, right_score) ->
+            let by_score = compare right_score left_score in
+            if by_score <> 0 then by_score
+            else String.compare left_schema.Masc_domain.name right_schema.name)
+  in
+  let rec take n xs =
+    if n <= 0 then []
+    else
+      match xs with
+      | [] -> []
+      | x :: rest -> x :: take (n - 1) rest
+  in
+  let selected = take max_results hits in
+  let result_json (schema, score) =
+    let help = Tool_help_registry.entry_of_schema schema in
+    `Assoc
+      [
+        ("name", `String schema.Masc_domain.name);
+        ("score", `Float score);
+        ("description", `String help.short_description);
+        ("when_to_use", `String help.when_to_use);
+        ("input_schema", schema.input_schema);
+        ("already_visible", `Bool false);
+      ]
+  in
+  let results = List.map result_json selected in
+  let hint =
+    if results = [] then
+      "No tools match this static fallback query. In normal keeper turns, \
+       the session-scoped BM25 index provides richer policy-aware search."
+    else
+      "Static fallback results from keeper schemas. Normal keeper turns \
+       use the richer session-scoped BM25 index."
+  in
+  `Assoc
+    [
+      ("ok", `Bool true);
+      ("query", `String query);
+      ("results", `List results);
+      ("result_count", `Int (List.length results));
+      ( "diagnostics",
+        `Assoc
+          [
+            ("source", `String "static_schema_fallback");
+            ("candidate_count", `Int (List.length schemas));
+          ] );
+      ("hint", `String hint);
+    ]
+
 type tool_searcher = query:string -> max_results:int -> Yojson.Safe.t
 
-let default_tool_searcher ~query:_ ~max_results:_ =
-  `Assoc [ ("results", `List []) ]
+let default_tool_searcher = default_tool_search_fn
 
 let tool_searcher_mutex = Stdlib.Mutex.create ()
 let tool_searcher = ref default_tool_searcher

--- a/lib/keeper/keeper_exec_tools.ml
+++ b/lib/keeper/keeper_exec_tools.ml
@@ -40,6 +40,7 @@ let record_keeper_tool_call ~tool_name ~success ~duration_ms =
 let search_char c =
   match c with
   | 'a' .. 'z' | 'A' .. 'Z' | '0' .. '9' | '_' | '-' -> c
+  | _ when Char.code c > 127 -> c
   | _ -> ' '
 
 let normalize_search_text text =

--- a/test/test_keeper_task_dispatch.ml
+++ b/test/test_keeper_task_dispatch.ml
@@ -1234,12 +1234,26 @@ let test_tool_search_whitespace_query_returns_error () =
 let test_tool_search_returns_results_list () =
   with_room (fun config ->
     let meta = make_test_meta () in
-    (* With no custom search_fn, the global default returns {results:[]} *)
+    (* With no custom search_fn, the global default must still be truthful:
+       search the static keeper schema universe instead of claiming no tools
+       match. Normal keeper turns pass a richer session-scoped BM25 search_fn. *)
     let result = call_tool config meta "keeper_tool_search"
-      (`Assoc [ ("query", `String "filesystem read write") ]) in
+      (`Assoc [ ("query", `String "filesystem read file") ]) in
     let json = parse_json result in
     match Yojson.Safe.Util.member "results" json with
-    | `List _ -> () (* results field present *)
+    | `List results ->
+      check bool "default search returns static fallback hits" true
+        (List.length results > 0);
+      let names =
+        List.filter_map
+          (fun hit ->
+             match Yojson.Safe.Util.member "name" hit with
+             | `String name -> Some name
+             | _ -> None)
+          results
+      in
+      check bool "keeper_fs_read discoverable by default" true
+        (List.mem "keeper_fs_read" names)
     | _ -> fail "expected results list in response")
 
 let test_tool_search_max_results_clamped_to_10 () =


### PR DESCRIPTION
## Summary
- Replaces the process-global keeper_tool_search default from an empty {results:[]} stub with a static schema fallback.
- Searches the built-in keeper schema universe by name, description, help text, and input schema when no session-scoped BM25 search_fn is installed.
- Keeps runtime policy context conservative: session search still wins, and the fallback excludes keeper-denied tools rather than exposing injected masc_* schemas without keeper metadata.

## Why It Matters
Keeper turns that missed the session search_fn path could previously receive a successful empty result and conclude that no filesystem or command tools existed. That is operationally misleading for autonomy: tool discovery should degrade to a truthful, bounded static search instead of a false negative.

## Validation
- ocamlc -stop-after parsing lib/keeper/keeper_exec_tools.ml
- ocamlc -stop-after parsing test/test_keeper_task_dispatch.ml
- git diff --check
- scripts/dune-local.sh build test/test_keeper_task_dispatch.exe
- ./_build/default/test/test_keeper_task_dispatch.exe (38 tests)
- scripts/dune-local.sh build test/test_keeper_exec_tools.exe

## Local Notes
- ./_build/default/test/test_keeper_exec_tools.exe still fails in an unrelated exec_cache case: the second docker echo call is not reported cached. The changed keeper_tool_search fallback assertions are covered by test_keeper_task_dispatch.exe.
- ocamlformat --check exits 1 without diagnostics for the touched files in this worktree, so this PR preserves the surrounding repo style instead of applying file-wide formatter churn.

## Review Focus
- Verify the fallback is intentionally static and policy-conservative when no per-turn BM25 search_fn is available.
- Check that result scoring stays simple and deterministic without introducing a second dynamic indexing path.