### PR TITLE
fix(keeper): fail closed without LLM bridge clock

### DIFF
--- a/lib/keeper/keeper_llm_bridge.ml
+++ b/lib/keeper/keeper_llm_bridge.ml
@@ -8,31 +8,38 @@
     (functional rollback), external tool side effects are not reverted.
 
     Timeout returns [Agent_sdk.Error.Api (Timeout ...)].
+    Missing Eio clock returns [Agent_sdk.Error.Internal] without running the
+    function because the bridge cannot enforce the advertised structural
+    timeout.
     Cancellation (server shutdown / parent fiber cancel) re-raises so the caller
     exits immediately instead of retrying. *)
 let run_with_timeout_and_fallback ~timeout_s fn =
-  let clock_opt = (Masc_eio_env.get ()).clock in
-  let t0 =
-    match clock_opt with
-    | Some clock -> Eio.Time.now clock
-    | None -> Unix.gettimeofday ()
+  let fail_without_clock ~site =
+    let message =
+      Printf.sprintf
+        "keeper_llm_bridge: Eio clock unavailable (%s); refusing to run OAS execution \
+         without enforcing timeout_s=%.0f"
+        site
+        timeout_s
+    in
+    Prometheus.inc_counter
+      Keeper_metrics.metric_keeper_llm_bridge_failures
+      ~labels:[ "site", "no_clock" ]
+      ();
+    Log.Keeper.error "%s" message;
+    Error (Agent_sdk.Error.Internal message)
   in
-  let elapsed () =
-    match clock_opt with
-    | Some clock -> Eio.Time.now clock -. t0
-    | None -> Unix.gettimeofday () -. t0
-  in
-  let do_timeout fn =
-    match clock_opt with
-    | Some clock -> Eio.Time.with_timeout_exn clock timeout_s fn
-    | None -> fn ()
-  in
-  try
-    do_timeout fn
-  with
-  | Eio.Time.Timeout ->
-    let wall = elapsed () in
-    (* #9639/#9662: Eio cancel is cooperative — [with_timeout_exn] fires
+  match Masc_eio_env.get_opt () with
+  | None -> fail_without_clock ~site:"env_not_initialized"
+  | Some { Masc_eio_env.clock = None; _ } ->
+    fail_without_clock ~site:"clock_not_initialized"
+  | Some { Masc_eio_env.clock = Some clock; _ } ->
+    let t0 = Eio.Time.now clock in
+    let elapsed () = Eio.Time.now clock -. t0 in
+    (try Eio.Time.with_timeout_exn clock timeout_s fn with
+     | Eio.Time.Timeout ->
+       let wall = elapsed () in
+       (* #9639/#9662: Eio cancel is cooperative — [with_timeout_exn] fires
        but the fiber must reach a cancel point (single_read, yield, etc.)
        to actually interrupt. Surface overshoot as a structured warn so
        stalls remain observable instead of silently inflating wall time.
@@ -54,72 +61,91 @@ let run_with_timeout_and_fallback ~timeout_s fn =
        ~/me/scripts/oas-hung-keeper-dump.sh to capture the fiber stack
        and identify the real layer.  Cross-ref:
        jeong-sik/me planning/claude-plans/oas-execution-cancellability.md *)
-    let deadline =
-      Timeout_policy.Deadline.make
-        ~layer:Timeout_policy.Layer.Oas_bridge
-        ~origin:"keeper_llm_bridge"
-        ~wall_cap_s:timeout_s
-        ~now:(t0)
-    in
-    let _ : bool =
-      Timeout_policy.overshoot_warn ~deadline ~actual_wall_s:wall ()
-    in
-    Prometheus.inc_counter
-      Keeper_metrics.metric_keeper_llm_bridge_failures
-      ~labels:[("site", "timeout")]
-      ();
-    Log.Keeper.warn
-      "keeper_llm_bridge: OAS execution timed out after %.1fs (budget=%.0fs; OAS context rollback only; external tool side effects are not reverted)"
-      wall timeout_s;
-    Error (Agent_sdk.Error.Api (Timeout { message = Printf.sprintf "Timeout after %.1fs (budget=%.0fs)" wall timeout_s }))
-  | Eio.Cancel.Cancelled inner_exn as exn ->
-    (* TLA+: FiberHandlesCancellation -> Rollback context.
-       Cancelled means a parent fiber (server shutdown, global stop) requested
-       cancellation — NOT a timeout. Re-raise so the keeper exits immediately
-       instead of entering the retry loop.
+       let deadline =
+         Timeout_policy.Deadline.make
+           ~layer:Timeout_policy.Layer.Oas_bridge
+           ~origin:"keeper_llm_bridge"
+           ~wall_cap_s:timeout_s
+           ~now:t0
+       in
+       let _ : bool = Timeout_policy.overshoot_warn ~deadline ~actual_wall_s:wall () in
+       Prometheus.inc_counter
+         Keeper_metrics.metric_keeper_llm_bridge_failures
+         ~labels:[ "site", "timeout" ]
+         ();
+       Log.Keeper.warn
+         "keeper_llm_bridge: OAS execution timed out after %.1fs (budget=%.0fs; OAS \
+          context rollback only; external tool side effects are not reverted)"
+         wall
+         timeout_s;
+       Error
+         (Agent_sdk.Error.Api
+            (Timeout
+               { message =
+                   Printf.sprintf "Timeout after %.1fs (budget=%.0fs)" wall timeout_s
+               }))
+     | Eio.Cancel.Cancelled inner_exn as exn ->
+       (* TLA+: FiberHandlesCancellation -> Rollback context.
+          Cancelled means a parent fiber (server shutdown, global stop) requested
+          cancellation — NOT a timeout. Re-raise so the keeper exits immediately
+          instead of entering the retry loop.
 
-       #10716: bimodal distribution observed in production — 21 events in
-       [60, 300)s (short-tail, routine cancel: supervisor pause / cascade
-       rotation) plus 8 events ≥1800s (long-tail, LLM provider hung). Same
-       opaque message for both made root-cause attribution impossible.
-       Categorize wall duration into a discrete bucket and surface the
-       inner cancel exception so operators can split short_tail / mid_tail
-       / long_tail in PromQL and the inner reason ([Eio.Cancel.Cancel_hook]
-       payload, parent-fiber Cancelled, etc.) appears in the log. *)
-    let bt = Printexc.get_raw_backtrace () in
-    let wall = elapsed () in
-    let bucket =
-      if wall < 60.0 then "fast"
-      else if wall < 300.0 then "short_tail"
-      else if wall < 600.0 then "mid_tail"
-      else if wall < 1800.0 then "long_mid"
-      else "long_tail"
-    in
-    let inner_str =
-      match inner_exn with
-      | Failure msg -> "Failure(" ^ msg ^ ")"
-      | _ -> Printexc.to_string inner_exn
-    in
-    Prometheus.inc_counter
-      Keeper_metrics.metric_keeper_llm_bridge_failures
-      ~labels:[("site", "cancelled")]
-      ();
-    Log.Keeper.warn
-      "keeper_llm_bridge: OAS execution cancelled after %.1fs bucket=%s inner=%s (re-raising; OAS context rollback only; external tool side effects are not reverted)"
-      wall bucket inner_str;
-    Prometheus.inc_counter Keeper_metrics.metric_keeper_oas_cancel
-      ~labels:[ ("bucket", bucket) ]
-      ();
-    Printexc.raise_with_backtrace exn bt
-  | exn ->
-    (* TLA+: HandleError -> Rollback context *)
-    let bt = Printexc.get_backtrace () in
-    Prometheus.inc_counter Keeper_metrics.metric_keeper_oas_execution_errors
-      ~labels:[("channel", "oas_bridge")]
-      ();
-    Prometheus.inc_counter
-      Keeper_metrics.metric_keeper_llm_bridge_failures
-      ~labels:[("site", "execution_error")]
-      ();
-    Log.Keeper.error "keeper_llm_bridge: OAS execution error: %s\n%s" (Printexc.to_string exn) bt;
-    Error (Agent_sdk.Error.Internal (Printexc.to_string exn))
+          #10716: bimodal distribution observed in production — 21 events in
+          [60, 300)s (short-tail, routine cancel: supervisor pause / cascade
+          rotation) plus 8 events ≥1800s (long-tail, LLM provider hung). Same
+          opaque message for both made root-cause attribution impossible.
+          Categorize wall duration into a discrete bucket and surface the
+          inner cancel exception so operators can split short_tail / mid_tail
+          / long_tail in PromQL and the inner reason ([Eio.Cancel.Cancel_hook]
+          payload, parent-fiber Cancelled, etc.) appears in the log. *)
+       let bt = Printexc.get_raw_backtrace () in
+       let wall = elapsed () in
+       let bucket =
+         if wall < 60.0
+         then "fast"
+         else if wall < 300.0
+         then "short_tail"
+         else if wall < 600.0
+         then "mid_tail"
+         else if wall < 1800.0
+         then "long_mid"
+         else "long_tail"
+       in
+       let inner_str =
+         match inner_exn with
+         | Failure msg -> "Failure(" ^ msg ^ ")"
+         | _ -> Printexc.to_string inner_exn
+       in
+       Prometheus.inc_counter
+         Keeper_metrics.metric_keeper_llm_bridge_failures
+         ~labels:[ "site", "cancelled" ]
+         ();
+       Log.Keeper.warn
+         "keeper_llm_bridge: OAS execution cancelled after %.1fs bucket=%s inner=%s \
+          (re-raising; OAS context rollback only; external tool side effects are not \
+          reverted)"
+         wall
+         bucket
+         inner_str;
+       Prometheus.inc_counter
+         Keeper_metrics.metric_keeper_oas_cancel
+         ~labels:[ "bucket", bucket ]
+         ();
+       Printexc.raise_with_backtrace exn bt
+     | exn ->
+       (* TLA+: HandleError -> Rollback context *)
+       let bt = Printexc.get_backtrace () in
+       Prometheus.inc_counter
+         Keeper_metrics.metric_keeper_oas_execution_errors
+         ~labels:[ "channel", "oas_bridge" ]
+         ();
+       Prometheus.inc_counter
+         Keeper_metrics.metric_keeper_llm_bridge_failures
+         ~labels:[ "site", "execution_error" ]
+         ();
+       Log.Keeper.error
+         "keeper_llm_bridge: OAS execution error: %s\n%s"
+         (Printexc.to_string exn)
+         bt;
+       Error (Agent_sdk.Error.Internal (Printexc.to_string exn)))
+;;

--- a/lib/keeper/keeper_llm_bridge.mli
+++ b/lib/keeper/keeper_llm_bridge.mli
@@ -5,11 +5,13 @@
 
     - Timeout: OAS-local context mutations are discarded (functional rollback),
       external tool side effects are not reverted, returns [Error (Agent_sdk.Error.Api Timeout)].
+    - Missing Eio clock: returns [Error (Agent_sdk.Error.Internal _)] without
+      running the function because the timeout cannot be enforced.
     - Cancellation (server shutdown / parent fiber cancel): re-raises
       [Eio.Cancel.Cancelled] so the caller exits immediately without retrying.
 
     @raises Eio.Cancel.Cancelled when the parent fiber/switch is cancelled. *)
-val run_with_timeout_and_fallback :
-  timeout_s:float ->
-  (unit -> ('a, Agent_sdk.Error.sdk_error) result) ->
-  ('a, Agent_sdk.Error.sdk_error) result
+val run_with_timeout_and_fallback
+  :  timeout_s:float
+  -> (unit -> ('a, Agent_sdk.Error.sdk_error) result)
+  -> ('a, Agent_sdk.Error.sdk_error) result

--- a/test/dune
+++ b/test/dune
@@ -64,6 +64,7 @@
         test_keeper_hooks_oas_pricing
         test_keeper_hooks_oas_telemetry
         test_masc_oas_bridge_timeout_guard
+        test_keeper_llm_bridge
         test_agent_stress
         test_keeper_tool_use_failure_counter
         test_keeper_compaction_outcome_counter
@@ -302,6 +303,7 @@
           test_keeper_hooks_oas_pricing
           test_keeper_hooks_oas_telemetry
           test_masc_oas_bridge_timeout_guard
+          test_keeper_llm_bridge
           test_agent_stress
           test_keeper_tool_use_failure_counter
           test_keeper_compaction_outcome_counter

--- a/test/test_keeper_llm_bridge.ml
+++ b/test/test_keeper_llm_bridge.ml
@@ -1,0 +1,88 @@
+open Masc_mcp
+
+let contains_substring text needle =
+  let text_len = String.length text in
+  let needle_len = String.length needle in
+  let rec loop idx =
+    idx + needle_len <= text_len
+    && (String.sub text idx needle_len = needle || loop (idx + 1))
+  in
+  needle_len = 0 || loop 0
+;;
+
+let assert_no_clock_error ~label ~called result =
+  Alcotest.(check bool) (label ^ ": function was not called") false !called;
+  match result with
+  | Error (Agent_sdk.Error.Internal msg) ->
+    Alcotest.(check bool)
+      (label ^ ": message names no-clock failure")
+      true
+      (contains_substring msg "Eio clock unavailable");
+    Alcotest.(check bool)
+      (label ^ ": message names timeout")
+      true
+      (contains_substring msg "timeout_s=1")
+  | Error err ->
+    Alcotest.failf "unexpected error shape: %s" (Agent_sdk.Error.to_string err)
+  | Ok value -> Alcotest.failf "unexpected success: %s" value
+;;
+
+let test_missing_env_fails_closed_without_calling_fn () =
+  Masc_eio_env.reset_for_test ();
+  let called = ref false in
+  let result =
+    Keeper_llm_bridge.run_with_timeout_and_fallback ~timeout_s:1.0 (fun () ->
+      called := true;
+      Ok "should-not-run")
+  in
+  assert_no_clock_error ~label:"missing env" ~called result
+;;
+
+let test_clockless_env_fails_closed_without_calling_fn () =
+  Eio_main.run (fun env ->
+    Eio.Switch.run (fun sw ->
+      Masc_eio_env.reset_for_test ();
+      Fun.protect ~finally:Masc_eio_env.reset_for_test (fun () ->
+        Masc_eio_env.init ~sw ~net:(Eio.Stdenv.net env) ();
+        let called = ref false in
+        let result =
+          Keeper_llm_bridge.run_with_timeout_and_fallback ~timeout_s:1.0 (fun () ->
+            called := true;
+            Ok "should-not-run")
+        in
+        assert_no_clock_error ~label:"clockless env" ~called result)))
+;;
+
+let test_clocked_env_runs_function () =
+  Eio_main.run (fun env ->
+    Eio.Switch.run (fun sw ->
+      Masc_eio_env.reset_for_test ();
+      Fun.protect ~finally:Masc_eio_env.reset_for_test (fun () ->
+        Masc_eio_env.init ~sw ~net:(Eio.Stdenv.net env) ~clock:(Eio.Stdenv.clock env) ();
+        let called = ref false in
+        match
+          Keeper_llm_bridge.run_with_timeout_and_fallback ~timeout_s:1.0 (fun () ->
+            called := true;
+            Ok "ok")
+        with
+        | Ok "ok" -> Alcotest.(check bool) "function was called" true !called
+        | Ok other -> Alcotest.failf "unexpected success: %s" other
+        | Error err -> Alcotest.fail (Agent_sdk.Error.to_string err))))
+;;
+
+let () =
+  Alcotest.run
+    "keeper_llm_bridge"
+    [ ( "timeout clock"
+      , [ Alcotest.test_case
+            "missing env fails closed"
+            `Quick
+            test_missing_env_fails_closed_without_calling_fn
+        ; Alcotest.test_case
+            "clockless env fails closed"
+            `Quick
+            test_clockless_env_fails_closed_without_calling_fn
+        ; Alcotest.test_case "clocked env runs" `Quick test_clocked_env_runs_function
+        ] )
+    ]
+;;


### PR DESCRIPTION
## Summary
- Makes Keeper_llm_bridge.run_with_timeout_and_fallback fail closed when Masc_eio_env is missing or initialized without an Eio clock.
- Returns a structured Agent_sdk.Error.Internal before running the OAS/LLM function, increments the bridge failure metric, and logs the no-clock condition.
- Keeps the existing timeout/cancellation behavior unchanged when a clock is present.

## Why It Matters
The Kimi Keeper execution audit flagged that clock=None made the bridge call fn() directly, bypassing the advertised structural timeout. In an always-on Keeper runtime, that is a silent liveness risk: one clockless edge path can run a provider call with no timeout and strand the turn. The bridge contract already says strict-clock users should fail loudly instead of substituting a fallback, so this turns the path into an observable fail-closed error.

## Validation
- ocamlc -stop-after parsing lib/keeper/keeper_llm_bridge.ml
- ocamlc -stop-after parsing lib/keeper/keeper_llm_bridge.mli
- ocamlc -stop-after parsing test/test_keeper_llm_bridge.ml
- ocamlformat --check lib/keeper/keeper_llm_bridge.ml lib/keeper/keeper_llm_bridge.mli test/test_keeper_llm_bridge.ml
- git diff --check
- scripts/dune-local.sh build test/test_keeper_llm_bridge.exe
- ./_build/default/test/test_keeper_llm_bridge.exe (3 tests)

## Review Focus
- Confirm fail-closed behavior is correct for missing/clockless Masc_eio_env in the Keeper LLM bridge.
- Confirm the normal clocked path still executes through Eio.Time.with_timeout_exn and preserves cancellation re-raise semantics.