### PR TITLE
fix(keeper): cap goal-scoped task creation

### DIFF
--- a/lib/coord/coord_task_create.ml
+++ b/lib/coord/coord_task_create.ml
@@ -49,6 +49,7 @@ let add_task
       ?contract
       ?goal_id
       ?created_by
+      ?reject_if
       config
       ~title
       ~priority
@@ -63,6 +64,12 @@ let add_task
       match read_backlog_r config with
       | Error msg -> Printf.sprintf "Error: %s" msg
       | Ok backlog ->
+        (match reject_if with
+         | Some reject_if -> reject_if backlog
+         | None -> None)
+        |> (function
+          | Some msg -> Printf.sprintf "Error: %s" msg
+          | None ->
         (* Dedup guard: reject if an active task with the same normalized title exists *)
         (match find_duplicate_task backlog ~title ~goal_id with
          | Some existing_id ->
@@ -135,7 +142,7 @@ let add_task
                ~from_agent:actor
                ~content:(Printf.sprintf "New quest: %s" title)
            in
-           Printf.sprintf "Added %s: %s" task_id title))
+           Printf.sprintf "Added %s: %s" task_id title)))
   with
   | Eio.Cancel.Cancelled _ as e -> raise e
   | e -> Printf.sprintf "Error: %s" (Printexc.to_string e)

--- a/lib/coord/coord_task_create.mli
+++ b/lib/coord/coord_task_create.mli
@@ -23,6 +23,7 @@ val add_task :
   ?contract:Masc_domain.task_contract ->
   ?goal_id:string ->
   ?created_by:string ->
+  ?reject_if:(Masc_domain.backlog -> string option) ->
   config -> title:string -> priority:int -> description:string -> string
 
 val batch_add_tasks :

--- a/lib/keeper/keeper_exec_task.ml
+++ b/lib/keeper/keeper_exec_task.ml
@@ -50,6 +50,69 @@ let parse_task_contract_arg args =
   | _ -> Error "contract must be an object when provided"
 ;;
 
+let keeper_task_create_goal_open_limit = 3
+
+type goal_task_capacity_error = {
+  goal_id : string;
+  open_task_count : int;
+  limit : int;
+  message : string;
+}
+
+let open_task_count_for_goal (backlog : Masc_domain.backlog) ~goal_id =
+  List.fold_left
+    (fun count (task : Masc_domain.task) ->
+       if
+         (not (Masc_domain.task_status_is_terminal task.task_status))
+         && Convergence.task_matches_goal ~goal_id task
+       then count + 1
+       else count)
+    0
+    backlog.tasks
+;;
+
+let goal_task_capacity_error (backlog : Masc_domain.backlog) ~goal_id =
+  let open_task_count = open_task_count_for_goal backlog ~goal_id in
+  let limit = keeper_task_create_goal_open_limit in
+  if open_task_count < limit
+  then None
+  else
+    let message =
+      Printf.sprintf
+        "goal_task_limit_exceeded: goal_id=%s already has %d open linked tasks \
+         (limit=%d). ACTION: claim or finish existing tasks for this goal before \
+         creating more."
+        goal_id
+        open_task_count
+        limit
+    in
+    Some { goal_id; open_task_count; limit; message }
+;;
+
+let task_create_capacity_error_json error =
+  error_json
+    ~fields:
+      [
+        "ok", `Bool false;
+        "error_kind", `String "goal_task_limit_exceeded";
+        "goal_id", `String error.goal_id;
+        "open_task_count", `Int error.open_task_count;
+        "limit", `Int error.limit;
+        ( "action",
+          `String
+            "claim_or_finish_existing_goal_tasks_before_creating_more" );
+      ]
+    error.message
+;;
+
+let task_create_goal_capacity_rejection ?goal_id backlog =
+  match goal_id with
+  | None -> None
+  | Some goal_id ->
+    goal_task_capacity_error backlog ~goal_id
+    |> Option.map (fun error -> error.message)
+;;
+
 let active_goal_scope_json ~(meta : keeper_meta) ?matched_goal_id
     ?excluded_count ?effective_mode ?effective_goal_ids ?fallback_reason () =
   let scoped = meta.active_goal_ids <> [] in
@@ -259,8 +322,24 @@ let handle_keeper_task_tool
           (match parse_task_contract_arg args with
            | Error message -> error_json message
            | Ok contract ->
+              let capacity_error =
+                match goal_id with
+                | None -> None
+                | Some goal_id ->
+                  let backlog = Coord.read_backlog config in
+                  goal_task_capacity_error backlog ~goal_id
+              in
+              (match capacity_error with
+               | Some error -> task_create_capacity_error_json error
+               | None ->
               let result =
-                Coord_task.add_task ?contract ?goal_id config ~title ~priority
+                Coord_task.add_task
+                  ?contract
+                  ?goal_id
+                  ~reject_if:(task_create_goal_capacity_rejection ?goal_id)
+                  config
+                  ~title
+                  ~priority
                   ~description
               in
               Yojson.Safe.to_string
@@ -269,7 +348,7 @@ let handle_keeper_task_tool
                     "ok", `Bool true;
                     "result", `String result;
                     "goal_id", Json_util.string_opt_to_json goal_id;
-                  ])))
+                  ]))))
   | "keeper_task_claim" ->
     let agent_tool_names = Keeper_tool_policy.keeper_allowed_tool_names meta in
     let claim_goal_scope =

--- a/test/test_keeper_task_dispatch.ml
+++ b/test/test_keeper_task_dispatch.ml
@@ -975,6 +975,95 @@ let test_create_rejects_unknown_goal_id () =
     check bool "error mentions unknown goal" true
       (contains_substring error "unknown goal_id"))
 
+let test_create_rejects_fourth_open_task_for_goal () =
+  with_room (fun config ->
+    let goal, _ =
+      match Goal_store.upsert_goal config ~title:"Scoped capacity goal" () with
+      | Ok payload -> payload
+      | Error msg -> fail msg
+    in
+    let meta = make_goal_scoped_meta [ goal.id ] in
+    for i = 1 to 3 do
+      ignore
+        (Coord_task.add_task
+           ~goal_id:goal.id
+           config
+           ~title:(Printf.sprintf "Existing goal task %d" i)
+           ~priority:3
+           ~description:"desc")
+    done;
+    let result =
+      call_tool config meta "keeper_task_create"
+        (`Assoc
+          [
+            ("title", `String "Fourth goal task");
+            ("description", `String "desc");
+          ])
+    in
+    let json = parse_json result in
+    check string "error kind" "goal_task_limit_exceeded"
+      (Yojson.Safe.Util.member "error_kind" json |> Yojson.Safe.Util.to_string);
+    check string "response goal_id" goal.id
+      (Yojson.Safe.Util.member "goal_id" json |> Yojson.Safe.Util.to_string);
+    check int "open task count" 3
+      (Yojson.Safe.Util.member "open_task_count" json |> Yojson.Safe.Util.to_int);
+    check int "limit" 3
+      (Yojson.Safe.Util.member "limit" json |> Yojson.Safe.Util.to_int);
+    check int "no task added" 3 (List.length (Coord.get_tasks_raw config)))
+
+let mark_first_task_done config ~agent_name =
+  let backlog = Coord.read_backlog config in
+  let tasks =
+    match backlog.tasks with
+    | first :: rest ->
+      {
+        first with
+        task_status =
+          Masc_domain.Done
+            {
+              assignee = agent_name;
+              completed_at = Masc_domain.now_iso ();
+              notes = Some "done";
+            };
+      }
+      :: rest
+    | [] -> fail "expected task to mark done"
+  in
+  Coord.write_backlog config { backlog with tasks; version = backlog.version + 1 }
+
+let test_create_goal_limit_ignores_terminal_tasks () =
+  with_room (fun config ->
+    let goal, _ =
+      match Goal_store.upsert_goal config ~title:"Scoped terminal goal" () with
+      | Ok payload -> payload
+      | Error msg -> fail msg
+    in
+    let meta = make_goal_scoped_meta [ goal.id ] in
+    for i = 1 to 3 do
+      ignore
+        (Coord_task.add_task
+           ~goal_id:goal.id
+           config
+           ~title:(Printf.sprintf "Maybe terminal task %d" i)
+           ~priority:3
+           ~description:"desc")
+    done;
+    mark_first_task_done config ~agent_name:meta.agent_name;
+    let result =
+      call_tool config meta "keeper_task_create"
+        (`Assoc
+          [
+            ("title", `String "Replacement goal task");
+            ("description", `String "desc");
+          ])
+    in
+    let json = parse_json result in
+    check bool "create ok" true
+      (Yojson.Safe.Util.member "ok" json |> Yojson.Safe.Util.to_bool);
+    check string "response goal_id" goal.id
+      (Yojson.Safe.Util.member "goal_id" json |> Yojson.Safe.Util.to_string);
+    check int "task added" 4 (List.length (Coord.get_tasks_raw config)))
+
 (* --- keeper_task_done tests --- *)
 
 let test_done_with_empty_task_id () =
@@ -1353,6 +1442,10 @@ let () =
         test_create_requires_goal_id_for_multiple_active_goals;
       test_case "create rejects unknown goal_id" `Quick
         test_create_rejects_unknown_goal_id;
+      test_case "create rejects fourth open task for goal" `Quick
+        test_create_rejects_fourth_open_task_for_goal;
+      test_case "create goal limit ignores terminal tasks" `Quick
+        test_create_goal_limit_ignores_terminal_tasks;
     ];
     "done", [
       test_case "empty task_id returns error" `Quick test_done_with_empty_task_id;


### PR DESCRIPTION
## Summary
- add an in-lock task creation guard so keeper_task_create can reject over-cap goal-scoped work without racing the backlog writer
- cap keeper-created goal work at three non-terminal linked tasks and return a structured goal_task_limit_exceeded response
- cover the fourth-task rejection and terminal-task exemption in keeper task dispatch tests

## Why it matters
Live keeper runtime showed keepers diagnosing goal-scope task floods and stale release churn around task-200..209. The existing goal_id defaulting was already present, but keeper_task_create could keep adding more open work to the same goal. This makes the creation surface stop producing unbounded same-goal backlog growth and tells the keeper to claim or finish existing tasks first.

## Validation
- ocamlc -stop-after parsing lib/coord/coord_task_create.ml
- ocamlc -stop-after parsing lib/coord/coord_task_create.mli
- ocamlc -stop-after parsing lib/keeper/keeper_exec_task.ml
- ocamlc -stop-after parsing test/test_keeper_task_dispatch.ml
- git diff --check
- scripts/dune-local.sh build test/test_keeper_task_dispatch.exe
- ./_build/default/test/test_keeper_task_dispatch.exe (40 tests)

Note: ocamlformat --check exits 1 with no diagnostics on the touched legacy files; applying it reformats large unrelated sections, so this PR keeps the local style.