### PR TITLE
fix(keeper): prevent death spiral from recurring saturation

### DIFF
--- a/lib/keeper/keeper_post_turn.ml
+++ b/lib/keeper/keeper_post_turn.ml
@@ -844,7 +844,12 @@ let recover_latest_checkpoint_for_overflow_retry
     | _ -> None
   in
   match selected with
-  | None -> None
+  | None ->
+      Log.Keeper.warn
+        "keeper:%s overflow-retry: all checkpoint recovery paths failed, \
+         starting fresh turn"
+        meta.name;
+      None
   | Some (ctx, turn_generation) ->
       let now_ts = Time_compat.now () in
       let ctx =

--- a/lib/keeper/keeper_recurring.ml
+++ b/lib/keeper/keeper_recurring.ml
@@ -117,11 +117,13 @@ let dispatch_due ~keeper_name ~now_ts ~dispatch =
       task.failure_count <- task.failure_count + 1;
       if task.max_failures > 0
          && task.failure_count >= task.max_failures
-      then task.enabled <- false
+      then begin
+        task.enabled <- false;
+        task.last_run_ts <- now_ts
+      end
   ) due_tasks;
   !count
 
-(* ================================================================ *)
 (* Re-enable                                                         *)
 (* ================================================================ *)
 

--- a/lib/keeper/keeper_recurring.mli
+++ b/lib/keeper/keeper_recurring.mli
@@ -74,5 +74,13 @@ val reenable_due_tasks :
 (** Serialize a task to JSON. *)
 val task_to_json : recurring_task -> Yojson.Safe.t
 
+(** Re-enable disabled recurring tasks after a cooldown period (2x the
+    task interval).  Called by the supervisor sweep to prevent permanent
+    coordination signal loss when tasks are auto-disabled after
+    [max_failures] consecutive failures.
+
+    Returns the number of tasks re-enabled. *)
+val reenable_due_tasks : keeper_name:string -> now_ts:float -> int
+
 (** Clear all tasks.  For testing only. *)
 val clear : unit -> unit

--- a/lib/keeper/keeper_turn_liveness.ml
+++ b/lib/keeper/keeper_turn_liveness.ml
@@ -134,8 +134,19 @@ let resolve_ollama_only_base_url
     active request.  [None] (no cache entry / probe never ran) and
     failed probes are deliberately treated as "not saturated" so a
     flaky probe never starves the keeper.  Mirrors the conservative
-    fail-open policy in [Cascade_ollama_probe.try_probe]. *)
+    fail-open policy in [Cascade_ollama_probe.try_probe].
+
+    After [max_consecutive_saturation_skips] consecutive saturated
+    checks for the same keeper, returns [false] to force a turn and
+    break the noop_failure_loop → watchdog kill death spiral. *)
+let max_consecutive_saturation_skips =
+  Env_config_core.get_int_nonneg ~default:6
+    "MASC_KEEPER_MAX_SATURATION_SKIPS"
+
+let saturation_skip_count : (string, int) Hashtbl.t = Hashtbl.create 16
+
 let is_ollama_saturated
+    ?(keeper_name = "")
     ?capacity_lookup
     (base_url : string) : bool =
   let capacity_lookup =
@@ -146,8 +157,39 @@ let is_ollama_saturated
   match capacity_lookup base_url with
   | None -> false
   | Some (info : Cascade_throttle.capacity_info) ->
-      info.process_available <= 0
-      && (info.process_active > 0 || info.process_queue_length > 0)
+      let saturated =
+        info.process_available <= 0
+        && (info.process_active > 0 || info.process_queue_length > 0)
+      in
+      if not saturated then begin
+        Hashtbl.remove saturation_skip_count keeper_name;
+        false
+      end else if keeper_name = "" then begin
+        saturated
+      end else begin
+        let count = Hashtbl.find_opt saturation_skip_count keeper_name
+                    |> Option.value ~default:0
+        in
+        if count >= max_consecutive_saturation_skips then begin
+          Log.Keeper.info
+            "%s: ollama saturation skip count %d >= max %d, forcing turn"
+            keeper_name count max_consecutive_saturation_skips;
+          Hashtbl.remove saturation_skip_count keeper_name;
+          false
+        end else begin
+          Hashtbl.replace saturation_skip_count keeper_name (count + 1);
+          true
+        end
+      end
+
+module For_testing = struct
+  let max_consecutive_saturation_skips = max_consecutive_saturation_skips
+
+  let reset_saturation_skip_count ?keeper_name () =
+    match keeper_name with
+    | None -> Hashtbl.clear saturation_skip_count
+    | Some keeper_name -> Hashtbl.remove saturation_skip_count keeper_name
+end
 
 (** Backoff sleep applied after a saturation skip so the keeper does
     not hot-spin against a busy ollama instance. Short by design:

--- a/lib/keeper/keeper_turn_liveness.mli
+++ b/lib/keeper/keeper_turn_liveness.mli
@@ -44,16 +44,27 @@ val resolve_ollama_only_base_url :
     structural: does not probe the network. *)
 
 val is_ollama_saturated :
+  ?keeper_name:string ->
   ?capacity_lookup:(string -> Cascade_throttle.capacity_info option) ->
   string ->
   bool
 (** Read the [Cascade_ollama_probe] cache and report whether the endpoint
     is saturated (no available slots while at least one request is active
     or queued). No cache / failed probe returns [false] (fail-open) so a
-    flaky probe never starves the keeper. *)
+    flaky probe never starves the keeper.
+
+    After [MASC_KEEPER_MAX_SATURATION_SKIPS] (default 6) consecutive
+    saturated checks for the same [keeper_name], returns [false] to force
+    a turn and break the noop_failure_loop death spiral. *)
 
 val saturation_skip_backoff_sec : float
 (** Backoff sleep applied after a saturation skip (seconds). *)
+
+module For_testing : sig
+  val max_consecutive_saturation_skips : int
+
+  val reset_saturation_skip_count : ?keeper_name:string -> unit -> unit
+end
 
 val saturation_skip_jitter_factor : float
 (** Jitter factor for saturation skip sleep. *)

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -333,7 +333,7 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
         match resolve_ollama_only_base_url labels with
         | None -> None
         | Some base_url ->
-            if not (is_ollama_saturated base_url) then None
+            if not (is_ollama_saturated ~keeper_name:meta.name base_url) then None
             else
               let info = Cascade_ollama_probe.cached_capacity base_url in
               let queue_len =

--- a/lib/keeper/keeper_unified_turn.mli
+++ b/lib/keeper/keeper_unified_turn.mli
@@ -219,6 +219,7 @@ val resolve_ollama_only_base_url :
     request is active or queued).  No cache / failed probe returns
     [false] (fail-open) so a flaky probe never starves the keeper. *)
 val is_ollama_saturated :
+  ?keeper_name:string ->
   ?capacity_lookup:(string -> Cascade_throttle.capacity_info option) ->
   string ->
   bool

--- a/test/dune
+++ b/test/dune
@@ -1179,6 +1179,7 @@
 (include stanzas/test_keeper_meta_heartbeat_retain_9733.inc)
 (include stanzas/test_keeper_meta_merge.inc)
 (include stanzas/test_keeper_mutex_coverage.inc)
+(include stanzas/test_keeper_death_spiral_prevention.inc)
 (include stanzas/test_keeper_path_roots_leak_10349.inc)
 (include stanzas/test_keeper_passive_loop_detector.inc)
 (include stanzas/test_keeper_pause_silent_failure_source.inc)

--- a/test/stanzas/test_keeper_death_spiral_prevention.inc
+++ b/test/stanzas/test_keeper_death_spiral_prevention.inc
@@ -1,0 +1,4 @@
+(test
+ (name test_keeper_death_spiral_prevention)
+ (modules test_keeper_death_spiral_prevention)
+ (libraries masc_test_deps))

--- a/test/test_keeper_death_spiral_prevention.ml
+++ b/test/test_keeper_death_spiral_prevention.ml
@@ -1,0 +1,105 @@
+open Alcotest
+module Rec = Masc_mcp.Keeper_recurring
+module Live = Masc_mcp.Keeper_turn_liveness
+
+let capacity_info ?(total = 1) ?(active = 1) ?(available = 0) ?(queue = 0) () =
+  Masc_mcp.Cascade_throttle.
+    { total
+    ; process_active = active
+    ; process_available = available
+    ; process_queue_length = queue
+    ; source = Llm_provider.Provider_throttle.Discovered
+    }
+;;
+
+let test_recurring_task_reenable_waits_for_disable_cooldown () =
+  Rec.clear ();
+  let keeper_name = "death-spiral-recurring" in
+  let _task =
+    Rec.add
+      ~keeper_name
+      ~label:"coordination"
+      ~interval_sec:10
+      ~max_failures:2
+      (Rec.Broadcast "tick")
+  in
+  let dispatch_failure _task _action = Error "boom" in
+  ignore (Rec.dispatch_due ~keeper_name ~now_ts:10.0 ~dispatch:dispatch_failure);
+  ignore (Rec.dispatch_due ~keeper_name ~now_ts:20.0 ~dispatch:dispatch_failure);
+  let disabled = List.hd (Rec.list ~keeper_name) in
+  check bool "task disabled after max failures" false disabled.enabled;
+  check
+    int
+    "before cooldown no reenable"
+    0
+    (Rec.reenable_due_tasks ~keeper_name ~now_ts:39.0);
+  check bool "task still disabled before cooldown" false disabled.enabled;
+  check
+    int
+    "after cooldown reenabled"
+    1
+    (Rec.reenable_due_tasks ~keeper_name ~now_ts:40.0);
+  check bool "task enabled after cooldown" true disabled.enabled;
+  check int "failure count reset" 0 disabled.failure_count
+;;
+
+let test_saturation_skip_cap_forces_turn_after_limit () =
+  let keeper_name = "death-spiral-saturation" in
+  Live.For_testing.reset_saturation_skip_count ~keeper_name ();
+  let url = "http://127.0.0.1:11434" in
+  let saturated = capacity_info ~active:1 ~available:0 ~queue:1 () in
+  let lookup _ = Some saturated in
+  for i = 1 to Live.For_testing.max_consecutive_saturation_skips do
+    check
+      bool
+      (Printf.sprintf "saturated skip %d remains true" i)
+      true
+      (Live.is_ollama_saturated ~keeper_name ~capacity_lookup:lookup url)
+  done;
+  check
+    bool
+    "skip cap forces a turn"
+    false
+    (Live.is_ollama_saturated ~keeper_name ~capacity_lookup:lookup url);
+  check
+    bool
+    "counter resets after forced turn"
+    true
+    (Live.is_ollama_saturated ~keeper_name ~capacity_lookup:lookup url);
+  Live.For_testing.reset_saturation_skip_count ~keeper_name ()
+;;
+
+let test_saturation_without_keeper_name_is_stateless () =
+  let url = "http://127.0.0.1:11434" in
+  let saturated = capacity_info ~active:1 ~available:0 ~queue:1 () in
+  let lookup _ = Some saturated in
+  for i = 1 to Live.For_testing.max_consecutive_saturation_skips + 2 do
+    check
+      bool
+      (Printf.sprintf "anonymous saturated check %d stays stateless" i)
+      true
+      (Live.is_ollama_saturated ~capacity_lookup:lookup url)
+  done
+;;
+
+let () =
+  run
+    "keeper_death_spiral_prevention"
+    [ ( "recurring"
+      , [ test_case
+            "reenable waits for disable cooldown"
+            `Quick
+            test_recurring_task_reenable_waits_for_disable_cooldown
+        ] )
+    ; ( "saturation"
+      , [ test_case
+            "skip cap forces turn"
+            `Quick
+            test_saturation_skip_cap_forces_turn_after_limit
+        ; test_case
+            "anonymous saturation checks stay stateless"
+            `Quick
+            test_saturation_without_keeper_name_is_stateless
+        ] )
+    ]
+;;


### PR DESCRIPTION
WORKAROUND: production-blocking, deprecated path
대체 RFC: TBD (cascade-pool-router-token-bucket / per-provider backpressure)
removal target: backpressure RFC merge or 2026-06-30 (whichever first)

---

## Summary
- Split the keeper death-spiral prevention work out of #13949 so the cascade pool-router PR remains cascade-only.
- Re-enable auto-disabled recurring tasks only after a cooldown measured from the disable time, preventing permanent coordination signal loss without immediate re-enable loops.
- Cap consecutive ollama saturation pre-skips per keeper and force a turn after the cap to break noop_failure_loop/watchdog-kill cycles.
- Keep anonymous/test saturation checks stateless unless a keeper name is provided.

## Verification
- `env MASC_DUNE_THROTTLE=0 MASC_SKIP_OPAM_LOCK=1 DUNE_LOCAL_JOBS=1 scripts/dune-local.sh build test/test_keeper_death_spiral_prevention.exe`
- `./_build/default/test/test_keeper_death_spiral_prevention.exe` (3 tests passed)
- `env MASC_DUNE_THROTTLE=0 MASC_SKIP_OPAM_LOCK=1 DUNE_LOCAL_JOBS=1 scripts/dune-local.sh build test/test_keeper_recurring.exe`
- `./_build/default/test/test_keeper_recurring.exe` (7 tests passed)
- `git diff --check`

Draft until review/CI gates are complete.


## ⚠️ Symptom 억제 패턴 인식

본 PR의 "Cap consecutive ollama saturation pre-skips per keeper and force a turn after the cap" + "cooldown after auto-disable"는 텍스트북 symptom suppression. Backpressure (token bucket per provider, semaphore with backpressure signal) 가 root.

production blocking 회피를 위해 머지하되, 위 `WORKAROUND:` 헤더가 본 PR을 deprecated path로 영구 마킹. 대체 RFC 작성 시 본 PR의 cap/cooldown 로직 제거가 RFC implementation의 일부.

근거: `instructions/software-development.md` §워크어라운드 거부 기준 §Override 조건 (PR jeong-sik/me#1100).
