### PR TITLE
fix(keeper): refresh stale watchdog kill class

### DIFF
--- a/lib/keeper/keeper_registry.ml
+++ b/lib/keeper/keeper_registry.ml
@@ -146,8 +146,7 @@ let stale_watchdog_failure_reason ~prior ~kill_class =
       ( Stale_termination_storm _
       | Stale_fleet_batch _
       | Stale_turn_timeout _
-      | Fiber_unresolved ) as prior ->
-      prior
+      | Fiber_unresolved )
   | None ->
       Some (Stale_turn_timeout kill_class)
 

--- a/lib/keeper/keeper_registry.mli
+++ b/lib/keeper/keeper_registry.mli
@@ -100,7 +100,9 @@ val failure_reason_cohort_key : failure_reason option -> string
 val stale_watchdog_failure_reason :
   prior:failure_reason option -> kill_class:stale_kill_class -> failure_reason option
 (** Preserve authoritative terminal failure reasons when the stale watchdog
-    fires after a failed turn. *)
+    fires after a failed turn, but do not carry stale-watchdog cohort labels
+    across fresh watchdog kills. Storm/fleet labels are relatched only by the
+    current threshold or batch detector. *)
 
 (** Pure control-flow signal for immediate fiber termination (RFC-0002).
     Carries no state — failure reason must be pre-stored via

--- a/test/test_stale_kill_class.ml
+++ b/test/test_stale_kill_class.ml
@@ -138,6 +138,42 @@ let test_stale_watchdog_uses_stale_reason_without_terminal_prior () =
         (failure_reason_to_string reason)
   | None -> Alcotest.fail "expected stale reason"
 
+let test_stale_watchdog_replaces_prior_stale_timeout () =
+  let prior =
+    Stale_turn_timeout (Idle_turn { stall_seconds = 7_777.0 })
+  in
+  let kill_class =
+    In_turn_hung { active_seconds = 720.0; timeout_threshold = 600.0 }
+  in
+  match stale_watchdog_failure_reason ~prior:(Some prior) ~kill_class with
+  | Some reason ->
+      r "replaces stale timeout with current kill class"
+        "stale_turn_timeout(in_turn_hung(active=720s threshold=600s))"
+        (failure_reason_to_string reason)
+  | None -> Alcotest.fail "expected stale reason"
+
+let test_stale_watchdog_replaces_prior_storm_label () =
+  let prior = Stale_termination_storm { count = 13 } in
+  let kill_class = Noop_failure_loop { noop_count = 4 } in
+  match stale_watchdog_failure_reason ~prior:(Some prior) ~kill_class with
+  | Some reason ->
+      r "replaces old storm with current kill class"
+        "stale_turn_timeout(noop_failure_loop(noop=4))"
+        (failure_reason_to_string reason)
+  | None -> Alcotest.fail "expected stale reason"
+
+let test_stale_watchdog_replaces_prior_fleet_batch_label () =
+  let prior = Stale_fleet_batch { distinct_count = 8 } in
+  let kill_class =
+    In_turn_hung { active_seconds = 720.0; timeout_threshold = 600.0 }
+  in
+  match stale_watchdog_failure_reason ~prior:(Some prior) ~kill_class with
+  | Some reason ->
+      r "replaces old fleet batch with current kill class"
+        "stale_turn_timeout(in_turn_hung(active=720s threshold=600s))"
+        (failure_reason_to_string reason)
+  | None -> Alcotest.fail "expected stale reason"
+
 let root_cause_label reasons =
   reasons
   |> SW.classify_batch_root_cause_for_test
@@ -227,6 +263,12 @@ let () =
             test_stale_watchdog_preserves_terminal_failure_reason;
           Alcotest.test_case "uses stale reason without terminal prior" `Quick
             test_stale_watchdog_uses_stale_reason_without_terminal_prior;
+          Alcotest.test_case "replaces prior stale timeout" `Quick
+            test_stale_watchdog_replaces_prior_stale_timeout;
+          Alcotest.test_case "replaces prior storm label" `Quick
+            test_stale_watchdog_replaces_prior_storm_label;
+          Alcotest.test_case "replaces prior fleet batch label" `Quick
+            test_stale_watchdog_replaces_prior_fleet_batch_label;
         ] );
       ( "batch_root_cause",
         [


### PR DESCRIPTION
## Summary

- Refresh `stale_watchdog_failure_reason` so old stale-watchdog cohort labels do not mask the current watchdog kill class.
- Keep authoritative non-watchdog root causes, including OAS timeout budget loops and provider/tool/turn failures, preserved.
- Add focused coverage for replacing prior stale timeout, storm, and fleet-batch labels with the current typed kill class.

## Why

Live runtime evidence showed keepers recovering into substantive work and later carrying older `stale_termination_storm` / `stale_fleet_batch` labels across fresh idle/noop/hung watchdog kills. That can route supervisor decisions from stale systemic evidence instead of the current kill reason.

This keeps storm/fleet labels explicit: the current threshold or batch detector must relatch them, instead of inheriting them from an older keeper generation.

## Validation

- `ocamlc -stop-after parsing lib/keeper/keeper_registry.ml`
- `ocamlc -stop-after parsing lib/keeper/keeper_registry.mli`
- `ocamlc -stop-after parsing test/test_stale_kill_class.ml`
- `git diff --check`
- `scripts/dune-local.sh build test/test_stale_kill_class.exe`
- `./_build/default/test/test_stale_kill_class.exe` (25 tests)

Note: `ocamlformat --check lib/keeper/keeper_registry.mli` still fails on an existing unrelated misplaced-docstring warning near line 525. `ocamlformat --check` on the touched `.ml` files also exits 1 without diagnostics in this worktree, matching the local formatter behavior seen in adjacent keeper PRs.
