### PR TITLE
fix(keeper): accept MCP-prefixed required tool calls

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -697,6 +697,16 @@ let run_turn
              ~actionable_signal_context
              ~tool_names:actual_keeper_tool_names
          in
+         let required_tool_violation_reason =
+           Keeper_tool_disclosure.required_tool_violation_reason
+             ~required_tool_names:acc.tool_surface.required_tool_names
+             ~tool_names:actual_keeper_tool_names
+         in
+         let tool_contract_violation_reason =
+           match required_tool_violation_reason with
+           | Some _ -> required_tool_violation_reason
+           | None -> actionable_tool_contract_violation_reason
+         in
          let contract_violation_error reason =
            Agent_sdk.Error.Agent
              (Agent_sdk.Error.CompletionContractViolation
@@ -761,7 +771,7 @@ let run_turn
              Keeper_tool_disclosure.validate_completion_contract_presence
                ~contract:effective_completion_contract
                ~tool_present:acc.keeper_surface_tool_used
-             , actionable_tool_contract_violation_reason
+             , tool_contract_violation_reason
            with
            | Ok (), Some reason ->
                let contract_status =

--- a/lib/keeper/keeper_agent_tool_surface.ml
+++ b/lib/keeper/keeper_agent_tool_surface.ml
@@ -259,9 +259,13 @@ let preferred_tool_choice_for_required_turn ~(has_current_task : bool)
        productive lanes into spurious pause-human failures. *)
     Agent_sdk.Types.Any
   else if (not has_current_task)
-     && has_task_claim_affordance turn_affordances
-     && progress_tool_available "keeper_task_claim"
-  then Agent_sdk.Types.Tool "keeper_task_claim"
+          && has_task_claim_affordance turn_affordances
+          && progress_tool_available "keeper_task_claim"
+  then
+    (* Runtime MCP providers report names as mcp__masc__keeper_task_claim,
+       while the internal keeper surface is keeper_task_claim. Use Any here;
+       keeper_agent_run post-validates the canonical required name. *)
+    Agent_sdk.Types.Any
   else if has_turn_affordance Task_audit turn_affordances
           && progress_tool_available "keeper_tasks_audit"
   then Agent_sdk.Types.Tool "keeper_tasks_audit"
@@ -307,7 +311,11 @@ let preferred_tool_choice_for_required_tool_names
     |> Keeper_types.dedupe_keep_order
   in
   match visible_required with
-  | [ name ] -> Agent_sdk.Types.Tool name
+  | [ _name ] ->
+      (* Exact SDK tool_choice compares raw response names. Runtime MCP
+         namespaces those names, so MASC enforces exact canonical required
+         usage after the turn instead. *)
+      Agent_sdk.Types.Any
   | _ :: _ -> Agent_sdk.Types.Any
   | [] -> Agent_sdk.Types.Auto
 

--- a/lib/keeper/keeper_agent_tool_surface.mli
+++ b/lib/keeper/keeper_agent_tool_surface.mli
@@ -135,9 +135,10 @@ val required_tool_names_for_turn :
   per_call_required_tool_names:string list ->
   string list
 
-(** Pick the model-facing [tool_choice] for an explicit required-tool list. A
-    single visible required tool should be forced specifically; multiple visible
-    required tools use [Any] and are checked after execution. *)
+(** Pick the model-facing [tool_choice] for an explicit required-tool list.
+    Required keeper tools use [Any] because runtime MCP providers namespace
+    response tool names; exact canonical required usage is checked after
+    execution. *)
 val preferred_tool_choice_for_required_tool_names :
   required_tool_names:string list ->
   allowed_tool_names:string list ->

--- a/lib/keeper/keeper_tool_disclosure.ml
+++ b/lib/keeper/keeper_tool_disclosure.ml
@@ -303,6 +303,38 @@ let required_tool_satisfaction
            "tool '%s' is read-only/passive and cannot satisfy a required-tool contract"
            tool_name)
 
+let canonical_dedupe_tool_names names =
+  names |> List.map canonical_tool_name |> Keeper_types.dedupe_keep_order
+
+let required_tool_violation_reason
+      ~(required_tool_names : string list)
+      ~(tool_names : string list)
+  : string option
+  =
+  let used_tool_names = canonical_dedupe_tool_names tool_names in
+  let required_tool_names =
+    required_tool_names
+    |> canonical_dedupe_tool_names
+    |> List.filter tool_name_can_satisfy_required_contract
+  in
+  match
+    List.filter
+      (fun name -> not (List.mem name used_tool_names))
+      required_tool_names
+  with
+  | [] -> None
+  | missing ->
+    let used =
+      match used_tool_names with
+      | [] -> "<none>"
+      | names -> String.concat ", " names
+    in
+    Some
+      (Printf.sprintf
+         "required keeper tool(s) not used: %s (used: %s)"
+         (String.concat ", " missing)
+         used)
+
 let classify_tool_progress name =
   let name = canonical_tool_name name in
   if is_completion_tool_name name

--- a/lib/keeper/keeper_tool_disclosure.mli
+++ b/lib/keeper/keeper_tool_disclosure.mli
@@ -138,6 +138,12 @@ val tool_name_can_satisfy_required_contract : string -> bool
 val required_tool_satisfaction :
   Agent_sdk.Completion_contract.tool_call -> (unit, string) result
 
+(** Return a canonical exact-required-tool violation for required tool names
+    that can satisfy a required-tool contract. Runtime MCP-prefixed observed
+    names are canonicalized before comparison. *)
+val required_tool_violation_reason :
+  required_tool_names:string list -> tool_names:string list -> string option
+
 (** Project a tool name to its [tool_progress_class]. *)
 val classify_tool_progress : string -> tool_progress_class
 

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -6605,6 +6605,8 @@ let test_required_tool_satisfaction_rejects_passive_tools () =
     (satisfies_required_tool "masc_status" (`Assoc []));
   check bool "keeper_tasks_list is passive" false
     (satisfies_required_tool "keeper_tasks_list" (`Assoc []));
+  check bool "runtime MCP task list is passive" false
+    (satisfies_required_tool "mcp__masc__keeper_tasks_list" (`Assoc []));
   (* keeper_stay_silent is a Completion tool and intentionally satisfies
      the required-tool contract despite its Read_only effect_domain.
      See keeper_tool_disclosure.ml is_completion_tool_name exemption. *)
@@ -6623,6 +6625,8 @@ let test_required_tool_satisfaction_rejects_passive_tools () =
 let test_required_tool_satisfaction_accepts_mutating_tools () =
   check bool "keeper_task_claim mutates" true
     (satisfies_required_tool "keeper_task_claim" (`Assoc []));
+  check bool "runtime MCP task claim mutates" true
+    (satisfies_required_tool "mcp__masc__keeper_task_claim" (`Assoc []));
   check bool "Write alias mutates" true
     (satisfies_required_tool "Write" (`Assoc []));
   check bool "mutating gh shell satisfies" true
@@ -6631,7 +6635,16 @@ let test_required_tool_satisfaction_accepts_mutating_tools () =
           [
             ("op", `String "gh");
             ("cmd", `String "pr comment 123 --body ok");
-          ]))
+          ]));
+  check (option string) "prefixed required task claim is canonical" None
+    (KTD.required_tool_violation_reason
+       ~required_tool_names:[ "keeper_task_claim" ]
+       ~tool_names:[ "mcp__masc__keeper_task_claim" ]);
+  check bool "wrong mutating tool misses required claim" true
+    (Option.is_some
+       (KTD.required_tool_violation_reason
+          ~required_tool_names:[ "keeper_task_claim" ]
+          ~tool_names:[ "keeper_board_post" ]))
 
 let test_tool_usage_delta_uses_registry_counts () =
   let before =
@@ -7564,7 +7577,7 @@ let test_tools_for_gated_affordance_covers_each_variant () =
     (List.mem "keeper_task_create"
        (Surface.tools_for_gated_affordance Surface.Work_discovery))
 
-let test_preferred_tool_choice_for_required_turn_claims_first () =
+let test_preferred_tool_choice_for_required_turn_uses_any_for_required_tools () =
   let module Surface = Masc_mcp.Keeper_agent_tool_surface in
   let choose ?(has_current_task = false) ?(turn_affordances = [ "task_claim" ])
       ?(allowed_tool_names =
@@ -7574,11 +7587,10 @@ let test_preferred_tool_choice_for_required_turn_claims_first () =
       ~turn_affordances ~allowed_tool_names
   in
   (match choose () with
-   | Agent_sdk.Types.Tool name ->
-       check string "forces claim tool first" "keeper_task_claim" name
+   | Agent_sdk.Types.Any -> ()
    | other ->
        fail
-         (Printf.sprintf "expected Tool keeper_task_claim, got %s"
+         (Printf.sprintf "expected Any for claim gate, got %s"
             (Agent_sdk.Types.show_tool_choice other)));
   (match choose ~has_current_task:true () with
    | Agent_sdk.Types.Any -> ()
@@ -7712,14 +7724,11 @@ let test_preferred_tool_choice_for_required_turn_claims_first () =
        ~allowed_tool_names:
          [ "keeper_board_curation_submit"; "keeper_board_post" ]
    with
-   | Agent_sdk.Types.Tool name ->
-       check string
-         "product/design per-call board post is not hijacked by stale curation"
-         "keeper_board_post" name
+   | Agent_sdk.Types.Any -> ()
    | other ->
        fail
          (Printf.sprintf
-            "expected Tool keeper_board_post for product/design reprobe, got %s"
+            "expected Any for product/design per-call board post, got %s"
             (Agent_sdk.Types.show_tool_choice other)));
   check (list string)
     "active task required tools remain when no per-call requirement exists"
@@ -7733,13 +7742,10 @@ let test_preferred_tool_choice_for_required_turn_claims_first () =
        ~allowed_tool_names:
          [ "keeper_board_curation_submit"; "keeper_board_post" ]
    with
-   | Agent_sdk.Types.Tool name ->
-       check string "single per-call required tool is forced"
-         "keeper_board_post" name
+   | Agent_sdk.Types.Any -> ()
    | other ->
-       fail
-         (Printf.sprintf "expected Tool keeper_board_post, got %s"
-            (Agent_sdk.Types.show_tool_choice other)));
+       fail (Printf.sprintf "expected Any for single required tool, got %s"
+               (Agent_sdk.Types.show_tool_choice other)));
   (match
      Surface.preferred_tool_choice_for_required_tool_names
        ~required_tool_names:
@@ -7768,14 +7774,11 @@ let test_preferred_tool_choice_for_required_turn_claims_first () =
        ~required_tool_names:[ "keeper_tasks_audit"; "keeper_board_post" ]
        ~allowed_tool_names:[ "keeper_tasks_audit"; "keeper_board_post" ]
    with
-   | Agent_sdk.Types.Tool name ->
-       check string "active required tool remains forced" "keeper_board_post"
-         name
+   | Agent_sdk.Types.Any -> ()
    | other ->
        fail
          (Printf.sprintf
-            "expected Tool keeper_board_post for mixed passive/active required \
-             tools, got %s"
+            "expected Any for mixed passive/active required tools, got %s"
             (Agent_sdk.Types.show_tool_choice other)));
   (* Active task keeper retains the strict gate even without a
      specific applicable tool — the caller is expected to make
@@ -8701,8 +8704,9 @@ let () =
           test_case "initial tool requirement covers actionable affordances"
             `Quick
             test_should_require_tools_for_initial_turn_covers_actionable_affordances;
-          test_case "task backlog required turn prefers claim tool choice"
-            `Quick test_preferred_tool_choice_for_required_turn_claims_first;
+          test_case "task backlog required turn uses any for required tools"
+            `Quick
+            test_preferred_tool_choice_for_required_turn_uses_any_for_required_tools;
           test_case "direct keeper msg timeout overrides stale per-provider timeout"
             `Quick
             test_direct_keeper_msg_timeout_overrides_meta_per_provider_timeout;


### PR DESCRIPTION
## Summary
- stop forcing exact SDK tool_choice for keeper required-tool turns because runtime MCP reports names as mcp__masc__<tool>
- add canonical post-run required-tool validation so mcp__masc__keeper_task_claim satisfies keeper_task_claim, while wrong mutating tools still fail the exact required-tool contract
- extend keeper unified tests for prefixed passive/mutating tool names and the Any tool-choice behavior

## Why it matters
A live keeper task claim succeeded through runtime MCP, but OAS marked the turn failed because the SDK compared requested keeper_task_claim to raw mcp__masc__keeper_task_claim. This keeps the successful mutation from being misclassified as a completion-contract failure.

## Validation
- git diff --check
- scripts/dune-local.sh build test/test_keeper_unified.exe
- ./_build/default/test/test_keeper_unified.exe test metrics_observation 54-55
- ./_build/default/test/test_keeper_unified.exe test tool_classification 3

## Known unrelated failure
- ./_build/default/test/test_keeper_unified.exe test world_observation 7 fails on current main too; tracked separately in #13984.