### PR TITLE
fix(keeper): restore auto-goal claimable observation

### DIFF
--- a/lib/keeper/keeper_runtime_contract.ml
+++ b/lib/keeper/keeper_runtime_contract.ml
@@ -116,6 +116,14 @@ let resolve_claim_goal_scope ?agent_tool_names
           fallback_reason = None;
         }
 
+let resolve_observation_claim_goal_scope ?agent_tool_names ~(config : Coord.config)
+    ~(meta : keeper_meta) () =
+  let allow_empty_goal_scope_fallback =
+    active_goal_ids_are_auto_keeper_goals config ~meta meta.active_goal_ids
+  in
+  resolve_claim_goal_scope ?agent_tool_names ~allow_empty_goal_scope_fallback
+    ~config ~meta ()
+
 let task_is_blocked (task : Masc_domain.task) =
   match task.task_status with
   | Masc_domain.AwaitingVerification _ -> true

--- a/lib/keeper/keeper_runtime_contract.mli
+++ b/lib/keeper/keeper_runtime_contract.mli
@@ -13,7 +13,7 @@ type claim_goal_scope = {
 
 val resolve_claim_goal_scope :
   ?agent_tool_names:string list ->
-  (** [allow_empty_goal_scope_fallback] should stay false for normal keeper
+  (* [allow_empty_goal_scope_fallback] should stay false for normal keeper
       task claims. Auto-repaired keeper-purpose goals may still fall back to
       all tasks; explicit persisted [active_goal_ids] stay scoped unless this
       flag is set. *)
@@ -22,6 +22,16 @@ val resolve_claim_goal_scope :
   meta:Keeper_types.keeper_meta ->
   unit ->
   claim_goal_scope
+
+val resolve_observation_claim_goal_scope :
+  ?agent_tool_names:string list ->
+  config:Coord.config ->
+  meta:Keeper_types.keeper_meta ->
+  unit ->
+  claim_goal_scope
+(** Signal-only claim scope for world observations. Auto-repaired keeper-purpose
+    goals may fall back to all claimable tasks; explicit persisted
+    [active_goal_ids] remain scoped. *)
 
 val runtime_contract_json :
   ?config:Coord.config -> Keeper_types.keeper_meta -> Yojson.Safe.t

--- a/lib/keeper/keeper_world_observation.ml
+++ b/lib/keeper/keeper_world_observation.ml
@@ -261,12 +261,8 @@ let backlog_updated_since_last_scheduled_autonomous
 let claim_goal_scope_filter ?agent_tool_names ~(config : Coord.config)
     ~(meta : keeper_meta) () =
   let scope =
-    Keeper_runtime_contract.resolve_claim_goal_scope
-      ?agent_tool_names
-      ~allow_empty_goal_scope_fallback:false
-      ~config
-      ~meta
-      ()
+    Keeper_runtime_contract.resolve_observation_claim_goal_scope
+      ?agent_tool_names ~config ~meta ()
   in
   scope.task_filter
 


### PR DESCRIPTION
## Summary
- add an observation-only claim scope resolver that falls back only for auto-repaired keeper-purpose goals
- keep normal keeper_task_claim scope strict unless explicit fallback is requested
- restore auto-goal claimable backlog visibility for world observations

Fixes #13984

## Validation
- scripts/dune-local.sh build test/test_keeper_unified.exe test/test_keeper_task_dispatch.exe
- ./_build/default/test/test_keeper_unified.exe test world_observation 6-8
- ./_build/default/test/test_keeper_task_dispatch.exe test claim 12-15
- git diff --check

Note: ocamlformat --check on touched files exits 1 with no diagnostics because it would reformat large existing files; broad formatting churn was intentionally left out.