### PR TITLE
fix(keeper): remove global tool hook fallbacks

### DIFF
--- a/lib/keeper/keeper_exec_tools.ml
+++ b/lib/keeper/keeper_exec_tools.ml
@@ -16,167 +16,6 @@ let has_mutating_side_effect_with_input ~(tool_name : string)
     ~(input : Yojson.Safe.t) : bool =
   not (Keeper_tool_registry.is_read_only_with_input ~tool_name ~input)
 
-type keeper_tool_call_recorder =
-  tool_name:string -> success:bool -> duration_ms:int -> unit
-
-let default_keeper_tool_call_recorder
-    ~tool_name:_ ~success:_ ~duration_ms:_ =
-  ()
-
-let keeper_tool_call_recorder_mutex = Stdlib.Mutex.create ()
-let keeper_tool_call_recorder = ref default_keeper_tool_call_recorder
-
-let set_on_keeper_tool_call (f : keeper_tool_call_recorder) =
-  Stdlib.Mutex.protect keeper_tool_call_recorder_mutex (fun () ->
-    keeper_tool_call_recorder := f)
-
-let record_keeper_tool_call ~tool_name ~success ~duration_ms =
-  let f =
-    Stdlib.Mutex.protect keeper_tool_call_recorder_mutex (fun () ->
-      !keeper_tool_call_recorder)
-  in
-  f ~tool_name ~success ~duration_ms
-
-let search_char c =
-  match c with
-  | 'a' .. 'z' | 'A' .. 'Z' | '0' .. '9' | '_' | '-' -> c
-  | _ when Char.code c > 127 -> c
-  | _ -> ' '
-
-let normalize_search_text text =
-  String.lowercase_ascii (String.map search_char text)
-
-let contains_substring text needle =
-  let text_len = String.length text in
-  let needle_len = String.length needle in
-  let rec loop idx =
-    idx + needle_len <= text_len
-    && (String.sub text idx needle_len = needle || loop (idx + 1))
-  in
-  needle_len = 0 || loop 0
-
-let search_terms query =
-  normalize_search_text query
-  |> String.split_on_char ' '
-  |> List.map String.trim
-  |> List.filter (fun term -> term <> "")
-  |> List.sort_uniq String.compare
-
-let dedupe_tool_search_schemas schemas =
-  let seen = Hashtbl.create (List.length schemas) in
-  List.filter
-    (fun (schema : Masc_domain.tool_schema) ->
-       if Hashtbl.mem seen schema.name then false
-       else begin
-         Hashtbl.replace seen schema.name ();
-         true
-       end)
-    schemas
-
-let default_tool_search_schemas () =
-  Tool_shard.all_keeper_tool_schemas
-  @ [ keeper_tool_search_schema ]
-  |> List.filter (fun (schema : Masc_domain.tool_schema) ->
-       not (is_keeper_denied schema.name))
-  |> dedupe_tool_search_schemas
-
-let score_tool_schema terms (schema : Masc_domain.tool_schema) =
-  let help = Tool_help_registry.entry_of_schema schema in
-  let name_text = normalize_search_text schema.name in
-  let search_text =
-    normalize_search_text
-      (String.concat " "
-         [ schema.name;
-           schema.description;
-           help.Tool_help_registry.when_to_use;
-           Yojson.Safe.to_string schema.input_schema;
-         ])
-  in
-  List.fold_left
-    (fun score term ->
-       if contains_substring name_text term then score +. 2.0
-       else if contains_substring search_text term then score +. 1.0
-       else score)
-    0.0
-    terms
-
-let default_tool_search_fn ~query ~max_results =
-  let terms = search_terms query in
-  let schemas = default_tool_search_schemas () in
-  let hits =
-    schemas
-    |> List.filter_map
-         (fun schema ->
-            let score = score_tool_schema terms schema in
-            if Float.compare score 0.0 <= 0 then None
-            else Some (schema, score))
-    |> List.sort
-         (fun (left_schema, left_score) (right_schema, right_score) ->
-            let by_score = compare right_score left_score in
-            if by_score <> 0 then by_score
-            else String.compare left_schema.Masc_domain.name right_schema.name)
-  in
-  let rec take n xs =
-    if n <= 0 then []
-    else
-      match xs with
-      | [] -> []
-      | x :: rest -> x :: take (n - 1) rest
-  in
-  let selected = take max_results hits in
-  let result_json (schema, score) =
-    let help = Tool_help_registry.entry_of_schema schema in
-    `Assoc
-      [
-        ("name", `String schema.Masc_domain.name);
-        ("score", `Float score);
-        ("description", `String help.short_description);
-        ("when_to_use", `String help.when_to_use);
-        ("input_schema", schema.input_schema);
-        ("already_visible", `Bool false);
-      ]
-  in
-  let results = List.map result_json selected in
-  let hint =
-    if results = [] then
-      "No tools match this static fallback query. In normal keeper turns, \
-       the session-scoped BM25 index provides richer policy-aware search."
-    else
-      "Static fallback results from keeper schemas. Normal keeper turns \
-       use the richer session-scoped BM25 index."
-  in
-  `Assoc
-    [
-      ("ok", `Bool true);
-      ("query", `String query);
-      ("results", `List results);
-      ("result_count", `Int (List.length results));
-      ( "diagnostics",
-        `Assoc
-          [
-            ("source", `String "static_schema_fallback");
-            ("candidate_count", `Int (List.length schemas));
-          ] );
-      ("hint", `String hint);
-    ]
-
-type tool_searcher = query:string -> max_results:int -> Yojson.Safe.t
-
-let default_tool_searcher = default_tool_search_fn
-
-let tool_searcher_mutex = Stdlib.Mutex.create ()
-let tool_searcher = ref default_tool_searcher
-
-let set_tool_search_fn (f : tool_searcher) =
-  Stdlib.Mutex.protect tool_searcher_mutex (fun () ->
-    tool_searcher := f)
-
-let search_tools ~query ~max_results =
-  let f =
-    Stdlib.Mutex.protect tool_searcher_mutex (fun () -> !tool_searcher)
-  in
-  f ~query ~max_results
-
 type tool_result_payload =
   | Structured_success
   | Structured_error
@@ -365,11 +204,14 @@ let execute_keeper_tool_call_with_outcome
              "query is required. Good: query='read file'. Bad: query=''.")
 
       else
-        let fn = match search_fn with
-          | Some f -> f
-          | None -> search_tools
-        in
-        success_tool_result (Yojson.Safe.to_string (fn ~query ~max_results))
+        (match search_fn with
+         | Some fn ->
+           success_tool_result (Yojson.Safe.to_string (fn ~query ~max_results))
+         | None ->
+           failure_tool_result
+             (error_json
+                "keeper_tool_search is not configured for this execution path. \
+                 Run through the keeper Agent tool bundle or pass search_fn."))
     | "keeper_stay_silent" ->
       success_tool_result
         (Yojson.Safe.to_string (`Assoc [ "status", `String "silent" ]))

--- a/lib/keeper/keeper_exec_tools.ml
+++ b/lib/keeper/keeper_exec_tools.ml
@@ -8,13 +8,14 @@
 
 open Keeper_types
 open Keeper_exec_shared
-
 include Keeper_tool_registry
 include Keeper_tool_policy
 
-let has_mutating_side_effect_with_input ~(tool_name : string)
-    ~(input : Yojson.Safe.t) : bool =
+let has_mutating_side_effect_with_input ~(tool_name : string) ~(input : Yojson.Safe.t)
+  : bool
+  =
   not (Keeper_tool_registry.is_read_only_with_input ~tool_name ~input)
+;;
 
 type tool_result_payload =
   | Structured_success
@@ -22,31 +23,41 @@ type tool_result_payload =
   | Plain_text
   | Malformed_structured of string
 
-type execution_outcome = [ `Success | `Failure ]
+type execution_outcome =
+  [ `Success
+  | `Failure
+  ]
 
-type executed_tool_result = {
-  raw_output : string;
-  outcome : execution_outcome;
-  payload_shape : tool_result_payload;
-}
+type executed_tool_result =
+  { raw_output : string
+  ; outcome : execution_outcome
+  ; payload_shape : tool_result_payload
+  }
 
 let looks_like_structured_payload payload =
   let len = String.length payload in
   let rec find_first_nonspace i =
-    if i >= len then None
-    else
+    if i >= len
+    then None
+    else (
       match payload.[i] with
       | ' ' | '\t' | '\n' | '\r' -> find_first_nonspace (i + 1)
-      | c -> Some c
+      | c -> Some c)
   in
   match find_first_nonspace 0 with
   | Some ('{' | '[') -> true
   | Some _ | None -> false
+;;
 
 let classify_tool_result_payload payload =
-  if not (looks_like_structured_payload payload) then Plain_text
-  else
-    match Safe_ops.parse_json_safe ~context:"Keeper_exec_tools.classify_tool_result_payload" payload with
+  if not (looks_like_structured_payload payload)
+  then Plain_text
+  else (
+    match
+      Safe_ops.parse_json_safe
+        ~context:"Keeper_exec_tools.classify_tool_result_payload"
+        payload
+    with
     | Error msg -> Malformed_structured msg
     | Ok (`Assoc fields) ->
       let is_error =
@@ -55,28 +66,26 @@ let classify_tool_result_payload payload =
         | _ -> List.mem_assoc "error" fields
       in
       if is_error then Structured_error else Structured_success
-    | Ok _ -> Structured_success
+    | Ok _ -> Structured_success)
+;;
 
 let is_policy_gate_error raw_output =
-  match Safe_ops.parse_json_safe
-          ~context:"Keeper_exec_tools.is_policy_gate_error"
-          raw_output
+  match
+    Safe_ops.parse_json_safe ~context:"Keeper_exec_tools.is_policy_gate_error" raw_output
   with
   | Ok json ->
-      (match Safe_ops.json_string_opt "error" json with
-       | Some msg -> String.equal (String.trim msg) "tool_not_allowed"
-       | None -> false)
+    (match Safe_ops.json_string_opt "error" json with
+     | Some msg -> String.equal (String.trim msg) "tool_not_allowed"
+     | None -> false)
   | Error _ -> false
+;;
 
 let inferred_outcome_of_result ~raw_output ~payload_shape =
   match payload_shape with
-  | Structured_success
-  | Plain_text ->
-      `Success
-  | Structured_error ->
-      `Failure
-  | Malformed_structured _ ->
-      `Failure
+  | Structured_success | Plain_text -> `Success
+  | Structured_error -> `Failure
+  | Malformed_structured _ -> `Failure
+;;
 
 let make_executed_tool_result ?outcome raw_output =
   let payload_shape = classify_tool_result_payload raw_output in
@@ -86,12 +95,15 @@ let make_executed_tool_result ?outcome raw_output =
     | None -> inferred_outcome_of_result ~raw_output ~payload_shape
   in
   { raw_output; outcome; payload_shape }
+;;
 
 let success_tool_result raw_output =
   make_executed_tool_result ~outcome:`Success raw_output
+;;
 
 let failure_tool_result raw_output =
   make_executed_tool_result ~outcome:`Failure raw_output
+;;
 
 let is_keeper_board_tool_name name =
   match Tool_name.Keeper.of_string name with
@@ -129,245 +141,272 @@ let execute_keeper_tool_call_with_outcome
     | `Failure, Malformed_structured parse_error ->
       Prometheus.inc_counter
         Keeper_metrics.metric_keeper_exec_tools_failures
-        ~labels:[("keeper", meta.name); ("tool", name)]
+        ~labels:[ "keeper", meta.name; "tool", name ]
         ();
       Log.Keeper.error
         "keeper:%s tool:%s produced malformed structured payload: %s"
-        meta.name name parse_error;
-      let breaker_msg =
-        Printf.sprintf "malformed_tool_result: %s" parse_error
-      in
+        meta.name
+        name
+        parse_error;
+      let breaker_msg = Printf.sprintf "malformed_tool_result: %s" parse_error in
       let raw_output =
         Keeper_failure_circuit_breaker.maybe_enrich_error
-          ~keeper_name:meta.name ~error_msg:breaker_msg
+          ~keeper_name:meta.name
+          ~error_msg:breaker_msg
       in
-      { raw_output; outcome = `Failure;
-        payload_shape = classify_tool_result_payload raw_output; }
-    | `Failure, Structured_error
-    | `Failure, Structured_success
-    | `Failure, Plain_text ->
+      { raw_output
+      ; outcome = `Failure
+      ; payload_shape = classify_tool_result_payload raw_output
+      }
+    | `Failure, Structured_error | `Failure, Structured_success | `Failure, Plain_text ->
       let raw_output =
         Keeper_failure_circuit_breaker.maybe_enrich_error
-          ~keeper_name:meta.name ~error_msg:result.raw_output
+          ~keeper_name:meta.name
+          ~error_msg:result.raw_output
       in
-      { raw_output; outcome = `Failure;
-        payload_shape = classify_tool_result_payload raw_output; }
+      { raw_output
+      ; outcome = `Failure
+      ; payload_shape = classify_tool_result_payload raw_output
+      }
   in
   let lookup = tool_access_lookup_of_meta meta in
-  apply_circuit_breaker (
-  if not (can_execute ~lookup name)
-  then
-    let reason, hint =
-      if not (StringSet.mem name lookup.candidate_set)
-      then
-        ( "not_in_candidate_set"
-        , Printf.sprintf
-            "'%s' is not a recognized tool. Check spelling or use keeper_tools_list to see available tools." name )
-      else if StringSet.mem name lookup.deny_set
-      then
-        ( "denied_by_policy"
-        , Printf.sprintf
-            "'%s' is blocked by your current policy. Ask operator to grant access." name )
-      else
-        ( "not_in_allow_set"
-        , Printf.sprintf
-            "'%s' exists but your preset does not allow it. Use keeper_tools_list to see available tools." name )
-    in
-    Prometheus.inc_counter
-      Keeper_metrics.metric_keeper_tool_not_allowed
-      ~labels:[("keeper", meta.name); ("tool", name); ("reason", reason)]
-      ();
-    make_executed_tool_result
-      (Yojson.Safe.to_string
-         (`Assoc [
-           ("ok", `Bool false);
-           ("error", `String "tool_not_allowed");
-           ("tool", `String name);
-           ("reason", `String reason);
-           ("hint", `String hint);
-         ]))
-  else (
-    match name with
-    | _ when is_keeper_board_tool_name name ->
-      make_executed_tool_result
-        (Keeper_exec_board.handle_keeper_board_tool ~meta ~name ~args)
-    | "keeper_tool_search" ->
-      let query =
-        Safe_ops.json_string ~default:"" "query" args |> String.trim
-      in
-      let max_results =
-        min 10 (max 1 (Safe_ops.json_int ~default:5 "max_results" args))
-      in
-      if query = "" then
-        failure_tool_result
-          (error_json
-             "query is required. Good: query='read file'. Bad: query=''.")
-
-      else
-        (match search_fn with
-         | Some fn ->
-           success_tool_result (Yojson.Safe.to_string (fn ~query ~max_results))
-         | None ->
+  apply_circuit_breaker
+    (if not (can_execute ~lookup name)
+     then (
+       let reason, hint =
+         if not (StringSet.mem name lookup.candidate_set)
+         then
+           ( "not_in_candidate_set"
+           , Printf.sprintf
+               "'%s' is not a recognized tool. Check spelling or use keeper_tools_list \
+                to see available tools."
+               name )
+         else if StringSet.mem name lookup.deny_set
+         then
+           ( "denied_by_policy"
+           , Printf.sprintf
+               "'%s' is blocked by your current policy. Ask operator to grant access."
+               name )
+         else
+           ( "not_in_allow_set"
+           , Printf.sprintf
+               "'%s' exists but your preset does not allow it. Use keeper_tools_list to \
+                see available tools."
+               name )
+       in
+       Prometheus.inc_counter
+         Keeper_metrics.metric_keeper_tool_not_allowed
+         ~labels:[ "keeper", meta.name; "tool", name; "reason", reason ]
+         ();
+       make_executed_tool_result
+         (Yojson.Safe.to_string
+            (`Assoc
+                [ "ok", `Bool false
+                ; "error", `String "tool_not_allowed"
+                ; "tool", `String name
+                ; "reason", `String reason
+                ; "hint", `String hint
+                ])))
+     else (
+       match name with
+       | _ when is_keeper_board_tool_name name ->
+         make_executed_tool_result
+           (Keeper_exec_board.handle_keeper_board_tool ~meta ~name ~args)
+       | "keeper_tool_search" ->
+         let query = Safe_ops.json_string ~default:"" "query" args |> String.trim in
+         let max_results =
+           min 10 (max 1 (Safe_ops.json_int ~default:5 "max_results" args))
+         in
+         if query = ""
+         then
            failure_tool_result
-             (error_json
-                "keeper_tool_search is not configured for this execution path. \
-                 Run through the keeper Agent tool bundle or pass search_fn."))
-    | "keeper_stay_silent" ->
-      success_tool_result
-        (Yojson.Safe.to_string (`Assoc [ "status", `String "silent" ]))
-    | "keeper_tools_list" ->
-      success_tool_result (Keeper_exec_shared.keeper_tools_list_json ~meta)
-    | "keeper_time_now" ->
-      success_tool_result
-        (Yojson.Safe.to_string
-           (`Assoc [ "now_iso", `String (now_iso ());
-                     "now_unix", `Float now_ts ]))
-    | "keeper_context_status" ->
-      success_tool_result
-        (Keeper_exec_memory.keeper_context_status_json ~config ~meta ~ctx_work)
-    | "keeper_memory_search" ->
-      success_tool_result
-        (Keeper_exec_memory.keeper_memory_search_json ~config ~meta ~ctx_work ~args)
-    | "keeper_library_search" ->
-      let ok, msg =
-        Tool_library.handle_search Tool_library.{ agent_name = meta.name } args
-      in
-      if ok then success_tool_result msg
-      else failure_tool_result
-             (Yojson.Safe.to_string (`Assoc [ "error", `String msg ]))
-    | "keeper_library_read" ->
-      let ok, msg =
-        Tool_library.handle_read Tool_library.{ agent_name = meta.name } args
-      in
-      if ok then success_tool_result msg
-      else failure_tool_result (error_json msg)
-    | "keeper_fs_read" ->
-      make_executed_tool_result
-        (Keeper_exec_fs.handle_keeper_fs_read ~turn_sandbox_factory ~config ~meta ~args)
-    | "keeper_fs_edit" ->
-      make_executed_tool_result
-        (Keeper_exec_fs.handle_keeper_fs_edit ~turn_sandbox_factory ~config ~meta ~args)
-    | "keeper_bash" ->
-      make_executed_tool_result
-        (Keeper_exec_shell.handle_keeper_bash
-           ~turn_sandbox_factory ~turn_sandbox_factory_git ~exec_cache ~config ~meta ~args
-           ())
-    | "keeper_bash_output" ->
-      make_executed_tool_result
-        (Keeper_exec_shell.handle_keeper_bash_output ~config ~meta ~args)
-    | "keeper_bash_kill" ->
-      make_executed_tool_result
-        (Keeper_exec_shell.handle_keeper_bash_kill ~config ~meta ~args)
-    | "keeper_shell" ->
-      make_executed_tool_result
-        (Keeper_exec_shell.handle_keeper_shell ~turn_sandbox_factory ~exec_cache ~config ~meta ~args)
-    | "keeper_voice_speak"
-    | "keeper_voice_listen"
-    | "keeper_voice_agent"
-    | "keeper_voice_sessions"
-    | "keeper_voice_session_start"
-    | "keeper_voice_session_end" ->
-      make_executed_tool_result
-        (Keeper_exec_voice.handle_keeper_voice_tool ~meta ~name ~args)
-    | "keeper_preflight_check" ->
-      (* A preflight can legitimately return ok=false to block a risky or
+             (error_json "query is required. Good: query='read file'. Bad: query=''.")
+         else (
+           match search_fn with
+           | Some fn ->
+             success_tool_result (Yojson.Safe.to_string (fn ~query ~max_results))
+           | None ->
+             failure_tool_result
+               (error_json
+                  "keeper_tool_search is not configured for this execution path. Run \
+                   through the keeper Agent tool bundle or pass search_fn."))
+       | "keeper_stay_silent" ->
+         success_tool_result
+           (Yojson.Safe.to_string (`Assoc [ "status", `String "silent" ]))
+       | "keeper_tools_list" ->
+         success_tool_result (Keeper_exec_shared.keeper_tools_list_json ~meta)
+       | "keeper_time_now" ->
+         success_tool_result
+           (Yojson.Safe.to_string
+              (`Assoc [ "now_iso", `String (now_iso ()); "now_unix", `Float now_ts ]))
+       | "keeper_context_status" ->
+         success_tool_result
+           (Keeper_exec_memory.keeper_context_status_json ~config ~meta ~ctx_work)
+       | "keeper_memory_search" ->
+         success_tool_result
+           (Keeper_exec_memory.keeper_memory_search_json ~config ~meta ~ctx_work ~args)
+       | "keeper_library_search" ->
+         let ok, msg =
+           Tool_library.handle_search Tool_library.{ agent_name = meta.name } args
+         in
+         if ok
+         then success_tool_result msg
+         else
+           failure_tool_result (Yojson.Safe.to_string (`Assoc [ "error", `String msg ]))
+       | "keeper_library_read" ->
+         let ok, msg =
+           Tool_library.handle_read Tool_library.{ agent_name = meta.name } args
+         in
+         if ok then success_tool_result msg else failure_tool_result (error_json msg)
+       | "keeper_fs_read" ->
+         make_executed_tool_result
+           (Keeper_exec_fs.handle_keeper_fs_read
+              ~turn_sandbox_factory
+              ~config
+              ~meta
+              ~args)
+       | "keeper_fs_edit" ->
+         make_executed_tool_result
+           (Keeper_exec_fs.handle_keeper_fs_edit
+              ~turn_sandbox_factory
+              ~config
+              ~meta
+              ~args)
+       | "keeper_bash" ->
+         make_executed_tool_result
+           (Keeper_exec_shell.handle_keeper_bash
+              ~turn_sandbox_factory
+              ~turn_sandbox_factory_git
+              ~exec_cache
+              ~config
+              ~meta
+              ~args
+              ())
+       | "keeper_bash_output" ->
+         make_executed_tool_result
+           (Keeper_exec_shell.handle_keeper_bash_output ~config ~meta ~args)
+       | "keeper_bash_kill" ->
+         make_executed_tool_result
+           (Keeper_exec_shell.handle_keeper_bash_kill ~config ~meta ~args)
+       | "keeper_shell" ->
+         make_executed_tool_result
+           (Keeper_exec_shell.handle_keeper_shell
+              ~turn_sandbox_factory
+              ~exec_cache
+              ~config
+              ~meta
+              ~args)
+       | "keeper_voice_speak"
+       | "keeper_voice_listen"
+       | "keeper_voice_agent"
+       | "keeper_voice_sessions"
+       | "keeper_voice_session_start"
+       | "keeper_voice_session_end" ->
+         make_executed_tool_result
+           (Keeper_exec_voice.handle_keeper_voice_tool ~meta ~name ~args)
+       | "keeper_preflight_check" ->
+         (* A preflight can legitimately return ok=false to block a risky or
          unready workflow.  That is a successful read-only diagnostic result,
          not a tool transport/execution failure.  The keeper still sees the
          raw ok=false report and must obey it. *)
-      success_tool_result
-        (Keeper_exec_preflight.handle_keeper_preflight_check ~config ~meta ~args)
-    | "keeper_pr_list" ->
-      make_executed_tool_result
-        (Keeper_tool_github_pr.handle_keeper_pr_list ~config ~meta ~args)
-    | "keeper_pr_status" ->
-      make_executed_tool_result
-        (Keeper_tool_github_pr.handle_keeper_pr_status ~config ~meta ~args)
-    | "keeper_pr_create" ->
-      make_executed_tool_result
-        (Keeper_tool_github_pr.handle_keeper_pr_create ~config ~meta ~args)
-    | "keeper_pr_review_read" ->
-      make_executed_tool_result
-        (Keeper_tool_pr_review.handle_keeper_pr_review_read ~config ~meta ~args)
-    | "keeper_pr_review_comment" ->
-      make_executed_tool_result
-        (Keeper_tool_pr_review.handle_keeper_pr_review_comment ~config ~meta ~args)
-    | "keeper_pr_review_reply" ->
-      make_executed_tool_result
-        (Keeper_tool_pr_review.handle_keeper_pr_review_reply ~config ~meta ~args)
-    | "keeper_tasks_list"
-    | "keeper_tasks_audit"
-    | "keeper_task_force_release"
-    | "keeper_task_force_done"
-    | "keeper_broadcast"
-    | "keeper_task_claim"
-    | "keeper_task_create"
-    | "keeper_task_done"
-    | "keeper_task_submit_for_verification" ->
-      make_executed_tool_result
-        (Keeper_exec_task.handle_keeper_task_tool ~config ~meta ~name ~args)
-    | other ->
-      (match
-         Keeper_exec_masc.handle_registered_keeper_tool
-           ~config ~meta ~name:other ~args
-       with
-       | Some raw_output -> make_executed_tool_result raw_output
-       | None ->
-         let suggestion =
-           let candidates = keeper_allowed_tool_names meta in
-           let scored =
-             candidates
-             |> List.filter_map (fun c ->
-               if String.length c > 2 && String.length other > 2 then
-                 let other_lower = String.lowercase_ascii other in
-                 let c_lower = String.lowercase_ascii c in
-                 let contains haystack needle =
-                   let nlen = String.length needle in
-                   let hlen = String.length haystack in
-                   if nlen = 0 then true
-                   else if nlen > hlen then false
-                   else
-                     let found = ref false in
-                     for i = 0 to hlen - nlen do
-                       if not !found
-                          && String.sub haystack i nlen = needle
-                       then found := true
-                     done;
-                     !found
-                 in
-                 if contains c_lower other_lower
-                    || contains other_lower c_lower
-                 then Some c
-                 else None
-               else None)
-             |> List.filteri (fun i _ -> i < 3)
-           in
-           scored
-         in
-         let masc_schemas =
-           Keeper_tool_registry.masc_schemas_snapshot ()
-         in
-         let enrich_suggestion name =
-           let schema_opt =
-             List.find_opt (fun (s : Masc_domain.tool_schema) -> s.name = name) masc_schemas
-           in
-           match schema_opt with
-           | Some s ->
-             `Assoc [
-               ("name", `String name);
-               ("description", `String s.description);
-               ("input_schema", s.input_schema);
-             ]
-           | None -> `String name
-         in
-         let fields =
-           [ ("error", `String "unknown_tool"); ("tool", `String other) ]
-           @ (match suggestion with
-              | [] -> [("hint", `String "Use keeper_tool_search to find available tools.")]
+         success_tool_result
+           (Keeper_exec_preflight.handle_keeper_preflight_check ~config ~meta ~args)
+       | "keeper_pr_list" ->
+         make_executed_tool_result
+           (Keeper_tool_github_pr.handle_keeper_pr_list ~config ~meta ~args)
+       | "keeper_pr_status" ->
+         make_executed_tool_result
+           (Keeper_tool_github_pr.handle_keeper_pr_status ~config ~meta ~args)
+       | "keeper_pr_create" ->
+         make_executed_tool_result
+           (Keeper_tool_github_pr.handle_keeper_pr_create ~config ~meta ~args)
+       | "keeper_pr_review_read" ->
+         make_executed_tool_result
+           (Keeper_tool_pr_review.handle_keeper_pr_review_read ~config ~meta ~args)
+       | "keeper_pr_review_comment" ->
+         make_executed_tool_result
+           (Keeper_tool_pr_review.handle_keeper_pr_review_comment ~config ~meta ~args)
+       | "keeper_pr_review_reply" ->
+         make_executed_tool_result
+           (Keeper_tool_pr_review.handle_keeper_pr_review_reply ~config ~meta ~args)
+       | "keeper_tasks_list"
+       | "keeper_tasks_audit"
+       | "keeper_task_force_release"
+       | "keeper_task_force_done"
+       | "keeper_broadcast"
+       | "keeper_task_claim"
+       | "keeper_task_create"
+       | "keeper_task_done"
+       | "keeper_task_submit_for_verification" ->
+         make_executed_tool_result
+           (Keeper_exec_task.handle_keeper_task_tool ~config ~meta ~name ~args)
+       | other ->
+         (match
+            Keeper_exec_masc.handle_registered_keeper_tool ~config ~meta ~name:other ~args
+          with
+          | Some raw_output -> make_executed_tool_result raw_output
+          | None ->
+            let suggestion =
+              let candidates = keeper_allowed_tool_names meta in
+              let scored =
+                candidates
+                |> List.filter_map (fun c ->
+                  if String.length c > 2 && String.length other > 2
+                  then (
+                    let other_lower = String.lowercase_ascii other in
+                    let c_lower = String.lowercase_ascii c in
+                    let contains haystack needle =
+                      let nlen = String.length needle in
+                      let hlen = String.length haystack in
+                      if nlen = 0
+                      then true
+                      else if nlen > hlen
+                      then false
+                      else (
+                        let found = ref false in
+                        for i = 0 to hlen - nlen do
+                          if (not !found) && String.sub haystack i nlen = needle
+                          then found := true
+                        done;
+                        !found)
+                    in
+                    if contains c_lower other_lower || contains other_lower c_lower
+                    then Some c
+                    else None)
+                  else None)
+                |> List.filteri (fun i _ -> i < 3)
+              in
+              scored
+            in
+            let masc_schemas = Keeper_tool_registry.masc_schemas_snapshot () in
+            let enrich_suggestion name =
+              let schema_opt =
+                List.find_opt
+                  (fun (s : Masc_domain.tool_schema) -> s.name = name)
+                  masc_schemas
+              in
+              match schema_opt with
+              | Some s ->
+                `Assoc
+                  [ "name", `String name
+                  ; "description", `String s.description
+                  ; "input_schema", s.input_schema
+                  ]
+              | None -> `String name
+            in
+            let fields =
+              [ "error", `String "unknown_tool"; "tool", `String other ]
+              @
+              match suggestion with
+              | [] ->
+                [ "hint", `String "Use keeper_tool_search to find available tools." ]
               | names ->
-                [ ("did_you_mean", `List (List.map enrich_suggestion names));
-                  ("hint", `String "Call one of these tools with the correct parameters.") ])
-         in
-         make_executed_tool_result (Yojson.Safe.to_string (`Assoc fields)))))
+                [ "did_you_mean", `List (List.map enrich_suggestion names)
+                ; "hint", `String "Call one of these tools with the correct parameters."
+                ]
+            in
+            make_executed_tool_result (Yojson.Safe.to_string (`Assoc fields)))))
+;;
 
 let execute_keeper_tool_call
       ~(config : Coord.config)
@@ -384,7 +423,16 @@ let execute_keeper_tool_call
   =
   let result =
     execute_keeper_tool_call_with_outcome
-      ~config ~meta ~ctx_work ?turn_sandbox_factory ?turn_sandbox_factory_git
-      ~exec_cache ?search_fn ~name ~input ()
+      ~config
+      ~meta
+      ~ctx_work
+      ?turn_sandbox_factory
+      ?turn_sandbox_factory_git
+      ~exec_cache
+      ?search_fn
+      ~name
+      ~input
+      ()
   in
   result.raw_output
+;;

--- a/lib/keeper/keeper_exec_tools.mli
+++ b/lib/keeper/keeper_exec_tools.mli
@@ -1,11 +1,15 @@
 open Keeper_types
 
-val keeper_allowed_tool_names :
-  ?write_done:bool ->
-  ?phase:Keeper_state_machine.phase ->
-  keeper_meta -> string list
-val keeper_allowed_model_tools :
-  ?write_done:bool -> keeper_meta -> Masc_domain.tool_schema list
+val keeper_allowed_tool_names
+  :  ?write_done:bool
+  -> ?phase:Keeper_state_machine.phase
+  -> keeper_meta
+  -> string list
+
+val keeper_allowed_model_tools
+  :  ?write_done:bool
+  -> keeper_meta
+  -> Masc_domain.tool_schema list
 
 (** Universe tool names: candidates minus denied, no policy filter.
     Superset of [keeper_allowed_tool_names].  Used as the BM25 retrieval
@@ -61,8 +65,7 @@ val has_mutating_side_effect : string -> bool
 
 (** Input-aware mutation check for mixed tools such as [keeper_shell] with
     op=gh where read-only and mutating subcommands share the same tool name. *)
-val has_mutating_side_effect_with_input :
-  tool_name:string -> input:Yojson.Safe.t -> bool
+val has_mutating_side_effect_with_input : tool_name:string -> input:Yojson.Safe.t -> bool
 
 (** Schema for the keeper_tool_search tool. *)
 val keeper_tool_search_schema : Masc_domain.tool_schema
@@ -76,8 +79,7 @@ val set_masc_schemas : Masc_domain.tool_schema list -> unit
 val masc_schemas_snapshot : unit -> Masc_domain.tool_schema list
 
 (** Scoped schema override for tests that need a synthetic MASC surface. *)
-val with_masc_schemas_for_test :
-  Masc_domain.tool_schema list -> (unit -> 'a) -> 'a
+val with_masc_schemas_for_test : Masc_domain.tool_schema list -> (unit -> 'a) -> 'a
 
 (** Injected masc_* tool names (populated at startup by [inject_masc_schemas]). *)
 val injected_masc_tool_names : unit -> string list
@@ -121,18 +123,21 @@ type tool_result_payload =
 (** Bridge-facing execution outcome.
     Structured tool errors, including [tool_not_allowed], are failures so
     preset/policy rejections cannot silently end a keeper turn as success. *)
-type execution_outcome = [ `Success | `Failure ]
+type execution_outcome =
+  [ `Success
+  | `Failure
+  ]
 
 (** Typed keeper tool execution result.
     [raw_output] preserves the original payload, [outcome] is the
     authoritative success/failure decision for bridge consumers, and
     [payload_shape] captures the post-execution wire shape for telemetry
     and malformed-payload handling. *)
-type executed_tool_result = {
-  raw_output : string;
-  outcome : execution_outcome;
-  payload_shape : tool_result_payload;
-}
+type executed_tool_result =
+  { raw_output : string
+  ; outcome : execution_outcome
+  ; payload_shape : tool_result_payload
+  }
 
 (** Inspect a keeper tool result payload without applying side effects. *)
 val classify_tool_result_payload : string -> tool_result_payload
@@ -150,28 +155,28 @@ val keeper_masc_tool_schemas : keeper_meta -> Masc_domain.tool_schema list
 (** Compute the keeper's sender identity for portals and broadcasts.
     Guards against double "keeper-" prefix. See #5104. *)
 
-val execute_keeper_tool_call_with_outcome :
-  config:Coord.config ->
-  meta:keeper_meta ->
-  ctx_work:working_context ->
-  ?turn_sandbox_factory:Keeper_sandbox_factory.t ->
-  ?turn_sandbox_factory_git:Keeper_sandbox_factory.t ->
-  exec_cache:Masc_exec.Exec_cache.t option ->
-  ?search_fn:(query:string -> max_results:int -> Yojson.Safe.t) ->
-  name:string ->
-  input:Yojson.Safe.t ->
-  unit ->
-  executed_tool_result
+val execute_keeper_tool_call_with_outcome
+  :  config:Coord.config
+  -> meta:keeper_meta
+  -> ctx_work:working_context
+  -> ?turn_sandbox_factory:Keeper_sandbox_factory.t
+  -> ?turn_sandbox_factory_git:Keeper_sandbox_factory.t
+  -> exec_cache:Masc_exec.Exec_cache.t option
+  -> ?search_fn:(query:string -> max_results:int -> Yojson.Safe.t)
+  -> name:string
+  -> input:Yojson.Safe.t
+  -> unit
+  -> executed_tool_result
 
-val execute_keeper_tool_call :
-  config:Coord.config ->
-  meta:keeper_meta ->
-  ctx_work:working_context ->
-  ?turn_sandbox_factory:Keeper_sandbox_factory.t ->
-  ?turn_sandbox_factory_git:Keeper_sandbox_factory.t ->
-  exec_cache:Masc_exec.Exec_cache.t option ->
-  ?search_fn:(query:string -> max_results:int -> Yojson.Safe.t) ->
-  name:string ->
-  input:Yojson.Safe.t ->
-  unit ->
-  string
+val execute_keeper_tool_call
+  :  config:Coord.config
+  -> meta:keeper_meta
+  -> ctx_work:working_context
+  -> ?turn_sandbox_factory:Keeper_sandbox_factory.t
+  -> ?turn_sandbox_factory_git:Keeper_sandbox_factory.t
+  -> exec_cache:Masc_exec.Exec_cache.t option
+  -> ?search_fn:(query:string -> max_results:int -> Yojson.Safe.t)
+  -> name:string
+  -> input:Yojson.Safe.t
+  -> unit
+  -> string

--- a/lib/keeper/keeper_exec_tools.mli
+++ b/lib/keeper/keeper_exec_tools.mli
@@ -105,28 +105,6 @@ val init_policy_config : base_path:string -> (unit, string) result
     and blocked at execution time by the pre_tool_use hook. *)
 val is_keeper_denied : string -> bool
 
-type keeper_tool_call_recorder =
-  tool_name:string -> success:bool -> duration_ms:int -> unit
-
-(** Set the keeper-internal tool-call recorder.
-    The setter is process-global because server initialization wires around
-    the Config dependency cycle; calls are mutex-protected so runtime readers
-    do not dereference a publicly mutable ref. *)
-val set_on_keeper_tool_call : keeper_tool_call_recorder -> unit
-
-(** Record a keeper-internal tool call through the configured recorder. *)
-val record_keeper_tool_call : keeper_tool_call_recorder
-
-type tool_searcher = query:string -> max_results:int -> Yojson.Safe.t
-
-(** Set the fallback BM25 searcher for [keeper_tool_search].
-    Prefer passing [~search_fn] to [execute_keeper_tool_call] for
-    session-scoped search. *)
-val set_tool_search_fn : tool_searcher -> unit
-
-(** Invoke the fallback BM25 searcher for [keeper_tool_search]. *)
-val search_tools : tool_searcher
-
 (** Classification of a keeper tool result payload for circuit-breaker
     bookkeeping.
 

--- a/lib/keeper/keeper_tools_oas.ml
+++ b/lib/keeper/keeper_tools_oas.ml
@@ -13,17 +13,16 @@
 
 (** Re-export from Keeper_types so dashboard code using
     [e.Keeper_tools_oas.count] keeps compiling. *)
-type tool_call_entry = Keeper_types.tool_call_entry = {
-  count : int;
-  successes : int;
-  failures : int;
-  last_used_at : float;
-}
+type tool_call_entry = Keeper_types.tool_call_entry =
+  { count : int
+  ; successes : int
+  ; failures : int
+  ; last_used_at : float
+  }
 
 type tool_bundle =
-  {
-    tools : Agent_sdk.Tool.t list;
-    cleanup : unit -> unit;
+  { tools : Agent_sdk.Tool.t list
+  ; cleanup : unit -> unit
   }
 
 (** Tool usage now lives in Keeper_registry (per-entry tool_usage Hashtbl).
@@ -31,30 +30,37 @@ type tool_bundle =
 
 let tool_usage_for_keeper keeper_name : (string * tool_call_entry) list =
   Keeper_registry.tool_usage_of_by_name keeper_name
+;;
 
 let tool_usage_json keeper_name : Yojson.Safe.t =
-  `List (List.map (fun (name, e) ->
-    `Assoc [
-      ("tool_name", `String name);
-      ("count", `Int e.count);
-      ("successes", `Int e.successes);
-      ("failures", `Int e.failures);
-      ("last_used_at", `Float e.last_used_at);
-    ]
-  ) (tool_usage_for_keeper keeper_name))
+  `List
+    (List.map
+       (fun (name, e) ->
+          `Assoc
+            [ "tool_name", `String name
+            ; "count", `Int e.count
+            ; "successes", `Int e.successes
+            ; "failures", `Int e.failures
+            ; "last_used_at", `Float e.last_used_at
+            ])
+       (tool_usage_for_keeper keeper_name))
+;;
 
 let record_keeper_internal_tool_call ~tool_name ~success ~duration_ms =
-  Tool_registry.record_call ~source:Keeper_internal ~tool_name ~success
-    ~duration_ms ()
+  Tool_registry.record_call ~source:Keeper_internal ~tool_name ~success ~duration_ms ()
+;;
 
 let recent_tools_for_keeper ?(limit = 5) keeper_name : string list =
   tool_usage_for_keeper keeper_name
   |> List.sort (fun (_, a) (_, b) -> Float.compare b.last_used_at a.last_used_at)
-  |> (fun l -> let rec take n acc = function
+  |> fun l ->
+  let rec take n acc = function
     | [] -> List.rev acc
     | _ when n <= 0 -> List.rev acc
     | (name, _) :: rest -> take (n - 1) (name :: acc) rest
-    in take limit [] l)
+  in
+  take limit [] l
+;;
 
 (* ── end tracking ────────────────────────────────────────────── *)
 
@@ -67,38 +73,39 @@ let recent_tools_for_keeper ?(limit = 5) keeper_name : string list =
    @param config Coord configuration for tool dispatch
    @param meta Keeper metadata (determines which tools are allowed)
    @param ctx_snapshot Immutable snapshot of current working context *)
+
 (** Repeated-failure guardrail: blocks a tool after [max_consecutive]
     consecutive failures with the same (tool_name, args_hash) key.
     Resets on success. Prevents infinite retry loops (e.g. keeper
     reading a non-existent file 400+ times). *)
-let max_consecutive_failures =
-  Env_config.KeeperToolExec.max_consecutive_tool_failures
+let max_consecutive_failures = Env_config.KeeperToolExec.max_consecutive_tool_failures
 
 type failure_counts =
-  {
-    table : (string, int) Hashtbl.t;
-    mutex : Mutex.t;
+  { table : (string, int) Hashtbl.t
+  ; mutex : Mutex.t
   }
 
-let create_failure_counts () =
-  { table = Hashtbl.create 16; mutex = Mutex.create () }
+let create_failure_counts () = { table = Hashtbl.create 16; mutex = Mutex.create () }
 
 let failure_count_get counts key =
   Mutex.protect counts.mutex (fun () ->
-      Option.value ~default:0 (Hashtbl.find_opt counts.table key))
+    Option.value ~default:0 (Hashtbl.find_opt counts.table key))
+;;
 
 let failure_count_record_failure counts key =
   Mutex.protect counts.mutex (fun () ->
-      let next =
-        match Hashtbl.find_opt counts.table key with
-        | Some n -> n + 1
-        | None -> 1
-      in
-      Hashtbl.replace counts.table key next;
-      next)
+    let next =
+      match Hashtbl.find_opt counts.table key with
+      | Some n -> n + 1
+      | None -> 1
+    in
+    Hashtbl.replace counts.table key next;
+    next)
+;;
 
 let failure_count_reset counts key =
   Mutex.protect counts.mutex (fun () -> Hashtbl.remove counts.table key)
+;;
 
 (** Normalize a raw tool result string into a consistent JSON envelope.
 
@@ -116,95 +123,93 @@ let failure_count_reset counts key =
 let normalize_tool_result ~(success : bool) (raw : string) : string =
   try
     let json = Yojson.Safe.from_string raw in
-    if success then
+    if success
+    then
       (* Success: wrap original JSON under "result" key.
          If original already has "ok":true, the normalized envelope
          is still consistent — "ok" at the top level is authoritative. *)
-      Yojson.Safe.to_string (`Assoc [
-        ("ok", `Bool true);
-        ("result", json);
-      ])
-    else
+      Yojson.Safe.to_string (`Assoc [ "ok", `Bool true; "result", json ])
+    else (
       (* Failure: extract error message from whichever field is present,
          preserve original JSON as "detail" for debugging. *)
       let error_msg =
         match Safe_ops.json_string_opt "error" json with
         | Some msg when String.trim msg <> "" -> msg
         | _ ->
-          match Safe_ops.json_string_opt "output" json with
-          | Some msg when String.trim msg <> "" -> msg
-          | _ ->
-            match Safe_ops.json_string_opt "message" json with
-            | Some msg when String.trim msg <> "" -> msg
-            | _ ->
-              match Safe_ops.json_string_opt "status" json with
-              | Some s when String.lowercase_ascii (String.trim s) = "error" ->
-                "tool returned error status"
-              | _ -> "tool call failed"
+          (match Safe_ops.json_string_opt "output" json with
+           | Some msg when String.trim msg <> "" -> msg
+           | _ ->
+             (match Safe_ops.json_string_opt "message" json with
+              | Some msg when String.trim msg <> "" -> msg
+              | _ ->
+                (match Safe_ops.json_string_opt "status" json with
+                 | Some s when String.lowercase_ascii (String.trim s) = "error" ->
+                   "tool returned error status"
+                 | _ -> "tool call failed")))
       in
-      Yojson.Safe.to_string (`Assoc [
-        ("ok", `Bool false);
-        ("error", `String error_msg);
-        ("detail", json);
-      ])
-  with Yojson.Json_error _ ->
+      Yojson.Safe.to_string
+        (`Assoc [ "ok", `Bool false; "error", `String error_msg; "detail", json ]))
+  with
+  | Yojson.Json_error _ ->
     (* Raw is not JSON (e.g. plain text from keeper_tasks_list).
        Wrap as-is. *)
-    if success then
-      Yojson.Safe.to_string (`Assoc [
-        ("ok", `Bool true);
-        ("result", `String raw);
-      ])
+    if success
+    then Yojson.Safe.to_string (`Assoc [ "ok", `Bool true; "result", `String raw ])
     else
-      Yojson.Safe.to_string (`Assoc [
-        ("ok", `Bool false);
-        ("error", `String raw);
-        ("detail", `Null);
-      ])
+      Yojson.Safe.to_string
+        (`Assoc [ "ok", `Bool false; "error", `String raw; "detail", `Null ])
+;;
 
 let transient_mutex_contention_error_class = "transient_mutex_contention"
 
 let transient_mutex_contention_tool_error
-    ~(tool_name : string)
-    ~(error_text : string)
-    ?backtrace
-    () : string =
+      ~(tool_name : string)
+      ~(error_text : string)
+      ?backtrace
+      ()
+  : string
+  =
   let message =
     Printf.sprintf
-      "tool %s hit transient mutex contention (EDEADLK); not counted toward consecutive-failure budget. Retry the same call or wait for the contending operation to finish."
+      "tool %s hit transient mutex contention (EDEADLK); not counted toward \
+       consecutive-failure budget. Retry the same call or wait for the contending \
+       operation to finish."
       tool_name
   in
   Yojson.Safe.to_string
-    (`Assoc [
-      ("ok", `Bool false);
-      ("error", `String message);
-      ("error_class", `String transient_mutex_contention_error_class);
-      ("recoverable", `Bool true);
-      ("transient", `Bool true);
-      ("retry_recommended", `Bool true);
-      ( "detail",
-        `Assoc [
-          ("tool_name", `String tool_name);
-          ("exception", `String error_text);
-          ("operator_action", `String "retry_same_call_or_wait");
-          ("backtrace_available", `Bool (Option.is_some backtrace));
-        ] );
-    ])
+    (`Assoc
+        [ "ok", `Bool false
+        ; "error", `String message
+        ; "error_class", `String transient_mutex_contention_error_class
+        ; "recoverable", `Bool true
+        ; "transient", `Bool true
+        ; "retry_recommended", `Bool true
+        ; ( "detail"
+          , `Assoc
+              [ "tool_name", `String tool_name
+              ; "exception", `String error_text
+              ; "operator_action", `String "retry_same_call_or_wait"
+              ; "backtrace_available", `Bool (Option.is_some backtrace)
+              ] )
+        ])
+;;
 
 let current_keeper_model (meta : Keeper_types.keeper_meta) =
   let m = meta.runtime.usage.last_model_used in
   if m = "" then Keeper_types.cascade_name_of_meta meta else m
+;;
 
 let persist_tool_call_io_from_handler
-    ~(meta : Keeper_types.keeper_meta)
-    ~(tool_name : string)
-    ~(input : Yojson.Safe.t)
-    ~(output_text : string)
-    ~(success : bool)
-    ~(duration_ms : float)
-    ?result_bytes
-    ?truncated_to
-    () =
+      ~(meta : Keeper_types.keeper_meta)
+      ~(tool_name : string)
+      ~(input : Yojson.Safe.t)
+      ~(output_text : string)
+      ~(success : bool)
+      ~(duration_ms : float)
+      ?result_bytes
+      ?truncated_to
+      ()
+  =
   try
     Keeper_tool_call_log.log_call
       ~keeper_name:meta.name
@@ -226,13 +231,16 @@ let persist_tool_call_io_from_handler
   with
   | Eio.Cancel.Cancelled _ as e -> raise e
   | exn ->
-      Prometheus.inc_counter
-        Keeper_metrics.metric_keeper_lifecycle_callback_failures
-        ~labels:[ ("keeper", meta.name); ("callback", "handler_tool_log_write") ]
-        ();
-      Log.Keeper.warn
-        "keeper:%s tool=%s handler-side tool_call log failed: %s"
-        meta.name tool_name (Printexc.to_string exn)
+    Prometheus.inc_counter
+      Keeper_metrics.metric_keeper_lifecycle_callback_failures
+      ~labels:[ "keeper", meta.name; "callback", "handler_tool_log_write" ]
+      ();
+    Log.Keeper.warn
+      "keeper:%s tool=%s handler-side tool_call log failed: %s"
+      meta.name
+      tool_name
+      (Printexc.to_string exn)
+;;
 
 (** Max chars for SSE error preview. Short enough for dashboard display,
     long enough to include the actionable portion of the error. *)
@@ -240,69 +248,78 @@ let sse_error_preview_max_chars = 300
 
 let add_unique_marker marker markers =
   if List.mem marker markers then markers else marker :: markers
+;;
 
 let json_string_field_opt key = function
-  | `Assoc fields -> (
-      match List.assoc_opt key fields with
-      | Some (`String value) -> Some value
-      | _ -> None)
+  | `Assoc fields ->
+    (match List.assoc_opt key fields with
+     | Some (`String value) -> Some value
+     | _ -> None)
   | _ -> None
+;;
 
 let strip_simple_quotes text =
   let len = String.length text in
-  if len >= 2 then
+  if len >= 2
+  then (
     match text.[0], text.[len - 1] with
     | '\'', '\'' | '"', '"' -> String.sub text 1 (len - 2)
-    | _ -> text
+    | _ -> text)
   else text
+;;
 
 let command_words command =
   command
   |> String.split_on_char ' '
   |> List.filter_map (fun word ->
-         match String.trim word with
-         | "" -> None
-         | word -> Some (strip_simple_quotes word |> String.lowercase_ascii))
+    match String.trim word with
+    | "" -> None
+    | word -> Some (strip_simple_quotes word |> String.lowercase_ascii))
+;;
 
 let add_command_markers command markers =
   match command_words command with
   | "git" :: "push" :: _ -> add_unique_marker "git push" markers
-  | "gh" :: "pr" :: "create" :: _ ->
-      add_unique_marker "gh pr create" markers
+  | "gh" :: "pr" :: "create" :: _ -> add_unique_marker "gh pr create" markers
   | _ -> markers
+;;
 
 let add_action_marker action markers =
   match String.lowercase_ascii (String.trim action) with
   | "push" -> add_unique_marker "git push" markers
   | _ -> markers
+;;
 
 let add_event_marker event markers =
   match String.uppercase_ascii (String.trim event) with
   | "APPROVE" -> add_unique_marker "event=APPROVE" markers
   | _ -> markers
+;;
 
 let add_operation_marker operation markers =
   match String.lowercase_ascii (String.trim operation) with
   | "pr_create" -> add_unique_marker "gh pr create" markers
   | _ -> markers
+;;
 
 let allowed_via_marker = function
-  | "brokered" | "docker" | "host" | "keeper" | "operator" | "system"
-  | "taskmaster" ->
-      true
+  | "brokered" | "docker" | "host" | "keeper" | "operator" | "system" | "taskmaster" ->
+    true
   | _ -> false
+;;
 
 let add_via_marker via markers =
   let value = String.trim via |> String.lowercase_ascii in
-  if allowed_via_marker value then add_unique_marker ("via=" ^ value) markers
-  else markers
+  if allowed_via_marker value then add_unique_marker ("via=" ^ value) markers else markers
+;;
 
 let add_json_marker_fields ?(trusted_route_fields = true) json markers =
   let markers =
-    if trusted_route_fields then
+    if trusted_route_fields
+    then (
       match json_string_field_opt "via" json with
       | Some via -> add_via_marker via markers
-      | None -> markers
+      | None -> markers)
     else markers
   in
   let markers =
@@ -321,78 +338,109 @@ let add_json_marker_fields ?(trusted_route_fields = true) json markers =
     | None -> markers
   in
   let markers =
-    if trusted_route_fields then
+    if trusted_route_fields
+    then (
       match json_string_field_opt "action" json with
       | Some action -> add_action_marker action markers
-      | None -> markers
+      | None -> markers)
     else markers
   in
   let markers =
-    if trusted_route_fields then
+    if trusted_route_fields
+    then (
       match json_string_field_opt "event" json with
       | Some event -> add_event_marker event markers
-      | None -> markers
+      | None -> markers)
     else markers
   in
-  if trusted_route_fields then
+  if trusted_route_fields
+  then (
     match json_string_field_opt "operation" json with
     | Some operation -> add_operation_marker operation markers
-    | None -> markers
+    | None -> markers)
   else markers
+;;
 
-let tool_exec_result_markers ~(input : Yojson.Safe.t) ~(output : string)
-    : string list =
+let tool_exec_result_markers ~(input : Yojson.Safe.t) ~(output : string) : string list =
   let markers = add_json_marker_fields ~trusted_route_fields:false input [] in
   let markers =
     try
       let json = Yojson.Safe.from_string output in
       let markers = add_json_marker_fields json markers in
       match json with
-      | `Assoc fields -> (
-          match List.assoc_opt "result" fields with
-          | Some result -> add_json_marker_fields result markers
-          | None -> markers)
+      | `Assoc fields ->
+        (match List.assoc_opt "result" fields with
+         | Some result -> add_json_marker_fields result markers
+         | None -> markers)
       | _ -> markers
-    with Yojson.Json_error _ -> markers
+    with
+    | Yojson.Json_error _ -> markers
   in
   List.rev markers
+;;
 
-let keeper_tool_call_event_json ~keeper_name ~tool_name ~duration_ms ~success
-    ?error_text ?(extra_fields = []) ~ts () =
+let keeper_tool_call_event_json
+      ~keeper_name
+      ~tool_name
+      ~duration_ms
+      ~success
+      ?error_text
+      ?(extra_fields = [])
+      ~ts
+      ()
+  =
   let fields =
-    [
-      ("type", `String "keeper_tool_call");
-      ("name", `String keeper_name);
-      ("tool_name", `String tool_name);
-      ("duration_ms", `Int duration_ms);
-      ("success", `Bool success);
-      ("ts_unix", `Float ts);
+    [ "type", `String "keeper_tool_call"
+    ; "name", `String keeper_name
+    ; "tool_name", `String tool_name
+    ; "duration_ms", `Int duration_ms
+    ; "success", `Bool success
+    ; "ts_unix", `Float ts
     ]
   in
   let fields =
     match error_text with
-    | Some error_text -> fields @ [ ("error_text", `String error_text) ]
+    | Some error_text -> fields @ [ "error_text", `String error_text ]
     | None -> fields
   in
   `Assoc (fields @ extra_fields)
 ;;
 
-let broadcast_keeper_tool_call_event ~keeper_name ~tool_name ~duration_ms
-    ~success ?error_text ?(extra_fields = []) ~site ~ts () =
+let broadcast_keeper_tool_call_event
+      ~keeper_name
+      ~tool_name
+      ~duration_ms
+      ~success
+      ?error_text
+      ?(extra_fields = [])
+      ~site
+      ~ts
+      ()
+  =
   try
     Sse.broadcast
-      (keeper_tool_call_event_json ~keeper_name ~tool_name ~duration_ms
-         ~success ?error_text ~extra_fields ~ts ())
+      (keeper_tool_call_event_json
+         ~keeper_name
+         ~tool_name
+         ~duration_ms
+         ~success
+         ?error_text
+         ~extra_fields
+         ~ts
+         ())
   with
   | Eio.Cancel.Cancelled _ as e -> raise e
   | exn ->
-      Prometheus.inc_counter
-        Keeper_metrics.metric_keeper_sse_broadcast_failures
-        ~labels:[("keeper", keeper_name)]
-        ();
-      Log.Keeper.warn
-        "keeper tool-call SSE broadcast failed: keeper=%s tool=%s site=%s err=%s"
-        keeper_name tool_name site (Printexc.to_string exn)
+    Prometheus.inc_counter
+      Keeper_metrics.metric_keeper_sse_broadcast_failures
+      ~labels:[ "keeper", keeper_name ]
+      ();
+    Log.Keeper.warn
+      "keeper tool-call SSE broadcast failed: keeper=%s tool=%s site=%s err=%s"
+      keeper_name
+      tool_name
+      site
+      (Printexc.to_string exn)
 ;;
 
 let append_tool_exec_decision_log ~config ~keeper_name ~site entry =
@@ -403,13 +451,16 @@ let append_tool_exec_decision_log ~config ~keeper_name ~site entry =
   with
   | Eio.Cancel.Cancelled _ as e -> raise e
   | exn ->
-      Prometheus.inc_counter
-        Keeper_metrics.metric_keeper_decision_audit_flush_failures
-        ~labels:[("keeper", keeper_name)]
-        ();
-      Log.Keeper.warn
-        "keeper tool execution decision-log append failed: keeper=%s site=%s err=%s"
-        keeper_name site (Printexc.to_string exn)
+    Prometheus.inc_counter
+      Keeper_metrics.metric_keeper_decision_audit_flush_failures
+      ~labels:[ "keeper", keeper_name ]
+      ();
+    Log.Keeper.warn
+      "keeper tool execution decision-log append failed: keeper=%s site=%s err=%s"
+      keeper_name
+      site
+      (Printexc.to_string exn)
+;;
 
 (** RFC-0006 Phase A.2: build the per-tool handler closure.
 
@@ -428,81 +479,73 @@ let append_tool_exec_decision_log ~config ~keeper_name ~site entry =
     to the internal tool's expected payload (e.g. [{command,timeout}] ->
     [{cmd,timeout_sec}]). Identity by default. *)
 let make_keeper_tool_handler
-    ~(name : string)
-    ~(input_schema : Yojson.Safe.t)
-    ~(config : Coord.config)
-    ~(meta : Keeper_types.keeper_meta)
-    ~(ctx_snapshot : Keeper_types.working_context)
-    ?turn_sandbox_factory
-    ?turn_sandbox_factory_git
-    ~(exec_cache : Masc_exec.Exec_cache.t option)
-    ?search_fn
-    ?on_tool_called
-    ?(translate_input = fun j -> j)
-    ~(failure_counts : failure_counts)
-    ()
-  : Yojson.Safe.t -> bool * string =
+      ~(name : string)
+      ~(input_schema : Yojson.Safe.t)
+      ~(config : Coord.config)
+      ~(meta : Keeper_types.keeper_meta)
+      ~(ctx_snapshot : Keeper_types.working_context)
+      ?turn_sandbox_factory
+      ?turn_sandbox_factory_git
+      ~(exec_cache : Masc_exec.Exec_cache.t option)
+      ?search_fn
+      ?on_tool_called
+      ?(translate_input = fun j -> j)
+      ~(failure_counts : failure_counts)
+      ()
+  : Yojson.Safe.t -> bool * string
+  =
   let args_key input =
     let h = Hashtbl.hash (Yojson.Safe.to_string input) in
     Printf.sprintf "%s:%d" name h
   in
   fun raw_input ->
     let input = translate_input raw_input in
-    match Tool_input_validation.validate_args ~schema:input_schema ~name ~args:input () with
+    match
+      Tool_input_validation.validate_args ~schema:input_schema ~name ~args:input ()
+    with
     | Error validation_result ->
       let raw_result = Yojson.Safe.to_string validation_result.data in
       let output_text = normalize_tool_result ~success:false raw_result in
       let duration_ms = 0 in
       let ts = Time_compat.now () in
       let error_text = Tool_result.message validation_result in
-      Keeper_registry.record_tool_use ~base_path:config.base_path meta.name
-        ~tool_name:name ~success:false;
+      Keeper_registry.record_tool_use
+        ~base_path:config.base_path
+        meta.name
+        ~tool_name:name
+        ~success:false;
       Keeper_exec_tools.record_keeper_tool_call
-        ~tool_name:name ~success:false ~duration_ms;
+        ~tool_name:name
+        ~success:false
+        ~duration_ms;
       ignore (Tool_dispatch.run_post_hooks validation_result);
       broadcast_keeper_tool_call_event
-        ~keeper_name:meta.name ~tool_name:name ~duration_ms
-        ~success:false ~error_text ~site:"input_validation" ~ts ();
-      Prometheus.inc_counter
-        Keeper_metrics.metric_keeper_tools_oas_failures
-        ~labels:[("tool", name); ("site", "input_validation")]
-        ();
-      append_tool_exec_decision_log ~config ~keeper_name:meta.name
+        ~keeper_name:meta.name
+        ~tool_name:name
+        ~duration_ms
+        ~success:false
+        ~error_text
         ~site:"input_validation"
-        (`Assoc [
-          "ts_unix", `Float ts;
-          "event", `String "tool_exec";
-          "keeper_name", `String meta.name;
-          "tool", `String name;
-          "duration_ms", `Int duration_ms;
-          "result_bytes", `Int (String.length output_text);
-          "ok", `Bool false;
-          "error", `String error_text;
-        ]);
-      persist_tool_call_io_from_handler
-        ~meta
-        ~tool_name:name
-        ~input
-        ~output_text
-        ~success:false
-        ~duration_ms:0.0
-        ~result_bytes:(String.length output_text)
+        ~ts
         ();
-      (false, output_text)
-    | Ok input ->
-    let key = args_key input in
-    let prior_fails = failure_count_get failure_counts key in
-    if prior_fails >= max_consecutive_failures then begin
       Prometheus.inc_counter
         Keeper_metrics.metric_keeper_tools_oas_failures
-        ~labels:[("tool", name); ("site", "blocked")]
+        ~labels:[ "tool", name; "site", "input_validation" ]
         ();
-      Log.Keeper.warn "tool %s blocked after %d consecutive failures (same args)"
-        name prior_fails;
-      let msg = Printf.sprintf
-        "This tool has failed %d times in a row with the same arguments. Try a different approach or different arguments."
-        prior_fails in
-      let output_text = normalize_tool_result ~success:false msg in
+      append_tool_exec_decision_log
+        ~config
+        ~keeper_name:meta.name
+        ~site:"input_validation"
+        (`Assoc
+            [ "ts_unix", `Float ts
+            ; "event", `String "tool_exec"
+            ; "keeper_name", `String meta.name
+            ; "tool", `String name
+            ; "duration_ms", `Int duration_ms
+            ; "result_bytes", `Int (String.length output_text)
+            ; "ok", `Bool false
+            ; "error", `String error_text
+            ]);
       persist_tool_call_io_from_handler
         ~meta
         ~tool_name:name
@@ -512,203 +555,284 @@ let make_keeper_tool_handler
         ~duration_ms:0.0
         ~result_bytes:(String.length output_text)
         ();
-      (false, output_text)
-    end else
-      let t0 = Time_compat.now () in
-      try
-        let (result, duration_ms) =
-          Inference_utils.timed (fun () ->
-            Keeper_exec_tools.execute_keeper_tool_call_with_outcome
-              ~config ~meta ~ctx_work:ctx_snapshot
-              ?turn_sandbox_factory
-              ?turn_sandbox_factory_git
-              ~exec_cache
-              ?search_fn
-              ~name ~input ())
+      false, output_text
+    | Ok input ->
+      let key = args_key input in
+      let prior_fails = failure_count_get failure_counts key in
+      if prior_fails >= max_consecutive_failures
+      then (
+        Prometheus.inc_counter
+          Keeper_metrics.metric_keeper_tools_oas_failures
+          ~labels:[ "tool", name; "site", "blocked" ]
+          ();
+        Log.Keeper.warn
+          "tool %s blocked after %d consecutive failures (same args)"
+          name
+          prior_fails;
+        let msg =
+          Printf.sprintf
+            "This tool has failed %d times in a row with the same arguments. Try a \
+             different approach or different arguments."
+            prior_fails
         in
-        let raw_result = result.raw_output in
-        let is_failure =
-          match result.outcome with
-          | `Failure -> true
-          | `Success -> false
-        in
-        if is_failure then begin
-          let count = failure_count_record_failure failure_counts key in
-          Keeper_registry.record_tool_use ~base_path:config.base_path meta.name ~tool_name:name ~success:false;
-          record_keeper_internal_tool_call ~tool_name:name ~success:false
-            ~duration_ms;
-          (* Tool-call observability flows through the OAS Event_bus
+        let output_text = normalize_tool_result ~success:false msg in
+        persist_tool_call_io_from_handler
+          ~meta
+          ~tool_name:name
+          ~input
+          ~output_text
+          ~success:false
+          ~duration_ms:0.0
+          ~result_bytes:(String.length output_text)
+          ();
+        false, output_text)
+      else (
+        let t0 = Time_compat.now () in
+        try
+          let result, duration_ms =
+            Inference_utils.timed (fun () ->
+              Keeper_exec_tools.execute_keeper_tool_call_with_outcome
+                ~config
+                ~meta
+                ~ctx_work:ctx_snapshot
+                ?turn_sandbox_factory
+                ?turn_sandbox_factory_git
+                ~exec_cache
+                ?search_fn
+                ~name
+                ~input
+                ())
+          in
+          let raw_result = result.raw_output in
+          let is_failure =
+            match result.outcome with
+            | `Failure -> true
+            | `Success -> false
+          in
+          if is_failure
+          then (
+            let count = failure_count_record_failure failure_counts key in
+            Keeper_registry.record_tool_use
+              ~base_path:config.base_path
+              meta.name
+              ~tool_name:name
+              ~success:false;
+            record_keeper_internal_tool_call ~tool_name:name ~success:false ~duration_ms;
+            (* Tool-call observability flows through the OAS Event_bus
              (ToolCalled + ToolCompleted). MASC-side observers removed
              in refactor/tool-call-single-source. *)
-          (let tr = Tool_result.{ tool_name = name; success = false;
-              duration_ms = Float.of_int duration_ms; data = `Null;
-              legacy_message = raw_result } in
-           ignore (Tool_dispatch.run_post_hooks tr));
-          let detail =
-            let s = String.trim raw_result in
-            String_util.utf8_safe ~max_bytes:(sse_error_preview_max_chars + 3) ~suffix:"..." s |> String_util.to_string
-          in
-          let ts = Time_compat.now () in
-          broadcast_keeper_tool_call_event
-            ~keeper_name:meta.name ~tool_name:name ~duration_ms
-            ~success:false ~error_text:detail ~site:"error_result" ~ts ();
-          Prometheus.inc_counter
-            Keeper_metrics.metric_keeper_tools_oas_failures
-            ~labels:[("tool", name); ("site", "error_result")]
-            ();
-          Log.Keeper.error
-            "tool %s returned error result (%d/%d): %s"
-            name count max_consecutive_failures detail;
-          let normalized_error =
-            normalize_tool_result ~success:false raw_result
-          in
-          append_tool_exec_decision_log ~config ~keeper_name:meta.name
-            ~site:"error_result"
-            (`Assoc [
-              "ts_unix", `Float ts;
-              "event", `String "tool_exec";
-              "keeper_name", `String meta.name;
-              "tool", `String name;
-              "duration_ms", `Int duration_ms;
-              "result_bytes", `Int (String.length normalized_error);
-              "ok", `Bool false;
-              "error_preview", `String detail;
-            ]);
-          Keeper_tool_call_log.set_truncation_info
-            ~keeper_name:meta.name
-            ~original_bytes:(String.length normalized_error) ();
-          let output_text = Tool_output_validation.cap normalized_error in
-          persist_tool_call_io_from_handler
-            ~meta
-            ~tool_name:name
-            ~input
-            ~output_text
-            ~success:false
-            ~duration_ms:(Float.of_int duration_ms)
-            ~result_bytes:(String.length normalized_error)
-            ();
-          (false, output_text)
-        end else begin
-          failure_count_reset failure_counts key;
-          Keeper_registry.record_tool_use ~base_path:config.base_path meta.name ~tool_name:name ~success:true;
-          record_keeper_internal_tool_call ~tool_name:name ~success:true
-            ~duration_ms;
-          (* Tool-call observability via OAS Event_bus. See above. *)
-          (let tr = Tool_result.{ tool_name = name; success = true;
-              duration_ms = Float.of_int duration_ms; data = `Null;
-              legacy_message = raw_result } in
-           ignore (Tool_dispatch.run_post_hooks tr));
-          let ts = Time_compat.now () in
-          broadcast_keeper_tool_call_event
-            ~keeper_name:meta.name ~tool_name:name ~duration_ms
-            ~success:true ~site:"success" ~ts ();
-          (* Notify session callback (e.g., mark_used for discovered tools) *)
-          (match on_tool_called with Some f -> f name | None -> ());
-          (* PR#814 Gap 1: Capture git status delta after successful tool execution.
+            (let tr =
+               Tool_result.
+                 { tool_name = name
+                 ; success = false
+                 ; duration_ms = Float.of_int duration_ms
+                 ; data = `Null
+                 ; legacy_message = raw_result
+                 }
+             in
+             ignore (Tool_dispatch.run_post_hooks tr));
+            let detail =
+              let s = String.trim raw_result in
+              String_util.utf8_safe
+                ~max_bytes:(sse_error_preview_max_chars + 3)
+                ~suffix:"..."
+                s
+              |> String_util.to_string
+            in
+            let ts = Time_compat.now () in
+            broadcast_keeper_tool_call_event
+              ~keeper_name:meta.name
+              ~tool_name:name
+              ~duration_ms
+              ~success:false
+              ~error_text:detail
+              ~site:"error_result"
+              ~ts
+              ();
+            Prometheus.inc_counter
+              Keeper_metrics.metric_keeper_tools_oas_failures
+              ~labels:[ "tool", name; "site", "error_result" ]
+              ();
+            Log.Keeper.error
+              "tool %s returned error result (%d/%d): %s"
+              name
+              count
+              max_consecutive_failures
+              detail;
+            let normalized_error = normalize_tool_result ~success:false raw_result in
+            append_tool_exec_decision_log
+              ~config
+              ~keeper_name:meta.name
+              ~site:"error_result"
+              (`Assoc
+                  [ "ts_unix", `Float ts
+                  ; "event", `String "tool_exec"
+                  ; "keeper_name", `String meta.name
+                  ; "tool", `String name
+                  ; "duration_ms", `Int duration_ms
+                  ; "result_bytes", `Int (String.length normalized_error)
+                  ; "ok", `Bool false
+                  ; "error_preview", `String detail
+                  ]);
+            Keeper_tool_call_log.set_truncation_info
+              ~keeper_name:meta.name
+              ~original_bytes:(String.length normalized_error)
+              ();
+            let output_text = Tool_output_validation.cap normalized_error in
+            persist_tool_call_io_from_handler
+              ~meta
+              ~tool_name:name
+              ~input
+              ~output_text
+              ~success:false
+              ~duration_ms:(Float.of_int duration_ms)
+              ~result_bytes:(String.length normalized_error)
+              ();
+            false, output_text)
+          else (
+            failure_count_reset failure_counts key;
+            Keeper_registry.record_tool_use
+              ~base_path:config.base_path
+              meta.name
+              ~tool_name:name
+              ~success:true;
+            record_keeper_internal_tool_call ~tool_name:name ~success:true ~duration_ms;
+            (* Tool-call observability via OAS Event_bus. See above. *)
+            (let tr =
+               Tool_result.
+                 { tool_name = name
+                 ; success = true
+                 ; duration_ms = Float.of_int duration_ms
+                 ; data = `Null
+                 ; legacy_message = raw_result
+                 }
+             in
+             ignore (Tool_dispatch.run_post_hooks tr));
+            let ts = Time_compat.now () in
+            broadcast_keeper_tool_call_event
+              ~keeper_name:meta.name
+              ~tool_name:name
+              ~duration_ms
+              ~success:true
+              ~site:"success"
+              ~ts
+              ();
+            (* Notify session callback (e.g., mark_used for discovered tools) *)
+            (match on_tool_called with
+             | Some f -> f name
+             | None -> ());
+            (* PR#814 Gap 1: Capture git status delta after successful tool execution.
              If the working tree changed, log it so the keeper is aware of
              file-system side effects from its tool calls. *)
-          let change_block =
-            Worktree_live_context.capture_change_block
-              ~base_path:config.base_path ~actor_key:meta.name
-          in
-          (match change_block with
-           | Some _cb ->
-               Log.Keeper.info "post-tool git delta detected for %s after %s"
-                 meta.name name
-           | None -> ());
-          let normalized =
-            normalize_tool_result ~success:true raw_result
-          in
-          let final_result =
-            match change_block with
-            | None -> normalized
-            | Some cb ->
-              (* Inject changes field into the normalized JSON envelope
+            let change_block =
+              Worktree_live_context.capture_change_block
+                ~base_path:config.base_path
+                ~actor_key:meta.name
+            in
+            (match change_block with
+             | Some _cb ->
+               Log.Keeper.info
+                 "post-tool git delta detected for %s after %s"
+                 meta.name
+                 name
+             | None -> ());
+            let normalized = normalize_tool_result ~success:true raw_result in
+            let final_result =
+              match change_block with
+              | None -> normalized
+              | Some cb ->
+                (* Inject changes field into the normalized JSON envelope
                  to preserve valid JSON structure. *)
-              (try
-                 let json = Yojson.Safe.from_string normalized in
-                 match json with
-                 | `Assoc fields ->
-                   Yojson.Safe.to_string
-                     (`Assoc (fields @ [("changes", `String cb)]))
-                 | _ -> normalized
-               with Yojson.Json_error _ -> normalized)
-          in
-          let original_len = String.length final_result in
-          let truncated_result = Tool_output_validation.cap final_result in
-          let was_truncated = original_len > Tool_output_validation.max_output_chars in
-          let result_markers =
-            tool_exec_result_markers ~input ~output:final_result
-          in
-          let result_marker_fields =
-            match result_markers with
-            | [] -> []
-            | markers ->
-                [
-                  ( "result_markers",
-                    `List (List.map (fun marker -> `String marker) markers) );
+                (try
+                   let json = Yojson.Safe.from_string normalized in
+                   match json with
+                   | `Assoc fields ->
+                     Yojson.Safe.to_string (`Assoc (fields @ [ "changes", `String cb ]))
+                   | _ -> normalized
+                 with
+                 | Yojson.Json_error _ -> normalized)
+            in
+            let original_len = String.length final_result in
+            let truncated_result = Tool_output_validation.cap final_result in
+            let was_truncated = original_len > Tool_output_validation.max_output_chars in
+            let result_markers = tool_exec_result_markers ~input ~output:final_result in
+            let result_marker_fields =
+              match result_markers with
+              | [] -> []
+              | markers ->
+                [ ( "result_markers"
+                  , `List (List.map (fun marker -> `String marker) markers) )
                 ]
-          in
-          if was_truncated then
-            Log.Keeper.info "tool %s output truncated: %d -> %d chars"
-              name original_len (String.length truncated_result);
-          append_tool_exec_decision_log ~config ~keeper_name:meta.name
-            ~site:"success"
-            (`Assoc ([
-              "ts_unix", `Float ts;
-              "event", `String "tool_exec";
-              "keeper_name", `String meta.name;
-              "tool", `String name;
-              "duration_ms", `Int duration_ms;
-              "result_bytes", `Int original_len;
-              "ok", `Bool true;
-            ] @ result_marker_fields @ (if was_truncated then
-              ["truncated_to", `Int (String.length truncated_result)]
-            else [])));
-          (* Publish truncation info for OAS hook's tool_call_log *)
-          Keeper_tool_call_log.set_truncation_info
-            ~keeper_name:meta.name
-            ~original_bytes:original_len
-            ?truncated_to:(if was_truncated
-              then Some (String.length truncated_result) else None) ();
-          persist_tool_call_io_from_handler
-            ~meta
-            ~tool_name:name
-            ~input
-            ~output_text:truncated_result
-            ~success:true
-            ~duration_ms:(Float.of_int duration_ms)
-            ~result_bytes:original_len
-            ?truncated_to:(if was_truncated
-              then Some (String.length truncated_result) else None)
-            ();
-          (true, truncated_result)
-        end
-      with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
-        (* #10682: capture backtrace BEFORE any other operation that might
+            in
+            if was_truncated
+            then
+              Log.Keeper.info
+                "tool %s output truncated: %d -> %d chars"
+                name
+                original_len
+                (String.length truncated_result);
+            append_tool_exec_decision_log
+              ~config
+              ~keeper_name:meta.name
+              ~site:"success"
+              (`Assoc
+                  ([ "ts_unix", `Float ts
+                   ; "event", `String "tool_exec"
+                   ; "keeper_name", `String meta.name
+                   ; "tool", `String name
+                   ; "duration_ms", `Int duration_ms
+                   ; "result_bytes", `Int original_len
+                   ; "ok", `Bool true
+                   ]
+                   @ result_marker_fields
+                   @
+                   if was_truncated
+                   then [ "truncated_to", `Int (String.length truncated_result) ]
+                   else []));
+            (* Publish truncation info for OAS hook's tool_call_log *)
+            Keeper_tool_call_log.set_truncation_info
+              ~keeper_name:meta.name
+              ~original_bytes:original_len
+              ?truncated_to:
+                (if was_truncated then Some (String.length truncated_result) else None)
+              ();
+            persist_tool_call_io_from_handler
+              ~meta
+              ~tool_name:name
+              ~input
+              ~output_text:truncated_result
+              ~success:true
+              ~duration_ms:(Float.of_int duration_ms)
+              ~result_bytes:original_len
+              ?truncated_to:
+                (if was_truncated then Some (String.length truncated_result) else None)
+              ();
+            true, truncated_result)
+        with
+        | Eio.Cancel.Cancelled _ as e -> raise e
+        | exn ->
+          (* #10682: capture backtrace BEFORE any other operation that might
            raise/handle exceptions and clobber the raw_backtrace.  Used
            below to attach a stack to mutex EDEADLK ("Resource deadlock
            avoided") errors so the exact Stdlib.Mutex site can be
            identified — without this, the issue body for #10682 had to
            speculate across 5 candidate sites because no caller wrote
            the backtrace anywhere. *)
-        let raw_bt = Printexc.get_raw_backtrace () in
-        let ts = Time_compat.now () in
-        let duration_ms =
-          int_of_float ((ts -. t0) *. 1000.0) in
-        let error_text = Printexc.to_string exn in
-        let edeadlk_backtrace =
-          (* Mutex EDEADLK signature on macOS / Linux pthread errorcheck
+          let raw_bt = Printexc.get_raw_backtrace () in
+          let ts = Time_compat.now () in
+          let duration_ms = int_of_float ((ts -. t0) *. 1000.0) in
+          let error_text = Printexc.to_string exn in
+          let edeadlk_backtrace =
+            (* Mutex EDEADLK signature on macOS / Linux pthread errorcheck
              mutexes is exactly this Sys_error message; targeting it
              keeps backtrace dump narrow (rare event) instead of
              spamming every routine tool error. *)
-          if String_util.contains_substring error_text
-               "Resource deadlock avoided"
-          then Some (Printexc.raw_backtrace_to_string raw_bt)
-          else None
-        in
-        let is_edeadlk = edeadlk_backtrace <> None in
-        (* #10567: EDEADLK is a transient mutex-contention race in shared
+            if String_util.contains_substring error_text "Resource deadlock avoided"
+            then Some (Printexc.raw_backtrace_to_string raw_bt)
+            else None
+          in
+          let is_edeadlk = edeadlk_backtrace <> None in
+          (* #10567: EDEADLK is a transient mutex-contention race in shared
            coord/keeper Stdlib.Mutex sites, not a real keeper-side failure.
            Counting it toward [failure_counts] burns the consecutive-failure
            budget (max 3) and ends the keeper turn even when the next call
@@ -716,97 +840,115 @@ let make_keeper_tool_handler
            warn so dashboards don't conflate transient EDEADLK with real
            tool errors. The #10682 EDEADLK backtrace logging stays so the
            underlying Stdlib.Mutex site can still be pinpointed. *)
-        let count =
-          if is_edeadlk then failure_count_get failure_counts key
-          else failure_count_record_failure failure_counts key
-        in
-        Keeper_registry.record_tool_use ~base_path:config.base_path meta.name ~tool_name:name ~success:false;
-        record_keeper_internal_tool_call ~tool_name:name ~success:false
-          ~duration_ms;
-        (* Tool-call observability via OAS Event_bus. See above. *)
-        broadcast_keeper_tool_call_event
-          ~keeper_name:meta.name ~tool_name:name ~duration_ms
-          ~success:false ~error_text
-          ~extra_fields:
-            (if is_edeadlk then
-               [
-                 ( "error_class",
-                   `String transient_mutex_contention_error_class );
-                 ("recoverable", `Bool true);
-               ]
-             else [])
-          ~site:"exception" ~ts ();
-        let msg =
-          if is_edeadlk then
-            Printf.sprintf
-              "tool %s hit transient mutex contention (EDEADLK); not counted toward consecutive-failure budget. Retry the same call or pick a different tool."
-              name
-          else
-            Printf.sprintf "tool %s failed (%d/%d): %s"
-              name count max_consecutive_failures
-              (Printexc.to_string exn)
-        in
-        Prometheus.inc_counter
-          Keeper_metrics.metric_keeper_tools_oas_failures
-          ~labels:[("tool", name); ("site", "exception")]
-          ();
-        if is_edeadlk then Log.Keeper.warn "%s" msg
-        else Log.Keeper.error "%s" msg;
-        (match edeadlk_backtrace with
-         | Some bt ->
-             Log.Keeper.error
-               "tool %s EDEADLK backtrace (#10682):\n%s" name bt
-         | None -> ());
-        let normalized_exn =
-          if is_edeadlk then
-            transient_mutex_contention_tool_error
-              ~tool_name:name ~error_text ?backtrace:edeadlk_backtrace ()
-          else
-            normalize_tool_result ~success:false msg
-        in
-        append_tool_exec_decision_log ~config ~keeper_name:meta.name
-          ~site:"exception"
-          (`Assoc ([
-            "ts_unix", `Float ts;
-            "event", `String "tool_exec";
-            "keeper_name", `String meta.name;
-            "tool", `String name;
-            "duration_ms", `Int duration_ms;
-            "result_bytes", `Int (String.length normalized_exn);
-            "ok", `Bool false;
-            "error", `String error_text;
-          ]
-          @
-          if is_edeadlk then
-            [
-              ( "error_class",
-                `String transient_mutex_contention_error_class );
-              ("recoverable", `Bool true);
-            ]
-          else []));
-        Keeper_tool_call_log.set_truncation_info
-          ~keeper_name:meta.name
-          ~original_bytes:(String.length normalized_exn) ();
-        let output_text = Tool_output_validation.cap normalized_exn in
-        persist_tool_call_io_from_handler
-          ~meta
-          ~tool_name:name
-          ~input
-          ~output_text
-          ~success:false
-          ~duration_ms:(Float.of_int duration_ms)
-          ~result_bytes:(String.length normalized_exn)
-          ();
-        (false, output_text)
+          let count =
+            if is_edeadlk
+            then failure_count_get failure_counts key
+            else failure_count_record_failure failure_counts key
+          in
+          Keeper_registry.record_tool_use
+            ~base_path:config.base_path
+            meta.name
+            ~tool_name:name
+            ~success:false;
+          record_keeper_internal_tool_call ~tool_name:name ~success:false ~duration_ms;
+          (* Tool-call observability via OAS Event_bus. See above. *)
+          broadcast_keeper_tool_call_event
+            ~keeper_name:meta.name
+            ~tool_name:name
+            ~duration_ms
+            ~success:false
+            ~error_text
+            ~extra_fields:
+              (if is_edeadlk
+               then
+                 [ "error_class", `String transient_mutex_contention_error_class
+                 ; "recoverable", `Bool true
+                 ]
+               else [])
+            ~site:"exception"
+            ~ts
+            ();
+          let msg =
+            if is_edeadlk
+            then
+              Printf.sprintf
+                "tool %s hit transient mutex contention (EDEADLK); not counted toward \
+                 consecutive-failure budget. Retry the same call or pick a different \
+                 tool."
+                name
+            else
+              Printf.sprintf
+                "tool %s failed (%d/%d): %s"
+                name
+                count
+                max_consecutive_failures
+                (Printexc.to_string exn)
+          in
+          Prometheus.inc_counter
+            Keeper_metrics.metric_keeper_tools_oas_failures
+            ~labels:[ "tool", name; "site", "exception" ]
+            ();
+          if is_edeadlk then Log.Keeper.warn "%s" msg else Log.Keeper.error "%s" msg;
+          (match edeadlk_backtrace with
+           | Some bt -> Log.Keeper.error "tool %s EDEADLK backtrace (#10682):\n%s" name bt
+           | None -> ());
+          let normalized_exn =
+            if is_edeadlk
+            then
+              transient_mutex_contention_tool_error
+                ~tool_name:name
+                ~error_text
+                ?backtrace:edeadlk_backtrace
+                ()
+            else normalize_tool_result ~success:false msg
+          in
+          append_tool_exec_decision_log
+            ~config
+            ~keeper_name:meta.name
+            ~site:"exception"
+            (`Assoc
+                ([ "ts_unix", `Float ts
+                 ; "event", `String "tool_exec"
+                 ; "keeper_name", `String meta.name
+                 ; "tool", `String name
+                 ; "duration_ms", `Int duration_ms
+                 ; "result_bytes", `Int (String.length normalized_exn)
+                 ; "ok", `Bool false
+                 ; "error", `String error_text
+                 ]
+                 @
+                 if is_edeadlk
+                 then
+                   [ "error_class", `String transient_mutex_contention_error_class
+                   ; "recoverable", `Bool true
+                   ]
+                 else []));
+          Keeper_tool_call_log.set_truncation_info
+            ~keeper_name:meta.name
+            ~original_bytes:(String.length normalized_exn)
+            ();
+          let output_text = Tool_output_validation.cap normalized_exn in
+          persist_tool_call_io_from_handler
+            ~meta
+            ~tool_name:name
+            ~input
+            ~output_text
+            ~success:false
+            ~duration_ms:(Float.of_int duration_ms)
+            ~result_bytes:(String.length normalized_exn)
+            ();
+          false, output_text)
+;;
 
 let make_tool_bundle
-    ~(config : Coord.config)
-    ~(meta : Keeper_types.keeper_meta)
-    ~(ctx_snapshot : Keeper_types.working_context)
-    ?search_fn
-    ?on_tool_called
-    ()
-  : tool_bundle =
+      ~(config : Coord.config)
+      ~(meta : Keeper_types.keeper_meta)
+      ~(ctx_snapshot : Keeper_types.working_context)
+      ?search_fn
+      ?on_tool_called
+      ()
+  : tool_bundle
+  =
   (* PR-3b (#11611 part 1): replace eager [Keeper_turn_sandbox_runtime]
      instances with a factory.  in_playground/cwd are unknown at
      turn-start, so the factory defers
@@ -815,17 +957,17 @@ let make_tool_bundle
      stays gated by [hard_mode]; when off, it carries a
      [default_network_override] so resolved runtimes always inherit the
      host network. *)
-  let turn_sandbox_factory =
-    Some (Keeper_sandbox_factory.create ~config ~meta ())
-  in
+  let turn_sandbox_factory = Some (Keeper_sandbox_factory.create ~config ~meta ()) in
   let turn_sandbox_factory_git =
-    if Env_config_keeper.KeeperSandbox.hard_mode () then
-      None
+    if Env_config_keeper.KeeperSandbox.hard_mode ()
+    then None
     else
       Some
         (Keeper_sandbox_factory.create
            ~default_network_override:Network_inherit
-           ~config ~meta ())
+           ~config
+           ~meta
+           ())
   in
   let exec_cache = Some (Masc_exec.Exec_cache.create ()) in
   (* Build Tool.t for the full universe so BM25 and Tool_op can
@@ -833,9 +975,7 @@ let make_tool_bundle
      (AllowList filter in before_turn_hook) controls LLM visibility;
      execute_keeper_tool_call uses can_execute for the execution gate. *)
   let universe_names = Keeper_exec_tools.keeper_universe_tool_names meta in
-  let tool_defs =
-    Keeper_exec_tools.keeper_universe_model_tools meta
-  in
+  let tool_defs = Keeper_exec_tools.keeper_universe_model_tools meta in
   (* Record tool assignment telemetry for causal tracing.
      assignment_id links Assigned → Called → Completed events. *)
   let (_assignment_id : Tool_assignment_telemetry.assignment_id) =
@@ -843,7 +983,7 @@ let make_tool_bundle
     let preset =
       match meta.tool_access with
       | Preset { preset; _ } ->
-          Some (Keeper_tool_policy.preset_name_of_tool_preset preset)
+        Some (Keeper_tool_policy.preset_name_of_tool_preset preset)
       | Custom _ -> None
     in
     Tool_assignment_telemetry.emit_assigned
@@ -859,23 +999,35 @@ let make_tool_bundle
   let failure_counts = create_failure_counts () in
   (* Pass A: existing internal tools. Behavior unchanged from pre-A.2. *)
   let internal_tools =
-    List.filter_map (fun (td : Masc_domain.tool_schema) ->
-      if List.mem td.name universe_names then
-        let h = make_keeper_tool_handler ~name:td.name
-              ~input_schema:td.input_schema ~config ~meta ~ctx_snapshot
-              ?turn_sandbox_factory
-              ?turn_sandbox_factory_git
-              ~exec_cache
-              ?search_fn ?on_tool_called ~failure_counts () in
-        Some (Tool_bridge.oas_tool_of_masc
-          ~name:td.name
-          ~description:td.description
-          ~input_schema:td.input_schema
-          (fun input ->
-            let start_time = Time_compat.now () in
-            Tool_result.wrap ~tool_name:td.name ~start_time (h input)))
-      else None
-    ) tool_defs
+    List.filter_map
+      (fun (td : Masc_domain.tool_schema) ->
+         if List.mem td.name universe_names
+         then (
+           let h =
+             make_keeper_tool_handler
+               ~name:td.name
+               ~input_schema:td.input_schema
+               ~config
+               ~meta
+               ~ctx_snapshot
+               ?turn_sandbox_factory
+               ?turn_sandbox_factory_git
+               ~exec_cache
+               ?search_fn
+               ?on_tool_called
+               ~failure_counts
+               ()
+           in
+           Some
+             (Tool_bridge.oas_tool_of_masc
+                ~name:td.name
+                ~description:td.description
+                ~input_schema:td.input_schema
+                (fun input ->
+                   let start_time = Time_compat.now () in
+                   Tool_result.wrap ~tool_name:td.name ~start_time (h input))))
+         else None)
+      tool_defs
   in
   (* Pass B: RFC-0006 Phase A.2 — register dual aliases so the LLM can
      call Anthropic Code names (Bash/Read) successfully. The handler
@@ -883,66 +1035,76 @@ let make_tool_bundle
      internal; only the Tool.schema.name (LLM-visible) is the public
      alias. translate_input reshapes the LLM's payload before dispatch. *)
   let alias_tools =
-    List.filter_map (fun (public, internal) ->
-      if not (List.mem internal universe_names) then None
-      else
-        match
-          List.find_opt (fun (td : Masc_domain.tool_schema) ->
-            String.equal td.name internal) tool_defs
-        with
-        | None -> None
-        | Some internal_def ->
-          let input_schema =
-            match Keeper_tool_alias.public_input_schema public with
-            | Some s -> s
-            | None -> internal_def.input_schema
-          in
-          let description =
-            match public with
-            | "Grep" ->
-                "Search file contents with ripgrep. This is a public alias \
-                 for keeper_shell op=rg only; use Bash/keeper_bash for \
-                 command execution."
-            | "Bash" ->
-                "Execute one shell command through keeper_bash, including \
-                 Legendary Bash safety gates, write gating, background \
-                 execution, and sandbox routing."
-            | _ -> internal_def.description
-          in
-          let h =
-            make_keeper_tool_handler ~name:internal
-               ~input_schema:internal_def.input_schema ~config ~meta ~ctx_snapshot
-               ?turn_sandbox_factory
-               ?turn_sandbox_factory_git
-               ~exec_cache
-               ?search_fn ?on_tool_called
-               ~translate_input:(fun j ->
-                 Keeper_tool_alias.translate_input ~public j)
-               ~failure_counts ()
-          in
-          Some (Tool_bridge.oas_tool_of_masc
-            ~name:public
-            ~description
-            ~input_schema
-            (fun input ->
-              let start_time = Time_compat.now () in
-              Tool_result.wrap ~tool_name:public ~start_time (h input)))
-    ) (Keeper_tool_alias.oas_dual_register_aliases ())
+    List.filter_map
+      (fun (public, internal) ->
+         if not (List.mem internal universe_names)
+         then None
+         else (
+           match
+             List.find_opt
+               (fun (td : Masc_domain.tool_schema) -> String.equal td.name internal)
+               tool_defs
+           with
+           | None -> None
+           | Some internal_def ->
+             let input_schema =
+               match Keeper_tool_alias.public_input_schema public with
+               | Some s -> s
+               | None -> internal_def.input_schema
+             in
+             let description =
+               match public with
+               | "Grep" ->
+                 "Search file contents with ripgrep. This is a public alias for \
+                  keeper_shell op=rg only; use Bash/keeper_bash for command execution."
+               | "Bash" ->
+                 "Execute one shell command through keeper_bash, including Legendary \
+                  Bash safety gates, write gating, background execution, and sandbox \
+                  routing."
+               | _ -> internal_def.description
+             in
+             let h =
+               make_keeper_tool_handler
+                 ~name:internal
+                 ~input_schema:internal_def.input_schema
+                 ~config
+                 ~meta
+                 ~ctx_snapshot
+                 ?turn_sandbox_factory
+                 ?turn_sandbox_factory_git
+                 ~exec_cache
+                 ?search_fn
+                 ?on_tool_called
+                 ~translate_input:(fun j -> Keeper_tool_alias.translate_input ~public j)
+                 ~failure_counts
+                 ()
+             in
+             Some
+               (Tool_bridge.oas_tool_of_masc
+                  ~name:public
+                  ~description
+                  ~input_schema
+                  (fun input ->
+                     let start_time = Time_compat.now () in
+                     Tool_result.wrap ~tool_name:public ~start_time (h input)))))
+      (Keeper_tool_alias.oas_dual_register_aliases ())
   in
-  {
-    tools = internal_tools @ alias_tools;
-    cleanup =
+  { tools = internal_tools @ alias_tools
+  ; cleanup =
       (fun () ->
         Option.iter Keeper_sandbox_factory.cleanup turn_sandbox_factory;
-        Option.iter Keeper_sandbox_factory.cleanup turn_sandbox_factory_git);
+        Option.iter Keeper_sandbox_factory.cleanup turn_sandbox_factory_git)
   }
+;;
 
 let make_tools
-    ~(config : Coord.config)
-    ~(meta : Keeper_types.keeper_meta)
-    ~(ctx_snapshot : Keeper_types.working_context)
-    ?search_fn
-    ?on_tool_called
-    ()
-  : Agent_sdk.Tool.t list =
+      ~(config : Coord.config)
+      ~(meta : Keeper_types.keeper_meta)
+      ~(ctx_snapshot : Keeper_types.working_context)
+      ?search_fn
+      ?on_tool_called
+      ()
+  : Agent_sdk.Tool.t list
+  =
   (make_tool_bundle ~config ~meta ~ctx_snapshot ?search_fn ?on_tool_called ()).tools
+;;

--- a/lib/keeper/keeper_tools_oas.ml
+++ b/lib/keeper/keeper_tools_oas.ml
@@ -43,6 +43,10 @@ let tool_usage_json keeper_name : Yojson.Safe.t =
     ]
   ) (tool_usage_for_keeper keeper_name))
 
+let record_keeper_internal_tool_call ~tool_name ~success ~duration_ms =
+  Tool_registry.record_call ~source:Keeper_internal ~tool_name ~success
+    ~duration_ms ()
+
 let recent_tools_for_keeper ?(limit = 5) keeper_name : string list =
   tool_usage_for_keeper keeper_name
   |> List.sort (fun (_, a) (_, b) -> Float.compare b.last_used_at a.last_used_at)
@@ -416,7 +420,7 @@ let append_tool_exec_decision_log ~config ~keeper_name ~site entry =
 
     Telemetry SSOT contract: [~name] flows into every observability
     sink (Keeper_registry.record_tool_use, SSE broadcast tool_name,
-    decision-log "tool" field, record_keeper_tool_call). The LLM-facing
+    decision-log "tool" field, Tool_registry). The LLM-facing
     public name (Bash/Read/...) only appears as the [Tool.schema.name]
     set by [Tool_bridge.oas_tool_of_masc] above this helper.
 
@@ -531,8 +535,8 @@ let make_keeper_tool_handler
         if is_failure then begin
           let count = failure_count_record_failure failure_counts key in
           Keeper_registry.record_tool_use ~base_path:config.base_path meta.name ~tool_name:name ~success:false;
-          Keeper_exec_tools.record_keeper_tool_call
-            ~tool_name:name ~success:false ~duration_ms;
+          record_keeper_internal_tool_call ~tool_name:name ~success:false
+            ~duration_ms;
           (* Tool-call observability flows through the OAS Event_bus
              (ToolCalled + ToolCompleted). MASC-side observers removed
              in refactor/tool-call-single-source. *)
@@ -587,8 +591,8 @@ let make_keeper_tool_handler
         end else begin
           failure_count_reset failure_counts key;
           Keeper_registry.record_tool_use ~base_path:config.base_path meta.name ~tool_name:name ~success:true;
-          Keeper_exec_tools.record_keeper_tool_call
-            ~tool_name:name ~success:true ~duration_ms;
+          record_keeper_internal_tool_call ~tool_name:name ~success:true
+            ~duration_ms;
           (* Tool-call observability via OAS Event_bus. See above. *)
           (let tr = Tool_result.{ tool_name = name; success = true;
               duration_ms = Float.of_int duration_ms; data = `Null;
@@ -717,8 +721,8 @@ let make_keeper_tool_handler
           else failure_count_record_failure failure_counts key
         in
         Keeper_registry.record_tool_use ~base_path:config.base_path meta.name ~tool_name:name ~success:false;
-        Keeper_exec_tools.record_keeper_tool_call
-          ~tool_name:name ~success:false ~duration_ms;
+        record_keeper_internal_tool_call ~tool_name:name ~success:false
+          ~duration_ms;
         (* Tool-call observability via OAS Event_bus. See above. *)
         broadcast_keeper_tool_call_event
           ~keeper_name:meta.name ~tool_name:name ~duration_ms

--- a/lib/mcp_server_eio.ml
+++ b/lib/mcp_server_eio.ml
@@ -125,14 +125,7 @@ let () =
      + String.length (Yojson.Safe.to_string s.input_schema)
    ) 0 schemas in
    Prometheus.set_tool_schema_stats ~count ~approx_tokens:(chars / 4));
-  (* Wire keeper-internal tool call recording to break Config dependency cycle.
-     keeper_exec_tools cannot reference Tool_registry directly. *)
-  Keeper_exec_tools.set_on_keeper_tool_call
-    (fun ~tool_name ~success ~duration_ms ->
-       Tool_registry.record_call ~source:Keeper_internal
-         ~tool_name ~success ~duration_ms ());
   (* Wire tag-based dispatch for keeper masc_* tools.
-     Breaks the same Config dependency cycle as on_keeper_tool_call.
      See #4579: keeper_exec_tools uses handler registry (Tool_Board only),
      this callback adds tag-registry dispatch for ~190 more tools. *)
   Keeper_exec_shared.tag_dispatch_fn := Keeper_tag_dispatch.dispatch;

--- a/lib/mcp_server_eio.ml
+++ b/lib/mcp_server_eio.ml
@@ -13,32 +13,39 @@
     - Mcp_server_eio_governance: Governance and MCP session helpers
 *)
 
-
 (** {1 Re-exported Types} *)
 
 type server_state = Mcp_server.server_state
 type jsonrpc_request = Mcp_transport_protocol.jsonrpc_request
+
 type tool_profile = Mcp_server_eio_types.tool_profile =
   | Full
   | Managed_agent
   | Operator_remote
 
-type eio_net = [`Generic | `Unix] Eio.Net.ty Eio.Resource.t
+type eio_net = [ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t
 
 (** {1 Eio Context Wrappers} *)
 
 let set_net net = Eio_context.set_net net
 let set_clock clock = Eio_context.set_clock clock
 let get_clock_opt () = Eio_context.get_clock_opt ()
-let get_clock () = Eio_context.get_clock ()
-(** {1 State Construction} *)
 
-let create_state ?test_mode:_ ~base_path () =
-  Mcp_server.create_state ~base_path
+(** {1 State Construction} *)
+let get_clock () = Eio_context.get_clock ()
+
+let create_state ?test_mode:_ ~base_path () = Mcp_server.create_state ~base_path
 
 let create_state_eio ~sw ~proc_mgr ~fs ~clock ~mono_clock ~net ~base_path =
-  Mcp_server.create_state_eio ~sw ~proc_mgr ~fs ~clock ~mono_clock
-    ~net:(net :> Eio_context.eio_net) ~base_path
+  Mcp_server.create_state_eio
+    ~sw
+    ~proc_mgr
+    ~fs
+    ~clock
+    ~mono_clock
+    ~net:(net :> Eio_context.eio_net)
+    ~base_path
+;;
 
 (** {1 Re-exported Mcp_server Functions} *)
 
@@ -51,19 +58,21 @@ let get_field = Mcp_transport_protocol.get_field
 
 (** {1 Governance Re-exports} *)
 
-type governance_config = Mcp_server_eio_governance.governance_config = {
-  level: string;
-  audit_enabled: bool;
-  anomaly_detection: bool;
-}
+type governance_config = Mcp_server_eio_governance.governance_config =
+  { level : string
+  ; audit_enabled : bool
+  ; anomaly_detection : bool
+  }
+
 let governance_defaults = Mcp_server_eio_governance.governance_defaults
 
-type mcp_session_record = Mcp_server_eio_governance.mcp_session_record = {
-  id: string;
-  agent_name: string option;
-  created_at: float;
-  last_seen: float;
-}
+type mcp_session_record = Mcp_server_eio_governance.mcp_session_record =
+  { id : string
+  ; agent_name : string option
+  ; created_at : float
+  ; last_seen : float
+  }
+
 let mcp_session_to_json = Mcp_server_eio_governance.mcp_session_to_json
 let mcp_session_of_json = Mcp_server_eio_governance.mcp_session_of_json
 
@@ -76,18 +85,18 @@ let mcp_session_of_json = Mcp_server_eio_governance.mcp_session_of_json
     Tool_shard schemas. *)
 
 let read_only_tools_inline =
-  List.map Tool_name.Masc.to_string
-    Tool_name.Masc.[ Status; Who; Messages ]
+  List.map Tool_name.Masc.to_string Tool_name.Masc.[ Status; Who; Messages ]
+;;
 
 let requires_join_tools_inline =
-  List.map Tool_name.Masc.to_string
-    Tool_name.Masc.[ Broadcast; Leave ]
+  List.map Tool_name.Masc.to_string Tool_name.Masc.[ Broadcast; Leave ]
+;;
 
 let mcp_context_required_tools_inline =
   Tool_schemas_inline.schemas
   |> List.map (fun (schema : Masc_domain.tool_schema) -> schema.name)
-  |> List.filter (fun name ->
-       not (Keeper_tool_policy.is_keeper_safe_inline_tool name))
+  |> List.filter (fun name -> not (Keeper_tool_policy.is_keeper_safe_inline_tool name))
+;;
 
 let () =
   (* [Keeper_exec_tools.keeper_read_only_tools] is the keeper SSOT.
@@ -95,15 +104,25 @@ let () =
      annotations and non-keeper callers see the same read-only metadata. *)
   Tool_dispatch.init_read_only_set
     (read_only_tools_inline @ Keeper_exec_tools.keeper_read_only_tools)
+;;
+
 let () = Tool_dispatch.init_requires_join_set requires_join_tools_inline
 let () = Tool_dispatch.init_mcp_context_required_set mcp_context_required_tools_inline
+
 (* Tools whose arguments contain executable commands subject to
    destructive pattern scanning (eval_gate step 6).
    Covers: keeper tools (eval_gate), OAS hooks (keeper_hooks_oas),
    and worker tools (worker_oas). *)
-let () = Tool_dispatch.init_destructive_set
-  [ "keeper_bash"; "keeper_fs_edit";
-    "shell_exec"; "masc_code_shell"; "masc_code_git"; "masc_code_delete" ]
+let () =
+  Tool_dispatch.init_destructive_set
+    [ "keeper_bash"
+    ; "keeper_fs_edit"
+    ; "shell_exec"
+    ; "masc_code_shell"
+    ; "masc_code_git"
+    ; "masc_code_delete"
+    ]
+;;
 
 (* Tag registry initialization.
    Most modules register via Tool_spec.register at module load time.
@@ -120,10 +139,16 @@ let () =
   (* Report tool schema budget to Prometheus (#7483 Step 1). *)
   (let schemas = Config.visible_tool_schemas () in
    let count = List.length schemas in
-   let chars = List.fold_left (fun acc (s : Masc_domain.tool_schema) ->
-     acc + String.length s.name + String.length s.description
-     + String.length (Yojson.Safe.to_string s.input_schema)
-   ) 0 schemas in
+   let chars =
+     List.fold_left
+       (fun acc (s : Masc_domain.tool_schema) ->
+          acc
+          + String.length s.name
+          + String.length s.description
+          + String.length (Yojson.Safe.to_string s.input_schema))
+       0
+       schemas
+   in
    Prometheus.set_tool_schema_stats ~count ~approx_tokens:(chars / 4));
   (* Wire tag-based dispatch for keeper masc_* tools.
      See #4579: keeper_exec_tools uses handler registry (Tool_Board only),
@@ -134,6 +159,7 @@ let () =
      Validates tool arguments against their declared input_schema
      before dispatch — catches missing required fields and type mismatches. *)
   Tool_input_validation.register_pre_hook ()
+;;
 
 (** {1 execute_tool_eio -- included from Mcp_server_eio_execute} *)
 
@@ -143,34 +169,62 @@ include Mcp_server_eio_execute
 
 let clear_resource_subscriptions_for_session =
   Mcp_server_eio_protocol.clear_resource_subscriptions_for_session
+;;
 
 (** {1 Public API} *)
 
 let handle_request
-    ~(clock : [> float Eio.Time.clock_ty ] Eio.Resource.t)
+      ~(clock : [> float Eio.Time.clock_ty ] Eio.Resource.t)
+      ~sw
+      ?(profile = Full)
+      ?mcp_session_id
+      ?auth_token
+      ?(internal_keeper_runtime = false)
+      state
+      request_str
+  =
+  Mcp_server_eio_protocol.handle_request
+    ~handle_call_tool_eio:
+      (fun
+        ~sw
+        ~clock
+        ~profile
+        ?mcp_session_id
+        ?auth_token
+        ~internal_keeper_runtime
+        state
+        id
+        params ->
+      Mcp_server_eio_call_tool.handle_call_tool_eio
+        ~execute_tool_eio
+        ~maybe_emit_resource_notifications:
+          Mcp_server_eio_protocol.maybe_emit_resource_notifications
+        ~broadcast_tools_list_changed:Mcp_server_eio_protocol.broadcast_tools_list_changed
+        ~sw
+        ~clock
+        ~profile
+        ?mcp_session_id
+        ?auth_token
+        ~internal_keeper_runtime
+        state
+        id
+        params)
+    ~handle_read_resource_eio:Mcp_server_eio_resource.handle_read_resource_eio
+    ~clock
     ~sw
-    ?(profile = Full)
+    ~profile:(profile : tool_profile :> Mcp_server_eio_types.tool_profile)
     ?mcp_session_id
     ?auth_token
-    ?(internal_keeper_runtime = false)
+    ~internal_keeper_runtime
     state
-    request_str =
-  Mcp_server_eio_protocol.handle_request
-    ~handle_call_tool_eio:(fun ~sw ~clock ~profile ?mcp_session_id ?auth_token
-        ~internal_keeper_runtime state id params ->
-       Mcp_server_eio_call_tool.handle_call_tool_eio
-         ~execute_tool_eio
-         ~maybe_emit_resource_notifications:Mcp_server_eio_protocol.maybe_emit_resource_notifications
-         ~broadcast_tools_list_changed:Mcp_server_eio_protocol.broadcast_tools_list_changed
-         ~sw ~clock ~profile ?mcp_session_id ?auth_token
-         ~internal_keeper_runtime state id params)
-    ~handle_read_resource_eio:Mcp_server_eio_resource.handle_read_resource_eio
-    ~clock ~sw
-    ~profile:(profile : tool_profile :> Mcp_server_eio_types.tool_profile)
-    ?mcp_session_id ?auth_token ~internal_keeper_runtime state request_str
+    request_str
+;;
 
 (** Re-export transport mode from protocol for backward compatibility *)
-type transport_mode = Mcp_server_eio_protocol.transport_mode = Framed | LineDelimited
+type transport_mode = Mcp_server_eio_protocol.transport_mode =
+  | Framed
+  | LineDelimited
+
 let detect_mode = Mcp_server_eio_protocol.detect_mode
 
 let run_stdio ~sw ~env state =
@@ -178,3 +232,4 @@ let run_stdio ~sw ~env state =
     handle_request ~clock ~sw ~mcp_session_id state request_str
   in
   Mcp_server_eio_protocol.run_stdio ~handle_request ~sw ~env state
+;;

--- a/lib/tool_registry.ml
+++ b/lib/tool_registry.ml
@@ -70,16 +70,21 @@ let registry : (string, call_stats) Hashtbl.t = Hashtbl.create 128
 let registry_mu = Eio.Mutex.create ()
 let with_registry_rw f = Eio_guard.with_mutex registry_mu f
 let with_registry_ro f = Eio_guard.with_mutex_ro registry_mu f
-(** Use raw_all_tool_schemas to include hidden/internal tools.
-    Previously used Config.all_tool_schemas (public-filtered), which caused
-    hidden tools to be structurally undercounted in telemetry. *)
+(** Use the leaf surface-name SSOT instead of Config.raw_all_tool_schemas.
+    Tool_registry sits below keeper/OAS dispatch, and depending on Config
+    creates Config -> keeper -> Tool_registry -> Config cycles.  Surface names
+    still include hidden/internal tools without importing the full schema graph. *)
 module StringSet = Set.Make (String)
 
 let known_tool_names : StringSet.t Eio.Lazy.t =
   Eio.Lazy.from_fun ~cancel:`Protect (fun () ->
     List.fold_left
-      (fun set (schema : Masc_domain.tool_schema) -> StringSet.add schema.name set)
-      StringSet.empty Config.raw_all_tool_schemas)
+      (fun set surface ->
+        List.fold_left
+          (fun set name -> StringSet.add name set)
+          set
+          (Tool_catalog_surfaces.tools_for_surface surface))
+      StringSet.empty Tool_catalog_surfaces.all_surfaces)
 
 let is_known_tool tool_name =
   StringSet.mem tool_name (Eio.Lazy.force known_tool_names)

--- a/lib/tool_registry.ml
+++ b/lib/tool_registry.ml
@@ -40,20 +40,21 @@ let string_of_source = function
   | Keeper_internal -> "keeper_internal"
   | Inline_dispatch -> "inline_dispatch"
   | Deprecated_alias -> "deprecated_alias"
+;;
 
 (** Per-tool call statistics *)
-type call_stats = {
-  call_count : int Atomic.t;
-  success_count : int Atomic.t;
-  failure_count : int Atomic.t;
-  last_called_at : float Atomic.t;  (** Unix timestamp, 0.0 = never *)
-  total_duration_ms : int Atomic.t;
-  external_mcp_count : int Atomic.t;
-  keeper_internal_count : int Atomic.t;
-  inline_dispatch_count : int Atomic.t;
-  deprecated_alias_count : int Atomic.t;
-  last_assignment_id : string option Atomic.t;
-}
+type call_stats =
+  { call_count : int Atomic.t
+  ; success_count : int Atomic.t
+  ; failure_count : int Atomic.t
+  ; last_called_at : float Atomic.t (** Unix timestamp, 0.0 = never *)
+  ; total_duration_ms : int Atomic.t
+  ; external_mcp_count : int Atomic.t
+  ; keeper_internal_count : int Atomic.t
+  ; inline_dispatch_count : int Atomic.t
+  ; deprecated_alias_count : int Atomic.t
+  ; last_assignment_id : string option Atomic.t
+  }
 
 (** Global registry — process-lifetime. Protected by [registry_mu] against
     concurrent access from tool dispatch (write path via [record_call]) and
@@ -70,24 +71,26 @@ let registry : (string, call_stats) Hashtbl.t = Hashtbl.create 128
 let registry_mu = Eio.Mutex.create ()
 let with_registry_rw f = Eio_guard.with_mutex registry_mu f
 let with_registry_ro f = Eio_guard.with_mutex_ro registry_mu f
+
+module StringSet = Set.Make (String)
+
 (** Use the leaf surface-name SSOT instead of Config.raw_all_tool_schemas.
     Tool_registry sits below keeper/OAS dispatch, and depending on Config
     creates Config -> keeper -> Tool_registry -> Config cycles.  Surface names
     still include hidden/internal tools without importing the full schema graph. *)
-module StringSet = Set.Make (String)
-
 let known_tool_names : StringSet.t Eio.Lazy.t =
   Eio.Lazy.from_fun ~cancel:`Protect (fun () ->
     List.fold_left
       (fun set surface ->
-        List.fold_left
-          (fun set name -> StringSet.add name set)
-          set
-          (Tool_catalog_surfaces.tools_for_surface surface))
-      StringSet.empty Tool_catalog_surfaces.all_surfaces)
+         List.fold_left
+           (fun set name -> StringSet.add name set)
+           set
+           (Tool_catalog_surfaces.tools_for_surface surface))
+      StringSet.empty
+      Tool_catalog_surfaces.all_surfaces)
+;;
 
-let is_known_tool tool_name =
-  StringSet.mem tool_name (Eio.Lazy.force known_tool_names)
+let is_known_tool tool_name = StringSet.mem tool_name (Eio.Lazy.force known_tool_names)
 
 (** Record a tool call with source attribution.
 
@@ -100,26 +103,35 @@ let get_or_create_stats tool_name =
   match with_registry_ro (fun () -> Hashtbl.find_opt registry tool_name) with
   | Some s -> s
   | None ->
-      with_registry_rw (fun () ->
-        match Hashtbl.find_opt registry tool_name with
-        | Some s -> s
-        | None ->
-            let s = {
-              call_count = Atomic.make 0;
-              success_count = Atomic.make 0;
-              failure_count = Atomic.make 0;
-              last_called_at = Atomic.make 0.0;
-              total_duration_ms = Atomic.make 0;
-              external_mcp_count = Atomic.make 0;
-              keeper_internal_count = Atomic.make 0;
-              inline_dispatch_count = Atomic.make 0;
-              deprecated_alias_count = Atomic.make 0;
-              last_assignment_id = Atomic.make None;
-            } in
-            Hashtbl.replace registry tool_name s;
-            s)
+    with_registry_rw (fun () ->
+      match Hashtbl.find_opt registry tool_name with
+      | Some s -> s
+      | None ->
+        let s =
+          { call_count = Atomic.make 0
+          ; success_count = Atomic.make 0
+          ; failure_count = Atomic.make 0
+          ; last_called_at = Atomic.make 0.0
+          ; total_duration_ms = Atomic.make 0
+          ; external_mcp_count = Atomic.make 0
+          ; keeper_internal_count = Atomic.make 0
+          ; inline_dispatch_count = Atomic.make 0
+          ; deprecated_alias_count = Atomic.make 0
+          ; last_assignment_id = Atomic.make None
+          }
+        in
+        Hashtbl.replace registry tool_name s;
+        s)
+;;
 
-let record_call ?(source = External_mcp) ?assignment_id ~tool_name ~success ~duration_ms () =
+let record_call
+      ?(source = External_mcp)
+      ?assignment_id
+      ~tool_name
+      ~success
+      ~duration_ms
+      ()
+  =
   let stats = get_or_create_stats tool_name in
   Atomic.incr stats.call_count;
   (match source with
@@ -127,19 +139,25 @@ let record_call ?(source = External_mcp) ?assignment_id ~tool_name ~success ~dur
    | Keeper_internal -> Atomic.incr stats.keeper_internal_count
    | Inline_dispatch -> Atomic.incr stats.inline_dispatch_count
    | Deprecated_alias -> Atomic.incr stats.deprecated_alias_count);
-  if success then
-    Atomic.incr stats.success_count
-  else
-    Atomic.incr stats.failure_count;
+  if success then Atomic.incr stats.success_count else Atomic.incr stats.failure_count;
   Atomic.set stats.last_called_at (Time_compat.now ());
   ignore (Atomic.fetch_and_add stats.total_duration_ms duration_ms);
-  (match assignment_id with
-   | Some _ as aid -> Atomic.set stats.last_assignment_id aid
-   | None -> ())
+  match assignment_id with
+  | Some _ as aid -> Atomic.set stats.last_assignment_id aid
+  | None -> ()
+;;
 
-let record_call_if_known ?(source = External_mcp) ?assignment_id ~tool_name ~success ~duration_ms () =
-  if is_known_tool tool_name then
-    record_call ~source ?assignment_id ~tool_name ~success ~duration_ms ()
+let record_call_if_known
+      ?(source = External_mcp)
+      ?assignment_id
+      ~tool_name
+      ~success
+      ~duration_ms
+      ()
+  =
+  if is_known_tool tool_name
+  then record_call ~source ?assignment_id ~tool_name ~success ~duration_ms ()
+;;
 
 (** Get all stats as a sorted list (by call_count descending).
 
@@ -153,7 +171,9 @@ let record_call_if_known ?(source = External_mcp) ?assignment_id ~tool_name ~suc
 let get_stats () : (string * call_stats) list =
   with_registry_ro (fun () ->
     Hashtbl.fold (fun name stats acc -> (name, stats) :: acc) registry [])
-  |> List.sort (fun (_, a) (_, b) -> compare (Atomic.get b.call_count) (Atomic.get a.call_count))
+  |> List.sort (fun (_, a) (_, b) ->
+    compare (Atomic.get b.call_count) (Atomic.get a.call_count))
+;;
 
 (** Get top N tools by call count *)
 let get_top_n n : (string * call_stats) list =
@@ -164,6 +184,7 @@ let get_top_n n : (string * call_stats) list =
     | x :: xs -> take (x :: acc) (n - 1) xs
   in
   take [] n all
+;;
 
 (** Get tool names not called since the given Unix timestamp.
     Only includes tools that are registered (have been called at least once)
@@ -172,52 +193,55 @@ let get_unused_since (cutoff : float) : string list =
   with_registry_ro (fun () ->
     Hashtbl.fold
       (fun name stats acc ->
-        if Stdlib.Float.compare (Atomic.get stats.last_called_at) cutoff < 0 then name :: acc else acc)
-      registry [])
+         if Stdlib.Float.compare (Atomic.get stats.last_called_at) cutoff < 0
+         then name :: acc
+         else acc)
+      registry
+      [])
   |> List.sort String.compare
+;;
 
 (** Get tools that have never been called (not in registry at all)
     compared against a list of all known tool names *)
 let get_never_called (all_tool_names : string list) : string list =
   with_registry_ro (fun () ->
-    List.filter
-      (fun name -> not (Hashtbl.mem registry name))
-      all_tool_names)
+    List.filter (fun name -> not (Hashtbl.mem registry name)) all_tool_names)
   |> List.sort String.compare
+;;
 
 (** Total calls across all tools *)
 let total_calls () : int =
   with_registry_ro (fun () ->
     Hashtbl.fold (fun _ stats acc -> acc + Atomic.get stats.call_count) registry 0)
+;;
 
 (** Number of distinct tools that have been called *)
-let distinct_tools_called () : int =
-  with_registry_ro (fun () -> Hashtbl.length registry)
+let distinct_tools_called () : int = with_registry_ro (fun () -> Hashtbl.length registry)
 
 (** Convert call_stats to JSON *)
 let stats_to_json (name, (stats : call_stats)) : Yojson.Safe.t =
   let calls = Atomic.get stats.call_count in
-  `Assoc [
-    ("name", `String name);
-    ("call_count", `Int calls);
-    ("success_count", `Int (Atomic.get stats.success_count));
-    ("failure_count", `Int (Atomic.get stats.failure_count));
-    ("avg_duration_ms",
-     `Int (if calls > 0
-           then (Atomic.get stats.total_duration_ms) / calls
-           else 0));
-    ("last_called_at", `Float (Atomic.get stats.last_called_at));
-    ("last_assignment_id",
-     match Atomic.get stats.last_assignment_id with
-     | Some aid -> `String aid
-     | None -> `Null);
-    ("by_source", `Assoc [
-       ("external_mcp", `Int (Atomic.get stats.external_mcp_count));
-       ("keeper_internal", `Int (Atomic.get stats.keeper_internal_count));
-       ("inline_dispatch", `Int (Atomic.get stats.inline_dispatch_count));
-       ("deprecated_alias", `Int (Atomic.get stats.deprecated_alias_count));
-     ]);
-  ]
+  `Assoc
+    [ "name", `String name
+    ; "call_count", `Int calls
+    ; "success_count", `Int (Atomic.get stats.success_count)
+    ; "failure_count", `Int (Atomic.get stats.failure_count)
+    ; ( "avg_duration_ms"
+      , `Int (if calls > 0 then Atomic.get stats.total_duration_ms / calls else 0) )
+    ; "last_called_at", `Float (Atomic.get stats.last_called_at)
+    ; ( "last_assignment_id"
+      , match Atomic.get stats.last_assignment_id with
+        | Some aid -> `String aid
+        | None -> `Null )
+    ; ( "by_source"
+      , `Assoc
+          [ "external_mcp", `Int (Atomic.get stats.external_mcp_count)
+          ; "keeper_internal", `Int (Atomic.get stats.keeper_internal_count)
+          ; "inline_dispatch", `Int (Atomic.get stats.inline_dispatch_count)
+          ; "deprecated_alias", `Int (Atomic.get stats.deprecated_alias_count)
+          ] )
+    ]
+;;
 
 (** Generate a full stats report as JSON *)
 let stats_report ~top_n ~all_tool_names : Yojson.Safe.t =
@@ -226,18 +250,19 @@ let stats_report ~top_n ~all_tool_names : Yojson.Safe.t =
   let cutoff_30d = Time_compat.now () -. Masc_time_constants.days_to_seconds 30 in
   let unused_30d = get_unused_since cutoff_30d in
   let never_called = get_never_called all_tool_names in
-  `Assoc [
-    ("total_calls", `Int (total_calls ()));
-    ("distinct_tools_called", `Int (distinct_tools_called ()));
-    ("total_tools_available", `Int (List.length all_tool_names));
-    ("top_n_requested", `Int bounded_top_n);
-    ("top_tools", `List (List.map stats_to_json top_tools));
-    ("top_20", `List (List.map stats_to_json top_tools));
-    ("unused_30d", `List (List.map (fun s -> `String s) unused_30d));
-    ("unused_30d_count", `Int (List.length unused_30d));
-    ("never_called", `List (List.map (fun s -> `String s) never_called));
-    ("never_called_count", `Int (List.length never_called));
-  ]
+  `Assoc
+    [ "total_calls", `Int (total_calls ())
+    ; "distinct_tools_called", `Int (distinct_tools_called ())
+    ; "total_tools_available", `Int (List.length all_tool_names)
+    ; "top_n_requested", `Int bounded_top_n
+    ; "top_tools", `List (List.map stats_to_json top_tools)
+    ; "top_20", `List (List.map stats_to_json top_tools)
+    ; "unused_30d", `List (List.map (fun s -> `String s) unused_30d)
+    ; "unused_30d_count", `Int (List.length unused_30d)
+    ; "never_called", `List (List.map (fun s -> `String s) never_called)
+    ; "never_called_count", `Int (List.length never_called)
+    ]
+;;
 
 (** Warm up registry from telemetry summary.
     Called once at server startup to restore persistent metrics.
@@ -250,26 +275,30 @@ let warm_up (summary : Telemetry_eio.tool_usage_summary) : int =
   with_registry_rw (fun () ->
     Hashtbl.iter
       (fun tool_name (stats : Telemetry_eio.tool_usage_stats) ->
-        if not (Hashtbl.mem registry tool_name) then (
-          Hashtbl.replace registry tool_name
-            {
-              call_count = Atomic.make stats.count;
-              success_count = Atomic.make stats.success_count;
-              failure_count = Atomic.make stats.failure_count;
-              last_called_at =
-                Atomic.make (match stats.last_used_at with
-                | Some t -> t
-                | None -> 0.0);
-              total_duration_ms = Atomic.make 0;
-              external_mcp_count = Atomic.make 0;
-              keeper_internal_count = Atomic.make 0;
-              inline_dispatch_count = Atomic.make 0;
-              deprecated_alias_count = Atomic.make 0;
-              last_assignment_id = Atomic.make None;
-            };
-          Stdlib.incr count))
+         if not (Hashtbl.mem registry tool_name)
+         then (
+           Hashtbl.replace
+             registry
+             tool_name
+             { call_count = Atomic.make stats.count
+             ; success_count = Atomic.make stats.success_count
+             ; failure_count = Atomic.make stats.failure_count
+             ; last_called_at =
+                 Atomic.make
+                   (match stats.last_used_at with
+                    | Some t -> t
+                    | None -> 0.0)
+             ; total_duration_ms = Atomic.make 0
+             ; external_mcp_count = Atomic.make 0
+             ; keeper_internal_count = Atomic.make 0
+             ; inline_dispatch_count = Atomic.make 0
+             ; deprecated_alias_count = Atomic.make 0
+             ; last_assignment_id = Atomic.make None
+             };
+           Stdlib.incr count))
       summary.stats_by_tool);
   !count
+;;
 
 (** Reset all counters (for testing) *)
 let reset () = with_registry_rw (fun () -> Hashtbl.clear registry)

--- a/test/test_keeper_task_dispatch.ml
+++ b/test/test_keeper_task_dispatch.ml
@@ -1320,30 +1320,18 @@ let test_tool_search_whitespace_query_returns_error () =
     | `String _ -> () (* expected *)
     | _ -> fail "expected error field for whitespace-only query")
 
-let test_tool_search_returns_results_list () =
+let test_tool_search_without_search_fn_returns_error () =
   with_room (fun config ->
     let meta = make_test_meta () in
-    (* With no custom search_fn, the global default must still be truthful:
-       search the static keeper schema universe instead of claiming no tools
-       match. Normal keeper turns pass a richer session-scoped BM25 search_fn. *)
+
     let result = call_tool config meta "keeper_tool_search"
       (`Assoc [ ("query", `String "filesystem read file") ]) in
     let json = parse_json result in
-    match Yojson.Safe.Util.member "results" json with
-    | `List results ->
-      check bool "default search returns static fallback hits" true
-        (List.length results > 0);
-      let names =
-        List.filter_map
-          (fun hit ->
-             match Yojson.Safe.Util.member "name" hit with
-             | `String name -> Some name
-             | _ -> None)
-          results
-      in
-      check bool "keeper_fs_read discoverable by default" true
-        (List.mem "keeper_fs_read" names)
-    | _ -> fail "expected results list in response")
+    match Yojson.Safe.Util.member "error" json with
+    | `String msg ->
+      check bool "error mentions missing search wiring" true
+        (String_util.contains_substring msg "not configured")
+    | _ -> fail "expected error field for missing search_fn")
 
 let test_tool_search_max_results_clamped_to_10 () =
   with_room (fun config ->
@@ -1481,7 +1469,8 @@ let () =
     "keeper_tool_search", [
       test_case "empty query returns error" `Quick test_tool_search_empty_query_returns_error;
       test_case "whitespace query returns error" `Quick test_tool_search_whitespace_query_returns_error;
-      test_case "non-empty query returns results list" `Quick test_tool_search_returns_results_list;
+      test_case "non-empty query requires search_fn" `Quick
+        test_tool_search_without_search_fn_returns_error;
       test_case "max_results clamped to 10" `Quick test_tool_search_max_results_clamped_to_10;
       test_case "max_results minimum is 1" `Quick test_tool_search_max_results_minimum_1;
       test_case "uses provided search_fn" `Quick test_tool_search_uses_provided_search_fn;

--- a/test/test_keeper_task_dispatch.ml
+++ b/test/test_keeper_task_dispatch.ml
@@ -6,28 +6,35 @@ open Alcotest
 open Masc_mcp
 
 let make_test_meta ?(name = "test-keeper") () : Keeper_types.keeper_meta =
-  match Masc_test_deps.meta_of_json_fixture
-    (`Assoc [("name", `String name); ("agent_name", `String name);
-             ("trace_id", `String "test-trace-task")]) with
+  match
+    Masc_test_deps.meta_of_json_fixture
+      (`Assoc
+          [ "name", `String name
+          ; "agent_name", `String name
+          ; "trace_id", `String "test-trace-task"
+          ])
+  with
   | Ok meta -> meta
   | Error e -> failwith (Printf.sprintf "make_test_meta failed: %s" e)
+;;
 
 let make_goal_scoped_meta goal_ids =
   { (make_test_meta ()) with active_goal_ids = goal_ids }
+;;
 
 let make_meta_with_tools tools =
   { (make_test_meta ()) with tool_access = Keeper_types.Custom tools }
+;;
 
-let make_ctx_work () =
-  Keeper_exec_context.create ~system_prompt:"test" ~max_tokens:4000
-
+let make_ctx_work () = Keeper_exec_context.create ~system_prompt:"test" ~max_tokens:4000
 let rng_initialized = ref false
 
 let ensure_rng () =
-  if not !rng_initialized then begin
+  if not !rng_initialized
+  then (
     Mirage_crypto_rng_unix.use_default ();
-    rng_initialized := true
-  end
+    rng_initialized := true)
+;;
 
 let with_env name value f =
   let previous = Sys.getenv_opt name in
@@ -40,13 +47,14 @@ let with_env name value f =
       | Some v -> Unix.putenv name v
       | None -> Unix.putenv name "")
     f
+;;
 
 let only_task config =
   match Coord.get_tasks_raw config with
   | [ task ] -> task
   | tasks ->
-    failwith
-      (Printf.sprintf "expected exactly one task, got %d" (List.length tasks))
+    failwith (Printf.sprintf "expected exactly one task, got %d" (List.length tasks))
+;;
 
 let task_by_title config title =
   Coord.get_tasks_raw config
@@ -54,6 +62,7 @@ let task_by_title config title =
   |> function
   | Some task -> task
   | None -> failwith (Printf.sprintf "task not found: %s" title)
+;;
 
 let set_task_created_at_by_title config ~title ~created_at =
   let backlog = Coord.read_backlog config in
@@ -70,48 +79,40 @@ let set_task_created_at_by_title config ~title ~created_at =
   in
   if not !seen then failwith (Printf.sprintf "task not found: %s" title);
   Coord.write_backlog config { backlog with tasks; version = backlog.version + 1 }
+;;
 
 let transition_task_exn ?notes config ~agent_name ~task_id ~action () =
-  match
-    Coord.transition_task_r config ~agent_name ~task_id ~action ?notes ()
-  with
+  match Coord.transition_task_r config ~agent_name ~task_id ~action ?notes () with
   | Ok _ -> ()
   | Error err ->
-      fail
-        (Printf.sprintf "transition %s failed: %s" task_id
-           (Masc_domain.masc_error_to_string err))
+    fail
+      (Printf.sprintf
+         "transition %s failed: %s"
+         task_id
+         (Masc_domain.masc_error_to_string err))
+;;
 
 let strict_contract ?(verify_gate_evidence = []) () : Masc_domain.task_contract =
-  {
-    strict = true;
-    completion_contract = [ "tests pass" ];
-    required_tools = [];
-    required_evidence = [];
-    inspect_gate_evidence = [];
-    verify_gate_evidence;
-    links =
-      {
-        operation_id = None;
-        session_id = None;
-        autoresearch_loop_id = None;
-      };
+  { strict = true
+  ; completion_contract = [ "tests pass" ]
+  ; required_tools = []
+  ; required_evidence = []
+  ; inspect_gate_evidence = []
+  ; verify_gate_evidence
+  ; links = { operation_id = None; session_id = None; autoresearch_loop_id = None }
   }
+;;
 
 let contract_requiring_tools required_tools : Masc_domain.task_contract =
-  {
-    strict = false;
-    completion_contract = [];
-    required_tools;
-    required_evidence = [];
-    inspect_gate_evidence = [];
-    verify_gate_evidence = [];
-    links =
-      {
-        operation_id = None;
-        session_id = None;
-        autoresearch_loop_id = None;
-      };
+  { strict = false
+  ; completion_contract = []
+  ; required_tools
+  ; required_evidence = []
+  ; inspect_gate_evidence = []
+  ; verify_gate_evidence = []
+  ; links = { operation_id = None; session_id = None; autoresearch_loop_id = None }
   }
+;;
 
 let create_pending_verification_request config ~task_id =
   match
@@ -126,15 +127,21 @@ let create_pending_verification_request config ~task_id =
   with
   | Ok _ -> ()
   | Error msg -> failwith (Printf.sprintf "create_request failed: %s" msg)
+;;
 
 (* Temp directory setup following test_keeper_tools_oas.ml pattern.
    Force filesystem backend by unsetting PG env vars. *)
 let with_room f =
-  Eio_main.run @@ fun env ->
+  Eio_main.run
+  @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
-  let dir = Filename.concat (Filename.get_temp_dir_name ())
-    (Printf.sprintf "test_keeper_task_%d" (Random.int 1_000_000)) in
-  (try Unix.mkdir dir 0o755 with Unix.Unix_error (Unix.EEXIST, _, _) -> ());
+  let dir =
+    Filename.concat
+      (Filename.get_temp_dir_name ())
+      (Printf.sprintf "test_keeper_task_%d" (Random.int 1_000_000))
+  in
+  (try Unix.mkdir dir 0o755 with
+   | Unix.Unix_error (Unix.EEXIST, _, _) -> ());
   (* Save and unset PG env vars to force filesystem backend *)
   let saved_pg = Sys.getenv_opt "MASC_POSTGRES_URL" in
   let saved_sb = Sys.getenv_opt "SB_PG_URL" in
@@ -144,53 +151,78 @@ let with_room f =
     ~finally:(fun () ->
       (match saved_pg with
        | Some v -> Unix.putenv "MASC_POSTGRES_URL" v
-       | None -> (try Unix.putenv "MASC_POSTGRES_URL" "" with _ -> ()));
+       | None ->
+         (try Unix.putenv "MASC_POSTGRES_URL" "" with
+          | _ -> ()));
       (match saved_sb with
        | Some v -> Unix.putenv "SB_PG_URL" v
-       | None -> (try Unix.putenv "SB_PG_URL" "" with _ -> ()));
-      (try
+       | None ->
+         (try Unix.putenv "SB_PG_URL" "" with
+          | _ -> ()));
+      try
         let rec rm path =
-          if Sys.is_directory path then begin
-            Sys.readdir path |> Array.iter (fun f ->
-              rm (Filename.concat path f));
-            Unix.rmdir path
-          end else
-            Sys.remove path
+          if Sys.is_directory path
+          then (
+            Sys.readdir path |> Array.iter (fun f -> rm (Filename.concat path f));
+            Unix.rmdir path)
+          else Sys.remove path
         in
         rm dir
-      with _ -> ()))
+      with
+      | _ -> ())
     (fun () ->
-      let config = Coord.default_config dir in
-      let _msg = Coord.init config ~agent_name:(Some "test-keeper") in
-      f config)
+       let config = Coord.default_config dir in
+       let _msg = Coord.init config ~agent_name:(Some "test-keeper") in
+       f config)
+;;
 
 let call_tool config meta name input =
   let ctx_work = make_ctx_work () in
   Keeper_exec_tools.execute_keeper_tool_call
-    ~config ~meta ~ctx_work ~exec_cache:None ~name ~input ()
+    ~config
+    ~meta
+    ~ctx_work
+    ~exec_cache:None
+    ~name
+    ~input
+    ()
+;;
 
 let call_tool_with_search config meta name input search_fn =
   let ctx_work = make_ctx_work () in
   Keeper_exec_tools.execute_keeper_tool_call
-    ~config ~meta ~ctx_work ~exec_cache:None ~search_fn ~name ~input ()
+    ~config
+    ~meta
+    ~ctx_work
+    ~exec_cache:None
+    ~search_fn
+    ~name
+    ~input
+    ()
+;;
 
 let parse_json s =
-  try Yojson.Safe.from_string s
-  with _ -> failwith (Printf.sprintf "invalid JSON: %s" s)
+  try Yojson.Safe.from_string s with
+  | _ -> failwith (Printf.sprintf "invalid JSON: %s" s)
+;;
 
 let json_is_null = function
   | `Null -> true
   | _ -> false
+;;
 
 let contains_substring s needle =
   let s_len = String.length s in
   let n_len = String.length needle in
   let rec loop i =
-    if i + n_len > s_len then false
-    else if String.sub s i n_len = needle then true
+    if i + n_len > s_len
+    then false
+    else if String.sub s i n_len = needle
+    then true
     else loop (i + 1)
   in
   if n_len = 0 then true else loop 0
+;;
 
 let check_effective_goal_ids label scope expected =
   let actual =
@@ -198,30 +230,44 @@ let check_effective_goal_ids label scope expected =
       scope |> member "effective_goal_ids" |> to_list |> List.map to_string)
   in
   check (list string) label expected actual
+;;
 
 let claimed_task_for_agent config agent_name =
   Coord.get_tasks_raw config
   |> List.find_opt (fun (task : Masc_domain.task) ->
-       Masc_domain.task_assignee_of_status task.task_status = Some agent_name)
+    Masc_domain.task_assignee_of_status task.task_status = Some agent_name)
+;;
 
 let check_no_task_claimed config meta =
   match claimed_task_for_agent config meta.Keeper_types.agent_name with
   | None -> ()
   | Some task ->
-      fail
-        (Printf.sprintf
-           "expected no claimed task for scoped keeper, got %s (%s)"
-           task.id task.title)
+    fail
+      (Printf.sprintf
+         "expected no claimed task for scoped keeper, got %s (%s)"
+         task.id
+         task.title)
+;;
 
 let check_active_goal_scope_no_fallback json ~goal_id =
   let scope = Yojson.Safe.Util.member "claim_scope" json in
-  check string "claim scope mode" "active_goal_ids"
+  check
+    string
+    "claim scope mode"
+    "active_goal_ids"
     Yojson.Safe.Util.(scope |> member "mode" |> to_string);
-  check (list string) "effective goal ids preserved" [ goal_id ]
+  check
+    (list string)
+    "effective goal ids preserved"
+    [ goal_id ]
     Yojson.Safe.Util.(
       scope |> member "effective_goal_ids" |> to_list |> List.map to_string);
-  check (option string) "fallback reason absent" None
+  check
+    (option string)
+    "fallback reason absent"
+    None
     Yojson.Safe.Util.(scope |> member "fallback_reason" |> to_string_option)
+;;
 
 let with_registered_keeper config meta f =
   Keeper_registry.unregister ~base_path:config.Coord.base_path meta.Keeper_types.name;
@@ -234,9 +280,11 @@ let with_registered_keeper config meta f =
     ~finally:(fun () ->
       Keeper_registry.unregister ~base_path:config.Coord.base_path meta.Keeper_types.name)
     f
+;;
 
 let current_task_id_string (meta : Keeper_types.keeper_meta) =
   Option.map Keeper_id.Task_id.to_string meta.current_task_id
+;;
 
 let with_claim_post_provision_hook hook f =
   let previous = Atomic.get Coord_hooks.claim_post_provision_fn in
@@ -244,18 +292,21 @@ let with_claim_post_provision_hook hook f =
   Fun.protect
     ~finally:(fun () -> Atomic.set Coord_hooks.claim_post_provision_fn previous)
     f
+;;
 
 let stale_worktree_info ~agent_name ~task_id : Masc_domain.worktree_info =
-  {
-    branch = Printf.sprintf "%s/%s" agent_name task_id;
-    path = Printf.sprintf ".worktrees/%s-%s" agent_name task_id;
-    git_root = "/tmp/stale-sandbox/repos/masc-mcp";
-    repo_name = "masc-mcp";
+  { branch = Printf.sprintf "%s/%s" agent_name task_id
+  ; path = Printf.sprintf ".worktrees/%s-%s" agent_name task_id
+  ; git_root = "/tmp/stale-sandbox/repos/masc-mcp"
+  ; repo_name = "masc-mcp"
   }
+;;
 
 let link_stale_worktree config ~agent_name ~task_id =
   match
-    Coord_worktree.link_worktree_to_task config ~task_id
+    Coord_worktree.link_worktree_to_task
+      config
+      ~task_id
       ~worktree_info:(stale_worktree_info ~agent_name ~task_id)
   with
   | Ok () -> ()
@@ -264,6 +315,7 @@ let link_stale_worktree config ~agent_name ~task_id =
       (Printf.sprintf
          "failed to link stale worktree: %s"
          (Masc_domain.masc_error_to_string e))
+;;
 
 (* --- keeper_task_claim tests --- *)
 
@@ -274,9 +326,9 @@ let test_claim_returns_result () =
     let result = call_tool config meta "keeper_task_claim" (`Assoc []) in
     let json = parse_json result in
     match Yojson.Safe.Util.member "result" json with
-    | `String s ->
-      check bool "claim result non-empty" true (String.length s > 0)
+    | `String s -> check bool "claim result non-empty" true (String.length s > 0)
     | _ -> fail "expected result string in claim response")
+;;
 
 let test_claim_returns_observation_fragment () =
   with_room (fun config ->
@@ -286,17 +338,33 @@ let test_claim_returns_observation_fragment () =
     in
     let result = call_tool config meta "keeper_task_claim" (`Assoc []) in
     let json = parse_json result in
-    check string "event type" "collaboration.todo.claim_observed"
+    check
+      string
+      "event type"
+      "collaboration.todo.claim_observed"
       Yojson.Safe.Util.(
         json |> member "claim_observation" |> member "event_type" |> to_string);
-    check string "state" "claim_verified"
+    check
+      string
+      "state"
+      "claim_verified"
       Yojson.Safe.Util.(
-        json |> member "claim_observation" |> member "todo_claim" |> member "state"
+        json
+        |> member "claim_observation"
+        |> member "todo_claim"
+        |> member "state"
         |> to_string);
-    check string "winner" meta.agent_name
+    check
+      string
+      "winner"
+      meta.agent_name
       Yojson.Safe.Util.(
-        json |> member "claim_observation" |> member "todo_claim"
-        |> member "winner_actor_id" |> to_string))
+        json
+        |> member "claim_observation"
+        |> member "todo_claim"
+        |> member "winner_actor_id"
+        |> to_string))
+;;
 
 let test_claim_syncs_keeper_current_task_id () =
   with_room (fun config ->
@@ -308,15 +376,17 @@ let test_claim_syncs_keeper_current_task_id () =
       let result = call_tool config meta "keeper_task_claim" (`Assoc []) in
       let json = parse_json result in
       let task_id =
-        Yojson.Safe.Util.(
-          json |> member "claimed_task" |> member "task_id" |> to_string)
+        Yojson.Safe.Util.(json |> member "claimed_task" |> member "task_id" |> to_string)
       in
       let registry_meta =
         match Keeper_registry.get ~base_path:config.Coord.base_path meta.name with
         | Some entry -> entry.meta
         | None -> fail "expected keeper registry entry"
       in
-      check (option string) "registry current_task_id" (Some task_id)
+      check
+        (option string)
+        "registry current_task_id"
+        (Some task_id)
         (current_task_id_string registry_meta);
       let persisted_meta =
         match Keeper_types.read_meta config meta.name with
@@ -324,32 +394,33 @@ let test_claim_syncs_keeper_current_task_id () =
         | Ok None -> fail "expected persisted keeper meta"
         | Error msg -> fail msg
       in
-      check (option string) "persisted current_task_id" (Some task_id)
+      check
+        (option string)
+        "persisted current_task_id"
+        (Some task_id)
         (current_task_id_string persisted_meta)))
+;;
 
 let test_release_clears_keeper_current_task_id () =
   with_room (fun config ->
     let meta = make_test_meta () in
     with_registered_keeper config meta (fun () ->
       let _ =
-        Coord.add_task config ~title:"Release task" ~priority:1
-          ~description:"desc"
+        Coord.add_task config ~title:"Release task" ~priority:1 ~description:"desc"
       in
       let result = call_tool config meta "keeper_task_claim" (`Assoc []) in
       let json = parse_json result in
       let task_id =
-        Yojson.Safe.Util.(
-          json |> member "claimed_task" |> member "task_id" |> to_string)
+        Yojson.Safe.Util.(json |> member "claimed_task" |> member "task_id" |> to_string)
       in
       let ok, message =
         Tool_task.handle_transition
           { Tool_task.config; agent_name = meta.agent_name; sw = None }
           (`Assoc
-             [
-               ("task_id", `String task_id);
-               ("action", `String "release");
-               ("reason", `String "scope changed");
-             ])
+              [ "task_id", `String task_id
+              ; "action", `String "release"
+              ; "reason", `String "scope changed"
+              ])
       in
       if not ok then fail message;
       let registry_meta =
@@ -357,7 +428,10 @@ let test_release_clears_keeper_current_task_id () =
         | Some entry -> entry.meta
         | None -> fail "expected keeper registry entry"
       in
-      check (option string) "registry current_task_id cleared" None
+      check
+        (option string)
+        "registry current_task_id cleared"
+        None
         (current_task_id_string registry_meta);
       let persisted_meta =
         match Keeper_types.read_meta config meta.name with
@@ -365,79 +439,108 @@ let test_release_clears_keeper_current_task_id () =
         | Ok None -> fail "expected persisted keeper meta"
         | Error msg -> fail msg
       in
-      check (option string) "persisted current_task_id cleared" None
+      check
+        (option string)
+        "persisted current_task_id cleared"
+        None
         (current_task_id_string persisted_meta)))
+;;
 
 let test_claim_clears_stale_task_worktree_metadata () =
   with_claim_post_provision_hook
     (fun _config ~agent_name:_ ~task_id:_ -> ())
     (fun () ->
-      with_room (fun config ->
-        let meta = make_test_meta () in
-        with_registered_keeper config meta (fun () ->
-          let _ =
-            Coord.add_task config ~title:"Stale worktree claim" ~priority:1
-              ~description:"desc"
-          in
-          let task_id = (only_task config).id in
-          link_stale_worktree config ~agent_name:"previous-agent" ~task_id;
-          check bool "stale worktree linked" true
-            (Option.is_some (only_task config).worktree);
-          let _ = call_tool config meta "keeper_task_claim" (`Assoc []) in
-          check bool "stale worktree cleared on claim" true
-            (Option.is_none (only_task config).worktree))))
+       with_room (fun config ->
+         let meta = make_test_meta () in
+         with_registered_keeper config meta (fun () ->
+           let _ =
+             Coord.add_task
+               config
+               ~title:"Stale worktree claim"
+               ~priority:1
+               ~description:"desc"
+           in
+           let task_id = (only_task config).id in
+           link_stale_worktree config ~agent_name:"previous-agent" ~task_id;
+           check
+             bool
+             "stale worktree linked"
+             true
+             (Option.is_some (only_task config).worktree);
+           let _ = call_tool config meta "keeper_task_claim" (`Assoc []) in
+           check
+             bool
+             "stale worktree cleared on claim"
+             true
+             (Option.is_none (only_task config).worktree))))
+;;
 
 let test_release_clears_task_worktree_metadata () =
   with_claim_post_provision_hook
     (fun _config ~agent_name:_ ~task_id:_ -> ())
     (fun () ->
-      with_room (fun config ->
-        let meta = make_test_meta () in
-        with_registered_keeper config meta (fun () ->
-          let _ =
-            Coord.add_task config ~title:"Worktree release task" ~priority:1
-              ~description:"desc"
-          in
-          let result = call_tool config meta "keeper_task_claim" (`Assoc []) in
-          let json = parse_json result in
-          let task_id =
-            Yojson.Safe.Util.(
-              json |> member "claimed_task" |> member "task_id" |> to_string)
-          in
-          link_stale_worktree config ~agent_name:meta.agent_name ~task_id;
-          check bool "worktree linked before release" true
-            (Option.is_some (only_task config).worktree);
-          let ok, message =
-            Tool_task.handle_transition
-              { Tool_task.config; agent_name = meta.agent_name; sw = None }
-              (`Assoc
-                 [
-                   ("task_id", `String task_id);
-                   ("action", `String "release");
-                   ("reason", `String "handoff to another keeper");
-                 ])
-          in
-          if not ok then fail message;
-          check bool "worktree cleared on release" true
-            (Option.is_none (only_task config).worktree))))
+       with_room (fun config ->
+         let meta = make_test_meta () in
+         with_registered_keeper config meta (fun () ->
+           let _ =
+             Coord.add_task
+               config
+               ~title:"Worktree release task"
+               ~priority:1
+               ~description:"desc"
+           in
+           let result = call_tool config meta "keeper_task_claim" (`Assoc []) in
+           let json = parse_json result in
+           let task_id =
+             Yojson.Safe.Util.(
+               json |> member "claimed_task" |> member "task_id" |> to_string)
+           in
+           link_stale_worktree config ~agent_name:meta.agent_name ~task_id;
+           check
+             bool
+             "worktree linked before release"
+             true
+             (Option.is_some (only_task config).worktree);
+           let ok, message =
+             Tool_task.handle_transition
+               { Tool_task.config; agent_name = meta.agent_name; sw = None }
+               (`Assoc
+                   [ "task_id", `String task_id
+                   ; "action", `String "release"
+                   ; "reason", `String "handoff to another keeper"
+                   ])
+           in
+           if not ok then fail message;
+           check
+             bool
+             "worktree cleared on release"
+             true
+             (Option.is_none (only_task config).worktree))))
+;;
 
 let test_claim_next_runs_post_provision_hook () =
   let observed = ref None in
   with_claim_post_provision_hook
     (fun _config ~agent_name ~task_id -> observed := Some (agent_name, task_id))
     (fun () ->
-      with_room (fun config ->
-        let meta = make_test_meta () in
-        with_registered_keeper config meta (fun () ->
-          let _ =
-            Coord.add_task config ~title:"Provision hook task" ~priority:1
-              ~description:"desc"
-          in
-          let task_id = (only_task config).id in
-          let _ = call_tool config meta "keeper_task_claim" (`Assoc []) in
-          check (option (pair string string)) "claim-next provision hook"
-            (Some (meta.agent_name, task_id))
-            !observed)))
+       with_room (fun config ->
+         let meta = make_test_meta () in
+         with_registered_keeper config meta (fun () ->
+           let _ =
+             Coord.add_task
+               config
+               ~title:"Provision hook task"
+               ~priority:1
+               ~description:"desc"
+           in
+           let task_id = (only_task config).id in
+           let _ = call_tool config meta "keeper_task_claim" (`Assoc []) in
+           check
+             (option (pair string string))
+             "claim-next provision hook"
+             (Some (meta.agent_name, task_id))
+             !observed)))
+;;
 
 let test_stale_current_task_id_is_cleared_from_backlog () =
   with_room (fun config ->
@@ -452,29 +555,38 @@ let test_stale_current_task_id_is_cleared_from_backlog () =
        | Ok () -> ()
        | Error msg -> fail msg);
       let synced =
-        Keeper_agent_tool_surface.sync_current_task_id_from_backlog
-          ~config meta
+        Keeper_agent_tool_surface.sync_current_task_id_from_backlog ~config meta
       in
-      check (option string) "stale current_task_id cleared" None
+      check
+        (option string)
+        "stale current_task_id cleared"
+        None
         (current_task_id_string synced)))
+;;
 
 let test_heartbeat_current_task_id_reconciles_terminal_backlog () =
   with_room (fun config ->
     let meta = make_test_meta ~name:"heartbeat-keeper" () in
     with_registered_keeper config meta (fun () ->
       let _ =
-        Coord.add_task config ~title:"Heartbeat stale task" ~priority:1
+        Coord.add_task
+          config
+          ~title:"Heartbeat stale task"
+          ~priority:1
           ~description:"desc"
       in
       let result = call_tool config meta "keeper_task_claim" (`Assoc []) in
       let json = parse_json result in
       let task_id =
-        Yojson.Safe.Util.(
-          json |> member "claimed_task" |> member "task_id" |> to_string)
+        Yojson.Safe.Util.(json |> member "claimed_task" |> member "task_id" |> to_string)
       in
       (match
-         Coord.force_done_task_r config ~agent_name:meta.agent_name ~task_id
-           ~notes:"terminal in backlog" ()
+         Coord.force_done_task_r
+           config
+           ~agent_name:meta.agent_name
+           ~task_id
+           ~notes:"terminal in backlog"
+           ()
        with
        | Ok _ -> ()
        | Error msg -> fail (Masc_domain.masc_error_to_string msg));
@@ -487,8 +599,12 @@ let test_heartbeat_current_task_id_reconciles_terminal_backlog () =
         | Some entry -> entry.meta
         | None -> fail "expected keeper registry entry"
       in
-      check (option string) "registry current_task_id cleared" None
+      check
+        (option string)
+        "registry current_task_id cleared"
+        None
         (current_task_id_string registry_meta)))
+;;
 
 let test_claim_empty_room () =
   with_room (fun config ->
@@ -499,28 +615,42 @@ let test_claim_empty_room () =
     match Yojson.Safe.Util.member "result" json with
     | `String _ -> () (* ok *)
     | _ ->
-      match Yojson.Safe.Util.member "error" json with
-      | `String _ -> () (* also ok *)
-      | _ -> fail "expected result or error in empty room claim")
+      (match Yojson.Safe.Util.member "error" json with
+       | `String _ -> () (* also ok *)
+       | _ -> fail "expected result or error in empty room claim"))
+;;
 
 let test_claim_prefers_oldest_same_priority_task () =
   with_room (fun config ->
     let meta = make_test_meta () in
     ignore
-      (Coord.add_task config ~title:"Fresh P0" ~priority:1
+      (Coord.add_task
+         config
+         ~title:"Fresh P0"
+         ~priority:1
          ~description:"newer high-priority work");
     ignore
-      (Coord.add_task config ~title:"Stale P0" ~priority:1
+      (Coord.add_task
+         config
+         ~title:"Stale P0"
+         ~priority:1
          ~description:"older high-priority work");
-    set_task_created_at_by_title config ~title:"Fresh P0"
+    set_task_created_at_by_title
+      config
+      ~title:"Fresh P0"
       ~created_at:"2026-05-05T12:00:00Z";
-    set_task_created_at_by_title config ~title:"Stale P0"
+    set_task_created_at_by_title
+      config
+      ~title:"Stale P0"
       ~created_at:"2026-05-04T12:00:00Z";
     let result = call_tool config meta "keeper_task_claim" (`Assoc []) in
     let json = parse_json result in
-    check string "oldest same-priority task claimed first" "Stale P0"
-      Yojson.Safe.Util.(
-        json |> member "claimed_task" |> member "title" |> to_string))
+    check
+      string
+      "oldest same-priority task claimed first"
+      "Stale P0"
+      Yojson.Safe.Util.(json |> member "claimed_task" |> member "title" |> to_string))
+;;
 
 let test_claim_respects_active_goal_ids () =
   with_room (fun config ->
@@ -536,39 +666,57 @@ let test_claim_respects_active_goal_ids () =
     in
     let meta = make_goal_scoped_meta [ goal.id ] in
     let _ =
-      Coord_task.add_task ~goal_id:other_goal.id config
-        ~title:"Other goal task" ~priority:1 ~description:"desc"
+      Coord_task.add_task
+        ~goal_id:other_goal.id
+        config
+        ~title:"Other goal task"
+        ~priority:1
+        ~description:"desc"
     in
     let _ =
-      Coord_task.add_task ~goal_id:goal.id config
-        ~title:"Masc goal task" ~priority:5 ~description:"desc"
+      Coord_task.add_task
+        ~goal_id:goal.id
+        config
+        ~title:"Masc goal task"
+        ~priority:5
+        ~description:"desc"
     in
     let result = call_tool config meta "keeper_task_claim" (`Assoc []) in
     let json = parse_json result in
     let claimed_task =
       Coord.get_tasks_raw config
       |> List.find_opt (fun (task : Masc_domain.task) ->
-           Masc_domain.task_assignee_of_status task.task_status = Some meta.agent_name)
+        Masc_domain.task_assignee_of_status task.task_status = Some meta.agent_name)
     in
     match claimed_task with
     | Some task ->
       check string "claimed scoped task" "Masc goal task" task.title;
       let scope = Yojson.Safe.Util.member "claim_scope" json in
-      check string "claim scope mode" "active_goal_ids"
+      check
+        string
+        "claim scope mode"
+        "active_goal_ids"
         Yojson.Safe.Util.(scope |> member "mode" |> to_string);
-      check string "claim scope matched goal" goal.id
+      check
+        string
+        "claim scope matched goal"
+        goal.id
         Yojson.Safe.Util.(scope |> member "matched_goal_id" |> to_string);
-      check string "claimed task goal" goal.id
-        Yojson.Safe.Util.(
-          json |> member "claimed_task" |> member "goal_id" |> to_string)
+      check
+        string
+        "claimed task goal"
+        goal.id
+        Yojson.Safe.Util.(json |> member "claimed_task" |> member "goal_id" |> to_string)
     | None -> fail "expected a claimed task")
+;;
 
 let test_claim_does_not_cross_goal_when_auto_goal_scope_empty () =
   with_room (fun config ->
     let meta = make_test_meta ~name:"executor" () in
     let auto_goal, _ =
       match
-        Goal_store.upsert_goal config
+        Goal_store.upsert_goal
+          config
           ~title:(Keeper_goal_repair.goal_title_of_purpose meta.goal)
           ()
       with
@@ -582,18 +730,29 @@ let test_claim_does_not_cross_goal_when_auto_goal_scope_empty () =
     in
     let meta = { meta with active_goal_ids = [ auto_goal.id ] } in
     let _ =
-      Coord_task.add_task ~goal_id:product_goal.id config
-        ~title:"Product task" ~priority:1 ~description:"desc"
+      Coord_task.add_task
+        ~goal_id:product_goal.id
+        config
+        ~title:"Product task"
+        ~priority:1
+        ~description:"desc"
     in
     let result = call_tool config meta "keeper_task_claim" (`Assoc []) in
     let json = parse_json result in
     let message = Yojson.Safe.Util.(json |> member "result" |> to_string) in
     check_no_task_claimed config meta;
     check_active_goal_scope_no_fallback json ~goal_id:auto_goal.id;
-    check bool "message keeps active scope" true
+    check
+      bool
+      "message keeps active scope"
+      true
       (contains_substring message "within active_goal_ids");
-    check bool "does not claim product fallback" false
+    check
+      bool
+      "does not claim product fallback"
+      false
       (contains_substring message "fallback to all tasks"))
+;;
 
 let test_claim_does_not_cross_goal_when_persisted_goal_scope_empty () =
   with_room (fun config ->
@@ -609,22 +768,33 @@ let test_claim_does_not_cross_goal_when_persisted_goal_scope_empty () =
     in
     let meta =
       { (make_test_meta ~name:"masc-improver" ()) with
-        active_goal_ids = [ keeper_goal.id ];
+        active_goal_ids = [ keeper_goal.id ]
       }
     in
     let _ =
-      Coord_task.add_task ~goal_id:product_goal.id config
-        ~title:"Product task" ~priority:1 ~description:"desc"
+      Coord_task.add_task
+        ~goal_id:product_goal.id
+        config
+        ~title:"Product task"
+        ~priority:1
+        ~description:"desc"
     in
     let result = call_tool config meta "keeper_task_claim" (`Assoc []) in
     let json = parse_json result in
     let message = Yojson.Safe.Util.(json |> member "result" |> to_string) in
     check_no_task_claimed config meta;
     check_active_goal_scope_no_fallback json ~goal_id:keeper_goal.id;
-    check bool "message keeps active scope" true
+    check
+      bool
+      "message keeps active scope"
+      true
       (contains_substring message "within active_goal_ids");
-    check bool "does not claim product fallback" false
+    check
+      bool
+      "does not claim product fallback"
+      false
       (contains_substring message "fallback to all tasks"))
+;;
 
 let test_explicit_empty_goal_scope_fallback_override_still_claims_cross_goal () =
   with_room (fun config ->
@@ -640,37 +810,51 @@ let test_explicit_empty_goal_scope_fallback_override_still_claims_cross_goal () 
     in
     let meta = make_goal_scoped_meta [ scoped_goal.id ] in
     let _ =
-      Coord_task.add_task ~goal_id:product_goal.id config
-        ~title:"Product fallback task" ~priority:1 ~description:"desc"
+      Coord_task.add_task
+        ~goal_id:product_goal.id
+        config
+        ~title:"Product fallback task"
+        ~priority:1
+        ~description:"desc"
     in
     let scope =
       Keeper_runtime_contract.resolve_claim_goal_scope
-        ~allow_empty_goal_scope_fallback:true ~config ~meta ()
+        ~allow_empty_goal_scope_fallback:true
+        ~config
+        ~meta
+        ()
     in
-    check string "claim scope fallback mode"
-      "empty_goal_scope_fallback_all_tasks" scope.mode;
+    check
+      string
+      "claim scope fallback mode"
+      "empty_goal_scope_fallback_all_tasks"
+      scope.mode;
     check (list string) "effective goal ids cleared" [] scope.effective_goal_ids;
-    check bool "fallback reason present" true
-      (Option.is_some scope.fallback_reason);
+    check bool "fallback reason present" true (Option.is_some scope.fallback_reason);
     match
-      Coord.claim_next_r config ~agent_name:meta.agent_name
+      Coord.claim_next_r
+        config
+        ~agent_name:meta.agent_name
         ~agent_tool_names:(Keeper_tool_policy.keeper_allowed_tool_names meta)
-        ~task_filter:scope.task_filter ()
+        ~task_filter:scope.task_filter
+        ()
     with
     | Coord.Claim_next_claimed { task_id; _ } ->
-        let task =
-          Coord.get_tasks_raw config
-          |> List.find_opt (fun (task : Masc_domain.task) ->
-               String.equal task.id task_id)
-        in
-        (match task with
-         | Some task ->
-             check string "fallback claimed product task" "Product fallback task"
-               task.title;
-             check string "fallback claimed product goal" product_goal.id
-               (Option.value task.goal_id ~default:"")
-         | None -> fail "claimed task not found")
+      let task =
+        Coord.get_tasks_raw config
+        |> List.find_opt (fun (task : Masc_domain.task) -> String.equal task.id task_id)
+      in
+      (match task with
+       | Some task ->
+         check string "fallback claimed product task" "Product fallback task" task.title;
+         check
+           string
+           "fallback claimed product goal"
+           product_goal.id
+           (Option.value task.goal_id ~default:"")
+       | None -> fail "claimed task not found")
     | _ -> fail "expected explicit fallback override to claim product task")
+;;
 
 let test_claim_does_not_cross_goal_when_scoped_task_requires_missing_tool () =
   with_room (fun config ->
@@ -686,7 +870,7 @@ let test_claim_does_not_cross_goal_when_scoped_task_requires_missing_tool () =
     in
     let meta =
       { (make_meta_with_tools [ "keeper_task_claim"; "keeper_tasks_list" ]) with
-        active_goal_ids = [ scoped_goal.id ];
+        active_goal_ids = [ scoped_goal.id ]
       }
     in
     let _ =
@@ -699,18 +883,29 @@ let test_claim_does_not_cross_goal_when_scoped_task_requires_missing_tool () =
         ~description:"requires shell execution"
     in
     let _ =
-      Coord_task.add_task ~goal_id:product_goal.id config
-        ~title:"Product fallback task" ~priority:2 ~description:"desc"
+      Coord_task.add_task
+        ~goal_id:product_goal.id
+        config
+        ~title:"Product fallback task"
+        ~priority:2
+        ~description:"desc"
     in
     let result = call_tool config meta "keeper_task_claim" (`Assoc []) in
     let json = parse_json result in
     let message = Yojson.Safe.Util.(json |> member "result" |> to_string) in
     check_no_task_claimed config meta;
     check_active_goal_scope_no_fallback json ~goal_id:scoped_goal.id;
-    check bool "message keeps active scope" true
+    check
+      bool
+      "message keeps active scope"
+      true
       (contains_substring message "within active_goal_ids");
-    check bool "does not claim product fallback" false
+    check
+      bool
+      "does not claim product fallback"
+      false
       (contains_substring message "fallback to all tasks"))
+;;
 
 let test_claim_does_not_cross_goal_when_all_scoped_tasks_unavailable () =
   with_room (fun config ->
@@ -726,49 +921,76 @@ let test_claim_does_not_cross_goal_when_all_scoped_tasks_unavailable () =
     in
     let meta =
       { (make_meta_with_tools [ "keeper_task_claim"; "keeper_tasks_list" ]) with
-        active_goal_ids = [ scoped_goal.id ];
+        active_goal_ids = [ scoped_goal.id ]
       }
     in
     let _ =
-      Coord_task.add_task ~goal_id:scoped_goal.id config
-        ~title:"Scoped already in progress" ~priority:1
+      Coord_task.add_task
+        ~goal_id:scoped_goal.id
+        config
+        ~title:"Scoped already in progress"
+        ~priority:1
         ~description:"owned by another worker"
     in
     let in_progress_task = task_by_title config "Scoped already in progress" in
     ignore
-      (Coord.claim_task config ~agent_name:"other-agent"
-         ~task_id:in_progress_task.id);
-    transition_task_exn config ~agent_name:"other-agent"
-      ~task_id:in_progress_task.id ~action:Masc_domain.Start ();
+      (Coord.claim_task config ~agent_name:"other-agent" ~task_id:in_progress_task.id);
+    transition_task_exn
+      config
+      ~agent_name:"other-agent"
+      ~task_id:in_progress_task.id
+      ~action:Masc_domain.Start
+      ();
     let _ =
-      Coord_task.add_task ~goal_id:scoped_goal.id config
-        ~title:"Scoped already done" ~priority:2 ~description:"terminal"
+      Coord_task.add_task
+        ~goal_id:scoped_goal.id
+        config
+        ~title:"Scoped already done"
+        ~priority:2
+        ~description:"terminal"
     in
     let done_task = task_by_title config "Scoped already done" in
-    ignore
-      (Coord.claim_task config ~agent_name:"other-agent" ~task_id:done_task.id);
-    transition_task_exn config ~agent_name:"other-agent"
-      ~task_id:done_task.id ~action:Masc_domain.Done_action ~notes:"done" ();
+    ignore (Coord.claim_task config ~agent_name:"other-agent" ~task_id:done_task.id);
+    transition_task_exn
+      config
+      ~agent_name:"other-agent"
+      ~task_id:done_task.id
+      ~action:Masc_domain.Done_action
+      ~notes:"done"
+      ();
     let _ =
       Coord_task.add_task
         ~contract:(contract_requiring_tools [ "keeper_bash" ])
-        ~goal_id:scoped_goal.id config
-        ~title:"Scoped task needing bash" ~priority:3
+        ~goal_id:scoped_goal.id
+        config
+        ~title:"Scoped task needing bash"
+        ~priority:3
         ~description:"requires unavailable shell access"
     in
     let _ =
-      Coord_task.add_task ~goal_id:product_goal.id config
-        ~title:"Product fallback task" ~priority:1 ~description:"desc"
+      Coord_task.add_task
+        ~goal_id:product_goal.id
+        config
+        ~title:"Product fallback task"
+        ~priority:1
+        ~description:"desc"
     in
     let result = call_tool config meta "keeper_task_claim" (`Assoc []) in
     let json = parse_json result in
     let message = Yojson.Safe.Util.(json |> member "result" |> to_string) in
     check_no_task_claimed config meta;
     check_active_goal_scope_no_fallback json ~goal_id:scoped_goal.id;
-    check bool "message keeps active scope" true
+    check
+      bool
+      "message keeps active scope"
+      true
       (contains_substring message "within active_goal_ids");
-    check bool "does not claim product fallback" false
+    check
+      bool
+      "does not claim product fallback"
+      false
       (contains_substring message "fallback to all tasks"))
+;;
 
 let test_claim_does_not_cross_goal_when_scoped_task_is_verification_blocked () =
   with_room (fun config ->
@@ -784,25 +1006,39 @@ let test_claim_does_not_cross_goal_when_scoped_task_is_verification_blocked () =
     in
     let meta = make_goal_scoped_meta [ scoped_goal.id ] in
     let _ =
-      Coord_task.add_task ~goal_id:scoped_goal.id config
-        ~title:"Scoped task pending verification" ~priority:1
+      Coord_task.add_task
+        ~goal_id:scoped_goal.id
+        config
+        ~title:"Scoped task pending verification"
+        ~priority:1
         ~description:"verification pending"
     in
     let scoped_task = task_by_title config "Scoped task pending verification" in
     create_pending_verification_request config ~task_id:scoped_task.id;
     let _ =
-      Coord_task.add_task ~goal_id:product_goal.id config
-        ~title:"Product fallback task" ~priority:2 ~description:"desc"
+      Coord_task.add_task
+        ~goal_id:product_goal.id
+        config
+        ~title:"Product fallback task"
+        ~priority:2
+        ~description:"desc"
     in
     let result = call_tool config meta "keeper_task_claim" (`Assoc []) in
     let json = parse_json result in
     let message = Yojson.Safe.Util.(json |> member "result" |> to_string) in
     check_no_task_claimed config meta;
     check_active_goal_scope_no_fallback json ~goal_id:scoped_goal.id;
-    check bool "message keeps active scope" true
+    check
+      bool
+      "message keeps active scope"
+      true
       (contains_substring message "within active_goal_ids");
-    check bool "does not claim product fallback" false
+    check
+      bool
+      "does not claim product fallback"
+      false
       (contains_substring message "fallback to all tasks"))
+;;
 
 let test_claim_no_eligible_scoped_reports_scope_truth () =
   with_room (fun config ->
@@ -818,7 +1054,7 @@ let test_claim_no_eligible_scoped_reports_scope_truth () =
     in
     let meta =
       { (make_meta_with_tools [ "keeper_task_claim"; "keeper_tasks_list" ]) with
-        active_goal_ids = [ scoped_goal.id ];
+        active_goal_ids = [ scoped_goal.id ]
       }
     in
     let _ =
@@ -844,12 +1080,22 @@ let test_claim_no_eligible_scoped_reports_scope_truth () =
     let message = Yojson.Safe.Util.(json |> member "result" |> to_string) in
     check_no_task_claimed config meta;
     check_active_goal_scope_no_fallback json ~goal_id:scoped_goal.id;
-    check bool "message avoids fallback search" false
+    check
+      bool
+      "message avoids fallback search"
+      false
       (contains_substring message "fallback to all tasks");
-    check bool "message stops task checking" true
+    check
+      bool
+      "message stops task checking"
+      true
       (contains_substring message "Stop task-checking");
-    check bool "message preserves active scope" true
+    check
+      bool
+      "message preserves active scope"
+      true
       (contains_substring message "within active_goal_ids"))
+;;
 
 let test_claim_skips_required_tools_without_access () =
   with_room (fun config ->
@@ -863,24 +1109,27 @@ let test_claim_skips_required_tools_without_access () =
         ~description:"requires shell execution"
     in
     let _ =
-      Coord.add_task config ~title:"Readable fallback" ~priority:2
+      Coord.add_task
+        config
+        ~title:"Readable fallback"
+        ~priority:2
         ~description:"does not require shell"
     in
     ignore (call_tool config meta "keeper_task_claim" (`Assoc []));
     let claimed =
       Coord.get_tasks_raw config
       |> List.find_opt (fun (task : Masc_domain.task) ->
-           Masc_domain.task_assignee_of_status task.task_status = Some meta.agent_name)
+        Masc_domain.task_assignee_of_status task.task_status = Some meta.agent_name)
     in
     match claimed with
     | Some task -> check string "claimed fallback" "Readable fallback" task.title
     | None -> fail "expected fallback task to be claimed")
+;;
 
 let test_claim_allows_required_tools_with_access () =
   with_room (fun config ->
     let meta =
-      make_meta_with_tools
-        [ "keeper_task_claim"; "keeper_tasks_list"; "keeper_bash" ]
+      make_meta_with_tools [ "keeper_task_claim"; "keeper_tasks_list"; "keeper_bash" ]
     in
     let _ =
       Coord.add_task
@@ -891,18 +1140,22 @@ let test_claim_allows_required_tools_with_access () =
         ~description:"requires shell execution"
     in
     let _ =
-      Coord.add_task config ~title:"Readable fallback" ~priority:2
+      Coord.add_task
+        config
+        ~title:"Readable fallback"
+        ~priority:2
         ~description:"does not require shell"
     in
     ignore (call_tool config meta "keeper_task_claim" (`Assoc []));
     let claimed =
       Coord.get_tasks_raw config
       |> List.find_opt (fun (task : Masc_domain.task) ->
-           Masc_domain.task_assignee_of_status task.task_status = Some meta.agent_name)
+        Masc_domain.task_assignee_of_status task.task_status = Some meta.agent_name)
     in
     match claimed with
     | Some task -> check string "claimed required-tool task" "Needs bash" task.title
     | None -> fail "expected required-tool task to be claimed")
+;;
 
 let test_create_defaults_single_active_goal_id () =
   with_room (fun config ->
@@ -913,20 +1166,25 @@ let test_create_defaults_single_active_goal_id () =
     in
     let meta = make_goal_scoped_meta [ goal.id ] in
     let result =
-      call_tool config meta "keeper_task_create"
-        (`Assoc
-          [
-            ("title", `String "Default scoped task");
-            ("description", `String "desc");
-          ])
+      call_tool
+        config
+        meta
+        "keeper_task_create"
+        (`Assoc [ "title", `String "Default scoped task"; "description", `String "desc" ])
     in
     let json = parse_json result in
-    check bool "create ok" true
+    check
+      bool
+      "create ok"
+      true
       (Yojson.Safe.Util.member "ok" json |> Yojson.Safe.Util.to_bool);
-    check string "response goal_id" goal.id
+    check
+      string
+      "response goal_id"
+      goal.id
       (Yojson.Safe.Util.member "goal_id" json |> Yojson.Safe.Util.to_string);
-    check (option string) "task linked goal" (Some goal.id)
-      (only_task config).goal_id)
+    check (option string) "task linked goal" (Some goal.id) (only_task config).goal_id)
+;;
 
 let test_create_requires_goal_id_for_multiple_active_goals () =
   with_room (fun config ->
@@ -942,38 +1200,44 @@ let test_create_requires_goal_id_for_multiple_active_goals () =
     in
     let meta = make_goal_scoped_meta [ goal_a.id; goal_b.id ] in
     let result =
-      call_tool config meta "keeper_task_create"
+      call_tool
+        config
+        meta
+        "keeper_task_create"
         (`Assoc
-          [
-            ("title", `String "Ambiguous scoped task");
-            ("description", `String "desc");
-          ])
+            [ "title", `String "Ambiguous scoped task"; "description", `String "desc" ])
     in
     let json = parse_json result in
-    let error =
-      Yojson.Safe.Util.member "error" json |> Yojson.Safe.Util.to_string
-    in
-    check bool "error asks for goal_id" true
+    let error = Yojson.Safe.Util.member "error" json |> Yojson.Safe.Util.to_string in
+    check
+      bool
+      "error asks for goal_id"
+      true
       (contains_substring error "goal_id is required"))
+;;
 
 let test_create_rejects_unknown_goal_id () =
   with_room (fun config ->
     let meta = make_test_meta () in
     let result =
-      call_tool config meta "keeper_task_create"
+      call_tool
+        config
+        meta
+        "keeper_task_create"
         (`Assoc
-          [
-            ("title", `String "Unknown goal task");
-            ("description", `String "desc");
-            ("goal_id", `String "goal-missing");
-          ])
+            [ "title", `String "Unknown goal task"
+            ; "description", `String "desc"
+            ; "goal_id", `String "goal-missing"
+            ])
     in
     let json = parse_json result in
-    let error =
-      Yojson.Safe.Util.member "error" json |> Yojson.Safe.Util.to_string
-    in
-    check bool "error mentions unknown goal" true
+    let error = Yojson.Safe.Util.member "error" json |> Yojson.Safe.Util.to_string in
+    check
+      bool
+      "error mentions unknown goal"
+      true
       (contains_substring error "unknown goal_id"))
+;;
 
 let test_create_rejects_fourth_open_task_for_goal () =
   with_room (fun config ->
@@ -993,43 +1257,50 @@ let test_create_rejects_fourth_open_task_for_goal () =
            ~description:"desc")
     done;
     let result =
-      call_tool config meta "keeper_task_create"
-        (`Assoc
-          [
-            ("title", `String "Fourth goal task");
-            ("description", `String "desc");
-          ])
+      call_tool
+        config
+        meta
+        "keeper_task_create"
+        (`Assoc [ "title", `String "Fourth goal task"; "description", `String "desc" ])
     in
     let json = parse_json result in
-    check string "error kind" "goal_task_limit_exceeded"
+    check
+      string
+      "error kind"
+      "goal_task_limit_exceeded"
       (Yojson.Safe.Util.member "error_kind" json |> Yojson.Safe.Util.to_string);
-    check string "response goal_id" goal.id
+    check
+      string
+      "response goal_id"
+      goal.id
       (Yojson.Safe.Util.member "goal_id" json |> Yojson.Safe.Util.to_string);
-    check int "open task count" 3
+    check
+      int
+      "open task count"
+      3
       (Yojson.Safe.Util.member "open_task_count" json |> Yojson.Safe.Util.to_int);
-    check int "limit" 3
-      (Yojson.Safe.Util.member "limit" json |> Yojson.Safe.Util.to_int);
+    check int "limit" 3 (Yojson.Safe.Util.member "limit" json |> Yojson.Safe.Util.to_int);
     check int "no task added" 3 (List.length (Coord.get_tasks_raw config)))
+;;
 
 let mark_first_task_done config ~agent_name =
   let backlog = Coord.read_backlog config in
   let tasks =
     match backlog.tasks with
     | first :: rest ->
-      {
-        first with
+      { first with
         task_status =
           Masc_domain.Done
-            {
-              assignee = agent_name;
-              completed_at = Masc_domain.now_iso ();
-              notes = Some "done";
-            };
+            { assignee = agent_name
+            ; completed_at = Masc_domain.now_iso ()
+            ; notes = Some "done"
+            }
       }
       :: rest
     | [] -> fail "expected task to mark done"
   in
   Coord.write_backlog config { backlog with tasks; version = backlog.version + 1 }
+;;
 
 let test_create_goal_limit_ignores_terminal_tasks () =
   with_room (fun config ->
@@ -1050,47 +1321,68 @@ let test_create_goal_limit_ignores_terminal_tasks () =
     done;
     mark_first_task_done config ~agent_name:meta.agent_name;
     let result =
-      call_tool config meta "keeper_task_create"
+      call_tool
+        config
+        meta
+        "keeper_task_create"
         (`Assoc
-          [
-            ("title", `String "Replacement goal task");
-            ("description", `String "desc");
-          ])
+            [ "title", `String "Replacement goal task"; "description", `String "desc" ])
     in
     let json = parse_json result in
-    check bool "create ok" true
+    check
+      bool
+      "create ok"
+      true
       (Yojson.Safe.Util.member "ok" json |> Yojson.Safe.Util.to_bool);
-    check string "response goal_id" goal.id
+    check
+      string
+      "response goal_id"
+      goal.id
       (Yojson.Safe.Util.member "goal_id" json |> Yojson.Safe.Util.to_string);
     check int "task added" 4 (List.length (Coord.get_tasks_raw config)))
+;;
 
 (* --- keeper_task_done tests --- *)
 
 let test_done_with_empty_task_id () =
   with_room (fun config ->
     let meta = make_test_meta () in
-    let result = call_tool config meta "keeper_task_done"
-      (`Assoc [("task_id", `String ""); ("result", `String "done")]) in
+    let result =
+      call_tool
+        config
+        meta
+        "keeper_task_done"
+        (`Assoc [ "task_id", `String ""; "result", `String "done" ])
+    in
     let json = parse_json result in
     match Yojson.Safe.Util.member "error" json with
     | `String s ->
-      check bool "error mentions task_id" true
+      check
+        bool
+        "error mentions task_id"
+        true
         (String.lowercase_ascii s |> fun s -> String.length s > 0)
     | _ -> fail "expected error for empty task_id")
+;;
 
 let test_done_with_nonexistent_id () =
   with_room (fun config ->
     let meta = make_test_meta () in
-    let result = call_tool config meta "keeper_task_done"
-      (`Assoc [("task_id", `String "nonexistent-999");
-               ("result", `String "completed")]) in
+    let result =
+      call_tool
+        config
+        meta
+        "keeper_task_done"
+        (`Assoc [ "task_id", `String "nonexistent-999"; "result", `String "completed" ])
+    in
     let json = parse_json result in
     match Yojson.Safe.Util.member "ok" json with
     | `Bool false -> () (* expected *)
     | _ ->
-      match Yojson.Safe.Util.member "error" json with
-      | `String _ -> () (* also acceptable *)
-      | _ -> fail "expected ok=false or error for nonexistent task")
+      (match Yojson.Safe.Util.member "error" json with
+       | `String _ -> () (* also acceptable *)
+       | _ -> fail "expected ok=false or error for nonexistent task"))
+;;
 
 let test_done_after_claim () =
   with_room (fun config ->
@@ -1101,14 +1393,18 @@ let test_done_after_claim () =
     let result_str = Yojson.Safe.Util.(member "result" claim_json |> to_string) in
     (* Extract task ID from claim result — format varies, try to find T-XXXX *)
     let task_id =
-      let re = Re.(compile (seq [str "T-"; rep1 (alt [digit; char '-'])])) in
+      let re = Re.(compile (seq [ str "T-"; rep1 (alt [ digit; char '-' ]) ])) in
       match Re.exec_opt re result_str with
       | Some g -> Re.Group.get g 0
-      | None -> "T-1"  (* fallback: first task *)
+      | None -> "T-1" (* fallback: first task *)
     in
-    let done_result = call_tool config meta "keeper_task_done"
-      (`Assoc [("task_id", `String task_id);
-               ("result", `String "completed by test")]) in
+    let done_result =
+      call_tool
+        config
+        meta
+        "keeper_task_done"
+        (`Assoc [ "task_id", `String task_id; "result", `String "completed by test" ])
+    in
     let done_json = parse_json done_result in
     match Yojson.Safe.Util.member "ok" done_json with
     | `Bool true -> ()
@@ -1117,9 +1413,10 @@ let test_done_after_claim () =
          per se, but the error path works *)
       ()
     | _ ->
-      match Yojson.Safe.Util.member "error" done_json with
-      | `String _ -> () (* error path also ok for format mismatch *)
-      | _ -> fail "expected ok or error in done response")
+      (match Yojson.Safe.Util.member "error" done_json with
+       | `String _ -> () (* error path also ok for format mismatch *)
+       | _ -> fail "expected ok or error in done response"))
+;;
 
 let test_done_respects_persisted_cdal_gate () =
   with_env "MASC_CDAL_GATE_ENABLED" (Some "true") (fun () ->
@@ -1127,22 +1424,33 @@ let test_done_respects_persisted_cdal_gate () =
       let meta = make_test_meta () in
       let contract = strict_contract () in
       let _ =
-        Coord.add_task ~contract config ~title:"Strict task" ~priority:1
+        Coord.add_task
+          ~contract
+          config
+          ~title:"Strict task"
+          ~priority:1
           ~description:"needs CDAL verdict"
       in
       let task_id = (only_task config).id in
       ignore (call_tool config meta "keeper_task_claim" (`Assoc []));
       let result =
-        call_tool config meta "keeper_task_done"
-          (`Assoc [ ("task_id", `String task_id); ("result", `String "tests pass") ])
+        call_tool
+          config
+          meta
+          "keeper_task_done"
+          (`Assoc [ "task_id", `String task_id; "result", `String "tests pass" ])
       in
       let json = parse_json result in
       match Yojson.Safe.Util.member "ok" json with
       | `Bool false ->
         let error = Yojson.Safe.Util.(member "error" json |> to_string) in
-        check bool "mentions CDAL verdict" true
+        check
+          bool
+          "mentions CDAL verdict"
+          true
           (Astring.String.is_infix ~affix:"CDAL verdict" error)
       | _ -> fail "expected strict contract gate rejection"))
+;;
 
 let test_done_redirects_to_verification_fsm () =
   ensure_rng ();
@@ -1152,14 +1460,21 @@ let test_done_redirects_to_verification_fsm () =
         let meta = make_test_meta () in
         let contract = strict_contract ~verify_gate_evidence:[ "output.json" ] () in
         let _ =
-          Coord.add_task ~contract config ~title:"Verification task" ~priority:1
+          Coord.add_task
+            ~contract
+            config
+            ~title:"Verification task"
+            ~priority:1
             ~description:"should enter awaiting verification"
         in
         let task_id = (only_task config).id in
         ignore (call_tool config meta "keeper_task_claim" (`Assoc []));
         let result =
-          call_tool config meta "keeper_task_done"
-            (`Assoc [ ("task_id", `String task_id); ("result", `String "tests pass") ])
+          call_tool
+            config
+            meta
+            "keeper_task_done"
+            (`Assoc [ "task_id", `String task_id; "result", `String "tests pass" ])
         in
         let json = parse_json result in
         match Yojson.Safe.Util.member "ok" json with
@@ -1173,6 +1488,7 @@ let test_done_redirects_to_verification_fsm () =
                   "expected awaiting_verification, got %s"
                   (Masc_domain.string_of_task_status status)))
         | _ -> fail "expected keeper_task_done to redirect into verification FSM")))
+;;
 
 let test_done_redirects_default_contract_task_to_verification_fsm () =
   ensure_rng ();
@@ -1180,18 +1496,23 @@ let test_done_redirects_default_contract_task_to_verification_fsm () =
     with_room (fun config ->
       let meta = make_test_meta () in
       let _ =
-        Coord.add_task config ~title:"Default verification task" ~priority:1
+        Coord.add_task
+          config
+          ~title:"Default verification task"
+          ~priority:1
           ~description:"created without explicit contract"
       in
       let task_id = (only_task config).id in
       ignore (call_tool config meta "keeper_task_claim" (`Assoc []));
       let result =
-        call_tool config meta "keeper_task_done"
+        call_tool
+          config
+          meta
+          "keeper_task_done"
           (`Assoc
-             [
-               ("task_id", `String task_id);
-               ("result", `String "Implemented change and ran focused checks.");
-             ])
+              [ "task_id", `String task_id
+              ; "result", `String "Implemented change and ran focused checks."
+              ])
       in
       let json = parse_json result in
       match Yojson.Safe.Util.member "ok" json with
@@ -1206,9 +1527,15 @@ let test_done_redirects_default_contract_task_to_verification_fsm () =
                 (Masc_domain.string_of_task_status status)));
         (match task.contract with
          | Some contract ->
-           check bool "default completion contract present" true
+           check
+             bool
+             "default completion contract present"
+             true
              (contract.completion_contract <> []);
-           check bool "default evidence contract present" true
+           check
+             bool
+             "default evidence contract present"
+             true
              (contract.verify_gate_evidence <> [])
          | None -> fail "expected default verification contract");
         let reqs = Verification.list_requests config.Coord.base_path in
@@ -1223,36 +1550,41 @@ let test_done_redirects_default_contract_task_to_verification_fsm () =
            check bool "criteria populated" true (req.criteria <> []);
            let evidence_refs =
              match req.output with
-             | `Assoc fields -> (
-                 match List.assoc_opt "evidence_refs" fields with
-                 | Some (`List refs) ->
-                   List.filter_map
-                     (function `String s -> Some s | _ -> None)
-                     refs
-                 | _ -> [])
+             | `Assoc fields ->
+               (match List.assoc_opt "evidence_refs" fields with
+                | Some (`List refs) ->
+                  List.filter_map
+                    (function
+                      | `String s -> Some s
+                      | _ -> None)
+                    refs
+                | _ -> [])
              | _ -> []
            in
            check bool "evidence refs populated" true (evidence_refs <> [])
          | None -> fail "expected verification request for default contract task")
       | _ -> fail "expected keeper_task_done to redirect into verification FSM"))
+;;
 
 let test_submit_for_verification_requires_pr_url () =
   with_room (fun config ->
     let meta = make_test_meta () in
     let result =
-      call_tool config meta "keeper_task_submit_for_verification"
+      call_tool
+        config
+        meta
+        "keeper_task_submit_for_verification"
         (`Assoc
-           [
-             ("task_id", `String "T-1");
-             ("notes", `String "tests pass");
-             ("pr_url", `String "");
-           ])
+            [ "task_id", `String "T-1"
+            ; "notes", `String "tests pass"
+            ; "pr_url", `String ""
+            ])
     in
     let json = parse_json result in
     match Yojson.Safe.Util.member "error" json with
-    | `String msg ->
-        check bool "mentions pr_url" true (contains_substring msg "pr_url")
+    | `String msg -> check bool "mentions pr_url" true (contains_substring msg "pr_url")
     | _ -> fail "expected error for empty pr_url")
+;;
 
 let test_submit_for_verification_transitions_task () =
   ensure_rng ();
@@ -1262,76 +1594,97 @@ let test_submit_for_verification_transitions_task () =
         let meta = make_test_meta () in
         let contract = strict_contract ~verify_gate_evidence:[ "pr_url" ] () in
         let _ =
-          Coord.add_task ~contract config ~title:"Verification submit task"
-            ~priority:1 ~description:"should enter awaiting verification"
+          Coord.add_task
+            ~contract
+            config
+            ~title:"Verification submit task"
+            ~priority:1
+            ~description:"should enter awaiting verification"
         in
         let task_id = (only_task config).id in
         ignore (call_tool config meta "keeper_task_claim" (`Assoc []));
         let result =
-          call_tool config meta "keeper_task_submit_for_verification"
+          call_tool
+            config
+            meta
+            "keeper_task_submit_for_verification"
             (`Assoc
-               [
-                 ("task_id", `String task_id);
-                 ("notes", `String "tests pass locally");
-                 ("pr_url", `String "https://github.com/jeong-sik/masc-mcp/pull/1");
-               ])
+                [ "task_id", `String task_id
+                ; "notes", `String "tests pass locally"
+                ; "pr_url", `String "https://github.com/jeong-sik/masc-mcp/pull/1"
+                ])
         in
         let json = parse_json result in
         match Yojson.Safe.Util.member "ok" json with
         | `Bool true ->
-            let task = only_task config in
-            (match task.task_status with
-             | Masc_domain.AwaitingVerification _ -> ()
-             | status ->
-                 fail
-                   (Printf.sprintf
-                      "expected awaiting_verification, got %s"
-                      (Masc_domain.string_of_task_status status)));
-            let persisted_meta =
-              match Keeper_types.read_meta config meta.name with
-              | Ok (Some meta) -> meta
-              | Ok None -> fail "expected persisted keeper meta"
-              | Error msg -> fail msg
-            in
-            check (option string) "awaiting verification clears current_task_id"
-              None (current_task_id_string persisted_meta)
+          let task = only_task config in
+          (match task.task_status with
+           | Masc_domain.AwaitingVerification _ -> ()
+           | status ->
+             fail
+               (Printf.sprintf
+                  "expected awaiting_verification, got %s"
+                  (Masc_domain.string_of_task_status status)));
+          let persisted_meta =
+            match Keeper_types.read_meta config meta.name with
+            | Ok (Some meta) -> meta
+            | Ok None -> fail "expected persisted keeper meta"
+            | Error msg -> fail msg
+          in
+          check
+            (option string)
+            "awaiting verification clears current_task_id"
+            None
+            (current_task_id_string persisted_meta)
         | _ -> fail "expected keeper_task_submit_for_verification to succeed")))
+;;
 
 (* --- keeper_tool_search tests --- *)
 
 let test_tool_search_empty_query_returns_error () =
   with_room (fun config ->
     let meta = make_test_meta () in
-    let result = call_tool config meta "keeper_tool_search"
-      (`Assoc [ ("query", `String "") ]) in
+    let result =
+      call_tool config meta "keeper_tool_search" (`Assoc [ "query", `String "" ])
+    in
     let json = parse_json result in
     match Yojson.Safe.Util.member "error" json with
-    | `String msg ->
-      check bool "error mentions query" true (String.length msg > 0)
+    | `String msg -> check bool "error mentions query" true (String.length msg > 0)
     | _ -> fail "expected error field for empty query")
+;;
 
 let test_tool_search_whitespace_query_returns_error () =
   with_room (fun config ->
     let meta = make_test_meta () in
-    let result = call_tool config meta "keeper_tool_search"
-      (`Assoc [ ("query", `String "   ") ]) in
+    let result =
+      call_tool config meta "keeper_tool_search" (`Assoc [ "query", `String "   " ])
+    in
     let json = parse_json result in
     match Yojson.Safe.Util.member "error" json with
     | `String _ -> () (* expected *)
     | _ -> fail "expected error field for whitespace-only query")
+;;
 
 let test_tool_search_without_search_fn_returns_error () =
   with_room (fun config ->
     let meta = make_test_meta () in
-
-    let result = call_tool config meta "keeper_tool_search"
-      (`Assoc [ ("query", `String "filesystem read file") ]) in
+    let result =
+      call_tool
+        config
+        meta
+        "keeper_tool_search"
+        (`Assoc [ "query", `String "filesystem read file" ])
+    in
     let json = parse_json result in
     match Yojson.Safe.Util.member "error" json with
     | `String msg ->
-      check bool "error mentions missing search wiring" true
+      check
+        bool
+        "error mentions missing search wiring"
+        true
         (String_util.contains_substring msg "not configured")
     | _ -> fail "expected error field for missing search_fn")
+;;
 
 let test_tool_search_max_results_clamped_to_10 () =
   with_room (fun config ->
@@ -1339,14 +1692,20 @@ let test_tool_search_max_results_clamped_to_10 () =
     let calls = ref [] in
     let search_fn ~query:_ ~max_results =
       calls := max_results :: !calls;
-      `Assoc [ ("results", `List []) ]
+      `Assoc [ "results", `List [] ]
     in
-    let _result = call_tool_with_search config meta "keeper_tool_search"
-      (`Assoc [ ("query", `String "worktree"); ("max_results", `Int 50) ])
-      search_fn in
+    let _result =
+      call_tool_with_search
+        config
+        meta
+        "keeper_tool_search"
+        (`Assoc [ "query", `String "worktree"; "max_results", `Int 50 ])
+        search_fn
+    in
     match !calls with
-    | [n] -> check int "max_results clamped to 10" 10 n
+    | [ n ] -> check int "max_results clamped to 10" 10 n
     | _ -> fail "expected exactly one search_fn call")
+;;
 
 let test_tool_search_max_results_minimum_1 () =
   with_room (fun config ->
@@ -1354,125 +1713,207 @@ let test_tool_search_max_results_minimum_1 () =
     let calls = ref [] in
     let search_fn ~query:_ ~max_results =
       calls := max_results :: !calls;
-      `Assoc [ ("results", `List []) ]
+      `Assoc [ "results", `List [] ]
     in
-    let _result = call_tool_with_search config meta "keeper_tool_search"
-      (`Assoc [ ("query", `String "worktree"); ("max_results", `Int 0) ])
-      search_fn in
+    let _result =
+      call_tool_with_search
+        config
+        meta
+        "keeper_tool_search"
+        (`Assoc [ "query", `String "worktree"; "max_results", `Int 0 ])
+        search_fn
+    in
     match !calls with
-    | [n] -> check int "max_results clamped to min 1" 1 n
+    | [ n ] -> check int "max_results clamped to min 1" 1 n
     | _ -> fail "expected exactly one search_fn call")
+;;
 
 let test_tool_search_uses_provided_search_fn () =
   with_room (fun config ->
     let meta = make_test_meta () in
     let search_fn ~query ~max_results:_ =
-      `Assoc [
-        ("ok", `Bool true);
-        ("query", `String query);
-        ("results", `List [
-          `Assoc [ ("name", `String "keeper_fs_read");
-                   ("score", `Float 0.9);
-                   ("description", `String "read a file") ];
-        ]);
-      ]
+      `Assoc
+        [ "ok", `Bool true
+        ; "query", `String query
+        ; ( "results"
+          , `List
+              [ `Assoc
+                  [ "name", `String "keeper_fs_read"
+                  ; "score", `Float 0.9
+                  ; "description", `String "read a file"
+                  ]
+              ] )
+        ]
     in
-    let result = call_tool_with_search config meta "keeper_tool_search"
-      (`Assoc [ ("query", `String "read file") ])
-      search_fn in
+    let result =
+      call_tool_with_search
+        config
+        meta
+        "keeper_tool_search"
+        (`Assoc [ "query", `String "read file" ])
+        search_fn
+    in
     let json = parse_json result in
     let results = Yojson.Safe.Util.(member "results" json |> to_list) in
     check int "one result returned" 1 (List.length results);
     let name = Yojson.Safe.Util.(List.hd results |> member "name" |> to_string) in
     check string "result name matches" "keeper_fs_read" name)
+;;
 
 let () =
   let base_path = Masc_test_deps.find_project_root () in
   ignore (Result.get_ok (Keeper_exec_tools.init_policy_config ~base_path));
-  Alcotest.run "Keeper_task_dispatch" [
-    "claim", [
-      test_case "claim returns result" `Quick test_claim_returns_result;
-      test_case "claim returns observation fragment" `Quick
-        test_claim_returns_observation_fragment;
-      test_case "claim syncs keeper current_task_id" `Quick
-        test_claim_syncs_keeper_current_task_id;
-      test_case "release clears keeper current_task_id" `Quick
-        test_release_clears_keeper_current_task_id;
-      test_case "claim clears stale task worktree metadata" `Quick
-        test_claim_clears_stale_task_worktree_metadata;
-      test_case "release clears task worktree metadata" `Quick
-        test_release_clears_task_worktree_metadata;
-      test_case "claim-next runs post-provision hook" `Quick
-        test_claim_next_runs_post_provision_hook;
-      test_case "stale current_task_id clears from backlog" `Quick
-        test_stale_current_task_id_is_cleared_from_backlog;
-      test_case "heartbeat current_task_id reconciles terminal backlog" `Quick
-        test_heartbeat_current_task_id_reconciles_terminal_backlog;
-      test_case "claim empty room" `Quick test_claim_empty_room;
-      test_case "claim prefers oldest same-priority task" `Quick
-        test_claim_prefers_oldest_same_priority_task;
-      test_case "claim respects active_goal_ids" `Quick
-        test_claim_respects_active_goal_ids;
-      test_case "claim does not cross-goal when auto goal scope is empty" `Quick
-        test_claim_does_not_cross_goal_when_auto_goal_scope_empty;
-      test_case "claim does not cross-goal when persisted goal scope is empty"
-        `Quick
-        test_claim_does_not_cross_goal_when_persisted_goal_scope_empty;
-      test_case
-        "explicit empty goal scope fallback override still claims cross-goal"
-        `Quick
-        test_explicit_empty_goal_scope_fallback_override_still_claims_cross_goal;
-      test_case "claim does not cross-goal when scoped task requires missing tool"
-        `Quick
-        test_claim_does_not_cross_goal_when_scoped_task_requires_missing_tool;
-      test_case "claim does not cross-goal when all scoped tasks unavailable"
-        `Quick
-        test_claim_does_not_cross_goal_when_all_scoped_tasks_unavailable;
-      test_case
-        "claim does not cross-goal when scoped task is verification blocked"
-        `Quick
-        test_claim_does_not_cross_goal_when_scoped_task_is_verification_blocked;
-      test_case "claim no eligible scoped reports scope truth" `Quick
-        test_claim_no_eligible_scoped_reports_scope_truth;
-      test_case "claim skips tasks requiring missing tools" `Quick
-        test_claim_skips_required_tools_without_access;
-      test_case "claim allows tasks requiring available tools" `Quick
-        test_claim_allows_required_tools_with_access;
-      test_case "create defaults single active goal_id" `Quick
-        test_create_defaults_single_active_goal_id;
-      test_case "create requires explicit goal_id for multiple active goals" `Quick
-        test_create_requires_goal_id_for_multiple_active_goals;
-      test_case "create rejects unknown goal_id" `Quick
-        test_create_rejects_unknown_goal_id;
-      test_case "create rejects fourth open task for goal" `Quick
-        test_create_rejects_fourth_open_task_for_goal;
-      test_case "create goal limit ignores terminal tasks" `Quick
-        test_create_goal_limit_ignores_terminal_tasks;
-    ];
-    "done", [
-      test_case "empty task_id returns error" `Quick test_done_with_empty_task_id;
-      test_case "nonexistent id returns error" `Quick test_done_with_nonexistent_id;
-      test_case "done after claim" `Quick test_done_after_claim;
-      test_case "strict contract uses CDAL gate" `Quick
-        test_done_respects_persisted_cdal_gate;
-      test_case "done redirects to verification FSM" `Quick
-        test_done_redirects_to_verification_fsm;
-      test_case "default contract redirects to verification FSM" `Quick
-        test_done_redirects_default_contract_task_to_verification_fsm;
-    ];
-    "submit_for_verification", [
-      test_case "requires pr_url" `Quick
-        test_submit_for_verification_requires_pr_url;
-      test_case "transitions task" `Quick
-        test_submit_for_verification_transitions_task;
-    ];
-    "keeper_tool_search", [
-      test_case "empty query returns error" `Quick test_tool_search_empty_query_returns_error;
-      test_case "whitespace query returns error" `Quick test_tool_search_whitespace_query_returns_error;
-      test_case "non-empty query requires search_fn" `Quick
-        test_tool_search_without_search_fn_returns_error;
-      test_case "max_results clamped to 10" `Quick test_tool_search_max_results_clamped_to_10;
-      test_case "max_results minimum is 1" `Quick test_tool_search_max_results_minimum_1;
-      test_case "uses provided search_fn" `Quick test_tool_search_uses_provided_search_fn;
-    ];
-  ]
+  Alcotest.run
+    "Keeper_task_dispatch"
+    [ ( "claim"
+      , [ test_case "claim returns result" `Quick test_claim_returns_result
+        ; test_case
+            "claim returns observation fragment"
+            `Quick
+            test_claim_returns_observation_fragment
+        ; test_case
+            "claim syncs keeper current_task_id"
+            `Quick
+            test_claim_syncs_keeper_current_task_id
+        ; test_case
+            "release clears keeper current_task_id"
+            `Quick
+            test_release_clears_keeper_current_task_id
+        ; test_case
+            "claim clears stale task worktree metadata"
+            `Quick
+            test_claim_clears_stale_task_worktree_metadata
+        ; test_case
+            "release clears task worktree metadata"
+            `Quick
+            test_release_clears_task_worktree_metadata
+        ; test_case
+            "claim-next runs post-provision hook"
+            `Quick
+            test_claim_next_runs_post_provision_hook
+        ; test_case
+            "stale current_task_id clears from backlog"
+            `Quick
+            test_stale_current_task_id_is_cleared_from_backlog
+        ; test_case
+            "heartbeat current_task_id reconciles terminal backlog"
+            `Quick
+            test_heartbeat_current_task_id_reconciles_terminal_backlog
+        ; test_case "claim empty room" `Quick test_claim_empty_room
+        ; test_case
+            "claim prefers oldest same-priority task"
+            `Quick
+            test_claim_prefers_oldest_same_priority_task
+        ; test_case
+            "claim respects active_goal_ids"
+            `Quick
+            test_claim_respects_active_goal_ids
+        ; test_case
+            "claim does not cross-goal when auto goal scope is empty"
+            `Quick
+            test_claim_does_not_cross_goal_when_auto_goal_scope_empty
+        ; test_case
+            "claim does not cross-goal when persisted goal scope is empty"
+            `Quick
+            test_claim_does_not_cross_goal_when_persisted_goal_scope_empty
+        ; test_case
+            "explicit empty goal scope fallback override still claims cross-goal"
+            `Quick
+            test_explicit_empty_goal_scope_fallback_override_still_claims_cross_goal
+        ; test_case
+            "claim does not cross-goal when scoped task requires missing tool"
+            `Quick
+            test_claim_does_not_cross_goal_when_scoped_task_requires_missing_tool
+        ; test_case
+            "claim does not cross-goal when all scoped tasks unavailable"
+            `Quick
+            test_claim_does_not_cross_goal_when_all_scoped_tasks_unavailable
+        ; test_case
+            "claim does not cross-goal when scoped task is verification blocked"
+            `Quick
+            test_claim_does_not_cross_goal_when_scoped_task_is_verification_blocked
+        ; test_case
+            "claim no eligible scoped reports scope truth"
+            `Quick
+            test_claim_no_eligible_scoped_reports_scope_truth
+        ; test_case
+            "claim skips tasks requiring missing tools"
+            `Quick
+            test_claim_skips_required_tools_without_access
+        ; test_case
+            "claim allows tasks requiring available tools"
+            `Quick
+            test_claim_allows_required_tools_with_access
+        ; test_case
+            "create defaults single active goal_id"
+            `Quick
+            test_create_defaults_single_active_goal_id
+        ; test_case
+            "create requires explicit goal_id for multiple active goals"
+            `Quick
+            test_create_requires_goal_id_for_multiple_active_goals
+        ; test_case
+            "create rejects unknown goal_id"
+            `Quick
+            test_create_rejects_unknown_goal_id
+        ; test_case
+            "create rejects fourth open task for goal"
+            `Quick
+            test_create_rejects_fourth_open_task_for_goal
+        ; test_case
+            "create goal limit ignores terminal tasks"
+            `Quick
+            test_create_goal_limit_ignores_terminal_tasks
+        ] )
+    ; ( "done"
+      , [ test_case "empty task_id returns error" `Quick test_done_with_empty_task_id
+        ; test_case "nonexistent id returns error" `Quick test_done_with_nonexistent_id
+        ; test_case "done after claim" `Quick test_done_after_claim
+        ; test_case
+            "strict contract uses CDAL gate"
+            `Quick
+            test_done_respects_persisted_cdal_gate
+        ; test_case
+            "done redirects to verification FSM"
+            `Quick
+            test_done_redirects_to_verification_fsm
+        ; test_case
+            "default contract redirects to verification FSM"
+            `Quick
+            test_done_redirects_default_contract_task_to_verification_fsm
+        ] )
+    ; ( "submit_for_verification"
+      , [ test_case "requires pr_url" `Quick test_submit_for_verification_requires_pr_url
+        ; test_case
+            "transitions task"
+            `Quick
+            test_submit_for_verification_transitions_task
+        ] )
+    ; ( "keeper_tool_search"
+      , [ test_case
+            "empty query returns error"
+            `Quick
+            test_tool_search_empty_query_returns_error
+        ; test_case
+            "whitespace query returns error"
+            `Quick
+            test_tool_search_whitespace_query_returns_error
+        ; test_case
+            "non-empty query requires search_fn"
+            `Quick
+            test_tool_search_without_search_fn_returns_error
+        ; test_case
+            "max_results clamped to 10"
+            `Quick
+            test_tool_search_max_results_clamped_to_10
+        ; test_case
+            "max_results minimum is 1"
+            `Quick
+            test_tool_search_max_results_minimum_1
+        ; test_case
+            "uses provided search_fn"
+            `Quick
+            test_tool_search_uses_provided_search_fn
+        ] )
+    ]
+;;

--- a/test/test_keeper_tools_oas.ml
+++ b/test/test_keeper_tools_oas.ml
@@ -277,6 +277,39 @@ let test_post_hook_does_not_duplicate_handler_logged_io () =
       check int "post hook did not duplicate handler row" 1
         (List.length entries))
 
+let test_oas_wrapper_records_keeper_internal_tool_call () =
+  let meta = make_test_meta ~name:"test-keeper-tool-registry" () in
+  let ctx_snapshot = make_test_ctx () in
+  let dir = Filename.temp_file "test_keeper_tools_registry_" "" in
+  Sys.remove dir;
+  Unix.mkdir dir 0o755;
+  Fun.protect
+    ~finally:(fun () -> rm_rf dir)
+    (fun () ->
+      Eio_main.run @@ fun env ->
+      Fs_compat.set_fs (Eio.Stdenv.fs env);
+      Tool_registry.reset ();
+      let config = Coord.default_config dir in
+      let bundle =
+        Keeper_tools_oas.make_tool_bundle ~config ~meta ~ctx_snapshot ()
+      in
+      Fun.protect
+        ~finally:(fun () ->
+          bundle.cleanup ();
+          Tool_registry.reset ())
+        (fun () ->
+          let tool = find_tool "keeper_stay_silent" bundle.tools in
+          match Tool.execute tool (`Assoc []) with
+          | Error { Agent_sdk.Types.message; _ } ->
+              fail (Printf.sprintf "expected tool success, got error: %s" message)
+          | Ok _ ->
+              let stats = Tool_registry.get_stats () in
+              let entry = List.assoc "keeper_stay_silent" stats in
+              check int "call_count" 1 (Atomic.get entry.call_count);
+              check int "success_count" 1 (Atomic.get entry.success_count);
+              check int "keeper_internal_count" 1
+                (Atomic.get entry.keeper_internal_count)))
+
 let is_guardrail_message message =
   string_contains
     ~sub:"failed 3 times in a row with the same arguments"
@@ -900,6 +933,8 @@ let () =
         test_handler_persists_tool_call_io_without_post_hook;
       test_case "post hook skips handler-logged tool-call I/O" `Quick
         test_post_hook_does_not_duplicate_handler_logged_io;
+      test_case "wrapper records keeper-internal calls" `Quick
+        test_oas_wrapper_records_keeper_internal_tool_call;
     ];
     "normalize_tool_result", [
       test_case "success JSON wraps under result" `Quick test_normalize_success_json;

--- a/test/test_keeper_tools_oas.ml
+++ b/test/test_keeper_tools_oas.ml
@@ -1,109 +1,158 @@
 (** Tests for Keeper_tools_oas — OAS Tool.t wrapping of keeper tools. *)
 
 module Mlog = Log
-
 open Agent_sdk
 open Alcotest
 open Masc_mcp
 
 let autoresearch_allowlist =
-  ["masc_autoresearch_start"; "masc_autoresearch_cycle";
-   "masc_autoresearch_status"; "masc_autoresearch_stop";
-   "masc_autoresearch_inject"]
+  [ "masc_autoresearch_start"
+  ; "masc_autoresearch_cycle"
+  ; "masc_autoresearch_status"
+  ; "masc_autoresearch_stop"
+  ; "masc_autoresearch_inject"
+  ]
+;;
 
-let make_test_meta ?(name = "test-keeper") ?(preset = Keeper_types.Full)
-    ?(also_allow = []) ?tool_access ()
-    : Keeper_types.keeper_meta =
+let make_test_meta
+      ?(name = "test-keeper")
+      ?(preset = Keeper_types.Full)
+      ?(also_allow = [])
+      ?tool_access
+      ()
+  : Keeper_types.keeper_meta
+  =
   let tool_access =
     match tool_access with
     | Some access -> access
     | None -> Keeper_types.Preset { preset; also_allow }
   in
-  match Masc_test_deps.meta_of_json_fixture
-    (`Assoc [("name", `String name); ("agent_name", `String name);
-             ("trace_id", `String "test-trace-001");
-             ("allowed_paths", `List [`String "*"]);
-             ("tool_access", Keeper_types.tool_access_to_json tool_access)]) with
+  match
+    Masc_test_deps.meta_of_json_fixture
+      (`Assoc
+          [ "name", `String name
+          ; "agent_name", `String name
+          ; "trace_id", `String "test-trace-001"
+          ; "allowed_paths", `List [ `String "*" ]
+          ; "tool_access", Keeper_types.tool_access_to_json tool_access
+          ])
+  with
   | Ok meta -> meta
   | Error e -> failwith (Printf.sprintf "make_test_meta failed: %s" e)
+;;
 
-let make_test_ctx () =
-  Keeper_exec_context.create ~system_prompt:"test" ~max_tokens:4000
+let make_test_ctx () = Keeper_exec_context.create ~system_prompt:"test" ~max_tokens:4000
 
 let test_make_tools_returns_nonempty () =
   let meta = make_test_meta () in
   let ctx_snapshot = make_test_ctx () in
-  let dir = Filename.concat (Filename.get_temp_dir_name ())
-    (Printf.sprintf "test_keeper_tools_%d" (Random.int 100000)) in
-  (try Unix.mkdir dir 0o755 with Unix.Unix_error (Unix.EEXIST, _, _) -> ());
+  let dir =
+    Filename.concat
+      (Filename.get_temp_dir_name ())
+      (Printf.sprintf "test_keeper_tools_%d" (Random.int 100000))
+  in
+  (try Unix.mkdir dir 0o755 with
+   | Unix.Unix_error (Unix.EEXIST, _, _) -> ());
   Fun.protect
     ~finally:(fun () ->
-      (try Sys.readdir dir |> Array.iter (fun f ->
-        Sys.remove (Filename.concat dir f));
-        Unix.rmdir dir with _ -> ()))
+      try
+        Sys.readdir dir |> Array.iter (fun f -> Sys.remove (Filename.concat dir f));
+        Unix.rmdir dir
+      with
+      | _ -> ())
     (fun () ->
-      Eio_main.run @@ fun env ->
-  Fs_compat.set_fs (Eio.Stdenv.fs env);
-      let config = Coord.default_config dir in
-      let tools = Keeper_tools_oas.make_tools ~config ~meta ~ctx_snapshot () in
-      check bool "tools nonempty" true (List.length tools > 0))
+       Eio_main.run
+       @@ fun env ->
+       Fs_compat.set_fs (Eio.Stdenv.fs env);
+       let config = Coord.default_config dir in
+       let tools = Keeper_tools_oas.make_tools ~config ~meta ~ctx_snapshot () in
+       check bool "tools nonempty" true (List.length tools > 0))
+;;
 
 let test_tools_have_valid_schemas () =
   let meta = make_test_meta () in
   let ctx_snapshot = make_test_ctx () in
-  let dir = Filename.concat (Filename.get_temp_dir_name ())
-    (Printf.sprintf "test_keeper_tools_schema_%d" (Random.int 100000)) in
-  (try Unix.mkdir dir 0o755 with Unix.Unix_error (Unix.EEXIST, _, _) -> ());
+  let dir =
+    Filename.concat
+      (Filename.get_temp_dir_name ())
+      (Printf.sprintf "test_keeper_tools_schema_%d" (Random.int 100000))
+  in
+  (try Unix.mkdir dir 0o755 with
+   | Unix.Unix_error (Unix.EEXIST, _, _) -> ());
   Fun.protect
     ~finally:(fun () ->
-      (try Sys.readdir dir |> Array.iter (fun f ->
-        Sys.remove (Filename.concat dir f));
-        Unix.rmdir dir with _ -> ()))
+      try
+        Sys.readdir dir |> Array.iter (fun f -> Sys.remove (Filename.concat dir f));
+        Unix.rmdir dir
+      with
+      | _ -> ())
     (fun () ->
-      Eio_main.run @@ fun env ->
-  Fs_compat.set_fs (Eio.Stdenv.fs env);
-      let config = Coord.default_config dir in
-      let tools = Keeper_tools_oas.make_tools ~config ~meta ~ctx_snapshot () in
-      List.iter (fun (tool : Agent_sdk.Tool.t) ->
-        check bool (Printf.sprintf "tool %s has name" tool.schema.name)
-          true (String.length tool.schema.name > 0);
-        check bool (Printf.sprintf "tool %s has description" tool.schema.name)
-          true (String.length tool.schema.description > 0)
-      ) tools)
+       Eio_main.run
+       @@ fun env ->
+       Fs_compat.set_fs (Eio.Stdenv.fs env);
+       let config = Coord.default_config dir in
+       let tools = Keeper_tools_oas.make_tools ~config ~meta ~ctx_snapshot () in
+       List.iter
+         (fun (tool : Agent_sdk.Tool.t) ->
+            check
+              bool
+              (Printf.sprintf "tool %s has name" tool.schema.name)
+              true
+              (String.length tool.schema.name > 0);
+            check
+              bool
+              (Printf.sprintf "tool %s has description" tool.schema.name)
+              true
+              (String.length tool.schema.description > 0))
+         tools)
+;;
 
 let test_tool_count_matches_allowed () =
   let meta = make_test_meta () in
   let ctx_snapshot = make_test_ctx () in
-  let dir = Filename.concat (Filename.get_temp_dir_name ())
-    (Printf.sprintf "test_keeper_tools_count_%d" (Random.int 100000)) in
-  (try Unix.mkdir dir 0o755 with Unix.Unix_error (Unix.EEXIST, _, _) -> ());
+  let dir =
+    Filename.concat
+      (Filename.get_temp_dir_name ())
+      (Printf.sprintf "test_keeper_tools_count_%d" (Random.int 100000))
+  in
+  (try Unix.mkdir dir 0o755 with
+   | Unix.Unix_error (Unix.EEXIST, _, _) -> ());
   Fun.protect
     ~finally:(fun () ->
-      (try Sys.readdir dir |> Array.iter (fun f ->
-        Sys.remove (Filename.concat dir f));
-        Unix.rmdir dir with _ -> ()))
+      try
+        Sys.readdir dir |> Array.iter (fun f -> Sys.remove (Filename.concat dir f));
+        Unix.rmdir dir
+      with
+      | _ -> ())
     (fun () ->
-      Eio_main.run @@ fun env ->
-  Fs_compat.set_fs (Eio.Stdenv.fs env);
-      let config = Coord.default_config dir in
-      let tools = Keeper_tools_oas.make_tools ~config ~meta ~ctx_snapshot () in
-      let allowed = Keeper_exec_tools.keeper_allowed_tool_names meta in
-      let tool_names = List.map (fun (t : Agent_sdk.Tool.t) -> t.schema.name) tools in
-      (* RFC-0006 Phase A.2: aliased Tool.t entries (Bash/Read) carry the
+       Eio_main.run
+       @@ fun env ->
+       Fs_compat.set_fs (Eio.Stdenv.fs env);
+       let config = Coord.default_config dir in
+       let tools = Keeper_tools_oas.make_tools ~config ~meta ~ctx_snapshot () in
+       let allowed = Keeper_exec_tools.keeper_allowed_tool_names meta in
+       let tool_names = List.map (fun (t : Agent_sdk.Tool.t) -> t.schema.name) tools in
+       (* RFC-0006 Phase A.2: aliased Tool.t entries (Bash/Read) carry the
          public name on Tool.schema.name even though their handler dispatches
          the internal keeper_* name. Accept either: name in allowed OR the
          alias's internal target in allowed. *)
-      check bool "all tools are in allowed list (or are an alias)" true
-        (List.for_all
-           (fun name ->
-              List.mem name allowed
-              || (match Keeper_tool_alias.to_internal name with
-                  | Some internal -> List.mem internal allowed
-                  | None -> false))
-           tool_names))
+       check
+         bool
+         "all tools are in allowed list (or are an alias)"
+         true
+         (List.for_all
+            (fun name ->
+               List.mem name allowed
+               ||
+               match Keeper_tool_alias.to_internal name with
+               | Some internal -> List.mem internal allowed
+               | None -> false)
+            tool_names))
+;;
 
 let find_tool name tools =
   List.find (fun (tool : Tool.t) -> String.equal tool.schema.name name) tools
+;;
 
 let dummy_schedule : Agent_sdk.Hooks.tool_schedule =
   { planned_index = 0
@@ -112,27 +161,31 @@ let dummy_schedule : Agent_sdk.Hooks.tool_schedule =
   ; concurrency_class = "default"
   ; batch_kind = "sequential"
   }
+;;
 
 let string_contains ~sub text =
   let text_len = String.length text in
   let sub_len = String.length sub in
   let rec loop idx =
-    if idx + sub_len > text_len then false
-    else if String.sub text idx sub_len = sub then true
+    if idx + sub_len > text_len
+    then false
+    else if String.sub text idx sub_len = sub
+    then true
     else loop (idx + 1)
   in
   sub_len = 0 || loop 0
+;;
 
 let rec rm_rf path =
   match Unix.lstat path with
   | exception Unix.Unix_error (Unix.ENOENT, _, _) -> ()
   | stat ->
-      match stat.Unix.st_kind with
-      | Unix.S_DIR ->
-          Sys.readdir path
-          |> Array.iter (fun name -> rm_rf (Filename.concat path name));
-          Unix.rmdir path
-      | _ -> Sys.remove path
+    (match stat.Unix.st_kind with
+     | Unix.S_DIR ->
+       Sys.readdir path |> Array.iter (fun name -> rm_rf (Filename.concat path name));
+       Unix.rmdir path
+     | _ -> Sys.remove path)
+;;
 
 let test_tool_side_effect_failures_are_observed () =
   let meta = make_test_meta ~name:"test-keeper-side-effects" () in
@@ -143,49 +196,61 @@ let test_tool_side_effect_failures_are_observed () =
   Fun.protect
     ~finally:(fun () -> rm_rf dir)
     (fun () ->
-      Eio_main.run @@ fun env ->
-      Fs_compat.set_fs (Eio.Stdenv.fs env);
-      let config = Coord.default_config dir in
-      let decision_path =
-        Keeper_types_support.keeper_decision_log_path config meta.name
-      in
-      Fs_compat.mkdir_p (Filename.dirname decision_path);
-      Unix.mkdir decision_path 0o755;
-      let tools = Keeper_tools_oas.make_tools ~config ~meta ~ctx_snapshot () in
-      let tool = find_tool "keeper_fs_read" tools in
-      let keeper_labels = [("keeper", meta.name)] in
-      let sse_before =
-        Prometheus.metric_value_or_zero
-          Masc_mcp.Keeper_metrics.metric_keeper_sse_broadcast_failures
-          ~labels:keeper_labels ()
-      in
-      let decision_before =
-        Prometheus.metric_value_or_zero
-          Masc_mcp.Keeper_metrics.metric_keeper_decision_audit_flush_failures
-          ~labels:keeper_labels ()
-      in
-      let original_hook = Atomic.get Sse.buffer_commit_test_hook in
-      Fun.protect
-        ~finally:(fun () ->
-          Atomic.set Sse.buffer_commit_test_hook original_hook)
-        (fun () ->
-          Atomic.set Sse.buffer_commit_test_hook
-            (Some (fun () -> failwith "forced keeper tool SSE failure"));
-          match Tool.execute tool
-                  (`Assoc [("path", `String "missing-side-effect-file.txt")])
-          with
-          | Error _ -> ()
-          | Ok _ -> fail "missing file should be surfaced as tool error");
-      check (float 0.001) "SSE failure metric incremented"
-        (sse_before +. 1.0)
-        (Prometheus.metric_value_or_zero
+       Eio_main.run
+       @@ fun env ->
+       Fs_compat.set_fs (Eio.Stdenv.fs env);
+       let config = Coord.default_config dir in
+       let decision_path =
+         Keeper_types_support.keeper_decision_log_path config meta.name
+       in
+       Fs_compat.mkdir_p (Filename.dirname decision_path);
+       Unix.mkdir decision_path 0o755;
+       let tools = Keeper_tools_oas.make_tools ~config ~meta ~ctx_snapshot () in
+       let tool = find_tool "keeper_fs_read" tools in
+       let keeper_labels = [ "keeper", meta.name ] in
+       let sse_before =
+         Prometheus.metric_value_or_zero
            Masc_mcp.Keeper_metrics.metric_keeper_sse_broadcast_failures
-           ~labels:keeper_labels ());
-      check (float 0.001) "decision-log failure metric incremented"
-        (decision_before +. 1.0)
-        (Prometheus.metric_value_or_zero
+           ~labels:keeper_labels
+           ()
+       in
+       let decision_before =
+         Prometheus.metric_value_or_zero
            Masc_mcp.Keeper_metrics.metric_keeper_decision_audit_flush_failures
-           ~labels:keeper_labels ()))
+           ~labels:keeper_labels
+           ()
+       in
+       let original_hook = Atomic.get Sse.buffer_commit_test_hook in
+       Fun.protect
+         ~finally:(fun () -> Atomic.set Sse.buffer_commit_test_hook original_hook)
+         (fun () ->
+            Atomic.set
+              Sse.buffer_commit_test_hook
+              (Some (fun () -> failwith "forced keeper tool SSE failure"));
+            match
+              Tool.execute
+                tool
+                (`Assoc [ "path", `String "missing-side-effect-file.txt" ])
+            with
+            | Error _ -> ()
+            | Ok _ -> fail "missing file should be surfaced as tool error");
+       check
+         (float 0.001)
+         "SSE failure metric incremented"
+         (sse_before +. 1.0)
+         (Prometheus.metric_value_or_zero
+            Masc_mcp.Keeper_metrics.metric_keeper_sse_broadcast_failures
+            ~labels:keeper_labels
+            ());
+       check
+         (float 0.001)
+         "decision-log failure metric incremented"
+         (decision_before +. 1.0)
+         (Prometheus.metric_value_or_zero
+            Masc_mcp.Keeper_metrics.metric_keeper_decision_audit_flush_failures
+            ~labels:keeper_labels
+            ()))
+;;
 
 let test_handler_persists_tool_call_io_without_post_hook () =
   let meta = make_test_meta ~name:"test-keeper-direct-tool-io" () in
@@ -198,31 +263,37 @@ let test_handler_persists_tool_call_io_without_post_hook () =
       Keeper_tool_call_log.reset_for_testing ();
       rm_rf dir)
     (fun () ->
-      Eio_main.run @@ fun env ->
-      Fs_compat.set_fs (Eio.Stdenv.fs env);
-      let config = Coord.default_config dir in
-      Keeper_tool_call_log.reset_for_testing ();
-      Keeper_tool_call_log.init ~base_path:dir ();
-      Keeper_tool_call_log.set_turn_context
-        ~keeper_name:meta.name
-        ~trace_id:"trace-direct-tool-io"
-        ~turn:1
-        ();
-      let tools = Keeper_tools_oas.make_tools ~config ~meta ~ctx_snapshot () in
-      let tool = find_tool "keeper_time_now" tools in
-      (match Tool.execute tool (`Assoc []) with
-       | Ok _ -> ()
-       | Error { Agent_sdk.Types.message; _ } ->
-           fail ("keeper_time_now should succeed: " ^ message));
-      let entries =
-        Keeper_tool_call_log.read_recent ~keeper_name:meta.name ~n:10 ()
-      in
-      check int "handler wrote one tool_call row" 1 (List.length entries);
-      let row = List.hd entries in
-      check string "tool" "keeper_time_now"
-        Yojson.Safe.Util.(row |> member "tool" |> to_string);
-      check string "trace id" "trace-direct-tool-io"
-        Yojson.Safe.Util.(row |> member "trace_id" |> to_string))
+       Eio_main.run
+       @@ fun env ->
+       Fs_compat.set_fs (Eio.Stdenv.fs env);
+       let config = Coord.default_config dir in
+       Keeper_tool_call_log.reset_for_testing ();
+       Keeper_tool_call_log.init ~base_path:dir ();
+       Keeper_tool_call_log.set_turn_context
+         ~keeper_name:meta.name
+         ~trace_id:"trace-direct-tool-io"
+         ~turn:1
+         ();
+       let tools = Keeper_tools_oas.make_tools ~config ~meta ~ctx_snapshot () in
+       let tool = find_tool "keeper_time_now" tools in
+       (match Tool.execute tool (`Assoc []) with
+        | Ok _ -> ()
+        | Error { Agent_sdk.Types.message; _ } ->
+          fail ("keeper_time_now should succeed: " ^ message));
+       let entries = Keeper_tool_call_log.read_recent ~keeper_name:meta.name ~n:10 () in
+       check int "handler wrote one tool_call row" 1 (List.length entries);
+       let row = List.hd entries in
+       check
+         string
+         "tool"
+         "keeper_time_now"
+         Yojson.Safe.Util.(row |> member "tool" |> to_string);
+       check
+         string
+         "trace id"
+         "trace-direct-tool-io"
+         Yojson.Safe.Util.(row |> member "trace_id" |> to_string))
+;;
 
 let test_post_hook_does_not_duplicate_handler_logged_io () =
   let meta = make_test_meta ~name:"test-keeper-direct-tool-dedupe" () in
@@ -236,46 +307,43 @@ let test_post_hook_does_not_duplicate_handler_logged_io () =
       Keeper_tool_call_log.reset_for_testing ();
       rm_rf dir)
     (fun () ->
-      Eio_main.run @@ fun env ->
-      Fs_compat.set_fs (Eio.Stdenv.fs env);
-      let config = Coord.default_config dir in
-      Keeper_tool_call_log.reset_for_testing ();
-      Keeper_tool_call_log.init ~base_path:dir ();
-      let tools = Keeper_tools_oas.make_tools ~config ~meta ~ctx_snapshot () in
-      let tool = find_tool "keeper_time_now" tools in
-      let output_text =
-        match Tool.execute tool (`Assoc []) with
-        | Ok { Agent_sdk.Types.content; _ } -> content
-        | Error { Agent_sdk.Types.message; _ } ->
-            fail ("keeper_time_now should succeed: " ^ message)
-      in
-      let hooks =
-        Keeper_hooks_oas.make_hooks ~config ~meta_ref ~generation:1 ()
-      in
-      let post_tool_use =
-        match hooks.Agent_sdk.Hooks.post_tool_use with
-        | Some hook -> hook
-        | None -> fail "post_tool_use hook missing"
-      in
-      ignore
-        (post_tool_use
-           (Agent_sdk.Hooks.PostToolUse
-              { tool_use_id = "tu-direct-dedupe"
-              ; tool_name = "keeper_time_now"
-              ; input = `Assoc []
-              ; output =
-                  Ok
-                    ({ Agent_sdk.Types.content = output_text }
-                     : Agent_sdk.Types.tool_output)
-              ; result_bytes = String.length output_text
-              ; duration_ms = 2.0
-              ; schedule = dummy_schedule
-              }));
-      let entries =
-        Keeper_tool_call_log.read_recent ~keeper_name:meta.name ~n:10 ()
-      in
-      check int "post hook did not duplicate handler row" 1
-        (List.length entries))
+       Eio_main.run
+       @@ fun env ->
+       Fs_compat.set_fs (Eio.Stdenv.fs env);
+       let config = Coord.default_config dir in
+       Keeper_tool_call_log.reset_for_testing ();
+       Keeper_tool_call_log.init ~base_path:dir ();
+       let tools = Keeper_tools_oas.make_tools ~config ~meta ~ctx_snapshot () in
+       let tool = find_tool "keeper_time_now" tools in
+       let output_text =
+         match Tool.execute tool (`Assoc []) with
+         | Ok { Agent_sdk.Types.content; _ } -> content
+         | Error { Agent_sdk.Types.message; _ } ->
+           fail ("keeper_time_now should succeed: " ^ message)
+       in
+       let hooks = Keeper_hooks_oas.make_hooks ~config ~meta_ref ~generation:1 () in
+       let post_tool_use =
+         match hooks.Agent_sdk.Hooks.post_tool_use with
+         | Some hook -> hook
+         | None -> fail "post_tool_use hook missing"
+       in
+       ignore
+         (post_tool_use
+            (Agent_sdk.Hooks.PostToolUse
+               { tool_use_id = "tu-direct-dedupe"
+               ; tool_name = "keeper_time_now"
+               ; input = `Assoc []
+               ; output =
+                   Ok
+                     ({ Agent_sdk.Types.content = output_text }
+                      : Agent_sdk.Types.tool_output)
+               ; result_bytes = String.length output_text
+               ; duration_ms = 2.0
+               ; schedule = dummy_schedule
+               }));
+       let entries = Keeper_tool_call_log.read_recent ~keeper_name:meta.name ~n:10 () in
+       check int "post hook did not duplicate handler row" 1 (List.length entries))
+;;
 
 let test_oas_wrapper_records_keeper_internal_tool_call () =
   let meta = make_test_meta ~name:"test-keeper-tool-registry" () in
@@ -286,305 +354,389 @@ let test_oas_wrapper_records_keeper_internal_tool_call () =
   Fun.protect
     ~finally:(fun () -> rm_rf dir)
     (fun () ->
-      Eio_main.run @@ fun env ->
-      Fs_compat.set_fs (Eio.Stdenv.fs env);
-      Tool_registry.reset ();
-      let config = Coord.default_config dir in
-      let bundle =
-        Keeper_tools_oas.make_tool_bundle ~config ~meta ~ctx_snapshot ()
-      in
-      Fun.protect
-        ~finally:(fun () ->
-          bundle.cleanup ();
-          Tool_registry.reset ())
-        (fun () ->
-          let tool = find_tool "keeper_stay_silent" bundle.tools in
-          match Tool.execute tool (`Assoc []) with
-          | Error { Agent_sdk.Types.message; _ } ->
+       Eio_main.run
+       @@ fun env ->
+       Fs_compat.set_fs (Eio.Stdenv.fs env);
+       Tool_registry.reset ();
+       let config = Coord.default_config dir in
+       let bundle = Keeper_tools_oas.make_tool_bundle ~config ~meta ~ctx_snapshot () in
+       Fun.protect
+         ~finally:(fun () ->
+           bundle.cleanup ();
+           Tool_registry.reset ())
+         (fun () ->
+            let tool = find_tool "keeper_stay_silent" bundle.tools in
+            match Tool.execute tool (`Assoc []) with
+            | Error { Agent_sdk.Types.message; _ } ->
               fail (Printf.sprintf "expected tool success, got error: %s" message)
-          | Ok _ ->
+            | Ok _ ->
               let stats = Tool_registry.get_stats () in
               let entry = List.assoc "keeper_stay_silent" stats in
               check int "call_count" 1 (Atomic.get entry.call_count);
               check int "success_count" 1 (Atomic.get entry.success_count);
-              check int "keeper_internal_count" 1
-                (Atomic.get entry.keeper_internal_count)))
+              check int "keeper_internal_count" 1 (Atomic.get entry.keeper_internal_count)))
+;;
 
 let is_guardrail_message message =
-  string_contains
-    ~sub:"failed 3 times in a row with the same arguments"
-    message
+  string_contains ~sub:"failed 3 times in a row with the same arguments" message
+;;
 
 let test_error_json_is_returned_as_tool_error () =
   let meta = make_test_meta () in
   let ctx_snapshot = make_test_ctx () in
-  let dir = Filename.concat (Filename.get_temp_dir_name ())
-    (Printf.sprintf "test_keeper_tools_error_%d" (Random.int 100000)) in
-  (try Unix.mkdir dir 0o755 with Unix.Unix_error (Unix.EEXIST, _, _) -> ());
+  let dir =
+    Filename.concat
+      (Filename.get_temp_dir_name ())
+      (Printf.sprintf "test_keeper_tools_error_%d" (Random.int 100000))
+  in
+  (try Unix.mkdir dir 0o755 with
+   | Unix.Unix_error (Unix.EEXIST, _, _) -> ());
   Fun.protect
     ~finally:(fun () ->
-      (try Sys.readdir dir |> Array.iter (fun f ->
-        Sys.remove (Filename.concat dir f));
-        Unix.rmdir dir with _ -> ()))
-    (fun () ->
-      Eio_main.run @@ fun env ->
-  Fs_compat.set_fs (Eio.Stdenv.fs env);
-      let config = Coord.default_config dir in
-      let tools = Keeper_tools_oas.make_tools ~config ~meta ~ctx_snapshot () in
-      let tool = find_tool "keeper_fs_read" tools in
-      match Tool.execute tool
-              (`Assoc [("path", `String "missing-file-for-keeper-tools-oas.txt")])
+      try
+        Sys.readdir dir |> Array.iter (fun f -> Sys.remove (Filename.concat dir f));
+        Unix.rmdir dir
       with
-      | Error { Agent_sdk.Types.message; _ } ->
-          let json = Yojson.Safe.from_string message in
-          (* After normalization, error results follow {"ok":false,"error":"...","detail":{...}} *)
-          check bool "ok is false" false
-            (Yojson.Safe.Util.(member "ok" json |> to_bool));
-          check bool "error field present" true
-            (Option.is_some (Safe_ops.json_string_opt "error" json));
-          let detail = Yojson.Safe.Util.member "detail" json in
-          check bool "detail preserves path" true
-            (Option.is_some (Safe_ops.json_string_opt "path" detail))
-      | Ok _ -> fail "missing file should be surfaced as tool error")
+      | _ -> ())
+    (fun () ->
+       Eio_main.run
+       @@ fun env ->
+       Fs_compat.set_fs (Eio.Stdenv.fs env);
+       let config = Coord.default_config dir in
+       let tools = Keeper_tools_oas.make_tools ~config ~meta ~ctx_snapshot () in
+       let tool = find_tool "keeper_fs_read" tools in
+       match
+         Tool.execute
+           tool
+           (`Assoc [ "path", `String "missing-file-for-keeper-tools-oas.txt" ])
+       with
+       | Error { Agent_sdk.Types.message; _ } ->
+         let json = Yojson.Safe.from_string message in
+         (* After normalization, error results follow {"ok":false,"error":"...","detail":{...}} *)
+         check bool "ok is false" false Yojson.Safe.Util.(member "ok" json |> to_bool);
+         check
+           bool
+           "error field present"
+           true
+           (Option.is_some (Safe_ops.json_string_opt "error" json));
+         let detail = Yojson.Safe.Util.member "detail" json in
+         check
+           bool
+           "detail preserves path"
+           true
+           (Option.is_some (Safe_ops.json_string_opt "path" detail))
+       | Ok _ -> fail "missing file should be surfaced as tool error")
+;;
 
 let test_oas_handler_rejects_missing_required_args () =
   let meta = make_test_meta () in
   let ctx_snapshot = make_test_ctx () in
-  let dir = Filename.concat (Filename.get_temp_dir_name ())
-    (Printf.sprintf "test_keeper_tools_validate_%d" (Random.int 100000)) in
-  (try Unix.mkdir dir 0o755 with Unix.Unix_error (Unix.EEXIST, _, _) -> ());
+  let dir =
+    Filename.concat
+      (Filename.get_temp_dir_name ())
+      (Printf.sprintf "test_keeper_tools_validate_%d" (Random.int 100000))
+  in
+  (try Unix.mkdir dir 0o755 with
+   | Unix.Unix_error (Unix.EEXIST, _, _) -> ());
   Fun.protect
     ~finally:(fun () ->
-      (try Sys.readdir dir |> Array.iter (fun f ->
-        Sys.remove (Filename.concat dir f));
-        Unix.rmdir dir with _ -> ()))
+      try
+        Sys.readdir dir |> Array.iter (fun f -> Sys.remove (Filename.concat dir f));
+        Unix.rmdir dir
+      with
+      | _ -> ())
     (fun () ->
-      Eio_main.run @@ fun env ->
-      Fs_compat.set_fs (Eio.Stdenv.fs env);
-      let config = Coord.default_config dir in
-      let tools = Keeper_tools_oas.make_tools ~config ~meta ~ctx_snapshot () in
-      let tool = find_tool "keeper_fs_read" tools in
-      match Tool.execute tool (`Assoc []) with
-      | Error { Agent_sdk.Types.message; _ } ->
-          let json = Yojson.Safe.from_string message in
-          check bool "ok is false" false
-            (Yojson.Safe.Util.(member "ok" json |> to_bool));
-          check bool "error mentions missing path" true
-            (string_contains ~sub:"path" message);
-          let detail = Yojson.Safe.Util.member "detail" json in
-          check string "validation source" "oas_tool_middleware"
-            Yojson.Safe.Util.(detail |> member "validation" |> to_string)
-      | Ok _ -> fail "missing required path should be rejected by OAS validation")
+       Eio_main.run
+       @@ fun env ->
+       Fs_compat.set_fs (Eio.Stdenv.fs env);
+       let config = Coord.default_config dir in
+       let tools = Keeper_tools_oas.make_tools ~config ~meta ~ctx_snapshot () in
+       let tool = find_tool "keeper_fs_read" tools in
+       match Tool.execute tool (`Assoc []) with
+       | Error { Agent_sdk.Types.message; _ } ->
+         let json = Yojson.Safe.from_string message in
+         check bool "ok is false" false Yojson.Safe.Util.(member "ok" json |> to_bool);
+         check
+           bool
+           "error mentions missing path"
+           true
+           (string_contains ~sub:"path" message);
+         let detail = Yojson.Safe.Util.member "detail" json in
+         check
+           string
+           "validation source"
+           "oas_tool_middleware"
+           Yojson.Safe.Util.(detail |> member "validation" |> to_string)
+       | Ok _ -> fail "missing required path should be rejected by OAS validation")
+;;
 
 let latest_log_seq () =
   match Mlog.Ring.recent ~limit:1 () with
   | (entry : Mlog.Ring.entry) :: _ -> entry.seq
   | [] -> -1
+;;
 
 let test_error_result_logs_at_error_level () =
   let meta = make_test_meta () in
   let ctx_snapshot = make_test_ctx () in
-  let dir = Filename.concat (Filename.get_temp_dir_name ())
-    (Printf.sprintf "test_keeper_tools_log_level_%d" (Random.int 100000)) in
-  (try Unix.mkdir dir 0o755 with Unix.Unix_error (Unix.EEXIST, _, _) -> ());
+  let dir =
+    Filename.concat
+      (Filename.get_temp_dir_name ())
+      (Printf.sprintf "test_keeper_tools_log_level_%d" (Random.int 100000))
+  in
+  (try Unix.mkdir dir 0o755 with
+   | Unix.Unix_error (Unix.EEXIST, _, _) -> ());
   Fun.protect
     ~finally:(fun () ->
-      (try Sys.readdir dir |> Array.iter (fun f ->
-        Sys.remove (Filename.concat dir f));
-        Unix.rmdir dir with _ -> ()))
+      try
+        Sys.readdir dir |> Array.iter (fun f -> Sys.remove (Filename.concat dir f));
+        Unix.rmdir dir
+      with
+      | _ -> ())
     (fun () ->
-      Eio_main.run @@ fun env ->
-      Fs_compat.set_fs (Eio.Stdenv.fs env);
-      let config = Coord.default_config dir in
-      let tools = Keeper_tools_oas.make_tools ~config ~meta ~ctx_snapshot () in
-      let tool = find_tool "keeper_fs_read" tools in
-      let baseline = latest_log_seq () in
-      (match Tool.execute tool
-               (`Assoc [("path", `String "missing-file-for-keeper-tools-oas.txt")])
-       with
-       | Error _ -> ()
-       | Ok _ -> fail "missing file should be surfaced as tool error");
-      let entry =
-        Mlog.Ring.recent ~limit:50 ~module_filter:"Keeper" ~since_seq:baseline ()
-        |> List.find_opt (fun (entry : Mlog.Ring.entry) ->
-          string_contains ~sub:"returned error result" entry.message)
-      in
-      match entry with
-      | None -> fail "expected keeper error log for failing tool result"
-      | Some (entry : Mlog.Ring.entry) ->
-          check string "failing tool result logs at ERROR" "ERROR"
-            entry.normalized_level)
+       Eio_main.run
+       @@ fun env ->
+       Fs_compat.set_fs (Eio.Stdenv.fs env);
+       let config = Coord.default_config dir in
+       let tools = Keeper_tools_oas.make_tools ~config ~meta ~ctx_snapshot () in
+       let tool = find_tool "keeper_fs_read" tools in
+       let baseline = latest_log_seq () in
+       (match
+          Tool.execute
+            tool
+            (`Assoc [ "path", `String "missing-file-for-keeper-tools-oas.txt" ])
+        with
+        | Error _ -> ()
+        | Ok _ -> fail "missing file should be surfaced as tool error");
+       let entry =
+         Mlog.Ring.recent ~limit:50 ~module_filter:"Keeper" ~since_seq:baseline ()
+         |> List.find_opt (fun (entry : Mlog.Ring.entry) ->
+           string_contains ~sub:"returned error result" entry.message)
+       in
+       match entry with
+       | None -> fail "expected keeper error log for failing tool result"
+       | Some (entry : Mlog.Ring.entry) ->
+         check string "failing tool result logs at ERROR" "ERROR" entry.normalized_level)
+;;
 
 let test_missing_file_error_includes_directory_suggestions () =
   let meta = make_test_meta () in
   let ctx_snapshot = make_test_ctx () in
-  let dir = Filename.concat (Filename.get_temp_dir_name ())
-    (Printf.sprintf "test_keeper_tools_suggest_%d" (Random.int 100000)) in
-  (try Unix.mkdir dir 0o755 with Unix.Unix_error (Unix.EEXIST, _, _) -> ());
+  let dir =
+    Filename.concat
+      (Filename.get_temp_dir_name ())
+      (Printf.sprintf "test_keeper_tools_suggest_%d" (Random.int 100000))
+  in
+  (try Unix.mkdir dir 0o755 with
+   | Unix.Unix_error (Unix.EEXIST, _, _) -> ());
   Fun.protect
     ~finally:(fun () ->
-      (try Sys.readdir dir |> Array.iter (fun f ->
-        Sys.remove (Filename.concat dir f));
-        Unix.rmdir dir with _ -> ()))
+      try
+        Sys.readdir dir |> Array.iter (fun f -> Sys.remove (Filename.concat dir f));
+        Unix.rmdir dir
+      with
+      | _ -> ())
     (fun () ->
-      Eio_main.run @@ fun env ->
-      Fs_compat.set_fs (Eio.Stdenv.fs env);
-      let config = Coord.default_config dir in
-      let pg_dir = Filename.concat
-        (Keeper_alerting_path.project_root_of_config config)
-        (Keeper_alerting_path.playground_path_of_keeper meta.name) in
-      Fs_compat.mkdir_p pg_dir;
-      let existing = Filename.concat pg_dir "known.txt" in
-      Out_channel.with_open_text existing
-        (fun oc -> Out_channel.output_string oc "known");
-      let tools = Keeper_tools_oas.make_tools ~config ~meta ~ctx_snapshot () in
-      let tool = find_tool "keeper_fs_read" tools in
-      match Tool.execute tool (`Assoc [("path", `String "missing.txt")]) with
-      | Error { Agent_sdk.Types.message; _ } ->
-          let json = Yojson.Safe.from_string message in
-          let detail = Yojson.Safe.Util.member "detail" json in
-          let suggestions =
-            match Yojson.Safe.Util.member "suggested_entries" detail with
-            | `List entries ->
-              List.filter_map
-                (function `String value -> Some value | _ -> None)
-                entries
-            | _ -> []
-          in
-          check bool "known file suggested" true (List.mem "known.txt" suggestions)
-      | Ok _ -> fail "missing file should be surfaced as tool error")
+       Eio_main.run
+       @@ fun env ->
+       Fs_compat.set_fs (Eio.Stdenv.fs env);
+       let config = Coord.default_config dir in
+       let pg_dir =
+         Filename.concat
+           (Keeper_alerting_path.project_root_of_config config)
+           (Keeper_alerting_path.playground_path_of_keeper meta.name)
+       in
+       Fs_compat.mkdir_p pg_dir;
+       let existing = Filename.concat pg_dir "known.txt" in
+       Out_channel.with_open_text existing (fun oc ->
+         Out_channel.output_string oc "known");
+       let tools = Keeper_tools_oas.make_tools ~config ~meta ~ctx_snapshot () in
+       let tool = find_tool "keeper_fs_read" tools in
+       match Tool.execute tool (`Assoc [ "path", `String "missing.txt" ]) with
+       | Error { Agent_sdk.Types.message; _ } ->
+         let json = Yojson.Safe.from_string message in
+         let detail = Yojson.Safe.Util.member "detail" json in
+         let suggestions =
+           match Yojson.Safe.Util.member "suggested_entries" detail with
+           | `List entries ->
+             List.filter_map
+               (function
+                 | `String value -> Some value
+                 | _ -> None)
+               entries
+           | _ -> []
+         in
+         check bool "known file suggested" true (List.mem "known.txt" suggestions)
+       | Ok _ -> fail "missing file should be surfaced as tool error")
+;;
 
 let test_repeated_error_results_are_blocked () =
   let meta = make_test_meta () in
   let ctx_snapshot = make_test_ctx () in
-  let dir = Filename.concat (Filename.get_temp_dir_name ())
-    (Printf.sprintf "test_keeper_tools_guard_%d" (Random.int 100000)) in
-  (try Unix.mkdir dir 0o755 with Unix.Unix_error (Unix.EEXIST, _, _) -> ());
+  let dir =
+    Filename.concat
+      (Filename.get_temp_dir_name ())
+      (Printf.sprintf "test_keeper_tools_guard_%d" (Random.int 100000))
+  in
+  (try Unix.mkdir dir 0o755 with
+   | Unix.Unix_error (Unix.EEXIST, _, _) -> ());
   Fun.protect
     ~finally:(fun () ->
-      (try Sys.readdir dir |> Array.iter (fun f ->
-        Sys.remove (Filename.concat dir f));
-        Unix.rmdir dir with _ -> ()))
+      try
+        Sys.readdir dir |> Array.iter (fun f -> Sys.remove (Filename.concat dir f));
+        Unix.rmdir dir
+      with
+      | _ -> ())
     (fun () ->
-      Eio_main.run @@ fun env ->
-  Fs_compat.set_fs (Eio.Stdenv.fs env);
-      let config = Coord.default_config dir in
-      let tools = Keeper_tools_oas.make_tools ~config ~meta ~ctx_snapshot () in
-      let tool = find_tool "keeper_fs_read" tools in
-      let args =
-        `Assoc [("path", `String "missing-file-for-keeper-tools-oas.txt")]
-      in
-      for _ = 1 to Keeper_tools_oas.max_consecutive_failures do
-        match Tool.execute tool args with
-        | Error _ -> ()
-        | Ok _ -> fail "missing file should be counted as a failure"
-      done;
-      match Tool.execute tool args with
-      | Error { Agent_sdk.Types.message; _ } ->
-          check bool "guardrail blocks repeated failures" true
-            (is_guardrail_message message)
-      | Ok _ -> fail "guardrail should block the repeated failure")
+       Eio_main.run
+       @@ fun env ->
+       Fs_compat.set_fs (Eio.Stdenv.fs env);
+       let config = Coord.default_config dir in
+       let tools = Keeper_tools_oas.make_tools ~config ~meta ~ctx_snapshot () in
+       let tool = find_tool "keeper_fs_read" tools in
+       let args = `Assoc [ "path", `String "missing-file-for-keeper-tools-oas.txt" ] in
+       for _ = 1 to Keeper_tools_oas.max_consecutive_failures do
+         match Tool.execute tool args with
+         | Error _ -> ()
+         | Ok _ -> fail "missing file should be counted as a failure"
+       done;
+       match Tool.execute tool args with
+       | Error { Agent_sdk.Types.message; _ } ->
+         check
+           bool
+           "guardrail blocks repeated failures"
+           true
+           (is_guardrail_message message)
+       | Ok _ -> fail "guardrail should block the repeated failure")
+;;
 
 let test_failure_count_resets_after_success () =
   let meta = make_test_meta () in
   let ctx_snapshot = make_test_ctx () in
-  let dir = Filename.concat (Filename.get_temp_dir_name ())
-    (Printf.sprintf "test_keeper_tools_reset_%d" (Random.int 100000)) in
-  (try Unix.mkdir dir 0o755 with Unix.Unix_error (Unix.EEXIST, _, _) -> ());
+  let dir =
+    Filename.concat
+      (Filename.get_temp_dir_name ())
+      (Printf.sprintf "test_keeper_tools_reset_%d" (Random.int 100000))
+  in
+  (try Unix.mkdir dir 0o755 with
+   | Unix.Unix_error (Unix.EEXIST, _, _) -> ());
   Fun.protect
     ~finally:(fun () ->
       let reset_path = Filename.concat dir "reset-after-success.txt" in
-      (try Sys.remove reset_path with _ -> ());
-      (try Sys.readdir dir |> Array.iter (fun f ->
-        Sys.remove (Filename.concat dir f));
-        Unix.rmdir dir with _ -> ()))
+      (try Sys.remove reset_path with
+       | _ -> ());
+      try
+        Sys.readdir dir |> Array.iter (fun f -> Sys.remove (Filename.concat dir f));
+        Unix.rmdir dir
+      with
+      | _ -> ())
     (fun () ->
-      Eio_main.run @@ fun env ->
-  Fs_compat.set_fs (Eio.Stdenv.fs env);
-      let config = Coord.default_config dir in
-      let pg_dir = Filename.concat
-        (Keeper_alerting_path.project_root_of_config config)
-        (Keeper_alerting_path.playground_path_of_keeper meta.name) in
-      Fs_compat.mkdir_p pg_dir;
-      let tools = Keeper_tools_oas.make_tools ~config ~meta ~ctx_snapshot () in
-      let tool = find_tool "keeper_fs_read" tools in
-      let path = "reset-after-success.txt" in
-      let args = `Assoc [("path", `String path)] in
-      for _ = 1 to Keeper_tools_oas.max_consecutive_failures - 1 do
-        match Tool.execute tool args with
-        | Error _ -> ()
-        | Ok _ -> fail "missing file should fail before reset"
-      done;
-      let abs_path = Filename.concat pg_dir path in
-      Out_channel.with_open_text abs_path
-        (fun oc -> Out_channel.output_string oc "ok");
-      (match Tool.execute tool args with
-       | Ok _ -> ()
-       | Error _ -> fail "existing file should reset failure count");
-      Sys.remove abs_path;
-      for _ = 1 to Keeper_tools_oas.max_consecutive_failures do
-        match Tool.execute tool args with
-        | Error { Agent_sdk.Types.message; _ } when is_guardrail_message message ->
-            fail "failure count should have reset after success"
-        | Error _ -> ()
-        | Ok _ -> fail "missing file should fail after removing reset file"
-      done;
-      match Tool.execute tool args with
-      | Error { Agent_sdk.Types.message; _ } ->
-          check bool "guardrail triggers only after fresh streak" true
-            (is_guardrail_message message)
-      | Ok _ -> fail "guardrail should eventually re-trigger after reset")
+       Eio_main.run
+       @@ fun env ->
+       Fs_compat.set_fs (Eio.Stdenv.fs env);
+       let config = Coord.default_config dir in
+       let pg_dir =
+         Filename.concat
+           (Keeper_alerting_path.project_root_of_config config)
+           (Keeper_alerting_path.playground_path_of_keeper meta.name)
+       in
+       Fs_compat.mkdir_p pg_dir;
+       let tools = Keeper_tools_oas.make_tools ~config ~meta ~ctx_snapshot () in
+       let tool = find_tool "keeper_fs_read" tools in
+       let path = "reset-after-success.txt" in
+       let args = `Assoc [ "path", `String path ] in
+       for _ = 1 to Keeper_tools_oas.max_consecutive_failures - 1 do
+         match Tool.execute tool args with
+         | Error _ -> ()
+         | Ok _ -> fail "missing file should fail before reset"
+       done;
+       let abs_path = Filename.concat pg_dir path in
+       Out_channel.with_open_text abs_path (fun oc -> Out_channel.output_string oc "ok");
+       (match Tool.execute tool args with
+        | Ok _ -> ()
+        | Error _ -> fail "existing file should reset failure count");
+       Sys.remove abs_path;
+       for _ = 1 to Keeper_tools_oas.max_consecutive_failures do
+         match Tool.execute tool args with
+         | Error { Agent_sdk.Types.message; _ } when is_guardrail_message message ->
+           fail "failure count should have reset after success"
+         | Error _ -> ()
+         | Ok _ -> fail "missing file should fail after removing reset file"
+       done;
+       match Tool.execute tool args with
+       | Error { Agent_sdk.Types.message; _ } ->
+         check
+           bool
+           "guardrail triggers only after fresh streak"
+           true
+           (is_guardrail_message message)
+       | Ok _ -> fail "guardrail should eventually re-trigger after reset")
+;;
 
 let test_failure_tracking_is_independent_per_args () =
   let meta = make_test_meta () in
   let ctx_snapshot = make_test_ctx () in
-  let dir = Filename.concat (Filename.get_temp_dir_name ())
-    (Printf.sprintf "test_keeper_tools_independent_%d" (Random.int 100000)) in
-  (try Unix.mkdir dir 0o755 with Unix.Unix_error (Unix.EEXIST, _, _) -> ());
+  let dir =
+    Filename.concat
+      (Filename.get_temp_dir_name ())
+      (Printf.sprintf "test_keeper_tools_independent_%d" (Random.int 100000))
+  in
+  (try Unix.mkdir dir 0o755 with
+   | Unix.Unix_error (Unix.EEXIST, _, _) -> ());
   Fun.protect
     ~finally:(fun () ->
-      (try Sys.readdir dir |> Array.iter (fun f ->
-        Sys.remove (Filename.concat dir f));
-        Unix.rmdir dir with _ -> ()))
+      try
+        Sys.readdir dir |> Array.iter (fun f -> Sys.remove (Filename.concat dir f));
+        Unix.rmdir dir
+      with
+      | _ -> ())
     (fun () ->
-      Eio_main.run @@ fun env ->
-  Fs_compat.set_fs (Eio.Stdenv.fs env);
-      let config = Coord.default_config dir in
-      let tools = Keeper_tools_oas.make_tools ~config ~meta ~ctx_snapshot () in
-      let tool = find_tool "keeper_fs_read" tools in
-      let args_a = `Assoc [("path", `String "missing-a.txt")] in
-      let args_b = `Assoc [("path", `String "missing-b.txt")] in
-      for _ = 1 to Keeper_tools_oas.max_consecutive_failures do
-        match Tool.execute tool args_a with
-        | Error _ -> ()
-        | Ok _ -> fail "first path should fail before guardrail"
-      done;
-      (match Tool.execute tool args_b with
-       | Error { Agent_sdk.Types.message; _ } ->
-           check bool "different args are not blocked by prior failures" false
-             (is_guardrail_message message)
-       | Ok _ -> fail "second path should still fail normally");
-      match Tool.execute tool args_a with
-      | Error { Agent_sdk.Types.message; _ } ->
-          check bool "original args are blocked" true
+       Eio_main.run
+       @@ fun env ->
+       Fs_compat.set_fs (Eio.Stdenv.fs env);
+       let config = Coord.default_config dir in
+       let tools = Keeper_tools_oas.make_tools ~config ~meta ~ctx_snapshot () in
+       let tool = find_tool "keeper_fs_read" tools in
+       let args_a = `Assoc [ "path", `String "missing-a.txt" ] in
+       let args_b = `Assoc [ "path", `String "missing-b.txt" ] in
+       for _ = 1 to Keeper_tools_oas.max_consecutive_failures do
+         match Tool.execute tool args_a with
+         | Error _ -> ()
+         | Ok _ -> fail "first path should fail before guardrail"
+       done;
+       (match Tool.execute tool args_b with
+        | Error { Agent_sdk.Types.message; _ } ->
+          check
+            bool
+            "different args are not blocked by prior failures"
+            false
             (is_guardrail_message message)
-      | Ok _ -> fail "guardrail should block original failing args")
+        | Ok _ -> fail "second path should still fail normally");
+       match Tool.execute tool args_a with
+       | Error { Agent_sdk.Types.message; _ } ->
+         check bool "original args are blocked" true (is_guardrail_message message)
+       | Ok _ -> fail "guardrail should block original failing args")
+;;
 
-let make_research_meta ?tool_access ()
-    : Keeper_types.keeper_meta =
+let make_research_meta ?tool_access () : Keeper_types.keeper_meta =
   let tool_access =
     match tool_access with
     | Some access -> access
     | None -> Keeper_types.Preset { preset = Keeper_types.Research; also_allow = [] }
   in
-  match Masc_test_deps.meta_of_json_fixture
-    (`Assoc [("name", `String "test-researcher");
-             ("agent_name", `String "test-researcher");
-             ("trace_id", `String "test-trace-research");
-             ("soul_profile", `String "research");
-             ("tool_access", Keeper_types.tool_access_to_json tool_access)]) with
+  match
+    Masc_test_deps.meta_of_json_fixture
+      (`Assoc
+          [ "name", `String "test-researcher"
+          ; "agent_name", `String "test-researcher"
+          ; "trace_id", `String "test-trace-research"
+          ; "soul_profile", `String "research"
+          ; "tool_access", Keeper_types.tool_access_to_json tool_access
+          ])
+  with
   | Ok meta -> meta
   | Error e -> failwith (Printf.sprintf "make_research_meta failed: %s" e)
+;;
 
 let test_research_keeper_has_autoresearch_tools () =
   let meta = make_research_meta () in
@@ -595,107 +747,138 @@ let test_research_keeper_has_autoresearch_tools () =
   check bool "has cycle" true has_cycle;
   check bool "has start" true has_start;
   check bool "has status" true has_status
+;;
 
 let test_non_research_keeper_has_autoresearch () =
   let meta =
-    make_test_meta
-      ~preset:Keeper_types.Minimal
-      ~also_allow:autoresearch_allowlist ()
+    make_test_meta ~preset:Keeper_types.Minimal ~also_allow:autoresearch_allowlist ()
   in
   let allowed = Keeper_exec_tools.keeper_allowed_tool_names meta in
-  let has_any = List.exists (fun n ->
-    String.length n > 18
-    && String.sub n 0 18 = "masc_autoresearch_") allowed in
+  let has_any =
+    List.exists
+      (fun n -> String.length n > 18 && String.sub n 0 18 = "masc_autoresearch_")
+      allowed
+  in
   check bool "has autoresearch tools" true has_any
+;;
 
 let test_research_model_tools_include_autoresearch () =
   let meta = make_research_meta () in
   let tools = Keeper_exec_tools.keeper_allowed_model_tools meta in
-  let has_cycle = List.exists (fun (t : Types_core.tool_schema) ->
-    t.name = "masc_autoresearch_cycle") tools in
+  let has_cycle =
+    List.exists
+      (fun (t : Types_core.tool_schema) -> t.name = "masc_autoresearch_cycle")
+      tools
+  in
   check bool "model tools have cycle" true has_cycle
+;;
 
 let make_learned_meta () : Keeper_types.keeper_meta =
-  match Masc_test_deps.meta_of_json_fixture
-    (`Assoc [("name", `String "test-learned");
-             ("agent_name", `String "test-learned");
-             ("trace_id", `String "test-trace-learned");
-             ( "tool_access",
-               Keeper_types.tool_access_to_json
-                 (Keeper_types.Preset { preset = Keeper_types.Full; also_allow = [] } ))]) with
+  match
+    Masc_test_deps.meta_of_json_fixture
+      (`Assoc
+          [ "name", `String "test-learned"
+          ; "agent_name", `String "test-learned"
+          ; "trace_id", `String "test-trace-learned"
+          ; ( "tool_access"
+            , Keeper_types.tool_access_to_json
+                (Keeper_types.Preset { preset = Keeper_types.Full; also_allow = [] }) )
+          ])
+  with
   | Ok meta -> meta
   | Error e -> failwith (Printf.sprintf "make_learned_meta failed: %s" e)
+;;
 
 let test_all_keepers_have_library_tools () =
   let meta = make_learned_meta () in
   let allowed = Keeper_exec_tools.keeper_allowed_tool_names meta in
   check bool "has keeper_library_search" true (List.mem "keeper_library_search" allowed);
   check bool "has keeper_library_read" true (List.mem "keeper_library_read" allowed)
+;;
 
 let test_library_search_returns_results () =
-  let fake_home = Filename.concat (Filename.get_temp_dir_name ())
-    (Printf.sprintf "test_lib_home_%d" (Random.int 100000)) in
-  let lib_path = List.fold_left Filename.concat fake_home ["me"; "docs"; "library"] in
+  let fake_home =
+    Filename.concat
+      (Filename.get_temp_dir_name ())
+      (Printf.sprintf "test_lib_home_%d" (Random.int 100000))
+  in
+  let lib_path = List.fold_left Filename.concat fake_home [ "me"; "docs"; "library" ] in
   let rec mkdir_p path =
-    if not (Sys.file_exists path) then begin
+    if not (Sys.file_exists path)
+    then (
       mkdir_p (Filename.dirname path);
-      (try Unix.mkdir path 0o755 with Unix.Unix_error (Unix.EEXIST, _, _) -> ())
-    end
+      try Unix.mkdir path 0o755 with
+      | Unix.Unix_error (Unix.EEXIST, _, _) -> ())
   in
   mkdir_p lib_path;
   let doc_path = Filename.concat lib_path "test-mlfq-scheduler-20260321.md" in
   let oc = open_out doc_path in
-  output_string oc
-    "---\ntitle: MLFQ Scheduler for LLM Agents\nsource: research\n\
-     confidence: 0.85\nauthor: test\ncreated: 2026-03-21\n\
-     tags: [llm-scheduling, mlfq]\n---\n\n\
+  output_string
+    oc
+    "---\n\
+     title: MLFQ Scheduler for LLM Agents\n\
+     source: research\n\
+     confidence: 0.85\n\
+     author: test\n\
+     created: 2026-03-21\n\
+     tags: [llm-scheduling, mlfq]\n\
+     ---\n\n\
      Multi-Level Feedback Queue scheduler for LLM request priority.\n";
   close_out oc;
   let orig_home = Sys.getenv_opt "HOME" in
   Unix.putenv "HOME" fake_home;
   Fun.protect
     ~finally:(fun () ->
-      (match orig_home with Some h -> Unix.putenv "HOME" h | None -> ());
-      (try Sys.remove doc_path with _ -> ()))
+      (match orig_home with
+       | Some h -> Unix.putenv "HOME" h
+       | None -> ());
+      try Sys.remove doc_path with
+      | _ -> ())
     (fun () ->
-      let ctx = Tool_library.{ agent_name = "test-keeper" } in
-      (* Search *)
-      let (ok, msg) = Tool_library.handle_search ctx
-        (`Assoc [("query", `String "mlfq")]) in
-      check bool "search succeeds" true ok;
-      check bool "search finds mlfq doc" true
-        (let low = String.lowercase_ascii msg in
-         String.length low > 0
-         && not (Tool_library.string_contains ~sub:"no documents" low));
-      (* Read *)
-      let (ok2, msg2) = Tool_library.handle_read ctx
-        (`Assoc [("topic", `String "test-mlfq")]) in
-      check bool "read succeeds" true ok2;
-      check bool "read contains MLFQ content" true
-        (Tool_library.string_contains ~sub:"Multi-Level Feedback Queue" msg2))
+       let ctx = Tool_library.{ agent_name = "test-keeper" } in
+       (* Search *)
+       let ok, msg =
+         Tool_library.handle_search ctx (`Assoc [ "query", `String "mlfq" ])
+       in
+       check bool "search succeeds" true ok;
+       check
+         bool
+         "search finds mlfq doc"
+         true
+         (let low = String.lowercase_ascii msg in
+          String.length low > 0
+          && not (Tool_library.string_contains ~sub:"no documents" low));
+       (* Read *)
+       let ok2, msg2 =
+         Tool_library.handle_read ctx (`Assoc [ "topic", `String "test-mlfq" ])
+       in
+       check bool "read succeeds" true ok2;
+       check
+         bool
+         "read contains MLFQ content"
+         true
+         (Tool_library.string_contains ~sub:"Multi-Level Feedback Queue" msg2))
+;;
 
 let test_library_search_empty_query () =
   let ctx = Tool_library.{ agent_name = "test-keeper" } in
-  let (ok, _msg) = Tool_library.handle_search ctx
-    (`Assoc [("query", `String "")]) in
+  let ok, _msg = Tool_library.handle_search ctx (`Assoc [ "query", `String "" ]) in
   check bool "empty query fails" false ok
+;;
 
 let test_library_read_missing_topic () =
   let ctx = Tool_library.{ agent_name = "test-keeper" } in
-  let (ok, _msg) = Tool_library.handle_read ctx
-    (`Assoc [("topic", `String "nonexistent-topic-xyz-999")]) in
+  let ok, _msg =
+    Tool_library.handle_read ctx (`Assoc [ "topic", `String "nonexistent-topic-xyz-999" ])
+  in
   check bool "missing topic fails" false ok
+;;
 
 (* ── normalize_tool_result tests ──────────────────────────── *)
 
-let parse json_str =
-  Yojson.Safe.from_string json_str
-
-let json_bool key json =
-  Yojson.Safe.Util.(member key json |> to_bool)
-
-let json_string key json =
-  Yojson.Safe.Util.(member key json |> to_string)
+let parse json_str = Yojson.Safe.from_string json_str
+let json_bool key json = Yojson.Safe.Util.(member key json |> to_bool)
+let json_string key json = Yojson.Safe.Util.(member key json |> to_string)
 
 let test_normalize_success_json () =
   let raw = {|{"ok":true,"path":"/tmp/a.ml","bytes":42}|} in
@@ -703,8 +886,12 @@ let test_normalize_success_json () =
   let json = parse normalized in
   check bool "ok is true" true (json_bool "ok" json);
   let result = Yojson.Safe.Util.member "result" json in
-  check string "path preserved" "/tmp/a.ml"
+  check
+    string
+    "path preserved"
+    "/tmp/a.ml"
     Yojson.Safe.Util.(member "path" result |> to_string)
+;;
 
 let test_normalize_success_plain_text () =
   let raw = "📋 No tasks yet." in
@@ -712,6 +899,7 @@ let test_normalize_success_plain_text () =
   let json = parse normalized in
   check bool "ok is true" true (json_bool "ok" json);
   check string "result is text" "📋 No tasks yet." (json_string "result" json)
+;;
 
 let test_normalize_failure_error_field () =
   let raw = {|{"error":"file not found","path":"/tmp/missing"}|} in
@@ -720,8 +908,12 @@ let test_normalize_failure_error_field () =
   check bool "ok is false" false (json_bool "ok" json);
   check string "error extracted" "file not found" (json_string "error" json);
   let detail = Yojson.Safe.Util.member "detail" json in
-  check string "detail preserves path" "/tmp/missing"
+  check
+    string
+    "detail preserves path"
+    "/tmp/missing"
     Yojson.Safe.Util.(member "path" detail |> to_string)
+;;
 
 let test_normalize_failure_status_error () =
   let raw = {|{"status":"error","agent_id":"v1","message":"voice unavailable"}|} in
@@ -729,6 +921,7 @@ let test_normalize_failure_status_error () =
   let json = parse normalized in
   check bool "ok is false" false (json_bool "ok" json);
   check string "error from message" "voice unavailable" (json_string "error" json)
+;;
 
 let test_normalize_failure_ok_false () =
   let raw = {|{"ok":false,"error":"command_blocked","reason":"not in allowlist"}|} in
@@ -736,6 +929,7 @@ let test_normalize_failure_ok_false () =
   let json = parse normalized in
   check bool "ok is false" false (json_bool "ok" json);
   check string "error extracted" "command_blocked" (json_string "error" json)
+;;
 
 let test_normalize_failure_plain_text () =
   let raw = "tool keeper_bash failed (3/5): Unix_error(ENOENT)" in
@@ -743,142 +937,138 @@ let test_normalize_failure_plain_text () =
   let json = parse normalized in
   check bool "ok is false" false (json_bool "ok" json);
   check string "error is raw text" raw (json_string "error" json)
+;;
 
 let test_transient_mutex_contention_envelope () =
   let normalized =
     Keeper_tools_oas.transient_mutex_contention_tool_error
       ~tool_name:"keeper_shell"
       ~error_text:"Sys_error(\"Mutex.lock: Resource deadlock avoided\")"
-      ~backtrace:"Raised at Mutex.lock" ()
+      ~backtrace:"Raised at Mutex.lock"
+      ()
   in
   let json = parse normalized in
   check bool "ok is false" false (json_bool "ok" json);
-  check bool "recoverable" true
-    Yojson.Safe.Util.(member "recoverable" json |> to_bool);
-  check string "error_class" "transient_mutex_contention"
+  check bool "recoverable" true Yojson.Safe.Util.(member "recoverable" json |> to_bool);
+  check
+    string
+    "error_class"
+    "transient_mutex_contention"
     Yojson.Safe.Util.(member "error_class" json |> to_string);
-  check bool "retry recommended" true
+  check
+    bool
+    "retry recommended"
+    true
     Yojson.Safe.Util.(member "retry_recommended" json |> to_bool);
   let detail = Yojson.Safe.Util.member "detail" json in
-  check string "tool_name" "keeper_shell"
+  check
+    string
+    "tool_name"
+    "keeper_shell"
     Yojson.Safe.Util.(member "tool_name" detail |> to_string);
-  check bool "backtrace available" true
+  check
+    bool
+    "backtrace available"
+    true
     Yojson.Safe.Util.(member "backtrace_available" detail |> to_bool)
+;;
 
 let test_result_markers_capture_docker_approve () =
   let output =
-    Keeper_tools_oas.normalize_tool_result ~success:true
+    Keeper_tools_oas.normalize_tool_result
+      ~success:true
       {|{"ok":true,"via":"docker","event":"APPROVE"}|}
   in
-  let markers =
-    Keeper_tools_oas.tool_exec_result_markers
-      ~input:(`Assoc [])
-      ~output
-  in
+  let markers = Keeper_tools_oas.tool_exec_result_markers ~input:(`Assoc []) ~output in
   check bool "via marker" true (List.mem "via=docker" markers);
   check bool "approve marker" true (List.mem "event=APPROVE" markers)
+;;
 
 let test_result_markers_keep_git_push_class_only () =
   let output =
-    Keeper_tools_oas.normalize_tool_result ~success:true
-      {|{"ok":true,"via":"docker"}|}
+    Keeper_tools_oas.normalize_tool_result ~success:true {|{"ok":true,"via":"docker"}|}
   in
   let markers =
     Keeper_tools_oas.tool_exec_result_markers
-      ~input:
-        (`Assoc
-          [
-            ("cmd", `String "git push origin feature/secret-proof");
-          ])
+      ~input:(`Assoc [ "cmd", `String "git push origin feature/secret-proof" ])
       ~output
   in
   check bool "git push class marker" true (List.mem "git push" markers);
   check bool "via marker" true (List.mem "via=docker" markers);
-  check bool "raw command not persisted as marker" false
+  check
+    bool
+    "raw command not persisted as marker"
+    false
     (List.mem "git push origin feature/secret-proof" markers)
+;;
 
 let test_result_markers_ignore_lifecycle_mentions () =
   let output =
-    Keeper_tools_oas.normalize_tool_result ~success:true
-      {|{"ok":true,"via":"docker"}|}
+    Keeper_tools_oas.normalize_tool_result ~success:true {|{"ok":true,"via":"docker"}|}
   in
   let markers =
     Keeper_tools_oas.tool_exec_result_markers
       ~input:
         (`Assoc
-          [
-            ("cmd", `String "echo git push");
-            ("command", `String "printf 'gh pr create'");
-          ])
+            [ "cmd", `String "echo git push"; "command", `String "printf 'gh pr create'" ])
       ~output
   in
-  check bool "mentioned git push not marked" false
-    (List.mem "git push" markers);
-  check bool "mentioned pr create not marked" false
-    (List.mem "gh pr create" markers);
-  check bool "output via marker still captured" true
-    (List.mem "via=docker" markers)
+  check bool "mentioned git push not marked" false (List.mem "git push" markers);
+  check bool "mentioned pr create not marked" false (List.mem "gh pr create" markers);
+  check bool "output via marker still captured" true (List.mem "via=docker" markers)
+;;
 
 let test_result_markers_ignore_input_via () =
-  let output =
-    Keeper_tools_oas.normalize_tool_result ~success:true {|{"ok":true}|}
-  in
+  let output = Keeper_tools_oas.normalize_tool_result ~success:true {|{"ok":true}|} in
   let markers =
     Keeper_tools_oas.tool_exec_result_markers
-      ~input:(`Assoc [ ("via", `String "docker") ])
+      ~input:(`Assoc [ "via", `String "docker" ])
       ~output
   in
-  check bool "input via marker ignored" false
-    (List.mem "via=docker" markers)
+  check bool "input via marker ignored" false (List.mem "via=docker" markers)
+;;
 
 let test_result_markers_ignore_input_route_fields () =
-  let output =
-    Keeper_tools_oas.normalize_tool_result ~success:true {|{"ok":true}|}
-  in
+  let output = Keeper_tools_oas.normalize_tool_result ~success:true {|{"ok":true}|} in
   let markers =
     Keeper_tools_oas.tool_exec_result_markers
       ~input:
         (`Assoc
-          [
-            ("action", `String "push");
-            ("event", `String "APPROVE");
-            ("operation", `String "pr_create");
-          ])
+            [ "action", `String "push"
+            ; "event", `String "APPROVE"
+            ; "operation", `String "pr_create"
+            ])
       ~output
   in
   check bool "input action marker ignored" false (List.mem "git push" markers);
-  check bool "input event marker ignored" false
-    (List.mem "event=APPROVE" markers);
-  check bool "input operation marker ignored" false
-    (List.mem "gh pr create" markers)
+  check bool "input event marker ignored" false (List.mem "event=APPROVE" markers);
+  check bool "input operation marker ignored" false (List.mem "gh pr create" markers)
+;;
 
 let test_result_markers_reject_untrusted_via () =
   let output =
-    Keeper_tools_oas.normalize_tool_result ~success:true
+    Keeper_tools_oas.normalize_tool_result
+      ~success:true
       {|{"ok":true,"via":"<script>alert(1)</script>"}|}
   in
-  let markers =
-    Keeper_tools_oas.tool_exec_result_markers
-      ~input:(`Assoc [])
-      ~output
-  in
-  check bool "untrusted via marker rejected" false
-    (List.exists
-       (fun marker -> String.starts_with ~prefix:"via=" marker)
-       markers)
+  let markers = Keeper_tools_oas.tool_exec_result_markers ~input:(`Assoc []) ~output in
+  check
+    bool
+    "untrusted via marker rejected"
+    false
+    (List.exists (fun marker -> String.starts_with ~prefix:"via=" marker) markers)
+;;
 
 let test_result_markers_capture_pr_create_operation () =
   let output =
-    Keeper_tools_oas.normalize_tool_result ~success:true
+    Keeper_tools_oas.normalize_tool_result
+      ~success:true
       {|{"ok":true,"via":"docker","operation":"pr_create"}|}
   in
-  let markers =
-    Keeper_tools_oas.tool_exec_result_markers
-      ~input:(`Assoc [])
-      ~output
-  in
+  let markers = Keeper_tools_oas.tool_exec_result_markers ~input:(`Assoc []) ~output in
   check bool "pr create marker" true (List.mem "gh pr create" markers);
   check bool "via marker" true (List.mem "via=docker" markers)
+;;
 
 (* ── Tool_output_validation tests (memory cap) ──────────────── *)
 
@@ -886,97 +1076,177 @@ let test_cap_short_unchanged () =
   let short = "hello world" in
   let result = Tool_output_validation.cap short in
   check string "short output unchanged" short result
+;;
 
 let test_cap_exact_limit_unchanged () =
   let exact = String.make Tool_output_validation.max_output_chars 'x' in
   let result = Tool_output_validation.cap exact in
   check string "exact limit unchanged" exact result
+;;
 
 let test_cap_over_limit () =
   let long = String.make (Tool_output_validation.max_output_chars + 1000) 'a' in
   let result = Tool_output_validation.cap long in
-  check bool "result shorter than original" true
+  check
+    bool
+    "result shorter than original"
+    true
     (String.length result < String.length long);
-  check bool "contains capped marker" true
-    (string_contains ~sub:"[capped:" result)
+  check bool "contains capped marker" true (string_contains ~sub:"[capped:" result)
+;;
 
 let test_cap_preserves_prefix () =
   let prefix = "HEADER:" in
   let long = prefix ^ String.make (Tool_output_validation.max_output_chars + 1000) 'z' in
   let result = Tool_output_validation.cap long in
-  check bool "prefix preserved" true
+  check
+    bool
+    "prefix preserved"
+    true
     (String.length result >= String.length prefix
      && String.sub result 0 (String.length prefix) = prefix)
+;;
 
 let () =
   let base_path = Masc_test_deps.find_project_root () in
   Keeper_exec_tools.inject_masc_schemas Config.raw_all_tool_schemas;
   ignore (Result.get_ok (Keeper_exec_tools.init_policy_config ~base_path));
-  run "Keeper_tools_oas" [
-    "make_tools", [
-      test_case "returns nonempty" `Quick test_make_tools_returns_nonempty;
-      test_case "valid schemas" `Quick test_tools_have_valid_schemas;
-      test_case "count matches allowed" `Quick test_tool_count_matches_allowed;
-      test_case "error json becomes tool error" `Quick test_error_json_is_returned_as_tool_error;
-      test_case "missing required args rejected before keeper exec" `Quick
-        test_oas_handler_rejects_missing_required_args;
-      test_case "error result logs at error level" `Quick
-        test_error_result_logs_at_error_level;
-      test_case "missing file error includes suggestions" `Quick
-        test_missing_file_error_includes_directory_suggestions;
-      test_case "repeated errors are blocked" `Quick test_repeated_error_results_are_blocked;
-      test_case "failure count resets after success" `Quick test_failure_count_resets_after_success;
-      test_case "failure tracking is independent per args" `Quick test_failure_tracking_is_independent_per_args;
-      test_case "tool side-effect failures are observed" `Quick
-        test_tool_side_effect_failures_are_observed;
-      test_case "handler persists tool-call I/O without post hook" `Quick
-        test_handler_persists_tool_call_io_without_post_hook;
-      test_case "post hook skips handler-logged tool-call I/O" `Quick
-        test_post_hook_does_not_duplicate_handler_logged_io;
-      test_case "wrapper records keeper-internal calls" `Quick
-        test_oas_wrapper_records_keeper_internal_tool_call;
-    ];
-    "normalize_tool_result", [
-      test_case "success JSON wraps under result" `Quick test_normalize_success_json;
-      test_case "success plain text wraps as string" `Quick test_normalize_success_plain_text;
-      test_case "failure extracts error field" `Quick test_normalize_failure_error_field;
-      test_case "failure extracts message from status:error" `Quick test_normalize_failure_status_error;
-      test_case "failure handles ok:false hybrid" `Quick test_normalize_failure_ok_false;
-      test_case "failure plain text wraps as error" `Quick test_normalize_failure_plain_text;
-      test_case "EDEADLK envelope is recoverable" `Quick
-        test_transient_mutex_contention_envelope;
-    ];
-    "result_markers", [
-      test_case "captures docker approve markers" `Quick
-        test_result_markers_capture_docker_approve;
-      test_case "keeps git push class only" `Quick
-        test_result_markers_keep_git_push_class_only;
-      test_case "ignores lifecycle mentions" `Quick
-        test_result_markers_ignore_lifecycle_mentions;
-      test_case "ignores caller-provided via marker" `Quick
-        test_result_markers_ignore_input_via;
-      test_case "ignores caller-provided route fields" `Quick
-        test_result_markers_ignore_input_route_fields;
-      test_case "rejects untrusted via marker" `Quick
-        test_result_markers_reject_untrusted_via;
-      test_case "captures pr create operation" `Quick
-        test_result_markers_capture_pr_create_operation;
-    ];
-    "research_profile", [
-      test_case "has autoresearch tools" `Quick test_research_keeper_has_autoresearch_tools;
-      test_case "allowlisted non-research has autoresearch" `Quick test_non_research_keeper_has_autoresearch;
-      test_case "allowlisted model tools include autoresearch" `Quick test_research_model_tools_include_autoresearch;
-    ];
-    "library_tools", [
-      test_case "all keepers have library tools" `Quick test_all_keepers_have_library_tools;
-      test_case "search returns results" `Quick test_library_search_returns_results;
-      test_case "empty query fails" `Quick test_library_search_empty_query;
-      test_case "missing topic fails" `Quick test_library_read_missing_topic;
-    ];
-    "output_cap", [
-      test_case "short output unchanged" `Quick test_cap_short_unchanged;
-      test_case "exact limit unchanged" `Quick test_cap_exact_limit_unchanged;
-      test_case "over limit capped with marker" `Quick test_cap_over_limit;
-      test_case "prefix preserved after cap" `Quick test_cap_preserves_prefix;
-    ];
-  ]
+  run
+    "Keeper_tools_oas"
+    [ ( "make_tools"
+      , [ test_case "returns nonempty" `Quick test_make_tools_returns_nonempty
+        ; test_case "valid schemas" `Quick test_tools_have_valid_schemas
+        ; test_case "count matches allowed" `Quick test_tool_count_matches_allowed
+        ; test_case
+            "error json becomes tool error"
+            `Quick
+            test_error_json_is_returned_as_tool_error
+        ; test_case
+            "missing required args rejected before keeper exec"
+            `Quick
+            test_oas_handler_rejects_missing_required_args
+        ; test_case
+            "error result logs at error level"
+            `Quick
+            test_error_result_logs_at_error_level
+        ; test_case
+            "missing file error includes suggestions"
+            `Quick
+            test_missing_file_error_includes_directory_suggestions
+        ; test_case
+            "repeated errors are blocked"
+            `Quick
+            test_repeated_error_results_are_blocked
+        ; test_case
+            "failure count resets after success"
+            `Quick
+            test_failure_count_resets_after_success
+        ; test_case
+            "failure tracking is independent per args"
+            `Quick
+            test_failure_tracking_is_independent_per_args
+        ; test_case
+            "tool side-effect failures are observed"
+            `Quick
+            test_tool_side_effect_failures_are_observed
+        ; test_case
+            "handler persists tool-call I/O without post hook"
+            `Quick
+            test_handler_persists_tool_call_io_without_post_hook
+        ; test_case
+            "post hook skips handler-logged tool-call I/O"
+            `Quick
+            test_post_hook_does_not_duplicate_handler_logged_io
+        ; test_case
+            "wrapper records keeper-internal calls"
+            `Quick
+            test_oas_wrapper_records_keeper_internal_tool_call
+        ] )
+    ; ( "normalize_tool_result"
+      , [ test_case "success JSON wraps under result" `Quick test_normalize_success_json
+        ; test_case
+            "success plain text wraps as string"
+            `Quick
+            test_normalize_success_plain_text
+        ; test_case
+            "failure extracts error field"
+            `Quick
+            test_normalize_failure_error_field
+        ; test_case
+            "failure extracts message from status:error"
+            `Quick
+            test_normalize_failure_status_error
+        ; test_case
+            "failure handles ok:false hybrid"
+            `Quick
+            test_normalize_failure_ok_false
+        ; test_case
+            "failure plain text wraps as error"
+            `Quick
+            test_normalize_failure_plain_text
+        ; test_case
+            "EDEADLK envelope is recoverable"
+            `Quick
+            test_transient_mutex_contention_envelope
+        ] )
+    ; ( "result_markers"
+      , [ test_case
+            "captures docker approve markers"
+            `Quick
+            test_result_markers_capture_docker_approve
+        ; test_case
+            "keeps git push class only"
+            `Quick
+            test_result_markers_keep_git_push_class_only
+        ; test_case
+            "ignores lifecycle mentions"
+            `Quick
+            test_result_markers_ignore_lifecycle_mentions
+        ; test_case
+            "ignores caller-provided via marker"
+            `Quick
+            test_result_markers_ignore_input_via
+        ; test_case
+            "ignores caller-provided route fields"
+            `Quick
+            test_result_markers_ignore_input_route_fields
+        ; test_case
+            "rejects untrusted via marker"
+            `Quick
+            test_result_markers_reject_untrusted_via
+        ; test_case
+            "captures pr create operation"
+            `Quick
+            test_result_markers_capture_pr_create_operation
+        ] )
+    ; ( "research_profile"
+      , [ test_case
+            "has autoresearch tools"
+            `Quick
+            test_research_keeper_has_autoresearch_tools
+        ; test_case
+            "allowlisted non-research has autoresearch"
+            `Quick
+            test_non_research_keeper_has_autoresearch
+        ; test_case
+            "allowlisted model tools include autoresearch"
+            `Quick
+            test_research_model_tools_include_autoresearch
+        ] )
+    ; ( "library_tools"
+      , [ test_case
+            "all keepers have library tools"
+            `Quick
+            test_all_keepers_have_library_tools
+        ; test_case "search returns results" `Quick test_library_search_returns_results
+        ; test_case "empty query fails" `Quick test_library_search_empty_query
+        ; test_case "missing topic fails" `Quick test_library_read_missing_topic
+        ] )
+    ; ( "output_cap"
+      , [ test_case "short output unchanged" `Quick test_cap_short_unchanged
+        ; test_case "exact limit unchanged" `Quick test_cap_exact_limit_unchanged
+        ; test_case "over limit capped with marker" `Quick test_cap_over_limit
+        ; test_case "prefix preserved after cap" `Quick test_cap_preserves_prefix
+        ] )
+    ]
+;;

--- a/test/test_tool_registry.ml
+++ b/test/test_tool_registry.ml
@@ -50,6 +50,15 @@ let () =
               Tool_registry.record_call_if_known ~tool_name:"totally_unknown_tool"
                 ~success:false ~duration_ms:1 ();
               check int "total" 0 (Tool_registry.total_calls ()));
+          test_case "gated recording includes keeper-internal tools" `Quick (fun () ->
+              Tool_registry.reset ();
+              Tool_registry.record_call_if_known ~source:Keeper_internal
+                ~tool_name:"keeper_stay_silent" ~success:true ~duration_ms:1 ();
+              let stats = Tool_registry.get_stats () in
+              let s = List.assoc "keeper_stay_silent" stats in
+              check int "call_count" 1 (Atomic.get s.call_count);
+              check int "keeper_internal_count" 1
+                (Atomic.get s.keeper_internal_count));
           test_case "tracks source attribution" `Quick (fun () ->
               Tool_registry.reset ();
               Tool_registry.record_call ~source:External_mcp

--- a/test/test_tool_registry.ml
+++ b/test/test_tool_registry.ml
@@ -3,180 +3,224 @@
 module Tool_registry = Masc_mcp.Tool_registry
 
 let () =
-  Eio_main.run @@ fun env ->
+  Eio_main.run
+  @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
   let open Alcotest in
-  run "Tool_registry"
-    [
-      ( "record_call",
-        [
-          test_case "increments call_count" `Quick (fun () ->
-              Tool_registry.reset ();
-              Tool_registry.record_call ~tool_name:"masc_status" ~success:true
-                ~duration_ms:10 ();
-              Tool_registry.record_call ~tool_name:"masc_status" ~success:true
-                ~duration_ms:20 ();
-              let stats = Tool_registry.get_stats () in
-              let count =
-                List.assoc_opt "masc_status" stats
-                |> Option.map (fun s -> (Atomic.get s.Tool_registry.call_count))
-                |> Option.value ~default:0
-              in
-              check int "call_count" 2 count);
-          test_case "tracks success and failure separately" `Quick (fun () ->
-              Tool_registry.reset ();
-              Tool_registry.record_call ~tool_name:"masc_join" ~success:true
-                ~duration_ms:5 ();
-              Tool_registry.record_call ~tool_name:"masc_join" ~success:false
-                ~duration_ms:15 ();
-              Tool_registry.record_call ~tool_name:"masc_join" ~success:true
-                ~duration_ms:8 ();
-              let stats = Tool_registry.get_stats () in
-              let s = List.assoc "masc_join" stats in
-              check int "call_count" 3 (Atomic.get s.call_count);
-              check int "success_count" 2 (Atomic.get s.success_count);
-              check int "failure_count" 1 (Atomic.get s.failure_count));
-          test_case "accumulates duration" `Quick (fun () ->
-              Tool_registry.reset ();
-              Tool_registry.record_call ~tool_name:"masc_broadcast" ~success:true
-                ~duration_ms:100 ();
-              Tool_registry.record_call ~tool_name:"masc_broadcast" ~success:true
-                ~duration_ms:200 ();
-              let stats = Tool_registry.get_stats () in
-              let s = List.assoc "masc_broadcast" stats in
-              check int "total_duration_ms" 300 (Atomic.get s.total_duration_ms));
-          test_case "ignores unknown tool names when gated" `Quick (fun () ->
-              Tool_registry.reset ();
-              Tool_registry.record_call_if_known ~tool_name:"totally_unknown_tool"
-                ~success:false ~duration_ms:1 ();
-              check int "total" 0 (Tool_registry.total_calls ()));
-          test_case "gated recording includes keeper-internal tools" `Quick (fun () ->
-              Tool_registry.reset ();
-              Tool_registry.record_call_if_known ~source:Keeper_internal
-                ~tool_name:"keeper_stay_silent" ~success:true ~duration_ms:1 ();
-              let stats = Tool_registry.get_stats () in
-              let s = List.assoc "keeper_stay_silent" stats in
-              check int "call_count" 1 (Atomic.get s.call_count);
-              check int "keeper_internal_count" 1
-                (Atomic.get s.keeper_internal_count));
-          test_case "tracks source attribution" `Quick (fun () ->
-              Tool_registry.reset ();
-              Tool_registry.record_call ~source:External_mcp
-                ~tool_name:"masc_status" ~success:true ~duration_ms:10 ();
-              Tool_registry.record_call ~source:Keeper_internal
-                ~tool_name:"masc_status" ~success:true ~duration_ms:20 ();
-              Tool_registry.record_call ~source:Keeper_internal
-                ~tool_name:"masc_status" ~success:false ~duration_ms:5 ();
-              let stats = Tool_registry.get_stats () in
-              let s = List.assoc "masc_status" stats in
-              check int "call_count" 3 (Atomic.get s.call_count);
-              check int "external_mcp_count" 1 (Atomic.get s.external_mcp_count);
-              check int "keeper_internal_count" 2 (Atomic.get s.keeper_internal_count));
-        ] );
-      ( "get_top_n",
-        [
-          test_case "returns top N by call count" `Quick (fun () ->
-              Tool_registry.reset ();
-              for _ = 1 to 3 do
-                Tool_registry.record_call ~tool_name:"tool_a" ~success:true
-                  ~duration_ms:1 ()
-              done;
-              Tool_registry.record_call ~tool_name:"tool_b" ~success:true
-                ~duration_ms:1 ();
-              for _ = 1 to 5 do
-                Tool_registry.record_call ~tool_name:"tool_c" ~success:true
-                  ~duration_ms:1 ()
-              done;
-              let top2 = Tool_registry.get_top_n 2 in
-              check int "length" 2 (List.length top2);
-              let names = List.map fst top2 in
-              check (list string) "order" [ "tool_c"; "tool_a" ] names);
-        ] );
-      ( "get_never_called",
-        [
-          test_case "identifies uncalled tools" `Quick (fun () ->
-              Tool_registry.reset ();
-              Tool_registry.record_call ~tool_name:"called_tool" ~success:true
-                ~duration_ms:1 ();
-              let never =
-                Tool_registry.get_never_called
-                  [ "called_tool"; "uncalled_a"; "uncalled_b" ]
-              in
-              check (list string) "never called"
-                [ "uncalled_a"; "uncalled_b" ]
-                never);
-        ] );
-      ( "totals",
-        [
-          test_case "total_calls sums all" `Quick (fun () ->
-              Tool_registry.reset ();
-              Tool_registry.record_call ~tool_name:"a" ~success:true
-                ~duration_ms:1 ();
-              Tool_registry.record_call ~tool_name:"b" ~success:true
-                ~duration_ms:1 ();
-              Tool_registry.record_call ~tool_name:"a" ~success:false
-                ~duration_ms:1 ();
-              check int "total" 3 (Tool_registry.total_calls ()));
-          test_case "distinct_tools_called" `Quick (fun () ->
-              Tool_registry.reset ();
-              Tool_registry.record_call ~tool_name:"x" ~success:true
-                ~duration_ms:1 ();
-              Tool_registry.record_call ~tool_name:"y" ~success:true
-                ~duration_ms:1 ();
-              Tool_registry.record_call ~tool_name:"x" ~success:true
-                ~duration_ms:1 ();
-              check int "distinct" 2 (Tool_registry.distinct_tools_called ()));
-        ] );
-      ( "stats_report",
-        [
-          test_case "generates valid JSON with source breakdown" `Quick (fun () ->
-              Tool_registry.reset ();
-              Tool_registry.record_call ~tool_name:"masc_status" ~success:true
-                ~duration_ms:42 ();
-              let json =
-                Tool_registry.stats_report
-                  ~top_n:20
-                  ~all_tool_names:[ "masc_status"; "masc_join" ]
-              in
-              let s = Yojson.Safe.to_string json in
-              check bool "contains total_calls"
-                (String.length s > 0)
-                true;
-              check bool "contains by_source"
-                (String.length s > 10)
-                true;
-              let _ = Yojson.Safe.from_string s in
-              ());
-          test_case "respects top_n" `Quick (fun () ->
-              Tool_registry.reset ();
-              for _ = 1 to 3 do
-                Tool_registry.record_call ~tool_name:"masc_status" ~success:true
-                  ~duration_ms:1 ()
-              done;
-              for _ = 1 to 2 do
-                Tool_registry.record_call ~tool_name:"masc_join" ~success:true
-                  ~duration_ms:1 ()
-              done;
-              Tool_registry.record_call ~tool_name:"masc_leave" ~success:true
-                ~duration_ms:1 ();
-              let json =
-                Tool_registry.stats_report ~top_n:2
-                  ~all_tool_names:[ "masc_status"; "masc_join"; "masc_leave" ]
-              in
-              let open Yojson.Safe.Util in
-              check int "top_n_requested" 2
-                (json |> member "top_n_requested" |> to_int);
-              check int "top_tools length" 2
-                (json |> member "top_tools" |> to_list |> List.length));
-        ] );
-      ( "reset",
-        [
-          test_case "clears all data" `Quick (fun () ->
-              Tool_registry.reset ();
-              Tool_registry.record_call ~tool_name:"z" ~success:true
-                ~duration_ms:1 ();
-              check int "before" 1 (Tool_registry.total_calls ());
-              Tool_registry.reset ();
-              check int "after" 0 (Tool_registry.total_calls ()));
-        ] );
+  run
+    "Tool_registry"
+    [ ( "record_call"
+      , [ test_case "increments call_count" `Quick (fun () ->
+            Tool_registry.reset ();
+            Tool_registry.record_call
+              ~tool_name:"masc_status"
+              ~success:true
+              ~duration_ms:10
+              ();
+            Tool_registry.record_call
+              ~tool_name:"masc_status"
+              ~success:true
+              ~duration_ms:20
+              ();
+            let stats = Tool_registry.get_stats () in
+            let count =
+              List.assoc_opt "masc_status" stats
+              |> Option.map (fun s -> Atomic.get s.Tool_registry.call_count)
+              |> Option.value ~default:0
+            in
+            check int "call_count" 2 count)
+        ; test_case "tracks success and failure separately" `Quick (fun () ->
+            Tool_registry.reset ();
+            Tool_registry.record_call
+              ~tool_name:"masc_join"
+              ~success:true
+              ~duration_ms:5
+              ();
+            Tool_registry.record_call
+              ~tool_name:"masc_join"
+              ~success:false
+              ~duration_ms:15
+              ();
+            Tool_registry.record_call
+              ~tool_name:"masc_join"
+              ~success:true
+              ~duration_ms:8
+              ();
+            let stats = Tool_registry.get_stats () in
+            let s = List.assoc "masc_join" stats in
+            check int "call_count" 3 (Atomic.get s.call_count);
+            check int "success_count" 2 (Atomic.get s.success_count);
+            check int "failure_count" 1 (Atomic.get s.failure_count))
+        ; test_case "accumulates duration" `Quick (fun () ->
+            Tool_registry.reset ();
+            Tool_registry.record_call
+              ~tool_name:"masc_broadcast"
+              ~success:true
+              ~duration_ms:100
+              ();
+            Tool_registry.record_call
+              ~tool_name:"masc_broadcast"
+              ~success:true
+              ~duration_ms:200
+              ();
+            let stats = Tool_registry.get_stats () in
+            let s = List.assoc "masc_broadcast" stats in
+            check int "total_duration_ms" 300 (Atomic.get s.total_duration_ms))
+        ; test_case "ignores unknown tool names when gated" `Quick (fun () ->
+            Tool_registry.reset ();
+            Tool_registry.record_call_if_known
+              ~tool_name:"totally_unknown_tool"
+              ~success:false
+              ~duration_ms:1
+              ();
+            check int "total" 0 (Tool_registry.total_calls ()))
+        ; test_case "gated recording includes keeper-internal tools" `Quick (fun () ->
+            Tool_registry.reset ();
+            Tool_registry.record_call_if_known
+              ~source:Keeper_internal
+              ~tool_name:"keeper_stay_silent"
+              ~success:true
+              ~duration_ms:1
+              ();
+            let stats = Tool_registry.get_stats () in
+            let s = List.assoc "keeper_stay_silent" stats in
+            check int "call_count" 1 (Atomic.get s.call_count);
+            check int "keeper_internal_count" 1 (Atomic.get s.keeper_internal_count))
+        ; test_case "tracks source attribution" `Quick (fun () ->
+            Tool_registry.reset ();
+            Tool_registry.record_call
+              ~source:External_mcp
+              ~tool_name:"masc_status"
+              ~success:true
+              ~duration_ms:10
+              ();
+            Tool_registry.record_call
+              ~source:Keeper_internal
+              ~tool_name:"masc_status"
+              ~success:true
+              ~duration_ms:20
+              ();
+            Tool_registry.record_call
+              ~source:Keeper_internal
+              ~tool_name:"masc_status"
+              ~success:false
+              ~duration_ms:5
+              ();
+            let stats = Tool_registry.get_stats () in
+            let s = List.assoc "masc_status" stats in
+            check int "call_count" 3 (Atomic.get s.call_count);
+            check int "external_mcp_count" 1 (Atomic.get s.external_mcp_count);
+            check int "keeper_internal_count" 2 (Atomic.get s.keeper_internal_count))
+        ] )
+    ; ( "get_top_n"
+      , [ test_case "returns top N by call count" `Quick (fun () ->
+            Tool_registry.reset ();
+            for _ = 1 to 3 do
+              Tool_registry.record_call
+                ~tool_name:"tool_a"
+                ~success:true
+                ~duration_ms:1
+                ()
+            done;
+            Tool_registry.record_call ~tool_name:"tool_b" ~success:true ~duration_ms:1 ();
+            for _ = 1 to 5 do
+              Tool_registry.record_call
+                ~tool_name:"tool_c"
+                ~success:true
+                ~duration_ms:1
+                ()
+            done;
+            let top2 = Tool_registry.get_top_n 2 in
+            check int "length" 2 (List.length top2);
+            let names = List.map fst top2 in
+            check (list string) "order" [ "tool_c"; "tool_a" ] names)
+        ] )
+    ; ( "get_never_called"
+      , [ test_case "identifies uncalled tools" `Quick (fun () ->
+            Tool_registry.reset ();
+            Tool_registry.record_call
+              ~tool_name:"called_tool"
+              ~success:true
+              ~duration_ms:1
+              ();
+            let never =
+              Tool_registry.get_never_called [ "called_tool"; "uncalled_a"; "uncalled_b" ]
+            in
+            check (list string) "never called" [ "uncalled_a"; "uncalled_b" ] never)
+        ] )
+    ; ( "totals"
+      , [ test_case "total_calls sums all" `Quick (fun () ->
+            Tool_registry.reset ();
+            Tool_registry.record_call ~tool_name:"a" ~success:true ~duration_ms:1 ();
+            Tool_registry.record_call ~tool_name:"b" ~success:true ~duration_ms:1 ();
+            Tool_registry.record_call ~tool_name:"a" ~success:false ~duration_ms:1 ();
+            check int "total" 3 (Tool_registry.total_calls ()))
+        ; test_case "distinct_tools_called" `Quick (fun () ->
+            Tool_registry.reset ();
+            Tool_registry.record_call ~tool_name:"x" ~success:true ~duration_ms:1 ();
+            Tool_registry.record_call ~tool_name:"y" ~success:true ~duration_ms:1 ();
+            Tool_registry.record_call ~tool_name:"x" ~success:true ~duration_ms:1 ();
+            check int "distinct" 2 (Tool_registry.distinct_tools_called ()))
+        ] )
+    ; ( "stats_report"
+      , [ test_case "generates valid JSON with source breakdown" `Quick (fun () ->
+            Tool_registry.reset ();
+            Tool_registry.record_call
+              ~tool_name:"masc_status"
+              ~success:true
+              ~duration_ms:42
+              ();
+            let json =
+              Tool_registry.stats_report
+                ~top_n:20
+                ~all_tool_names:[ "masc_status"; "masc_join" ]
+            in
+            let s = Yojson.Safe.to_string json in
+            check bool "contains total_calls" (String.length s > 0) true;
+            check bool "contains by_source" (String.length s > 10) true;
+            let _ = Yojson.Safe.from_string s in
+            ())
+        ; test_case "respects top_n" `Quick (fun () ->
+            Tool_registry.reset ();
+            for _ = 1 to 3 do
+              Tool_registry.record_call
+                ~tool_name:"masc_status"
+                ~success:true
+                ~duration_ms:1
+                ()
+            done;
+            for _ = 1 to 2 do
+              Tool_registry.record_call
+                ~tool_name:"masc_join"
+                ~success:true
+                ~duration_ms:1
+                ()
+            done;
+            Tool_registry.record_call
+              ~tool_name:"masc_leave"
+              ~success:true
+              ~duration_ms:1
+              ();
+            let json =
+              Tool_registry.stats_report
+                ~top_n:2
+                ~all_tool_names:[ "masc_status"; "masc_join"; "masc_leave" ]
+            in
+            let open Yojson.Safe.Util in
+            check int "top_n_requested" 2 (json |> member "top_n_requested" |> to_int);
+            check
+              int
+              "top_tools length"
+              2
+              (json |> member "top_tools" |> to_list |> List.length))
+        ] )
+    ; ( "reset"
+      , [ test_case "clears all data" `Quick (fun () ->
+            Tool_registry.reset ();
+            Tool_registry.record_call ~tool_name:"z" ~success:true ~duration_ms:1 ();
+            check int "before" 1 (Tool_registry.total_calls ());
+            Tool_registry.reset ();
+            check int "after" 0 (Tool_registry.total_calls ()))
+        ] )
     ]
+;;


### PR DESCRIPTION
## Summary
- remove process-global no-op keeper tool callbacks from `Keeper_exec_tools`
- make `keeper_tool_search` fail explicitly when direct dispatch omits a session `search_fn`
- record keeper-internal tool calls directly from the OAS wrapper after breaking `Tool_registry`'s `Config` dependency through catalog surfaces
- add regression coverage for direct search wiring, keeper-internal registry attribution, and gated internal tool names

## Audit context
- Addresses Kimi cleanup roadmap item: `keeper_exec_tools.ml` global no-op refs for tool callbacks/search fallback.
- Keeps the session-scoped `keeper_tool_search` path intact through `Keeper_tools_oas` / `Keeper_run_tools`.

## Rebase note
Rebased onto current `origin/main` (`13f50256fc`). The only conflict was in `test/test_keeper_tools_oas.ml`; the resolution preserves both main's direct tool-call I/O persistence tests and this PR's keeper-internal ToolRegistry attribution test.

## Validation
- `ocamlc -stop-after parsing lib/keeper/keeper_exec_tools.ml lib/keeper/keeper_exec_tools.mli lib/keeper/keeper_tools_oas.ml lib/mcp_server_eio.ml lib/tool_registry.ml test/test_keeper_task_dispatch.ml test/test_keeper_tools_oas.ml test/test_tool_registry.ml`
- `scripts/check-oas-pin.sh --local-only`
- `scripts/dune-local.sh build test/test_keeper_tools_oas.exe test/test_keeper_task_dispatch.exe test/test_tool_registry.exe`
- `scripts/dune-local.sh build test/test_keeper_exec_tools.exe`
- `./_build/default/test/test_keeper_task_dispatch.exe` (40 tests)
- `./_build/default/test/test_keeper_tools_oas.exe` (38 tests)
- `./_build/default/test/test_tool_registry.exe` (13 tests)
- `./_build/default/test/test_keeper_exec_tools.exe test execute_keeper_tool_call_with_outcome 0-4` (5 targeted tests)
- `git diff --check`
- `git diff --check origin/main...HEAD`

Note: full `./_build/default/test/test_keeper_exec_tools.exe` includes the Docker exec-cache test and failed in this shell because Docker socket access is denied (`permission denied ... docker.sock`). The non-Docker touched execution cases passed.
