### PR TITLE
fix: expose turn slot bookkeeping failures

### DIFF
--- a/lib/keeper/keeper_turn_slot.ml
+++ b/lib/keeper/keeper_turn_slot.ml
@@ -525,6 +525,12 @@ let run_after_acquire_flag_hook_for_test ~label ~keeper_name =
   | None -> ()
   | Some hook -> hook ~label ~keeper_name
 
+let observe_bookkeeping_failure ~op ~kind =
+  Prometheus.inc_counter
+    Prometheus.metric_keeper_turn_slot_bookkeeping_failures
+    ~labels:[ ("op", op); ("kind", kind) ]
+    ()
+
 (* Cancel-safe wrapper for bookkeeping calls that touch [Eio.Mutex.use_rw].
    Reached from [Fun.protect ~finally] in [with_keeper_turn_slot] when the
    keeper fiber is being cancelled.  If a mutex acquisition raises
@@ -539,8 +545,10 @@ let safe_bookkeeping ~op f =
     (* Bookkeeping (holder table / waiter queue / completion stamp) is
        advisory and self-healing; skipping under fiber cancellation is
        acceptable.  The semaphore release that follows must still run. *)
+    observe_bookkeeping_failure ~op ~kind:"cancelled";
     Log.Keeper.warn "release_keeper_turn_slot: %s skipped (Cancelled)" op
   | exn ->
+    observe_bookkeeping_failure ~op ~kind:"exception";
     Log.Keeper.warn "release_keeper_turn_slot: %s failed: %s"
       op (Printexc.to_string exn)
 
@@ -560,7 +568,17 @@ let release_recorded_holder
     Eio.Semaphore.release sem
   | Some acquisition_id ->
     let force_released =
-      try consume_force_release ~label ~keeper_name ~acquisition_id with exn ->
+      try consume_force_release ~label ~keeper_name ~acquisition_id with
+      | Eio.Cancel.Cancelled _ ->
+        observe_bookkeeping_failure
+          ~op:("drop_holder " ^ label) ~kind:"cancelled";
+        Log.Keeper.warn
+          "release_keeper_turn_slot: drop_holder %s skipped (Cancelled)"
+          label;
+        false
+      | exn ->
+        observe_bookkeeping_failure
+          ~op:("drop_holder " ^ label) ~kind:"exception";
         Log.Keeper.warn "release_keeper_turn_slot: drop_holder %s failed: %s"
           label (Printexc.to_string exn);
         false

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -459,6 +459,9 @@ let metric_tool_join_required_guard =
 let metric_keeper_semaphore_wait_timeout =
   "masc_keeper_semaphore_wait_timeout_total"
 
+let metric_keeper_turn_slot_bookkeeping_failures =
+  "masc_keeper_turn_slot_bookkeeping_failures_total"
+
 (* Goal-loop Observe contract: the Grafana p99 query consumes
    [masc_keeper_semaphore_wait_seconds_bucket] grouped by keeper and cascade.
    The generic [register_histogram] exporter currently exposes summaries, so
@@ -1512,6 +1515,11 @@ let init () =
   add metric_keeper_turn_queue_depth
     "Current keeper turn wait queue depth (labels: channel=autonomous_queue)"
     Gauge;
+  add metric_keeper_turn_slot_bookkeeping_failures
+    "Total keeper turn-slot release bookkeeping callbacks that could not \
+     complete while preserving semaphore release (labels: op, \
+     kind=cancelled|exception)"
+    Counter;
   register_histogram ~name:metric_keeper_semaphore_wait_seconds
     ~help:"Seconds spent waiting to acquire keeper turn semaphores \
            (labels: keeper_name, cascade_profile, channel)." ();

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -218,6 +218,11 @@ val metric_keeper_semaphore_wait_timeout : string
     Labels: [keeper, channel] with channel in
     [autonomous_queue_head | autonomous | turn]. *)
 
+val metric_keeper_turn_slot_bookkeeping_failures : string
+(** Counter for cancellation-safe keeper turn-slot release bookkeeping
+    callbacks that could not complete. Labels: [op, kind] with
+    kind in [cancelled | exception]. *)
+
 val metric_keeper_semaphore_wait_seconds : string
 (** Cumulative keeper turn-slot semaphore wait seconds. Labels:
     [keeper_name, cascade_profile, channel]. *)

--- a/test/test_keeper_turn_slot_release_cancel_safe.ml
+++ b/test/test_keeper_turn_slot_release_cancel_safe.ml
@@ -10,11 +10,13 @@
    the slot leaked permanently — turn_available pinned at 0 while
    the entire 14-keeper fleet skipped turns with "wait > 180s".
 
-   The fix wraps each bookkeeping call in [safe_bookkeeping ~op],
-   which catches Cancelled and lets the subsequent semaphore
-   release run. This test asserts the structural pattern by
-   anchored substring search, so a future refactor that removes
-   the wrap fails CI before it deadlocks production.
+   The fix keeps each bookkeeping failure isolated from the semaphore
+   release: standalone cleanup callbacks go through [safe_bookkeeping ~op],
+   while recorded-holder cleanup catches [consume_force_release] failures
+   inside [release_recorded_holder]. Both paths now emit a metric before
+   continuing. This test asserts the structural pattern by anchored
+   substring search, so a future refactor that removes the guard fails CI
+   before it deadlocks production.
 
    Why structural rather than behavioural: deterministically
    raising Cancelled inside a sub-mutex during fiber teardown
@@ -79,20 +81,21 @@ let () =
             (cwd=%s, exe=%s): %s"
            (Sys.getcwd ()) exe (String.concat ", " candidates))
   in
-  (* The five labeled wraps that the fix introduces.  Ordering
-     is not asserted (release order is documented as quota-
-     independent) — only presence of each anchored op label. *)
+  (* The cancel-safe release path has two cleanup shapes:
+     [safe_bookkeeping] wraps standalone cleanup callbacks, while
+     recorded-holder release catches [consume_force_release] failures
+     and still releases the semaphore. Ordering is not asserted
+     (release order is quota-independent); the source contract only
+     pins each labeled cleanup site. *)
   let must_contain =
     [ "drop_autonomous_waiter wrap",
       {|safe_bookkeeping ~op:"drop_autonomous_waiter"|}
-    ; "drop_holder turn wrap",
-      {|safe_bookkeeping ~op:"drop_holder turn"|}
     ; "record_autonomous_completion wrap",
       {|safe_bookkeeping ~op:"record_autonomous_completion"|}
-    ; "drop_holder autonomous wrap",
-      {|safe_bookkeeping ~op:"drop_holder autonomous"|}
-    ; "drop_holder reactive wrap",
-      {|safe_bookkeeping ~op:"drop_holder reactive"|}
+    ; "drop_holder metric op",
+      {|~op:("drop_holder " ^ label)|}
+    ; "drop_holder cancellation catch",
+      {|release_keeper_turn_slot: drop_holder %s skipped (Cancelled)|}
     ]
   in
   List.iter
@@ -105,6 +108,26 @@ let () =
     ~label:"safe_bookkeeping catches Cancelled"
     src
     "Eio.Cancel.Cancelled _ ->";
+  assert_contains
+    ~label:"safe_bookkeeping metrics cancelled"
+    src
+    {|observe_bookkeeping_failure ~op ~kind:"cancelled"|};
+  assert_contains
+    ~label:"safe_bookkeeping metrics exception"
+    src
+    {|observe_bookkeeping_failure ~op ~kind:"exception"|};
+  assert_contains
+    ~label:"safe_bookkeeping metric name"
+    src
+    "metric_keeper_turn_slot_bookkeeping_failures";
+  assert_contains
+    ~label:"drop_holder metrics cancelled"
+    src
+    {|~op:("drop_holder " ^ label) ~kind:"cancelled"|};
+  assert_contains
+    ~label:"drop_holder metrics exception"
+    src
+    {|~op:("drop_holder " ^ label) ~kind:"exception"|};
   (* All three semaphore releases must remain reachable
      (turn / autonomous / reactive). *)
   let count_substring ~needle s =


### PR DESCRIPTION
## Summary
- add a Prometheus counter for keeper turn-slot release bookkeeping failures
- label cancelled vs exception paths while preserving semaphore release semantics
- update the release-cancel source guard to cover both safe_bookkeeping and recorded-holder cleanup

## Verification
- scripts/dune-local.sh build test/test_keeper_turn_slot_release_cancel_safe.exe test/test_keeper_turn_slot_holders.exe
- ./_build/default/test/test_keeper_turn_slot_release_cancel_safe.exe
- ./_build/default/test/test_keeper_turn_slot_holders.exe test holder 0-2
- git diff --check