### PR TITLE
fix: surface missing keeper prompt config

### DIFF
--- a/lib/keeper/keeper_prompt.ml
+++ b/lib/keeper/keeper_prompt.ml
@@ -118,9 +118,38 @@ let render_world_prompt ~git_clone_policy_loaded ~allowed_orgs ~denied_repos :
         msg;
       Prompt_registry.get_prompt Keeper_prompt_names.world
 
-let behavior_prompt_block name ~fallback =
-  Option.value (Keeper_prompt_external.get name) ~default:fallback
-  |> String.trim
+let behavior_prompt_block name =
+  match Keeper_prompt_external.get name with
+  | Some content -> String.trim content
+  | None ->
+      Prometheus.inc_counter
+        Prometheus.metric_keeper_prompt_failures
+        ~labels:[("prompt", "behavior/" ^ name)]
+        ();
+      Log.Keeper.warn
+        "build_keeper_system_prompt: behavior prompt %s missing; \
+         rendering config-drift marker instead of generic in-source behavior"
+        name;
+      Printf.sprintf
+        "Behavior prompt config drift: missing config/prompts/behavior/%s.md. \
+         Preserve the keeper's configured goal, persona, and runtime policy; \
+         ask the operator to restore the missing behavior prompt file."
+        name
+
+let missing_personality_field field =
+  Prometheus.inc_counter
+    Prometheus.metric_keeper_prompt_failures
+    ~labels:[("prompt", "personality/" ^ field)]
+    ();
+  Log.Keeper.warn
+    "build_keeper_system_prompt: personality field %s is empty; rendering \
+     config-drift marker instead of generic in-source self-model text"
+    field;
+  Printf.sprintf
+    "Personality config drift: empty %s field. Preserve the keeper's \
+     configured goal, persona, and runtime policy; ask the operator to \
+     restore this self-model field."
+    field
 
 let build_keeper_system_prompt
     ~goal ~short_goal ~mid_goal ~long_goal ~will ~needs ~desires
@@ -133,47 +162,34 @@ let build_keeper_system_prompt
     resolve_goal_horizons ~goal ~short_goal_opt:(Some short_goal)
       ~mid_goal_opt:(Some mid_goal) ~long_goal_opt:(Some long_goal)
   in
-  (* Tier C C-5a: profile_policy is the first behavior block migrated
-     out of OCaml source.  The .md file lives at
-     [<prompts_dir>/behavior/profile_policy.md] and is read once per
-     process via [Keeper_prompt_external.get].  The original literal
-     is kept as a fallback so a missing/unreadable file does not
-     brick keepers — instead the loader emits a WARN and we use the
-     in-source string.  Subsequent C-5b PRs migrate the remaining
-     blocks in this function. *)
-  let profile_policy =
-    behavior_prompt_block "profile_policy"
-      ~fallback:
-        "Maintain high standard of reasoning, factual grounding, and clear communication."
-  in
-  let continuity_contract =
-    behavior_prompt_block "continuity_contract"
-      ~fallback:
-        "Continuity and any end-of-reply STATE formatting requirements apply unless a more specific turn-level mode or output guard disables them.\n\
-         When <direct_reply_mode> is present, follow it instead: do not emit SKILL:, SKILL_REASON:, or [STATE]."
-  in
+  (* Behavior prompt blocks live under
+     [<prompts_dir>/behavior/<name>.md] and are read once per process via
+     [Keeper_prompt_external.get]. Missing/unreadable files no longer inject
+     generic in-source behavior text: they produce an operator-visible drift
+     marker so the prompt tells the keeper that config is incomplete instead
+     of silently changing persona policy. *)
+  let profile_policy = behavior_prompt_block "profile_policy" in
+  let continuity_contract = behavior_prompt_block "continuity_contract" in
   (* Layer 2 PR-B (commit 7): three normalize_self_model_text calls
-     consolidated through [Keeper_personality_io.to_prompt_form]. The
-     fallback strings below are the same; only the trim+truncate path
-     is centralised so a future cap change (Layer 3 RFC integration)
-     touches one location instead of three. *)
+     consolidated through [Keeper_personality_io.to_prompt_form]. Blank fields
+     now render config-drift markers instead of generic self-model text. *)
   let rendered =
     Keeper_personality_io.to_prompt_form
       ~max_bytes:Keeper_config.prompt_render_max_bytes
       { will; needs; desires; instructions = "" }
   in
   let will =
-    if rendered.will = "" then "Maintain coherent identity and goal continuity."
+    if rendered.will = "" then missing_personality_field "will"
     else rendered.will
   in
   let needs =
     if rendered.needs = "" then
-      "Reliable context continuity, factual grounding, and explicit next steps."
+      missing_personality_field "needs"
     else rendered.needs
   in
   let desires =
     if rendered.desires = "" then
-      "Make progress that is observable and useful to the user."
+      missing_personality_field "desires"
     else rendered.desires
   in
   let custom =

--- a/lib/keeper/keeper_prompt_external.ml
+++ b/lib/keeper/keeper_prompt_external.ml
@@ -54,18 +54,18 @@ let load_uncached name =
     | None ->
         Log.Keeper.warn
           "keeper_prompt_external: failed to read %s (returning None; \
-           caller will use fallback)"
+           caller will render config-drift marker)"
           path;
         None)
   else (
     (* P1-4: missing external prompt file is expected during startup when
-       the operator's base-path config does not yet have the file.  The
-       in-source OCaml fallback in keeper_prompt.ml handles this path
-       explicitly, so a WARN here fires on every startup and becomes noise.
-       Downgrade to INFO so the path is visible but not alarming. *)
+       the operator's base-path config does not yet have the file.
+       keeper_prompt.ml renders an explicit config-drift marker, so a WARN
+       here fires on every startup and becomes noise. Downgrade to INFO so
+       the path is visible but not alarming. *)
     Log.Keeper.info
       "keeper_prompt_external: missing %s (returning None; caller will \
-       use in-source fallback)"
+       render config-drift marker)"
       path;
     None)
 

--- a/lib/keeper/keeper_prompt_external.mli
+++ b/lib/keeper/keeper_prompt_external.mli
@@ -8,13 +8,13 @@
     stripped so callers receive only prompt body text.
 
     Missing files do not crash.  [get name] returns [None] and logs
-    once per name so callers can fall back to an in-source string while
-    operators iterate on the external file.
+    once per name so callers can render an explicit config-drift marker
+    while operators restore the external file.
 
     This module is a thin sibling of [Prompt_registry]: that registry
     handles versioned, override-able, frontmatter-aware system prompts.
     [Keeper_prompt_external] is for the long tail of operator-facing
-    *behavior* blocks that today live as OCaml string literals in
+    *behavior* blocks that used to live as OCaml string literals in
     [keeper_prompt.ml] — content that operators want to tune without
     rebuilding the binary, but that does not need version management
     or runtime overrides. *)

--- a/test/test_keeper_prompt_external.ml
+++ b/test/test_keeper_prompt_external.ml
@@ -18,6 +18,12 @@ let contains_substring haystack needle =
     in
     loop 0
 
+let read_file path =
+  let ic = open_in path in
+  Fun.protect
+    ~finally:(fun () -> close_in_noerr ic)
+    (fun () -> In_channel.input_all ic)
+
 let with_repo_root_cwd f =
   let original_cwd = Sys.getcwd () in
   (* Test runs out of [_build/default/test]; walk up until we find the
@@ -116,7 +122,8 @@ let test_missing_returns_none () =
       | None -> ()
       | Some _ ->
           Alcotest.fail
-            "missing file should return None (caller handles fallback)")
+            "missing file should return None (caller renders config-drift \
+             marker)")
 
 let test_cache_is_used () =
   with_repo_root_cwd (fun () ->
@@ -125,6 +132,36 @@ let test_cache_is_used () =
       let second = Lib.Keeper_prompt_external.get "profile_policy" in
       Alcotest.(check (option string))
         "cache returns identical content" first second)
+
+let test_source_has_no_generic_behavior_fallbacks () =
+  with_repo_root_cwd (fun () ->
+      let src = read_file "lib/keeper/keeper_prompt.ml" in
+      Alcotest.(check bool)
+        "profile policy generic fallback removed" false
+        (contains_substring src
+           "Maintain high standard of reasoning, factual grounding, and clear communication.");
+      Alcotest.(check bool)
+        "continuity generic fallback removed" false
+        (contains_substring src
+           "Continuity and any end-of-reply STATE formatting requirements apply");
+      Alcotest.(check bool)
+        "missing behavior marker present" true
+        (contains_substring src "Behavior prompt config drift");
+      Alcotest.(check bool)
+        "will generic fallback removed" false
+        (contains_substring src
+           "Maintain coherent identity and goal continuity.");
+      Alcotest.(check bool)
+        "needs generic fallback removed" false
+        (contains_substring src
+           "Reliable context continuity, factual grounding, and explicit next steps.");
+      Alcotest.(check bool)
+        "desires generic fallback removed" false
+        (contains_substring src
+           "Make progress that is observable and useful to the user.");
+      Alcotest.(check bool)
+        "missing personality marker present" true
+        (contains_substring src "Personality config drift"))
 
 let () =
   Alcotest.run "Keeper_prompt_external"
@@ -141,5 +178,7 @@ let () =
             test_missing_returns_none;
           Alcotest.test_case "second lookup uses cache" `Quick
             test_cache_is_used;
+          Alcotest.test_case "source has no generic behavior fallbacks"
+            `Quick test_source_has_no_generic_behavior_fallbacks;
         ] );
     ]


### PR DESCRIPTION
## Summary
- remove generic in-source behavior prompt fallbacks for missing external behavior blocks
- render explicit config-drift markers for missing behavior prompt files and blank keeper self-model fields
- update external prompt loader docs/log text so missing files no longer claim an in-source fallback path

## Why it matters
Missing prompt config should be observable to operators and keepers. Silent generic persona fallback can hide base-path/config drift and make a keeper operate under a different policy than the configured persona implies.

## Validation
- scripts/dune-local.sh build test/test_keeper_prompt_external.exe test/test_keeper_prompt_metrics.exe
- ./_build/default/test/test_keeper_prompt_external.exe
- ./_build/default/test/test_keeper_prompt_metrics.exe
- git diff --check
- rg source-only scan for removed generic fallback strings and stale in-source fallback wording