### PR TITLE
fix: mark cloud catalog probes not applicable

### DIFF
--- a/docs/observability/goal-loop-observe-metrics.md
+++ b/docs/observability/goal-loop-observe-metrics.md
@@ -68,6 +68,13 @@ The script is intentionally stdlib-only. CI can run it without installing
 YAML tooling because it checks explicit alert names, metric names, and
 threshold fragments from the contract.
 
+Cloud and subprocess-CLI providers do not support an auth-free bootstrap
+health probe. Catalog validation reports those candidates as
+`not_applicable` and keeps `masc_provider_actual_health_status` at `0`
+(`unknown`) without incrementing
+`masc_provider_health_probe_skipped_total`. The skipped counter is reserved
+for providers where a probe was expected but could not run.
+
 ## Apply
 
 Prometheus deployments should include

--- a/infrastructure/monitoring/goal-loop-observe-alerts.yml
+++ b/infrastructure/monitoring/goal-loop-observe-alerts.yml
@@ -164,9 +164,10 @@ groups:
         annotations:
           summary: "Provider health probe skipped for {{ $labels.provider_name }}"
           description: |
-            Bootstrap skipped a live probe and treated provider health as
-            advisory. The provider must not be counted healthy until a
-            completed probe writes actual health status.
+            Bootstrap expected a live probe but skipped it. Cloud and CLI
+            providers that do not support auth-free bootstrap health probes
+            are reported as not_applicable instead of incrementing this
+            warning counter.
 
       - alert: GoalLoopProviderActualHealthUnhealthyCritical
         expr: |
@@ -180,7 +181,7 @@ groups:
           summary: "Provider {{ $labels.provider_name }} is unhealthy"
           description: |
             Provider actual health status is unhealthy. Values are:
-            0 unknown, 1 healthy, 2 degraded, 3 unhealthy.
+            0 unknown or not_applicable, 1 healthy, 2 degraded, 3 unhealthy.
 
       - alert: GoalLoopPricingCatalogMissCritical
         expr: |

--- a/lib/cascade/cascade_catalog_runtime.ml
+++ b/lib/cascade/cascade_catalog_runtime.ml
@@ -1,6 +1,7 @@
 type candidate_probe_status =
   | Probe_ok
   | Probe_skipped of string
+  | Probe_not_applicable of string
   | Probe_error of string
 
 let probe_timeout_sec = 5.0
@@ -199,11 +200,21 @@ let candidate_probe_skipped (candidate : candidate_runtime) reason =
     status = Probe_skipped reason;
   }
 
+let candidate_probe_not_applicable (candidate : candidate_runtime) reason =
+  {
+    model_string = candidate.model_string;
+    provider_kind = provider_kind_string candidate.provider_cfg;
+    model_id = candidate.provider_cfg.model_id;
+    base_url = candidate.provider_cfg.base_url;
+    status = Probe_not_applicable reason;
+  }
+
 let local_probe_unavailable_reason =
   "local provider health probe requires Eio runtime capabilities"
 
-let cloud_skip_reason =
-  "cloud provider health is advisory; bootstrap probes local endpoints only"
+let cloud_probe_not_applicable_reason =
+  "cloud provider live health is not an auth-free bootstrap probe; \
+   credential/config validation is handled before execution"
 
 let profile_probes (profile_candidates : candidate_runtime list) =
   List.map
@@ -211,7 +222,8 @@ let profile_probes (profile_candidates : candidate_runtime list) =
       if Llm_provider.Provider_config.is_local candidate.provider_cfg then
         candidate_probe_error candidate local_probe_unavailable_reason
       else
-        candidate_probe_skipped candidate cloud_skip_reason)
+        candidate_probe_not_applicable candidate
+          cloud_probe_not_applicable_reason)
     profile_candidates
 
 let normalize_endpoint_url url =
@@ -236,7 +248,8 @@ let profile_probes_from_statuses statuses profile_candidates =
   List.map
     (fun (candidate : candidate_runtime) ->
       if not (Llm_provider.Provider_config.is_local candidate.provider_cfg) then
-        candidate_probe_skipped candidate cloud_skip_reason
+        candidate_probe_not_applicable candidate
+          cloud_probe_not_applicable_reason
       else
         match endpoint_status_for_candidate statuses candidate with
         | Some status when status.healthy -> candidate_probe_ok candidate
@@ -282,6 +295,7 @@ let attach_probe_results ?sw ?net (profiles : profile_snapshot list) =
 
 let probe_health_value = function
   | Probe_skipped _ -> 0.0
+  | Probe_not_applicable _ -> 0.0
   | Probe_ok -> 1.0
   | Probe_error _ -> 3.0
 
@@ -300,7 +314,7 @@ let record_probe_metrics (profiles : profile_snapshot list) =
                      ("profile_name", profile.name);
                    ]
                  ()
-           | Probe_ok | Probe_error _ -> ());
+           | Probe_not_applicable _ | Probe_ok | Probe_error _ -> ());
           Prometheus.set_gauge
             Prometheus.metric_provider_actual_health_status
             ~labels:
@@ -324,12 +338,13 @@ let candidate_probe_to_yojson (probe : candidate_probe) =
         match probe.status with
         | Probe_ok -> `String "ok"
         | Probe_skipped _ -> `String "skipped"
-        | Probe_error message ->
-            `String "error" );
+        | Probe_not_applicable _ -> `String "not_applicable"
+        | Probe_error _ -> `String "error" );
       ( "error",
         match probe.status with
         | Probe_ok -> `Null
         | Probe_skipped message -> `String message
+        | Probe_not_applicable message -> `String message
         | Probe_error message -> `String message );
     ]
 

--- a/lib/cascade/cascade_catalog_runtime.mli
+++ b/lib/cascade/cascade_catalog_runtime.mli
@@ -12,6 +12,7 @@
 type candidate_probe_status =
   | Probe_ok
   | Probe_skipped of string
+  | Probe_not_applicable of string
   | Probe_error of string
 
 type candidate_probe = {

--- a/test/test_cascade_catalog_runtime.ml
+++ b/test/test_cascade_catalog_runtime.ml
@@ -486,6 +486,48 @@ let test_valid_catalog_probes_local_endpoints_when_eio_caps_available () =
     (skip_metric () -. before_skip_metric);
   check (float 0.0001) "unhealthy local probe gauge" 3.0 (health_metric ())
 
+let test_cloud_probe_is_not_applicable_not_skipped () =
+  with_temp_dir "cascade-catalog-runtime-cloud-probe" @@ fun dir ->
+  let config_dir = Filename.concat dir "config" in
+  init_config_root config_dir;
+  with_config_dir config_dir @@ fun () ->
+  let skipped_metric () =
+    Prometheus.metric_value_or_zero
+      Prometheus.metric_provider_health_probe_skipped
+      ~labels:[("provider_name", "codex_cli"); ("profile_name", "big_three")]
+      ()
+  in
+  let before_skipped_metric = skipped_metric () in
+  ignore
+    (write_cascade_json config_dir
+       {|{
+  "big_three_models": ["codex_cli:auto"]
+}|});
+  let snapshot =
+    match Cascade_catalog_runtime.inspect_active () with
+    | Ok (Cascade_catalog_runtime.Validated snapshot) -> snapshot
+    | Ok state ->
+        failf "expected fully validated cloud-only snapshot, got %s"
+          (Yojson.Safe.to_string
+             (Cascade_catalog_runtime.state_to_yojson state))
+    | Error rejection ->
+        failf "unexpected cloud-only rejection: %s"
+          (Yojson.Safe.to_string
+             (Cascade_catalog_runtime.rejection_to_yojson rejection))
+  in
+  let snapshot_string =
+    Yojson.Safe.to_string (Cascade_catalog_runtime.snapshot_to_yojson snapshot)
+  in
+  check bool "cloud probe is explicitly not applicable" true
+    (contains_substring snapshot_string "\"status\":\"not_applicable\"");
+  check bool "cloud probe explains auth-free bootstrap boundary" true
+    (contains_substring snapshot_string "auth-free bootstrap probe");
+  check bool "cloud probe is not counted as skipped" false
+    (contains_substring snapshot_string "\"status\":\"skipped\"");
+  check (float 0.0001) "cloud probe skipped metric does not increment"
+    0.0
+    (skipped_metric () -. before_skipped_metric)
+
 let test_invalid_hot_reload_preserves_last_known_good () =
   with_temp_dir "cascade-catalog-lkg" @@ fun dir ->
   let config_dir = Filename.concat dir "config" in
@@ -1192,6 +1234,10 @@ let () =
             "invalid hot reload preserves last-known-good"
             `Quick
             test_invalid_hot_reload_preserves_last_known_good;
+          test_case
+            "cloud probe is not applicable, not skipped"
+            `Quick
+            test_cloud_probe_is_not_applicable_not_skipped;
           test_case
             "legacy runtime wrapper does not fallback to defaults"
             `Quick


### PR DESCRIPTION
## Summary
- add a distinct catalog probe status for cloud/subprocess CLI providers where auth-free bootstrap health probing is not meaningful
- keep actual health status at unknown for those providers without incrementing the skipped-probe warning counter
- update GOAL LOOP Observe alert/docs wording and add a cascade catalog regression test

## Why it matters
Cloud providers were serialized as skipped probes even though the runtime only has an auth-free bootstrap probe for local endpoints. That made skipped-probe warnings ambiguous: a real skipped local probe and an intentionally unprobed cloud/CLI provider looked the same.

## Validation
- scripts/dune-local.sh build test/test_cascade_catalog_runtime.exe
- ./_build/default/test/test_cascade_catalog_runtime.exe
- python3 scripts/validate_goal_loop_observe_metrics.py infrastructure/monitoring/goal-loop-observe-metrics.contract.json --alerts-yml infrastructure/monitoring/goal-loop-observe-alerts.yml --dashboard-json infrastructure/monitoring/grafana-goal-loop-observe-dashboard.json --require-complete --format text
- git diff --check