### PR TITLE
fix: make status tray thresholds data-driven

### DIFF
--- a/dashboard/cockpit-kit/README.md
+++ b/dashboard/cockpit-kit/README.md
@@ -25,6 +25,11 @@ Interactive recreation of the MASC single-pane cockpit. One HTML, React-driven, 
 - `Chrome.jsx` — `Topbar` · `Ticker` · `KpiStrip` · `Lifeline` (top-of-screen surfaces)
 - `Panels.jsx` — `Sidebar` · `Swimlanes` · `Deck` · `Rail` · `Composer` · `StatusBar` (main work area)
 
+## Data knobs
+
+- `MASC_DATA.status_tray_thresholds.fail_urgent` controls when the status tray promotes failure events to urgent. Fallback: `3`.
+- `MASC_DATA.status_tray_thresholds.cascade_info` controls when cascade events become the KPI spotlight. Fallback: `2`.
+
 ## Notes
 
 - Surfaces are grouped into two JSX files (`Chrome.jsx` and `Panels.jsx`) rather than one file per surface — small, related components share a file to keep the module count low.

--- a/dashboard/cockpit-kit/StatusTray.jsx
+++ b/dashboard/cockpit-kit/StatusTray.jsx
@@ -12,6 +12,43 @@
 
 const { useState: _stUseState, useEffect: _stUseEffect, useRef: _stUseRef, useMemo: _stUseMemo } = React;
 
+const STATUS_TRAY_DEFAULT_THRESHOLDS = Object.freeze({
+  failUrgent: 3,
+  cascadeInfo: 2,
+});
+
+function _statusTrayPositiveInt(value, fallback) {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed > 0 ? Math.floor(parsed) : fallback;
+}
+
+function _statusTrayThresholds(D) {
+  const thresholds = (D && (
+    D.status_tray_thresholds ||
+    D.statusTrayThresholds ||
+    (D.thresholds && (D.thresholds.status_tray || D.thresholds.statusTray)) ||
+    {}
+  )) || {};
+  return {
+    failUrgent: _statusTrayPositiveInt(
+      thresholds.fail_urgent ||
+      thresholds.failUrgent ||
+      thresholds.fail_count ||
+      thresholds.failCount ||
+      thresholds.fails,
+      STATUS_TRAY_DEFAULT_THRESHOLDS.failUrgent
+    ),
+    cascadeInfo: _statusTrayPositiveInt(
+      thresholds.cascade_info ||
+      thresholds.cascadeInfo ||
+      thresholds.cascade_count ||
+      thresholds.cascadeCount ||
+      thresholds.cascades,
+      STATUS_TRAY_DEFAULT_THRESHOLDS.cascadeInfo
+    ),
+  };
+}
+
 function _useTrayPop() {
   const [open, setOpen] = _stUseState(null); // 'kpi' | 'life' | 'ticker' | 'keepers' | null
   const ref = _stUseRef(null);
@@ -65,9 +102,13 @@ function _statusCounts(D) {
 // Pick the dot to spotlight in the KPI slot. Only the urgent paths
 // have real meaning today; for the calm path we expose the raw event
 // count rather than a fabricated TPS number.
-function _kpiSpotlight(counts) {
-  if (counts.fails >= 3) return { l: "fails", v: counts.fails, t: "err", u: "", urgent: true };
-  if (counts.cascades >= 2) return { l: "cascade", v: counts.cascades, t: "info", u: "" };
+function _kpiSpotlight(counts, thresholds) {
+  if (counts.fails >= thresholds.failUrgent) {
+    return { l: "fails", v: counts.fails, t: "err", u: "", urgent: true };
+  }
+  if (counts.cascades >= thresholds.cascadeInfo) {
+    return { l: "cascade", v: counts.cascades, t: "info", u: "" };
+  }
   return { l: "events", v: counts.evCount, t: "brass", u: "" };
 }
 
@@ -77,7 +118,11 @@ function StatusTray() {
   const hidden = !!cs.trayHidden;
   const [open, setOpen, ref] = _useTrayPop();
   const counts = _stUseMemo(() => _statusCounts(D), [D.events, D.keepers]);
-  const spot = _kpiSpotlight(counts);
+  const thresholds = _stUseMemo(
+    () => _statusTrayThresholds(D),
+    [D.status_tray_thresholds, D.statusTrayThresholds, D.thresholds]
+  );
+  const spot = _kpiSpotlight(counts, thresholds);
   const events = counts.lastEvent;
   const evCount = counts.evCount;
   const keepers = D.keepers || [];

--- a/dashboard/design-system/ui_kits/cockpit/StatusTray.jsx
+++ b/dashboard/design-system/ui_kits/cockpit/StatusTray.jsx
@@ -12,6 +12,43 @@
 
 const { useState: _stUseState, useEffect: _stUseEffect, useRef: _stUseRef } = React;
 
+const STATUS_TRAY_DEFAULT_THRESHOLDS = Object.freeze({
+  failUrgent: 3,
+  cascadeInfo: 2,
+});
+
+function _statusTrayPositiveInt(value, fallback) {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed > 0 ? Math.floor(parsed) : fallback;
+}
+
+function _statusTrayThresholds(D) {
+  const thresholds = (D && (
+    D.status_tray_thresholds ||
+    D.statusTrayThresholds ||
+    (D.thresholds && (D.thresholds.status_tray || D.thresholds.statusTray)) ||
+    {}
+  )) || {};
+  return {
+    failUrgent: _statusTrayPositiveInt(
+      thresholds.fail_urgent ||
+      thresholds.failUrgent ||
+      thresholds.fail_count ||
+      thresholds.failCount ||
+      thresholds.fails,
+      STATUS_TRAY_DEFAULT_THRESHOLDS.failUrgent
+    ),
+    cascadeInfo: _statusTrayPositiveInt(
+      thresholds.cascade_info ||
+      thresholds.cascadeInfo ||
+      thresholds.cascade_count ||
+      thresholds.cascadeCount ||
+      thresholds.cascades,
+      STATUS_TRAY_DEFAULT_THRESHOLDS.cascadeInfo
+    ),
+  };
+}
+
 function _useTrayPop() {
   const [open, setOpen] = _stUseState(null); // 'kpi' | 'life' | 'ticker' | 'keepers' | null
   const ref = _stUseRef(null);
@@ -31,12 +68,16 @@ function _useTrayPop() {
   return [open, setOpen, ref];
 }
 
-function _kpiSpotlight(D) {
+function _kpiSpotlight(D, thresholds) {
   const evs = (D && D.events) || [];
   const fails = evs.filter(e => e.kind === "fail").length;
   const cascades = evs.filter(e => e.kind === "cascade").length;
-  if (fails >= 3) return { l: "Fails", v: fails, t: "err",  u: "/47", urgent: true };
-  if (cascades >= 2) return { l: "Cascade", v: cascades, t: "info", u: "@step" };
+  if (fails >= thresholds.failUrgent) {
+    return { l: "Fails", v: fails, t: "err",  u: "/47", urgent: true };
+  }
+  if (cascades >= thresholds.cascadeInfo) {
+    return { l: "Cascade", v: cascades, t: "info", u: "@step" };
+  }
   return { l: "tps", v: "1.24", t: "brass", u: "tps" };
 }
 
@@ -45,7 +86,8 @@ function StatusTray() {
   const [cs, setCs] = (window.useCockpitState ? window.useCockpitState() : [{trayHidden:false}, ()=>{}]);
   const hidden = !!cs.trayHidden;
   const [open, setOpen, ref] = _useTrayPop();
-  const spot = _kpiSpotlight(D);
+  const thresholds = _statusTrayThresholds(D);
+  const spot = _kpiSpotlight(D, thresholds);
   const events = (D.events || []).slice(-1)[0];
   const evCount = (D.events || []).length;
   const keepers = (D.keepers || []);

--- a/dashboard/src/cockpit-status-tray-source.test.ts
+++ b/dashboard/src/cockpit-status-tray-source.test.ts
@@ -1,0 +1,29 @@
+import { readFileSync } from 'node:fs'
+
+import { describe, expect, it } from 'vitest'
+
+const readSource = (relativePath: string) =>
+  readFileSync(new URL(relativePath, import.meta.url), 'utf8')
+
+describe('cockpit status tray source', () => {
+  const sources = [
+    ['live cockpit kit', '../cockpit-kit/StatusTray.jsx'],
+    ['design-system cockpit kit', '../design-system/ui_kits/cockpit/StatusTray.jsx'],
+  ] as const
+
+  it.each(sources)('uses MASC_DATA threshold knobs in %s', (_label, path) => {
+    const src = readSource(path)
+    expect(src).toContain('status_tray_thresholds')
+    expect(src).toContain('statusTrayThresholds')
+    expect(src).toContain('failUrgent')
+    expect(src).toContain('cascadeInfo')
+  })
+
+  it.each(sources)('does not branch on fixed event thresholds in %s', (_label, path) => {
+    const src = readSource(path)
+    expect(src).not.toMatch(/\bfails\s*>=\s*3\b/)
+    expect(src).not.toMatch(/\bcascades\s*>=\s*2\b/)
+    expect(src).not.toMatch(/\bcounts\.fails\s*>=\s*3\b/)
+    expect(src).not.toMatch(/\bcounts\.cascades\s*>=\s*2\b/)
+  })
+})


### PR DESCRIPTION
## Summary

- Replace hardcoded StatusTray failure/cascade promotion branches with data-driven `MASC_DATA.status_tray_thresholds` knobs.
- Keep conservative fallback values for absent runtime data while letting dashboard payloads override the thresholds.
- Mirror the behavior in the design-system cockpit copy and document the supported data knobs.
- Add a source-level regression guard so the fixed `fails >= 3` / `cascades >= 2` branches do not come back.

## Why

The Kimi cleanup roadmap flagged StatusTray threshold hardcoding as another runtime-truth drift point. The tray should reflect runtime-provided policy when available instead of baking those policy cutoffs into the UI branch conditions.

## Validation

- `rg -n "fails\\s*>=\\s*3|cascades\\s*>=\\s*2|counts\\.fails\\s*>=\\s*3|counts\\.cascades\\s*>=\\s*2" dashboard/cockpit-kit/StatusTray.jsx dashboard/design-system/ui_kits/cockpit/StatusTray.jsx dashboard/src/cockpit-status-tray-source.test.ts` returned no matches.
- `git diff --check`
- `node -e "const fs=require('fs'); const paths=['dashboard/cockpit-kit/StatusTray.jsx','dashboard/design-system/ui_kits/cockpit/StatusTray.jsx']; for (const p of paths) { const s=fs.readFileSync(p,'utf8'); if (!s.includes('status_tray_thresholds') || !s.includes('statusTrayThresholds')) throw new Error(p + ': missing threshold knobs'); if (/\\bfails\\s*>=\\s*3\\b/.test(s) || /\\bcascades\\s*>=\\s*2\\b/.test(s) || /\\bcounts\\.fails\\s*>=\\s*3\\b/.test(s) || /\\bcounts\\.cascades\\s*>=\\s*2\\b/.test(s)) throw new Error(p + ': fixed threshold branch'); } console.log('status tray threshold source check: PASS');"`
- Focused Vitest command was attempted but not runnable locally in this fresh worktree because `dashboard/node_modules` is absent and `vitest` is not installed there; the committed Vitest guard is intended for CI/dependency-equipped runs.