### PR TITLE
fix: derive keeper badge registry by default

### DIFF
--- a/dashboard/cockpit-kit/cb-shared.jsx
+++ b/dashboard/cockpit-kit/cb-shared.jsx
@@ -104,22 +104,37 @@ function SectionHeading({
 // SPEC §3.6 v0.3: color alone never identifies a keeper. Always emit
 // color + sigil. <KeeperBadge> is the canonical attribution unit.
 //
-// kSlot(id)  → 1..12, deterministic hash → palette slot
-// kSigil(id) → 2-letter monogram for the badge face
+// kSlot(id)  → optional runtime override, else deterministic hash → palette slot
+// kSigil(id) → optional runtime override, else 2-letter monogram
 //
 // 12-slot mapping uses skip-3 stride so adjacent IDs in a list land on
 // hues ≥90° apart, preserving discriminability up to ~10 active keepers.
 
-const KEEPER_REGISTRY = {
-  // canonical 5 — pinned to fixed slots for brand recall.
-  // These match the legacy alias targets in tokens.css §3 so visual
-  // identity is preserved across the v0.2→v0.3 migration.
-  'nick0cave':     { slot: 3,  sigil: 'NK' },  /* amber */
-  'masc-improver': { slot: 6,  sigil: 'MS' },  /* jade  */
-  'sangsu':        { slot: 9,  sigil: 'SS' },  /* sky   */
-  'qa-king':       { slot: 2,  sigil: 'QA' },  /* clay  */
-  'rama':          { slot: 11, sigil: 'RM' },  /* violet */
-};
+const KEEPER_REGISTRY = Object.freeze({});
+
+function _keeperRegistryEntry(raw) {
+  if (!raw || typeof raw !== 'object') return null;
+  const slot = Number(raw.slot);
+  const sigil = String(raw.sigil || '').replace(/[^a-z0-9]/gi, '').slice(0, 2).toUpperCase();
+  if (!Number.isInteger(slot) || slot < 1 || slot > 12 || sigil.length !== 2) return null;
+  return { slot, sigil };
+}
+
+function _keeperRegistry() {
+  const data = window.MASC_DATA || {};
+  const raw = data.keeper_registry || data.keeperRegistry || KEEPER_REGISTRY;
+  if (!raw || typeof raw !== 'object') return {};
+  const resolved = {};
+  Object.entries(raw).forEach(([id, entry]) => {
+    const normalized = _keeperRegistryEntry(entry);
+    if (normalized) resolved[id] = normalized;
+  });
+  return resolved;
+}
+
+function _keeperRegistryLookup(id) {
+  return _keeperRegistry()[String(id)] || null;
+}
 
 // FNV-1a 32-bit hash → 1..12 (avoid 0)
 function _hash12(str) {
@@ -132,12 +147,14 @@ function _hash12(str) {
 }
 
 function kSlot(id) {
-  if (KEEPER_REGISTRY[id]) return KEEPER_REGISTRY[id].slot;
+  const reg = _keeperRegistryLookup(id);
+  if (reg) return reg.slot;
   return _hash12(String(id));
 }
 
 function kSigil(id) {
-  if (KEEPER_REGISTRY[id]) return KEEPER_REGISTRY[id].sigil;
+  const reg = _keeperRegistryLookup(id);
+  if (reg) return reg.sigil;
   // Auto-derive: first letter + first letter after hyphen, else first 2.
   const s = String(id).replace(/[^a-z0-9-]/gi, '');
   const parts = s.split('-').filter(Boolean);

--- a/dashboard/design-system/preview/cb-shared.jsx
+++ b/dashboard/design-system/preview/cb-shared.jsx
@@ -98,22 +98,37 @@ function SectionHeading({
 // SPEC §3.6 v0.3: color alone never identifies a keeper. Always emit
 // color + sigil. <KeeperBadge> is the canonical attribution unit.
 //
-// kSlot(id)  → 1..12, deterministic hash → palette slot
-// kSigil(id) → 2-letter monogram for the badge face
+// kSlot(id)  → optional runtime override, else deterministic hash → palette slot
+// kSigil(id) → optional runtime override, else 2-letter monogram
 //
 // 12-slot mapping uses skip-3 stride so adjacent IDs in a list land on
 // hues ≥90° apart, preserving discriminability up to ~10 active keepers.
 
-const KEEPER_REGISTRY = {
-  // canonical 5 — pinned to fixed slots for brand recall.
-  // These match the legacy alias targets in tokens.css §3 so visual
-  // identity is preserved across the v0.2→v0.3 migration.
-  'nick0cave':     { slot: 3,  sigil: 'NK' },  /* amber */
-  'masc-improver': { slot: 6,  sigil: 'MS' },  /* jade  */
-  'sangsu':        { slot: 9,  sigil: 'SS' },  /* sky   */
-  'qa-king':       { slot: 2,  sigil: 'QA' },  /* clay  */
-  'rama':          { slot: 11, sigil: 'RM' },  /* violet */
-};
+const KEEPER_REGISTRY = Object.freeze({});
+
+function _keeperRegistryEntry(raw) {
+  if (!raw || typeof raw !== 'object') return null;
+  const slot = Number(raw.slot);
+  const sigil = String(raw.sigil || '').replace(/[^a-z0-9]/gi, '').slice(0, 2).toUpperCase();
+  if (!Number.isInteger(slot) || slot < 1 || slot > 12 || sigil.length !== 2) return null;
+  return { slot, sigil };
+}
+
+function _keeperRegistry() {
+  const data = window.MASC_DATA || {};
+  const raw = data.keeper_registry || data.keeperRegistry || KEEPER_REGISTRY;
+  if (!raw || typeof raw !== 'object') return {};
+  const resolved = {};
+  Object.entries(raw).forEach(([id, entry]) => {
+    const normalized = _keeperRegistryEntry(entry);
+    if (normalized) resolved[id] = normalized;
+  });
+  return resolved;
+}
+
+function _keeperRegistryLookup(id) {
+  return _keeperRegistry()[String(id)] || null;
+}
 
 // FNV-1a 32-bit hash → 1..12 (avoid 0)
 function _hash12(str) {
@@ -126,12 +141,14 @@ function _hash12(str) {
 }
 
 function kSlot(id) {
-  if (KEEPER_REGISTRY[id]) return KEEPER_REGISTRY[id].slot;
+  const reg = _keeperRegistryLookup(id);
+  if (reg) return reg.slot;
   return _hash12(String(id));
 }
 
 function kSigil(id) {
-  if (KEEPER_REGISTRY[id]) return KEEPER_REGISTRY[id].sigil;
+  const reg = _keeperRegistryLookup(id);
+  if (reg) return reg.sigil;
   // Auto-derive: first letter + first letter after hyphen, else first 2.
   const s = String(id).replace(/[^a-z0-9-]/gi, '');
   const parts = s.split('-').filter(Boolean);

--- a/dashboard/src/cb-shared-registry-source.test.ts
+++ b/dashboard/src/cb-shared-registry-source.test.ts
@@ -1,0 +1,35 @@
+import { readFileSync } from 'node:fs'
+
+import { describe, expect, it } from 'vitest'
+
+const readSource = (relativePath: string) =>
+  readFileSync(new URL(relativePath, import.meta.url), 'utf8')
+
+describe('cb-shared keeper registry source', () => {
+  const sources = [
+    ['live cockpit kit', '../cockpit-kit/cb-shared.jsx'],
+    ['design-system preview', '../design-system/preview/cb-shared.jsx'],
+  ] as const
+
+  const bakedInKeeperNames = [
+    'nick0cave',
+    'masc-improver',
+    'sangsu',
+    'qa-king',
+    'rama',
+  ]
+
+  it.each(sources)('does not bake keeper names into %s', (_label, path) => {
+    const src = readSource(path)
+    for (const name of bakedInKeeperNames) {
+      expect(src).not.toContain(name)
+    }
+  })
+
+  it.each(sources)('uses runtime data plus hash fallback in %s', (_label, path) => {
+    const src = readSource(path)
+    expect(src).toContain('MASC_DATA')
+    expect(src).toContain('keeper_registry')
+    expect(src).toContain('_hash12')
+  })
+})

--- a/dashboard/src/components/keeper-badge.test.ts
+++ b/dashboard/src/components/keeper-badge.test.ts
@@ -1,13 +1,38 @@
 import { describe, it, expect } from 'vitest'
-import { kSlot, kSigil, KEEPER_REGISTRY } from './keeper-badge'
+import {
+  kSlot,
+  kSigil,
+  KEEPER_REGISTRY,
+  normalizeKeeperRegistry,
+} from './keeper-badge'
+
+interface TestMascWindow extends Window {
+  MASC_DATA?: {
+    keeper_registry?: unknown
+    keeperRegistry?: unknown
+  }
+}
+
+function withMascData(data: TestMascWindow['MASC_DATA'], fn: () => void) {
+  const w = window as TestMascWindow
+  const previous = w.MASC_DATA
+  w.MASC_DATA = data
+  try {
+    fn()
+  } finally {
+    if (previous === undefined) {
+      delete w.MASC_DATA
+    } else {
+      w.MASC_DATA = previous
+    }
+  }
+}
 
 describe('kSlot', () => {
-  it('returns pinned slot for KEEPER_REGISTRY ids', () => {
-    expect(kSlot('nick0cave')).toBe(3)
-    expect(kSlot('masc-improver')).toBe(6)
-    expect(kSlot('sangsu')).toBe(9)
-    expect(kSlot('qa-king')).toBe(2)
-    expect(kSlot('rama')).toBe(11)
+  it('uses runtime keeper_registry overrides when present', () => {
+    withMascData({ keeper_registry: { runtime_keeper: { slot: 7, sigil: 'RK' } } }, () => {
+      expect(kSlot('runtime_keeper')).toBe(7)
+    })
   })
 
   it('returns deterministic slot 1..12 for unknown ids', () => {
@@ -25,10 +50,10 @@ describe('kSlot', () => {
 })
 
 describe('kSigil', () => {
-  it('returns pinned sigil for KEEPER_REGISTRY ids', () => {
-    expect(kSigil('nick0cave')).toBe('NK')
-    expect(kSigil('masc-improver')).toBe('MS')
-    expect(kSigil('rama')).toBe('RM')
+  it('uses runtime keeper_registry sigils when present', () => {
+    withMascData({ keeper_registry: { runtime_keeper: { slot: 7, sigil: 'RK' } } }, () => {
+      expect(kSigil('runtime_keeper')).toBe('RK')
+    })
   })
 
   it('extracts first letter + first letter after hyphen for hyphenated ids', () => {
@@ -51,26 +76,28 @@ describe('kSigil', () => {
   })
 })
 
+describe('normalizeKeeperRegistry', () => {
+  it('keeps valid runtime entries and drops invalid entries', () => {
+    expect(
+      normalizeKeeperRegistry({
+        good: { slot: 12, sigil: 'GK' },
+        low: { slot: 0, sigil: 'LO' },
+        high: { slot: 13, sigil: 'HI' },
+        sigil: { slot: 1, sigil: '?' },
+      }),
+    ).toEqual({ good: { slot: 12, sigil: 'GK' } })
+  })
+
+  it('accepts camelCase runtime key for browser data', () => {
+    withMascData({ keeperRegistry: { camel: { slot: 4, sigil: 'CM' } } }, () => {
+      expect(kSlot('camel')).toBe(4)
+      expect(kSigil('camel')).toBe('CM')
+    })
+  })
+})
+
 describe('KEEPER_REGISTRY', () => {
-  it('has 5 pinned canonical ids', () => {
-    expect(Object.keys(KEEPER_REGISTRY)).toHaveLength(5)
-  })
-
-  it('all pinned slots are within 1..12', () => {
-    for (const entry of Object.values(KEEPER_REGISTRY)) {
-      expect(entry.slot).toBeGreaterThanOrEqual(1)
-      expect(entry.slot).toBeLessThanOrEqual(12)
-    }
-  })
-
-  it('all sigils are exactly 2 uppercase chars', () => {
-    for (const entry of Object.values(KEEPER_REGISTRY)) {
-      expect(entry.sigil).toMatch(/^[A-Z]{2}$/)
-    }
-  })
-
-  it('all pinned slots are unique', () => {
-    const slots = Object.values(KEEPER_REGISTRY).map((e) => e.slot)
-    expect(new Set(slots).size).toBe(slots.length)
+  it('ships with no baked-in keeper names', () => {
+    expect(Object.keys(KEEPER_REGISTRY)).toHaveLength(0)
   })
 })

--- a/dashboard/src/components/keeper-badge.ts
+++ b/dashboard/src/components/keeper-badge.ts
@@ -4,10 +4,9 @@
 // a keeper. Always emit color + sigil. <KeeperBadge> is the canonical
 // attribution unit anywhere in the dashboard.
 //
-// Slot resolution: kSlot(id) → 1..12 deterministic FNV-1a hash, with
-// 5 anchor ids in KEEPER_REGISTRY pinned for brand recall.
-// Sigil: kSigil(id) → 2-letter monogram (registry override or
-// auto-derived from id).
+// Slot resolution: kSlot(id) → optional runtime override, else 1..12
+// deterministic FNV-1a hash.
+// Sigil: kSigil(id) → optional runtime override, else 2-letter monogram.
 
 import { html } from 'htm/preact'
 import type { VNode } from 'preact'
@@ -18,15 +17,43 @@ export interface KeeperRegistryEntry {
   sigil: string
 }
 
-export const KEEPER_REGISTRY: Record<string, KeeperRegistryEntry> = {
-  // Canonical 5 — pinned slots for brand recall.
-  // These match the v0.2 alias targets in design-system tokens
-  // so visual identity is preserved across the v0.2→v0.3 migration.
-  'nick0cave':     { slot: 3,  sigil: 'NK' },  /* amber  */
-  'masc-improver': { slot: 6,  sigil: 'MS' },  /* jade   */
-  'sangsu':        { slot: 9,  sigil: 'SS' },  /* sky    */
-  'qa-king':       { slot: 2,  sigil: 'QA' },  /* clay   */
-  'rama':          { slot: 11, sigil: 'RM' },  /* violet */
+export const KEEPER_REGISTRY: Record<string, KeeperRegistryEntry> = {}
+
+interface MascDataWindow extends Window {
+  MASC_DATA?: {
+    keeper_registry?: unknown
+    keeperRegistry?: unknown
+  }
+}
+
+function normalizeKeeperSigil(raw: unknown): string | null {
+  if (typeof raw !== 'string') return null
+  const sigil = raw.replace(/[^a-z0-9]/gi, '').slice(0, 2).toUpperCase()
+  return sigil.length === 2 ? sigil : null
+}
+
+export function normalizeKeeperRegistry(
+  raw: unknown,
+): Record<string, KeeperRegistryEntry> {
+  if (!raw || typeof raw !== 'object') return {}
+  const resolved: Record<string, KeeperRegistryEntry> = {}
+  for (const [id, value] of Object.entries(raw)) {
+    if (!value || typeof value !== 'object') continue
+    const entry = value as Record<string, unknown>
+    const slot = Number(entry.slot)
+    const sigil = normalizeKeeperSigil(entry.sigil)
+    if (!Number.isInteger(slot) || slot < 1 || slot > 12 || !sigil) continue
+    resolved[id] = { slot, sigil }
+  }
+  return resolved
+}
+
+function runtimeKeeperRegistry(): Record<string, KeeperRegistryEntry> {
+  if (typeof window === 'undefined') return KEEPER_REGISTRY
+  const data = (window as MascDataWindow).MASC_DATA
+  return normalizeKeeperRegistry(
+    data?.keeper_registry ?? data?.keeperRegistry ?? KEEPER_REGISTRY,
+  )
 }
 
 // FNV-1a 32-bit hash mapped onto 1..12 (avoids 0 so slot is 1-indexed).
@@ -40,13 +67,13 @@ function hash12(str: string): number {
 }
 
 export function kSlot(id: string): number {
-  const reg = KEEPER_REGISTRY[id]
+  const reg = runtimeKeeperRegistry()[id]
   if (reg) return reg.slot
   return hash12(String(id))
 }
 
 export function kSigil(id: string): string {
-  const reg = KEEPER_REGISTRY[id]
+  const reg = runtimeKeeperRegistry()[id]
   if (reg) return reg.sigil
   // Auto-derive: first letter + first letter after hyphen, else first 2.
   const s = String(id).replace(/[^a-z0-9-]/gi, '')
@@ -152,4 +179,3 @@ export function KeeperBadge({
     </span>
   `
 }
-


### PR DESCRIPTION
## Summary

- Remove the five baked-in keeper identities from the cockpit `cb-shared.jsx` badge registry.
- Apply the same no-baked-names behavior to the design-system preview twin and production `keeper-badge.ts` helper.
- Keep deterministic hash/sigil derivation as the default identity path, with optional `MASC_DATA.keeper_registry` / `keeperRegistry` runtime overrides for explicitly supplied slots and sigils.
- Add tests for runtime overrides, empty default registry behavior, and source-level protection against reintroducing the old hardcoded keeper names in the two `cb-shared.jsx` copies.

## Why

The Kimi cleanup roadmap flagged `cb-shared.jsx` `KEEPER_REGISTRY` as a dead hardcoded cache. The badge surface should not carry a fixed list of keeper names; runtime data can override identity metadata when needed, otherwise the existing deterministic fallback is the stable default.

## Validation

- `pnpm --dir dashboard install --frozen-lockfile --offline` (used local store; no downloads)
- `pnpm --dir dashboard exec tsc --noEmit --pretty`
- `pnpm --dir dashboard exec vitest run src/components/keeper-badge.test.ts src/cb-shared-registry-source.test.ts --config vitest.config.ts --no-file-parallelism --maxWorkers=1` (2 files, 15 tests)
- `pnpm --dir dashboard exec eslint src/components/keeper-badge.ts`
- `pnpm --dir dashboard exec eslint src/components/keeper-badge.ts src/components/keeper-badge.test.ts src/cb-shared-registry-source.test.ts` returned 0; the two test files are currently ignored by the dashboard ESLint config.
- `node -e "const fs=require('fs'); const sources=['dashboard/cockpit-kit/cb-shared.jsx','dashboard/design-system/preview/cb-shared.jsx','dashboard/src/components/keeper-badge.ts']; const names=['nick0cave','masc-improver','sangsu','qa-king','rama']; for (const p of sources) { const s=fs.readFileSync(p,'utf8'); for (const name of names) { if (s.includes(name)) throw new Error(p + ': baked keeper name ' + name); } if (!s.includes('keeper_registry')) throw new Error(p + ': missing keeper_registry runtime key'); } console.log('keeper badge registry source check: PASS');"`
- `git diff --check`