### PR TITLE
fix: make heuristic metrics buffer cap configurable

### DIFF
--- a/lib/config/env_config_runtime.ml
+++ b/lib/config/env_config_runtime.ml
@@ -74,6 +74,20 @@ module Cache = struct
     get_int ~default:1000 "MASC_CACHE_MAX_ENTRIES"
 end
 
+(** {1 Heuristic Metrics} *)
+
+module Heuristic_metrics = struct
+  (** Maximum in-memory heuristic metric rows to batch before forcing a
+      JSONL flush.
+
+      @category Telemetry
+      @ops_class operator *)
+  let buffer_cap =
+    get_int ~default:64 "MASC_HEURISTIC_METRICS_BUFFER_CAP"
+    |> max 1
+    |> min 10_000
+end
+
 (** {1 Task Claim Configuration} *)
 
 module Claim = struct

--- a/lib/config/env_config_runtime.mli
+++ b/lib/config/env_config_runtime.mli
@@ -53,6 +53,12 @@ module Cache : sig
   val max_entries : int
 end
 
+(** {1 Heuristic metrics} *)
+
+module Heuristic_metrics : sig
+  val buffer_cap : int
+end
+
 (** {1 Task claim} *)
 
 module Claim : sig

--- a/lib/heuristic_metrics.ml
+++ b/lib/heuristic_metrics.ml
@@ -152,7 +152,11 @@ let mu = Stdlib.Mutex.create ()
 
 (** In-memory buffer to batch writes.  Flushed periodically or on [flush]. *)
 let buffer : Yojson.Safe.t Queue.t = Queue.create ()
-let buffer_cap = 64
+let default_buffer_cap () = Env_config_runtime.Heuristic_metrics.buffer_cap
+let buffer_cap_ref = ref (default_buffer_cap ())
+
+let buffer_cap () =
+  max 1 !buffer_cap_ref
 
 (* #10348: time-based flush so sub-cap emit rates produce visible ledger output.
    Without this, the file stays at 0 bytes for low-rate sites (drift_guard
@@ -165,6 +169,7 @@ let last_flush_ref = ref 0.0
 let uninitialized_record_warned_ref = ref false
 
 let set_flush_interval_for_test sec = flush_interval_sec_ref := sec
+let set_buffer_cap_for_test cap = buffer_cap_ref := max 1 cap
 
 (* #10348: tests need to re-[init] against fresh tmp paths.  Production
    code only calls [init] once at boot. *)
@@ -172,6 +177,7 @@ let reset_for_test () =
   Stdlib.Mutex.protect mu (fun () ->
     store_path_ref := None;
     uninitialized_record_warned_ref := false;
+    buffer_cap_ref := default_buffer_cap ();
     Queue.clear buffer;
     (* Initialize the clock to "now" rather than 0.0 so tests that pin a
        large flush interval can verify batching without the [now -.
@@ -314,7 +320,7 @@ let record (e : event) =
     Queue.add json buffer;
     let now = Unix.gettimeofday () in
     let elapsed = now -. !last_flush_ref in
-    if Queue.length buffer >= buffer_cap
+    if Queue.length buffer >= buffer_cap ()
        || elapsed >= !flush_interval_sec_ref
     then do_flush ())
 

--- a/lib/heuristic_metrics.mli
+++ b/lib/heuristic_metrics.mli
@@ -72,7 +72,12 @@ val flush : unit -> unit
 val set_flush_interval_for_test : float -> unit
 (** Override the time-based flush interval (default 30 s).  Exposed for
     tests that need [record] to flush on every call without waiting for
-    [buffer_cap] (64) records or shutdown.  #10348. *)
+    the configured buffer cap or shutdown.  #10348. *)
+
+val set_buffer_cap_for_test : int -> unit
+(** Override the in-memory flush batch size.  Tests only.  Production
+    uses [Env_config_runtime.Heuristic_metrics.buffer_cap], backed by
+    [MASC_HEURISTIC_METRICS_BUFFER_CAP] and clamped to [1, 10000]. *)
 
 val reset_for_test : unit -> unit
 (** Clear the in-memory store reference, buffer and last-flush clock so

--- a/test/test_heuristic_metrics_periodic_flush_10348.ml
+++ b/test/test_heuristic_metrics_periodic_flush_10348.ml
@@ -1,6 +1,6 @@
 (** #10348: heuristic_metrics.jsonl was 0 bytes for 24 h+ despite three
     active emit sites because [record] only flushed when the in-memory
-    buffer reached [buffer_cap=64] or when [shutdown_hooks] ran.  The
+    buffer reached the configured buffer cap or when [shutdown_hooks] ran.  The
     keeper daemon never reaches either path quickly: post_verifier.verify
     is dead, drift_guard.verify_handoff fires only on handoffs, and
     keeper_alert_signal is env-gated.  These tests pin the time-based
@@ -45,7 +45,7 @@ let count_lines path =
       with End_of_file -> !n)
 
 (* Pre-fix behavior: with default 30 s interval and no shutdown,
-   a single [record] (well under buffer_cap=64) leaves the file empty.
+   a single [record] (well under the default buffer cap) leaves the file empty.
    Post-fix: setting interval to 0.0 flushes on every record. *)
 let test_periodic_flush_below_cap () =
   let base = tmp_base () in
@@ -85,6 +85,21 @@ let test_large_interval_still_batches () =
   HM.flush ();
   Alcotest.(check int) "explicit flush still works" 1 (count_lines path)
 
+let test_configured_buffer_cap_flushes () =
+  let base = tmp_base () in
+  HM.reset_for_test ();
+  HM.set_flush_interval_for_test 1e9;
+  HM.set_buffer_cap_for_test 3;
+  HM.init ~base_path:base;
+  HM.record (make_event ~site:"cap_1");
+  HM.record (make_event ~site:"cap_2");
+  let path = ledger_path base in
+  Alcotest.(check int) "below configured cap stays buffered" 0
+    (count_lines path);
+  HM.record (make_event ~site:"cap_3");
+  Alcotest.(check int) "configured cap flushes buffered rows" 3
+    (count_lines path)
+
 (* Audit regression: [record] before [init] used to leave data only in the
    volatile in-memory buffer, with no warning and no flush when [init] finally
    installed the store path.  Late init must make already-buffered rows durable. *)
@@ -110,6 +125,8 @@ let () =
         `Quick test_multiple_records_below_cap;
       Alcotest.test_case "large interval batches; explicit flush works"
         `Quick test_large_interval_still_batches;
+      Alcotest.test_case "configured buffer cap flushes"
+        `Quick test_configured_buffer_cap_flushes;
       Alcotest.test_case "late init flushes pre-init buffer"
         `Quick test_late_init_flushes_preinit_buffer;
     ];


### PR DESCRIPTION
## Summary

Addresses the Kimi cleanup finding that `heuristic_metrics.ml` still used a fixed in-memory batch cap for heuristic metric buffering.

- adds typed env config for `MASC_HEURISTIC_METRICS_BUFFER_CAP`
- clamps the runtime cap to `[1, 10000]` so misconfiguration cannot disable flush pressure or create unbounded batches
- wires heuristic metrics buffering through the typed config instead of the previous hardcoded `64`
- adds a focused regression test proving a small configured cap forces a durable JSONL flush

## Why it matters

Heuristic metrics can run in long-lived keeper/runtime processes. Keeping the buffer cap typed and configurable lets operators tune memory/IO pressure for their runtime without patching source code, while preserving the previous default behavior.

## Validation

- `scripts/dune-local.sh build test/test_heuristic_metrics_periodic_flush_10348.exe`
- `./_build/default/test/test_heuristic_metrics_periodic_flush_10348.exe` (5 tests)
- `python3 scripts/ci/check-env-knob-classification.py --base origin/main --head HEAD`
- `git diff --check`