### PR TITLE
fix: stop preview telemetry trace fabrication

### DIFF
--- a/dashboard/design-system/preview/cb-shared.jsx
+++ b/dashboard/design-system/preview/cb-shared.jsx
@@ -8,37 +8,43 @@ function Dot({ kind = 'idle', size = 'md', beat = false, style }) {
   return <span className={`cb-dot ${kind} ${size === 'sm' ? 'sm' : size === 'lg' ? 'lg' : ''} ${beat ? 'beat' : ''}`} style={style} aria-hidden="true" />;
 }
 
-// Mini sparkline (random but seeded bars) — used in KPI + lifeline
+// Mini sparkline — renders supplied bar heights (0..100). When `data`
+// is absent we render an empty container instead of fabricating bars,
+// so missing telemetry is visible rather than hidden behind noise.
 function Spark({ data, color = 'brass', bars = 14 }) {
-  const d = data || Array.from({ length: bars }, (_, i) => 30 + Math.sin(i * 0.7) * 20 + Math.random() * 30);
+  if (!Array.isArray(data) || data.length === 0) {
+    return <span className={`spark is-${color} is-empty`} style={{ height: 16 }} aria-label="no data" data-empty="true" />;
+  }
   return (
     <span className={`spark is-${color}`} style={{ height: 16 }} aria-hidden="true">
-      {d.map((h, i) => <i key={i} style={{ height: `${Math.max(5, Math.min(100, h))}%` }} />)}
+      {data.map((h, i) => <i key={i} style={{ height: `${Math.max(5, Math.min(100, h))}%` }} />)}
     </span>
   );
 }
 
-// Lifeline-style sine+spike svg path
-function Heartbeat({ height = 32, width = 320, phase = 0 }) {
-  const points = [];
-  const segs = 60;
-  for (let i = 0; i <= segs; i++) {
-    const t = i / segs;
-    const x = t * width;
-    // mostly flat with a spike every ~12 samples
-    let y = height / 2 + Math.sin((t + phase) * 6) * 1.5;
-    const s = (i + Math.floor(phase * 60)) % 12;
-    if (s === 3) y -= height * 0.35;
-    if (s === 4) y += height * 0.4;
-    if (s === 5) y -= height * 0.15;
-    points.push(`${x.toFixed(1)},${y.toFixed(1)}`);
+// Lifeline-style svg path. Caller passes `data` (array of y-samples in
+// 0..100) plus optional `min`/`max` bounds. Without data we render a
+// dashed baseline so the indicator visibly reflects "no signal" rather
+// than animating a fake heartbeat.
+function Heartbeat({ height = 32, width = 320, data, min = 0, max = 100 }) {
+  if (!Array.isArray(data) || data.length === 0) {
+    return (
+      <svg viewBox={`0 0 ${width} ${height}`} preserveAspectRatio="none" aria-label="no data" data-empty="true" focusable="false">
+        <line x1="0" y1={height / 2} x2={width} y2={height / 2} stroke="var(--color-fg-muted)" strokeWidth="1" strokeDasharray="3 3" />
+      </svg>
+    );
   }
+  const span = Math.max(1, max - min);
+  const segs = data.length - 1 || 1;
+  const points = data.map((v, i) => {
+    const x = (i / segs) * width;
+    const clamped = Math.max(min, Math.min(max, v));
+    const y = height - ((clamped - min) / span) * height;
+    return `${x.toFixed(1)},${y.toFixed(1)}`;
+  });
   return (
     <svg viewBox={`0 0 ${width} ${height}`} preserveAspectRatio="none" aria-hidden="true" focusable="false">
       <polyline points={points.join(' ')} fill="none" stroke="var(--color-accent-fg)" strokeWidth="1.2" />
-      <circle cx={width - 2} cy={height / 2} r="2" fill="var(--color-accent-fg)">
-        <animate attributeName="r" values="2;3.5;2" dur="1.4s" repeatCount="indefinite" />
-      </circle>
     </svg>
   );
 }

--- a/dashboard/eslint.config.mjs
+++ b/dashboard/eslint.config.mjs
@@ -27,6 +27,7 @@ const TARGET_FILES = [
 ]
 
 const TEST_FILES = [
+  'src/cb-shared-telemetry-source.test.ts',
   'src/components/common/markdown.test.ts',
   'src/components/connector-status.test.ts',
   'src/components/fleet-fsm-matrix.test.ts',

--- a/dashboard/src/cb-shared-telemetry-source.test.ts
+++ b/dashboard/src/cb-shared-telemetry-source.test.ts
@@ -1,0 +1,22 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+import { describe, expect, it } from 'vitest'
+
+const sharedSources = [
+  ['cockpit kit', 'cockpit-kit/cb-shared.jsx'],
+  ['design-system preview', 'design-system/preview/cb-shared.jsx'],
+] as const
+
+describe('cb-shared telemetry primitives source', () => {
+  for (const [label, file] of sharedSources) {
+    it(`${label} does not fabricate telemetry traces`, () => {
+      const source = readFileSync(resolve(process.cwd(), file), 'utf8')
+
+      expect(source).not.toContain('Math.random()')
+      expect(source).not.toContain('Array.from({ length: bars }')
+      expect(source).not.toMatch(/function Heartbeat\([^)]*phase/)
+      expect(source).toContain('data-empty="true"')
+    })
+  }
+})


### PR DESCRIPTION
## Summary

Addresses the remaining Kimi cleanup finding for `cb-shared.jsx` telemetry fabrication in the design-system preview copy.

- removes the preview `Spark` fallback that generated bars with `Math.random()`
- removes the synthetic sine/spike heartbeat path when no telemetry samples are supplied
- renders explicit empty/no-signal states for missing sparkline and heartbeat data
- adds a source-level Vitest guard over both `cockpit-kit/cb-shared.jsx` and `design-system/preview/cb-shared.jsx`
- adds the new source guard test to the dashboard ESLint allow-list so it is actually linted

## Why it matters

The cockpit kit already stopped fabricating telemetry, but the design-system preview twin still made missing data look live. This keeps preview primitives aligned with runtime-truth behavior: real samples render traces; absent samples render no-data markers.

## Validation

- `pnpm --dir dashboard install --frozen-lockfile --offline`
- `pnpm --dir dashboard exec tsc --noEmit --pretty`
- `pnpm --dir dashboard exec vitest run src/cb-shared-telemetry-source.test.ts --config vitest.config.ts --no-file-parallelism --maxWorkers=1` (2 tests)
- `pnpm --dir dashboard exec eslint src/cb-shared-telemetry-source.test.ts`
- `rg -n "Math\\.random\\(\\)|Array\\.from\\(\\{ length: bars \\}|function Heartbeat\\([^)]*phase" dashboard/cockpit-kit/cb-shared.jsx dashboard/design-system/preview/cb-shared.jsx` (no matches)
- `git diff --check`