### PR TITLE
fix: configure oas timeout budget strike limit

### DIFF
--- a/docs/BOOT-ENV-STATE-INVENTORY.md
+++ b/docs/BOOT-ENV-STATE-INVENTORY.md
@@ -124,7 +124,7 @@ also preempts TOML. Example: `MASC_KEEPER_AUTOBOT_MAX` preempts
 Legacy compatibility names that are no longer read by the unified turn path
 are intentionally excluded from this TOML surface.
 
-**Sections** (80 knobs total):
+**Sections** (81 knobs total):
 
 | Section | Count | Key examples |
 | --- | --- | --- |
@@ -132,7 +132,7 @@ are intentionally excluded from this TOML surface.
 | `[autonomous]` | 6 | `max_turns_per_call`, `semaphore_wait_timeout_sec`, `concurrency` |
 | `[reactive]` | 3 | `max_turns_per_call`, `concurrency`, `max_idle_turns` |
 | `[heartbeat]` | 10 | `interval_sec`, `max_silence_sec`, `smart_heartbeat`, `board_generic_wakeup_limit` |
-| `[turn]` | 18 | `timeout_sec`, `stream_idle_timeout_sec`, `tool_cost_max_usd`, `temperature` |
+| `[turn]` | 19 | `timeout_sec`, `stream_idle_timeout_sec`, `tool_cost_max_usd`, `oas_timeout_budget_strike_limit` |
 | `[watchdog]` | 4 | `stale_sec`, `grace_sec`, `noop_threshold` |
 | `[supervisor]` | 4 | `max_restarts`, `backoff_base_sec`, `backoff_max_sec` |
 | `[lifecycle]` | 4 | `self_preservation_ratio`, `dead_ttl_sec` |
@@ -166,6 +166,7 @@ stream_idle_timeout_sec = 120
 tool_cost_max_usd = 1.25
 max_tools_per_turn = 64
 llm_rerank = true
+oas_timeout_budget_strike_limit = 3
 
 [watchdog]
 stale_sec = 600

--- a/lib/keeper/keeper_runtime_config.ml
+++ b/lib/keeper/keeper_runtime_config.ml
@@ -56,6 +56,8 @@ let key_to_env =
     "turn.enable_thinking",             "MASC_KEEPER_ENABLE_THINKING";
     "turn.adaptive_thinking",           "MASC_KEEPER_ADAPTIVE_THINKING";
     "turn.adaptive_thinking_mode",      "MASC_KEEPER_ADAPTIVE_THINKING_MODE";
+    "turn.oas_timeout_budget_strike_limit",
+                                        "MASC_KEEPER_OAS_TIMEOUT_BUDGET_STRIKE_LIMIT";
     "turn.degraded_retry_slot_phase_budget_sec",
                                         "MASC_KEEPER_DEGRADED_RETRY_SLOT_PHASE_BUDGET_SEC";
     (* [watchdog] *)

--- a/lib/keeper/keeper_turn_slot.ml
+++ b/lib/keeper/keeper_turn_slot.ml
@@ -723,8 +723,23 @@ let reset_autonomous_completion_for_test () : unit =
    any successful turn (see [Ok updated] branch). On first bump after a
    process restart, callers may seed it from the persisted
    [Oas_timeout_budget_loop] failure reason so restart cannot erase a
-   partially observed loop. *)
-let oas_timeout_budget_strike_limit = 3
+   partially observed loop.
+
+   Env: [MASC_KEEPER_OAS_TIMEOUT_BUDGET_STRIKE_LIMIT]. Default 3. Min 1.
+   Max 100 keeps the operator knob usable without turning an auto-pause
+   safety guard into an effectively disabled loop. *)
+let oas_timeout_budget_strike_limit_int_of_env_default =
+  Keeper_config.int_of_env_default
+
+let oas_timeout_budget_strike_limit_int_of_env_default_for_test =
+  oas_timeout_budget_strike_limit_int_of_env_default
+
+let oas_timeout_budget_strike_limit =
+  oas_timeout_budget_strike_limit_int_of_env_default
+    "MASC_KEEPER_OAS_TIMEOUT_BUDGET_STRIKE_LIMIT"
+    ~default:3
+    ~min_v:1
+    ~max_v:100
 
 module Budget_strike_map = Map.Make (String)
 

--- a/lib/keeper/keeper_turn_slot.mli
+++ b/lib/keeper/keeper_turn_slot.mli
@@ -165,6 +165,11 @@ val set_after_acquire_flag_hook_for_test :
     restart or another process update. *)
 val oas_timeout_budget_strike_limit : int
 
+(** Test-only parser/clamp hook for
+    [MASC_KEEPER_OAS_TIMEOUT_BUDGET_STRIKE_LIMIT]. *)
+val oas_timeout_budget_strike_limit_int_of_env_default_for_test :
+  string -> default:int -> min_v:int -> max_v:int -> int
+
 val bump_budget_exhaustion_seeded :
   keeper_name:string -> prior_strikes:int -> int
 val bump_budget_exhaustion : keeper_name:string -> int

--- a/test/stanzas/test_oas_timeout_budget_strike.inc
+++ b/test/stanzas/test_oas_timeout_budget_strike.inc
@@ -1,4 +1,4 @@
 (test
  (name test_oas_timeout_budget_strike)
  (modules test_oas_timeout_budget_strike)
- (libraries masc_mcp alcotest eio eio_main))
+ (libraries masc_mcp alcotest eio eio_main unix))

--- a/test/test_keeper_runtime_toml.ml
+++ b/test/test_keeper_runtime_toml.ml
@@ -180,12 +180,13 @@ let test_applies_turn_execution_overrides () =
      llm_rerank_cascade = \"tool_rerank_fast\"\n\
      temperature = 0.65\n\
      max_output_tokens = 8192\n\
-     stream_idle_timeout_sec = 90\n"
+     stream_idle_timeout_sec = 90\n\
+     oas_timeout_budget_strike_limit = 5\n"
   in
   let count, overrides =
     Keeper_runtime_config.resolve_overrides ~env_lookup:empty_env doc
   in
-  check int "applied 7" 7 count;
+  check int "applied 8" 8 count;
   check (option string) "tool cost ceiling"
     (Some "1.25")
     (List.assoc_opt "MASC_KEEPER_TOOL_COST_MAX_USD" overrides);
@@ -206,7 +207,12 @@ let test_applies_turn_execution_overrides () =
     (List.assoc_opt "MASC_KEEPER_UNIFIED_MAX_TOKENS" overrides);
   check (option string) "stream idle timeout"
     (Some "90")
-    (List.assoc_opt "MASC_KEEPER_STREAM_IDLE_TIMEOUT_SEC" overrides)
+    (List.assoc_opt "MASC_KEEPER_STREAM_IDLE_TIMEOUT_SEC" overrides);
+  check (option string) "oas timeout budget strike limit"
+    (Some "5")
+    (List.assoc_opt
+       "MASC_KEEPER_OAS_TIMEOUT_BUDGET_STRIKE_LIMIT"
+       overrides)
 
 let test_applies_proactive_min_interval_override () =
   let doc = parse_or_fail "[proactive]\nmin_interval_sec = 1234\n" in

--- a/test/test_oas_timeout_budget_strike.ml
+++ b/test/test_oas_timeout_budget_strike.ml
@@ -1,6 +1,17 @@
 open Masc_mcp
 
 module KK = Keeper_keepalive
+module KTS = Keeper_turn_slot
+
+let with_env name value f =
+  let previous = Sys.getenv_opt name in
+  Unix.putenv name value;
+  Fun.protect
+    ~finally:(fun () ->
+      match previous with
+      | Some prior -> Unix.putenv name prior
+      | None -> Unix.putenv name "")
+    f
 
 let with_reset keeper f =
   KK.reset_budget_exhaustion ~keeper_name:keeper;
@@ -59,6 +70,24 @@ let test_concurrent_bumps_do_not_lose_updates () =
       (workers * bumps_per_worker)
       (KK.peek_budget_exhaustion_for_test ~keeper_name:keeper))
 
+let strike_limit_from_env_for_test () =
+  KTS.oas_timeout_budget_strike_limit_int_of_env_default_for_test
+    "MASC_KEEPER_OAS_TIMEOUT_BUDGET_STRIKE_LIMIT"
+    ~default:3
+    ~min_v:1
+    ~max_v:100
+
+let test_strike_limit_env_clamps () =
+  with_env "MASC_KEEPER_OAS_TIMEOUT_BUDGET_STRIKE_LIMIT" "0" (fun () ->
+    Alcotest.(check int) "low clamp" 1
+      (strike_limit_from_env_for_test ()));
+  with_env "MASC_KEEPER_OAS_TIMEOUT_BUDGET_STRIKE_LIMIT" "250" (fun () ->
+    Alcotest.(check int) "high clamp" 100
+      (strike_limit_from_env_for_test ()));
+  with_env "MASC_KEEPER_OAS_TIMEOUT_BUDGET_STRIKE_LIMIT" "7" (fun () ->
+    Alcotest.(check int) "operator value" 7
+      (strike_limit_from_env_for_test ()))
+
 let () =
   Alcotest.run "oas_timeout_budget_strike"
   [
@@ -73,5 +102,7 @@ let () =
         Alcotest.test_case "reset clears" `Quick test_reset_clears;
         Alcotest.test_case "concurrent bumps do not lose updates" `Quick
           test_concurrent_bumps_do_not_lose_updates;
+        Alcotest.test_case "strike limit env clamps" `Quick
+          test_strike_limit_env_clamps;
       ] );
   ]


### PR DESCRIPTION
## Summary

Addresses the Kimi cleanup finding that `keeper_turn_slot.ml` baked in `oas_timeout_budget_strike_limit = 3`.

- reads the limit from `MASC_KEEPER_OAS_TIMEOUT_BUDGET_STRIKE_LIMIT`
- preserves the default of `3`
- clamps the value to `[1, 100]` so the auto-pause guard cannot be disabled by typo-scale values
- maps `turn.oas_timeout_budget_strike_limit` through `keeper_runtime.toml` startup seeding
- updates the boot-env inventory count/examples
- adds regression coverage for env clamp behavior and TOML mapping

## Why it matters

The strike limit controls how many consecutive structured `oas_timeout_budget` failures a keeper tolerates before it is promoted into the existing pause/supervisor path. Making it operator-configurable keeps the safety default intact while allowing runtime-specific tuning without source edits.

## Rebase note

Rebased onto current `origin/main` (`13f50256fc`). The only conflict was in `test/test_oas_timeout_budget_strike.ml`; the resolution preserves both main's concurrent bump accounting guard and this PR's strike-limit env clamp coverage.

## Validation

- `ocamlc -stop-after parsing lib/keeper/keeper_runtime_config.ml lib/keeper/keeper_turn_slot.ml lib/keeper/keeper_turn_slot.mli test/test_keeper_runtime_toml.ml test/test_oas_timeout_budget_strike.ml`
- `scripts/check-oas-pin.sh --local-only`
- `scripts/dune-local.sh build test/test_oas_timeout_budget_strike.exe test/test_keeper_runtime_toml.exe`
- `./_build/default/test/test_oas_timeout_budget_strike.exe` (6 tests)
- `./_build/default/test/test_keeper_runtime_toml.exe` (31 tests, 1 existing skip)
- `python3 scripts/ci/check-env-knob-classification.py --base origin/main --head HEAD`
- `git diff --check`
- `git diff --check origin/main...HEAD`
