### PR TITLE
fix: remove budget strike cas spin

### DIFF
--- a/lib/keeper/keeper_turn_slot.ml
+++ b/lib/keeper/keeper_turn_slot.ml
@@ -728,17 +728,22 @@ let oas_timeout_budget_strike_limit = 3
 
 module Budget_strike_map = Map.Make (String)
 
-let budget_exhaustions : int Budget_strike_map.t Atomic.t =
-  Atomic.make Budget_strike_map.empty
+(* Stdlib.Mutex: this ledger is updated from keeper Eio fibers and from
+   non-Eio unit tests. The critical section is pure map replacement and
+   cannot yield, so a plain mutex avoids the previous CAS retry loop without
+   introducing Eio-context requirements. *)
+let budget_exhaustions_mutex = Stdlib.Mutex.create ()
+let budget_exhaustions : int Budget_strike_map.t ref =
+  ref Budget_strike_map.empty
 
 let update_budget_exhaustions f =
-  let rec loop () =
-    let current = Atomic.get budget_exhaustions in
-    let next, result = f current in
-    if Atomic.compare_and_set budget_exhaustions current next then result
-    else loop ()
-  in
-  loop ()
+  Stdlib.Mutex.lock budget_exhaustions_mutex;
+  Fun.protect
+    ~finally:(fun () -> Stdlib.Mutex.unlock budget_exhaustions_mutex)
+    (fun () ->
+      let next, result = f !budget_exhaustions in
+      budget_exhaustions := next;
+      result)
 
 let bump_budget_exhaustion_seeded ~keeper_name ~prior_strikes : int =
   let prior_strikes = max 0 prior_strikes in
@@ -758,8 +763,12 @@ let reset_budget_exhaustion ~keeper_name : unit =
     (Budget_strike_map.remove keeper_name current, ()))
 
 let peek_budget_exhaustion_for_test ~keeper_name : int =
-  Budget_strike_map.find_opt keeper_name (Atomic.get budget_exhaustions)
-  |> Option.value ~default:0
+  update_budget_exhaustions (fun current ->
+    let strikes =
+      Budget_strike_map.find_opt keeper_name current
+      |> Option.value ~default:0
+    in
+    (current, strikes))
 
 let set_budget_exhaustion_for_test ~keeper_name ~strikes : unit =
   if strikes <= 0 then reset_budget_exhaustion ~keeper_name

--- a/test/test_oas_timeout_budget_strike.ml
+++ b/test/test_oas_timeout_budget_strike.ml
@@ -42,6 +42,23 @@ let test_reset_clears () =
   Alcotest.(check int) "reset clears" 0
     (KK.peek_budget_exhaustion_for_test ~keeper_name:"reset")
 
+let test_concurrent_bumps_do_not_lose_updates () =
+  let keeper = "parallel-bumps" in
+  with_reset keeper (fun () ->
+    let workers = 4 in
+    let bumps_per_worker = 25 in
+    let domains =
+      List.init workers (fun _ ->
+        Domain.spawn (fun () ->
+          for _ = 1 to bumps_per_worker do
+            ignore (KK.bump_budget_exhaustion ~keeper_name:keeper : int)
+          done))
+    in
+    List.iter Domain.join domains;
+    Alcotest.(check int) "all bumps accounted"
+      (workers * bumps_per_worker)
+      (KK.peek_budget_exhaustion_for_test ~keeper_name:keeper))
+
 let () =
   Alcotest.run "oas_timeout_budget_strike"
   [
@@ -54,5 +71,7 @@ let () =
         Alcotest.test_case "seeded bump uses higher persisted count" `Quick
           test_seeded_bump_uses_higher_persisted_count;
         Alcotest.test_case "reset clears" `Quick test_reset_clears;
+        Alcotest.test_case "concurrent bumps do not lose updates" `Quick
+          test_concurrent_bumps_do_not_lose_updates;
       ] );
   ]


### PR DESCRIPTION
## Summary

Addresses the Kimi cleanup finding that the `oas_timeout_budget` strike ledger used an Atomic CAS retry loop around an immutable map.

- replaces `budget_exhaustions` with a plain ref guarded by `Stdlib.Mutex`
- keeps the critical section pure and non-yielding, so it is safe for keeper Eio fibers and non-Eio tests
- preserves existing bump/reset/seed semantics
- adds a concurrent bump regression test using 4 domains to prove updates are not lost

## Why it matters

`oas_timeout_budget` strikes are part of the keeper safety path that promotes repeated budget failures into pause/supervisor handling. The ledger should account for concurrent updates without spinning on CAS retries under contention.

## Validation

- `scripts/dune-local.sh build test/test_oas_timeout_budget_strike.exe`
- `./_build/default/test/test_oas_timeout_budget_strike.exe` (5 tests)
- `rg -n "Atomic\\.(compare_and_set|get) budget_exhaustions|budget_exhaustions_mutex|Domain\\.spawn" lib/keeper/keeper_turn_slot.ml test/test_oas_timeout_budget_strike.ml`
- `git diff --check`