### PR TITLE
fix: preserve missing keeper config latency

### DIFF
--- a/dashboard/src/api/dashboard.test.ts
+++ b/dashboard/src/api/dashboard.test.ts
@@ -991,6 +991,36 @@ describe('fetchKeeperConfig', () => {
     expect(result.runtime_trust?.disposition).toBe('Pass')
   })
 
+  it('preserves missing keeper config latency as null instead of zero', async () => {
+    const cases: Array<[string, Record<string, unknown>]> = [
+      ['null', { last_latency_ms: null }],
+      ['missing', {}],
+      ['zero number', { last_latency_ms: 0 }],
+      ['zero string', { last_latency_ms: '0' }],
+    ]
+
+    for (const [label, metrics] of cases) {
+      const fetchMock = vi.fn().mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            name: 'keeper-sangsu',
+            metrics,
+          }),
+          {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          },
+        ),
+      )
+      vi.stubGlobal('fetch', fetchMock)
+
+      const result = await fetchKeeperConfig('keeper-sangsu')
+
+      expect(result.metrics.last_latency_ms, label).toBeNull()
+      vi.unstubAllGlobals()
+    }
+  })
+
   it('preserves terminal runtime blocker classes through config fetch and display labeling', async () => {
     const cases = [
       ['no_tool_capable_provider', '도구 실행 Provider 없음'],

--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -2095,6 +2095,7 @@ function normalizeKeeperConfig(raw: unknown, requestedName: string): KeeperConfi
   const metrics = isRecord(data.metrics) ? data.metrics : {}
   const sandboxEnvironment = normalizeKeeperSandboxEnvironment(data.sandbox_environment)
   const perProviderTimeoutSec = asLooseNullableNumber(execution.per_provider_timeout_sec)
+  const lastLatencyMs = asInt(metrics.last_latency_ms)
 
   return {
     name: asNullableString(data.name) ?? requestedName,
@@ -2247,7 +2248,7 @@ function normalizeKeeperConfig(raw: unknown, requestedName: string): KeeperConfi
       last_input_tokens: asInt(metrics.last_input_tokens) ?? 0,
       last_output_tokens: asInt(metrics.last_output_tokens) ?? 0,
       last_total_tokens: asInt(metrics.last_total_tokens) ?? 0,
-      last_latency_ms: asInt(metrics.last_latency_ms) ?? 0,
+      last_latency_ms: lastLatencyMs != null && lastLatencyMs > 0 ? lastLatencyMs : null,
       last_total_tokens_per_sec: asLooseNullableNumber(metrics.last_total_tokens_per_sec),
       last_output_tokens_per_sec: asLooseNullableNumber(metrics.last_output_tokens_per_sec),
       compaction_count: asInt(metrics.compaction_count) ?? 0,

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -1204,7 +1204,7 @@ interface KeeperConfigMetrics {
   last_input_tokens: number
   last_output_tokens: number
   last_total_tokens: number
-  last_latency_ms: number
+  last_latency_ms: number | null
   last_total_tokens_per_sec: number | null
   last_output_tokens_per_sec: number | null
   compaction_count: number

--- a/lib/dashboard/dashboard_http_keeper.ml
+++ b/lib/dashboard/dashboard_http_keeper.ml
@@ -232,6 +232,9 @@ let tokens_per_sec_json ~tokens ~latency_ms =
   if tokens <= 0 || latency_ms <= 0 then `Null
   else `Float ((float_of_int tokens *. 1000.0) /. float_of_int latency_ms)
 
+let last_latency_ms_json latency_ms =
+  if latency_ms <= 0 then `Null else `Int latency_ms
+
 let json_string_list_member key json =
   match Yojson.Safe.Util.member key json with
   | `List items ->
@@ -1154,7 +1157,7 @@ let keepers_dashboard_json ?(compact = false) (config : Coord.config) : Yojson.S
                 ("output_tokens", `Int m.runtime.usage.last_output_tokens);
                 ("total_tokens", `Int m.runtime.usage.last_total_tokens);
               ]);
-              ("last_latency_ms", `Int m.runtime.usage.last_latency_ms);
+              ("last_latency_ms", last_latency_ms_json m.runtime.usage.last_latency_ms);
               ("compaction_count", `Int m.runtime.compaction_rt.count);
               ("last_compaction_saved_tokens", `Int last_compaction_saved_tokens);
               ("compaction_profile", `String m.compaction.profile);
@@ -1702,7 +1705,7 @@ let keeper_config_json (config : Coord.config) (name : string)
           ("last_input_tokens", `Int m.runtime.usage.last_input_tokens);
           ("last_output_tokens", `Int m.runtime.usage.last_output_tokens);
           ("last_total_tokens", `Int m.runtime.usage.last_total_tokens);
-          ("last_latency_ms", `Int m.runtime.usage.last_latency_ms);
+          ("last_latency_ms", last_latency_ms_json m.runtime.usage.last_latency_ms);
           ( "last_total_tokens_per_sec",
             tokens_per_sec_json ~tokens:m.runtime.usage.last_total_tokens
               ~latency_ms:m.runtime.usage.last_latency_ms );

--- a/test/test_operator_control_keeper.ml
+++ b/test/test_operator_control_keeper.ml
@@ -2938,6 +2938,39 @@ proactive_enabled = true
       Alcotest.(check (option (float 0.001))) "last output tokens per sec surfaced"
         (Some 20.0)
         (json |> member "metrics" |> member "last_output_tokens_per_sec" |> to_float_option);
+      let zero_latency_base = read_keeper_meta_exn config keeper_name in
+      let zero_latency_meta =
+        {
+          zero_latency_base with
+          runtime =
+            {
+              zero_latency_base.runtime with
+              usage =
+                {
+                  zero_latency_base.runtime.usage with
+                  last_latency_ms = 0;
+                };
+            };
+          updated_at = Masc_domain.now_iso ();
+        }
+      in
+      (match Masc_mcp.Keeper_types.write_meta config zero_latency_meta with
+      | Ok () -> ()
+      | Error err -> Alcotest.fail ("zero latency meta write failed: " ^ err));
+      let zero_status, zero_json =
+        Masc_mcp.Dashboard_http_keeper.keeper_config_json config keeper_name
+      in
+      Alcotest.(check bool) "zero latency config found" true (zero_status = `OK);
+      Alcotest.(check bool) "zero latency surfaced as missing" true
+        (zero_json |> member "metrics" |> member "last_latency_ms" = `Null);
+      Alcotest.(check (option (float 0.001))) "zero latency total tps missing"
+        None
+        (zero_json |> member "metrics" |> member "last_total_tokens_per_sec"
+       |> to_float_option);
+      Alcotest.(check (option (float 0.001))) "zero latency output tps missing"
+        None
+        (zero_json |> member "metrics" |> member "last_output_tokens_per_sec"
+       |> to_float_option);
       (* Prompt source depends on runtime bootstrap and any restored overrides;
          accepted values come from Prompt_registry.resolve_prompt_unlocked. *)
       let prompt_source =


### PR DESCRIPTION
## Summary

- emit `null` instead of `0` for non-positive keeper `last_latency_ms` on dashboard keeper surfaces
- preserve missing/zero keeper config latency as `null` in the dashboard API contract
- add backend and frontend regressions for the missing-latency path while keeping positive latency unchanged

## Why

`0ms` is not a measured keeper runtime latency. Treating missing or failed measurement as a normal zero makes the dashboard look faster than reality and feeds the broader zero-latency observability problem from the redesign plan.

## Validation

- `git diff --check`
- `lockf -k -t 1200 /tmp/me-dune-local.lock env MASC_DUNE_LOCK_HELD=1 MASC_SKIP_OPAM_LOCK=1 MASC_INCLUDE_OPERATOR_CONTROL=true DUNE_JOBS=1 DUNE_CACHE=disabled scripts/dune-local.sh build test/test_operator_control.exe`
- `_build/default/test/test_operator_control.exe test operator 58 --show-errors`
- `pnpm install --offline --frozen-lockfile`
- `pnpm exec vitest run --config vitest.config.ts src/api/dashboard.test.ts --no-file-parallelism --maxWorkers=1`
- `pnpm exec tsc --noEmit --pretty`
- `pnpm exec eslint src --quiet`

## Note

The full `test_operator_control.exe` run was not used as the final validation surface: case 8 fails on a runtime-trust expectation (`Pause` vs `Alert`) outside the keeper-config latency assertion, and the broader run stayed active long enough that I interrupted it. The targeted keeper-config case added/changed here passes.
