### PR TITLE
test: stabilize tool matrix runners

### DIFF
--- a/test/keeper_tool_matrix_case_runner.ml
+++ b/test/keeper_tool_matrix_case_runner.ml
@@ -54,8 +54,8 @@ let () =
       let fs = Eio.Stdenv.fs env in
       let net = Eio.Stdenv.net env in
       let mono_clock = Eio.Stdenv.mono_clock env in
+      Eio.Switch.run @@ fun sw ->
       let base_path, result =
-        Eio.Switch.run @@ fun sw ->
         Cases.run_case sw ~proc_mgr ~fs ~net ~mono_clock clock schema
       in
       emit_result ~base_path tool_name result;

--- a/test/test_keeper_tool_matrix_cases.ml
+++ b/test/test_keeper_tool_matrix_cases.ml
@@ -240,6 +240,9 @@ let keeper_arguments fixture (schema : Masc_domain.tool_schema) =
   | "keeper_board_get" ->
       `Assoc [ ("post_id", `String (Generic.ensure_board_post fixture.generic)) ]
   | "keeper_board_list" -> `Assoc [ ("limit", `Int 5) ]
+  | "keeper_board_curation_read" -> `Assoc []
+  | "keeper_board_curation_submit" ->
+      `Assoc [ ("rationale", `String "tool matrix curation") ]
   | "keeper_board_comment" ->
       `Assoc
         [
@@ -264,7 +267,7 @@ let keeper_arguments fixture (schema : Masc_domain.tool_schema) =
           ("content", `String "matrix write\n");
           ("mode", `String "overwrite");
         ]
-  | "keeper_shell" -> `Assoc [ ("op", `String "git_status") ]
+  | "keeper_shell" -> `Assoc [ ("op", `String "pwd") ]
   | "keeper_bash" ->
       `Assoc [ ("cmd", `String "pwd"); ("timeout_sec", `Float 5.0) ]
   | "keeper_bash_output" ->
@@ -415,6 +418,9 @@ let extra_guard_fragments_for_name = function
   | "masc_get_metrics" -> [ "no metrics found" ]
   | "masc_library_promote" -> [ "no candidate matching" ]
   | "masc_portal_send" -> [ "no portal open" ]
+  | "masc_keeper_list" | "masc_keeper_msg" | "masc_keeper_msg_result"
+  | "masc_keeper_status" ->
+      [ "keeper management tool"; "use MCP client" ]
   | "masc_worktree_remove" -> [ "worktree not found" ]
   | _ -> []
 

--- a/test/test_mcp_tool_matrix_cases.ml
+++ b/test/test_mcp_tool_matrix_cases.ml
@@ -2,6 +2,7 @@ module Types = Masc_domain
 
 module Mcp_eio = Masc_mcp.Mcp_server_eio
 module Config = Masc_mcp.Config
+module Goal_store = Masc_mcp.Goal_store
 
 type init_mode =
   | Fresh
@@ -17,6 +18,7 @@ type fixture = {
   base_path : string;
   sid : string;
   agent_name : string;
+  auth_token : string;
   clock : float Eio.Time.clock_ty Eio.Resource.t;
   sw : Eio.Switch.t;
   state : Mcp_eio.server_state;
@@ -30,6 +32,7 @@ type fixture = {
   mutable library_topic : string option;
   mutable worktree_task_id : string option;
   mutable code_file_path : string option;
+  mutable goal_id : string option;
 }
 
 type contract_case = {
@@ -229,6 +232,18 @@ let temp_dir prefix =
   Unix.mkdir dir 0o755;
   dir
 
+let tool_matrix_agent_name = "matrix"
+
+let seed_persona_dir base_path agent_name =
+  let personas_dir =
+    Filename.concat
+      (Filename.concat (Filename.concat base_path ".masc") "config")
+      "personas"
+  in
+  mkdir_p (Filename.concat personas_dir agent_name);
+  Unix.putenv "MASC_PERSONAS_DIR" personas_dir;
+  Masc_mcp.Config_dir_resolver.reset ()
+
 let run_cmd_exn argv =
   let cmd = String.concat " " (List.map Filename.quote argv) in
   match Sys.command cmd with
@@ -260,6 +275,7 @@ let setup_git_repo base_path =
 
 let execute_tool fixture ~name ~arguments =
   Mcp_eio.execute_tool_eio ~sw:fixture.sw ~clock:fixture.clock
+    ~auth_token:fixture.auth_token
     ~mcp_session_id:fixture.sid fixture.state ~name ~arguments
 
 let execute_tool_ok fixture ~name ~arguments =
@@ -302,11 +318,24 @@ let make_fixture sw ~proc_mgr ~fs ~net ~mono_clock clock ~base_path init_mode =
     Mcp_eio.create_state_eio ~sw ~proc_mgr ~fs ~clock ~mono_clock ~net
       ~base_path
   in
+  seed_persona_dir base_path tool_matrix_agent_name;
+  let auth_token =
+    match
+      Masc_mcp.Auth.create_token base_path ~agent_name:tool_matrix_agent_name
+        ~role:Masc_domain.Admin
+    with
+    | Ok (token, _cred) -> token
+    | Error err ->
+        failwith
+          ("failed to create tool matrix auth token: "
+          ^ Masc_domain.masc_error_to_string err)
+  in
   let fixture =
     {
       base_path;
       sid = "mcp-tool-matrix";
-      agent_name = "codex-tool-matrix";
+      agent_name = tool_matrix_agent_name;
+      auth_token;
       clock;
       sw;
       state;
@@ -320,6 +349,7 @@ let make_fixture sw ~proc_mgr ~fs ~net ~mono_clock clock ~base_path init_mode =
       library_topic = None;
       worktree_task_id = None;
       code_file_path = None;
+      goal_id = None;
     }
   in
   (match init_mode with
@@ -329,6 +359,21 @@ let make_fixture sw ~proc_mgr ~fs ~net ~mono_clock clock ~base_path init_mode =
       ensure_initialized fixture;
       ensure_joined fixture);
   fixture
+
+let ensure_goal fixture =
+  match fixture.goal_id with
+  | Some goal_id -> goal_id
+  | None ->
+      let goal =
+        match
+          Goal_store.upsert_goal fixture.state.room_config
+            ~title:"Tool Matrix Goal" ()
+        with
+        | Ok (goal, _status) -> goal
+        | Error err -> failwith ("failed to seed tool matrix goal: " ^ err)
+      in
+      fixture.goal_id <- Some goal.Goal_store.id;
+      goal.Goal_store.id
 
 let ensure_task fixture =
   match fixture.task_id with
@@ -342,6 +387,7 @@ let ensure_task fixture =
                 ("title", `String "Tool Matrix Task");
                 ("priority", `Int 2);
                 ("description", `String "task fixture");
+                ("goal_id", `String (ensure_goal fixture));
               ])
       in
       let task_id =
@@ -591,6 +637,13 @@ let field_type = function
 
 let task_id_for_tool fixture _tool_name = ensure_task fixture
 
+let goal_principal fixture =
+  `Assoc
+    [
+      ("kind", `String "keeper");
+      ("id", `String fixture.agent_name);
+    ]
+
 let field_value fixture ~tool_name field_name schema =
   let enum_choice = enum_first schema in
   match field_name with
@@ -611,6 +664,8 @@ let field_value fixture ~tool_name field_name schema =
   | "new_string" -> `String "after"
   | "key" -> `String "tool-matrix-cache"
   | "task_id" -> `String (task_id_for_tool fixture tool_name)
+  | "goal_id" -> `String (ensure_goal fixture)
+  | "actor" | "principal" -> goal_principal fixture
   | "task_title" -> `String "Tool Matrix Started Task"
   | "title" -> `String "Tool Matrix Title"
   | "summary" -> `String "tool matrix summary"
@@ -638,6 +693,7 @@ let field_value fixture ~tool_name field_name schema =
               ("title", `String "Tool Matrix Batch Task");
               ("priority", `Int 2);
               ("description", `String "batch");
+              ("goal_id", `String (ensure_goal fixture));
             ];
         ]
   | "post_id" | "parent_id" -> `String (ensure_board_post fixture)
@@ -978,7 +1034,8 @@ let call_tool_json fixture (schema : Masc_domain.tool_schema) arguments =
         ])
   in
   Mcp_eio.handle_request ~clock:fixture.clock ~sw:fixture.sw
-    ~mcp_session_id:fixture.sid fixture.state request
+    ~mcp_session_id:fixture.sid ~auth_token:fixture.auth_token fixture.state
+    request
 
 let run_case sw ~proc_mgr ~fs ~net ~mono_clock clock
     (schema : Masc_domain.tool_schema) =
@@ -991,6 +1048,7 @@ let run_case sw ~proc_mgr ~fs ~net ~mono_clock clock
       ("DATABASE_URL", Sys.getenv_opt "DATABASE_URL");
       ("SUPABASE_DB_URL", Sys.getenv_opt "SUPABASE_DB_URL");
       ("SB_PG_URL", Sys.getenv_opt "SB_PG_URL");
+      ("MASC_PERSONAS_DIR", Sys.getenv_opt "MASC_PERSONAS_DIR");
     ]
   in
   Unix.putenv "MASC_STORAGE_TYPE" "filesystem";
@@ -1009,6 +1067,7 @@ let run_case sw ~proc_mgr ~fs ~net ~mono_clock clock
             | Some raw -> Unix.putenv name raw
             | None -> Unix.putenv name "")
           saved_env;
+        Masc_mcp.Config_dir_resolver.reset ();
         match saved_home with
         | Some home -> Unix.putenv "HOME" home
         | None -> Unix.putenv "HOME" "")

--- a/test/tool_matrix_case_runner.ml
+++ b/test/tool_matrix_case_runner.ml
@@ -53,8 +53,8 @@ let () =
       let fs = Eio.Stdenv.fs env in
       let net = Eio.Stdenv.net env in
       let mono_clock = Eio.Stdenv.mono_clock env in
+      Eio.Switch.run @@ fun sw ->
       let base_path, result =
-        Eio.Switch.run @@ fun sw ->
         Cases.run_case sw ~proc_mgr ~fs ~net ~mono_clock clock schema
       in
       emit_result ~base_path tool_name result;


### PR DESCRIPTION
## What changed

- Keep each tool-matrix case runner inside the Eio switch until after it emits the case result and exits, so long-lived fibers from runtime state cannot keep the runner alive after a case finishes.
- Seed the MCP matrix fixture with a real admin bearer token and temp persona directory, matching the authenticated MCP path used by the live server.
- Seed a real goal for task/goal-related matrix cases and provide valid goal principal objects for goal FSM tools.
- Update keeper matrix arguments for board curation and `keeper_shell`, and treat keeper-management tools as MCP-client-only guards when exercised from keeper context.

## Why

The full matrix exposed a runner lifecycle issue: individual case processes could finish the tool call but then hang while `Eio.Switch.run` waited on long-lived fibers created by the server state. That made matrix coverage unreliable and hid real contract failures behind timeout noise.

After the runner fix, the matrix reached real tool contracts. The fixture updates align the test inputs with current auth, persona, task, board, goal, and keeper surface contracts instead of relying on stale unauthenticated or pre-goal assumptions.

## Validation

- `git diff --check`
- Before the final fixture-contract edits, focused build passed:
  `scripts/dune-local.sh build test/keeper_tool_matrix_case_runner.exe test/tool_matrix_case_runner.exe test/test_keeper_tool_matrix.exe test/test_mcp_tool_matrix.exe`
- Before the final fixture-contract edits, focused keeper matrix passed:
  `KEEPER_TOOL_MATRIX_ONLY=keeper_bash KEEPER_TOOL_MATRIX_CASE_TIMEOUT_SEC=25 _build/default/test/test_keeper_tool_matrix.exe`
- Before the final fixture-contract edits, focused MCP matrix passed:
  `MCP_TOOL_MATRIX_ONLY=masc_status MCP_TOOL_MATRIX_CASE_TIMEOUT_SEC=25 _build/default/test/test_mcp_tool_matrix.exe`
- Full keeper matrix completed instead of hanging: 134 cases ran in 153.160s, surfacing contract failures that this PR addresses in the harness.

## Local verification limitation

After the final fixture-contract edits, the focused Dune wrapper rerun could not acquire `/tmp/me-dune-local.lock` within the bounded wait because other local MASC builds were already queued/running. CI should be treated as the current compile/test authority for this pushed head.
