### PR TITLE
fix(keeper): reload goal scope for claims

### DIFF
--- a/lib/keeper/keeper_exec_task.ml
+++ b/lib/keeper/keeper_exec_task.ml
@@ -51,7 +51,8 @@ let parse_task_contract_arg args =
 ;;
 
 let active_goal_scope_json ~(meta : keeper_meta) ?matched_goal_id
-    ?excluded_count ?effective_mode ?effective_goal_ids ?fallback_reason () =
+    ?excluded_count ?effective_mode ?effective_goal_ids ?fallback_reason
+    ?(source = "caller_meta") () =
   let scoped = meta.active_goal_ids <> [] in
   let mode =
     match effective_mode with
@@ -73,6 +74,7 @@ let active_goal_scope_json ~(meta : keeper_meta) ?matched_goal_id
       ( "effective_goal_ids",
         `List (List.map (fun goal_id -> `String goal_id) effective_goal_ids)
       );
+      ("source", `String source);
       ("fallback_reason", Json_util.string_opt_to_json fallback_reason);
       ("matched_goal_id", Json_util.string_opt_to_json matched_goal_id);
     ]
@@ -127,6 +129,23 @@ let merge_current_task_id ~(latest : keeper_meta) ~(caller : keeper_meta) =
     current_task_id = caller.current_task_id;
     updated_at = caller.updated_at;
   }
+;;
+
+let claim_time_meta ~(config : Coord.config) ~(caller : keeper_meta) =
+  let from_registry () =
+    match Keeper_registry.get ~base_path:config.base_path caller.name with
+    | Some entry -> entry.meta, "registry_keeper_meta_at_claim"
+    | None -> caller, "caller_meta_fallback"
+  in
+  match read_meta config caller.name with
+  | Ok (Some latest) -> latest, "latest_keeper_meta_at_claim"
+  | Ok None -> from_registry ()
+  | Error msg ->
+    Log.Keeper.warn
+      "keeper:%s failed to read latest meta for claim scope; falling back: %s"
+      caller.name
+      msg;
+    from_registry ()
 ;;
 
 let sync_keeper_meta_current_task
@@ -271,6 +290,7 @@ let handle_keeper_task_tool
                     "goal_id", Json_util.string_opt_to_json goal_id;
                   ])))
   | "keeper_task_claim" ->
+    let meta, scope_source = claim_time_meta ~config ~caller:meta in
     let agent_tool_names = Keeper_tool_policy.keeper_allowed_tool_names meta in
     let claim_goal_scope =
       Keeper_runtime_contract.resolve_claim_goal_scope
@@ -327,7 +347,8 @@ let handle_keeper_task_tool
           ( active_goal_scope_json ~meta ?matched_goal_id
               ~effective_mode:claim_goal_scope.mode
               ~effective_goal_ids:claim_goal_scope.effective_goal_ids
-              ?fallback_reason:claim_goal_scope.fallback_reason ()
+              ?fallback_reason:claim_goal_scope.fallback_reason
+              ~source:scope_source ()
           , [
               ( "claim_observation",
                 Tool_task.build_claim_observation_payload
@@ -349,12 +370,14 @@ let handle_keeper_task_tool
           ( active_goal_scope_json ~meta ~excluded_count
               ~effective_mode:claim_goal_scope.mode
               ~effective_goal_ids:claim_goal_scope.effective_goal_ids
-              ?fallback_reason:claim_goal_scope.fallback_reason ()
+              ?fallback_reason:claim_goal_scope.fallback_reason
+              ~source:scope_source ()
           , [] )
       | Coord.Claim_next_no_unclaimed | Coord.Claim_next_error _ ->
           ( active_goal_scope_json ~meta ~effective_mode:claim_goal_scope.mode
               ~effective_goal_ids:claim_goal_scope.effective_goal_ids
-              ?fallback_reason:claim_goal_scope.fallback_reason ()
+              ?fallback_reason:claim_goal_scope.fallback_reason
+              ~source:scope_source ()
           , [] )
     in
     Yojson.Safe.to_string

--- a/test/test_keeper_task_dispatch.ml
+++ b/test/test_keeper_task_dispatch.ml
@@ -223,6 +223,11 @@ let check_active_goal_scope_no_fallback json ~goal_id =
   check (option string) "fallback reason absent" None
     Yojson.Safe.Util.(scope |> member "fallback_reason" |> to_string_option)
 
+let write_keeper_meta_exn config meta =
+  match Keeper_types.write_meta ~force:true config meta with
+  | Ok () -> ()
+  | Error msg -> fail msg
+
 let with_registered_keeper config meta f =
   Keeper_registry.unregister ~base_path:config.Coord.base_path meta.Keeper_types.name;
   ignore
@@ -562,6 +567,60 @@ let test_claim_respects_active_goal_ids () =
         Yojson.Safe.Util.(
           json |> member "claimed_task" |> member "goal_id" |> to_string)
     | None -> fail "expected a claimed task")
+
+let test_claim_reloads_goal_scope_after_stale_observation () =
+  with_room (fun config ->
+    let observed_goal, _ =
+      match Goal_store.upsert_goal config ~title:"Observed scope" () with
+      | Ok payload -> payload
+      | Error msg -> fail msg
+    in
+    let current_goal, _ =
+      match Goal_store.upsert_goal config ~title:"Current scope" () with
+      | Ok payload -> payload
+      | Error msg -> fail msg
+    in
+    let stale_meta = make_goal_scoped_meta [ observed_goal.id ] in
+    let latest_meta = { stale_meta with active_goal_ids = [ current_goal.id ] } in
+    with_registered_keeper config stale_meta (fun () ->
+      write_keeper_meta_exn config stale_meta;
+      let _ =
+        Coord_task.add_task ~goal_id:observed_goal.id config
+          ~title:"Observed-scope task" ~priority:1 ~description:"old view"
+      in
+      let _ =
+        Coord_task.add_task ~goal_id:current_goal.id config
+          ~title:"Current-scope task" ~priority:5 ~description:"latest view"
+      in
+      let observed =
+        Keeper_world_observation.observe
+          ~allowed_tool_names:
+            (Some (Keeper_tool_policy.keeper_allowed_tool_names stale_meta))
+          ~pending_board_events:(Some [])
+          ~config
+          ~meta:stale_meta
+      in
+      check int "stale observation claimable count" 1
+        observed.claimable_task_count;
+      write_keeper_meta_exn config latest_meta;
+      let result = call_tool config stale_meta "keeper_task_claim" (`Assoc []) in
+      let json = parse_json result in
+      let scope = Yojson.Safe.Util.member "claim_scope" json in
+      check string "claim scope source" "latest_keeper_meta_at_claim"
+        Yojson.Safe.Util.(scope |> member "source" |> to_string);
+      check_effective_goal_ids "latest effective goal ids" scope
+        [ current_goal.id ];
+      check (list string) "latest active goal ids" [ current_goal.id ]
+        Yojson.Safe.Util.(
+          scope |> member "active_goal_ids" |> to_list |> List.map to_string);
+      check string "matched current goal" current_goal.id
+        Yojson.Safe.Util.(scope |> member "matched_goal_id" |> to_string);
+      check string "claimed current-scope task" "Current-scope task"
+        Yojson.Safe.Util.(
+          json |> member "claimed_task" |> member "title" |> to_string);
+      let stale_task = task_by_title config "Observed-scope task" in
+      check (option string) "stale observed task not claimed" None
+        (Masc_domain.task_assignee_of_status stale_task.task_status)))
 
 let test_claim_does_not_cross_goal_when_auto_goal_scope_empty () =
   with_room (fun config ->
@@ -1322,6 +1381,8 @@ let () =
         test_claim_prefers_oldest_same_priority_task;
       test_case "claim respects active_goal_ids" `Quick
         test_claim_respects_active_goal_ids;
+      test_case "claim reloads goal scope after stale observation" `Quick
+        test_claim_reloads_goal_scope_after_stale_observation;
       test_case "claim does not cross-goal when auto goal scope is empty" `Quick
         test_claim_does_not_cross_goal_when_auto_goal_scope_empty;
       test_case "claim does not cross-goal when persisted goal scope is empty"


### PR DESCRIPTION
## Summary

- Enforce the latest-scope-at-claim contract for `keeper_task_claim` by reloading keeper meta before resolving `active_goal_ids` and tool access.
- Add `claim_scope.source` so the claim result shows whether scope came from latest persisted meta, registry fallback, or the caller snapshot.
- Add a regression that observes claimable work under stale scope G1, persists scope G2 before claim, and verifies the claim follows G2 instead of the stale observation.

## Why

Observation and claim are separate operations. Without an explicit scope token, the safest contract is that claim time is authoritative. This prevents a keeper from claiming work using a stale active-goal snapshot after an operator or runtime update changes its scope.

## Validation

- `git diff --check`
- `env DUNE_BUILD_DIR=_build_codex_13738_goal_scope_race scripts/dune-local.sh build test/test_keeper_task_dispatch.exe`
- `./_build_codex_13738_goal_scope_race/default/test/test_keeper_task_dispatch.exe test claim` (25 tests)

Closes #13738



## TODO (Symptom 억제 후속 RFC 의무)

`claim_scope.source` 필드는 출처를 *기록*하는 것 자체가 observation/claim 사이 race가 빈발한다는 자인. typed scope token이 흐르지 않는 root는 미해결.

- **TODO**: scope token을 phantom-typed로 observation→claim 사이에 thread하는 RFC 작성. 별도 RFC 머지 시 `claim_scope.source` 필드 deprecate.
- 머지는 가능 (production race 차단 우선), 단 RFC 번호 부여 후 본 PR body에 링크.

근거: `instructions/software-development.md` §워크어라운드 거부 기준 §Symptom 억제 패턴 (PR jeong-sik/me#1100).
