### PR TITLE
fix: require keeper gh credential mount

### DIFF
--- a/lib/keeper/host_config_provider.ml
+++ b/lib/keeper/host_config_provider.ml
@@ -9,20 +9,16 @@ let mount_if_present ~host ~container : Credential_provider.ro_mount list =
   else if not (Sys.file_exists host) then []
   else [ { host; container } ]
 
-(* ── Skipped credential mount warn dedup ───────────────────────
+(* ── Skipped credential mount warnings ─────────────────────────
 
    [mount_if_present] silently drops mounts whose host path is empty
-   or missing.  For the selected GH config bundle this would make a
-   keeper git/gh dispatch fail later with an opaque CLI error, so the
-   composition layer emits a single diagnostic and [resolve] fail-closes
-   when no credential mount remains.
+   or missing.  The selected GH config bundle is a required credential
+   mount, so the composition layer reports that absence as an explicit
+   error before docker dispatch.
 
-   Fires at [compose_ro_mounts] (one observation point per keeper
+   Fires at [compose_ro_mounts_result] (one observation point per keeper
    sandbox launch), not inside [mount_if_present] which is exposed
    via [For_testing] and must stay pure. *)
-let mount_skip_warn_emitted : (string, unit) Hashtbl.t = Hashtbl.create 16
-let mount_skip_warn_mu = Eio.Mutex.create ()
-
 type mount_attempt = {
   label : string;
   host : string;
@@ -45,47 +41,36 @@ let warn_mount_skips_if_any ~keeper_name (attempts : mount_attempt list) =
   in
   if skipped = [] then ()
   else begin
-    let should_emit =
-      Eio.Mutex.use_rw ~protect:true mount_skip_warn_mu (fun () ->
-        if Hashtbl.mem mount_skip_warn_emitted keeper_name then false
-        else begin
-          Hashtbl.add mount_skip_warn_emitted keeper_name ();
-          true
-        end)
-    in
-    if should_emit then begin
-      List.iter
-        (fun a ->
-          let reason =
-            match a.status with
-            | `Empty -> "empty"
-            | `Not_found -> "not_found"
-            | `Mounted -> "mounted"
-          in
-          Prometheus.inc_counter
-            "masc_keeper_credential_mount_skipped_total"
-            ~labels:[ ("keeper", keeper_name); ("mount", a.label);
-                      ("reason", reason) ]
-            ())
-        skipped;
-      let pp_skip a =
-        let r = match a.status with
+    List.iter
+      (fun a ->
+        let reason =
+          match a.status with
           | `Empty -> "empty"
           | `Not_found -> "not_found"
           | `Mounted -> "mounted"
         in
-        Printf.sprintf "%s=%s(%s)" a.label
-          (if a.host = "" then "<empty>" else a.host) r
+        Prometheus.inc_counter
+          "masc_keeper_credential_mount_skipped_total"
+          ~labels:[ ("keeper", keeper_name); ("mount", a.label);
+                    ("reason", reason) ]
+          ())
+      skipped;
+    let pp_skip a =
+      let r = match a.status with
+        | `Empty -> "empty"
+        | `Not_found -> "not_found"
+        | `Mounted -> "mounted"
       in
-      Log.Keeper.warn
-        "%s: sandbox credential mount(s) skipped — keeper inside docker \
-         will be missing the corresponding host credential.  Skipped: \
-         [%s].  Resolution: install the selected root/keeper GitHub \
-         identity bundle under $base_path/.masc/github-identities.  See \
-         [host_config_provider.ml compose_ro_mounts]."
-        keeper_name
-        (String.concat "; " (List.map pp_skip skipped))
-    end
+      Printf.sprintf "%s(%s)" a.label r
+    in
+    Log.Keeper.warn
+      "%s: sandbox credential mount(s) skipped; keeper docker dispatch \
+       will fail before credentials are projected. Skipped: [%s]. \
+       Resolution: materialize the selected root/keeper GitHub identity \
+       bundle under $base_path/.masc/github-identities. See \
+       [host_config_provider.ml compose_ro_mounts_result]."
+      keeper_name
+      (String.concat "; " (List.map pp_skip skipped))
   end
 
 (* Env composition for the selected identity bundle inside the docker
@@ -117,7 +102,22 @@ let compose_env ?ssh_key_container ~git_author_name ~git_author_email () =
   @ ssh_env
   @ Env_git_noninteractive.env
 
-let compose_ro_mounts ?keeper_name (kb : Keeper_gh_env.keeper_binding) =
+let required_mount_result (attempt : mount_attempt) ~container =
+  match attempt.status with
+  | `Mounted -> Ok Credential_provider.{ host = attempt.host; container }
+  | `Empty ->
+      Error
+        (Printf.sprintf
+           "required credential mount %s has an empty host path"
+           attempt.label)
+  | `Not_found ->
+      Error
+        (Printf.sprintf
+           "required credential mount %s host path is missing"
+           attempt.label)
+
+let compose_ro_mounts_result ?keeper_name
+    (kb : Keeper_gh_env.keeper_binding) =
   let gh_creds = kb.gh_config_dir in
   let identity_gitconfig = Filename.concat kb.bundle_root "gitconfig" in
   let identity_ssh_dir = Filename.concat kb.bundle_root "ssh" in
@@ -129,18 +129,23 @@ let compose_ro_mounts ?keeper_name (kb : Keeper_gh_env.keeper_binding) =
       identity_ssh_dir
     else ""
   in
-  let attempts = [
-    classify_mount_attempt ~label:"gh_creds" ~host:gh_creds;
-  ] in
+  let gh_attempt = classify_mount_attempt ~label:"gh_creds" ~host:gh_creds in
+  let attempts = [ gh_attempt ] in
   Option.iter
     (fun name -> warn_mount_skips_if_any ~keeper_name:name attempts)
     keeper_name;
-  mount_if_present ~host:gh_creds
-    ~container:(Filename.concat cred_root ".config/gh")
-  @ mount_if_present ~host:gitconfig
-      ~container:(Filename.concat cred_root ".gitconfig")
-  @ mount_if_present ~host:ssh_dir
-      ~container:(Filename.concat cred_root ".ssh")
+  match
+    required_mount_result gh_attempt
+      ~container:(Filename.concat cred_root ".config/gh")
+  with
+  | Error _ as err -> err
+  | Ok gh_mount ->
+      Ok
+        (gh_mount
+         :: (mount_if_present ~host:gitconfig
+               ~container:(Filename.concat cred_root ".gitconfig")
+            @ mount_if_present ~host:ssh_dir
+                ~container:(Filename.concat cred_root ".ssh")))
 
 let resolve_git_identity (kb : Keeper_gh_env.keeper_binding) ~keeper_name =
   match kb.github_identity, kb.git_identity_mode with
@@ -168,7 +173,7 @@ let metadata_of_binding (kb : Keeper_gh_env.keeper_binding) =
    (#12304).  When a keeper has a [Keeper_repo_mapping] entry that
    resolves to exactly one [Credential_store] credential we synthesise
    a [Keeper_gh_env.keeper_binding] from that credential and reuse the
-   existing [compose_env]/[compose_ro_mounts] flow verbatim, preserving
+   existing [compose_env]/[compose_ro_mounts_result] flow verbatim, preserving
    every fail-closed semantics and warning the legacy path already
    carries.  Keepers with no mapping fall through to [legacy_resolve]
    exactly as before.
@@ -195,31 +200,23 @@ let bind_from_keeper_binding ?ssh_key_path ~keeper_name
   let env =
     compose_env ?ssh_key_container ~git_author_name ~git_author_email ()
   in
-  let ro_mounts =
-    compose_ro_mounts ~keeper_name kb
-    @
-    match ssh_key_path with
-    | None -> []
-    | Some host ->
-        [
-          Credential_provider.
-            { host; container = explicit_ssh_key_container_path };
-        ]
-  in
-  (* β7 fail-closed: resolve is called only when git_creds_enabled
-     (caller at keeper_shell_docker.ml:398-400).  If ALL credential
-     host paths are empty or missing, ro_mounts will be [].  Returning
-     Ok with empty mounts lets the keeper start in Docker with no
-     credential files — gh/git commands then fail with confusing 401
-     or "permission denied" errors.  Return Error so the caller
-     reports the real cause at sandbox creation time. *)
-  if ro_mounts = [] then
-    Error
-      (Credential_provider.Missing_bundle
-         { identity = keeper_name
-         ; path = "all credential host paths empty or missing"
-         })
-  else
+  match compose_ro_mounts_result ~keeper_name kb with
+  | Error reason ->
+      Error
+        (Credential_provider.Missing_bundle
+           { identity = keeper_name; path = reason })
+  | Ok bundle_mounts ->
+    let ro_mounts =
+      bundle_mounts
+      @
+      match ssh_key_path with
+      | None -> []
+      | Some host ->
+          [
+            Credential_provider.
+              { host; container = explicit_ssh_key_container_path };
+          ]
+    in
     (* #12685: credential preflight — verify the bundle is actually
        materialized before handing it to the sandbox.  Directory
        presence alone is insufficient: a stale or corrupt hosts.yml
@@ -278,9 +275,8 @@ let legacy_resolve ~config ~keeper_name =
    matches the existing host bundle layout
    (<base>/.masc/github-identities/<id>/gh) but tolerates operator-set
    custom paths — sibling files (gitconfig, ssh) that happen to live next
-   to [gh_config_dir] are picked up by [compose_ro_mounts] via
-   [mount_if_present]; absent siblings are silently skipped, just as in
-   the legacy path. *)
+   to [gh_config_dir] are picked up by [compose_ro_mounts_result] via
+   [mount_if_present]; absent siblings are optional. *)
 let binding_of_credential (cred : Repo_manager_types.credential)
     : (Keeper_gh_env.keeper_binding, string) result =
   match cred.gh_config_dir with
@@ -460,4 +456,5 @@ module For_testing = struct
     compose_env ?ssh_key_container ~git_author_name ~git_author_email ()
 
   let mount_if_present = mount_if_present
+  let compose_ro_mounts_result = compose_ro_mounts_result
 end

--- a/lib/keeper/host_config_provider.mli
+++ b/lib/keeper/host_config_provider.mli
@@ -30,4 +30,9 @@ module For_testing : sig
 
   val mount_if_present :
     host:string -> container:string -> Credential_provider.ro_mount list
+
+  val compose_ro_mounts_result :
+    ?keeper_name:string ->
+    Keeper_gh_env.keeper_binding ->
+    (Credential_provider.ro_mount list, string) result
 end

--- a/test/test_credential_provider.ml
+++ b/test/test_credential_provider.ml
@@ -12,9 +12,10 @@
     1. [Credential_provider.pp_error] formats every variant.  Mostly
        a regression guard: if a future PR adds a fifth error case
        and forgets [pp_error], the [exhaustive] assertion catches it.
-    2. [Host_config_provider.For_testing.mount_if_present] returns
-       [[]] for empty / missing host paths and a single-element
-       [ro_mount] when the path exists.
+    2. [Host_config_provider.For_testing.compose_ro_mounts_result]
+       fails closed when the selected GH config mount is empty/missing.
+       [mount_if_present] stays a pure optional-mount helper for
+       sibling gitconfig/ssh paths.
     3. [For_testing.compose_env] emits only container-local path/env
        keys for the selected identity bundle plus non-interactive git
        guards.  Ambient operator GitHub credentials stay outside this
@@ -27,6 +28,7 @@ open Alcotest
 
 module CP = Masc_mcp.Credential_provider
 module HCP = Masc_mcp.Host_config_provider
+module KGE = Masc_mcp.Keeper_gh_env
 open Repo_manager_types
 
 let mkdir_p path =
@@ -135,6 +137,16 @@ let make_repo ~id ~credential_id : repository =
     updated_at = Int64.zero;
   }
 
+let make_keeper_binding ~bundle_root ~gh_config_dir : KGE.keeper_binding =
+  {
+    KGE.github_identity = Some "test-gh";
+    effective_github_identity = "test-gh";
+    credential_scope = KGE.Keeper_identity;
+    git_identity_mode = "github_identity";
+    bundle_root;
+    gh_config_dir;
+  }
+
 (* --- 1. pp_error covers every variant --- *)
 
 let test_pp_error_all_variants () =
@@ -156,37 +168,78 @@ let test_pp_error_all_variants () =
          && String.sub rendered 0 (String.length prefix) = prefix))
     cases
 
-(* --- 2. mount_if_present skip rules --- *)
+(* --- 2. required GH mount fail-closed rules --- *)
 
-(* β7 fail-closed: [resolve] returns Error when ALL credential host paths
-   are empty or missing.  [resolve] itself requires a Coord.config, so
-   unit-testing it directly needs the integration test suite
-   ([test_keeper_shell_docker_route]).  What we can pin here is the
-   precondition: three mount_if_present calls with empty/missing hosts
-   produce an empty mount list, and the error format is correct. *)
-let test_fail_closed_all_credential_paths_empty () =
-  let gh_creds = "" and gitconfig = "" and ssh_dir = "" in
-  let ro_mounts =
-    HCP.For_testing.mount_if_present ~host:gh_creds
-      ~container:"/tmp/keeper-creds/.config/gh"
-    @ HCP.For_testing.mount_if_present ~host:gitconfig
-        ~container:"/tmp/keeper-creds/.gitconfig"
-    @ HCP.For_testing.mount_if_present ~host:ssh_dir
-        ~container:"/tmp/keeper-creds/.ssh"
+let test_required_gh_mount_empty_path_fails_closed () =
+  let kb = make_keeper_binding ~bundle_root:"" ~gh_config_dir:"" in
+  match HCP.For_testing.compose_ro_mounts_result kb with
+  | Ok mounts ->
+      failf "empty required gh_config_dir should fail, got %d mounts"
+        (List.length mounts)
+  | Error reason ->
+      check bool "mentions required mount" true
+        (try
+           ignore
+             (Str.search_forward
+                (Str.regexp_string "required credential mount gh_creds")
+                reason 0);
+           true
+         with Not_found -> false);
+      check bool "mentions empty host path" true
+        (try
+           ignore
+             (Str.search_forward (Str.regexp_string "empty host path")
+                reason 0);
+           true
+         with Not_found -> false)
+
+let test_required_gh_mount_missing_path_fails_closed () =
+  let missing_path =
+    Filename.concat (Filename.get_temp_dir_name ())
+      "nonexistent-host-path-rfc0008-pr1"
   in
-  check int "all-empty paths -> empty mounts" 0 (List.length ro_mounts);
-  let err =
-    CP.Missing_bundle
-      { identity = "test-keeper"; path = "all credential host paths empty or missing" }
+  let kb =
+    make_keeper_binding ~bundle_root:(Filename.dirname missing_path)
+      ~gh_config_dir:missing_path
   in
-  let rendered = CP.pp_error err in
-  check bool "error rendered with identity"
-    true
-    (String.length rendered > 0);
-  check bool "error mentions credential paths"
-    true
-    (try ignore (Str.search_forward (Str.regexp "credential") rendered 0); true
-     with Not_found -> false)
+  match HCP.For_testing.compose_ro_mounts_result kb with
+  | Ok mounts ->
+      failf "missing required gh_config_dir should fail, got %d mounts"
+        (List.length mounts)
+  | Error reason ->
+      check bool "mentions missing host path" true
+        (try
+           ignore
+             (Str.search_forward (Str.regexp_string "host path is missing")
+                reason 0);
+           true
+         with Not_found -> false);
+      check bool "does not leak raw host path" false
+        (try
+           ignore (Str.search_forward (Str.regexp_string missing_path) reason 0);
+           true
+         with Not_found -> false)
+
+let test_required_gh_mount_allows_absent_optional_siblings () =
+  with_temp_base_path (fun base_path ->
+      let bundle_root =
+        Filename.concat base_path ".masc/github-identities/test-gh"
+      in
+      let gh_config_dir = Filename.concat bundle_root "gh" in
+      mkdir_p gh_config_dir;
+      let kb = make_keeper_binding ~bundle_root ~gh_config_dir in
+      match HCP.For_testing.compose_ro_mounts_result kb with
+      | Error reason ->
+          failf "existing required gh_config_dir should mount: %s" reason
+      | Ok mounts ->
+          check int "only required gh mount" 1 (List.length mounts);
+          match mounts with
+          | [ mount ] ->
+              check string "host preserved" gh_config_dir mount.CP.host;
+              check string "container"
+                (Filename.concat HCP.cred_root ".config/gh")
+                mount.CP.container
+          | _ -> fail "expected exactly one mount")
 
 let test_mount_if_present_empty_host () =
   let r = HCP.For_testing.mount_if_present ~host:"" ~container:"/x" in
@@ -610,8 +663,12 @@ let () =
         ( "errors",
         [
           test_case "pp_error covers all variants" `Quick test_pp_error_all_variants;
-          test_case "fail-closed: all-empty paths produce Missing_bundle" `Quick
-            test_fail_closed_all_credential_paths_empty;
+          test_case "empty required gh mount fails closed" `Quick
+            test_required_gh_mount_empty_path_fails_closed;
+          test_case "missing required gh mount fails closed" `Quick
+            test_required_gh_mount_missing_path_fails_closed;
+          test_case "absent optional siblings are allowed" `Quick
+            test_required_gh_mount_allows_absent_optional_siblings;
         ] );
       ( "mount_if_present",
         [


### PR DESCRIPTION
## Summary

- Make the selected keeper GH config mount a required `Result` path before Docker dispatch.
- Keep `gitconfig` and `ssh` sibling mounts optional, but fail closed when `gh_config_dir` is empty or missing.
- Remove mount-skip warning deduplication and avoid logging raw host credential paths in the warning/error for this gate.

## Product impact

Keeper git/GitHub work now fails at sandbox credential resolution when the selected GH identity bundle is absent, instead of starting a container that later fails with opaque `gh` or `git` auth errors. Repeated missing-bundle attempts remain visible through metrics/logs, while the emitted warning only names the mount label and reason.

## Evidence

- `git diff --check`
- `scripts/dune-local.sh build test/test_credential_provider.exe`
- `./_build/default/test/test_credential_provider.exe` (23 tests)

## Review evidence

This addresses the Keeper FSM/security audit finding that credential mount composition could silently drop the selected GH credential path and proceed. The test coverage now pins empty path, missing path, non-leaking error text, and absent optional sibling behavior.

## Linked issue

None.
