### PR TITLE
ci(str): fail new enum string dispatch

### DIFF
--- a/scripts/ci/check-enum-string-safety.sh
+++ b/scripts/ci/check-enum-string-safety.sh
@@ -14,7 +14,138 @@ set -euo pipefail
 
 cd "$(git rev-parse --show-toplevel)"
 
+base_ref="origin/main"
+head_ref="HEAD"
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --base)
+      if [ "$#" -lt 2 ]; then
+        echo "usage: $0 [--base REF] [--head REF]" >&2
+        exit 2
+      fi
+      base_ref="$2"
+      shift 2
+      ;;
+    --head)
+      if [ "$#" -lt 2 ]; then
+        echo "usage: $0 [--base REF] [--head REF]" >&2
+        exit 2
+      fi
+      head_ref="$2"
+      shift 2
+      ;;
+    *)
+      echo "usage: $0 [--base REF] [--head REF]" >&2
+      exit 2
+      ;;
+  esac
+done
+
 exit_code=0
+
+print_first_lines() {
+  local limit="$1"
+  awk -v limit="$limit" 'NR <= limit { print }'
+}
+
+is_enum_string_pattern() {
+  local text="$1"
+  if rg -q 'String\.lowercase_ascii.*=\s*"' <<< "$text"; then
+    return 0
+  fi
+  if rg -q 'json_string_opt\s+"(status|state|kind|type|action|mode|profile)"' <<< "$text"; then
+    return 0
+  fi
+  if rg -q 'List\.mem.*\[.*"' <<< "$text"; then
+    return 0
+  fi
+  return 1
+}
+
+has_str_ok_comment() {
+  local path="$1"
+  local line_no="$2"
+  local start=$((line_no > 2 ? line_no - 2 : 1))
+  local end=$((line_no + 2))
+  [ -f "$path" ] || return 1
+  sed -n "${start},${end}p" "$path" \
+    | rg -q 'STR-OK|STRING-BOUNDARY-OK|enum-string-safety: allow'
+}
+
+scan_new_enum_string_dispatch() {
+  local failures=()
+  local current_path=""
+  local new_line_no=0
+  local raw=""
+  local source_label=""
+  local text=""
+
+  scan_diff_stream() {
+    source_label="$1"
+    current_path=""
+    new_line_no=0
+    while IFS= read -r raw; do
+      case "$raw" in
+        "diff --git "*)
+          current_path=""
+          new_line_no=0
+          ;;
+        "+++ b/"*)
+          current_path="${raw#+++ b/}"
+          new_line_no=0
+          ;;
+        "@@ "*)
+          if [[ "$raw" =~ \+([0-9]+)(,([0-9]+))? ]]; then
+            new_line_no="${BASH_REMATCH[1]}"
+          else
+            new_line_no=0
+          fi
+          ;;
+        +*)
+          if [[ "$raw" != "+++"* && "$current_path" == lib/*.ml && "$new_line_no" -gt 0 ]]; then
+            text="${raw:1}"
+            if is_enum_string_pattern "$text" \
+               && ! has_str_ok_comment "$current_path" "$new_line_no"; then
+              failures+=("${source_label}: ${current_path}:${new_line_no}: ${text}")
+            fi
+            new_line_no=$((new_line_no + 1))
+          fi
+          ;;
+        -*)
+          ;;
+        *)
+          if [ "$new_line_no" -gt 0 ]; then
+            new_line_no=$((new_line_no + 1))
+          fi
+          ;;
+      esac
+    done
+  }
+
+  scan_diff_stream "${base_ref}...${head_ref}" \
+    < <(git diff --unified=0 "${base_ref}...${head_ref}" -- lib/ || true)
+  scan_diff_stream "staged" \
+    < <(git diff --cached --unified=0 -- lib/ || true)
+  scan_diff_stream "worktree" \
+    < <(git diff --unified=0 -- lib/ || true)
+
+  if [ "${#failures[@]}" -gt 0 ]; then
+    echo "FAIL: new enum-like string dispatch added:"
+    printf '%s\n' "${failures[@]}" | print_first_lines 40
+    echo
+    echo "Use a typed parser/variant, or add a nearby STR-OK comment for a real boundary parser."
+    return 1
+  fi
+
+  echo "PASS: no new enum-like string dispatch added in ${base_ref}...${head_ref}, staged diff, or worktree diff"
+}
+
+# Diff ratchet: existing debt remains warning-only, but new STR sites fail.
+echo "=== Scan: new enum-like string dispatch ratchet ==="
+if ! scan_new_enum_string_dispatch; then
+  exit_code=1
+fi
 
 # 1. Flag String.lowercase_ascii + equality chains in non-parsing code
 #    Heuristic: three or more consecutive string comparisons on the same variable
@@ -22,7 +153,7 @@ echo "=== Scan: repeated string equality dispatch ==="
 matches=$(rg -n 'String\.lowercase_ascii.*=\s*"' lib/ --type ml -g '!test/' || true)
 if [ -n "$matches" ]; then
   echo "WARN: String.lowercase_ascii + literal comparison found (consider variant):"
-  echo "$matches" | head -20
+  print_first_lines 20 <<< "$matches"
 fi
 
 # 2. json_string_opt on fields that should be enum-constrained
@@ -34,7 +165,7 @@ matches=$(
 )
 if [ -n "$matches" ]; then
   echo "WARN: json_string_opt on enum-like field (consider strict enum parser):"
-  echo "$matches" | head -20
+  print_first_lines 20 <<< "$matches"
 fi
 
 # 3. List.mem + string literals for category dispatch
@@ -42,11 +173,13 @@ echo "=== Scan: List.mem string literal dispatch ==="
 matches=$(rg -n 'List\.mem.*\[.*"' lib/ --type ml -g '!test/' || true)
 if [ -n "$matches" ]; then
   echo "WARN: List.mem with string literals (consider variant + List.mem on variant):"
-  echo "$matches" | head -20
+  print_first_lines 20 <<< "$matches"
 fi
 
 if [ "$exit_code" -eq 0 ]; then
   echo "=== STR gate: PASS ==="
+else
+  echo "=== STR gate: FAIL ==="
 fi
 
 exit "$exit_code"


### PR DESCRIPTION
## Summary
- Add a diff ratchet to scripts/ci/check-enum-string-safety.sh so new enum-like string dispatch in lib/*.ml fails CI.
- Keep existing STR debt warning-only while scanning origin/main...HEAD, staged diff, and worktree diff.
- Allow explicit nearby STR-OK / STRING-BOUNDARY-OK comments for real boundary parsers.

## Why
#9521 already had a WARN-only scan, but it did not prevent new string-based enum dispatch from landing. This makes the guard preventive without forcing a mass cleanup of existing warnings.

## Validation
- bash -n scripts/ci/check-enum-string-safety.sh
- shellcheck scripts/ci/check-enum-string-safety.sh
- bash scripts/ci/check-enum-string-safety.sh --base origin/main --head HEAD
- bash scripts/ci/check-enum-string-safety.sh
- git diff --check
- git diff --cached --check
- Negative probe: temporarily added a String.lowercase_ascii literal comparison in lib/gh_command_validation.ml and verified the ratchet failed; probe was removed before commit.

Refs #9521