### PR TITLE
ci(det): fail new deterministic boundary debt

### DIFF
--- a/scripts/ci/check-determinism-contract.sh
+++ b/scripts/ci/check-determinism-contract.sh
@@ -15,12 +15,138 @@ set -euo pipefail
 
 cd "$(git rev-parse --show-toplevel)"
 
+base_ref="origin/main"
+head_ref="HEAD"
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --base)
+      if [ "$#" -lt 2 ]; then
+        echo "usage: $0 [--base REF] [--head REF]" >&2
+        exit 2
+      fi
+      base_ref="$2"
+      shift 2
+      ;;
+    --head)
+      if [ "$#" -lt 2 ]; then
+        echo "usage: $0 [--base REF] [--head REF]" >&2
+        exit 2
+      fi
+      head_ref="$2"
+      shift 2
+      ;;
+    *)
+      echo "usage: $0 [--base REF] [--head REF]" >&2
+      exit 2
+      ;;
+  esac
+done
+
 exit_code=0
 
 print_first_lines() {
   local limit="$1"
   awk -v limit="$limit" 'NR <= limit { print }'
 }
+
+is_det_ndt_pattern() {
+  local text="$1"
+  if rg -q 'Unix\.gettimeofday|Random\.|Unix\.times|Sys\.time|Unix\.getpid' <<< "$text"; then
+    return 0
+  fi
+  if rg -q 'Option\.value.*~default:' <<< "$text"; then
+    return 0
+  fi
+  if rg -q '\|\s*_\s*->\s*Some' <<< "$text"; then
+    return 0
+  fi
+  return 1
+}
+
+has_det_ndt_ok_comment() {
+  local path="$1"
+  local line_no="$2"
+  local start=$((line_no > 2 ? line_no - 2 : 1))
+  local end=$((line_no + 2))
+  [ -f "$path" ] || return 1
+  sed -n "${start},${end}p" "$path" \
+    | rg -q 'DET-OK|NDT-OK|determinism-contract: allow|sound-partial: allow'
+}
+
+scan_new_det_ndt_debt() {
+  local failures=()
+  local current_path=""
+  local new_line_no=0
+  local raw=""
+  local source_label=""
+  local text=""
+
+  scan_diff_stream() {
+    source_label="$1"
+    current_path=""
+    new_line_no=0
+    while IFS= read -r raw; do
+      case "$raw" in
+        "diff --git "*)
+          current_path=""
+          new_line_no=0
+          ;;
+        "+++ b/"*)
+          current_path="${raw#+++ b/}"
+          new_line_no=0
+          ;;
+        "@@ "*)
+          if [[ "$raw" =~ \+([0-9]+)(,([0-9]+))? ]]; then
+            new_line_no="${BASH_REMATCH[1]}"
+          else
+            new_line_no=0
+          fi
+          ;;
+        +*)
+          if [[ "$raw" != "+++"* && "$current_path" == lib/*.ml && "$new_line_no" -gt 0 ]]; then
+            text="${raw:1}"
+            if is_det_ndt_pattern "$text" \
+               && ! has_det_ndt_ok_comment "$current_path" "$new_line_no"; then
+              failures+=("${source_label}: ${current_path}:${new_line_no}: ${text}")
+            fi
+            new_line_no=$((new_line_no + 1))
+          fi
+          ;;
+        -*)
+          ;;
+        *)
+          if [ "$new_line_no" -gt 0 ]; then
+            new_line_no=$((new_line_no + 1))
+          fi
+          ;;
+      esac
+    done
+  }
+
+  scan_diff_stream "${base_ref}...${head_ref}" \
+    < <(git diff --unified=0 "${base_ref}...${head_ref}" -- lib/ || true)
+  scan_diff_stream "staged" \
+    < <(git diff --cached --unified=0 -- lib/ || true)
+  scan_diff_stream "worktree" \
+    < <(git diff --unified=0 -- lib/ || true)
+
+  if [ "${#failures[@]}" -gt 0 ]; then
+    echo "FAIL: new deterministic-boundary debt added:"
+    printf '%s\n' "${failures[@]}" | print_first_lines 40
+    echo
+    echo "Wrap non-determinism at the boundary, keep parsing sound-partial, or add a nearby DET-OK/NDT-OK comment with rationale."
+    return 1
+  fi
+
+  echo "PASS: no new deterministic-boundary debt added in ${base_ref}...${head_ref}, staged diff, or worktree diff"
+}
+
+# Diff ratchet: existing DET/NDT debt remains warning-only, but new sites fail.
+echo "=== Scan: new deterministic-boundary ratchet ==="
+if ! scan_new_det_ndt_debt; then
+  exit_code=1
+fi
 
 # 1. Deterministic code branching on non-deterministic values
 echo "=== Scan: deterministic branch on non-deterministic source ==="
@@ -65,6 +191,8 @@ fi
 
 if [ "$exit_code" -eq 0 ]; then
   echo "=== DET/NDT gate: PASS ==="
+else
+  echo "=== DET/NDT gate: FAIL ==="
 fi
 
 exit "$exit_code"


### PR DESCRIPTION
## Summary
- Add a diff ratchet to scripts/ci/check-determinism-contract.sh so new DET/NDT debt in lib/*.ml fails CI.
- Keep existing nondeterminism, permissive-default, and catch-all Some findings warning-only.
- Scan origin/main...HEAD, staged diff, and worktree diff, with explicit DET-OK / NDT-OK comments for intentional boundary cases.

## Why
#9522 already had a WARN-only deterministic-boundary scan. That records existing debt, but it does not prevent new wall-clock/random dependencies or unsound partial parsing defaults from landing. This PR makes the gate preventive while avoiding a mass refactor of existing warnings.

## Validation
- bash -n scripts/ci/check-determinism-contract.sh
- shellcheck scripts/ci/check-determinism-contract.sh
- bash scripts/ci/check-determinism-contract.sh --base origin/main --head HEAD
- bash scripts/ci/check-determinism-contract.sh
- git diff --check
- git diff --cached --check
- Negative probe: temporarily added Unix.gettimeofday in lib/gh_command_validation.ml and verified the ratchet failed; probe was removed before commit.

Refs #9522