### PR TITLE
fix: preserve same-second runtime trust receipts

### DIFF
--- a/lib/keeper/keeper_runtime_trust_snapshot.ml
+++ b/lib/keeper/keeper_runtime_trust_snapshot.ml
@@ -190,10 +190,11 @@ let receipt_ended_at_unix receipt =
       if ts > 0.0 then Some ts else None
   | None -> None
 
-(* Receipt timestamps are serialized with lower precision than runtime
-   last-turn observations, so a tiny tolerance avoids treating same-turn
-   observations as newer blockers because of formatting jitter. *)
-let runtime_blocker_receipt_timestamp_epsilon_sec = 0.001
+(* Receipt timestamps are serialized as whole-second ISO strings, while runtime
+   last-turn observations keep fractional seconds.  A same-second receipt must
+   still be allowed to explain the blocker; otherwise the runtime blocker
+   silently overrides its operator disposition. *)
+let runtime_blocker_receipt_timestamp_epsilon_sec = 1.0
 
 let runtime_blocker_supersedes_receipt ~meta ~runtime_blocker_fields
     latest_receipt =


### PR DESCRIPTION
## Summary

- allow same-second execution receipts to remain current for runtime-trust snapshots
- document why receipt ISO timestamps need a one-second tolerance against fractional runtime `last_turn_ts`

## Why

Paused keeper summary snapshots could ignore a freshly written execution receipt because `ended_at` is serialized at whole-second precision while `meta.runtime.usage.last_turn_ts` retains fractional seconds. That made the runtime blocker look newer and silently replaced the receipt's `pause_human` disposition with an `Alert`.

## Validation

- `git diff --check`
- `lockf -k -t 1200 /tmp/me-dune-local.lock env MASC_DUNE_LOCK_HELD=1 MASC_SKIP_OPAM_LOCK=1 MASC_INCLUDE_OPERATOR_CONTROL=true DUNE_JOBS=1 DUNE_CACHE=disabled scripts/dune-local.sh build test/test_operator_control.exe`
- `_build/default/test/test_operator_control.exe test operator 8 --show-errors`
