### PR TITLE
fix(keeper): honor direct product design timeouts

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -12,6 +12,19 @@ include Keeper_agent_checkpoint_hygiene
 
 (* Post-turn telemetry logging — extracted to Keeper_turn_telemetry (#5732) *)
 
+let per_provider_timeout_for_turn
+    ~(meta : Keeper_types.keeper_meta)
+    ?oas_timeout_s
+    ~(timeout_s : float)
+    ()
+  =
+  match oas_timeout_s with
+  | Some _ as explicit_timeout -> explicit_timeout
+  | None ->
+      (match meta.per_provider_timeout_s with
+       | Some _ as configured -> configured
+       | None -> Some timeout_s)
+
 (** Run a single keeper turn via OAS Agent.run().
 
     Loads checkpoint, creates working context with the base keeper system
@@ -265,9 +278,7 @@ let run_turn
             ~estimated_input_tokens
     in
     let per_provider_timeout_s =
-      match meta.per_provider_timeout_s with
-      | Some _ as configured -> configured
-      | None -> Some timeout_s
+      per_provider_timeout_for_turn ~meta ?oas_timeout_s ~timeout_s ()
     in
     (* OAS [stream_idle_timeout_s] bounds inter-line idle on HTTP streams
        (Anthropic/OpenAI/Gemini/GLM/Ollama). The deadline resets after each

--- a/lib/keeper/keeper_agent_run.mli
+++ b/lib/keeper/keeper_agent_run.mli
@@ -208,6 +208,19 @@ val adaptive_thinking_budget :
   -> intent:Keeper_turn_intent.t option
   -> int option
 
+(** Resolve the per-provider OAS timeout for this keeper turn.
+
+    Explicit [masc_keeper_msg.timeout_sec] / [oas_timeout_s] wins over
+    persisted keeper [per_provider_timeout_s] because the direct caller is
+    intentionally setting the budget for this run. Without that precedence,
+    a stale 300s keeper profile can silently defeat a one-off 900s reprobe. *)
+val per_provider_timeout_for_turn :
+     meta:Keeper_types.keeper_meta
+  -> ?oas_timeout_s:float
+  -> timeout_s:float
+  -> unit
+  -> float option
+
 (** {1 Turn execution} *)
 
 (** Run a single keeper turn.

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -7677,6 +7677,26 @@ let test_preferred_tool_choice_for_required_turn_claims_first () =
     (Surface.required_tool_names_for_turn
        ~current_task_required_tool_names:[ "keeper_board_curation_submit" ]
        ~per_call_required_tool_names:[ "keeper_board_post" ]);
+  let product_design_required_tools =
+    Surface.required_tool_names_for_turn
+      ~current_task_required_tool_names:[ "keeper_board_curation_submit" ]
+      ~per_call_required_tool_names:[ "keeper_board_post" ]
+  in
+  (match
+     Surface.preferred_tool_choice_for_required_tool_names
+       ~required_tool_names:product_design_required_tools
+       ~allowed_tool_names:
+         [ "keeper_board_curation_submit"; "keeper_board_post" ]
+   with
+   | Agent_sdk.Types.Tool name ->
+       check string
+         "product/design per-call board post is not hijacked by stale curation"
+         "keeper_board_post" name
+   | other ->
+       fail
+         (Printf.sprintf
+            "expected Tool keeper_board_post for product/design reprobe, got %s"
+            (Agent_sdk.Types.show_tool_choice other)));
   check (list string)
     "active task required tools remain when no per-call requirement exists"
     [ "keeper_board_curation_submit" ]
@@ -7749,6 +7769,22 @@ let test_preferred_tool_choice_for_required_turn_claims_first () =
            "expected Any for active-task keeper (must make \
             progress), got %s"
            (Agent_sdk.Types.show_tool_choice other))
+
+let test_direct_keeper_msg_timeout_overrides_meta_per_provider_timeout () =
+  let meta =
+    { (make_meta "product-design-timeout") with
+      per_provider_timeout_s = Some 300.0;
+    }
+  in
+  check (option (float 0.001))
+    "explicit direct-message timeout wins over stale per-provider timeout"
+    (Some 900.0)
+    (KAR.per_provider_timeout_for_turn ~meta ~oas_timeout_s:900.0
+       ~timeout_s:900.0 ());
+  check (option (float 0.001))
+    "profile per-provider timeout still applies without explicit override"
+    (Some 300.0)
+    (KAR.per_provider_timeout_for_turn ~meta ~timeout_s:900.0 ())
 
 (* ---------- render_inline_skip_reason tests ---------- *)
 
@@ -8643,6 +8679,9 @@ let () =
             test_should_require_tools_for_initial_turn_covers_actionable_affordances;
           test_case "task backlog required turn prefers claim tool choice"
             `Quick test_preferred_tool_choice_for_required_turn_claims_first;
+          test_case "direct keeper msg timeout overrides stale per-provider timeout"
+            `Quick
+            test_direct_keeper_msg_timeout_overrides_meta_per_provider_timeout;
           test_case "affordance gate filters by allowed_tool_names"
             `Quick
             test_turn_affordances_require_tool_gate_with_allowed_filters_by_tool;


### PR DESCRIPTION
## Summary

- Make explicit direct-message timeouts (`masc_keeper_msg.timeout_sec`) win over stale keeper `per_provider_timeout_s` profile values.
- Preserve the existing profile timeout behavior when no explicit direct-message timeout is provided.
- Add a regression that the product/design reprobe's per-call `keeper_board_post` requirement cannot be hijacked by an active task's stale `keeper_board_curation_submit` requirement.

## Why

#13737 exposed two blockers in the product/design evidence reprobe:

- `required_tools=["keeper_board_post"]` must remain authoritative for that one direct keeper message, even if the keeper already has task context that required `keeper_board_curation_submit`.
- A retry sent with `timeout_sec=900` still surfaced as `Timeout after 300.0s (budget=300s)`, because the keeper profile's per-provider timeout could narrow the explicit direct-message budget.

This PR keeps profile defaults intact for normal turns, but treats a direct-message timeout override as intentional operator input for that run.

## Validation

- `git diff --check`
- `env DUNE_BUILD_DIR=_build_codex_13737_product_design scripts/dune-local.sh build test/test_keeper_unified.exe`
- `./_build_codex_13737_product_design/default/test/test_keeper_unified.exe test tool_classification` (8 tests)

## Follow-up Runtime Proof

The live product/design reprobe was not rerun from this branch because the active keeper runtime is not executing this worktree build. After this lands in the runtime, rerun the scoped retry from #13737 against `tech_glutton,verifier` and then the strict product/design audit.

Closes #13737
