### PR TITLE
fix(auth): reuse closed error kind for MCP token fallback

### DIFF
--- a/lib/auth_error_kind.ml
+++ b/lib/auth_error_kind.ml
@@ -3,7 +3,7 @@
 
     Replaces inline string-label matching at:
     - [lib/server/server_auth.ml] dashboard_actor_fallback warn/counter
-    - [lib/mcp_server_eio_execute.ml] silent_auth_token_error_kind (follow-up)
+    - [lib/mcp_server_eio_execute.ml] silent_auth_token_error_kind
 
     The string labels are stable contract for prometheus dashboards and
     must round-trip through [to_string] / [of_string]. The variant is

--- a/lib/mcp_server_eio_execute.ml
+++ b/lib/mcp_server_eio_execute.ml
@@ -79,11 +79,8 @@ let is_transient_agent_name name =
   is_ephemeral_agent_name name
   || Nickname.is_dictionary_generated_nickname name
 
-let silent_auth_token_error_kind = function
-  | Masc_domain.Auth (Masc_domain.Auth_error.InvalidToken _) -> "token_mismatch"
-  | Masc_domain.Auth (Masc_domain.Auth_error.TokenExpired _) -> "token_expired"
-  | Masc_domain.Auth (Masc_domain.Auth_error.Unauthorized _) -> "unauthorized"
-  | _ -> "other"
+let silent_auth_token_error_kind err =
+  Auth_error_kind.to_string (Auth_error_kind.classify err)
 
 let should_read_legacy_persisted_agent_name ~has_explicit_agent_name ~agent_name =
   (not has_explicit_agent_name) && is_ephemeral_agent_name agent_name

--- a/lib/server/server_auth.ml
+++ b/lib/server/server_auth.ml
@@ -319,8 +319,7 @@ let dashboard_actor_for_request ~base_path request =
             | None -> "<none>"
           in
           (* err_kind is a closed enum in [Auth_error_kind] — issue #11266
-             Track 2a. The inline label match here previously diverged
-             silently from the MCP-side dispatch in
+             Track 2a. The stable label is shared with the MCP-side dispatch in
              [mcp_server_eio_execute.ml:silent_auth_token_error_kind]. *)
           let err_kind = Auth_error_kind.to_string (Auth_error_kind.classify err) in
           (* P3-5: token_mismatch means the dashboard's bearer token does not


### PR DESCRIPTION
## Summary
- route `mcp_server_eio_execute.ml:silent_auth_token_error_kind` through `Auth_error_kind.classify`
- remove the explicit follow-up wording from the shared enum module docs
- keep the existing Prometheus label strings stable

## Why
#11266 Track 2a migrated dashboard actor fallback auth labels to the `Auth_error_kind` closed enum, but the MCP token fallback path still had its own inline string match. This closes that remaining split so future auth-label changes happen in one enum instead of two helpers.

## Validation
- `env MASC_SKIP_PIN_CHECK=1 scripts/dune-local.sh build ./test/test_auth_error_kind.exe`
- `./_build/default/test/test_auth_error_kind.exe`
- `git diff --check HEAD~1..HEAD`

Refs #11266