### PR TITLE
fix: wake idle keepers before stale termination

### DIFF
--- a/lib/keeper/keeper_event_queue.ml
+++ b/lib/keeper/keeper_event_queue.ml
@@ -56,6 +56,7 @@ type stimulus_class =
   | Board_signal
   | Bootstrap
   | Alive_but_stuck_recovery
+  | Stale_watchdog_idle_recovery
   | Unsupported of string
 
 let classify (s : stimulus) : stimulus_class =
@@ -68,6 +69,8 @@ let classify (s : stimulus) : stimulus_class =
   if String.equal s.payload "Keeper bootstrap signal" then Bootstrap
   else if has_prefix "{\"source\":\"alive_but_stuck_recovery\"" then
     Alive_but_stuck_recovery
+  else if has_prefix "{\"source\":\"stale_watchdog_idle_recovery\"" then
+    Stale_watchdog_idle_recovery
   (* Board signals carry JSON with "source":"board_signal". Lightweight
      prefix check avoids a full Yojson parse in the data layer. *)
   else if has_prefix "{\"source\":\"board_signal\"" then Board_signal

--- a/lib/keeper/keeper_event_queue.mli
+++ b/lib/keeper/keeper_event_queue.mli
@@ -64,6 +64,8 @@ type stimulus_class =
   | Bootstrap      (** Plain string "Keeper bootstrap signal" *)
   | Alive_but_stuck_recovery
       (** JSON payload with {"source":"alive_but_stuck_recovery", ...} *)
+  | Stale_watchdog_idle_recovery
+      (** JSON payload with {"source":"stale_watchdog_idle_recovery", ...} *)
   | Unsupported of string  (** Unrecognized: payload prefix (max 40 chars) for audit *)
 
 val classify : stimulus -> stimulus_class

--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -451,6 +451,8 @@ let run_keepalive_unified_turn
               | Board_signal -> "board_signal"
               | Bootstrap -> "bootstrap"
               | Alive_but_stuck_recovery -> "alive_but_stuck_recovery"
+              | Stale_watchdog_idle_recovery ->
+                  "stale_watchdog_idle_recovery"
               | Unsupported _ -> "unsupported"
             in
             Prometheus.inc_counter
@@ -481,6 +483,11 @@ let run_keepalive_unified_turn
                     signal worth alerting on. *)
                  Log.Keeper.info
                    "turn entry: alive-but-stuck recovery stimulus consumed post_id=%s (keeper=%s)"
+                   stim.post_id meta_after_triage.name;
+                 None
+             | Stale_watchdog_idle_recovery ->
+                 Log.Keeper.info
+                   "turn entry: stale-watchdog idle recovery stimulus consumed post_id=%s (keeper=%s)"
                    stim.post_id meta_after_triage.name;
                  None
              | Unsupported prefix ->

--- a/lib/keeper/keeper_stale_watchdog.ml
+++ b/lib/keeper/keeper_stale_watchdog.ml
@@ -8,7 +8,9 @@
     1. [Idle_turn]: [last_turn_ts] older than the idle threshold while
        the keeper phase is [Running] but no [current_turn_observation]
        is recorded, with no recent keepalive skip verdict proving the
-       fiber is still evaluating work.
+       fiber is still evaluating work. This class terminates only after
+       wake-first idle recovery has been ignored for the active-turn timeout
+       budget.
     2. [In_turn_hung]: a turn started ([current_turn_observation = Some])
        and ran past [timeout_threshold] seconds — covers the
        "Orphaned Streaming" pattern (executor FSM analysis §4 I2:
@@ -18,8 +20,12 @@
        watchdog threshold — catches keepers in LLM timeout loops where
        [last_turn_ts] stays fresh because each failed turn updates it.
 
-    On detection, sets [fiber_stop] and emits a stale broadcast so the
-    supervisor's [sweep_and_recover] can restart the keeper.
+    Idle stalls are wake-first: the watchdog enqueues a recovery stimulus and
+    wakes the heartbeat fiber before considering termination. In-turn hangs
+    and no-op failure loops still set [fiber_stop] and emit a stale broadcast
+    so the supervisor's [sweep_and_recover] can restart the keeper. An idle
+    stall only escalates to termination if it ignores a watchdog wake for the
+    active-turn timeout budget.
 
     @since PR #10670 — extracted from Keeper_supervisor. *)
 
@@ -50,7 +56,9 @@
 
    Spec semantics modelled (TLA+ -> OCaml):
      phase = StaleRunning      reached when this watchdog detects a
-                               stall (idle or failure-loop) and sets
+                               terminating stall (in-turn hang, no-op
+                               failure-loop, or idle stall that ignored
+                               the wake-first recovery path) and sets
                                fiber_stop.
      OperatorBroadcast emit    line 287 below calls
                                Keeper_execution_receipt.emit_stale_keeper_broadcast
@@ -120,6 +128,64 @@ let stale_kill_class_label (cls : Keeper_registry.stale_kill_class) : string =
   | Idle_turn _ -> "idle_turn"
   | In_turn_hung _ -> "in_turn_hung"
   | Noop_failure_loop _ -> "noop_failure_loop"
+
+type stale_watchdog_action =
+  | No_action
+  | Request_idle_recovery of { stall_seconds : float }
+  | Terminate of Keeper_registry.stale_kill_class
+
+let classify_stale_watchdog_action ~now ~threshold:_ ~active_turn_timeout_sec
+    ~last_turn ~idle_stale ~in_turn_stale ~in_turn_age ~failure_loop
+    ~noop_count ~last_idle_wakeup_ts =
+  if in_turn_stale then
+    Terminate
+      (Keeper_registry.In_turn_hung
+         { active_seconds = in_turn_age; timeout_threshold = active_turn_timeout_sec })
+  else if failure_loop then
+    Terminate (Keeper_registry.Noop_failure_loop { noop_count })
+  else if idle_stale then
+    let stall_seconds = now -. last_turn in
+    if last_idle_wakeup_ts <= 0.0 then
+      Request_idle_recovery { stall_seconds }
+    else if now -. last_idle_wakeup_ts > active_turn_timeout_sec then
+      Terminate (Keeper_registry.Idle_turn { stall_seconds })
+    else
+      No_action
+  else
+    No_action
+
+let classify_stale_watchdog_action_for_test =
+  classify_stale_watchdog_action
+
+let current_generation_noop_failure_loop ~noop_count ~noop_threshold
+    ~last_turn ~started_at =
+  noop_count >= noop_threshold && last_turn >= started_at
+
+let current_generation_noop_failure_loop_for_test =
+  current_generation_noop_failure_loop
+
+let stale_watchdog_idle_recovery_stimulus ~now ~stall_seconds ~threshold
+    ~last_turn ~(meta : keeper_meta) : Keeper_event_queue.stimulus =
+  let payload =
+    `Assoc [
+      "source", `String "stale_watchdog_idle_recovery";
+      "keeper", `String meta.name;
+      "stall_seconds", `Float stall_seconds;
+      "threshold_seconds", `Float threshold;
+      "last_turn_ts", `Float last_turn;
+      "message",
+      `String
+        "stale watchdog detected an idle keeper; run a recovery cycle before considering termination";
+    ]
+    |> Yojson.Safe.to_string
+  in
+  {
+    Keeper_event_queue.post_id =
+      Printf.sprintf "stale-watchdog-idle:%s:%.0f" meta.name last_turn;
+    urgency = Keeper_event_queue.Immediate;
+    arrived_at = now;
+    payload;
+  }
 
 type batch_root_cause =
   | Cascade_unhealthy
@@ -382,6 +448,8 @@ let fork_stale_watchdog (ctx : _ context) (meta : keeper_meta)
     Env_config_keeper.KeeperWatchdog.grace_period_sec
   in
   let last_broadcast_ts = ref 0.0 in
+  let last_idle_wakeup_ts = ref 0.0 in
+  let last_idle_wakeup_last_turn = ref 0.0 in
   let request_watchdog_stop () =
     (* tla-lint: allow-mutation: fiber signal — stale watchdog asks the
        heartbeat fiber to exit and wakes it if it is in interruptible sleep. *)
@@ -460,17 +528,50 @@ let fork_stale_watchdog (ctx : _ context) (meta : keeper_meta)
              let noop_count =
                entry.meta.runtime.proactive_rt.consecutive_noop_count
              in
-             let failure_loop = noop_count >= noop_threshold () in
+             (* [consecutive_noop_count] is persisted in keeper meta so the
+                scheduler can apply backoff across process restarts.  Do not
+                reuse that persisted value as an immediate watchdog kill
+                signal for a fresh fiber: the new generation must first
+                complete a turn, otherwise a keeper can crash-loop on boot
+                with [noop_failure_loop(noop=N)]. *)
+             let noop_current_generation =
+               current_generation_noop_failure_loop
+                 ~noop_count
+                 ~noop_threshold:(noop_threshold ())
+                 ~last_turn
+                 ~started_at:entry.started_at
+             in
+             let failure_loop = noop_current_generation in
              let stale = idle_stale || in_turn_stale || failure_loop in
+             if
+               (not idle_stale)
+               || not (Float.equal last_turn !last_idle_wakeup_last_turn)
+             then begin
+               last_idle_wakeup_ts := 0.0;
+               last_idle_wakeup_last_turn := 0.0
+             end;
+             let watchdog_action =
+               classify_stale_watchdog_action ~now ~threshold
+                 ~active_turn_timeout_sec ~last_turn ~idle_stale
+                 ~in_turn_stale ~in_turn_age ~failure_loop ~noop_count
+                 ~last_idle_wakeup_ts:!last_idle_wakeup_ts
+             in
+             let action_label =
+               match watchdog_action with
+               | No_action -> "none"
+               | Request_idle_recovery _ -> "idle_recovery_wakeup"
+               | Terminate kill_class ->
+                   "terminate:" ^ stale_kill_class_label kill_class
+             in
              (* The tick line is a sampled state snapshot. Stale termination
                 and broadcasts below remain ERROR, so INFO does not need every
                 intermediate heartbeat/noop snapshot. *)
              let log_line =
                Printf.sprintf
-                 "%s: watchdog tick noop=%d idle_stale=%b idle_skip_suppressed=%b in_turn_stale=%b in_turn_age=%.0f failure_loop=%b stale=%b last_turn=%.0f fiber_age=%.0f grace_rem=%.0f"
-                 meta.name noop_count idle_stale idle_skip_suppressed
-                 in_turn_stale in_turn_age failure_loop stale last_turn
-                 fiber_age grace_remaining
+                 "%s: watchdog tick noop=%d noop_current_generation=%b idle_stale=%b idle_skip_suppressed=%b in_turn_stale=%b in_turn_age=%.0f failure_loop=%b stale=%b action=%s last_turn=%.0f fiber_age=%.0f grace_rem=%.0f"
+                 meta.name noop_count noop_current_generation idle_stale
+                 idle_skip_suppressed in_turn_stale in_turn_age failure_loop
+                 stale action_label last_turn fiber_age grace_remaining
              in
              Log.Keeper.routine "%s" log_line;
              let cooldown_ok =
@@ -527,7 +628,22 @@ let fork_stale_watchdog (ctx : _ context) (meta : keeper_meta)
                    meta.name stall_seconds count meta.cascade_name;
                  emit_watchdog_broadcast ~failure_reason:(Some failure_reason)
                    ~stall_seconds
-               | _ ->
+               | _ -> (
+               match watchdog_action with
+               | Request_idle_recovery { stall_seconds } ->
+                 let stimulus =
+                   stale_watchdog_idle_recovery_stimulus ~now
+                     ~stall_seconds ~threshold ~last_turn ~meta
+                 in
+                 Keeper_registry.enqueue_event ~base_path meta.name stimulus;
+                 Keeper_registry.wakeup ~base_path meta.name;
+                 last_idle_wakeup_ts := now;
+                 last_idle_wakeup_last_turn := last_turn;
+                 Log.Keeper.warn
+                   "%s: stale watchdog requested idle recovery wakeup (idle %.0fs threshold %.0fs; not terminating) [cascade=%s]"
+                   meta.name stall_seconds threshold meta.cascade_name
+               | No_action -> ()
+               | Terminate kill_class ->
                (* #10940 follow-up: surface the most recent skip reasons
                   alongside [idle %.0fs] so operators can tell whether
                   the kill targeted a *stuck* fiber or a *deliberately
@@ -558,17 +674,6 @@ let fork_stale_watchdog (ctx : _ context) (meta : keeper_meta)
                   actions, so they need different typed labels.  The
                   surrounding [reason_desc] log line still embeds the
                   same human-readable text via [stale_kill_class_to_string]. *)
-               let kill_class : Keeper_registry.stale_kill_class =
-                 if in_turn_stale then
-                   In_turn_hung
-                     { active_seconds = in_turn_age;
-                       timeout_threshold = active_turn_timeout_sec;
-                     }
-                 else if idle_stale then
-                   Idle_turn { stall_seconds = now -. last_turn }
-                 else
-                   Noop_failure_loop { noop_count }
-               in
                let reason_desc =
                  match kill_class with
                  | Idle_turn { stall_seconds } ->
@@ -716,7 +821,7 @@ let fork_stale_watchdog (ctx : _ context) (meta : keeper_meta)
                    distinct_count batch_window_sec
                    (String.concat ", " batch) root_cause_label
                end;
-               emit_watchdog_broadcast ~failure_reason ~stall_seconds
+               emit_watchdog_broadcast ~failure_reason ~stall_seconds)
              end
            | None ->
              Log.Keeper.warn "%s: watchdog: registry entry NOT FOUND" meta.name

--- a/lib/keeper/keeper_stale_watchdog.mli
+++ b/lib/keeper/keeper_stale_watchdog.mli
@@ -37,6 +37,34 @@ val latch_stale_fleet_batch_reasons_for_test :
   config:Coord.config -> distinct_count:int -> string list -> unit
 (** Test-only wrapper for the batch failure-reason latch. *)
 
+type stale_watchdog_action =
+  | No_action
+  | Request_idle_recovery of { stall_seconds : float }
+  | Terminate of Keeper_registry.stale_kill_class
+(** Action chosen after the watchdog has classified the current liveness
+    snapshot. Idle stalls are wake-first; watchdog termination is reserved
+    for active-turn hangs, no-op failure loops, and idle stalls that ignore
+    a prior watchdog wake for the active-turn timeout budget. *)
+
+val classify_stale_watchdog_action_for_test :
+  now:float ->
+  threshold:float ->
+  active_turn_timeout_sec:float ->
+  last_turn:float ->
+  idle_stale:bool ->
+  in_turn_stale:bool ->
+  in_turn_age:float ->
+  failure_loop:bool ->
+  noop_count:int ->
+  last_idle_wakeup_ts:float ->
+  stale_watchdog_action
+(** Test-only view of the watchdog action selector. *)
+
+val current_generation_noop_failure_loop_for_test :
+  noop_count:int -> noop_threshold:int -> last_turn:float -> started_at:float -> bool
+(** Test-only view of the no-op loop guard. Persisted no-op counts are
+    only watchdog-fatal after this fiber generation has completed a turn. *)
+
 val fork_stale_watchdog :
   'a context -> keeper_meta -> Keeper_registry.registry_entry -> unit
 (** Fork a stale-turn watchdog fiber for the given keeper.
@@ -44,7 +72,9 @@ val fork_stale_watchdog :
     Three detection modes — see {!Keeper_registry.stale_kill_class}:
     - [Idle_turn]: [last_turn_ts] older than the idle threshold while
       the keeper phase is [Running] but no [current_turn_observation]
-      is recorded.
+      is recorded. This class now terminates only after a wake-first idle
+      recovery stimulus has also been ignored for the active-turn timeout
+      budget.
     - [In_turn_hung]: a turn started ([current_turn_observation = Some])
       and ran past [timeout_threshold] seconds — covers the
       "Orphaned Streaming" pattern described in the executor FSM
@@ -58,7 +88,11 @@ val fork_stale_watchdog :
     [masc_keeper_stale_termination_by_class] Prometheus counter for
     per-class root-cause attribution.
 
-    On detection, sets [fiber_stop] and emits a stale broadcast. The
-    supervisor's [sweep_and_recover] picks up the stopped fiber and restarts
-    with exponential backoff, unless a per-keeper stale storm or fleet batch
-    latch routes the keeper to auto-pause/backoff first. *)
+    Idle stalls first enqueue a recovery stimulus and wake the heartbeat
+    fiber. Termination is reserved for [In_turn_hung],
+    [Noop_failure_loop], unresolved OAS timeout budget loops, or an idle
+    stall that ignores a prior watchdog wake for the active-turn timeout
+    budget. On termination, sets [fiber_stop] and emits a stale broadcast.
+    The supervisor's [sweep_and_recover] picks up the stopped fiber and
+    restarts with exponential backoff, unless a per-keeper stale storm or
+    fleet batch latch routes the keeper to auto-pause/backoff first. *)

--- a/lib/keeper/keeper_status_bridge.ml
+++ b/lib/keeper/keeper_status_bridge.ml
@@ -282,7 +282,7 @@ let stale_kill_class_summary (kill_class : Keeper_registry.stale_kill_class) =
   match kill_class with
   | Keeper_registry.Idle_turn { stall_seconds } ->
       Printf.sprintf
-        "idle_turn: no completed turn for %.0fs; stale watchdog stopped the keeper before restart."
+        "idle_turn: no completed turn for %.0fs after watchdog idle recovery wake; stale watchdog stopped the keeper before restart."
         stall_seconds
   | Keeper_registry.In_turn_hung { active_seconds; timeout_threshold } ->
       Printf.sprintf

--- a/test/keeper_event_queue/test_keeper_event_queue.ml
+++ b/test/keeper_event_queue/test_keeper_event_queue.ml
@@ -121,6 +121,15 @@ let test_classify_alive_but_stuck_recovery () =
   | Alive_but_stuck_recovery -> ()
   | _ -> assert false
 
+let test_classify_stale_watchdog_idle_recovery () =
+  let s =
+    make_stim "stale-watchdog-idle:k"
+      "{\"source\":\"stale_watchdog_idle_recovery\",\"keeper\":\"k\"}"
+  in
+  match classify s with
+  | Stale_watchdog_idle_recovery -> ()
+  | _ -> assert false
+
 let () =
   test_empty ();
   test_enqueue_dequeue_fifo ();
@@ -132,4 +141,5 @@ let () =
   test_queue_overrides_policy ();
   test_dequeue_only_consumes_enqueued ();
   test_classify_alive_but_stuck_recovery ();
+  test_classify_stale_watchdog_idle_recovery ();
   print_endline "Keeper_event_queue: all tests passed"

--- a/test/test_keeper_event_queue.ml
+++ b/test/test_keeper_event_queue.ml
@@ -14,7 +14,8 @@ let () =
         | Bootstrap -> "Bootstrap"
         | Unsupported s -> "Unsupported("^s^")"
         | Board_signal -> "Board_signal"
-        | Alive_but_stuck_recovery -> "Alive_but_stuck_recovery")));
+        | Alive_but_stuck_recovery -> "Alive_but_stuck_recovery"
+        | Stale_watchdog_idle_recovery -> "Stale_watchdog_idle_recovery")));
 
   let live_comment_payload =
     {|{"source":"board_signal","kind":"comment","post_id":"p2","author":"alice","title":"Long board event","content":"this mirrors the long live payload that used to miss the prefix check","hearth":null,"wake_reason":"scope_message"}|}
@@ -30,7 +31,8 @@ let () =
         | Bootstrap -> "Bootstrap"
         | Unsupported s -> "Unsupported("^s^")"
         | Board_signal -> "Board_signal"
-        | Alive_but_stuck_recovery -> "Alive_but_stuck_recovery")));
+        | Alive_but_stuck_recovery -> "Alive_but_stuck_recovery"
+        | Stale_watchdog_idle_recovery -> "Stale_watchdog_idle_recovery")));
 
   (* --- classify: bootstrap --- *)
   let bootstrap_stim = {
@@ -45,7 +47,8 @@ let () =
         | Board_signal -> "Board_signal"
         | Unsupported s -> "Unsupported("^s^")"
         | Bootstrap -> "Bootstrap"
-        | Alive_but_stuck_recovery -> "Alive_but_stuck_recovery")));
+        | Alive_but_stuck_recovery -> "Alive_but_stuck_recovery"
+        | Stale_watchdog_idle_recovery -> "Stale_watchdog_idle_recovery")));
 
   (* --- classify: unsupported --- *)
   let unknown_stim = {
@@ -79,7 +82,17 @@ let () =
         | Board_signal -> "Board_signal"
         | Bootstrap -> "Bootstrap"
         | Unsupported _ -> "Unsupported"
-        | Alive_but_stuck_recovery -> "Alive_but_stuck_recovery")));
+        | Alive_but_stuck_recovery -> "Alive_but_stuck_recovery"
+        | Stale_watchdog_idle_recovery -> "Stale_watchdog_idle_recovery")));
+
+  (* --- classify: stale watchdog idle recovery --- *)
+  let idle_recovery_stim = {
+    post_id = "stale-watchdog-idle:k"; urgency = Immediate; arrived_at = 0.0;
+    payload = {|{"source":"stale_watchdog_idle_recovery","keeper":"k"}|};
+  } in
+  (match classify idle_recovery_stim with
+   | Stale_watchdog_idle_recovery -> ()
+   | _ -> Alcotest.fail "expected Stale_watchdog_idle_recovery");
 
   (* --- queue operations preserved --- *)
   let q = empty in

--- a/test/test_stale_kill_class.ml
+++ b/test/test_stale_kill_class.ml
@@ -182,6 +182,82 @@ let test_batch_root_cause_unknown () =
   r "unknown" "unknown"
     (root_cause_label [ Heartbeat_consecutive_failures 3 ])
 
+let stale_action ?(now = 1_000.0) ?(last_turn = 600.0)
+    ?(last_idle_wakeup_ts = 0.0) ?(idle_stale = false)
+    ?(in_turn_stale = false) ?(in_turn_age = 0.0) ?(failure_loop = false)
+    ?(noop_count = 0) () =
+  SW.classify_stale_watchdog_action_for_test
+    ~now
+    ~threshold:300.0
+    ~active_turn_timeout_sec:3_600.0
+    ~last_turn
+    ~idle_stale
+    ~in_turn_stale
+    ~in_turn_age
+    ~failure_loop
+    ~noop_count
+    ~last_idle_wakeup_ts
+
+let test_stale_watchdog_action_wakes_idle_first () =
+  match stale_action ~idle_stale:true () with
+  | SW.Request_idle_recovery { stall_seconds } ->
+      Alcotest.(check (float 0.001)) "stall seconds" 400.0 stall_seconds
+  | SW.No_action -> Alcotest.fail "expected idle recovery wakeup"
+  | SW.Terminate _ -> Alcotest.fail "idle stale must wake before terminating"
+
+let test_stale_watchdog_action_suppresses_recent_idle_wake () =
+  match stale_action ~idle_stale:true ~last_idle_wakeup_ts:900.0 () with
+  | SW.No_action -> ()
+  | SW.Request_idle_recovery _ ->
+      Alcotest.fail "expected recent idle wake to be suppressed"
+  | SW.Terminate _ ->
+      Alcotest.fail "expected recent idle wake to suppress termination"
+
+let test_stale_watchdog_action_terminates_idle_after_wake_timeout () =
+  match
+    stale_action ~now:5_000.0 ~last_turn:4_600.0 ~idle_stale:true
+      ~last_idle_wakeup_ts:1_000.0 ()
+  with
+  | SW.Terminate (Idle_turn { stall_seconds }) ->
+      Alcotest.(check (float 0.001)) "stall seconds" 400.0 stall_seconds
+  | SW.Terminate _ -> Alcotest.fail "expected idle-turn termination"
+  | SW.No_action -> Alcotest.fail "expected idle wake timeout termination"
+  | SW.Request_idle_recovery _ ->
+      Alcotest.fail "expected idle wake timeout to terminate"
+
+let test_stale_watchdog_action_terminates_active_turn_hang () =
+  match stale_action ~in_turn_stale:true ~in_turn_age:4_000.0 () with
+  | SW.Terminate (In_turn_hung { active_seconds; timeout_threshold }) ->
+      Alcotest.(check (float 0.001)) "active seconds" 4_000.0 active_seconds;
+      Alcotest.(check (float 0.001)) "timeout" 3_600.0 timeout_threshold
+  | _ -> Alcotest.fail "expected active-turn hang termination"
+
+let test_stale_watchdog_action_terminates_noop_loop () =
+  match stale_action ~failure_loop:true ~noop_count:4 () with
+  | SW.Terminate (Noop_failure_loop { noop_count }) ->
+      Alcotest.(check int) "noop count" 4 noop_count
+  | _ -> Alcotest.fail "expected no-op loop termination"
+
+let test_noop_failure_loop_requires_current_generation_turn () =
+  let before_first_turn =
+    SW.current_generation_noop_failure_loop_for_test
+      ~noop_count:3 ~noop_threshold:3 ~last_turn:900.0 ~started_at:1_000.0
+  in
+  let after_first_turn =
+    SW.current_generation_noop_failure_loop_for_test
+      ~noop_count:3 ~noop_threshold:3 ~last_turn:1_001.0 ~started_at:1_000.0
+  in
+  let below_threshold =
+    SW.current_generation_noop_failure_loop_for_test
+      ~noop_count:2 ~noop_threshold:3 ~last_turn:1_001.0 ~started_at:1_000.0
+  in
+  Alcotest.(check bool)
+    "persisted pre-start noop count is not fatal" false before_first_turn;
+  Alcotest.(check bool)
+    "current-generation noop count is fatal" true after_first_turn;
+  Alcotest.(check bool)
+    "below threshold is not fatal" false below_threshold
+
 let () =
   Alcotest.run "stale_kill_class"
     [
@@ -240,5 +316,20 @@ let () =
           Alcotest.test_case "mixed" `Quick test_batch_root_cause_mixed;
           Alcotest.test_case "unknown" `Quick
             test_batch_root_cause_unknown;
+        ] );
+      ( "stale_watchdog_action",
+        [
+          Alcotest.test_case "idle wake first" `Quick
+            test_stale_watchdog_action_wakes_idle_first;
+          Alcotest.test_case "recent idle wake suppresses termination" `Quick
+            test_stale_watchdog_action_suppresses_recent_idle_wake;
+          Alcotest.test_case "idle wake timeout terminates" `Quick
+            test_stale_watchdog_action_terminates_idle_after_wake_timeout;
+          Alcotest.test_case "active turn hang terminates" `Quick
+            test_stale_watchdog_action_terminates_active_turn_hang;
+          Alcotest.test_case "noop loop terminates" `Quick
+            test_stale_watchdog_action_terminates_noop_loop;
+          Alcotest.test_case "noop loop requires current generation turn"
+            `Quick test_noop_failure_loop_requires_current_generation_turn;
         ] );
     ]


### PR DESCRIPTION
## Summary
- change stale watchdog idle handling to enqueue a structured idle-recovery stimulus and wake the heartbeat before termination
- keep immediate termination for in-turn hangs and unresolved OAS timeout budget loops
- prevent persisted no-op counts from killing a freshly restarted keeper before that fiber generation completes a turn
- classify the new recovery stimulus in the keeper event queue and update idle-turn status wording

## Why it matters
Live runtime evidence on 2026-05-07 showed long-idle keepers being crash/restart classified as stale_turn_timeout(idle_turn(...)). Persistent keepers should not be killed just because they are quiet; idle termination should mean the keeper ignored a recovery wake, not that it had no completed turn for the short stale threshold.

The same live audit showed analyst repeatedly crash-looping on stale_turn_timeout(noop_failure_loop(noop=3)) while its persisted keeper meta already had consecutive_noop_count=3. Persisted backoff state should influence scheduling, but it should not be an immediate watchdog kill signal for a fresh fiber generation.

## Validation
- scripts/dune-local.sh build test/test_stale_kill_class.exe test/keeper_event_queue/test_keeper_event_queue.exe test/test_keeper_event_queue.exe
- ./_build/default/test/test_stale_kill_class.exe
- ./_build/default/test/keeper_event_queue/test_keeper_event_queue.exe
- ./_build/default/test/test_keeper_event_queue.exe
- git diff --check HEAD

## Notes
- ocamlformat --check was attempted on touched OCaml files, but these legacy files are not safely whole-file formatted; the PR intentionally avoids formatting churn.