### PR TITLE
fix: instrument memory pipeline flushes

### DIFF
--- a/lib/memory_hooks.ml
+++ b/lib/memory_hooks.ml
@@ -86,6 +86,32 @@ let compose_with_inner ~memory_hooks ~inner =
         inner.Agent_sdk.Hooks.before_turn_params
   }
 
+let record_pipeline_flush
+    ~(agent_name : string)
+    ~(outcome : string)
+    ~(duration_s : float)
+    ~(episodes : int)
+    ~(procedures : int) =
+  let outcome_labels = [ ("agent_name", agent_name); ("outcome", outcome) ] in
+  Prometheus.inc_counter
+    Prometheus.metric_memory_pipeline_flushes
+    ~labels:outcome_labels
+    ();
+  Prometheus.observe_histogram
+    Prometheus.metric_memory_pipeline_flush_duration_seconds
+    ~labels:outcome_labels
+    duration_s;
+  let record_records ~tier count =
+    if count > 0 then
+      Prometheus.inc_counter
+        Prometheus.metric_memory_pipeline_flush_records
+        ~labels:[ ("agent_name", agent_name); ("tier", tier) ]
+        ~delta:(float_of_int count)
+        ()
+  in
+  record_records ~tier:"episodic" episodes;
+  record_records ~tier:"procedural" procedures
+
 (** Create OAS hooks for hook-first memory injection.
 
     @param agent_name Keeper agent name (for procedure/episode lookup)
@@ -139,8 +165,16 @@ let make
     after_turn = Some (fun event ->
       match event with
       | Agent_sdk.Hooks.AfterTurn _ ->
+        let started_at = Time_compat.now () in
         (try
            let (ep, pr) = flush_incremental ~memory ~agent_name in
+           let duration_s = max 0.0 (Time_compat.now () -. started_at) in
+           record_pipeline_flush
+             ~agent_name
+             ~outcome:"success"
+             ~duration_s
+             ~episodes:ep
+             ~procedures:pr;
            if ep > 0 || pr > 0 then
              Log.Keeper.debug
                "memory_hooks: flush_incremental agent=%s episodes=%d procedures=%d"
@@ -153,6 +187,13 @@ let make
                ~labels:
                  [("callback", "memory_after_turn_flush")]
                ();
+             let duration_s = max 0.0 (Time_compat.now () -. started_at) in
+             record_pipeline_flush
+               ~agent_name
+               ~outcome:"error"
+               ~duration_s
+               ~episodes:0
+               ~procedures:0;
              Log.Keeper.warn
                "memory_hooks: flush_incremental failed agent=%s: %s"
                agent_name (Printexc.to_string exn));

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -1063,6 +1063,12 @@ let metric_keeper_lifecycle_transitions =
 let metric_fsm_guard_violation = "masc_fsm_guard_violation_total"
 let metric_keeper_lifecycle_callback_failures =
   "masc_keeper_lifecycle_callback_failures_total"
+let metric_memory_pipeline_flushes =
+  "masc_memory_pipeline_flushes_total"
+let metric_memory_pipeline_flush_records =
+  "masc_memory_pipeline_flush_records_total"
+let metric_memory_pipeline_flush_duration_seconds =
+  "masc_memory_pipeline_flush_duration_seconds"
 let metric_keeper_event_bus_drain = "masc_keeper_event_bus_drain_total"
 let metric_keeper_supervisor_cleanup_failures =
   "masc_keeper_supervisor_cleanup_failures_total"
@@ -1860,6 +1866,19 @@ let init () =
      tool-call-log, or action-metric gaps. Labels: callback plus optional \
      keeper at per-keeper hook sites."
     Counter;
+  add metric_memory_pipeline_flushes
+    "Total memory AfterTurn flush attempts. A success with zero records proves \
+     the pipeline ran but had no episodic/procedural deltas; an error surfaces \
+     a hidden hook failure. Labels: agent_name, outcome=success|error."
+    Counter;
+  add metric_memory_pipeline_flush_records
+    "Total memory records persisted by the AfterTurn bridge. Labels: \
+     agent_name, tier=episodic|procedural."
+    Counter;
+  add metric_memory_pipeline_flush_duration_seconds
+    "Wall-clock seconds spent in the memory AfterTurn flush bridge. Labels: \
+     agent_name, outcome=success|error."
+    Histogram;
   add metric_keeper_event_bus_drain
     "Total per-turn OAS event-bus drain helper runs. Labels: site and \
      outcome=drained|empty."

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -745,6 +745,9 @@ val metric_fsm_guard_violation : string
 
     Cardinality is bounded by fleet size times this callback vocabulary. *)
 val metric_keeper_lifecycle_callback_failures : string
+val metric_memory_pipeline_flushes : string
+val metric_memory_pipeline_flush_records : string
+val metric_memory_pipeline_flush_duration_seconds : string
 val metric_keeper_supervisor_cleanup_failures : string
 val metric_keeper_slot_force_released : string
 val metric_keeper_stale_watchdog_tick_failures : string

--- a/test/test_memory_hooks.ml
+++ b/test/test_memory_hooks.ml
@@ -56,6 +56,19 @@ let make_before_turn_params_event ?(extra_ctx = None) ~turn () =
     reasoning = Agent_sdk.Hooks.empty_reasoning_summary;
   }
 
+let make_after_turn_event ?(turn = 1) () =
+  Agent_sdk.Hooks.AfterTurn {
+    turn;
+    response = {
+      Agent_sdk.Types.id = "r1";
+      model = "test";
+      stop_reason = Agent_sdk.Types.EndTurn;
+      content = [];
+      usage = None;
+      telemetry = None;
+    };
+  }
+
 (* ── Pure read function tests ──────────────────────────────── *)
 
 let test_load_episodes_text_type () =
@@ -245,17 +258,7 @@ let test_after_turn_hook_returns_continue () =
     ~memory
     ()
   in
-  let event = Agent_sdk.Hooks.AfterTurn {
-    turn = 1;
-    response = {
-      Agent_sdk.Types.id = "r1";
-      model = "test";
-      stop_reason = Agent_sdk.Types.EndTurn;
-      content = [];
-      usage = None;
-      telemetry = None;
-    };
-  } in
+  let event = make_after_turn_event () in
   let decision = match hooks.after_turn with
     | Some f -> f event
     | None -> fail "after_turn hook should be Some"
@@ -297,17 +300,7 @@ let test_after_turn_flush_failure_still_continues () =
   let hooks =
     Memory_hooks.compose_with_inner ~memory_hooks ~inner:inner_hooks
   in
-  let event = Agent_sdk.Hooks.AfterTurn {
-    turn = 1;
-    response = {
-      Agent_sdk.Types.id = "r1";
-      model = "test";
-      stop_reason = Agent_sdk.Types.EndTurn;
-      content = [];
-      usage = None;
-      telemetry = None;
-    };
-  } in
+  let event = make_after_turn_event () in
   let decision =
     match hooks.after_turn with
     | Some f -> f event
@@ -321,6 +314,68 @@ let test_after_turn_flush_failure_still_continues () =
       ~labels ()
   in
   check (float 0.0001) "flush failure counted" (before +. 1.0) after;
+  (try Sys.rmdir tmp_dir with _ -> ())
+
+let test_after_turn_flush_records_pipeline_metrics () =
+  let tmp_dir = Filename.temp_dir "masc_test_mh" "" in
+  let config = make_test_config ~base_path:tmp_dir in
+  let memory = Memory_oas_bridge.create_memory ~agent_name:"test_pipeline" () in
+  let success_labels =
+    [ ("agent_name", "test_pipeline"); ("outcome", "success") ]
+  in
+  let episodic_labels =
+    [ ("agent_name", "test_pipeline"); ("tier", "episodic") ]
+  in
+  let procedural_labels =
+    [ ("agent_name", "test_pipeline"); ("tier", "procedural") ]
+  in
+  let before_flushes =
+    P.metric_value_or_zero P.metric_memory_pipeline_flushes
+      ~labels:success_labels ()
+  in
+  let before_duration_count =
+    P.metric_value_or_zero
+      (P.metric_memory_pipeline_flush_duration_seconds ^ "_count")
+      ~labels:success_labels ()
+  in
+  let before_episodes =
+    P.metric_value_or_zero P.metric_memory_pipeline_flush_records
+      ~labels:episodic_labels ()
+  in
+  let before_procedures =
+    P.metric_value_or_zero P.metric_memory_pipeline_flush_records
+      ~labels:procedural_labels ()
+  in
+  let hooks =
+    Memory_hooks.make
+      ~agent_name:"test_pipeline"
+      ~config
+      ~memory
+      ~flush_incremental:(fun ~memory:_ ~agent_name:_ -> (2, 3))
+      ()
+  in
+  let decision =
+    match hooks.after_turn with
+    | Some f -> f (make_after_turn_event ())
+    | None -> fail "after_turn hook should be Some"
+  in
+  check bool "after_turn returns Continue" true
+    (match decision with Agent_sdk.Hooks.Continue -> true | _ -> false);
+  check (float 0.0001) "success flush counted" (before_flushes +. 1.0)
+    (P.metric_value_or_zero P.metric_memory_pipeline_flushes
+       ~labels:success_labels ());
+  check (float 0.0001) "duration observation counted"
+    (before_duration_count +. 1.0)
+    (P.metric_value_or_zero
+       (P.metric_memory_pipeline_flush_duration_seconds ^ "_count")
+       ~labels:success_labels ());
+  check (float 0.0001) "episodic records counted" (before_episodes +. 2.0)
+    (P.metric_value_or_zero P.metric_memory_pipeline_flush_records
+       ~labels:episodic_labels ());
+  check (float 0.0001) "procedural records counted"
+    (before_procedures +. 3.0)
+    (P.metric_value_or_zero P.metric_memory_pipeline_flush_records
+       ~labels:procedural_labels ());
   (try Sys.rmdir tmp_dir with _ -> ())
 
 (* ── Flush idempotency test ────────────────────────────────── *)
@@ -371,6 +426,8 @@ let () =
       test_case "composition preserves inner before_turn_params" `Quick
         test_compose_preserves_inner_before_turn_params;
       test_case "after_turn returns Continue" `Quick test_after_turn_hook_returns_continue;
+      test_case "after_turn records pipeline metrics" `Quick
+        test_after_turn_flush_records_pipeline_metrics;
       test_case "after_turn flush failure still continues" `Quick
         test_after_turn_flush_failure_still_continues;
     ];

--- a/test/test_prometheus_coverage.ml
+++ b/test/test_prometheus_coverage.ml
@@ -330,6 +330,12 @@ let test_review_blocker_metrics_registered () =
     check bool (metric ^ " TYPE") true
       (text_has_literal text ("# TYPE " ^ metric ^ " counter"))
   in
+  let check_histogram_registered metric =
+    check bool (metric ^ " HELP") true
+      (text_has_literal text ("# HELP " ^ metric ^ " "));
+    check bool (metric ^ " TYPE") true
+      (text_has_literal text ("# TYPE " ^ metric ^ " summary"))
+  in
   check_registered Prometheus.metric_tool_join_required_guard;
   check_registered Prometheus.metric_timeout_policy_overshoot;
   check_registered Prometheus.metric_auth_credential_token_duplicate;
@@ -343,6 +349,10 @@ let test_review_blocker_metrics_registered () =
   check_registered Prometheus.metric_coord_telemetry_drop;
   check_registered Prometheus.metric_coord_claim_post_provision_failures;
   check_registered Prometheus.metric_keeper_lifecycle_callback_failures;
+  check_registered Prometheus.metric_memory_pipeline_flushes;
+  check_registered Prometheus.metric_memory_pipeline_flush_records;
+  check_histogram_registered
+    Prometheus.metric_memory_pipeline_flush_duration_seconds;
   check_registered Prometheus.metric_keeper_oas_on_stop;
   check_registered Prometheus.metric_keeper_oas_on_idle_escalated;
   check_registered Prometheus.metric_keeper_event_bus_drain


### PR DESCRIPTION
## Summary
- add memory pipeline flush counters for AfterTurn success/error attempts
- count episodic/procedural records persisted by the OAS memory bridge
- record flush duration as a Prometheus histogram and pin coverage/tests

## Verification
- git diff --check
- lockf -k -t 1200 /tmp/me-dune-local.lock env MASC_DUNE_LOCK_HELD=1 MASC_SKIP_OPAM_LOCK=1 DUNE_JOBS=1 DUNE_CACHE=disabled scripts/dune-local.sh build test/test_memory_hooks.exe test/test_prometheus_coverage.exe
- ./_build/default/test/test_memory_hooks.exe
- ./_build/default/test/test_prometheus_coverage.exe