### PR TITLE
feat(web): add masc_web_fetch tool + complete search→fetch pipeline

### DIFF
--- a/config/prompts/keeper.unified.system.md
+++ b/config/prompts/keeper.unified.system.md
@@ -65,7 +65,7 @@ Decide what to do based on the current world state below.
 ### Research evidence
 - Ground novel technical, policy, library, model, pricing, API, or industry-pattern claims with evidence before presenting them as fact.
 - Use code evidence for repo-local claims: search/read the relevant files and cite stable `path:line` references in the post or reply.
-- Use web evidence for external or current claims: call `masc_web_search` when it is available. If a separate page-read or fetch tool is actually present in your current tool schema, read the selected source before citing it.
+- Use web evidence for external or current claims: call `masc_web_search` to find sources, then call `masc_web_fetch` to read the selected source before citing it.
 - If no source is found or the available tools cannot verify the claim, mark the claim with `[uncited]` instead of presenting it as verified.
 - When posting research-backed findings to the board, include a `sources` array on `keeper_board_post`/`masc_board_post` with `{url, quote}` entries. The board will persist those sources in metadata and append a Sources footer.
 
@@ -83,7 +83,7 @@ Use extend_turns only when a single coherent action genuinely requires more step
 - Respond to board activity (`keeper_board_comment`, if available)
 - Search knowledge library (`keeper_library_search` / `keeper_library_read`, if available)
 - Run shell commands to investigate (`keeper_bash cmd="git log --oneline -10"`, `keeper_bash cmd="rg pattern lib/"`, if available)
-- Search the web (`masc_web_search`, if available) for tech context or documentation
+- Search the web (`masc_web_search`) for tech context or documentation, then fetch (`masc_web_fetch`) selected pages before citing
 - Recall past context (`keeper_memory_search`, if available) before repeating past work
 - Search code patterns (`keeper_shell op=rg pattern=<regex> type=ml`, if available)
 - Audit failed tasks (`keeper_tasks_audit`, if available) before deciding there is nothing to do

--- a/config/tool_policy.toml
+++ b/config/tool_policy.toml
@@ -86,7 +86,7 @@ tools = ["masc_code_write", "masc_code_edit", "masc_code_delete", "masc_code_she
 # Tools allowed on the keeper's last turn (safety constraint).
 # On last turn, visible tools are intersected with this set.
 [groups.last_turn_safe]
-tools = ["keeper_board_post", "keeper_board_comment", "keeper_board_curation_submit", "keeper_context_status", "extend_turns", "keeper_time_now", "keeper_tool_search", "keeper_broadcast", "keeper_task_done", "keeper_task_submit_for_verification", "masc_web_search"]
+tools = ["keeper_board_post", "keeper_board_comment", "keeper_board_curation_submit", "keeper_context_status", "extend_turns", "keeper_time_now", "keeper_tool_search", "keeper_broadcast", "keeper_task_done", "keeper_task_submit_for_verification", "masc_web_search", "masc_web_fetch"]
 
 # Optional tools that require explicit opt-in via also_allow.
 # Excluded from all presets by default; a keeper must list them in also_allow.
@@ -108,7 +108,7 @@ tools = ["keeper_board_delete", "keeper_board_cleanup"]
 
 # Essential: tools every keeper needs (orientation + web search).
 [masc.essential]
-tools = ["masc_status", "masc_web_search", "masc_approval_pending"]
+tools = ["masc_status", "masc_web_search", "masc_web_fetch", "masc_approval_pending"]
 
 # Coordination: external agent coordination tools.
 # Only needed by keepers that manage tasks across agents.
@@ -127,7 +127,7 @@ tools = [
 tools = [
   "masc_status", "masc_tasks", "masc_claim_next", "masc_transition",
   "masc_add_task", "masc_batch_add_tasks", "masc_agents", "masc_dashboard",
-  "masc_agent_card", "masc_tool_help", "masc_web_search",
+  "masc_agent_card", "masc_tool_help", "masc_web_search", "masc_web_fetch",
   "masc_join", "masc_leave", "masc_who", "masc_heartbeat",
   "masc_messages", "masc_broadcast",
 ]

--- a/lib/dashboard/dashboard_keeper_feature_catalog.ml
+++ b/lib/dashboard/dashboard_keeper_feature_catalog.ml
@@ -68,7 +68,16 @@ let tool_features =
         "masc_web_search";
       ];
       next_action =
-        "Run a current-information keeper search and verify successful masc_web_search evidence.";
+        "Run a current-information keeper search, then fetch a selected result with masc_web_fetch and verify both tools succeed.";
+    };
+    {
+      id = "web_fetch_tools";
+      label = "Web fetch tools";
+      required_tools = [
+        "masc_web_fetch";
+      ];
+      next_action =
+        "Run a web page fetch and verify successful masc_web_fetch evidence.";
     };
     {
       id = "taskboard_tools";

--- a/lib/dune
+++ b/lib/dune
@@ -165,6 +165,7 @@
   tool_misc_transport
   tool_misc_admin
   tool_misc_web_search
+  tool_misc_web_fetch
   oas_worker_cascade
   oas_worker_exec_agent
   oas_worker_exec

--- a/lib/keeper/keeper_agent_tool_surface.ml
+++ b/lib/keeper/keeper_agent_tool_surface.ml
@@ -411,6 +411,7 @@ let tool_search_alias_entries =
   ; "masc_plan_clear_task", "계획 태스크 제거 해제 클리어"
   ; "masc_agent_fitness", "에이전트 평가 점수 피트니스"
   ; "masc_web_search", "웹 검색 인터넷 온라인 구글"
+  ; "masc_web_fetch", "웹 페이지 가져오기 읽기 URL 페치"
   ; "masc_claim_next", "다음태스크 가져오기 할당"
   ]
 

--- a/lib/keeper/keeper_tool_alias.ml
+++ b/lib/keeper/keeper_tool_alias.ml
@@ -19,6 +19,7 @@ let aliases : (string * string) list =
     "Grep", "keeper_shell";   (* op=rg routed at dispatch layer, Phase A.4 *)
     "Read", "keeper_fs_read";
     "Shell", "keeper_bash";   (* LLM occasionally hallucinates "Shell" for bash *)
+    "WebFetch", "masc_web_fetch";
     "WebSearch", "masc_web_search";
     "Write", "keeper_fs_edit"; (* create-vs-update collapsed at dispatch layer *)
   ]
@@ -35,6 +36,7 @@ let oas_dual_register : (string * string) list =
     "Edit", "keeper_fs_edit";
     "Grep", "keeper_shell";
     "Read", "keeper_fs_read";
+    "WebFetch", "masc_web_fetch";
     "WebSearch", "masc_web_search";
     "Write", "keeper_fs_edit";
   ]
@@ -43,7 +45,7 @@ let oas_dual_register : (string * string) list =
    check should not nuke a turn solely because these appeared — instead a
    teaching tool_result tells the LLM what surface to use. RFC-0006 §3.1. *)
 let hallucinated_builtins =
-  [ "Agent"; "Skill"; "WebFetch"; "TodoWrite"; "NotebookEdit" ]
+  [ "Agent"; "Skill"; "TodoWrite"; "NotebookEdit" ]
 
 let public_to_internal_tbl =
   let t = Hashtbl.create (List.length aliases) in
@@ -259,6 +261,17 @@ let grep_public_schema =
          schema parity.";
     ]
 
+(* Anthropic Code "WebFetch" schema. Maps directly to masc_web_fetch;
+   the payload already uses url/timeout. *)
+let web_fetch_public_schema =
+  object_schema ~required:[ "url" ]
+    [
+      property "url" "string"
+        "URL to fetch (http or https only).";
+      property "timeout" "integer"
+        "Request timeout in seconds (default 15, max 60).";
+    ]
+
 (* Anthropic Code "WebSearch" schema. Maps directly to masc_web_search;
    the payload already uses query/limit. *)
 let web_search_public_schema =
@@ -275,6 +288,7 @@ let public_input_schema = function
   | "Edit" -> Some edit_public_schema
   | "Grep" -> Some grep_public_schema
   | "Read" -> Some read_public_schema
+  | "WebFetch" -> Some web_fetch_public_schema
   | "WebSearch" -> Some web_search_public_schema
   | "Write" -> Some write_public_schema
   | _ -> None
@@ -393,6 +407,7 @@ let translate_input ~public input =
   | "Edit" -> translate_edit_input input
   | "Grep" -> translate_grep_input input
   | "Read" -> translate_read_input input
+  | "WebFetch" -> input
   | "WebSearch" -> input
   | "Write" -> translate_write_input input
   | _ -> input

--- a/lib/keeper/keeper_tool_guidance.ml
+++ b/lib/keeper/keeper_tool_guidance.ml
@@ -64,6 +64,10 @@ let hints =
     ; call = "`masc_web_search` { query: \"<current-info query>\", limit: 5 }"
     ; description = "look up current public context before time-sensitive claims"
     }
+  ; { name = "masc_web_fetch"
+    ; call = "`masc_web_fetch` { url: \"<page-url>\", timeout: 15 }"
+    ; description = "fetch and read a web page before citing it"
+    }
   ; { name = "masc_worktree_create"
     ; call = "`masc_worktree_create` { task_id: \"<task-id>\", repo_name: \"masc-mcp\" }"
     ; description = "create a repo worktree before code edits"

--- a/lib/tool_catalog.ml
+++ b/lib/tool_catalog.ml
@@ -519,6 +519,7 @@ let inferred_effect_domain_of_typed_tool_name = function
   | TN.Masc TM.Tool_help
   | TN.Masc TM.Tool_list
   | TN.Masc TM.Tool_stats
+  | TN.Masc TM.Web_fetch
   | TN.Masc TM.Web_search
   | TN.Masc TM.Who
   | TN.Masc TM.Workflow_guide
@@ -770,6 +771,7 @@ let tool_group_of_typed_tool_name = function
       | TM.Tool_stats
       | TM.Transition
       | TM.Update_priority
+      | TM.Web_fetch
       | TM.Web_search
       | TM.Webrtc_answer
       | TM.Webrtc_offer

--- a/lib/tool_catalog_surfaces.ml
+++ b/lib/tool_catalog_surfaces.ml
@@ -177,7 +177,7 @@ let public_mcp_surface_tools =
     (* Agent discovery *)
     "masc_agents"; "masc_agent_card"; "masc_dashboard";
     (* Utility *)
-    "masc_tool_help"; "masc_web_search"; "masc_check";
+    "masc_tool_help"; "masc_web_search"; "masc_web_fetch"; "masc_check";
     (* HITL approval queue *)
     "masc_approval_pending";
     "masc_approval_get";
@@ -199,7 +199,7 @@ let spawned_agent_surface_tools =
     "masc_board_list"; "masc_board_post"; "masc_board_comment";
     "masc_board_vote"; "masc_board_get";
     "masc_board_curation_read"; "masc_board_curation_submit";
-    "masc_tool_help"; "masc_web_search";
+    "masc_tool_help"; "masc_web_search"; "masc_web_fetch";
     "masc_spawn";
     (* Phase 2: surface SSOT *)
     "masc_code_delete"; "masc_code_edit"; "masc_code_git";

--- a/lib/tool_dispatch.ml
+++ b/lib/tool_dispatch.ml
@@ -298,6 +298,7 @@ let static_tag_of_tool_name (tool : Tool_name.t) : module_tag option =
     | Tool_admin_update
     | Tool_help
     | Tool_stats
+    | Web_fetch
     | Web_search
     | Webrtc_answer
     | Webrtc_offer -> Some Mod_misc

--- a/lib/tool_misc.ml
+++ b/lib/tool_misc.ml
@@ -102,6 +102,9 @@ let handle_tool_help _ctx args =
 let handle_web_search _ctx args =
   Tool_misc_web_search.handle args
 
+let handle_web_fetch _ctx args =
+  Tool_misc_web_fetch.handle args
+
 (* ================================================================ *)
 (* Public re-exports from sub-modules                               *)
 (* ================================================================ *)
@@ -131,6 +134,7 @@ let dispatch ctx ~name ~args : tool_result option =
   | "masc_tool_stats" -> Some (handle_tool_stats ctx args)
   | "masc_tool_help" -> Some (handle_tool_help ctx args)
   | "masc_web_search" -> Some (handle_web_search ctx args)
+  | "masc_web_fetch" -> Some (handle_web_fetch ctx args)
   | "masc_tool_admin_snapshot" -> Some (Tool_misc_admin.handle_tool_admin_snapshot admin_ctx args)
   | "masc_tool_admin_update" -> Some (Tool_misc_admin.handle_tool_admin_update admin_ctx args)
   | "masc_deep_review" -> Some (Tool_deep_review.handle_deep_review ctx.config args)
@@ -146,12 +150,13 @@ let _tool_spec_read_only =
   [
     "masc_tool_help";
     "masc_web_search";
+    "masc_web_fetch";
     "masc_dashboard";
   ]
 
 let tool_required_permission = function
   | "masc_config" | "masc_dashboard"
-  | "masc_tool_stats" | "masc_tool_help" | "masc_web_search" ->
+  | "masc_tool_stats" | "masc_tool_help" | "masc_web_search" | "masc_web_fetch" ->
       Some Masc_domain.CanReadState
   | "masc_tool_admin_snapshot" | "masc_tool_admin_update" ->
       Some Masc_domain.CanAdmin

--- a/lib/tool_misc_web_fetch.ml
+++ b/lib/tool_misc_web_fetch.ml
@@ -1,0 +1,217 @@
+module Format = Stdlib.Format
+module Map = Stdlib.Map
+module Set = Stdlib.Set
+module Queue = Stdlib.Queue
+module Hashtbl = Stdlib.Hashtbl
+module Mutex = Stdlib.Mutex
+module Option = Stdlib.Option
+module Result = Stdlib.Result
+module Sys = Stdlib.Sys
+module Filename = Stdlib.Filename
+module List = Stdlib.List
+module Array = Stdlib.Array
+module String = Stdlib.String
+module Char = Stdlib.Char
+module Int = Stdlib.Int
+module Float = Stdlib.Float
+
+open Tool_args
+
+(** JSON response helpers — same pattern as Tool_misc_web_search *)
+let json_error message =
+  Yojson.Safe.to_string
+    (`Assoc [ ("status", `String "error"); ("message", `String message) ])
+
+let json_ok fields =
+  Yojson.Safe.to_string (`Assoc (("status", `String "ok") :: fields))
+
+(** Extract <title> from HTML *)
+let title_tag_re =
+  Re.Pcre.re ~flags:[ `CASELESS; `DOTALL ] "<title[^>]*>(.*?)</title>"
+  |> Re.compile
+
+let extract_title html =
+  match Re.exec_opt title_tag_re html with
+  | Some groups ->
+      let raw = Re.Group.get groups 1 in
+      let cleaned = Tool_misc_web_search.clean_search_text raw in
+      if String.equal cleaned "" then None else Some cleaned
+  | None -> None
+
+(** Extract <meta name="description"> or og:description from HTML *)
+let meta_description_re =
+  Re.Pcre.re
+    ~flags:[ `CASELESS; `DOTALL ]
+    "<meta[^>]+name\\s*=\\s*['\"]description['\"][^>]+content\\s*=\\s*['\"]([^'\"]+)['\"][^>]*>"
+  |> Re.compile
+
+let meta_description_reversed_re =
+  Re.Pcre.re
+    ~flags:[ `CASELESS; `DOTALL ]
+    "<meta[^>]+content\\s*=\\s*['\"]([^'\"]+)['\"][^>]+name\\s*=\\s*['\"]description['\"][^>]*>"
+  |> Re.compile
+
+let og_description_re =
+  Re.Pcre.re
+    ~flags:[ `CASELESS; `DOTALL ]
+    "<meta[^>]+property\\s*=\\s*['\"]og:description['\"][^>]+content\\s*=\\s*['\"]([^'\"]+)['\"][^>]*>"
+  |> Re.compile
+
+let og_description_reversed_re =
+  Re.Pcre.re
+    ~flags:[ `CASELESS; `DOTALL ]
+    "<meta[^>]+content\\s*=\\s*['\"]([^'\"]+)['\"][^>]+property\\s*=\\s*['\"]og:description['\"][^>]*>"
+  |> Re.compile
+
+let first_match html pattern =
+  match Re.exec_opt pattern html with
+  | Some groups ->
+      let cleaned = Tool_misc_web_search.clean_search_text (Re.Group.get groups 1) in
+      if String.equal cleaned "" then None else Some cleaned
+  | None -> None
+
+let extract_description html =
+  match first_match html og_description_re with
+  | Some _ as value -> value
+  | None -> (
+      match first_match html og_description_reversed_re with
+      | Some _ as value -> value
+      | None -> (
+          match first_match html meta_description_re with
+          | Some _ as value -> value
+          | None -> first_match html meta_description_reversed_re))
+
+(** URL validation *)
+let valid_url url =
+  let trimmed = String.trim url in
+  if String.equal trimmed "" then false
+  else
+    let uri = Uri.of_string trimmed in
+    match Uri.scheme uri |> Option.map String.lowercase_ascii with
+    | Some "http" | Some "https" -> true
+    | _ -> false
+
+(** Cache + rate limit — same pattern as web_search but separate state *)
+type cache_entry = {
+  response : string;
+  expires_at : float;
+}
+
+let initial_cache_capacity = 32
+let cache_entries : (string, cache_entry) Hashtbl.t =
+  Hashtbl.create initial_cache_capacity
+let cache_mutex = Eio.Mutex.create ()
+let request_times : float Queue.t = Queue.create ()
+let rate_limit_mutex = Eio.Mutex.create ()
+
+let cache_ttl_sec () = Env_config.Tools.web_search_cache_ttl_sec ()
+
+let cache_lookup key now =
+  let ttl = cache_ttl_sec () in
+  if Stdlib.Float.compare ttl 0.0 <= 0 then None
+  else
+    Eio.Mutex.use_rw ~protect:true cache_mutex (fun () ->
+        Hashtbl.filter_map_inplace
+          (fun _ entry ->
+            if Stdlib.Float.compare entry.expires_at now <= 0 then None
+            else Some entry)
+          cache_entries;
+        match Hashtbl.find_opt cache_entries key with
+        | Some entry when Stdlib.Float.compare entry.expires_at now > 0 ->
+            Some entry.response
+        | _ -> None)
+
+let cache_store key response now =
+  let ttl = cache_ttl_sec () in
+  if Stdlib.Float.compare ttl 0.0 > 0 then
+    Eio.Mutex.use_rw ~protect:true cache_mutex (fun () ->
+        Hashtbl.replace cache_entries key { response; expires_at = now +. ttl })
+
+let enforce_rate_limit now =
+  let window = Env_config.Tools.web_search_rate_limit_window_sec () in
+  let max_calls = Env_config.Tools.web_search_rate_limit_max_calls () in
+  Eio.Mutex.use_rw ~protect:true rate_limit_mutex (fun () ->
+      while
+        Queue.length request_times > 0
+        && Stdlib.( > ) (Stdlib.Float.sub now (Queue.peek request_times)) window
+      do
+        let (_ : float) = Queue.pop request_times in
+        ()
+      done;
+      if Queue.length request_times >= max_calls then
+        Error "web fetch rate limit exceeded; retry shortly"
+      else (
+        Queue.push now request_times;
+        Ok ()))
+
+(** Max content length — prevent context overflow *)
+let max_content_length = 100_000
+
+(** Redact transport error detail before the " for " suffix *)
+let redact_transport_error_detail message =
+  match String.index_opt message ' ' with
+  | Some idx -> String.sub message 0 idx
+  | None -> message
+
+(** Main fetch implementation *)
+let fetch_impl ~url ~timeout_sec =
+  let headers =
+    [ ("User-Agent", "Mozilla/5.0 (compatible; MASC-WebFetch/1.0)") ]
+  in
+  match
+    Tool_local_runtime_http.http_get_text_with_status_with_headers
+      ~timeout_sec ~headers url
+  with
+  | Error detail ->
+      Error
+        (Printf.sprintf "fetch failed: %s"
+           (redact_transport_error_detail detail))
+  | Ok (Some status, payload) when status >= 200 && status < 300 ->
+      let title = extract_title payload in
+      let description = extract_description payload in
+      let text =
+        let cleaned = Tool_misc_web_search.clean_search_text payload in
+        if String.length cleaned > max_content_length then
+          String.sub cleaned 0 max_content_length
+          ^ "\n[TRUNCATED at 100KB]"
+        else cleaned
+      in
+      Ok (status, title, description, text)
+  | Ok (Some status, _) -> Error (Printf.sprintf "HTTP %d" status)
+  | Ok (None, _) -> Error "no HTTP status received"
+
+let handle args =
+  let url = get_string args "url" "" in
+  let timeout = max 1 (min 60 (get_int args "timeout" 15)) in
+  if not (valid_url url) then
+    (false, json_error "url must be a valid http or https URL")
+  else
+    let now = Unix.gettimeofday () in
+    let key = url ^ "|" ^ Int.to_string timeout in
+    match cache_lookup key now with
+    | Some cached -> (true, cached)
+    | None -> (
+        match enforce_rate_limit now with
+        | Error message -> (false, json_error message)
+        | Ok () -> (
+            match fetch_impl ~url ~timeout_sec:timeout with
+            | Ok (http_status, title, description, text) ->
+                let fields =
+                  [
+                    ("url", `String url);
+                    ("http_status", `Int http_status);
+                    ("text", `String text);
+                  ]
+                  @
+                  (match title with
+                  | Some t -> [ ("title", `String t) ]
+                  | None -> [])
+                  @
+                  (match description with
+                  | Some d -> [ ("description", `String d) ]
+                  | None -> [])
+                in
+                let json = json_ok fields in
+                cache_store key json now;
+                (true, json)
+            | Error message -> (false, json_error message)))

--- a/lib/tool_misc_web_fetch.mli
+++ b/lib/tool_misc_web_fetch.mli
@@ -1,0 +1,26 @@
+(** Tool_misc_web_fetch — Fetch a URL and return cleaned text content.
+
+    Uses [curl] via [Tool_local_runtime_http] for HTTP GET, then applies
+    the shared HTML cleaning pipeline from [Tool_misc_web_search] to
+    strip tags, decode entities, and normalize whitespace.
+
+    Provides separate cache + rate-limit state (same env config keys as
+    web_search) and optional [<title>] / [<meta name="description">]
+    extraction. *)
+
+val handle : Yojson.Safe.t -> bool * string
+(** [handle args] handles [masc_web_fetch] tool dispatch.
+    Required: [url] (string, http/https only).
+    Optional: [timeout] (int, clamped to [\[1, 60\]], default 15).
+
+    Returns [(true, json)] with fields:
+    - [url]: the requested URL
+    - [http_status]: HTTP status code
+    - [text]: cleaned text content (HTML tags stripped, entities decoded,
+      whitespace normalized, truncated at 100KB)
+    - [title]: optional, extracted from [<title>] tag
+    - [description]: optional, extracted from [<meta name="description">]
+      or [og:description]
+
+    Returns [(false, error_json)] on validation failure, rate limit,
+    transport error, or non-2xx HTTP status. *)

--- a/lib/tool_misc_web_search.mli
+++ b/lib/tool_misc_web_search.mli
@@ -128,6 +128,15 @@ val parse_bing_search_json : string -> (string * string * string) list
 (** Parse Bing Search API JSON response from
     [{ "webPages": { "value": \[{name, url, snippet}, ...\] } }]. *)
 
+(** {1 HTML cleaning} *)
+
+val clean_search_text : string -> string
+(** [clean_search_text html] strips HTML tags, CDATA sections, decodes
+    common HTML entities, and normalizes whitespace.  Reusable for any
+    HTML snippet — not limited to search result cleaning.  Exposed so
+    [Tool_misc_web_fetch] can share the same pipeline without
+    duplicating regexes and entity tables. *)
+
 (** {1 Tool dispatch + simulation} *)
 
 val handle : Yojson.Safe.t -> bool * string

--- a/lib/tool_name.ml
+++ b/lib/tool_name.ml
@@ -302,6 +302,7 @@ module Masc = struct
     | Tool_revoke
     | Transition
     | Update_priority
+    | Web_fetch
     | Web_search
     | Who
     | Workflow_guide
@@ -411,6 +412,7 @@ module Masc = struct
     | Tool_revoke -> "masc_tool_revoke"
     | Transition -> "masc_transition"
     | Update_priority -> "masc_update_priority"
+    | Web_fetch -> "masc_web_fetch"
     | Web_search -> "masc_web_search"
     | Who -> "masc_who"
     | Workflow_guide -> "masc_workflow_guide"
@@ -520,6 +522,7 @@ module Masc = struct
     | "masc_tool_revoke" -> Some Tool_revoke
     | "masc_transition" -> Some Transition
     | "masc_update_priority" -> Some Update_priority
+    | "masc_web_fetch" -> Some Web_fetch
     | "masc_web_search" -> Some Web_search
     | "masc_who" -> Some Who
     | "masc_workflow_guide" -> Some Workflow_guide

--- a/lib/tool_name.mli
+++ b/lib/tool_name.mli
@@ -157,6 +157,7 @@ module Masc : sig
     | Tool_revoke
     | Transition
     | Update_priority
+    | Web_fetch
     | Web_search
     | Who
     | Workflow_guide

--- a/lib/tool_prefilter.ml
+++ b/lib/tool_prefilter.ml
@@ -214,9 +214,11 @@ let synonyms : (string * string list) list =
      [ "update agent"; "change agent"; "agent modify"; "agent settings" ]);
     ("masc_agent_fitness",
      [ "agent fitness"; "agent evaluation"; "agent score"; "rate agent" ]);
-    (* masc web search *)
+    (* masc web search + fetch *)
     ("masc_web_search",
      [ "web search"; "search internet"; "search online"; "google" ]);
+    ("masc_web_fetch",
+     [ "web fetch"; "fetch page"; "read url"; "download page" ]);
     (* masc keeper management — tools available via BM25 but missing from TF-IDF *)
     ("masc_keeper_up",
      [ "start keeper"; "launch keeper"; "spawn keeper"; "keeper create" ]);

--- a/lib/tool_schemas/tool_schemas_misc.ml
+++ b/lib/tool_schemas/tool_schemas_misc.ml
@@ -203,6 +203,31 @@ Uses configured web-search providers with structured fallback behavior and retur
     ];
   };
   {
+    name = "masc_web_fetch";
+    description = "Fetch a web page by URL and return cleaned text content. \
+Read-only helper for reading selected sources after web search before citing them. \
+Strips HTML tags, decodes entities, normalizes whitespace, and optionally extracts \
+<title> and <meta name=\"description\">. Returns structured JSON with the cleaned text.";
+    input_schema = `Assoc [
+      ("type", `String "object");
+      ("properties", `Assoc [
+        ("url", `Assoc [
+          ("type", `String "string");
+          ("description", `String "URL to fetch (http or https only)");
+        ]);
+        ("timeout", `Assoc [
+          ("type", `String "integer");
+          ("description", `String "Request timeout in seconds (default 15, max 60)");
+          ("default", `Int 15);
+          ("minimum", `Int 1);
+          ("maximum", `Int 60);
+        ]);
+      ]);
+      ("required", `List [`String "url"]);
+      ("additionalProperties", `Bool false);
+    ];
+  };
+  {
     name = "masc_tool_admin_snapshot";
     description = "Return a unified admin snapshot of tool inventory, auth/RBAC, and command-plane surfaces.";
     input_schema = `Assoc [

--- a/lib/worker_dev_tools.ml
+++ b/lib/worker_dev_tools.ml
@@ -228,7 +228,7 @@ let command_blocked_hint name =
     | "sort" | "uniq" -> " Use rg or jq for filtering."
     | "sed" | "awk" -> " Use keeper_fs_edit for in-place edits."
     | "find" -> " Use rg --files or masc_code_search."
-    | "curl" | "wget" -> " Use masc_web_search for content fetching."
+    | "curl" | "wget" -> " Use masc_web_fetch to fetch page content, or masc_web_search to find sources."
     | "gh" ->
       " 'gh' is NOT available in the keeper sandbox. For pull-request \
        work use keeper_pr_list / keeper_pr_status / keeper_pr_create / \
@@ -245,7 +245,7 @@ let command_blocked_hint name =
     | "ssh" | "scp" | "rsync" | "ftp" | "sftp" | "nc" ->
       Printf.sprintf
         " '%s' is a network primitive and is not permitted. Keeper \
-         network access goes through masc_web_search or \
+         network access goes through masc_web_search, masc_web_fetch, or \
          masc_autoresearch_* tools."
         name
     | _ when looks_like_source_code name ->

--- a/test/test_keeper_tool_alias.ml
+++ b/test/test_keeper_tool_alias.ml
@@ -110,8 +110,8 @@ let test_hallucinated_builtins () =
     true (Alias.is_hallucinated_builtin "Agent");
   Alcotest.(check bool) "WebSearch is NOT hallucinated (has cognate)"
     false (Alias.is_hallucinated_builtin "WebSearch");
-  Alcotest.(check bool) "WebFetch is hallucinated"
-    true (Alias.is_hallucinated_builtin "WebFetch");
+  Alcotest.(check bool) "WebFetch is NOT hallucinated (has cognate)"
+    false (Alias.is_hallucinated_builtin "WebFetch");
   Alcotest.(check bool) "Bash is NOT hallucinated (has cognate)"
     false (Alias.is_hallucinated_builtin "Bash");
   Alcotest.(check bool) "keeper_bash is NOT hallucinated"
@@ -128,7 +128,7 @@ let test_no_overlap_alias_and_hallucinated () =
 
 let test_alias_table_is_stable () =
   let pairs = Alias.all_aliases () in
-  Alcotest.(check int) "seven canonical aliases" 7 (List.length pairs);
+  Alcotest.(check int) "eight canonical aliases" 8 (List.length pairs);
   (* Round-trip: every alias should round-trip via to_internal then to_public,
      except where collapse happens (Write -> keeper_fs_edit -> Edit). *)
   List.iter
@@ -146,7 +146,7 @@ let test_alias_table_is_stable () =
     must NOT produce any unexpected names. *)
 let allowed_keeper_surface =
   [ "keeper_bash"; "keeper_fs_read"; "keeper_fs_edit"; "keeper_shell";
-    "keeper_board_post"; "masc_web_search"; "extend_turns" ]
+    "keeper_board_post"; "masc_web_search"; "masc_web_fetch"; "extend_turns" ]
 
 let test_pure_alias_turn_no_longer_unexpected () =
   let observed = [ "Bash" ] in
@@ -209,8 +209,8 @@ let yojson_field name j =
 let test_oas_dual_register_subset () =
   let pairs = Alias.oas_dual_register_aliases () in
   let names = List.map fst pairs in
-  Alcotest.(check (list string)) "dual-reg covers shell/fs/search aliases"
-    [ "Bash"; "Edit"; "Grep"; "Read"; "WebSearch"; "Write" ] names;
+  Alcotest.(check (list string)) "dual-reg covers shell/fs/search/fetch aliases"
+    [ "Bash"; "Edit"; "Grep"; "Read"; "WebFetch"; "WebSearch"; "Write" ] names;
   (* Every entry must also appear in the full alias table. *)
   let full = List.map fst (Alias.all_aliases ()) in
   List.iter


### PR DESCRIPTION
## Summary

MASC has `masc_web_search` (7-provider search API) but **no page content fetching tool**. The keeper prompt says "read the selected source before citing it" but there was no tool to do this. This is why `masc_web_search` had 0 actual invocations in logs — the search→fetch pipeline was broken at the second step.

This PR adds `masc_web_fetch` that fetches a URL and returns cleaned text content, completing the pipeline alongside the existing search tool.

## Changes

### New tool: `masc_web_fetch`
- **Input**: `url` (required, http/https only), `timeout` (optional, default 15s, max 60s)
- **Output**: `{url, http_status, text, title?, description?}`
- HTML cleaning: strip tags, decode entities, normalize whitespace (reuses `Tool_misc_web_search.clean_search_text` pipeline)
- Optional extraction: `<title>`, `<meta name="description">`, `og:description`
- 100KB truncation guard to prevent context overflow
- Cache + rate limit (same env config keys as `web_search`, separate state)

### Prompt fix
- Replace "call `masc_web_search` when it is available" with unconditional imperative: "call `masc_web_search` to find sources, then call `masc_web_fetch` to read the selected source before citing it"
- Only web tools affected; other "if available" conditionals preserved

### Wiring (17 files)
- `tool_name`: `Web_fetch` variant
- `tool_dispatch`: `Mod_misc` tag mapping
- `tool_schemas`: JSON schema with `url` + `timeout`
- `tool_misc`: handler, dispatch, read_only, `CanReadState`
- `tool_catalog`: `inferred_effect_domain=Read_only`, `tool_group=Masc_core`
- `tool_catalog_surfaces`: `public_mcp` + `spawned_agent`
- `tool_policy`: `essential` + `core` + `last_turn_safe`
- `keeper_tool_alias`: `WebFetch` cognate, OAS dual register, public schema
- `keeper_tool_guidance`: usage hint
- `keeper_agent_tool_surface`: Korean aliases
- `dashboard_feature_catalog`: `web_fetch_tools` feature
- `worker_dev_tools`: curl/wget hint references `masc_web_fetch`
- `tool_prefilter`: search aliases for fetch keywords
- `dune`: register `tool_misc_web_fetch` module

## Verification

- [x] `dune build @check` PASS
- [x] `test_tool_misc_coverage` 44/44 PASS
- [x] `test_keeper_tool_alias` 33/33 PASS
- [x] Server starts, `/health` returns commit `c5a3cbf8c7`, 130 tools registered

## Test plan

- [ ] Integration test: call `masc_web_fetch` with `https://example.com`
- [ ] Verify cache hit on second identical call
- [ ] Verify rate limit after rapid calls
- [ ] Verify title/description extraction on real pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)