### PR TITLE
fix: surface governance metrics record failures

### DIFF
--- a/lib/dashboard/dashboard_governance_metrics.ml
+++ b/lib/dashboard/dashboard_governance_metrics.ml
@@ -35,9 +35,30 @@ let ring_mu = Eio.Mutex.create ()
 let ring : rejection_event list ref = ref []
 (** Most recent first; truncated to [max_ring_size]. *)
 
-(** Record a tool-skip event. Called from [Keeper_hooks_oas.broadcast_tool_skipped]
-    so the in-memory ring stays in sync with the SSE event stream. *)
-let record_tool_skipped ~keeper_name ~tool_name ~reason_code =
+let record_failure_callback_label =
+  "dashboard_governance_tool_skipped_record"
+
+let record_tool_skipped_failure exn =
+  Prometheus.inc_counter
+    Prometheus.metric_keeper_lifecycle_callback_failures
+    ~labels:[ ("callback", record_failure_callback_label) ]
+    ();
+  Log.Dashboard.warn
+    "dashboard governance metrics failed to record tool skip: %s"
+    (Printexc.to_string exn)
+
+let append_rejection_event event =
+  Eio.Mutex.use_rw ~protect:true ring_mu (fun () ->
+    let next = event :: !ring in
+    let truncated =
+      if List.length next > max_ring_size
+      then List.filteri (fun i _ -> i < max_ring_size) next
+      else next
+    in
+    ring := truncated)
+
+let record_tool_skipped_with_append ~append
+    ~keeper_name ~tool_name ~reason_code =
   let event = {
     ts = Unix.gettimeofday ();
     tool_name;
@@ -45,17 +66,19 @@ let record_tool_skipped ~keeper_name ~tool_name ~reason_code =
     keeper_name;
   } in
   try
-    Eio.Mutex.use_rw ~protect:true ring_mu (fun () ->
-      let next = event :: !ring in
-      let truncated =
-        if List.length next > max_ring_size
-        then List.filteri (fun i _ -> i < max_ring_size) next
-        else next
-      in
-      ring := truncated)
+    append event
   with
   | Eio.Cancel.Cancelled _ as e -> raise e
-  | exn -> ()
+  | exn -> record_tool_skipped_failure exn
+
+(** Record a tool-skip event. Called from [Keeper_hooks_oas.broadcast_tool_skipped]
+    so the in-memory ring stays in sync with the SSE event stream. *)
+let record_tool_skipped ~keeper_name ~tool_name ~reason_code =
+  record_tool_skipped_with_append
+    ~append:append_rejection_event
+    ~keeper_name
+    ~tool_name
+    ~reason_code
 
 (** Reset the ring. Test-only helper — exposed because the alcotest cases
     need to start from a clean state regardless of test order. *)
@@ -69,6 +92,14 @@ let snapshot_ring () =
 let inject_for_testing ~keeper_name ~tool_name ~reason_code ~ts =
   let event = { ts; tool_name; reason_code; keeper_name } in
   ring := event :: !ring
+
+let record_tool_skipped_with_append_for_testing
+    ~append ~keeper_name ~tool_name ~reason_code =
+  record_tool_skipped_with_append
+    ~append:(fun _event -> append ())
+    ~keeper_name
+    ~tool_name
+    ~reason_code
 
 (** Aggregate [(tool_name, reason_code) -> count] over the supplied window.
     [now_ts] is injectable for testing.  Returns a deterministic ordering:

--- a/lib/dashboard/dashboard_governance_metrics.mli
+++ b/lib/dashboard/dashboard_governance_metrics.mli
@@ -26,8 +26,9 @@ val record_tool_skipped :
   keeper_name:string -> tool_name:string -> reason_code:string -> unit
 (** Record a tool-skip event into the bounded ring. Safe to call from
     cancellable Eio fibers — internal cancellation is re-raised, all
-    other exceptions are swallowed so SSE broadcast can never fail
-    because of metrics bookkeeping. *)
+    other exceptions are reported via
+    {!Prometheus.metric_keeper_lifecycle_callback_failures} and logged
+    without failing the SSE broadcast path. *)
 
 val approval_queue_summary : unit -> approval_summary
 (** Read the current approval queue and produce depth + wait-time
@@ -54,6 +55,16 @@ val inject_for_testing :
 (** Push a synthetic skip event into the ring without going through
     the production [record_tool_skipped] path so tests can backdate
     [ts] for window-boundary assertions. *)
+
+val record_tool_skipped_with_append_for_testing :
+  append:(unit -> unit) ->
+  keeper_name:string ->
+  tool_name:string ->
+  reason_code:string ->
+  unit
+(** Run the production exception-handling path with an injected append
+    callback so tests can prove metrics/log visibility without relying
+    on an actual mutex failure. *)
 
 val tool_rejection_counts :
   ?now_ts:float ->

--- a/test/test_dashboard_governance_metrics.ml
+++ b/test/test_dashboard_governance_metrics.ml
@@ -1,6 +1,7 @@
 (** Tests for Dashboard_governance_metrics — tool rejection ring + approval queue. *)
 
 module GM = Masc_mcp.Dashboard_governance_metrics
+module P = Masc_mcp.Prometheus
 
 open Alcotest
 
@@ -64,6 +65,31 @@ let test_json_shape () =
   let window = json |> member "window_minutes" |> to_int in
   check int "window propagated" 60 window
 
+let test_record_failure_is_metric_visible () =
+  let labels =
+    [ ("callback", "dashboard_governance_tool_skipped_record") ]
+  in
+  let before =
+    P.metric_value_or_zero
+      P.metric_keeper_lifecycle_callback_failures
+      ~labels
+      ()
+  in
+  GM.record_tool_skipped_with_append_for_testing
+    ~append:(fun () -> raise (Failure "synthetic ring failure"))
+    ~keeper_name:"k1"
+    ~tool_name:"bash"
+    ~reason_code:"policy";
+  let after =
+    P.metric_value_or_zero
+      P.metric_keeper_lifecycle_callback_failures
+      ~labels
+      ()
+  in
+  check (float 0.0001) "ring failure metric increments" (before +. 1.0) after;
+  let counts = GM.tool_rejection_counts ~now_ts:now ~window_minutes:60 () in
+  check int "failed append does not create a phantom event" 0 (List.length counts)
+
 let () =
   run "Dashboard_governance_metrics" [
     "tool_rejection_counts", [
@@ -77,5 +103,9 @@ let () =
     ];
     "json", [
       test_case "json shape" `Quick (with_fresh test_json_shape);
+    ];
+    "failure_visibility", [
+      test_case "record failure increments metric" `Quick
+        (with_fresh test_record_failure_is_metric_visible);
     ];
   ]


### PR DESCRIPTION
## Summary
- report dashboard governance tool-skip ring failures through keeper lifecycle callback metrics
- log non-cancellation failures instead of dropping them silently
- add a focused regression using an injected append failure

## Verification
- git diff --check
- lockf -k -t 1200 /tmp/me-dune-local.lock env MASC_DUNE_LOCK_HELD=1 MASC_SKIP_OPAM_LOCK=1 DUNE_JOBS=1 DUNE_CACHE=disabled scripts/dune-local.sh build test/test_dashboard_governance_metrics.exe
- ./_build/default/test/test_dashboard_governance_metrics.exe