### PR TITLE
chore: extract dashboard alert thresholds + deprecate cascade_pool_router

### DIFF
--- a/dashboard/cockpit-kit/StatusTray.jsx
+++ b/dashboard/cockpit-kit/StatusTray.jsx
@@ -62,12 +62,17 @@ function _statusCounts(D) {
   };
 }
 
+// Alert thresholds for the KPI spotlight. Configurable via MASC_DATA so
+// operators can tune without a rebuild.
+const FAIL_URGENT_THRESHOLD = (window.MASC_DATA && window.MASC_DATA.failUrgentThreshold) || 3;
+const CASCADE_ALERT_THRESHOLD = (window.MASC_DATA && window.MASC_DATA.cascadeAlertThreshold) || 2;
+
 // Pick the dot to spotlight in the KPI slot. Only the urgent paths
 // have real meaning today; for the calm path we expose the raw event
 // count rather than a fabricated TPS number.
 function _kpiSpotlight(counts) {
-  if (counts.fails >= 3) return { l: "fails", v: counts.fails, t: "err", u: "", urgent: true };
-  if (counts.cascades >= 2) return { l: "cascade", v: counts.cascades, t: "info", u: "" };
+  if (counts.fails >= FAIL_URGENT_THRESHOLD) return { l: "fails", v: counts.fails, t: "err", u: "", urgent: true };
+  if (counts.cascades >= CASCADE_ALERT_THRESHOLD) return { l: "cascade", v: counts.cascades, t: "info", u: "" };
   return { l: "events", v: counts.evCount, t: "brass", u: "" };
 }
 

--- a/lib/cascade/cascade_pool_router.ml
+++ b/lib/cascade/cascade_pool_router.ml
@@ -1,3 +1,13 @@
+(** Cascade_pool_router — DEPRECATED, unused by any call site.
+
+    Provider routing has moved to {!Cascade_routes} / {!Cascade_catalog_runtime}.
+    The tier-based pool model with hardcoded [provider_keys] was an early design
+    that conflated admission with rate-limiting; see feedback memory
+    [semaphore_tier_is_architectural_anti_pattern].
+
+    This module is retained only for compilation compatibility.  Do not add new
+    references.  Remove in a future cleanup sweep.  *)
+
 type t = {
   pools : Cascade_pool.t list;
   keeper_pool_map : (string, Cascade_pool.pool_id) Hashtbl.t;

--- a/lib/cascade/cascade_pool_router.mli
+++ b/lib/cascade/cascade_pool_router.mli
@@ -1,10 +1,4 @@
-(** Pool router — maps keepers to pools and handles pool-level fallback.
-
-    Implements the Bulkhead pattern: each keeper is assigned to a
-    primary pool.  When the primary pool is fully in cooldown, the
-    router falls through to lower tiers (Tier1 → Tier2 → Emergency).
-
-    @since Phase 1 — Resilience Architecture *)
+(** Pool router — DEPRECATED, no call sites.  See {!Cascade_pool_router} body. *)
 
 type t
 


### PR DESCRIPTION
## Summary

- **StatusTray.jsx**: Extract hardcoded alert thresholds (`fails >= 3`, `cascades >= 2`) into named constants configurable via `MASC_DATA` props
- **cascade_pool_router.ml/mli**: Mark as deprecated — zero external call sites. Provider routing moved to `Cascade_routes`/`Cascade_catalog_runtime`

## Context

From `/Downloads/Kimi_Agent_코드 정리와 중복 제거 (2)/CLEANUP_ROADMAP.md` items #12 (StatusTray hardcoded thresholds) and #3 (cascade_pool_router dead code analysis). The pool router module has been dead code since provider routing moved to the catalog system.

## Test plan

- [ ] Dashboard renders correctly with default thresholds (3 / 2)
- [ ] `dune build` passes — pool_router still compiles but is marked deprecated
- [ ] Verify no new references to cascade_pool_router are introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>