### PR TITLE
fix(keeper): expose internal PR tools in MCP list

### DIFF
--- a/bin/main_eio.ml
+++ b/bin/main_eio.ml
@@ -393,9 +393,12 @@ let dispatch_route ~routes ~request ~path reqd =
       let post_id = String.sub p 14 (String.length p - 14) in
       let format = Option.value ~default:"nested" (query_param request "format") in
       let voter = board_voter_query request in
+      let config =
+        Option.map (fun state -> state.Mcp_server.room_config) !server_state
+      in
       let (status, body) =
         board_post_detail_json ~include_moderation:false ~blind_votes:false
-          ~voter ~response_format:format ~post_id
+          ~config ~voter ~response_format:format ~post_id
       in
       Http.Response.json ~status body reqd
   | _ -> Http.Router.dispatch routes request reqd

--- a/lib/mcp_server_eio_protocol.ml
+++ b/lib/mcp_server_eio_protocol.ml
@@ -210,8 +210,19 @@ let handle_list_tools_eio ?(profile = Full) ?names ?(include_hidden = false)
        | Some wanted ->
            List.filter (fun (schema : Masc_domain.tool_schema) ->
              List.mem schema.name wanted))
-    |> List.sort (fun (a : Masc_domain.tool_schema) (b : Masc_domain.tool_schema) ->
-           String.compare a.name b.name)
+    |> List.sort
+         (fun (a : Masc_domain.tool_schema) (b : Masc_domain.tool_schema) ->
+           let rank (schema : Masc_domain.tool_schema) =
+             if
+               include_keeper_internal
+               && Tool_catalog.is_on_surface Tool_catalog.Keeper_internal
+                    schema.name
+             then 0
+             else 1
+           in
+           match Int.compare (rank a) (rank b) with
+           | 0 -> String.compare a.name b.name
+           | order -> order)
   in
   (match agent_id with
    | Some aid ->

--- a/lib/mcp_server_eio_tool_profile.ml
+++ b/lib/mcp_server_eio_tool_profile.ml
@@ -70,7 +70,7 @@ let tool_schemas_for_profile ?(include_hidden = false)
         let keeper_internal_schemas =
           if not include_keeper_internal then []
           else
-            Tool_shard.keeper_model_tools
+            Tool_shard.all_keeper_tool_schemas
             |> List.filter (fun (schema : Masc_domain.tool_schema) ->
                    Tool_catalog.is_on_surface Tool_catalog.Keeper_internal
                      schema.name

--- a/lib/server/server_h2_gateway.ml
+++ b/lib/server/server_h2_gateway.ml
@@ -455,9 +455,19 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
                                    let profile =
                                      mcp_eio_profile_of_transport_profile profile
                                    in
+                                   let body_with_agent =
+                                     Server_mcp_transport_http.body_with_canonical_http_actor
+                                       ~base_path ~auth_token httpun_request body_str
+                                   in
+                                   let internal_keeper_runtime =
+                                     Server_auth.is_verified_internal_keeper_request
+                                       ~base_path httpun_request
+                                   in
                                    let response_json =
                                      Mcp_eio.handle_request ~clock ~sw ~profile
-                                       ~mcp_session_id:session_id ?auth_token state body_str
+                                       ~mcp_session_id:session_id ?auth_token
+                                       ~internal_keeper_runtime state
+                                       body_with_agent
                                    in
                                    (match protocol_version_from_body body_str with
                                    | Some v -> remember_protocol_version session_id v

--- a/lib/tool_catalog_surfaces.ml
+++ b/lib/tool_catalog_surfaces.ml
@@ -80,6 +80,8 @@ let keeper_internal_tools =
     "keeper_voice_session_end";
     (* Tool discovery *)
     "keeper_tool_search";
+    (* Keeper-scoped workflow preflight. *)
+    "keeper_preflight_check";
     (* Keeper-scoped GitHub PR tools. These are native keeper tools, not
        public MCP tools, so CLI lanes must materialize them through the
        keeper-bound runtime MCP surface instead of silently dropping them. *)
@@ -301,11 +303,6 @@ let system_internal_surface_tools =
     (* Keeper board maintenance schemas remain callable for backward
        compatibility, but are hidden from keeper/public discovery. *)
     "keeper_board_delete"; "keeper_board_cleanup";
-    (* Keeper GitHub workflow tools are schema-registered for keeper model
-       routing, but must stay hidden from public tools/list. *)
-    "keeper_preflight_check";
-    "keeper_pr_list"; "keeper_pr_status"; "keeper_pr_create";
-    "keeper_pr_review_read"; "keeper_pr_review_comment"; "keeper_pr_review_reply";
   ]
 
 (* ================================================================ *)

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -1673,6 +1673,14 @@ let test_transport_route_contracts () =
     (file_contains_pattern "lib/server/server_mcp_transport_http.ml"
        {|Option.is_none existing_agent
                     && Option.is_none existing_legacy_agent|});
+  check bool "h2 mcp post injects canonical http actor" true
+    (file_contains_pattern "lib/server/server_h2_gateway.ml"
+       "body_with_canonical_http_actor");
+  check bool "h2 mcp post forwards internal keeper runtime" true
+    (file_contains_pattern "lib/server/server_h2_gateway.ml"
+       "is_verified_internal_keeper_request"
+    && file_contains_pattern "lib/server/server_h2_gateway.ml"
+         "~internal_keeper_runtime state");
   check bool "common http deps prefer runtime captured in server_state" true
     (file_contains_pattern "lib/server/server_routes_http_common.ml"
        "state.Mcp_server.sw");

--- a/test/test_mcp_server_eio.ml
+++ b/test/test_mcp_server_eio.ml
@@ -2289,6 +2289,10 @@ let test_handle_request_tools_list_internal_keeper_runtime_includes_keeper_inter
       let names = tool_names_from_list_response response in
       Alcotest.(check bool) "keeper_bash listed" true
         (List.mem "keeper_bash" names);
+      Alcotest.(check bool) "keeper_pr_create listed" true
+        (List.mem "keeper_pr_create" names);
+      Alcotest.(check bool) "keeper_pr_review_comment listed" true
+        (List.mem "keeper_pr_review_comment" names);
       Alcotest.(check bool) "system internal still hidden" false
         (List.mem "masc_mcp_session" names))
 

--- a/test/test_tool_surface_ssot.ml
+++ b/test/test_tool_surface_ssot.ml
@@ -125,7 +125,14 @@ let test_keeper_internal_contains_known_tools () =
   List.iter
     (fun name ->
       Alcotest.(check bool) (name ^ " is internal") true (SS.mem name internal))
-    [ "keeper_time_now"; "keeper_board_post"; "keeper_bash"; "keeper_memory_search" ]
+    [
+      "keeper_time_now";
+      "keeper_board_post";
+      "keeper_bash";
+      "keeper_memory_search";
+      "keeper_pr_create";
+      "keeper_pr_review_comment";
+    ]
 
 let test_keeper_voice_replacement_contract () =
   Alcotest.(check (option string))
@@ -206,14 +213,12 @@ let test_replacement_targets_have_schemas () =
   ) internal
 
 let test_keeper_internal_tools_have_schemas () =
-  (* Every tool in keeper_internal_tools should have a schema in
-     keeper shards (model_tools + voice shard). A name without a schema
+  (* Every tool in keeper_internal_tools should have a schema in the
+     keeper-facing schema SSOT. A name without a schema
      means the LLM can never select it — a silent capability gap. *)
-  let voice_schemas = match Tool_shard.get_shard "voice" with
-    | Some shard -> shard.tools | None -> [] in
   let standalone_schemas = [ Keeper_exec_tools.keeper_tool_search_schema ] in
   let schema_names =
-    (Tool_shard.keeper_model_tools @ voice_schemas @ standalone_schemas)
+    (Tool_shard.all_keeper_tool_schemas @ standalone_schemas)
     |> List.map (fun (s : Masc_domain.tool_schema) -> s.name)
     |> SS.of_list
   in


### PR DESCRIPTION
## Summary

Fixes the keeper runtime MCP tool discovery path that allowed `keeper_pr_create` / review tools in policy but failed to expose their function schemas to Claude Code.

Root cause:
- `tools/list` only added `Tool_shard.keeper_model_tools`, which excludes non-shard keeper PR/preflight schemas.
- Keeper GitHub PR tools were also classified as `System_internal`, and the MCP list path always removes system-internal tools, even for verified keeper runtime requests.
- The HTTP/2 `/mcp` gateway verified internal keeper auth but did not forward `internal_keeper_runtime` or canonical HTTP actor injection into `Mcp_eio.handle_request`.
- Pagination could still bury keeper-internal tools behind public tools, so keeper-internal tools are prioritized on the first page when the internal keeper runtime is active.

Changes:
- Use `Tool_shard.all_keeper_tool_schemas` for internal keeper schema listing.
- Keep PR/preflight tools on `Keeper_internal`, not `System_internal`.
- Prioritize keeper-internal tools in internal runtime `tools/list` results.
- Wire HTTP/2 `/mcp` through the same canonical actor and internal keeper runtime path as HTTP/1.1.
- Pass server config to the legacy `bin/main_eio.ml` board detail route so the pushed head builds after the newer board API change.
- Add regression coverage for `keeper_pr_create` and `keeper_pr_review_comment` discovery.

## Validation

- `git diff --check`
- `scripts/dune-local.sh build test/test_mcp_server_eio.exe test/test_ci_hardening_source.exe test/test_tool_surface_ssot.exe`
- `./_build/default/test/test_mcp_server_eio.exe test eio 41`
- `./_build/default/test/test_ci_hardening_source.exe` (55 tests)
- `./_build/default/test/test_tool_surface_ssot.exe` (25 tests)
- `env DUNE_BUILD_DIR=_build_codex_14031_lifecycle_smoke scripts/dune-local.sh build bin/main_eio.exe`
- GitHub checks on pushed head `b4a12cdf40` are pass or expected skipped for draft.

## Runtime Smoke

Isolated git-backed base: `/private/tmp/masc-lifecycle-14031-gitbase-20260507-joSUT7`

Run dir: `/private/tmp/keeper-docker-pr-lifecycle-14031-smoke-20260507-codex1`

Patched server incarnation: `b4a12cdf40|2026-05-07T02:14:46Z`

3-keeper mutate smoke results:
- `sangsu`: created draft PR #14039 with `docker_pr_create=true` and `docker_git_push=true`.
- `qa-king`: created draft PR #14040 with `docker_pr_create=true` and `docker_git_push=true`.
- `verifier`: `keeper_pr_create` was callable and executed via Docker, but the fork route failed because Docker egress for `verifier` has an empty allowlist, so the fork branch could not be pushed.

This proves the missing `keeper_pr_create` function-schema failure for upstream writer keepers is fixed. Remaining #13920 work is verifier/fork egress policy plus audit evidence accounting for successful runtime creates.

## Operator impact

This removes the observed split-brain state where keeper guidance and policy said `keeper_pr_create` was available, but the actual Claude Code function schema did not include it. The full Docker keeper PR lifecycle can now see the PR create/review tools through the verified keeper-bound MCP runtime instead of falling back to shell-only branch pushes.