### PR TITLE
fix(board): move delete persistence out of state lock

### DIFF
--- a/lib/board_core.mli
+++ b/lib/board_core.mli
@@ -53,6 +53,9 @@ val persist_error_count : unit -> int
     swallowed during JSONL append / rotate; consumed by the
     operator dashboard for at-a-glance health. *)
 
+val record_persist_error : where:string -> string -> unit
+(** Record and log a board persistence failure. *)
+
 (** {1 Configuration} *)
 
 val flush_interval_sec : float

--- a/lib/board_votes.ml
+++ b/lib/board_votes.ml
@@ -703,63 +703,107 @@ let set_thread_id store ~post_id ~thread_id : (unit, board_error) Result.t =
             Ok ()
       )
 
+let posts_jsonl_snapshot store =
+  let buf = Buffer.create 4096 in
+  Hashtbl.iter (fun _ (pst : post) ->
+    Buffer.add_string buf (Yojson.Safe.to_string (post_to_yojson pst));
+    Buffer.add_char buf '\n'
+  ) store.posts;
+  Buffer.contents buf
+
+let comments_jsonl_snapshot store =
+  let buf = Buffer.create 4096 in
+  Hashtbl.iter (fun _ (cmt : comment) ->
+    Buffer.add_string buf (Yojson.Safe.to_string (comment_to_yojson cmt));
+    Buffer.add_char buf '\n'
+  ) store.comments;
+  Buffer.contents buf
+
+let reactions_jsonl_snapshot store =
+  let buf = Buffer.create 4096 in
+  Hashtbl.iter
+    (fun _ (reaction : reaction) ->
+       Buffer.add_string buf (Yojson.Safe.to_string (reaction_to_yojson reaction));
+       Buffer.add_char buf '\n')
+    store.reactions;
+  Buffer.contents buf
+
+let save_jsonl_snapshot ~where ~path content =
+  try
+    ensure_masc_dir ();
+    match Fs_compat.save_file_atomic path content with
+    | Ok () -> ()
+    | Error msg -> record_persist_error ~where msg
+  with Sys_error msg -> record_persist_error ~where msg
+
 let delete_post store ~post_id : (unit, board_error) Result.t =
   match Post_id.of_string post_id with
   | Error e -> Error e
   | Ok pid ->
-      with_lock store (fun () ->
-        let post_key = Post_id.to_string pid in
-        match Hashtbl.find_opt store.posts post_key with
-        | None -> Error (Post_not_found post_id)
-        | Some _ ->
-            let comment_ids =
-              Hashtbl.fold
-                (fun key (c : comment) acc ->
-                  if String.equal (Post_id.to_string c.post_id) post_key then key :: acc else acc)
-                store.comments []
-            in
-            Hashtbl.remove store.posts post_key;
-            Hashtbl.remove store.comments_by_post post_key;
-            List.iter (fun comment_key -> Hashtbl.remove store.comments comment_key) comment_ids;
-            let vote_keys =
-              Hashtbl.fold
-                (fun key _ acc ->
-                  if String.starts_with ~prefix:("post:" ^ post_key ^ ":") key
-                     || List.exists
-                          (fun comment_key ->
-                            String.starts_with ~prefix:("comment:" ^ comment_key ^ ":") key)
-                          comment_ids
-                  then key :: acc
-                  else acc)
-                store.vote_log []
-            in
-            let reaction_keys =
-              Hashtbl.fold
-                (fun key (reaction : reaction) acc ->
-                  if
-                    ((=) reaction.target_type Reaction_post
-                     && String.equal reaction.target_id post_key)
-                    || ((=) reaction.target_type Reaction_comment
-                        && List.exists (String.equal reaction.target_id)
-                             comment_ids)
-                  then key :: acc
-                  else acc)
-                store.reactions []
-            in
-            List.iter (fun key -> Hashtbl.remove store.vote_log key) vote_keys;
-            List.iter (fun key -> Hashtbl.remove store.reactions key) reaction_keys;
-            store.post_count := max 0 (!(store.post_count) - 1);
-            invalidate_post_caches store;
-            invalidate_comment_caches store;
-            rewrite_posts store;
-            rewrite_comments store;
-            rewrite_vote_log store;
-            rewrite_reactions_unlocked store;
-            store.dirty_posts <- false;
-            store.dirty_comments <- false;
-            Hashtbl.clear store.dirty_post_ids;
-            Hashtbl.clear store.dirty_comment_ids;
-            store.last_flush <- Time_compat.now ();
+      with_persist_lock store (fun () ->
+        let snapshot =
+          with_lock store (fun () ->
+            let post_key = Post_id.to_string pid in
+            match Hashtbl.find_opt store.posts post_key with
+            | None -> Error (Post_not_found post_id)
+            | Some _ ->
+                let comment_ids =
+                  Hashtbl.fold
+                    (fun key (c : comment) acc ->
+                      if String.equal (Post_id.to_string c.post_id) post_key then key :: acc else acc)
+                    store.comments []
+                in
+                Hashtbl.remove store.posts post_key;
+                Hashtbl.remove store.comments_by_post post_key;
+                List.iter (fun comment_key -> Hashtbl.remove store.comments comment_key) comment_ids;
+                let vote_keys =
+                  Hashtbl.fold
+                    (fun key _ acc ->
+                      if String.starts_with ~prefix:("post:" ^ post_key ^ ":") key
+                         || List.exists
+                              (fun comment_key ->
+                                String.starts_with ~prefix:("comment:" ^ comment_key ^ ":") key)
+                              comment_ids
+                      then key :: acc
+                      else acc)
+                    store.vote_log []
+                in
+                let reaction_keys =
+                  Hashtbl.fold
+                    (fun key (reaction : reaction) acc ->
+                      if
+                        ((=) reaction.target_type Reaction_post
+                         && String.equal reaction.target_id post_key)
+                        || ((=) reaction.target_type Reaction_comment
+                            && List.exists (String.equal reaction.target_id)
+                                 comment_ids)
+                      then key :: acc
+                      else acc)
+                    store.reactions []
+                in
+                List.iter (fun key -> Hashtbl.remove store.vote_log key) vote_keys;
+                List.iter (fun key -> Hashtbl.remove store.reactions key) reaction_keys;
+                store.post_count := max 0 (!(store.post_count) - 1);
+                invalidate_post_caches store;
+                invalidate_comment_caches store;
+                store.dirty_posts <- false;
+                store.dirty_comments <- false;
+                Hashtbl.clear store.dirty_post_ids;
+                Hashtbl.clear store.dirty_comment_ids;
+                store.last_flush <- Time_compat.now ();
+                Ok
+                  ( posts_jsonl_snapshot store
+                  , comments_jsonl_snapshot store
+                  , vote_log_jsonl store
+                  , reactions_jsonl_snapshot store ))
+        in
+        match snapshot with
+        | Error _ as e -> e
+        | Ok (posts_jsonl, comments_jsonl, votes_jsonl, reactions_jsonl) ->
+            save_jsonl_snapshot ~where:"rewrite_posts" ~path:(persist_path ()) posts_jsonl;
+            save_jsonl_snapshot ~where:"rewrite_comments" ~path:(comments_path ()) comments_jsonl;
+            save_vote_log_jsonl votes_jsonl;
+            save_jsonl_snapshot ~where:"rewrite_reactions" ~path:(reactions_path ()) reactions_jsonl;
             Ok ())
 
 (** {1 Global Store}

--- a/test/test_board_karma_ledger.ml
+++ b/test/test_board_karma_ledger.ml
@@ -239,6 +239,57 @@ let test_replay_invariant () =
   Alcotest.(check (list (pair string int)))
     "ledger totals == get_all_karma" direct_totals ledger_totals
 
+let file_contains path needle =
+  if not (Sys.file_exists path) then false
+  else
+    let ic = open_in path in
+    Fun.protect
+      ~finally:(fun () -> close_in_noerr ic)
+      (fun () ->
+        let rec loop () =
+          match input_line ic with
+          | line ->
+              (String.length needle > 0
+               && String.contains line needle.[0]
+               && String_util.contains_substring line needle)
+              || loop ()
+          | exception End_of_file -> false
+        in
+        loop ())
+
+let test_delete_post_rewrites_persisted_snapshots () =
+  let post = create_post_exn ~author:"alice" ~content:"delete me" in
+  let pid = Board.Post_id.to_string post.id in
+  let comment =
+    match
+      Board_dispatch.add_comment ~post_id:pid ~author:"bob"
+        ~content:"also delete" ()
+    with
+    | Ok c -> c
+    | Error e -> Alcotest.fail (Board.show_board_error e)
+  in
+  let cid = Board.Comment_id.to_string comment.id in
+  vote_exn ~voter:"carol" ~post_id:pid ~direction:Board.Up;
+  (match
+     Board_dispatch.toggle_reaction ~target_type:Board.Reaction_post
+       ~target_id:pid ~user_id:"dave" ~emoji:"👍"
+   with
+   | Ok _ -> ()
+   | Error e -> Alcotest.fail (Board.show_board_error e));
+  (match Board_dispatch.delete_post ~post_id:pid with
+   | Ok () -> ()
+   | Error e -> Alcotest.fail (Board.show_board_error e));
+  (match Board_dispatch.get_post ~post_id:pid with
+   | Ok _ -> Alcotest.fail "deleted post remained readable"
+   | Error _ -> ());
+  let check_absent label path needle =
+    Alcotest.(check bool) label false (file_contains path needle)
+  in
+  check_absent "posts snapshot removes deleted post" (Board.persist_path ()) pid;
+  check_absent "comments snapshot removes deleted comment" (Board.comments_path ()) cid;
+  check_absent "vote snapshot removes deleted post vote" (Board_votes.vote_log_path ()) pid;
+  check_absent "reaction snapshot removes deleted post reaction" (Board.reactions_path ()) pid
+
 (** {1 JSON serialisation} *)
 
 let test_karma_event_json_fields () =
@@ -323,6 +374,8 @@ let () =
     "replay", [
       Alcotest.test_case "rebuild invariant" `Quick
         (with_eio test_replay_invariant);
+      Alcotest.test_case "delete post rewrites persisted snapshots" `Quick
+        (with_eio test_delete_post_rewrites_persisted_snapshots);
     ];
     "serialisation", [
       Alcotest.test_case "json fields" `Quick


### PR DESCRIPTION
## Summary

- move `Board.delete_post` filesystem rewrites out of the board state mutex
- keep synchronous durability by taking the board persist lock before mutation, snapshotting under `store.mutex`, then writing the snapshots after releasing the state lock
- add regression coverage that delete rewrites persisted post/comment/vote/reaction snapshots

## Why

#10569 tracks board write RPC stalls caused by board persistence acting as a fleet-wide single point of failure. PR #13678 raised the board tool timeout; this slice reduces one remaining admin write hot path where `delete_post` rewrote posts, comments, votes, and reactions while holding `store.mutex` and bypassing the persist-lock timing bucket.

The ordering is intentional: `with_persist_lock` is acquired before the state mutation so a later writer cannot append and then be overwritten by the delete snapshot. The state lock is still released before filesystem I/O.

## Validation

- `git diff --check`
- `scripts/dune-local.sh build test/test_board_karma_ledger.exe` attempted first; stopped while queued behind `/tmp/me-dune-local.lock` host contention.
- `env DUNE_JOBS=1 MASC_SKIP_OPAM_LOCK=1 MASC_SKIP_PIN_CHECK=1 dune build --root . test/test_board_karma_ledger.exe`
- `env MASC_SKIP_PIN_CHECK=1 ./_build/default/test/test_board_karma_ledger.exe` - 16 tests passed

## Review Focus

- Whether the persist-lock-before-state-lock ordering is the right tradeoff for delete snapshot ordering.
- Whether exposing `Board_core.record_persist_error` for this internal snapshot writer is acceptable, or whether the save helpers should be promoted instead.

Refs #10569.
