### PR TITLE
fix: recover hook output json snippets

### DIFF
--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -1137,6 +1137,109 @@ let observe_output_parse_failure ~surface ~output_bytes =
         "keeper_hooks_oas output JSON parse failed: surface=%s output_bytes=%d"
         surface output_bytes)
 
+let find_substring_from text ~needle ~start =
+  let text_len = String.length text in
+  let needle_len = String.length needle in
+  let rec loop i =
+    if needle_len = 0 then Some i
+    else if i + needle_len > text_len then None
+    else if String.sub text i needle_len = needle then Some i
+    else loop (i + 1)
+  in
+  loop start
+
+let strip_fence_language block =
+  let block = String.trim block in
+  match String.index_opt block '\n' with
+  | None -> block
+  | Some first_line_end ->
+      let first_line =
+        String.sub block 0 first_line_end
+        |> String.trim
+        |> String.lowercase_ascii
+      in
+      let rest =
+        String.sub block (first_line_end + 1)
+          (String.length block - first_line_end - 1)
+        |> String.trim
+      in
+      if first_line = "json" || first_line = "jsonc" then rest else block
+
+let fenced_json_candidates text =
+  let fence = "```" in
+  let rec loop start acc =
+    match find_substring_from text ~needle:fence ~start with
+    | None -> List.rev acc
+    | Some open_at ->
+        let content_start = open_at + String.length fence in
+        (match find_substring_from text ~needle:fence ~start:content_start with
+         | None -> List.rev acc
+         | Some close_at ->
+             let raw =
+               String.sub text content_start (close_at - content_start)
+               |> strip_fence_language
+             in
+             let acc = if raw = "" then acc else raw :: acc in
+             loop (close_at + String.length fence) acc)
+  in
+  loop 0 []
+
+let json_close_for_open = function
+  | '{' -> Some '}'
+  | '[' -> Some ']'
+  | _ -> None
+
+let balanced_json_candidates text =
+  let len = String.length text in
+  let rec finish_candidate i in_string escaped stack =
+    if i >= len then None
+    else
+      let ch = text.[i] in
+      if in_string then
+        if escaped then finish_candidate (i + 1) true false stack
+        else
+          match ch with
+          | '\\' -> finish_candidate (i + 1) true true stack
+          | '"' -> finish_candidate (i + 1) false false stack
+          | _ -> finish_candidate (i + 1) true false stack
+      else
+        match ch with
+        | '"' -> finish_candidate (i + 1) true false stack
+        | '{' | '[' ->
+            (match json_close_for_open ch with
+             | None -> finish_candidate (i + 1) false false stack
+             | Some close ->
+                 finish_candidate (i + 1) false false (close :: stack))
+        | '}' | ']' ->
+            (match stack with
+             | close :: rest when close = ch ->
+                 if rest = [] then Some i
+                 else finish_candidate (i + 1) false false rest
+             | _ -> None)
+        | _ -> finish_candidate (i + 1) false false stack
+  in
+  let rec loop i acc =
+    if i >= len then List.rev acc
+    else
+      match json_close_for_open text.[i] with
+      | None -> loop (i + 1) acc
+      | Some expected ->
+          (match finish_candidate (i + 1) false false [ expected ] with
+           | None -> loop (i + 1) acc
+           | Some close_at ->
+               let candidate =
+                 String.sub text i (close_at - i + 1)
+                 |> String.trim
+               in
+               loop (close_at + 1) (candidate :: acc))
+  in
+  loop 0 []
+
+let parse_json_candidate ~surface candidate =
+  Safe_ops.parse_json_safe
+    ~context:("Keeper_hooks_oas." ^ surface ^ ".output.embedded")
+    candidate
+
 let output_json_opt ~surface output_text =
   match
     Safe_ops.parse_json_safe
@@ -1145,9 +1248,22 @@ let output_json_opt ~surface output_text =
   with
   | Ok json -> Some json
   | Error _ ->
-      observe_output_parse_failure ~surface
-        ~output_bytes:(String.length output_text);
-      None
+      let candidates =
+        fenced_json_candidates output_text @ balanced_json_candidates output_text
+      in
+      (match
+         List.find_map
+           (fun candidate ->
+              match parse_json_candidate ~surface candidate with
+              | Ok json -> Some json
+              | Error _ -> None)
+           candidates
+       with
+       | Some json -> Some json
+       | None ->
+           observe_output_parse_failure ~surface
+             ~output_bytes:(String.length output_text);
+           None)
 
 let normalized_route_via raw =
   let value = String.trim raw |> String.lowercase_ascii in

--- a/test/test_keeper_hooks_oas_telemetry.ml
+++ b/test/test_keeper_hooks_oas_telemetry.ml
@@ -953,6 +953,26 @@ let test_pr_review_action_metric_observes_invalid_output_json () =
   check (float 0.001) "parse failure counted" (before +. 1.0)
     (hook_output_parse_failures "pr_review_action")
 
+let test_pr_review_action_metric_extracts_fenced_output_json () =
+  let before = hook_output_parse_failures "pr_review_action" in
+  let event =
+    pr_review_event
+      ~tool_name:"keeper_pr_review_comment"
+      ~input:(`Assoc [ ("number", `Int 71); ("event", `String "comment") ])
+      ~output_text:
+        "Review submitted.\n\
+         ```json\n\
+         {\"ok\":true,\"pr_number\":71,\"event\":\"APPROVE\",\"via\":\"docker\"}\n\
+         ```\n"
+      ()
+    |> require_pr_review_event "fenced output json"
+  in
+  check string "action from fenced output" "APPROVE" event.action;
+  check (option int) "pr number" (Some 71) event.pr_number;
+  check (option string) "route via" (Some "docker") event.route_via;
+  check (float 0.001) "parse failure not counted" before
+    (hook_output_parse_failures "pr_review_action")
+
 let test_pr_review_action_metric_extracts_keeper_shell_approve () =
   let event =
     pr_review_event
@@ -1010,6 +1030,39 @@ let test_pr_work_action_metric_observes_invalid_output_json () =
   check (list string) "actions fallback from input" [ "GIT_PUSH" ]
     (work_actions events);
   check (float 0.001) "parse failure counted" (before +. 1.0)
+    (hook_output_parse_failures "pr_work_action")
+
+let test_pr_work_action_metric_extracts_embedded_output_json () =
+  let before = hook_output_parse_failures "pr_work_action" in
+  let events =
+    pr_work_events
+      ~tool_name:"keeper_pr_create"
+      ~input:
+        (`Assoc
+          [
+            ("title", `String "proof");
+            ("head", `String "proof/embedded-json");
+          ])
+      ~output_text:
+        "Created draft PR successfully:\n\
+         {\"ok\":true,\"tool\":\"keeper_pr_create\",\"operation\":\"pr_create\",\
+         \"via\":\"brokered\",\"result\":{\"output\":\"https://github.com/acme/repo/pull/43\\n\"}}\n\
+         Done."
+      ()
+  in
+  check (list string) "pr create action" [ "PR_CREATE" ]
+    (work_actions events);
+  (match events with
+   | [ event ] ->
+       check string "source" "keeper_pr_create" event.work_source;
+       check (option string) "head ref" (Some "proof/embedded-json")
+         event.work_ref;
+       check (option string) "pr url"
+         (Some "https://github.com/acme/repo/pull/43")
+         event.pr_url;
+       check (option string) "route via" (Some "brokered") event.route_via
+   | _ -> failf "expected one keeper_pr_create event");
+  check (float 0.001) "parse failure not counted" before
     (hook_output_parse_failures "pr_work_action")
 
 let test_pr_work_action_metric_extracts_gh_pr_create () =
@@ -1279,6 +1332,8 @@ let () =
             test_pr_review_action_metric_extracts_reply
         ; test_case "observes invalid output JSON" `Quick
             test_pr_review_action_metric_observes_invalid_output_json
+        ; test_case "extracts fenced output JSON" `Quick
+            test_pr_review_action_metric_extracts_fenced_output_json
         ; test_case "extracts keeper_shell approve" `Quick
             test_pr_review_action_metric_extracts_keeper_shell_approve
         ] )
@@ -1287,6 +1342,8 @@ let () =
             test_pr_work_action_metric_extracts_masc_code_git_push
         ; test_case "observes invalid output JSON" `Quick
             test_pr_work_action_metric_observes_invalid_output_json
+        ; test_case "extracts embedded output JSON" `Quick
+            test_pr_work_action_metric_extracts_embedded_output_json
         ; test_case "extracts keeper_shell gh pr create" `Quick
             test_pr_work_action_metric_extracts_gh_pr_create
         ; test_case "extracts quoted output gh pr create" `Quick


### PR DESCRIPTION
## Summary

- Recover structured hook output JSON when tools return prose with fenced or embedded JSON snippets.
- Keep direct JSON parsing as the fast path, and only emit `keeper_hooks_oas output JSON parse failed` when all recovery candidates fail.
- Add telemetry tests for `pr_review_action` fenced JSON and `pr_work_action` embedded JSON.

## Product impact

- User-visible change: operator telemetry stops classifying successful PR work/review hook outputs as parse failures when the structured result is wrapped in ordinary tool prose.

## Evidence

- Live local evidence: today's `~/me/.masc/logs/system_log_2026-05-07.jsonl` had repeated `keeper_hooks_oas output JSON parse failed` warnings for `pr_work_action` / `pr_review_action`.
- `git diff --check`
- `scripts/dune-local.sh build test/test_keeper_hooks_oas_telemetry.exe` passed before the formatting rollback; a later rerun was canceled while waiting behind other shared Dune lock holders.
- `./_build/default/test/test_keeper_hooks_oas_telemetry.exe` passed after restoring the focused diff: 46 tests.
- Tool-call behavior/provider support: no provider tool support changed; this only recovers JSON from existing hook output text.

## GOAL LOOP ACT checklist

- [x] Observe — live `~/me/.masc` logs showed repeated hook output parse failures.
- [x] Orient — mapped to the keeper FSM audit's instrumentation/review-action reliability follow-up and current runtime log pattern.
- [x] Decide — bounded telemetry repair chosen because it is current, reproducible log noise and does not overlap existing open hook-surface PRs.
- [x] Act — parser fallback added only in `keeper_hooks_oas` output handling with regression coverage.
- [x] Verify — focused test binary passed locally; CI will run the full PR gate.
- [x] Loop — broader stale-turn / require-tool-use runtime failures remain tracked outside this narrow PR.

## Review evidence

- Self-review only so far. Please focus review on parser recovery bounds, balanced JSON scanning, and whether fenced non-JSON blocks should remain eligible as parse candidates.

## Linked issue

- Closes #
- Relates # keeper FSM audit / live runtime log cleanup

## Variant addition checklist

- [ ] **OCaml** — N/A: no variant added/removed.
- [ ] **TypeScript** — N/A: no TypeScript union changed.
- [ ] **TLA+ spec** — N/A: no TLA+ domain literal changed.
- [ ] **Event / JSON schema** — N/A: no event type string, JSON schema enum, or canonical key changed.
- [ ] **`make check-variants` passes** — N/A: no variant/schema-domain change in this PR.
