### PR TITLE
fix(worktree): skip runtime-pinned cleanup candidates

### DIFF
--- a/scripts/cleanup-merged-worktrees.sh
+++ b/scripts/cleanup-merged-worktrees.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # Safely remove worktrees whose branch is already merged into main.
-# Never uses --force.  Respects uncommitted changes.
+# Never uses --force. Respects uncommitted changes, nested worktrees, and
+# runtime-pinned paths.
 #
 # Usage:
 #   ./scripts/cleanup-merged-worktrees.sh          # dry run, shows candidates
@@ -17,6 +18,9 @@ for arg in "$@"; do
     *) echo "unknown arg: $arg" >&2; exit 2 ;;
   esac
 done
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+. "$SCRIPT_DIR/lib/worktree-cleanup-guards.sh"
 
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd "$REPO_ROOT"
@@ -44,6 +48,8 @@ fi
 removed=0
 skipped=0
 dirty=0
+nested=0
+active=0
 
 while read -r branch; do
   [ -z "$branch" ] && continue
@@ -55,6 +61,18 @@ while read -r branch; do
   if ! git -C "$wt_path" diff --quiet 2>/dev/null || ! git -C "$wt_path" diff --cached --quiet 2>/dev/null; then
     echo "DIRTY  $wt_path (branch $branch) — skipped"
     dirty=$((dirty+1))
+    continue
+  fi
+
+  if [ -d "$wt_path/.worktrees" ]; then
+    echo "NESTED $wt_path (branch $branch) — skipped"
+    nested=$((nested+1))
+    continue
+  fi
+
+  if worktree_cleanup_is_runtime_referenced "$wt_path"; then
+    echo "ACTIVE $wt_path (branch $branch) — skipped (referenced by tmux/process/launchd)"
+    active=$((active+1))
     continue
   fi
 
@@ -76,8 +94,8 @@ done <<< "$MERGED_BRANCHES"
 if [ "$APPLY" -eq 1 ]; then
   git worktree prune
   echo ""
-  echo "Summary: removed=$removed skipped=$skipped dirty=$dirty"
+  echo "Summary: removed=$removed skipped=$skipped dirty=$dirty nested=$nested active=$active"
 else
   echo ""
-  echo "Summary: $removed candidates (dry run — pass --apply to remove)"
+  echo "Summary: $removed candidates (dry run — pass --apply to remove; dirty=$dirty nested=$nested active=$active)"
 fi

--- a/scripts/cleanup-stale-worktrees.sh
+++ b/scripts/cleanup-stale-worktrees.sh
@@ -11,6 +11,7 @@
 #   - dry-run by default; --apply required to actually remove
 #   - skips dirty worktrees (uncommitted or staged changes)
 #   - skips worktrees containing nested worktrees (.worktrees/ inside)
+#   - skips worktrees referenced by tmux, running processes, or launchd plists
 #   - never uses --force
 #   - leaves the branch in place (only removes the worktree directory)
 #
@@ -34,6 +35,9 @@ while [ $# -gt 0 ]; do
   esac
 done
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+. "$SCRIPT_DIR/lib/worktree-cleanup-guards.sh"
+
 if ! [[ "$DAYS" =~ ^[0-9]+$ ]]; then
   echo "--days must be a non-negative integer (got: $DAYS)" >&2
   exit 2
@@ -47,6 +51,7 @@ CUTOFF_TS=$(( $(date +%s) - DAYS * 86400 ))
 stale=0
 dirty=0
 nested=0
+active=0
 removed=0
 skipped=0
 
@@ -87,6 +92,12 @@ while read -r wt_path; do
     continue
   fi
 
+  if worktree_cleanup_is_runtime_referenced "$wt_path"; then
+    echo "ACTIVE  $wt_path — skipped (referenced by tmux/process/launchd)"
+    active=$((active+1))
+    continue
+  fi
+
   age_days=$(( ( $(date +%s) - last_ts ) / 86400 ))
   stale=$((stale+1))
 
@@ -106,9 +117,9 @@ done < <(git worktree list --porcelain | awk '/^worktree /{print $2}')
 if [ "$APPLY" -eq 1 ]; then
   git worktree prune
   echo ""
-  echo "Summary (--days $DAYS --apply): stale=$stale removed=$removed dirty=$dirty nested=$nested skipped=$skipped"
+  echo "Summary (--days $DAYS --apply): stale=$stale removed=$removed dirty=$dirty nested=$nested active=$active skipped=$skipped"
 else
   echo ""
-  echo "Summary (--days $DAYS dry-run): stale=$stale dirty=$dirty nested=$nested skipped=$skipped"
+  echo "Summary (--days $DAYS dry-run): stale=$stale dirty=$dirty nested=$nested active=$active skipped=$skipped"
   echo "Pass --apply to remove the listed candidates."
 fi

--- a/scripts/lib/worktree-cleanup-guards.sh
+++ b/scripts/lib/worktree-cleanup-guards.sh
@@ -1,0 +1,46 @@
+# Shared safety guards for worktree cleanup scripts.
+#
+# The stale-worktree incident in #11040 showed that a merged/stale worktree can
+# still be operationally pinned by a tmux pane, a running server command, or a
+# LaunchAgent plist. Cleanup scripts should treat those references as a hard
+# skip signal.
+
+_WORKTREE_CLEANUP_RUNTIME_REFS_LOADED=0
+_WORKTREE_CLEANUP_RUNTIME_REFS=""
+
+worktree_cleanup_append_refs() {
+  local text="$1"
+  [ -z "$text" ] && return 0
+  _WORKTREE_CLEANUP_RUNTIME_REFS="${_WORKTREE_CLEANUP_RUNTIME_REFS}${text}"$'\n'
+}
+
+worktree_cleanup_load_runtime_refs() {
+  [ "$_WORKTREE_CLEANUP_RUNTIME_REFS_LOADED" -eq 1 ] && return 0
+  _WORKTREE_CLEANUP_RUNTIME_REFS_LOADED=1
+
+  if command -v tmux >/dev/null 2>&1; then
+    worktree_cleanup_append_refs "$(tmux list-panes -a -F '#{pane_current_path}' 2>/dev/null || true)"
+    worktree_cleanup_append_refs "$(tmux list-panes -a -F '#{pane_start_path}' 2>/dev/null || true)"
+  fi
+
+  if command -v ps >/dev/null 2>&1; then
+    worktree_cleanup_append_refs "$(ps -axww -o command= 2>/dev/null || true)"
+  fi
+
+  local dir file home_dir
+  home_dir="${HOME:-}"
+  for dir in "$home_dir/Library/LaunchAgents" "/Library/LaunchAgents" "/Library/LaunchDaemons"; do
+    [ -d "$dir" ] || continue
+    for file in "$dir"/*.plist; do
+      [ -e "$file" ] || continue
+      worktree_cleanup_append_refs "$(cat "$file" 2>/dev/null || true)"
+    done
+  done
+}
+
+worktree_cleanup_is_runtime_referenced() {
+  local wt_path="$1"
+  worktree_cleanup_load_runtime_refs
+  [ -n "$_WORKTREE_CLEANUP_RUNTIME_REFS" ] || return 1
+  printf '%s\n' "$_WORKTREE_CLEANUP_RUNTIME_REFS" | grep -F -- "$wt_path" >/dev/null 2>&1
+}


### PR DESCRIPTION
## Summary
- add a shared worktree cleanup guard that detects candidate paths referenced by tmux panes, running process commands, or launchd plists
- make stale and merged worktree cleanup skip those runtime-pinned paths before removal
- extend merged cleanup with the same nested-worktree guard already used by stale cleanup

## Why
#11040 showed stale worktrees can still be production launch targets. Cleanup must not remove a worktree while a tmux/runtime process or launchd config still points at it.

## Validation
- `bash -n scripts/lib/worktree-cleanup-guards.sh scripts/cleanup-stale-worktrees.sh scripts/cleanup-merged-worktrees.sh`
- `scripts/cleanup-stale-worktrees.sh --help`
- `scripts/cleanup-merged-worktrees.sh --help`
- sourced guard smoke: synthetic runtime ref matches candidate path
- `scripts/cleanup-stale-worktrees.sh --days 99999` (dry-run, no candidates)
- `git diff --check HEAD~1..HEAD`

## Review focus
- guard false positives should prefer skipping over deletion
- no cleanup is performed unless the caller still passes `--apply`