### PR TITLE
fix: stop repeating satisfied keeper required tools

### DIFF
--- a/lib/keeper/keeper_agent_tool_surface.ml
+++ b/lib/keeper/keeper_agent_tool_surface.ml
@@ -297,6 +297,30 @@ let required_tool_names_for_turn ~(current_task_required_tool_names : string lis
   | [] -> current_task_required_tool_names
   | _ :: _ -> per_call_required_tool_names
 
+let outstanding_required_tool_names ~(required_tool_names : string list)
+    ~(satisfied_tool_names : string list) =
+  let satisfied =
+    satisfied_tool_names
+    |> List.map Keeper_tool_disclosure.canonical_tool_name
+    |> Keeper_types.dedupe_keep_order
+  in
+  required_tool_names
+  |> List.filter (fun name ->
+    let canonical = Keeper_tool_disclosure.canonical_tool_name name in
+    not (List.mem canonical satisfied))
+  |> Keeper_types.dedupe_keep_order
+
+let satisfied_required_tool_names_of_outcomes
+    (calls : (string * string) list) =
+  calls
+  |> List.filter_map (fun (tool_name, outcome) ->
+    if String.equal outcome "ok"
+       && Keeper_tool_disclosure.tool_name_can_satisfy_required_contract
+            tool_name
+    then Some tool_name
+    else None)
+  |> Keeper_types.dedupe_keep_order
+
 let preferred_tool_choice_for_required_tool_names
     ~(required_tool_names : string list) ~(allowed_tool_names : string list) =
   let visible_required =

--- a/lib/keeper/keeper_agent_tool_surface.ml
+++ b/lib/keeper/keeper_agent_tool_surface.ml
@@ -331,8 +331,14 @@ let preferred_tool_choice_for_required_tool_names
     |> Keeper_types.dedupe_keep_order
   in
   match visible_required with
-  | [ name ] -> Agent_sdk.Types.Tool name
-  | _ :: _ -> Agent_sdk.Types.Any
+  | _ :: _ ->
+    (* Use the provider-level "some tool is required" contract here, even
+       for a single explicit required tool. Runtime MCP transports may return
+       names such as [mcp__masc__keeper_pr_create]; OAS exact-tool contracts
+       compare raw names before MASC can canonicalize them, so exact Tool(name)
+       can reject a correct call. MASC still validates the specific required
+       names after execution via [outstanding_required_tool_names]. *)
+    Agent_sdk.Types.Any
   | [] -> Agent_sdk.Types.Auto
 
 let owned_active_task_id_for_meta =

--- a/lib/keeper/keeper_agent_tool_surface.mli
+++ b/lib/keeper/keeper_agent_tool_surface.mli
@@ -135,6 +135,17 @@ val required_tool_names_for_turn :
   per_call_required_tool_names:string list ->
   string list
 
+(** Remove required tools that have already been satisfied in the current
+    Agent.run. This keeps a multi-turn keeper message from forcing the same
+    specific tool again after the successful tool call has already happened. *)
+val outstanding_required_tool_names :
+  required_tool_names:string list -> satisfied_tool_names:string list -> string list
+
+(** Extract successfully satisfied required-contract tools from observed
+    [(tool_name, outcome)] pairs. Failed or passive calls stay outstanding. *)
+val satisfied_required_tool_names_of_outcomes :
+  (string * string) list -> string list
+
 (** Pick the model-facing [tool_choice] for an explicit required-tool list. A
     single visible required tool should be forced specifically; multiple visible
     required tools use [Any] and are checked after execution. *)

--- a/lib/keeper/keeper_agent_tool_surface.mli
+++ b/lib/keeper/keeper_agent_tool_surface.mli
@@ -146,9 +146,10 @@ val outstanding_required_tool_names :
 val satisfied_required_tool_names_of_outcomes :
   (string * string) list -> string list
 
-(** Pick the model-facing [tool_choice] for an explicit required-tool list. A
-    single visible required tool should be forced specifically; multiple visible
-    required tools use [Any] and are checked after execution. *)
+(** Pick the model-facing [tool_choice] for an explicit required-tool list.
+    Visible required tools use [Any] so OAS enforces tool use without
+    exact-name matching before MASC canonicalizes MCP-prefixed tool names. The
+    specific required names are checked after execution. *)
 val preferred_tool_choice_for_required_tool_names :
   required_tool_names:string list ->
   allowed_tool_names:string list ->

--- a/lib/keeper/keeper_run_tools.ml
+++ b/lib/keeper/keeper_run_tools.ml
@@ -1278,6 +1278,17 @@ let prepare_agent_setup
                          with keeper_task_done or keeper_task_submit_for_verification."
                         computed_surface.per_call_turn
                         computed_surface.per_call_max_turns)
+                 else if computed_surface.required_tool_names <> []
+                 then
+                   append_ctx
+                     ctx
+                     (Printf.sprintf
+                        "[REQUIRED TOOLS] This Agent.run call has explicit \
+                         required_tools: %s. You MUST use these exact runtime \
+                         tools before answering in natural language. Do not \
+                         substitute a shell command or status read for a \
+                         listed required tool."
+                        (String.concat ", " computed_surface.required_tool_names))
                  else if is_retry
                  then
                    append_ctx

--- a/lib/keeper/keeper_run_tools.ml
+++ b/lib/keeper/keeper_run_tools.ml
@@ -563,6 +563,12 @@ let prepare_agent_setup
         || turn_affordances_require_tool_gate_with_allowed
              ~record_suppression_metric:true ~allowed_tool_names turn_affordances)
   in
+  let satisfied_required_tool_names () =
+    acc.tool_calls
+    |> List.map (fun (detail : tool_call_detail) ->
+      detail.tool_name, detail.outcome)
+    |> satisfied_required_tool_names_of_outcomes
+  in
   let compute_tool_surface ~turn ~messages ~current_tool_choice ~decay_discovered
       : computed_tool_surface =
     let last_user_text =
@@ -715,11 +721,23 @@ let prepare_agent_setup
         ~discovered
 
     in
-    let required_tool_names =
+    let required_tool_names_raw =
       required_tool_names_for_turn
         ~current_task_required_tool_names:(current_task_required_tools ())
         ~per_call_required_tool_names:required_tool_names
       |> Keeper_types.dedupe_keep_order
+    in
+    let required_tool_names =
+      outstanding_required_tool_names
+        ~required_tool_names:required_tool_names_raw
+        ~satisfied_tool_names:(satisfied_required_tool_names ())
+    in
+    let current_tool_choice =
+      match current_tool_choice with
+      | Some (Agent_sdk.Types.Any | Agent_sdk.Types.Tool _)
+        when required_tool_names_raw <> [] && required_tool_names = [] ->
+        None
+      | _ -> current_tool_choice
     in
     let visible_required_tool_names =
       required_tool_names

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -7712,14 +7712,11 @@ let test_preferred_tool_choice_for_required_turn_claims_first () =
        ~allowed_tool_names:
          [ "keeper_board_curation_submit"; "keeper_board_post" ]
    with
-   | Agent_sdk.Types.Tool name ->
-       check string
-         "product/design per-call board post is not hijacked by stale curation"
-         "keeper_board_post" name
+   | Agent_sdk.Types.Any -> ()
    | other ->
        fail
          (Printf.sprintf
-            "expected Tool keeper_board_post for product/design reprobe, got %s"
+            "expected Any for product/design reprobe required tool, got %s"
             (Agent_sdk.Types.show_tool_choice other)));
   check (list string)
     "active task required tools remain when no per-call requirement exists"
@@ -7762,12 +7759,21 @@ let test_preferred_tool_choice_for_required_turn_claims_first () =
        ~allowed_tool_names:
          [ "keeper_board_curation_submit"; "keeper_board_post" ]
    with
-   | Agent_sdk.Types.Tool name ->
-       check string "single per-call required tool is forced"
-         "keeper_board_post" name
+   | Agent_sdk.Types.Any -> ()
+   | other ->
+       fail (Printf.sprintf "expected Any for single required tool, got %s"
+               (Agent_sdk.Types.show_tool_choice other)));
+  (match
+     Surface.preferred_tool_choice_for_required_tool_names
+       ~required_tool_names:[ "keeper_pr_create" ]
+       ~allowed_tool_names:[ "keeper_pr_create"; "keeper_bash" ]
+   with
+   | Agent_sdk.Types.Any -> ()
    | other ->
        fail
-         (Printf.sprintf "expected Tool keeper_board_post, got %s"
+         (Printf.sprintf
+            "expected Any for keeper_pr_create to avoid raw require_specific_tool \
+             MCP-prefix mismatches, got %s"
             (Agent_sdk.Types.show_tool_choice other)));
   (match
      Surface.preferred_tool_choice_for_required_tool_names
@@ -7797,13 +7803,11 @@ let test_preferred_tool_choice_for_required_turn_claims_first () =
        ~required_tool_names:[ "keeper_tasks_audit"; "keeper_board_post" ]
        ~allowed_tool_names:[ "keeper_tasks_audit"; "keeper_board_post" ]
    with
-   | Agent_sdk.Types.Tool name ->
-       check string "active required tool remains forced" "keeper_board_post"
-         name
+   | Agent_sdk.Types.Any -> ()
    | other ->
        fail
          (Printf.sprintf
-            "expected Tool keeper_board_post for mixed passive/active required \
+            "expected Any for mixed passive/active required \
              tools, got %s"
             (Agent_sdk.Types.show_tool_choice other)));
   (* Active task keeper retains the strict gate even without a

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -7727,6 +7727,35 @@ let test_preferred_tool_choice_for_required_turn_claims_first () =
     (Surface.required_tool_names_for_turn
        ~current_task_required_tool_names:[ "keeper_board_curation_submit" ]
        ~per_call_required_tool_names:[]);
+  check (list string)
+    "satisfied per-call required tool is not forced again"
+    []
+    (Surface.outstanding_required_tool_names
+       ~required_tool_names:[ "keeper_pr_review_comment" ]
+       ~satisfied_tool_names:[ "keeper_pr_review_comment" ]);
+  check (list string)
+    "unsatisfied required tool remains outstanding"
+    [ "keeper_board_post" ]
+    (Surface.outstanding_required_tool_names
+       ~required_tool_names:
+         [ "keeper_pr_review_comment"; "keeper_board_post" ]
+       ~satisfied_tool_names:[ "keeper_pr_review_comment" ]);
+  check (list string)
+    "failed required tool call remains outstanding"
+    [ "keeper_pr_review_comment" ]
+    (Surface.outstanding_required_tool_names
+       ~required_tool_names:[ "keeper_pr_review_comment" ]
+       ~satisfied_tool_names:
+         (Surface.satisfied_required_tool_names_of_outcomes
+            [ "keeper_pr_review_comment", "error" ]));
+  check (list string)
+    "successful required tool call is satisfied"
+    []
+    (Surface.outstanding_required_tool_names
+       ~required_tool_names:[ "keeper_pr_review_comment" ]
+       ~satisfied_tool_names:
+         (Surface.satisfied_required_tool_names_of_outcomes
+            [ "keeper_pr_review_comment", "ok" ]));
   (match
      Surface.preferred_tool_choice_for_required_tool_names
        ~required_tool_names:[ "keeper_board_post" ]


### PR DESCRIPTION
## Summary

Fixes the remaining runtime-contract half of #14021.

A `masc_keeper_msg` request can pass `required_tools` such as `keeper_pr_review_comment`. During a multi-turn OAS `Agent.run`, the first internal turn may successfully call the required tool, but later internal turns were still given the same required-tool surface and `tool_choice`. That let OAS fail the overall async result with a required-tool contract error after the evidence-producing tool call had already succeeded.

This change tracks successful keeper tool calls inside the current `Agent.run` and removes already-satisfied required tools from later per-turn tool surfaces. If the required list is fully satisfied, stale `Any` or specific `Tool` choices from that required-tool path are cleared so the final text or state turn can complete normally.

Follow-up: explicit per-message `required_tools` now use provider-level `Any` rather than exact `Tool(name)`. Runtime MCP providers can report names like `mcp__masc__keeper_pr_create`; OAS exact-tool contracts compare raw names before MASC canonicalizes them, so a correct PR tool call could still fail as `require_specific_tool(...)`. MASC keeps the exact required-tool validation after execution and adds a `[REQUIRED TOOLS]` system-context nudge to preserve model guidance.

## Impact

- Prevents false async `masc_keeper_msg_result` failures after a successful required tool call.
- Prevents `require_specific_tool(keeper_pr_create|keeper_pr_review_comment)` failures caused by MCP-prefixed raw tool names.
- Keeps unsatisfied required tools strict; only successful keeper tools that can satisfy required-tool contracts are removed from the outstanding set.
- Preserves existing required-tool gate ordering before last-turn relaxation.

## Validation

- `git diff --check`
- `scripts/dune-local.sh build test/test_keeper_unified.exe test/test_ci_hardening_source.exe`
- `./_build/default/test/test_keeper_unified.exe test tool_classification`
- `./_build/default/test/test_ci_hardening_source.exe`

## Residual risk

- Draft/human policy gate remains expected for this `agent-pr` PR until a human applies the required bypass label.