### PR TITLE
fix(main): pass board detail config in standalone route

### DIFF
--- a/bin/main_eio.ml
+++ b/bin/main_eio.ml
@@ -393,9 +393,12 @@ let dispatch_route ~routes ~request ~path reqd =
       let post_id = String.sub p 14 (String.length p - 14) in
       let format = Option.value ~default:"nested" (query_param request "format") in
       let voter = board_voter_query request in
+      let config =
+        Option.map (fun state -> state.Mcp_server.room_config) !server_state
+      in
       let (status, body) =
         board_post_detail_json ~include_moderation:false ~blind_votes:false
-          ~voter ~response_format:format ~post_id
+          ~config ~voter ~response_format:format ~post_id
       in
       Http.Response.json ~status body reqd
   | _ -> Http.Router.dispatch routes request reqd


### PR DESCRIPTION
## What changed

- Pass the active room config from `!server_state` into the standalone `bin/main_eio.ml` `/api/v1/board/<post_id>` route before calling `board_post_detail_json`.

## Why

`board_post_detail_json` now requires `config:Coord.config option`. The H2 and extracted HTTP routes already pass config, but the standalone main entry route still used the older call shape, which breaks `bin/main_eio.exe` builds. Reading the config from `server_state` keeps the standalone route aligned with the other board detail surfaces.

## Validation

- `git diff --check`
- `scripts/dune-local.sh build bin/main_eio.exe`