### PR TITLE
fix: count execution cache invalidation failures

### DIFF
--- a/lib/server/server_dashboard_http_execution_surfaces.ml
+++ b/lib/server/server_dashboard_http_execution_surfaces.ml
@@ -112,13 +112,38 @@ let _execution_cache =
     release) routed through [observe_task_transition].
     Best-effort: never raises — cache staleness must not break
     the mutation path. *)
+let record_invalidation_failure ~callback ~message exn =
+  Prometheus.inc_counter
+    Prometheus.metric_keeper_lifecycle_callback_failures
+    ~labels:[ ("callback", callback) ]
+    ();
+  Log.Dashboard.error "%s: %s" message (Printexc.to_string exn)
+
+let invalidate_execution_cache_with_hooks_for_testing
+    ~invalidate_execution_surface
+    ~invalidate_light_cache
+    () =
+  (try invalidate_execution_surface () with
+   | Eio.Cancel.Cancelled _ as e -> raise e
+   | exn ->
+       record_invalidation_failure
+         ~callback:"execution_surface_cache_invalidate"
+         ~message:"Failed to invalidate execution surface cache"
+         exn);
+  (try invalidate_light_cache () with
+   | Eio.Cancel.Cancelled _ as e -> raise e
+   | exn ->
+       record_invalidation_failure
+         ~callback:"dashboard_execution_light_cache_invalidate"
+         ~message:"Failed to invalidate dashboard execution cache"
+         exn)
+
 let invalidate_execution_cache () =
-  (try invalidate_cached_surface _execution_cache with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
-     Log.Dashboard.error "Failed to invalidate execution surface cache: %s"
-       (Printexc.to_string exn));
-  (try Dashboard_cache.invalidate "execution:default:light" with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
-     Log.Dashboard.error "Failed to invalidate dashboard execution cache: %s"
-       (Printexc.to_string exn))
+  invalidate_execution_cache_with_hooks_for_testing
+    ~invalidate_execution_surface:(fun () -> invalidate_cached_surface _execution_cache)
+    ~invalidate_light_cache:(fun () ->
+      Dashboard_cache.invalidate "execution:default:light")
+    ()
 
 (** Bypass the proactive warm-up guard so tests that call
     [dashboard_namespace_truth_http_json] get the full response instead of

--- a/lib/server/server_dashboard_http_execution_surfaces.mli
+++ b/lib/server/server_dashboard_http_execution_surfaces.mli
@@ -97,8 +97,17 @@ val execution_actor_for_request :
 val invalidate_execution_cache : unit -> unit
 (** Drops the cached execution surface so the next
     snapshot read recomputes from upstream.  Swallows
-    [Eio.Cancel.Cancelled] re-raise plus logs other
-    exceptions through [Log.Dashboard.error]. *)
+    [Eio.Cancel.Cancelled] re-raise plus logs and counts other
+    exceptions through
+    {!Prometheus.metric_keeper_lifecycle_callback_failures}. *)
+
+val invalidate_execution_cache_with_hooks_for_testing :
+  invalidate_execution_surface:(unit -> unit) ->
+  invalidate_light_cache:(unit -> unit) ->
+  unit ->
+  unit
+(** Test seam for the best-effort invalidation failure path. Production
+    callers should use {!invalidate_execution_cache}. *)
 
 val patch_keeper_dependent_caches :
   keeper_name:string -> event:string -> unit

--- a/test/test_dashboard_execution.ml
+++ b/test/test_dashboard_execution.ml
@@ -933,6 +933,30 @@ let test_patch_keeper_dependent_caches_tolerates_null_agent () =
       true
       (row |> member "keepalive_running" |> to_bool))
 
+let callback_metric_value callback =
+  Lib.Prometheus.metric_value_or_zero
+    Lib.Prometheus.metric_keeper_lifecycle_callback_failures
+    ~labels:[ ("callback", callback) ]
+    ()
+
+let test_invalidate_execution_cache_counts_failures () =
+  let surface_callback = "execution_surface_cache_invalidate" in
+  let light_callback = "dashboard_execution_light_cache_invalidate" in
+  let before_surface = callback_metric_value surface_callback in
+  let before_light = callback_metric_value light_callback in
+  Lib.Server_dashboard_http.invalidate_execution_cache_with_hooks_for_testing
+    ~invalidate_execution_surface:(fun () ->
+      raise (Failure "synthetic surface invalidation failure"))
+    ~invalidate_light_cache:(fun () ->
+      raise (Failure "synthetic light invalidation failure"))
+    ();
+  check (float 0.0001) "surface invalidation failure counted"
+    (before_surface +. 1.0)
+    (callback_metric_value surface_callback);
+  check (float 0.0001) "light invalidation failure counted"
+    (before_light +. 1.0)
+    (callback_metric_value light_callback)
+
 let test_patch_surface_json_for_running_keepers_tolerates_null_agent () =
   let dir = test_dir () in
   Fun.protect
@@ -1033,6 +1057,8 @@ let () =
             test_dashboard_execution_queue_surfaces_keeper_runtime_trust;
           Alcotest.test_case "execution trust surfaces coverage gap health" `Quick
             test_execution_trust_surfaces_coverage_gap_health;
+          Alcotest.test_case "cache invalidation failures are counted" `Quick
+            test_invalidate_execution_cache_counts_failures;
           Alcotest.test_case "lifecycle patch tolerates null agent" `Quick
             test_patch_keeper_dependent_caches_tolerates_null_agent;
           Alcotest.test_case "running keeper patch tolerates null agent" `Quick


### PR DESCRIPTION
## Summary
- count dashboard execution cache invalidation failures through the existing callback-failure metric
- keep cancellation re-raising and best-effort invalidation behavior intact
- add focused dashboard execution regression for both invalidation paths

## Verification
- git diff --check HEAD~1..HEAD
- lockf -k -t 1200 /tmp/me-dune-local.lock env MASC_DUNE_LOCK_HELD=1 MASC_SKIP_OPAM_LOCK=1 DUNE_JOBS=1 DUNE_CACHE=disabled scripts/dune-local.sh build test/test_dashboard_execution.exe
- env MASC_ALLOW_REPO_CONFIG_FALLBACK=true ./_build/default/test/test_dashboard_execution.exe test read_model 10,14
- env MASC_ALLOW_REPO_CONFIG_FALLBACK=true ./_build/default/test/test_dashboard_execution.exe