### PR TITLE
diag: add OAS hang tail baseline columns

### DIFF
--- a/scripts/diag-keeper-cycle.sh
+++ b/scripts/diag-keeper-cycle.sh
@@ -8,7 +8,8 @@
 #
 # Usage: diag-keeper-cycle.sh [--base-path PATH] [--keeper NAME]
 #                             [--window-min N] [--top-gaps N]
-# Exit codes: 0 ok, 2 base path missing, 3 jq missing.
+#                             [--tail-min N]
+# Exit codes: 0 ok, 2 base path missing, 3 jq missing, 4 no files.
 
 set -euo pipefail
 
@@ -16,6 +17,7 @@ BASE_PATH="${MASC_BASE_PATH:-${ME_ROOT:-$HOME/me}}"
 KEEPER_FILTER=""
 WINDOW_MIN=60
 TOP_GAPS=5
+TAIL_MIN=30
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -23,6 +25,7 @@ while [[ $# -gt 0 ]]; do
     --keeper)    KEEPER_FILTER="$2"; shift 2 ;;
     --window-min) WINDOW_MIN="$2"; shift 2 ;;
     --top-gaps)  TOP_GAPS="$2"; shift 2 ;;
+    --tail-min)  TAIL_MIN="$2"; shift 2 ;;
     -h|--help)
       sed -n '2,12p' "$0"; exit 0 ;;
     *) echo "unknown flag: $1" >&2; exit 64 ;;
@@ -35,9 +38,15 @@ KEEPERS_DIR="$BASE_PATH/.masc/keepers"
 
 NOW="$(date +%s)"
 WINDOW_AGO=$((NOW - WINDOW_MIN * 60))
+TAIL_SEC=$((TAIL_MIN * 60))
 
 if [[ -n "$KEEPER_FILTER" ]]; then
-  files=( "$KEEPERS_DIR/$KEEPER_FILTER.decisions.jsonl" )
+  filter_file="$KEEPERS_DIR/$KEEPER_FILTER.decisions.jsonl"
+  if [[ ! -f "$filter_file" ]]; then
+    echo "no decision file for keeper '$KEEPER_FILTER' at $filter_file" >&2
+    exit 4
+  fi
+  files=( "$filter_file" )
 else
   files=()
   while IFS= read -r line; do files+=( "$line" ); done < <(
@@ -45,23 +54,40 @@ else
   )
 fi
 
-printf '%-14s %6s %6s %6s %6s %6s %8s %8s %8s %8s %s\n' \
-  KEEPER TOTAL OK ERR NULL RECENT P50_S P95_S MAX_S SILENT_MIN TOP_GAPS_MIN
-printf '%s\n' "------------------------------------------------------------------------------------------------------------"
+if [[ ${#files[@]} -eq 0 ]]; then
+  echo "no keeper decision files at $KEEPERS_DIR" >&2
+  exit 4
+fi
+
+tail_header="R_GT_${TAIL_MIN}M"
+printf '%-14s %6s %6s %6s %6s %6s %8s %8s %8s %8s %8s %8s %8s %8s %s\n' \
+  KEEPER TOTAL OK ERR NULL RECENT P50_S P95_S MAX_S R_P50_S R_P95_S \
+  R_MAX_S "$tail_header" SILENT_MIN TOP_GAPS_MIN
+printf '%s\n' "------------------------------------------------------------------------------------------------------------------------------------------------"
 
 for f in "${files[@]}"; do
   [[ -f "$f" ]] || continue
   name="$(basename "$f" .decisions.jsonl)"
 
-  read -r total ok err nul recent p50 p95 mx silent gaps_csv < <(
-    jq -sr --argjson now "$NOW" --argjson cutoff "$WINDOW_AGO" --argjson topn "$TOP_GAPS" '
-      def safe_lat: (.latency_ms // 0) / 1000;
+  read -r total ok err nul recent p50 p95 mx recent_p50 recent_p95 recent_mx recent_tail silent gaps_csv < <(
+    jq -sr \
+      --argjson now "$NOW" \
+      --argjson cutoff "$WINDOW_AGO" \
+      --argjson topn "$TOP_GAPS" \
+      --argjson tail_sec "$TAIL_SEC" \
+      '
+      def n: (. // 0 | tonumber? // 0);
+      def safe_lat: (.latency_ms | n) / 1000;
+      def ts_value: (.ts_unix | n);
       def percentile($p):
         if length == 0 then 0 else
           sort | .[(length * $p / 100 | floor) | if . >= length then length-1 else . end]
         end;
       ( . ) as $all
-      | ([ .[] | .ts_unix // 0 ] | sort) as $ts
+      | ([ .[] | ts_value ] | sort) as $ts
+      | ([ $all[] | select(ts_value >= $cutoff) ]) as $recent_rows
+      | ([ $all[] | safe_lat ]) as $latencies
+      | ([ $recent_rows[] | safe_lat ]) as $recent_latencies
       | (
           [range(1; $ts | length) | ($ts[.] - $ts[.-1])]
           | map(select(. > 0))
@@ -72,10 +98,14 @@ for f in "${files[@]}"; do
           ([ .[] | select(.outcome == "success") ] | length),
           ([ .[] | select(.outcome == "error") ] | length),
           ([ .[] | select(.outcome == null) ] | length),
-          ([ .[] | select((.ts_unix // 0) >= $cutoff) ] | length),
-          ([ .[] | safe_lat ] | percentile(50)),
-          ([ .[] | safe_lat ] | percentile(95)),
-          ([ .[] | safe_lat ] | max // 0),
+          ($recent_rows | length),
+          ($latencies | percentile(50)),
+          ($latencies | percentile(95)),
+          ($latencies | max // 0),
+          ($recent_latencies | percentile(50)),
+          ($recent_latencies | percentile(95)),
+          ($recent_latencies | max // 0),
+          ([ $recent_latencies[] | select(. >= $tail_sec) ] | length),
           (if $last_ts > 0 then (($now - $last_ts) / 60) else -1 end),
           ($gaps | sort | reverse | .[0:$topn] | map(. / 60 | floor) | join(","))
         ]
@@ -83,9 +113,10 @@ for f in "${files[@]}"; do
     ' "$f"
   )
 
-  printf '%-14s %6s %6s %6s %6s %6s %8.1f %8.1f %8.1f %8.1f %s\n' \
+  printf '%-14s %6s %6s %6s %6s %6s %8.1f %8.1f %8.1f %8.1f %8.1f %8.1f %8s %8.1f %s\n' \
     "$name" "$total" "$ok" "$err" "$nul" "$recent" \
-    "$p50" "$p95" "$mx" "$silent" "$gaps_csv"
+    "$p50" "$p95" "$mx" "$recent_p50" "$recent_p95" "$recent_mx" \
+    "$recent_tail" "$silent" "$gaps_csv"
 done
 
 echo
@@ -93,5 +124,7 @@ echo "Legend:"
 echo "  TOTAL/OK/ERR/NULL  decision count by outcome"
 echo "  RECENT             decisions in last ${WINDOW_MIN}m"
 echo "  P50/P95/MAX_S      latency seconds across all decisions"
+echo "  R_*                latency seconds inside the selected window"
+echo "  R_GT_${TAIL_MIN}M          recent decisions at or above ${TAIL_MIN} minutes latency"
 echo "  SILENT_MIN         minutes since last decision (-1 = no data)"
 echo "  TOP_GAPS_MIN       largest gaps between decisions (minutes), top ${TOP_GAPS}"


### PR DESCRIPTION
## Summary

- add `--tail-min` to `scripts/diag-keeper-cycle.sh` with a default 30-minute tail threshold
- keep the existing all-time latency columns and add selected-window `R_P50_S`, `R_P95_S`, `R_MAX_S`, and `R_GT_<N>M` columns
- return exit 4 when a keeper filter or base path has no decision files instead of emitting a header-only successful report

## Why

#11929 still needs a bounded 24h hang baseline and post-guard 30-minute tail verification. Before this change, `RECENT` was window-scoped but the latency percentiles and max were all-time, so operators could not directly answer whether the current window still has >30 minute OAS keeper turns.

[근거] `gh issue view 11929 --repo jeong-sik/masc-mcp --comments --json number,state,title,comments,url` 확인일시 2026-05-07T11:26:57+0900 신뢰도 High: the open issue comments still leave live hang baseline measurement and 30-minute tail verification as remaining H5 work.

[근거] `scripts/diag-keeper-cycle.sh --base-path /Users/dancer/me --window-min 1440 --tail-min 30 --top-gaps 1` 확인일시 2026-05-07T11:26:57+0900 신뢰도 Medium: local live base path emitted the new `R_*` columns; current 24h `R_GT_30M` was 0 while all-time max values still show the historical 1170s-3602s tail.

## Validation

- `bash -n scripts/diag-keeper-cycle.sh`
- `shellcheck scripts/diag-keeper-cycle.sh`
- `scripts/diag-keeper-cycle.sh --help`
- `scripts/diag-keeper-cycle.sh --base-path /Users/dancer/me --window-min 1440 --tail-min 30 --top-gaps 1`
- empty keeper directory smoke: exits 4 with `no keeper decision files ...`
- `git diff --check`
- `git diff --cached --check`