### PR TITLE
fix: count eval harness callback failures

### DIFF
--- a/lib/eval_calibration.ml
+++ b/lib/eval_calibration.ml
@@ -220,10 +220,16 @@ let record_verdict
   Dated_jsonl.append (get_store ()) (verdict_record_to_json record);
   match on_harness_verdict with
   | Some cb ->
-    (try cb (to_harness_verdict record)
-     with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
-       Log.Harness.warn "[eval_calibration] on_harness_verdict callback failed: %s"
-         (Printexc.to_string exn))
+    (match
+       Telemetry_observe.observe_or_fail
+         ~kind:"eval_calibration_harness_verdict_callback"
+         (fun () -> cb (to_harness_verdict record))
+     with
+     | Ok () -> ()
+     | Error msg ->
+       Log.Harness.warn
+         "[eval_calibration] on_harness_verdict callback failed: %s"
+         msg)
   | None -> ()
 
 let record_human_label

--- a/test/test_eval_calibration.ml
+++ b/test/test_eval_calibration.ml
@@ -408,12 +408,27 @@ let test_on_harness_verdict_exception_safe () =
   Cal.set_store_for_testing ~base_dir:dir;
   let req = make_req () in
   let result = make_result () in
+  let metric_labels =
+    [ ("kind", "eval_calibration_harness_verdict_callback") ]
+  in
+  let before =
+    Masc_mcp.Prometheus.metric_value_or_zero
+      Masc_mcp.Prometheus.metric_telemetry_observe_failures
+      ~labels:metric_labels
+      ()
+  in
   Cal.record_verdict ~task_id:"exc-1" ~req ~result
     ~on_harness_verdict:(fun _hv -> failwith "boom") ();
   let store = Cal.get_store () in
   let records = Dated_jsonl.read_recent store 10 in
   check bool "record persisted despite callback failure" true
     (List.length records >= 1);
+  check (float 0.0001) "callback failure counted"
+    (before +. 1.0)
+    (Masc_mcp.Prometheus.metric_value_or_zero
+       Masc_mcp.Prometheus.metric_telemetry_observe_failures
+       ~labels:metric_labels
+       ());
   Cal.reset_store_for_testing ()
 
 (* ================================================================ *)


### PR DESCRIPTION
## Summary
- route eval harness verdict callback failures through Telemetry_observe so callback exceptions are counted
- preserve cancellation re-raise and non-fatal record persistence behavior
- extend eval calibration regression to assert the telemetry failure counter increments

## Verification
- git diff --check
- lockf -k -t 1200 /tmp/me-dune-local.lock env MASC_DUNE_LOCK_HELD=1 MASC_SKIP_OPAM_LOCK=1 DUNE_JOBS=1 DUNE_CACHE=disabled scripts/dune-local.sh build test/test_eval_calibration.exe
- ./_build/default/test/test_eval_calibration.exe