### PR TITLE
proof(create): Docker PR lifecycle proof run keeper-docker-pr-lifecycle-gitbase-full-20260507-0507c-live

### DIFF
--- a/docs/runtime-proof/keepers/analyst-keeper-docker-pr-lifecycle-gitbase-full-20260507-0507c-live.md
+++ b/docs/runtime-proof/keepers/analyst-keeper-docker-pr-lifecycle-gitbase-full-20260507-0507c-live.md
@@ -1,0 +1,15 @@
+# Docker PR Lifecycle Proof
+
+## Metadata
+
+- **run_id**: keeper-docker-pr-lifecycle-gitbase-full-20260507-0507c-live
+- **branch**: keeper-analyst-agent/keeper-docker-pr-lifecycle-gitbase-full-20260507-0507c-live
+- **keeper**: analyst
+- **phase**: create
+- **sandbox_profile**: docker
+- **github_account**: anyang-keepers
+
+## Purpose
+
+This file verifies that a Docker-backed keeper can create a proof branch, push
+commits, and open a draft PR through the brokered GitHub credential route.


### PR DESCRIPTION
## Docker PR Lifecycle Proof — Create Phase

- **run_id**: `keeper-docker-pr-lifecycle-gitbase-full-20260507-0507c-live`
- **keeper**: `analyst`
- **sandbox_profile**: `docker`
- **github_account**: `anyang-keepers`

This is a non-product proof file verifying that a Docker-backed keeper can:
1. Create an isolated worktree and branch
2. Commit and push through the Docker sandbox
3. Open a draft PR via the brokered GitHub credential route

Do not merge. Do not mark ready for review.