### PR TITLE
fix(audit): correlate redacted keeper tool calls

### DIFF
--- a/scripts/audit-keeper-fleet-readiness.py
+++ b/scripts/audit-keeper-fleet-readiness.py
@@ -366,6 +366,16 @@ def pr_ref_texts_from_structured_output(row: dict[str, Any]) -> list[str]:
             texts.append(f"PR#{value}")
         elif isinstance(value, str) and value.strip().isdigit():
             texts.append(f"PR#{value.strip()}")
+    route_evidence = dict_field(row, "route_evidence")
+    if route_evidence is not None:
+        for key in ("pr_url", "pull_request_url", "url", "html_url"):
+            texts.append(text_field(route_evidence, key))
+        for key in ("pr_number", "number"):
+            value = route_evidence.get(key)
+            if isinstance(value, int) and value > 0:
+                texts.append(f"PR#{value}")
+            elif isinstance(value, str) and value.strip().isdigit():
+                texts.append(f"PR#{value.strip()}")
     return [text for text in texts if text]
 
 
@@ -391,7 +401,32 @@ def row_mentions_evidence_run_id(
         haystack = json.dumps(row, ensure_ascii=False, sort_keys=True)
     except (TypeError, ValueError):
         haystack = str(row)
-    return evidence_run_id.lower() in haystack.lower()
+    haystack = haystack.lower()
+    return any(alias in haystack for alias in evidence_run_id_aliases(evidence_run_id))
+
+
+def evidence_run_id_aliases(evidence_run_id: str) -> set[str]:
+    raw = evidence_run_id.strip().lower()
+    aliases = {raw}
+    parts = [part for part in re.split(r"[^a-z0-9]+", raw) if part]
+    date_index = next(
+        (
+            index
+            for index, part in enumerate(parts)
+            if re.fullmatch(r"20[0-9]{6}", part)
+        ),
+        None,
+    )
+    if date_index is not None and date_index > 0 and date_index + 1 < len(parts):
+        suffix = "-".join(parts[date_index + 1 :])
+        prefix = parts[:date_index]
+        aliases.add("-".join(prefix + [suffix]))
+        for index in range(len(prefix) - 1, -1, -1):
+            if any(char.isdigit() for char in prefix[index]):
+                aliases.add("-".join([prefix[index], suffix]))
+                aliases.add("-".join(prefix[index:] + [suffix]))
+                break
+    return {alias for alias in aliases if len(alias) >= 8}
 
 
 def pr_numbers_from_text(text: str) -> set[int]:
@@ -1062,6 +1097,70 @@ def pr_action_metric_paths(
     return [path for _, _, path in sorted(candidates, reverse=True)]
 
 
+def keeper_run_correlation_paths(
+    base_path: Path, name: str, *, min_day_key: int | None = None
+) -> list[Path]:
+    root = base_path / ".masc" / "keepers" / name
+    paths = decision_log_paths(base_path, name)
+    for subdir in ("metrics", "pr-action-metrics", "execution-receipts"):
+        base = root / subdir
+        if not base.is_dir():
+            continue
+        for path in sorted(path for path in base.rglob("*.jsonl") if path.is_file()):
+            day_key = pr_action_metric_day_key(path)
+            if (
+                min_day_key is not None
+                and day_key is not None
+                and day_key < min_day_key
+            ):
+                continue
+            paths.append(path)
+    return paths
+
+
+def trace_session_ids_from_row(row: dict[str, Any]) -> set[str]:
+    ids: set[str] = set()
+
+    def add(value: Any) -> None:
+        if isinstance(value, str) and value.strip():
+            ids.add(value.strip())
+
+    for container in (
+        row,
+        dict_field(row, "runtime_contract"),
+        dict_field(row, "route_evidence"),
+        dict_field(row, "action_radius"),
+    ):
+        if container is None:
+            continue
+        add(container.get("trace_id"))
+        add(container.get("session_id"))
+    return ids
+
+
+def collect_run_correlation_ids(
+    base_path: Path,
+    name: str,
+    *,
+    evidence_run_id: str | None,
+    min_metric_ts: float | None,
+    min_metric_day_key: int | None,
+) -> set[str]:
+    if not evidence_run_id:
+        return set()
+    ids: set[str] = set()
+    for path in keeper_run_correlation_paths(
+        base_path, name, min_day_key=min_metric_day_key
+    ):
+        for row in iter_jsonl(path):
+            ts = numeric_field(row, "ts_unix") or numeric_field(row, "ts")
+            if min_metric_ts is not None and ts is not None and ts < min_metric_ts:
+                continue
+            if row_mentions_evidence_run_id(row, evidence_run_id):
+                ids.update(trace_session_ids_from_row(row))
+    return ids
+
+
 def pr_creation_scan_paths(base_path: Path, name: str) -> list[Path]:
     root = base_path / ".masc"
     paths: list[Path] = decision_log_paths(base_path, name)
@@ -1286,6 +1385,13 @@ def scan_keeper_evidence(
             max_silence_hours * 3600.0
         )
         min_metric_day_key = day_key_from_unix(min_metric_ts)
+    run_correlation_ids = collect_run_correlation_ids(
+        base_path,
+        name,
+        evidence_run_id=evidence_run_id,
+        min_metric_ts=min_metric_ts,
+        min_metric_day_key=min_metric_day_key,
+    )
     for decisions in decision_log_paths(base_path, name):
         for row in iter_jsonl(decisions):
             ts = numeric_field(row, "ts_unix")
@@ -1338,9 +1444,13 @@ def scan_keeper_evidence(
                 tool = row.get("tool")
                 if isinstance(tool, str):
                     tools.add(tool)
-                if row_matches_evidence_scope(
+                scope_matches = row_matches_evidence_scope(
                     row, evidence_run_id, evidence_run_pr_numbers, evidence_windows
-                ):
+                )
+                trace_matches = run_correlation_ids.intersection(
+                    trace_session_ids_from_row(row)
+                )
+                if scope_matches or trace_matches:
                     row_evidence, row_docker_evidence = (
                         pr_lifecycle_evidence_from_tool_call(row)
                     )

--- a/test/test_audit_keeper_fleet_readiness.py
+++ b/test/test_audit_keeper_fleet_readiness.py
@@ -475,6 +475,24 @@ class AuditKeeperFleetReadinessTest(unittest.TestCase):
         self.assertEqual(evidence, set())
         self.assertEqual(docker_evidence, set())
 
+    def test_pr_creation_evidence_reads_route_evidence_pr_url(self):
+        row = {
+            "_source_path": "tool_calls.jsonl",
+            "tool": "keeper_pr_create",
+            "success": True,
+            "route_evidence": {
+                "pr_url": "https://github.com/acme/repo/pull/42\n",
+                "via": "docker",
+            },
+        }
+
+        refs, sources = audit.pr_evidence_from_row(row)
+
+        self.assertEqual(
+            refs, {"keeper_pr_create", "https://github.com/acme/repo/pull/42"}
+        )
+        self.assertEqual(sources, {"tool_calls.jsonl"})
+
     def test_scan_keeper_evidence_reads_rotated_decision_logs(self):
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
@@ -1175,6 +1193,112 @@ class AuditKeeperFleetReadinessTest(unittest.TestCase):
         self.assertEqual(tools, {"keeper_bash", "keeper_pr_create"})
         self.assertEqual(
             evidence, {"git_push:keeper_bash", "pr_create:keeper_pr_create"}
+        )
+        self.assertEqual(docker_evidence, evidence)
+
+    def test_scan_keeper_evidence_correlates_redacted_tool_calls_by_trace(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            calls_dir = root / ".masc" / "tool_calls" / "2026-05"
+            metrics_dir = root / ".masc" / "keepers" / "alpha" / "metrics" / "2026-05"
+            calls_dir.mkdir(parents=True)
+            metrics_dir.mkdir(parents=True)
+            run_id = "keeper-docker-pr-lifecycle-14031-smoke-20260507-codex1"
+            trace_id = "trace-current-run"
+            metric_rows = [
+                {
+                    "ts_unix": 45.0,
+                    "name": "alpha",
+                    "trace_id": trace_id,
+                    "continuity_summary": (
+                        "Goal: Docker PR lifecycle proof create-phase "
+                        "for run 14031-codex1"
+                    ),
+                }
+            ]
+            call_rows = [
+                {
+                    "ts": 50.0,
+                    "keeper": "alpha",
+                    "tool": "keeper_bash",
+                    "trace_id": "trace-other-run",
+                    "session_id": "trace-other-run",
+                    "input": {"cmd": "git push -u origin [REDACTED]"},
+                    "output": json.dumps({"ok": True, "via": "docker"}),
+                    "success": True,
+                },
+                {
+                    "ts": 55.0,
+                    "keeper": "alpha",
+                    "tool": "keeper_shell",
+                    "trace_id": "trace-other-run",
+                    "session_id": "trace-other-run",
+                    "input": {"op": "gh", "cmd": "pr review 99 --approve"},
+                    "output": json.dumps(
+                        {
+                            "ok": True,
+                            "command": "gh pr review 99 --approve",
+                            "via": "docker",
+                        }
+                    ),
+                    "success": True,
+                },
+                {
+                    "ts": 60.0,
+                    "keeper": "alpha",
+                    "tool": "keeper_bash",
+                    "trace_id": trace_id,
+                    "session_id": trace_id,
+                    "input": {"cmd": "git push -u origin [REDACTED]"},
+                    "output": json.dumps({"ok": True, "via": "docker"}),
+                    "success": True,
+                },
+                {
+                    "ts": 70.0,
+                    "keeper": "alpha",
+                    "tool": "keeper_pr_create",
+                    "runtime_contract": {
+                        "trace_id": trace_id,
+                        "session_id": trace_id,
+                    },
+                    "input": {"title": "proof"},
+                    "output": json.dumps(
+                        {
+                            "ok": True,
+                            "pr_url": "https://github.com/acme/repo/pull/42",
+                            "via": "docker",
+                        }
+                    ),
+                    "success": True,
+                },
+                {
+                    "ts": 80.0,
+                    "keeper": "beta",
+                    "tool": "keeper_pr_create",
+                    "trace_id": trace_id,
+                    "input": {"title": "wrong keeper"},
+                    "output": json.dumps({"ok": True, "via": "docker"}),
+                    "success": True,
+                },
+            ]
+            (metrics_dir / "07.jsonl").write_text(
+                "".join(json.dumps(row) + "\n" for row in metric_rows),
+                encoding="utf-8",
+            )
+            (calls_dir / "07.jsonl").write_text(
+                "".join(json.dumps(row) + "\n" for row in call_rows),
+                encoding="utf-8",
+            )
+
+            latest_ts, tools, evidence, docker_evidence = audit.scan_keeper_evidence(
+                root, "alpha", evidence_run_id=run_id
+            )
+
+        self.assertEqual(latest_ts, 70.0)
+        self.assertEqual(tools, {"keeper_bash", "keeper_shell", "keeper_pr_create"})
+        self.assertEqual(
+            evidence,
+            {"git_push:keeper_bash", "pr_create:keeper_pr_create"},
         )
         self.assertEqual(docker_evidence, evidence)
 


### PR DESCRIPTION
## Summary
- correlate run-scoped keeper metrics/receipts to redacted global tool_call rows by trace/session id
- accept date-stripped evidence run aliases like 14031-codex1 for generated proof summaries
- count PR URLs recorded in route_evidence.pr_url

## Rebase note
Rebased onto current `origin/main` (`f34a94b61b`) and resolved conflicts by preserving both current harness-window evidence scoping and this PRs trace/session-id correlation for redacted global tool-call rows.

## Validation
- `python3 -m py_compile scripts/audit-keeper-fleet-readiness.py test/test_audit_keeper_fleet_readiness.py`
- `python3 test/test_audit_keeper_fleet_readiness.py`
- `ruff check scripts/audit-keeper-fleet-readiness.py test/test_audit_keeper_fleet_readiness.py`
- `ruff format --check scripts/audit-keeper-fleet-readiness.py test/test_audit_keeper_fleet_readiness.py`
- `scripts/check-oas-pin.sh --local-only`
- `git diff --check`
- `git diff --check origin/main...HEAD`
- live #14031 smoke base summary: sangsu and qa-king now show Docker git_push + keeper_pr_create evidence and PR URLs; verifier remains blocked by the pre-existing egress/branch publish path

Refs #13920

Note: `pyright --outputjson scripts/audit-keeper-fleet-readiness.py test/test_audit_keeper_fleet_readiness.py` is unavailable in this shell (`command not found`).