### PR TITLE
fix(audit): require keeper web search evidence

### DIFF
--- a/docs/KEEPER-DOCKER-PR-LIFECYCLE-REPROBE.md
+++ b/docs/KEEPER-DOCKER-PR-LIFECYCLE-REPROBE.md
@@ -45,7 +45,9 @@ but lacked `build.commit`, also treated as transient). Only the first
 status records pending requests as lost; the other two log a transient
 notice and the next poll iteration retries.
 When mutation is enabled, the harness sends two sequential phases. The create phase
-requires `keeper_bash` and `keeper_pr_create`. Before it sends any mutation
+requires `masc_web_search`, `keeper_bash`, and `keeper_pr_create`, so each
+fresh proof run captures current-information behavior as well as Docker git/PR
+mutation evidence. Before it sends any mutation
 prompt, the harness checks the run-scoped proof branches and fails closed with
 `branch_collision_preflight` if a local branch, remote-tracking branch, remote
 head, or local worktree already exists for the selected `--run-id`. After the

--- a/scripts/audit-keeper-fleet-readiness.py
+++ b/scripts/audit-keeper-fleet-readiness.py
@@ -34,6 +34,10 @@ BOARD_TOOLS = {
     "keeper_board_list",
     "keeper_board_search",
 }
+WEB_SEARCH_TOOLS = {
+    "masc_web_search",
+    "WebSearch",
+}
 PR_SURFACE_TOOLS = {
     "keeper_bash",
     "keeper_shell",
@@ -106,6 +110,7 @@ class KeeperAudit:
     last_turn_age_hours: float | None
     recent_action: bool
     board_action: bool
+    web_search_action: bool
     product_action: bool
     design_action: bool
     pr_surface_action: bool
@@ -122,6 +127,7 @@ class KeeperAudit:
     pr_url_evidence: bool
     evidence_tools: list[str]
     board_post_evidence: list[str]
+    web_search_evidence: list[str]
     product_evidence: list[str]
     design_evidence: list[str]
     pr_lifecycle_evidence: list[str]
@@ -516,6 +522,99 @@ def tool_succeeded_in_row(row: dict[str, Any], tool_name: str) -> bool:
             if call.get("tool_name") == tool_name and call.get("outcome") == "ok":
                 return True
     return False
+
+
+def explicit_success(row: dict[str, Any]) -> bool:
+    for key in ("ok", "success"):
+        value = row.get(key)
+        if isinstance(value, bool):
+            return value
+    outcome = row.get("outcome")
+    if isinstance(outcome, str):
+        return outcome.lower() in {"ok", "success", "succeeded"}
+    output = output_json(row)
+    for key in ("ok", "success"):
+        value = output.get(key)
+        if isinstance(value, bool):
+            return value
+    status = output.get("status")
+    return isinstance(status, str) and status.lower() in {"ok", "success", "succeeded"}
+
+
+SECRETISH_QUERY_RE = re.compile(
+    r"(?i)\b(api[_-]?key|authorization|bearer|password|secret|token)\b"
+)
+
+
+def web_search_query_preview(row: dict[str, Any]) -> str | None:
+    candidates: list[Any] = [row.get("query")]
+    for key in ("args", "input", "params", "request"):
+        value = row.get(key)
+        if isinstance(value, dict):
+            candidates.append(value.get("query"))
+            candidates.append(value.get("q"))
+    for candidate in candidates:
+        if not isinstance(candidate, str):
+            continue
+        query = " ".join(candidate.split())
+        if not query:
+            continue
+        if SECRETISH_QUERY_RE.search(query):
+            return "[redacted]"
+        return query if len(query) <= 96 else f"{query[:93]}..."
+    return None
+
+
+def source_slug(source: str) -> str:
+    return re.sub(r"[^a-z0-9_.=-]+", "_", source.lower()).strip("_") or "unknown"
+
+
+def web_search_evidence_item(tool: str, row: dict[str, Any], source: str) -> str:
+    parts = [f"web_search:{tool}"]
+    query = web_search_query_preview(row)
+    if query:
+        parts.append(f"query={query}")
+    ts = numeric_field(row, "ts_unix") or numeric_field(row, "ts")
+    if ts is not None:
+        parts.append(f"ts={int(ts)}")
+    parts.append(f"source={source_slug(Path(source).name)}")
+    return ":".join(parts)
+
+
+def web_search_evidence_from_decision(row: dict[str, Any], source: str) -> set[str]:
+    if not row_succeeded(row):
+        return set()
+
+    evidence: set[str] = set()
+    tool = row.get("tool")
+    if isinstance(tool, str) and tool in WEB_SEARCH_TOOLS and explicit_success(row):
+        evidence.add(web_search_evidence_item(tool, row, source))
+
+    tools = set(tools_from_decision(row))
+    for tool_name in sorted(tools & WEB_SEARCH_TOOLS):
+        if explicit_success(row):
+            evidence.add(web_search_evidence_item(tool_name, row, source))
+
+    calls = row.get("tool_calls")
+    if isinstance(calls, list):
+        for call in calls:
+            if not isinstance(call, dict):
+                continue
+            name = call.get("tool_name") or call.get("tool")
+            if not isinstance(name, str) or name not in WEB_SEARCH_TOOLS:
+                continue
+            if explicit_success(call) or row_success(row):
+                evidence.add(web_search_evidence_item(name, call, source))
+    return evidence
+
+
+def web_search_evidence_from_tool_call(row: dict[str, Any], source: str) -> set[str]:
+    tool = row.get("tool")
+    if not isinstance(tool, str) or tool not in WEB_SEARCH_TOOLS:
+        return set()
+    if not explicit_success(row) or not row_succeeded(row):
+        return set()
+    return {web_search_evidence_item(tool, row, source)}
 
 
 MARKER_LIST_FIELDS = (
@@ -1184,12 +1283,60 @@ def scan_keeper_evidence(
     return latest_ts, tools, pr_lifecycle_evidence, docker_pr_lifecycle_evidence
 
 
+def scan_keeper_web_search_evidence(
+    base_path: Path,
+    name: str,
+    *,
+    max_silence_hours: float | None = None,
+    evidence_run_id: str | None = None,
+    now: float | None = None,
+) -> tuple[float | None, set[str]]:
+    latest_ts: float | None = None
+    evidence: set[str] = set()
+    min_ts: float | None = None
+    if max_silence_hours is not None:
+        min_ts = (time.time() if now is None else now) - (max_silence_hours * 3600.0)
+
+    def fresh_enough(row: dict[str, Any]) -> bool:
+        ts = numeric_field(row, "ts_unix") or numeric_field(row, "ts")
+        return ts is None or min_ts is None or ts >= min_ts
+
+    def observe_ts(row: dict[str, Any]) -> None:
+        nonlocal latest_ts
+        ts = numeric_field(row, "ts_unix") or numeric_field(row, "ts")
+        if ts is not None:
+            latest_ts = ts if latest_ts is None else max(latest_ts, ts)
+
+    for decisions in decision_log_paths(base_path, name):
+        for row in iter_jsonl(decisions):
+            if not fresh_enough(row):
+                continue
+            observe_ts(row)
+            if not row_mentions_evidence_run_id(row, evidence_run_id):
+                continue
+            evidence.update(web_search_evidence_from_decision(row, str(decisions)))
+
+    for calls in global_tool_call_paths(base_path):
+        for row in iter_jsonl(calls):
+            if row.get("keeper") != name:
+                continue
+            if not fresh_enough(row):
+                continue
+            observe_ts(row)
+            if not row_mentions_evidence_run_id(row, evidence_run_id):
+                continue
+            evidence.update(web_search_evidence_from_tool_call(row, str(calls)))
+
+    return latest_ts, evidence
+
+
 def audit_keeper(
     *,
     base_path: Path,
     config_path: Path,
     max_silence_hours: float,
     require_board_evidence: bool,
+    require_web_search_evidence: bool,
     require_product_evidence: bool,
     require_design_evidence: bool,
     require_pr_surface_evidence: bool,
@@ -1276,6 +1423,12 @@ def audit_keeper(
         evidence_run_pr_numbers=evidence_run_pr_numbers,
     )
     pr_creation_evidence = scan_pr_creation_evidence(base_path, name)
+    web_search_ts, web_search_evidence = scan_keeper_web_search_evidence(
+        base_path,
+        name,
+        max_silence_hours=max_silence_hours,
+        evidence_run_id=evidence_run_id,
+    )
     (
         board_post_ts,
         board_post_evidence,
@@ -1287,7 +1440,13 @@ def audit_keeper(
     last_turn_ts = max(
         (
             ts
-            for ts in (evidence_ts, board_post_ts, runtime_turn_ts, updated_ts)
+            for ts in (
+                evidence_ts,
+                board_post_ts,
+                web_search_ts,
+                runtime_turn_ts,
+                updated_ts,
+            )
             if ts is not None
         ),
         default=None,
@@ -1303,6 +1462,7 @@ def audit_keeper(
             failures.append("silence_window_exceeded")
 
     board_action = bool(tools & BOARD_TOOLS) or bool(board_post_evidence)
+    web_search_action = bool(web_search_evidence)
     product_action = bool(product_evidence)
     design_action = bool(design_evidence)
     pr_surface_action = bool(tools & PR_SURFACE_TOOLS)
@@ -1335,6 +1495,8 @@ def audit_keeper(
     pr_url_evidence = pr_creation_evidence.url_present
     if require_board_evidence and not board_action:
         failures.append("board_action_evidence_missing")
+    if require_web_search_evidence and not web_search_action:
+        failures.append("web_search_evidence_missing")
     if require_product_evidence and not product_action:
         failures.append("product_action_evidence_missing")
     if require_design_evidence and not design_action:
@@ -1384,6 +1546,7 @@ def audit_keeper(
         last_turn_age_hours=last_turn_age_hours,
         recent_action=recent_action,
         board_action=board_action,
+        web_search_action=web_search_action,
         product_action=product_action,
         design_action=design_action,
         pr_surface_action=pr_surface_action,
@@ -1400,6 +1563,7 @@ def audit_keeper(
         pr_url_evidence=pr_url_evidence,
         evidence_tools=sorted(tools),
         board_post_evidence=sorted(board_post_evidence),
+        web_search_evidence=sorted(web_search_evidence),
         product_evidence=sorted(product_evidence),
         design_evidence=sorted(design_evidence),
         pr_lifecycle_evidence=sorted(pr_lifecycle_evidence),
@@ -1429,6 +1593,7 @@ def build_report(args: argparse.Namespace) -> dict[str, Any]:
             config_path=path,
             max_silence_hours=args.max_silence_hours,
             require_board_evidence=args.require_board_evidence,
+            require_web_search_evidence=args.require_web_search_evidence,
             require_product_evidence=args.require_product_evidence,
             require_design_evidence=args.require_design_evidence,
             require_pr_surface_evidence=args.require_pr_surface_evidence,
@@ -1514,6 +1679,7 @@ def build_report(args: argparse.Namespace) -> dict[str, Any]:
         "github_account_counts": dict(sorted(github_account_counts.items())),
         "requirements": {
             "require_board_evidence": args.require_board_evidence,
+            "require_web_search_evidence": args.require_web_search_evidence,
             "require_product_evidence": args.require_product_evidence,
             "require_design_evidence": args.require_design_evidence,
             "forbid_github_identity": args.forbid_github_identity or [],
@@ -1566,6 +1732,7 @@ def print_text(report: dict[str, Any]) -> None:
         print(
             "- {name}: {marker} preset={preset} sandbox={sandbox}/{network} "
             "gh={github} recent={recent} age={age} board={board} "
+            "web_search={web_search} "
             "gh_account={github_account} "
             "product={product} design={design} "
             "pr_surface={pr_surface} pr_review={pr_review} "
@@ -1584,6 +1751,7 @@ def print_text(report: dict[str, Any]) -> None:
                 recent=str(keeper["recent_action"]).lower(),
                 age=age_label,
                 board=str(keeper["board_action"]).lower(),
+                web_search=str(keeper["web_search_action"]).lower(),
                 product=str(keeper["product_action"]).lower(),
                 design=str(keeper["design_action"]).lower(),
                 pr_surface=str(keeper["pr_surface_action"]).lower(),
@@ -1600,6 +1768,8 @@ def print_text(report: dict[str, Any]) -> None:
         )
         for ref in keeper["pr_evidence_refs"][:5]:
             print(f"    pr_evidence: {ref}")
+        for ref in keeper["web_search_evidence"][:5]:
+            print(f"    web_search_evidence: {ref}")
         for failure in failures:
             print(f"    fail: {failure}")
         for warning in warnings:
@@ -1635,6 +1805,14 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         action="store_false",
         dest="require_board_evidence",
         help="Do not fail when a keeper lacks board action evidence.",
+    )
+    parser.add_argument(
+        "--require-web-search-evidence",
+        action="store_true",
+        help=(
+            "Fail unless each keeper has successful masc_web_search/WebSearch "
+            "evidence from decision or global tool-call logs."
+        ),
     )
     parser.add_argument(
         "--require-product-evidence",

--- a/scripts/audit-keeper-fleet-readiness.py
+++ b/scripts/audit-keeper-fleet-readiness.py
@@ -152,6 +152,9 @@ class PrCreationEvidence:
         return any(ref.startswith("https://github.com/") for ref in self.refs)
 
 
+EvidenceWindow = tuple[float, float, str]
+
+
 def load_json(path: Path) -> dict[str, Any]:
     with path.open("r", encoding="utf-8", errors="replace") as handle:
         data = json.load(handle)
@@ -443,6 +446,68 @@ def row_matches_evidence_run(
     if not evidence_run_id or not evidence_run_pr_numbers:
         return False
     return bool(pr_numbers_from_row(row) & evidence_run_pr_numbers)
+
+
+def row_timestamp(row: dict[str, Any]) -> float | None:
+    return numeric_field(row, "ts_unix") or numeric_field(row, "ts")
+
+
+def row_within_evidence_windows(
+    row: dict[str, Any], evidence_windows: list[EvidenceWindow] | None
+) -> bool:
+    if not evidence_windows:
+        return False
+    ts = row_timestamp(row)
+    if ts is None:
+        return False
+    return any(start <= ts <= end for start, end, _phase in evidence_windows)
+
+
+def row_matches_evidence_scope(
+    row: dict[str, Any],
+    evidence_run_id: str | None,
+    evidence_run_pr_numbers: set[int] | None,
+    evidence_windows: list[EvidenceWindow] | None,
+) -> bool:
+    return row_matches_evidence_run(
+        row, evidence_run_id, evidence_run_pr_numbers
+    ) or row_within_evidence_windows(row, evidence_windows)
+
+
+def load_harness_evidence_windows(
+    harness_run_dir: str | None,
+) -> dict[str, list[EvidenceWindow]]:
+    if not harness_run_dir:
+        return {}
+    run_dir = Path(harness_run_dir).expanduser()
+    results_path = run_dir / "results.jsonl"
+    if not results_path.is_file():
+        return {}
+
+    windows: dict[str, list[EvidenceWindow]] = {}
+    for row in iter_jsonl(results_path):
+        keeper = string_field(row, "keeper")
+        phase = string_field(row, "phase") or "unknown"
+        text_file_raw = row.get("text_file")
+        if not keeper or not isinstance(text_file_raw, str) or not text_file_raw:
+            continue
+        text_path = Path(text_file_raw).expanduser()
+        if not text_path.is_absolute():
+            text_path = run_dir / text_path
+        if not text_path.is_file():
+            continue
+        try:
+            result = load_json(text_path)
+        except (OSError, ValueError, json.JSONDecodeError):
+            continue
+        submitted_at = numeric_field(result, "submitted_at")
+        completed_at = numeric_field(result, "completed_at")
+        if submitted_at is None or completed_at is None:
+            continue
+        start = min(submitted_at, completed_at)
+        end = max(submitted_at, completed_at)
+        windows.setdefault(keeper, []).append((max(0.0, start - 5.0), end + 5.0, phase))
+    return windows
 
 
 def add_pr_refs_from_structured_output(
@@ -1207,6 +1272,7 @@ def scan_keeper_evidence(
     max_silence_hours: float | None = None,
     evidence_run_id: str | None = None,
     evidence_run_pr_numbers: set[int] | None = None,
+    evidence_windows: list[EvidenceWindow] | None = None,
     now: float | None = None,
 ) -> tuple[float | None, set[str], set[str], set[str]]:
     latest_ts: float | None = None
@@ -1226,7 +1292,9 @@ def scan_keeper_evidence(
             if ts is not None:
                 latest_ts = ts if latest_ts is None else max(latest_ts, ts)
             tools.update(tools_from_decision(row))
-            if row_matches_evidence_run(row, evidence_run_id, evidence_run_pr_numbers):
+            if row_matches_evidence_scope(
+                row, evidence_run_id, evidence_run_pr_numbers, evidence_windows
+            ):
                 row_evidence, row_docker_evidence = pr_lifecycle_evidence_from_decision(
                     row
                 )
@@ -1242,7 +1310,9 @@ def scan_keeper_evidence(
             if ts is not None:
                 latest_ts = ts if latest_ts is None else max(latest_ts, ts)
             tools.update(tools_from_action_metric(row))
-            if row_matches_evidence_run(row, evidence_run_id, evidence_run_pr_numbers):
+            if row_matches_evidence_scope(
+                row, evidence_run_id, evidence_run_pr_numbers, evidence_windows
+            ):
                 row_evidence, row_docker_evidence = (
                     pr_lifecycle_evidence_from_action_metric(row)
                 )
@@ -1268,8 +1338,8 @@ def scan_keeper_evidence(
                 tool = row.get("tool")
                 if isinstance(tool, str):
                     tools.add(tool)
-                if row_matches_evidence_run(
-                    row, evidence_run_id, evidence_run_pr_numbers
+                if row_matches_evidence_scope(
+                    row, evidence_run_id, evidence_run_pr_numbers, evidence_windows
                 ):
                     row_evidence, row_docker_evidence = (
                         pr_lifecycle_evidence_from_tool_call(row)
@@ -1351,6 +1421,7 @@ def audit_keeper(
     require_docker_pr_approve_evidence: bool,
     evidence_run_id: str | None,
     evidence_run_pr_numbers: set[int] | None,
+    evidence_windows: list[EvidenceWindow] | None = None,
     forbidden_github_identities: set[str] | None = None,
 ) -> KeeperAudit:
     name = config_path.stem
@@ -1421,6 +1492,7 @@ def audit_keeper(
         max_silence_hours=max_silence_hours,
         evidence_run_id=evidence_run_id,
         evidence_run_pr_numbers=evidence_run_pr_numbers,
+        evidence_windows=evidence_windows,
     )
     pr_creation_evidence = scan_pr_creation_evidence(base_path, name)
     web_search_ts, web_search_evidence = scan_keeper_web_search_evidence(
@@ -1581,6 +1653,9 @@ def build_report(args: argparse.Namespace) -> dict[str, Any]:
     if not config_dir.is_dir():
         raise SystemExit(f"keeper config dir not found: {config_dir}")
 
+    evidence_windows_by_keeper = load_harness_evidence_windows(
+        getattr(args, "harness_run_dir", None)
+    )
     config_paths = sorted(
         path for path in config_dir.glob("*.toml") if path.name != "base.toml"
     )
@@ -1623,6 +1698,7 @@ def build_report(args: argparse.Namespace) -> dict[str, Any]:
             ),
             evidence_run_id=args.evidence_run_id,
             evidence_run_pr_numbers=evidence_run_pr_numbers,
+            evidence_windows=evidence_windows_by_keeper.get(path.stem),
             forbidden_github_identities=set(args.forbid_github_identity or []),
         )
         for path in config_paths
@@ -1703,6 +1779,7 @@ def build_report(args: argparse.Namespace) -> dict[str, Any]:
             ),
             "evidence_run_id": args.evidence_run_id,
             "evidence_run_pr_numbers": sorted(evidence_run_pr_numbers),
+            "harness_run_dir": getattr(args, "harness_run_dir", None),
         },
         "fleet_failures": fleet_failures,
         "failed_keepers": [keeper.name for keeper in failed_keepers],
@@ -1912,6 +1989,16 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
             "When set, count PR lifecycle evidence only from rows that mention "
             "this run id. This prevents older proof runs from satisfying a "
             "fresh lifecycle reprobe."
+        ),
+    )
+    parser.add_argument(
+        "--harness-run-dir",
+        default=None,
+        help=(
+            "Optional keeper lifecycle harness artifact directory. When set, "
+            "the audit also treats each keeper message request's submitted_at "
+            "to completed_at window as run-scoped evidence, covering telemetry "
+            "rows whose branch/run id was redacted before persistence."
         ),
     )
     parser.add_argument("--json", action="store_true", help="Emit JSON report.")

--- a/scripts/audit-keeper-fleet-readiness.py
+++ b/scripts/audit-keeper-fleet-readiness.py
@@ -1361,6 +1361,9 @@ def scan_keeper_web_search_evidence(
     evidence_run_id: str | None = None,
     now: float | None = None,
 ) -> tuple[float | None, set[str]]:
+    # ``evidence_run_id`` scopes PR lifecycle proof only. Web search proof is a
+    # separate behavioral signal and should remain visible when a lifecycle
+    # reprobe asks for fresh PR evidence.
     latest_ts: float | None = None
     evidence: set[str] = set()
     min_ts: float | None = None
@@ -1382,8 +1385,6 @@ def scan_keeper_web_search_evidence(
             if not fresh_enough(row):
                 continue
             observe_ts(row)
-            if not row_mentions_evidence_run_id(row, evidence_run_id):
-                continue
             evidence.update(web_search_evidence_from_decision(row, str(decisions)))
 
     for calls in global_tool_call_paths(base_path):
@@ -1393,8 +1394,6 @@ def scan_keeper_web_search_evidence(
             if not fresh_enough(row):
                 continue
             observe_ts(row)
-            if not row_mentions_evidence_run_id(row, evidence_run_id):
-                continue
             evidence.update(web_search_evidence_from_tool_call(row, str(calls)))
 
     return latest_ts, evidence

--- a/scripts/harness/workload/keeper_docker_pr_lifecycle_reprobe.sh
+++ b/scripts/harness/workload/keeper_docker_pr_lifecycle_reprobe.sh
@@ -1496,6 +1496,7 @@ run_audit() {
     --expected-keepers "$EXPECTED_KEEPERS"
     --require-docker-pr-lifecycle-evidence
     --evidence-run-id "$RUN_ID"
+    --harness-run-dir "$RUN_DIR"
     --json
   )
   if [[ -n "$FORBID_GITHUB_IDENTITIES" ]]; then

--- a/scripts/harness/workload/keeper_docker_pr_lifecycle_reprobe.sh
+++ b/scripts/harness/workload/keeper_docker_pr_lifecycle_reprobe.sh
@@ -40,7 +40,7 @@ POLL_TIMEOUT_SEC="${POLL_TIMEOUT_SEC:-1200}"
 POLL_INTERVAL_SEC="${POLL_INTERVAL_SEC:-10}"
 LIFECYCLE_MUTATION_MODE="split"
 REQUIRED_TOOLS_LEGACY="${REQUIRED_TOOLS:-}"
-CREATE_REQUIRED_TOOLS="${CREATE_REQUIRED_TOOLS:-${REQUIRED_TOOLS_LEGACY:-keeper_bash,keeper_pr_create}}"
+CREATE_REQUIRED_TOOLS="${CREATE_REQUIRED_TOOLS:-${REQUIRED_TOOLS_LEGACY:-masc_web_search,keeper_bash,keeper_pr_create}}"
 REVIEW_REQUIRED_TOOLS="${REVIEW_REQUIRED_TOOLS:-${REQUIRED_TOOLS_LEGACY:-keeper_pr_review_comment}}"
 MCP_URL="${MCP_URL:-http://127.0.0.1:8935/mcp}"
 MCP_TOKEN="${MASC_MCP_TOKEN:-}"
@@ -1108,7 +1108,7 @@ prompt_for_keeper_create() {
     head_ref="$account:$branch"
     git_route_rule="- You may use keeper_bash for gh repo fork / git remote setup only to prepare your own fork branch for this proof. Do not run gh pr create, gh pr review, or other PR mutations through keeper_shell or keeper_bash."
     push_step="$(cat <<EOF
-4. Commit and push exactly branch $branch with keeper_bash using the fork PR route because your upstream repo permission is $permission:
+5. Commit and push exactly branch $branch with keeper_bash using the fork PR route because your upstream repo permission is $permission:
    - Confirm your GitHub account login is $account.
    - Ensure the fork $account/${REPO_SLUG#*/} exists. If needed, run gh repo fork $REPO_SLUG --remote=false from keeper_bash; if GitHub blocks fork creation, stop and report blocker="fork_create_blocked" with the exact output.
    - Add or update a remote named keeper-fork pointing at https://github.com/$account/${REPO_SLUG#*/}.git in the returned proof worktree.
@@ -1117,7 +1117,7 @@ prompt_for_keeper_create() {
 EOF
 )"
     pr_step="$(cat <<EOF
-5. Create a draft PR from your fork branch with keeper_pr_create. The call must include
+6. Create a draft PR from your fork branch with keeper_pr_create. The call must include
    repo="$REPO_SLUG", head="$head_ref", base="main", draft=true, and cwd set to
    the returned proof worktree path. Do not leave head/base empty and do not use
    the base repo path if the proof branch lives in a separate worktree. Do not
@@ -1128,11 +1128,11 @@ EOF
     head_ref="$branch"
     git_route_rule="- Do not run gh pr create, gh pr review, or other mutating GitHub commands through keeper_shell or keeper_bash."
     push_step="$(cat <<EOF
-4. Commit and git push exactly branch $branch with keeper_bash. The tool result must show explicit Docker-backed route evidence such as via=docker, route_via=docker, via=brokered, or route_via=brokered.
+5. Commit and git push exactly branch $branch with keeper_bash. The tool result must show explicit Docker-backed route evidence such as via=docker, route_via=docker, via=brokered, or route_via=brokered.
 EOF
 )"
     pr_step="$(cat <<EOF
-5. Create a draft PR for that branch with keeper_pr_create. The call must include
+6. Create a draft PR for that branch with keeper_pr_create. The call must include
    repo="$REPO_SLUG", head="$head_ref", base="main", draft=true, and cwd set to
    the returned proof worktree path. Do not leave head/base empty and do not use
    the base repo path if the proof branch lives in a separate worktree. Do not
@@ -1161,8 +1161,12 @@ $git_route_rule
 - Use keeper_pr_create for PR creation.
 
 Required create lane:
-1. Confirm your runtime is sandbox_profile=docker before mutating.
-2. Create a unique proof worktree/branch for exactly this run id:
+1. Use masc_web_search once for current external context before mutating. The
+   query should be about GitHub draft PR creation or GitHub CLI draft PR
+   behavior. Do not search for secrets, credentials, bearer tokens, or private
+   repository content.
+2. Confirm your runtime is sandbox_profile=docker before mutating.
+3. Create a unique proof worktree/branch for exactly this run id:
    - branch: $branch
    - preferred tool: masc_worktree_create with task_id=$RUN_ID
    - use the returned worktree path for every later keeper_bash git/file command.
@@ -1170,10 +1174,10 @@ Required create lane:
    - Do not reuse any branch, worktree, or proof file from another run id.
    - Do not remove this run's worktree during the proof attempt. If Git says
      the branch/worktree already exists, stop and report blocker="branch_collision".
-3. Make a minimal, non-product proof edit under docs/runtime-proof/keepers/$keeper-$RUN_ID.md with keeper_bash from inside the Docker playground. The file content must include run_id=$RUN_ID and branch=$branch.
+4. Make a minimal, non-product proof edit under docs/runtime-proof/keepers/$keeper-$RUN_ID.md with keeper_bash from inside the Docker playground. The file content must include run_id=$RUN_ID and branch=$branch.
 $push_step
 $pr_step
-6. Reply with one compact JSON object:
+7. Reply with one compact JSON object:
    {
      "run_id": "$RUN_ID",
      "phase": "create",
@@ -1181,6 +1185,7 @@ $pr_step
      "branch": "$branch",
      "head": "$head_ref",
      "pr_url": "...",
+     "web_search": true,
      "docker_pr_create": true,
      "docker_git_push": true,
      "blocker": null
@@ -1195,7 +1200,7 @@ Safety rules:
 
 This prompt is sent with create-phase masc_keeper_msg.required_tools so the
 runtime records tool_surface_mismatch or missing_required_tool_use when
-keeper_bash/keeper_pr_create are not visible or not used.
+masc_web_search/keeper_bash/keeper_pr_create are not visible or not used.
 EOF
 }
 

--- a/test/test_audit_keeper_fleet_readiness.py
+++ b/test/test_audit_keeper_fleet_readiness.py
@@ -1330,7 +1330,7 @@ class AuditKeeperFleetReadinessTest(unittest.TestCase):
             },
         )
 
-    def test_scan_keeper_web_search_evidence_filters_keeper_and_run_id(self):
+    def test_scan_keeper_web_search_evidence_filters_keeper_not_run_id(self):
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
             calls_dir = root / ".masc" / "tool_calls" / "2026-05"
@@ -1375,9 +1375,13 @@ class AuditKeeperFleetReadinessTest(unittest.TestCase):
             evidence,
             {
                 "web_search:masc_web_search:"
+                "query=keeper proof old-run:"
+                "ts=80:"
+                "source=06.jsonl",
+                "web_search:masc_web_search:"
                 "query=keeper proof current-run:"
                 "ts=90:"
-                "source=06.jsonl"
+                "source=06.jsonl",
             },
         )
 

--- a/test/test_audit_keeper_fleet_readiness.py
+++ b/test/test_audit_keeper_fleet_readiness.py
@@ -34,6 +34,7 @@ def audit_args(base_path: Path, expected_keepers: int):
         expected_keepers=expected_keepers,
         max_silence_hours=2400.0,
         require_board_evidence=True,
+        require_web_search_evidence=False,
         require_product_evidence=False,
         require_design_evidence=False,
         require_pr_surface_evidence=False,
@@ -144,6 +145,13 @@ def write_board_post(
     board_path = root / ".masc" / "board_posts.jsonl"
     board_path.parent.mkdir(parents=True, exist_ok=True)
     with board_path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(row) + "\n")
+
+
+def append_decision(root: Path, keeper: str, row: dict) -> None:
+    decisions_path = root / ".masc" / "keepers" / f"{keeper}.decisions.jsonl"
+    decisions_path.parent.mkdir(parents=True, exist_ok=True)
+    with decisions_path.open("a", encoding="utf-8") as handle:
         handle.write(json.dumps(row) + "\n")
 
 
@@ -1164,6 +1172,152 @@ class AuditKeeperFleetReadinessTest(unittest.TestCase):
             },
         )
         self.assertEqual(docker_evidence, evidence)
+
+    def test_web_search_evidence_counts_successful_decision_tool(self):
+        row = {
+            "ts_unix": 100.0,
+            "event": "tool_exec",
+            "tool": "masc_web_search",
+            "ok": True,
+            "args": {"query": "MASC keeper web search proof"},
+        }
+
+        evidence = audit.web_search_evidence_from_decision(row, "alpha.decisions.jsonl")
+
+        self.assertEqual(
+            evidence,
+            {
+                "web_search:masc_web_search:"
+                "query=MASC keeper web search proof:"
+                "ts=100:"
+                "source=alpha.decisions.jsonl"
+            },
+        )
+
+    def test_web_search_evidence_rejects_failed_decision_tool(self):
+        row = {
+            "ts_unix": 100.0,
+            "event": "tool_exec",
+            "tool": "masc_web_search",
+            "ok": False,
+            "args": {"query": "MASC keeper web search proof"},
+        }
+
+        evidence = audit.web_search_evidence_from_decision(row, "alpha.decisions.jsonl")
+
+        self.assertEqual(evidence, set())
+
+    def test_web_search_evidence_counts_successful_global_tool_call(self):
+        row = {
+            "ts": 110.0,
+            "keeper": "alpha",
+            "tool": "WebSearch",
+            "input": {"query": "latest MASC MCP keeper proof"},
+            "output": json.dumps({"ok": True}),
+            "success": True,
+        }
+
+        evidence = audit.web_search_evidence_from_tool_call(row, "06.jsonl")
+
+        self.assertEqual(
+            evidence,
+            {
+                "web_search:WebSearch:"
+                "query=latest MASC MCP keeper proof:"
+                "ts=110:"
+                "source=06.jsonl"
+            },
+        )
+
+    def test_scan_keeper_web_search_evidence_filters_keeper_and_run_id(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            calls_dir = root / ".masc" / "tool_calls" / "2026-05"
+            calls_dir.mkdir(parents=True)
+            rows = [
+                {
+                    "ts": 80.0,
+                    "keeper": "alpha",
+                    "tool": "masc_web_search",
+                    "input": {"query": "keeper proof old-run"},
+                    "output": json.dumps({"ok": True}),
+                    "success": True,
+                },
+                {
+                    "ts": 90.0,
+                    "keeper": "alpha",
+                    "tool": "masc_web_search",
+                    "input": {"query": "keeper proof current-run"},
+                    "output": json.dumps({"ok": True}),
+                    "success": True,
+                },
+                {
+                    "ts": 95.0,
+                    "keeper": "beta",
+                    "tool": "masc_web_search",
+                    "input": {"query": "keeper proof current-run"},
+                    "output": json.dumps({"ok": True}),
+                    "success": True,
+                },
+            ]
+            (calls_dir / "06.jsonl").write_text(
+                "".join(json.dumps(row) + "\n" for row in rows),
+                encoding="utf-8",
+            )
+
+            latest_ts, evidence = audit.scan_keeper_web_search_evidence(
+                root, "alpha", evidence_run_id="current-run"
+            )
+
+        self.assertEqual(latest_ts, 90.0)
+        self.assertEqual(
+            evidence,
+            {
+                "web_search:masc_web_search:"
+                "query=keeper proof current-run:"
+                "ts=90:"
+                "source=06.jsonl"
+            },
+        )
+
+    def test_require_web_search_evidence_fails_without_success(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            write_ready_keeper(root, "alpha")
+            args = audit_args(root, expected_keepers=1)
+            args.require_web_search_evidence = True
+
+            report = audit.build_report(args)
+
+        self.assertFalse(report["ok"])
+        keeper = report["keepers"][0]
+        self.assertFalse(keeper["web_search_action"])
+        self.assertIn("web_search_evidence_missing", keeper["failures"])
+
+    def test_require_web_search_evidence_passes_with_success(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            write_ready_keeper(root, "alpha")
+            append_decision(
+                root,
+                "alpha",
+                {
+                    "ts_unix": time.time(),
+                    "event": "tool_exec",
+                    "tool": "masc_web_search",
+                    "ok": True,
+                    "args": {"query": "MASC keeper web search proof"},
+                },
+            )
+            args = audit_args(root, expected_keepers=1)
+            args.require_web_search_evidence = True
+
+            report = audit.build_report(args)
+
+        self.assertTrue(report["ok"])
+        keeper = report["keepers"][0]
+        self.assertTrue(keeper["web_search_action"])
+        self.assertEqual(len(keeper["web_search_evidence"]), 1)
 
 
 if __name__ == "__main__":

--- a/test/test_audit_keeper_fleet_readiness.py
+++ b/test/test_audit_keeper_fleet_readiness.py
@@ -50,6 +50,7 @@ def audit_args(base_path: Path, expected_keepers: int):
         require_docker_pr_approve_evidence=False,
         require_docker_pr_lifecycle_evidence=False,
         evidence_run_id=None,
+        harness_run_dir=None,
         forbid_github_identity=[],
     )
 
@@ -1074,6 +1075,106 @@ class AuditKeeperFleetReadinessTest(unittest.TestCase):
                 "pr_approve:keeper_pr_review_comment",
                 "pr_create:keeper_pr_create",
             },
+        )
+        self.assertEqual(docker_evidence, evidence)
+
+    def test_load_harness_evidence_windows_reads_result_timestamps(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            run_dir = Path(tmp)
+            raw_dir = run_dir / "raw"
+            raw_dir.mkdir()
+            text_file = raw_dir / "result-create-alpha-request-1.text"
+            text_file.write_text(
+                json.dumps(
+                    {
+                        "request_id": "request-1",
+                        "keeper_name": "alpha",
+                        "status": "done",
+                        "submitted_at": 100.0,
+                        "completed_at": 120.0,
+                    }
+                ),
+                encoding="utf-8",
+            )
+            (run_dir / "results.jsonl").write_text(
+                json.dumps(
+                    {
+                        "keeper": "alpha",
+                        "phase": "create",
+                        "request_id": "request-1",
+                        "status": "done",
+                        "text_file": str(text_file),
+                    }
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+
+            windows = audit.load_harness_evidence_windows(str(run_dir))
+
+        self.assertEqual(windows, {"alpha": [(95.0, 125.0, "create")]})
+
+    def test_scan_keeper_evidence_uses_harness_window_when_run_id_redacted(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            calls_dir = root / ".masc" / "tool_calls" / "2026-05"
+            calls_dir.mkdir(parents=True)
+            rows = [
+                {
+                    "ts": 40.0,
+                    "keeper": "alpha",
+                    "tool": "keeper_bash",
+                    "input": {"cmd": "git push -u origin [REDACTED]"},
+                    "output": json.dumps({"ok": True, "via": "docker"}),
+                    "success": True,
+                },
+                {
+                    "ts": 60.0,
+                    "keeper": "alpha",
+                    "tool": "keeper_bash",
+                    "input": {"cmd": "git push -u origin [REDACTED]"},
+                    "output": json.dumps({"ok": True, "via": "docker"}),
+                    "success": True,
+                },
+                {
+                    "ts": 65.0,
+                    "keeper": "alpha",
+                    "tool": "keeper_pr_create",
+                    "input": {
+                        "repo": "acme/repo",
+                        "head": "[REDACTED]",
+                        "body": "run_id: [REDACTED]",
+                    },
+                    "output": json.dumps(
+                        {
+                            "ok": True,
+                            "tool": "keeper_pr_create",
+                            "operation": "pr_create",
+                            "via": "docker",
+                            "route_via": "docker",
+                        }
+                    ),
+                    "success": True,
+                    "route_evidence": {"via": "docker"},
+                },
+            ]
+            (calls_dir / "06.jsonl").write_text(
+                "".join(json.dumps(row) + "\n" for row in rows),
+                encoding="utf-8",
+            )
+
+            latest_ts, tools, evidence, docker_evidence = audit.scan_keeper_evidence(
+                root,
+                "alpha",
+                evidence_run_id="current-run",
+                evidence_run_pr_numbers=set(),
+                evidence_windows=[(55.0, 70.0, "create")],
+            )
+
+        self.assertEqual(latest_ts, 65.0)
+        self.assertEqual(tools, {"keeper_bash", "keeper_pr_create"})
+        self.assertEqual(
+            evidence, {"git_push:keeper_bash", "pr_create:keeper_pr_create"}
         )
         self.assertEqual(docker_evidence, evidence)
 

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -1161,7 +1161,7 @@ let test_keeper_required_tool_contracts () =
        {|REQUIRED_TOOLS_LEGACY="${REQUIRED_TOOLS:-}"|}
      && file_contains_pattern
           "scripts/harness/workload/keeper_docker_pr_lifecycle_reprobe.sh"
-          {|CREATE_REQUIRED_TOOLS="${CREATE_REQUIRED_TOOLS:-${REQUIRED_TOOLS_LEGACY:-keeper_bash,keeper_pr_create}}"|}
+          {|CREATE_REQUIRED_TOOLS="${CREATE_REQUIRED_TOOLS:-${REQUIRED_TOOLS_LEGACY:-masc_web_search,keeper_bash,keeper_pr_create}}"|}
      && file_contains_pattern
           "scripts/harness/workload/keeper_docker_pr_lifecycle_reprobe.sh"
           {|REVIEW_REQUIRED_TOOLS="${REVIEW_REQUIRED_TOOLS:-${REQUIRED_TOOLS_LEGACY:-keeper_pr_review_comment}}"|});
@@ -1169,7 +1169,7 @@ let test_keeper_required_tool_contracts () =
     (file_contains_pattern "docs/KEEPER-DOCKER-PR-LIFECYCLE-REPROBE.md"
        "The create phase"
      && file_contains_pattern "docs/KEEPER-DOCKER-PR-LIFECYCLE-REPROBE.md"
-          "requires `keeper_bash` and `keeper_pr_create`"
+          "requires `masc_web_search`, `keeper_bash`, and `keeper_pr_create`"
      && file_contains_pattern "docs/KEEPER-DOCKER-PR-LIFECYCLE-REPROBE.md"
           "the review phase requires `keeper_pr_review_comment`");
   check bool "docker PR lifecycle prompt accepts brokered route proof" true

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -1394,8 +1394,12 @@ let test_keeper_pr_audit_contracts () =
   check bool "keeper fleet audit can scope lifecycle evidence by run id" true
     (file_contains_pattern "scripts/audit-keeper-fleet-readiness.py"
        "--evidence-run-id"
+     && file_contains_pattern "scripts/audit-keeper-fleet-readiness.py"
+          "load_harness_evidence_windows"
      && file_contains_pattern "scripts/harness/workload/keeper_docker_pr_lifecycle_reprobe.sh"
-          "--evidence-run-id \"$RUN_ID\"");
+          "--evidence-run-id \"$RUN_ID\""
+     && file_contains_pattern "scripts/harness/workload/keeper_docker_pr_lifecycle_reprobe.sh"
+          "--harness-run-dir \"$RUN_DIR\"");
   check bool "keeper fleet audit survives live invalid utf8 rows" true
     (file_contains_pattern "scripts/audit-keeper-fleet-readiness.py"
        {|errors="replace"|})


### PR DESCRIPTION
## Summary

- adds a first-class `--require-web-search-evidence` gate to `scripts/audit-keeper-fleet-readiness.py`
- records successful `masc_web_search` / `WebSearch` evidence from keeper decision logs and global tool-call logs
- scopes Docker PR lifecycle/tool-call evidence by `--evidence-run-id`, PR numbers, and `--harness-run-dir` request windows
- keeps web-search proof independent from PR lifecycle run-id scoping, so a fresh Docker PR reprobe does not hide valid recent web-search behavior
- requires the Docker PR lifecycle reprobe create phase to call `masc_web_search` before Docker-backed branch/commit/push/PR mutation
- wires the Docker PR lifecycle reprobe harness to pass its run directory into the readiness audit

## Product impact

The keeper runtime-completion audit now checks configured capability against proven behavior in one place: Board/Task/Goal evidence, Docker PR lifecycle evidence, and web-search evidence. The harness-window scope prevents stale or unrelated PR lifecycle tool calls from satisfying a current proof run, while web-search remains a separate behavioral proof signal. Future lifecycle reprobes now also produce fresh current-information evidence in the same run that proves Docker credential isolation and PR mutation.

## Evidence

- `python3 -m unittest discover -s test -p 'test_audit_keeper_fleet_readiness.py'`
- `ruff check scripts/audit-keeper-fleet-readiness.py test/test_audit_keeper_fleet_readiness.py`
- `ruff format --check scripts/audit-keeper-fleet-readiness.py test/test_audit_keeper_fleet_readiness.py`
- `python3 -m py_compile scripts/audit-keeper-fleet-readiness.py test/test_audit_keeper_fleet_readiness.py`
- `bash -n scripts/harness/workload/keeper_docker_pr_lifecycle_reprobe.sh`
- `RUN_AUDIT=0 RUN_ID=keeper-web-search-dry-test2 RUN_DIR=/private/tmp/keeper-web-search-dry-test2 KEEPER_NAMES=analyst scripts/harness/workload/keeper_docker_pr_lifecycle_reprobe.sh --dry-run --base-path /Users/dancer/me`
- `git diff --check`
- `scripts/dune-local.sh build test/test_ci_hardening_source.exe`
- `./_build/default/test/test_ci_hardening_source.exe`

## Review evidence

- Unit coverage for successful and failed decision-log web search rows.
- Unit coverage for successful global tool-call rows using the legacy `WebSearch` alias.
- Unit coverage for keeper scoping, lifecycle `--evidence-run-id` filtering, and harness run-dir windows.
- Report-level coverage for `web_search_evidence_missing`, successful `web_search_action`, and lifecycle evidence scoped to the current harness request window.
- Regression coverage that web-search evidence is not filtered by lifecycle run id.
- Source-guard coverage that the lifecycle reprobe create phase requires `masc_web_search`, `keeper_bash`, and `keeper_pr_create`.

## Live Runtime Note

The live audit now separates two remaining proof gaps: only 5/17 keepers currently have successful web-search evidence in `/Users/dancer/me/.masc`, and the 0507c Docker PR lifecycle run does not yet prove Docker PR create + git push + approve for all 17 keepers. The audit reports those as explicit missing evidence instead of silently passing on stale proof.
