### PR TITLE
fix: count prompt override restore failures

### DIFF
--- a/lib/prompt_defaults.ml
+++ b/lib/prompt_defaults.ml
@@ -10,6 +10,13 @@ let prompt_markdown_dir_candidates ~workspace_path ~base_path =
   let _ = workspace_path, base_path in
   [ Config_dir_resolver.prompts_dir () ]
 
+let install_prompt_registry_observers () =
+  Prompt_registry.set_restore_failure_observer (fun () ->
+      Prometheus.inc_counter
+        Prometheus.metric_keeper_prompt_failures
+        ~labels:[ ("prompt", "override_restore") ]
+        ())
+
 let resolve_prompt_markdown_dir ~workspace_path ~base_path =
   match
     List.find_opt existing_dir
@@ -23,11 +30,13 @@ let bootstrapped_signature : (string * string) option ref = ref None
 (** Scan the current markdown dir and register all prompts with frontmatter.
     Called by [bootstrap_runtime]; also usable in tests after [set_markdown_dir]. *)
 let init () =
+  install_prompt_registry_observers ();
   match Prompt_registry.get_markdown_dir () with
   | Some dir -> Prompt_registry.load_prompts_from_directory dir
   | None -> ()
 
 let bootstrap_runtime ~workspace_path ~base_path =
+  install_prompt_registry_observers ();
   Config_dir_resolver.log_warnings ~context:"PromptDefaults" ();
   let prompt_markdown_dir =
     resolve_prompt_markdown_dir ~workspace_path ~base_path

--- a/lib/prompt_registry/prompt_registry.ml
+++ b/lib/prompt_registry/prompt_registry.ml
@@ -946,6 +946,14 @@ let persist_overrides base_path =
 
 (** Restore overrides from JSON file, applying the same validation as
     [set_override] so that stale or manually-edited entries are rejected. *)
+let restore_failure_observer : (unit -> unit) ref = ref (fun () -> ())
+
+let set_restore_failure_observer observer =
+  restore_failure_observer := observer
+
+let record_override_restore_failure () =
+  !restore_failure_observer ()
+
 let restore_overrides base_path =
   let path =
     Filename.concat
@@ -964,11 +972,13 @@ let restore_overrides base_path =
               match apply_override_validated key s with
               | Ok () -> ()
               | Error reason ->
+                  record_override_restore_failure ();
                   Log.Misc.warn "prompt override restore: skipping %s: %s"
                     key reason)
           | `Null | `Bool _ | `Int _ | `Intlit _ | `Float _ | `Assoc _ | `List _ -> ()
         ) pairs
       | `Null | `Bool _ | `Int _ | `Intlit _ | `Float _ | `String _ | `List _ -> ()
     with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
+      record_override_restore_failure ();
       Log.Misc.warn "prompt override restore failed: %s" (Printexc.to_string exn)
   end

--- a/lib/prompt_registry/prompt_registry.mli
+++ b/lib/prompt_registry/prompt_registry.mli
@@ -172,6 +172,12 @@ val restore_overrides : string -> unit
     Stale or manually-edited entries are skipped with a
     [Log.Misc.warn] instead of being silently accepted. *)
 
+val set_restore_failure_observer : (unit -> unit) -> unit
+(** Installs the process-local observer called whenever override
+    restore rejects an entry or cannot parse the persisted override
+    file. The default observer is a no-op so this sub-library stays
+    independent of the runtime metrics implementation. *)
+
 (** {1 Listing + JSON export} *)
 
 val list_prompts : unit -> Yojson.Safe.t list

--- a/test/test_prompt_registry_defaults.ml
+++ b/test/test_prompt_registry_defaults.ml
@@ -280,6 +280,31 @@ let () =
                        true
                      with Not_found -> false)
               | Ok () -> fail "should reject unknown template variable");
+          test_case "restore_overrides counts rejected entries" `Quick
+            (fun () ->
+              with_registry @@ fun ~dir ~prompts_dir:_ ->
+              let labels = [ ("prompt", "override_restore") ] in
+              let before =
+                Lib.Prometheus.metric_value_or_zero
+                  Lib.Prometheus.metric_keeper_prompt_failures
+                  ~labels
+                  ()
+              in
+              let masc_dir = Filename.concat dir ".masc" in
+              Unix.mkdir masc_dir 0o755;
+              write_file
+                (Filename.concat masc_dir "prompt_overrides.json")
+                {|{"keeper.deliberation":"Keeper {{unknown}}"}|};
+              Prompt_registry.restore_overrides dir;
+              check (float 0.0001) "restore rejection counted"
+                (before +. 1.0)
+                (Lib.Prometheus.metric_value_or_zero
+                   Lib.Prometheus.metric_keeper_prompt_failures
+                   ~labels
+                   ());
+              check string "invalid override not applied"
+                (fixture "keeper.deliberation")
+                (Prompt_registry.get_prompt "keeper.deliberation"));
         ] );
       ( "integration",
         [


### PR DESCRIPTION
## Summary
- count prompt override restore rejections through the existing keeper prompt failure metric
- keep prompt_registry independent of runtime metrics via a process-local observer hook
- add focused prompt registry regression proving invalid override restores are rejected and counted

## Why it matters
Prompt override restore previously rejected bad persisted entries silently. Operators could see the override fail to take effect, but there was no metric signal tied to the restore path. This keeps the failure non-fatal while making it visible through the existing keeper prompt failure counter.

## Verification
- git diff --check
- lockf -k -t 1200 /tmp/me-dune-local.lock env MASC_DUNE_LOCK_HELD=1 MASC_SKIP_OPAM_LOCK=1 DUNE_JOBS=1 DUNE_CACHE=disabled scripts/dune-local.sh build test/test_prompt_registry_defaults.exe
- ./_build/default/test/test_prompt_registry_defaults.exe