### PR TITLE
fix: count recurring task auto-disable failures

### DIFF
--- a/lib/keeper/keeper_recurring.ml
+++ b/lib/keeper/keeper_recurring.ml
@@ -86,6 +86,12 @@ let list_all () =
   with_tasks_ro (fun () ->
     Hashtbl.fold (fun _id task acc -> task :: acc) tasks [])
 
+let record_failure ~task ~phase =
+  Prometheus.inc_counter
+    Prometheus.metric_keeper_recurring_failures
+    ~labels:[("task", task.id); ("phase", phase)]
+    ()
+
 (* ================================================================ *)
 (* Dispatch                                                          *)
 (* ================================================================ *)
@@ -117,7 +123,10 @@ let dispatch_due ~keeper_name ~now_ts ~dispatch =
       task.failure_count <- task.failure_count + 1;
       if task.max_failures > 0
          && task.failure_count >= task.max_failures
-      then task.enabled <- false
+      then begin
+        task.enabled <- false;
+        record_failure ~task ~phase:"auto_disable"
+      end
   ) due_tasks;
   !count
 

--- a/test/test_keeper_recurring.ml
+++ b/test/test_keeper_recurring.ml
@@ -2,11 +2,19 @@
 
 open Alcotest
 module Rec = Masc_mcp.Keeper_recurring
+module Prom = Masc_mcp.Prometheus
 
 let check = Alcotest.check
 
 let task_by_label label =
   List.find (fun (task : Rec.recurring_task) -> String.equal task.label label)
+;;
+
+let recurring_failure_value ~task ~phase =
+  Prom.metric_value_or_zero
+    Prom.metric_keeper_recurring_failures
+    ~labels:[("task", task); ("phase", phase)]
+    ()
 ;;
 
 let test_add_and_list () =
@@ -85,6 +93,9 @@ let test_failure_auto_disable () =
       ~max_failures:2
       (Rec.Broadcast "oops")
   in
+  let auto_disable_before =
+    recurring_failure_value ~task:t.id ~phase:"auto_disable"
+  in
   (* Fail twice *)
   let _ =
     Rec.dispatch_due ~keeper_name:"k1" ~now_ts:100.0 ~dispatch:(fun _task _action ->
@@ -94,6 +105,11 @@ let test_failure_auto_disable () =
   let task = List.hd tasks in
   check int "failure 1" 1 task.failure_count;
   check bool "still enabled" true task.enabled;
+  check
+    (float 0.001)
+    "auto-disable metric unchanged below threshold"
+    auto_disable_before
+    (recurring_failure_value ~task:t.id ~phase:"auto_disable");
   (* Need to set last_run_ts back to allow re-dispatch *)
   (* Actually, on failure we don't update last_run_ts, so it stays 0.0 *)
   let _ =
@@ -104,6 +120,11 @@ let test_failure_auto_disable () =
   let task2 = List.hd tasks2 in
   check int "failure 2" 2 task2.failure_count;
   check bool "auto-disabled" false task2.enabled;
+  check
+    (float 0.001)
+    "auto-disable metric increments"
+    (auto_disable_before +. 1.0)
+    (recurring_failure_value ~task:t.id ~phase:"auto_disable");
   (* No more dispatches *)
   let count =
     Rec.dispatch_due ~keeper_name:"k1" ~now_ts:300.0 ~dispatch:(fun _task _action ->


### PR DESCRIPTION
## Summary
- count recurring-task auto-disable transitions with the existing keeper recurring failure metric
- keep per-dispatch exception counting unchanged while surfacing the threshold crossing that disables the task
- extend the focused recurring-task regression to prove the metric only increments when max failures disables the task

## Why it matters
Recurring tasks can be disabled after repeated dispatcher Error results. That state transition is operationally important because it can silence keeper heartbeat broadcasts until a later re-enable pass. This makes the auto-disable point visible without adding a new metric schema.

## Verification
- git diff --check
- lockf -k -t 1200 /tmp/me-dune-local.lock env MASC_DUNE_LOCK_HELD=1 MASC_SKIP_OPAM_LOCK=1 DUNE_JOBS=1 DUNE_CACHE=disabled scripts/dune-local.sh build test/test_keeper_recurring.exe
- ./_build/default/test/test_keeper_recurring.exe