### PR TITLE
feat(cascade_ollama_probe): env-tunable probe timeout

### DIFF
--- a/lib/cascade/cascade_ollama_probe.ml
+++ b/lib/cascade/cascade_ollama_probe.ml
@@ -90,7 +90,58 @@ let probe_endpoint_of base_url =
   in
   stripped ^ Masc_network_defaults.ollama_api_ps_path
 
-let try_probe ~sw ~net ?clock ?(timeout_s = 0.5) ?now url =
+(* Operator-tunable default for the probe timeout.
+
+   Was a literal [0.5] embedded twice (in [try_probe] and
+   [refresh_many]).  Operators reported that 0.5s is fine for ollama
+   serving small models on a fast box but is tight when the box is
+   loading a big model (the [/api/ps] handler shares the same lock
+   as model load) — in those cases the probe times out, the cache
+   stays cold, and the cascade backs off to a non-local provider
+   even though ollama is healthy and only briefly busy.
+
+   Resolution order (process env > literal default):
+   - [MASC_OLLAMA_PROBE_TIMEOUT_SEC]  (float)
+
+   Range [0.05, 30.0]; out-of-range or unparseable values fall back
+   to the literal default with a one-shot WARN.
+
+   Read at every call site so operator changes via runtime tooling
+   take effect without a process restart.  The cost is one
+   [Sys.getenv_opt] per probe attempt, which is negligible compared
+   to the HTTP round-trip the probe makes. *)
+let probe_timeout_default_s = 0.5
+
+let probe_timeout_env_var = "MASC_OLLAMA_PROBE_TIMEOUT_SEC"
+
+let probe_timeout_warned = Atomic.make false
+
+let probe_timeout_resolved () =
+  match Sys.getenv_opt probe_timeout_env_var with
+  | None -> probe_timeout_default_s
+  | Some raw ->
+    let trimmed = String.trim raw in
+    if trimmed = "" then probe_timeout_default_s
+    else (
+      match float_of_string_opt trimmed with
+      | Some v when v >= 0.05 && v <= 30.0 -> v
+      | Some _ | None ->
+        if not (Atomic.exchange probe_timeout_warned true)
+        then
+          Log.Misc.warn
+            "Ignoring %s=%S (expected float in [0.05, 30.0]); using \
+             default %.2fs."
+            probe_timeout_env_var
+            raw
+            probe_timeout_default_s;
+        probe_timeout_default_s)
+
+let try_probe ~sw ~net ?clock ?timeout_s ?now url =
+  let timeout_s =
+    match timeout_s with
+    | Some v -> v
+    | None -> probe_timeout_resolved ()
+  in
   let _ = sw in
   let now = match now with Some n -> n | None -> now_default () in
   let endpoint = probe_endpoint_of url in
@@ -115,7 +166,12 @@ let try_probe ~sw ~net ?clock ?(timeout_s = 0.5) ?now url =
          Some cap)
   | Ok _ -> None
 
-let refresh_many ~sw ~net ?(timeout_s = 0.5) urls =
+let refresh_many ~sw ~net ?timeout_s urls =
+  let timeout_s =
+    match timeout_s with
+    | Some v -> v
+    | None -> probe_timeout_resolved ()
+  in
   List.iter
     (fun url ->
        if is_ollama_url url then

--- a/lib/cascade/cascade_ollama_probe.mli
+++ b/lib/cascade/cascade_ollama_probe.mli
@@ -62,10 +62,14 @@ val try_probe :
   string ->
   Cascade_throttle.capacity_info option
 (** [try_probe ~sw ~net url] issues [GET <url>/api/ps] with a short
-    timeout (default [0.5] seconds), parses the JSON body, and
-    updates the cache.  Returns the freshly-recorded
-    [capacity_info] on success; returns [None] (and does not touch
-    the cache) on timeout, non-200, or parse failure.
+    timeout, parses the JSON body, and updates the cache.  Returns
+    the freshly-recorded [capacity_info] on success; returns [None]
+    (and does not touch the cache) on timeout, non-200, or parse
+    failure.
+
+    Default [timeout_s] is read from [MASC_OLLAMA_PROBE_TIMEOUT_SEC]
+    on every call (range [0.05, 30.0], literal fallback [0.5]).
+    Pass an explicit [?timeout_s] argument to override per-call.
 
     Caller is responsible for picking [url]s that look like ollama
     (use {!is_ollama_url}); calling on a non-ollama URL will fail


### PR DESCRIPTION
## Summary

Replaces the hardcoded literal `timeout_s = 0.5` in `try_probe` (L93) and `refresh_many` (L118) with a per-call lookup of `MASC_OLLAMA_PROBE_TIMEOUT_SEC` (range [0.05, 30.0], literal fallback 0.5s).

## Why

0.5s is fine for ollama serving small models on a fast box, but tight when the box is loading a big model — the `/api/ps` handler shares the same lock as model load, so a brief load stall causes the probe to time out, the cache stays cold, and the cascade backs off to a non-local provider even though ollama is healthy and only briefly busy. There was no way to tune that without recompile.

## Behavior

- Two literals (try_probe L93, refresh_many L118) collapse to a single resolver `probe_timeout_resolved` read on every call.
- Existing callers that pass an explicit `?timeout_s` are unchanged. Callers that omit it (currently `oas_worker_named.ml:1116` via `refresh_many`, `keeper_turn_liveness.ml:75` via `try_probe`) now pick up the env value.
- Out-of-range or unparseable env values fall back to the 0.5s literal with a one-shot WARN through `Log.Misc`; the WARN deduplication uses `Atomic.exchange` so only one log line is emitted per process even under heavy probe traffic.

## Diff shape

```
lib/cascade/cascade_ollama_probe.ml  | 60 ++++++++++++++++++++++++++++++++++--
lib/cascade/cascade_ollama_probe.mli | 12 +++++---
2 files changed, 66 insertions(+), 6 deletions(-)
```

The `.mli` signature does not change — `try_probe` and `refresh_many` already exposed `?timeout_s:float` as optional; only the doc strings were updated.

## Test plan

- [x] Local build: `dune build lib/cascade` exit=0, no errors involving `cascade_ollama_probe`.
- [ ] CI green
- [ ] Operator-facing: `MASC_OLLAMA_PROBE_TIMEOUT_SEC=2.5 ./run` should observe the new value at probe time.

## Source

fork-1 audit finding #7 (`timeout_s = 0.5` literal at `lib/cascade/cascade_ollama_probe.ml:93,118`).

## RFC

Not required. `lib/cascade/*` is not in CLAUDE.md `agent_delegation` RFC-gated list. Pure operator-facing tunable; the literal default is preserved as fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)