### PR TITLE
fix(mcp): respect effective Codex sync audit env

### DIFF
--- a/lib/keeper/keeper_config.ml
+++ b/lib/keeper/keeper_config.ml
@@ -91,23 +91,21 @@ let bool_default_true_of_env name =
       let v = String.trim v |> String.lowercase_ascii in
       not (v = "0" || v = "false" || v = "no" || v = "n")
 
+let bool_of_string raw =
+  let v = String.trim raw |> String.lowercase_ascii in
+  if v = "1" || v = "true" || v = "yes" || v = "y" || v = "on" then Some true
+  else if v = "0" || v = "false" || v = "no" || v = "n" || v = "off" then Some false
+  else None
+
 let bool_of_env_default name ~(default : bool) =
   match Env_config_core.raw_value_opt name with
   | None -> default
-  | Some raw ->
-      let v = String.trim raw |> String.lowercase_ascii in
-      if v = "1" || v = "true" || v = "yes" || v = "y" || v = "on" then true
-      else if v = "0" || v = "false" || v = "no" || v = "n" || v = "off" then false
-      else default
+  | Some raw -> Option.value (bool_of_string raw) ~default
 
 let bool_of_env_opt name =
   match Env_config_core.raw_value_opt name with
   | None -> None
-  | Some raw ->
-      let v = String.trim raw |> String.lowercase_ascii in
-      if v = "1" || v = "true" || v = "yes" || v = "y" || v = "on" then Some true
-      else if v = "0" || v = "false" || v = "no" || v = "n" || v = "off" then Some false
-      else None
+  | Some raw -> bool_of_string raw
 
 let valid_name_re = Re.Pcre.re "^[A-Za-z0-9._-]+$" |> Re.compile
 

--- a/lib/keeper/keeper_config.mli
+++ b/lib/keeper/keeper_config.mli
@@ -78,6 +78,12 @@ val bool_of_env_default : string -> default:bool -> bool
 (** Parse a boolean env var, returning [None] when unset or unrecognized. *)
 val bool_of_env_opt : string -> bool option
 
+(** Parse a raw string as a boolean.
+    Recognizes 1/true/yes/y/on and 0/false/no/n/off (case-insensitive).
+    Returns [None] for other values. Shared parsing logic for
+    [bool_of_env_default] and [bool_of_env_opt]. *)
+val bool_of_string : string -> bool option
+
 (** Parse an integer env var with default and clamping. *)
 val int_of_env_default : string -> default:int -> min_v:int -> max_v:int -> int
 

--- a/lib/keeper/keeper_mcp_provider_audit.ml
+++ b/lib/keeper/keeper_mcp_provider_audit.ml
@@ -104,17 +104,11 @@ let auto_construct_active_by_default (r : result) =
   | No_auto_construct_path _ -> false
   | Not_applicable_http_api -> true (* HTTP API providers don't need it *)
 
-let bool_of_env_value raw =
-  match String.trim raw |> String.lowercase_ascii with
-  | "1" | "true" | "yes" | "y" | "on" -> Some true
-  | "0" | "false" | "no" | "n" | "off" -> Some false
-  | _ -> None
-
 let auto_construct_effectively_active ?(env_lookup = Sys.getenv_opt)
     (r : result) =
   match r.construct with
   | Auto_construct_active { env_flag; default_when_unset; _ } -> (
-      match Option.bind (env_lookup env_flag) bool_of_env_value with
+      match Option.bind (env_lookup env_flag) Keeper_config.bool_of_string with
       | Some enabled -> enabled
       | None -> default_when_unset)
   | No_auto_construct_path _ -> false

--- a/lib/keeper/keeper_mcp_provider_audit.ml
+++ b/lib/keeper/keeper_mcp_provider_audit.ml
@@ -104,6 +104,22 @@ let auto_construct_active_by_default (r : result) =
   | No_auto_construct_path _ -> false
   | Not_applicable_http_api -> true (* HTTP API providers don't need it *)
 
+let bool_of_env_value raw =
+  match String.trim raw |> String.lowercase_ascii with
+  | "1" | "true" | "yes" | "y" | "on" -> Some true
+  | "0" | "false" | "no" | "n" | "off" -> Some false
+  | _ -> None
+
+let auto_construct_effectively_active ?(env_lookup = Sys.getenv_opt)
+    (r : result) =
+  match r.construct with
+  | Auto_construct_active { env_flag; default_when_unset; _ } -> (
+      match Option.bind (env_lookup env_flag) bool_of_env_value with
+      | Some enabled -> enabled
+      | None -> default_when_unset)
+  | No_auto_construct_path _ -> false
+  | Not_applicable_http_api -> true (* HTTP API providers don't need it *)
+
 let format_log_line (r : result) =
   match r.construct with
   | Auto_construct_active { env_flag; default_when_unset; module_name } ->

--- a/lib/keeper/keeper_mcp_provider_audit.mli
+++ b/lib/keeper/keeper_mcp_provider_audit.mli
@@ -35,6 +35,12 @@ val auto_construct_active_by_default : result -> bool
     as "true" because they have no MCP client and therefore need no
     construct path. *)
 
+val auto_construct_effectively_active :
+  ?env_lookup:(string -> string option) -> result -> bool
+(** True iff the provider has an active construct path after applying
+    the current env override.  Invalid env values fall back to the
+    documented default. *)
+
 val format_log_line : result -> string
 (** Grep-friendly tag:
     [[mcp_audit:active|no_construct_path|http_api]]. *)

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -50,9 +50,10 @@ let () =
     ~help:
       "Boot-time provider × MCP-config-construct audit \
        (PR-Mp3b / Leak 12): a provider has an auto-construct path \
-       but its env flag defaults to off (e.g. codex_cli + \
-       MASC_SYNC_CODEX_MCP_CONFIG=false). Operator must opt in or \
-       the keeper will fail tool calls on this lane. Labels: \
+       but its env flag defaults to off and is not enabled in the \
+       effective startup environment (e.g. codex_cli + \
+       MASC_SYNC_CODEX_MCP_CONFIG unset/false). Operator must opt in \
+       or the keeper will fail tool calls on this lane. Labels: \
        provider, env_flag."
     ()
 
@@ -683,15 +684,24 @@ let audit_provider_mcp_config_paths (_state : Mcp_server.server_state) =
         match r.Keeper_mcp_provider_audit.construct with
         | Auto_construct_active
             { default_when_unset = false; env_flag; _ } ->
-            Log.Misc.warn
-              "[mcp_audit:default_off] provider=%s env_flag=%s — \
-               operator must set %s=true for this lane to emit MCP \
-               config"
-              r.provider env_flag env_flag;
-            Prometheus.inc_counter
-              "masc_mcp_audit_default_off_total"
-              ~labels:[("provider", r.provider);
-                       ("env_flag", env_flag)] ()
+            if
+              Keeper_mcp_provider_audit.auto_construct_effectively_active r
+            then
+              Log.Misc.info
+                "[mcp_audit:default_off_overridden] provider=%s env_flag=%s — \
+                 effective env enables this lane"
+                r.provider env_flag
+            else begin
+              Log.Misc.warn
+                "[mcp_audit:default_off] provider=%s env_flag=%s — \
+                 operator must set %s=true for this lane to emit MCP \
+                 config"
+                r.provider env_flag env_flag;
+              Prometheus.inc_counter
+                "masc_mcp_audit_default_off_total"
+                ~labels:[("provider", r.provider);
+                         ("env_flag", env_flag)] ()
+            end
         | _ -> ())
         active;
       List.iter (fun r ->

--- a/test/test_keeper_mcp_provider_audit.ml
+++ b/test/test_keeper_mcp_provider_audit.ml
@@ -32,13 +32,14 @@ let test_codex_cli_active_default_false () =
         "default false (operator must opt in)" false default_when_unset
   | _ -> Alcotest.fail "codex_cli must be Auto_construct_active"
 
-let test_gemini_cli_no_construct_path () =
+let test_gemini_cli_active_default_true () =
   let r = Audit.lookup "gemini_cli" in
   match r.construct with
-  | Audit.No_auto_construct_path _ -> ()
-  | _ ->
-      Alcotest.fail
-        "gemini_cli has no enable path; only OAS_GEMINI_NO_MCP disable flag"
+  | Audit.Auto_construct_active { env_flag; default_when_unset; _ } ->
+      Alcotest.(check string)
+        "env flag" "OAS_GEMINI_ALLOWED_MCP" env_flag;
+      Alcotest.(check bool) "default true" true default_when_unset
+  | _ -> Alcotest.fail "gemini_cli must be Auto_construct_active"
 
 let test_glm_is_http_api () =
   let r = Audit.lookup "glm" in
@@ -89,9 +90,9 @@ let test_active_default_codex_false () =
     "codex_cli default-off — Leak 12 root cause" false
     (Audit.auto_construct_active_by_default (Audit.lookup "codex_cli"))
 
-let test_active_default_gemini_false () =
+let test_active_default_gemini_true () =
   Alcotest.(check bool)
-    "gemini_cli has no construct path" false
+    "gemini_cli default-on" true
     (Audit.auto_construct_active_by_default (Audit.lookup "gemini_cli"))
 
 let test_active_default_glm_true () =
@@ -102,6 +103,29 @@ let test_active_default_glm_true () =
     "glm is HTTP API, considered satisfied" true
     (Audit.auto_construct_active_by_default (Audit.lookup "glm"))
 
+let env_lookup pairs key = List.assoc_opt key pairs
+
+let test_effective_codex_uses_enabled_env () =
+  Alcotest.(check bool)
+    "codex_cli env override enables default-off construct path" true
+    (Audit.auto_construct_effectively_active
+       ~env_lookup:(env_lookup [ ("MASC_SYNC_CODEX_MCP_CONFIG", "1") ])
+       (Audit.lookup "codex_cli"))
+
+let test_effective_codex_false_env_stays_inactive () =
+  Alcotest.(check bool)
+    "codex_cli explicit false keeps construct path inactive" false
+    (Audit.auto_construct_effectively_active
+       ~env_lookup:(env_lookup [ ("MASC_SYNC_CODEX_MCP_CONFIG", "false") ])
+       (Audit.lookup "codex_cli"))
+
+let test_effective_invalid_env_falls_back_to_default () =
+  Alcotest.(check bool)
+    "invalid codex env falls back to default false" false
+    (Audit.auto_construct_effectively_active
+       ~env_lookup:(env_lookup [ ("MASC_SYNC_CODEX_MCP_CONFIG", "maybe") ])
+       (Audit.lookup "codex_cli"))
+
 (* ── audit_providers + partition ─────────────────────────────── *)
 
 let test_audit_providers_partitions_correctly () =
@@ -111,8 +135,9 @@ let test_audit_providers_partitions_correctly () =
   let results = Audit.audit_providers providers in
   Alcotest.(check int) "5 providers in" 5 (List.length results);
   let active, no_path, http_api = Audit.partition results in
-  Alcotest.(check int) "2 active (claude+codex)" 2 (List.length active);
-  Alcotest.(check int) "1 no construct path (gemini)" 1 (List.length no_path);
+  Alcotest.(check int) "3 active (claude+codex+gemini)" 3
+    (List.length active);
+  Alcotest.(check int) "0 no construct path" 0 (List.length no_path);
   Alcotest.(check int) "2 http api (glm+ollama)" 2 (List.length http_api)
 
 (* ── log line tags ───────────────────────────────────────────── *)
@@ -127,8 +152,8 @@ let test_format_log_tags () =
     (starts_with "[mcp_audit:active]"
        (Audit.format_log_line (Audit.lookup "claude_code")));
   Alcotest.(check bool)
-    "no_construct_path tag" true
-    (starts_with "[mcp_audit:no_construct_path]"
+    "gemini active tag" true
+    (starts_with "[mcp_audit:active]"
        (Audit.format_log_line (Audit.lookup "gemini_cli")));
   Alcotest.(check bool)
     "http_api tag" true
@@ -146,8 +171,8 @@ let () =
             test_kimi_cli_aliases_to_claude_path;
           Alcotest.test_case "codex_cli default false" `Quick
             test_codex_cli_active_default_false;
-          Alcotest.test_case "gemini_cli no construct path" `Quick
-            test_gemini_cli_no_construct_path;
+          Alcotest.test_case "gemini_cli default true" `Quick
+            test_gemini_cli_active_default_true;
           Alcotest.test_case "glm is HTTP API" `Quick test_glm_is_http_api;
           Alcotest.test_case "ollama is HTTP API" `Quick
             test_ollama_is_http_api;
@@ -160,10 +185,19 @@ let () =
             test_active_default_claude_true;
           Alcotest.test_case "codex default-off (Leak 12 root)" `Quick
             test_active_default_codex_false;
-          Alcotest.test_case "gemini no path => false" `Quick
-            test_active_default_gemini_false;
+          Alcotest.test_case "gemini default-on" `Quick
+            test_active_default_gemini_true;
           Alcotest.test_case "glm http_api => true" `Quick
             test_active_default_glm_true;
+        ] );
+      ( "auto_construct_effective_env semantics",
+        [
+          Alcotest.test_case "codex env true => active" `Quick
+            test_effective_codex_uses_enabled_env;
+          Alcotest.test_case "codex env false => inactive" `Quick
+            test_effective_codex_false_env_stays_inactive;
+          Alcotest.test_case "invalid env falls back" `Quick
+            test_effective_invalid_env_falls_back_to_default;
         ] );
       ( "aggregation",
         [


### PR DESCRIPTION
## Summary
- add an effective-env helper for provider MCP auto-construct audit
- suppress the misleading codex_cli default_off WARN/metric when MASC_SYNC_CODEX_MCP_CONFIG is actually enabled by the startup environment
- refresh the audit tests for current gemini_cli default-on behavior

## Verification
- scripts/dune-local.sh build test/test_keeper_mcp_provider_audit.exe
- ./_build/default/test/test_keeper_mcp_provider_audit.exe
- git diff --check

## Operator impact
When start-masc-mcp.sh exports MASC_SYNC_CODEX_MCP_CONFIG=1, startup now reports codex_cli as default_off_overridden instead of warning that the operator still needs to enable it. This removes a false alarm from the IDE/Codex MCP lane while preserving the warning when the env is unset or false.