### PR TITLE
fix(audit): scope keeper evidence by harness windows

### DIFF
--- a/docs/KEEPER-DOCKER-PR-LIFECYCLE-REPROBE.md
+++ b/docs/KEEPER-DOCKER-PR-LIFECYCLE-REPROBE.md
@@ -67,6 +67,13 @@ branches before re-running. An empty file means no collisions; rows look like:
  "remote_head":false,"worktree_branch":false,
  "blocker":"branch_collision_preflight"}
 ```
+The create-readiness gate also writes `create-readiness-audit.json` from a
+run-scoped durable evidence audit. If a keeper successfully executed
+Docker-backed `git push` and `keeper_pr_create` for the current run but the
+final Agent.run reply timed out before emitting the compact JSON, that durable
+tool evidence is accepted for review readiness. This keeps the gate
+evidence-first without letting stale run ids or self-reported replies advance
+the review phase.
 By default, mutation preflight also requires every selected keeper account to
 have upstream `WRITE`, `MAINTAIN`, or `ADMIN` permission for the target repo. For
 PUBLIC repositories, `--allow-fork-pr-for-readonly` permits `READ`/`TRIAGE`

--- a/scripts/audit-keeper-fleet-readiness.py
+++ b/scripts/audit-keeper-fleet-readiness.py
@@ -1401,8 +1401,8 @@ def scan_keeper_evidence(
             if row_matches_evidence_scope(
                 row, evidence_run_id, evidence_run_pr_numbers, evidence_windows
             ):
-                row_evidence, row_docker_evidence = pr_lifecycle_evidence_from_decision(
-                    row
+                row_evidence, row_docker_evidence = (
+                    pr_lifecycle_evidence_from_decision(row)
                 )
                 pr_lifecycle_evidence.update(row_evidence)
                 docker_pr_lifecycle_evidence.update(row_docker_evidence)

--- a/scripts/harness/workload/keeper_docker_pr_lifecycle_reprobe.sh
+++ b/scripts/harness/workload/keeper_docker_pr_lifecycle_reprobe.sh
@@ -20,6 +20,7 @@ REVIEW_TARGETS_FILE="$RUN_DIR/review-targets.jsonl"
 GITHUB_IDENTITY_COUNTS_FILE="$RUN_DIR/github-identity-counts.json"
 PROOF_BRANCH_COLLISIONS_FILE="$RUN_DIR/proof-branch-collisions.jsonl"
 CREATE_READINESS_FAILURES_FILE="$RUN_DIR/create-readiness-failures.jsonl"
+CREATE_READINESS_AUDIT_FILE="$RUN_DIR/create-readiness-audit.json"
 SUMMARY_FILE="$RUN_DIR/summary.json"
 AUDIT_FILE="$RUN_DIR/audit-docker-pr-lifecycle.json"
 AUDIT_STATUS_RESULT=0
@@ -190,6 +191,7 @@ while [[ $# -gt 0 ]]; do
         GITHUB_IDENTITY_COUNTS_FILE="$RUN_DIR/github-identity-counts.json"
         PROOF_BRANCH_COLLISIONS_FILE="$RUN_DIR/proof-branch-collisions.jsonl"
         CREATE_READINESS_FAILURES_FILE="$RUN_DIR/create-readiness-failures.jsonl"
+        CREATE_READINESS_AUDIT_FILE="$RUN_DIR/create-readiness-audit.json"
         SUMMARY_FILE="$RUN_DIR/summary.json"
         AUDIT_FILE="$RUN_DIR/audit-docker-pr-lifecycle.json"
       fi
@@ -207,6 +209,7 @@ while [[ $# -gt 0 ]]; do
       GITHUB_IDENTITY_COUNTS_FILE="$RUN_DIR/github-identity-counts.json"
       PROOF_BRANCH_COLLISIONS_FILE="$RUN_DIR/proof-branch-collisions.jsonl"
       CREATE_READINESS_FAILURES_FILE="$RUN_DIR/create-readiness-failures.jsonl"
+      CREATE_READINESS_AUDIT_FILE="$RUN_DIR/create-readiness-audit.json"
       SUMMARY_FILE="$RUN_DIR/summary.json"
       AUDIT_FILE="$RUN_DIR/audit-docker-pr-lifecycle.json"
       shift 2
@@ -242,6 +245,7 @@ mkdir -p "$RUN_DIR" "$RAW_DIR" "$PROMPT_DIR"
 : >"$REVIEW_TARGETS_FILE"
 : >"$PROOF_BRANCH_COLLISIONS_FILE"
 : >"$CREATE_READINESS_FAILURES_FILE"
+: >"$CREATE_READINESS_AUDIT_FILE"
 
 log() {
   printf '[%s] %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$*" >&2
@@ -1492,8 +1496,39 @@ create_result_has_success_markers() {
     && printf '%s' "$reply" | grep -Eq 'https://github\.com/[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+/pull/[0-9]+'
 }
 
+run_create_readiness_audit() {
+  local tmp_file
+  tmp_file="$CREATE_READINESS_AUDIT_FILE.tmp"
+  if ! scripts/audit-keeper-fleet-readiness.py \
+      --base-path "$BASE_PATH" \
+      --expected-keepers 0 \
+      --max-silence-hours "$MAX_SILENCE_HOURS" \
+      --no-require-board-evidence \
+      --require-docker-pr-create-evidence \
+      --require-docker-git-push-evidence \
+      --evidence-run-id "$RUN_ID" \
+      --harness-run-dir "$RUN_DIR" \
+      --json >"$tmp_file"; then
+    :
+  fi
+  mv "$tmp_file" "$CREATE_READINESS_AUDIT_FILE"
+}
+
+create_durable_evidence_has_success_markers() {
+  local keeper="$1"
+  [[ -s "$CREATE_READINESS_AUDIT_FILE" ]] || return 1
+  jq -e --arg keeper "$keeper" '
+    (.keepers // [])[]
+    | select(.name == $keeper)
+    | (.docker_pr_create_action == true)
+      and (.docker_git_push_action == true)
+      and ((.pr_url_evidence == true) or (.pr_created_evidence == true))
+  ' "$CREATE_READINESS_AUDIT_FILE" >/dev/null
+}
+
 all_create_results_ready_for_review() {
   : >"$CREATE_READINESS_FAILURES_FILE"
+  run_create_readiness_audit
 
   local keeper status text_file
   while IFS= read -r keeper; do
@@ -1512,18 +1547,30 @@ all_create_results_ready_for_review() {
     )"
 
     if [[ -z "$status" || -z "$text_file" ]]; then
+      if create_durable_evidence_has_success_markers "$keeper"; then
+        log "create readiness accepted durable tool evidence for $keeper with missing result row"
+        continue
+      fi
       jq -nc --arg keeper "$keeper" \
         '{keeper:$keeper, blocker:"create_result_missing"}' \
         >>"$CREATE_READINESS_FAILURES_FILE"
       continue
     fi
     if [[ "$status" != "done" && "$status" != "completed" && "$status" != "complete" ]]; then
+      if create_durable_evidence_has_success_markers "$keeper"; then
+        log "create readiness accepted durable tool evidence for $keeper despite status=$status"
+        continue
+      fi
       jq -nc --arg keeper "$keeper" --arg status "$status" \
         '{keeper:$keeper, status:$status, blocker:"create_status_not_success"}' \
         >>"$CREATE_READINESS_FAILURES_FILE"
       continue
     fi
     if ! create_result_has_success_markers "$keeper" "$text_file"; then
+      if create_durable_evidence_has_success_markers "$keeper"; then
+        log "create readiness accepted durable tool evidence for $keeper despite missing reply markers"
+        continue
+      fi
       jq -nc --arg keeper "$keeper" --arg status "$status" --arg text_file "$text_file" \
         '{keeper:$keeper, status:$status, text_file:$text_file, blocker:"create_success_markers_missing"}' \
         >>"$CREATE_READINESS_FAILURES_FILE"

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -1204,9 +1204,20 @@ let test_keeper_required_tool_contracts () =
           "create_success_markers_missing"
      && file_contains_pattern
           "scripts/harness/workload/keeper_docker_pr_lifecycle_reprobe.sh"
+          "create_durable_evidence_has_success_markers"
+     && file_contains_pattern
+          "scripts/harness/workload/keeper_docker_pr_lifecycle_reprobe.sh"
+          {|--harness-run-dir "$RUN_DIR"|}
+     && file_contains_pattern
+          "scripts/harness/workload/keeper_docker_pr_lifecycle_reprobe.sh"
+          "create-readiness-audit.json"
+     && file_contains_pattern
+          "scripts/harness/workload/keeper_docker_pr_lifecycle_reprobe.sh"
           "skipping review phase because create phase did not produce complete success evidence"
      && file_contains_pattern "docs/KEEPER-DOCKER-PR-LIFECYCLE-REPROBE.md"
-          "`create-readiness-failures.jsonl`");
+          "`create-readiness-failures.jsonl`"
+     && file_contains_pattern "docs/KEEPER-DOCKER-PR-LIFECYCLE-REPROBE.md"
+          "`create-readiness-audit.json`");
   check bool "docker PR lifecycle supports review-only resume" true
     (file_contains_pattern
        "scripts/harness/workload/keeper_docker_pr_lifecycle_reprobe.sh"


### PR DESCRIPTION
## Summary
- pass the lifecycle harness run directory into fleet readiness audit
- let audit scope redacted tool-call rows by each keeper message request window
- accept run-scoped durable Docker `git push` + `keeper_pr_create` evidence for create-readiness when the final Agent.run reply times out after the tools already succeeded
- keep existing run-id/PR-number correlation and add source guards/tests

## Why
A stack smoke on isolated server commit `9d134fcdc8` produced this exact shape:

- `sangsu` executed Docker-backed `keeper_bash` git push and `keeper_pr_create`, opening draft PR #14078.
- The keeper request still returned `Timeout after 900.0s` before emitting the compact JSON reply.
- The previous harness gate treated that as `create_status_not_success` and skipped review, even though durable tool evidence for create/push was present and run-scoped.

The review gate now remains evidence-first: stale run ids and self-reported text still do not count, but successful durable tool rows from the current run/request window can advance create-readiness.

## Rebase note
Rebased onto current `origin/main` (`2ac0a471e6`) after #13954/#13961 landed. The only conflict was in `test/test_ci_hardening_source.ml`; the resolution preserves both the new review-resume/fork-head assertions from main and this PR's `create-readiness-audit.json` assertion.

## Verification
- `python3 -m py_compile scripts/audit-keeper-fleet-readiness.py test/test_audit_keeper_fleet_readiness.py`
- `ruff check scripts/audit-keeper-fleet-readiness.py test/test_audit_keeper_fleet_readiness.py`
- `python3 test/test_audit_keeper_fleet_readiness.py`
- `bash -n scripts/harness/workload/keeper_docker_pr_lifecycle_reprobe.sh`
- `ocamlc -stop-after parsing test/test_ci_hardening_source.ml`
- `scripts/dune-local.sh build test/test_ci_hardening_source.exe`
- `./_build/default/test/test_ci_hardening_source.exe`
- `scripts/check-oas-pin.sh --local-only`
- `git diff --check`
- `git diff --check origin/main...HEAD`

Note: `pyright --outputjson scripts/audit-keeper-fleet-readiness.py test/test_audit_keeper_fleet_readiness.py` is unavailable in this shell (`command not found`).
