### PR TITLE
fix: count meta cognition jsonl read drops

### DIFF
--- a/lib/meta_cognition_snapshot.ml
+++ b/lib/meta_cognition_snapshot.ml
@@ -14,15 +14,43 @@ open Meta_cognition_types
 (* Data loading                                                     *)
 (* ================================================================ *)
 
+let persistence_surface = "meta_cognition_snapshot"
+
+let observe_drop ~reason ~delta =
+  Prometheus.inc_counter Prometheus.metric_persistence_read_drops
+    ~labels:[("surface", persistence_surface); ("reason", reason)]
+    ~delta
+    ()
+
+let report_drop ?(delta = 1.0) ~reason ~path ~detail () =
+  Safe_ops.report_persistence_read_drop
+    ~on_drop:(fun () -> observe_drop ~reason ~delta)
+    ~surface:persistence_surface
+    ~reason
+    ~path
+    ~detail
+
 let load_jsonl_safe path =
   if not (Sys.file_exists path) then []
   else
-    try Fs_compat.load_jsonl path
+    try
+      let rows, malformed = Fs_compat.load_jsonl_diagnostics path in
+      if malformed > 0 then
+        report_drop
+          ~delta:(float_of_int malformed)
+          ~reason:Safe_ops.persistence_read_drop_reason_entry_load_error
+          ~path
+          ~detail:(Printf.sprintf "%d malformed JSONL line(s)" malformed)
+          ();
+      rows
     with
     | Eio.Cancel.Cancelled _ as e -> raise e
     | exn ->
-        Log.Pages.warn "load_jsonl_safe: failed to load %s: %s"
-          path (Printexc.to_string exn);
+        report_drop
+          ~reason:Safe_ops.persistence_read_drop_reason_entry_load_error
+          ~path
+          ~detail:(Printexc.to_string exn)
+          ();
         []
 
 let load_board_posts config =
@@ -40,26 +68,17 @@ let load_board_vote_count config =
   List.length (load_jsonl_safe path)
 
 let load_governance_cases config =
-  let surface = "meta_cognition_snapshot" in
-  let observe_drop ~reason =
-    Prometheus.inc_counter Prometheus.metric_persistence_read_drops
-      ~labels:[("surface", surface); ("reason", reason)] ()
-  in
-  let report_drop ~reason ~path ~detail =
-    Safe_ops.report_persistence_read_drop
-      ~on_drop:(fun () -> observe_drop ~reason)
-      ~surface
-      ~reason
-      ~path
-      ~detail
-  in
   let dir = Filename.concat (Coord.masc_dir config) "governance_v2/cases" in
   if not (Sys.file_exists dir) then
     []
   else
     match Safe_ops.list_dir_safe dir with
     | Error detail ->
-      report_drop ~reason:Safe_ops.persistence_read_drop_reason_list_dir_error ~path:dir ~detail;
+      report_drop
+        ~reason:Safe_ops.persistence_read_drop_reason_list_dir_error
+        ~path:dir
+        ~detail
+        ();
       []
     | Ok names ->
         names
@@ -71,8 +90,10 @@ let load_governance_cases config =
                match
                  Safe_ops.result_to_option_logged
                    ~on_drop:(fun () ->
-                     observe_drop ~reason:Safe_ops.persistence_read_drop_reason_entry_load_error)
-                   ~surface
+                     observe_drop
+                       ~reason:Safe_ops.persistence_read_drop_reason_entry_load_error
+                       ~delta:1.0)
+                   ~surface:persistence_surface
                    ~reason:Safe_ops.persistence_read_drop_reason_entry_load_error
                    ~path
                    (Safe_ops.read_json_file_safe path)
@@ -84,7 +105,8 @@ let load_governance_cases config =
                      report_drop
                        ~reason:Safe_ops.persistence_read_drop_reason_invalid_payload
                        ~path
-                       ~detail:"missing required id";
+                       ~detail:"missing required id"
+                       ();
                      None
                    ) else
                      let title = Safe_ops.json_string ~default:"" "title" json in

--- a/test/test_meta_cognition_snapshot.ml
+++ b/test/test_meta_cognition_snapshot.ml
@@ -254,6 +254,23 @@ let test_parse_summary_preserves_refs_and_secondary_signals () =
         [ "comment:c-1"; "post:p-root" ]
         (interpretation.evidence_refs |> List.sort String.compare)
 
+let test_snapshot_jsonl_load_failure_increments_drop_metric () =
+  with_ctx @@ fun ctx ->
+  let posts_path =
+    Filename.concat (Coord.masc_dir ctx.config) "board_posts.jsonl"
+  in
+  Fs_compat.save_file posts_path "{not-json\n";
+  let before =
+    persistence_counter Safe_ops.persistence_read_drop_reason_entry_load_error
+  in
+  let json = Meta_cognition.snapshot_json ~limit:5 ctx.config in
+  let open Yojson.Safe.Util in
+  Alcotest.(check int) "snapshot falls back to empty beliefs" 0
+    (json |> member "beliefs" |> to_list |> List.length);
+  Alcotest.(check (float 0.1)) "jsonl load failure increments entry_load_error" 1.0
+    (persistence_counter Safe_ops.persistence_read_drop_reason_entry_load_error
+     -. before)
+
 let test_snapshot_governance_cases_skip_bad_entries_with_metric () =
   with_ctx @@ fun ctx ->
   let cases_dir = Filename.concat (Coord.masc_dir ctx.config) "governance_v2/cases" in
@@ -302,6 +319,8 @@ let () =
             test_snapshot_marks_contested_belief;
           Alcotest.test_case "parses summary refs and secondary signals" `Quick
             test_parse_summary_preserves_refs_and_secondary_signals;
+          Alcotest.test_case "jsonl load failures increment drop metric" `Quick
+            test_snapshot_jsonl_load_failure_increments_drop_metric;
           Alcotest.test_case "governance cases skip bad entries with metric"
             `Quick test_snapshot_governance_cases_skip_bad_entries_with_metric;
         ] );


### PR DESCRIPTION
## Summary
- count malformed meta-cognition board JSONL lines through the existing persistence read drop metric
- reuse the meta_cognition_snapshot persistence-drop surface for board, comment, vote, and governance reads
- add a focused regression for malformed board_posts.jsonl falling back to an empty snapshot while incrementing entry_load_error

## Why it matters
Meta-cognition snapshots can currently look empty when a board JSONL file has malformed rows. Fs_compat already logs malformed JSONL lines, but the meta-cognition surface did not convert those drops into the shared persistence drop metric. This keeps the dashboard fallback behavior but makes the data loss visible to operators.

## Verification
- git diff --check
- lockf -k -t 1200 /tmp/me-dune-local.lock env MASC_DUNE_LOCK_HELD=1 MASC_SKIP_OPAM_LOCK=1 DUNE_JOBS=1 DUNE_CACHE=disabled scripts/dune-local.sh build test/test_meta_cognition_snapshot.exe
- ./_build/default/test/test_meta_cognition_snapshot.exe test snapshot 3

## Local caveat
- ./_build/default/test/test_meta_cognition_snapshot.exe still fails the pre-existing snapshot case 0 assertion: stagnation score elevated. The new jsonl load failure metric case passes directly.