### PR TITLE
fix(dashboard): land progress blocker classifier on main

### DIFF
--- a/dashboard/src/api/dashboard.test.ts
+++ b/dashboard/src/api/dashboard.test.ts
@@ -998,6 +998,11 @@ describe('fetchKeeperConfig', () => {
       ['tool_required_unsatisfied', '필수 도구 미충족'],
       ['fiber_unresolved', 'Fiber 미해결'],
       ['stale_turn_timeout', '오래된 턴 만료'],
+      ['awaiting_operator', '운영자 조치 대기'],
+      ['awaiting_sandbox_egress', '샌드박스 egress 대기'],
+      ['supervisor_paused', 'Supervisor 일시정지'],
+      ['synthetic_stall', '합성 상태 정체'],
+      ['self_imposed_idle', '자체 대기'],
     ] as const
 
     for (const [blockerClass, label] of cases) {

--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -2051,6 +2051,11 @@ function normalizeRuntimeBlockerClass(value: unknown): KeeperConfig['runtime']['
     case 'turn_failures':
     case 'exception':
     case 'stale_fleet_batch':
+    case 'awaiting_operator':
+    case 'awaiting_sandbox_egress':
+    case 'supervisor_paused':
+    case 'synthetic_stall':
+    case 'self_imposed_idle':
       return blockerClass
     default:
       return null

--- a/dashboard/src/lib/keeper-runtime-display.test.ts
+++ b/dashboard/src/lib/keeper-runtime-display.test.ts
@@ -201,6 +201,26 @@ describe('keeperRuntimeBlockerHint', () => {
       'exception',
       'Keeper 런타임 예외가 기록되어 로그와 최근 turn 상태 확인이 필요합니다.',
     ],
+    [
+      'awaiting_operator',
+      '진행을 위해 운영자의 승인, 결정, 또는 게이트 해제가 필요합니다.',
+    ],
+    [
+      'awaiting_sandbox_egress',
+      '샌드박스 네트워크 또는 push egress 정책 때문에 keeper가 진행하지 못하고 있습니다.',
+    ],
+    [
+      'supervisor_paused',
+      'Supervisor가 keeper를 일시정지한 상태라 재개 조건을 확인해야 합니다.',
+    ],
+    [
+      'synthetic_stall',
+      '실제 STATE 없이 합성된 진행 기록만 남아 최근 턴 산출물을 재확인해야 합니다.',
+    ],
+    [
+      'self_imposed_idle',
+      'Keeper가 관찰 또는 대기만 계획하고 있어 다음 실행 지시가 필요할 수 있습니다.',
+    ],
   ]
 
   it.each(registryBlockerHintCases)(

--- a/dashboard/src/lib/keeper-runtime-display.ts
+++ b/dashboard/src/lib/keeper-runtime-display.ts
@@ -247,6 +247,11 @@ const runtimeBlockerLabels = {
   turn_failures: '턴 실패 반복',
   exception: '런타임 예외',
   stale_fleet_batch: 'Fleet stale 배치',
+  awaiting_operator: '운영자 조치 대기',
+  awaiting_sandbox_egress: '샌드박스 egress 대기',
+  supervisor_paused: 'Supervisor 일시정지',
+  synthetic_stall: '합성 상태 정체',
+  self_imposed_idle: '자체 대기',
 } satisfies Record<KeeperRuntimeBlockerClass, string>
 
 export function keeperRuntimeBlockerLabel(
@@ -318,6 +323,21 @@ export function keeperRuntimeBlockerHint(keeper: Keeper | null | undefined): str
   }
   if (blockerClass === 'stale_fleet_batch') {
     return '여러 keeper가 같은 watchdog 창에서 stale로 종료되어 supervisor pause/backoff 상태 확인이 필요합니다.'
+  }
+  if (blockerClass === 'awaiting_operator') {
+    return '진행을 위해 운영자의 승인, 결정, 또는 게이트 해제가 필요합니다.'
+  }
+  if (blockerClass === 'awaiting_sandbox_egress') {
+    return '샌드박스 네트워크 또는 push egress 정책 때문에 keeper가 진행하지 못하고 있습니다.'
+  }
+  if (blockerClass === 'supervisor_paused') {
+    return 'Supervisor가 keeper를 일시정지한 상태라 재개 조건을 확인해야 합니다.'
+  }
+  if (blockerClass === 'synthetic_stall') {
+    return '실제 STATE 없이 합성된 진행 기록만 남아 최근 턴 산출물을 재확인해야 합니다.'
+  }
+  if (blockerClass === 'self_imposed_idle') {
+    return 'Keeper가 관찰 또는 대기만 계획하고 있어 다음 실행 지시가 필요할 수 있습니다.'
   }
   return null
 }

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -392,6 +392,11 @@ export type KeeperRuntimeBlockerClass =
   | 'turn_failures'
   | 'exception'
   | 'stale_fleet_batch'
+  | 'awaiting_operator'
+  | 'awaiting_sandbox_egress'
+  | 'supervisor_paused'
+  | 'synthetic_stall'
+  | 'self_imposed_idle'
 
 export interface KeeperTrustLatestEvent {
   kind: string

--- a/lib/keeper/keeper_status_bridge.ml
+++ b/lib/keeper/keeper_status_bridge.ml
@@ -389,6 +389,155 @@ let runtime_blocker_surface_of_failure_reason
           continue_gate = false;
         }
 
+let has_any_ci text needles =
+  List.exists (String_util.contains_substring_ci text) needles
+
+let first_nonempty_line label values =
+  values
+  |> List.map String.trim
+  |> List.find_map (fun value ->
+         if String.equal value "" then None
+         else Some (Printf.sprintf "%s: %s" label value))
+
+let progress_snapshot_narrative_lines
+    (snapshot : Keeper_memory_policy.keeper_state_snapshot) =
+  [
+    (match snapshot.progress with
+     | Some progress -> Some ("Progress: " ^ String.trim progress)
+     | None -> None);
+    (match snapshot.done_summary with
+     | Some done_summary -> Some ("Done: " ^ String.trim done_summary)
+     | None -> None);
+    (match snapshot.next_summary with
+     | Some next_summary -> Some ("Next plan: " ^ String.trim next_summary)
+     | None -> None);
+    first_nonempty_line "Next" snapshot.next_items;
+    first_nonempty_line "Decisions" snapshot.decisions;
+    first_nonempty_line "OpenQuestions" snapshot.open_questions;
+    first_nonempty_line "Constraints" snapshot.constraints;
+  ]
+  |> List.filter_map (function
+         | Some line when not (String.equal (String.trim line) "") -> Some line
+         | _ -> None)
+
+let narrative_summary line =
+  String_util.utf8_safe ~max_bytes:220 ~suffix:"..." line
+  |> String_util.to_string
+
+let runtime_blocker_surface_of_progress_snapshot
+    (snapshot : Keeper_memory_policy.keeper_state_snapshot) =
+  let lines = progress_snapshot_narrative_lines snapshot in
+  let text = String.concat "\n" lines in
+  let line_with needles =
+    List.find_opt (fun line -> has_any_ci line needles) lines
+  in
+  let surface blocker_class line =
+    Some
+      {
+        blocker_class;
+        summary = narrative_summary line;
+        continue_gate = false;
+      }
+  in
+  if lines = [] then None
+  else
+    match
+      line_with
+        [
+          "sandbox egress";
+          "push egress";
+          "github.com push";
+          "github push";
+          "network egress";
+          "sandbox";
+        ]
+    with
+    | Some line
+      when has_any_ci line [ "egress"; "push"; "github.com"; "network" ] ->
+        surface "awaiting_sandbox_egress" line
+    | _ ->
+      (match line_with [ "supervisor"; "supervisor가" ] with
+       | Some line when has_any_ci line [ "pause"; "paused"; "unpause"; "의도" ]
+         -> surface "supervisor_paused" line
+       | _ ->
+         (match
+            line_with
+              [
+                "push gate";
+                "operator";
+                "human";
+                "approval";
+                "approve";
+                "decision tree";
+                "4-gate";
+                "4 gate";
+                "unblock";
+                "manual";
+              ]
+          with
+          | Some line
+            when has_any_ci
+                   line
+                   [
+                     "waiting";
+                     "await";
+                     "blocked";
+                     "respond";
+                     "resolved";
+                     "gate";
+                     "decision";
+                     "approval";
+                     "approve";
+                     "unblock";
+                     "manual";
+                   ] ->
+              surface "awaiting_operator" line
+          | _ ->
+            if Keeper_synthetic_marker.contains_marker text
+               && has_any_ci
+                    text
+                    [
+                      "no visible output";
+                      "last output";
+                      "belief_summary";
+                      "social_model";
+                      "실제 막힘";
+                    ]
+            then
+              surface "synthetic_stall"
+                (line_with [ Keeper_synthetic_marker.marker_prefix ]
+                 |> Option.value ~default:(List.hd lines))
+            else (
+              match
+                line_with
+                  [
+                    "watching";
+                    "monitor";
+                    "no action";
+                    "no next action";
+                    "자체 action 부재";
+                    "감시";
+                  ]
+              with
+              | Some line -> surface "self_imposed_idle" line
+              | None -> None)))
+
+let runtime_blocker_surface_of_progress_narrative config
+    (meta : keeper_meta) =
+  let from_continuity_summary =
+    match
+      Keeper_memory_policy.progress_snapshot_cache_of_text meta.continuity_summary
+    with
+    | Some cache -> runtime_blocker_surface_of_progress_snapshot cache.snapshot
+    | None -> None
+  in
+  match from_continuity_summary with
+  | Some _ as blocker -> blocker
+  | None ->
+      (match Keeper_memory_policy.read_progress_snapshot ~config ~name:meta.name with
+       | Some snapshot -> runtime_blocker_surface_of_progress_snapshot snapshot
+       | None -> None)
+
 let proactive_runtime_reason_is_current (meta : keeper_meta) =
   let proactive_ts = meta.runtime.proactive_rt.last_ts in
   let last_turn_ts = meta.runtime.usage.last_turn_ts in
@@ -426,7 +575,7 @@ let runtime_blocker_surface_opt (config : Coord_utils.config)
                  Some (runtime_blocker_surface_of_legacy_string
                          meta.runtime.proactive_rt.last_reason cls)
              | None -> None)
-        | None -> None)
+        | None -> runtime_blocker_surface_of_progress_narrative config meta)
   in
   derived
 

--- a/test/test_keeper_exec_status.ml
+++ b/test/test_keeper_exec_status.ml
@@ -4,6 +4,8 @@ module ES = Masc_mcp.Keeper_exec_status
 module KSB = Masc_mcp.Keeper_status_bridge
 module KR = Masc_mcp.Keeper_registry
 module KT = Masc_mcp.Keeper_types
+module KMP = Masc_mcp.Keeper_memory_policy
+module KTS = Masc_mcp.Keeper_types_support
 module Coord = Masc_mcp.Coord
 module OWN = Masc_mcp.Oas_worker_named
 
@@ -789,6 +791,101 @@ let test_runtime_surface_maps_registry_failure_reason_blockers () =
          (runtime |> member "needs_attention" |> to_bool))
     cases
 
+let test_runtime_surface_classifies_progress_narrative_blockers () =
+  let cases =
+    [
+      ( "operator-gate",
+        "OpenQuestions: Why hasn't the push gate been resolved in 24h+?",
+        "awaiting_operator",
+        "push gate" );
+      ( "sandbox-egress",
+        "OpenQuestions: whether keeper docker sandboxes can be granted github.com push egress",
+        "awaiting_sandbox_egress",
+        "github.com push egress" );
+      ( "supervisor-paused",
+        "Decisions: [SYNTHETIC] Last output: 실제 막힘. supervisor가 의도적으로 건 pause",
+        "supervisor_paused",
+        "supervisor" );
+      ( "synthetic-stall",
+        "Decisions: [SYNTHETIC] BELIEF_SUMMARY: Continuity advisory flags backlog delta",
+        "synthetic_stall",
+        "BELIEF_SUMMARY" );
+      ( "self-imposed-idle",
+        "Next: watch the next dispatch cycle; no next action",
+        "self_imposed_idle",
+        "no next action" );
+    ]
+  in
+  List.iter
+    (fun (suffix, continuity_summary, expected_class, expected_summary_substring) ->
+       KR.clear ();
+       let base = make_meta ~name:("runtime-progress-" ^ suffix ^ "-test") () in
+       let meta = { base with continuity_summary } in
+       let config =
+         Coord.default_config ("/tmp/test-keeper-exec-status-progress-" ^ suffix)
+       in
+       let runtime = KSB.runtime_surface_json config meta in
+       let open Yojson.Safe.Util in
+       check string (suffix ^ " runtime blocker class") expected_class
+         (runtime |> member "runtime_blocker_class" |> to_string);
+       let summary =
+         runtime |> member "runtime_blocker_summary" |> to_string
+       in
+       check bool (suffix ^ " summary preserves progress narrative") true
+         (has_substring summary expected_summary_substring);
+       check bool (suffix ^ " runtime attention needed") true
+         (runtime |> member "needs_attention" |> to_bool))
+    cases
+
+let test_runtime_surface_reads_progress_md_narrative_blocker () =
+  KR.clear ();
+  with_temp_base_path "test-keeper-exec-status-progress-md-" (fun base_path ->
+    let meta = make_meta ~name:"runtime-progress-md-narrative-test" () in
+    let config = Coord.default_config base_path in
+    let snapshot =
+      {
+        KMP.empty_keeper_state_snapshot with
+        open_questions =
+          [
+            "when operator responds to the 4-gate decision tree";
+          ];
+      }
+    in
+    let path = KTS.keeper_progress_path config meta.name in
+    match KMP.write_progress_snapshot_path ~path snapshot with
+    | Error err -> fail ("write_progress_snapshot_path failed: " ^ err)
+    | Ok () ->
+        let runtime = KSB.runtime_surface_json config meta in
+        let open Yojson.Safe.Util in
+        check string "progress.md blocker class" "awaiting_operator"
+          (runtime |> member "runtime_blocker_class" |> to_string);
+        check bool "progress.md blocker summary keeps narrative" true
+          (has_substring
+             (runtime |> member "runtime_blocker_summary" |> to_string)
+             "4-gate decision tree"))
+
+let test_runtime_surface_prefers_typed_blocker_over_progress_narrative () =
+  KR.clear ();
+  let base = make_meta ~name:"runtime-progress-typed-priority-test" () in
+  let meta =
+    {
+      base with
+      continuity_summary =
+        "OpenQuestions: when operator responds to the 4-gate decision tree";
+      runtime =
+        {
+          base.runtime with
+          last_blocker = "turn wall-clock timeout exceeded";
+          last_blocker_class = Some KT.Turn_timeout;
+        };
+    }
+  in
+  let config = Coord.default_config "/tmp/test-keeper-exec-status-progress-priority" in
+  let runtime = KSB.runtime_surface_json config meta in
+  let open Yojson.Safe.Util in
+  check string "typed runtime blocker wins" "turn_timeout"
+    (runtime |> member "runtime_blocker_class" |> to_string)
+
 let test_runtime_surface_exposes_social_model_resolution_fields () =
   KR.clear ();
   let base = make_meta ~name:"runtime-social-model-test" () in
@@ -982,6 +1079,15 @@ let () =
             test_runtime_surface_maps_heartbeat_failure_reason;
           test_case "runtime surface maps registry failure blockers" `Quick
             test_runtime_surface_maps_registry_failure_reason_blockers;
+          test_case "runtime surface classifies progress narrative blockers"
+            `Quick
+            test_runtime_surface_classifies_progress_narrative_blockers;
+          test_case "runtime surface reads progress.md narrative blocker"
+            `Quick
+            test_runtime_surface_reads_progress_md_narrative_blocker;
+          test_case "runtime surface prefers typed blocker over progress narrative"
+            `Quick
+            test_runtime_surface_prefers_typed_blocker_over_progress_narrative;
           test_case "runtime surface exposes social model fields" `Quick
             test_runtime_surface_exposes_social_model_resolution_fields;
           test_case "runtime surface exposes model display labels" `Quick


### PR DESCRIPTION
## Summary
- Rebuild the #13755 progress-narrative blocker classifier from current `origin/main`.
- The previous #13755 merge landed only into stack base `fix/keeper-pr-create-guidance-0506` after that stack base had already merged to main, so live `origin/main` still lacked the #10512 narrative blocker classes.
- Adds structured classes for progress/continuity narrative blockers: `awaiting_operator`, `awaiting_sandbox_egress`, `supervisor_paused`, `synthetic_stall`, and `self_imposed_idle`.
- Preserves typed runtime/registry blockers above narrative fallback and extends dashboard normalization/display coverage.

## Validation
- `git diff --check HEAD~1..HEAD`
- `scripts/dune-local.sh build test/test_keeper_exec_status.exe` attempted first; shared `/tmp/me-dune-local.lock` was held by unrelated worktrees, so I stopped the queued wrapper and used the focused single-job fallback below.
- `env DUNE_JOBS=1 MASC_SKIP_OPAM_LOCK=1 MASC_SKIP_PIN_CHECK=1 dune build --root . test/test_keeper_exec_status.exe`
- `env MASC_SKIP_PIN_CHECK=1 ./_build/default/test/test_keeper_exec_status.exe` — 39 tests
- `pnpm --dir dashboard install --frozen-lockfile --offline` — reused pnpm store, downloaded 0
- `pnpm --dir dashboard exec tsc --noEmit --pretty false`
- `pnpm --dir dashboard exec vitest run --config vitest.config.ts src/api/dashboard.test.ts src/lib/keeper-runtime-display.test.ts --no-file-parallelism --maxWorkers=1` — 55 tests

Fixes #10512.