### PR TITLE
fix: count agent reputation jsonl read drops

### DIFF
--- a/lib/agent_reputation.ml
+++ b/lib/agent_reputation.ml
@@ -107,20 +107,44 @@ let reputation_of_json (json : Yojson.Safe.t) : agent_reputation option =
 
 (** {1 JSONL Helpers} *)
 
+let persistence_surface = "agent_reputation"
+
+let observe_jsonl_drop ~reason ~delta =
+  Prometheus.inc_counter Prometheus.metric_persistence_read_drops
+    ~labels:[("surface", persistence_surface); ("reason", reason)]
+    ~delta
+    ()
+
+let report_jsonl_drop ~reason ~path ~detail ~delta =
+  Safe_ops.report_persistence_read_drop
+    ~on_drop:(fun () -> observe_jsonl_drop ~reason ~delta)
+    ~surface:persistence_surface
+    ~reason
+    ~path
+    ~detail
+
 (** Load a JSONL file, filter out malformed lines. *)
 let load_jsonl_safe (path : string) : Yojson.Safe.t list =
   if not (Sys.file_exists path) then []
   else
-    match Safe_ops.read_file_safe path with
-    | Error msg ->
-        Log.Misc.warn "agent_reputation: failed to read %s: %s" path msg;
+    try
+      let rows, malformed = Fs_compat.load_jsonl_diagnostics path in
+      if malformed > 0 then
+        report_jsonl_drop
+          ~reason:Safe_ops.persistence_read_drop_reason_entry_load_error
+          ~path
+          ~detail:(Printf.sprintf "%d malformed JSONL line(s)" malformed)
+          ~delta:(Float.of_int malformed);
+      rows
+    with
+    | Eio.Cancel.Cancelled _ as e -> raise e
+    | exn ->
+        report_jsonl_drop
+          ~reason:Safe_ops.persistence_read_drop_reason_entry_load_error
+          ~path
+          ~detail:(Printexc.to_string exn)
+          ~delta:1.0;
         []
-    | Ok content ->
-      String.split_on_char '\n' content
-      |> List.filter (fun line -> String.length (String.trim line) > 0)
-      |> List.filter_map (fun line ->
-          try Some (Yojson.Safe.from_string line)
-          with Yojson.Json_error _ -> None)
 
 (** {1 Task Counting from Coord State} *)
 

--- a/test/test_reputation_multi_dim.ml
+++ b/test/test_reputation_multi_dim.ml
@@ -3,6 +3,33 @@
 open Alcotest
 open Masc_mcp
 
+let persistence_counter reason =
+  Prometheus.metric_value_or_zero Prometheus.metric_persistence_read_drops
+    ~labels:[("surface", "agent_reputation"); ("reason", reason)]
+    ()
+
+let with_temp_config f =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let dir = Filename.temp_file "test_agent_reputation_" "" in
+  Unix.unlink dir;
+  Unix.mkdir dir 0o755;
+  let rec cleanup path =
+    if Sys.file_exists path then
+      if Sys.is_directory path then (
+        Array.iter
+          (fun name -> cleanup (Filename.concat path name))
+          (Sys.readdir path);
+        Unix.rmdir path)
+      else Unix.unlink path
+  in
+  Fun.protect
+    ~finally:(fun () -> try cleanup dir with _ -> ())
+    (fun () ->
+      let config = Coord.default_config dir in
+      ignore (Coord.init config ~agent_name:(Some "tester"));
+      f config)
+
 (* ── Reputation_autonomy tests ────────────────────────────────────── *)
 
 let test_autonomy_string_round_trip () =
@@ -151,6 +178,36 @@ let test_compute_accountability_score_penalty () =
   in
   check (float 0.0001) "fully penalized → 0.0" 0.0 penalized
 
+let test_reputation_jsonl_drop_metric () =
+  with_temp_config @@ fun config ->
+  let posts_path =
+    Filename.concat (Coord.masc_dir config) "board_posts.jsonl"
+  in
+  Fs_compat.save_file posts_path
+    (String.concat "\n"
+       [
+         "{not-json";
+         Yojson.Safe.to_string
+           (`Assoc
+             [
+               ("id", `String "post-1");
+               ("author", `String "rep-agent");
+               ("title", `String "valid");
+             ]);
+       ]
+     ^ "\n");
+  let before =
+    persistence_counter Safe_ops.persistence_read_drop_reason_entry_load_error
+  in
+  let rep = Agent_reputation.compute_reputation config ~agent_name:"rep-agent" in
+  check int "valid post still counted" 1 rep.board_posts;
+  check
+    (float 0.1)
+    "malformed board JSONL increments persistence drop metric"
+    1.0
+    (persistence_counter Safe_ops.persistence_read_drop_reason_entry_load_error
+     -. before)
+
 let () =
   run "Reputation_multi_dim"
     [ ( "autonomy",
@@ -182,5 +239,7 @@ let () =
             test_compute_overall_score_pure
         ; test_case "full accountability penalty → 0.0" `Quick
             test_compute_accountability_score_penalty
+        ; test_case "jsonl drops increment metric" `Quick
+            test_reputation_jsonl_drop_metric
         ] )
     ]


### PR DESCRIPTION
## Summary
- count agent reputation JSONL read and malformed-line drops with the existing persistence read drop metric
- preserve existing behavior: missing files still return empty rows, malformed rows are skipped, and valid board rows still count
- add a focused regression proving malformed board_posts data increments the metric while preserving the valid reputation count

## Why it matters
Agent reputation feeds routing and dashboard quality signals from board posts and comments. A malformed board JSONL row used to disappear from reputation calculations with no metric signal. This keeps reputation computation tolerant, but makes the data loss visible on the shared persistence-drop surface.

## Verification
- git diff --check
- lockf -k -t 1200 /tmp/me-dune-local.lock env MASC_DUNE_LOCK_HELD=1 MASC_SKIP_OPAM_LOCK=1 DUNE_JOBS=1 DUNE_CACHE=disabled scripts/dune-local.sh build test/test_reputation_multi_dim.exe
- ./_build/default/test/test_reputation_multi_dim.exe