### PR TITLE
fix: count activity feed jsonl read drops

### DIFF
--- a/lib/activity_feed.ml
+++ b/lib/activity_feed.ml
@@ -47,12 +47,23 @@ let warn_read_failure ~kind ~path msg =
 let warn_parse_failure ~kind ~path ~line_no msg =
   Log.Feed.warn "%s parse failed for %s line %d: %s" kind path line_no msg
 
+let persistence_surface = "activity_feed"
+
+let record_persistence_drop ~reason ~delta =
+  Prometheus.inc_counter Prometheus.metric_persistence_read_drops
+    ~labels:[("surface", persistence_surface); ("reason", reason)]
+    ~delta
+    ()
+
 let load_jsonl_safe ?(kind = "jsonl") (path : string) : Yojson.Safe.t list =
   if not (Fs_compat.file_exists path) then []
   else
     match Safe_ops.read_file_safe path with
     | Error msg ->
         warn_read_failure ~kind ~path msg;
+        record_persistence_drop
+          ~reason:Safe_ops.persistence_read_drop_reason_entry_load_error
+          ~delta:1.0;
         []
     | Ok content ->
         content
@@ -65,6 +76,9 @@ let load_jsonl_safe ?(kind = "jsonl") (path : string) : Yojson.Safe.t list =
                  try Some (Yojson.Safe.from_string trimmed)
                  with Yojson.Json_error msg ->
                    warn_parse_failure ~kind ~path ~line_no msg;
+                   record_persistence_drop
+                     ~reason:Safe_ops.persistence_read_drop_reason_entry_load_error
+                     ~delta:1.0;
                    None)
 
 (** Fallback timestamp used when a source record has no parseable

--- a/test/test_auto_recall_activity_coverage.ml
+++ b/test/test_auto_recall_activity_coverage.ml
@@ -290,6 +290,11 @@ let str_contains haystack needle =
     !found
   end
 
+let activity_persistence_counter reason =
+  Prometheus.metric_value_or_zero Prometheus.metric_persistence_read_drops
+    ~labels:[("surface", "activity_feed"); ("reason", reason)]
+    ()
+
 let test_recent_activity_skips_malformed_jsonl_lines () =
   with_temp_dir "activity-feed-jsonl" @@ fun base_path ->
   let config = Coord.default_config base_path in
@@ -310,7 +315,18 @@ let test_recent_activity_skips_malformed_jsonl_lines () =
              ]);
          "not-json";
        ] ^ "\n");
+  let before =
+    activity_persistence_counter
+      Safe_ops.persistence_read_drop_reason_entry_load_error
+  in
   let items = Activity_feed.recent_activity config ~limit:10 () in
+  check
+    (float 0.1)
+    "malformed jsonl increments persistence drop metric"
+    1.0
+    (activity_persistence_counter
+       Safe_ops.persistence_read_drop_reason_entry_load_error
+     -. before);
   check int "valid board post survives" 1 (List.length items);
   match items with
   | [item] ->


### PR DESCRIPTION
## Summary
- count activity feed JSONL read failures and malformed rows with the existing persistence read drop metric
- preserve the existing Feed warnings and tolerant timeline behavior
- extend the existing malformed JSONL activity-feed regression to assert the metric delta while valid activity still survives

## Why it matters
The unified activity timeline tolerates malformed board/comment/mention JSONL by skipping bad rows. That is right for dashboard continuity, but the skipped data was only visible in logs. This makes the loss measurable on the shared persistence-drop surface without adding a new metric schema.

## Verification
- git diff --check
- lockf -k -t 1200 /tmp/me-dune-local.lock env MASC_DUNE_LOCK_HELD=1 MASC_SKIP_OPAM_LOCK=1 DUNE_JOBS=1 DUNE_CACHE=disabled scripts/dune-local.sh build test/test_auto_recall_activity_coverage.exe
- ./_build/default/test/test_auto_recall_activity_coverage.exe