### PR TITLE
fix(keeper): persist tool I/O from handler

### DIFF
--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -2082,6 +2082,14 @@ let make_hooks
             ~keeper_name:(!meta_ref).name ()
         in
         let result_bytes = if original_bytes > 0 then original_bytes else out_len in
+        let handler_logged =
+          Keeper_tool_call_log.consume_handler_logged
+            ~keeper_name:(!meta_ref).name
+            ~tool_name
+            ~output_text
+            ~success:(outcome = "ok")
+            ()
+        in
         let ( lane
             , tool_choice
             , thinking_enabled
@@ -2099,33 +2107,34 @@ let make_hooks
           Keeper_tool_call_log.get_turn_context
             ~keeper_name:(!meta_ref).name ()
         in
-        (try
-           Keeper_tool_call_log.log_call
-             ~keeper_name:(!meta_ref).name
-             ~tool_name ~input ~output_text
-             ~success:(outcome = "ok") ~duration_ms
-             ~model:(let m = (!meta_ref).runtime.usage.last_model_used in
-                     if m = "" then (!meta_ref).cascade_name else m)
-             ?lane ?tool_choice ?thinking_enabled ?thinking_budget
-             ?prompt_fingerprint
-             ?trace_id ?session_id ?turn ?keeper_turn_id ?task_id ?goal_ids
-             ?sandbox_profile ?network_mode ?approval_mode
-             ~result_bytes ?truncated_to ()
-         with
-         | Eio.Cancel.Cancelled _ as e -> raise e
-         | exn ->
-             (* P2 silent-failure fix (same pattern as the broadcast site
-                above at line ~1098): tool-call audit log write failures
-                were dropped without trace.  Loss of these rows leaves
-                downstream replay / debugging tools with gaps that look
-                identical to "no tool calls in this turn." *)
-             Prometheus.inc_counter
-               Prometheus.metric_keeper_lifecycle_callback_failures
-               ~labels:[("keeper", (!meta_ref).name); ("callback", "post_tool_log_write")]
-               ();
-             Log.Keeper.warn
-               "keeper:%s tool=%s log_call write failed: %s"
-               (!meta_ref).name tool_name (Printexc.to_string exn));
+        if not handler_logged then
+          (try
+             Keeper_tool_call_log.log_call
+               ~keeper_name:(!meta_ref).name
+               ~tool_name ~input ~output_text
+               ~success:(outcome = "ok") ~duration_ms
+               ~model:(let m = (!meta_ref).runtime.usage.last_model_used in
+                       if m = "" then (!meta_ref).cascade_name else m)
+               ?lane ?tool_choice ?thinking_enabled ?thinking_budget
+               ?prompt_fingerprint
+               ?trace_id ?session_id ?turn ?keeper_turn_id ?task_id ?goal_ids
+               ?sandbox_profile ?network_mode ?approval_mode
+               ~result_bytes ?truncated_to ()
+           with
+           | Eio.Cancel.Cancelled _ as e -> raise e
+           | exn ->
+               (* P2 silent-failure fix (same pattern as the broadcast site
+                  above at line ~1098): tool-call audit log write failures
+                  were dropped without trace.  Loss of these rows leaves
+                  downstream replay / debugging tools with gaps that look
+                  identical to "no tool calls in this turn." *)
+               Prometheus.inc_counter
+                 Prometheus.metric_keeper_lifecycle_callback_failures
+                 ~labels:[("keeper", (!meta_ref).name); ("callback", "post_tool_log_write")]
+                 ();
+               Log.Keeper.warn
+                 "keeper:%s tool=%s log_call write failed: %s"
+                 (!meta_ref).name tool_name (Printexc.to_string exn));
         (try
            append_pr_review_action_metric
              ~config

--- a/lib/keeper/keeper_tools_oas.ml
+++ b/lib/keeper/keeper_tools_oas.ml
@@ -187,6 +187,49 @@ let transient_mutex_contention_tool_error
         ] );
     ])
 
+let current_keeper_model (meta : Keeper_types.keeper_meta) =
+  let m = meta.runtime.usage.last_model_used in
+  if m = "" then meta.cascade_name else m
+
+let persist_tool_call_io_from_handler
+    ~(meta : Keeper_types.keeper_meta)
+    ~(tool_name : string)
+    ~(input : Yojson.Safe.t)
+    ~(output_text : string)
+    ~(success : bool)
+    ~(duration_ms : float)
+    ?result_bytes
+    ?truncated_to
+    () =
+  try
+    Keeper_tool_call_log.log_call
+      ~keeper_name:meta.name
+      ~tool_name
+      ~input
+      ~output_text
+      ~success
+      ~duration_ms
+      ~model:(current_keeper_model meta)
+      ?result_bytes
+      ?truncated_to
+      ();
+    Keeper_tool_call_log.remember_handler_logged
+      ~keeper_name:meta.name
+      ~tool_name
+      ~output_text
+      ~success
+      ()
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | exn ->
+      Prometheus.inc_counter
+        Prometheus.metric_keeper_lifecycle_callback_failures
+        ~labels:[ ("keeper", meta.name); ("callback", "handler_tool_log_write") ]
+        ();
+      Log.Keeper.warn
+        "keeper:%s tool=%s handler-side tool_call log failed: %s"
+        meta.name tool_name (Printexc.to_string exn)
+
 (** Max chars for SSE error preview. Short enough for dashboard display,
     long enough to include the actionable portion of the error. *)
 let sse_error_preview_max_chars = 300
@@ -412,7 +455,17 @@ let make_keeper_tool_handler
       let msg = Printf.sprintf
         "This tool has failed %d times in a row with the same arguments. Try a different approach or different arguments."
         prior_fails in
-      (false, normalize_tool_result ~success:false msg)
+      let output_text = normalize_tool_result ~success:false msg in
+      persist_tool_call_io_from_handler
+        ~meta
+        ~tool_name:name
+        ~input
+        ~output_text
+        ~success:false
+        ~duration_ms:0.0
+        ~result_bytes:(String.length output_text)
+        ();
+      (false, output_text)
     end else
       let t0 = Time_compat.now () in
       try
@@ -477,7 +530,17 @@ let make_keeper_tool_handler
           Keeper_tool_call_log.set_truncation_info
             ~keeper_name:meta.name
             ~original_bytes:(String.length normalized_error) ();
-          (false, Tool_output_validation.cap normalized_error)
+          let output_text = Tool_output_validation.cap normalized_error in
+          persist_tool_call_io_from_handler
+            ~meta
+            ~tool_name:name
+            ~input
+            ~output_text
+            ~success:false
+            ~duration_ms:(Float.of_int duration_ms)
+            ~result_bytes:(String.length normalized_error)
+            ();
+          (false, output_text)
         end else begin
           failure_count_reset failure_counts key;
           Keeper_registry.record_tool_use ~base_path:config.base_path meta.name ~tool_name:name ~success:true;
@@ -561,6 +624,17 @@ let make_keeper_tool_handler
             ~original_bytes:original_len
             ?truncated_to:(if was_truncated
               then Some (String.length truncated_result) else None) ();
+          persist_tool_call_io_from_handler
+            ~meta
+            ~tool_name:name
+            ~input
+            ~output_text:truncated_result
+            ~success:true
+            ~duration_ms:(Float.of_int duration_ms)
+            ~result_bytes:original_len
+            ?truncated_to:(if was_truncated
+              then Some (String.length truncated_result) else None)
+            ();
           (true, truncated_result)
         end
       with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
@@ -666,7 +740,17 @@ let make_keeper_tool_handler
         Keeper_tool_call_log.set_truncation_info
           ~keeper_name:meta.name
           ~original_bytes:(String.length normalized_exn) ();
-        (false, Tool_output_validation.cap normalized_exn)
+        let output_text = Tool_output_validation.cap normalized_exn in
+        persist_tool_call_io_from_handler
+          ~meta
+          ~tool_name:name
+          ~input
+          ~output_text
+          ~success:false
+          ~duration_ms:(Float.of_int duration_ms)
+          ~result_bytes:(String.length normalized_exn)
+          ();
+        (false, output_text)
 
 let make_tool_bundle
     ~(config : Coord.config)

--- a/lib/keeper_tool_call_log.ml
+++ b/lib/keeper_tool_call_log.ml
@@ -22,6 +22,10 @@ let max_output_len = 4000
     sequential so set→consume ordering is guaranteed. *)
 let pending_truncation : (string, int * int option) Hashtbl.t = Hashtbl.create 8
 
+let handler_logged_mutex = Stdlib.Mutex.create ()
+let handler_logged_recent : (string, float) Hashtbl.t = Hashtbl.create 32
+let handler_logged_ttl_sec = 300.0
+
 type turn_context = {
   agent_name: string option;
   lane: string option;
@@ -75,6 +79,42 @@ let empty_turn_context = {
 }
 
 let pending_turn_context : (string, turn_context) Hashtbl.t = Hashtbl.create 8
+
+let handler_logged_key ~keeper_name ~tool_name ~output_text ~success =
+  let canonical_tool_name =
+    match Keeper_tool_alias.to_internal tool_name with
+    | Some internal -> internal
+    | None -> tool_name
+  in
+  Printf.sprintf "%s\000%s\000%b\000%d"
+    keeper_name canonical_tool_name success (Hashtbl.hash output_text)
+
+let remember_handler_logged ~keeper_name ~tool_name ~output_text ~success () =
+  let key = handler_logged_key ~keeper_name ~tool_name ~output_text ~success in
+  let now = Time_compat.now () in
+  Stdlib.Mutex.protect handler_logged_mutex (fun () ->
+      let stale =
+        Hashtbl.fold
+          (fun key ts acc ->
+            if now -. ts > handler_logged_ttl_sec then key :: acc else acc)
+          handler_logged_recent
+          []
+      in
+      List.iter (Hashtbl.remove handler_logged_recent) stale;
+      Hashtbl.replace handler_logged_recent key now)
+
+let consume_handler_logged ~keeper_name ~tool_name ~output_text ~success () =
+  let key = handler_logged_key ~keeper_name ~tool_name ~output_text ~success in
+  let now = Time_compat.now () in
+  Stdlib.Mutex.protect handler_logged_mutex (fun () ->
+      match Hashtbl.find_opt handler_logged_recent key with
+      | Some ts when now -. ts <= handler_logged_ttl_sec ->
+          Hashtbl.remove handler_logged_recent key;
+          true
+      | Some _ ->
+          Hashtbl.remove handler_logged_recent key;
+          false
+      | None -> false)
 
 let set_truncation_info ~keeper_name ~original_bytes ?truncated_to () =
   Hashtbl.replace pending_truncation keeper_name (original_bytes, truncated_to)
@@ -374,7 +414,9 @@ let reset_for_testing () =
   store_ref := None;
   configured_store_ref := None;
   Hashtbl.reset pending_truncation;
-  Hashtbl.reset pending_turn_context
+  Hashtbl.reset pending_turn_context;
+  Stdlib.Mutex.protect handler_logged_mutex (fun () ->
+      Hashtbl.reset handler_logged_recent)
 
 let store_dir () =
   match !store_ref with

--- a/lib/keeper_tool_call_log.mli
+++ b/lib/keeper_tool_call_log.mli
@@ -150,6 +150,28 @@ val log_call :
     any truncation. [truncated_to] is present when Tool_output_validation
     truncated the output. Best-effort (failures logged). *)
 
+val remember_handler_logged :
+  keeper_name:string ->
+  tool_name:string ->
+  output_text:string ->
+  success:bool ->
+  unit ->
+  unit
+(** [remember_handler_logged ...] records that the keeper tool handler has
+    already persisted the full I/O for this just-completed tool execution.
+    Agent SDK post-tool hooks consume this marker to avoid duplicate rows
+    when a provider emits both handler-side and hook-side signals. *)
+
+val consume_handler_logged :
+  keeper_name:string ->
+  tool_name:string ->
+  output_text:string ->
+  success:bool ->
+  unit ->
+  bool
+(** [consume_handler_logged ...] returns [true] once when a recent
+    handler-side log marker matches the post-tool hook event. *)
+
 val read_recent :
   ?keeper_name:string ->
   ?n:int ->

--- a/test/test_keeper_tools_oas.ml
+++ b/test/test_keeper_tools_oas.ml
@@ -105,6 +105,14 @@ let test_tool_count_matches_allowed () =
 let find_tool name tools =
   List.find (fun (tool : Tool.t) -> String.equal tool.schema.name name) tools
 
+let dummy_schedule : Agent_sdk.Hooks.tool_schedule =
+  { planned_index = 0
+  ; batch_index = 0
+  ; batch_size = 1
+  ; concurrency_class = "default"
+  ; batch_kind = "sequential"
+  }
+
 let string_contains ~sub text =
   let text_len = String.length text in
   let sub_len = String.length sub in
@@ -178,6 +186,96 @@ let test_tool_side_effect_failures_are_observed () =
         (Prometheus.metric_value_or_zero
            Prometheus.metric_keeper_decision_audit_flush_failures
            ~labels:keeper_labels ()))
+
+let test_handler_persists_tool_call_io_without_post_hook () =
+  let meta = make_test_meta ~name:"test-keeper-direct-tool-io" () in
+  let ctx_snapshot = make_test_ctx () in
+  let dir = Filename.temp_file "test_keeper_tools_direct_io_" "" in
+  Sys.remove dir;
+  Unix.mkdir dir 0o755;
+  Fun.protect
+    ~finally:(fun () ->
+      Keeper_tool_call_log.reset_for_testing ();
+      rm_rf dir)
+    (fun () ->
+      Eio_main.run @@ fun env ->
+      Fs_compat.set_fs (Eio.Stdenv.fs env);
+      let config = Coord.default_config dir in
+      Keeper_tool_call_log.reset_for_testing ();
+      Keeper_tool_call_log.init ~base_path:dir ();
+      Keeper_tool_call_log.set_turn_context
+        ~keeper_name:meta.name
+        ~trace_id:"trace-direct-tool-io"
+        ~turn:1
+        ();
+      let tools = Keeper_tools_oas.make_tools ~config ~meta ~ctx_snapshot () in
+      let tool = find_tool "keeper_time_now" tools in
+      (match Tool.execute tool (`Assoc []) with
+       | Ok _ -> ()
+       | Error { Agent_sdk.Types.message; _ } ->
+           fail ("keeper_time_now should succeed: " ^ message));
+      let entries =
+        Keeper_tool_call_log.read_recent ~keeper_name:meta.name ~n:10 ()
+      in
+      check int "handler wrote one tool_call row" 1 (List.length entries);
+      let row = List.hd entries in
+      check string "tool" "keeper_time_now"
+        Yojson.Safe.Util.(row |> member "tool" |> to_string);
+      check string "trace id" "trace-direct-tool-io"
+        Yojson.Safe.Util.(row |> member "trace_id" |> to_string))
+
+let test_post_hook_does_not_duplicate_handler_logged_io () =
+  let meta = make_test_meta ~name:"test-keeper-direct-tool-dedupe" () in
+  let meta_ref = ref meta in
+  let ctx_snapshot = make_test_ctx () in
+  let dir = Filename.temp_file "test_keeper_tools_direct_dedupe_" "" in
+  Sys.remove dir;
+  Unix.mkdir dir 0o755;
+  Fun.protect
+    ~finally:(fun () ->
+      Keeper_tool_call_log.reset_for_testing ();
+      rm_rf dir)
+    (fun () ->
+      Eio_main.run @@ fun env ->
+      Fs_compat.set_fs (Eio.Stdenv.fs env);
+      let config = Coord.default_config dir in
+      Keeper_tool_call_log.reset_for_testing ();
+      Keeper_tool_call_log.init ~base_path:dir ();
+      let tools = Keeper_tools_oas.make_tools ~config ~meta ~ctx_snapshot () in
+      let tool = find_tool "keeper_time_now" tools in
+      let output_text =
+        match Tool.execute tool (`Assoc []) with
+        | Ok { Agent_sdk.Types.content; _ } -> content
+        | Error { Agent_sdk.Types.message; _ } ->
+            fail ("keeper_time_now should succeed: " ^ message)
+      in
+      let hooks =
+        Keeper_hooks_oas.make_hooks ~config ~meta_ref ~generation:1 ()
+      in
+      let post_tool_use =
+        match hooks.Agent_sdk.Hooks.post_tool_use with
+        | Some hook -> hook
+        | None -> fail "post_tool_use hook missing"
+      in
+      ignore
+        (post_tool_use
+           (Agent_sdk.Hooks.PostToolUse
+              { tool_use_id = "tu-direct-dedupe"
+              ; tool_name = "keeper_time_now"
+              ; input = `Assoc []
+              ; output =
+                  Ok
+                    ({ Agent_sdk.Types.content = output_text }
+                     : Agent_sdk.Types.tool_output)
+              ; result_bytes = String.length output_text
+              ; duration_ms = 2.0
+              ; schedule = dummy_schedule
+              }));
+      let entries =
+        Keeper_tool_call_log.read_recent ~keeper_name:meta.name ~n:10 ()
+      in
+      check int "post hook did not duplicate handler row" 1
+        (List.length entries))
 
 let is_guardrail_message message =
   string_contains
@@ -767,6 +865,10 @@ let () =
       test_case "failure tracking is independent per args" `Quick test_failure_tracking_is_independent_per_args;
       test_case "tool side-effect failures are observed" `Quick
         test_tool_side_effect_failures_are_observed;
+      test_case "handler persists tool-call I/O without post hook" `Quick
+        test_handler_persists_tool_call_io_without_post_hook;
+      test_case "post hook skips handler-logged tool-call I/O" `Quick
+        test_post_hook_does_not_duplicate_handler_logged_io;
     ];
     "normalize_tool_result", [
       test_case "success JSON wraps under result" `Quick test_normalize_success_json;


### PR DESCRIPTION
## Summary
- Move keeper tool-call I/O persistence to the actual `Keeper_tools_oas` handler path so provider/adapters that skip Agent SDK `post_tool_use` still write `.masc/tool_calls/YYYY-MM/DD.jsonl` rows.
- Add a short-lived handler-log marker consumed by `Keeper_hooks_oas` to avoid duplicate rows when both handler and post-hook signals fire.
- Cover the regression with direct `Tool.execute` tests proving a handler-only execution writes durable tool I/O and a later post-hook event does not duplicate it.

## Why This Matters
Issue #14065 blocks strict Docker keeper PR lifecycle audits: successful provider turns can report `tools_used` in receipts while leaving no durable global tool-call row. That makes create/push/review/approve evidence look indistinguishable from self-report. This patch makes the execution handler the persistence source of truth, so actual tool execution creates auditable I/O even when a provider bridge misses lifecycle hooks.

## Verification
- `scripts/dune-local.sh build test/test_keeper_tools_oas.exe`
- `./_build/default/test/test_keeper_tools_oas.exe` (37 tests)
- `scripts/dune-local.sh build test/test_keeper_tool_call_log.exe test/test_keeper_hooks_oas_telemetry.exe test/test_mcp_server_eio_call_tool.exe`
- `./_build/default/test/test_keeper_tool_call_log.exe` (22 tests)
- `./_build/default/test/test_keeper_hooks_oas_telemetry.exe` (44 tests)
- `./_build/default/test/test_mcp_server_eio_call_tool.exe` (12 tests)
- `git diff --check`

Fixes #14065