### PR TITLE
fix(keeper): gate noop watchdog across restarts

### DIFF
--- a/lib/keeper/keeper_stale_watchdog.ml
+++ b/lib/keeper/keeper_stale_watchdog.ml
@@ -127,10 +127,9 @@ let should_trigger_noop_failure_loop
     ~started_at
     ~last_completed_turn_ended_at =
   noop_count >= noop_threshold
-  &&
-  match last_completed_turn_ended_at with
-  | Some ended_at -> ended_at >= started_at
-  | None -> false
+  && (match last_completed_turn_ended_at with
+      | Some ended_at -> ended_at >= started_at
+      | None -> false)
 
 let should_trigger_noop_failure_loop_for_test =
   should_trigger_noop_failure_loop

--- a/lib/keeper/keeper_stale_watchdog.ml
+++ b/lib/keeper/keeper_stale_watchdog.ml
@@ -121,6 +121,20 @@ let stale_kill_class_label (cls : Keeper_registry.stale_kill_class) : string =
   | In_turn_hung _ -> "in_turn_hung"
   | Noop_failure_loop _ -> "noop_failure_loop"
 
+let should_trigger_noop_failure_loop
+    ~noop_count
+    ~noop_threshold
+    ~started_at
+    ~last_completed_turn_ended_at =
+  noop_count >= noop_threshold
+  &&
+  match last_completed_turn_ended_at with
+  | Some ended_at -> ended_at >= started_at
+  | None -> false
+
+let should_trigger_noop_failure_loop_for_test =
+  should_trigger_noop_failure_loop
+
 type batch_root_cause =
   | Cascade_unhealthy
   | Provider_auth
@@ -461,7 +475,21 @@ let fork_stale_watchdog (ctx : _ context) (meta : keeper_meta)
              let noop_count =
                entry.meta.runtime.proactive_rt.consecutive_noop_count
              in
-             let failure_loop = noop_count >= noop_threshold () in
+             let last_completed_turn_ended_at =
+               match entry.last_completed_turn with
+               | Some
+                   ({ ct_ended_at; _ }
+                    : Keeper_registry.completed_turn_observation) ->
+                 Some ct_ended_at
+               | None -> None
+             in
+             let failure_loop =
+               should_trigger_noop_failure_loop
+                 ~noop_count
+                 ~noop_threshold:(noop_threshold ())
+                 ~started_at:entry.started_at
+                 ~last_completed_turn_ended_at
+             in
              let stale = idle_stale || in_turn_stale || failure_loop in
              (* The tick line is a sampled state snapshot. Stale termination
                 and broadcasts below remain ERROR, so INFO does not need every

--- a/lib/keeper/keeper_stale_watchdog.mli
+++ b/lib/keeper/keeper_stale_watchdog.mli
@@ -27,6 +27,16 @@ val classify_batch_root_cause_for_test :
   Keeper_registry.failure_reason list -> batch_root_cause
 (** Test-only view of the batch root-cause classifier. *)
 
+val should_trigger_noop_failure_loop_for_test :
+  noop_count:int ->
+  noop_threshold:int ->
+  started_at:float ->
+  last_completed_turn_ended_at:float option ->
+  bool
+(** Test-only view of the no-op watchdog gate.  A persisted
+    [consecutive_noop_count] only triggers a no-op failure-loop kill
+    after the current keeper fiber has completed a turn. *)
+
 val reset_batch_terminations_for_test : unit -> unit
 (** Test-only reset for fleet batch termination history. *)
 

--- a/test/test_stale_kill_class.ml
+++ b/test/test_stale_kill_class.ml
@@ -182,6 +182,42 @@ let test_batch_root_cause_unknown () =
   r "unknown" "unknown"
     (root_cause_label [ Heartbeat_consecutive_failures 3 ])
 
+let test_noop_failure_loop_ignores_persisted_count_before_current_turn () =
+  Alcotest.(check bool)
+    "persisted noop count alone does not kill a freshly restarted fiber"
+    false
+    (SW.should_trigger_noop_failure_loop_for_test
+       ~noop_count:3
+       ~noop_threshold:3
+       ~started_at:200.0
+       ~last_completed_turn_ended_at:None);
+  Alcotest.(check bool)
+    "previous-lifecycle completed turn does not satisfy current fiber"
+    false
+    (SW.should_trigger_noop_failure_loop_for_test
+       ~noop_count:3
+       ~noop_threshold:3
+       ~started_at:200.0
+       ~last_completed_turn_ended_at:(Some 199.0))
+
+let test_noop_failure_loop_triggers_after_current_turn () =
+  Alcotest.(check bool)
+    "current-fiber completed turn plus threshold triggers"
+    true
+    (SW.should_trigger_noop_failure_loop_for_test
+       ~noop_count:3
+       ~noop_threshold:3
+       ~started_at:200.0
+       ~last_completed_turn_ended_at:(Some 201.0));
+  Alcotest.(check bool)
+    "below threshold still does not trigger"
+    false
+    (SW.should_trigger_noop_failure_loop_for_test
+       ~noop_count:2
+       ~noop_threshold:3
+       ~started_at:200.0
+       ~last_completed_turn_ended_at:(Some 201.0))
+
 let () =
   Alcotest.run "stale_kill_class"
     [
@@ -240,5 +276,12 @@ let () =
           Alcotest.test_case "mixed" `Quick test_batch_root_cause_mixed;
           Alcotest.test_case "unknown" `Quick
             test_batch_root_cause_unknown;
+        ] );
+      ( "noop_failure_loop_gate",
+        [
+          Alcotest.test_case "ignores persisted count before current turn" `Quick
+            test_noop_failure_loop_ignores_persisted_count_before_current_turn;
+          Alcotest.test_case "triggers after current turn" `Quick
+            test_noop_failure_loop_triggers_after_current_turn;
         ] );
     ]

--- a/test/test_stale_kill_class.ml
+++ b/test/test_stale_kill_class.ml
@@ -218,6 +218,20 @@ let test_noop_failure_loop_triggers_after_current_turn () =
        ~started_at:200.0
        ~last_completed_turn_ended_at:(Some 201.0))
 
+let test_noop_failure_loop_boundary_equal_timestamps () =
+  (* The gate uses [ended_at >= started_at] (inclusive).  A turn whose
+     [ct_ended_at] is exactly the fiber's [started_at] still counts as a
+     completed turn under the current fiber — covers the boundary the
+     other tests step over with [199.0]/[201.0]. *)
+  Alcotest.(check bool)
+    "ended_at = started_at satisfies the inclusive bound"
+    true
+    (SW.should_trigger_noop_failure_loop_for_test
+       ~noop_count:3
+       ~noop_threshold:3
+       ~started_at:200.0
+       ~last_completed_turn_ended_at:(Some 200.0))
+
 let () =
   Alcotest.run "stale_kill_class"
     [
@@ -283,5 +297,7 @@ let () =
             test_noop_failure_loop_ignores_persisted_count_before_current_turn;
           Alcotest.test_case "triggers after current turn" `Quick
             test_noop_failure_loop_triggers_after_current_turn;
+          Alcotest.test_case "boundary equal timestamps" `Quick
+            test_noop_failure_loop_boundary_equal_timestamps;
         ] );
     ]


### PR DESCRIPTION
## Summary
- prevent persisted consecutive no-op counts from immediately triggering the stale watchdog on a freshly restarted keeper fiber
- require a completed turn in the current fiber before classifying the keeper as a no-op failure loop
- add regression coverage for pre-turn restart state and current-turn trigger behavior

## Operator Impact
Today\'s live log showed ramarama repeatedly restarting, consuming only the bootstrap stimulus, and then being killed again as `noop_failure_loop(noop=3)` before it could run a new turn. This makes the dashboard look like a storm even when the current fiber has not produced a fresh no-op yet.

After this change, old no-op counters still inform backoff and remain visible, but they cannot kill a newly launched fiber until the new fiber has completed a turn. Idle/in-turn stale paths still remain available for genuine stalls.

## Validation
- `git diff --check`
- `scripts/dune-local.sh build test/test_stale_kill_class.exe`
- `./_build/default/test/test_stale_kill_class.exe` (24 tests)

## Residual Risk
- This does not make passive models more compliant with required tool contracts; that is tracked separately by the required-tool accounting PRs. This PR only stops stale persisted no-op counters from causing immediate restart storms.