### PR TITLE
fix: count agent economy ledger read drops

### DIFF
--- a/lib/agent_economy.ml
+++ b/lib/agent_economy.ml
@@ -188,6 +188,13 @@ let append_transaction base_path (txn : transaction) : (unit, string) Result.t =
     Error (Printf.sprintf "[agent_economy] ledger write failed: %s"
              (Stdlib.Printexc.to_string e))
 
+let persistence_surface = "agent_economy"
+
+let record_persistence_read_drop ~reason () =
+  Prometheus.inc_counter Prometheus.metric_persistence_read_drops
+    ~labels:[("surface", persistence_surface); ("reason", reason)]
+    ()
+
 (** {1 Balance Cache} *)
 
 (* In-memory balance cache: (base_path, agent_name) -> current balance.
@@ -207,7 +214,10 @@ let load_balances_from_ledger base_path =
     let path = ledger_path base_path in
     if Sys.file_exists path then begin
       match Safe_ops.read_file_safe path with
-      | Error e -> Log.Misc.warn "economy ledger read failed for %s: %s" path e
+      | Error e ->
+        Log.Misc.warn "economy ledger read failed for %s: %s" path e;
+        record_persistence_read_drop
+          ~reason:Safe_ops.persistence_read_drop_reason_entry_load_error ()
       | Ok content ->
         String.split_on_char '\n' content
         |> List.iter (fun line ->
@@ -219,9 +229,13 @@ let load_balances_from_ledger base_path =
               | Some txn ->
                 with_economy_rw (fun () ->
                   Hashtbl.replace balance_cache (base_path, txn.agent_name) txn.balance_after)
-              | None -> ()
+              | None ->
+                record_persistence_read_drop
+                  ~reason:Safe_ops.persistence_read_drop_reason_invalid_payload ()
             with Yojson.Json_error msg ->
-              Log.Misc.warn "agent_economy: skipping malformed ledger entry: %s" msg)
+              Log.Misc.warn "agent_economy: skipping malformed ledger entry: %s" msg;
+              record_persistence_read_drop
+                ~reason:Safe_ops.persistence_read_drop_reason_entry_load_error ())
     end;
     with_economy_rw (fun () -> Hashtbl.replace loaded_paths base_path true)
   end
@@ -240,6 +254,8 @@ let list_transactions ~base_path =
     match Safe_ops.read_file_safe path with
     | Error e ->
       Log.Misc.warn "economy ledger read failed for %s: %s" path e;
+      record_persistence_read_drop
+        ~reason:Safe_ops.persistence_read_drop_reason_entry_load_error ();
       []
     | Ok content ->
       content
@@ -248,10 +264,18 @@ let list_transactions ~base_path =
         let trimmed = String.trim line in
         if String.equal trimmed "" then None
         else
-          try transaction_of_json (Yojson.Safe.from_string trimmed)
+          try
+            match transaction_of_json (Yojson.Safe.from_string trimmed) with
+            | Some txn -> Some txn
+            | None ->
+              record_persistence_read_drop
+                ~reason:Safe_ops.persistence_read_drop_reason_invalid_payload ();
+              None
           with Yojson.Json_error msg ->
             Log.Misc.warn
               "agent_economy: skipping malformed ledger entry: %s" msg;
+            record_persistence_read_drop
+              ~reason:Safe_ops.persistence_read_drop_reason_entry_load_error ();
             None)
 
 (** {1 Reputation Integration} *)

--- a/test/test_agent_economy.ml
+++ b/test/test_agent_economy.ml
@@ -8,6 +8,8 @@
 (* Workaround: stale opam-installed masc_mcp shadows the local library's
    wrapper module. Use direct module alias instead of open Masc_mcp. *)
 module Agent_economy = Masc_mcp__Agent_economy
+module Prometheus = Masc_mcp.Prometheus
+module Safe_ops = Safe_ops
 
 let () = Mirage_crypto_rng_unix.use_default ()
 
@@ -55,6 +57,55 @@ let with_economy_enabled f =
 (** Reset balance cache between tests *)
 let reset_cache () =
   Agent_economy.reset_cache ()
+
+let ensure_ledger_dir base_path =
+  let masc = Filename.concat base_path Common.masc_dirname in
+  if not (Sys.file_exists masc) then Unix.mkdir masc 0o755;
+  let economy = Filename.concat masc "economy" in
+  if not (Sys.file_exists economy) then Unix.mkdir economy 0o755;
+  economy
+
+let ledger_path base_path =
+  Filename.concat (ensure_ledger_dir base_path) "ledger.jsonl"
+
+let persistence_drop_value reason =
+  Prometheus.metric_value_or_zero Prometheus.metric_persistence_read_drops
+    ~labels:[("surface", "agent_economy"); ("reason", reason)]
+    ()
+
+let write_ledger_with_drops base_path =
+  let valid : Agent_economy.transaction =
+    {
+      id = "txn-valid";
+      agent_name = "ledger-agent";
+      kind = Earn_task_done;
+      amount = 2.5;
+      balance_after = 7.5;
+      reason = "valid row";
+      counterparty = "system";
+      metadata = `Assoc [("goal_id", `String "goal-valid")];
+      timestamp = 10.0;
+    }
+  in
+  let lines =
+    [
+      Yojson.Safe.to_string (Agent_economy.transaction_to_json valid);
+      "{not-json";
+      Yojson.Safe.to_string
+        (`Assoc
+          [
+            ("id", `String "txn-invalid");
+            ("agent_name", `String "ledger-agent");
+            ("kind", `String "unknown_kind");
+          ]);
+    ]
+  in
+  let oc = open_out (ledger_path base_path) in
+  Fun.protect
+    ~finally:(fun () -> close_out_noerr oc)
+    (fun () ->
+      output_string oc (String.concat "\n" lines);
+      output_char oc '\n')
 
 (** {1 Configuration Tests} *)
 
@@ -251,6 +302,46 @@ let test_list_transactions () =
         (first.metadata |> member "goal_id" |> to_string)));
   rm_rf dir
 
+let test_list_transactions_records_ledger_drop_metrics () =
+  let dir = fresh_tmpdir () in
+  reset_cache ();
+  let entry_error = Safe_ops.persistence_read_drop_reason_entry_load_error in
+  let invalid_payload = Safe_ops.persistence_read_drop_reason_invalid_payload in
+  let before_entry_error = persistence_drop_value entry_error in
+  let before_invalid_payload = persistence_drop_value invalid_payload in
+  write_ledger_with_drops dir;
+  let txns = Agent_economy.list_transactions ~base_path:dir in
+  Alcotest.(check int) "only valid transaction survives" 1 (List.length txns);
+  Alcotest.(check string) "valid transaction id" "txn-valid" (List.hd txns).id;
+  let after_entry_error = persistence_drop_value entry_error in
+  let after_invalid_payload = persistence_drop_value invalid_payload in
+  Alcotest.(check (float 0.001)) "malformed row increments entry error" 1.0
+    (after_entry_error -. before_entry_error);
+  Alcotest.(check (float 0.001)) "invalid row increments invalid payload" 1.0
+    (after_invalid_payload -. before_invalid_payload);
+  rm_rf dir
+
+let test_balance_reload_records_ledger_drop_metrics () =
+  let dir = fresh_tmpdir () in
+  reset_cache ();
+  write_ledger_with_drops dir;
+  reset_cache ();
+  let entry_error = Safe_ops.persistence_read_drop_reason_entry_load_error in
+  let invalid_payload = Safe_ops.persistence_read_drop_reason_invalid_payload in
+  let before_entry_error = persistence_drop_value entry_error in
+  let before_invalid_payload = persistence_drop_value invalid_payload in
+  let balance =
+    Agent_economy.get_balance ~base_path:dir ~agent_name:"ledger-agent"
+  in
+  Alcotest.(check (float 0.001)) "valid ledger balance survives" 7.5 balance;
+  let after_entry_error = persistence_drop_value entry_error in
+  let after_invalid_payload = persistence_drop_value invalid_payload in
+  Alcotest.(check (float 0.001)) "malformed row increments entry error" 1.0
+    (after_entry_error -. before_entry_error);
+  Alcotest.(check (float 0.001)) "invalid row increments invalid payload" 1.0
+    (after_invalid_payload -. before_invalid_payload);
+  rm_rf dir
+
 (** {1 Reputation Multiplier Tests} *)
 
 let test_reward_multiplier_range () =
@@ -354,6 +445,10 @@ let () =
       Alcotest.test_case "ledger persistence" `Quick test_ledger_persistence;
       Alcotest.test_case "ledger file created" `Quick test_ledger_file_created;
       Alcotest.test_case "list transactions" `Quick test_list_transactions;
+      Alcotest.test_case "list transaction drop metrics" `Quick
+        test_list_transactions_records_ledger_drop_metrics;
+      Alcotest.test_case "balance reload drop metrics" `Quick
+        test_balance_reload_records_ledger_drop_metrics;
     ]);
     ("reputation", [
       Alcotest.test_case "multiplier range" `Quick test_reward_multiplier_range;


### PR DESCRIPTION
Summary
- Count agent economy ledger read failures and malformed JSONL rows with masc_persistence_read_drops_total surface=agent_economy reason=entry_load_error.
- Count syntactically valid but invalid transaction rows with reason=invalid_payload.
- Add focused regressions for list_transactions and balance cache reload so valid ledger rows still survive while drop counters increment.

Why it matters
- Economy ledger corruption previously stayed log-only for malformed rows and silent for invalid transaction payloads. Operators now get bounded persistence damage metrics for this ledger without changing the public economy API.

Verification
- git diff --check
- lockf -k -t 1200 /tmp/me-dune-local.lock env MASC_DUNE_LOCK_HELD=1 MASC_SKIP_OPAM_LOCK=1 DUNE_JOBS=1 DUNE_CACHE=disabled scripts/dune-local.sh build test/test_agent_economy.exe
- ./_build/default/test/test_agent_economy.exe