### PR TITLE
fix: count agent stress jsonl read drops

### DIFF
--- a/lib/agent_stress.ml
+++ b/lib/agent_stress.ml
@@ -256,6 +256,13 @@ let mu = Stdlib.Mutex.create ()
 let buffer : Yojson.Safe.t Queue.t = Queue.create ()
 let buffer_cap = 64
 
+let persistence_surface = "agent_stress"
+
+let record_persistence_read_drop ~reason () =
+  Prometheus.inc_counter Prometheus.metric_persistence_read_drops
+    ~labels:[("surface", persistence_surface); ("reason", reason)]
+    ()
+
 let ensure_dir path =
   let dir = Filename.dirname path in
   if not (Sys.file_exists dir) then
@@ -318,6 +325,8 @@ let recent n =
       match Safe_ops.read_file_safe path with
       | Error msg ->
           Log.Misc.warn "[AgentStress] recent read_file_safe failed: %s" msg;
+          record_persistence_read_drop
+            ~reason:Safe_ops.persistence_read_drop_reason_entry_load_error ();
           []
       | Ok content ->
         let lines =
@@ -336,4 +345,6 @@ let recent n =
           try Some (Yojson.Safe.from_string line)
           with Yojson.Json_error msg ->
             Log.warn ~ctx:"agent_stress" "dropping malformed line: %s" msg;
+            record_persistence_read_drop
+              ~reason:Safe_ops.persistence_read_drop_reason_entry_load_error ();
             None)

--- a/test/test_agent_stress.ml
+++ b/test/test_agent_stress.ml
@@ -1,4 +1,6 @@
 module Stress = Masc_mcp.Agent_stress
+module Prometheus = Masc_mcp.Prometheus
+module Safe_ops = Safe_ops
 
 let assoc_field name = function
   | `Assoc fields -> List.assoc_opt name fields
@@ -8,6 +10,39 @@ let nested_assoc_field outer inner json =
   match assoc_field outer json with
   | Some (`Assoc fields) -> List.assoc_opt inner fields
   | _ -> None
+
+let temp_dir () =
+  let dir =
+    Filename.concat (Filename.get_temp_dir_name ())
+      (Printf.sprintf "agent-stress-test-%d-%d"
+         (Unix.getpid ()) (Random.int 1_000_000))
+  in
+  Unix.mkdir dir 0o755;
+  dir
+
+let rec rm_rf path =
+  if Sys.file_exists path then
+    if Sys.is_directory path then (
+      Array.iter (fun name -> rm_rf (Filename.concat path name)) (Sys.readdir path);
+      Unix.rmdir path)
+    else Sys.remove path
+
+let with_temp_base f =
+  let dir = temp_dir () in
+  Fun.protect ~finally:(fun () -> rm_rf dir) (fun () -> f dir)
+
+let write_lines path lines =
+  let oc = open_out path in
+  Fun.protect
+    ~finally:(fun () -> close_out_noerr oc)
+    (fun () ->
+      output_string oc (String.concat "\n" lines);
+      output_char oc '\n')
+
+let persistence_drop_value reason =
+  Prometheus.metric_value_or_zero Prometheus.metric_persistence_read_drops
+    ~labels:[("surface", "agent_stress"); ("reason", reason)]
+    ()
 
 let test_turn_failure_json_contract () =
   let event : Stress.event =
@@ -97,6 +132,29 @@ let test_turn_failure_omits_absent_error_kind () =
     true
     (Option.is_none (nested_assoc_field "kind" "error_kind" json))
 
+let test_recent_records_jsonl_drop_metric () =
+  with_temp_base @@ fun base_path ->
+  let masc_dir = Filename.concat base_path ".masc" in
+  Unix.mkdir masc_dir 0o755;
+  Stress.init ~base_path;
+  let valid : Stress.event =
+    {
+      agent_name = "sangsu";
+      room_id = "default";
+      kind = Stress.Timeout;
+      timestamp = 2.0;
+    }
+  in
+  let reason = Safe_ops.persistence_read_drop_reason_entry_load_error in
+  let before = persistence_drop_value reason in
+  write_lines
+    (Filename.concat masc_dir "agent_stress.jsonl")
+    [ Yojson.Safe.to_string (Stress.event_to_json valid); "{not-json" ];
+  let recent = Stress.recent 10 in
+  Alcotest.(check int) "valid event survives" 1 (List.length recent);
+  Alcotest.(check (float 0.001)) "malformed row increments drop counter" 1.0
+    (persistence_drop_value reason -. before)
+
 let () =
   Alcotest.run
     "Agent_stress"
@@ -109,5 +167,8 @@ let () =
           Alcotest.test_case
             "omits absent error kind" `Quick
             test_turn_failure_omits_absent_error_kind;
+          Alcotest.test_case
+            "recent counts malformed jsonl drops" `Quick
+            test_recent_records_jsonl_drop_metric;
         ] );
     ]


### PR DESCRIPTION
Summary
- Count agent stress recent-read failures and malformed JSONL rows with masc_persistence_read_drops_total surface=agent_stress reason=entry_load_error.
- Keep valid stress events readable when a later row is malformed.
- Add a focused regression for Agent_stress.recent around malformed JSONL drop observability.

Why it matters
- Agent stress feeds were log-only for damaged rows. This makes stress telemetry corruption visible through the same bounded persistence drop metric used by the other Phase 0 silent-failure slices.

Verification
- git diff --check
- lockf -k -t 1200 /tmp/me-dune-local.lock env MASC_DUNE_LOCK_HELD=1 MASC_SKIP_OPAM_LOCK=1 DUNE_JOBS=1 DUNE_CACHE=disabled scripts/dune-local.sh build test/test_agent_stress.exe
- ./_build/default/test/test_agent_stress.exe