### PR TITLE
fix(ws): classify standalone close diagnostics (#10701)

### DIFF
--- a/lib/server/server_ws_standalone.ml
+++ b/lib/server/server_ws_standalone.ml
@@ -76,37 +76,39 @@ let summarize_ws_close_payload bytes ~received_len ~declared_len =
       received_len declared_len partial
 
 let log_ws_client_close_payload ~session_id ~declared_len payload =
-  let log_once =
-    let logged = ref false in
+  (* Terminal action for a single close-payload handling: log once + close
+     payload once.  Every reachable leaf of the read state machine (early
+     reject, on_eof, on_read completion, schedule re-entry on full buffer,
+     exception) routes through here so the payload is never logged twice
+     and never leaked. *)
+  let finish =
+    let finished = ref false in
     fun summary ->
-      if not !logged then begin
-        logged := true;
+      if not !finished then begin
+        finished := true;
         Log.Server.debug "[ws-standalone] session %s client close (%s)"
-          session_id summary
+          session_id summary;
+        Ws.Payload.close payload
       end
   in
-  if declared_len <= 0 then begin
-    log_once "code=none received_len=0 declared_len=0";
-    Ws.Payload.close payload
-  end
-  else if declared_len > max_ws_close_payload_len then begin
-    log_once
+  if declared_len <= 0 then
+    finish "code=none received_len=0 declared_len=0"
+  else if declared_len > max_ws_close_payload_len then
+    finish
       (Printf.sprintf "payload_len=%d exceeds_control_frame_limit"
-         declared_len);
-    Ws.Payload.close payload
-  end
+         declared_len)
   else
     let buffer = Bytes.create declared_len in
     let offset = ref 0 in
     let rec schedule () =
       if !offset >= declared_len then
-        log_once
+        finish
           (summarize_ws_close_payload buffer ~received_len:!offset
              ~declared_len)
       else
         Ws.Payload.schedule_read payload
           ~on_eof:(fun () ->
-            log_once
+            finish
               (summarize_ws_close_payload buffer ~received_len:!offset
                  ~declared_len))
           ~on_read:(fun bs ~off ~len:chunk_len ->
@@ -116,7 +118,7 @@ let log_ws_client_close_payload ~session_id ~declared_len payload =
               ~dst_off:!offset ~len:copy_len;
             offset := !offset + copy_len;
             if !offset >= declared_len then
-              log_once
+              finish
                 (summarize_ws_close_payload buffer ~received_len:!offset
                    ~declared_len)
             else
@@ -125,10 +127,9 @@ let log_ws_client_close_payload ~session_id ~declared_len payload =
     try schedule () with
     | Eio.Cancel.Cancelled _ as e -> raise e
     | exn ->
-        log_once
+        finish
           (Printf.sprintf "payload_read_error=%s declared_len=%d"
-             (Printexc.to_string exn) declared_len);
-        Ws.Payload.close payload
+             (Printexc.to_string exn) declared_len)
 
 let standalone_ws_eof_summary = function
   | None -> "error=none"

--- a/lib/server/server_ws_standalone.ml
+++ b/lib/server/server_ws_standalone.ml
@@ -36,6 +36,104 @@ let is_enabled () =
     classify_write_failure-recognised error. *)
 let heartbeat_interval_s = 30.0
 
+let max_ws_close_reason_log_len = 96
+
+let max_ws_close_payload_len = 125
+
+let truncate_ws_close_reason reason =
+  if String.length reason <= max_ws_close_reason_log_len then
+    reason
+  else
+    String.sub reason 0 max_ws_close_reason_log_len ^ "...<truncated>"
+
+let summarize_ws_close_payload bytes ~received_len ~declared_len =
+  if received_len = 0 then
+    Printf.sprintf "code=none received_len=0 declared_len=%d" declared_len
+  else if received_len = 1 then
+    Printf.sprintf "malformed_close_payload received_len=1 declared_len=%d"
+      declared_len
+  else
+    let code =
+      (Char.code (Bytes.get bytes 0) lsl 8) lor Char.code (Bytes.get bytes 1)
+    in
+    let reason_len = received_len - 2 in
+    let reason =
+      if reason_len = 0 then
+        "reason=<empty>"
+      else
+        let reason =
+          Bytes.sub_string bytes 2 reason_len |> truncate_ws_close_reason
+        in
+        Printf.sprintf "reason=%S" reason
+    in
+    let partial =
+      if received_len = declared_len then
+        ""
+      else
+        " partial=true"
+    in
+    Printf.sprintf "code=%d %s received_len=%d declared_len=%d%s" code reason
+      received_len declared_len partial
+
+let log_ws_client_close_payload ~session_id ~declared_len payload =
+  let log_once =
+    let logged = ref false in
+    fun summary ->
+      if not !logged then begin
+        logged := true;
+        Log.Server.debug "[ws-standalone] session %s client close (%s)"
+          session_id summary
+      end
+  in
+  if declared_len <= 0 then begin
+    log_once "code=none received_len=0 declared_len=0";
+    Ws.Payload.close payload
+  end
+  else if declared_len > max_ws_close_payload_len then begin
+    log_once
+      (Printf.sprintf "payload_len=%d exceeds_control_frame_limit"
+         declared_len);
+    Ws.Payload.close payload
+  end
+  else
+    let buffer = Bytes.create declared_len in
+    let offset = ref 0 in
+    let rec schedule () =
+      if !offset >= declared_len then
+        log_once
+          (summarize_ws_close_payload buffer ~received_len:!offset
+             ~declared_len)
+      else
+        Ws.Payload.schedule_read payload
+          ~on_eof:(fun () ->
+            log_once
+              (summarize_ws_close_payload buffer ~received_len:!offset
+                 ~declared_len))
+          ~on_read:(fun bs ~off ~len:chunk_len ->
+            let remaining = declared_len - !offset in
+            let copy_len = min chunk_len remaining in
+            Bigstringaf.blit_to_bytes bs ~src_off:off buffer
+              ~dst_off:!offset ~len:copy_len;
+            offset := !offset + copy_len;
+            if !offset >= declared_len then
+              log_once
+                (summarize_ws_close_payload buffer ~received_len:!offset
+                   ~declared_len)
+            else
+              schedule ())
+    in
+    try schedule () with
+    | Eio.Cancel.Cancelled _ as e -> raise e
+    | exn ->
+        log_once
+          (Printf.sprintf "payload_read_error=%s declared_len=%d"
+             (Printexc.to_string exn) declared_len);
+        Ws.Payload.close payload
+
+let standalone_ws_eof_summary = function
+  | None -> "error=none"
+  | Some (`Exn exn) -> Printf.sprintf "error=%s" (Printexc.to_string exn)
+
 (** WebSocket handler factory.
 
     For each accepted connection, httpun-ws-eio calls this with the
@@ -63,8 +161,12 @@ let make_websocket_handler ~sw ~clock ~on_message _client_addr
          && not
               (Server_mcp_transport_ws.send_dashboard_or_raw_sse session
                  sse_event)
-      then
-        Server_mcp_transport_ws.cleanup_session session_id)
+      then begin
+        Log.Server.debug
+          "[ws-standalone] session %s sse-forward send failed; cleaning up"
+          session_id;
+        Server_mcp_transport_ws.cleanup_session session_id
+      end)
     ();
   (* Heartbeat fiber: emit a protocol-level ping every
      [heartbeat_interval_s] to keep NAT/proxy mappings warm and surface
@@ -86,12 +188,13 @@ let make_websocket_handler ~sw ~clock ~on_message _client_addr
              with
              | Some _ ->
                  Log.Server.debug
-                   "[ws-standalone] heartbeat skipped (writer closed during \
-                    cancel race)"
+                   "[ws-standalone] session %s heartbeat skipped (writer \
+                    closed during cancel race)"
+                   session_id
              | None ->
                  Log.Server.warn
-                   "[ws-standalone] heartbeat send_ping failed: %s"
-                   (Printexc.to_string exn)));
+                   "[ws-standalone] session %s heartbeat send_ping failed: %s"
+                   session_id (Printexc.to_string exn)));
         if !send_failed then begin
           (* If send_ping failed while [session.closed]/[Wsd.is_closed]
              still read false, the loop would otherwise spin emitting
@@ -146,12 +249,14 @@ let make_websocket_handler ~sw ~clock ~on_message _client_addr
                        (Printexc.to_string exn)));
         Ws.Payload.close payload
       | `Connection_close ->
+        log_ws_client_close_payload ~session_id ~declared_len:len payload;
         Server_mcp_transport_ws.cleanup_session session_id;
-        Ws.Payload.close payload
       | `Pong | `Other _ ->
         Ws.Payload.close payload
     );
-    eof = (fun ?error:_ () ->
+    eof = (fun ?error () ->
+      Log.Server.debug "[ws-standalone] session %s eof (%s)" session_id
+        (standalone_ws_eof_summary error);
       Server_mcp_transport_ws.cleanup_session session_id)
   }
 

--- a/lib/server/server_ws_standalone.ml
+++ b/lib/server/server_ws_standalone.ml
@@ -40,11 +40,35 @@ let max_ws_close_reason_log_len = 96
 
 let max_ws_close_payload_len = 125
 
+let utf8_codepoint_width first_byte =
+  let byte = Char.code first_byte in
+  if byte land 0x80 = 0 then
+    1
+  else if byte land 0xE0 = 0xC0 then
+    2
+  else if byte land 0xF0 = 0xE0 then
+    3
+  else if byte land 0xF8 = 0xF0 then
+    4
+  else
+    1
+
 let truncate_ws_close_reason reason =
   if String.length reason <= max_ws_close_reason_log_len then
     reason
-  else
-    String.sub reason 0 max_ws_close_reason_log_len ^ "...<truncated>"
+  else begin
+    let rec boundary idx =
+      if idx >= String.length reason || idx >= max_ws_close_reason_log_len then
+        idx
+      else
+        let next_idx = idx + utf8_codepoint_width reason.[idx] in
+        if next_idx > max_ws_close_reason_log_len then
+          idx
+        else
+          boundary next_idx
+    in
+    String.sub reason 0 (boundary 0) ^ "...<truncated>"
+  end
 
 let summarize_ws_close_payload bytes ~received_len ~declared_len =
   if received_len = 0 then
@@ -75,6 +99,54 @@ let summarize_ws_close_payload bytes ~received_len ~declared_len =
     Printf.sprintf "code=%d %s received_len=%d declared_len=%d%s" code reason
       received_len declared_len partial
 
+let immediate_ws_close_payload_summary ~declared_len =
+  if declared_len <= 0 then
+    Some (Printf.sprintf "code=none received_len=0 declared_len=%d" declared_len)
+  else if declared_len > max_ws_close_payload_len then
+    Some
+      (Printf.sprintf "payload_len=%d exceeds_control_frame_limit"
+         declared_len)
+  else
+    None
+
+type ws_close_payload_chunk_plan =
+  | Reject_empty_chunk of string
+  | Copy_then_finish of { copy_len : int; next_offset : int }
+  | Copy_then_continue of { copy_len : int; next_offset : int }
+
+let plan_ws_close_payload_chunk ~offset ~declared_len ~chunk_len =
+  if chunk_len <= 0 then
+    Reject_empty_chunk
+      (Printf.sprintf "payload_read_empty_chunk received_len=%d declared_len=%d"
+         offset declared_len)
+  else
+    let remaining = max 0 (declared_len - offset) in
+    let copy_len = min chunk_len remaining in
+    let next_offset = offset + copy_len in
+    if next_offset >= declared_len then
+      Copy_then_finish { copy_len; next_offset }
+    else
+      Copy_then_continue { copy_len; next_offset }
+
+module For_testing = struct
+  let max_ws_close_reason_log_len = max_ws_close_reason_log_len
+
+  let max_ws_close_payload_len = max_ws_close_payload_len
+
+  let truncate_ws_close_reason = truncate_ws_close_reason
+
+  let summarize_ws_close_payload = summarize_ws_close_payload
+
+  let immediate_ws_close_payload_summary = immediate_ws_close_payload_summary
+
+  type nonrec ws_close_payload_chunk_plan = ws_close_payload_chunk_plan =
+    | Reject_empty_chunk of string
+    | Copy_then_finish of { copy_len : int; next_offset : int }
+    | Copy_then_continue of { copy_len : int; next_offset : int }
+
+  let plan_ws_close_payload_chunk = plan_ws_close_payload_chunk
+end
+
 let log_ws_client_close_payload ~session_id ~declared_len payload =
   (* Terminal action for a single close-payload handling: log once + close
      payload once.  Every reachable leaf of the read state machine (early
@@ -91,13 +163,9 @@ let log_ws_client_close_payload ~session_id ~declared_len payload =
         Ws.Payload.close payload
       end
   in
-  if declared_len <= 0 then
-    finish "code=none received_len=0 declared_len=0"
-  else if declared_len > max_ws_close_payload_len then
-    finish
-      (Printf.sprintf "payload_len=%d exceeds_control_frame_limit"
-         declared_len)
-  else
+  match immediate_ws_close_payload_summary ~declared_len with
+  | Some summary -> finish summary
+  | None ->
     let buffer = Bytes.create declared_len in
     let offset = ref 0 in
     let rec schedule () =
@@ -112,17 +180,23 @@ let log_ws_client_close_payload ~session_id ~declared_len payload =
               (summarize_ws_close_payload buffer ~received_len:!offset
                  ~declared_len))
           ~on_read:(fun bs ~off ~len:chunk_len ->
-            let remaining = declared_len - !offset in
-            let copy_len = min chunk_len remaining in
-            Bigstringaf.blit_to_bytes bs ~src_off:off buffer
-              ~dst_off:!offset ~len:copy_len;
-            offset := !offset + copy_len;
-            if !offset >= declared_len then
-              finish
-                (summarize_ws_close_payload buffer ~received_len:!offset
-                   ~declared_len)
-            else
-              schedule ())
+            match
+              plan_ws_close_payload_chunk ~offset:!offset ~declared_len
+                ~chunk_len
+            with
+            | Reject_empty_chunk summary -> finish summary
+            | Copy_then_finish { copy_len; next_offset } ->
+                Bigstringaf.blit_to_bytes bs ~src_off:off buffer
+                  ~dst_off:!offset ~len:copy_len;
+                offset := next_offset;
+                finish
+                  (summarize_ws_close_payload buffer ~received_len:!offset
+                     ~declared_len)
+            | Copy_then_continue { copy_len; next_offset } ->
+                Bigstringaf.blit_to_bytes bs ~src_off:off buffer
+                  ~dst_off:!offset ~len:copy_len;
+                offset := next_offset;
+                schedule ())
     in
     try schedule () with
     | Eio.Cancel.Cancelled _ as e -> raise e

--- a/lib/server/server_ws_standalone.mli
+++ b/lib/server/server_ws_standalone.mli
@@ -33,6 +33,27 @@ val is_enabled : unit -> bool
     standalone WS be running" — agent_card, transport_read_model,
     and the bootstrap loop all branch on this predicate. *)
 
+module For_testing : sig
+  val max_ws_close_reason_log_len : int
+
+  val max_ws_close_payload_len : int
+
+  val truncate_ws_close_reason : string -> string
+
+  val summarize_ws_close_payload :
+    bytes -> received_len:int -> declared_len:int -> string
+
+  val immediate_ws_close_payload_summary : declared_len:int -> string option
+
+  type ws_close_payload_chunk_plan =
+    | Reject_empty_chunk of string
+    | Copy_then_finish of { copy_len : int; next_offset : int }
+    | Copy_then_continue of { copy_len : int; next_offset : int }
+
+  val plan_ws_close_payload_chunk :
+    offset:int -> declared_len:int -> chunk_len:int -> ws_close_payload_chunk_plan
+end
+
 val start :
   sw:Eio.Switch.t ->
   env:Eio_unix.Stdenv.base ->

--- a/test/dune
+++ b/test/dune
@@ -1262,6 +1262,7 @@
 (include stanzas/test_transport_bridge_seal.inc)
 (include stanzas/test_work_as_heartbeat.inc)
 (include stanzas/test_worker_safety_gates.inc)
+(include stanzas/test_ws_standalone_close_payload.inc)
 
 (test
  (name test_dashboard_yjs)

--- a/test/stanzas/test_ws_standalone_close_payload.inc
+++ b/test/stanzas/test_ws_standalone_close_payload.inc
@@ -1,0 +1,4 @@
+(test
+ (name test_ws_standalone_close_payload)
+ (modules test_ws_standalone_close_payload)
+ (libraries masc_test_deps))

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -1805,7 +1805,9 @@ let test_http_cancel_response_contracts () =
     && file_contains_pattern "lib/server/server_ws_standalone.ml"
          {|standalone_ws_eof_summary|}
     && file_contains_pattern "lib/server/server_ws_standalone.ml"
-         {|declared_len|})
+         {|declared_len|}
+    && file_contains_pattern "lib/server/server_ws_standalone.ml"
+         {|chunk_len <= 0|})
 
 let test_worktree_list_contracts () =
   check bool "worktree list stays read-only" true

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -1794,7 +1794,18 @@ let test_http_cancel_response_contracts () =
     && file_contains_pattern "lib/server/server_ws_standalone.ml"
          {|send_pong skipped|}
     && file_contains_pattern "lib/server/server_ws_standalone.ml"
-         {|WS standalone handler closed before write completed|})
+         {|WS standalone handler closed before write completed|});
+  check bool "standalone ws close diagnostics classify cleanup causes" true
+    (file_contains_pattern "lib/server/server_ws_standalone.ml"
+       {|log_ws_client_close_payload|}
+    && file_contains_pattern "lib/server/server_ws_standalone.ml"
+         {|client close|}
+    && file_contains_pattern "lib/server/server_ws_standalone.ml"
+         {|sse-forward send failed; cleaning up|}
+    && file_contains_pattern "lib/server/server_ws_standalone.ml"
+         {|standalone_ws_eof_summary|}
+    && file_contains_pattern "lib/server/server_ws_standalone.ml"
+         {|declared_len|})
 
 let test_worktree_list_contracts () =
   check bool "worktree list stays read-only" true

--- a/test/test_ws_standalone_close_payload.ml
+++ b/test/test_ws_standalone_close_payload.ml
@@ -1,0 +1,147 @@
+open Alcotest
+module WS = Masc_mcp.Server_ws_standalone.For_testing
+
+let truncation_suffix = "...<truncated>"
+let utf8_han = "\237\149\156"
+
+let close_payload ?(reason = "") code =
+  let payload = Bytes.create (2 + String.length reason) in
+  Bytes.set payload 0 (Char.chr ((code lsr 8) land 0xff));
+  Bytes.set payload 1 (Char.chr (code land 0xff));
+  Bytes.blit_string reason 0 payload 2 (String.length reason);
+  payload
+;;
+
+let test_truncate_ws_close_reason_boundaries () =
+  let exact_ascii = String.make WS.max_ws_close_reason_log_len 'a' in
+  check
+    string
+    "96-byte ascii unchanged"
+    exact_ascii
+    (WS.truncate_ws_close_reason exact_ascii);
+  let over_ascii = String.make (WS.max_ws_close_reason_log_len + 1) 'a' in
+  check
+    string
+    "97-byte ascii truncates"
+    (exact_ascii ^ truncation_suffix)
+    (WS.truncate_ws_close_reason over_ascii);
+  let exact_utf8 =
+    String.make (WS.max_ws_close_reason_log_len - String.length utf8_han) 'a' ^ utf8_han
+  in
+  check
+    string
+    "full utf8 codepoint at boundary unchanged"
+    exact_utf8
+    (WS.truncate_ws_close_reason exact_utf8);
+  let crossing_utf8 = String.make (WS.max_ws_close_reason_log_len - 2) 'a' ^ utf8_han in
+  check
+    string
+    "utf8 codepoint crossing boundary is not split"
+    (String.make (WS.max_ws_close_reason_log_len - 2) 'a' ^ truncation_suffix)
+    (WS.truncate_ws_close_reason crossing_utf8)
+;;
+
+let test_summarize_ws_close_payload_boundaries () =
+  check
+    string
+    "zero-length close payload"
+    "code=none received_len=0 declared_len=0"
+    (WS.summarize_ws_close_payload (Bytes.create 0) ~received_len:0 ~declared_len:0);
+  check
+    string
+    "single-byte close payload is malformed"
+    "malformed_close_payload received_len=1 declared_len=1"
+    (WS.summarize_ws_close_payload (Bytes.of_string "x") ~received_len:1 ~declared_len:1);
+  check
+    string
+    "two-byte close payload reports code"
+    "code=1000 reason=<empty> received_len=2 declared_len=2"
+    (WS.summarize_ws_close_payload (close_payload 1000) ~received_len:2 ~declared_len:2);
+  check
+    string
+    "partial payload is tagged"
+    "code=1000 reason=<empty> received_len=2 declared_len=4 partial=true"
+    (WS.summarize_ws_close_payload
+       (close_payload ~reason:"xy" 1000)
+       ~received_len:2
+       ~declared_len:4);
+  check
+    string
+    "reason payload is escaped"
+    "code=1000 reason=\"bye\" received_len=5 declared_len=5"
+    (WS.summarize_ws_close_payload
+       (close_payload ~reason:"bye" 1000)
+       ~received_len:5
+       ~declared_len:5)
+;;
+
+let check_some label expected = function
+  | Some actual -> check string label expected actual
+  | None -> failf "%s: expected Some" label
+;;
+
+let check_none label = function
+  | None -> ()
+  | Some actual -> failf "%s: expected None, got %S" label actual
+;;
+
+let test_immediate_ws_close_payload_summary_boundaries () =
+  check_some
+    "declared_len 0 finishes immediately"
+    "code=none received_len=0 declared_len=0"
+    (WS.immediate_ws_close_payload_summary ~declared_len:0);
+  check_some
+    "negative declared_len is retained in diagnostics"
+    "code=none received_len=0 declared_len=-1"
+    (WS.immediate_ws_close_payload_summary ~declared_len:(-1));
+  check_none
+    "declared_len 1 reads payload"
+    (WS.immediate_ws_close_payload_summary ~declared_len:1);
+  check_none
+    "declared_len 125 reads payload"
+    (WS.immediate_ws_close_payload_summary ~declared_len:125);
+  check_some
+    "declared_len 126 rejects control frame"
+    "payload_len=126 exceeds_control_frame_limit"
+    (WS.immediate_ws_close_payload_summary ~declared_len:126)
+;;
+
+let test_plan_ws_close_payload_chunk_guards_zero_len () =
+  (match WS.plan_ws_close_payload_chunk ~offset:0 ~declared_len:3 ~chunk_len:0 with
+   | WS.Reject_empty_chunk summary ->
+     check
+       string
+       "zero chunk finishes instead of rescheduling"
+       "payload_read_empty_chunk received_len=0 declared_len=3"
+       summary
+   | _ -> fail "expected zero chunk to reject");
+  match WS.plan_ws_close_payload_chunk ~offset:1 ~declared_len:3 ~chunk_len:5 with
+  | WS.Copy_then_finish { copy_len; next_offset } ->
+    check int "copy remaining bytes" 2 copy_len;
+    check int "next offset reaches declared len" 3 next_offset
+  | _ -> fail "expected oversized chunk to finish after copying remaining bytes"
+;;
+
+let () =
+  run
+    "ws_standalone_close_payload"
+    [ ( "close payload diagnostics"
+      , [ test_case
+            "truncate close reason boundaries"
+            `Quick
+            test_truncate_ws_close_reason_boundaries
+        ; test_case
+            "summarize payload boundaries"
+            `Quick
+            test_summarize_ws_close_payload_boundaries
+        ; test_case
+            "immediate declared length boundaries"
+            `Quick
+            test_immediate_ws_close_payload_summary_boundaries
+        ; test_case
+            "zero-length read chunk guard"
+            `Quick
+            test_plan_ws_close_payload_chunk_guards_zero_len
+        ] )
+    ]
+;;


### PR DESCRIPTION
## Summary

- Add standalone WebSocket DEBUG diagnostics for each cleanup path in #10701: client close frame, EOF, and SSE-forward send failure.
- Decode client close payloads into close code, reason, received length, declared length, and malformed/partial payload state without raising log volume above DEBUG.
- Address QA review gaps with UTF-8-safe close-reason truncation, zero-length read-chunk termination, and focused close-payload unit tests.

## Product impact

Operators investigating the WS connect/close storm can now distinguish browser/client close frames from TCP EOF and server send-cleanup paths on the server side. This complements the browser CloseEvent visibility from #13648 without reintroducing INFO-level per-session log noise.

## Evidence

- [근거] Rebases: final PR head is rebased onto live `origin/main` = `9ba828033468964cc9a7bd4d1e18df333bc42c3f` on 2026-05-07 KST. 신뢰도 High.
- [근거] Pushed PR head: `cb47b1713ab3390e7c149193db19cf05ba9490fa`, force-pushed with explicit lease from prior remote head `b62e9df8f4af3533530bd2a4661e17fc8e3251ab`. 신뢰도 High.
- `ocamlc -stop-after parsing lib/server/server_ws_standalone.ml lib/server/server_ws_standalone.mli test/test_ws_standalone_close_payload.ml test/test_ci_hardening_source.ml`
- `ocamlformat --check test/test_ws_standalone_close_payload.ml`
- `git diff --check origin/main...HEAD`
- `scripts/check-oas-pin.sh --local-only`
- `scripts/dune-local.sh build test/test_ws_standalone_close_payload.exe test/test_ci_hardening_source.exe`
- `./_build/default/test/test_ws_standalone_close_payload.exe`: 4 tests passed.
- `./_build/default/test/test_ci_hardening_source.exe`: 55 tests passed.

## Review evidence

- `truncate_ws_close_reason` now truncates on UTF-8 codepoint boundaries instead of blindly cutting the 96th byte.
- `summarize_ws_close_payload` has unit coverage for received lengths 0, 1, 2+, partial payloads, and escaped reasons.
- `log_ws_client_close_payload` now routes declared length 0/negative and >125 through a tested immediate summary helper; declared lengths 1 and 125 continue to read payload bytes.
- The schedule read path now terminates on `chunk_len <= 0`, preventing offset-stable recursion; the source guard and unit test both cover that condition.
- Existing legacy files still return exit 1 with no output under whole-file `ocamlformat --check`, so only the new test file was formatted in this patch.

## Linked issue

Fixes part of #10701.
