### PR TITLE
fix: count governance anomaly profile read drops

### DIFF
--- a/lib/governance_anomaly.ml
+++ b/lib/governance_anomaly.ml
@@ -252,6 +252,13 @@ let save_profile ~base_path (profile : behavioral_profile) =
   let json = profile_json profile in
   Fs_compat.save_file path (Yojson.Safe.pretty_to_string json)
 
+let persistence_surface = "governance_anomaly_profile"
+
+let record_persistence_read_drop ~reason () =
+  Prometheus.inc_counter Prometheus.metric_persistence_read_drops
+    ~labels:[("surface", persistence_surface); ("reason", reason)]
+    ()
+
 let load_profile ~base_path ~agent_id =
   let path = profile_path base_path agent_id in
   if not (Sys.file_exists path) then None
@@ -259,8 +266,15 @@ let load_profile ~base_path ~agent_id =
     match Safe_ops.read_file_safe path with
     | Error msg ->
         Log.Misc.warn "governance_anomaly: failed to read profile %s: %s" path msg;
+        record_persistence_read_drop
+          ~reason:Safe_ops.persistence_read_drop_reason_entry_load_error ();
         None
     | Ok content -> (
+        let invalid_payload () =
+          record_persistence_read_drop
+            ~reason:Safe_ops.persistence_read_drop_reason_invalid_payload ();
+          None
+        in
         try
           let json = Yojson.Safe.from_string content in
           match json with
@@ -340,13 +354,18 @@ let load_profile ~base_path ~agent_id =
                           hourly_dist;
                           updated_at;
                         }
-                  | _ -> None)
-              | _ -> None)
-          | _ -> None
+                  | _ -> invalid_payload ())
+              | _ -> invalid_payload ())
+          | _ -> invalid_payload ()
         with
-        | Yojson.Json_error _ -> None
+        | Yojson.Json_error _ ->
+            record_persistence_read_drop
+              ~reason:Safe_ops.persistence_read_drop_reason_entry_load_error ();
+            None
         | exn ->
             Log.Governance.warn "load_profile parse error: %s" (Printexc.to_string exn);
+            record_persistence_read_drop
+              ~reason:Safe_ops.persistence_read_drop_reason_invalid_payload ();
             None)
 
 (* ── Deviation detection ──────────────────────────────────── *)

--- a/test/test_governance_anomaly.ml
+++ b/test/test_governance_anomaly.ml
@@ -23,6 +23,33 @@ let cleanup_tmpdir dir =
   in
   rm_rf dir
 
+let rec mkdir_p path =
+  if path = "" || path = "." || path = "/" then ()
+  else if Sys.file_exists path then ()
+  else begin
+    mkdir_p (Filename.dirname path);
+    Unix.mkdir path 0o755
+  end
+
+let write_file path content =
+  mkdir_p (Filename.dirname path);
+  let oc = open_out path in
+  Fun.protect
+    ~finally:(fun () -> close_out_noerr oc)
+    (fun () -> output_string oc content)
+
+let profile_file base_path agent_id =
+  Filename.concat
+    (Filename.concat
+       (Filename.concat base_path ".masc")
+       "governance/baselines")
+    (agent_id ^ ".json")
+
+let anomaly_profile_drop_value reason =
+  Prometheus.metric_value_or_zero Prometheus.metric_persistence_read_drops
+    ~labels:[("surface", "governance_anomaly_profile"); ("reason", reason)]
+    ()
+
 (** Generate [count] audit entries spaced [spacing_sec] apart,
     ending at [end_ts]. All share [agent_id]. *)
 let gen_entries ~end_ts ~spacing_sec ~count ~tool_names ~outcomes ~token_counts =
@@ -229,6 +256,35 @@ let test_load_profile_missing () =
       | None -> ()
       | Some _ -> fail "expected None for missing profile")
 
+let test_load_profile_malformed_json_records_drop () =
+  let dir = make_tmpdir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_tmpdir dir)
+    (fun () ->
+      let reason = Safe_ops.persistence_read_drop_reason_entry_load_error in
+      let before = anomaly_profile_drop_value reason in
+      write_file (profile_file dir agent_id) "{not-json";
+      (match Governance_anomaly.load_profile ~base_path:dir ~agent_id with
+      | None -> ()
+      | Some _ -> fail "expected malformed profile to be dropped");
+      check (float 0.001) "malformed profile increments entry load error" 1.0
+        (anomaly_profile_drop_value reason -. before))
+
+let test_load_profile_invalid_payload_records_drop () =
+  let dir = make_tmpdir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_tmpdir dir)
+    (fun () ->
+      let reason = Safe_ops.persistence_read_drop_reason_invalid_payload in
+      let before = anomaly_profile_drop_value reason in
+      write_file (profile_file dir agent_id)
+        (Yojson.Safe.to_string (`Assoc [("agent_id", `String agent_id)]));
+      (match Governance_anomaly.load_profile ~base_path:dir ~agent_id with
+      | None -> ()
+      | Some _ -> fail "expected invalid profile to be dropped");
+      check (float 0.001) "invalid profile increments invalid payload" 1.0
+        (anomaly_profile_drop_value reason -. before))
+
 let test_check_agent_insufficient_entries () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
@@ -264,6 +320,10 @@ let () =
         [
           test_case "save/load profile roundtrip" `Quick test_save_load_profile_roundtrip;
           test_case "load_profile returns None when missing" `Quick test_load_profile_missing;
+          test_case "load_profile malformed json records drop" `Quick
+            test_load_profile_malformed_json_records_drop;
+          test_case "load_profile invalid payload records drop" `Quick
+            test_load_profile_invalid_payload_records_drop;
         ] );
       ( "pipeline",
         [


### PR DESCRIPTION
Summary
- Count governance anomaly profile file read failures and malformed JSON with masc_persistence_read_drops_total surface=governance_anomaly_profile reason=entry_load_error.
- Count syntactically valid but schema-invalid profile payloads with reason=invalid_payload.
- Add focused load_profile regressions for malformed JSON and invalid profile payloads.

Why it matters
- Governance anomaly baselines previously disappeared as None on damaged files without a bounded operator metric. This keeps missing profiles quiet while making corrupt or invalid profile data measurable.

Verification
- git diff --check origin/main...HEAD
- lockf -k -t 1200 /tmp/me-dune-local.lock env MASC_DUNE_LOCK_HELD=1 MASC_SKIP_OPAM_LOCK=1 DUNE_JOBS=1 DUNE_CACHE=disabled scripts/dune-local.sh build test/test_governance_anomaly.exe
- ./_build/default/test/test_governance_anomaly.exe