### PR TITLE
fix: count team context findings read drops

### DIFF
--- a/lib/team_context.ml
+++ b/lib/team_context.ml
@@ -36,6 +36,13 @@ let findings_path ~base_path =
     (Coord_utils.masc_dir_from_base_path ~base_path)
     "shared_findings.jsonl"
 
+let persistence_surface = "team_context_findings"
+
+let record_persistence_read_drop ~reason () =
+  Prometheus.inc_counter Prometheus.metric_persistence_read_drops
+    ~labels:[("surface", persistence_surface); ("reason", reason)]
+    ()
+
 let add_finding ~base_path ~worker_name ~finding =
   let path = findings_path ~base_path in
   let dir = Filename.dirname path in
@@ -70,10 +77,19 @@ let load_findings ~base_path : string list =
                           |> Option.value ~default:"" in
             if finding <> "" then
               Some (Printf.sprintf "[%s] %s" worker finding)
-            else None
-          with Yojson.Json_error _ -> None
+            else (
+              record_persistence_read_drop
+                ~reason:Safe_ops.persistence_read_drop_reason_invalid_payload ();
+              None)
+          with Yojson.Json_error _ ->
+            record_persistence_read_drop
+              ~reason:Safe_ops.persistence_read_drop_reason_entry_load_error ();
+            None
       ) lines
-    with Sys_error _ -> []
+    with Sys_error _ ->
+      record_persistence_read_drop
+        ~reason:Safe_ops.persistence_read_drop_reason_entry_load_error ();
+      []
 
 let build ~base_path =
   let shared_findings = load_findings ~base_path in

--- a/test/test_autonomy_liberation.ml
+++ b/test/test_autonomy_liberation.ml
@@ -3,6 +3,7 @@
 module Spawn = Masc_mcp.Spawn
 module Agent_tool_surfaces = Masc_mcp.Agent_tool_surfaces
 module Keeper_deliberation = Masc_mcp.Keeper_deliberation
+module Prometheus = Masc_mcp.Prometheus
 
 (* New modules may not be visible via Masc_mcp wrapper in large libraries
    due to dune's incremental wrapper compilation. Use internal names. *)
@@ -89,6 +90,75 @@ let test_team_context_prompt_section () =
     (contains_s section "Found bug");
   Alcotest.(check bool) "contains workers" true
     (contains_s section "worker-1")
+
+let rec rm_rf path =
+  if Sys.file_exists path then
+    if Sys.is_directory path then begin
+      Sys.readdir path
+      |> Array.iter (fun name -> rm_rf (Filename.concat path name));
+      Unix.rmdir path
+    end else
+      Sys.remove path
+
+let temp_base_path prefix =
+  Filename.concat (Filename.get_temp_dir_name ())
+    (Printf.sprintf "%s-%d-%d" prefix (Unix.getpid ()) (Random.bits ()))
+
+let write_file path content =
+  let rec mkdir_p dir =
+    if dir = "" || dir = "." || dir = "/" then ()
+    else if Sys.file_exists dir then ()
+    else begin
+      mkdir_p (Filename.dirname dir);
+      Unix.mkdir dir 0o755
+    end
+  in
+  mkdir_p (Filename.dirname path);
+  let oc = open_out path in
+  Fun.protect
+    ~finally:(fun () -> close_out_noerr oc)
+    (fun () -> output_string oc content)
+
+let team_context_drop_value reason =
+  Prometheus.metric_value_or_zero Prometheus.metric_persistence_read_drops
+    ~labels:[("surface", "team_context_findings"); ("reason", reason)]
+    ()
+
+let test_team_context_load_findings_records_drop_metrics () =
+  let base_path = temp_base_path "test-team-context-drops" in
+  Fun.protect
+    ~finally:(fun () -> rm_rf base_path)
+    (fun () ->
+      let path =
+        Filename.concat
+          (Filename.concat base_path Common.masc_dirname)
+          "shared_findings.jsonl"
+      in
+      let entry_error = Safe_ops.persistence_read_drop_reason_entry_load_error in
+      let invalid_payload = Safe_ops.persistence_read_drop_reason_invalid_payload in
+      let before_entry_error = team_context_drop_value entry_error in
+      let before_invalid_payload = team_context_drop_value invalid_payload in
+      write_file path
+        (String.concat "\n"
+           [
+             Yojson.Safe.to_string
+               (`Assoc
+                 [
+                   ("worker", `String "w1");
+                   ("finding", `String "valid finding");
+                 ]);
+             "{not-json";
+             Yojson.Safe.to_string (`Assoc [("worker", `String "w2")]);
+           ]
+        ^ "\n");
+      let findings = Team_context.load_findings ~base_path in
+      Alcotest.(check int) "valid finding survives" 1 (List.length findings);
+      Alcotest.(check bool) "valid finding content" true
+        (List.exists (fun f -> contains_s f "valid finding") findings);
+      Alcotest.(check (float 0.001)) "malformed json increments entry error"
+        1.0 (team_context_drop_value entry_error -. before_entry_error);
+      Alcotest.(check (float 0.001)) "missing finding increments invalid payload"
+        1.0 (team_context_drop_value invalid_payload -. before_invalid_payload))
 
 (* ── Phase 4: Prompt Composer ─────────────────────────────────── *)
 
@@ -268,6 +338,8 @@ let () =
           Alcotest.test_case "empty context" `Quick test_team_context_empty;
           Alcotest.test_case "prompt section" `Quick
             test_team_context_prompt_section;
+          Alcotest.test_case "load findings drop metrics" `Quick
+            test_team_context_load_findings_records_drop_metrics;
         ] );
       ( "phase4_prompt_composer",
         [


### PR DESCRIPTION
Summary
- Count shared findings JSONL read failures and malformed rows with masc_persistence_read_drops_total surface=team_context_findings reason=entry_load_error.
- Count syntactically valid rows missing a finding with reason=invalid_payload.
- Add a focused regression in test_autonomy_liberation that keeps valid findings readable while asserting both counter deltas.

Why it matters
- Team context shared findings previously dropped damaged rows silently, which weakens coordination and hides corruption in the worker handoff surface. This makes the damage visible through the same bounded persistence drop metric used by the other Phase 0 slices.

Verification
- git diff --check
- lockf -k -t 1200 /tmp/me-dune-local.lock env MASC_DUNE_LOCK_HELD=1 MASC_SKIP_OPAM_LOCK=1 DUNE_JOBS=1 DUNE_CACHE=disabled scripts/dune-local.sh build test/test_autonomy_liberation.exe
- ./_build/default/test/test_autonomy_liberation.exe