### PR TITLE
fix: count coord receipt read drops

### DIFF
--- a/lib/coord.ml
+++ b/lib/coord.ml
@@ -317,6 +317,16 @@ let () =
   Atomic.set Coord_hooks.task_auto_release_observed_fn
     record_task_auto_release
 
+let record_persistence_read_drop ~surface ~reason =
+  Prometheus.inc_counter
+    Prometheus.metric_persistence_read_drops
+    ~labels:[ ("surface", surface); ("reason", reason) ]
+    ()
+
+let () =
+  Atomic.set Coord_hooks.persistence_read_drop_fn
+    record_persistence_read_drop
+
 let clear_agent_current_task_cache config ~task_id =
   let agents_path = agents_dir config in
   if path_exists config agents_path then

--- a/lib/coord.mli
+++ b/lib/coord.mli
@@ -95,3 +95,11 @@ val record_distributed_lock_acquire_failed :
     {!Coord_hooks.distributed_lock_acquire_failed_fn} so
     [Coord_utils_ops] can fire the metric without taking a
     direct [Prometheus] dependency. *)
+
+(** {1 Coord persistence read-drop observability} *)
+
+val record_persistence_read_drop : surface:string -> reason:string -> unit
+(** Increment [masc_persistence_read_drops_total] for coord-owned read-model
+    drops.  Production coord modules fire this through
+    {!Coord_hooks.persistence_read_drop_fn} to keep [masc_coord] below the
+    Prometheus layer. *)

--- a/lib/coord/coord_hooks.ml
+++ b/lib/coord/coord_hooks.ml
@@ -241,6 +241,13 @@ let task_auto_release_observed_fn
   : (agent_name:string -> from_status:string -> unit) Atomic.t
   = Atomic.make (fun ~agent_name:_ ~from_status:_ -> ())
 
+(** Persistence read-drop observability for coord-owned read models.
+    Coord sub-modules call this instead of depending on Prometheus directly;
+    [lib/coord.ml] wires the bounded [surface]/[reason] labels at startup. *)
+let persistence_read_drop_fn
+  : (surface:string -> reason:string -> unit) Atomic.t
+  = Atomic.make (fun ~surface:_ ~reason:_ -> ())
+
 (** #13460: stale task-state cache emission observability.
     Coord sub-modules fire this when they replace a stale active-task
     broadcast/mention with a cache invalidation message. [lib/coord.ml]

--- a/lib/coord/coord_hooks.mli
+++ b/lib/coord/coord_hooks.mli
@@ -65,6 +65,8 @@ val task_completion_path_observed_fn : (path:string -> contract_state:string -> 
            Atomic.t
 val task_auto_release_observed_fn :
   (agent_name:string -> from_status:string -> unit) Atomic.t
+val persistence_read_drop_fn :
+  (surface:string -> reason:string -> unit) Atomic.t
 val cache_desync_cleared_fn :
   (Coord_utils_backend_setup.config ->
    module_name:string -> task_id:string -> status:string -> unit) Atomic.t

--- a/lib/coord/coord_task_schedule.ml
+++ b/lib/coord/coord_task_schedule.ml
@@ -146,6 +146,19 @@ let directory_exists path =
 let directory_entries path =
   try Sys.readdir path |> Array.to_list with Sys_error _ -> []
 
+let receipt_persistence_surface = "coord_task_schedule_receipt"
+
+let report_receipt_read_drop ~reason ~path ~detail =
+  Safe_ops.report_persistence_read_drop
+    ~on_drop:(fun () ->
+      (Atomic.get Coord_hooks.persistence_read_drop_fn)
+        ~surface:receipt_persistence_surface
+        ~reason)
+    ~surface:receipt_persistence_surface
+    ~reason
+    ~path
+    ~detail
+
 let jsonl_files_under base_dir =
   if not (directory_exists base_dir) then []
   else
@@ -174,7 +187,12 @@ let last_nonempty_line path =
          loop None)
   with
   | Eio.Cancel.Cancelled _ as e -> raise e
-  | Sys_error _ -> None
+  | Sys_error detail ->
+      report_receipt_read_drop
+        ~reason:Safe_ops.persistence_read_drop_reason_entry_load_error
+        ~path
+        ~detail;
+      None
 
 let latest_json_in_receipt_dir base_dir =
   jsonl_files_under base_dir
@@ -184,7 +202,12 @@ let latest_json_in_receipt_dir base_dir =
        | None -> None
        | Some line -> (
            try Some (Yojson.Safe.from_string line)
-           with Yojson.Json_error _ -> None))
+           with Yojson.Json_error detail ->
+             report_receipt_read_drop
+               ~reason:Safe_ops.persistence_read_drop_reason_entry_load_error
+               ~path
+               ~detail;
+             None))
 
 let json_member_path path json =
   List.fold_left

--- a/test/test_types.ml
+++ b/test/test_types.ml
@@ -3,6 +3,48 @@ open Types
 
 (** Tests for Types module *)
 
+let rec remove_tree path =
+  if Sys.file_exists path then
+    if Sys.is_directory path then begin
+      Sys.readdir path
+      |> Array.iter (fun name -> remove_tree (Filename.concat path name));
+      Unix.rmdir path
+    end else
+      Sys.remove path
+
+let rec mkdir_p dir =
+  if dir = "" || dir = "." || dir = "/" then ()
+  else if Sys.file_exists dir then ()
+  else begin
+    mkdir_p (Filename.dirname dir);
+    Unix.mkdir dir 0o755
+  end
+
+let temp_dir prefix =
+  let path =
+    Filename.concat (Filename.get_temp_dir_name ())
+      (Printf.sprintf "%s-%d-%d" prefix (Unix.getpid ()) (Random.bits ()))
+  in
+  Unix.mkdir path 0o755;
+  path
+
+let write_file path content =
+  mkdir_p (Filename.dirname path);
+  let oc = open_out path in
+  Fun.protect
+    ~finally:(fun () -> close_out_noerr oc)
+    (fun () -> output_string oc content)
+
+let coord_receipt_drop_value reason =
+  Masc_mcp.Prometheus.metric_value_or_zero
+    Masc_mcp.Prometheus.metric_persistence_read_drops
+    ~labels:
+      [
+        ("surface", "coord_task_schedule_receipt");
+        ("reason", reason);
+      ]
+    ()
+
 let test_agent_status_roundtrip () =
   let statuses = [Active; Busy; Listening; Inactive] in
   List.iter (fun status ->
@@ -100,6 +142,40 @@ let test_strict_parser_unchanged () =
   match task_action_of_string "claimed" with
   | Error _ -> ()
   | Ok _ -> Alcotest.fail "strict parser must reject aliases; lenient owns aliases"
+
+let test_latest_receipt_malformed_json_records_drop () =
+  let previous_hook = Atomic.get Coord_hooks.persistence_read_drop_fn in
+  Atomic.set Coord_hooks.persistence_read_drop_fn
+    Masc_mcp.Coord.record_persistence_read_drop;
+  let base_dir = temp_dir "coord-receipt-drop" in
+  Fun.protect
+    ~finally:(fun () ->
+      Atomic.set Coord_hooks.persistence_read_drop_fn previous_hook;
+      try remove_tree base_dir with _ -> ())
+    (fun () ->
+      let month_dir = Filename.concat base_dir "2026-05" in
+      let bad_path = Filename.concat month_dir "z-bad.jsonl" in
+      let good_path = Filename.concat month_dir "a-good.jsonl" in
+      let reason = Safe_ops.persistence_read_drop_reason_entry_load_error in
+      let before = coord_receipt_drop_value reason in
+      write_file bad_path "{not-json\n";
+      write_file good_path
+        (Yojson.Safe.to_string
+           (`Assoc
+             [
+               ("id", `String "receipt-ok");
+               ("recorded_at", `String "2026-05-07T00:00:00Z");
+             ])
+        ^ "\n");
+      match Coord_task_schedule.latest_json_in_receipt_dir base_dir with
+      | Some json ->
+          Alcotest.(check (option string)) "falls back to valid receipt"
+            (Some "receipt-ok")
+            Yojson.Safe.Util.(member "id" json |> to_string_option);
+          Alcotest.(check (float 0.001)) "malformed receipt increments drop"
+            1.0
+            (coord_receipt_drop_value reason -. before)
+      | None -> Alcotest.fail "expected valid fallback receipt")
 
 (* Issue #8372: schema enums for [agent_status] used to be hand-rolled.
    The witness function ensures every variant produces a string that
@@ -1199,6 +1275,10 @@ let () =
         Alcotest.(check bool) "Cancelled -> NOT claim pool" false
           (S.task_is_claim_pool_candidate
              (dummy_task (Masc_domain.Cancelled { cancelled_by = "a"; cancelled_at = "t"; reason = None }))));
+    ];
+    "coord_receipt_read_drops", [
+      Alcotest.test_case "malformed latest receipt increments drop metric" `Quick
+        test_latest_receipt_malformed_json_records_drop;
     ];
     "publish_phase_lifecycle_ssot", [
       (* Issue #8572: phase-bearing publish_lifecycle calls used to pass


### PR DESCRIPTION
Summary
- Add a coord-layer persistence read-drop hook so masc_coord can emit bounded read-model drop metrics without depending on Prometheus directly.
- Count malformed execution receipt JSONL rows and receipt read errors as masc_persistence_read_drops_total surface=coord_task_schedule_receipt reason=entry_load_error.
- Add a regression in test_types proving a malformed newest receipt increments the counter while the older valid receipt is still returned.

Why it matters
- The task scheduler used execution receipts to block unsafe tool claims, but malformed receipt JSON was silently skipped. This makes receipt corruption visible through the same Phase 0 persistence-drop metric without changing fallback behavior.

Verification
- git diff --check
- lockf -k -t 1200 /tmp/me-dune-local.lock env MASC_DUNE_LOCK_HELD=1 MASC_SKIP_OPAM_LOCK=1 DUNE_JOBS=1 DUNE_CACHE=disabled scripts/dune-local.sh build test/test_types.exe
- ./_build/default/test/test_types.exe