### PR TITLE
fix: count board post meta read drops

### DIFF
--- a/lib/board_votes.ml
+++ b/lib/board_votes.ml
@@ -29,6 +29,18 @@ let all_vote_directions = [ Up; Down ]
 let valid_vote_direction_strings =
   List.map vote_direction_to_string all_vote_directions
 
+let post_meta_json_persistence_surface = "board_post_meta_json"
+
+let record_post_meta_json_read_drop () =
+  Prometheus.inc_counter
+    Prometheus.metric_persistence_read_drops
+    ~labels:
+      [
+        ("surface", post_meta_json_persistence_surface);
+        ("reason", Safe_ops.persistence_read_drop_reason_invalid_payload);
+      ]
+    ()
+
 (* Sound partial parser — case-insensitive, trims whitespace, accepts
    empty as default Up for back-compat with [tool_board.ml] which
    defaults to "up" when the field is missing. *)
@@ -369,7 +381,11 @@ let post_of_yojson (json : Yojson.Safe.t) : post option =
       | Some (`Assoc _ as meta) -> Some meta
       | Some _ | None ->
         (match Safe_ops.json_string_opt "meta_json" json with
-         | Some raw -> (try Some (Yojson.Safe.from_string raw) with Yojson.Json_error _ -> None)
+         | Some raw -> (
+           try Some (Yojson.Safe.from_string raw)
+           with Yojson.Json_error _ ->
+             record_post_meta_json_read_drop ();
+             None)
          | None -> None)
     in
     (match Post_id.of_string id_str, Agent_id.of_string author_str, visibility_of_string vis_str with

--- a/test/test_board_vote_quarantine.ml
+++ b/test/test_board_vote_quarantine.ml
@@ -3,6 +3,7 @@
 open Alcotest
 
 module BV = Masc_mcp.Board_votes
+module P = Masc_mcp.Prometheus
 
 let with_env key value f =
   let prev = Sys.getenv_opt key in
@@ -41,6 +42,37 @@ let test_quarantine_explicit_false () =
   with_env "MASC_BOARD_VOTE_QUARANTINE" "off" (fun () ->
     check bool "'off' disables" false (BV.quarantine_enabled ()))
 
+let board_post_meta_drop_value () =
+  P.metric_value_or_zero P.metric_persistence_read_drops
+    ~labels:
+      [
+        ("surface", "board_post_meta_json");
+        ("reason", Safe_ops.persistence_read_drop_reason_invalid_payload);
+      ]
+    ()
+
+let test_malformed_post_meta_json_counts_drop () =
+  let before = board_post_meta_drop_value () in
+  let json =
+    `Assoc
+      [
+        ("id", `String "post-meta-json-drop");
+        ("author", `String "keeper-board");
+        ("content", `String "body");
+        ("visibility", `String "public");
+        ("created_at", `Float 1.0);
+        ("expires_at", `Float 2.0);
+        ("meta_json", `String "{not-json");
+      ]
+  in
+  match BV.post_of_yojson json with
+  | Some post ->
+      check (option string) "malformed meta dropped" None
+        (Option.map Yojson.Safe.to_string post.meta_json);
+      check (float 0.001) "malformed meta increments drop" 1.0
+        (board_post_meta_drop_value () -. before)
+  | None -> fail "expected post with malformed meta_json to load"
+
 let () =
   run "board_vote_quarantine" [
     "explicit", [
@@ -48,5 +80,9 @@ let () =
         test_quarantine_empty_treated_as_disabled;
       test_case "truthy values enable" `Quick test_quarantine_explicit_true;
       test_case "falsy values disable" `Quick test_quarantine_explicit_false;
+    ];
+    "persistence_read_drops", [
+      test_case "malformed post meta_json increments drop metric" `Quick
+        test_malformed_post_meta_json_counts_drop;
     ];
   ]


### PR DESCRIPTION
Summary
- Count malformed persisted board post meta_json payloads with masc_persistence_read_drops_total surface=board_post_meta_json reason=invalid_payload.
- Keep the existing fail-soft behavior: the post still loads while malformed metadata is ignored.
- Add a focused regression in test_board_vote_quarantine for the counter delta and fallback behavior.

Why it matters
- Board post metadata can carry automation and attachment context. Previously malformed legacy meta_json vanished silently during post decode, which hid persistence corruption from operators.

Verification
- git diff --check
- lockf -k -t 1200 /tmp/me-dune-local.lock env MASC_DUNE_LOCK_HELD=1 MASC_SKIP_OPAM_LOCK=1 DUNE_JOBS=1 DUNE_CACHE=disabled scripts/dune-local.sh build test/test_board_vote_quarantine.exe
- ./_build/default/test/test_board_vote_quarantine.exe