### PR TITLE
fix: count keeper chat store read drops

### DIFF
--- a/lib/keeper/keeper_chat_store.ml
+++ b/lib/keeper/keeper_chat_store.ml
@@ -17,6 +17,22 @@ let chat_dir base_dir =
 let chat_path ~base_dir ~keeper_name =
   Filename.concat (chat_dir base_dir) (sanitize_name keeper_name ^ ".jsonl")
 
+let persistence_surface = "keeper_chat_store"
+
+let record_persistence_read_drop ~reason () =
+  Prometheus.inc_counter
+    Prometheus.metric_persistence_read_drops
+    ~labels:[("surface", persistence_surface); ("reason", reason)]
+    ()
+
+let report_persistence_read_drop ~reason ~path ~detail =
+  Safe_ops.report_persistence_read_drop
+    ~on_drop:(fun () -> record_persistence_read_drop ~reason ())
+    ~surface:persistence_surface
+    ~reason
+    ~path
+    ~detail
+
 let ensure_dir_once ~base_dir =
   ignore (Keeper_fs.ensure_dir (chat_dir base_dir))
 
@@ -54,7 +70,7 @@ type chat_message = {
   ts : float option;
 }
 
-let parse_line (line : string) : chat_message option =
+let parse_line ~file_path (line : string) : chat_message option =
   try
     let json = Yojson.Safe.from_string line in
     let open Yojson.Safe.Util in
@@ -63,14 +79,26 @@ let parse_line (line : string) : chat_message option =
     let ts =
       (try Some (member "ts" json |> to_float)
        with Eio.Cancel.Cancelled _ as e -> raise e | _ -> None) in
-    if role = "" || content = "" then None
+    if role = "" || content = "" then (
+      report_persistence_read_drop
+        ~reason:Safe_ops.persistence_read_drop_reason_invalid_payload
+        ~path:file_path
+        ~detail:"chat row missing non-empty role/content";
+      None)
     else Some { role; content; ts }
-  with Yojson.Json_error _ -> None
+  with Yojson.Json_error detail ->
+    report_persistence_read_drop
+      ~reason:Safe_ops.persistence_read_drop_reason_entry_load_error
+      ~path:file_path
+      ~detail;
+    None
 
 let max_history = 100
 
 let load ~base_dir ~keeper_name : chat_message list =
   let path = chat_path ~base_dir ~keeper_name in
+  if not (Sys.file_exists path) then []
+  else
   try
     let content = Fs_compat.load_file path in
     let lines = String.split_on_char '\n' content in
@@ -80,7 +108,7 @@ let load ~base_dir ~keeper_name : chat_message list =
       (fun line ->
         let trimmed = String.trim line in
         if trimmed <> "" then
-          match parse_line trimmed with
+          match parse_line ~file_path:path trimmed with
           | Some msg ->
               Queue.push msg q;
               if Queue.length q > max_history then ignore (Queue.pop q)
@@ -88,7 +116,12 @@ let load ~base_dir ~keeper_name : chat_message list =
       lines;
     Queue.fold (fun acc msg -> msg :: acc) [] q |> List.rev
   with
-  | Sys_error _ -> []
+  | Sys_error detail ->
+      report_persistence_read_drop
+        ~reason:Safe_ops.persistence_read_drop_reason_entry_load_error
+        ~path
+        ~detail;
+      []
   | exn ->
       Prometheus.inc_counter
         Prometheus.metric_keeper_chat_store_failures

--- a/test/dune
+++ b/test/dune
@@ -78,6 +78,7 @@
         test_keeper_wake_telemetry
         test_keeper_timing
         test_keeper_memory
+        test_keeper_chat_store
         test_keeper_accountability
         test_reputation_ledger_v2
         test_reputation_multi_dim
@@ -301,6 +302,7 @@
           test_keeper_wake_telemetry
           test_keeper_timing
           test_keeper_memory
+          test_keeper_chat_store
           test_keeper_accountability
           test_reputation_ledger_v2
           test_reputation_multi_dim

--- a/test/test_keeper_chat_store.ml
+++ b/test/test_keeper_chat_store.ml
@@ -1,0 +1,96 @@
+module K = Masc_mcp.Keeper_chat_store
+module P = Masc_mcp.Prometheus
+
+let rec remove_tree path =
+  if Sys.file_exists path then
+    if Sys.is_directory path then begin
+      Sys.readdir path
+      |> Array.iter (fun name -> remove_tree (Filename.concat path name));
+      Unix.rmdir path
+    end else
+      Sys.remove path
+
+let rec mkdir_p dir =
+  if dir = "" || dir = "." || dir = "/" then ()
+  else if Sys.file_exists dir then ()
+  else begin
+    mkdir_p (Filename.dirname dir);
+    Unix.mkdir dir 0o755
+  end
+
+let temp_base_path prefix =
+  Filename.concat (Filename.get_temp_dir_name ())
+    (Printf.sprintf "%s-%d-%d" prefix (Unix.getpid ()) (Random.bits ()))
+
+let write_file path content =
+  mkdir_p (Filename.dirname path);
+  let oc = open_out path in
+  Fun.protect
+    ~finally:(fun () -> close_out_noerr oc)
+    (fun () -> output_string oc content)
+
+let drop_value reason =
+  P.metric_value_or_zero P.metric_persistence_read_drops
+    ~labels:[("surface", "keeper_chat_store"); ("reason", reason)]
+    ()
+
+let chat_path ~base_dir ~keeper_name =
+  Filename.concat
+    (Filename.concat
+       (Common.masc_dir_from_base_path ~base_path:base_dir)
+       "keeper_chat")
+    (Coord_utils_backend_setup.sanitize_namespace_segment keeper_name ^ ".jsonl")
+
+let test_load_records_malformed_row_drops () =
+  let base_dir = temp_base_path "keeper-chat-store-drops" in
+  Fun.protect
+    ~finally:(fun () -> try remove_tree base_dir with _ -> ())
+    (fun () ->
+      let keeper_name = "keeper-chat-drop" in
+      let path = chat_path ~base_dir ~keeper_name in
+      let entry_error = Safe_ops.persistence_read_drop_reason_entry_load_error in
+      let invalid_payload = Safe_ops.persistence_read_drop_reason_invalid_payload in
+      let before_entry_error = drop_value entry_error in
+      let before_invalid_payload = drop_value invalid_payload in
+      write_file path
+        (String.concat "\n"
+           [
+             Yojson.Safe.to_string
+               (`Assoc
+                  [
+                    ("role", `String "user");
+                    ("content", `String "hello");
+                    ("ts", `Float 1.0);
+                  ]);
+             "{not-json";
+             Yojson.Safe.to_string (`Assoc [("role", `String "assistant")]);
+             Yojson.Safe.to_string
+               (`Assoc
+                  [
+                    ("role", `String "assistant");
+                    ("content", `String "world");
+                    ("ts", `Float 2.0);
+                  ]);
+           ]
+        ^ "\n");
+      let messages = K.load ~base_dir ~keeper_name in
+      Alcotest.(check int) "valid messages survive" 2 (List.length messages);
+      Alcotest.(check (list string)) "content order"
+        [ "hello"; "world" ]
+        (List.map (fun (msg : K.chat_message) -> msg.content) messages);
+      Alcotest.(check (float 0.001)) "malformed json increments entry error"
+        1.0
+        (drop_value entry_error -. before_entry_error);
+      Alcotest.(check (float 0.001)) "missing content increments invalid payload"
+        1.0
+        (drop_value invalid_payload -. before_invalid_payload))
+
+let () =
+  Alcotest.run "keeper_chat_store"
+    [
+      ( "persistence_read_drops",
+        [
+          Alcotest.test_case "malformed rows increment drop metrics" `Quick
+            test_load_records_malformed_row_drops;
+        ] );
+    ]


### PR DESCRIPTION
Summary
- Count malformed keeper chat JSONL rows with masc_persistence_read_drops_total surface=keeper_chat_store reason=entry_load_error.
- Count syntactically valid rows missing non-empty role/content with reason=invalid_payload.
- Add a focused keeper_chat_store regression proving valid rows survive while both drop counters increment.

Why it matters
- Keeper direct-message history is part of the operator coordination surface. Damaged chat rows previously disappeared silently, which hid persistence corruption and made chat context gaps hard to diagnose.

Verification
- git diff --check
- scripts/opam-pin-external-deps.sh --install
- lockf -k -t 1200 /tmp/me-dune-local.lock env MASC_DUNE_LOCK_HELD=1 MASC_SKIP_OPAM_LOCK=1 DUNE_JOBS=1 DUNE_CACHE=disabled scripts/dune-local.sh build test/test_keeper_chat_store.exe
- ./_build/default/test/test_keeper_chat_store.exe