### PR TITLE
fix: count runtime trust decision read drops

### DIFF
--- a/lib/keeper/keeper_runtime_trust_snapshot.ml
+++ b/lib/keeper/keeper_runtime_trust_snapshot.ml
@@ -731,6 +731,19 @@ let disposition_fields_json ~(config : Coord.config) ~(meta : keeper_meta) :
       ("disposition_reason", `String disposition_reason);
     ]
 
+let decision_log_persistence_surface = "keeper_runtime_trust_decision_log"
+
+let report_decision_log_read_drop ~reason ~path ~detail =
+  Safe_ops.report_persistence_read_drop
+    ~on_drop:(fun () ->
+      Prometheus.inc_counter Prometheus.metric_persistence_read_drops
+        ~labels:[("surface", decision_log_persistence_surface); ("reason", reason)]
+        ())
+    ~surface:decision_log_persistence_surface
+    ~reason
+    ~path
+    ~detail
+
 let latest_decision_json ~(config : Coord.config) ~(keeper_name : string) :
     Yojson.Safe.t option =
   let path = Keeper_types.keeper_decision_log_path config keeper_name in
@@ -740,9 +753,19 @@ let latest_decision_json ~(config : Coord.config) ~(keeper_name : string) :
     |> List.rev
     |> List.find_map (fun line ->
            match Yojson.Safe.from_string line with
-           | exception Yojson.Json_error _ -> None
+           | exception Yojson.Json_error detail ->
+               report_decision_log_read_drop
+                 ~reason:Safe_ops.persistence_read_drop_reason_entry_load_error
+                 ~path
+                 ~detail;
+               None
            | (`Assoc _ as json) -> Some json
-           | _ -> None)
+           | _ ->
+               report_decision_log_read_drop
+                 ~reason:Safe_ops.persistence_read_drop_reason_invalid_payload
+                 ~path
+                 ~detail:"decision log row is not a JSON object";
+               None)
 
 let latest_tool_call_json ~(keeper_name : string) =
   Keeper_tool_call_log.read_latest ~keeper_name ()

--- a/test/dune
+++ b/test/dune
@@ -80,6 +80,7 @@
         test_keeper_timing
         test_keeper_memory
         test_keeper_chat_store
+        test_keeper_runtime_trust_snapshot
         test_keeper_accountability
         test_reputation_ledger_v2
         test_reputation_multi_dim
@@ -306,6 +307,7 @@
           test_keeper_timing
           test_keeper_memory
           test_keeper_chat_store
+          test_keeper_runtime_trust_snapshot
           test_keeper_accountability
           test_reputation_ledger_v2
           test_reputation_multi_dim

--- a/test/test_keeper_runtime_trust_snapshot.ml
+++ b/test/test_keeper_runtime_trust_snapshot.ml
@@ -1,0 +1,130 @@
+module K = Masc_mcp.Keeper_runtime_trust_snapshot
+module P = Masc_mcp.Prometheus
+
+let rec remove_tree path =
+  if Sys.file_exists path
+  then
+    if Sys.is_directory path
+    then (
+      Sys.readdir path |> Array.iter (fun name -> remove_tree (Filename.concat path name));
+      Unix.rmdir path)
+    else Sys.remove path
+;;
+
+let rec mkdir_p dir =
+  if dir = "" || dir = "." || dir = "/"
+  then ()
+  else if Sys.file_exists dir
+  then ()
+  else (
+    mkdir_p (Filename.dirname dir);
+    Unix.mkdir dir 0o755)
+;;
+
+let temp_dir () =
+  let dir = Filename.temp_file "runtime_trust_decision_drop_" "" in
+  Unix.unlink dir;
+  Unix.mkdir dir 0o755;
+  dir
+;;
+
+let write_file path content =
+  mkdir_p (Filename.dirname path);
+  let oc = open_out path in
+  Fun.protect ~finally:(fun () -> close_out_noerr oc) (fun () -> output_string oc content)
+;;
+
+let with_env name value f =
+  let old = Sys.getenv_opt name in
+  Unix.putenv name value;
+  Fun.protect
+    ~finally:(fun () ->
+      match old with
+      | Some v -> Unix.putenv name v
+      | None -> Unix.putenv name "")
+    f
+;;
+
+let make_meta name : Masc_mcp.Keeper_types.keeper_meta =
+  match
+    Masc_test_deps.meta_of_json_fixture
+      (`Assoc
+          [ "name", `String name
+          ; "trace_id", `String ("trace-" ^ name)
+          ; "goal", `String "test goal"
+          ])
+  with
+  | Ok meta -> meta
+  | Error err -> Alcotest.fail ("meta fixture failed: " ^ err)
+;;
+
+let drop_value reason =
+  P.metric_value_or_zero
+    P.metric_persistence_read_drops
+    ~labels:[ "surface", "keeper_runtime_trust_decision_log"; "reason", reason ]
+    ()
+;;
+
+let test_snapshot_counts_malformed_decision_rows () =
+  Eio_main.run
+  @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> remove_tree base_dir)
+    (fun () ->
+       with_env "MASC_BASE_PATH" base_dir
+       @@ fun () ->
+       let config = Masc_mcp.Coord.default_config base_dir in
+       let keeper_name = "runtime-trust-decision-drop" in
+       let meta = make_meta keeper_name in
+       let path = Masc_mcp.Keeper_types.keeper_decision_log_path config keeper_name in
+       let entry_error = Safe_ops.persistence_read_drop_reason_entry_load_error in
+       let invalid_payload = Safe_ops.persistence_read_drop_reason_invalid_payload in
+       let before_entry_error = drop_value entry_error in
+       let before_invalid_payload = drop_value invalid_payload in
+       write_file
+         path
+         (String.concat
+            "\n"
+            [ Yojson.Safe.to_string
+                (`Assoc
+                    [ "turn_id", `Int 11
+                    ; "turn_verdict", `String "run"
+                    ; "telemetry", `Assoc [ "selected_model", `String "test-model" ]
+                    ])
+            ; Yojson.Safe.to_string (`List [])
+            ; "{not-json"
+            ]
+          ^ "\n");
+       let snapshot = K.snapshot_json ~config ~meta in
+       let open Yojson.Safe.Util in
+       Alcotest.(check int)
+         "falls back to older valid decision"
+         11
+         (snapshot |> member "latest_decision" |> member "turn_id" |> to_int);
+       Alcotest.(check string)
+         "selected model survives fallback"
+         "test-model"
+         (snapshot |> member "selected_model" |> to_string);
+       Alcotest.(check (float 0.001))
+         "malformed json increments entry error"
+         1.0
+         (drop_value entry_error -. before_entry_error);
+       Alcotest.(check (float 0.001))
+         "non-object row increments invalid payload"
+         1.0
+         (drop_value invalid_payload -. before_invalid_payload))
+;;
+
+let () =
+  Alcotest.run
+    "keeper_runtime_trust_snapshot"
+    [ ( "decision_log_read_drops"
+      , [ Alcotest.test_case
+            "malformed decision rows increment drop metrics"
+            `Quick
+            test_snapshot_counts_malformed_decision_rows
+        ] )
+    ]
+;;


### PR DESCRIPTION
Summary
- Count malformed runtime-trust decision-log JSONL rows with `masc_persistence_read_drops_total{surface="keeper_runtime_trust_decision_log",reason="entry_load_error"}`.
- Count valid non-object decision-log rows with `reason="invalid_payload"`.
- Add a focused runtime-trust snapshot regression proving fallback to the older valid decision still works while both counters increment.

Why it matters
- Runtime trust snapshots drive dashboard/operator attention state. Damaged decision-log rows previously disappeared silently, hiding why selected-model and latest-decision fields looked stale or missing.

Evidence
- [근거] Rebased onto live `origin/main` = `25dd9005f36a64241465aface7daed12b647da2c` on 2026-05-07 KST. 신뢰도 High.
- [근거] Pushed PR head = `7b48fa4d86bbbe50f3229f3b374828c07b3370d7`, force-pushed with explicit lease from prior remote head `d3873a8451c8ee651a74875aceb47e82a0bd4cc6`. 신뢰도 High.
- Resolved the `test/dune` rebase conflict by keeping both current-main `test_keeper_chat_store` and this PR's `test_keeper_runtime_trust_snapshot` entries.
- `ocamlc -stop-after parsing lib/keeper/keeper_runtime_trust_snapshot.ml test/test_keeper_runtime_trust_snapshot.ml`
- `ocamlformat --check test/test_keeper_runtime_trust_snapshot.ml`
- `git diff --check origin/main...HEAD`
- `scripts/check-oas-pin.sh --local-only`
- `scripts/dune-local.sh build test/test_keeper_runtime_trust_snapshot.exe`
- `./_build/default/test/test_keeper_runtime_trust_snapshot.exe`: 1 test passed.

Note
- `ocamlformat --check lib/keeper/keeper_runtime_trust_snapshot.ml` exits 1 with no output on the existing legacy-formatted library file, so this rebase only formatted the new test file.
