### PR TITLE
fix(keeper): honor explicit read-only required tools

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -435,7 +435,10 @@ let run_turn
              feedback_style = Agent_sdk.Tool_retry_policy.Structured_tool_result;
            }
            ~required_tool_satisfaction:
-             Keeper_tool_disclosure.required_tool_satisfaction
+             (fun call ->
+               Keeper_tool_disclosure.required_tool_satisfaction_for_required_names
+                 ~required_tool_names:acc.tool_surface.required_tool_names
+                 call)
            ~max_turns
            ~max_idle_turns
            ?stream_idle_timeout_s

--- a/lib/keeper/keeper_agent_tool_surface.ml
+++ b/lib/keeper/keeper_agent_tool_surface.ml
@@ -207,19 +207,31 @@ let turn_affordances_require_tool_gate_with_allowed
 
 let tool_names_for_required_gate_surface
     ~(tool_gate_requested : bool)
+    ~(required_tool_names : string list)
     (tool_names : string list) : string list =
   let is_stay_silent name =
     match Tool_name.of_string name with
     | Some (Tool_name.Keeper Tool_name.Keeper.Stay_silent) -> true
     | _ -> false
   in
+  let canonical_required_tool_names =
+    required_tool_names
+    |> List.map Keeper_tool_disclosure.canonical_tool_name
+    |> Keeper_types.dedupe_keep_order
+  in
+  let is_explicit_required_tool_name name =
+    List.mem
+      (Keeper_tool_disclosure.canonical_tool_name name)
+      canonical_required_tool_names
+  in
   if not tool_gate_requested then tool_names
   else
     let actionable =
       tool_names
       |> List.filter (fun name ->
-        Keeper_tool_disclosure.tool_name_can_satisfy_required_contract name
-        && not (is_stay_silent name))
+        is_explicit_required_tool_name name
+        || (Keeper_tool_disclosure.tool_name_can_satisfy_required_contract name
+            && not (is_stay_silent name)))
       |> Keeper_types.dedupe_keep_order
     in
     match actionable with
@@ -301,9 +313,11 @@ let preferred_tool_choice_for_required_tool_names
     ~(required_tool_names : string list) ~(allowed_tool_names : string list) =
   let visible_required =
     required_tool_names
-    |> List.filter (fun name ->
-      List.mem name allowed_tool_names
-      && Keeper_tool_disclosure.tool_name_can_satisfy_required_contract name)
+    |> List.filter_map (fun name ->
+      let canonical = Keeper_tool_disclosure.canonical_tool_name name in
+      if List.mem canonical allowed_tool_names then Some canonical
+      else if List.mem name allowed_tool_names then Some name
+      else None)
     |> Keeper_types.dedupe_keep_order
   in
   match visible_required with

--- a/lib/keeper/keeper_agent_tool_surface.mli
+++ b/lib/keeper/keeper_agent_tool_surface.mli
@@ -106,9 +106,17 @@ val turn_affordances_require_tool_gate_with_allowed :
 
 (** On a required-action turn, trim the visible surface to tools that can make
     progress when such tools exist. Passive status/read tools remain visible on
-    optional turns and on surfaces that have no actionable alternative. *)
+    optional turns and on surfaces that have no actionable alternative.
+
+    Explicit [required_tool_names] are preserved even when they are read-only:
+    operator/harness calls such as [masc_keeper_msg.required_tools =
+    ["masc_web_search"]] are a direct evidence contract, not a generic
+    actionable-world-signal gate. *)
 val tool_names_for_required_gate_surface :
-  tool_gate_requested:bool -> string list -> string list
+  tool_gate_requested:bool ->
+  required_tool_names:string list ->
+  string list ->
+  string list
 
 (** Whether the very first turn of a multi-turn slot should require
     a tool call. *)

--- a/lib/keeper/keeper_run_tools.ml
+++ b/lib/keeper/keeper_run_tools.ml
@@ -719,6 +719,7 @@ let prepare_agent_setup
       required_tool_names_for_turn
         ~current_task_required_tool_names:(current_task_required_tools ())
         ~per_call_required_tool_names:required_tool_names
+      |> List.map Keeper_tool_disclosure.canonical_tool_name
       |> Keeper_types.dedupe_keep_order
     in
     let visible_required_tool_names =
@@ -792,7 +793,8 @@ let prepare_agent_setup
            ~allowed_tool_names:all_allowed
     in
     let all_allowed =
-      tool_names_for_required_gate_surface ~tool_gate_requested all_allowed
+      tool_names_for_required_gate_surface
+        ~tool_gate_requested ~required_tool_names all_allowed
     in
     let all_allowed =
       if List.length all_allowed > max_tools then (

--- a/lib/keeper/keeper_tool_disclosure.ml
+++ b/lib/keeper/keeper_tool_disclosure.ml
@@ -303,6 +303,20 @@ let required_tool_satisfaction
            "tool '%s' is read-only/passive and cannot satisfy a required-tool contract"
            tool_name)
 
+let required_tool_satisfaction_for_required_names
+      ~(required_tool_names : string list)
+      (call : Agent_sdk.Completion_contract.tool_call)
+  : (unit, string) result
+  =
+  let required_tool_names =
+    required_tool_names
+    |> List.map canonical_tool_name
+    |> Keeper_types.dedupe_keep_order
+  in
+  let tool_name = canonical_tool_name call.name in
+  if List.mem tool_name required_tool_names then Ok ()
+  else required_tool_satisfaction call
+
 let classify_tool_progress name =
   let name = canonical_tool_name name in
   if is_completion_tool_name name

--- a/lib/keeper/keeper_tool_disclosure.mli
+++ b/lib/keeper/keeper_tool_disclosure.mli
@@ -138,6 +138,15 @@ val tool_name_can_satisfy_required_contract : string -> bool
 val required_tool_satisfaction :
   Agent_sdk.Completion_contract.tool_call -> (unit, string) result
 
+(** Variant of [required_tool_satisfaction] for an explicit
+    [required_tools] contract. A read-only tool can satisfy the turn only when
+    the operator/task contract named that exact tool; generic required-tool
+    gates remain mutating-only. *)
+val required_tool_satisfaction_for_required_names :
+  required_tool_names:string list ->
+  Agent_sdk.Completion_contract.tool_call ->
+  (unit, string) result
+
 (** Project a tool name to its [tool_progress_class]. *)
 val classify_tool_progress : string -> tool_progress_class
 

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -6600,6 +6600,12 @@ let satisfies_required_tool name input =
   Result.is_ok
     (KTD.required_tool_satisfaction (required_tool_call name input))
 
+let satisfies_explicit_required_tool ~required_tool_names name input =
+  Result.is_ok
+    (KTD.required_tool_satisfaction_for_required_names
+       ~required_tool_names
+       (required_tool_call name input))
+
 let test_required_tool_satisfaction_rejects_passive_tools () =
   check bool "masc_status is passive" false
     (satisfies_required_tool "masc_status" (`Assoc []));
@@ -6632,6 +6638,22 @@ let test_required_tool_satisfaction_accepts_mutating_tools () =
             ("op", `String "gh");
             ("cmd", `String "pr comment 123 --body ok");
           ]))
+
+let test_explicit_required_tool_satisfaction_accepts_named_passive_tool () =
+  check bool "generic masc_web_search remains passive" false
+    (satisfies_required_tool "masc_web_search" (`Assoc []));
+  check bool "explicit masc_web_search satisfies required contract" true
+    (satisfies_explicit_required_tool
+       ~required_tool_names:[ "masc_web_search" ]
+       "masc_web_search" (`Assoc []));
+  check bool "explicit required list canonicalizes WebSearch alias" true
+    (satisfies_explicit_required_tool
+       ~required_tool_names:[ "masc_web_search" ]
+       "WebSearch" (`Assoc []));
+  check bool "unlisted passive tool still rejected" false
+    (satisfies_explicit_required_tool
+       ~required_tool_names:[ "keeper_bash" ]
+       "masc_web_search" (`Assoc []))
 
 let test_tool_usage_delta_uses_registry_counts () =
   let before =
@@ -7505,6 +7527,7 @@ let test_required_gate_surface_removes_passive_distractions () =
     [ "keeper_task_claim"; "keeper_board_post" ]
     (Surface.tool_names_for_required_gate_surface
        ~tool_gate_requested:true
+       ~required_tool_names:[]
        [ "keeper_tasks_list"; "keeper_task_claim"; "keeper_stay_silent";
          "keeper_board_post"; "masc_status" ]);
   check (list string)
@@ -7512,13 +7535,22 @@ let test_required_gate_surface_removes_passive_distractions () =
     [ "keeper_tasks_list"; "keeper_board_post" ]
     (Surface.tool_names_for_required_gate_surface
        ~tool_gate_requested:false
+       ~required_tool_names:[]
        [ "keeper_tasks_list"; "keeper_board_post" ]);
   check (list string)
     "passive-only surface remains unchanged when no action exists"
     [ "keeper_tasks_list"; "masc_status" ]
     (Surface.tool_names_for_required_gate_surface
        ~tool_gate_requested:true
-       [ "keeper_tasks_list"; "masc_status" ])
+       ~required_tool_names:[]
+       [ "keeper_tasks_list"; "masc_status" ]);
+  check (list string)
+    "explicit read-only required tool survives required gate"
+    [ "masc_web_search"; "keeper_board_post" ]
+    (Surface.tool_names_for_required_gate_surface
+       ~tool_gate_requested:true
+       ~required_tool_names:[ "masc_web_search" ]
+       [ "keeper_tasks_list"; "masc_web_search"; "keeper_board_post" ])
 
 let test_tools_for_gated_affordance_covers_each_variant () =
   (* Compile-time exhaustiveness already ensures every variant is
@@ -7757,24 +7789,24 @@ let test_preferred_tool_choice_for_required_turn_claims_first () =
        ~required_tool_names:[ "keeper_tasks_audit" ]
        ~allowed_tool_names:[ "keeper_tasks_audit"; "keeper_board_post" ]
    with
-   | Agent_sdk.Types.Auto -> ()
+   | Agent_sdk.Types.Tool name ->
+       check string "explicit passive required tool is forced"
+         "keeper_tasks_audit" name
    | other ->
        fail
          (Printf.sprintf
-            "expected Auto for passive-only required tool, got %s"
+            "expected Tool keeper_tasks_audit for passive-only explicit required tool, got %s"
             (Agent_sdk.Types.show_tool_choice other)));
   (match
      Surface.preferred_tool_choice_for_required_tool_names
        ~required_tool_names:[ "keeper_tasks_audit"; "keeper_board_post" ]
        ~allowed_tool_names:[ "keeper_tasks_audit"; "keeper_board_post" ]
    with
-   | Agent_sdk.Types.Tool name ->
-       check string "active required tool remains forced" "keeper_board_post"
-         name
+   | Agent_sdk.Types.Any -> ()
    | other ->
        fail
          (Printf.sprintf
-            "expected Tool keeper_board_post for mixed passive/active required \
+            "expected Any for mixed passive/active required \
              tools, got %s"
             (Agent_sdk.Types.show_tool_choice other)));
   (* Active task keeper retains the strict gate even without a
@@ -8284,6 +8316,10 @@ let () =
             test_required_tool_satisfaction_rejects_passive_tools;
           test_case "required tool predicate accepts mutating tools" `Quick
             test_required_tool_satisfaction_accepts_mutating_tools;
+          test_case
+            "explicit required tool predicate accepts named passive tool"
+            `Quick
+            test_explicit_required_tool_satisfaction_accepts_named_passive_tool;
           test_case "tool usage delta uses registry counts" `Quick
             test_tool_usage_delta_uses_registry_counts;
           test_case "tool usage delta ignores removed tools" `Quick


### PR DESCRIPTION
## Summary

- preserves explicit `required_tools` in the keeper required-tool surface even when the named tool is read-only
- allows a read-only tool call to satisfy the contract only when that exact tool was explicitly required
- canonicalizes required tool names so aliases such as `WebSearch` line up with `masc_web_search`
- keeps the generic actionable-signal `Require_tool_use` contract mutating-only

## Why

After #14056 made the Docker PR lifecycle reprobe require `masc_web_search`, live evidence-refresh messages to 12 keepers failed before model execution with:

- `tool_surface_mismatch`
- `missing_required_tools:["masc_web_search"]`

The policy config allowed `masc_web_search`, but the required-gate surface filtered read-only tools before checking explicit `required_tools`. That made web-search proof impossible to request through `masc_keeper_msg.required_tools`.

## Evidence

- `scripts/dune-local.sh build test/test_keeper_unified.exe`
- `./_build/default/test/test_keeper_unified.exe test metrics_observation 54-56`
- `./_build/default/test/test_keeper_unified.exe test tool_classification 7`
- `./_build/default/test/test_ci_hardening_source.exe`
- `python3 -m unittest discover -s test -p 'test_audit_keeper_fleet_readiness.py'`
- `ruff check scripts/audit-keeper-fleet-readiness.py test/test_audit_keeper_fleet_readiness.py`
- `git diff --check`

## Residual

Full `./_build/default/test/test_keeper_unified.exe` still fails in the existing `world_observation.007` case: `auto-goal fallback claimable backlog` expected 1, received 0. The new required-tool tests and changed surface paths pass in focused runs.

After adding the standard `agent-pr` label, `Draft Auto-Merge Guard` blocks on missing verified human approval label `human-approved-ready`, which is the expected human gate for this draft PR.
