### PR TITLE
fix(board): move sub-board persistence out of state lock (#10569)

### DIFF
--- a/lib/board_core.ml
+++ b/lib/board_core.ml
@@ -1156,19 +1156,26 @@ let sub_board_of_yojson (json : Yojson.Safe.t) : sub_board option =
        | _ -> None)
   | _ -> None
 
-let rewrite_sub_boards store =
+let sub_boards_jsonl_unlocked store =
+  let buf = Buffer.create 1024 in
+  Hashtbl.iter (fun _ (sb : sub_board) ->
+    Buffer.add_string buf (Yojson.Safe.to_string (sub_board_to_yojson sb));
+    Buffer.add_char buf '\n'
+  ) store.sub_boards;
+  Buffer.contents buf
+
+let save_sub_boards_jsonl content =
   try
     ensure_masc_dir ();
     let path = sub_boards_path () in
-    let buf = Buffer.create 1024 in
-    Hashtbl.iter (fun _ (sb : sub_board) ->
-      Buffer.add_string buf (Yojson.Safe.to_string (sub_board_to_yojson sb));
-      Buffer.add_char buf '\n'
-    ) store.sub_boards;
-    (match Fs_compat.save_file_atomic path (Buffer.contents buf) with
+    (match Fs_compat.save_file_atomic path content with
      | Ok () -> ()
      | Error msg -> record_persist_error ~where:"rewrite_sub_boards" msg)
   with Sys_error msg -> record_persist_error ~where:"rewrite_sub_boards" msg
+
+let rewrite_sub_boards store =
+  let content = with_lock store (fun () -> sub_boards_jsonl_unlocked store) in
+  with_persist_lock store (fun () -> save_sub_boards_jsonl content)
 
 let append_sub_board (sb : sub_board) =
   try
@@ -1193,36 +1200,42 @@ let create_sub_board store ~slug ~name ~description ~owner
         match parse_sub_board_members ~owner:owner_id members with
         | Error e -> Error e
         | Ok members ->
-            with_lock store (fun () ->
-              if Hashtbl.mem store.sub_boards_by_slug slug then
-                Error
-                  (Already_exists
-                     (Printf.sprintf "Sub-board slug %S already exists" slug))
-              else begin
-                let current = Hashtbl.length store.sub_boards in
-                if current >= Limits.max_sub_boards then
+            let result =
+              with_lock store (fun () ->
+                if Hashtbl.mem store.sub_boards_by_slug slug then
                   Error
-                    (Capacity_exceeded { current; max = Limits.max_sub_boards })
+                    (Already_exists
+                       (Printf.sprintf "Sub-board slug %S already exists" slug))
                 else begin
-                  let id = Sub_board_id.generate () in
-                  let sb = {
-                    id;
-                    slug;
-                    name = String.trim name;
-                    description = String.trim description;
-                    owner = owner_id;
-                    members;
-                    access;
-                    created_at = Time_compat.now ();
-                    post_count = 0;
-                  } in
-                  Hashtbl.replace store.sub_boards (Sub_board_id.to_string id) sb;
-                  Hashtbl.replace store.sub_boards_by_slug slug
-                    (Sub_board_id.to_string id);
-                  append_sub_board sb;
-                  Ok sb
-                end
-              end)
+                  let current = Hashtbl.length store.sub_boards in
+                  if current >= Limits.max_sub_boards then
+                    Error
+                      (Capacity_exceeded { current; max = Limits.max_sub_boards })
+                  else begin
+                    let id = Sub_board_id.generate () in
+                    let sb = {
+                      id;
+                      slug;
+                      name = String.trim name;
+                      description = String.trim description;
+                      owner = owner_id;
+                      members;
+                      access;
+                      created_at = Time_compat.now ();
+                      post_count = 0;
+                    } in
+                    Hashtbl.replace store.sub_boards (Sub_board_id.to_string id) sb;
+                    Hashtbl.replace store.sub_boards_by_slug slug
+                      (Sub_board_id.to_string id);
+                    Ok sb
+                  end
+                end)
+            in
+            (match result with
+             | Ok sb ->
+                 with_persist_lock store (fun () -> append_sub_board sb);
+                 Ok sb
+             | Error _ as e -> e)
 
 let get_sub_board store ~sub_board_id : (sub_board, board_error) Result.t =
   with_lock store (fun () ->
@@ -1247,20 +1260,29 @@ let list_sub_boards store : sub_board list =
         compare a.created_at b.created_at))
 
 let delete_sub_board store ~sub_board_id : (unit, board_error) Result.t =
-  with_lock store (fun () ->
-    match Hashtbl.find_opt store.sub_boards sub_board_id with
-    | None ->
-        (match Hashtbl.find_opt store.sub_boards_by_slug sub_board_id with
-         | None -> Error (Invalid_id (Printf.sprintf "Sub-board not found: %s" sub_board_id))
-         | Some id ->
-             Hashtbl.remove store.sub_boards id;
-             Hashtbl.remove store.sub_boards_by_slug sub_board_id;
-             rewrite_sub_boards store;
-             Ok ())
-    | Some sb ->
-        Hashtbl.remove store.sub_boards sub_board_id;
-        Hashtbl.remove store.sub_boards_by_slug sb.slug;
-        rewrite_sub_boards store;
+  with_persist_lock store (fun () ->
+    let snapshot =
+      with_lock store (fun () ->
+        match Hashtbl.find_opt store.sub_boards sub_board_id with
+        | None ->
+            (match Hashtbl.find_opt store.sub_boards_by_slug sub_board_id with
+             | None ->
+                 Error
+                   (Invalid_id
+                      (Printf.sprintf "Sub-board not found: %s" sub_board_id))
+             | Some id ->
+                 Hashtbl.remove store.sub_boards id;
+                 Hashtbl.remove store.sub_boards_by_slug sub_board_id;
+                 Ok (sub_boards_jsonl_unlocked store))
+        | Some sb ->
+            Hashtbl.remove store.sub_boards sub_board_id;
+            Hashtbl.remove store.sub_boards_by_slug sb.slug;
+            Ok (sub_boards_jsonl_unlocked store))
+    in
+    match snapshot with
+    | Error _ as e -> e
+    | Ok content ->
+        save_sub_boards_jsonl content;
         Ok ())
 
 (** {1 Voting - Deduplicated} *)

--- a/lib/board_core.mli
+++ b/lib/board_core.mli
@@ -335,7 +335,8 @@ val sub_board_to_yojson : sub_board -> Yojson.Safe.t
 val sub_board_of_yojson : Yojson.Safe.t -> sub_board option
 
 val rewrite_sub_boards : store -> unit
-(** Atomically rewrites {!sub_boards_path} from [store.sub_boards]. *)
+(** Snapshots [store.sub_boards] under the state lock, then atomically
+    rewrites {!sub_boards_path} under the persist lock. *)
 
 val create_sub_board :
   store ->
@@ -350,7 +351,8 @@ val create_sub_board :
 (** Creates a new sub-board with the given slug (unique, lowercase).
     [members] are canonicalised agent ids; the owner is always included.
     Returns [Validation_error] when the slug is invalid or already taken,
-    [Capacity_exceeded] when the sub-board limit is reached. *)
+    [Capacity_exceeded] when the sub-board limit is reached. JSONL append
+    persistence is performed outside the state lock. *)
 
 val get_sub_board :
   store ->
@@ -365,4 +367,5 @@ val delete_sub_board :
   store ->
   sub_board_id:string ->
   (unit, board_error) Result.t
-(** Removes a sub-board by ID or slug and persists the change. *)
+(** Removes a sub-board by ID or slug under the state lock, then persists the
+    rewritten snapshot outside the state lock. *)

--- a/test/test_board_dispatch.ml
+++ b/test/test_board_dispatch.ml
@@ -927,6 +927,34 @@ let test_sub_board_delete () =
             | Ok _ -> Alcotest.fail "expected not found after delete"
             | Error e -> Alcotest.fail (Board.show_board_error e))))
 
+let sub_board_slugs_from_disk () =
+  let path = Board.sub_boards_path () in
+  if not (Fs_compat.file_exists path) then []
+  else
+    Fs_compat.load_jsonl path
+    |> List.filter_map (fun json ->
+           match Yojson.Safe.Util.member "slug" json with
+           | `String slug -> Some slug
+           | _ -> None)
+
+let test_sub_board_create_delete_persisted_snapshot () =
+  let created =
+    Board_dispatch.create_sub_board ~slug:"persisted-team" ~name:"Persisted"
+      ~description:"" ~owner:"agent-1" ()
+  in
+  let id =
+    match created with
+    | Error e -> Alcotest.fail (Board.show_board_error e)
+    | Ok sb -> Board.Sub_board_id.to_string sb.Board.id
+  in
+  Alcotest.(check bool) "created slug persisted" true
+    (List.exists (String.equal "persisted-team") (sub_board_slugs_from_disk ()));
+  (match Board_dispatch.delete_sub_board ~sub_board_id:id with
+   | Error e -> Alcotest.fail (Board.show_board_error e)
+   | Ok () -> ());
+  Alcotest.(check bool) "deleted slug removed from persisted snapshot" false
+    (List.exists (String.equal "persisted-team") (sub_board_slugs_from_disk ()))
+
 let test_sub_board_access_default_open () =
   (match Board_dispatch.create_sub_board ~slug:"open-board" ~name:"Open"
            ~description:"" ~owner:"agent-1" () with
@@ -1099,6 +1127,8 @@ let () =
       Alcotest.test_case "list" `Quick (with_eio test_sub_board_list);
       Alcotest.test_case "slug conflict" `Quick (with_eio test_sub_board_slug_conflict);
       Alcotest.test_case "delete" `Quick (with_eio test_sub_board_delete);
+      Alcotest.test_case "persisted create/delete snapshot" `Quick
+        (with_eio test_sub_board_create_delete_persisted_snapshot);
       Alcotest.test_case "default access open" `Quick (with_eio test_sub_board_access_default_open);
       Alcotest.test_case "members include owner" `Quick (with_eio test_sub_board_members_include_owner);
       Alcotest.test_case "members-only post policy" `Quick (with_eio test_sub_board_members_only_post_policy);


### PR DESCRIPTION
## Summary

- Move sub-board create/delete persistence out of the board state mutex.
- Keep full delete rewrites serialized by `with_persist_lock`, snapshotting under `store.mutex` and writing after the state lock is released.
- Add regression coverage that sub-board create/delete updates the persisted JSONL snapshot.

## Product impact

This removes another synchronous filesystem write path from the shared board state lock. It is a narrow follow-up to #10569 after the board timeout and delete-post persistence slices, reducing the remaining board writer SPOF surface without changing the JSONL wire format or synchronous durability behavior.

## Evidence

- `git diff --check` passed.
- `git diff --cached --check` passed.
- `env DUNE_JOBS=1 MASC_SKIP_OPAM_LOCK=1 MASC_SKIP_PIN_CHECK=1 dune build --root . test/test_board_dispatch.exe` passed.
- `env MASC_SKIP_PIN_CHECK=1 ./_build/default/test/test_board_dispatch.exe` passed: 51 tests.
- `ocamlformat --check lib/board_core.ml lib/board_core.mli test/test_board_dispatch.ml` is blocked by the existing `lib/board_core.ml` unattached docstring warning at lines 185-193; no whole-file reformat applied.

## Review evidence

- `scripts/dune-local.sh build test/test_board_dispatch.exe` was attempted first and stopped while queued behind `/tmp/me-dune-local.lock`.
- `create_sub_board` mutates in memory under `store.mutex`, then appends under `with_persist_lock`.
- `delete_sub_board` holds `with_persist_lock`, snapshots under `store.mutex`, then rewrites after releasing the state lock so concurrent append/rewrite ordering remains serialized.

## Linked issue

Refs #10569.
