### PR TITLE
fix(keeper): normalize stale tool policy names

### DIFF
--- a/lib/keeper/keeper_tool_policy_config.ml
+++ b/lib/keeper/keeper_tool_policy_config.ml
@@ -77,6 +77,46 @@ let collect_table_names (doc : Keeper_toml_loader.toml_doc) ~(prefix : string) :
       None)
   |> List.sort_uniq String.compare
 
+let normalize_tool_names ~scope tools =
+  let alias_notes = ref [] in
+  let dropped_notes = ref [] in
+  let rec add seen acc = function
+    | [] -> List.rev acc
+    | raw :: rest ->
+        let raw = String.trim raw in
+        if String.equal raw "" then
+          add seen acc rest
+        else
+          let resolved =
+            match raw with
+            | "keeper_fs_write" ->
+                alias_notes := "keeper_fs_write -> keeper_fs_edit" :: !alias_notes;
+                Some "keeper_fs_edit"
+            | "keeper_fs_delete" ->
+                dropped_notes :=
+                  "keeper_fs_delete removed; use keeper_fs_edit patch/write or masc_code_delete"
+                  :: !dropped_notes;
+                None
+            | name -> Some name
+          in
+          match resolved with
+          | None -> add seen acc rest
+          | Some name when List.mem name seen -> add seen acc rest
+          | Some name -> add (name :: seen) (name :: acc) rest
+  in
+  let normalized = add [] [] tools in
+  (match List.rev !alias_notes with
+  | [] -> ()
+  | notes ->
+      Log.Keeper.info "tool_policy_config: normalized legacy tool name(s) in %s: %s"
+        scope (String.concat ", " notes));
+  (match List.rev !dropped_notes with
+  | [] -> ()
+  | notes ->
+      Log.Keeper.info "tool_policy_config: dropped removed legacy tool name(s) in %s: %s"
+        scope (String.concat ", " notes));
+  normalized
+
 (* ── Loading ──────────────────────────────────────────────────────── *)
 
 let parse_groups (doc : Keeper_toml_loader.toml_doc) : ((string, group_source) Hashtbl.t, string) result =
@@ -94,6 +134,7 @@ let parse_groups (doc : Keeper_toml_loader.toml_doc) : ((string, group_source) H
         Hashtbl.replace tbl name (Shard_ref shard_name);
         None
       | None, _ :: _ ->
+        let tools = normalize_tool_names ~scope:("groups." ^ name ^ ".tools") tools in
         Hashtbl.replace tbl name (Static tools);
         None
       | None, [] ->
@@ -111,6 +152,7 @@ let parse_masc_groups (doc : Keeper_toml_loader.toml_doc) : (string, string list
   List.iter (fun name ->
     let tools = toml_string_list_at doc "masc" (name ^ ".tools") in
     if tools <> [] then
+      let tools = normalize_tool_names ~scope:("masc." ^ name ^ ".tools") tools in
       Hashtbl.replace tbl name tools
   ) names;
   tbl
@@ -123,7 +165,10 @@ let parse_presets
   List.iter (fun name ->
     let groups = toml_string_list_at doc "presets" (name ^ ".groups") in
     let masc_groups = toml_string_list_at doc "presets" (name ^ ".masc_groups") in
-    let masc_tools = toml_string_list_at doc "presets" (name ^ ".masc_tools") in
+    let masc_tools =
+      toml_string_list_at doc "presets" (name ^ ".masc_tools")
+      |> normalize_tool_names ~scope:("presets." ^ name ^ ".masc_tools")
+    in
     let all_candidates =
       Option.value ~default:false
         (toml_bool_at doc "presets" (name ^ ".all_candidates"))

--- a/test/test_keeper_tool_policy_config.ml
+++ b/test/test_keeper_tool_policy_config.ml
@@ -101,6 +101,44 @@ let test_load_anchors_resolution_to_base_path_over_cwd_candidate () =
            "expected config load to use base_path=%s instead of cwd=%s: %s"
            source_root fake_build_root msg)
 
+let test_load_normalizes_legacy_fs_tool_names () =
+  with_temp_dir "tool-policy-legacy-tools" @@ fun root ->
+  let config_dir = Filename.concat root "config" in
+  mkdir_p config_dir;
+  write_file
+    (Filename.concat config_dir "tool_policy.toml")
+    {|
+[groups.legacy]
+tools = ["keeper_fs_write", "keeper_fs_delete", "keeper_fs_edit"]
+
+[masc.legacy]
+tools = ["keeper_fs_write", "keeper_fs_delete", "masc_status"]
+
+[presets.legacy]
+groups = ["legacy"]
+masc_groups = ["legacy"]
+masc_tools = ["keeper_fs_write", "keeper_fs_delete", "masc_status"]
+|};
+  match KTPC.load ~base_path:root with
+  | Error msg -> fail ("expected legacy policy config to load: " ^ msg)
+  | Ok cfg ->
+      let assert_no_legacy label tools =
+        check bool (label ^ " drops keeper_fs_write") false
+          (List.mem "keeper_fs_write" tools);
+        check bool (label ^ " drops keeper_fs_delete") false
+          (List.mem "keeper_fs_delete" tools);
+        check bool (label ^ " keeps canonical fs_edit") true
+          (List.mem "keeper_fs_edit" tools)
+      in
+      (match KTPC.resolve_group cfg "legacy" with
+      | Some tools -> assert_no_legacy "group" tools
+      | None -> fail "legacy group missing");
+      assert_no_legacy "masc groups" (KTPC.all_masc_tools cfg);
+      (match KTPC.resolve_preset cfg "legacy" () with
+      | Some (KTPC.Subset tools) -> assert_no_legacy "preset" tools
+      | Some KTPC.All_candidates -> fail "legacy preset should be explicit subset"
+      | None -> fail "legacy preset missing")
+
 (* ── preset_can_satisfy tests ───────────────────────────────── *)
 
 let load_config () =
@@ -182,6 +220,8 @@ let () =
             test_load_honors_masc_config_dir_override;
           test_case "anchors resolution to base_path over cwd candidate" `Quick
             test_load_anchors_resolution_to_base_path_over_cwd_candidate;
+          test_case "normalizes legacy fs tool names" `Quick
+            test_load_normalizes_legacy_fs_tool_names;
         ] );
       ( "preset_can_satisfy",
         [

--- a/test/test_tool_registration_consistency.ml
+++ b/test/test_tool_registration_consistency.ml
@@ -280,6 +280,23 @@ let test_tool_registration_check_does_not_depend_on_injected_masc_schemas () =
           Alcotest.(check (list string))
             "no masc orphan_toml without injected schemas" [] masc_orphans)
 
+let test_judge_tool_schema_names_resolve () =
+  let requested =
+    [ "masc_status"; "masc_tasks"; "masc_agents"; "masc_agent_card";
+      "masc_board_list" ]
+  in
+  match Agent_tool_surfaces.local_worker_tool_schemas ~names:requested () with
+  | Error msg ->
+      Alcotest.failf "judge tool names must resolve: %s" msg
+  | Ok schemas ->
+      let names =
+        schemas
+        |> List.map (fun (schema : Masc_domain.tool_schema) -> schema.name)
+        |> List.sort String.compare
+      in
+      let expected = List.sort String.compare requested in
+      Alcotest.(check (list string)) "judge tool schemas" expected names
+
 (* ── Test 3: No duplicate tool names in schemas ──────────────── *)
 
 let test_no_duplicate_schemas () =
@@ -382,6 +399,8 @@ let () =
             "tool registration check does not depend on injected masc schemas"
             `Quick
             test_tool_registration_check_does_not_depend_on_injected_masc_schemas;
+          Alcotest.test_case "judge tool schema names resolve" `Quick
+            test_judge_tool_schema_names_resolve;
           Alcotest.test_case
             "admin-dispatched keeper tools not flagged as orphan_toml (#7696)"
             `Quick


### PR DESCRIPTION
Summary
- Normalize stale tool_policy.toml names before policy resolution: keeper_fs_write now resolves to keeper_fs_edit, and removed keeper_fs_delete is dropped from stale runtime configs.
- Add regression coverage for legacy policy config normalization and local-worker schema resolution for judge/agent tools.

Why it matters
- The live startup log showed tool_policy unknown tool names for stale filesystem policy entries. This keeps old local .masc configs from producing noisy false-positive startup drift warnings while preserving the canonical keeper_fs_edit execution surface.
- The schema test pins masc_agents/masc_agent_card availability so judge/local-worker startup warnings do not regress.

Validation
- scripts/dune-local.sh build test/test_keeper_tool_policy_config.exe test/test_tool_registration_consistency.exe
- ./_build/default/test/test_keeper_tool_policy_config.exe
- ./_build/default/test/test_tool_registration_consistency.exe
- git diff --check