### PR TITLE
ci: detect branch protection drift (#9738)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -353,9 +353,15 @@ jobs:
           scripts/check-sandbox-dune-version.sh
 
       - name: Meta bug-class gates (SSOT, SIL, STR, BND)
+        env:
+          GH_TOKEN: ${{ github.token }}
+          BRANCH_PROTECTION_REPOSITORY: ${{ github.repository }}
+          BRANCH_PROTECTION_BRANCH: ${{ github.base_ref || github.ref_name }}
+          BRANCH_PROTECTION_REQUIRED_CONTEXTS: CI Gate,Draft Auto-Merge Guard
         run: |
           chmod +x scripts/ci/*.sh
           echo "=== Running meta bug-class gates (see #9516 #9517 #9519 #9521) ==="
+          bash scripts/ci/check-main-branch-protection.sh
           bash scripts/ci/check-ssot-spawn-drift.sh
           bash scripts/check-spec-truth.sh
           bash scripts/ci/check-silent-failure-patterns.sh

--- a/scripts/ci/check-main-branch-protection.sh
+++ b/scripts/ci/check-main-branch-protection.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# check-main-branch-protection.sh - detect branch-protection drift for #9738.
+#
+# The draft PR guard only prevents ready/merge races when GitHub branch
+# protection requires the guard checks and applies them to admins.  This check
+# keeps that repository setting visible in CI instead of relying on memory of a
+# one-time settings change.
+set -euo pipefail
+
+repo="${BRANCH_PROTECTION_REPOSITORY:-${GITHUB_REPOSITORY:-}}"
+branch="${BRANCH_PROTECTION_BRANCH:-${GITHUB_BASE_REF:-${GITHUB_REF_NAME:-main}}}"
+required_contexts_csv="${BRANCH_PROTECTION_REQUIRED_CONTEXTS:-CI Gate,Draft Auto-Merge Guard}"
+
+if [[ -z "$repo" ]]; then
+  echo "::error title=Branch protection check misconfigured::BRANCH_PROTECTION_REPOSITORY or GITHUB_REPOSITORY is required."
+  exit 1
+fi
+
+if [[ "$branch" != "main" ]]; then
+  echo "branch protection drift: skipped for branch ${branch}; #9738 guard applies to main"
+  exit 0
+fi
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "::error title=Branch protection check unavailable::GitHub CLI 'gh' is required."
+  exit 1
+fi
+
+endpoint="repos/${repo}/branches/${branch}/protection"
+
+if ! enforce_admins="$(gh api "$endpoint" --jq '.enforce_admins.enabled' 2>&1)"; then
+  echo "::error title=Branch protection check failed::Could not read ${repo}/${branch} branch protection: ${enforce_admins}"
+  exit 1
+fi
+
+if ! contexts="$(gh api "$endpoint" --jq '.required_status_checks.contexts[]?' 2>&1)"; then
+  echo "::error title=Branch protection check failed::Could not read required status contexts for ${repo}/${branch}: ${contexts}"
+  exit 1
+fi
+
+failures=()
+if [[ "$enforce_admins" != "true" ]]; then
+  failures+=("enforce_admins.enabled=${enforce_admins}; expected true")
+fi
+
+IFS=',' read -r -a required_contexts <<<"$required_contexts_csv"
+for context in "${required_contexts[@]}"; do
+  context="$(printf '%s' "$context" | xargs)"
+  [[ -n "$context" ]] || continue
+  if ! printf '%s\n' "$contexts" | grep -Fxq "$context"; then
+    failures+=("missing required status context: ${context}")
+  fi
+done
+
+if ((${#failures[@]} > 0)); then
+  printf '::error title=Branch protection drift::%s\n' "${failures[*]}"
+  printf 'Configured contexts for %s/%s:\n%s\n' "$repo" "$branch" "${contexts:-"(none)"}"
+  exit 1
+fi
+
+printf 'branch protection drift: OK for %s/%s (enforce_admins=true; required contexts present: %s)\n' \
+  "$repo" "$branch" "$required_contexts_csv"

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -190,6 +190,18 @@ let test_ci_sync_and_asset_contracts () =
   check bool "ci gate aggregates live PR gate" true
     (file_contains_pattern ".github/workflows/ci.yml"
        "PR_LIVE_GATE_RESULT");
+  check bool "meta guards verify main branch protection drift" true
+    (file_contains_pattern ".github/workflows/ci.yml"
+       "bash scripts/ci/check-main-branch-protection.sh");
+  check bool "branch protection drift check exists" true
+    (file_contains_pattern "scripts/ci/check-main-branch-protection.sh"
+       "enforce_admins.enabled");
+  check bool "branch protection drift check requires draft guard context" true
+    (file_contains_pattern "scripts/ci/check-main-branch-protection.sh"
+       "Draft Auto-Merge Guard");
+  check bool "branch protection drift check requires CI gate context" true
+    (file_contains_pattern "scripts/ci/check-main-branch-protection.sh"
+       "CI Gate");
   check bool "heavy CI no longer trusts stale draft payload" true
     (file_not_contains_pattern ".github/workflows/ci.yml"
        "github.event.pull_request.draft == false");


### PR DESCRIPTION
## Summary

- Add `scripts/ci/check-main-branch-protection.sh` to detect live `main` branch-protection drift.
- Wire the check into the existing Meta Guards lane so `CI Gate` goes red when `enforce_admins` is off or the required draft/CI contexts are missing.
- Extend `test/test_ci_hardening_source.ml` so the source contract pins the new drift guard.

## Product impact

Issue #9738 keeps recurring when repository settings drift away from the draft-only PR invariant. The live setting had drifted again: `enforce_admins=false` while `CI Gate` and `Draft Auto-Merge Guard` were still required. I restored `enforce_admins=true` live, and this patch makes future drift visible in CI instead of depending on manual memory of repository settings.

## Evidence

- Before live repair on 2026-05-07 KST: `gh api repos/jeong-sik/masc-mcp/branches/main/protection --jq '{enforce_admins: .enforce_admins.enabled, contexts: (.required_status_checks.contexts // []), strict: .required_status_checks.strict}'` returned `enforce_admins=false`, contexts `["CI Gate","Draft Auto-Merge Guard"]`, `strict=false`.
- Live repair: `gh api --method POST repos/jeong-sik/masc-mcp/branches/main/protection/enforce_admins`.
- After repair: the same branch-protection query returned `enforce_admins=true`, contexts `["CI Gate","Draft Auto-Merge Guard"]`, `strict=false`.

## Review evidence

- `git diff --check`
- `git diff --cached --check`
- `bash -n scripts/ci/check-main-branch-protection.sh`
- `BRANCH_PROTECTION_REPOSITORY=jeong-sik/masc-mcp BRANCH_PROTECTION_BRANCH=main bash scripts/ci/check-main-branch-protection.sh`
- `BRANCH_PROTECTION_REPOSITORY=jeong-sik/masc-mcp BRANCH_PROTECTION_BRANCH=develop bash scripts/ci/check-main-branch-protection.sh`
- `scripts/dune-local.sh build test/test_ci_hardening_source.exe` attempted first; stopped while queued behind `/tmp/me-dune-local.lock`.
- `env DUNE_JOBS=1 MASC_SKIP_OPAM_LOCK=1 MASC_SKIP_PIN_CHECK=1 dune build --root . test/test_ci_hardening_source.exe`
- `env MASC_SKIP_PIN_CHECK=1 ./_build/default/test/test_ci_hardening_source.exe` - 55 tests passed.

Note: `ocamlformat --check test/test_ci_hardening_source.ml` exits 1 with no output on this file's existing style; no whole-file reformat was applied.

## Linked issue

Closes #9738.
