### PR TITLE
fix: count keeper exec status read drops

### DIFF
--- a/lib/keeper/keeper_exec_status_metrics.ml
+++ b/lib/keeper/keeper_exec_status_metrics.ml
@@ -47,6 +47,30 @@ type tool_audit_snapshot = {
   tool_audit_at : string option;
 }
 
+let metrics_summary_persistence_surface = "keeper_exec_status_metrics"
+let decision_log_tool_audit_persistence_surface =
+  "keeper_exec_status_decision_log"
+let metrics_tool_audit_persistence_surface =
+  "keeper_exec_status_keeper_metrics"
+
+let report_persistence_read_drop ~surface ~reason ~path ~detail =
+  Safe_ops.report_persistence_read_drop
+    ~on_drop:(fun () ->
+      Prometheus.inc_counter Prometheus.metric_persistence_read_drops
+        ~labels:[("surface", surface); ("reason", reason)]
+        ())
+    ~surface
+    ~reason
+    ~path
+    ~detail
+
+let report_metrics_summary_read_drop ~reason ~detail =
+  report_persistence_read_drop
+    ~surface:metrics_summary_persistence_surface
+    ~reason
+    ~path:"<keeper_metrics_lines>"
+    ~detail
+
 let empty_metrics_summary =
   {
     sample_points = 0;
@@ -226,7 +250,15 @@ let summarize_metrics_lines (lines : string list) ~(default_generation : int) :
   List.fold_left
     (fun acc line ->
       try
-        let j = Yojson.Safe.from_string line in
+        let j =
+          match Yojson.Safe.from_string line with
+          | `Assoc _ as json -> json
+          | _ ->
+              report_metrics_summary_read_drop
+                ~reason:Safe_ops.persistence_read_drop_reason_invalid_payload
+                ~detail:"keeper metrics row is not a JSON object";
+              raise Exit
+        in
         let ts_unix = Safe_ops.json_float ~default:0.0 "ts_unix" j in
         let trace_id = Safe_ops.json_string ~default:"" "trace_id" j in
         let generation =
@@ -443,7 +475,18 @@ let summarize_metrics_lines (lines : string list) ~(default_generation : int) :
           last_handoff = handoff_json;
           last_compaction = compaction_json;
         }
-      with Yojson.Json_error _ | Yojson.Safe.Util.Type_error _ -> acc)
+      with
+      | Exit -> acc
+      | Yojson.Json_error detail ->
+          report_metrics_summary_read_drop
+            ~reason:Safe_ops.persistence_read_drop_reason_entry_load_error
+            ~detail;
+          acc
+      | Yojson.Safe.Util.Type_error (detail, _) ->
+          report_metrics_summary_read_drop
+            ~reason:Safe_ops.persistence_read_drop_reason_invalid_payload
+            ~detail;
+          acc)
     empty_metrics_summary lines
 
 let json_string_list_member key json =
@@ -507,7 +550,12 @@ let latest_snapshot_of_lines lines ~parse_snapshot ~has_legacy_shape =
         (fun line ->
           try
             let json = Yojson.Safe.from_string line in
-            match parse_snapshot line with
+            let snapshot =
+              match json with
+              | `Assoc _ -> parse_snapshot line
+              | _ -> None
+            in
+            match snapshot with
             | Some _ as snapshot -> snapshot
             | None ->
                 if has_legacy_shape json then
@@ -528,9 +576,24 @@ let latest_tool_audit_snapshot_from_decisions config keeper_name =
   if not (Fs_compat.file_exists path) then None
   else
     let lines = Keeper_memory.read_file_tail_lines path ~max_bytes:40000 ~max_lines:12 in
+    let report_drop ~reason ~detail =
+      report_persistence_read_drop
+        ~surface:decision_log_tool_audit_persistence_surface
+        ~reason
+        ~path
+        ~detail
+    in
     let parse_snapshot line =
       try
-        let json = Yojson.Safe.from_string line in
+        let json =
+          match Yojson.Safe.from_string line with
+          | `Assoc _ as json -> json
+          | _ ->
+              report_drop
+                ~reason:Safe_ops.persistence_read_drop_reason_invalid_payload
+                ~detail:"decision log row is not a JSON object";
+              raise Exit
+        in
         let tools = json_string_list_member "tools_used" json in
         let raw_tool_call_count = json_int_opt_member "tool_call_count" json in
         let tool_call_count =
@@ -550,7 +613,13 @@ let latest_tool_audit_snapshot_from_decisions config keeper_name =
               tool_audit_source = Some "keeper_decision_log";
               tool_audit_at = json_iso_opt json;
             }
-      with Yojson.Json_error _ -> None
+      with
+      | Exit -> None
+      | Yojson.Json_error detail ->
+          report_drop
+            ~reason:Safe_ops.persistence_read_drop_reason_entry_load_error
+            ~detail;
+          None
     in
     latest_snapshot_of_lines lines
       ~parse_snapshot
@@ -570,9 +639,25 @@ let latest_tool_audit_snapshot_from_decisions config keeper_name =
 
 let latest_tool_audit_snapshot_from_metrics config keeper_name =
   let lines = read_recent_metrics_lines config keeper_name in
+  let metrics_path = Keeper_types.keeper_metrics_path config keeper_name in
+  let report_drop ~reason ~detail =
+    report_persistence_read_drop
+      ~surface:metrics_tool_audit_persistence_surface
+      ~reason
+      ~path:metrics_path
+      ~detail
+  in
   let parse_snapshot line =
     try
-      let json = Yojson.Safe.from_string line in
+      let json =
+        match Yojson.Safe.from_string line with
+        | `Assoc _ as json -> json
+        | _ ->
+            report_drop
+              ~reason:Safe_ops.persistence_read_drop_reason_invalid_payload
+              ~detail:"keeper metrics row is not a JSON object";
+            raise Exit
+      in
       let tools =
         json_string_list_member "tools_used" json
         |> List.sort_uniq String.compare
@@ -595,7 +680,13 @@ let latest_tool_audit_snapshot_from_metrics config keeper_name =
             tool_audit_source = Some "keeper_metrics";
             tool_audit_at = json_iso_opt json;
           }
-    with Yojson.Json_error _ -> None
+    with
+    | Exit -> None
+    | Yojson.Json_error detail ->
+        report_drop
+          ~reason:Safe_ops.persistence_read_drop_reason_entry_load_error
+          ~detail;
+        None
   in
   latest_snapshot_of_lines lines
     ~parse_snapshot

--- a/test/test_keeper_exec_status.ml
+++ b/test/test_keeper_exec_status.ml
@@ -1,11 +1,13 @@
 open Alcotest
 
 module ES = Masc_mcp.Keeper_exec_status
+module Metrics = Masc_mcp.Keeper_exec_status_metrics
 module KSB = Masc_mcp.Keeper_status_bridge
 module KR = Masc_mcp.Keeper_registry
 module KT = Masc_mcp.Keeper_types
 module Coord = Masc_mcp.Coord
 module OWN = Masc_mcp.Oas_worker_named
+module Prom = Masc_mcp.Prometheus
 
 let keeper_health_testable : KT.keeper_health Alcotest.testable =
   Alcotest.testable
@@ -123,6 +125,134 @@ let assoc_member key fields =
   match List.assoc_opt key fields with
   | Some value -> value
   | None -> `Null
+
+let write_lines path lines =
+  KT.mkdir_p (Filename.dirname path);
+  let oc = open_out path in
+  Fun.protect
+    ~finally:(fun () -> close_out_noerr oc)
+    (fun () ->
+      List.iter
+        (fun line ->
+          output_string oc line;
+          output_char oc '\n')
+        lines)
+
+let persistence_read_drop_total ~surface ~reason =
+  Prom.metric_value_or_zero Prom.metric_persistence_read_drops
+    ~labels:[("surface", surface); ("reason", reason)]
+    ()
+
+let check_persistence_drop_delta ~surface ~reason ~before ~delta =
+  Alcotest.(check (float 0.0001))
+    (Printf.sprintf "%s/%s persistence drops" surface reason)
+    (before +. float_of_int delta)
+    (persistence_read_drop_total ~surface ~reason)
+
+let test_metrics_summary_counts_parse_drops () =
+  let surface = "keeper_exec_status_metrics" in
+  let entry_reason = "entry_load_error" in
+  let invalid_reason = "invalid_payload" in
+  let before_entry =
+    persistence_read_drop_total ~surface ~reason:entry_reason
+  in
+  let before_invalid =
+    persistence_read_drop_total ~surface ~reason:invalid_reason
+  in
+  let summary =
+    Metrics.summarize_metrics_lines
+      [
+        {|{"channel":"turn","ts_unix":1.0,"trace_id":"trace-ok"}|};
+        "{not-json";
+        "[]";
+      ]
+      ~default_generation:0
+  in
+  let summary_json = Metrics.metrics_summary_to_json summary in
+  let sample_points =
+    match assoc_member "sample_points" (Yojson.Safe.Util.to_assoc summary_json) with
+    | `Int value -> value
+    | other ->
+        Alcotest.failf "unexpected sample_points JSON: %s"
+          (Yojson.Safe.to_string other)
+  in
+  check int "only valid object rows are summarized" 1 sample_points;
+  check_persistence_drop_delta ~surface ~reason:entry_reason
+    ~before:before_entry ~delta:1;
+  check_persistence_drop_delta ~surface ~reason:invalid_reason
+    ~before:before_invalid ~delta:1
+
+let test_tool_audit_counts_decision_log_parse_drops () =
+  let surface = "keeper_exec_status_decision_log" in
+  let entry_reason = "entry_load_error" in
+  let invalid_reason = "invalid_payload" in
+  let before_entry =
+    persistence_read_drop_total ~surface ~reason:entry_reason
+  in
+  let before_invalid =
+    persistence_read_drop_total ~surface ~reason:invalid_reason
+  in
+  with_temp_base_path "test-keeper-exec-status-decision-drops" (fun base_path ->
+      let config = Coord.default_config base_path in
+      let keeper_name = "keeper-tool-audit-decisions" in
+      write_lines
+        (KT.keeper_decision_log_path config keeper_name)
+        [
+          {|{"ts":"2026-05-07T00:00:00Z","tools_used":["masc_task_status"],"tool_call_count":1}|};
+          "[]";
+          "{not-json";
+        ];
+      match
+        Metrics.latest_tool_audit_snapshot_from_files config ~keeper_name
+      with
+      | None -> Alcotest.fail "expected decision log tool audit snapshot"
+      | Some snapshot ->
+          check (list string) "decision tools" ["masc_task_status"]
+            snapshot.latest_tool_names;
+          check (option int) "decision tool count" (Some 1)
+            snapshot.latest_tool_call_count;
+          check (option string) "decision source" (Some "keeper_decision_log")
+            snapshot.tool_audit_source);
+  check_persistence_drop_delta ~surface ~reason:entry_reason
+    ~before:before_entry ~delta:1;
+  check_persistence_drop_delta ~surface ~reason:invalid_reason
+    ~before:before_invalid ~delta:1
+
+let test_tool_audit_counts_metrics_parse_drops () =
+  let surface = "keeper_exec_status_keeper_metrics" in
+  let entry_reason = "entry_load_error" in
+  let invalid_reason = "invalid_payload" in
+  let before_entry =
+    persistence_read_drop_total ~surface ~reason:entry_reason
+  in
+  let before_invalid =
+    persistence_read_drop_total ~surface ~reason:invalid_reason
+  in
+  with_temp_base_path "test-keeper-exec-status-metrics-drops" (fun base_path ->
+      let config = Coord.default_config base_path in
+      let keeper_name = "keeper-tool-audit-metrics" in
+      write_lines
+        (KT.keeper_metrics_path config keeper_name)
+        [
+          {|{"ts":"2026-05-07T00:00:00Z","tools_used":["masc_board_post"],"tool_call_count":1}|};
+          "[]";
+          "{not-json";
+        ];
+      match
+        Metrics.latest_tool_audit_snapshot_from_files config ~keeper_name
+      with
+      | None -> Alcotest.fail "expected metrics tool audit snapshot"
+      | Some snapshot ->
+          check (list string) "metrics tools" ["masc_board_post"]
+            snapshot.latest_tool_names;
+          check (option int) "metrics tool count" (Some 1)
+            snapshot.latest_tool_call_count;
+          check (option string) "metrics source" (Some "keeper_metrics")
+            snapshot.tool_audit_source);
+  check_persistence_drop_delta ~surface ~reason:entry_reason
+    ~before:before_entry ~delta:1;
+  check_persistence_drop_delta ~surface ~reason:invalid_reason
+    ~before:before_invalid ~delta:1
 
 let test_attention_fields_promote_runtime_trust_attention () =
   let fields =
@@ -905,6 +1035,15 @@ let () =
             test_parser_roundtrip_all_constructors;
           test_case "rejects unknown wire strings" `Quick
             test_parser_rejects_unknown;
+        ] );
+      ( "metrics_read_drops",
+        [
+          test_case "metrics summary counts malformed rows" `Quick
+            test_metrics_summary_counts_parse_drops;
+          test_case "decision log tool audit counts malformed rows" `Quick
+            test_tool_audit_counts_decision_log_parse_drops;
+          test_case "metrics tool audit counts malformed rows" `Quick
+            test_tool_audit_counts_metrics_parse_drops;
         ] );
       ( "health_state",
         [


### PR DESCRIPTION
## Summary
- Count malformed and non-object keeper metrics summary rows in the persistence read-drop counter.
- Count malformed and non-object keeper decision-log / metrics tool-audit rows while preserving fallback snapshots.
- Add focused regression coverage in test_keeper_exec_status.

## Verification
- git diff --check origin/main...HEAD
- lockf -k -t 1200 /tmp/me-dune-local.lock env MASC_DUNE_LOCK_HELD=1 MASC_SKIP_OPAM_LOCK=1 DUNE_JOBS=1 DUNE_CACHE=disabled scripts/dune-local.sh build test/test_keeper_exec_status.exe
- ./_build/default/test/test_keeper_exec_status.exe (39 tests)