### PR TITLE
feat(safe_ops): add json_syntax_error typed reason for persistence read drops

### DIFF
--- a/lib/core/safe_ops.ml
+++ b/lib/core/safe_ops.ml
@@ -377,6 +377,7 @@ let read_json_file_logged ~label path : Yojson.Safe.t option =
 let persistence_read_drop_reason_list_dir_error = "list_dir_error"
 let persistence_read_drop_reason_entry_load_error = "entry_load_error"
 let persistence_read_drop_reason_invalid_payload = "invalid_payload"
+let persistence_read_drop_reason_json_syntax_error = "json_syntax_error"
 
 let report_persistence_read_drop ~on_drop ~surface ~reason ~path ~detail =
   Log.Misc.warn "[%s] persistence read drop (%s) path=%s: %s"

--- a/lib/core/safe_ops.mli
+++ b/lib/core/safe_ops.mli
@@ -93,8 +93,23 @@ val read_json_file_logged : label:string -> string -> Yojson.Safe.t option
     Returns [Some json] on success, [None] on failure with a warning log. *)
 
 val persistence_read_drop_reason_list_dir_error : string
+(** Failure listing a directory that backs a persistence surface. *)
+
 val persistence_read_drop_reason_entry_load_error : string
+(** Failure loading an entry's bytes (file IO error) or, when the loader
+    combines IO + parse in a single result, either of those failures.
+    Use the more specific {!persistence_read_drop_reason_json_syntax_error}
+    when IO and JSON parse are split into separate code paths. *)
+
 val persistence_read_drop_reason_invalid_payload : string
+(** Entry parsed successfully but failed schema/structural validation
+    (e.g. record-of-yojson [Error _], required field missing). *)
+
+val persistence_read_drop_reason_json_syntax_error : string
+(** [Yojson.Json_error] raised while parsing a single line/value.  Use
+    this when the load step is logically split from the parse step
+    (typical of JSONL surfaces) so the metric distinguishes "file
+    unreadable" from "lines malformed". *)
 
 val report_persistence_read_drop :
   on_drop:(unit -> unit) ->

--- a/lib/telemetry_eio.ml
+++ b/lib/telemetry_eio.ml
@@ -169,8 +169,9 @@ let read_all_events_from_path (file : string) : event_record list =
                    ~path:file ~detail:msg;
                  None
            with Yojson.Json_error msg ->
-             report_telemetry_drop ~reason:"json_syntax_error" ~path:file
-               ~detail:msg;
+             report_telemetry_drop
+               ~reason:Safe_ops.persistence_read_drop_reason_json_syntax_error
+               ~path:file ~detail:msg;
              None)
 
 let event_to_json event =


### PR DESCRIPTION
## Summary

Adds a typed identifier `Safe_ops.persistence_read_drop_reason_json_syntax_error` to the persistence drop-reason vocabulary, alongside the existing `list_dir_error` / `entry_load_error` / `invalid_payload`. Replaces the lone raw string `"json_syntax_error"` literal in `telemetry_eio.ml:172` with the typed reference.

## Why

The codebase carried two _different_ conventions for classifying persistence read drops on JSONL surfaces:

| File | IO load fail | `Yojson.Json_error` | parsed-but-invalid |
|------|--------------|---------------------|--------------------|
| `meta_cognition_snapshot` | `entry_load_error` | (combined via `read_json_file_safe` → `entry_load_error`) | `invalid_payload` |
| `telemetry_eio` | (n/a in scanner) | **raw `"json_syntax_error"`** (untyped) | `invalid_payload` |
| Sibling JSONL surfaces (`activity_feed`, `agent_reputation`, `mention_inbox`, `agent_economy_ledger`, `agent_stress`, `governance_anomaly_profile`, `team_context_findings`, `keeper_chat_store`, ...) | `entry_load_error` | `entry_load_error` (collapsed) | varied |

`telemetry_eio` already wanted to keep IO-vs-parse separated, but the only available typed reasons (`entry_load_error`, `invalid_payload`) didn't match either case, so it leaned on a string literal that nothing else in the codebase referenced. That literal is the part this PR converts into a typed identifier.

The new vocabulary lets downstream surfaces converge:

- `entry_load_error` — IO/load failure (or combined load+parse when a single helper like `read_json_file_safe` returns `Result`)
- `json_syntax_error` — `Yojson.Json_error` raised in a code path where IO and parse are split into separate steps
- `invalid_payload` — parsed OK, but record/schema validation fails

## Behavior parity

The underlying Prometheus label string is unchanged (`"json_syntax_error"`). Type-level refactor only. Any dashboard or alert keyed on that label continues to work.

## Validation

- `dune build --root . lib/` exit 0 — clean.
- `dune build --root . test/test_telemetry_eio_coverage.exe` exit 0.
- `./_build/default/test/test_telemetry_eio_coverage.exe test` — 38/38 OK.
- Repo-wide grep for raw `"json_syntax_error"` after the change: only the canonical definition in `lib/core/safe_ops.ml:380` remains.

## Out of scope

This PR is intentionally narrow:

- It does **not** modify `activity_feed.ml` or any of the in-flight sibling JSONL drop-counter PRs (#14037, #14064, #14067-#14086 etc.) — those should adopt the new identifier in their own commits to avoid cross-PR conflicts.
- A pre-existing build error in `bin/main_eio.ml:397` (callsite mismatch of `board_post_detail_json`) is on `origin/main` (HEAD `13f50256fc`) and is being fixed by PR #14041; it does not touch the lib paths in this PR.

## RFC

Not required. `lib/core/safe_ops.{ml,mli}` is not in the CLAUDE.md `agent_delegation` RFC-gated subsystem list. Pure additive vocabulary expansion on a leaf utility module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)