### PR TITLE
fix(keeper): validate OAS tool inputs before exec

### DIFF
--- a/lib/keeper/keeper_tools_oas.ml
+++ b/lib/keeper/keeper_tools_oas.ml
@@ -425,6 +425,7 @@ let append_tool_exec_decision_log ~config ~keeper_name ~site entry =
     [{cmd,timeout_sec}]). Identity by default. *)
 let make_keeper_tool_handler
     ~(name : string)
+    ~(input_schema : Yojson.Safe.t)
     ~(config : Coord.config)
     ~(meta : Keeper_types.keeper_meta)
     ~(ctx_snapshot : Keeper_types.working_context)
@@ -443,6 +444,48 @@ let make_keeper_tool_handler
   in
   fun raw_input ->
     let input = translate_input raw_input in
+    match Tool_input_validation.validate_args ~schema:input_schema ~name ~args:input () with
+    | Error validation_result ->
+      let raw_result = Yojson.Safe.to_string validation_result.data in
+      let output_text = normalize_tool_result ~success:false raw_result in
+      let duration_ms = 0 in
+      let ts = Time_compat.now () in
+      let error_text = Tool_result.message validation_result in
+      Keeper_registry.record_tool_use ~base_path:config.base_path meta.name
+        ~tool_name:name ~success:false;
+      Keeper_exec_tools.record_keeper_tool_call
+        ~tool_name:name ~success:false ~duration_ms;
+      ignore (Tool_dispatch.run_post_hooks validation_result);
+      broadcast_keeper_tool_call_event
+        ~keeper_name:meta.name ~tool_name:name ~duration_ms
+        ~success:false ~error_text ~site:"input_validation" ~ts ();
+      Prometheus.inc_counter
+        Prometheus.metric_keeper_tools_oas_failures
+        ~labels:[("tool", name); ("site", "input_validation")]
+        ();
+      append_tool_exec_decision_log ~config ~keeper_name:meta.name
+        ~site:"input_validation"
+        (`Assoc [
+          "ts_unix", `Float ts;
+          "event", `String "tool_exec";
+          "keeper_name", `String meta.name;
+          "tool", `String name;
+          "duration_ms", `Int duration_ms;
+          "result_bytes", `Int (String.length output_text);
+          "ok", `Bool false;
+          "error", `String error_text;
+        ]);
+      persist_tool_call_io_from_handler
+        ~meta
+        ~tool_name:name
+        ~input
+        ~output_text
+        ~success:false
+        ~duration_ms:0.0
+        ~result_bytes:(String.length output_text)
+        ();
+      (false, output_text)
+    | Ok input ->
     let key = args_key input in
     let prior_fails = failure_count_get failure_counts key in
     if prior_fails >= max_consecutive_failures then begin
@@ -814,7 +857,8 @@ let make_tool_bundle
   let internal_tools =
     List.filter_map (fun (td : Masc_domain.tool_schema) ->
       if List.mem td.name universe_names then
-        let h = make_keeper_tool_handler ~name:td.name ~config ~meta ~ctx_snapshot
+        let h = make_keeper_tool_handler ~name:td.name
+              ~input_schema:td.input_schema ~config ~meta ~ctx_snapshot
               ?turn_sandbox_factory
               ?turn_sandbox_factory_git
               ~exec_cache
@@ -862,7 +906,8 @@ let make_tool_bundle
             | _ -> internal_def.description
           in
           let h =
-            make_keeper_tool_handler ~name:internal ~config ~meta ~ctx_snapshot
+            make_keeper_tool_handler ~name:internal
+               ~input_schema:internal_def.input_schema ~config ~meta ~ctx_snapshot
                ?turn_sandbox_factory
                ?turn_sandbox_factory_git
                ~exec_cache

--- a/lib/keeper/keeper_tools_oas.mli
+++ b/lib/keeper/keeper_tools_oas.mli
@@ -77,11 +77,13 @@ val tool_exec_result_markers :
 (** Build the per-tool handler closure used by both internal and
     alias tool entries. The closure dispatches via
     [execute_keeper_tool_call_with_outcome] using [~name] as the
-    INTERNAL tool name (telemetry SSOT). [?translate_input]
-    reshapes incoming JSON from a public alias schema to the
-    internal payload (identity by default). *)
+    INTERNAL tool name (telemetry SSOT). [~input_schema] is the
+    internal tool schema used for pre-execution validation after
+    [?translate_input] reshapes incoming JSON from a public alias
+    schema to the internal payload (identity by default). *)
 val make_keeper_tool_handler :
   name:string ->
+  input_schema:Yojson.Safe.t ->
   config:Coord.config ->
   meta:Keeper_types.keeper_meta ->
   ctx_snapshot:Keeper_types.working_context ->

--- a/lib/tool_input_validation.ml
+++ b/lib/tool_input_validation.ml
@@ -121,34 +121,52 @@ let prepare_args ?schema ~name args =
   in
   normalize_blank_optional_enum_args ?schema args
 
-let register_pre_hook () =
+let validation_action ?schema ~name ~args () : Tool_dispatch.pre_hook_action =
   let lookup name =
+    let schema =
+      match schema with
+      | Some schema -> Some schema
+      | None -> Tool_dispatch.lookup_schema name
+    in
     Option.map
       (Agent_sdk.Tool_middleware.tool_schema_of_json ~name)
-      (Tool_dispatch.lookup_schema name)
+      schema
   in
   let hook = Agent_sdk.Tool_middleware.make_validation_hook ~lookup in
+  let schema =
+    match schema with
+    | Some _ as schema -> schema
+    | None -> Tool_dispatch.lookup_schema name
+  in
+  let prepared_args = prepare_args ?schema ~name args in
+  match hook ~name ~args:prepared_args with
+  | Agent_sdk.Tool_middleware.Pass
+    when not (Yojson.Safe.equal prepared_args args) ->
+    Log.debug "tool_input_validation normalized args for %s" name;
+    Proceed prepared_args
+  | Agent_sdk.Tool_middleware.Pass -> Pass
+  | Agent_sdk.Tool_middleware.Proceed coerced ->
+    Log.debug "tool_input_validation coerced args for %s" name;
+    Proceed coerced
+  | Agent_sdk.Tool_middleware.Reject { message; _ } ->
+    Log.info "tool_input_validation rejected %s: %s" name message;
+    Reject {
+      Tool_result.success = false;
+      data = `Assoc [
+        ("error", `String message);
+        ("validation", `String "oas_tool_middleware");
+      ];
+      legacy_message = message;
+      tool_name = name;
+      duration_ms = 0.0;
+    }
+
+let validate_args ?schema ~name ~args () =
+  match validation_action ?schema ~name ~args () with
+  | Pass -> Ok args
+  | Proceed coerced -> Ok coerced
+  | Reject result -> Error result
+
+let register_pre_hook () =
   Tool_dispatch.register_pre_hook (fun ~name ~args ->
-    let schema = Tool_dispatch.lookup_schema name in
-    let prepared_args = prepare_args ?schema ~name args in
-    match hook ~name ~args:prepared_args with
-    | Agent_sdk.Tool_middleware.Pass
-      when not (Yojson.Safe.equal prepared_args args) ->
-      Log.debug "tool_input_validation normalized args for %s" name;
-      Proceed prepared_args
-    | Agent_sdk.Tool_middleware.Pass -> Pass
-    | Agent_sdk.Tool_middleware.Proceed coerced ->
-      Log.debug "tool_input_validation coerced args for %s" name;
-      Proceed coerced
-    | Agent_sdk.Tool_middleware.Reject { message; _ } ->
-      Log.info "tool_input_validation rejected %s: %s" name message;
-      Reject {
-        Tool_result.success = false;
-        data = `Assoc [
-          ("error", `String message);
-          ("validation", `String "oas_tool_middleware");
-        ];
-        legacy_message = message;
-        tool_name = name;
-        duration_ms = 0.0;
-      })
+    validation_action ~name ~args ())

--- a/lib/tool_input_validation.mli
+++ b/lib/tool_input_validation.mli
@@ -10,3 +10,17 @@
 (** Register input validation as a Tool_dispatch pre-hook.
     Must be called after all tool schemas are registered (server init). *)
 val register_pre_hook : unit -> unit
+
+(** Validate and normalize a tool argument object through the same OAS
+    middleware used by [register_pre_hook].
+
+    [?schema] lets direct OAS tool handlers validate against the schema they
+    already hold, without depending on the global Tool_dispatch schema registry
+    being populated in that execution path. When omitted, validation falls back
+    to [Tool_dispatch.lookup_schema]. *)
+val validate_args :
+  ?schema:Yojson.Safe.t ->
+  name:string ->
+  args:Yojson.Safe.t ->
+  unit ->
+  (Yojson.Safe.t, Tool_result.t) result

--- a/test/test_keeper_tools_oas.ml
+++ b/test/test_keeper_tools_oas.ml
@@ -314,6 +314,35 @@ let test_error_json_is_returned_as_tool_error () =
             (Option.is_some (Safe_ops.json_string_opt "path" detail))
       | Ok _ -> fail "missing file should be surfaced as tool error")
 
+let test_oas_handler_rejects_missing_required_args () =
+  let meta = make_test_meta () in
+  let ctx_snapshot = make_test_ctx () in
+  let dir = Filename.concat (Filename.get_temp_dir_name ())
+    (Printf.sprintf "test_keeper_tools_validate_%d" (Random.int 100000)) in
+  (try Unix.mkdir dir 0o755 with Unix.Unix_error (Unix.EEXIST, _, _) -> ());
+  Fun.protect
+    ~finally:(fun () ->
+      (try Sys.readdir dir |> Array.iter (fun f ->
+        Sys.remove (Filename.concat dir f));
+        Unix.rmdir dir with _ -> ()))
+    (fun () ->
+      Eio_main.run @@ fun env ->
+      Fs_compat.set_fs (Eio.Stdenv.fs env);
+      let config = Coord.default_config dir in
+      let tools = Keeper_tools_oas.make_tools ~config ~meta ~ctx_snapshot () in
+      let tool = find_tool "keeper_fs_read" tools in
+      match Tool.execute tool (`Assoc []) with
+      | Error { Agent_sdk.Types.message; _ } ->
+          let json = Yojson.Safe.from_string message in
+          check bool "ok is false" false
+            (Yojson.Safe.Util.(member "ok" json |> to_bool));
+          check bool "error mentions missing path" true
+            (string_contains ~sub:"path" message);
+          let detail = Yojson.Safe.Util.member "detail" json in
+          check string "validation source" "oas_tool_middleware"
+            Yojson.Safe.Util.(detail |> member "validation" |> to_string)
+      | Ok _ -> fail "missing required path should be rejected by OAS validation")
+
 let latest_log_seq () =
   match Mlog.Ring.recent ~limit:1 () with
   | (entry : Mlog.Ring.entry) :: _ -> entry.seq
@@ -856,6 +885,8 @@ let () =
       test_case "valid schemas" `Quick test_tools_have_valid_schemas;
       test_case "count matches allowed" `Quick test_tool_count_matches_allowed;
       test_case "error json becomes tool error" `Quick test_error_json_is_returned_as_tool_error;
+      test_case "missing required args rejected before keeper exec" `Quick
+        test_oas_handler_rejects_missing_required_args;
       test_case "error result logs at error level" `Quick
         test_error_result_logs_at_error_level;
       test_case "missing file error includes suggestions" `Quick

--- a/test/test_tool_input_validation.ml
+++ b/test/test_tool_input_validation.ml
@@ -345,6 +345,24 @@ let test_registered_hook_bypasses_empty_schema () =
   Alcotest.(check bool) "args unchanged" true
     (Yojson.Safe.equal forwarded args)
 
+let test_validate_args_uses_explicit_schema_without_registry () =
+  Tool_dispatch.clear_hooks ();
+  let schema = make_schema ~required:["path"] [("path", "string")] in
+  match
+    Tool_input_validation.validate_args
+      ~schema
+      ~name:"__tool_input_validation_direct_schema"
+      ~args:(`Assoc [])
+      ()
+  with
+  | Error result ->
+    let msg = Yojson.Safe.to_string result.Tool_result.data in
+    Alcotest.(check bool) "mentions missing path" true
+      (string_contains msg "path");
+    Alcotest.(check bool) "marks oas validation" true
+      (string_contains msg "oas_tool_middleware")
+  | Ok _ -> Alcotest.fail "Expected Error for missing required field"
+
 let find_schema_exn name schemas =
   match List.find_opt (fun (schema : Masc_domain.tool_schema) -> String.equal schema.name name) schemas with
   | Some schema -> schema.input_schema
@@ -540,6 +558,8 @@ let () =
         test_registered_hook_bypasses_unknown_tool;
       Alcotest.test_case "empty schema bypasses validation" `Quick
         test_registered_hook_bypasses_empty_schema;
+      Alcotest.test_case "direct validation uses explicit schema" `Quick
+        test_validate_args_uses_explicit_schema_without_registry;
       Alcotest.test_case "masc_transition compat: to/note keys" `Quick
         test_registered_hook_transition_compat_to_and_note;
       Alcotest.test_case "masc_transition compat: status-like action value" `Quick


### PR DESCRIPTION
## Summary

- Expose `Tool_input_validation.validate_args` so direct OAS tool handlers can use the same OAS middleware validation as the MCP pre-hook.
- Validate translated keeper OAS inputs against the internal tool schema before `execute_keeper_tool_call_with_outcome` runs.
- Preserve validation failures in keeper observability: tool-use accounting, post hooks, SSE event, Prometheus failure site, decision log, and handler-persisted tool-call I/O.

## Why

The MCP dispatch path had schema pre-hooks, but the keeper OAS internal handler translated public/alias input and then executed the internal tool directly. That left required-field/type validation dependent on each executor instead of the declared `input_schema`, and it also let tests pass without the global schema registry being populated.

## Validation

- `scripts/dune-local.sh build test/test_tool_input_validation.exe test/test_keeper_tools_oas.exe`
- `./_build/default/test/test_tool_input_validation.exe` (29 tests)
- `./_build/default/test/test_keeper_tools_oas.exe` (38 tests)
- `git diff --check`