### PR TITLE
fix: count generation lineage manifest read drops

### DIFF
--- a/lib/keeper/keeper_generation_lineage.ml
+++ b/lib/keeper/keeper_generation_lineage.ml
@@ -259,10 +259,33 @@ let record_handoff_artifacts
 let load_json_file_opt path =
   if not (Fs_compat.file_exists path) then None
   else
-    try Some (Yojson.Safe.from_string (Fs_compat.load_file path))
+    let surface = "keeper_generation_lineage_manifest" in
+    let report_drop ~reason ~detail =
+      Safe_ops.report_persistence_read_drop
+        ~on_drop:(fun () ->
+          Prometheus.inc_counter Prometheus.metric_persistence_read_drops
+            ~labels:[("surface", surface); ("reason", reason)]
+            ())
+        ~surface
+        ~reason
+        ~path
+        ~detail
+    in
+    try
+      let contents = Fs_compat.load_file path in
+      try Some (Yojson.Safe.from_string contents)
+      with Yojson.Json_error detail ->
+        report_drop
+          ~reason:Safe_ops.persistence_read_drop_reason_entry_load_error
+          ~detail;
+        None
     with
     | Eio.Cancel.Cancelled _ as e -> raise e
-    | _ -> None
+    | exn ->
+        report_drop
+          ~reason:Safe_ops.persistence_read_drop_reason_entry_load_error
+          ~detail:(Printexc.to_string exn);
+        None
 
 let load_jsonl_file path =
   if not (Fs_compat.file_exists path) then []

--- a/test/test_keeper_generation_lineage.ml
+++ b/test/test_keeper_generation_lineage.ml
@@ -2,6 +2,28 @@ open Alcotest
 
 module KGL = Masc_mcp.Keeper_generation_lineage
 
+let rec rm_rf path =
+  if Sys.file_exists path then
+    if Sys.is_directory path then (
+      Sys.readdir path
+      |> Array.iter (fun name -> rm_rf (Filename.concat path name));
+      Unix.rmdir path)
+    else Sys.remove path
+
+let with_temp_file prefix contents f =
+  let path = Filename.temp_file prefix ".json" in
+  let oc = open_out path in
+  Fun.protect
+    ~finally:(fun () -> close_out_noerr oc)
+    (fun () -> output_string oc contents);
+  Fun.protect ~finally:(fun () -> rm_rf path) (fun () -> f path)
+
+let persistence_read_drop_total ~surface ~reason =
+  Masc_mcp.Prometheus.metric_value_or_zero
+    Masc_mcp.Prometheus.metric_persistence_read_drops
+    ~labels:[("surface", surface); ("reason", reason)]
+    ()
+
 let classify_identity_fields_marks_changed_and_dropped () =
   let inherited, changed, dropped =
     KGL.classify_identity_fields
@@ -40,6 +62,17 @@ let continuity_judgment_verifies_identical_summary () =
   check string "identical summary verdict" "verified" judgment.verdict;
   check bool "similarity available" true (Option.is_some judgment.similarity)
 
+let malformed_manifest_load_counts_read_drop () =
+  let surface = "keeper_generation_lineage_manifest" in
+  let reason = "entry_load_error" in
+  let before = persistence_read_drop_total ~surface ~reason in
+  with_temp_file "keeper-generation-lineage-bad-manifest" "{not-json"
+    (fun path ->
+      check bool "malformed manifest is absent" true
+        (Option.is_none (KGL.load_json_file_opt path)));
+  check (float 0.0001) "manifest read drop counted" (before +. 1.0)
+    (persistence_read_drop_total ~surface ~reason)
+
 let () =
   run "Keeper_generation_lineage"
     [
@@ -54,5 +87,10 @@ let () =
             continuity_judgment_reports_missing_summary;
           test_case "identical continuity summary verifies" `Quick
             continuity_judgment_verifies_identical_summary;
+        ] );
+      ( "persistence read drops",
+        [
+          test_case "malformed manifest load is counted" `Quick
+            malformed_manifest_load_counts_read_drop;
         ] );
     ]


### PR DESCRIPTION
## Summary
- Count malformed or unreadable keeper generation-lineage manifest loads with `masc_persistence_read_drops_total`.
- Preserve best-effort behavior by returning `None` for bad manifests while surfacing the drop to metrics/logs.
- Add focused regression coverage in `test_keeper_generation_lineage`.

## Verification
- git diff --check
- scripts/opam-pin-external-deps.sh --install (repair local agent_sdk pin drift)
- lockf -k -t 1200 /tmp/me-dune-local.lock env MASC_DUNE_LOCK_HELD=1 MASC_SKIP_OPAM_LOCK=1 DUNE_JOBS=1 DUNE_CACHE=disabled scripts/dune-local.sh build test/test_keeper_generation_lineage.exe
- ./_build/default/test/test_keeper_generation_lineage.exe (4 tests)