### PR TITLE
feat(keeper): cap consecutive saturation skips to prevent probe-stale starvation

### DIFF
--- a/lib/keeper/keeper_turn_liveness.ml
+++ b/lib/keeper/keeper_turn_liveness.ml
@@ -175,3 +175,60 @@ let turn_livelock_stuck_after_sec () =
   Float.max 1.0
     (Env_config_core.get_float ~default:1800.0
        "MASC_KEEPER_TURN_LIVELOCK_STUCK_AFTER_SEC")
+
+(* PR-B follow-up: bound consecutive saturation skips per keeper.
+
+   Pre-existing PR-B logic skips a turn whenever the ollama probe
+   cache reports saturation, with a 5s jittered backoff.  Without an
+   upper bound, a stuck or stale probe (e.g. /api/ps handler hung
+   behind a model load) can produce indefinite consecutive skips —
+   the keeper makes no progress, the watchdog stays unaware (each
+   skip records as a soft "skipped" terminal observation rather than
+   a FAILED→DEAD escalation), and a saturated cache poisons
+   subsequent cycles.
+
+   The cap is intentionally a per-keeper count rather than a global
+   one: different keepers race the same probe cache, and cross-talk
+   between keepers should not consume each other's skip budget.
+
+   Reset rule: any non-skip path clears the counter.  A single
+   successful probe (saturated → false) wipes the history, matching
+   the documented fail-open invariant. *)
+
+let saturation_skip_counts : (string, int) Hashtbl.t = Hashtbl.create 32
+
+let saturation_skip_counts_mutex = Eio.Mutex.create ()
+
+let max_consecutive_saturation_skips_default = 5
+
+let max_consecutive_saturation_skips_env =
+  "MASC_MAX_CONSECUTIVE_SATURATION_SKIPS"
+
+let max_consecutive_saturation_skips () =
+  Int.max 1
+    (Env_config_core.get_int
+       ~default:max_consecutive_saturation_skips_default
+       max_consecutive_saturation_skips_env)
+
+let saturation_skip_count_get ~keeper_name =
+  Eio.Mutex.use_ro saturation_skip_counts_mutex (fun () ->
+    Option.value ~default:0
+      (Hashtbl.find_opt saturation_skip_counts keeper_name))
+
+let saturation_skip_count_inc ~keeper_name =
+  Eio.Mutex.use_rw ~protect:false saturation_skip_counts_mutex (fun () ->
+    let cur =
+      Option.value ~default:0
+        (Hashtbl.find_opt saturation_skip_counts keeper_name)
+    in
+    let next = cur + 1 in
+    Hashtbl.replace saturation_skip_counts keeper_name next;
+    next)
+
+let saturation_skip_count_reset ~keeper_name =
+  Eio.Mutex.use_rw ~protect:false saturation_skip_counts_mutex (fun () ->
+    Hashtbl.remove saturation_skip_counts keeper_name)
+
+let saturation_skip_count_clear_all () =
+  Eio.Mutex.use_rw ~protect:false saturation_skip_counts_mutex (fun () ->
+    Hashtbl.clear saturation_skip_counts)

--- a/lib/keeper/keeper_turn_liveness.mli
+++ b/lib/keeper/keeper_turn_liveness.mli
@@ -66,3 +66,27 @@ val turn_livelock_max_attempts : unit -> int
 
 val turn_livelock_stuck_after_sec : unit -> float
 (** Configurable livelock detection stuck threshold (seconds). *)
+
+val max_consecutive_saturation_skips : unit -> int
+(** Upper bound on consecutive saturation skips per keeper (env
+    [MASC_MAX_CONSECUTIVE_SATURATION_SKIPS], default 5, floored at
+    1).  When a keeper exceeds this count its next dispatch escapes
+    the saturation pre-skip path so a stuck or stale probe cannot
+    starve the keeper indefinitely. *)
+
+val saturation_skip_count_get : keeper_name:string -> int
+(** Current consecutive-skip count for [keeper_name].  Returns 0 when
+    the keeper has no recorded skips. *)
+
+val saturation_skip_count_inc : keeper_name:string -> int
+(** Increment and return the new consecutive-skip count for
+    [keeper_name].  Caller decides whether to act on the new count
+    (compare against {!max_consecutive_saturation_skips}). *)
+
+val saturation_skip_count_reset : keeper_name:string -> unit
+(** Reset [keeper_name]'s consecutive-skip count to zero.  Called on
+    every non-skip path (probe reports unsaturated, non-ollama
+    cascade, force-dispatch escape). *)
+
+val saturation_skip_count_clear_all : unit -> unit
+(** Test helper: clear all per-keeper consecutive-skip counters. *)

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -331,10 +331,28 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
           Keeper_coordination.effective_model_labels_for_turn meta_for_check
         in
         match resolve_ollama_only_base_url labels with
-        | None -> None
+        | None ->
+            saturation_skip_count_reset ~keeper_name:meta.name;
+            None
         | Some base_url ->
-            if not (is_ollama_saturated base_url) then None
+            if not (is_ollama_saturated base_url) then begin
+              saturation_skip_count_reset ~keeper_name:meta.name;
+              None
+            end
             else
+              let next_count =
+                saturation_skip_count_inc ~keeper_name:meta.name
+              in
+              let cap = max_consecutive_saturation_skips () in
+              if next_count > cap then begin
+                Log.Keeper.warn
+                  ~keeper_name:meta.name ~turn_id:keeper_turn_id
+                  "%s: saturation skip cap reached (count=%d cap=%d) \
+                   \xe2\x80\x94 force-dispatching despite saturated probe"
+                  meta.name next_count cap;
+                saturation_skip_count_reset ~keeper_name:meta.name;
+                None
+              end else
               let info = Cascade_ollama_probe.cached_capacity base_url in
               let queue_len =
                 match info with
@@ -349,9 +367,9 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
               Log.Keeper.info
                 ~keeper_name:meta.name ~turn_id:keeper_turn_id
                 "%s: ollama saturated for keeper=%s cascade=%s queue=%d \
-                 available=%d \xe2\x80\x94 skipping turn"
+                 available=%d skip_count=%d/%d \xe2\x80\x94 skipping turn"
                 meta.name meta.name effective_cascade_name queue_len
-                available;
+                available next_count cap;
               record_pre_dispatch_terminal_observation
                 ~config
                 ~meta

--- a/lib/keeper/keeper_unified_turn.mli
+++ b/lib/keeper/keeper_unified_turn.mli
@@ -223,6 +223,27 @@ val is_ollama_saturated :
   string ->
   bool
 
+(** Upper bound on consecutive saturation skips per keeper (env
+    [MASC_MAX_CONSECUTIVE_SATURATION_SKIPS], default 5, floored at
+    1).  When a keeper exceeds this count its next dispatch escapes
+    the saturation pre-skip path so a stuck or stale probe cannot
+    starve the keeper indefinitely. *)
+val max_consecutive_saturation_skips : unit -> int
+
+(** Current consecutive-skip count for [keeper_name].  Returns 0 when
+    the keeper has no recorded skips. *)
+val saturation_skip_count_get : keeper_name:string -> int
+
+(** Increment and return the new consecutive-skip count for
+    [keeper_name]. *)
+val saturation_skip_count_inc : keeper_name:string -> int
+
+(** Reset [keeper_name]'s consecutive-skip count to zero. *)
+val saturation_skip_count_reset : keeper_name:string -> unit
+
+(** Test helper: clear all per-keeper consecutive-skip counters. *)
+val saturation_skip_count_clear_all : unit -> unit
+
 (** Pure merge step for runtime-owned fail-open rotation candidates. The
     active path feeds this from the live cascade catalog: catalog order is
     preserved while retaining only reserved recovery profiles and

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -4492,6 +4492,45 @@ let test_is_ollama_saturated_ignores_zero_available_when_idle () =
     (UT.is_ollama_saturated
        ~capacity_lookup:(fun _ -> Some info) url)
 
+let test_saturation_skip_count_starts_at_zero () =
+  UT.saturation_skip_count_clear_all ();
+  check int "fresh keeper has zero skip count" 0
+    (UT.saturation_skip_count_get ~keeper_name:"fresh_keeper")
+
+let test_saturation_skip_count_inc_returns_new_value () =
+  UT.saturation_skip_count_clear_all ();
+  let n1 = UT.saturation_skip_count_inc ~keeper_name:"k_inc" in
+  let n2 = UT.saturation_skip_count_inc ~keeper_name:"k_inc" in
+  let n3 = UT.saturation_skip_count_inc ~keeper_name:"k_inc" in
+  check int "first inc returns 1" 1 n1;
+  check int "second inc returns 2" 2 n2;
+  check int "third inc returns 3" 3 n3;
+  check int "get matches last inc" 3
+    (UT.saturation_skip_count_get ~keeper_name:"k_inc")
+
+let test_saturation_skip_count_reset_zeros_one_keeper () =
+  UT.saturation_skip_count_clear_all ();
+  let _ = UT.saturation_skip_count_inc ~keeper_name:"k_a" in
+  let _ = UT.saturation_skip_count_inc ~keeper_name:"k_b" in
+  let _ = UT.saturation_skip_count_inc ~keeper_name:"k_b" in
+  UT.saturation_skip_count_reset ~keeper_name:"k_a";
+  check int "reset target zeroed" 0
+    (UT.saturation_skip_count_get ~keeper_name:"k_a");
+  check int "untouched keeper preserved" 2
+    (UT.saturation_skip_count_get ~keeper_name:"k_b")
+
+let test_saturation_skip_cap_default_is_at_least_one () =
+  (* The cap is floored at 1 even if the env var is set to 0 or
+     negative — a cap of 0 would force-dispatch every cycle. *)
+  let prev = try Some (Sys.getenv "MASC_MAX_CONSECUTIVE_SATURATION_SKIPS")
+             with Not_found -> None in
+  Unix.putenv "MASC_MAX_CONSECUTIVE_SATURATION_SKIPS" "0";
+  let cap = UT.max_consecutive_saturation_skips () in
+  (match prev with
+   | Some v -> Unix.putenv "MASC_MAX_CONSECUTIVE_SATURATION_SKIPS" v
+   | None -> Unix.putenv "MASC_MAX_CONSECUTIVE_SATURATION_SKIPS" "");
+  check bool "cap floored at 1 even with env=0" true (cap >= 1)
+
 let wrapped_claude_limit_error () =
   Agent_sdk.Error.Api
     (NetworkError
@@ -8606,6 +8645,14 @@ let () =
             test_is_ollama_saturated_returns_true_when_full_with_queue;
           test_case "PR-B: zero available without traffic is fail-open" `Quick
             test_is_ollama_saturated_ignores_zero_available_when_idle;
+          test_case "PR-B follow-up: fresh keeper has zero skip count" `Quick
+            test_saturation_skip_count_starts_at_zero;
+          test_case "PR-B follow-up: inc returns monotonic counts" `Quick
+            test_saturation_skip_count_inc_returns_new_value;
+          test_case "PR-B follow-up: reset zeros one keeper only" `Quick
+            test_saturation_skip_count_reset_zeros_one_keeper;
+          test_case "PR-B follow-up: cap floored at 1" `Quick
+            test_saturation_skip_cap_default_is_at_least_one;
           test_case "hard quota degraded retry uses local_recovery" `Quick
             test_degraded_retry_after_recoverable_error_uses_local_recovery_for_hard_quota;
           test_case "resumable session degraded retry uses local_recovery"


### PR DESCRIPTION
## Summary

Bound consecutive saturation skips per keeper to prevent indefinite probe-stale starvation.

**Problem**: Pre-existing PR-B logic (`keeper_turn_liveness.is_ollama_saturated`) skips a turn whenever the ollama probe cache reports saturation, with a 5s jittered backoff. Without an upper bound, a stuck or stale probe (e.g. `/api/ps` handler hung behind a model load) can produce indefinite consecutive skips — the keeper makes no progress, the watchdog stays unaware (each skip records as a soft `skipped` terminal observation rather than `FAILED→DEAD`), and a saturated cache poisons subsequent cycles.

**Fix**: Per-keeper consecutive-skip counter. When count exceeds `max_consecutive_saturation_skips ()` (env `MASC_MAX_CONSECUTIVE_SATURATION_SKIPS`, default 5, floored at 1), the next dispatch escapes the skip path so the actual cascade error path can run. Reset rule: any non-skip path clears the counter.

## Changes

- `lib/keeper/keeper_turn_liveness.{ml,mli}`: add `max_consecutive_saturation_skips`, per-keeper counter primitives (`saturation_skip_count_{get,inc,reset,clear_all}`)
- `lib/keeper/keeper_unified_turn.{ml,mli}`: re-export new primitives + wire counter into existing PR-B skip path at L333-391
- `test/test_keeper_unified.ml`: 4 unit tests covering count start/inc/reset/cap-floor

## Why per-keeper, not global

Different keepers race the same probe cache. Cross-talk between keepers should not consume each other's skip budget — a global counter would let a heavy-traffic keeper deny lighter ones a chance to skip.

## Tradeoffs

- Force-dispatching after N skips will likely fail the next cycle (ollama still saturated). That's intentional: a real error path is preferable to indefinite soft-skips, because it surfaces FSM transitions the watchdog can act on.
- Default 5 corresponds to ~25-30s of accumulated backoff (5s × 5 + jitter). Operators tuning for very busy local hosts can raise this.

## RFC

No RFC needed: change is in `lib/keeper/keeper_turn_liveness*` / `keeper_unified_turn*`, not in the `credential_*`/`keeper_gh_*`/`host_config_*` subsystems gated by `agent_delegation` block in CLAUDE.md.

## Test plan

- [x] `dune build --root . lib` passes (clean)
- [x] `dune build --root . test/test_keeper_unified.exe` passes
- [x] 4 new unit tests pass (`PR-B follow-up: ...`) plus existing 52 phase_gate tests (56/56 OK)
- [ ] CI green
- [ ] Manual: confirm log line `saturation skip cap reached (count=N cap=M) — force-dispatching` fires under simulated stuck probe (operator validation post-merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
