### PR TITLE
fix(keeper): route actionable turns to tool-capable providers

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -267,9 +267,19 @@ let run_turn
     let require_tool_choice_support =
       initial_tool_surface.tool_requirement = Required
     in
+    let actionable_observation_requires_tool_support =
+      match world_observation with
+      | None -> false
+      | Some observation ->
+          observation
+          |> Keeper_contract_classifier.of_keeper_world_observation
+          |> Keeper_contract_classifier.requires_tool_support_for_allowed_tools
+               ~allowed_tool_names:all_tool_names
+    in
     let require_tool_support =
-      initial_tool_surface.tool_requirement = Required
-      && tools <> []
+      tools <> []
+      && (initial_tool_surface.tool_requirement = Required
+          || actionable_observation_requires_tool_support)
     in
     let timeout_s =
       match oas_timeout_s with

--- a/lib/keeper/keeper_contract_classifier.ml
+++ b/lib/keeper/keeper_contract_classifier.ml
@@ -86,3 +86,8 @@ let classify_actionable_signal_with_allowed_tools =
 let is_actionable = function
   | No_actionable_signal -> false
   | Has_unclaimed_tasks | Has_board_activity | Has_discovered_work -> true
+
+let requires_tool_support_for_allowed_tools ~(allowed_tool_names : string list) o =
+  o
+  |> classify_actionable_signal_for_tools ~allowed_tool_names
+  |> is_actionable

--- a/lib/keeper/keeper_contract_classifier.mli
+++ b/lib/keeper/keeper_contract_classifier.mli
@@ -78,6 +78,14 @@ val classify_actionable_signal_for_tools :
 val classify_actionable_signal_with_allowed_tools :
   allowed_tool_names:string list -> world_observation -> actionable_signal
 
+(** [requires_tool_support_for_allowed_tools ~allowed_tool_names o] is true
+    when [o] carries an actionable signal that can be satisfied by at least
+    one tool in [allowed_tool_names]. Use this before provider routing so the
+    same structured signal that later enforces the completion contract also
+    selects a provider capable of exposing keeper tools. *)
+val requires_tool_support_for_allowed_tools :
+  allowed_tool_names:string list -> world_observation -> bool
+
 (** [is_actionable s] is [false] iff [s = No_actionable_signal].
     Provided so callers comparing the structured signal against the
     legacy boolean can do so without a manual pattern match. *)

--- a/lib/oas_worker_named.ml
+++ b/lib/oas_worker_named.ml
@@ -342,7 +342,7 @@ let run_named
       in
       Error
         (sdk_error_of_masc_internal_error
-           (if require_tool_choice_support then
+           (if require_tool_choice_support || require_tool_support then
               No_tool_capable_provider
                 {
                   cascade_name = error_cascade_name;

--- a/test/test_keeper_contract_classifier_pure.ml
+++ b/test/test_keeper_contract_classifier_pure.ml
@@ -51,15 +51,16 @@ let test_signal_label_none () =
 (* ── contract_status_label ───────────────────────────────────────────── *)
 
 let test_status_label_tool_surface_mismatch () =
-  let label =
-    KCC.contract_status_label
+  let rendered =
+    Format.asprintf "%a" KCC.pp_contract_status
       (KCC.Tool_surface_mismatch { missing = [ "keeper_task_claim"; "masc_broadcast" ] })
   in
-  (* Label must include the missing tool names for grep-ability. *)
-  check_bool "label mentions missing keeper_task_claim" true
-    (Astring.String.is_infix ~affix:"keeper_task_claim" label);
-  check_bool "label mentions missing masc_broadcast" true
-    (Astring.String.is_infix ~affix:"masc_broadcast" label)
+  (* The stable label is intentionally low-cardinality; the pretty printer
+     carries missing tool names for grep/debug output. *)
+  check_bool "rendered status mentions missing keeper_task_claim" true
+    (Astring.String.is_infix ~affix:"keeper_task_claim" rendered);
+  check_bool "rendered status mentions missing masc_broadcast" true
+    (Astring.String.is_infix ~affix:"masc_broadcast" rendered)
 
 let test_status_label_satisfied_completion () =
   check_string "Satisfied_completion is a stable token"
@@ -154,6 +155,18 @@ let test_classify_for_tools_alias_matches () =
   in
   check_signal "alias matches direct" direct aliased
 
+let test_requires_tool_support_for_allowed_tools_true () =
+  let o = make_obs ~tasks:1 ~board:0 ~discovered:false in
+  check_bool "claimable task + claim tool requires tool-capable provider" true
+    (KCC.requires_tool_support_for_allowed_tools
+       ~allowed_tool_names:[ "keeper_task_claim" ] o)
+
+let test_requires_tool_support_for_allowed_tools_false_without_matching_tool () =
+  let o = make_obs ~tasks:1 ~board:0 ~discovered:false in
+  check_bool "claimable task without claim tool does not require tool support" false
+    (KCC.requires_tool_support_for_allowed_tools
+       ~allowed_tool_names:[ "keeper_board_post" ] o)
+
 (* ── runner ──────────────────────────────────────────────────────────── *)
 
 let () =
@@ -203,5 +216,10 @@ let () =
             test_classify_for_tools_no_actionable_when_no_tools;
           Alcotest.test_case "alias matches direct" `Quick
             test_classify_for_tools_alias_matches;
+          Alcotest.test_case "matching actionable signal requires tool support"
+            `Quick test_requires_tool_support_for_allowed_tools_true;
+          Alcotest.test_case
+            "unmatched actionable signal does not require tool support" `Quick
+            test_requires_tool_support_for_allowed_tools_false_without_matching_tool;
         ] );
     ]


### PR DESCRIPTION
## Summary

Fixes a keeper routing gap visible in the operator logs: an actionable structured world signal could be enforced only after the OAS run completed, while provider selection still treated the turn as optional-tool. That let `codex_cli` silently omit keeper-bound runtime MCP tools, then the keeper failed later with `required_tool_contract` / `tool_required_unsatisfied`.

Changes:

- Add a pure `Keeper_contract_classifier.requires_tool_support_for_allowed_tools` helper.
- Make `Keeper_agent_run` require a tool-capable provider when the structured world observation has actionable work that the keeper can satisfy with its tool surface.
- Report `No_tool_capable_provider` when `require_tool_support` alone empties a cascade, not only when exact `tool_choice` support was requested.
- Correct the pure classifier test to keep `contract_status_label` low-cardinality and assert missing tool details via `pp_contract_status`.

## Product impact

Actionable turns with claimable tasks, board activity, or discovered work should now route away from providers that cannot expose keeper-bound runtime MCP tools before the model gets a chance to emit a passive no-op. This turns a late noisy failure into earlier capability-aware routing or a clearer `no_tool_capable_provider` error.

## Evidence

From the pasted runtime logs, `codex_cli` omitted keeper-bound tools and later keeper turns failed with `required tool contract violated` under `has_unclaimed_tasks` / `has_board_activity`. This patch connects the same structured actionable signal used by the post-run contract gate to the pre-run provider capability gate.

## Review evidence

- `scripts/opam-pin-external-deps.sh --install`
- `scripts/dune-local.sh build test/test_keeper_contract_classifier_pure.exe`
- `./_build/default/test/test_keeper_contract_classifier_pure.exe`
- `scripts/dune-local.sh build test/test_oas_worker.exe`
- `./_build/default/test/test_oas_worker.exe`
- `git diff --check`

## Linked issue

- Related: #11083
