### PR TITLE
feat(coord): expose broadcast temporal decay schema (#11329)

### DIFF
--- a/lib/coord/coord_broadcast.ml
+++ b/lib/coord/coord_broadcast.ml
@@ -128,6 +128,8 @@ let broadcast ?trace_context ?(msg_type = "broadcast")
     mention;
     timestamp = now_iso ();
     trace_context;
+    expires_at = None;
+    relevance = Event_kind.Relevance.(to_string Medium);
   } in
   let msg_file =
     Filename.concat (messages_dir config)

--- a/lib/coord/event_kind.ml
+++ b/lib/coord/event_kind.ml
@@ -80,3 +80,29 @@ module Board = struct
 
   let all = [ Posted; Commented; Voted; Deleted ]
 end
+
+module Relevance = struct
+  type t =
+    | Critical
+    | High
+    | Medium
+    | Low
+    | Stale
+
+  let to_string = function
+    | Critical -> "critical"
+    | High -> "high"
+    | Medium -> "medium"
+    | Low -> "low"
+    | Stale -> "stale"
+
+  let of_string = function
+    | "critical" -> Some Critical
+    | "high" -> Some High
+    | "medium" -> Some Medium
+    | "low" -> Some Low
+    | "stale" -> Some Stale
+    | _ -> None
+
+  let all = [ Critical; High; Medium; Low; Stale ]
+end

--- a/lib/coord/event_kind.mli
+++ b/lib/coord/event_kind.mli
@@ -65,3 +65,18 @@ module Board : sig
   val of_string : string -> t option
   val all : t list
 end
+
+module Relevance : sig
+  type t =
+    | Critical
+    | High
+    | Medium
+    | Low
+    | Stale
+
+  val to_string : t -> string
+  (** Canonical broadcast relevance label (e.g. [medium]). *)
+
+  val of_string : string -> t option
+  val all : t list
+end

--- a/lib/dashboard/dashboard_execution.ml
+++ b/lib/dashboard/dashboard_execution.ml
@@ -474,8 +474,13 @@ let message_json (message : Masc_domain.message) =
   `Assoc
     [
       ("from", `String message.from_agent);
+      ("type", `String message.msg_type);
       ("content", `String message.content);
+      ("mention", Json_util.string_opt_to_json message.mention);
       ("timestamp", `String message.timestamp);
+      ("trace_context", Json_util.string_opt_to_json message.trace_context);
+      ("expires_at", Json_util.float_opt_to_json message.expires_at);
+      ("relevance", `String message.relevance);
       ("seq", `Int message.seq);
     ]
 

--- a/lib/dashboard/dashboard_rooms.ml
+++ b/lib/dashboard/dashboard_rooms.ml
@@ -144,8 +144,12 @@ let message_json (msg : Masc_domain.message) =
     ; "room_id", `String default_room_id
     ; "ts", `String msg.timestamp
     ; "sender", `String msg.from_agent
+    ; "type", `String msg.msg_type
     ; "body", `String body
     ; "mentions", `List (List.map (fun target -> `String target) mentions)
+    ; ( "expires_at"
+      , match msg.expires_at with Some value -> `Float value | None -> `Null )
+    ; "relevance", `String msg.relevance
     ]
   in
   let fields =

--- a/lib/graphql_api.ml
+++ b/lib/graphql_api.ml
@@ -375,6 +375,14 @@ let message_typ =
         ~typ:(Schema.non_null Schema.string)
         ~args:Arg.[]
         ~resolve:(fun _ (message : Masc_domain.message) -> message.timestamp);
+      Schema.field "expiresAt"
+        ~typ:Schema.float
+        ~args:Arg.[]
+        ~resolve:(fun _ (message : Masc_domain.message) -> message.expires_at);
+      Schema.field "relevance"
+        ~typ:(Schema.non_null Schema.string)
+        ~args:Arg.[]
+        ~resolve:(fun _ (message : Masc_domain.message) -> message.relevance);
     ]
 
 let room_state_typ =

--- a/lib/server/server_dashboard_http_core.ml
+++ b/lib/server/server_dashboard_http_core.ml
@@ -752,8 +752,13 @@ let dashboard_message_json (message : Masc_domain.message) =
   `Assoc
     [
       ("from", `String message.from_agent);
+      ("type", `String message.msg_type);
       ("content", `String message.content);
+      ("mention", Json_util.string_opt_to_json message.mention);
       ("timestamp", `String message.timestamp);
+      ("trace_context", Json_util.string_opt_to_json message.trace_context);
+      ("expires_at", Json_util.float_opt_to_json message.expires_at);
+      ("relevance", `String message.relevance);
       ("seq", `Int message.seq);
     ]
 

--- a/lib/server/server_routes_http_routes_room.ml
+++ b/lib/server/server_routes_http_routes_room.ml
@@ -118,12 +118,17 @@ module Keeper_stream = Server_routes_http_keeper_stream
          let total = List.length filtered in
          let page = filtered |> List.filteri (fun idx _ -> idx < limit) in
          let msgs_json = List.map (fun (m : Masc_domain.message) ->
-           `Assoc [
-             ("from", `String m.from_agent);
-             ("content", `String m.content);
-             ("timestamp", `String m.timestamp);
-             ("seq", `Int m.seq);
-           ]
+             `Assoc [
+               ("from", `String m.from_agent);
+               ("type", `String m.msg_type);
+               ("content", `String m.content);
+               ("mention", Json_util.string_opt_to_json m.mention);
+               ("timestamp", `String m.timestamp);
+               ("trace_context", Json_util.string_opt_to_json m.trace_context);
+               ("expires_at", Json_util.float_opt_to_json m.expires_at);
+               ("relevance", `String m.relevance);
+               ("seq", `Int m.seq);
+             ]
          ) page in
          let json = `Assoc [
            ("messages", `List msgs_json);

--- a/lib/types/types_core.ml
+++ b/lib/types/types_core.ml
@@ -660,6 +660,8 @@ type message = {
   mention: string option; [@default None]
   timestamp: string;
   trace_context: string option; [@default None]
+  expires_at: float option; [@default None]
+  relevance: string; [@default "medium"]
 } [@@deriving yojson { strict = false }, show]
 
 (** Coord state *)

--- a/test/test_dashboard_http_core.ml
+++ b/test/test_dashboard_http_core.ml
@@ -420,6 +420,30 @@ let test_verifier_of_request_canonicalizes_token_owner () =
       check string "verification verifier canonicalized to token owner"
         "operator:codex" verifier
 
+let test_dashboard_message_json_surfaces_temporal_decay_fields () =
+  let message : Types.message =
+    {
+      seq = 7;
+      from_agent = "operator";
+      msg_type = "broadcast";
+      content = "hello";
+      mention = None;
+      timestamp = "2026-05-07T00:00:00Z";
+      trace_context = Some "traceparent";
+      expires_at = Some 1_714_067_200.0;
+      relevance = "critical";
+    }
+  in
+  let json = Lib.Server_dashboard_http_core.dashboard_message_json message in
+  let open Yojson.Safe.Util in
+  check string "type" "broadcast" (json |> member "type" |> to_string);
+  check string "trace_context" "traceparent"
+    (json |> member "trace_context" |> to_string);
+  check (float 0.001) "expires_at" 1_714_067_200.0
+    (json |> member "expires_at" |> to_float);
+  check string "relevance" "critical"
+    (json |> member "relevance" |> to_string)
+
 let () =
   run "dashboard_http_core"
     [
@@ -451,5 +475,7 @@ let () =
             test_execution_actor_for_request_canonicalizes_token_owner;
           test_case "verification verifier canonicalizes token owner" `Quick
             test_verifier_of_request_canonicalizes_token_owner;
+          test_case "message JSON exposes temporal decay fields" `Quick
+            test_dashboard_message_json_surfaces_temporal_decay_fields;
         ] );
     ]

--- a/test/test_dashboard_rooms.ml
+++ b/test/test_dashboard_rooms.ml
@@ -64,6 +64,12 @@ let test_rooms_projection_includes_messages_and_mentions () =
     (List.mem "sangsu" (string_list_field "participants" room));
   let first = List.hd messages in
   Alcotest.(check string) "first sender" "operator" (string_field "sender" first);
+  Alcotest.(check string) "first type" "broadcast" (string_field "type" first);
+  Alcotest.(check string) "first relevance" "medium" (string_field "relevance" first);
+  Alcotest.(check bool)
+    "first expires_at null"
+    true
+    Yojson.Safe.Util.(first |> member "expires_at" = `Null);
   Alcotest.(check (list string))
     "mentions"
     [ "sangsu" ]

--- a/test/test_event_kind.ml
+++ b/test/test_event_kind.ml
@@ -99,4 +99,32 @@ let () =
         exit 1
       end)
     Event_kind.Board.all;
+  (* Relevance family: broadcast temporal decay schema labels. *)
+  List.iter
+    (fun v ->
+      let s = Event_kind.Relevance.to_string v in
+      match Event_kind.Relevance.of_string s with
+      | Some v' when v' = v -> ()
+      | Some _ ->
+          Printf.eprintf
+            "event_kind Relevance roundtrip mismatch for %s\n%!" s;
+          exit 1
+      | None ->
+          Printf.eprintf
+            "event_kind Relevance of_string returned None for %s\n%!" s;
+          exit 1)
+    Event_kind.Relevance.all;
+  (match Event_kind.Relevance.of_string "meduim" with
+   | Some _ ->
+       prerr_endline "event_kind Relevance.of_string accepted a typo";
+       exit 1
+   | None -> ());
+  let relevance_names =
+    List.map Event_kind.Relevance.to_string Event_kind.Relevance.all
+  in
+  let unique_relevance_names = List.sort_uniq String.compare relevance_names in
+  if List.length relevance_names <> List.length unique_relevance_names then begin
+    prerr_endline "event_kind Relevance contains duplicate wire labels";
+    exit 1
+  end;
   print_endline "test_event_kind: OK"

--- a/test/test_graphql_api.ml
+++ b/test/test_graphql_api.ml
@@ -65,10 +65,46 @@ let test_tasks_connection () =
   Alcotest.(check string) "title" "GraphQL task" title;
   cleanup_dir base_path
 
+let test_messages_temporal_decay_fields () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let base_path = temp_dir () in
+  let config = Coord_utils.default_config base_path in
+  let _ = Coord.init config ~agent_name:None in
+  let _ =
+    Coord.broadcast config ~from_agent:"operator" ~content:"hello @sangsu"
+  in
+  let json =
+    graphql_query config
+      "{ messages(first: 10) { totalCount edges { node { from messageType content mention expiresAt relevance } } } }"
+  in
+  let open Yojson.Safe.Util in
+  let total = json |> member "data" |> member "messages" |> member "totalCount" |> to_int in
+  let edges = json |> member "data" |> member "messages" |> member "edges" |> to_list in
+  let node =
+    match edges with
+    | first :: _ -> first |> member "node"
+    | [] -> Alcotest.fail "missing message edge"
+  in
+  Alcotest.(check int) "totalCount" 1 total;
+  Alcotest.(check string) "from" "operator" (node |> member "from" |> to_string);
+  Alcotest.(check string) "messageType" "broadcast"
+    (node |> member "messageType" |> to_string);
+  Alcotest.(check string) "content" "hello @sangsu"
+    (node |> member "content" |> to_string);
+  Alcotest.(check string) "mention" "sangsu"
+    (node |> member "mention" |> to_string);
+  Alcotest.(check bool) "expiresAt null" true
+    (node |> member "expiresAt" = `Null);
+  Alcotest.(check string) "relevance" "medium"
+    (node |> member "relevance" |> to_string);
+  cleanup_dir base_path
+
 let () =
   let open Alcotest in
   run "Graphql_api"
     [
       ("status", [test_case "status query" `Quick test_status_query]);
       ("tasks", [test_case "tasks connection" `Quick test_tasks_connection]);
+      ("messages", [test_case "temporal decay fields" `Quick test_messages_temporal_decay_fields]);
     ]

--- a/test/test_keeper_memory.ml
+++ b/test/test_keeper_memory.ml
@@ -34,6 +34,8 @@ let room_message content =
     content;
     mention = None;
     timestamp = "2026-03-12T00:00:00Z"; trace_context = None;
+    expires_at = None;
+    relevance = "medium";
   }
 
 let test_any_mentioned_exact_target () =

--- a/test/test_types.ml
+++ b/test/test_types.ml
@@ -50,13 +50,36 @@ let test_message_roundtrip () =
     mention = Some "gemini";
     timestamp = "2024-01-01T00:00:00Z";
     trace_context = None;
+    expires_at = Some 1704067200.0;
+    relevance = "high";
   } in
   let json = message_to_yojson msg in
   match message_of_yojson json with
   | Ok parsed ->
       Alcotest.(check int) "seq" 1 parsed.seq;
       Alcotest.(check string) "from" "claude" parsed.from_agent;
-      Alcotest.(check (option string)) "mention" (Some "gemini") parsed.mention
+      Alcotest.(check (option string)) "mention" (Some "gemini") parsed.mention;
+      Alcotest.(check (option (float 0.001))) "expires_at"
+        (Some 1704067200.0) parsed.expires_at;
+      Alcotest.(check string) "relevance" "high" parsed.relevance
+  | Error e -> Alcotest.fail e
+
+let test_message_temporal_decay_defaults () =
+  let json =
+    `Assoc [
+      ("seq", `Int 2);
+      ("from", `String "gemini");
+      ("type", `String "broadcast");
+      ("content", `String "status ping");
+      ("timestamp", `String "2024-01-01T00:00:00Z");
+    ]
+  in
+  match message_of_yojson json with
+  | Ok parsed ->
+      Alcotest.(check (option (float 0.001))) "expires_at default" None
+        parsed.expires_at;
+      Alcotest.(check string) "relevance default" "medium"
+        parsed.relevance
   | Error e -> Alcotest.fail e
 
 let test_parse_iso8601_epoch_utc () =
@@ -288,6 +311,8 @@ let () =
     ];
     "message", [
       Alcotest.test_case "roundtrip" `Quick test_message_roundtrip;
+      Alcotest.test_case "temporal decay defaults" `Quick
+        test_message_temporal_decay_defaults;
     ];
     "timestamp", [
       Alcotest.test_case "parse utc epoch" `Quick test_parse_iso8601_epoch_utc;


### PR DESCRIPTION
## Summary

- Add `Event_kind.Relevance` as the typed SSOT for broadcast relevance labels: `critical`, `high`, `medium`, `low`, `stale`.
- Extend `Masc_domain.message` with backward-compatible temporal decay fields: `expires_at: float option` and `relevance: string`, defaulting old message JSON to `None` / `medium`.
- Surface the new fields through broadcast persistence, dashboard rooms/execution message JSON, dashboard HTTP message JSON, `/api/v1/messages`, and GraphQL `Message.expiresAt` / `Message.relevance`.

## Product impact

Operators and future keeper/backpressure logic now have a stable message-level schema for temporal relevance without breaking old message JSON. This gives #11329 a typed foundation before implementing decay scoring or cascade-storm behavior.

## Scope

This is PR-1 for #11329: schema and API surface only. It does not implement decay scoring, backpressure decisions, stale-claim filtering, or cascade-storm throttling behavior.

## Evidence

- `git diff --check`
- `git diff --cached --check`
- `env DUNE_JOBS=1 MASC_SKIP_OPAM_LOCK=1 MASC_SKIP_PIN_CHECK=1 dune build --root . test/test_dashboard_rooms.exe test/test_dashboard_http_core.exe test/test_graphql_api.exe test/test_event_kind.exe test/test_types.exe test/test_keeper_memory.exe`
- `./_build/default/test/test_event_kind.exe`
- `env MASC_SKIP_PIN_CHECK=1 ./_build/default/test/test_types.exe`
- `env MASC_SKIP_PIN_CHECK=1 ./_build/default/test/test_keeper_memory.exe`
- `env MASC_SKIP_PIN_CHECK=1 ./_build/default/test/test_dashboard_rooms.exe`
- `env MASC_SKIP_PIN_CHECK=1 ./_build/default/test/test_dashboard_http_core.exe`
- `env MASC_SKIP_PIN_CHECK=1 ./_build/default/test/test_graphql_api.exe`

## Review evidence

Review focus: confirm the new broadcast relevance labels are the desired canonical wire strings, and confirm adding nullable/defaulted fields to the message JSON surfaces is acceptable for existing dashboard/API clients.

## Local Caveats

- `ocamlformat --check ...` still exits 1 with no diagnostics on touched files, matching existing repo style behavior observed before this branch.
- `env DUNE_JOBS=1 MASC_SKIP_OPAM_LOCK=1 MASC_SKIP_PIN_CHECK=1 dune build --root . bin/main_eio.exe ...` is blocked by an unrelated existing `bin/main_eio.ml` partial application around `board_post_detail_json`.
- `env MASC_SKIP_PIN_CHECK=1 ./_build/default/test/test_dashboard_execution.exe` fails locally on `primary model surfaced on execution keeper row` after repeated `cascade config resolve failed` warnings; the failing assertion is outside this PR's message JSON path.

## Linked issue

Refs #11329. This PR intentionally covers only the schema/API surface; behavior work should follow in separate PRs.
