### PR TITLE
fix: count heartbeat history read drops

### DIFF
--- a/lib/keeper/keeper_heartbeat_snapshot.ml
+++ b/lib/keeper/keeper_heartbeat_snapshot.ml
@@ -26,6 +26,19 @@ let keepalive_interval_sec () =
 (* ── Heartbeat history fallback read limits ── *)
 let max_history_read_bytes = 256 * 1024
 let max_history_read_lines = 200
+let heartbeat_history_persistence_surface = "keeper_heartbeat_history"
+
+let report_heartbeat_history_drop ~reason ~path ~detail =
+  Safe_ops.report_persistence_read_drop
+    ~on_drop:(fun () ->
+      Prometheus.inc_counter Prometheus.metric_persistence_read_drops
+        ~labels:[("surface", heartbeat_history_persistence_surface); ("reason", reason)]
+        ())
+    ~surface:heartbeat_history_persistence_surface
+    ~reason
+    ~path
+    ~detail
+;;
 
 let status_tick_usage_json () =
   `Assoc
@@ -99,10 +112,19 @@ let write_heartbeat_snapshot
            |> List.concat_map (fun path ->
                 read_file_tail_lines path
                   ~max_bytes:max_history_read_bytes
-                  ~max_lines:max_history_read_lines)
-           |> List.filter_map (fun line ->
+                  ~max_lines:max_history_read_lines
+                |> List.filter_map (fun line ->
              try
-               let json = Yojson.Safe.from_string line in
+               let json =
+                 match Yojson.Safe.from_string line with
+                 | `Assoc _ as json -> json
+                 | _ ->
+                   report_heartbeat_history_drop
+                     ~reason:Safe_ops.persistence_read_drop_reason_invalid_payload
+                     ~path
+                     ~detail:"history row is not a JSON object";
+                   raise Exit
+               in
                let source =
                  Safe_ops.json_string ~default:"" "source" json |> String.trim
                in
@@ -114,9 +136,30 @@ let write_heartbeat_snapshot
                else Some (Keeper_context_core.message_of_json json)
              with
              | Eio.Cancel.Cancelled _ as e -> raise e
-             | _exn ->
+             | Exit ->
                incr parse_errors;
-               None)
+               None
+             | Yojson.Json_error detail ->
+               incr parse_errors;
+               report_heartbeat_history_drop
+                 ~reason:Safe_ops.persistence_read_drop_reason_entry_load_error
+                 ~path
+                 ~detail;
+               None
+             | Yojson.Safe.Util.Type_error (detail, _) ->
+               incr parse_errors;
+               report_heartbeat_history_drop
+                 ~reason:Safe_ops.persistence_read_drop_reason_invalid_payload
+                 ~path
+                 ~detail;
+               None
+             | exn ->
+               incr parse_errors;
+               report_heartbeat_history_drop
+                 ~reason:Safe_ops.persistence_read_drop_reason_invalid_payload
+                 ~path
+                 ~detail:(Printexc.to_string exn);
+               None))
          with
          | Eio.Cancel.Cancelled _ as e -> raise e
          | exn ->

--- a/test/test_keeper_lifecycle.ml
+++ b/test/test_keeper_lifecycle.ml
@@ -6,6 +6,7 @@ module KAR = Masc_mcp.Keeper_agent_run
 module KMP = Masc_mcp.Keeper_memory_policy
 module KT = Masc_mcp.Keeper_types
 module KR = Masc_mcp.Keeper_registry
+module KHB = Masc_mcp.Keeper_heartbeat_snapshot
 module KHS = Masc_mcp.Keeper_keepalive_signal
 module KST = Masc_mcp.Keeper_state_machine
 module KCB = Masc_mcp.Keeper_turn_cascade_budget
@@ -31,6 +32,29 @@ let cleanup_dir dir =
         Unix.unlink path
   in
   try rm dir with _ -> ()
+
+let write_lines path lines =
+  KT.mkdir_p (Filename.dirname path);
+  let oc = open_out path in
+  Fun.protect
+    ~finally:(fun () -> close_out_noerr oc)
+    (fun () ->
+      List.iter
+        (fun line ->
+          output_string oc line;
+          output_char oc '\n')
+        lines)
+
+let persistence_read_drop_total ~surface ~reason =
+  P.metric_value_or_zero P.metric_persistence_read_drops
+    ~labels:[("surface", surface); ("reason", reason)]
+    ()
+
+let check_persistence_read_drop_delta ~surface ~reason ~before ~delta =
+  check (float 0.0001)
+    (Printf.sprintf "%s/%s persistence read drops" surface reason)
+    (before +. float_of_int delta)
+    (persistence_read_drop_total ~surface ~reason)
 
 let with_env key value f =
   let prev = Sys.getenv_opt key in
@@ -2560,6 +2584,67 @@ let test_keepalive_dispatch_event_rejection_increments_metric () =
       check bool "keepalive registry rejection metric increments" true
         (after > before))
 
+let test_heartbeat_history_fallback_counts_malformed_rows () =
+  let base_dir = temp_dir "keeper_lifecycle_heartbeat_history_drops" in
+  Fun.protect
+    ~finally:(fun () ->
+      KR.clear ();
+      cleanup_dir base_dir)
+    (fun () ->
+      Eio_main.run @@ fun env ->
+      Eio.Switch.run @@ fun sw ->
+      Fs_compat.set_fs (Eio.Stdenv.fs env);
+      KR.clear ();
+      let config = Masc_mcp.Coord.default_config base_dir in
+      ignore (Masc_mcp.Coord.init config ~agent_name:None);
+      let meta =
+        make_keeper_meta
+          ~name:"keeper-heartbeat-history-drop"
+          ~trace_id:"trace-heartbeat-history-drop"
+          ()
+      in
+      ignore (KR.register ~base_path:config.base_path meta.name meta);
+      let trace_id =
+        Masc_mcp.Keeper_id.Trace_id.to_string meta.runtime.trace_id
+      in
+      let history_path = KT.keeper_history_path config trace_id in
+      write_lines history_path
+        [
+          {|{"role":"user","content":"keep continuity","source":"user"}|};
+          "[]";
+          "{not-json";
+        ];
+      let surface = "keeper_heartbeat_history" in
+      let entry_reason = "entry_load_error" in
+      let invalid_reason = "invalid_payload" in
+      let before_entry =
+        persistence_read_drop_total ~surface ~reason:entry_reason
+      in
+      let before_invalid =
+        persistence_read_drop_total ~surface ~reason:invalid_reason
+      in
+      let ctx : _ KT.context =
+        {
+          config;
+          agent_name = "test-operator";
+          sw;
+          clock = Eio.Stdenv.clock env;
+          proc_mgr = Some (Eio.Stdenv.process_mgr env);
+          net = None;
+        }
+      in
+      KHB.write_heartbeat_snapshot
+        ~ctx
+        ~meta_current:meta
+        ~now_ts:(Time_compat.now ())
+        ~consecutive_hb_failures:0
+        ~timing_ring:[||]
+        ~timing_filled:0;
+      check_persistence_read_drop_delta ~surface ~reason:entry_reason
+        ~before:before_entry ~delta:1;
+      check_persistence_read_drop_delta ~surface ~reason:invalid_reason
+        ~before:before_invalid ~delta:1)
+
 let () =
   run "keeper_lifecycle"
     [
@@ -2678,5 +2763,7 @@ let () =
             test_dispatch_keeper_phase_event_rejection_increments_metric;
           test_case "keepalive event rejection increments metric" `Quick
             test_keepalive_dispatch_event_rejection_increments_metric;
+          test_case "heartbeat history fallback counts malformed rows" `Quick
+            test_heartbeat_history_fallback_counts_malformed_rows;
         ] );
     ]


### PR DESCRIPTION
## Summary
- count malformed heartbeat history fallback rows in masc_persistence_read_drops_total
- preserve the existing keeper heartbeat failure counter for aggregate parse failures
- add a regression that drives write_heartbeat_snapshot through malformed history.jsonl rows

## Verification
- git diff --check
- lockf -k -t 1200 /tmp/me-dune-local.lock env MASC_DUNE_LOCK_HELD=1 MASC_SKIP_OPAM_LOCK=1 DUNE_JOBS=1 DUNE_CACHE=disabled scripts/dune-local.sh build test/test_keeper_lifecycle.exe
- ./_build/default/test/test_keeper_lifecycle.exe