### PR TITLE
refactor(prometheus): bind histogram head metric in pattern instead of List.hd

### DIFF
--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -2882,7 +2882,7 @@ let to_prometheus_text () =
     else
     match ms with
     | [] -> ()
-    | _ :: _ ->
+    | (head_metric :: _) as ms ->
       (* Pick HELP deterministically from the unlabeled parent row that
          [register_histogram] created at startup; without this, the
          exported HELP becomes nondeterministically either the real
@@ -2907,9 +2907,8 @@ let to_prometheus_text () =
            | Some m -> m.help
            | None -> name)
       in
-      let m = List.hd ms in
       Printf.bprintf buf "# HELP %s %s\n" name chosen_help;
-      (match m.metric_type with
+      (match head_metric.metric_type with
        | Histogram ->
          (* No bucket distribution is tracked, so emit as summary
             (sum + count) which is the closest valid Prometheus type. *)
@@ -2930,7 +2929,8 @@ let to_prometheus_text () =
          ) ms
        | _ ->
          Buffer.add_string buf
-           (Printf.sprintf "# TYPE %s %s\n" name (type_to_string m.metric_type));
+           (Printf.sprintf "# TYPE %s %s\n" name
+              (type_to_string head_metric.metric_type));
          List.iter (fun (metric : metric) ->
            Printf.bprintf buf "%s%s %g\n"
              metric.name (labels_to_string metric.labels) metric.value


### PR DESCRIPTION
## Summary

Replace `let m = List.hd ms in` in the histogram-export hot path with a head-binding pattern (`(head_metric :: _) as ms`).  Two call sites (`head_metric.metric_type` lookups) updated; `ms` retained where the full list is iterated.

## Why

The block was structured as:

```ocaml
match ms with
| [] -> ()
| _ :: _ ->
  ...
  let m = List.hd ms in
  ...
```

The runtime call was *safe* because the outer pattern already proved `ms` is non-empty.  But `List.hd` is a partial function (`Failure "hd"` on `[]`), so the safety relied on a *runtime fact* the type system could not verify.  Pattern-binding the head at the match site moves the invariant into the type level and removes the partial function from a hot path that runs on every metrics scrape.

This is the standard OCaml-best-practice replacement for `List.hd` when an outer pattern has already discriminated on emptiness — same axis as the project's existing avoidance of `List.hd_opt` shells in places where the pattern can carry the value.

## Validation

- `dune build --root . lib/` — exit 0.
- `dune build --root . test/test_prometheus_coverage.exe` — exit 0.
- `./_build/default/test/test_prometheus_coverage.exe test` — 60/60 OK.
- `git diff --stat` — `lib/prometheus.ml | 8 ++++----` (single file, +4/-4).

## RFC

Not required.  `lib/prometheus.ml` is not in the CLAUDE.md `agent_delegation` RFC-gated list (credential / identity / operator-control / sandbox / dashboard-credential / hooks / workflow).  Pure shape refactor with no public API change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)