### PR TITLE
feat(cascade): per-class cooldown policy (RFC-0037 §4.5)

### DIFF
--- a/lib/cascade/cascade_health_tracker.ml
+++ b/lib/cascade/cascade_health_tracker.ml
@@ -100,6 +100,41 @@ let cooldown_sec =
     ~default:30.0
     ()
 
+(** RFC-0037 §4.5: local providers (ollama, llama.cpp, etc.) get a
+    more generous failure budget than remote APIs.  Local probes are
+    flaky by nature (process startup, model load latency, transient
+    /api/ps stalls) but recover within seconds — locking them out for
+    the full [cooldown_sec] window denies the keeper a viable provider
+    when the remote alternatives are also failing.
+
+    Defaults: 5 consecutive failures (vs remote 3), 10s cooldown (vs
+    remote 30s).  Both are env-tunable and floored at 1 / 1.0
+    respectively to prevent zero-value misconfiguration from disabling
+    cooldown entirely.
+
+    Provider classification uses {!Provider_adapter.is_local_provider},
+    the same primitive cascade_runtime already consumes — no new
+    classifier introduced. *)
+let local_cooldown_threshold =
+  Int.max 1
+    (read_int_setting
+       ~primary:"MASC_LOCAL_COOLDOWN_THRESHOLD"
+       ~default:5
+       ())
+
+let local_cooldown_sec =
+  Float.max 1.0
+    (read_float_setting
+       ~primary:"MASC_LOCAL_COOLDOWN_SEC"
+       ~default:10.0
+       ())
+
+let cooldown_config_for ~provider_key =
+  if Provider_adapter.is_local_provider provider_key then
+    (local_cooldown_threshold, local_cooldown_sec)
+  else
+    (cooldown_threshold, cooldown_sec)
+
 (** Cooldown duration for provider calls classified as hard-quota exhaustion
     (account balance depleted, monthly quota reached, resource exhausted).
     Unlike transient 429s, hard-quota errors will not recover within a short
@@ -495,12 +530,13 @@ let record t ~provider_key ~outcome ?error_kind ?error_reason
          [provider_info] can count Rejected separately for dashboards. *)
       state.consecutive_failures <- state.consecutive_failures + 1;
       bump_failure_fp ();
-      if state.consecutive_failures >= cooldown_threshold then begin
-        let new_until = now +. cooldown_sec in
+      let (threshold, cooldown_dur) = cooldown_config_for ~provider_key in
+      if state.consecutive_failures >= threshold then begin
+        let new_until = now +. cooldown_dur in
         if new_until > state.cooldown_until then begin
           state.cooldown_until <- new_until;
           Prometheus.observe_histogram Prometheus.metric_keeper_provider_block_duration_sec
-            ~labels:[("provider", provider_key)] cooldown_sec
+            ~labels:[("provider", provider_key)] cooldown_dur
         end
       end
     | Soft_rate_limited ->

--- a/test/test_cascade_health_tracker.ml
+++ b/test/test_cascade_health_tracker.ml
@@ -41,6 +41,42 @@ let test_cooldown_after_threshold () =
   check bool "cooldown trips after 3 consecutive failures"
     true (H.is_in_cooldown t ~provider_key:"p")
 
+(* RFC-0037 §4.5: local providers (ollama, llama.cpp) get a more
+   generous failure budget than remote APIs.  Remote default is
+   3 fails / 30s; local default is 5 fails / 10s. *)
+
+let test_local_provider_threshold_higher_than_remote () =
+  let t = H.create () in
+  H.record_failure t ~provider_key:"ollama" ();
+  H.record_failure t ~provider_key:"ollama" ();
+  H.record_failure t ~provider_key:"ollama" ();
+  H.record_failure t ~provider_key:"ollama" ();
+  check bool "ollama not yet in cooldown after 4 failures (remote would be)"
+    false (H.is_in_cooldown t ~provider_key:"ollama");
+  H.record_failure t ~provider_key:"ollama" ();
+  check bool "ollama enters cooldown at 5 failures"
+    true (H.is_in_cooldown t ~provider_key:"ollama")
+
+let test_remote_provider_threshold_unchanged () =
+  let t = H.create () in
+  H.record_failure t ~provider_key:"claude" ();
+  H.record_failure t ~provider_key:"claude" ();
+  check bool "claude not in cooldown after 2 failures"
+    false (H.is_in_cooldown t ~provider_key:"claude");
+  H.record_failure t ~provider_key:"claude" ();
+  check bool "claude enters cooldown at 3 failures (existing default)"
+    true (H.is_in_cooldown t ~provider_key:"claude")
+
+let test_unknown_provider_uses_remote_threshold () =
+  (* Defensive: a provider name not registered in Provider_adapter
+     defaults to the conservative (remote) threshold. *)
+  let t = H.create () in
+  H.record_failure t ~provider_key:"unknown_xyz" ();
+  H.record_failure t ~provider_key:"unknown_xyz" ();
+  H.record_failure t ~provider_key:"unknown_xyz" ();
+  check bool "unknown provider treated as remote (cools at 3)"
+    true (H.is_in_cooldown t ~provider_key:"unknown_xyz")
+
 let test_success_resets_streak () =
   let t = H.create () in
   H.record_failure t ~provider_key:"p" ();
@@ -806,6 +842,12 @@ let () =
         test_terminal_failure_preserves_longer_existing_cooldown;
       test_case "terminal_failure records fingerprint" `Quick
         test_terminal_failure_records_fingerprint;
+      test_case "RFC-0037 §4.5: local provider threshold is generous (5 vs 3)" `Quick
+        test_local_provider_threshold_higher_than_remote;
+      test_case "RFC-0037 §4.5: remote provider threshold unchanged (3)" `Quick
+        test_remote_provider_threshold_unchanged;
+      test_case "RFC-0037 §4.5: unknown provider treated as remote" `Quick
+        test_unknown_provider_uses_remote_threshold;
     ];
     "soft_rate_limit", [
       test_case "single 429 trips immediate cooldown" `Quick


### PR DESCRIPTION
## Summary

Implements RFC-0037 §4.5 (tag **H** — harness layer). Local providers (ollama, llama.cpp, custom) now have a more generous failure budget than remote APIs.

**Before**: uniform 3 fails / 30s cooldown for all providers.
**After**: local providers 5 fails / 10s; remote unchanged 3 / 30.

## Why

Local probes are flaky by nature (process startup, model load latency, transient `/api/ps` stalls) but typically recover within seconds. A uniform 30s lockout after 3 fails turned a recoverable local hiccup into 30s of lost capacity — and ollama is often the *only* viable provider when remote alternatives are also failing (the entire point of having a local fallback).

## Reuses existing primitive

Classifier is `Provider_adapter.is_local_provider` (already at `lib/provider_adapter.mli:221`, already consumed by `cascade_runtime`). No new classifier introduced.

## Knobs

Per RFC-0032 catalog:

| Knob | Default | Floor | Purpose |
|------|---------|-------|---------|
| `MASC_LOCAL_COOLDOWN_THRESHOLD` | 5 | 1 | local fail count before cooldown |
| `MASC_LOCAL_COOLDOWN_SEC` | 10.0 | 1.0 | local cooldown duration |

Existing `MASC_CASCADE_COOLDOWN_THRESHOLD` / `MASC_CASCADE_COOLDOWN_SEC` apply unchanged to remote providers.

## Test plan

- [x] `dune build --root . lib` clean
- [x] 57/57 tests pass in `test_cascade_health_tracker` (54 existing + 3 new)
  - ollama survives 4 fails, cools at 5
  - claude unchanged at 3
  - unknown provider defaults to remote semantics (conservative)
- [ ] CI green
- [ ] Manual: under simulated ollama 4-fail burst, dashboard shows ollama still selectable

## RFC

References RFC-0037 §4.5 (PR #14108). RFC defines this as Phase 1 / tag **H** — harness layer change, no SSOT modification, no further RFC gate beyond #14108 approval.

## Layer classification

**H (harness)** — operator does not see this knob in normal use; defaults are tuned so local Ollama Just Works. Knobs are operator escape hatch only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>