### PR TITLE
feat(cascade): warn-once on partial Eio_context (RFC-0037 §4.3)

### DIFF
--- a/lib/cascade/cascade_runtime.ml
+++ b/lib/cascade/cascade_runtime.ml
@@ -62,6 +62,26 @@ let labels_require_local_discovery (labels : string list) : bool =
       | None -> false)
     labels
 
+(* RFC-0037 §4.3: surface partial Eio_context as a loud, warn-once
+   diagnostic instead of a silent skip.  The Provider_registry public
+   API on this module's downstream (Llm_provider) requires both [sw]
+   and [net] to probe — there is no register-without-probe path — so
+   we cannot register a fallback endpoint here.  What we *can* do is
+   tell the operator exactly why local discovery did not run, so they
+   can fix their bootstrap (typically: ensure [Eio_context] is
+   populated before the first cascade attempt that requires
+   discovery). *)
+let local_discovery_warned = Atomic.make false
+
+let warn_partial_eio_context_once ~sw_some ~net_some =
+  if not (Atomic.exchange local_discovery_warned true) then
+    Log.warn ~ctx:"CascadeRuntime"
+      "Local discovery skipped: Eio_context partial (sw=%b net=%b). \
+       Local providers (ollama, llama.cpp) will not be auto-discovered. \
+       Ensure Eio_context.set_switch and set_net run before the first \
+       cascade attempt that requires local discovery. (RFC-0037 §4.3)"
+      sw_some net_some
+
 let refresh_local_discovery_if_possible ?sw ?net (labels : string list) : bool =
   if not (labels_require_local_discovery labels) then false
   else
@@ -95,7 +115,11 @@ let refresh_local_discovery_if_possible ?sw ?net (labels : string list) : bool =
                "local runtime discovery refresh failed: %s"
                (Printexc.to_string exn);
              false)
-    | _ -> false
+    | _ ->
+        warn_partial_eio_context_once
+          ~sw_some:(Option.is_some sw)
+          ~net_some:(Option.is_some net);
+        false
 
 let context_floor = 4_096
 


### PR DESCRIPTION
## Summary

Implements RFC-0037 §4.3 (tag **H** — harness layer). Replace silent-skip with a one-shot WARN when `refresh_local_discovery_if_possible` runs but `Eio_context` lacks either switch or net.

## Why scope is visibility-only (not register-fallback)

The RFC originally proposed registering a fallback endpoint in this code path. Investigation showed `Llm_provider.Provider_registry`'s public API on this module's downstream requires both `~sw` and `~net` to probe — there is no register-without-probe entry point exposed to masc-mcp. So the realistic surgical change is **diagnostic visibility**: tell the operator exactly why discovery did not run.

This unblocks the operator-facing problem (silent ollama auto-discovery failure) without taking on the larger SDK work of adding a register-without-probe API.

## Behavior

```
Old: silent return false (no log)
New: first call:  Log.warn "Local discovery skipped: Eio_context partial (sw=true net=false). Local providers will not be auto-discovered. Ensure Eio_context.set_switch and set_net run before the first cascade attempt that requires local discovery. (RFC-0037 §4.3)"
     subsequent:  silent return false (warn-once via Atomic.exchange)
```

## Test plan

- [x] `dune build --root . lib` clean
- [x] `test_cascade_runtime` still passes its 6 tests; 3 pre-existing failures in `provider_filter 4/5/6` (gemini_cli runtime MCP) confirmed unrelated by stashing my change and re-running on origin/main with same 3 failures
- [ ] CI green
- [ ] Manual: operator running ollama-only setup with broken bootstrap sees the WARN line in logs once, can act on it

## RFC

References RFC-0037 §4.3 (PR #14108). RFC scope updated to match implementation reality (visibility, not register-fallback).

## Layer classification

**H (harness)** — operator does not interact with this directly; the WARN line is diagnostic when something the harness should auto-handle is mis-bootstrapped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>