### PR TITLE
refactor(chronicle_ingest): encode non-empty commits invariant in make_candidate signature

### DIFF
--- a/lib/chronicle_ingest.ml
+++ b/lib/chronicle_ingest.ml
@@ -229,24 +229,27 @@ and within_days d1 d2 days =
     abs (to_days y1 m1 day1 - to_days y2 m2 day2) <= days
   | _ -> false
 
-(* Build a candidate_epoch from a group of commits. *)
-let make_candidate commits =
-  match commits with
-  | [] -> assert false
-  | first :: rest ->
-    let last = List.fold_left (fun _ ev -> ev) first rest in
-    let all_goals =
-      commits
-      |> List.map extract_goal_ids
-      |> List.concat
-      |> List.sort_uniq String.compare
-    in
-    let all_files =
-      commits
-      |> List.map (fun ev -> ev.files)
-      |> List.concat
-      |> List.sort_uniq String.compare
-    in
+(* Build a candidate_epoch from a non-empty group of commits.
+
+   The non-emptiness invariant is encoded in the signature ([first]
+   plus a separately-passed [rest]) so callers must produce the head
+   from a pattern match rather than rely on a runtime [assert false]
+   below the call site. *)
+let make_candidate first rest =
+  let commits = first :: rest in
+  let last = List.fold_left (fun _ ev -> ev) first rest in
+  let all_goals =
+    commits
+    |> List.map extract_goal_ids
+    |> List.concat
+    |> List.sort_uniq String.compare
+  in
+  let all_files =
+    commits
+    |> List.map (fun ev -> ev.files)
+    |> List.concat
+    |> List.sort_uniq String.compare
+  in
     let label =
       let subj = first.subject in
       if String.length subj > 60 then
@@ -313,8 +316,9 @@ let group_events ?(time_window_days = 7) events =
   let time_groups = group_by_time_window ungrouped ~days:time_window_days in
   let all_groups = grouped @ time_groups in
   List.filter_map (fun g ->
-    if g = [] then None
-    else Some (make_candidate g))
+    match g with
+    | [] -> None
+    | first :: rest -> Some (make_candidate first rest))
     all_groups
   |> List.sort (fun a b -> String.compare a.start_date b.start_date)
 


### PR DESCRIPTION
## Summary

Replace the `assert false` empty-list guard in `chronicle_ingest.make_candidate` with a type-level encoding of the non-empty invariant: split the `commits : commit list` parameter into `first : commit` plus `rest : commit list`.

## Why

The internal helper relied on the caller — `List.filter_map (fun g -> if g = [] then None else Some (make_candidate g))` — to never pass an empty list, but the type system did not carry that invariant, so the body had to defend with `| [] -> assert false`.

This is the standard *Parse, don't validate* replacement for an invariant the caller already proves at the use site.  Moving the proof into the signature makes the empty case unrepresentable, so the runtime check disappears and the caller is forced to deconstruct the head via pattern match.

## Behavior parity

The produced `candidate_epoch` is identical.  The caller's runtime check `if g = [] then None else Some (make_candidate g)` turns into a `match g with [] | first :: rest` arm — same control flow, same outputs.

## Validation

- `dune build --root . lib/` exit 0 — clean.
- `dune build --root . test/test_chronicle_ingest.exe` exit 0.
- `./_build/default/test/test_chronicle_ingest.exe test` — 24/24 OK, including the `candidate_epoch` coverage that exercises this path.

## Scope

- `make_candidate` is private (not in `chronicle_ingest.mli`); zero API impact.
- One file, +24/-20 net.

## RFC

Not required.  `lib/chronicle_ingest.ml` is not in the CLAUDE.md `agent_delegation` RFC-gated list (credential / identity / operator-control / sandbox / dashboard-credential / hooks / workflow).

## Related

Companion to #14107 (`List.hd` → pattern bind).  Both are surgical "OCaml partial function on a path the caller already proves" cleanups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)