### PR TITLE
perf(sse): wire MASC_SSE_STREAM_CAPACITY (default 256) + drop dead clock_ref

### DIFF
--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -900,6 +900,7 @@ let metric_sse_stream_queue_depth = "masc_sse_stream_queue_depth"
 let metric_sse_queue_depth_avg = "masc_sse_queue_depth_avg"
 let metric_sse_queue_depth_max = "masc_sse_queue_depth_max"
 let metric_sse_external_subscribers = "masc_sse_external_subscribers_total"
+let metric_sse_client_evictions = "masc_sse_client_evictions_total"
 let metric_grpc_active_streams = "masc_grpc_active_streams_total"
 let metric_grpc_heartbeat_latency = "masc_grpc_heartbeat_latency_seconds"
 let metric_grpc_subscribers = "masc_grpc_subscribers_total"
@@ -2540,6 +2541,14 @@ let init () =
     "Maximum SSE event queue depth across live sessions" Gauge;
   add metric_sse_external_subscribers
     "Active non-SSE subscribers bridged from the SSE fanout path" Gauge;
+  add metric_sse_client_evictions
+    "SSE clients evicted from the registry because [max_clients] was \
+     reached and a new client connected.  Pairs with the [Evicting \
+     oldest client] log line so operators can see eviction storms in \
+     metrics without scraping logs.  A non-zero rate is the early \
+     warning that broadcast fan-out is keeping mailboxes full faster \
+     than slow consumers can drain."
+    Counter;
 
   (* The keeper turn / cascade / persistence-failure metrics
      (turn_livelock_blocks .. session_cleanup_failures, plus

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -1002,6 +1002,7 @@ val metric_sse_stream_queue_depth : string
 val metric_sse_queue_depth_avg : string
 val metric_sse_queue_depth_max : string
 val metric_sse_external_subscribers : string
+val metric_sse_client_evictions : string
 val metric_grpc_active_streams : string
 val metric_grpc_heartbeat_latency : string
 val metric_grpc_subscribers : string

--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -117,7 +117,6 @@ let iteri_with_fair_yield f xs =
 let start_keeper_loops ~sw ~clock ~net ~domain_mgr ~proc_mgr
     (state : Mcp_server.server_state) =
   Progress.set_sse_callback Sse.broadcast;
-  Sse.set_clock clock;
   (* Wire stop_keeper hook so zombie GC can terminate keeper fibers *)
   Atomic.set Coord_hooks.stop_keeper_fn Keeper_keepalive.stop_keepalive;
   (* task-103: auto-provision a per-task sandbox worktree on successful

--- a/lib/sse.ml
+++ b/lib/sse.ml
@@ -54,11 +54,30 @@ type broadcast_target =
 let max_clients = 200
 
 (** Per-client event stream capacity.
+
     Must be > 0 to avoid synchronous rendez-vous semantics
-    (Eio.Stream.create 0 blocks add until a matching take).
-    64 events at 3-10s intervals covers 3-10 minutes of buffering.
-    A client that falls this far behind should reconnect. *)
-let stream_capacity = 64
+    ([Eio.Stream.create 0] blocks add until a matching take).
+
+    Read from [MASC_SSE_STREAM_CAPACITY] (catalog: clamped 8-1024,
+    default 256).  256 events at 3-10s intervals covers 13-43 minutes of
+    buffering.  A client that falls this far behind should reconnect.
+    Cap exists because broadcast fan-out at 64+ keepers + multiple
+    dashboard tabs accumulates faster than slow consumers can drain;
+    the default is sized so silent eviction does not coincide with the
+    operator's keeper count.
+
+    The catalog entry in [Env_config_snapshot.sse_entries] documents the
+    same clamp range; keep them in sync. *)
+let stream_capacity =
+  let default = 256 in
+  let lower = 8 and upper = 1024 in
+  let clamp n = max lower (min upper n) in
+  match Sys.getenv_opt "MASC_SSE_STREAM_CAPACITY" with
+  | None -> default
+  | Some raw ->
+    (match int_of_string_opt (String.trim raw) with
+     | Some n -> clamp n
+     | None -> default)
 
 (** SSE client state.
     [event_stream] is the per-session mailbox.  [broadcast] pushes here;
@@ -408,6 +427,7 @@ let register ?(kind = Coordinator) session_id ~last_event_id =
   in
   (match evicted with
    | Some sid ->
+       Transport_metrics.inc_sse_client_evicted ();
        Log.Server.info "Evicting oldest client %s (at cap %d)" sid max_clients
    | None ->
        ());
@@ -487,17 +507,6 @@ let update_last_event_id session_id event_id =
       Atomic.set client.last_event_id event_id;
       mark_seen client
   | None -> ()
-
-(** Eio clock ref for per-client push timeout.
-    Set during startup via [set_clock]. Without a clock, push has no timeout. *)
-let clock_ref : float Eio.Time.clock_ty Eio.Resource.t option ref = ref None
-
-let set_clock (clock : float Eio.Time.clock_ty Eio.Resource.t) =
-  clock_ref := Some clock
-
-(** Per-client push timeout (seconds).
-    5s is generous for a local TCP write; slow clients beyond this are dropped. *)
-let push_timeout_s = 5.0
 
 let client_matches_target target ~jsonrpc_payload (client : client) =
   match target with

--- a/lib/sse.ml
+++ b/lib/sse.ml
@@ -72,12 +72,8 @@ let stream_capacity =
   let default = 256 in
   let lower = 8 and upper = 1024 in
   let clamp n = max lower (min upper n) in
-  match Sys.getenv_opt "MASC_SSE_STREAM_CAPACITY" with
-  | None -> default
-  | Some raw ->
-    (match int_of_string_opt (String.trim raw) with
-     | Some n -> clamp n
-     | None -> default)
+  clamp
+    (Env_config_core.get_int ~default "MASC_SSE_STREAM_CAPACITY")
 
 (** SSE client state.
     [event_stream] is the per-session mailbox.  [broadcast] pushes here;

--- a/lib/sse.mli
+++ b/lib/sse.mli
@@ -64,10 +64,6 @@ val client_count : unit -> int
 val close_all_clients : unit -> int
 val cleanup_stale : ?max_age_s:float -> unit -> string list
 
-(** {1 Clock} *)
-
-val set_clock : float Eio.Time.clock_ty Eio.Resource.t -> unit
-
 (** {1 Events} *)
 
 val format_event : ?id:int -> ?event_type:string -> string -> string

--- a/lib/transport_metrics.ml
+++ b/lib/transport_metrics.ml
@@ -78,6 +78,9 @@ let set_sse_queue_snapshot ~avg_depth ~max_depth ~hot_sessions =
 let set_sse_external_subscribers count =
   Prometheus.set_gauge Prometheus.metric_sse_external_subscribers (float_of_int count)
 
+let inc_sse_client_evicted () =
+  Prometheus.inc_counter Prometheus.metric_sse_client_evictions ()
+
 (** {1 gRPC Metrics} *)
 
 let set_grpc_active_streams count =

--- a/lib/transport_metrics.mli
+++ b/lib/transport_metrics.mli
@@ -87,6 +87,12 @@ val set_sse_queue_snapshot :
 val set_sse_external_subscribers : int -> unit
 (** Sets [masc_sse_external_subscribers] gauge. *)
 
+val inc_sse_client_evicted : unit -> unit
+(** Increments [masc_sse_client_evictions_total] when {!Sse.register}
+    drops the oldest client because [max_clients] was reached.  Paired
+    with the [Evicting oldest client] log line so operators can see
+    eviction storms in metrics. *)
+
 (** {1 gRPC metrics} *)
 
 val set_grpc_active_streams : int -> unit

--- a/test/test_oas_integration.ml
+++ b/test/test_oas_integration.ml
@@ -255,7 +255,6 @@ let test_oas_event_bridge_persists_native_events () =
     (fun () ->
       let config = Coord.default_config dir in
       let bus = Event_bus.create () in
-      Sse.set_clock (Eio.Stdenv.clock env);
       try
         Eio.Switch.run (fun sw ->
             Oas_event_bridge.start_with_interval ~drain_interval_s:0.1
@@ -308,7 +307,6 @@ let test_oas_event_bridge_broadcasts_lifecycle_to_observers () =
       let config = Coord.default_config dir in
       let bus = Event_bus.create () in
       Masc_event_bus.set bus;
-      Masc_mcp.Sse.set_clock (Eio.Stdenv.clock env);
       try
         Eio.Switch.run (fun sw ->
             ignore (Masc_mcp.Sse.register ~kind:Masc_mcp.Sse.Observer
@@ -347,7 +345,6 @@ let test_oas_event_bridge_retries_append_failure_then_recovers () =
     (fun () ->
       let config = relay_test_config broken_root in
       let bus = Event_bus.create () in
-      Masc_mcp.Sse.set_clock (Eio.Stdenv.clock env);
       try
         Eio.Switch.run (fun sw ->
             ignore (Masc_mcp.Sse.register ~kind:Masc_mcp.Sse.Observer
@@ -392,7 +389,6 @@ let test_oas_event_bridge_drop_marker_on_exhausted_append_failure () =
     (fun () ->
       let config = relay_test_config broken_root in
       let bus = Event_bus.create () in
-      Masc_mcp.Sse.set_clock (Eio.Stdenv.clock env);
       try
         Eio.Switch.run (fun sw ->
             ignore (Masc_mcp.Sse.register ~kind:Masc_mcp.Sse.Observer
@@ -864,7 +860,6 @@ let test_oas_event_bridge_logs_turn_completed_with_agent_name () =
         | [] -> None
         | entry :: _ -> Some entry.seq
       in
-      Sse.set_clock (Eio.Stdenv.clock env);
       try
         Eio.Switch.run (fun sw ->
           Oas_event_bridge.start ~sw ~clock:(Eio.Stdenv.clock env) ~config ~bus;
@@ -926,7 +921,6 @@ let test_oas_event_bridge_logs_tool_completed_with_agent_name () =
         | [] -> None
         | entry :: _ -> Some entry.seq
       in
-      Sse.set_clock (Eio.Stdenv.clock env);
       try
         Eio.Switch.run (fun sw ->
           Oas_event_bridge.start ~sw ~clock:(Eio.Stdenv.clock env) ~config ~bus;


### PR DESCRIPTION
## Context

64+ keeper 운영 목표 + claude.ai MCP client + 다중 dashboard tab 환경에서 server performance 저하의 1순위 root cause 중 하나를 surgical fix로 해소합니다. 운영자 호소 — *\"WS event가 거의 안 들어온다 + 수동 새로고침\"* — 에 직결.

`Env_config_snapshot.sse_entries` 가 `MASC_SSE_STREAM_CAPACITY` 를 *\"clamped 8-1024\"* 로 catalog에 문서화해 두었으나, `lib/sse.ml:61` 은 `let stream_capacity = 64` 로 hardcoded이고 env read site가 없습니다. 64는 사용자 keeper 수와 정확히 일치하므로 `register()` 가 broadcast fan-out 직후 oldest client를 silent eviction 하는 임계점이 운영자가 도달하는 keeper 수와 합치합니다. `clock_ref` / `set_clock` / `push_timeout_s` 는 모두 dead — 호출 site를 grep으로 전수 확인했습니다.

## Summary

* `lib/sse.ml`: `stream_capacity` 가 `MASC_SSE_STREAM_CAPACITY` 를 읽고 8-1024로 clamp, 기본 256. 256 events × 3-10s = 13-43 분 buffering — 64+ keeper 환경에서 silent eviction 임계가 운영자 keeper 수와 분리됩니다.
* `lib/sse.{ml,mli}`: `clock_ref` / `set_clock` / `push_timeout_s = 5.0` 제거. `push_timeout_s` 는 어디서도 read되지 않고, `clock_ref` 는 startup에 할당만 되고 read되지 않습니다. dead since at least #11075 transport scan.
* `lib/server/server_bootstrap_loops.ml`: 이제 noop인 `Sse.set_clock clock;` 한 줄 제거.
* `test/test_oas_integration.ml`: 6개 dead `Sse.set_clock` 호출 제거.
* `lib/prometheus.{ml,mli}`: `masc_sse_client_evictions_total` counter 등록. \"Evicting oldest client %s\" log line만 있으면 metrics에서 안 보였던 eviction storm이 가시화됩니다.
* `lib/transport_metrics.{ml,mli}`: `inc_sse_client_evicted` helper.

## Verification

| 게이트 | 결과 |
|------|------|
| `dune build --root .` | ✅ pass |
| test_sse | ✅ 4/4 |
| test_sse_coverage | ✅ 35/35 |
| test_sse_external_sub | ✅ 9/9 |
| test_transport_metrics | ✅ 21/21 |
| test_oas_integration | ✅ 28/28 |
| test_sse_storm_e2e | ⚠️ 1 pre-existing 401 auth fail (origin/main 동일) |

origin/main fresh worktree 에서 동일 test_sse_storm_e2e 가 \"main_eio executable not found\" / 401 로 실패하는 것을 직접 확인했습니다. 본 변경의 표면(capacity / dead code / counter)은 auth path와 무관.

운영 환경에서의 정량 게이트 (64-client SSE harness broadcast < 200ms, eviction counter 0 sustain) 는 server restart 후 prod 측정으로 확인 예정 — Plan §End-to-end Verification 참조.

## Test plan

- [x] dune build pass
- [x] sse / transport / oas test 0 regression
- [ ] env knob 동작 확인 — `MASC_SSE_STREAM_CAPACITY=512` 로 server 재기동 후 `/metrics` 에서 `masc_sse_client_evictions_total` 0 sustain 측정
- [ ] 64-keeper bring-up 후 broadcast → dashboard 도달 latency p99 < 200ms
- [ ] 24h soak: `masc_sse_client_evictions_total` rate ≈ 0

## Bump and Pump (PR series)

이 PR은 *3-Draft 시퀀스의 PR-1 (transport)* 입니다. PR-2 (persistence — broadcast hot path file I/O 분리), PR-3 (concurrency — lock-free queue + delta scan) 가 뒤따릅니다. agent-authored Draft — `human-approved-ready` 라벨이 붙은 후에만 ready 전환합니다 (`feedback_user_rejects_cron_pr_loop.md` / `feedback_masc_mcp_draft_guard_blocks_agent_ready.md`).

## RFC

`bash ~/me/scripts/pr-rfc-check.sh` 통과 (변경 영역이 credential / identity / repo / operator / sandbox / hooks / workflow 어느 것도 건드리지 않음).

🤖 Generated with [Claude Code](https://claude.com/claude-code)