### PR TITLE
feat(keeper): per-keeper skip-log dedup for stable states

### DIFF
--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -576,17 +576,37 @@ let run_keepalive_unified_turn
               Log.Keeper.debug
           | _ -> Log.Keeper.info
         in
-        log_not_scheduled
-          "keepalive turn not scheduled for %s: should_run=%b channel=%s reasons=[%s] idle=%ds since_last=%s idle_gate=%s cooldown=%s task_cooldown=%s"
-          meta_after_triage.name
-          turn_decision.should_run channel_str
-          (String.concat "," verdict_strs)
-          obs.idle_seconds
-          (Keeper_keepalive_signal.format_since_last_scheduled_autonomous
-             turn_decision.since_last_scheduled_autonomous)
-          (format_opt_int turn_decision.idle_gate_sec)
-          (format_opt_int turn_decision.effective_cooldown)
-          (format_opt_int turn_decision.task_reactive_cooldown));
+        let emit_skip_log =
+          let is_stable_skip =
+            List.for_all
+              (fun r ->
+                 String.equal r "keeper_paused"
+                 || String.equal r "approval_pending"
+                 || String.equal r "scheduled_autonomous_disabled")
+              verdict_strs
+          in
+          if is_stable_skip
+          then
+            Keeper_skip_log_dedup.should_emit
+              ~keeper_name:meta_after_triage.name
+              ~reasons:verdict_strs
+              ~now:(Time_compat.now ())
+              ~ttl_sec:600.0
+          else
+            true
+        in
+        if emit_skip_log then
+          log_not_scheduled
+            "keepalive turn not scheduled for %s: should_run=%b channel=%s reasons=[%s] idle=%ds since_last=%s idle_gate=%s cooldown=%s task_cooldown=%s"
+            meta_after_triage.name
+            turn_decision.should_run channel_str
+            (String.concat "," verdict_strs)
+            obs.idle_seconds
+            (Keeper_keepalive_signal.format_since_last_scheduled_autonomous
+               turn_decision.since_last_scheduled_autonomous)
+            (format_opt_int turn_decision.idle_gate_sec)
+            (format_opt_int turn_decision.effective_cooldown)
+            (format_opt_int turn_decision.task_reactive_cooldown));
       if should_run_turn
       then
         Log.Keeper.info

--- a/lib/keeper/keeper_skip_log_dedup.ml
+++ b/lib/keeper/keeper_skip_log_dedup.ml
@@ -1,0 +1,18 @@
+(* Per-keeper skip-log deduplication.  See [.mli] for design rationale. *)
+
+let last_emitted : (string, string * float) Hashtbl.t = Hashtbl.create 32
+
+let mu = Eio.Mutex.create ()
+
+let should_emit ~keeper_name ~reasons ~now ~ttl_sec =
+  if ttl_sec <= 0.0 then true
+  else
+    let key = String.concat "," (List.sort compare reasons) in
+    Eio.Mutex.use_rw ~protect:false mu (fun () ->
+      match Hashtbl.find_opt last_emitted keeper_name with
+      | Some (prev_key, prev_ts)
+        when String.equal prev_key key && now -. prev_ts < ttl_sec ->
+          false
+      | _ ->
+          Hashtbl.replace last_emitted keeper_name (key, now);
+          true)

--- a/lib/keeper/keeper_skip_log_dedup.mli
+++ b/lib/keeper/keeper_skip_log_dedup.mli
@@ -1,0 +1,16 @@
+(** Per-keeper skip-log deduplication.
+
+    Keepalive sweeps fire every ~30s.  A paused keeper would emit an
+    identical [{keeper_paused}] INFO log every sweep (~120 logs/hour).
+    This module bounds emission to at most one identical-reason log per
+    [ttl_sec], while still surfacing every transition (reason set change)
+    immediately.  Prometheus counters are unaffected; only human-visible
+    log lines are gated. *)
+
+(** [should_emit ~keeper_name ~reasons ~now ~ttl_sec] returns [true]
+    when [keeper_name] has not logged the exact same [reasons] set
+    within [ttl_sec] seconds (as measured by [now]).  [reasons] are
+    normalised (sorted and joined) so order differences do not create
+    false transitions. *)
+val should_emit :
+  keeper_name:string -> reasons:string list -> now:float -> ttl_sec:float -> bool

--- a/test/dune
+++ b/test/dune
@@ -66,6 +66,7 @@
         test_response_model_empty_10083
         test_heuristic_theatre_audit
         test_keeper_proactive_skip_counter
+        test_keeper_skip_log_dedup
         test_oas_error_kind_counter
         test_board_author_identity_10297
         test_fsm_drift_counter
@@ -290,6 +291,7 @@
           test_response_model_empty_10083
           test_heuristic_theatre_audit
           test_keeper_proactive_skip_counter
+          test_keeper_skip_log_dedup
           test_oas_error_kind_counter
           test_board_author_identity_10297
           test_fsm_drift_counter

--- a/test/test_keeper_skip_log_dedup.ml
+++ b/test/test_keeper_skip_log_dedup.ml
@@ -1,0 +1,57 @@
+(* Dedup tests for keeper_skip_log_dedup.  Pure synchronous; no I/O. *)
+
+let test_dedup_blocks_same_within_ttl () =
+  let now = 0.0 in
+  let ttl = 10.0 in
+  Alcotest.(check bool) "first emit" true
+    (Masc_mcp.Keeper_skip_log_dedup.should_emit ~keeper_name:"k1"
+       ~reasons:["keeper_paused"; "scheduled_autonomous_disabled"]
+       ~now ~ttl_sec:ttl);
+  Alcotest.(check bool) "same within ttl" false
+    (Masc_mcp.Keeper_skip_log_dedup.should_emit ~keeper_name:"k1"
+       ~reasons:["keeper_paused"; "scheduled_autonomous_disabled"]
+       ~now:(now +. 5.0) ~ttl_sec:ttl);
+  Alcotest.(check bool) "ttl boundary" true
+    (Masc_mcp.Keeper_skip_log_dedup.should_emit ~keeper_name:"k1"
+       ~reasons:["keeper_paused"; "scheduled_autonomous_disabled"]
+       ~now:(now +. 10.0) ~ttl_sec:ttl)
+
+let test_dedup_different_reasons_transition () =
+  let now = 0.0 in
+  let ttl = 10.0 in
+  Alcotest.(check bool) "first" true
+    (Masc_mcp.Keeper_skip_log_dedup.should_emit ~keeper_name:"k2"
+       ~reasons:["keeper_paused"] ~now ~ttl_sec:ttl);
+  Alcotest.(check bool) "different reasons" true
+    (Masc_mcp.Keeper_skip_log_dedup.should_emit ~keeper_name:"k2"
+       ~reasons:["approval_pending"] ~now:(now +. 1.0) ~ttl_sec:ttl)
+
+let test_dedup_sorted_normalises () =
+  let now = 0.0 in
+  let ttl = 10.0 in
+  Alcotest.(check bool) "order a" true
+    (Masc_mcp.Keeper_skip_log_dedup.should_emit ~keeper_name:"k3"
+       ~reasons:["keeper_paused"; "approval_pending"] ~now ~ttl_sec:ttl);
+  Alcotest.(check bool) "order b same set" false
+    (Masc_mcp.Keeper_skip_log_dedup.should_emit ~keeper_name:"k3"
+       ~reasons:["approval_pending"; "keeper_paused"]
+       ~now:(now +. 1.0) ~ttl_sec:ttl)
+
+let test_zero_ttl_always_emits () =
+  Alcotest.(check bool) "zero ttl" true
+    (Masc_mcp.Keeper_skip_log_dedup.should_emit ~keeper_name:"k4"
+       ~reasons:["keeper_paused"] ~now:0.0 ~ttl_sec:0.0)
+
+let () =
+  Alcotest.run "keeper_skip_log_dedup" [
+    "dedup", [
+      Alcotest.test_case "blocks_same_within_ttl" `Quick
+        test_dedup_blocks_same_within_ttl;
+      Alcotest.test_case "allows_different_reasons" `Quick
+        test_dedup_different_reasons_transition;
+      Alcotest.test_case "sorted_normalises" `Quick
+        test_dedup_sorted_normalises;
+      Alcotest.test_case "zero_ttl_always_emits" `Quick
+        test_zero_ttl_always_emits;
+    ]
+  ]


### PR DESCRIPTION
## 요약
paused/approval-pending keeper가 매 heartbeat sweep(~30초)마다 동일한
\"keepalive turn not scheduled\" INFO 로그를 찍어, 2시간이면 약 240개의
동일 로그가 쌓입니다. 이는 운영자 대시보드의 signal-to-noise ratio를
급격히 떨어뜨립니다.

\"Keeper_skip_log_dedup\" 모듈을 추가하여 동일한 stable reason set
(keeper_paused, approval_pending, scheduled_autonomous_disabled)에
대해서는 600초당 1회로 로그를 제한합니다. reason set이 변경되는
transition은 즉시 emit됩니다. Prometheus counter는 영향받지 않습니다.

## 변경 파일
- lib/keeper/keeper_skip_log_dedup.ml{,i}: 신규 dedup 모듈
- lib/keeper/keeper_heartbeat_loop.ml: emit 가드 추가
- test/test_keeper_skip_log_dedup.ml: 4가지 케이스 테스트
- test/dune: 모듈 등록

## 테스트
- dune runtest test/test_keeper_skip_log_dedup.exe: 4/4 pass
- dune build lib/: 성공

## 참고
- #10008 fm3 (proactive skip counter 도입 시 로그 노이즈 문제 최초 발견)
- #10940 follow-up (stale-watchdog kill 직전 reason stamp를 위해
  registry 기록은 유지, 로그만 dedup)