### PR TITLE
fix: count history migration read drops

### DIFF
--- a/lib/keeper/keeper_context_core.ml
+++ b/lib/keeper/keeper_context_core.ml
@@ -635,6 +635,26 @@ type history_line_action =
   | Move_internal
   | Drop_line
 
+type history_line_parse_error = {
+  reason : string;
+  detail : string;
+}
+
+let history_migration_persistence_surface = "keeper_context_history_migration"
+
+let report_history_migration_drop ~path { reason; detail } =
+  Safe_ops.report_persistence_read_drop
+    ~on_drop:(fun () ->
+      Prometheus.inc_counter Prometheus.metric_persistence_read_drops
+        ~labels:
+          [ ("surface", history_migration_persistence_surface); ("reason", reason) ]
+        ())
+    ~surface:history_migration_persistence_surface
+    ~reason
+    ~path
+    ~detail
+;;
+
 let classify_history_entry ~(source : string) ~(content : string) :
     history_line_action =
   (* World-state headings can appear in user-authored long-term memory.
@@ -645,18 +665,48 @@ let classify_history_entry ~(source : string) ~(content : string) :
     Move_internal
   else Keep_main
 
-let classify_history_jsonl_line (line : string) : history_line_action option =
+let classify_history_jsonl_line_result
+    (line : string) : (history_line_action, history_line_parse_error) result =
   try
-    let json = Yojson.Safe.from_string line in
-    let source =
-      Yojson.Safe.Util.(json |> member "source" |> to_string_option)
-      |> Option.value ~default:""
-      |> String.trim
-    in
-    let content = String.trim (text_of_history_jsonl_json json) in
-    Some (classify_history_entry ~source ~content)
+    match Yojson.Safe.from_string line with
+    | `Assoc _ as json ->
+        let source =
+          Yojson.Safe.Util.(json |> member "source" |> to_string_option)
+          |> Option.value ~default:""
+          |> String.trim
+        in
+        let content = String.trim (text_of_history_jsonl_json json) in
+        Ok (classify_history_entry ~source ~content)
+    | _ ->
+        Error
+          {
+            reason = Safe_ops.persistence_read_drop_reason_invalid_payload;
+            detail = "history row is not a JSON object";
+          }
   with
-  | Yojson.Json_error _ | Yojson.Safe.Util.Type_error _ -> None
+  | Yojson.Json_error detail ->
+      Error
+        {
+          reason = Safe_ops.persistence_read_drop_reason_entry_load_error;
+          detail;
+        }
+  | Yojson.Safe.Util.Type_error (detail, _) ->
+      Error
+        {
+          reason = Safe_ops.persistence_read_drop_reason_invalid_payload;
+          detail;
+        }
+  | exn ->
+      Error
+        {
+          reason = Safe_ops.persistence_read_drop_reason_invalid_payload;
+          detail = Printexc.to_string exn;
+        }
+
+let classify_history_jsonl_line (line : string) : history_line_action option =
+  match classify_history_jsonl_line_result line with
+  | Ok action -> Some action
+  | Error _ -> None
 
 let render_jsonl_lines (lines : string list) : string =
   match lines with
@@ -693,14 +743,15 @@ let migrate_session_history_logs
     let kept_rev, moved_rev, dropped_main, malformed_main =
       List.fold_left
         (fun (kept_rev, moved_rev, dropped_lines, malformed_lines) line ->
-           match classify_history_jsonl_line line with
-           | Some Keep_main ->
+           match classify_history_jsonl_line_result line with
+           | Ok Keep_main ->
                (line :: kept_rev, moved_rev, dropped_lines, malformed_lines)
-           | Some Move_internal ->
+           | Ok Move_internal ->
                (kept_rev, line :: moved_rev, dropped_lines, malformed_lines)
-           | Some Drop_line ->
+           | Ok Drop_line ->
                (kept_rev, moved_rev, dropped_lines + 1, malformed_lines)
-           | None ->
+           | Error error ->
+               report_history_migration_drop ~path:main_path error;
                (line :: kept_rev, moved_rev, dropped_lines, malformed_lines + 1))
         ([], [], 0, 0)
         main_lines
@@ -710,10 +761,12 @@ let migrate_session_history_logs
     let internal_kept_rev, dropped_internal, malformed_internal =
       List.fold_left
         (fun (kept_rev, dropped_lines, malformed_lines) line ->
-           match classify_history_jsonl_line line with
-           | Some Drop_line -> (kept_rev, dropped_lines + 1, malformed_lines)
-           | Some _ -> (line :: kept_rev, dropped_lines, malformed_lines)
-           | None -> (line :: kept_rev, dropped_lines, malformed_lines + 1))
+           match classify_history_jsonl_line_result line with
+           | Ok Drop_line -> (kept_rev, dropped_lines + 1, malformed_lines)
+           | Ok _ -> (line :: kept_rev, dropped_lines, malformed_lines)
+           | Error error ->
+               report_history_migration_drop ~path:internal_path error;
+               (line :: kept_rev, dropped_lines, malformed_lines + 1))
         ([], 0, 0)
         existing_internal
     in

--- a/test/test_keeper_context_core_dedup.ml
+++ b/test/test_keeper_context_core_dedup.ml
@@ -11,7 +11,42 @@
        inlining the full [Yojson.Safe.to_string] output. *)
 
 module C = Masc_mcp.Keeper_context_core
+module P = Masc_mcp.Prometheus
 module T = Agent_sdk.Types
+
+let temp_dir prefix =
+  let dir = Filename.temp_file prefix "" in
+  Unix.unlink dir;
+  Unix.mkdir dir 0o755;
+  dir
+
+let cleanup_dir dir =
+  let rec rm path =
+    if Sys.file_exists path then
+      if Sys.is_directory path then (
+        Array.iter (fun name -> rm (Filename.concat path name)) (Sys.readdir path);
+        Unix.rmdir path)
+      else
+        Unix.unlink path
+  in
+  try rm dir with _ -> ()
+
+let write_file path content =
+  let oc = open_out path in
+  Fun.protect
+    ~finally:(fun () -> close_out_noerr oc)
+    (fun () -> output_string oc content)
+
+let persistence_read_drop_total ~surface ~reason =
+  P.metric_value_or_zero P.metric_persistence_read_drops
+    ~labels:[ ("surface", surface); ("reason", reason) ]
+    ()
+
+let check_persistence_read_drop_delta ~surface ~reason ~before ~delta =
+  Alcotest.(check (float 0.0001))
+    (Printf.sprintf "%s/%s persistence read drops" surface reason)
+    (before +. float_of_int delta)
+    (persistence_read_drop_total ~surface ~reason)
 
 (* --- message_to_json: no flat [content] field --- *)
 
@@ -217,6 +252,44 @@ let test_roundtrip_text_preserved () =
   Alcotest.(check string) "text preserved"
     (text_of original) (text_of reparsed)
 
+let test_migrate_session_history_logs_counts_malformed_rows () =
+  let dir = temp_dir "keeper_context_history_migration" in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir dir)
+    (fun () ->
+      let history_path = Filename.concat dir "history.jsonl" in
+      let internal_path = Filename.concat dir "history.internal.jsonl" in
+      write_file history_path
+        (String.concat "\n"
+           [
+             {|{"role":"user","content":"real conversation"}|};
+             "[]";
+             "{not-json";
+           ]
+         ^ "\n");
+      write_file internal_path
+        (String.concat "\n"
+           [
+             {|{"role":"assistant","source":"internal_assistant","content":"ok"}|};
+             "42";
+           ]
+         ^ "\n");
+      let surface = "keeper_context_history_migration" in
+      let entry_reason = "entry_load_error" in
+      let invalid_reason = "invalid_payload" in
+      let before_entry =
+        persistence_read_drop_total ~surface ~reason:entry_reason
+      in
+      let before_invalid =
+        persistence_read_drop_total ~surface ~reason:invalid_reason
+      in
+      let stats = C.migrate_session_history_logs ~session_dir:dir in
+      Alcotest.(check int) "malformed lines counted" 3 stats.malformed_lines;
+      check_persistence_read_drop_delta ~surface ~reason:entry_reason
+        ~before:before_entry ~delta:1;
+      check_persistence_read_drop_delta ~surface ~reason:invalid_reason
+        ~before:before_invalid ~delta:2)
+
 let () =
   Alcotest.run "keeper_context_core_dedup"
     [
@@ -257,5 +330,10 @@ let () =
             test_tool_result_large_json_elided;
           Alcotest.test_case "no content no json" `Quick
             test_tool_result_no_content_no_json;
+        ] );
+      ( "history_migration",
+        [
+          Alcotest.test_case "counts malformed persisted rows" `Quick
+            test_migrate_session_history_logs_counts_malformed_rows;
         ] );
     ]


### PR DESCRIPTION
## Summary
- report malformed history.jsonl rows encountered during history migration to masc_persistence_read_drops_total
- split migration parse failures into entry_load_error and invalid_payload reasons
- keep the existing option-returning classifier API while using reason-aware parsing inside migration

## Verification
- git diff --check
- lockf -k -t 1200 /tmp/me-dune-local.lock env MASC_DUNE_LOCK_HELD=1 MASC_SKIP_OPAM_LOCK=1 DUNE_JOBS=1 DUNE_CACHE=disabled scripts/dune-local.sh build test/test_keeper_context_core_dedup.exe
- ./_build/default/test/test_keeper_context_core_dedup.exe