### PR TITLE
chore(provider): wrap default_api_key_env via Provider_kind_resolver

### DIFF
--- a/lib/auth_resolve.ml
+++ b/lib/auth_resolve.ml
@@ -86,7 +86,7 @@ let resolve ~base_path ~keeper_id ~provider_kind
                 (Api_key_env_unset { var_name = "MASC_INTERNAL_MCP_TOKEN" })
         else Error (Token_hash_missing { path = hash_path })
   else
-    match Llm_provider.Provider_kind.default_api_key_env provider_kind with
+    match Provider_kind_resolver.env_var_for_kind provider_kind with
     | None -> (
         match provider_kind with
         | PK.Codex_cli ->

--- a/lib/provider_kind_resolver.ml
+++ b/lib/provider_kind_resolver.ml
@@ -84,3 +84,6 @@ let kind_of_spec (spec : string) :
   | Registered { kind; _ } -> Some kind
   | Custom_url _ -> Some Llm_provider.Provider_config.OpenAI_compat
   | Unknown _ -> None
+
+let env_var_for_kind kind =
+  Llm_provider.Provider_kind.default_api_key_env kind

--- a/lib/provider_kind_resolver.mli
+++ b/lib/provider_kind_resolver.mli
@@ -53,3 +53,12 @@ val resolve : string -> resolution
     only need the kind and not the split model id. *)
 val kind_of_spec :
   string -> Llm_provider.Provider_config.provider_kind option
+
+(** [env_var_for_kind kind] returns the conventional environment variable
+    name that holds the API key for [kind], delegating to OAS's
+    {!Llm_provider.Provider_kind.default_api_key_env}. Centralizing this
+    lookup here keeps direct {!Llm_provider.Provider_kind} usage out of
+    keeper / auth call sites and gives masc-mcp a single hook for future
+    overrides (e.g. provider aliases, env-var customization). *)
+val env_var_for_kind :
+  Llm_provider.Provider_config.provider_kind -> string option


### PR DESCRIPTION
## Context

Part of the OAS ↔ masc-mcp boundary cleanup planned in
`~/me/planning/claude-plans/me-workspace-yousleepwhen-masc-mcp-oas-crispy-oasis.md`
(originally PR-2; reduced to PR-2-mini after a fresh measurement
inverted the plan's baseline assumption).

The original plan estimated ~28 files of `Provider_kind` sprawl in
masc-mcp `lib/` and proposed a 4-axis Provider_kind_resolver expansion
(billing / retry / tool support / capability). A scoped audit ran
fresh:

```
rg -l 'Llm_provider\.Provider_kind|Provider_kind\.' lib/ \
  | grep -v provider_kind_resolver
```

returns **6 files / 8 references**, not 28. Each ref reviewed in
context:

| File:Line | Use | Verdict |
|---|---|---|
| auth_resolve.ml:43 | `PK.to_string` (serialization) | legit |
| auth_resolve.ml:89 | `PK.default_api_key_env` (kind → env var) | **real fan-out** |
| cascade_catalog_validator.ml:136 | `let module PK = ...` (local alias) | legit |
| keeper_hooks_oas.ml:631 | `PK.to_string` | legit |
| keeper_hooks_oas.mli:28 | `PK.t option` (interface type) | legit |
| model_inference_metrics.ml:529 | `PK.of_string` (parsing) | legit |
| oas_worker_named.ml:1085, 1089 | reference inside a comment | comment-only |

Only `auth_resolve.ml:89` is a real branch-by-`Provider_kind`
decision; the remaining 7 are serialization, type annotations,
comments, or local-module aliases that do not benefit from going
through the resolver.

This PR addresses the single real site and closes the audit.

## Changes

`lib/provider_kind_resolver.{ml,mli}` (+ ~13 LOC):
```ocaml
val env_var_for_kind :
  Llm_provider.Provider_config.provider_kind -> string option
```

A pure pass-through to `Llm_provider.Provider_kind.default_api_key_env`.
The point isn't behavioral — it's that `auth_resolve.ml`'s
`resolve_api_key` no longer pulls in two qualified `Llm_provider.*`
imports for credential resolution. Future masc-mcp-side overrides
(provider aliases, env-var customization) get a single hook.

`lib/auth_resolve.ml` (1 line):
```diff
-    match Llm_provider.Provider_kind.default_api_key_env provider_kind with
+    match Provider_kind_resolver.env_var_for_kind provider_kind with
```

## Test plan

- [x] `bash scripts/dune-local.sh build lib/` passes (changes compile clean)
- [ ] CI green
- [ ] Unchanged behavior verified (pure delegation)

## RFC posture

Related RFCs (informational, not blocking):
- `docs/rfc/RFC-0008-credential-provider.md`
- `docs/rfc/RFC-0019-keeper-credential-unification.md`

RFC-WAIVED: 15-LOC facade wrap, no semantic change, no new credential
policy. The wrapper is a pure pass-through to an existing OAS
function and centralizes the direct `Provider_kind` import out of
the auth resolution call site.

## What this PR does NOT do

- Does NOT rename external HTTP headers (`X-MASC-Agent`,
  `x-masc-agent-name`) — those are real cross-repo contracts, see
  oas#1462 discussion.
- Does NOT migrate the 7 legitimate Provider_kind uses listed above.
- Does NOT expand the resolver to "4-axis" surface from the plan;
  that surface had no caller demand once the inflated baseline was
  corrected.