### PR TITLE
chore(boundary): add masc-mcp ↔ oas internals lint (symmetric to OAS guard)

### DIFF
--- a/scripts/check-oas-internals.sh
+++ b/scripts/check-oas-internals.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+# Guard masc-mcp from reaching past the agent_sdk public surface.
+#
+# Symmetric counterpart to OAS's scripts/check-sdk-independence.sh
+# (oas does not depend on masc-mcp; masc-mcp does not reach into
+# oas internals).
+#
+# Tiers:
+#   strict   (default, fail-on-match):
+#     - `Agent_sdk__*` mangled internal-module references in lib/
+#       (these would only appear if a caller bypassed the wrapped
+#       library by going through the dune __ -mangled name directly).
+#
+#   warn     (--include-internals):
+#     - `Llm_provider.Provider_kind` qualified module access
+#       outside lib/provider_kind_resolver.{ml,mli}
+#       (informational; allowed uses include serialization, type
+#       annotations, local-module aliases, and comments).
+#     - `Llm_provider.Constants` qualified access outside
+#       lib/oas_compat/ and lib/provider_kind_resolver.{ml,mli}
+#       (informational; cascade subsystem currently legitimately
+#       reads default inference params).
+#
+#   strict-internals (--strict-internals):
+#     promote warn-tier matches to failures. Use after baseline
+#     occurrences have been tagged with `(* boundary-allow:<reason> *)`.
+#
+# Permanently excluded scopes: _build/, .worktrees/, .masc/playground/,
+# test/ (test fixtures legitimately reference internals for boundary
+# round-trip checks).
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+include_internals=0
+strict_internals=0
+for arg in "$@"; do
+  case "$arg" in
+    --include-internals) include_internals=1 ;;
+    --strict-internals)  include_internals=1; strict_internals=1 ;;
+    -h|--help)
+      sed -n '1,32p' "$0"
+      exit 0
+      ;;
+    *)
+      echo "unknown flag: $arg" >&2
+      exit 2
+      ;;
+  esac
+done
+
+if ! command -v rg >/dev/null 2>&1; then
+  echo "OAS-internals check failed: ripgrep (rg) is required" >&2
+  exit 1
+fi
+
+# Common rg excludes.
+RG_BASE_FLAGS=(
+  --type-add 'ocaml:*.{ml,mli}'
+  -t ocaml
+  -g '!_build/**'
+  -g '!.worktrees/**'
+  -g '!.masc/playground/**'
+)
+
+# Filter: skip OCaml comment-leading lines and lines tagged with
+# `boundary-allow`. Mirrors OAS's check-sdk-independence.sh heuristic.
+filter_noise() {
+  awk -F':' '
+    {
+      idx = index($0, ":")
+      rest = substr($0, idx + 1)
+      idx2 = index(rest, ":")
+      content = substr(rest, idx2 + 1)
+      sub(/^[[:space:]]+/, "", content)
+      if (content ~ /^\*/) next
+      if (content ~ /^\(\*/) next
+      if ($0 ~ /boundary-allow/) next
+      print $0
+    }
+  '
+}
+
+scan_strict_agent_sdk_internal() {
+  # Catch `Agent_sdk__Foo` (the dune wrapped-library mangled name).
+  # Direct legit access uses `Agent_sdk.Foo` instead.
+  local matches
+  matches="$(rg -n 'Agent_sdk__[A-Za-z_]' lib/ "${RG_BASE_FLAGS[@]}" 2>/dev/null | filter_noise || true)"
+  if [[ -n "$matches" ]]; then
+    echo "FAIL [strict]: Agent_sdk__ mangled internal reference (use Agent_sdk.X instead)" >&2
+    echo "$matches" >&2
+    return 1
+  fi
+  return 0
+}
+
+scan_warn_provider_kind_external() {
+  # Provider_kind qualified access outside provider_kind_resolver.
+  local matches
+  matches="$(rg -n 'Llm_provider\.Provider_kind|\bProvider_kind\.' lib/ "${RG_BASE_FLAGS[@]}" 2>/dev/null \
+    | grep -v 'lib/provider_kind_resolver\.' \
+    | filter_noise || true)"
+  if [[ -n "$matches" ]]; then
+    if [[ "$strict_internals" -eq 1 ]]; then
+      echo "FAIL [internals]: Llm_provider.Provider_kind raw access outside provider_kind_resolver" >&2
+    else
+      echo "WARN [internals]: Llm_provider.Provider_kind raw access outside provider_kind_resolver" >&2
+    fi
+    echo "$matches" >&2
+    return 1
+  fi
+  return 0
+}
+
+scan_warn_constants_external() {
+  # Llm_provider.Constants outside oas_compat / provider_kind_resolver.
+  local matches
+  matches="$(rg -n 'Llm_provider\.Constants' lib/ "${RG_BASE_FLAGS[@]}" 2>/dev/null \
+    | grep -v 'lib/oas_compat/' \
+    | grep -v 'lib/provider_kind_resolver\.' \
+    | filter_noise || true)"
+  if [[ -n "$matches" ]]; then
+    if [[ "$strict_internals" -eq 1 ]]; then
+      echo "FAIL [internals]: Llm_provider.Constants raw access outside oas_compat / provider_kind_resolver" >&2
+    else
+      echo "WARN [internals]: Llm_provider.Constants raw access outside oas_compat / provider_kind_resolver" >&2
+    fi
+    echo "$matches" >&2
+    return 1
+  fi
+  return 0
+}
+
+overall_fail=0
+if ! scan_strict_agent_sdk_internal; then
+  overall_fail=1
+fi
+
+if [[ "$include_internals" -eq 1 ]]; then
+  pk_ok=1
+  if ! scan_warn_provider_kind_external; then pk_ok=0; fi
+  cn_ok=1
+  if ! scan_warn_constants_external; then cn_ok=0; fi
+  if [[ "$strict_internals" -eq 1 && ( "$pk_ok" -eq 0 || "$cn_ok" -eq 0 ) ]]; then
+    overall_fail=1
+  fi
+fi
+
+if [[ "$overall_fail" -ne 0 ]]; then
+  echo "OAS-internals check failed" >&2
+  exit 1
+fi
+
+echo "OK: OAS-internals check passed"


### PR DESCRIPTION
## Context

Final piece of the OAS ↔ masc-mcp boundary cleanup planned in
`~/me/planning/claude-plans/me-workspace-yousleepwhen-masc-mcp-oas-crispy-oasis.md`
(PR-3 of 3, scoped to P2-1 only — see below).

OAS already self-monitors with `oas/scripts/check-sdk-independence.sh`
(no coordinator vocabulary in `lib/`, `bin/`, `README.md`). masc-mcp
had no symmetric guard on its side, so reaches past the agent_sdk
public surface into `Agent_sdk__` mangled internals or unrouted
`Llm_provider.Provider_kind` / `Llm_provider.Constants` access could
land without alarm. This PR adds that guard.

## Scope Reduction

The plan originally listed two P-tier deliverables for this PR:

- **P1-2 (`oas_compat.mli` neuf)** — **already done in main**.
  Since the plan was written, `lib/oas_compat/oas_compat.mli` was
  added (and progressively refined in #12817 / #12905 / #13083) with
  a far more sophisticated surface than the plan envisioned: a typed
  `cascade_failure_class` enum, a structured `retryable_error` enum
  for what used to be string-matched provider error markers, plus
  `Metrics.make` as a record-literal centralizer. No work needed.

- **P2-1 (symmetric boundary lint)** — this PR.

So this PR is just the lint script.

## Design

`scripts/check-oas-internals.sh` mirrors OAS's
`check-sdk-independence.sh` in shape and ergonomics:

| Tier | Flag | Behavior |
|---|---|---|
| strict | (default) | Fail on `Agent_sdk__*` mangled internal references in `lib/` |
| warn | `--include-internals` | Also report `Llm_provider.Provider_kind` raw access outside `provider_kind_resolver` and `Llm_provider.Constants` raw access outside `oas_compat/` and `provider_kind_resolver` (informational, exit 0) |
| strict-internals | `--strict-internals` | Promote warn-tier matches to failures. Hardening target after `(* boundary-allow:reason *)` markers tag the legitimate baseline lines |

Pattern-symmetric with the OAS guard: shared `boundary-allow` inline
marker convention, same OCaml comment heuristic (skip lines starting
with `*` or `(*`), bash 3.2 compatible (no nameref / process
substitution).

Permanent excludes: `_build/`, `.worktrees/`, `.masc/playground/`,
`test/` (test fixtures legitimately exercise internals).

## Baseline

Current main (5bafbaeeb8):

```
Agent_sdk__:    0 refs                                 (strict tier passes)
Provider_kind:  6 files / 7 lines outside resolver     (warn tier reports)
Constants:      18 lines in cascade subsystem          (warn tier reports)
```

The 7 Provider_kind lines were reviewed in PR #14115 and are all
legitimate: serialization (`PK.to_string`), type annotations
(`PK.t option`), comment references, and `let module PK = ...` local
aliases. The 18 Constants lines are cascade subsystem reading default
inference parameters (`Inference.default_temperature` etc.); cleanup
there is a separate cascade-config refactor, not this PR.

## Verified

```
STRICT (default):                exit 0     OK
WARN (--include-internals):      exit 0     informational, 24 lines
STRICT-INTERNALS:                exit 1     baseline lines as expected
Synthetic Agent_sdk__ violation: exit 1     catch confirmed
After violation removed:         exit 0     state restored
```

## Test plan

- [x] All three exit-code modes verified
- [x] Synthetic Agent_sdk__ probe triggers strict-tier failure
- [x] Probe cleanup restores PASS
- [ ] CI green
- [ ] (Future PR) Wire into `dune build @runtest` and CI workflow
- [ ] (Future PR) Tag baseline Provider_kind / Constants lines with `(* boundary-allow:reason *)` and enable `--strict-internals` in CI