### PR TITLE
fix(auth): dedupe dashboard actor fallback warnings

### DIFF
--- a/lib/server/server_auth.ml
+++ b/lib/server/server_auth.ml
@@ -275,6 +275,28 @@ let sanitize_dashboard_actor_name raw =
     value;
   Buffer.contents buf
 
+let dashboard_actor_fallback_warn_seen : (string, float) Hashtbl.t =
+  Hashtbl.create 32
+
+let dashboard_actor_fallback_warn_seen_mutex = Mutex.create ()
+
+let dashboard_actor_fallback_warn_restate_sec = 3600.0
+
+let dashboard_actor_fallback_should_warn ~key =
+  let now = Unix.gettimeofday () in
+  Mutex.lock dashboard_actor_fallback_warn_seen_mutex;
+  Fun.protect
+    ~finally:(fun () -> Mutex.unlock dashboard_actor_fallback_warn_seen_mutex)
+    (fun () ->
+      let should_warn =
+        match Hashtbl.find_opt dashboard_actor_fallback_warn_seen key with
+        | None -> true
+        | Some last -> now -. last >= dashboard_actor_fallback_warn_restate_sec
+      in
+      if should_warn then
+        Hashtbl.replace dashboard_actor_fallback_warn_seen key now;
+      should_warn)
+
 let dashboard_actor_for_request ~base_path request =
   match auth_token_from_request request with
   | Some token -> (
@@ -295,11 +317,27 @@ let dashboard_actor_for_request ~base_path request =
           (* PR-I: surface the silent fallback. Token did not resolve to any
              agent, so we drop to the request actor hint (header / query
              param), masking identity drift in the HTTP transport. *)
-          Log.Auth.warn
-            "[silent:dashboard_actor_fallback] outcome=none token_hash_prefix=%s \
-             — bearer token resolved to no agent, falling back to request \
-             actor hint"
-            token_hash_prefix;
+          let hint =
+            match request_actor_hint request with
+            | Some s -> s
+            | None -> "<none>"
+          in
+          let log_key =
+            String.concat "|"
+              [ "none"; token_hash_prefix; hint ]
+          in
+          if dashboard_actor_fallback_should_warn ~key:log_key then
+            Log.Auth.warn
+              "[silent:dashboard_actor_fallback] outcome=none \
+               token_hash_prefix=%s actor_hint=%s — bearer token resolved \
+               to no agent, falling back to request actor hint; repeated \
+               identical fallbacks demoted to DEBUG for %.0fs"
+              token_hash_prefix hint dashboard_actor_fallback_warn_restate_sec
+          else
+            Log.Auth.debug
+              "[silent:dashboard_actor_fallback] repeated outcome=none \
+               token_hash_prefix=%s actor_hint=%s"
+              token_hash_prefix hint;
           Prometheus.inc_counter
             Prometheus.metric_silent_dashboard_actor_fallback
             ~labels:[ ("outcome", "none") ]
@@ -337,11 +375,23 @@ let dashboard_actor_for_request ~base_path request =
                the next dashboard load."
             else ""
           in
-          Log.Auth.warn
-            "[silent:dashboard_actor_fallback] outcome=error \
-             token_hash_prefix=%s err_kind=%s actor_hint=%s err=%s — falling \
-             back to request actor hint.%s"
-            token_hash_prefix err_kind hint err_str extra_hint;
+          let log_key =
+            String.concat "|"
+              [ "error"; err_kind; token_hash_prefix; hint ]
+          in
+          if dashboard_actor_fallback_should_warn ~key:log_key then
+            Log.Auth.warn
+              "[silent:dashboard_actor_fallback] outcome=error \
+               token_hash_prefix=%s err_kind=%s actor_hint=%s err=%s — falling \
+               back to request actor hint.%s Repeated identical fallbacks \
+               demoted to DEBUG for %.0fs"
+              token_hash_prefix err_kind hint err_str extra_hint
+              dashboard_actor_fallback_warn_restate_sec
+          else
+            Log.Auth.debug
+              "[silent:dashboard_actor_fallback] repeated outcome=error \
+               token_hash_prefix=%s err_kind=%s actor_hint=%s"
+              token_hash_prefix err_kind hint;
           Prometheus.inc_counter
             Prometheus.metric_silent_dashboard_actor_fallback
             ~labels:[ ("outcome", "error"); ("err_kind", err_kind) ]

--- a/test/test_auth_coverage.ml
+++ b/test/test_auth_coverage.ml
@@ -957,6 +957,61 @@ let test_dashboard_actor_invalid_token_fallback_is_counted () =
       in
       check bool "counter increments" true (after > before))
 
+let latest_log_seq_opt () =
+  match Log.Ring.recent ~limit:1 () with
+  | (entry : Log.Ring.entry) :: _ -> Some entry.seq
+  | [] -> None
+
+let recent_dashboard_actor_fallback_warns ?since_seq () =
+  Log.Ring.recent ~limit:50 ~module_filter:"Auth" ?since_seq ()
+  |> List.filter (fun (entry : Log.Ring.entry) ->
+       String.equal entry.level "WARN"
+       && Astring.String.is_infix
+            ~affix:"[silent:dashboard_actor_fallback] outcome=error"
+            entry.message)
+
+let test_dashboard_actor_invalid_token_fallback_warn_is_deduped () =
+  let module SA = Masc_mcp.Server_auth in
+  let dir = setup_test_room () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_test_room dir)
+    (fun () ->
+      ignore (Auth.enable_auth dir ~require_token:true ~agent_name:"bootstrap-admin");
+      let invalid_token = "definitely-invalid-token-dedupe-9786" in
+      let before =
+        Prometheus.metric_value_or_zero
+          Prometheus.metric_silent_dashboard_actor_fallback
+          ~labels:[ ("outcome", "error"); ("err_kind", "token_mismatch") ]
+          ()
+      in
+      let before_seq = latest_log_seq_opt () in
+      let headers =
+        Httpun.Headers.of_list
+          [
+            ("authorization", "Bearer " ^ invalid_token);
+            ("x-masc-agent", "dashboard-admin");
+          ]
+      in
+      let request = Httpun.Request.create ~headers `GET "/dashboard" in
+      check (option string) "first call falls back to actor hint"
+        (Some "dashboard-admin")
+        (SA.dashboard_actor_for_request ~base_path:dir request);
+      check (option string) "second call still falls back to actor hint"
+        (Some "dashboard-admin")
+        (SA.dashboard_actor_for_request ~base_path:dir request);
+      let warnings =
+        recent_dashboard_actor_fallback_warns ?since_seq:before_seq ()
+      in
+      let after =
+        Prometheus.metric_value_or_zero
+          Prometheus.metric_silent_dashboard_actor_fallback
+          ~labels:[ ("outcome", "error"); ("err_kind", "token_mismatch") ]
+          ()
+      in
+      check int "identical fallback emits one WARN" 1 (List.length warnings);
+      check bool "counter still records both fallbacks" true
+        (after >= before +. 2.0))
+
 let test_resolve_agent_name_rejects_invalid_token () =
   let module SA = Masc_mcp.Server_auth in
   let dir = setup_test_room () in
@@ -1200,6 +1255,8 @@ let () =
         test_sanitized_dashboard_actor_for_request_uses_token_owner;
       test_case "dashboard actor invalid token fallback is counted" `Quick
         test_dashboard_actor_invalid_token_fallback_is_counted;
+      test_case "dashboard actor invalid token fallback WARN is deduped" `Quick
+        test_dashboard_actor_invalid_token_fallback_warn_is_deduped;
       test_case "invalid token fails" `Quick
         test_resolve_agent_name_rejects_invalid_token;
       test_case "read request uses token owner" `Quick


### PR DESCRIPTION
## Summary

Deduplicate repeated `dashboard_actor_fallback` WARN logs for identical dashboard auth fallbacks.

The first unique fallback still emits the full WARN with token hash prefix, error kind, actor hint, and remediation. Repeated identical fallbacks are demoted to DEBUG for one hour, while the Prometheus counter continues to record every fallback.

## Product impact

- User-visible change: startup/runtime logs stop repeating the same dashboard token-mismatch WARN every refresh cycle.
- Operators keep the actionable first warning and metric count, so the signal is still diagnosable without flooding the dashboard/server logs.

## Evidence

- `scripts/dune-local.sh build test/test_auth_coverage.exe`
- `./_build/default/test/test_auth_coverage.exe` — 109 tests passed.
- `git diff --check`

## GOAL LOOP ACT checklist

- [x] Observe — user-provided startup logs showed repeated `[silent:dashboard_actor_fallback] outcome=error ... err_kind=token_mismatch ... falling back to request actor hint` warnings.
- [x] Orient — mapped to the dashboard actor fallback auth path and existing `token_mismatch` metric label.
- [x] Decide — this scope preserves the first WARN and metrics while reducing repeated identical noise.
- [x] Act — changed only `lib/server/server_auth.ml` and the focused auth coverage test.
- [x] Verify — focused Dune build, executable test run, and diff hygiene passed locally.
- [x] Loop — no follow-up for this narrow log-noise fix; broader dashboard/keeper runtime work remains outside this PR.

## Review evidence

- Added a regression test proving two identical invalid dashboard bearer requests emit only one WARN.
- The same test verifies the `token_mismatch` fallback counter still records both calls.
- Uses a small `Stdlib.Mutex`-protected in-process dedupe table because this path is a global auth/logging throttle and does not need Eio context.

## Linked issue

- Relates #11266

## Variant addition checklist

- [ ] **OCaml** — N/A: no OCaml variant was added, removed, or renamed.
- [ ] **TypeScript** — N/A: no TypeScript union member changed.
- [ ] **TLA+ spec** — N/A: no TLA+ domain literal changed.
- [ ] **Event / JSON schema** — N/A: no event type string, JSON schema enum, or canonical TOML key changed.
- [ ] **`make check-variants` passes** — N/A: this PR does not change variants or schemas.
