### PR TITLE
refactor(chronicle_event): replace try List.assoc/Not_found with List.assoc_opt

### DIFF
--- a/lib/chronicle_event.ml
+++ b/lib/chronicle_event.ml
@@ -278,8 +278,7 @@ let expect_assoc ~where = function
   | `Assoc fields -> Ok fields
   | _ -> Error (Printf.sprintf "%s: expected JSON object" where)
 
-let find_field fields name =
-  try Some (List.assoc name fields) with Not_found -> None
+let find_field fields name = List.assoc_opt name fields
 
 let require_string fields name =
   match find_field fields name with


### PR DESCRIPTION
## Summary

`chronicle_event.find_field` hand-rolled `List.assoc_opt` semantics with `try Some (List.assoc ...) with Not_found -> None`.  Replace with the direct call.

## Why

OCaml stdlib has shipped `List.assoc_opt : 'k -> ('k * 'v) list -> 'v option` since 4.05.  The manual `try`/`with` form *is the implementation* of `assoc_opt` — there is no semantic difference:

```ocaml
List.assoc_opt name fields
≡ try Some (List.assoc name fields) with Not_found -> None
```

The benefits of the direct call:

- removes a `try`/`with` block from a parse-path hot helper
- removes one `Not_found`-typed exception handler that a future reader would otherwise have to verify is the right one (it could plausibly be too narrow if the call surface ever grows beyond `List.assoc`)
- collapses three lines to one with no expressive loss

This is the standard OCaml-best-practice replacement for the manual `assoc_opt` shape that pre-dates 4.05's stdlib addition.

## Validation

- `dune build --root . lib/` — exit 0.
- `dune build --root . test/test_chronicle_event.exe` — exit 0.
- `./_build/default/test/test_chronicle_event.exe test` — 10/10 OK.

## RFC

Not required.  `lib/chronicle_event.ml` is not in the CLAUDE.md `agent_delegation` RFC-gated list.

## Related

Same family as #14107 (`List.hd` → pattern bind) and #14111 (non-empty invariant in signature) — small, surgical OCaml partial-function/exception-shape cleanups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)