### PR TITLE
fix: count dashboard metrics read drops

### DIFF
--- a/lib/dashboard/dashboard_http_keeper_metrics.ml
+++ b/lib/dashboard/dashboard_http_keeper_metrics.ml
@@ -245,6 +245,21 @@ let metrics_row_has_context_snapshot (j : Yojson.Safe.t) : bool =
   && has_int (member "context_max" j)
   && has_int (member "message_count" j)
 
+let keeper_metrics_24h_persistence_surface = "dashboard_keeper_metrics_24h"
+
+let report_keeper_metrics_24h_drop ~reason ~detail =
+  Safe_ops.report_persistence_read_drop
+    ~on_drop:(fun () ->
+      Prometheus.inc_counter Prometheus.metric_persistence_read_drops
+        ~labels:
+          [ ("surface", keeper_metrics_24h_persistence_surface); ("reason", reason) ]
+        ())
+    ~surface:keeper_metrics_24h_persistence_surface
+    ~reason
+    ~path:"<keeper_metrics_lines>"
+    ~detail
+;;
+
 let keeper_metrics_24h_json
     ~(metrics_lines : string list)
     ~(now_ts : float) : Yojson.Safe.t * Yojson.Safe.t =
@@ -258,7 +273,15 @@ let keeper_metrics_24h_json
   List.iter
     (fun line ->
       try
-        let j = Yojson.Safe.from_string line in
+        let j =
+          match Yojson.Safe.from_string line with
+          | `Assoc _ as json -> json
+          | _ ->
+              report_keeper_metrics_24h_drop
+                ~reason:Safe_ops.persistence_read_drop_reason_invalid_payload
+                ~detail:"keeper metrics row is not a JSON object";
+              raise Exit
+        in
         let ts_unix = Safe_ops.json_float ~default:0.0 "ts_unix" j in
         if ts_unix >= start_ts && ts_unix <= (now_ts +. 60.0)
            && metrics_row_has_context_snapshot j
@@ -292,7 +315,23 @@ let keeper_metrics_24h_json
             end
           end
         end
-      with Eio.Cancel.Cancelled _ as e -> raise e | exn -> Log.Server.info "keeper log parse: %s" (Printexc.to_string exn))
+      with
+      | Eio.Cancel.Cancelled _ as e -> raise e
+      | Exit -> ()
+      | Yojson.Json_error detail ->
+          report_keeper_metrics_24h_drop
+            ~reason:Safe_ops.persistence_read_drop_reason_entry_load_error
+            ~detail
+      | Yojson.Safe.Util.Type_error (detail, _) ->
+          report_keeper_metrics_24h_drop
+            ~reason:Safe_ops.persistence_read_drop_reason_invalid_payload
+            ~detail
+      | exn ->
+          let detail = Printexc.to_string exn in
+          report_keeper_metrics_24h_drop
+            ~reason:Safe_ops.persistence_read_drop_reason_invalid_payload
+            ~detail;
+          Log.Server.info "keeper log parse: %s" detail)
     lines;
   let rows =
     buckets

--- a/test/test_dashboard_keeper_metrics_10286.ml
+++ b/test/test_dashboard_keeper_metrics_10286.ml
@@ -2,6 +2,7 @@ open Alcotest
 
 module Metrics = Masc_mcp.Dashboard_http_keeper_metrics
 module Detail = Masc_mcp.Dashboard_http_keeper_detail
+module Prom = Masc_mcp.Prometheus
 
 let metric ?(channel = "turn") tools =
   `Assoc
@@ -66,6 +67,17 @@ let summary_bool field summary =
   match Yojson.Safe.Util.(summary |> member field) with
   | `Bool value -> value
   | other -> failf "expected bool field %s, got %s" field (Yojson.Safe.to_string other)
+
+let persistence_read_drop_total ~surface ~reason =
+  Prom.metric_value_or_zero Prom.metric_persistence_read_drops
+    ~labels:[("surface", surface); ("reason", reason)]
+    ()
+
+let check_persistence_read_drop_delta ~surface ~reason ~before ~delta =
+  check (float 0.0001)
+    (Printf.sprintf "%s/%s persistence read drops" surface reason)
+    (before +. float_of_int delta)
+    (persistence_read_drop_total ~surface ~reason)
 
 let test_contains_ci_preserves_literal_ascii_semantics () =
   check bool "ascii case-insensitive hit" true
@@ -246,6 +258,33 @@ let test_24h_context_ignores_sparse_tool_events () =
   | other ->
       failf "expected one 24h bucket, got %s" (Yojson.Safe.to_string other)
 
+let test_24h_context_counts_malformed_metric_rows () =
+  let surface = "dashboard_keeper_metrics_24h" in
+  let entry_reason = "entry_load_error" in
+  let invalid_reason = "invalid_payload" in
+  let before_entry =
+    persistence_read_drop_total ~surface ~reason:entry_reason
+  in
+  let before_invalid =
+    persistence_read_drop_total ~surface ~reason:invalid_reason
+  in
+  let _rows, summary =
+    Metrics.keeper_metrics_24h_json
+      ~metrics_lines:
+        [
+          json_line (context_snapshot ~context_ratio:0.75 ());
+          "[]";
+          "{not-json";
+        ]
+      ~now_ts:100.0
+  in
+  check int "valid sample preserved" 1
+    (summary_int "sample_points" summary);
+  check_persistence_read_drop_delta ~surface ~reason:entry_reason
+    ~before:before_entry ~delta:1;
+  check_persistence_read_drop_delta ~surface ~reason:invalid_reason
+    ~before:before_invalid ~delta:1
+
 let test_context_snapshot_classifier_rejects_sparse_tool_events () =
   check bool "context row qualifies" true
     (Metrics.metrics_row_has_context_snapshot (context_snapshot ()));
@@ -303,6 +342,8 @@ let () =
             test_metrics_window_action_rows_drive_observed_pr_work;
           test_case "24h context ignores sparse tool events" `Quick
             test_24h_context_ignores_sparse_tool_events;
+          test_case "24h context counts malformed rows" `Quick
+            test_24h_context_counts_malformed_metric_rows;
           test_case "classifies sparse tool events" `Quick
             test_context_snapshot_classifier_rejects_sparse_tool_events;
           test_case "series ignores sparse tool events" `Quick


### PR DESCRIPTION
## Summary
- count malformed rows in the dashboard keeper 24h metrics aggregator via masc_persistence_read_drops_total
- split syntax failures as entry_load_error and non-object/type failures as invalid_payload
- keep sparse tool_event rows ignored without treating them as malformed

## Verification
- git diff --check
- lockf -k -t 1200 /tmp/me-dune-local.lock env MASC_DUNE_LOCK_HELD=1 MASC_SKIP_OPAM_LOCK=1 DUNE_JOBS=1 DUNE_CACHE=disabled scripts/dune-local.sh build test/test_dashboard_keeper_metrics_10286.exe
- ./_build/default/test/test_dashboard_keeper_metrics_10286.exe