### PR TITLE
chore(docker): expand .dockerignore + document worker base image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -15,6 +15,12 @@ logs
 !dashboard/.env.production
 *.exe
 masc-mcp-linux-x64
+a.out
+*.native
+dashboard/dist/
+tmp_my_files/
+.recovered/
+cascade_trust/
 .github/
 docs/
 specs/

--- a/Dockerfile.worker-runtime
+++ b/Dockerfile.worker-runtime
@@ -10,6 +10,8 @@ RUN sudo apt-get update \
 
 RUN opam exec -- bash -lc "scripts/opam-pin-external-deps.sh && opam install . --deps-only -y && dune build @install"
 
+# debian:12-slim for worker — single-binary, lighter base sufficient.
+# Main Dockerfile uses ubuntu:24.04 for broader runtime libs (full server).
 FROM debian:12-slim AS runtime
 
 USER root


### PR DESCRIPTION
## Summary
- Add 6 missing exclusion patterns to `.dockerignore` (a.out, *.native, dashboard/dist/, tmp_my_files/, .recovered/, cascade_trust/) to keep build context lean
- Add comment to `Dockerfile.worker-runtime` explaining the intentional `debian:12-slim` vs main Dockerfile's `ubuntu:24.04` difference

## Test plan
- [ ] Verify `docker build` context size is reduced (no artifacts leaking)
- [ ] Verify `Dockerfile.worker-runtime` still builds successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)