### PR TITLE
refactor(cascade_catalog_runtime): bind secondary in pattern instead of Option.get

### DIFF
--- a/lib/cascade/cascade_catalog_runtime.ml
+++ b/lib/cascade/cascade_catalog_runtime.ml
@@ -1156,7 +1156,7 @@ let resolve_secondary_provider_for_primary ?sw ?net ?clock
       let try_entry (entry : Cascade_config_loader.weighted_entry) =
         match entry.secondary with
         | None -> None
-        | Some _ ->
+        | Some secondary ->
             (* Confirm this entry's primary parses to the same provider
                we were called with. We compare on the parsed
                Provider_config rather than on raw strings to handle
@@ -1172,8 +1172,7 @@ let resolve_secondary_provider_for_primary ?sw ?net ?clock
              | Some parsed when same_kind_model parsed ->
                  Cascade_config.parse_weighted_entry
                    ~api_key_env_overrides:profile.api_key_env_overrides
-                   (synth_secondary_entry entry
-                      (Option.get entry.secondary))
+                   (synth_secondary_entry entry secondary)
              | _ -> None)
       in
       (* Expand provider:auto entries without a rotation scope: this legacy


### PR DESCRIPTION
## Summary

`try_entry` discriminated `entry.secondary` with `| Some _ ->`, discarded the bound value, then re-extracted it inside the body with `Option.get entry.secondary`.  Bind it as `Some secondary ->` and hand `secondary` directly to `synth_secondary_entry` — the runtime invariant moves into the type system and the partial function call disappears.

## Why

`Option.get : 'a option -> 'a` raises `Invalid_argument "option is None"` on `None`.  Calling it inside a `Some _` arm is safe at runtime but leaves a partial function on the secondary-resolver hot path that runs on every cascade lookup.  If the surrounding pattern is ever refactored, the runtime guarantee is lost silently while the call still type-checks — exactly the kind of footgun the `private`-typed wrappers in RFC-0038 (#14116) are converging on.

This is the same axis as #14107 (`List.hd` after `_ :: _` pattern) and #14111 (`assert false` after caller-side non-empty proof) — the caller already proves the invariant; lift the proof from a runtime guard into the binding.

## Validation

- `dune build --root . lib/` — exit 0.
- `dune build --root . test/test_cascade_catalog_runtime.exe` — exit 0.
- `./_build/default/test/test_cascade_catalog_runtime.exe test` — 22/22 OK, including "secondary resolver disambiguates duplicates" and "applies provider_filter" which exercise this code path.

## Diff shape

`lib/cascade/cascade_catalog_runtime.ml | 5 +++--` — 1 file, +2/-3.  No `.mli` changes.

## RFC

Not required.  `lib/cascade/cascade_catalog_runtime.ml` is not in the CLAUDE.md `agent_delegation` RFC-gated list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)