### PR TITLE
perf(coord): observability for broadcast hot path + file lock contention

### DIFF
--- a/lib/coord.ml
+++ b/lib/coord.ml
@@ -317,6 +317,39 @@ let () =
   Atomic.set Coord_hooks.task_auto_release_observed_fn
     record_task_auto_release
 
+(* Coord broadcast latency histogram and file lock retry/duration metrics.
+
+   At 64+ keepers the broadcast hot path serialises against [state.json]
+   (next_seq) and writes msg.json + activity events under file locks.
+   Without these series operators see only the SSE-side latency
+   ([masc_sse_broadcast_duration_seconds]); the publisher-side cost
+   (state lock + read/write + activity emit) was invisible.
+
+   File-lock metrics are wired here rather than in [masc_process]
+   because that sub-library does not depend on [Prometheus]; the hook
+   in [File_lock_eio.on_lock_attempt_fn] forwards each attempt outcome
+   to this site. *)
+let record_coord_broadcast ~msg_type ~elapsed_s =
+  Prometheus.observe_histogram Prometheus.metric_coord_broadcast_duration
+    ~labels:[ ("msg_type", msg_type) ] elapsed_s
+
+let () =
+  Atomic.set Coord_hooks.coord_broadcast_observed_fn
+    record_coord_broadcast
+
+let record_file_lock_attempt ~caller ~retries ~elapsed_s ~outcome =
+  if retries > 0 then
+    Prometheus.inc_counter Prometheus.metric_file_lock_retries
+      ~labels:[ ("caller", caller) ]
+      ~delta:(float_of_int retries) ();
+  Prometheus.observe_histogram Prometheus.metric_file_lock_acquire_duration
+    ~labels:[ ("caller", caller); ("outcome", outcome) ]
+    elapsed_s
+
+let () =
+  Atomic.set File_lock_eio.on_lock_attempt_fn
+    record_file_lock_attempt
+
 let clear_agent_current_task_cache config ~task_id =
   let agents_path = agents_dir config in
   if path_exists config agents_path then

--- a/lib/coord/coord_broadcast.ml
+++ b/lib/coord/coord_broadcast.ml
@@ -63,6 +63,13 @@ let on_broadcast_mention : (string option -> unit) ref =
 
 let broadcast ?trace_context ?(msg_type = "broadcast")
     ?(task_cache_invariant_checked = false) config ~from_agent ~content =
+  let started_at = Time_compat.now () in
+  let observe final_msg_type =
+    let elapsed_s = Float.max 0.0 (Time_compat.now () -. started_at) in
+    try (Atomic.get Coord_hooks.coord_broadcast_observed_fn)
+          ~msg_type:final_msg_type ~elapsed_s
+    with Eio.Cancel.Cancelled _ as e -> raise e | _ -> ()
+  in
   ensure_initialized config;
   (* Fleet-wide invariant (PR-B): if the broadcasting agent's current_task is
      terminal in the backlog, replace the original broadcast with a single
@@ -146,4 +153,5 @@ let broadcast ?trace_context ?(msg_type = "broadcast")
    with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
      Log.Misc.warn "on_broadcast_mention callback failed: %s"
        (Printexc.to_string exn));
+  observe safe_msg_type;
   Printf.sprintf "\xF0\x9F\x93\xA2 [%s] %s" safe_agent safe_content

--- a/lib/coord/coord_hooks.ml
+++ b/lib/coord/coord_hooks.ml
@@ -241,6 +241,19 @@ let task_auto_release_observed_fn
   : (agent_name:string -> from_status:string -> unit) Atomic.t
   = Atomic.make (fun ~agent_name:_ ~from_status:_ -> ())
 
+(** Wall-clock latency of [Coord_broadcast.broadcast] including
+    [next_seq] (state.json file lock + read + write), agent.json read
+    for the cache-invariant check, msg.json write, [backend_publish],
+    [emit_message_activity], and the [on_broadcast_mention] callback.
+    Labelled by [msg_type] so [cache_invalidated] follow-ups (which
+    skip the agent.json read + use the rewritten content) are
+    distinguishable from regular broadcasts.  Default no-op; emit
+    lives in [lib/coord.ml] to avoid a [masc_coord → Prometheus] dep
+    cycle. *)
+let coord_broadcast_observed_fn
+  : (msg_type:string -> elapsed_s:float -> unit) Atomic.t
+  = Atomic.make (fun ~msg_type:_ ~elapsed_s:_ -> ())
+
 (** #13460: stale task-state cache emission observability.
     Coord sub-modules fire this when they replace a stale active-task
     broadcast/mention with a cache invalidation message. [lib/coord.ml]

--- a/lib/coord/coord_hooks.mli
+++ b/lib/coord/coord_hooks.mli
@@ -65,6 +65,16 @@ val task_completion_path_observed_fn : (path:string -> contract_state:string -> 
            Atomic.t
 val task_auto_release_observed_fn :
   (agent_name:string -> from_status:string -> unit) Atomic.t
+
+(** Fires once per [Coord_broadcast.broadcast] return, with the wall-clock
+    duration of the broadcast body (next_seq + agent.json read +
+    msg.json write + activity emit + on_broadcast_mention).  Wired at
+    startup ([lib/coord.ml]) to a Prometheus histogram
+    [masc_coord_broadcast_duration_seconds] labelled by [msg_type] so
+    operators can compare regular broadcasts against
+    [cache_invalidated] / mention follow-ups. *)
+val coord_broadcast_observed_fn :
+  (msg_type:string -> elapsed_s:float -> unit) Atomic.t
 val cache_desync_cleared_fn :
   (Coord_utils_backend_setup.config ->
    module_name:string -> task_id:string -> status:string -> unit) Atomic.t

--- a/lib/process/file_lock_eio.ml
+++ b/lib/process/file_lock_eio.ml
@@ -15,6 +15,29 @@ module SMap = Map.Make(String)
 
 exception Flock_timeout of { caller : string; path : string; attempts : int }
 
+(** Observability hook fired after each [acquire_flock_retry*] attempt
+    sequence completes — once on success, once on timeout.  Wired at
+    startup ([lib/coord.ml]) to a Prometheus counter + histogram so
+    lock-contention spikes become visible without scraping logs.
+
+    [retries] is the number of failed [F_TLOCK] attempts before the
+    final outcome (0 means the first attempt succeeded).  [elapsed_s]
+    is the wall-clock time spent inside [acquire_flock_retry*]
+    excluding [openfile].  [outcome] is ["acquired"] or ["timeout"].
+
+    Default no-op; [masc_process] cannot depend on [Prometheus]
+    (sub-library boundary, would be a cycle), so emission is wired
+    from the [masc_mcp] root via this Atomic ref. *)
+let on_lock_attempt_fn :
+    (caller:string -> retries:int -> elapsed_s:float -> outcome:string -> unit)
+      Atomic.t =
+  Atomic.make (fun ~caller:_ ~retries:_ ~elapsed_s:_ ~outcome:_ -> ())
+
+let observe_lock_attempt ~caller ~retries ~started_at ~outcome =
+  let elapsed_s = max 0.0 (Time_compat.now () -. started_at) in
+  try (Atomic.get on_lock_attempt_fn) ~caller ~retries ~elapsed_s ~outcome
+  with Eio.Cancel.Cancelled _ as e -> raise e | _ -> ()
+
 let rec atomic_update atomic f =
   let old_val = Atomic.get atomic in
   let new_val = f old_val in
@@ -96,9 +119,13 @@ let run_blocking_lock_op f = Eio_guard.run_in_systhread f
 let acquire_flock_retry ?clock:(_clock = None) ~lock_path ~mode ~perm
     ?(max_attempts = 200) ?(sleep_sec = 0.01) ~caller () =
   let fd = Unix.openfile lock_path mode perm in
+  let started_at = Time_compat.now () in
   let rec acquire attempts =
-    if attempts <= 0 then
+    if attempts <= 0 then begin
+      observe_lock_attempt ~caller ~retries:max_attempts ~started_at
+        ~outcome:"timeout";
       raise (Flock_timeout { caller; path = lock_path; attempts = max_attempts })
+    end
     else
       let success =
         try
@@ -108,7 +135,11 @@ let acquire_flock_retry ?clock:(_clock = None) ~lock_path ~mode ~perm
         | Unix.Unix_error (Unix.EAGAIN, _, _)
         | Unix.Unix_error (Unix.EACCES, _, _) -> false
       in
-      if success then fd
+      if success then begin
+        observe_lock_attempt ~caller
+          ~retries:(max_attempts - attempts) ~started_at ~outcome:"acquired";
+        fd
+      end
       else begin
         Unix.sleepf sleep_sec;
         acquire (attempts - 1)
@@ -128,9 +159,13 @@ let acquire_flock_retry ?clock:(_clock = None) ~lock_path ~mode ~perm
 let acquire_flock_retry_cooperative ?clock ~lock_path ~mode ~perm
     ?(max_attempts = 200) ?(sleep_sec = 0.01) ~caller () =
   let fd = run_blocking_lock_op (fun () -> Unix.openfile lock_path mode perm) in
+  let started_at = Time_compat.now () in
   let rec acquire attempts =
-    if attempts <= 0 then
+    if attempts <= 0 then begin
+      observe_lock_attempt ~caller ~retries:max_attempts ~started_at
+        ~outcome:"timeout";
       raise (Flock_timeout { caller; path = lock_path; attempts = max_attempts })
+    end
     else
       let success =
         run_blocking_lock_op (fun () ->
@@ -141,7 +176,11 @@ let acquire_flock_retry_cooperative ?clock ~lock_path ~mode ~perm
             | Unix.Unix_error (Unix.EAGAIN, _, _)
             | Unix.Unix_error (Unix.EACCES, _, _) -> false)
       in
-      if success then fd
+      if success then begin
+        observe_lock_attempt ~caller
+          ~retries:(max_attempts - attempts) ~started_at ~outcome:"acquired";
+        fd
+      end
       else begin
         (match clock with
          | Some c -> Eio.Time.sleep c sleep_sec

--- a/lib/process/file_lock_eio.mli
+++ b/lib/process/file_lock_eio.mli
@@ -85,6 +85,25 @@ val with_lock :
   (unit -> 'a) ->
   'a
 
+(** {1 Observability hook} *)
+
+(** Fires after every {!acquire_flock_retry} / {!acquire_flock_retry_cooperative}
+    attempt sequence completes — once per [acquire_*] invocation, with
+    [outcome] = ["acquired"] or ["timeout"].
+
+    [retries] is the number of failed [F_TLOCK] attempts before the
+    final outcome (0 = succeeded on the first attempt).  [elapsed_s]
+    is the wall-clock time spent in the retry loop excluding [openfile].
+
+    Default no-op.  Wired at startup ([lib/coord.ml]) to a Prometheus
+    counter ([masc_file_lock_retries_total]) and histogram
+    ([masc_file_lock_acquire_seconds]) so contention storms surface in
+    metrics.  [masc_process] cannot depend on [Prometheus] (sub-library
+    boundary), so emission goes through this Atomic ref. *)
+val on_lock_attempt_fn :
+  (caller:string -> retries:int -> elapsed_s:float -> outcome:string -> unit)
+    Atomic.t
+
 (** {1 Diagnostics} *)
 
 (** Current number of tracked lock paths. *)

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -901,6 +901,9 @@ let metric_sse_queue_depth_avg = "masc_sse_queue_depth_avg"
 let metric_sse_queue_depth_max = "masc_sse_queue_depth_max"
 let metric_sse_external_subscribers = "masc_sse_external_subscribers_total"
 let metric_sse_client_evictions = "masc_sse_client_evictions_total"
+let metric_coord_broadcast_duration = "masc_coord_broadcast_duration_seconds"
+let metric_file_lock_retries = "masc_file_lock_retries_total"
+let metric_file_lock_acquire_duration = "masc_file_lock_acquire_seconds"
 let metric_grpc_active_streams = "masc_grpc_active_streams_total"
 let metric_grpc_heartbeat_latency = "masc_grpc_heartbeat_latency_seconds"
 let metric_grpc_subscribers = "masc_grpc_subscribers_total"
@@ -2549,6 +2552,15 @@ let init () =
      warning that broadcast fan-out is keeping mailboxes full faster \
      than slow consumers can drain."
     Counter;
+  register_histogram ~name:metric_coord_broadcast_duration
+    ~help:"Coord_broadcast.broadcast latency (next_seq + agent.json read + msg.json write + activity emit + on_broadcast_mention). Pairs with masc_sse_broadcast_duration_seconds. Labels: msg_type."
+    ();
+  add metric_file_lock_retries
+    "F_TLOCK retries before [acquire_flock_retry*] returned. Pairs with masc_file_lock_acquire_seconds. Labels: caller."
+    Counter;
+  register_histogram ~name:metric_file_lock_acquire_duration
+    ~help:"acquire_flock_retry* wall-clock excluding openfile. Labels: caller, outcome (acquired|timeout)."
+    ();
 
   (* The keeper turn / cascade / persistence-failure metrics
      (turn_livelock_blocks .. session_cleanup_failures, plus

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -1003,6 +1003,9 @@ val metric_sse_queue_depth_avg : string
 val metric_sse_queue_depth_max : string
 val metric_sse_external_subscribers : string
 val metric_sse_client_evictions : string
+val metric_coord_broadcast_duration : string
+val metric_file_lock_retries : string
+val metric_file_lock_acquire_duration : string
 val metric_grpc_active_streams : string
 val metric_grpc_heartbeat_latency : string
 val metric_grpc_subscribers : string


### PR DESCRIPTION
## Context

64+ keeper 운영 목표 환경에서 broadcast publisher path는 [state.json] (next_seq → with_file_lock → 200×10ms F_TLOCK retry = ~2s tail) + msg.json write + activity event emit 를 hot path 에서 직렬 수행합니다. 17-keeper baseline 에서 측정한 [/health] p99 = 1.4s 의 변동성(13×)이 lock contention 시그니처 그대로지만, **publisher 측 측정 신호가 zero** 였습니다 — [masc_sse_broadcast_duration_seconds] 는 SSE fan-out 만 cover.

**이 PR은 의도적으로 observability-only** 입니다. CLAUDE.md \"Harness First — 측정 가능한 evaluator 없이 AI 에이전트 코드 진행 금지\" 와 메모리 [feedback_pr_13221_cache_poisoning_misanalysis.md] (caller-context 검증 안 한 fix 의 사고 사례) 에 따라, *실제 어디가 느린가* 를 데이터로 확인한 뒤 PR-3 (concurrency surgical) 의 fix target 을 결정합니다. async msg.json write 같은 변경은 [state.json] message_seq ↔ messages/<seq>_*.json 정합성 위험이 커서 별도 RFC 로 분리합니다.

## Summary

- [lib/process/file_lock_eio.{ml,mli}] — [on_lock_attempt_fn] Atomic hook: [acquire_flock_retry*] 한 번 끝날 때마다 (caller / retries / elapsed_s / outcome) 발화. [masc_process] 가 [Prometheus] 에 직접 의존할 수 없어(서브라이브러리 dep cycle) hook 으로 우회.
- [lib/coord/coord_hooks.{ml,mli}] — [coord_broadcast_observed_fn] Atomic hook: [Coord_broadcast.broadcast] 반환 직전 (msg_type / elapsed_s) 발화. 같은 dep cycle 이유.
- [lib/coord/coord_broadcast.ml] — broadcast 본문을 [Time_compat.now] 로 감싸고 종료 시 hook 호출. 예외 경로는 측정 제외 (불완전 broadcast 의 duration 은 misleading).
- [lib/coord.ml] — 두 hook 을 [Prometheus.observe_histogram] / [inc_counter] 로 wiring. 기존 [task_completion_path_observed_fn] / [task_auto_release_observed_fn] 패턴 그대로.
- [lib/prometheus.{ml,mli}] — 3 metric 등록:
  - [masc_coord_broadcast_duration_seconds] histogram, label [msg_type]
  - [masc_file_lock_retries_total] counter, label [caller]
  - [masc_file_lock_acquire_seconds] histogram, label [caller, outcome]

## After-PR diagnostic surface

| 질문 | 사용 metric |
|------|-------------|
| Broadcast 느림이 publisher인가 consumer인가? | [coord_broadcast_duration] vs [sse_broadcast_duration] |
| 어느 caller 가 file lock retry 를 만드는가? | [file_lock_retries_total{caller}] |
| Lock acquire latency p99 / timeout 비율? | [file_lock_acquire_seconds{caller, outcome}] |

## Verification

| Gate | Result |
|------|--------|
| dune build --root . | ✅ pass |
| test_sse | ✅ 4/4 |
| test_sse_coverage | ✅ 35/35 |
| test_transport_metrics | ✅ 21/21 |
| test_file_lock_eio | ✅ 3/3 |
| test_oas_integration | ✅ 28/28 |
| test_distributed_lock_acquire_failed_counter | ✅ 4/4 |

운영 환경 검증 (PR 머지 후): server restart 후 [/metrics] 에서 broadcast 1회당 [coord_broadcast_duration] p99 / file_lock_retries rate 를 측정 → PR-3 의 정확한 target 확인.

## Test plan

- [x] dune build pass
- [x] sse / coord / transport / oas / file_lock test 0 regression
- [ ] 머지 후 [/metrics] 에서 신규 3 series 노출 확인
- [ ] 17-keeper baseline 측정: broadcast p99 / lock retry rate
- [ ] 64-keeper bring-up 후 동일 measurement

## Bump and Pump (PR series)

PR-2 of 3 staged Draft series. PR-1 [#14112] (transport SSE capacity wired) 머지됨. PR-3 (concurrency surgical) 는 본 PR 의 metric 으로 식별된 target 을 가지고 진행 — speculation 이 아닌 data-driven. agent-authored Draft, [human-approved-ready] 라벨 후 ready 전환.

## RFC

[bash ~/me/scripts/pr-rfc-check.sh] 통과 (변경 영역이 credential / identity / repo / operator / sandbox / hooks / workflow 어느 것도 건드리지 않음).

🤖 Generated with [Claude Code](https://claude.com/claude-code)