### PR TITLE
refactor(coord_hooks): use Safe_ops.protect for cancel-aware exception suppression

### DIFF
--- a/lib/coord/coord_hooks.ml
+++ b/lib/coord/coord_hooks.ml
@@ -284,12 +284,16 @@ let claim_post_provision_failed_fn
 
 let observe_claim_post_provision_failure ~site ~agent_name ~task_id exn =
   let error = Printexc.to_string exn in
-  (try
-     (Atomic.get claim_post_provision_failed_fn)
-       ~site ~agent_name ~task_id ~error
-   with _ -> ());
-  (try
-     Log.RoomTask.warn
-       "claim_post_provision failed site=%s agent=%s task=%s err=%s"
-       site agent_name task_id error
-   with _ -> ())
+  (* This is the failure-observation path; we suppress secondary
+     exceptions from the callback and log so the original [exn] is
+     not masked by an instrumentation failure.  [Safe_ops.protect]
+     re-raises [Eio.Cancel.Cancelled] so a cancel racing with the
+     surrounding fiber still propagates instead of being silently
+     swallowed by [with _ -> ()]. *)
+  Safe_ops.protect ~default:() (fun () ->
+    (Atomic.get claim_post_provision_failed_fn)
+      ~site ~agent_name ~task_id ~error);
+  Safe_ops.protect ~default:() (fun () ->
+    Log.RoomTask.warn
+      "claim_post_provision failed site=%s agent=%s task=%s err=%s"
+      site agent_name task_id error)


### PR DESCRIPTION
## Summary

Replace two raw `try ... with _ -> ()` blocks in `observe_claim_post_provision_failure` with `Safe_ops.protect ~default:()`.  Same suppression behavior for ordinary exceptions; `Eio.Cancel.Cancelled` is now re-raised instead of silently swallowed.

## Why

`observe_claim_post_provision_failure` is the failure-observation path — when a claim fails, it records the failure via an atomic-stored callback and logs a warning.  Both side effects were wrapped in `try ... with _ -> ()` to keep instrumentation failures from masking the original `exn`.

The raw `with _ ->` also catches `Eio.Cancel.Cancelled`.  In an Eio fiber a cancel racing with the surrounding handler is silently absorbed by the observation path — the cancel never propagates and the parent switch never tears down.

`Safe_ops.protect ~default:()` (already used in `lib/coord/coord_query.ml:67`) has the cancel-aware semantics documented in `lib/core/safe_ops.ml:13-21`:

```ocaml
let protect ~default f =
  try f ()
  with
  | Eio.Cancel.Cancelled _ as e ->
    let bt = Printexc.get_raw_backtrace () in
    Printexc.raise_with_backtrace e bt
  | _ -> default
```

Cancel re-raised with the original backtrace; other exceptions swallowed exactly as before.

## Validation

- `dune build --root . lib/` — exit 0.
- `dune build --root . test/test_claim_post_provision_hook.exe` — exit 0.
- `./_build/default/test/test_claim_post_provision_hook.exe test` — 4/4 OK, including:
  - `does not block claim on hook failure` (suppression path)
  - `observes claim_next hook failure` (observation callback path)

## Diff shape

`lib/coord/coord_hooks.ml | 22 ++++++++++++----------` — 1 file, +13/-9 (the additional 4 lines are the inline why-comment explaining cancel-awareness).

## RFC

Not required.  `lib/coord/coord_hooks.ml` is not in the CLAUDE.md `agent_delegation` RFC-gated list.

## Companion

Continues the typed-correctness ratchet alongside #14107 / #14111 / #14119 / #14123 — each removes one OCaml partial-function or cancel-unsafe shape with the helper the rest of the codebase already uses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)