### PR TITLE
fix(coord): clear agent current_task on stale claim release (RFC-0034.d)

### DIFF
--- a/docs/rfc/RFC-0034d-stale-agent-sync.md
+++ b/docs/rfc/RFC-0034d-stale-agent-sync.md
@@ -1,0 +1,92 @@
+# RFC 0034.d — release_stale_claims agent-side sync
+
+- **Status**: Draft (loop-iter-5, 2026-05-07)
+- **Author**: Vincent + Claude (auto-mode loop)
+- **Sister RFC**: RFC-0034.v2 (cap-all-callers)
+- **Resolves Board Issue**: "Tripartite Coordination Breakdown — task-037 stale claim spam, MASC claim_scope still lists task-037 as claimed" + "Fact 2: nick0cave runtime shows current_task_id=null"
+
+## 1. Motivation
+
+`Coord_task_schedule.release_stale_claims` (lib/coord/coord_task_schedule.ml:761~825) is the only path that auto-recovers stale claims. Currently it mutates *only* the backlog file:
+
+```ocaml
+match task.task_status with
+| Claimed { ts; ... } when now-ts > ttl ->
+    stale_tasks += (id, assignee);
+    log_event "stale_claim_released";
+    { task with task_status = Todo; worktree = None; }   (* ← only mutation *)
+```
+
+It does **NOT** update the assignee's agent file — the assignee's `current_task_id` field still points to the released task. Result: 4-surface mismatch reported by board:
+
+- backlog: `task_status = Todo` ✓
+- agent file `current_task_id`: still set to `task-037` ✗
+- dashboard cache: stale until TTL expiry ✗ (out-of-scope)
+- worktree HEAD: external cleanup (out-of-scope)
+
+`Coord_task.update_local_agent_state config ~agent_name (fun agent -> { agent with current_task_id = None })` 가 이미 존재 — 호출만 추가하면 됨.
+
+## 2. Design
+
+`release_stale_claims` 본문에서 `stale_tasks`에 추가될 때마다 해당 assignee의 agent state도 정리.
+
+```ocaml
+(* Before *)
+if now_f -. ts > ttl_seconds then begin
+  stale_tasks := (task.id, assignee) :: !stale_tasks;
+  log_event config (...);
+  { task with task_status = Todo; worktree = None }
+end else task
+
+(* After *)
+if now_f -. ts > ttl_seconds then begin
+  stale_tasks := (task.id, assignee) :: !stale_tasks;
+  log_event config (...);
+  (* RFC-0034.d: clear assignee's current_task_id to keep
+     agent state in sync with backlog release *)
+  Coord_task.update_local_agent_state config ~agent_name:assignee (fun agent ->
+    if agent.current_task_id = Some task.id then
+      { agent with current_task_id = None }
+    else agent);
+  { task with task_status = Todo; worktree = None }
+end else task
+```
+
+`InProgress` 분기에도 동일 호출 추가.
+
+`Coord_task.update_local_agent_state`는 `if agent.current_task_id = Some task.id` 체크로 *이미 다른 task를 잡은 keeper의 state는 건드리지 않음*. 안전한 idempotent 정정.
+
+## 3. Risks
+
+- `update_local_agent_state`가 `with_file_lock`을 잡음 → release_stale_claims도 backlog file_lock 안에서 호출 중. 다른 file lock 잡음 → potential deadlock?
+  - 검증 필요: agent file lock과 backlog lock이 다른 path → 다른 lock identity. 일반적으로 OK.
+  - 안전 장치: agent state update가 실패해도 backlog mutation은 이미 성공한 상태. 둘 사이 atomicity는 *이미 부재* (현 시스템도 그러함). RFC는 best-effort sync.
+
+## 4. Tests
+
+`test/test_coord_task_schedule.ml` (or 기존 test)에 추가:
+- `test_release_stale_claims_clears_agent_current_task` — task를 keeper A가 claim, ttl 초과 → release_stale_claims → keeper A의 agent file `current_task_id = None`.
+- `test_release_stale_claims_preserves_other_agent_task` — 다른 keeper B가 다른 task 작업 중 → release_stale_claims → keeper B의 `current_task_id` 보존.
+
+## 5. Implementation Plan
+
+| 단계 | 산출물 | LOC |
+|---|---|---|
+| S1 | `release_stale_claims` 본문 두 분기에 호출 추가 | +6 |
+| S2 | 회귀 테스트 2건 | +50 |
+| S3 | dune build + test green | — |
+| S4 | Draft PR | — |
+
+총 ~+56 LOC, 단일 micro-PR.
+
+## 6. Verification
+
+- 기존 stale claim release 테스트 green
+- 신규 2건 green
+- `Prometheus.metric_keeper_slot_force_released` 등 기존 카운터 변경 없음 (count는 동일, agent state 동기화만 추가)
+
+## 7. References
+
+- iter-4 §2 ("release_stale_claims가 정정 못 하는 surface")
+- iter-5 §1 (claim_scope 정체 분석)
+- 코드: `lib/coord/coord_task_schedule.ml:761~825`, `lib/coord/coord_task_classify.ml:109` `update_local_agent_state`

--- a/lib/coord/coord_task_schedule.ml
+++ b/lib/coord/coord_task_schedule.ml
@@ -775,6 +775,26 @@ let release_stale_claims config ~ttl_seconds =
           `Float (max 0.0 (now_f -. ts))
         in
         let stale_tasks = ref [] in
+        (* RFC-0034.d: clear assignee's [current_task] mirror when we
+           release a stale Claimed/InProgress task.  Best-effort — agent
+           file lock is a different file/identity from the backlog lock,
+           and on failure we keep the backlog mutation (the source of
+           truth) and only log the agent-side miss.  Eio.Cancel.Cancelled
+           is re-raised to match surrounding cancel semantics. *)
+        let clear_assignee_current_task ~assignee ~task_id =
+          try
+            Coord_task.update_local_agent_state config ~agent_name:assignee
+              (fun agent ->
+                if agent.current_task = Some task_id
+                then { agent with current_task = None }
+                else agent)
+          with
+          | Eio.Cancel.Cancelled _ as e -> raise e
+          | exn ->
+              Log.Orchestrator.warn
+                "[stale-claims] agent state clear failed for %s task=%s: %s"
+                assignee task_id (Printexc.to_string exn)
+        in
         let updated_tasks = List.map (fun (task : task) ->
           match task.task_status with
           | Claimed { assignee; claimed_at } ->
@@ -788,6 +808,7 @@ let release_stale_claims config ~ttl_seconds =
                   ("age_s", age_seconds_json ts);
                   ("ts", `String now_str);
                 ]);
+                clear_assignee_current_task ~assignee ~task_id:task.id;
                 { task with
                   task_status = Todo;
                   worktree = None;
@@ -804,6 +825,7 @@ let release_stale_claims config ~ttl_seconds =
                   ("age_s", age_seconds_json ts);
                   ("ts", `String now_str);
                 ]);
+                clear_assignee_current_task ~assignee ~task_id:task.id;
                 { task with
                   task_status = Todo;
                   worktree = None;

--- a/test/test_room.ml
+++ b/test/test_room.ml
@@ -914,6 +914,60 @@ let test_release_stale_claims_skips_invalid_backlog () =
     Alcotest.(check (list (pair string string))) "no stale claims released" [] released
   )
 
+(* RFC-0034.d: release_stale_claims must clear the assignee's
+   on-disk current_task mirror so the agent file no longer points at
+   a backlog task that has been forced back to Todo. *)
+let agent_current_task config ~agent_name =
+  let agents = Coord.get_all_agents config in
+  match List.find_opt (fun (a : Masc_domain.agent) -> a.name = agent_name) agents with
+  | Some agent -> agent.current_task
+  | None -> None
+
+(* Use pre-formed nicknames so the assignee written into the backlog
+   by [Coord.claim_task] matches the [<nickname>.json] agent file. The
+   production board issue (RFC-0034.d §1) was reported with nicknames
+   (e.g. nick0cave), so this models the actual desync surface. *)
+let stale_nick = "claude-stale-fox"
+let other_nick = "claude-other-bear"
+
+let test_release_stale_claims_clears_agent_current_task () =
+  with_test_env (fun config ->
+    let _ = Coord.join config ~agent_name:stale_nick ~capabilities:[] () in
+    let _ = Coord.add_task config ~title:"Stale work" ~priority:1 ~description:"" in
+    let _ = Coord.claim_task config ~agent_name:stale_nick ~task_id:"task-001" in
+    (* claim_task does not mirror current_task on the agent file —
+       transition/start does — so set the mirror explicitly to model
+       a keeper that progressed to InProgress before going stale. *)
+    Coord.update_local_agent_state config ~agent_name:stale_nick
+      (fun agent -> { agent with current_task = Some "task-001" });
+    Alcotest.(check (option string)) "precondition: agent.current_task set"
+      (Some "task-001") (agent_current_task config ~agent_name:stale_nick);
+    (* ttl_seconds:0.0 forces the just-recorded claim to be stale. *)
+    let released = Coord.release_stale_claims config ~ttl_seconds:0.0 in
+    Alcotest.(check (list (pair string string)))
+      "task-001 released against assignee" [("task-001", stale_nick)] released;
+    Alcotest.(check (option string)) "agent.current_task cleared" None
+      (agent_current_task config ~agent_name:stale_nick)
+  )
+
+(* Spec: agent A claimed task X, then its on-disk pointer moved to a
+   different task Y (e.g. a fresh claim under a different lock window).
+   When the stale sweep releases X, A's [current_task] must remain
+   [Some Y] — only the task-X-specific pointer gets cleared. *)
+let test_release_stale_claims_preserves_other_agent_task () =
+  with_test_env (fun config ->
+    let _ = Coord.join config ~agent_name:other_nick ~capabilities:[] () in
+    let _ = Coord.add_task config ~title:"Stale work" ~priority:1 ~description:"" in
+    let _ = Coord.claim_task config ~agent_name:other_nick ~task_id:"task-001" in
+    Coord.update_local_agent_state config ~agent_name:other_nick
+      (fun agent -> { agent with current_task = Some "task-999" });
+    let released = Coord.release_stale_claims config ~ttl_seconds:0.0 in
+    Alcotest.(check (list (pair string string)))
+      "task-001 released from backlog" [("task-001", other_nick)] released;
+    Alcotest.(check (option string)) "agent kept its newer current_task"
+      (Some "task-999") (agent_current_task config ~agent_name:other_nick)
+  )
+
 
 let test_heartbeat_nonexistent_agent () =
   with_test_env (fun config ->
@@ -1834,6 +1888,10 @@ let () =
         test_read_backlog_r_reports_parse_error_when_recovery_is_also_invalid;
       Alcotest.test_case "release stale claims skips invalid backlog" `Quick
         test_release_stale_claims_skips_invalid_backlog;
+      Alcotest.test_case "release stale claims clears agent current_task" `Quick
+        test_release_stale_claims_clears_agent_current_task;
+      Alcotest.test_case "release stale claims preserves other agent task" `Quick
+        test_release_stale_claims_preserves_other_agent_task;
       Alcotest.test_case "cleanup zombies empty" `Quick test_cleanup_zombies_empty;
       Alcotest.test_case "cleanup detects regular zombie" `Quick test_cleanup_zombies_detects_regular;
       Alcotest.test_case "cleanup detects keeper zombie" `Quick test_cleanup_zombies_detects_keeper;


### PR DESCRIPTION
## Summary

- `Coord_task_schedule.release_stale_claims` now clears the assignee's on-disk `agent.current_task` mirror whenever it rewrites a stale `Claimed`/`InProgress` task back to `Todo`.
- Implements RFC-0034.d (single-axis fix; sister RFC-0034.v2 covers the broader cap-all-callers track).

## Root cause

Operators reported a 4-surface mismatch on the coordination board:

- backlog: `task_status = Todo` after stale sweep ✓
- agent file `current_task`: still pointed at the released task ✗
- dashboard cache + worktree HEAD: out-of-scope follow-ups

The stale-sweep path was the only auto-recovery hook, and it only mutated the backlog. Existing `transition_task` already pairs backlog writes with `update_local_agent_state`; the stale path was the missing pair.

## Files changed

| Path | LOC |
|---|---|
| `docs/rfc/RFC-0034d-stale-agent-sync.md` | +93 (new) |
| `lib/coord/coord_task_schedule.ml` | +22 |
| `test/test_room.ml` | +58 (incl. test wiring) |

## Implementation notes

- New `clear_assignee_current_task` helper lives inside `release_stale_claims`'s outer backlog-lock scope. It calls `Coord_task.update_local_agent_state` (own `with_file_lock` on the agent file — different lock identity from the backlog file, so no deadlock).
- Guard `if agent.current_task = Some task.id then ... else agent` keeps the call idempotent and refuses to stomp a keeper that already re-targeted to a different task (covered by test 2).
- Errors are logged (`Log.Orchestrator.warn`) and swallowed so an agent-file lock contention cannot prevent the backlog mutation. `Eio.Cancel.Cancelled _` is re-raised to match the surrounding cancel semantics in `coord_task.ml`.

## RFC reference

- Repo doc: [`docs/rfc/RFC-0034d-stale-agent-sync.md`](docs/rfc/RFC-0034d-stale-agent-sync.md)

## Test plan

- [x] `test_release_stale_claims_clears_agent_current_task` — claim with mirrored `current_task`, sweep with `ttl_seconds:0.0`, assert backlog released and agent pointer cleared.
- [x] `test_release_stale_claims_preserves_other_agent_task` — agent re-targeted to `task-999` before sweep; sweep releases `task-001` from backlog but leaves `current_task = Some "task-999"` intact (idempotency guard).
- [x] Full `_build/default/test/test_room.exe` (91 tests) green locally.

## Validation

- `env DUNE_JOBS=4 MASC_SKIP_OPAM_LOCK=1 MASC_SKIP_PIN_CHECK=1 dune build --root .` (clean)
- `env MASC_SKIP_PIN_CHECK=1 ./_build/default/test/test_room.exe` → `Test Successful in 12.668s. 91 tests run.`
- `gh pr list --search "release_stale_claims OR stale agent OR current_task_id sync"` checked — no overlap with #13604, #13579, or #14038 (those touch read-side status / owner identity, not stale write-side mirror).

## Co-author

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
