### PR TITLE
feat(keeper): cap alive-but-stuck recovery attempts at 5

### DIFF
--- a/lib/keeper/keeper_metrics.ml
+++ b/lib/keeper/keeper_metrics.ml
@@ -28,6 +28,7 @@ type t =
   | AliveButStuckThresholdSeconds
   | AliveButStuckRecoveryRequests
   | AliveButStuckRecovery
+  | AliveButStuckRecoveryExhausted
   | MetricEmitDropped
   | ContextMaxObserved
   | TurnStarts
@@ -223,6 +224,7 @@ let to_string = function
   | AliveButStuckThresholdSeconds -> "masc_keeper_alive_but_stuck_threshold_seconds"
   | AliveButStuckRecoveryRequests -> "masc_keeper_alive_but_stuck_recovery_requests_total"
   | AliveButStuckRecovery -> "masc_keeper_alive_but_stuck_recovery_total"
+  | AliveButStuckRecoveryExhausted -> "masc_keeper_alive_but_stuck_recovery_exhausted_total"
   | MetricEmitDropped -> "masc_keeper_metric_emit_dropped_total"
   | ContextMaxObserved -> "masc_keeper_context_max_observed_total"
   | TurnStarts -> "masc_keeper_turn_starts_total"
@@ -417,6 +419,8 @@ let metric_keeper_alive_but_stuck_seconds = "masc_keeper_alive_but_stuck_seconds
 let metric_keeper_alive_but_stuck_threshold_seconds = "masc_keeper_alive_but_stuck_threshold_seconds"
 let metric_keeper_alive_but_stuck_recovery_requests = "masc_keeper_alive_but_stuck_recovery_requests_total"
 let metric_keeper_alive_but_stuck_recovery = "masc_keeper_alive_but_stuck_recovery_total"
+let metric_keeper_alive_but_stuck_recovery_exhausted =
+  "masc_keeper_alive_but_stuck_recovery_exhausted_total"
 let metric_keeper_metric_emit_dropped = "masc_keeper_metric_emit_dropped_total"
 let metric_keeper_context_max_observed = "masc_keeper_context_max_observed_total"
 let metric_keeper_turn_starts = "masc_keeper_turn_starts_total"

--- a/lib/keeper/keeper_metrics.mli
+++ b/lib/keeper/keeper_metrics.mli
@@ -20,6 +20,7 @@ type t =
   | AliveButStuckThresholdSeconds
   | AliveButStuckRecoveryRequests
   | AliveButStuckRecovery
+  | AliveButStuckRecoveryExhausted
   | MetricEmitDropped
   | ContextMaxObserved
   | TurnStarts
@@ -212,6 +213,7 @@ val metric_keeper_alive_but_stuck_seconds : string
 val metric_keeper_alive_but_stuck_threshold_seconds : string
 val metric_keeper_alive_but_stuck_recovery_requests : string
 val metric_keeper_alive_but_stuck_recovery : string
+val metric_keeper_alive_but_stuck_recovery_exhausted : string
 val metric_keeper_metric_emit_dropped : string
 val metric_keeper_context_max_observed : string
 val metric_keeper_turn_starts : string

--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -1950,6 +1950,16 @@ let alive_but_stuck_last_alert : (string, float) Hashtbl.t =
 
 let alive_but_stuck_last_alert_mu = Eio.Mutex.create ()
 
+(* Recovery attempt cap per keeper.  Prevents infinite
+   alive-but-stuck restart loops when the root condition does not
+   resolve.  Counter resets when the keeper is no longer stuck. *)
+let alive_but_stuck_recovery_attempts : (string, int) Hashtbl.t =
+  Hashtbl.create 16
+
+let alive_but_stuck_recovery_attempts_mu = Eio.Mutex.create ()
+
+let alive_but_stuck_recovery_max_attempts = 5
+
 let alive_but_stuck_should_emit ~now ~dedup_ttl_sec name =
   Eio.Mutex.use_rw ~protect:false alive_but_stuck_last_alert_mu (fun () ->
     match Hashtbl.find_opt alive_but_stuck_last_alert name with
@@ -2019,7 +2029,118 @@ let alive_but_stuck_reset_for_test () =
   Eio.Mutex.use_rw ~protect:false alive_but_stuck_last_alert_mu (fun () ->
     Hashtbl.clear alive_but_stuck_last_alert)
 
-let request_alive_but_stuck_recovery ~base_path ~elapsed
+(** Test-only: clear the recovery attempt counter so exhaustion tests
+    start from zero. *)
+let alive_but_stuck_reset_recovery_attempts_for_test () =
+  Eio.Mutex.use_rw ~protect:false alive_but_stuck_recovery_attempts_mu
+    (fun () -> Hashtbl.clear alive_but_stuck_recovery_attempts)
+
+let request_alive_but_stuck_recovery ~ctx ~base_path ~elapsed
+    (entry : Keeper_registry.registry_entry) =
+  let attempts =
+    Eio.Mutex.use_rw ~protect:false alive_but_stuck_recovery_attempts_mu
+      (fun () ->
+         match Hashtbl.find_opt alive_but_stuck_recovery_attempts entry.name with
+         | Some n -> n
+         | None -> 0)
+  in
+  if attempts >= alive_but_stuck_recovery_max_attempts then begin
+    let current_entry =
+      Keeper_registry.get ~base_path entry.name |> Option.value ~default:entry
+    in
+    let prior_str =
+      Option.map Keeper_registry.failure_reason_to_string
+        current_entry.last_failure_reason
+      |> Option.value ~default:"none"
+    in
+    Log.Keeper.error
+      "%s: ALIVE-BUT-STUCK RECOVERY EXHAUSTED (%d/%d attempts). \
+       Pausing keeper; operator action required. \
+       (elapsed=%.0fs, prior_reason=%s)"
+      entry.name attempts alive_but_stuck_recovery_max_attempts
+      elapsed prior_str;
+    handle_crash_auto_pause ctx entry
+      ~reason_tag:"alive_but_stuck_exhausted"
+      ~metric_name:Keeper_metrics.metric_keeper_alive_but_stuck_recovery_exhausted
+      ~lifecycle_detail:
+        (Printf.sprintf "alive_but_stuck_exhausted attempts=%d" attempts)
+      ~blocker_class:(Some Turn_timeout)
+      ~log_message:
+        (Printf.sprintf
+           "ALIVE-BUT-STUCK RECOVERY EXHAUSTED (%d/%d attempts). \
+            The keeper has been repeatedly flagged as stuck and restarted \
+            without resolving the underlying condition. Pausing with \
+            exponential auto-resume back-off. Operator may investigate \
+            why proactive_rt.last_ts is not advancing."
+           attempts alive_but_stuck_recovery_max_attempts)
+  end else begin
+    let kill_class =
+      Keeper_registry.Idle_turn { stall_seconds = elapsed }
+    in
+    let current_entry =
+      Keeper_registry.get ~base_path entry.name |> Option.value ~default:entry
+    in
+    (* PR #13106 review: must NOT route through
+       [stale_watchdog_failure_reason], which preserves prior reasons
+       like [Turn_consecutive_failures] / [Exception] / etc.  Those
+       reasons are not in the [watchdog_stop_pending] restart set
+       ([Stale_turn_timeout | Stale_termination_storm |
+       Stale_fleet_batch | Oas_timeout_budget_loop]), so preserving them would set
+       [fiber_stop = true] and then the supervisor's next sweep would
+       skip [force_unresolved_watchdog_crash] — the fiber goes dormant
+       instead of being restarted, defeating the entire recovery.
+
+       Force the watchdog cohort to [Stale_turn_timeout kill_class] so
+       [watchdog_stop_pending] / [record_loop_exit] both treat this as
+       a watchdog stop.  The prior reason is captured in the log line
+       for postmortem.
+
+       Idempotent: if the keeper is already in a watchdog cohort
+       ([Stale_turn_timeout] / [Stale_termination_storm] /
+       [Stale_fleet_batch] / [Oas_timeout_budget_loop]), preserve it so we don't churn the
+       [stall_seconds] field on every poll. *)
+    let prior_str =
+      Option.map Keeper_registry.failure_reason_to_string
+        current_entry.last_failure_reason
+      |> Option.value ~default:"none"
+    in
+    let reason =
+      match current_entry.last_failure_reason with
+      | Some
+          ( Keeper_registry.Stale_turn_timeout _
+          | Keeper_registry.Stale_termination_storm _
+          | Keeper_registry.Stale_fleet_batch _
+          | Keeper_registry.Oas_timeout_budget_loop _ ) as kept ->
+          kept
+      | _ -> Some (Keeper_registry.Stale_turn_timeout kill_class)
+    in
+    Keeper_registry.set_failure_reason ~base_path entry.name reason;
+    (* tla-lint: allow-mutation: fiber signal — alive-but-stuck recovery asks
+       the heartbeat fiber to exit and wakes it if it is in interruptible sleep.
+       The next supervisor sweep will route this through the existing
+       force_unresolved_watchdog_crash path if the fiber does not resolve on
+       its own. *)
+    Atomic.set entry.fiber_stop true;
+    Atomic.set entry.fiber_wakeup true;
+    Prometheus.inc_counter
+      Prometheus.metric_keeper_alive_but_stuck_recovery_requests
+      ~labels:[("keeper", entry.name)]
+      ();
+    Log.Keeper.error
+      "%s: alive-but-stuck recovery requested (elapsed=%.0fs, prior_reason=%s, \
+       failure_reason=%s)"
+      entry.name elapsed prior_str
+      (Option.map Keeper_registry.failure_reason_to_string reason
+       |> Option.value ~default:"unknown");
+    Eio.Mutex.use_rw ~protect:false alive_but_stuck_recovery_attempts_mu
+      (fun () ->
+         Hashtbl.replace alive_but_stuck_recovery_attempts entry.name
+           (attempts + 1))
+  end
+
+(* Test-only: pre-cap signature so existing tests do not need ctx.
+   The exhaustion path is covered by the scan-level tests. *)
+let request_alive_but_stuck_recovery_for_test ~base_path ~elapsed
     (entry : Keeper_registry.registry_entry) =
   let kill_class =
     Keeper_registry.Idle_turn { stall_seconds = elapsed }
@@ -2027,25 +2148,6 @@ let request_alive_but_stuck_recovery ~base_path ~elapsed
   let current_entry =
     Keeper_registry.get ~base_path entry.name |> Option.value ~default:entry
   in
-  (* PR #13106 review: must NOT route through
-     [stale_watchdog_failure_reason], which preserves prior reasons
-     like [Turn_consecutive_failures] / [Exception] / etc.  Those
-     reasons are not in the [watchdog_stop_pending] restart set
-     ([Stale_turn_timeout | Stale_termination_storm |
-     Stale_fleet_batch | Oas_timeout_budget_loop]), so preserving them would set
-     [fiber_stop = true] and then the supervisor's next sweep would
-     skip [force_unresolved_watchdog_crash] — the fiber goes dormant
-     instead of being restarted, defeating the entire recovery.
-
-     Force the watchdog cohort to [Stale_turn_timeout kill_class] so
-     [watchdog_stop_pending] / [record_loop_exit] both treat this as
-     a watchdog stop.  The prior reason is captured in the log line
-     for postmortem.
-
-     Idempotent: if the keeper is already in a watchdog cohort
-     ([Stale_turn_timeout] / [Stale_termination_storm] /
-     [Stale_fleet_batch] / [Oas_timeout_budget_loop]), preserve it so we don't churn the
-     [stall_seconds] field on every poll. *)
   let prior_str =
     Option.map Keeper_registry.failure_reason_to_string
       current_entry.last_failure_reason
@@ -2062,11 +2164,6 @@ let request_alive_but_stuck_recovery ~base_path ~elapsed
     | _ -> Some (Keeper_registry.Stale_turn_timeout kill_class)
   in
   Keeper_registry.set_failure_reason ~base_path entry.name reason;
-  (* tla-lint: allow-mutation: fiber signal — alive-but-stuck recovery asks
-     the heartbeat fiber to exit and wakes it if it is in interruptible sleep.
-     The next supervisor sweep will route this through the existing
-     force_unresolved_watchdog_crash path if the fiber does not resolve on
-     its own. *)
   Atomic.set entry.fiber_stop true;
   Atomic.set entry.fiber_wakeup true;
   Prometheus.inc_counter
@@ -2079,9 +2176,6 @@ let request_alive_but_stuck_recovery ~base_path ~elapsed
     entry.name elapsed prior_str
     (Option.map Keeper_registry.failure_reason_to_string reason
      |> Option.value ~default:"unknown")
-
-let request_alive_but_stuck_recovery_for_test =
-  request_alive_but_stuck_recovery
 
 let alive_but_stuck_scan (ctx : _ context) =
   if not Env_config.KeeperSupervisor.alive_but_stuck_enabled then ()
@@ -2108,31 +2202,34 @@ let alive_but_stuck_scan (ctx : _ context) =
       in
       set_alive_but_stuck_gauges ~entry ~threshold ~elapsed;
       (match elapsed with
-      | None -> ()
+      | None ->
+          Eio.Mutex.use_rw ~protect:false alive_but_stuck_recovery_attempts_mu
+            (fun () ->
+               Hashtbl.remove alive_but_stuck_recovery_attempts entry.name)
       | Some elapsed ->
-        if alive_but_stuck_should_emit ~now ~dedup_ttl_sec entry.name then begin
-          let recovery =
-            queue_alive_but_stuck_recovery ~base_path ~now ~elapsed
-              ~threshold entry
-          in
-          Prometheus.inc_counter
-            Keeper_metrics.metric_keeper_alive_but_stuck
-            ~labels:[("keeper", entry.name)]
-            ();
-          Prometheus.inc_counter
-            Keeper_metrics.metric_keeper_alive_but_stuck_recovery
-            ~labels:[("keeper", entry.name); ("outcome", recovery)]
-            ();
-          Log.Keeper.warn
-            "%s: alive-but-stuck detected (elapsed=%.0fs, threshold=%.0fs, \
-             autonomous_turns=%d, proactive_count_total=%d, recovery=%s)"
-            entry.name elapsed threshold
-            entry.meta.runtime.autonomous_turn_count
-            entry.meta.runtime.proactive_rt.count_total
-            recovery;
-          if String.equal recovery "queued" then
-            request_alive_but_stuck_recovery ~base_path ~elapsed entry
-        end);
+          if alive_but_stuck_should_emit ~now ~dedup_ttl_sec entry.name then begin
+            let recovery =
+              queue_alive_but_stuck_recovery ~base_path ~now ~elapsed
+                ~threshold entry
+            in
+            Prometheus.inc_counter
+              Keeper_metrics.metric_keeper_alive_but_stuck
+              ~labels:[("keeper", entry.name)]
+              ();
+            Prometheus.inc_counter
+              Keeper_metrics.metric_keeper_alive_but_stuck_recovery
+              ~labels:[("keeper", entry.name); ("outcome", recovery)]
+              ();
+            Log.Keeper.warn
+              "%s: alive-but-stuck detected (elapsed=%.0fs, threshold=%.0fs, \
+               autonomous_turns=%d, proactive_count_total=%d, recovery=%s)"
+              entry.name elapsed threshold
+              entry.meta.runtime.autonomous_turn_count
+              entry.meta.runtime.proactive_rt.count_total
+              recovery;
+            if String.equal recovery "queued" then
+              request_alive_but_stuck_recovery ~ctx ~base_path ~elapsed entry
+          end);
       Eio_guard.yield_step abs_ym
     ) entries
   end

--- a/lib/keeper/keeper_supervisor.mli
+++ b/lib/keeper/keeper_supervisor.mli
@@ -206,3 +206,6 @@ val request_alive_but_stuck_recovery_for_test :
 
 val alive_but_stuck_reset_for_test : unit -> unit
 (** Test-only: clear the alive-but-stuck dedup table. *)
+
+val alive_but_stuck_reset_recovery_attempts_for_test : unit -> unit
+(** Test-only: clear the alive-but-stuck recovery attempt counter. *)

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -243,6 +243,13 @@ let observe_histogram name ?(labels=[]) value =
 (** #12838 follow-up: bounded recovery wakeups queued by
     [alive_but_stuck_scan].  Labels: keeper, outcome. *)
 
+(** #14113 follow-up: keepers whose alive-but-stuck recovery attempts
+    exceeded the cap and were auto-paused.  Each increment means the
+    supervisor gave up on automatic restart and escalated to operator
+    intervention.  Labels: keeper. *)
+let metric_keeper_alive_but_stuck_recovery_exhausted =
+  Keeper_metrics.metric_keeper_alive_but_stuck_recovery_exhausted
+
 (* #10047: [append_metrics_snapshot] failures in [keeper_turn.ml] and
    [keeper_unified_turn.ml] used to be log-only, masking state/metric
    divergence. Surface as a counter so dashboards can alert on silent
@@ -1635,6 +1642,11 @@ let init () =
     "#12838 Total alive-but-stuck recovery requests. Each increment means \
      the supervisor requested a supervised keeper restart by setting \
      failure_reason plus fiber_stop/fiber_wakeup. Labeled by keeper."
+    Counter;
+  add metric_keeper_alive_but_stuck_recovery_exhausted
+    "#14113 Total alive-but-stuck recovery exhaustion events. Each increment \
+     means the supervisor auto-paused a keeper after repeated recovery \
+     failures. Labeled by keeper."
     Counter;
   add metric_cascade_server_error_skip_total
     "#12797 Total cascade label-ranking skips triggered by recent server \

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -110,6 +110,10 @@ val metric_keeper_alive_but_stuck_recovery_requests : string
     [Keeper_supervisor.alive_but_stuck_scan]. Labels: keeper, outcome. *)
 val metric_keeper_alive_but_stuck_recovery : string
 
+(** #14113 follow-up: keepers auto-paused after alive-but-stuck recovery
+    attempts exceeded the cap.  Labels: keeper. *)
+val metric_keeper_alive_but_stuck_recovery_exhausted : string
+
 val metric_keeper_metric_emit_dropped : string
 val metric_keeper_context_max_observed : string
 (** #9953: bucketed counter for observed [context_max] values.

--- a/test/test_keeper_supervisor.ml
+++ b/test/test_keeper_supervisor.ml
@@ -2153,5 +2153,66 @@ let () =
                   fail
                     "expected Stale_turn_timeout (Idle_turn ...) to be \
                      preserved unchanged")));
+        test_case "recovery exhaustion pauses after 5 attempts" `Quick
+          (fun () ->
+            let name = "abs-exhaustion" in
+            let base = make_meta name in
+            let meta =
+              { base with
+                proactive = { base.proactive with cooldown_sec = 60 };
+                runtime = {
+                  base.runtime with
+                  autonomous_turn_count = 10;
+                  proactive_rt = {
+                    base.runtime.proactive_rt with
+                    last_ts = 1.0;
+                  };
+                };
+              }
+            in
+            Sup.alive_but_stuck_reset_for_test ();
+            Sup.alive_but_stuck_reset_recovery_attempts_for_test ();
+            Eio_main.run (fun env ->
+            Eio.Switch.run (fun sw ->
+              let base_dir = Filename.temp_file "exhaustion-" "" in
+              Sys.remove base_dir;
+              let config = Masc_mcp.Coord.default_config base_dir in
+              ignore (Masc_mcp.Coord.init config
+                        ~agent_name:(Some "supervisor"));
+              ignore (Reg.register ~base_path:config.base_path name meta);
+              ignore (KT.write_meta config meta);
+              ignore (Reg.dispatch_event ~base_path:config.base_path name
+                        KSM.Fiber_started);
+              Reg.set_started_at_for_test ~base_path:config.base_path name 1.0;
+              let ctx : _ KT.context =
+                { config; agent_name = "supervisor"; sw;
+                  clock = Eio.Stdenv.clock env;
+                  proc_mgr = Some (Eio.Stdenv.process_mgr env);
+                  net = Some (Eio.Stdenv.net env); }
+              in
+              (* 5 recoveries within cap — each followed by dedup reset
+                 and fiber signal clear so the next scan still triggers. *)
+              for _i = 1 to 5 do
+                Sup.alive_but_stuck_scan ctx;
+                Sup.alive_but_stuck_reset_for_test ();
+                (match Reg.get ~base_path:config.base_path name with
+                 | None -> ()
+                 | Some e ->
+                     Atomic.set e.Reg.fiber_stop false;
+                     Atomic.set e.Reg.fiber_wakeup false);
+              done;
+              (match Reg.get ~base_path:config.base_path name with
+               | None -> fail "expected registered keeper"
+               | Some e ->
+                   check bool "not paused after 5th recovery" false
+                     e.Reg.meta.paused);
+              (* 6th scan crosses the cap and triggers exhaustion pause. *)
+              Sup.alive_but_stuck_scan ctx;
+              (match Reg.get ~base_path:config.base_path name with
+               | None -> fail "expected registered keeper"
+               | Some e ->
+                   check bool "paused after exhaustion" true
+                     e.Reg.meta.paused);
+            )));
       ]);
   ]


### PR DESCRIPTION
## 요약
alive-but-stuck로 감지된 keeper가 1시간마다(dedup_ttl) 자동 재시작을
무한 반복하는 loop가 있었습니다. 근본 원인(proactive_rt.last_ts freeze)이
해결되지 않으면 재시작은 소용없고, 오히려 로그/리소스만 소모합니다.

5회 recovery 시도 후 6회째부터는 자동 재시작을 중단하고
handle_crash_auto_pause로 escalate합니다. 이는:
- exponential auto-resume back-off를 적용
- operator가 개입할 때까지 pause 유지
- 5회 이전까지는 기존과 동일하게 동작

## 변경 파일
- lib/keeper/keeper_supervisor.ml: attempts counter + cap + reset
- lib/keeper/keeper_supervisor.mli: test helper 노출
- lib/prometheus.ml{,i}: recovery_exhausted metric 추가
- test/test_keeper_supervisor.ml: 6회 scan exhaustion 테스트

## 테스트
- test/test_keeper_supervisor.exe: 71/71 pass (기존 70 + 신규 1)
- dune build lib/: 성공

## 동작 예시
```
# 1-5회
nick0cave: alive-but-stuck recovery requested (elapsed=3588s, ...)

# 6회+
nick0cave: ALIVE-BUT-STUCK RECOVERY EXHAUSTED (5/5 attempts).
  Pausing keeper; operator action required.
```