### PR TITLE
refactor: collapse identity Option matches in exec_core and tool_local_runtime_probe

### DIFF
--- a/lib/exec_core.ml
+++ b/lib/exec_core.ml
@@ -566,11 +566,7 @@ let build_process_outcome ~artifact_policy ~base_path ~keeper_name ~cmd ~status
     artifact_refs_of_output ~artifact_policy ~base_path ~keeper_name ~cmd
       ~output
   in
-  let recovery_hint =
-    match default_recovery_hint classification semantic_status with
-    | Some hint -> Some hint
-    | None -> None
-  in
+  let recovery_hint = default_recovery_hint classification semantic_status in
   Executed
     {
       command = cmd;

--- a/lib/tool_local_runtime_probe.ml
+++ b/lib/tool_local_runtime_probe.ml
@@ -418,14 +418,11 @@ let fetch_ollama_ps ?(timeout_sec = 8) ~server_url () =
 
 let select_effective_model ~requested_model loaded_models =
   match Option.bind requested_model trim_to_option with
-  | Some model_id -> Some model_id
-  | None -> (
-      match loaded_models with
-      | model :: _ -> loaded_model_name model
-      | [] -> (
-          match trim_to_option Env_config_runtime.Ollama.default_model with
-          | Some configured -> Some configured
-          | None -> None))
+  | Some _ as result -> result
+  | None ->
+    (match loaded_models with
+     | model :: _ -> loaded_model_name model
+     | [] -> trim_to_option Env_config_runtime.Ollama.default_model)
 
 let model_is_loaded model_id loaded_models =
   List.exists


### PR DESCRIPTION
## Summary

Two equivalent `match opt with | Some x -> Some x | None -> None` patterns that re-wrap an option through itself.  Both are pure identity — they introduce no conditional behavior, no field projection, no normalization — so the match adds reader cost without buying anything.

## Sites

| File:Line | Before | After |
|-----------|--------|-------|
| `lib/exec_core.ml:569-573` | 5-line `match` re-wrapping `default_recovery_hint ...` | inlined to a 1-line `let recovery_hint = ...` |
| `lib/tool_local_runtime_probe.ml:420-428` | outer arm `\| Some model_id -> Some model_id`, innermost arm re-wrapping `trim_to_option ...` | outer: `\| Some _ as result -> result`; innermost: direct call |

## Why

This is the standard OCaml-style cleanup of "match-as-no-op" patterns that accumulate during refactors — typically when an earlier version of the function had a non-identity arm (e.g. logging, normalization) that was later simplified, but the match shape was left in place.  Each remaining identity arm is a small reader tax: anyone touching the function has to verify that nothing differs between the two branches before they can trust that the option flows through unchanged.

## Validation

- `dune build --root . lib/` — exit 0.
- `dune build --root . test/test_exec_core.exe test/test_tool_local_runtime_probe.exe` — exit 0.
- `./_build/default/test/test_exec_core.exe test` — 39/39 OK.
- `./_build/default/test/test_tool_local_runtime_probe.exe test` — 16/16 OK.

## Diff shape

`lib/exec_core.ml | 6 +-----` and `lib/tool_local_runtime_probe.ml | 13 +++++--------` — 2 files, +6/-13 net.

## RFC

Not required.  Neither file is in the CLAUDE.md `agent_delegation` RFC-gated list.

## Companion

Same axis family as #14107 / #14111 / #14119 / #14123 / #14126 — small surgical cleanups of OCaml shapes that the rest of the codebase has already moved past.

🤖 Generated with [Claude Code](https://claude.com/claude-code)