### PR TITLE
docs: add bisect coverage closeout gate

### DIFF
--- a/docs/qa/BISECT-COVERAGE-CLOSEOUT-RUNBOOK.md
+++ b/docs/qa/BISECT-COVERAGE-CLOSEOUT-RUNBOOK.md
@@ -1,0 +1,79 @@
+# bisect_ppx Coverage Closeout Runbook
+
+This runbook is the evidence path for any goal that claims 100% OCaml line
+coverage. A goal is not done because `*_coverage.ml` files exist, and it is not
+done because stale `_coverage` files are present. It is done only when a fresh
+bisect artifact for the target commit measures at or above the required
+threshold.
+
+## Closeout Gate
+
+Use the repo wrapper so local and CI coverage use the same dependency and test
+setup:
+
+```bash
+scripts/opam-pin-external-deps.sh --with-bisect
+opam install . --deps-only --with-test
+scripts/coverage_percent.sh --fail-under 100
+```
+
+The final command must be run from the target commit. It deletes and recreates
+`_coverage` unless `--reuse-existing` is passed.
+
+`--reuse-existing` is allowed only when the operator records all of these facts
+beside the result:
+
+- the exact commit SHA that produced `_coverage`
+- the exact coverage command that produced it
+- the `COVERAGE_DIR` path
+- the timestamp of the coverage files
+- a successful `scripts/coverage_percent.sh --reuse-existing --fail-under 100`
+  run on the same checkout
+
+If any fact is missing, regenerate coverage instead of reusing local files.
+
+## Required Evidence
+
+Attach or link this evidence before closing a 100% coverage goal:
+
+| Evidence | Required content |
+| --- | --- |
+| Target revision | repo, branch, and full commit SHA |
+| Tooling proof | `opam exec -- which bisect-ppx-report` output |
+| Coverage command | exact `scripts/coverage_percent.sh --fail-under 100` command |
+| Measured result | stdout percentage and exit status |
+| Artifact path | `_coverage` or explicit `COVERAGE_DIR` path |
+| CI relation | GitHub run/check name and head SHA for the same commit |
+
+For GitHub issues, paste the above as a short comment. For PRs, put it in the
+verification section so reviewers can see that the claim is tied to a measured
+artifact.
+
+## When Coverage Is Below 100
+
+Do not close the parent goal. Create follow-up issues or keeper tasks from the
+generated HTML report:
+
+```bash
+opam exec -- bisect-ppx-report html --coverage-path _coverage
+```
+
+Each follow-up must include:
+
+- uncovered file and function/module name
+- why the path is expected to be reachable
+- the smallest intended test target
+- the coverage command that will verify the fix
+- links to the parent coverage goal and any PR that adds the test
+
+Keep the parent issue open until `scripts/coverage_percent.sh --fail-under 100`
+passes on the commit that contains the final coverage PR.
+
+## Operator Checklist
+
+- [ ] Reporter is installed: `opam exec -- which bisect-ppx-report`.
+- [ ] Coverage was regenerated, or `--reuse-existing` has the required facts.
+- [ ] `scripts/coverage_percent.sh --fail-under 100` passed.
+- [ ] The measured percentage, commit SHA, and artifact path are recorded.
+- [ ] Any uncovered surface has a linked follow-up issue/task.
+- [ ] The closing comment names the PR/check that validated the same SHA.

--- a/docs/spec/15-testing.md
+++ b/docs/spec/15-testing.md
@@ -267,12 +267,17 @@ Contract harness는 hermetic bootstrap으로 실행된다. 사전 서버 실행�
 
 ## 7. Coverage
 
+100% coverage closeout uses the checklist in
+`docs/qa/BISECT-COVERAGE-CLOSEOUT-RUNBOOK.md`. Do not close a coverage goal from
+stale `_coverage` files or from the existence of `*_coverage.ml` supplement
+tests alone.
+
 ### 7.1 bisect_ppx
 
 OCaml 코드 커버리지 도구. `BISECT_FILE` 환경변수로 출력 경로를 지정한다.
 
 ```bash
-BISECT_FILE=$(pwd)/_coverage dune test --instrument-with bisect_ppx
+scripts/coverage_percent.sh --fail-under 100
 bisect-ppx-report html --coverage-path _coverage
 ```
 

--- a/scripts/coverage_percent.sh
+++ b/scripts/coverage_percent.sh
@@ -4,6 +4,23 @@ set -euo pipefail
 root_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 coverage_dir="${COVERAGE_DIR:-$root_dir/_coverage}"
 reuse_existing=false
+fail_under=""
+
+usage() {
+  cat <<'EOF'
+usage: scripts/coverage_percent.sh [--reuse-existing] [--fail-under PERCENT]
+
+Print the bisect_ppx line coverage percentage.
+
+Options:
+  --reuse-existing       Read COVERAGE_DIR without running tests again.
+  --fail-under PERCENT   Exit non-zero if measured coverage is below PERCENT.
+EOF
+}
+
+is_number() {
+  awk -v value="$1" 'BEGIN { exit (value ~ /^[0-9]+([.][0-9]+)?$/ ? 0 : 1) }'
+}
 
 require_bisect_reporter() {
   if ! command -v opam >/dev/null 2>&1; then
@@ -24,16 +41,30 @@ EOF
   fi
 }
 
-for arg in "$@"; do
-  case "$arg" in
+while [ "$#" -gt 0 ]; do
+  case "$1" in
     --reuse-existing)
       reuse_existing=true
       ;;
+    --fail-under)
+      shift
+      if [ "$#" -eq 0 ] || ! is_number "$1"; then
+        echo "--fail-under requires a numeric percentage" >&2
+        exit 2
+      fi
+      fail_under="$1"
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
     *)
-      echo "unknown argument: $arg" >&2
+      echo "unknown argument: $1" >&2
+      usage >&2
       exit 2
       ;;
   esac
+  shift
 done
 
 require_bisect_reporter
@@ -64,3 +95,11 @@ if [ -z "$percent" ]; then
 fi
 
 printf '%s\n' "$percent"
+
+if [ -n "$fail_under" ]; then
+  if ! awk -v percent="$percent" -v threshold="$fail_under" \
+    'BEGIN { exit (percent + 0 >= threshold + 0 ? 0 : 1) }'; then
+    echo "coverage ${percent}% is below required ${fail_under}%" >&2
+    exit 1
+  fi
+fi


### PR DESCRIPTION
## Summary

- add a bisect_ppx coverage closeout runbook for 100% coverage goals
- add `scripts/coverage_percent.sh --fail-under PERCENT` so coverage thresholds can be enforced by the existing script
- point the testing spec at the runbook and the executable `--fail-under 100` gate

## Why

Issue #13718 identified that the 100% coverage goal had no prompt-to-artifact checklist. Existing `*_coverage.ml` supplement tests and stale `_coverage` files are not enough to close the goal without a measured bisect artifact tied to a target commit.

## Validation

- `bash -n scripts/coverage_percent.sh`
- `scripts/coverage_percent.sh --help`
- `scripts/coverage_percent.sh --fail-under nope` exits 2 with the expected validation error
- `git diff --check`
- `scripts/coverage_percent.sh --reuse-existing --fail-under 100` exits 127 because `bisect-ppx-report` is not installed in the active local switch; this matches the blocker recorded in #13718 and prevents claiming a current percentage from stale local files

## Notes

This PR does not claim 100% coverage is achieved. It makes the closeout gate explicit and machine-checkable so a later coverage run with `bisect-ppx-report` installed can provide the actual percentage evidence.

Closes #13718.
