### PR TITLE
fix(goal): escalate stale unlinked tasks

### DIFF
--- a/lib/goal/goal_janitor.ml
+++ b/lib/goal/goal_janitor.ml
@@ -1,27 +1,32 @@
 (** Goal_janitor — Periodic cleanup of stale and dropped goals.
 
-    Three sweep rules:
+    Four sweep rules:
     1. Purge: delete Dropped goals older than [dropped_ttl_days].
     2. Stagnate: mark Active goals with no update for [stagnant_days] as Dropped.
     3. Orphan: remove active_goal_ids from keeper_meta that reference
        non-existent goals in the Goal Store.
+    4. Escalate: report stale unclaimed tasks that have no goal linkage.
 
     @since 2.236.0 *)
 
 type sweep_config = {
   dropped_ttl_days : int;  (** Delete Dropped goals after this many days. Default 7. *)
   stagnant_days : int;     (** Drop Active goals with no update after this many days. Default 30. *)
+  orphan_task_escalation_age_seconds : int;
+      (** Report unclaimed tasks without goal linkage after this age. Default 30 min. *)
 }
 
 let default_config = {
   dropped_ttl_days = 7;
   stagnant_days = 30;
+  orphan_task_escalation_age_seconds = 30 * 60;
 }
 
 type sweep_result = {
   purged : int;     (** Dropped goals deleted *)
   stagnated : int;  (** Active goals marked Dropped *)
   orphans : int;    (** Orphaned active_goal_ids cleaned *)
+  orphan_tasks : int;  (** Stale unclaimed tasks missing goal linkage *)
 }
 
 let sweep_result_to_yojson r =
@@ -29,19 +34,12 @@ let sweep_result_to_yojson r =
     ("purged", `Int r.purged);
     ("stagnated", `Int r.stagnated);
     ("orphans", `Int r.orphans);
+    ("orphan_tasks", `Int r.orphan_tasks);
   ]
 
 (** Parse ISO 8601 timestamp to Unix epoch seconds. *)
 let parse_iso_ts s =
-  Safe_ops.protect ~default:None (fun () ->
-    Scanf.sscanf s "%d-%d-%dT%d:%d:%d" (fun y mo d h mi se ->
-      let tm = {
-        Unix.tm_sec = se; tm_min = mi; tm_hour = h;
-        tm_mday = d; tm_mon = mo - 1; tm_year = y - 1900;
-        tm_wday = 0; tm_yday = 0; tm_isdst = false;
-      } in
-      let epoch, _ = Unix.mktime tm in
-      Some epoch))
+  Masc_domain.parse_iso8601_opt s
 
 let days_since_update (goal : Goal_store.goal) ~now =
   match parse_iso_ts goal.updated_at with
@@ -77,7 +75,69 @@ let sweep_goals ~(config : sweep_config) (goals : Goal_store.goal list)
                updated_at = iso_now }
       | _ -> Some g)
   in
-  (result, { purged = !purged; stagnated = !stagnated; orphans = 0 })
+  (result, { purged = !purged; stagnated = !stagnated; orphans = 0;
+             orphan_tasks = 0 })
+
+let task_age_seconds ?(now = Unix.gettimeofday ()) (task : Masc_domain.task) =
+  match parse_iso_ts task.created_at with
+  | None -> None
+  | Some created_at -> Some (int_of_float (max 0.0 (now -. created_at)))
+
+let task_has_current_goal_link ~valid_goal_ids (task : Masc_domain.task) =
+  match task.goal_id with
+  | Some goal_id -> List.mem goal_id valid_goal_ids
+  | None ->
+      List.exists
+        (fun goal_id -> Convergence.task_matches_goal ~goal_id task)
+        valid_goal_ids
+
+let audit_unclaimed_goal_orphan_tasks ?(now = Unix.gettimeofday ())
+    ~valid_goal_ids ~min_age_seconds (tasks : Masc_domain.task list) =
+  tasks
+  |> List.filter_map (fun (task : Masc_domain.task) ->
+    match task.task_status, task.goal_id, task_age_seconds ~now task with
+    | Masc_domain.Todo, None, Some age_seconds
+      when age_seconds >= min_age_seconds
+           && not (task_has_current_goal_link ~valid_goal_ids task) ->
+        Some (task, age_seconds)
+    | _ -> None)
+
+let emit_orphan_task_escalation room_config ~threshold_seconds orphan_tasks =
+  match orphan_tasks with
+  | [] -> ()
+  | _ ->
+      let task_ids =
+        List.map
+          (fun ((task, _) : Masc_domain.task * int) -> `String task.id)
+          orphan_tasks
+      in
+      let task_items =
+        List.map
+          (fun ((task, age_seconds) : Masc_domain.task * int) ->
+             `Assoc
+               [ ("task_id", `String task.id)
+               ; ("title", `String task.title)
+               ; ("created_at", `String task.created_at)
+               ; ("age_seconds", `Int age_seconds)
+               ; ("created_by", Json_util.string_opt_to_json task.created_by)
+               ])
+          orphan_tasks
+      in
+      Coord.log_event room_config
+        (`Assoc
+           [ ("type", `String "goal_orphan_task_escalation")
+           ; ("subsystem", `String "goal_janitor")
+           ; ("threshold_seconds", `Int threshold_seconds)
+           ; ("orphan_task_count", `Int (List.length orphan_tasks))
+           ; ("task_ids", `List task_ids)
+           ; ("tasks", `List task_items)
+           ; ( "action",
+               `String "link_task_goal_id_or_cancel_stale_unclaimed_task" )
+           ; ("ts", `String (Masc_domain.now_iso ()))
+           ]);
+      Log.Misc.warn
+        "[GoalJanitor] escalated %d stale unclaimed task(s) without goal linkage"
+        (List.length orphan_tasks)
 
 (** Clean orphaned active_goal_ids from keeper meta.
     Returns the pruned list and count of removed IDs. *)
@@ -133,8 +193,20 @@ let run ?(config = default_config) (room_config : Coord.config) : sweep_result =
           end
         | Ok None | Ok (Some _) | Error _ -> ()
       end);
-  let result = { partial with orphans = !total_orphans } in
-  if result.purged > 0 || result.stagnated > 0 || result.orphans > 0 then
-    Log.Misc.info "[GoalJanitor] sweep done: purged=%d stagnated=%d orphans=%d"
-      result.purged result.stagnated result.orphans;
+  let orphan_task_rows =
+    Coord.get_tasks_safe room_config
+    |> audit_unclaimed_goal_orphan_tasks ~valid_goal_ids:valid_ids
+         ~min_age_seconds:config.orphan_task_escalation_age_seconds
+  in
+  emit_orphan_task_escalation room_config
+    ~threshold_seconds:config.orphan_task_escalation_age_seconds
+    orphan_task_rows;
+  let result = { partial with orphans = !total_orphans;
+                              orphan_tasks = List.length orphan_task_rows } in
+  if result.purged > 0 || result.stagnated > 0 || result.orphans > 0
+     || result.orphan_tasks > 0 then
+    Log.Misc.info
+      "[GoalJanitor] sweep done: purged=%d stagnated=%d orphans=%d \
+       orphan_tasks=%d"
+      result.purged result.stagnated result.orphans result.orphan_tasks;
   result

--- a/lib/goal/goal_janitor.mli
+++ b/lib/goal/goal_janitor.mli
@@ -1,13 +1,14 @@
 (** Goal_janitor — Periodic cleanup of stale and dropped goals.
 
-    Three sweep rules:
+    Four sweep rules:
     1. Purge: delete [Dropped] goals older than
        [dropped_ttl_days] (default 7).
-    2. Stagnate: mark [Active] goals with no update for
+    2. Stagnate: mark [Active] goals with no update after
        [stagnant_days] (default 30) as [Dropped].
     3. Orphan: remove [active_goal_ids] entries from each
        [keeper_meta] that reference non-existent goals in the Goal
        Store.
+    4. Escalate: report stale unclaimed tasks without goal linkage.
 
     @since 2.236.0 *)
 
@@ -16,6 +17,8 @@
 type sweep_config = {
   dropped_ttl_days : int;  (** Delete Dropped goals after this many days. *)
   stagnant_days : int;     (** Drop Active goals with no update after this many days. *)
+  orphan_task_escalation_age_seconds : int;
+      (** Report unclaimed tasks without goal linkage after this age. *)
 }
 
 val default_config : sweep_config
@@ -26,6 +29,7 @@ type sweep_result = {
   purged : int;     (** Dropped goals deleted. *)
   stagnated : int;  (** Active goals marked Dropped. *)
   orphans : int;    (** Orphaned [active_goal_ids] cleaned. *)
+  orphan_tasks : int;  (** Stale unclaimed tasks missing goal linkage. *)
 }
 
 val sweep_result_to_yojson : sweep_result -> Yojson.Safe.t
@@ -39,6 +43,16 @@ val prune_active_goal_ids :
   valid_goal_ids:string list ->
   string list ->
   string list * int
+
+(** [audit_unclaimed_goal_orphan_tasks ~valid_goal_ids
+    ~min_age_seconds tasks] returns stale [Todo] tasks with no structured
+    [goal_id] and no current legacy title-tag linkage. *)
+val audit_unclaimed_goal_orphan_tasks :
+  ?now:float ->
+  valid_goal_ids:string list ->
+  min_age_seconds:int ->
+  Masc_domain.task list ->
+  (Masc_domain.task * int) list
 
 (** {1 Entry point} *)
 

--- a/test/test_goal_janitor.ml
+++ b/test/test_goal_janitor.ml
@@ -39,6 +39,13 @@ let old_iso days_ago =
     (tm.Unix.tm_year + 1900) (tm.Unix.tm_mon + 1) tm.Unix.tm_mday
     tm.Unix.tm_hour tm.Unix.tm_min tm.Unix.tm_sec
 
+let iso_seconds_ago seconds_ago =
+  let ts = Unix.gettimeofday () -. float_of_int seconds_ago in
+  let tm = Unix.gmtime ts in
+  Printf.sprintf "%04d-%02d-%02dT%02d:%02d:%02dZ"
+    (tm.Unix.tm_year + 1900) (tm.Unix.tm_mon + 1) tm.Unix.tm_mday
+    tm.Unix.tm_hour tm.Unix.tm_min tm.Unix.tm_sec
+
 let make_goal ?(status = Goal_store.Active) ?(days_ago = 0) id title =
   let ts = old_iso days_ago in
   {
@@ -50,6 +57,58 @@ let make_goal ?(status = Goal_store.Active) ?(days_ago = 0) id title =
     last_review_note = None; last_review_at = None;
     created_at = ts; updated_at = ts;
   }
+
+let set_task_created_at config ~title ~created_at =
+  let backlog = Coord.read_backlog config in
+  let tasks =
+    List.map
+      (fun (task : Masc_domain.task) ->
+         if String.equal task.title title then { task with created_at } else task)
+      backlog.tasks
+  in
+  Coord.write_backlog config
+    { tasks; last_updated = Masc_domain.now_iso ();
+      version = backlog.version + 1 }
+
+let contains_substring haystack needle =
+  let h_len = String.length haystack in
+  let n_len = String.length needle in
+  let rec loop idx =
+    if n_len = 0 then true
+    else if idx + n_len > h_len then false
+    else if String.sub haystack idx n_len = needle then true
+    else loop (idx + 1)
+  in
+  loop 0
+
+let event_log_text config =
+  let events_dir = Filename.concat (Coord.masc_dir config) "events" in
+  let rec collect dir =
+    if not (Sys.file_exists dir) then []
+    else if Sys.is_directory dir then
+      Sys.readdir dir
+      |> Array.to_list
+      |> List.concat_map (fun entry -> collect (Filename.concat dir entry))
+    else if Filename.check_suffix dir ".jsonl" then [ dir ]
+    else []
+  in
+  collect events_dir
+  |> List.map (fun path ->
+         let ic = open_in path in
+         match really_input_string ic (in_channel_length ic) with
+         | content ->
+             close_in_noerr ic;
+             content
+         | exception exn ->
+             close_in_noerr ic;
+             raise exn)
+  |> String.concat "\n"
+
+let event_lines_containing config marker =
+  event_log_text config
+  |> String.split_on_char '\n'
+  |> List.filter (fun line -> contains_substring line marker)
+  |> String.concat "\n"
 
 let test_purge_old_dropped () =
   with_room @@ fun config ->
@@ -97,7 +156,35 @@ let test_no_changes_when_clean () =
   let result = Goal_janitor.run config in
   check int "no purge" 0 result.purged;
   check int "no stagnation" 0 result.stagnated;
-  check int "no orphans" 0 result.orphans
+  check int "no orphans" 0 result.orphans;
+  check int "no orphan tasks" 0 result.orphan_tasks
+
+let test_escalate_stale_unclaimed_tasks_without_goal_linkage () =
+  with_room @@ fun config ->
+  let goal = make_goal "g1" "Current goal" in
+  Goal_store.write_state config
+    { version = 1; updated_at = Masc_domain.now_iso (); goals = [ goal ] };
+  ignore (Coord.add_task config ~title:"Stale unlinked task" ~priority:1
+            ~description:"missing goal linkage");
+  ignore (Coord.add_task config ~title:"Fresh unlinked task" ~priority:2
+            ~description:"fresh enough to avoid escalation");
+  ignore (Coord.add_task config ~title:"Legacy linked [goal:g1]" ~priority:3
+            ~description:"title tag keeps legacy linkage visible");
+  ignore (Coord.add_task ~goal_id:"g1" config ~title:"Explicit linked task"
+            ~priority:4 ~description:"structured linkage");
+  let stale = iso_seconds_ago (31 * 60) in
+  set_task_created_at config ~title:"Stale unlinked task" ~created_at:stale;
+  set_task_created_at config ~title:"Legacy linked [goal:g1]" ~created_at:stale;
+  set_task_created_at config ~title:"Explicit linked task" ~created_at:stale;
+  let result = Goal_janitor.run config in
+  check int "one stale unlinked task escalated" 1 result.orphan_tasks;
+  let events = event_lines_containing config "goal_orphan_task_escalation" in
+  check bool "escalation event emitted" true
+    (not (String.equal events ""));
+  check bool "stale unlinked task id included" true
+    (contains_substring events "task-001");
+  check bool "legacy title-tag task not escalated" false
+    (contains_substring events "task-003")
 
 let test_prune_orphaned_ids () =
   let valid = ["g1"; "g2"; "g3"] in
@@ -114,6 +201,8 @@ let () =
       test_case "purge old dropped goals" `Quick test_purge_old_dropped;
       test_case "stagnate old active goals" `Quick test_stagnate_old_active;
       test_case "no changes when clean" `Quick test_no_changes_when_clean;
+      test_case "escalate stale unclaimed tasks without goal linkage" `Quick
+        test_escalate_stale_unclaimed_tasks_without_goal_linkage;
     ];
     "prune", [
       test_case "prune orphaned active_goal_ids" `Quick test_prune_orphaned_ids;


### PR DESCRIPTION
## Summary
- Add Goal_janitor detection for stale unclaimed Todo tasks with no structured goal_id and no current legacy [goal:<id>] title linkage.
- Emit durable goal_orphan_task_escalation events after the 30 minute threshold instead of blocking fresh standalone task creation.
- Switch janitor timestamp parsing to the domain UTC parser so sub-day thresholds are correct outside UTC.

## Validation
- ocamlc -stop-after parsing lib/goal/goal_janitor.mli lib/goal/goal_janitor.ml test/test_goal_janitor.ml
- git diff --check
- scripts/check-oas-pin.sh --local-only
- scripts/dune-local.sh build test/test_goal_janitor.exe
- ./_build/default/test/test_goal_janitor.exe (5 tests)

[근거] Local validation commands above, confirmed 2026-05-07 KST. OAS pin check verified main@f09f30eb4b47d5ebd7096fdb289c97e6c6c77ce2 / v0.190.26. Trust: High.