### PR TITLE
fix(keeper): relax timer-only work discovery gate

### DIFF
--- a/lib/keeper/keeper_agent_tool_surface.ml
+++ b/lib/keeper/keeper_agent_tool_surface.ml
@@ -111,6 +111,7 @@ let turn_affordance_to_string = function
   | Inspect_worktree_delta -> "inspect_worktree_delta"
 
 let should_tool_gate_affordance = function
+  | Work_discovery -> false
   | Board_curation
   | Board_post_or_comment
   | Message_sweep
@@ -118,7 +119,6 @@ let should_tool_gate_affordance = function
   | Task_claim
   | Task_audit
   | Task_verify
-  | Work_discovery
   | Inspect_worktree_delta -> true
 
 let turn_affordances_require_tool_gate turn_affordances =
@@ -131,8 +131,10 @@ let turn_affordances_require_tool_gate turn_affordances =
 (* Affordance -> minimum viable tools that can satisfy that affordance.
    The list is intentionally narrow ("at least one of these is enough").
    Keepers without any matching tool cannot satisfy a [Require_tool_use]
-   contract for that affordance and must be allowed to respond with
-   text instead. *)
+   contract for that affordance and must be allowed to respond with text
+   instead. [Work_discovery] remains listed for routing/search guidance, but it
+   does not hard-gate by itself; the concrete signals inside a discovery turn
+   (claimable tasks, board activity, worktree delta) own the strict contract. *)
 let tools_for_gated_affordance = function
   | Board_curation -> [ "keeper_board_curation_submit" ]
   | Board_post_or_comment ->
@@ -345,6 +347,13 @@ let preferred_tool_choice_for_required_tool_names
     |> Keeper_types.dedupe_keep_order
   in
   match visible_required with
+  | [ name ] when
+      not (Keeper_tool_disclosure.tool_name_can_satisfy_required_contract name) ->
+    (* Passive/read-only tools do not suffer the mutating-tool raw-name
+       satisfaction ambiguity described below. When an operator explicitly
+       requires one passive tool, exact tool_choice keeps the model from
+       satisfying the turn with an unrelated write. *)
+    Agent_sdk.Types.Tool name
   | _ :: _ ->
     (* Use the provider-level "some tool is required" contract here, even
        for a single explicit required tool. Runtime MCP transports may return

--- a/lib/keeper/keeper_contract_classifier.ml
+++ b/lib/keeper/keeper_contract_classifier.ml
@@ -48,8 +48,13 @@ let of_keeper_world_observation
     unclaimed_task_count = observation.claimable_task_count;
     board_activity_count = List.length observation.pending_board_events;
     has_discovered_work_section =
-      observation.work_discovery_due
-      || Option.is_some observation.worktree_change_summary;
+      (* The interval-based work-discovery nudge is a scheduling hint, not
+         proof that concrete work exists. Treating a timer tick as an
+         actionable required-tool signal makes keepers fail when the nudge has
+         no discovered task/board/worktree payload. Concrete work still reaches
+         this classifier through claimable tasks, board activity, or a live
+         worktree delta. *)
+      Option.is_some observation.worktree_change_summary;
   }
 
 let classify_actionable_signal o =

--- a/lib/keeper/keeper_contract_classifier.mli
+++ b/lib/keeper/keeper_contract_classifier.mli
@@ -35,8 +35,10 @@ type world_observation = {
           processed. Mirrors the count rendered after
           ["### Board Activity"]. *)
   has_discovered_work_section : bool;
-      (** True iff the prompt build emitted a
-          ["## Discovered Work (auto, Ns interval)"] section. *)
+      (** True iff the prompt carries concrete discovered-work payload that
+          should satisfy the weakest actionable-signal tier. A timer-only
+          work-discovery nudge is intentionally excluded; concrete tasks,
+          board activity, and worktree deltas have their own signals. *)
 }
 
 (** Project the full keeper heartbeat observation into the compact contract

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -7454,7 +7454,7 @@ let test_should_require_tools_for_initial_turn_matches_first_turn_gate () =
   check bool "pending verification requires an action tool" true
     (KAR.should_require_tools_for_initial_turn ~max_turns:3
        ~turn_affordances:[ "task_verify" ]);
-  check bool "work discovery requires an action tool" true
+  check bool "timer-only work discovery stays optional" false
     (KAR.should_require_tools_for_initial_turn ~max_turns:3
        ~turn_affordances:[ "work_discovery" ]);
   check bool "worktree delta inspection requires an action tool" true
@@ -7520,6 +7520,14 @@ let test_turn_affordances_require_tool_gate_with_allowed_filters_by_tool () =
   check bool
     "task_verify with submit tool -> gate fires" true
     (gate ~tools:[ "keeper_task_submit_for_verification" ] [ "task_verify" ]);
+  check bool
+    "timer-only work_discovery does not hard-gate even with progress tools"
+    false
+    (gate ~tools:[ "keeper_board_post"; "keeper_task_create" ]
+       [ "work_discovery" ]);
+  check bool
+    "work_discovery can accompany another concrete gated affordance" true
+    (gate ~tools:[ "keeper_task_claim" ] [ "work_discovery"; "task_claim" ]);
   check bool
     "all gated affordances missing tools -> gate suppressed" false
     (gate
@@ -8873,14 +8881,23 @@ let () =
               in
               check bool "task_verify present without meta" true
                 (List.mem "task_verify" affordances));
-          test_case "affordance: work discovery requires action" `Quick
+          test_case "affordance: work discovery nudge is not a hard contract"
+            `Quick
             (fun () ->
               let obs = { base_observation with work_discovery_due = true } in
               let affordances =
                 UM.observed_affordances_of_observation obs
               in
               check bool "work_discovery present" true
-                (List.mem "work_discovery" affordances));
+                (List.mem "work_discovery" affordances);
+              let contract_obs =
+                Masc_mcp.Keeper_contract_classifier.of_keeper_world_observation
+                  obs
+              in
+              check bool "timer-only discovery is not actionable" false
+                (Masc_mcp.Keeper_contract_classifier.is_actionable
+                   (Masc_mcp.Keeper_contract_classifier.classify_actionable_signal
+                      contract_obs)));
           test_case "affordance: board curation requires multi-event window"
             `Quick
             (fun () ->


### PR DESCRIPTION
## Summary

Fixes a follow-up keeper contract failure visible in the live logs after #14104 merged:

- `work_discovery_due` was treated as a hard actionable required-tool signal even when it was only a timer nudge.
- A due timer could therefore force `Require_tool_use` on keepers with no concrete discovered task, board event, or worktree delta, producing `required tool contract violated (signal=has_discovered_work)` and then noisy local-recovery timeout retries.
- `Work_discovery` now remains an affordance/nudge, but it does not hard-gate by itself. Concrete signals still own strict contracts: claimable tasks, board activity, and worktree deltas.
- Explicit single passive/read-only `required_tools` now use exact `Tool(name)` so the model cannot satisfy a read-only operator contract with an unrelated write.

## Product impact

This reduces false-positive keeper failures from scheduled discovery timer ticks while keeping real work strict. A keeper should no longer be paused just because the discovery interval elapsed; it is still forced to act when there is actual claimable work, board activity, verification work, or worktree delta.

## Evidence

The live log failure class was `required tool contract violated (signal=has_discovered_work)` followed by local-recovery timeout after the discovery interval fired without a concrete task/board/worktree payload. This patch keeps the discovery nudge visible but removes it from the hard required-tool gate unless another concrete affordance is present.

## Review evidence

- `scripts/opam-pin-external-deps.sh --install`
- `scripts/dune-local.sh build test/test_keeper_contract_classifier_pure.exe`
- `./_build/default/test/test_keeper_contract_classifier_pure.exe`
- `scripts/dune-local.sh build test/test_keeper_unified.exe`
- `./_build/default/test/test_keeper_unified.exe test tool_classification`
- `./_build/default/test/test_keeper_unified.exe test verification_surface`
- `git diff --check`

## Known Local Test Gap

Full `./_build/default/test/test_keeper_unified.exe` still fails at pre-existing `world_observation.007` (`auto-goal fallback claimable backlog`: expected 1, got 0). The changed subsets pass, and that failure reproduced before and after this patch in the same unrelated fixture.

## Linked issue

- Follow-up to #14104
