### PR TITLE
fix(http): surface primary listener accept health

### DIFF
--- a/lib/http_server_eio.ml
+++ b/lib/http_server_eio.ml
@@ -19,7 +19,7 @@ let default_config = {
     Env_config_core.get_string
       ~default:Masc_network_defaults.masc_http_default_host
       "MASC_HTTP_HOST";
-  max_connections = Env_config_core.get_int ~default:128 "MASC_HTTP_MAX_CONNECTIONS";
+  max_connections = Env_config_core.get_int ~default:512 "MASC_HTTP_MAX_CONNECTIONS";
 }
 
 (** HTTP request handler type *)

--- a/lib/http_server_eio.mli
+++ b/lib/http_server_eio.mli
@@ -36,7 +36,7 @@ val default_config : config
 (** [default_config] is
     [{ port = Env_config_core.masc_http_port_int ();
        host = MASC_HTTP_HOST or default;
-       max_connections = MASC_HTTP_MAX_CONNECTIONS or 128 }].
+       max_connections = MASC_HTTP_MAX_CONNECTIONS or 512 }].
     Reads env at module load time — restart required for env
     changes to take effect. *)
 

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -947,6 +947,9 @@ let metric_grpc_backlog_replay_lines_scanned =
   "masc_grpc_backlog_replay_lines_scanned_total"
 let metric_grpc_backlog_replay_events_replayed =
   "masc_grpc_backlog_replay_events_replayed_total"
+let metric_http_accepts = "masc_http_accepts_total"
+let metric_http_accept_errors = "masc_http_accept_errors_total"
+let metric_http_active_connections = "masc_http_active_connections"
 
 (* Admission queue metrics — used in admission_queue_metrics.ml. *)
 let metric_inference_queue_depth = "masc_inference_queue_depth"
@@ -2670,6 +2673,18 @@ let init () =
   add metric_ws_bytes_cache_misses
     "WS raw-SSE-forward Bytes cache misses (fresh allocation required)"
     Counter;
+  add metric_http_accepts
+    "TCP connections accepted by the primary HTTP listener. Labels: mode \
+     (h1|h2|auto)."
+    Counter;
+  add metric_http_accept_errors
+    "Primary HTTP listener accept-loop errors. Labels: mode (h1|h2|auto). \
+     A non-zero rate means fresh control-plane connections may be blocked \
+     even while existing dashboard/SSE sessions remain established."
+    Counter;
+  add metric_http_active_connections
+    "Currently active primary HTTP connections accepted by the listener."
+    Gauge;
   register_histogram ~name:metric_dashboard_execution_render_phase_sec
     ~help:
       "Dashboard execution render phase latency in seconds. Labels: \

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -1072,6 +1072,15 @@ val metric_grpc_backlog_replay_events_replayed : string
     on a gRPC Subscribe RPC. The gap between scanned-lines and
     replayed-events isolates wasted scan cost. *)
 
+val metric_http_accepts : string
+(** Primary HTTP listener accepted TCP connections. Labels: [mode]. *)
+
+val metric_http_accept_errors : string
+(** Primary HTTP listener accept-loop errors. Labels: [mode]. *)
+
+val metric_http_active_connections : string
+(** Primary HTTP listener active accepted connections. *)
+
 (** {1 Admission queue metrics} *)
 
 val metric_inference_queue_depth : string

--- a/lib/server/server_bootstrap_http.ml
+++ b/lib/server/server_bootstrap_http.ml
@@ -65,7 +65,27 @@ let print_startup_banner ~(config : Http.config) ~resolved_base ~base_path
     Printf.printf
       "   POST /webrtc/offer, /webrtc/answer → WebRTC signaling\n%!"
 
+let on_connection_release conn_sw ~mode flow =
+  Eio.Switch.on_release conn_sw (fun () ->
+      Transport_metrics.record_http_connection_closed ~mode;
+      try Eio.Flow.close flow
+      with
+      | Eio.Cancel.Cancelled _ as e -> raise e
+      | exn -> Log.Misc.warn "flow close: %s" (Printexc.to_string exn))
+
+let register_listener_lifecycle ~sw ~mode =
+  Transport_metrics.record_http_listener_started ~mode;
+  let stopped = Atomic.make false in
+  let mark_stopped () =
+    if Atomic.compare_and_set stopped false true then
+      Transport_metrics.record_http_listener_stopped ~mode
+  in
+  Eio.Switch.on_release sw mark_stopped;
+  mark_stopped
+
 let serve ~sw ~clock ~socket ~request_handler =
+  let mode = "h1" in
+  let mark_stopped = register_listener_lifecycle ~sw ~mode in
   let is_cancelled exn =
     match exn with
     | Eio.Cancel.Cancelled _ -> true
@@ -74,13 +94,10 @@ let serve ~sw ~clock ~socket ~request_handler =
   let rec accept_loop backoff_s =
     try
       let flow, client_addr = Eio.Net.accept ~sw socket in
+      Transport_metrics.record_http_accept ~mode;
       Eio.Fiber.fork ~sw (fun () ->
           Eio.Switch.run (fun conn_sw ->
-              Eio.Switch.on_release conn_sw (fun () ->
-                  try Eio.Flow.close flow
-                  with
-                  | Eio.Cancel.Cancelled _ as e -> raise e
-                  | exn -> Log.Misc.warn "flow close: %s" (Printexc.to_string exn));
+              on_connection_release conn_sw ~mode flow;
               try
                 let conn_handler =
                   Httpun_eio.Server.create_connection_handler ~sw:conn_sw
@@ -111,10 +128,15 @@ let serve ~sw ~clock ~socket ~request_handler =
                   (Printexc.to_string exn)))
       ;
       accept_loop 0.05
-    with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
-      if is_cancelled exn then ()
+    with Eio.Cancel.Cancelled _ as e ->
+      mark_stopped ();
+      raise e
+    | exn ->
+      if is_cancelled exn then mark_stopped ()
       else begin
-        Log.Misc.error "Accept error: %s" (Printexc.to_string exn);
+        let error = Printexc.to_string exn in
+        Transport_metrics.record_http_accept_error ~mode ~error;
+        Log.Misc.error "Accept error: %s" error;
         (try Eio.Time.sleep clock backoff_s
          with
          | Eio.Cancel.Cancelled _ as e -> raise e
@@ -125,6 +147,8 @@ let serve ~sw ~clock ~socket ~request_handler =
   accept_loop 0.05
 
 let serve_h2 ~sw ~clock ~socket ~h2_request_handler ~h2_error_handler =
+  let mode = "h2" in
+  let mark_stopped = register_listener_lifecycle ~sw ~mode in
   let is_cancelled exn =
     match exn with
     | Eio.Cancel.Cancelled _ -> true
@@ -134,13 +158,10 @@ let serve_h2 ~sw ~clock ~socket ~h2_request_handler ~h2_error_handler =
   let rec accept_loop backoff_s =
     try
       let flow, client_addr = Eio.Net.accept ~sw socket in
+      Transport_metrics.record_http_accept ~mode;
       Eio.Fiber.fork ~sw (fun () ->
           Eio.Switch.run (fun conn_sw ->
-              Eio.Switch.on_release conn_sw (fun () ->
-                  try Eio.Flow.close flow
-                  with
-                  | Eio.Cancel.Cancelled _ as e -> raise e
-                  | exn -> Log.Misc.warn "[h2] flow close: %s" (Printexc.to_string exn));
+              on_connection_release conn_sw ~mode flow;
               try
                 H2_eio.Server.create_connection_handler ~sw:conn_sw
                   ~request_handler:h2_request_handler
@@ -153,10 +174,15 @@ let serve_h2 ~sw ~clock ~socket ~h2_request_handler ~h2_error_handler =
                 Log.Misc.error "[h2] Connection error: %s"
                   (Printexc.to_string exn)));
       accept_loop 0.05
-    with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
-      if is_cancelled exn then ()
+    with Eio.Cancel.Cancelled _ as e ->
+      mark_stopped ();
+      raise e
+    | exn ->
+      if is_cancelled exn then mark_stopped ()
       else begin
-        Log.Misc.error "[h2] Accept error: %s" (Printexc.to_string exn);
+        let error = Printexc.to_string exn in
+        Transport_metrics.record_http_accept_error ~mode ~error;
+        Log.Misc.error "[h2] Accept error: %s" error;
         (try Eio.Time.sleep clock backoff_s
          with
          | Eio.Cancel.Cancelled _ as e -> raise e
@@ -172,6 +198,8 @@ let serve_h2 ~sw ~clock ~socket ~h2_request_handler ~h2_error_handler =
     non-destructive, so both libraries read the socket normally. *)
 let serve_auto ~sw ~clock ~socket ~request_handler ~h2_request_handler
     ~h2_error_handler =
+  let mode = "auto" in
+  let mark_stopped = register_listener_lifecycle ~sw ~mode in
   let is_cancelled exn =
     match exn with
     | Eio.Cancel.Cancelled _ -> true
@@ -184,15 +212,10 @@ let serve_auto ~sw ~clock ~socket ~request_handler ~h2_request_handler
   let rec accept_loop backoff_s =
     try
       let flow, client_addr = Eio.Net.accept ~sw socket in
+      Transport_metrics.record_http_accept ~mode;
       Eio.Fiber.fork ~sw (fun () ->
           Eio.Switch.run (fun conn_sw ->
-              Eio.Switch.on_release conn_sw (fun () ->
-                  try Eio.Flow.close flow
-                  with
-                  | Eio.Cancel.Cancelled _ as e -> raise e
-                  | exn ->
-                    Log.Misc.warn "[auto] flow close: %s"
-                      (Printexc.to_string exn));
+              on_connection_release conn_sw ~mode flow;
               try
                 match Http_protocol_detect.detect flow with
                 | Ok Http_protocol_detect.Http2 ->
@@ -239,15 +262,20 @@ let serve_auto ~sw ~clock ~socket ~request_handler ~h2_request_handler
       if Atomic.compare_and_set stats_logged false true then
         Log.Server.info "[auto] stats: h2=%d h1=%d"
           (Atomic.get h2_count) (Atomic.get h1_count);
+      mark_stopped ();
       raise e
     | exn ->
       if is_cancelled exn then begin
         if Atomic.compare_and_set stats_logged false true then
           Log.Server.info "[auto] stats: h2=%d h1=%d"
             (Atomic.get h2_count) (Atomic.get h1_count)
+        ;
+        mark_stopped ()
       end
       else begin
-        Log.Misc.error "[auto] Accept error: %s" (Printexc.to_string exn);
+        let error = Printexc.to_string exn in
+        Transport_metrics.record_http_accept_error ~mode ~error;
+        Log.Misc.error "[auto] Accept error: %s" error;
         (try Eio.Time.sleep clock backoff_s
          with
          | Eio.Cancel.Cancelled _ as e -> raise e

--- a/lib/server/server_routes_http_runtime.ml
+++ b/lib/server/server_routes_http_runtime.ml
@@ -201,6 +201,7 @@ let make_health_json ?(listener = "http/1.1") request =
             `List (List.map (fun v -> `String v) mcp_protocol_versions) );
         ] );
     ("transport", transport_json request);
+    ("http_listener", Transport_metrics.http_listener_json ());
     ("paths", Server_base_path_diagnostics.to_yojson (health_path_diagnostics ()));
     ("uptime", `String uptime_str);
     ("sse_clients", `Int (Sse.client_count ()));

--- a/lib/transport_metrics.ml
+++ b/lib/transport_metrics.ml
@@ -162,6 +162,88 @@ let inc_grpc_backlog_replay_events_replayed ?(delta=1) () =
       Prometheus.metric_grpc_backlog_replay_events_replayed
       ~delta:(float_of_int delta) ()
 
+(** {1 Primary HTTP listener state} *)
+
+let http_listener_mode_runtime : string Atomic.t = Atomic.make "unknown"
+let http_listener_status : string Atomic.t = Atomic.make "not_started"
+let http_active_connections : int Atomic.t = Atomic.make 0
+let http_last_accept_unix : float option Atomic.t = Atomic.make None
+let http_last_accept_error : string option Atomic.t = Atomic.make None
+
+let set_http_connection_gauge value =
+  Prometheus.set_gauge Prometheus.metric_http_active_connections
+    (float_of_int (max 0 value))
+
+let record_http_listener_started ~mode =
+  Atomic.set http_listener_mode_runtime mode;
+  Atomic.set http_listener_status "listening";
+  set_http_connection_gauge (Atomic.get http_active_connections)
+
+let record_http_listener_stopped ~mode =
+  Atomic.set http_listener_mode_runtime mode;
+  Atomic.set http_listener_status "stopped";
+  set_http_connection_gauge (Atomic.get http_active_connections)
+
+let record_http_accept ~mode =
+  Atomic.set http_listener_mode_runtime mode;
+  Atomic.set http_listener_status "listening";
+  Atomic.set http_last_accept_unix (Some (Unix.gettimeofday ()));
+  Atomic.set http_last_accept_error None;
+  Prometheus.inc_counter Prometheus.metric_http_accepts
+    ~labels:[ ("mode", mode) ] ();
+  let active = Atomic.fetch_and_add http_active_connections 1 + 1 in
+  set_http_connection_gauge active
+
+let rec dec_http_active_connections () =
+  let before = Atomic.get http_active_connections in
+  let after = max 0 (before - 1) in
+  if Atomic.compare_and_set http_active_connections before after then
+    after
+  else
+    dec_http_active_connections ()
+
+let record_http_connection_closed ~mode =
+  Atomic.set http_listener_mode_runtime mode;
+  let active = dec_http_active_connections () in
+  set_http_connection_gauge active
+
+let record_http_accept_error ~mode ~error =
+  Atomic.set http_listener_mode_runtime mode;
+  Atomic.set http_listener_status "accept_error";
+  Atomic.set http_last_accept_error (Some error);
+  Prometheus.inc_counter Prometheus.metric_http_accept_errors
+    ~labels:[ ("mode", mode) ] ()
+
+let json_float_option = function
+  | Some value -> `Float value
+  | None -> `Null
+
+let json_string_option = function
+  | Some value -> `String value
+  | None -> `Null
+
+let http_listener_json ?now () =
+  let now = match now with Some value -> value | None -> Unix.gettimeofday () in
+  let last_accept_unix = Atomic.get http_last_accept_unix in
+  let last_accept_age_seconds =
+    Option.map (fun ts -> max 0.0 (now -. ts)) last_accept_unix
+  in
+  `Assoc
+    [
+      ("mode", `String (Atomic.get http_listener_mode_runtime));
+      ("status", `String (Atomic.get http_listener_status));
+      ("active_connections", `Int (Atomic.get http_active_connections));
+      ( "accepted_total",
+        `Int (int_of_float (Prometheus.metric_total Prometheus.metric_http_accepts)) );
+      ( "accept_errors_total",
+        `Int
+          (int_of_float
+             (Prometheus.metric_total Prometheus.metric_http_accept_errors)) );
+      ("last_accept_unix", json_float_option last_accept_unix);
+      ("last_accept_age_seconds", json_float_option last_accept_age_seconds);
+      ("last_error", json_string_option (Atomic.get http_last_accept_error));
+    ]
+
 (** {1 Environment-derived Transport Config} *)
 
 let grpc_runtime_listening : bool Atomic.t = Atomic.make false
@@ -514,6 +596,7 @@ let transport_health_json ~config =
       ("supports_post", `Bool true);
       ("supports_sse_upgrade", `Bool true);
       ("supports_delete", `Bool true);
+      ("listener", http_listener_json ());
     ]);
     ("http2", `Assoc [
       ("listener_mode", `String listener_mode);

--- a/lib/transport_metrics.mli
+++ b/lib/transport_metrics.mli
@@ -128,6 +128,30 @@ val inc_grpc_backlog_replay_events_replayed :
     increments [masc_grpc_backlog_replay_events_replayed_total].
     No-op when [delta <= 0]. *)
 
+(** {1 Primary HTTP listener state} *)
+
+val record_http_listener_started : mode:string -> unit
+(** Marks the primary HTTP accept loop as listening.  [mode] is one of
+    ["h1"], ["h2"], or ["auto"]. *)
+
+val record_http_listener_stopped : mode:string -> unit
+(** Marks the primary HTTP accept loop as stopped during shutdown. *)
+
+val record_http_accept : mode:string -> unit
+(** Records one accepted TCP connection and increments the active
+    connection gauge. *)
+
+val record_http_connection_closed : mode:string -> unit
+(** Records release of one accepted TCP connection. *)
+
+val record_http_accept_error : mode:string -> error:string -> unit
+(** Records an accept-loop error without using the error text as a
+    metric label. *)
+
+val http_listener_json : ?now:float -> unit -> Yojson.Safe.t
+(** Snapshot of primary HTTP accept-loop status for [/health] and
+    dashboard transport health. *)
+
 (** {1 WebSocket metrics} *)
 
 val set_ws_sessions : int -> unit

--- a/test/test_keeper_toml.ml
+++ b/test/test_keeper_toml.ml
@@ -1764,6 +1764,15 @@ legacy_scope = "removed"
   let request = Httpun.Request.create `GET "/health" in
   let json = Runtime.make_health_json request in
   let open Yojson.Safe.Util in
+  let listener = json |> member "http_listener" in
+  check bool "health exposes http listener diagnostics" true
+    (match listener with `Assoc _ -> true | _ -> false);
+  check bool "health listener status is surfaced" true
+    (match listener |> member "status" with `String _ -> true | _ -> false);
+  check bool "health listener active connections surfaced" true
+    (match listener |> member "active_connections" with
+    | `Int _ -> true
+    | _ -> false);
   check int "unknown key count" 1
     (json |> member "keeper_config_unknown_key_count" |> to_int);
   check string "schema status" "blocked"

--- a/test/test_transport_metrics.ml
+++ b/test/test_transport_metrics.ml
@@ -61,6 +61,12 @@ let test_init () =
        let _ = Str.search_forward
          (Str.regexp_string "masc_agent_heartbeat_age_seconds") text 0 in
        true
+     with Not_found -> false);
+  check bool "http accept metric registered" true
+    (try
+       let _ = Str.search_forward
+         (Str.regexp_string "masc_http_accepts_total") text 0 in
+       true
      with Not_found -> false)
 
 (* ============================================================
@@ -169,6 +175,46 @@ let test_ws_runtime_listening_cache () =
   TM.set_ws_runtime_listening false;
   check bool "ws listening resets" false (TM.ws_listening ())
 
+let test_http_listener_state_json () =
+  let accepts_before =
+    Prometheus.metric_total Prometheus.metric_http_accepts
+  in
+  let errors_before =
+    Prometheus.metric_total Prometheus.metric_http_accept_errors
+  in
+  TM.record_http_listener_started ~mode:"auto";
+  TM.record_http_accept ~mode:"auto";
+  let accepted = TM.http_listener_json () in
+  check string "http listener mode" "auto"
+    (accepted |> U.member "mode" |> U.to_string);
+  check string "http listener listening" "listening"
+    (accepted |> U.member "status" |> U.to_string);
+  check int "http listener active connection" 1
+    (accepted |> U.member "active_connections" |> U.to_int);
+  check bool "http listener accepted total advanced" true
+    (float_of_int (accepted |> U.member "accepted_total" |> U.to_int)
+     >= accepts_before +. 1.0);
+  check bool "last accept age present" true
+    (match accepted |> U.member "last_accept_age_seconds" with
+    | `Float _ | `Int _ -> true
+    | _ -> false);
+  TM.record_http_accept_error ~mode:"auto" ~error:"accept failed";
+  let errored = TM.http_listener_json () in
+  check string "http listener accept error status" "accept_error"
+    (errored |> U.member "status" |> U.to_string);
+  check string "http listener last error" "accept failed"
+    (errored |> U.member "last_error" |> U.to_string);
+  check bool "http listener accept error total advanced" true
+    (float_of_int (errored |> U.member "accept_errors_total" |> U.to_int)
+     >= errors_before +. 1.0);
+  TM.record_http_connection_closed ~mode:"auto";
+  TM.record_http_listener_stopped ~mode:"auto";
+  let stopped = TM.http_listener_json () in
+  check string "http listener stopped" "stopped"
+    (stopped |> U.member "status" |> U.to_string);
+  check int "http listener active connection released" 0
+    (stopped |> U.member "active_connections" |> U.to_int)
+
 (* ============================================================
    Agent Health Metrics
    ============================================================ *)
@@ -259,6 +305,17 @@ let test_transport_health_json () =
   check bool "streamable http auth_policy_present field exists" true
     (match streamable_json |> U.member "auth_policy_present" with
     | `Bool _ -> true
+    | _ -> false);
+  let streamable_listener_json = streamable_json |> U.member "listener" in
+  check bool "streamable http listener object exists" true
+    (match streamable_listener_json with `Assoc _ -> true | _ -> false);
+  check bool "streamable http listener status exists" true
+    (match streamable_listener_json |> U.member "status" with
+    | `String _ -> true
+    | _ -> false);
+  check bool "streamable http active connection count exists" true
+    (match streamable_listener_json |> U.member "active_connections" with
+    | `Int _ -> true
     | _ -> false);
   check string "presence stream endpoint" "/events/presence"
     (streamable_json |> U.member "presence_stream" |> U.to_string);
@@ -408,6 +465,10 @@ let () =
         test_ws_enabled_normalized_env_matches_runtime;
       test_case "runtime listening cache" `Quick
         test_ws_runtime_listening_cache;
+    ]);
+    ("http_listener", [
+      test_case "primary listener state json" `Quick
+        test_http_listener_state_json;
     ]);
     ("agent_health", [
       test_case "set_agent_heartbeat_age" `Quick test_agent_heartbeat_age;


### PR DESCRIPTION
## Summary

- Track primary HTTP accept-loop lifecycle state: mode, status, active connections, accepted count, accept errors, last accept time, and last error.
- Surface that snapshot in `/health` and the cached dashboard transport-health payload so existing dashboard/WS sessions can distinguish an alive runtime from a stalled or erroring accept path.
- Raise the default primary listener backlog from 128 to 512 while preserving `MASC_HTTP_MAX_CONNECTIONS` as the operator override.

## Why

Issue #13642 observed fresh loopback probes failing while the process still owned the listen socket and existing dashboard sessions remained established. The runtime had no operator-visible signal for whether the primary accept loop was still accepting fresh control-plane connections. This patch adds that signal at the accept path itself and gives bursty dashboard/SSE sessions more backlog headroom.

## Validation

- `git diff --check`
- `env DUNE_JOBS=1 MASC_SKIP_OPAM_LOCK=1 MASC_SKIP_PIN_CHECK=1 dune build --root . test/test_transport_metrics.exe test/test_keeper_toml.exe`
- `./_build/default/test/test_transport_metrics.exe` (22 tests)
- `env MASC_ALLOW_REPO_CONFIG_FALLBACK=true ./_build/default/test/test_keeper_toml.exe` (96 tests)

Note: `scripts/dune-local.sh build test/test_transport_metrics.exe test/test_keeper_toml.exe` was blocked waiting on `/tmp/me-dune-local.lock` and `/tmp/me-opam-switch.lock`, so I used the documented single-job fallback.

Tracks #13642