### PR TITLE
fix(task): return claim lock acquisition errors

### DIFF
--- a/lib/coord/coord_task_schedule.ml
+++ b/lib/coord/coord_task_schedule.ml
@@ -404,7 +404,7 @@ let claim_next_r
   ensure_initialized config;
 
   let backlog_path = Filename.concat (tasks_dir config) ".backlog" in
-  with_file_lock config backlog_path (fun () ->
+  let claim_under_lock () =
     try
       match read_backlog_r config with
       | Error msg -> Claim_next_error msg
@@ -741,7 +741,10 @@ let claim_next_r
     | Eio.Cancel.Cancelled _ as e -> raise e
     | e ->
       Claim_next_error (Printexc.to_string e)
-  )
+  in
+  match with_file_lock_r config backlog_path claim_under_lock with
+  | Ok result -> result
+  | Error err -> Claim_next_error (Masc_domain.masc_error_to_string err)
 
 (** Claim next highest priority unclaimed task (legacy string API). *)
 let claim_next config ~agent_name =


### PR DESCRIPTION
## Summary
- Route claim_next_r through with_file_lock_r so distributed backlog-lock acquisition exhaustion returns Claim_next_error instead of escaping as Invalid_argument.
- Preserve the existing task selection, existing-claim, and cancellation handling inside the lock callback.

## Evidence
- Live runtime log /Users/dancer/me/.masc/logs/system_log_2026-05-07.jsonl:25018-25020 showed keeper_task_claim crashing with Invalid_argument("Failed to acquire distributed lock for key: tasks:.backlog (50 attempts exhausted)").
- Root cause: claim_next_r caught exceptions inside the with_file_lock callback, but distributed lock acquisition happened before that callback was entered.

## Validation
- git diff --check HEAD~1..HEAD
- gh pr checks --watch: source/policy checks passed where applicable (Env knob classification, Fun.protect finalizer guard, Godfile size, Hardcoded model prefix, Math.random in components, PR Live Gate, PR Sync Check, Workflow YAML syntax).
- Build/Lint jobs were skipped by changed-surface policy on this draft.
- Attempted scripts/dune-local.sh build test/test_keeper_task_dispatch.exe twice; first attempt stayed queued behind another Dune holder, second acquired the Dune lock but waited on another worktree's opam switch lock, so I stopped my waiter to avoid blocking shared local work.
- Red checks are policy-only for agent-pr/draft: CI Gate and Draft Auto-Merge Guard require a human-added human-approved-ready label.