### PR TITLE
fix: count dashboard keeper alert read drops

### DIFF
--- a/lib/dashboard/dashboard_http_keeper.ml
+++ b/lib/dashboard/dashboard_http_keeper.ml
@@ -24,6 +24,38 @@ let runtime_warning_ctx_ratio =
 let live_keeper_cascade_name (raw : string) =
   Keeper_cascade_profile.resolve_live raw
 
+let dashboard_keeper_recent_alerts_surface = "dashboard_keeper_recent_alerts"
+
+let report_dashboard_keeper_recent_alert_drop ~reason ~path ~detail =
+  Safe_ops.report_persistence_read_drop
+    ~on_drop:(fun () ->
+      Prometheus.inc_counter Prometheus.metric_persistence_read_drops
+        ~labels:[("surface", dashboard_keeper_recent_alerts_surface); ("reason", reason)]
+        ())
+    ~surface:dashboard_keeper_recent_alerts_surface
+    ~reason
+    ~path
+    ~detail
+
+let parse_recent_alert_line ~path line =
+  match Yojson.Safe.from_string line with
+  | `Assoc _ as json -> Some json
+  | _ ->
+      report_dashboard_keeper_recent_alert_drop
+        ~reason:Safe_ops.persistence_read_drop_reason_invalid_payload
+        ~path
+        ~detail:"expected JSON object row";
+      None
+  | exception (Eio.Cancel.Cancelled _ as exn) ->
+      let bt = Printexc.get_raw_backtrace () in
+      Printexc.raise_with_backtrace exn bt
+  | exception Yojson.Json_error detail ->
+      report_dashboard_keeper_recent_alert_drop
+        ~reason:Safe_ops.persistence_read_drop_reason_entry_load_error
+        ~path
+        ~detail;
+      None
+
 (** Compute keeper health score (0-100). Pure function.
     Inputs: restart_count, max_restarts, recent_crash_count,
             is_dead, context_ratio (0.0-1.0). *)
@@ -1290,9 +1322,7 @@ let keepers_dashboard_json ?(compact = false) (config : Coord.config) : Yojson.S
     let lines =
       Keeper_memory.read_file_tail_lines alerts_path ~max_bytes:50000 ~max_lines:10
     in
-    List.filter_map (fun line ->
-      try Some (Yojson.Safe.from_string line) with Yojson.Json_error _ -> None
-    ) lines
+    List.filter_map (parse_recent_alert_line ~path:alerts_path) lines
   in
   `Assoc [
     ("keepers", `List summaries);

--- a/test/dune
+++ b/test/dune
@@ -1119,6 +1119,7 @@
 (include stanzas/test_dashboard_feature_health.inc)
 (include stanzas/test_dashboard_goals.inc)
 (include stanzas/test_dashboard_governance_metrics.inc)
+(include stanzas/test_dashboard_keeper_alerts_read_drop.inc)
 (include stanzas/test_dashboard_keeper_metrics_10286.inc)
 (include stanzas/test_dashboard_keeper_routes.inc)
 (include stanzas/test_dashboard_tla_specs.inc)

--- a/test/stanzas/test_dashboard_keeper_alerts_read_drop.inc
+++ b/test/stanzas/test_dashboard_keeper_alerts_read_drop.inc
@@ -1,0 +1,4 @@
+(test
+ (name test_dashboard_keeper_alerts_read_drop)
+ (modules test_dashboard_keeper_alerts_read_drop)
+ (libraries masc_test_deps))

--- a/test/test_dashboard_keeper_alerts_read_drop.ml
+++ b/test/test_dashboard_keeper_alerts_read_drop.ml
@@ -1,0 +1,92 @@
+module Dash = Masc_mcp.Dashboard_http_keeper
+module P = Masc_mcp.Prometheus
+module KT = Masc_mcp.Keeper_types
+
+open Alcotest
+
+let temp_dir () =
+  let dir = Filename.temp_file "dashboard_keeper_alerts_drop_" "" in
+  Unix.unlink dir;
+  Unix.mkdir dir 0o755;
+  dir
+
+let cleanup_dir dir =
+  let rec rm path =
+    if Sys.file_exists path then
+      if Sys.is_directory path then (
+        Array.iter (fun name -> rm (Filename.concat path name)) (Sys.readdir path);
+        Unix.rmdir path)
+      else
+        Unix.unlink path
+  in
+  try rm dir with _ -> ()
+
+let write_lines path lines =
+  KT.mkdir_p (Filename.dirname path);
+  let oc = open_out path in
+  Fun.protect
+    ~finally:(fun () -> close_out_noerr oc)
+    (fun () ->
+      List.iter
+        (fun line ->
+          output_string oc line;
+          output_char oc '\n')
+        lines)
+
+let persistence_read_drop_total ~surface ~reason =
+  P.metric_value_or_zero P.metric_persistence_read_drops
+    ~labels:[("surface", surface); ("reason", reason)]
+    ()
+
+let check_persistence_read_drop_delta ~surface ~reason ~before ~delta =
+  check (float 0.0001)
+    (Printf.sprintf "%s/%s persistence read drops" surface reason)
+    (before +. float_of_int delta)
+    (persistence_read_drop_total ~surface ~reason)
+
+let test_recent_alerts_count_malformed_rows () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let base = temp_dir () in
+  Fun.protect ~finally:(fun () -> cleanup_dir base) (fun () ->
+    let config = Masc_mcp.Coord.default_config base in
+    let surface = "dashboard_keeper_recent_alerts" in
+    let entry_error = Safe_ops.persistence_read_drop_reason_entry_load_error in
+    let invalid_payload = Safe_ops.persistence_read_drop_reason_invalid_payload in
+    let entry_before = persistence_read_drop_total ~surface ~reason:entry_error in
+    let invalid_before = persistence_read_drop_total ~surface ~reason:invalid_payload in
+    let alerts_path = KT.keeper_alerts_path config in
+    write_lines alerts_path [
+      Yojson.Safe.to_string
+        (`Assoc
+          [ ("keeper", `String "alpha")
+          ; ("level", `String "bad")
+          ; ("message", `String "alert visible")
+          ]);
+      "[1]";
+      "{not-json";
+    ];
+    let json = Dash.keepers_dashboard_json ~compact:true config in
+    let open Yojson.Safe.Util in
+    let alerts = json |> member "recent_alerts" |> to_list in
+    check int "valid alert preserved" 1 (List.length alerts);
+    check string "alert message" "alert visible"
+      (List.hd alerts |> member "message" |> to_string);
+    check_persistence_read_drop_delta
+      ~surface
+      ~reason:entry_error
+      ~before:entry_before
+      ~delta:1;
+    check_persistence_read_drop_delta
+      ~surface
+      ~reason:invalid_payload
+      ~before:invalid_before
+      ~delta:1)
+
+let () =
+  run "dashboard_keeper_alerts_read_drop" [
+    "recent_alerts", [
+      test_case "malformed persisted rows count read drops" `Quick
+        test_recent_alerts_count_malformed_rows;
+    ];
+  ]


### PR DESCRIPTION
Summary:
- Count malformed persisted keeper alert rows in `masc_persistence_read_drops_total`.
- Add bounded surface `dashboard_keeper_recent_alerts`.
- Map JSON syntax errors to `entry_load_error` and non-object rows to `invalid_payload`.
- Preserve valid alert rows in dashboard `recent_alerts`.

Validation:
- `git diff --check`
- `lockf -k -t 1200 /tmp/me-dune-local.lock env MASC_DUNE_LOCK_HELD=1 MASC_SKIP_OPAM_LOCK=1 DUNE_JOBS=1 DUNE_CACHE=disabled scripts/dune-local.sh build test/test_dashboard_keeper_alerts_read_drop.exe`
- `./_build/default/test/test_dashboard_keeper_alerts_read_drop.exe` (1 test)