### PR TITLE
feat(coord): sender-side mention dedup at broadcast (RFC-0040)

### DIFF
--- a/docs/rfc/RFC-0040-mention-dedup.md
+++ b/docs/rfc/RFC-0040-mention-dedup.md
@@ -1,0 +1,221 @@
+# RFC 0040 — Mention dedup at sender (broadcast-time)
+
+> Note: drafted as RFC-0036.v2 in loop-iter-8 (2026-05-07).  Renumbered
+> to RFC-0040 at PR time because RFC-0036 was already taken by
+> RFC-0036-oas-cognitive-mapping (PR #13915).  Content unchanged from
+> the iter-8 draft.
+
+- **Status**: Draft (loop-iter-8, 2026-05-07) — *replaces* iter-6/7 sketch
+- **Author**: Vincent + Claude (auto-mode loop)
+- **Resolves Board Issues**: "24+ mention spam to nick0cave" (taskmaster), "Tripartite Coordination Breakdown — same task re-mention" (sangsu/imseonghan)
+- **Sister**: RFC-0035 (memory write — orthogonal complement that lets keepers act on mentions)
+
+---
+
+## 1. iter-6/7 sketch correction (Narrative cascade)
+
+Earlier iter-6 sketch + iter-7 *correction* both assumed:
+> "Mention dispatch happens at broadcast time; resolve_targets filters recipient set."
+
+**Verified (iter-8 grep, iter-9 cross-check 정정)**: `Mention.resolve_targets` has **0 callers in `lib/` production code** (test/docs는 별도). 정확히는:
+- `lib/coord/mention.ml:110` 정의 + `lib/coord/mention.mli:32` export
+- `docs/spec/03-room-coordination.md:437`에서 *공식 API 명시* — design 의도 존재
+- `test/test_mention.ml`, `test/test_mention_coverage.ml`에 6+ test
+- **lib/ 의 production caller는 0** — 의도된 API이나 미사용 (intended-but-unused infra)
+
+Mention model is actually:
+
+| Step | Where | Action |
+|---|---|---|
+| Sender writes content | `Coord_broadcast.broadcast` | Persist to disk, emit hook |
+| Sender extracts mention | `coord_broadcast.ml:122 Mention.extract content` | parse `@target` token, *informational only* |
+| Recipient pulls | `keeper_prompt.ml:16 Mention.any_mentioned ~targets:[my_name] content` | Each keeper checks own name in board on its turn |
+| Recipient handles | `keeper_exec_context.ml:418`, `keeper_memory_policy.ml:83` | direct_mention boolean → prompt injection / memory tagging |
+
+즉 **pull model**. Keeper가 자기 board를 읽고 mention 검색. iter-6 sketch의 *push-time dispatch filter* 가정은 **틀린 design**.
+
+이는 R3 (caller 전체 grep + 1-2 사이트 본문 read) 미적용 사례 — `resolve_targets`만 보고 *export = used*로 가정.
+
+## 2. Motivation (정정)
+
+24-mention spam 흐름:
+1. taskmaster가 task-037 stale 의심 → broadcast 호출 (with `@nick0cave` in content)
+2. content 디스크 persistence + hook (recipient 결정 안 함)
+3. nick0cave가 자기 turn에 board 읽고 `Mention.any_mentioned ~targets:["nick0cave"]` → True
+4. nick0cave가 응답할 capability 없음 (P4 write-path 부재) → board에 또 글 쓰거나 무응답
+5. taskmaster가 *같은 stale*에 또 broadcast → 1로 돌아감
+
+매 cycle 발생 → 24회 누적.
+
+근본 원인 두 축:
+- **A. 발신자 dedup 부재**: taskmaster가 같은 (target, topic) 발신을 N분 내 반복 차단 안 함.
+- **B. 수신자 acknowledgement 부재**: nick0cave가 mention 받았다는 신호를 발신자에게 보낼 capability 없음 (P4 RFC-0035 미해결 시).
+
+본 RFC는 **A**만 다룸. B는 RFC-0035로 별도.
+
+## 3. Non-Goals
+
+- pull model 자체 변경 — 그대로.
+- recipient 측 mention 처리 변경 — 그대로.
+- Mention.extract / any_mentioned API 변경 — 그대로.
+- A2A / direct delivery 도입 — 별도.
+
+## 4. Design
+
+### 4.1 발신자 측 dedup (sender-side)
+
+`lib/coord/coord_broadcast.ml:122` `Mention.extract content` 직후, mention이 `Some target`이면 *최근 N분 내 같은 (from_agent, target, topic_hash) 발신 여부* 검사.
+
+```ocaml
+(* lib/coord/coord_broadcast.ml — 변경 후 *)
+let mention = Mention.extract content in
+let dedup_skip =
+  match mention with
+  | Some target ->
+    Mention_dedup.should_skip
+      ~from_agent ~target
+      ~content_hash:(content_topic_hash content)
+      ~now:(Time_compat.now ())
+  | None -> false
+in
+if dedup_skip then begin
+  Log.Misc.info
+    "[mention-dedup] skipped duplicate mention from %s to %s within window"
+    from_agent (Option.value ~default:"<none>" mention);
+  Coord_hooks.coord_broadcast_observed_fn ~msg_type:"dedup_skipped" ~elapsed_s:0.0;
+  Result.Ok "dedup_skipped"
+end else
+  (* 기존 흐름 그대로 *)
+  ...
+```
+
+### 4.2 신규 모듈 `lib/coord/mention_dedup.{ml,mli}`
+
+```ocaml
+type t (* abstract; module-level singleton via Atomic / Mutex *)
+
+(** Default 5min window; configurable via env MASC_MENTION_DEDUP_TTL_S. *)
+val default_ttl_seconds : float
+
+val should_skip :
+  from_agent:string ->
+  target:string ->
+  content_hash:string ->
+  now:float ->
+  bool
+
+(** Test-only reset hook. *)
+val reset_for_test : unit -> unit
+
+(** Emit Prometheus metric on every check. *)
+(* internal: metric_mention_dedup_decisions_total{outcome} *)
+```
+
+**구현 내부**:
+- `Hashtbl` keyed by `(from_agent, target, content_hash)` → last_seen timestamp
+- `should_skip` 호출 시 entry 있고 `now - last_seen < ttl` → true (skip), 아니면 entry 갱신 + return false
+- Hashtbl size > 1000 시 LRU prune (낮은 priority — 확장 시점 별도 PR)
+- Server restart 시 fresh — *의도된 동작* (restart는 1회 mention OK)
+
+### 4.3 `content_topic_hash`
+
+같은 topic의 동일 변종 문구도 dedup하기 위해 hash key는 *문장 단위가 아닌 topic*. 단순화 — 처음에는 *content 그대로 SHA1*로 시작 (variant detection 미적용). 발견 시 `Coord_topic.normalize_for_dedup`(별도 RFC) 추가.
+
+```ocaml
+let content_topic_hash content =
+  Digest.string (String.lowercase_ascii (String.trim content)) |> Digest.to_hex
+```
+
+trade-off: *exact-match dedup*. taskmaster가 *조금 다르게 같은 의미*를 여러 번 보내면 모두 통과. 시작점 conservative.
+
+### 4.4 Bypass 옵션
+
+명시적 *force broadcast* 필요한 caller (예: incident response)는 `?bypass_dedup:bool` 추가:
+```ocaml
+val broadcast :
+  ?trace_context:... ->
+  ?msg_type:string ->
+  ?task_cache_invariant_checked:bool ->
+  ?bypass_dedup:bool ->          (* 신규 *)
+  config -> from_agent:string -> content:string -> result
+```
+default `false`. Keeper code는 default. system-level alert은 `~bypass_dedup:true`.
+
+## 5. Migration
+
+### 5.1 영향 범위
+
+8개 production broadcast 사이트 전부 자동으로 dedup 가드 통과:
+- `lib/orchestrator.ml:120` system broadcast
+- `lib/coord/coord_lifecycle.ml:108, 178, 247` (agent join/state/system)
+- `lib/coord/coord_task_create.ml:236` task create alert
+- `lib/coord/coord_eio.ml:588` (eio variant — 별도 함수, dedup 적용 여부 확인 필요)
+- `lib/grpc/masc_grpc_client.ml:77` grpc broadcast (별도 path)
+
+eio variant + grpc는 별도 stack — 본 RFC의 dedup이 *coord_broadcast.ml:64 broadcast*만 거치는 caller에만 적용. eio/grpc 계열 caller는 별도 fix.
+
+### 5.2 회귀 테스트
+
+`test/test_mention_dedup.ml` (신규):
+- `test_dedup_skips_within_window` — 같은 from/target/content 5초 간격 두 번 → 두 번째 dedup_skipped
+- `test_dedup_clears_after_ttl` — ttl 초과 후 동일 broadcast 통과
+- `test_dedup_distinguishes_targets` — 같은 from, 다른 target → 둘 다 통과
+- `test_dedup_distinguishes_content` — 같은 from/target, 다른 content_hash → 둘 다 통과
+- `test_bypass_dedup_force` — `~bypass_dedup:true` → ttl 내 동일도 통과
+- `test_dedup_no_target` — mention=None → dedup 미적용 (목적은 *mention 발신 dedup*)
+
+## 6. Risks
+
+- **Legitimate retry**: keeper가 같은 task에 의해 정상적으로 다시 mention 필요 (실제 새 정보 추가) → exact-match SHA1이라 *content 변화 시 통과*. 운영 관찰로 false positive 감지.
+- **Cross-server inconsistency**: server restart 시 dedup state 사라짐. *의도된*. 운영자 명시 fault tolerance.
+- **Hashtbl memory growth**: 1000+ entries 후 LRU prune 미구현. 일주일 동안 unique mention pair 수가 1000+ 이면 OOM 가능 — 별도 RFC.
+- **eio/grpc broadcast bypass**: 본 RFC의 dedup이 그쪽엔 적용 안 됨. 24-mention spam이 그쪽으로 들어왔다면 본 RFC는 부분 fix.
+
+## 7. Implementation Plan
+
+| 단계 | 산출물 | LOC |
+|---|---|---|
+| S1 | `lib/coord/mention_dedup.{ml,mli}` 신설 | ~80 |
+| S2 | `coord_broadcast.ml:122` 직후 dedup 호출 | ~10 |
+| S3 | `~bypass_dedup` 옵션 추가 + 시그니처 변경 | ~15 |
+| S4 | Prometheus counter `metric_mention_dedup_decisions_total{outcome}` | ~10 |
+| S5 | 회귀 테스트 6건 | ~120 |
+| S6 | env `MASC_MENTION_DEDUP_TTL_S` 통합 | ~5 |
+| S7 | dune build + test green | — |
+| S8 | Draft PR + RFC 인용 | — |
+
+총 **~+240 LOC**.
+
+## 8. Verification
+
+### 코드 verification
+- `scripts/dune-local.sh build`
+- 신규 + 기존 회귀 테스트 모두 green
+
+### 운영 verification
+- 배포 24시간 후 `metric_mention_dedup_decisions_total{outcome="dedup_skipped"}` non-zero
+- nick0cave류 keeper의 인바운드 mention 카운트가 *기존 대비 감소* (board에서 정성적 측정)
+- false positive 사례 (legitimate retry 차단) 발견 시 별도 fix
+
+## 9. Open Questions
+
+1. eio variant `lib/coord/coord_eio.ml:588 broadcast`가 main `coord_broadcast.broadcast`를 호출하는지, 별도 path인지 확인 미수행. iter-9 grep.
+2. grpc broadcast (`lib/grpc/masc_grpc_client.ml:77`)는 본 dedup 미적용 — *분리 RFC 또는 grpc client 측 dedup* 필요.
+3. dedup state file로 persist 옵션 추후 추가 가능성 (현재 RAM only).
+
+## 10. Self-skepticism
+
+- §4.1 broadcast 본문 변경 sketch는 *현 broadcast.ml:64 `result` 반환 형식*과 일치 가정. 실제 함수 sig 확인은 위에서 수행했으나 return type은 미확인 — `Result.Ok "dedup_skipped"` 가 적합한지 PR 작업 중 정정 가능.
+- §4.3 SHA1 hash는 *exact-match*. taskmaster가 *날짜/timestamp 포함 변종 발신* 패턴이라면 dedup 통과 → 실효성 낮을 수 있음. iter-9에서 board 24-mention 사례의 *실제 content variation*을 dump해서 확인.
+- §5.1 eio/grpc broadcast가 같은 dedup 거치는지 미확인 — Open Question 1.
+- iter-6/7 sketch의 design 방향이 *틀렸다*는 발견은 *meta-protocol R3 적용 안 한 결과*. 본 RFC가 R1~R6 적용 사례.
+
+## 11. References
+
+- iter-2 §2.P5 (initial framing)
+- iter-5 §2 (P4↔P5 통합)
+- iter-6 §3 (sketch — *틀린 design 방향*)
+- iter-7 §3 (sketch 보강 — *부분 정정만 한 narrative cascade*)
+- iter-8 §1 (본 RFC — pull model 발견 후 정정)
+- 코드: `lib/coord/coord_broadcast.ml:64,122`, `lib/coord/mention.ml:121` (`resolve_targets`, 0 callers), `lib/keeper/keeper_prompt.ml:16`, `lib/keeper/keeper_exec_context.ml:418`, `lib/keeper/keeper_memory_policy.ml:83`
+- Memory: `feedback_keeper_hallucinated_audit_cascade`, `feedback_rfc_section_1_4_caller_context_unverified`

--- a/lib/coord.ml
+++ b/lib/coord.ml
@@ -337,6 +337,18 @@ let () =
   Atomic.set Coord_hooks.coord_broadcast_observed_fn
     record_coord_broadcast
 
+(* RFC-0040: route Mention_dedup decision counts to Prometheus.
+   Default no-op in [Coord_hooks] is replaced at startup so the
+   coord layer keeps zero static dep on Prometheus. *)
+let record_mention_dedup_decision ~outcome =
+  Prometheus.inc_counter
+    Prometheus.metric_mention_dedup_decisions_total
+    ~labels:[ ("outcome", outcome) ] ()
+
+let () =
+  Atomic.set Coord_hooks.mention_dedup_decision_fn
+    record_mention_dedup_decision
+
 let record_file_lock_attempt ~caller ~retries ~elapsed_s ~outcome =
   if retries > 0 then
     Prometheus.inc_counter Prometheus.metric_file_lock_retries

--- a/lib/coord/coord_broadcast.ml
+++ b/lib/coord/coord_broadcast.ml
@@ -62,7 +62,8 @@ let on_broadcast_mention : (string option -> unit) ref =
   ref (fun _mention -> ())
 
 let broadcast ?trace_context ?(msg_type = "broadcast")
-    ?(task_cache_invariant_checked = false) config ~from_agent ~content =
+    ?(task_cache_invariant_checked = false) ?(bypass_dedup = false)
+    config ~from_agent ~content =
   let started_at = Time_compat.now () in
   let observe final_msg_type =
     let elapsed_s = Float.max 0.0 (Time_compat.now () -. started_at) in
@@ -118,8 +119,45 @@ let broadcast ?trace_context ?(msg_type = "broadcast")
           msg_type )
     else (content, msg_type)
   in
+  (* RFC-0040: sender-side mention dedup.  When [Mention.extract]
+     finds an [@target] and the same (from_agent, target, content_hash)
+     was broadcast within [Mention_dedup.default_ttl_seconds], skip the
+     entire broadcast: no msg file, no activity emit, no on_broadcast
+     callback.  Keeper pull-model (keeper_prompt.ml:16
+     [Mention.any_mentioned]) re-reads the board on every turn, so a
+     spammy resender otherwise floods the recipient's inbox.  Set
+     [~bypass_dedup:true] to override for system-level alerts. *)
+  let pre_extract_mention = Mention.extract content in
+  let dedup_skipped =
+    (not bypass_dedup)
+    && (match pre_extract_mention with
+        | Some target when String.trim target <> "" ->
+            let content_hash = Mention_dedup.content_topic_hash content in
+            Mention_dedup.should_skip ~from_agent ~target ~content_hash
+              ~now:(Time_compat.now ())
+        | _ ->
+            (try (Atomic.get Coord_hooks.mention_dedup_decision_fn)
+                   ~outcome:(if bypass_dedup then "bypassed" else "no_target")
+             with _ -> ());
+            false)
+  in
+  if dedup_skipped then begin
+    Log.Misc.info
+      "[mention-dedup] skipped duplicate mention from %s to %s within %.0fs window"
+      from_agent
+      (Option.value ~default:"<none>" pre_extract_mention)
+      Mention_dedup.default_ttl_seconds;
+    observe "dedup_skipped";
+    Printf.sprintf "\xF0\x9F\x93\xA2 [%s] dedup_skipped" from_agent
+  end else
+  let () =
+    if bypass_dedup then
+      try (Atomic.get Coord_hooks.mention_dedup_decision_fn)
+            ~outcome:"bypassed"
+      with _ -> ()
+  in
   let seq = Coord_state.next_seq config in
-  let mention = Mention.extract content in
+  let mention = pre_extract_mention in
   let safe_content = sanitize_message content in
   let safe_agent = sanitize_agent_name from_agent in
   let safe_msg_type =

--- a/lib/coord/coord_broadcast.mli
+++ b/lib/coord/coord_broadcast.mli
@@ -17,5 +17,10 @@ val on_broadcast_mention : (string option -> unit) ref
 val broadcast : ?trace_context:string ->
            ?msg_type:string ->
            ?task_cache_invariant_checked:bool ->
+           ?bypass_dedup:bool ->
            Coord_utils_backend_setup.config ->
            from_agent:string -> content:string -> string
+(** [bypass_dedup] (default [false]): skip the RFC-0040 sender-side
+    mention dedup window check.  Use only for system-level alerts that
+    must always reach the recipient (e.g. incident response).  Keeper
+    code paths leave the default. *)

--- a/lib/coord/coord_hooks.ml
+++ b/lib/coord/coord_hooks.ml
@@ -254,6 +254,14 @@ let coord_broadcast_observed_fn
   : (msg_type:string -> elapsed_s:float -> unit) Atomic.t
   = Atomic.make (fun ~msg_type:_ ~elapsed_s:_ -> ())
 
+(** RFC-0040: sender-side mention dedup decision counter.  Default
+    no-op; emit lives in [lib/coord.ml] to avoid a
+    [masc_coord → Prometheus] dep cycle.
+    Outcome vocabulary: [skipped|passed|no_target|bypassed]. *)
+let mention_dedup_decision_fn
+  : (outcome:string -> unit) Atomic.t
+  = Atomic.make (fun ~outcome:_ -> ())
+
 (** #13460: stale task-state cache emission observability.
     Coord sub-modules fire this when they replace a stale active-task
     broadcast/mention with a cache invalidation message. [lib/coord.ml]

--- a/lib/coord/coord_hooks.mli
+++ b/lib/coord/coord_hooks.mli
@@ -75,6 +75,13 @@ val task_auto_release_observed_fn :
     [cache_invalidated] / mention follow-ups. *)
 val coord_broadcast_observed_fn :
   (msg_type:string -> elapsed_s:float -> unit) Atomic.t
+
+(** RFC-0040: sender-side mention dedup decision counter.
+    Wired at startup ([lib/coord.ml]) to
+    [masc_mention_dedup_decisions_total{outcome}].
+    Outcome vocabulary: [skipped|passed|no_target|bypassed]. *)
+val mention_dedup_decision_fn :
+  (outcome:string -> unit) Atomic.t
 val cache_desync_cleared_fn :
   (Coord_utils_backend_setup.config ->
    module_name:string -> task_id:string -> status:string -> unit) Atomic.t

--- a/lib/coord/dune
+++ b/lib/coord/dune
@@ -36,6 +36,7 @@
   playground_repo_cache
   coord_worktree
   mention
+  mention_dedup
   coord_resilience
   heartbeat
   nickname)

--- a/lib/coord/mention_dedup.ml
+++ b/lib/coord/mention_dedup.ml
@@ -1,0 +1,44 @@
+(** Sender-side mention dedup. See [mention_dedup.mli] for contract. *)
+
+let default_ttl_seconds : float =
+  match Sys.getenv_opt "MASC_MENTION_DEDUP_TTL_S" with
+  | None -> 300.0
+  | Some raw ->
+      (match float_of_string_opt (String.trim raw) with
+       | Some v when v > 0.0 -> v
+       | _ -> 300.0)
+
+(* Module-level singleton. Hashtbl is not thread-safe across Eio fibers
+   that may re-enter via [run_in_main]; guard with a Mutex. *)
+let table : (string * string * string, float) Hashtbl.t = Hashtbl.create 256
+let mu : Mutex.t = Mutex.create ()
+
+let inc_outcome outcome =
+  try (Atomic.get Coord_hooks.mention_dedup_decision_fn) ~outcome
+  with _ -> ()
+
+let content_topic_hash content =
+  let normalized = String.lowercase_ascii (String.trim content) in
+  Digest.string normalized |> Digest.to_hex
+
+let should_skip ~from_agent ~target ~content_hash ~now =
+  let key = (from_agent, target, content_hash) in
+  Mutex.lock mu;
+  let decision =
+    match Hashtbl.find_opt table key with
+    | Some last_seen when now -. last_seen < default_ttl_seconds ->
+        (* Within window — skip; do NOT refresh last_seen so the window
+           is anchored to the first observation, not the last attempt. *)
+        true
+    | _ ->
+        Hashtbl.replace table key now;
+        false
+  in
+  Mutex.unlock mu;
+  inc_outcome (if decision then "skipped" else "passed");
+  decision
+
+let reset_for_test () =
+  Mutex.lock mu;
+  Hashtbl.clear table;
+  Mutex.unlock mu

--- a/lib/coord/mention_dedup.mli
+++ b/lib/coord/mention_dedup.mli
@@ -1,0 +1,48 @@
+(** Sender-side mention dedup (RFC-0040).
+
+    Suppresses duplicate broadcasts where the sender mentions the same
+    target with the same content within a short TTL window. Pull-model
+    keepers (see [keeper_prompt.ml:16] [Mention.any_mentioned]) re-read
+    the board on every turn, so a sender resending the same
+    [@target topic] message every cycle floods the recipient's inbox
+    even though no new information was added.
+
+    Scope: only the broadcast path through [coord_broadcast.ml broadcast]
+    is covered. eio/grpc broadcast variants ([coord_eio.ml],
+    [masc_grpc_client.ml]) are NOT covered — see RFC-0040 §5.1.
+
+    State: in-process Hashtbl keyed by
+    [(from_agent, target, content_hash)]. RAM only — server restart
+    resets dedup state, which is intended (one mention per restart is
+    acceptable). *)
+
+(** Default dedup TTL window in seconds. Read from env
+    [MASC_MENTION_DEDUP_TTL_S]; falls back to 300.0s (5min). *)
+val default_ttl_seconds : float
+
+(** [should_skip ~from_agent ~target ~content_hash ~now] returns
+    [true] if a broadcast with the same triple was observed within
+    [default_ttl_seconds] of [now]. Otherwise it records [now] as the
+    last_seen for this triple and returns [false].
+
+    Side effects:
+    - Updates the in-process Hashtbl entry for the triple to [now].
+    - Increments the
+      [masc_mention_dedup_decisions_total]{outcome=skipped|passed}
+      Prometheus counter.
+
+    Thread safety: caller-side mutex; safe for concurrent fibers. *)
+val should_skip :
+  from_agent:string ->
+  target:string ->
+  content_hash:string ->
+  now:float ->
+  bool
+
+(** Stable SHA1 of [String.lowercase_ascii (String.trim content)]. *)
+val content_topic_hash : string -> string
+
+(** Test-only: clears the in-process Hashtbl. Not exported in
+    production wiring — only [test/test_mention_dedup.ml] should
+    call this. *)
+val reset_for_test : unit -> unit

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -1396,6 +1396,12 @@ let metric_keeper_recurring_failures =
 let metric_keeper_turn_cleanup_failures =
   "masc_keeper_turn_cleanup_failures_total"
 
+(* RFC-0040: sender-side mention dedup decision counter.  Labels:
+   [outcome] in [skipped|passed|no_target|bypassed].  Wired from
+   [lib/coord.ml] via [Coord_hooks.mention_dedup_decision_fn]. *)
+let metric_mention_dedup_decisions_total =
+  "masc_mention_dedup_decisions_total"
+
 (** {1 Built-in Metrics} *)
 
 let init () =
@@ -2648,6 +2654,8 @@ let init () =
     "Recurring task execution/dispatch failures. Labels: task, phase." Counter;
   add metric_keeper_turn_cleanup_failures
     "Turn cleanup failures (unsubscribe event_bus, mark_turn_finished). Labels: keeper, site." Counter;
+  add metric_mention_dedup_decisions_total
+    "RFC-0040 sender-side mention dedup decisions. Labels: outcome={skipped|passed|no_target|bypassed}." Counter;
   add metric_grpc_active_streams "Active gRPC bidirectional streams" Gauge;
   register_histogram ~name:metric_grpc_heartbeat_latency
     ~help:"gRPC heartbeat round-trip latency" ();

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -1182,6 +1182,11 @@ val metric_keeper_post_turn_wirein_failures : string
 val metric_keeper_recurring_failures : string
 val metric_keeper_turn_cleanup_failures : string
 
+(** RFC-0040: sender-side mention dedup decision counter.
+    Labels: [outcome] with values
+    [skipped|passed|no_target|bypassed]. *)
+val metric_mention_dedup_decisions_total : string
+
 (** {1 Process monitoring} *)
 
 val approximate_open_fd_count : unit -> int

--- a/test/dune
+++ b/test/dune
@@ -43,6 +43,7 @@
         test_gate_keeper_backend
         test_transport_read_model
         test_multi_room test_worktree_detection test_bounded test_mention
+        test_mention_dedup
         test_heartbeat_qw test_sse_qw test_sse_stream test_agent_health
         test_post_verifier
         test_reward_advice_artifact
@@ -269,6 +270,7 @@
           test_gate_keeper_backend
           test_transport_read_model
           test_multi_room test_worktree_detection test_bounded test_mention
+          test_mention_dedup
           test_heartbeat_qw test_sse_qw test_sse_stream test_agent_health
           test_post_verifier
         test_reward_advice_artifact

--- a/test/test_mention_dedup.ml
+++ b/test/test_mention_dedup.ml
@@ -1,0 +1,147 @@
+(** Tests for [Mention_dedup] — RFC-0040.
+
+    Window arithmetic uses the [~now] parameter directly, so the suite
+    runs without [Unix.sleep].  Each test calls [reset_for_test ()] in
+    its prelude to reset the in-process Hashtbl. *)
+
+let ttl = Mention_dedup.default_ttl_seconds
+
+(* Sanity guard: env override could change defaults; keep the
+   integration testable by asserting a positive window. *)
+let () =
+  if ttl <= 0.0 then
+    failwith
+      (Printf.sprintf
+         "Mention_dedup.default_ttl_seconds must be > 0; got %.3f" ttl)
+
+let hash content = Mention_dedup.content_topic_hash content
+
+let test_dedup_skips_within_window () =
+  Mention_dedup.reset_for_test ();
+  let h = hash "@nick0cave task-037 is stale" in
+  let first =
+    Mention_dedup.should_skip
+      ~from_agent:"taskmaster" ~target:"nick0cave"
+      ~content_hash:h ~now:1000.0
+  in
+  let second =
+    Mention_dedup.should_skip
+      ~from_agent:"taskmaster" ~target:"nick0cave"
+      ~content_hash:h ~now:1005.0
+  in
+  Alcotest.(check bool) "first call passes" false first;
+  Alcotest.(check bool) "second call within window skips" true second
+
+let test_dedup_clears_after_ttl () =
+  Mention_dedup.reset_for_test ();
+  let h = hash "@nick0cave please ack" in
+  let first =
+    Mention_dedup.should_skip
+      ~from_agent:"taskmaster" ~target:"nick0cave"
+      ~content_hash:h ~now:0.0
+  in
+  let after_ttl =
+    Mention_dedup.should_skip
+      ~from_agent:"taskmaster" ~target:"nick0cave"
+      ~content_hash:h ~now:(ttl +. 1.0)
+  in
+  Alcotest.(check bool) "first call passes" false first;
+  Alcotest.(check bool) "after ttl passes again" false after_ttl
+
+let test_dedup_distinguishes_targets () =
+  Mention_dedup.reset_for_test ();
+  let h = hash "shared content" in
+  let to_a =
+    Mention_dedup.should_skip
+      ~from_agent:"taskmaster" ~target:"alice"
+      ~content_hash:h ~now:100.0
+  in
+  let to_b =
+    Mention_dedup.should_skip
+      ~from_agent:"taskmaster" ~target:"bob"
+      ~content_hash:h ~now:101.0
+  in
+  Alcotest.(check bool) "first to alice passes" false to_a;
+  Alcotest.(check bool) "first to bob passes (different target)" false to_b
+
+let test_dedup_distinguishes_content () =
+  Mention_dedup.reset_for_test ();
+  let from_agent = "taskmaster" in
+  let target = "nick0cave" in
+  let first =
+    Mention_dedup.should_skip
+      ~from_agent ~target
+      ~content_hash:(hash "@nick0cave task-037 stale") ~now:200.0
+  in
+  let different =
+    Mention_dedup.should_skip
+      ~from_agent ~target
+      ~content_hash:(hash "@nick0cave task-038 also stale") ~now:201.0
+  in
+  Alcotest.(check bool) "first content passes" false first;
+  Alcotest.(check bool) "different content passes (different hash)"
+    false different
+
+let test_bypass_dedup_force () =
+  (* The [bypass_dedup] flag is enforced in [Coord_broadcast.broadcast].
+     The dedup module itself does not implement bypass — the broadcast
+     path skips the [should_skip] call entirely.  This test asserts the
+     dedup module remains the "would skip" oracle: with the same
+     triple inside the window, [should_skip] still returns true.  A
+     bypass caller is expected to NOT invoke [should_skip]. *)
+  Mention_dedup.reset_for_test ();
+  let h = hash "@alerts critical incident" in
+  let first =
+    Mention_dedup.should_skip
+      ~from_agent:"system" ~target:"alerts"
+      ~content_hash:h ~now:300.0
+  in
+  let would_skip =
+    Mention_dedup.should_skip
+      ~from_agent:"system" ~target:"alerts"
+      ~content_hash:h ~now:301.0
+  in
+  Alcotest.(check bool) "first call passes" false first;
+  Alcotest.(check bool)
+    "second call would skip (bypass caller must avoid should_skip)"
+    true would_skip
+
+let test_dedup_no_target () =
+  (* mention=None must not consume dedup state for any target. *)
+  Mention_dedup.reset_for_test ();
+  (* Simulate: caller sees mention=None and skips should_skip. State
+     remains empty.  A later mention=Some ("foo") should then pass. *)
+  let later =
+    Mention_dedup.should_skip
+      ~from_agent:"taskmaster" ~target:"foo"
+      ~content_hash:(hash "first @foo") ~now:400.0
+  in
+  Alcotest.(check bool)
+    "no_target path leaves table empty; first @foo passes"
+    false later
+
+let test_content_hash_normalizes () =
+  let h1 = Mention_dedup.content_topic_hash "  @Foo Bar  " in
+  let h2 = Mention_dedup.content_topic_hash "@foo bar" in
+  Alcotest.(check string)
+    "trim+lowercase yields stable hash" h1 h2
+
+let () =
+  let open Alcotest in
+  run "Mention Dedup (RFC-0040)" [
+    "window", [
+      test_case "skips within window" `Quick test_dedup_skips_within_window;
+      test_case "clears after ttl" `Quick test_dedup_clears_after_ttl;
+    ];
+    "key", [
+      test_case "distinguishes targets" `Quick test_dedup_distinguishes_targets;
+      test_case "distinguishes content" `Quick test_dedup_distinguishes_content;
+    ];
+    "policy", [
+      test_case "bypass force" `Quick test_bypass_dedup_force;
+      test_case "no target" `Quick test_dedup_no_target;
+    ];
+    "hash", [
+      test_case "trim+lowercase" `Quick test_content_hash_normalizes;
+    ];
+  ]


### PR DESCRIPTION
## Summary

- Sender-side mention dedup at `Coord_broadcast.broadcast`. When the same `(from_agent, target, content_hash)` is broadcast within a 5min window (env `MASC_MENTION_DEDUP_TTL_S`), the entire broadcast is skipped: no msg file, no backend publish, no activity emit, no `on_broadcast_mention` callback.
- Closes the "24+ mention spam to nick0cave" board pattern — a sender re-sending the same `@target topic` every cycle floods the recipient's inbox.
- New `?bypass_dedup:bool` parameter for system-level alerts (default `false`).
- New Prometheus metric `masc_mention_dedup_decisions_total{outcome}` with vocabulary `skipped|passed|no_target|bypassed`.

## Pull-model framing (RFC §1)

`lib/coord/mention.ml:Mention.resolve_targets` is exported but has **0 callers in `lib/` production code**. The actual recipient path is **pull**:

| Step | Where | Action |
|---|---|---|
| Sender writes content | `coord_broadcast.ml:64 broadcast` | Persist to disk + emit hook |
| Sender extracts mention | `coord_broadcast.ml:122 Mention.extract` | Parse `@target`, informational |
| Recipient pulls | `keeper_prompt.ml:16 Mention.any_mentioned ~targets:[my_name]` | Each keeper checks own name on its turn |

Earlier iter-6/7 sketches assumed push-time dispatch filtering — wrong design. This PR fixes the actual axis: the sender. RFC-0035 covers the recipient acknowledgement axis (orthogonal, separate PR).

## Files changed

| File | LOC |
|---|---|
| `lib/coord/mention_dedup.ml` (new) | +44 |
| `lib/coord/mention_dedup.mli` (new) | +48 |
| `lib/coord/coord_broadcast.ml` | +40 / -2 |
| `lib/coord/coord_broadcast.mli` | +5 |
| `lib/coord/coord_hooks.{ml,mli}` | +15 |
| `lib/coord.ml` (hook wiring → Prometheus) | +12 |
| `lib/prometheus.{ml,mli}` | +13 |
| `lib/coord/dune` | +1 |
| `test/test_mention_dedup.ml` (new, 7 tests) | +147 |
| `test/dune` | +2 |
| `docs/rfc/RFC-0040-mention-dedup.md` (RFC doc) | +221 |

Total: **+548 / -2** across 13 files.

## RFC reference

`docs/rfc/RFC-0040-mention-dedup.md` (in this PR).

> Drafted as RFC-0036.v2 in loop-iter-8 (2026-05-07). Renumbered to RFC-0040 because RFC-0036 was already taken by `RFC-0036-oas-cognitive-mapping` (PR #13915).

## Test plan

7 alcotest cases in `test/test_mention_dedup.ml` (uses `~now` parameter — no `Unix.sleep`):

- [x] `test_dedup_skips_within_window`
- [x] `test_dedup_clears_after_ttl`
- [x] `test_dedup_distinguishes_targets`
- [x] `test_dedup_distinguishes_content`
- [x] `test_bypass_dedup_force` (bypass semantics — caller skips `should_skip`, dedup module still acts as oracle)
- [x] `test_dedup_no_target` (mention=None must not consume dedup state)
- [x] `test_content_hash_normalizes` (trim+lowercase yields stable hash)

Local verification status:
- `dune build @lib/coord/check`: PASS (clean)
- `dune build _build/default/lib/.masc_mcp.objs/byte/masc_mcp__{Prometheus,Coord}.cmi`: PASS
- Full repo `@check` blocked by **pre-existing main breakage from agent_sdk pin bump (`a5c51ed6ba`)** — `request_latency_ms : int option` mismatch in `oas_worker_exec_transport.ml`, `keeper_hooks_oas.ml`, `keeper_unified_metrics.ml` etc. **None of those files are touched by this PR.** GitHub Actions will validate in clean env.
- `test_mention_dedup.exe` build blocked by same upstream breakage; will run once main is unblocked.

## Best Programmer self-review

- **Goal**: Stop sender-side mention spam; observable via Prometheus.
- **Files changed**: 13 (4 new, 9 modified). Surface area within RFC §7 budget.
- **Local verification**: coord library type-check clean. Test runner depends on broken upstream lib.
- **Unverified**: full integration test pass — gated on main green.
- **Regression risk**: `coord_broadcast.broadcast` signature gained an optional `?bypass_dedup` (default `false`); existing callers unaffected. Behavior change: when dedup hits, return string is `"📢 [<agent>] dedup_skipped"` instead of the original content echo.

## Concurrency note

Lands alongside agent A's RFC-0034.v2 (`rfc/0034-v2-cap-all-callers`) which touches `lib/coord/coord_task_capacity.{ml,mli}` (new) and `lib/keeper/keeper_exec_task.ml`. **Different files — should not conflict at PR-merge time.**

## Narrative inaccuracies discovered in RFC

1. RFC §4.1 sketches `Result.Ok "dedup_skipped"` as the dedup-skip return, but `coord_broadcast.broadcast` actually returns `string` (the broadcast echo). Implementation uses a literal `"📢 [%s] dedup_skipped"` string to stay consistent with the existing return shape. RFC body left as-is — narrative inaccuracy not silently overwritten.
2. RFC §5.1 lists 8 production broadcast call sites; `rg "broadcast.*from_agent" lib/ -g '*.ml'` actually shows ≥14 callers (orchestrator, coord_lifecycle, coord_task, coord_task_create, server_routes_http_routes_dashboard, operator_control, tool_suspend, auto_responder, keeper_exec_task, plus the eio/grpc paths). The dedup behavior covers all callers that go through `Coord_broadcast.broadcast`, which is the dominant path — but the RFC undercounts the surface.

## RFC compliance

- RFC waiver not required: `pr-rfc-check.sh` enforced areas (credential / repo_manager / operator_control credential / dashboard credential / hooks / workflow) are not touched. RFC body included in PR body above + as `docs/rfc/RFC-0040-mention-dedup.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
