### PR TITLE
fix(task,oas): handle stale lock and optional latency

### DIFF
--- a/lib/coord/coord_task_schedule.ml
+++ b/lib/coord/coord_task_schedule.ml
@@ -764,7 +764,7 @@ let claim_next config ~agent_name =
 let release_stale_claims config ~ttl_seconds =
   ensure_initialized config;
   let backlog_path = Filename.concat (tasks_dir config) ".backlog" in
-  with_file_lock config backlog_path (fun () ->
+  let release_under_lock () =
     match read_backlog_r config with
     | Error msg ->
         Log.Orchestrator.error
@@ -842,4 +842,11 @@ let release_stale_claims config ~ttl_seconds =
           write_backlog config updated_backlog
         end;
         List.rev !stale_tasks
-  )
+  in
+  match with_file_lock_r config backlog_path release_under_lock with
+  | Ok released -> released
+  | Error err ->
+      Log.Orchestrator.warn
+        "[stale-claims] skipping backlog mutation due to lock failure: %s"
+        (Masc_domain.masc_error_to_string err);
+      []

--- a/lib/oas_compat/oas_compat.mli
+++ b/lib/oas_compat/oas_compat.mli
@@ -145,7 +145,7 @@ module Metrics : sig
     ?on_cache_hit:(model_id:string -> unit) ->
     ?on_cache_miss:(model_id:string -> unit) ->
     ?on_request_start:(model_id:string -> unit) ->
-    ?on_request_end:(model_id:string -> latency_ms:int -> unit) ->
+    ?on_request_end:(model_id:string -> latency_ms:int option -> unit) ->
     ?on_error:(model_id:string -> error:string -> unit) ->
     ?on_http_status:(provider:string -> model_id:string -> status:int -> unit) ->
     ?on_capability_drop:(model_id:string -> field:string -> unit) ->

--- a/lib/oas_worker_cascade.ml
+++ b/lib/oas_worker_cascade.ml
@@ -413,13 +413,16 @@ let cascade_metrics_for_candidates
         Llm_metric_bridge.emit_request_start ~model_id)
       ~on_request_end:(fun ~model_id ~latency_ms ->
         ensure_terminal_attempt capture ~candidate_cfgs ~model_id
-          ~latency_ms:(Some latency_ms) ~error:None;
+          ~latency_ms ~error:None;
         (* Forward to Prometheus so per-model latency is visible on
            the dashboard. Without this, the cascade capture records
            latency internally but never exports it — the global
            Llm_metric_bridge sink is not consulted because this
            per-call metrics object takes precedence. *)
-        Llm_metric_bridge.emit_request_latency ~model_id ~latency_ms)
+        match latency_ms with
+        | Some latency_ms ->
+            Llm_metric_bridge.emit_request_latency ~model_id ~latency_ms
+        | None -> ())
       ~on_error:(fun ~model_id ~error ->
         ensure_terminal_attempt capture ~candidate_cfgs ~model_id
           ~latency_ms:None ~error:(Some error);


### PR DESCRIPTION
## Summary
- Convert stale-claim cleanup to use with_file_lock_r so distributed backlog lock acquisition exhaustion logs a skip and returns [] instead of throwing through orchestrator cleanup.
- Update the OAS metrics compatibility layer for the merged agent_sdk pin: request-end latency is now int option, and Prometheus latency emission only runs when latency is present.

## Evidence
- Live runtime log /Users/dancer/me/.masc/logs/system_log_2026-05-07.jsonl:24947 and :25060 showed stale-claims cleanup throwing Invalid_argument("Failed to acquire distributed lock for key: tasks:.backlog (50 attempts exhausted)").
- Focused local build on current main exposed the OAS drift before this patch: oas_compat.ml implemented latency_ms:int option while oas_compat.mli still declared latency_ms:int.

## Validation
- git diff --check origin/main..HEAD
- Attempted scripts/dune-local.sh build test/test_keeper_task_dispatch.exe test/test_room.exe. It first exposed the OAS interface mismatch fixed here, then subsequent reruns were blocked by shared Dune/opam locks held by other worktrees; I stopped my waiters to avoid monopolizing the host.
- PR CI is the remaining compile/test surface for this draft.