### PR TITLE
refactor(keeper_health_probe): protect probe loop against transient errors

### DIFF
--- a/lib/keeper/keeper_health_probe.ml
+++ b/lib/keeper/keeper_health_probe.ml
@@ -68,7 +68,10 @@ let run_once ~base_path =
     results
 
 let rec probe_loop ~base_path ~interval_sec () =
-  run_once ~base_path;
+  (* Cancel-aware: Safe_ops.protect re-raises Eio.Cancel.Cancelled and swallows
+     other exceptions so a transient registry I/O failure cannot kill the fiber
+     and freeze [is_healthy] at [false] forever. *)
+  Safe_ops.protect ~default:() (fun () -> run_once ~base_path);
   Eio_unix.sleep interval_sec;
   probe_loop ~base_path ~interval_sec ()
 


### PR DESCRIPTION
## Summary

`lib/keeper/keeper_health_probe.ml` (added in #14146) runs `run_once` in a
recursive Eio fiber with **no exception protection**. Wrap the call in
`Safe_ops.protect ~default:()` so a transient `Keeper_registry.all` failure
(file read race, malformed entry, fs permission flap) cannot kill the fiber
and freeze the health cache at `Unknown`/stale until process restart.

## Why this matters

`probe_loop` is the only writer of the health cache that
`should_attempt_resume` (documented in the `.mli`) consumes:

- If `run_once` raises, the recursive fiber dies silently.
- `is_healthy ~keeper_name` then returns `false` for every cascade forever.
- `ResumeFromPause` never fires → auto-resume contract silently degrades to
  *stay paused*.

`Safe_ops.protect` is the cancel-aware suppression helper used elsewhere in
`lib/keeper`:

- `keeper_hooks_oas.ml:1132,1136`
- `keeper_decision_audit.ml:188`
- `keeper_approval_queue.ml:911`
- `keeper_toml_loader.ml:584,587`
- `keeper_exec_preflight.ml:44`

It re-raises `Eio.Cancel.Cancelled` (so switch teardown still works) and
swallows all other exceptions, returning `default`. That is exactly the
*keep iterating; let the next tick try again* semantic this loop wants.

## Scope

- 1 file, +4 / -1.
- Successful iterations are byte-identical to before.
- Cancellation path unchanged.
- No public API change (no `.mli` edit needed — `start_probe` signature
  preserved).

## Self-review

- Wrapped at the **call site** of `run_once`, not the recursive call —
  each iteration stays independent; a failure in tick N does not unwind
  the recursion or affect tick N+1.
- Build verified: `bash scripts/dune-local.sh build @lib/keeper/all --root .`
  succeeds.
- No new dependency (`Safe_ops` already linked in `lib/keeper`).
- Comment explains *why* (cancellation semantics + freeze risk), not *what*.

## Test plan

- [x] `dune build @lib/keeper/all --root .` succeeds.
- [ ] Reviewer confirms `Safe_ops.protect` semantics match expectation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
