### PR TITLE
feat(keeper): wire health probe into supervisor auto-resume (Step 3)

### DIFF
--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -1592,58 +1592,69 @@ let sweep_and_recover (ctx : _ context) =
                                  && not (paused_meta_requires_reconcile_recovery meta)
                                  && not (Keeper_approval_queue.has_pending_for_keeper
                                            ~keeper_name:meta.name) ->
-               let resume_after_sec =
-                 Option.value ~default:0.0 meta.auto_resume_after_sec in
-               let paused_ts =
-                 Coord_resilience.Time.parse_iso8601_opt meta.updated_at
-                 |> Option.value ~default:0.0
-               in
-               if paused_ts > 0.0 && now -. paused_ts >= resume_after_sec then begin
-                 (* Resume: clear [paused] flag but retain [auto_resume_after_sec]
-                    so the doubled delay is ready for the next auto-pause.  It
-                    will be reset to [None] on a successful turn completion. *)
-                 let resumed_meta =
-                   { meta with
-                     paused = false;
-                     updated_at = now_iso ();
-                     runtime =
-                       { meta.runtime with
-                         last_blocker = "";
-                         last_blocker_class = None;
-                       };
-                   }
+               if not (Keeper_health_probe.is_healthy
+                         ~keeper_name:meta.cascade_name) then begin
+                 Log.Keeper.info
+                   "%s: auto-resume blocked; cascade %s is unhealthy"
+                   name meta.cascade_name;
+                 Prometheus.inc_counter
+                   Prometheus.metric_keeper_auto_resume_blocked_total
+                   ~labels:[("keeper", name); ("cascade", meta.cascade_name)]
+                   ()
+               end else begin
+                 let resume_after_sec =
+                   Option.value ~default:0.0 meta.auto_resume_after_sec in
+                 let paused_ts =
+                   Coord_resilience.Time.parse_iso8601_opt meta.updated_at
+                   |> Option.value ~default:0.0
                  in
-                 (match
-                    write_meta_with_merge
-                      ~merge:Keeper_meta_merge.heartbeat_fields_from_disk
-                      ctx.config resumed_meta
-                  with
-                  | Ok () ->
-                      publish_lifecycle
-                        ~event:(Keeper_lifecycle_events.Custom_event
-                                  { verb = Keeper_lifecycle_events.Auto_resumed;
-                                    phase = None })
-                        name
-                        (Printf.sprintf "auto_resume backoff=%.0fs" resume_after_sec) ();
-                      Prometheus.inc_counter
-                        Prometheus.metric_keeper_auto_resumed_total
-                        ~labels:[("keeper", name)]
-                        ();
-                      Log.Keeper.info
-                        "%s: auto-resumed after %.0fs backoff (next backoff=%.0fs if \
-                         re-paused; resets to initial on successful turn)"
-                        name resume_after_sec
-                        (Float.min
-                           (Env_config.KeeperSupervisor.auto_resume_max_sec)
-                           (resume_after_sec *. 2.0))
-                  | Error err ->
-                      Prometheus.inc_counter
-                        Prometheus.metric_keeper_write_meta_failures
-                        ~labels:[("keeper", name); ("phase", "auto_resume")]
-                        ();
-                      Log.Keeper.warn
-                        "%s: auto-resume meta write failed: %s"
-                        name err)
+                 if paused_ts > 0.0 && now -. paused_ts >= resume_after_sec then begin
+                   (* Resume: clear [paused] flag but retain [auto_resume_after_sec]
+                      so the doubled delay is ready for the next auto-pause.  It
+                      will be reset to [None] on a successful turn completion. *)
+                   let resumed_meta =
+                     { meta with
+                       paused = false;
+                       updated_at = now_iso ();
+                       runtime =
+                         { meta.runtime with
+                           last_blocker = "";
+                           last_blocker_class = None;
+                         };
+                     }
+                   in
+                   (match
+                      write_meta_with_merge
+                        ~merge:Keeper_meta_merge.heartbeat_fields_from_disk
+                        ctx.config resumed_meta
+                    with
+                    | Ok () ->
+                        publish_lifecycle
+                          ~event:(Keeper_lifecycle_events.Custom_event
+                                    { verb = Keeper_lifecycle_events.Auto_resumed;
+                                      phase = None })
+                          name
+                          (Printf.sprintf "auto_resume backoff=%.0fs" resume_after_sec) ();
+                        Prometheus.inc_counter
+                          Prometheus.metric_keeper_auto_resumed_total
+                          ~labels:[("keeper", name)]
+                          ();
+                        Log.Keeper.info
+                          "%s: auto-resumed after %.0fs backoff (next backoff=%.0fs if \
+                           re-paused; resets to initial on successful turn)"
+                          name resume_after_sec
+                          (Float.min
+                             (Env_config.KeeperSupervisor.auto_resume_max_sec)
+                             (resume_after_sec *. 2.0))
+                    | Error err ->
+                        Prometheus.inc_counter
+                          Prometheus.metric_keeper_write_meta_failures
+                          ~labels:[("keeper", name); ("phase", "auto_resume")]
+                          ();
+                        Log.Keeper.warn
+                          "%s: auto-resume meta write failed: %s"
+                          name err)
+                 end
                end
            | _ -> ());
          Eio_guard.yield_step sweep_names_ym);

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -1138,6 +1138,13 @@ let metric_keeper_dead_total = "masc_keeper_dead_total"
    [auto_resume_after_sec] means the sweep is not firing or the meta write
    is failing. Labels: keeper. *)
 let metric_keeper_auto_resumed_total = "masc_keeper_auto_resumed_total"
+(* Phase-3.5 health-gate block: incremented when the supervisor skips
+   auto-resume because the keeper's cascade is unhealthy (failure ratio
+   >= threshold).  Labels: keeper, cascade.  A positive rate means the
+   health probe is actively protecting the fleet from resuming into a
+   still-failing cascade. *)
+let metric_keeper_auto_resume_blocked_total =
+  "masc_keeper_auto_resume_blocked_total"
 (* Positive signal for the Skip_idle + Woken gate-promotion path added
    by #12271. Increments every time run_smart_heartbeat_gate observes
    that an external wakeup_keeper call cut a Skip_idle backoff sleep
@@ -1868,6 +1875,12 @@ let init () =
     "Total keepers auto-resumed by the self-healing circuit breaker after \
      the back-off timer elapsed. Labeled by keeper. A positive rate means \
      the system is self-healing from transient provider outages."
+    Counter;
+  add metric_keeper_auto_resume_blocked_total
+    "Total keepers whose auto-resume was blocked because the cascade health \
+     probe reported unhealthy. Labeled by keeper and cascade. A positive rate \
+     means the health gate is protecting the fleet from resuming into a \
+     still-failing cascade."
     Counter;
   add metric_keeper_supervisor_cleanup_failures
     "Total supervisor finally-cleanup failures suppressed to avoid \

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -817,6 +817,13 @@ val metric_keeper_auto_resumed_total : string
     intervention.  A sustained zero rate while [auto_resume_after_sec] is
     set in meta files indicates a sweep or meta-write regression. *)
 
+val metric_keeper_auto_resume_blocked_total : string
+(** Total keepers whose auto-resume was blocked in
+    [Keeper_supervisor.sweep_and_recover] because the cascade health probe
+    reported unhealthy (failure ratio >= threshold).  Labeled by [keeper]
+    and [cascade].  A positive rate means the health gate is protecting
+    the fleet from resuming into a still-failing cascade. *)
+
 val metric_keeper_skip_idle_wake_resumed : string
 
 (** RFC-0020 Rule 2 evidence — incremented every time


### PR DESCRIPTION
## Summary

Step 3 of incremental plan for root-cause fix of keeper pause/resume behavior.

Wires `Keeper_health_probe.is_healthy` into the supervisor's Phase 3.5
self-healing circuit breaker so that auto-resume is gated on cascade health.

### Changes
- `lib/keeper/keeper_supervisor.ml`:
  - Before auto-resuming a paused keeper, check `is_healthy` for the
    keeper's cascade.
  - If unhealthy: skip resume, emit INFO log, increment Prometheus counter.
  - If healthy AND backoff timer elapsed: proceed with existing auto-resume.
- `lib/prometheus.ml{i}`: new metric `masc_keeper_auto_resume_blocked_total`
  (labels: keeper, cascade)

### Why

Without this gate, the supervisor repeatedly launches keepers into cascades
that are still experiencing high failure ratios (e.g. provider outages,
stale termination storms). The time-only backoff only spreads out the
failures; it does not verify whether the root cause is resolved.

The health probe (added in Step 2 / #14146) scans the registry every
N seconds and computes a failure ratio per cascade. Using that cached
value here avoids I/O in the 30s supervisor sweep.

### Test Plan
- [x] Verified `is_healthy` integration compiles against supervisor
- Integration test: `test_keeper_supervisor.ml` covers the sweep path

### Next Steps
- Step 4 (optional): Make failure ratio threshold configurable (currently
  hard-coded at 0.10 in `keeper_health_probe.ml`)
- Step 5 (optional): Start the probe fiber at server boot time

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>