### PR TITLE
fix(oas): unwrap optional latency_ms in 5 callers (#14148 follow-up)

### DIFF
--- a/lib/dashboard/dashboard_oas_bridge.ml
+++ b/lib/dashboard/dashboard_oas_bridge.ml
@@ -161,9 +161,10 @@ let duration_from_response ?total_duration_ms
   in
   match total_duration_ms, response.telemetry with
   | Some ms, _ when ms > 0.0 -> ms
-  | _, Some telemetry when telemetry.request_latency_ms > 0 ->
-      Float.of_int telemetry.request_latency_ms
-  | _, Some telemetry -> duration_from_timings telemetry.timings
+  | _, Some telemetry ->
+      (match telemetry.request_latency_ms with
+       | Some n when n > 0 -> Float.of_int n
+       | _ -> duration_from_timings telemetry.timings)
   | _ -> 0.0
 
 let ttfb_from_response (response : Agent_sdk.Types.api_response) =

--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -662,12 +662,13 @@ let record_llm_inference_latency_metric
   match telemetry with
   | Some t ->
     let observed_latency_ms =
-      if t.request_latency_ms > 0 then t.request_latency_ms
-      else (
+      match t.request_latency_ms with
+      | Some n when n > 0 -> n
+      | _ ->
         Prometheus.inc_counter
           Prometheus.metric_after_turn_telemetry_zero_latency
           ~labels ();
-        1)
+        1
     in
     Prometheus.observe_histogram
       Prometheus.metric_llm_inference_duration
@@ -684,11 +685,11 @@ let wall_tokens_per_second
     ~(telemetry : Agent_sdk.Types.inference_telemetry option)
   : float option =
   match telemetry with
-  | Some t when not usage_missing && output_tokens > 0
-                && t.request_latency_ms > 0 ->
+  | Some { request_latency_ms = Some lm; _ }
+    when not usage_missing && output_tokens > 0 && lm > 0 ->
       Some
         (Float.of_int output_tokens
-         /. (Float.of_int t.request_latency_ms /. 1000.0))
+         /. (Float.of_int lm /. 1000.0))
   | _ -> None
 
 (** #10318: classify why [cost_usd] ended up as it did so the
@@ -845,7 +846,9 @@ let assemble_cost_event_payload
          | None -> [])
       @ float_field "peak_memory_gb" t.peak_memory_gb
       @ int_field "request_latency_ms"
-          (if t.request_latency_ms > 0 then Some t.request_latency_ms else None)
+          (match t.request_latency_ms with
+           | Some n when n > 0 -> Some n
+           | _ -> None)
     | None -> []
   in
   let wall_tok_s_fields =
@@ -2070,7 +2073,7 @@ let make_hooks
         in
         let latency_ms =
           match response.telemetry with
-          | Some t -> t.request_latency_ms
+          | Some t -> Option.value t.request_latency_ms ~default:0
           | None -> 0
         in
         let wall_tok_s_opt =

--- a/lib/keeper/keeper_unified_metrics.ml
+++ b/lib/keeper/keeper_unified_metrics.ml
@@ -963,7 +963,10 @@ let append_decision_record
                     [
                       ("system_fingerprint", match t.system_fingerprint with Some s -> `String s | None -> `Null);
                       ("reasoning_tokens", match t.reasoning_tokens with Some n -> `Int n | None -> `Null);
-                      ("request_latency_ms", `Int t.request_latency_ms);
+                      ("request_latency_ms",
+                       match t.request_latency_ms with
+                       | Some n -> `Int n
+                       | None -> `Null);
                     ] @ timings_fields
                 | None -> []
               in

--- a/lib/llm_metric_bridge.ml
+++ b/lib/llm_metric_bridge.ml
@@ -201,7 +201,11 @@ let make_sink () : Llm_provider.Metrics.t =
         emit_http_status ~provider ~model_id ~status);
     on_request_end =
       (fun ~model_id ~latency_ms ->
-        emit_request_latency ~model_id ~latency_ms);
+        match latency_ms with
+        | Some n -> emit_request_latency ~model_id ~latency_ms:n
+        | None ->
+            emit_request_latency_clamped ~model_id
+              ~reason:"missing_latency_ms");
     on_capability_drop =
       (fun ~model_id ~field ->
         emit_capability_drop ~model_id ~field);

--- a/lib/oas_worker_exec_transport.ml
+++ b/lib/oas_worker_exec_transport.ml
@@ -1294,13 +1294,16 @@ module Kimi_cli_transport_local = struct
           | Error _ as err ->
               {
                 Llm_provider.Llm_transport.response = classify_cli_error err;
-                latency_ms = measured_latency_ms;
+                latency_ms = Some measured_latency_ms;
               }
           | Ok { latency_ms; _ } ->
               let response =
                 parse_jsonl_result ~model_id (List.rev !seen_lines)
               in
-              { Llm_provider.Llm_transport.response; latency_ms });
+              {
+                Llm_provider.Llm_transport.response;
+                latency_ms = Some latency_ms;
+              });
       complete_stream =
         (fun ~on_event (req : Llm_provider.Llm_transport.completion_request) ->
           warn_external_tools_once warned req.tools;


### PR DESCRIPTION
## Summary

PR #14148 (`fix(task,oas): handle stale lock and optional latency`) made `telemetry.request_latency_ms : int option` but updated only some call sites. 5 files still treated it as `int`, leaving `main` broken since merge.

`dune build @lib/check` failed at HEAD `aceb157e72` with 5+ type errors. This PR adds the missing `int option` handling at 8 sites total (5 files), preserving existing behavior on the `Some` branch.

## Files

- `lib/llm_metric_bridge.ml` — `on_request_end` callback matches `int option` signature; `None` case emits clamped counter (reason `missing_latency_ms`).
- `lib/dashboard/dashboard_oas_bridge.ml` — `latency_ms_from_response` precedence preserved.
- `lib/oas_worker_exec_transport.ml` — `Llm_transport.t` record literal wraps in `Some` (Error and Ok branches).
- `lib/keeper/keeper_hooks_oas.ml` (3 sites) — `observed_latency_ms` unwraps with zero-counter side-effect, `wall_tokens_per_second` uses Some-guard destructure, `int_field` filters None+zero, summary log line uses `Option.value … ~default:0` for `%d`.
- `lib/keeper/keeper_unified_metrics.ml` — telemetry JSON encodes `None` as `` `Null ``.

## Behavior Change

Only `None` branches are new:
- `missing_latency_ms` clamped counter increment when telemetry callback fires with `None`.
- JSON `null` (instead of fabricated `0`) in unified-metrics output for `request_latency_ms`.
- `0` default in `%d` log format and zero-counter side-effect path (matches prior `if > 0 then x else 1` semantics).

All `Some` paths preserve existing behavior — Prometheus histogram emission, latency precedence, JSON `Int n`.

## Test plan

- [x] `dune build @lib/check` passes (was broken at HEAD `aceb157e72`)
- [x] `dune build` passes (full lib + test deps)
- [ ] `dune runtest`
- [ ] CI green

## RFC-WAIVED

`RFC-WAIVED: #14148 follow-up — same axis fix completion, no new design.`

This PR completes the type-signature transition started in #14148 across the remaining 5 callers. No design change, no new module, no behavior axis introduced — only the `int option` plumbing the original PR was missing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>