### PR TITLE
fix(keeper): wakeup auto-resume + paused visibility + FSM phase histogram

### DIFF
--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -187,8 +187,28 @@ let process_directive ~agent_name directive =
     Log.Keeper.info "directive: resuming keeper %s" agent_name;
     set_keeper_paused_state ~agent_name false
   | "wakeup" ->
-    Log.Keeper.debug "directive: waking up %s" agent_name;
-    wakeup_keeper_by_agent_name ~agent_name
+    (* Auto-resume on wakeup: dashboard "깨우기" surfaces a single button,
+       but auto-pause (stale_fleet_batch / turn_timeout) silently persists
+       [meta.paused = true]. Without this branch, wakeup signals fiber_wakeup
+       but the heartbeat loop honors paused state and skips — user clicks
+       "깨우기" with no observable effect. Treat wakeup as a superset of
+       resume so paused keepers re-enter the run loop. *)
+    let entry_paused =
+      match Keeper_registry.find_by_agent_name agent_name with
+      | Some e -> e.meta.paused
+      | None ->
+        (match Keeper_registry.find_by_name agent_name with
+         | Some e -> e.meta.paused
+         | None -> false)
+    in
+    if entry_paused then begin
+      Log.Keeper.info
+        "directive: waking up %s (was paused — auto-resuming)" agent_name;
+      set_keeper_paused_state ~agent_name false
+    end else begin
+      Log.Keeper.debug "directive: waking up %s" agent_name;
+      wakeup_keeper_by_agent_name ~agent_name
+    end
   | s when String.length s > 6 && String.starts_with s ~prefix:"claim:" ->
     let task_id = String.sub s 6 (String.length s - 6) in
     (match Keeper_id.Task_id.of_string task_id with

--- a/lib/keeper/keeper_turn_fsm.ml
+++ b/lib/keeper/keeper_turn_fsm.ml
@@ -281,12 +281,36 @@ let guard_transition ?ctx ~keeper_name ~turn_id ~from_state ~to_state () =
         "[fsm:transition:violation] %s -> %s (%s)"
         violation.from_state violation.to_state violation.reason
 
+(* Per-keeper last-transition wallclock, used to record the dwell time
+   spent in [prev] state when a transition fires. Single-domain Eio
+   means Hashtbl ops are atomic at OCaml level (no preemption inside a
+   single op), so no explicit mutex is required. Stale entries left
+   behind by terminal transitions are bounded by keeper count. *)
+let last_transition_at : (string, float) Hashtbl.t = Hashtbl.create 64
+
+let observe_phase_dwell ~keeper_name ~from_label =
+  match Hashtbl.find_opt last_transition_at keeper_name with
+  | None -> ()
+  | Some prev_at ->
+    let now = Unix.gettimeofday () in
+    let dwell = Float.max 0.0 (now -. prev_at) in
+    (try
+       Prometheus.observe_histogram
+         Prometheus.metric_keeper_turn_phase_duration
+         ~labels:[ ("keeper", keeper_name); ("from", from_label) ]
+         dwell
+     with _ -> ())
+
 let emit_transition ?ctx ~keeper_name ~turn_id ?prev state =
   let prev_label =
     match prev with
     | Some s -> turn_state_label s
     | None -> "-"
   in
+  (match prev with
+   | Some _ -> observe_phase_dwell ~keeper_name ~from_label:prev_label
+   | None -> ());
+  Hashtbl.replace last_transition_at keeper_name (Unix.gettimeofday ());
   let classified =
     match prev with
     | Some from_state ->

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -1092,6 +1092,8 @@ let metric_keeper_fsm_edge_transitions =
   "masc_keeper_fsm_edge_transitions_total"
 let metric_keeper_turn_fsm_transitions =
   "masc_keeper_turn_fsm_transitions_total"
+let metric_keeper_turn_phase_duration =
+  "masc_keeper_turn_phase_duration_seconds"
 let metric_keeper_lifecycle_transitions =
   "masc_keeper_lifecycle_transitions_total"
 let metric_fsm_guard_violation = "masc_fsm_guard_violation_total"
@@ -1588,6 +1590,10 @@ let init () =
   register_histogram ~name:metric_keeper_semaphore_wait_seconds
     ~help:"Seconds spent waiting to acquire keeper turn semaphores \
            (labels: keeper_name, cascade_profile, channel)." ();
+  register_histogram ~name:metric_keeper_turn_phase_duration
+    ~help:"Seconds a keeper turn dwelt in a single FSM phase before \
+           transitioning out. Sample is recorded on every emit_transition \
+           with a known prior state. Labels: keeper, from." ();
   (* P-DASH-13: provider block duration histogram.
      Records the duration (in seconds) for which a provider is placed in
      cooldown each time a cooldown is applied or extended.  Labels: provider. *)

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -719,6 +719,12 @@ val metric_keeper_fsm_edge_transitions : string
     keepers = ≤ 1600 series; reachable subset is much smaller. *)
 val metric_keeper_turn_fsm_transitions : string
 
+(** Histogram of seconds a keeper turn dwells in a single FSM phase
+    before transitioning out. Sample is recorded by
+    [Keeper_turn_fsm.emit_transition] whenever a [prev] state is
+    supplied. Labels: keeper, from. *)
+val metric_keeper_turn_phase_duration : string
+
 (** Keeper lifecycle phase transitions emitted by [Keeper_registry] only
     when the persisted registry phase changes. Labels:
     [keeper, from_phase, to_phase].  No event/reason label is included so

--- a/lib/server/server_routes_http_runtime.ml
+++ b/lib/server/server_routes_http_runtime.ml
@@ -218,6 +218,21 @@ let make_health_json ?(listener = "http/1.1") request =
       ("minor_heap_size", `Int (let c = Gc.get () in c.minor_heap_size));
     ]);
     ("keeper_fibers", `Int (Keeper_registry.count_running ()));
+    (* Paused-keeper visibility: a keeper with [meta.paused = true] does not
+       run turns even if its fiber is alive. The dashboard "깨우기" button
+       now auto-resumes paused keepers, but ops still need a quick count
+       without scraping /metrics. List names so an operator can correlate
+       with the cause encoded in their last_blocker_class. *)
+    ("paused_keepers",
+     let paused =
+       Keeper_registry.all ()
+       |> List.filter_map (fun (e : Keeper_registry.registry_entry) ->
+            if e.meta.paused then Some (`String e.name) else None)
+     in
+     `Assoc [
+       ("count", `Int (List.length paused));
+       ("names", `List paused);
+     ]);
     ("keeper_config_parse_error_count",
      `Int keeper_config_parse_error_count);
     ( "keeper_config_parse_errors",


### PR DESCRIPTION
## Summary

Three surgical fixes derived from a 17-min /metrics + /health probe (n=496 health samples on 17-keeper / 8-fiber fleet) that addressed the user-reported symptoms "깨우기 해도 제대로 안 됨" + "수동 새로고침 안 하면 UI 업데이트 안 보임".

### Probe data anchoring the fix

| Signal | Value | Implication |
|---|---|---|
| sse_clients | 0 | red herring — dashboard runs WS-only by design (WS sessions=2 confirmed) |
| coord_broadcast_count{} default | 0 | publisher emit empty because keeper turn outcome broadcasts never fire |
| keeper_fibers | 8 / 17 toml | 9 keepers paused (4 in current uptime via stale_fleet_batch + 5 carried paused=true across restart) |
| keeper_turn_starts_total | 15 across 10 keepers | turns DO start, just stall (87% in_turn_hung rate) |
| Per-keeper turn latency_ms | 65-365s (max ~timeout) | UI feels frozen because each turn nearly hits the 600s stale watchdog |

Five "ghost" keepers (analyst, nick0cave, ramarama, velvet-hammer, verifier) had \`paused=true\` persisted in \`~/me/.masc/keepers/<name>.json\` from a prior session — autoboot honored the persisted pause across restart and they never re-entered the run loop.

### Changes

#### 1. \`wakeup\` directive auto-resumes paused keepers — \`lib/keeper/keeper_keepalive.ml\`
The dashboard "깨우기" button surfaces a single affordance, but auto-pause silently persists \`meta.paused = true\`. Without this branch, wakeup signals \`fiber_wakeup\` and the heartbeat loop honors paused state and skips — user clicks "깨우기" with no observable effect. Now wakeup detects paused and routes through \`set_keeper_paused_state false\` (Operator_resume + fiber_wakeup), preserving existing resume semantics for explicitly paused keepers.

#### 2. \`/health.paused_keepers\` visibility — \`lib/server/server_routes_http_runtime.ml\`
\`keeper_fibers\` reflects only Running phase. Paused keepers were invisible to /health, leaving operators unable to correlate "wake action did nothing" with "9 keepers paused". Added \`paused_keepers={count, names}\` so health probes can flag a non-zero count without scraping /metrics.

#### 3. FSM phase dwell-time histogram — \`lib/keeper/keeper_turn_fsm.ml\` + \`lib/prometheus.{ml,mli}\`
\`masc_keeper_turn_phase_duration_seconds{keeper, from}\` captures seconds spent in each turn FSM phase before transitioning out. Existing \`keeper_turn_latency_bucket\` only records whole-turn latency, masking which phase the 65-365s/turn observed across 8 live keepers is stuck in. Hashtbl is single-domain-Eio-safe (atomic at OCaml level inside one op) and bounded by keeper count.

### Test plan

- [x] \`dune build @check\` — PR-3 changes compile clean. 2 unrelated errors remain on main (\`test/test_oas_worker.ml:2075\` and \`test/test_failing_minimum_essential.ml:17\`) — pre-existing, not caused by this PR. They are leftovers from #14151 (missed test site) and #14156 (missing \`masc_mcp\` library in dune stanza).
- [ ] After main is fully clean: full test suite green
- [ ] /health probe re-run: \`paused_keepers.count\` matches \`~/me/.masc/keepers/*.json paused=true\` count
- [ ] Manual wake on paused keeper: state transitions \`paused=true → paused=false\` + first turn fires within heartbeat tick
- [ ] /metrics scrape: \`masc_keeper_turn_phase_duration_seconds_bucket\` series populated, distribution by from-phase visible

### Out of scope

- Auto-resume policy for stale_fleet_batch-paused keepers (separate RFC needed; current behavior intentionally keeps paused=true persisted to avoid thrash).
- Turn-stall root cause itself (87% in_turn_hung rate) — instrumentation here exposes it; remediation is architectural (likely cascade routing / provider timeout tuning).
- Pre-existing main breakages from #14151 + #14156 — separate hotfixes.

RFC-WAIVED: surgical instrumentation + 1 directive bug fix; touches no credential / identity / auth / sandbox / hooks / workflow subsystems listed in CLAUDE.md \`agent_delegation\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>