### PR TITLE
ci: cap godfile exception for prometheus split

### DIFF
--- a/scripts/lint/godfile-size-regression.sh
+++ b/scripts/lint/godfile-size-regression.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Block regression on .ml file size:
 #   - New files added in this PR may not exceed 600 lines.
-#   - Any .ml file may not exceed 3000 lines (absolute Godfile cap).
+#   - Any .ml file may not exceed 3100 lines (absolute Godfile cap).
 #
 # Why this gate exists:
 #   `fundamental_roadmap.md` Phase 5 targets six Godfiles (env_config_keeper,
@@ -12,7 +12,10 @@
 #
 # Limits chosen from the audit baseline (HEAD 5806519c0b, 2026-05-05):
 #   - Largest existing file: lib/prometheus.ml @ 2,326 lines.
-#     3000 leaves headroom for one round of additions before the cap forces split.
+#     3000 left headroom for one round of additions before the cap forced split.
+#     Main reached 3,052 lines on 2026-05-07; issue #14161 tracks the proper
+#     Prometheus metric-name split. 3100 is a narrow temporary exception, not
+#     a new growth budget.
 #   - 40+ files are already over 600 lines. New files start clean.
 #
 # Modes:
@@ -27,7 +30,7 @@ set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 BASE="${BASE:-}"
-ABSOLUTE_CAP="${ABSOLUTE_CAP:-3000}"
+ABSOLUTE_CAP="${ABSOLUTE_CAP:-3100}"
 NEW_FILE_CAP="${NEW_FILE_CAP:-600}"
 
 cd "${ROOT}"


### PR DESCRIPTION
Summary:
- Raise `scripts/lint/godfile-size-regression.sh` `ABSOLUTE_CAP` from 3000 to 3100.
- Document this as a narrow temporary exception for `lib/prometheus.ml` currently at 3052 lines.
- Link the proper split follow-up to #14161 so this is not treated as new growth budget.

Validation:
- `git diff --check`
- `bash scripts/lint/godfile-size-regression.sh`
- `BASE=origin/main bash scripts/lint/godfile-size-regression.sh`