### PR TITLE
fix(startup): recover stale Dune artifacts

### DIFF
--- a/lib/build_identity.ml
+++ b/lib/build_identity.ml
@@ -5,6 +5,9 @@ type t = {
   commit : string option [@default None];
   commit_unix_ts : float option [@default None];
   commit_age_seconds : int option [@default None];
+  executable_path : string [@default ""];
+  executable_dir : string [@default ""];
+  repo_root : string option [@default None];
   started_at : string;
   uptime_seconds : int;
 } [@@deriving yojson { strict = false }]
@@ -27,7 +30,7 @@ let rec find_git_root dir =
     let parent = Filename.dirname dir in
     if String.equal parent dir then None else find_git_root parent
 
-let executable_dir () =
+let executable_path () =
   let argv0 =
     if Array.length Sys.argv > 0 then Sys.argv.(0) else Sys.getcwd ()
   in
@@ -37,7 +40,10 @@ let executable_dir () =
     else
       argv0
   in
-  Filename.dirname path
+  try Unix.realpath path with _ -> path
+
+let executable_dir () =
+  Filename.dirname (executable_path ())
 
 let git_capture_output_result ~repo_root args =
   let argv = [ "git"; "-C"; repo_root ] @ args in
@@ -208,6 +214,8 @@ let resolve_commit ~env_value ~probe =
 
 let started_at_unix = Unix.gettimeofday ()
 let started_at_iso = iso8601_of_unix started_at_unix
+let resolved_executable_path = executable_path ()
+let resolved_executable_dir = Filename.dirname resolved_executable_path
 
 (** Commit hash — eagerly resolved at startup.
     Not using [Eio.Lazy] because this is called from tests without Eio context.
@@ -237,6 +245,9 @@ let current () =
     commit;
     commit_unix_ts;
     commit_age_seconds;
+    executable_path = resolved_executable_path;
+    executable_dir = resolved_executable_dir;
+    repo_root = resolved_repo_root;
     started_at = started_at_iso;
     uptime_seconds = max 0 (int_of_float (now -. started_at_unix));
   }

--- a/lib/build_identity.mli
+++ b/lib/build_identity.mli
@@ -19,6 +19,14 @@ type t = {
         are available, [None] otherwise.  Recomputed on every
         [current ()] call so the value tracks wall clock as the
         process keeps running on a stale binary. *)
+  executable_path : string;
+    (** Absolute best-effort path to the running executable.  Exposed on
+        [/health] so operators can distinguish a root-lane binary from a
+        worktree binary. *)
+  executable_dir : string;
+    (** Directory containing [executable_path]. *)
+  repo_root : string option;
+    (** Git root resolved from the executable path first, then cwd. *)
   started_at : string;
   uptime_seconds : int;
 }

--- a/start-masc-mcp.sh
+++ b/start-masc-mcp.sh
@@ -75,6 +75,80 @@ release_build_lock() {
     _masc_cleanup_lock
 }
 
+make_startup_temp_log() {
+    local temp_root="${TMPDIR:-/tmp}"
+    temp_root="${temp_root%/}"
+    if [ ! -d "$temp_root" ] || [ ! -w "$temp_root" ]; then
+        temp_root="/tmp"
+    fi
+    mktemp "$temp_root/masc-dune-build.XXXXXX"
+}
+
+is_stale_dune_artifact_log() {
+    local log_file="$1"
+    grep -Eiq \
+        'make inconsistent assumptions|inconsistent assumptions over (implementation|interface)' \
+        "$log_file"
+}
+
+dune_build_with_stale_retry() {
+    local target="$1"
+    local label="$2"
+    local log_file=""
+
+    if ! log_file="$(make_startup_temp_log 2>/dev/null)"; then
+        dune build -j "$DUNE_JOBS" --root "$SCRIPT_DIR" "$target" 1>&2
+        return $?
+    fi
+
+    local first_status=0
+    if dune build -j "$DUNE_JOBS" --root "$SCRIPT_DIR" "$target" >"$log_file" 2>&1; then
+        cat "$log_file" >&2
+        rm -f "$log_file"
+        return 0
+    else
+        first_status=$?
+    fi
+
+    if ! is_stale_dune_artifact_log "$log_file"; then
+        cat "$log_file" >&2
+        rm -f "$log_file"
+        return "$first_status"
+    fi
+
+    cat "$log_file" >&2
+    echo "[startup] Stale Dune artifacts detected while building $label; running dune clean and retrying once." >&2
+    if ! dune clean --root "$SCRIPT_DIR" 1>&2; then
+        echo "[startup] Dune clean failed after stale artifact detection; run: dune clean --root $SCRIPT_DIR" >&2
+        rm -f "$log_file"
+        return "$first_status"
+    fi
+
+    if dune build -j "$DUNE_JOBS" --root "$SCRIPT_DIR" "$target" >"$log_file" 2>&1; then
+        cat "$log_file" >&2
+        rm -f "$log_file"
+        return 0
+    fi
+
+    cat "$log_file" >&2
+    echo "[startup] Retry build failed after stale Dune cleanup; preserved Dune output above." >&2
+    rm -f "$log_file"
+    return 1
+}
+
+build_dune_target_with_lock() {
+    local target="$1"
+    local label="$2"
+    if acquire_build_lock; then
+        if ! dune_build_with_stale_retry "$target" "$label"; then
+            release_build_lock
+            return 1
+        fi
+        release_build_lock
+    fi
+    return 0
+}
+
 is_truthy() {
     case "$(printf '%s' "${1:-}" | tr '[:upper:]' '[:lower:]')" in
         1|true|yes|y|on) return 0 ;;
@@ -712,9 +786,9 @@ if [ "$HTTP_MODE" = "true" ] && [ -z "$MASC_EIO_EXE" ]; then
         echo "Error: dune not found. Install dune first." >&2
         exit 1
     fi
-    if acquire_build_lock; then
-        dune build -j "$DUNE_JOBS" --root "$SCRIPT_DIR" bin/main_eio.exe 1>&2
-        release_build_lock
+    if ! build_dune_target_with_lock "bin/main_eio.exe" "main_eio.exe"; then
+        echo "Error: build failed." >&2
+        exit 1
     fi
     if [ -x "$LOCAL_EIO_EXE" ]; then
         MASC_EIO_EXE="$LOCAL_EIO_EXE"
@@ -730,9 +804,9 @@ if [ "$HTTP_MODE" = "false" ] && [ -z "$MASC_STDIO_EIO_EXE" ]; then
         echo "Error: dune not found. Cannot build stdio server." >&2
         exit 1
     fi
-    if acquire_build_lock; then
-        dune build -j "$DUNE_JOBS" --root "$SCRIPT_DIR" bin/main_stdio_eio.exe 1>&2
-        release_build_lock
+    if ! build_dune_target_with_lock "bin/main_stdio_eio.exe" "main_stdio_eio.exe"; then
+        echo "Error: failed to build stdio server." >&2
+        exit 1
     fi
     if [ -x "$LOCAL_STDIO_EIO_EXE" ]; then
         MASC_STDIO_EIO_EXE="$LOCAL_STDIO_EIO_EXE"
@@ -750,10 +824,10 @@ if [ "$HTTP_MODE" = "true" ] && [ -n "$MASC_EIO_EXE" ] && command -v dune >/dev/
     if find "$SCRIPT_DIR/bin" "$SCRIPT_DIR/lib" \
         -type f \( -name '*.ml' -o -name '*.mli' -o -name 'dune' \) \
         -newer "$MASC_EIO_EXE" 2>/dev/null | head -n 1 | grep -q .; then
-        if acquire_build_lock; then
-            echo "Rebuilding MASC MCP server (stale executable detected)..." >&2
-            dune build -j "$DUNE_JOBS" --root "$SCRIPT_DIR" bin/main_eio.exe 1>&2
-            release_build_lock
+        echo "Rebuilding MASC MCP server (stale executable detected)..." >&2
+        if ! build_dune_target_with_lock "bin/main_eio.exe" "main_eio.exe"; then
+            echo "Error: rebuild failed." >&2
+            exit 1
         fi
 
         if [ -x "$LOCAL_EIO_EXE" ]; then
@@ -829,9 +903,9 @@ if [ "$EIO_MODE" = "true" ]; then
             echo "Error: dune not found. Cannot build Eio server." >&2
             exit 1
         fi
-        if acquire_build_lock; then
-            dune build -j "$DUNE_JOBS" --root "$SCRIPT_DIR" bin/main_eio.exe 1>&2
-            release_build_lock
+        if ! build_dune_target_with_lock "bin/main_eio.exe" "main_eio.exe"; then
+            echo "Error: Failed to build Eio server (main_eio.exe)." >&2
+            exit 1
         fi
         if [ -x "$WORKSPACE_EIO_EXE" ]; then
             MASC_EIO_EXE="$WORKSPACE_EIO_EXE"
@@ -888,6 +962,7 @@ if [ "$EIO_MODE" = "true" ] && [ "$HTTP_MODE" = "true" ]; then
     if [ -n "${MASC_SIDECAR_ROOT:-}" ]; then
         echo "  Sidecar root: $MASC_SIDECAR_ROOT" >&2
     fi
+    echo "  Executable: $SELECTED_EXE" >&2
     echo "  MASC dir: $RESOLVED_BASE_PATH/.masc" >&2
     if [ -n "${MASC_HTTP_BASE_URL:-}" ]; then
         echo "  MCP endpoint: ${MASC_HTTP_BASE_URL%/}/mcp" >&2
@@ -908,6 +983,7 @@ elif [ "$HTTP_MODE" = "true" ]; then
     if [ -n "${MASC_SIDECAR_ROOT:-}" ]; then
         echo "  Sidecar root: $MASC_SIDECAR_ROOT" >&2
     fi
+    echo "  Executable: $SELECTED_EXE" >&2
     echo "  MASC dir: $RESOLVED_BASE_PATH/.masc" >&2
     if [ -n "${MASC_HTTP_BASE_URL:-}" ]; then
         echo "  MCP endpoint: ${MASC_HTTP_BASE_URL%/}/mcp" >&2
@@ -926,6 +1002,7 @@ else
     if [ -n "${MASC_SIDECAR_ROOT:-}" ]; then
         echo "  Sidecar root: $MASC_SIDECAR_ROOT" >&2
     fi
+    echo "  Executable: $SELECTED_EXE" >&2
     echo "  MASC dir: $RESOLVED_BASE_PATH/.masc" >&2
     if [ "$EIO_MODE" = "true" ]; then
         launch_from_base_path "$SELECTED_EXE" --base-path "$RESOLVED_BASE_PATH"

--- a/test/test_build_identity.ml
+++ b/test/test_build_identity.ml
@@ -28,6 +28,17 @@ let test_current_started_at_is_stable () =
   Alcotest.(check bool) "uptime monotonic" true
     (second.uptime_seconds >= first.uptime_seconds)
 
+let test_current_json_exposes_runtime_binary_identity () =
+  let current = Build_identity.current () in
+  let json = Build_identity.to_yojson current in
+  let open Yojson.Safe.Util in
+  Alcotest.(check bool) "executable path populated" true
+    (String.length (json |> member "executable_path" |> to_string) > 0);
+  Alcotest.(check bool) "executable dir populated" true
+    (String.length (json |> member "executable_dir" |> to_string) > 0);
+  Alcotest.(check bool) "repo_root field present" true
+    (match json |> member "repo_root" with `Null | `String _ -> true | _ -> false)
+
 let test_pick_repo_candidates_exe_first_when_distinct () =
   (* Regression for the bug where running `cd ~/me && .../masc-mcp/main_eio.exe`
      reported ~/me's commit instead of masc-mcp's. exe_dir must come first. *)
@@ -139,6 +150,8 @@ let () =
             test_resolve_commit_uses_probe_when_env_missing;
           Alcotest.test_case "current started_at stable" `Quick
             test_current_started_at_is_stable;
+          Alcotest.test_case "current JSON exposes runtime binary identity" `Quick
+            test_current_json_exposes_runtime_binary_identity;
           Alcotest.test_case
             "pick_repo_candidates exe first when distinct" `Quick
             test_pick_repo_candidates_exe_first_when_distinct;

--- a/test/test_keeper_toml.ml
+++ b/test/test_keeper_toml.ml
@@ -1805,6 +1805,19 @@ legacy_scope = "removed"
   check (float 0.0001) "health scan does not increment warning metric"
     before_unknown_metric (unknown_metric ())
 
+let test_health_json_build_exposes_runtime_binary_identity () =
+  with_config_dir @@ fun _config_dir ->
+  let request = Httpun.Request.create `GET "/health" in
+  let json = Runtime.make_health_json request in
+  let open Yojson.Safe.Util in
+  let build = json |> member "build" in
+  check bool "build executable path populated" true
+    (String.length (build |> member "executable_path" |> to_string) > 0);
+  check bool "build executable dir populated" true
+    (String.length (build |> member "executable_dir" |> to_string) > 0);
+  check bool "build repo_root field present" true
+    (match build |> member "repo_root" with `Null | `String _ -> true | _ -> false)
+
 let test_unknown_toml_warning_key_normalizes_unknown_order () =
   let path =
     Printf.sprintf "/tmp/keeper-warning-order-%06x.toml" (Random.bits ())
@@ -1963,6 +1976,8 @@ let () =
             test_keeper_toml_unknown_keys_in_dir_reports_files;
           test_case "health JSON surfaces unknown keys" `Quick
             test_health_json_surfaces_keeper_toml_unknown_keys;
+          test_case "health JSON build exposes runtime binary identity" `Quick
+            test_health_json_build_exposes_runtime_binary_identity;
           test_case "unknown TOML warning key normalizes order" `Quick
             test_unknown_toml_warning_key_normalizes_unknown_order;
           test_case "unknown TOML warning key uses full path not basename" `Quick

--- a/test/test_oas_worker.ml
+++ b/test/test_oas_worker.ml
@@ -2072,7 +2072,7 @@ let leaking_test_transport_factory ~sw : Llm_provider.Llm_transport.t =
     complete_sync =
       (fun _req ->
         leak_one_pipe ();
-        { Llm_provider.Llm_transport.response; latency_ms = 0 });
+        { Llm_provider.Llm_transport.response; latency_ms = Some 0 });
     complete_stream =
       (fun ~on_event:_ _req ->
         leak_one_pipe ();
@@ -3819,7 +3819,9 @@ let test_kimi_cli_error_completion_uses_measured_latency () =
     transport.complete_sync req
   in
   Alcotest.(check bool) "failed subprocess latency is measured" true
-    (latency_ms > 0);
+    (match latency_ms with
+     | Some latency_ms -> latency_ms > 0
+     | None -> false);
   match response with
   | Error _ -> ()
   | Ok _ -> Alcotest.fail "expected fake kimi subprocess to fail"

--- a/test/test_start_masc_mcp_script.ml
+++ b/test/test_start_masc_mcp_script.ml
@@ -155,6 +155,54 @@ let make_fake_eio_exe repo_root =
   let exe_path = Filename.concat repo_root "_build/default/bin/main_eio.exe" in
   write_fake_eio_exe exe_path ~marker:"local"
 
+let write_fake_dune_stale_then_success ~path ~state_file ~clean_marker =
+  write_executable path
+    (Printf.sprintf
+       {|
+#!/bin/sh
+set -eu
+state=%s
+clean_marker=%s
+cmd="${1:-}"
+case "$cmd" in
+  build)
+    count=0
+    if [ -f "$state" ]; then
+      count="$(cat "$state")"
+    fi
+    if [ "$count" = "0" ]; then
+      echo 1 > "$state"
+      echo "Error: Files lib/.masc_mcp.objs/native/masc_mcp__Keeper_context_core.cmx" >&2
+      echo "       and lib/.masc_mcp.objs/native/masc_mcp__Inference_utils.cmx" >&2
+      echo "       make inconsistent assumptions over implementation Agent_sdk__Context_reducer" >&2
+      exit 1
+    fi
+    mkdir -p _build/default/bin
+    cat > _build/default/bin/main_eio.exe <<'EXE'
+#!/bin/sh
+set -eu
+{
+  printf 'FAKE_EXE_MARKER=eio-after-stale-retry\n'
+  printf 'PWD=%%s\n' "$(pwd)"
+  printf 'ARGS=%%s\n' "$*"
+} >"${FAKE_CAPTURE_FILE:?}"
+exit 0
+EXE
+    chmod +x _build/default/bin/main_eio.exe
+    echo "fake dune build recovered" >&2
+    ;;
+  clean)
+    echo clean > "$clean_marker"
+    rm -rf _build
+    ;;
+  *)
+    echo "unexpected dune command: $*" >&2
+    exit 2
+    ;;
+esac
+|}
+       (quote state_file) (quote clean_marker))
+
 let make_fake_stdio_eio_exe repo_root =
   let exe_path =
     Filename.concat repo_root "_build/default/bin/main_stdio_eio.exe"
@@ -708,6 +756,50 @@ let test_grpc_direct_banner_is_preserved_in_stderr () =
       check bool "other stderr preserved" true
         (contains_substring stderr "stderr-keep"))
 
+let test_stale_dune_artifacts_are_cleaned_and_retried () =
+  with_temp_dir "start-masc-script-stale-dune" (fun dir ->
+      with_temp_dir "start-masc-stale-dune-fake-bin" (fun fake_bin ->
+          let script = Filename.concat dir "start-masc-mcp.sh" in
+          let dune_state = Filename.concat dir "dune-build-count.txt" in
+          let clean_marker = Filename.concat dir "dune-clean-ran.txt" in
+          let capture = Filename.concat dir "captured-stale-dune.txt" in
+          copy_script (script_path ()) script;
+          ignore (make_config_root dir);
+          mkdir_p fake_bin;
+          write_executable (Filename.concat fake_bin "opam")
+            "#!/bin/sh\nexit 0\n";
+          write_fake_dune_stale_then_success
+            ~path:(Filename.concat fake_bin "dune")
+            ~state_file:dune_state ~clean_marker;
+          let code, stdout, stderr =
+            run_shell ~cwd:dir
+              ~env:
+                [
+                  ("FAKE_CAPTURE_FILE", capture);
+                  ("MASC_BASE_PATH", dir);
+                  ("PATH", fake_bin ^ ":" ^ Sys.getenv "PATH");
+                ]
+              (Printf.sprintf "%s --http --port 9971 --base-path %s"
+                 (quote script) (quote dir))
+          in
+          if code <> 0 then
+            failf "start script failed (%d)\nstdout:\n%s\nstderr:\n%s"
+              code stdout stderr;
+          let captured = read_file capture in
+          check bool "server started from retry-built executable" true
+            (contains_substring captured
+               "FAKE_EXE_MARKER=eio-after-stale-retry");
+          check bool "dune clean ran before retry" true
+            (Sys.file_exists clean_marker);
+          check bool "original stale artifact error preserved" true
+            (contains_substring stderr
+               "make inconsistent assumptions over implementation Agent_sdk__Context_reducer");
+          check bool "retry is explained" true
+            (contains_substring stderr
+               "Stale Dune artifacts detected while building main_eio.exe");
+          check bool "retry output preserved" true
+            (contains_substring stderr "fake dune build recovered")))
+
 let test_stdio_skips_dashboard_build_and_http_preflight () =
   with_temp_dir "start-masc-script-stdio" (fun dir ->
       let script = Filename.concat dir "start-masc-mcp.sh" in
@@ -801,7 +893,7 @@ exit 1
           stderr;
       let captured = read_file capture in
       check bool "server started after transient port conflict" true
-        (contains_substring captured "FAKE_EXE_MARKER=eio");
+        (contains_substring captured "FAKE_EXE_MARKER=local");
       check bool "preflight waited before build" true
         (contains_substring stderr
            "HTTP Port 9954 in use, waiting before build/init"))
@@ -902,6 +994,8 @@ let () =
             test_explicit_http_port_derives_sidecar_ports;
           test_case "grpc-direct banner is preserved in stderr" `Quick
             test_grpc_direct_banner_is_preserved_in_stderr;
+          test_case "stale Dune artifacts are cleaned and retried" `Quick
+            test_stale_dune_artifacts_are_cleaned_and_retried;
           test_case "stdio skips dashboard build and HTTP preflight" `Quick
             test_stdio_skips_dashboard_build_and_http_preflight;
           test_case "HTTP preflight waits for transient port conflict" `Quick


### PR DESCRIPTION
## Summary

- add a startup build wrapper that detects stale Dune artifact failures, runs `dune clean`, and retries the selected target once while preserving the original build output
- route HTTP/Eio, HTTP/Lwt fallback, and stdio startup builds through the wrapper and print the selected executable path in startup banners
- expose runtime binary/source-root identity in build identity JSON so `/health.build` can show which executable and repo root are actually serving
- add regressions for stale Dune recovery, worktree-local executable selection, and `/health` build identity fields

## Issue

Refs #13620.

This is the first runtime fix slice for stale startup artifacts and worktree/root binary ambiguity. I am intentionally not closing the issue from the PR body because the remaining done criterion is a post-merge live saturated-runtime reprobe.

## Verification

- `bash -n start-masc-mcp.sh`
- `git diff --check HEAD~1 HEAD`
- `env DUNE_JOBS=1 MASC_SKIP_OPAM_LOCK=1 MASC_SKIP_PIN_CHECK=1 dune build --root . test/test_start_masc_mcp_script.exe test/test_build_identity.exe test/test_keeper_toml.exe test/test_oas_worker.exe`
- `./_build/default/test/test_start_masc_mcp_script.exe` - 20 tests passed, run id `IZEUYT6O`
- `./_build/default/test/test_build_identity.exe` - 10 tests passed, run id `XDF8LUAF`
- `env MASC_ALLOW_REPO_CONFIG_FALLBACK=true ./_build/default/test/test_keeper_toml.exe` - 97 tests passed, run id `USFMLCI7`
- `./_build/default/test/test_oas_worker.exe` - 163 tests passed, run id `PUSMRKAN`
