### PR TITLE
fix(test): finish latency_ms int->int option migration in test_oas_worker

### DIFF
--- a/test/test_oas_worker.ml
+++ b/test/test_oas_worker.ml
@@ -2072,7 +2072,7 @@ let leaking_test_transport_factory ~sw : Llm_provider.Llm_transport.t =
     complete_sync =
       (fun _req ->
         leak_one_pipe ();
-        { Llm_provider.Llm_transport.response; latency_ms = 0 });
+        { Llm_provider.Llm_transport.response; latency_ms = None });
     complete_stream =
       (fun ~on_event:_ _req ->
         leak_one_pipe ();
@@ -3819,7 +3819,7 @@ let test_kimi_cli_error_completion_uses_measured_latency () =
     transport.complete_sync req
   in
   Alcotest.(check bool) "failed subprocess latency is measured" true
-    (latency_ms > 0);
+    (match latency_ms with Some n -> n > 0 | None -> false);
   match response with
   | Error _ -> ()
   | Ok _ -> Alcotest.fail "expected fake kimi subprocess to fail"


### PR DESCRIPTION
## Why

PR #14151 (d6468f28) updated `Llm_provider.Llm_transport.sync_result.latency_ms` from `int` to `int option` to match agent_sdk PR jeong-sik/oas#1463, but only fixed 4 of 6 sites in `test_oas_worker.ml`. The remaining 2 still emit `int` literals, breaking `dune build test/test_oas_worker.exe` on a clean main checkout.

Reproduced on origin/main HEAD (8e7ce099ac) via `scripts/dune-local.sh build test/test_oas_worker.exe`:

```
File "test/test_oas_worker.ml", line 2075, characters 60-61:
2075 |         { Llm_provider.Llm_transport.response; latency_ms = 0 });
                                                                   ^
Error: The constant 0 has type int but an expression was expected of type
         int option
```

## What

- `test/test_oas_worker.ml:2075` — `leaking_test_transport_factory` returns `latency_ms = 0`. This transport never measures latency (purpose is fd-leak observation), so the truthful value is `None`, not `Some 0`.
- `test/test_oas_worker.ml:3818-3822` — `test_kimi_cli_failure_*` assertion `latency_ms > 0` (`int` comparison). Migrated to `match latency_ms with Some n -> n > 0 | None -> false` so the original intent ("failed subprocess latency is measured" => transport must record positive duration even on subprocess error) survives under the option-typed field.

## Verification

```
$ scripts/dune-local.sh build test/test_oas_worker.exe
[dune-local] command: dune build --root ... test/test_oas_worker.exe
$ echo $?
0
```

Diff: 2 lines changed across 1 file.

## Test plan

- [x] `dune build test/test_oas_worker.exe` succeeds locally
- [ ] CI Build & Test (OCaml 5.4.1) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)