### PR TITLE
refactor(keeper_turn_fsm): use Safe_ops.protect for cancel-aware observe_histogram

### DIFF
--- a/lib/keeper/keeper_turn_fsm.ml
+++ b/lib/keeper/keeper_turn_fsm.ml
@@ -294,12 +294,13 @@ let observe_phase_dwell ~keeper_name ~from_label =
   | Some prev_at ->
     let now = Unix.gettimeofday () in
     let dwell = Float.max 0.0 (now -. prev_at) in
-    (try
-       Prometheus.observe_histogram
-         Prometheus.metric_keeper_turn_phase_duration
-         ~labels:[ ("keeper", keeper_name); ("from", from_label) ]
-         dwell
-     with _ -> ())
+    (* Cancel-aware: bare [try ... with _ -> ()] would swallow
+       [Eio.Cancel.Cancelled] and break switch teardown. *)
+    Safe_ops.protect ~default:() (fun () ->
+      Prometheus.observe_histogram
+        Prometheus.metric_keeper_turn_phase_duration
+        ~labels:[ ("keeper", keeper_name); ("from", from_label) ]
+        dwell)
 
 let emit_transition ?ctx ~keeper_name ~turn_id ?prev state =
   let prev_label =


### PR DESCRIPTION
## Summary

Replace `try Prometheus.observe_histogram ... with _ -> ()` (added in
`#14158`/`#14163` at `lib/keeper/keeper_turn_fsm.ml:297-302`) with
`Safe_ops.protect ~default:()`. The bare `try _` swallows
`Eio.Cancel.Cancelled` and breaks switch teardown — the keeper would
hang in a half-cancelled state if the cancellation arrives during a
`observe_histogram` call.

## Why this matters

`observe_phase_dwell` runs on every keeper FSM transition. When the
supervisor cancels the keeper switch, the cancellation propagates by
raising `Eio.Cancel.Cancelled` at the next yield point. If
`observe_histogram` (which acquires a Prometheus mutex) is mid-flight
during cancellation, the bare `try _` catches `Cancelled`, returns
`()`, and the cancellation never reaches the surrounding switch.

`Safe_ops.protect ~default:()` re-raises `Eio.Cancel.Cancelled` on its
original backtrace and only swallows non-cancellation exceptions. That
preserves both intents: telemetry keeps working under transient
mutation/IO failures, AND cancellation continues propagating.

This is the same pattern `#14126` applied to `coord_hooks.ml`.

## Established pattern in this codebase

`Safe_ops.protect` already used at:

- `keeper_hooks_oas.ml:1132,1136`
- `keeper_decision_audit.ml:188`
- `keeper_approval_queue.ml:911`
- `keeper_toml_loader.ml:584,587`
- `keeper_exec_preflight.ml:44`
- `coord_hooks.ml` (via #14126)

## Scope

- 1 file, +7/-6.
- No public API change.
- Cancellation path correctly preserved.
- Successful telemetry calls are byte-identical to before.

## Self-review

- Comment explains *why* (cancellation semantics + half-cancellation
  hang risk), not *what*.
- `dune build lib/keeper --root .` succeeds.
- The dwell measurement (`Float.max 0.0 (now -. prev_at)`) is computed
  outside the protect call, so it's never lost — only the histogram
  observation is wrapped.

## Test plan

- [x] `dune build lib/keeper --root .` succeeds.
- [ ] Reviewer confirms `Safe_ops.protect` matches expected semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
