### PR TITLE
fix(keeper): use resolved persona name for drift detection

### DIFF
--- a/lib/keeper/keeper_health_probe.ml
+++ b/lib/keeper/keeper_health_probe.ml
@@ -22,6 +22,14 @@ let set_health ~keeper_name status =
     Hashtbl.replace health_cache keeper_name
       (status, Time_compat.now ()))
 
+let set_health_for_test ~keeper_name ~healthy =
+  set_health ~keeper_name
+    (if healthy then Healthy else Unhealthy "test")
+
+let reset_for_test () =
+  Eio.Mutex.use_rw ~protect:true health_cache_mu (fun () ->
+    Hashtbl.clear health_cache)
+
 (* ------------------------------------------------------------------ *)
 (* Cascade health check                                               *)
 

--- a/lib/keeper/keeper_health_probe.mli
+++ b/lib/keeper/keeper_health_probe.mli
@@ -13,6 +13,13 @@
     (Unknown) or the last probe reported Unhealthy. *)
 val is_healthy : keeper_name:string -> bool
 
+val set_health_for_test : keeper_name:string -> healthy:bool -> unit
+(** Test-only: seed the cached health status for deterministic supervisor
+    auto-resume tests. *)
+
+val reset_for_test : unit -> unit
+(** Test-only: clear the cached health statuses. *)
+
 (** [check_cascade_health ~base_path] scans the registry and computes
     the failure ratio for each active cascade.  Returns a list of
     (cascade_name, is_healthy) pairs.  This function performs I/O and

--- a/lib/keeper/keeper_hooks_oas.mli
+++ b/lib/keeper/keeper_hooks_oas.mli
@@ -231,8 +231,9 @@ val record_llm_tok_s_metrics :
 val record_llm_inference_latency_metric :
   model:string ->
   telemetry:Agent_sdk.Types.inference_telemetry option -> unit
-(** Record after-turn inference latency. [request_latency_ms <= 0] is counted
-    by [masc_after_turn_telemetry_zero_latency_total] and floored to 1ms in
+(** Record after-turn inference latency. Missing or non-positive
+    [request_latency_ms] is counted by
+    [masc_after_turn_telemetry_zero_latency_total] and floored to 1ms in
     [masc_llm_inference_duration_seconds] so a live hook does not leave the
     latency histogram blank. *)
 

--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -489,40 +489,54 @@ let launch_supervised_fiber ~proactive_warmup_sec ctx (meta : keeper_meta)
      run a quick \[ls personas/\] and reconcile.
 
    Surface the gap once at supervise_keepalive entry — the code path
-   that actually puts the keeper into the registry. Behaviour is
-   unchanged (still proceeds with fallback) so the boot path stays
-   compatible with the current 9-missing-personas fleet; the value is
-   in turning a silent runtime drift into a single ERROR per keeper
-   per supervisor restart.
+   that actually puts the keeper into the registry.  The check resolves
+   the keeper's configured persona through keeper TOML/profile defaults
+   before probing the persona directory, so keepers that intentionally
+   share a persona are not reported as missing their keeper-name persona.
+   Behaviour is unchanged (still proceeds with fallback) so the boot
+   path stays compatible with the current 9-missing-personas fleet; the
+   value is in turning a silent runtime drift into a single ERROR per
+   keeper per supervisor restart.
 
    The visibility ERROR is bounded by fleet size (~14 keepers) and
    only fires on first registration — the [is_registered] guard above
    skips repeat calls. *)
-let log_persona_drift_if_missing ~base_path (meta : keeper_meta) =
+let persona_name_for_drift_check (meta : keeper_meta) =
+  let defaults = Keeper_types_profile.load_keeper_profile_defaults meta.name in
+  let persona_name =
+    Keeper_types_profile.resolved_persona_name ~keeper_name:meta.name defaults
+    |> String.trim
+  in
+  if persona_name = "" then meta.name else persona_name
+
+let persona_drift_missing_for_test ~base_path (meta : keeper_meta) =
+  let input_agent_name = persona_name_for_drift_check meta in
   match
     Keeper_identity.normalize_all_names
-      ~input_agent_name:meta.name
+      ~input_agent_name
       ~base_path
       ~check_persona:true
       ~check_credential:false
       ()
   with
-  | Ok _ -> ()
+  | Ok _ -> None
   | Error (Keeper_identity.Persona_not_found { resolved; searched; _ }) ->
+      Some (input_agent_name, resolved, searched)
+  | Error _ -> None
+
+let log_persona_drift_if_missing ~base_path (meta : keeper_meta) =
+  match persona_drift_missing_for_test ~base_path meta with
+  | None -> ()
+  | Some (persona_name, resolved, searched) ->
       Prometheus.inc_counter
         Prometheus.metric_keeper_persona_drift_missing
         ~labels:[("keeper", meta.name)]
         ();
       Log.Keeper.error
-        "[#10993][persona_drift] keeper=%s resolved=%s persona file missing at %s \
+        "[#10993][persona_drift] keeper=%s persona=%s resolved=%s persona file missing at %s \
          — runtime falls through to logging-only RFC P3-a path; \
          operator action: create persona file or remove keeper from registry"
-        meta.name resolved searched
-  | Error _ ->
-      (* Other validation errors (Empty_input, Credential_missing — but
-         we passed check_credential:false) are not the silent-drift
-         class this hook is documenting. Stay silent to avoid noise. *)
-      ()
+        meta.name persona_name resolved searched
 
 let supervise_keepalive ~proactive_warmup_sec (ctx : _ context)
     (meta : keeper_meta) =

--- a/lib/keeper/keeper_supervisor.mli
+++ b/lib/keeper/keeper_supervisor.mli
@@ -47,6 +47,11 @@ val backoff_delay : int -> float
 val keep_last_n : int -> 'a -> 'a list -> 'a list
 (** [keep_last_n n item lst] prepends [item] and keeps at most [n] entries. *)
 
+val persona_drift_missing_for_test :
+  base_path:string -> Keeper_types.keeper_meta -> (string * string * string) option
+(** Test-only: returns [Some (persona_name, resolved, searched)] when the
+    configured persona for a keeper is missing. *)
+
 val supervision_cohort_size : int
 (** Target keeper count per supervisor cohort.  The first 2-level
     supervision slice groups the 64-keeper fleet as 8 cohorts of 8. *)

--- a/test/test_keeper_supervisor.ml
+++ b/test/test_keeper_supervisor.ml
@@ -32,6 +32,59 @@ let cleanup_dir dir =
   in
   try rm dir with _ -> ()
 
+let restore_env key = function
+  | Some value -> Unix.putenv key value
+  | None -> Unix.putenv key ""
+
+let rec mkdir_p dir =
+  if dir = "" || dir = "." || dir = "/" then ()
+  else if Sys.file_exists dir then ()
+  else begin
+    mkdir_p (Filename.dirname dir);
+    Unix.mkdir dir 0o755
+  end
+
+let write_file path content =
+  let oc = open_out path in
+  Fun.protect
+    ~finally:(fun () -> close_out_noerr oc)
+    (fun () -> output_string oc content)
+
+let with_config_root f =
+  let base_dir = temp_dir () in
+  let config_dir = Filename.concat base_dir "config" in
+  let keepers_dir = Filename.concat config_dir "keepers" in
+  let personas_dir = Filename.concat config_dir "personas" in
+  let original_config_dir = Sys.getenv_opt "MASC_CONFIG_DIR" in
+  let original_personas_dir = Sys.getenv_opt "MASC_PERSONAS_DIR" in
+  Fun.protect
+    ~finally:(fun () ->
+      restore_env "MASC_CONFIG_DIR" original_config_dir;
+      restore_env "MASC_PERSONAS_DIR" original_personas_dir;
+      Masc_mcp.Config_dir_resolver.reset ();
+      cleanup_dir base_dir)
+    (fun () ->
+      mkdir_p keepers_dir;
+      mkdir_p personas_dir;
+      Unix.putenv "MASC_CONFIG_DIR" config_dir;
+      Unix.putenv "MASC_PERSONAS_DIR" "";
+      Masc_mcp.Config_dir_resolver.reset ();
+      f ~base_dir ~keepers_dir ~personas_dir)
+
+let write_persona_profile personas_dir persona_name =
+  let persona_dir = Filename.concat personas_dir persona_name in
+  mkdir_p persona_dir;
+  write_file
+    (Filename.concat persona_dir "profile.json")
+    {|
+{
+  "name": "Test Persona",
+  "keeper": {
+    "goal": "test persona"
+  }
+}
+|}
+
 let contains_substring haystack needle =
   let haystack_len = String.length haystack in
   let needle_len = String.length needle in
@@ -208,6 +261,34 @@ let make_meta name =
   match KT.meta_of_json json with
   | Ok meta -> meta
   | Error err -> fail ("make_meta: " ^ err)
+
+let test_persona_drift_uses_configured_persona_name () =
+  with_config_root @@ fun ~base_dir ~keepers_dir ~personas_dir ->
+  write_persona_profile personas_dir "velvet-hammer";
+  write_file
+    (Filename.concat keepers_dir "taskmaster.toml")
+    {|
+[keeper]
+persona_name = "velvet-hammer"
+|};
+  let drift = Sup.persona_drift_missing_for_test ~base_path:base_dir
+      (make_meta "taskmaster")
+  in
+  check bool "configured shared persona exists" true (Option.is_none drift)
+
+let test_persona_drift_reports_missing_configured_persona_name () =
+  with_config_root @@ fun ~base_dir ~keepers_dir:_ ~personas_dir ->
+  let drift = Sup.persona_drift_missing_for_test ~base_path:base_dir
+      (make_meta "janitor")
+  in
+  match drift with
+  | None -> fail "expected missing persona drift"
+  | Some (persona_name, resolved, searched) ->
+      check string "persona_name" "janitor" persona_name;
+      check string "resolved" "janitor" resolved;
+      check string "searched path"
+        (Filename.concat personas_dir "janitor")
+        searched
 
 let registered_entries names =
   Reg.clear ();
@@ -603,6 +684,7 @@ let test_restart_path_emits_meta_unavailable_outcome_metric () =
   let name = "restart-missing-meta-metric-keeper" in
   Fun.protect
     ~finally:(fun () ->
+      Masc_mcp.Keeper_health_probe.reset_for_test ();
       Reg.clear ();
       Masc_mcp.Keeper_runtime.reset_test_state base_dir;
       cleanup_dir base_dir)
@@ -1310,6 +1392,9 @@ let test_sweep_auto_resumes_after_backoff () =
       (match KT.write_meta config paused_meta with
        | Ok () -> ()
        | Error err -> fail err);
+      Masc_mcp.Keeper_health_probe.set_health_for_test
+        ~keeper_name:paused_meta.cascade_name
+        ~healthy:true;
       let baseline_auto_resume =
         Masc_mcp.Prometheus.metric_total
           Masc_mcp.Prometheus.metric_keeper_auto_resumed_total
@@ -1538,6 +1623,12 @@ let () =
     ];
     "keep_last_n_properties", [
       test_case "never exceeds limit" `Quick test_keep_last_n_never_exceeds;
+    ];
+    "persona_drift", [
+      test_case "uses configured shared persona" `Quick
+        test_persona_drift_uses_configured_persona_name;
+      test_case "reports missing configured persona" `Quick
+        test_persona_drift_reports_missing_configured_persona_name;
     ];
     "supervision_cohorts", [
       test_case "64 keepers form 8 cohorts of 8" `Quick


### PR DESCRIPTION
## Summary
- Persona drift check at supervisor entry used `meta.name` (keeper name) directly to probe the persona directory, producing false-positive "missing persona" ERROR for keepers that intentionally share a base persona via TOML profile defaults (the meta-persona pattern).
- Resolve the keeper's configured persona via `Keeper_types_profile.load_keeper_profile_defaults` + `resolved_persona_name` before probing. Falls back to `meta.name` when no resolved persona is set.
- Behaviour unchanged otherwise (still proceeds with fallback).

## Changes
- `lib/keeper/keeper_supervisor.ml`: extract `persona_name_for_drift_check` helper, expose `persona_drift_missing_for_test`.
- `lib/keeper/keeper_health_probe.{ml,mli}`: add `set_health_for_test` / `reset_for_test` for test isolation.
- `lib/keeper/keeper_hooks_oas.mli`: minor signature update.
- `test/test_keeper_supervisor.ml`: add 91-line test covering shared-persona scenario.

## Test plan
- [x] `dune build lib/keeper --root .` passes
- [x] `dune exec test/test_keeper_supervisor.exe --root .` — 72/72 tests pass in 31.25s (including new shared-persona case)
- [ ] Full `dune build` is currently blocked by main-side issues unrelated to this PR (`test_failing_minimum_essential`: Unbound `Keeper_tool_policy`; `test_oas_worker:2075`: latency_ms type mismatch). Will report separately.

## RFC check
- Subsystem touched: `lib/keeper/keeper_supervisor`, `lib/keeper/keeper_health_probe`, `lib/keeper/keeper_hooks_oas.mli`. Not in the credential / identity / repo_manager / operator / sandbox / hooks / workflow guarded list. RFC not required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)