### PR TITLE
fix(observability): instrument UTF-8 repair + per_provider_timeout type hint

### DIFF
--- a/lib/core/safe_ops.ml
+++ b/lib/core/safe_ops.ml
@@ -149,12 +149,13 @@ let record_utf8_repair ~surface ~path ~invalid_bytes =
           |> List.filteri (fun i _ -> i < utf8_repair_path_sample_limit);
       let key = utf8_repair_log_key ~surface ~path in
       let now = Time_compat.now () in
+      let entry_count = Hashtbl.length utf8_repair_log_seen in
       match Hashtbl.find_opt utf8_repair_log_seen key with
       | None ->
           prune_utf8_repair_log_seen_if_needed ~now;
           Hashtbl.replace utf8_repair_log_seen key
             { last_emit = now; last_seen = now; suppressed = 0 };
-          Some 0
+          Some (0, entry_count, 0.0)
       | Some entry
         when (let elapsed = now -. entry.last_emit in
               elapsed >= utf8_repair_log_restate_sec || elapsed < 0.0) ->
@@ -165,9 +166,10 @@ let record_utf8_repair ~surface ~path ~invalid_bytes =
              warning until the clock catches back up to the recorded
              [last_emit].  Treat backwards motion as a forced restate
              so the rate limiter recovers within one record call. *)
+          let elapsed = now -. entry.last_emit in
           Hashtbl.replace utf8_repair_log_seen key
             { last_emit = now; last_seen = now; suppressed = 0 };
-          Some entry.suppressed
+          Some (entry.suppressed, entry_count, elapsed)
       | Some entry ->
           Hashtbl.replace utf8_repair_log_seen key
             { entry with last_seen = now; suppressed = entry.suppressed + 1 };
@@ -176,13 +178,15 @@ let record_utf8_repair ~surface ~path ~invalid_bytes =
   emit_persistence_utf8_repair_metric ();
   match log_decision with
   | None -> ()
-  | Some 0 ->
-      Log.Misc.warn "[%s] persistence UTF-8 repaired path=%s invalid_bytes=%d"
-        surface path invalid_bytes
-  | Some suppressed_repeats ->
+  | Some (suppressed_repeats, entry_count, elapsed) ->
+      let suppressed_suffix =
+        if suppressed_repeats > 0
+        then Printf.sprintf " suppressed_repeats=%d" suppressed_repeats
+        else ""
+      in
       Log.Misc.warn
-        "[%s] persistence UTF-8 repaired path=%s invalid_bytes=%d suppressed_repeats=%d"
-        surface path invalid_bytes suppressed_repeats
+        "[%s] persistence UTF-8 repaired path=%s invalid_bytes=%d entries=%d elapsed=%.1f%s"
+        surface path invalid_bytes entry_count elapsed suppressed_suffix
 
 let persistence_utf8_repair_stats () =
   Stdlib.Mutex.protect utf8_repair_mu (fun () ->

--- a/lib/keeper/keeper_types_profile.ml
+++ b/lib/keeper/keeper_types_profile.ml
@@ -518,10 +518,35 @@ let per_provider_timeout_of_toml ~(source : string)
     (doc : Keeper_toml_loader.toml_doc)
     (key : string)
     : per_provider_timeout_state * float option =
-  per_provider_timeout_of_declared_float_opt
-    ~source
-    ~declared:(List.mem_assoc key doc)
-    (Keeper_toml_loader.toml_float_opt doc key)
+  let declared = List.mem_assoc key doc in
+  let value = Keeper_toml_loader.toml_float_opt doc key in
+  if not declared then
+    Per_provider_timeout_unset, None
+  else
+    match value with
+    | None ->
+        let actual_type =
+          match List.assoc_opt key doc with
+          | Some (Keeper_toml_loader.Toml_float f) ->
+              Printf.sprintf "float(%f)" f
+          | Some (Keeper_toml_loader.Toml_int i) ->
+              Printf.sprintf "int(%d)" i
+          | Some (Keeper_toml_loader.Toml_string s) ->
+              Printf.sprintf "string(%s)" s
+          | Some (Keeper_toml_loader.Toml_bool b) ->
+              Printf.sprintf "bool(%b)" b
+          | Some (Keeper_toml_loader.Toml_string_array _) ->
+              "string_array"
+          | None -> "missing"
+        in
+        Log.Keeper.warn
+          "%s per_provider_timeout has invalid type (got %s); ignoring"
+          source actual_type;
+        Per_provider_timeout_invalid, None
+    | Some f ->
+        (match normalize_per_provider_timeout_opt ~source (Some f) with
+         | Some normalized -> Per_provider_timeout_set, Some normalized
+         | None -> Per_provider_timeout_invalid, None)
 ;;
 
 let per_provider_timeout_of_json_field ~(source : string)


### PR DESCRIPTION
## Summary

`/loop 10m` 시스템 로그 분석 사이클 3 결과입니다.

### UTF-8 repair rate-limiter instrumentation

- `lib/core/safe_ops.ml`: `record_utf8_repair`가 매 emit마다 `entries=N elapsed=X.X`를 로그에 포함
- 이유: 3일간 9,379회 WARN 중 97.4%(9,135회)가 60초 이내 재발생. 코드상 rate-limiter는 정상이나 운영 데이터와 충돌
- `entries`가 항상 ~0이면 state loss(Hashtbl reset). `elapsed`가 음수이면 NTP/VM time step
- 테스트 통과: `test_safe_ops.ml` 70/70 (prefix 기반 필터 유지)

### per_provider_timeout 타입 힌트

- `lib/keeper/keeper_types_profile.ml`: `per_provider_timeout_of_toml`이 실제 TOML 값 타입을 로그에 포함
- 이유: 5/5 14:34에 439회 집중 발생 후 소멸. 현재 TOML 파일은 `120.0` valid float
- 다음 재발생 시 `got float(120.0)`, `got string(30s)`, `got int(120)` 등으로 즉시 원인 파악

### Test plan
- [x] `test/test_safe_ops.ml` 70 tests pass
- [ ] 배포 후 system_log에서 `entries=` / `elapsed=` 패턴 확인
- [ ] 배포 후 `per_provider_timeout` WARN 재발생 시 actual_type 확인

### Note
- `test/test_keeper_toml.ml` 5개 실패는 persona resolver 테스트로, sandbox config 디렉토리 누락으로 인한 기존 문제(본 PR과 무관)