### PR TITLE
test: 누락된 회귀 테스트 4개 등록 (tool_agent + auth)

### DIFF
--- a/test/test_auth.ml
+++ b/test/test_auth.ml
@@ -1087,6 +1087,10 @@ let () =
         test_ensure_keeper_credential_uses_per_keeper_token;
       test_case "ensure_keeper_credential reuses uuid" `Quick
         test_ensure_keeper_credential_reuses_uuid;
+      test_case
+        "ensure_keeper_credential reuses persisted raw token when env mismatched"
+        `Quick
+        test_ensure_keeper_credential_reuses_persisted_raw_token_when_env_mismatched;
       test_case "ensure_keeper_credential archives dual-identity bare" `Quick
         test_ensure_keeper_credential_archives_dual_identity_bare;
       test_case "ensure_keeper_credential archives redirect stub bare" `Quick

--- a/test/test_tool_agent_coverage.ml
+++ b/test/test_tool_agent_coverage.ml
@@ -426,8 +426,13 @@ let () =
     ]);
     ("agent_update", [
       Alcotest.test_case "status update" `Quick test_agent_update_status;
+      Alcotest.test_case "capabilities update" `Quick test_agent_update_capabilities;
       Alcotest.test_case "no agents" `Quick test_agent_fitness_no_agents;
       Alcotest.test_case "specific agent" `Quick test_agent_fitness_specific;
+    ]);
+    ("get_metrics", [
+      Alcotest.test_case "no data returns not_found" `Quick test_get_metrics_no_data;
+      Alcotest.test_case "missing agent_name fails" `Quick test_get_metrics_missing_agent_name;
     ]);
     ("meta_cognition_snapshot", [
       Alcotest.test_case "detects beliefs tensions desires and edges" `Quick


### PR DESCRIPTION
## Summary

`let test_X () = ...` 로 정의되었지만 `Alcotest.run` list 에 등록되지 않은 테스트 4개를 등록합니다. **production code 는 손대지 않으며 test 등록만** 추가합니다.

| 파일 | 함수 | 검증 |
|------|------|------|
| `test/test_tool_agent_coverage.ml:204` | `test_agent_update_capabilities` | `handle_agent_update` 응답이 비어있지 않음 |
| `test/test_tool_agent_coverage.ml:215` | `test_get_metrics_no_data` | `error_code=\"not_found\"` + 메시지 contract |
| `test/test_tool_agent_coverage.ml:228` | `test_get_metrics_missing_agent_name` | `\"agent_name is required\"` 검증 |
| `test/test_auth.ml:726` | `test_ensure_keeper_credential_reuses_persisted_raw_token_when_env_mismatched` | credential 재사용 + file mode 0600 + agent_name 일치 (5 check) |

## 발견 경위

`test/` 전수 인벤토리 (735 `test_*.ml` + 198 `stanzas/*.inc`) 중 자동 검출 가능한 진짜 dead test 함수가 정확히 4개. 모두 의미 있는 회귀 검증인데 등록 누락된 케이스. 자동 검출 방법:

- top-level `let test_<name> () = ...` 정의 추출
- 같은 파일 + 다른 파일 안에서 bare identifier reference 카운트
- 정의 site 외 reference 0인 함수만 picked

`test_operator_control_*` 7-module group (66 funcs) 도 검사했지만 모두 entry point 에서 호출됨 → 그쪽은 0 dead.

## Local 검증

```
test/test_tool_agent_coverage.exe : 25 tests run, 24 OK + 1 unrelated FAIL
  - 24 OK 안에 capabilities update / no data returns not_found / missing agent_name fails 모두 통과
  - 1 FAIL: meta_cognition_snapshot \"detects beliefs tensions...\" stagnation_score
    이 테스트는 본 PR 변경과 무관 (라인 263 정의, 변경 없음).
    main 의 최근 CI run 도 동일 fail 영역이라 pre-existing 으로 추정.
test/test_auth.exe                : 45 tests run, all OK
```

빌드: `opam exec -- dune build test/test_tool_agent_coverage.exe test/test_auth.exe --root .` (worktree 격리)

## Out of Scope

- production code 변경 0줄
- 다른 dead helper 정리는 본 PR 에 포함 안 함 (Surgical Changes)
- `test_agent_update` 그룹의 `test_agent_fitness_*` 라벨 mismatch 는 이번에 손대지 않음

## RFC

- 변경 영역: `test/test_auth.ml` (credential 영역) + `test/test_tool_agent_coverage.ml` (agent dispatch 영역)
- 관련 RFC: RFC-0008 (credential-provider) — auth credential 재사용 contract 검증 추가
- production credential / identity logic 변경 없음 → 본 PR 은 spec 검증의 활성화에 한정

`RFC-WAIVED: test-only registration, no production code change. RFC-0008 covers the contract being verified.`

## Test Plan

- [x] `dune build test/test_tool_agent_coverage.exe --root .`
- [x] `dune build test/test_auth.exe --root .`
- [x] tool_agent_coverage: 새 3 case (capabilities update, get_metrics × 2) PASS
- [x] auth: 새 1 case (reuses persisted raw token) PASS
- [ ] CI quick suite green (또는 main baseline 과 동일 fail 패턴)
- [ ] human-approved-ready 라벨 후 ready_for_review

🤖 Generated with [Claude Code](https://claude.com/claude-code)