### PR TITLE
fix(dashboard): show offline keepers in cascade assignment and fix config save

### DIFF
--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -2306,7 +2306,7 @@ export function patchKeeperConfig(
   name: string,
   payload: KeeperConfigUpdatePayload,
 ): Promise<KeeperConfig> {
-  return patch<unknown>(
+  return post<unknown>(
     `/api/v1/keepers/${encodeURIComponent(name)}/config`,
     payload,
   ).then(raw => normalizeKeeperConfig(raw, name))

--- a/lib/dashboard_cascade.ml
+++ b/lib/dashboard_cascade.ml
@@ -235,6 +235,24 @@ let config_json () =
     | Eio.Cancel.Cancelled _ as e -> raise e
     | _ -> []
   in
+  let active_names =
+    List.fold_left (fun acc (e : Keeper_registry.registry_entry) -> StringSet.add e.name acc) StringSet.empty keeper_entries
+  in
+  let offline_keepers_json =
+    try
+      Config_dir_resolver.keepers_dir ()
+      |> Keeper_types_profile.discover_keepers_toml
+      |> List.filter_map (fun (name, doc) ->
+             if StringSet.mem name active_names then None
+             else
+               let cascade_name =
+                 match doc.Keeper_types_profile.cascade_name with
+                 | Some c -> c
+                 | None -> "default"
+               in
+               Some (`Assoc (keeper_profile_fields ~keeper:name ~cascade_name)))
+    with _ -> []
+  in
   let profiles =
     match Cascade_catalog_runtime.known_profile_names () with
     | Ok names ->
@@ -279,7 +297,7 @@ let config_json () =
     @ validation_summary_json ?config_path ()
     @ [
         ("profiles", `List profiles);
-        ("keeper_profiles", `List (List.map keeper_profile_json keeper_entries));
+        ("keeper_profiles", `List (List.map keeper_profile_json keeper_entries @ offline_keepers_json));
       ]
   in
   `Assoc fields

--- a/test/test_failing_minimum_essential.ml
+++ b/test/test_failing_minimum_essential.ml
@@ -14,7 +14,7 @@
     4. Non-empty (TLA+ ToolSetNeverEmpty). *)
 
 let test_includes_shard_floor () =
-  let names = Keeper_tool_policy.failing_minimum_tool_names () in
+  let names = Masc_mcp.Keeper_tool_policy.failing_minimum_tool_names () in
   let assert_includes tool =
     Alcotest.(check bool)
       (Printf.sprintf "%s in shard floor" tool) true (List.mem tool names)
@@ -26,7 +26,7 @@ let test_includes_shard_floor () =
   assert_includes "keeper_tools_list"
 
 let test_includes_essential_masc () =
-  let names = Keeper_tool_policy.failing_minimum_tool_names () in
+  let names = Masc_mcp.Keeper_tool_policy.failing_minimum_tool_names () in
   let assert_includes tool =
     Alcotest.(check bool)
       (Printf.sprintf "%s in essential masc" tool) true (List.mem tool names)
@@ -37,13 +37,13 @@ let test_includes_essential_masc () =
   assert_includes "masc_approval_pending"
 
 let test_no_duplicates () =
-  let names = Keeper_tool_policy.failing_minimum_tool_names () in
+  let names = Masc_mcp.Keeper_tool_policy.failing_minimum_tool_names () in
   let sorted = List.sort_uniq String.compare names in
   Alcotest.(check int) "no duplicates after union"
     (List.length sorted) (List.length names)
 
 let test_nonempty () =
-  let names = Keeper_tool_policy.failing_minimum_tool_names () in
+  let names = Masc_mcp.Keeper_tool_policy.failing_minimum_tool_names () in
   Alcotest.(check bool) "non-empty (TLA+ ToolSetNeverEmpty)"
     true (names <> [])
 
@@ -59,7 +59,7 @@ let test_essential_masc_ssot_matches_toml () =
   Alcotest.(check (list string))
     "essential_masc_minimum_names mirrors [masc.essential] toml group"
     expected
-    Keeper_tool_policy.essential_masc_minimum_names
+    Masc_mcp.Keeper_tool_policy.essential_masc_minimum_names
 
 let () =
   Alcotest.run "failing_minimum_essential" [


### PR DESCRIPTION
- Surface offline keepers from TOML configurations in `config.keeper_profiles` so the cascade UI accurately reflects assignment status even when keepers are not actively running.
- Fix "save runtime config" and "edit prompt" ghost buttons in the keeper config panel by correctly routing the API call as `POST` instead of `PATCH` to match the OCaml backend.
- Fix `Unbound module Keeper_tool_policy` compilation error in `test_failing_minimum_essential.ml` by fully qualifying the module path with `Masc_mcp`.
