### PR TITLE
ci(ocamlformat): add changed-files format check

### DIFF
--- a/.github/workflows/ocamlformat.yml
+++ b/.github/workflows/ocamlformat.yml
@@ -1,0 +1,75 @@
+name: ocamlformat (changed files)
+
+on:
+  pull_request:
+    paths:
+      - '**/*.ml'
+      - '**/*.mli'
+      - '.ocamlformat'
+      - '.github/workflows/ocamlformat.yml'
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  ocamlformat-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout PR
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up OCaml
+        uses: ocaml/setup-ocaml@v3
+        with:
+          ocaml-compiler: '5.2'
+
+      - name: Install ocamlformat
+        run: |
+          version=$(grep -E '^version' .ocamlformat | head -1 | awk -F= '{gsub(/[ \t]/,"",$2); print $2}')
+          if [ -z "$version" ]; then
+            echo "::error::no version pin in .ocamlformat"
+            exit 1
+          fi
+          opam install -y "ocamlformat.${version}"
+
+      - name: Identify changed OCaml files
+        id: changed
+        run: |
+          set -euo pipefail
+          base="${{ github.event.pull_request.base.sha }}"
+          head="${{ github.event.pull_request.head.sha }}"
+          if ! git cat-file -e "$base" 2>/dev/null; then
+            git fetch --no-tags --depth=1 origin "$base" || true
+          fi
+          files=$(git diff --name-only --diff-filter=AMR "$base...$head" -- '*.ml' '*.mli' || true)
+          if [ -z "$files" ]; then
+            echo "no_files=true" >> "$GITHUB_OUTPUT"
+            echo "No OCaml files changed in this PR; skipping ocamlformat check."
+          else
+            printf '%s\n' "$files" > /tmp/changed-ocaml-files.txt
+            echo "no_files=false" >> "$GITHUB_OUTPUT"
+            echo "Changed OCaml files:"
+            cat /tmp/changed-ocaml-files.txt
+          fi
+
+      - name: Check formatting (changed files only)
+        if: steps.changed.outputs.no_files != 'true'
+        run: |
+          set -euo pipefail
+          violations=0
+          while IFS= read -r f; do
+            [ -z "$f" ] && continue
+            [ -f "$f" ] || continue
+            if ! opam exec -- ocamlformat --check "$f" >/dev/null 2>&1; then
+              echo "::error file=$f::ocamlformat violation. Local fix: opam exec -- ocamlformat -i $f"
+              violations=$((violations+1))
+            fi
+          done < /tmp/changed-ocaml-files.txt
+          if [ "$violations" -gt 0 ]; then
+            echo "::error::$violations file(s) violate ocamlformat ($(opam exec -- ocamlformat --version))"
+            exit 1
+          fi
+          echo "All changed OCaml files match ocamlformat profile."


### PR DESCRIPTION
## 목표

리포지토리에 `.ocamlformat` (`version=0.29.0`, `profile=janestreet`) 이 이미 핀되어 있으나 CI gate 가 없어, 키퍼/사람 PR이 포맷 드리프트를 silent 하게 누적하고 있습니다. 본 PR은 **변경된 `.ml`/`.mli` 파일에만** `ocamlformat --check` 를 적용하는 좁은 첫 게이트를 추가합니다.

## 범위 (의도적으로 좁게)

- `pull_request` 트리거만 (main push 시 트리거 X)
- `paths` 필터: `**/*.ml`, `**/*.mli`, `.ocamlformat`, 본 워크플로 자체
- 변경 파일 한정 (`git diff base..head`) — fleet-wide rewrite 회피, 진행 중인 100+ PR 과 rebase 폭탄 방지
- 위반 시 inline annotation + 로컬 fix 명령 (`opam exec -- ocamlformat -i <file>`)
- ocamlformat 버전은 `.ocamlformat` 의 pin 을 그대로 사용 (drift 없음)

## 검증 (로컬)

- 로컬 `python3 -c \"import yaml; yaml.safe_load(...)\"` — YAML lint 통과
- 로컬 `ocamlformat --version` = `0.29.0` (pin과 일치)
- workflow 자체 변경만 포함된 PR 은 \"no_files\" 분기로 skip 됨 — 자기 자신은 트리거되지 않음

## 후속 (별도 PR)

이 gate 가 첫 incremental 위반을 한 번 잡은 뒤, 트리 전체 일괄 포맷을 별도 PR 로 진행합니다 (지금 일괄 변환 시 머지 충돌 폭탄).

## Best Programmer self-review

- 목표: 새로운 CI gate 1 개 추가, 기존 코드 영향 0
- 변경 파일: `.github/workflows/ocamlformat.yml` (75 LOC, 신규 1 파일)
- 로컬 검증: YAML 파싱 OK, ocamlformat 0.29.0 가용 확인
- 미검증: 실제 GitHub Actions 실행 결과 (PR open 후 첫 실행에서 확인 예정)

## 안전 가드

- `.github/workflows/` 는 `agent_delegation` RFC 영역 밖
- workflow 변경 외 코드 0 줄 변경 — main blocker 위험 없음
- Draft 유지, `human-approved-ready` 라벨 대기