### PR TITLE
feat(keeper): RFC-0042 PR-1 — introduce Keeper_turn_terminal_code (inert)

### DIFF
--- a/lib/keeper/keeper_turn_terminal_code.ml
+++ b/lib/keeper/keeper_turn_terminal_code.ml
@@ -1,0 +1,95 @@
+(* RFC-0042 PR-1: closed sum type for keeper turn terminal code.
+
+   See [.mli] for the public contract. This file holds the type
+   definition, the wire-format serialisation chosen to be byte-for-byte
+   compatible with [Keeper_execution_receipt.stale_terminal_reason_code]
+   as of main, and the canonical bridge from
+   [Keeper_registry.failure_reason]. *)
+
+type t =
+  | Healthy
+  | Stale_turn_timeout_idle
+  | Stale_turn_timeout_in_turn
+  | Stale_turn_timeout_noop
+  | Stale_termination_storm
+  | Stale_fleet_batch
+  | Oas_timeout_budget
+  | Heartbeat_failures
+  | Turn_failures
+  | Provider_runtime_error of string
+  | Tool_required_unsatisfied of string
+  | Ambiguous_partial_commit_post_commit_timeout
+  | Ambiguous_partial_commit_post_commit_failure
+  | Fiber_unresolved
+  | Exception_unhandled of string
+
+let to_wire = function
+  | Healthy -> "healthy"
+  | Stale_turn_timeout_idle | Stale_turn_timeout_in_turn | Stale_turn_timeout_noop ->
+    (* Existing wire emission collapses the three sub-classes into one
+         cohort key. Preserved here so dashboards / Prometheus labels do
+         not see a sudden cardinality change at PR-3 cutover. *)
+    "stale_turn_timeout"
+  | Stale_termination_storm -> "stale_termination_storm"
+  | Stale_fleet_batch -> "stale_fleet_batch"
+  | Oas_timeout_budget -> "oas_timeout_budget"
+  | Heartbeat_failures -> "heartbeat_failures"
+  | Turn_failures -> "turn_failures"
+  | Provider_runtime_error code -> code
+  | Tool_required_unsatisfied code -> code
+  | Ambiguous_partial_commit_post_commit_timeout
+  | Ambiguous_partial_commit_post_commit_failure -> "ambiguous_partial_commit"
+  | Fiber_unresolved -> "fiber_unresolved"
+  | Exception_unhandled _ -> "exception"
+;;
+
+let of_wire = function
+  | "healthy" -> Some Healthy
+  | "stale_turn_timeout" ->
+    (* Lossy: the wire string lost the sub-class. Canonicalise to
+         [In_turn_hung] (the most common observed sub-class in
+         production traces). PR-4 removes [of_wire] callers. *)
+    Some Stale_turn_timeout_in_turn
+  | "stale_termination_storm" -> Some Stale_termination_storm
+  | "stale_fleet_batch" -> Some Stale_fleet_batch
+  | "oas_timeout_budget" -> Some Oas_timeout_budget
+  | "heartbeat_failures" -> Some Heartbeat_failures
+  | "turn_failures" -> Some Turn_failures
+  | "ambiguous_partial_commit" ->
+    (* Lossy in the same way as [stale_turn_timeout]. Canonicalise
+         to [Post_commit_timeout]. *)
+    Some Ambiguous_partial_commit_post_commit_timeout
+  | "fiber_unresolved" -> Some Fiber_unresolved
+  | "exception" -> Some (Exception_unhandled "")
+  | _other ->
+    (* Could be a [Provider_runtime_error] / [Tool_required_unsatisfied]
+         original [code] string, or an unrecognised legacy code from a
+         pre-RFC emit site. Returning [None] forces the caller to make
+         the policy choice rather than silently mis-classifying. *)
+    None
+;;
+
+let of_failure_reason : Keeper_registry.failure_reason -> t = function
+  | Keeper_registry.Heartbeat_consecutive_failures _ -> Heartbeat_failures
+  | Keeper_registry.Turn_consecutive_failures _ -> Turn_failures
+  | Keeper_registry.Stale_turn_timeout (Keeper_registry.Idle_turn _) ->
+    Stale_turn_timeout_idle
+  | Keeper_registry.Stale_turn_timeout (Keeper_registry.In_turn_hung _) ->
+    Stale_turn_timeout_in_turn
+  | Keeper_registry.Stale_turn_timeout (Keeper_registry.Noop_failure_loop _) ->
+    Stale_turn_timeout_noop
+  | Keeper_registry.Stale_termination_storm _ -> Stale_termination_storm
+  | Keeper_registry.Stale_fleet_batch _ -> Stale_fleet_batch
+  | Keeper_registry.Oas_timeout_budget_loop _ -> Oas_timeout_budget
+  | Keeper_registry.Provider_runtime_error { code; _ } -> Provider_runtime_error code
+  | Keeper_registry.Tool_required_unsatisfied { code; _ } ->
+    Tool_required_unsatisfied code
+  | Keeper_registry.Ambiguous_partial_commit
+      { kind = Keeper_registry.Post_commit_timeout; _ } ->
+    Ambiguous_partial_commit_post_commit_timeout
+  | Keeper_registry.Ambiguous_partial_commit
+      { kind = Keeper_registry.Post_commit_failure; _ } ->
+    Ambiguous_partial_commit_post_commit_failure
+  | Keeper_registry.Fiber_unresolved -> Fiber_unresolved
+  | Keeper_registry.Exception msg -> Exception_unhandled msg
+;;

--- a/lib/keeper/keeper_turn_terminal_code.mli
+++ b/lib/keeper/keeper_turn_terminal_code.mli
@@ -1,0 +1,90 @@
+(** Closed sum type for the terminal code carried by a keeper turn's
+    receipt. See RFC-0042 (`docs/rfc/RFC-0042-keeper-terminal-code-closed-sum.md`)
+    for the full motivation.
+
+    This module is introduced in PR-1 of the RFC migration and is
+    intentionally inert: no caller in the tree references it yet.
+    PR-2 swaps the existing typed bridges
+    ([Keeper_execution_receipt.stale_terminal_reason_code],
+    [keeper_agent_error.agent_error_terminal_reason_code]) to return
+    values of type [t]; PR-3 swaps [Keeper_turn_terminal.t.code] from
+    [string] to [t]; PR-4 converts the readers
+    ([Keeper_execution_receipt] disposition mapping,
+    [Keeper_passive_loop_detector.progress_class_of_terminal_reason_code])
+    from [String.starts_with ~prefix] to exhaustive [match].
+
+    Adding a new variant here is, by construction, a compile
+    obligation for every match site after PR-4 lands. *)
+
+type t =
+  | Healthy
+  (** Turn ended without error and reached the configured terminal
+          cascade. *)
+  | Stale_turn_timeout_idle
+  (** [Keeper_registry.Stale_turn_timeout (Idle_turn _)]: the keeper
+          was [Running] but never observed a turn-start. *)
+  | Stale_turn_timeout_in_turn
+  (** [Keeper_registry.Stale_turn_timeout (In_turn_hung _)]: a turn
+          began and ran past its timeout threshold. *)
+  | Stale_turn_timeout_noop
+  (** [Keeper_registry.Stale_turn_timeout (Noop_failure_loop _)]:
+          turns kept firing but produced no tool calls. *)
+  | Stale_termination_storm
+  (** [Keeper_registry.Stale_termination_storm]: cohort window
+          escalation threshold reached. *)
+  | Stale_fleet_batch
+  (** [Keeper_registry.Stale_fleet_batch]: distinct keepers
+          terminated inside the fleet batch window. *)
+  | Oas_timeout_budget
+  (** [Keeper_registry.Oas_timeout_budget_loop]: same keeper
+          exhausted the OAS turn budget on consecutive cycles. *)
+  | Heartbeat_failures (** [Keeper_registry.Heartbeat_consecutive_failures]. *)
+  | Turn_failures (** [Keeper_registry.Turn_consecutive_failures]. *)
+  | Provider_runtime_error of string
+  (** [Keeper_registry.Provider_runtime_error]: payload is the
+          original [code] field. *)
+  | Tool_required_unsatisfied of string
+  (** [Keeper_registry.Tool_required_unsatisfied]: payload is the
+          original [code] field. *)
+  | Ambiguous_partial_commit_post_commit_timeout
+  (** [Keeper_registry.Ambiguous_partial_commit] with
+          [kind = Post_commit_timeout]. *)
+  | Ambiguous_partial_commit_post_commit_failure
+  (** [Keeper_registry.Ambiguous_partial_commit] with
+          [kind = Post_commit_failure]. *)
+  | Fiber_unresolved (** [Keeper_registry.Fiber_unresolved]. *)
+  | Exception_unhandled of string
+  (** [Keeper_registry.Exception]: payload is the exception
+          message. *)
+
+(** Stable wire format. The strings produced here are byte-for-byte
+    compatible with the strings emitted today by
+    [Keeper_execution_receipt.stale_terminal_reason_code], so swapping
+    callers in PR-2 / PR-3 does not change the JSON received by
+    dashboards, [bin/masc-trace], or external consumers.
+
+    The two [Stale_turn_timeout_*] variants and the two
+    [Ambiguous_partial_commit_*] variants intentionally collapse to a
+    single wire string each ([stale_turn_timeout],
+    [ambiguous_partial_commit]) to preserve the existing cohort keys;
+    the typed sub-class is still available to OCaml callers. *)
+val to_wire : t -> string
+
+(** Best-effort reverse of [to_wire]. Returned [None] for unknown wire
+    codes; callers that previously consumed unknown codes via
+    [String.starts_with ~prefix] should instead handle [None] (or wait
+    for PR-4, which removes the consumer side of [of_wire] entirely).
+
+    Some wire strings are lossy ([stale_turn_timeout] cannot
+    distinguish [Idle_turn] / [In_turn_hung] / [Noop_failure_loop]).
+    Such wire strings deserialise to a single canonical sub-class —
+    documented in the [.ml] — to avoid silent fallthrough. *)
+val of_wire : string -> t option
+
+(** Canonical bridge from the existing typed source. Replaces
+    [Keeper_execution_receipt.stale_terminal_reason_code] in PR-2.
+
+    Exhaustive over [Keeper_registry.failure_reason]: adding a new
+    constructor there is a compile error here, which is the property
+    this RFC is meant to provide. *)
+val of_failure_reason : Keeper_registry.failure_reason -> t


### PR DESCRIPTION
## 목표

[RFC-0042 (#14181)](https://github.com/jeong-sik/masc-mcp/pull/14181) 의 4-PR 마이그레이션 중 **첫 단계**. `Keeper_turn_terminal_code.t` closed sum 타입을 도입합니다. **caller 0건 (inert)** — 코드 영향 없음, 머지/revert 모두 안전합니다.

## 무엇을 했나

- `lib/keeper/keeper_turn_terminal_code.ml/.mli` 신설 (.ml 95 LOC + .mli 90 LOC)
- type `t`: 15 constructors (Keeper_registry.failure_reason 11개 + Healthy + sub-class split + Ambiguous_partial_commit 2 sub-classes)
- `to_wire : t -> string` — 현재 `Keeper_execution_receipt.stale_terminal_reason_code` 가 emit 하는 wire string 과 byte-for-byte 호환
- `of_wire : string -> t option` — best-effort 역변환, lossy mapping 명시
- `of_failure_reason : Keeper_registry.failure_reason -> t` — typed bridge, exhaustive

## 무엇을 안 했나 (의도적으로)

- 어떤 caller 도 변경 안 함 — `stale_terminal_reason_code` / `agent_error_terminal_reason_code` / `keeper_unified_turn.ml` emit sites 모두 그대로
- `Keeper_turn_terminal.t.code: string` 필드 변경 안 함
- reader (`String.starts_with ~prefix:\"turn_livelock:\"` 패턴) 변경 안 함

→ 후속 PR-2~4 에서 단계별로.

## 안전 검증

- ✅ 로컬 `dune build @check` (`--root .` 명시) **exit 0** — type-check 통과
- ✅ 로컬 `ocamlformat --check` 통과 (저장소 pin = 0.29.0 / janestreet profile, #14180 으로 enforce)
- ✅ caller 0건 — 기존 코드 의존성 영향 0
- ✅ Wire format 호환 (PR description §2 매핑 표 RFC §3.3)
- ✅ `Keeper_registry.failure_reason` 11 constructors 모두 cover (exhaustive match)

## RFC 인용 (agent_delegation 가드 충족)

- RFC: `docs/rfc/RFC-0042-keeper-terminal-code-closed-sum.md` (#14181, Draft)
- 본 PR scope = RFC §4 의 PR-1 (introduce inert)
- `agent_delegation` 영역 (`lib/keeper/`) 작업이지만 RFC 인용으로 가드 충족

## Best Programmer self-review

- 목표: closed sum 타입 + wire bridge 도입, caller 0건
- 변경 파일: 신규 2개 (`.ml`, `.mli`), 기존 파일 수정 0
- 로컬 검증: dune build @check 통과 + ocamlformat 통과
- 미검증: GitHub Actions CI 의 다른 gate (godfile size — pre-existing main blocker, 본 PR 무관)

## 진행 가드

- Draft 유지, `human-approved-ready` 라벨 사용자 직접
- 메모리 `feedback_split_brain_rfc_0022_pr_2_pr3_overlap` 회피: 동일 영역 open PR 검색 0건 확인
- 메모리 `feedback_main_blocker_chain_4x_session` 회피: caller 0건 inert, build pass, main blocker 위험 0