### PR TITLE
fix(dashboard): use runtime fallback for offline keeper cascade_name

### DIFF
--- a/lib/dashboard_cascade.ml
+++ b/lib/dashboard_cascade.ml
@@ -248,7 +248,7 @@ let config_json () =
                let cascade_name =
                  match doc.Keeper_types_profile.cascade_name with
                  | Some c -> c
-                 | None -> "default"
+                 | None -> Keeper_config.default_cascade_name
                in
                Some (`Assoc (keeper_profile_fields ~keeper:name ~cascade_name)))
     with _ -> []


### PR DESCRIPTION
Address review feedback by replacing hardcoded 'default' with
'Keeper_config.default_cascade_name' for offline keepers missing a
cascade_name in their TOML configuration, ensuring consistency with
runtime fallback behavior.
