### PR TITLE
fix(keeper): reset turn-livelock counter on keeper restart

### DIFF
--- a/lib/keeper/keeper_execution_receipt.ml
+++ b/lib/keeper/keeper_execution_receipt.ml
@@ -678,7 +678,7 @@ let emit_operator_broadcast config (receipt : t) ~disposition ~reason =
       ~payload
       ()
   in
-  Log.Keeper.info
+  Log.Keeper.error
     "%s: operator_broadcast_required emitted disposition=%s reason=%s seq=%d"
     receipt.keeper_name disposition reason event.seq
 

--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -386,6 +386,14 @@ let launch_supervised_fiber ~proactive_warmup_sec ctx (meta : keeper_meta)
            already fired on the body's happy/error paths. *)
         try
           Keeper_registry.cleanup_tracking ~base_path meta.name;
+          (* #14187 follow-up: a keeper that crashed after exhausting its
+             turn-livelock budget would restart into the same turn_id
+             (because blocked turns do not increment total_turns).  The
+             in-memory livelock state then immediately re-blocked the
+             fresh restart, making recovery impossible.  Clear the
+             per-keeper livelock bookkeeping during cleanup so the next
+             restart starts with a fresh counter. *)
+          Keeper_turn_livelock.reset_keeper_livelock ~keeper:meta.name;
           if not !resolved then begin
             if Shutdown.is_shutting_down_global () then begin
               Log.Keeper.warn "%s: fiber unresolved during shutdown (not a crash)" meta.name;

--- a/lib/keeper/keeper_turn_livelock.ml
+++ b/lib/keeper/keeper_turn_livelock.ml
@@ -39,6 +39,14 @@ let state : (string, attempt_state) Hashtbl.t = Hashtbl.create 16
 let reset_for_tests () =
   Eio.Mutex.use_rw ~protect:true mu (fun () -> Hashtbl.clear state)
 
+(** Remove the attempt state for a single keeper.  Called by the
+    supervisor when a keeper fiber is cleaned up after a crash so
+    that the next restart begins with a fresh counter rather than
+    inheriting the previous stuck turn's exhaustion. *)
+let reset_keeper_livelock ~(keeper : string) : unit =
+  Eio.Mutex.use_rw ~protect:true mu (fun () ->
+    Hashtbl.remove state keeper)
+
 (** [start_outcome] records what happened on a [record_turn_start]
     call.  Returned so callers (tests, future gating logic) don't
     have to re-derive the classification from external data. *)

--- a/lib/keeper/keeper_turn_livelock.mli
+++ b/lib/keeper/keeper_turn_livelock.mli
@@ -73,3 +73,9 @@ val seconds_since_first_attempt : keeper:string -> float option
 (** Reset the in-memory state.  Intended for unit tests; the live
     server resets state implicitly on process restart. *)
 val reset_for_tests : unit -> unit
+
+(** Remove the attempt state for a single keeper.  Called by the
+    supervisor when a keeper fiber is cleaned up after a crash so
+    that the next restart begins with a fresh counter rather than
+    inheriting the previous stuck turn's exhaustion. *)
+val reset_keeper_livelock : keeper:string -> unit


### PR DESCRIPTION
## Summary

When a keeper crashes after exhausting its turn-livelock budget (3 attempts by default), the supervisor restarts it into the same `turn_id` because blocked turns do not increment `total_turns`. The in-memory `Keeper_turn_livelock` state then immediately re-blocked the fresh restart, making recovery impossible.

## Root Cause

`Keeper_turn_livelock` stores per-keeper attempt counts in a process-local `Hashtbl.t` keyed by keeper name. The classification logic (`classify_and_update_start`, line 109-131) treats the same `turn_id` as a **Reattempt**, incrementing the counter. When a blocked turn never advances `total_turns`, the counter stays at `attempts=3` across restarts.

Log evidence (sangsu):
```
restart (attempt 1) → livelock blocked 3/3 immediately
restart (attempt 2) → livelock blocked 3/3 immediately
restart (attempt 3) → tool_required_unsatisfied → pause
```

## Fix

1. **`lib/keeper/keeper_turn_livelock.ml`**: Add `reset_keeper_livelock ~keeper` — removes the keeper's entry from the in-memory state.
2. **`lib/keeper/keeper_supervisor.ml`**: Call `reset_keeper_livelock` in the `finally` cleanup block after a crash, so the next restart starts with `attempts=1` (Fresh).
3. **`lib/keeper/keeper_execution_receipt.ml`**: Promote `operator_broadcast_required` from `Log.Keeper.info` to `Log.Keeper.error` so pause/alert events are visible in ERROR-level monitoring.

## Verification

- `dune build --root . lib/keeper/ test/` — pass
- `dune exec test/test_keeper_sub_fsm_guards.exe` — 10/10 pass

## Files Changed

| File | Action |
|------|--------|
| `lib/keeper/keeper_turn_livelock.ml` | Add `reset_keeper_livelock ~keeper` |
| `lib/keeper/keeper_turn_livelock.mli` | Expose new API |
| `lib/keeper/keeper_supervisor.ml` | Call reset in `finally` cleanup block |
| `lib/keeper/keeper_execution_receipt.ml` | `Log.Keeper.info` → `Log.Keeper.error` |

## Related

- PR #14187 (cascade FSM fix) — same incident, different axis
- Issue #10121 (original livelock observability)

RFC-WAIVED: keeper subsystem livelock fix; no credential/identity/sandbox/operator/hook/workflow scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)