### PR TITLE
feat(metrics): register 11 keeper metrics previously missing from init()

### DIFF
--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -2351,6 +2351,31 @@ let init () =
     "Recurring task execution/dispatch failures. Labels: task, phase." Counter;
   add Keeper_metrics.metric_keeper_turn_cleanup_failures
     "Turn cleanup failures (unsubscribe event_bus, mark_turn_finished). Labels: keeper, site." Counter;
+  (* === Keeper metrics previously unregistered in init() ===
+     These were auto-registered on first inc_counter call with no HELP text.
+     Explicit registration adds proper documentation. *)
+  add Keeper_metrics.metric_keeper_fsm_edge_transitions
+    "Keeper FSM edge transitions across lifecycle states. Labels: edge." Counter;
+  add Keeper_metrics.metric_keeper_invariant_violations
+    "Keeper composite lifecycle invariant violations. Labels: keeper, invariant." Counter;
+  add Keeper_metrics.metric_keeper_metric_emit_dropped
+    "Keeper metric emit attempts dropped (buffer full / unregistered). Labels: keeper, reason." Counter;
+  add Keeper_metrics.metric_keeper_oas_timeout_budget_strike
+    "OAS timeout budget strikes (consecutive timeouts before escalation). Labels: keeper." Counter;
+  add Keeper_metrics.metric_keeper_path_rejection
+    "Keeper path rejections (sandbox escape / outside roots). Labels: kind." Counter;
+  add Keeper_metrics.metric_keeper_provider_cooldown_remaining_sec
+    "Provider cooldown remaining seconds. Labels: keeper, provider." Gauge;
+  add Keeper_metrics.metric_keeper_provider_cooldown_skip
+    "Provider cooldown skips (fallback cascade used while cooling). Labels: keeper, provider." Counter;
+  add Keeper_metrics.metric_keeper_require_tool_use_violations
+    "Tool contract require_tool_use violations. Labels: keeper, contract_status." Counter;
+  add Keeper_metrics.metric_keeper_semaphore_wait_seconds_bucket
+    "Keeper turn semaphore wait duration buckets (le label)." Counter;
+  add Keeper_metrics.metric_keeper_semaphore_wait_timeout
+    "Keeper turn semaphore wait timeouts. Labels: keeper, channel." Counter;
+  add Keeper_metrics.metric_keeper_turn_fsm_transitions
+    "Keeper turn FSM state transitions. Labels: keeper, from, to." Counter;
   add metric_mention_dedup_decisions_total
     "RFC-0040 sender-side mention dedup decisions. Labels: outcome={skipped|passed|no_target|bypassed}." Counter;
   add metric_grpc_active_streams "Active gRPC bidirectional streams" Gauge;

--- a/test/test_cascade_health_tracker.ml
+++ b/test/test_cascade_health_tracker.ml
@@ -13,11 +13,11 @@ let kind value = H.error_kind_of_string value
 let provider_block_metric_labels provider_key = [("provider", provider_key)]
 
 let provider_block_duration_sum provider_key =
-  P.metric_value_or_zero P.metric_keeper_provider_block_duration_sec
+  P.metric_value_or_zero Masc_mcp.Keeper_metrics.metric_keeper_provider_block_duration_sec
     ~labels:(provider_block_metric_labels provider_key) ()
 
 let provider_block_duration_count provider_key =
-  P.metric_value_or_zero (P.metric_keeper_provider_block_duration_sec ^ "_count")
+  P.metric_value_or_zero (Masc_mcp.Keeper_metrics.metric_keeper_provider_block_duration_sec ^ "_count")
     ~labels:(provider_block_metric_labels provider_key) ()
 
 let test_record_success_keeps_rate_1 () =

--- a/test/test_context_max_observed_9953.ml
+++ b/test/test_context_max_observed_9953.ml
@@ -36,7 +36,7 @@ let () =
 module UM = Masc_mcp.Keeper_unified_metrics
 module Prom = Masc_mcp.Prometheus
 
-let metric = Prom.metric_keeper_context_max_observed
+let metric = Masc_mcp.Keeper_metrics.metric_keeper_context_max_observed
 
 let counter_for ~keeper ~model_used ~resolved_model_id ~bucket =
   Prom.metric_value_or_zero metric

--- a/test/test_dashboard_execution.ml
+++ b/test/test_dashboard_execution.ml
@@ -935,7 +935,7 @@ let test_patch_keeper_dependent_caches_tolerates_null_agent () =
 
 let callback_metric_value callback =
   Lib.Prometheus.metric_value_or_zero
-    Lib.Keeper_metrics.metric_keeper_lifecycle_callback_failures
+    Masc_mcp.Keeper_metrics.metric_keeper_lifecycle_callback_failures
     ~labels:[ ("callback", callback) ]
     ()
 

--- a/test/test_dashboard_governance_metrics.ml
+++ b/test/test_dashboard_governance_metrics.ml
@@ -71,7 +71,7 @@ let test_record_failure_is_metric_visible () =
   in
   let before =
     P.metric_value_or_zero
-      P.metric_keeper_lifecycle_callback_failures
+      Masc_mcp.Keeper_metrics.metric_keeper_lifecycle_callback_failures
       ~labels
       ()
   in
@@ -82,7 +82,7 @@ let test_record_failure_is_metric_visible () =
     ~reason_code:"policy";
   let after =
     P.metric_value_or_zero
-      P.metric_keeper_lifecycle_callback_failures
+      Masc_mcp.Keeper_metrics.metric_keeper_lifecycle_callback_failures
       ~labels
       ()
   in

--- a/test/test_keeper_agent_memory_episode_activity.ml
+++ b/test/test_keeper_agent_memory_episode_activity.ml
@@ -59,7 +59,7 @@ let with_activity_emit fn f =
 
 let read_failure ~keeper ~outcome =
   P.metric_value_or_zero
-    P.metric_keeper_memory_activity_emit_failures
+    Masc_mcp.Keeper_metrics.metric_keeper_memory_activity_emit_failures
     ~labels:[("keeper", keeper); ("outcome", outcome)]
     ()
 

--- a/test/test_keeper_callback_hardening.ml
+++ b/test/test_keeper_callback_hardening.ml
@@ -25,24 +25,24 @@ let test_lifecycle_callback_metric_name () =
   Alcotest.(check string)
     "lifecycle callback failures counter has the documented series name"
     "masc_keeper_lifecycle_callback_failures_total"
-    P.metric_keeper_lifecycle_callback_failures
+    Masc_mcp.Keeper_metrics.metric_keeper_lifecycle_callback_failures
 
 let test_event_bus_drain_metric_name () =
   Alcotest.(check string)
     "event-bus drain counter has the documented series name"
     "masc_keeper_event_bus_drain_total"
-    P.metric_keeper_event_bus_drain
+    Masc_mcp.Keeper_metrics.metric_keeper_event_bus_drain
 
 (* ── Counter mechanics — labels distinct and isolated ────── *)
 
 let read_lifecycle_failure ~callback =
   P.metric_value_or_zero
-    P.metric_keeper_lifecycle_callback_failures
+    Masc_mcp.Keeper_metrics.metric_keeper_lifecycle_callback_failures
     ~labels:[("callback", callback)] ()
 
 let read_keeper_hook_failure ~keeper ~callback =
   P.metric_value_or_zero
-    P.metric_keeper_lifecycle_callback_failures
+    Masc_mcp.Keeper_metrics.metric_keeper_lifecycle_callback_failures
     ~labels:[("keeper", keeper); ("callback", callback)] ()
 
 let test_lifecycle_callback_label_isolation () =
@@ -50,7 +50,7 @@ let test_lifecycle_callback_label_isolation () =
   let cb_b = "on_handoff_started" in
   let a_before = read_lifecycle_failure ~callback:cb_a in
   let b_before = read_lifecycle_failure ~callback:cb_b in
-  P.inc_counter P.metric_keeper_lifecycle_callback_failures
+  P.inc_counter Masc_mcp.Keeper_metrics.metric_keeper_lifecycle_callback_failures
     ~labels:[("callback", cb_a)] ();
   let a_after = read_lifecycle_failure ~callback:cb_a in
   let b_after = read_lifecycle_failure ~callback:cb_b in
@@ -66,7 +66,7 @@ let test_keeper_hook_label_shape_is_isolated () =
   let callback = "post_tool_log_write" in
   let keeper_before = read_keeper_hook_failure ~keeper ~callback in
   let lifecycle_before = read_lifecycle_failure ~callback in
-  P.inc_counter P.metric_keeper_lifecycle_callback_failures
+  P.inc_counter Masc_mcp.Keeper_metrics.metric_keeper_lifecycle_callback_failures
     ~labels:[("keeper", keeper); ("callback", callback)] ();
   let keeper_after = read_keeper_hook_failure ~keeper ~callback in
   let lifecycle_after = read_lifecycle_failure ~callback in
@@ -79,7 +79,7 @@ let test_keeper_hook_label_shape_is_isolated () =
 
 let read_drain ~site ~outcome =
   P.metric_value_or_zero
-    P.metric_keeper_event_bus_drain
+    Masc_mcp.Keeper_metrics.metric_keeper_event_bus_drain
     ~labels:[("site", site); ("outcome", outcome)] ()
 
 let test_drain_site_label_isolation () =
@@ -88,7 +88,7 @@ let test_drain_site_label_isolation () =
   let outcome = "empty" in
   let x_before = read_drain ~site:site_x ~outcome in
   let y_before = read_drain ~site:site_y ~outcome in
-  P.inc_counter P.metric_keeper_event_bus_drain
+  P.inc_counter Masc_mcp.Keeper_metrics.metric_keeper_event_bus_drain
     ~labels:[("site", site_x); ("outcome", outcome)] ();
   let x_after = read_drain ~site:site_x ~outcome in
   let y_after = read_drain ~site:site_y ~outcome in
@@ -103,7 +103,7 @@ let test_drain_outcome_label_distinction () =
   let site = "test_outcome_isolation" in
   let drained_before = read_drain ~site ~outcome:"drained" in
   let empty_before = read_drain ~site ~outcome:"empty" in
-  P.inc_counter P.metric_keeper_event_bus_drain
+  P.inc_counter Masc_mcp.Keeper_metrics.metric_keeper_event_bus_drain
     ~labels:[("site", site); ("outcome", "drained")] ();
   let drained_after = read_drain ~site ~outcome:"drained" in
   let empty_after = read_drain ~site ~outcome:"empty" in
@@ -138,7 +138,7 @@ let test_documented_callback_label_vocabulary () =
     ]
   in
   List.iter (fun label ->
-    P.inc_counter P.metric_keeper_lifecycle_callback_failures
+    P.inc_counter Masc_mcp.Keeper_metrics.metric_keeper_lifecycle_callback_failures
       ~labels:[("callback", label)] ();
     let v = read_lifecycle_failure ~callback:label in
     Alcotest.(check bool)
@@ -151,7 +151,7 @@ let test_documented_drain_outcome_vocabulary () =
   let documented_outcomes = ["drained"; "empty"] in
   let site = "vocab_check" in
   List.iter (fun outcome ->
-    P.inc_counter P.metric_keeper_event_bus_drain
+    P.inc_counter Masc_mcp.Keeper_metrics.metric_keeper_event_bus_drain
       ~labels:[("site", site); ("outcome", outcome)] ();
     let v = read_drain ~site ~outcome in
     Alcotest.(check bool)

--- a/test/test_keeper_compaction_noop_counter_9943.ml
+++ b/test/test_keeper_compaction_noop_counter_9943.ml
@@ -27,7 +27,7 @@ module Prom = Masc_mcp.Prometheus
 
 let noop_for ~keeper ~trigger =
   Prom.metric_value_or_zero
-    Prom.metric_keeper_compaction_noop
+    Masc_mcp.Keeper_metrics.metric_keeper_compaction_noop
     ~labels:[ ("keeper", keeper); ("trigger", trigger) ]
     ()
 
@@ -36,7 +36,7 @@ let noop_for ~keeper ~trigger =
    call, the dashboard would silently flatten this signal — pin
    the registration. *)
 let test_metric_registered () =
-  let _ = Prom.metric_total Prom.metric_keeper_compaction_noop in
+  let _ = Prom.metric_total Masc_mcp.Keeper_metrics.metric_keeper_compaction_noop in
   Alcotest.(check pass) "metric registered at init" () ()
 
 (* Direct increment using the same call shape
@@ -47,7 +47,7 @@ let test_counter_advances_for_noop_pattern () =
   let trigger = "context_overflow_imminent" in
   let before = noop_for ~keeper ~trigger in
   Prom.inc_counter
-    Prom.metric_keeper_compaction_noop
+    Masc_mcp.Keeper_metrics.metric_keeper_compaction_noop
     ~labels:[ ("keeper", keeper); ("trigger", trigger) ]
     ();
   Alcotest.(check (float 0.0001))
@@ -63,12 +63,12 @@ let test_distinct_triggers_separate_rows () =
   let before_overflow = noop_for ~keeper ~trigger:"context_overflow_imminent" in
   let before_proactive = noop_for ~keeper ~trigger:"proactive_warmup" in
   Prom.inc_counter
-    Prom.metric_keeper_compaction_noop
+    Masc_mcp.Keeper_metrics.metric_keeper_compaction_noop
     ~labels:[ ("keeper", keeper);
               ("trigger", "context_overflow_imminent") ]
     ();
   Prom.inc_counter
-    Prom.metric_keeper_compaction_noop
+    Masc_mcp.Keeper_metrics.metric_keeper_compaction_noop
     ~labels:[ ("keeper", keeper); ("trigger", "proactive_warmup") ]
     ();
   Alcotest.(check (float 0.0001)) "overflow row +1"
@@ -88,11 +88,11 @@ let test_per_keeper_isolation () =
   let trigger = "context_overflow_imminent" in
   let before_b = noop_for ~keeper:b ~trigger in
   Prom.inc_counter
-    Prom.metric_keeper_compaction_noop
+    Masc_mcp.Keeper_metrics.metric_keeper_compaction_noop
     ~labels:[ ("keeper", a); ("trigger", trigger) ]
     ();
   Prom.inc_counter
-    Prom.metric_keeper_compaction_noop
+    Masc_mcp.Keeper_metrics.metric_keeper_compaction_noop
     ~labels:[ ("keeper", a); ("trigger", trigger) ]
     ();
   Alcotest.(check (float 0.0001))
@@ -106,7 +106,7 @@ let test_prometheus_text_export () =
   let keeper = "test-keeper-compaction-noop-9943-export" in
   let trigger = "context_overflow_imminent" in
   Prom.inc_counter
-    Prom.metric_keeper_compaction_noop
+    Masc_mcp.Keeper_metrics.metric_keeper_compaction_noop
     ~labels:[ ("keeper", keeper); ("trigger", trigger) ]
     ();
   let text = Prom.to_prometheus_text () in
@@ -120,7 +120,7 @@ let test_prometheus_text_export () =
     loop 0
   in
   Alcotest.(check bool) "metric name in export"
-    true (contains text Prom.metric_keeper_compaction_noop);
+    true (contains text Masc_mcp.Keeper_metrics.metric_keeper_compaction_noop);
   Alcotest.(check bool) "keeper label key in export"
     true (contains text "keeper=");
   Alcotest.(check bool) "trigger label key in export"

--- a/test/test_keeper_fsm_edges.ml
+++ b/test/test_keeper_fsm_edges.ml
@@ -26,7 +26,7 @@
 module P = Masc_mcp.Prometheus
 
 let edge_label = "ksm_to_kcl_routing"
-let counter_name = P.metric_keeper_fsm_edge_transitions
+let counter_name = Masc_mcp.Keeper_metrics.metric_keeper_fsm_edge_transitions
 
 let read_edge_count edge =
   P.metric_value_or_zero counter_name ~labels:[("edge", edge)] ()

--- a/test/test_keeper_guards.ml
+++ b/test/test_keeper_guards.ml
@@ -234,7 +234,7 @@ let test_gate_observer_failure_counts_actual_keeper () =
   let keeper = (!meta_ref).name in
   let labels = [ ("keeper", keeper); ("site", "gate_observer") ] in
   let before =
-    P.metric_value_or_zero P.metric_keeper_guards_failures ~labels ()
+    P.metric_value_or_zero Masc_mcp.Keeper_metrics.metric_keeper_guards_failures ~labels ()
   in
   let on_gate_decision _event =
     raise (Failure "synthetic gate observer failure")
@@ -245,7 +245,7 @@ let test_gate_observer_failure_counts_actual_keeper () =
   let d = invoke hook (pre_tool_use_event ~tool_name:"dangerous_tool" ()) in
   check string "denied tool still overrides" "Override" (decision_kind d);
   let after =
-    P.metric_value_or_zero P.metric_keeper_guards_failures ~labels ()
+    P.metric_value_or_zero Masc_mcp.Keeper_metrics.metric_keeper_guards_failures ~labels ()
   in
   check (float 0.0001) "observer failure counted for keeper"
     (before +. 1.0) after

--- a/test/test_keeper_lifecycle.ml
+++ b/test/test_keeper_lifecycle.ml
@@ -388,7 +388,7 @@ let test_compaction_callback_failure_records_coverage_gap () =
       let labels = [ ("callback", "on_compaction_started") ] in
       let before =
         P.metric_value_or_zero
-          P.metric_keeper_lifecycle_callback_failures
+          Masc_mcp.Keeper_metrics.metric_keeper_lifecycle_callback_failures
           ~labels
           ()
       in
@@ -410,7 +410,7 @@ let test_compaction_callback_failure_records_coverage_gap () =
       check (float 0.0001) "callback failure metric increments"
         (before +. 1.0)
         (P.metric_value_or_zero
-           P.metric_keeper_lifecycle_callback_failures
+           Masc_mcp.Keeper_metrics.metric_keeper_lifecycle_callback_failures
            ~labels
            ());
       match TCG.read_recent ~masc_root:base_dir ~n:1 with
@@ -609,7 +609,7 @@ let test_handoff_callback_failure_records_coverage_gap () =
       let labels = [ ("callback", "on_handoff_started") ] in
       let before =
         P.metric_value_or_zero
-          P.metric_keeper_lifecycle_callback_failures
+          Masc_mcp.Keeper_metrics.metric_keeper_lifecycle_callback_failures
           ~labels
           ()
       in
@@ -632,7 +632,7 @@ let test_handoff_callback_failure_records_coverage_gap () =
       check (float 0.0001) "handoff callback failure metric increments"
         (before +. 1.0)
         (P.metric_value_or_zero
-           P.metric_keeper_lifecycle_callback_failures
+           Masc_mcp.Keeper_metrics.metric_keeper_lifecycle_callback_failures
            ~labels
            ());
       match TCG.read_recent ~masc_root:base_dir ~n:1 with

--- a/test/test_keeper_lifecycle_hooks.ml
+++ b/test/test_keeper_lifecycle_hooks.ml
@@ -48,7 +48,7 @@ let make_keeper_meta ~name ~trace_id =
 
 let lifecycle_hook_failure_count ~keeper =
   P.metric_value_or_zero
-    P.metric_keeper_lifecycle_callback_failures
+    Masc_mcp.Keeper_metrics.metric_keeper_lifecycle_callback_failures
     ~labels:
       [
         ("keeper", keeper);

--- a/test/test_keeper_long_turn_9943.ml
+++ b/test/test_keeper_long_turn_9943.ml
@@ -38,14 +38,14 @@ module Prom = Masc_mcp.Prometheus
 
 let bucket_count ~keeper ~bucket =
   Prom.metric_value_or_zero
-    Prom.metric_keeper_turn_latency_bucket
+    Masc_mcp.Keeper_metrics.metric_keeper_turn_latency_bucket
     ~labels:[ ("keeper", keeper); ("bucket", bucket) ]
     ()
 
 let model_bucket_count ~keeper ~channel ~provider_kind ~model_used
     ~resolved_model_id ~cascade_profile ~bucket =
   Prom.metric_value_or_zero
-    Prom.metric_keeper_turn_latency_by_model_bucket
+    Masc_mcp.Keeper_metrics.metric_keeper_turn_latency_by_model_bucket
     ~labels:
       [ ("keeper", keeper)
       ; ("channel", channel)

--- a/test/test_keeper_meta_unknown_keys_warn.ml
+++ b/test/test_keeper_meta_unknown_keys_warn.ml
@@ -17,7 +17,7 @@
 open Masc_mcp
 
 let counter_total () =
-  Prometheus.metric_total Keeper_metrics.metric_keeper_meta_json_failures
+  Prometheus.metric_total Masc_mcp.Keeper_metrics.metric_keeper_meta_json_failures
 
 let canonical_only_meta_json () =
   (* Build an `Assoc whose every key is in [canonical_keeper_meta_key_names].
@@ -75,12 +75,12 @@ let test_progress_updated_line_failure_is_observable () =
     Keeper_types.mkdir_p progress_path;
     let before =
       Prometheus.metric_total
-        Keeper_metrics.metric_keeper_progress_updated_line_failures
+        Masc_mcp.Keeper_metrics.metric_keeper_progress_updated_line_failures
     in
     Keeper_meta_store.refresh_progress_updated_line config keeper_name;
     let after =
       Prometheus.metric_total
-        Keeper_metrics.metric_keeper_progress_updated_line_failures
+        Masc_mcp.Keeper_metrics.metric_keeper_progress_updated_line_failures
     in
     Alcotest.(check bool)
       "progress Updated-line refresh failure increments counter"

--- a/test/test_keeper_passive_loop_detector.ml
+++ b/test/test_keeper_passive_loop_detector.ml
@@ -56,12 +56,12 @@ let test_required_tool_no_call_fires_metric_at_three () =
   in
   let before =
     P.metric_value_or_zero
-      P.metric_keeper_required_tool_loop_detected_total
+      Masc_mcp.Keeper_metrics.metric_keeper_required_tool_loop_detected_total
       ~labels ()
   in
   let zombie_before =
     P.metric_value_or_zero
-      P.metric_keeper_zombie_loop_detected_total
+      Masc_mcp.Keeper_metrics.metric_keeper_zombie_loop_detected_total
       ~labels:[("keeper_name", "k-required-no-call")]
       ()
   in
@@ -73,7 +73,7 @@ let test_required_tool_no_call_fires_metric_at_three () =
     (PLD.current_streak ~keeper_name:"k-required-no-call");
   check (float 0.001) "no metric before threshold" before
     (P.metric_value_or_zero
-       P.metric_keeper_required_tool_loop_detected_total
+       Masc_mcp.Keeper_metrics.metric_keeper_required_tool_loop_detected_total
        ~labels ());
   PLD.record_turn ~keeper_name:"k-required-no-call"
     ~progress_class:"required_tool_no_call";
@@ -82,12 +82,12 @@ let test_required_tool_no_call_fires_metric_at_three () =
   check (float 0.001) "required-tool metric increments once"
     (before +. 1.0)
     (P.metric_value_or_zero
-       P.metric_keeper_required_tool_loop_detected_total
+       Masc_mcp.Keeper_metrics.metric_keeper_required_tool_loop_detected_total
        ~labels ());
   check (float 0.001) "Observe zombie-loop metric increments once"
     (zombie_before +. 1.0)
     (P.metric_value_or_zero
-       P.metric_keeper_zombie_loop_detected_total
+       Masc_mcp.Keeper_metrics.metric_keeper_zombie_loop_detected_total
        ~labels:[("keeper_name", "k-required-no-call")]
        ())
 
@@ -141,12 +141,12 @@ let test_detection_fires_metric_at_threshold () =
   (* Default threshold is 5. Fire exactly 5 passive turns and check metric. *)
   let before =
     P.metric_value_or_zero
-      P.metric_keeper_passive_loop_detected_total
+      Masc_mcp.Keeper_metrics.metric_keeper_passive_loop_detected_total
       ~labels:[("keeper", "k-metric")] ()
   in
   let zombie_before =
     P.metric_value_or_zero
-      P.metric_keeper_zombie_loop_detected_total
+      Masc_mcp.Keeper_metrics.metric_keeper_zombie_loop_detected_total
       ~labels:[("keeper_name", "k-metric")] ()
   in
   for _ = 1 to 5 do
@@ -154,12 +154,12 @@ let test_detection_fires_metric_at_threshold () =
   done;
   let after =
     P.metric_value_or_zero
-      P.metric_keeper_passive_loop_detected_total
+      Masc_mcp.Keeper_metrics.metric_keeper_passive_loop_detected_total
       ~labels:[("keeper", "k-metric")] ()
   in
   let zombie_after =
     P.metric_value_or_zero
-      P.metric_keeper_zombie_loop_detected_total
+      Masc_mcp.Keeper_metrics.metric_keeper_zombie_loop_detected_total
       ~labels:[("keeper_name", "k-metric")] ()
   in
   check bool "metric incremented at threshold" true (after > before);
@@ -171,12 +171,12 @@ let test_detection_latch_does_not_double_fire () =
   setup ();
   let before =
     P.metric_value_or_zero
-      P.metric_keeper_passive_loop_detected_total
+      Masc_mcp.Keeper_metrics.metric_keeper_passive_loop_detected_total
       ~labels:[("keeper", "k-latch")] ()
   in
   let zombie_before =
     P.metric_value_or_zero
-      P.metric_keeper_zombie_loop_detected_total
+      Masc_mcp.Keeper_metrics.metric_keeper_zombie_loop_detected_total
       ~labels:[("keeper_name", "k-latch")] ()
   in
   (* Fire well above threshold — latch should prevent repeated increments *)
@@ -185,7 +185,7 @@ let test_detection_latch_does_not_double_fire () =
   done;
   let after =
     P.metric_value_or_zero
-      P.metric_keeper_passive_loop_detected_total
+      Masc_mcp.Keeper_metrics.metric_keeper_passive_loop_detected_total
       ~labels:[("keeper", "k-latch")] ()
   in
   check (float 0.001) "latch: counter increments exactly once per episode"
@@ -194,7 +194,7 @@ let test_detection_latch_does_not_double_fire () =
     "latch: Observe zombie-loop counter increments exactly once per episode"
     (zombie_before +. 1.0)
     (P.metric_value_or_zero
-       P.metric_keeper_zombie_loop_detected_total
+       Masc_mcp.Keeper_metrics.metric_keeper_zombie_loop_detected_total
        ~labels:[("keeper_name", "k-latch")] ())
 
 let test_reset_clears_state () =

--- a/test/test_keeper_path_roots_leak_10349.ml
+++ b/test/test_keeper_path_roots_leak_10349.ml
@@ -68,7 +68,7 @@ let with_clean_env f =
 
 let counter_value labels =
   Prometheus.metric_value_or_zero
-    Keeper_metrics.metric_keeper_path_rejection
+    Masc_mcp.Keeper_metrics.metric_keeper_path_rejection
     ~labels ()
 
 let assert_no_roots_leak msg err =

--- a/test/test_keeper_pause_silent_failure_source.ml
+++ b/test/test_keeper_pause_silent_failure_source.ml
@@ -149,7 +149,7 @@ let test_counter_inc_calls () =
   check bool "Prometheus.inc_counter called for new metric >= 6 times"
     true
     (count_occurrences
-       ~needle:"Keeper_metrics.metric_keeper_paused_state_persist_errors"
+       ~needle:"Masc_mcp.Keeper_metrics.metric_keeper_paused_state_persist_errors"
        src
      >= 6)
 

--- a/test/test_keeper_recurring.ml
+++ b/test/test_keeper_recurring.ml
@@ -12,7 +12,7 @@ let task_by_label label =
 
 let recurring_failure_value ~task ~phase =
   Prom.metric_value_or_zero
-    Prom.metric_keeper_recurring_failures
+    Masc_mcp.Keeper_metrics.metric_keeper_recurring_failures
     ~labels:[("task", task); ("phase", phase)]
     ()
 ;;

--- a/test/test_keeper_supervisor_observability_10125.ml
+++ b/test/test_keeper_supervisor_observability_10125.ml
@@ -39,13 +39,13 @@ module Prom = Masc_mcp.Prometheus
 
 let starts_for ~base_path =
   Prom.metric_value_or_zero
-    Prom.metric_keeper_supervisor_sweep_starts
+    Masc_mcp.Keeper_metrics.metric_keeper_supervisor_sweep_starts
     ~labels:[ ("base_path", base_path) ]
     ()
 
 let last_sweep_for ~base_path =
   Prom.get_metric_value
-    Prom.metric_keeper_supervisor_last_sweep_unixtime
+    Masc_mcp.Keeper_metrics.metric_keeper_supervisor_last_sweep_unixtime
     ~labels:[ ("base_path", base_path) ]
     ()
 
@@ -55,8 +55,8 @@ let last_sweep_for ~base_path =
    if either name is missing the whole #10125 dashboard
    becomes invisible on a fresh install. *)
 let test_metrics_registered () =
-  let _ = Prom.metric_total Prom.metric_keeper_supervisor_sweep_starts in
-  let _ = Prom.metric_total Prom.metric_keeper_supervisor_last_sweep_unixtime in
+  let _ = Prom.metric_total Masc_mcp.Keeper_metrics.metric_keeper_supervisor_sweep_starts in
+  let _ = Prom.metric_total Masc_mcp.Keeper_metrics.metric_keeper_supervisor_last_sweep_unixtime in
   Alcotest.(check pass) "both supervisor metrics are registered" () ()
 
 (* Helper returns [None] before the sweep gauge is set in
@@ -82,7 +82,7 @@ let test_age_helper_returns_none_before_first_sweep () =
 let test_age_helper_advances_after_gauge_set () =
   let base_path = "/tmp/test-supervisor-obs-advances-10125" in
   Prom.set_gauge
-    Prom.metric_keeper_supervisor_last_sweep_unixtime
+    Masc_mcp.Keeper_metrics.metric_keeper_supervisor_last_sweep_unixtime
     ~labels:[ ("base_path", base_path) ]
     (Unix.gettimeofday ());
   match R.supervisor_sweep_age_seconds ~base_path with
@@ -100,7 +100,7 @@ let test_age_helper_reports_stale_when_gauge_old () =
   let base_path = "/tmp/test-supervisor-obs-stale-10125" in
   let stale_ts = Unix.gettimeofday () -. 3600.0 in
   Prom.set_gauge
-    Prom.metric_keeper_supervisor_last_sweep_unixtime
+    Masc_mcp.Keeper_metrics.metric_keeper_supervisor_last_sweep_unixtime
     ~labels:[ ("base_path", base_path) ]
     stale_ts;
   match R.supervisor_sweep_age_seconds ~base_path with
@@ -118,11 +118,11 @@ let test_counter_per_base_path_isolation () =
   let b = "/tmp/test-supervisor-obs-iso-B-10125" in
   let before_b = starts_for ~base_path:b in
   Prom.inc_counter
-    Prom.metric_keeper_supervisor_sweep_starts
+    Masc_mcp.Keeper_metrics.metric_keeper_supervisor_sweep_starts
     ~labels:[ ("base_path", a) ]
     ();
   Prom.inc_counter
-    Prom.metric_keeper_supervisor_sweep_starts
+    Masc_mcp.Keeper_metrics.metric_keeper_supervisor_sweep_starts
     ~labels:[ ("base_path", a) ]
     ();
   Alcotest.(check (float 0.0001))
@@ -140,11 +140,11 @@ let test_counter_per_base_path_isolation () =
 let test_prometheus_text_export_includes_metrics () =
   let base_path = "/tmp/test-supervisor-obs-export-10125" in
   Prom.inc_counter
-    Prom.metric_keeper_supervisor_sweep_starts
+    Masc_mcp.Keeper_metrics.metric_keeper_supervisor_sweep_starts
     ~labels:[ ("base_path", base_path) ]
     ();
   Prom.set_gauge
-    Prom.metric_keeper_supervisor_last_sweep_unixtime
+    Masc_mcp.Keeper_metrics.metric_keeper_supervisor_last_sweep_unixtime
     ~labels:[ ("base_path", base_path) ]
     (Unix.gettimeofday ());
   let text = Prom.to_prometheus_text () in
@@ -159,10 +159,10 @@ let test_prometheus_text_export_includes_metrics () =
   in
   Alcotest.(check bool)
     "counter name appears in export"
-    true (contains text Prom.metric_keeper_supervisor_sweep_starts);
+    true (contains text Masc_mcp.Keeper_metrics.metric_keeper_supervisor_sweep_starts);
   Alcotest.(check bool)
     "gauge name appears in export"
-    true (contains text Prom.metric_keeper_supervisor_last_sweep_unixtime);
+    true (contains text Masc_mcp.Keeper_metrics.metric_keeper_supervisor_last_sweep_unixtime);
   Alcotest.(check bool)
     "base_path label appears for export"
     true (contains text "base_path=")

--- a/test/test_keeper_tools_oas.ml
+++ b/test/test_keeper_tools_oas.ml
@@ -156,12 +156,12 @@ let test_tool_side_effect_failures_are_observed () =
       let keeper_labels = [("keeper", meta.name)] in
       let sse_before =
         Prometheus.metric_value_or_zero
-          Keeper_metrics.metric_keeper_sse_broadcast_failures
+          Masc_mcp.Keeper_metrics.metric_keeper_sse_broadcast_failures
           ~labels:keeper_labels ()
       in
       let decision_before =
         Prometheus.metric_value_or_zero
-          Keeper_metrics.metric_keeper_decision_audit_flush_failures
+          Masc_mcp.Keeper_metrics.metric_keeper_decision_audit_flush_failures
           ~labels:keeper_labels ()
       in
       let original_hook = Atomic.get Sse.buffer_commit_test_hook in
@@ -179,12 +179,12 @@ let test_tool_side_effect_failures_are_observed () =
       check (float 0.001) "SSE failure metric incremented"
         (sse_before +. 1.0)
         (Prometheus.metric_value_or_zero
-           Keeper_metrics.metric_keeper_sse_broadcast_failures
+           Masc_mcp.Keeper_metrics.metric_keeper_sse_broadcast_failures
            ~labels:keeper_labels ());
       check (float 0.001) "decision-log failure metric incremented"
         (decision_before +. 1.0)
         (Prometheus.metric_value_or_zero
-           Keeper_metrics.metric_keeper_decision_audit_flush_failures
+           Masc_mcp.Keeper_metrics.metric_keeper_decision_audit_flush_failures
            ~labels:keeper_labels ()))
 
 let test_handler_persists_tool_call_io_without_post_hook () =

--- a/test/test_keeper_transition_audit.ml
+++ b/test/test_keeper_transition_audit.ml
@@ -64,7 +64,7 @@ let transition ?(prev_phase = KSM.Running) ?(new_phase = KSM.Paused)
   }
 
 let transition_audit_failure_count site =
-  P.metric_value_or_zero P.metric_keeper_transition_audit_failures
+  P.metric_value_or_zero Masc_mcp.Keeper_metrics.metric_keeper_transition_audit_failures
     ~labels:[("site", site)]
     ()
 

--- a/test/test_keeper_turn_helpers_side_effect_metric.ml
+++ b/test/test_keeper_turn_helpers_side_effect_metric.ml
@@ -10,7 +10,7 @@ let test_side_effect_issue_increments_failure_metric () =
   in
   let before =
     Prometheus.metric_value_or_zero
-      Keeper_metrics.metric_keeper_dispatch_event_failures
+      Masc_mcp.Keeper_metrics.metric_keeper_dispatch_event_failures
       ~labels
       ()
   in
@@ -26,7 +26,7 @@ let test_side_effect_issue_increments_failure_metric () =
     "test failure";
   let after =
     Prometheus.metric_value_or_zero
-      Keeper_metrics.metric_keeper_dispatch_event_failures
+      Masc_mcp.Keeper_metrics.metric_keeper_dispatch_event_failures
       ~labels
       ()
   in

--- a/test/test_keeper_turn_livelock_10121.ml
+++ b/test/test_keeper_turn_livelock_10121.ml
@@ -44,23 +44,23 @@ module Prom = Masc_mcp.Prometheus
 let with_eio f () = Eio_main.run @@ fun _env -> f ()
 
 let starts_for ~keeper =
-  Prom.metric_value_or_zero Prom.metric_keeper_turn_starts
+  Prom.metric_value_or_zero Masc_mcp.Keeper_metrics.metric_keeper_turn_starts
     ~labels:[ ("keeper", keeper) ] ()
 
 let scheduled_for ~keeper =
-  Prom.metric_value_or_zero Prom.metric_keeper_turn_scheduled
+  Prom.metric_value_or_zero Masc_mcp.Keeper_metrics.metric_keeper_turn_scheduled
     ~labels:[ ("keeper_name", keeper) ] ()
 
 let reattempts_for ~keeper =
-  Prom.metric_value_or_zero Prom.metric_keeper_turn_reattempts
+  Prom.metric_value_or_zero Masc_mcp.Keeper_metrics.metric_keeper_turn_reattempts
     ~labels:[ ("keeper", keeper) ] ()
 
 let regressions_for ~keeper =
-  Prom.metric_value_or_zero Prom.metric_keeper_turn_regressions
+  Prom.metric_value_or_zero Masc_mcp.Keeper_metrics.metric_keeper_turn_regressions
     ~labels:[ ("keeper", keeper) ] ()
 
 let blocks_for ~keeper ~reason =
-  Prom.metric_value_or_zero Prom.metric_keeper_turn_livelock_blocks
+  Prom.metric_value_or_zero Masc_mcp.Keeper_metrics.metric_keeper_turn_livelock_blocks
     ~labels:[ ("keeper", keeper); ("reason", reason) ] ()
 
 (* Fresh start: no prior state → [Fresh] outcome, starts counter

--- a/test/test_memory_hooks.ml
+++ b/test/test_memory_hooks.ml
@@ -275,7 +275,7 @@ let test_after_turn_flush_failure_still_continues () =
     [("callback", "memory_after_turn_flush")]
   in
   let before =
-    P.metric_value_or_zero P.metric_keeper_lifecycle_callback_failures
+    P.metric_value_or_zero Masc_mcp.Keeper_metrics.metric_keeper_lifecycle_callback_failures
       ~labels ()
   in
   let memory_hooks =
@@ -310,7 +310,7 @@ let test_after_turn_flush_failure_still_continues () =
     (match decision with Agent_sdk.Hooks.Continue -> true | _ -> false);
   check bool "inner after_turn still ran" true !inner_seen;
   let after =
-    P.metric_value_or_zero P.metric_keeper_lifecycle_callback_failures
+    P.metric_value_or_zero Masc_mcp.Keeper_metrics.metric_keeper_lifecycle_callback_failures
       ~labels ()
   in
   check (float 0.0001) "flush failure counted" (before +. 1.0) after;

--- a/test/test_prometheus_coverage.ml
+++ b/test/test_prometheus_coverage.ml
@@ -287,10 +287,10 @@ let test_keeper_metrics_registered () =
     (has "masc_keeper_heartbeat_failures_total");
   check bool "has keeper total cost gauge" true
     (text_has_literal text
-       ("# TYPE " ^ Keeper_metrics.metric_keeper_total_cost_usd ^ " gauge"));
+       ("# TYPE " ^ Masc_mcp.Keeper_metrics.metric_keeper_total_cost_usd ^ " gauge"));
   check bool "has keeper idle seconds gauge" true
     (text_has_literal text
-       ("# TYPE " ^ Keeper_metrics.metric_keeper_idle_seconds ^ " gauge"));
+       ("# TYPE " ^ Masc_mcp.Keeper_metrics.metric_keeper_idle_seconds ^ " gauge"));
   check bool "has keeper tool duration histogram" true
     (has "masc_keeper_tool_call_duration_seconds");
   check bool "has keeper underused allowed tool count gauge" true
@@ -315,12 +315,12 @@ let test_new_issue_metrics_registered () =
     in
     check bool (name ^ " registered") true has_help
   in
-  check_metric_name Keeper_metrics.metric_keeper_liveness_recovery_attempts;
-  check_metric_name Keeper_metrics.metric_keeper_liveness_recovery_outcomes;
+  check_metric_name Masc_mcp.Keeper_metrics.metric_keeper_liveness_recovery_attempts;
+  check_metric_name Masc_mcp.Keeper_metrics.metric_keeper_liveness_recovery_outcomes;
   check_metric_name Prometheus.metric_cascade_server_error_skip_total;
-  check_metric_name Keeper_metrics.metric_keeper_passive_loop_detected_total;
+  check_metric_name Masc_mcp.Keeper_metrics.metric_keeper_passive_loop_detected_total;
   check_metric_name Prometheus.metric_write_meta_cas_retry_total;
-  check_metric_name Keeper_metrics.metric_keeper_zombie_loop_detected_total
+  check_metric_name Masc_mcp.Keeper_metrics.metric_keeper_zombie_loop_detected_total
 
 let test_review_blocker_metrics_registered () =
   let text = Prometheus.to_prometheus_text () in
@@ -343,19 +343,19 @@ let test_review_blocker_metrics_registered () =
   check_registered Prometheus.metric_telemetry_coverage_gap;
   check_registered Prometheus.metric_telemetry_unified_source_read_failures;
   check_registered Prometheus.metric_tool_assignment_telemetry_failures;
-  check_registered Keeper_metrics.metric_keeper_oas_hook_output_parse_failures;
+  check_registered Masc_mcp.Keeper_metrics.metric_keeper_oas_hook_output_parse_failures;
   check_registered Prometheus.metric_inference_queue_rejected;
   check_registered Prometheus.metric_telemetry_observe_failures;
   check_registered Prometheus.metric_coord_telemetry_drop;
   check_registered Prometheus.metric_coord_claim_post_provision_failures;
-  check_registered Keeper_metrics.metric_keeper_lifecycle_callback_failures;
+  check_registered Masc_mcp.Keeper_metrics.metric_keeper_lifecycle_callback_failures;
   check_registered Prometheus.metric_memory_pipeline_flushes;
   check_registered Prometheus.metric_memory_pipeline_flush_records;
   check_histogram_registered
     Prometheus.metric_memory_pipeline_flush_duration_seconds;
-  check_registered Keeper_metrics.metric_keeper_oas_on_stop;
-  check_registered Keeper_metrics.metric_keeper_oas_on_idle_escalated;
-  check_registered Keeper_metrics.metric_keeper_event_bus_drain
+  check_registered Masc_mcp.Keeper_metrics.metric_keeper_oas_on_stop;
+  check_registered Masc_mcp.Keeper_metrics.metric_keeper_oas_on_idle_escalated;
+  check_registered Masc_mcp.Keeper_metrics.metric_keeper_event_bus_drain
 
 let test_distributed_lock_metric_registered () =
   let text = Prometheus.to_prometheus_text () in

--- a/test/test_prompt_registry_defaults.ml
+++ b/test/test_prompt_registry_defaults.ml
@@ -286,7 +286,7 @@ let () =
               let labels = [ ("prompt", "override_restore") ] in
               let before =
                 Lib.Prometheus.metric_value_or_zero
-                  Lib.Keeper_metrics.metric_keeper_prompt_failures
+                  Masc_mcp.Keeper_metrics.metric_keeper_prompt_failures
                   ~labels
                   ()
               in
@@ -299,7 +299,7 @@ let () =
               check (float 0.0001) "restore rejection counted"
                 (before +. 1.0)
                 (Lib.Prometheus.metric_value_or_zero
-                   Lib.Keeper_metrics.metric_keeper_prompt_failures
+                   Masc_mcp.Keeper_metrics.metric_keeper_prompt_failures
                    ~labels
                    ());
               check string "invalid override not applied"

--- a/test/test_require_tool_use_violation_counter_10091.ml
+++ b/test/test_require_tool_use_violation_counter_10091.ml
@@ -41,7 +41,7 @@ let () =
 module D = Masc_mcp.Keeper_tool_disclosure
 module Prom = Masc_mcp.Prometheus
 
-let metric = Prom.metric_keeper_require_tool_use_violations
+let metric = Masc_mcp.Keeper_metrics.metric_keeper_require_tool_use_violations
 
 let counter_for ~keeper ~has_current_task ~contract_status =
   Prom.metric_value_or_zero metric

--- a/test/test_smart_heartbeat_keepalive.ml
+++ b/test/test_smart_heartbeat_keepalive.ml
@@ -283,13 +283,13 @@ let test_skip_idle_wake_resumed_metric_registered () =
   let labels = [ ("keeper", "test_keeper_a") ] in
   let before =
     Prom.metric_value_or_zero
-      Prom.metric_keeper_skip_idle_wake_resumed ~labels ()
+      Masc_mcp.Keeper_metrics.metric_keeper_skip_idle_wake_resumed ~labels ()
   in
   Prom.inc_counter
-    Prom.metric_keeper_skip_idle_wake_resumed ~labels ();
+    Masc_mcp.Keeper_metrics.metric_keeper_skip_idle_wake_resumed ~labels ();
   let after =
     Prom.metric_value_or_zero
-      Prom.metric_keeper_skip_idle_wake_resumed ~labels ()
+      Masc_mcp.Keeper_metrics.metric_keeper_skip_idle_wake_resumed ~labels ()
   in
   check (float 0.001) "counter increments by 1" 1.0 (after -. before)
 
@@ -301,15 +301,15 @@ let test_skip_idle_wake_resumed_label_isolation () =
   let lb = [ ("keeper", "test_keeper_iso_b") ] in
   let b_before =
     Prom.metric_value_or_zero
-      Prom.metric_keeper_skip_idle_wake_resumed ~labels:lb ()
+      Masc_mcp.Keeper_metrics.metric_keeper_skip_idle_wake_resumed ~labels:lb ()
   in
   Prom.inc_counter
-    Prom.metric_keeper_skip_idle_wake_resumed ~labels:la ();
+    Masc_mcp.Keeper_metrics.metric_keeper_skip_idle_wake_resumed ~labels:la ();
   Prom.inc_counter
-    Prom.metric_keeper_skip_idle_wake_resumed ~labels:la ();
+    Masc_mcp.Keeper_metrics.metric_keeper_skip_idle_wake_resumed ~labels:la ();
   let b_after =
     Prom.metric_value_or_zero
-      Prom.metric_keeper_skip_idle_wake_resumed ~labels:lb ()
+      Masc_mcp.Keeper_metrics.metric_keeper_skip_idle_wake_resumed ~labels:lb ()
   in
   check (float 0.001) "keeper_b counter unchanged" 0.0
     (b_after -. b_before)

--- a/test/test_tool_code_write_coverage.ml
+++ b/test/test_tool_code_write_coverage.ml
@@ -29,7 +29,7 @@ let json_string_field key text =
 
 let tool_code_write_policy_load_failure_metric () =
   Prometheus.metric_value_or_zero
-    Keeper_metrics.metric_keeper_tool_policy_failures
+    Masc_mcp.Keeper_metrics.metric_keeper_tool_policy_failures
     ~labels:[("site", "tool_code_write_load_failed"); ("preset", "n/a")]
     ()
 

--- a/test/test_transport_metrics.ml
+++ b/test/test_transport_metrics.ml
@@ -266,7 +266,7 @@ let test_transport_health_json () =
     ~labels:[ ("stage", "queue") ] ~delta:3.0 ();
   Prometheus.inc_counter Prometheus.metric_oas_sse_relay_drops
     ~labels:[ ("stage", "append") ] ~delta:1.0 ();
-  Prometheus.inc_counter Keeper_metrics.metric_keeper_lifecycle_dispatch_rejections
+  Prometheus.inc_counter Masc_mcp.Keeper_metrics.metric_keeper_lifecycle_dispatch_rejections
     ~labels:[ ("event", "compaction_started") ] ~delta:2.0 ();
   Masc_mcp.Sse.broadcast (`Assoc [ ("type", `String "transport-test") ]);
   let json = TM.transport_health_json ~config in


### PR DESCRIPTION
## Summary

11 keeper metrics were referenced by production code via `inc_counter` / `set_gauge` but never explicitly registered in `Prometheus.init()`. They worked via auto-registration on first use, but lacked `# HELP` text and proper type metadata.

## Changes

### `lib/prometheus.ml`

Register 11 metrics in `init()` with proper documentation:

| Metric | Type | Labels |
|--------|------|--------|
| `metric_keeper_fsm_edge_transitions` | Counter | edge |
| `metric_keeper_invariant_violations` | Counter | keeper, invariant |
| `metric_keeper_metric_emit_dropped` | Counter | keeper, reason |
| `metric_keeper_oas_timeout_budget_strike` | Counter | keeper |
| `metric_keeper_path_rejection` | Counter | kind |
| `metric_keeper_provider_cooldown_remaining_sec` | Gauge | keeper, provider |
| `metric_keeper_provider_cooldown_skip` | Counter | keeper, provider |
| `metric_keeper_require_tool_use_violations` | Counter | keeper, contract_status |
| `metric_keeper_semaphore_wait_seconds_bucket` | Counter | le |
| `metric_keeper_semaphore_wait_timeout` | Counter | keeper, channel |
| `metric_keeper_turn_fsm_transitions` | Counter | keeper, from, to |

### Test files

- Migrate remaining `P.metric_keeper_*` and `Prom.metric_keeper_*` references to `Masc_mcp.Keeper_metrics.metric_keeper_*` (25 test files)

## Verification

- `dune build --root .` ✅
- `scripts/lint/godfile-size-regression.sh` ✅ clean

## Related

- Follow-up to #14189 (alias removal)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>