### PR TITLE
fix(keeper): allow Decision_undecided -> Decision_tool_policy_selected transition

### DIFF
--- a/lib/keeper/keeper_registry.ml
+++ b/lib/keeper/keeper_registry.ml
@@ -708,6 +708,7 @@ let validate_decision_transition ~from ~to_ =
          match (from, to_) with
          | (Decision_undecided, Decision_guard_ok) -> true
          | (Decision_undecided, Decision_gate_rejected) -> true
+         | (Decision_undecided, Decision_tool_policy_selected) -> true
          | (Decision_guard_ok, Decision_tool_policy_selected) -> true
          | (old, new_) when old = new_ -> true
          | _ -> false


### PR DESCRIPTION
## Summary

`validate_decision_transition`의 decision matrix에 `(Decision_undecided, Decision_tool_policy_selected)` 쌍이 누락되어 있어, 해당 상태 전이 시 `assert false`가 발생했습니다. 이 PR은 1줄 추가로 spec과 정합화합니다.

## 변경 내용

- `lib/keeper/keeper_registry.ml:711` — `(Decision_undecided, Decision_tool_policy_selected) -> true` 추가

## 원인

keeper turn 시작 시 `Decision_undecided` 상태에서 tool policy가 바로 선택되는 경로가 있으나, `validate_decision_transition` guard가 이를 허용하지 않아 keeper cycle exception이 발생했습니다.

## ⚠️ 머지 전 경로 분석 의무 (TODO)

본 PR이 1-line spec 약화가 되지 않으려면 다음 분석이 필요:

- **caller 인용**: `Decision_undecided → Decision_tool_policy_selected`를 트리거하는 caller 1-2건의 file:line
- **중간 상태 분석**: `Decision_tool_inventory_loaded` 같은 중간 Decision 상태가 *건너뛰어지는* 경로인지 vs 의도된 직접 전이인지
- **결정**:
  - (a) 의도된 직접 전이 → 본 PR 그대로 머지
  - (b) 중간 상태 누락 → 본 PR close하고 caller 측에서 중간 전이 추가

분석 없이 매트릭스 추가는 spec *약화*가 될 수 있음.

근거: `instructions/software-development.md` §워크어라운드 거부 기준 §체크리스트 §1·§7 (PR jeong-sik/me#1100).

## Test plan

- [x] `dune build @check` 통과 (수정 파일 타입 체크)
- [ ] 전체 빌드 — 현재 브랜치에 PR #14189(metric alias 제거)의 테스트 잔여 에러가 존재하여 별도 처리 필요
- [ ] 위 경로 분석 완료

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
