### PR TITLE
refactor(keeper): exhaustive match for turn_phase validator

### DIFF
--- a/lib/keeper/keeper_registry.ml
+++ b/lib/keeper/keeper_registry.ml
@@ -774,14 +774,36 @@ let validate_turn_phase_transition ~from ~to_ =
     (fun () ->
        assert (
          match (from, to_) with
-         | (Turn_idle, Turn_prompting) -> true
-         | (Turn_prompting, Turn_executing) -> true
-         | (Turn_prompting, Turn_finalizing) -> true
-         | (Turn_executing, Turn_compacting) -> true
-         | (Turn_executing, Turn_finalizing) -> true
-         | (Turn_compacting, Turn_prompting) -> true
-         | (old, new_) when old = new_ -> true
-         | _ -> false
+         (* from Turn_idle *)
+         | (Turn_idle, Turn_idle) -> true
+         | (Turn_idle, Turn_prompting) -> true  (* via turn init / prepare_turn_retry_after_compaction (bypassed) *)
+         | (Turn_idle, Turn_executing) -> false
+         | (Turn_idle, Turn_compacting) -> false
+         | (Turn_idle, Turn_finalizing) -> false
+         (* from Turn_prompting *)
+         | (Turn_prompting, Turn_idle) -> false  (* new turn init is reset, not transition *)
+         | (Turn_prompting, Turn_prompting) -> true
+         | (Turn_prompting, Turn_executing) -> true  (* via set_turn_phase *)
+         | (Turn_prompting, Turn_compacting) -> false
+         | (Turn_prompting, Turn_finalizing) -> true  (* via set_turn_phase / bypassed: mark_turn_gate_rejected_by_name *)
+         (* from Turn_executing *)
+         | (Turn_executing, Turn_idle) -> false  (* new turn init is reset, not transition *)
+         | (Turn_executing, Turn_prompting) -> false
+         | (Turn_executing, Turn_executing) -> true
+         | (Turn_executing, Turn_compacting) -> true  (* via set_turn_phase: retry plan *)
+         | (Turn_executing, Turn_finalizing) -> true  (* via set_turn_phase / bypassed: mark_turn_gate_rejected_by_name *)
+         (* from Turn_compacting *)
+         | (Turn_compacting, Turn_idle) -> false  (* new turn init is reset, not transition *)
+         | (Turn_compacting, Turn_prompting) -> false  (* was via set_turn_phase; now bypassed: prepare_turn_retry_after_compaction *)
+         | (Turn_compacting, Turn_executing) -> false
+         | (Turn_compacting, Turn_compacting) -> true
+         | (Turn_compacting, Turn_finalizing) -> true  (* via set_turn_phase: compaction failure *)
+         (* from Turn_finalizing *)
+         | (Turn_finalizing, Turn_idle) -> false  (* terminal; new turn is reset *)
+         | (Turn_finalizing, Turn_prompting) -> false  (* terminal; new turn is reset *)
+         | (Turn_finalizing, Turn_executing) -> false  (* terminal *)
+         | (Turn_finalizing, Turn_compacting) -> false  (* terminal *)
+         | (Turn_finalizing, Turn_finalizing) -> true
        ))
 
 let set_turn_decision_stage ~base_path name decision_stage =


### PR DESCRIPTION
## Summary

`validate_turn_phase_transition`의 `_ -> false` catch-all을 제거하고 25개 쌍을 모두 명시합니다.

## Key change

`(Turn_compacting, Turn_prompting)`을 `true`에서 `false`로 변경합니다. 이 전이는 과거 `set_turn_phase`를 통해 처리되었으나, 현재는 `prepare_turn_retry_after_compaction`의 직접 업데이트로 처리되어 validator를 우회합니다.

## TODO (next-step 의무)

본 PR은 catch-all *제거*는 했으나 main에 잔존하는 validator bypass를 닫지 않음. half-fix 그대로 머지되면 컴파일러 만족-런타임 우회가 영구화됨.

- **TODO**: `prepare_turn_retry_after_compaction`을 typed setter (예: `set_turn_phase_with_compaction_proof`) 경유로 강제하여 bypass 제거. 후속 PR 또는 RFC 번호 부여 필요.
- 머지 전에 본 TODO를 issue로 등록하거나 후속 PR 링크를 본문에 추가.

근거: `instructions/software-development.md` §워크어라운드 거부 기준 (PR jeong-sik/me#1100).

## Test plan

- [x] `dune build @check` 통과

## Related

- PR #14192: decision / cascade / compaction validators

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
