### PR TITLE
fix(keeper): reactive turn last_ts + stigmergy wake reason

### DIFF
--- a/lib/keeper/keeper_unified_metrics.ml
+++ b/lib/keeper/keeper_unified_metrics.ml
@@ -1117,6 +1117,9 @@ let update_metrics_from_result (meta : keeper_meta) ~(latency_ms : int)
   in
   let is_board_reactive = observation.pending_board_events <> [] in
   let is_mention_reactive = observation.pending_mentions <> [] in
+  let has_meaningful_work =
+    has_text || has_substantive_tools || has_validated_evidence
+  in
   let rt = meta.runtime in
   let social_state : Social.social_state =
     Option.value social_state
@@ -1171,7 +1174,11 @@ let update_metrics_from_result (meta : keeper_meta) ~(latency_ms : int)
           rt.proactive_rt.count_total
           + (if update_proactive_rt && is_scheduled_autonomous_cycle then 1 else 0);
         last_ts =
-          (if update_proactive_rt && is_scheduled_autonomous_cycle then now_ts
+          (if update_proactive_rt
+              && (is_scheduled_autonomous_cycle
+                  || ((is_board_reactive || is_mention_reactive)
+                      && has_meaningful_work))
+           then now_ts
            else rt.proactive_rt.last_ts);
         visible_count_total =
           rt.proactive_rt.visible_count_total

--- a/lib/keeper/keeper_world_observation.ml
+++ b/lib/keeper/keeper_world_observation.ml
@@ -574,6 +574,28 @@ let check_self_comment_status ~self_tokens ~(post_id : string)
               Board.Agent_id.to_string latest.author,
               short_preview ~max_len:60 latest.content )
 
+type stigmergy_match_result = { overall_score : int }
+
+let stigmergy_match ~(meta : keeper_meta)
+    ~(signal : Board_dispatch.keeper_board_signal) : stigmergy_match_result =
+  let signal_text = String.lowercase_ascii (board_signal_text signal) in
+  let goal_keywords =
+    [ meta.goal; meta.short_goal; meta.mid_goal; meta.long_goal ]
+    |> List.filter (fun s -> String.trim s <> "")
+    |> List.concat_map (fun g ->
+         String.split_on_char ' ' (String.lowercase_ascii g)
+         |> List.map String.trim
+         |> List.filter (fun s -> String.length s > 3))
+    |> List.sort_uniq String.compare
+  in
+  let score =
+    List.fold_left
+      (fun acc kw ->
+        if String_util.contains_substring signal_text kw then acc + 5 else acc)
+      0 goal_keywords
+  in
+  { overall_score = min score 50 }
+
 let board_signal_wake_reason
     ~continuity_summary
     ~(meta : keeper_meta)
@@ -584,13 +606,17 @@ let board_signal_wake_reason
   else if scope_message_feed_enabled meta then
     Some "board_activity"
   else
-    let self_tokens = self_identity_tokens meta in
-    match signal.kind with
-    | Board_dispatch.Board_comment_added ->
-        (match check_self_comment_status ~self_tokens ~post_id:signal.post_id with
-         | `New_external _ -> Some "thread_reply_after_self_comment"
-         | `Never | `No_new_external -> None)
-    | Board_dispatch.Board_post_created -> None
+    let stigmergy = stigmergy_match ~meta ~signal in
+    if stigmergy.overall_score > 0 then
+      Some ("stigmergy: score=" ^ string_of_int stigmergy.overall_score)
+    else
+      let self_tokens = self_identity_tokens meta in
+      match signal.kind with
+      | Board_dispatch.Board_comment_added ->
+          (match check_self_comment_status ~self_tokens ~post_id:signal.post_id with
+           | `New_external _ -> Some "thread_reply_after_self_comment"
+           | `Never | `No_new_external -> None)
+      | Board_dispatch.Board_post_created -> None
 
 let json_string_member name fields =
   match List.assoc_opt name fields with


### PR DESCRIPTION
## Summary

Two fixes for the idle fleet liveness issue (#14195):

1. **Reactive turn last_ts update** (`keeper_unified_metrics.ml`)
   - Previously `proactive_rt.last_ts` only updated on scheduled autonomous turns.
   - Reactive turns (board/mention triggered) that performed meaningful work did not reset the timestamp, leading to false idle detection and sleep chain.
   - Now updates `last_ts` when reactive turns produce substantive output (tools, text, or validated evidence).

2. **Stigmergy board signal wake reason** (`keeper_world_observation.ml`)
   - When `scope_message_feed_enabled` is false, board posts were completely ignored unless they were explicit mentions.
   - Added `stigmergy_match` that scores board signal text against keeper goals (goal/short_goal/mid_goal/long_goal keywords).
   - Non-mention board posts matching keeper goals now wake the keeper with a scored stigmergy reason.

## Test Plan

- [ ] Verify `dune build @check` passes (✅ local)
- [ ] Monitor keeper fleet for reduced idle-to-sleep transitions after deploy

## Related

- Closes #14195 (partial — event queue layer separation was already in main via #12396)