### PR TITLE
refactor(keeper): exhaustive match in keeper_error_classify (#14195)

### DIFF
--- a/lib/keeper/keeper_error_classify.ml
+++ b/lib/keeper/keeper_error_classify.ml
@@ -64,7 +64,22 @@ let is_transient_network_error (err : Agent_sdk.Error.sdk_error) : bool =
       not (is_structural_oas_timeout_message message)
   | Agent_sdk.Error.Api (Overloaded _) -> true
   | Agent_sdk.Error.Api (ServerError { status = 503; _ }) -> true
-  | _ -> false
+  (* Non-transient API errors. *)
+  | Agent_sdk.Error.Api (ServerError _)
+  | Agent_sdk.Error.Api (RateLimited _)
+  | Agent_sdk.Error.Api (AuthError _)
+  | Agent_sdk.Error.Api (InvalidRequest _)
+  | Agent_sdk.Error.Api (NotFound _)
+  | Agent_sdk.Error.Api (ContextOverflow _) -> false
+  (* Non-API error families are by definition not transient network errors. *)
+  | Agent_sdk.Error.Agent _
+  | Agent_sdk.Error.Mcp _
+  | Agent_sdk.Error.Config _
+  | Agent_sdk.Error.Serialization _
+  | Agent_sdk.Error.Io _
+  | Agent_sdk.Error.Orchestration _
+  | Agent_sdk.Error.A2a _
+  | Agent_sdk.Error.Internal _ -> false
 
 (** Detect server-side request body parse errors (e.g. Ollama yyjson
     rejecting a request with "Value looks like object, but can't find
@@ -87,13 +102,48 @@ let is_server_rejected_parse_error (err : Agent_sdk.Error.sdk_error) : bool =
       || string_contains_substring ~needle:"unexpected character in json" lower
       || string_contains_substring ~needle:"unterminated" lower
       || string_contains_substring ~needle:"parse error" lower
-  | _ -> false
+  (* All other API error variants do not represent server-side parse failures. *)
+  | Agent_sdk.Error.Api (RateLimited _)
+  | Agent_sdk.Error.Api (Overloaded _)
+  | Agent_sdk.Error.Api (ServerError _)
+  | Agent_sdk.Error.Api (AuthError _)
+  | Agent_sdk.Error.Api (NotFound _)
+  | Agent_sdk.Error.Api (ContextOverflow _)
+  | Agent_sdk.Error.Api (NetworkError _)
+  | Agent_sdk.Error.Api (Timeout _) -> false
+  (* Non-API error families. *)
+  | Agent_sdk.Error.Agent _
+  | Agent_sdk.Error.Mcp _
+  | Agent_sdk.Error.Config _
+  | Agent_sdk.Error.Serialization _
+  | Agent_sdk.Error.Io _
+  | Agent_sdk.Error.Orchestration _
+  | Agent_sdk.Error.A2a _
+  | Agent_sdk.Error.Internal _ -> false
 
 let is_required_tool_contract_violation (err : Agent_sdk.Error.sdk_error) : bool =
   match err with
   | Agent_sdk.Error.Agent (Agent_sdk.Error.CompletionContractViolation { contract; _ }) ->
       contract = Agent_sdk.Completion_contract_id.Require_tool_use
-  | _ -> false
+  (* Other agent-level errors are not require-tool-use contract violations. *)
+  | Agent_sdk.Error.Agent (MaxTurnsExceeded _)
+  | Agent_sdk.Error.Agent (TokenBudgetExceeded _)
+  | Agent_sdk.Error.Agent (CostBudgetExceeded _)
+  | Agent_sdk.Error.Agent (UnrecognizedStopReason _)
+  | Agent_sdk.Error.Agent (IdleDetected _)
+  | Agent_sdk.Error.Agent (ToolRetryExhausted _)
+  | Agent_sdk.Error.Agent (GuardrailViolation _)
+  | Agent_sdk.Error.Agent (TripwireViolation _)
+  | Agent_sdk.Error.Agent (ExitConditionMet _) -> false
+  (* Non-Agent error families. *)
+  | Agent_sdk.Error.Api _
+  | Agent_sdk.Error.Mcp _
+  | Agent_sdk.Error.Config _
+  | Agent_sdk.Error.Serialization _
+  | Agent_sdk.Error.Io _
+  | Agent_sdk.Error.Orchestration _
+  | Agent_sdk.Error.A2a _
+  | Agent_sdk.Error.Internal _ -> false
 
 let is_auto_recoverable_cascade_exhausted_error (err : Agent_sdk.Error.sdk_error) : bool =
   match Oas_worker_named.classify_masc_internal_error err with
@@ -289,7 +339,26 @@ let recoverable_cascade_failure_reason (err : Agent_sdk.Error.sdk_error) =
              Some "server_error"
          | Agent_sdk.Error.Api (Llm_provider.Retry.AuthError _) ->
              Some "auth_error"
-         | _ -> None)
+         (* Sub-500 server errors (4xx already handled above for AuthError /
+            RateLimited) are not classified as recoverable cascade failures. *)
+         | Agent_sdk.Error.Api (Llm_provider.Retry.ServerError _)
+         | Agent_sdk.Error.Api (Llm_provider.Retry.Overloaded _)
+         | Agent_sdk.Error.Api (Llm_provider.Retry.InvalidRequest _)
+         | Agent_sdk.Error.Api (Llm_provider.Retry.NotFound _)
+         | Agent_sdk.Error.Api (Llm_provider.Retry.ContextOverflow _)
+         | Agent_sdk.Error.Api (Llm_provider.Retry.NetworkError _)
+         | Agent_sdk.Error.Api (Llm_provider.Retry.Timeout _) -> None
+         (* Non-API error families have no rotation reason here: structured
+            MASC internal errors are handled by [classify_masc_internal_error]
+            above; agent / mcp / config / etc. are not provider-level rotations. *)
+         | Agent_sdk.Error.Agent _
+         | Agent_sdk.Error.Mcp _
+         | Agent_sdk.Error.Config _
+         | Agent_sdk.Error.Serialization _
+         | Agent_sdk.Error.Io _
+         | Agent_sdk.Error.Orchestration _
+         | Agent_sdk.Error.A2a _
+         | Agent_sdk.Error.Internal _ -> None)
 
 let normalized_cascade_name ~catalog_names name =
   let trimmed = String.trim name in
@@ -432,8 +501,26 @@ let is_ambiguous_side_effect_error (err : Agent_sdk.Error.sdk_error) : bool =
       | Agent_sdk.Error.Internal msg ->
           string_contains_substring
             ~needle:ambiguous_side_effect_error_prefix msg
-      | _ -> false)
-  | _ -> false
+      (* Non-Internal sdk_error variants do not encode the legacy
+         ambiguous-side-effect string prefix; the structured
+         [Ambiguous_post_commit] arm above covers the new path. *)
+      | Agent_sdk.Error.Api _
+      | Agent_sdk.Error.Agent _
+      | Agent_sdk.Error.Mcp _
+      | Agent_sdk.Error.Config _
+      | Agent_sdk.Error.Serialization _
+      | Agent_sdk.Error.Io _
+      | Agent_sdk.Error.Orchestration _
+      | Agent_sdk.Error.A2a _ -> false)
+  (* All other MASC-internal classifications are unambiguous failures. *)
+  | Some (Oas_worker_named.Cascade_exhausted _)
+  | Some (Oas_worker_named.No_tool_capable_provider _)
+  | Some (Oas_worker_named.Accept_rejected _)
+  | Some (Oas_worker_named.Resumable_cli_session _)
+  | Some (Oas_worker_named.Admission_queue_rejected _)
+  | Some (Oas_worker_named.Admission_queue_timeout _)
+  | Some (Oas_worker_named.Turn_timeout _)
+  | Some (Oas_worker_named.Oas_timeout_budget _) -> false
 
 let reclassify_error_after_side_effect
     ~(tool_names : string list)
@@ -443,7 +530,26 @@ let reclassify_error_after_side_effect
   else
     let tools = committed_tools in
     let original = short_preview (Agent_sdk.Error.to_string err) in
-    let is_timeout = match err with Agent_sdk.Error.Api (Timeout _) -> true | _ -> false in
+    let is_timeout =
+      match err with
+      | Agent_sdk.Error.Api (Timeout _) -> true
+      | Agent_sdk.Error.Api (RateLimited _)
+      | Agent_sdk.Error.Api (Overloaded _)
+      | Agent_sdk.Error.Api (ServerError _)
+      | Agent_sdk.Error.Api (AuthError _)
+      | Agent_sdk.Error.Api (InvalidRequest _)
+      | Agent_sdk.Error.Api (NotFound _)
+      | Agent_sdk.Error.Api (ContextOverflow _)
+      | Agent_sdk.Error.Api (NetworkError _) -> false
+      | Agent_sdk.Error.Agent _
+      | Agent_sdk.Error.Mcp _
+      | Agent_sdk.Error.Config _
+      | Agent_sdk.Error.Serialization _
+      | Agent_sdk.Error.Io _
+      | Agent_sdk.Error.Orchestration _
+      | Agent_sdk.Error.A2a _
+      | Agent_sdk.Error.Internal _ -> false
+    in
     Oas_worker_named.sdk_error_of_masc_internal_error
       (Oas_worker_named.Ambiguous_post_commit
          { is_timeout; tools; original_error = original })
@@ -451,7 +557,23 @@ let reclassify_error_after_side_effect
 let post_commit_failure_kind_of_error (err : Agent_sdk.Error.sdk_error) =
   match err with
   | Agent_sdk.Error.Api (Timeout _) -> Keeper_registry.Post_commit_timeout
-  | _ -> Keeper_registry.Post_commit_failure
+  (* All non-Timeout failures classify as generic post-commit failure. *)
+  | Agent_sdk.Error.Api (RateLimited _)
+  | Agent_sdk.Error.Api (Overloaded _)
+  | Agent_sdk.Error.Api (ServerError _)
+  | Agent_sdk.Error.Api (AuthError _)
+  | Agent_sdk.Error.Api (InvalidRequest _)
+  | Agent_sdk.Error.Api (NotFound _)
+  | Agent_sdk.Error.Api (ContextOverflow _)
+  | Agent_sdk.Error.Api (NetworkError _)
+  | Agent_sdk.Error.Agent _
+  | Agent_sdk.Error.Mcp _
+  | Agent_sdk.Error.Config _
+  | Agent_sdk.Error.Serialization _
+  | Agent_sdk.Error.Io _
+  | Agent_sdk.Error.Orchestration _
+  | Agent_sdk.Error.A2a _
+  | Agent_sdk.Error.Internal _ -> Keeper_registry.Post_commit_failure
 
 let summarize_post_commit_failure
     ~(tool_names : string list)
@@ -519,7 +641,35 @@ let is_context_overflow (err : Agent_sdk.Error.sdk_error) : bool =
   match err with
   | Agent_sdk.Error.Api (ContextOverflow _) -> true
   | Agent_sdk.Error.Agent (TokenBudgetExceeded { kind = "Input"; _ }) -> true
-  | _ -> false
+  (* Output / non-input token budget exceeded does not represent prompt overflow. *)
+  | Agent_sdk.Error.Agent (TokenBudgetExceeded _) -> false
+  (* Other API error variants do not indicate context overflow. *)
+  | Agent_sdk.Error.Api (RateLimited _)
+  | Agent_sdk.Error.Api (Overloaded _)
+  | Agent_sdk.Error.Api (ServerError _)
+  | Agent_sdk.Error.Api (AuthError _)
+  | Agent_sdk.Error.Api (InvalidRequest _)
+  | Agent_sdk.Error.Api (NotFound _)
+  | Agent_sdk.Error.Api (NetworkError _)
+  | Agent_sdk.Error.Api (Timeout _) -> false
+  (* Other agent error variants. *)
+  | Agent_sdk.Error.Agent (MaxTurnsExceeded _)
+  | Agent_sdk.Error.Agent (CostBudgetExceeded _)
+  | Agent_sdk.Error.Agent (UnrecognizedStopReason _)
+  | Agent_sdk.Error.Agent (IdleDetected _)
+  | Agent_sdk.Error.Agent (ToolRetryExhausted _)
+  | Agent_sdk.Error.Agent (CompletionContractViolation _)
+  | Agent_sdk.Error.Agent (GuardrailViolation _)
+  | Agent_sdk.Error.Agent (TripwireViolation _)
+  | Agent_sdk.Error.Agent (ExitConditionMet _) -> false
+  (* Non-API / non-Agent error families. *)
+  | Agent_sdk.Error.Mcp _
+  | Agent_sdk.Error.Config _
+  | Agent_sdk.Error.Serialization _
+  | Agent_sdk.Error.Io _
+  | Agent_sdk.Error.Orchestration _
+  | Agent_sdk.Error.A2a _
+  | Agent_sdk.Error.Internal _ -> false
 
 (** [true] when an error represents terminal cascade exhaustion or a
     final accept-rejected result from the MASC OAS boundary. *)


### PR DESCRIPTION
## Summary

Closes part of #14195. Converts the 9 catch-all patterns in `lib/keeper/keeper_error_classify.ml` (the `keeper_error_classify` row in the issue's High-risk table) to exhaustive `match` expressions over `Agent_sdk.Error.sdk_error` and the structured `Oas_worker_named` MASC-internal error variants.

The issue tracked 7 in this file by line; the actual count via `rg '\| _ ->' lib/keeper/keeper_error_classify.ml` is 9 (one is an inline `let is_timeout = match … | _ -> false`, one is on the post-commit failure kind helper). All 9 are now explicit.

## Why

Previous behavior: any new variant added to upstream `agent_sdk`'s `api_error` / `agent_error` (or to MASC's internal Oas_worker_named error) would silently fall into `_ -> false` / `_ -> None` and the runtime classification would diverge without any compile-time signal.

After this PR the compiler forces every reader of these classifiers to be updated when an upstream variant is added. This matches the rule in `instructions/software-development.md` §"AI 코드 생성 안티패턴 #4 — FSM Sparse Match / `_ -> false` Catch-all".

## Scope (this PR)

| Function | Was | Now |
|---|---|---|
| `is_transient_network_error` | `_ -> false` | enumerates 6 non-transient `api_error` + 8 non-`Api` families |
| `is_server_rejected_parse_error` | `_ -> false` | enumerates 8 other `api_error` + 8 non-`Api` families |
| `is_required_tool_contract_violation` | `_ -> false` | enumerates 9 other `agent_error` + 8 non-`Agent` families |
| `recoverable_cascade_failure_reason` (inner) | `_ -> None` | enumerates 7 other `api_error` + 8 non-`Api` families |
| `is_ambiguous_side_effect_error` | nested 2× `_ -> false` | both layers enumerated |
| inline `is_timeout` in `reclassify_error_after_side_effect` | `_ -> false` | full enumeration |
| `post_commit_failure_kind_of_error` | `_ -> Post_commit_failure` | full enumeration |
| `is_context_overflow` | `_ -> false` | enumerates `TokenBudgetExceeded` non-Input + other families |

Behavior is preserved: every variant that was previously absorbed by the catch-all is still mapped to the same value, just explicitly enumerated.

## Verification

- `dune build --root . @check` — clean (no warnings)
- `dune build --root . lib/keeper` — clean
- `rg -c '\| _ ->' lib/keeper/keeper_error_classify.ml` — `0`
- `.mli` interface unchanged

## Out of scope

Per #14195's risk-tiered approach, the remaining ~91 catch-alls in other `lib/keeper/` files (medium/low risk) are not addressed here. They will be handled in follow-up PRs grouped by file (e.g. `keeper_status_bridge.ml`, `keeper_supervisor.ml`, `keeper_types_profile.ml`).

## Risk

Low — pure refactor; no logic changes, no `.mli` change, public API preserved. The only externally-observable change is that adding a new `Agent_sdk.Error` variant upstream will now break this module's compile until each function's match is updated.

## Refs

- Issue: #14195
- Anti-pattern rule: `instructions/software-development.md` §AI 코드 생성 안티패턴 #4
- Reference exhaustive-match precedent: `lib/oas_event_bridge.ml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
