### PR TITLE
refactor(keeper): exhaustive match in keeper_status_bridge sum-type catch-alls (#14195)

### DIFF
--- a/lib/keeper/keeper_status_bridge.ml
+++ b/lib/keeper/keeper_status_bridge.ml
@@ -232,7 +232,27 @@ let blocker_class_of_sdk_error (err : Agent_sdk.Error.sdk_error) : blocker_class
              enum target.  Direct typed match preferred over text-substring
              fallback when the SDK gave us a structured error. *)
           Some Completion_contract_violation
-      | _ -> None)
+      (* Other agent_error variants do not carry a structured blocker_class.
+         If a new agent variant deserves its own blocker_class, the compiler
+         will force a decision here when it is added upstream. *)
+      | Agent_sdk.Error.Agent (MaxTurnsExceeded _)
+      | Agent_sdk.Error.Agent (TokenBudgetExceeded _)
+      | Agent_sdk.Error.Agent (CostBudgetExceeded _)
+      | Agent_sdk.Error.Agent (UnrecognizedStopReason _)
+      | Agent_sdk.Error.Agent (IdleDetected _)
+      | Agent_sdk.Error.Agent (ToolRetryExhausted _)
+      | Agent_sdk.Error.Agent (GuardrailViolation _)
+      | Agent_sdk.Error.Agent (TripwireViolation _)
+      | Agent_sdk.Error.Agent (ExitConditionMet _) -> None
+      (* Provider-level [Api] errors are surfaced via OAS retry / cascade
+         layers and do not map to a typed blocker_class by themselves. *)
+      | Agent_sdk.Error.Api _
+      | Agent_sdk.Error.Mcp _
+      | Agent_sdk.Error.Config _
+      | Agent_sdk.Error.Serialization _
+      | Agent_sdk.Error.Io _
+      | Agent_sdk.Error.Orchestration _
+      | Agent_sdk.Error.A2a _ -> None)
 
 (* ── Runtime blocker surface ───────────────────────────────── *)
 
@@ -267,7 +287,18 @@ let runtime_blocker_surface_of_typed_class ?(summary = "") (cls : blocker_class)
             | Some structured_summary -> structured_summary
             | None -> if summary = "" then str else summary)
         | None -> if summary = "" then str else summary)
-    | _ -> if summary = "" then str else summary
+    (* All remaining blocker_class variants carry no class-specific summary
+       transformation — fall back to the live summary or the typed name. *)
+    | Ambiguous_post_commit_timeout
+    | Ambiguous_post_commit_failure
+    | Autonomous_slot_wait_timeout
+    | Admission_queue_wait_timeout
+    | Turn_timeout_after_queue_wait
+    | Turn_timeout
+    | Completion_contract_violation
+    | Fiber_unresolved
+    | Stale_turn_timeout
+    | Stale_fleet_batch -> if summary = "" then str else summary
   in
   { blocker_class = str; summary; continue_gate }
 
@@ -275,7 +306,20 @@ let runtime_blocker_surface_of_legacy_string reason cls =
   match cls with
   | Cascade_exhausted _ ->
       runtime_blocker_surface_of_typed_class cls
-  | _ ->
+  (* All other blocker classes carry no embedded reason payload, so the
+     legacy string [reason] argument provides the fallback summary. *)
+  | Ambiguous_post_commit_timeout
+  | Ambiguous_post_commit_failure
+  | Autonomous_slot_wait_timeout
+  | Admission_queue_wait_timeout
+  | Turn_timeout_after_queue_wait
+  | Oas_timeout_budget
+  | Turn_timeout
+  | Completion_contract_violation
+  | No_tool_capable_provider
+  | Fiber_unresolved
+  | Stale_turn_timeout
+  | Stale_fleet_batch ->
       runtime_blocker_surface_of_typed_class ~summary:reason cls
 
 let stale_kill_class_summary (kill_class : Keeper_registry.stale_kill_class) =


### PR DESCRIPTION
## Summary

Closes part of #14195. Converts the 3 *sum-type* catch-all patterns in `lib/keeper/keeper_status_bridge.ml` to exhaustive matches.

## Why

Memory `feedback_keeper_status_bridge_sdk_error_unmapped_variants.md` records that `blocker_class_of_sdk_error` silently dropped 5+ `agent_error` variants under its `_ -> None` arm. Same shape for the two `blocker_class` matches in `runtime_blocker_surface_of_typed_class` / `_of_legacy_string` — any new `blocker_class` variant added to `keeper_types.mli` would have been absorbed silently.

After this PR the compiler forces every reader to be updated when an `agent_error` or `blocker_class` variant is added.

## Scope (this PR)

| Function | Was | Now |
|---|---|---|
| `blocker_class_of_sdk_error` (inner) | `_ -> None` (absorbed 9 agent + 7 non-Agent families) | full enumeration of all 9 `agent_error` variants + 7 non-`Agent` families |
| `runtime_blocker_surface_of_typed_class` (inner) | `_ -> if summary = "" then str else summary` | enumerates 10 remaining `blocker_class` variants |
| `runtime_blocker_surface_of_legacy_string` | `_ -> runtime_blocker_surface_of_typed_class ~summary:reason cls` | enumerates 12 remaining `blocker_class` variants |

Behavior is preserved: every variant previously absorbed by a catch-all is now mapped to the same value, just explicitly enumerated.

## Out of scope (intentional)

13 of the 16 raw `| _ ->` patterns in this file are not sum-type catch-alls and are left untouched:

| Lines | Pattern | Why kept |
|---|---|---|
| 57, 64, 72, 87 | `_ -> acc` (fold accumulator on `option`) | `Option` only has 2 variants; predicate guards already cover both — no enforcement value |
| 270, 421, 638, 653, 665, 673, 806 | option / Yojson `_ -> None` / `_ -> false` | option/Yojson destructuring; not a closed sum that benefits from variant enforcement |
| 458, 462, 495 | nested string-search fallbacks | `option line_with` chained heuristic; not a sum type |

Converting these would lengthen the file without adding compile-time enforcement against new `agent_error` / `blocker_class` variants — exactly the anti-pattern guard the issue is targeting.

## Verification

- `git diff --stat`: 1 file changed, +47/-3
- `rg -c '\| _ ->' lib/keeper/keeper_status_bridge.ml`: `13` (was `16`; the 3 high-value sum-type catch-alls are gone)
- `.mli` interface unchanged

## CI status note

`origin/main` (commit `cd1945b475`, PR #14198) introduced two pre-existing compile errors in `lib/cascade/cascade_metrics.ml` + `lib/cascade/cascade_fsm.mli` that are **unrelated** to this PR. CI for this PR will fail on the cascade module before reaching `lib/keeper/`. A separate hotfix PR is being prepared for the cascade blockers; once that lands, this PR should be rebased and CI re-run.

## Risk

Low — pure refactor; no logic changes, no `.mli` change, public API preserved.

## Refs

- Issue: #14195
- Memory: `memory/feedback_keeper_status_bridge_sdk_error_unmapped_variants.md`
- Anti-pattern rule: `instructions/software-development.md` §AI 코드 생성 안티패턴 #4
- Predecessor PR: #14199 (`keeper_error_classify` exhaustive match)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
