### PR TITLE
hotfix(cascade): repair main build broken by #14198

### DIFF
--- a/lib/cascade/cascade_fsm.mli
+++ b/lib/cascade/cascade_fsm.mli
@@ -57,8 +57,8 @@ val decide :
 val decide_and_record :
   cascade_name:string ->
   accept_on_exhaustion:bool ->
-  is_last:bool -
-  provider_outcome -
+  is_last:bool ->
+  provider_outcome ->
   decision
 (** Observable wrapper around [decide]. Emits Prometheus counters for
     cascade decisions, fallbacks, and exhaustion events before returning

--- a/lib/cascade/cascade_metrics.ml
+++ b/lib/cascade/cascade_metrics.ml
@@ -2,25 +2,34 @@
 
     Mirrors TLA+ invariants in runtime telemetry.
 
+    Metric ownership follows RFC-0043: this module owns the cascade metric
+    name constants. [Prometheus.ml]'s [register_all()] still mirrors them
+    for /metrics endpoint registration (transitional); the SSOT remains here.
+
     @since 0.192.0 *)
 
+let metric_decisions = "masc_cascade_decisions_total"
+let metric_fallbacks = "masc_cascade_fallbacks_total"
+let metric_providers_exhausted = "masc_cascade_providers_exhausted_total"
+let metric_routing_phase_overrides = "masc_cascade_routing_phase_overrides_total"
+
 let on_decision ~cascade_name ~decision_label =
-  Prometheus.inc_counter Prometheus.metric_cascade_decisions
+  Prometheus.inc_counter metric_decisions
     ~labels:[ ("decision", decision_label); ("cascade", cascade_name) ]
     ()
 
 let on_fallback ~cascade_name ~reason =
-  Prometheus.inc_counter Prometheus.metric_cascade_fallbacks
+  Prometheus.inc_counter metric_fallbacks
     ~labels:[ ("reason", reason); ("cascade", cascade_name) ]
     ()
 
 let on_exhausted ~cascade_name =
-  Prometheus.inc_counter Prometheus.metric_cascade_providers_exhausted
+  Prometheus.inc_counter metric_providers_exhausted
     ~labels:[ ("cascade", cascade_name) ]
     ()
 
 let on_phase_override ~phase ~from_cascade ~to_cascade =
-  Prometheus.inc_counter Prometheus.metric_cascade_routing_phase_overrides
+  Prometheus.inc_counter metric_routing_phase_overrides
     ~labels:
       [ ("phase", phase)
       ; ("from_cascade", from_cascade)


### PR DESCRIPTION
## Summary

PR #14198 (`cd1945b475`, merged 2026-05-08 11:00 KST) introduced two build failures present on main right now. This PR is the minimal fix to restore `dune build` green.

## Two bugs

### 1. `lib/cascade/cascade_fsm.mli:60-61` — truncated `->`

```
is_last:bool -
provider_outcome -
```

Both arrows lost the `>` (likely an editor/sed accident — line 43-44 of the same file have correct `is_last:bool ->` / `provider_outcome ->`).

**Fix**: restore arrows.

### 2. `lib/cascade/cascade_metrics.ml` — Prometheus metric refs hidden by signature

`cascade_metrics.ml` references `Prometheus.metric_cascade_decisions` (and 3 siblings). Those `let` bindings exist in `lib/prometheus.ml:715-722` but are NOT exposed via `lib/prometheus.mli`. Result: `Error: Unbound value Prometheus.metric_cascade_decisions`.

**Fix**: define the 4 metric name constants directly inside `cascade_metrics.ml` (RFC-0043 alignment — domain module owns its metrics). `Prometheus.ml`'s mirrors and `register_all()` registrations stay (transitional); cleanup-removal can come in a proper RFC-0043 follow-up.

## Verification

- `dune build --root .` → exit 0 (was 2 failed pre-fix)
- 2 files touched, +15/-6 LOC
- Behavior change: 0 (metric strings identical, definitions just relocated)

## Why hotfix instead of waiting for RFC-0043 PR

main is currently red. Every other PR's CI is running on a broken base. This is the smallest correct fix; full RFC-0043 cascade migration (remove the prometheus.ml mirrors, drop them from `register_all`, keep cascade_metrics.ml as SSOT) belongs in a separate PR with own scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)