### PR TITLE
fix(cascade): repair main blocker after #14198 — mli typo + missing prometheus.mli expose

### DIFF
--- a/lib/cascade/cascade_fsm.mli
+++ b/lib/cascade/cascade_fsm.mli
@@ -57,8 +57,8 @@ val decide :
 val decide_and_record :
   cascade_name:string ->
   accept_on_exhaustion:bool ->
-  is_last:bool -
-  provider_outcome -
+  is_last:bool ->
+  provider_outcome ->
   decision
 (** Observable wrapper around [decide]. Emits Prometheus counters for
     cascade decisions, fallbacks, and exhaustion events before returning

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -510,6 +510,22 @@ val metric_cascade_provider_health_score : string
     [success_rate * speed_score * cost_score] in [0.0, 1.0].
     Labels: [provider_key]. *)
 
+val metric_cascade_decisions : string
+(** Counter: cascade routing decisions emitted by [Cascade_fsm.decide].
+    Labels: [decision] in [accept|accept_on_exhaustion|try_next|exhausted]. *)
+
+val metric_cascade_fallbacks : string
+(** Counter: cascade fallback transitions ([Try_next] outcomes).
+    Labels: [reason] in [call_err|slot_full|accept_rejected|health_filter]. *)
+
+val metric_cascade_providers_exhausted : string
+(** Counter: terminal exhaustion events emitted when a cascade has no
+    further provider candidates. *)
+
+val metric_cascade_routing_phase_overrides : string
+(** Counter: cascade routing phase overrides applied during decision.
+    Labels: [phase], [from_cascade], [to_cascade]. *)
+
 val metric_oas_context_overflow_ratio : string
 (** Gauge: context overflow ratio [estimated_tokens / limit_tokens] when
     [ContextOverflowImminent] fires.  Labels: [agent_name]. *)


### PR DESCRIPTION
## Summary

Restores `dune build --root . @check` to clean on `main`. Two pre-existing compile errors landed in `cd1945b475` (PR #14198 `feat(cascade): Prometheus metrics for cascade routing observability`) and are not covered by any open PR (`gh pr list --search 'cascade Prometheus' --state open` → empty).

## Errors fixed

### 1. `lib/cascade/cascade_fsm.mli:60-61` — Syntax error

```
val decide_and_record :
  cascade_name:string ->
  accept_on_exhaustion:bool ->
  is_last:bool -            ← was `-`, fixed to `->`
  provider_outcome -        ← was `-`, fixed to `->`
  decision
```

Likely a rebase artifact — the `>` was clipped from both arrows.

### 2. `lib/prometheus.mli` — `Unbound value` for 4 metric symbols

`cascade_metrics.ml` (added in #14198) calls:

- `Prometheus.metric_cascade_decisions`
- `Prometheus.metric_cascade_fallbacks`
- `Prometheus.metric_cascade_providers_exhausted`
- `Prometheus.metric_cascade_routing_phase_overrides`

All four are defined in `lib/prometheus.ml` (lines 715-722) but were never added to `lib/prometheus.mli`, so the structure restricts them out at the module boundary.

Fix: add four `val` declarations to `prometheus.mli` immediately after `metric_cascade_provider_health_score`, using doc strings that mirror the inline notes already present in `prometheus.ml`.

## Verification

Before:

```
File "lib/cascade/cascade_metrics.ml", line 8: Error: Unbound value Prometheus.metric_cascade_decisions
File "lib/cascade/cascade_fsm.mli", line 60: Error: Syntax error
```

After: `dune build --root . @check` exits clean.

## Risk

None — `.mli` declarations are restorations of contracts the `.ml` files already implement. No behavior changes.

## Out of scope

Memory `feedback_main_blocker_chain_4x_session.md` and `feedback_pre_merge_typecheck_drag_in_blocker.md` already capture the recurring pattern: PRs merged before `dune build @check` is verified locally. A `Build CI` required-status follow-up would prevent recurrence, but that is broader than this hotfix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
