### PR TITLE
refactor(keeper): exhaustive match in keeper_supervisor sum-type catch-alls (#14195)

### DIFF
--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -83,7 +83,21 @@ let should_cleanup_dead ~now ~dead_ttl_sec
   match entry.phase, entry.dead_since_ts with
   | Keeper_state_machine.Dead, Some dead_since ->
       now -. dead_since >= dead_ttl_sec
-  | _ -> false
+  (* Dead but no [dead_since_ts] yet — first observation will set it. *)
+  | Keeper_state_machine.Dead, None -> false
+  (* Non-Dead phases never trigger Dead cleanup, regardless of timestamp. *)
+  | (Keeper_state_machine.Offline
+    | Keeper_state_machine.Running
+    | Keeper_state_machine.Failing
+    | Keeper_state_machine.Overflowed
+    | Keeper_state_machine.Compacting
+    | Keeper_state_machine.HandingOff
+    | Keeper_state_machine.Draining
+    | Keeper_state_machine.Paused
+    | Keeper_state_machine.Stopped
+    | Keeper_state_machine.Crashed
+    | Keeper_state_machine.Restarting
+    | Keeper_state_machine.Zombie), _ -> false
 
 (** Check if a paused keeper meta file on disk is stale enough to remove. *)
 let is_stale_paused_meta ~now ~paused_ttl_sec (meta : keeper_meta) =
@@ -284,7 +298,15 @@ let launch_supervised_fiber ~proactive_warmup_sec ctx (meta : keeper_meta)
                  | Some (Keeper_registry.Stale_termination_storm _)
                  | Some (Keeper_registry.Stale_fleet_batch _)
                  | Some (Keeper_registry.Oas_timeout_budget_loop _) -> true
-                 | _ -> false)
+                 (* Other failure reasons are not stale-watchdog signals. *)
+                 | Some (Keeper_registry.Heartbeat_consecutive_failures _)
+                 | Some (Keeper_registry.Turn_consecutive_failures _)
+                 | Some (Keeper_registry.Provider_runtime_error _)
+                 | Some (Keeper_registry.Tool_required_unsatisfied _)
+                 | Some (Keeper_registry.Ambiguous_partial_commit _)
+                 | Some Keeper_registry.Fiber_unresolved
+                 | Some (Keeper_registry.Exception _)
+                 | None -> false)
              | None -> false
            in
            if watchdog_triggered then begin
@@ -1273,7 +1295,19 @@ let sweep_and_recover (ctx : _ context) =
            burns another multi-minute budget, so pause instead. *)
         handle_oas_timeout_budget_pause ctx entry ~count;
         to_unregister := entry :: !to_unregister
-    | _ ->
+    (* All other failure reasons (and missing reason) fall through to the
+       standard restart-budget path: restart up to [max_restarts], then mark
+       Dead.  Any new [failure_reason] variant that warrants pause-instead-of-
+       restart must be added explicitly; the compiler will enforce it. *)
+    | Some (Keeper_registry.Heartbeat_consecutive_failures _)
+    | Some (Keeper_registry.Turn_consecutive_failures _)
+    | Some (Keeper_registry.Stale_turn_timeout _)
+    | Some (Keeper_registry.Provider_runtime_error _)
+    | Some (Keeper_registry.Tool_required_unsatisfied _)
+    | Some (Keeper_registry.Ambiguous_partial_commit _)
+    | Some Keeper_registry.Fiber_unresolved
+    | Some (Keeper_registry.Exception _)
+    | None ->
         if entry.restart_count >= max_restarts then
           to_mark_dead := (entry, msg) :: !to_mark_dead
         else begin
@@ -1290,7 +1324,15 @@ let sweep_and_recover (ctx : _ context) =
     | Some (Keeper_registry.Stale_termination_storm _)
     | Some (Keeper_registry.Stale_fleet_batch _)
     | Some (Keeper_registry.Oas_timeout_budget_loop _) -> true
-    | _ -> false
+    (* Other failure reasons are not stale-watchdog signals. *)
+    | Some (Keeper_registry.Heartbeat_consecutive_failures _)
+    | Some (Keeper_registry.Turn_consecutive_failures _)
+    | Some (Keeper_registry.Provider_runtime_error _)
+    | Some (Keeper_registry.Tool_required_unsatisfied _)
+    | Some (Keeper_registry.Ambiguous_partial_commit _)
+    | Some Keeper_registry.Fiber_unresolved
+    | Some (Keeper_registry.Exception _)
+    | None -> false
   in
   let force_unresolved_watchdog_crash (entry : Keeper_registry.registry_entry) =
     let msg =
@@ -1316,7 +1358,15 @@ let sweep_and_recover (ctx : _ context) =
       | Some (Keeper_registry.Stale_turn_timeout _)
       | Some (Keeper_registry.Stale_termination_storm _) ->
         Some Stale_turn_timeout
-      | _ -> None
+      (* Non-watchdog failure reasons do not seed a watchdog blocker_class. *)
+      | Some (Keeper_registry.Heartbeat_consecutive_failures _)
+      | Some (Keeper_registry.Turn_consecutive_failures _)
+      | Some (Keeper_registry.Provider_runtime_error _)
+      | Some (Keeper_registry.Tool_required_unsatisfied _)
+      | Some (Keeper_registry.Ambiguous_partial_commit _)
+      | Some Keeper_registry.Fiber_unresolved
+      | Some (Keeper_registry.Exception _)
+      | None -> None
     in
     (match stamp_cohort with
      | None -> ()
@@ -2067,7 +2117,17 @@ let request_alive_but_stuck_recovery ~base_path ~elapsed
         | Keeper_registry.Stale_fleet_batch _
         | Keeper_registry.Oas_timeout_budget_loop _ ) as kept ->
         kept
-    | _ -> Some (Keeper_registry.Stale_turn_timeout kill_class)
+    (* Non-stale failure reasons (and no prior reason) are overwritten with
+       a fresh [Stale_turn_timeout] carrying the current kill class.  Any new
+       [failure_reason] variant must be classified explicitly here. *)
+    | Some (Keeper_registry.Heartbeat_consecutive_failures _)
+    | Some (Keeper_registry.Turn_consecutive_failures _)
+    | Some (Keeper_registry.Provider_runtime_error _)
+    | Some (Keeper_registry.Tool_required_unsatisfied _)
+    | Some (Keeper_registry.Ambiguous_partial_commit _)
+    | Some Keeper_registry.Fiber_unresolved
+    | Some (Keeper_registry.Exception _)
+    | None -> Some (Keeper_registry.Stale_turn_timeout kill_class)
   in
   Keeper_registry.set_failure_reason ~base_path entry.name reason;
   (* tla-lint: allow-mutation: fiber signal — alive-but-stuck recovery asks


### PR DESCRIPTION
## Summary

Closes part of #14195. Converts the 6 *sum-type* catch-all patterns in `lib/keeper/keeper_supervisor.ml` to exhaustive matches over `Keeper_state_machine.phase` (13 variants) and `Keeper_registry.failure_reason` (11 variants).

## Why

The supervisor decides whether to restart, pause, or mark Dead based on `last_failure_reason`. With `_ -> false` / `_ -> None` catch-alls, any new `failure_reason` variant added upstream silently fell into the default arm — including new pause-eligible failure modes. After this PR the compiler forces an explicit pause-vs-restart decision per variant.

Same shape for `phase` in `should_cleanup_dead` — only `Dead` had explicit handling; the catch-all absorbed all 12 other phases plus the `None` timestamp case.

## Scope (this PR)

| Function | Sum type | Was | Now |
|---|---|---|---|
| `should_cleanup_dead` | `(phase, dead_since_ts)` | `_ -> false` (absorbed 25 of 26 cases) | `(Dead, Some _)`, `(Dead, None)`, and 12 non-Dead phases × any timestamp enumerated |
| `watchdog_triggered` (resume path) | `failure_reason option` | `_ -> false` | 7 non-watchdog variants + `None` enumerated |
| `queue_crashed_entry` (sweep path) | `failure_reason option` | `_ -> default-restart` | 8 fall-through variants + `None` enumerated explicitly |
| `watchdog_stop_pending` | `failure_reason option` | `_ -> false` | 7 non-watchdog variants + `None` enumerated |
| `stamp_cohort` (force_unresolved_watchdog_crash) | `failure_reason option -> blocker_class option` | `_ -> None` | 7 non-watchdog variants + `None` enumerated |
| `record_stale_failure_reason` | `failure_reason option` | `_ -> Some (Stale_turn_timeout kill_class)` | 7 non-stale variants + `None` enumerated explicitly |

Behavior is preserved — every variant previously absorbed by a catch-all is now mapped to the same value, just explicitly enumerated.

## Out of scope (intentional)

14 of the 20 raw `| _ ->` patterns in this file are not sum-type catch-alls and are left untouched:

| Lines | Pattern | Why kept |
|---|---|---|
| 56 | `_ -> ` recursive cohort split on `list` | List with `[]` and `_::_`; standard recursive shape |
| 139, 140, 141, 154 | Yojson `_ -> []` / `_ -> None` | JSON destructuring, not closed-sum variant enforcement |
| 376 | `_ -> Exception "fiber_crash …"` | Exception fallback over `match exn with`; OCaml exns are open |
| 616, 1020 | `_ -> meta` / `_ -> Some e.name` | option / Result fallback |
| 1445, 1585, 1618, 1701 | `_ -> ()` unit fold over option | Option default, no enforcement value |
| 1563, 1999 | `_ -> ` exception/Hashtbl fallback | open type / time guard |

Converting these would lengthen the file without adding compile-time enforcement against new `failure_reason` / `phase` variants — exactly the anti-pattern the issue is targeting.

## Verification

- Cherry-picked hotfix #14202 (cascade_fsm.mli + prometheus.mli) on top to bypass the unrelated main blocker, ran `dune build --root . @check` — clean. Cherry-pick was reverted before commit.
- `git diff --stat`: 1 file changed, +66/-6
- `rg -c '\| _ ->' lib/keeper/keeper_supervisor.ml`: `14` (was `20`; the 6 high-value sum-type catch-alls are gone)
- `.mli` interface unchanged

## CI status note

`origin/main` (commit `cd1945b475`, PR #14198) introduced two pre-existing compile errors in `lib/cascade/`. CI for this PR will fail on the cascade module before reaching `lib/keeper/`. PR #14202 fixes those; once it lands, this PR should be rebased and CI re-run.

## Risk

Low — pure refactor; no logic changes, no `.mli` change, public API preserved.

## Refs

- Issue: #14195
- Anti-pattern rule: `instructions/software-development.md` §AI 코드 생성 안티패턴 #4
- Predecessors: #14199 (`keeper_error_classify`), #14200 (`keeper_status_bridge`)
- Hotfix dependency: #14202

🤖 Generated with [Claude Code](https://claude.com/claude-code)
