### PR TITLE
refactor(keeper): exhaustive match in keeper_context_core sum-type catch-alls (#14195)

### DIFF
--- a/lib/keeper/keeper_context_core.ml
+++ b/lib/keeper/keeper_context_core.ml
@@ -295,9 +295,19 @@ let message_to_json (m : Agent_sdk.Types.message) : Yojson.Safe.t =
              List.find_map
                (function
                  | Agent_sdk.Types.ToolResult { tool_use_id; _ } -> Some tool_use_id
-                 | _ -> None)
+                 (* Other content_block variants do not carry a tool_use_id. *)
+                 | Agent_sdk.Types.Text _
+                 | Agent_sdk.Types.Thinking _
+                 | Agent_sdk.Types.RedactedThinking _
+                 | Agent_sdk.Types.ToolUse _
+                 | Agent_sdk.Types.Image _
+                 | Agent_sdk.Types.Document _
+                 | Agent_sdk.Types.Audio _ -> None)
                m.content
-         | _ -> None)
+         (* Non-Tool roles never own a tool_call_id. *)
+         | Agent_sdk.Types.System
+         | Agent_sdk.Types.User
+         | Agent_sdk.Types.Assistant -> None)
   in
   (* SSOT: structured [content_blocks] only. The previous flat [content]
      field was a duplicate of [text_of_message m] used by legacy
@@ -371,21 +381,42 @@ let tool_use_ids_of_message (msg : Agent_sdk.Types.message) : string list =
   List.filter_map
     (function
       | Agent_sdk.Types.ToolUse { id; _ } -> Some id
-      | _ -> None)
+      (* Only [ToolUse] carries a tool-use id; other blocks contribute none. *)
+      | Agent_sdk.Types.Text _
+      | Agent_sdk.Types.Thinking _
+      | Agent_sdk.Types.RedactedThinking _
+      | Agent_sdk.Types.ToolResult _
+      | Agent_sdk.Types.Image _
+      | Agent_sdk.Types.Document _
+      | Agent_sdk.Types.Audio _ -> None)
     msg.content
 
 let tool_result_ids_of_message (msg : Agent_sdk.Types.message) : string list =
   List.filter_map
     (function
       | Agent_sdk.Types.ToolResult { tool_use_id; _ } -> Some tool_use_id
-      | _ -> None)
+      (* Only [ToolResult] carries a tool_use_id reference; others contribute none. *)
+      | Agent_sdk.Types.Text _
+      | Agent_sdk.Types.Thinking _
+      | Agent_sdk.Types.RedactedThinking _
+      | Agent_sdk.Types.ToolUse _
+      | Agent_sdk.Types.Image _
+      | Agent_sdk.Types.Document _
+      | Agent_sdk.Types.Audio _ -> None)
     msg.content
 
 let has_tool_result_block (msg : Agent_sdk.Types.message) : bool =
   List.exists
     (function
       | Agent_sdk.Types.ToolResult _ -> true
-      | _ -> false)
+      (* Only [ToolResult] qualifies; other blocks are not tool-result evidence. *)
+      | Agent_sdk.Types.Text _
+      | Agent_sdk.Types.Thinking _
+      | Agent_sdk.Types.RedactedThinking _
+      | Agent_sdk.Types.ToolUse _
+      | Agent_sdk.Types.Image _
+      | Agent_sdk.Types.Document _
+      | Agent_sdk.Types.Audio _ -> false)
     msg.content
 
 (** Trim messages to at most [max_count] while preserving ToolUse/ToolResult
@@ -464,7 +495,14 @@ let repair_dangling_tool_use_messages
         (function
           | Agent_sdk.Types.ToolUse { id; _ } ->
               not (List.mem id next_tool_result_ids)
-          | _ -> false)
+          (* Only [ToolUse] blocks can be dangling without a paired ToolResult. *)
+          | Agent_sdk.Types.Text _
+          | Agent_sdk.Types.Thinking _
+          | Agent_sdk.Types.RedactedThinking _
+          | Agent_sdk.Types.ToolResult _
+          | Agent_sdk.Types.Image _
+          | Agent_sdk.Types.Document _
+          | Agent_sdk.Types.Audio _ -> false)
         current.content
     in
     if not has_dangling then current
@@ -516,7 +554,14 @@ let repair_orphan_tool_result_messages
                 (function
                   | Agent_sdk.Types.ToolResult { tool_use_id; _ } ->
                       not (List.mem tool_use_id prev_tool_use_ids)
-                  | _ -> false)
+                  (* Only [ToolResult] can be orphaned w.r.t. prior ToolUse ids. *)
+                  | Agent_sdk.Types.Text _
+                  | Agent_sdk.Types.Thinking _
+                  | Agent_sdk.Types.RedactedThinking _
+                  | Agent_sdk.Types.ToolUse _
+                  | Agent_sdk.Types.Image _
+                  | Agent_sdk.Types.Document _
+                  | Agent_sdk.Types.Audio _ -> false)
                 msg.content
             in
             if not has_orphan then msg
@@ -777,7 +822,14 @@ let persist_message ?source session msg =
     msg.content
     |> List.filter_map (function
          | Agent_sdk.Types.Text text -> Some text
-         | _ -> None)
+         (* Non-Text blocks contribute no inline text to the legacy field. *)
+         | Agent_sdk.Types.Thinking _
+         | Agent_sdk.Types.RedactedThinking _
+         | Agent_sdk.Types.ToolUse _
+         | Agent_sdk.Types.ToolResult _
+         | Agent_sdk.Types.Image _
+         | Agent_sdk.Types.Document _
+         | Agent_sdk.Types.Audio _ -> None)
     |> String.concat "\n"
   in
   if classify_history_entry ~source:source_text ~content:content_text = Drop_line then


### PR DESCRIPTION
## Summary

Closes part of #14195. Converts the 8 *sum-type* catch-all patterns in `lib/keeper/keeper_context_core.ml` to exhaustive matches over `Agent_sdk.Types.content_block` (8 variants) and `Agent_sdk.Types.role` (4 variants).

## Why

`Agent_sdk.Types.content_block` is an actively-evolving sum (the `Audio` variant was added in a recent SDK release; `RedactedThinking` and `Thinking` are also relatively recent additions). Every `_ -> None` / `_ -> false` catch-all in this file's content-block iterators has been absorbing new variants without any compile-time signal — exactly the silent-drop pattern issue #14195 is targeting.

After this PR the compiler forces every reader to decide what a new content-block contributes when the SDK adds one (e.g. is the new block carrying a `tool_use_id`? does it count as orphan-tool-result evidence? is it text-equivalent for the legacy history field?).

## Scope (this PR)

| Function | Sum type | Was | Now |
|---|---|---|---|
| `message_to_json` (tool_call_id derivation) | `role`, `content_block` | nested `_ -> None` x2 | 4 role variants + 8 content_block variants enumerated |
| `tool_use_ids_of_message` | `content_block` | `_ -> None` | 7 non-ToolUse variants enumerated |
| `tool_result_ids_of_message` | `content_block` | `_ -> None` | 7 non-ToolResult variants enumerated |
| `has_tool_result_block` | `content_block` | `_ -> false` | 7 non-ToolResult variants enumerated |
| `trim_pending_tool_calls` (dangling check) | `content_block` | `_ -> false` | 7 non-ToolUse variants enumerated |
| `trim_pending_tool_calls` (orphan check) | `content_block` | `_ -> false` | 7 non-ToolResult variants enumerated |
| legacy `content_text` derivation | `content_block` | `_ -> None` | 7 non-Text variants enumerated |

Behavior is preserved — every variant previously absorbed by a catch-all is now mapped to the same value, just explicitly enumerated.

## Out of scope (intentional)

17 of the 24 raw `| _ ->` patterns in this file are not sum-type catch-alls and are left untouched:

| Pattern | Why kept |
|---|---|
| `_ -> None` / `_ -> []` after `match Yojson.Safe.Util.member …` | Yojson destructuring; Yojson is a polymorphic-variant facade and the high-arity sum is not fluctuating |
| `_ -> ""` / `_ -> drop` / `_ -> fallback` on option/result destructuring | Option / Result patterns; not a fluctuating closed sum |
| `Sys_error _ \| _ -> "[UNEXPECTED]"` exception classifier | OCaml exceptions are an open type; exhaustive match is impossible |
| `match raw_role with "system" \| "user" \| … \| _ -> None` | String dispatch, not a sum |

Converting these would lengthen the file without adding compile-time enforcement.

## Verification

- `dune build --root . @check` — clean
- `git diff --stat`: 1 file changed, +60/-8
- `rg -c '\| _ ->' lib/keeper/keeper_context_core.ml` — `16` (was `24`; 8 sum-type catch-alls gone)
- `.mli` interface unchanged

## Risk

Low — pure refactor; no logic changes, no `.mli` change, public API preserved.

## Issue triage note

Initial scan of the remaining `lib/keeper/` files in #14195 (`keeper_types_profile.ml`, `keeper_shell_docker.ml`, `keeper_exec_context.ml`, `keeper_exec_tools.ml`) shows the bulk of their raw `| _ ->` counts are string match / option / Yojson / exception patterns rather than closed-sum enforcement gaps. The high-value sum-type sweep across `lib/keeper/` is largely complete with PR #14199 + #14200 + #14203 + this PR (~30 sum-type catch-alls converted across 4 files); the remaining ~70 are candidates for the lint-rule path the issue itself proposes for low-risk patterns.

## Refs

- Issue: #14195
- Anti-pattern rule: `instructions/software-development.md` §AI 코드 생성 안티패턴 #4
- Predecessors: #14199 (`keeper_error_classify`), #14200 (`keeper_status_bridge`), #14203 (`keeper_supervisor`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
