### PR TITLE
refactor(oas): exhaustive match in oas_worker_named_fsm sum-type catch-alls

### DIFF
--- a/lib/oas_worker_named_fsm.ml
+++ b/lib/oas_worker_named_fsm.ml
@@ -30,7 +30,18 @@ let sdk_error_to_cascade_outcome (err : Agent_sdk.Error.sdk_error)
       (Cascade_fsm.Call_err
          (Llm_provider.Http_client.NetworkError
             { message = detail; kind = Llm_provider.Http_client.Unknown }))
-  | _ -> (
+  (* All other MASC-internal classifications (and unclassified errors) fall
+     through to the structured [match err with] below to derive the cascade
+     outcome from the raw [sdk_error] payload. *)
+  | Some (Oas_worker_named_error.Cascade_exhausted _)
+  | Some (Oas_worker_named_error.No_tool_capable_provider _)
+  | Some (Oas_worker_named_error.Accept_rejected _)
+  | Some (Oas_worker_named_error.Admission_queue_timeout _)
+  | Some (Oas_worker_named_error.Admission_queue_rejected _)
+  | Some (Oas_worker_named_error.Turn_timeout _)
+  | Some (Oas_worker_named_error.Oas_timeout_budget _)
+  | Some (Oas_worker_named_error.Ambiguous_post_commit _)
+  | None -> (
   match err with
   | Agent_sdk.Error.Api api_err ->
     let http_err = match[@warning "-8"] api_err with
@@ -85,7 +96,28 @@ let sdk_error_to_cascade_outcome (err : Agent_sdk.Error.sdk_error)
     Some
       (Cascade_fsm.Call_err
          (Llm_provider.Http_client.AcceptRejected { reason = detail }))
-  | _ -> None)
+  (* Other Agent error variants are structural (budget, idle, exit, retries,
+     guardrails, tripwires) and would recur on any model — not cascadeable. *)
+  | Agent_sdk.Error.Agent (MaxTurnsExceeded _)
+  | Agent_sdk.Error.Agent (TokenBudgetExceeded _)
+  | Agent_sdk.Error.Agent (CostBudgetExceeded _)
+  | Agent_sdk.Error.Agent (IdleDetected _)
+  | Agent_sdk.Error.Agent (ToolRetryExhausted _)
+  | Agent_sdk.Error.Agent (GuardrailViolation _)
+  | Agent_sdk.Error.Agent (TripwireViolation _)
+  | Agent_sdk.Error.Agent (ExitConditionMet _) -> None
+  (* Other Config errors (different InvalidConfig field, MissingEnvVar,
+     UnsupportedProvider) and non-Api / non-Agent / non-Config families are
+     not cascade-recoverable. *)
+  | Agent_sdk.Error.Config (InvalidConfig _)
+  | Agent_sdk.Error.Config (MissingEnvVar _)
+  | Agent_sdk.Error.Config (UnsupportedProvider _)
+  | Agent_sdk.Error.Mcp _
+  | Agent_sdk.Error.Serialization _
+  | Agent_sdk.Error.Io _
+  | Agent_sdk.Error.Orchestration _
+  | Agent_sdk.Error.A2a _
+  | Agent_sdk.Error.Internal _ -> None)
 
 let sdk_error_is_model_access_denied (err : Agent_sdk.Error.sdk_error) =
   match sdk_error_to_cascade_outcome err with
@@ -392,7 +424,15 @@ let sdk_error_is_hard_quota (err : Agent_sdk.Error.sdk_error) : bool =
      | Some message ->
        message_looks_like_cli_wrapped_hard_quota message
      | None -> false)
-  | _ -> false
+  (* Non-Api error families never carry provider-level hard-quota signals. *)
+  | Agent_sdk.Error.Agent _
+  | Agent_sdk.Error.Mcp _
+  | Agent_sdk.Error.Config _
+  | Agent_sdk.Error.Serialization _
+  | Agent_sdk.Error.Io _
+  | Agent_sdk.Error.Orchestration _
+  | Agent_sdk.Error.A2a _
+  | Agent_sdk.Error.Internal _ -> false
 
 let provider_label provider =
   match String.trim provider with
@@ -437,7 +477,15 @@ let sdk_error_to_provider_error ~provider err =
       retry_api_error_to_provider_error ~provider
         ~capacity_exhausted:(sdk_error_is_hard_quota err)
         api_err
-  | _ -> None
+  (* Non-Api families do not map to a provider-level error. *)
+  | Agent_sdk.Error.Agent _
+  | Agent_sdk.Error.Mcp _
+  | Agent_sdk.Error.Config _
+  | Agent_sdk.Error.Serialization _
+  | Agent_sdk.Error.Io _
+  | Agent_sdk.Error.Orchestration _
+  | Agent_sdk.Error.A2a _
+  | Agent_sdk.Error.Internal _ -> None
 
 let provider_error_total_metric = "masc_provider_error_total"
 
@@ -476,7 +524,22 @@ let timeout_source_label (err : Agent_sdk.Error.sdk_error) : string =
     match err with
     | Agent_sdk.Error.Api (Llm_provider.Retry.Timeout { message }) ->
         String_util.contains_substring_ci message "max_execution_time_s"
-    | _ -> false
+    | Agent_sdk.Error.Api (Llm_provider.Retry.RateLimited _)
+    | Agent_sdk.Error.Api (Llm_provider.Retry.Overloaded _)
+    | Agent_sdk.Error.Api (Llm_provider.Retry.ServerError _)
+    | Agent_sdk.Error.Api (Llm_provider.Retry.AuthError _)
+    | Agent_sdk.Error.Api (Llm_provider.Retry.InvalidRequest _)
+    | Agent_sdk.Error.Api (Llm_provider.Retry.NotFound _)
+    | Agent_sdk.Error.Api (Llm_provider.Retry.ContextOverflow _)
+    | Agent_sdk.Error.Api (Llm_provider.Retry.NetworkError _)
+    | Agent_sdk.Error.Agent _
+    | Agent_sdk.Error.Mcp _
+    | Agent_sdk.Error.Config _
+    | Agent_sdk.Error.Serialization _
+    | Agent_sdk.Error.Io _
+    | Agent_sdk.Error.Orchestration _
+    | Agent_sdk.Error.A2a _
+    | Agent_sdk.Error.Internal _ -> false
   in
   if is_max_execution_time then "max_execution_time" else "provider"
 
@@ -521,7 +584,25 @@ let sdk_error_soft_rate_limited (err : Agent_sdk.Error.sdk_error)
   | Agent_sdk.Error.Api (Llm_provider.Retry.RateLimited { retry_after; _ } as api_err)
     when not (Llm_provider.Retry.is_hard_quota api_err) ->
     Some retry_after
-  | _ -> None
+  (* Hard-quota RateLimited is handled separately and other Api / non-Api
+     errors do not represent soft rate limiting. *)
+  | Agent_sdk.Error.Api (Llm_provider.Retry.RateLimited _)
+  | Agent_sdk.Error.Api (Llm_provider.Retry.Overloaded _)
+  | Agent_sdk.Error.Api (Llm_provider.Retry.ServerError _)
+  | Agent_sdk.Error.Api (Llm_provider.Retry.AuthError _)
+  | Agent_sdk.Error.Api (Llm_provider.Retry.InvalidRequest _)
+  | Agent_sdk.Error.Api (Llm_provider.Retry.NotFound _)
+  | Agent_sdk.Error.Api (Llm_provider.Retry.ContextOverflow _)
+  | Agent_sdk.Error.Api (Llm_provider.Retry.NetworkError _)
+  | Agent_sdk.Error.Api (Llm_provider.Retry.Timeout _)
+  | Agent_sdk.Error.Agent _
+  | Agent_sdk.Error.Mcp _
+  | Agent_sdk.Error.Config _
+  | Agent_sdk.Error.Serialization _
+  | Agent_sdk.Error.Io _
+  | Agent_sdk.Error.Orchestration _
+  | Agent_sdk.Error.A2a _
+  | Agent_sdk.Error.Internal _ -> None
 
 let sdk_error_is_max_turns_exceeded (err : Agent_sdk.Error.sdk_error) : bool =
   match Oas_worker_named_error.classify_masc_internal_error err with


### PR DESCRIPTION
## Summary

Extends the same exhaustive-match anti-pattern fix from #14195 (which scoped to `lib/keeper/`) into `lib/oas_worker_named_fsm.ml`.  Converts 6 sum-type `_ -> false` / `_ -> None` catch-alls over `Agent_sdk.Error.sdk_error` (9 variants) and `Oas_worker_named_error.masc_internal_error` (9 variants) to explicit enumerations.

This file sits on the cascade FSM boundary — provider errors flow through these classifiers into the cascade routing decision — so silent-drop on a new agent_sdk variant has a larger blast radius than the keeper-internal classifiers fixed in #14195.

## Why

`instructions/software-development.md` §"AI 코드 생성 안티패턴 #4 — FSM Sparse Match / `_ -> false` Catch-all" specifically targets FSM transition-style matches that absorb new variants without compile-time signal.  `oas_worker_named_fsm.ml` is precisely an FSM (cascade decision FSM bridge) and was carrying 14 of 15 `_ ->` patterns over closed sums (`sdk_error`, `api_error`, `masc_internal_error`).

After this PR the compiler forces a routing decision when:
- agent_sdk adds a new `Retry.api_error` variant
- agent_sdk adds a new `Agent_sdk.Error.*` family
- MASC adds a new `Oas_worker_named_error.masc_internal_error` variant

## Scope (this PR)

| Function | Sum type | Was | Now |
|---|---|---|---|
| `sdk_error_to_cascade_outcome` (outer) | `masc_internal_error option` | `_ -> (...inner...)` | 8 other variants + `None` enumerated |
| `sdk_error_to_cascade_outcome` (inner) | `sdk_error` | `_ -> None` | 8 other Agent variants + 7 non-cascadeable Config / Mcp / Serialization / Io / Orchestration / A2a / Internal enumerated |
| `sdk_error_is_hard_quota` | `sdk_error` | `_ -> false` | 8 non-Api families enumerated |
| `sdk_error_to_provider_error` | `sdk_error` | `_ -> None` | 8 non-Api families enumerated |
| `timeout_source_label` (inline `is_max_execution_time`) | `sdk_error` | `_ -> false` | 8 non-Timeout `api_error` variants + 8 non-Api families enumerated |
| `sdk_error_soft_rate_limited` | `sdk_error` | `_ -> None` | hard-quota RateLimited + 8 other api_error + 8 non-Api families enumerated |

Behavior is preserved — every variant previously absorbed by a catch-all is now mapped to the same value.

## Out of scope (intentional, follow-up candidates)

9 of the 15 raw `| _ ->` patterns are not converted in this PR:

| Pattern class | Why deferred |
|---|---|
| Nested record over `Cascade_fsm.provider_outcome` (e.g. `sdk_error_is_model_access_denied` 7-deep `Some (Call_err (ProviderFailure { kind = Capability_mismatch …}))`) | Negation set explodes when enumerated; needs helper extraction or `function`-style sub-match |
| Nested message-substring heuristic helpers (`message_looks_like_…`) where catch-all is inside a `let … = match api_err with …` binding | Inner sum type is `api_error` but enumeration path requires intermediate let-scope refactor |
| Single-line `_ -> err` / `_ -> ()` pass-throughs (L215, L528) | Same shape but high-volume; bundling separately keeps this PR reviewable |

These can be addressed in a follow-up PR once the helper extractions are scoped.

## Verification

- `dune build --root . @check` — clean
- `git diff --stat`: 1 file changed, +87/-6
- `rg -c '\| _ ->' lib/oas_worker_named_fsm.ml` — `9` (was `15`)
- `.mli` interface unchanged

## Risk

Low — pure refactor; no logic changes, no `.mli` change, public API preserved.

## Refs

- Anti-pattern rule: `instructions/software-development.md` §AI 코드 생성 안티패턴 #4
- Sister PRs (`lib/keeper/` sweep, all merged):
  - #14199 `keeper_error_classify` (9 catch-alls)
  - #14200 `keeper_status_bridge` (3 catch-alls)
  - #14203 `keeper_supervisor` (6 catch-alls)
  - #14204 `keeper_context_core` (8 catch-alls)
- Issue #14195 is the original `lib/keeper/` sweep; this PR is **out of that issue's named scope** but applies the same rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
