### PR TITLE
refactor(oas): exhaustive match in oas_event_bridge sum-type catch-alls

### DIFF
--- a/lib/oas_event_bridge.ml
+++ b/lib/oas_event_bridge.ml
@@ -544,7 +544,19 @@ let emit_native_event_log (evt : Agent_sdk.Event_bus.event) (json : Yojson.Safe.
         (Printf.sprintf
            "context compact started agent=%s trigger=%s"
            agent_name trigger)
-  | _ -> ()
+  (* Variants below previously absorbed by [_ -> ()] catch-all.  Each is
+     enumerated explicitly so adding a new [Agent_sdk.Event_bus.payload]
+     variant fails the build instead of silently dropping the log line. *)
+  | Agent_sdk.Event_bus.AgentFailed _
+  | Agent_sdk.Event_bus.HandoffRequested _
+  | Agent_sdk.Event_bus.HandoffCompleted _
+  | Agent_sdk.Event_bus.ElicitationCompleted _
+  | Agent_sdk.Event_bus.ContentReplacementReplaced _
+  | Agent_sdk.Event_bus.ContentReplacementKept _
+  | Agent_sdk.Event_bus.SlotSchedulerObserved _
+  | Agent_sdk.Event_bus.InferenceTelemetry _
+  | Agent_sdk.Event_bus.Custom _ ->
+      ()
 
 (** Build the SSE JSON wrapper. [correlation_id] and [run_id] are
     mandatory (from the envelope); all other fields are optional. *)


### PR DESCRIPTION
## Summary

Extends the same exhaustive-match anti-pattern fix from #14195 / #14205 into `lib/oas_event_bridge.ml`.  Converts 1 sum-type `_ -> ()` catch-all over `Agent_sdk.Event_bus.payload` (21 variants) in `emit_native_event_log` to an explicit enumeration of the 9 variants that were previously absorbed silently.

This PR is **out of #14195's named scope** (`lib/keeper/`) but applies the same rule from `instructions/software-development.md` §AI 코드 생성 안티패턴 #4 — FSM Sparse Match / `_ -> false` Catch-all.

## Why

`emit_native_event_log` is the operator-visible logging path for OAS native events.  The catch-all silently dropped log lines for 9 of 21 `Agent_sdk.Event_bus.payload` variants (`AgentFailed`, `HandoffRequested`, `HandoffCompleted`, `ElicitationCompleted`, `ContentReplacementReplaced`, `ContentReplacementKept`, `SlotSchedulerObserved`, `InferenceTelemetry`, `Custom`).  Adding a new upstream variant produced **zero observability** in masc-mcp logs.

After this PR, adding a new `Agent_sdk.Event_bus.payload` variant fails the build at compile time, forcing an explicit decision: log it explicitly, or list it under the no-op enumeration with intent.

## Scope (this PR)

| Function | Sum type | Was | Now |
|---|---|---|---|
| `emit_native_event_log` | `Agent_sdk.Event_bus.payload` (21 variants) | `_ -> ()` | 12 explicit logging arms + 9 explicit no-op arms enumerated |

Behavior is preserved — every variant previously absorbed by the catch-all is now mapped to the same `()` value, but as a named no-op rather than a wildcard.

## Out of scope (intentional)

13 of the 14 raw `| _ ->` patterns in this file are not converted:

| Lines | Pattern class | Why deferred |
|---|---|---|
| 27, 33, 34, 41, 42, 891, 892 | Yojson `\`Assoc` / `\`Null` matches and option fall-through | Open polymorphic-variant union, not a closed sum |
| 82, 91, 98, 115, 126 | `Some n when n > 0` / `Some r when positive_finite r` numeric guards | `option` pattern with refinement guard, not a sum-type catch-all |
| 905 | `"masc:keeper:snapshot" -> true \| _ -> false` | String match |
| 833 (`other ->` in `native_event_to_json`) | Deliberate `[@warning "-11"]` graceful-degradation arm | Documented intent (#10490, #10574, #10584 OAS pin-bump P0) — `payload_kind` fallback + warn log is **the design**, not an oversight |

These are correctly out of scope per the conversion criteria (string match / option guard / Yojson / explicit `[@warning "-11"]` design).

## Verification

- `dune build --root . @check` — clean (empty output)
- `git diff --stat`: 1 file changed, +13/-1
- `rg -c '\| _ ->' lib/oas_event_bridge.ml` — `13` (was `14`)
- `.mli` interface unchanged

## Risk

Low — pure refactor; no logic changes, no `.mli` change, public API preserved. The 9 enumerated no-op variants previously hit `_ -> ()` and continue to hit `()`.

## Refs

- Anti-pattern rule: `instructions/software-development.md` §AI 코드 생성 안티패턴 #4
- Sister PRs (`lib/keeper/` sweep + `lib/` boundary):
  - #14199 `keeper_error_classify`
  - #14200 `keeper_status_bridge`
  - #14203 `keeper_supervisor`
  - #14204 `keeper_context_core`
  - #14205 `oas_worker_named_fsm`
- Issue #14195 is the original `lib/keeper/` sweep; this PR is **out of that issue's named scope** but applies the same rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)