### PR TITLE
refactor(oas): exhaustive match in oas_worker_named sum-type catch-alls

### DIFF
--- a/lib/oas_worker_named.ml
+++ b/lib/oas_worker_named.ml
@@ -960,7 +960,14 @@ let run_named
              if sdk_error_is_hard_quota sdk_err then
                let last_err = match outcome with
                  | Cascade_fsm.Call_err e -> Some e
-                 | _ -> None
+                 (* Non-error provider outcomes carry no http_error to surface
+                    as the terminal cause when forcing Exhausted on hard
+                    quota.  Enumerated explicitly so a future addition to
+                    [Cascade_fsm.provider_outcome] is flagged at compile time
+                    instead of silently mapping to [None]. *)
+                 | Cascade_fsm.Call_ok _
+                 | Cascade_fsm.Accept_rejected _
+                 | Cascade_fsm.Slot_full -> None
                in
                Cascade_fsm.Exhausted { last_err }
              else
@@ -1028,7 +1035,14 @@ let run_named
               Log.Misc.error "cascade %s exhausted: all tiers failed (last model=%s, error=%s)"
                 cascade_name provider_cfg.model_id (Agent_sdk.Error.to_string sdk_err);
               Error sdk_err
-            | _ -> Error sdk_err)
+            (* [Accept] / [Accept_on_exhaustion] are reachable only from
+               [Cascade_fsm.Call_ok] / [Accept_rejected] outcomes, but this
+               branch handles a [Call_err] outcome so the FSM cannot return
+               them here.  Surface the original sdk_err and let the caller
+               see the unexpected mapping rather than silently absorbing a
+               new decision variant added to [Cascade_fsm.decision]. *)
+            | Cascade_fsm.Accept _
+            | Cascade_fsm.Accept_on_exhaustion _ -> Error sdk_err)
          | None ->
            (* Non-API error (agent, config, etc.) — not cascadeable *)
            let observation =


### PR DESCRIPTION
## Summary

Sibling of #14205 — applies the same exhaustive-match anti-pattern fix to the smaller `lib/oas_worker_named.ml` (the named-cascade facade that re-exports `oas_worker_named_fsm` + `_cascade` + `_error`). Converts 2 `_ ->` catch-alls over `Cascade_fsm.provider_outcome` (4 variants) and `Cascade_fsm.decision` (4 variants) to explicit enumeration.

This file is **out of #14195's named scope** (it sits in `lib/`, not `lib/keeper/`) but carries the same FSM-sparse-match risk as #14205: cascade routing decisions flow through these matches, so a new variant added to `Cascade_fsm.provider_outcome` or `Cascade_fsm.decision` would silently route through the catch-all without compile-time signal.

## Why

`instructions/software-development.md` §"AI 코드 생성 안티패턴 #4 — FSM Sparse Match / `_ -> false` Catch-all" specifically targets FSM-shaped matches that absorb new variants. `Cascade_fsm` is the cascade FSM itself — these two catch-alls are the highest-leverage instances of the anti-pattern in this file.

After this PR the compiler forces a routing decision when:
- `Cascade_fsm.provider_outcome` gains a new variant (currently 4: `Call_ok`, `Call_err`, `Accept_rejected`, `Slot_full`)
- `Cascade_fsm.decision` gains a new variant (currently 4: `Accept`, `Accept_on_exhaustion`, `Try_next`, `Exhausted`)

## Scope (this PR)

| Function | Sum type | Was | Now |
|---|---|---|---|
| Hard-quota fast-path inside `try_cascade` (extract `last_err` from outcome) | `Cascade_fsm.provider_outcome` | `_ -> None` | `Call_ok` / `Accept_rejected` / `Slot_full` enumerated |
| `Call_err` branch decision routing | `Cascade_fsm.decision` | `_ -> Error sdk_err` | `Accept` / `Accept_on_exhaustion` enumerated |

Behavior is preserved — every variant previously absorbed by a catch-all is now mapped to the same value.

## Out of scope (intentional)

7 of the 9 raw `| _ ->` patterns are not converted in this PR — none are closed sum-type catch-alls:

| Line | Pattern class | Why skipped |
|---|---|---|
| L98 | `option` with `Some _ when ...` guard | not a sum-type catch-all |
| L236 | `string list option` with `Some ms when ms <> []` guard | option + list guard |
| L330, L333, L1213 | list pattern (`[] -> ...` / `_ -> ...`) | list, not closed sum |
| L257 | tuple match (`(Error _, _) \| (_, Error _)`) | tuple of `result`, not closed sum |
| L398 | tuple of `option + string` with guard | option pattern with guard |
| L697 | deeply nested record over `Llm_provider.Http_client` errors with `when message_looks_like_resumable_cli_session` string guards | deeply nested record + string heuristic |
| L1219-1222 | `(Ok _ as ok)` / `(Error _ as err) when last_cycle` / `Error _` | `result` pattern with guard |

These match the conservative-bias skip rules: option, list, tuple, deeply nested record, string-guarded.

## Verification

- `dune build --root . @check` — clean
- `git diff --stat`: 1 file changed, +16/-2
- `rg -c '\| _ ->' lib/oas_worker_named.ml` — `7` (was `9`)
- `.mli` interface unchanged

## Risk

Low — pure refactor; no logic changes, no `.mli` change, public API preserved.

## Refs

- Anti-pattern rule: `instructions/software-development.md` §AI 코드 생성 안티패턴 #4
- Sister PR: #14205 (`lib/oas_worker_named_fsm.ml`, merged)
- Predecessors in `lib/keeper/` sweep (all merged): #14199, #14200, #14203, #14204
- Note: this PR is **out of #14195's named scope** (different directory) but applies the same rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>