### PR TITLE
refactor(oas): exhaustive match in oas_worker_named_error sum-type catch-alls

### DIFF
--- a/lib/oas_worker_named_error.ml
+++ b/lib/oas_worker_named_error.ml
@@ -265,7 +265,17 @@ let summary_of_masc_internal_error = function
            "OAS timeout budget exhausted; phase=%s; source=%s; budget=%.1fs; remaining=%s; min_required=%.1fs; estimated_input_tokens=%d; keeper_turn_timeout=%.1fs"
            phase source budget_sec remaining min_required_sec
            estimated_input_tokens keeper_turn_timeout_sec)
-  | _ -> None
+  (* Variants without a custom long-form summary: callers fall back to
+     [kind_of_masc_internal_error] / the JSON payload.  Enumerated
+     explicitly so adding a new [masc_internal_error] variant forces
+     a decision on whether it deserves a long-form summary string. *)
+  | Cascade_exhausted _
+  | Resumable_cli_session _
+  | Accept_rejected _
+  | Admission_queue_timeout _
+  | Admission_queue_rejected _
+  | Turn_timeout _
+  | Ambiguous_post_commit _ -> None
 
 (* #9933: classify emitted [masc_oas_error] payloads by kind so
    dashboards and Grafana alerts can watch the fleet-wide rate per
@@ -683,7 +693,16 @@ let codex_cli_prompt_preflight ~(config : Oas_worker_exec.config) ~(goal : strin
           hits_argv_limit;
           hits_context_window;
         }
-  | _ -> None
+  (* Other provider kinds: argv-limit + context-window preflight only
+     applies to the [codex exec] subprocess transport (it serialises the
+     full prompt onto a single argv vector).  Other transports either
+     stream over HTTP (no argv limit) or have their own preflight in
+     their adapter — return [None] here so the caller skips preflight
+     wrapping.  Enumerated explicitly so adding a new
+     [Llm_provider.Provider_config.provider_kind] forces a decision on
+     whether it needs codex-style prompt preflight. *)
+  | Anthropic | Kimi | OpenAI_compat | Ollama | Gemini | Glm
+  | DashScope | Claude_code | Gemini_cli | Kimi_cli -> None
 
 let codex_cli_preflight_error ~(scope : string)
     ~(provider_cfg : Llm_provider.Provider_config.t)


### PR DESCRIPTION
## Summary

Extends the same exhaustive-match anti-pattern fix from #14195 (`lib/keeper/` sweep) and #14205 (`lib/oas_worker_named_fsm.ml`) into `lib/oas_worker_named_error.ml`. Converts 2 sum-type `_ -> None` catch-alls to explicit enumerations.

This file owns the `masc_internal_error` variant type and the codex-CLI prompt preflight, so silent-drop on a new `masc_internal_error` family or a new `Llm_provider.Provider_config.provider_kind` would lose user-visible operator messaging or skip preflight on a new subprocess transport.

## Why

`instructions/software-development.md` §"AI 코드 생성 안티패턴 #4 — FSM Sparse Match / `_ -> false` Catch-all" specifically targets matches that absorb new variants from a closed sum without compile-time signal. Both of the converted sites are over closed sums maintained inside this codebase (`masc_internal_error`, 9 variants) or in agent_sdk (`Provider_config.provider_kind`, 11 variants).

After this PR the compiler forces a decision when:
- a new `masc_internal_error` variant is added (does it need a long-form summary?)
- a new `Provider_config.provider_kind` is added (does it need codex-style argv/context-window preflight?)

## Scope (this PR)

| Function | Sum type | Was | Now |
|---|---|---|---|
| `summary_of_masc_internal_error` | `masc_internal_error` (9 variants) | `_ -> None` | 7 other variants enumerated → `None` |
| `codex_cli_prompt_preflight` (`match config.provider_cfg.kind`) | `Llm_provider.Provider_config.provider_kind` (11 variants) | `_ -> None` | 10 non-`Codex_cli` variants enumerated → `None` |

Behavior preserved — every variant previously absorbed by a catch-all maps to the same `None` value.

## Skipped (intentional, per project skip rules)

`oas_worker_named_error.ml` has 39 raw `| _ ->` patterns. 37 are deliberately not converted because they are not closed-sum-vs-other catch-alls:

| Pattern class | Examples (line) | Why skipped |
|---|---|---|
| Yojson value match (`Yojson.Safe.t`) | `string_list_of_assoc` (83-85), `provider_rejection_of_json` (100-106), `string_opt_of_assoc` (119-120), all 18 `_ -> None` / `_ -> []` inside `classify_masc_internal_error` (369-545) | `Yojson.Safe.t` has too many variants and is not a fluctuating closed sum — guarded by `Yojson.Json_error` already |
| List `[]` vs cons (`_`) | `summarize_list` (221), `summarize_provider_rejections` (226) | List has 2 cases, `_` carries the cons binding implicitly via earlier shape — converting to `:: _` adds no compile-time signal |
| Tuple `(option, option)` pairs in `classify_masc_internal_error` | 421, 448, 469, 476, 484, 516, 541 | Negation set is the cartesian product of `Some`/`None` over 2-4 fields; explosion exceeds the value of the signal |
| String literal match | `req_config` (636) | string-key match, not closed sum |

## Verification

- `dune build --root . @check` — clean (empty output)
- `git diff --stat`: 1 file changed, +21/-2
- `rg -c '\| _ ->' lib/oas_worker_named_error.ml` — `37` (was `39`)
- `.mli` interface unchanged

## Risk

Low — pure refactor; no logic changes, no `.mli` change, public API preserved.

## Refs

- Anti-pattern rule: `instructions/software-development.md` §AI 코드 생성 안티패턴 #4
- Sister PRs (sum-type catch-all sweep):
  - #14195 `lib/keeper/` original sweep
  - #14199 `keeper_error_classify`
  - #14200 `keeper_status_bridge`
  - #14203 `keeper_supervisor`
  - #14204 `keeper_context_core`
  - #14205 `oas_worker_named_fsm`
- This PR is **out of #14195's named scope; same anti-pattern**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)