### PR TITLE
feat(keeper): RFC-0042 PR-2 — wire stale_terminal_reason_code through typed bridge

### DIFF
--- a/lib/keeper/keeper_execution_receipt.ml
+++ b/lib/keeper/keeper_execution_receipt.ml
@@ -715,22 +715,16 @@ let stale_kill_class_label = function
   | Keeper_registry.In_turn_hung _ -> "in_turn_hung"
   | Keeper_registry.Noop_failure_loop _ -> "noop_failure_loop"
 
-let stale_terminal_reason_code = function
-  | Some (Keeper_registry.Provider_runtime_error { code; _ }) -> code
-  | Some (Keeper_registry.Tool_required_unsatisfied { code; _ }) -> code
-  | Some (Keeper_registry.Oas_timeout_budget_loop _) -> "oas_timeout_budget"
-  | Some (Keeper_registry.Stale_turn_timeout _) -> "stale_turn_timeout"
-  | Some (Keeper_registry.Stale_fleet_batch _) -> "stale_fleet_batch"
-  | Some (Keeper_registry.Stale_termination_storm _) ->
-      "stale_termination_storm"
-  | Some (Keeper_registry.Heartbeat_consecutive_failures _) ->
-      "heartbeat_failures"
-  | Some (Keeper_registry.Turn_consecutive_failures _) -> "turn_failures"
-  | Some (Keeper_registry.Ambiguous_partial_commit _) ->
-      "ambiguous_partial_commit"
-  | Some Keeper_registry.Fiber_unresolved -> "fiber_unresolved"
-  | Some (Keeper_registry.Exception _) -> "exception"
-  | None -> "stale_turn_timeout"
+(* RFC-0042 PR-2: delegate to [Keeper_turn_terminal_code]. The pre-RFC
+   inline match has been preserved as the test oracle in
+   [test/test_keeper_turn_terminal_code.ml] (byte-for-byte invariant).
+   New [Keeper_registry.failure_reason] constructors are now a compile
+   error in [Keeper_turn_terminal_code.of_failure_reason]. *)
+let stale_terminal_reason_code_typed reason =
+  Keeper_turn_terminal_code.of_failure_reason_option reason
+
+let stale_terminal_reason_code reason =
+  Keeper_turn_terminal_code.to_wire (stale_terminal_reason_code_typed reason)
 
 let stale_broadcast_failure_cohort = function
   | Some _ as reason -> Keeper_registry.failure_reason_cohort_key reason

--- a/lib/keeper/keeper_turn_terminal_code.ml
+++ b/lib/keeper/keeper_turn_terminal_code.ml
@@ -93,3 +93,13 @@ let of_failure_reason : Keeper_registry.failure_reason -> t = function
   | Keeper_registry.Fiber_unresolved -> Fiber_unresolved
   | Keeper_registry.Exception msg -> Exception_unhandled msg
 ;;
+
+let of_failure_reason_option = function
+  | Some fr -> of_failure_reason fr
+  | None ->
+    (* Legacy [stale_terminal_reason_code None] emitted "stale_turn_timeout".
+       Canonical sub-class for that wire string is [In_turn_hung] (see
+       [of_wire]); we reuse it here so [to_wire (of_failure_reason_option None)]
+       is byte-for-byte equal to the pre-RFC default. *)
+    Stale_turn_timeout_in_turn
+;;

--- a/lib/keeper/keeper_turn_terminal_code.mli
+++ b/lib/keeper/keeper_turn_terminal_code.mli
@@ -88,3 +88,13 @@ val of_wire : string -> t option
     constructor there is a compile error here, which is the property
     this RFC is meant to provide. *)
 val of_failure_reason : Keeper_registry.failure_reason -> t
+
+(** Option-wrapped bridge. [None] is the legacy convention for a
+    keeper that became stale without a recorded [failure_reason]; the
+    pre-RFC string emitter mapped this to ["stale_turn_timeout"]. We
+    canonicalise to [Stale_turn_timeout_in_turn] so [to_wire] reproduces
+    the same bytes. PR-3 narrows callers to a non-option representation
+    where applicable.
+
+    @since 0.193.0 *)
+val of_failure_reason_option : Keeper_registry.failure_reason option -> t

--- a/test/dune
+++ b/test/dune
@@ -26,6 +26,7 @@
 ; Group 1: Pure synchronous tests
 (tests
  (names test_attribution test_attribution_tagged test_autoresearch_result_bridge test_dashboard_attribution test_dashboard_oas_bridge test_masc_runtime_events test_room test_room_state_recovery test_types test_exec_tap test_auth test_auth_doctor test_auth_error_kind test_auth_login test_audit_log test_governance_anomaly test_http_negotiation
+        test_keeper_turn_terminal_code_byte_compat
         test_attempt_state
         test_sse test_graphql_api
         test_graphql_endpoint
@@ -256,6 +257,7 @@
         test_alignment_score
         )
  (modules test_attribution test_attribution_tagged test_autoresearch_result_bridge test_dashboard_attribution test_dashboard_oas_bridge test_masc_runtime_events test_room test_room_state_recovery test_types test_exec_tap test_auth test_auth_doctor test_auth_error_kind test_auth_login test_audit_log test_governance_anomaly test_http_negotiation
+          test_keeper_turn_terminal_code_byte_compat
           test_attempt_state
           test_sse test_graphql_api
           test_graphql_endpoint

--- a/test/test_keeper_turn_terminal_code_byte_compat.ml
+++ b/test/test_keeper_turn_terminal_code_byte_compat.ml
@@ -1,0 +1,84 @@
+(** RFC-0042 PR-2 invariant: [Keeper_execution_receipt.stale_terminal_reason_code]
+    output must remain byte-for-byte identical to the pre-RFC inline match
+    after delegation through [Keeper_turn_terminal_code]. The oracle below
+    is the literal pre-PR-2 implementation; if PR-2 (or any later refactor)
+    drifts, this test fails the build. *)
+
+module R = Masc_mcp.Keeper_registry
+module Code = Masc_mcp.Keeper_turn_terminal_code
+
+(* PR-2 invariant target: every failure_reason (and [None]) flowing
+   through the new typed bridge must produce the same wire string as
+   the pre-RFC inline match. The pre-RFC match has been deleted from
+   [Keeper_execution_receipt] and replaced by a delegation; this test
+   guards the typed bridge directly so the invariant survives later
+   refactors. *)
+let typed_wire fr = Code.to_wire (Code.of_failure_reason_option fr)
+
+(* Oracle: copy of the pre-PR-2 [stale_terminal_reason_code] from
+   [keeper_execution_receipt.ml]. Do not edit casually — drift here is
+   the bug this test is meant to catch. *)
+let oracle = function
+  | Some (R.Provider_runtime_error { code; _ }) -> code
+  | Some (R.Tool_required_unsatisfied { code; _ }) -> code
+  | Some (R.Oas_timeout_budget_loop _) -> "oas_timeout_budget"
+  | Some (R.Stale_turn_timeout _) -> "stale_turn_timeout"
+  | Some (R.Stale_fleet_batch _) -> "stale_fleet_batch"
+  | Some (R.Stale_termination_storm _) -> "stale_termination_storm"
+  | Some (R.Heartbeat_consecutive_failures _) -> "heartbeat_failures"
+  | Some (R.Turn_consecutive_failures _) -> "turn_failures"
+  | Some (R.Ambiguous_partial_commit _) -> "ambiguous_partial_commit"
+  | Some R.Fiber_unresolved -> "fiber_unresolved"
+  | Some (R.Exception _) -> "exception"
+  | None -> "stale_turn_timeout"
+
+let cases : (string * R.failure_reason option) list = [
+  "Heartbeat_consecutive_failures",
+    Some (R.Heartbeat_consecutive_failures 3);
+  "Turn_consecutive_failures",
+    Some (R.Turn_consecutive_failures 5);
+  "Stale_turn_timeout/Idle",
+    Some (R.Stale_turn_timeout (R.Idle_turn { stall_seconds = 60.0 }));
+  "Stale_turn_timeout/In_turn_hung",
+    Some (R.Stale_turn_timeout
+      (R.In_turn_hung { active_seconds = 120.0; timeout_threshold = 90.0 }));
+  "Stale_turn_timeout/Noop_failure_loop",
+    Some (R.Stale_turn_timeout (R.Noop_failure_loop { noop_count = 7 }));
+  "Stale_termination_storm",
+    Some (R.Stale_termination_storm { count = 4 });
+  "Stale_fleet_batch",
+    Some (R.Stale_fleet_batch { distinct_count = 6 });
+  "Oas_timeout_budget_loop",
+    Some (R.Oas_timeout_budget_loop { count = 2 });
+  "Provider_runtime_error",
+    Some (R.Provider_runtime_error
+      { code = "provider_http_500"; detail = "upstream 500" });
+  "Tool_required_unsatisfied",
+    Some (R.Tool_required_unsatisfied
+      { code = "tool_unsat_no_call"; detail = "no tool" });
+  "Ambiguous_partial_commit/Post_commit_timeout",
+    Some (R.Ambiguous_partial_commit
+      { kind = R.Post_commit_timeout; detail = "" });
+  "Ambiguous_partial_commit/Post_commit_failure",
+    Some (R.Ambiguous_partial_commit
+      { kind = R.Post_commit_failure; detail = "" });
+  "Fiber_unresolved",
+    Some R.Fiber_unresolved;
+  "Exception",
+    Some (R.Exception "boom");
+  "None", None;
+]
+
+let test_byte_compat () =
+  List.iter (fun (label, fr) ->
+    let expected = oracle fr in
+    let actual = typed_wire fr in
+    Alcotest.(check string) label expected actual
+  ) cases
+
+let () =
+  Alcotest.run "keeper_turn_terminal_code_byte_compat" [
+    "stale_terminal_reason_code byte invariant",
+      [ Alcotest.test_case "all failure_reason cases match oracle"
+          `Quick test_byte_compat ];
+  ]


### PR DESCRIPTION
## Goal

Activate the inert `Keeper_turn_terminal_code` module from PR-1 (#14182).
Replace the inline match in `keeper_execution_receipt.stale_terminal_reason_code`
with a delegation through the typed bridge, locked behind a byte-compat
test invariant.

## Why

PR-1 introduced the closed sum but left it with **0 callsites**. As
flagged in today's diagnosis, that is the well-known *inert module*
trap — RFC-0035 P4 already exhibited it. PR-2 is the first activation
step. It is intentionally minimal: same wire output, same Prometheus
labels, same JSON. Type safety only kicks in when a new
`Keeper_registry.failure_reason` constructor is added — at that point
`Keeper_turn_terminal_code.of_failure_reason` is a compile error
instead of silent fallthrough.

## What changed

| File | Δ |
|---|---|
| `lib/keeper/keeper_turn_terminal_code.ml/.mli` | New `of_failure_reason_option : failure_reason option -> t`. None → `Stale_turn_timeout_in_turn` for byte-compat with legacy `\"stale_turn_timeout\"` default. |
| `lib/keeper/keeper_execution_receipt.ml` | `stale_terminal_reason_code` now delegates to `to_wire (of_failure_reason_option r)`. New typed accessor `stale_terminal_reason_code_typed` exposes the variant for callers. |
| `test/test_keeper_turn_terminal_code_byte_compat.ml` | NEW. Pre-RFC inline match preserved as oracle. 15 cases × all variants × None — drift fails the build. |
| `test/dune` | Register the new test binary. |

## Verification

```
$ bash scripts/dune-local.sh build @check  # OK
$ bash scripts/dune-local.sh exec test/test_keeper_turn_terminal_code_byte_compat.exe
Testing keeper_turn_terminal_code_byte_compat.
  [OK]  stale_terminal_reason_code byte invariant  0  all failure_reason cases match oracle
Test Successful in 0.000s. 1 test run.
```

## Wire stability

- `masc_persistence_read_drops_total` label cardinality: unchanged.
- Receipt JSON `terminal_reason_code` field: byte-for-byte equal.
- Dashboards filtering on string codes: continue to match.

## Out of scope

- **`agent_error_terminal_reason_code` migration**: its wire format
  embeds parameters (e.g. `agent_error_max_turns_exceeded:turns=10,limit=10`)
  not modeled by current `t`. Either extend `t` with parametrised
  constructors, or introduce a separate typed module. → PR-2.5.
- **`Keeper_turn_terminal.t.code` field swap (string → t)**: PR-3.
- **Consumer-side exhaustive match** (replace `String.starts_with ~prefix`
  in `Keeper_execution_receipt` disposition mapping and
  `Keeper_passive_loop_detector.progress_class_of_terminal_reason_code`):
  PR-4.

## Anti-pattern self-check (`software-development.md §워크어라운드 거부 기준`)

- [ ] ❌ Telemetry-as-fix — N/A (no counter touched)
- [ ] ❌ String/substring classifier — **removed** (replaces inline match with typed bridge)
- [ ] ❌ N-of-M patch — **partial**: 1 of 2 callsites migrated. Remaining (`agent_error_terminal_reason_code`) explicitly tracked above as PR-2.5 with reason (parametrised wire format requires `t` extension).
- [ ] ❌ catch-all `_ ->` added — N/A
- [ ] ❌ cap/cooldown/dedup/repair — N/A

## RFC reference

`docs/rfc/RFC-0042-keeper-terminal-code-closed-sum.md` (PR-1 inert intro).
This PR is PR-2 of that sequence.