### PR TITLE
refactor(oas): exhaustive match in worker_oas sum-type catch-alls

### DIFF
--- a/lib/worker_oas.ml
+++ b/lib/worker_oas.ml
@@ -364,19 +364,55 @@ let make_tool_tracking_hooks ?gate_config ?context () =
                     | None -> Agent_sdk.Hooks.Continue)
                  else
                    Agent_sdk.Hooks.Continue)
-            | _ -> Agent_sdk.Hooks.Continue);
+            | Agent_sdk.Hooks.BeforeTurn _
+            | Agent_sdk.Hooks.BeforeTurnParams _
+            | Agent_sdk.Hooks.AfterTurn _
+            | Agent_sdk.Hooks.PostToolUse _
+            | Agent_sdk.Hooks.PostToolUseFailure _
+            | Agent_sdk.Hooks.OnStop _
+            | Agent_sdk.Hooks.OnIdle _
+            | Agent_sdk.Hooks.OnIdleEscalated _
+            | Agent_sdk.Hooks.OnError _
+            | Agent_sdk.Hooks.OnToolError _
+            | Agent_sdk.Hooks.PreCompact _
+            | Agent_sdk.Hooks.PostCompact _
+            | Agent_sdk.Hooks.OnContextCompacted _ -> Agent_sdk.Hooks.Continue);
       on_error = Some (function
         | Agent_sdk.Hooks.OnError { detail; context = err_ctx } ->
           Log.LocalWorker.warn "worker on_error: %s (context: %s)"
             detail err_ctx;
           Agent_sdk.Hooks.Continue
-        | _ -> Agent_sdk.Hooks.Continue);
+        | Agent_sdk.Hooks.BeforeTurn _
+        | Agent_sdk.Hooks.BeforeTurnParams _
+        | Agent_sdk.Hooks.AfterTurn _
+        | Agent_sdk.Hooks.PreToolUse _
+        | Agent_sdk.Hooks.PostToolUse _
+        | Agent_sdk.Hooks.PostToolUseFailure _
+        | Agent_sdk.Hooks.OnStop _
+        | Agent_sdk.Hooks.OnIdle _
+        | Agent_sdk.Hooks.OnIdleEscalated _
+        | Agent_sdk.Hooks.OnToolError _
+        | Agent_sdk.Hooks.PreCompact _
+        | Agent_sdk.Hooks.PostCompact _
+        | Agent_sdk.Hooks.OnContextCompacted _ -> Agent_sdk.Hooks.Continue);
       on_tool_error = Some (function
         | Agent_sdk.Hooks.OnToolError { tool_name; error } ->
           Log.LocalWorker.warn "worker tool_error: %s — %s"
             tool_name error;
           Agent_sdk.Hooks.Continue
-        | _ -> Agent_sdk.Hooks.Continue);
+        | Agent_sdk.Hooks.BeforeTurn _
+        | Agent_sdk.Hooks.BeforeTurnParams _
+        | Agent_sdk.Hooks.AfterTurn _
+        | Agent_sdk.Hooks.PreToolUse _
+        | Agent_sdk.Hooks.PostToolUse _
+        | Agent_sdk.Hooks.PostToolUseFailure _
+        | Agent_sdk.Hooks.OnStop _
+        | Agent_sdk.Hooks.OnIdle _
+        | Agent_sdk.Hooks.OnIdleEscalated _
+        | Agent_sdk.Hooks.OnError _
+        | Agent_sdk.Hooks.PreCompact _
+        | Agent_sdk.Hooks.PostCompact _
+        | Agent_sdk.Hooks.OnContextCompacted _ -> Agent_sdk.Hooks.Continue);
     }
   in
   let hooks = match context with
@@ -395,7 +431,19 @@ let make_tool_tracking_hooks ?gate_config ?context () =
                    in
                    Agent_sdk.Hooks.AdjustParams { current_params with
                      extra_system_context = Some ctx_str })
-              | _ -> Agent_sdk.Hooks.Continue);
+              | Agent_sdk.Hooks.BeforeTurn _
+              | Agent_sdk.Hooks.AfterTurn _
+              | Agent_sdk.Hooks.PreToolUse _
+              | Agent_sdk.Hooks.PostToolUse _
+              | Agent_sdk.Hooks.PostToolUseFailure _
+              | Agent_sdk.Hooks.OnStop _
+              | Agent_sdk.Hooks.OnIdle _
+              | Agent_sdk.Hooks.OnIdleEscalated _
+              | Agent_sdk.Hooks.OnError _
+              | Agent_sdk.Hooks.OnToolError _
+              | Agent_sdk.Hooks.PreCompact _
+              | Agent_sdk.Hooks.PostCompact _
+              | Agent_sdk.Hooks.OnContextCompacted _ -> Agent_sdk.Hooks.Continue);
         }
       in
       Agent_sdk.Hooks.compose ~outer:temporal ~inner:tracking
@@ -615,7 +663,13 @@ and run_existing_worker_agent
             response.content
             |> List.filter_map (function
                  | Agent_sdk.Types.Text text -> Some text
-                 | _ -> None)
+                 | Agent_sdk.Types.Thinking _
+                 | Agent_sdk.Types.RedactedThinking _
+                 | Agent_sdk.Types.ToolUse _
+                 | Agent_sdk.Types.ToolResult _
+                 | Agent_sdk.Types.Image _
+                 | Agent_sdk.Types.Document _
+                 | Agent_sdk.Types.Audio _ -> None)
             |> String.concat "\n"
           in
           let* () =


### PR DESCRIPTION
## Summary

Extends the same exhaustive-match anti-pattern fix from #14195 (`lib/keeper/` sweep) and #14205 (`lib/oas_worker_named_fsm.ml`) into `lib/worker_oas.ml`. Converts 5 sum-type `_ -> Continue` / `_ -> None` catch-alls to explicit enumerations across two closed sums (`Agent_sdk.Hooks.hook_event`, `Agent_sdk.Types.content_block`).

The compiler immediately caught 3 hook_event variants the catch-alls were silently absorbing (`OnIdleEscalated`, `PostCompact`, `OnContextCompacted`) — direct evidence of the anti-pattern in this file.

## Why

`instructions/software-development.md` §"AI 코드 생성 안티패턴 #4 — FSM Sparse Match / `_ -> false` Catch-all" specifically targets matches that absorb new variants from a closed sum without compile-time signal. Both converted families are over closed sums maintained outside this codebase (in agent_sdk), so future SDK upgrades silently drop new event/content variants.

After this PR the compiler forces a decision when:
- a new `Agent_sdk.Hooks.hook_event` variant is added (does the worker need to react to a new lifecycle event?)
- a new `Agent_sdk.Types.content_block` variant is added (does the worker output extraction need to surface a new block type?)

## Scope (this PR)

| Function | Sum type | Was | Now |
|---|---|---|---|
| `make_tool_tracking_hooks` — `pre_tool_use` (line 309) | `hook_event` (14 variants) | `_ -> Continue` | 13 non-`PreToolUse` variants enumerated |
| `make_tool_tracking_hooks` — `on_error` (line 377) | `hook_event` (14 variants) | `_ -> Continue` | 13 non-`OnError` variants enumerated |
| `make_tool_tracking_hooks` — `on_tool_error` (line 392) | `hook_event` (14 variants) | `_ -> Continue` | 13 non-`OnToolError` variants enumerated |
| `make_tool_tracking_hooks` — `before_turn_params` (temporal context, line 414) | `hook_event` (14 variants) | `_ -> Continue` | 13 non-`BeforeTurnParams` variants enumerated |
| Run output extraction `List.filter_map` (line 627) | `content_block` (8 variants) | `_ -> None` | 7 non-`Text` variants enumerated → `None` |

Behavior preserved — every variant previously absorbed by a catch-all maps to the same `Continue`/`None` value.

## Skipped (intentional, per project skip rules)

`worker_oas.ml` had 6 raw `| _ ->` patterns. 1 is intentionally not converted:

| Pattern class | Example (line) | Why skipped |
|---|---|---|
| Yojson value match (`Yojson.Safe.t`) | `string_member` inner match (line 255) | `Yojson.Safe.t` is not a fluctuating closed sum the project maintains; per skip rule |

## Verification

- `dune build --root . @check` — clean (empty output) after exhaustive enumeration; initially failed with 4× `partial-match` errors, exposing 3 hook_event variants the catch-alls were silently absorbing
- `git diff --stat`: 1 file changed, +59/-5
- `rg -c '\| _ ->' lib/worker_oas.ml` — `1` (was `6`)
- `.mli` interface unchanged (no `.mli` exists for this file)

## Risk

Low — pure refactor; no logic changes, no public API change. The 3 newly-explicit hook_event variants (`OnIdleEscalated`, `PostCompact`, `OnContextCompacted`) all map to `Continue`, identical to the previous catch-all behavior.

## Refs

- Anti-pattern rule: `instructions/software-development.md` §AI 코드 생성 안티패턴 #4
- Sister PRs (sum-type catch-all sweep):
  - #14195 `lib/keeper/` original sweep
  - #14199 `keeper_error_classify`
  - #14200 `keeper_status_bridge`
  - #14203 `keeper_supervisor`
  - #14204 `keeper_context_core`
  - #14205 `oas_worker_named_fsm`
  - #14208, #14209, #14210
- This PR is **out of #14195's named scope; same anti-pattern**.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)