### PR TITLE
refactor(oas): exhaustive match in oas_worker_exec_transport sum-type catch-alls

### DIFF
--- a/lib/oas_worker_exec_transport.ml
+++ b/lib/oas_worker_exec_transport.ml
@@ -326,7 +326,12 @@ let authorization_header_from_policy
     (function
       | Llm_provider.Llm_transport.Http_server { name = "masc"; headers; _ } ->
           List.find_opt is_authorization_header headers
-      | _ -> None)
+      (* Only the [Http_server] entry whose [name = "masc"] carries the
+         per-request Authorization header. Other named [Http_server]s and
+         [Stdio_server]s contribute no auth header on this lane. New
+         transport variants must re-decide explicitly. *)
+      | Llm_provider.Llm_transport.Http_server _
+      | Llm_provider.Llm_transport.Stdio_server _ -> None)
     policy.servers
 
 let per_keeper_authorization_header ~agent_name =


### PR DESCRIPTION
## Summary

Extends the exhaustive-match anti-pattern fix from #14195 / #14205 into `lib/oas_worker_exec_transport.ml`. Converts 1 sum-type `_ -> None` catch-all over `Llm_provider.Llm_transport.runtime_mcp_server` (2 variants: `Stdio_server`, `Http_server`) in `authorization_header_from_policy` to an explicit enumeration.

This file sits on the runtime-MCP transport boundary — auth-header routing flows through this classifier into provider request construction — so silent-drop on a new transport variant would silently mis-auth (or leak) per-request bearer tokens.

## Why

`instructions/software-development.md` §"AI 코드 생성 안티패턴 #4 — FSM Sparse Match / `_ -> false` Catch-all" specifically targets matches that absorb new variants without compile-time signal. After this PR the compiler forces a routing decision when `Llm_provider.Llm_transport` adds a new transport variant (e.g. WebSocket).

This PR is **out of #14195's named scope** but applies the same anti-pattern rule.

## Scope (this PR)

| Function | Sum type | Was | Now |
|---|---|---|---|
| `authorization_header_from_policy` | `runtime_mcp_server` | `_ -> None` | `Http_server _` + `Stdio_server _` enumerated |

Behavior is preserved — every variant previously absorbed by the catch-all is now mapped to the same value (`None`).

## Out of scope (intentional, follow-up candidates)

23 of the file's 24 raw `| _ ->` patterns are not converted in this PR:

| Pattern class | Why skipped |
|---|---|
| `option` fallback with guard (`Some _ when guard \| _`) | Not a closed sum-type variant catch-all; option semantics |
| Tuple of `option`s (`Some _, _ \| _` etc.) | Same as above; AND-of-options patterns |
| String match (`match s with "x" \| "y" -> ... \| _ -> ...`) | Open string set; rule explicitly excludes |
| Yojson `_ -> None` / `_ -> Ok []` | Open JSON shape; rule explicitly excludes |
| Tuple `(provider_kind, agent_name option)` with `Codex_cli, Some _ when guard -> ... \| _ -> ...` | Negation set explodes (10+ provider kinds × 2 option states) |
| `option int` matches (`Some 75 \| Some 1 \| _`) | Int discriminator, not a closed sum type |
| `Llm_transport` variant with `name = "masc"` string filter inside record | Conservative bias — string filter complicates negation enumeration |

These remaining patterns are either not closed sum types or carry expansion costs that would obscure the fix.

## Verification

- `dune build --root . @check` — clean (empty output)
- `git diff --stat`: 1 file changed, +6/-1
- `rg -c '^\s*\| _ ->' lib/oas_worker_exec_transport.ml` — `23` (was `24`)
- `.mli` interface unchanged

## Risk

Low — pure refactor; no logic changes, no `.mli` change, public API preserved. Surgical 6-line change.

## Refs

- Anti-pattern rule: `instructions/software-development.md` §AI 코드 생성 안티패턴 #4
- Sister PRs (5-PR sweep, anti-pattern):
  - #14199 `keeper_error_classify` (9 catch-alls)
  - #14200 `keeper_status_bridge` (3 catch-alls)
  - #14203 `keeper_supervisor` (6 catch-alls)
  - #14204 `keeper_context_core` (8 catch-alls)
  - #14205 `oas_worker_named_fsm` (6 catch-alls)
- Issue #14195 is the original `lib/keeper/` sweep; this PR is **out of that issue's named scope** but applies the same anti-pattern rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)