### PR TITLE
feat(keeper): extract EventPriorityMonotone pure predicate for QCheck (PR-D2)

### DIFF
--- a/lib/keeper/keeper_composite_observer.ml
+++ b/lib/keeper/keeper_composite_observer.ml
@@ -290,14 +290,29 @@ let check_no_cascade_before_measurement
   | Cascade_selecting | Cascade_trying | Cascade_done | Cascade_exhausted ->
       measurement_captured
 
+type event_priority_state = {
+  ep_measurement_bind_count : int;
+  ep_has_measurement : bool;
+  ep_has_pending_measurement : bool;
+}
+
+let check_event_priority_monotone_pure
+    (state : event_priority_state)
+    : bool =
+  state.ep_measurement_bind_count <= 1
+  && not (state.ep_has_measurement && state.ep_has_pending_measurement)
+
 let check_event_priority_monotone
     (entry : Keeper_registry.registry_entry)
     : bool =
   match entry.current_turn_observation with
   | None -> true
   | Some obs ->
-      obs.measurement_bind_count <= 1
-      && not (Option.is_some obs.measurement && Option.is_some entry.pending_turn_measurement)
+      check_event_priority_monotone_pure {
+        ep_measurement_bind_count = obs.measurement_bind_count;
+        ep_has_measurement = Option.is_some obs.measurement;
+        ep_has_pending_measurement = Option.is_some entry.pending_turn_measurement;
+      }
 
 let check_phase_derivation_agreement
     (entry : Keeper_registry.registry_entry)

--- a/lib/keeper/keeper_composite_observer.mli
+++ b/lib/keeper/keeper_composite_observer.mli
@@ -137,6 +137,21 @@ val check_phase_derivation_agreement :
     [Keeper_invariant_check.DerivePhaseAgreement]: the recorded registry
     phase must equal [Keeper_state_machine.derive_phase conditions]. *)
 
+(** Minimal state extracted from {!Keeper_registry.registry_entry} for
+    the [EventPriorityMonotone] invariant. Separating this type allows
+    QCheck property tests to exercise the predicate without constructing
+    a full registry entry (~20 fields). *)
+type event_priority_state = {
+  ep_measurement_bind_count : int;
+  ep_has_measurement : bool;
+  ep_has_pending_measurement : bool;
+}
+
+(** Pure predicate for TLA+ I4 [EventPriorityMonotone]
+    (KeeperCompositeLifecycle.tla:374): at most one measurement binding
+    per turn, and a live measurement excludes a pending one. *)
+val check_event_priority_monotone_pure : event_priority_state -> bool
+
 (** Frozen outcome of the most recently completed turn (RFC-0003
     Phase 2). Surfaces terminal data ([Done]/[Guard_ok]/...) without
     polluting the live sub-FSM fields. [None] until the first turn

--- a/test/dune
+++ b/test/dune
@@ -498,12 +498,12 @@
         test_keeper_state_machine_pbt test_telemetry_eio_pbt
         test_metrics_store_eio_pbt test_prompt_registry_pbt
         test_keeper_fsm_joints test_clean_only_bug_mirrors
-        test_keeper_phase_drift_contract)
+        test_keeper_phase_drift_contract test_event_priority_monotone_pbt)
  (modules test_pbt_mention test_pbt_validation test_pbt_text_processing test_pbt_context_overflow
           test_keeper_state_machine_pbt test_telemetry_eio_pbt
           test_metrics_store_eio_pbt test_prompt_registry_pbt
           test_keeper_fsm_joints test_clean_only_bug_mirrors
-          test_keeper_phase_drift_contract)
+          test_keeper_phase_drift_contract test_event_priority_monotone_pbt)
  (libraries masc_test_deps))
 
 ; Focused single-module tests

--- a/test/test_event_priority_monotone_pbt.ml
+++ b/test/test_event_priority_monotone_pbt.ml
@@ -1,0 +1,115 @@
+(** Property-based tests for check_event_priority_monotone_pure.
+
+    Exercises the pure EventPriorityMonotone predicate (TLA+ I4)
+    over the full cross-product of {bind_count, has_measurement, has_pending}
+    to verify the invariant holds for exactly the expected states.
+
+    @see KeeperCompositeLifecycle.tla I4 EventPriorityMonotone *)
+
+module Obs = Masc_mcp.Keeper_composite_observer
+
+let gen_event_priority_state =
+  QCheck.Gen.(
+    let* bind_count = int_range 0 3 in
+    let* has_measurement = bool in
+    let* has_pending = bool in
+    return {
+      Obs.ep_measurement_bind_count = bind_count;
+      Obs.ep_has_measurement = has_measurement;
+      Obs.ep_has_pending_measurement = has_pending;
+    })
+
+let arb_state =
+  QCheck.make gen_event_priority_state
+    ~print:(fun s ->
+      Printf.sprintf
+        "{bind=%d; meas=%b; pending=%b}"
+        s.Obs.ep_measurement_bind_count
+        s.Obs.ep_has_measurement
+        s.Obs.ep_has_pending_measurement)
+
+(** Property 1: bind_count > 1 always violates. *)
+let prop_bind_gt1_violates =
+  QCheck.Test.make ~count:500 ~name:"bind_count > 1 always violates"
+    arb_state
+    (fun s ->
+      if s.Obs.ep_measurement_bind_count > 1 then
+        not (Obs.check_event_priority_monotone_pure s)
+      else
+        true)
+
+(** Property 2: has_measurement && has_pending always violates. *)
+let prop_both_active_violates =
+  QCheck.Test.make ~count:500 ~name:"has_measurement && has_pending always violates"
+    arb_state
+    (fun s ->
+      if s.Obs.ep_has_measurement && s.Obs.ep_has_pending_measurement then
+        not (Obs.check_event_priority_monotone_pure s)
+      else
+        true)
+
+(** Property 3: the predicate is equivalent to the direct boolean expression. *)
+let prop_equiv_direct =
+  QCheck.Test.make ~count:1000 ~name:"predicate matches direct expression"
+    arb_state
+    (fun s ->
+      let direct =
+        s.Obs.ep_measurement_bind_count <= 1
+        && not (s.Obs.ep_has_measurement && s.Obs.ep_has_pending_measurement)
+      in
+      Obs.check_event_priority_monotone_pure s = direct)
+
+(** Property 4: known-satisfying states satisfy. *)
+let prop_known_satisfying =
+  QCheck.Test.make ~count:1 ~name:"canonical satisfying states hold"
+    QCheck.(make QCheck.Gen.(oneof [
+      return {
+        Obs.ep_measurement_bind_count = 0;
+        Obs.ep_has_measurement = false;
+        Obs.ep_has_pending_measurement = false;
+      };
+      return {
+        Obs.ep_measurement_bind_count = 1;
+        Obs.ep_has_measurement = true;
+        Obs.ep_has_pending_measurement = false;
+      };
+      return {
+        Obs.ep_measurement_bind_count = 0;
+        Obs.ep_has_measurement = false;
+        Obs.ep_has_pending_measurement = true;
+      };
+    ]))
+    (fun s -> Obs.check_event_priority_monotone_pure s)
+
+(** Property 5: known-violating states violate. *)
+let prop_known_violating =
+  QCheck.Test.make ~count:1 ~name:"canonical violating states fail"
+    QCheck.(make QCheck.Gen.(oneof [
+      return {
+        Obs.ep_measurement_bind_count = 2;
+        Obs.ep_has_measurement = false;
+        Obs.ep_has_pending_measurement = false;
+      };
+      return {
+        Obs.ep_measurement_bind_count = 3;
+        Obs.ep_has_measurement = true;
+        Obs.ep_has_pending_measurement = false;
+      };
+      return {
+        Obs.ep_measurement_bind_count = 1;
+        Obs.ep_has_measurement = true;
+        Obs.ep_has_pending_measurement = true;
+      };
+    ]))
+    (fun s -> not (Obs.check_event_priority_monotone_pure s))
+
+let () =
+  let suite =
+    List.map QCheck_alcotest.to_alcotest
+      [ prop_bind_gt1_violates;
+        prop_both_active_violates;
+        prop_equiv_direct;
+        prop_known_satisfying;
+        prop_known_violating ]
+  in
+  Alcotest.run "event_priority_monotone_pbt" [ ("properties", suite) ]


### PR DESCRIPTION
## Summary
- Extract `check_event_priority_monotone_pure` from the full `registry_entry`-dependent `check_event_priority_monotone`
- Pure predicate operates on minimal `event_priority_state` record (3 fields vs ~20), enabling QCheck PBT without constructing full registry entry
- Adds 5 QCheck properties covering all violation conditions and equivalence verification

## Test plan
- [x] `test_event_priority_monotone_pbt` passes (5/5 QCheck properties, 1000 random states)
- [x] `test_keeper_composite_observer` — no regression from extraction (3 pre-existing failures on main, unchanged)
- [ ] GitHub Actions CI clean build

## Context
Plan Phase D, PR-D2: TLA+/FSM/PPX implementation alignment audit.
The pure predicate mirrors TLA+ I4 `EventPriorityMonotone` from `KeeperCompositeLifecycle.tla:374`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)