### PR TITLE
chore(dashboard): remove dead marketing copy + fix sidebar double-scroll

### DIFF
--- a/dashboard/src/app.ts
+++ b/dashboard/src/app.ts
@@ -312,7 +312,7 @@ export function App() {
         ${compactChromeMode
           ? null
           : html`
-            <aside id="dashboard-side-rail" aria-label="Sidebar navigation" class="${sidebarCollapsed.value ? 'w-14' : 'w-55'} shrink-0 overflow-y-auto overflow-x-hidden rounded-[var(--r-2)] border border-[var(--color-border-default)] bg-[var(--shell-rail-bg)] backdrop-blur-xl transition-[width] duration-[var(--t-slow)] ease-[var(--ease)] max-[1100px]:w-full max-[1100px]:max-h-75 ${mobileMenuOpen.value ? '' : 'max-[768px]:hidden'}">
+            <aside id="dashboard-side-rail" aria-label="Sidebar navigation" class="${sidebarCollapsed.value ? 'w-14' : 'w-55'} shrink-0 overflow-hidden rounded-[var(--r-2)] border border-[var(--color-border-default)] bg-[var(--shell-rail-bg)] backdrop-blur-xl transition-[width] duration-[var(--t-slow)] ease-[var(--ease)] max-[1100px]:w-full max-[1100px]:max-h-75 ${mobileMenuOpen.value ? '' : 'max-[768px]:hidden'}">
               <${SideRail} collapsed=${sidebarCollapsed.value} onToggle=${() => { sidebarCollapsed.value = !sidebarCollapsed.value }} />
             </aside>
           `}

--- a/dashboard/src/components/keeper-detail-panels.ts
+++ b/dashboard/src/components/keeper-detail-panels.ts
@@ -319,29 +319,17 @@ function OutcomesLedger({ keeper, outcomes }: {
 }
 
 // ── KPI Grid ─────────────────────────────────────────────
-//
 // 4-section layout mirrors the keeper's 3-layer state model
-// (Events → Phase+Conditions → Counters) projected onto the four
-// questions an operator asks when opening the modal:
-//   1) "얼마나 오래 살았나?"       → identity      (세대/턴/인계)
-//   2) "지금 위험한가?"             → memory       (컨텍스트/토큰/압축 + 운영 건강도)
-//   3) "스스로 돌고 있나?"          → autonomy     (자율 턴/행동 비율)
-//   4) "무엇을 해냈고 실패했나?"   → outcomes     (backed by KeeperOutcomes)
-//
-// Each section is a rounded-[var(--r-1)] card with a ko-language question-header.
-// PR 5 will expand the outcomes section with the full Success/Failure
-// Ledger, Validator pass-rate grouping, and Resilience Profile.
+// (Events → Phase+Conditions → Counters): identity / memory / autonomy / outcomes.
 
-function KpiSection({ title, question, children }: {
+function KpiSection({ title, children }: {
   title: string
-  question: string
   children: unknown
 }) {
   return html`
     <section class="rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] p-3" aria-label=${title}>
-      <header class="mb-2 flex items-baseline justify-between gap-2">
+      <header class="mb-2">
         <h3 class="text-2xs font-semibold tracking-[var(--track-caps)] uppercase text-[var(--color-fg-muted)]">${title}</h3>
-        <span class="text-3xs text-[var(--color-fg-disabled)] truncate">${question}</span>
       </header>
       ${children}
     </section>
@@ -374,7 +362,7 @@ export function KpiGrid({ keeper }: { keeper: Keeper }) {
 
   return html`
     <div class="flex flex-col gap-3 mb-5">
-      <${KpiSection} title="정체성" question="얼마나 오래 살았나?">
+      <${KpiSection} title="정체성">
         <div class="grid grid-cols-3 gap-2">
           <${StatTile}
             label="세대"
@@ -391,7 +379,7 @@ export function KpiGrid({ keeper }: { keeper: Keeper }) {
         </div>
       <//>
 
-      <${KpiSection} title="메모리 압력" question="지금 위험한가?">
+      <${KpiSection} title="메모리 압력">
         <div class="flex flex-col gap-3">
           <div class="grid grid-cols-2 sm:grid-cols-4 gap-2">
             <${StatTile}
@@ -442,7 +430,7 @@ export function KpiGrid({ keeper }: { keeper: Keeper }) {
         </div>
       <//>
 
-      <${KpiSection} title="자율성 패턴" question="스스로 돌고 있나?">
+      <${KpiSection} title="자율성 패턴">
         <div class="grid grid-cols-2 sm:grid-cols-4 gap-2">
           <${StatTile}
             label="자율 턴"
@@ -463,7 +451,7 @@ export function KpiGrid({ keeper }: { keeper: Keeper }) {
         </div>
       <//>
 
-      <${KpiSection} title="결과" question="무엇을 해냈고 실패했고 검증을 통과했나?">
+      <${KpiSection} title="결과">
         ${outcomes ? html`<${OutcomesLedger} keeper=${keeper} outcomes=${outcomes} />` : html`
           <div class="text-2xs text-[var(--color-fg-disabled)] leading-snug">
             outcomes 집계를 불러오는 중이거나, 이 키퍼는 아직 관찰된 전이가 없습니다.

--- a/dashboard/src/components/keeper-detail-shell.test.ts
+++ b/dashboard/src/components/keeper-detail-shell.test.ts
@@ -16,13 +16,12 @@ describe('KeeperDetailSection', () => {
     container.remove()
   })
 
-  it('renders eyebrow, title, description, and children', () => {
+  it('renders eyebrow, title, and children', () => {
     render(
       html`<${KeeperDetailSection}
         id="keeper-summary"
         eyebrow="OVERVIEW"
         title="Status Overview"
-        description="Summary of keeper state."
       >
         <div data-testid="child">Child</div>
       <//>`,
@@ -31,7 +30,6 @@ describe('KeeperDetailSection', () => {
 
     expect(container.textContent).toContain('OVERVIEW')
     expect(container.textContent).toContain('Status Overview')
-    expect(container.textContent).toContain('Summary of keeper state.')
     expect(container.querySelector('[data-testid="child"]')).not.toBeNull()
   })
 
@@ -41,7 +39,6 @@ describe('KeeperDetailSection', () => {
         id="keeper-debug"
         eyebrow="DEBUG"
         title="Debug"
-        description="Debug info."
       >
         <span>content</span>
       <//>`,
@@ -59,7 +56,6 @@ describe('KeeperDetailSection', () => {
         id="keeper-config"
         eyebrow="CONFIG"
         title="Configuration"
-        description="Config details."
       >
         <div>inner</div>
       <//>`,

--- a/dashboard/src/components/keeper-detail-shell.ts
+++ b/dashboard/src/components/keeper-detail-shell.ts
@@ -295,13 +295,6 @@ export function KeeperDetailOverviewSidebar({
   return html`
     <aside class="order-2 xl:order-1 xl:sticky xl:top-[104px] xl:self-start" aria-label="키퍼 프로필 요약">
       <div class="flex flex-col gap-4 rounded-[var(--r-6)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] p-4 shadow-[var(--shadow-panel)]">
-        <div>
-          <${SectionLabel}>개요</${SectionLabel}>
-          <p class="m-0 mt-2 text-sm leading-relaxed text-[var(--color-fg-secondary)]">
-            긴 단일 모달 대신 keeper 상세를 별도 화면으로 펼쳤습니다. 운영자가 자주 오가는 맥락 단위로 나눠서 바로 점프할 수 있습니다.
-          </p>
-        </div>
-
         <div class="grid gap-3 sm:grid-cols-2 xl:grid-cols-1">
           <${KeeperDetailQuickFact} label="상태">${effectiveStatus}<//>
           <${KeeperDetailQuickFact} label="컨텍스트">${contextRatioPct}<//>
@@ -335,13 +328,11 @@ export function KeeperDetailSection({
   id,
   eyebrow,
   title,
-  description,
   children,
 }: {
   id: KeeperDetailSectionId
   eyebrow: string
   title: string
-  description: string
   children: ComponentChildren
 }) {
   return html`
@@ -352,12 +343,7 @@ export function KeeperDetailSection({
     >
       <div class="border-b border-[var(--color-border-default)] px-5 py-4 sm:px-6">
         <div class="text-3xs font-semibold uppercase tracking-[var(--track-brand)] text-[var(--color-fg-muted)]">${eyebrow}</div>
-        <div class="mt-1 flex flex-col gap-1 lg:flex-row lg:items-end lg:justify-between">
-          <div>
-            <h3 class="m-0 text-lg font-semibold text-[var(--color-fg-primary)]">${title}</h3>
-            <p class="m-0 mt-1 text-sm leading-relaxed text-[var(--color-fg-secondary)]">${description}</p>
-          </div>
-        </div>
+        <h3 class="m-0 mt-1 text-lg font-semibold text-[var(--color-fg-primary)]">${title}</h3>
       </div>
       <div class="flex flex-col gap-4 px-5 py-5 sm:px-6">
         ${children}

--- a/dashboard/src/components/keeper-detail.ts
+++ b/dashboard/src/components/keeper-detail.ts
@@ -1012,7 +1012,6 @@ export function KeeperDetailPage() {
             id="keeper-summary"
             eyebrow="상태 개요"
             title="운영 상태 개요"
-            description="상태 기계, 메모리 티어, KPI, 추론/컨텍스트 계측을 먼저 훑어 keeper의 현재 건강도를 빠르게 판단합니다."
           >
         <${PipelineStageBar} stage=${keeper.pipeline_stage} />
         <${CollapsibleSection} title="Phase State Machine">
@@ -1097,7 +1096,6 @@ export function KeeperDetailPage() {
             id="keeper-comms"
             eyebrow="대화 & 세션"
             title="대화 / 활동 흐름"
-            description="운영자가 keeper와 바로 대화하고, 같은 화면에서 세션 이벤트를 대조할 수 있도록 묶었습니다."
           >
             <${KeeperCommsPanel} keeper=${keeper} />
             <${PanelCard} title="세션 활동 로그">
@@ -1110,7 +1108,6 @@ export function KeeperDetailPage() {
             id="keeper-runtime"
             eyebrow="런타임 진단"
             title="진단 / 운영"
-            description="eval, supervisor, 복구 액션, tool audit, 품질 시그널을 한 군데로 모아 원인 파악과 개입을 빠르게 합니다."
           >
             <${KeeperToolTelemetry} keeperName=${keeper.name} />
             <${KeeperEvalQualityPanel} keeperName=${keeper.name} />
@@ -1143,7 +1140,6 @@ export function KeeperDetailPage() {
             id="keeper-identity"
             eyebrow="신원 & 계보"
             title="정체성 / 세대"
-            description="프로필, 관계, 장비, generation lineage, checkpoints를 하나의 맥락으로 보고 continuity를 해석합니다."
           >
             <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
               <${PanelCard} title="프로필">
@@ -1209,7 +1205,6 @@ export function KeeperDetailPage() {
             id="keeper-config"
             eyebrow="설정"
             title="설정 / 작업 방식"
-            description="분산되어 있던 허용 도구 목록, 작업 budget, playground repo, keeper config를 한 섹션으로 모았습니다."
           >
             <${TurnBudgetSection} keeper=${keeper} />
             <${CollapsibleSection} title="허용 도구">
@@ -1229,7 +1224,6 @@ export function KeeperDetailPage() {
             id="keeper-debug"
             eyebrow="디버그"
             title="디버그"
-            description="운영 중에는 덜 자주 보지만, 문제를 깊게 파고들 때 필요한 raw surface를 마지막에 모았습니다."
           >
             <details class="mt-0">
           <summary class="cursor-pointer py-3 px-4 text-2xs font-semibold uppercase tracking-[var(--track-caps)] text-[var(--color-fg-muted)] list-none select-none rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] hover:bg-[var(--color-bg-hover)] transition-colors flex items-center gap-2">


### PR DESCRIPTION
## 요약

200+ PR이 백엔드에 누적되는 동안 dashboard에 쌓인 dead marketing copy와 사이드바 이중 스크롤 버그를 정리합니다.

## 변경 (Phase 1 of 3)

### 1) 의인화 question subtitle 제거 (`KpiSection`)
| 제거 전 | 제거 후 |
|---|---|
| "정체성 — 얼마나 오래 살았나?" | "정체성" |
| "메모리 압력 — 지금 위험한가?" | "메모리 압력" |
| "자율성 패턴 — 스스로 돌고 있나?" | "자율성 패턴" |
| "결과 — 무엇을 해냈고 실패했고 검증을 통과했나?" | "결과" |

운영자는 키퍼 상세 화면에 들어온 이유를 이미 알고 있음. 의인화된 한국어 질문은 anti-hype 룰 위반 (가치 주장이지 동작 기술이 아님).

### 2) `KeeperDetailSection.description` prop 제거 (6개 호출 모두)
| 섹션 | 제거된 마케팅 카피 |
|---|---|
| 상태 개요 | "상태 기계, 메모리 티어, KPI, 추론/컨텍스트 계측을 먼저 훑어 keeper의 현재 건강도를 빠르게 판단합니다." |
| 대화 / 활동 흐름 | "운영자가 keeper와 바로 대화하고, 같은 화면에서 세션 이벤트를 대조할 수 있도록 묶었습니다." |
| 진단 / 운영 | "eval, supervisor, 복구 액션, tool audit, 품질 시그널을 한 군데로 모아 원인 파악과 개입을 빠르게 합니다." |
| 정체성 / 세대 | "프로필, 관계, 장비, generation lineage, checkpoints를 하나의 맥락으로 보고 continuity를 해석합니다." |
| 설정 / 작업 방식 | "분산되어 있던 허용 도구 목록, 작업 budget, playground repo, keeper config를 한 섹션으로 모았습니다." |
| 디버그 | "운영 중에는 덜 자주 보지만, 문제를 깊게 파고들 때 필요한 raw surface를 마지막에 모았습니다." |

eyebrow + title이 SSOT. description은 dead noise.

### 3) `KeeperDetailOverviewSidebar` meta paragraph 제거
\`\`\`
긴 단일 모달 대신 keeper 상세를 별도 화면으로 펼쳤습니다. 운영자가 자주 오가는
맥락 단위로 나눠서 바로 점프할 수 있습니다.
\`\`\`
운영자는 이미 detail surface 위에 있음. meta-tour 카피는 noise.

### 4) 사이드바 이중 스크롤 버그 fix
**증상**: 사용자 보고 — 좌측 메뉴바 스크롤 안 됨, 너무 많이 차지함.

**원인**: `<aside>` (`app.ts:315`)에 `overflow-y-auto`, 그 안 `<nav>` 내부에도 `<div class="flex-1 overflow-y-auto">` (`dashboard-shell.ts:438`). 이중 스크롤 컨테이너 → outer가 콘텐츠 전체 높이로 자라서 inner가 절대 스크롤 안 됨. footer (`HealthIndicator`, `shrink-0`)가 sticky-bottom 의도였으나 outer 확장에 밀려 viewport 밖으로 빠짐.

**Fix**: aside의 `overflow-y-auto` → `overflow-hidden`. nav 내부의 `flex-1 overflow-y-auto`가 단일 스크롤 컨테이너로 동작. footer 자동 sticky.

## 검증
- `pnpm typecheck`: 내 변경 파일에서 0 error (baseline 23 errors는 fsm-hub 관련, main에 동일 존재)
- `pnpm vitest run` (scoped, 5 files): **40/40 passed**
- `pnpm build`: 성공 (9.97s)
- LoC: **-46 / +10** (net negative)

## 후속 작업 (Phase 2/3, 별도 PR)
- Phase 2: 추가 dead-info 인벤토리 (loading-state copy, 죽은 백엔드 필드 노출)
- Phase 3 (RFC): TLA FSM (KSM/KTC/KDP/KMC/KCL) 진짜 상태만 노출하는 정보 아키텍처 재구성

## RFC 발견 체크
- credential / identity / operator_control / keeper_sandbox / .claude/hooks / workflow* 미수정 → RFC 면제

## ⚠️ Draft 유지 요청
agent-authored PR이므로 \`gh pr ready\`는 사용자가 \`human-approved-ready\` 라벨 추가 후에만 진행해주세요 (memory: \`feedback_masc_mcp_draft_guard_blocks_agent_ready.md\`).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>