### PR TITLE
chore(dashboard): drop redundant panel-card description blurbs

### DIFF
--- a/dashboard/src/components/keeper-detail.ts
+++ b/dashboard/src/components/keeper-detail.ts
@@ -1101,7 +1101,6 @@ export function KeeperDetailPage() {
           >
             <${KeeperCommsPanel} keeper=${keeper} />
             <${PanelCard} title="세션 활동 로그">
-              <div class="text-2xs text-[var(--color-fg-muted)] mb-3">현재 세션의 도구 호출, 태스크 완료, 메시지 등 이벤트 기록</div>
               <${SessionTraceView} agentName=${keeper.name} isKeeper=${true} keeperStatus=${keeper.status} keeperGeneration=${keeper.generation} />
             <//>
           <//>
@@ -1134,7 +1133,6 @@ export function KeeperDetailPage() {
               </div>
             <//>
             <${CollapsibleSection} title="품질 시그널 (고급 지표)">
-              <div class="mt-3 text-2xs text-[var(--color-fg-muted)] mb-3">폴백 비율, 정렬 품질, 자율 행동 비율 등 metrics_window 기반 런타임 품질 지표</div>
               <${RuntimeSignals} keeper=${keeper} />
             <//>
           </${KeeperDetailSection}>


### PR DESCRIPTION
## 요약

PR #14219의 후속. 같은 anti-hype 안티패턴이 PanelCard / CollapsibleSection 안에서 두 번 더 발견됨 — 임베드된 컴포넌트가 이미 그 정보를 직접 표시하는데도 위에 한 줄 explainer가 중복 노출됨.

## 변경

### 1) `세션 활동 로그` PanelCard (keeper-detail.ts:1104)
\`\`\`diff
- <div class="text-2xs text-[var(--color-fg-muted)] mb-3">
-   현재 세션의 도구 호출, 태스크 완료, 메시지 등 이벤트 기록
- </div>
\`\`\`
→ `SessionTraceView`가 도구 호출/태스크/메시지를 그대로 렌더. 한 줄 위 explainer는 중복.

### 2) `품질 시그널 (고급 지표)` CollapsibleSection (keeper-detail.ts:1137)
\`\`\`diff
- <div class="mt-3 text-2xs text-[var(--color-fg-muted)] mb-3">
-   폴백 비율, 정렬 품질, 자율 행동 비율 등 metrics_window 기반 런타임 품질 지표
- </div>
\`\`\`
→ `RuntimeSignals`가 각 metric을 inline label로 보여줌.

## 검증
- `pnpm vitest run keeper-detail.test.ts`: **21/21 passed**
- `pnpm build`: 성공 (8.72s)
- LoC: **-2 / +0**

## Scope
keeper-detail.ts 단일 파일 2줄. 다른 영역에서 grep한 결과 비슷한 정적 explainer는 모두 label / empty-state / keyboard-hint 같은 valid 용도 (예: "Enter로 전송, Shift+Enter로 줄바꿈")로 보존.

## 후속 (Phase 3, 별도)
TLA FSM (KSM/KTC/KDP/KMC/KCL) 진짜 상태만 노출하는 정보 아키텍처 RFC는 별도 토론.

## ⚠️ Draft 유지 요청
agent-authored — `human-approved-ready` 라벨 후 `gh pr ready` 부탁드립니다.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>