### PR TITLE
feat(keeper): RFC-0042 PR-2.5 — typed SDK-error bridge (Sdk_error variant)

### DIFF
--- a/lib/keeper/keeper_agent_error.ml
+++ b/lib/keeper/keeper_agent_error.ml
@@ -31,15 +31,17 @@ let keeper_internal_error_to_json = function
       [ "kind", `String "tool_surface_mismatch"
       ; "keeper_name", `String keeper_name
       ; "required_tools", `List (List.map (fun value -> `String value) required_tools)
-      ; ( "missing_required_tools",
-          `List (List.map (fun value -> `String value) missing_required_tools) )
+      ; ( "missing_required_tools"
+        , `List (List.map (fun value -> `String value) missing_required_tools) )
       ; "visible_tools", `List (List.map (fun value -> `String value) visible_tools)
       ]
+;;
 
 let sdk_error_of_keeper_internal_error err =
   Agent_sdk.Error.Internal
     (keeper_internal_error_prefix
      ^ Yojson.Safe.to_string (keeper_internal_error_to_json err))
+;;
 
 let sdk_error_kind = function
   | Agent_sdk.Error.Api _ -> "api"
@@ -51,6 +53,7 @@ let sdk_error_kind = function
   | Agent_sdk.Error.Orchestration _ -> "orchestration"
   | Agent_sdk.Error.A2a _ -> "a2a"
   | Agent_sdk.Error.Internal _ -> "internal"
+;;
 
 (* Per-variant terminal_reason_code for Agent_sdk.Error.Api.
    Previously every API failure collapsed to "api_error", so 7 keepers
@@ -70,6 +73,7 @@ let api_error_terminal_reason_code (err : Agent_sdk.Error.api_error) : string =
   | Agent_sdk.Retry.ContextOverflow _ -> "api_error_context_overflow"
   | Agent_sdk.Retry.NetworkError _ -> "api_error_network"
   | Agent_sdk.Retry.Timeout _ -> "api_error_timeout"
+;;
 
 (* Per-variant terminal_reason_code for Agent_sdk.Error.Agent.
    Previously every Agent failure collapsed to "agent_error", mirroring
@@ -80,41 +84,33 @@ let agent_error_terminal_reason_code = function
       "completion_contract_violation:%s"
       (Agent_sdk.Completion_contract_id.to_string contract)
   | Agent_sdk.Error.MaxTurnsExceeded { turns; limit } ->
-    Printf.sprintf
-      "agent_error_max_turns_exceeded:turns=%d,limit=%d"
-      turns limit
+    Printf.sprintf "agent_error_max_turns_exceeded:turns=%d,limit=%d" turns limit
   | Agent_sdk.Error.ExitConditionMet { turn } ->
-    Printf.sprintf
-      "agent_error_exit_condition_met:turn=%d"
-      turn
+    Printf.sprintf "agent_error_exit_condition_met:turn=%d" turn
   | Agent_sdk.Error.UnrecognizedStopReason { reason } ->
-    Printf.sprintf
-      "agent_error_unrecognized_stop_reason:%s"
-      reason
+    Printf.sprintf "agent_error_unrecognized_stop_reason:%s" reason
   | Agent_sdk.Error.TokenBudgetExceeded { kind; used; limit } ->
     Printf.sprintf
       "agent_error_token_budget_exceeded:kind=%s,used=%d,limit=%d"
-      kind used limit
+      kind
+      used
+      limit
   | Agent_sdk.Error.CostBudgetExceeded { spent_usd; limit_usd } ->
     Printf.sprintf
       "agent_error_cost_budget_exceeded:spent_usd=%.2f,limit_usd=%.2f"
-      spent_usd limit_usd
+      spent_usd
+      limit_usd
   | Agent_sdk.Error.IdleDetected { consecutive_idle_turns } ->
     Printf.sprintf
       "agent_error_idle_detected:consecutive_idle_turns=%d"
       consecutive_idle_turns
   | Agent_sdk.Error.ToolRetryExhausted { attempts; limit; detail = _ } ->
-    Printf.sprintf
-      "agent_error_tool_retry_exhausted:attempts=%d,limit=%d"
-      attempts limit
+    Printf.sprintf "agent_error_tool_retry_exhausted:attempts=%d,limit=%d" attempts limit
   | Agent_sdk.Error.GuardrailViolation { validator; reason = _ } ->
-    Printf.sprintf
-      "agent_error_guardrail_violation:validator=%s"
-      validator
+    Printf.sprintf "agent_error_guardrail_violation:validator=%s" validator
   | Agent_sdk.Error.TripwireViolation { tripwire; reason = _ } ->
-    Printf.sprintf
-      "agent_error_tripwire_violation:tripwire=%s"
-      tripwire
+    Printf.sprintf "agent_error_tripwire_violation:tripwire=%s" tripwire
+;;
 
 let terminal_reason_code_of_sdk_error = function
   | Agent_sdk.Error.Agent err -> agent_error_terminal_reason_code err
@@ -126,6 +122,22 @@ let terminal_reason_code_of_sdk_error = function
   | Agent_sdk.Error.Orchestration _ -> "orchestration_error"
   | Agent_sdk.Error.A2a _ -> "a2a_error"
   | Agent_sdk.Error.Internal _ -> "internal_error"
+;;
+
+(* RFC-0042 PR-2.5: typed bridge for SDK errors. The wire format is the
+   existing parametrised string (kept by [terminal_reason_code_of_sdk_error]
+   above) wrapped in [Keeper_turn_terminal_code.Sdk_error]. PR-3 swaps
+   [Keeper_turn_terminal.t.code] from [string] to [Keeper_turn_terminal_code.t]
+   and uses these typed accessors at every emit site. RFC §5.2 defers the
+   sub-sum split (per-variant constructors for [MaxTurnsExceeded] etc.) to
+   a follow-up RFC. *)
+let terminal_reason_code_of_sdk_error_typed err =
+  Keeper_turn_terminal_code.of_sdk_error_wire (terminal_reason_code_of_sdk_error err)
+;;
+
+let api_error_terminal_reason_code_typed err =
+  Keeper_turn_terminal_code.of_sdk_error_wire (api_error_terminal_reason_code err)
+;;
 
 let receipt_outcome_kind_of_sdk_error = function
   | Agent_sdk.Error.Api (Agent_sdk.Retry.Timeout _) -> `Cancelled
@@ -133,15 +145,19 @@ let receipt_outcome_kind_of_sdk_error = function
   | Agent_sdk.Error.Agent (Agent_sdk.Error.IdleDetected _) -> `Cancelled
   | Agent_sdk.Error.Agent (Agent_sdk.Error.ExitConditionMet _) -> `Cancelled
   | _ -> `Error
+;;
 
 let checkpoint_persistence_error ~keeper_name ~detail =
   Agent_sdk.Error.Internal
     (Printf.sprintf
        "keeper_checkpoint_persist_failed: keeper=%s detail=%s"
-       keeper_name detail)
+       keeper_name
+       detail)
+;;
 
 let cascade_outcome_of_observation = function
   | Some (obs : Oas_worker.cascade_observation) when obs.fallback_applied ->
     "passed_to_next_model"
   | Some _ -> "completed"
   | None -> "not_observed"
+;;

--- a/lib/keeper/keeper_agent_error.mli
+++ b/lib/keeper/keeper_agent_error.mli
@@ -24,7 +24,9 @@ val keeper_internal_error_to_json : keeper_internal_error -> Yojson.Safe.t
 (** Wrap a [keeper_internal_error] inside [Agent_sdk.Error.Internal] so it
     flows through the standard SDK error channel with a recognizable
     prefix. *)
-val sdk_error_of_keeper_internal_error : keeper_internal_error -> Agent_sdk.Error.sdk_error
+val sdk_error_of_keeper_internal_error
+  :  keeper_internal_error
+  -> Agent_sdk.Error.sdk_error
 
 (** Coarse categorisation of [Agent_sdk.Error.sdk_error] (for dashboards). *)
 val sdk_error_kind : Agent_sdk.Error.sdk_error -> string
@@ -40,19 +42,42 @@ val api_error_terminal_reason_code : Agent_sdk.Error.api_error -> string
     embedding the contract id for completion-contract violations. *)
 val terminal_reason_code_of_sdk_error : Agent_sdk.Error.sdk_error -> string
 
+(** RFC-0042 PR-2.5: typed bridge variants of the wire accessors.
+    Wrap the existing parametrised wire string in
+    [Keeper_turn_terminal_code.Sdk_error]. PR-3 swaps
+    [Keeper_turn_terminal.t.code] from [string] to
+    [Keeper_turn_terminal_code.t] and uses these accessors at every
+    emit site. RFC §5.2 explicitly defers per-variant constructors
+    (~25-variant explosion); a follow-up RFC will split [Sdk_error] once
+    production traces narrow the actual sub-kind set.
+
+    Byte invariant guarded by [test_keeper_sdk_error_typed_bridge].
+
+    @since 0.193.1 *)
+val terminal_reason_code_of_sdk_error_typed
+  :  Agent_sdk.Error.sdk_error
+  -> Keeper_turn_terminal_code.t
+
+(** Typed counterpart of [api_error_terminal_reason_code]. *)
+val api_error_terminal_reason_code_typed
+  :  Agent_sdk.Error.api_error
+  -> Keeper_turn_terminal_code.t
+
 (** Receipt outcome for terminal SDK errors.  Provider timeouts map to
     [`Cancelled] to match [KeeperTurnFSM.tla] [ProviderTimeout], while
     all other SDK errors remain ordinary failed receipts. *)
-val receipt_outcome_kind_of_sdk_error :
-  Agent_sdk.Error.sdk_error -> Keeper_execution_receipt.outcome_kind
+val receipt_outcome_kind_of_sdk_error
+  :  Agent_sdk.Error.sdk_error
+  -> Keeper_execution_receipt.outcome_kind
 
 (** Structured internal error for post-turn checkpoint persistence
     failures.  Used to prevent an otherwise successful keeper turn from
     returning [Ok] when the replay checkpoint is not durable. *)
-val checkpoint_persistence_error :
-  keeper_name:string -> detail:string -> Agent_sdk.Error.sdk_error
+val checkpoint_persistence_error
+  :  keeper_name:string
+  -> detail:string
+  -> Agent_sdk.Error.sdk_error
 
 (** Map an optional cascade observation to a textual outcome label
     ("passed_to_next_model" / "completed" / "not_observed"). *)
-val cascade_outcome_of_observation :
-  Oas_worker.cascade_observation option -> string
+val cascade_outcome_of_observation : Oas_worker.cascade_observation option -> string

--- a/lib/keeper/keeper_turn_terminal_code.ml
+++ b/lib/keeper/keeper_turn_terminal_code.ml
@@ -22,6 +22,7 @@ type t =
   | Ambiguous_partial_commit_post_commit_failure
   | Fiber_unresolved
   | Exception_unhandled of string
+  | Sdk_error of string
 
 let to_wire = function
   | Healthy -> "healthy"
@@ -41,6 +42,7 @@ let to_wire = function
   | Ambiguous_partial_commit_post_commit_failure -> "ambiguous_partial_commit"
   | Fiber_unresolved -> "fiber_unresolved"
   | Exception_unhandled _ -> "exception"
+  | Sdk_error wire -> wire
 ;;
 
 let of_wire = function
@@ -103,3 +105,5 @@ let of_failure_reason_option = function
        is byte-for-byte equal to the pre-RFC default. *)
     Stale_turn_timeout_in_turn
 ;;
+
+let of_sdk_error_wire wire = Sdk_error wire

--- a/lib/keeper/keeper_turn_terminal_code.mli
+++ b/lib/keeper/keeper_turn_terminal_code.mli
@@ -56,6 +56,20 @@ type t =
   | Exception_unhandled of string
   (** [Keeper_registry.Exception]: payload is the exception
           message. *)
+  | Sdk_error of string
+  (** Catch-all for [Agent_sdk.Error.t] wire strings (agent / api /
+          mcp / config / serialization / io / orchestration / a2a /
+          internal). The payload is the existing parametrised wire
+          format produced by [Keeper_agent_error.terminal_reason_code_of_sdk_error]
+          (e.g. ["agent_error_max_turns_exceeded:turns=10,limit=10"],
+          ["completion_contract_violation:require_tool_use"],
+          ["api_error_server:502"]). PR-2.5 wraps the existing typed
+          accessors in this variant so the typed bridge becomes a
+          single source of truth for [Keeper_turn_terminal.t.code]
+          field swap (PR-3). RFC-0042 §5.2 explicitly defers refining
+          this into per-variant constructors (~25-variant explosion);
+          a follow-up RFC will split it once production traces narrow
+          the actual sub-kind set. *)
 
 (** Stable wire format. The strings produced here are byte-for-byte
     compatible with the strings emitted today by
@@ -98,3 +112,18 @@ val of_failure_reason : Keeper_registry.failure_reason -> t
 
     @since 0.193.0 *)
 val of_failure_reason_option : Keeper_registry.failure_reason option -> t
+
+(** Wrap an [Agent_sdk.Error.t] wire string into the typed bridge.
+    The argument is the legacy parametrised wire string produced by
+    [Keeper_agent_error.terminal_reason_code_of_sdk_error] /
+    [agent_error_terminal_reason_code] /
+    [api_error_terminal_reason_code]. Returns [Sdk_error s] verbatim;
+    [to_wire] reproduces [s] byte-for-byte.
+
+    PR-2.5 introduces this as a thin typed bridge; a follow-up RFC
+    will replace [s] with a closed sub-sum once the parametrised
+    sub-kinds (`turns=N,limit=M`, `kind=token,used=K,limit=L`, …) are
+    inventoried from production traces.
+
+    @since 0.193.1 *)
+val of_sdk_error_wire : string -> t

--- a/test/dune
+++ b/test/dune
@@ -27,6 +27,7 @@
 (tests
  (names test_attribution test_attribution_tagged test_autoresearch_result_bridge test_dashboard_attribution test_dashboard_oas_bridge test_masc_runtime_events test_room test_room_state_recovery test_types test_exec_tap test_auth test_auth_doctor test_auth_error_kind test_auth_login test_audit_log test_governance_anomaly test_http_negotiation
         test_keeper_turn_terminal_code_byte_compat
+        test_keeper_sdk_error_typed_bridge
         test_attempt_state
         test_sse test_graphql_api
         test_graphql_endpoint
@@ -258,6 +259,7 @@
         )
  (modules test_attribution test_attribution_tagged test_autoresearch_result_bridge test_dashboard_attribution test_dashboard_oas_bridge test_masc_runtime_events test_room test_room_state_recovery test_types test_exec_tap test_auth test_auth_doctor test_auth_error_kind test_auth_login test_audit_log test_governance_anomaly test_http_negotiation
           test_keeper_turn_terminal_code_byte_compat
+          test_keeper_sdk_error_typed_bridge
           test_attempt_state
           test_sse test_graphql_api
           test_graphql_endpoint

--- a/test/test_keeper_sdk_error_typed_bridge.ml
+++ b/test/test_keeper_sdk_error_typed_bridge.ml
@@ -1,0 +1,98 @@
+(** RFC-0042 PR-2.5 invariant: the typed accessors
+    [Keeper_agent_error.terminal_reason_code_of_sdk_error_typed] and
+    [Keeper_agent_error.api_error_terminal_reason_code_typed] must
+    produce wire bytes byte-for-byte identical to the existing untyped
+    string accessors. PR-3 will swap [Keeper_turn_terminal.t.code]
+    from [string] to [Keeper_turn_terminal_code.t]; this test guards
+    that the swap does not change what dashboards / [bin/masc-trace]
+    / Prometheus labels see.
+
+    Coverage:
+    - all 9 [api_error] variants (RateLimited / Overloaded / ServerError /
+      AuthError / InvalidRequest / NotFound / ContextOverflow /
+      NetworkError / Timeout)
+    - all 9 [agent_error] variants reached via [SdkE.Agent _] routing
+    - all 7 top-level non-Agent / non-Api wrappers (Mcp / Config /
+      Serialization / Io / Orchestration / A2a / Internal) *)
+
+module AE = Masc_mcp.Keeper_agent_error
+module Code = Masc_mcp.Keeper_turn_terminal_code
+module SdkE = Agent_sdk.Error
+module Retry = Agent_sdk.Retry
+module Http = Llm_provider.Http_client
+
+let typed_wire t = Code.to_wire t
+
+let api_cases : (string * SdkE.api_error) list =
+  [ "RateLimited", Retry.RateLimited { retry_after = Some 30.0; message = "" }
+  ; "Overloaded", Retry.Overloaded { message = "" }
+  ; "ServerError", Retry.ServerError { status = 502; message = "" }
+  ; "AuthError", Retry.AuthError { message = "" }
+  ; "InvalidRequest", Retry.InvalidRequest { message = "bad" }
+  ; "NotFound", Retry.NotFound { message = "missing" }
+  ; "ContextOverflow", Retry.ContextOverflow { message = "ctx"; limit = Some 8192 }
+  ; ( "NetworkError"
+    , Retry.NetworkError { message = "ECONNRESET"; kind = Http.Connection_refused } )
+  ; "Timeout", Retry.Timeout { message = "60s" }
+  ]
+;;
+
+(* All variants reached through the top-level dispatcher. *)
+let sdk_cases : (string * SdkE.sdk_error) list =
+  [ ( "Agent/MaxTurnsExceeded"
+    , SdkE.Agent (SdkE.MaxTurnsExceeded { turns = 10; limit = 10 }) )
+  ; "Agent/ExitConditionMet", SdkE.Agent (SdkE.ExitConditionMet { turn = 5 })
+  ; ( "Agent/UnrecognizedStopReason"
+    , SdkE.Agent (SdkE.UnrecognizedStopReason { reason = "abrupt" }) )
+  ; ( "Agent/TokenBudgetExceeded"
+    , SdkE.Agent (SdkE.TokenBudgetExceeded { kind = "token"; used = 4096; limit = 4096 })
+    )
+  ; ( "Agent/CostBudgetExceeded"
+    , SdkE.Agent (SdkE.CostBudgetExceeded { spent_usd = 0.42; limit_usd = 0.40 }) )
+  ; "Agent/IdleDetected", SdkE.Agent (SdkE.IdleDetected { consecutive_idle_turns = 3 })
+  ; "Api/Timeout", SdkE.Api (Retry.Timeout { message = "60s" })
+  ; "Mcp", SdkE.Mcp (SdkE.InitializeFailed { detail = "boot" })
+  ; "Config", SdkE.Config (SdkE.MissingEnvVar { var_name = "X" })
+  ; "Serialization", SdkE.Serialization (SdkE.JsonParseError { detail = "syntax" })
+  ; "Io", SdkE.Io (SdkE.ValidationFailed { detail = "vfd" })
+  ; "Orchestration", SdkE.Orchestration (SdkE.UnknownAgent { name = "ghost" })
+  ; "A2a", SdkE.A2a (SdkE.TaskNotFound { task_id = "id" })
+  ; "Internal", SdkE.Internal "internal issue"
+  ]
+;;
+
+let test_api_byte_compat () =
+  List.iter
+    (fun (label, err) ->
+       let expected = AE.api_error_terminal_reason_code err in
+       let actual = typed_wire (AE.api_error_terminal_reason_code_typed err) in
+       Alcotest.(check string) ("api/" ^ label) expected actual)
+    api_cases
+;;
+
+let test_sdk_byte_compat () =
+  List.iter
+    (fun (label, err) ->
+       let expected = AE.terminal_reason_code_of_sdk_error err in
+       let actual = typed_wire (AE.terminal_reason_code_of_sdk_error_typed err) in
+       Alcotest.(check string) ("sdk/" ^ label) expected actual)
+    sdk_cases
+;;
+
+let () =
+  Alcotest.run
+    "keeper_sdk_error_typed_bridge"
+    [ ( "api_error byte invariant"
+      , [ Alcotest.test_case
+            "all api_error cases match untyped"
+            `Quick
+            test_api_byte_compat
+        ] )
+    ; ( "sdk_error byte invariant"
+      , [ Alcotest.test_case
+            "all sdk_error cases match untyped"
+            `Quick
+            test_sdk_byte_compat
+        ] )
+    ]
+;;


### PR DESCRIPTION
## Goal

Close the N-of-M obligation declared in PR-2 (#14211) self-check
("Remaining \`agent_error_terminal_reason_code\` explicitly tracked
above as PR-2.5 with reason — parametrised wire format requires \`t\`
extension").

Activate the typed bridge for the SDK-error half:
\`Keeper_agent_error.terminal_reason_code_of_sdk_error_typed\` and
\`api_error_terminal_reason_code_typed\`. PR-3 can then swap
\`Keeper_turn_terminal.t.code\` from \`string\` to
\`Keeper_turn_terminal_code.t\` without losing agent / api error info.

## What changed

| File | Δ |
|---|---|
| \`lib/keeper/keeper_turn_terminal_code.ml/.mli\` | New \`Sdk_error of string\` constructor. \`to_wire (Sdk_error s) = s\` — byte-for-byte preserved. |
| \`lib/keeper/keeper_agent_error.ml/.mli\` | New typed accessors \`terminal_reason_code_of_sdk_error_typed\`, \`api_error_terminal_reason_code_typed\`. Untyped accessors unchanged. |
| \`test/test_keeper_sdk_error_typed_bridge.ml\` | NEW. 23 cases (9 api_error + 14 sdk_error wrappers). Byte invariant locked: typed → \`to_wire\` must equal untyped accessor. |
| \`test/dune\` | Register the new test binary. |

## Verification

\`\`\`
$ bash scripts/dune-local.sh build @check  # OK
$ bash scripts/dune-local.sh exec test/test_keeper_sdk_error_typed_bridge.exe
  [OK]  api_error byte invariant   all api_error cases match untyped
  [OK]  sdk_error byte invariant   all sdk_error cases match untyped
Test Successful in 0.000s. 2 tests run.

# previous PR-2 invariant still passes
$ bash scripts/dune-local.sh exec test/test_keeper_turn_terminal_code_byte_compat.exe
  [OK]  stale_terminal_reason_code byte invariant
\`\`\`

## Why \`Sdk_error of string\` (not per-variant)

RFC-0042 §5.2 explicitly notes \"Closed sums grow … the type can have ~25
variants\" and §3.1 defers \"Provider_runtime_error of provider_kind\" and
similar refinements to follow-up RFCs that need a production-trace
analysis pass. The current wire format embeds parameters
(\`turns=N,limit=M\`, \`kind=K,used=U,limit=L\`, …) that are downstream-
parsed by dashboards and \`bin/masc-trace\`; pulling those parameters
into typed sub-records is a separate scope.

PR-2.5 keeps the closed-sum discipline (no new free-string emit sites
added; the only producer is now the typed accessor) while leaving the
existing parametrised wire intact. A follow-up RFC will split
\`Sdk_error\` into per-variant constructors once the production-trace
inventory is complete.

## Wire stability

- \`masc_persistence_read_drops_total\` label cardinality: unchanged.
- Receipt JSON \`terminal_reason_code\` field: byte-for-byte equal.
- Dashboards filtering on prefix substrings (\`completion_contract_violation:\`,
  \`agent_error_*\`, \`api_error_*\`): continue to match.

## Anti-pattern self-check (\`software-development.md §워크어라운드 거부 기준\`)

- [ ] ❌ Telemetry-as-fix — N/A
- [ ] ❌ String/substring classifier — *gated*, not removed: the
  free-string wire is now only producible via the typed accessor.
  Consumer-side substring matching (\`String.starts_with
  ~prefix:\"completion_contract_violation:\"\` in
  \`keeper_execution_receipt.ml\`) is **unchanged** and waits for PR-4
  (reader migration). Acknowledged: this PR does not solve the
  consumer side; it only closes the producer-side N-of-M.
- [ ] ❌ N-of-M patch — **closes** the PR-2 N-of-M (1 of 2 → 2 of 2)
- [ ] ❌ catch-all — N/A
- [ ] ❌ cap/cooldown/dedup/repair — N/A

## Out of scope

- Reader-side substring match removal (PR-4).
- \`Keeper_turn_terminal.t.code\` string→t field swap (PR-3).
- Per-variant \`Sdk_error\` split into typed sub-records — needs prod
  trace inventory; tracked as follow-up RFC.

## Sequence position

\`\`\`
RFC-0042 PR-1 (#14182, MERGED)  : introduce inert Keeper_turn_terminal_code module
RFC-0042 PR-2 (#14211, MERGED)  : delegate stale_terminal_reason_code through typed bridge
RFC-0042 PR-2.5 (this PR)       : typed SDK-error bridge
RFC-0042 PR-3   (next)          : Keeper_turn_terminal.t.code: string -> t (field swap)
RFC-0042 PR-4   (later)         : reader-side String.starts_with -> exhaustive match
\`\`\`