### PR TITLE
feat(keeper): mark_sdk_turn_started boundary helper (RFC-0045)

### DIFF
--- a/lib/keeper/keeper_registry.ml
+++ b/lib/keeper/keeper_registry.ml
@@ -679,6 +679,37 @@ let mark_turn_started ~base_path name =
     });
   if !changed then broadcast_composite_changed ~name ~ts_unix:now
 
+(* RFC-0045: SDK-turn boundary reset.  Resets in-turn FSM fields without
+   touching keeper-turn-scoped data ([turn_id], [started_at],
+   [selected_model], [measurement], [measurement_bind_count]).  Bypasses
+   validators the same way [mark_turn_started] does — by installing a new
+   observation directly.
+
+   No-op when the observation is already in the post-reset shape (first
+   SDK turn after [mark_turn_started]) so the dashboard composite
+   broadcast doesn't fire spuriously every SDK turn. *)
+let mark_sdk_turn_started ~base_path name =
+  let changed = ref false in
+  let now = Time_compat.now () in
+  update_entry ~base_path name (fun e ->
+    match e.current_turn_observation with
+    | None -> e
+    | Some obs ->
+      if obs.turn_phase = Turn_prompting
+         && obs.cascade_state = Cascade_idle
+         && obs.decision_stage = Decision_undecided
+      then e
+      else (
+        changed := true;
+        let new_obs = {
+          obs with
+          turn_phase = Turn_prompting;
+          cascade_state = Cascade_idle;
+          decision_stage = Decision_undecided;
+        } in
+        { e with current_turn_observation = Some new_obs }));
+  if !changed then broadcast_composite_changed ~name ~ts_unix:now
+
 let mark_turn_measurement ~base_path name =
   let changed = ref false in
   let now = Time_compat.now () in

--- a/lib/keeper/keeper_registry.mli
+++ b/lib/keeper/keeper_registry.mli
@@ -317,6 +317,30 @@ val set_last_correlation_id : base_path:string -> string -> string -> unit
     Must be paired with [mark_turn_finished] (or [mark_turn_failed]). *)
 val mark_turn_started : base_path:string -> string -> unit
 
+(** Mark the beginning of an SDK turn within an existing keeper turn.
+
+    The Agent SDK [run_loop] iterates N SDK turns inside a single MASC
+    keeper-turn window. Each SDK turn fires [before_turn_params] which
+    leads to [prepare_agent_setup] writing
+    [Cascade_selecting]/[Decision_tool_policy_selected]/[Turn_prompting].
+    Without this boundary signal, the second-and-later SDK turn writes
+    transition from the previous SDK turn's terminal phase
+    ([Turn_finalizing] after [Cascade_done]/[Cascade_exhausted]), which
+    [validate_turn_phase_transition] rejects with [Assert_failure].
+
+    This function resets the in-turn FSM fields ([turn_phase],
+    [cascade_state], [decision_stage]) on the existing observation, the
+    same way [mark_turn_started] bypasses the validator with a fresh
+    install. [turn_id], [started_at], [selected_model], [measurement],
+    and [measurement_bind_count] are preserved across SDK turns inside
+    one keeper turn (they are keeper-turn-scoped, not SDK-turn-scoped).
+
+    No-op when [current_turn_observation = None] (defensive: should not
+    happen in normal flow because [mark_turn_started] runs first).
+
+    See RFC-0045 (SDK turn boundary alignment with MASC keeper FSM). *)
+val mark_sdk_turn_started : base_path:string -> string -> unit
+
 (** Attach the most recent [Context_measured] snapshot to the live turn.
     No-op if no turn is active or no pending measurement exists. *)
 val mark_turn_measurement : base_path:string -> string -> unit

--- a/lib/keeper/keeper_run_tools.ml
+++ b/lib/keeper/keeper_run_tools.ml
@@ -1104,6 +1104,17 @@ let prepare_agent_setup
                  { turn; current_params; messages; last_tool_results; _ } ->
                let hook_t0 = Time_compat.now () in
                acc.current_turn <- turn;
+               (* RFC-0045: signal an SDK-turn boundary so the in-turn FSM
+                  fields ([turn_phase], [cascade_state], [decision_stage])
+                  are reset before the hook writes [Cascade_selecting] /
+                  [Decision_tool_policy_selected] / [Turn_prompting] below.
+                  The MASC keeper-turn boundary ([mark_turn_started]) only
+                  fires once per [Agent_sdk.run_loop] call; every additional
+                  SDK turn inside that loop must use this entry point or
+                  [validate_turn_phase_transition] rejects the transition
+                  from the previous SDK turn's [Turn_finalizing] terminal. *)
+               Keeper_registry.mark_sdk_turn_started
+                 ~base_path:config.base_path meta.name;
                let intent =
                  if Keeper_config.keeper_adaptive_thinking_mode () then
                    let last_tool_calls =

--- a/test/test_keeper_registry.ml
+++ b/test/test_keeper_registry.ml
@@ -1351,6 +1351,90 @@ let test_effective_keepalive_meta_prefers_registry_when_disk_unchanged () =
   check int "turn count comes from registry" 9
     chosen.runtime.usage.total_turns
 
+(* ── RFC-0045: SDK turn boundary alignment ─────────────────── *)
+
+let drive_turn_to_finalizing keeper_name =
+  R.mark_turn_started ~base_path:bp keeper_name;
+  R.set_turn_decision_stage
+    ~base_path:bp keeper_name R.Decision_tool_policy_selected;
+  R.set_turn_cascade_state ~base_path:bp keeper_name R.Cascade_selecting;
+  R.set_turn_cascade_state ~base_path:bp keeper_name R.Cascade_trying;
+  R.set_turn_cascade_state ~base_path:bp keeper_name R.Cascade_done
+
+let test_mark_sdk_turn_started_resets_after_finalizing () =
+  R.clear ();
+  let keeper_name = "k-rfc-0045-reset" in
+  ignore (R.register ~base_path:bp keeper_name (make_meta keeper_name));
+  drive_turn_to_finalizing keeper_name;
+  R.mark_sdk_turn_started ~base_path:bp keeper_name;
+  match R.get ~base_path:bp keeper_name with
+  | None -> fail "entry missing after mark_sdk_turn_started"
+  | Some entry ->
+    (match entry.R.current_turn_observation with
+     | None -> fail "observation cleared by mark_sdk_turn_started"
+     | Some obs ->
+       check bool "turn_phase reset to Turn_prompting" true
+         (obs.R.turn_phase = R.Turn_prompting);
+       check bool "cascade_state reset to Cascade_idle" true
+         (obs.R.cascade_state = R.Cascade_idle);
+       check bool "decision_stage reset to Decision_undecided" true
+         (obs.R.decision_stage = R.Decision_undecided))
+
+let test_mark_sdk_turn_started_preserves_keeper_scope () =
+  R.clear ();
+  let keeper_name = "k-rfc-0045-preserve" in
+  ignore (R.register ~base_path:bp keeper_name (make_meta keeper_name));
+  drive_turn_to_finalizing keeper_name;
+  let started_at_before, turn_id_before =
+    match R.get ~base_path:bp keeper_name with
+    | Some { current_turn_observation = Some obs; _ } ->
+      (obs.R.started_at, obs.R.turn_id)
+    | _ -> fail "obs missing before SDK boundary"
+  in
+  R.mark_sdk_turn_started ~base_path:bp keeper_name;
+  match R.get ~base_path:bp keeper_name with
+  | Some { current_turn_observation = Some obs; _ } ->
+    check int "turn_id preserved across SDK boundary"
+      turn_id_before obs.R.turn_id;
+    check (float 1e-6) "started_at preserved" started_at_before obs.R.started_at
+  | _ -> fail "obs missing after SDK boundary"
+
+let test_mark_sdk_turn_started_no_op_without_obs () =
+  R.clear ();
+  let keeper_name = "k-rfc-0045-no-obs" in
+  ignore (R.register ~base_path:bp keeper_name (make_meta keeper_name));
+  (* No mark_turn_started has been called yet. *)
+  R.mark_sdk_turn_started ~base_path:bp keeper_name;
+  match R.get ~base_path:bp keeper_name with
+  | Some { current_turn_observation = None; _ } -> ()
+  | Some { current_turn_observation = Some _; _ } ->
+    fail "mark_sdk_turn_started installed observation without keeper-turn"
+  | None -> fail "entry missing"
+
+(* The production [Assert_failure] at keeper_registry.ml:775 was triggered
+   when the SDK fired [before_turn_params] for a second time inside one
+   keeper-turn.  This test reproduces the same shape: two
+   [set_turn_cascade_state(Cascade_selecting)] calls separated by a
+   [Cascade_done] terminal, with [mark_sdk_turn_started] used as the
+   boundary.  Without the RFC-0045 boundary call this test would crash
+   on the second [set_turn_cascade_state]. *)
+let test_two_sdk_turn_boundaries_no_assert () =
+  R.clear ();
+  let keeper_name = "k-rfc-0045-two-boundaries" in
+  ignore (R.register ~base_path:bp keeper_name (make_meta keeper_name));
+  drive_turn_to_finalizing keeper_name;
+  (* Second SDK turn arrives via before_turn_params hook. *)
+  R.mark_sdk_turn_started ~base_path:bp keeper_name;
+  R.set_turn_decision_stage
+    ~base_path:bp keeper_name R.Decision_tool_policy_selected;
+  R.set_turn_cascade_state ~base_path:bp keeper_name R.Cascade_selecting;
+  match R.get ~base_path:bp keeper_name with
+  | Some { current_turn_observation = Some obs; _ } ->
+    check bool "second SDK turn lands in Cascade_selecting / Turn_prompting" true
+      (obs.R.cascade_state = R.Cascade_selecting
+       && obs.R.turn_phase = R.Turn_prompting)
+  | _ -> fail "obs missing after second SDK boundary"
+
 let test_effective_keepalive_meta_prefers_disk_when_present () =
   R.clear ();
   let stale = make_meta "loop-meta-disk" in
@@ -1506,5 +1590,16 @@ let () =
             test_effective_keepalive_meta_prefers_registry_when_disk_unchanged;
           eio_test "effective keepalive meta prefers disk when present"
             test_effective_keepalive_meta_prefers_disk_when_present;
+        ] );
+      ( "rfc_0045_sdk_turn_boundary",
+        [
+          eio_test "mark_sdk_turn_started resets in-turn FSM after Turn_finalizing"
+            test_mark_sdk_turn_started_resets_after_finalizing;
+          eio_test "mark_sdk_turn_started preserves keeper-turn-scoped data"
+            test_mark_sdk_turn_started_preserves_keeper_scope;
+          eio_test "mark_sdk_turn_started no-op without observation"
+            test_mark_sdk_turn_started_no_op_without_obs;
+          eio_test "two SDK-turn boundaries inside one keeper-turn"
+            test_two_sdk_turn_boundaries_no_assert;
         ] );
     ]


### PR DESCRIPTION
## Summary

Implements **RFC-0045 Option A** (PR #14217, merged). Closes the production `Assert_failure` at `keeper_registry.ml:775` reported on 2026-05-08 20:58 KST.

## What changed

| File | Change | LoC |
|---|---|---|
| `lib/keeper/keeper_registry.mli` | New `val mark_sdk_turn_started` with full RFC-cited docstring | +24 |
| `lib/keeper/keeper_registry.ml` | New `mark_sdk_turn_started` definition (validator-bypassed reset of in-turn FSM fields, no-op when already in post-reset shape) | +31 |
| `lib/keeper/keeper_run_tools.ml` | Calls `mark_sdk_turn_started` at the head of the `before_turn_params` hook closure | +11 |
| `test/test_keeper_registry.ml` | 4 regression tests for SDK-turn boundary semantics | +95 |
| **Total** | | **+161** |

## How it fixes the assert

Previously: SDK `run_loop` iterates N SDK turns inside one MASC keeper-turn. After the first SDK turn ends in `Cascade_done`/`Cascade_exhausted` (→ `Turn_finalizing`), the second SDK turn's `before_turn_params` hook → `prepare_agent_setup` → `set_turn_cascade_state(Cascade_selecting)` → `Turn_prompting` was rejected by `validate_turn_phase_transition` because `(Turn_finalizing, Turn_prompting)` is `false` per the spec table ("new turn is reset, not transition").

Now: the same hook calls `mark_sdk_turn_started` first, which **bypasses the validator** (same way `mark_turn_started` already does for the keeper-turn boundary) and resets `turn_phase`/`cascade_state`/`decision_stage` to their fresh-turn shape. The subsequent `set_turn_cascade_state(Cascade_selecting)` call now transitions from `(Cascade_idle, Cascade_selecting)` and `(Turn_prompting, Turn_prompting)` — both already valid in the spec table.

## Design decisions vs RFC-0045 §9 open questions

- **Q1: should `mark_sdk_turn_started` reset `selected_model` / `measurement`?** No. They are keeper-turn-scoped (the dashboard composite observer reads them across SDK turns). Only `turn_phase`, `cascade_state`, `decision_stage` reset — exactly the fields that drive the FSM transition asserts.
- **Q2: should there be a `keeper_sdk_turn_count` Prometheus gauge?** Deferred per RFC §9. Can be added in a separate observability PR after a week of production data.
- **Q3: do other writers (`set_turn_decision_stage`, `set_turn_phase`, `set_turn_selected_model`) need the same boundary treatment?** No — only `set_turn_cascade_state` was the trigger because it's the writer that fires earliest in `prepare_agent_setup`. The other writers fire later (or in different paths) and operate on already-reset state.

The `mark_sdk_turn_started` is **idempotent** (no-op when the observation is already in the post-reset shape) so the dashboard composite broadcast doesn't fire spuriously on the very first SDK turn (which `mark_turn_started` already left in the post-reset shape).

## Why this avoids the stop-gap (RFC §6 / Option B)

The RFC documented a 1-line spec table widening as a stop-gap (`(Turn_finalizing, Turn_prompting) -> true`). This PR makes that stop-gap unnecessary because the SDK-turn boundary is now validator-bypassed at the `mark_sdk_turn_started` API, exactly mirroring how `mark_turn_started` has always been validator-bypassed for the keeper-turn boundary. The spec invariant "new turn is reset, not transition" is preserved.

If a stop-gap PR with `WORKAROUND:` label was already landed in production, it should be reverted now that this PR is in.

## Verification

- `dune build --root . @check` — clean
- `dune exec test/test_keeper_registry.exe -- test rfc_0045_sdk_turn_boundary`:
  - `mark_sdk_turn_started resets in-turn FSM after Turn_finalizing` — PASS
  - `mark_sdk_turn_started preserves keeper-turn-scoped data` — PASS
  - `mark_sdk_turn_started no-op without observation` — PASS
  - `two SDK-turn boundaries inside one keeper-turn` — PASS (regression for the exact production assert)
- `.mli` interface gained one new function with full docstring; existing API unchanged.

## Refs

- **RFC-0045** (PR #14217, merged) — design doc this implements
- PR #14194 — FSM unify validation (the invariant this builds on)
- PR #14207 — prior 1-line spec table widening (the pattern this avoids)
- `instructions/software-development.md` §"AI 코드 생성 안티패턴 #4 — FSM Sparse Match"

🤖 Generated with [Claude Code](https://claude.com/claude-code)
