### PR TITLE
fix(keeper): allow Turn_finalizing -> Turn_prompting transition

### DIFF
--- a/lib/keeper/keeper_registry.ml
+++ b/lib/keeper/keeper_registry.ml
@@ -800,7 +800,7 @@ let validate_turn_phase_transition ~from ~to_ =
          | (Turn_compacting, Turn_finalizing) -> true  (* via set_turn_phase: compaction failure *)
          (* from Turn_finalizing *)
          | (Turn_finalizing, Turn_idle) -> false  (* new turn is reset *)
-         | (Turn_finalizing, Turn_prompting) -> false  (* new turn is reset *)
+         | (Turn_finalizing, Turn_prompting) -> true  (* via set_turn_cascade_state: degraded retry re-entering selecting *)
          | (Turn_finalizing, Turn_executing) -> false
          | (Turn_finalizing, Turn_compacting) -> false
          | (Turn_finalizing, Turn_finalizing) -> true


### PR DESCRIPTION
## Summary

Fixes `Assertion_failed` at `keeper_registry.ml:775` when a degraded retry re-enters `Cascade_selecting` after the prior cascade had already reached `Turn_finalizing`.

## Root Cause

`validate_turn_phase_transition` rejected `(Turn_finalizing, Turn_prompting)` as `false`, assuming a new turn would always reset from idle. However, the degraded retry path (`local_recovery` cascade) calls `set_turn_cascade_state Cascade_selecting`, and `turn_phase_of_cascade_state` maps `Cascade_selecting` to `Turn_prompting`. When the previous cascade completed (`Cascade_done` -> `Turn_finalizing`) but the keeper timed out before cleanup, the retry attempts this transition and hits the assertion.

## Fix

- `(Turn_finalizing, Turn_prompting)` -> `true`
- Added comment: `via set_turn_cascade_state: degraded retry re-entering selecting`

## Verification

- `dune build` passes in worktree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)