### PR TITLE
docs(rfc): RFC-0046 — keeper detail FSM hub as SSOT

### DIFF
--- a/docs/rfc/RFC-0046-keeper-detail-fsm-hub-ssot.md
+++ b/docs/rfc/RFC-0046-keeper-detail-fsm-hub-ssot.md
@@ -1,0 +1,202 @@
+# RFC-0046 — Keeper Detail FSM Hub as SSOT
+
+Status: Draft
+Author: jeong-sik (with Claude Opus 4.7)
+Date: 2026-05-08
+Supersedes: —
+Related: PR #14219, #14220 (dashboard cleanup precursors), KeeperCompositeLifecycle.tla
+
+## 1. Problem
+
+Keeper detail surface renders the same FSM state through **four parallel
+paths**, none of them the canonical composite hub that already exists.
+
+### 1.1 Concrete duplication map
+
+| Surface | Source field(s) | Reads from |
+|---|---|---|
+| `keeper-detail-shell.ts:193` `KeeperPhaseAndStage` | `keeper.phase`, `keeper.pipeline_stage` | flat keeper signal |
+| `keeper-detail.ts:1016` `PipelineStageBar` | `keeper.pipeline_stage` | flat keeper signal |
+| `keeper-detail.ts:1018` `KeeperStateDiagramPanel` | `keeper.phase` | flat keeper signal |
+| `keeper-detail.ts:1022` `KeeperMemoryTierPanel` | `keeper.phase` | flat keeper signal |
+| `agents-unified.ts:156` `FsmHub` (NOT in detail) | `KeeperCompositeSnapshot` (6 axes) | composite endpoint |
+
+The first four reach into the **flat keeper record** and pull two scalar
+fields (`phase`, `pipeline_stage`). The fifth — already deployed at
+`fsm-hub.ts` (1010 LoC) and `fsm-hub-types.ts` (`KeeperCompositeSnapshot`)
+— consumes the same five sub-FSM projections that
+`KeeperCompositeLifecycle.tla` declares as the joint observer:
+
+| TLA projection | Snapshot field | Currently surfaced where |
+|---|---|---|
+| `ksm_phase` (KSM) | `snapshot.phase` | flat → 4 panels (above), composite → FsmHub |
+| `ktc_turn_phase` (KTC) | `snapshot.turn_phase` | composite → FsmHub only |
+| `kdp_decision` (KDP) | `snapshot.decision.stage` | composite → FsmHub only |
+| `kcl_cascade_state` (KCL) | `snapshot.cascade.state` | composite → FsmHub only |
+| `kmc_compaction` (KMC) | `snapshot.compaction.stage` | composite → FsmHub only |
+| `circuit_breaker.state` | `snapshot.circuit_breaker.state` | composite → FsmHub only |
+
+Result: an operator opening keeper detail sees **`phase` four times** but
+**zero** of `turn_phase / decision / cascade / compaction / breaker`. To
+get the full FSM picture they must back out to fleet view, find the
+keeper, and use the FsmHub drill-down. Per-keeper analysis is the *exact*
+flow that needs the composite, and it is the flow without it.
+
+### 1.2 User-reported symptoms (PR #14219 / #14220 review)
+
+> "TLA FSM 제대로 된 상태만 보여주면 되는 건데… SSOT 가 아니라 막
+> 널부러져있음."
+
+> "지금 위험한가? 음 ㅋㅋ 뭐 이런 번역이 있음? 스스로 돌고 있나? …"
+
+The anthropomorphic Korean question subtitles (already removed in #14219)
+were a symptom: with the composite snapshot **not surfaced**, panels
+attempted to compensate by adding interpretive copy on top of partial
+state. Removing the copy without fixing the underlying surface leaves
+operators with even less signal than before.
+
+## 2. Goals
+
+1. Make the **FsmHub composite snapshot** the single SSOT for keeper FSM
+   state on the detail surface.
+2. Delete or downgrade the four parallel phase-only panels that
+   duplicate one axis of the snapshot.
+3. Preserve the diagrams (`KeeperStateDiagramPanel` for `phase`
+   transition history, `KeeperMemoryTierPanel` for memory-tier visual)
+   as **derived views fed from the snapshot**, not independent fetchers.
+4. Zero new backend fields. Zero new RPCs. The composite endpoint
+   already exists (`KeeperCompositeSnapshot`).
+
+## 3. Non-goals
+
+- No change to `KeeperCompositeLifecycle.tla` or any sub-FSM spec.
+- No change to backend OCaml — this is dashboard-only re-wiring.
+- No change to fleet-level FsmHub (`agents-unified.ts:156`).
+- No new info architecture sections. Existing 6 sections
+  (요약 / 대화 / 진단 / 정체성 / 설정 / 디버그) stay; 요약 section
+  internals are reorganized.
+
+## 4. Design
+
+### 4.1 Surface change in 운영 상태 개요 section
+
+Before (`keeper-detail.ts:1011-1093`):
+
+```
+KeeperRuntimeAlertStrip
+KeeperDetailSection eyebrow="상태 개요" title="운영 상태 개요"
+  PipelineStageBar          ← duplicates phase
+  CollapsibleSection "Phase State Machine"
+    KeeperStateDiagramPanel  ← reads keeper.phase directly
+  CollapsibleSection "메모리 티어"
+    KeeperMemoryTierPanel    ← reads keeper.phase directly
+  KpiGrid                    ← stays (4 KPI sections, post-#14219)
+  CtxCompositionPanel
+  PromptTelemetryPanel
+  InferenceTelemetryPanel
+```
+
+After:
+
+```
+KeeperRuntimeAlertStrip
+KeeperDetailSection eyebrow="상태 개요" title="운영 상태 개요"
+  FsmHub keeperName=${keeper.name} mode="detail"   ← NEW: single hub
+                                                    showing 6 axes
+  KpiGrid                                           ← unchanged
+  CtxCompositionPanel
+  PromptTelemetryPanel
+  InferenceTelemetryPanel
+```
+
+`KeeperPhaseAndStage` in the page header (`keeper-detail-shell.ts:193`)
+stays — it is the breadcrumb-level summary. The redundant
+`PipelineStageBar` inside the section body goes.
+
+`KeeperStateDiagramPanel` and `KeeperMemoryTierPanel` are **moved**
+under FsmHub as expandable derived views (existing `<details>` /
+collapsible pattern). Their inputs change from `currentPhase=
+${keeper.phase}` to `snapshot=${fsmHub.snapshot}` so they read the same
+SSOT FsmHub already consumes.
+
+### 4.2 FsmHub `mode` prop
+
+FsmHub is currently fleet-targeted. Add a `mode: 'fleet' | 'detail'`
+prop (default `'fleet'` for back-compat). In `'detail'` mode:
+
+- Skip the "select a keeper" affordance (the parent already pinned one).
+- Render a more compact lane stack (vertical, 6 lanes, suited for the
+  detail page width).
+- Surface invariant violations inline with the keeper's
+  `KeeperRuntimeAlertStrip` (avoid double-warning).
+
+This is additive. No fleet-side regression.
+
+### 4.3 Removed surfaces
+
+| File | Action | Reason |
+|---|---|---|
+| `keeper-pipeline-stage.ts` (`PipelineStageBar`) | **Delete** if no other caller; otherwise leave for fleet | Single-axis duplicate of FsmHub `phase` lane |
+| `keeper-state-diagram.ts` (`KeeperStateDiagramPanel`) | **Refactor** to take `snapshot` prop | Diagram still useful, source must be SSOT |
+| `keeper-memory-tier-panel.ts` (`KeeperMemoryTierPanel`) | **Refactor** to take `snapshot` prop | Same |
+
+Net LoC: estimated **−250 to −400** (PipelineStageBar deletion + prop
+plumbing simplification). FsmHub adds ≤30 LoC for `mode='detail'`.
+
+## 5. Migration plan
+
+Single PR is acceptable; the dashboard already passes typecheck (baseline
+fsm-hub-types-2026-05-05 errors aside). Splitting is fine if reviewer
+prefers smaller diffs.
+
+| Step | Files | Verification |
+|---|---|---|
+| 1 | `fsm-hub.ts` — add `mode` prop | unit test: `mode='detail'` skips selector |
+| 2 | `keeper-state-diagram.ts`, `keeper-memory-tier-panel.ts` — accept `snapshot` prop, fall back to `currentPhase` for one cycle | existing tests stay green |
+| 3 | `keeper-detail.ts` — replace `PipelineStageBar` + raw panel mounts with `<FsmHub mode="detail" />` and snapshot-fed children | `keeper-detail.test.ts` updated |
+| 4 | Delete `keeper-pipeline-stage.ts` if grep shows no other caller | typecheck |
+| 5 | Remove fallback prop on the two refactored panels | typecheck |
+
+## 6. Risks
+
+| Risk | Mitigation |
+|---|---|
+| FsmHub backend snapshot endpoint slower than flat keeper field | Already in production for fleet view; per-keeper detail load includes snapshot fetch in same WS frame today (see `dashboard-ws.ts`) |
+| Diagram component coupling to flat field | Compatibility prop kept for one cycle (Step 2), removed in Step 5 |
+| FsmHub detail mode feels too dense in narrow viewports | Vertical lane stack + compact KPI tiles already in design system; verify <520px breakpoint |
+| Test churn | Snapshot-prop refactor is mechanical; tests already use `KeeperCompositeSnapshot` fixtures elsewhere |
+
+## 7. Out of scope (future RFCs)
+
+- Composite-snapshot-driven *event timeline* (`KeeperCompositeLifecycle`
+  ActionSet → human-readable transitions). Currently rendered ad-hoc
+  inside fsm-hub; deserves its own RFC.
+- Backend deduplication of `keeper.phase` vs `snapshot.phase` (two
+  paths to the same value via different stores). Dashboard-only fix
+  here; backend SSOT enforcement is RFC-0044-adjacent work.
+
+## 8. Acceptance criteria
+
+- [ ] Operator opening `monitoring?section=agents&view=keepers&keeper=X`
+      sees all six FSM lanes (phase, turn_phase, decision, cascade,
+      compaction, circuit_breaker) at the top of 운영 상태 개요.
+- [ ] No component on the detail surface reads `keeper.phase` /
+      `keeper.pipeline_stage` directly *except* the page-header
+      breadcrumb (`KeeperPhaseAndStage`).
+- [ ] `pnpm typecheck` introduces zero new errors over baseline.
+- [ ] `pnpm test` passes; new test asserts that opening detail surface
+      renders exactly one composite snapshot consumer in the page body.
+
+## 9. Evidence Record
+
+- Evidence: `specs/keeper-state-machine/KeeperCompositeLifecycle.tla`
+  L60-L130 (5 sub-FSM state sets); `dashboard/src/components/fsm-hub-types.ts`
+  L1-L40 (`CompositeObservation` + 6th breaker axis);
+  `dashboard/src/components/keeper-detail.ts` L1011-L1093 (current
+  duplication site).
+- Timestamp: 2026-05-08T21:30+09:00
+- Confidence: High — TLA spec and FsmHub component both exist in main
+  at HEAD `4542ace9ec`.
+- Delta: User-reported "SSOT가 아니라 막 널부러져있음" maps to
+  exactly one structural defect (composite hub not mounted in detail
+  surface). Fix is re-wiring, not redesign.


### PR DESCRIPTION
## 요약

PR #14219 / #14220 후속 Phase 3. 사용자 보고 — *"TLA FSM 제대로 된 상태만 보여주면 되는 건데… SSOT 가 아니라 막 널부러져있음"* — 의 구조적 진단 + 마이그레이션 RFC.

## 진단

**근본 원인은 추가 인프라 부재가 아니라 기존 인프라 미마운트.**

`KeeperCompositeLifecycle.tla` (449 LoC observer)는 5 sub-FSM (KSM/KTC/KDP/KMC/KCL) 합동 invariant를 이미 검증하고, `fsm-hub.ts` (1010 LoC) + `fsm-hub-types.ts`는 그 6 axis (phase/turn_phase/decision/cascade/compaction/circuit_breaker)를 단일 `KeeperCompositeSnapshot`으로 노출. **하지만 keeper detail 페이지는 이 hub를 마운트하지 않음** — 대신:

| Surface | 표시하는 axis | 데이터 소스 |
|---|---|---|
| `KeeperPhaseAndStage` (header) | phase | flat keeper signal |
| `PipelineStageBar` | pipeline_stage | flat keeper signal |
| `KeeperStateDiagramPanel` | phase | flat keeper signal |
| `KeeperMemoryTierPanel` | phase | flat keeper signal |
| `FsmHub` (fleet view only) | 6 axis composite | snapshot endpoint |

→ 운영자는 `phase`를 4번 보지만 `turn_phase / decision / cascade / compaction / breaker`는 0번. 정작 per-keeper drill-down에 composite가 빠져 있음.

## 제안

`<FsmHub mode="detail" keeperName=${keeper.name} />`을 운영 상태 개요 섹션 머리에 마운트. `PipelineStageBar` 삭제. `KeeperStateDiagramPanel` / `KeeperMemoryTierPanel`은 `currentPhase` prop 대신 `snapshot` prop을 받도록 refactor (FsmHub와 같은 SSOT 소비).

**Net**: 백엔드 0 변경, RPC 0 추가, LoC 추정 −250 ~ −400.

## 5단계 마이그레이션 (단일 또는 분할 PR)

1. FsmHub `mode` prop 추가 (`'fleet' | 'detail'`)
2. State diagram + memory tier 패널을 snapshot prop 수용 (compat fallback 1 cycle)
3. keeper-detail.ts 운영 상태 개요 head 교체
4. PipelineStageBar 제거 (다른 caller 없으면)
5. compat fallback 제거

## 위험 + 완화

| 위험 | 완화 |
|---|---|
| FsmHub snapshot fetch 지연 | 이미 fleet view에서 production 동작; per-keeper detail load는 동일 WS frame |
| 패널 refactor 충돌 | compat prop 1 cycle 유지 |
| narrow viewport 밀도 | vertical lane + compact KPI 기존 디자인 시스템 재사용 |

## RFC 발견 체크
- 변경 영역: `dashboard/src/components/` only — RFC required subsystem (credential / operator / hooks / workflow*) 미수정
- Self-citing RFC라 RFC-WAIVED 불필요

## ⚠️ Draft 유지 요청
docs-only이지만 구현 PR은 별도. 이 RFC가 주제별 합의 후 `human-approved-ready` 라벨 → 구현 작업 시작.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>