### PR TITLE
feat(core): RFC-0044 PR-1 — introduce Read_drop_reason closed sum (inert)

### DIFF
--- a/lib/core/dune
+++ b/lib/core/dune
@@ -3,5 +3,5 @@
  (name masc_core)
  (public_name masc_mcp.masc_core)
  (wrapped false)
- (modules json_util safe_ops common validation circuit_breaker eio_guard executor_pool_ref masc_runtime_events provider_error text_similarity string_util list_util)
+ (modules json_util safe_ops common validation circuit_breaker eio_guard executor_pool_ref masc_runtime_events provider_error text_similarity string_util list_util read_drop_reason)
  (libraries yojson unix re re.pcre eio eio.unix time_compat fs_compat masc_log runtime_events))

--- a/lib/core/read_drop_reason.ml
+++ b/lib/core/read_drop_reason.ml
@@ -1,0 +1,70 @@
+(* RFC-0044 PR-1: closed sum type for persistence read-drop reason.
+
+   See [.mli] for the public contract. This file holds the type
+   definition and the wire-format serialisation chosen to be
+   byte-for-byte compatible with the legacy [string] constants in
+   [Core.Safe_ops] as of main. *)
+
+type t =
+  | List_dir_error
+  | Entry_load_error
+  | Invalid_payload
+  | Json_syntax_error
+  | Lock_contention
+  | Schema_version_mismatch
+  | Decompression_error
+  | Path_normalization_error
+  | Stat_error
+  | Other of string
+
+let to_wire = function
+  | List_dir_error -> "list_dir_error"
+  | Entry_load_error -> "entry_load_error"
+  | Invalid_payload -> "invalid_payload"
+  | Json_syntax_error -> "json_syntax_error"
+  | Lock_contention -> "lock_contention"
+  | Schema_version_mismatch -> "schema_version_mismatch"
+  | Decompression_error -> "decompression_error"
+  | Path_normalization_error -> "path_normalization_error"
+  | Stat_error -> "stat_error"
+  | Other s -> s
+;;
+
+let of_wire = function
+  | "list_dir_error" -> List_dir_error
+  | "entry_load_error" -> Entry_load_error
+  | "invalid_payload" -> Invalid_payload
+  | "json_syntax_error" -> Json_syntax_error
+  | "lock_contention" -> Lock_contention
+  | "schema_version_mismatch" -> Schema_version_mismatch
+  | "decompression_error" -> Decompression_error
+  | "path_normalization_error" -> Path_normalization_error
+  | "stat_error" -> Stat_error
+  | s -> Other s
+;;
+
+let equal a b =
+  match a, b with
+  | List_dir_error, List_dir_error
+  | Entry_load_error, Entry_load_error
+  | Invalid_payload, Invalid_payload
+  | Json_syntax_error, Json_syntax_error
+  | Lock_contention, Lock_contention
+  | Schema_version_mismatch, Schema_version_mismatch
+  | Decompression_error, Decompression_error
+  | Path_normalization_error, Path_normalization_error
+  | Stat_error, Stat_error -> true
+  | Other a, Other b -> String.equal a b
+  | List_dir_error, _
+  | Entry_load_error, _
+  | Invalid_payload, _
+  | Json_syntax_error, _
+  | Lock_contention, _
+  | Schema_version_mismatch, _
+  | Decompression_error, _
+  | Path_normalization_error, _
+  | Stat_error, _
+  | Other _, _ -> false
+;;
+
+let pp fmt t = Format.pp_print_string fmt (to_wire t)

--- a/lib/core/read_drop_reason.mli
+++ b/lib/core/read_drop_reason.mli
@@ -1,0 +1,71 @@
+(** Closed sum type for the [reason] label of
+    [Prometheus.metric_persistence_read_drops]. See RFC-0044
+    (`docs/rfc/RFC-0044-persistence-read-drop-typed.md`) for the full
+    motivation.
+
+    This module is introduced in PR-1 of the RFC-0044 migration and is
+    intentionally inert: no caller in the tree references it yet.
+    PR-2 changes [Core.Safe_ops.report_persistence_read_drop] to
+    accept [t] instead of [string]; existing constants in
+    [safe_ops.ml] become wire-compatible aliases. PR-3 (optional)
+    introduces a [read_outcome] Result-style helper for opt-in
+    caller migration.
+
+    Adding a new variant here is, by construction, a compile
+    obligation for every callsite once PR-2 lands.
+
+    @stability Evolving
+    @since 0.193.2 *)
+
+type t =
+  | List_dir_error (** Directory enumeration failed (permission / I/O / missing). *)
+  | Entry_load_error (** A specific file under a directory failed to load. *)
+  | Invalid_payload (** Payload was loaded but failed schema / shape validation. *)
+  | Json_syntax_error (** Payload was loaded but JSON parsing raised. *)
+  | Lock_contention
+  (** Read aborted because a writer held the lock past the
+          configured deadline. *)
+  | Schema_version_mismatch
+  (** Payload version is not understood by the current reader. *)
+  | Decompression_error (** Compressed payload (gzip/zstd) failed to decompress. *)
+  | Path_normalization_error
+  (** Path containment / canonicalisation rejected the entry. *)
+  | Stat_error (** [stat] / [lstat] failed before file open. *)
+  | Other of string
+  (** Escape hatch for one-off surfaces. PR introducing a new
+          [Other] payload must justify why the value cannot be
+          promoted to a constructor. The lint
+          [scripts/lint/no-free-string-read-drop-reason.sh] (PR-2)
+          flags PRs that add [Other] for a value already used at
+          another site. *)
+
+(** Stable wire format. The strings produced here are byte-for-byte
+    compatible with the existing string constants in
+    [Core.Safe_ops] ([persistence_read_drop_reason_list_dir_error],
+    [_entry_load_error], [_invalid_payload]) so swapping callers in
+    PR-2 does not change the Prometheus label cardinality.
+
+    Wire mapping:
+    - [List_dir_error] → ["list_dir_error"]
+    - [Entry_load_error] → ["entry_load_error"]
+    - [Invalid_payload] → ["invalid_payload"]
+    - [Json_syntax_error] → ["json_syntax_error"]
+    - [Lock_contention] → ["lock_contention"]
+    - [Schema_version_mismatch] → ["schema_version_mismatch"]
+    - [Decompression_error] → ["decompression_error"]
+    - [Path_normalization_error] → ["path_normalization_error"]
+    - [Stat_error] → ["stat_error"]
+    - [Other s] → [s] (verbatim) *)
+val to_wire : t -> string
+
+(** Best-effort reverse of [to_wire]. Returns [Some] for canonical
+    constructors, [Some (Other s)] for any other input (so callers can
+    round-trip). PR-2 may narrow this once the lint blocks free
+    strings. *)
+val of_wire : string -> t
+
+(** Equality (structural). *)
+val equal : t -> t -> bool
+
+(** Pretty-printer for debug output. Emits [to_wire t]. *)
+val pp : Format.formatter -> t -> unit

--- a/test/dune
+++ b/test/dune
@@ -28,6 +28,7 @@
  (names test_attribution test_attribution_tagged test_autoresearch_result_bridge test_dashboard_attribution test_dashboard_oas_bridge test_masc_runtime_events test_room test_room_state_recovery test_types test_exec_tap test_auth test_auth_doctor test_auth_error_kind test_auth_login test_audit_log test_governance_anomaly test_http_negotiation
         test_keeper_turn_terminal_code_byte_compat
         test_keeper_sdk_error_typed_bridge
+        test_read_drop_reason
         test_attempt_state
         test_sse test_graphql_api
         test_graphql_endpoint
@@ -260,6 +261,7 @@
  (modules test_attribution test_attribution_tagged test_autoresearch_result_bridge test_dashboard_attribution test_dashboard_oas_bridge test_masc_runtime_events test_room test_room_state_recovery test_types test_exec_tap test_auth test_auth_doctor test_auth_error_kind test_auth_login test_audit_log test_governance_anomaly test_http_negotiation
           test_keeper_turn_terminal_code_byte_compat
           test_keeper_sdk_error_typed_bridge
+          test_read_drop_reason
           test_attempt_state
           test_sse test_graphql_api
           test_graphql_endpoint

--- a/test/test_read_drop_reason.ml
+++ b/test/test_read_drop_reason.ml
@@ -1,0 +1,91 @@
+(** RFC-0044 PR-1 invariants for [Read_drop_reason]:
+
+    1. Round-trip: [of_wire (to_wire t) = t] for every canonical
+       constructor; [Other s] survives unchanged.
+    2. Byte-for-byte wire compatibility with the legacy [string]
+       constants in [Core.Safe_ops]
+       ([persistence_read_drop_reason_list_dir_error],
+       [_entry_load_error], [_invalid_payload]).
+
+    PR-2 will swap [report_persistence_read_drop ~reason:string] to
+    accept [t]; this test guards that the wire never drifts during
+    that swap. *)
+
+module R = Read_drop_reason
+module Safe = Safe_ops
+
+let canonical : (string * R.t) list =
+  [ "List_dir_error", R.List_dir_error
+  ; "Entry_load_error", R.Entry_load_error
+  ; "Invalid_payload", R.Invalid_payload
+  ; "Json_syntax_error", R.Json_syntax_error
+  ; "Lock_contention", R.Lock_contention
+  ; "Schema_version_mismatch", R.Schema_version_mismatch
+  ; "Decompression_error", R.Decompression_error
+  ; "Path_normalization_error", R.Path_normalization_error
+  ; "Stat_error", R.Stat_error
+  ]
+;;
+
+let test_canonical_round_trip () =
+  List.iter
+    (fun (label, t) ->
+       let wire = R.to_wire t in
+       let parsed = R.of_wire wire in
+       Alcotest.(check bool) (label ^ " round-trip") true (R.equal t parsed))
+    canonical
+;;
+
+let test_other_round_trip () =
+  let exotic = R.Other "freshly_invented_reason" in
+  let wire = R.to_wire exotic in
+  Alcotest.(check string) "Other wire = payload" "freshly_invented_reason" wire;
+  Alcotest.(check bool) "Other round-trip" true (R.equal exotic (R.of_wire wire))
+;;
+
+let test_unknown_wire_becomes_other () =
+  match R.of_wire "totally_new_label" with
+  | R.Other s -> Alcotest.(check string) "unknown → Other s" "totally_new_label" s
+  | _ -> Alcotest.fail "expected Other for unknown wire"
+;;
+
+let test_legacy_constants_byte_compat () =
+  (* The three pre-RFC string constants in Safe_ops must be the wire
+     forms of the corresponding typed constructors so PR-2 can swap
+     callers without changing Prometheus label cardinality. *)
+  Alcotest.(check string)
+    "list_dir_error matches Safe_ops constant"
+    Safe.persistence_read_drop_reason_list_dir_error
+    (R.to_wire R.List_dir_error);
+  Alcotest.(check string)
+    "entry_load_error matches Safe_ops constant"
+    Safe.persistence_read_drop_reason_entry_load_error
+    (R.to_wire R.Entry_load_error);
+  Alcotest.(check string)
+    "invalid_payload matches Safe_ops constant"
+    Safe.persistence_read_drop_reason_invalid_payload
+    (R.to_wire R.Invalid_payload)
+;;
+
+let () =
+  Alcotest.run
+    "read_drop_reason"
+    [ ( "round-trip"
+      , [ Alcotest.test_case
+            "canonical constructors round-trip"
+            `Quick
+            test_canonical_round_trip
+        ; Alcotest.test_case "Other s round-trips verbatim" `Quick test_other_round_trip
+        ; Alcotest.test_case
+            "unknown wire deserialises to Other"
+            `Quick
+            test_unknown_wire_becomes_other
+        ] )
+    ; ( "byte invariant vs Safe_ops constants"
+      , [ Alcotest.test_case
+            "Safe_ops legacy constants byte-equal to to_wire"
+            `Quick
+            test_legacy_constants_byte_compat
+        ] )
+    ]
+;;


### PR DESCRIPTION
## Goal

First implementation step of RFC-0044 (merged in #14212). Introduce
\`Read_drop_reason.t\` as inert, mirroring RFC-0042 PR-1 (#14182).
PR-2 will swap \`report_persistence_read_drop ~reason:string\` to
accept \`t\`, closing the typed-mechanism door for future
free-string \`~reason:\"...\"\` emit sites at the persistence surface.

## What changed

| File | Δ |
|---|---|
| \`lib/core/read_drop_reason.ml/.mli\` | NEW. 9 canonical variants + \`Other of string\` escape hatch. \`to_wire\` byte-for-byte compatible with the 3 existing \`Safe_ops\` constants. \`of_wire\`, \`equal\`, \`pp\`. |
| \`lib/core/dune\` | Register the new module. |
| \`test/test_read_drop_reason.ml\` | NEW. 4 cases: canonical round-trip, \`Other s\` round-trip, unknown→\`Other\` deserialisation, byte invariant vs 3 legacy constants. |
| \`test/dune\` | Register the new test binary. |

## Verification

\`\`\`
$ bash scripts/dune-local.sh build @check  # OK
$ bash scripts/dune-local.sh exec test/test_read_drop_reason.exe
  [OK]  round-trip                          0  canonical constructors round-trip
  [OK]  round-trip                          1  Other s round-trips verbatim
  [OK]  round-trip                          2  unknown wire deserialises to Other
  [OK]  byte invariant vs Safe_ops          0  Safe_ops legacy constants byte-equal to to_wire
Test Successful in 0.001s. 4 tests run.
\`\`\`

## Why \`Other of string\` exists

RFC-0044 §3.1 documents the trade-off. Strict reading of the
instructions §AI 코드 생성 안티패턴 §1 says \"every new value must be a
constructor\". Reality: the persistence surface owners are scattered
(12 PRs in one day on 2026-05-07 each invented a new surface), and
forcing every new surface PR to land a code change in
\`lib/core/read_drop_reason.ml\` would create high friction.

\`Other s\` exists as a documented escape hatch with two guard rails:
1. Documented in the .mli with a justification clause (\"PR introducing
   a new \`Other\` payload must justify why the value cannot be promoted
   to a constructor\").
2. PR-2 will land \`scripts/lint/no-free-string-read-drop-reason.sh\`
   which fails CI when the same \`Other s\` payload is used at >= 2
   sites — forcing promotion to a constructor.

## Wire stability

- \`masc_persistence_read_drops_total\` label cardinality: unchanged by
  this PR (no callsite touched).
- Once PR-2 swaps producers, label set is bounded by the closed sum.

## Anti-pattern self-check (\`software-development.md §워크어라운드 거부 기준\`)

- [ ] ❌ Telemetry-as-fix — N/A (this is the typed-mechanism step
      RFC-0044 §3 promised; counter not modified)
- [ ] ❌ String/substring classifier — *prevents future cases*
- [ ] ❌ N-of-M patch — N/A (inert module; no callsite touched)
- [ ] ❌ catch-all — \`Other of string\` is **explicitly documented**
      with §5 lint scheduled to block reuse
- [ ] ❌ cap/cooldown/dedup/repair — N/A

## Sequence position

\`\`\`
RFC-0044 docs (#14212, MERGED) : policy framing + closed-sum design
RFC-0044 PR-1 (this PR)         : introduce inert Read_drop_reason module
RFC-0044 PR-2 (next)            : swap report_persistence_read_drop signature; lint drift guard
RFC-0044 PR-3 (optional)        : Result-style read_outcome for opt-in caller migration
\`\`\`