### PR TITLE
feat(dashboard): RFC-0046 Step 3+4 — mount FsmHub in keeper detail, remove PipelineStageBar

### DIFF
--- a/dashboard/src/components/keeper-detail.ts
+++ b/dashboard/src/components/keeper-detail.ts
@@ -68,7 +68,7 @@ import {
   loadKeeperConfig,
   resetKeeperConfig,
 } from './keeper-config-panel'
-import { PipelineStageBar } from './keeper-pipeline-stage'
+import { FsmHub } from './fsm-hub'
 import { KeeperConditionsDivergent } from './keeper-conditions-divergent'
 import { KeeperStateDiagramPanel } from './keeper-state-diagram'
 import { KeeperMemoryTierPanel } from './keeper-memory-tier-panel'
@@ -1013,7 +1013,8 @@ export function KeeperDetailPage() {
             eyebrow="상태 개요"
             title="운영 상태 개요"
           >
-        <${PipelineStageBar} stage=${keeper.pipeline_stage} />
+        ${'' /* RFC-0046: 6-axis composite snapshot (KSM/KTC/KDP/KCL/KMC/breaker) — SSOT for keeper FSM state */}
+        <${FsmHub} mode="detail" selectedName=${keeper.name} />
         <${CollapsibleSection} title="Phase State Machine">
           <${KeeperStateDiagramPanel} keeperName=${keeper.name} currentPhase=${keeper.phase} />
         <//>

--- a/dashboard/src/components/keeper-pipeline-stage.test.ts
+++ b/dashboard/src/components/keeper-pipeline-stage.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment happy-dom
 import { describe, expect, it } from 'vitest'
 import { render, h } from 'preact'
-import { PipelineStageBar, PipelineStageBadge } from './keeper-pipeline-stage'
+import { PipelineStageBadge } from './keeper-pipeline-stage'
 
 describe('PipelineStageBadge', () => {
   it('renders label for known stage', () => {
@@ -25,66 +25,5 @@ describe('PipelineStageBadge', () => {
     const container = document.createElement('div')
     render(h(PipelineStageBadge, { stage: 'unknown_stage' as any }), container)
     expect(container.textContent).toContain('unknown_stage')
-  })
-})
-
-describe('PipelineStageBar', () => {
-  it('renders single offline node for null stage', () => {
-    const container = document.createElement('div')
-    render(h(PipelineStageBar, { stage: null }), container)
-    const nodes = container.querySelectorAll('.pipeline-stage-node')
-    expect(nodes.length).toBe(1)
-    expect(nodes[0]!.classList.contains('active')).toBe(true)
-    expect(container.textContent).toContain('offline')
-  })
-
-  it('renders full bar for idle stage', () => {
-    const container = document.createElement('div')
-    render(h(PipelineStageBar, { stage: 'idle' }), container)
-    const nodes = container.querySelectorAll('.pipeline-stage-node')
-    expect(nodes.length).toBe(6)
-    expect(nodes[0]!.classList.contains('active')).toBe(true)
-    expect(nodes[0]!.classList.contains('stage-idle')).toBe(true)
-    expect(container.textContent).toContain('idle')
-  })
-
-  it('marks passed stages for thinking', () => {
-    const container = document.createElement('div')
-    render(h(PipelineStageBar, { stage: 'thinking' }), container)
-    const nodes = container.querySelectorAll('.pipeline-stage-node')
-    expect(nodes[0]!.classList.contains('passed')).toBe(true)
-    expect(nodes[1]!.classList.contains('active')).toBe(true)
-    expect(nodes[1]!.classList.contains('passed')).toBe(false)
-    expect(nodes[2]!.classList.contains('passed')).toBe(false)
-  })
-
-  it('renders connectors between nodes', () => {
-    const container = document.createElement('div')
-    render(h(PipelineStageBar, { stage: 'idle' }), container)
-    const connectors = container.querySelectorAll('.pipeline-stage-connector')
-    expect(connectors.length).toBe(5)
-  })
-
-  it('shows no connectors for offline', () => {
-    const container = document.createElement('div')
-    render(h(PipelineStageBar, { stage: 'offline' as any }), container)
-    const connectors = container.querySelectorAll('.pipeline-stage-connector')
-    expect(connectors.length).toBe(0)
-  })
-
-  it('shows label only on active node', () => {
-    const container = document.createElement('div')
-    render(h(PipelineStageBar, { stage: 'tool_use' }), container)
-    const labels = container.querySelectorAll('.pipeline-stage-label')
-    expect(labels.length).toBe(1)
-    expect(labels[0]!.textContent).toBe('tool')
-  })
-
-  it('handles unknown stage as offline fallback', () => {
-    const container = document.createElement('div')
-    render(h(PipelineStageBar, { stage: 'unknown' as any }), container)
-    const nodes = container.querySelectorAll('.pipeline-stage-node')
-    expect(nodes.length).toBe(1)
-    expect(container.textContent).toContain('unknown')
   })
 })

--- a/dashboard/src/components/keeper-pipeline-stage.ts
+++ b/dashboard/src/components/keeper-pipeline-stage.ts
@@ -14,60 +14,14 @@ const STAGES: { key: PipelineStage; label: string }[] = [
   { key: 'scheduled_autonomous', label: 'auto' },
 ]
 
-const STAGE_ORDER: Record<string, number> = Object.fromEntries(
-  STAGES.map((s, i) => [s.key, i]),
-)
-
-/**
- * Full horizontal pipeline stage indicator.
- * Shows all stages as dots connected by lines. The current stage is highlighted.
- */
-export function PipelineStageBar({ stage }: { stage?: PipelineStage | null }) {
-  const current = stage ?? 'offline'
-  const currentIdx = STAGE_ORDER[current] ?? -1
-
-  if (current === 'offline' || currentIdx === -1) {
-    return html`
-      <div class="flex items-center py-1.5">
-        <div class="pipeline-stage-node active stage-${current}">
-          <span class="pipeline-stage-dot transition-colors duration-[var(--t-slow)]"></span>
-          <span class="pipeline-stage-label">${current}</span>
-        </div>
-      </div>
-    `
-  }
-
-  return html`
-    <div class="flex items-center py-1.5">
-      ${STAGES.map((s, i) => {
-        const isActive = s.key === current
-        const isPassed = i < currentIdx
-        const nodeClass = [
-          'pipeline-stage-node',
-          isActive ? 'active' : '',
-          isPassed ? 'passed' : '',
-          isActive ? `stage-${s.key}` : '',
-        ]
-          .filter(Boolean)
-          .join(' ')
-
-        return html`
-          ${i > 0 ? html`<span class="pipeline-stage-connector"></span>` : null}
-          <div class=${nodeClass}>
-            <span class="pipeline-stage-dot transition-colors duration-[var(--t-slow)]"></span>
-            ${isActive
-              ? html`<span class="pipeline-stage-label">${s.label}</span>`
-              : null}
-          </div>
-        `
-      })}
-    </div>
-  `
-}
-
 /**
  * Compact badge variant for roster cards.
  * Shows only the current stage as a small pill.
+ *
+ * Note: A wider `PipelineStageBar` once lived here. RFC-0046 removed
+ * its sole caller (keeper detail) in favour of the FsmHub composite
+ * snapshot; the badge survives because agent-monitor / fleet roster
+ * still need a one-axis stage hint outside the FSM hub.
  */
 export function PipelineStageBadge({
   stage,


### PR DESCRIPTION
## 요약

RFC-0046 (#14224) Step 3+4 구현. PR #14226 (Step 1+2)이 깔아둔 surface 위에 keeper detail의 운영 상태 개요를 6 axis composite snapshot으로 교체.

## Step 3 — `FsmHub` mount in keeper detail

**Before** (`keeper-detail.ts:1016`):
\`\`\`tsx
<PipelineStageBar stage={keeper.pipeline_stage} />   {/* 1 axis: phase */}
<CollapsibleSection title="Phase State Machine">
  <KeeperStateDiagramPanel keeperName={keeper.name} currentPhase={keeper.phase} />
</CollapsibleSection>
<CollapsibleSection title="Memory Tier & Compaction">
  <KeeperMemoryTierPanel keeperName={keeper.name} currentPhase={keeper.phase} />
</CollapsibleSection>
\`\`\`

**After**:
\`\`\`tsx
{/* RFC-0046: 6-axis composite snapshot — SSOT for keeper FSM state */}
<FsmHub mode="detail" selectedName={keeper.name} />
<CollapsibleSection title="Phase State Machine">
  <KeeperStateDiagramPanel keeperName={keeper.name} currentPhase={keeper.phase} />
</CollapsibleSection>
<CollapsibleSection title="Memory Tier & Compaction">
  <KeeperMemoryTierPanel keeperName={keeper.name} currentPhase={keeper.phase} />
</CollapsibleSection>
\`\`\`

운영자는 이제 keeper detail 첫 화면에서 KSM phase / KTC turn_phase / KDP decision / KCL cascade / KMC compaction / circuit_breaker 6 axis를 한 번에 봅니다. `keeper.pipeline_stage` 단일 axis bar는 같은 정보의 약한 그림자였으므로 제거.

## Step 4 — `PipelineStageBar` 제거

**숨은 caller 발견**: 첫 grep은 keeper-detail만 잡았으나 `pnpm typecheck`에서 `agent-monitor/runtime-strip.ts:6: import { PipelineStageBadge }` 에러로 두 번째 caller 노출. RFC §4.3 "Delete if no other caller; otherwise leave"의 conditional 그대로 적용:

| Export | 처리 |
|---|---|
| `PipelineStageBar` (function + STAGE_ORDER) | **삭제** |
| `PipelineStageBadge` (sole survivor) | **유지** — agent-monitor compact pill용 |
| `keeper-pipeline-stage.test.ts` | PipelineStageBar describe 블록 7건 제거, PipelineStageBadge 3건 유지 |

미래 reader가 bar variant를 추측-복원하지 않도록 PipelineStageBadge에 한 줄 RFC 주석 추가.

## 검증

| 검사 | 결과 |
|---|---|
| `pnpm typecheck` | 변경 파일 0 새 에러, post-#14226 baseline 그대로 |
| `pnpm vitest run keeper-pipeline-stage keeper-detail keeper-detail-shell keeper-detail-layout` | **30/30 passed** |
| `pnpm build` | 성공 (12.38s) |
| LoC | **−115 / +9** |

## RFC §8 acceptance 부분 충족
- [x] 운영자가 keeper detail에서 6 axis FSM lane 한 번에 봄
- [ ] 모든 panel이 keeper.phase 직접 안 읽음 — *Step 5에서 완료* (현재는 KeeperStateDiagram/MemoryTier에 currentPhase compat 유지)
- [x] 새 typecheck 에러 0
- [x] 테스트 통과

## 후속 (Step 5, 별도 PR)

KeeperStateDiagramPanel / KeeperMemoryTierPanel에 keeper-detail가 직접 fetch한 snapshot prop 전달. currentPhase compat fallback + 두 패널의 자체 /composite fetch 제거. RFC §5 step 5.

## RFC 발견 체크
- 변경 영역: `dashboard/src/components/` only — required subsystem 미수정.

## ⚠️ Draft 유지 요청
agent-authored — `human-approved-ready` 라벨 후 ready.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>