### PR TITLE
feat(dashboard): RFC-0046 Step 5 — drop currentPhase compat fallback

### DIFF
--- a/dashboard/src/components/keeper-detail.ts
+++ b/dashboard/src/components/keeper-detail.ts
@@ -1016,11 +1016,11 @@ export function KeeperDetailPage() {
         ${'' /* RFC-0046: 6-axis composite snapshot (KSM/KTC/KDP/KCL/KMC/breaker) — SSOT for keeper FSM state */}
         <${FsmHub} mode="detail" selectedName=${keeper.name} />
         <${CollapsibleSection} title="Phase State Machine">
-          <${KeeperStateDiagramPanel} keeperName=${keeper.name} currentPhase=${keeper.phase} />
+          <${KeeperStateDiagramPanel} keeperName=${keeper.name} />
         <//>
 
         <${CollapsibleSection} title="Memory Tier & Compaction">
-          <${KeeperMemoryTierPanel} keeperName=${keeper.name} currentPhase=${keeper.phase} />
+          <${KeeperMemoryTierPanel} keeperName=${keeper.name} />
         <//>
 
         ${'' /* ── Divergent conditions (amber banner; renders only when phase lags observed signals) ── */}

--- a/dashboard/src/components/keeper-memory-tier-panel.ts
+++ b/dashboard/src/components/keeper-memory-tier-panel.ts
@@ -21,11 +21,9 @@ const REFRESH_MS = 30_000
 
 interface KeeperMemoryTierPanelProps {
   keeperName: string
-  currentPhase?: string | null
   /** RFC-0046: parent-supplied composite snapshot. When provided,
-   *  this panel skips its own /composite fetch and reads from the
-   *  shared SSOT (FsmHub). currentPhase remains as compat fallback
-   *  for one cycle and will be removed in RFC-0046 Step 5. */
+   *  this panel reads the SSOT from the shared FsmHub fetch instead
+   *  of issuing its own /composite call. */
   snapshot?: KeeperCompositeSnapshot | null
 }
 
@@ -73,7 +71,6 @@ export function filterMemoryKindUsage(
  */
 export function KeeperMemoryTierPanel({
   keeperName,
-  currentPhase,
   snapshot: externalSnapshot,
 }: KeeperMemoryTierPanelProps) {
   const [usage, setUsage] = useState<MemoryKindUsageEntry[] | null>(null)
@@ -156,7 +153,7 @@ export function KeeperMemoryTierPanel({
     () => filterMemoryKindUsage(usage, query, filter),
     [usage, query, filter],
   )
-  const phase = snapshot?.phase ?? currentPhase ?? null
+  const phase = snapshot?.phase ?? null
   const isCompacting = phase === 'Compacting' || phase === 'compacting'
   const compactionStage = snapshot?.compaction.stage ?? (isCompacting ? 'compacting' : 'accumulating')
   const compactionSpec = buildCompactionSpec(compactionStage, phase)

--- a/dashboard/src/components/keeper-state-diagram.ts
+++ b/dashboard/src/components/keeper-state-diagram.ts
@@ -21,15 +21,12 @@ import {
   normalizePhaseDiagnosis,
   PhaseConditionsPanel,
 } from './phase-conditions-panel'
-import type { KeeperPhase } from '../types'
 
 interface KeeperStateDiagramProps {
   keeperName: string
-  currentPhase?: KeeperPhase | string | null
   /** RFC-0046: parent-supplied composite snapshot. When provided,
    *  this panel reads the SSOT from the shared FsmHub fetch instead
-   *  of issuing its own /composite call. currentPhase remains as
-   *  compat fallback for one cycle (RFC-0046 Step 5 will remove it). */
+   *  of issuing its own /composite call. */
   snapshot?: KeeperCompositeSnapshot | null
 }
 
@@ -129,7 +126,7 @@ function snapshotPhaseDiagnosis(snapshot: KeeperCompositeSnapshot): unknown {
   return isRecord(snapshot) ? snapshot.phase_diagnosis : undefined
 }
 
-export function KeeperStateDiagramPanel({ keeperName, currentPhase, snapshot: externalSnapshot }: KeeperStateDiagramProps) {
+export function KeeperStateDiagramPanel({ keeperName, snapshot: externalSnapshot }: KeeperStateDiagramProps) {
   const [internalSnapshot, setInternalSnapshot] = useState<KeeperCompositeSnapshot | null>(null)
   const snapshot = externalSnapshot ?? internalSnapshot
   const [stateDiagram, setStateDiagram] = useState<KeeperStateDiagramResponse | null>(null)
@@ -189,9 +186,9 @@ export function KeeperStateDiagramPanel({ keeperName, currentPhase, snapshot: ex
     return () => { controller.abort() }
   }, [keeperName])
 
-  const keeperPhase = normalizePhase(currentPhase)
-  const compositePhase = normalizePhase(snapshot?.phase)
-  const phaseMismatch = Boolean(keeperPhase && compositePhase && keeperPhase !== compositePhase)
+  // RFC-0046 Step 5: keeper.phase (flat field) is no longer surfaced here.
+  // Composite snapshot is the single source of truth; backend two-store
+  // drift detection moves to the FsmHub invariant area (future RFC).
   const phaseDiagnosis = useMemo(
     () => snapshot ? normalizePhaseDiagnosis(snapshotPhaseDiagnosis(snapshot)) : null,
     [snapshot],
@@ -228,9 +225,6 @@ export function KeeperStateDiagramPanel({ keeperName, currentPhase, snapshot: ex
     <div class="flex flex-col gap-3">
       <div class="flex flex-wrap items-center gap-2 text-3xs text-[var(--color-fg-disabled)]">
         <${PhaseBadge} accent>composite ${snapshot.phase}<//>
-        ${keeperPhase ? html`
-          <${PhaseBadge}>keeper ${keeperPhase}<//>
-        ` : null}
         <${PhaseBadge}>KTC ${snapshot.turn_phase}<//>
         <${PhaseBadge}>KDP ${snapshot.decision.stage}<//>
         <${PhaseBadge}>KCL ${snapshot.cascade.state}<//>
@@ -239,12 +233,6 @@ export function KeeperStateDiagramPanel({ keeperName, currentPhase, snapshot: ex
           <${PhaseBadge}>observed ${transitions.length} transitions<//>
         ` : null}
       </div>
-
-      ${phaseMismatch ? html`
-        <div class="rounded-[var(--r-1)] border border-[var(--warn-24)] bg-[var(--warn-8)] px-3 py-2 text-2xs leading-normal text-[var(--color-fg-primary)]">
-          keeper row phase와 composite snapshot phase가 다릅니다. composite snapshot을 authoritative runtime-truth로 사용합니다.
-        </div>
-      ` : null}
 
       <div>
         <div class="mb-2 flex flex-wrap items-center justify-between gap-2">


### PR DESCRIPTION
## 요약

RFC-0046 (#14224) 마지막 단계. PR #14226 Step 2에서 도입한 `currentPhase` compat prop을 제거. `KeeperStateDiagramPanel` + `KeeperMemoryTierPanel`은 이제 composite snapshot만을 SSOT로 읽음.

## 제거된 surface

### 1) `KeeperStateDiagramPanel`
- prop `currentPhase: KeeperPhase | string | null` 삭제
- `const keeperPhase = normalizePhase(currentPhase)` 변수 + 의존 UI 제거:
  - 보조 `<PhaseBadge>keeper ${keeperPhase}` 제거 (composite-side만 표시)
  - 경고 배너 삭제: *"keeper row phase와 composite snapshot phase가 다릅니다. composite snapshot을 authoritative runtime-truth로 사용합니다"*
- `KeeperPhase` import (now unused) 제거

### 2) `KeeperMemoryTierPanel`
- prop `currentPhase` 삭제
- `const phase = snapshot?.phase ?? currentPhase ?? null` → `snapshot?.phase ?? null`. 압축/스펙 렌더링은 snapshot.phase로만 분기.

### 3) `keeper-detail.ts` 호출자
- `<KeeperStateDiagramPanel keeperName={...} currentPhase={keeper.phase} />` → `<KeeperStateDiagramPanel keeperName={...} />`
- `<KeeperMemoryTierPanel ...>` 동일.

## RFC §8 acceptance — 두 번째 bullet 충족

> *"No component on the detail surface reads `keeper.phase` / `keeper.pipeline_stage` directly except the page-header breadcrumb (`KeeperPhaseAndStage`)."*

Step 4 (#14229)에서 `pipeline_stage` 직접 reader가 없어졌고, Step 5 (이 PR)에서 `keeper.phase` 직접 reader도 page-header 1곳만 남음.

## 검증

| 검사 | 결과 |
|---|---|
| `pnpm typecheck` | 변경 파일 0 새 에러, post-#14229 baseline 그대로 |
| `pnpm vitest run keeper-state-diagram keeper-memory-tier-panel keeper-detail keeper-detail-shell` | **62/62 passed** |
| `pnpm build` | 성공 (10.49s) |
| LoC | **−19 / +9** |

## 향후 작업 (RFC §7 future RFC)

1. **Backend two-store drift detection** — 사라진 phase mismatch 배너의 진짜 자리. `keeper.phase` (flat row) vs `snapshot.phase` (composite) 가 backend에서 SSOT 합쳐지지 않은 RFC-0044-adjacent 결함. dashboard scope 아님.
2. **Single keeper-detail-level `useKeeperComposite` hook** — 현재 FsmHub + state-diagram + memory-tier 3개 fetch가 같은 endpoint를 친다. 부모 hook으로 dedup.

이 두 항목은 별도 RFC에서 다룰 예정.

## RFC-0046 종합 결과

| PR | Step | LoC delta |
|---|---|---|
| #14219 / #14220 | Phase 1+2 (precursor cleanup) | −48 / +10 |
| #14224 | RFC 본문 | +202 (docs) |
| #14226 | Step 1+2 (additive props) | +34 / −8 |
| #14229 | Step 3+4 (mount + delete bar) | −115 / +9 |
| **#이 PR** | **Step 5 (compat fallback)** | **−19 / +9** |
| **합계 (코드만)** | | **−155 / +27** |

순 절감 −128 LoC. RFC 추정 −250~−400은 자체 fetch dedup까지 포함했으므로 이번 5단계로는 −128. 자체 fetch dedup는 follow-up RFC scope.

## ⚠️ Draft 유지 요청
agent-authored — `human-approved-ready` 라벨 후 ready.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>