### PR TITLE
feat(keeper): RFC-0047 PR-1 — introduce Keeper_turn_disposition (inert)

### DIFF
--- a/lib/keeper/keeper_turn_disposition.ml
+++ b/lib/keeper/keeper_turn_disposition.ml
@@ -1,0 +1,163 @@
+(* RFC-0047 PR-1: operator-facing disposition closed sum.
+
+   See [.mli] for the public contract. This file holds the type
+   definition, the canonical projection from
+   [Keeper_turn_terminal_code], and the wire-format serialisation
+   chosen to be byte-for-byte compatible with the strings emitted
+   today by [Keeper_turn_terminal.t.code]. *)
+
+module Code = Keeper_turn_terminal_code
+
+type t =
+  | Success
+  | External_cancel
+  | Turn_wall_clock_timeout
+  | Oas_timeout_budget
+  | Gh_repo_context_missing_worktree
+  | Required_tool_use_no_tool_call
+  | Required_tool_use_unsatisfied
+  | Post_commit_ambiguous
+  | Provider_error of Code.t
+  | Unknown of { raw_error : string }
+
+type severity =
+  | Ok
+  | Warn
+  | Bad
+  | Unknown_bad
+
+let severity = function
+  | Success -> Ok
+  | External_cancel
+  | Turn_wall_clock_timeout
+  | Oas_timeout_budget
+  | Gh_repo_context_missing_worktree -> Warn
+  | Required_tool_use_no_tool_call
+  | Required_tool_use_unsatisfied
+  | Post_commit_ambiguous
+  | Provider_error _ -> Bad
+  | Unknown _ -> Unknown_bad
+;;
+
+let summary = function
+  | Success -> "turn completed"
+  | External_cancel -> "keeper turn was cancelled before completion"
+  | Turn_wall_clock_timeout -> "keeper turn hit the wall-clock timeout"
+  | Oas_timeout_budget ->
+    "OAS call was skipped or failed because the turn timeout budget was exhausted"
+  | Gh_repo_context_missing_worktree ->
+    "GitHub command blocked because the active task has no linked worktree"
+  | Required_tool_use_no_tool_call ->
+    "required keeper tool use was requested, but the model returned no keeper tool call"
+  | Required_tool_use_unsatisfied ->
+    "required keeper tool use was requested, but the tool contract was not satisfied"
+  | Post_commit_ambiguous ->
+    "provider failed after a mutating tool may have committed side effects"
+  | Provider_error (Code.Provider_runtime_error "provider_error") ->
+    (* Legacy producer alias: pre-RFC [normalize_code "api_error_timeout"]
+       collapsed to the literal string "provider_error", which got the
+       specific summary below. PR-2/PR-3 retire that producer-side
+       normalize; this arm preserves byte-compat until then. *)
+    "provider or cascade failed"
+  | Provider_error code -> Printf.sprintf "keeper turn ended with %s" (Code.to_wire code)
+  | Unknown { raw_error = "" } ->
+    "keeper turn failed without a classified terminal reason"
+  | Unknown { raw_error } -> Printf.sprintf "keeper turn ended with %s" raw_error
+;;
+
+let next_action = function
+  | Success -> None
+  | External_cancel -> Some "rerun_if_still_relevant"
+  | Turn_wall_clock_timeout | Oas_timeout_budget -> Some "inspect_timeout_budget"
+  | Gh_repo_context_missing_worktree -> Some "create_or_link_worktree"
+  | Required_tool_use_no_tool_call | Required_tool_use_unsatisfied ->
+    Some "inspect_provider_tool_contract"
+  | Post_commit_ambiguous -> Some "reconcile_partial_commit"
+  | Provider_error _ | Unknown _ -> Some "inspect_latest_error"
+;;
+
+let to_wire = function
+  | Success -> "success"
+  | External_cancel -> "external_cancel"
+  | Turn_wall_clock_timeout -> "turn_wall_clock_timeout"
+  | Oas_timeout_budget -> "oas_timeout_budget"
+  | Gh_repo_context_missing_worktree -> "gh_repo_context_missing_worktree"
+  | Required_tool_use_no_tool_call -> "required_tool_use_no_tool_call"
+  | Required_tool_use_unsatisfied -> "required_tool_use_unsatisfied"
+  | Post_commit_ambiguous -> "post_commit_ambiguous"
+  | Provider_error code -> Code.to_wire code
+  | Unknown { raw_error = "" } -> "unknown_error"
+  | Unknown { raw_error } -> raw_error
+;;
+
+(* Projection from runtime layer to operator layer.
+
+   A runtime cause maps directly to a non-[Provider_error] arm only
+   when the runtime classification fully determines the operator
+   action. Stale_turn_timeout_* are operator-equivalent to the
+   "wall-clock timeout" disposition; Tool_required_unsatisfied is
+   operator-equivalent to "required tool use unsatisfied"; the
+   Ambiguous_partial_commit_* pair both indicate post-commit ambiguity.
+   All other runtime causes are wrapped so the typed cause is
+   preserved for diagnostics. *)
+let of_termination_code (c : Code.t) : t =
+  match c with
+  | Code.Healthy -> Success
+  | Code.Stale_turn_timeout_idle
+  | Code.Stale_turn_timeout_in_turn
+  | Code.Stale_turn_timeout_noop -> Turn_wall_clock_timeout
+  | Code.Oas_timeout_budget -> Oas_timeout_budget
+  | Code.Tool_required_unsatisfied _ -> Required_tool_use_unsatisfied
+  | Code.Ambiguous_partial_commit_post_commit_timeout
+  | Code.Ambiguous_partial_commit_post_commit_failure -> Post_commit_ambiguous
+  | Code.Heartbeat_failures
+  | Code.Turn_failures
+  | Code.Stale_termination_storm
+  | Code.Stale_fleet_batch
+  | Code.Provider_runtime_error _
+  | Code.Fiber_unresolved
+  | Code.Exception_unhandled _
+  | Code.Sdk_error _ -> Provider_error c
+;;
+
+let of_wire = function
+  | "success" -> Success
+  | "external_cancel" -> External_cancel
+  | "turn_wall_clock_timeout" -> Turn_wall_clock_timeout
+  | "oas_timeout_budget" -> Oas_timeout_budget
+  | "gh_repo_context_missing_worktree" -> Gh_repo_context_missing_worktree
+  | "required_tool_use_no_tool_call" -> Required_tool_use_no_tool_call
+  | "required_tool_use_unsatisfied" -> Required_tool_use_unsatisfied
+  | "post_commit_ambiguous" -> Post_commit_ambiguous
+  | "unknown_error" -> Unknown { raw_error = "" }
+  | other ->
+    (match Code.of_wire other with
+     | Some c -> of_termination_code c
+     | None -> Unknown { raw_error = other })
+;;
+
+let equal a b =
+  match a, b with
+  | Success, Success
+  | External_cancel, External_cancel
+  | Turn_wall_clock_timeout, Turn_wall_clock_timeout
+  | Oas_timeout_budget, Oas_timeout_budget
+  | Gh_repo_context_missing_worktree, Gh_repo_context_missing_worktree
+  | Required_tool_use_no_tool_call, Required_tool_use_no_tool_call
+  | Required_tool_use_unsatisfied, Required_tool_use_unsatisfied
+  | Post_commit_ambiguous, Post_commit_ambiguous -> true
+  | Provider_error a, Provider_error b -> String.equal (Code.to_wire a) (Code.to_wire b)
+  | Unknown a, Unknown b -> String.equal a.raw_error b.raw_error
+  | Success, _
+  | External_cancel, _
+  | Turn_wall_clock_timeout, _
+  | Oas_timeout_budget, _
+  | Gh_repo_context_missing_worktree, _
+  | Required_tool_use_no_tool_call, _
+  | Required_tool_use_unsatisfied, _
+  | Post_commit_ambiguous, _
+  | Provider_error _, _
+  | Unknown _, _ -> false
+;;
+
+let pp fmt t = Format.pp_print_string fmt (to_wire t)

--- a/lib/keeper/keeper_turn_disposition.mli
+++ b/lib/keeper/keeper_turn_disposition.mli
@@ -1,0 +1,127 @@
+(** Operator-facing disposition for keeper turns. RFC-0047.
+
+    This module is the *application-layer* counterpart of
+    [Keeper_turn_terminal_code] (RFC-0042, runtime/SDK layer). The
+    runtime layer answers "what terminated this turn at the
+    SDK/registry boundary?"; this layer answers "what should the
+    operator see and do?".
+
+    The two layers are deliberately separate types:
+    - [Keeper_turn_terminal_code.t] stays narrow (RFC-0042 §3.1) and
+      is sourced from [Keeper_registry.failure_reason] /
+      [Agent_sdk.Error.sdk_error].
+    - [Keeper_turn_disposition.t] is what
+      [Keeper_turn_terminal.t.code: string] *currently mashes
+      together*; PR-2 swaps the field type to this closed sum, PR-3
+      removes the legacy string field.
+
+    PR-1 introduces this module as inert (no callers in the tree).
+    PR-2 populates [Keeper_turn_terminal.t.disposition] from typed
+    producers. PR-3 deletes the legacy [code: string] field, making
+    [severity / summary / next_action] exhaustive matches with no
+    string-substring classifiers.
+
+    @stability Evolving
+    @since 0.193.3 *)
+
+type t =
+  | Success (** Turn completed normally. *)
+  | External_cancel
+  (** Turn cancelled before completion (operator stop, switch_keeper, …). *)
+  | Turn_wall_clock_timeout (** Turn exceeded its wall-clock budget. *)
+  | Oas_timeout_budget (** OAS turn-budget cooldown / cap rejection. *)
+  | Gh_repo_context_missing_worktree
+  (** GitHub command blocked because the active task has no linked
+          worktree. *)
+  | Required_tool_use_no_tool_call
+  (** Required-tool-use contract: model returned no tool call. *)
+  | Required_tool_use_unsatisfied
+  (** Required-tool-use contract: tool call did not satisfy the
+          contract. *)
+  | Post_commit_ambiguous
+  (** Provider failed after a mutating tool may have committed side
+          effects. Reconcile required. *)
+  | Provider_error of Keeper_turn_terminal_code.t
+  (** Runtime-layer termination promoted to operator-facing
+          disposition. The inner code preserves the typed runtime cause
+          for diagnostics (Prometheus / dashboard / bin/masc-trace).
+          [to_wire (Provider_error code) = Keeper_turn_terminal_code.to_wire code].
+          PR-3 readers match on this constructor instead of
+          [String.starts_with ~prefix:"api_error_"]. *)
+  | Unknown of { raw_error : string }
+  (** Last-resort escape hatch for un-classified producer paths
+          (mainly [Keeper_turn_terminal.of_legacy_error_text] until
+          PR-3). [to_wire] returns ["unknown_error"] when [raw_error]
+          is empty, else [raw_error] verbatim — matches the legacy
+          [of_legacy_error_text "" → "unknown_error"] behaviour.
+
+          PR-3 lint
+          [scripts/lint/no-free-unknown-disposition.sh] will block
+          PRs that construct [Unknown { raw_error = X }] with the same
+          [X] at >= 2 sites; such [X] must be promoted to a
+          constructor. *)
+
+(** {1 Severity} *)
+
+type severity =
+  | Ok
+  | Warn
+  | Bad
+  | Unknown_bad
+
+(** Severity classification. Exhaustive — every disposition has a
+    severity assigned at the type level, not at substring level. *)
+val severity : t -> severity
+
+(** Operator-readable summary string. Exhaustive. *)
+val summary : t -> string
+
+(** Optional follow-up action the operator can take. Exhaustive. *)
+val next_action : t -> string option
+
+(** {1 Wire format} *)
+
+(** Stable wire format. The strings produced here are byte-for-byte
+    compatible with the strings emitted today by
+    [Keeper_turn_terminal.t.code] for every code consumed by the
+    legacy [severity_of_code / summary_of_code / next_action_of_code]
+    in [keeper_turn_terminal.ml].
+
+    Mapping:
+    - [Success] → ["success"]
+    - [External_cancel] → ["external_cancel"]
+    - [Turn_wall_clock_timeout] → ["turn_wall_clock_timeout"]
+    - [Oas_timeout_budget] → ["oas_timeout_budget"]
+    - [Gh_repo_context_missing_worktree] → ["gh_repo_context_missing_worktree"]
+    - [Required_tool_use_no_tool_call] → ["required_tool_use_no_tool_call"]
+    - [Required_tool_use_unsatisfied] → ["required_tool_use_unsatisfied"]
+    - [Post_commit_ambiguous] → ["post_commit_ambiguous"]
+    - [Provider_error code] → [Keeper_turn_terminal_code.to_wire code]
+    - [Unknown { raw_error = "" }] → ["unknown_error"]
+    - [Unknown { raw_error }] → [raw_error] (verbatim) *)
+val to_wire : t -> string
+
+(** Best-effort deserialiser. Recognised application strings round-trip
+    exactly. Unrecognised strings first try
+    [Keeper_turn_terminal_code.of_wire]; if that succeeds, the result
+    is wrapped via [of_termination_code] (which may itself collapse to
+    a non-Provider_error disposition such as [Required_tool_use_unsatisfied]).
+    Otherwise [Unknown { raw_error = wire }] is returned. *)
+val of_wire : string -> t
+
+(** {1 Layer projection} *)
+
+(** Canonical projection from runtime layer to operator layer. See
+    RFC-0047 §3.1 for the full mapping table.
+
+    A runtime cause maps to a non-[Provider_error] disposition only
+    when the runtime classification fully determines the operator
+    action (e.g., [Tool_required_unsatisfied → Required_tool_use_unsatisfied]).
+    Otherwise the runtime cause is preserved by wrapping with
+    [Provider_error] so dashboards keep the typed runtime trace. *)
+val of_termination_code : Keeper_turn_terminal_code.t -> t
+
+(** {1 Equality / debug} *)
+
+val equal : t -> t -> bool
+val pp : Format.formatter -> t -> unit

--- a/test/dune
+++ b/test/dune
@@ -29,6 +29,7 @@
         test_keeper_turn_terminal_code_byte_compat
         test_keeper_sdk_error_typed_bridge
         test_read_drop_reason
+        test_keeper_turn_disposition
         test_attempt_state
         test_sse test_graphql_api
         test_graphql_endpoint
@@ -262,6 +263,7 @@
           test_keeper_turn_terminal_code_byte_compat
           test_keeper_sdk_error_typed_bridge
           test_read_drop_reason
+          test_keeper_turn_disposition
           test_attempt_state
           test_sse test_graphql_api
           test_graphql_endpoint

--- a/test/test_keeper_turn_disposition.ml
+++ b/test/test_keeper_turn_disposition.ml
@@ -1,0 +1,285 @@
+(** RFC-0047 PR-1 invariants for [Keeper_turn_disposition]:
+
+    1. Byte-compat: for every wire string consumed by the legacy
+       [Keeper_turn_terminal.severity_of_code / summary_of_code /
+       next_action_of_code], the new typed
+       [Keeper_turn_disposition.severity / summary / next_action]
+       must agree on severity (rendered as string), summary, and
+       next_action — *after* the legacy [normalize_code] is applied
+       to the input wire (since PR-2 will keep the same producer-side
+       normalisation; this test isolates the *consumer-side*
+       invariant).
+
+    2. Round-trip: [of_wire (to_wire t) = t] for every canonical
+       constructor and for [Provider_error] wrapping each runtime
+       variant.
+
+    3. Projection: [of_termination_code] is deterministic and total
+       over [Keeper_turn_terminal_code.t]. *)
+
+module D = Masc_mcp.Keeper_turn_disposition
+module Code = Masc_mcp.Keeper_turn_terminal_code
+module Legacy = Masc_mcp.Keeper_turn_terminal
+
+(* ===== Byte-compat oracle ====================================== *)
+(* For every legacy wire code, build the corresponding disposition,
+   then assert that the typed accessors agree with the legacy
+   substring-based accessors. *)
+
+(* Group A: canonical application codes — strict byte-compat.
+   Severity / summary / next_action must match the legacy substring
+   classifier exactly. *)
+let canonical_app_codes : (string * D.t) list =
+  [ "success", D.Success
+  ; "external_cancel", D.External_cancel
+  ; "turn_wall_clock_timeout", D.Turn_wall_clock_timeout
+  ; "oas_timeout_budget", D.Oas_timeout_budget
+  ; "gh_repo_context_missing_worktree", D.Gh_repo_context_missing_worktree
+  ; "required_tool_use_no_tool_call", D.Required_tool_use_no_tool_call
+  ; "required_tool_use_unsatisfied", D.Required_tool_use_unsatisfied
+  ; "post_commit_ambiguous", D.Post_commit_ambiguous
+  ; "provider_error", D.Provider_error (Code.Provider_runtime_error "provider_error")
+  ; "unknown_error", D.Unknown { raw_error = "" }
+  ]
+;;
+
+(* Group B: runtime-layer wire strings that legacy
+   [severity_of_code] classifies via [String.starts_with ~prefix:"api_error_"]
+   or via the [_ -> Unknown_bad] fallback. The legacy
+   [next_action_of_code] returns [None] for these (its [_ -> None] arm),
+   which is inconsistent with the legacy "provider_error" alias path
+   that returns [Some "inspect_latest_error"]. RFC-0047 unifies the
+   two: every [Provider_error _] disposition recommends
+   [inspect_latest_error]. This is an intentional behaviour change
+   documented in the RFC; only [severity] (rendered as string) is
+   asserted against legacy here. *)
+let runtime_wire_codes : (string * D.t) list =
+  [ "api_error_overloaded", D.Provider_error (Code.Sdk_error "api_error_overloaded")
+  ; "api_error_server:502", D.Provider_error (Code.Sdk_error "api_error_server:502")
+  ; ( "agent_error_max_turns_exceeded:turns=10,limit=10"
+    , D.Provider_error (Code.Sdk_error "agent_error_max_turns_exceeded:turns=10,limit=10")
+    )
+  ]
+;;
+
+(* The legacy [severity] type and [D.severity] type are isomorphic; we
+   compare via [severity_to_string] for ergonomics. *)
+let legacy_severity_str (sev : Legacy.severity) : string = Legacy.severity_to_string sev
+
+let typed_severity_str (sev : D.severity) : string =
+  match sev with
+  | D.Ok -> "ok"
+  | D.Warn -> "warn"
+  | D.Bad -> "bad"
+  | D.Unknown_bad -> "bad"
+;;
+
+let test_canonical_severity_byte_compat () =
+  List.iter
+    (fun (wire, disp) ->
+       let legacy = Legacy.of_code wire in
+       let expected = legacy_severity_str legacy.severity in
+       let actual = typed_severity_str (D.severity disp) in
+       Alcotest.(check string) (Printf.sprintf "severity[%s]" wire) expected actual)
+    canonical_app_codes
+;;
+
+let test_canonical_summary_byte_compat () =
+  List.iter
+    (fun (wire, disp) ->
+       let legacy = Legacy.of_code wire in
+       let expected = legacy.summary in
+       let actual = D.summary disp in
+       Alcotest.(check string) (Printf.sprintf "summary[%s]" wire) expected actual)
+    canonical_app_codes
+;;
+
+let test_canonical_next_action_byte_compat () =
+  List.iter
+    (fun (wire, disp) ->
+       let legacy = Legacy.of_code wire in
+       let expected =
+         match legacy.next_action with
+         | Some s -> "Some:" ^ s
+         | None -> "None"
+       in
+       let actual =
+         match D.next_action disp with
+         | Some s -> "Some:" ^ s
+         | None -> "None"
+       in
+       Alcotest.(check string) (Printf.sprintf "next_action[%s]" wire) expected actual)
+    canonical_app_codes
+;;
+
+(* Runtime-wire codes: severity-only oracle. RFC-0047 §3 documents
+   that [Provider_error _] uniformly recommends "inspect_latest_error"
+   for next_action and uses the inner code wire as the summary suffix
+   ("keeper turn ended with X"); both are intentional improvements
+   over the legacy substring path. *)
+let test_runtime_wire_severity_byte_compat () =
+  List.iter
+    (fun (wire, disp) ->
+       let legacy = Legacy.of_code wire in
+       let expected = legacy_severity_str legacy.severity in
+       let actual = typed_severity_str (D.severity disp) in
+       Alcotest.(check string) (Printf.sprintf "severity[%s]" wire) expected actual)
+    runtime_wire_codes
+;;
+
+(* ===== Round-trip ============================================== *)
+
+(* Round-trip is asymmetric:
+   - [to_wire] is total (every disposition produces a string).
+   - [of_wire] is best-effort. Recognised app strings round-trip.
+     Recognised runtime wires (RFC-0042) round-trip via projection.
+     Parametrised runtime payloads (Provider_runtime_error of string,
+     Sdk_error of string, Exception_unhandled of string) and
+     unrecognised legacy wires deserialise to [Unknown { raw_error }];
+     no round-trip is possible without a wire-prefix scheme that
+     RFC-0042 explicitly defers (§3.1 "intentionally flat"). *)
+let round_trippable : (string * D.t) list =
+  [ "Success", D.Success
+  ; "External_cancel", D.External_cancel
+  ; "Turn_wall_clock_timeout", D.Turn_wall_clock_timeout
+  ; "Oas_timeout_budget", D.Oas_timeout_budget
+  ; "Gh_repo_context_missing_worktree", D.Gh_repo_context_missing_worktree
+  ; "Required_tool_use_no_tool_call", D.Required_tool_use_no_tool_call
+  ; "Required_tool_use_unsatisfied", D.Required_tool_use_unsatisfied
+  ; "Post_commit_ambiguous", D.Post_commit_ambiguous
+  ; "Unknown empty", D.Unknown { raw_error = "" }
+  ; "Unknown raw", D.Unknown { raw_error = "fresh_unmapped_label" }
+  ; (* Runtime wires that Code.of_wire recognises losslessly (no payload
+     or payload-loss is acceptable per RFC-0042 §5.2). *)
+    "Provider_error/Heartbeat", D.Provider_error Code.Heartbeat_failures
+  ; "Provider_error/Turn_failures", D.Provider_error Code.Turn_failures
+  ; "Provider_error/Storm", D.Provider_error Code.Stale_termination_storm
+  ; "Provider_error/FleetBatch", D.Provider_error Code.Stale_fleet_batch
+  ; "Provider_error/Fiber", D.Provider_error Code.Fiber_unresolved
+  ]
+;;
+
+let test_round_trip_recognised () =
+  List.iter
+    (fun (label, t) ->
+       let wire = D.to_wire t in
+       let parsed = D.of_wire wire in
+       Alcotest.(check bool)
+         (label ^ " round-trip via to_wire/of_wire")
+         true
+         (D.equal t parsed))
+    round_trippable
+;;
+
+(* Documented asymmetric cases: parametrised payloads survive serialisation
+   but deserialise to [Unknown { raw_error = wire }] because the wire
+   loses the constructor identity. *)
+let test_round_trip_lossy_payloads () =
+  let cases =
+    [ ( "Provider_error/Provider_runtime payload"
+      , D.Provider_error (Code.Provider_runtime_error "p_500")
+      , "p_500" )
+    ; ( "Provider_error/Sdk payload"
+      , D.Provider_error (Code.Sdk_error "api_error_overloaded")
+      , "api_error_overloaded" )
+    ]
+  in
+  List.iter
+    (fun (label, t, expected_raw) ->
+       let wire = D.to_wire t in
+       Alcotest.(check string) (label ^ " to_wire") expected_raw wire;
+       match D.of_wire wire with
+       | D.Unknown { raw_error } ->
+         Alcotest.(check string)
+           (label ^ " of_wire → Unknown raw_error")
+           expected_raw
+           raw_error
+       | other -> Alcotest.failf "%s expected Unknown, got %a" label D.pp other)
+    cases
+;;
+
+(* ===== Projection (of_termination_code) ======================= *)
+
+let runtime_codes_to_projection : (string * Code.t * D.t) list =
+  [ "Healthy", Code.Healthy, D.Success
+  ; "Stale_turn_timeout/idle", Code.Stale_turn_timeout_idle, D.Turn_wall_clock_timeout
+  ; ( "Stale_turn_timeout/in_turn"
+    , Code.Stale_turn_timeout_in_turn
+    , D.Turn_wall_clock_timeout )
+  ; "Stale_turn_timeout/noop", Code.Stale_turn_timeout_noop, D.Turn_wall_clock_timeout
+  ; "Oas_timeout_budget", Code.Oas_timeout_budget, D.Oas_timeout_budget
+  ; ( "Tool_required_unsatisfied"
+    , Code.Tool_required_unsatisfied "x"
+    , D.Required_tool_use_unsatisfied )
+  ; ( "Ambiguous/timeout"
+    , Code.Ambiguous_partial_commit_post_commit_timeout
+    , D.Post_commit_ambiguous )
+  ; ( "Ambiguous/failure"
+    , Code.Ambiguous_partial_commit_post_commit_failure
+    , D.Post_commit_ambiguous )
+  ; "Heartbeat", Code.Heartbeat_failures, D.Provider_error Code.Heartbeat_failures
+  ; "Turn_failures", Code.Turn_failures, D.Provider_error Code.Turn_failures
+  ; "Storm", Code.Stale_termination_storm, D.Provider_error Code.Stale_termination_storm
+  ; "FleetBatch", Code.Stale_fleet_batch, D.Provider_error Code.Stale_fleet_batch
+  ; ( "Provider_runtime"
+    , Code.Provider_runtime_error "p"
+    , D.Provider_error (Code.Provider_runtime_error "p") )
+  ; "Fiber", Code.Fiber_unresolved, D.Provider_error Code.Fiber_unresolved
+  ; ( "Exception"
+    , Code.Exception_unhandled "x"
+    , D.Provider_error (Code.Exception_unhandled "x") )
+  ; ( "Sdk"
+    , Code.Sdk_error "agent_error_max_turns_exceeded:turns=1,limit=1"
+    , D.Provider_error (Code.Sdk_error "agent_error_max_turns_exceeded:turns=1,limit=1") )
+  ]
+;;
+
+let test_projection () =
+  List.iter
+    (fun (label, code, expected) ->
+       let actual = D.of_termination_code code in
+       Alcotest.(check bool) (label ^ " projection") true (D.equal expected actual))
+    runtime_codes_to_projection
+;;
+
+let () =
+  Alcotest.run
+    "keeper_turn_disposition"
+    [ ( "byte-compat oracle vs legacy keeper_turn_terminal (canonical app codes)"
+      , [ Alcotest.test_case
+            "severity matches legacy"
+            `Quick
+            test_canonical_severity_byte_compat
+        ; Alcotest.test_case
+            "summary matches legacy"
+            `Quick
+            test_canonical_summary_byte_compat
+        ; Alcotest.test_case
+            "next_action matches legacy"
+            `Quick
+            test_canonical_next_action_byte_compat
+        ] )
+    ; ( "byte-compat (runtime-wire codes, severity-only)"
+      , [ Alcotest.test_case
+            "severity matches legacy substring classifier"
+            `Quick
+            test_runtime_wire_severity_byte_compat
+        ] )
+    ; ( "round-trip"
+      , [ Alcotest.test_case
+            "recognised wires round-trip exactly"
+            `Quick
+            test_round_trip_recognised
+        ; Alcotest.test_case
+            "parametrised payloads land in Unknown (asymmetric)"
+            `Quick
+            test_round_trip_lossy_payloads
+        ] )
+    ; ( "of_termination_code projection"
+      , [ Alcotest.test_case
+            "every runtime variant projects deterministically"
+            `Quick
+            test_projection
+        ] )
+    ]
+;;


### PR DESCRIPTION
## Goal

First implementation step of RFC-0047. Mirrors the RFC-0042 PR-1
(#14182) and RFC-0044 PR-1 (#14225) inert-introduction pattern: ship
the closed sum first, swap callers in PR-2.

## Why a separate type from \`Keeper_turn_terminal_code\`

Diagnosis from the RFC-0042 PR-3 attempt (2026-05-08): the wire codes
consumed by \`Keeper_turn_terminal.t.code\` are at a *different
abstraction layer* than \`Keeper_turn_terminal_code.t\`. Their wire
sets are nearly disjoint. Conflating them in one type would force every
reader of either layer to match on the other layer's variants.

The clean fix is two types with explicit promotion:

\`\`\`ocaml
| Provider_error of Keeper_turn_terminal_code.t
\`\`\`

so the runtime cause is preserved for diagnostics while the operator
disposition stays exhaustive over its own concern.

## What changed

| File | Δ |
|---|---|
| \`lib/keeper/keeper_turn_disposition.ml/.mli\` | NEW. 8 canonical operator dispositions + \`Provider_error of Keeper_turn_terminal_code.t\` for layer promotion + \`Unknown of { raw_error }\` last-resort escape hatch (PR-3 lint blocks reuse). \`severity / summary / next_action\` exhaustive on disposition. \`to_wire\` byte-for-byte compatible. |
| \`test/test_keeper_turn_disposition.ml\` | NEW. 7 cases. |
| \`test/dune\` | Register the new test binary. |

## Verification

\`\`\`
$ bash scripts/dune-local.sh build @check  # OK
$ bash scripts/dune-local.sh exec test/test_keeper_turn_disposition.exe
  [OK]  byte-compat oracle (canonical app codes)  0  severity matches legacy
  [OK]                                            1  summary matches legacy
  [OK]                                            2  next_action matches legacy
  [OK]  runtime-wire codes severity-only          0  matches legacy substring classifier
  [OK]  round-trip                                0  recognised wires round-trip exactly
  [OK]                                            1  parametrised payloads land in Unknown (asymmetric)
  [OK]  of_termination_code projection            0  every runtime variant projects deterministically
Test Successful in 0.004s. 7 tests run.
\`\`\`

## Intentional behaviour changes (RFC-0047 §3)

- Every \`Provider_error _\` recommends \`next_action = inspect_latest_error\`.
  Legacy was inconsistent: literal "provider_error" returned that
  recommendation, but \`api_error_*\` substring path returned \`None\`.
  RFC-0047 unifies the two (operator always gets a next_action when
  the runtime layer reports a provider failure).
- \`Provider_error code\` summary uses
  \`Printf.sprintf "keeper turn ended with %s" (Code.to_wire code)\`
  uniformly. The legacy alias "provider_error" → "provider or cascade
  failed" is preserved as a single special-cased arm until PR-2/PR-3
  retire the producer-side \`normalize_code "api_error_timeout" → "provider_error"\`
  path.

Both behaviour changes are documented in the test (\`runtime_wire_codes\`
asserts severity-only; the canonical-app-codes oracle still asserts
strict byte-compat for severity / summary / next_action).

## Wire stability

- Receipt JSON \`code\` field: byte-for-byte preserved (PR-2/PR-3 add a
  new \`disposition\` field; this PR doesn't change anything on the
  wire).

## Anti-pattern self-check (\`software-development.md §워크어라운드 거부 기준\`)

- [ ] ❌ Telemetry-as-fix — N/A
- [ ] ❌ String/substring classifier — *prevents future cases* (no
      substring code added; new severity/summary/next_action are
      exhaustive matches)
- [ ] ❌ N-of-M patch — N/A (inert module, no callsite touched)
- [ ] ❌ catch-all — \`Unknown of { raw_error }\` is **explicitly
      documented** with PR-3 lint scheduled
- [ ] ❌ cap/cooldown/dedup/repair — N/A

## Out of scope

- PR-2: add \`disposition\` field to \`Keeper_turn_terminal.t\`
  alongside legacy \`code: string\`. Producers populate from typed
  source.
- PR-3: remove \`code: string\`; \`severity / summary / next_action\`
  exhaustive on disposition. ~10-12 file sweep + lint guard.

## Companion docs PR

RFC-0047 docs: filed in parallel.