### PR TITLE
chore(dashboard): purge marketing-copy explainers across non-keeper-detail surfaces

### DIFF
--- a/dashboard/src/components/cascade-inspector.ts
+++ b/dashboard/src/components/cascade-inspector.ts
@@ -423,9 +423,6 @@ export function CascadeInspector() {
             <h3 class="mt-2 text-[22px] font-semibold tracking-[-0.02em] text-text-strong">
               전략 추적 · 프로바이더 건강도
             </h3>
-            <p class="mt-2 text-sm leading-relaxed text-text-muted">
-              cascade 의사결정 이력과 프로바이더 상태를 한 화면에서 봅니다.
-            </p>
           </div>
           <${CascadeFocusRail}
             focus=${focus}

--- a/dashboard/src/components/keeper-reactivity-monitor.ts
+++ b/dashboard/src/components/keeper-reactivity-monitor.ts
@@ -621,9 +621,6 @@ export function KeeperReactivityMonitor({ defaultView }: { defaultView?: Reactiv
       <div class="flex items-center justify-between">
         <div class="flex flex-col gap-0.5">
           <h3 class="text-sm font-semibold text-[var(--color-fg-secondary)]">키퍼 반응성 모니터</h3>
-          <p class="text-2xs text-[var(--color-fg-muted)]">
-            phase 전환, 자동 일시정지, 프로액티브 스킵 이유, stale 종료 패턴을 한 곳에서 봅니다
-          </p>
         </div>
         ${isNonLifecycle ? html`
           <div class="flex items-center gap-2">

--- a/dashboard/src/components/keeper-shared.ts
+++ b/dashboard/src/components/keeper-shared.ts
@@ -325,9 +325,6 @@ export function KeeperConversationPanel({
                 ${conversationStateLabel(sending, hydrating)}
               </span>
             </div>
-            <div class="mt-1 text-sm leading-loose text-[var(--color-fg-secondary)]">
-              Keeper 상세 안에서 직접 대화와 내부 메시지를 함께 봅니다. 필요하면 토글로 내부 프롬프트와 tool chatter를 숨길 수 있습니다.
-            </div>
           </div>
           <div class="flex flex-wrap items-center gap-2">
             <${GhostButton} onClick=${toggleMetadata} ariaExpanded=${showMetadata}>

--- a/dashboard/src/components/lab-inspector.ts
+++ b/dashboard/src/components/lab-inspector.ts
@@ -114,9 +114,6 @@ export function LabInspector() {
     <div class="flex flex-col gap-4">
       <${Card} title="운영 인스펙터" class="section">
         <div class="flex flex-col gap-3">
-          <div class="text-sm leading-airy text-[var(--color-fg-primary)]">
-            피처 플래그와 서버 설정을 한 곳에서 보고, 대시보드에서 실제 자주 쓰는 운영 화면으로 빠르게 이동합니다.
-          </div>
           <div class="flex flex-wrap gap-2">
             <${InspectorTabButton} id="overview" label="개요" />
             <${InspectorTabButton} id="features" label="피처 플래그" />

--- a/dashboard/src/components/tools/config-resolution-panel.ts
+++ b/dashboard/src/components/tools/config-resolution-panel.ts
@@ -526,8 +526,8 @@ export function ConfigResolutionPanel({
 
   return html`
     <${Card} title="설정 경로" class="section mb-4">
-      <div class="mb-4 text-xs leading-relaxed text-[var(--color-fg-muted)]">
-        서버가 실제로 해석한 config root와 runtime/data root를 함께 보여줍니다. cascade는 human-authored cascade.toml과 runtime cascade.json을 분리해 보여주며, 현재 실행이 바라보는 경로와 체크인된 seed config는 다를 수 있습니다.
+      <div class="mb-4 text-xs text-[var(--color-fg-muted)]">
+        cascade.toml(seed) ≠ cascade.json(runtime). 현재 실행 경로가 체크인된 seed config와 다를 수 있습니다.
       </div>
 
       ${resolution


### PR DESCRIPTION
## 요약

PR #14219 / #14220 / RFC-0046 (#14224 ~ #14233)이 시작한 anti-explainer 작업을 keeper-detail 외 5개 surface로 확장. 같은 패턴 — 컴포넌트가 이미 보여주는 데이터를 한 줄 더 설명하는 noise.

## 제거 (5곳)

### 1) `cascade-inspector.ts:426-428`
\`\`\`diff
- <p class="mt-2 text-sm leading-relaxed text-text-muted">
-   cascade 의사결정 이력과 프로바이더 상태를 한 화면에서 봅니다.
- </p>
\`\`\`
H3 title \`전략 추적 · 프로바이더 건강도\` 가 같은 signal 운반.

### 2) `lab-inspector.ts:117-119`
\`\`\`diff
- <div class="text-sm leading-airy text-[var(--color-fg-primary)]">
-   피처 플래그와 서버 설정을 한 곳에서 보고, 대시보드에서 실제 자주 쓰는 운영 화면으로 빠르게 이동합니다.
- </div>
\`\`\`
바로 아래 InspectorTabButton (개요 / 피처 플래그 / 서버 설정 / 진단)이 navigation 자체.

### 3) `keeper-reactivity-monitor.ts:624-626`
\`\`\`diff
- <p class="text-2xs text-[var(--color-fg-muted)]">
-   phase 전환, 자동 일시정지, 프로액티브 스킵 이유, stale 종료 패턴을 한 곳에서 봅니다
- </p>
\`\`\`
패널들이 4 axis를 inline label로 직접 렌더.

### 4) `keeper-shared.ts:328-330`
\`\`\`diff
- <div class="mt-1 text-sm leading-loose text-[var(--color-fg-secondary)]">
-   Keeper 상세 안에서 직접 대화와 내부 메시지를 함께 봅니다. 필요하면 토글로 내부 프롬프트와 tool chatter를 숨길 수 있습니다.
- </div>
\`\`\`
바로 아래 toggle 버튼 (\`메타데이터 표시\` / \`내부 메시지\`)이 self-explanatory.

## 압축 (1곳, warning 유지)

### 5) `tools/config-resolution-panel.ts:529-531`
\`\`\`diff
- 서버가 실제로 해석한 config root와 runtime/data root를 함께 보여줍니다.
- cascade는 human-authored cascade.toml과 runtime cascade.json을 분리해 보여주며,
- 현재 실행이 바라보는 경로와 체크인된 seed config는 다를 수 있습니다.
+ cascade.toml(seed) ≠ cascade.json(runtime).
+ 현재 실행 경로가 체크인된 seed config와 다를 수 있습니다.
\`\`\`
**핵심**: drift warning은 운영자 안전에 가치 있어 보존. marketing copy preamble만 제거.

## 검증

| 검사 | 결과 |
|---|---|
| `pnpm vitest run` (cascade-inspector / lab-inspector / keeper-reactivity-monitor / config-resolution-panel) | **56/56 passed** |
| `pnpm build` | 성공 (10.51s) |
| LoC | **−14 / +2** |

## 검토 후보 (이 PR 미포함)

추가 grep에서 일부 검토 후보 발견했으나 보존:
- `keeper-detail-shell.ts` summary들 (4개) — 빠른 이동 카드 navigation aid (RFC-0046에서 의도적으로 보존)
- `agent-roster.ts:211 paused.description` 등 FILTER_META — filter chip 짧은 hint
- `transport-health.ts:582, 630` — technical hint + reference disclaimer
- `goals/planning.ts:222` — empty state headline
- `lab-inspector.ts:32` — navigation card description (target tab guidance)

이들은 *functional information carrier*라 별도 토론 후 판단.

## RFC 발견 체크
- 변경 영역: `dashboard/src/components/` only — RFC required subsystem 미수정.

## ⚠️ Draft 유지 요청
agent-authored — `human-approved-ready` 라벨 후 ready.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>