### PR TITLE
feat(keeper): RFC-0047 PR-2 — add disposition field (additive, derived from code)

### DIFF
--- a/lib/keeper/keeper_turn_terminal.ml
+++ b/lib/keeper/keeper_turn_terminal.ml
@@ -8,6 +8,14 @@ type severity =
 
 type t =
   { code : string
+  ; disposition : Keeper_turn_disposition.t
+    (** RFC-0047 PR-2: typed operator-facing disposition. Always
+          equals [Keeper_turn_disposition.of_wire code] after the
+          producer-side [normalize_code]; this PR does not change
+          producers, so the field is derived. PR-3 will swap
+          [severity / summary / next_action] derivation to use
+          [disposition] directly (exhaustive match, no substring
+          classifier) and remove the [code: string] field. *)
   ; source : string
   ; severity : severity
   ; summary : string
@@ -19,167 +27,161 @@ let severity_to_string = function
   | Warn -> "warn"
   | Bad -> "bad"
   | Unknown_bad -> "bad"
+;;
 
 let severity_of_code = function
   | "success" -> Ok
   | "external_cancel"
   | "oas_timeout_budget"
   | "turn_wall_clock_timeout"
-  | "gh_repo_context_missing_worktree" ->
-      Warn
+  | "gh_repo_context_missing_worktree" -> Warn
   | "required_tool_use_no_tool_call"
   | "required_tool_use_unsatisfied"
   | "post_commit_ambiguous"
   | "provider_error"
-  | "unknown_error" ->
-      Bad
+  | "unknown_error" -> Bad
   | code when String.starts_with ~prefix:"api_error_" code -> Bad
   | _unknown -> Unknown_bad
+;;
 
 let summary_of_code = function
   | "success" -> "turn completed"
   | "required_tool_use_no_tool_call" ->
-      "required keeper tool use was requested, but the model returned no keeper tool call"
+    "required keeper tool use was requested, but the model returned no keeper tool call"
   | "required_tool_use_unsatisfied" ->
-      "required keeper tool use was requested, but the tool contract was not satisfied"
+    "required keeper tool use was requested, but the tool contract was not satisfied"
   | "gh_repo_context_missing_worktree" ->
-      "GitHub command blocked because the active task has no linked worktree"
+    "GitHub command blocked because the active task has no linked worktree"
   | "oas_timeout_budget" ->
-      "OAS call was skipped or failed because the turn timeout budget was exhausted"
-  | "turn_wall_clock_timeout" ->
-      "keeper turn hit the wall-clock timeout"
-  | "external_cancel" ->
-      "keeper turn was cancelled before completion"
+    "OAS call was skipped or failed because the turn timeout budget was exhausted"
+  | "turn_wall_clock_timeout" -> "keeper turn hit the wall-clock timeout"
+  | "external_cancel" -> "keeper turn was cancelled before completion"
   | "post_commit_ambiguous" ->
-      "provider failed after a mutating tool may have committed side effects"
-  | "provider_error" ->
-      "provider or cascade failed"
-  | "unknown_error" ->
-      "keeper turn failed without a classified terminal reason"
-  | code ->
-      Printf.sprintf "keeper turn ended with %s" code
+    "provider failed after a mutating tool may have committed side effects"
+  | "provider_error" -> "provider or cascade failed"
+  | "unknown_error" -> "keeper turn failed without a classified terminal reason"
+  | code -> Printf.sprintf "keeper turn ended with %s" code
+;;
 
 let next_action_of_code = function
-  | "required_tool_use_no_tool_call"
-  | "required_tool_use_unsatisfied" ->
-      Some "inspect_provider_tool_contract"
-  | "gh_repo_context_missing_worktree" ->
-      Some "create_or_link_worktree"
-  | "oas_timeout_budget"
-  | "turn_wall_clock_timeout" ->
-      Some "inspect_timeout_budget"
-  | "external_cancel" ->
-      Some "rerun_if_still_relevant"
-  | "post_commit_ambiguous" ->
-      Some "reconcile_partial_commit"
-  | "provider_error"
-  | "unknown_error" ->
-      Some "inspect_latest_error"
+  | "required_tool_use_no_tool_call" | "required_tool_use_unsatisfied" ->
+    Some "inspect_provider_tool_contract"
+  | "gh_repo_context_missing_worktree" -> Some "create_or_link_worktree"
+  | "oas_timeout_budget" | "turn_wall_clock_timeout" -> Some "inspect_timeout_budget"
+  | "external_cancel" -> Some "rerun_if_still_relevant"
+  | "post_commit_ambiguous" -> Some "reconcile_partial_commit"
+  | "provider_error" | "unknown_error" -> Some "inspect_latest_error"
   | _ -> None
+;;
 
 let normalize_code = function
   | "completed" -> "success"
-  | "completion_contract_violation:require_tool_use" ->
-      "required_tool_use_unsatisfied"
+  | "completion_contract_violation:require_tool_use" -> "required_tool_use_unsatisfied"
   | "api_error_timeout" -> "provider_error"
   | code -> code
+;;
 
 let make ?(source = "typed") ?summary ?next_action code =
   let code = normalize_code code in
+  let disposition = Keeper_turn_disposition.of_wire code in
   let summary = Option.value ~default:(summary_of_code code) summary in
   let next_action =
     match next_action with
     | Some _ as value -> value
     | None -> next_action_of_code code
   in
-  { code; source; severity = severity_of_code code; summary; next_action }
+  { code; disposition; source; severity = severity_of_code code; summary; next_action }
+;;
 
 let success () = make ~source:"turn_result" "success"
-
-let contains_ci text needle =
-  String_util.contains_substring_ci text needle
+let contains_ci text needle = String_util.contains_substring_ci text needle
 
 let contract_code_from_error_text raw_error =
-  if contains_ci raw_error "no ToolUse block"
-     || contains_ci raw_error "called no keeper tools"
-     || contains_ci raw_error "returned no keeper tool"
+  if
+    contains_ci raw_error "no ToolUse block"
+    || contains_ci raw_error "called no keeper tools"
+    || contains_ci raw_error "returned no keeper tool"
   then "required_tool_use_no_tool_call"
   else "required_tool_use_unsatisfied"
+;;
 
 let of_legacy_error_text raw_error =
   let trimmed = String.trim raw_error in
-  if trimmed = "" then make ~source:"legacy_error_text" "unknown_error"
-  else if contains_ci trimmed "gh_repo_context_missing_worktree" then
-    make ~source:"legacy_error_text" "gh_repo_context_missing_worktree"
-  else if contains_ci trimmed "oas_timeout_budget" then
-    make ~source:"legacy_error_text" "oas_timeout_budget"
-  else if contains_ci trimmed "Turn wall-clock timeout" then
-    make ~source:"legacy_error_text" "turn_wall_clock_timeout"
-  else if contains_ci trimmed "require_tool_use" then
-    make ~source:"legacy_error_text" (contract_code_from_error_text trimmed)
-  else
-    make ~source:"legacy_error_text" "unknown_error"
+  if trimmed = ""
+  then make ~source:"legacy_error_text" "unknown_error"
+  else if contains_ci trimmed "gh_repo_context_missing_worktree"
+  then make ~source:"legacy_error_text" "gh_repo_context_missing_worktree"
+  else if contains_ci trimmed "oas_timeout_budget"
+  then make ~source:"legacy_error_text" "oas_timeout_budget"
+  else if contains_ci trimmed "Turn wall-clock timeout"
+  then make ~source:"legacy_error_text" "turn_wall_clock_timeout"
+  else if contains_ci trimmed "require_tool_use"
+  then make ~source:"legacy_error_text" (contract_code_from_error_text trimmed)
+  else make ~source:"legacy_error_text" "unknown_error"
+;;
 
-let of_failure ?(post_commit_ambiguous = false) ?(tool_call_count = 0)
-    ~raw_error err =
-  if post_commit_ambiguous then
-    make ~source:"typed_error" "post_commit_ambiguous"
-  else
+let of_failure ?(post_commit_ambiguous = false) ?(tool_call_count = 0) ~raw_error err =
+  if post_commit_ambiguous
+  then make ~source:"typed_error" "post_commit_ambiguous"
+  else (
     match Oas_worker_named.classify_masc_internal_error err with
     | Some (Oas_worker_named.Oas_timeout_budget _) ->
-        make ~source:"typed_error" "oas_timeout_budget"
+      make ~source:"typed_error" "oas_timeout_budget"
     | Some (Oas_worker_named.Turn_timeout _) ->
-        make ~source:"typed_error" "turn_wall_clock_timeout"
+      make ~source:"typed_error" "turn_wall_clock_timeout"
     | _ ->
-        (match err with
-         | Agent_sdk.Error.Agent
-             (Agent_sdk.Error.CompletionContractViolation
-                { contract = Agent_sdk.Completion_contract_id.Require_tool_use; _ }) ->
-             let code =
-               if tool_call_count <= 0 then
-                 contract_code_from_error_text raw_error
-               else
-                 "required_tool_use_unsatisfied"
-             in
-             make ~source:"typed_error" code
-         | _ ->
-             let fallback = of_legacy_error_text raw_error in
-             if String.equal fallback.code "unknown_error" then
-               make ~source:"typed_error"
-                 (Keeper_agent_error.terminal_reason_code_of_sdk_error err)
-             else
-               fallback)
+      (match err with
+       | Agent_sdk.Error.Agent
+           (Agent_sdk.Error.CompletionContractViolation
+              { contract = Agent_sdk.Completion_contract_id.Require_tool_use; _ }) ->
+         let code =
+           if tool_call_count <= 0
+           then contract_code_from_error_text raw_error
+           else "required_tool_use_unsatisfied"
+         in
+         make ~source:"typed_error" code
+       | _ ->
+         let fallback = of_legacy_error_text raw_error in
+         if String.equal fallback.code "unknown_error"
+         then
+           make
+             ~source:"typed_error"
+             (Keeper_agent_error.terminal_reason_code_of_sdk_error err)
+         else fallback))
+;;
 
 let of_code ?source ?summary ?next_action code =
   let source = Option.value ~default:"legacy_code" source in
   make ~source ?summary ?next_action code
+;;
 
 let to_json reason =
   `Assoc
-    [ ("code", `String reason.code)
-    ; ("source", `String reason.source)
-    ; ("severity", `String (severity_to_string reason.severity))
-    ; ("summary", `String reason.summary)
-    ; ( "next_action",
-        match reason.next_action with
+    [ "code", `String reason.code
+    ; "source", `String reason.source
+    ; "severity", `String (severity_to_string reason.severity)
+    ; "summary", `String reason.summary
+    ; ( "next_action"
+      , match reason.next_action with
         | Some action -> `String action
         | None -> `Null )
     ]
+;;
 
 let string_member key = function
-  | `Assoc fields -> (
-      match List.assoc_opt key fields with
-      | Some (`String value) when String.trim value <> "" -> Some value
-      | _ -> None)
+  | `Assoc fields ->
+    (match List.assoc_opt key fields with
+     | Some (`String value) when String.trim value <> "" -> Some value
+     | _ -> None)
   | _ -> None
+;;
 
 let of_json json =
   match string_member "code" json with
   | None -> None
   | Some code ->
-      let source =
-        string_member "source" json |> Option.value ~default:"decision_log"
-      in
-      let summary = string_member "summary" json in
-      let next_action = string_member "next_action" json in
-      Some (of_code ~source ?summary ?next_action code)
+    let source = string_member "source" json |> Option.value ~default:"decision_log" in
+    let summary = string_member "summary" json in
+    let next_action = string_member "next_action" json in
+    Some (of_code ~source ?summary ?next_action code)
+;;

--- a/lib/keeper/keeper_turn_terminal.mli
+++ b/lib/keeper/keeper_turn_terminal.mli
@@ -8,6 +8,12 @@ type severity =
 
 type t =
   { code : string
+  ; disposition : Keeper_turn_disposition.t
+    (** RFC-0047 PR-2: typed operator-facing disposition. Derived
+          from [code] via [Keeper_turn_disposition.of_wire] at
+          construction time. PR-3 swaps
+          [severity / summary / next_action] derivation to be
+          exhaustive on this field and removes [code: string]. *)
   ; source : string
   ; severity : severity
   ; summary : string
@@ -15,20 +21,16 @@ type t =
   }
 
 val severity_to_string : severity -> string
-
 val success : unit -> t
-
 val of_code : ?source:string -> ?summary:string -> ?next_action:string -> string -> t
 
-val of_failure :
-  ?post_commit_ambiguous:bool ->
-  ?tool_call_count:int ->
-  raw_error:string ->
-  Agent_sdk.Error.sdk_error ->
-  t
+val of_failure
+  :  ?post_commit_ambiguous:bool
+  -> ?tool_call_count:int
+  -> raw_error:string
+  -> Agent_sdk.Error.sdk_error
+  -> t
 
 val of_legacy_error_text : string -> t
-
 val to_json : t -> Yojson.Safe.t
-
 val of_json : Yojson.Safe.t -> t option

--- a/test/dune
+++ b/test/dune
@@ -30,6 +30,7 @@
         test_keeper_sdk_error_typed_bridge
         test_read_drop_reason
         test_keeper_turn_disposition
+        test_keeper_turn_terminal_disposition_field
         test_attempt_state
         test_sse test_graphql_api
         test_graphql_endpoint
@@ -264,6 +265,7 @@
           test_keeper_sdk_error_typed_bridge
           test_read_drop_reason
           test_keeper_turn_disposition
+          test_keeper_turn_terminal_disposition_field
           test_attempt_state
           test_sse test_graphql_api
           test_graphql_endpoint

--- a/test/test_keeper_turn_terminal_disposition_field.ml
+++ b/test/test_keeper_turn_terminal_disposition_field.ml
@@ -1,0 +1,92 @@
+(** RFC-0047 PR-2 invariant: every [Keeper_turn_terminal.t]
+    constructed via the public surface populates [disposition]
+    consistently with the legacy [code] string field, i.e.
+
+      t.disposition = Keeper_turn_disposition.of_wire t.code
+
+    PR-3 swaps the consumer side ([severity / summary / next_action])
+    to read [disposition] directly; this PR establishes the
+    invariant. *)
+
+module T = Masc_mcp.Keeper_turn_terminal
+module D = Masc_mcp.Keeper_turn_disposition
+
+let check_invariant label (t : T.t) =
+  let expected = D.of_wire t.code in
+  Alcotest.(check bool)
+    (Printf.sprintf "%s: disposition derived from code" label)
+    true
+    (D.equal expected t.disposition)
+;;
+
+(* Cover every public constructor + every code path through
+   [normalize_code]. *)
+let constructor_cases : (string * T.t) list =
+  [ "success", T.success ()
+  ; "of_code/explicit", T.of_code "post_commit_ambiguous"
+  ; "of_code/normalize/completed", T.of_code "completed"
+  ; ( "of_code/normalize/contract_violation"
+    , T.of_code "completion_contract_violation:require_tool_use" )
+  ; "of_code/normalize/api_error_timeout", T.of_code "api_error_timeout"
+  ; "of_code/api_error_overloaded", T.of_code "api_error_overloaded"
+  ; ( "of_code/agent_error_max_turns"
+    , T.of_code "agent_error_max_turns_exceeded:turns=10,limit=10" )
+  ; "of_code/unknown", T.of_code "totally_unmapped"
+  ; "of_legacy_error_text/empty", T.of_legacy_error_text ""
+  ; ( "of_legacy_error_text/gh_repo"
+    , T.of_legacy_error_text "gh_repo_context_missing_worktree" )
+  ; "of_legacy_error_text/oas_timeout", T.of_legacy_error_text "oas_timeout_budget"
+  ; ( "of_legacy_error_text/turn_wall_clock"
+    , T.of_legacy_error_text "Turn wall-clock timeout fired" )
+  ; ( "of_legacy_error_text/require_tool_use"
+    , T.of_legacy_error_text "called no keeper tools and require_tool_use was set" )
+  ]
+;;
+
+let test_invariant () =
+  List.iter (fun (label, t) -> check_invariant label t) constructor_cases
+;;
+
+let test_of_failure_post_commit_ambiguous () =
+  (* of_failure with post_commit_ambiguous=true short-circuits to a
+     specific code regardless of the SDK error. *)
+  let err = Agent_sdk.Error.Internal "x" in
+  let t = T.of_failure ~post_commit_ambiguous:true ~raw_error:"" err in
+  check_invariant "of_failure/post_commit_ambiguous" t
+;;
+
+let test_to_json_keeps_code_field () =
+  (* Wire stability: PR-2 must not change the JSON field set. *)
+  let t = T.of_code "success" in
+  let json = T.to_json t in
+  match json with
+  | `Assoc fields ->
+    let keys = List.map fst fields |> List.sort String.compare in
+    Alcotest.(check (list string))
+      "JSON fields unchanged"
+      [ "code"; "next_action"; "severity"; "source"; "summary" ]
+      keys
+  | _ -> Alcotest.fail "expected JSON object"
+;;
+
+let () =
+  Alcotest.run
+    "keeper_turn_terminal_disposition_field"
+    [ ( "PR-2 invariant: disposition derived from code"
+      , [ Alcotest.test_case
+            "every public constructor preserves invariant"
+            `Quick
+            test_invariant
+        ; Alcotest.test_case
+            "of_failure/post_commit_ambiguous preserves invariant"
+            `Quick
+            test_of_failure_post_commit_ambiguous
+        ] )
+    ; ( "wire stability"
+      , [ Alcotest.test_case
+            "to_json field set unchanged"
+            `Quick
+            test_to_json_keeps_code_field
+        ] )
+    ]
+;;


### PR DESCRIPTION
## Goal

Second step of RFC-0047. Add the typed [disposition] field to
[Keeper_turn_terminal.t], derived from [code] at construction time.
PR-3 will swap the [severity / summary / next_action] consumers from
code-based substring classifiers to disposition-based exhaustive
matches.

## Why additive (Approach A)

PR-2 carries no producer migration and no consumer swap. It only
introduces the field and locks the invariant
\`t.disposition = Keeper_turn_disposition.of_wire t.code\`. This
keeps PR-2 small, revertable, and decouples from PR-3's larger
substring-classifier removal sweep.

## What changed

| File | Δ |
|---|---|
| \`lib/keeper/keeper_turn_terminal.ml/.mli\` | New \`disposition : Keeper_turn_disposition.t\` field. \`make\` constructor derives via \`Keeper_turn_disposition.of_wire (normalize_code code)\`. All 4 public constructors (\`success\`, \`of_code\`, \`of_legacy_error_text\`, \`of_failure\`) flow through \`make\`. |
| \`test/test_keeper_turn_terminal_disposition_field.ml\` | NEW. 3 cases: invariant across 13 constructor inputs, \`of_failure\` short-circuit, JSON wire stability. |
| \`test/dune\` | Register the new test binary. |

## Verification

\`\`\`
$ MASC_SKIP_PIN_CHECK=1 bash scripts/dune-local.sh build  # OK
$ bash scripts/dune-local.sh exec test/test_keeper_turn_terminal_disposition_field.exe
  [OK]  PR-2 invariant: disposition derived from code  0  every public constructor preserves invariant
  [OK]                                                  1  of_failure/post_commit_ambiguous preserves invariant
  [OK]  wire stability                                  0  to_json field set unchanged
Test Successful in 0.000s. 3 tests run.
\`\`\`

## Wire stability

- JSON \`code\` field: byte-for-byte preserved.
- JSON field set: unchanged (\`code\`, \`source\`, \`severity\`,
  \`summary\`, \`next_action\` — same 5 keys).
- Internal \`severity\` / \`summary\` / \`next_action\`: unchanged
  (still derived via legacy substring helpers; PR-3 swaps them).

## Anti-pattern self-check (\`software-development.md §워크어라운드 거부 기준\`)

- [ ] ❌ Telemetry-as-fix — N/A
- [ ] ❌ String/substring classifier — *unchanged* in this PR
      (\`severity_of_code\` / \`summary_of_code\` /
      \`next_action_of_code\` still substring-based). PR-3 deletes them.
- [ ] ❌ N-of-M patch — additive, no migration sweep. PR-3 is the
      sweep.
- [ ] ❌ catch-all — N/A
- [ ] ❌ cap/cooldown/dedup/repair — N/A

## Out of scope

- PR-3: swap \`severity / summary / next_action\` from code-based to
  disposition-based exhaustive matches. Remove \`code: string\` field.
  Add \`scripts/lint/no-free-unknown-disposition.sh\` guard.
- Optional \`of_disposition : Keeper_turn_disposition.t -> t\` typed
  constructor. PR-2 derives so producers don't need to change yet.

## Sequence position

\`\`\`
RFC-0047 docs (#14232, MERGED)            : design + 3-PR plan
RFC-0047 PR-1 inert (#14234, MERGED)      : Keeper_turn_disposition module
RFC-0047 PR-2 (this PR)                   : add disposition field (additive)
RFC-0047 PR-3 (next)                      : swap consumers + remove code field + lint
\`\`\`