### PR TITLE
chore(dashboard): purge dead 'legacy' section from lab tab

### DIFF
--- a/dashboard/src/components/lab.ts
+++ b/dashboard/src/components/lab.ts
@@ -1,45 +1,18 @@
 import { html } from 'htm/preact'
 import { route } from '../router'
-import { Card, SectionCard } from './common/card'
+import { Card } from './common/card'
 import { Tools } from './tools'
 import { Autoresearch } from './autoresearch'
 import { HarnessHealth } from './harness-health'
-import { severityToneClass } from './overview/overview'
-import type { OperatorAttentionItem } from '../types/dashboard-mission'
 
-type LabSection = 'tools' | 'autoresearch' | 'harness' | 'legacy'
+type LabSection = 'tools' | 'autoresearch' | 'harness'
 
 function currentSection(): LabSection {
   const section = route.value.params.section
-  if (section === 'autoresearch' || section === 'harness' || section === 'legacy') {
+  if (section === 'autoresearch' || section === 'harness') {
     return section
   }
   return 'tools'
-}
-
-// ─── Highlight (Moved from Overview Item 2) ───────────────────────────────────
-
-function Highlight({ attention }: { attention: OperatorAttentionItem | null }) {
-  if (!attention) {
-    return html`
-      <${SectionCard} title="Legacy Highlight" data-testid="overview-highlight-empty">
-        <p class="text-2xs text-[var(--color-fg-muted)] italic">No critical attention items (Preview Mode)</p>
-      <//>
-    `
-  }
-  return html`
-    <${SectionCard} title="Legacy Highlight" data-testid="overview-highlight">
-      <div class="flex items-center gap-3">
-        <span class="flex-shrink-0 flex h-2 w-2 rounded-full bg-[var(--color-status-err)] animate-pulse" />
-        <div class="flex-1 min-w-0">
-          <p class="text-xs font-medium truncate ${severityToneClass(attention.severity)}">${attention.summary}</p>
-          <p class="text-2xs text-[var(--color-fg-secondary)] truncate">
-            ${attention.actor ?? attention.target_id ?? attention.target_type}
-          </p>
-        </div>
-      </div>
-    <//>
-  `
 }
 
 export function Lab() {
@@ -59,18 +32,6 @@ export function Lab() {
 
       ${section === 'harness' ? html`
         <${HarnessHealth} />
-      ` : null}
-
-      ${section === 'legacy' ? html`
-        <div class="space-y-4">
-          <header class="flex items-center justify-between">
-            <h2 class="text-sm font-bold uppercase tracking-wider text-[var(--color-fg-muted)]">Legacy / Hidden Widgets</h2>
-          </header>
-          <${Highlight} attention=${null} />
-          <p class="text-2xs text-[var(--color-fg-muted)] italic">
-            This widget was removed from the main Overview tab to reduce clutter.
-          </p>
-        </div>
       ` : null}
     </div>
   `


### PR DESCRIPTION
## 요약

사용자 본 dashboard 첫 메시지의 *"죽은기능, 상태, 이제는 무의미가 된 정보"*에 정확히 해당하는 dead UI surface 발견. lab tab의 `legacy` section은:

1. **사이드바에 등록 안 됨** — `config/navigation.ts`의 `lab` sections 배열에 없음. 운영자는 URL을 직접 `?section=legacy`로 편집해야만 도달 가능. 사실상 unreachable.
2. **`Highlight` 컴포넌트가 `attention=${null}`로 hardcoded** (line 69) — 항상 empty branch만 그림: *"No critical attention items (Preview Mode)"* + *"This widget was removed from the main Overview tab to reduce clutter."*
3. **워크어라운드 누적 패턴**: "Overview에서 제거했지만 lab에 보존" 자체가 미래 PR이 *합리적 선례*로 학습할 수 있는 안티패턴. PR #14219에서 keeper detail의 같은 shape (meta-tour text) 제거한 정신과 동형.

## 변경

- `LabSection` type의 `'legacy'` 제거
- `currentSection()` 의 legacy fallthrough 제거  
- `Highlight` 컴포넌트 + `${section === 'legacy' ? ...}` 렌더링 분기 제거
- 미사용 import 4개: `severityToneClass`, `OperatorAttentionItem`, `SectionCard` 제거

## 검증

| 검사 | 결과 |
|---|---|
| `pnpm typecheck` | lab.ts 0 새 에러 |
| `pnpm build` | 성공 (9.96s) |
| LoC | **−42 / +3** (실제 −58 line, 일부 import 줄임) |

## RFC 발견 체크
- 변경 영역: `dashboard/src/components/lab.ts` only.

## ⚠️ Draft 유지 요청
agent-authored — `human-approved-ready` 라벨 후 ready.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>