### PR TITLE
feat(exec): RFC-0005 Week 3 — GADT Shell IR prototype

### DIFF
--- a/lib/exec/approval_policy_typed.ml
+++ b/lib/exec/approval_policy_typed.ml
@@ -1,0 +1,16 @@
+(** Approval_policy_typed — GADT-based policy decision.
+
+    Thin wrapper around [Approval_policy.decide]: the GADT gives us a
+    total capability extractor, but the rule cascade (destructive-git
+    check, write-escape check, trust-level dispatch) is intentionally
+    reused without duplication. *)
+
+let decide ~config ~actor cmd raw_simple =
+  let overlay = Approval_config.lookup config ~actor in
+  let caps = Capability_check_typed.of_command cmd in
+  Approval_policy.decide
+    { Approval_policy.raw_source = Bin.to_string raw_simple.Shell_ir.bin;
+      summary = "Typed dispatch" }
+    ~overlay
+    ~caps
+    ~simple:raw_simple

--- a/lib/exec/approval_policy_typed.mli
+++ b/lib/exec/approval_policy_typed.mli
@@ -1,0 +1,18 @@
+(** Approval_policy_typed — GADT-based policy decision.
+
+    Bridges the typed IR back to the existing approval policy by
+    1. extracting capabilities via [Capability_check_typed],
+    2. looking up the agent overlay in [Approval_config],
+    3. delegating to [Approval_policy.decide] with the reconstructed
+       capability list and the original [Shell_ir.simple].
+
+    The typed command is used for capability extraction; the untyped
+    [Shell_ir.simple] is retained so that [Verdict.trust] can mint a
+    [Trusted_argv.t] carrying the original env / cwd / redirects. *)
+
+val decide :
+  config:Approval_config.t ->
+  actor:Agent_id.t ->
+  Shell_ir_typed.wrapped ->
+  Shell_ir.simple ->
+  Verdict.t

--- a/lib/exec/capability_check_typed.ml
+++ b/lib/exec/capability_check_typed.ml
@@ -1,0 +1,71 @@
+(** Capability_check_typed — GADT-based capability derivation.
+
+    Each arm reconstructs the [Shell_ir.arg list] that the untyped walker
+    would have produced, then wraps it in [Capability.Exec_bin].  This
+    keeps the capability model unchanged while making the walker indexed
+    by the GADT. *)
+
+let arg s = Shell_ir.Lit s
+
+let args_of_flags flags =
+  List.map (function
+    | `Long -> arg "-l"
+    | `All -> arg "-a"
+    | `Human -> arg "-h") flags
+
+let of_command = function
+  | Shell_ir_typed.W (Ls { path; flags }) ->
+    let args = args_of_flags flags @ (match path with None -> [] | Some p -> [arg p]) in
+    [Capability.Exec_bin (Result.get_ok (Bin.of_string "ls"), args)]
+  | Shell_ir_typed.W (Cat { path }) ->
+    [Capability.Exec_bin (Result.get_ok (Bin.of_string "cat"), [arg path])]
+  | Shell_ir_typed.W (Rg { pattern; path; case_sensitive }) ->
+    let args =
+      (if case_sensitive then [] else [arg "-i"])
+      @ [arg pattern]
+      @ (match path with None -> [] | Some p -> [arg p])
+    in
+    [Capability.Exec_bin (Result.get_ok (Bin.of_string "rg"), args)]
+  | Shell_ir_typed.W (Git_status { short }) ->
+    let args = arg "status" :: (if short then [arg "-s"] else []) in
+    [Capability.Exec_bin (Result.get_ok (Bin.of_string "git"), args)]
+  | Shell_ir_typed.W (Git_clone { repo; branch; depth }) ->
+    let args =
+      arg "clone"
+      :: (if depth <> 1 then [arg "--depth"; arg (string_of_int depth)] else [])
+      @ (match branch with None -> [] | Some b -> [arg "-b"; arg b])
+      @ [arg repo]
+    in
+    [Capability.Exec_bin (Result.get_ok (Bin.of_string "git"), args)]
+  | Shell_ir_typed.W (Curl { url; method_; headers; body }) ->
+    let method_args =
+      match method_ with
+      | `GET -> []
+      | `POST -> [arg "-X"; arg "POST"]
+      | `PUT -> [arg "-X"; arg "PUT"]
+      | `DELETE -> [arg "-X"; arg "DELETE"]
+    in
+    let header_args =
+      match headers with
+      | None -> []
+      | Some hs ->
+        List.concat_map (fun (k, v) -> [arg "-H"; arg (k ^ ": " ^ v)]) hs
+    in
+    let body_args =
+      match body with
+      | None -> []
+      | Some d -> [arg "-d"; arg d]
+    in
+    let args = method_args @ header_args @ body_args @ [arg url] in
+    [Capability.Exec_bin (Result.get_ok (Bin.of_string "curl"), args)]
+  | Shell_ir_typed.W (Rm { paths; recursive; force }) ->
+    let flag_args =
+      (if recursive then [arg "-r"] else [])
+      @ (if force then [arg "-f"] else [])
+    in
+    [Capability.Exec_bin (Result.get_ok (Bin.of_string "rm"),
+                          flag_args @ List.map arg paths)]
+  | Shell_ir_typed.W (Sudo { target }) ->
+    let args = List.map arg (String.split_on_char ' ' target) in
+    [Capability.Exec_bin (Result.get_ok (Bin.of_string "sudo"), args)]
+  | Shell_ir_typed.W (Generic s) -> Capability_check.of_simple s

--- a/lib/exec/capability_check_typed.ml
+++ b/lib/exec/capability_check_typed.ml
@@ -3,7 +3,16 @@
     Each arm reconstructs the [Shell_ir.arg list] that the untyped walker
     would have produced, then wraps it in [Capability.Exec_bin].  This
     keeps the capability model unchanged while making the walker indexed
-    by the GADT. *)
+    by the GADT.
+
+    Env / redirect handling: typed constructors do not carry [env] or
+    [redirects], so [Shell_ir_typed.of_simple] forces the [Generic]
+    fallback whenever the source [simple] has either set.  That keeps
+    redirect-derived [Read_path] / [Write_path] and [Env_set]
+    capabilities flowing through [Capability_check.of_simple] for the
+    [Generic] arm below — without this any redirect outside the
+    worktree would be invisible to [Approval_policy.find_write_escape]
+    on a parsed command. *)
 
 let arg s = Shell_ir.Lit s
 
@@ -65,7 +74,7 @@ let of_command = function
     in
     [Capability.Exec_bin (Result.get_ok (Bin.of_string "rm"),
                           flag_args @ List.map arg paths)]
-  | Shell_ir_typed.W (Sudo { target }) ->
-    let args = List.map arg (String.split_on_char ' ' target) in
+  | Shell_ir_typed.W (Sudo { target_argv }) ->
+    let args = List.map arg target_argv in
     [Capability.Exec_bin (Result.get_ok (Bin.of_string "sudo"), args)]
   | Shell_ir_typed.W (Generic s) -> Capability_check.of_simple s

--- a/lib/exec/capability_check_typed.mli
+++ b/lib/exec/capability_check_typed.mli
@@ -1,0 +1,10 @@
+(** Capability_check_typed — GADT-based capability derivation.
+
+    Unlike [Capability_check.of_simple] which walks an untyped [Shell_ir.t]
+    and re-parses literal arguments, this module extracts capabilities
+    directly from a typed command where the constructor already encodes the
+    operation semantics.  The result is identical to the untyped walker
+    for well-formed commands, but the extraction is total (no [None]
+    fallthrough) because the GADT constructor guarantees the shape. *)
+
+val of_command : Shell_ir_typed.wrapped -> Capability.t list

--- a/lib/exec/risk_classifier_typed.ml
+++ b/lib/exec/risk_classifier_typed.ml
@@ -1,0 +1,7 @@
+(** Risk_classifier_typed — GADT-based risk classification.
+
+    Exhaustive match on the GADT.  Adding a new constructor forces an arm
+    here, so the risk mapping can never silently default to a wrong class. *)
+
+let of_command (cmd : Shell_ir_typed.wrapped) : Bin.risk_class =
+  (Shell_ir_typed.risk cmd :> Bin.risk_class)

--- a/lib/exec/risk_classifier_typed.mli
+++ b/lib/exec/risk_classifier_typed.mli
@@ -1,0 +1,7 @@
+(** Risk_classifier_typed — GADT-based risk classification.
+
+    The risk level is already encoded in the GADT parameter ['r]; this
+    module projects it back to the external [Bin.risk_class] type so that
+    the approval policy can consume it without knowing about the GADT. *)
+
+val of_command : Shell_ir_typed.wrapped -> Bin.risk_class

--- a/lib/exec/shell_ir_typed.ml
+++ b/lib/exec/shell_ir_typed.ml
@@ -50,7 +50,12 @@ and (_, _, _, _) command =
     } -> (unit, unit, [ `Privileged ], [ `Host ]) command
 
   | Sudo : {
-      target : string;
+      target_argv : string list;
+        (** Tokenized argv to be passed to [sudo].  Stored as a list
+            (not a space-joined string) so that arguments containing
+            spaces — e.g. [sudo sh -c "echo hi"] — round-trip cleanly
+            through [to_simple] and [Capability_check_typed.of_command]
+            without being re-split on whitespace. *)
     } -> (unit, string, [ `Privileged ], [ `Host ]) command
 
   | Generic : Shell_ir.simple ->
@@ -210,34 +215,64 @@ let parse_rm (args : string list) : wrapped option =
 let parse_sudo (args : string list) : wrapped option =
   match args with
   | [] -> None
-  | args -> Some (W (Sudo { target = String.concat " " args }))
+  | args -> Some (W (Sudo { target_argv = args }))
 
 (* ---------------------------------------------------------------------- *)
-(* of_simple *)
+(* of_simple
+ *
+ * Fail-closed: anything we cannot lift into a specific constructor
+ * falls through to [W (Generic s)], which the [risk] extractor pins
+ * to [`Privileged] and which [Capability_check_typed.of_command]
+ * routes back to the untyped [Capability_check.of_simple] so that
+ * env, redirect (Read_path / Write_path) and head capabilities are
+ * preserved.  Never returning [None] removes a silent "no typed
+ * command" outcome that callers could mishandle.
+ *
+ * Conditions that force the Generic fallback:
+ *   - any non-literal arg (Var / Concat) — typed grammar only
+ *     covers literal argv;
+ *   - a non-empty [env] or [redirects] list — typed constructors
+ *     do not carry env/redirect state, so retaining the original
+ *     simple is the only way to keep the [Approval_policy] hooks
+ *     (e.g. [find_write_escape]) wired correctly;
+ *   - any binary kind we do not yet have a dedicated parser for
+ *     (Docker, Ssh, Other_audited, unknown Safe / Privileged
+ *     binaries) or sub-command we did not match (e.g. [git push]). *)
 
-let of_simple (s : Shell_ir.simple) : wrapped option =
-  match all_lits_opt s.Shell_ir.args with
-  | None -> None
-  | Some lit_argv ->
-    match Bin.kind s.Shell_ir.bin with
-    | `Safe_bin ->
-      (match Bin.to_string s.Shell_ir.bin with
-       | "ls" -> parse_ls lit_argv
-       | "cat" -> parse_cat lit_argv
-       | "rg" -> parse_rg lit_argv
-       | _ -> None)
-    | `Git ->
-      (match lit_argv with
-       | "status" :: rest -> parse_git_status rest
-       | "clone" :: rest -> parse_git_clone rest
-       | _ -> None)
-    | `Curl -> parse_curl lit_argv
-    | `Privileged_bin ->
-      (match Bin.to_string s.Shell_ir.bin with
-       | "rm" -> parse_rm lit_argv
-       | "sudo" -> parse_sudo lit_argv
-       | _ -> None)
-    | `Docker | `Ssh | `Other_audited -> None
+let typed_carries_no_extras (s : Shell_ir.simple) : bool =
+  s.Shell_ir.env = [] && s.Shell_ir.redirects = []
+
+let of_simple (s : Shell_ir.simple) : wrapped =
+  let generic () = W (Generic s) in
+  if not (typed_carries_no_extras s) then generic ()
+  else
+    match all_lits_opt s.Shell_ir.args with
+    | None -> generic ()
+    | Some lit_argv ->
+      let parsed : wrapped option =
+        match Bin.kind s.Shell_ir.bin with
+        | `Safe_bin ->
+          (match Bin.to_string s.Shell_ir.bin with
+           | "ls" -> parse_ls lit_argv
+           | "cat" -> parse_cat lit_argv
+           | "rg" -> parse_rg lit_argv
+           | _ -> None)
+        | `Git ->
+          (match lit_argv with
+           | "status" :: rest -> parse_git_status rest
+           | "clone" :: rest -> parse_git_clone rest
+           | _ -> None)
+        | `Curl -> parse_curl lit_argv
+        | `Privileged_bin ->
+          (match Bin.to_string s.Shell_ir.bin with
+           | "rm" -> parse_rm lit_argv
+           | "sudo" -> parse_sudo lit_argv
+           | _ -> None)
+        | `Docker | `Ssh | `Other_audited -> None
+      in
+      match parsed with
+      | Some w -> w
+      | None -> generic ()
 
 (* ---------------------------------------------------------------------- *)
 (* to_simple *)
@@ -324,9 +359,9 @@ let to_simple : type i o r s. (i, o, r, s) command -> Shell_ir.simple =
       args = List.map arg_of_string (flag_args @ paths);
       env = []; cwd = None; redirects = [];
       sandbox = Sandbox_target.host () }
-  | Sudo { target } ->
+  | Sudo { target_argv } ->
     { Shell_ir.bin = Result.get_ok (Bin.of_string "sudo");
-      args = List.map arg_of_string (String.split_on_char ' ' target);
+      args = List.map arg_of_string target_argv;
       env = []; cwd = None; redirects = [];
       sandbox = Sandbox_target.host () }
   | Generic s -> s
@@ -392,7 +427,9 @@ let pp fmt = function
     Format.fprintf fmt "Rm(paths=%a, recursive=%b, force=%b)"
       (Format.pp_print_list Format.pp_print_string) paths
       recursive force
-  | W (Sudo { target }) ->
-    Format.fprintf fmt "Sudo(target=%s)" target
+  | W (Sudo { target_argv }) ->
+    Format.fprintf fmt "Sudo(target_argv=%a)"
+      (Format.pp_print_list ~pp_sep:(fun fmt () -> Format.fprintf fmt " ") Format.pp_print_string)
+      target_argv
   | W (Generic s) ->
     Format.fprintf fmt "Generic(%a)" Shell_ir.pp (Shell_ir.Simple s)

--- a/lib/exec/shell_ir_typed.ml
+++ b/lib/exec/shell_ir_typed.ml
@@ -1,0 +1,398 @@
+(** Shell_ir_typed — GADT-based typed command IR implementation.
+
+    Coexists with the untyped [Shell_ir.t].  Each constructor records the
+    command's input type, output type, risk level, and sandbox requirement
+    in the GADT parameters so that policy dispatch can be indexed by the
+    compiler. *)
+
+type risk = [ `Safe | `Audited | `Privileged ]
+type sandbox = [ `Host | `Docker ]
+
+type wrapped = W : ('i, 'o, 'r, 's) command -> wrapped
+
+and (_, _, _, _) command =
+  | Ls : {
+      path : string option;
+      flags : [ `Long | `All | `Human ] list;
+    } -> (unit, string, [ `Safe ], [ `Host ]) command
+
+  | Cat : {
+      path : string;
+    } -> (unit, string, [ `Safe ], [ `Host ]) command
+
+  | Rg : {
+      pattern : string;
+      path : string option;
+      case_sensitive : bool;
+    } -> (unit, string, [ `Safe ], [ `Host ]) command
+
+  | Git_status : {
+      short : bool;
+    } -> (unit, string, [ `Audited ], [ `Host ]) command
+
+  | Git_clone : {
+      repo : string;
+      branch : string option;
+      depth : int;
+    } -> (unit, string, [ `Audited ], [ `Host | `Docker ]) command
+
+  | Curl : {
+      url : string;
+      method_ : [ `GET | `POST | `PUT | `DELETE ];
+      headers : (string * string) list option;
+      body : string option;
+    } -> (unit, string, [ `Audited ], [ `Host ]) command
+
+  | Rm : {
+      paths : string list;
+      recursive : bool;
+      force : bool;
+    } -> (unit, unit, [ `Privileged ], [ `Host ]) command
+
+  | Sudo : {
+      target : string;
+    } -> (unit, string, [ `Privileged ], [ `Host ]) command
+
+  | Generic : Shell_ir.simple ->
+      (Shell_ir.simple, string, [ `Privileged ], [ `Host ]) command
+
+(* ---------------------------------------------------------------------- *)
+(* Helpers — mirror the pattern used in [Capability_check.all_lits_opt].  *)
+
+let lit_of_arg = function
+  | Shell_ir.Lit s -> Some s
+  | Shell_ir.Var _ | Shell_ir.Concat _ -> None
+
+let rec all_lits_opt (args : Shell_ir.arg list) : string list option =
+  let rec go acc = function
+    | [] -> Some (List.rev acc)
+    | a :: rest ->
+      (match lit_of_arg a with
+       | Some s -> go (s :: acc) rest
+       | None -> None)
+  in
+  go [] args
+
+(* ---------------------------------------------------------------------- *)
+(* Individual parsers.
+   Each returns [Some (W cmd)] on success or [None] when the argv shape
+   does not match the constructor's grammar (caller falls back to
+   [Generic]). *)
+
+let parse_ls (args : string list) : wrapped option =
+  let rec parse flags path = function
+    | [] -> Some (W (Ls { path; flags = List.rev flags }))
+    | "-l" :: rest | "--long" :: rest -> parse (`Long :: flags) path rest
+    | "-a" :: rest | "--all" :: rest -> parse (`All :: flags) path rest
+    | "-h" :: rest | "--human-readable" :: rest -> parse (`Human :: flags) path rest
+    | arg :: rest ->
+      if String.length arg > 0 && arg.[0] = '-' then None
+      else
+        (match path with
+         | None -> parse flags (Some arg) rest
+         | Some _ -> None)
+  in
+  parse [] None args
+
+let parse_cat (args : string list) : wrapped option =
+  match args with
+  | [path] -> Some (W (Cat { path }))
+  | _ -> None
+
+let parse_rg (args : string list) : wrapped option =
+  let rec parse case_sensitive pattern path = function
+    | [] ->
+      (match pattern with
+       | Some p -> Some (W (Rg { pattern = p; path; case_sensitive }))
+       | None -> None)
+    | "-i" :: rest | "--ignore-case" :: rest ->
+      parse false pattern path rest
+    | arg :: rest ->
+      if String.length arg > 0 && arg.[0] = '-' then None
+      else
+        (match pattern with
+         | None -> parse case_sensitive (Some arg) path rest
+         | Some _ ->
+           (match path with
+            | None -> parse case_sensitive pattern (Some arg) rest
+            | Some _ -> None))
+  in
+  parse true None None args
+
+let parse_git_status (args : string list) : wrapped option =
+  let rec parse short = function
+    | [] -> Some (W (Git_status { short }))
+    | "-s" :: rest | "--short" :: rest -> parse true rest
+    | "--porcelain" :: rest -> parse true rest
+    | _ :: _ -> None
+  in
+  parse false args
+
+let parse_git_clone (args : string list) : wrapped option =
+  let rec parse depth branch repo = function
+    | [] ->
+      (match repo with
+       | Some r -> Some (W (Git_clone { repo = r; branch; depth }))
+       | None -> None)
+    | "--depth" :: n :: rest ->
+      (match int_of_string_opt n with
+       | Some d -> parse d branch repo rest
+       | None -> None)
+    | "-b" :: b :: rest | "--branch" :: b :: rest ->
+      parse depth (Some b) repo rest
+    | arg :: rest ->
+      if String.length arg > 0 && arg.[0] = '-' then None
+      else
+        (match repo with
+         | None -> parse depth branch (Some arg) rest
+         | Some _ -> None)
+  in
+  parse 1 None None args
+
+let parse_curl (args : string list) : wrapped option =
+  let rec parse method_ headers body url = function
+    | [] ->
+      (match url with
+       | Some u ->
+         Some (W (Curl {
+             url = u;
+             method_;
+             headers =
+               (match headers with [] -> None | _ -> Some (List.rev headers));
+             body;
+           }))
+       | None -> None)
+    | "-X" :: m :: rest | "--request" :: m :: rest ->
+      (match String.uppercase_ascii m with
+       | "GET" -> parse `GET headers body url rest
+       | "POST" -> parse `POST headers body url rest
+       | "PUT" -> parse `PUT headers body url rest
+       | "DELETE" -> parse `DELETE headers body url rest
+       | _ -> None)
+    | "-H" :: h :: rest | "--header" :: h :: rest ->
+      (match String.index_opt h ':' with
+       | Some i ->
+         let key = String.trim (String.sub h 0 i) in
+         let value =
+           String.trim (String.sub h (i + 1) (String.length h - i - 1))
+         in
+         parse method_ ((key, value) :: headers) body url rest
+       | None -> None)
+    | "-d" :: d :: rest | "--data" :: d :: rest ->
+      (match body with
+       | None -> parse method_ headers (Some d) url rest
+       | Some _ -> None)
+    | arg :: rest ->
+      if String.length arg > 0 && arg.[0] = '-' then None
+      else
+        (match url with
+         | None -> parse method_ headers body (Some arg) rest
+         | Some _ -> None)
+  in
+  parse `GET [] None None args
+
+let parse_rm (args : string list) : wrapped option =
+  let rec parse recursive force paths = function
+    | [] ->
+      (match paths with
+       | [] -> None
+       | _ -> Some (W (Rm { paths = List.rev paths; recursive; force })))
+    | "-r" :: rest | "-R" :: rest | "--recursive" :: rest ->
+      parse true force paths rest
+    | "-f" :: rest | "--force" :: rest ->
+      parse recursive true paths rest
+    | arg :: rest ->
+      if String.length arg > 0 && arg.[0] = '-' then None
+      else parse recursive force (arg :: paths) rest
+  in
+  parse false false [] args
+
+let parse_sudo (args : string list) : wrapped option =
+  match args with
+  | [] -> None
+  | args -> Some (W (Sudo { target = String.concat " " args }))
+
+(* ---------------------------------------------------------------------- *)
+(* of_simple *)
+
+let of_simple (s : Shell_ir.simple) : wrapped option =
+  match all_lits_opt s.Shell_ir.args with
+  | None -> None
+  | Some lit_argv ->
+    match Bin.kind s.Shell_ir.bin with
+    | `Safe_bin ->
+      (match Bin.to_string s.Shell_ir.bin with
+       | "ls" -> parse_ls lit_argv
+       | "cat" -> parse_cat lit_argv
+       | "rg" -> parse_rg lit_argv
+       | _ -> None)
+    | `Git ->
+      (match lit_argv with
+       | "status" :: rest -> parse_git_status rest
+       | "clone" :: rest -> parse_git_clone rest
+       | _ -> None)
+    | `Curl -> parse_curl lit_argv
+    | `Privileged_bin ->
+      (match Bin.to_string s.Shell_ir.bin with
+       | "rm" -> parse_rm lit_argv
+       | "sudo" -> parse_sudo lit_argv
+       | _ -> None)
+    | `Docker | `Ssh | `Other_audited -> None
+
+(* ---------------------------------------------------------------------- *)
+(* to_simple *)
+
+let arg_of_string s = Shell_ir.Lit s
+
+let to_simple : type i o r s. (i, o, r, s) command -> Shell_ir.simple =
+  function
+  | Ls { path; flags } ->
+    let flag_args =
+      List.map (function
+        | `Long -> "-l"
+        | `All -> "-a"
+        | `Human -> "-h") flags
+    in
+    let args = match path with None -> flag_args | Some p -> flag_args @ [p] in
+    { Shell_ir.bin = Result.get_ok (Bin.of_string "ls");
+      args = List.map arg_of_string args;
+      env = [];
+      cwd = None;
+      redirects = [];
+      sandbox = Sandbox_target.host () }
+  | Cat { path } ->
+    { Shell_ir.bin = Result.get_ok (Bin.of_string "cat");
+      args = [arg_of_string path];
+      env = []; cwd = None; redirects = [];
+      sandbox = Sandbox_target.host () }
+  | Rg { pattern; path; case_sensitive } ->
+    let flag_args = if case_sensitive then [] else ["-i"] in
+    let args =
+      flag_args @ [pattern]
+      @ (match path with None -> [] | Some p -> [p])
+    in
+    { Shell_ir.bin = Result.get_ok (Bin.of_string "rg");
+      args = List.map arg_of_string args;
+      env = []; cwd = None; redirects = [];
+      sandbox = Sandbox_target.host () }
+  | Git_status { short } ->
+    let args = if short then ["-s"] else [] in
+    { Shell_ir.bin = Result.get_ok (Bin.of_string "git");
+      args = List.map arg_of_string ("status" :: args);
+      env = []; cwd = None; redirects = [];
+      sandbox = Sandbox_target.host () }
+  | Git_clone { repo; branch; depth } ->
+    let args =
+      (if depth <> 1 then ["--depth"; string_of_int depth] else [])
+      @ (match branch with None -> [] | Some b -> ["-b"; b])
+      @ [repo]
+    in
+    { Shell_ir.bin = Result.get_ok (Bin.of_string "git");
+      args = List.map arg_of_string ("clone" :: args);
+      env = []; cwd = None; redirects = [];
+      sandbox = Sandbox_target.host () }
+  | Curl { url; method_; headers; body } ->
+    let method_args =
+      match method_ with
+      | `GET -> []
+      | `POST -> ["-X"; "POST"]
+      | `PUT -> ["-X"; "PUT"]
+      | `DELETE -> ["-X"; "DELETE"]
+    in
+    let header_args =
+      match headers with
+      | None -> []
+      | Some hs ->
+        List.concat_map (fun (k, v) -> ["-H"; k ^ ": " ^ v]) hs
+    in
+    let body_args =
+      match body with
+      | None -> []
+      | Some d -> ["-d"; d]
+    in
+    let args = method_args @ header_args @ body_args @ [url] in
+    { Shell_ir.bin = Result.get_ok (Bin.of_string "curl");
+      args = List.map arg_of_string args;
+      env = []; cwd = None; redirects = [];
+      sandbox = Sandbox_target.host () }
+  | Rm { paths; recursive; force } ->
+    let flag_args =
+      (if recursive then ["-r"] else [])
+      @ (if force then ["-f"] else [])
+    in
+    { Shell_ir.bin = Result.get_ok (Bin.of_string "rm");
+      args = List.map arg_of_string (flag_args @ paths);
+      env = []; cwd = None; redirects = [];
+      sandbox = Sandbox_target.host () }
+  | Sudo { target } ->
+    { Shell_ir.bin = Result.get_ok (Bin.of_string "sudo");
+      args = List.map arg_of_string (String.split_on_char ' ' target);
+      env = []; cwd = None; redirects = [];
+      sandbox = Sandbox_target.host () }
+  | Generic s -> s
+
+(* ---------------------------------------------------------------------- *)
+(* GADT extractors — operate through the existential wrapper so that the
+   input type is uniform across constructors with different parameters. *)
+
+let risk = function
+  | W (Ls _) -> `Safe
+  | W (Cat _) -> `Safe
+  | W (Rg _) -> `Safe
+  | W (Git_status _) -> `Audited
+  | W (Git_clone _) -> `Audited
+  | W (Curl _) -> `Audited
+  | W (Rm _) -> `Privileged
+  | W (Sudo _) -> `Privileged
+  | W (Generic _) -> `Privileged
+
+let sandbox = function
+  | W (Ls _) -> `Host
+  | W (Cat _) -> `Host
+  | W (Rg _) -> `Host
+  | W (Git_status _) -> `Host
+  | W (Git_clone _) -> `Docker
+  | W (Curl _) -> `Host
+  | W (Rm _) -> `Host
+  | W (Sudo _) -> `Host
+  | W (Generic _) -> `Host
+
+(* ---------------------------------------------------------------------- *)
+(* Pretty-printer *)
+
+let pp fmt = function
+  | W (Ls { path; flags }) ->
+    Format.fprintf fmt "Ls(path=%a, flags=%d)"
+      (Format.pp_print_option Format.pp_print_string) path
+      (List.length flags)
+  | W (Cat { path }) ->
+    Format.fprintf fmt "Cat(path=%s)" path
+  | W (Rg { pattern; path; case_sensitive }) ->
+    Format.fprintf fmt "Rg(pattern=%s, path=%a, case_sensitive=%b)"
+      pattern
+      (Format.pp_print_option Format.pp_print_string) path
+      case_sensitive
+  | W (Git_status { short }) ->
+    Format.fprintf fmt "Git_status(short=%b)" short
+  | W (Git_clone { repo; branch; depth }) ->
+    Format.fprintf fmt "Git_clone(repo=%s, branch=%a, depth=%d)"
+      repo
+      (Format.pp_print_option Format.pp_print_string) branch
+      depth
+  | W (Curl { url; method_; headers; body }) ->
+    Format.fprintf fmt "Curl(url=%s, method=%s, headers=%a, body=%a)"
+      url
+      (match method_ with
+       | `GET -> "GET" | `POST -> "POST" | `PUT -> "PUT" | `DELETE -> "DELETE")
+      (Format.pp_print_option (fun fmt hs ->
+         List.iter (fun (k, v) -> Format.fprintf fmt "%s:%s " k v) hs))
+      headers
+      (Format.pp_print_option Format.pp_print_string) body
+  | W (Rm { paths; recursive; force }) ->
+    Format.fprintf fmt "Rm(paths=%a, recursive=%b, force=%b)"
+      (Format.pp_print_list Format.pp_print_string) paths
+      recursive force
+  | W (Sudo { target }) ->
+    Format.fprintf fmt "Sudo(target=%s)" target
+  | W (Generic s) ->
+    Format.fprintf fmt "Generic(%a)" Shell_ir.pp (Shell_ir.Simple s)

--- a/lib/exec/shell_ir_typed.mli
+++ b/lib/exec/shell_ir_typed.mli
@@ -61,7 +61,12 @@ and (_, _, _, _) command =
     } -> (unit, unit, [ `Privileged ], [ `Host ]) command
 
   | Sudo : {
-      target : string;
+      target_argv : string list;
+        (** Tokenized argv for [sudo].  Stored as a list (not
+            space-joined) so that quoted arguments — e.g.
+            [sudo sh -c "echo hi"] — survive [to_simple] /
+            [Capability_check_typed.of_command] without being
+            re-split on whitespace. *)
     } -> (unit, string, [ `Privileged ], [ `Host ]) command
 
   | Generic : Shell_ir.simple ->
@@ -69,10 +74,18 @@ and (_, _, _, _) command =
 (** Catch-all for unknown or unparseable commands.  The risk is pinned to
     [`Privileged] so the policy layer treats it as fail-closed. *)
 
-(** Best-effort conversion from an untyped [Shell_ir.simple] to a typed
-    command.  Known binaries with parseable literal arguments are lifted
-    to specific constructors; everything else falls through to [Generic]. *)
-val of_simple : Shell_ir.simple -> wrapped option
+(** Lift an untyped [Shell_ir.simple] into a typed command.
+
+    Fail-closed: known binaries with parseable literal arguments lift
+    to specific constructors; anything that does not match — including
+    non-literal args ([Var] / [Concat]), unhandled binary kinds, and
+    any [simple] that carries non-empty [env] or [redirects] — falls
+    through to [W (Generic s)].  The [Generic] arm pins the risk to
+    [`Privileged] and routes capability derivation back to
+    [Capability_check.of_simple] so that env / redirect-derived
+    [Read_path] / [Write_path] / [Env_set] capabilities are not
+    silently dropped on the typed path. *)
+val of_simple : Shell_ir.simple -> wrapped
 
 (** Reconstruct an untyped [Shell_ir.simple] from a typed command.
     [env], [cwd], [redirects] and [sandbox] receive default values because

--- a/lib/exec/shell_ir_typed.mli
+++ b/lib/exec/shell_ir_typed.mli
@@ -1,0 +1,89 @@
+(** Shell_ir_typed — GADT-based typed command IR (RFC-0005 Week 3 prototype).
+
+    Coexists with the untyped [Shell_ir.t].  Each constructor records the
+    command's input type, output type, risk level, and sandbox requirement
+    in the GADT parameters so that policy dispatch can be indexed by the
+    compiler.
+
+    Fail-closed: any command that does not match a known shape becomes
+    [Generic], which carries the full untyped [Shell_ir.simple] and is
+    classified at the most restrictive risk level. *)
+
+type risk = [ `Safe | `Audited | `Privileged ]
+type sandbox = [ `Host | `Docker ]
+
+(** Existential wrapper so that [of_simple] can return commands with
+    different risk and sandbox parameters through a single uniform type. *)
+type wrapped = W : ('i, 'o, 'r, 's) command -> wrapped
+
+(** [('i, 'o, 'r, 's) command] indexes by:
+    - ['i]: input type (currently [unit] for parsed commands)
+    - ['o]: output type ([string] for most, [unit] for side-effect only)
+    - ['r]: risk level ([`Safe | `Audited | `Privileged])
+    - ['s]: sandbox requirement ([`Host | `Docker]) *)
+and (_, _, _, _) command =
+  | Ls : {
+      path : string option;
+      flags : [ `Long | `All | `Human ] list;
+    } -> (unit, string, [ `Safe ], [ `Host ]) command
+
+  | Cat : {
+      path : string;
+    } -> (unit, string, [ `Safe ], [ `Host ]) command
+
+  | Rg : {
+      pattern : string;
+      path : string option;
+      case_sensitive : bool;
+    } -> (unit, string, [ `Safe ], [ `Host ]) command
+
+  | Git_status : {
+      short : bool;
+    } -> (unit, string, [ `Audited ], [ `Host ]) command
+
+  | Git_clone : {
+      repo : string;
+      branch : string option;
+      depth : int;
+    } -> (unit, string, [ `Audited ], [ `Host | `Docker ]) command
+
+  | Curl : {
+      url : string;
+      method_ : [ `GET | `POST | `PUT | `DELETE ];
+      headers : (string * string) list option;
+      body : string option;
+    } -> (unit, string, [ `Audited ], [ `Host ]) command
+
+  | Rm : {
+      paths : string list;
+      recursive : bool;
+      force : bool;
+    } -> (unit, unit, [ `Privileged ], [ `Host ]) command
+
+  | Sudo : {
+      target : string;
+    } -> (unit, string, [ `Privileged ], [ `Host ]) command
+
+  | Generic : Shell_ir.simple ->
+      (Shell_ir.simple, string, [ `Privileged ], [ `Host ]) command
+(** Catch-all for unknown or unparseable commands.  The risk is pinned to
+    [`Privileged] so the policy layer treats it as fail-closed. *)
+
+(** Best-effort conversion from an untyped [Shell_ir.simple] to a typed
+    command.  Known binaries with parseable literal arguments are lifted
+    to specific constructors; everything else falls through to [Generic]. *)
+val of_simple : Shell_ir.simple -> wrapped option
+
+(** Reconstruct an untyped [Shell_ir.simple] from a typed command.
+    [env], [cwd], [redirects] and [sandbox] receive default values because
+    the typed constructors do not carry them; callers that need the
+    original context should retain the source [Shell_ir.simple]. *)
+val to_simple : ('i, 'o, 'r, 's) command -> Shell_ir.simple
+
+(** Extract the risk level through the existential wrapper. *)
+val risk : wrapped -> risk
+
+(** Extract the sandbox requirement through the existential wrapper. *)
+val sandbox : wrapped -> sandbox
+
+val pp : Format.formatter -> wrapped -> unit

--- a/lib/exec/test/dune
+++ b/lib/exec/test/dune
@@ -4,6 +4,7 @@
         test_exec_gate_runtime test_exec_semantic test_exec_buffer
         test_exec_run test_exec_run_json test_exit_code test_output_parse_p14
         test_history_insight test_exec_cache test_exec_budget
-        test_exec_adaptive_timeout test_risk_classifier test_egress_policy)
+        test_exec_adaptive_timeout test_risk_classifier test_egress_policy
+        test_shell_ir_typed)
  (libraries masc_exec masc_exec_bash_parser masc_process
             masc_core masc_config alcotest eio eio_main yojson unix re))

--- a/lib/exec/test/test_shell_ir_typed.ml
+++ b/lib/exec/test/test_shell_ir_typed.ml
@@ -1,0 +1,158 @@
+(** Shell_ir_typed tests — round-trip, risk/sandbox extractors, capability mapping. *)
+
+open Masc_exec
+
+let bin_ok name =
+  match Bin.of_string name with
+  | Ok b -> b
+  | Error _ -> assert false
+
+let simple ?(args = []) ?(env = []) ?(cwd = None) ?(redirects = [])
+    ?(sandbox = Sandbox_target.host ()) bin
+    : Shell_ir.simple =
+  { bin; args; env; cwd; redirects; sandbox }
+
+let lit s = Shell_ir.Lit s
+
+let arg_to_string = function
+  | Shell_ir.Lit s -> s
+  | Shell_ir.Var _ | Shell_ir.Concat _ ->
+    assert false (* tests use only literal args *)
+
+let argv_of_simple s =
+  Bin.to_string s.Shell_ir.bin :: List.map arg_to_string s.Shell_ir.args
+
+(* ---------------------------------------------------------------------- *)
+(* Round-trip: simple -> of_simple -> to_simple -> identical argv *)
+
+let roundtrip simple =
+  let (Shell_ir_typed.W cmd) = Shell_ir_typed.of_simple simple in
+  let reconstructed = Shell_ir_typed.to_simple cmd in
+  let orig = argv_of_simple simple in
+  let next = argv_of_simple reconstructed in
+  assert (orig = next)
+
+let test_ls_roundtrip () =
+  let _ = roundtrip (simple ~args:[lit "-l"; lit "-a"] (bin_ok "ls")) in
+  ()
+
+let test_cat_roundtrip () =
+  let _ = roundtrip (simple ~args:[lit "/etc/passwd"] (bin_ok "cat")) in
+  ()
+
+let test_rg_roundtrip () =
+  let _ = roundtrip (simple ~args:[lit "-i"; lit "foo"; lit "."] (bin_ok "rg")) in
+  ()
+
+let test_git_status_roundtrip () =
+  let _ = roundtrip (simple ~args:[lit "status"; lit "-s"] (bin_ok "git")) in
+  ()
+
+let test_git_clone_roundtrip () =
+  let _ =
+    roundtrip
+      (simple
+         ~args:[lit "clone"; lit "https://github.com/foo/bar.git"]
+         (bin_ok "git"))
+  in
+  ()
+
+let test_curl_get_roundtrip () =
+  let _ = roundtrip (simple ~args:[lit "https://example.com"] (bin_ok "curl")) in
+  ()
+
+let test_curl_post_roundtrip () =
+  let _ =
+    roundtrip
+      (simple
+         ~args:[
+           lit "-X"; lit "POST";
+           lit "-H"; lit "Content-Type: application/json";
+           lit "-d"; lit "{}";
+           lit "https://example.com"
+         ]
+         (bin_ok "curl"))
+  in
+  ()
+
+let test_rm_roundtrip () =
+  let _ = roundtrip (simple ~args:[lit "-r"; lit "-f"; lit "/tmp/old"] (bin_ok "rm")) in
+  ()
+
+let test_sudo_roundtrip () =
+  let _ = roundtrip (simple ~args:[lit "apt"; lit "update"] (bin_ok "sudo")) in
+  ()
+
+(* ---------------------------------------------------------------------- *)
+(* Risk / Sandbox extractors *)
+
+let test_risk_levels () =
+  let check simple expected =
+    let w = Shell_ir_typed.of_simple simple in
+    assert (Shell_ir_typed.risk w = expected)
+  in
+  check (simple (bin_ok "ls")) `Safe;
+  check (simple (bin_ok "cat")) `Safe;
+  check (simple (bin_ok "rg")) `Safe;
+  check (simple ~args:[lit "status"] (bin_ok "git")) `Audited;
+  check (simple ~args:[lit "clone"; lit "x"] (bin_ok "git")) `Audited;
+  check (simple (bin_ok "curl")) `Audited;
+  check (simple (bin_ok "rm")) `Privileged;
+  check (simple (bin_ok "sudo")) `Privileged
+
+let test_sandbox_levels () =
+  let check simple expected =
+    let w = Shell_ir_typed.of_simple simple in
+    assert (Shell_ir_typed.sandbox w = expected)
+  in
+  check (simple (bin_ok "ls")) `Host;
+  check (simple (bin_ok "cat")) `Host;
+  check (simple (bin_ok "rg")) `Host;
+  check (simple ~args:[lit "status"] (bin_ok "git")) `Host;
+  check (simple ~args:[lit "clone"; lit "x"] (bin_ok "git")) `Docker;
+  check (simple (bin_ok "curl")) `Host;
+  check (simple (bin_ok "rm")) `Host;
+  check (simple (bin_ok "sudo")) `Host
+
+(* ---------------------------------------------------------------------- *)
+(* Capability_check_typed — total extraction, no None fallthrough *)
+
+let test_capability_extraction_is_total () =
+  let check simple =
+    let w = Shell_ir_typed.of_simple simple in
+    let caps = Capability_check_typed.of_command w in
+    assert (List.length caps > 0)
+  in
+  check (simple (bin_ok "ls"));
+  check (simple ~args:[lit "status"] (bin_ok "git"));
+  check (simple (bin_ok "curl"));
+  check (simple (bin_ok "rm"));
+  check (simple (bin_ok "sudo"))
+
+let test_generic_falls_back_to_capability_check () =
+  (* An unknown binary becomes Generic, which delegates to Capability_check.of_simple *)
+  let simple = simple (bin_ok "dd") in
+  let w = Shell_ir_typed.of_simple simple in
+  (match Shell_ir_typed.risk w with
+   | `Privileged -> ()
+   | _ -> assert false);
+  let caps = Capability_check_typed.of_command w in
+  assert (List.length caps > 0)
+
+(* ---------------------------------------------------------------------- *)
+
+let () =
+  test_ls_roundtrip ();
+  test_cat_roundtrip ();
+  test_rg_roundtrip ();
+  test_git_status_roundtrip ();
+  test_git_clone_roundtrip ();
+  test_curl_get_roundtrip ();
+  test_curl_post_roundtrip ();
+  test_rm_roundtrip ();
+  test_sudo_roundtrip ();
+  test_risk_levels ();
+  test_sandbox_levels ();
+  test_capability_extraction_is_total ();
+  test_generic_falls_back_to_capability_check ();
+  print_endline "[test_shell_ir_typed] all tests passed"


### PR DESCRIPTION
## Summary

RFC-0005 Week 3: GADT-based typed command IR prototype for the local exec gate.

Adds `Shell_ir_typed` — a GADT-indexed command IR that coexists with the untyped `Shell_ir.t`. Each constructor encodes input type, output type, risk level, and sandbox requirement in the GADT parameters so that policy dispatch can be indexed by the compiler.

## Changes

- `lib/exec/shell_ir_typed.ml{i}` — typed IR with 9 constructors:
  `Ls`, `Cat`, `Rg`, `Git_status`, `Git_clone`, `Curl`, `Rm`, `Sudo`, `Generic`
  - `of_simple`: best-effort lift from untyped `Shell_ir.simple`
  - `to_simple`: reconstruct untyped `Shell_ir.simple` from typed command
  - `risk` / `sandbox` / `pp`: extractors via existential `wrapped` wrapper
- `lib/exec/capability_check_typed.ml{i}` — total capability extraction from typed commands (no `None` fallthrough)
- `lib/exec/risk_classifier_typed.ml{i}` — risk classification via `Shell_ir_typed.risk`
- `lib/exec/approval_policy_typed.ml{i}` — policy bridge: typed capabilities → existing `Approval_policy.decide`

## Design

- Fail-closed: unknown commands fall through to `Generic` (risk=`Privileged`)
- Existential wrapper `type wrapped = W : ('i, 'o, 'r, 's) command -> wrapped` hides GADT indices for uniform handling
- Capability extraction is total because the GADT constructor already encodes the operation semantics

## RFC Reference

- `docs/rfc/RFC-0005-typed-capability-substrate.md`

## Test Plan

- [ ] `dune build --root . lib/exec` compiles
- [ ] Add round-trip tests: `Shell_ir.simple` → `of_simple` → `to_simple` → identical argv
- [ ] Add risk/sandbox extractor tests per constructor
- [ ] Wire typed dispatch into `exec_gate` (future PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)