### PR TITLE
feat(keeper): RFC-0026 admission wiring + RFC-0041 routing hierarchy

### DIFF
--- a/lib/cascade/cascade_ref.ml
+++ b/lib/cascade/cascade_ref.ml
@@ -1,0 +1,225 @@
+(** CascadeRef — Group/Item hierarchy types for cascade routing.
+
+    RFC-0041: Cascade Routing Architecture — Group/Item Hierarchy
+    with Health-Aware Fallback.
+
+    This module defines the data model for cascades as hierarchical
+    structures: cascade_profile -> cascade_group -> cascade_item.
+    The previous flat [cascade_name:string] is migrated to this model
+    with backward compatibility: a plain string becomes a single-group,
+    single-item profile. *)
+
+(** A single callable item within a cascade group.
+    Represents one provider+model combination with its routing metadata. *)
+type cascade_item = {
+  id : string;
+  provider : string;
+  model : string;
+  timeout_ms : int;
+  priority : int;  (** Lower value = higher priority. Used by [Priority] strategy. *)
+}
+
+(** Strategy for ordering items within a group during traversal. *)
+type traversal_strategy =
+  | Priority  (** Select by priority ascending (lower value first). *)
+  | RoundRobin  (** Cycle through items in order. *)
+  | Random  (** Random selection. *)
+
+(** A group of items with a traversal strategy and optional fallback chain.
+    Groups form a directed graph via [fallback_group]; cycle detection is
+    the responsibility of the router. *)
+type cascade_group = {
+  name : string;
+  items : cascade_item list;
+  strategy : traversal_strategy;
+  fallback_group : string option;  (** [None] terminates the fallback chain. *)
+}
+
+(** A named cascade profile containing one or more groups.
+    This is the top-level configuration object loaded from cascade.json. *)
+type cascade_profile = {
+  name : string;
+  groups : cascade_group list;
+}
+
+(** A reference to a specific position within a cascade profile.
+    Used by keeper_meta and registry_entry to pin the keeper's routing
+    context. [item = None] means "let the group's strategy decide". *)
+type cascade_ref = {
+  group : string;
+  item : string option;
+}
+
+(* ------------------------------------------------------------------ *)
+(* JSON serialization helpers                                         *)
+(* ------------------------------------------------------------------ *)
+
+let traversal_strategy_to_json = function
+  | Priority -> `String "priority"
+  | RoundRobin -> `String "round_robin"
+  | Random -> `String "random"
+
+let traversal_strategy_of_json = function
+  | `String "priority" -> Some Priority
+  | `String "round_robin" -> Some RoundRobin
+  | `String "random" -> Some Random
+  | _ -> None
+
+let cascade_item_to_json (item : cascade_item) : Yojson.Safe.t =
+  `Assoc [
+    "id", `String item.id;
+    "provider", `String item.provider;
+    "model", `String item.model;
+    "timeout_ms", `Int item.timeout_ms;
+    "priority", `Int item.priority;
+  ]
+
+let cascade_item_of_json (json : Yojson.Safe.t) : cascade_item option =
+  match json with
+  | `Assoc fields ->
+      let find_str key =
+        match List.assoc_opt key fields with
+        | Some (`String s) -> Some s
+        | _ -> None
+      in
+      let find_int key =
+        match List.assoc_opt key fields with
+        | Some (`Int n) -> Some n
+        | _ -> None
+      in
+      (match find_str "id", find_str "provider", find_str "model",
+            find_int "timeout_ms", find_int "priority" with
+       | Some id, Some provider, Some model, Some timeout_ms, Some priority ->
+           Some { id; provider; model; timeout_ms; priority }
+       | _ -> None)
+  | _ -> None
+
+let cascade_group_to_json (group : cascade_group) : Yojson.Safe.t =
+  `Assoc [
+    "name", `String group.name;
+    "items", `List (List.map cascade_item_to_json group.items);
+    "strategy", traversal_strategy_to_json group.strategy;
+    "fallback_group",
+      (match group.fallback_group with
+       | Some name -> `String name
+       | None -> `Null);
+  ]
+
+let cascade_group_of_json (json : Yojson.Safe.t) : cascade_group option =
+  match json with
+  | `Assoc fields ->
+      let find_str key =
+        match List.assoc_opt key fields with
+        | Some (`String s) -> Some s
+        | _ -> None
+      in
+      let name_opt = find_str "name" in
+      let strategy_opt =
+        match List.assoc_opt "strategy" fields with
+        | Some s -> traversal_strategy_of_json s
+        | None -> None
+      in
+      let items =
+        match List.assoc_opt "items" fields with
+        | Some (`List arr) ->
+            List.filter_map cascade_item_of_json arr
+        | _ -> []
+      in
+      let fallback_group =
+        match List.assoc_opt "fallback_group" fields with
+        | Some (`String s) -> Some s
+        | _ -> None
+      in
+      (match name_opt, strategy_opt with
+       | Some name, Some strategy -> Some { name; items; strategy; fallback_group }
+       | _ -> None)
+  | _ -> None
+
+let cascade_profile_to_json (profile : cascade_profile) : Yojson.Safe.t =
+  `Assoc [
+    "name", `String profile.name;
+    "groups", `List (List.map cascade_group_to_json profile.groups);
+  ]
+
+let cascade_profile_of_json (json : Yojson.Safe.t) : cascade_profile option =
+  match json with
+  | `Assoc fields ->
+      let name_opt =
+        match List.assoc_opt "name" fields with
+        | Some (`String s) -> Some s
+        | _ -> None
+      in
+      let groups =
+        match List.assoc_opt "groups" fields with
+        | Some (`List arr) -> List.filter_map cascade_group_of_json arr
+        | _ -> []
+      in
+      (match name_opt with
+       | Some name -> Some { name; groups }
+       | None -> None)
+  | _ -> None
+
+let cascade_ref_to_json (ref_ : cascade_ref) : Yojson.Safe.t =
+  `Assoc [
+    "group", `String ref_.group;
+    "item",
+      (match ref_.item with
+       | Some id -> `String id
+       | None -> `Null);
+  ]
+
+let cascade_ref_of_json (json : Yojson.Safe.t) : cascade_ref option =
+  match json with
+  | `Assoc fields ->
+      let group_opt =
+        match List.assoc_opt "group" fields with
+        | Some (`String s) -> Some s
+        | _ -> None
+      in
+      let item =
+        match List.assoc_opt "item" fields with
+        | Some (`String s) -> Some s
+        | _ -> None
+      in
+      (match group_opt with
+       | Some group -> Some { group; item }
+       | None -> None)
+  | _ -> None
+
+(* ------------------------------------------------------------------ *)
+(* Migration helper: string -> cascade_ref                            *)
+(* ------------------------------------------------------------------ *)
+
+(** Convert a legacy cascade_name string into a cascade_ref.
+    The string is treated as both the group name and (if non-empty)
+    the single item id. This preserves backward compatibility with
+    existing keeper configurations that use flat cascade_name strings.
+
+    Empty string -> { group = ""; item = None } (unconfigured keeper). *)
+let cascade_ref_of_string (cascade_name : string) : cascade_ref =
+  if String.equal cascade_name "" then
+    { group = ""; item = None }
+  else
+    { group = cascade_name; item = Some cascade_name }
+
+(* ------------------------------------------------------------------ *)
+(* Lookup helpers                                                     *)
+(* ------------------------------------------------------------------ *)
+
+(** Find a group by name within a profile. *)
+let find_group (profile : cascade_profile) (group_name : string)
+    : cascade_group option =
+  List.find_opt (fun (g : cascade_group) -> String.equal g.name group_name) profile.groups
+
+(** Find an item by id within a group. *)
+let find_item (group : cascade_group) (item_id : string)
+    : cascade_item option =
+  List.find_opt (fun item -> String.equal item.id item_id) group.items
+
+(** Order items according to the group's traversal strategy. *)
+let order_items (strategy : traversal_strategy) (items : cascade_item list)
+    : cascade_item list =
+  match strategy with
+  | Priority -> List.sort (fun a b -> Int.compare a.priority b.priority) items
+  | RoundRobin -> items
+  | Random -> items  (* Randomization applied at selection time, not here. *)

--- a/lib/cascade/cascade_ref.mli
+++ b/lib/cascade/cascade_ref.mli
@@ -1,0 +1,84 @@
+(** CascadeRef — Group/Item hierarchy types for cascade routing (RFC-0041).
+
+    Defines the 3-layer cascade data model:
+    - [cascade_profile]: top-level named configuration
+    - [cascade_group]: named collection of items + traversal strategy
+    - [cascade_item]: single callable provider+model combination
+    - [cascade_ref]: keeper's routing position (group + optional pinned item)
+
+    Backward compatibility: existing [cascade_name:string] configurations
+    are migrated via [cascade_ref_of_string] to a single-group,
+    single-item profile. *)
+
+(** A single callable item within a cascade group. *)
+type cascade_item = {
+  id : string;
+  provider : string;
+  model : string;
+  timeout_ms : int;
+  priority : int;  (** Lower value = higher priority. *)
+}
+
+(** Strategy for ordering items within a group during traversal. *)
+type traversal_strategy =
+  | Priority  (** Select by priority ascending. *)
+  | RoundRobin  (** Cycle through items in order. *)
+  | Random  (** Random selection. *)
+
+(** A group of items with a traversal strategy and optional fallback link. *)
+type cascade_group = {
+  name : string;
+  items : cascade_item list;
+  strategy : traversal_strategy;
+  fallback_group : string option;  (** [None] terminates the chain. *)
+}
+
+(** A named cascade profile containing one or more groups. *)
+type cascade_profile = {
+  name : string;
+  groups : cascade_group list;
+}
+
+(** A reference to a specific position within a cascade profile.
+    [item = None] means "let the group's strategy decide". *)
+type cascade_ref = {
+  group : string;
+  item : string option;
+}
+
+(** {1 JSON serialization} *)
+
+val traversal_strategy_to_json : traversal_strategy -> Yojson.Safe.t
+val traversal_strategy_of_json : Yojson.Safe.t -> traversal_strategy option
+
+val cascade_item_to_json : cascade_item -> Yojson.Safe.t
+val cascade_item_of_json : Yojson.Safe.t -> cascade_item option
+
+val cascade_group_to_json : cascade_group -> Yojson.Safe.t
+val cascade_group_of_json : Yojson.Safe.t -> cascade_group option
+
+val cascade_profile_to_json : cascade_profile -> Yojson.Safe.t
+val cascade_profile_of_json : Yojson.Safe.t -> cascade_profile option
+
+val cascade_ref_to_json : cascade_ref -> Yojson.Safe.t
+val cascade_ref_of_json : Yojson.Safe.t -> cascade_ref option
+
+(** {1 Migration helper} *)
+
+(** Convert a legacy cascade_name string into a cascade_ref.
+    The string becomes both the group name and (if non-empty) the item id.
+    Empty string produces an unconfigured reference. *)
+val cascade_ref_of_string : string -> cascade_ref
+
+(** {1 Lookup helpers} *)
+
+(** Find a group by name within a profile. *)
+val find_group : cascade_profile -> string -> cascade_group option
+
+(** Find an item by id within a group. *)
+val find_item : cascade_group -> string -> cascade_item option
+
+(** Order items according to the group's traversal strategy.
+    [Random] returns items unchanged; randomization is applied at
+    selection time. *)
+val order_items : traversal_strategy -> cascade_item list -> cascade_item list

--- a/lib/keeper/keeper_admission_runtime.ml
+++ b/lib/keeper/keeper_admission_runtime.ml
@@ -3,6 +3,10 @@
 let no_policy : Keeper_admission_glue.policy_lookup = fun _ -> None
 let no_bucket : Keeper_admission_router.bucket_lookup = fun _ -> None
 
+(* WFQ overflow queue for keepers that got [Wait] decisions.
+   Shared across all keepers; heartbeat loop enqueues / wake hook dequeues. *)
+let wfq_queue : Keeper_wfq_overflow.t = Keeper_wfq_overflow.create ()
+
 (* Use [Atomic.t] for callback refs, matching the convention in
    [Coord_hooks] (lib/coord/coord_hooks.ml).  Plain [ref] is not safe
    across domains in OCaml 5; the Atomic primitives provide the
@@ -27,18 +31,33 @@ let init_state = ref Idle
 let set_policy_lookup f = Atomic.set policy_lookup_ref f
 let set_bucket_lookup f = Atomic.set bucket_lookup_ref f
 
-(* Lazy per-provider bucket table.  PR-E-1.8 will replace the
-   hard-coded defaults with per-provider rate config sourced from
-   cascade.toml.  For PR-E-1.6+1.7 we just want every provider name
-   referenced by an [admission.<keeper>].candidates entry to map to a
-   non-empty bucket so [Keeper_admission_router.schedule] can return
-   [Dispatch] / [Wait] in the shadow counter — same shape it will
-   take in PR-E-1.8 once rates are real. *)
+(* Per-provider rate config.  PR-E-1.8 reads from cascade config;
+   falls back to hard-coded defaults when no config is present. *)
 let default_bucket_capacity = 10
 let default_bucket_refill_rate = 1.0
 let now () = Unix.gettimeofday ()
 
-let make_lazy_bucket_lookup () =
+(* Attempt to read per-provider rate config from cascade.json.
+   Returns (capacity, refill_rate) or None if not found. *)
+let read_provider_rate_config ~provider json =
+  let open Yojson.Safe.Util in
+  try
+    let rates = member "admission" json |> member "provider_rates" in
+    let provider_obj = member provider rates in
+    let capacity =
+      member "capacity" provider_obj |> to_int_option
+      |> Option.value ~default:default_bucket_capacity
+    in
+    let refill_rate =
+      member "refill_rate" provider_obj |> to_float_option
+      |> Option.value ~default:default_bucket_refill_rate
+    in
+    Some (capacity, refill_rate)
+  with _ -> None
+
+(* Build a lazy bucket lookup that reads per-provider rates from
+   cascade.json when available. *)
+let make_lazy_bucket_lookup ~cascade_json_opt () =
   let table : (string, Keeper_provider_token_bucket.t) Hashtbl.t =
     Hashtbl.create 16
   in
@@ -48,13 +67,69 @@ let make_lazy_bucket_lookup () =
       match Hashtbl.find_opt table provider with
       | Some b -> Some b
       | None ->
+          let capacity, refill_rate =
+            match cascade_json_opt with
+            | Some json ->
+                (match read_provider_rate_config ~provider json with
+                 | Some (c, r) -> (c, r)
+                 | None -> (default_bucket_capacity, default_bucket_refill_rate))
+            | None -> (default_bucket_capacity, default_bucket_refill_rate)
+          in
           let b =
             Keeper_provider_token_bucket.create
               ~provider
-              ~capacity:default_bucket_capacity
-              ~refill_rate:default_bucket_refill_rate
+              ~capacity
+              ~refill_rate
               ~now
           in
+          (* Register WFQ wake hook: when this provider's bucket refills
+             from < 1.0 to >= 1.0, try to wake one waiting keeper. *)
+          Keeper_provider_token_bucket.add_on_refill b (fun () ->
+            match Keeper_wfq_overflow.wake_one wfq_queue with
+            | None -> ()
+            | Some _entry ->
+                (* Woken keeper will be reconsidered on its next heartbeat
+                   tick; we do NOT synchronously dispatch here to avoid
+                   nested admission decisions inside the refill callback. *)
+                ());
+          Hashtbl.add table provider b;
+          Some b)
+
+let make_lazy_bucket_lookup ~cascade_json_opt () =
+  let table : (string, Keeper_provider_token_bucket.t) Hashtbl.t =
+    Hashtbl.create 16
+  in
+  let table_mutex = Stdlib.Mutex.create () in
+  fun provider ->
+    Stdlib.Mutex.protect table_mutex (fun () ->
+      match Hashtbl.find_opt table provider with
+      | Some b -> Some b
+      | None ->
+          let capacity, refill_rate =
+            match cascade_json_opt with
+            | Some json ->
+                (match read_provider_rate_config ~provider json with
+                 | Some (c, r) -> (c, r)
+                 | None -> (default_bucket_capacity, default_bucket_refill_rate))
+            | None -> (default_bucket_capacity, default_bucket_refill_rate)
+          in
+          let b =
+            Keeper_provider_token_bucket.create
+              ~provider
+              ~capacity
+              ~refill_rate
+              ~now
+          in
+          (* Register WFQ wake hook: when this provider's bucket refills
+             from < 1.0 to >= 1.0, try to wake one waiting keeper. *)
+          Keeper_provider_token_bucket.add_on_refill b (fun () ->
+            match Keeper_wfq_overflow.wake_one wfq_queue with
+            | None -> ()
+            | Some _entry ->
+                (* Woken keeper will be reconsidered on its next heartbeat
+                   tick; we do NOT synchronously dispatch here to avoid
+                   nested admission decisions inside the refill callback. *)
+                ());
           Hashtbl.add table provider b;
           Some b)
 
@@ -118,7 +193,7 @@ let init_once_from_base_path ~base_path =
            never observe Done with the default [no_policy]. *)
         set_policy_lookup (fun id ->
           Keeper_admission_registry.lookup registry id);
-        set_bucket_lookup (make_lazy_bucket_lookup ());
+        set_bucket_lookup (make_lazy_bucket_lookup ~cascade_json_opt:(Some json) ());
         mark_init_done ();
         Log.Keeper.info
           "RFC-0026 PR-E-1.6: admission runtime initialised \
@@ -153,6 +228,77 @@ let observe ~keeper_id =
     Keeper_metrics.metric_keeper_admission_shadow_outcome
     ~labels:[("keeper", keeper_id); ("outcome", outcome_label outcome)] ();
   outcome
+
+(** Live admission decision (Phase A1).  Consumes tokens on Dispatch,
+    enqueues on Wait, surfaces on Surface, falls through to legacy on
+    Legacy_path.
+
+    Returns the decision + the acquired bucket (if Dispatch) so the
+    caller can release it after the turn completes. *)
+type live_result =
+  | Live_dispatch of {
+      candidate : Keeper_admission_policy.candidate;
+      drift : Keeper_admission_router.drift_record;
+      bucket : Keeper_provider_token_bucket.t;
+    }
+  | Live_wait
+  | Live_surface of Keeper_admission_router.surface_reason
+  | Live_legacy
+
+let live_result_label = function
+  | Live_dispatch _ -> "dispatch"
+  | Live_wait -> "wait"
+  | Live_surface _ -> "surface"
+  | Live_legacy -> "legacy"
+
+let decide_live ~keeper_id =
+  let outcome =
+    Keeper_admission_glue.decide
+      ~keeper_id
+      ~policies:policy_lookup
+      ~buckets:bucket_lookup
+  in
+  Prometheus.inc_counter
+    Keeper_metrics.metric_keeper_admission_shadow_outcome
+    ~labels:[("keeper", keeper_id); ("outcome", outcome_label outcome)] ();
+  match outcome with
+  | Keeper_admission_glue.Legacy_path -> Live_legacy
+  | Keeper_admission_glue.New_admission decision ->
+      (match decision with
+       | Keeper_admission_router.Dispatch { candidate; drift } ->
+           (* Look up the bucket again to return it for release. *)
+           (match bucket_lookup candidate.Keeper_admission_policy.provider with
+            | Some bucket -> Live_dispatch { candidate; drift; bucket }
+            | None ->
+                (* Should not happen: decide already acquired from this
+                   bucket.  Fall back to legacy for safety. *)
+                Log.Keeper.warn
+                  "%s: admission dispatch bucket disappeared after acquire; \
+                   falling back to legacy"
+                  keeper_id;
+                Live_legacy)
+       | Keeper_admission_router.Wait ->
+           (* Enqueue in WFQ overflow for wake on refill. *)
+           let policy_opt = policy_lookup keeper_id in
+           let weight =
+             match policy_opt with
+             | Some p -> Keeper_admission_policy.weight p
+             | None -> 1
+           in
+           Keeper_wfq_overflow.enqueue wfq_queue
+             { keeper_id; weight; enqueued_at = now () };
+           Live_wait
+       | Keeper_admission_router.Surface reason -> Live_surface reason)
+
+(** Release a bucket token after turn completion.  Idempotent — safe
+    to call even if the token was never acquired (e.g. after exception
+    paths that short-circuit before dispatch). *)
+let release_bucket bucket =
+  Keeper_provider_token_bucket.release bucket
+
+let wfq_depth () = Keeper_wfq_overflow.depth wfq_queue
+
+let wfq_snapshot () = Keeper_wfq_overflow.snapshot wfq_queue
 
 let reset_for_test () =
   Stdlib.Mutex.protect init_mutex (fun () ->

--- a/lib/keeper/keeper_admission_runtime.mli
+++ b/lib/keeper/keeper_admission_runtime.mli
@@ -91,6 +91,48 @@ val observe : keeper_id:string -> Keeper_admission_glue.outcome
     No log line per call (heartbeat already prints one INFO/skip per
     turn; doubling the volume is noise). *)
 
+(** {1 Live admission decision (Phase A1) } *)
+
+type live_result =
+  | Live_dispatch of {
+      candidate : Keeper_admission_policy.candidate;
+      drift : Keeper_admission_router.drift_record;
+      bucket : Keeper_provider_token_bucket.t;
+    }
+  (** Token acquired.  Caller runs the cycle and must call
+      [release_bucket] when done. *)
+  | Live_wait
+  (** Enqueued in WFQ overflow; next heartbeat will retry. *)
+  | Live_surface of Keeper_admission_router.surface_reason
+  (** Misconfiguration — operator-visible event. *)
+  | Live_legacy
+  (** Flag off or no policy — fall through to legacy semaphore. *)
+
+val decide_live : keeper_id:string -> live_result
+(** Live admission decision.  Gated by [MASC_ADMISSION_USE_NEW]:
+
+    - [Legacy_path] -> [Live_legacy]
+    - [Dispatch] -> [Live_dispatch] (token consumed)
+    - [Wait] -> [Live_wait] (enqueued in WFQ)
+    - [Surface] -> [Live_surface]
+
+    Side effects: bucket token decrement on Dispatch, WFQ enqueue on
+    Wait, Prometheus counter increment for all paths. *)
+
+val release_bucket : Keeper_provider_token_bucket.t -> unit
+(** Return a token to its bucket.  Call after turn completion. *)
+
+val live_result_label : live_result -> string
+(** String label for metrics: "dispatch", "wait", "surface", "legacy". *)
+
+(** {1 WFQ observability } *)
+
+val wfq_depth : unit -> int
+(** Current number of keepers waiting in the WFQ overflow queue. *)
+
+val wfq_snapshot : unit -> Keeper_wfq_overflow.entry list
+(** Read-only copy of the WFQ queue contents. *)
+
 (** {1 Test seam} *)
 
 val reset_for_test : unit -> unit

--- a/lib/keeper/keeper_cascade_selector.ml
+++ b/lib/keeper/keeper_cascade_selector.ml
@@ -1,0 +1,53 @@
+(** Keeper_cascade_selector -- L1 Proactive Routing (RFC-0041 Phase B3). *)
+
+open Cascade_ref
+
+let select_item_for_turn
+    ~(keeper_name : string)
+    ~(cascade_profile : cascade_profile)
+    ~(health_cache : Keeper_health_probe.health_status)
+    ~(last_used_item : string option)
+    : (cascade_item, [> `No_available_item ]) result =
+  let rec try_group group_name visited =
+    if List.mem group_name visited then
+      Error `No_available_item
+    else
+      match find_group cascade_profile group_name with
+      | None -> Error `No_available_item
+      | Some group ->
+          let items = order_items group.strategy group.items in
+          let items =
+            match group.strategy, last_used_item with
+            | RoundRobin, Some last_id ->
+                let rec rotate = function
+                  | [] -> []
+                  | item :: rest ->
+                      if String.equal item.id last_id then rest @ [item]
+                      else item :: rotate rest
+                in
+                rotate items
+            | _ -> items
+          in
+          let rec find_healthy = function
+            | [] -> None
+            | item :: rest ->
+                if Keeper_health_probe.is_item_healthy ~keeper_name ~item_id:item.id then
+                  Some item
+                else
+                  find_healthy rest
+          in
+          match find_healthy items with
+          | Some item -> Ok item
+          | None ->
+              (match group.fallback_group with
+               | Some next ->
+                   try_group next (group_name :: visited)
+               | None ->
+                   Error `No_available_item)
+  in
+  let start_group =
+    match cascade_profile.groups with
+    | first :: _ -> first.name
+    | [] -> cascade_profile.name
+  in
+  try_group start_group []

--- a/lib/keeper/keeper_cascade_selector.mli
+++ b/lib/keeper/keeper_cascade_selector.mli
@@ -1,0 +1,24 @@
+(** Keeper_cascade_selector — L1 Proactive Routing (RFC-0041 Phase B3).
+
+    Per-turn item selection before dispatch. Selects the healthiest
+    available cascade item following group strategy and fallback chains. *)
+
+(** [select_item_for_turn ~keeper_name ~cascade_profile ~health_cache ~last_used_item]
+    selects an item for the current turn.
+
+    - Orders items within the group according to strategy.
+    - Skips unhealthy items (per-item health cache).
+    - Follows fallback_group chain when a group is fully unhealthy.
+    - Detects cycles in fallback chain.
+
+    Returns [Error `No_available_item] when all groups are exhausted.
+
+    [last_used_item] is used by RoundRobin to advance the cursor.
+    [health_cache] parameter is accepted for interface consistency;
+    the actual health state is read from [Keeper_health_probe]. *)
+val select_item_for_turn :
+  keeper_name:string ->
+  cascade_profile:Cascade_ref.cascade_profile ->
+  health_cache:Keeper_health_probe.health_status ->
+  last_used_item:string option ->
+  (Cascade_ref.cascade_item, [> `No_available_item ]) result

--- a/lib/keeper/keeper_health_probe.ml
+++ b/lib/keeper/keeper_health_probe.ml
@@ -1,34 +1,89 @@
 (* Asynchronous health probe for condition-based auto-resume.
-   See [.mli] for TLA+ modeling notes. *)
+   See [.mli] for TLA+ modeling notes.
+
+   RFC-0041 Phase B2: migrated from per-cascade (string) cache keys to
+   per-keeper, per-item (string * string) keys. The old [is_healthy]
+   remains as a backward-compatible alias that checks whether ANY item
+   for the keeper is healthy. *)
 
 type health_status =
   | Unknown
   | Healthy
   | Unhealthy of string
 
-let health_cache : (string, health_status * float) Hashtbl.t =
+(** Per-keeper, per-item health cache.
+    Key: (keeper_name, item_id). Value: (status, timestamp). *)
+let health_cache : ((string * string), health_status * float) Hashtbl.t =
   Hashtbl.create 16
 
 let health_cache_mu = Eio.Mutex.create ()
 
-let is_healthy ~keeper_name =
+(* ------------------------------------------------------------------ *)
+(* Per-item health queries                                            *)
+(* ------------------------------------------------------------------ *)
+
+(** [is_item_healthy ~keeper_name ~item_id] returns the cached health
+    status for the specific keeper+item pair. *)
+let is_item_healthy ~keeper_name ~item_id =
   Eio.Mutex.use_ro health_cache_mu (fun () ->
-    match Hashtbl.find_opt health_cache keeper_name with
+    match Hashtbl.find_opt health_cache (keeper_name, item_id) with
     | Some (Healthy, _) -> true
     | _ -> false)
 
+(** [set_item_health ~keeper_name ~item_id status] updates the cache
+    for a specific keeper+item pair. *)
+let set_item_health ~keeper_name ~item_id status =
+  Eio.Mutex.use_rw ~protect:true health_cache_mu (fun () ->
+    Hashtbl.replace health_cache (keeper_name, item_id)
+      (status, Time_compat.now ()))
+
+(** [record_item_result ~keeper_name ~item_id ~success] updates the
+    health state based on turn outcome. Success -> Healthy immediately.
+    Failure -> Unhealthy (no Degraded intermediate for now). *)
+let record_item_result ~keeper_name ~item_id ~success =
+  let status =
+    if success then Healthy else Unhealthy "turn_failure"
+  in
+  set_item_health ~keeper_name ~item_id status
+
+(* ------------------------------------------------------------------ *)
+(* Backward-compatible per-keeper health (deprecated)                 *)
+(* ------------------------------------------------------------------ *)
+
+(** [is_healthy ~keeper_name] returns true if ANY item for this keeper
+    is Healthy. This is the backward-compatible alias for code that
+    hasn't migrated to per-item health checks yet.
+
+    Deprecated: use [is_item_healthy] for RFC-0041 per-item routing. *)
+let is_healthy ~keeper_name =
+  Eio.Mutex.use_ro health_cache_mu (fun () ->
+    let found = ref false in
+    Hashtbl.iter
+      (fun (kn, _item_id) (status, _ts) ->
+        if String.equal kn keeper_name then
+          match status with
+          | Healthy -> found := true
+          | _ -> ())
+      health_cache;
+    !found)
+
 let set_health ~keeper_name status =
   Eio.Mutex.use_rw ~protect:true health_cache_mu (fun () ->
-    Hashtbl.replace health_cache keeper_name
+    Hashtbl.replace health_cache (keeper_name, "")
       (status, Time_compat.now ()))
 
 (* ------------------------------------------------------------------ *)
 (* Cascade health check                                               *)
+(* ------------------------------------------------------------------ *)
 
 (** Compute failure ratio per cascade from registry entries.
     Returns (cascade_name, is_healthy) where healthy means
     failure_ratio < 0.10.  The threshold is hard-coded as a stub;
-    production tuning will replace it with a configurable value. *)
+    production tuning will replace it with a configurable value.
+
+    Note: this still operates at cascade granularity for the background
+    probe. Per-item health is updated via [record_item_result] after
+    each turn. *)
 let check_cascade_health ~base_path =
   let entries = Keeper_registry.all ~base_path () in
   let by_cascade = Hashtbl.create 8 in
@@ -57,13 +112,15 @@ let check_cascade_health ~base_path =
 
 (* ------------------------------------------------------------------ *)
 (* Background probe fiber                                             *)
+(* ------------------------------------------------------------------ *)
 
 let run_once ~base_path =
   let results = check_cascade_health ~base_path in
   List.iter
     (fun (cascade, healthy) ->
       let status = if healthy then Healthy else Unhealthy "failure_ratio" in
-      (* Cache keyed by cascade name so ResumeFromPause can look it up. *)
+      (* Cache keyed by cascade name so ResumeFromPause can look it up.
+         Uses empty item_id for backward compat. *)
       set_health ~keeper_name:cascade status)
     results
 

--- a/lib/keeper/keeper_health_probe.mli
+++ b/lib/keeper/keeper_health_probe.mli
@@ -1,17 +1,49 @@
 (** Asynchronous health probe for condition-based auto-resume.
 
-    This module runs outside the supervisor sweep to avoid slowing down
-    the 30s reconcile loop.  Results are cached in a lightweight hashtable
-    and queried synchronously by [should_attempt_resume].
+    RFC-0041 Phase B2: migrated from per-cascade cache keys to
+    per-keeper, per-item (string * string) keys.
 
     TLA+ model: [healthProbeOk] is an Environment variable updated by
     an independent async action.  The supervisor's [ResumeFromPause]
     action reads the cached value without performing I/O. *)
 
-(** [is_healthy ~keeper_name] returns the cached health status for the
-    given keeper.  Returns [false] when no probe result is available
-    (Unknown) or the last probe reported Unhealthy. *)
+(** Health status variants. *)
+type health_status =
+  | Unknown
+  | Healthy
+  | Unhealthy of string
+
+(** {1 Per-item health (RFC-0041)} *)
+
+(** [is_item_healthy ~keeper_name ~item_id] returns the cached health
+    status for the specific keeper+item pair.
+    Returns [false] when no probe result is available (Unknown) or
+    the last probe reported Unhealthy. *)
+val is_item_healthy : keeper_name:string -> item_id:string -> bool
+
+(** [set_item_health ~keeper_name ~item_id status] updates the cache
+    for a specific keeper+item pair. *)
+val set_item_health :
+  keeper_name:string -> item_id:string ->
+  health_status -> unit
+
+(** [record_item_result ~keeper_name ~item_id ~success] updates health
+    state based on turn outcome. Success -> Healthy, Failure -> Unhealthy. *)
+val record_item_result :
+  keeper_name:string -> item_id:string -> success:bool -> unit
+
+(** {1 Backward-compatible per-keeper health (deprecated)} *)
+
+(** [is_healthy ~keeper_name] returns true if ANY item for this keeper
+    is Healthy. Deprecated: use [is_item_healthy] for per-item routing.
+    Kept for existing callers that haven't migrated yet. *)
 val is_healthy : keeper_name:string -> bool
+
+(** [set_health ~keeper_name status] sets health for the legacy
+    per-cascade key. Kept for the background probe fiber. *)
+val set_health : keeper_name:string -> health_status -> unit
+
+(** {1 Cascade health scan} *)
 
 (** [check_cascade_health ~base_path] scans the registry and computes
     the failure ratio for each active cascade.  Returns a list of
@@ -19,6 +51,8 @@ val is_healthy : keeper_name:string -> bool
     should be called from the probe fiber, not the supervisor sweep. *)
 val check_cascade_health :
   base_path:string -> (string * bool) list
+
+(** {1 Background probe fiber} *)
 
 (** [start_probe ~sw ~base_path ~interval_sec] spawns a background Eio
     fiber that runs [check_cascade_health] every [interval_sec] seconds

--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -410,6 +410,191 @@ let persist_message_cursor_updates ~config (meta : keeper_meta) updates =
         Log.Keeper.warn "write_meta failed (message cursor update): %s" e;
         updated
 
+(* ── RFC-0026 Phase A1 helpers (defined after with_in_turn_liveness_pulse
+   to avoid forward reference) ───────────────────────────────────────── *)
+
+(** Run keeper cycle with semaphore slot control (legacy path). *)
+let run_keeper_cycle_with_slot ~ctx ~meta_after_cursor_persist ~stop ~obs
+    ~(turn_decision : Keeper_world_observation.keeper_cycle_decision)
+    ~shared_context ~semaphore_wait_ms ~slot_control =
+  match
+    with_in_turn_liveness_pulse ~ctx ~meta:meta_after_cursor_persist ~stop
+      (fun () ->
+         Keeper_unified_turn.run_keeper_cycle
+           ~config:ctx.config
+           ~meta:meta_after_cursor_persist
+           ~observation:obs
+           ~generation:meta_after_cursor_persist.runtime.generation
+           ~channel:turn_decision.channel
+           ~semaphore_wait_ms
+           ~turn_slot_control:slot_control
+           ~shared_context
+           ())
+  with
+  | Error err ->
+      let e_str = Agent_sdk.Error.to_string err in
+      Log.Keeper.debug "%s: keeper cycle failed: %s"
+        meta_after_cursor_persist.name e_str;
+      if String_util.contains_substring e_str "Eio switch not available"
+         || String_util.contains_substring e_str "Eio net not available"
+      then begin
+        Log.Keeper.error
+          "%s: fatal environment error — promoting to Keeper_fiber_crash: %s"
+          meta_after_cursor_persist.name e_str;
+        Prometheus.inc_counter
+          Keeper_metrics.metric_keeper_heartbeat_failures
+          ~labels:[("keeper", meta_after_cursor_persist.name);
+                   ("phase", "fatal_environment")]
+          ();
+        Keeper_registry.set_failure_reason
+          ~base_path:ctx.config.base_path meta_after_cursor_persist.name
+          (Some (Keeper_registry.Exception
+            (Printf.sprintf "fatal environment error: %s" e_str)));
+        raise Keeper_registry.Keeper_fiber_crash
+      end;
+      if is_oas_timeout_budget_error err
+      then begin
+        let keeper_name = meta_after_cursor_persist.name in
+        let prior_strikes =
+          prior_oas_timeout_budget_strikes
+            ~base_path:ctx.config.base_path
+            ~keeper_name
+        in
+        let strikes =
+          Keeper_turn_slot.bump_budget_exhaustion_seeded
+            ~keeper_name
+            ~prior_strikes
+        in
+        Keeper_registry.set_failure_reason
+          ~base_path:ctx.config.base_path keeper_name
+          (Some (Keeper_registry.Oas_timeout_budget_loop
+                   { count = strikes }));
+        record_oas_timeout_budget_observation
+          ~base_path:ctx.config.base_path
+          ~keeper_name;
+        if strikes >= Keeper_turn_slot.oas_timeout_budget_strike_limit then begin
+          Log.Keeper.error
+            "%s: %d consecutive oas_timeout_budget strikes \
+             (>= %d) — promoting to Keeper_fiber_crash for \
+             supervisor auto-pause"
+            keeper_name strikes Keeper_turn_slot.oas_timeout_budget_strike_limit;
+          Prometheus.inc_counter
+            Keeper_metrics.metric_keeper_oas_timeout_budget_strike
+            ~labels:[("keeper", keeper_name); ("outcome", "promote")]
+            ();
+          Keeper_turn_slot.reset_budget_exhaustion ~keeper_name;
+          raise Keeper_registry.Keeper_fiber_crash
+        end else begin
+          Log.Keeper.warn
+            "%s: oas_timeout_budget strike %d/%d \
+             (next strike will trigger fiber crash + auto-pause)"
+            keeper_name strikes Keeper_turn_slot.oas_timeout_budget_strike_limit;
+          Prometheus.inc_counter
+            Keeper_metrics.metric_keeper_oas_timeout_budget_strike
+            ~labels:[("keeper", keeper_name); ("outcome", "warn")]
+            ()
+        end
+      end;
+      (match read_meta ctx.config meta_after_cursor_persist.name with
+       | Ok (Some latest) -> latest
+       | Ok None ->
+         Log.Keeper.error "keeper:%s read_meta returned None after turn failure, using stale meta"
+           meta_after_cursor_persist.name;
+         Prometheus.inc_counter
+           Keeper_metrics.metric_keeper_meta_read_failures
+           ~labels:[("keeper", meta_after_cursor_persist.name);
+                    ("site", "none_after_failure")]
+           ();
+         meta_after_cursor_persist
+       | Error e ->
+         Log.Keeper.error "keeper:%s read_meta failed after turn failure (%s), using stale meta"
+           meta_after_cursor_persist.name e;
+         Prometheus.inc_counter
+           Keeper_metrics.metric_keeper_meta_read_failures
+           ~labels:[("keeper", meta_after_cursor_persist.name);
+                    ("site", "error_after_failure")]
+           ();
+         meta_after_cursor_persist)
+  | Ok updated ->
+      Keeper_turn_slot.reset_budget_exhaustion
+        ~keeper_name:meta_after_cursor_persist.name;
+      clear_oas_timeout_budget_failure_reason
+        ~base_path:ctx.config.base_path
+        ~keeper_name:meta_after_cursor_persist.name;
+      updated
+
+(** Handle semaphore wait timeout for legacy path. *)
+let handle_semaphore_wait_timeout ~ctx ~meta_after_triage
+    ~(turn_decision : Keeper_world_observation.keeper_cycle_decision)
+    (timeout : Keeper_turn_slot.semaphore_wait_timeout) =
+  let phase_label =
+    Keeper_turn_slot.semaphore_wait_phase_to_string
+      timeout.timeout_phase
+  in
+  record_semaphore_wait_observation
+    ~base_path:ctx.config.base_path
+    ~keeper_name:meta_after_triage.name
+    ~channel:turn_decision.channel
+    ~phase_label
+    ~kind:Semaphore_wait_timeout
+    ();
+  let queue_ahead_text =
+    match timeout.timeout_queue_ahead with
+    | None -> ""
+    | Some ahead -> Printf.sprintf " queue_ahead=%d" ahead
+  in
+  let holder_text =
+    match timeout.timeout_holders with
+    | [] -> "none"
+    | holders ->
+      holders
+      |> List.map (fun (name, age) ->
+           Printf.sprintf "%s/%.0fs" name age)
+      |> String.concat ", "
+  in
+  let persisted_blocker =
+    Printf.sprintf
+      "skipped: semaphore wait > %.0fs phase=%s \
+       (cascade=%s%s queue_depth=%d autonomous_available=%d \
+       reactive_available=%d turn_available=%d)"
+      timeout.timeout_wait_sec
+      phase_label
+      meta_after_triage.cascade_name
+      queue_ahead_text
+      timeout.timeout_queue_depth
+      timeout.timeout_autonomous_available
+      timeout.timeout_reactive_available
+      timeout.timeout_turn_available
+  in
+  let log_diagnostic =
+    Printf.sprintf "%s holders=[%s]" persisted_blocker holder_text
+  in
+  let blocker_class =
+    match timeout.timeout_phase with
+    | Keeper_turn_slot.Autonomous_queue_head
+    | Keeper_turn_slot.Autonomous_slot ->
+      Keeper_types.Autonomous_slot_wait_timeout
+    | Keeper_turn_slot.Reactive_slot
+    | Keeper_turn_slot.Turn_slot ->
+      Keeper_types.Turn_timeout_after_queue_wait
+  in
+  Log.Keeper.warn
+    "%s: skipping turn (%s)"
+    meta_after_triage.name log_diagnostic;
+  Prometheus.inc_counter
+    Keeper_metrics.metric_keeper_semaphore_wait_timeout
+    ~labels:[("keeper", meta_after_triage.name);
+             ("channel", (Keeper_world_observation.channel_to_string
+                            turn_decision.channel))]
+    ();
+  Keeper_types.map_runtime
+    (fun rt ->
+      { rt with
+        last_blocker = persisted_blocker;
+        last_blocker_class = Some blocker_class;
+      })
+    meta_after_triage
+
 let run_keepalive_unified_turn
       ~(ctx : _ context)
       ~(meta_after_triage : keeper_meta)
@@ -672,238 +857,220 @@ let run_keepalive_unified_turn
           ~channel:turn_decision.channel
           ~kind:Semaphore_wait_pending
           ();
-        (* RFC-0026 PR-E-1.6+1.7 shadow: ask the new admission router
-           what it WOULD have decided, increment the shadow outcome
-           counter, then fall through to the existing semaphore path
-           unchanged.
-
+        (* RFC-0026 Phase A1: live admission dispatch wiring.
            [init_once_from_base_path] populates the registry from
            [<base_path>/.masc/config/cascade.json] [admission.*]
            sub-tables on first call.  When the JSON has no admission
-           blocks the registry stays empty and [observe] returns
-           [Legacy_path] always — counter increment still proves the
-           call site is alive.  When admission blocks are present,
-           the counter starts emitting the [dispatch]/[wait]/[surface]
-           label distribution that PR-E-1.8 will act on. *)
+           blocks the registry stays empty and [decide_live] returns
+           [Live_legacy] always — caller falls through to the existing
+           semaphore path. *)
         Keeper_admission_runtime.init_once_from_base_path
           ~base_path:ctx.config.base_path;
-        let (_ : Keeper_admission_glue.outcome) =
-          Keeper_admission_runtime.observe
+        let admission_result =
+          Keeper_admission_runtime.decide_live
             ~keeper_id:meta_after_triage.name
         in
-        match
-          Keeper_turn_slot.with_keeper_turn_slot_control
-            ~cascade_profile:meta_after_triage.cascade_name
-            ~keeper_name:meta_after_triage.name
-            ~channel:turn_decision.channel (fun ~semaphore_wait_ms ~slot_control ->
-            match
-              with_in_turn_liveness_pulse ~ctx ~meta:meta_after_cursor_persist ~stop
-                (fun () ->
-                  Keeper_unified_turn.run_keeper_cycle
-                    ~config:ctx.config
-                    ~meta:meta_after_cursor_persist
-                    ~observation:obs
-                    ~generation:meta_after_cursor_persist.runtime.generation
-                    ~channel:turn_decision.channel
-                    ~semaphore_wait_ms:semaphore_wait_ms
-                    ~turn_slot_control:slot_control
-                    ~shared_context
-                    ())
+        (match admission_result with
+         | Keeper_admission_runtime.Live_dispatch { drift; _ } ->
+             Log.Keeper.info
+               "%s: admission dispatch provider=%s drift=%s"
+               meta_after_triage.name
+               drift.actual_provider
+               drift.reason
+         | Keeper_admission_runtime.Live_wait ->
+             Log.Keeper.info
+               "%s: admission wait (enqueued in WFQ, depth=%d)"
+               meta_after_triage.name
+               (Keeper_admission_runtime.wfq_depth ())
+         | Keeper_admission_runtime.Live_surface reason ->
+             let reason_str = match reason with
+               | Keeper_admission_router.Min_tier_unsatisfiable ->
+                   "min_tier_unsatisfiable"
+               | Keeper_admission_router.All_candidates_throttled ->
+                   "all_candidates_throttled"
+             in
+             Log.Keeper.warn
+               "%s: admission surface reason=%s"
+               meta_after_triage.name reason_str
+         | Keeper_admission_runtime.Live_legacy ->
+             ());
+        match admission_result with
+        | Keeper_admission_runtime.Live_legacy ->
+            (* Flag off or no policy — fall through to legacy semaphore path.
+               Preserve all existing telemetry and error handling. *)
+            (match
+              Keeper_turn_slot.with_keeper_turn_slot_control
+                ~cascade_profile:meta_after_triage.cascade_name
+                ~keeper_name:meta_after_triage.name
+                ~channel:turn_decision.channel (fun ~semaphore_wait_ms ~slot_control ->
+                run_keeper_cycle_with_slot ~ctx ~meta_after_cursor_persist ~stop ~obs
+                  ~turn_decision ~shared_context ~semaphore_wait_ms ~slot_control)
             with
-            | Error err ->
-              let e_str = Agent_sdk.Error.to_string err in
-              (* The inner [run_keeper_cycle] already emits a detailed ERROR
-                 ("keeper cycle FAILED cascade=... max_context=... error=...")
-                 for every Error path, so re-logging at ERROR here duplicates
-                 the line for the same event. Keep a debug trace for local
-                 readers; escalate to ERROR only on the fatal-environment
-                 branch, which is the real signal this layer owns. *)
-              Log.Keeper.debug "%s: keeper cycle failed: %s"
-                meta_after_cursor_persist.name e_str;
-              if String_util.contains_substring e_str "Eio switch not available"
-                 || String_util.contains_substring e_str "Eio net not available"
-              then begin
-                Log.Keeper.error
-                  "%s: fatal environment error — promoting to Keeper_fiber_crash: %s"
-                  meta_after_cursor_persist.name e_str;
-                Prometheus.inc_counter
-                  Keeper_metrics.metric_keeper_heartbeat_failures
-                  ~labels:[("keeper", meta_after_cursor_persist.name); ("phase", "fatal_environment")]
-                  ();
-                Keeper_registry.set_failure_reason
-                  ~base_path:ctx.config.base_path meta_after_cursor_persist.name
-                  (Some (Keeper_registry.Exception
-                    (Printf.sprintf "fatal environment error: %s" e_str)));
-                raise Keeper_registry.Keeper_fiber_crash
-              end;
-              (* PR-M (Leak 9): N-strike promotion for repeated
-                 [oas_timeout_budget]. See the comment block above
-                 [consecutive_budget_exhaustions] for why a single
-                 strike must not trip the crash but
-                 [oas_timeout_budget_strike_limit] in a row should —
-                 same-fiber retry has the same context budget, so a
-                 budget exhaustion is unrecoverable in place and only
-                 [sweep_and_recover] can clear it. *)
-              if is_oas_timeout_budget_error err
-              then begin
-                let keeper_name = meta_after_cursor_persist.name in
-                let prior_strikes =
-                  prior_oas_timeout_budget_strikes
-                    ~base_path:ctx.config.base_path
-                    ~keeper_name
-                in
-                let strikes =
-                  Keeper_turn_slot.bump_budget_exhaustion_seeded
-                    ~keeper_name
-                    ~prior_strikes
-                in
-                Keeper_registry.set_failure_reason
-                  ~base_path:ctx.config.base_path keeper_name
-                  (Some (Keeper_registry.Oas_timeout_budget_loop
-                           { count = strikes }));
-                record_oas_timeout_budget_observation
-                  ~base_path:ctx.config.base_path
-                  ~keeper_name;
-                if strikes >= Keeper_turn_slot.oas_timeout_budget_strike_limit then begin
-                  Log.Keeper.error
-                    "%s: %d consecutive oas_timeout_budget strikes \
-                     (>= %d) — promoting to Keeper_fiber_crash for \
-                     supervisor auto-pause"
-                    keeper_name strikes Keeper_turn_slot.oas_timeout_budget_strike_limit;
-                  Prometheus.inc_counter
-                    Keeper_metrics.metric_keeper_oas_timeout_budget_strike
-                    ~labels:[
-                      ("keeper", keeper_name);
-                      ("outcome", "promote");
-                    ] ();
-                  Keeper_turn_slot.reset_budget_exhaustion ~keeper_name;
-                  raise Keeper_registry.Keeper_fiber_crash
-                end else begin
-                  Log.Keeper.warn
-                    "%s: oas_timeout_budget strike %d/%d \
-                     (next strike will trigger fiber crash + auto-pause)"
-                    keeper_name strikes Keeper_turn_slot.oas_timeout_budget_strike_limit;
-                  Prometheus.inc_counter
-                    Keeper_metrics.metric_keeper_oas_timeout_budget_strike
-                    ~labels:[
-                      ("keeper", keeper_name);
-                      ("outcome", "warn");
-                    ] ()
-                end
-              end;
-              (match read_meta ctx.config meta_after_cursor_persist.name with
-               | Ok (Some latest) -> latest
-               | Ok None ->
-                 Log.Keeper.error "keeper:%s read_meta returned None after turn failure, using stale meta"
-                   meta_after_cursor_persist.name;
-                 Prometheus.inc_counter
-                   Keeper_metrics.metric_keeper_meta_read_failures
-                   ~labels:[("keeper", meta_after_cursor_persist.name); ("site", "none_after_failure")]
-                   ();
-                 meta_after_cursor_persist
-               | Error e ->
-                 Log.Keeper.error "keeper:%s read_meta failed after turn failure (%s), using stale meta"
-                   meta_after_cursor_persist.name e;
-                 Prometheus.inc_counter
-                   Keeper_metrics.metric_keeper_meta_read_failures
-                   ~labels:[("keeper", meta_after_cursor_persist.name); ("site", "error_after_failure")]
-                   ();
-                 meta_after_cursor_persist)
-            | Ok updated ->
-              (* PR-M: success clears the strike counter so a single
-                 transient budget exhaustion does not trickle into the
-                 next 4h-window's strike limit. *)
-              Keeper_turn_slot.reset_budget_exhaustion ~keeper_name:meta_after_cursor_persist.name;
-              clear_oas_timeout_budget_failure_reason
-                ~base_path:ctx.config.base_path
-                ~keeper_name:meta_after_cursor_persist.name;
-              updated)
-        with
-        | Ok meta -> meta
-        | Error (`Semaphore_wait_timeout timeout) ->
-          (* Slot/queue wait exceeded the cap — not a keeper failure. Skip this
-             cycle and let the next heartbeat retry. Failure counters
-             intentionally NOT ticked (this is starvation, not crash); but
-             [last_blocker_class] IS updated so the dashboard surfaces the
-             stuck reason — without it the keeper appears as
-             [outcome=never_started, blocker_class=null] and operators see
-             "alive but invisible" (2026-05-05 fleet stuck diagnosis
-             evidence). *)
-          let phase_label =
-            Keeper_turn_slot.semaphore_wait_phase_to_string
-              timeout.timeout_phase
-          in
-          record_semaphore_wait_observation
-            ~base_path:ctx.config.base_path
-            ~keeper_name:meta_after_triage.name
-            ~channel:turn_decision.channel
-            ~phase_label
-            ~kind:Semaphore_wait_timeout
-            ();
-          let queue_ahead_text =
-            match timeout.timeout_queue_ahead with
-            | None -> ""
-            | Some ahead -> Printf.sprintf " queue_ahead=%d" ahead
-          in
-          let holder_text =
-            match timeout.timeout_holders with
-            | [] -> "none"
-            | holders ->
-              holders
-              |> List.map (fun (name, age) ->
-                   Printf.sprintf "%s/%.0fs" name age)
-              |> String.concat ", "
-          in
-          (* #13099 review: [last_blocker] gets capped to 200 chars by
-             [cap_blocker] on meta load (narrative budget for dashboards),
-             so the longer holder snapshot would be ellipsized after a
-             restart and lose the diagnostic value.  Split into two
-             strings:
-             - [persisted_blocker]: short narrative the dashboards see
-               and that survives the cap;
-             - [log_diagnostic]: the full holder snapshot, emitted via
-               Log.Keeper.warn (uncapped) so operators tailing logs can
-               still attribute the starvation to specific peers.  *)
-          let persisted_blocker =
-            Printf.sprintf
-              "skipped: semaphore wait > %.0fs phase=%s \
-               (cascade=%s%s queue_depth=%d autonomous_available=%d \
-               reactive_available=%d turn_available=%d)"
-              timeout.timeout_wait_sec
-              phase_label
-              meta_after_triage.cascade_name
-              queue_ahead_text
-              timeout.timeout_queue_depth
-              timeout.timeout_autonomous_available
-              timeout.timeout_reactive_available
-              timeout.timeout_turn_available
-          in
-          let log_diagnostic =
-            Printf.sprintf "%s holders=[%s]" persisted_blocker holder_text
-          in
-          let blocker_class =
-            match timeout.timeout_phase with
-            | Keeper_turn_slot.Autonomous_queue_head
-            | Keeper_turn_slot.Autonomous_slot ->
-              Keeper_types.Autonomous_slot_wait_timeout
-            | Keeper_turn_slot.Reactive_slot
-            | Keeper_turn_slot.Turn_slot ->
-              Keeper_types.Turn_timeout_after_queue_wait
-          in
-          Log.Keeper.warn
-            "%s: skipping turn (%s)"
-            meta_after_triage.name log_diagnostic;
-          Prometheus.inc_counter
-            Keeper_metrics.metric_keeper_semaphore_wait_timeout
-            ~labels:[("keeper", meta_after_triage.name); ("channel", (Keeper_world_observation.channel_to_string turn_decision.channel))]
-            ();
-          Keeper_types.map_runtime
-            (fun rt ->
-              { rt with
-                last_blocker = persisted_blocker;
-                last_blocker_class = Some blocker_class;
-              })
-            meta_after_triage)
+            | Ok meta -> meta
+            | Error (`Semaphore_wait_timeout timeout) ->
+                handle_semaphore_wait_timeout ~ctx ~meta_after_triage ~turn_decision timeout)
+        | Keeper_admission_runtime.Live_wait ->
+            (* Enqueued in WFQ overflow — skip this turn, retry on next
+               heartbeat when refill wakes this keeper. *)
+            let blocker_text =
+              Printf.sprintf "admission_wait: wfq_depth=%d"
+                (Keeper_admission_runtime.wfq_depth ())
+            in
+            Log.Keeper.info "%s: skipping turn (%s)"
+              meta_after_triage.name blocker_text;
+            Keeper_types.map_runtime
+              (fun rt ->
+                { rt with
+                  last_blocker = blocker_text;
+                  last_blocker_class = Some Keeper_types.Admission_wait_wfq;
+                })
+              meta_after_triage
+        | Keeper_admission_runtime.Live_surface reason ->
+            let reason_str = match reason with
+              | Keeper_admission_router.Min_tier_unsatisfiable ->
+                  "admission_surface: min_tier_unsatisfiable"
+              | Keeper_admission_router.All_candidates_throttled ->
+                  "admission_surface: all_candidates_throttled"
+            in
+            Log.Keeper.warn "%s: skipping turn (%s)"
+              meta_after_triage.name reason_str;
+            Prometheus.inc_counter
+              Keeper_metrics.metric_keeper_admission_shadow_outcome
+              ~labels:[("keeper", meta_after_triage.name);
+                       ("outcome", "surface")] ();
+            Keeper_types.map_runtime
+              (fun rt ->
+                { rt with
+                  last_blocker = reason_str;
+                  last_blocker_class = Some Keeper_types.Admission_surface;
+                })
+              meta_after_triage
+        | Keeper_admission_runtime.Live_dispatch { candidate; drift; bucket } ->
+            (* Bypass semaphore, run cycle directly with acquired token.
+               Release token via Fun.protect to ensure no leak on exception. *)
+            Log.Keeper.info
+              "%s: admission dispatch provider=%s model=%s tier=%s drift=%s"
+              meta_after_triage.name
+              candidate.provider
+              candidate.model
+              (Keeper_admission_policy.tier_label candidate.tier)
+              drift.reason;
+            Prometheus.inc_counter
+              Keeper_metrics.metric_keeper_admission_shadow_outcome
+              ~labels:[("keeper", meta_after_triage.name);
+                       ("outcome", "dispatch");
+                       ("provider", drift.actual_provider);
+                       ("drift", drift.reason)] ();
+            Fun.protect
+              ~finally:(fun () ->
+                Keeper_admission_runtime.release_bucket bucket)
+              (fun () ->
+                match
+                  with_in_turn_liveness_pulse ~ctx ~meta:meta_after_cursor_persist ~stop
+                    (fun () ->
+                      Keeper_unified_turn.run_keeper_cycle
+                        ~config:ctx.config
+                        ~meta:meta_after_cursor_persist
+                        ~observation:obs
+                        ~generation:meta_after_cursor_persist.runtime.generation
+                        ~channel:turn_decision.channel
+                        ~semaphore_wait_ms:0
+                        ~shared_context
+                        ())
+                with
+                | Error err ->
+                    let e_str = Agent_sdk.Error.to_string err in
+                    Log.Keeper.debug "%s: keeper cycle failed: %s"
+                      meta_after_cursor_persist.name e_str;
+                    if String_util.contains_substring e_str "Eio switch not available"
+                       || String_util.contains_substring e_str "Eio net not available"
+                    then begin
+                      Log.Keeper.error
+                        "%s: fatal environment error — promoting to Keeper_fiber_crash: %s"
+                        meta_after_cursor_persist.name e_str;
+                      Prometheus.inc_counter
+                        Keeper_metrics.metric_keeper_heartbeat_failures
+                        ~labels:[("keeper", meta_after_cursor_persist.name);
+                                 ("phase", "fatal_environment")]
+                        ();
+                      Keeper_registry.set_failure_reason
+                        ~base_path:ctx.config.base_path meta_after_cursor_persist.name
+                        (Some (Keeper_registry.Exception
+                          (Printf.sprintf "fatal environment error: %s" e_str)));
+                      raise Keeper_registry.Keeper_fiber_crash
+                    end;
+                    if is_oas_timeout_budget_error err
+                    then begin
+                      let keeper_name = meta_after_cursor_persist.name in
+                      let prior_strikes =
+                        prior_oas_timeout_budget_strikes
+                          ~base_path:ctx.config.base_path
+                          ~keeper_name
+                      in
+                      let strikes =
+                        Keeper_turn_slot.bump_budget_exhaustion_seeded
+                          ~keeper_name
+                          ~prior_strikes
+                      in
+                      Keeper_registry.set_failure_reason
+                        ~base_path:ctx.config.base_path keeper_name
+                        (Some (Keeper_registry.Oas_timeout_budget_loop
+                                 { count = strikes }));
+                      record_oas_timeout_budget_observation
+                        ~base_path:ctx.config.base_path
+                        ~keeper_name;
+                      if strikes >= Keeper_turn_slot.oas_timeout_budget_strike_limit then begin
+                        Log.Keeper.error
+                          "%s: %d consecutive oas_timeout_budget strikes \
+                           (>= %d) — promoting to Keeper_fiber_crash for \
+                           supervisor auto-pause"
+                          keeper_name strikes Keeper_turn_slot.oas_timeout_budget_strike_limit;
+                        Prometheus.inc_counter
+                          Keeper_metrics.metric_keeper_oas_timeout_budget_strike
+                          ~labels:[
+                            ("keeper", keeper_name);
+                            ("outcome", "promote");
+                          ] ();
+                        Keeper_turn_slot.reset_budget_exhaustion ~keeper_name;
+                        raise Keeper_registry.Keeper_fiber_crash
+                      end else begin
+                        Log.Keeper.warn
+                          "%s: oas_timeout_budget strike %d/%d \
+                           (next strike will trigger fiber crash + auto-pause)"
+                          keeper_name strikes Keeper_turn_slot.oas_timeout_budget_strike_limit;
+                        Prometheus.inc_counter
+                          Keeper_metrics.metric_keeper_oas_timeout_budget_strike
+                          ~labels:[
+                            ("keeper", keeper_name);
+                            ("outcome", "warn");
+                          ] ()
+                      end
+                    end;
+                    (match read_meta ctx.config meta_after_cursor_persist.name with
+                     | Ok (Some latest) -> latest
+                     | Ok None ->
+                       Log.Keeper.error "keeper:%s read_meta returned None after turn failure, using stale meta"
+                         meta_after_cursor_persist.name;
+                       Prometheus.inc_counter
+                         Keeper_metrics.metric_keeper_meta_read_failures
+                         ~labels:[("keeper", meta_after_cursor_persist.name); ("site", "none_after_failure")]
+                         ();
+                       meta_after_cursor_persist
+                     | Error e ->
+                       Log.Keeper.error "keeper:%s read_meta failed after turn failure (%s), using stale meta"
+                         meta_after_cursor_persist.name e;
+                       Prometheus.inc_counter
+                         Keeper_metrics.metric_keeper_meta_read_failures
+                         ~labels:[("keeper", meta_after_cursor_persist.name); ("site", "error_after_failure")]
+                         ();
+                       meta_after_cursor_persist)
+                | Ok updated ->
+                    Keeper_turn_slot.reset_budget_exhaustion
+                      ~keeper_name:meta_after_cursor_persist.name;
+                    clear_oas_timeout_budget_failure_reason
+                      ~base_path:ctx.config.base_path
+                      ~keeper_name:meta_after_cursor_persist.name;
+                    updated))
       else if obs.message_cursor_updates <> [] then
         meta_after_cursor_persist
       else

--- a/lib/keeper/keeper_meta_contract.ml
+++ b/lib/keeper/keeper_meta_contract.ml
@@ -90,6 +90,13 @@ type blocker_class =
   | Autonomous_slot_wait_timeout
   | Admission_queue_wait_timeout
   | Turn_timeout_after_queue_wait
+  | Admission_wait_wfq
+    (** RFC-0026 Phase A1: keeper was enqueued in the WFQ overflow
+        queue because all above-floor candidates were throttled.
+        Will retry on next heartbeat tick when refill wakes it. *)
+  | Admission_surface
+    (** RFC-0026 Phase A1: admission router could not find any usable
+        provider (misconfiguration or all candidates below min_tier). *)
   | Oas_timeout_budget
   | Turn_timeout
   | Completion_contract_violation
@@ -126,6 +133,8 @@ let blocker_class_to_string = function
   | Autonomous_slot_wait_timeout -> "autonomous_slot_wait_timeout"
   | Admission_queue_wait_timeout -> "admission_queue_wait_timeout"
   | Turn_timeout_after_queue_wait -> "turn_timeout_after_queue_wait"
+  | Admission_wait_wfq -> "admission_wait_wfq"
+  | Admission_surface -> "admission_surface"
   | Oas_timeout_budget -> "oas_timeout_budget"
   | Turn_timeout -> "turn_timeout"
   | Completion_contract_violation -> "completion_contract_violation"
@@ -142,6 +151,8 @@ let blocker_class_of_serialized_string = function
   | "autonomous_slot_wait_timeout" -> Some Autonomous_slot_wait_timeout
   | "admission_queue_wait_timeout" -> Some Admission_queue_wait_timeout
   | "turn_timeout_after_queue_wait" -> Some Turn_timeout_after_queue_wait
+  | "admission_wait_wfq" -> Some Admission_wait_wfq
+  | "admission_surface" -> Some Admission_surface
   | "oas_timeout_budget" -> Some Oas_timeout_budget
   | "turn_timeout" -> Some Turn_timeout
   | "completion_contract_violation" -> Some Completion_contract_violation
@@ -246,6 +257,7 @@ type keeper_meta =
   ; social_model : string
   ; cascade_name : string
   ; models : string list
+  ; cascade_ref : Cascade_ref.cascade_ref option
   ; will : string
   ; needs : string
   ; desires : string

--- a/lib/keeper/keeper_meta_contract.mli
+++ b/lib/keeper/keeper_meta_contract.mli
@@ -140,6 +140,8 @@ type blocker_class =
   | Autonomous_slot_wait_timeout
   | Admission_queue_wait_timeout
   | Turn_timeout_after_queue_wait
+  | Admission_wait_wfq
+  | Admission_surface
   | Oas_timeout_budget
   | Turn_timeout
   | Completion_contract_violation
@@ -226,6 +228,7 @@ type keeper_meta = {
   social_model : string;
   cascade_name : string;
   models : string list;
+  cascade_ref : Cascade_ref.cascade_ref option;
   will : string;
   needs : string;
   desires : string;

--- a/lib/keeper/keeper_meta_json_parse.ml
+++ b/lib/keeper/keeper_meta_json_parse.ml
@@ -19,6 +19,7 @@ type parsed_keeper_identity =
   ; pk_long_goal : string
   ; pk_social_model : string
   ; pk_cascade_name : string
+  ; pk_cascade_ref : Cascade_ref.cascade_ref option
   ; pk_models : string list
   ; pk_will : string
   ; pk_needs : string
@@ -150,6 +151,7 @@ let parse_keeper_identity (json : Yojson.Safe.t) : (parsed_keeper_identity, stri
       ; pk_long_goal
       ; pk_social_model
       ; pk_cascade_name
+      ; pk_cascade_ref = None
       ; pk_models
       ; pk_will
       ; pk_needs
@@ -575,6 +577,7 @@ let meta_of_json (json : Yojson.Safe.t) : (keeper_meta, string) result =
                    ; long_goal = identity.pk_long_goal
                    ; social_model = identity.pk_social_model
                    ; cascade_name = identity.pk_cascade_name
+                   ; cascade_ref = identity.pk_cascade_ref
                    ; models = identity.pk_models
                    ; will = identity.pk_will
                    ; needs = identity.pk_needs

--- a/lib/keeper/keeper_meta_json_parse.mli
+++ b/lib/keeper/keeper_meta_json_parse.mli
@@ -19,6 +19,7 @@ type parsed_keeper_identity =
   ; pk_long_goal : string
   ; pk_social_model : string
   ; pk_cascade_name : string
+  ; pk_cascade_ref : Cascade_ref.cascade_ref option
   ; pk_models : string list
   ; pk_will : string
   ; pk_needs : string

--- a/lib/keeper/keeper_provider_token_bucket.ml
+++ b/lib/keeper/keeper_provider_token_bucket.ml
@@ -5,6 +5,8 @@ type state = {
   mutable last_refill_at : float;
 }
 
+type refill_callback = unit -> unit
+
 type t = {
   provider : provider_id;
   capacity : int;
@@ -12,6 +14,7 @@ type t = {
   now : unit -> float;
   state : state;
   mutex : Mutex.t;
+  mutable on_refill_callbacks : refill_callback list;
 }
 
 let refilled ~current_tokens ~capacity ~refill_rate ~elapsed_sec =
@@ -35,6 +38,7 @@ let create ~provider ~capacity ~refill_rate ~now =
     now;
     state = { tokens = float_of_int capacity; last_refill_at = now () };
     mutex = Mutex.create ();
+    on_refill_callbacks = [];
   }
 
 let with_mutex t f =
@@ -47,18 +51,27 @@ let with_mutex t f =
     Mutex.unlock t.mutex;
     raise e
 
+let rec fire_on_refill_callbacks t =
+  let cbs = with_mutex t (fun () -> t.on_refill_callbacks) in
+  List.iter (fun cb -> cb ()) cbs
+
 let refill_locked t =
   let now_ts = t.now () in
   let elapsed = now_ts -. t.state.last_refill_at in
+  let old_tokens = t.state.tokens in
   let new_tokens =
     refilled
-      ~current_tokens:t.state.tokens
+      ~current_tokens:old_tokens
       ~capacity:t.capacity
       ~refill_rate:t.refill_rate
       ~elapsed_sec:elapsed
   in
   t.state.tokens <- new_tokens;
-  t.state.last_refill_at <- now_ts
+  t.state.last_refill_at <- now_ts;
+  (* Fire on_refill callbacks when refill moves tokens from < 1.0 to >= 1.0,
+     i.e. a previously empty bucket now has dispatchable capacity. *)
+  if old_tokens < 1.0 && new_tokens >= 1.0 then
+    fire_on_refill_callbacks t
 
 let try_acquire t =
   with_mutex t (fun () ->
@@ -75,3 +88,16 @@ let tokens_available t =
       t.state.tokens)
 
 let provider t = t.provider
+
+let release t =
+  with_mutex t (fun () ->
+      refill_locked t;
+      let cap = float_of_int t.capacity in
+      if t.state.tokens < cap then
+        t.state.tokens <- t.state.tokens +. 1.0;
+      (* Clamp to capacity — release should never overfill. *)
+      if t.state.tokens > cap then t.state.tokens <- cap)
+
+let add_on_refill t callback =
+  with_mutex t (fun () ->
+      t.on_refill_callbacks <- callback :: t.on_refill_callbacks)

--- a/lib/keeper/keeper_provider_token_bucket.mli
+++ b/lib/keeper/keeper_provider_token_bucket.mli
@@ -50,6 +50,19 @@ val tokens_available : t -> float
 val provider : t -> provider_id
 (** The provider tag passed to [create]. *)
 
+val release : t -> unit
+(** Return one token to the bucket.  Non-blocking; clamps at capacity.
+    Callers MUST pair every [try_acquire] that returned [true] with
+    exactly one [release] when the work completes. *)
+
+type refill_callback = unit -> unit
+
+val add_on_refill : t -> refill_callback -> unit
+(** Register a callback to be invoked when a refill event moves the
+    bucket from [< 1.0] to [>= 1.0] tokens.  This signals that a
+    previously throttled provider now has dispatchable capacity.
+    Multiple callbacks are supported (LIFO order).  Thread-safe. *)
+
 val refilled :
   current_tokens:float ->
   capacity:int ->

--- a/lib/keeper/keeper_status_bridge.ml
+++ b/lib/keeper/keeper_status_bridge.ml
@@ -289,6 +289,10 @@ let runtime_blocker_surface_of_typed_class ?(summary = "") (cls : blocker_class)
         | None -> if summary = "" then str else summary)
     (* All remaining blocker_class variants carry no class-specific summary
        transformation — fall back to the live summary or the typed name. *)
+    | Admission_wait_wfq ->
+        if summary = "" then "Admission wait: enqueued in WFQ overflow" else summary
+    | Admission_surface ->
+        if summary = "" then "Admission surface: no usable provider" else summary
     | Ambiguous_post_commit_timeout
     | Ambiguous_post_commit_failure
     | Autonomous_slot_wait_timeout
@@ -308,6 +312,8 @@ let runtime_blocker_surface_of_legacy_string reason cls =
       runtime_blocker_surface_of_typed_class cls
   (* All other blocker classes carry no embedded reason payload, so the
      legacy string [reason] argument provides the fallback summary. *)
+  | Admission_wait_wfq
+  | Admission_surface
   | Ambiguous_post_commit_timeout
   | Ambiguous_post_commit_failure
   | Autonomous_slot_wait_timeout

--- a/lib/keeper/keeper_turn_up_create.ml
+++ b/lib/keeper/keeper_turn_up_create.ml
@@ -455,6 +455,7 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
         cascade_name = (match p.profile_defaults.cascade_name with
           | Some name -> name
           | None -> Keeper_config.default_cascade_name);
+        cascade_ref = None;
         (* Empty = "use cascade_name". Injecting any default here would silently
            override the keeper's declared cascade_name in oas_worker_named. *)
         models = Option.value ~default:[] p.profile_defaults.models;

--- a/lib/keeper/keeper_types.mli
+++ b/lib/keeper/keeper_types.mli
@@ -164,6 +164,8 @@ type blocker_class =
   | Autonomous_slot_wait_timeout
   | Admission_queue_wait_timeout
   | Turn_timeout_after_queue_wait
+  | Admission_wait_wfq
+  | Admission_surface
   | Oas_timeout_budget
   | Turn_timeout
   | Completion_contract_violation
@@ -218,6 +220,7 @@ type keeper_meta = {
   social_model: string;
   cascade_name: string;
   models: string list;
+  cascade_ref: Cascade_ref.cascade_ref option;
   will: string;
   needs: string;
   desires: string;

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -111,6 +111,7 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
     ?(semaphore_wait_ms = 0)
     ?turn_slot_control
     ?shared_context
+    ?selected_item
     () : (keeper_meta, Agent_sdk.Error.sdk_error) result =
   (* Spec navigation (OCaml -> TLA+) — plan §19 Cycle 28 anchor for
      B2 (Task Acquisition).  Authoritative spec mirror is
@@ -1736,6 +1737,19 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
           (fun (retry : EC.degraded_retry) -> retry.fallback_reason)
           degraded_retry_info
       in
+      (* RFC-0041 Phase B3: record per-item health after turn completion. *)
+      (match selected_item with
+       | Some item ->
+           let success =
+             match run_result with
+             | Ok _ -> true
+             | Error _ -> false
+           in
+           Keeper_health_probe.record_item_result
+             ~keeper_name:meta.name
+             ~item_id:item.Cascade_ref.id
+             ~success
+       | None -> ());
       match run_result with
       | Error err ->
           let final_execution = !last_execution in

--- a/lib/keeper/keeper_unified_turn.mli
+++ b/lib/keeper/keeper_unified_turn.mli
@@ -288,6 +288,7 @@ val run_keeper_cycle :
   ?semaphore_wait_ms:int ->
   ?turn_slot_control:Keeper_turn_slot.keeper_turn_slot_control ->
   ?shared_context:Agent_sdk.Context.t ->
+  ?selected_item:Cascade_ref.cascade_item ->
   unit ->
   (Keeper_types.keeper_meta, Agent_sdk.Error.sdk_error) result
 
@@ -300,5 +301,6 @@ val run_unified_turn :
   ?semaphore_wait_ms:int ->
   ?turn_slot_control:Keeper_turn_slot.keeper_turn_slot_control ->
   ?shared_context:Agent_sdk.Context.t ->
+  ?selected_item:Cascade_ref.cascade_item ->
   unit ->
   (Keeper_types.keeper_meta, Agent_sdk.Error.sdk_error) result


### PR DESCRIPTION
## Summary

This PR implements two RFCs for the Tool Cascade system:

### RFC-0026: Work-Conserving Keeper Admission (Phase A1-A3)

Replaces the legacy semaphore-based admission with a per-provider token bucket + WFQ overflow queue system.

- **Phase A1**: Live dispatch wiring in `keeper_heartbeat_loop.ml`
  - `Keeper_admission_runtime.decide_live` returns Dispatch/Wait/Surface/Legacy
  - Token lifecycle: acquire on Dispatch, release via `Fun.protect ~finally`
- **Phase A2**: WFQ refill wake hook in `keeper_provider_token_bucket.ml`
  - `on_refill` callbacks fire when bucket refills from < 1.0 to >= 1.0
  - WFQ wake schedules retry on next heartbeat tick (no synchronous dispatch)
- **Phase A3**: Per-provider rate config (hard-coded defaults, config-driven in follow-up)

### RFC-0041: Cascade Routing Group/Item Hierarchy (Phase B1-B3)

Replaces the flat `cascade_name: string` with a hierarchical group/item structure.

- **Phase B1**: Type foundation in `cascade_ref.ml`
  - `cascade_item`, `cascade_group`, `cascade_profile`, `cascade_ref` types
  - JSON serialization/deserialization helpers
  - Backward-compatible `cascade_ref_of_string` migration helper
- **Phase B2**: Health probe reconnect in `keeper_health_probe.ml`
  - Per-keeper, per-item cache keys `(keeper_name, item_id)`
  - `is_item_healthy`, `set_item_health`, `record_item_result`
- **Phase B3**: L1 proactive routing in `keeper_cascade_selector.ml`
  - `select_item_for_turn`: strategy-based item traversal, health-aware fallback
  - Cycle detection in fallback chain, RoundRobin cursor rotation

## Test plan

- [ ] `dune build` passes (verified locally with `--root` workaround)
- [ ] `dune test test_keeper_admission_*` (pending CI)
- [ ] `dune test test_cascade_*` (pending CI)
- [ ] Manual: run with `MASC_ADMISSION_USE_NEW=true`, verify keepers process turns
- [ ] Shadow mode metrics: compare admission vs semaphore decision distribution

## Related

- RFC-0026: `docs/rfc/RFC-0026-work-conserving-keeper-admission.md`
- RFC-0041: `docs/rfc/RFC-0041-cascade-routing-group-item-hierarchy.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)