### PR TITLE
feat(dashboard): RFC-0046 §7 follow-up #1 — single composite snapshot fetch in keeper detail

### DIFF
--- a/dashboard/src/components/keeper-detail.ts
+++ b/dashboard/src/components/keeper-detail.ts
@@ -20,12 +20,15 @@ import { currentDashboardActor, runOperatorAction } from '../api'
 import {
   bootKeeper,
   clearKeeper,
+  fetchKeeperComposite,
   fetchKeeperTransitions,
+  type KeeperCompositeSnapshot,
   pauseKeeper,
   resumeKeeper,
   shutdownKeeper,
   wakeKeeper,
 } from '../api/keeper'
+import { setupVisibleAutoRefresh } from '../lib/auto-refresh'
 import { TimeAgo } from './common/time-ago'
 import { Checkbox } from './common/checkbox'
 import { TextArea } from './common/input'
@@ -828,6 +831,42 @@ function PlaygroundReposPanel({ keeperName }: { keeperName: string }) {
 
 // ── Main Detail Page ─────────────────────────────────────
 
+/**
+ * RFC-0046 §7 follow-up #1: single composite snapshot fetch shared
+ * across the detail surface. Before this hook KeeperStateDiagramPanel
+ * and KeeperMemoryTierPanel each issued their own /composite call;
+ * now keeper-detail owns the fetch and threads the snapshot down via
+ * the snapshot prop introduced in PR #14226.
+ *
+ * FsmHub still has its own polling/reducer loop — see RFC §7 for the
+ * remaining dedup work. This hook handles only the two derived panels.
+ */
+const COMPOSITE_REFRESH_MS = 30_000
+
+function useKeeperComposite(keeperName: string): KeeperCompositeSnapshot | null {
+  const [snapshot, setSnapshot] = useState<KeeperCompositeSnapshot | null>(null)
+  useEffect(() => {
+    const controller = new AbortController()
+    let cancelled = false
+    const refresh = async () => {
+      try {
+        const result = await fetchKeeperComposite(keeperName, { signal: controller.signal })
+        if (!cancelled && !controller.signal.aborted) setSnapshot(result)
+      } catch {
+        // best-effort polling — leave the previous snapshot in place
+      }
+    }
+    void refresh()
+    const cleanup = setupVisibleAutoRefresh(refresh, COMPOSITE_REFRESH_MS)
+    return () => {
+      cancelled = true
+      controller.abort()
+      cleanup()
+    }
+  }, [keeperName])
+  return snapshot
+}
+
 export function KeeperDetailPage() {
   const keeperName =
     route.value.tab === 'monitoring' && route.value.params.section === 'agents'
@@ -860,6 +899,9 @@ export function KeeperDetailPage() {
   // the header KeeperPhaseAndStage to render "현재 phase에 머문 시간" without
   // requiring a new backend field — derivation is plan-approved trade-off.
   const [phaseEnteredAtSec, setPhaseEnteredAtSec] = useState<number | null>(null)
+  // RFC-0046 §7 #1: single composite snapshot shared with the two
+  // derived panels (state-diagram + memory-tier).
+  const compositeSnapshot = useKeeperComposite(keeper.name)
   const prevKeeperRef = useRef(keeper.name)
   if (prevKeeperRef.current !== keeper.name) {
     prevKeeperRef.current = keeper.name
@@ -1016,11 +1058,11 @@ export function KeeperDetailPage() {
         ${'' /* RFC-0046: 6-axis composite snapshot (KSM/KTC/KDP/KCL/KMC/breaker) — SSOT for keeper FSM state */}
         <${FsmHub} mode="detail" selectedName=${keeper.name} />
         <${CollapsibleSection} title="Phase State Machine">
-          <${KeeperStateDiagramPanel} keeperName=${keeper.name} />
+          <${KeeperStateDiagramPanel} keeperName=${keeper.name} snapshot=${compositeSnapshot} />
         <//>
 
         <${CollapsibleSection} title="Memory Tier & Compaction">
-          <${KeeperMemoryTierPanel} keeperName=${keeper.name} />
+          <${KeeperMemoryTierPanel} keeperName=${keeper.name} snapshot=${compositeSnapshot} />
         <//>
 
         ${'' /* ── Divergent conditions (amber banner; renders only when phase lags observed signals) ── */}

--- a/dashboard/src/components/keeper-memory-tier-panel.ts
+++ b/dashboard/src/components/keeper-memory-tier-panel.ts
@@ -87,9 +87,16 @@ export function KeeperMemoryTierPanel({
     setError(null)
 
     const refresh = async () => {
+      // RFC-0046 §7 #1: skip composite fetch when parent supplies it.
+      // `undefined` = standalone caller (legacy fallback); `null` =
+      // parent is still loading, wait rather than dual-fetch.
+      const compositePromise: Promise<KeeperCompositeSnapshot | null> = externalSnapshot !== undefined
+        ? Promise.resolve(externalSnapshot)
+        : fetchKeeperComposite(keeperName, { signal: controller.signal })
+
       Promise.allSettled([
         fetchKeeperStateDiagram(keeperName, { signal: controller.signal }),
-        fetchKeeperComposite(keeperName, { signal: controller.signal }),
+        compositePromise,
       ])
         .then(([usageResult, compositeResult]) => {
           if (controller.signal.aborted) return

--- a/dashboard/src/components/keeper-state-diagram.ts
+++ b/dashboard/src/components/keeper-state-diagram.ts
@@ -143,8 +143,15 @@ export function KeeperStateDiagramPanel({ keeperName, snapshot: externalSnapshot
     setDiagramError(null)
     setStateDiagram(null)
 
+    // RFC-0046 §7 #1: skip composite fetch when parent supplies it.
+    // Caller-passed `undefined` means standalone mode (legacy); `null`
+    // means parent is loading — wait rather than dual-fetch.
+    const compositePromise: Promise<KeeperCompositeSnapshot | null> = externalSnapshot !== undefined
+      ? Promise.resolve(externalSnapshot)
+      : fetchKeeperComposite(keeperName, { signal: controller.signal })
+
     Promise.allSettled([
-      fetchKeeperComposite(keeperName, { signal: controller.signal }),
+      compositePromise,
       fetchKeeperStateDiagram(keeperName, { signal: controller.signal }),
       fetchKeeperTransitions(keeperName, 5, { signal: controller.signal }),
     ])


### PR DESCRIPTION
## 요약

RFC-0046 §7 follow-up #1 구현. PR #14233 (Step 5) 후 keeper-detail이 cycle 당 `/composite` 를 3번 fetch (FsmHub + KeeperStateDiagramPanel + KeeperMemoryTierPanel) 하던 문제를 2번으로 줄임. FsmHub의 자체 reducer/polling loop는 이번 PR에서 손대지 않음 — 그 surface change는 다음 PR로 분리.

## 변경

### 1) `keeper-detail.ts` — `useKeeperComposite(keeperName)` hook 추가
\`\`\`ts
const COMPOSITE_REFRESH_MS = 30_000

function useKeeperComposite(keeperName: string): KeeperCompositeSnapshot | null {
  const [snapshot, setSnapshot] = useState(...)
  useEffect(() => {
    const controller = new AbortController()
    const refresh = async () => {
      try {
        const result = await fetchKeeperComposite(keeperName, { signal: controller.signal })
        if (!cancelled && !controller.signal.aborted) setSnapshot(result)
      } catch {}
    }
    void refresh()
    const cleanup = setupVisibleAutoRefresh(refresh, COMPOSITE_REFRESH_MS)
    return () => { controller.abort(); cleanup() }
  }, [keeperName])
  return snapshot
}
\`\`\`
30s tab-visible cadence (panels이 쓰던 것 그대로). 결과는 두 panel에 prop으로 전달.

### 2) Panel fetch — three-state contract

panel의 useEffect가 caller 의도에 따라 분기:

| `externalSnapshot` 값 | 동작 |
|---|---|
| `undefined` (caller가 prop 안 줌) | standalone mode — 자체 composite fetch (legacy fallback, 테스트 fixture/외부 caller 보존) |
| `null` (parent 로딩 중) | **wait** — race fetch 안 함 |
| 값 있음 | 그것을 사용 |

\`\`\`ts
const compositePromise: Promise<KeeperCompositeSnapshot | null> = externalSnapshot !== undefined
  ? Promise.resolve(externalSnapshot)
  : fetchKeeperComposite(keeperName, { signal: controller.signal })
\`\`\`

state-diagram (memory_kind_usage용) + transitions fetch는 독립 endpoint라 그대로.

## 효과

| | Before (#14233) | After |
|---|---|---|
| `/composite` per cycle | 3 (FsmHub + StateDiagram + MemoryTier) | **2** (FsmHub + parent hook) |
| `state-diagram` per cycle | 2 (StateDiagram + MemoryTier) | 2 (변경 없음) |
| `transitions` per cycle | 1 (StateDiagram) | 1 (변경 없음) |

FsmHub dedup은 다음 PR — FsmHub의 reducer가 polling 결과를 dispatch로 받는 구조라 external snapshot 수용 surface가 큰 변경 (Step 1 mode prop과 비슷한 additive지만 reducer 분기 추가 필요).

## 검증

| 검사 | 결과 |
|---|---|
| `pnpm typecheck` | 변경 파일 0 새 에러 |
| `pnpm vitest run keeper-detail keeper-state-diagram keeper-memory-tier-panel` | **59/59 passed** |
| `pnpm build` | 성공 (13.36s) |
| LoC | **+60 / −4** |

## RFC 발견 체크
- 변경 영역: `dashboard/src/components/` only.

## ⚠️ Draft 유지 요청
agent-authored — `human-approved-ready` 라벨 후 ready.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>