### PR TITLE
docs(rfc): RFC-0048 + RFC-0049 — dashboard IA Phase 2 + surface telemetry

### DIFF
--- a/docs/rfc/RFC-0048-dashboard-ia-phase-2.md
+++ b/docs/rfc/RFC-0048-dashboard-ia-phase-2.md
@@ -1,0 +1,249 @@
+# RFC-0048 — Dashboard Information Architecture Phase 2
+
+Status: Draft
+Author: jeong-sik (with Claude Opus 4.7)
+Date: 2026-05-08
+Supersedes: —
+Related: RFC-0046 (FsmHub SSOT), RFC-0049 (Surface Telemetry Foundation),
+PRs #14219 / #14220 / #14235 / #14236 / #14238 (anti-explainer + dead-section purge)
+
+## 1. Problem
+
+The dashboard surface graph has accreted faster than its consolidation
+work. Phase 1 already merged a handful of `monitoring:*` redirects and
+hid two Monitor sub-sections. The remaining graph is still wider than
+operators can hold in working memory, and ongoing cleanup PRs are
+treating *symptoms* (explainer copy, dead routes) without touching the
+*shape*.
+
+### 1.1 Surface inventory (origin/main @ 6665e6ebfc)
+
+`dashboard/src/config/navigation.ts`:
+
+| Surface | Sections (visible) | Sections (hidden) | Notes |
+|---|---|---|---|
+| cockpit | (no sections) | — | single-pane |
+| overview | (no sections) | — | single-pane |
+| **monitoring** | journey, agents, cognition, runtime, goal-loop, fleet-health (**6**) | observatory, memory-subsystems (**2**) | Phase 1 absorbed telemetry/fleet/tool-quality/governance into `fleet-health` |
+| command | operations | — | single-section surface |
+| connectors | connector-status | — | single-section surface |
+| workspace | board, sub-boards, planning, repositories, verification (**5**) | — | |
+| lab | tools, autoresearch, harness | — | `legacy` section purged in PR #14238 |
+| code | ide-shell | — | single-section surface |
+| logs | (no sections) | — | single-pane |
+
+Total: **9 top-level surfaces**, **19 visible sections**, **2 hidden
+sections** retained as redirect targets.
+
+Existing redirects (line 339-345 of navigation.ts) prove the pattern is
+already in use:
+
+```
+'monitoring:sessions'   -> agents
+'monitoring:activity'   -> observatory
+'monitoring:live'       -> observatory (view=live)
+'monitoring:telemetry'  -> fleet-health (view=event-log)
+'monitoring:fleet'      -> fleet-health (view=comparison)
+'monitoring:tool-quality' -> fleet-health
+'monitoring:governance' -> fleet-health
+```
+
+### 1.2 Decision deficit
+
+We do not know which of the 19 visible sections operators actually open.
+Every consolidation proposal so far has been driven by static reading of
+the navigation file, not by usage data. That produced two errors in the
+external Kimi audit (Downloads/Kimi_Agent_대시보드 메뉴 정비, 2026-05-07):
+
+1. Audit listed Monitor as 8 sections; 2 of them were already
+   `hidden: true`.
+2. Audit treated `fleet-health` as if it still co-existed with
+   telemetry/fleet/tool-quality; it had already absorbed them in Phase 1.
+
+The fix is not "draft a tighter audit." It is "stop debating section
+counts without data." This RFC blocks on RFC-0049 producing real open
+counters first.
+
+### 1.3 Component LoC blowup (separate RFC, listed for context only)
+
+`dashboard/src/components/` has **321 .ts files** totalling **82,086 LoC**.
+Eleven files exceed 1000 LoC each. The larger ones (connector-status
+1689, cost-dashboard 1442, cascade-config-panel 1386, keeper-detail
+1263, fleet-fsm-matrix 1250) cluster around the surfaces this RFC
+considers. **Component decomposition is RFC-0050 scope.** RFC-0048
+treats only IA — section list, ordering, default surface, redirects.
+File splits driven by LoC caps are out of scope and have already been
+rejected as a workaround pattern (see `prometheus.ml` extraction issue
+#14166, closed by user).
+
+## 2. Goals
+
+1. Make every IA change **data-driven**: drop or merge a section only
+   after RFC-0049 telemetry shows ≤ X opens / 7 days for that section.
+2. Keep the **redirect ledger** authoritative — any removed section
+   must continue to resolve via a `CROSS_SURFACE_SECTION_REDIRECTS`
+   entry (or the existing `'<surface>:<section>'` map) for at least one
+   release after deletion.
+3. Maintain hash-route stability for deep-linked operator bookmarks and
+   external dashboards that link into specific sections.
+4. Reduce visible-section count without removing capability. Every
+   "removed" section must point to the surface that now hosts the same
+   data.
+
+## 3. Non-goals
+
+- No file splits, no component decomposition (→ RFC-0050).
+- No new backend RPC. RFC-0048 is wholly client-side IA.
+- No design-language changes (color, type, spacing). The "ferris wheel"
+  metaphor floated in the Kimi plan is **not adopted** in RFC-0048; if
+  warranted it can become a separate design RFC after the IA settles.
+- No change to surfaces with zero or one section (cockpit, overview,
+  command, connectors, code, logs).
+
+## 4. Design
+
+### 4.1 Phase 2 sequencing
+
+```
+PR-A (this RFC, docs only)
+   |
+PR-B = RFC-0049 PR-1 (instrument)
+   |
+   v
+   [7-day collection window]
+   |
+   v
+PR-C  candidate selection (Markdown report + thresholds)
+   |
+   v
+PR-D  hidden=true on bottom-N sections (still routable via redirect)
+   |
+   v
+   [7-day soak window — operator complaint window]
+   |
+   v
+PR-E  delete component code + add redirect entry
+   |
+   v
+PR-F (optional)  reorder surface graph if ordering data warrants it
+```
+
+PR-D and PR-E are the only PRs that touch user-visible IA. Both gated
+on RFC-0049 metric thresholds, defined in §4.4.
+
+### 4.2 Threshold proposal (subject to data)
+
+After 7 days of `surface_open_total` and `section_open_total`:
+
+| Action | Threshold | Soak |
+|---|---|---|
+| Mark `hidden: true` (sidebar removal, route preserved) | < 5 opens / week, ≥ 2 active operators on the dashboard | 7 days |
+| Delete component, replace with redirect | section stayed `hidden: true` 7 days with **zero** redirect target hits | — |
+| Promote section to surface default | > 40% of that surface's opens land on this section | — |
+| Merge two sections | both individually < 20 opens / week, share > 60% of operators | requires ad-hoc proposal |
+
+These numbers are **placeholders**. PR-C will revise them once the
+distribution is visible.
+
+### 4.3 Redirect ledger contract
+
+Every section ID ever shown in the sidebar MUST resolve forever. The
+deletion order is:
+
+1. PR-D: `hidden: true` — sidebar gone, hash route still works.
+2. PR-E: section component code deleted, but
+   `CROSS_SURFACE_SECTION_REDIRECTS` (router.ts:24) gains an entry
+   mapping the old `<surface>:<section>` key to its successor.
+
+A test (`router.test.ts`) enforces: for every section ID in
+`navigation.ts` *or* in the redirect map, `hashForRoute` must produce
+a route whose final tab/section pair is currently rendered.
+
+### 4.4 Telemetry handshake
+
+This RFC depends on RFC-0049 exposing the following counters (full
+schema in RFC-0049):
+
+```
+dashboard_surface_open_total{surface}
+dashboard_section_open_total{surface, section}
+dashboard_section_open_total{surface, section, redirected_from}
+```
+
+PR-C consumes these via PromQL and emits a Markdown report into
+`docs/audits/2026-MM-dashboard-ia-usage.md`. Threshold-crossing rows
+become the candidate list for PR-D.
+
+## 5. Compatibility & risk
+
+### 5.1 Hash-route compatibility
+
+All deletions go through the redirect map, so existing bookmarks and
+external links keep resolving. We add an integration test that loops
+over every section ID present in the last 6 months of git history and
+asserts it still routes.
+
+### 5.2 Operator surprise
+
+Hiding a low-traffic section is easy to revert (`hidden: false` toggle).
+Deletion is harder. The 7-day `hidden: true` soak in PR-D is the
+escape hatch — any operator who still uses the section can complain
+during the soak; reverting before PR-E is one-line.
+
+### 5.3 Telemetry blind spots
+
+`section_open_total` cannot distinguish "operator opened section
+intentionally" from "auto-redirect landed there." The `redirected_from`
+label in §4.4 is what makes the difference observable. PR-C must
+exclude redirect-driven opens when computing the threshold for PR-D —
+otherwise we would protect a dead section just because old links keep
+firing it.
+
+### 5.4 Cold-start bias
+
+The first 7 days of telemetry will under-count weekly tasks and
+over-count whatever happened to be in focus. PR-C should re-sample for
+a second 7-day window before any deletion fires. Hide-only (PR-D)
+decisions can run on a single window.
+
+## 6. Open questions
+
+1. **Per-operator privacy.** Should `section_open_total` include an
+   operator label, or stay aggregate? Aggregate is enough for PR-D
+   thresholds. Per-operator would let us answer "is this section used
+   by anyone, or only by one person on Tuesday afternoons?" — but adds
+   PII. Default: aggregate only.
+2. **Redirect-loop guard.** If section A redirects to section B and we
+   later delete B, the chain must collapse, not chain. Test infra in
+   PR-C must walk redirect chains to a fixed point.
+3. **Mobile / narrow viewport.** Current dashboard does not target
+   mobile, so we ignore viewport-conditional IA. Flag for future RFC if
+   priorities change.
+4. **`overview` and `cockpit` ratio.** Both are single-pane top-level
+   surfaces. If one of them dominates `surface_open_total`, the other
+   may be a candidate to fold into it. RFC-0048 does not pre-commit to
+   this — it depends on data.
+
+## 7. Out of scope (cross-references)
+
+- Component file decomposition: RFC-0050 (TBD).
+- Design-language refresh: separate design RFC, post-IA.
+- Backend telemetry consolidation: RFC-0044 (persistence read-drop).
+- Composite snapshot rendering on keeper detail: RFC-0046 (merged
+  through Step 5).
+
+## 8. Done criteria
+
+RFC-0048 is "Done" when:
+
+1. Two consecutive 7-day usage reports show no section below the
+   `hidden: true` threshold that has not already been hidden or has a
+   recorded operator carve-out.
+2. The `dashboard_section_open_total` redirect-from ratio for every
+   visible section is < 50% (i.e., visible sections are reached
+   directly, not as redirect destinations).
+3. `router.test.ts` enforces the redirect-ledger contract from §4.3.
+4. No component file deletion has produced an unresolved hash route in
+   the last 30 days of dashboard logs.
+
+If any of those four metrics regresses, RFC-0048 reopens.

--- a/docs/rfc/RFC-0049-surface-telemetry-foundation.md
+++ b/docs/rfc/RFC-0049-surface-telemetry-foundation.md
@@ -1,0 +1,292 @@
+# RFC-0049 — Dashboard Surface Telemetry Foundation
+
+Status: Draft
+Author: jeong-sik (with Claude Opus 4.7)
+Date: 2026-05-08
+Supersedes: —
+Related: RFC-0048 (Dashboard IA Phase 2 — primary consumer)
+
+## 1. Problem
+
+The dashboard has nine top-level surfaces and nineteen visible
+sections. We have no data on which of them operators open. Every
+consolidation proposal so far has been static — read the navigation
+file, guess at duplication, propose merges. The Kimi audit
+(2026-05-07) is the most recent failure of this method: it listed
+already-hidden sections as duplicates and treated already-merged
+surfaces as separate.
+
+`dashboard/src/router.ts` is the SSOT for surface transitions. The
+`route` signal (line 225) updates synchronously on every navigation,
+hashchange, and deep-link entry. There is no instrumentation hooked
+into it. Backend `Prometheus.register_counter` and `Prometheus.inc_counter`
+already exist (`lib/prometheus.ml`), so the missing piece is a
+client → backend ingest endpoint and the client-side observer.
+
+This RFC defines the minimum-surface-area telemetry needed to make
+RFC-0048 decisions data-driven, with two non-negotiable properties:
+
+1. Every transition is recorded exactly once (no double-count on
+   redirect collapse).
+2. No PII. No operator label, no session ID, no IP. Aggregate counts
+   per `(surface, section)` only.
+
+## 2. Goals
+
+1. Produce three Prometheus counters (`dashboard_surface_open_total`,
+   `dashboard_section_open_total`, `dashboard_section_open_total` with
+   `redirected_from` label).
+2. Single client observer hooked into the existing `route` signal —
+   no router refactor, no new state store.
+3. Single backend POST endpoint that increments counters. No
+   per-event storage. No log file.
+4. Survive hashchange spam (browser back/forward repeated): collapse
+   identical consecutive `(surface, section)` pairs within 500 ms into
+   one event.
+
+## 3. Non-goals
+
+- No per-operator analytics. Aggregate only.
+- No latency / dwell-time / bounce-rate metrics in this RFC. Adding
+  them later is OK; pre-committing to them now expands surface area
+  without a consumer.
+- No A/B test infrastructure.
+- No client-side persistence (localStorage, IndexedDB). Counters live
+  on the server.
+- No redirect rewrite. The router's existing
+  `CROSS_SURFACE_SECTION_REDIRECTS` map is observed, not modified.
+
+## 4. Design
+
+### 4.1 Counter schema
+
+```
+# HELP dashboard_surface_open_total Top-level dashboard surface opens.
+# TYPE dashboard_surface_open_total counter
+dashboard_surface_open_total{surface="<id>"} <count>
+
+# HELP dashboard_section_open_total Section-level opens within a surface.
+# TYPE dashboard_section_open_total counter
+dashboard_section_open_total{surface="<id>",section="<id>",redirected_from="<surface>:<section>|none"} <count>
+```
+
+`redirected_from` carries the literal `<original_surface>:<original_section>`
+key from `CROSS_SURFACE_SECTION_REDIRECTS` when the route resolution
+came through a redirect, otherwise `"none"`. This is the label that
+RFC-0048 §4.4 needs to exclude redirect-driven hits from deletion
+thresholds.
+
+### 4.2 Event semantics
+
+A single "open" event fires when:
+
+1. The `route` signal value changes such that either `tab` or
+   `params.section` differs from the previous emission, AND
+2. ≥ 500 ms have elapsed since the last identical `(tab, section)` was
+   emitted, OR the new pair differs from the last emitted pair.
+
+The 500 ms window collapses three browser-history bursts into one (back,
+forward, back-again) without losing genuine same-pair re-opens
+separated by real operator action.
+
+The first emission after page load fires unconditionally and carries
+the route resolved by `initRouter`.
+
+### 4.3 Client → backend POST
+
+```
+POST /api/dashboard/nav-event
+Content-Type: application/json
+Body: { "surface": "<id>", "section": "<id>|null", "redirected_from": "<key>|null" }
+Response: 204 No Content
+```
+
+Failure modes:
+
+- 4xx → drop event, log to console at `info`. No retry. We accept
+  rare loss; we don't queue.
+- 5xx → drop event. Same as above.
+- Network offline → drop event. `navigator.sendBeacon` would survive
+  page-unload but adds shutdown semantics we don't need yet.
+
+`fetch(..., { keepalive: true })` is sufficient. No batching.
+
+### 4.4 Backend handler
+
+`lib/dashboard_nav_event.ml`:
+
+```ocaml
+let handle_nav_event ~surface ~section ~redirected_from =
+  let labels =
+    [ ("surface", surface)
+    ; ("section", Option.value ~default:"" section)
+    ; ("redirected_from", Option.value ~default:"none" redirected_from)
+    ]
+  in
+  Prometheus.inc_counter "dashboard_surface_open_total"
+    ~labels:[("surface", surface)] ~delta:1.0 () ;
+  match section with
+  | None -> ()
+  | Some _ ->
+    Prometheus.inc_counter "dashboard_section_open_total"
+      ~labels ~delta:1.0 ()
+```
+
+Validation: `surface` must be a member of `VALID_TABS` (mirrored from
+the TS `types.ts` constant). `section` must either be `null` or a
+known section ID for the given surface (validated against a frozen
+allowlist generated at startup from the navigation manifest).
+`redirected_from` is parsed as `<surface>:<section>` and validated the
+same way; unknown values are rejected with 400.
+
+This is the entire backend surface. No other endpoint, no other
+counter.
+
+### 4.5 Client observer
+
+A single file, `dashboard/src/lib/nav-telemetry.ts`:
+
+```ts
+import { effect } from '@preact/signals'
+import { route } from '../router'
+
+const COLLAPSE_WINDOW_MS = 500
+let last: { surface: string; section: string | null; at: number } | null = null
+
+function emit(surface: string, section: string | null, redirectedFrom: string | null) {
+  void fetch('/api/dashboard/nav-event', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ surface, section, redirected_from: redirectedFrom }),
+    keepalive: true,
+  }).catch(() => { /* drop */ })
+}
+
+export function startNavTelemetry(): void {
+  effect(() => {
+    const r = route.value
+    const surface = r.tab
+    const section = r.params.section ?? null
+    const redirectedFrom = r.params.__redirected_from ?? null
+    const now = Date.now()
+    if (
+      last &&
+      last.surface === surface &&
+      last.section === section &&
+      now - last.at < COLLAPSE_WINDOW_MS
+    ) {
+      return
+    }
+    last = { surface, section, at: now }
+    emit(surface, section, redirectedFrom)
+  })
+}
+```
+
+`startNavTelemetry()` is called once from `main.ts` after `initRouter()`.
+
+The observer reads `__redirected_from` from `route.params`. Adding
+that field requires a one-line change in `applyCrossSurfaceRedirect`
+(router.ts:75): when the redirect fires, write the source key into
+`nextParams.__redirected_from`. The router already strips
+`tab`-equivalent keys from the canonical hash (router.ts:215), so we
+extend that filter to also strip `__redirected_from` — i.e., the field
+is internal-only and never appears in URLs.
+
+### 4.6 Test plan
+
+`dashboard/src/lib/nav-telemetry.test.ts`:
+
+- emits one event for the initial route on `startNavTelemetry()` call.
+- collapses two identical `(surface, section)` pairs within 500 ms
+  into one.
+- emits separately when surface or section changes.
+- carries `redirected_from` when the route arrived via a redirect.
+- emits `redirected_from: "none"` for a direct navigation.
+- never emits `surface` outside `VALID_TABS`.
+
+`router.test.ts`:
+
+- `__redirected_from` is set on params when a redirect resolves and is
+  cleared otherwise.
+- `__redirected_from` is stripped from `toHash` output (no leak into URL).
+
+OCaml side: `test/test_dashboard_nav_event.ml` validates surface and
+section against the navigation manifest and increments counters.
+
+### 4.7 Rollout
+
+PR-1 (this RFC's first implementation PR):
+
+1. Backend handler + counter registration.
+2. Frontend `nav-telemetry.ts` + one-line `__redirected_from` plumbing
+   in router.
+3. Tests above.
+4. `main.ts` call site.
+
+PR-2 (consumed by RFC-0048):
+
+- Add a Grafana panel sourcing the counters.
+- Add a small CLI: `scripts/dashboard-ia-usage.sh --since=7d` that
+  produces the Markdown report RFC-0048 PR-C consumes.
+
+PR-3 (deferred until RFC-0048 PR-C asks for it):
+
+- Optional `redirected_from` exclusion view in Grafana.
+
+## 5. Compatibility & risk
+
+### 5.1 Wire-format compatibility
+
+The `redirected_from` label is added on day one. We pay the cardinality
+cost (≈ 19 sections × at most 3-4 redirect sources = ~60 distinct label
+combinations) up front so we never have to migrate the counter.
+
+### 5.2 Hash-URL leakage
+
+`__redirected_from` is internal to the route signal and never written
+to the URL. A regression test in `router.test.ts` enforces this. If
+the leak ever happens, the field becomes user-bookmarkable and would
+distort downstream counters.
+
+### 5.3 PII
+
+There is no operator label, no session cookie, no IP. The handler
+must not log the request body — only increment the counter.
+
+### 5.4 Failure modes
+
+Telemetry is best-effort. We accept loss on 4xx, 5xx, offline. If the
+endpoint returns 5xx for an extended period we under-count uniformly,
+which is acceptable for an "is this section used at all" question. It
+would not be acceptable for SLO measurement; that is out of scope.
+
+### 5.5 Cardinality cap
+
+Hard ceiling: at most `|surfaces| × |sections| × (|redirects| + 1)`
+distinct label combinations. Today: 9 × 20 × 4 ≈ 720, well under any
+Prometheus limit. If we ever cross 10k we add an opt-in flag.
+
+## 6. Open questions
+
+1. **CSRF.** Should the POST require an origin check? The dashboard
+   already uses the same origin for its other writes. We default to
+   the existing CSRF middleware; if there is none on the dashboard
+   write path, the answer is "yes, add one before this RFC merges."
+2. **Test fakes.** RFC-0048 PR-C reads from Prometheus via PromQL.
+   Should we expose a fake-clock test mode? Not in this RFC — defer
+   until a consumer asks.
+3. **`redirected_from` chain.** If A redirects to B which redirects to
+   C, the field carries A's key, not B's. Test in §4.6 covers the
+   single-hop case; chain-collapse needs RFC-0048 PR-C's redirect-walk
+   to handle this consistently.
+
+## 7. Done criteria
+
+1. Both counters appear in `/metrics` after the first navigation.
+2. The Markdown report in PR-2 produces a non-empty section list with
+   non-zero counts after 24 hours of dashboard use.
+3. `redirected_from` distribution across `dashboard_section_open_total`
+   matches the redirect map cardinality (no leaks, no missing
+   redirect sources).
+4. `router.test.ts` and `nav-telemetry.test.ts` pass.


### PR DESCRIPTION
## Summary

Two paired RFC drafts to make dashboard IA cleanup **data-driven** instead of audit-driven. Continues the anti-explainer thread (#14219, #14220, #14235, #14236, #14238) but addresses the *shape* of the surface graph, not just copy.

- **RFC-0048 — Dashboard IA Phase 2**: blocks all section deletions on telemetry data. Hide → 7-day soak → delete + redirect entry. Excludes file-split (RFC-0050 scope).
- **RFC-0049 — Surface Telemetry Foundation**: three Prometheus counters, single client observer on the existing `route` signal, single backend POST endpoint. Aggregate-only, no PII.

## Why

The Kimi audit (Downloads, 2026-05-07) treated `monitoring:fleet/telemetry/tool-quality` as separate sections — they were absorbed into `fleet-health` in Phase 1. It listed `observatory` and `memory-subsystems` as duplicates — both already `hidden: true`. **Static audits keep producing stale lists**. RFC-0048 makes that error class impossible by gating deletion on counter data, and RFC-0049 produces the counters.

## Scope

- +541 LoC, docs only.
- No code changes in this PR.
- Implementation lives in the RFC-0049 PR-1 follow-up (already scoped in §4.7).

## Surface inventory captured (origin/main @ 6665e6ebfc)

| Surface | Visible sections | Hidden sections |
|---|---|---|
| monitoring | journey, agents, cognition, runtime, goal-loop, fleet-health (6) | observatory, memory-subsystems (2) |
| workspace | board, sub-boards, planning, repositories, verification (5) | — |
| lab | tools, autoresearch, harness (3) | — |
| cockpit, overview, command, connectors, code, logs | (0–1 each) | — |

Total: 9 surfaces, 19 visible sections, 2 hidden retained as redirect targets.

## RFC pre-flight

This PR creates RFCs; it does not touch credential/identity/operator/sandbox/dashboard-credential/hooks/workflow* paths. `pr-rfc-check.sh` not strictly applicable, but RFC-0048 and RFC-0049 are self-citing for the implementation PR-1 to follow.

## Test plan

- [ ] PR-1 (separate, follow-up) implements `nav-telemetry.ts` + backend handler + tests
- [ ] PR-2 produces 7-day usage report — input to RFC-0048 PR-C
- [ ] PR-D (RFC-0048) is gated on PR-2 output
- [ ] No PR in this RFC-0048/0049 family touches IA *visible* state without prior data

## Open questions surfaced in the RFCs

- Per-operator privacy (RFC-0049 §6.1): default aggregate.
- CSRF on POST endpoint (RFC-0049 §6.1): use existing middleware.
- Redirect-loop guard (RFC-0048 §6.2): test walks chain to fixed point.
- Cold-start bias (RFC-0048 §5.4): hide-only after one window, delete after two.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>