### PR TITLE
test(cascade): sync glm-coding auto-models with updated agent_sdk catalog

### DIFF
--- a/test/test_cascade_model_resolve.ml
+++ b/test/test_cascade_model_resolve.ml
@@ -72,7 +72,6 @@ let test_glm_coding_auto_models_default_order () =
   with_clean_env (fun () ->
     check (list string) "glm-coding:auto expands to coding-plan order"
       [
-        "glm-5-code";
         "glm-5.1";
         "glm-5";
         "glm-5-turbo";


### PR DESCRIPTION
## Summary

Companion test update for the OAS `agent_sdk` change that removes `glm-5-code` from the coding-plan auto-model rotation.

## Changes

- **`test/test_cascade_model_resolve.ml`**
  - Remove `\"glm-5-code\"` from the expected list in `test_glm_coding_auto_models_default_order`.

## Test plan

- [x] `dune exec --root . test/test_cascade_model_resolve.exe` passes (16/16).

## Dependency

Requires the OAS PR (`fix/glm-5-code-removal`) to be merged and the `agent_sdk` opam pin updated so that `R.glm_coding_auto_models()` returns the corrected list.