### PR TITLE
feat(dashboard): RFC-0049 PR-1 — surface telemetry foundation

### DIFF
--- a/dashboard/src/lib/nav-telemetry.test.ts
+++ b/dashboard/src/lib/nav-telemetry.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, test } from 'vitest'
+import { signal } from '@preact/signals'
+import { startNavTelemetry, type NavEvent } from './nav-telemetry'
+import { REDIRECTED_FROM_PARAM } from '../router'
+import type { RouteState } from '../types'
+
+function harness() {
+  const events: NavEvent[] = []
+  let clock = 1_000
+  const r = signal<RouteState>({ tab: 'overview', params: {}, postId: null })
+  const dispose = startNavTelemetry({
+    routeSignal: r,
+    send: (e) => events.push(e),
+    now: () => clock,
+    collapseWindowMs: 500,
+  })
+  return {
+    events,
+    advance(ms: number) { clock += ms },
+    setRoute(next: RouteState) { r.value = next },
+    dispose,
+  }
+}
+
+describe('nav-telemetry', () => {
+  test('emits initial route on subscribe', () => {
+    const h = harness()
+    expect(h.events).toEqual([
+      { surface: 'overview', section: null, redirected_from: null },
+    ])
+    h.dispose()
+  })
+
+  test('emits on surface change', () => {
+    const h = harness()
+    h.advance(1000)
+    h.setRoute({ tab: 'monitoring', params: { section: 'journey' }, postId: null })
+    expect(h.events).toEqual([
+      { surface: 'overview', section: null, redirected_from: null },
+      { surface: 'monitoring', section: 'journey', redirected_from: null },
+    ])
+    h.dispose()
+  })
+
+  test('emits on section change within same surface', () => {
+    const h = harness()
+    h.advance(1000)
+    h.setRoute({ tab: 'monitoring', params: { section: 'journey' }, postId: null })
+    h.advance(1000)
+    h.setRoute({ tab: 'monitoring', params: { section: 'agents' }, postId: null })
+    expect(h.events.map(e => e.section)).toEqual([null, 'journey', 'agents'])
+    h.dispose()
+  })
+
+  test('collapses identical (surface, section) within window', () => {
+    const h = harness()
+    h.advance(100)
+    h.setRoute({ tab: 'monitoring', params: { section: 'journey' }, postId: null })
+    h.advance(100)
+    h.setRoute({ tab: 'monitoring', params: { section: 'journey' }, postId: null })
+    h.advance(100)
+    h.setRoute({ tab: 'monitoring', params: { section: 'journey' }, postId: null })
+    expect(h.events).toHaveLength(2)
+    h.dispose()
+  })
+
+  test('re-emits identical pair after collapse window expires', () => {
+    const h = harness()
+    h.advance(100)
+    h.setRoute({ tab: 'monitoring', params: { section: 'journey' }, postId: null })
+    h.advance(800)
+    // Force a re-emission by mutating then restoring.
+    h.setRoute({ tab: 'monitoring', params: { section: 'agents' }, postId: null })
+    h.advance(800)
+    h.setRoute({ tab: 'monitoring', params: { section: 'journey' }, postId: null })
+    expect(h.events.map(e => e.section)).toEqual([null, 'journey', 'agents', 'journey'])
+    h.dispose()
+  })
+
+  test('carries redirected_from when route arrived via redirect', () => {
+    const h = harness()
+    h.advance(1000)
+    h.setRoute({
+      tab: 'workspace',
+      params: {
+        section: 'repositories',
+        view: 'graph',
+        [REDIRECTED_FROM_PARAM]: 'monitoring:git-graph',
+      },
+      postId: null,
+    })
+    expect(h.events.at(-1)).toEqual({
+      surface: 'workspace',
+      section: 'repositories',
+      redirected_from: 'monitoring:git-graph',
+    })
+    h.dispose()
+  })
+
+  test('emits redirected_from null for direct navigation', () => {
+    const h = harness()
+    h.advance(1000)
+    h.setRoute({ tab: 'lab', params: { section: 'tools' }, postId: null })
+    expect(h.events.at(-1)?.redirected_from).toBeNull()
+    h.dispose()
+  })
+
+  test('disposer stops further emissions', () => {
+    const h = harness()
+    h.dispose()
+    h.advance(1000)
+    h.setRoute({ tab: 'monitoring', params: { section: 'journey' }, postId: null })
+    expect(h.events).toHaveLength(1)
+  })
+})

--- a/dashboard/src/lib/nav-telemetry.ts
+++ b/dashboard/src/lib/nav-telemetry.ts
@@ -1,0 +1,83 @@
+// Nav telemetry — RFC-0049 client observer.
+// Posts one event per surface/section transition to /api/v1/dashboard/nav-event.
+// Aggregate counters only — no PII, no per-event storage on the server.
+
+import { effect, type Signal } from '@preact/signals'
+import { route, REDIRECTED_FROM_PARAM } from '../router'
+import type { RouteState } from '../types'
+
+export interface NavEvent {
+  surface: string
+  section: string | null
+  redirected_from: string | null
+}
+
+export interface NavTelemetryOptions {
+  /** Override the route signal (test seam). */
+  routeSignal?: Signal<RouteState>
+  /** Override the POST sender (test seam). */
+  send?: (event: NavEvent) => void
+  /** Override the clock (test seam, ms). */
+  now?: () => number
+  /** Collapse identical (surface, section) re-emissions within this window. */
+  collapseWindowMs?: number
+}
+
+export const DEFAULT_COLLAPSE_WINDOW_MS = 500
+
+const ENDPOINT = '/api/v1/dashboard/nav-event'
+
+function defaultSend(event: NavEvent): void {
+  // keepalive lets the request survive page-unload without retry semantics.
+  void fetch(ENDPOINT, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(event),
+    keepalive: true,
+  }).catch(() => { /* drop — telemetry is best-effort */ })
+}
+
+interface LastEmission {
+  surface: string
+  section: string | null
+  at: number
+}
+
+/**
+ * Subscribe to route changes and emit nav events.
+ *
+ * Returns the disposer so callers (and tests) can stop the subscription.
+ */
+export function startNavTelemetry(
+  options: NavTelemetryOptions = {},
+): () => void {
+  const signal = options.routeSignal ?? route
+  const send = options.send ?? defaultSend
+  const now = options.now ?? Date.now
+  const window = options.collapseWindowMs ?? DEFAULT_COLLAPSE_WINDOW_MS
+
+  let last: LastEmission | null = null
+
+  const dispose = effect(() => {
+    const r = signal.value
+    const surface = r.tab
+    const section = r.params.section ?? null
+    const rawRedirected = r.params[REDIRECTED_FROM_PARAM]
+    const redirected_from = rawRedirected && rawRedirected.length > 0 ? rawRedirected : null
+    const at = now()
+
+    if (
+      last !== null
+      && last.surface === surface
+      && last.section === section
+      && at - last.at < window
+    ) {
+      return
+    }
+    last = { surface, section, at }
+
+    send({ surface, section, redirected_from })
+  })
+
+  return dispose
+}

--- a/dashboard/src/main.ts
+++ b/dashboard/src/main.ts
@@ -41,6 +41,7 @@ import { html } from 'htm/preact'
 import { App } from './app'
 import { performanceMonitor } from './lib/performance-monitor'
 import { startWebVitalsCapture } from './utils/performance-metrics'
+import { startNavTelemetry } from './lib/nav-telemetry'
 
 const THEME_STORAGE_KEYS = ['dashboardTheme', 'masc-theme-v2'] as const
 const THEME_SEARCH_PARAM = 'theme'
@@ -109,3 +110,7 @@ performanceMonitor.start()
 // Begin capturing synthetic web-vitals (TTFB, FCP, LCP, CLS, FID).
 // Snapshot available on window.__MASC_WEB_VITALS__ for test/playwright inspection.
 startWebVitalsCapture()
+
+// RFC-0049 — surface/section open counters to /api/v1/dashboard/nav-event.
+// Aggregate only, no PII. Drives RFC-0048 IA decisions.
+startNavTelemetry()

--- a/dashboard/src/router.test.ts
+++ b/dashboard/src/router.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest'
-import { navigate, replaceRoute, route } from './router'
+import { navigate, replaceRoute, route, hashForRoute, REDIRECTED_FROM_PARAM } from './router'
 
 describe('navigate', () => {
   it('navigates to monitoring tab with agent param', () => {
@@ -165,5 +165,34 @@ describe('navigate', () => {
     } finally {
       window.removeEventListener('hashchange', onHashChange)
     }
+  })
+})
+
+describe('REDIRECTED_FROM_PARAM (RFC-0049)', () => {
+  it('records the original surface:section when a redirect resolves', () => {
+    navigate('monitoring', { section: 'git-graph' })
+    expect(route.value.tab).toBe('workspace')
+    expect(route.value.params.section).toBe('repositories')
+    expect(route.value.params[REDIRECTED_FROM_PARAM]).toBe('monitoring:git-graph')
+  })
+
+  it('omits the param entirely on direct (non-redirected) navigation', () => {
+    navigate('lab', { section: 'tools' })
+    expect(route.value.params[REDIRECTED_FROM_PARAM]).toBeUndefined()
+  })
+
+  it('never leaks the internal param into the URL hash', () => {
+    navigate('monitoring', { section: 'git-graph' })
+    expect(window.location.hash).not.toContain(REDIRECTED_FROM_PARAM)
+    expect(window.location.hash).not.toContain('__redirected_from')
+  })
+
+  it('hashForRoute strips the internal param even if callers pass it', () => {
+    const hash = hashForRoute('workspace', {
+      section: 'repositories',
+      [REDIRECTED_FROM_PARAM]: 'monitoring:git-graph',
+    })
+    expect(hash).not.toContain(REDIRECTED_FROM_PARAM)
+    expect(hash).not.toContain('__redirected_from')
   })
 })

--- a/dashboard/src/router.ts
+++ b/dashboard/src/router.ts
@@ -72,6 +72,10 @@ function shouldApplyCockpitModeRoute(segments: string[], params: Record<string, 
   return false
 }
 
+// Internal-only param key recording the original `<tab>:<section>` key
+// when a redirect resolved the route. RFC-0049 §4.5 — never written to URL.
+export const REDIRECTED_FROM_PARAM = '__redirected_from'
+
 function applyCrossSurfaceRedirect(
   tab: TabId,
   params: Record<string, string>,
@@ -84,6 +88,7 @@ function applyCrossSurfaceRedirect(
   const nextParams = { ...params, ...(redirect.params ?? {}) }
   nextParams.section = redirect.section
   if (redirect.view && !nextParams.view) nextParams.view = redirect.view
+  nextParams[REDIRECTED_FROM_PARAM] = `${tab}:${section}`
   return { tab: redirect.tab, params: nextParams }
 }
 
@@ -213,6 +218,7 @@ function toHash(r: RouteState): string {
   const path = r.tab
   const paramEntries = Object.entries(r.params).filter(([key, value]) => {
     if (key === 'tab' && value === r.tab) return false
+    if (key === REDIRECTED_FROM_PARAM) return false
     return true
   })
   if (paramEntries.length === 0) return `#${path}`

--- a/lib/dashboard/dashboard_nav_event.ml
+++ b/lib/dashboard/dashboard_nav_event.ml
@@ -1,0 +1,156 @@
+(* RFC-0049 — dashboard surface/section open counters. *)
+
+type event = {
+  surface : string;
+  section : string option;
+  redirected_from : string option;
+}
+
+(* Mirror of dashboard/src/types/sse.ts:VALID_TABS. *)
+let valid_surfaces =
+  [ "cockpit"
+  ; "overview"
+  ; "monitoring"
+  ; "command"
+  ; "connectors"
+  ; "workspace"
+  ; "lab"
+  ; "code"
+  ; "logs"
+  ]
+
+(* Mirror of dashboard/src/config/navigation.ts:DASHBOARD_SECTION_ITEMS.
+   Includes hidden sections (observatory, memory-subsystems) because they
+   remain reachable via redirects and continue to fire telemetry. *)
+let valid_sections =
+  [ "monitoring",
+      [ "journey"
+      ; "observatory"
+      ; "agents"
+      ; "cognition"
+      ; "runtime"
+      ; "goal-loop"
+      ; "fleet-health"
+      ; "memory-subsystems"
+      ]
+  ; "command", [ "operations" ]
+  ; "connectors", [ "connector-status" ]
+  ; "workspace",
+      [ "board"
+      ; "sub-boards"
+      ; "planning"
+      ; "repositories"
+      ; "verification"
+      ]
+  ; "lab", [ "tools"; "autoresearch"; "harness" ]
+  ; "code", [ "ide-shell" ]
+  ]
+
+let is_valid_surface s = List.mem s valid_surfaces
+
+let is_valid_section ~surface section =
+  match List.assoc_opt surface valid_sections with
+  | None -> false
+  | Some sections -> List.mem section sections
+
+let counter_surface = "dashboard_surface_open_total"
+let counter_section = "dashboard_section_open_total"
+
+let () =
+  Prometheus.register_counter ~name:counter_surface
+    ~help:"Top-level dashboard surface opens (RFC-0049). Aggregate, no PII." ()
+
+let () =
+  Prometheus.register_counter ~name:counter_section
+    ~help:
+      "Section-level opens within a dashboard surface (RFC-0049). \
+       redirected_from carries the original surface:section key when the \
+       route arrived through CROSS_SURFACE_SECTION_REDIRECTS, otherwise \
+       \"none\". Aggregate, no PII." ()
+
+let parse_redirected_from ~target_surface ~target_section raw =
+  match String.index_opt raw ':' with
+  | None -> Error (Printf.sprintf "redirected_from missing ':' separator: %s" raw)
+  | Some idx ->
+      let from_surface = String.sub raw 0 idx in
+      let from_section = String.sub raw (idx + 1) (String.length raw - idx - 1) in
+      if not (is_valid_surface from_surface) then
+        Error
+          (Printf.sprintf "redirected_from references unknown surface: %s"
+             from_surface)
+      else if from_surface = target_surface && Some from_section = target_section
+      then
+        Error
+          "redirected_from must differ from the resolved (surface, section)"
+      else if not (is_valid_section ~surface:from_surface from_section) then
+        (* The original section may have been deleted but the redirect
+           survives; we still require the surface to be known. Allowlist
+           is "known surfaces", not "known sections" for the *from* side. *)
+        Ok raw
+      else Ok raw
+
+let parse_event_json json =
+  let open Yojson.Safe.Util in
+  try
+    let surface =
+      match member "surface" json with
+      | `String s -> s
+      | `Null -> raise (Type_error ("missing surface", json))
+      | _ -> raise (Type_error ("surface must be string", json))
+    in
+    if not (is_valid_surface surface) then
+      Error (Printf.sprintf "unknown surface: %s" surface)
+    else
+      let section =
+        match member "section" json with
+        | `Null -> None
+        | `String "" -> None
+        | `String s -> Some s
+        | _ -> raise (Type_error ("section must be string or null", json))
+      in
+      let section_ok =
+        match section with
+        | None -> Ok ()
+        | Some s ->
+            if is_valid_section ~surface s then Ok ()
+            else Error (Printf.sprintf "unknown section %s for surface %s" s surface)
+      in
+      match section_ok with
+      | Error e -> Error e
+      | Ok () ->
+          let redirected_from_result =
+            match member "redirected_from" json with
+            | `Null -> Ok None
+            | `String "" -> Ok None
+            | `String "none" -> Ok None
+            | `String raw ->
+                (match
+                   parse_redirected_from ~target_surface:surface
+                     ~target_section:section raw
+                 with
+                 | Ok v -> Ok (Some v)
+                 | Error e -> Error e)
+            | _ ->
+                Error "redirected_from must be string or null"
+          in
+          (match redirected_from_result with
+          | Error e -> Error e
+          | Ok redirected_from -> Ok { surface; section; redirected_from })
+  with
+  | Type_error (msg, _) -> Error msg
+  | Yojson.Json_error msg -> Error msg
+
+let record { surface; section; redirected_from } =
+  Prometheus.inc_counter counter_surface
+    ~labels:[ ("surface", surface) ] ~delta:1.0 ();
+  match section with
+  | None -> ()
+  | Some s ->
+      let labels =
+        [ ("surface", surface)
+        ; ("section", s)
+        ; ( "redirected_from"
+          , Option.value ~default:"none" redirected_from )
+        ]
+      in
+      Prometheus.inc_counter counter_section ~labels ~delta:1.0 ()

--- a/lib/dashboard/dashboard_nav_event.mli
+++ b/lib/dashboard/dashboard_nav_event.mli
@@ -1,0 +1,40 @@
+(** Dashboard surface/section open counters (RFC-0049).
+
+    Increments aggregate Prometheus counters
+    [dashboard_surface_open_total] and [dashboard_section_open_total] in
+    response to a [POST /api/v1/dashboard/nav-event] from the dashboard.
+
+    No PII, no per-event storage. The body of every accepted request is
+    discarded after the counter increment.
+*)
+
+type event = {
+  surface : string;
+  section : string option;
+  redirected_from : string option;
+}
+
+(** Strict allowlist of valid surface IDs. Mirrors [VALID_TABS] in
+    [dashboard/src/types/sse.ts]. *)
+val valid_surfaces : string list
+
+(** Strict allowlist of [(surface, section)] pairs. Generated from
+    [dashboard/src/config/navigation.ts]. *)
+val valid_sections : (string * string list) list
+
+(** [is_valid_surface s] returns [true] iff [s] is in [valid_surfaces]. *)
+val is_valid_surface : string -> bool
+
+(** [is_valid_section ~surface section] checks the pair against the
+    allowlist. Returns [true] for known visible *and* hidden sections. *)
+val is_valid_section : surface:string -> string -> bool
+
+(** [parse_event_json json] parses the request body. Returns [Error msg]
+    for any of: malformed JSON shape, missing [surface], unknown
+    [surface], unknown [(surface, section)] pair, malformed
+    [redirected_from], or [redirected_from] referring to an unknown pair. *)
+val parse_event_json : Yojson.Safe.t -> (event, string) result
+
+(** [record event] increments the relevant Prometheus counters.
+    Idempotent w.r.t. counter registration. *)
+val record : event -> unit

--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -469,6 +469,29 @@ let rec add_routes ~sw ~clock router =
                     (`Assoc [ ("ok", `Bool false); ("error", `String message) ]))
                  reqd)
        ) request reqd)
+  (* RFC-0049 — surface/section open counters. Aggregate Prometheus
+     counters only; the request body is discarded after increment. *)
+  |> Http.Router.post "/api/v1/dashboard/nav-event" (fun request reqd ->
+       with_public_read (fun _state req reqd ->
+         Http.Request.read_body_async reqd (fun body_str ->
+           let result =
+             try
+               let json = Yojson.Safe.from_string body_str in
+               Dashboard_nav_event.parse_event_json json
+             with Yojson.Json_error err ->
+               Error ("invalid json: " ^ err)
+           in
+           match result with
+           | Ok event ->
+               Dashboard_nav_event.record event;
+               Http.Response.json ~request:req {|{"ok":true}|} reqd
+           | Error message ->
+               Http.Response.json ~status:`Bad_request ~request:req
+                 (Yojson.Safe.to_string
+                    (`Assoc
+                      [ ("ok", `Bool false); ("error", `String message) ]))
+                 reqd)
+       ) request reqd)
   |> Http.Router.get "/api/v1/dashboard/config" (fun request reqd ->
        with_public_read (fun _state req reqd ->
          let json = Env_config_introspect.to_json () in

--- a/test/dune
+++ b/test/dune
@@ -43,6 +43,7 @@
         test_dashboard_branches
         test_dashboard_perf
         test_dashboard_tool_host_events
+        test_dashboard_nav_event
         test_tool_assignment_telemetry
         test_dashboard_link_preview
         test_gate_keeper_backend
@@ -278,6 +279,7 @@
           test_dashboard_branches
           test_dashboard_perf
           test_dashboard_tool_host_events
+          test_dashboard_nav_event
           test_tool_assignment_telemetry
           test_dashboard_link_preview
           test_gate_keeper_backend

--- a/test/test_dashboard_nav_event.ml
+++ b/test/test_dashboard_nav_event.ml
@@ -1,0 +1,156 @@
+open Alcotest
+open Masc_mcp
+
+let parse_ok json_str =
+  match Dashboard_nav_event.parse_event_json (Yojson.Safe.from_string json_str) with
+  | Ok event -> event
+  | Error msg -> failf "expected Ok, got Error %s" msg
+
+let parse_err json_str =
+  match Dashboard_nav_event.parse_event_json (Yojson.Safe.from_string json_str) with
+  | Ok _ -> fail "expected Error, got Ok"
+  | Error msg -> msg
+
+let test_parse_minimal_surface_only () =
+  let event = parse_ok {|{"surface":"overview"}|} in
+  check string "surface" "overview" event.surface;
+  check (option string) "section" None event.section;
+  check (option string) "redirected_from" None event.redirected_from
+
+let test_parse_full_event () =
+  let event =
+    parse_ok
+      {|{"surface":"monitoring","section":"journey","redirected_from":"none"}|}
+  in
+  check string "surface" "monitoring" event.surface;
+  check (option string) "section" (Some "journey") event.section;
+  check (option string) "redirected_from" None event.redirected_from
+
+let test_parse_redirected () =
+  let event =
+    parse_ok
+      {|{"surface":"workspace","section":"repositories","redirected_from":"monitoring:git-graph"}|}
+  in
+  check (option string) "redirected_from"
+    (Some "monitoring:git-graph") event.redirected_from
+
+let test_reject_unknown_surface () =
+  let msg = parse_err {|{"surface":"bogus"}|} in
+  check bool "mentions surface" true
+    (Astring.String.is_infix ~affix:"unknown surface" msg)
+
+let test_reject_unknown_section () =
+  let msg = parse_err {|{"surface":"monitoring","section":"ferris-wheel"}|} in
+  check bool "mentions section" true
+    (Astring.String.is_infix ~affix:"unknown section" msg)
+
+let test_reject_redirected_from_unknown_surface () =
+  let msg =
+    parse_err
+      {|{"surface":"workspace","section":"repositories","redirected_from":"bogus:foo"}|}
+  in
+  check bool "mentions redirected_from" true
+    (Astring.String.is_infix ~affix:"redirected_from" msg)
+
+let test_reject_redirected_from_self () =
+  let msg =
+    parse_err
+      {|{"surface":"workspace","section":"repositories","redirected_from":"workspace:repositories"}|}
+  in
+  check bool "mentions self" true
+    (Astring.String.is_infix ~affix:"differ" msg)
+
+let test_reject_missing_surface () =
+  let msg = parse_err {|{"section":"journey"}|} in
+  check bool "mentions surface" true
+    (Astring.String.is_infix ~affix:"surface" msg)
+
+let test_reject_malformed_json () =
+  let msg = parse_err "not json {" in
+  check bool "non-empty error" true (String.length msg > 0)
+
+let test_section_null_explicit () =
+  let event = parse_ok {|{"surface":"cockpit","section":null}|} in
+  check (option string) "section" None event.section
+
+let test_record_increments_surface_counter () =
+  let before =
+    Prometheus.get_metric_value "dashboard_surface_open_total"
+      ~labels:[ ("surface", "overview") ] ()
+    |> Option.value ~default:0.0
+  in
+  Dashboard_nav_event.record
+    { surface = "overview"; section = None; redirected_from = None };
+  let after =
+    Prometheus.get_metric_value "dashboard_surface_open_total"
+      ~labels:[ ("surface", "overview") ] ()
+    |> Option.value ~default:0.0
+  in
+  check (float 1e-9) "incremented by 1" 1.0 (after -. before)
+
+let test_record_increments_section_counter_with_redirect_label () =
+  let labels =
+    [ ("surface", "workspace")
+    ; ("section", "repositories")
+    ; ("redirected_from", "monitoring:git-graph")
+    ]
+  in
+  let before =
+    Prometheus.get_metric_value "dashboard_section_open_total" ~labels ()
+    |> Option.value ~default:0.0
+  in
+  Dashboard_nav_event.record
+    { surface = "workspace"
+    ; section = Some "repositories"
+    ; redirected_from = Some "monitoring:git-graph"
+    };
+  let after =
+    Prometheus.get_metric_value "dashboard_section_open_total" ~labels ()
+    |> Option.value ~default:0.0
+  in
+  check (float 1e-9) "incremented by 1" 1.0 (after -. before)
+
+let test_record_section_counter_redirect_none_label () =
+  let labels =
+    [ ("surface", "lab")
+    ; ("section", "tools")
+    ; ("redirected_from", "none")
+    ]
+  in
+  let before =
+    Prometheus.get_metric_value "dashboard_section_open_total" ~labels ()
+    |> Option.value ~default:0.0
+  in
+  Dashboard_nav_event.record
+    { surface = "lab"; section = Some "tools"; redirected_from = None };
+  let after =
+    Prometheus.get_metric_value "dashboard_section_open_total" ~labels ()
+    |> Option.value ~default:0.0
+  in
+  check (float 1e-9) "incremented by 1 with 'none' label" 1.0 (after -. before)
+
+let () =
+  Alcotest.run "dashboard_nav_event"
+    [ ( "parse_event_json"
+      , [ test_case "minimal surface only" `Quick test_parse_minimal_surface_only
+        ; test_case "full event" `Quick test_parse_full_event
+        ; test_case "redirected_from accepted" `Quick test_parse_redirected
+        ; test_case "rejects unknown surface" `Quick test_reject_unknown_surface
+        ; test_case "rejects unknown section" `Quick test_reject_unknown_section
+        ; test_case "rejects redirected_from unknown surface" `Quick
+            test_reject_redirected_from_unknown_surface
+        ; test_case "rejects redirected_from = self" `Quick
+            test_reject_redirected_from_self
+        ; test_case "rejects missing surface" `Quick test_reject_missing_surface
+        ; test_case "rejects malformed json" `Quick test_reject_malformed_json
+        ; test_case "explicit null section" `Quick test_section_null_explicit
+        ] )
+    ; ( "record"
+      , [ test_case "increments surface counter" `Quick
+            test_record_increments_surface_counter
+        ; test_case "increments section counter with redirect label" `Quick
+            test_record_increments_section_counter_with_redirect_label
+        ; test_case "section counter falls back to 'none' label" `Quick
+            test_record_section_counter_redirect_none_label
+        ] )
+    ]


### PR DESCRIPTION
## Summary

First implementation step of RFC-0049 (`docs/rfc/RFC-0049-surface-telemetry-foundation.md`). Adds aggregate Prometheus counters for dashboard surface/section opens. Drives RFC-0048 IA decisions — without this, every consolidation proposal stays static-audit-driven.

## What lands

**Counters (Prometheus)**
- `dashboard_surface_open_total{surface}`
- `dashboard_section_open_total{surface, section, redirected_from}`

`redirected_from` is `none` for direct navigation, otherwise carries the original `<surface>:<section>` key from `CROSS_SURFACE_SECTION_REDIRECTS`. This is the label RFC-0048 §4.4 uses to exclude redirect-driven hits from deletion thresholds.

**Client**
- `dashboard/src/lib/nav-telemetry.ts` — `effect` on `route` signal, posts to `POST /api/v1/dashboard/nav-event`, 500 ms collapse window for back-forward-back spam, all seams (clock/send/signal/window) injectable.
- `dashboard/src/router.ts` — internal `__redirected_from` param recorded by `applyCrossSurfaceRedirect`, stripped by `toHash` so it never leaks to URL.
- `dashboard/src/main.ts` — `startNavTelemetry()` after web-vitals capture.
- `dashboard/src/router.test.ts` — 4 new tests including a regression guard against `__redirected_from` URL leak.
- `dashboard/src/lib/nav-telemetry.test.ts` — 8 tests covering initial emit, surface/section change, collapse window, post-window re-emission, redirect carry, direct-nav null, disposer.

**Server**
- `lib/dashboard/dashboard_nav_event.ml` + `.mli` — `parse_event_json` validates surface (mirrors `VALID_TABS`), section (mirrors `navigation.ts` per-surface allowlist incl. hidden sections), `redirected_from` (rejects unknown surface and self-reference). `record` increments Prometheus counters. Counters registered at module load.
- `lib/server/server_routes_http_routes_dashboard.ml` — `POST /api/v1/dashboard/nav-event` handler, `with_public_read` auth (matches other dashboard observability endpoints).
- `test/test_dashboard_nav_event.ml` — 13 tests (10 parse cases + 3 record cases).
- `test/dune` — registered in both `(names ...)` and `(modules ...)` lists.

## Endpoint path divergence from RFC

RFC-0049 §4.3 specifies `/api/dashboard/nav-event`. Implementation uses `/api/v1/dashboard/nav-event` to match the existing convention (`logs/tool-host-failures`, `config`, `governance/approvals/*`, etc.). RFC text can be updated in a follow-up if you prefer.

## Local verification status

- TypeScript: changed-file `tsc --noEmit` clean.
- Vitest: skipped locally — node_modules not installed in this fresh worktree.
- OCaml: skipped locally — global `dune-local.sh` lock held by another worktree (rfc-0047, ~50 min). Per `feedback_masc_mcp_dune_local_lock_contention`, GitHub Actions clean env is the verification path.

## RFC pre-flight (governance check)

- Not in agent-delegation subsystems (no credential / operator / sandbox / dashboard-credential / hooks / workflow*).
- RFC explicitly cited: `docs/rfc/RFC-0049-surface-telemetry-foundation.md`.

## Test plan (CI)

- [ ] `pnpm test` (vitest) — `nav-telemetry.test.ts` + `router.test.ts` extended cases pass.
- [ ] `dune build` — `lib/dashboard/dashboard_nav_event.{ml,mli}` + route handler compile.
- [ ] `dune runtest` — `test_dashboard_nav_event` 13 tests pass.
- [ ] No `__redirected_from` leaks into URL hash (regression test in `router.test.ts`).

## Next steps (post-merge)

- PR-2: Grafana panel + `scripts/dashboard-ia-usage.sh --since=7d` Markdown report (RFC-0049 §4.7).
- 7-day collection window before RFC-0048 PR-C.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>