### PR TITLE
fix(keeper): wire health probe + permissive Unknown for auto-resume

### DIFF
--- a/lib/keeper/keeper_health_probe.ml
+++ b/lib/keeper/keeper_health_probe.ml
@@ -72,6 +72,19 @@ let set_health ~keeper_name status =
     Hashtbl.replace health_cache (keeper_name, "")
       (status, Time_compat.now ()))
 
+(** [get_cascade_status ~cascade_name] reads the cascade-level entry
+    written by [set_health]/[run_once].  Three-valued:
+      - [Healthy]    : last probe saw the cascade at < threshold ratio.
+      - [Unhealthy r]: last probe saw the cascade at >= threshold ratio.
+      - [Unknown]    : probe never wrote this cascade (e.g. boot before
+                       first sweep, or no running keepers in the cascade
+                       at the time of the last scan). *)
+let get_cascade_status ~cascade_name =
+  Eio.Mutex.use_ro health_cache_mu (fun () ->
+    match Hashtbl.find_opt health_cache (cascade_name, "") with
+    | Some (status, _) -> status
+    | None -> Unknown)
+
 (* ------------------------------------------------------------------ *)
 (* Cascade health check                                               *)
 (* ------------------------------------------------------------------ *)

--- a/lib/keeper/keeper_health_probe.mli
+++ b/lib/keeper/keeper_health_probe.mli
@@ -52,11 +52,33 @@ val set_health : keeper_name:string -> health_status -> unit
 val check_cascade_health :
   base_path:string -> (string * bool) list
 
+(** [get_cascade_status ~cascade_name] returns the cached cascade-level
+    [health_status] written by [run_once]/[set_health].  Unlike
+    [is_healthy], this preserves the [Unknown] case so the supervisor's
+    auto-resume guard can distinguish "no probe data yet" from
+    "probe observed restart pressure" and treat the former
+    permissively.
+
+    Background: prior to wiring this distinction, the supervisor's
+    Phase 3.5 guard called [is_healthy] which collapsed [Unknown] and
+    [Unhealthy] to [false] — turning the boot-time cold-cache window
+    into a permanent auto-resume lockout for every cascade. *)
+val get_cascade_status : cascade_name:string -> health_status
+
+(** [run_once ~base_path] runs [check_cascade_health] and writes the
+    results into the cascade cache.  Idempotent and bounded (registry
+    scan, no I/O).  Safe to call from the supervisor sweep on every
+    beat — [Keeper_supervisor.sweep_and_recover] does so to keep the
+    cache live without depending on the background fiber. *)
+val run_once : base_path:string -> unit
+
 (** {1 Background probe fiber} *)
 
 (** [start_probe ~sw ~base_path ~interval_sec] spawns a background Eio
     fiber that runs [check_cascade_health] every [interval_sec] seconds
     and updates the internal cache.  The fiber exits when [sw] is
-    cancelled. *)
+    cancelled.  Currently unused — the supervisor calls [run_once]
+    inline.  Retained for future use when a faster cadence than the
+    30 s sweep is needed. *)
 val start_probe :
   sw:Eio.Switch.t -> base_path:string -> interval_sec:float -> unit

--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -1260,6 +1260,15 @@ let sweep_and_recover (ctx : _ context) =
   let max_restarts = Runtime_params.get Governance_registry.keeper_supervisor_max_restarts in
   let dead_ttl_sec = Runtime_params.get Governance_registry.keeper_dead_ttl_sec in
   let base_path = ctx.config.base_path in
+  (* Refresh the cascade health cache before Phase 3.5 reads it.  Without this
+     call the cache stayed cold (PR #14146 introduced the cache and
+     [Phase 3.5] guard but never wired a writer), so [is_healthy] returned
+     [false] for every cascade and silently disabled auto-resume across the
+     fleet.  [run_once] is a registry scan — bounded, no I/O — so running it
+     inline on every 30 s sweep is cheap.  [Safe_ops.protect] keeps a
+     transient registry exception from killing the sweep. *)
+  Safe_ops.protect ~default:() (fun () ->
+    Keeper_health_probe.run_once ~base_path);
   (* Phase 2: sweep order — restart/unregister FIRST, reconcile LAST.
      This prevents reconcile from re-launching keepers that sweep is about
      to process (defense-in-depth alongside is_registered check). *)
@@ -1650,16 +1659,35 @@ let sweep_and_recover (ctx : _ context) =
                                  && not (paused_meta_requires_reconcile_recovery meta)
                                  && not (Keeper_approval_queue.has_pending_for_keeper
                                            ~keeper_name:meta.name) ->
-               if not (Keeper_health_probe.is_healthy
-                         ~keeper_name:meta.cascade_name) then begin
-                 Log.Keeper.info
-                   "%s: auto-resume blocked; cascade %s is unhealthy"
-                   name meta.cascade_name;
-                 Prometheus.inc_counter
-                   Keeper_metrics.metric_keeper_auto_resume_blocked_total
-                   ~labels:[("keeper", name); ("cascade", meta.cascade_name)]
-                   ()
-               end else begin
+               let cascade_status =
+                 Keeper_health_probe.get_cascade_status
+                   ~cascade_name:meta.cascade_name
+               in
+               (* Three-valued admission:
+                    Unhealthy   — block, the probe saw restart pressure.
+                    Healthy     — proceed with timer check.
+                    Unknown     — proceed with timer check.  No probe data
+                                  yet (e.g. all keepers in the cascade
+                                  paused so the registry has no entries
+                                  to score).  Defaulting to "block" here
+                                  is the bug PR #14146 shipped: it turned
+                                  the boot-time race window into a
+                                  permanent lockout.  See instructions/
+                                  software-development.md anti-pattern
+                                  "Unknown -> Permissive Default". *)
+               (match cascade_status with
+                | Keeper_health_probe.Unhealthy reason ->
+                    Log.Keeper.info
+                      "%s: auto-resume blocked; cascade %s is unhealthy (%s)"
+                      name meta.cascade_name reason;
+                    Prometheus.inc_counter
+                      Keeper_metrics.metric_keeper_auto_resume_blocked_total
+                      ~labels:[("keeper", name);
+                               ("cascade", meta.cascade_name)]
+                      ()
+                | Keeper_health_probe.Unknown
+                | Keeper_health_probe.Healthy ->
+                  begin
                  let resume_after_sec =
                    Option.value ~default:0.0 meta.auto_resume_after_sec in
                  let paused_ts =
@@ -1713,7 +1741,7 @@ let sweep_and_recover (ctx : _ context) =
                           "%s: auto-resume meta write failed: %s"
                           name err)
                  end
-               end
+                  end)
            | _ -> ());
          Eio_guard.yield_step sweep_names_ym);
   (* Phase 4: reconcile LAST — only orphaned durable keepers *)

--- a/test/test_keeper_health_probe.ml
+++ b/test/test_keeper_health_probe.ml
@@ -1,13 +1,41 @@
 (* Tests for keeper_health_probe.  Pure synchronous tests for the
-   cache and cascade ratio logic; the async fiber is covered by
-   integration tests in test_keeper_supervisor.ml. *)
+   cache and cascade ratio logic; the supervisor wiring (run_once
+   call site, get_cascade_status branch) is covered by integration
+   tests in test_keeper_supervisor.ml. *)
+
+module H = Masc_mcp.Keeper_health_probe
+
+let pp_status fmt = function
+  | H.Unknown -> Format.fprintf fmt "Unknown"
+  | H.Healthy -> Format.fprintf fmt "Healthy"
+  | H.Unhealthy r -> Format.fprintf fmt "Unhealthy(%s)" r
+
+let status_eq a b =
+  match a, b with
+  | H.Unknown, H.Unknown -> true
+  | H.Healthy, H.Healthy -> true
+  | H.Unhealthy x, H.Unhealthy y -> String.equal x y
+  | _ -> false
+
+let status_t = Alcotest.testable pp_status status_eq
+
+let test_get_cascade_status_default_unknown () =
+  (* Cold-cache regression: a cascade name never written must return
+     Unknown.  Before [get_cascade_status] existed, the supervisor
+     consulted [is_healthy] which collapses Unknown to false — turning
+     the boot-time race window into a permanent auto-resume lockout
+     for every keeper paused with [auto_resume_after_sec].  See PR
+     #14146 + supervisor Phase 3.5. *)
+  Alcotest.check status_t "cold cascade cache = Unknown" H.Unknown
+    (H.get_cascade_status ~cascade_name:"never-written-cascade-xyz")
 
 let test_is_healthy_unknown () =
-  Alcotest.(check bool) "unknown = false" false
-    (Masc_mcp.Keeper_health_probe.is_healthy ~keeper_name:"k1")
+  (* Backward-compat shim returns false on Unknown — kept to document
+     the old behavior callers should migrate away from. *)
+  Alcotest.(check bool) "is_healthy on uninitialized keeper = false" false
+    (Masc_mcp.Keeper_health_probe.is_healthy ~keeper_name:"k1-never-set")
 
 let test_check_cascade_health_all_healthy () =
-  (* With 0 registry entries, every cascade has 0/0 failures = healthy. *)
   let base_dir = Filename.temp_file "probe-" "" in
   Sys.remove base_dir;
   let results =
@@ -20,7 +48,9 @@ let test_check_cascade_health_all_healthy () =
 let () =
   Alcotest.run "keeper_health_probe" [
     "cache", [
-      Alcotest.test_case "unknown_is_false" `Quick
+      Alcotest.test_case "default_status_is_unknown" `Quick
+        test_get_cascade_status_default_unknown;
+      Alcotest.test_case "is_healthy_unknown_compat" `Quick
         test_is_healthy_unknown;
     ];
     "cascade", [


### PR DESCRIPTION
## Summary

Auto-resume across the entire paused-keeper fleet is silently disabled. Every 30 seconds the supervisor logs:

```
[Keeper] <name>: auto-resume blocked; cascade <X> is unhealthy
```

…for every paused keeper, regardless of actual cascade health. 16/17 keepers in the local fleet (with 1 h–16 h `auto_resume_after_sec` backoffs) sit permanently locked out.

## Root cause (two stacked defects)

`Keeper_supervisor.sweep_and_recover` Phase 3.5 (introduced by PR #14146) gates auto-resume on `Keeper_health_probe.is_healthy ~keeper_name:meta.cascade_name`. The bug is the cache feeding that lookup:

1. **`start_probe` was never wired** — the background fiber that populates the cascade health cache has zero callers in `bin/` / `lib/`. Cache stays cold forever.
2. **`is_healthy` collapses `Unknown` to `false`** — cache miss = unhealthy. Combined with (1), the boot-time race window becomes a permanent lockout.

This is the `Unknown → Permissive Default` anti-pattern from `instructions/software-development.md` §1, applied with the wrong polarity (Unknown → Restrictive). Same root: compressing a tri-valued health state into a boolean.

## Changes

| File | Change |
|------|--------|
| `lib/keeper/keeper_health_probe.{ml,mli}` | Expose `get_cascade_status ~cascade_name` returning the three-valued `health_status` so callers can branch on `Unknown` explicitly. Document the cold-cache regression in the `.mli` preamble. |
| `lib/keeper/keeper_supervisor.ml` (`sweep_and_recover`) | Call `Keeper_health_probe.run_once` at the top of every sweep (wrapped in `Safe_ops.protect`) so the cascade cache is populated from the in-memory registry without depending on the unwired fiber. Phase 3.5 switches to typed `match`: `Unhealthy` blocks (logs reason tag), `Healthy` and `Unknown` both proceed to the timer check. |
| `test/test_keeper_health_probe.ml` | Regression: `get_cascade_status` returns `Unknown` for a never-written cascade. |

Diffstat: `+111 / -18` across 4 files.

## Why typed `match` instead of just wiring `start_probe`

`check_cascade_health` reads only the in-memory keeper registry. When all keepers in a cascade are paused (the production state right now), the registry has zero entries to score, so even with the fiber wired the cache stays empty for that cascade. The Unknown→permissive branch is what unblocks production; the wiring is a defense-in-depth supplement.

## Verification

```
dune build --root . @check               # clean
dune exec test/test_keeper_health_probe.exe                  # 3/3 pass
dune exec test/test_keeper_supervisor.exe                    # 70/70 pass
dune exec test/test_keeper_supervisor_finally_cancel_swallow.exe   # OK
dune exec test/test_keeper_supervisor_observability_10125.exe      # 6/6
dune exec test/test_keeper_supervisor_write_meta_source.exe        # 2/2
dune exec test/test_keeper_autoboot_supervisor_start_10125.exe     # 2/2
dune exec test/test_supervisor_start_predicate.exe                 # 3/3
```

## Out of scope (intentional)

- Threshold (`< 0.10` hard-coded in `check_cascade_health`) and the cascade-vs-keeper key semantics confusion (`is_healthy ~keeper_name:cascade_name`) belong in a follow-up RFC (proposed RFC-0046 — keeper health probe lifecycle).
- `start_probe` background fiber is retained for future faster-cadence use; remains unwired in this PR.

## Test plan

- [ ] Restart server, confirm "auto-resume blocked" log stops repeating for every paused keeper on every sweep.
- [ ] Verify a keeper with elapsed `auto_resume_after_sec` actually transitions to `paused=false` and gets restarted on the next sweep.
- [ ] If a cascade is genuinely unhealthy (e.g. provider outage), the new log line `cascade <X> is unhealthy (failure_ratio)` should still fire and `masc_keeper_auto_resume_blocked_total` should increment.

## Anti-patterns referenced

- `instructions/software-development.md` §1 — Unknown → Permissive Default (this PR fixes the inverted polarity).
- `instructions/software-development.md` "워크어라운드 거부 기준" §1 — telemetry-as-fix: the prior `auto_resume_blocked_total` counter made the lockout *visible* without *fixing* it. This PR fixes it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)