### PR TITLE
feat(cdal_runtime): empty sublibrary skeleton (RFC-OAS-011 MM-1)

### DIFF
--- a/lib/cdal_runtime/cdal_runtime.ml
+++ b/lib/cdal_runtime/cdal_runtime.ml
@@ -1,0 +1,18 @@
+(** Cdal_runtime — Skeleton placeholder for the OAS CDAL runtime sublibrary.
+
+    This module exists solely to give the [masc_mcp.cdal_runtime] dune library
+    one buildable compilation unit while RFC-OAS-011 MM-1 is in flight.
+
+    No public API will live in this module. MM-2 leaf-first batches replace
+    this placeholder with the migrated CDAL runtime modules in the order:
+
+      B1 (pure leaves):  execution_mode, effect_evidence, guardrail_llm
+      B2 (low-deps):     risk_class, verified_output, conformance
+      B3 (mid-deps):     risk_contract, cdal_proof, mode_resolver, cognitive_event
+      B4 (high-deps):    proof_capture, proof_store, mode_enforcer,
+                         contract_runner, direct_evidence
+      B5 (top-deps):     audit, autonomy_*, sessions_proof, etc.
+
+    @rfc RFC-OAS-011 *)
+
+let placeholder_marker = "RFC-OAS-011 MM-1 skeleton"

--- a/lib/cdal_runtime/dune
+++ b/lib/cdal_runtime/dune
@@ -1,0 +1,30 @@
+; RFC-OAS-011 MM-1 — Skeleton dune sublibrary for OAS CDAL runtime migration.
+;
+; This sublibrary will host the agent-runtime side of CDAL (Cdal_proof,
+; Mode_enforcer, Risk_contract, Execution_mode, Proof_capture, Audit, ...)
+; once MM-2 leaf-first migration begins. It is intentionally separated from
+; masc-mcp's existing CDAL Phase 1A evaluators (lib/cdal_*.ml + lib/cdal/)
+; because the two layers have different responsibilities:
+;
+;   masc_mcp (本体, lib/cdal_*.ml + lib/cdal/) — CDAL Phase 1A evaluator:
+;     consumer-side judge, verdict_gate, labeling, adversarial_eval.
+;
+;   masc_mcp.cdal_runtime (this) — CDAL runtime/producer:
+;     proof capture middleware, mode enforcement, risk contract typing.
+;
+; Dependencies are intentionally minimal: only OAS's *core* (agent_sdk.base
+; for Tool/Hooks/Types) plus Yojson for serialization. NO dependency on the
+; masc_mcp main library — the producer side must remain reusable independently.
+;
+; @rfc RFC-OAS-011 (CDAL Migration to masc-mcp)
+; @phase MM-1 — empty skeleton; modules arrive in MM-2 leaf-first batches
+
+(library
+ (name masc_mcp_cdal_runtime)
+ (public_name masc_mcp.cdal_runtime)
+ (libraries
+  agent_sdk.base
+  yojson
+  ppx_deriving_yojson.runtime)
+ (preprocess
+  (pps ppx_deriving_yojson ppx_deriving.show ppx_inline_test ppx_let)))


### PR DESCRIPTION
## 요약

RFC-OAS-011의 첫 PR — masc-mcp에 `masc_mcp.cdal_runtime` dune sublibrary skeleton 생성. **모듈 0개, placeholder만**. MM-2 leaf-first batches에서 실제 CDAL 모듈을 OAS에서 이주.

## Background — 왜 이주

PR #1480에서 머지된 RFC-OAS-011 docs는 *"CDAL은 cross-system, OAS와 masc-mcp 양쪽이 함께 design"*이라는 가정으로 OAS의 일부 보존을 시사했으나, 사용자가 직접 짚어주신 핵심:

> *"OAS는 SDK인데 CDAL이 있을 이유가 없어보이는데?"*

검증 결과:
- OAS = unopinionated agent SDK (LLM client + agent loop). README/CLAUDE.md/dune-project synopsis가 일관 정의.
- CDAL = opinionated governance/proof framework. *consumer 책임*이어야 정공.
- masc-mcp의 `docs/design/contract-driven-agent-loop-rfc.md`의 *"Scope: OAS / MASC / MCP"*는 *현재 코드 현실의 post-hoc rationalization* — design intent가 아님 (메모리 `feedback_telemetry_as_fix_workaround` 정신).
- masc-mcp가 OAS의 `Cdal_proof`/`Mode_enforcer`/`Risk_contract`/`Execution_mode`를 import하는 것은 *과거 layering 위반의 흔적*, 유지되어야 할 design이 아님.

RFC-OAS-009 v2 (#1480/#1481/#1482/#1483)가 OAS 내부 boundary를 lock한 것 위에, RFC-OAS-011이 *생성 위치*도 정정. 즉 producer 타입도 *유일한 consumer 안*으로 이주.

## Naming rationale

masc-mcp는 *이미* CDAL 시스템을 가지고 있음 (Phase 1A evaluator, 5월 1일자):

| Layer | 위치 | 책임 |
|---|---|---|
| `masc_mcp` 본체 | `lib/cdal_*.ml` (8 modules) + `lib/cdal/` (adversarial_eval, labeling) | CDAL Phase 1A *evaluator* — judge, verdict_gate, labeling, friction_projection |
| **`masc_mcp.cdal_runtime`** (this PR) | `lib/cdal_runtime/` (sublibrary) | CDAL *runtime/producer* — proof capture, mode enforcement, risk contract typing |

다른 책임이므로 별 sublibrary로 분리. 두 layer가 같은 디렉토리에 섞이면 *Phase 1A의 evaluator 코드가 producer 코드에 의도치 않게 의존*할 수 있음.

## 변경

| 파일 | 내용 |
|---|---|
| `lib/cdal_runtime/dune` | dune library `masc_mcp_cdal_runtime` (public_name `masc_mcp.cdal_runtime`). 의존: `agent_sdk.base`, `yojson`, `ppx_deriving_yojson.runtime`. ppx: `ppx_deriving_yojson`, `ppx_deriving.show`, `ppx_inline_test`, `ppx_let`. masc_mcp 자체는 의존 안 함 |
| `lib/cdal_runtime/cdal_runtime.ml` | 1줄 placeholder (`let placeholder_marker = "RFC-OAS-011 MM-1 skeleton"`). 헤더 주석에 MM-2 batch 순서 명시 |

Stat: **+48 / -0** (skeleton).

## Verification

- `git status -s` 두 파일 추가 확인
- `agent_sdk.base` 의존 해결 가능성: `ocamlfind list | grep agent_sdk` 결과 active switch (5.4.1)에 `agent_sdk.base v0.191.0-11-g186e51c` 존재 확인
- 로컬 `scripts/dune-local.sh build lib/cdal_runtime/`은 `/tmp/me-dune-local.lock` multi-worktree 직렬화로 stuck. 메모리 `reference_masc_mcp_dune_local_lock_contention`에 명시된 *우회 전략*: GitHub Actions clean 환경의 CI 검증

## RFC 시리즈 진행 상황

| PR | 상태 |
|---|---|
| RFC-OAS-009 v2 + 011 + 012 docs (oas#1480) | MERGED |
| OAS-B agent_tools (oas#1481) | MERGED |
| OAS-C mcp_schema + test (oas#1482) | MERGED |
| OAS-D boundary CI lint (oas#1483) | MERGED |
| **MM-1 (this) cdal_runtime skel** | OPEN, Draft |
| MM-2-leaves (B1: execution_mode, effect_evidence, guardrail_llm) | TBD |
| MM-2-low~top (B2~B5) | TBD |
| MM-3-rewire (Phase 1A evaluator → masc_mcp.cdal_runtime types) | TBD |
| OAS-E (CDAL 30+ 모듈 OAS 제거, agent_sdk 0.193.0) | masc-mcp MM-3 머지 후 |
| MM-4 (opam pin → 0.193.0) | OAS-E 머지 후 |

## Test plan

- [ ] CI green 확인 — sublibrary가 clean 환경에서 빌드 통과
- [ ] CodeRabbit/사람 리뷰 코멘트 대응
- [ ] `human-approved-ready` 라벨 부착 후 머지

## 위험 (1건)

masc_mcp 본체와 `masc_mcp.cdal_runtime` 사이 의존성 cycle 위험: 본 PR은 masc_mcp 본체 → masc_mcp.cdal_runtime 의존을 *추가하지 않음*. cycle 위험은 MM-3-rewire에서 본체의 `cdal_loader` 등이 `Masc_mcp_cdal_runtime.X`를 import할 때 발생할 수 있으나, 그 시점에는 masc_mcp.cdal_runtime이 *self-contained*이므로 단방향 의존만 형성 — cycle 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)