### PR TITLE
style(keeper): apply ocamlformat to PR #14246 files

### DIFF
--- a/lib/keeper/keeper_health_probe.ml
+++ b/lib/keeper/keeper_health_probe.ml
@@ -13,8 +13,7 @@ type health_status =
 
 (** Per-keeper, per-item health cache.
     Key: (keeper_name, item_id). Value: (status, timestamp). *)
-let health_cache : ((string * string), health_status * float) Hashtbl.t =
-  Hashtbl.create 16
+let health_cache : (string * string, health_status * float) Hashtbl.t = Hashtbl.create 16
 
 let health_cache_mu = Eio.Mutex.create ()
 
@@ -29,22 +28,22 @@ let is_item_healthy ~keeper_name ~item_id =
     match Hashtbl.find_opt health_cache (keeper_name, item_id) with
     | Some (Healthy, _) -> true
     | _ -> false)
+;;
 
 (** [set_item_health ~keeper_name ~item_id status] updates the cache
     for a specific keeper+item pair. *)
 let set_item_health ~keeper_name ~item_id status =
   Eio.Mutex.use_rw ~protect:true health_cache_mu (fun () ->
-    Hashtbl.replace health_cache (keeper_name, item_id)
-      (status, Time_compat.now ()))
+    Hashtbl.replace health_cache (keeper_name, item_id) (status, Time_compat.now ()))
+;;
 
 (** [record_item_result ~keeper_name ~item_id ~success] updates the
     health state based on turn outcome. Success -> Healthy immediately.
     Failure -> Unhealthy (no Degraded intermediate for now). *)
 let record_item_result ~keeper_name ~item_id ~success =
-  let status =
-    if success then Healthy else Unhealthy "turn_failure"
-  in
+  let status = if success then Healthy else Unhealthy "turn_failure" in
   set_item_health ~keeper_name ~item_id status
+;;
 
 (* ------------------------------------------------------------------ *)
 (* Backward-compatible per-keeper health (deprecated)                 *)
@@ -60,17 +59,19 @@ let is_healthy ~keeper_name =
     let found = ref false in
     Hashtbl.iter
       (fun (kn, _item_id) (status, _ts) ->
-        if String.equal kn keeper_name then
-          match status with
-          | Healthy -> found := true
-          | _ -> ())
+         if String.equal kn keeper_name
+         then (
+           match status with
+           | Healthy -> found := true
+           | _ -> ()))
       health_cache;
     !found)
+;;
 
 let set_health ~keeper_name status =
   Eio.Mutex.use_rw ~protect:true health_cache_mu (fun () ->
-    Hashtbl.replace health_cache (keeper_name, "")
-      (status, Time_compat.now ()))
+    Hashtbl.replace health_cache (keeper_name, "") (status, Time_compat.now ()))
+;;
 
 (** [get_cascade_status ~cascade_name] reads the cascade-level entry
     written by [set_health]/[run_once].  Three-valued:
@@ -84,6 +85,7 @@ let get_cascade_status ~cascade_name =
     match Hashtbl.find_opt health_cache (cascade_name, "") with
     | Some (status, _) -> status
     | None -> Unknown)
+;;
 
 (* ------------------------------------------------------------------ *)
 (* Cascade health check                                               *)
@@ -102,26 +104,25 @@ let check_cascade_health ~base_path =
   let by_cascade = Hashtbl.create 8 in
   List.iter
     (fun (entry : Keeper_registry.registry_entry) ->
-      let cascade = entry.meta.cascade_name in
-      let (total, failed) =
-        match Hashtbl.find_opt by_cascade cascade with
-        | Some pair -> pair
-        | None -> (0, 0)
-      in
-      let failed' =
-        if entry.restart_count > 0 then failed + 1 else failed
-      in
-      Hashtbl.replace by_cascade cascade (total + 1, failed'))
+       let cascade = entry.meta.cascade_name in
+       let total, failed =
+         match Hashtbl.find_opt by_cascade cascade with
+         | Some pair -> pair
+         | None -> 0, 0
+       in
+       let failed' = if entry.restart_count > 0 then failed + 1 else failed in
+       Hashtbl.replace by_cascade cascade (total + 1, failed'))
     entries;
   Hashtbl.fold
     (fun cascade (total, failed) acc ->
-      let ratio =
-        if total <= 0 then 0.0
-        else float_of_int failed /. float_of_int total
-      in
-      let healthy = ratio < 0.10 in
-      (cascade, healthy) :: acc)
-    by_cascade []
+       let ratio =
+         if total <= 0 then 0.0 else float_of_int failed /. float_of_int total
+       in
+       let healthy = ratio < 0.10 in
+       (cascade, healthy) :: acc)
+    by_cascade
+    []
+;;
 
 (* ------------------------------------------------------------------ *)
 (* Background probe fiber                                             *)
@@ -131,11 +132,12 @@ let run_once ~base_path =
   let results = check_cascade_health ~base_path in
   List.iter
     (fun (cascade, healthy) ->
-      let status = if healthy then Healthy else Unhealthy "failure_ratio" in
-      (* Cache keyed by cascade name so ResumeFromPause can look it up.
+       let status = if healthy then Healthy else Unhealthy "failure_ratio" in
+       (* Cache keyed by cascade name so ResumeFromPause can look it up.
          Uses empty item_id for backward compat. *)
-      set_health ~keeper_name:cascade status)
+       set_health ~keeper_name:cascade status)
     results
+;;
 
 let rec probe_loop ~base_path ~interval_sec () =
   (* Cancel-aware: Safe_ops.protect re-raises Eio.Cancel.Cancelled and swallows
@@ -144,10 +146,12 @@ let rec probe_loop ~base_path ~interval_sec () =
   Safe_ops.protect ~default:() (fun () -> run_once ~base_path);
   Eio_unix.sleep interval_sec;
   probe_loop ~base_path ~interval_sec ()
+;;
 
 let start_probe ~sw ~base_path ~interval_sec =
-  if interval_sec <= 0.0 then ()
+  if interval_sec <= 0.0
+  then ()
   else
     Eio.Fiber.fork ~sw (fun () ->
-      Eio.Switch.run (fun _sw ->
-        probe_loop ~base_path ~interval_sec ()))
+      Eio.Switch.run (fun _sw -> probe_loop ~base_path ~interval_sec ()))
+;;

--- a/lib/keeper/keeper_health_probe.mli
+++ b/lib/keeper/keeper_health_probe.mli
@@ -23,14 +23,11 @@ val is_item_healthy : keeper_name:string -> item_id:string -> bool
 
 (** [set_item_health ~keeper_name ~item_id status] updates the cache
     for a specific keeper+item pair. *)
-val set_item_health :
-  keeper_name:string -> item_id:string ->
-  health_status -> unit
+val set_item_health : keeper_name:string -> item_id:string -> health_status -> unit
 
 (** [record_item_result ~keeper_name ~item_id ~success] updates health
     state based on turn outcome. Success -> Healthy, Failure -> Unhealthy. *)
-val record_item_result :
-  keeper_name:string -> item_id:string -> success:bool -> unit
+val record_item_result : keeper_name:string -> item_id:string -> success:bool -> unit
 
 (** {1 Backward-compatible per-keeper health (deprecated)} *)
 
@@ -49,8 +46,7 @@ val set_health : keeper_name:string -> health_status -> unit
     the failure ratio for each active cascade.  Returns a list of
     (cascade_name, is_healthy) pairs.  This function performs I/O and
     should be called from the probe fiber, not the supervisor sweep. *)
-val check_cascade_health :
-  base_path:string -> (string * bool) list
+val check_cascade_health : base_path:string -> (string * bool) list
 
 (** [get_cascade_status ~cascade_name] returns the cached cascade-level
     [health_status] written by [run_once]/[set_health].  Unlike
@@ -80,5 +76,4 @@ val run_once : base_path:string -> unit
     cancelled.  Currently unused — the supervisor calls [run_once]
     inline.  Retained for future use when a faster cadence than the
     30 s sweep is needed. *)
-val start_probe :
-  sw:Eio.Switch.t -> base_path:string -> interval_sec:float -> unit
+val start_probe : sw:Eio.Switch.t -> base_path:string -> interval_sec:float -> unit

--- a/test/test_keeper_health_probe.ml
+++ b/test/test_keeper_health_probe.ml
@@ -9,6 +9,7 @@ let pp_status fmt = function
   | H.Unknown -> Format.fprintf fmt "Unknown"
   | H.Healthy -> Format.fprintf fmt "Healthy"
   | H.Unhealthy r -> Format.fprintf fmt "Unhealthy(%s)" r
+;;
 
 let status_eq a b =
   match a, b with
@@ -16,6 +17,7 @@ let status_eq a b =
   | H.Healthy, H.Healthy -> true
   | H.Unhealthy x, H.Unhealthy y -> String.equal x y
   | _ -> false
+;;
 
 let status_t = Alcotest.testable pp_status status_eq
 
@@ -26,35 +28,44 @@ let test_get_cascade_status_default_unknown () =
      the boot-time race window into a permanent auto-resume lockout
      for every keeper paused with [auto_resume_after_sec].  See PR
      #14146 + supervisor Phase 3.5. *)
-  Alcotest.check status_t "cold cascade cache = Unknown" H.Unknown
+  Alcotest.check
+    status_t
+    "cold cascade cache = Unknown"
+    H.Unknown
     (H.get_cascade_status ~cascade_name:"never-written-cascade-xyz")
+;;
 
 let test_is_healthy_unknown () =
   (* Backward-compat shim returns false on Unknown — kept to document
      the old behavior callers should migrate away from. *)
-  Alcotest.(check bool) "is_healthy on uninitialized keeper = false" false
+  Alcotest.(check bool)
+    "is_healthy on uninitialized keeper = false"
+    false
     (Masc_mcp.Keeper_health_probe.is_healthy ~keeper_name:"k1-never-set")
+;;
 
 let test_check_cascade_health_all_healthy () =
   let base_dir = Filename.temp_file "probe-" "" in
   Sys.remove base_dir;
-  let results =
-    Masc_mcp.Keeper_health_probe.check_cascade_health
-      ~base_path:base_dir
-  in
-  Alcotest.(check int) "empty registry = no cascades" 0
-    (List.length results)
+  let results = Masc_mcp.Keeper_health_probe.check_cascade_health ~base_path:base_dir in
+  Alcotest.(check int) "empty registry = no cascades" 0 (List.length results)
+;;
 
 let () =
-  Alcotest.run "keeper_health_probe" [
-    "cache", [
-      Alcotest.test_case "default_status_is_unknown" `Quick
-        test_get_cascade_status_default_unknown;
-      Alcotest.test_case "is_healthy_unknown_compat" `Quick
-        test_is_healthy_unknown;
-    ];
-    "cascade", [
-      Alcotest.test_case "empty_registry_all_healthy" `Quick
-        test_check_cascade_health_all_healthy;
-    ];
-  ]
+  Alcotest.run
+    "keeper_health_probe"
+    [ ( "cache"
+      , [ Alcotest.test_case
+            "default_status_is_unknown"
+            `Quick
+            test_get_cascade_status_default_unknown
+        ; Alcotest.test_case "is_healthy_unknown_compat" `Quick test_is_healthy_unknown
+        ] )
+    ; ( "cascade"
+      , [ Alcotest.test_case
+            "empty_registry_all_healthy"
+            `Quick
+            test_check_cascade_health_all_healthy
+        ] )
+    ]
+;;


### PR DESCRIPTION
## Summary

PR #14246 was admin-merged through a failing \`ocamlformat-check (changed files only)\` step. This PR cleans up the 3 files I authored as new content so subsequent PRs touching them aren't blocked by stale violations.

## Scope (intentionally narrow)

| File | Change |
|------|--------|
| \`lib/keeper/keeper_health_probe.ml\` | \`ocamlformat -i\` (whitespace) |
| \`lib/keeper/keeper_health_probe.mli\` | \`ocamlformat -i\` (whitespace, val signatures consolidated to single line per janestreet profile) |
| \`test/test_keeper_health_probe.ml\` | \`ocamlformat -i\` (whitespace) |

\`lib/keeper/keeper_supervisor.ml\` is **deliberately excluded**: it has 2,726 lines of pre-existing format drift unrelated to PR #14246. Reformatting it belongs in a dedicated chore PR with its own scope review.

## Verification

\`\`\`
ocamlformat --check lib/keeper/keeper_health_probe.ml      # exit 0
ocamlformat --check lib/keeper/keeper_health_probe.mli     # exit 0
ocamlformat --check test/test_keeper_health_probe.ml       # exit 0
\`\`\`

(ocamlformat 0.29.0, profile = janestreet, matches \`.ocamlformat\`.)

\`dune build @check\` is currently blocked on main by an unrelated \`lib/cdal_runtime/dune\` stanza error introduced by PR #14247 (also admin-merged) — confirmed by stashing this PR's diff and reproducing the same dune error on a clean origin/main checkout.

No semantic changes; tests verified at PR #14246 merge time still apply.

## Test plan

- [ ] CI \`ocamlformat-check\` should pass green on the 3 files in this PR's diff.
- [ ] Once \`lib/cdal_runtime/dune\` is fixed (separate concern), \`dune exec test/test_keeper_health_probe.exe\` should still produce 3/3 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)