### PR TITLE
feat(dashboard): RFC-0046 §7 #2 — FsmHub external snapshot prop, full composite dedup

### DIFF
--- a/dashboard/src/components/fsm-hub.ts
+++ b/dashboard/src/components/fsm-hub.ts
@@ -240,10 +240,23 @@ export interface FsmHubProps {
    *  selector — the parent surface (keeper detail page) has already
    *  pinned a single keeper, so re-offering selection is noise. */
   mode?: 'fleet' | 'detail'
+  /** RFC-0046 §7 #2 follow-up: parent-supplied composite snapshot.
+   *  When the prop is present (not `undefined`), this hub stops
+   *  issuing its own /composite poll and feeds the parent value into
+   *  its reducer as a `fetch_succeeded` event. `null` means the
+   *  parent is loading — wait, do not race a duplicate fetch.
+   *  Only honoured in `mode='detail'`; in `'fleet'` mode the keeper
+   *  selector tablist drives `selectedName` directly and the parent
+   *  has no single snapshot to share. */
+  externalSnapshot?: KeeperCompositeSnapshot | null
 }
 
 export function FsmHub(props: FsmHubProps = {}) {
   const mode = props.mode ?? 'fleet'
+  // RFC-0046 §7 #2: parent-supplied snapshot only honoured in 'detail'
+  // mode. Fleet mode drives selection internally and has no single
+  // snapshot to share, so we fall back to the existing fetch path.
+  const externalSnapshot = mode === 'detail' ? props.externalSnapshot : undefined
   const [selected, setSelected] = useState<string | null>(props.selectedName ?? null)
   useEffect(() => {
     if (props.selectedName !== undefined && props.selectedName !== selected) {
@@ -435,6 +448,25 @@ export function FsmHub(props: FsmHubProps = {}) {
 
   useEffect(() => {
     if (!activeSelected) return
+
+    // RFC-0046 §7 #2: parent supplies the snapshot in 'detail' mode.
+    // Inject it into the reducer instead of issuing a duplicate fetch.
+    // `null` = parent is still loading — emit fetch_started so the
+    // skeleton UI shows, then wait for the next prop update.
+    if (externalSnapshot !== undefined) {
+      if (externalSnapshot == null) {
+        dispatch({ type: 'fetch_started', keeperName: activeSelected })
+      } else {
+        dispatch({
+          type: 'fetch_succeeded',
+          keeperName: activeSelected,
+          snapshot: externalSnapshot,
+          fetchedAt: Date.now() / 1000,
+        })
+      }
+      return
+    }
+
     const requestId = requestIdRef.current + 1
     requestIdRef.current = requestId
     dispatch({ type: 'fetch_started', keeperName: activeSelected })
@@ -468,7 +500,7 @@ export function FsmHub(props: FsmHubProps = {}) {
         })
       }
     })()
-  }, [activeSelected, shouldRefetchForTick, pollTick])
+  }, [activeSelected, shouldRefetchForTick, pollTick, externalSnapshot])
 
   useGlobalShortcut(
     (ev) => ev.key >= '1' && ev.key <= '9',

--- a/dashboard/src/components/keeper-detail.ts
+++ b/dashboard/src/components/keeper-detail.ts
@@ -1056,7 +1056,12 @@ export function KeeperDetailPage() {
             title="운영 상태 개요"
           >
         ${'' /* RFC-0046: 6-axis composite snapshot (KSM/KTC/KDP/KCL/KMC/breaker) — SSOT for keeper FSM state */}
-        <${FsmHub} mode="detail" selectedName=${keeper.name} />
+        ${'' /* RFC-0046 §7 #2: share useKeeperComposite with FsmHub to dedup the /composite poll */}
+        <${FsmHub}
+          mode="detail"
+          selectedName=${keeper.name}
+          externalSnapshot=${compositeSnapshot}
+        />
         <${CollapsibleSection} title="Phase State Machine">
           <${KeeperStateDiagramPanel} keeperName=${keeper.name} snapshot=${compositeSnapshot} />
         <//>


### PR DESCRIPTION
## 요약

RFC-0046 §7 마무리. PR #14242에서 3→2로 줄인 `/composite` fetch를 1로 마무리. 사용자 요청 "순서대로 개선" 1번.

## 효과

| Phase | 한 cycle 당 `/composite` 호출 | 트리거 |
|---|---|---|
| #14219 baseline | **3** | FsmHub + StateDiagramPanel + MemoryTierPanel 각자 |
| #14242 후 | **2** | parent `useKeeperComposite` + FsmHub |
| **이 PR 후** | **1** | parent hook만 |

## 변경

### 1) `FsmHub` `externalSnapshot` prop 추가 (`mode='detail'` 한정)

PR #14226 (Step 1 mode prop) + PR #14242 (panel snapshot prop)와 동일한 three-state contract:

| value | 동작 |
|---|---|
| `undefined` | parent 미참여 → 기존 internal fetch path (fleet mode + 기존 caller 보존) |
| `null` | parent 로딩 중 → `fetch_started` dispatch만, network 호출 X |
| `KeeperCompositeSnapshot` | `fetch_succeeded` reducer 이벤트로 직접 주입 |

`mode==='detail'`에서만 honor — fleet mode는 keeper selector tablist가 selection 주체라 parent가 single snapshot 가질 수 없음.

### 2) `keeper-detail.ts` — `externalSnapshot` prop 전달

\`\`\`diff
 <${FsmHub}
   mode="detail"
   selectedName=${keeper.name}
+  externalSnapshot=${compositeSnapshot}
 />
\`\`\`

`compositeSnapshot`은 #14242에서 도입한 `useKeeperComposite(keeper.name)` hook 결과.

## 검증

| 검사 | 결과 |
|---|---|
| `pnpm typecheck` | 변경 파일 0 새 에러 |
| `pnpm vitest run fsm-hub keeper-detail` | **93/93 passed** |
| `pnpm build` | 성공 (9.06s) |
| Baseline 3 fail in `fsm-hub.integration.test.ts` | main에 동일 — `fsm_guard_violations` schema drift, 이번 PR 무관 |
| LoC | **+37 / −2** |

## RFC §7 종결

RFC-0046 §7 follow-up 두 항목 중 #1 (single composite fetch) 마무리. #2 (backend two-store drift detector)는 OCaml backend RFC 스코프로 분리.

## RFC 발견 체크
- 변경 영역: `dashboard/src/components/` only.

## ⚠️ Draft 유지 요청
agent-authored — `human-approved-ready` 라벨 후 ready.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>