### PR TITLE
chore(dashboard): RFC-0049 PR-1 follow-up — apply ocamlformat janestreet

### DIFF
--- a/lib/dashboard/dashboard_nav_event.ml
+++ b/lib/dashboard/dashboard_nav_event.ml
@@ -1,10 +1,10 @@
 (* RFC-0049 — dashboard surface/section open counters. *)
 
-type event = {
-  surface : string;
-  section : string option;
-  redirected_from : string option;
-}
+type event =
+  { surface : string
+  ; section : string option
+  ; redirected_from : string option
+  }
 
 (* Mirror of dashboard/src/types/sse.ts:VALID_TABS. *)
 let valid_surfaces =
@@ -18,13 +18,14 @@ let valid_surfaces =
   ; "code"
   ; "logs"
   ]
+;;
 
 (* Mirror of dashboard/src/config/navigation.ts:DASHBOARD_SECTION_ITEMS.
    Includes hidden sections (observatory, memory-subsystems) because they
    remain reachable via redirects and continue to fire telemetry. *)
 let valid_sections =
-  [ "monitoring",
-      [ "journey"
+  [ ( "monitoring"
+    , [ "journey"
       ; "observatory"
       ; "agents"
       ; "cognition"
@@ -32,19 +33,14 @@ let valid_sections =
       ; "goal-loop"
       ; "fleet-health"
       ; "memory-subsystems"
-      ]
+      ] )
   ; "command", [ "operations" ]
   ; "connectors", [ "connector-status" ]
-  ; "workspace",
-      [ "board"
-      ; "sub-boards"
-      ; "planning"
-      ; "repositories"
-      ; "verification"
-      ]
+  ; "workspace", [ "board"; "sub-boards"; "planning"; "repositories"; "verification" ]
   ; "lab", [ "tools"; "autoresearch"; "harness" ]
   ; "code", [ "ide-shell" ]
   ]
+;;
 
 let is_valid_surface s = List.mem s valid_surfaces
 
@@ -52,42 +48,47 @@ let is_valid_section ~surface section =
   match List.assoc_opt surface valid_sections with
   | None -> false
   | Some sections -> List.mem section sections
+;;
 
 let counter_surface = "dashboard_surface_open_total"
 let counter_section = "dashboard_section_open_total"
 
 let () =
-  Prometheus.register_counter ~name:counter_surface
-    ~help:"Top-level dashboard surface opens (RFC-0049). Aggregate, no PII." ()
+  Prometheus.register_counter
+    ~name:counter_surface
+    ~help:"Top-level dashboard surface opens (RFC-0049). Aggregate, no PII."
+    ()
+;;
 
 let () =
-  Prometheus.register_counter ~name:counter_section
+  Prometheus.register_counter
+    ~name:counter_section
     ~help:
-      "Section-level opens within a dashboard surface (RFC-0049). \
-       redirected_from carries the original surface:section key when the \
-       route arrived through CROSS_SURFACE_SECTION_REDIRECTS, otherwise \
-       \"none\". Aggregate, no PII." ()
+      "Section-level opens within a dashboard surface (RFC-0049). redirected_from \
+       carries the original surface:section key when the route arrived through \
+       CROSS_SURFACE_SECTION_REDIRECTS, otherwise \"none\". Aggregate, no PII."
+    ()
+;;
 
 let parse_redirected_from ~target_surface ~target_section raw =
   match String.index_opt raw ':' with
   | None -> Error (Printf.sprintf "redirected_from missing ':' separator: %s" raw)
   | Some idx ->
-      let from_surface = String.sub raw 0 idx in
-      let from_section = String.sub raw (idx + 1) (String.length raw - idx - 1) in
-      if not (is_valid_surface from_surface) then
-        Error
-          (Printf.sprintf "redirected_from references unknown surface: %s"
-             from_surface)
-      else if from_surface = target_surface && Some from_section = target_section
-      then
-        Error
-          "redirected_from must differ from the resolved (surface, section)"
-      else if not (is_valid_section ~surface:from_surface from_section) then
-        (* The original section may have been deleted but the redirect
+    let from_surface = String.sub raw 0 idx in
+    let from_section = String.sub raw (idx + 1) (String.length raw - idx - 1) in
+    if not (is_valid_surface from_surface)
+    then
+      Error (Printf.sprintf "redirected_from references unknown surface: %s" from_surface)
+    else if from_surface = target_surface && Some from_section = target_section
+    then Error "redirected_from must differ from the resolved (surface, section)"
+    else if not (is_valid_section ~surface:from_surface from_section)
+    then
+      (* The original section may have been deleted but the redirect
            survives; we still require the surface to be known. Allowlist
            is "known surfaces", not "known sections" for the *from* side. *)
-        Ok raw
-      else Ok raw
+      Ok raw
+    else Ok raw
+;;
 
 let parse_event_json json =
   let open Yojson.Safe.Util in
@@ -98,9 +99,9 @@ let parse_event_json json =
       | `Null -> raise (Type_error ("missing surface", json))
       | _ -> raise (Type_error ("surface must be string", json))
     in
-    if not (is_valid_surface surface) then
-      Error (Printf.sprintf "unknown surface: %s" surface)
-    else
+    if not (is_valid_surface surface)
+    then Error (Printf.sprintf "unknown surface: %s" surface)
+    else (
       let section =
         match member "section" json with
         | `Null -> None
@@ -112,45 +113,44 @@ let parse_event_json json =
         match section with
         | None -> Ok ()
         | Some s ->
-            if is_valid_section ~surface s then Ok ()
-            else Error (Printf.sprintf "unknown section %s for surface %s" s surface)
+          if is_valid_section ~surface s
+          then Ok ()
+          else Error (Printf.sprintf "unknown section %s for surface %s" s surface)
       in
       match section_ok with
       | Error e -> Error e
       | Ok () ->
-          let redirected_from_result =
-            match member "redirected_from" json with
-            | `Null -> Ok None
-            | `String "" -> Ok None
-            | `String "none" -> Ok None
-            | `String raw ->
-                (match
-                   parse_redirected_from ~target_surface:surface
-                     ~target_section:section raw
-                 with
-                 | Ok v -> Ok (Some v)
-                 | Error e -> Error e)
-            | _ ->
-                Error "redirected_from must be string or null"
-          in
-          (match redirected_from_result with
-          | Error e -> Error e
-          | Ok redirected_from -> Ok { surface; section; redirected_from })
+        let redirected_from_result =
+          match member "redirected_from" json with
+          | `Null -> Ok None
+          | `String "" -> Ok None
+          | `String "none" -> Ok None
+          | `String raw ->
+            (match
+               parse_redirected_from ~target_surface:surface ~target_section:section raw
+             with
+             | Ok v -> Ok (Some v)
+             | Error e -> Error e)
+          | _ -> Error "redirected_from must be string or null"
+        in
+        (match redirected_from_result with
+         | Error e -> Error e
+         | Ok redirected_from -> Ok { surface; section; redirected_from }))
   with
   | Type_error (msg, _) -> Error msg
   | Yojson.Json_error msg -> Error msg
+;;
 
 let record { surface; section; redirected_from } =
-  Prometheus.inc_counter counter_surface
-    ~labels:[ ("surface", surface) ] ~delta:1.0 ();
+  Prometheus.inc_counter counter_surface ~labels:[ "surface", surface ] ~delta:1.0 ();
   match section with
   | None -> ()
   | Some s ->
-      let labels =
-        [ ("surface", surface)
-        ; ("section", s)
-        ; ( "redirected_from"
-          , Option.value ~default:"none" redirected_from )
-        ]
-      in
-      Prometheus.inc_counter counter_section ~labels ~delta:1.0 ()
+    let labels =
+      [ "surface", surface
+      ; "section", s
+      ; "redirected_from", Option.value ~default:"none" redirected_from
+      ]
+    in
+    Prometheus.inc_counter counter_section ~labels ~delta:1.0 ()
+;;

--- a/lib/dashboard/dashboard_nav_event.mli
+++ b/lib/dashboard/dashboard_nav_event.mli
@@ -8,11 +8,11 @@
     discarded after the counter increment.
 *)
 
-type event = {
-  surface : string;
-  section : string option;
-  redirected_from : string option;
-}
+type event =
+  { surface : string
+  ; section : string option
+  ; redirected_from : string option
+  }
 
 (** Strict allowlist of valid surface IDs. Mirrors [VALID_TABS] in
     [dashboard/src/types/sse.ts]. *)

--- a/test/test_dashboard_nav_event.ml
+++ b/test/test_dashboard_nav_event.ml
@@ -5,94 +5,120 @@ let parse_ok json_str =
   match Dashboard_nav_event.parse_event_json (Yojson.Safe.from_string json_str) with
   | Ok event -> event
   | Error msg -> failf "expected Ok, got Error %s" msg
+;;
 
 let parse_err json_str =
   match Dashboard_nav_event.parse_event_json (Yojson.Safe.from_string json_str) with
   | Ok _ -> fail "expected Error, got Ok"
   | Error msg -> msg
+;;
 
 let test_parse_minimal_surface_only () =
   let event = parse_ok {|{"surface":"overview"}|} in
   check string "surface" "overview" event.surface;
   check (option string) "section" None event.section;
   check (option string) "redirected_from" None event.redirected_from
+;;
 
 let test_parse_full_event () =
   let event =
-    parse_ok
-      {|{"surface":"monitoring","section":"journey","redirected_from":"none"}|}
+    parse_ok {|{"surface":"monitoring","section":"journey","redirected_from":"none"}|}
   in
   check string "surface" "monitoring" event.surface;
   check (option string) "section" (Some "journey") event.section;
   check (option string) "redirected_from" None event.redirected_from
+;;
 
 let test_parse_redirected () =
   let event =
     parse_ok
       {|{"surface":"workspace","section":"repositories","redirected_from":"monitoring:git-graph"}|}
   in
-  check (option string) "redirected_from"
-    (Some "monitoring:git-graph") event.redirected_from
+  check
+    (option string)
+    "redirected_from"
+    (Some "monitoring:git-graph")
+    event.redirected_from
+;;
 
 let test_reject_unknown_surface () =
   let msg = parse_err {|{"surface":"bogus"}|} in
-  check bool "mentions surface" true
+  check
+    bool
+    "mentions surface"
+    true
     (Astring.String.is_infix ~affix:"unknown surface" msg)
+;;
 
 let test_reject_unknown_section () =
   let msg = parse_err {|{"surface":"monitoring","section":"ferris-wheel"}|} in
-  check bool "mentions section" true
+  check
+    bool
+    "mentions section"
+    true
     (Astring.String.is_infix ~affix:"unknown section" msg)
+;;
 
 let test_reject_redirected_from_unknown_surface () =
   let msg =
     parse_err
       {|{"surface":"workspace","section":"repositories","redirected_from":"bogus:foo"}|}
   in
-  check bool "mentions redirected_from" true
+  check
+    bool
+    "mentions redirected_from"
+    true
     (Astring.String.is_infix ~affix:"redirected_from" msg)
+;;
 
 let test_reject_redirected_from_self () =
   let msg =
     parse_err
       {|{"surface":"workspace","section":"repositories","redirected_from":"workspace:repositories"}|}
   in
-  check bool "mentions self" true
-    (Astring.String.is_infix ~affix:"differ" msg)
+  check bool "mentions self" true (Astring.String.is_infix ~affix:"differ" msg)
+;;
 
 let test_reject_missing_surface () =
   let msg = parse_err {|{"section":"journey"}|} in
-  check bool "mentions surface" true
-    (Astring.String.is_infix ~affix:"surface" msg)
+  check bool "mentions surface" true (Astring.String.is_infix ~affix:"surface" msg)
+;;
 
 let test_reject_malformed_json () =
   let msg = parse_err "not json {" in
   check bool "non-empty error" true (String.length msg > 0)
+;;
 
 let test_section_null_explicit () =
   let event = parse_ok {|{"surface":"cockpit","section":null}|} in
   check (option string) "section" None event.section
+;;
 
 let test_record_increments_surface_counter () =
   let before =
-    Prometheus.get_metric_value "dashboard_surface_open_total"
-      ~labels:[ ("surface", "overview") ] ()
+    Prometheus.get_metric_value
+      "dashboard_surface_open_total"
+      ~labels:[ "surface", "overview" ]
+      ()
     |> Option.value ~default:0.0
   in
   Dashboard_nav_event.record
     { surface = "overview"; section = None; redirected_from = None };
   let after =
-    Prometheus.get_metric_value "dashboard_surface_open_total"
-      ~labels:[ ("surface", "overview") ] ()
+    Prometheus.get_metric_value
+      "dashboard_surface_open_total"
+      ~labels:[ "surface", "overview" ]
+      ()
     |> Option.value ~default:0.0
   in
   check (float 1e-9) "incremented by 1" 1.0 (after -. before)
+;;
 
 let test_record_increments_section_counter_with_redirect_label () =
   let labels =
-    [ ("surface", "workspace")
-    ; ("section", "repositories")
-    ; ("redirected_from", "monitoring:git-graph")
+    [ "surface", "workspace"
+    ; "section", "repositories"
+    ; "redirected_from", "monitoring:git-graph"
     ]
   in
   let before =
@@ -109,14 +135,10 @@ let test_record_increments_section_counter_with_redirect_label () =
     |> Option.value ~default:0.0
   in
   check (float 1e-9) "incremented by 1" 1.0 (after -. before)
+;;
 
 let test_record_section_counter_redirect_none_label () =
-  let labels =
-    [ ("surface", "lab")
-    ; ("section", "tools")
-    ; ("redirected_from", "none")
-    ]
-  in
+  let labels = [ "surface", "lab"; "section", "tools"; "redirected_from", "none" ] in
   let before =
     Prometheus.get_metric_value "dashboard_section_open_total" ~labels ()
     |> Option.value ~default:0.0
@@ -128,29 +150,42 @@ let test_record_section_counter_redirect_none_label () =
     |> Option.value ~default:0.0
   in
   check (float 1e-9) "incremented by 1 with 'none' label" 1.0 (after -. before)
+;;
 
 let () =
-  Alcotest.run "dashboard_nav_event"
+  Alcotest.run
+    "dashboard_nav_event"
     [ ( "parse_event_json"
       , [ test_case "minimal surface only" `Quick test_parse_minimal_surface_only
         ; test_case "full event" `Quick test_parse_full_event
         ; test_case "redirected_from accepted" `Quick test_parse_redirected
         ; test_case "rejects unknown surface" `Quick test_reject_unknown_surface
         ; test_case "rejects unknown section" `Quick test_reject_unknown_section
-        ; test_case "rejects redirected_from unknown surface" `Quick
+        ; test_case
+            "rejects redirected_from unknown surface"
+            `Quick
             test_reject_redirected_from_unknown_surface
-        ; test_case "rejects redirected_from = self" `Quick
+        ; test_case
+            "rejects redirected_from = self"
+            `Quick
             test_reject_redirected_from_self
         ; test_case "rejects missing surface" `Quick test_reject_missing_surface
         ; test_case "rejects malformed json" `Quick test_reject_malformed_json
         ; test_case "explicit null section" `Quick test_section_null_explicit
         ] )
     ; ( "record"
-      , [ test_case "increments surface counter" `Quick
+      , [ test_case
+            "increments surface counter"
+            `Quick
             test_record_increments_surface_counter
-        ; test_case "increments section counter with redirect label" `Quick
+        ; test_case
+            "increments section counter with redirect label"
+            `Quick
             test_record_increments_section_counter_with_redirect_label
-        ; test_case "section counter falls back to 'none' label" `Quick
+        ; test_case
+            "section counter falls back to 'none' label"
+            `Quick
             test_record_section_counter_redirect_none_label
         ] )
     ]
+;;


### PR DESCRIPTION
## Summary

PR #14245 was merged with `ocamlformat-check` failing because I missed `opam exec -- ocamlformat -i` on the three newly-added files. This follow-up applies the formatter so main becomes ocamlformat-compliant for those files.

## Files reformatted

- `lib/dashboard/dashboard_nav_event.ml`
- `lib/dashboard/dashboard_nav_event.mli`
- `test/test_dashboard_nav_event.ml`

ocamlformat 0.29.0 + `profile = janestreet` per `.ocamlformat`.

## Scope discipline — what this PR does *not* fix

`lib/server/server_routes_http_routes_dashboard.ml` also fails `ocamlformat --check` on main (1990+ unformatted lines), but it has been failing for many merged PRs before mine (#13904, #13874, #13850, #13864, …). Whole-file reformat belongs in a dedicated cleanup PR — bundling it here would be pure-noise diff and risk hidden semantic changes from the formatter on legacy code that no human has reviewed in this PR's context.

## Verification

```
$ ocamlformat --check lib/dashboard/dashboard_nav_event.ml
$ echo $?  # 0
$ ocamlformat --check lib/dashboard/dashboard_nav_event.mli
$ echo $?  # 0
$ ocamlformat --check test/test_dashboard_nav_event.ml
$ echo $?  # 0
```

No behavior change. No new code.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>