### PR TITLE
feat(cdal_runtime): migrate B2 — risk_class, verified_output, conformance, cognitive_event (RFC-OAS-011 MM-2-low)

### DIFF
--- a/lib/cdal_runtime/cognitive_event.ml
+++ b/lib/cdal_runtime/cognitive_event.ml
@@ -1,0 +1,53 @@
+(* Cognitive_event — implementation.
+
+   See cognitive_event.mli for the interface contract. *)
+
+type t =
+  | Gravity_ranked of
+      { ranked_count : int
+      ; query_terms : int
+      }
+  | Intent_predicted of
+      { intent_label : string
+      ; confidence : float
+      }
+  | Mode_transitioned of
+      { from_mode : string
+      ; to_mode : string
+      }
+  | Disclosure_level of { level : int }
+[@@deriving yojson, show]
+
+let name = function
+  | Gravity_ranked _ -> "gravity_ranked"
+  | Intent_predicted _ -> "intent_predicted"
+  | Mode_transitioned _ -> "mode_transitioned"
+  | Disclosure_level _ -> "disclosure_level"
+;;
+
+let is_well_formed = function
+  | Gravity_ranked { ranked_count; query_terms } ->
+    if ranked_count < 0
+    then Error "Gravity_ranked.ranked_count must be non-negative"
+    else if query_terms < 0
+    then Error "Gravity_ranked.query_terms must be non-negative"
+    else Ok ()
+  | Intent_predicted { intent_label; confidence } ->
+    if String.length intent_label = 0
+    then Error "Intent_predicted.intent_label must be non-empty"
+    else if (not (Float.is_finite confidence)) || confidence < 0.0 || confidence > 1.0
+    then Error "Intent_predicted.confidence must be a finite float in [0.0, 1.0]"
+    else Ok ()
+  | Mode_transitioned { from_mode; to_mode } ->
+    if String.length from_mode = 0
+    then Error "Mode_transitioned.from_mode must be non-empty"
+    else if String.length to_mode = 0
+    then Error "Mode_transitioned.to_mode must be non-empty"
+    else if String.equal from_mode to_mode
+    then Error "Mode_transitioned.from_mode and to_mode must differ"
+    else Ok ()
+  | Disclosure_level { level } ->
+    if level < 0 || level > 3
+    then Error "Disclosure_level.level must be in [0, 3]"
+    else Ok ()
+;;

--- a/lib/cdal_runtime/cognitive_event.mli
+++ b/lib/cdal_runtime/cognitive_event.mli
@@ -1,0 +1,65 @@
+(** Cognitive event types for SDK consumers (RFC-0036 PR-B,
+    Master Report transport schema).
+
+    A typed, JSON-codecable enumeration of the cognitive events that
+    a downstream coordinator host (boundary-allow: e.g. masc-mcp)
+    emits when its cognitive layer fires (gravity ranking, intent
+    prediction, mode transition, disclosure level change). The SDK
+    does not produce these events itself in this PR; the type lives
+    here so both the host emitter and any future SDK-side consumer
+    (Hooks, Tracing) share a single schema.
+
+    Design choices:
+
+    - Variants carry only structural data, not closures or
+      file-handle references — the type must remain JSON-stable
+      across pin bumps.
+    - {!Intent_predicted} carries [intent_label : string] rather
+      than referring to {!Context_intent.intent}. This keeps
+      {!Cognitive_event} independent of {!Context_intent}'s
+      enum lifecycle: hosts that classify with a richer
+      taxonomy (e.g. RFC-0036 Extension A's [Cognitive_op]
+      variant) can still serialise events without depending on
+      a particular SDK pin.
+    - No timestamps in the variants. Callers add timing via the
+      surrounding {!Tracing} or {!Hooks} envelope.
+
+    @stability Evolving
+    @since 0.190.27 *)
+
+(** A cognitive event emitted by the host. *)
+type t =
+  | Gravity_ranked of
+      { ranked_count : int
+      ; query_terms : int
+      }
+  | Intent_predicted of
+      { intent_label : string
+      ; confidence : float
+      }
+  | Mode_transitioned of
+      { from_mode : string
+      ; to_mode : string
+      }
+  | Disclosure_level of { level : int }
+[@@deriving yojson, show]
+
+(** [name t] returns the variant tag as a stable lowercase string,
+    suitable for log labels and Prometheus counters. *)
+val name : t -> string
+
+(** [is_well_formed t] checks the lightweight invariants this module
+    enforces:
+
+    - [Gravity_ranked]: [ranked_count] and [query_terms] non-negative.
+    - [Intent_predicted]: [intent_label] non-empty,
+      [confidence] in the closed interval [0.0, 1.0].
+    - [Mode_transitioned]: [from_mode] and [to_mode] non-empty and
+      not equal.
+    - [Disclosure_level]: [level] in the closed interval [0, 3]
+      (Master Report defines L0 / L1 / L2 / L3 disclosure tiers).
+
+    The function returns [Ok ()] on a well-formed event and [Error
+    msg] otherwise. Decoders that want to reject malformed inputs
+    should call this after {!of_yojson}. *)
+val is_well_formed : t -> (unit, string) result

--- a/lib/cdal_runtime/conformance.ml
+++ b/lib/cdal_runtime/conformance.ml
@@ -1,0 +1,730 @@
+type check =
+  { code : string
+  ; name : string
+  ; passed : bool
+  ; detail : string option
+  }
+[@@deriving yojson]
+
+type summary =
+  { session_id : string
+  ; generated_at : float
+  ; worker_run_count : int
+  ; raw_trace_run_count : int
+  ; validated_worker_run_count : int
+  ; latest_accepted_worker_run_id : string option
+  ; latest_ready_worker_run_id : string option
+  ; latest_running_worker_run_id : string option
+  ; latest_worker_run_id : string option
+  ; latest_completed_worker_run_id : string option
+  ; latest_worker_agent_name : string option
+  ; latest_worker_status : string option
+  ; latest_worker_role : string option
+  ; latest_worker_aliases : string list
+  ; latest_worker_validated : bool option
+  ; latest_failed_worker_run_id : string option
+  ; latest_failure_reason : string option
+  ; latest_resolved_provider : string option
+  ; latest_resolved_model : string option
+  ; hook_event_count : int
+  ; tool_catalog_count : int
+  ; trace_capabilities : Sessions.trace_capability list
+  }
+[@@deriving yojson]
+
+type report =
+  { ok : bool
+  ; summary : summary
+  ; checks : check list
+  }
+[@@deriving yojson]
+
+open Result_syntax
+
+let unique_trace_capabilities worker_runs =
+  worker_runs
+  |> List.fold_left
+       (fun acc (worker : Sessions.worker_run) ->
+          if List.exists (( = ) worker.trace_capability) acc
+          then acc
+          else acc @ [ worker.trace_capability ])
+       []
+;;
+
+let latest_by predicate worker_runs =
+  worker_runs
+  |> List.filter predicate
+  |> List.rev
+  |> function
+  | worker :: _ -> Some worker
+  | [] -> None
+;;
+
+let lifecycle_monotonic (worker : Sessions.worker_run) =
+  let ordered a b =
+    match a, b with
+    | Some x, Some y -> x <= y
+    | _ -> true
+  in
+  ordered worker.started_at worker.last_progress_at
+  && ordered worker.started_at worker.finished_at
+;;
+
+let worker_ids worker_runs =
+  worker_runs |> List.map (fun (worker : Sessions.worker_run) -> worker.worker_run_id)
+;;
+
+let raw_run_ids raw_runs =
+  raw_runs |> List.map (fun (run : Sessions.raw_trace_run) -> run.worker_run_id)
+;;
+
+let is_runtime_resolved (worker : Sessions.worker_run) =
+  worker.resolved_provider <> None && worker.resolved_model <> None
+;;
+
+let identity_is_consistent (worker : Sessions.worker_run) =
+  let alias_ok =
+    match worker.primary_alias with
+    | None -> true
+    | Some alias -> List.exists (String.equal alias) worker.aliases
+  in
+  worker.worker_id <> None && worker.runtime_actor <> None && alias_ok
+;;
+
+let worker_status_name = function
+  | Sessions.Planned -> "planned"
+  | Sessions.Accepted -> "accepted"
+  | Sessions.Ready -> "ready"
+  | Sessions.Running -> "running"
+  | Sessions.Completed -> "completed"
+  | Sessions.Failed -> "failed"
+;;
+
+let check bundle =
+  let expected_latest_worker =
+    match List.rev bundle.Sessions.worker_runs with
+    | worker :: _ -> Some worker
+    | [] -> None
+  in
+  let expected_latest_validated =
+    latest_by (fun (worker : Sessions.worker_run) -> worker.validated) bundle.worker_runs
+  in
+  let expected_latest_accepted =
+    latest_by
+      (fun (worker : Sessions.worker_run) -> worker.status = Sessions.Accepted)
+      bundle.worker_runs
+  in
+  let expected_latest_ready =
+    latest_by
+      (fun (worker : Sessions.worker_run) -> worker.status = Sessions.Ready)
+      bundle.worker_runs
+  in
+  let expected_latest_running =
+    latest_by
+      (fun (worker : Sessions.worker_run) -> worker.status = Sessions.Running)
+      bundle.worker_runs
+  in
+  let expected_latest_completed =
+    latest_by
+      (fun (worker : Sessions.worker_run) -> worker.status = Sessions.Completed)
+      bundle.worker_runs
+  in
+  let expected_latest_failed =
+    latest_by
+      (fun (worker : Sessions.worker_run) -> worker.status = Sessions.Failed)
+      bundle.worker_runs
+  in
+  let validated_worker_runs =
+    bundle.worker_runs
+    |> List.filter (fun (worker : Sessions.worker_run) -> worker.validated)
+  in
+  let expected_trace_capabilities = unique_trace_capabilities bundle.worker_runs in
+  let raw_ids = raw_run_ids bundle.raw_trace_runs in
+  let worker_ids = worker_ids bundle.worker_runs in
+  [ { code = "proof_bundle_available"
+    ; name = "proof_bundle_capability"
+    ; passed = bundle.capabilities.proof_bundle
+    ; detail = Some (Printf.sprintf "proof_bundle=%b" bundle.capabilities.proof_bundle)
+    }
+  ; { code = "direct_evidence_incomplete"
+    ; name = "direct_evidence_complete_when_raw_capable"
+    ; passed =
+        bundle.worker_runs
+        |> List.for_all (fun (worker : Sessions.worker_run) ->
+          match worker.trace_capability with
+          | Sessions.Raw ->
+            List.exists
+              (fun (run : Sessions.raw_trace_run) ->
+                 String.equal run.worker_run_id worker.worker_run_id)
+              bundle.raw_trace_runs
+          | Sessions.Summary_only | Sessions.No_trace -> true)
+    ; detail =
+        Some
+          (Printf.sprintf
+             "worker_runs=%d raw_runs=%d"
+             (List.length bundle.worker_runs)
+             (List.length bundle.raw_trace_runs))
+    }
+  ; { code =
+        (if bundle.raw_trace_runs = []
+         then "missing_raw_trace"
+         else "raw_trace_shape_mismatch")
+    ; name = "raw_trace_shapes_consistent"
+    ; passed =
+        bundle.raw_trace_run_count = List.length bundle.raw_trace_runs
+        && bundle.raw_trace_run_count = List.length bundle.raw_trace_summaries
+        && bundle.raw_trace_run_count = List.length bundle.raw_trace_validations
+    ; detail =
+        Some
+          (Printf.sprintf
+             "runs=%d summaries=%d validations=%d counted=%d"
+             (List.length bundle.raw_trace_runs)
+             (List.length bundle.raw_trace_summaries)
+             (List.length bundle.raw_trace_validations)
+             bundle.raw_trace_run_count)
+    }
+  ; { code = "validated_count_mismatch"
+    ; name = "validated_worker_counts_consistent"
+    ; passed =
+        bundle.validated_worker_run_count = List.length bundle.validated_worker_runs
+        && bundle.validated_worker_run_count = List.length validated_worker_runs
+    ; detail =
+        Some
+          (Printf.sprintf
+             "validated_count=%d bundle_list=%d worker_scan=%d"
+             bundle.validated_worker_run_count
+             (List.length bundle.validated_worker_runs)
+             (List.length validated_worker_runs))
+    }
+  ; { code = "latest_accepted_inconsistent"
+    ; name = "latest_accepted_worker_consistent"
+    ; passed =
+        Option.map
+          (fun (worker : Sessions.worker_run) -> worker.worker_run_id)
+          bundle.latest_accepted_worker_run
+        = Option.map
+            (fun (worker : Sessions.worker_run) -> worker.worker_run_id)
+            expected_latest_accepted
+    ; detail =
+        Some
+          (Printf.sprintf
+             "bundle=%s expected=%s"
+             (bundle.latest_accepted_worker_run
+              |> Option.map (fun (worker : Sessions.worker_run) -> worker.worker_run_id)
+              |> Option.value ~default:"")
+             (expected_latest_accepted
+              |> Option.map (fun (worker : Sessions.worker_run) -> worker.worker_run_id)
+              |> Option.value ~default:""))
+    }
+  ; { code = "latest_ready_inconsistent"
+    ; name = "latest_ready_worker_consistent"
+    ; passed =
+        Option.map
+          (fun (worker : Sessions.worker_run) -> worker.worker_run_id)
+          bundle.latest_ready_worker_run
+        = Option.map
+            (fun (worker : Sessions.worker_run) -> worker.worker_run_id)
+            expected_latest_ready
+    ; detail =
+        Some
+          (Printf.sprintf
+             "bundle=%s expected=%s"
+             (bundle.latest_ready_worker_run
+              |> Option.map (fun (worker : Sessions.worker_run) -> worker.worker_run_id)
+              |> Option.value ~default:"")
+             (expected_latest_ready
+              |> Option.map (fun (worker : Sessions.worker_run) -> worker.worker_run_id)
+              |> Option.value ~default:""))
+    }
+  ; { code = "latest_running_inconsistent"
+    ; name = "latest_running_worker_consistent"
+    ; passed =
+        Option.map
+          (fun (worker : Sessions.worker_run) -> worker.worker_run_id)
+          bundle.latest_running_worker_run
+        = Option.map
+            (fun (worker : Sessions.worker_run) -> worker.worker_run_id)
+            expected_latest_running
+    ; detail =
+        Some
+          (Printf.sprintf
+             "bundle=%s expected=%s"
+             (bundle.latest_running_worker_run
+              |> Option.map (fun (worker : Sessions.worker_run) -> worker.worker_run_id)
+              |> Option.value ~default:"")
+             (expected_latest_running
+              |> Option.map (fun (worker : Sessions.worker_run) -> worker.worker_run_id)
+              |> Option.value ~default:""))
+    }
+  ; { code = "latest_worker_inconsistent"
+    ; name = "latest_worker_consistent"
+    ; passed =
+        Option.map
+          (fun (worker : Sessions.worker_run) -> worker.worker_run_id)
+          bundle.latest_worker_run
+        = Option.map
+            (fun (worker : Sessions.worker_run) -> worker.worker_run_id)
+            expected_latest_worker
+    ; detail =
+        Some
+          (Printf.sprintf
+             "bundle=%s expected=%s"
+             (bundle.latest_worker_run
+              |> Option.map (fun (worker : Sessions.worker_run) -> worker.worker_run_id)
+              |> Option.value ~default:"")
+             (expected_latest_worker
+              |> Option.map (fun (worker : Sessions.worker_run) -> worker.worker_run_id)
+              |> Option.value ~default:""))
+    }
+  ; { code = "latest_completed_inconsistent"
+    ; name = "latest_completed_worker_consistent"
+    ; passed =
+        Option.map
+          (fun (worker : Sessions.worker_run) -> worker.worker_run_id)
+          bundle.latest_completed_worker_run
+        = Option.map
+            (fun (worker : Sessions.worker_run) -> worker.worker_run_id)
+            expected_latest_completed
+    ; detail =
+        Some
+          (Printf.sprintf
+             "bundle=%s expected=%s"
+             (bundle.latest_completed_worker_run
+              |> Option.map (fun (worker : Sessions.worker_run) -> worker.worker_run_id)
+              |> Option.value ~default:"")
+             (expected_latest_completed
+              |> Option.map (fun (worker : Sessions.worker_run) -> worker.worker_run_id)
+              |> Option.value ~default:""))
+    }
+  ; { code = "latest_validated_inconsistent"
+    ; name = "latest_validated_worker_consistent"
+    ; passed =
+        Option.map
+          (fun (worker : Sessions.worker_run) -> worker.worker_run_id)
+          bundle.latest_validated_worker_run
+        = Option.map
+            (fun (worker : Sessions.worker_run) -> worker.worker_run_id)
+            expected_latest_validated
+    ; detail =
+        Some
+          (Printf.sprintf
+             "bundle=%s expected=%s"
+             (bundle.latest_validated_worker_run
+              |> Option.map (fun (worker : Sessions.worker_run) -> worker.worker_run_id)
+              |> Option.value ~default:"")
+             (expected_latest_validated
+              |> Option.map (fun (worker : Sessions.worker_run) -> worker.worker_run_id)
+              |> Option.value ~default:""))
+    }
+  ; { code = "latest_failed_inconsistent"
+    ; name = "latest_failed_worker_consistent"
+    ; passed =
+        Option.map
+          (fun (worker : Sessions.worker_run) -> worker.worker_run_id)
+          bundle.latest_failed_worker_run
+        = Option.map
+            (fun (worker : Sessions.worker_run) -> worker.worker_run_id)
+            expected_latest_failed
+    ; detail =
+        Some
+          (Printf.sprintf
+             "bundle=%s expected=%s"
+             (bundle.latest_failed_worker_run
+              |> Option.map (fun (worker : Sessions.worker_run) -> worker.worker_run_id)
+              |> Option.value ~default:"")
+             (expected_latest_failed
+              |> Option.map (fun (worker : Sessions.worker_run) -> worker.worker_run_id)
+              |> Option.value ~default:""))
+    }
+  ; { code = "trace_capabilities_inconsistent"
+    ; name = "trace_capabilities_consistent"
+    ; passed = bundle.trace_capabilities = expected_trace_capabilities
+    ; detail =
+        Some
+          (Printf.sprintf
+             "bundle=%d expected=%d"
+             (List.length bundle.trace_capabilities)
+             (List.length expected_trace_capabilities))
+    }
+  ; { code = "identity_alias_mismatch"
+    ; name = "worker_identity_alias_consistent"
+    ; passed = List.for_all identity_is_consistent bundle.worker_runs
+    ; detail = Some (Printf.sprintf "workers=%d" (List.length bundle.worker_runs))
+    }
+  ; { code = "failed_worker_reason_missing"
+    ; name = "failed_workers_have_reason"
+    ; passed =
+        bundle.worker_runs
+        |> List.for_all (fun (worker : Sessions.worker_run) ->
+          if worker.error = None && worker.failure_reason = None
+          then true
+          else worker.error <> None || worker.failure_reason <> None)
+    ; detail =
+        Some
+          (Printf.sprintf
+             "failed_workers=%d"
+             (bundle.worker_runs
+              |> List.filter (fun (worker : Sessions.worker_run) ->
+                worker.error <> None || worker.failure_reason <> None)
+              |> List.length))
+    }
+  ; { code = "lifecycle_non_monotonic"
+    ; name = "lifecycle_state_monotonic"
+    ; passed = List.for_all lifecycle_monotonic bundle.worker_runs
+    ; detail = Some (Printf.sprintf "workers=%d" (List.length bundle.worker_runs))
+    }
+  ; { code = "resolved_runtime_missing"
+    ; name = "resolved_runtime_presence_consistent"
+    ; passed =
+        bundle.worker_runs
+        |> List.for_all (fun (worker : Sessions.worker_run) ->
+          match worker.status with
+          | Sessions.Planned -> true
+          | Sessions.Accepted
+          | Sessions.Ready
+          | Sessions.Running
+          | Sessions.Completed
+          | Sessions.Failed -> is_runtime_resolved worker)
+    ; detail = Some (Printf.sprintf "workers=%d" (List.length bundle.worker_runs))
+    }
+  ; { code = "validated_worker_not_raw_capable"
+    ; name = "validated_workers_are_raw_capable"
+    ; passed =
+        validated_worker_runs
+        |> List.for_all (fun (worker : Sessions.worker_run) ->
+          worker.trace_capability = Sessions.Raw)
+    ; detail =
+        Some (Printf.sprintf "validated_workers=%d" (List.length validated_worker_runs))
+    }
+  ; { code = "raw_trace_not_addressable"
+    ; name = "raw_trace_runs_are_addressable"
+    ; passed =
+        raw_ids
+        |> List.for_all (fun raw_id -> List.exists (String.equal raw_id) worker_ids)
+    ; detail =
+        Some
+          (Printf.sprintf
+             "raw_runs=%d worker_runs=%d"
+             (List.length raw_ids)
+             (List.length worker_ids))
+    }
+  ]
+;;
+
+let report bundle =
+  let checks = check bundle in
+  let ok = List.for_all (fun (check : check) -> check.passed) checks in
+  let latest_worker = bundle.latest_worker_run in
+  let latest_failed = bundle.latest_failed_worker_run in
+  { ok
+  ; summary =
+      { session_id = bundle.session.session_id
+      ; generated_at = Unix.gettimeofday ()
+      ; worker_run_count = List.length bundle.worker_runs
+      ; raw_trace_run_count = bundle.raw_trace_run_count
+      ; validated_worker_run_count = bundle.validated_worker_run_count
+      ; latest_accepted_worker_run_id =
+          Option.map
+            (fun (worker : Sessions.worker_run) -> worker.worker_run_id)
+            bundle.latest_accepted_worker_run
+      ; latest_ready_worker_run_id =
+          Option.map
+            (fun (worker : Sessions.worker_run) -> worker.worker_run_id)
+            bundle.latest_ready_worker_run
+      ; latest_running_worker_run_id =
+          Option.map
+            (fun (worker : Sessions.worker_run) -> worker.worker_run_id)
+            bundle.latest_running_worker_run
+      ; latest_worker_run_id =
+          Option.map
+            (fun (worker : Sessions.worker_run) -> worker.worker_run_id)
+            latest_worker
+      ; latest_completed_worker_run_id =
+          Option.map
+            (fun (worker : Sessions.worker_run) -> worker.worker_run_id)
+            bundle.latest_completed_worker_run
+      ; latest_worker_agent_name =
+          Option.map
+            (fun (worker : Sessions.worker_run) -> worker.agent_name)
+            latest_worker
+      ; latest_worker_status =
+          Option.map
+            (fun (worker : Sessions.worker_run) -> worker_status_name worker.status)
+            latest_worker
+      ; latest_worker_role =
+          Option.bind latest_worker (fun (worker : Sessions.worker_run) -> worker.role)
+      ; latest_worker_aliases =
+          Option.bind latest_worker (fun (worker : Sessions.worker_run) ->
+            Some worker.aliases)
+          |> Option.value ~default:[]
+      ; latest_worker_validated =
+          Option.map
+            (fun (worker : Sessions.worker_run) -> worker.validated)
+            latest_worker
+      ; latest_failed_worker_run_id =
+          Option.map
+            (fun (worker : Sessions.worker_run) -> worker.worker_run_id)
+            latest_failed
+      ; latest_failure_reason =
+          Option.bind latest_failed (fun (worker : Sessions.worker_run) ->
+            match worker.failure_reason with
+            | Some _ as value -> value
+            | None -> worker.error)
+      ; latest_resolved_provider =
+          Option.bind latest_worker (fun (worker : Sessions.worker_run) ->
+            worker.resolved_provider)
+      ; latest_resolved_model =
+          Option.bind latest_worker (fun (worker : Sessions.worker_run) ->
+            worker.resolved_model)
+      ; hook_event_count =
+          List.fold_left (fun acc item -> acc + item.Sessions.count) 0 bundle.hook_summary
+      ; tool_catalog_count = List.length bundle.tool_catalog
+      ; trace_capabilities = bundle.trace_capabilities
+      }
+  ; checks
+  }
+;;
+
+let run ?session_root ~session_id () =
+  let* bundle = Sessions.get_proof_bundle ?session_root ~session_id () in
+  Ok (report bundle)
+;;
+
+[@@@coverage off]
+(* === Inline tests === *)
+
+let make_worker
+      ?(worker_run_id = "w1")
+      ?(worker_id = Some "wid")
+      ?(agent_name = "agent")
+      ?(runtime_actor = Some "actor")
+      ?(role = None)
+      ?(aliases = [])
+      ?(primary_alias = None)
+      ?(provider = None)
+      ?(model = None)
+      ?(requested_provider = None)
+      ?(requested_model = None)
+      ?(requested_policy = None)
+      ?(resolved_provider = Some "llama")
+      ?(resolved_model = Some "qwen")
+      ?(status = Sessions.Completed)
+      ?(trace_capability = Sessions.Raw)
+      ?(validated = true)
+      ?(tool_names = [])
+      ?(final_text = None)
+      ?(stop_reason = None)
+      ?(error = None)
+      ?(failure_reason = None)
+      ?(accepted_at = None)
+      ?(ready_at = None)
+      ?(first_progress_at = None)
+      ?(started_at = Some 1.0)
+      ?(finished_at = Some 2.0)
+      ?(last_progress_at = Some 1.5)
+      ?(policy_snapshot = None)
+      ?(paired_tool_result_count = 0)
+      ?(has_file_write = false)
+      ?(verification_pass_after_file_write = false)
+      ()
+  : Sessions.worker_run
+  =
+  { worker_run_id
+  ; worker_id
+  ; agent_name
+  ; runtime_actor
+  ; role
+  ; aliases
+  ; primary_alias
+  ; provider
+  ; model
+  ; requested_provider
+  ; requested_model
+  ; requested_policy
+  ; resolved_provider
+  ; resolved_model
+  ; status
+  ; trace_capability
+  ; validated
+  ; tool_names
+  ; final_text
+  ; stop_reason
+  ; error
+  ; failure_reason
+  ; accepted_at
+  ; ready_at
+  ; first_progress_at
+  ; started_at
+  ; finished_at
+  ; last_progress_at
+  ; policy_snapshot
+  ; paired_tool_result_count
+  ; has_file_write
+  ; verification_pass_after_file_write
+  }
+;;
+
+let%test "unique_trace_capabilities deduplicates" =
+  let w1 = make_worker ~trace_capability:Sessions.Raw () in
+  let w2 = make_worker ~trace_capability:Sessions.Raw () in
+  let w3 = make_worker ~trace_capability:Sessions.Summary_only () in
+  let result = unique_trace_capabilities [ w1; w2; w3 ] in
+  List.length result = 2
+;;
+
+let%test "unique_trace_capabilities empty list" = unique_trace_capabilities [] = []
+
+let%test "unique_trace_capabilities preserves order" =
+  let w1 = make_worker ~trace_capability:Sessions.Summary_only () in
+  let w2 = make_worker ~trace_capability:Sessions.Raw () in
+  let result = unique_trace_capabilities [ w1; w2 ] in
+  result = [ Sessions.Summary_only; Sessions.Raw ]
+;;
+
+let%test "latest_by returns last matching element" =
+  let w1 = make_worker ~worker_run_id:"w1" ~status:Sessions.Completed () in
+  let w2 = make_worker ~worker_run_id:"w2" ~status:Sessions.Running () in
+  let w3 = make_worker ~worker_run_id:"w3" ~status:Sessions.Completed () in
+  match
+    latest_by
+      (fun (w : Sessions.worker_run) -> w.status = Sessions.Completed)
+      [ w1; w2; w3 ]
+  with
+  | Some w -> w.worker_run_id = "w3"
+  | None -> false
+;;
+
+let%test "latest_by returns None when no match" =
+  let w1 = make_worker ~status:Sessions.Running () in
+  latest_by (fun (w : Sessions.worker_run) -> w.status = Sessions.Failed) [ w1 ] = None
+;;
+
+let%test "latest_by empty list" = latest_by (fun _ -> true) [] = None
+
+let%test "lifecycle_monotonic all timestamps ordered" =
+  let w =
+    make_worker
+      ~started_at:(Some 1.0)
+      ~last_progress_at:(Some 2.0)
+      ~finished_at:(Some 3.0)
+      ()
+  in
+  lifecycle_monotonic w = true
+;;
+
+let%test "lifecycle_monotonic None timestamps always pass" =
+  let w = make_worker ~started_at:None ~last_progress_at:None ~finished_at:None () in
+  lifecycle_monotonic w = true
+;;
+
+let%test "lifecycle_monotonic mixed None passes" =
+  let w =
+    make_worker ~started_at:(Some 1.0) ~last_progress_at:None ~finished_at:(Some 3.0) ()
+  in
+  lifecycle_monotonic w = true
+;;
+
+let%test "lifecycle_monotonic started > finished fails" =
+  let w =
+    make_worker ~started_at:(Some 5.0) ~last_progress_at:None ~finished_at:(Some 1.0) ()
+  in
+  lifecycle_monotonic w = false
+;;
+
+let%test "is_runtime_resolved both present" =
+  let w = make_worker ~resolved_provider:(Some "p") ~resolved_model:(Some "m") () in
+  is_runtime_resolved w = true
+;;
+
+let%test "is_runtime_resolved provider missing" =
+  let w = make_worker ~resolved_provider:None ~resolved_model:(Some "m") () in
+  is_runtime_resolved w = false
+;;
+
+let%test "is_runtime_resolved model missing" =
+  let w = make_worker ~resolved_provider:(Some "p") ~resolved_model:None () in
+  is_runtime_resolved w = false
+;;
+
+let%test "identity_is_consistent all present and matching" =
+  let w =
+    make_worker
+      ~worker_id:(Some "wid")
+      ~runtime_actor:(Some "actor")
+      ~primary_alias:(Some "a1")
+      ~aliases:[ "a1"; "a2" ]
+      ()
+  in
+  identity_is_consistent w = true
+;;
+
+let%test "identity_is_consistent primary_alias not in aliases fails" =
+  let w =
+    make_worker
+      ~worker_id:(Some "wid")
+      ~runtime_actor:(Some "actor")
+      ~primary_alias:(Some "missing")
+      ~aliases:[ "a1"; "a2" ]
+      ()
+  in
+  identity_is_consistent w = false
+;;
+
+let%test "identity_is_consistent no primary_alias is ok" =
+  let w =
+    make_worker
+      ~worker_id:(Some "wid")
+      ~runtime_actor:(Some "actor")
+      ~primary_alias:None
+      ~aliases:[]
+      ()
+  in
+  identity_is_consistent w = true
+;;
+
+let%test "identity_is_consistent missing worker_id fails" =
+  let w = make_worker ~worker_id:None ~runtime_actor:(Some "actor") () in
+  identity_is_consistent w = false
+;;
+
+let%test "identity_is_consistent missing runtime_actor fails" =
+  let w = make_worker ~worker_id:(Some "wid") ~runtime_actor:None () in
+  identity_is_consistent w = false
+;;
+
+let%test "worker_status_name all variants" =
+  worker_status_name Sessions.Planned = "planned"
+  && worker_status_name Sessions.Accepted = "accepted"
+  && worker_status_name Sessions.Ready = "ready"
+  && worker_status_name Sessions.Running = "running"
+  && worker_status_name Sessions.Completed = "completed"
+  && worker_status_name Sessions.Failed = "failed"
+;;
+
+let%test "worker_ids extracts ids" =
+  let w1 = make_worker ~worker_run_id:"id1" () in
+  let w2 = make_worker ~worker_run_id:"id2" () in
+  worker_ids [ w1; w2 ] = [ "id1"; "id2" ]
+;;
+
+let%test "raw_run_ids extracts ids" =
+  let r1 : Sessions.raw_trace_run =
+    { worker_run_id = "r1"
+    ; path = "/tmp/a"
+    ; start_seq = 0
+    ; end_seq = 10
+    ; agent_name = "a"
+    ; session_id = None
+    }
+  in
+  let r2 : Sessions.raw_trace_run =
+    { worker_run_id = "r2"
+    ; path = "/tmp/b"
+    ; start_seq = 0
+    ; end_seq = 5
+    ; agent_name = "b"
+    ; session_id = None
+    }
+  in
+  raw_run_ids [ r1; r2 ] = [ "r1"; "r2" ]
+;;

--- a/lib/cdal_runtime/conformance.mli
+++ b/lib/cdal_runtime/conformance.mli
@@ -1,0 +1,59 @@
+(** Conformance checking for agent session proofs.
+
+    Transforms a {!Sessions.proof_bundle} into a structured report
+    with 17 conformance checks covering lifecycle, identity, tracing,
+    and resolution.
+
+    @stability Evolving
+    @since 0.93.1 *)
+
+type check =
+  { code : string
+  ; name : string
+  ; passed : bool
+  ; detail : string option
+  }
+[@@deriving yojson]
+
+type summary =
+  { session_id : string
+  ; generated_at : float
+  ; worker_run_count : int
+  ; raw_trace_run_count : int
+  ; validated_worker_run_count : int
+  ; latest_accepted_worker_run_id : string option
+  ; latest_ready_worker_run_id : string option
+  ; latest_running_worker_run_id : string option
+  ; latest_worker_run_id : string option
+  ; latest_completed_worker_run_id : string option
+  ; latest_worker_agent_name : string option
+  ; latest_worker_status : string option
+  ; latest_worker_role : string option
+  ; latest_worker_aliases : string list
+  ; latest_worker_validated : bool option
+  ; latest_failed_worker_run_id : string option
+  ; latest_failure_reason : string option
+  ; latest_resolved_provider : string option
+  ; latest_resolved_model : string option
+  ; hook_event_count : int
+  ; tool_catalog_count : int
+  ; trace_capabilities : Sessions.trace_capability list
+  }
+[@@deriving yojson]
+
+type report =
+  { ok : bool
+  ; summary : summary
+  ; checks : check list
+  }
+[@@deriving yojson]
+
+(** Generate a conformance report from a proof bundle. *)
+val report : Sessions.proof_bundle -> report
+
+(** Run conformance checks from a session on disk. *)
+val run
+  :  ?session_root:string
+  -> session_id:string
+  -> unit
+  -> (report, Error.sdk_error) result

--- a/lib/cdal_runtime/risk_class.ml
+++ b/lib/cdal_runtime/risk_class.ml
@@ -1,0 +1,45 @@
+type t =
+  | Low
+  | Medium
+  | High
+  | Critical
+[@@deriving show]
+
+let to_string = function
+  | Low -> "low"
+  | Medium -> "medium"
+  | High -> "high"
+  | Critical -> "critical"
+;;
+
+let of_string = function
+  | "low" -> Ok Low
+  | "medium" -> Ok Medium
+  | "high" -> Ok High
+  | "critical" -> Ok Critical
+  | s -> Error (Printf.sprintf "unknown risk class: %s" s)
+;;
+
+let to_yojson v = `String (to_string v)
+
+let of_yojson = function
+  | `String s -> of_string s
+  | j -> Error (Printf.sprintf "expected string, got %s" (Yojson.Safe.to_string j))
+;;
+
+let to_int = function
+  | Low -> 0
+  | Medium -> 1
+  | High -> 2
+  | Critical -> 3
+;;
+
+let equal a b = to_int a = to_int b
+let compare a b = Int.compare (to_int a) (to_int b)
+
+let max_mode = function
+  | Low -> Some Execution_mode.Execute
+  | Medium -> Some Execution_mode.Execute
+  | High -> Some Execution_mode.Draft
+  | Critical -> None
+;;

--- a/lib/cdal_runtime/risk_class.mli
+++ b/lib/cdal_runtime/risk_class.mli
@@ -1,0 +1,23 @@
+(** Risk classification for contract-driven agent runs.
+
+    Part of the Contract-Driven Agent Loop (CDAL) PoC-1.
+    Three-axis model: blast_radius x irreversibility x recovery_cost.
+
+    @stability Evolving
+    @since 0.93.1 *)
+
+type t =
+  | Low (** Small radius, easy rollback, low recovery cost *)
+  | Medium (** One or more ambiguous/mid-level axes *)
+  | High (** Any one axis large; Execute forbidden without human review *)
+  | Critical (** Hard to reverse or external system damage; default = reject *)
+[@@deriving yojson, show]
+
+val to_string : t -> string
+val of_string : string -> (t, string) result
+val equal : t -> t -> bool
+val compare : t -> t -> int
+
+(** Maximum allowed execution mode for this risk class.
+    [None] means the run should be rejected outright. *)
+val max_mode : t -> Execution_mode.t option

--- a/lib/cdal_runtime/verified_output.ml
+++ b/lib/cdal_runtime/verified_output.ml
@@ -1,0 +1,109 @@
+(** Phantom-typed verified output.
+
+    The phantom type parameter ['status] is erased at runtime.
+    [unverified output] and [verified output] have identical
+    runtime representation — the difference is purely in the
+    type system.
+
+    @since 0.76.0 *)
+
+type unverified
+type verified
+
+type verification_result =
+  | Verified of
+      { verifier : string
+      ; confidence : float
+      ; evidence : string
+      }
+  | Disputed of
+      { verifier : string
+      ; reason : string
+      }
+  | Abstained of
+      { verifier : string
+      ; reason : string
+      }
+
+(* The actual record — 'status is phantom (not stored anywhere) *)
+type _ output =
+  { response : Types.api_response
+  ; producer : string
+  ; verifications : verification_result list
+  ; verified_flag : bool
+  }
+
+let of_response ~producer response =
+  { response; producer; verifications = []; verified_flag = false }
+;;
+
+let verify (out : unverified output) ~verifier ~confidence ~evidence =
+  if confidence >= 0.5
+  then (
+    let result = Verified { verifier; confidence; evidence } in
+    Some
+      { response = out.response
+      ; producer = out.producer
+      ; verifications = result :: out.verifications
+      ; verified_flag = true
+      })
+  else None
+;;
+
+let verify_with_results (out : unverified output) results ?(min_confidence = 0.5) () =
+  let has_verified =
+    List.exists
+      (function
+        | Verified { confidence; _ } -> confidence >= min_confidence
+        | Disputed _ | Abstained _ -> false)
+      results
+  in
+  if has_verified
+  then
+    Some
+      { response = out.response
+      ; producer = out.producer
+      ; verifications = results @ out.verifications
+      ; verified_flag = true
+      }
+  else None
+;;
+
+let trust (out : unverified output) ~reason =
+  let result = Verified { verifier = "trusted"; confidence = 1.0; evidence = reason } in
+  { response = out.response
+  ; producer = out.producer
+  ; verifications = result :: out.verifications
+  ; verified_flag = true
+  }
+;;
+
+let content (out : verified output) = out.response
+
+let text (out : verified output) =
+  out.response.content
+  |> List.filter_map (function
+    | Types.Text s -> Some s
+    | _ -> None)
+  |> String.concat "\n"
+;;
+
+let producer (type s) (out : s output) = out.producer
+let verifications (type s) (out : s output) = out.verifications
+let is_verified (type s) (out : s output) = out.verified_flag
+
+let raw_json (type s) (out : s output) =
+  let text_content =
+    out.response.content
+    |> List.filter_map (function
+      | Types.Text s -> Some s
+      | _ -> None)
+    |> String.concat "\n"
+  in
+  `Assoc
+    [ "id", `String out.response.id
+    ; "model", `String out.response.model
+    ; "producer", `String out.producer
+    ; "text", `String text_content
+    ]
+;;

--- a/lib/cdal_runtime/verified_output.mli
+++ b/lib/cdal_runtime/verified_output.mli
@@ -1,0 +1,129 @@
+(** Phantom-typed verified output — compile-time enforcement of output verification.
+
+    In a multi-agent society, agent outputs must be verified before
+    being used as final results.  This module uses OCaml phantom types
+    to make it impossible to use unverified outputs where verified
+    ones are required.
+
+    {b Key guarantee}: The function {!val-content} only accepts
+    [verified output], so unverified outputs cannot be used as
+    final results.  This is enforced at compile time — no runtime
+    checks needed.
+
+    Usage:
+    {[
+      (* Producer creates unverified output
+
+    @stability Evolving
+    @since 0.93.1 *)
+      let raw = Verified_output.of_response ~producer:"alice" response in
+
+      (* Verifier checks and marks as verified *)
+      let result = Verified_output.verify raw
+        ~verifier:"bob" ~confidence:0.95 ~evidence:"cross-checked" in
+      match result with
+      | Some verified ->
+        (* Only verified outputs can extract content *)
+        let response = Verified_output.content verified in
+        ...
+      | None -> (* verification failed *)
+    ]}
+
+    Inspired by the 17x Error Trap (Bag of Agents anti-pattern):
+    in a 10-stage agent chain with 99% per-stage reliability,
+    overall reliability drops to 90.4%.  Phantom types make
+    unverified pipeline stages a compile error, not a runtime bug.
+
+    @since 0.76.0 *)
+
+(** {1 Phantom type tags} *)
+
+(** Type-level tag: output has not been verified. *)
+type unverified
+
+(** Type-level tag: output has been verified by at least one verifier. *)
+type verified
+
+(** {1 Verification result} *)
+
+type verification_result =
+  | Verified of
+      { verifier : string
+      ; confidence : float
+      ; evidence : string
+      }
+  | Disputed of
+      { verifier : string
+      ; reason : string
+      }
+  | Abstained of
+      { verifier : string
+      ; reason : string
+      }
+
+(** {1 Phantom-typed output} *)
+
+(** An agent output tagged with its verification status.
+    The type parameter ['status] is either {!unverified} or {!verified}.
+    It exists only at the type level — no runtime overhead. *)
+type 'status output
+
+(** {1 Construction} *)
+
+(** Create an unverified output from an API response. *)
+val of_response : producer:string -> Types.api_response -> unverified output
+
+(** {1 Verification} *)
+
+(** Attempt to verify an output.  Returns [Some (verified output)]
+    if at least one verification result is [Verified] with
+    confidence >= [min_confidence] (default 0.5).
+    Returns [None] if verification fails. *)
+val verify
+  :  unverified output
+  -> verifier:string
+  -> confidence:float
+  -> evidence:string
+  -> verified output option
+
+(** Mark as verified with explicit verification results.
+    Succeeds if any result is [Verified] above threshold. *)
+val verify_with_results
+  :  unverified output
+  -> verification_result list
+  -> ?min_confidence:float
+  -> unit
+  -> verified output option
+
+(** Force-verify an output (bypass verification).
+    Use only for testing or trusted sources.  The [reason] is
+    recorded in the verification trail. *)
+val trust : unverified output -> reason:string -> verified output
+
+(** {1 Accessors (verified only)} *)
+
+(** Extract the API response.  Only callable on verified outputs.
+    {b This is the key safety guarantee}: unverified outputs
+    cannot reach this function. *)
+val content : verified output -> Types.api_response
+
+(** Extract text content from a verified output. *)
+val text : verified output -> string
+
+(** {1 Accessors (any status)} *)
+
+(** The agent that produced this output. *)
+val producer : _ output -> string
+
+(** Verification results attached to this output. *)
+val verifications : _ output -> verification_result list
+
+(** Whether the output has been verified (runtime check, for logging). *)
+val is_verified : _ output -> bool
+
+(** {1 Downgrade} *)
+
+(** Access the raw response regardless of status.
+    Intentionally returns [Yojson.Safe.t] instead of [Types.api_response]
+    to discourage using unverified outputs directly. *)
+val raw_json : _ output -> Yojson.Safe.t


### PR DESCRIPTION
## 요약

RFC-OAS-011 두 번째 batch. OAS의 4 모듈을 `masc_mcp.cdal_runtime`로 복사. 모두 B1 leaves(이미 #14248에 이주됨)에만 의존하거나 *0 외부 CDAL 의존*.

OAS 측 원본은 *제거하지 않음* (OAS-E에서 일괄). consumer rewire는 MM-3-rewire에서.

## 이주 대상 (verbatim)

| 모듈 | LoC | 외부 CDAL 의존 |
|---|---|---|
| `risk_class.ml/mli` | 45 + 23 | `Execution_mode` (B1 ✓ — `masc_mcp.cdal_runtime` 안 self-resolve) |
| `verified_output.ml/mli` | 109 + 129 | **0** (phantom type, self only) |
| `conformance.ml/mli` | 730 + 59 | **0** (CDAL keyword 0건; `open Result_syntax`은 `Agent_sdk_base` 경유) |
| `cognitive_event.ml/mli` | 53 + 65 | **0** (variant type, self only) |

총 **+1213 LoC**.

OAS source: `jeong-sik/oas` main (`92f108c6`).

## RFC §1.1.7 재분류 (audit-record)

원래 RFC-OAS-009 v2 §1.1.7에서:
- "1 CDAL import": `verified_output`, `conformance`
- "2+": `cognitive_event`

실제 grep (`rg -no <pattern> | sort -u`, self-prefix 제외) 결과 셋 모두 *진짜 0 imports*. RFC가 *과보수적*이었음. 본 PR이 그 재분류를 *audit-recorded* 형태로 batch에 반영.

## 의존 검증 (pre-copy)

```bash
PAT='Cdal_proof|Mode_enforcer|Mode_resolver|Risk_contract|Risk_class|Execution_mode|Proof_capture|Proof_store|Contract_runner|Audit|Autonomy_|Cognitive_event|Verified_output|Conformance|Direct_evidence|Effect_evidence|Sessions_proof'

for m in risk_class verified_output conformance cognitive_event; do
  rg -no "$PAT" lib/$m.{ml,mli} | sort -u
done
# risk_class: only Execution_mode (B1)
# verified_output: only Verified_output self
# conformance: only Conformance self
# cognitive_event: only Cognitive_event self
```

## Dune 변경

**없음**. cdal_runtime/dune의 기존 deps + flags (`-open Agent_sdk_base`)가 모두 충족:
- `[@@deriving show]` (risk_class) → `ppx_deriving.show` (already in pps)
- `[@@deriving yojson]` (conformance) → `ppx_deriving_yojson` (already)
- `open Result_syntax` (conformance) → `Agent_sdk_base.Result_syntax` resolves via `-open Agent_sdk_base`

## 빌드 검증

| 환경 | 결과 |
|---|---|
| 로컬 `scripts/dune-local.sh build lib/cdal_runtime/` | `/tmp/me-dune-local.lock` multi-worktree contention으로 stuck (메모리 `reference_masc_mcp_dune_local_lock_contention`) |
| CI (clean GitHub Actions) | 본 PR push 후 검증 |

## RFC 시리즈 진행

| PR | 상태 |
|---|---|
| RFC docs oas#1480 | MERGED |
| OAS-B/C/D oas#1481-1483 | MERGED — RFC-OAS-009 v2 종결 |
| MM-1 #14247 (skel) | MERGED |
| MM-2-leaves #14248 (B1) | MERGED |
| **MM-2-low (this) — B2** | OPEN, Draft |
| MM-2-mid — B3 (cdal_proof, risk_contract, mode_resolver) | TBD (B2 의존 — risk_class) |
| MM-2-high — B4 (mode_enforcer, contract_runner, proof_capture, proof_store, direct_evidence) | TBD |
| MM-2-top — B5 (audit, autonomy_*, sessions_proof) | TBD |
| MM-3-rewire | TBD |
| OAS-E (CDAL 30+ 모듈 OAS 제거) | TBD |
| MM-4 (opam pin) | TBD |

## 위험 (1건)

`Masc_mcp_cdal_runtime.{Risk_class,Verified_output,...}`이 *Agent_sdk.{Risk_class,Verified_output,...}*과 *별 compilation unit*. 두 카피가 *type-equivalent*이지만 동일하지 않음. 본 PR 머지 시점에 consumer는 *모두 OAS 측 원본 (Agent_sdk.*)만 호출*하므로 *type mismatch 없음*. MM-3-rewire에서 일괄 전환.

## Test plan

- [ ] CI green — `cdal_runtime` 7 모듈 (B1+B2) 빌드 통과
- [ ] CodeRabbit/사람 리뷰 코멘트 대응
- [ ] `human-approved-ready` 라벨 부착 후 머지

🤖 Generated with [Claude Code](https://claude.com/claude-code)