### PR TITLE
feat(cdal_runtime): migrate B3 — cdal_proof, risk_contract (RFC-OAS-011 MM-2-mid)

### DIFF
--- a/lib/cdal_runtime/cdal_proof.ml
+++ b/lib/cdal_runtime/cdal_proof.ml
@@ -1,0 +1,73 @@
+type result_status =
+  | Completed
+  | Errored
+  | Timed_out
+  | Cancelled
+  | Context_overflow
+[@@deriving show]
+
+let result_status_to_string = function
+  | Completed -> "completed"
+  | Errored -> "errored"
+  | Timed_out -> "timed_out"
+  | Cancelled -> "cancelled"
+  | Context_overflow -> "context_overflow"
+;;
+
+let result_status_of_string = function
+  | "completed" -> Ok Completed
+  | "errored" -> Ok Errored
+  | "timed_out" -> Ok Timed_out
+  | "cancelled" -> Ok Cancelled
+  | "context_overflow" -> Ok Context_overflow
+  | s -> Error (Printf.sprintf "unknown result status: %s" s)
+;;
+
+let result_status_to_yojson v = `String (result_status_to_string v)
+
+let result_status_of_yojson = function
+  | `String s -> result_status_of_string s
+  | j -> Error (Printf.sprintf "expected string, got %s" (Yojson.Safe.to_string j))
+;;
+
+type provider_snapshot =
+  { provider_name : string
+  ; model_id : string
+  ; api_version : string option
+  }
+[@@deriving yojson, show]
+
+type capability_snapshot =
+  { tools : string list
+  ; mcp_servers : string list
+  ; max_turns : int
+  ; max_tokens : int option
+  ; thinking_enabled : bool option
+  }
+[@@deriving yojson, show]
+
+type artifact_ref = string [@@deriving yojson, show]
+
+type t =
+  { schema_version : int
+  ; run_id : string
+  ; contract_id : string
+  ; requested_execution_mode : Execution_mode.t
+  ; effective_execution_mode : Execution_mode.t
+  ; mode_decision_source : string
+  ; risk_class : Risk_class.t
+  ; provider_snapshot : provider_snapshot
+  ; capability_snapshot : capability_snapshot
+  ; tool_trace_refs : artifact_ref list
+  ; raw_evidence_refs : artifact_ref list
+  ; checkpoint_ref : artifact_ref option
+  ; result_status : result_status
+  ; started_at : float
+  ; ended_at : float
+  ; scope : string option [@yojson.default None]
+  }
+[@@deriving yojson, show]
+
+let schema_version_current = 1
+let to_json = to_yojson
+let of_json = of_yojson

--- a/lib/cdal_runtime/cdal_proof.mli
+++ b/lib/cdal_runtime/cdal_proof.mli
@@ -1,0 +1,64 @@
+(** CDAL proof bundle -- 15-field contract-driven execution evidence.
+
+    Part of the Contract-Driven Agent Loop (CDAL) PoC-1.
+
+    Distinct from {!Sessions_types.proof_bundle} which is a 25+ field
+    internal conformance structure. This type is the cross-repo evidence
+    manifest consumed by downstream coordinators.
+
+    Agent code is NOT proof-aware. Proof capture is performed
+    entirely by middleware hooking into the agent lifecycle.
+
+    @stability Evolving
+    @since 0.93.1 *)
+
+type result_status =
+  | Completed (** Agent reached EndTurn *)
+  | Errored (** Hook crash, verifier crash, unexpected runtime failure *)
+  | Timed_out (** max_turns exceeded or wall-clock timeout *)
+  | Cancelled (** Hook/policy gate intentionally blocked continuation *)
+  | Context_overflow (** Provider rejected request due to context window exhaustion *)
+[@@deriving yojson, show]
+
+type provider_snapshot =
+  { provider_name : string
+  ; model_id : string
+  ; api_version : string option
+  }
+[@@deriving yojson, show]
+
+type capability_snapshot =
+  { tools : string list
+  ; mcp_servers : string list
+  ; max_turns : int
+  ; max_tokens : int option
+  ; thinking_enabled : bool option
+  }
+[@@deriving yojson, show]
+
+(** Artifact reference. Format: ["proof-store://{run_id}/..."]. *)
+type artifact_ref = string [@@deriving yojson, show]
+
+type t =
+  { schema_version : int
+  ; run_id : string
+  ; contract_id : string
+  ; requested_execution_mode : Execution_mode.t
+  ; effective_execution_mode : Execution_mode.t
+  ; mode_decision_source : string
+  ; risk_class : Risk_class.t
+  ; provider_snapshot : provider_snapshot
+  ; capability_snapshot : capability_snapshot
+  ; tool_trace_refs : artifact_ref list
+  ; raw_evidence_refs : artifact_ref list
+  ; checkpoint_ref : artifact_ref option
+  ; result_status : result_status
+  ; started_at : float
+  ; ended_at : float
+  ; scope : string option
+  }
+[@@deriving yojson, show]
+
+val to_json : t -> Yojson.Safe.t
+val of_json : Yojson.Safe.t -> (t, string) result
+val schema_version_current : int

--- a/lib/cdal_runtime/risk_contract.ml
+++ b/lib/cdal_runtime/risk_contract.ml
@@ -1,0 +1,25 @@
+type runtime_constraints =
+  { requested_execution_mode : Execution_mode.t
+  ; risk_class : Risk_class.t
+  ; allowed_mutations : string list
+  ; review_requirement : string option
+  }
+[@@deriving yojson, show]
+
+type eval_criteria = Yojson.Safe.t [@@deriving yojson, show]
+
+type t =
+  { runtime_constraints : runtime_constraints
+  ; eval_criteria : eval_criteria
+  }
+[@@deriving yojson, show]
+
+let canonical_json contract =
+  contract |> to_yojson |> Yojson.Safe.sort |> Yojson.Safe.to_string
+;;
+
+let contract_id contract =
+  let canonical = canonical_json contract in
+  let hash = Digest.string canonical |> Digest.to_hex in
+  "md5:" ^ hash
+;;

--- a/lib/cdal_runtime/risk_contract.mli
+++ b/lib/cdal_runtime/risk_contract.mli
@@ -1,0 +1,35 @@
+(** Risk contract for contract-driven agent runs.
+
+    Part of the Contract-Driven Agent Loop (CDAL) PoC-1.
+
+    A risk contract has two surfaces:
+    - [runtime_constraints]: enforced by OAS at execution time
+    - [eval_criteria]: opaque passthrough carried to the proof bundle
+
+    @stability Evolving
+    @since 0.93.1 *)
+
+(** Runtime constraints enforced by OAS. *)
+type runtime_constraints =
+  { requested_execution_mode : Execution_mode.t
+  ; risk_class : Risk_class.t
+  ; allowed_mutations : string list
+  ; review_requirement : string option
+  }
+[@@deriving yojson, show]
+
+(** Eval criteria -- opaque to OAS, consumed by downstream coordinators post-eval. *)
+type eval_criteria = Yojson.Safe.t [@@deriving yojson, show]
+
+type t =
+  { runtime_constraints : runtime_constraints
+  ; eval_criteria : eval_criteria
+  }
+[@@deriving yojson, show]
+
+(** Content-addressed hash of the canonical JSON representation.
+    Format: ["md5:{hex}"] for PoC, upgradeable to ["sha256:{hex}"]. *)
+val contract_id : t -> string
+
+(** Canonical JSON string (sorted keys, compact) for external verification. *)
+val canonical_json : t -> string


### PR DESCRIPTION
## 요약

RFC-OAS-011 세 번째 batch. OAS의 2 mid-deps 모듈을 `masc_mcp.cdal_runtime`로 복사. 둘 다 B1 (Execution_mode) + B2 (Risk_class)에만 의존 — 이미 cdal_runtime 안에 있음.

## 이주 대상 (verbatim)

| 모듈 | LoC | 외부 CDAL 의존 |
|---|---|---|
| `cdal_proof.ml/mli` | 73 + 64 | Execution_mode (B1 ✓), Risk_class (B2 ✓) |
| `risk_contract.ml/mli` | 25 + 35 | Execution_mode (B1 ✓), Risk_class (B2 ✓) |

총 **+197 LoC**.

OAS source: `jeong-sik/oas` main (`92f108c6`).

## 의존 검증 (pre-copy)

```bash
$ rg -no '\b(Cdal_proof|Mode_enforcer|...|Sessions_proof)\b' \
     lib/{cdal_proof,risk_contract}.{ml,mli} | sort -u

# cdal_proof.ml:55:Execution_mode
# cdal_proof.ml:56:Execution_mode
# cdal_proof.ml:58:Risk_class
# cdal_proof.mli:46:Execution_mode
# cdal_proof.mli:47:Execution_mode
# cdal_proof.mli:49:Risk_class
# risk_contract.ml:2:Execution_mode
# risk_contract.ml:3:Risk_class
# risk_contract.mli:14:Execution_mode
# risk_contract.mli:15:Risk_class
```

오직 B1+B2 모듈에만 의존 → masc_mcp.cdal_runtime 안에서 self-resolve.

## Capability_snapshot 시그니처 (스코프 외)

`cdal_proof.t`의 `capability_snapshot` 필드는 현재 `tools : string list` — RFC-OAS-012가 이것을 `(string * Mode_enforcer.tool_effect_class) list`로 evolve + `Cdal_proof.schema_version` bump 예정. 본 PR은 *위치 이동만*.

## Consumer rewire (스코프 외)

masc-mcp 본체의 기존 consumer는 *그대로*:
- `cdal_loader.mli:8` `proof : Agent_sdk.Cdal_proof.t`
- `cdal_loader.mli:9` `contract : Agent_sdk.Risk_contract.t`
- `cdal_eval_v1.mli`, `cdal_judge.mli`, `cdal_friction_projection.mli`, `cdal_verdict_gate.mli`
- `oas_worker_exec.mli`, `oas_worker.mli`, `worker_oas.ml`, `worker_runtime_helper_protocol.ml`, `proof_artifact_reader.mli`
- `masc_contract_catalog.ml`, `violation_record.ml/mli`, `cdal_loader.ml`

이 모든 호출처는 *MM-3-rewire*에서 `Agent_sdk.X` → `Masc_mcp_cdal_runtime.X`로 *일괄* 전환. 그 전까지는 두 카피가 *type-equivalent이지만 별 compilation unit*으로 공존 — consumer 영향 0.

## RFC 시리즈 진행

| PR | 상태 |
|---|---|
| RFC docs oas#1480, OAS-B/C/D oas#1481-1483 | MERGED — RFC-OAS-009 v2 종결 |
| MM-1 #14247 (skel) | MERGED |
| MM-2-leaves #14248 (B1) | MERGED |
| MM-2-low #14253 (B2) | MERGED |
| **MM-2-mid (this) — B3** | OPEN, Draft |
| MM-2-high — B4 (mode_enforcer, mode_resolver, contract_runner, proof_capture, proof_store, direct_evidence) | TBD (B3 의존 — cdal_proof, risk_contract) |
| MM-2-top — B5 (audit, autonomy_*, sessions_proof) | TBD |
| MM-3-rewire (모든 consumer를 cdal_runtime으로) | TBD |
| OAS-E (CDAL 30+ 모듈 OAS 제거, agent_sdk 0.193.0) | TBD |
| MM-4 (opam pin → 0.193.0) | TBD |

## 위험 (1건)

`Agent_sdk.Cdal_proof.t`의 `capability_snapshot.tools : string list`가 *runtime wire format*. 본 PR이 *동일 type을 다른 위치에 복제*하므로 *둘 다 같은 wire JSON*을 만듬. 머지 후에도 `cdal_loader`가 `Agent_sdk.Cdal_proof.of_json`으로 디스크 manifest를 parse하면 OAS pin이 0.192라 그대로 작동. MM-3-rewire 시점에 의존을 `Masc_mcp_cdal_runtime.Cdal_proof.of_json`으로 전환하더라도 *JSON wire format이 동일*하므로 backward-compatible.

## Test plan

- [ ] CI green — `cdal_runtime` 9 모듈 (B1+B2+B3) 빌드 통과
- [ ] CodeRabbit/사람 리뷰 코멘트 대응
- [ ] `human-approved-ready` 라벨 부착 후 머지

🤖 Generated with [Claude Code](https://claude.com/claude-code)