### PR TITLE
fix(cdal_runtime): unblock main — add include_subdirs no + open Agent_sdk

### DIFF
--- a/lib/cdal_runtime/dune
+++ b/lib/cdal_runtime/dune
@@ -19,17 +19,31 @@
 ; @rfc RFC-OAS-011 (CDAL Migration to masc-mcp)
 ; @phase MM-2-leaves — B1 batch (execution_mode, effect_evidence, guardrail_llm)
 
+; The parent [lib/dune] uses [(include_subdirs unqualified)] which would
+; otherwise absorb every .ml under lib/ into the main [masc_mcp] library
+; and forbid declaring our own [(library)] stanza.  Marking this directory
+; with [(include_subdirs no)] opts out of the parent's traversal so this
+; sub-library compiles as a separate unit, mirroring sibling sub-libs
+; (lib/activity_graph, lib/embedded_config, lib/mcp_session, ...).
+(include_subdirs no)
+
 (library
  (name masc_mcp_cdal_runtime)
  (public_name masc_mcp.cdal_runtime)
  (libraries
   agent_sdk.base
+  ; agent_sdk (full) is needed for Guardrails_async, referenced from
+  ; guardrail_llm.{ml,mli}.  The dune-package places guardrails_async
+  ; in the wrapped [agent_sdk] library, not under agent_sdk.base.
+  agent_sdk
   yojson
   ppx_deriving_yojson.runtime)
  ; Mirror agent_sdk's flag so migrated modules' `open Types` /
  ; `open Result_syntax` resolve against Agent_sdk_base, matching their
- ; original OAS compilation context.
+ ; original OAS compilation context.  Also open the wrapped [Agent_sdk]
+ ; namespace so unqualified references such as [Guardrails_async] in
+ ; [guardrail_llm.{ml,mli}] resolve to [Agent_sdk.Guardrails_async].
  (flags
-  (:standard -open Agent_sdk_base))
+  (:standard -open Agent_sdk_base -open Agent_sdk))
  (preprocess
   (pps ppx_deriving_yojson ppx_deriving.show ppx_inline_test ppx_let)))


### PR DESCRIPTION
## Problem

PR #14247 (\`feat(cdal_runtime): empty sublibrary skeleton (RFC-OAS-011 MM-1)\`) was admin-merged with a dune stanza error that fails every \`dune build\` on main:

\`\`\`
File "lib/cdal_runtime/dune", lines 22-30, characters 0-229:
Error: This stanza is not allowed in a sub-directory of directory with
(include_subdirs unqualified).
Hint: add (include_subdirs no) to this file.
\`\`\`

\`lib/dune\` declares \`(include_subdirs unqualified)\`, which absorbs every \`.ml\` under \`lib/**\` into the main \`masc_mcp\` library and forbids nested \`(library)\` stanzas. PR #14247's new sub-library missed the standard escape hatch.

After fixing (1), a second blocker surfaces — \`guardrail_llm.{ml,mli}\` reference \`Guardrails_async\` which lives in \`Agent_sdk\` proper, not the listed \`agent_sdk.base\` dependency.

## Changes (single file: \`lib/cdal_runtime/dune\`)

| Fix | Why |
|-----|-----|
| Add \`(include_subdirs no)\` before the \`(library)\` stanza | Mirrors sibling sub-libs (\`lib/activity_graph\`, \`lib/embedded_config\`, \`lib/mcp_session\`, \`lib/board_types\`, …) which all open with this directive for the same reason. |
| Add \`agent_sdk\` to \`(libraries …)\` and \`-open Agent_sdk\` to \`(flags …)\` | \`Guardrails_async\` lives in the wrapped \`Agent_sdk\` namespace per \`opam/.../agent_sdk/dune-package\` (not in \`agent_sdk.base\`, which only exposes the sync \`Guardrails\`). |

Diffstat: \`+16 / -2\`.

## Note on architectural intent

The dune file's preamble states "Dependencies are intentionally minimal: only OAS's *core* (\`agent_sdk.base\` for Tool/Hooks/Types) plus Yojson". This PR adds a second OAS dependency (\`agent_sdk\` full) to make the merged code build. RFC-OAS-011 owners can later choose to:

- (a) move \`Guardrails_async\` down into \`agent_sdk.base\` in the upstream pin, or
- (b) qualify the references in \`guardrail_llm.{ml,mli}\` as \`Agent_sdk.Guardrails_async\` and drop the \`-open Agent_sdk\` flag.

This PR picks the smallest main-unblocking change and defers that scope decision. No source files outside \`lib/cdal_runtime/dune\` are touched.

## Verification

\`\`\`
dune build --root . @check                              # clean (was failing on main)
dune exec test/test_keeper_health_probe.exe             # 3/3 pass (regression check from PR #14246 still green)
\`\`\`

Dune files are not OCaml source, so the \`ocamlformat-check\` workflow does not apply.

## Test plan

- [ ] CI \`Build and Test\` should pass on this PR (currently fails on main).
- [ ] Existing \`lib/cdal_runtime/\` modules (\`effect_evidence\`, \`execution_mode\`, \`guardrail_llm\`) compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)