### PR TITLE
feat(exec): wire Shell_ir_typed GADT dispatch into exec_gate (RFC-0005 Week 3)

### DIFF
--- a/lib/exec/exec_gate.ml
+++ b/lib/exec/exec_gate.ml
@@ -149,9 +149,16 @@ let verdict_for_argv ~actor ~raw_source ~summary ~argv ?env ?cwd () =
   | Error `Parse_failed ->
     Error (`Denied Verdict.Parse_failed)
   | Ok simple ->
-    let caps = Capability_check.of_simple simple in
     let overlay = Approval_config.lookup rollout_config ~actor:(Agent_id.of_string actor) in
     let policy : Approval_policy.t = { raw_source; summary } in
+    let typed = Shell_ir_typed.of_simple simple in
+    let caps =
+      match typed with
+      | Shell_ir_typed.W (Shell_ir_typed.Generic _) ->
+        Capability_check.of_simple simple
+      | _ ->
+        Capability_check_typed.of_command typed
+    in
     let verdict = Approval_policy.decide policy ~overlay ~caps ~simple in
     Ok verdict
 

--- a/lib/exec/test/test_exec_gate_runtime.ml
+++ b/lib/exec/test/test_exec_gate_runtime.ml
@@ -83,9 +83,56 @@ let test_enforced_internal_stdin_allows () =
     assert (status = Unix.WEXITED 0);
     assert (String_util.contains_substring out "hello"))
 
+let test_typed_safe_enforced_blocks () =
+  with_env "MASC_EXEC_GATE" (Some "enforced") (fun () ->
+    let status, out =
+      Exec_gate.run_argv_with_status
+        ~actor:"unknown/strict"
+        ~raw_source:"ls"
+        ~summary:"typed ls"
+        ~timeout_sec:(Env_config_exec_timeout.timeout_sec ~caller:Test ())
+        [ "ls" ]
+    in
+    assert (status = Unix.WEXITED 126);
+    assert (String_util.contains_substring out "ask_required"))
+
+let test_typed_audited_internal_allows () =
+  with_env "MASC_EXEC_GATE" (Some "enforced") (fun () ->
+    let status, out =
+      Exec_gate.run_argv_with_status
+        ~actor:"coord/git"
+        ~raw_source:"git status"
+        ~summary:"typed git status"
+        ~timeout_sec:(Env_config_exec_timeout.timeout_sec ~caller:Test ())
+        [ "git"; "status" ]
+    in
+    assert (status <> Unix.WEXITED 126))
+
+let test_typed_safe_parallel_records_shadow_and_executes () =
+  with_tap_capture (fun captured ->
+    with_env "MASC_EXEC_GATE" (Some "parallel") (fun () ->
+      let out =
+        Exec_gate.run_argv
+          ~actor:"unknown/strict"
+          ~raw_source:"ls"
+          ~summary:"typed ls"
+          ~timeout_sec:(Env_config_exec_timeout.timeout_sec ~caller:Test ())
+          [ "ls" ]
+      in
+      assert (String.trim out <> "");
+      match find_gate_line !captured with
+      | None -> assert false
+      | Some line ->
+        assert (String_util.contains_substring line "\"gate_mode\":\"parallel\"");
+        assert (String_util.contains_substring line "\"gate_verdict\":\"ask\"");
+        assert (String_util.contains_substring line "\"gate_enforced\":false")))
+
 let () =
   test_enforced_strict_safe_blocks ();
   test_parallel_records_shadow_and_executes ();
   test_enforced_internal_audited_allows ();
   test_enforced_internal_stdin_allows ();
+  test_typed_safe_enforced_blocks ();
+  test_typed_audited_internal_allows ();
+  test_typed_safe_parallel_records_shadow_and_executes ();
   print_endline "[test_exec_gate_runtime] all tests passed"

--- a/lib/exec/test/test_shell_ir_typed.ml
+++ b/lib/exec/test/test_shell_ir_typed.ml
@@ -89,14 +89,19 @@ let test_sudo_roundtrip () =
 let test_risk_levels () =
   let check simple expected =
     let w = Shell_ir_typed.of_simple simple in
-    assert (Shell_ir_typed.risk w = expected)
+    let actual = Shell_ir_typed.risk w in
+    if actual <> expected then
+      (Printf.printf "risk mismatch: expected %s, got %s\n"
+         (match expected with `Safe -> "Safe" | `Audited -> "Audited" | `Privileged -> "Privileged")
+         (match actual with `Safe -> "Safe" | `Audited -> "Audited" | `Privileged -> "Privileged");
+       assert false)
   in
   check (simple (bin_ok "ls")) `Safe;
-  check (simple (bin_ok "cat")) `Safe;
-  check (simple (bin_ok "rg")) `Safe;
+  check (simple ~args:[lit "/etc/passwd"] (bin_ok "cat")) `Safe;
+  check (simple ~args:[lit "foo"] (bin_ok "rg")) `Safe;
   check (simple ~args:[lit "status"] (bin_ok "git")) `Audited;
   check (simple ~args:[lit "clone"; lit "x"] (bin_ok "git")) `Audited;
-  check (simple (bin_ok "curl")) `Audited;
+  check (simple ~args:[lit "https://example.com"] (bin_ok "curl")) `Audited;
   check (simple (bin_ok "rm")) `Privileged;
   check (simple (bin_ok "sudo")) `Privileged
 
@@ -106,11 +111,11 @@ let test_sandbox_levels () =
     assert (Shell_ir_typed.sandbox w = expected)
   in
   check (simple (bin_ok "ls")) `Host;
-  check (simple (bin_ok "cat")) `Host;
-  check (simple (bin_ok "rg")) `Host;
+  check (simple ~args:[lit "/etc/passwd"] (bin_ok "cat")) `Host;
+  check (simple ~args:[lit "foo"] (bin_ok "rg")) `Host;
   check (simple ~args:[lit "status"] (bin_ok "git")) `Host;
   check (simple ~args:[lit "clone"; lit "x"] (bin_ok "git")) `Docker;
-  check (simple (bin_ok "curl")) `Host;
+  check (simple ~args:[lit "https://example.com"] (bin_ok "curl")) `Host;
   check (simple (bin_ok "rm")) `Host;
   check (simple (bin_ok "sudo")) `Host
 


### PR DESCRIPTION
## Summary

RFC-0005 §Week 3 follow-up: integrate `Shell_ir_typed` GADT-based typed dispatch into `Exec_gate.verdict_for_argv`.

## Changes

- `lib/exec/exec_gate.ml`
  - `verdict_for_argv` now lifts `Shell_ir.simple` into `Shell_ir_typed.wrapped` before capability extraction.
  - `Generic` fallback preserves the existing untyped path (`Capability_check.of_simple`).
  - Typed constructors (e.g. `Ls`, `Git_status`, `Curl`, `Rm`) route to `Capability_check_typed.of_command` for total capability extraction.
- `lib/exec/test/test_exec_gate_runtime.ml`
  - Add 3 runtime gate tests:
    - `test_typed_safe_enforced_blocks`: `unknown/strict` + `ls` in enforced mode → blocked (exit 126).
    - `test_typed_audited_internal_allows`: `coord/git` + `git status` in enforced mode → allowed.
    - `test_typed_safe_parallel_records_shadow_and_executes`: `unknown/strict` + `ls` in parallel mode → executes + tap record.
- `lib/exec/test/test_shell_ir_typed.ml`
  - Fix `test_risk_levels` and `test_sandbox_levels` assertions: `cat`, `rg`, `curl` now use parseable argv shapes so they lift to typed constructors instead of falling back to `Generic`.

## RFC Reference

- `docs/rfc/RFC-0005-typed-capability-substrate.md`

## Test Plan

- [x] `dune runtest lib/exec/test` passes
- [x] `test_shell_ir_typed.exe` all tests passed
- [x] `test_exec_gate_runtime.exe` all tests passed

## Co-Authored-By

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>