### PR TITLE
feat(cdal_runtime): migrate B4 — mode_enforcer/resolver, contract_runner, proof_capture/store, direct_evidence (RFC-OAS-011 MM-2-high)

### DIFF
--- a/lib/cdal_runtime/contract_runner.ml
+++ b/lib/cdal_runtime/contract_runner.ml
@@ -1,0 +1,137 @@
+module Retry = Llm_provider.Retry
+
+type run_result =
+  { response : (Types.api_response, Error.sdk_error) result
+  ; proof : Cdal_proof.t
+  }
+
+let extract_capability_snapshot (agent : Agent.t) : Cdal_proof.capability_snapshot =
+  let tools = Agent.tools agent |> Tool_set.to_list in
+  let tool_names = List.map (fun (t : Tool.t) -> t.schema.name) tools in
+  let config = (Agent.state agent).config in
+  { tools = tool_names
+  ; mcp_servers = []
+  ; max_turns = config.max_turns
+  ; max_tokens = config.max_tokens
+  ; thinking_enabled = config.enable_thinking
+  }
+;;
+
+(** Detect context window exhaustion from provider error messages. *)
+let is_context_overflow_error (err : Error.sdk_error) : bool =
+  Retry.is_context_overflow_message (Error.to_string err)
+;;
+
+let map_result_status (response : (Types.api_response, Error.sdk_error) result)
+  : Cdal_proof.result_status
+  =
+  match response with
+  | Error err ->
+    if is_context_overflow_error err
+    then Cdal_proof.Context_overflow
+    else Cdal_proof.Errored
+  | Ok resp ->
+    (match resp.stop_reason with
+     | Types.EndTurn -> Cdal_proof.Completed
+     | Types.MaxTokens -> Cdal_proof.Completed
+     | Types.StopSequence -> Cdal_proof.Completed
+     | Types.StopToolUse -> Cdal_proof.Completed
+     | Types.Unknown _ -> Cdal_proof.Errored)
+;;
+
+let run
+      ~sw
+      ?clock
+      ?(store = Proof_store.default_config)
+      ~contract
+      (agent : Agent.t)
+      prompt
+  =
+  let capabilities = extract_capability_snapshot agent in
+  let requested = contract.Risk_contract.runtime_constraints.requested_execution_mode in
+  let risk_class = contract.Risk_contract.runtime_constraints.risk_class in
+  match Mode_resolver.resolve ~requested ~risk_class ~capabilities with
+  | Error reason ->
+    (* Critical risk or mode forbidden -- produce Cancelled proof *)
+    let now = Unix.gettimeofday () in
+    let proof : Cdal_proof.t =
+      { schema_version = Cdal_proof.schema_version_current
+      ; run_id =
+          Printf.sprintf
+            "cdal-rejected-%d-%06x"
+            (int_of_float (now *. 1000.0))
+            (Random.bits () land 0xFFFFFF)
+      ; contract_id = Risk_contract.contract_id contract
+      ; requested_execution_mode = requested
+      ; effective_execution_mode = Execution_mode.Diagnose
+      ; mode_decision_source = "rejected"
+      ; risk_class
+      ; provider_snapshot =
+          { provider_name = "none"; model_id = "none"; api_version = None }
+      ; capability_snapshot = capabilities
+      ; tool_trace_refs = []
+      ; raw_evidence_refs = []
+      ; checkpoint_ref = None
+      ; result_status = Cancelled
+      ; started_at = now
+      ; ended_at = now
+      ; scope = None
+      }
+    in
+    Proof_store.init_run store ~run_id:proof.run_id;
+    Proof_store.write_manifest store ~run_id:proof.run_id proof;
+    Proof_store.write_contract store ~run_id:proof.run_id contract;
+    { response = Error (Error.Internal (Printf.sprintf "contract rejected: %s" reason))
+    ; proof
+    }
+  | Ok mode_decision ->
+    let capture_state =
+      Proof_capture.create
+        ~store
+        ~contract
+        ~mode_decision
+        ~capability_snapshot:capabilities
+        ()
+    in
+    let tool_classifications =
+      Agent.tools agent
+      |> Tool_set.to_list
+      |> List.filter_map (fun (t : Tool.t) ->
+        match t.descriptor with
+        | Some d ->
+          Option.bind d.Tool.mutation_class Mode_enforcer.mutation_class_of_string
+          |> Option.map (fun cls -> t.schema.name, cls)
+        | None -> None)
+    in
+    let enforcer_state =
+      Mode_enforcer.create
+        ~contract
+        ~effective_mode:mode_decision.effective_mode
+        ~tool_classifications
+        ()
+    in
+    Proof_capture.set_enforcer capture_state enforcer_state;
+    let enforcement_hooks = Mode_enforcer.hooks enforcer_state in
+    let proof_hooks = Proof_capture.hooks capture_state in
+    let user_hooks = (Agent.options agent).hooks in
+    let composed_hooks =
+      Hooks.compose
+        ~outer:enforcement_hooks
+        ~inner:(Hooks.compose ~outer:proof_hooks ~inner:user_hooks)
+    in
+    let opts = Agent.options agent in
+    let new_opts = { opts with hooks = composed_hooks } in
+    let config = (Agent.state agent).config in
+    let tools = Agent.tools agent |> Tool_set.to_list in
+    let context = Agent.context agent in
+    let net = Agent.net agent in
+    let new_agent = Agent.create ~net ~config ~tools ~context ~options:new_opts () in
+    let response = Agent.run ~sw ?clock new_agent prompt in
+    (* Sync execution state back to the original agent so that
+       downstream checkpoint capture sees the post-run messages,
+       turn_count, and usage — not the pre-run empty state. *)
+    Agent.set_state agent (Agent.state new_agent);
+    let result_status = map_result_status response in
+    let proof = Proof_capture.finalize capture_state ~result_status in
+    { response; proof }
+;;

--- a/lib/cdal_runtime/contract_runner.mli
+++ b/lib/cdal_runtime/contract_runner.mli
@@ -1,0 +1,33 @@
+(** Contract-driven agent runner -- PoC-1 entry point.
+
+    Wraps {!Agent.run} with contract enforcement and proof capture.
+    The agent code remains completely unaware of contracts and proofs.
+
+    When not called, agent runs proceed with zero overhead.
+
+    @stability Evolving
+    @since 0.93.1 *)
+
+type run_result =
+  { response : (Types.api_response, Error.sdk_error) result
+  ; proof : Cdal_proof.t
+  }
+
+(** Run an agent with contract enforcement and proof capture.
+
+    Flow:
+    1. Validate contract and compute effective execution mode
+    2. Create proof capture hooks and compose with agent's hooks
+    3. Run agent via {!Agent.run}
+    4. Finalize proof bundle and write artifacts
+
+    Returns [Error] in response if risk class forbids execution
+    (Critical), with [proof.result_status = Cancelled]. *)
+val run
+  :  sw:Eio.Switch.t
+  -> ?clock:_ Eio.Time.clock
+  -> ?store:Proof_store.config
+  -> contract:Risk_contract.t
+  -> Agent.t
+  -> string
+  -> run_result

--- a/lib/cdal_runtime/direct_evidence.ml
+++ b/lib/cdal_runtime/direct_evidence.ml
@@ -1,0 +1,757 @@
+open Runtime
+open Result_syntax
+
+type options =
+  { session_root : string option
+  ; session_id : string
+  ; goal : string
+  ; title : string option
+  ; tag : string option
+  ; worker_id : string option
+  ; runtime_actor : string option
+  ; role : string option
+  ; aliases : string list
+  ; requested_provider : string option
+  ; requested_model : string option
+  ; requested_policy : string option
+  ; workdir : string option
+  }
+
+let now () = Unix.gettimeofday ()
+let first_some = Util.first_some
+let validation_error detail = Error.Io (ValidationFailed { detail })
+
+let safe_name name =
+  let trimmed = String.trim name in
+  let base = if trimmed = "" then "agent" else trimmed in
+  String.map
+    (function
+      | '/' | '\\' | ' ' | '\t' | '\n' | '\r' -> '_'
+      | c -> c)
+    base
+;;
+
+let save_events store session_id (events : event list) =
+  let content =
+    events
+    |> List.map (fun event -> event |> event_to_yojson |> Yojson.Safe.to_string)
+    |> String.concat "\n"
+    |> fun body -> if body = "" then "" else body ^ "\n"
+  in
+  Runtime_store.save_text (Runtime_store.events_path store session_id) content
+;;
+
+let lifecycle_snapshot_or_default (agent : Agent.t) : Agent.lifecycle_snapshot =
+  match Agent.lifecycle_snapshot agent with
+  | Some snapshot -> snapshot
+  | None ->
+    let cfg = (Agent.state agent).config in
+    { Agent_lifecycle.current_run_id = None
+    ; agent_name = cfg.name
+    ; worker_id = Some cfg.name
+    ; runtime_actor = Some cfg.name
+    ; status = Completed
+    ; requested_provider = None
+    ; requested_model = Some (Types.model_to_string cfg.model)
+    ; resolved_provider = None
+    ; resolved_model = Some (Types.model_to_string cfg.model)
+    ; last_error = None
+    ; accepted_at = None
+    ; ready_at = None
+    ; first_progress_at = None
+    ; started_at = None
+    ; last_progress_at = None
+    ; finished_at = None
+    }
+;;
+
+let default_runtime_actor (agent : Agent.t) options =
+  first_some options.runtime_actor (Some (Agent.state agent).config.name)
+;;
+
+let default_worker_id (agent : Agent.t) options =
+  first_some options.worker_id (default_runtime_actor agent options)
+;;
+
+let primary_alias aliases =
+  match aliases with
+  | alias :: _ when String.trim alias <> "" -> Some alias
+  | _ -> None
+;;
+
+let workdir_policy_to_json = function
+  | Tool.Required -> `String "required"
+  | Tool.Recommended -> `String "recommended"
+  | Tool.None_expected -> `String "none_expected"
+;;
+
+let shell_constraints_to_json (shell : Tool.shell_constraints) =
+  `Assoc
+    [ "single_command_only", `Bool shell.single_command_only
+    ; "shell_metacharacters_allowed", `Bool shell.shell_metacharacters_allowed
+    ; "chaining_allowed", `Bool shell.chaining_allowed
+    ; "redirection_allowed", `Bool shell.redirection_allowed
+    ; "pipes_allowed", `Bool shell.pipes_allowed
+    ; ( "workdir_policy"
+      , Option.value
+          ~default:`Null
+          (Option.map workdir_policy_to_json shell.workdir_policy) )
+    ]
+;;
+
+let tool_contracts_to_json tools =
+  `List
+    (List.map
+       (fun (tool : Tool.t) ->
+          let descriptor = Tool.descriptor tool in
+          let kind =
+            match Option.bind descriptor (fun d -> d.kind) with
+            | Some value -> `String value
+            | None -> `Null
+          in
+          let shell =
+            match Option.bind descriptor (fun d -> d.shell) with
+            | Some shell -> shell_constraints_to_json shell
+            | None -> `Null
+          in
+          let notes =
+            descriptor
+            |> Option.map (fun (d : Tool.descriptor) -> d.notes)
+            |> Option.value ~default:[]
+          in
+          let examples =
+            descriptor
+            |> Option.map (fun (d : Tool.descriptor) -> d.examples)
+            |> Option.value ~default:[]
+          in
+          let mutation_class =
+            match Option.bind descriptor (fun d -> d.mutation_class) with
+            | Some value -> `String value
+            | None -> `Null
+          in
+          `Assoc
+            [ "name", `String tool.schema.name
+            ; "description", `String tool.schema.description
+            ; "origin", `String "local"
+            ; "kind", kind
+            ; "mutation_class", mutation_class
+            ; "shell", shell
+            ; "notes", Util.json_of_string_list notes
+            ; "examples", Util.json_of_string_list examples
+            ])
+       tools)
+;;
+
+let worker_status_of_lifecycle = function
+  | Agent.Accepted -> Sessions.Accepted
+  | Agent.Ready -> Sessions.Ready
+  | Agent.Running -> Sessions.Running
+  | Agent.Completed -> Sessions.Completed
+  | Agent.Failed -> Sessions.Failed
+;;
+
+type raw_details =
+  { validated : bool
+  ; tool_names : string list
+  ; final_text : string option
+  ; stop_reason : string option
+  ; error : string option
+  ; paired_tool_result_count : int
+  ; has_file_write : bool
+  ; verification_pass_after_file_write : bool
+  ; failure_reason : string option
+  }
+
+let empty_raw_details =
+  { validated = false
+  ; tool_names = []
+  ; final_text = None
+  ; stop_reason = None
+  ; error = None
+  ; paired_tool_result_count = 0
+  ; has_file_write = false
+  ; verification_pass_after_file_write = false
+  ; failure_reason = None
+  }
+;;
+
+let raw_details_of_run run_ref =
+  let* validation = Raw_trace_query.validate_run run_ref in
+  Ok
+    { validated = validation.ok
+    ; tool_names = validation.tool_names
+    ; final_text = validation.final_text
+    ; stop_reason = validation.stop_reason
+    ; error = validation.failure_reason
+    ; paired_tool_result_count = validation.paired_tool_result_count
+    ; has_file_write = validation.has_file_write
+    ; verification_pass_after_file_write = validation.verification_pass_after_file_write
+    ; failure_reason = validation.failure_reason
+    }
+;;
+
+let worker_run_of_agent
+      ~(agent : Agent.t)
+      ~options
+      ~(snapshot : Agent.lifecycle_snapshot)
+      raw_details
+  =
+  let aliases = options.aliases in
+  let worker_id = default_worker_id agent options in
+  let runtime_actor = default_runtime_actor agent options in
+  { Sessions.worker_run_id =
+      Option.value ~default:"direct-untracked" snapshot.current_run_id
+  ; worker_id
+  ; agent_name = (Agent.state agent).config.name
+  ; runtime_actor
+  ; role = options.role
+  ; aliases
+  ; primary_alias = primary_alias aliases
+  ; provider = snapshot.resolved_provider
+  ; model = snapshot.resolved_model
+  ; requested_provider = first_some snapshot.requested_provider options.requested_provider
+  ; requested_model = first_some snapshot.requested_model options.requested_model
+  ; requested_policy = options.requested_policy
+  ; resolved_provider = snapshot.resolved_provider
+  ; resolved_model = snapshot.resolved_model
+  ; status = worker_status_of_lifecycle snapshot.status
+  ; trace_capability =
+      (match snapshot.current_run_id with
+       | Some _ -> Sessions.Raw
+       | None -> Sessions.No_trace)
+  ; validated =
+      (match snapshot.status with
+       | Agent.Completed -> raw_details.validated
+       | Agent.Accepted | Agent.Ready | Agent.Running | Agent.Failed -> false)
+  ; tool_names = raw_details.tool_names
+  ; final_text = raw_details.final_text
+  ; stop_reason = raw_details.stop_reason
+  ; error = first_some snapshot.last_error raw_details.error
+  ; failure_reason = first_some snapshot.last_error raw_details.failure_reason
+  ; accepted_at = snapshot.accepted_at
+  ; ready_at = snapshot.ready_at
+  ; first_progress_at = snapshot.first_progress_at
+  ; started_at = snapshot.started_at
+  ; finished_at = snapshot.finished_at
+  ; last_progress_at = snapshot.last_progress_at
+  ; policy_snapshot = options.requested_policy
+  ; paired_tool_result_count = raw_details.paired_tool_result_count
+  ; has_file_write = raw_details.has_file_write
+  ; verification_pass_after_file_write = raw_details.verification_pass_after_file_write
+  }
+;;
+
+let current_worker_run ~(agent : Agent.t) ~raw_trace ~options () =
+  let snapshot = lifecycle_snapshot_or_default agent in
+  let raw_details =
+    match
+      match Raw_trace.last_run raw_trace with
+      | Some run -> Some run
+      | None -> Agent.last_raw_trace_run agent
+    with
+    | Some run -> raw_details_of_run run
+    | None -> Ok empty_raw_details
+  in
+  let* raw_details = raw_details in
+  Ok (worker_run_of_agent ~agent ~options ~snapshot raw_details)
+;;
+
+let extract_prompt (records : Raw_trace.record list) =
+  records
+  |> List.find_map (fun (record : Raw_trace.record) ->
+    match record.record_type, record.prompt with
+    | Raw_trace.Run_started, Some prompt -> Some prompt
+    | _ -> None)
+  |> Option.value ~default:""
+;;
+
+let extract_text_deltas (records : Raw_trace.record list) =
+  records
+  |> List.filter_map (fun (record : Raw_trace.record) ->
+    match record.record_type, record.block_kind, record.assistant_block with
+    | Raw_trace.Assistant_block, Some "text", Some (`Assoc fields) ->
+      (match List.assoc_opt "text" fields with
+       | Some (`String text) when String.trim text <> "" -> Some (record.ts, text)
+       | _ -> None)
+    | _ -> None)
+;;
+
+let write_latest_run_to_session store session_id agent_name (run_ref : Raw_trace.run_ref) =
+  let* records = Raw_trace_query.read_run run_ref in
+  let path =
+    Filename.concat
+      (Runtime_store.raw_traces_dir store session_id)
+      (safe_name agent_name ^ ".jsonl")
+  in
+  let content =
+    records
+    |> List.map (fun record ->
+      record |> Raw_trace.record_to_json |> Yojson.Safe.to_string)
+    |> String.concat "\n"
+    |> fun body -> if body = "" then "" else body ^ "\n"
+  in
+  let* () = Runtime_store.save_text path content in
+  let* runs = Raw_trace_query.read_runs ~path () in
+  match
+    List.find_opt
+      (fun (candidate : Raw_trace.run_ref) ->
+         String.equal candidate.worker_run_id run_ref.worker_run_id)
+      runs
+  with
+  | Some run -> Ok (run, records)
+  | None ->
+    Error
+      (validation_error
+         (Printf.sprintf
+            "Failed to materialize latest raw trace run %s"
+            run_ref.worker_run_id))
+;;
+
+let apply_events initial_session (events : event list) =
+  List.fold_left
+    (fun acc event ->
+       let* session = acc in
+       Runtime_projection.apply_event session event)
+    (Ok initial_session)
+    events
+;;
+
+let make_event seq ts kind = { seq; ts; kind }
+
+let persist ~agent ~raw_trace ~(options : options) () =
+  let cfg = (Agent.state agent).config in
+  let snapshot = lifecycle_snapshot_or_default agent in
+  let terminal =
+    match snapshot.status with
+    | Agent.Completed | Agent.Failed -> true
+    | Agent.Accepted | Agent.Ready | Agent.Running -> false
+  in
+  if not terminal
+  then
+    Error
+      (validation_error
+         "Direct evidence materialization requires a terminal direct-agent run")
+  else
+    let* store = Runtime_store.create ?root:options.session_root () in
+    let raw_session_id = Raw_trace.session_id raw_trace in
+    let* () =
+      match raw_session_id with
+      | Some value when not (String.equal value options.session_id) ->
+        Error
+          (validation_error
+             (Printf.sprintf
+                "Raw trace session_id %s did not match requested session_id %s"
+                value
+                options.session_id))
+      | _ -> Ok ()
+    in
+    let last_run =
+      match Raw_trace.last_run raw_trace with
+      | Some run -> Some run
+      | None -> Agent.last_raw_trace_run agent
+    in
+    let* last_run =
+      match last_run with
+      | Some run -> Ok run
+      | None -> Error (validation_error "No raw trace run was available")
+    in
+    let* raw_run, latest_records =
+      write_latest_run_to_session store options.session_id cfg.name last_run
+    in
+    let existing_bundle =
+      match
+        Sessions.get_proof_bundle
+          ?session_root:options.session_root
+          ~session_id:options.session_id
+          ()
+      with
+      | Ok bundle ->
+        (match bundle.Sessions.latest_raw_trace_run with
+         | Some existing when String.equal existing.worker_run_id raw_run.worker_run_id ->
+           Some bundle
+         | _ -> None)
+      | Error _ -> None
+    in
+    match existing_bundle with
+    | Some bundle -> Ok bundle
+    | None ->
+      let* raw_summary = Raw_trace_query.summarize_run raw_run in
+      let* raw_validation = Raw_trace_query.validate_run raw_run in
+      let prompt = extract_prompt latest_records in
+      let selected_provider =
+        first_some snapshot.requested_provider options.requested_provider
+      in
+      let selected_model = first_some snapshot.requested_model options.requested_model in
+      let start_request =
+        { session_id = Some options.session_id
+        ; goal = options.goal
+        ; participants = [ cfg.name ]
+        ; provider = selected_provider
+        ; model = selected_model
+        ; permission_mode = options.requested_policy
+        ; system_prompt = cfg.system_prompt
+        ; max_turns = Some cfg.max_turns
+        ; workdir = options.workdir
+        }
+      in
+      let initial_session =
+        let session = Runtime_projection.initial_session start_request in
+        { session with
+          title = options.title
+        ; tag = options.tag
+        ; participants =
+            session.participants
+            |> List.map (fun (participant : Runtime.participant) ->
+              if String.equal participant.name cfg.name
+              then
+                { participant with
+                  worker_id = default_worker_id agent options
+                ; runtime_actor = default_runtime_actor agent options
+                ; role = first_some options.role participant.role
+                ; aliases = options.aliases
+                }
+              else participant)
+        }
+      in
+      let started_at = Option.value raw_summary.started_at ~default:(now ()) in
+      let finished_at =
+        Option.value
+          raw_summary.finished_at
+          ~default:(Option.value snapshot.finished_at ~default:started_at)
+      in
+      let deltas = extract_text_deltas latest_records in
+      let base_events =
+        [ make_event
+            1
+            (started_at -. 0.003)
+            (Session_started { goal = options.goal; participants = [ cfg.name ] })
+        ; make_event
+            2
+            (started_at -. 0.002)
+            (Turn_recorded { actor = None; message = prompt })
+        ; make_event
+            3
+            (started_at -. 0.001)
+            (Agent_spawn_requested
+               { participant_name = cfg.name
+               ; role = first_some options.role None
+               ; prompt
+               ; provider = selected_provider
+               ; model = selected_model
+               ; permission_mode = options.requested_policy
+               })
+        ; make_event
+            4
+            started_at
+            (Agent_became_live
+               { participant_name = cfg.name
+               ; summary = Some "direct-agent-started"
+               ; provider = snapshot.resolved_provider
+               ; model = snapshot.resolved_model
+               ; error = None
+               ; raw_trace_run_id = Some raw_run.worker_run_id
+               ; stop_reason = None
+               ; completion_anomaly = None
+               ; failure_cause = None
+               })
+        ]
+        @ (deltas
+           |> List.mapi (fun index (ts, text) ->
+             make_event
+               (5 + index)
+               ts
+               (Agent_output_delta { participant_name = cfg.name; delta = text })))
+        @ [ make_event
+              (5 + List.length deltas)
+              finished_at
+              (match snapshot.status with
+               | Agent.Failed ->
+                 Agent_failed
+                   { participant_name = cfg.name
+                   ; summary = raw_summary.final_text
+                   ; provider = snapshot.resolved_provider
+                   ; model = snapshot.resolved_model
+                   ; error = first_some snapshot.last_error raw_summary.error
+                   ; raw_trace_run_id = Some raw_run.worker_run_id
+                   ; stop_reason = raw_summary.stop_reason
+                   ; completion_anomaly = None
+                   ; failure_cause =
+                       first_some snapshot.last_error raw_summary.error
+                       |> Option.map (fun detail -> Runtime.Execution_error detail)
+                   }
+               | Agent.Accepted | Agent.Ready | Agent.Running | Agent.Completed ->
+                 Agent_completed
+                   { participant_name = cfg.name
+                   ; summary = raw_summary.final_text
+                   ; provider = snapshot.resolved_provider
+                   ; model = snapshot.resolved_model
+                   ; error = None
+                   ; raw_trace_run_id = Some raw_run.worker_run_id
+                   ; stop_reason = raw_summary.stop_reason
+                   ; completion_anomaly = None
+                   ; failure_cause = None
+                   })
+          ; make_event
+              (6 + List.length deltas)
+              (finished_at +. 0.001)
+              (Finalize_requested { reason = None })
+          ; make_event
+              (7 + List.length deltas)
+              (finished_at +. 0.002)
+              (match snapshot.status with
+               | Agent.Failed ->
+                 Session_failed
+                   { outcome = first_some snapshot.last_error raw_summary.error }
+               | Agent.Accepted | Agent.Ready | Agent.Running | Agent.Completed ->
+                 Session_completed { outcome = raw_summary.stop_reason })
+          ]
+      in
+      let* terminal_session = apply_events initial_session base_events in
+      let* () = Runtime_store.save_session store terminal_session in
+      let* () = save_events store options.session_id base_events in
+      let telemetry =
+        Runtime_evidence.build_telemetry_report terminal_session base_events
+      in
+      let telemetry_json =
+        Runtime_evidence.telemetry_report_to_json telemetry
+        |> Yojson.Safe.pretty_to_string
+      in
+      let telemetry_md = Runtime_evidence.telemetry_report_to_markdown telemetry in
+      let report = Runtime_projection.build_report terminal_session base_events in
+      let proof = Runtime_projection.build_proof terminal_session base_events in
+      let* () = Runtime_store.save_report store report in
+      let* () = Runtime_store.save_proof store proof in
+      let* telemetry_json_artifact =
+        Artifact_service.save_text_internal
+          store
+          ~session_id:options.session_id
+          ~name:"runtime-telemetry-json"
+          ~kind:"json"
+          ~content:telemetry_json
+      in
+      let* telemetry_md_artifact =
+        Artifact_service.save_text_internal
+          store
+          ~session_id:options.session_id
+          ~name:"runtime-telemetry"
+          ~kind:"markdown"
+          ~content:telemetry_md
+      in
+      let raw_trace_manifest =
+        Runtime_evidence.build_raw_trace_manifest
+          ~session_id:options.session_id
+          ~latest_raw_trace_run:(Some raw_run)
+          ~raw_trace_runs:[ raw_run ]
+          ~raw_trace_summaries:[ raw_summary ]
+          ~raw_trace_validations:[ raw_validation ]
+      in
+      let raw_trace_json =
+        Runtime_evidence.raw_trace_manifest_to_json raw_trace_manifest
+        |> Yojson.Safe.pretty_to_string
+      in
+      let* raw_trace_artifact =
+        Artifact_service.save_text_internal
+          store
+          ~session_id:options.session_id
+          ~name:"runtime-raw-trace-json"
+          ~kind:"json"
+          ~content:raw_trace_json
+      in
+      let tool_catalog_json =
+        tool_contracts_to_json (Tool_set.to_list (Agent.tools agent))
+        |> Yojson.Safe.pretty_to_string
+      in
+      let* tool_catalog_artifact =
+        Artifact_service.save_text_internal
+          store
+          ~session_id:options.session_id
+          ~name:"tool-catalog"
+          ~kind:"json"
+          ~content:tool_catalog_json
+      in
+      let* telemetry_json_path =
+        Artifact_service.persisted_path telemetry_json_artifact
+      in
+      let* telemetry_md_path = Artifact_service.persisted_path telemetry_md_artifact in
+      let* raw_trace_json_path = Artifact_service.persisted_path raw_trace_artifact in
+      let* tool_catalog_path = Artifact_service.persisted_path tool_catalog_artifact in
+      let evidence =
+        Runtime_evidence.build_evidence_bundle
+          ~session_id:options.session_id
+          (Runtime_evidence.base_evidence_file_specs store options.session_id
+           @ [ "telemetry_json", telemetry_json_path
+             ; "telemetry_md", telemetry_md_path
+             ; "raw_trace_json", raw_trace_json_path
+             ; "tool_catalog_json", tool_catalog_path
+             ])
+      in
+      let evidence_json =
+        Runtime_evidence.evidence_bundle_to_json evidence |> Yojson.Safe.pretty_to_string
+      in
+      let* evidence_artifact =
+        Artifact_service.save_text_internal
+          store
+          ~session_id:options.session_id
+          ~name:"runtime-evidence"
+          ~kind:"json"
+          ~content:evidence_json
+      in
+      let artifact_events =
+        [ telemetry_json_artifact
+        ; telemetry_md_artifact
+        ; raw_trace_artifact
+        ; tool_catalog_artifact
+        ; evidence_artifact
+        ]
+        |> List.mapi (fun index (artifact : Runtime.artifact) ->
+          make_event
+            (8 + List.length deltas + index)
+            (finished_at +. 0.003 +. (float_of_int index *. 0.001))
+            (Runtime_evidence.artifact_attached_event artifact))
+      in
+      let all_events = base_events @ artifact_events in
+      let* final_session = apply_events initial_session all_events in
+      let final_report = Runtime_projection.build_report final_session all_events in
+      let final_proof = Runtime_projection.build_proof final_session all_events in
+      let final_telemetry =
+        Runtime_evidence.build_telemetry_report final_session all_events
+      in
+      let final_telemetry_json =
+        Runtime_evidence.telemetry_report_to_json final_telemetry
+        |> Yojson.Safe.pretty_to_string
+      in
+      let final_telemetry_md =
+        Runtime_evidence.telemetry_report_to_markdown final_telemetry
+      in
+      let* () = Runtime_store.save_session store final_session in
+      let* () = save_events store options.session_id all_events in
+      let* () = Runtime_store.save_report store final_report in
+      let* () = Runtime_store.save_proof store final_proof in
+      let* () =
+        Artifact_service.overwrite_text_internal
+          telemetry_json_artifact
+          ~content:final_telemetry_json
+      in
+      let* () =
+        Artifact_service.overwrite_text_internal
+          telemetry_md_artifact
+          ~content:final_telemetry_md
+      in
+      let final_evidence =
+        Runtime_evidence.build_evidence_bundle
+          ~session_id:options.session_id
+          (Runtime_evidence.base_evidence_file_specs store options.session_id
+           @ [ "telemetry_json", telemetry_json_path
+             ; "telemetry_md", telemetry_md_path
+             ; "raw_trace_json", raw_trace_json_path
+             ; "tool_catalog_json", tool_catalog_path
+             ])
+      in
+      let final_evidence_json =
+        Runtime_evidence.evidence_bundle_to_json final_evidence
+        |> Yojson.Safe.pretty_to_string
+      in
+      let* () =
+        Artifact_service.overwrite_text_internal
+          evidence_artifact
+          ~content:final_evidence_json
+      in
+      Sessions.get_proof_bundle
+        ?session_root:options.session_root
+        ~session_id:options.session_id
+        ()
+;;
+
+let get_worker_run ~agent ~raw_trace ~options () =
+  current_worker_run ~agent ~raw_trace ~options ()
+;;
+
+let get_proof_bundle ~agent ~raw_trace ~options () = persist ~agent ~raw_trace ~options ()
+
+let get_conformance ~agent ~raw_trace ~options () =
+  let* bundle = get_proof_bundle ~agent ~raw_trace ~options () in
+  Ok (Conformance.report bundle)
+;;
+
+let run_conformance ~agent ~raw_trace ~options () =
+  let* report = get_conformance ~agent ~raw_trace ~options () in
+  Ok report
+;;
+
+[@@@coverage off]
+(* === Inline tests === *)
+
+let%test "safe_name replaces slashes and spaces" = safe_name "my agent/v1" = "my_agent_v1"
+let%test "safe_name replaces backslash" = safe_name "path\\to" = "path_to"
+let%test "safe_name replaces tab and newline" = safe_name "a\tb\nc" = "a_b_c"
+let%test "safe_name trims whitespace" = safe_name "  agent  " = "agent"
+let%test "safe_name empty string becomes agent" = safe_name "" = "agent"
+let%test "safe_name whitespace only becomes agent" = safe_name "   " = "agent"
+let%test "safe_name normal string unchanged" = safe_name "my-agent_v1" = "my-agent_v1"
+
+let%test "primary_alias returns first non-empty alias" =
+  primary_alias [ "alice"; "bob" ] = Some "alice"
+;;
+
+let%test "primary_alias empty list returns None" = primary_alias [] = None
+let%test "primary_alias blank first returns None" = primary_alias [ "  "; "bob" ] = None
+
+let%test "worker_status_of_lifecycle Accepted" =
+  worker_status_of_lifecycle Agent.Accepted = Sessions.Accepted
+;;
+
+let%test "worker_status_of_lifecycle Ready" =
+  worker_status_of_lifecycle Agent.Ready = Sessions.Ready
+;;
+
+let%test "worker_status_of_lifecycle Running" =
+  worker_status_of_lifecycle Agent.Running = Sessions.Running
+;;
+
+let%test "worker_status_of_lifecycle Completed" =
+  worker_status_of_lifecycle Agent.Completed = Sessions.Completed
+;;
+
+let%test "worker_status_of_lifecycle Failed" =
+  worker_status_of_lifecycle Agent.Failed = Sessions.Failed
+;;
+
+let%test "empty_raw_details has expected defaults" =
+  empty_raw_details.validated = false
+  && empty_raw_details.tool_names = []
+  && empty_raw_details.final_text = None
+  && empty_raw_details.stop_reason = None
+  && empty_raw_details.error = None
+  && empty_raw_details.paired_tool_result_count = 0
+  && empty_raw_details.has_file_write = false
+  && empty_raw_details.verification_pass_after_file_write = false
+  && empty_raw_details.failure_reason = None
+;;
+
+let%test "validation_error creates Io error" =
+  match validation_error "test detail" with
+  | Error.Io (ValidationFailed { detail }) -> detail = "test detail"
+  | _ -> false
+;;
+
+let%test "workdir_policy_to_json Required" =
+  workdir_policy_to_json Tool.Required = `String "required"
+;;
+
+let%test "workdir_policy_to_json Recommended" =
+  workdir_policy_to_json Tool.Recommended = `String "recommended"
+;;
+
+let%test "workdir_policy_to_json None_expected" =
+  workdir_policy_to_json Tool.None_expected = `String "none_expected"
+;;
+
+let%test "make_event creates event with correct fields" =
+  let event =
+    make_event 42 1234.0 (Session_started { goal = "test"; participants = [ "a" ] })
+  in
+  event.seq = 42 && event.ts = 1234.0
+;;
+
+let%test "extract_prompt empty records returns empty" = extract_prompt [] = ""
+let%test "extract_text_deltas empty records returns empty" = extract_text_deltas [] = []

--- a/lib/cdal_runtime/direct_evidence.mli
+++ b/lib/cdal_runtime/direct_evidence.mli
@@ -1,0 +1,76 @@
+(** Direct evidence extraction from agent runs.
+
+    Materializes worker run data, proof bundles, and conformance
+    reports from a live {!Agent.t} and its {!Raw_trace.t}.
+
+    @stability Evolving
+    @since 0.93.1 *)
+
+type options =
+  { session_root : string option
+  ; session_id : string
+  ; goal : string
+  ; title : string option
+  ; tag : string option
+  ; worker_id : string option
+  ; runtime_actor : string option
+  ; role : string option
+  ; aliases : string list
+  ; requested_provider : string option
+  ; requested_model : string option
+  ; requested_policy : string option
+  ; workdir : string option
+  }
+
+type raw_details =
+  { validated : bool
+  ; tool_names : string list
+  ; final_text : string option
+  ; stop_reason : string option
+  ; error : string option
+  ; paired_tool_result_count : int
+  ; has_file_write : bool
+  ; verification_pass_after_file_write : bool
+  ; failure_reason : string option
+  }
+
+(** Extract a single worker run from an agent and its trace. *)
+val get_worker_run
+  :  agent:Agent.t
+  -> raw_trace:Raw_trace.t
+  -> options:options
+  -> unit
+  -> (Sessions.worker_run, Error.sdk_error) result
+
+(** Persist evidence and return a proof bundle. *)
+val get_proof_bundle
+  :  agent:Agent.t
+  -> raw_trace:Raw_trace.t
+  -> options:options
+  -> unit
+  -> (Sessions.proof_bundle, Error.sdk_error) result
+
+(** Generate a conformance report from an agent run. *)
+val get_conformance
+  :  agent:Agent.t
+  -> raw_trace:Raw_trace.t
+  -> options:options
+  -> unit
+  -> (Conformance.report, Error.sdk_error) result
+
+(** Alias for {!get_conformance}. *)
+val run_conformance
+  :  agent:Agent.t
+  -> raw_trace:Raw_trace.t
+  -> options:options
+  -> unit
+  -> (Conformance.report, Error.sdk_error) result
+
+(** Persist evidence to disk and return a proof bundle.
+    Used by examples and external tools. *)
+val persist
+  :  agent:Agent.t
+  -> raw_trace:Raw_trace.t
+  -> options:options
+  -> unit
+  -> (Sessions.proof_bundle, Error.sdk_error) result

--- a/lib/cdal_runtime/mode_enforcer.ml
+++ b/lib/cdal_runtime/mode_enforcer.ml
@@ -1,0 +1,598 @@
+type tool_effect_class =
+  | Read_only
+  | Local_mutation
+  | External_effect
+  | Shell_dynamic
+
+(* Backward-compatible alias. *)
+type mutation_class = tool_effect_class
+
+type violation_kind =
+  | Mutating_in_diagnose
+  | External_in_draft
+  | Scope_violation
+
+let violation_kind_to_string = function
+  | Mutating_in_diagnose -> "mutating_in_diagnose"
+  | External_in_draft -> "external_in_draft"
+  | Scope_violation -> "scope_violation"
+;;
+
+let violation_kind_of_string = function
+  | "mutating_in_diagnose" -> Ok Mutating_in_diagnose
+  | "external_in_draft" -> Ok External_in_draft
+  | "scope_violation" -> Ok Scope_violation
+  | s -> Error (Printf.sprintf "unknown violation_kind: %s" s)
+;;
+
+let violation_kind_to_yojson v = `String (violation_kind_to_string v)
+
+let violation_kind_of_yojson = function
+  | `String s -> violation_kind_of_string s
+  | j -> Error (Printf.sprintf "expected string, got %s" (Yojson.Safe.to_string j))
+;;
+
+type violation =
+  { ts : float
+  ; tool_name : string
+  ; input_summary : string
+  ; effective_mode : Execution_mode.t
+  ; violation_kind : violation_kind
+  }
+
+let violation_to_yojson v =
+  `Assoc
+    [ "ts", `Float v.ts
+    ; "tool_name", `String v.tool_name
+    ; "input_summary", `String v.input_summary
+    ; "effective_mode", Execution_mode.to_yojson v.effective_mode
+    ; "violation_kind", violation_kind_to_yojson v.violation_kind
+    ]
+;;
+
+let violation_of_yojson = function
+  | `Assoc fields ->
+    (match
+       ( List.assoc_opt "ts" fields
+       , List.assoc_opt "tool_name" fields
+       , List.assoc_opt "input_summary" fields
+       , List.assoc_opt "effective_mode" fields
+       , List.assoc_opt "violation_kind" fields )
+     with
+     | ( Some (`Float ts)
+       , Some (`String tool_name)
+       , Some (`String input_summary)
+       , Some mode_json
+       , Some kind_json ) ->
+       (match Execution_mode.of_yojson mode_json, violation_kind_of_yojson kind_json with
+        | Ok effective_mode, Ok violation_kind ->
+          Ok { ts; tool_name; input_summary; effective_mode; violation_kind }
+        | Error e, _ | _, Error e -> Error e)
+     | _ -> Error "missing or invalid fields in violation")
+  | _ -> Error "violation: expected JSON object"
+;;
+
+type token_snapshot =
+  { input_tokens : int
+  ; output_tokens : int
+  ; cost_usd : float option
+  ; turn : int
+  }
+
+(* ── Tool classification registry ────────────────────────────────── *)
+
+(** Default tool-name -> effect-class mappings. Data, not inline code. *)
+let default_tool_entries : (string * tool_effect_class) list =
+  [ (* ── Read-only tools ─────────────────────────────────────── *)
+    (* File & code navigation *)
+    "read", Read_only
+  ; "glob", Read_only
+  ; "grep", Read_only
+  ; "search", Read_only
+  ; "list_dir", Read_only
+  ; "find_file", Read_only
+  ; "read_file", Read_only
+  ; "find_symbol", Read_only
+  ; "get_symbols_overview", Read_only
+  ; "find_referencing_symbols", Read_only
+  ; "search_for_pattern", Read_only
+  ; (* Notebook *)
+    "notebook_read", Read_only
+  ; (* Browser observation *)
+    "read_console_messages", Read_only
+  ; "read_network_requests", Read_only
+  ; "get_page_text", Read_only
+  ; "read_page", Read_only
+  ; "tabs_context_mcp", Read_only
+  ; (* Task queries *)
+    "task_list", Read_only
+  ; "task_get", Read_only
+  ; "task_output", Read_only
+  ; (* ── Local-mutation tools ────────────────────────────────── *)
+    (* File editing *)
+    "write", Local_mutation
+  ; "edit", Local_mutation
+  ; "create_text_file", Local_mutation
+  ; "replace_content", Local_mutation
+  ; "rename_symbol", Local_mutation
+  ; "insert_after_symbol", Local_mutation
+  ; "insert_before_symbol", Local_mutation
+  ; "replace_symbol_body", Local_mutation
+  ; "notebook_edit", Local_mutation
+  ; (* Task & team management *)
+    "task_create", Local_mutation
+  ; "task_update", Local_mutation
+  ; "task_stop", Local_mutation
+  ; "team_create", Local_mutation
+  ; "team_delete", Local_mutation
+  ; (* ── External-effect tools ───────────────────────────────── *)
+    (* HITL *)
+    "ask_user_question", External_effect
+  ; (* Web & research *)
+    "web_fetch", External_effect
+  ; "web_search", External_effect
+  ; (* Browser interaction *)
+    "navigate", External_effect
+  ; "computer", External_effect
+  ; "find", External_effect
+  ; "form_input", External_effect
+  ; "javascript_tool", External_effect
+  ; "tabs_create_mcp", External_effect
+  ; "upload_image", External_effect
+  ; (* ── Shell-dynamic tools (require input analysis at runtime) *)
+    "bash", Shell_dynamic
+  ; "execute_shell_command", Shell_dynamic
+  ]
+;;
+
+(** Global mutable registry seeded from [default_tool_entries].
+    Supports runtime extension via [register_tool_class]. *)
+let tool_registry : (string, tool_effect_class) Hashtbl.t =
+  let tbl = Hashtbl.create (List.length default_tool_entries) in
+  List.iter (fun (name, cls) -> Hashtbl.replace tbl name cls) default_tool_entries;
+  tbl
+;;
+
+let register_tool_class name cls =
+  Hashtbl.replace tool_registry (String.lowercase_ascii name) cls
+;;
+
+type state =
+  { effective_mode : Execution_mode.t
+  ; allowed_mutations : string list
+  ; review_requirement : string option
+  ; tool_classifications : (string * tool_effect_class) list
+  ; mutable violations : violation list
+  ; mutable token_snapshots : token_snapshot list
+  ; mutable review_warning : string option
+  ; mutable effect_evidence : Effect_evidence.t list
+  }
+
+let create ~contract ~effective_mode ?(tool_classifications = []) () =
+  let rc = contract.Risk_contract.runtime_constraints in
+  { effective_mode
+  ; allowed_mutations = rc.allowed_mutations
+  ; review_requirement = rc.review_requirement
+  ; tool_classifications
+  ; violations = []
+  ; token_snapshots = []
+  ; review_warning = None
+  ; effect_evidence = []
+  }
+;;
+
+let violations st = List.rev st.violations
+let token_snapshots st = List.rev st.token_snapshots
+let review_warning st = st.review_warning
+let effect_evidence st = List.rev st.effect_evidence
+
+(* ── Tool classification ─────────────────────────────────────────── *)
+
+let classify_tool name =
+  let key = String.lowercase_ascii name in
+  match Hashtbl.find_opt tool_registry key with
+  | Some cls -> cls
+  | None ->
+    (* Fail closed: MCP tools and anything unknown -> External_effect *)
+    if String.length key > 5 && String.sub key 0 5 = "mcp__"
+    then External_effect
+    else External_effect
+;;
+
+(** Structured shell-command pattern entries.
+    Each pair maps a substring pattern to the effect class it implies.
+    Order does not matter -- [classify_bash_tool] checks external patterns
+    first (fail closed) and falls back to mutating, then read-only. *)
+
+type shell_pattern_entry =
+  { pattern : string
+  ; effect_class : tool_effect_class
+  }
+
+let shell_pattern_entries : shell_pattern_entry list =
+  [ (* External-effect patterns (network, remote, deploy) *)
+    { pattern = "curl "; effect_class = External_effect }
+  ; { pattern = "wget "; effect_class = External_effect }
+  ; { pattern = "ssh "; effect_class = External_effect }
+  ; { pattern = "scp "; effect_class = External_effect }
+  ; { pattern = "rsync "; effect_class = External_effect }
+  ; { pattern = "git push"; effect_class = External_effect }
+  ; { pattern = "git fetch"; effect_class = External_effect }
+  ; { pattern = "git pull"; effect_class = External_effect }
+  ; { pattern = "git clone"; effect_class = External_effect }
+  ; { pattern = "docker "; effect_class = External_effect }
+  ; { pattern = "kubectl "; effect_class = External_effect }
+  ; { pattern = "helm "; effect_class = External_effect }
+  ; { pattern = "npm publish"; effect_class = External_effect }
+  ; { pattern = "pip install"; effect_class = External_effect }
+  ; { pattern = "cargo publish"; effect_class = External_effect }
+  ; { pattern = "systemctl "; effect_class = External_effect }
+  ; { pattern = "launchctl "; effect_class = External_effect }
+  ; (* Local-mutation patterns (filesystem, vcs local, package managers) *)
+    { pattern = "rm "; effect_class = Local_mutation }
+  ; { pattern = "rm\t"; effect_class = Local_mutation }
+  ; { pattern = "rmdir "; effect_class = Local_mutation }
+  ; { pattern = "mv "; effect_class = Local_mutation }
+  ; { pattern = "cp "; effect_class = Local_mutation }
+  ; { pattern = "mkdir "; effect_class = Local_mutation }
+  ; { pattern = "touch "; effect_class = Local_mutation }
+  ; { pattern = "chmod "; effect_class = Local_mutation }
+  ; { pattern = "chown "; effect_class = Local_mutation }
+  ; { pattern = "dd "; effect_class = Local_mutation }
+  ; { pattern = "mkfs"; effect_class = Local_mutation }
+  ; { pattern = "apt "; effect_class = Local_mutation }
+  ; { pattern = "brew "; effect_class = Local_mutation }
+  ; { pattern = "pip "; effect_class = Local_mutation }
+  ; { pattern = "npm "; effect_class = Local_mutation }
+  ; { pattern = "yarn "; effect_class = Local_mutation }
+  ; { pattern = "cargo "; effect_class = Local_mutation }
+  ; { pattern = "git commit"; effect_class = Local_mutation }
+  ; { pattern = "git add"; effect_class = Local_mutation }
+  ; { pattern = "git reset"; effect_class = Local_mutation }
+  ; { pattern = "git rebase"; effect_class = Local_mutation }
+  ; { pattern = "git merge"; effect_class = Local_mutation }
+  ; { pattern = "git checkout"; effect_class = Local_mutation }
+  ]
+;;
+
+(** Collect the highest-severity effect class from all matching patterns.
+    External_effect > Local_mutation > Read_only. *)
+let classify_shell_command cmd =
+  let has_redirect = String.contains cmd '>' || Util.string_contains ~needle:"tee " cmd in
+  let max_effect = ref Read_only in
+  List.iter
+    (fun entry ->
+       if Util.string_contains ~needle:entry.pattern cmd
+       then (
+         match entry.effect_class, !max_effect with
+         | External_effect, _ -> max_effect := External_effect
+         | Local_mutation, Read_only -> max_effect := Local_mutation
+         | _ -> ()))
+    shell_pattern_entries;
+  if has_redirect && !max_effect = Read_only then max_effect := Local_mutation;
+  !max_effect
+;;
+
+let extract_bash_command (input : Yojson.Safe.t) =
+  match input with
+  | `Assoc fields ->
+    (match List.assoc_opt "command" fields with
+     | Some (`String cmd) -> Some (String.lowercase_ascii cmd)
+     | _ -> None)
+  | _ -> None
+;;
+
+let classify_bash_tool input =
+  match extract_bash_command input with
+  | None -> External_effect (* fail closed: unparseable -> external *)
+  | Some cmd -> classify_shell_command cmd
+;;
+
+let effective_class tool_name input =
+  match classify_tool tool_name with
+  | Shell_dynamic -> classify_bash_tool input
+  | c -> c
+;;
+
+let tool_effect_class_of_string = function
+  | "read_only" -> Some Read_only
+  | "workspace" | "workspace_mutating" | "local_mutation" -> Some Local_mutation
+  | "external" | "external_effect" -> Some External_effect
+  | "shell_dynamic" -> Some Shell_dynamic
+  | _ -> None
+;;
+
+(* Backward-compatible alias *)
+let mutation_class_of_string = tool_effect_class_of_string
+
+(* ── Builtin descriptor derivation ─────────────────────────────── *)
+
+let effect_class_to_mutation_class = function
+  | Read_only -> "read_only"
+  | Local_mutation -> "local_mutation"
+  | External_effect -> "external_effect"
+  | Shell_dynamic -> "external_effect"
+;;
+
+let effect_class_to_concurrency_class = function
+  | Read_only -> Tool.Parallel_read
+  | Local_mutation -> Tool.Sequential_workspace
+  | External_effect | Shell_dynamic -> Tool.Exclusive_external
+;;
+
+let effect_class_to_permission = function
+  | Read_only -> Tool.ReadOnly
+  | Local_mutation -> Tool.Write
+  | External_effect | Shell_dynamic -> Tool.Destructive
+;;
+
+let builtin_descriptor name : Tool.descriptor option =
+  let key = String.lowercase_ascii name in
+  match Hashtbl.find_opt tool_registry key with
+  | None -> None
+  | Some cls ->
+    Some
+      { Tool.kind = Some "builtin"
+      ; mutation_class = Some (effect_class_to_mutation_class cls)
+      ; concurrency_class = Some (effect_class_to_concurrency_class cls)
+      ; permission = Some (effect_class_to_permission cls)
+      ; shell =
+          (if cls = Shell_dynamic
+           then
+             Some
+               { single_command_only = false
+               ; shell_metacharacters_allowed = true
+               ; chaining_allowed = true
+               ; redirection_allowed = true
+               ; pipes_allowed = true
+               ; workdir_policy = None
+               }
+           else None)
+      ; notes = []
+      ; examples = []
+      }
+;;
+
+let effective_class_with_hints ~tool_classifications tool_name input =
+  match List.assoc_opt tool_name tool_classifications with
+  | Some cls -> cls
+  | None -> effective_class tool_name input
+;;
+
+let all_read_only tools = List.for_all (fun name -> classify_tool name = Read_only) tools
+
+let all_workspace_only tools =
+  List.for_all
+    (fun name ->
+       match classify_tool name with
+       | Read_only | Local_mutation -> true
+       | External_effect | Shell_dynamic -> false)
+    tools
+;;
+
+(* ── Enforcement check ───────────────────────────────────────────── *)
+
+let truncate_input input = Util.clip (Yojson.Safe.to_string input) 200
+
+let evidence_effect_class_of_tool_class = function
+  | Read_only -> Effect_evidence.Read_only
+  | Local_mutation -> Effect_evidence.Local_mutation
+  | External_effect -> Effect_evidence.External_effect
+  | Shell_dynamic -> Effect_evidence.Shell_dynamic
+;;
+
+let violation_kind_for_class st cls =
+  match st.effective_mode, cls with
+  | Execution_mode.Diagnose, (Local_mutation | External_effect) ->
+    Some Mutating_in_diagnose
+  | Execution_mode.Draft, External_effect -> Some External_in_draft
+  | _ ->
+    if List.mem "workspace_only" st.allowed_mutations && cls = External_effect
+    then Some Scope_violation
+    else None
+;;
+
+let record_effect_evidence
+      st
+      ~tool_use_id
+      ~tool_name
+      ~input
+      ~turn
+      ~ts
+      ~effect_class
+      ~decision
+      ~result_status
+      ?violation_kind
+      ()
+  =
+  let violation_kind = Option.map violation_kind_to_string violation_kind in
+  let row =
+    Effect_evidence.make
+      ~tool_use_id
+      ~tool_name
+      ~effect_class:(evidence_effect_class_of_tool_class effect_class)
+      ~decision
+      ~decision_source:"mode_enforcer"
+      ~input
+      ~input_summary:(truncate_input input)
+      ~source_path:"lib/mode_enforcer.ml"
+      ~source_line:__LINE__
+      ~started_at:ts
+      ~ended_at:ts
+      ~result_status
+      ?violation_kind
+      ~turn
+      ~execution_mode:(Execution_mode.to_string st.effective_mode)
+      ()
+  in
+  st.effect_evidence <- row :: st.effect_evidence
+;;
+
+let check_violation st ~tool_use_id ~tool_name ~input ~turn =
+  let ts = Unix.gettimeofday () in
+  let cls =
+    effective_class_with_hints
+      ~tool_classifications:st.tool_classifications
+      tool_name
+      input
+  in
+  let kind = violation_kind_for_class st cls in
+  match kind with
+  | None ->
+    record_effect_evidence
+      st
+      ~tool_use_id
+      ~tool_name
+      ~input
+      ~turn
+      ~ts
+      ~effect_class:cls
+      ~decision:Effect_evidence.Allowed
+      ~result_status:Effect_evidence.Pending
+      ();
+    None
+  | Some violation_kind ->
+    let v =
+      { ts
+      ; tool_name
+      ; input_summary = truncate_input input
+      ; effective_mode = st.effective_mode
+      ; violation_kind
+      }
+    in
+    st.violations <- v :: st.violations;
+    record_effect_evidence
+      st
+      ~tool_use_id
+      ~tool_name
+      ~input
+      ~turn
+      ~ts
+      ~effect_class:cls
+      ~decision:Effect_evidence.Denied
+      ~result_status:Effect_evidence.Not_run
+      ~violation_kind
+      ();
+    Some v
+;;
+
+(* ── Hooks ───────────────────────────────────────────────────────── *)
+
+let hooks st =
+  let open Hooks in
+  { empty with
+    before_turn =
+      Some
+        (fun event ->
+          (match event with
+           | BeforeTurn { turn = 1; _ } ->
+             (match st.review_requirement, st.effective_mode with
+              | Some req, Execution_mode.Execute ->
+                st.review_warning
+                <- Some
+                     (Printf.sprintf
+                        "review_requirement '%s' active but running in Execute mode"
+                        req)
+              | _ -> ())
+           | _ -> ());
+          Continue)
+  ; pre_tool_use =
+      Some
+        (fun event ->
+          match event with
+          | PreToolUse { tool_use_id; tool_name; input; turn; _ } ->
+            (match check_violation st ~tool_use_id ~tool_name ~input ~turn with
+             | Some v ->
+               Format.eprintf
+                 "[mode_enforcer] SKIP tool=%s kind=%s mode=%s@."
+                 tool_name
+                 (violation_kind_to_string v.violation_kind)
+                 (Execution_mode.to_string v.effective_mode);
+               Skip
+             | None -> Continue)
+          | _ -> Continue)
+  ; after_turn =
+      Some
+        (fun event ->
+          (match event with
+           | AfterTurn { turn; response; _ } ->
+             (match response.Types.usage with
+              | Some u ->
+                let snap =
+                  { input_tokens = u.input_tokens
+                  ; output_tokens = u.output_tokens
+                  ; cost_usd = u.cost_usd
+                  ; turn
+                  }
+                in
+                st.token_snapshots <- snap :: st.token_snapshots
+              | None -> ())
+           | _ -> ());
+          Continue)
+  }
+;;
+
+(* ── Inline tests ──────────────────────────────────────────────── *)
+[@@@coverage off]
+
+let%test "builtin_descriptor returns Some for read-only tools" =
+  match builtin_descriptor "read" with
+  | Some d ->
+    d.mutation_class = Some "read_only"
+    && d.concurrency_class = Some Tool.Parallel_read
+    && d.permission = Some Tool.ReadOnly
+  | None -> false
+;;
+
+let%test "builtin_descriptor returns Some for mutation tools" =
+  match builtin_descriptor "edit" with
+  | Some d ->
+    d.mutation_class = Some "local_mutation"
+    && d.concurrency_class = Some Tool.Sequential_workspace
+    && d.permission = Some Tool.Write
+  | None -> false
+;;
+
+let%test "builtin_descriptor returns Some for external tools" =
+  match builtin_descriptor "web_fetch" with
+  | Some d ->
+    d.mutation_class = Some "external_effect"
+    && d.concurrency_class = Some Tool.Exclusive_external
+    && d.permission = Some Tool.Destructive
+  | None -> false
+;;
+
+let%test "builtin_descriptor returns Some for ask_user_question" =
+  match builtin_descriptor "ask_user_question" with
+  | Some d -> d.concurrency_class = Some Tool.Exclusive_external
+  | None -> false
+;;
+
+let%test "builtin_descriptor returns Some for task tools" =
+  match builtin_descriptor "task_list" with
+  | Some d -> d.concurrency_class = Some Tool.Parallel_read
+  | None -> false
+;;
+
+let%test "builtin_descriptor returns Some for task_create" =
+  match builtin_descriptor "task_create" with
+  | Some d -> d.concurrency_class = Some Tool.Sequential_workspace
+  | None -> false
+;;
+
+let%test "builtin_descriptor returns Some for shell tools" =
+  match builtin_descriptor "bash" with
+  | Some d -> d.mutation_class = Some "external_effect" && d.shell <> None
+  | None -> false
+;;
+
+let%test "builtin_descriptor returns None for unknown tools" =
+  builtin_descriptor "nonexistent_tool_xyz" = None
+;;
+
+let%test "register_tool_class extends registry" =
+  register_tool_class "my_custom_tool" Read_only;
+  match builtin_descriptor "my_custom_tool" with
+  | Some d -> d.mutation_class = Some "read_only"
+  | None -> false
+;;

--- a/lib/cdal_runtime/mode_enforcer.mli
+++ b/lib/cdal_runtime/mode_enforcer.mli
@@ -1,0 +1,104 @@
+(** Mode enforcement middleware for CDAL.
+
+    Creates hooks that block tool calls violating the effective execution mode.
+    Violations are recorded as evidence for the proof bundle.
+
+    Tool classification uses a descriptor-driven registry:
+    - Read_only: read, glob, grep, search, etc.
+    - Local_mutation: write, edit, create_text_file, etc.
+    - External_effect: mcp__*, unknown tools (fail closed)
+    - Shell_dynamic: bash, execute_shell_command (resolved via input analysis)
+
+    @stability Evolving
+    @since 0.93.1 *)
+
+type tool_effect_class =
+  | Read_only
+  | Local_mutation
+  | External_effect
+  | Shell_dynamic
+
+(** Backward-compatible alias for [tool_effect_class]. *)
+type mutation_class = tool_effect_class
+
+type violation_kind =
+  | Mutating_in_diagnose
+  | External_in_draft
+  | Scope_violation
+
+val violation_kind_to_string : violation_kind -> string
+val violation_kind_of_string : string -> (violation_kind, string) result
+val violation_kind_to_yojson : violation_kind -> Yojson.Safe.t
+val violation_kind_of_yojson : Yojson.Safe.t -> (violation_kind, string) result
+
+type violation =
+  { ts : float
+  ; tool_name : string
+  ; input_summary : string
+  ; effective_mode : Execution_mode.t
+  ; violation_kind : violation_kind
+  }
+
+(** Canonical JSON serialization for violation records.
+    Downstream consumers should use these instead of manual JSON parsing. *)
+val violation_to_yojson : violation -> Yojson.Safe.t
+
+val violation_of_yojson : Yojson.Safe.t -> (violation, string) result
+
+type token_snapshot =
+  { input_tokens : int
+  ; output_tokens : int
+  ; cost_usd : float option
+  ; turn : int
+  }
+
+type state
+
+val create
+  :  contract:Risk_contract.t
+  -> effective_mode:Execution_mode.t
+  -> ?tool_classifications:(string * tool_effect_class) list
+  -> unit
+  -> state
+
+(** Returns hooks that enforce mode constraints.
+    PreToolUse returns [Hooks.Skip] on violation. *)
+val hooks : state -> Hooks.hooks
+
+val violations : state -> violation list
+val token_snapshots : state -> token_snapshot list
+val review_warning : state -> string option
+
+(** Tool-effect decision evidence recorded for every PreToolUse decision,
+    including allowed attempts and denied/skipped attempts. *)
+val effect_evidence : state -> Effect_evidence.t list
+
+(** Classify a tool by name using the global registry.
+    Returns [Shell_dynamic] for bash/execute_shell_command.
+    Unknown tools default to [External_effect] (fail closed). *)
+val classify_tool : string -> tool_effect_class
+
+(** Register or override a tool classification in the global registry. *)
+val register_tool_class : string -> tool_effect_class -> unit
+
+(** Parse a [tool_effect_class] from a descriptor string.
+    Accepted values: "read_only", "workspace", "workspace_mutating",
+    "local_mutation", "external", "external_effect", "shell_dynamic". *)
+val tool_effect_class_of_string : string -> tool_effect_class option
+
+(** Backward-compatible alias for [tool_effect_class_of_string]. *)
+val mutation_class_of_string : string -> mutation_class option
+
+(** Derive a [Tool.descriptor] from the builtin registry for a given tool name.
+    Returns [None] for unknown tools.
+    Read-only tools get [Parallel_read], mutation tools get [Sequential_workspace],
+    external/shell tools get [Exclusive_external].
+    @since 0.104.0 *)
+val builtin_descriptor : string -> Tool.descriptor option
+
+(** Check if all tools in a list are read-only. *)
+val all_read_only : string list -> bool
+
+(** Check if all tools are at most local-mutation (no external effects).
+    [Shell_dynamic] tools are treated as potentially external. *)
+val all_workspace_only : string list -> bool

--- a/lib/cdal_runtime/mode_resolver.ml
+++ b/lib/cdal_runtime/mode_resolver.ml
@@ -1,0 +1,32 @@
+type decision =
+  { effective_mode : Execution_mode.t
+  ; source : string
+  }
+
+let min_mode a b = if Execution_mode.compare a b <= 0 then a else b
+
+let capability_cap (capabilities : Cdal_proof.capability_snapshot) =
+  if Mode_enforcer.all_read_only capabilities.tools
+  then Execution_mode.Diagnose
+  else if Mode_enforcer.all_workspace_only capabilities.tools
+  then Execution_mode.Draft
+  else Execution_mode.Execute
+;;
+
+let resolve ~requested ~risk_class ~capabilities =
+  match Risk_class.max_mode risk_class with
+  | None ->
+    Error
+      (Printf.sprintf
+         "risk class %s forbids all execution"
+         (Risk_class.to_string risk_class))
+  | Some risk_cap ->
+    let cap_limit = capability_cap capabilities in
+    let combined_cap = min_mode risk_cap cap_limit in
+    let effective = min_mode requested combined_cap in
+    if Execution_mode.equal effective requested
+    then Ok { effective_mode = effective; source = "passthrough" }
+    else if Execution_mode.compare cap_limit risk_cap < 0
+    then Ok { effective_mode = effective; source = "capability_limit" }
+    else Ok { effective_mode = effective; source = "risk_class_downgrade" }
+;;

--- a/lib/cdal_runtime/mode_resolver.mli
+++ b/lib/cdal_runtime/mode_resolver.mli
@@ -1,0 +1,22 @@
+(** Execution mode resolution -- deterministic downgrade logic.
+
+    Part of the Contract-Driven Agent Loop (CDAL) PoC-1.
+    Computes [effective_execution_mode] from [requested] + [risk_class]
+    + [capabilities]. Never upgrades beyond requested mode.
+
+    @stability Evolving
+    @since 0.93.1 *)
+
+type decision =
+  { effective_mode : Execution_mode.t
+  ; source : string
+  }
+
+(** Resolve the effective execution mode.
+    Returns [Error msg] when the risk class forbids all execution
+    (e.g., Critical risk). *)
+val resolve
+  :  requested:Execution_mode.t
+  -> risk_class:Risk_class.t
+  -> capabilities:Cdal_proof.capability_snapshot
+  -> (decision, string) result

--- a/lib/cdal_runtime/proof_capture.ml
+++ b/lib/cdal_runtime/proof_capture.ml
@@ -1,0 +1,302 @@
+type trace_entry =
+  { ts : float
+  ; tool_name : string
+  ; input : Yojson.Safe.t
+  ; tool_use_id : string
+  ; planned_index : int
+  ; batch_index : int
+  ; batch_size : int
+  ; concurrency_class : string
+  ; output : string option
+  ; error : string option
+  ; duration_ms : int option
+  }
+
+type pending_tool =
+  { start_ts : float
+  ; tool_use_id : string
+  ; tool_name : string
+  ; input : Yojson.Safe.t
+  ; planned_index : int
+  ; batch_index : int
+  ; batch_size : int
+  ; concurrency_class : string
+  }
+
+type state =
+  { run_id : string
+  ; store : Proof_store.config
+  ; contract : Risk_contract.t
+  ; mode_decision : Mode_resolver.decision
+  ; capability_snapshot : Cdal_proof.capability_snapshot
+  ; scope : string option
+  ; mutable started_at : float
+  ; mutable ended_at : float
+  ; mutable provider_snapshot : Cdal_proof.provider_snapshot
+  ; mutable pending_tool : pending_tool option
+  ; mutable trace_count : int
+  ; mutable enforcer : Mode_enforcer.state option
+  }
+
+let generate_run_id () =
+  let now = Unix.gettimeofday () in
+  let rand = Random.bits () land 0xFFFFFF in
+  Printf.sprintf "cdal-%d-%06x" (int_of_float (now *. 1000.0)) rand
+;;
+
+let create ~store ~contract ~mode_decision ~capability_snapshot ?scope () =
+  let run_id = generate_run_id () in
+  Proof_store.init_run store ~run_id;
+  { run_id
+  ; store
+  ; contract
+  ; mode_decision
+  ; capability_snapshot
+  ; scope
+  ; started_at = 0.0
+  ; ended_at = 0.0
+  ; provider_snapshot =
+      { provider_name = "unknown"; model_id = "unknown"; api_version = None }
+  ; pending_tool = None
+  ; trace_count = 0
+  ; enforcer = None
+  }
+;;
+
+let run_id st = st.run_id
+let set_enforcer st e = st.enforcer <- Some e
+
+let flush_trace st entry =
+  st.trace_count <- st.trace_count + 1;
+  let trace_id = Printf.sprintf "trace-%04d" st.trace_count in
+  let json =
+    `Assoc
+      [ "ts", `Float entry.ts
+      ; "tool_use_id", `String entry.tool_use_id
+      ; "tool_name", `String entry.tool_name
+      ; "input", entry.input
+      ; "planned_index", `Int entry.planned_index
+      ; "batch_index", `Int entry.batch_index
+      ; "batch_size", `Int entry.batch_size
+      ; "concurrency_class", `String entry.concurrency_class
+      ; ( "output"
+        , match entry.output with
+          | Some s -> `String s
+          | None -> `Null )
+      ; ( "error"
+        , match entry.error with
+          | Some s -> `String s
+          | None -> `Null )
+      ; ( "duration_ms"
+        , match entry.duration_ms with
+          | Some d -> `Int d
+          | None -> `Null )
+      ]
+  in
+  Proof_store.append_tool_trace st.store ~run_id:st.run_id ~trace_id json
+;;
+
+let complete_pending_tool st ~output ~error =
+  match st.pending_tool with
+  | None -> ()
+  | Some pending ->
+    let now = Unix.gettimeofday () in
+    let duration_ms = int_of_float ((now -. pending.start_ts) *. 1000.0) in
+    flush_trace
+      st
+      { ts = pending.start_ts
+      ; tool_use_id = pending.tool_use_id
+      ; tool_name = pending.tool_name
+      ; input = pending.input
+      ; planned_index = pending.planned_index
+      ; batch_index = pending.batch_index
+      ; batch_size = pending.batch_size
+      ; concurrency_class = pending.concurrency_class
+      ; output
+      ; error
+      ; duration_ms = Some duration_ms
+      };
+    st.pending_tool <- None
+;;
+
+let hooks st =
+  let open Hooks in
+  { before_turn =
+      Some
+        (fun event ->
+          (match event with
+           | BeforeTurn { turn = 1; _ } -> st.started_at <- Unix.gettimeofday ()
+           | BeforeTurn _ -> ()
+           | _ -> ());
+          Continue)
+  ; before_turn_params = None
+  ; after_turn =
+      Some
+        (fun event ->
+          (match event with
+           | AfterTurn { response; _ } ->
+             st.provider_snapshot
+             <- { provider_name =
+                    (match st.provider_snapshot.provider_name with
+                     | "unknown" -> "detected"
+                     | p -> p)
+                ; model_id = response.Types.model
+                ; api_version = None
+                }
+           | _ -> ());
+          Continue)
+  ; pre_tool_use =
+      Some
+        (fun event ->
+          (match event with
+           | PreToolUse { tool_use_id; tool_name; input; schedule; _ } ->
+             complete_pending_tool st ~output:None ~error:None;
+             st.pending_tool
+             <- Some
+                  { start_ts = Unix.gettimeofday ()
+                  ; tool_use_id
+                  ; tool_name
+                  ; input
+                  ; planned_index = schedule.planned_index
+                  ; batch_index = schedule.batch_index
+                  ; batch_size = schedule.batch_size
+                  ; concurrency_class = schedule.concurrency_class
+                  }
+           | _ -> ());
+          Continue)
+  ; post_tool_use =
+      Some
+        (fun event ->
+          (match event with
+           | PostToolUse { output; _ } ->
+             let output_str, error_str =
+               match output with
+               | Ok { Types.content; _ } -> Some content, None
+               | Error { Types.message; _ } -> None, Some message
+             in
+             complete_pending_tool st ~output:output_str ~error:error_str
+           | _ -> ());
+          Continue)
+  ; post_tool_use_failure =
+      Some
+        (fun event ->
+          (match event with
+           | PostToolUseFailure { error; _ } ->
+             complete_pending_tool st ~output:None ~error:(Some error)
+           | _ -> ());
+          Continue)
+  ; on_stop =
+      Some
+        (fun event ->
+          (match event with
+           | OnStop _ -> st.ended_at <- Unix.gettimeofday ()
+           | _ -> ());
+          Continue)
+  ; on_idle = None
+  ; on_idle_escalated = None
+  ; on_error =
+      Some
+        (fun event ->
+          (match event with
+           | OnError _ -> st.ended_at <- Unix.gettimeofday ()
+           | _ -> ());
+          Continue)
+  ; on_tool_error = None
+  ; pre_compact = None
+  ; post_compact = None
+  ; on_context_compacted = None
+  }
+;;
+
+let collect_evidence_refs st =
+  match st.enforcer with
+  | None -> []
+  | Some enforcer ->
+    let refs = ref [] in
+    let effects = Mode_enforcer.effect_evidence enforcer in
+    if effects <> []
+    then (
+      let json = `List (List.map Effect_evidence.to_json effects) in
+      Proof_store.write_evidence st.store ~run_id:st.run_id ~ref_id:"effects" json;
+      refs
+      := Proof_store.make_ref ~run_id:st.run_id ~subpath:"evidence/effects.json" :: !refs);
+    let violations = Mode_enforcer.violations enforcer in
+    if violations <> []
+    then (
+      let json = `List (List.map Mode_enforcer.violation_to_yojson violations) in
+      Proof_store.write_evidence st.store ~run_id:st.run_id ~ref_id:"mode_violations" json;
+      refs
+      := Proof_store.make_ref ~run_id:st.run_id ~subpath:"evidence/mode_violations.json"
+         :: !refs);
+    let snapshots = Mode_enforcer.token_snapshots enforcer in
+    if snapshots <> []
+    then (
+      let json =
+        `List
+          (List.map
+             (fun (s : Mode_enforcer.token_snapshot) ->
+                `Assoc
+                  [ "turn", `Int s.turn
+                  ; "input_tokens", `Int s.input_tokens
+                  ; "output_tokens", `Int s.output_tokens
+                  ; ( "cost_usd"
+                    , match s.cost_usd with
+                      | Some c -> `Float c
+                      | None -> `Null )
+                  ])
+             snapshots)
+      in
+      Proof_store.write_evidence st.store ~run_id:st.run_id ~ref_id:"token_usage" json;
+      refs
+      := Proof_store.make_ref ~run_id:st.run_id ~subpath:"evidence/token_usage.json"
+         :: !refs);
+    (match Mode_enforcer.review_warning enforcer with
+     | Some warning ->
+       let json =
+         `Assoc
+           [ "warning", `String warning
+           ; "effective_mode", Execution_mode.to_yojson st.mode_decision.effective_mode
+           ]
+       in
+       Proof_store.write_evidence st.store ~run_id:st.run_id ~ref_id:"review_warning" json;
+       refs
+       := Proof_store.make_ref ~run_id:st.run_id ~subpath:"evidence/review_warning.json"
+          :: !refs
+     | None -> ());
+    List.rev !refs
+;;
+
+let finalize st ~result_status =
+  complete_pending_tool st ~output:None ~error:None;
+  let now = Unix.gettimeofday () in
+  if st.started_at = 0.0 then st.started_at <- now;
+  if st.ended_at = 0.0 then st.ended_at <- now;
+  let tool_trace_refs =
+    List.init st.trace_count (fun i ->
+      Proof_store.make_ref
+        ~run_id:st.run_id
+        ~subpath:(Printf.sprintf "tool_traces/trace-%04d.jsonl" (i + 1)))
+  in
+  let proof : Cdal_proof.t =
+    { schema_version = Cdal_proof.schema_version_current
+    ; run_id = st.run_id
+    ; contract_id = Risk_contract.contract_id st.contract
+    ; requested_execution_mode = st.contract.runtime_constraints.requested_execution_mode
+    ; effective_execution_mode = st.mode_decision.effective_mode
+    ; mode_decision_source = st.mode_decision.source
+    ; risk_class = st.contract.runtime_constraints.risk_class
+    ; provider_snapshot = st.provider_snapshot
+    ; capability_snapshot = st.capability_snapshot
+    ; tool_trace_refs
+    ; raw_evidence_refs = collect_evidence_refs st
+    ; checkpoint_ref = None
+    ; result_status
+    ; started_at = st.started_at
+    ; ended_at = st.ended_at
+    ; scope = st.scope
+    }
+  in
+  Proof_store.write_manifest st.store ~run_id:st.run_id proof;
+  Proof_store.write_contract st.store ~run_id:st.run_id st.contract;
+  proof
+;;

--- a/lib/cdal_runtime/proof_capture.mli
+++ b/lib/cdal_runtime/proof_capture.mli
@@ -1,0 +1,35 @@
+(** Transparent proof capture middleware for CDAL.
+
+    Part of the Contract-Driven Agent Loop (CDAL) PoC-1.
+
+    Creates hooks that observe agent lifecycle events and accumulate
+    proof data. Agent code is completely unaware of proof capture.
+    Call [finalize] after agent run to write manifest and return proof.
+
+    @stability Evolving
+    @since 0.93.1 *)
+
+(** Opaque mutable accumulator. One per agent run, not shared. *)
+type state
+
+val create
+  :  store:Proof_store.config
+  -> contract:Risk_contract.t
+  -> mode_decision:Mode_resolver.decision
+  -> capability_snapshot:Cdal_proof.capability_snapshot
+  -> ?scope:string
+  -> unit
+  -> state
+
+(** Returns hooks that intercept lifecycle events for proof capture.
+    Compose with agent's existing hooks via [Hooks.compose]. *)
+val hooks : state -> Hooks.hooks
+
+(** Finalize: write manifest.json + contract.json to store,
+    return the assembled proof bundle. *)
+val finalize : state -> result_status:Cdal_proof.result_status -> Cdal_proof.t
+
+val run_id : state -> string
+
+(** Attach an enforcer state for evidence enrichment at finalize time. *)
+val set_enforcer : state -> Mode_enforcer.state -> unit

--- a/lib/cdal_runtime/proof_store.ml
+++ b/lib/cdal_runtime/proof_store.ml
@@ -1,0 +1,278 @@
+type config = { root : string }
+
+type resolved_ref =
+  { run_id : string
+  ; subpath : string
+  ; path : string
+  }
+
+open Result_syntax
+
+let default_config =
+  let home =
+    try Sys.getenv "HOME" with
+    | Not_found -> "/tmp"
+  in
+  { root = Filename.concat home ".oas" }
+;;
+
+let proofs_dir config = Filename.concat config.root "proofs"
+let run_dir config ~run_id = Filename.concat (proofs_dir config) run_id
+let traces_dir config ~run_id = Filename.concat (run_dir config ~run_id) "tool_traces"
+let evidence_dir config ~run_id = Filename.concat (run_dir config ~run_id) "evidence"
+
+let contract_path config ~run_id =
+  Filename.concat (run_dir config ~run_id) "contract.json"
+;;
+
+let manifest_path config ~run_id =
+  Filename.concat (run_dir config ~run_id) "manifest.json"
+;;
+
+let log_error context = function
+  | Ok () -> ()
+  | Error err -> Printf.eprintf "[proof_store] %s: %s\n%!" context (Error.to_string err)
+;;
+
+let init_run config ~run_id =
+  log_error "mkdir traces" (Fs_result.ensure_dir (traces_dir config ~run_id));
+  log_error "mkdir evidence" (Fs_result.ensure_dir (evidence_dir config ~run_id))
+;;
+
+let write_json context path json =
+  let content = Yojson.Safe.pretty_to_string json ^ "\n" in
+  log_error context (Fs_result.write_file path content)
+;;
+
+let write_manifest config ~run_id proof =
+  write_json "write manifest" (manifest_path config ~run_id) (Cdal_proof.to_json proof)
+;;
+
+let write_contract config ~run_id contract =
+  write_json
+    "write contract"
+    (contract_path config ~run_id)
+    (Risk_contract.to_yojson contract)
+;;
+
+let append_tool_trace config ~run_id ~trace_id json =
+  let path = Filename.concat (traces_dir config ~run_id) (trace_id ^ ".jsonl") in
+  let line = Yojson.Safe.to_string json ^ "\n" in
+  log_error "append trace" (Fs_result.append_file path line)
+;;
+
+let write_evidence config ~run_id ~ref_id json =
+  let path = Filename.concat (evidence_dir config ~run_id) (ref_id ^ ".json") in
+  write_json "write evidence" path json
+;;
+
+let make_ref ~run_id ~subpath = Printf.sprintf "proof-store://%s/%s" run_id subpath
+let ref_prefix = "proof-store://"
+let ref_prefix_len = String.length ref_prefix
+
+let validate_ref_run_id run_id =
+  if run_id = ""
+  then Error "artifact ref run_id is empty"
+  else if run_id = "." || run_id = ".."
+  then Error (Printf.sprintf "artifact ref has invalid run_id: %s" run_id)
+  else Ok ()
+;;
+
+let validate_ref_subpath subpath =
+  let segments = String.split_on_char '/' subpath in
+  if subpath = ""
+  then Error "artifact ref subpath is empty"
+  else if List.exists (fun seg -> seg = "" || seg = "." || seg = "..") segments
+  then Error (Printf.sprintf "artifact ref has invalid subpath: %s" subpath)
+  else Ok ()
+;;
+
+let resolve_ref config (ref_ : Cdal_proof.artifact_ref) =
+  let len = String.length ref_ in
+  if len <= ref_prefix_len || String.sub ref_ 0 ref_prefix_len <> ref_prefix
+  then Error (Printf.sprintf "invalid proof-store ref: %s" ref_)
+  else (
+    let rel = String.sub ref_ ref_prefix_len (len - ref_prefix_len) in
+    match String.index_opt rel '/' with
+    | None -> Error (Printf.sprintf "artifact ref missing subpath: %s" ref_)
+    | Some slash_idx ->
+      let run_id = String.sub rel 0 slash_idx in
+      let subpath = String.sub rel (slash_idx + 1) (String.length rel - slash_idx - 1) in
+      let* () = validate_ref_run_id run_id in
+      (match validate_ref_subpath subpath with
+       | Error _ as err -> err
+       | Ok () ->
+         Ok { run_id; subpath; path = Filename.concat (run_dir config ~run_id) subpath }))
+;;
+
+let read_json_path path =
+  let open Result in
+  let* content = Fs_result.read_file path |> map_error Error.to_string in
+  try Ok (Yojson.Safe.from_string content) with
+  | Yojson.Json_error msg -> Error (Printf.sprintf "JSON parse error in %s: %s" path msg)
+;;
+
+let read_json config ref_ =
+  let* resolved = resolve_ref config ref_ in
+  read_json_path resolved.path
+;;
+
+let read_jsonl config ref_ =
+  let* resolved = resolve_ref config ref_ in
+  let* content = Fs_result.read_file resolved.path |> Result.map_error Error.to_string in
+  let lines = String.split_on_char '\n' content in
+  let rec parse acc line_no = function
+    | [] -> Ok (List.rev acc)
+    | line :: rest when String.trim line = "" -> parse acc (line_no + 1) rest
+    | line :: rest ->
+      (try
+         let json = Yojson.Safe.from_string line in
+         parse (json :: acc) (line_no + 1) rest
+       with
+       | Yojson.Json_error msg ->
+         Error
+           (Printf.sprintf
+              "JSONL parse error in %s at line %d: %s"
+              resolved.path
+              line_no
+              msg))
+  in
+  parse [] 1 lines
+;;
+
+let load_manifest config ~run_id =
+  let path = manifest_path config ~run_id in
+  let* json = read_json_path path in
+  Cdal_proof.of_json json
+  |> Result.map_error (fun msg ->
+    Printf.sprintf "manifest decode error in %s: %s" path msg)
+  |> Result.map (fun proof -> proof, json)
+;;
+
+let load_contract config ~run_id =
+  let path = contract_path config ~run_id in
+  let* json = read_json_path path in
+  Risk_contract.of_yojson json
+  |> Result.map_error (fun msg ->
+    Printf.sprintf "contract decode error in %s: %s" path msg)
+  |> Result.map (fun contract -> contract, json)
+;;
+
+let list_runs config =
+  if not (Sys.file_exists (proofs_dir config))
+  then Ok []
+  else
+    Fs_result.read_dir (proofs_dir config)
+    |> Result.map_error Error.to_string
+    |> Result.map (fun entries ->
+      List.filter
+        (fun entry ->
+           try Sys.is_directory (run_dir config ~run_id:entry) with
+           | Sys_error _ -> false)
+        entries)
+;;
+
+(* ================================================================ *)
+(* Cross-run window support                                          *)
+(* ================================================================ *)
+
+type run_info =
+  { run_id : string
+  ; ended_at : float
+  ; schema_version : int
+  ; scope : string option
+  }
+
+type window_bounds =
+  { max_runs : int
+  ; max_bytes : int
+  }
+
+let default_window_bounds = { max_runs = 50; max_bytes = 50 * 1024 * 1024 }
+
+let list_runs_ordered config ?scope ?(bounds = default_window_bounds) () =
+  let* run_ids = list_runs config in
+  let infos = ref [] in
+  let errors = ref [] in
+  List.iter
+    (fun run_id ->
+       match load_manifest config ~run_id with
+       | Ok (proof, _json) ->
+         let matches_scope =
+           match scope with
+           | None -> true
+           | Some s -> proof.Cdal_proof.scope = Some s
+         in
+         if matches_scope
+         then
+           infos
+           := { run_id
+              ; ended_at = proof.Cdal_proof.ended_at
+              ; schema_version = proof.Cdal_proof.schema_version
+              ; scope = proof.Cdal_proof.scope
+              }
+              :: !infos
+       | Error msg -> errors := Printf.sprintf "run %s: %s" run_id msg :: !errors)
+    run_ids;
+  let sorted =
+    List.sort
+      (fun a b ->
+         let c = Float.compare a.ended_at b.ended_at in
+         if c <> 0 then c else String.compare a.run_id b.run_id)
+      !infos
+  in
+  if List.length sorted > bounds.max_runs
+  then
+    Error
+      (Printf.sprintf
+         "run count %d exceeds max_runs %d"
+         (List.length sorted)
+         bounds.max_runs)
+  else Ok (sorted, List.rev !errors)
+;;
+
+let load_window config ~run_ids ?(bounds = default_window_bounds) () =
+  if List.length run_ids > bounds.max_runs
+  then
+    Error
+      (Printf.sprintf
+         "run count %d exceeds max_runs %d"
+         (List.length run_ids)
+         bounds.max_runs)
+  else (
+    let loaded = ref [] in
+    let errors = ref [] in
+    let bytes_total = ref 0 in
+    let check_bytes () =
+      if !bytes_total > bounds.max_bytes
+      then
+        Some
+          (Printf.sprintf
+             "total bytes %d exceeds max_bytes %d"
+             !bytes_total
+             bounds.max_bytes)
+      else None
+    in
+    let rec process = function
+      | [] -> Ok ()
+      | run_id :: rest ->
+        (match check_bytes () with
+         | Some msg -> Error msg
+         | None ->
+           (match load_manifest config ~run_id with
+            | Ok (proof, json) ->
+              let json_str = Yojson.Safe.to_string json in
+              bytes_total := !bytes_total + String.length json_str;
+              (match check_bytes () with
+               | Some msg -> Error msg
+               | None ->
+                 loaded := (proof, json) :: !loaded;
+                 process rest)
+            | Error msg ->
+              errors := Printf.sprintf "run %s: %s" run_id msg :: !errors;
+              process rest))
+    in
+    match process run_ids with
+    | Error msg -> Error msg
+    | Ok () -> Ok (List.rev !loaded, List.rev !errors))
+;;

--- a/lib/cdal_runtime/proof_store.mli
+++ b/lib/cdal_runtime/proof_store.mli
@@ -1,0 +1,115 @@
+(** Local filesystem artifact store for CDAL proof bundles.
+
+    Part of the Contract-Driven Agent Loop (CDAL) PoC-1.
+    Stores proof manifests, contract snapshots, tool traces,
+    and evidence artifacts under [{root}/proofs/{run_id}/].
+
+    @stability Evolving
+    @since 0.93.1 *)
+
+type config = { root : string (** Default: [~/.oas] *) }
+
+type resolved_ref =
+  { run_id : string
+  ; subpath : string
+  ; path : string
+  }
+
+val default_config : config
+
+(** Create directory structure for a new run. *)
+val init_run : config -> run_id:string -> unit
+
+(** Write the 15-field proof manifest. *)
+val write_manifest : config -> run_id:string -> Cdal_proof.t -> unit
+
+(** Write the frozen contract snapshot. *)
+val write_contract : config -> run_id:string -> Risk_contract.t -> unit
+
+(** Append a single tool trace entry (JSONL). *)
+val append_tool_trace
+  :  config
+  -> run_id:string
+  -> trace_id:string
+  -> Yojson.Safe.t
+  -> unit
+
+(** Write a raw evidence artifact. *)
+val write_evidence : config -> run_id:string -> ref_id:string -> Yojson.Safe.t -> unit
+
+(** Construct a [proof-store://] artifact reference. *)
+val make_ref : run_id:string -> subpath:string -> Cdal_proof.artifact_ref
+
+(** Path to manifest.json for a run. *)
+val manifest_path : config -> run_id:string -> string
+
+(** Resolve a [proof-store://] artifact reference into its run-scoped path. *)
+val resolve_ref : config -> Cdal_proof.artifact_ref -> (resolved_ref, string) result
+
+(** Read a JSON artifact referenced by [proof-store://]. *)
+val read_json : config -> Cdal_proof.artifact_ref -> (Yojson.Safe.t, string) result
+
+(** Read a JSONL artifact referenced by [proof-store://]. *)
+val read_jsonl : config -> Cdal_proof.artifact_ref -> (Yojson.Safe.t list, string) result
+
+(** Load and decode a stored proof manifest by [run_id]. *)
+val load_manifest
+  :  config
+  -> run_id:string
+  -> (Cdal_proof.t * Yojson.Safe.t, string) result
+
+(** Load and decode a stored contract snapshot by [run_id]. *)
+val load_contract
+  :  config
+  -> run_id:string
+  -> (Risk_contract.t * Yojson.Safe.t, string) result
+
+(** List known proof-store run IDs. *)
+val list_runs : config -> (string list, string) result
+
+(** {1 Cross-run window support}
+
+    @since cross-run-temporal *)
+
+(** Run metadata for ordering and filtering. *)
+type run_info =
+  { run_id : string
+  ; ended_at : float
+  ; schema_version : int
+  ; scope : string option
+  }
+
+(** Resource bounds for cross-run queries. *)
+type window_bounds =
+  { max_runs : int
+  ; max_bytes : int
+  }
+
+val default_window_bounds : window_bounds
+
+(** List runs with metadata, ordered by [ended_at] ascending,
+    tie-broken by [run_id].
+    Corrupted manifests are excluded from the result and reported
+    in the second element of the tuple.
+    Returns [Error] when the number of matching runs exceeds
+    [bounds.max_runs].
+    @since cross-run-temporal *)
+val list_runs_ordered
+  :  config
+  -> ?scope:string
+  -> ?bounds:window_bounds
+  -> unit
+  -> (run_info list * string list, string) result
+
+(** Load manifests for a window of runs.
+    Readable runs are returned; unreadable runs are reported
+    in the second element of the tuple.
+    Returns [Error] when [run_ids] length exceeds [bounds.max_runs]
+    or when accumulated manifest bytes exceed [bounds.max_bytes].
+    @since cross-run-temporal *)
+val load_window
+  :  config
+  -> run_ids:string list
+  -> ?bounds:window_bounds
+  -> unit
+  -> ((Cdal_proof.t * Yojson.Safe.t) list * string list, string) result


### PR DESCRIPTION
## 요약

RFC-OAS-011 가장 큰 batch — **6 modules / 12 files / +2489 LoC**. mid+high deps. dune deps 변경 0건 (#14257 fix가 이미 covers).

## 이주 대상 (verbatim)

| 모듈 | LoC | 외부 CDAL 의존 |
|---|---|---|
| `mode_enforcer.ml/mli` | **598** + 104 | Execution_mode (B1), Effect_evidence (B1), Risk_contract (B3) |
| `mode_resolver.ml/mli` | 32 + 22 | Execution_mode (B1), Risk_class (B2), Cdal_proof (B3), **Mode_enforcer (B4 self)** |
| `contract_runner.ml/mli` | 137 + 33 | Cdal_proof (B3), Risk_contract (B3), Execution_mode (B1), **Mode_enforcer/Mode_resolver/Proof_capture/Proof_store (B4 self)** |
| `proof_capture.ml/mli` | 302 + 35 | Cdal_proof (B3), Risk_contract (B3), Execution_mode (B1), Effect_evidence (B1), **Mode_enforcer/Mode_resolver/Proof_store (B4 self)** |
| `proof_store.ml/mli` | 278 + 115 | Cdal_proof (B3), Risk_contract (B3) |
| `direct_evidence.ml/mli` | **757** + 76 | Conformance (B2) |

dune 자동으로 batch 내부 의존 그래프 (mode_enforcer → mode_resolver → proof_capture → contract_runner) 해결.

## 비-CDAL imports (#14257 fix가 covers)

- `contract_runner.ml`: `Agent.*`, `Tool.*`, `Tool_set.*`, `Hooks.*` → `agent_sdk` full + `-open Agent_sdk`
- `direct_evidence.ml`: `open Runtime` → `agent_sdk` full + `-open Agent_sdk`
- `proof_store.ml`: `open Result_syntax` → `agent_sdk.base` + `-open Agent_sdk_base`

**dune 변경 0건** — 사용자 hotfix #14257이 이미 `agent_sdk` full 추가 + `-open Agent_sdk` flag 추가 해놓음.

## #14257 hotfix 상속

| Fix | 효과 |
|---|---|
| `(include_subdirs no)` | parent `lib/dune`의 `(include_subdirs unqualified)`가 cdal_runtime 모듈을 *masc_mcp 본체에도* 흡수하던 충돌 차단 |
| `agent_sdk` full | `Guardrails_async`/`Runtime`/`Agent`/`Hooks`/`Tool_set`이 base 아닌 wrapped lib 안에 거주 |
| `-open Agent_sdk` flag | unqualified `Runtime`/`Agent` 등이 자동 해결 |

본 batch가 *최초로 이 fix들의 가치를 행사하는 PR* — `direct_evidence.ml`의 `open Runtime`, `contract_runner.ml`의 `Agent.tools` 등이 fix 없이는 빌드 실패.

## RFC-OAS-012 cleanup 예약

`mode_enforcer.ml`은 *RFC-OAS-009 v1의 정리 대상*인 코드를 *그대로* 들고 옴:
- `default_tool_entries` (46 builtin strings, line 85+)
- 글로벌 `classify_tool` (호출자 0건의 dead public API)
- `builtin_descriptor` (오스 측 PR-B/C로 호출처 끊었지만 함수 자체는 잔존)

이주 시 *그대로* 옮긴 이유: bisect-friendly 1:1 파일 매핑 보존 + RFC-OAS-012가 이주 *후* 정리 약속. 이주 도중에 cleanup 섞으면 git blame/혁신 history가 흐려짐.

## 의존 검증 (pre-copy)

```bash
$ rg -no '\b(Cdal_proof|Mode_enforcer|...|Sessions_proof)\b' \
     lib/{mode_enforcer,mode_resolver,contract_runner,proof_capture,proof_store,direct_evidence}.{ml,mli} | sort -u
# (B1, B2, B3, B4-self only — verified)
```

## RFC 시리즈 진행

| PR | 상태 |
|---|---|
| RFC docs + OAS-B/C/D #1480-1483 | MERGED |
| MM-1 #14247 (skel) | MERGED |
| MM-2-leaves #14248 (B1) | MERGED |
| MM-2-low #14253 (B2) | MERGED |
| MM-2-mid #14255 (B3) | MERGED |
| #14257 hotfix (include_subdirs no + open Agent_sdk) | MERGED |
| **MM-2-high (this) — B4** | OPEN, Draft |
| MM-2-top — B5 (audit, autonomy_*, sessions_proof) | TBD |
| MM-3-rewire | TBD |
| OAS-E + MM-4 | TBD |

## 위험 (2건)

| # | 위험 | 완화 |
|---|---|---|
| 1 | mode_enforcer.ml 598 LoC + 6 modules concurrent build — 한 batch에서 컴파일 에러 시 *어느 모듈*인지 식별 비용 | dune이 정확한 module-level error 출력. 의존 그래프상 leaf부터 컴파일 (mode_enforcer + proof_store + direct_evidence 먼저, 그 다음 mode_resolver, proof_capture, contract_runner) — 첫 깨지는 모듈이 leaf 결함 |
| 2 | direct_evidence가 `Conformance` (B2 ✓) 의존 — 단 `Conformance.X`가 cdal_runtime 안 self-resolve하는지 wrapper module 행동 | dune wrapped library default 동작: B2 PR #14253 머지 후 main에 `Masc_mcp_cdal_runtime.Conformance`가 등록. cdal_runtime 안 다른 모듈은 *unwrapped* 형태로 `Conformance.X` 직접 접근 (wrapped library 내부 alias). 검증: cdal_runtime/dune의 default `(wrapped true)`가 자동 alias 생성 |

## Test plan

- [ ] CI green — `cdal_runtime` 15 모듈 (B1+B2+B3+B4) 빌드 통과
- [ ] CodeRabbit/사람 리뷰 코멘트 대응
- [ ] `human-approved-ready` 라벨 부착 후 머지

🤖 Generated with [Claude Code](https://claude.com/claude-code)