### PR TITLE
fix(cdal_runtime): add unix lib dep — unblock conformance.ml

### DIFF
--- a/lib/cdal_runtime/dune
+++ b/lib/cdal_runtime/dune
@@ -36,6 +36,11 @@
   ; guardrail_llm.{ml,mli}.  The dune-package places guardrails_async
   ; in the wrapped [agent_sdk] library, not under agent_sdk.base.
   agent_sdk
+  ; unix is needed for [Unix.gettimeofday] in conformance.ml (added by
+  ; PR #14255 RFC-OAS-011 MM-2-mid B3).  Listed explicitly so dune
+  ; resolves the [Unix] module without requiring the consumer to open
+  ; it.
+  unix
   yojson
   ppx_deriving_yojson.runtime)
  ; Mirror agent_sdk's flag so migrated modules' `open Types` /


### PR DESCRIPTION
## Problem

PR #14255 (\`feat(cdal_runtime): migrate B3 — cdal_proof, risk_contract (RFC-OAS-011 MM-2-mid)\`) introduced \`lib/cdal_runtime/conformance.ml\` which calls \`Unix.gettimeofday\` at line 422 but did not list \`unix\` in the sublibrary's \`(libraries …)\` stanza. Main fails to build:

\`\`\`
File "lib/cdal_runtime/conformance.ml", line 422, characters 23-40:
Error: Unbound module Unix
\`\`\`

\`Unix.gettimeofday\` usage:

\`\`\`ocaml
; generated_at = Unix.gettimeofday ()
\`\`\`

## Fix (single file: \`lib/cdal_runtime/dune\`)

Add \`unix\` to \`(libraries)\`. \`+5 / -0\` (single dep + comment).

## Verification

\`\`\`
dune build --root . @check                              # clean (was failing on main)
dune exec test/test_keeper_health_probe.exe             # 3/3 pass (PR #14246 regression)
\`\`\`

## Recurrence note

This is the **third** sequential admin-merged blocker on \`lib/cdal_runtime/\` in 24h:

| # | PR | Layer | Failed CI signal |
|---|----|-------|------------------|
| 1 | #14246 (mine) | ocamlformat | \`ocamlformat-check\` (changed files only) |
| 2 | #14247 | dune \`(include_subdirs no)\` + \`Guardrails_async\` import | \`Build and Test\` |
| 3 | #14255 | \`Unix\` library missing | \`Build and Test\` |

Each round needed a hotfix PR. RFC-OAS-011 owners should add a local \`dune build --root . @check\` pre-push gate so the next layer (whatever it is) gets caught before merge. The \`agent_sdk\` full dep added in PR #14257 also still needs the architectural decision flagged in that PR's body (move \`Guardrails_async\` to \`agent_sdk.base\`, or qualify the references).

## Test plan

- [ ] CI \`Build and Test\` passes on this PR.
- [ ] Existing \`lib/cdal_runtime/\` modules continue to compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)