### PR TITLE
feat(monitoring): RFC-0049 PR-2.5 — Grafana dashboard for surface telemetry

### DIFF
--- a/docs/observability/dashboard-surface-metrics.md
+++ b/docs/observability/dashboard-surface-metrics.md
@@ -1,0 +1,73 @@
+# Dashboard Surface & Section Metrics
+
+> RFC-0049 telemetry foundation — companion to
+> `infrastructure/monitoring/grafana-dashboard-surface-dashboard.json`.
+
+## Counters
+
+| Counter | Labels | Description |
+|---|---|---|
+| `dashboard_surface_open_total` | `surface` | Top-level dashboard surface opens (cockpit, overview, monitoring, command, connectors, workspace, lab, code, logs). |
+| `dashboard_section_open_total` | `surface`, `section`, `redirected_from` | Section-level opens within a surface. `redirected_from` carries the original `<surface>:<section>` key when the route arrived via `CROSS_SURFACE_SECTION_REDIRECTS` or `SECTION_REDIRECTS`, otherwise `none`. |
+
+Aggregate-only. **No PII.** No operator label, session ID, or IP.
+
+## Producers
+
+| Layer | Module | Behavior |
+|---|---|---|
+| Client | `dashboard/src/lib/nav-telemetry.ts` | Subscribes to the `route` signal. Emits one event per unique `(surface, section)` transition; collapses identical re-emissions within 500 ms. |
+| Client → server | `POST /api/v1/dashboard/nav-event` | One JSON body per transition: `{ surface, section, redirected_from }`. Best-effort, no retry. |
+| Server | `lib/dashboard/dashboard_nav_event.ml` | Validates against the surface + section allowlist, then calls `Prometheus.inc_counter`. The body is discarded after the increment. |
+
+Counters are registered at module load (`let () = Prometheus.register_counter …`) so they exist in `/metrics` immediately on server start, even before the first request.
+
+## Consumers
+
+- **Grafana**: `infrastructure/monitoring/grafana-dashboard-surface-dashboard.json` — surface ranking, section ranking with direct/total split, redirect provenance table, total opens stat, rate timeseries.
+- **CLI report**: `scripts/dashboard-ia-usage.sh` — point-in-time Markdown report scraped from `/metrics`. No Prometheus dependency. Drives RFC-0048 PR-C deletion threshold decisions.
+
+## Key derived metric: "direct opens"
+
+The `redirected_from="none"` filter is the deletion-threshold metric per RFC-0048 §4.4. A section with high `Total` but low `Direct` is alive **only because of legacy bookmarks** — the redirect entry can stay in `CROSS_SURFACE_SECTION_REDIRECTS`/`SECTION_REDIRECTS`, but the section component itself can be deleted.
+
+PromQL pattern:
+
+```promql
+# Direct opens per (surface, section), last 7d
+sum by (surface, section) (
+  increase(dashboard_section_open_total{redirected_from="none"}[7d])
+)
+```
+
+## Cardinality bound
+
+```
+|surfaces|     × |sections|     × (|redirects| + 1)
+       9       ×        20      ×              4    ≈ 720 distinct label combinations
+```
+
+Far below any Prometheus practical limit. RFC-0049 §5.5 caps further growth: if cardinality crosses 10k, an opt-in flag is added. As of 2026-05, growth would require either new surfaces or new redirect sources, neither of which is in flight.
+
+## Failure modes
+
+| Symptom | Cause | What to do |
+|---|---|---|
+| `/metrics` shows zero `dashboard_surface_open_total` | Server has not seen any dashboard navigation since start, or PR-1 (#14245) not yet deployed | Open the dashboard and click around; if still zero, check `dashboard/src/main.ts` calls `startNavTelemetry()` |
+| `redirected_from` distribution off | URL leak — internal param escaped to URL, distorting counters from operator bookmarks | Run `dashboard/src/router.test.ts` regression cases (URL leak guards). Fix and ratchet down to clean counter |
+| Timeseries flat after a deploy | Either `route` signal listener detached, or `effect()` dispose triggered prematurely | Check `nav-telemetry.test.ts` "disposer stops further emissions" inversion. Verify HMR didn't double-mount the observer |
+| One specific section never registers | Section ID missing from `lib/dashboard/dashboard_nav_event.ml`'s `valid_sections` allowlist | Add to allowlist; the server returns 400 for unknown `(surface, section)` pairs and the client drops the event |
+
+## Out of scope (future work)
+
+- **Per-operator analytics**: aggregate-only by RFC-0049 §3 non-goal. Would require a session label and PII review.
+- **Dwell time / bounce rate**: deferred until a consumer asks. Adding now expands surface area without justification (RFC-0049 §3).
+- **A/B test routing**: not in scope — would require a treatment label and randomized assignment.
+
+## Related
+
+- RFC-0049 — `docs/rfc/RFC-0049-surface-telemetry-foundation.md`
+- RFC-0048 — `docs/rfc/RFC-0048-dashboard-ia-phase-2.md` (primary consumer)
+- PR-1 #14245 — telemetry foundation
+- PR-1.1 #14251 — ocamlformat follow-up
+- PR-2 #14256 — `scripts/dashboard-ia-usage.sh`

--- a/infrastructure/monitoring/README.md
+++ b/infrastructure/monitoring/README.md
@@ -15,6 +15,7 @@ Prometheus / Grafana files that live alongside the masc-mcp source so deployment
 | `goal-loop-observe-metrics.contract.json` | GOAL LOOP Observe | exporter contract | `docs/observability/goal-loop-observe-metrics.md` |
 | `keeper-turn-fsm-alerts.yml` | keeper turn FSM | alerts | `docs/observability/keeper-turn-fsm-metrics.md` |
 | `keeper-turn-fsm-slo.yml` | keeper turn FSM | recording rules | `docs/observability/keeper-turn-fsm-metrics.md` |
+| `grafana-dashboard-surface-dashboard.json` | dashboard IA | Grafana dashboard | `docs/observability/dashboard-surface-metrics.md` |
 
 ## Domains
 
@@ -33,6 +34,10 @@ signal.
 ### Cascade
 
 Tracks cascade-routing decisions inside `Oas_worker_named.cycle_loop`. Counters: `masc_cascade_strategy_decisions_total{cascade,strategy,kind}`, `masc_cascade_capacity_events_total{kind,key_type}`. State vocabulary: `ordered / filtered_empty / exhausted` (TLA+ `KeeperCascadeLifecycle`).
+
+### Dashboard IA
+
+Tracks dashboard surface and section opens to drive RFC-0048 IA Phase 2 deletion-threshold decisions. Counters: `dashboard_surface_open_total{surface}`, `dashboard_section_open_total{surface, section, redirected_from}`. The `redirected_from` label distinguishes direct opens from redirect-driven opens (legacy bookmarks) — only direct opens count toward RFC-0048 §4.4 hide/delete thresholds. Aggregate-only, no PII. Producer code: `lib/dashboard/dashboard_nav_event.ml`, `dashboard/src/lib/nav-telemetry.ts`. CLI consumer: `scripts/dashboard-ia-usage.sh`.
 
 ### Keeper turn FSM
 

--- a/infrastructure/monitoring/grafana-dashboard-surface-dashboard.json
+++ b/infrastructure/monitoring/grafana-dashboard-surface-dashboard.json
@@ -1,0 +1,282 @@
+{
+  "__meta": {
+    "purpose": "MASC dashboard IA — surface and section open counters (RFC-0049). Imports into Grafana 10+ via File → Import.",
+    "metrics": [
+      "dashboard_surface_open_total{surface}",
+      "dashboard_section_open_total{surface, section, redirected_from}"
+    ],
+    "companion_doc": "docs/observability/dashboard-surface-metrics.md",
+    "code_refs": [
+      "lib/dashboard/dashboard_nav_event.ml",
+      "dashboard/src/lib/nav-telemetry.ts",
+      "dashboard/src/router.ts",
+      "scripts/dashboard-ia-usage.sh"
+    ],
+    "consumed_by": [
+      "RFC-0048 PR-C deletion threshold report"
+    ]
+  },
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": { "type": "datasource", "uid": "grafana" },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "graphTooltip": 1,
+  "liveNow": false,
+  "panels": [
+    {
+      "type": "barchart",
+      "title": "Surface opens — last 7d",
+      "gridPos": { "x": 0, "y": 0, "w": 12, "h": 9 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "description": "Top-level surface openings in the last 7 days. Counter is cumulative since process start; this is the increase over the time range.",
+      "targets": [
+        {
+          "expr": "sum by (surface) (increase(dashboard_surface_open_total[7d]))",
+          "legendFormat": "{{surface}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "color": { "mode": "palette-classic" }
+        }
+      },
+      "options": {
+        "orientation": "horizontal",
+        "legend": { "displayMode": "list", "placement": "right", "showLegend": true },
+        "xTickLabelRotation": 0,
+        "showValue": "always"
+      }
+    },
+    {
+      "type": "barchart",
+      "title": "Section direct opens — last 7d (redirected_from=none)",
+      "gridPos": { "x": 12, "y": 0, "w": 12, "h": 9 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "description": "Direct opens are the deletion-threshold metric per RFC-0048 §4.4. Sections low on this chart are candidates for hide → soak → delete (RFC-0048 §4.2).",
+      "targets": [
+        {
+          "expr": "sum by (surface, section) (increase(dashboard_section_open_total{redirected_from=\"none\"}[7d]))",
+          "legendFormat": "{{surface}}:{{section}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "color": { "mode": "palette-classic" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "yellow", "value": 5 },
+              { "color": "green", "value": 20 }
+            ]
+          }
+        }
+      },
+      "options": {
+        "orientation": "horizontal",
+        "legend": { "displayMode": "list", "placement": "right", "showLegend": true },
+        "showValue": "always"
+      }
+    },
+    {
+      "type": "table",
+      "title": "Section ranking — direct vs total (last 7d)",
+      "gridPos": { "x": 0, "y": 9, "w": 24, "h": 11 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "description": "Direct opens drive RFC-0048 §4.4 thresholds. Total includes redirect-driven hits — large gap between Direct and Total means the section is alive only because of legacy bookmarks (the redirect can stay, the section component can be deleted).",
+      "targets": [
+        {
+          "expr": "sum by (surface, section) (increase(dashboard_section_open_total{redirected_from=\"none\"}[7d]))",
+          "legendFormat": "Direct",
+          "refId": "A",
+          "instant": true,
+          "format": "table"
+        },
+        {
+          "expr": "sum by (surface, section) (increase(dashboard_section_open_total[7d]))",
+          "legendFormat": "Total",
+          "refId": "B",
+          "instant": true,
+          "format": "table"
+        }
+      ],
+      "transformations": [
+        {
+          "id": "joinByField",
+          "options": { "byField": "section", "mode": "outer" }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": { "Time 1": true, "Time 2": true, "surface 2": true },
+            "renameByName": {
+              "surface 1": "Surface",
+              "section": "Section",
+              "Value #A": "Direct",
+              "Value #B": "Total"
+            }
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": { "align": "auto", "displayMode": "auto" }
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "Direct" },
+            "properties": [
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    { "color": "red", "value": null },
+                    { "color": "yellow", "value": 5 },
+                    { "color": "green", "value": 20 }
+                  ]
+                }
+              },
+              {
+                "id": "custom.cellOptions",
+                "value": { "type": "color-background" }
+              }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "sortBy": [{ "displayName": "Direct", "desc": false }]
+      }
+    },
+    {
+      "type": "table",
+      "title": "Redirect provenance — last 7d",
+      "gridPos": { "x": 0, "y": 20, "w": 24, "h": 9 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "description": "Sections reached only via redirect from a deleted/renamed ID. Each row is a legacy ID still in use somewhere (operator bookmark, external link, hardcoded reference). Removing the source ID requires an audit of these origins.",
+      "targets": [
+        {
+          "expr": "sum by (surface, section, redirected_from) (increase(dashboard_section_open_total{redirected_from!=\"none\"}[7d]))",
+          "legendFormat": "{{surface}}:{{section}} ← {{redirected_from}}",
+          "refId": "A",
+          "instant": true,
+          "format": "table"
+        }
+      ],
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": { "Time": true },
+            "renameByName": {
+              "surface": "Surface",
+              "section": "Section",
+              "redirected_from": "Redirected from",
+              "Value": "Opens"
+            }
+          }
+        }
+      ],
+      "options": {
+        "sortBy": [{ "displayName": "Opens", "desc": true }]
+      }
+    },
+    {
+      "type": "stat",
+      "title": "Total dashboard opens — last 7d",
+      "gridPos": { "x": 0, "y": 29, "w": 8, "h": 6 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "description": "Sanity check: how much dashboard activity is even happening. If this is near zero, RFC-0048 PR-C should not run — the data isn't dense enough to justify deletions.",
+      "targets": [
+        {
+          "expr": "sum(increase(dashboard_surface_open_total[7d]))",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "yellow", "value": 50 },
+              { "color": "green", "value": 200 }
+            ]
+          }
+        }
+      },
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Surface opens — rate over time",
+      "gridPos": { "x": 8, "y": 29, "w": 16, "h": 6 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "description": "Per-surface open rate. Useful to spot diurnal patterns and confirm telemetry is actually flowing — a flat line at zero means the client observer never fired (PR-1 not deployed, or hashchange listener broke).",
+      "targets": [
+        {
+          "expr": "sum by (surface) (rate(dashboard_surface_open_total[15m]))",
+          "legendFormat": "{{surface}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "color": { "mode": "palette-classic" }
+        }
+      },
+      "options": {
+        "legend": { "displayMode": "table", "placement": "right", "showLegend": true }
+      }
+    }
+  ],
+  "refresh": "5m",
+  "schemaVersion": 39,
+  "tags": ["masc", "dashboard", "ia", "rfc-0049"],
+  "templating": {
+    "list": [
+      {
+        "current": { "selected": false, "text": "Prometheus", "value": "Prometheus" },
+        "hide": 0,
+        "includeAll": false,
+        "label": "Datasource",
+        "multi": false,
+        "name": "DS_PROMETHEUS",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      }
+    ]
+  },
+  "time": { "from": "now-7d", "to": "now" },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "MASC Dashboard IA — Surface & Section",
+  "uid": "masc-dashboard-surface",
+  "version": 1,
+  "weekStart": ""
+}


### PR DESCRIPTION
## Summary

Grafana panel JSON + companion doc for the `dashboard_surface_open_total` / `dashboard_section_open_total` counters from RFC-0049 PR-1 (#14245). Slots into the existing `infrastructure/monitoring/` catalogue convention.

## Files

- `infrastructure/monitoring/grafana-dashboard-surface-dashboard.json` — 6 panels: surface bar (7d), section direct-opens bar with thresholds, section ranking table joining direct vs total, redirect provenance table, total-opens stat, surface rate timeseries.
- `docs/observability/dashboard-surface-metrics.md` — counter schema, producers, consumers, derived "direct opens" metric for RFC-0048 §4.4, cardinality bound (~720), failure modes.
- `infrastructure/monitoring/README.md` — added catalogue row + "Dashboard IA" Domains subsection following existing convention.

## Direct opens panel = deletion threshold

The bar chart filters `redirected_from="none"`. RFC-0048 §4.4 uses this exact filter to exclude redirect-driven hits from hide/delete decisions. Threshold bands: red (<5/week), yellow (5-20), green (>20).

## Out of scope

- No alert rules — counters are diagnostic, not SLO. Adding alerts before any IA deletion would be premature.
- No `--since=7d` wiring in `dashboard-ia-usage.sh` — needs PromQL backend, queued separately.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>