### PR TITLE
feat(cdal_runtime): migrate B5 — audit, autonomy_*, sessions_proof, guardrails, runtime_evidence (RFC-OAS-011 MM-2-top)

### DIFF
--- a/lib/cdal_runtime/audit.ml
+++ b/lib/cdal_runtime/audit.ml
@@ -1,0 +1,92 @@
+(** Audit trail — append-only log of policy decisions and agent actions.
+
+    Records every decision point evaluation, providing accountability
+    and transparency for agent behavior in a society.
+
+    @since 0.76.0 *)
+
+type entry =
+  { id : string
+  ; timestamp : float
+  ; agent_name : string
+  ; action : string
+  ; decision_point : Policy.decision_point option
+  ; verdict : Policy.verdict option
+  ; detail : Yojson.Safe.t
+  }
+
+type t =
+  { mutable entries : entry list
+  ; mutable size : int
+  ; max_entries : int option
+  }
+
+let create ?max_entries () = { entries = []; size = 0; max_entries }
+
+let record t entry =
+  t.entries <- entry :: t.entries;
+  t.size <- t.size + 1;
+  match t.max_entries with
+  | None -> ()
+  | Some max when t.size > max ->
+    t.entries <- List.filteri (fun i _ -> i < max) t.entries;
+    t.size <- max
+  | Some _ -> ()
+;;
+
+let record_decision t ~id ~agent_name ~action ~decision_point (d : Policy.decision) =
+  let entry : entry =
+    { id
+    ; timestamp = d.evaluated_at
+    ; agent_name
+    ; action
+    ; decision_point = Some decision_point
+    ; verdict = Some d.verdict
+    ; detail = Policy.decision_to_json d
+    }
+  in
+  record t entry
+;;
+
+let query t ?agent ?action ?since () =
+  t.entries
+  |> List.filter (fun e ->
+    (match agent with
+     | None -> true
+     | Some a -> e.agent_name = a)
+    && (match action with
+        | None -> true
+        | Some a -> e.action = a)
+    &&
+    match since with
+    | None -> true
+    | Some ts -> e.timestamp >= ts)
+;;
+
+let count t = t.size
+let latest t n = List.filteri (fun i _ -> i < n) t.entries
+
+let entry_to_json e =
+  let verdict_json =
+    match e.verdict with
+    | None -> `Null
+    | Some v -> `String (Policy.verdict_to_string v)
+  in
+  let dp_json =
+    match e.decision_point with
+    | None -> `Null
+    | Some dp -> `String (Policy.decision_point_to_string dp)
+  in
+  `Assoc
+    [ "id", `String e.id
+    ; "timestamp", `Float e.timestamp
+    ; "agent_name", `String e.agent_name
+    ; "action", `String e.action
+    ; "decision_point", dp_json
+    ; "verdict", verdict_json
+    ; "detail", e.detail
+    ]
+;;
+
+let entries_to_json entries = `List (List.map entry_to_json entries)
+let to_json t = entries_to_json t.entries

--- a/lib/cdal_runtime/audit.mli
+++ b/lib/cdal_runtime/audit.mli
@@ -1,0 +1,55 @@
+(** Audit trail — append-only log of policy decisions and agent actions.
+
+    Records every decision point evaluation, providing accountability
+    and transparency for agent behavior in a society.
+
+    @since 0.76.0
+
+    @stability Evolving
+    @since 0.93.1 *)
+
+(** {1 Audit entries} *)
+
+type entry =
+  { id : string
+  ; timestamp : float
+  ; agent_name : string
+  ; action : string
+  ; decision_point : Policy.decision_point option
+  ; verdict : Policy.verdict option
+  ; detail : Yojson.Safe.t
+  }
+
+(** {1 Audit log} *)
+
+type t
+
+(** Create an audit log with optional max capacity.
+    When capacity is exceeded, oldest entries are evicted. *)
+val create : ?max_entries:int -> unit -> t
+
+(** Record an entry. *)
+val record : t -> entry -> unit
+
+(** Record a structured [Policy.decision] as an audit entry.
+    The decision's lineage is stored in the [detail] field as JSON.
+    @since 0.99.2 *)
+val record_decision
+  :  t
+  -> id:string
+  -> agent_name:string
+  -> action:string
+  -> decision_point:Policy.decision_point
+  -> Policy.decision
+  -> unit
+
+(** {1 Queries} *)
+
+val query : t -> ?agent:string -> ?action:string -> ?since:float -> unit -> entry list
+val count : t -> int
+val latest : t -> int -> entry list
+
+(** {1 Export} *)
+
+val to_json : t -> Yojson.Safe.t
+val entries_to_json : entry list -> Yojson.Safe.t

--- a/lib/cdal_runtime/autonomy_diff_guard.ml
+++ b/lib/cdal_runtime/autonomy_diff_guard.ml
@@ -1,0 +1,410 @@
+(** Autonomy_diff_guard — pure unified-diff validation helper.
+
+    @since 0.92.1 *)
+
+type issue =
+  | Empty_patch
+  | Unsafe_path of string
+  | Outside_allowed_paths of string
+  | Banned_addition of
+      { path : string option
+      ; pattern : string
+      ; line : string
+      }
+
+type report =
+  { accepted : bool
+  ; touched_paths : string list
+  ; issues : issue list
+  }
+
+let default_banned_patterns =
+  [ "ptrace"; "mount("; "umount("; "reboot("; "shutdown("; "mkfs"; "rm -rf /" ]
+;;
+
+(* Normalize a command-ish string for matching:
+   - strip shell-style line comments (# to end of line) per line
+   - drop quote / backslash characters that don't change semantics for the
+     coarse substrings we care about
+   - collapse runs of ASCII whitespace to single spaces
+   - lowercase ASCII
+
+   This is intentionally cheap; it is a bypass-resistance layer, not a full
+   shell parser. The original line is still passed through to the issue
+   record so reviewers can see the verbatim source. *)
+let normalize_command s =
+  let buf = Buffer.create (String.length s) in
+  let in_comment = ref false in
+  String.iter
+    (fun c ->
+       if !in_comment
+       then (
+         if c = '\n'
+         then (
+           in_comment := false;
+           let len = Buffer.length buf in
+           if len > 0 && Buffer.nth buf (len - 1) <> ' ' then Buffer.add_char buf ' '))
+       else (
+         match c with
+         | '#' -> in_comment := true
+         | '\'' | '"' | '`' | '\\' -> ()
+         | ' ' | '\t' | '\n' | '\r' ->
+           let len = Buffer.length buf in
+           if len > 0 && Buffer.nth buf (len - 1) <> ' ' then Buffer.add_char buf ' '
+         | _ -> Buffer.add_char buf (Char.lowercase_ascii c)))
+    s;
+  String.trim (Buffer.contents buf)
+;;
+
+let show_issue = function
+  | Empty_patch -> "patch is empty or has no touched paths"
+  | Unsafe_path path -> Printf.sprintf "unsafe patch path: %s" path
+  | Outside_allowed_paths path ->
+    Printf.sprintf "patch touches path outside allowlist: %s" path
+  | Banned_addition { path; pattern; line } ->
+    let where = Option.value ~default:"<unknown>" path in
+    Printf.sprintf
+      "banned addition in %s matched %S: %s"
+      where
+      pattern
+      (Util.clip line 120)
+;;
+
+type allowed_spec =
+  | Exact of string
+  | Prefix of string
+
+let normalize_path raw =
+  let trimmed = String.trim raw in
+  let stripped =
+    if String.length trimmed >= 2
+    then (
+      let prefix = String.sub trimmed 0 2 in
+      if prefix = "a/" || prefix = "b/"
+      then String.sub trimmed 2 (String.length trimmed - 2)
+      else trimmed)
+    else trimmed
+  in
+  if stripped = "" || stripped = "/dev/null"
+  then Error (Unsafe_path raw)
+  else if String.get stripped 0 = '/'
+  then Error (Unsafe_path raw)
+  else (
+    let segments = String.split_on_char '/' stripped in
+    let rec loop acc = function
+      | [] -> Ok (String.concat "/" (List.rev acc))
+      | "" :: rest | "." :: rest -> loop acc rest
+      | ".." :: _ -> Error (Unsafe_path raw)
+      | seg :: rest -> loop (seg :: acc) rest
+    in
+    loop [] segments)
+;;
+
+let normalize_allowed_path raw =
+  let trimmed = String.trim raw in
+  let is_prefix =
+    String.length trimmed > 0 && trimmed.[String.length trimmed - 1] = '/'
+  in
+  match normalize_path trimmed with
+  | Ok path when is_prefix -> Ok (Prefix path)
+  | Ok path -> Ok (Exact path)
+  | Error issue -> Error issue
+;;
+
+let path_allowed specs path =
+  List.exists
+    (function
+      | Exact allowed -> allowed = path
+      | Prefix prefix ->
+        let with_sep = prefix ^ "/" in
+        path = prefix
+        || (String.length path > String.length with_sep
+            && String.sub path 0 (String.length with_sep) = with_sep))
+    specs
+;;
+
+let parse_path_token line prefix_len =
+  let remainder =
+    String.sub line prefix_len (String.length line - prefix_len) |> String.trim
+  in
+  match String.split_on_char '\t' remainder with
+  | token :: _ -> token
+  | [] -> remainder
+;;
+
+let parse_diff_git_path line =
+  let parts = String.split_on_char ' ' line in
+  match parts with
+  | "diff" :: "--git" :: old_path :: new_path :: _ ->
+    let pick = if new_path <> "/dev/null" then new_path else old_path in
+    normalize_path pick
+  | _ -> Error (Unsafe_path line)
+;;
+
+let add_unique items value = if List.mem value items then items else items @ [ value ]
+
+let validate_patch ~allowed_paths ?(banned_patterns = default_banned_patterns) patch =
+  let allowed_specs, setup_issues =
+    List.fold_left
+      (fun (specs, issues) raw ->
+         match normalize_allowed_path raw with
+         | Ok spec -> spec :: specs, issues
+         | Error issue -> specs, issue :: issues)
+      ([], [])
+      allowed_paths
+  in
+  let rec loop current_path touched issues = function
+    | [] -> current_path, touched, issues
+    | line :: rest when Util.contains_substring_ci ~haystack:line ~needle:"diff --git " ->
+      let current_path, touched, issues =
+        match parse_diff_git_path line with
+        | Ok path -> Some path, add_unique touched path, issues
+        | Error issue -> current_path, touched, issue :: issues
+      in
+      loop current_path touched issues rest
+    | line :: rest when Util.string_contains ~needle:"+++ " line ->
+      let token = parse_path_token line 4 in
+      let current_path, touched, issues =
+        if token = "/dev/null"
+        then current_path, touched, issues
+        else (
+          match normalize_path token with
+          | Ok path -> Some path, add_unique touched path, issues
+          | Error issue -> current_path, touched, issue :: issues)
+      in
+      loop current_path touched issues rest
+    | line :: rest when Util.string_contains ~needle:"--- " line ->
+      let token = parse_path_token line 4 in
+      let current_path, touched, issues =
+        if token = "/dev/null"
+        then current_path, touched, issues
+        else (
+          match normalize_path token with
+          | Ok path when current_path = None -> Some path, add_unique touched path, issues
+          | Ok _ -> current_path, touched, issues
+          | Error issue -> current_path, touched, issue :: issues)
+      in
+      loop current_path touched issues rest
+    | line :: rest
+      when String.length line > 0
+           && line.[0] = '+'
+           && not (Util.string_contains ~needle:"+++ " line) ->
+      (* Strip the leading '+' before normalization so comment-stripping
+         and whitespace-collapsing operate on the actual added content. *)
+      let added = String.sub line 1 (String.length line - 1) in
+      let normalized_line = normalize_command added in
+      let content_issues =
+        List.filter_map
+          (fun pattern ->
+             let normalized_pattern = normalize_command pattern in
+             if
+               normalized_pattern <> ""
+               && Util.contains_substring_ci
+                    ~haystack:normalized_line
+                    ~needle:normalized_pattern
+             then Some (Banned_addition { path = current_path; pattern; line })
+             else None)
+          banned_patterns
+      in
+      loop current_path touched (List.rev_append content_issues issues) rest
+    | _ :: rest -> loop current_path touched issues rest
+  in
+  let _, touched_paths, issues =
+    loop None [] setup_issues (String.split_on_char '\n' patch)
+  in
+  let allowlist_issues =
+    List.fold_left
+      (fun acc path ->
+         if path_allowed allowed_specs path
+         then acc
+         else Outside_allowed_paths path :: acc)
+      []
+      touched_paths
+  in
+  let issues = List.rev_append issues (List.rev allowlist_issues) in
+  let issues =
+    if String.trim patch = "" || touched_paths = [] then Empty_patch :: issues else issues
+  in
+  { accepted = issues = []; touched_paths; issues = List.rev issues }
+;;
+
+[@@@coverage off]
+(* === Inline tests === *)
+
+let sample_patch =
+  String.concat
+    "\n"
+    [ "diff --git a/lib/foo.ml b/lib/foo.ml"
+    ; "--- a/lib/foo.ml"
+    ; "+++ b/lib/foo.ml"
+    ; "@@"
+    ; "+let answer = 42"
+    ; ""
+    ]
+;;
+
+let%test "validate_patch accepts allowlisted file" =
+  let report = validate_patch ~allowed_paths:[ "lib/" ] sample_patch in
+  report.accepted && report.touched_paths = [ "lib/foo.ml" ]
+;;
+
+let%test "validate_patch rejects outside allowlist" =
+  let report = validate_patch ~allowed_paths:[ "test/" ] sample_patch in
+  (not report.accepted)
+  && List.exists
+       (function
+         | Outside_allowed_paths "lib/foo.ml" -> true
+         | _ -> false)
+       report.issues
+;;
+
+let%test "validate_patch rejects parent traversal" =
+  let patch =
+    String.concat
+      "\n"
+      [ "diff --git a/../secret.txt b/../secret.txt"
+      ; "--- a/../secret.txt"
+      ; "+++ b/../secret.txt"
+      ; "@@"
+      ; "+oops"
+      ]
+  in
+  let report = validate_patch ~allowed_paths:[ "lib/" ] patch in
+  (not report.accepted)
+  && List.exists
+       (function
+         | Unsafe_path _ -> true
+         | _ -> false)
+       report.issues
+;;
+
+let%test "validate_patch rejects banned addition" =
+  let patch =
+    String.concat
+      "\n"
+      [ "diff --git a/lib/foo.ml b/lib/foo.ml"
+      ; "--- a/lib/foo.ml"
+      ; "+++ b/lib/foo.ml"
+      ; "@@"
+      ; "+let _ = ptrace ()"
+      ]
+  in
+  let report = validate_patch ~allowed_paths:[ "lib/" ] patch in
+  (not report.accepted)
+  && List.exists
+       (function
+         | Banned_addition { pattern = "ptrace"; _ } -> true
+         | _ -> false)
+       report.issues
+;;
+
+let%test "validate_patch allows deletion when file is allowlisted" =
+  let patch =
+    String.concat
+      "\n"
+      [ "diff --git a/lib/foo.ml b/lib/foo.ml"
+      ; "--- a/lib/foo.ml"
+      ; "+++ /dev/null"
+      ; "@@"
+      ; "-let answer = 42"
+      ]
+  in
+  let report = validate_patch ~allowed_paths:[ "lib/" ] patch in
+  report.accepted && report.touched_paths = [ "lib/foo.ml" ]
+;;
+
+let%test "validate_patch rejects empty patch" =
+  let report = validate_patch ~allowed_paths:[ "lib/" ] "" in
+  (not report.accepted)
+  && List.exists
+       (function
+         | Empty_patch -> true
+         | _ -> false)
+       report.issues
+;;
+
+(* === Bypass-resistance tests (Tier C C-4) ===
+
+   Each helper builds a minimal patch with [added_line] as the added
+   content; we then assert whether the matcher catches a [rm -rf /]
+   class addition. *)
+
+let make_addition_patch added_line =
+  String.concat
+    "\n"
+    [ "diff --git a/lib/foo.ml b/lib/foo.ml"
+    ; "--- a/lib/foo.ml"
+    ; "+++ b/lib/foo.ml"
+    ; "@@"
+    ; "+" ^ added_line
+    ]
+;;
+
+let has_banned_rm_rf report =
+  List.exists
+    (function
+      | Banned_addition { pattern = "rm -rf /"; _ } -> true
+      | _ -> false)
+    report.issues
+;;
+
+let%test "normalize catches double-whitespace bypass" =
+  let patch = make_addition_patch "rm  -rf /" in
+  let report = validate_patch ~allowed_paths:[ "lib/" ] patch in
+  has_banned_rm_rf report
+;;
+
+let%test "normalize catches backslash-escape bypass" =
+  let patch = make_addition_patch {|r\m -rf /|} in
+  let report = validate_patch ~allowed_paths:[ "lib/" ] patch in
+  has_banned_rm_rf report
+;;
+
+let%test "normalize catches surrounding-whitespace bypass" =
+  let patch = make_addition_patch "  rm   -rf  /  " in
+  let report = validate_patch ~allowed_paths:[ "lib/" ] patch in
+  has_banned_rm_rf report
+;;
+
+let%test "normalize catches uppercase bypass" =
+  let patch = make_addition_patch "RM -RF /" in
+  let report = validate_patch ~allowed_paths:[ "lib/" ] patch in
+  has_banned_rm_rf report
+;;
+
+let%test "normalize catches per-token quoting bypass" =
+  let patch = make_addition_patch {|'rm' '-rf' '/'|} in
+  let report = validate_patch ~allowed_paths:[ "lib/" ] patch in
+  has_banned_rm_rf report
+;;
+
+let%test "normalize catches pre-comment dangerous content" =
+  (* semicolon-separated: dangerous part is BEFORE the comment, must match *)
+  let patch = make_addition_patch "echo hello; rm -rf /" in
+  let report = validate_patch ~allowed_paths:[ "lib/" ] patch in
+  has_banned_rm_rf report
+;;
+
+let%test "normalize ignores content inside line comment" =
+  (* the dangerous text is after [#] so it's a comment, not executed.
+     Per audit, this must NOT trigger. *)
+  let patch = make_addition_patch "echo hello # rm -rf /" in
+  let report = validate_patch ~allowed_paths:[ "lib/" ] patch in
+  not (has_banned_rm_rf report)
+;;
+
+let%test "normalize still flags mount(" =
+  let patch = make_addition_patch "let _ = mount(something)" in
+  let report = validate_patch ~allowed_paths:[ "lib/" ] patch in
+  List.exists
+    (function
+      | Banned_addition { pattern = "mount("; _ } -> true
+      | _ -> false)
+    report.issues
+;;
+
+let%test "normalize keeps benign line accepted" =
+  let patch = make_addition_patch "let answer = 42" in
+  let report = validate_patch ~allowed_paths:[ "lib/" ] patch in
+  report.accepted
+;;

--- a/lib/cdal_runtime/autonomy_diff_guard.mli
+++ b/lib/cdal_runtime/autonomy_diff_guard.mli
@@ -1,0 +1,35 @@
+(** Autonomy_diff_guard — pure unified-diff validation helper.
+
+    This module does not apply or revert patches. It only validates whether
+    a patch stays within explicit file boundaries and whether added lines
+    contain banned patterns.
+
+    @since 0.92.1
+
+    @stability Evolving
+    @since 0.93.1 *)
+
+type issue =
+  | Empty_patch
+  | Unsafe_path of string
+  | Outside_allowed_paths of string
+  | Banned_addition of
+      { path : string option
+      ; pattern : string
+      ; line : string
+      }
+
+type report =
+  { accepted : bool
+  ; touched_paths : string list
+  ; issues : issue list
+  }
+
+val default_banned_patterns : string list
+val show_issue : issue -> string
+
+val validate_patch
+  :  allowed_paths:string list
+  -> ?banned_patterns:string list
+  -> string
+  -> report

--- a/lib/cdal_runtime/autonomy_exec.ml
+++ b/lib/cdal_runtime/autonomy_exec.ml
@@ -1,0 +1,458 @@
+(** Autonomy_exec — external execution primitive for autonomy loops.
+
+    This module is intentionally orchestration-agnostic. Consumers supply
+    the command argv, timeout, and optional sandbox/container wrapper.
+
+    @since 0.92.1 *)
+
+type backend =
+  | Direct
+  | Argv_prefix of string list
+
+type kill_scope =
+  | Single_process
+  | Process_group
+
+type config =
+  { backend : backend
+  ; cwd : string option
+  ; env_allowlist : string list
+  ; extra_env : (string * string) list
+  ; stdout_limit_bytes : int
+  ; stderr_limit_bytes : int
+  ; kill_scope : kill_scope
+  }
+
+let default_env_allowlist = [ "PATH"; "HOME"; "TMPDIR"; "LANG"; "LC_ALL"; "LC_CTYPE" ]
+
+let default_config =
+  { backend = Direct
+  ; cwd = None
+  ; env_allowlist = default_env_allowlist
+  ; extra_env = []
+  ; stdout_limit_bytes = 256 * 1024
+  ; stderr_limit_bytes = 64 * 1024
+  ; kill_scope = Single_process
+  }
+;;
+
+type exit_status =
+  | Exit_code of int
+  | Exit_signal of int
+  | Timed_out of int option
+
+type output =
+  { effective_argv : string list
+  ; status : exit_status
+  ; stdout : string
+  ; stderr : string
+  ; stdout_truncated : bool
+  ; stderr_truncated : bool
+  ; elapsed_s : float
+  }
+
+type capture =
+  { text : string
+  ; truncated : bool
+  }
+
+open Result_syntax
+
+let argv_to_string argv = String.concat " " (List.map Filename.quote argv)
+
+let status_to_string = function
+  | Exit_code code -> Printf.sprintf "exit(%d)" code
+  | Exit_signal signal -> Printf.sprintf "signal(%d)" signal
+  | Timed_out None -> "timed_out"
+  | Timed_out (Some signal) -> Printf.sprintf "timed_out(signal=%d)" signal
+;;
+
+let invalid_config field detail = Error.Config (Error.InvalidConfig { field; detail })
+let file_op_error ~op ~path ~detail = Error.Io (Error.FileOpFailed { op; path; detail })
+
+let validate_config config argv =
+  match argv with
+  | [] -> Error (invalid_config "argv" "command argv must not be empty")
+  | _ when config.stdout_limit_bytes <= 0 ->
+    Error (invalid_config "stdout_limit_bytes" "must be > 0")
+  | _ when config.stderr_limit_bytes <= 0 ->
+    Error (invalid_config "stderr_limit_bytes" "must be > 0")
+  | _ when config.kill_scope = Process_group && config.backend = Direct ->
+    Error
+      (invalid_config
+         "kill_scope"
+         "Process_group requires an Argv_prefix wrapper that creates a dedicated process \
+          group")
+  | _ ->
+    (match config.backend with
+     | Argv_prefix [] ->
+       Error (invalid_config "backend" "Argv_prefix wrapper must not be empty")
+     | _ -> Ok ())
+;;
+
+let effective_argv ~config ~argv =
+  let* () = validate_config config argv in
+  let cwd_wrapper =
+    match config.cwd with
+    | None -> []
+    | Some cwd when String.trim cwd = "" -> []
+    | Some cwd -> [ "/usr/bin/env"; "-C"; cwd ]
+  in
+  let prefix =
+    match config.backend with
+    | Direct -> []
+    | Argv_prefix items -> items
+  in
+  Ok (prefix @ cwd_wrapper @ argv)
+;;
+
+let split_env_entry entry =
+  match String.index_opt entry '=' with
+  | None -> None
+  | Some idx ->
+    let key = String.sub entry 0 idx in
+    let value = String.sub entry (idx + 1) (String.length entry - idx - 1) in
+    Some (key, value)
+;;
+
+let build_env ~config =
+  let table = Hashtbl.create 16 in
+  let allow key = List.mem key config.env_allowlist in
+  Array.iter
+    (fun entry ->
+       match split_env_entry entry with
+       | Some (key, value) when allow key -> Hashtbl.replace table key value
+       | _ -> ())
+    (Unix.environment ());
+  List.iter (fun (key, value) -> Hashtbl.replace table key value) config.extra_env;
+  Hashtbl.to_seq table
+  |> List.of_seq
+  |> List.sort (fun (ka, _) (kb, _) -> String.compare ka kb)
+  |> List.map (fun (key, value) -> key ^ "=" ^ value)
+  |> Array.of_list
+;;
+
+let status_of_unix_status = function
+  | Unix.WEXITED code -> Exit_code code
+  | Unix.WSIGNALED signal -> Exit_signal signal
+  | Unix.WSTOPPED signal -> Exit_signal signal
+;;
+
+let drain_fd ~limit fd =
+  let buf = Bytes.create 4096 in
+  let out = Buffer.create (min limit 4096) in
+  let truncated = ref false in
+  let rec loop () =
+    try
+      match Unix.read fd buf 0 (Bytes.length buf) with
+      | 0 -> ()
+      | read ->
+        let remaining = limit - Buffer.length out in
+        if remaining > 0
+        then (
+          let keep = min read remaining in
+          Buffer.add_string out (Bytes.sub_string buf 0 keep);
+          if keep < read then truncated := true)
+        else truncated := true;
+        loop ()
+    with
+    | Unix.Unix_error ((Unix.EAGAIN | Unix.EWOULDBLOCK | Unix.EINTR), _, _) ->
+      Eio_unix.await_readable fd;
+      loop ()
+  in
+  Fun.protect
+    ~finally:(fun () ->
+      try Unix.close fd with
+      | Unix.Unix_error _ -> ())
+    (fun () ->
+       loop ();
+       { text = Buffer.contents out; truncated = !truncated })
+;;
+
+let kill_child config pid =
+  let target =
+    match config.kill_scope with
+    | Single_process -> pid
+    | Process_group -> -pid
+  in
+  try Unix.kill target Sys.sigkill with
+  | Unix.Unix_error ((Unix.ESRCH | Unix.EPERM), _, _) -> ()
+;;
+
+let spawn_child config effective =
+  let stdin_fd = Unix.openfile "/dev/null" [ Unix.O_RDONLY ] 0 in
+  let stdout_r, stdout_w = Unix.pipe () in
+  let stderr_r, stderr_w = Unix.pipe () in
+  let close_quietly fd =
+    try Unix.close fd with
+    | Unix.Unix_error _ -> ()
+  in
+  try
+    Unix.set_nonblock stdout_r;
+    Unix.set_nonblock stderr_r;
+    let env = build_env ~config in
+    let exec = List.hd effective in
+    let pid =
+      Unix.create_process_env
+        exec
+        (Array.of_list effective)
+        env
+        stdin_fd
+        stdout_w
+        stderr_w
+    in
+    close_quietly stdin_fd;
+    close_quietly stdout_w;
+    close_quietly stderr_w;
+    Ok (pid, stdout_r, stderr_r)
+  with
+  | Unix.Unix_error (err, fn, arg) ->
+    close_quietly stdin_fd;
+    close_quietly stdout_r;
+    close_quietly stdout_w;
+    close_quietly stderr_r;
+    close_quietly stderr_w;
+    Error
+      (file_op_error
+         ~op:"spawn"
+         ~path:(argv_to_string effective)
+         ~detail:(Printf.sprintf "%s(%s): %s" fn arg (Unix.error_message err)))
+;;
+
+let spawn_result_promise ~sw fn =
+  let promise, resolver = Eio.Promise.create () in
+  Eio.Fiber.fork ~sw (fun () ->
+    let result =
+      try Ok (fn ()) with
+      | exn -> Error exn
+    in
+    Eio.Promise.resolve resolver result);
+  promise
+;;
+
+let await_result promise map_exn =
+  match Eio.Promise.await promise with
+  | Ok value -> Ok value
+  | Error (Eio.Cancel.Cancelled _ as exn) -> raise exn
+  | Error exn -> Error (map_exn exn)
+;;
+
+let run ~sw ~clock ~config ~argv ~timeout_s =
+  let t0 = Unix.gettimeofday () in
+  let* effective = effective_argv ~config ~argv in
+  let* pid, stdout_r, stderr_r = spawn_child config effective in
+  let close_quietly fd =
+    try Unix.close fd with
+    | Unix.Unix_error _ -> ()
+  in
+  let stdout_reader_started = ref false in
+  let stderr_reader_started = ref false in
+  let completed = ref false in
+  Fun.protect
+    ~finally:(fun () ->
+      if not !completed
+      then (
+        kill_child config pid;
+        if not !stdout_reader_started then close_quietly stdout_r;
+        if not !stderr_reader_started then close_quietly stderr_r))
+    (fun () ->
+       let wait_promise =
+         spawn_result_promise ~sw (fun () ->
+           Eio_unix.run_in_systhread ~label:"autonomy-exec-waitpid" (fun () ->
+             snd (Unix.waitpid [] pid)))
+       in
+       stdout_reader_started := true;
+       let stdout_promise =
+         spawn_result_promise ~sw (fun () ->
+           drain_fd ~limit:config.stdout_limit_bytes stdout_r)
+       in
+       stderr_reader_started := true;
+       let stderr_promise =
+         spawn_result_promise ~sw (fun () ->
+           drain_fd ~limit:config.stderr_limit_bytes stderr_r)
+       in
+       let capture_and_finish status =
+         let* stdout_capture =
+           await_result stdout_promise (fun exn ->
+             file_op_error ~op:"read" ~path:"stdout" ~detail:(Printexc.to_string exn))
+         in
+         let* stderr_capture =
+           await_result stderr_promise (fun exn ->
+             file_op_error ~op:"read" ~path:"stderr" ~detail:(Printexc.to_string exn))
+         in
+         Ok
+           { effective_argv = effective
+           ; status
+           ; stdout = stdout_capture.text
+           ; stderr = stderr_capture.text
+           ; stdout_truncated = stdout_capture.truncated
+           ; stderr_truncated = stderr_capture.truncated
+           ; elapsed_s = Unix.gettimeofday () -. t0
+           }
+       in
+       try
+         let* unix_status =
+           Eio.Time.with_timeout_exn clock timeout_s (fun () ->
+             await_result wait_promise (fun exn ->
+               file_op_error
+                 ~op:"waitpid"
+                 ~path:(string_of_int pid)
+                 ~detail:(Printexc.to_string exn)))
+         in
+         let result = capture_and_finish (status_of_unix_status unix_status) in
+         completed := true;
+         result
+       with
+       | Eio.Time.Timeout ->
+         kill_child config pid;
+         let timed_out_signal =
+           match
+             await_result wait_promise (fun exn ->
+               file_op_error
+                 ~op:"waitpid"
+                 ~path:(string_of_int pid)
+                 ~detail:(Printexc.to_string exn))
+           with
+           | Ok (Unix.WSIGNALED signal | Unix.WSTOPPED signal) -> Some signal
+           | Ok (Unix.WEXITED _) -> None
+           | Error _ -> None
+         in
+         let result = capture_and_finish (Timed_out timed_out_signal) in
+         completed := true;
+         result
+       | Eio.Cancel.Cancelled _ as exn -> raise exn)
+;;
+
+[@@@coverage off]
+(* === Inline tests === *)
+
+let with_eio f =
+  Eio_main.run @@ fun env -> Eio.Switch.run @@ fun sw -> f ~sw ~clock:env#clock
+;;
+
+let%test "effective_argv direct preserves argv" =
+  match effective_argv ~config:default_config ~argv:[ "cmd"; "--flag" ] with
+  | Ok argv -> argv = [ "cmd"; "--flag" ]
+  | Error _ -> false
+;;
+
+let%test "effective_argv adds cwd wrapper and backend prefix" =
+  let config =
+    { default_config with
+      backend = Argv_prefix [ "docker"; "run"; "--rm" ]
+    ; cwd = Some "/tmp/work"
+    }
+  in
+  match effective_argv ~config ~argv:[ "tool"; "arg" ] with
+  | Ok argv ->
+    argv = [ "docker"; "run"; "--rm"; "/usr/bin/env"; "-C"; "/tmp/work"; "tool"; "arg" ]
+  | Error _ -> false
+;;
+
+let%test "effective_argv rejects process group without wrapper" =
+  let config = { default_config with kill_scope = Process_group } in
+  match effective_argv ~config ~argv:[ "cmd" ] with
+  | Error (Error.Config (Error.InvalidConfig { field = "kill_scope"; _ })) -> true
+  | _ -> false
+;;
+
+let%test "build_env keeps allowlisted variables and overrides" =
+  Unix.putenv "AUTONOMY_EXEC_TEST_KEEP" "keep";
+  Unix.putenv "AUTONOMY_EXEC_TEST_DROP" "drop";
+  let env =
+    build_env
+      ~config:
+        { default_config with
+          env_allowlist = [ "AUTONOMY_EXEC_TEST_KEEP" ]
+        ; extra_env = [ "AUTONOMY_EXEC_TEST_KEEP", "override"; "EXTRA_ONLY", "yes" ]
+        }
+    |> Array.to_list
+  in
+  List.mem "AUTONOMY_EXEC_TEST_KEEP=override" env
+  && List.mem "EXTRA_ONLY=yes" env
+  && not
+       (List.exists
+          (fun s ->
+             Util.contains_substring_ci ~haystack:s ~needle:"AUTONOMY_EXEC_TEST_DROP")
+          env)
+;;
+
+let%test_unit "run captures stdout and stderr" =
+  with_eio
+  @@ fun ~sw ~clock ->
+  let result =
+    run
+      ~sw
+      ~clock
+      ~config:default_config
+      ~argv:
+        [ "/usr/bin/env"
+        ; "python3"
+        ; "-c"
+        ; "import sys; sys.stdout.write('ok'); sys.stderr.write('err')"
+        ]
+      ~timeout_s:2.0
+  in
+  match result with
+  | Ok output ->
+    assert (output.stdout = "ok");
+    assert (output.stderr = "err");
+    assert (output.status = Exit_code 0)
+  | Error err -> failwith (Error.to_string err)
+;;
+
+let%test_unit "run times out and returns Timed_out" =
+  with_eio
+  @@ fun ~sw ~clock ->
+  let result =
+    run
+      ~sw
+      ~clock
+      ~config:default_config
+      ~argv:[ "/usr/bin/env"; "python3"; "-c"; "import time; time.sleep(5)" ]
+      ~timeout_s:0.1
+  in
+  match result with
+  | Ok output ->
+    (match output.status with
+     | Timed_out _ -> ()
+     | status -> failwith ("expected timeout, got " ^ status_to_string status))
+  | Error err -> failwith (Error.to_string err)
+;;
+
+let%test_unit "run preserves switch cancellation" =
+  with_eio
+  @@ fun ~sw:_ ~clock ->
+  let run_outcome = ref None in
+  (try
+     Eio.Switch.run
+     @@ fun child_sw ->
+     Eio.Fiber.fork ~sw:child_sw (fun () ->
+       Eio.Time.sleep clock 0.05;
+       Eio.Switch.fail child_sw Exit);
+     run_outcome
+     := Some
+          (try
+             match
+               run
+                 ~sw:child_sw
+                 ~clock
+                 ~config:default_config
+                 ~argv:[ "/usr/bin/env"; "python3"; "-c"; "import time; time.sleep(0.5)" ]
+                 ~timeout_s:0.2
+             with
+             | Ok _ -> `Returned_ok
+             | Error err -> `Returned_error (Error.to_string err)
+           with
+           | Eio.Cancel.Cancelled _ -> `Cancelled
+           | exn -> `Raised (Printexc.to_string exn))
+   with
+   | Exit -> ());
+  match !run_outcome with
+  | Some `Cancelled -> ()
+  | Some `Returned_ok -> failwith "expected switch cancellation, got normal return"
+  | Some (`Returned_error err) ->
+    failwith ("expected switch cancellation, got error: " ^ err)
+  | Some (`Raised exn) -> failwith ("expected switch cancellation, got exception: " ^ exn)
+  | None -> failwith "run outcome was not recorded before switch failure"
+;;

--- a/lib/cdal_runtime/autonomy_exec.mli
+++ b/lib/cdal_runtime/autonomy_exec.mli
@@ -1,0 +1,71 @@
+(** Autonomy_exec — external execution primitive for autonomy loops.
+
+    This module intentionally stays below any AutoResearch-specific policy.
+    It provides argv-only process execution with timeout, bounded capture,
+    env allowlisting, and optional wrapper prefixes for container/sandbox
+    launchers such as Docker or Bubblewrap.
+
+    @since 0.92.1
+
+    @stability Evolving
+    @since 0.93.1 *)
+
+type backend =
+  | Direct
+  | Argv_prefix of string list
+
+type kill_scope =
+  | Single_process
+  | Process_group
+  (** Requires a wrapper that creates a dedicated process group
+          (for example: [setsid], [docker run], [bwrap]). *)
+
+type config =
+  { backend : backend
+  ; cwd : string option
+  ; env_allowlist : string list
+  ; extra_env : (string * string) list
+  ; stdout_limit_bytes : int
+  ; stderr_limit_bytes : int
+  ; kill_scope : kill_scope
+  }
+
+val default_env_allowlist : string list
+val default_config : config
+
+type exit_status =
+  | Exit_code of int
+  | Exit_signal of int
+  | Timed_out of int option
+
+type output =
+  { effective_argv : string list
+  ; status : exit_status
+  ; stdout : string
+  ; stderr : string
+  ; stdout_truncated : bool
+  ; stderr_truncated : bool
+  ; elapsed_s : float
+  }
+
+(** Shell-quoted rendering for logs and diagnostics. *)
+val argv_to_string : string list -> string
+
+(** Compose backend prefix and cwd wrapper into the final argv list. *)
+val effective_argv
+  :  config:config
+  -> argv:string list
+  -> (string list, Error.sdk_error) result
+
+(** Build the child environment from inherited allowlisted vars and overrides. *)
+val build_env : config:config -> string array
+
+val status_to_string : exit_status -> string
+
+val run
+  :  sw:Eio.Switch.t
+  -> clock:_ Eio.Time.clock
+  -> config:config
+  -> argv:string list
+  -> timeout_s:float
+  -> (output, Error.sdk_error) result

--- a/lib/cdal_runtime/autonomy_trace_analyzer.ml
+++ b/lib/cdal_runtime/autonomy_trace_analyzer.ml
@@ -1,0 +1,247 @@
+(** Autonomy Trace Analyzer — quantify whether agent behavior is
+    autonomous, scripted, or random.
+
+    Pure computation over {!Raw_trace.run_summary} values.
+    No LLM calls, no IO. *)
+
+(* ── Types ─────────────────────────────────────────────────── *)
+
+type worker_metric =
+  { diversity : float
+  ; unique_tool_count : int
+  ; total_calls : int
+  ; turn_count : int
+  ; tool_set : string list
+  }
+[@@deriving yojson, show]
+
+type divergence =
+  { jaccard_distance : float
+  ; shared_tools : string list
+  ; exclusive_a : string list
+  ; exclusive_b : string list
+  }
+[@@deriving yojson, show]
+
+type classification =
+  | Autonomous
+  | Scripted
+  | Random
+  | Insufficient_data
+[@@deriving yojson, show]
+
+type verdict =
+  { classification : classification
+  ; confidence : float
+  ; evidence : string list
+  ; metrics : worker_metric list
+  ; mean_diversity : float
+  ; mean_divergence : float
+  ; pairwise_divergences : divergence list
+  }
+[@@deriving yojson, show]
+
+type thresholds =
+  { diversity_autonomous : float
+  ; diversity_scripted : float
+  ; divergence_autonomous : float
+  ; divergence_scripted : float
+  ; min_unique_tools : int
+  ; random_divergence : float
+    (** divergence above this with low diversity → Random (default 0.8) *)
+  }
+
+let default_thresholds =
+  { diversity_autonomous = 0.3
+  ; diversity_scripted = 0.15
+  ; divergence_autonomous = 0.15
+  ; divergence_scripted = 0.05
+  ; min_unique_tools = 3
+  ; random_divergence = 0.8
+  }
+;;
+
+(* ── Helpers ───────────────────────────────────────────────── *)
+
+module SSet = Set.Make (String)
+
+let set_of_list xs = List.fold_left (fun acc x -> SSet.add x acc) SSet.empty xs
+let sorted_elements s = SSet.elements s |> List.sort String.compare
+
+let mean xs =
+  match xs with
+  | [] -> 0.0
+  | _ ->
+    let sum = List.fold_left ( +. ) 0.0 xs in
+    sum /. Float.of_int (List.length xs)
+;;
+
+(* ── Core functions ────────────────────────────────────────── *)
+
+let metric_of_summary (s : Raw_trace.run_summary) : worker_metric =
+  let tool_set = s.tool_names in
+  let unique_tool_count = List.length tool_set in
+  let total_calls = s.tool_execution_started_count in
+  let diversity =
+    if total_calls = 0
+    then 0.0
+    else Float.of_int unique_tool_count /. Float.of_int total_calls
+  in
+  let turn_count = s.assistant_block_count in
+  { diversity; unique_tool_count; total_calls; turn_count; tool_set }
+;;
+
+let divergence_of_pair (a : worker_metric) (b : worker_metric) : divergence =
+  let set_a = set_of_list a.tool_set in
+  let set_b = set_of_list b.tool_set in
+  let intersection = SSet.inter set_a set_b in
+  let union = SSet.union set_a set_b in
+  let jaccard_distance =
+    let union_size = SSet.cardinal union in
+    if union_size = 0
+    then 0.0
+    else (
+      let inter_size = SSet.cardinal intersection in
+      1.0 -. (Float.of_int inter_size /. Float.of_int union_size))
+  in
+  let shared_tools = sorted_elements intersection in
+  let exclusive_a = sorted_elements (SSet.diff set_a set_b) in
+  let exclusive_b = sorted_elements (SSet.diff set_b set_a) in
+  { jaccard_distance; shared_tools; exclusive_a; exclusive_b }
+;;
+
+let all_pairs (xs : 'a list) : ('a * 'a) list =
+  let rec go acc = function
+    | [] -> List.rev acc
+    | x :: rest ->
+      let pairs = List.map (fun y -> x, y) rest in
+      go (List.rev_append pairs acc) rest
+  in
+  go [] xs
+;;
+
+let classify
+      ~(t : thresholds)
+      ~mean_div
+      ~mean_divg
+      ~min_unique
+      ~(metrics : worker_metric list)
+      ~(n : int)
+  : classification * float * string list
+  =
+  if n < 1
+  then Insufficient_data, 0.0, [ "no summaries provided" ]
+  else (
+    let evidence = ref [] in
+    let add e = evidence := e :: !evidence in
+    add (Printf.sprintf "workers=%d" n);
+    add (Printf.sprintf "mean_diversity=%.3f" mean_div);
+    if n >= 2 then add (Printf.sprintf "mean_divergence=%.3f" mean_divg);
+    add (Printf.sprintf "min_unique_tools=%d" min_unique);
+    (* Scoring *)
+    let diversity_ok = mean_div >= t.diversity_autonomous in
+    let diversity_low = mean_div < t.diversity_scripted in
+    let divergence_ok = n < 2 || mean_divg >= t.divergence_autonomous in
+    let divergence_low = n >= 2 && mean_divg < t.divergence_scripted in
+    let tools_ok = min_unique >= t.min_unique_tools in
+    (* Single-worker case: can only assess diversity *)
+    if n = 1
+    then (
+      add "single_worker: divergence not measurable";
+      if diversity_ok && tools_ok
+      then (
+        add "PASS: diversity and tool count meet thresholds";
+        Autonomous, 0.6, List.rev !evidence)
+      else if diversity_low
+      then (
+        add "FAIL: diversity below scripted threshold";
+        Scripted, 0.7, List.rev !evidence)
+      else (
+        add "INCONCLUSIVE: single worker, moderate diversity";
+        Insufficient_data, 0.4, List.rev !evidence))
+    else (
+      (* Multi-worker case *)
+      let score = ref 0.0 in
+      if diversity_ok
+      then (
+        score := !score +. 0.3;
+        add "PASS: diversity >= threshold")
+      else if diversity_low
+      then add "FAIL: diversity < scripted threshold"
+      else add "WARN: diversity between thresholds";
+      if divergence_ok
+      then (
+        score := !score +. 0.4;
+        add "PASS: divergence >= threshold")
+      else if divergence_low
+      then add "FAIL: divergence < scripted threshold"
+      else add "WARN: divergence between thresholds";
+      if tools_ok
+      then (
+        score := !score +. 0.3;
+        add "PASS: unique tools >= minimum")
+      else add "FAIL: unique tools < minimum";
+      (* Check for random: high divergence but low diversity *)
+      let has_low_diversity =
+        List.exists
+          (fun (m : worker_metric) -> m.diversity < t.diversity_scripted)
+          metrics
+      in
+      let has_high_divergence = mean_divg > t.random_divergence in
+      if has_high_divergence && has_low_diversity
+      then (
+        add "RANDOM: high divergence but low diversity suggests random tool use";
+        Random, 0.6, List.rev !evidence)
+      else if !score >= 0.7
+      then (
+        add (Printf.sprintf "VERDICT: autonomous (score=%.1f)" !score);
+        Autonomous, !score, List.rev !evidence)
+      else if divergence_low || diversity_low
+      then (
+        add (Printf.sprintf "VERDICT: scripted (score=%.1f)" !score);
+        Scripted, Float.max 0.5 (1.0 -. !score), List.rev !evidence)
+      else (
+        add (Printf.sprintf "VERDICT: insufficient evidence (score=%.1f)" !score);
+        Insufficient_data, 0.4, List.rev !evidence)))
+;;
+
+let analyze ?(thresholds = default_thresholds) (summaries : Raw_trace.run_summary list)
+  : verdict
+  =
+  let metrics = List.map metric_of_summary summaries in
+  let n = List.length metrics in
+  let mean_diversity = mean (List.map (fun (m : worker_metric) -> m.diversity) metrics) in
+  let pairs = all_pairs metrics in
+  let pairwise_divergences = List.map (fun (a, b) -> divergence_of_pair a b) pairs in
+  let mean_divergence =
+    mean (List.map (fun (d : divergence) -> d.jaccard_distance) pairwise_divergences)
+  in
+  let min_unique =
+    match metrics with
+    | [] -> 0
+    | _ ->
+      List.fold_left
+        (fun acc (m : worker_metric) -> min acc m.unique_tool_count)
+        Int.max_int
+        metrics
+  in
+  let classification, confidence, evidence =
+    classify
+      ~t:thresholds
+      ~mean_div:mean_diversity
+      ~mean_divg:mean_divergence
+      ~min_unique
+      ~metrics
+      ~n
+  in
+  { classification
+  ; confidence
+  ; evidence
+  ; metrics
+  ; mean_diversity
+  ; mean_divergence
+  ; pairwise_divergences
+  }
+;;
+
+let verdict_to_json (v : verdict) : Yojson.Safe.t = verdict_to_yojson v

--- a/lib/cdal_runtime/autonomy_trace_analyzer.mli
+++ b/lib/cdal_runtime/autonomy_trace_analyzer.mli
@@ -1,0 +1,81 @@
+(** Autonomy Trace Analyzer — quantify whether agent behavior is
+    autonomous, scripted, or random based on raw trace summaries.
+
+    Layer 1 (pure OCaml, no LLM required): computes diversity,
+    divergence, and relevance metrics from {!Raw_trace.run_summary}
+    values produced by {!Raw_trace_query.summarize_run}.
+
+    @stability Evolving
+    @since 0.93.1 *)
+
+(** {2 Metrics} *)
+
+type worker_metric =
+  { diversity : float (** unique_tools / total_calls.  Higher = more exploratory. *)
+  ; unique_tool_count : int
+  ; total_calls : int
+  ; turn_count : int
+  ; tool_set : string list (** sorted unique tool names *)
+  }
+[@@deriving yojson, show]
+
+(** {2 Divergence between two workers} *)
+
+type divergence =
+  { jaccard_distance : float
+    (** 1.0 - |A inter B| / |A union B|. 0 = identical, 1 = disjoint. *)
+  ; shared_tools : string list
+  ; exclusive_a : string list
+  ; exclusive_b : string list
+  }
+[@@deriving yojson, show]
+
+(** {2 Verdict} *)
+
+type classification =
+  | Autonomous
+  | Scripted
+  | Random
+  | Insufficient_data
+[@@deriving yojson, show]
+
+type verdict =
+  { classification : classification
+  ; confidence : float (** 0.0 to 1.0 *)
+  ; evidence : string list
+  ; metrics : worker_metric list
+  ; mean_diversity : float
+  ; mean_divergence : float
+  ; pairwise_divergences : divergence list
+  }
+[@@deriving yojson, show]
+
+(** {2 Thresholds (configurable)} *)
+
+type thresholds =
+  { diversity_autonomous : float (** >= this is considered diverse (default 0.3) *)
+  ; diversity_scripted : float (** < this is considered scripted (default 0.15) *)
+  ; divergence_autonomous : float (** >= this is considered divergent (default 0.15) *)
+  ; divergence_scripted : float (** < this is considered identical (default 0.05) *)
+  ; min_unique_tools : int (** minimum unique tools for autonomous (default 3) *)
+  ; random_divergence : float
+    (** divergence above this with low diversity → Random (default 0.8) *)
+  }
+
+val default_thresholds : thresholds
+
+(** {2 Core functions} *)
+
+(** Extract a worker metric from a single run summary. *)
+val metric_of_summary : Raw_trace.run_summary -> worker_metric
+
+(** Compute Jaccard-based divergence between two workers' tool sets. *)
+val divergence_of_pair : worker_metric -> worker_metric -> divergence
+
+(** Analyze a list of run summaries and produce a verdict.
+    Requires >= 2 summaries for meaningful divergence comparison.
+    With 1 summary, only diversity is evaluated. *)
+val analyze : ?thresholds:thresholds -> Raw_trace.run_summary list -> verdict
+
+(** Serialize a verdict to JSON for CLI output. *)
+val verdict_to_json : verdict -> Yojson.Safe.t

--- a/lib/cdal_runtime/guardrail_tripwire.ml
+++ b/lib/cdal_runtime/guardrail_tripwire.ml
@@ -1,0 +1,84 @@
+(** Tripwire guardrails: fail-fast parallel validators.
+
+    Uses [Eio.Fiber.first] for cancel-on-first-completion semantics.
+    When the tripwire fiber finishes (violation found), the action fiber
+    is cancelled. When the action finishes first, tripwires are cancelled.
+
+    @since 0.102.0 *)
+
+type tripwire =
+  { name : string
+  ; check : Types.message list -> (unit, string) result
+  }
+
+type tripwire_result =
+  | All_clear
+  | Tripped of
+      { tripwire_name : string
+      ; reason : string
+      }
+
+(** Run all tripwire checks. Returns as soon as any check fails (Error).
+    If all pass, blocks forever (Promise.await) so the action fiber can win.
+    Runs inside Fiber.first — the losing fiber gets cancelled. *)
+let check_tripwires ~messages tripwires =
+  let violation = ref None in
+  (* Run all checks in a switch — first failure wins *)
+  let found_violation =
+    try
+      Eio.Switch.run
+      @@ fun sw ->
+      List.iter
+        (fun (tw : tripwire) ->
+           Eio.Fiber.fork ~sw (fun () ->
+             match tw.check messages with
+             | Ok () -> ()
+             | Error reason ->
+               violation := Some (tw.name, reason);
+               (* Cancel the switch to stop other checks *)
+               raise Exit))
+        tripwires;
+      (* If we reach here, all checks passed *)
+      false
+    with
+    | Exit -> true
+    | Eio.Cancel.Cancelled _ -> false
+  in
+  match found_violation, !violation with
+  | true, Some (name, reason) -> Tripped { tripwire_name = name; reason }
+  | _ -> All_clear
+;;
+
+let guarded_action ~tripwires ~messages ~action =
+  if tripwires = []
+  then (
+    match action () with
+    | Ok v -> Ok v
+    | Error e -> Error (`Action e))
+  else (
+    let action_result = ref None in
+    let trip_result = ref All_clear in
+    Eio.Fiber.first
+      (fun () ->
+         (* Action fiber *)
+         action_result := Some (action ()))
+      (fun () ->
+         (* Tripwire fiber *)
+         let tw_result = check_tripwires ~messages tripwires in
+         match tw_result with
+         | All_clear ->
+           (* All passed — block forever so action fiber wins.
+             Fiber.first will cancel this when action completes. *)
+           let p, _ = Eio.Promise.create () in
+           Eio.Promise.await p
+         | Tripped _ ->
+           (* Violation — return normally, Fiber.first cancels action *)
+           trip_result := tw_result);
+    match !trip_result with
+    | Tripped _ as t -> Error (`Tripped t)
+    | All_clear ->
+      (match !action_result with
+       | Some (Ok v) -> Ok v
+       | Some (Error e) -> Error (`Action e)
+       | None -> Error (`Action (Error.Internal "action cancelled without tripwire"))))
+;;

--- a/lib/cdal_runtime/guardrail_tripwire.mli
+++ b/lib/cdal_runtime/guardrail_tripwire.mli
@@ -1,0 +1,40 @@
+(** Tripwire guardrails: fail-fast parallel validators.
+
+    A tripwire runs concurrently with the main agent LLM call.
+    If any tripwire fires before the action completes, the action's
+    fiber is cancelled via Eio structured concurrency.
+
+    Uses [Eio.Fiber.first] (not [both]) so the first completion
+    cancels the other fiber.
+
+    @stability Evolving
+    @since 0.102.0 *)
+
+(** {1 Types} *)
+
+type tripwire =
+  { name : string
+  ; check : Types.message list -> (unit, string) result
+    (** Blocking check. Return [Error reason] to trip. *)
+  }
+
+type tripwire_result =
+  | All_clear
+  | Tripped of
+      { tripwire_name : string
+      ; reason : string
+      }
+
+(** {1 Execution} *)
+
+(** Run the action and all tripwires concurrently.
+    If any tripwire fires (returns [Error]) before the action completes,
+    the action fiber is cancelled and [Error (`Tripped ...)] is returned.
+    If the action completes first, tripwire fibers are cancelled.
+
+    With zero tripwires, runs the action directly (no fiber overhead). *)
+val guarded_action
+  :  tripwires:tripwire list
+  -> messages:Types.message list
+  -> action:(unit -> ('a, Error.sdk_error) result)
+  -> ('a, [ `Tripped of tripwire_result | `Action of Error.sdk_error ]) result

--- a/lib/cdal_runtime/guardrails_async.ml
+++ b/lib/cdal_runtime/guardrails_async.ml
@@ -1,0 +1,170 @@
+(** Async guardrails: parallel input/output validation via Eio fibers.
+
+    Extends {!Guardrails} (tool filtering) with content validation:
+    - {b Input validators} run before the LLM call (gate).
+    - {b Output validators} run after the LLM call (parallel).
+
+    All validators within a group run concurrently via [Eio.Fiber.all]
+    inside a dedicated [Eio.Switch]. Cancellation propagates correctly.
+
+    @since 0.67.0 *)
+open Types
+
+let log = Log.create ~module_name:"guardrails_async" ()
+
+(** Input validator: checks messages before sending to the LLM. *)
+type input_validator =
+  { name : string
+  ; validate : message list -> (unit, string) Result.t
+  }
+
+(** Output validator: checks the LLM response. *)
+type output_validator =
+  { name : string
+  ; validate : api_response -> (unit, string) Result.t
+  }
+
+(** Result of a validation run. *)
+type validation_result =
+  | Pass
+  | Fail of
+      { validator_name : string
+      ; reason : string
+      }
+
+(** Configuration for async guardrails. *)
+type t =
+  { input_validators : input_validator list
+  ; output_validators : output_validator list
+  }
+
+let empty = { input_validators = []; output_validators = [] }
+
+let exception_reason ~validator_name = function
+  | Eio.Time.Timeout -> "validator timed out"
+  | exn ->
+    Log.debug
+      log
+      "validator raised"
+      [ Log.S ("validator", validator_name)
+      ; Log.S ("exception", Stdlib.Printexc.to_string exn)
+      ];
+    "validator raised"
+;;
+
+(* Per-validator deadline. When supplied the validator is wrapped in
+   [Eio.Time.with_timeout_exn], so a stuck validator turns into
+   [Fail "validator timed out"] instead of blocking sibling fibers and
+   the rest of the turn pipeline. The audit (Kimi 1-3) flagged the
+   unguarded [Eio.Fiber.all] as a Silent Failure path: one validator
+   hanging would block the entire turn. Default is [None] for backward
+   compatibility — call sites opt in by passing [~deadline]. *)
+type deadline =
+  { clock : float Eio.Time.clock_ty Eio.Resource.t
+  ; timeout_sec : float
+  }
+
+let run_validator ?deadline ~validator_name f =
+  let invoke () =
+    match f () with
+    | Ok () -> Pass
+    | Error reason -> Fail { validator_name; reason }
+  in
+  try
+    match deadline with
+    | Some { clock; timeout_sec } when timeout_sec > 0.0 ->
+      Eio.Time.with_timeout_exn clock timeout_sec invoke
+    | _ -> invoke ()
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | Out_of_memory -> raise Out_of_memory
+  | Stack_overflow -> raise Stack_overflow
+  | Stdlib.Sys.Break -> raise Stdlib.Sys.Break
+  | exn -> Fail { validator_name; reason = exception_reason ~validator_name exn }
+;;
+
+(** Run all input validators concurrently.
+
+    Creates a dedicated [Eio.Switch] for parallel execution.
+    Returns the first failure found, or [Pass] if all succeed.
+    Cancellation exceptions propagate correctly. *)
+let run_input ?deadline (validators : input_validator list) (messages : message list)
+  : validation_result
+  =
+  match validators with
+  | [] -> Pass
+  | _ ->
+    let results = Array.make (List.length validators) Pass in
+    let fns =
+      List.mapi
+        (fun i (v : input_validator) ->
+           fun () ->
+           results.(i)
+           <- run_validator ?deadline ~validator_name:v.name (fun () ->
+                v.validate messages))
+        validators
+    in
+    Eio.Switch.run ~name:"input_validators" (fun _sw -> Eio.Fiber.all fns);
+    Array.to_list results
+    |> List.find_opt (function
+      | Fail _ -> true
+      | Pass -> false)
+    |> Option.value ~default:Pass
+;;
+
+(** Run all output validators concurrently.
+
+    Same parallel execution pattern as {!run_input}. *)
+let run_output ?deadline (validators : output_validator list) (response : api_response)
+  : validation_result
+  =
+  match validators with
+  | [] -> Pass
+  | _ ->
+    let results = Array.make (List.length validators) Pass in
+    let fns =
+      List.mapi
+        (fun i (v : output_validator) ->
+           fun () ->
+           results.(i)
+           <- run_validator ?deadline ~validator_name:v.name (fun () ->
+                v.validate response))
+        validators
+    in
+    Eio.Switch.run ~name:"output_validators" (fun _sw -> Eio.Fiber.all fns);
+    Array.to_list results
+    |> List.find_opt (function
+      | Fail _ -> true
+      | Pass -> false)
+    |> Option.value ~default:Pass
+;;
+
+(** Convenience: run input validation, then an action, then output validation.
+
+    If input validation fails, the action is not executed.
+    Returns [Ok response] on success, [Error validation_result] on failure. *)
+let guarded
+      ?deadline
+      ~(config : t)
+      ~(messages : message list)
+      ~(action : unit -> (api_response, 'e) Result.t)
+      ()
+  : (api_response, [ `Validation of validation_result | `Action of 'e ]) Result.t
+  =
+  match run_input ?deadline config.input_validators messages with
+  | Fail _ as f -> Error (`Validation f)
+  | Pass ->
+    (match action () with
+     | Error e -> Error (`Action e)
+     | Ok response ->
+       (match run_output ?deadline config.output_validators response with
+        | Fail _ as f -> Error (`Validation f)
+        | Pass -> Ok response))
+;;
+
+(** Format a validation result for logging. *)
+let result_to_string = function
+  | Pass -> "pass"
+  | Fail { validator_name; reason } ->
+    Printf.sprintf "FAIL [%s]: %s" validator_name reason
+;;

--- a/lib/cdal_runtime/guardrails_async.mli
+++ b/lib/cdal_runtime/guardrails_async.mli
@@ -1,0 +1,78 @@
+(** Async guardrails: parallel input/output validation.
+
+    Validators run concurrently inside a dedicated [Eio.Switch]. Validator
+    failures, timeouts, and ordinary exceptions are contained to that
+    validator's [Fail] result so sibling validators can finish. Parent switch
+    cancellation still propagates through Eio structured concurrency.
+
+    @since 0.67.0
+
+    @stability Evolving
+    @since 0.93.1 *)
+
+(** Input validator: checks messages before the LLM call. *)
+type input_validator =
+  { name : string
+  ; validate : Types.message list -> (unit, string) Result.t
+  }
+
+(** Output validator: checks the response after the LLM call. *)
+type output_validator =
+  { name : string
+  ; validate : Types.api_response -> (unit, string) Result.t
+  }
+
+type validation_result =
+  | Pass
+  | Fail of
+      { validator_name : string
+      ; reason : string
+      }
+
+type t =
+  { input_validators : input_validator list
+  ; output_validators : output_validator list
+  }
+
+val empty : t
+
+(** Per-validator deadline. When passed to {!run_input} / {!run_output}
+    each validator is wrapped in [Eio.Time.with_timeout_exn], so a
+    stuck validator returns [Fail "validator timed out"] instead of
+    blocking sibling fibers and the rest of the turn. *)
+type deadline =
+  { clock : float Eio.Time.clock_ty Eio.Resource.t
+  ; timeout_sec : float
+  }
+
+(** Run input validators concurrently. Returns first failure or [Pass].
+
+    When [?deadline] is provided each validator gets a hard deadline
+    via [Eio.Time.with_timeout_exn]. *)
+val run_input
+  :  ?deadline:deadline
+  -> input_validator list
+  -> Types.message list
+  -> validation_result
+
+(** Run output validators concurrently. Returns first failure or [Pass].
+
+    Same [?deadline] semantics as {!run_input}. *)
+val run_output
+  :  ?deadline:deadline
+  -> output_validator list
+  -> Types.api_response
+  -> validation_result
+
+(** Run input validation, action, output validation in sequence.
+    Input failure skips the action. [?deadline] is forwarded to both
+    {!run_input} and {!run_output}. *)
+val guarded
+  :  ?deadline:deadline
+  -> config:t
+  -> messages:Types.message list
+  -> action:(unit -> (Types.api_response, 'e) Result.t)
+  -> unit
+  -> (Types.api_response, [ `Validation of validation_result | `Action of 'e ]) Result.t
+
+val result_to_string : validation_result -> string

--- a/lib/cdal_runtime/runtime_evidence.ml
+++ b/lib/cdal_runtime/runtime_evidence.ml
@@ -1,0 +1,623 @@
+open Runtime
+
+let runtime_persist_failure_prefix = "[runtime_persist_failure phase="
+let dropped_output_deltas_marker = "[runtime telemetry] dropped_output_deltas="
+
+type telemetry_step =
+  { seq : int
+  ; ts : float
+  ; event_name : string
+  ; kind : string
+  ; participant : string option
+  ; detail : string option
+  ; actor : string option
+  ; role : string option
+  ; provider : string option
+  ; model : string option
+  ; raw_trace_run_id : string option
+  ; stop_reason : string option
+  ; artifact_id : string option
+  ; artifact_name : string option
+  ; artifact_kind : string option
+  ; checkpoint_label : string option
+  ; outcome : string option
+  ; dropped_output_deltas : int option
+  ; persistence_failure_phase : string option
+  }
+
+type telemetry_report =
+  { session_id : string
+  ; generated_at : float
+  ; step_count : int
+  ; event_counts : (string * int) list
+  ; event_name_counts : (string * int) list
+  ; dropped_output_deltas : int
+  ; persistence_failure_count : int
+  ; participants_with_dropped_output_deltas : string list
+  ; participants_with_persistence_failures : string list
+  ; steps : telemetry_step list
+  }
+
+type evidence_file =
+  { label : string
+  ; path : string
+  ; size_bytes : int
+  ; md5 : string
+  }
+
+type evidence_bundle =
+  { session_id : string
+  ; generated_at : float
+  ; files : evidence_file list
+  ; missing_files : (string * string) list
+  }
+
+type raw_trace_manifest = Sessions.raw_trace_manifest
+
+let now () = Unix.gettimeofday ()
+
+let encode_persist_failure_detail ~phase message =
+  Printf.sprintf "%s%s] %s" runtime_persist_failure_prefix phase message
+;;
+
+let append_dropped_output_deltas_summary ~summary ~dropped_output_deltas =
+  Printf.sprintf "%s\n\n%s%d" summary dropped_output_deltas_marker dropped_output_deltas
+;;
+
+let artifact_attached_event (artifact : Runtime.artifact) =
+  Artifact_attached
+    { artifact_id = artifact.artifact_id
+    ; name = artifact.name
+    ; kind = artifact.kind
+    ; mime_type = artifact.mime_type
+    ; path = Option.value ~default:"" artifact.path
+    ; size_bytes = artifact.size_bytes
+    }
+;;
+
+let base_evidence_file_specs store session_id =
+  [ "session_json", Runtime_store.session_path store session_id
+  ; "events_jsonl", Runtime_store.events_path store session_id
+  ; "report_json", Runtime_store.report_json_path store session_id
+  ; "report_md", Runtime_store.report_md_path store session_id
+  ; "proof_json", Runtime_store.proof_json_path store session_id
+  ; "proof_md", Runtime_store.proof_md_path store session_id
+  ]
+;;
+
+let find_last_substring_index ~needle haystack =
+  let needle_len = String.length needle in
+  let haystack_len = String.length haystack in
+  let rec loop idx =
+    if idx < 0
+    then None
+    else if String.sub haystack idx needle_len = needle
+    then Some idx
+    else loop (idx - 1)
+  in
+  if needle_len = 0 || haystack_len < needle_len
+  then None
+  else loop (haystack_len - needle_len)
+;;
+
+let dropped_output_deltas_of_text = function
+  | None -> None
+  | Some text ->
+    let text = String.trim text in
+    (match find_last_substring_index ~needle:dropped_output_deltas_marker text with
+     | None -> None
+     | Some idx ->
+       let start = idx + String.length dropped_output_deltas_marker in
+       if start >= String.length text
+       then None
+       else (
+         let raw = String.sub text start (String.length text - start) |> String.trim in
+         match int_of_string_opt raw with
+         | Some n when n > 0 -> Some n
+         | _ -> None))
+;;
+
+let persistence_failure_phase_of_text = function
+  | None -> None
+  | Some text ->
+    let text = String.trim text in
+    if not (String.starts_with ~prefix:runtime_persist_failure_prefix text)
+    then None
+    else (
+      let start = String.length runtime_persist_failure_prefix in
+      match String.index_from_opt text start ']' with
+      | None -> None
+      | Some stop when stop > start -> Some (String.sub text start (stop - start))
+      | Some _ -> None)
+;;
+
+let failure_cause_message = function
+  | Runtime.Execution_error detail -> detail
+  | Runtime.Persistence_failure { phase; detail } -> Printf.sprintf "%s: %s" phase detail
+;;
+
+let failure_detail_of_event (detail : Runtime.participant_event) =
+  match detail.error, detail.failure_cause with
+  | Some error, _ -> Some error
+  | None, Some cause -> Some (failure_cause_message cause)
+  | None, None -> None
+;;
+
+let participant_and_detail_of_event = function
+  | Session_started _ -> None, Some "session_started"
+  | Session_settings_updated _ -> None, Some "session_settings_updated"
+  | Turn_recorded detail -> detail.actor, Some detail.message
+  | Agent_spawn_requested detail -> Some detail.participant_name, Some detail.prompt
+  | Agent_became_live detail -> Some detail.participant_name, detail.summary
+  | Agent_output_delta detail -> Some detail.participant_name, Some detail.delta
+  | Agent_completed detail -> Some detail.participant_name, detail.summary
+  | Agent_failed detail -> Some detail.participant_name, failure_detail_of_event detail
+  | Artifact_attached detail -> None, Some (detail.name ^ ":" ^ detail.kind)
+  | Checkpoint_saved detail -> None, detail.label
+  | Finalize_requested detail -> None, detail.reason
+  | Session_completed detail -> None, detail.outcome
+  | Session_failed detail -> None, detail.outcome
+;;
+
+let anomaly_fields_of_event = function
+  | Agent_completed detail ->
+    let dropped_output_deltas =
+      match detail.completion_anomaly with
+      | Some (Runtime.Dropped_output_deltas { count }) when count > 0 -> Some count
+      | Some _ | None -> dropped_output_deltas_of_text detail.summary
+    in
+    dropped_output_deltas, None
+  | Agent_failed detail ->
+    let persistence_failure_phase =
+      match detail.failure_cause with
+      | Some (Runtime.Persistence_failure { phase; _ }) -> Some phase
+      | Some _ | None ->
+        persistence_failure_phase_of_text (failure_detail_of_event detail)
+    in
+    None, persistence_failure_phase
+  | _ -> None, None
+;;
+
+let event_name_of_kind = function
+  | Session_started _ -> "session_started"
+  | Session_settings_updated _ -> "session_settings_updated"
+  | Turn_recorded _ -> "turn_recorded"
+  | Agent_spawn_requested _ -> "agent_spawn_requested"
+  | Agent_became_live _ -> "agent_became_live"
+  | Agent_output_delta _ -> "agent_output_delta"
+  | Agent_completed _ -> "agent_completed"
+  | Agent_failed _ -> "agent_failed"
+  | Artifact_attached _ -> "artifact_attached"
+  | Checkpoint_saved _ -> "checkpoint_saved"
+  | Finalize_requested _ -> "finalize_requested"
+  | Session_completed _ -> "session_completed"
+  | Session_failed _ -> "session_failed"
+;;
+
+let structured_fields_of_event = function
+  | Session_started _ -> None, None, None, None, None, None, None, None, None, None, None
+  | Session_settings_updated detail ->
+    None, None, None, detail.model, None, None, None, None, None, None, None
+  | Turn_recorded detail ->
+    detail.actor, None, None, None, None, None, None, None, None, None, None
+  | Agent_spawn_requested detail ->
+    ( None
+    , detail.role
+    , detail.provider
+    , detail.model
+    , None
+    , None
+    , None
+    , None
+    , None
+    , None
+    , None )
+  | Agent_became_live detail ->
+    ( None
+    , None
+    , detail.provider
+    , detail.model
+    , detail.raw_trace_run_id
+    , detail.stop_reason
+    , None
+    , None
+    , None
+    , None
+    , None )
+  | Agent_output_delta _ ->
+    None, None, None, None, None, None, None, None, None, None, None
+  | Agent_completed detail ->
+    ( None
+    , None
+    , detail.provider
+    , detail.model
+    , detail.raw_trace_run_id
+    , detail.stop_reason
+    , None
+    , None
+    , None
+    , None
+    , None )
+  | Agent_failed detail ->
+    ( None
+    , None
+    , detail.provider
+    , detail.model
+    , detail.raw_trace_run_id
+    , detail.stop_reason
+    , None
+    , None
+    , None
+    , None
+    , None )
+  | Artifact_attached detail ->
+    ( None
+    , None
+    , None
+    , None
+    , None
+    , None
+    , Some detail.artifact_id
+    , Some detail.name
+    , Some detail.kind
+    , None
+    , None )
+  | Checkpoint_saved detail ->
+    None, None, None, None, None, None, None, None, None, detail.label, None
+  | Finalize_requested _ ->
+    None, None, None, None, None, None, None, None, None, None, None
+  | Session_completed detail ->
+    None, None, None, None, None, None, None, None, None, None, detail.outcome
+  | Session_failed detail ->
+    None, None, None, None, None, None, None, None, None, None, detail.outcome
+;;
+
+let build_telemetry_report (session : session) (events : event list) =
+  let event_counts =
+    List.fold_left
+      (fun acc (event : event) ->
+         let key = show_event_kind event.kind in
+         let prev = Option.value (List.assoc_opt key acc) ~default:0 in
+         (key, prev + 1) :: List.remove_assoc key acc)
+      []
+      events
+    |> List.sort (fun (a, _) (b, _) -> String.compare a b)
+  in
+  let event_name_counts =
+    List.fold_left
+      (fun acc (event : event) ->
+         let key = event_name_of_kind event.kind in
+         let prev = Option.value (List.assoc_opt key acc) ~default:0 in
+         (key, prev + 1) :: List.remove_assoc key acc)
+      []
+      events
+    |> List.sort (fun (a, _) (b, _) -> String.compare a b)
+  in
+  let steps =
+    List.map
+      (fun (event : event) ->
+         let participant, detail = participant_and_detail_of_event event.kind in
+         let ( actor
+             , role
+             , provider
+             , model
+             , raw_trace_run_id
+             , stop_reason
+             , artifact_id
+             , artifact_name
+             , artifact_kind
+             , checkpoint_label
+             , outcome )
+           =
+           structured_fields_of_event event.kind
+         in
+         let dropped_output_deltas, persistence_failure_phase =
+           anomaly_fields_of_event event.kind
+         in
+         { seq = event.seq
+         ; ts = event.ts
+         ; event_name = event_name_of_kind event.kind
+         ; kind = show_event_kind event.kind
+         ; participant
+         ; detail
+         ; actor
+         ; role
+         ; provider
+         ; model
+         ; raw_trace_run_id
+         ; stop_reason
+         ; artifact_id
+         ; artifact_name
+         ; artifact_kind
+         ; checkpoint_label
+         ; outcome
+         ; dropped_output_deltas
+         ; persistence_failure_phase
+         })
+      events
+  in
+  let dropped_output_deltas =
+    List.fold_left
+      (fun acc (step : telemetry_step) ->
+         acc + Option.value step.dropped_output_deltas ~default:0)
+      0
+      steps
+  in
+  let participants_with_dropped_output_deltas =
+    steps
+    |> List.filter_map (fun (step : telemetry_step) ->
+      match step.participant, step.dropped_output_deltas with
+      | Some participant, Some n when n > 0 -> Some participant
+      | _ -> None)
+    |> List.sort_uniq String.compare
+  in
+  let participants_with_persistence_failures =
+    steps
+    |> List.filter_map (fun (step : telemetry_step) ->
+      match step.participant, step.persistence_failure_phase with
+      | Some participant, Some _ -> Some participant
+      | _ -> None)
+    |> List.sort_uniq String.compare
+  in
+  let persistence_failure_count =
+    List.fold_left
+      (fun acc (step : telemetry_step) ->
+         match step.persistence_failure_phase with
+         | Some _ -> acc + 1
+         | None -> acc)
+      0
+      steps
+  in
+  { session_id = session.session_id
+  ; generated_at = now ()
+  ; step_count = List.length steps
+  ; event_counts
+  ; event_name_counts
+  ; dropped_output_deltas
+  ; persistence_failure_count
+  ; participants_with_dropped_output_deltas
+  ; participants_with_persistence_failures
+  ; steps
+  }
+;;
+
+let telemetry_report_to_json (report : telemetry_report) =
+  `Assoc
+    [ "session_id", `String report.session_id
+    ; "generated_at", `Float report.generated_at
+    ; "step_count", `Int report.step_count
+    ; "dropped_output_deltas", `Int report.dropped_output_deltas
+    ; "persistence_failure_count", `Int report.persistence_failure_count
+    ; ( "participants_with_dropped_output_deltas"
+      , `List
+          (List.map
+             (fun participant -> `String participant)
+             report.participants_with_dropped_output_deltas) )
+    ; ( "participants_with_persistence_failures"
+      , `List
+          (List.map
+             (fun participant -> `String participant)
+             report.participants_with_persistence_failures) )
+    ; ( "event_counts"
+      , `Assoc (List.map (fun (name, count) -> name, `Int count) report.event_counts) )
+    ; ( "event_name_counts"
+      , `List
+          (List.map
+             (fun (event_name, count) ->
+                `Assoc [ "event_name", `String event_name; "count", `Int count ])
+             report.event_name_counts) )
+    ; ( "steps"
+      , `List
+          (List.map
+             (fun step ->
+                `Assoc
+                  [ "seq", `Int step.seq
+                  ; "ts", `Float step.ts
+                  ; "event_name", `String step.event_name
+                  ; "kind", `String step.kind
+                  ; ( "participant"
+                    , match step.participant with
+                      | Some value -> `String value
+                      | None -> `Null )
+                  ; ( "detail"
+                    , match step.detail with
+                      | Some value -> `String value
+                      | None -> `Null )
+                  ; ( "actor"
+                    , match step.actor with
+                      | Some value -> `String value
+                      | None -> `Null )
+                  ; ( "role"
+                    , match step.role with
+                      | Some value -> `String value
+                      | None -> `Null )
+                  ; ( "provider"
+                    , match step.provider with
+                      | Some value -> `String value
+                      | None -> `Null )
+                  ; ( "model"
+                    , match step.model with
+                      | Some value -> `String value
+                      | None -> `Null )
+                  ; ( "raw_trace_run_id"
+                    , match step.raw_trace_run_id with
+                      | Some value -> `String value
+                      | None -> `Null )
+                  ; ( "stop_reason"
+                    , match step.stop_reason with
+                      | Some value -> `String value
+                      | None -> `Null )
+                  ; ( "artifact_id"
+                    , match step.artifact_id with
+                      | Some value -> `String value
+                      | None -> `Null )
+                  ; ( "artifact_name"
+                    , match step.artifact_name with
+                      | Some value -> `String value
+                      | None -> `Null )
+                  ; ( "artifact_kind"
+                    , match step.artifact_kind with
+                      | Some value -> `String value
+                      | None -> `Null )
+                  ; ( "checkpoint_label"
+                    , match step.checkpoint_label with
+                      | Some value -> `String value
+                      | None -> `Null )
+                  ; ( "outcome"
+                    , match step.outcome with
+                      | Some value -> `String value
+                      | None -> `Null )
+                  ; ( "dropped_output_deltas"
+                    , match step.dropped_output_deltas with
+                      | Some value -> `Int value
+                      | None -> `Null )
+                  ; ( "persistence_failure_phase"
+                    , match step.persistence_failure_phase with
+                      | Some value -> `String value
+                      | None -> `Null )
+                  ])
+             report.steps) )
+    ]
+;;
+
+let telemetry_report_to_markdown (report : telemetry_report) =
+  let counts =
+    report.event_counts
+    |> List.map (fun (name, count) -> Printf.sprintf "- %s: %d" name count)
+    |> String.concat "\n"
+  in
+  let steps =
+    report.steps
+    |> List.map (fun step ->
+      let participant =
+        match step.participant with
+        | Some value -> value
+        | None -> "-"
+      in
+      let detail =
+        match step.detail with
+        | Some value when String.trim value <> "" -> value
+        | _ -> "-"
+      in
+      let anomalies =
+        [ (match step.dropped_output_deltas with
+           | Some count -> Some (Printf.sprintf " dropped_output_deltas=%d" count)
+           | None -> None)
+        ; (match step.persistence_failure_phase with
+           | Some phase -> Some (Printf.sprintf " persistence_failure_phase=%s" phase)
+           | None -> None)
+        ]
+        |> List.filter_map (fun item -> item)
+        |> String.concat ""
+      in
+      Printf.sprintf
+        "- #%d %s participant=%s detail=%s%s"
+        step.seq
+        step.kind
+        participant
+        detail
+        anomalies)
+    |> String.concat "\n"
+  in
+  let anomaly_lines =
+    [ Printf.sprintf "- Dropped Output Deltas: %d" report.dropped_output_deltas
+    ; Printf.sprintf "- Persistence Failures: %d" report.persistence_failure_count
+    ]
+    @ (report.participants_with_dropped_output_deltas
+       |> List.map (fun participant ->
+         Printf.sprintf "- dropped_output_deltas participant=%s" participant))
+    @ (report.participants_with_persistence_failures
+       |> List.map (fun participant ->
+         Printf.sprintf "- persistence_failure participant=%s" participant))
+  in
+  String.concat
+    "\n"
+    [ "# Runtime Telemetry"
+    ; ""
+    ; Printf.sprintf "- Session ID: %s" report.session_id
+    ; Printf.sprintf "- Step Count: %d" report.step_count
+    ; ""
+    ; "## Anomalies"
+    ; String.concat "\n" anomaly_lines
+    ; ""
+    ; "## Event Name Counts"
+    ; report.event_name_counts
+      |> List.map (fun (name, count) -> Printf.sprintf "- %s: %d" name count)
+      |> String.concat "\n"
+    ; ""
+    ; "## Event Counts"
+    ; counts
+    ; ""
+    ; "## Steps"
+    ; steps
+    ; ""
+    ]
+;;
+
+let digest_file_md5 path = Digest.file path |> Digest.to_hex
+let file_size path = (Unix.stat path).st_size
+
+let build_evidence_bundle ~session_id file_specs =
+  let files, missing_files =
+    List.fold_left
+      (fun (files, missing_files) (label, path) ->
+         if Sys.file_exists path
+         then
+           ( { label; path; size_bytes = file_size path; md5 = digest_file_md5 path }
+             :: files
+           , missing_files )
+         else files, (label, path) :: missing_files)
+      ([], [])
+      file_specs
+  in
+  { session_id
+  ; generated_at = now ()
+  ; files = List.rev files
+  ; missing_files = List.rev missing_files
+  }
+;;
+
+let build_raw_trace_manifest
+      ~session_id
+      ~latest_raw_trace_run
+      ~raw_trace_runs
+      ~raw_trace_summaries
+      ~raw_trace_validations
+  =
+  ({ session_id
+   ; generated_at = now ()
+   ; latest_raw_trace_run
+   ; raw_trace_runs
+   ; raw_trace_summaries
+   ; raw_trace_validations
+   }
+   : Sessions.raw_trace_manifest)
+;;
+
+let evidence_bundle_to_json (bundle : evidence_bundle) =
+  `Assoc
+    [ "session_id", `String bundle.session_id
+    ; "generated_at", `Float bundle.generated_at
+    ; ( "files"
+      , `List
+          (List.map
+             (fun file ->
+                `Assoc
+                  [ "label", `String file.label
+                  ; "path", `String file.path
+                  ; "size_bytes", `Int file.size_bytes
+                  ; "md5", `String file.md5
+                  ])
+             bundle.files) )
+    ; ( "missing_files"
+      , `List
+          (List.map
+             (fun (label, path) ->
+                `Assoc [ "label", `String label; "path", `String path ])
+             bundle.missing_files) )
+    ]
+;;
+
+let raw_trace_manifest_to_json (manifest : raw_trace_manifest) =
+  Sessions.raw_trace_manifest_to_yojson manifest
+;;

--- a/lib/cdal_runtime/runtime_evidence.mli
+++ b/lib/cdal_runtime/runtime_evidence.mli
@@ -1,0 +1,86 @@
+(** Runtime evidence: telemetry reports and evidence bundles.
+
+    Generates structured telemetry from session events and
+    collects file-level evidence with MD5 checksums.
+
+    @stability Internal
+    @since 0.93.1 *)
+
+type telemetry_step =
+  { seq : int
+  ; ts : float
+  ; event_name : string
+  ; kind : string
+  ; participant : string option
+  ; detail : string option
+  ; actor : string option
+  ; role : string option
+  ; provider : string option
+  ; model : string option
+  ; raw_trace_run_id : string option
+  ; stop_reason : string option
+  ; artifact_id : string option
+  ; artifact_name : string option
+  ; artifact_kind : string option
+  ; checkpoint_label : string option
+  ; outcome : string option
+  ; dropped_output_deltas : int option
+  ; persistence_failure_phase : string option
+  }
+
+type telemetry_report =
+  { session_id : string
+  ; generated_at : float
+  ; step_count : int
+  ; event_counts : (string * int) list
+  ; event_name_counts : (string * int) list
+  ; dropped_output_deltas : int
+  ; persistence_failure_count : int
+  ; participants_with_dropped_output_deltas : string list
+  ; participants_with_persistence_failures : string list
+  ; steps : telemetry_step list
+  }
+
+type evidence_file =
+  { label : string
+  ; path : string
+  ; size_bytes : int
+  ; md5 : string
+  }
+
+type evidence_bundle =
+  { session_id : string
+  ; generated_at : float
+  ; files : evidence_file list
+  ; missing_files : (string * string) list
+  }
+
+type raw_trace_manifest = Sessions.raw_trace_manifest
+
+val now : unit -> float
+val runtime_persist_failure_prefix : string
+val dropped_output_deltas_marker : string
+val encode_persist_failure_detail : phase:string -> string -> string
+
+val append_dropped_output_deltas_summary
+  :  summary:string
+  -> dropped_output_deltas:int
+  -> string
+
+val artifact_attached_event : Runtime.artifact -> Runtime.event_kind
+val base_evidence_file_specs : Runtime_store.t -> string -> (string * string) list
+val build_telemetry_report : Runtime.session -> Runtime.event list -> telemetry_report
+val telemetry_report_to_json : telemetry_report -> Yojson.Safe.t
+val telemetry_report_to_markdown : telemetry_report -> string
+val build_evidence_bundle : session_id:string -> (string * string) list -> evidence_bundle
+val evidence_bundle_to_json : evidence_bundle -> Yojson.Safe.t
+
+val build_raw_trace_manifest
+  :  session_id:string
+  -> latest_raw_trace_run:Sessions.raw_trace_run option
+  -> raw_trace_runs:Sessions.raw_trace_run list
+  -> raw_trace_summaries:Sessions.raw_trace_summary list
+  -> raw_trace_validations:Sessions.raw_trace_validation list
+  -> raw_trace_manifest
+
+val raw_trace_manifest_to_json : raw_trace_manifest -> Yojson.Safe.t

--- a/lib/cdal_runtime/sessions_proof.ml
+++ b/lib/cdal_runtime/sessions_proof.ml
@@ -1,0 +1,362 @@
+(** Sessions proof assembly — worker-run construction and proof bundle.
+
+    Transforms raw trace data and runtime participant metadata into
+    structured worker_run records and assembles the complete proof_bundle
+    used for conformance checking and evidence export. *)
+
+open Sessions_types
+open Sessions_store
+open Result_syntax
+
+let participant_by_name (session : Runtime.session) name =
+  List.find_opt
+    (fun (participant : Runtime.participant) -> String.equal participant.name name)
+    session.participants
+;;
+
+let resolved_provider_of_participant
+      (session : Runtime.session)
+      (participant : Runtime.participant option)
+  =
+  match participant with
+  | Some p ->
+    (match p.resolved_provider with
+     | Some _ as value -> value
+     | None -> p.provider)
+  | None -> session.provider
+;;
+
+let resolved_model_of_participant
+      (session : Runtime.session)
+      (participant : Runtime.participant option)
+  =
+  match participant with
+  | Some p ->
+    (match p.resolved_model with
+     | Some _ as value -> value
+     | None -> p.model)
+  | None -> session.model
+;;
+
+let worker_status_of_participant (participant : Runtime.participant option) =
+  match participant with
+  | Some p ->
+    (match p.state with
+     | Runtime.Failed_participant -> Failed
+     | Runtime.Done -> Completed
+     | Runtime.Live | Runtime.Idle ->
+       if p.last_progress_at <> None && p.last_progress_at <> p.started_at
+       then Running
+       else Ready
+     | Runtime.Starting -> Accepted
+     | Runtime.Planned | Runtime.Detached -> Planned)
+  | None -> Completed
+;;
+
+let worker_order_ts (worker : worker_run) =
+  match worker.finished_at with
+  | Some _ as value -> value
+  | None ->
+    (match worker.last_progress_at with
+     | Some _ as value -> value
+     | None -> worker.started_at)
+;;
+
+let sort_worker_runs worker_runs =
+  List.sort
+    (fun a b ->
+       match worker_order_ts a, worker_order_ts b with
+       | Some x, Some y -> Float.compare x y
+       | Some _, None -> -1
+       | None, Some _ -> 1
+       | None, None -> String.compare a.worker_run_id b.worker_run_id)
+    worker_runs
+;;
+
+let latest_worker_by predicate worker_runs =
+  worker_runs
+  |> List.filter predicate
+  |> sort_worker_runs
+  |> List.rev
+  |> function
+  | worker :: _ -> Some worker
+  | [] -> None
+;;
+
+let worker_run_of_raw
+      (session : Runtime.session)
+      (summary : raw_trace_summary)
+      (validation : raw_trace_validation)
+  =
+  let participant = participant_by_name session summary.run_ref.agent_name in
+  let provider = resolved_provider_of_participant session participant in
+  let model = resolved_model_of_participant session participant in
+  let final_text =
+    match summary.final_text with
+    | Some _ as value -> value
+    | None -> Option.bind participant (fun p -> p.summary)
+  in
+  let error =
+    match summary.error with
+    | Some _ as value -> value
+    | None -> Option.bind participant (fun p -> p.last_error)
+  in
+  let failure_reason =
+    match validation.failure_reason with
+    | Some _ as value -> value
+    | None -> error
+  in
+  { worker_run_id = summary.run_ref.worker_run_id
+  ; worker_id =
+      first_some
+        (Option.bind participant (fun p -> p.worker_id))
+        (Some summary.run_ref.agent_name)
+  ; agent_name = summary.run_ref.agent_name
+  ; runtime_actor =
+      first_some
+        (Option.bind participant (fun p -> p.runtime_actor))
+        (Some summary.run_ref.agent_name)
+  ; role = Option.bind participant (fun p -> p.role)
+  ; aliases =
+      Option.bind participant (fun p -> Some p.aliases) |> Option.value ~default:[]
+  ; primary_alias = Option.bind participant (fun p -> primary_alias p.aliases)
+  ; provider
+  ; model
+  ; requested_provider = Option.bind participant (fun p -> p.requested_provider)
+  ; requested_model = Option.bind participant (fun p -> p.requested_model)
+  ; requested_policy =
+      first_some
+        (Option.bind participant (fun p -> p.requested_policy))
+        session.permission_mode
+  ; resolved_provider = provider
+  ; resolved_model = model
+  ; status = worker_status_of_participant participant
+  ; trace_capability = Raw
+  ; validated = validation.ok
+  ; tool_names = validation.tool_names
+  ; final_text
+  ; stop_reason = validation.stop_reason
+  ; error
+  ; failure_reason
+  ; accepted_at = Option.bind participant (fun p -> p.accepted_at)
+  ; ready_at = Option.bind participant (fun p -> p.ready_at)
+  ; first_progress_at = Option.bind participant (fun p -> p.first_progress_at)
+  ; started_at =
+      first_some (Option.bind participant (fun p -> p.started_at)) summary.started_at
+  ; finished_at =
+      first_some (Option.bind participant (fun p -> p.finished_at)) summary.finished_at
+  ; last_progress_at = Option.bind participant (fun p -> p.last_progress_at)
+  ; policy_snapshot = session.permission_mode
+  ; paired_tool_result_count = validation.paired_tool_result_count
+  ; has_file_write = validation.has_file_write
+  ; verification_pass_after_file_write = validation.verification_pass_after_file_write
+  }
+;;
+
+let summary_only_worker_run
+      (session : Runtime.session)
+      index
+      (participant : Runtime.participant)
+  =
+  let ts =
+    match participant.started_at with
+    | Some _ as value -> value
+    | None -> participant.finished_at
+  in
+  let stamp =
+    match ts with
+    | Some ts -> Int64.of_float (ts *. 1000.)
+    | None -> Int64.of_int index
+  in
+  { worker_run_id = Printf.sprintf "summary-only:%s:%Ld" participant.name stamp
+  ; worker_id = first_some participant.worker_id (Some participant.name)
+  ; agent_name = participant.name
+  ; runtime_actor = first_some participant.runtime_actor (Some participant.name)
+  ; role = participant.role
+  ; aliases = participant.aliases
+  ; primary_alias = primary_alias participant.aliases
+  ; provider = resolved_provider_of_participant session (Some participant)
+  ; model = resolved_model_of_participant session (Some participant)
+  ; requested_provider = participant.requested_provider
+  ; requested_model = participant.requested_model
+  ; requested_policy = first_some participant.requested_policy session.permission_mode
+  ; resolved_provider = resolved_provider_of_participant session (Some participant)
+  ; resolved_model = resolved_model_of_participant session (Some participant)
+  ; status = worker_status_of_participant (Some participant)
+  ; trace_capability = Summary_only
+  ; validated = false
+  ; tool_names = []
+  ; final_text = participant.summary
+  ; stop_reason = None
+  ; error = participant.last_error
+  ; failure_reason = participant.last_error
+  ; accepted_at = participant.accepted_at
+  ; ready_at = participant.ready_at
+  ; first_progress_at = participant.first_progress_at
+  ; started_at = participant.started_at
+  ; finished_at = participant.finished_at
+  ; last_progress_at = participant.last_progress_at
+  ; policy_snapshot = session.permission_mode
+  ; paired_tool_result_count = 0
+  ; has_file_write = false
+  ; verification_pass_after_file_write = false
+  }
+;;
+
+let unique_trace_capabilities worker_runs =
+  worker_runs
+  |> List.fold_left
+       (fun acc (worker : worker_run) ->
+          if List.exists (( = ) worker.trace_capability) acc
+          then acc
+          else acc @ [ worker.trace_capability ])
+       []
+;;
+
+let evidence_capabilities_of_bundle
+      ~raw_trace_runs
+      ~raw_trace_summaries
+      ~raw_trace_validations
+  =
+  { raw_trace = raw_trace_runs <> []
+  ; validated_summary = raw_trace_summaries <> [] && raw_trace_validations <> []
+  ; proof_bundle = true
+  }
+;;
+
+let get_worker_runs ?session_root ~session_id () =
+  let* session = get_session ?session_root session_id in
+  let* summaries = get_raw_trace_summaries ?session_root ~session_id () in
+  let* validations = get_raw_trace_validations ?session_root ~session_id () in
+  let validation_by_run =
+    validations
+    |> List.map (fun (validation : raw_trace_validation) ->
+      validation.run_ref.worker_run_id, validation)
+  in
+  let raw_worker_runs =
+    summaries
+    |> List.filter_map (fun (summary : raw_trace_summary) ->
+      match List.assoc_opt summary.run_ref.worker_run_id validation_by_run with
+      | Some validation -> Some (worker_run_of_raw session summary validation)
+      | None -> None)
+  in
+  let raw_agent_names = raw_worker_runs |> List.map (fun worker -> worker.agent_name) in
+  let summary_only_runs =
+    session.participants
+    |> List.mapi (fun index (participant : Runtime.participant) ->
+      if List.exists (String.equal participant.name) raw_agent_names
+      then None
+      else Some (summary_only_worker_run session index participant))
+    |> List.filter_map (fun value -> value)
+  in
+  Ok (sort_worker_runs (raw_worker_runs @ summary_only_runs))
+;;
+
+let get_latest_worker_run ?session_root ~session_id () =
+  let* workers = get_worker_runs ?session_root ~session_id () in
+  Ok (latest_worker_by (fun _ -> true) workers)
+;;
+
+let get_latest_accepted_worker_run ?session_root ~session_id () =
+  let* workers = get_worker_runs ?session_root ~session_id () in
+  Ok (latest_worker_by (fun worker -> worker.status = Accepted) workers)
+;;
+
+let get_latest_ready_worker_run ?session_root ~session_id () =
+  let* workers = get_worker_runs ?session_root ~session_id () in
+  Ok (latest_worker_by (fun worker -> worker.status = Ready) workers)
+;;
+
+let get_latest_running_worker_run ?session_root ~session_id () =
+  let* workers = get_worker_runs ?session_root ~session_id () in
+  Ok (latest_worker_by (fun worker -> worker.status = Running) workers)
+;;
+
+let get_latest_completed_worker_run ?session_root ~session_id () =
+  let* workers = get_worker_runs ?session_root ~session_id () in
+  Ok (latest_worker_by (fun worker -> worker.status = Completed) workers)
+;;
+
+let get_latest_failed_worker_run ?session_root ~session_id () =
+  let* workers = get_worker_runs ?session_root ~session_id () in
+  Ok (latest_worker_by (fun worker -> worker.status = Failed) workers)
+;;
+
+let get_latest_validated_worker_run ?session_root ~session_id () =
+  let* workers = get_worker_runs ?session_root ~session_id () in
+  Ok (latest_worker_by (fun worker -> worker.validated) workers)
+;;
+
+let get_proof_bundle ?session_root ~session_id () =
+  let* session = get_session ?session_root session_id in
+  let* report = get_report ?session_root ~session_id () in
+  let* proof = get_proof ?session_root ~session_id () in
+  let* telemetry = get_telemetry ?session_root ~session_id () in
+  let* structured_telemetry = get_telemetry_structured ?session_root ~session_id () in
+  let* evidence = get_evidence ?session_root ~session_id () in
+  let* hook_summary = get_hook_summary ?session_root ~session_id () in
+  let* tool_catalog = get_tool_catalog ?session_root ~session_id () in
+  let* latest_raw_trace_run = get_latest_raw_trace_run ?session_root ~session_id () in
+  let* raw_trace_runs = get_raw_trace_runs ?session_root ~session_id () in
+  let* raw_trace_summaries = summarize_runs raw_trace_runs in
+  let* raw_trace_validations = validate_runs raw_trace_runs in
+  let* worker_runs = get_worker_runs ?session_root ~session_id () in
+  let latest_worker_run = latest_worker_by (fun _ -> true) worker_runs in
+  let latest_accepted_worker_run =
+    latest_worker_by (fun worker -> worker.status = Accepted) worker_runs
+  in
+  let latest_ready_worker_run =
+    latest_worker_by (fun worker -> worker.status = Ready) worker_runs
+  in
+  let latest_running_worker_run =
+    latest_worker_by (fun worker -> worker.status = Running) worker_runs
+  in
+  let latest_completed_worker_run =
+    latest_worker_by (fun worker -> worker.status = Completed) worker_runs
+  in
+  let latest_validated_worker_run =
+    latest_worker_by (fun worker -> worker.validated) worker_runs
+  in
+  let latest_failed_worker_run =
+    latest_worker_by (fun worker -> worker.status = Failed) worker_runs
+  in
+  let validated_worker_runs =
+    worker_runs |> List.filter (fun worker -> worker.validated)
+  in
+  let raw_trace_run_count = List.length raw_trace_runs in
+  let validated_worker_run_count = List.length validated_worker_runs in
+  let trace_capabilities = unique_trace_capabilities worker_runs in
+  let capabilities =
+    evidence_capabilities_of_bundle
+      ~raw_trace_runs
+      ~raw_trace_summaries
+      ~raw_trace_validations
+  in
+  Ok
+    { session
+    ; report
+    ; proof
+    ; telemetry
+    ; structured_telemetry
+    ; evidence
+    ; hook_summary
+    ; tool_catalog
+    ; latest_raw_trace_run
+    ; raw_trace_runs
+    ; raw_trace_summaries
+    ; raw_trace_validations
+    ; worker_runs
+    ; latest_accepted_worker_run
+    ; latest_ready_worker_run
+    ; latest_running_worker_run
+    ; latest_worker_run
+    ; latest_completed_worker_run
+    ; latest_validated_worker_run
+    ; latest_failed_worker_run
+    ; validated_worker_runs
+    ; raw_trace_run_count
+    ; validated_worker_run_count
+    ; trace_capabilities
+    ; capabilities
+    }
+;;

--- a/lib/cdal_runtime/sessions_proof.mli
+++ b/lib/cdal_runtime/sessions_proof.mli
@@ -1,0 +1,118 @@
+(** Sessions proof assembly — worker-run construction and proof bundle.
+
+    Transforms raw trace data and runtime participant metadata into
+    structured {!Sessions_types.worker_run} records and assembles
+    the complete {!Sessions_types.proof_bundle}.
+
+    @stability Evolving
+    @since 0.93.1 *)
+
+open Sessions_types
+
+(** {1 Participant lookup} *)
+
+val participant_by_name : Runtime.session -> string -> Runtime.participant option
+
+(** Resolve the effective provider for a participant,
+    falling back to the session provider. *)
+val resolved_provider_of_participant
+  :  Runtime.session
+  -> Runtime.participant option
+  -> string option
+
+(** Resolve the effective model for a participant,
+    falling back to the session model. *)
+val resolved_model_of_participant
+  :  Runtime.session
+  -> Runtime.participant option
+  -> string option
+
+(** Map participant state to worker status. *)
+val worker_status_of_participant
+  :  Runtime.participant option
+  -> Sessions_types.worker_status
+
+(** Compute the ordering timestamp for a worker run:
+    [finished_at] > [last_progress_at] > [started_at]. *)
+val worker_order_ts : Sessions_types.worker_run -> float option
+
+(** {1 Worker run construction} *)
+
+val worker_run_of_raw
+  :  Runtime.session
+  -> raw_trace_summary
+  -> raw_trace_validation
+  -> worker_run
+
+val summary_only_worker_run : Runtime.session -> int -> Runtime.participant -> worker_run
+
+(** {1 Worker run queries} *)
+
+val sort_worker_runs : worker_run list -> worker_run list
+val latest_worker_by : (worker_run -> bool) -> worker_run list -> worker_run option
+
+val get_worker_runs
+  :  ?session_root:string
+  -> session_id:string
+  -> unit
+  -> (worker_run list, Error.sdk_error) result
+
+val get_latest_worker_run
+  :  ?session_root:string
+  -> session_id:string
+  -> unit
+  -> (worker_run option, Error.sdk_error) result
+
+val get_latest_accepted_worker_run
+  :  ?session_root:string
+  -> session_id:string
+  -> unit
+  -> (worker_run option, Error.sdk_error) result
+
+val get_latest_ready_worker_run
+  :  ?session_root:string
+  -> session_id:string
+  -> unit
+  -> (worker_run option, Error.sdk_error) result
+
+val get_latest_running_worker_run
+  :  ?session_root:string
+  -> session_id:string
+  -> unit
+  -> (worker_run option, Error.sdk_error) result
+
+val get_latest_completed_worker_run
+  :  ?session_root:string
+  -> session_id:string
+  -> unit
+  -> (worker_run option, Error.sdk_error) result
+
+val get_latest_failed_worker_run
+  :  ?session_root:string
+  -> session_id:string
+  -> unit
+  -> (worker_run option, Error.sdk_error) result
+
+val get_latest_validated_worker_run
+  :  ?session_root:string
+  -> session_id:string
+  -> unit
+  -> (worker_run option, Error.sdk_error) result
+
+(** {1 Evidence capabilities} *)
+
+val unique_trace_capabilities : worker_run list -> trace_capability list
+
+val evidence_capabilities_of_bundle
+  :  raw_trace_runs:raw_trace_run list
+  -> raw_trace_summaries:raw_trace_summary list
+  -> raw_trace_validations:raw_trace_validation list
+  -> evidence_capabilities
+
+(** {1 Proof bundle} *)
+
+val get_proof_bundle
+  :  ?session_root:string
+  -> session_id:string
+  -> unit
+  -> (proof_bundle, Error.sdk_error) result


### PR DESCRIPTION
## 요약

RFC-OAS-011 *마지막 이주 batch*. 8 모듈 / 16 파일 / **+3010 LoC**. governance/proof/safety scope의 모든 모듈 — 외부 CDAL deps 0건 verified. dune 변경 0.

본 PR 머지 시 *RFC-OAS-011 §2의 30+ 모듈이 모두 `masc_mcp.cdal_runtime`에 이주 완료* — 다음은 MM-3-rewire (consumer 일괄 전환).

## 이주 대상 (verbatim)

| 모듈 | LoC | Role |
|---|---|---|
| `audit.ml/mli` | 92 + 55 | agent run audit log |
| `autonomy_exec.ml/mli` | 458 + 71 | autonomous-mode execution safety |
| `autonomy_diff_guard.ml/mli` | 410 + 35 | autonomous diff guard |
| `autonomy_trace_analyzer.ml/mli` | 247 + 81 | autonomous trace analysis |
| `sessions_proof.ml/mli` | 362 + 118 | session-level proof bundle |
| `guardrail_tripwire.ml/mli` | 84 + 40 | content guardrail tripwire |
| `guardrails_async.ml/mli` | 170 + 78 | async guardrail runner |
| `runtime_evidence.ml/mli` | 623 + 86 | runtime evidence collector |

## 의존 검증 (pre-copy)

8 모듈 *모두* 외부 CDAL deps 0:

```bash
$ for m in audit autonomy_exec autonomy_diff_guard autonomy_trace_analyzer \
           sessions_proof guardrail_tripwire guardrails_async runtime_evidence; do
    rg -no '\b(Cdal_proof|Mode_enforcer|...|Sessions_proof)\b' \
       lib/$m.{ml,mli} | sort -u
  done
# 모두 self-prefix만 (audit:Audit, autonomy_exec:Autonomy_exec, ...)
```

이게 RFC-OAS-011 §1.1.2 *Implied CDAL* 분류의 *결정적 검증*: 이 모듈들이 *gold-standard CDAL types*에 직접 의존하지 않더라도 *architectural role*은 같음 (consumer-supplied governance instrumentation).

## Non-CDAL imports (existing dune covers)

| 모듈 | Import | 해결 |
|---|---|---|
| `autonomy_exec.ml` | `open Result_syntax` | `Agent_sdk_base` |
| `sessions_proof.ml` | `open Sessions_types`, `open Sessions_store`, `open Result_syntax` | `Agent_sdk` (full) + `Agent_sdk_base` |
| `guardrails_async.ml` | `open Types` | `Agent_sdk_base` |
| `runtime_evidence.ml` | `open Runtime`, `Session.X` | `Agent_sdk` (full) |
| `autonomy_trace_analyzer.ml` | `Trace.X` | `Agent_sdk` (full) |

**dune 변경 0건** — `cdal_runtime/dune`이 이미 #14257 fix 후 `agent_sdk` + `agent_sdk.base` libraries + `-open Agent_sdk_base -open Agent_sdk` flags 갖춤.

## RFC 시리즈 진행 (이주 phase 종결)

| PR | 상태 |
|---|---|
| RFC docs + OAS-B/C/D #1480-1483 | MERGED — RFC-OAS-009 v2 종결 |
| MM-1 #14247 (skel) | MERGED |
| MM-2-leaves #14248 (B1, 3 modules) | MERGED |
| MM-2-low #14253 (B2, 4 modules) | MERGED |
| MM-2-mid #14255 (B3, 2 modules) | MERGED |
| #14257 hotfix (include_subdirs no + open Agent_sdk) | MERGED |
| MM-2-high #14259 (B4, 6 modules) | MERGED |
| **MM-2-top (this) — B5, 8 modules** | OPEN, Draft |
| **이주 phase 누적** | **23 modules / ~7710 LoC migrated** |
| MM-3-rewire (Phase 1A consumers → Masc_mcp_cdal_runtime.*) | TBD |
| OAS-E (CDAL 30+ 모듈 OAS 제거 + agent_sdk 0.193.0) | masc-mcp MM-3 머지 후 |
| MM-4 (opam pin → 0.193.0) | OAS-E 머지 후 |

## 위험 (3건)

| # | 위험 | 완화 |
|---|---|---|
| 1 | runtime_evidence 623 LoC + sessions_proof 362 LoC가 *Sessions_types/Sessions_store/Runtime* 같은 *agent_sdk full*의 deeper API 사용 — 이주 후 wrapped library context에서 같은 module path 해결되는지 | `cdal_runtime/dune`의 `-open Agent_sdk` flag로 unqualified `Sessions_types`/`Sessions_store`/`Runtime`이 모두 `Agent_sdk.X`로 resolve. agent_sdk full library에 이 모듈 모두 포함됨 |
| 2 | `autonomy_*` 4 모듈 (1115 + 187 LoC)이 *cross-module 호출*이 있을 수 있음 — autonomy_exec가 audit 호출, autonomy_diff_guard가 autonomy_exec 호출 등 | grep으로 verified: B5 모듈 간 *cross-prefix 매치 0건*. 즉 self-contained — dune이 batch 내 ordering 자동 (의존 0이므로 순서 무관) |
| 3 | 16 파일 동시 ppx_inline_test 처리 중 dune이 stuck | dune 4.x default parallel 빌드. 사용자가 머지한 main 환경에서 CI 검증 |

## Test plan

- [ ] CI green — `cdal_runtime` 23 모듈 (B1+B2+B3+B4+B5) 빌드 통과
- [ ] CodeRabbit/사람 리뷰 코멘트 대응
- [ ] `human-approved-ready` 라벨 부착 후 머지

🤖 Generated with [Claude Code](https://claude.com/claude-code)