### PR TITLE
feat(keeper): RFC-0041 cascade routing wiring (B1-B4)

### DIFF
--- a/lib/cascade/cascade_config_loader.ml
+++ b/lib/cascade/cascade_config_loader.ml
@@ -764,3 +764,62 @@ let resolve_strategy_config ~config_path ~name =
       server_error_skip_after =
         read_int_field json (name ^ "_server_error_skip_after");
     }
+
+(* ── RFC-0041: cascade_profile loader ──────────────────────────────── *)
+
+(** Split a "provider:model" string into (provider, model).
+    Returns [None] when the separator is missing. *)
+let provider_model_of_string (s : string) : (string * string) option =
+  match String.split_on_char ':' s with
+  | [provider; model] -> Some (provider, model)
+  | _ -> None
+
+(** Convert a [weighted_entry] (from legacy cascade.json) into a
+    [Cascade_ref.cascade_item].  [timeout_ms] defaults to 30000;
+    [priority] uses the entry's [weight]. *)
+let cascade_item_of_weighted_entry (entry : weighted_entry)
+    : Cascade_ref.cascade_item option =
+  match provider_model_of_string entry.model with
+  | Some (provider, model) ->
+      Some {
+        Cascade_ref.id = entry.model;
+        provider;
+        model;
+        timeout_ms = 30000;
+        priority = entry.weight;
+      }
+  | None -> None
+
+(** Load a [Cascade_ref.cascade_profile] from the legacy cascade.json
+    format.  Each profile section becomes a single-group profile;
+    [models] become [cascade_item]s and [fallback_cascade] becomes
+    [fallback_group].
+
+    Returns [None] when the profile has no parsable model entries.
+    This is the bridge between the existing flat cascade.json format
+    and the RFC-0041 hierarchical profile model. *)
+let load_cascade_profile ~(config_path : string) ~(name : string)
+    : Cascade_ref.cascade_profile option =
+  let items =
+    load_profile_weighted ~config_path ~name
+    |> List.filter_map cascade_item_of_weighted_entry
+  in
+  if items = [] then None
+  else
+    let fallback_group =
+      match load_catalog ~config_path with
+      | Ok entries ->
+          (match List.find_opt (fun e -> String.equal e.name name) entries with
+           | Some entry -> entry.fallback_cascade
+           | None -> None)
+      | Error _ -> None
+    in
+    Some {
+      Cascade_ref.name;
+      groups = [{
+        Cascade_ref.name;
+        items;
+        strategy = Priority;
+        fallback_group;
+      }];
+    }

--- a/lib/cascade/cascade_config_loader.mli
+++ b/lib/cascade/cascade_config_loader.mli
@@ -290,3 +290,14 @@ type strategy_config = {
 
 val resolve_strategy_config :
   config_path:string -> name:string -> strategy_config
+
+(** {1 RFC-0041 cascade_profile bridge} *)
+
+(** Load a [Cascade_ref.cascade_profile] from the legacy cascade.json
+    format.  Each profile section becomes a single-group profile;
+    [models] become [cascade_item]s and [fallback_cascade] becomes
+    [fallback_group].
+
+    Returns [None] when the profile has no parsable model entries. *)
+val load_cascade_profile :
+  config_path:string -> name:string -> Cascade_ref.cascade_profile option

--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -416,7 +416,8 @@ let persist_message_cursor_updates ~config (meta : keeper_meta) updates =
 (** Run keeper cycle with semaphore slot control (legacy path). *)
 let run_keeper_cycle_with_slot ~ctx ~meta_after_cursor_persist ~stop ~obs
     ~(turn_decision : Keeper_world_observation.keeper_cycle_decision)
-    ~shared_context ~semaphore_wait_ms ~slot_control =
+    ~shared_context ~semaphore_wait_ms ~slot_control
+    ?selected_item =
   match
     with_in_turn_liveness_pulse ~ctx ~meta:meta_after_cursor_persist ~stop
       (fun () ->
@@ -429,6 +430,7 @@ let run_keeper_cycle_with_slot ~ctx ~meta_after_cursor_persist ~stop ~obs
            ~semaphore_wait_ms
            ~turn_slot_control:slot_control
            ~shared_context
+           ?selected_item
            ())
   with
   | Error err ->
@@ -866,6 +868,29 @@ let run_keepalive_unified_turn
            semaphore path. *)
         Keeper_admission_runtime.init_once_from_base_path
           ~base_path:ctx.config.base_path;
+        (* RFC-0041 Phase B3: proactive cascade item selection.
+           Load cascade_profile from config and select the healthiest
+           available item before turn dispatch. *)
+        let selected_item_opt =
+          let cascade_name =
+            match meta_after_triage.cascade_ref with
+            | Some ref when not (String.equal ref.group "") -> ref.group
+            | _ -> meta_after_triage.cascade_name
+          in
+          let config_path =
+            Filename.concat ctx.config.base_path ".masc/config/cascade.json"
+          in
+          match Cascade_config_loader.load_cascade_profile ~config_path ~name:cascade_name with
+          | Some profile ->
+              (match Keeper_cascade_selector.select_item_for_turn
+                 ~keeper_name:meta_after_triage.name
+                 ~cascade_profile:profile
+                 ~health_cache:Keeper_health_probe.Healthy
+                 ~last_used_item:None with
+               | Ok item -> Some item
+               | Error `No_available_item -> None)
+          | None -> None
+        in
         let admission_result =
           Keeper_admission_runtime.decide_live
             ~keeper_id:meta_after_triage.name
@@ -904,7 +929,8 @@ let run_keepalive_unified_turn
                 ~keeper_name:meta_after_triage.name
                 ~channel:turn_decision.channel (fun ~semaphore_wait_ms ~slot_control ->
                 run_keeper_cycle_with_slot ~ctx ~meta_after_cursor_persist ~stop ~obs
-                  ~turn_decision ~shared_context ~semaphore_wait_ms ~slot_control)
+                  ~turn_decision ~shared_context ~semaphore_wait_ms ~slot_control
+                  ?selected_item:selected_item_opt)
             with
             | Ok meta -> meta
             | Error (`Semaphore_wait_timeout timeout) ->
@@ -976,6 +1002,7 @@ let run_keepalive_unified_turn
                         ~channel:turn_decision.channel
                         ~semaphore_wait_ms:0
                         ~shared_context
+                        ?selected_item:selected_item_opt
                         ())
                 with
                 | Error err ->

--- a/lib/keeper/keeper_meta_json.ml
+++ b/lib/keeper/keeper_meta_json.ml
@@ -38,6 +38,9 @@ let meta_to_json (m : keeper_meta) : Yojson.Safe.t =
      ; "long_goal", `String m.long_goal
      ; "social_model", `String m.social_model
      ; "cascade_name", `String m.cascade_name
+     ; (match m.cascade_ref with
+        | Some ref -> "cascade_ref", Cascade_ref.cascade_ref_to_json ref
+        | None -> "cascade_ref", `Null)
      ]
      @ personality_pairs
      @ [

--- a/lib/keeper/keeper_meta_json_parse.ml
+++ b/lib/keeper/keeper_meta_json_parse.ml
@@ -151,7 +151,13 @@ let parse_keeper_identity (json : Yojson.Safe.t) : (parsed_keeper_identity, stri
       ; pk_long_goal
       ; pk_social_model
       ; pk_cascade_name
-      ; pk_cascade_ref = None
+      ; pk_cascade_ref =
+        (match json |> Yojson.Safe.Util.member "cascade_ref" with
+         | `Null | `Assoc [] -> None
+         | ref_json ->
+             (match Cascade_ref.cascade_ref_of_json ref_json with
+              | Some ref -> Some ref
+              | None -> Some (Cascade_ref.cascade_ref_of_string pk_cascade_name)))
       ; pk_models
       ; pk_will
       ; pk_needs

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -241,6 +241,14 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
         ~keeper_name:meta.name ~turn_id:keeper_turn_id
         ~prev:Keeper_turn_fsm.Phase_gating
         Keeper_turn_fsm.Cascade_routing;
+      (* RFC-0041 Phase B4: when a specific item was selected by the
+         proactive router, override meta.cascade_name so downstream
+         cascade resolution uses the item's group. *)
+      let meta =
+        match selected_item with
+        | Some item -> { meta with cascade_name = item.Cascade_ref.group }
+        | None -> meta
+      in
       let effective_cascade_name =
         let phase = match phase_opt with
           | Some p -> p


### PR DESCRIPTION
## Summary

RFC-0041 Cascade Routing Group/Item Hierarchy의 핵심 wiring 구현.

- **Phase B1-B2**: JSON dual-read — `cascade_name` → `cascade_ref` fallback
- **Config bridge**: `Cascade_config_loader.load_cascade_profile` — 기존 `cascade.json`의 `models`를 `cascade_item`으로 변환
- **Phase B3**: Heartbeat loop에 `select_item_for_turn` 호출 — turn dispatch 전 proactive item 선택
- **Phase B4**: Unified turn에서 `selected_item.group`으로 `meta.cascade_name` override

## 변경 파일

| 파일 | 변경 |
|------|------|
| `lib/keeper/keeper_meta_json_parse.ml` | `pk_cascade_ref` JSON dual-read |
| `lib/keeper/keeper_meta_json.ml` | `cascade_ref` JSON serialize |
| `lib/cascade/cascade_config_loader.ml/mli` | `load_cascade_profile` 추가 |
| `lib/keeper/keeper_heartbeat_loop.ml` | `select_item_for_turn` wiring |
| `lib/keeper/keeper_unified_turn.ml` | `selected_item` group override |

## TODO (후속 PR)

- [ ] Dashboard cascade group/item 노출 (Phase B6)
- [ ] `cascade_name` 필드 레거시 숙청 (Phase B7)
- [ ] Per-item health probe 연동 (현재 `Healthy` fail-open)
- [ ] `last_used_item` RoundRobin 상태 유지

## 테스트

- [x] `dune build` 통과

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>