### PR TITLE
feat(masc_mcp): atomic flip Agent_sdk → Masc_mcp_cdal_runtime (RFC-OAS-011 MM-3-rewire)

### DIFF
--- a/lib/autoresearch/autoresearch_metric.ml
+++ b/lib/autoresearch/autoresearch_metric.ml
@@ -126,14 +126,14 @@ let parse_metric_output output =
 
 let run_metric_argv ~workdir ~timeout_s argv =
   let config =
-    { Agent_sdk.Autonomy_exec.default_config with
+    { Masc_mcp_cdal_runtime.Autonomy_exec.default_config with
       cwd = Some workdir; }
   in
   match Process_eio.get_clock () with
   | Error e -> Result.error (Printf.sprintf "metric_fn runtime unavailable: %s" e)
   | Ok clock ->
     Eio.Switch.run @@ fun sw ->
-    match Agent_sdk.Autonomy_exec.run ~sw ~clock ~config ~argv ~timeout_s with
+    match Masc_mcp_cdal_runtime.Autonomy_exec.run ~sw ~clock ~config ~argv ~timeout_s with
     | Error err ->
       Result.error
         (Printf.sprintf "metric_fn exec failed: %s"
@@ -141,7 +141,7 @@ let run_metric_argv ~workdir ~timeout_s argv =
     | Ok output ->
       let elapsed_ms = int_of_float (output.elapsed_s *. 1000.0) in
       (match output.status with
-       | Agent_sdk.Autonomy_exec.Exit_code 0 ->
+       | Masc_mcp_cdal_runtime.Autonomy_exec.Exit_code 0 ->
          Result.ok (output.stdout, elapsed_ms)
        | status ->
          let detail =
@@ -149,17 +149,17 @@ let run_metric_argv ~workdir ~timeout_s argv =
            let stdout = String.trim output.stdout in
            if stderr <> "" then stderr
            else if stdout <> "" then stdout
-           else Agent_sdk.Autonomy_exec.argv_to_string output.effective_argv
+           else Masc_mcp_cdal_runtime.Autonomy_exec.argv_to_string output.effective_argv
          in
          Result.error
            (Printf.sprintf "metric_fn %s: %s"
-              (Agent_sdk.Autonomy_exec.status_to_string status)
+              (Masc_mcp_cdal_runtime.Autonomy_exec.status_to_string status)
               (clip detail 240)))
 
 (** Run metric_fn command and parse either a strict metric tag or the last
     non-empty stdout line as a float.
     Returns Error if command fails, metric_fn is unsafe, or output is not a valid float.
-    Uses Agent_sdk.Autonomy_exec for argv-only execution. *)
+    Uses Masc_mcp_cdal_runtime.Autonomy_exec for argv-only execution. *)
 let measure_metric ~workdir ~timeout_s metric_fn =
   match split_metric_fn_argv metric_fn with
   | Error e -> Error e

--- a/lib/autoresearch/autoresearch_metric.mli
+++ b/lib/autoresearch/autoresearch_metric.mli
@@ -1,6 +1,6 @@
 (** Autoresearch_metric — Metric measurement and retry logic.
 
-    Runs a shell command ([metric_fn]) via [Agent_sdk.Autonomy_exec]
+    Runs a shell command ([metric_fn]) via [Masc_mcp_cdal_runtime.Autonomy_exec]
     (argv-only execution, no shell interpreter) and parses either a
     strict metric-contract tag or the last non-empty stdout line as a
     float score. Supports retry on transient errors (timeout,
@@ -37,7 +37,7 @@ val validate_metric_fn : string -> (string, string) result
 (** {1 Execution} *)
 
 (** [run_metric_argv ~workdir ~timeout_s argv] executes [argv] under
-    [Agent_sdk.Autonomy_exec.run] and returns
+    [Masc_mcp_cdal_runtime.Autonomy_exec.run] and returns
     [(stdout, elapsed_ms)] on exit code 0, or an [Error] describing the
     failure (including clock unavailability, non-zero exit, timeout,
     signal). *)

--- a/lib/autoresearch/dune
+++ b/lib/autoresearch/dune
@@ -21,4 +21,5 @@
    masc_process
    masc_mcp.masc_exec
    agent_sdk
+   masc_mcp.cdal_runtime
    eio))

--- a/lib/cdal_eval_v1.ml
+++ b/lib/cdal_eval_v1.ml
@@ -19,7 +19,7 @@ let load_failure_artifact = function
   | Cdal_loader.Schema_unsupported _ -> "manifest.json"
   | Cdal_loader.Ref_resolution_error _ -> "contract.json"
 
-let synthesize_inconclusive ~(proof : Agent_sdk.Cdal_proof.t)
+let synthesize_inconclusive ~(proof : Masc_mcp_cdal_runtime.Cdal_proof.t)
     (err : Cdal_loader.load_error) : Cdal_types.contract_verdict =
   let gap : Cdal_types.completeness_gap = {
     artifact = load_failure_artifact err;
@@ -53,8 +53,8 @@ let synthesize_inconclusive ~(proof : Agent_sdk.Cdal_proof.t)
 (* Evaluation pipeline                                              *)
 (* ================================================================ *)
 
-let evaluate ~(store : Agent_sdk.Proof_store.config)
-    (proof : Agent_sdk.Cdal_proof.t) : eval_outcome =
+let evaluate ~(store : Masc_mcp_cdal_runtime.Proof_store.config)
+    (proof : Masc_mcp_cdal_runtime.Cdal_proof.t) : eval_outcome =
   match Cdal_loader.load ~store proof with
   | Ok bundle ->
     let verdict = Cdal_judge.judge bundle in

--- a/lib/cdal_eval_v1.mli
+++ b/lib/cdal_eval_v1.mli
@@ -14,8 +14,8 @@ type eval_outcome =
 
 (** Run the full evaluation pipeline: load bundle, judge, compute friction. *)
 val evaluate :
-  store:Agent_sdk.Proof_store.config ->
-  Agent_sdk.Cdal_proof.t ->
+  store:Masc_mcp_cdal_runtime.Proof_store.config ->
+  Masc_mcp_cdal_runtime.Cdal_proof.t ->
   eval_outcome
 
 (** Extract the verdict from either outcome branch. *)

--- a/lib/cdal_friction_projection.ml
+++ b/lib/cdal_friction_projection.ml
@@ -44,13 +44,13 @@ let effects_suffix = "evidence/effects.json"
 let review_warning_suffix = "evidence/review_warning.json"
 
 (** Find the first raw_evidence_ref that ends with mode_violations.json. *)
-let find_violations_ref (proof : Agent_sdk.Cdal_proof.t) : string option =
+let find_violations_ref (proof : Masc_mcp_cdal_runtime.Cdal_proof.t) : string option =
   List.find_opt
     (fun ref_ -> String.ends_with ~suffix:mode_violations_suffix ref_)
     proof.raw_evidence_refs
 
 (** Find the first raw_evidence_ref that ends with effects.json. *)
-let find_effects_ref (proof : Agent_sdk.Cdal_proof.t) : string option =
+let find_effects_ref (proof : Masc_mcp_cdal_runtime.Cdal_proof.t) : string option =
   List.find_opt
     (fun ref_ -> String.ends_with ~suffix:effects_suffix ref_)
     proof.raw_evidence_refs
@@ -60,7 +60,7 @@ let key_of_violation (v : Violation_record.t) : blocked_attempt_key =
   {
     tool_name = v.tool_name;
     violation_kind = Violation_record.violation_kind_to_string v.violation_kind;
-    effective_mode = Agent_sdk.Execution_mode.to_string v.effective_mode;
+    effective_mode = Masc_mcp_cdal_runtime.Execution_mode.to_string v.effective_mode;
   }
 
 (** Compare two keys for stable sorting. *)
@@ -152,8 +152,8 @@ let source_path_gap : Cdal_types.completeness_gap =
 
 let source_path_tripwire = "source_path_evidence:mode_enforcer"
 
-let effects_have_source_path ~(store : Agent_sdk.Proof_store.config)
-    (proof : Agent_sdk.Cdal_proof.t) : bool =
+let effects_have_source_path ~(store : Masc_mcp_cdal_runtime.Proof_store.config)
+    (proof : Masc_mcp_cdal_runtime.Cdal_proof.t) : bool =
   match find_effects_ref proof with
   | None -> false
   | Some ref_ ->
@@ -164,8 +164,8 @@ let effects_have_source_path ~(store : Agent_sdk.Proof_store.config)
       | Error _ -> false
       | Ok events -> Effect_evidence.any_source_path_present events
 
-let source_path_gaps_for_run ~(store : Agent_sdk.Proof_store.config)
-    ~(blocked_attempt_count : int) (proof : Agent_sdk.Cdal_proof.t)
+let source_path_gaps_for_run ~(store : Masc_mcp_cdal_runtime.Proof_store.config)
+    ~(blocked_attempt_count : int) (proof : Masc_mcp_cdal_runtime.Cdal_proof.t)
     : Cdal_types.completeness_gap list =
   if blocked_attempt_count = 0 || effects_have_source_path ~store proof then []
   else [ source_path_gap ]
@@ -175,10 +175,10 @@ let source_path_gaps_for_run ~(store : Agent_sdk.Proof_store.config)
 (* ================================================================ *)
 
 let project_single_run
-    ~(store : Agent_sdk.Proof_store.config)
+    ~(store : Masc_mcp_cdal_runtime.Proof_store.config)
     ?(completeness_gaps : Cdal_types.completeness_gap list = [])
     ?(tripwire_threshold = 3)
-    (proof : Agent_sdk.Cdal_proof.t)
+    (proof : Masc_mcp_cdal_runtime.Cdal_proof.t)
     : friction_projection option =
   let groups, blocked_attempt_count =
     match find_violations_ref proof with
@@ -288,8 +288,8 @@ let merge_groups (all_groups : blocked_attempt_group list list)
   |> List.sort (fun a b -> compare_key a.key b.key)
 
 let project_single_run_groups
-    ~(store : Agent_sdk.Proof_store.config)
-    (proof : Agent_sdk.Cdal_proof.t)
+    ~(store : Masc_mcp_cdal_runtime.Proof_store.config)
+    (proof : Masc_mcp_cdal_runtime.Cdal_proof.t)
     : blocked_attempt_group list * int =
   match find_violations_ref proof with
   | None -> ([], 0)
@@ -306,11 +306,11 @@ let project_single_run_groups
         (g, c)
 
 let project_window
-    ~(store : Agent_sdk.Proof_store.config)
+    ~(store : Masc_mcp_cdal_runtime.Proof_store.config)
     ~(window : run_window)
     ?(completeness_gaps : Cdal_types.completeness_gap list = [])
     ?(tripwire_threshold = 3)
-    (proofs : Agent_sdk.Cdal_proof.t list)
+    (proofs : Masc_mcp_cdal_runtime.Cdal_proof.t list)
     : friction_projection option =
   match window, proofs with
   | Single_run, [proof] ->
@@ -350,7 +350,7 @@ let project_window
     in
     if blocked_attempt_count = 0 && gap_groups = [] then None
     else
-      let run_ids = List.map (fun (p : Agent_sdk.Cdal_proof.t) -> p.run_id) proofs in
+      let run_ids = List.map (fun (p : Masc_mcp_cdal_runtime.Cdal_proof.t) -> p.run_id) proofs in
       Some {
         window = window_to_string window;
         based_on_run_ids = run_ids;

--- a/lib/cdal_friction_projection.mli
+++ b/lib/cdal_friction_projection.mli
@@ -56,10 +56,10 @@ type friction_projection = {
 
     Returns [None] when no violations and no completeness gaps exist. *)
 val project_single_run :
-  store:Agent_sdk.Proof_store.config ->
+  store:Masc_mcp_cdal_runtime.Proof_store.config ->
   ?completeness_gaps:Cdal_types.completeness_gap list ->
   ?tripwire_threshold:int ->
-  Agent_sdk.Cdal_proof.t ->
+  Masc_mcp_cdal_runtime.Cdal_proof.t ->
   friction_projection option
 
 (** Canonical JSON serialization with sorted keys. *)
@@ -86,11 +86,11 @@ type run_window =
 
     @since CDAL Phase 3 *)
 val project_window :
-  store:Agent_sdk.Proof_store.config ->
+  store:Masc_mcp_cdal_runtime.Proof_store.config ->
   window:run_window ->
   ?completeness_gaps:Cdal_types.completeness_gap list ->
   ?tripwire_threshold:int ->
-  Agent_sdk.Cdal_proof.t list ->
+  Masc_mcp_cdal_runtime.Cdal_proof.t list ->
   friction_projection option
 
 (** Compute deterministic basis hash for cross-run window.

--- a/lib/cdal_judge.ml
+++ b/lib/cdal_judge.ml
@@ -15,10 +15,10 @@ let check_execution_mode (b : Cdal_loader.loaded_bundle) : Cdal_types.check_resu
   let proof_effective = proof.effective_execution_mode in
   (* Propagation: proof.requested must match contract.runtime_constraints.requested *)
   let propagation_ok =
-    Agent_sdk.Execution_mode.equal proof_requested contract_mode in
+    Masc_mcp_cdal_runtime.Execution_mode.equal proof_requested contract_mode in
   (* No-upward-escalation: effective <= requested *)
   let escalation_ok =
-    Agent_sdk.Execution_mode.can_serve
+    Masc_mcp_cdal_runtime.Execution_mode.can_serve
       ~requested:proof_requested ~effective:proof_effective in
   if propagation_ok && escalation_ok then
     { check_id; status = Satisfied; findings = []; completeness_gaps = [] }
@@ -28,18 +28,18 @@ let check_execution_mode (b : Cdal_loader.loaded_bundle) : Cdal_types.check_resu
       findings := ({ Cdal_types.
         check_id;
         event_id = None;
-        observed = `String (Agent_sdk.Execution_mode.to_string proof_requested);
-        expected = `String (Agent_sdk.Execution_mode.to_string contract_mode);
+        observed = `String (Masc_mcp_cdal_runtime.Execution_mode.to_string proof_requested);
+        expected = `String (Masc_mcp_cdal_runtime.Execution_mode.to_string contract_mode);
         trace_ref = None;
       } : Cdal_types.contract_finding) :: !findings;
     if not escalation_ok then
       findings := ({ Cdal_types.
         check_id;
         event_id = Some "escalation";
-        observed = `String (Agent_sdk.Execution_mode.to_string proof_effective);
+        observed = `String (Masc_mcp_cdal_runtime.Execution_mode.to_string proof_effective);
         expected = `String
           (Printf.sprintf "<= %s"
-             (Agent_sdk.Execution_mode.to_string proof_requested));
+             (Masc_mcp_cdal_runtime.Execution_mode.to_string proof_requested));
         trace_ref = None;
       } : Cdal_types.contract_finding) :: !findings;
     { check_id; status = Violated;
@@ -54,15 +54,15 @@ let check_risk_class (b : Cdal_loader.loaded_bundle) : Cdal_types.check_result =
   let check_id = "runtime.risk_class" in
   let contract_risk = b.contract.runtime_constraints.risk_class in
   let proof_risk = b.proof.risk_class in
-  if Agent_sdk.Risk_class.equal contract_risk proof_risk then
+  if Masc_mcp_cdal_runtime.Risk_class.equal contract_risk proof_risk then
     { check_id; status = Satisfied; findings = []; completeness_gaps = [] }
   else
     { check_id; status = Violated;
       findings = [{
         check_id;
         event_id = None;
-        observed = `String (Agent_sdk.Risk_class.to_string proof_risk);
-        expected = `String (Agent_sdk.Risk_class.to_string contract_risk);
+        observed = `String (Masc_mcp_cdal_runtime.Risk_class.to_string proof_risk);
+        expected = `String (Masc_mcp_cdal_runtime.Risk_class.to_string contract_risk);
         trace_ref = None;
       }];
       completeness_gaps = [] }
@@ -106,7 +106,7 @@ let check_required_artifact (_b : Cdal_loader.loaded_bundle) : Cdal_types.check_
 
 let review_warning_artifact = "evidence/review_warning.json"
 
-let has_review_warning_ref (proof : Agent_sdk.Cdal_proof.t) : bool =
+let has_review_warning_ref (proof : Masc_mcp_cdal_runtime.Cdal_proof.t) : bool =
   List.exists
     (fun ref_ -> String.ends_with ~suffix:review_warning_artifact ref_)
     proof.raw_evidence_refs

--- a/lib/cdal_loader.ml
+++ b/lib/cdal_loader.ml
@@ -3,9 +3,9 @@
     @since CDAL Phase 1A *)
 
 type loaded_bundle = {
-  proof : Agent_sdk.Cdal_proof.t;
+  proof : Masc_mcp_cdal_runtime.Cdal_proof.t;
   manifest_json : Yojson.Safe.t;
-  contract : Agent_sdk.Risk_contract.t;
+  contract : Masc_mcp_cdal_runtime.Risk_contract.t;
   contract_json : Yojson.Safe.t;
   recomputed_contract_id : string;
 }
@@ -29,7 +29,7 @@ let load_error_to_string = function
     Printf.sprintf "contract parse error: %s" msg
   | Schema_unsupported v ->
     Printf.sprintf "unsupported schema version: %d (expected %d)"
-      v Agent_sdk.Cdal_proof.schema_version_current
+      v Masc_mcp_cdal_runtime.Cdal_proof.schema_version_current
   | Ref_resolution_error msg ->
     Printf.sprintf "ref resolution error: %s" msg
 
@@ -50,13 +50,13 @@ let read_json_file path =
 (* Load pipeline                                                     *)
 (* ================================================================ *)
 
-let load ~(store : Agent_sdk.Proof_store.config)
-    (proof : Agent_sdk.Cdal_proof.t)
+let load ~(store : Masc_mcp_cdal_runtime.Proof_store.config)
+    (proof : Masc_mcp_cdal_runtime.Cdal_proof.t)
     : (loaded_bundle, load_error) result =
   let open Result.Syntax in
   (* 1. Compute manifest path and read *)
   let manifest_path =
-    Agent_sdk.Proof_store.manifest_path store ~run_id:proof.run_id in
+    Masc_mcp_cdal_runtime.Proof_store.manifest_path store ~run_id:proof.run_id in
   let* manifest_json =
     read_json_file manifest_path
     |> Result.map_error (function
@@ -64,11 +64,11 @@ let load ~(store : Agent_sdk.Proof_store.config)
       | Parse_error msg -> Manifest_parse_error msg)
   in
   let* manifest_proof =
-    Agent_sdk.Cdal_proof.of_json manifest_json
+    Masc_mcp_cdal_runtime.Cdal_proof.of_json manifest_json
     |> Result.map_error (fun msg -> Manifest_parse_error msg)
   in
   (* 2. Check schema version from stored manifest *)
-  if manifest_proof.schema_version <> Agent_sdk.Cdal_proof.schema_version_current then
+  if manifest_proof.schema_version <> Masc_mcp_cdal_runtime.Cdal_proof.schema_version_current then
     Error (Schema_unsupported manifest_proof.schema_version)
   else
   (* 3. Compute contract path via the local proof-store adapter. *)
@@ -85,11 +85,11 @@ let load ~(store : Agent_sdk.Proof_store.config)
   in
   (* 4. Decode contract with Agent_sdk *)
   let* contract =
-    Agent_sdk.Risk_contract.of_yojson contract_json
+    Masc_mcp_cdal_runtime.Risk_contract.of_yojson contract_json
     |> Result.map_error (fun msg -> Contract_parse_error msg)
   in
   (* 5. Recompute contract_id *)
-  let recomputed_contract_id = Agent_sdk.Risk_contract.contract_id contract in
+  let recomputed_contract_id = Masc_mcp_cdal_runtime.Risk_contract.contract_id contract in
   Ok {
     proof = manifest_proof;
     manifest_json;

--- a/lib/cdal_loader.mli
+++ b/lib/cdal_loader.mli
@@ -10,9 +10,9 @@
     [proof] is the decoded manifest proof, which is treated as the
     stored truth source for phase-1A replay. *)
 type loaded_bundle = {
-  proof : Agent_sdk.Cdal_proof.t;
+  proof : Masc_mcp_cdal_runtime.Cdal_proof.t;
   manifest_json : Yojson.Safe.t;
-  contract : Agent_sdk.Risk_contract.t;
+  contract : Masc_mcp_cdal_runtime.Risk_contract.t;
   contract_json : Yojson.Safe.t;
   recomputed_contract_id : string;
 }
@@ -35,8 +35,8 @@ type load_error =
     4. Decode with Agent_sdk types
     5. Recompute contract_id *)
 val load :
-  store:Agent_sdk.Proof_store.config ->
-  Agent_sdk.Cdal_proof.t ->
+  store:Masc_mcp_cdal_runtime.Proof_store.config ->
+  Masc_mcp_cdal_runtime.Cdal_proof.t ->
   (loaded_bundle, load_error) result
 
 (** Human-readable error description. *)

--- a/lib/dune
+++ b/lib/dune
@@ -238,6 +238,7 @@
    agent_sdk
    agent_sdk.base
    agent_sdk.llm_provider
+   masc_mcp.cdal_runtime
    masc_mcp.oas_compat
 
    uri

--- a/lib/keeper/keeper_agent_result.ml
+++ b/lib/keeper/keeper_agent_result.ml
@@ -40,7 +40,7 @@ type run_result =
   ; tools_used : string list
   ; tool_calls : tool_call_detail list
   ; checkpoint : Agent_sdk.Checkpoint.t option
-  ; proof : Agent_sdk.Cdal_proof.t option
+  ; proof : Masc_mcp_cdal_runtime.Cdal_proof.t option
   ; trace_ref : Agent_sdk.Raw_trace.run_ref option
   ; run_validation : Agent_sdk.Raw_trace.run_validation option
   ; stop_reason : Oas_worker.stop_reason

--- a/lib/keeper/keeper_agent_result.mli
+++ b/lib/keeper/keeper_agent_result.mli
@@ -24,7 +24,7 @@ type run_result =
   ; tools_used : string list
   ; tool_calls : tool_call_detail list
   ; checkpoint : Agent_sdk.Checkpoint.t option
-  ; proof : Agent_sdk.Cdal_proof.t option
+  ; proof : Masc_mcp_cdal_runtime.Cdal_proof.t option
   ; trace_ref : Agent_sdk.Raw_trace.run_ref option
   ; run_validation : Agent_sdk.Raw_trace.run_validation option
   ; stop_reason : Oas_worker.stop_reason

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -964,7 +964,7 @@ let run_turn
            (match result.proof with
             | Some p ->
               Keeper_turn_telemetry.log_keeper_proof ~keeper_name:meta.name p;
-              let store = Agent_sdk.Proof_store.default_config in
+              let store = Masc_mcp_cdal_runtime.Proof_store.default_config in
               let outcome = Cdal_eval_v1.evaluate ~store p in
               let verdict = Cdal_eval_v1.verdict_of_outcome outcome in
 	              let task_subject =

--- a/lib/keeper/keeper_agent_run.mli
+++ b/lib/keeper/keeper_agent_run.mli
@@ -88,7 +88,7 @@ type run_result =
   ; tools_used : string list
   ; tool_calls : tool_call_detail list
   ; checkpoint : Agent_sdk.Checkpoint.t option
-  ; proof : Agent_sdk.Cdal_proof.t option
+  ; proof : Masc_mcp_cdal_runtime.Cdal_proof.t option
   ; trace_ref : Agent_sdk.Raw_trace.run_ref option
   ; run_validation : Agent_sdk.Raw_trace.run_validation option
   ; stop_reason : Oas_worker.stop_reason

--- a/lib/keeper/keeper_cdal_contract.ml
+++ b/lib/keeper/keeper_cdal_contract.ml
@@ -1,4 +1,4 @@
 (* Team session contract system removed (#6107). *)
 let of_keeper_meta (_meta : Keeper_types.keeper_meta)
-    : Agent_sdk.Risk_contract.t option =
+    : Masc_mcp_cdal_runtime.Risk_contract.t option =
   None

--- a/lib/keeper/keeper_cdal_contract.mli
+++ b/lib/keeper/keeper_cdal_contract.mli
@@ -3,4 +3,4 @@
 (** Risk-contract projection of a [keeper_meta]. Always returns
     [None] since the team-session contract system was removed. *)
 val of_keeper_meta :
-  Keeper_types.keeper_meta -> Agent_sdk.Risk_contract.t option
+  Keeper_types.keeper_meta -> Masc_mcp_cdal_runtime.Risk_contract.t option

--- a/lib/keeper/keeper_turn_telemetry.ml
+++ b/lib/keeper/keeper_turn_telemetry.ml
@@ -59,9 +59,9 @@ let friction_activity_payload
     ]
 ;;
 
-let log_keeper_proof ~(keeper_name : string) (proof : Agent_sdk.Cdal_proof.t) =
+let log_keeper_proof ~(keeper_name : string) (proof : Masc_mcp_cdal_runtime.Cdal_proof.t) =
   let status_string =
-    Agent_sdk.Cdal_proof.show_result_status proof.result_status
+    Masc_mcp_cdal_runtime.Cdal_proof.show_result_status proof.result_status
     |> fun raw ->
     match String.rindex_opt raw '.' with
     | Some idx when idx + 1 < String.length raw ->
@@ -69,14 +69,14 @@ let log_keeper_proof ~(keeper_name : string) (proof : Agent_sdk.Cdal_proof.t) =
     | _ -> raw |> String.lowercase_ascii
   in
   match proof.result_status with
-  | Agent_sdk.Cdal_proof.Completed ->
+  | Masc_mcp_cdal_runtime.Cdal_proof.Completed ->
     if Keeper_types_profile.keeper_debug
     then
       Log.Keeper.debug
         "keeper:%s proof: run_id=%s mode=%s status=%s evidence_refs=%d"
         keeper_name
         proof.run_id
-        (Agent_sdk.Execution_mode.to_string proof.effective_execution_mode)
+        (Masc_mcp_cdal_runtime.Execution_mode.to_string proof.effective_execution_mode)
         status_string
         (List.length proof.raw_evidence_refs)
   | _ ->
@@ -84,7 +84,7 @@ let log_keeper_proof ~(keeper_name : string) (proof : Agent_sdk.Cdal_proof.t) =
       "keeper:%s proof: run_id=%s mode=%s status=%s evidence_refs=%d"
       keeper_name
       proof.run_id
-      (Agent_sdk.Execution_mode.to_string proof.effective_execution_mode)
+      (Masc_mcp_cdal_runtime.Execution_mode.to_string proof.effective_execution_mode)
       status_string
       (List.length proof.raw_evidence_refs)
 ;;

--- a/lib/keeper/keeper_turn_telemetry.mli
+++ b/lib/keeper/keeper_turn_telemetry.mli
@@ -32,7 +32,7 @@ val friction_activity_payload :
 
 (** Log a CDAL proof at debug (Completed) or warn level. *)
 val log_keeper_proof :
-  keeper_name:string -> Agent_sdk.Cdal_proof.t -> unit
+  keeper_name:string -> Masc_mcp_cdal_runtime.Cdal_proof.t -> unit
 
 (** Log a contract verdict at debug (Satisfied) or warn (Violated,
     Inconclusive) level. *)

--- a/lib/keeper/keeper_unified_metrics.ml
+++ b/lib/keeper/keeper_unified_metrics.ml
@@ -43,10 +43,10 @@ let string_contains_substring_ci ~(needle : string) (haystack : string) : bool =
 
 let cdal_mode_violations_ref_suffix = "evidence/mode_violations.json"
 
-let cdal_raw_evidence_ref_count (proof : Agent_sdk.Cdal_proof.t) : int =
+let cdal_raw_evidence_ref_count (proof : Masc_mcp_cdal_runtime.Cdal_proof.t) : int =
   List.length proof.raw_evidence_refs
 
-let cdal_violation_ref_count (proof : Agent_sdk.Cdal_proof.t) : int =
+let cdal_violation_ref_count (proof : Masc_mcp_cdal_runtime.Cdal_proof.t) : int =
   proof.raw_evidence_refs
   |> List.filter (String.ends_with ~suffix:cdal_mode_violations_ref_suffix)
   |> List.length
@@ -847,9 +847,9 @@ let append_decision_record
           | Some { proof = Some p; _ } ->
               `Assoc
                 [
-                  ("run_id", `String p.Agent_sdk.Cdal_proof.run_id);
+                  ("run_id", `String p.Masc_mcp_cdal_runtime.Cdal_proof.run_id);
                   ( "result_status",
-                    Agent_sdk.Cdal_proof.result_status_to_yojson p.result_status );
+                    Masc_mcp_cdal_runtime.Cdal_proof.result_status_to_yojson p.result_status );
                   ("tool_trace_count", `Int (List.length p.tool_trace_refs));
                 ]
           | _ -> `Null );
@@ -1496,11 +1496,11 @@ let append_metrics_snapshot ~(config : Coord.config) ~(meta : keeper_meta)
          match result.proof with
          | Some p ->
            `Assoc [
-             ("run_id", `String p.Agent_sdk.Cdal_proof.run_id);
+             ("run_id", `String p.Masc_mcp_cdal_runtime.Cdal_proof.run_id);
              ("effective_mode",
-              Agent_sdk.Execution_mode.to_yojson p.effective_execution_mode);
+              Masc_mcp_cdal_runtime.Execution_mode.to_yojson p.effective_execution_mode);
              ("result_status",
-              Agent_sdk.Cdal_proof.result_status_to_yojson p.result_status);
+              Masc_mcp_cdal_runtime.Cdal_proof.result_status_to_yojson p.result_status);
              ("violation_count",
               `Int (cdal_violation_ref_count p));
              ("raw_evidence_ref_count",

--- a/lib/local/worker_container.ml
+++ b/lib/local/worker_container.ml
@@ -502,7 +502,7 @@ let materialize_direct_evidence ~base_path ~worker_name
       in
       let options =
         {
-          Agent_sdk.Direct_evidence.session_root =
+          Masc_mcp_cdal_runtime.Direct_evidence.session_root =
             Some (oas_trace_session_root ~base_path);
           session_id;
           goal = prompt;
@@ -519,7 +519,7 @@ let materialize_direct_evidence ~base_path ~worker_name
           workdir = Some workspace_path;
         }
       in
-      match Agent_sdk.Direct_evidence.persist ~agent ~raw_trace ~options () with
+      match Masc_mcp_cdal_runtime.Direct_evidence.persist ~agent ~raw_trace ~options () with
       | Ok _ -> ()
       | Error err ->
           Log.LocalWorker.error

--- a/lib/local/worker_container_types.ml
+++ b/lib/local/worker_container_types.ml
@@ -16,7 +16,7 @@ type run_result = {
   session_id : string;
   raw_trace_run : Agent_sdk.Raw_trace.run_ref option;
   api_response : Agent_sdk.Types.api_response option;
-  proof : Agent_sdk.Cdal_proof.t option;
+  proof : Masc_mcp_cdal_runtime.Cdal_proof.t option;
 }
 
 type worker_container_state =

--- a/lib/local/worker_container_types.mli
+++ b/lib/local/worker_container_types.mli
@@ -57,7 +57,7 @@ type run_result = {
   session_id : string;
   raw_trace_run : Agent_sdk.Raw_trace.run_ref option;
   api_response : Agent_sdk.Types.api_response option;
-  proof : Agent_sdk.Cdal_proof.t option;
+  proof : Masc_mcp_cdal_runtime.Cdal_proof.t option;
 }
 (** Summary of a finished worker run: aggregated text
     [output], the model id that handled the run,

--- a/lib/masc_contract_catalog.ml
+++ b/lib/masc_contract_catalog.ml
@@ -2,8 +2,8 @@ type contract_spec =
   { name : string
   ; description : string
   ; invariants : string list
-  ; requested_execution_mode : Agent_sdk.Execution_mode.t
-  ; risk_class : Agent_sdk.Risk_class.t
+  ; requested_execution_mode : Masc_mcp_cdal_runtime.Execution_mode.t
+  ; risk_class : Masc_mcp_cdal_runtime.Risk_class.t
   ; allowed_mutations : string list
   ; review_requirement : string option
   }
@@ -17,8 +17,8 @@ let cascade_critical =
       ; "cascade_step_timeout_max_5s"
       ; "keeper_stall_max_60s"
       ]
-  ; requested_execution_mode = Agent_sdk.Execution_mode.Execute
-  ; risk_class = Agent_sdk.Risk_class.Critical
+  ; requested_execution_mode = Masc_mcp_cdal_runtime.Execution_mode.Execute
+  ; risk_class = Masc_mcp_cdal_runtime.Risk_class.Critical
   ; allowed_mutations = [ "cascade_route"; "provider_fallback"; "telemetry_emit" ]
   ; review_requirement = None
   }
@@ -32,8 +32,8 @@ let keeper_lifecycle =
       ; "fiber_isolation_no_propagation"
       ; "state_drift_detected_within_30s"
       ]
-  ; requested_execution_mode = Agent_sdk.Execution_mode.Draft
-  ; risk_class = Agent_sdk.Risk_class.High
+  ; requested_execution_mode = Masc_mcp_cdal_runtime.Execution_mode.Draft
+  ; risk_class = Masc_mcp_cdal_runtime.Risk_class.High
   ; allowed_mutations =
       [ "keeper_lifecycle_update"; "supervisor_restart"; "telemetry_emit" ]
   ; review_requirement = None
@@ -48,8 +48,8 @@ let dashboard_telemetry =
       ; "operator_nudge_response_5s"
       ; "cascade_hits_visible_realtime"
       ]
-  ; requested_execution_mode = Agent_sdk.Execution_mode.Diagnose
-  ; risk_class = Agent_sdk.Risk_class.Medium
+  ; requested_execution_mode = Masc_mcp_cdal_runtime.Execution_mode.Diagnose
+  ; risk_class = Masc_mcp_cdal_runtime.Risk_class.Medium
   ; allowed_mutations = []
   ; review_requirement = None
   }
@@ -69,7 +69,7 @@ let eval_criteria spec =
     ]
 ;;
 
-let to_risk_contract spec : Agent_sdk.Risk_contract.t =
+let to_risk_contract spec : Masc_mcp_cdal_runtime.Risk_contract.t =
   { runtime_constraints =
       { requested_execution_mode = spec.requested_execution_mode
       ; risk_class = spec.risk_class

--- a/lib/masc_contract_catalog.mli
+++ b/lib/masc_contract_catalog.mli
@@ -1,6 +1,6 @@
 (** MASC-owned catalog of OAS risk contracts.
 
-    OAS owns the generic {!Agent_sdk.Risk_contract.t} carrier and proof
+    OAS owns the generic {!Masc_mcp_cdal_runtime.Risk_contract.t} carrier and proof
     verification primitives. MASC owns these product-specific contract names,
     invariant strings, and operational meaning. *)
 
@@ -8,8 +8,8 @@ type contract_spec =
   { name : string
   ; description : string
   ; invariants : string list
-  ; requested_execution_mode : Agent_sdk.Execution_mode.t
-  ; risk_class : Agent_sdk.Risk_class.t
+  ; requested_execution_mode : Masc_mcp_cdal_runtime.Execution_mode.t
+  ; risk_class : Masc_mcp_cdal_runtime.Risk_class.t
   ; allowed_mutations : string list
   ; review_requirement : string option
   }
@@ -20,4 +20,4 @@ val dashboard_telemetry : contract_spec
 val all : contract_spec list
 val find : string -> contract_spec option
 val eval_criteria : contract_spec -> Yojson.Safe.t
-val to_risk_contract : contract_spec -> Agent_sdk.Risk_contract.t
+val to_risk_contract : contract_spec -> Masc_mcp_cdal_runtime.Risk_contract.t

--- a/lib/oas_worker.mli
+++ b/lib/oas_worker.mli
@@ -71,7 +71,7 @@ type run_result = {
   turns : int;
   trace_ref : Agent_sdk.Raw_trace.run_ref option;
   run_validation : Agent_sdk.Raw_trace.run_validation option;
-  proof : Agent_sdk.Cdal_proof.t option;
+  proof : Masc_mcp_cdal_runtime.Cdal_proof.t option;
   cascade_observation : cascade_observation option;
   stop_reason : stop_reason;
 }
@@ -121,8 +121,8 @@ val run_named :
   ?on_yield:(unit -> unit) ->
   ?on_resume:(unit -> unit) ->
   ?agent_ref:Agent_sdk.Agent.t option ref ->
-  ?proof_ref:Agent_sdk.Cdal_proof.t option ref ->
-  ?contract:Agent_sdk.Risk_contract.t ->
+  ?proof_ref:Masc_mcp_cdal_runtime.Cdal_proof.t option ref ->
+  ?contract:Masc_mcp_cdal_runtime.Risk_contract.t ->
   ?transport:Masc_grpc_transport.t ->
   ?cli_transport_overrides:cli_transport_overrides ->
   ?allowed_paths:string list ->
@@ -170,7 +170,7 @@ val run_model_by_label :
   ?tool_retry_policy:Agent_sdk.Tool_retry_policy.t ->
   ?enable_thinking:bool ->
   ?compact_ratio:float ->
-  ?contract:Agent_sdk.Risk_contract.t ->
+  ?contract:Masc_mcp_cdal_runtime.Risk_contract.t ->
   ?on_event:(Agent_sdk.Types.sse_event -> unit) ->
   ?transport:Masc_grpc_transport.t ->
   ?sw:Eio.Switch.t ->
@@ -202,8 +202,8 @@ val run_named_with_masc_tools :
   ?on_event:(Agent_sdk.Types.sse_event -> unit) ->
   ?on_yield:(unit -> unit) ->
   ?on_resume:(unit -> unit) ->
-  ?proof_ref:Agent_sdk.Cdal_proof.t option ref ->
-  ?contract:Agent_sdk.Risk_contract.t ->
+  ?proof_ref:Masc_mcp_cdal_runtime.Cdal_proof.t option ref ->
+  ?contract:Masc_mcp_cdal_runtime.Risk_contract.t ->
   ?transport:Masc_grpc_transport.t ->
   ?yield_on_tool:bool ->
   ?compact_ratio:float ->
@@ -232,7 +232,7 @@ val run_model_with_masc_tools :
   ?tool_retry_policy:Agent_sdk.Tool_retry_policy.t ->
   ?enable_thinking:bool ->
   ?compact_ratio:float ->
-  ?contract:Agent_sdk.Risk_contract.t ->
+  ?contract:Masc_mcp_cdal_runtime.Risk_contract.t ->
   ?raw_trace:Agent_sdk.Raw_trace.t ->
   ?on_event:(Agent_sdk.Types.sse_event -> unit) ->
   ?transport:Masc_grpc_transport.t ->

--- a/lib/oas_worker_exec.ml
+++ b/lib/oas_worker_exec.ml
@@ -59,7 +59,7 @@ type config =
   tool_retry_policy : Agent_sdk.Tool_retry_policy.t option;
   required_tool_satisfaction :
     Agent_sdk.Completion_contract.required_tool_satisfaction;
-  contract : Agent_sdk.Risk_contract.t option;
+  contract : Masc_mcp_cdal_runtime.Risk_contract.t option;
   enable_thinking : bool option;
   transport : Masc_grpc_transport.t;
   allowed_paths : string list;
@@ -90,7 +90,7 @@ type run_result = {
   turns : int;
   trace_ref : Agent_sdk.Raw_trace.run_ref option;
   run_validation : Agent_sdk.Raw_trace.run_validation option;
-  proof : Agent_sdk.Cdal_proof.t option;
+  proof : Masc_mcp_cdal_runtime.Cdal_proof.t option;
   cascade_observation : Oas_worker_cascade.cascade_observation option;
   stop_reason : stop_reason;
 }
@@ -105,7 +105,7 @@ let lowercase_enum_case_name raw =
   String.lowercase_ascii raw
 
 let proof_result_status_to_string status =
-  Agent_sdk.Cdal_proof.show_result_status status |> lowercase_enum_case_name
+  Masc_mcp_cdal_runtime.Cdal_proof.show_result_status status |> lowercase_enum_case_name
 
 (* ================================================================ *)
 (* Internal: resolve provider                                        *)
@@ -370,8 +370,8 @@ let run
     ?(on_yield : (unit -> unit) option)
     ?(on_resume : (unit -> unit) option)
     ?(agent_ref : Agent_sdk.Agent.t option ref option)
-    ?(proof_ref : Agent_sdk.Cdal_proof.t option ref option)
-    ?(contract : Agent_sdk.Risk_contract.t option)
+    ?(proof_ref : Masc_mcp_cdal_runtime.Cdal_proof.t option ref option)
+    ?(contract : Masc_mcp_cdal_runtime.Risk_contract.t option)
     (goal : string)
   : (run_result, Agent_sdk.Error.sdk_error) result =
   let session_id = match config.session_id with
@@ -420,7 +420,7 @@ let run
   (try
     let result, proof = match effective_contract with
       | Some c ->
-        let cr = Agent_sdk.Contract_runner.run ~sw ~contract:c agent goal in
+        let cr = Masc_mcp_cdal_runtime.Contract_runner.run ~sw ~contract:c agent goal in
         (cr.response, Some cr.proof)
       | None ->
         (* Pass the process-level Eio clock when available so agent_sdk's

--- a/lib/oas_worker_exec.mli
+++ b/lib/oas_worker_exec.mli
@@ -96,7 +96,7 @@ type config = Oas_worker_exec_agent.config = {
   tool_retry_policy : Agent_sdk.Tool_retry_policy.t option;
   required_tool_satisfaction :
     Agent_sdk.Completion_contract.required_tool_satisfaction;
-  contract : Agent_sdk.Risk_contract.t option;
+  contract : Masc_mcp_cdal_runtime.Risk_contract.t option;
   enable_thinking : bool option;
   transport : Masc_grpc_transport.t;
   allowed_paths : string list;
@@ -135,13 +135,13 @@ type run_result = {
   turns : int;
   trace_ref : Agent_sdk.Raw_trace.run_ref option;
   run_validation : Agent_sdk.Raw_trace.run_validation option;
-  proof : Agent_sdk.Cdal_proof.t option;
+  proof : Masc_mcp_cdal_runtime.Cdal_proof.t option;
   cascade_observation : Oas_worker_cascade.cascade_observation option;
   stop_reason : stop_reason;
 }
 
 val proof_result_status_to_string :
-  Agent_sdk.Cdal_proof.result_status -> string
+  Masc_mcp_cdal_runtime.Cdal_proof.result_status -> string
 
 (** {1 Label resolution} *)
 
@@ -272,8 +272,8 @@ val run :
   ?on_yield:(unit -> unit) ->
   ?on_resume:(unit -> unit) ->
   ?agent_ref:Agent_sdk.Agent.t option ref ->
-  ?proof_ref:Agent_sdk.Cdal_proof.t option ref ->
-  ?contract:Agent_sdk.Risk_contract.t ->
+  ?proof_ref:Masc_mcp_cdal_runtime.Cdal_proof.t option ref ->
+  ?contract:Masc_mcp_cdal_runtime.Risk_contract.t ->
   string ->
   (run_result, Agent_sdk.Error.sdk_error) result
 (** Runs an OAS agent against [goal].  When
@@ -288,7 +288,7 @@ val run_with_masc_tools :
   config:config ->
   masc_tools:Masc_domain.tool_schema list ->
   dispatch:(name:string -> args:Yojson.Safe.t -> Tool_result.t) ->
-  ?contract:Agent_sdk.Risk_contract.t ->
+  ?contract:Masc_mcp_cdal_runtime.Risk_contract.t ->
   ?on_event:(Agent_sdk.Types.sse_event -> unit) ->
   ?on_yield:(unit -> unit) ->
   ?on_resume:(unit -> unit) ->

--- a/lib/oas_worker_exec_agent.ml
+++ b/lib/oas_worker_exec_agent.ml
@@ -50,7 +50,7 @@ type config = {
   tool_retry_policy : Agent_sdk.Tool_retry_policy.t option;
   required_tool_satisfaction :
     Agent_sdk.Completion_contract.required_tool_satisfaction;
-  contract : Agent_sdk.Risk_contract.t option;
+  contract : Masc_mcp_cdal_runtime.Risk_contract.t option;
   enable_thinking : bool option;
   transport : Masc_grpc_transport.t;
   allowed_paths : string list;

--- a/lib/oas_worker_exec_agent.mli
+++ b/lib/oas_worker_exec_agent.mli
@@ -61,7 +61,7 @@ type config = {
   tool_retry_policy : Agent_sdk.Tool_retry_policy.t option;
   required_tool_satisfaction :
     Agent_sdk.Completion_contract.required_tool_satisfaction;
-  contract : Agent_sdk.Risk_contract.t option;
+  contract : Masc_mcp_cdal_runtime.Risk_contract.t option;
   enable_thinking : bool option;
   transport : Masc_grpc_transport.t;
   allowed_paths : string list;

--- a/lib/oas_worker_named.mli
+++ b/lib/oas_worker_named.mli
@@ -73,8 +73,8 @@ val run_named :
   ?on_yield:(unit -> unit) ->
   ?on_resume:(unit -> unit) ->
   ?agent_ref:Agent_sdk.Agent.t option ref ->
-  ?proof_ref:Agent_sdk.Cdal_proof.t option ref ->
-  ?contract:Agent_sdk.Risk_contract.t ->
+  ?proof_ref:Masc_mcp_cdal_runtime.Cdal_proof.t option ref ->
+  ?contract:Masc_mcp_cdal_runtime.Risk_contract.t ->
   ?transport:Masc_grpc_transport.t ->
   ?cli_transport_overrides:Oas_worker_exec.cli_transport_overrides ->
   ?allowed_paths:string list ->
@@ -126,7 +126,7 @@ val run_model_by_label :
   ?tool_retry_policy:Agent_sdk.Tool_retry_policy.t ->
   ?enable_thinking:bool ->
   ?compact_ratio:float ->
-  ?contract:Agent_sdk.Risk_contract.t ->
+  ?contract:Masc_mcp_cdal_runtime.Risk_contract.t ->
   ?on_event:(Agent_sdk.Types.sse_event -> unit) ->
   ?transport:Masc_grpc_transport.t ->
   ?sw:Eio.Switch.t ->
@@ -161,8 +161,8 @@ val run_named_with_masc_tools :
   ?on_event:(Agent_sdk.Types.sse_event -> unit) ->
   ?on_yield:(unit -> unit) ->
   ?on_resume:(unit -> unit) ->
-  ?proof_ref:Agent_sdk.Cdal_proof.t option ref ->
-  ?contract:Agent_sdk.Risk_contract.t ->
+  ?proof_ref:Masc_mcp_cdal_runtime.Cdal_proof.t option ref ->
+  ?contract:Masc_mcp_cdal_runtime.Risk_contract.t ->
   ?transport:Masc_grpc_transport.t ->
   ?yield_on_tool:bool ->
   ?compact_ratio:float ->
@@ -193,7 +193,7 @@ val run_model_with_masc_tools :
   ?tool_retry_policy:Agent_sdk.Tool_retry_policy.t ->
   ?enable_thinking:bool ->
   ?compact_ratio:float ->
-  ?contract:Agent_sdk.Risk_contract.t ->
+  ?contract:Masc_mcp_cdal_runtime.Risk_contract.t ->
   ?raw_trace:Agent_sdk.Raw_trace.t ->
   ?on_event:(Agent_sdk.Types.sse_event -> unit) ->
   ?transport:Masc_grpc_transport.t ->

--- a/lib/oas_worker_named_error.mli
+++ b/lib/oas_worker_named_error.mli
@@ -127,7 +127,7 @@ val config_for_label :
   ?tool_retry_policy:Agent_sdk.Tool_retry_policy.t ->
   ?enable_thinking:bool ->
   ?compact_ratio:float ->
-  ?contract:Agent_sdk.Risk_contract.t ->
+  ?contract:Masc_mcp_cdal_runtime.Risk_contract.t ->
   ?approval:Agent_sdk.Hooks.approval_callback ->
   description:string option ->
   unit ->

--- a/lib/proof_artifact_reader.ml
+++ b/lib/proof_artifact_reader.ml
@@ -1,20 +1,20 @@
 (** Proof_artifact_reader — Dereference proof-store:// artifact refs.
 
-    Delegates to [Agent_sdk.Proof_store] which owns the canonical path layout.
+    Delegates to [Masc_mcp_cdal_runtime.Proof_store] which owns the canonical path layout.
     Eliminates the previous hardcoded directory layout mirror.
 
     @since CDAL eval content-based redesign *)
 
-let resolve_path (config : Agent_sdk.Proof_store.config)
-    (ref_ : Agent_sdk.Cdal_proof.artifact_ref) : (string, string) result =
-  Agent_sdk.Proof_store.resolve_ref config ref_
-  |> Result.map (fun r -> r.Agent_sdk.Proof_store.path)
+let resolve_path (config : Masc_mcp_cdal_runtime.Proof_store.config)
+    (ref_ : Masc_mcp_cdal_runtime.Cdal_proof.artifact_ref) : (string, string) result =
+  Masc_mcp_cdal_runtime.Proof_store.resolve_ref config ref_
+  |> Result.map (fun r -> r.Masc_mcp_cdal_runtime.Proof_store.path)
 
-let run_artifact_path (config : Agent_sdk.Proof_store.config)
+let run_artifact_path (config : Masc_mcp_cdal_runtime.Proof_store.config)
     ~(run_id : string) ~(relative_path : string) : (string, string) result =
-  let ref_ = Agent_sdk.Proof_store.make_ref ~run_id ~subpath:relative_path in
+  let ref_ = Masc_mcp_cdal_runtime.Proof_store.make_ref ~run_id ~subpath:relative_path in
   resolve_path config ref_
 
-let read_json = Agent_sdk.Proof_store.read_json
+let read_json = Masc_mcp_cdal_runtime.Proof_store.read_json
 
-let read_jsonl = Agent_sdk.Proof_store.read_jsonl
+let read_jsonl = Masc_mcp_cdal_runtime.Proof_store.read_jsonl

--- a/lib/proof_artifact_reader.mli
+++ b/lib/proof_artifact_reader.mli
@@ -1,6 +1,6 @@
 (** Proof_artifact_reader — Dereference proof-store:// artifact refs via OAS.
 
-    This module is MASC's narrow adapter over [Agent_sdk.Proof_store].
+    This module is MASC's narrow adapter over [Masc_mcp_cdal_runtime.Proof_store].
     OAS owns the canonical proof-store scheme, layout validation, and JSON
     readers; MASC callers should avoid reconstructing those details here.
 
@@ -9,14 +9,14 @@
 (** Resolve a proof-store:// artifact_ref to a filesystem path.
     Returns [Error] if the ref does not have the expected prefix. *)
 val resolve_path :
-  Agent_sdk.Proof_store.config ->
-  Agent_sdk.Cdal_proof.artifact_ref ->
+  Masc_mcp_cdal_runtime.Proof_store.config ->
+  Masc_mcp_cdal_runtime.Cdal_proof.artifact_ref ->
   (string, string) result
 
 (** Resolve a relative artifact path under a run directory.
     Returns [Error] when the run id or relative path attempts traversal. *)
 val run_artifact_path :
-  Agent_sdk.Proof_store.config ->
+  Masc_mcp_cdal_runtime.Proof_store.config ->
   run_id:string ->
   relative_path:string ->
   (string, string) result
@@ -24,13 +24,13 @@ val run_artifact_path :
 (** Read and parse a JSON artifact from the proof store.
     Returns [Error] if the file does not exist or is not valid JSON. *)
 val read_json :
-  Agent_sdk.Proof_store.config ->
-  Agent_sdk.Cdal_proof.artifact_ref ->
+  Masc_mcp_cdal_runtime.Proof_store.config ->
+  Masc_mcp_cdal_runtime.Cdal_proof.artifact_ref ->
   (Yojson.Safe.t, string) result
 
 (** Read and parse a JSONL artifact from the proof store.
     Returns [Error] if the file does not exist or contains invalid JSONL. *)
 val read_jsonl :
-  Agent_sdk.Proof_store.config ->
-  Agent_sdk.Cdal_proof.artifact_ref ->
+  Masc_mcp_cdal_runtime.Proof_store.config ->
+  Masc_mcp_cdal_runtime.Cdal_proof.artifact_ref ->
   (Yojson.Safe.t list, string) result

--- a/lib/tool_autoresearch_cycle.ml
+++ b/lib/tool_autoresearch_cycle.ml
@@ -264,8 +264,8 @@ let restore_original_content ~workdir ~target_file ~original_content ~sync_index
     Log.Autoresearch.warn "failed to restore %s: %s" target_file err
 
 let diff_guard_summary report =
-  report.Agent_sdk.Autonomy_diff_guard.issues
-  |> List.map Agent_sdk.Autonomy_diff_guard.show_issue
+  report.Masc_mcp_cdal_runtime.Autonomy_diff_guard.issues
+  |> List.map Masc_mcp_cdal_runtime.Autonomy_diff_guard.show_issue
   |> String.concat "; "
 
 (** Run one experiment cycle: the real Karpathy loop turn.
@@ -434,13 +434,13 @@ let handle_cycle (ctx : Tool_autoresearch_context.t) args =
                    ]
                | Ok patch ->
                  let report =
-                   Agent_sdk.Autonomy_diff_guard.validate_patch
+                   Masc_mcp_cdal_runtime.Autonomy_diff_guard.validate_patch
                      ~allowed_paths:[ target_file ]
                      patch
                  in
                  if List.exists
                       (function
-                        | Agent_sdk.Autonomy_diff_guard.Empty_patch -> true
+                        | Masc_mcp_cdal_runtime.Autonomy_diff_guard.Empty_patch -> true
                         | _ -> false)
                       report.issues
                  then (

--- a/lib/violation_record.ml
+++ b/lib/violation_record.ml
@@ -1,35 +1,35 @@
 (** Violation_record — Typed violation records + constraint algebra.
 
-    Delegates JSON serialization to Agent_sdk.Mode_enforcer canonical types.
+    Delegates JSON serialization to Masc_mcp_cdal_runtime.Mode_enforcer canonical types.
     MASC consumers use this module for backward-compatible access.
 
     @since CDAL eval content-based redesign
-    @see Agent_sdk.Mode_enforcer for canonical serializers *)
+    @see Masc_mcp_cdal_runtime.Mode_enforcer for canonical serializers *)
 
 (** Re-export OAS canonical violation_kind. *)
-type violation_kind = Agent_sdk.Mode_enforcer.violation_kind =
+type violation_kind = Masc_mcp_cdal_runtime.Mode_enforcer.violation_kind =
   | Mutating_in_diagnose
   | External_in_draft
   | Scope_violation
 
 (** Re-export OAS canonical violation record. *)
-type t = Agent_sdk.Mode_enforcer.violation = {
+type t = Masc_mcp_cdal_runtime.Mode_enforcer.violation = {
   ts : float;
   tool_name : string;
   input_summary : string;
-  effective_mode : Agent_sdk.Execution_mode.t;
+  effective_mode : Masc_mcp_cdal_runtime.Execution_mode.t;
   violation_kind : violation_kind;
 }
 
 let violation_kind_of_string s =
   match String.lowercase_ascii s with
-  | "mutating_in_diagnose" -> Ok Agent_sdk.Mode_enforcer.Mutating_in_diagnose
-  | "external_in_draft" -> Ok Agent_sdk.Mode_enforcer.External_in_draft
-  | "scope_violation" -> Ok Agent_sdk.Mode_enforcer.Scope_violation
+  | "mutating_in_diagnose" -> Ok Masc_mcp_cdal_runtime.Mode_enforcer.Mutating_in_diagnose
+  | "external_in_draft" -> Ok Masc_mcp_cdal_runtime.Mode_enforcer.External_in_draft
+  | "scope_violation" -> Ok Masc_mcp_cdal_runtime.Mode_enforcer.Scope_violation
   | other -> Error (Printf.sprintf "unknown violation_kind: %s" other)
 
 let violation_kind_to_string v =
-  Agent_sdk.Mode_enforcer.violation_kind_to_string v
+  Masc_mcp_cdal_runtime.Mode_enforcer.violation_kind_to_string v
 
 let of_json (json : Yojson.Safe.t) : (t, string) result =
   let open Yojson.Safe.Util in
@@ -37,7 +37,7 @@ let of_json (json : Yojson.Safe.t) : (t, string) result =
     let ts = json |> member "ts" |> to_float in
     let tool_name = json |> member "tool_name" |> to_string in
     let input_summary = json |> member "input_summary" |> to_string in
-    match Agent_sdk.Execution_mode.of_yojson (json |> member "effective_mode") with
+    match Masc_mcp_cdal_runtime.Execution_mode.of_yojson (json |> member "effective_mode") with
     | Error e -> Error (Printf.sprintf "effective_mode parse: %s" e)
     | Ok effective_mode ->
         (match violation_kind_of_string (json |> member "violation_kind" |> to_string) with
@@ -59,8 +59,8 @@ let of_json_list (json : Yojson.Safe.t) : (t list, string) result =
     parse [] items
   | _ -> Error "expected JSON array of violation records"
 
-let minimum_required_mode (v : t) : Agent_sdk.Execution_mode.t =
+let minimum_required_mode (v : t) : Masc_mcp_cdal_runtime.Execution_mode.t =
   match v.violation_kind with
-  | Mutating_in_diagnose -> Agent_sdk.Execution_mode.Draft
-  | External_in_draft -> Agent_sdk.Execution_mode.Execute
-  | Scope_violation -> Agent_sdk.Execution_mode.Execute
+  | Mutating_in_diagnose -> Masc_mcp_cdal_runtime.Execution_mode.Draft
+  | External_in_draft -> Masc_mcp_cdal_runtime.Execution_mode.Execute
+  | Scope_violation -> Masc_mcp_cdal_runtime.Execution_mode.Execute

--- a/lib/violation_record.mli
+++ b/lib/violation_record.mli
@@ -1,28 +1,28 @@
 (** Violation_record — Typed violation records from CDAL proof artifacts.
 
-    Re-exports [Agent_sdk.Mode_enforcer] canonical types and provides
+    Re-exports [Masc_mcp_cdal_runtime.Mode_enforcer] canonical types and provides
     MASC-specific constraint algebra (minimum_required_mode).
 
     @since CDAL eval content-based redesign
-    @see Agent_sdk.Mode_enforcer for canonical serializers *)
+    @see Masc_mcp_cdal_runtime.Mode_enforcer for canonical serializers *)
 
-(** Violation kind — re-exported from [Agent_sdk.Mode_enforcer.violation_kind]. *)
-type violation_kind = Agent_sdk.Mode_enforcer.violation_kind =
+(** Violation kind — re-exported from [Masc_mcp_cdal_runtime.Mode_enforcer.violation_kind]. *)
+type violation_kind = Masc_mcp_cdal_runtime.Mode_enforcer.violation_kind =
   | Mutating_in_diagnose  (** workspace mutation attempted in Diagnose mode *)
   | External_in_draft     (** external effect attempted in Draft mode *)
   | Scope_violation       (** violated allowed_mutations constraint *)
 
-(** A single violation record — re-exported from [Agent_sdk.Mode_enforcer.violation]. *)
-type t = Agent_sdk.Mode_enforcer.violation = {
+(** A single violation record — re-exported from [Masc_mcp_cdal_runtime.Mode_enforcer.violation]. *)
+type t = Masc_mcp_cdal_runtime.Mode_enforcer.violation = {
   ts : float;
   tool_name : string;
   input_summary : string;
-  effective_mode : Agent_sdk.Execution_mode.t;
+  effective_mode : Masc_mcp_cdal_runtime.Execution_mode.t;
   violation_kind : violation_kind;
 }
 
 (** Parse a single violation from JSON.
-    Delegates to [Agent_sdk.Mode_enforcer.violation_of_yojson].
+    Delegates to [Masc_mcp_cdal_runtime.Mode_enforcer.violation_of_yojson].
 
     @warning This returns [Error] for unrecognized [violation_kind] or
     [effective_mode]. Call sites should decide explicitly whether to surface,
@@ -40,7 +40,7 @@ val of_json_list : Yojson.Safe.t -> (t list, string) result
     - [Mutating_in_diagnose] -> [Draft]
     - [External_in_draft] -> [Execute]
     - [Scope_violation] -> [Execute] *)
-val minimum_required_mode : t -> Agent_sdk.Execution_mode.t
+val minimum_required_mode : t -> Masc_mcp_cdal_runtime.Execution_mode.t
 
 (** Violation kind to/from string. Delegates to OAS canonical functions. *)
 val violation_kind_to_string : violation_kind -> string

--- a/lib/worker_oas.ml
+++ b/lib/worker_oas.ml
@@ -628,7 +628,7 @@ and run_existing_worker_agent
     (fun () ->
       let result, proof = match contract with
         | Some c ->
-          let cr = Agent_sdk.Contract_runner.run ~sw ~contract:c agent prompt in
+          let cr = Masc_mcp_cdal_runtime.Contract_runner.run ~sw ~contract:c agent prompt in
           (cr.response, Some cr.proof)
         | None ->
           (Agent_sdk.Agent.run ~sw agent prompt, None)
@@ -678,10 +678,10 @@ and run_existing_worker_agent
               ~status:"ok" ~output
               ?raw_trace_run
               ?evidence_session_id
-              ?proof_run_id:(Option.map (fun p -> p.Agent_sdk.Cdal_proof.run_id) proof)
+              ?proof_run_id:(Option.map (fun p -> p.Masc_mcp_cdal_runtime.Cdal_proof.run_id) proof)
               ?proof_result_status:
                 (Option.map
-                   (fun p -> proof_result_status_to_string p.Agent_sdk.Cdal_proof.result_status)
+                   (fun p -> proof_result_status_to_string p.Masc_mcp_cdal_runtime.Cdal_proof.result_status)
                    proof)
               ()
           in
@@ -718,10 +718,10 @@ and run_existing_worker_agent
               ~status:"error" ~output:detail ~error:detail
               ?raw_trace_run
               ?evidence_session_id
-              ?proof_run_id:(Option.map (fun p -> p.Agent_sdk.Cdal_proof.run_id) proof)
+              ?proof_run_id:(Option.map (fun p -> p.Masc_mcp_cdal_runtime.Cdal_proof.run_id) proof)
               ?proof_result_status:
                 (Option.map
-                   (fun p -> proof_result_status_to_string p.Agent_sdk.Cdal_proof.result_status)
+                   (fun p -> proof_result_status_to_string p.Masc_mcp_cdal_runtime.Cdal_proof.result_status)
                    proof)
               ()
           in

--- a/lib/worker_oas.mli
+++ b/lib/worker_oas.mli
@@ -50,7 +50,7 @@ val run_worker_via_oas :
   tools:Agent_sdk.Tool.t list ->
   raw_trace:Agent_sdk.Raw_trace.t ->
   ?gate_config:Eval_gate.gate_config ->
-  ?contract:Agent_sdk.Risk_contract.t ->
+  ?contract:Masc_mcp_cdal_runtime.Risk_contract.t ->
   ?worker_run_id:string ->
   unit ->
   (Worker_container_types.run_result, string) result
@@ -65,7 +65,7 @@ val resume_worker_via_oas :
   prompt:string ->
   tools:Agent_sdk.Tool.t list ->
   raw_trace:Agent_sdk.Raw_trace.t ->
-  ?contract:Agent_sdk.Risk_contract.t ->
+  ?contract:Masc_mcp_cdal_runtime.Risk_contract.t ->
   ?worker_run_id:string ->
   ?approval:Agent_sdk.Hooks.approval_callback ->
   unit ->

--- a/lib/worker_runtime_helper_protocol.ml
+++ b/lib/worker_runtime_helper_protocol.ml
@@ -72,12 +72,12 @@ let api_response_of_yojson = function
       | None -> Error "invalid api_response in worker helper payload")
 
 let proof_to_yojson =
-  option_to_yojson Agent_sdk.Cdal_proof.to_json
+  option_to_yojson Masc_mcp_cdal_runtime.Cdal_proof.to_json
 
 let proof_of_yojson = function
   | `Null -> Ok None
   | json -> (
-      match Agent_sdk.Cdal_proof.of_json json with
+      match Masc_mcp_cdal_runtime.Cdal_proof.of_json json with
       | Ok proof -> Ok (Some proof)
       | Error msg -> Error ("invalid proof in worker helper payload: " ^ msg))
 


### PR DESCRIPTION
## 요약

RFC-OAS-011 *atomic flip*. masc-mcp의 모든 CDAL consumer가 이제 *masc_mcp.cdal_runtime*의 카피를 호출. agent_sdk pin은 그대로 (0.192) — OAS 측 원본 제거는 OAS-E에서.

**40 files changed, +174 / -172** (대부분 line-level 1:1 token swap).

## 변경 메커니즘

```bash
$ rg -l '\bAgent_sdk\.(Cdal_proof|Mode_enforcer|Mode_resolver|Risk_contract|Risk_class|\
Execution_mode|Proof_capture|Proof_store|Contract_runner|Audit|Autonomy_exec|\
Autonomy_diff_guard|Autonomy_trace_analyzer|Cognitive_event|Verified_output|\
Conformance|Direct_evidence|Effect_evidence|Sessions_proof|Guardrail_tripwire|\
Guardrails_async|Runtime_evidence)\b' lib/ bin/ | grep -v '^lib/cdal_runtime/'

$ # 38 files, then bulk:

$ perl -pi -e 's/\bAgent_sdk\.(Cdal_proof|Mode_enforcer|...|Runtime_evidence)\b/Masc_mcp_cdal_runtime.$1/g' \
       <38 files>

$ rg <same pattern>  # → 0 matches outside lib/cdal_runtime
```

## Files rewired (38)

| Group | Files |
|---|---|
| **CDAL Phase 1A evaluator** (consumer-side) | `cdal_loader.{ml,mli}`, `cdal_eval_v1.{ml,mli}`, `cdal_judge.ml`, `cdal_friction_projection.{ml,mli}` |
| **OAS worker bridge** | `oas_worker.mli`, `oas_worker_exec.{ml,mli}`, `oas_worker_exec_agent.{ml,mli}`, `oas_worker_named.mli`, `oas_worker_named_error.mli`, `worker_oas.{ml,mli}`, `worker_runtime_helper_protocol.ml` |
| **Contract / catalog / violations** | `masc_contract_catalog.{ml,mli}`, `violation_record.{ml,mli}`, `proof_artifact_reader.{ml,mli}` |
| **Keeper integration** | `keeper/keeper_agent_result.{ml,mli}`, `keeper/keeper_agent_run.{ml,mli}`, `keeper/keeper_cdal_contract.{ml,mli}`, `keeper/keeper_turn_telemetry.{ml,mli}`, `keeper/keeper_unified_metrics.ml` |
| **Local + autoresearch + tool** | `local/worker_container.ml`, `local/worker_container_types.{ml,mli}`, `autoresearch/autoresearch_metric.{ml,mli}`, `tool_autoresearch_cycle.ml` |

## Dune library deps 추가 (2)

```dune
; lib/dune (libraries ...)
   agent_sdk
   agent_sdk.base
   agent_sdk.llm_provider
+  masc_mcp.cdal_runtime
   masc_mcp.oas_compat

; lib/autoresearch/dune (libraries ...)
   agent_sdk
+  masc_mcp.cdal_runtime
   eio
```

## Type-equivalence (non-trivial bit)

agent_sdk pin 0.192가 그대로 있어 `Agent_sdk.Cdal_proof`/`Agent_sdk.Mode_enforcer`/etc도 *남아있음*. 두 OCaml type (`Agent_sdk.Cdal_proof.t` vs `Masc_mcp_cdal_runtime.Cdal_proof.t`)은 *record-equivalent*이지만 *별 compilation unit*. 값을 mix할 수 없음.

본 PR이 *atomic flip*인 이유: **모든 consumer가 lockstep으로 변경** → mix 발생 불가. JSON wire format 동일이므로 디스크 manifest는 호환.

## 위험 (3건)

| # | 위험 | 완화 |
|---|---|---|
| 1 | bulk perl rewrite로 *문맥 잘못된 매치* (예: 변수 이름 안에 `Agent_sdk.Cdal_proof_x` 같은 wildcard) | `\b...\b` word-boundary로 prefix tokenization. 23 prefix 명시적 alternation. perl 끝나고 *post-grep 0 matches* 검증함 |
| 2 | autoresearch_metric이 `Cdal_proof.t`를 type signature로 들고 있어 cdal_runtime 의존 추가 후 cyclic dependency | autoresearch는 별 sublibrary. cdal_runtime은 autoresearch를 모름 (단방향). cycle 없음 |
| 3 | `cdal_loader.of_json` parse 시 *옛 manifest*가 `Agent_sdk.Cdal_proof.t` JSON을 만들어둔 경우 | 두 카피가 *동일 JSON wire format* (verbatim copy). Cdal_proof.of_json이 새 위치에서 호출되더라도 동일 schema parse 가능 |

## RFC 시리즈 진행

| PR | 상태 |
|---|---|
| OAS RFC docs + B/C/D #1480-1483 | MERGED |
| MM-1 #14247 (skel) | MERGED |
| MM-2-leaves #14248 (B1) | MERGED |
| MM-2-low #14253 (B2) | MERGED |
| MM-2-mid #14255 (B3) | MERGED |
| #14257 hotfix | MERGED |
| MM-2-high #14259 (B4) | MERGED |
| MM-2-top #14264 (B5) | MERGED — 이주 phase 종결 (23 modules) |
| **MM-3-rewire (this) — atomic flip** | OPEN, Draft |
| OAS-E (CDAL 30+ 모듈 OAS 제거 + agent_sdk 0.193.0) | TBD (this 머지 후) |
| MM-4 (opam pin → 0.193.0) | OAS-E 머지 후 |

## Test plan

- [ ] CI green — masc-mcp 본체 + autoresearch 모두 새 import path로 빌드 통과
- [ ] CodeRabbit/사람 리뷰 코멘트 대응
- [ ] `human-approved-ready` 라벨 부착 후 머지

🤖 Generated with [Claude Code](https://claude.com/claude-code)