### PR TITLE
fix(cdal_runtime): unblock main — eio/eio.unix/eio_main/llm_provider deps + Sessions_types workaround

### DIFF
--- a/lib/cdal_runtime/dune
+++ b/lib/cdal_runtime/dune
@@ -41,6 +41,16 @@
   ; resolves the [Unix] module without requiring the consumer to open
   ; it.
   unix
+  ; eio + eio.unix are needed by guardrails_async.mli, guardrail_tripwire.ml,
+  ; autonomy_exec.{ml,mli}, contract_runner.mli (added by PR #14264
+  ; RFC-OAS-011 MM-2-top B5).  These modules have async fiber-based
+  ; signatures (Eio.*) and call Eio_unix.* helpers.
+  eio
+  eio.unix
+  ; eio_main needed by autonomy_exec.ml (Eio_main.run for async runtime entry).
+  eio_main
+  ; agent_sdk.llm_provider is needed by contract_runner.ml (Llm_provider.*).
+  agent_sdk.llm_provider
   yojson
   ppx_deriving_yojson.runtime)
  ; Mirror agent_sdk's flag so migrated modules' `open Types` /
@@ -48,7 +58,16 @@
  ; original OAS compilation context.  Also open the wrapped [Agent_sdk]
  ; namespace so unqualified references such as [Guardrails_async] in
  ; [guardrail_llm.{ml,mli}] resolve to [Agent_sdk.Guardrails_async].
+ ; XXX -open Agent_sdk__ accesses agent_sdk's internal wrapper module
+ ; (no .mli, so all submodule aliases are visible — including
+ ; [Sessions_types], which is referenced by sessions_proof.mli but
+ ; deliberately not re-exported in agent_sdk.mli).  This is an
+ ; internal-API workaround for PR #14264 RFC-OAS-011 MM-2-top B5;
+ ; it should be replaced by either (a) re-exporting [Sessions_types]
+ ; in [agent_sdk.mli] upstream, or (b) qualifying the cdal_runtime
+ ; references to use [Agent_sdk.Sessions]/[Agent_sdk.Sessions_store].
+ ; Using [Agent_sdk__] is fragile across dune wrapper-name changes.
  (flags
-  (:standard -open Agent_sdk_base -open Agent_sdk))
+  (:standard -open Agent_sdk_base -open Agent_sdk -open Agent_sdk__))
  (preprocess
   (pps ppx_deriving_yojson ppx_deriving.show ppx_inline_test ppx_let)))


### PR DESCRIPTION
## Problem

PR #14264 (\`feat(cdal_runtime): migrate B5 — audit, autonomy_*, sessions_proof, guardrails, runtime_evidence (RFC-OAS-011 MM-2-top)\`) admin-merged with **six** unbound module references that fail \`dune build @check\` on main:

| File | Line | Unbound |
|------|------|---------|
| \`guardrails_async.mli\` | 44 | \`Eio\` |
| \`guardrail_tripwire.ml\` | 29 | \`Eio\` |
| \`autonomy_exec.mli\` | 66 | \`Eio\` |
| \`autonomy_exec.ml\` | 330 | \`Eio_main\` |
| \`contract_runner.{ml,mli}\` | 1, 27 | \`Llm_provider\` / \`Eio\` |
| \`sessions_proof.mli\` | 10 | \`Sessions_types\` |

This is the **fourth sequential** dune-dep cascade on \`lib/cdal_runtime/\` in 24h.

| # | PR | Layer | Hotfix |
|---|----|-------|--------|
| 1 | #14246 (mine) | ocamlformat | #14249 |
| 2 | #14247 | dune \`(include_subdirs no)\` + \`Guardrails_async\` | #14257 |
| 3 | #14255 | \`Unix\` | #14260 |
| 4 | #14264 | \`Eio\` / \`Eio_main\` / \`Llm_provider\` / \`Sessions_types\` | **this PR** |

## Fix (single file: \`lib/cdal_runtime/dune\`)

Diffstat: \`+20 / -1\`.

1. Add four library deps:
   - \`eio\`, \`eio.unix\`, \`eio_main\` for async fiber signatures + \`Eio_main.run\` runtime entry.
   - \`agent_sdk.llm_provider\` for \`Llm_provider.*\` in \`contract_runner.ml\`.

2. Add \`-open Agent_sdk__\` to \`(flags …)\` as an **internal-API workaround** for \`Sessions_types\`. **This part needs RFC-OAS-011 owner attention.**

## ⚠️ \`Sessions_types\` is a public-API violation

\`Sessions_types\` is a wrapped module in the \`agent_sdk\` library but is **deliberately not re-exported** in \`agent_sdk.mli\`:

\`\`\`
$ grep -E "Sessions" /Users/dancer/.opam/.../agent_sdk.mli
module Sessions = Sessions
module Sessions_store = Sessions_store
\`\`\`

PR #14264's \`sessions_proof.mli:10\` writes \`open Sessions_types\` — that's reaching into a private module of the upstream library. The clean fixes are **upstream**, not in this dune file:

- (a) re-export \`Sessions_types\` in \`agent_sdk.mli\` in the agent_sdk pin, or
- (b) qualify the cdal_runtime references to \`Agent_sdk.Sessions\` / \`Agent_sdk.Sessions_store\` / a small adapter shim.

Using \`-open Agent_sdk__\` (the dune-generated internal wrapper module, no \`.mli\` so all submodule aliases are visible) unblocks main today but is fragile across dune wrapper-name changes (the \`__\` convention is a dune implementation detail).

**Action required**: RFC-OAS-011 owners should pick (a) or (b) and remove the \`-open Agent_sdk__\` flag in a follow-up PR.

## Per saved memory \`feedback_rfc_oas_011_cdal_runtime_admin_merge_cascade.md\`

This PR follows the protocol established by the prior 3 cascade fixes:

- ✅ Single-file scope (\`lib/cdal_runtime/dune\` only).
- ✅ No silent rewrite of RFC-OAS-011 source files.
- ✅ Workaround clearly flagged with \`XXX\` comment + escalation path.
- ✅ Body documents the cascade table for reviewer pattern recognition.

## Verification

\`\`\`
dune build --root . @check                           # clean (was failing on main)
dune exec test/test_keeper_health_probe.exe          # 3/3 pass (PR #14246 regression)
\`\`\`

## Test plan

- [ ] CI \`Build and Test\` passes on this PR.
- [ ] Sub-library \`masc_mcp.cdal_runtime\` continues to compile.
- [ ] Follow-up PR replaces \`-open Agent_sdk__\` with proper public-API usage (assigned to RFC-OAS-011 owners, not this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)