### PR TITLE
refactor(dashboard): RFC-0050 PR-1 — cost-dashboard.ts ownership split

### DIFF
--- a/dashboard/src/components/cost-dashboard.ts
+++ b/dashboard/src/components/cost-dashboard.ts
@@ -39,37 +39,38 @@ import { StatTile } from './common/stat-tile'
 import { FilterChips } from './common/filter-chips'
 import { formatCost, formatPct1 } from '../lib/format-number'
 import { replaceRoute, route } from '../router'
+import {
+  type ViewMode,
+  type CostFocus,
+  type AuditFocus,
+  type CostView,
+  isCostView,
+  isCostFocus,
+  viewModeForCostFocus,
+  isAuditFocus,
+  auditRouteParams,
+} from './cost/cost-types'
+import { formatTokens, severityClass } from './cost/cost-formatters'
+import {
+  severityBuckets,
+  summarizeAuditActors,
+  summarizeAuditKinds,
+} from './cost/audit-summarizer'
 
-type ViewMode = 'model' | 'keeper'
-export type CostFocus = 'agent' | 'matrix' | 'latency'
-export type AuditFocus = 'actor' | 'summary'
-
-export type CostView = 'cost' | 'heuristics' | 'stress' | 'audit' | 'decisions'
-
-const COST_VIEWS: CostView[] = ['cost', 'heuristics', 'stress', 'audit', 'decisions']
-const COST_FOCUSES: CostFocus[] = ['agent', 'matrix', 'latency']
-const AUDIT_FOCUSES: AuditFocus[] = ['actor', 'summary']
-
-export function isCostView(v: string | undefined): v is CostView {
-  return !!v && (COST_VIEWS as string[]).includes(v)
-}
-
-export function isCostFocus(v: string | undefined): v is CostFocus {
-  return !!v && (COST_FOCUSES as string[]).includes(v)
-}
-
-export function viewModeForCostFocus(focus: CostFocus | null): ViewMode {
-  return focus === 'agent' ? 'keeper' : 'model'
-}
-
-export function isAuditFocus(v: string | undefined): v is AuditFocus {
-  return !!v && (AUDIT_FOCUSES as string[]).includes(v)
-}
-
-export function auditRouteParams(focus: 'ledger' | AuditFocus): Record<string, string> {
-  return focus === 'ledger'
-    ? { section: 'runtime', view: 'audit' }
-    : { section: 'runtime', view: 'audit', focus }
+// Re-export RFC-0050 PR-1 — preserve every public symbol callers import
+// from this module so the per-domain split is mechanical.
+export {
+  type CostFocus,
+  type AuditFocus,
+  type CostView,
+  isCostView,
+  isCostFocus,
+  viewModeForCostFocus,
+  isAuditFocus,
+  auditRouteParams,
+  formatTokens,
+  summarizeAuditActors,
+  summarizeAuditKinds,
 }
 
 type ModelLoadState =
@@ -356,12 +357,6 @@ const keeperTotals = computed(() => {
   const p50Avg = p50Count > 0 ? Math.round(p50Sum / p50Count) : 0
   return { totalCost, totalIn, totalOut, p50Avg, p95Max, count: data.length }
 })
-
-export function formatTokens(n: number): string {
-  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(2)}M`
-  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`
-  return `${n}`
-}
 
 function ThRight({ children }: { children: unknown }) {
   return html`<th scope="col" class="px-2 py-1.5 text-right">${children}</th>`
@@ -828,91 +823,6 @@ function HeuristicByModule({ coverage }: { coverage: HeuristicCoverage }) {
 }
 
 type AuditChip = 'ledger' | AuditFocus
-
-interface AuditActorSummary {
-  actor: string
-  count: number
-  error: number
-  warn: number
-  info: number
-  latest: string
-  topKind: string
-}
-
-interface AuditKindSummary {
-  kind: string
-  count: number
-  error: number
-  warn: number
-  info: number
-  latest: string
-}
-
-function severityClass(sev: string): string {
-  if (sev === 'error') return 'text-[var(--color-danger-fg)]'
-  if (sev === 'warn') return 'text-[var(--color-warning-fg)]'
-  return 'text-text-muted'
-}
-
-function severityBuckets(entries: readonly AuditEntry[]): { error: number; warn: number; info: number } {
-  let error = 0
-  let warn = 0
-  for (const entry of entries) {
-    if (entry.severity === 'error') error += 1
-    else if (entry.severity === 'warn') warn += 1
-  }
-  return { error, warn, info: Math.max(0, entries.length - error - warn) }
-}
-
-function latestTs(entries: readonly AuditEntry[]): string {
-  return entries.reduce((latest, entry) => entry.ts > latest ? entry.ts : latest, '')
-}
-
-function mostFrequentKind(entries: readonly AuditEntry[]): string {
-  const counts = new Map<string, number>()
-  for (const entry of entries) {
-    const kind = entry.kind.trim() || '(unknown)'
-    counts.set(kind, (counts.get(kind) ?? 0) + 1)
-  }
-  return [...counts.entries()].sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))[0]?.[0] ?? '—'
-}
-
-export function summarizeAuditActors(entries: readonly AuditEntry[]): AuditActorSummary[] {
-  const byActor = new Map<string, AuditEntry[]>()
-  for (const entry of entries) {
-    const actor = entry.actor.trim() || '(unknown)'
-    const bucket = byActor.get(actor) ?? []
-    bucket.push(entry)
-    byActor.set(actor, bucket)
-  }
-  return [...byActor.entries()]
-    .map(([actor, actorEntries]) => ({
-      actor,
-      count: actorEntries.length,
-      ...severityBuckets(actorEntries),
-      latest: latestTs(actorEntries),
-      topKind: mostFrequentKind(actorEntries),
-    }))
-    .sort((a, b) => b.count - a.count || a.actor.localeCompare(b.actor))
-}
-
-export function summarizeAuditKinds(entries: readonly AuditEntry[]): AuditKindSummary[] {
-  const byKind = new Map<string, AuditEntry[]>()
-  for (const entry of entries) {
-    const kind = entry.kind.trim() || '(unknown)'
-    const bucket = byKind.get(kind) ?? []
-    bucket.push(entry)
-    byKind.set(kind, bucket)
-  }
-  return [...byKind.entries()]
-    .map(([kind, kindEntries]) => ({
-      kind,
-      count: kindEntries.length,
-      ...severityBuckets(kindEntries),
-      latest: latestTs(kindEntries),
-    }))
-    .sort((a, b) => b.count - a.count || a.kind.localeCompare(b.kind))
-}
 
 function updateAuditFocusParam(focus: AuditChip): void {
   replaceRoute('monitoring', auditRouteParams(focus))

--- a/dashboard/src/components/cost/audit-summarizer.ts
+++ b/dashboard/src/components/cost/audit-summarizer.ts
@@ -1,0 +1,84 @@
+// RFC-0050 PR-1 — extracted from cost-dashboard.ts.
+// Pure audit-ledger aggregation. Depends only on the AuditEntry shape
+// from the dashboard API. No signals, no render, no module-level state.
+
+import type { AuditEntry } from '../../api/dashboard'
+
+export interface AuditActorSummary {
+  actor: string
+  count: number
+  error: number
+  warn: number
+  info: number
+  latest: string
+  topKind: string
+}
+
+export interface AuditKindSummary {
+  kind: string
+  count: number
+  error: number
+  warn: number
+  info: number
+  latest: string
+}
+
+export function severityBuckets(entries: readonly AuditEntry[]): { error: number; warn: number; info: number } {
+  let error = 0
+  let warn = 0
+  for (const entry of entries) {
+    if (entry.severity === 'error') error += 1
+    else if (entry.severity === 'warn') warn += 1
+  }
+  return { error, warn, info: Math.max(0, entries.length - error - warn) }
+}
+
+function latestTs(entries: readonly AuditEntry[]): string {
+  return entries.reduce((latest, entry) => entry.ts > latest ? entry.ts : latest, '')
+}
+
+function mostFrequentKind(entries: readonly AuditEntry[]): string {
+  const counts = new Map<string, number>()
+  for (const entry of entries) {
+    const kind = entry.kind.trim() || '(unknown)'
+    counts.set(kind, (counts.get(kind) ?? 0) + 1)
+  }
+  return [...counts.entries()].sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))[0]?.[0] ?? '—'
+}
+
+export function summarizeAuditActors(entries: readonly AuditEntry[]): AuditActorSummary[] {
+  const byActor = new Map<string, AuditEntry[]>()
+  for (const entry of entries) {
+    const actor = entry.actor.trim() || '(unknown)'
+    const bucket = byActor.get(actor) ?? []
+    bucket.push(entry)
+    byActor.set(actor, bucket)
+  }
+  return [...byActor.entries()]
+    .map(([actor, actorEntries]) => ({
+      actor,
+      count: actorEntries.length,
+      ...severityBuckets(actorEntries),
+      latest: latestTs(actorEntries),
+      topKind: mostFrequentKind(actorEntries),
+    }))
+    .sort((a, b) => b.count - a.count || a.actor.localeCompare(b.actor))
+}
+
+export function summarizeAuditKinds(entries: readonly AuditEntry[]): AuditKindSummary[] {
+  const byKind = new Map<string, AuditEntry[]>()
+  for (const entry of entries) {
+    const kind = entry.kind.trim() || '(unknown)'
+    const bucket = byKind.get(kind) ?? []
+    bucket.push(entry)
+    byKind.set(kind, bucket)
+  }
+  return [...byKind.entries()]
+    .map(([kind, kindEntries]) => ({
+      kind,
+      count: kindEntries.length,
+      ...severityBuckets(kindEntries),
+      latest: latestTs(kindEntries),
+    }))
+    .sort((a, b) => b.count - a.count || a.kind.localeCompare(b.kind))
+}

--- a/dashboard/src/components/cost/cost-formatters.ts
+++ b/dashboard/src/components/cost/cost-formatters.ts
@@ -1,0 +1,14 @@
+// RFC-0050 PR-1 — extracted from cost-dashboard.ts.
+// Pure formatting helpers. No render dependencies.
+
+export function formatTokens(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(2)}M`
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`
+  return `${n}`
+}
+
+export function severityClass(sev: string): string {
+  if (sev === 'error') return 'text-[var(--color-danger-fg)]'
+  if (sev === 'warn') return 'text-[var(--color-warning-fg)]'
+  return 'text-text-muted'
+}

--- a/dashboard/src/components/cost/cost-types.ts
+++ b/dashboard/src/components/cost/cost-types.ts
@@ -1,0 +1,34 @@
+// RFC-0050 PR-1 — extracted from cost-dashboard.ts.
+// Pure data types + guards + route helpers. No render dependencies.
+
+export type ViewMode = 'model' | 'keeper'
+export type CostFocus = 'agent' | 'matrix' | 'latency'
+export type AuditFocus = 'actor' | 'summary'
+
+export type CostView = 'cost' | 'heuristics' | 'stress' | 'audit' | 'decisions'
+
+export const COST_VIEWS: CostView[] = ['cost', 'heuristics', 'stress', 'audit', 'decisions']
+export const COST_FOCUSES: CostFocus[] = ['agent', 'matrix', 'latency']
+export const AUDIT_FOCUSES: AuditFocus[] = ['actor', 'summary']
+
+export function isCostView(v: string | undefined): v is CostView {
+  return !!v && (COST_VIEWS as string[]).includes(v)
+}
+
+export function isCostFocus(v: string | undefined): v is CostFocus {
+  return !!v && (COST_FOCUSES as string[]).includes(v)
+}
+
+export function viewModeForCostFocus(focus: CostFocus | null): ViewMode {
+  return focus === 'agent' ? 'keeper' : 'model'
+}
+
+export function isAuditFocus(v: string | undefined): v is AuditFocus {
+  return !!v && (AUDIT_FOCUSES as string[]).includes(v)
+}
+
+export function auditRouteParams(focus: 'ledger' | AuditFocus): Record<string, string> {
+  return focus === 'ledger'
+    ? { section: 'runtime', view: 'audit' }
+    : { section: 'runtime', view: 'audit', focus }
+}


### PR DESCRIPTION
## Summary

First mechanical split per RFC-0050 §4.1 (`docs/rfc/RFC-0050-component-ownership-decomposition.md`). Extracts three pure modules from `cost-dashboard.ts` and keeps all public exports via re-export so callers see no API change.

## What moved

| New file | LoC | Contents |
|---|---:|---|
| `dashboard/src/components/cost/cost-types.ts` | 34 | `CostView`/`CostFocus`/`AuditFocus`/`ViewMode` types, `is*` guards, `viewModeForCostFocus`, `auditRouteParams` |
| `dashboard/src/components/cost/cost-formatters.ts` | 14 | `formatTokens`, `severityClass` |
| `dashboard/src/components/cost/audit-summarizer.ts` | 84 | `AuditActorSummary`/`AuditKindSummary` interfaces, private `latestTs`/`mostFrequentKind`, exported `severityBuckets`/`summarizeAuditActors`/`summarizeAuditKinds` |

`cost-dashboard.ts`: 1442 → 1352 LoC (−90). Net dashboard tree change: +42 LoC (~3%) from import/re-export glue, well under RFC-0050 §5's ~10% allowance.

## §3 criteria audit

| Criterion | Result |
|---|---|
| 1. Plurality of distinct domains | ✓ types, formatters, audit aggregation are independently coherent |
| 2. No cross-domain shared mutable state | ✓ all three new files pure — no signals, no module-level state |
| 3. Domain count ≥ 3 | ✓ exactly three |
| 4. No path-based reach into private helpers | ✓ external callers import only public names already in re-export block |
| 5. No public-export rename | ✓ every name preserved verbatim |

`severityBuckets` was promoted from private to exported because the render at the `AuditSummaryBoard` StatTile (line ~899) calls it directly. Same function, same body — only the visibility changed.

## Caller compatibility

- `runtime-panel.ts` imports `CostDashboard` (component, still in `cost-dashboard.ts`) and `CostView` (re-exported). ✓
- `cost-dashboard.test.ts` imports 8 names — all in the re-export block. ✓

## RFC-0050 §4.1 amendment to follow

`connector-status.ts` (1689 LoC) was the other in-scope candidate. On re-verification it **FAILS** §3 criterion 1: zero per-connector branches, all four connectors (`discord`, `imessage`, `slack`, `telegram`) share one render parameterized by `connectorId: string`. The original analysis counted data rows (3 lookup tables × 4 = ~30 LoC) and missed that the implementation is one shared pipeline (~1650 LoC). Splitting would move 30 LoC out and leave the rest — exactly the §2 anti-pattern (mechanical split with no ownership distribution).

That candidate is dropped. A follow-up RFC amendment PR will revise §4.1.

## Verification

- TypeScript: changed-file inventory only (no `node_modules` in this fresh worktree). All references resolve via grep — every `severityBuckets`/`summarizeAudit*`/`formatTokens`/`severityClass` usage either lives inside the new module or imports from the new path.
- `vitest` + `tsc --noEmit`: deferred to CI.

Per memory `feedback_masc_mcp_admin_merge_fast_track`: leaving Draft for user admin-merge.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>