### PR TITLE
feat(keeper): RFC-0047 PR-3 — remove substring classifiers + code field

### DIFF
--- a/lib/keeper/keeper_turn_disposition.ml
+++ b/lib/keeper/keeper_turn_disposition.ml
@@ -53,12 +53,6 @@ let summary = function
     "required keeper tool use was requested, but the tool contract was not satisfied"
   | Post_commit_ambiguous ->
     "provider failed after a mutating tool may have committed side effects"
-  | Provider_error (Code.Provider_runtime_error "provider_error") ->
-    (* Legacy producer alias: pre-RFC [normalize_code "api_error_timeout"]
-       collapsed to the literal string "provider_error", which got the
-       specific summary below. PR-2/PR-3 retire that producer-side
-       normalize; this arm preserves byte-compat until then. *)
-    "provider or cascade failed"
   | Provider_error code -> Printf.sprintf "keeper turn ended with %s" (Code.to_wire code)
   | Unknown { raw_error = "" } ->
     "keeper turn failed without a classified terminal reason"

--- a/lib/keeper/keeper_turn_terminal.ml
+++ b/lib/keeper/keeper_turn_terminal.ml
@@ -1,26 +1,29 @@
-(** Structured terminal-reason surface for keeper turn ledgers. *)
+(** Structured terminal-reason surface for keeper turn ledgers.
 
-type severity =
+    RFC-0047 PR-3:
+    - [code: string] field removed; [disposition] is the SSOT.
+    - [severity_of_code / summary_of_code / next_action_of_code]
+      substring classifiers deleted; severity / summary / next_action
+      are now derived via exhaustive matches on
+      [Keeper_turn_disposition.t].
+    - [normalize_code] retained as a producer-side string preprocessor
+      until producers are themselves typed (out of scope for this RFC). *)
+
+type severity = Keeper_turn_disposition.severity =
   | Ok
   | Warn
   | Bad
   | Unknown_bad
 
 type t =
-  { code : string
-  ; disposition : Keeper_turn_disposition.t
-    (** RFC-0047 PR-2: typed operator-facing disposition. Always
-          equals [Keeper_turn_disposition.of_wire code] after the
-          producer-side [normalize_code]; this PR does not change
-          producers, so the field is derived. PR-3 will swap
-          [severity / summary / next_action] derivation to use
-          [disposition] directly (exhaustive match, no substring
-          classifier) and remove the [code: string] field. *)
+  { disposition : Keeper_turn_disposition.t
   ; source : string
   ; severity : severity
   ; summary : string
   ; next_action : string option
   }
+
+let code t = Keeper_turn_disposition.to_wire t.disposition
 
 let severity_to_string = function
   | Ok -> "ok"
@@ -29,51 +32,11 @@ let severity_to_string = function
   | Unknown_bad -> "bad"
 ;;
 
-let severity_of_code = function
-  | "success" -> Ok
-  | "external_cancel"
-  | "oas_timeout_budget"
-  | "turn_wall_clock_timeout"
-  | "gh_repo_context_missing_worktree" -> Warn
-  | "required_tool_use_no_tool_call"
-  | "required_tool_use_unsatisfied"
-  | "post_commit_ambiguous"
-  | "provider_error"
-  | "unknown_error" -> Bad
-  | code when String.starts_with ~prefix:"api_error_" code -> Bad
-  | _unknown -> Unknown_bad
-;;
-
-let summary_of_code = function
-  | "success" -> "turn completed"
-  | "required_tool_use_no_tool_call" ->
-    "required keeper tool use was requested, but the model returned no keeper tool call"
-  | "required_tool_use_unsatisfied" ->
-    "required keeper tool use was requested, but the tool contract was not satisfied"
-  | "gh_repo_context_missing_worktree" ->
-    "GitHub command blocked because the active task has no linked worktree"
-  | "oas_timeout_budget" ->
-    "OAS call was skipped or failed because the turn timeout budget was exhausted"
-  | "turn_wall_clock_timeout" -> "keeper turn hit the wall-clock timeout"
-  | "external_cancel" -> "keeper turn was cancelled before completion"
-  | "post_commit_ambiguous" ->
-    "provider failed after a mutating tool may have committed side effects"
-  | "provider_error" -> "provider or cascade failed"
-  | "unknown_error" -> "keeper turn failed without a classified terminal reason"
-  | code -> Printf.sprintf "keeper turn ended with %s" code
-;;
-
-let next_action_of_code = function
-  | "required_tool_use_no_tool_call" | "required_tool_use_unsatisfied" ->
-    Some "inspect_provider_tool_contract"
-  | "gh_repo_context_missing_worktree" -> Some "create_or_link_worktree"
-  | "oas_timeout_budget" | "turn_wall_clock_timeout" -> Some "inspect_timeout_budget"
-  | "external_cancel" -> Some "rerun_if_still_relevant"
-  | "post_commit_ambiguous" -> Some "reconcile_partial_commit"
-  | "provider_error" | "unknown_error" -> Some "inspect_latest_error"
-  | _ -> None
-;;
-
+(* Producer-side legacy-string preprocessor. Three legacy puns map to
+   their canonical app-layer codes before [Keeper_turn_disposition.of_wire]
+   is consulted. PR-2.5 / a follow-up RFC retires these by typing the
+   producers themselves; PR-3 keeps the table because every consumer of
+   the resulting disposition is now exhaustive on the typed value. *)
 let normalize_code = function
   | "completed" -> "success"
   | "completion_contract_violation:require_tool_use" -> "required_tool_use_unsatisfied"
@@ -82,15 +45,22 @@ let normalize_code = function
 ;;
 
 let make ?(source = "typed") ?summary ?next_action code =
-  let code = normalize_code code in
-  let disposition = Keeper_turn_disposition.of_wire code in
-  let summary = Option.value ~default:(summary_of_code code) summary in
+  let normalised = normalize_code code in
+  let disposition = Keeper_turn_disposition.of_wire normalised in
+  let summary =
+    Option.value ~default:(Keeper_turn_disposition.summary disposition) summary
+  in
   let next_action =
     match next_action with
     | Some _ as value -> value
-    | None -> next_action_of_code code
+    | None -> Keeper_turn_disposition.next_action disposition
   in
-  { code; disposition; source; severity = severity_of_code code; summary; next_action }
+  { disposition
+  ; source
+  ; severity = Keeper_turn_disposition.severity disposition
+  ; summary
+  ; next_action
+  }
 ;;
 
 let success () = make ~source:"turn_result" "success"
@@ -120,6 +90,18 @@ let of_legacy_error_text raw_error =
   else make ~source:"legacy_error_text" "unknown_error"
 ;;
 
+(* The fallback was previously detected via [String.equal fallback.code
+   "unknown_error"]. Now we match on the typed disposition: only the
+   empty-raw [Unknown { raw_error = "" }] case (produced by
+   [of_legacy_error_text ""]) opts into the SDK-error-derived code. Any
+   other [of_legacy_error_text] result has classified the error and
+   should be returned as-is. *)
+let is_unknown_empty (reason : t) =
+  match reason.disposition with
+  | Keeper_turn_disposition.Unknown { raw_error = "" } -> true
+  | _ -> false
+;;
+
 let of_failure ?(post_commit_ambiguous = false) ?(tool_call_count = 0) ~raw_error err =
   if post_commit_ambiguous
   then make ~source:"typed_error" "post_commit_ambiguous"
@@ -142,7 +124,7 @@ let of_failure ?(post_commit_ambiguous = false) ?(tool_call_count = 0) ~raw_erro
          make ~source:"typed_error" code
        | _ ->
          let fallback = of_legacy_error_text raw_error in
-         if String.equal fallback.code "unknown_error"
+         if is_unknown_empty fallback
          then
            make
              ~source:"typed_error"
@@ -157,7 +139,7 @@ let of_code ?source ?summary ?next_action code =
 
 let to_json reason =
   `Assoc
-    [ "code", `String reason.code
+    [ "code", `String (code reason)
     ; "source", `String reason.source
     ; "severity", `String (severity_to_string reason.severity)
     ; "summary", `String reason.summary

--- a/lib/keeper/keeper_turn_terminal.mli
+++ b/lib/keeper/keeper_turn_terminal.mli
@@ -1,24 +1,40 @@
-(** Structured terminal-reason surface for keeper turn ledgers. *)
+(** Structured terminal-reason surface for keeper turn ledgers.
 
-type severity =
+    RFC-0047 PR-3: the [code: string] field is removed; the typed
+    [disposition] field is the SSOT. [code : t -> string] is provided
+    as an accessor for callers that still need the wire string
+    (Prometheus labels, JSON, dashboard chips). [severity / summary /
+    next_action] are now exhaustive matches on [disposition]; the
+    legacy [severity_of_code / summary_of_code / next_action_of_code]
+    substring classifiers are deleted.
+
+    The [severity] type is re-exported from [Keeper_turn_disposition]
+    so external callers using [Keeper_turn_terminal.Ok | Warn | Bad |
+    Unknown_bad] continue to compile. *)
+
+type severity = Keeper_turn_disposition.severity =
   | Ok
   | Warn
   | Bad
   | Unknown_bad
 
 type t =
-  { code : string
-  ; disposition : Keeper_turn_disposition.t
-    (** RFC-0047 PR-2: typed operator-facing disposition. Derived
-          from [code] via [Keeper_turn_disposition.of_wire] at
-          construction time. PR-3 swaps
-          [severity / summary / next_action] derivation to be
-          exhaustive on this field and removes [code: string]. *)
+  { disposition : Keeper_turn_disposition.t
+    (** Typed operator-facing disposition. SSOT after RFC-0047 PR-3.
+          [severity / summary / next_action] are derived from this
+          field at construction time. The wire-format string
+          (previously [t.code]) is now [Keeper_turn_terminal.code t]. *)
   ; source : string
   ; severity : severity
   ; summary : string
   ; next_action : string option
   }
+
+(** Wire-format accessor. Returns
+    [Keeper_turn_disposition.to_wire t.disposition]. Use this when
+    the caller needs the legacy string code (JSON serialisation,
+    Prometheus labels, dashboard chips). *)
+val code : t -> string
 
 val severity_to_string : severity -> string
 val success : unit -> t

--- a/lib/keeper/keeper_unified_metrics.ml
+++ b/lib/keeper/keeper_unified_metrics.ml
@@ -734,7 +734,7 @@ let append_decision_record
         | _, Some err -> Keeper_turn_terminal.of_legacy_error_text err
         | _ -> Keeper_turn_terminal.of_code "unknown_error")
   in
-  let terminal_reason_code = terminal_reason.Keeper_turn_terminal.code in
+  let terminal_reason_code = Keeper_turn_terminal.code terminal_reason in
   let json =
     `Assoc
       ([

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -19,20 +19,15 @@ let registry_failure_reason_of_terminal_reason
     (terminal_reason : Keeper_turn_terminal.t)
     ~(raw_error : string) : Keeper_registry.failure_reason option =
   let detail = short_preview raw_error in
-  match terminal_reason.code with
+  let code = Keeper_turn_terminal.code terminal_reason in
+  match code with
   | "required_tool_use_no_tool_call"
   | "required_tool_use_unsatisfied" ->
-      Some
-        (Keeper_registry.Tool_required_unsatisfied
-           { code = terminal_reason.code; detail })
+      Some (Keeper_registry.Tool_required_unsatisfied { code; detail })
   | "provider_error" ->
-      Some
-        (Keeper_registry.Provider_runtime_error
-           { code = terminal_reason.code; detail })
-  | code when String.starts_with ~prefix:"api_error_" code ->
-      Some
-        (Keeper_registry.Provider_runtime_error
-           { code = terminal_reason.code; detail })
+      Some (Keeper_registry.Provider_runtime_error { code; detail })
+  | _ when String.starts_with ~prefix:"api_error_" code ->
+      Some (Keeper_registry.Provider_runtime_error { code; detail })
   | _ -> None
 
 let should_auto_pause_required_tool_contract_violation
@@ -1905,7 +1900,7 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
           end;
           (match
              Keeper_passive_loop_detector.progress_class_of_terminal_reason_code
-               terminal_reason.code
+               (Keeper_turn_terminal.code terminal_reason)
            with
            | Some progress_class ->
                Keeper_passive_loop_detector.record_turn

--- a/test/test_keeper_terminal_reason.ml
+++ b/test/test_keeper_terminal_reason.ml
@@ -16,7 +16,7 @@ let mk_api err = Agent_sdk.Error.Api err
 let mk_agent err = Agent_sdk.Error.Agent err
 let code = KAE.terminal_reason_code_of_sdk_error
 
-let terminal_code (reason : KT.t) = reason.code
+let terminal_code (reason : KT.t) = KT.code reason
 let terminal_next_action (reason : KT.t) = reason.next_action
 let terminal_severity (reason : KT.t) = reason.severity
 

--- a/test/test_keeper_turn_terminal_disposition_field.ml
+++ b/test/test_keeper_turn_terminal_disposition_field.ml
@@ -12,7 +12,7 @@ module T = Masc_mcp.Keeper_turn_terminal
 module D = Masc_mcp.Keeper_turn_disposition
 
 let check_invariant label (t : T.t) =
-  let expected = D.of_wire t.code in
+  let expected = D.of_wire (T.code t) in
   Alcotest.(check bool)
     (Printf.sprintf "%s: disposition derived from code" label)
     true


### PR DESCRIPTION
## Summary

Closes the RFC-0047 sequence (#14232 → #14234 → #14237 → THIS). Removes the
substring-based classifiers in `Keeper_turn_terminal` and replaces the
legacy `code: string` record field with a `code : t -> string` accessor
that projects from the typed `Keeper_turn_disposition.t`.

This is the **anti-pattern removal** PR. PR-1 introduced the typed sum
inert; PR-2 added it as a derived field while keeping the substring
path live; PR-3 deletes the substring path and makes the typed value
the SSOT.

## What changes

**Removed** (string/substring classifier anti-pattern):
- `severity_of_code` — substring → severity wildcard match
- `summary_of_code` — substring → summary
- `next_action_of_code` — substring → next-action hint
- `code: string` record field (replaced by accessor function)
- `Keeper_turn_disposition.summary` legacy alias special-case for
  `Provider_error (Provider_runtime_error \"provider_error\")` —
  introduced in PR-1 to preserve byte-compat with the substring path
  that this PR deletes; now redundant.

**Kept** (deliberately scoped out — separate layer / RFC):
- `normalize_code` producer-side legacy-string preprocessor
  (3 legacy puns; retired separately by typing producers themselves)
- `registry_failure_reason_of_terminal_reason` substring routing
  in `Keeper_unified_turn` — runtime → registry `failure_reason`
  layer, routed through the new `code` accessor; out of PR-3 scope.

## Anti-pattern self-check (`software-development.md` workaround rejection bar)

- ❌ **String/substring classifier** — substring severity/summary/next_action
  classifiers REMOVED from consumer side (this PR's stated goal).
- ❌ **N-of-M patch** — all `code` / `.code` consumers in `lib/keeper` /
  `test/` updated in this commit; `rg` confirms 0 record-field accesses remain.
- ❌ **Telemetry-as-fix** — no counter-only / instrumentation-only diff.

## Verification

| Test | Result |
|---|---|
| `test_keeper_turn_terminal_disposition_field` | 3/3 ✅ (PR-2 invariant preserved: `disposition = D.of_wire (T.code t)`) |
| `test_keeper_turn_disposition` | 7/7 ✅ (byte-compat oracle vs legacy canonical app codes; the alias-removal aligns typed `Provider_error` summary with `Unknown { raw_error }` for the same wire — `\"keeper turn ended with provider_error\"`) |
| `test_keeper_terminal_reason` | 32/32 ✅ |
| `dune build lib/` | exit 0 |

**Pre-existing failures** observed on this branch reproduce on stash-popped
main state; unrelated to PR-3:
- `test_keeper_pause_silent_failure_source` (paused-state metric)
- `test_auth_token_uniqueness_audit` (duplicate group oracle)
- `test_reqd_invalid_state_swallow` (cycle9 OAS cancellation race ref)

## Wire stability

`to_json` still emits the same five fields (`code`, `source`, `severity`,
`summary`, `next_action`) with the same wire codes; the `code` string
is now derived via accessor instead of read from a record field.

## RFC sequence

| PR | Role |
|---|---|
| #14232 | RFC-0047 docs |
| #14234 | PR-1 — `Keeper_turn_disposition.t` inert sum |
| #14237 | PR-2 — additive `disposition` field, derived from `code` |
| THIS | PR-3 — substring classifier removal + `code: string` field removal |

🤖 Generated with [Claude Code](https://claude.com/claude-code)