### PR TITLE
fix(cdal_runtime): include_subdirs no + Guardrails_async stubs

### DIFF
--- a/lib/cdal_runtime/dune
+++ b/lib/cdal_runtime/dune
@@ -19,6 +19,8 @@
 ; @rfc RFC-OAS-011 (CDAL Migration to masc-mcp)
 ; @phase MM-2-leaves — B1 batch (execution_mode, effect_evidence, guardrail_llm)
 
+(include_subdirs no)
+
 (library
  (name masc_mcp_cdal_runtime)
  (public_name masc_mcp.cdal_runtime)

--- a/lib/cdal_runtime/guardrails_async.ml
+++ b/lib/cdal_runtime/guardrails_async.ml
@@ -1,0 +1,11 @@
+(** Async guardrail validator types — see [.mli] for docs. *)
+
+type input_validator =
+  { name : string
+  ; validate : Types.message list -> (unit, string) result
+  }
+
+type output_validator =
+  { name : string
+  ; validate : Types.api_response -> (unit, string) result
+  }

--- a/lib/cdal_runtime/guardrails_async.mli
+++ b/lib/cdal_runtime/guardrails_async.mli
@@ -1,0 +1,18 @@
+(** Async guardrail validator types.
+
+    Stub for MM-2 CDAL runtime migration. Full implementation will
+    move here from agent_sdk when RFC-OAS-011 leaf migration begins.
+
+    @since 0.102.0 *)
+
+open Types
+
+type input_validator =
+  { name : string
+  ; validate : message list -> (unit, string) result
+  }
+
+type output_validator =
+  { name : string
+  ; validate : api_response -> (unit, string) result
+  }


### PR DESCRIPTION
## Summary
- Fixes `lib/cdal_runtime/dune` build failure caused by `(include_subdirs unqualified)` inheritance from parent `lib/dune`.
- Adds `(include_subdirs no)` to isolate the sublibrary.
- Creates minimal `Guardrails_async` stub (`guardrails_async.ml{,i}`) to resolve forward reference from `guardrail_llm.ml{,i}` (RFC-OAS-011 MM-2 skeleton).

## Verification
- `dune build --root .` passes
- `dune runtest --root . lib/cdal_runtime/` passes
- `test_cascade_model_resolve` passes (16/16)

## Test plan
- [ ] CI checks green

🤖 Generated with [Claude Code](https://claude.com/claude-code)