### PR TITLE
feat(dashboard): collapse 5 of 6 keeper-detail sections by default

### DIFF
--- a/dashboard/src/components/keeper-detail-shell.ts
+++ b/dashboard/src/components/keeper-detail-shell.ts
@@ -328,26 +328,49 @@ export function KeeperDetailSection({
   id,
   eyebrow,
   title,
+  defaultCollapsed = false,
   children,
 }: {
   id: KeeperDetailSectionId
   eyebrow: string
   title: string
+  /** When true, the section body starts collapsed and the operator
+   *  expands it by clicking the header. Defaults to expanded so the
+   *  long-standing always-open behaviour is preserved for callers
+   *  that do not opt in. Quick-jump links via [scrollToKeeperDetailSection]
+   *  still resolve to the header anchor regardless of the body state. */
+  defaultCollapsed?: boolean
   children: ComponentChildren
 }) {
+  const [collapsed, setCollapsed] = useState(defaultCollapsed)
+  const bodyId = `${id}-body`
   return html`
     <section
       id=${id}
       class="scroll-mt-24 rounded-[var(--r-6)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] shadow-[var(--shadow-raised)]"
       aria-label=${title}
     >
-      <div class="border-b border-[var(--color-border-default)] px-5 py-4 sm:px-6">
-        <div class="text-3xs font-semibold uppercase tracking-[var(--track-brand)] text-[var(--color-fg-muted)]">${eyebrow}</div>
-        <h3 class="m-0 mt-1 text-lg font-semibold text-[var(--color-fg-primary)]">${title}</h3>
-      </div>
-      <div class="flex flex-col gap-4 px-5 py-5 sm:px-6">
-        ${children}
-      </div>
+      <button
+        type="button"
+        class="flex w-full items-center justify-between gap-3 border-b border-[var(--color-border-default)] px-5 py-4 text-left transition-colors hover:bg-[var(--color-bg-hover)] sm:px-6"
+        aria-expanded=${!collapsed}
+        aria-controls=${bodyId}
+        onClick=${() => setCollapsed((c: boolean) => !c)}
+      >
+        <div class="min-w-0">
+          <div class="text-3xs font-semibold uppercase tracking-[var(--track-brand)] text-[var(--color-fg-muted)]">${eyebrow}</div>
+          <h3 class="m-0 mt-1 text-lg font-semibold text-[var(--color-fg-primary)]">${title}</h3>
+        </div>
+        <span
+          aria-hidden="true"
+          class=${`shrink-0 text-[var(--color-fg-muted)] transition-transform duration-[var(--t-med)] ${collapsed ? '' : 'rotate-180'}`}
+        >▾</span>
+      </button>
+      ${collapsed ? null : html`
+        <div id=${bodyId} class="flex flex-col gap-4 px-5 py-5 sm:px-6">
+          ${children}
+        </div>
+      `}
     </section>
   `
 }

--- a/dashboard/src/components/keeper-detail.ts
+++ b/dashboard/src/components/keeper-detail.ts
@@ -1144,6 +1144,7 @@ export function KeeperDetailPage() {
             id="keeper-comms"
             eyebrow="대화 & 세션"
             title="대화 / 활동 흐름"
+            defaultCollapsed=${true}
           >
             <${KeeperCommsPanel} keeper=${keeper} />
             <${PanelCard} title="세션 활동 로그">
@@ -1155,6 +1156,7 @@ export function KeeperDetailPage() {
             id="keeper-runtime"
             eyebrow="런타임 진단"
             title="진단 / 운영"
+            defaultCollapsed=${true}
           >
             <${KeeperToolTelemetry} keeperName=${keeper.name} />
             <${KeeperEvalQualityPanel} keeperName=${keeper.name} />
@@ -1186,6 +1188,7 @@ export function KeeperDetailPage() {
             id="keeper-identity"
             eyebrow="신원 & 계보"
             title="정체성 / 세대"
+            defaultCollapsed=${true}
           >
             <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
               <${PanelCard} title="프로필">
@@ -1251,6 +1254,7 @@ export function KeeperDetailPage() {
             id="keeper-config"
             eyebrow="설정"
             title="설정 / 작업 방식"
+            defaultCollapsed=${true}
           >
             <${TurnBudgetSection} keeper=${keeper} />
             <${CollapsibleSection} title="허용 도구">
@@ -1270,6 +1274,7 @@ export function KeeperDetailPage() {
             id="keeper-debug"
             eyebrow="디버그"
             title="디버그"
+            defaultCollapsed=${true}
           >
             <details class="mt-0">
           <summary class="cursor-pointer py-3 px-4 text-2xs font-semibold uppercase tracking-[var(--track-caps)] text-[var(--color-fg-muted)] list-none select-none rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] hover:bg-[var(--color-bg-hover)] transition-colors flex items-center gap-2">


### PR DESCRIPTION
Direct response to user's first-message complaint about keeper-detail vertical density. 5 of 6 sections default-collapsed (운영 상태 개요만 펼침). KeeperDetailSection grows defaultCollapsed?: boolean prop. Tests 27/27, build green. RFC-0048 PR-C will replace these hand-picked defaults with telemetry-driven policy after 7-day window.