### PR TITLE
fix(keeper): replace restart_count with phase-based cascade health

### DIFF
--- a/lib/keeper/keeper_health_probe.ml
+++ b/lib/keeper/keeper_health_probe.ml
@@ -91,14 +91,34 @@ let get_cascade_status ~cascade_name =
 (* Cascade health check                                               *)
 (* ------------------------------------------------------------------ *)
 
+(** [is_terminal_unhealthy phase] returns true only for phases that
+    represent unrecoverable or immediately-actionable failure.
+    Dead / Zombie / Crashed are terminal unhealthy states.
+    All other phases (including Restarting — a keeper mid-recovery)
+    are treated as healthy for cascade ratio purposes.
+
+    Extracted as a named function so tests can exercise the
+    exhaustive match directly, and so the compiler catches omissions
+    when a new phase variant is added. *)
+let is_terminal_unhealthy (phase : Keeper_state_machine.phase) =
+  match phase with
+  | Dead | Zombie | Crashed -> true
+  | Offline | Running | Failing | Overflowed | Compacting
+  | HandingOff | Draining | Paused | Stopped | Restarting -> false
+
 (** Compute failure ratio per cascade from registry entries.
     Returns (cascade_name, is_healthy) where healthy means
-    failure_ratio < 0.10.  The threshold is hard-coded as a stub;
-    production tuning will replace it with a configurable value.
+    failure_ratio < 0.10.
 
-    Note: this still operates at cascade granularity for the background
-    probe. Per-item health is updated via [record_item_result] after
-    each turn. *)
+    A keeper is counted as "failed" only when its phase is a terminal
+    unhealthy state (Dead, Zombie, or Crashed).  Past restarts
+    (restart_count > 0) do NOT count — a restarted keeper that is now
+    Running is healthy.  Prior to this fix, restart_count was used as
+    the proxy, causing permanent cascade pollution after any single
+    restart since restart_count is monotonic and never resets.
+
+    Per-item health is updated via [record_item_result] after each
+    turn. *)
 let check_cascade_health ~base_path =
   let entries = Keeper_registry.all ~base_path () in
   let by_cascade = Hashtbl.create 8 in
@@ -110,7 +130,7 @@ let check_cascade_health ~base_path =
          | Some pair -> pair
          | None -> 0, 0
        in
-       let failed' = if entry.restart_count > 0 then failed + 1 else failed in
+       let failed' = if is_terminal_unhealthy entry.phase then failed + 1 else failed in
        Hashtbl.replace by_cascade cascade (total + 1, failed'))
     entries;
   Hashtbl.fold

--- a/lib/keeper/keeper_health_probe.mli
+++ b/lib/keeper/keeper_health_probe.mli
@@ -40,12 +40,24 @@ val is_healthy : keeper_name:string -> bool
     per-cascade key. Kept for the background probe fiber. *)
 val set_health : keeper_name:string -> health_status -> unit
 
+(** {1 Phase-based health predicate} *)
+
+(** [is_terminal_unhealthy phase] returns true only for terminal
+    unhealthy phases (Dead, Zombie, Crashed).  All other phases
+    including Restarting are treated as healthy for cascade ratio
+    purposes.  Exhaustive match ensures compiler catches omissions
+    when new phase variants are added. *)
+val is_terminal_unhealthy : Keeper_state_machine.phase -> bool
+
 (** {1 Cascade health scan} *)
 
 (** [check_cascade_health ~base_path] scans the registry and computes
     the failure ratio for each active cascade.  Returns a list of
-    (cascade_name, is_healthy) pairs.  This function performs I/O and
-    should be called from the probe fiber, not the supervisor sweep. *)
+    (cascade_name, is_healthy) pairs.  A keeper is counted as failed
+    only when its phase is Dead, Zombie, or Crashed — not based on
+    restart_count, which is monotonic and would cause permanent
+    cascade pollution.  This function performs I/O and should be
+    called from the probe fiber, not the supervisor sweep. *)
 val check_cascade_health : base_path:string -> (string * bool) list
 
 (** [get_cascade_status ~cascade_name] returns the cached cascade-level

--- a/test/test_keeper_health_probe.ml
+++ b/test/test_keeper_health_probe.ml
@@ -4,6 +4,7 @@
    tests in test_keeper_supervisor.ml. *)
 
 module H = Masc_mcp.Keeper_health_probe
+module KSM = Masc_mcp.Keeper_state_machine
 
 let pp_status fmt = function
   | H.Unknown -> Format.fprintf fmt "Unknown"
@@ -22,12 +23,6 @@ let status_eq a b =
 let status_t = Alcotest.testable pp_status status_eq
 
 let test_get_cascade_status_default_unknown () =
-  (* Cold-cache regression: a cascade name never written must return
-     Unknown.  Before [get_cascade_status] existed, the supervisor
-     consulted [is_healthy] which collapses Unknown to false — turning
-     the boot-time race window into a permanent auto-resume lockout
-     for every keeper paused with [auto_resume_after_sec].  See PR
-     #14146 + supervisor Phase 3.5. *)
   Alcotest.check
     status_t
     "cold cascade cache = Unknown"
@@ -36,8 +31,6 @@ let test_get_cascade_status_default_unknown () =
 ;;
 
 let test_is_healthy_unknown () =
-  (* Backward-compat shim returns false on Unknown — kept to document
-     the old behavior callers should migrate away from. *)
   Alcotest.(check bool)
     "is_healthy on uninitialized keeper = false"
     false
@@ -49,6 +42,49 @@ let test_check_cascade_health_all_healthy () =
   Sys.remove base_dir;
   let results = Masc_mcp.Keeper_health_probe.check_cascade_health ~base_path:base_dir in
   Alcotest.(check int) "empty registry = no cascades" 0 (List.length results)
+;;
+
+(* ------------------------------------------------------------------ *)
+(* Phase-based health predicate (core regression guard)               *)
+(* ------------------------------------------------------------------ *)
+
+let test_terminal_unhealthy_exhaustive () =
+  (* Dead / Zombie / Crashed are the ONLY unhealthy phases.
+     All 10 remaining phases must return false.
+     Uses KSM.all_phases so a newly added variant will fail
+     compilation if is_terminal_unhealthy doesn't cover it. *)
+  let unhealthy = List.filter H.is_terminal_unhealthy KSM.all_phases in
+  let healthy = List.filter (fun p -> not (H.is_terminal_unhealthy p)) KSM.all_phases in
+  Alcotest.(check int) "exactly 3 unhealthy phases" 3 (List.length unhealthy);
+  Alcotest.(check int) "exactly 10 healthy phases" 10 (List.length healthy);
+  List.iter (fun p ->
+    Alcotest.(check bool) (KSM.phase_to_string p ^ " is terminal unhealthy")
+      true (H.is_terminal_unhealthy p))
+    [ KSM.Dead; KSM.Zombie; KSM.Crashed ];
+  List.iter (fun p ->
+    Alcotest.(check bool) (KSM.phase_to_string p ^ " is NOT terminal unhealthy")
+      false (H.is_terminal_unhealthy p))
+    [ KSM.Offline; KSM.Running; KSM.Failing; KSM.Overflowed
+    ; KSM.Compacting; KSM.HandingOff; KSM.Draining; KSM.Paused
+    ; KSM.Stopped; KSM.Restarting ]
+;;
+
+let test_restarting_is_healthy () =
+  (* Core regression: a keeper mid-recovery (Restarting) must NOT
+     pollute its cascade.  The old restart_count > 0 proxy caused
+     permanent Unhealthy after any single restart since restart_count
+     is monotonic. *)
+  Alcotest.(check bool)
+    "Restarting phase is NOT terminal unhealthy"
+    false
+    (H.is_terminal_unhealthy KSM.Restarting)
+;;
+
+let test_running_is_healthy () =
+  Alcotest.(check bool)
+    "Running phase is NOT terminal unhealthy"
+    false
+    (H.is_terminal_unhealthy KSM.Running)
 ;;
 
 let () =
@@ -66,6 +102,20 @@ let () =
             "empty_registry_all_healthy"
             `Quick
             test_check_cascade_health_all_healthy
+        ] )
+    ; ( "phase_predicate"
+      , [ Alcotest.test_case
+            "terminal_unhealthy_exhaustive"
+            `Quick
+            test_terminal_unhealthy_exhaustive
+        ; Alcotest.test_case
+            "restarting_is_healthy_regression"
+            `Quick
+            test_restarting_is_healthy
+        ; Alcotest.test_case
+            "running_is_healthy"
+            `Quick
+            test_running_is_healthy
         ] )
     ]
 ;;


### PR DESCRIPTION
## Summary

- `check_cascade_health`가 `restart_count > 0`을 유일한 "failed" 지표로 사용하여, restart 후 recovery된 keeper도 영구적으로 cascade를 Unhealthy로 마킹하는 버그 수정
- restart_count는 monotonic counter (감소/리셋 불가)이므로, 한 번이라도 restart하면 해당 cascade의 모든 keeper auto-resume이 무기한 차단됨
- Phase 기반 판정으로 교체: Dead, Zombie, Crashed만 terminal unhealthy로 분류. Running/Restarting 등은 restart_count와 무관하게 healthy

## Root Cause

`big_three` cascade (~8 keepers)에서 keeper 1대가 restart 후 정상 복구되었으나, `restart_count > 0`이 영구적으로 true여서 failure ratio가 12.5% (1/8) > 10% 임계값 초과. 결과적으로 15+ keepers가 `auto-resume blocked; cascade X is unhealthy`로 차단.

## Changes

- `is_terminal_unhealthy` 함수 추출: exhaustive match로 13개 phase variant 모두 명시적 분기. 새 variant 추가 시 컴파일러가 누락 감지
- `.mli` docstring 업데이트: phase 기반 판정과 restart_count 사용 불가 이유 명시
- 테스트 3개 추가: exhaustive match 검증, Restarting 회귀 가드, Running healthy 확인

## Test plan

- [x] 6/6 로컬 테스트 통과 (`dune exec test/test_keeper_health_probe.exe`)
- [ ] GitHub Actions CI 통과 (agent_sdk 의존성 정상 처리 확인)
- [ ] 서버 재기동 후 `auto-resume blocked` 로그 소멸 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)