### PR TITLE
style(cdal_runtime): apply ocamlformat to PR #14272 conformance.ml

### DIFF
--- a/lib/cdal_runtime/conformance.ml
+++ b/lib/cdal_runtime/conformance.ml
@@ -71,7 +71,8 @@ let lifecycle_monotonic (worker : Sessions_types.worker_run) =
 ;;
 
 let worker_ids worker_runs =
-  worker_runs |> List.map (fun (worker : Sessions_types.worker_run) -> worker.worker_run_id)
+  worker_runs
+  |> List.map (fun (worker : Sessions_types.worker_run) -> worker.worker_run_id)
 ;;
 
 let raw_run_ids raw_runs =
@@ -107,11 +108,14 @@ let check bundle =
     | [] -> None
   in
   let expected_latest_validated =
-    latest_by (fun (worker : Sessions_types.worker_run) -> worker.validated) bundle.worker_runs
+    latest_by
+      (fun (worker : Sessions_types.worker_run) -> worker.validated)
+      bundle.worker_runs
   in
   let expected_latest_accepted =
     latest_by
-      (fun (worker : Sessions_types.worker_run) -> worker.status = Sessions_types.Accepted)
+      (fun (worker : Sessions_types.worker_run) ->
+         worker.status = Sessions_types.Accepted)
       bundle.worker_runs
   in
   let expected_latest_ready =
@@ -126,7 +130,8 @@ let check bundle =
   in
   let expected_latest_completed =
     latest_by
-      (fun (worker : Sessions_types.worker_run) -> worker.status = Sessions_types.Completed)
+      (fun (worker : Sessions_types.worker_run) ->
+         worker.status = Sessions_types.Completed)
       bundle.worker_runs
   in
   let expected_latest_failed =
@@ -210,10 +215,12 @@ let check bundle =
           (Printf.sprintf
              "bundle=%s expected=%s"
              (bundle.latest_accepted_worker_run
-              |> Option.map (fun (worker : Sessions_types.worker_run) -> worker.worker_run_id)
+              |> Option.map (fun (worker : Sessions_types.worker_run) ->
+                worker.worker_run_id)
               |> Option.value ~default:"")
              (expected_latest_accepted
-              |> Option.map (fun (worker : Sessions_types.worker_run) -> worker.worker_run_id)
+              |> Option.map (fun (worker : Sessions_types.worker_run) ->
+                worker.worker_run_id)
               |> Option.value ~default:""))
     }
   ; { code = "latest_ready_inconsistent"
@@ -230,10 +237,12 @@ let check bundle =
           (Printf.sprintf
              "bundle=%s expected=%s"
              (bundle.latest_ready_worker_run
-              |> Option.map (fun (worker : Sessions_types.worker_run) -> worker.worker_run_id)
+              |> Option.map (fun (worker : Sessions_types.worker_run) ->
+                worker.worker_run_id)
               |> Option.value ~default:"")
              (expected_latest_ready
-              |> Option.map (fun (worker : Sessions_types.worker_run) -> worker.worker_run_id)
+              |> Option.map (fun (worker : Sessions_types.worker_run) ->
+                worker.worker_run_id)
               |> Option.value ~default:""))
     }
   ; { code = "latest_running_inconsistent"
@@ -250,10 +259,12 @@ let check bundle =
           (Printf.sprintf
              "bundle=%s expected=%s"
              (bundle.latest_running_worker_run
-              |> Option.map (fun (worker : Sessions_types.worker_run) -> worker.worker_run_id)
+              |> Option.map (fun (worker : Sessions_types.worker_run) ->
+                worker.worker_run_id)
               |> Option.value ~default:"")
              (expected_latest_running
-              |> Option.map (fun (worker : Sessions_types.worker_run) -> worker.worker_run_id)
+              |> Option.map (fun (worker : Sessions_types.worker_run) ->
+                worker.worker_run_id)
               |> Option.value ~default:""))
     }
   ; { code = "latest_worker_inconsistent"
@@ -270,10 +281,12 @@ let check bundle =
           (Printf.sprintf
              "bundle=%s expected=%s"
              (bundle.latest_worker_run
-              |> Option.map (fun (worker : Sessions_types.worker_run) -> worker.worker_run_id)
+              |> Option.map (fun (worker : Sessions_types.worker_run) ->
+                worker.worker_run_id)
               |> Option.value ~default:"")
              (expected_latest_worker
-              |> Option.map (fun (worker : Sessions_types.worker_run) -> worker.worker_run_id)
+              |> Option.map (fun (worker : Sessions_types.worker_run) ->
+                worker.worker_run_id)
               |> Option.value ~default:""))
     }
   ; { code = "latest_completed_inconsistent"
@@ -290,10 +303,12 @@ let check bundle =
           (Printf.sprintf
              "bundle=%s expected=%s"
              (bundle.latest_completed_worker_run
-              |> Option.map (fun (worker : Sessions_types.worker_run) -> worker.worker_run_id)
+              |> Option.map (fun (worker : Sessions_types.worker_run) ->
+                worker.worker_run_id)
               |> Option.value ~default:"")
              (expected_latest_completed
-              |> Option.map (fun (worker : Sessions_types.worker_run) -> worker.worker_run_id)
+              |> Option.map (fun (worker : Sessions_types.worker_run) ->
+                worker.worker_run_id)
               |> Option.value ~default:""))
     }
   ; { code = "latest_validated_inconsistent"
@@ -310,10 +325,12 @@ let check bundle =
           (Printf.sprintf
              "bundle=%s expected=%s"
              (bundle.latest_validated_worker_run
-              |> Option.map (fun (worker : Sessions_types.worker_run) -> worker.worker_run_id)
+              |> Option.map (fun (worker : Sessions_types.worker_run) ->
+                worker.worker_run_id)
               |> Option.value ~default:"")
              (expected_latest_validated
-              |> Option.map (fun (worker : Sessions_types.worker_run) -> worker.worker_run_id)
+              |> Option.map (fun (worker : Sessions_types.worker_run) ->
+                worker.worker_run_id)
               |> Option.value ~default:""))
     }
   ; { code = "latest_failed_inconsistent"
@@ -330,10 +347,12 @@ let check bundle =
           (Printf.sprintf
              "bundle=%s expected=%s"
              (bundle.latest_failed_worker_run
-              |> Option.map (fun (worker : Sessions_types.worker_run) -> worker.worker_run_id)
+              |> Option.map (fun (worker : Sessions_types.worker_run) ->
+                worker.worker_run_id)
               |> Option.value ~default:"")
              (expected_latest_failed
-              |> Option.map (fun (worker : Sessions_types.worker_run) -> worker.worker_run_id)
+              |> Option.map (fun (worker : Sessions_types.worker_run) ->
+                worker.worker_run_id)
               |> Option.value ~default:""))
     }
   ; { code = "trace_capabilities_inconsistent"
@@ -452,7 +471,8 @@ let report bundle =
             (fun (worker : Sessions_types.worker_run) -> worker_status_name worker.status)
             latest_worker
       ; latest_worker_role =
-          Option.bind latest_worker (fun (worker : Sessions_types.worker_run) -> worker.role)
+          Option.bind latest_worker (fun (worker : Sessions_types.worker_run) ->
+            worker.role)
       ; latest_worker_aliases =
           Option.bind latest_worker (fun (worker : Sessions_types.worker_run) ->
             Some worker.aliases)
@@ -477,7 +497,10 @@ let report bundle =
           Option.bind latest_worker (fun (worker : Sessions_types.worker_run) ->
             worker.resolved_model)
       ; hook_event_count =
-          List.fold_left (fun acc item -> acc + item.Sessions_types.count) 0 bundle.hook_summary
+          List.fold_left
+            (fun acc item -> acc + item.Sessions_types.count)
+            0
+            bundle.hook_summary
       ; tool_catalog_count = List.length bundle.tool_catalog
       ; trace_capabilities = bundle.trace_capabilities
       }
@@ -596,7 +619,10 @@ let%test "latest_by returns last matching element" =
 
 let%test "latest_by returns None when no match" =
   let w1 = make_worker ~status:Sessions_types.Running () in
-  latest_by (fun (w : Sessions_types.worker_run) -> w.status = Sessions_types.Failed) [ w1 ] = None
+  latest_by
+    (fun (w : Sessions_types.worker_run) -> w.status = Sessions_types.Failed)
+    [ w1 ]
+  = None
 ;;
 
 let%test "latest_by empty list" = latest_by (fun _ -> true) [] = None


### PR DESCRIPTION
## Summary

PR #14272 (\`refactor(cdal_runtime): replace Sessions facade with direct module refs (RFC-OAS-011 OAS-E PR-2)\`) was admin-merged with the \`ocamlformat-check (changed files only)\` step failing — \`lib/cdal_runtime/conformance.ml\` had 110 lines of formatting drift after the rename.

**Cause**: replacing \`Sessions.X\` (8-char prefix) with \`Sessions_types.X\` (14-char prefix) pushed several lambda + pipe lines past the column limit. ocamlformat wraps them; PR #14272 didn't run \`ocamlformat -i\`. Pure whitespace, no semantic change.

## Verification I did locally

| Check | Result |
|-------|--------|
| \`dune build --root . lib/cdal_runtime/\` (PR #14272's scope) | ✅ clean |
| \`ocamlformat --check\` on the 6 files PR #14272 touched | 5/6 OK; only \`conformance.ml\` failed |
| \`ocamlformat --check lib/cdal_runtime/conformance.ml\` after \`-i\` | ✅ pass |

## ⚠️ Out of scope: pre-existing main-broken state

\`dune build --root . @check\` on origin/main (with or without this PR) fails with **8 errors** that originate from earlier PR #14267 (\`feat(masc_mcp): atomic flip Agent_sdk → Masc_mcp_cdal_runtime\`):

\`\`\`
lib/keeper/keeper_heartbeat_loop.ml:420   warning 16 [unerasable-optional-argument]
lib/keeper/keeper_unified_turn.ml:1753    Cascade_ref.id field belongs to wrong record
test/test_masc_contract_catalog.ml:32     spec.risk_class type mismatch
test/test_keeper_unified.ml:3330          Agent_sdk.Cdal_proof.t (renamed to Masc_mcp_cdal_runtime)
test/test_cdal_friction_projection.ml:140 Agent_sdk.Proof_store.config (same)
test/test_cdal_eval_v1.ml:108             Agent_sdk.Proof_store.config (same)
test/test_cdal_loader.ml:94               Agent_sdk.Proof_store.config (same)
test/test_cdal_judge.ml:92                Agent_sdk.Cdal_proof.t (same)
\`\`\`

These pre-date PR #14272 and are owned by RFC-OAS-011 OAS-E (atomic flip didn't update all caller sites). **Not addressed by this PR.**

## Memory referenced

- \`feedback_masc_mcp_admin_merge_fast_track.md\` — admin-merge fast-track for agent IA work; \`style()\` follow-up is established pattern.
- \`feedback_rfc_oas_011_cdal_runtime_admin_merge_cascade.md\` — RFC-OAS-011 cdal_runtime admin-merge dep cascade; this is layer N (5th of the cascade if we count #14246/#14249/#14257/#14260/#14269 as layers 1–4 of the dep chain, this is the format-only sibling).

## Test plan

- [ ] CI \`ocamlformat-check\` passes on this PR's diff.
- [ ] No new build errors introduced by the wrap-only changes.
- [ ] (Out of scope) Atomic-flip caller sites in lib/keeper/ + test/ remain RFC-OAS-011 OAS-E owner's task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)