### PR TITLE
feat(dashboard): collapse 6 of 11 agent-detail sections by default

### DIFF
--- a/dashboard/src/components/agent-detail-journal.ts
+++ b/dashboard/src/components/agent-detail-journal.ts
@@ -1,7 +1,7 @@
 // Agent detail journal stream — real-time activity stream filtered by agent
 
 import { html } from 'htm/preact'
-import { Card } from './common/card'
+import { CollapsibleSection } from './common/collapsible'
 import { EmptyState } from './common/empty-state'
 import { TimeAgo } from './common/time-ago'
 import { agentJournalEntries, journalKindIcon } from './agent-detail-state'
@@ -10,9 +10,12 @@ import type { JournalEntry } from '../types'
 
 export function AgentJournalStream({ agentName }: { agentName: string }) {
   const entries = agentJournalEntries(agentName)
+  const title = entries.length > 0
+    ? `실시간 활동 스트림 (${entries.length})`
+    : '실시간 활동 스트림'
 
   return html`
-    <${Card} title="실시간 활동 스트림">
+    <${CollapsibleSection} title=${title} mountWhenOpen=${true}>
       ${entries.length === 0
         ? html`<${EmptyState} message="아직 활동 기록이 없습니다" compact />`
         : html`

--- a/dashboard/src/components/agent-detail-memory.ts
+++ b/dashboard/src/components/agent-detail-memory.ts
@@ -3,7 +3,7 @@ import { useSignal } from '@preact/signals'
 import { useEffect, useMemo } from 'preact/hooks'
 import { LoadingState } from './common/feedback-state'
 import { ProgressBar } from './common/progress-bar'
-import { Card } from './common/card'
+import { CollapsibleSection } from './common/collapsible'
 import {
   fetchMemorySubsystems,
   type MemorySubsystemsResponse,
@@ -120,7 +120,7 @@ export function AgentDetailMemory({ agentName }: Props) {
   const isFilteringEpisodes = episodeQuery.value.trim() !== ''
 
   return html`
-    <${Card} title="협업 & 기억">
+    <${CollapsibleSection} title="협업 & 기억" mountWhenOpen=${true}>
       <div class="space-y-4">
         <!-- Hebbian collaboration -->
         <div>

--- a/dashboard/src/components/agent-detail-timeline.ts
+++ b/dashboard/src/components/agent-detail-timeline.ts
@@ -3,7 +3,7 @@
 
 import { html } from 'htm/preact'
 import { signal } from '@preact/signals'
-import { Card } from './common/card'
+import { CollapsibleSection } from './common/collapsible'
 import { EmptyState } from './common/empty-state'
 import { TimeAgo } from './common/time-ago'
 import { FilterChips } from './common/filter-chips'
@@ -145,7 +145,7 @@ export function AgentTimelineSection() {
   const filterActive = activeCategory !== 'all' || query.trim() !== ''
 
   return html`
-    <${Card} title="활동 타임라인 (${summary?.total_events ?? 0}건)">
+    <${CollapsibleSection} title=${`활동 타임라인 (${summary?.total_events ?? 0})`} mountWhenOpen=${true}>
       ${summary ? html`
         <div class="flex gap-1.5 flex-wrap mb-2">
           ${summary.tasks_completed > 0 ? html`<${SummaryBadge}>완료 ${summary.tasks_completed}<//>` : null}

--- a/dashboard/src/components/agent-detail-worker.ts
+++ b/dashboard/src/components/agent-detail-worker.ts
@@ -1,7 +1,7 @@
 // Agent detail worker brief — execution worker status panel
 
 import { html } from 'htm/preact'
-import { Card } from './common/card'
+import { CollapsibleSection } from './common/collapsible'
 import { StatusBadge } from './common/status-badge'
 import { TimeAgo } from './common/time-ago'
 import { CopyIdButton } from './common/copy-id-button'
@@ -21,7 +21,7 @@ export function AgentWorkerBrief({ agentName }: { agentName: string }) {
   if (!worker) return null
 
   return html`
-    <${Card} title="워커 상태">
+    <${CollapsibleSection} title="워커 상태" mountWhenOpen=${true}>
       <div class="flex flex-col gap-1.5">
         <${WorkerInfoRow}>
           <${DetailLabel}>상태</${DetailLabel}>

--- a/dashboard/src/components/agent-detail.ts
+++ b/dashboard/src/components/agent-detail.ts
@@ -373,7 +373,7 @@ export function AgentDetailOverlay() {
           <${AgentDetailMemory} agentName=${agentName} />
           <${AgentWorkerBrief} agentName=${agentName} />
           ${agentFitness.value ? html`
-            <${Card} title="적합도 (7일)" role="region" ariaLabel="에이전트 적합도">
+            <${CollapsibleSection} title="적합도 (7일)" mountWhenOpen=${true}>
               <div class="grid grid-cols-2 sm:grid-cols-4 gap-3">
                 ${([
                   ['완료율', agentFitness.value.completion_rate],
@@ -390,7 +390,7 @@ export function AgentDetailOverlay() {
             <//>
           ` : null}
 
-          <${Card} title="작업 이력">
+          <${CollapsibleSection} title=${`작업 이력 (${historyRows.length})`} mountWhenOpen=${true}>
             ${renderTaskHistories(historyRows, visibleHistories, isFilteringTasks)}
           <//>
 


### PR DESCRIPTION
## Summary

Mirror the #14275 vertical-density treatment to the **agent-detail overlay**. Six sub-panels switch from always-open `Card` to `CollapsibleSection { mountWhenOpen: true, default-closed }`:

- 실시간 활동 스트림 (`agent-detail-journal`)
- 활동 타임라인 (`agent-detail-timeline`)
- 협업 & 기억 (`agent-detail-memory`)
- 워커 상태 (`agent-detail-worker`)
- 적합도 (7일) (inline in `agent-detail.ts`)
- 작업 이력 (inline in `agent-detail.ts`)

Stay visible by default (quick-glance / action):
- Header (status, model, last seen, linked keeper)
- `AgentSessionReport`
- `활동 추적` (already collapsible — pre-existing)
- 작업 필터 + 2-col grid (`할당된 작업` / `최근 활동`)
- 직접 멘션 (input — keep accessible)

## Why

Agent detail modal had 11 stacked panels, all open. Operators clicked an agent name and got a vertical wall on first open. Same complaint as keeper-detail: \"우측도 뭐가 존나 많은데\" (#14275). Six of those panels are deep-dive — open them on demand.

## How

- `<\${Card} title=\"X\">` → `<\${CollapsibleSection} title=\"X\" mountWhenOpen={true}>` in 4 sub-component files
- Inline `Card` wrappers in `agent-detail.ts` for `적합도` and `작업 이력` get the same swap
- `mountWhenOpen=true` defers child DOM mount until first expand. Data fetches (`agentJournalEntries`, `fetchMemorySubsystems`, `agentTimeline.value`) still run at component mount so first expand has data ready
- `agent-detail-journal` and `agent-detail-timeline` titles get a count suffix (\`(${n})\`) so collapsed state still shows useful information

## Build / Test

- `npx vitest run agent-detail-state.test.ts agent-detail-timeline.test.ts` → 11/11 pass
- `npx vite build` → 9.39s, green
- `npx tsc --noEmit` — no new errors. Pre-existing baseline drift (`fsm_guard_violations`, `collapsed_from`, `NonHomeTabId`) unchanged from `main`

## Trade-offs

- `mountWhenOpen=true` slightly delays first paint of child content; the closed panels render only their summary, then their body on first expand. Acceptable since closed-by-default
- Keep `직접 멘션` open: the input is an action surface, hiding it raises friction. If we later observe nobody mentions from agent-detail, candidate for follow-up collapse

🤖 Generated with [Claude Code](https://claude.com/claude-code)