### PR TITLE
chore(rfc-0047): Phase 3a — move 3 cascade leaves to lib/cascade/

### DIFF
--- a/lib/cascade/cascade_attempt_fsm.ml
+++ b/lib/cascade/cascade_attempt_fsm.ml
@@ -1,4 +1,4 @@
-(** Oas_worker_named_fsm — SDK error to FSM outcome, session/resumption analysis.
+(** Cascade_attempt_fsm — SDK error to FSM outcome, session/resumption analysis.
 
     Extracted from oas_worker_named.ml (God file decomposition).
     Converts OAS SDK errors into Cascade_fsm provider outcomes,
@@ -24,8 +24,8 @@ let retry_message_looks_like_model_access_denied (message : string) : bool =
     errors (budget, idle, exit) are not — they would recur on any model. *)
 let sdk_error_to_cascade_outcome (err : Agent_sdk.Error.sdk_error)
     : Cascade_fsm.provider_outcome option =
-  match Oas_worker_named_error.classify_masc_internal_error err with
-  | Some (Oas_worker_named_error.Resumable_cli_session { detail; _ }) ->
+  match Cascade_error_classify.classify_masc_internal_error err with
+  | Some (Cascade_error_classify.Resumable_cli_session { detail; _ }) ->
     Some
       (Cascade_fsm.Call_err
          (Llm_provider.Http_client.NetworkError
@@ -33,14 +33,14 @@ let sdk_error_to_cascade_outcome (err : Agent_sdk.Error.sdk_error)
   (* All other MASC-internal classifications (and unclassified errors) fall
      through to the structured [match err with] below to derive the cascade
      outcome from the raw [sdk_error] payload. *)
-  | Some (Oas_worker_named_error.Cascade_exhausted _)
-  | Some (Oas_worker_named_error.No_tool_capable_provider _)
-  | Some (Oas_worker_named_error.Accept_rejected _)
-  | Some (Oas_worker_named_error.Admission_queue_timeout _)
-  | Some (Oas_worker_named_error.Admission_queue_rejected _)
-  | Some (Oas_worker_named_error.Turn_timeout _)
-  | Some (Oas_worker_named_error.Oas_timeout_budget _)
-  | Some (Oas_worker_named_error.Ambiguous_post_commit _)
+  | Some (Cascade_error_classify.Cascade_exhausted _)
+  | Some (Cascade_error_classify.No_tool_capable_provider _)
+  | Some (Cascade_error_classify.Accept_rejected _)
+  | Some (Cascade_error_classify.Admission_queue_timeout _)
+  | Some (Cascade_error_classify.Admission_queue_rejected _)
+  | Some (Cascade_error_classify.Turn_timeout _)
+  | Some (Cascade_error_classify.Oas_timeout_budget _)
+  | Some (Cascade_error_classify.Ambiguous_post_commit _)
   | None -> (
   match err with
   | Agent_sdk.Error.Api api_err ->
@@ -141,7 +141,7 @@ let is_moonshot_provider (provider_cfg : Llm_provider.Provider_config.t) =
   String_util.contains_substring_ci provider_cfg.base_url "moonshot.ai"
   || String.starts_with ~prefix:"kimi" provider_cfg.model_id
 
-let cascade_name_to_string = Oas_worker_named_error.cascade_name_to_string
+let cascade_name_to_string = Cascade_error_classify.cascade_name_to_string
 
 let resolve_kimi_api_key_env_name ~cascade_name =
   let cascade_name = cascade_name_to_string cascade_name in
@@ -341,14 +341,14 @@ let resumable_cli_session_exit_code (message : string) : int option =
 
 let sdk_error_to_resumable_cli_session ~cascade_name
     (err : Agent_sdk.Error.sdk_error) =
-  match Oas_worker_named_error.classify_masc_internal_error err with
-  | Some (Oas_worker_named_error.Resumable_cli_session _) -> Some err
+  match Cascade_error_classify.classify_masc_internal_error err with
+  | Some (Cascade_error_classify.Resumable_cli_session _) -> Some err
   | _ ->
       let message = Agent_sdk.Error.to_string err in
       if message_looks_like_resumable_cli_session message then
         Some
-          (Oas_worker_named_error.sdk_error_of_masc_internal_error
-             (Oas_worker_named_error.Resumable_cli_session
+          (Cascade_error_classify.sdk_error_of_masc_internal_error
+             (Cascade_error_classify.Resumable_cli_session
                 {
                   cascade_name =
                     cascade_name;
@@ -358,8 +358,8 @@ let sdk_error_to_resumable_cli_session ~cascade_name
       else None
 
 let sdk_error_is_resumable_cli_session (err : Agent_sdk.Error.sdk_error) : bool =
-  match Oas_worker_named_error.classify_masc_internal_error err with
-  | Some (Oas_worker_named_error.Resumable_cli_session _) -> true
+  match Cascade_error_classify.classify_masc_internal_error err with
+  | Some (Cascade_error_classify.Resumable_cli_session _) -> true
   | _ ->
       let direct_api_message =
         match err with
@@ -605,24 +605,24 @@ let sdk_error_soft_rate_limited (err : Agent_sdk.Error.sdk_error)
   | Agent_sdk.Error.Internal _ -> None
 
 let sdk_error_is_max_turns_exceeded (err : Agent_sdk.Error.sdk_error) : bool =
-  match Oas_worker_named_error.classify_masc_internal_error err with
+  match Cascade_error_classify.classify_masc_internal_error err with
   | Some
-      (Oas_worker_named_error.Cascade_exhausted
+      (Cascade_error_classify.Cascade_exhausted
          { reason = Keeper_types.Max_turns_exceeded; _ }) ->
       true
   | Some
-      (Oas_worker_named_error.Cascade_exhausted
+      (Cascade_error_classify.Cascade_exhausted
          { reason = Keeper_types.Other_detail detail; _ }) ->
       message_looks_like_cli_wrapped_max_turns detail
-  | Some (Oas_worker_named_error.Cascade_exhausted _)
-  | Some (Oas_worker_named_error.Resumable_cli_session _)
-  | Some (Oas_worker_named_error.No_tool_capable_provider _)
-  | Some (Oas_worker_named_error.Accept_rejected _)
-  | Some (Oas_worker_named_error.Admission_queue_timeout _)
-  | Some (Oas_worker_named_error.Admission_queue_rejected _)
-  | Some (Oas_worker_named_error.Turn_timeout _)
-  | Some (Oas_worker_named_error.Oas_timeout_budget _)
-  | Some (Oas_worker_named_error.Ambiguous_post_commit _) ->
+  | Some (Cascade_error_classify.Cascade_exhausted _)
+  | Some (Cascade_error_classify.Resumable_cli_session _)
+  | Some (Cascade_error_classify.No_tool_capable_provider _)
+  | Some (Cascade_error_classify.Accept_rejected _)
+  | Some (Cascade_error_classify.Admission_queue_timeout _)
+  | Some (Cascade_error_classify.Admission_queue_rejected _)
+  | Some (Cascade_error_classify.Turn_timeout _)
+  | Some (Cascade_error_classify.Oas_timeout_budget _)
+  | Some (Cascade_error_classify.Ambiguous_post_commit _) ->
       false
   | None -> (
       match err with

--- a/lib/cascade/cascade_attempt_fsm.mli
+++ b/lib/cascade/cascade_attempt_fsm.mli
@@ -1,4 +1,4 @@
-(** Oas_worker_named_fsm — SDK error to FSM outcome, session/resumption analysis.
+(** Cascade_attempt_fsm — SDK error to FSM outcome, session/resumption analysis.
 
     Extracted from oas_worker_named.ml (God file decomposition).
     Converts OAS SDK errors into Cascade_fsm provider outcomes,
@@ -19,7 +19,7 @@ val sdk_error_to_cascade_outcome :
 (** {1 Error enrichment} *)
 
 val enrich_sdk_error :
-  cascade_name:Oas_worker_named_error.cascade_name ->
+  cascade_name:Cascade_error_classify.cascade_name ->
   provider_cfg:Llm_provider.Provider_config.t ->
   Agent_sdk.Error.sdk_error -> Agent_sdk.Error.sdk_error
 (** Enrich an SDK error with provider-specific diagnostic hints
@@ -57,7 +57,7 @@ val retry_message_looks_like_not_found : string -> bool
 (** {1 SDK error predicates} *)
 
 val sdk_error_to_resumable_cli_session :
-  cascade_name:Oas_worker_named_error.cascade_name ->
+  cascade_name:Cascade_error_classify.cascade_name ->
   Agent_sdk.Error.sdk_error ->
   Agent_sdk.Error.sdk_error option
 (** If the error looks like a resumable CLI session, convert it into the
@@ -97,7 +97,7 @@ val provider_error_total_metric : string
 (** Prometheus counter for additive provider-error variant emission. *)
 
 val emit_provider_error_metric :
-  cascade_name:Oas_worker_named_error.cascade_name ->
+  cascade_name:Cascade_error_classify.cascade_name ->
   provider:string ->
   Provider_error.t ->
   unit
@@ -105,7 +105,7 @@ val emit_provider_error_metric :
     string-based health tracker labels. *)
 
 val emit_sdk_provider_error_metric :
-  cascade_name:Oas_worker_named_error.cascade_name ->
+  cascade_name:Cascade_error_classify.cascade_name ->
   provider:string ->
   Agent_sdk.Error.sdk_error ->
   Provider_error.t option
@@ -131,7 +131,7 @@ val sdk_error_cascade_fallback_class :
 val is_moonshot_provider : Llm_provider.Provider_config.t -> bool
 
 val resolve_kimi_api_key_env_name :
-  cascade_name:Oas_worker_named_error.cascade_name -> string
+  cascade_name:Cascade_error_classify.cascade_name -> string
 
 val moonshot_auth_hint_marker : string
 val openai_compat_not_found_hint_marker : string

--- a/lib/cascade/cascade_error_classify.ml
+++ b/lib/cascade/cascade_error_classify.ml
@@ -1,4 +1,4 @@
-(** Oas_worker_named_error — masc_internal_error type, error conversion, codex CLI preflight.
+(** Cascade_error_classify — masc_internal_error type, error conversion, codex CLI preflight.
 
     Extracted from oas_worker_named.ml (God file decomposition).
     Defines the [masc_internal_error] variant type, JSON serialization,

--- a/lib/cascade/cascade_error_classify.mli
+++ b/lib/cascade/cascade_error_classify.mli
@@ -1,4 +1,4 @@
-(** Oas_worker_named_error — masc_internal_error type, error conversion, codex CLI preflight.
+(** Cascade_error_classify — masc_internal_error type, error conversion, codex CLI preflight.
 
     Extracted from oas_worker_named.ml (God file decomposition).
     Defines the [masc_internal_error] variant type, JSON serialization,

--- a/lib/cascade/cascade_transport.ml
+++ b/lib/cascade/cascade_transport.ml
@@ -1,4 +1,4 @@
-(** Oas_worker_exec_transport — Transport and tool-lane helpers for OAS worker exec.
+(** Cascade_transport — Transport and tool-lane helpers for OAS worker exec.
 
     Keeps provider label resolution, runtime MCP lane selection, and per-call
     CLI transport construction separate from the build/run orchestration in

--- a/lib/cascade/cascade_transport.mli
+++ b/lib/cascade/cascade_transport.mli
@@ -1,4 +1,4 @@
-(** Oas_worker_exec_transport — Transport and tool-lane helpers for OAS worker exec.
+(** Cascade_transport — Transport and tool-lane helpers for OAS worker exec.
 
     Keeps provider label resolution, runtime MCP lane selection, and per-call
     CLI transport construction separate from the build/run orchestration in

--- a/lib/dune
+++ b/lib/dune
@@ -170,11 +170,8 @@
   oas_worker_exec_agent
   oas_worker_exec
   oas_worker_exec_checkpoint
-  oas_worker_exec_transport
   oas_worker_named
   oas_worker_named_cascade
-  oas_worker_named_error
-  oas_worker_named_fsm
   meta_cognition_types
   meta_cognition_rules
   meta_cognition_snapshot

--- a/lib/oas_worker_exec.ml
+++ b/lib/oas_worker_exec.ml
@@ -17,7 +17,7 @@ type stop_reason =
   | MutationBoundaryReached of { turns_used : int; tool_name : string option }
 
 type cli_transport_overrides =
-  Oas_worker_exec_transport.cli_transport_overrides = {
+  Cascade_transport.cli_transport_overrides = {
   cwd : string option;
   claude_mcp_config : string option;
   claude_allowed_tools : string list option;
@@ -117,97 +117,97 @@ let proof_result_status_to_string status =
     discovery-only model. Callers are expected to validate labels
     before reaching this helper. *)
 type label_resolution_error =
-  Oas_worker_exec_transport.label_resolution_error =
+  Cascade_transport.label_resolution_error =
   | Invalid_model_label of string
 
 let label_resolution_error_to_string =
-  Oas_worker_exec_transport.label_resolution_error_to_string
+  Cascade_transport.label_resolution_error_to_string
 
 let label_resolution_error_to_sdk_error =
-  Oas_worker_exec_transport.label_resolution_error_to_sdk_error
+  Cascade_transport.label_resolution_error_to_sdk_error
 
 let resolve_provider_config_of_label =
-  Oas_worker_exec_transport.resolve_provider_config_of_label
+  Cascade_transport.resolve_provider_config_of_label
 
 let invalid_runtime_config =
-  Oas_worker_exec_transport.invalid_runtime_config
+  Cascade_transport.invalid_runtime_config
 
 let cli_model_override =
-  Oas_worker_exec_transport.cli_model_override
+  Cascade_transport.cli_model_override
 
 let provider_caps_of_config =
-  Oas_worker_exec_transport.provider_caps_of_config
+  Cascade_transport.provider_caps_of_config
 
 let kimi_mcp_config_json_of_policy =
-  Oas_worker_exec_transport.kimi_mcp_config_json_of_policy
+  Cascade_transport.kimi_mcp_config_json_of_policy
 
 let kimi_cli_model_for_provider =
-  Oas_worker_exec_transport.kimi_cli_model_for_provider
+  Cascade_transport.kimi_cli_model_for_provider
 
 let kimi_cli_config_json_for_provider =
-  Oas_worker_exec_transport.kimi_cli_config_json_for_provider
+  Cascade_transport.kimi_cli_config_json_for_provider
 
 let provider_supports_inline_tools =
-  Oas_worker_exec_transport.provider_supports_inline_tools
+  Cascade_transport.provider_supports_inline_tools
 
 let provider_supports_runtime_mcp_lane =
-  Oas_worker_exec_transport.provider_supports_runtime_mcp_lane
+  Cascade_transport.provider_supports_runtime_mcp_lane
 
 let dedupe_preserve_order =
-  Oas_worker_exec_transport.dedupe_preserve_order
+  Cascade_transport.dedupe_preserve_order
 
 let public_mcp_tool_names_of_oas_tools =
-  Oas_worker_exec_transport.public_mcp_tool_names_of_oas_tools
+  Cascade_transport.public_mcp_tool_names_of_oas_tools
 
 let public_mcp_tool_requires_bound_actor =
-  Oas_worker_exec_transport.public_mcp_tool_requires_bound_actor
+  Cascade_transport.public_mcp_tool_requires_bound_actor
 
 let runtime_mcp_tool_requires_bound_actor =
-  Oas_worker_exec_transport.runtime_mcp_tool_requires_bound_actor
+  Cascade_transport.runtime_mcp_tool_requires_bound_actor
 
 let runtime_mcp_policy_with_masc_agent_name =
-  Oas_worker_exec_transport.runtime_mcp_policy_with_masc_agent_name
+  Cascade_transport.runtime_mcp_policy_with_masc_agent_name
 
 let codex_cli_can_auth_keeper_bound_runtime_mcp =
-  Oas_worker_exec_transport.codex_cli_can_auth_keeper_bound_runtime_mcp
+  Cascade_transport.codex_cli_can_auth_keeper_bound_runtime_mcp
 
 let runtime_mcp_policy_for_provider =
-  Oas_worker_exec_transport.runtime_mcp_policy_for_provider
+  Cascade_transport.runtime_mcp_policy_for_provider
 
 let kimi_cli_runtime_mcp_jsons =
-  Oas_worker_exec_transport.kimi_cli_runtime_mcp_jsons
+  Cascade_transport.kimi_cli_runtime_mcp_jsons
 
 let public_mcp_tools_of_oas_tools =
-  Oas_worker_exec_transport.public_mcp_tools_of_oas_tools
+  Cascade_transport.public_mcp_tools_of_oas_tools
 
 let tool_names_are_public_mcp =
-  Oas_worker_exec_transport.tool_names_are_public_mcp
+  Cascade_transport.tool_names_are_public_mcp
 
 let public_mcp_runtime_policy_of_tool_names =
-  Oas_worker_exec_transport.public_mcp_runtime_policy_of_tool_names
+  Cascade_transport.public_mcp_runtime_policy_of_tool_names
 
 let runtime_mcp_policy_of_tool_names =
-  Oas_worker_exec_transport.runtime_mcp_policy_of_tool_names
+  Cascade_transport.runtime_mcp_policy_of_tool_names
 
 let provider_label =
-  Oas_worker_exec_transport.provider_label
+  Cascade_transport.provider_label
 
 let claude_code_max_turns_hard_cap =
-  Oas_worker_exec_transport.claude_code_max_turns_hard_cap
+  Cascade_transport.claude_code_max_turns_hard_cap
 
 let provider_effective_max_turns =
-  Oas_worker_exec_transport.provider_effective_max_turns
+  Cascade_transport.provider_effective_max_turns
 
 let resolve_tool_lane_for_oas_tools =
-  Oas_worker_exec_transport.resolve_tool_lane_for_oas_tools
+  Cascade_transport.resolve_tool_lane_for_oas_tools
 
 let make_per_call_switch_transport =
-  Oas_worker_exec_transport.make_per_call_switch_transport
+  Cascade_transport.make_per_call_switch_transport
 
-module Kimi_cli_transport_local = Oas_worker_exec_transport.Kimi_cli_transport_local
+module Kimi_cli_transport_local = Cascade_transport.Kimi_cli_transport_local
 
 let non_http_transport_of_provider =
-  Oas_worker_exec_transport.non_http_transport_of_provider
+  Cascade_transport.non_http_transport_of_provider
 
 (* ================================================================ *)
 (* Internal: event publishing                                        *)

--- a/lib/oas_worker_exec.mli
+++ b/lib/oas_worker_exec.mli
@@ -2,12 +2,12 @@
     for OAS agent execution.
 
     Thin facade over {!Oas_worker_exec_agent},
-    {!Oas_worker_exec_transport}, and
+    {!Cascade_transport}, and
     {!Oas_worker_exec_checkpoint}.  External callers reach
     the entry points via [Oas_worker_exec.X]; the heavy
     transport machinery (CLI / MCP wire formats, runtime
     policy projections) is implemented in
-    {!Oas_worker_exec_transport} and re-exposed here for
+    {!Cascade_transport} and re-exposed here for
     backward compatibility — that sub-module has no .mli
     of its own, so the canonical contract is the one
     pinned at this boundary.
@@ -49,7 +49,7 @@ type stop_reason = Oas_worker_exec_agent.stop_reason =
 (** {1 CLI transport overrides} *)
 
 type cli_transport_overrides =
-  Oas_worker_exec_transport.cli_transport_overrides = {
+  Cascade_transport.cli_transport_overrides = {
   cwd : string option;
   claude_mcp_config : string option;
   claude_allowed_tools : string list option;
@@ -61,7 +61,7 @@ type cli_transport_overrides =
 (** Per-call overrides threaded into the local CLI transports
     (Claude Code, Gemini CLI, Kimi CLI).
     [cli_subprocess_idle_sec] is currently honoured only by Kimi CLI;
-    see {!Oas_worker_exec_transport.cli_transport_overrides}. *)
+    see {!Cascade_transport.cli_transport_overrides}. *)
 
 (** {1 Config} *)
 
@@ -146,14 +146,14 @@ val proof_result_status_to_string :
 (** {1 Label resolution} *)
 
 val label_resolution_error_to_string :
-  Oas_worker_exec_transport.label_resolution_error -> string
+  Cascade_transport.label_resolution_error -> string
 val label_resolution_error_to_sdk_error :
-  Oas_worker_exec_transport.label_resolution_error ->
+  Cascade_transport.label_resolution_error ->
   Agent_sdk.Error.sdk_error
 
 val resolve_provider_config_of_label :
   string -> (Llm_provider.Provider_config.t,
-             Oas_worker_exec_transport.label_resolution_error) result
+             Cascade_transport.label_resolution_error) result
 
 (** {1 Provider helpers} *)
 
@@ -180,7 +180,7 @@ val kimi_cli_runtime_mcp_jsons :
   string list
 
 module Kimi_cli_transport_local :
-  module type of Oas_worker_exec_transport.Kimi_cli_transport_local
+  module type of Cascade_transport.Kimi_cli_transport_local
 
 (** {1 Runtime-MCP policy} *)
 

--- a/lib/oas_worker_exec_agent.ml
+++ b/lib/oas_worker_exec_agent.ml
@@ -66,7 +66,7 @@ type config = {
   exit_condition_result : (int -> stop_reason * string option) option;
   summarizer : (Agent_sdk.Types.message list -> string) option;
   cli_transport_overrides :
-    Oas_worker_exec_transport.cli_transport_overrides option;
+    Cascade_transport.cli_transport_overrides option;
       (** Custom summarizer for OAS [Budget_strategy.reduce_for_budget]
           Emergency-phase compaction. Defaults to OAS's extractive
           default. Keeper workers inject [Keeper_summarizer.keeper_summarizer]

--- a/lib/oas_worker_exec_agent.mli
+++ b/lib/oas_worker_exec_agent.mli
@@ -77,7 +77,7 @@ type config = {
   exit_condition_result : (int -> stop_reason * string option) option;
   summarizer : (Agent_sdk.Types.message list -> string) option;
   cli_transport_overrides :
-    Oas_worker_exec_transport.cli_transport_overrides option;
+    Cascade_transport.cli_transport_overrides option;
 }
 (** Per-worker configuration.  47 fields — concrete record because
     callers ({!Oas_worker_exec}, keeper workers) construct + tweak

--- a/lib/oas_worker_named.ml
+++ b/lib/oas_worker_named.ml
@@ -13,8 +13,8 @@ open Result.Syntax
    Each sub-module is self-contained; the facade re-exports everything
    so existing callers do not need qualification. *)
 include Oas_worker_named_cascade
-include Oas_worker_named_error
-include Oas_worker_named_fsm
+include Cascade_error_classify
+include Cascade_attempt_fsm
 
 let provider_health_keys_of_config provider_cfg =
   let provider_key = Provider_adapter.provider_health_key_of_config provider_cfg in

--- a/lib/oas_worker_named.mli
+++ b/lib/oas_worker_named.mli
@@ -6,14 +6,14 @@
 
     The facade [include]s the three sub-modules:
     - {!Oas_worker_named_cascade} — Eio context, cascade resolution, runtime MCP policy
-    - {!Oas_worker_named_error} — masc_internal_error type, error conversion, codex CLI preflight
-    - {!Oas_worker_named_fsm} — SDK error to FSM outcome, session/resumption analysis
+    - {!Cascade_error_classify} — masc_internal_error type, error conversion, codex CLI preflight
+    - {!Cascade_attempt_fsm} — SDK error to FSM outcome, session/resumption analysis
 
     @since God file decomposition — extracted from oas_worker.ml *)
 
 include module type of Oas_worker_named_cascade
-include module type of Oas_worker_named_error
-include module type of Oas_worker_named_fsm
+include module type of Cascade_error_classify
+include module type of Cascade_attempt_fsm
 
 (** [effective_provider_attempt_timeout_s] applies provider-specific
     timeout constraints to a configured cascade attempt budget.

--- a/test/test_codex_cli_omission_dedup_10097.ml
+++ b/test/test_codex_cli_omission_dedup_10097.ml
@@ -37,7 +37,7 @@ let () =
   in
   Unix.putenv "MASC_BASE_PATH" dir
 
-module T = Masc_mcp.Oas_worker_exec_transport
+module T = Masc_mcp.Cascade_transport
 module Prom = Masc_mcp.Prometheus
 
 let metric = Prom.metric_codex_cli_mcp_tool_omission

--- a/test/test_oas_worker.ml
+++ b/test/test_oas_worker.ml
@@ -4079,7 +4079,7 @@ let test_sanitize_cli_completion_request_for_argv_scrubs_codex_request () =
     }
   in
   let sanitized =
-    Oas_worker_exec_transport.sanitize_cli_completion_request_for_argv req
+    Cascade_transport.sanitize_cli_completion_request_for_argv req
   in
   Alcotest.(check (option string))
     "system prompt sanitized" (Some "sys prompt")

--- a/test/test_per_keeper_token_fallback.ml
+++ b/test/test_per_keeper_token_fallback.ml
@@ -2,7 +2,7 @@
 
     Verifies that [Auth.load_raw_token] reads the raw bearer token from
     [<base_path>/.masc/auth/<agent_name>.token]. This is the data path
-    consumed by [Oas_worker_exec_transport.runtime_mcp_policy_of_tool_names]
+    consumed by [Cascade_transport.runtime_mcp_policy_of_tool_names]
     when [MASC_MCP_TOKEN] is unset (the CLI subprocess case for
     codex_cli/gemini_cli/kimi_cli that callback into masc-mcp).
 


### PR DESCRIPTION
## Summary

RFC-0047 Phase 3a: move 3 cascade-leaf files from `oas_*` dumping ground into `lib/cascade/` where they actually belong.

## Renames

| From | To | LOC |
|---|---|---|
| `lib/oas_worker_named_fsm.ml` (+`.mli`) | `lib/cascade/cascade_attempt_fsm.ml` (+`.mli`) | 653 |
| `lib/oas_worker_named_error.ml` (+`.mli`) | `lib/cascade/cascade_error_classify.ml` (+`.mli`) | 730 |
| `lib/oas_worker_exec_transport.ml` (+`.mli`) | `lib/cascade/cascade_transport.ml` (+`.mli`) | 1636 |

Total ~3019 LOC migrated to correct layer.

## Intra-family deps (verified pre-move)

- `_fsm` references `_error` (single direction → both move together).
- `_transport` independent.
- `_error` leaf.

No cross-edges to `oas_*` after move (verified via build green).

## Caller updates

15 files, ~80 module-name references replaced via `perl -i` (BSD `sed \b` unsupported for word boundary):

- `Oas_worker_named_fsm` → `Cascade_attempt_fsm`
- `Oas_worker_named_error` → `Cascade_error_classify`
- `Oas_worker_exec_transport` → `Cascade_transport`

## Build infrastructure

`lib/dune` `private_modules` pruned of 3 entries (`oas_worker_named_fsm`, `oas_worker_named_error`, `oas_worker_exec_transport`). Existing `lib/cascade/cascade_*.ml` files are public, so the moved files inherit that visibility.

## Verification

- [x] `dune build`: exit 0 (after `opam reinstall agent_sdk -y` to repair env damage from earlier parallel build storm).
- [ ] `dune runtest`: blocked locally (test sandbox in degraded state from kill-9 storm). CI authoritative.
- [x] Rebased on fresh `origin/main`.

## Inventory baseline regen — deferred

The `scripts/rfc-0047-oas-adapter-inventory.sh` regen hung in the local environment (process residue from earlier parallel-build storm corrupted some state). The baseline diff for Phase 3a will land in a follow-up commit on this PR or a small chore PR — whichever is cleaner. Not a blocker.

## Coordination notes

⚠️ **RFC-0047 number collision** persists: `RFC-0047-keeper-turn-disposition-typed.md` and continuing PR-1 / PR-2 / PR-3 (#14234, #14237, #14271) share the number with this RFC's `oas-adapter-decomposition` track. Renumber follow-up still pending.

## Status

**Draft.** Awaiting `human-approved-ready` label per draft-guard policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
