### PR TITLE
feat(cdal_runtime): RFC-0005 §3.1 — typed Tool_id for default classification

### DIFF
--- a/lib/cdal_runtime/mode_enforcer.ml
+++ b/lib/cdal_runtime/mode_enforcer.ml
@@ -81,75 +81,83 @@ type token_snapshot =
 
 (* ── Tool classification registry ────────────────────────────────── *)
 
-(** Default tool-name -> effect-class mappings. Data, not inline code. *)
-let default_tool_entries : (string * tool_effect_class) list =
+(** Default tool-id -> effect-class mappings. RFC-0005 §3.1 — keys are
+    [Tool_id.t] poly-variant constructors so that adding a new built-in
+    tool requires extending [Tool_id] and the compiler then flags every
+    site that needs to acknowledge it. The runtime registry below stays
+    string-keyed because plugin tools register at runtime by name. *)
+let default_tool_entries : (Tool_id.t * tool_effect_class) list =
   [ (* ── Read-only tools ─────────────────────────────────────── *)
     (* File & code navigation *)
-    "read", Read_only
-  ; "glob", Read_only
-  ; "grep", Read_only
-  ; "search", Read_only
-  ; "list_dir", Read_only
-  ; "find_file", Read_only
-  ; "read_file", Read_only
-  ; "find_symbol", Read_only
-  ; "get_symbols_overview", Read_only
-  ; "find_referencing_symbols", Read_only
-  ; "search_for_pattern", Read_only
+    `Read, Read_only
+  ; `Glob, Read_only
+  ; `Grep, Read_only
+  ; `Search, Read_only
+  ; `List_dir, Read_only
+  ; `Find_file, Read_only
+  ; `Read_file, Read_only
+  ; `Find_symbol, Read_only
+  ; `Get_symbols_overview, Read_only
+  ; `Find_referencing_symbols, Read_only
+  ; `Search_for_pattern, Read_only
   ; (* Notebook *)
-    "notebook_read", Read_only
+    `Notebook_read, Read_only
   ; (* Browser observation *)
-    "read_console_messages", Read_only
-  ; "read_network_requests", Read_only
-  ; "get_page_text", Read_only
-  ; "read_page", Read_only
-  ; "tabs_context_mcp", Read_only
+    `Read_console_messages, Read_only
+  ; `Read_network_requests, Read_only
+  ; `Get_page_text, Read_only
+  ; `Read_page, Read_only
+  ; `Tabs_context_mcp, Read_only
   ; (* Task queries *)
-    "task_list", Read_only
-  ; "task_get", Read_only
-  ; "task_output", Read_only
+    `Task_list, Read_only
+  ; `Task_get, Read_only
+  ; `Task_output, Read_only
   ; (* ── Local-mutation tools ────────────────────────────────── *)
     (* File editing *)
-    "write", Local_mutation
-  ; "edit", Local_mutation
-  ; "create_text_file", Local_mutation
-  ; "replace_content", Local_mutation
-  ; "rename_symbol", Local_mutation
-  ; "insert_after_symbol", Local_mutation
-  ; "insert_before_symbol", Local_mutation
-  ; "replace_symbol_body", Local_mutation
-  ; "notebook_edit", Local_mutation
+    `Write, Local_mutation
+  ; `Edit, Local_mutation
+  ; `Create_text_file, Local_mutation
+  ; `Replace_content, Local_mutation
+  ; `Rename_symbol, Local_mutation
+  ; `Insert_after_symbol, Local_mutation
+  ; `Insert_before_symbol, Local_mutation
+  ; `Replace_symbol_body, Local_mutation
+  ; `Notebook_edit, Local_mutation
   ; (* Task & team management *)
-    "task_create", Local_mutation
-  ; "task_update", Local_mutation
-  ; "task_stop", Local_mutation
-  ; "team_create", Local_mutation
-  ; "team_delete", Local_mutation
+    `Task_create, Local_mutation
+  ; `Task_update, Local_mutation
+  ; `Task_stop, Local_mutation
+  ; `Team_create, Local_mutation
+  ; `Team_delete, Local_mutation
   ; (* ── External-effect tools ───────────────────────────────── *)
     (* HITL *)
-    "ask_user_question", External_effect
+    `Ask_user_question, External_effect
   ; (* Web & research *)
-    "web_fetch", External_effect
-  ; "web_search", External_effect
+    `Web_fetch, External_effect
+  ; `Web_search, External_effect
   ; (* Browser interaction *)
-    "navigate", External_effect
-  ; "computer", External_effect
-  ; "find", External_effect
-  ; "form_input", External_effect
-  ; "javascript_tool", External_effect
-  ; "tabs_create_mcp", External_effect
-  ; "upload_image", External_effect
+    `Navigate, External_effect
+  ; `Computer, External_effect
+  ; `Find, External_effect
+  ; `Form_input, External_effect
+  ; `Javascript_tool, External_effect
+  ; `Tabs_create_mcp, External_effect
+  ; `Upload_image, External_effect
   ; (* ── Shell-dynamic tools (require input analysis at runtime) *)
-    "bash", Shell_dynamic
-  ; "execute_shell_command", Shell_dynamic
+    `Bash, Shell_dynamic
+  ; `Execute_shell_command, Shell_dynamic
   ]
 ;;
 
 (** Global mutable registry seeded from [default_tool_entries].
-    Supports runtime extension via [register_tool_class]. *)
+    Supports runtime extension via [register_tool_class].
+    Keys are wire-format strings so plugin tools registered by name
+    interoperate transparently with the typed defaults. *)
 let tool_registry : (string, tool_effect_class) Hashtbl.t =
   let tbl = Hashtbl.create (List.length default_tool_entries) in
-  List.iter (fun (name, cls) -> Hashtbl.replace tbl name cls) default_tool_entries;
+  List.iter
+    (fun (id, cls) -> Hashtbl.replace tbl (Tool_id.to_string id) cls)
+    default_tool_entries;
   tbl
 ;;
 

--- a/lib/cdal_runtime/tool_id.ml
+++ b/lib/cdal_runtime/tool_id.ml
@@ -1,0 +1,208 @@
+(* RFC-0005 Phase 1 §3.1 follow-up — typed tool identifier for the
+   CDAL runtime's built-in classification table.
+
+   Pattern reuses Agent_id.t (RFC-0005 Week 2, PR #14227): polymorphic
+   variant with a fail-open `Other_tool of string` for runtime-registered
+   plugin tools, paired with explicit to_string/of_string round-trip. *)
+
+type t =
+  [ `Read
+  | `Glob
+  | `Grep
+  | `Search
+  | `List_dir
+  | `Find_file
+  | `Read_file
+  | `Find_symbol
+  | `Get_symbols_overview
+  | `Find_referencing_symbols
+  | `Search_for_pattern
+  | `Notebook_read
+  | `Read_console_messages
+  | `Read_network_requests
+  | `Get_page_text
+  | `Read_page
+  | `Tabs_context_mcp
+  | `Task_list
+  | `Task_get
+  | `Task_output
+  | `Write
+  | `Edit
+  | `Create_text_file
+  | `Replace_content
+  | `Rename_symbol
+  | `Insert_after_symbol
+  | `Insert_before_symbol
+  | `Replace_symbol_body
+  | `Notebook_edit
+  | `Task_create
+  | `Task_update
+  | `Task_stop
+  | `Team_create
+  | `Team_delete
+  | `Ask_user_question
+  | `Web_fetch
+  | `Web_search
+  | `Navigate
+  | `Computer
+  | `Find
+  | `Form_input
+  | `Javascript_tool
+  | `Tabs_create_mcp
+  | `Upload_image
+  | `Bash
+  | `Execute_shell_command
+  | `Other_tool of string
+  ]
+
+let to_string : t -> string = function
+  | `Read -> "read"
+  | `Glob -> "glob"
+  | `Grep -> "grep"
+  | `Search -> "search"
+  | `List_dir -> "list_dir"
+  | `Find_file -> "find_file"
+  | `Read_file -> "read_file"
+  | `Find_symbol -> "find_symbol"
+  | `Get_symbols_overview -> "get_symbols_overview"
+  | `Find_referencing_symbols -> "find_referencing_symbols"
+  | `Search_for_pattern -> "search_for_pattern"
+  | `Notebook_read -> "notebook_read"
+  | `Read_console_messages -> "read_console_messages"
+  | `Read_network_requests -> "read_network_requests"
+  | `Get_page_text -> "get_page_text"
+  | `Read_page -> "read_page"
+  | `Tabs_context_mcp -> "tabs_context_mcp"
+  | `Task_list -> "task_list"
+  | `Task_get -> "task_get"
+  | `Task_output -> "task_output"
+  | `Write -> "write"
+  | `Edit -> "edit"
+  | `Create_text_file -> "create_text_file"
+  | `Replace_content -> "replace_content"
+  | `Rename_symbol -> "rename_symbol"
+  | `Insert_after_symbol -> "insert_after_symbol"
+  | `Insert_before_symbol -> "insert_before_symbol"
+  | `Replace_symbol_body -> "replace_symbol_body"
+  | `Notebook_edit -> "notebook_edit"
+  | `Task_create -> "task_create"
+  | `Task_update -> "task_update"
+  | `Task_stop -> "task_stop"
+  | `Team_create -> "team_create"
+  | `Team_delete -> "team_delete"
+  | `Ask_user_question -> "ask_user_question"
+  | `Web_fetch -> "web_fetch"
+  | `Web_search -> "web_search"
+  | `Navigate -> "navigate"
+  | `Computer -> "computer"
+  | `Find -> "find"
+  | `Form_input -> "form_input"
+  | `Javascript_tool -> "javascript_tool"
+  | `Tabs_create_mcp -> "tabs_create_mcp"
+  | `Upload_image -> "upload_image"
+  | `Bash -> "bash"
+  | `Execute_shell_command -> "execute_shell_command"
+  | `Other_tool s -> s
+;;
+
+let of_string : string -> t = function
+  | "read" -> `Read
+  | "glob" -> `Glob
+  | "grep" -> `Grep
+  | "search" -> `Search
+  | "list_dir" -> `List_dir
+  | "find_file" -> `Find_file
+  | "read_file" -> `Read_file
+  | "find_symbol" -> `Find_symbol
+  | "get_symbols_overview" -> `Get_symbols_overview
+  | "find_referencing_symbols" -> `Find_referencing_symbols
+  | "search_for_pattern" -> `Search_for_pattern
+  | "notebook_read" -> `Notebook_read
+  | "read_console_messages" -> `Read_console_messages
+  | "read_network_requests" -> `Read_network_requests
+  | "get_page_text" -> `Get_page_text
+  | "read_page" -> `Read_page
+  | "tabs_context_mcp" -> `Tabs_context_mcp
+  | "task_list" -> `Task_list
+  | "task_get" -> `Task_get
+  | "task_output" -> `Task_output
+  | "write" -> `Write
+  | "edit" -> `Edit
+  | "create_text_file" -> `Create_text_file
+  | "replace_content" -> `Replace_content
+  | "rename_symbol" -> `Rename_symbol
+  | "insert_after_symbol" -> `Insert_after_symbol
+  | "insert_before_symbol" -> `Insert_before_symbol
+  | "replace_symbol_body" -> `Replace_symbol_body
+  | "notebook_edit" -> `Notebook_edit
+  | "task_create" -> `Task_create
+  | "task_update" -> `Task_update
+  | "task_stop" -> `Task_stop
+  | "team_create" -> `Team_create
+  | "team_delete" -> `Team_delete
+  | "ask_user_question" -> `Ask_user_question
+  | "web_fetch" -> `Web_fetch
+  | "web_search" -> `Web_search
+  | "navigate" -> `Navigate
+  | "computer" -> `Computer
+  | "find" -> `Find
+  | "form_input" -> `Form_input
+  | "javascript_tool" -> `Javascript_tool
+  | "tabs_create_mcp" -> `Tabs_create_mcp
+  | "upload_image" -> `Upload_image
+  | "bash" -> `Bash
+  | "execute_shell_command" -> `Execute_shell_command
+  | other -> `Other_tool other
+;;
+
+let of_string_normalised s = s |> String.trim |> String.lowercase_ascii |> of_string
+
+let known : t list =
+  [ `Read
+  ; `Glob
+  ; `Grep
+  ; `Search
+  ; `List_dir
+  ; `Find_file
+  ; `Read_file
+  ; `Find_symbol
+  ; `Get_symbols_overview
+  ; `Find_referencing_symbols
+  ; `Search_for_pattern
+  ; `Notebook_read
+  ; `Read_console_messages
+  ; `Read_network_requests
+  ; `Get_page_text
+  ; `Read_page
+  ; `Tabs_context_mcp
+  ; `Task_list
+  ; `Task_get
+  ; `Task_output
+  ; `Write
+  ; `Edit
+  ; `Create_text_file
+  ; `Replace_content
+  ; `Rename_symbol
+  ; `Insert_after_symbol
+  ; `Insert_before_symbol
+  ; `Replace_symbol_body
+  ; `Notebook_edit
+  ; `Task_create
+  ; `Task_update
+  ; `Task_stop
+  ; `Team_create
+  ; `Team_delete
+  ; `Ask_user_question
+  ; `Web_fetch
+  ; `Web_search
+  ; `Navigate
+  ; `Computer
+  ; `Find
+  ; `Form_input
+  ; `Javascript_tool
+  ; `Tabs_create_mcp
+  ; `Upload_image
+  ; `Bash
+  ; `Execute_shell_command
+  ]
+;;

--- a/lib/cdal_runtime/tool_id.mli
+++ b/lib/cdal_runtime/tool_id.mli
@@ -1,0 +1,94 @@
+(** Typed tool identifier for the CDAL runtime's built-in classification
+    table (RFC-0005 Phase 1 §3.1 follow-up).
+
+    Each constructor is a tool that ships with masc-mcp's default
+    classification in [Mode_enforcer.default_tool_entries]. Adding a new
+    built-in tool requires extending this variant — the compiler then
+    flags every site that needs to acknowledge the new entry.
+
+    Public APIs of [Mode_enforcer] (e.g. [classify_tool],
+    [register_tool_class]) remain string-typed because plugin tools
+    register at runtime by name. The variant only types the
+    *compile-time-known* default table.
+
+    @stability Evolving
+    @since 0.19.17 *)
+
+type t =
+  (* Read-only — file & code navigation *)
+  [ `Read
+  | `Glob
+  | `Grep
+  | `Search
+  | `List_dir
+  | `Find_file
+  | `Read_file
+  | `Find_symbol
+  | `Get_symbols_overview
+  | `Find_referencing_symbols
+  | `Search_for_pattern
+  | (* Read-only — notebook *)
+      `Notebook_read
+  | (* Read-only — browser observation *)
+      `Read_console_messages
+  | `Read_network_requests
+  | `Get_page_text
+  | `Read_page
+  | `Tabs_context_mcp
+  | (* Read-only — task queries *)
+      `Task_list
+  | `Task_get
+  | `Task_output
+  | (* Local mutation — file editing *)
+      `Write
+  | `Edit
+  | `Create_text_file
+  | `Replace_content
+  | `Rename_symbol
+  | `Insert_after_symbol
+  | `Insert_before_symbol
+  | `Replace_symbol_body
+  | `Notebook_edit
+  | (* Local mutation — task & team management *)
+      `Task_create
+  | `Task_update
+  | `Task_stop
+  | `Team_create
+  | `Team_delete
+  | (* External effect — HITL *)
+      `Ask_user_question
+  | (* External effect — web & research *)
+      `Web_fetch
+  | `Web_search
+  | (* External effect — browser interaction *)
+      `Navigate
+  | `Computer
+  | `Find
+  | `Form_input
+  | `Javascript_tool
+  | `Tabs_create_mcp
+  | `Upload_image
+  | (* Shell-dynamic — runtime input analysis required *)
+      `Bash
+  | `Execute_shell_command
+  | (* Plugin / unknown — fallback that preserves the wire-format string. *)
+    `Other_tool of string
+  ]
+
+(** Project a [t] to its canonical wire-format string. *)
+val to_string : t -> string
+
+(** Parse a wire-format string into [t]. Unknown names map to
+    [`Other_tool s] (lowercased) — fail-open with provenance preserved
+    for downstream classification. *)
+val of_string : string -> t
+
+(** Same as [of_string] but normalised: input is lowercased and trimmed
+    before lookup. Matches the lowercasing convention used by
+    [Mode_enforcer.register_tool_class]. *)
+val of_string_normalised : string -> t
+
+(** All known constructors (excludes [`Other_tool _]). Useful for
+    enumerating the built-in classification table and for tests that
+    assert round-trip stability. *)
+val known : t list

--- a/test/dune
+++ b/test/dune
@@ -44,6 +44,7 @@
         test_dashboard_perf
         test_dashboard_tool_host_events
         test_dashboard_nav_event
+        test_cdal_tool_id
         test_tool_assignment_telemetry
         test_dashboard_link_preview
         test_gate_keeper_backend
@@ -281,6 +282,7 @@
           test_dashboard_perf
           test_dashboard_tool_host_events
           test_dashboard_nav_event
+          test_cdal_tool_id
           test_tool_assignment_telemetry
           test_dashboard_link_preview
           test_gate_keeper_backend

--- a/test/test_cdal_tool_id.ml
+++ b/test/test_cdal_tool_id.ml
@@ -1,0 +1,85 @@
+open Alcotest
+module Tool_id = Masc_mcp_cdal_runtime.Tool_id
+
+let test_round_trip_known () =
+  List.iter
+    (fun id ->
+       let s = Tool_id.to_string id in
+       let parsed = Tool_id.of_string s in
+       check bool (Printf.sprintf "round-trip %s" s) true (parsed = id))
+    Tool_id.known
+;;
+
+let test_known_count () =
+  (* RFC-0005 §3.1 baseline: 46 built-in tools at PR-1 land time. If
+     this number changes, update Tool_id.t and acknowledge here so a
+     drift between Tool_id.known and the default classification table
+     is impossible to ship silently. *)
+  check int "known constructor count" 46 (List.length Tool_id.known)
+;;
+
+let test_unknown_falls_back () =
+  match Tool_id.of_string "definitely_not_a_real_tool" with
+  | `Other_tool s -> check string "preserves wire string" "definitely_not_a_real_tool" s
+  | _ -> fail "expected `Other_tool fallback for unknown tool"
+;;
+
+let test_other_tool_round_trip () =
+  let id = `Other_tool "custom_plugin_tool" in
+  check string "Other_tool to_string" "custom_plugin_tool" (Tool_id.to_string id);
+  match Tool_id.of_string "custom_plugin_tool" with
+  | `Other_tool s when s = "custom_plugin_tool" -> ()
+  | other ->
+    failf
+      "Other_tool round-trip diverged: %s -> %s"
+      "custom_plugin_tool"
+      (Tool_id.to_string other)
+;;
+
+let test_normalised_lowercases () =
+  match Tool_id.of_string_normalised "  Read  " with
+  | `Read -> ()
+  | other -> failf "expected `Read after trim+lowercase, got %s" (Tool_id.to_string other)
+;;
+
+let test_normalised_unknown_lowercased () =
+  match Tool_id.of_string_normalised "  CUSTOM_Plugin  " with
+  | `Other_tool "custom_plugin" -> ()
+  | other ->
+    failf "expected `Other_tool \"custom_plugin\", got %s" (Tool_id.to_string other)
+;;
+
+let test_known_unique_strings () =
+  let strings = List.map Tool_id.to_string Tool_id.known in
+  let sorted = List.sort String.compare strings in
+  let rec has_duplicates = function
+    | a :: b :: _ when a = b -> Some a
+    | _ :: rest -> has_duplicates rest
+    | [] -> None
+  in
+  match has_duplicates sorted with
+  | None -> ()
+  | Some dup -> failf "duplicate string in Tool_id.known: %s" dup
+;;
+
+let () =
+  Alcotest.run
+    "cdal_tool_id"
+    [ ( "round_trip"
+      , [ test_case "all known constructors round-trip" `Quick test_round_trip_known
+        ; test_case "known count stable" `Quick test_known_count
+        ; test_case "unknown falls back to Other_tool" `Quick test_unknown_falls_back
+        ; test_case
+            "Other_tool round-trip preserves string"
+            `Quick
+            test_other_tool_round_trip
+        ] )
+    ; ( "normalisation"
+      , [ test_case "trim + lowercase resolves known" `Quick test_normalised_lowercases
+        ; test_case "trim + lowercase + unknown" `Quick test_normalised_unknown_lowercased
+        ] )
+    ; ( "uniqueness"
+      , [ test_case "no two constructors share a string" `Quick test_known_unique_strings
+        ] )
+    ]
+;;


### PR DESCRIPTION
## Summary

Closes the explicit Phase 1 follow-up flagged in `RFC-0005-typed-capability-substrate.md §3.1` (and re-listed in the 2026-05-09 progress report you shared). Converts `Mode_enforcer.default_tool_entries` from `(string * tool_effect_class) list` to `(Tool_id.t * tool_effect_class) list`, where `Tool_id.t` is a 46-constructor poly variant + `Other_tool of string` fail-open fallback.

Same recipe as `Agent_id.t` (RFC-0005 Week 2, PR #14227).

## Why

Before: a typo like `("red", Read_only)` in the static table silently creates a useless entry — no compile error, no test failure, just a tool nobody can ever classify by name.

After: the table is keyed on a typed constructor (`` `Read``). The misspelling `` `Red`` is **not a constructor** — compile-time error, can't ship.

## Scope

| File | LoC | Role |
|---|---:|---|
| `lib/cdal_runtime/tool_id.mli` | 94 | 46 constructors + `Other_tool of string` |
| `lib/cdal_runtime/tool_id.ml` | 208 | `to_string` / `of_string` / `of_string_normalised` / `known` |
| `lib/cdal_runtime/mode_enforcer.ml` | ±58 net | `default_tool_entries` typed; Hashtbl seeding via `Tool_id.to_string` |
| `test/test_cdal_tool_id.ml` | 85 | 7 alcotest cases — round-trip, fallback, normalisation, count baseline, uniqueness |
| `test/dune` | +2 | Registered in `(names ...)` and `(modules ...)` |

Net: +447 / −50.

## What does NOT change

- Public API of `Mode_enforcer`. `classify_tool`, `register_tool_class`, `builtin_descriptor`, `all_read_only`, `all_workspace_only` all stay string-typed. Plugin tools register at runtime by name — the wire format is unchanged.
- Tool registry remains a `Hashtbl<string, tool_effect_class>`. Strings stay the runtime key; typing is compile-time only.
- Behavior. Same 46 tools, same effect classes, same Prometheus output.

## §3 criteria check (RFC-0050 lens, even though this is RFC-0005 work)

| Criterion | Result |
|---|---|
| 1. Plurality of distinct domains | ✓ `Tool_id` is its own concept, separable from enforcement state |
| 2. No cross-domain shared mutable state | ✓ pure functions only |
| 3. Domain count ≥ 3 OR ≥ 60% boundary | ✓ Tool_id is a clean module-level boundary |
| 4. No path-based reach into private helpers | ✓ public exports only |
| 5. No public-export rename | ✓ Mode_enforcer surface unchanged |

## Verification

```
$ ocamlformat --check lib/cdal_runtime/tool_id.ml ; echo $?
0
$ ocamlformat --check lib/cdal_runtime/tool_id.mli ; echo $?
0
$ ocamlformat --check test/test_cdal_tool_id.ml ; echo $?
0
$ ocamlformat --check lib/cdal_runtime/mode_enforcer.ml ; echo $?
0
```

Local build skipped — global `dune-local.sh` lock held by another worktree (memory `feedback_masc_mcp_dune_local_lock_contention`). GitHub Actions clean env handles the build verification.

## Phase 1 status after this PR

| RFC-0005 §3.1 item | Status |
|---|---|
| S1 `Bin.kind` typed dispatch | ✅ #14216 |
| S2 `Agent_id.t` typed approval | ✅ #14227 |
| S3 `exec_gate` rollout typed keys | ✅ #14227 |
| S4 `Capability_check` typed dispatch | ✅ #14216 |
| **mode_enforcer.ml string → Variant** | ✅ **this PR** |

Phase 1 closed for in-scope work. Phase 2 PPX deriving + Phase 3 61-tool migration remain (out of scope for this PR).

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>