### PR TITLE
refactor(dashboard): drop UI-explainer copy from connector-status

### DIFF
--- a/dashboard/src/components/connector-status.test.ts
+++ b/dashboard/src/components/connector-status.test.ts
@@ -270,9 +270,7 @@ describe('ConnectorStatusPanel', () => {
     expect(fetchGateStatus).toHaveBeenCalled()
     expect(fetchGateConnectors).toHaveBeenCalled()
     expect(fetchGateKeepers).toHaveBeenCalled()
-    // Heading copy is now Korean ("커넥터" + intro line). Asserting on the
-    // intro substring keeps the test resilient to title tweaks.
-    expect(text).toContain('4종 채널 sidecar')
+    expect(text).toContain('커넥터')
     expect(text).toContain('connected')
     expect(text).toContain('Discord')
     expect(text).toContain('sangsu')
@@ -435,8 +433,8 @@ describe('ConnectorStatusPanel', () => {
 
     expect(text).toContain('Discord')
     expect(text).toContain('stale')
-    expect(text).toContain('Gate metrics unavailable')
-    expect(text).toContain('게이트가 광고하는 connector runtime 은 보이지만')
+    expect(text).toContain('메트릭 없음')
+    expect(text).toContain('connector runtime은 등록됐으나 게이트가 관찰한 트래픽은 아직 없습니다')
     expect(text).toContain('keeper 디렉토리 사용 불가, 수동 입력만 가능')
     expect(text).toContain('Next: 지금은 수동 입력으로 진행')
     expect(text).toContain('config/keepers/')

--- a/dashboard/src/components/connector-status.ts
+++ b/dashboard/src/components/connector-status.ts
@@ -1407,24 +1407,24 @@ function EventRow({ event }: { event: GateEventInfo }) {
 
 function DisclosurePanel({
   title,
-  subtitle,
+  badge,
   children,
   testId,
 }: {
   title: string
-  subtitle: string
+  badge?: ComponentChildren
   children: ComponentChildren
   testId: string
 }) {
   return html`
-    <details class="mb-4 rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)]" data-testid=${testId}>
+    <details class="group mb-4 rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)]" data-testid=${testId}>
       <summary class="cursor-pointer list-none px-3 py-2.5">
         <div class="flex items-center justify-between gap-3">
-          <div>
-            <div class="text-2xs font-semibold uppercase tracking-4 text-[var(--color-fg-primary)]">${title}</div>
-            <div class="mt-1 text-2xs text-[var(--color-fg-disabled)]">${subtitle}</div>
+          <div class="text-2xs font-semibold uppercase tracking-4 text-[var(--color-fg-primary)]">${title}</div>
+          <div class="flex items-center gap-2 text-2xs text-[var(--color-fg-disabled)]">
+            ${badge ?? null}
+            <span aria-hidden="true" class="transition-transform group-open:rotate-180">▾</span>
           </div>
-          <span class="text-2xs text-[var(--color-fg-disabled)]">펴기</span>
         </div>
       </summary>
       <div class="border-t border-[var(--color-border-default)] px-3 py-3">
@@ -1441,23 +1441,25 @@ function GateAnalyticsSection({
   gate: GateStatusData | null
   gateError: string | null
 }) {
-  let subtitle = '메시지, 에러, 최근 이벤트와 room binding을 필요할 때만 펼쳐 봅니다.'
+  let badge: ComponentChildren = null
   if (gateError) {
-    subtitle = `Gate metrics unavailable: ${gateError}`
+    badge = html`<span class="text-[var(--color-status-err)]">메트릭 없음</span>`
   } else if (gate === null) {
-    subtitle = 'Gate-observed traffic is not available yet.'
+    badge = html`<span>관찰된 트래픽 없음</span>`
+  } else {
+    badge = html`<span>메시지 ${gate.total_messages} · 오류 ${gate.total_errors}</span>`
   }
 
   return html`
     <${DisclosurePanel}
       title="게이트 분석"
-      subtitle=${subtitle}
+      badge=${badge}
       testId="connector-gate-analytics"
     >
       ${gate === null
         ? html`
             <div class="rounded-[var(--r-1)] border border-dashed border-[var(--color-border-default)] px-3 py-4 text-xs text-[var(--color-fg-disabled)]">
-              게이트가 광고하는 connector runtime 은 보이지만, 게이트가 관찰한 트래픽 은 아직 없습니다.
+              connector runtime은 등록됐으나 게이트가 관찰한 트래픽은 아직 없습니다.
             </div>
           `
         : html`
@@ -1591,20 +1593,13 @@ export function ConnectorStatusPanel() {
 
   return html`
     <div class="contain-content">
-      <div class="mb-3 flex items-start justify-between gap-3">
-        <div>
-          <h3 class="text-sm font-semibold text-[var(--color-fg-primary)]">${filterId ? CONNECTOR_DISPLAY_NAMES[filterId as KnownConnectorId] ?? '커넥터' : '커넥터'}</h3>
-          <div class="mt-1 text-2xs text-[var(--color-fg-disabled)]">
-            ${filterId
-              ? `${CONNECTOR_DISPLAY_NAMES[filterId as KnownConnectorId] ?? filterId} sidecar의 라이브 상태와 keeper 바인딩.`
-              : '4종 채널 sidecar overview 카드에서 커넥터를 고르면 아래 상세 패널이 교체됩니다.'}
-          </div>
-        </div>
+      <div class="mb-3 flex items-center justify-between gap-3">
+        <h3 class="text-sm font-semibold text-[var(--color-fg-primary)]">${filterId ? CONNECTOR_DISPLAY_NAMES[filterId as KnownConnectorId] ?? '커넥터' : '커넥터'}</h3>
         ${filterId
           ? html`
               <div class="text-right text-3xs uppercase tracking-5 text-[var(--color-fg-disabled)]">
                 <div>${d ? `success ${d.success_rate_pct}%` : `${visibleConnectors.length} connector${visibleConnectors.length !== 1 ? 's' : ''}`}</div>
-                <div>${d ? `uptime ${formatUptime(d.uptime_seconds)}` : 'gate metrics unavailable'}</div>
+                <div>${d ? `uptime ${formatUptime(d.uptime_seconds)}` : '게이트 메트릭 없음'}</div>
               </div>
             `
           : null}
@@ -1630,11 +1625,7 @@ export function ConnectorStatusPanel() {
               data-testid="connector-detail-panel"
             >
               <div class="mb-3 flex items-center justify-between gap-3 text-2xs">
-                <div>
-                  <span class="font-semibold text-[var(--color-fg-primary)]">${CONNECTOR_DISPLAY_NAMES[focusedConnectorId]}</span>
-                  <span class="ml-2 text-[var(--color-fg-disabled)]">선택한 커넥터의 상세와 액션만 보여줍니다.</span>
-                </div>
-                <${MutedSpan}>overview 카드에서 전환</${MutedSpan}>
+                <span class="font-semibold text-[var(--color-fg-primary)]">${CONNECTOR_DISPLAY_NAMES[focusedConnectorId]}</span>
               </div>
               <${ConnectorLivePanel}
                 connector=${focusedConnector}
@@ -1665,7 +1656,7 @@ export function ConnectorStatusPanel() {
         ? html`
             <${DisclosurePanel}
               title="키퍼 매트릭스"
-              subtitle="cross-connector binding 현황은 필요할 때만 펼쳐 봅니다."
+              badge=${html`<span>키퍼 ${snapshot.keepers.length}</span>`}
               testId="connector-matrix-disclosure"
             >
               <${ConnectorKeeperMatrix} matrix=${deriveMatrix(allConnectors, snapshot.keepers)} />


### PR DESCRIPTION
## Summary

Continues the dashboard cleanup track (#14219, #14224, #14275, #14280). Connector-status panel had 6 layers of self-referential explainer copy describing what the UI does instead of what the connectors are doing. Replace with concrete data, drop where redundant.

## Removed

| Where | Text |
|---|---|
| 게이트 분석 disclosure subtitle | \`메시지, 에러, 최근 이벤트와 room binding을 필요할 때만 펼쳐 봅니다\` |
| 키퍼 매트릭스 disclosure subtitle | \`cross-connector binding 현황은 필요할 때만 펼쳐 봅니다\` |
| Panel intro (no filter) | \`4종 채널 sidecar overview 카드에서 커넥터를 고르면 아래 상세 패널이 교체됩니다\` |
| Panel intro (filtered) | \`{name} sidecar의 라이브 상태와 keeper 바인딩\` |
| Detail panel header note | \`선택한 커넥터의 상세와 액션만 보여줍니다\` |
| Detail panel right-side meta | \`overview 카드에서 전환\` |
| Disclosure summary affordance | \`펴기\` text on right of every disclosure |

## Replaced

- **\`DisclosurePanel.subtitle\` (required string)** → **\`badge\` (optional ComponentChildren)**. Callers pass concrete counts: \`메시지 N · 오류 M\`, \`키퍼 N\`, \`메트릭 없음\`, \`관찰된 트래픽 없음\`.
- **\`펴기\` text** → \`▾\` chevron with \`group-open:rotate-180\` transform.
- **English-only subtitle \`Gate-observed traffic is not available yet.\`** → Korean badge \`관찰된 트래픽 없음\` + Korean body copy (\`connector runtime은 등록됐으나 게이트가 관찰한 트래픽은 아직 없습니다\`).
- **\`gate metrics unavailable\`** → **\`게이트 메트릭 없음\`** (filtered view).

## Test plan

- \`connector-status.test.ts\`: 25/25. Two assertions updated to match the data badges that replaced the marketing substrings (\`4종 채널 sidecar\` → \`커넥터\`, \`Gate metrics unavailable\` → \`메트릭 없음\`).
- \`control.test.ts\`: 5/5. \`operations-panel.test.ts\`: 5/5. (other consumers of \`ConnectorStatusPanel\`)
- \`vite build\`: 14.64s green.

## Trade-offs

- **DisclosurePanel API change**: \`subtitle: string\` was required; now \`badge: ComponentChildren?\`. Only 2 internal callers; both updated. If this disclosure pattern shows up elsewhere later, consider migrating to the shared \`CollapsibleSection\` instead — same shape, more callers.
- **Lost first-time-user hint**: the \`overview 카드에서 커넥터를 고르면 ...\` line was UX onboarding for someone who's never seen this panel. The connector tiles already have hover affordances and keyboard focus — the prose was redundant. If onboarding regressions surface, prefer a one-line tooltip on the overview strip header over a permanent text block.
- Pre-existing baseline \`tsc --noEmit\` errors (\`fsm_guard_violations\`, \`collapsed_from\`, \`NonHomeTabId\`) on \`main\` are unaffected by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)