### PR TITLE
fix(main-blocker): cdal namespace rename in tests + selector tuple return

### DIFF
--- a/lib/keeper/keeper_cascade_selector.ml
+++ b/lib/keeper/keeper_cascade_selector.ml
@@ -7,7 +7,7 @@ let select_item_for_turn
     ~(cascade_profile : cascade_profile)
     ~(health_cache : Keeper_health_probe.health_status)
     ~(last_used_item : string option)
-    : (cascade_item, [> `No_available_item ]) result =
+    : (string * cascade_item, [> `No_available_item ]) result =
   let rec try_group group_name visited =
     if List.mem group_name visited then
       Error `No_available_item
@@ -37,7 +37,7 @@ let select_item_for_turn
                   find_healthy rest
           in
           match find_healthy items with
-          | Some item -> Ok item
+          | Some item -> Ok (group_name, item)
           | None ->
               (match group.fallback_group with
                | Some next ->

--- a/lib/keeper/keeper_cascade_selector.mli
+++ b/lib/keeper/keeper_cascade_selector.mli
@@ -21,4 +21,11 @@ val select_item_for_turn :
   cascade_profile:Cascade_ref.cascade_profile ->
   health_cache:Keeper_health_probe.health_status ->
   last_used_item:string option ->
-  (Cascade_ref.cascade_item, [> `No_available_item ]) result
+  (string * Cascade_ref.cascade_item, [> `No_available_item ]) result
+(** Returns [(group_name, item)] so callers can route subsequent
+    [meta.cascade_name] to the correct group.  PR #14266 originally
+    returned just [cascade_item], but [Cascade_ref.cascade_item] has no
+    [group] field — the caller in [Keeper_unified_turn] tried
+    [item.Cascade_ref.group] which fails to type-check.  Carrying the
+    [group_name] alongside the item lets the caller perform the
+    intended override without depending on a non-existent field. *)

--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -417,7 +417,7 @@ let persist_message_cursor_updates ~config (meta : keeper_meta) updates =
 let run_keeper_cycle_with_slot ~ctx ~meta_after_cursor_persist ~stop ~obs
     ~(turn_decision : Keeper_world_observation.keeper_cycle_decision)
     ~shared_context ~semaphore_wait_ms ~slot_control
-    ?selected_item =
+    ?selected_item () =
   match
     with_in_turn_liveness_pulse ~ctx ~meta:meta_after_cursor_persist ~stop
       (fun () ->
@@ -887,7 +887,7 @@ let run_keepalive_unified_turn
                  ~cascade_profile:profile
                  ~health_cache:Keeper_health_probe.Healthy
                  ~last_used_item:None with
-               | Ok item -> Some item
+               | Ok pair -> Some pair
                | Error `No_available_item -> None)
           | None -> None
         in
@@ -930,7 +930,7 @@ let run_keepalive_unified_turn
                 ~channel:turn_decision.channel (fun ~semaphore_wait_ms ~slot_control ->
                 run_keeper_cycle_with_slot ~ctx ~meta_after_cursor_persist ~stop ~obs
                   ~turn_decision ~shared_context ~semaphore_wait_ms ~slot_control
-                  ?selected_item:selected_item_opt)
+                  ?selected_item:selected_item_opt ())
             with
             | Ok meta -> meta
             | Error (`Semaphore_wait_timeout timeout) ->

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -241,7 +241,7 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
          cascade resolution uses the item's group. *)
       let meta =
         match selected_item with
-        | Some item -> { meta with cascade_name = item.Cascade_ref.group }
+        | Some (group, _item) -> { meta with cascade_name = group }
         | None -> meta
       in
       let effective_cascade_name =
@@ -1742,7 +1742,7 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
       in
       (* RFC-0041 Phase B3: record per-item health after turn completion. *)
       (match selected_item with
-       | Some item ->
+       | Some (_group, item) ->
            let success =
              match run_result with
              | Ok _ -> true

--- a/lib/keeper/keeper_unified_turn.mli
+++ b/lib/keeper/keeper_unified_turn.mli
@@ -288,7 +288,7 @@ val run_keeper_cycle :
   ?semaphore_wait_ms:int ->
   ?turn_slot_control:Keeper_turn_slot.keeper_turn_slot_control ->
   ?shared_context:Agent_sdk.Context.t ->
-  ?selected_item:Cascade_ref.cascade_item ->
+  ?selected_item:(string * Cascade_ref.cascade_item) ->
   unit ->
   (Keeper_types.keeper_meta, Agent_sdk.Error.sdk_error) result
 
@@ -301,6 +301,6 @@ val run_unified_turn :
   ?semaphore_wait_ms:int ->
   ?turn_slot_control:Keeper_turn_slot.keeper_turn_slot_control ->
   ?shared_context:Agent_sdk.Context.t ->
-  ?selected_item:Cascade_ref.cascade_item ->
+  ?selected_item:(string * Cascade_ref.cascade_item) ->
   unit ->
   (Keeper_types.keeper_meta, Agent_sdk.Error.sdk_error) result

--- a/test/deps/dune
+++ b/test/deps/dune
@@ -33,6 +33,10 @@
    (re_export masc_mcp)
    (re_export masc_mcp.oas_compat)
    (re_export masc_mcp.activity_graph)
+   ;; PR #14267 atomic flip moved Cdal_proof / Proof_store / Risk_class /
+   ;; Execution_mode / Risk_contract from agent_sdk into this sub-library;
+   ;; tests need it re-exported so [Masc_mcp_cdal_runtime.*] resolves.
+   (re_export masc_mcp.cdal_runtime)
    (re_export masc_mcp.ag_ui)
    (re_export masc_mcp.config)
    (re_export masc_mcp.fs_compat)

--- a/test/test_cdal_eval_v1.ml
+++ b/test/test_cdal_eval_v1.ml
@@ -14,10 +14,10 @@ module CL = Masc_mcp.Cdal_loader
 let make_proof
     ?(run_id = "eval-v1-test-001")
     ?(contract_id = "md5:abc123")
-    ?(schema_version = Agent_sdk.Cdal_proof.schema_version_current)
-    ?(requested = Agent_sdk.Execution_mode.Execute)
-    ?(effective = Agent_sdk.Execution_mode.Execute)
-    () : Agent_sdk.Cdal_proof.t =
+    ?(schema_version = Masc_mcp_cdal_runtime.Cdal_proof.schema_version_current)
+    ?(requested = Masc_mcp_cdal_runtime.Execution_mode.Execute)
+    ?(effective = Masc_mcp_cdal_runtime.Execution_mode.Execute)
+    () : Masc_mcp_cdal_runtime.Cdal_proof.t =
   {
     schema_version;
     run_id;
@@ -25,7 +25,7 @@ let make_proof
     requested_execution_mode = requested;
     effective_execution_mode = effective;
     mode_decision_source = "passthrough";
-    risk_class = Agent_sdk.Risk_class.Low;
+    risk_class = Masc_mcp_cdal_runtime.Risk_class.Low;
     provider_snapshot = {
       provider_name = "test";
       model_id = "test-model";
@@ -47,7 +47,7 @@ let make_proof
     scope = None;
   }
 
-let make_contract () : Agent_sdk.Risk_contract.t =
+let make_contract () : Masc_mcp_cdal_runtime.Risk_contract.t =
   {
     runtime_constraints = {
       requested_execution_mode = Execute;
@@ -60,7 +60,7 @@ let make_contract () : Agent_sdk.Risk_contract.t =
     ];
   }
 
-let make_contract_with_review_requirement () : Agent_sdk.Risk_contract.t =
+let make_contract_with_review_requirement () : Masc_mcp_cdal_runtime.Risk_contract.t =
   {
     runtime_constraints = {
       requested_execution_mode = Execute;
@@ -78,7 +78,7 @@ let setup_store () =
     (Filename.get_temp_dir_name ())
     (Printf.sprintf "cdal_eval_v1_%d_%d"
        (Unix.getpid ()) (int_of_float (Unix.gettimeofday () *. 1000.0))) in
-  let store : Agent_sdk.Proof_store.config = { root = tmp_dir } in
+  let store : Masc_mcp_cdal_runtime.Proof_store.config = { root = tmp_dir } in
   (store, tmp_dir)
 
 let with_env name value f =
@@ -100,11 +100,11 @@ let test_full_pipeline () =
   let (store, _tmp) = setup_store () in
   let run_id = "full-pipeline-001" in
   let contract = make_contract () in
-  let contract_id = Agent_sdk.Risk_contract.contract_id contract in
+  let contract_id = Masc_mcp_cdal_runtime.Risk_contract.contract_id contract in
   let proof = make_proof ~run_id ~contract_id () in
-  Agent_sdk.Proof_store.init_run store ~run_id;
-  Agent_sdk.Proof_store.write_manifest store ~run_id proof;
-  Agent_sdk.Proof_store.write_contract store ~run_id contract;
+  Masc_mcp_cdal_runtime.Proof_store.init_run store ~run_id;
+  Masc_mcp_cdal_runtime.Proof_store.write_manifest store ~run_id proof;
+  Masc_mcp_cdal_runtime.Proof_store.write_contract store ~run_id contract;
   match CE.evaluate ~store proof with
   | Verdict (v, _) ->
     Alcotest.(check string) "status" "satisfied"
@@ -162,11 +162,11 @@ let test_verdict_of_outcome () =
   let (store1, _) = setup_store () in
   let run_id = "voo-test-001" in
   let contract = make_contract () in
-  let contract_id = Agent_sdk.Risk_contract.contract_id contract in
+  let contract_id = Masc_mcp_cdal_runtime.Risk_contract.contract_id contract in
   let proof1 = make_proof ~run_id ~contract_id () in
-  Agent_sdk.Proof_store.init_run store1 ~run_id;
-  Agent_sdk.Proof_store.write_manifest store1 ~run_id proof1;
-  Agent_sdk.Proof_store.write_contract store1 ~run_id contract;
+  Masc_mcp_cdal_runtime.Proof_store.init_run store1 ~run_id;
+  Masc_mcp_cdal_runtime.Proof_store.write_manifest store1 ~run_id proof1;
+  Masc_mcp_cdal_runtime.Proof_store.write_contract store1 ~run_id contract;
   let outcome1 = CE.evaluate ~store:store1 proof1 in
   let v1 = CE.verdict_of_outcome outcome1 in
   Alcotest.(check string) "verdict branch status" "satisfied"
@@ -183,11 +183,11 @@ let test_review_requirement_yields_inconclusive () =
   let (store, _tmp) = setup_store () in
   let run_id = "review-gate-001" in
   let contract = make_contract_with_review_requirement () in
-  let contract_id = Agent_sdk.Risk_contract.contract_id contract in
+  let contract_id = Masc_mcp_cdal_runtime.Risk_contract.contract_id contract in
   let proof = make_proof ~run_id ~contract_id () in
-  Agent_sdk.Proof_store.init_run store ~run_id;
-  Agent_sdk.Proof_store.write_manifest store ~run_id proof;
-  Agent_sdk.Proof_store.write_contract store ~run_id contract;
+  Masc_mcp_cdal_runtime.Proof_store.init_run store ~run_id;
+  Masc_mcp_cdal_runtime.Proof_store.write_manifest store ~run_id proof;
+  Masc_mcp_cdal_runtime.Proof_store.write_contract store ~run_id contract;
   match CE.evaluate ~store proof with
   | Verdict (v, Some fp) ->
     Alcotest.(check string) "status" "inconclusive"
@@ -213,11 +213,11 @@ let test_persist_explicit_base_dir_avoids_default_resolution () =
   let store, tmp = setup_store () in
   let run_id = "persist-explicit-base-dir" in
   let contract = make_contract () in
-  let contract_id = Agent_sdk.Risk_contract.contract_id contract in
+  let contract_id = Masc_mcp_cdal_runtime.Risk_contract.contract_id contract in
   let proof = make_proof ~run_id ~contract_id () in
-  Agent_sdk.Proof_store.init_run store ~run_id;
-  Agent_sdk.Proof_store.write_manifest store ~run_id proof;
-  Agent_sdk.Proof_store.write_contract store ~run_id contract;
+  Masc_mcp_cdal_runtime.Proof_store.init_run store ~run_id;
+  Masc_mcp_cdal_runtime.Proof_store.write_manifest store ~run_id proof;
+  Masc_mcp_cdal_runtime.Proof_store.write_contract store ~run_id contract;
   match CE.evaluate ~store proof with
   | Verdict (v, _) ->
       let base_dir = Filename.concat tmp "cdal_verdicts" in

--- a/test/test_cdal_friction_projection.ml
+++ b/test/test_cdal_friction_projection.ml
@@ -13,15 +13,15 @@ module CFP = Masc_mcp.Cdal_friction_projection
 let make_proof
     ?(run_id = "friction-test-001")
     ?(raw_evidence_refs = [])
-    () : Agent_sdk.Cdal_proof.t =
+    () : Masc_mcp_cdal_runtime.Cdal_proof.t =
   {
-    schema_version = Agent_sdk.Cdal_proof.schema_version_current;
+    schema_version = Masc_mcp_cdal_runtime.Cdal_proof.schema_version_current;
     run_id;
     contract_id = "md5:test";
     requested_execution_mode = Execute;
     effective_execution_mode = Execute;
     mode_decision_source = "passthrough";
-    risk_class = Agent_sdk.Risk_class.Low;
+    risk_class = Masc_mcp_cdal_runtime.Risk_class.Low;
     provider_snapshot = {
       provider_name = "test";
       model_id = "test-model";
@@ -48,7 +48,7 @@ let setup_store () =
     (Filename.get_temp_dir_name ())
     (Printf.sprintf "cdal_friction_%d_%d"
        (Unix.getpid ()) (int_of_float (Unix.gettimeofday () *. 1000.0))) in
-  let store : Agent_sdk.Proof_store.config = { root = tmp_dir } in
+  let store : Masc_mcp_cdal_runtime.Proof_store.config = { root = tmp_dir } in
   (store, tmp_dir)
 
 let mkdirp path =
@@ -60,7 +60,7 @@ let mkdirp path =
   in
   go path
 
-let write_violations_file (store : Agent_sdk.Proof_store.config) ~run_id
+let write_violations_file (store : Masc_mcp_cdal_runtime.Proof_store.config) ~run_id
     (violations : Yojson.Safe.t) =
   let dir = Filename.concat
     (Filename.concat
@@ -71,7 +71,7 @@ let write_violations_file (store : Agent_sdk.Proof_store.config) ~run_id
   let path = Filename.concat dir "mode_violations.json" in
   Yojson.Safe.to_file path violations
 
-let write_effects_file (store : Agent_sdk.Proof_store.config) ~run_id
+let write_effects_file (store : Masc_mcp_cdal_runtime.Proof_store.config) ~run_id
     (effects : Yojson.Safe.t) =
   let dir = Filename.concat
     (Filename.concat
@@ -458,7 +458,7 @@ let test_effect_source_path_satisfies_gap () =
       (List.mem "source_path_evidence:mode_enforcer" fp.review_tripwires)
 
 let test_path_traversal_rejected () =
-  let store : Agent_sdk.Proof_store.config = { root = "/tmp/test-store" } in
+  let store : Masc_mcp_cdal_runtime.Proof_store.config = { root = "/tmp/test-store" } in
   let result = Masc_mcp.Proof_artifact_reader.resolve_path store
     "proof-store://../../../etc/passwd" in
   match result with
@@ -506,15 +506,15 @@ let make_proof_for_cross_run
     ?(run_id = "cr-001")
     ?(raw_evidence_refs = [])
     ?(ended_at = 1001.0)
-    () : Agent_sdk.Cdal_proof.t =
+    () : Masc_mcp_cdal_runtime.Cdal_proof.t =
   {
-    schema_version = Agent_sdk.Cdal_proof.schema_version_current;
+    schema_version = Masc_mcp_cdal_runtime.Cdal_proof.schema_version_current;
     run_id;
     contract_id = "md5:test";
     requested_execution_mode = Execute;
     effective_execution_mode = Execute;
     mode_decision_source = "passthrough";
-    risk_class = Agent_sdk.Risk_class.Low;
+    risk_class = Masc_mcp_cdal_runtime.Risk_class.Low;
     provider_snapshot = {
       provider_name = "test"; model_id = "test-model"; api_version = None;
     };

--- a/test/test_cdal_judge.ml
+++ b/test/test_cdal_judge.ml
@@ -14,11 +14,11 @@ module CL = Masc_mcp.Cdal_loader
 let make_proof
     ?(run_id = "judge-test-001")
     ?(contract_id = "md5:abc123")
-    ?(schema_version = Agent_sdk.Cdal_proof.schema_version_current)
-    ?(requested = Agent_sdk.Execution_mode.Execute)
-    ?(effective = Agent_sdk.Execution_mode.Execute)
-    ?(risk_class = Agent_sdk.Risk_class.Low)
-    () : Agent_sdk.Cdal_proof.t =
+    ?(schema_version = Masc_mcp_cdal_runtime.Cdal_proof.schema_version_current)
+    ?(requested = Masc_mcp_cdal_runtime.Execution_mode.Execute)
+    ?(effective = Masc_mcp_cdal_runtime.Execution_mode.Execute)
+    ?(risk_class = Masc_mcp_cdal_runtime.Risk_class.Low)
+    () : Masc_mcp_cdal_runtime.Cdal_proof.t =
   {
     schema_version;
     run_id;
@@ -49,10 +49,10 @@ let make_proof
   }
 
 let make_contract
-    ?(requested = Agent_sdk.Execution_mode.Execute)
-    ?(risk_class = Agent_sdk.Risk_class.Low)
+    ?(requested = Masc_mcp_cdal_runtime.Execution_mode.Execute)
+    ?(risk_class = Masc_mcp_cdal_runtime.Risk_class.Low)
     ?review_requirement
-    () : Agent_sdk.Risk_contract.t =
+    () : Masc_mcp_cdal_runtime.Risk_contract.t =
   {
     runtime_constraints = {
       requested_execution_mode = requested;
@@ -67,11 +67,11 @@ let make_contract
 
 let make_bundle
     ?(run_id = "judge-test-001")
-    ?(proof_requested = Agent_sdk.Execution_mode.Execute)
-    ?(proof_effective = Agent_sdk.Execution_mode.Execute)
-    ?(proof_risk = Agent_sdk.Risk_class.Low)
-    ?(contract_requested = Agent_sdk.Execution_mode.Execute)
-    ?(contract_risk = Agent_sdk.Risk_class.Low)
+    ?(proof_requested = Masc_mcp_cdal_runtime.Execution_mode.Execute)
+    ?(proof_effective = Masc_mcp_cdal_runtime.Execution_mode.Execute)
+    ?(proof_risk = Masc_mcp_cdal_runtime.Risk_class.Low)
+    ?(contract_requested = Masc_mcp_cdal_runtime.Execution_mode.Execute)
+    ?(contract_risk = Masc_mcp_cdal_runtime.Risk_class.Low)
     ?contract_review_requirement
     ?(proof_raw_evidence_refs = [])
     ?(contract_id_match = true)
@@ -80,7 +80,7 @@ let make_bundle
       ~risk_class:contract_risk
       ?review_requirement:contract_review_requirement () in
   let recomputed_contract_id =
-    Agent_sdk.Risk_contract.contract_id contract in
+    Masc_mcp_cdal_runtime.Risk_contract.contract_id contract in
   let proof_contract_id =
     if contract_id_match then recomputed_contract_id
     else "md5:mismatched_hash" in
@@ -120,9 +120,9 @@ let test_all_satisfied () =
 let test_mode_propagation_violated () =
   (* proof requests Draft but contract requires Execute *)
   let bundle = make_bundle
-      ~proof_requested:Agent_sdk.Execution_mode.Draft
-      ~proof_effective:Agent_sdk.Execution_mode.Draft
-      ~contract_requested:Agent_sdk.Execution_mode.Execute () in
+      ~proof_requested:Masc_mcp_cdal_runtime.Execution_mode.Draft
+      ~proof_effective:Masc_mcp_cdal_runtime.Execution_mode.Draft
+      ~contract_requested:Masc_mcp_cdal_runtime.Execution_mode.Execute () in
   let cr = CJ.check_execution_mode bundle in
   Alcotest.(check string) "status" "violated"
     (CT.contract_status_to_string cr.status);
@@ -136,9 +136,9 @@ let test_mode_propagation_violated () =
 let test_mode_escalation_violated () =
   (* effective Execute > requested Draft *)
   let bundle = make_bundle
-      ~proof_requested:Agent_sdk.Execution_mode.Draft
-      ~proof_effective:Agent_sdk.Execution_mode.Execute
-      ~contract_requested:Agent_sdk.Execution_mode.Draft () in
+      ~proof_requested:Masc_mcp_cdal_runtime.Execution_mode.Draft
+      ~proof_effective:Masc_mcp_cdal_runtime.Execution_mode.Execute
+      ~contract_requested:Masc_mcp_cdal_runtime.Execution_mode.Draft () in
   let cr = CJ.check_execution_mode bundle in
   Alcotest.(check string) "status" "violated"
     (CT.contract_status_to_string cr.status);
@@ -153,8 +153,8 @@ let test_mode_escalation_violated () =
 
 let test_risk_class_violated () =
   let bundle = make_bundle
-      ~proof_risk:Agent_sdk.Risk_class.High
-      ~contract_risk:Agent_sdk.Risk_class.Low () in
+      ~proof_risk:Masc_mcp_cdal_runtime.Risk_class.High
+      ~contract_risk:Masc_mcp_cdal_runtime.Risk_class.Low () in
   let cr = CJ.check_risk_class bundle in
   Alcotest.(check string) "status" "violated"
     (CT.contract_status_to_string cr.status);
@@ -221,8 +221,8 @@ let test_review_requirement_inconclusive_warning_only () =
 let test_verdict_priority_violated_wins () =
   (* One violated check (risk mismatch) + others satisfied *)
   let bundle = make_bundle
-      ~proof_risk:Agent_sdk.Risk_class.Medium
-      ~contract_risk:Agent_sdk.Risk_class.Low () in
+      ~proof_risk:Masc_mcp_cdal_runtime.Risk_class.Medium
+      ~contract_risk:Masc_mcp_cdal_runtime.Risk_class.Low () in
   let verdict = CJ.judge bundle in
   Alcotest.(check string) "status" "violated"
     (CT.contract_status_to_string verdict.status)
@@ -254,8 +254,8 @@ let test_claim_scope_always_set () =
     "phase1_scoped_runtime_audit" verdict_ok.claim_scope;
   (* Violated case *)
   let bundle_bad = make_bundle
-      ~proof_risk:Agent_sdk.Risk_class.High
-      ~contract_risk:Agent_sdk.Risk_class.Low () in
+      ~proof_risk:Masc_mcp_cdal_runtime.Risk_class.High
+      ~contract_risk:Masc_mcp_cdal_runtime.Risk_class.Low () in
   let verdict_bad = CJ.judge bundle_bad in
   Alcotest.(check string) "claim_scope violated"
     "phase1_scoped_runtime_audit" verdict_bad.claim_scope
@@ -287,8 +287,8 @@ let test_replay_determinism () =
 
 let test_findings_populated () =
   let bundle = make_bundle
-      ~proof_risk:Agent_sdk.Risk_class.Critical
-      ~contract_risk:Agent_sdk.Risk_class.Low () in
+      ~proof_risk:Masc_mcp_cdal_runtime.Risk_class.Critical
+      ~contract_risk:Masc_mcp_cdal_runtime.Risk_class.Low () in
   let verdict = CJ.judge bundle in
   Alcotest.(check string) "violated" "violated"
     (CT.contract_status_to_string verdict.status);

--- a/test/test_cdal_loader.ml
+++ b/test/test_cdal_loader.ml
@@ -13,10 +13,10 @@ module CL = Masc_mcp.Cdal_loader
 let make_proof
     ?(run_id = "loader-test-001")
     ?(contract_id = "md5:abc123")
-    ?(schema_version = Agent_sdk.Cdal_proof.schema_version_current)
-    ?(requested = Agent_sdk.Execution_mode.Execute)
-    ?(effective = Agent_sdk.Execution_mode.Execute)
-    () : Agent_sdk.Cdal_proof.t =
+    ?(schema_version = Masc_mcp_cdal_runtime.Cdal_proof.schema_version_current)
+    ?(requested = Masc_mcp_cdal_runtime.Execution_mode.Execute)
+    ?(effective = Masc_mcp_cdal_runtime.Execution_mode.Execute)
+    () : Masc_mcp_cdal_runtime.Cdal_proof.t =
   {
     schema_version;
     run_id;
@@ -24,7 +24,7 @@ let make_proof
     requested_execution_mode = requested;
     effective_execution_mode = effective;
     mode_decision_source = "passthrough";
-    risk_class = Agent_sdk.Risk_class.Low;
+    risk_class = Masc_mcp_cdal_runtime.Risk_class.Low;
     provider_snapshot = {
       provider_name = "test";
       model_id = "test-model";
@@ -46,7 +46,7 @@ let make_proof
     scope = None;
   }
 
-let make_contract () : Agent_sdk.Risk_contract.t =
+let make_contract () : Masc_mcp_cdal_runtime.Risk_contract.t =
   {
     runtime_constraints = {
       requested_execution_mode = Execute;
@@ -65,7 +65,7 @@ let setup_store () =
     (Filename.get_temp_dir_name ())
     (Printf.sprintf "cdal_loader_%d_%d"
        (Unix.getpid ()) (int_of_float (Unix.gettimeofday () *. 1000.0))) in
-  let store : Agent_sdk.Proof_store.config = { root = tmp_dir } in
+  let store : Masc_mcp_cdal_runtime.Proof_store.config = { root = tmp_dir } in
   (store, tmp_dir)
 
 let mkdirp path =
@@ -85,19 +85,19 @@ let test_load_valid_bundle () =
   let (store, _tmp) = setup_store () in
   let run_id = "valid-bundle-001" in
   let contract = make_contract () in
-  let contract_id = Agent_sdk.Risk_contract.contract_id contract in
+  let contract_id = Masc_mcp_cdal_runtime.Risk_contract.contract_id contract in
   let proof = make_proof ~run_id ~contract_id () in
   (* Write manifest and contract to disk *)
-  Agent_sdk.Proof_store.init_run store ~run_id;
-  Agent_sdk.Proof_store.write_manifest store ~run_id proof;
-  Agent_sdk.Proof_store.write_contract store ~run_id contract;
+  Masc_mcp_cdal_runtime.Proof_store.init_run store ~run_id;
+  Masc_mcp_cdal_runtime.Proof_store.write_manifest store ~run_id proof;
+  Masc_mcp_cdal_runtime.Proof_store.write_contract store ~run_id contract;
   match CL.load ~store proof with
   | Ok bundle ->
     Alcotest.(check string) "run_id" run_id bundle.proof.run_id;
     Alcotest.(check string) "recomputed contract_id"
       contract_id bundle.recomputed_contract_id;
     Alcotest.(check string) "contract mode" "execute"
-      (Agent_sdk.Execution_mode.to_string
+      (Masc_mcp_cdal_runtime.Execution_mode.to_string
          bundle.contract.runtime_constraints.requested_execution_mode)
   | Error e -> Alcotest.fail (CL.load_error_to_string e)
 
@@ -152,8 +152,8 @@ let test_missing_contract () =
   let run_id = "no-contract" in
   let proof = make_proof ~run_id () in
   (* Write manifest but not contract *)
-  Agent_sdk.Proof_store.init_run store ~run_id;
-  Agent_sdk.Proof_store.write_manifest store ~run_id proof;
+  Masc_mcp_cdal_runtime.Proof_store.init_run store ~run_id;
+  Masc_mcp_cdal_runtime.Proof_store.write_manifest store ~run_id proof;
   match CL.load ~store proof with
   | Error (Contract_not_found _) -> ()
   | Error e ->
@@ -169,8 +169,8 @@ let test_malformed_contract () =
   let (store, _tmp) = setup_store () in
   let run_id = "bad-contract" in
   let proof = make_proof ~run_id () in
-  Agent_sdk.Proof_store.init_run store ~run_id;
-  Agent_sdk.Proof_store.write_manifest store ~run_id proof;
+  Masc_mcp_cdal_runtime.Proof_store.init_run store ~run_id;
+  Masc_mcp_cdal_runtime.Proof_store.write_manifest store ~run_id proof;
   (* Write invalid contract JSON *)
   let contract_path =
     match
@@ -198,12 +198,12 @@ let test_schema_unsupported () =
   let (store, _tmp) = setup_store () in
   let run_id = "bad-schema" in
   let contract = make_contract () in
-  let contract_id = Agent_sdk.Risk_contract.contract_id contract in
+  let contract_id = Masc_mcp_cdal_runtime.Risk_contract.contract_id contract in
   (* Create manifest proof with wrong schema version *)
   let proof = make_proof ~run_id ~contract_id ~schema_version:99 () in
-  Agent_sdk.Proof_store.init_run store ~run_id;
-  Agent_sdk.Proof_store.write_manifest store ~run_id proof;
-  Agent_sdk.Proof_store.write_contract store ~run_id contract;
+  Masc_mcp_cdal_runtime.Proof_store.init_run store ~run_id;
+  Masc_mcp_cdal_runtime.Proof_store.write_manifest store ~run_id proof;
+  Masc_mcp_cdal_runtime.Proof_store.write_contract store ~run_id contract;
   match CL.load ~store proof with
   | Error (Schema_unsupported 99) -> ()
   | Error e ->
@@ -219,18 +219,18 @@ let test_contract_id_roundtrip () =
   let (store, _tmp) = setup_store () in
   let run_id = "roundtrip-001" in
   let contract = make_contract () in
-  let original_id = Agent_sdk.Risk_contract.contract_id contract in
+  let original_id = Masc_mcp_cdal_runtime.Risk_contract.contract_id contract in
   let proof = make_proof ~run_id ~contract_id:original_id () in
-  Agent_sdk.Proof_store.init_run store ~run_id;
-  Agent_sdk.Proof_store.write_manifest store ~run_id proof;
-  Agent_sdk.Proof_store.write_contract store ~run_id contract;
+  Masc_mcp_cdal_runtime.Proof_store.init_run store ~run_id;
+  Masc_mcp_cdal_runtime.Proof_store.write_manifest store ~run_id proof;
+  Masc_mcp_cdal_runtime.Proof_store.write_contract store ~run_id contract;
   match CL.load ~store proof with
   | Ok bundle ->
     Alcotest.(check string) "recomputed matches original"
       original_id bundle.recomputed_contract_id;
     (* Also verify the recomputed ID matches what contract_id produces *)
     let recomputed_again =
-      Agent_sdk.Risk_contract.contract_id bundle.contract in
+      Masc_mcp_cdal_runtime.Risk_contract.contract_id bundle.contract in
     Alcotest.(check string) "recomputed from loaded contract"
       original_id recomputed_again
   | Error e -> Alcotest.fail (CL.load_error_to_string e)
@@ -243,26 +243,26 @@ let test_manifest_is_truth_source () =
   let (store, _tmp) = setup_store () in
   let run_id = "manifest-truth-001" in
   let contract = make_contract () in
-  let contract_id = Agent_sdk.Risk_contract.contract_id contract in
+  let contract_id = Masc_mcp_cdal_runtime.Risk_contract.contract_id contract in
   let manifest_proof =
     make_proof ~run_id ~contract_id
-      ~requested:Agent_sdk.Execution_mode.Execute
-      ~effective:Agent_sdk.Execution_mode.Draft () in
+      ~requested:Masc_mcp_cdal_runtime.Execution_mode.Execute
+      ~effective:Masc_mcp_cdal_runtime.Execution_mode.Draft () in
   let input_proof =
     make_proof ~run_id ~contract_id
-      ~requested:Agent_sdk.Execution_mode.Diagnose
-      ~effective:Agent_sdk.Execution_mode.Diagnose () in
-  Agent_sdk.Proof_store.init_run store ~run_id;
-  Agent_sdk.Proof_store.write_manifest store ~run_id manifest_proof;
-  Agent_sdk.Proof_store.write_contract store ~run_id contract;
+      ~requested:Masc_mcp_cdal_runtime.Execution_mode.Diagnose
+      ~effective:Masc_mcp_cdal_runtime.Execution_mode.Diagnose () in
+  Masc_mcp_cdal_runtime.Proof_store.init_run store ~run_id;
+  Masc_mcp_cdal_runtime.Proof_store.write_manifest store ~run_id manifest_proof;
+  Masc_mcp_cdal_runtime.Proof_store.write_contract store ~run_id contract;
   match CL.load ~store input_proof with
   | Ok bundle ->
     Alcotest.(check string) "requested from manifest"
       "execute"
-      (Agent_sdk.Execution_mode.to_string bundle.proof.requested_execution_mode);
+      (Masc_mcp_cdal_runtime.Execution_mode.to_string bundle.proof.requested_execution_mode);
     Alcotest.(check string) "effective from manifest"
       "draft"
-      (Agent_sdk.Execution_mode.to_string bundle.proof.effective_execution_mode)
+      (Masc_mcp_cdal_runtime.Execution_mode.to_string bundle.proof.effective_execution_mode)
   | Error e -> Alcotest.fail (CL.load_error_to_string e)
 
 (* ================================================================ *)
@@ -277,7 +277,7 @@ let test_load_error_to_string () =
     (CL.Contract_parse_error "bad", "contract parse error: bad");
     (CL.Schema_unsupported 99,
      Printf.sprintf "unsupported schema version: 99 (expected %d)"
-       Agent_sdk.Cdal_proof.schema_version_current);
+       Masc_mcp_cdal_runtime.Cdal_proof.schema_version_current);
     (CL.Ref_resolution_error "ref", "ref resolution error: ref");
   ] in
   List.iter (fun (err, expected) ->

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -2468,15 +2468,15 @@ let make_run_result ~text ~tools ~model ~input_tok ~output_tok
     tool_surface = sample_tool_surface_metrics ();
   }
 
-let sample_cdal_proof ?(raw_evidence_refs = []) () : Agent_sdk.Cdal_proof.t =
+let sample_cdal_proof ?(raw_evidence_refs = []) () : Masc_mcp_cdal_runtime.Cdal_proof.t =
   {
-    schema_version = Agent_sdk.Cdal_proof.schema_version_current;
+    schema_version = Masc_mcp_cdal_runtime.Cdal_proof.schema_version_current;
     run_id = "keeper-metrics-proof-test";
     contract_id = "md5:test";
     requested_execution_mode = Execute;
     effective_execution_mode = Execute;
     mode_decision_source = "passthrough";
-    risk_class = Agent_sdk.Risk_class.Low;
+    risk_class = Masc_mcp_cdal_runtime.Risk_class.Low;
     provider_snapshot =
       {
         provider_name = "test";

--- a/test/test_masc_contract_catalog.ml
+++ b/test/test_masc_contract_catalog.ml
@@ -29,14 +29,14 @@ let test_cascade_contract_shape () =
     bool
     "critical risk"
     true
-    (Agent_sdk.Risk_class.equal spec.risk_class Agent_sdk.Risk_class.Critical);
+    (Masc_mcp_cdal_runtime.Risk_class.equal spec.risk_class Masc_mcp_cdal_runtime.Risk_class.Critical);
   check
     bool
     "execute mode"
     true
-    (Agent_sdk.Execution_mode.equal
+    (Masc_mcp_cdal_runtime.Execution_mode.equal
        spec.requested_execution_mode
-       Agent_sdk.Execution_mode.Execute)
+       Masc_mcp_cdal_runtime.Execution_mode.Execute)
 ;;
 
 let test_find_by_name () =
@@ -47,7 +47,7 @@ let test_find_by_name () =
       bool
       "high risk"
       true
-      (Agent_sdk.Risk_class.equal spec.risk_class Agent_sdk.Risk_class.High)
+      (Masc_mcp_cdal_runtime.Risk_class.equal spec.risk_class Masc_mcp_cdal_runtime.Risk_class.High)
   | None -> fail "expected keeper lifecycle contract"
 ;;
 
@@ -74,8 +74,8 @@ let test_risk_contract_projection_is_deterministic () =
   check
     string
     "contract id deterministic"
-    (Agent_sdk.Risk_contract.contract_id first)
-    (Agent_sdk.Risk_contract.contract_id second);
+    (Masc_mcp_cdal_runtime.Risk_contract.contract_id first)
+    (Masc_mcp_cdal_runtime.Risk_contract.contract_id second);
   check
     (list string)
     "allowed mutations"
@@ -91,7 +91,7 @@ let test_risk_contract_projection_is_deterministic () =
 let test_risk_contract_ids_are_pinned () =
   let ids =
     Catalog.all
-    |> List.map (fun spec -> Agent_sdk.Risk_contract.contract_id (Catalog.to_risk_contract spec))
+    |> List.map (fun spec -> Masc_mcp_cdal_runtime.Risk_contract.contract_id (Catalog.to_risk_contract spec))
   in
   check
     (list string)


### PR DESCRIPTION
## Summary

Unblocks origin/main from **8 build errors** that have been silently failing \`dune build @check\` since PR #14266 (RFC-0041 cascade routing wiring) and PR #14267 (Agent_sdk → Masc_mcp_cdal_runtime atomic flip). Both were admin-merged through cancelled CI.

Verified locally on origin/main → \`@check\` clean after this PR.

## Errors fixed (8)

| # | File:Line | Issue |
|---|-----------|-------|
| 1 | \`test/test_cdal_loader.ml:94\` | \`Agent_sdk.Proof_store.config\` vs \`Masc_mcp_cdal_runtime__Proof_store.config\` |
| 2 | \`test/test_cdal_eval_v1.ml:108\` | same Proof_store mismatch |
| 3 | \`test/test_cdal_friction_projection.ml:140\` | same Proof_store mismatch |
| 4 | \`test/test_cdal_judge.ml:92\` | \`Agent_sdk.Cdal_proof.t\` vs \`Masc_mcp_cdal_runtime__Cdal_proof.t\` |
| 5 | \`test/test_keeper_unified.ml:3330\` | same Cdal_proof mismatch |
| 6 | \`test/test_masc_contract_catalog.ml:32\` | same Risk_class mismatch |
| 7 | \`lib/keeper/keeper_unified_turn.ml:1753\` | \`item.Cascade_ref.id\` — item typed as \`cascade_ref\` but \`id\` belongs to \`cascade_item\` |
| 8 | \`lib/keeper/keeper_heartbeat_loop.ml:420\` | warning 16 \`[unerasable-optional-argument]\` on trailing \`?selected_item\` |

## Changes (5 categories, 12 files, +129 / -118)

### (A) test_deps re-export
\`test/deps/dune\` — add \`(re_export masc_mcp.cdal_runtime)\`. The atomic flip moved 5 modules out of \`agent_sdk\` into this sub-library; tests need it visible.

### (B) Test renames (6 files, ~108 sites)
Bulk perl rename:
\`\`\`
\\bAgent_sdk\\.(Cdal_proof|Proof_store|Risk_class|Execution_mode|Risk_contract)\\b
→ Masc_mcp_cdal_runtime.$1
\`\`\`

Files: \`test_cdal_eval_v1\`, \`test_cdal_friction_projection\`, \`test_cdal_judge\`, \`test_cdal_loader\`, \`test_keeper_unified\`, \`test_masc_contract_catalog\`.

### (C) Selector tuple return
\`lib/keeper/keeper_cascade_selector.{ml,mli}\` — change \`select_item_for_turn\` from \`cascade_item result\` to \`(string * cascade_item) result\`.

**Why**: PR #14266 wrote \`item.Cascade_ref.group\` in \`keeper_unified_turn\` assuming \`cascade_item\` had a \`group\` field. It doesn't — \`group\` is a field of \`cascade_ref\`. Returning the group name alongside lets the caller perform the intended \`meta.cascade_name\` override without depending on a non-existent field. Preserves PR #14266's RFC-0041 routing intent.

### (D) Caller pattern matching
\`lib/keeper/keeper_unified_turn.{ml,mli}\` — destructure \`Some (group, item)\` in the two \`match selected_item with\` sites (line 244 \`cascade_name\` override, line 1744 \`record_item_result\`) + update \`?selected_item\` type annotations in both \`run_keeper_cycle\` and \`run_unified_turn\` mli signatures.

### (E) Heartbeat loop fixes
\`lib/keeper/keeper_heartbeat_loop.ml\`:
1. \`Ok item → Some item\` becomes \`Ok pair → Some pair\` for the new tuple shape (line 891).
2. Add \`()\` to \`run_keeper_cycle_with_slot\`'s parameter list (line 420) + matching caller (line 933) so trailing \`?selected_item\` becomes erasable.

## Verification

\`\`\`
dune build --root . @check                          # clean (was 8 errors on main)
dune exec test/test_keeper_health_probe.exe         # 3/3 pass
dune exec test/test_cdal_eval_v1.exe                # 5/5 pass (renamed)
dune exec test/test_masc_contract_catalog.exe       # 6/6 pass (renamed)
\`\`\`

## Memory referenced

\`feedback_rfc_oas_011_cdal_runtime_admin_merge_cascade.md\` — this is the 5th layer of the cascade pattern (after #14246/#14249/#14257/#14260/#14269/#14272/#14278). Per protocol, single-PR scope, no silent rewrites of RFC source semantics — only the cascade_selector tuple return is a structural change, and it preserves the original PR #14266 intent while fixing the type bug.

## Test plan

- [ ] CI \`Build and Test\` passes on this PR (was failing on every recent main HEAD).
- [ ] No regressions in renamed tests.
- [ ] PR #14279 (\`refactor(keeper): promote FSM transition validators to GADT compile-time safety\`) can be rebased onto a buildable main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)