### PR TITLE
chore(opam): bump agent_sdk SHA pin to RFC-OAS-011 OAS-E final commit (MM-4)

### DIFF
--- a/scripts/oas-agent-sdk-pin.sh
+++ b/scripts/oas-agent-sdk-pin.sh
@@ -3,5 +3,5 @@
 readonly OAS_AGENT_SDK_URL="https://github.com/jeong-sik/oas.git"
 readonly OAS_AGENT_SDK_BASE_VERSION="v0.192.1"
 readonly OAS_AGENT_SDK_TRACK_REF="main"
-readonly OAS_AGENT_SDK_SHA="7149c5a7e0a41985fc981fbe727ea120e673bc09"
+readonly OAS_AGENT_SDK_SHA="57ee93e1a889fa2b74a43a1436593b3db21f144e"
 readonly OAS_AGENT_SDK_MIN_VERSION="0.192.1"


### PR DESCRIPTION
## 요약 — RFC-OAS-011의 *마지막 lockstep*

agent_sdk opam pin SHA를 `7149c5a7` (RFC-OAS-009 v2 PR-A 머지) → `57ee93e1` (OAS-E PR-6 #1489 머지 후 main HEAD)로 갱신.

**변경 1 line**. masc-mcp가 *CDAL이 모두 제거된 OAS main*에 정렬.

## 변경

```diff
-readonly OAS_AGENT_SDK_SHA="7149c5a7e0a41985fc981fbe727ea120e673bc09"
+readonly OAS_AGENT_SDK_SHA="57ee93e1a889fa2b74a43a1436593b3db21f144e"
```

## 새 SHA가 포함하는 RFC-OAS-011 OAS-E

| OAS PR | 변경 |
|---|---|
| PR-1 #1485 | boundary lint 9→20 prefix |
| PR-2 #14272 | cdal_runtime sessions facade direct refs |
| PR-3 #1486 | `execution_manifest` dead removal (-326) |
| PR-4 #1487 | `runtime_server_worker` dead removal (-2039) |
| PR-5 #1488 | test/+examples CDAL coverage purge (-8725) |
| PR-6 #1489 | 20 modules + 19 façade re-exports + sessions facade trim (-7004) |

= 누적 **-18,237 LoC** OAS 정리.

## masc-mcp 영향 = 0 (이미 정렬됨)

새 pin은 *agent_sdk가 더 이상 노출하지 않는* 모듈들을 가짐:

```
사라진 export — Agent_sdk.{Cdal_proof, Mode_enforcer, Mode_resolver,
  Risk_contract, Risk_class, Execution_mode, Proof_capture, Proof_store,
  Contract_runner, Effect_evidence, Verified_output, Conformance,
  Cognitive_event, Direct_evidence, Audit, Autonomy_exec,
  Autonomy_diff_guard, Autonomy_trace_analyzer, Sessions_proof,
  Runtime_evidence}
```

masc-mcp 본체는 MM-3-rewire (#14267)에서 *모두* `Masc_mcp_cdal_runtime.X`로 전환됨. 즉 본 PR이 가져오는 OAS main이 그 모듈들을 *없애더라도* masc-mcp 빌드 영향 0. 단지 *pin이 새 main에 정렬*될 뿐.

## 유지된 surface (Guardrails 3종 재분류)

`Agent_sdk.Guardrails_async`, `Agent_sdk.Guardrail_llm`, `Agent_sdk.Guardrail_tripwire`은 *SDK core*로 재분류되어 (RFC-OAS-009 v3 lint expansion, OAS-E PR-1) OAS lib에 그대로 남음. masc-mcp의 `cdal_runtime` 안 카피는 *redundant*이며 RFC-OAS-013에서 정리.

## 의도적 out of scope

| 항목 | 이유 |
|---|---|
| `OAS_AGENT_SDK_BASE_VERSION` (`v0.192.1` 유지) | release-please가 0.193.0 cut을 아직 안 함 |
| `OAS_AGENT_SDK_MIN_VERSION` (`0.192.1` 유지) | OAS의 `lib/sdk_version.ml`이 아직 `0.192.1` (release-please workflow가 처리 예정) |

→ Follow-up PR: release-please의 0.193.0 PR이 머지되면 *별 PR*로 BASE_VERSION + MIN_VERSION 갱신.

## RFC-OAS-011 종결 상태

| Phase | 상태 |
|---|---|
| MM-1 #14247 (cdal_runtime skel) | MERGED |
| MM-2-leaves~top #14248~#14264 | MERGED — 23 modules / +7531 LoC migrated |
| #14257 hotfix | MERGED |
| MM-3-rewire #14267 (atomic flip) | MERGED |
| OAS-E PR-1~6 #1485~#1489 | MERGED — -18,237 LoC OAS cleanup |
| **MM-4 (this) — opam pin bump** | OPEN, Draft |
| Follow-up: release-please 0.193.0 + BASE/MIN_VERSION bump | TBD |

본 PR 머지 시 RFC-OAS-011의 *runtime/build 정렬* 완료.

## Test plan

- [ ] CI green — masc-mcp 본체 + cdal_runtime + autoresearch 모두 새 pin으로 빌드 통과
- [ ] `human-approved-ready` 라벨 부착 후 머지

🤖 Generated with [Claude Code](https://claude.com/claude-code)