### PR TITLE
chore(rfc-0047): Phase 3b — move 2 cascade entry files to lib/cascade/

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -829,7 +829,7 @@ Follow-up to v0.18.1 ProviderTerminal rescue. This release collects a wave of ke
 - `keeper`: cap cascade rotation at 1 for `required_tool_contract_violation` so a single proactive contract miss can't cycle through every provider (#10851).
 - `coord/task`: emit warn when a task crosses the 5-cycle oscillation threshold so operators see escalation candidates (#10719, #10920).
 - `server/autoboot`: per-task boot guard so a single hung lazy task can't block keeper boot — restore_sessions now degrades gracefully instead of hanging the boot pipeline (#10857).
-- `boot`: start `Oas_worker_cascade` actor consumer fiber that was dropped in a refactor and left the cascade actor without a reader (#10895).
+- `boot`: start `Cascade_legacy_runner` actor consumer fiber that was dropped in a refactor and left the cascade actor without a reader (#10895).
 - `cascade-filter`: per-provider rejection diagnostics for #10681 so cascade-skip reasons are visible per provider, not aggregate (#10852).
 - `keeper-shell-docker`: detect `gh --repo X api Y` LLM-hallucinated form and self-correct (108 events / day pre-fix, #10855, #10900).
 - `keeper-shell-docker`: replace `List.hd` with pattern match (Health ratchet, #10905).

--- a/docs/rfc/RFC-0047-oas-adapter-decomposition.md
+++ b/docs/rfc/RFC-0047-oas-adapter-decomposition.md
@@ -215,7 +215,7 @@ Build-green hard gate at every PR.
 
 **Scope correction (during Phase 2 PR, 2026-05-08).** The original RFC
 listed 4 files. Inspection found `lib/oas_worker.ml` is structurally a
-**facade** — `include Oas_worker_exec`, `include Oas_worker_cascade`,
+**facade** — `include Oas_worker_exec`, `include Cascade_legacy_runner`,
 `include Oas_worker_named` — over three modules that are NOT clean
 (Phase 3 / Phase 4 targets). Renaming the facade alone produces an
 `Agent_sdk_call` module that still re-exports `Oas_worker_named.run_named`,

--- a/lib/anti_rationalization.ml
+++ b/lib/anti_rationalization.ml
@@ -574,7 +574,7 @@ let review
            ~masc_tools:[report_review_verdict_schema]
            ~dispatch
            ~max_turns:1
-           ~temperature:Oas_worker_cascade.deterministic_temperature
+           ~temperature:Cascade_legacy_runner.deterministic_temperature
            ~max_tokens:200
            ~approval:Approval_callbacks.auto_approve
            ?sw

--- a/lib/cascade/cascade_attempt_fsm.ml
+++ b/lib/cascade/cascade_attempt_fsm.ml
@@ -159,7 +159,7 @@ let resolve_kimi_api_key_env_name ~cascade_name =
        | Some env_name -> env_name
        | None -> fallback_env)
   in
-  match Oas_worker_named_cascade.default_config_path () with
+  match Cascade_oas_runner.default_config_path () with
   | Some config_path ->
     let overrides =
       Cascade_config.resolve_api_key_env ~config_path ~name:cascade_name

--- a/lib/cascade/cascade_legacy_runner.ml
+++ b/lib/cascade/cascade_legacy_runner.ml
@@ -1,4 +1,4 @@
-(** Oas_worker_cascade — Cascade metrics types, observation building, and recording.
+(** Cascade_legacy_runner — Cascade metrics types, observation building, and recording.
 
     Tracks per-cascade call counts, model selection distribution, fallback
     hops, and per-attempt latency/error detail. Aggregate counters stay

--- a/lib/cascade/cascade_legacy_runner.mli
+++ b/lib/cascade/cascade_legacy_runner.mli
@@ -1,4 +1,4 @@
-(** Oas_worker_cascade — cascade observation, metrics
+(** Cascade_legacy_runner — cascade observation, metrics
     capture, and a single-actor cascade-counter store.
 
     The .ml is 685 lines.  Splits into three concerns:
@@ -21,10 +21,10 @@
       maps.
 
     Sister facade {!Oas_worker} does
-    [include Oas_worker_cascade] to re-expose the constants
+    [include Cascade_legacy_runner] to re-expose the constants
     + observation type at the package boundary; this .mli
     therefore pins the surface that
-    {!Oas_worker_cascade.X} dotted callers and the
+    {!Cascade_legacy_runner.X} dotted callers and the
     cascade-include consumer both rely on.
 
     Internal helpers stay private at this boundary
@@ -228,7 +228,7 @@ val cascade_metrics_json : unit -> Yojson.Safe.t
     aggregated cascade-counter JSON snapshot for the
     operator dashboard.  Pinned because
     [lib/oas_worker.mli] re-exposes it via the
-    [include Oas_worker_cascade] cascade. *)
+    [include Cascade_legacy_runner] cascade. *)
 
 val cascade_observation_to_json :
   cascade_observation -> Yojson.Safe.t

--- a/lib/cascade/cascade_oas_runner.ml
+++ b/lib/cascade/cascade_oas_runner.ml
@@ -1,4 +1,4 @@
-(** Oas_worker_named_cascade — Eio context, cascade resolution, runtime MCP policy.
+(** Cascade_oas_runner — Eio context, cascade resolution, runtime MCP policy.
 
     Extracted from oas_worker_named.ml (God file decomposition).
     Provides cascade profile defaults, Eio context validation,

--- a/lib/cascade/cascade_oas_runner.mli
+++ b/lib/cascade/cascade_oas_runner.mli
@@ -1,4 +1,4 @@
-(** Oas_worker_named_cascade — Eio context, cascade resolution, runtime MCP policy.
+(** Cascade_oas_runner — Eio context, cascade resolution, runtime MCP policy.
 
     Extracted from oas_worker_named.ml (God file decomposition).
     Provides cascade profile defaults, Eio context validation,

--- a/lib/dune
+++ b/lib/dune
@@ -166,12 +166,10 @@
   tool_misc_admin
   tool_misc_web_search
   tool_misc_web_fetch
-  oas_worker_cascade
   oas_worker_exec_agent
   oas_worker_exec
   oas_worker_exec_checkpoint
   oas_worker_named
-  oas_worker_named_cascade
   meta_cognition_types
   meta_cognition_rules
   meta_cognition_snapshot

--- a/lib/llm_metric_bridge.ml
+++ b/lib/llm_metric_bridge.ml
@@ -44,7 +44,7 @@ let output_tokens_metric = Prometheus.metric_llm_provider_output_tokens
 (** Emit a single HTTP status observation to the Prometheus counter.
 
     Exposed so that per-call metrics sinks (e.g. the cascade-observation
-    capture in [Oas_worker_cascade]) can forward [on_http_status] to the
+    capture in [Cascade_legacy_runner]) can forward [on_http_status] to the
     same counter without duplicating the label shape.  This is the
     single source of truth for the label key names. *)
 let emit_http_status ~provider ~model_id ~status =
@@ -170,7 +170,7 @@ let emit_request_latency_clamped ~model_id ~reason =
 (** Emit a single latency observation to the Prometheus histogram.
 
     Exposed so that per-call metrics sinks (e.g. the cascade-observation
-    capture in [Oas_worker_cascade]) can forward [on_request_end] to the
+    capture in [Cascade_legacy_runner]) can forward [on_request_end] to the
     same histogram without duplicating the label shape.  This is the
     single source of truth for the label key names. *)
 let emit_request_latency ~model_id ~latency_ms =

--- a/lib/local/worker_container.ml
+++ b/lib/local/worker_container.ml
@@ -451,9 +451,9 @@ let build_resume_config ~worker_name ~provider ~model_id ~system_prompt ~tools
       system_prompt = Some system_prompt;
       max_tokens = Some (local_worker_max_tokens ());
       max_turns;
-      temperature = Some Oas_worker_cascade.worker_temperature;
-      top_p = Some Oas_worker_cascade.worker_top_p;
-      top_k = Some Oas_worker_cascade.worker_top_k;
+      temperature = Some Cascade_legacy_runner.worker_temperature;
+      top_p = Some Cascade_legacy_runner.worker_top_p;
+      top_k = Some Cascade_legacy_runner.worker_top_k;
       (* min_p is effectively disabled (0.0) and some cloud providers
          reject the field itself even when the value is a no-op. *)
       min_p = None;
@@ -467,7 +467,7 @@ let build_resume_config ~worker_name ~provider ~model_id ~system_prompt ~tools
     | None ->
         { Agent_sdk.Guardrails.tool_filter =
             Agent_sdk.Guardrails.AllowList (oas_tool_names tools);
-          max_tool_calls_per_turn = Some Oas_worker_cascade.worker_max_tool_calls_per_turn;
+          max_tool_calls_per_turn = Some Cascade_legacy_runner.worker_max_tool_calls_per_turn;
         }
   in
   let options =

--- a/lib/mcp_server.ml
+++ b/lib/mcp_server.ml
@@ -537,13 +537,13 @@ let create_state_eio ~sw ~proc_mgr ~fs ~clock ~mono_clock ~net ~base_path =
      Missed when #10664 introduced the actor model. *)
   Session.start_loop registry ~sw;
   (* Same sweep miss as Session.start_loop above: PR #10730 introduced
-     [Oas_worker_cascade] as an Eio actor (mailbox + Promise.await) but
+     [Cascade_legacy_runner] as an Eio actor (mailbox + Promise.await) but
      never wired its [start_actor_if_needed] into a bootstrap path.
      [cascade_metrics_json ()] (called from [tool_unified.ml:summary_report],
      which the dashboard tool inspector hits) does
      [Stream.add Get_metrics_json u; Promise.await p]. Without an actor
      fiber draining [stream], the await blocks forever. *)
-  Oas_worker_cascade.start_actor_if_needed ~sw;
+  Cascade_legacy_runner.start_actor_if_needed ~sw;
   (* Wire notification harness: subscription events → session queues *)
   Subscriptions.set_session_push_fn (fun event ->
     Session.push_notification_to_active_agents registry ~event

--- a/lib/mcp_server.mli
+++ b/lib/mcp_server.mli
@@ -207,7 +207,7 @@ val create_state_eio :
   server_state
 (** Production bootstrap.  Wires every Eio handle into
     [Some], starts the [Session] actor consumer, starts
-    the {!Oas_worker_cascade} actor, and installs the
+    the {!Cascade_legacy_runner} actor, and installs the
     Subscriptions notification harness. *)
 
 (** {1 SSE broadcast} *)

--- a/lib/oas_worker.ml
+++ b/lib/oas_worker.ml
@@ -3,7 +3,7 @@
     Facade module: re-exports sub-modules for backward compatibility.
 
     Implementation split into:
-    - {!Oas_worker_cascade} — cascade metrics types, observation, recording
+    - {!Cascade_legacy_runner} — cascade metrics types, observation, recording
     - {!Oas_worker_exec} — config, build, run, run_with_masc_tools
     - {!Oas_worker_named} — run_named, run_model_by_label, convenience wrappers
 
@@ -12,5 +12,5 @@
 (* Oas_worker_exec defines [module Oas = Agent_sdk]; include it first
    so the alias is available for the .mli contract. *)
 include Oas_worker_exec
-include Oas_worker_cascade
+include Cascade_legacy_runner
 include Oas_worker_named

--- a/lib/oas_worker_exec.ml
+++ b/lib/oas_worker_exec.ml
@@ -2,7 +2,7 @@
 
     Contains the [config] type, [build], [run], and [run_with_masc_tools]
     functions. All model-selection and cascade logic lives in
-    {!Oas_worker_cascade} and {!Oas_worker_named}.
+    {!Cascade_legacy_runner} and {!Oas_worker_named}.
 
     @since God file decomposition — extracted from oas_worker.ml *)
 
@@ -91,7 +91,7 @@ type run_result = {
   trace_ref : Agent_sdk.Raw_trace.run_ref option;
   run_validation : Agent_sdk.Raw_trace.run_validation option;
   proof : Masc_mcp_cdal_runtime.Cdal_proof.t option;
-  cascade_observation : Oas_worker_cascade.cascade_observation option;
+  cascade_observation : Cascade_legacy_runner.cascade_observation option;
   stop_reason : stop_reason;
 }
 

--- a/lib/oas_worker_exec.mli
+++ b/lib/oas_worker_exec.mli
@@ -13,7 +13,7 @@
     pinned at this boundary.
 
     All model-selection and cascade logic lives in
-    {!Oas_worker_cascade} and {!Oas_worker_named}.
+    {!Cascade_legacy_runner} and {!Oas_worker_named}.
 
     Internal helpers stay private at this boundary
     ([lowercase_enum_case_name],
@@ -136,7 +136,7 @@ type run_result = {
   trace_ref : Agent_sdk.Raw_trace.run_ref option;
   run_validation : Agent_sdk.Raw_trace.run_validation option;
   proof : Masc_mcp_cdal_runtime.Cdal_proof.t option;
-  cascade_observation : Oas_worker_cascade.cascade_observation option;
+  cascade_observation : Cascade_legacy_runner.cascade_observation option;
   stop_reason : stop_reason;
 }
 

--- a/lib/oas_worker_exec_agent.ml
+++ b/lib/oas_worker_exec_agent.ml
@@ -120,10 +120,10 @@ let default_config
     max_idle_turns = 3;
     stream_idle_timeout_s = None;
     max_execution_time_s = None;
-    max_tokens = Oas_worker_cascade.default_max_tokens;
+    max_tokens = Cascade_legacy_runner.default_max_tokens;
     max_input_tokens = None;
     max_cost_usd = None;
-    temperature = Oas_worker_cascade.default_temperature;
+    temperature = Cascade_legacy_runner.default_temperature;
     hooks = None;
     context_reducer = None;
     guardrails = None;

--- a/lib/oas_worker_named.ml
+++ b/lib/oas_worker_named.ml
@@ -12,7 +12,7 @@ open Result.Syntax
 (* Sub-module includes (God file decomposition).
    Each sub-module is self-contained; the facade re-exports everything
    so existing callers do not need qualification. *)
-include Oas_worker_named_cascade
+include Cascade_oas_runner
 include Cascade_error_classify
 include Cascade_attempt_fsm
 
@@ -159,8 +159,8 @@ let run_named
     ?(max_turns = 20)
     ?(max_idle_turns = 3)
     ?stream_idle_timeout_s
-    ?(temperature = Oas_worker_cascade.default_temperature)
-    ?(max_tokens = Oas_worker_cascade.default_max_tokens)
+    ?(temperature = Cascade_legacy_runner.default_temperature)
+    ?(max_tokens = Cascade_legacy_runner.default_max_tokens)
     ?max_input_tokens
     ?max_cost_usd
     ?wait_timeout_sec
@@ -358,7 +358,7 @@ let run_named
                 }))
   | _ ->
   let capture, _metrics =
-    Oas_worker_cascade.cascade_metrics_for_candidates ~candidate_cfgs ()
+    Cascade_legacy_runner.cascade_metrics_for_candidates ~candidate_cfgs ()
   in
   let cascade_strategy_name_ref = ref None in
   let name = Printf.sprintf "oas-%s" cascade_name in
@@ -666,12 +666,12 @@ let run_named
         | None -> Keeper_types.No_providers_available
       in
       let observation =
-        Oas_worker_cascade.cascade_observation_with_metrics
+        Cascade_legacy_runner.cascade_observation_with_metrics
           ~cascade_name:error_cascade_name
           ?strategy:!cascade_strategy_name_ref ~configured_labels
           ~candidate_cfgs ~selected_model_raw:None ~capture ()
       in
-      Oas_worker_cascade.record_cascade ~keeper_name
+      Cascade_legacy_runner.record_cascade ~keeper_name
         ~cascade_name:error_cascade_name
         ~outcome:`Failure ~observation:(Some observation) ();
       let terminal_error =
@@ -758,14 +758,14 @@ let run_named
           ~latency_ms:attempt_latency_ms ());
         (* FSM: Call_ok → Accept *)
         let observation =
-          Oas_worker_cascade.cascade_observation_with_metrics
+          Cascade_legacy_runner.cascade_observation_with_metrics
             ~cascade_name:error_cascade_name
             ?strategy:!cascade_strategy_name_ref ~configured_labels
             ~candidate_cfgs ~selected_model_raw:(Some result.response.model)
             ~capture ()
         in
         let result = { result with cascade_observation = Some observation } in
-        Oas_worker_cascade.record_cascade ~keeper_name
+        Cascade_legacy_runner.record_cascade ~keeper_name
           ~cascade_name:error_cascade_name
           ~outcome:`Success ~observation:(Some observation) ();
         on_success ~provider_key:provider_health_key;
@@ -789,14 +789,14 @@ let run_named
         (match Cascade_fsm.decide ~accept_on_exhaustion:false ~is_last outcome with
          | Cascade_fsm.Accept_on_exhaustion { response; _ } ->
            let observation =
-             Oas_worker_cascade.cascade_observation_with_metrics
+             Cascade_legacy_runner.cascade_observation_with_metrics
                ~cascade_name:error_cascade_name
                ?strategy:!cascade_strategy_name_ref ~configured_labels
                ~candidate_cfgs ~selected_model_raw:(Some response.model)
                ~capture ()
            in
            let result = { result with cascade_observation = Some observation } in
-           Oas_worker_cascade.record_cascade ~keeper_name
+           Cascade_legacy_runner.record_cascade ~keeper_name
              ~cascade_name:error_cascade_name
              ~outcome:`Success ~observation:(Some observation) ();
            on_success ~provider_key:provider_health_key;
@@ -806,7 +806,7 @@ let run_named
               next tier.  Tagged [cascade-fallback] so dashboard filters
               can distinguish recovery-in-progress from hard failures. *)
            Log.Misc.info "[cascade-fallback] cascade %s: accept rejected %s (%s), trying next" cascade_name provider_cfg.model_id reason;
-           Oas_worker_cascade.record_fallback_event capture ~candidate_cfgs
+           Cascade_legacy_runner.record_fallback_event capture ~candidate_cfgs
              ~from_model:provider_cfg.model_id ~to_model:"next" ~reason;
            (* The rejected response is not trusted progress.  Resuming
               from its checkpoint can turn a fallback provider into a
@@ -814,13 +814,13 @@ let run_named
            try_cascade ?resume_checkpoint rest new_err
          | Cascade_fsm.Exhausted _ ->
            let observation =
-             Oas_worker_cascade.cascade_observation_with_metrics
+             Cascade_legacy_runner.cascade_observation_with_metrics
                ~cascade_name:error_cascade_name
                ?strategy:!cascade_strategy_name_ref ~configured_labels
                ~candidate_cfgs ~selected_model_raw:(Some result.response.model)
                ~capture ()
            in
-           Oas_worker_cascade.record_cascade ~keeper_name
+           Cascade_legacy_runner.record_cascade ~keeper_name
              ~cascade_name:error_cascade_name
              ~outcome:`Rejected ~observation:(Some observation) ();
            Log.Misc.error "cascade %s exhausted: all tiers rejected by accept predicate (last model=%s, reason=%s)"
@@ -837,13 +837,13 @@ let run_named
            (* Should be unreachable with accept_on_exhaustion:false, but handle gracefully *)
            Log.Misc.warn "cascade %s: unexpected Accept in Accept_rejected branch (model=%s)" cascade_name resp.model;
            let observation =
-             Oas_worker_cascade.cascade_observation_with_metrics
+             Cascade_legacy_runner.cascade_observation_with_metrics
                ~cascade_name:error_cascade_name
                ?strategy:!cascade_strategy_name_ref ~configured_labels
                ~candidate_cfgs ~selected_model_raw:(Some resp.model) ~capture ()
            in
            let result = { result with cascade_observation = Some observation } in
-           Oas_worker_cascade.record_cascade ~keeper_name
+           Cascade_legacy_runner.record_cascade ~keeper_name
              ~cascade_name:error_cascade_name
              ~outcome:`Success ~observation:(Some observation) ();
            on_success ~provider_key:provider_health_key;
@@ -1018,18 +1018,18 @@ let run_named
                   "[cascade-fallback] cascade %s: %s failed (%s%s), trying next"
                   cascade_name provider_cfg.model_id class_label
                   (Agent_sdk.Error.to_string sdk_err);
-              Oas_worker_cascade.record_fallback_event capture ~candidate_cfgs
+              Cascade_legacy_runner.record_fallback_event capture ~candidate_cfgs
                 ~from_model:provider_cfg.model_id ~to_model:"next"
                 ~reason:(class_label ^ Agent_sdk.Error.to_string sdk_err);
               try_cascade ?resume_checkpoint:next_resume rest new_err
             | Cascade_fsm.Exhausted _ ->
               let observation =
-                Oas_worker_cascade.cascade_observation_with_metrics
+                Cascade_legacy_runner.cascade_observation_with_metrics
                   ~cascade_name:error_cascade_name
                   ?strategy:!cascade_strategy_name_ref ~configured_labels
                   ~candidate_cfgs ~selected_model_raw:None ~capture ()
               in
-              Oas_worker_cascade.record_cascade ~keeper_name
+              Cascade_legacy_runner.record_cascade ~keeper_name
                 ~cascade_name:error_cascade_name
                 ~outcome:`Failure ~observation:(Some observation) ();
               Log.Misc.error "cascade %s exhausted: all tiers failed (last model=%s, error=%s)"
@@ -1046,12 +1046,12 @@ let run_named
          | None ->
            (* Non-API error (agent, config, etc.) — not cascadeable *)
            let observation =
-             Oas_worker_cascade.cascade_observation_with_metrics
+             Cascade_legacy_runner.cascade_observation_with_metrics
                ~cascade_name:error_cascade_name
                ?strategy:!cascade_strategy_name_ref ~configured_labels
                ~candidate_cfgs ~selected_model_raw:None ~capture ()
            in
-           Oas_worker_cascade.record_cascade ~keeper_name
+           Cascade_legacy_runner.record_cascade ~keeper_name
              ~cascade_name:error_cascade_name
              ~outcome:`Failure ~observation:(Some observation) ();
            Log.Misc.error "cascade %s: non-cascadable error from %s: %s"
@@ -1171,12 +1171,12 @@ let run_named
   in
   let cascade_exhausted_after_filter ~cycle =
     let observation =
-      Oas_worker_cascade.cascade_observation_with_metrics
+      Cascade_legacy_runner.cascade_observation_with_metrics
         ~cascade_name:error_cascade_name
         ?strategy:!cascade_strategy_name_ref ~configured_labels
         ~candidate_cfgs ~selected_model_raw:None ~capture ()
     in
-    Oas_worker_cascade.record_cascade ~keeper_name
+    Cascade_legacy_runner.record_cascade ~keeper_name
       ~cascade_name:error_cascade_name
       ~outcome:`Failure ~observation:(Some observation) ();
     Error
@@ -1262,8 +1262,8 @@ let run_model_by_label
     ?(max_turns = 20)
     ?(max_idle_turns = 3)
     ?stream_idle_timeout_s
-    ?(temperature = Oas_worker_cascade.default_temperature)
-    ?(max_tokens = Oas_worker_cascade.default_max_tokens)
+    ?(temperature = Cascade_legacy_runner.default_temperature)
+    ?(max_tokens = Cascade_legacy_runner.default_max_tokens)
     ?max_input_tokens
     ?max_cost_usd
     ?wait_timeout_sec
@@ -1345,8 +1345,8 @@ let run_named_with_masc_tools
     ~(dispatch : name:string -> args:Yojson.Safe.t -> Tool_result.t)
     ?(max_turns = 20)
     ?stream_idle_timeout_s
-    ?(temperature = Oas_worker_cascade.default_temperature)
-    ?(max_tokens = Oas_worker_cascade.default_max_tokens)
+    ?(temperature = Cascade_legacy_runner.default_temperature)
+    ?(max_tokens = Cascade_legacy_runner.default_max_tokens)
     ?max_input_tokens
     ?max_cost_usd
     ?wait_timeout_sec
@@ -1396,8 +1396,8 @@ let run_model_with_masc_tools
     ~(dispatch : name:string -> args:Yojson.Safe.t -> Tool_result.t)
     ?(max_turns = 20)
     ?stream_idle_timeout_s
-    ?(temperature = Oas_worker_cascade.default_temperature)
-    ?(max_tokens = Oas_worker_cascade.default_max_tokens)
+    ?(temperature = Cascade_legacy_runner.default_temperature)
+    ?(max_tokens = Cascade_legacy_runner.default_max_tokens)
     ?max_input_tokens
     ?max_cost_usd
     ?wait_timeout_sec

--- a/lib/oas_worker_named.mli
+++ b/lib/oas_worker_named.mli
@@ -5,13 +5,13 @@
     with optional MASC tool bridging variants.
 
     The facade [include]s the three sub-modules:
-    - {!Oas_worker_named_cascade} — Eio context, cascade resolution, runtime MCP policy
+    - {!Cascade_oas_runner} — Eio context, cascade resolution, runtime MCP policy
     - {!Cascade_error_classify} — masc_internal_error type, error conversion, codex CLI preflight
     - {!Cascade_attempt_fsm} — SDK error to FSM outcome, session/resumption analysis
 
     @since God file decomposition — extracted from oas_worker.ml *)
 
-include module type of Oas_worker_named_cascade
+include module type of Cascade_oas_runner
 include module type of Cascade_error_classify
 include module type of Cascade_attempt_fsm
 

--- a/lib/server/server_openai_compat.ml
+++ b/lib/server/server_openai_compat.ml
@@ -138,9 +138,9 @@ let handle_chat_completions ~config ~sw ~clock (body : string)
       | None -> `List []
     in
     let max_tokens = Safe_ops.json_int
-      ~default:Oas_worker_cascade.default_max_tokens "max_tokens" json in
+      ~default:Cascade_legacy_runner.default_max_tokens "max_tokens" json in
     let temperature = Safe_ops.json_float
-      ~default:Oas_worker_cascade.default_temperature "temperature" json in
+      ~default:Cascade_legacy_runner.default_temperature "temperature" json in
     if model = "" then
       (`Bad_request,
        error_response ~status:"invalid_request_error"

--- a/lib/server/server_openai_compat.mli
+++ b/lib/server/server_openai_compat.mli
@@ -70,8 +70,8 @@ val handle_chat_completions :
 
     | Field | Default |
     |---|---|
-    | [max_tokens] | {!Oas_worker_cascade.default_max_tokens} |
-    | [temperature] | {!Oas_worker_cascade.default_temperature} |
+    | [max_tokens] | {!Cascade_legacy_runner.default_max_tokens} |
+    | [temperature] | {!Cascade_legacy_runner.default_temperature} |
     | [system] (concat of all system messages) | empty string |
 
     {2 Response shape}

--- a/lib/tool_local_runtime_verify.ml
+++ b/lib/tool_local_runtime_verify.ml
@@ -160,7 +160,7 @@ let probe_chat_completion_compatible
           ~kind:Llm_provider.Provider_config.OpenAI_compat
           ~model_id ~base_url:endpoint.url
           ~request_path:Masc_network_defaults.openai_chat_completions_path
-          ~max_tokens:1 ~temperature:Oas_worker_cascade.deterministic_temperature ()
+          ~max_tokens:1 ~temperature:Cascade_legacy_runner.deterministic_temperature ()
       in
       let messages : Oas_types.message list =
         [

--- a/lib/verifier_oas.ml
+++ b/lib/verifier_oas.ml
@@ -120,7 +120,7 @@ let verify (req : verification_request) : (verdict, string) result =
         ~masc_tools:[report_verdict_schema]
         ~dispatch
         ~max_turns:1
-        ~temperature:Oas_worker_cascade.deterministic_temperature
+        ~temperature:Cascade_legacy_runner.deterministic_temperature
         ~max_tokens:200
         ~approval:Approval_callbacks.auto_approve
         ()

--- a/lib/worker_oas.ml
+++ b/lib/worker_oas.ml
@@ -57,9 +57,9 @@ let agent_config_of_worker_meta
     system_prompt = Some system_prompt;
     max_tokens = Some max_tokens;
     max_turns = effective_max_turns meta;
-    temperature = Some Oas_worker_cascade.worker_temperature;
-    top_p = Some Oas_worker_cascade.worker_top_p;
-    top_k = Some Oas_worker_cascade.worker_top_k;
+    temperature = Some Cascade_legacy_runner.worker_temperature;
+    top_p = Some Cascade_legacy_runner.worker_top_p;
+    top_k = Some Cascade_legacy_runner.worker_top_k;
     (* min_p intentionally omitted: the constant is 0.0 (no-op) and some
        cloud providers (Groq, GLM) reject the field itself with
        "Invalid request: property 'min_p' is unsupported". OAS capability
@@ -162,7 +162,7 @@ let build_agent
     | None ->
         {
           Agent_sdk.Guardrails.tool_filter = AllowList tool_names;
-          max_tool_calls_per_turn = Some Oas_worker_cascade.worker_max_tool_calls_per_turn;
+          max_tool_calls_per_turn = Some Cascade_legacy_runner.worker_max_tool_calls_per_turn;
         }
   in
   let builder =
@@ -171,9 +171,9 @@ let build_agent
     |> Agent_sdk.Builder.with_system_prompt system_prompt
     |> (fun b -> match config.max_tokens with Some n -> Agent_sdk.Builder.with_max_tokens n b | None -> b)
     |> Agent_sdk.Builder.with_max_turns config.max_turns
-    |> Agent_sdk.Builder.with_temperature Oas_worker_cascade.worker_temperature
-    |> Agent_sdk.Builder.with_top_p Oas_worker_cascade.worker_top_p
-    |> Agent_sdk.Builder.with_top_k Oas_worker_cascade.worker_top_k
+    |> Agent_sdk.Builder.with_temperature Cascade_legacy_runner.worker_temperature
+    |> Agent_sdk.Builder.with_top_p Cascade_legacy_runner.worker_top_p
+    |> Agent_sdk.Builder.with_top_k Cascade_legacy_runner.worker_top_k
     (* with_min_p intentionally omitted — see agent_config_of_worker_meta
        above for the reason. The worker_min_p constant is 0.0 (a no-op)
        and cloud providers (Groq, GLM) reject the field itself. *)

--- a/test/test_cascade_per_candidate_telemetry.ml
+++ b/test/test_cascade_per_candidate_telemetry.ml
@@ -1,7 +1,7 @@
 (** test_cascade_per_candidate_telemetry — pin the JSON shape contract
     of the per-candidate cascade attempt telemetry payload emitted into
     [system_log_YYYY-MM-DD.jsonl] from
-    [Oas_worker_cascade.cascade_attempt_terminal_event_json].
+    [Cascade_legacy_runner.cascade_attempt_terminal_event_json].
 
     The shape is the operator-facing contract: when a cascade exhausts
     all 14 candidates and [selected_model: null] lands in the decision
@@ -39,7 +39,7 @@ let assoc_field key json =
 
 let test_success_shape () =
   let json =
-    Oas_worker_cascade.cascade_attempt_terminal_event_json
+    Cascade_legacy_runner.cascade_attempt_terminal_event_json
       ~model_id:"glm-coding:glm-4.7"
       ~model_label:(Some "glm-coding:glm-4.7") ~latency_ms:(Some 35921)
       ~error:None ()
@@ -78,7 +78,7 @@ let test_success_shape () =
 
 let test_failure_shape () =
   let json =
-    Oas_worker_cascade.cascade_attempt_terminal_event_json
+    Cascade_legacy_runner.cascade_attempt_terminal_event_json
       ~model_id:"gemini_cli:gemini-2.5-pro" ~model_label:None
       ~latency_ms:(Some 1200)
       ~error:(Some "OAS budget timeout after 600.0s") ()
@@ -102,7 +102,7 @@ let test_failure_with_no_latency () =
   (* Provider that never started a request (e.g. CLI exit 1, DNS fail) —
      latency_ms is None, error is Some. Outcome must still be "failure". *)
   let json =
-    Oas_worker_cascade.cascade_attempt_terminal_event_json
+    Cascade_legacy_runner.cascade_attempt_terminal_event_json
       ~model_id:"codex_cli:gpt-5.3-codex-spark"
       ~model_label:(Some "codex_cli:gpt-5.3-codex-spark") ~latency_ms:None
       ~error:(Some "rollout thread not found") ()
@@ -116,7 +116,7 @@ let test_failure_with_no_latency () =
 
 let test_slot_phase_shape () =
   let json =
-    Oas_worker_cascade.cascade_attempt_terminal_event_json
+    Cascade_legacy_runner.cascade_attempt_terminal_event_json
       ~slot_release_at_phase:"productive_phase_exhausted"
       ~productive_phase_elapsed_ms:174000 ~retry_phase_elapsed_ms:0
       ~model_id:"anthropic:claude-sonnet-4.5"

--- a/test/test_oas_worker.ml
+++ b/test/test_oas_worker.ml
@@ -260,7 +260,7 @@ let with_cascade_attempt_liveness mode f =
     f
 
 let flush_cascade_actor () =
-  ignore (Oas_worker_cascade.cascade_metrics_json () : Yojson.Safe.t)
+  ignore (Cascade_legacy_runner.cascade_metrics_json () : Yojson.Safe.t)
 
 let with_liveness_off f = with_cascade_attempt_liveness "off" f
 
@@ -731,16 +731,16 @@ let find_cascade_metric_entry name (json : Yojson.Safe.t) =
 
 let test_cascade_metrics_concurrent_recording () =
   with_temp_masc_base_path "test_cascade_metrics_concurrent" @@ fun () ->
-  Masc_mcp.Oas_worker_cascade.reset_cascade_counters_for_test ();
+  Masc_mcp.Cascade_legacy_runner.reset_cascade_counters_for_test ();
   Fun.protect
     ~finally:(fun () ->
-      Masc_mcp.Oas_worker_cascade.reset_cascade_counters_for_test ())
+      Masc_mcp.Cascade_legacy_runner.reset_cascade_counters_for_test ())
     (fun () ->
       Eio.Fiber.all
         (List.init 8 (fun _ ->
              fun () ->
                for _ = 1 to 25 do
-                 Masc_mcp.Oas_worker_cascade.record_cascade
+                 Masc_mcp.Cascade_legacy_runner.record_cascade
                    ~cascade_name:(internal_cascade_name "concurrent-cascade")
                    ~observation:None
                    ~outcome:`Success
@@ -761,31 +761,31 @@ let test_cascade_metrics_concurrent_recording () =
 
 let test_cascade_metrics_evicts_lowest_call_key () =
   with_temp_masc_base_path "test_cascade_metrics_evicts" @@ fun () ->
-  Masc_mcp.Oas_worker_cascade.reset_cascade_counters_for_test ();
+  Masc_mcp.Cascade_legacy_runner.reset_cascade_counters_for_test ();
   Fun.protect
     ~finally:(fun () ->
-      Masc_mcp.Oas_worker_cascade.reset_cascade_counters_for_test ())
+      Masc_mcp.Cascade_legacy_runner.reset_cascade_counters_for_test ())
     (fun () ->
-      Masc_mcp.Oas_worker_cascade.record_cascade
+      Masc_mcp.Cascade_legacy_runner.record_cascade
         ~cascade_name:(internal_cascade_name "victim-key")
         ~observation:None
         ~outcome:`Success
         ();
       for i = 1 to 254 do
         let name = Printf.sprintf "stable-%03d" i in
-        Masc_mcp.Oas_worker_cascade.record_cascade
+        Masc_mcp.Cascade_legacy_runner.record_cascade
           ~cascade_name:(internal_cascade_name name)
           ~observation:None
           ~outcome:`Success
           ();
-        Masc_mcp.Oas_worker_cascade.record_cascade
+        Masc_mcp.Cascade_legacy_runner.record_cascade
           ~cascade_name:(internal_cascade_name name)
           ~observation:None
           ~outcome:`Success
           ()
       done;
       for _ = 1 to 3 do
-        Masc_mcp.Oas_worker_cascade.record_cascade
+        Masc_mcp.Cascade_legacy_runner.record_cascade
           ~cascade_name:(internal_cascade_name "hot-key")
           ~observation:None
           ~outcome:`Success
@@ -793,7 +793,7 @@ let test_cascade_metrics_evicts_lowest_call_key () =
       done;
       let before = Yojson.Safe.Util.to_list (Oas_worker.cascade_metrics_json ()) in
       Alcotest.(check int) "table capped before admit" 256 (List.length before);
-      Masc_mcp.Oas_worker_cascade.record_cascade
+      Masc_mcp.Cascade_legacy_runner.record_cascade
         ~cascade_name:(internal_cascade_name "new-key")
         ~observation:None
         ~outcome:`Success
@@ -815,7 +815,7 @@ let test_cascade_audit_persists_observation () =
   let base = temp_dir "test_cascade_audit" in
   let old_base_path = Sys.getenv_opt "MASC_BASE_PATH" in
   let old_base_path_input = Sys.getenv_opt "MASC_BASE_PATH_INPUT" in
-  Masc_mcp.Oas_worker_cascade.reset_cascade_counters_for_test ();
+  Masc_mcp.Cascade_legacy_runner.reset_cascade_counters_for_test ();
   Fun.protect
     ~finally:(fun () ->
       (match old_base_path with
@@ -824,12 +824,12 @@ let test_cascade_audit_persists_observation () =
       (match old_base_path_input with
        | Some value -> Unix.putenv "MASC_BASE_PATH_INPUT" value
        | None -> Unix.putenv "MASC_BASE_PATH_INPUT" "");
-      Masc_mcp.Oas_worker_cascade.reset_cascade_counters_for_test ();
+      Masc_mcp.Cascade_legacy_runner.reset_cascade_counters_for_test ();
       cleanup_dir base)
     (fun () ->
       Unix.putenv "MASC_BASE_PATH" base;
       Unix.putenv "MASC_BASE_PATH_INPUT" base;
-      let observation : Masc_mcp.Oas_worker_cascade.cascade_observation =
+      let observation : Masc_mcp.Cascade_legacy_runner.cascade_observation =
         {
           cascade_name =
             Masc_mcp.Keeper_cascade_profile.Runtime_name "audit-cascade";
@@ -873,7 +873,7 @@ let test_cascade_audit_persists_observation () =
           attempt_details_source = "oas_metrics_callbacks";
         }
       in
-      Masc_mcp.Oas_worker_cascade.record_cascade
+      Masc_mcp.Cascade_legacy_runner.record_cascade
         ~keeper_name:"keeper-glm-agent-test"
         ~cascade_name:(internal_cascade_name "audit-cascade")
         ~observation:(Some observation)
@@ -2238,9 +2238,9 @@ let make_kimi_cli_provider_cfg ?(model_id = "kimi-for-coding") () =
     ()
 
 let test_cascade_provider_labels_keep_glm_and_glm_coding_distinct () =
-  let glm = Masc_mcp.Oas_worker_cascade.provider_name_of_config
+  let glm = Masc_mcp.Cascade_legacy_runner.provider_name_of_config
       (make_glm_provider_cfg ()) in
-  let glm_coding = Masc_mcp.Oas_worker_cascade.provider_name_of_config
+  let glm_coding = Masc_mcp.Cascade_legacy_runner.provider_name_of_config
       (make_glm_provider_cfg ~base_url:Llm_provider.Zai_catalog.coding_base_url ()) in
   Alcotest.(check string) "general GLM label" "glm" glm;
   Alcotest.(check string) "coding GLM label" "glm-coding" glm_coding
@@ -2312,18 +2312,18 @@ let test_provider_attempt_timeout_leaves_unconstrained_last_to_outer_budget () =
        (make_openai_compat_provider_cfg ()))
 
 let test_cascade_provider_labels_preserve_registered_openai_compat_family () =
-  let provider_name = Masc_mcp.Oas_worker_cascade.provider_name_of_config
+  let provider_name = Masc_mcp.Cascade_legacy_runner.provider_name_of_config
       (make_openrouter_provider_cfg ()) in
-  let model_label = Masc_mcp.Oas_worker_cascade.model_label_of_config
+  let model_label = Masc_mcp.Cascade_legacy_runner.model_label_of_config
       (make_openrouter_provider_cfg ()) in
   Alcotest.(check string) "openrouter provider name" "openrouter" provider_name;
   Alcotest.(check string) "openrouter model label"
     "openrouter:anthropic/claude-3.5" model_label
 
 let test_cascade_provider_labels_detect_kimi_from_endpoint_metadata () =
-  let provider_name = Masc_mcp.Oas_worker_cascade.provider_name_of_config
+  let provider_name = Masc_mcp.Cascade_legacy_runner.provider_name_of_config
       (make_kimi_provider_cfg ()) in
-  let model_label = Masc_mcp.Oas_worker_cascade.model_label_of_config
+  let model_label = Masc_mcp.Cascade_legacy_runner.model_label_of_config
       (make_kimi_provider_cfg ()) in
   Alcotest.(check string) "kimi provider name" "kimi" provider_name;
   Alcotest.(check string) "kimi model label" "kimi:kimi-k2.5" model_label
@@ -5382,7 +5382,7 @@ let () =
     ~clock:(Eio.Stdenv.clock env);
   Eio_guard.enable ();
   Eio.Switch.run @@ fun sw ->
-  Masc_mcp.Oas_worker_cascade.start_actor_if_needed ~sw;
+  Masc_mcp.Cascade_legacy_runner.start_actor_if_needed ~sw;
   Masc_mcp.Masc_eio_env.reset_for_test ();
   Alcotest.run "OAS Worker" [
     "direct_run_env", [


### PR DESCRIPTION
## Summary

RFC-0047 Phase 3b: move 2 cascade entry files (provider rotation + cascade observation/metrics) from `oas_*` family into `lib/cascade/`.

Follows Phase 3a (#14281, merged) which moved 3 leaves.

## Renames

| From | To | LOC |
|---|---|---|
| `lib/oas_worker_named_cascade.ml` (+`.mli`) | `lib/cascade/cascade_oas_runner.ml` (+`.mli`) | 549 |
| `lib/oas_worker_cascade.ml` (+`.mli`) | `lib/cascade/cascade_legacy_runner.ml` (+`.mli`) | 767 |

~1316 LOC migrated to correct layer.

## Intra-family deps (verified pre-move)

- 0 deps between the 2 files.
- 0 deps on Phase 3a-moved files (`Cascade_attempt_fsm`, `Cascade_error_classify`, `Cascade_transport`).

Independent move possible in single PR.

## Caller updates

25 files, ~30 module-name references replaced via `perl -i`:
- `Oas_worker_named_cascade` → `Cascade_oas_runner`
- `Oas_worker_cascade` → `Cascade_legacy_runner`

## Build infrastructure

`lib/dune` `private_modules` pruned of 2 entries (`oas_worker_cascade`, `oas_worker_named_cascade`). New `lib/cascade/cascade_*.ml` files are public.

## Verification

- [x] `dune build lib/`: exit 0 after rebase to current main (`0d79542d6c` includes #14284 main-blocker fix and #14285 agent_sdk SHA bump).
- [ ] `dune runtest`: deferred to CI (local test runner remained degraded from earlier session's parallel-build storm).
- [x] Rebased on fresh `origin/main`.

## Status

**Draft.** Awaiting `human-approved-ready` label per draft-guard policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
