### PR TITLE
refactor(dashboard): drop 4 explainer-prose blocks across roster/keeper/memory/connector

### DIFF
--- a/dashboard/src/components/agent-roster.ts
+++ b/dashboard/src/components/agent-roster.ts
@@ -609,10 +609,7 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
 
           <div class="monitor-muted-panel p-3.5 md:p-4">
             <div class="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
-              <div class="flex flex-col gap-1">
-                <div class="text-2xs font-semibold tracking-[var(--track-caps)] text-[var(--color-fg-secondary)] uppercase">운영 상태</div>
-                <p class="m-0 text-xs leading-normal text-[var(--color-fg-muted)]">live runtime 신호로 먼저 걸러 보고, 필요할 때만 세부 상태와 최근 근거를 확인합니다.</p>
-              </div>
+              <div class="text-2xs font-semibold tracking-[var(--track-caps)] text-[var(--color-fg-secondary)] uppercase">운영 상태</div>
               <${FilterChips}
                 chips=${statusChips}
                 value=${filter}

--- a/dashboard/src/components/connector-status.test.ts
+++ b/dashboard/src/components/connector-status.test.ts
@@ -683,10 +683,9 @@ describe('ConnectorStatusPanel', () => {
     const text = container.textContent?.replace(/\s+/g, ' ').trim() ?? ''
     expect(text).toContain('사이드카 미시작')
     expect(text).toContain('cd sidecars/discord-bot && ./run.sh')
-    expect(text).toContain('원인: 사이드카 status 파일이')
+    expect(text).toContain('사이드카 status 파일이')
     expect(text).toContain('/tmp/discord_status.json')
     expect(text).toContain('관찰되지 않았습니다')
-    expect(text).toContain('다음:')
     expect(text).toContain('Start')
     expect(text).toContain('status')
     expect(text).toContain('tail logs')

--- a/dashboard/src/components/connector-status.ts
+++ b/dashboard/src/components/connector-status.ts
@@ -995,12 +995,7 @@ function ConnectorLivePanel({
                   </div>
                 </div>
                 <div class="text-2xs text-[var(--color-status-warn)]/80">
-                  <div>
-                    <${BoldLabel}>원인: </${BoldLabel}> 사이드카 status 파일이 <${Tk}>${connector?.status_path || `sidecars/${connectorId}-bot/status.json`}<//> 에서 관찰되지 않았습니다.
-                  </div>
-                  <div class="mt-1">
-                    <${BoldLabel}>다음: </${BoldLabel}> <strong>Start</strong> 버튼으로 백엔드를 통해 실행하거나, 아래 명령을 복사해 터미널에서 실행하세요. 오프라인이 지속되면 <strong>status</strong> 와 <strong>tail logs</strong> 를 사용하세요.
-                  </div>
+                  사이드카 status 파일이 <${Tk}>${connector?.status_path || `sidecars/${connectorId}-bot/status.json`}<//> 에서 관찰되지 않았습니다.
                 </div>
                 <div class="mt-2 grid grid-cols-1 gap-1.5">
                   <${CopyableCode}

--- a/dashboard/src/components/keeper-shared.ts
+++ b/dashboard/src/components/keeper-shared.ts
@@ -230,11 +230,11 @@ export function KeeperDiagnosticSummary({
           : null}
         ${busy ? html`<${DiagChip} label="refreshing" />` : null}
       </div>
-      <div class="text-xs text-[var(--color-fg-primary)] leading-relaxed">
-        ${diagnostic?.continuity_summary
-          ?? diagnostic?.summary
-          ?? '자동 판단 필드는 기본으로 채우지 않습니다. 필요할 때만 상태를 불러오세요.'}
-      </div>
+      ${diagnostic?.continuity_summary || diagnostic?.summary
+        ? html`<div class="text-xs text-[var(--color-fg-primary)] leading-relaxed">
+            ${diagnostic.continuity_summary ?? diagnostic.summary}
+          </div>`
+        : null}
       <div class="text-xs text-[var(--color-fg-primary)] leading-relaxed mt-1">
         응답: ${diagnostic?.last_reply_status ?? '미조회'}
         ${diagnostic?.last_reply_at ? html` -- ${formatTime(diagnostic.last_reply_at)}` : null}

--- a/dashboard/src/components/memory-subsystems.ts
+++ b/dashboard/src/components/memory-subsystems.ts
@@ -667,12 +667,6 @@ export function MemorySubsystems({ focus = 'overview' }: { readonly focus?: Memo
 
   return html`
     <div class="space-y-6">
-      <div class="rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] px-3 py-2 text-xs text-[var(--color-fg-muted)]">
-        이 화면은 <span class="text-[var(--color-fg-muted)] font-medium">global memory surface</span>만 보여줍니다.
-        institution episodes와 Hebbian graph는 여기서 보고,
-        keeper checkpoint/history/memory bank는 Keeper Detail에서 확인합니다.
-      </div>
-
       ${showMemoryEntries ? html`
         <${MemoryEntriesPanel}
           entries=${memoryEntries}


### PR DESCRIPTION
## Summary

Continues the dashboard cleanup track (#14219, #14224, #14275, #14280, #14283). Removes prose that explains what the UI does or what scope the screen has, while leaving operational diagnostic info intact.

## Removed

| Surface | Removed text | Why |
|---|---|---|
| \`agent-roster\` 운영 상태 header | \"live runtime 신호로 먼저 걸러 보고, 필요할 때만 세부 상태와 최근 근거를 확인합니다.\" | The \`FilterChips\` on the same row are the actual control. The eyebrow \"운영 상태\" already names what the chips filter. |
| \`keeper-shared\` KeeperDiagnostic body | \"자동 판단 필드는 기본으로 채우지 않습니다. 필요할 때만 상태를 불러오세요.\" | Was the fallback when both \`continuity_summary\` and \`summary\` were null. Drop the placeholder div entirely in that case — the row above (DiagChips) and below (응답: ...) carry the actual signal. |
| \`memory-subsystems\` top-of-page scope notice | 3-line scope explainer about \`global memory surface\`, \`institution episodes\`, \`Hebbian graph\`, \`Keeper Detail\` | Section headings inside the page name what's there; Keeper Detail's own header names what's there. |
| \`connector-status\` Sidecar Offline block | \"다음: Start 버튼으로 ... tail logs를 사용하세요.\" + leading \"원인:\" label | Restated the Start button + CopyableCode + 'Or for diagnostics' header sitting immediately below. The single sentence with the missing file path is the message. |

## Test plan

- vitest: \`connector-status\` 25/25, \`agent-roster\` 11/11, \`keeper-shared\` 4/4, \`memory-subsystems\` 8/8 — 48/48 total. One substring assertion in \`connector-status.test.ts\` updated to match the trimmed line (\`원인: 사이드카\` → \`사이드카\`; the \`다음:\` assertion dropped because that prose is gone).
- vite build: 13.28s green.

## Trade-offs

- **No replacement copy**: prose is gone, no replacement tooltip. The headings and chip labels carry the rest. If first-time users get lost, prefer per-control tooltips over reintroducing wall-of-text panels.
- **\"원인:\" label dropped from one diagnostic**: the parallel "Cause: / Next:" pair (lines 885-888, 917-920) keep the label structure since they pair with another labeled line. The standalone Sidecar Offline diagnostic now has just one sentence — labeling it adds visual chrome without disambiguation.
- Pre-existing baseline \`tsc --noEmit\` errors (\`fsm_guard_violations\`, \`collapsed_from\`, \`NonHomeTabId\`) on \`main\` are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)