### PR TITLE
feat(keeper): RFC-0047 PR-4 — retire normalize_code, type the producer

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -1280,8 +1280,12 @@ let run_turn
     let terminal_reason_code =
       match turn_result with
       | Ok _ ->
+        (* RFC-0047 PR-4: emit canonical "success" wire directly. Pre-PR-4
+           this defaulted to "completed", which [Keeper_turn_terminal.normalize_code]
+           remapped to "success" before disposition lookup. The producer-side
+           default is now the canonical wire; the normalize step is gone. *)
         Option.value
-          ~default:"completed"
+          ~default:"success"
           !receipt_stop_reason_ref
       | Error err ->
         terminal_reason_code_of_sdk_error err

--- a/lib/keeper/keeper_runtime_trust_snapshot.ml
+++ b/lib/keeper/keeper_runtime_trust_snapshot.ml
@@ -111,12 +111,26 @@ let severity_of_decision = function
 
 let severity_of_tool_call success = if success then "ok" else "bad"
 
+(* RFC-0047 PR-4: deserialization-boundary normalize for legacy persisted
+   wires. Pre-PR-4, [Keeper_turn_terminal.normalize_code] silently remapped
+   "completed" → "success" inside [make]. PR-4 retires that table by typing
+   producers; old JSON files still carry the legacy wire, so the
+   compatibility hop now lives explicitly here at the deserialization
+   boundary. New entries are written with the canonical wire by
+   [keeper_agent_run.ml]. *)
+let normalize_persisted_terminal_reason_code = function
+  | "completed" -> "success"
+  | code -> code
+
 let terminal_reason_from_decision json =
   match json_member "terminal_reason" json with
   | `Assoc _ as terminal_reason -> Keeper_turn_terminal.of_json terminal_reason
   | _ ->
       Option.map
-        (Keeper_turn_terminal.of_code ~source:"decision_log")
+        (fun code ->
+          Keeper_turn_terminal.of_code
+            ~source:"decision_log"
+            (normalize_persisted_terminal_reason_code code))
         (json_string_opt_member "terminal_reason_code" json)
 
 let terminal_reason_from_receipt receipt =
@@ -152,7 +166,10 @@ let terminal_reason_from_receipt receipt =
         (Keeper_turn_terminal.of_code ~source:"execution_receipt"
            "required_tool_use_unsatisfied")
   | Some code ->
-      Some (Keeper_turn_terminal.of_code ~source:"execution_receipt" code)
+      Some
+        (Keeper_turn_terminal.of_code
+           ~source:"execution_receipt"
+           (normalize_persisted_terminal_reason_code code))
   | None when receipt_requires_tool_attention ->
       Some
         (Keeper_turn_terminal.of_code ~source:"execution_receipt"

--- a/lib/keeper/keeper_turn_terminal.ml
+++ b/lib/keeper/keeper_turn_terminal.ml
@@ -32,21 +32,8 @@ let severity_to_string = function
   | Unknown_bad -> "bad"
 ;;
 
-(* Producer-side legacy-string preprocessor. Three legacy puns map to
-   their canonical app-layer codes before [Keeper_turn_disposition.of_wire]
-   is consulted. PR-2.5 / a follow-up RFC retires these by typing the
-   producers themselves; PR-3 keeps the table because every consumer of
-   the resulting disposition is now exhaustive on the typed value. *)
-let normalize_code = function
-  | "completed" -> "success"
-  | "completion_contract_violation:require_tool_use" -> "required_tool_use_unsatisfied"
-  | "api_error_timeout" -> "provider_error"
-  | code -> code
-;;
-
 let make ?(source = "typed") ?summary ?next_action code =
-  let normalised = normalize_code code in
-  let disposition = Keeper_turn_disposition.of_wire normalised in
+  let disposition = Keeper_turn_disposition.of_wire code in
   let summary =
     Option.value ~default:(Keeper_turn_disposition.summary disposition) summary
   in

--- a/test/test_keeper_turn_terminal_disposition_field.ml
+++ b/test/test_keeper_turn_terminal_disposition_field.ml
@@ -19,17 +19,19 @@ let check_invariant label (t : T.t) =
     (D.equal expected t.disposition)
 ;;
 
-(* Cover every public constructor + every code path through
-   [normalize_code]. *)
+(* Cover every public constructor + assorted wire shapes (canonical
+   app codes, legacy persisted wires, sdk-error wires, and unmapped
+   strings) so the invariant survives PR-4's removal of the
+   [normalize_code] producer-side preprocessor. *)
 let constructor_cases : (string * T.t) list =
   [ "success", T.success ()
   ; "of_code/explicit", T.of_code "post_commit_ambiguous"
-  ; "of_code/normalize/completed", T.of_code "completed"
-  ; ( "of_code/normalize/contract_violation"
+  ; "of_code/legacy_persisted/completed", T.of_code "completed"
+  ; ( "of_code/sdk_error/contract_violation_require_tool_use"
     , T.of_code "completion_contract_violation:require_tool_use" )
-  ; "of_code/normalize/api_error_timeout", T.of_code "api_error_timeout"
-  ; "of_code/api_error_overloaded", T.of_code "api_error_overloaded"
-  ; ( "of_code/agent_error_max_turns"
+  ; "of_code/sdk_error/api_error_timeout", T.of_code "api_error_timeout"
+  ; "of_code/sdk_error/api_error_overloaded", T.of_code "api_error_overloaded"
+  ; ( "of_code/sdk_error/agent_error_max_turns"
     , T.of_code "agent_error_max_turns_exceeded:turns=10,limit=10" )
   ; "of_code/unknown", T.of_code "totally_unmapped"
   ; "of_legacy_error_text/empty", T.of_legacy_error_text ""


### PR DESCRIPTION
## Summary

Continues the RFC-0047 sequence (#14232 → #14234 → #14237 → #14271 → THIS).
PR-3 removed the consumer-side substring classifiers; PR-4 retires the
remaining producer-side legacy-string preprocessor inside
\`Keeper_turn_terminal.make\`.

## What changes

| # | File | Change |
|---|------|--------|
| 1 | \`lib/keeper/keeper_turn_terminal.ml\` | Delete \`normalize_code\` (3 legacy puns); \`make\` passes wire straight to \`Keeper_turn_disposition.of_wire\` |
| 2 | \`lib/keeper/keeper_agent_run.ml:1284\` | Producer fix: default \`terminal_reason_code\` for successful turns from \`"completed"\` → \`"success"\` (canonical wire) |
| 3 | \`lib/keeper/keeper_runtime_trust_snapshot.ml\` | Add \`normalize_persisted_terminal_reason_code\` at the deserialization boundary; legacy JSON \`"completed"\` decodes losslessly |
| 4 | \`test/test_keeper_turn_terminal_disposition_field.ml\` | Rename \`"of_code/normalize/*"\` cases to \`"of_code/legacy_persisted/*"\` and \`"of_code/sdk_error/*"\` to match new reality |

## Why each pun was retireable

| Pun | Live producer? | Treatment |
|-----|----------------|-----------|
| \`"completed"\` → \`"success"\` | Yes — \`keeper_agent_run.ml:1284\` for successful turns | Producer fixed at source; deserialization-boundary kept for old JSON |
| \`"completion_contract_violation:require_tool_use"\` → \`"required_tool_use_unsatisfied"\` | No — \`Keeper_turn_terminal.of_failure\` line 117 typed-dispatches \`CompletionContractViolation\` to canonical wire before any string flows | Removed; not present in persisted wires |
| \`"api_error_timeout"\` → \`"provider_error"\` | Yes — SDK \`Retry.Timeout\` flows through, but post-PR-3 both wires land in \`Unknown { raw_error }\` with identical severity (\`Unknown_bad\`) | Removed — lossy collapse; preserving the SDK code in \`raw_error\` is strictly more informative |

## Anti-pattern self-check (`software-development.md` workaround rejection bar)

- ❌ **String/substring classifier** — \`normalize_code\` was a 3-arm wildcard match in the producer hot path classifying at the wrong layer; deleted.
- ❌ **N-of-M patch** — every \`of_code\` call site in \`lib/\` surveyed (\`keeper_unified_metrics:735\`, \`keeper_runtime_trust_snapshot\` lines 119/152/155/158/184); the only in-tree live producer of the \`"completed"\` wire is fixed at source.
- ❌ **Telemetry-as-fix** — no counter/instrumentation-only diff.

## Verification

| Test | Result |
|---|---|
| \`test_keeper_turn_terminal_disposition_field\` | 3/3 ✅ (PR-2 invariant preserved across renamed cases) |
| \`test_keeper_turn_disposition\` | 7/7 ✅ |
| \`test_keeper_terminal_reason\` | 32/32 ✅ |
| \`dune build --root . lib/\` | exit 0 |

## Wire stability

- Producer side: successful turn JSON receipts now write \`terminal_reason_code: "success"\` (was \`"completed"\`). All other wire fields unchanged.
- Reader side: legacy persisted \`"completed"\` is normalized at the boundary in \`keeper_runtime_trust_snapshot\` so existing receipts/decision logs continue to classify as \`Success\` disposition.
- Dashboards / consumers reading \`terminal_reason_code\`: see \`"success"\` going forward; back-compat reads decode old data losslessly.

## Out of scope

- Does not retype \`Keeper_agent_error.terminal_reason_code_of_sdk_error\` — RFC §5.2 defers this.
- Does not type \`registry_failure_reason_of_terminal_reason\` substring routing in \`Keeper_unified_turn\` — different layer, covered by a follow-up.

## RFC sequence (closed)

| PR | Role |
|---|---|
| #14232 | RFC-0047 docs |
| #14234 | PR-1 — \`Keeper_turn_disposition.t\` inert sum |
| #14237 | PR-2 — additive \`disposition\` field, derived from \`code\` |
| #14271 | PR-3 — substring classifier removal + \`code: string\` field removal |
| THIS | PR-4 — \`normalize_code\` retirement, producer-side typing |

🤖 Generated with [Claude Code](https://claude.com/claude-code)