### PR TITLE
fix(supervisor): release current_task_id on Dead entry

### DIFF
--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -1496,6 +1496,20 @@ let sweep_and_recover (ctx : _ context) =
     Keeper_registry.dispatch_event_unit ~base_path entry.name
       Keeper_state_machine.Restart_budget_exhausted;
     Keeper_registry.mark_dead ~base_path entry.name ~at:now;
+    (* Task release: Dead keepers cannot make progress on claimed tasks.
+       Without this release, current_task_id stays claimed forever —
+       the task is invisible to peers while this keeper is permanently
+       stopped.  Mirrors handle_crash_auto_pause (line 1163). *)
+    (match entry.meta.current_task_id with
+     | Some _ ->
+         (match read_meta ctx.config entry.name with
+          | Ok (Some meta) ->
+              ignore (write_meta_with_merge
+                ~merge:Keeper_meta_merge.heartbeat_fields_from_disk
+                ctx.config
+                { meta with current_task_id = None })
+          | _ -> ())
+     | None -> ());
     let detail =
       Printf.sprintf "restart budget exhausted (%d), last: %s"
         max_restarts msg


### PR DESCRIPTION
## Summary
- Dead state entry (`mark_dead` after restart budget exhaustion) now releases `current_task_id` via `write_meta_with_merge`
- Without this fix, claimed tasks become permanently invisible to peers when a keeper dies
- Mirrors the existing release in `handle_crash_auto_pause` (line 1163)

## Test plan
- [x] `dune build --root . @check` passes
- [ ] Fleet observation: after merge, Dead keepers should show `current_task_id=null` in executor.json

🤖 Generated with [Claude Code](https://claude.com/claude-code)