### PR TITLE
refactor(keeper): type registry_failure_reason routing — remove substring guard

### DIFF
--- a/lib/keeper/keeper_turn_terminal.ml
+++ b/lib/keeper/keeper_turn_terminal.ml
@@ -32,8 +32,7 @@ let severity_to_string = function
   | Unknown_bad -> "bad"
 ;;
 
-let make ?(source = "typed") ?summary ?next_action code =
-  let disposition = Keeper_turn_disposition.of_wire code in
+let make_from_disposition ?(source = "typed") ?summary ?next_action disposition =
   let summary =
     Option.value ~default:(Keeper_turn_disposition.summary disposition) summary
   in
@@ -48,6 +47,16 @@ let make ?(source = "typed") ?summary ?next_action code =
   ; summary
   ; next_action
   }
+;;
+
+let make ?(source = "typed") ?summary ?next_action code =
+  let disposition = Keeper_turn_disposition.of_wire code in
+  make_from_disposition ~source ?summary ?next_action disposition
+;;
+
+let of_disposition ?source ?summary ?next_action disposition =
+  let source = Option.value ~default:"typed" source in
+  make_from_disposition ~source ?summary ?next_action disposition
 ;;
 
 let success () = make ~source:"turn_result" "success"
@@ -112,10 +121,16 @@ let of_failure ?(post_commit_ambiguous = false) ?(tool_call_count = 0) ~raw_erro
        | _ ->
          let fallback = of_legacy_error_text raw_error in
          if is_unknown_empty fallback
-         then
-           make
+         then (
+           (* RFC-0047 follow-up: emit typed [Provider_error (Sdk_error _)]
+              directly so [registry_failure_reason_of_terminal_reason] can
+              match exhaustively on disposition without a substring guard
+              for "api_error_*" wires. *)
+           let wire = Keeper_agent_error.terminal_reason_code_of_sdk_error err in
+           of_disposition
              ~source:"typed_error"
-             (Keeper_agent_error.terminal_reason_code_of_sdk_error err)
+             (Keeper_turn_disposition.Provider_error
+                (Keeper_turn_terminal_code.Sdk_error wire)))
          else fallback))
 ;;
 

--- a/lib/keeper/keeper_turn_terminal.mli
+++ b/lib/keeper/keeper_turn_terminal.mli
@@ -40,6 +40,18 @@ val severity_to_string : severity -> string
 val success : unit -> t
 val of_code : ?source:string -> ?summary:string -> ?next_action:string -> string -> t
 
+(** Typed constructor. Skips the wire→[Keeper_turn_disposition.t]
+    decode step that [of_code] performs; useful for producers that
+    have already committed to a typed disposition (e.g. wrapping an
+    SDK error code as [Provider_error (Sdk_error _)] without losing
+    the typed identity in an [Unknown { raw_error = _ }] fallback). *)
+val of_disposition
+  :  ?source:string
+  -> ?summary:string
+  -> ?next_action:string
+  -> Keeper_turn_disposition.t
+  -> t
+
 val of_failure
   :  ?post_commit_ambiguous:bool
   -> ?tool_call_count:int

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -15,20 +15,39 @@ include Keeper_turn_helpers
 include Keeper_turn_liveness
 include Keeper_turn_cascade_budget
 
+(* RFC-0047 follow-up: exhaustive match on [Keeper_turn_disposition.t].
+   Pre-fix this used [String.starts_with ~prefix:"api_error_"] on the
+   wire form of [terminal_reason.code]; that substring guard depended
+   on SDK-error wires being routed through [Unknown { raw_error = _ }]
+   because [normalize_code] no longer collapsed them to "provider_error".
+   With [of_failure] now emitting [Provider_error (Sdk_error _)] typed
+   for the SDK-error fallback, this routing reduces to a clean variant
+   match — no substring classifier left in this function. *)
 let registry_failure_reason_of_terminal_reason
     (terminal_reason : Keeper_turn_terminal.t)
     ~(raw_error : string) : Keeper_registry.failure_reason option =
   let detail = short_preview raw_error in
-  let code = Keeper_turn_terminal.code terminal_reason in
-  match code with
-  | "required_tool_use_no_tool_call"
-  | "required_tool_use_unsatisfied" ->
-      Some (Keeper_registry.Tool_required_unsatisfied { code; detail })
-  | "provider_error" ->
-      Some (Keeper_registry.Provider_runtime_error { code; detail })
-  | _ when String.starts_with ~prefix:"api_error_" code ->
-      Some (Keeper_registry.Provider_runtime_error { code; detail })
-  | _ -> None
+  match terminal_reason.disposition with
+  | Keeper_turn_disposition.Required_tool_use_no_tool_call ->
+      Some
+        (Keeper_registry.Tool_required_unsatisfied
+           { code = "required_tool_use_no_tool_call"; detail })
+  | Keeper_turn_disposition.Required_tool_use_unsatisfied ->
+      Some
+        (Keeper_registry.Tool_required_unsatisfied
+           { code = "required_tool_use_unsatisfied"; detail })
+  | Keeper_turn_disposition.Provider_error c ->
+      Some
+        (Keeper_registry.Provider_runtime_error
+           { code = Keeper_turn_terminal_code.to_wire c; detail })
+  | Keeper_turn_disposition.Success
+  | Keeper_turn_disposition.External_cancel
+  | Keeper_turn_disposition.Turn_wall_clock_timeout
+  | Keeper_turn_disposition.Oas_timeout_budget
+  | Keeper_turn_disposition.Gh_repo_context_missing_worktree
+  | Keeper_turn_disposition.Post_commit_ambiguous
+  | Keeper_turn_disposition.Unknown _ ->
+      None
 
 let should_auto_pause_required_tool_contract_violation
     ~(paused : bool)


### PR DESCRIPTION
## Summary

Follow-up to RFC-0047 PR-4 (#14290). Closes the last substring
classifier in \`Keeper_unified_turn\` by typing the producer side so the
consumer is exhaustive on \`Keeper_turn_disposition.t\`.

## What changes

| # | File | Change |
|---|------|--------|
| 1 | \`lib/keeper/keeper_turn_terminal.{ml,mli}\` | Add \`of_disposition\` (typed counterpart to \`of_code\`) and internal \`make_from_disposition\` core |
| 2 | \`lib/keeper/keeper_turn_terminal.ml\` (\`of_failure\` SDK fallback, line 122-134) | Construct \`Provider_error (Sdk_error wire)\` typed via \`of_disposition\` instead of going \`terminal_reason_code_of_sdk_error → make → Unknown\` |
| 3 | \`lib/keeper/keeper_unified_turn.ml\` (\`registry_failure_reason_of_terminal_reason\`) | Replace substring match on \`terminal_reason.code\` with exhaustive match on \`.disposition\`. \`String.starts_with ~prefix:"api_error_"\` guard removed |

## Why this works

Pre-PR-4, SDK errors flowed through \`make wire → D.of_wire → Unknown { raw_error = "api_error_*" }\`, so the consumer needed a substring guard to recognise them as \`Provider_error\` semantically. PR-4 retired \`normalize_code\`; this PR finishes the migration by typing the SDK fallback at the producer.

After this PR, every disposition that a Keeper turn can finalize with reaches the registry consumer with a typed identity — no string introspection.

## Behavioural equivalence

| Wire (pre-fix) | Disposition (post-fix) | Registry routing |
|---|---|---|
| \`required_tool_use_no_tool_call\` | \`Required_tool_use_no_tool_call\` | \`Tool_required_unsatisfied\` |
| \`required_tool_use_unsatisfied\` | \`Required_tool_use_unsatisfied\` | \`Tool_required_unsatisfied\` |
| \`api_error_*\` (SDK) | \`Provider_error (Sdk_error _)\` | \`Provider_runtime_error\` |
| \`provider_error\` (was rare) | \`Provider_error _\` | \`Provider_runtime_error\` |
| anything else | one of: \`Success\` / \`External_cancel\` / \`Turn_wall_clock_timeout\` / \`Oas_timeout_budget\` / \`Gh_repo_context_missing_worktree\` / \`Post_commit_ambiguous\` / \`Unknown _\` | \`None\` |

The catch-all is removed; the consumer enumerates all disposition variants. A future addition to the closed sum is a compile-time prompt to choose registry semantics rather than a silent \`None\`.

## Anti-pattern self-check (\`software-development.md\` workaround rejection bar)

- ❌ **String/substring classifier** — substring routing on \`.code\` removed from \`registry_failure_reason_of_terminal_reason\`; function is now an exhaustive variant match.
- ❌ **N-of-M patch** — function has a single in-tree caller (\`keeper_unified_turn.ml:1914\`). Verified \`rg -n registry_failure_reason_of_terminal_reason lib/ test/\`.
- ❌ **Telemetry-as-fix** — no counter / instrumentation diff.

## Verification

| Test | Result |
|---|---|
| \`test_keeper_turn_terminal_disposition_field\` | 3/3 ✅ |
| \`test_keeper_turn_disposition\` | 7/7 ✅ |
| \`test_keeper_terminal_reason\` | 32/32 ✅ |
| \`dune build --root . lib/\` | exit 0 |

## RFC-0047 sequence

| PR | Role |
|---|---|
| #14232 | docs |
| #14234 | PR-1 — \`Keeper_turn_disposition.t\` inert sum |
| #14237 | PR-2 — additive \`disposition\` field |
| #14271 | PR-3 — substring classifier removal + \`code: string\` field removal |
| #14290 | PR-4 — \`normalize_code\` retirement, producer typing for "completed" wire |
| THIS | followup — \`registry_failure_reason\` typed, SDK fallback typed |

🤖 Generated with [Claude Code](https://claude.com/claude-code)