### PR TITLE
refactor(dashboard): purge dead value + redundant prose in telemetry-unified

### DIFF
--- a/dashboard/src/components/telemetry-unified.ts
+++ b/dashboard/src/components/telemetry-unified.ts
@@ -522,16 +522,14 @@ export function buildTelemetryDisplayItems(entries: TelemetryEntry[]): Telemetry
 function condensedStats(items: readonly TelemetryDisplayItem[]) {
   let groups = 0
   let groupedEntries = 0
-  let collapsedEntries = 0
   const byCategory = new Map<TelemetryCondensedCategory, number>()
   for (const item of items) {
     if (item.kind !== 'group') continue
     groups += 1
     groupedEntries += item.count
-    collapsedEntries += Math.max(0, item.count - 1)
     byCategory.set(item.category, (byCategory.get(item.category) ?? 0) + item.count)
   }
-  return { groups, groupedEntries, collapsedEntries, byCategory }
+  return { groups, groupedEntries, byCategory }
 }
 
 function SummaryCard({ src }: { src: TelemetrySourceSummary }) {
@@ -881,10 +879,7 @@ export function TelemetryUnified() {
     <div class="flex flex-col gap-4">
       <div class="rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] p-4">
         <div class="text-xs font-semibold uppercase tracking-wider text-[var(--color-fg-muted)]">런타임 진단</div>
-        <div class="mt-1 text-base leading-relaxed text-[var(--color-fg-secondary)]">
-          MASC telemetry store (keeper/tool/agent) 진단 뷰.
-        </div>
-        <div class="mt-3 flex flex-wrap gap-2">
+        <div class="mt-2 flex flex-wrap gap-2">
           <span class="rounded-[var(--r-1)] bg-[var(--color-bg-elevated)] px-2 py-1 text-2xs text-[var(--color-fg-disabled)]">MASC: keeper/tool/agent store</span>
           ${sessionFilter.value ? html`<span class="rounded-[var(--r-1)] bg-[var(--color-bg-elevated)] px-2 py-1 text-2xs font-mono text-[var(--color-fg-disabled)]">session ${sessionFilter.value}</span>` : null}
           ${operationFilter.value ? html`<span class="rounded-[var(--r-1)] bg-[var(--color-bg-elevated)] px-2 py-1 text-2xs font-mono text-[var(--color-fg-disabled)]">operation ${operationFilter.value}</span>` : null}


### PR DESCRIPTION
## Summary

Continues the dashboard cleanup track (#14275, #14280, #14283, #14289). Two cleanups in \`telemetry-unified.ts\` after **verifying** an external triage report against backend + tests.

## Removed

| Where | What | Why |
|---|---|---|
| \`condensedStats\` return (lines 522-535) | \`collapsedEntries\` accumulator | Computed but never read in any render. Verified: only 2 hits in the file (definition + accumulator), 0 in consumers. \`condensed.groups\`, \`.groupedEntries\`, \`.byCategory\` are the only consumed keys. |
| 런타임 진단 panel header (lines 884-886) | Subtitle prose \"MASC telemetry store (keeper/tool/agent) 진단 뷰.\" | The eyebrow + the \`MASC: keeper/tool/agent store\` badge that follows already convey both label and scope. Same anti-pattern fixed in #14289. |

## Verified NOT dead (kept as-is)

External triage flagged these as dead; manual verification rejected them:

- \`filterTelemetryDisplayItems\` export (line 356) — \`telemetry-unified.test.ts\` imports it (lines 466, 505, 765, 815). Keep export.
- \`src.exists === false\` branch (lines 554-556) — backend (\`lib/telemetry_unified.ml:1041\`) emits \`false\` for \`Store_missing | Store_directory\`. Live branch.

## Test plan

- vitest \`telemetry-unified.test.ts\`: 26/26 pass.
- vite build: 9.27s green.

## Trade-offs

- Net **-5 LoC**. Tiny PR but verified — would have been worse to take the triage report at face value (4 false positives out of 6 items).

🤖 Generated with [Claude Code](https://claude.com/claude-code)