### PR TITLE
refactor(dashboard): drop redundant ProfileCard 키퍼 할당 hint

### DIFF
--- a/dashboard/src/components/cascade-config-panel.ts
+++ b/dashboard/src/components/cascade-config-panel.ts
@@ -405,9 +405,6 @@ function ProfileCard({
           >
             <div class="flex items-center gap-2 flex-wrap mb-2">
               <span class="text-xs font-medium text-[var(--color-fg-primary)]">키퍼 할당</span>
-              <span class="text-xs text-[var(--color-fg-muted)]">
-                current profile로 keeper를 이동합니다.
-              </span>
             </div>
             ${availableKeepers.length > 0
               ? html`


### PR DESCRIPTION
## Summary

Single-line UX trim: drop \"current profile로 keeper를 이동합니다.\" inline help that sat next to the \"키퍼 할당\" form header. The header + dropdown + \"키퍼 할당\" submit button already make the action self-evident.

## Verified NOT dead (kept as-is)

External triage flagged several other items in \`cascade-config-panel.ts\` for trimming. Manual verification rejected them:

- \`validationDescription\` cases (lines 234-245) — actual operational context for \`invalid\` / \`serving_valid_subset\` / \`serving_last_known_good\` states. Operators need to know *which profile subset is being served* during partial-failure modes. Trimming would harm operability.
- \`rawConfigModeSummary\` primary/secondary (lines 143-164) — config editor docs (paths + save semantics) for an editor that affects production cascade routing. Path info + parse-validation behavior is essential.
- \`mode.previewTitle\` null in JSON mode (lines 1202-1220) — intentional UX. JSON-mode editor IS the JSON; preview only useful in TOML mode where the editor source is TOML and the materialized JSON is a derived artifact.
- \"currently known keepers are already assigned to this profile.\" (line 440) — empty-state message that tells the operator *why* the dropdown is empty (vs broken).

## Test plan

- vitest \`runtime-panel.test.ts\` (CascadeConfigPanel consumer): 9/9 pass.
- vite build: 11.78s green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)