### PR TITLE
docs(dashboard): clarify fsmGuardViolationsTotal reads snapshots[0] intentionally

### DIFF
--- a/dashboard/src/components/fleet-fsm-matrix.ts
+++ b/dashboard/src/components/fleet-fsm-matrix.ts
@@ -924,6 +924,10 @@ export function FleetFsmMatrix(props: FleetFsmMatrixProps = {}) {
     () => (data ? tallyInvariantViolations(data.snapshots) : null),
     [data],
   )
+  // Backend emits this Prometheus counter (`metric_fsm_guard_violation`)
+  // as a fleet-wide total duplicated onto every snapshot — see
+  // keeper_composite_observer.ml:452. Reading [0] is intentional;
+  // summing across snapshots would multiply the count by fleet size.
   const fsmGuardViolationsTotal = useMemo(
     () => (data ? (data.snapshots[0]?.fsm_guard_violations ?? 0) : 0),
     [data],


### PR DESCRIPTION
## Summary

Comment-only PR. No behavior change.

## Why

The \`fsm_guard_violations\` field on \`KeeperCompositeSnapshot\` looks per-keeper from the schema (\`fsm_guard_violations: number()\`), but the backend (\`keeper_composite_observer.ml:452\`) reads \`Prometheus.metric_total Prometheus.metric_fsm_guard_violation\` — a fleet-wide counter — and stamps the **same value** onto every snapshot in the fleet poll.

Reading \`data.snapshots[0]?.fsm_guard_violations\` is therefore correct: it picks up the fleet-wide total once. Summing across snapshots (a tempting \"fix\") would multiply the fleet total by fleet size.

A recent automated triage agent flagged this exact line as a bug and recommended summing. The flag was wrong, but the fact that the read pattern looks suspicious to a fresh reader is real. Adding 4 lines of comment so future readers (human or agent) don't repeat the same misanalysis.

## Test plan

Comment-only. No build or test change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)