### PR TITLE
chore(rfc-0047): Phase 6 — move keeper residue (exec_agent, exec_checkpoint) to lib/keeper/

### DIFF
--- a/lib/cascade/cascade_runner.ml
+++ b/lib/cascade/cascade_runner.ml
@@ -11,7 +11,7 @@
 (* ================================================================ *)
 
 type stop_reason =
-  Oas_worker_exec_agent.stop_reason =
+  Keeper_agent_context.stop_reason =
   | Completed
   | TurnBudgetExhausted of { turns_used : int; limit : int }
   | MutationBoundaryReached of { turns_used : int; tool_name : string option }
@@ -28,7 +28,7 @@ type cli_transport_overrides =
 }
 
 type config =
-  Oas_worker_exec_agent.config = {
+  Keeper_agent_context.config = {
   name : string;
   provider_cfg : Llm_provider.Provider_config.t;
   provider : Agent_sdk.Provider.config;
@@ -81,7 +81,7 @@ type config =
           to scrub [STATE] blocks before the 100-char truncation. *)
 }
 
-let default_config = Oas_worker_exec_agent.default_config
+let default_config = Keeper_agent_context.default_config
 
 type run_result = {
   response : Agent_sdk.Types.api_response;
@@ -214,20 +214,20 @@ let non_http_transport_of_provider =
 (* ================================================================ *)
 
 let publish_lifecycle =
-  Oas_worker_exec_checkpoint.publish_lifecycle
+  Keeper_oas_checkpoint.publish_lifecycle
 
 (* ================================================================ *)
 (* Internal: checkpoint persistence                                  *)
 (* ================================================================ *)
 
 let persist_checkpoint =
-  Oas_worker_exec_checkpoint.persist_checkpoint
+  Keeper_oas_checkpoint.persist_checkpoint
 
 let build_checkpoint =
-  Oas_worker_exec_checkpoint.build_checkpoint
+  Keeper_oas_checkpoint.build_checkpoint
 
 let partial_response_of_stop =
-  Oas_worker_exec_checkpoint.partial_response_of_stop
+  Keeper_oas_checkpoint.partial_response_of_stop
 
 (* ================================================================ *)
 (* Build                                                             *)
@@ -247,7 +247,7 @@ let build
   | Error _ as e -> e
   | Ok transport ->
       let builder =
-        Oas_worker_exec_agent.builder_without_approval ~net ~config ?transport ()
+        Keeper_agent_context.builder_without_approval ~net ~config ?transport ()
       in
       let builder =
         match config.approval with
@@ -267,7 +267,7 @@ let build
     Exposed at module level so it can be unit-tested independently of
     the network-bound [run] function. *)
 let enrich_idle_detail =
-  Oas_worker_exec_checkpoint.enrich_idle_detail
+  Keeper_oas_checkpoint.enrich_idle_detail
 
 let run_duration_ms_since started_at =
   Float.max 0.0 ((Unix.gettimeofday () -. started_at) *. 1000.0)
@@ -345,7 +345,7 @@ let resume_from_checkpoint
   | Error _ as e -> e
   | Ok transport ->
       let prepared_resume =
-        Oas_worker_exec_agent.prepare_resume ~config ~checkpoint
+        Keeper_agent_context.prepare_resume ~config ~checkpoint
       in
       Log.Misc.info
         "oas_worker %s: resume checkpoint_turn_count=%d per_call_turn_budget=%d effective_max_turns=%d"

--- a/lib/cascade/cascade_runner.mli
+++ b/lib/cascade/cascade_runner.mli
@@ -1,9 +1,9 @@
 (** Cascade_runner — config, build, and run entry points
     for OAS agent execution.
 
-    Thin facade over {!Oas_worker_exec_agent},
+    Thin facade over {!Keeper_agent_context},
     {!Cascade_transport}, and
-    {!Oas_worker_exec_checkpoint}.  External callers reach
+    {!Keeper_oas_checkpoint}.  External callers reach
     the entry points via [Cascade_runner.X]; the heavy
     transport machinery (CLI / MCP wire formats, runtime
     policy projections) is implemented in
@@ -32,7 +32,7 @@
 
 (** {1 Stop reason} *)
 
-type stop_reason = Oas_worker_exec_agent.stop_reason =
+type stop_reason = Keeper_agent_context.stop_reason =
   | Completed
   | TurnBudgetExhausted of { turns_used : int; limit : int }
   | MutationBoundaryReached of {
@@ -65,7 +65,7 @@ type cli_transport_overrides =
 
 (** {1 Config} *)
 
-type config = Oas_worker_exec_agent.config = {
+type config = Keeper_agent_context.config = {
   name : string;
   provider_cfg : Llm_provider.Provider_config.t;
   provider : Agent_sdk.Provider.config;
@@ -259,7 +259,7 @@ val resume_from_checkpoint :
   checkpoint:Agent_sdk.Checkpoint.t ->
   (Agent_sdk.Agent.t, Agent_sdk.Error.sdk_error) result
 (** Resumes from a persisted checkpoint.  Uses
-    [Oas_worker_exec_agent.prepare_resume] to reconcile
+    [Keeper_agent_context.prepare_resume] to reconcile
     [checkpoint.turn_count] with the current
     [config.max_turns]. *)
 

--- a/lib/dune
+++ b/lib/dune
@@ -113,6 +113,8 @@
   keeper_agent_result
   keeper_agent_error
   keeper_agent_memory_episode
+  keeper_agent_context
+  keeper_oas_checkpoint
   keeper_exec_context
   keeper_guards
   keeper_turn_setup
@@ -166,8 +168,6 @@
   tool_misc_admin
   tool_misc_web_search
   tool_misc_web_fetch
-  oas_worker_exec_agent
-  oas_worker_exec_checkpoint
   oas_worker_named
   meta_cognition_types
   meta_cognition_rules

--- a/lib/keeper/keeper_agent_context.ml
+++ b/lib/keeper/keeper_agent_context.ml
@@ -1,4 +1,4 @@
-(** Oas_worker_exec_agent — Shared config and agent assembly helpers.
+(** Keeper_agent_context — Shared config and agent assembly helpers.
 
     This module owns the shared [config] surface plus the pure/defaulted
     preparation logic used by both [build] and [resume_from_checkpoint].

--- a/lib/keeper/keeper_agent_context.mli
+++ b/lib/keeper/keeper_agent_context.mli
@@ -1,4 +1,4 @@
-(** Oas_worker_exec_agent — shared {!config} surface and agent
+(** Keeper_agent_context — shared {!config} surface and agent
     assembly helpers.
 
     Owns the shared per-worker {!config} record + pure / defaulted

--- a/lib/keeper/keeper_oas_checkpoint.ml
+++ b/lib/keeper/keeper_oas_checkpoint.ml
@@ -1,4 +1,4 @@
-(** Oas_worker_exec_checkpoint — Lifecycle, checkpoint, and idle-detail helpers.
+(** Keeper_oas_checkpoint — Lifecycle, checkpoint, and idle-detail helpers.
 
     Keeps side-effecting run helpers separate from the main build/resume/run
     orchestration in {!Cascade_runner}. *)

--- a/lib/keeper/keeper_oas_checkpoint.mli
+++ b/lib/keeper/keeper_oas_checkpoint.mli
@@ -1,4 +1,4 @@
-(** Oas_worker_exec_checkpoint — lifecycle, checkpoint, and
+(** Keeper_oas_checkpoint — lifecycle, checkpoint, and
     idle-detail helpers extracted from {!Cascade_runner}.
 
     Keeps side-effecting run helpers separate from the main

--- a/test/test_oas_worker_exec_checkpoint.ml
+++ b/test/test_oas_worker_exec_checkpoint.ml
@@ -9,7 +9,7 @@
 open Masc_mcp
 open Alcotest
 
-module CP = Oas_worker_exec_checkpoint
+module CP = Keeper_oas_checkpoint
 
 let rec rm_rf path =
   if Sys.file_exists path then


### PR DESCRIPTION
## Summary

RFC-0047 Phase 6: move 2 keeper-localized residue files from `oas_*` family into `lib/keeper/`.

## Renames

| From | To | LOC |
|---|---|---|
| `lib/oas_worker_exec_agent.ml` (+`.mli`) | `lib/keeper/keeper_agent_context.ml` (+`.mli`) | 396 + 133 |
| `lib/oas_worker_exec_checkpoint.ml` (+`.mli`) | `lib/keeper/keeper_oas_checkpoint.ml` (+`.mli`) | 99 + 90 |

~718 LOC migrated to correct layer.

The retained "oas" in `keeper_oas_checkpoint` is intentional — these checkpoints are about agent_sdk call resumability, not the `oas_*`-as-prefix family.

## Caller updates

7 files via `perl -i` rename.

## lib/dune

- Removed: `oas_worker_exec_agent`, `oas_worker_exec_checkpoint`
- Added: `keeper_agent_context`, `keeper_oas_checkpoint` (private, consistent with existing `keeper_agent_*` convention)

## Verification

- [x] `dune build lib/`: exit 0.
- [ ] `dune runtest`: deferred to CI.

## Status

**Draft.** Awaiting `human-approved-ready` label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
