### PR TITLE
refactor(dashboard): drop 4 more "이 화면은 ..." explainer-prose blocks

### DIFF
--- a/dashboard/src/components/autoresearch.test.ts
+++ b/dashboard/src/components/autoresearch.test.ts
@@ -148,7 +148,6 @@ describe('Autoresearch surface refresh', () => {
     expect(container.textContent).toContain('실험 결과')
     expect(container.textContent).toContain('하네스 열기')
     expect(container.textContent).toContain('연구 브리프')
-    expect(container.textContent).toContain('이 화면은 generator loop 자체를 설명합니다.')
     expect(container.textContent).toContain('1 / 5')
     expect(container.textContent).toContain('사이클 이력 (1건)')
 

--- a/dashboard/src/components/autoresearch.ts
+++ b/dashboard/src/components/autoresearch.ts
@@ -440,11 +440,6 @@ function ResearchBrief({ loop }: { loop: AutoresearchLoopSummary }) {
             </div>
           </${InfoCard}>
         </div>
-
-        <div class="rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-3 py-2 text-xs leading-normal text-[var(--color-fg-muted)]">
-          이 화면은 generator loop 자체를 설명합니다. Safety Harness는 evaluator와 장기 실행 safety rail을 보여주며,
-          각 cycle의 keep/discard 판정을 직접 대체하지 않습니다.
-        </div>
       </div>
     <//>
   `
@@ -456,7 +451,6 @@ function OutcomeVsHarnessCallout({ loopCount }: { loopCount: number }) {
       <div class="grid grid-cols-1 gap-3 md:grid-cols-[1.3fr_1fr]">
         <${InfoCard}>
           <${Eyebrow}>실험 결과</${Eyebrow}>
-          <div class="mt-1 text-sm font-medium text-[var(--color-fg-primary)]">이 화면은 keep/discard 루프를 봅니다.</div>
           <div class="mt-2 text-sm leading-loose text-[var(--color-fg-secondary)]">
             어떤 파일을 바꾸고 어떤 metric을 밀어 올리려는지, 그리고 현재 ${loopCount}개 루프가 어떤 cycle에 있는지 직접 봅니다.
           </div>
@@ -464,7 +458,6 @@ function OutcomeVsHarnessCallout({ loopCount }: { loopCount: number }) {
 
         <div class="rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] p-3">
           <${Eyebrow}>안전 하네스</${Eyebrow}>
-          <div class="mt-1 text-sm font-medium text-[var(--color-fg-primary)]">심판 기계의 건강도는 별도로 봅니다.</div>
           <div class="mt-2 text-sm leading-loose text-[var(--color-fg-secondary)]">
             평가 모델, 압축 전 상태, 세대 교체 rail 상태는 하네스에서 봅니다.
           </div>

--- a/dashboard/src/components/fleet-health-panel.ts
+++ b/dashboard/src/components/fleet-health-panel.ts
@@ -67,12 +67,7 @@ export function FleetHealthPanel() {
 
   return html`
     <div class="contain-content flex flex-col gap-4">
-        <div class="flex flex-col gap-1">
-          <div class="text-2xs font-semibold uppercase tracking-[var(--track-caps)] text-[var(--color-fg-muted)]">운영 신호 묶음</div>
-          <p class="m-0 text-xs leading-paragraph text-[var(--color-fg-muted)]">
-            이 화면은 roster가 아니라 이벤트, 비교, 도구 품질, 거버넌스 같은 플릿 신호를 보는 곳입니다.
-          </p>
-        </div>
+        <div class="text-2xs font-semibold uppercase tracking-[var(--track-caps)] text-[var(--color-fg-muted)]">운영 신호 묶음</div>
       <${FilterChips}
         chips=${VIEW_CHIPS}
         value=${view}


### PR DESCRIPTION
## Summary

Round 2 of the dashboard prose cleanup track (#14219, #14289, #14296). Wider grep on \`이 화면은\`, \`이 패널은\`, \`여기서는\`, \`만 보여줍니다\` across \`dashboard/src/components/\` surfaced 4 more occurrences of the same anti-pattern: prose paragraphs/lines under or beside an eyebrow that restate what the screen does without showing data.

## Removed

| Where | Removed text | Why |
|---|---|---|
| \`fleet-health-panel.ts:72-74\` | \"이 화면은 roster가 아니라 이벤트, 비교, 도구 품질, 거버넌스 같은 플릿 신호를 보는 곳입니다.\" | The FilterChips below already enumerate the views (default / event-log / comparison / governance). The \"운영 신호 묶음\" eyebrow names the surface. |
| \`autoresearch.ts:444-447\` | 2-line meta block describing both this surface and the sibling \"Safety Harness\" surface | Four data-rich InfoCards directly above (무엇을 연구하나 / 무엇으로 성공을 보나 / 연결된 실행 컨텍스트 / 현재 가설) carry actual loop info. The \`OutcomeVsHarnessCallout\` right below has a \"하네스 열기\" button for navigation. |
| \`autoresearch.ts:459\` | \"이 화면은 keep/discard 루프를 봅니다.\" | Anthropomorphic middle-title in \`OutcomeVsHarnessCallout\` between Eyebrow and description. Description below carries the data (\"${loopCount}개 루프가 어떤 cycle에 있는지...\"). |
| \`autoresearch.ts:467\` | \"심판 기계의 건강도는 별도로 봅니다.\" | Same pattern in the harness card. Description + \"하네스 열기\" button do the work. |

## Test plan

- vitest \`autoresearch.test.ts\` + \`fleet-health-panel.test.ts\`: 32/32 pass. One substring assertion in \`autoresearch.test.ts\` line 151 dropped because that prose is gone.
- vite build: 9.78s green.

## Trade-offs

- **No replacement copy**: prose is gone, no replacement tooltip. Eyebrows + chips + buttons + descriptions carry the rest.
- **The pattern keeps reappearing**: this is round 2 of explainer-prose cleanup; new anti-pattern instances will likely keep landing as long as there's no lint rule. Consider a follow-up: ESLint rule (or grep CI guard) banning specific Korean phrases (\`이 화면은\`, \`...만 보여줍니다\`, \`...됩니다\.\`) inside dashboard JSX strings. Out of scope for this PR.
- Net **-13 LoC**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)