### PR TITLE
chore(rfc-0047): Phase 4 — rename oas_worker_named (1459 LOC) -> keeper_turn_driver

### DIFF
--- a/docs/TIMEOUT-MATRIX.md
+++ b/docs/TIMEOUT-MATRIX.md
@@ -12,7 +12,7 @@ is effectively advisory.
 |-------|------|-------------|-----------------|
 | `Tool` | per-tool HTTP / shell invocation | 10–60 s | `Env_config_runtime.*`, `lib/tool_local_runtime_http.ml` |
 | `MCP tools/call` | outer per-tool dispatcher cap | 60 s default; board writes 90 s default | `MASC_TOOL_TIMEOUT_DEFAULT_SEC`, `MASC_TOOL_TIMEOUT_BOARD_SEC`, `Mcp_server_eio_call_tool.tool_timeout_sec_opt` |
-| `Oas_bridge` | single OAS `Agent.run` / `Model.call` | 300 s default; provider attempt caps may be lower | `Env_config_keeper.oas_timeout_sec*`, `Oas_worker_named.effective_provider_attempt_timeout_s` |
+| `Oas_bridge` | single OAS `Agent.run` / `Model.call` | 300 s default; provider attempt caps may be lower | `Env_config_keeper.oas_timeout_sec*`, `Keeper_turn_driver.effective_provider_attempt_timeout_s` |
 | `Keeper_turn` | one keeper turn (may issue many OAS calls) | 600 s default/hard ceiling | `MASC_KEEPER_TURN_TIMEOUT_SEC` |
 | `Keeper_cycle` | full keeper lifecycle | N×turn | cycle supervisor |
 | `Shutdown` | graceful shutdown board flush | 2 s | `bin/main_eio.ml` |

--- a/docs/design/dashboard-fsm-redesign.md
+++ b/docs/design/dashboard-fsm-redesign.md
@@ -40,7 +40,7 @@ code_refs:
 - provider health (healthy/unhealthy/slot_full)는 렌더에 반영되지 않는다.
 - `last_provider_result`가 success든 timeout이든 edge 색이 동일하다.
 
-동시에 model 목록은 `lib/server/server_routes_http_routes_dashboard.ml:618-633`에서 `Oas_worker_named.default_model_strings`로부터 동적으로 읽는다. 즉 **데이터는 흐르는데 렌더가 그것을 쓰지 않는다.**
+동시에 model 목록은 `lib/server/server_routes_http_routes_dashboard.ml:618-633`에서 `Keeper_turn_driver.default_model_strings`로부터 동적으로 읽는다. 즉 **데이터는 흐르는데 렌더가 그것을 쓰지 않는다.**
 
 ### Decision FSM 부분 동적
 
@@ -75,7 +75,7 @@ MASC `agent`와 OAS `keeper`는 다른 개념이다 (`docs/design/oas-masc-state
 |------|------|------|
 | `lib/keeper/keeper_decision_audit.ml` | 256-315 | `cascade_fsm_to_mermaid` state set을 `CascadeLiveness.tla`의 `{idle, selecting, trying, done, exhausted}` subset으로 제한. 렌더 시점에 받은 실제 profile name, provider health list, last_provider_result로 label/색 bind |
 | `lib/keeper/keeper_decision_audit.mli` | 55-73 | 시그니처 확장 (optional labelled args): `?provider_health:(string * [`Healthy|`Unhealthy|`SlotFull|`Unknown]) list`, `?slot_state:int * int`, `?effective_cascade_reason:string` |
-| `lib/server/server_routes_http_routes_dashboard.ml` | 618-633 | 기존 `Oas_worker_named.default_model_strings` 호출 유지, `Keeper_cascade_routing.select_cascade` 결과와 `Keeper_exec_status_metrics.last_model_used`를 함께 넘긴다 |
+| `lib/server/server_routes_http_routes_dashboard.ml` | 618-633 | 기존 `Keeper_turn_driver.default_model_strings` 호출 유지, `Keeper_cascade_routing.select_cascade` 결과와 `Keeper_exec_status_metrics.last_model_used`를 함께 넘긴다 |
 | `lib/dashboard/dashboard_http_keeper.ml` | 147-148 | 이미 phase-aware cascade 리졸브 로직 보유 — `effective_cascade_reason` 노출 경로만 추가 |
 
 ### 재사용할 기존 함수 (새 추상화 금지)

--- a/docs/observability/cascade-metrics.md
+++ b/docs/observability/cascade-metrics.md
@@ -12,7 +12,7 @@ How to read the cascade counters exposed by `/metrics` and the alerting rules th
 
 ## Background
 
-After the LT-* series (LT-1 through LT-7) every cycle of `Oas_worker_named.cycle_loop` produces observable state on **five surfaces**:
+After the LT-* series (LT-1 through LT-7) every cycle of `Keeper_turn_driver.cycle_loop` produces observable state on **five surfaces**:
 
 | Surface | Location | Use case |
 |---------|----------|----------|

--- a/docs/rfc/RFC-0047-oas-adapter-decomposition.md
+++ b/docs/rfc/RFC-0047-oas-adapter-decomposition.md
@@ -58,7 +58,7 @@ keeper sub-library extraction analysis (memory
   `Cascade_fsm` (26), `Keeper_types` (17), `Cascade_health_tracker` (11).
   These are **strategy and bookkeeping**, not Agent SDK calls.
 
-- Caller surface: `rg -l 'Oas_worker_named\.|Cascade_runner\.|Oas_worker\.'` reports
+- Caller surface: `rg -l 'Keeper_turn_driver\.|Cascade_runner\.|Oas_worker\.'` reports
   **49 files in `lib/`** (20 keeper-side, 2 cascade-side, 27 elsewhere) plus
   test/bin = **504 total references**. Any rename or extraction must
   preserve these call sites or migrate them in lockstep.
@@ -202,7 +202,7 @@ Build-green hard gate at every PR.
   - Top callers (code): `test/test_oas_worker.ml` (223), `lib/keeper/keeper_error_classify.ml` (82),
     `lib/oas_worker_exec.ml` (44), `test/test_keeper_unified.ml` (40),
     `lib/oas_worker_named.ml` (40 — intra-family coupling).
-  - Most-referenced module: `Oas_worker_named` (131 external refs)
+  - Most-referenced module: `Keeper_turn_driver` (131 external refs)
     confirms the Phase 4 hotspot.
   - Module graph: 25 cross-domain edges. `oas_worker_named → Cascade_*`
     weighs 77 (largest single edge), `oas_worker_exec → Dashboard_*`
@@ -216,9 +216,9 @@ Build-green hard gate at every PR.
 **Scope correction (during Phase 2 PR, 2026-05-08).** The original RFC
 listed 4 files. Inspection found `lib/oas_worker.ml` is structurally a
 **facade** — `include Cascade_runner`, `include Cascade_legacy_runner`,
-`include Oas_worker_named` — over three modules that are NOT clean
+`include Keeper_turn_driver` — over three modules that are NOT clean
 (Phase 3 / Phase 4 targets). Renaming the facade alone produces an
-`Agent_sdk_call` module that still re-exports `Oas_worker_named.run_named`,
+`Agent_sdk_call` module that still re-exports `Keeper_turn_driver.run_named`,
 i.e. the lie moves but does not disappear. `oas_worker.ml` is deferred
 to Phase 4, when its dependents are dissolved.
 
@@ -261,7 +261,7 @@ to Phase 4, when its dependents are dissolved.
 ### Phase 4 — Hotspot split: `oas_worker_named.ml` (1459 LOC)
 
 - The single largest and most-tangled file. Contains A/B/C concerns
-  interleaved within `Oas_worker_named.run`.
+  interleaved within `Keeper_turn_driver.run`.
 - Action: split body into three modules:
   - **A. agent_sdk call sites.** Pure `Agent_sdk.run_loop` invocation
     with prompt + tools + transport. Lands as additions to
@@ -273,7 +273,7 @@ to Phase 4, when its dependents are dissolved.
     blocker class stamping, status bridge calls. Lands as new file
     `lib/keeper/keeper_turn_driver.ml`. Existing keeper callers (20
     files) point at `Keeper_turn_driver.run` instead of
-    `Oas_worker_named.run`.
+    `Keeper_turn_driver.run`.
 - The old `oas_worker_named.ml` becomes a 5-line shim that delegates to
   `Keeper_turn_driver.run` for one PR cycle, then is deleted in the same
   release.

--- a/infrastructure/monitoring/README.md
+++ b/infrastructure/monitoring/README.md
@@ -33,7 +33,7 @@ signal.
 
 ### Cascade
 
-Tracks cascade-routing decisions inside `Oas_worker_named.cycle_loop`. Counters: `masc_cascade_strategy_decisions_total{cascade,strategy,kind}`, `masc_cascade_capacity_events_total{kind,key_type}`. State vocabulary: `ordered / filtered_empty / exhausted` (TLA+ `KeeperCascadeLifecycle`).
+Tracks cascade-routing decisions inside `Keeper_turn_driver.cycle_loop`. Counters: `masc_cascade_strategy_decisions_total{cascade,strategy,kind}`, `masc_cascade_capacity_events_total{kind,key_type}`. State vocabulary: `ordered / filtered_empty / exhausted` (TLA+ `KeeperCascadeLifecycle`).
 
 ### Dashboard IA
 

--- a/lib/anti_rationalization.ml
+++ b/lib/anti_rationalization.ml
@@ -639,8 +639,8 @@ let review
           by liveness — the operator must fix the cascade definition
           before the safety net can do useful work. *)
        let cascade_permanently_dead =
-         match Oas_worker_named.classify_masc_internal_error err with
-         | Some (Oas_worker_named.No_tool_capable_provider _) -> true
+         match Keeper_turn_driver.classify_masc_internal_error err with
+         | Some (Keeper_turn_driver.No_tool_capable_provider _) -> true
          | _ -> false
        in
        let mode = Env_config.AntiRationalization.fail_mode in

--- a/lib/cascade/cascade_attempt_fsm.mli
+++ b/lib/cascade/cascade_attempt_fsm.mli
@@ -5,7 +5,7 @@
     classifies CLI-wrapped error patterns (hard quota, max turns,
     resumable sessions), and enriches errors with provider-specific hints.
 
-    This module is [include]d by {!Oas_worker_named}; all bindings are
+    This module is [include]d by {!Keeper_turn_driver}; all bindings are
     re-exported by the facade.  @since God file decomposition *)
 
 (** {1 Cascade outcome classification} *)

--- a/lib/cascade/cascade_error_classify.mli
+++ b/lib/cascade/cascade_error_classify.mli
@@ -5,7 +5,7 @@
     SDK error conversion, error classification, and codex CLI prompt
     preflight checks.
 
-    This module is [include]d by {!Oas_worker_named}; all bindings are
+    This module is [include]d by {!Keeper_turn_driver}; all bindings are
     re-exported by the facade.  @since God file decomposition *)
 
 (** {1 MASC internal error type} *)

--- a/lib/cascade/cascade_legacy_runner.mli
+++ b/lib/cascade/cascade_legacy_runner.mli
@@ -10,7 +10,7 @@
       OAS-named worker path.
     - {b Cascade observation}: the {!cascade_observation}
       record + companion attempt / fallback events,
-      built per-turn in {!Oas_worker_named} via the
+      built per-turn in {!Keeper_turn_driver} via the
       {!cascade_metrics_for_candidates} +
       {!cascade_observation_with_metrics} pair.
     - {b Cascade audit actor}: a single-fiber consumer

--- a/lib/cascade/cascade_oas_runner.mli
+++ b/lib/cascade/cascade_oas_runner.mli
@@ -4,7 +4,7 @@
     Provides cascade profile defaults, Eio context validation,
     provider resolution, tool-support filtering, and cross-cascade fallback.
 
-    This module is [include]d by {!Oas_worker_named}; all bindings are
+    This module is [include]d by {!Keeper_turn_driver}; all bindings are
     re-exported by the facade.  @since God file decomposition *)
 
 (** {1 Cascade profile defaults} *)

--- a/lib/cascade/cascade_runner.ml
+++ b/lib/cascade/cascade_runner.ml
@@ -2,7 +2,7 @@
 
     Contains the [config] type, [build], [run], and [run_with_masc_tools]
     functions. All model-selection and cascade logic lives in
-    {!Cascade_legacy_runner} and {!Oas_worker_named}.
+    {!Cascade_legacy_runner} and {!Keeper_turn_driver}.
 
     @since God file decomposition — extracted from oas_worker.ml *)
 
@@ -570,7 +570,7 @@ let run
         ~status:(Dashboard_oas_bridge.Error { transient = false })
         error_response;
       (* Demoted from WARN to DEBUG (task-239): this fires once per tier,
-         but a cascade caller (Oas_worker_named.run_named) retries on the
+         but a cascade caller (Keeper_turn_driver.run_named) retries on the
          next provider.  Emitting WARN/ERROR here creates noise on
          recovered cascades.  The cascade layer logs [cascade-fallback] at
          INFO when it retries and emits ERROR only on full exhaustion. *)

--- a/lib/cascade/cascade_runner.mli
+++ b/lib/cascade/cascade_runner.mli
@@ -13,7 +13,7 @@
     pinned at this boundary.
 
     All model-selection and cascade logic lives in
-    {!Cascade_legacy_runner} and {!Oas_worker_named}.
+    {!Cascade_legacy_runner} and {!Keeper_turn_driver}.
 
     Internal helpers stay private at this boundary
     ([lowercase_enum_case_name],

--- a/lib/cascade/cascade_strategy_trace.mli
+++ b/lib/cascade/cascade_strategy_trace.mli
@@ -7,7 +7,7 @@
     "how long were Circuit_breaker_cycling retries in the last hour?".
 
     This module captures the decision outcome of every cycle iteration
-    of {!Oas_worker_named.try_cascade} as a ring event, so the dashboard
+    of {!Keeper_turn_driver.try_cascade} as a ring event, so the dashboard
     can surface recent runtime behaviour alongside the TLA+-verified
     strategy kind.
 

--- a/lib/dune
+++ b/lib/dune
@@ -115,6 +115,7 @@
   keeper_agent_memory_episode
   keeper_agent_context
   keeper_oas_checkpoint
+  keeper_turn_driver
   keeper_exec_context
   keeper_guards
   keeper_turn_setup
@@ -168,7 +169,6 @@
   tool_misc_admin
   tool_misc_web_search
   tool_misc_web_fetch
-  oas_worker_named
   meta_cognition_types
   meta_cognition_rules
   meta_cognition_snapshot

--- a/lib/keeper/keeper_error_classify.ml
+++ b/lib/keeper/keeper_error_classify.ml
@@ -146,51 +146,51 @@ let is_required_tool_contract_violation (err : Agent_sdk.Error.sdk_error) : bool
   | Agent_sdk.Error.Internal _ -> false
 
 let is_auto_recoverable_cascade_exhausted_error (err : Agent_sdk.Error.sdk_error) : bool =
-  match Oas_worker_named.classify_masc_internal_error err with
+  match Keeper_turn_driver.classify_masc_internal_error err with
   | Some
-      (Oas_worker_named.Cascade_exhausted
+      (Keeper_turn_driver.Cascade_exhausted
          { reason = Keeper_types.Candidates_filtered_after_cycles; _ }) ->
       true
   | Some
-      (Oas_worker_named.Cascade_exhausted
+      (Keeper_turn_driver.Cascade_exhausted
          { reason = Keeper_types.Max_turns_exceeded; _ }) ->
       true
   | Some
-      (Oas_worker_named.Cascade_exhausted
+      (Keeper_turn_driver.Cascade_exhausted
          { reason = Keeper_types.Other_detail detail; _ }) ->
-      Oas_worker_named.message_looks_like_cli_wrapped_hard_quota detail
-      || Oas_worker_named.message_looks_like_cli_wrapped_max_turns detail
-  | Some (Oas_worker_named.Cascade_exhausted _) ->
+      Keeper_turn_driver.message_looks_like_cli_wrapped_hard_quota detail
+      || Keeper_turn_driver.message_looks_like_cli_wrapped_max_turns detail
+  | Some (Keeper_turn_driver.Cascade_exhausted _) ->
       false
-  | Some (Oas_worker_named.No_tool_capable_provider _)
-  | Some (Oas_worker_named.Accept_rejected _)
-  | Some (Oas_worker_named.Resumable_cli_session _)
-  | Some (Oas_worker_named.Admission_queue_rejected _)
-  | Some (Oas_worker_named.Admission_queue_timeout _)
-  | Some (Oas_worker_named.Turn_timeout _)
-  | Some (Oas_worker_named.Oas_timeout_budget _)
-  | Some (Oas_worker_named.Ambiguous_post_commit _)
+  | Some (Keeper_turn_driver.No_tool_capable_provider _)
+  | Some (Keeper_turn_driver.Accept_rejected _)
+  | Some (Keeper_turn_driver.Resumable_cli_session _)
+  | Some (Keeper_turn_driver.Admission_queue_rejected _)
+  | Some (Keeper_turn_driver.Admission_queue_timeout _)
+  | Some (Keeper_turn_driver.Turn_timeout _)
+  | Some (Keeper_turn_driver.Oas_timeout_budget _)
+  | Some (Keeper_turn_driver.Ambiguous_post_commit _)
   | None ->
       false
 
 let is_resumable_cli_session_error (err : Agent_sdk.Error.sdk_error) : bool =
-  match Oas_worker_named.classify_masc_internal_error err with
-  | Some (Oas_worker_named.Resumable_cli_session _) -> true
-  | Some (Oas_worker_named.Cascade_exhausted _)
-  | Some (Oas_worker_named.No_tool_capable_provider _)
-  | Some (Oas_worker_named.Accept_rejected _)
-  | Some (Oas_worker_named.Admission_queue_timeout _)
-  | Some (Oas_worker_named.Admission_queue_rejected _)
-  | Some (Oas_worker_named.Turn_timeout _)
-  | Some (Oas_worker_named.Oas_timeout_budget _)
-  | Some (Oas_worker_named.Ambiguous_post_commit _)
+  match Keeper_turn_driver.classify_masc_internal_error err with
+  | Some (Keeper_turn_driver.Resumable_cli_session _) -> true
+  | Some (Keeper_turn_driver.Cascade_exhausted _)
+  | Some (Keeper_turn_driver.No_tool_capable_provider _)
+  | Some (Keeper_turn_driver.Accept_rejected _)
+  | Some (Keeper_turn_driver.Admission_queue_timeout _)
+  | Some (Keeper_turn_driver.Admission_queue_rejected _)
+  | Some (Keeper_turn_driver.Turn_timeout _)
+  | Some (Keeper_turn_driver.Oas_timeout_budget _)
+  | Some (Keeper_turn_driver.Ambiguous_post_commit _)
   | None ->
       false
 
 let is_auto_recoverable_cascade_fail_open_error
     (err : Agent_sdk.Error.sdk_error) : bool =
-  Oas_worker_named.sdk_error_is_hard_quota err
-  || Oas_worker_named.sdk_error_is_max_turns_exceeded err
+  Keeper_turn_driver.sdk_error_is_hard_quota err
+  || Keeper_turn_driver.sdk_error_is_max_turns_exceeded err
   || is_resumable_cli_session_error err
   || is_auto_recoverable_cascade_exhausted_error err
 
@@ -235,72 +235,72 @@ let degraded_retry_after_recoverable_error
      || String.equal normalized_effective
           Keeper_config.local_recovery_cascade_name
   then None
-  else if Oas_worker_named.sdk_error_is_hard_quota err then
+  else if Keeper_turn_driver.sdk_error_is_hard_quota err then
     local_recovery_retry "hard_quota"
-  else if Oas_worker_named.sdk_error_is_max_turns_exceeded err then
+  else if Keeper_turn_driver.sdk_error_is_max_turns_exceeded err then
     local_recovery_retry "max_turns"
   else
-    match Oas_worker_named.classify_masc_internal_error err with
-    | Some (Oas_worker_named.Resumable_cli_session _) ->
+    match Keeper_turn_driver.classify_masc_internal_error err with
+    | Some (Keeper_turn_driver.Resumable_cli_session _) ->
         local_recovery_retry "resumable_cli_session"
-    | Some (Oas_worker_named.Admission_queue_timeout _) ->
+    | Some (Keeper_turn_driver.Admission_queue_timeout _) ->
         local_recovery_retry "admission_queue_timeout"
-    | Some (Oas_worker_named.Oas_timeout_budget _) ->
+    | Some (Keeper_turn_driver.Oas_timeout_budget _) ->
         local_recovery_retry "oas_timeout_budget"
-    | Some (Oas_worker_named.Turn_timeout _) ->
+    | Some (Keeper_turn_driver.Turn_timeout _) ->
         local_recovery_retry "turn_timeout"
     | Some
-        (Oas_worker_named.Cascade_exhausted
+        (Keeper_turn_driver.Cascade_exhausted
            { reason = Keeper_types.Candidates_filtered_after_cycles; _ }) ->
         local_recovery_retry "cascade_candidates_filtered"
     | Some
-        (Oas_worker_named.Cascade_exhausted
+        (Keeper_turn_driver.Cascade_exhausted
            { reason = Keeper_types.Max_turns_exceeded; _ }) ->
         local_recovery_retry "max_turns"
     | Some
-        (Oas_worker_named.Cascade_exhausted
+        (Keeper_turn_driver.Cascade_exhausted
            { reason = Keeper_types.Other_detail detail; _ })
-      when Oas_worker_named.message_looks_like_cli_wrapped_hard_quota detail ->
+      when Keeper_turn_driver.message_looks_like_cli_wrapped_hard_quota detail ->
         local_recovery_retry "hard_quota"
-    | Some (Oas_worker_named.Cascade_exhausted _)
-    | Some (Oas_worker_named.No_tool_capable_provider _)
-    | Some (Oas_worker_named.Accept_rejected _)
-    | Some (Oas_worker_named.Admission_queue_rejected _)
-    | Some (Oas_worker_named.Ambiguous_post_commit _)
+    | Some (Keeper_turn_driver.Cascade_exhausted _)
+    | Some (Keeper_turn_driver.No_tool_capable_provider _)
+    | Some (Keeper_turn_driver.Accept_rejected _)
+    | Some (Keeper_turn_driver.Admission_queue_rejected _)
+    | Some (Keeper_turn_driver.Ambiguous_post_commit _)
     | None ->
         None
 
 let recoverable_cascade_failure_reason (err : Agent_sdk.Error.sdk_error) =
   if is_required_tool_contract_violation err then
     Some "required_tool_contract_violation"
-  else if Oas_worker_named.sdk_error_is_hard_quota err then
+  else if Keeper_turn_driver.sdk_error_is_hard_quota err then
     Some "hard_quota"
-  else if Oas_worker_named.sdk_error_is_max_turns_exceeded err then
+  else if Keeper_turn_driver.sdk_error_is_max_turns_exceeded err then
     Some "max_turns"
   else
-    match Oas_worker_named.classify_masc_internal_error err with
-    | Some (Oas_worker_named.Resumable_cli_session _) ->
+    match Keeper_turn_driver.classify_masc_internal_error err with
+    | Some (Keeper_turn_driver.Resumable_cli_session _) ->
         Some "resumable_cli_session"
-    | Some (Oas_worker_named.Admission_queue_timeout _) ->
+    | Some (Keeper_turn_driver.Admission_queue_timeout _) ->
         Some "admission_queue_timeout"
-    | Some (Oas_worker_named.Oas_timeout_budget _) ->
+    | Some (Keeper_turn_driver.Oas_timeout_budget _) ->
         Some "oas_timeout_budget"
-    | Some (Oas_worker_named.Turn_timeout _) ->
+    | Some (Keeper_turn_driver.Turn_timeout _) ->
         Some "turn_timeout"
     | Some
-        (Oas_worker_named.Cascade_exhausted
+        (Keeper_turn_driver.Cascade_exhausted
            { reason = Keeper_types.Candidates_filtered_after_cycles; _ }) ->
         Some "cascade_candidates_filtered"
     | Some
-        (Oas_worker_named.Cascade_exhausted
+        (Keeper_turn_driver.Cascade_exhausted
            { reason = Keeper_types.Max_turns_exceeded; _ }) ->
         Some "max_turns"
     | Some
-        (Oas_worker_named.Cascade_exhausted
+        (Keeper_turn_driver.Cascade_exhausted
            { reason = Keeper_types.Other_detail detail; _ })
-      when Oas_worker_named.message_looks_like_cli_wrapped_hard_quota detail ->
+      when Keeper_turn_driver.message_looks_like_cli_wrapped_hard_quota detail ->
         Some "hard_quota"
-    | Some (Oas_worker_named.Cascade_exhausted _) ->
+    | Some (Keeper_turn_driver.Cascade_exhausted _) ->
         (* Generic cascade exhaustion: all candidates failed without a more
            specific reason. Treat as recoverable so declarative
            [fallback_cascade] hints declared in cascade.toml actually
@@ -309,10 +309,10 @@ let recoverable_cascade_failure_reason (err : Agent_sdk.Error.sdk_error) =
            arm previously returned [None]. Other arms below remain
            non-recoverable to keep the surface conservative. *)
         Some "cascade_exhausted"
-    | Some (Oas_worker_named.No_tool_capable_provider _)
-    | Some (Oas_worker_named.Accept_rejected _)
-    | Some (Oas_worker_named.Admission_queue_rejected _)
-    | Some (Oas_worker_named.Ambiguous_post_commit _) ->
+    | Some (Keeper_turn_driver.No_tool_capable_provider _)
+    | Some (Keeper_turn_driver.Accept_rejected _)
+    | Some (Keeper_turn_driver.Admission_queue_rejected _)
+    | Some (Keeper_turn_driver.Ambiguous_post_commit _) ->
         None
     | None ->
         (* Status-code-aware cascade rotation: raw provider API errors that are
@@ -481,7 +481,7 @@ let degraded_rotation_after_recoverable_error
 let is_auto_recoverable_turn_error (err : Agent_sdk.Error.sdk_error) : bool =
   is_transient_network_error err
   || is_server_rejected_parse_error err
-  || Oas_worker_named.sdk_error_is_max_turns_exceeded err
+  || Keeper_turn_driver.sdk_error_is_max_turns_exceeded err
   || is_resumable_cli_session_error err
   || is_auto_recoverable_cascade_exhausted_error err
 
@@ -494,8 +494,8 @@ let committed_mutating_tools tool_names =
   |> List.filter Keeper_exec_tools.has_mutating_side_effect
 
 let is_ambiguous_side_effect_error (err : Agent_sdk.Error.sdk_error) : bool =
-  match Oas_worker_named.classify_masc_internal_error err with
-  | Some (Oas_worker_named.Ambiguous_post_commit _) -> true
+  match Keeper_turn_driver.classify_masc_internal_error err with
+  | Some (Keeper_turn_driver.Ambiguous_post_commit _) -> true
   | None -> (
       match err with
       | Agent_sdk.Error.Internal msg ->
@@ -513,14 +513,14 @@ let is_ambiguous_side_effect_error (err : Agent_sdk.Error.sdk_error) : bool =
       | Agent_sdk.Error.Orchestration _
       | Agent_sdk.Error.A2a _ -> false)
   (* All other MASC-internal classifications are unambiguous failures. *)
-  | Some (Oas_worker_named.Cascade_exhausted _)
-  | Some (Oas_worker_named.No_tool_capable_provider _)
-  | Some (Oas_worker_named.Accept_rejected _)
-  | Some (Oas_worker_named.Resumable_cli_session _)
-  | Some (Oas_worker_named.Admission_queue_rejected _)
-  | Some (Oas_worker_named.Admission_queue_timeout _)
-  | Some (Oas_worker_named.Turn_timeout _)
-  | Some (Oas_worker_named.Oas_timeout_budget _) -> false
+  | Some (Keeper_turn_driver.Cascade_exhausted _)
+  | Some (Keeper_turn_driver.No_tool_capable_provider _)
+  | Some (Keeper_turn_driver.Accept_rejected _)
+  | Some (Keeper_turn_driver.Resumable_cli_session _)
+  | Some (Keeper_turn_driver.Admission_queue_rejected _)
+  | Some (Keeper_turn_driver.Admission_queue_timeout _)
+  | Some (Keeper_turn_driver.Turn_timeout _)
+  | Some (Keeper_turn_driver.Oas_timeout_budget _) -> false
 
 let reclassify_error_after_side_effect
     ~(tool_names : string list)
@@ -550,8 +550,8 @@ let reclassify_error_after_side_effect
       | Agent_sdk.Error.A2a _
       | Agent_sdk.Error.Internal _ -> false
     in
-    Oas_worker_named.sdk_error_of_masc_internal_error
-      (Oas_worker_named.Ambiguous_post_commit
+    Keeper_turn_driver.sdk_error_of_masc_internal_error
+      (Keeper_turn_driver.Ambiguous_post_commit
          { is_timeout; tools; original_error = original })
 
 let post_commit_failure_kind_of_error (err : Agent_sdk.Error.sdk_error) =
@@ -674,16 +674,16 @@ let is_context_overflow (err : Agent_sdk.Error.sdk_error) : bool =
 (** [true] when an error represents terminal cascade exhaustion or a
     final accept-rejected result from the MASC OAS boundary. *)
 let is_cascade_exhausted_error (err : Agent_sdk.Error.sdk_error) : bool =
-  match Oas_worker_named.classify_masc_internal_error err with
-  | Some (Oas_worker_named.Cascade_exhausted _)
-  | Some (Oas_worker_named.Resumable_cli_session _)
-  | Some (Oas_worker_named.No_tool_capable_provider _)
-  | Some (Oas_worker_named.Accept_rejected _) -> true
-  | Some (Oas_worker_named.Admission_queue_timeout _)
-  | Some (Oas_worker_named.Admission_queue_rejected _)
-  | Some (Oas_worker_named.Oas_timeout_budget _)
-  | Some (Oas_worker_named.Turn_timeout _)
-  | Some (Oas_worker_named.Ambiguous_post_commit _) -> false
+  match Keeper_turn_driver.classify_masc_internal_error err with
+  | Some (Keeper_turn_driver.Cascade_exhausted _)
+  | Some (Keeper_turn_driver.Resumable_cli_session _)
+  | Some (Keeper_turn_driver.No_tool_capable_provider _)
+  | Some (Keeper_turn_driver.Accept_rejected _) -> true
+  | Some (Keeper_turn_driver.Admission_queue_timeout _)
+  | Some (Keeper_turn_driver.Admission_queue_rejected _)
+  | Some (Keeper_turn_driver.Oas_timeout_budget _)
+  | Some (Keeper_turn_driver.Turn_timeout _)
+  | Some (Keeper_turn_driver.Ambiguous_post_commit _) -> false
   | None -> false
 
 (** [true] when the rotation-cap fast-fail should fire for a

--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -372,8 +372,8 @@ let prior_oas_timeout_budget_strikes ~base_path ~keeper_name =
   | _ -> 0
 
 let is_oas_timeout_budget_error (err : Agent_sdk.Error.sdk_error) =
-  match Oas_worker_named.classify_masc_internal_error err with
-  | Some (Oas_worker_named.Oas_timeout_budget _) -> true
+  match Keeper_turn_driver.classify_masc_internal_error err with
+  | Some (Keeper_turn_driver.Oas_timeout_budget _) -> true
   | _ -> false
 
 let persist_message_cursor_updates ~config (meta : keeper_meta) updates =

--- a/lib/keeper/keeper_status_bridge.ml
+++ b/lib/keeper/keeper_status_bridge.ml
@@ -202,24 +202,24 @@ let blocker_class_of_string (reason : string) : blocker_class option =
     None
 
 let blocker_class_of_sdk_error (err : Agent_sdk.Error.sdk_error) : blocker_class option =
-  match Oas_worker_named.classify_masc_internal_error err with
-  | Some (Oas_worker_named.Cascade_exhausted { reason; _ }) ->
+  match Keeper_turn_driver.classify_masc_internal_error err with
+  | Some (Keeper_turn_driver.Cascade_exhausted { reason; _ }) ->
       Some (Cascade_exhausted reason)
-  | Some (Oas_worker_named.Resumable_cli_session { detail; _ }) ->
+  | Some (Keeper_turn_driver.Resumable_cli_session { detail; _ }) ->
       Some (Cascade_exhausted (Other_detail detail))
-  | Some (Oas_worker_named.No_tool_capable_provider _) ->
+  | Some (Keeper_turn_driver.No_tool_capable_provider _) ->
       Some No_tool_capable_provider
-  | Some (Oas_worker_named.Accept_rejected _) ->
+  | Some (Keeper_turn_driver.Accept_rejected _) ->
       None
-  | Some (Oas_worker_named.Admission_queue_timeout _) ->
+  | Some (Keeper_turn_driver.Admission_queue_timeout _) ->
       Some Admission_queue_wait_timeout
-  | Some (Oas_worker_named.Admission_queue_rejected _) ->
+  | Some (Keeper_turn_driver.Admission_queue_rejected _) ->
       None
-  | Some (Oas_worker_named.Oas_timeout_budget _) ->
+  | Some (Keeper_turn_driver.Oas_timeout_budget _) ->
       Some Oas_timeout_budget
-  | Some (Oas_worker_named.Turn_timeout _) ->
+  | Some (Keeper_turn_driver.Turn_timeout _) ->
       Some Turn_timeout
-  | Some (Oas_worker_named.Ambiguous_post_commit { is_timeout; _ }) ->
+  | Some (Keeper_turn_driver.Ambiguous_post_commit { is_timeout; _ }) ->
       Some
         (if is_timeout then Ambiguous_post_commit_timeout
          else Ambiguous_post_commit_failure)
@@ -279,11 +279,11 @@ let runtime_blocker_surface_of_typed_class ?(summary = "") (cls : blocker_class)
         else summary
     | No_tool_capable_provider -> (
         match
-          Oas_worker_named.classify_masc_internal_error
+          Keeper_turn_driver.classify_masc_internal_error
             (Agent_sdk.Error.Internal summary)
         with
         | Some err -> (
-            match Oas_worker_named.summary_of_masc_internal_error err with
+            match Keeper_turn_driver.summary_of_masc_internal_error err with
             | Some structured_summary -> structured_summary
             | None -> if summary = "" then str else summary)
         | None -> if summary = "" then str else summary)

--- a/lib/keeper/keeper_turn_cascade_budget.ml
+++ b/lib/keeper/keeper_turn_cascade_budget.ml
@@ -306,8 +306,8 @@ let degraded_retry_slot_phase_available ~(time_spent_in_turn_s : float) : bool =
 
 let degraded_retry_bypasses_slot_phase_guard
     (err : Agent_sdk.Error.sdk_error) : bool =
-  match Oas_worker_named.classify_masc_internal_error err with
-  | Some (Oas_worker_named.Oas_timeout_budget _) -> true
+  match Keeper_turn_driver.classify_masc_internal_error err with
+  | Some (Keeper_turn_driver.Oas_timeout_budget _) -> true
   | _ -> false
 
 let reclassify_oas_timeout_for_attempt
@@ -316,8 +316,8 @@ let reclassify_oas_timeout_for_attempt
   match err, timeout_budget with
   | Agent_sdk.Error.Api (Timeout { message }), Some timeout_budget
     when EC.is_structural_oas_timeout_message message ->
-      Oas_worker_named.sdk_error_of_masc_internal_error
-        (Oas_worker_named.Oas_timeout_budget
+      Keeper_turn_driver.sdk_error_of_masc_internal_error
+        (Keeper_turn_driver.Oas_timeout_budget
            {
              budget_sec = timeout_budget.effective_timeout_sec;
              keeper_turn_timeout_sec =

--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -1,4 +1,4 @@
-(** Oas_worker_named — MASC named-cascade and model-label execution entry points.
+(** Keeper_turn_driver — MASC named-cascade and model-label execution entry points.
 
     Public API for running OAS agents through MASC-managed named cascade
     profiles ([run_named])

--- a/lib/keeper/keeper_turn_driver.mli
+++ b/lib/keeper/keeper_turn_driver.mli
@@ -1,4 +1,4 @@
-(** Oas_worker_named — MASC named-cascade and model-label execution entry points.
+(** Keeper_turn_driver — MASC named-cascade and model-label execution entry points.
 
     Public API for running OAS agents through MASC-managed named cascade
     profiles ([run_named]) or explicit model label ([run_model_by_label]),

--- a/lib/keeper/keeper_turn_terminal.ml
+++ b/lib/keeper/keeper_turn_terminal.ml
@@ -102,10 +102,10 @@ let of_failure ?(post_commit_ambiguous = false) ?(tool_call_count = 0) ~raw_erro
   if post_commit_ambiguous
   then make ~source:"typed_error" "post_commit_ambiguous"
   else (
-    match Oas_worker_named.classify_masc_internal_error err with
-    | Some (Oas_worker_named.Oas_timeout_budget _) ->
+    match Keeper_turn_driver.classify_masc_internal_error err with
+    | Some (Keeper_turn_driver.Oas_timeout_budget _) ->
       make ~source:"typed_error" "oas_timeout_budget"
-    | Some (Oas_worker_named.Turn_timeout _) ->
+    | Some (Keeper_turn_driver.Turn_timeout _) ->
       make ~source:"typed_error" "turn_wall_clock_timeout"
     | _ ->
       (match err with

--- a/lib/keeper/keeper_unified_metrics.ml
+++ b/lib/keeper/keeper_unified_metrics.ml
@@ -1615,18 +1615,18 @@ let update_metrics_from_failure (meta : keeper_meta) ~(latency_ms : int)
   let public_reason =
     match sdk_error with
     | Some err -> (
-        match Oas_worker_named.classify_masc_internal_error err with
-        | Some (Oas_worker_named.Resumable_cli_session { detail; _ }) ->
+        match Keeper_turn_driver.classify_masc_internal_error err with
+        | Some (Keeper_turn_driver.Resumable_cli_session { detail; _ }) ->
             let trimmed = String.trim detail in
             if trimmed = "" then reason else trimmed
         | Some
-            (Oas_worker_named.Oas_timeout_budget
+            (Keeper_turn_driver.Oas_timeout_budget
                _ as err) ->
             Option.value
               ~default:reason
-              (Oas_worker_named.summary_of_masc_internal_error err)
-        | Some (Oas_worker_named.No_tool_capable_provider _ as err) -> (
-            match Oas_worker_named.summary_of_masc_internal_error err with
+              (Keeper_turn_driver.summary_of_masc_internal_error err)
+        | Some (Keeper_turn_driver.No_tool_capable_provider _ as err) -> (
+            match Keeper_turn_driver.summary_of_masc_internal_error err with
             | Some summary -> summary
             | None -> reason)
         | _ -> reason)
@@ -1637,14 +1637,14 @@ let update_metrics_from_failure (meta : keeper_meta) ~(latency_ms : int)
     &&
     match sdk_error with
     | Some err -> (
-        match Oas_worker_named.classify_masc_internal_error err with
+        match Keeper_turn_driver.classify_masc_internal_error err with
         | Some
-            (Oas_worker_named.Oas_timeout_budget _
-            | Oas_worker_named.Turn_timeout _
-            | Oas_worker_named.Admission_queue_timeout _
-            | Oas_worker_named.Admission_queue_rejected _
-            | Oas_worker_named.Resumable_cli_session _
-            | Oas_worker_named.No_tool_capable_provider _) ->
+            (Keeper_turn_driver.Oas_timeout_budget _
+            | Keeper_turn_driver.Turn_timeout _
+            | Keeper_turn_driver.Admission_queue_timeout _
+            | Keeper_turn_driver.Admission_queue_rejected _
+            | Keeper_turn_driver.Resumable_cli_session _
+            | Keeper_turn_driver.No_tool_capable_provider _) ->
             true
         | Some _ | None -> false)
     | None -> false
@@ -1653,11 +1653,11 @@ let update_metrics_from_failure (meta : keeper_meta) ~(latency_ms : int)
      cycle outcomes so Grafana can surface fleet-wide health ratios. *)
   (match sdk_error with
    | Some err ->
-       (match Oas_worker_named.classify_masc_internal_error err with
-        | Some (Oas_worker_named.No_tool_capable_provider
+       (match Keeper_turn_driver.classify_masc_internal_error err with
+        | Some (Keeper_turn_driver.No_tool_capable_provider
 	                  { cascade_name; _ }) ->
             let cascade_name =
-              Oas_worker_named.cascade_name_to_string cascade_name
+              Keeper_turn_driver.cascade_name_to_string cascade_name
             in
             Prometheus.inc_counter
               Keeper_metrics.metric_keeper_no_tool_provider

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -1138,8 +1138,8 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
               with
               | None ->
                   Error
-                    (Oas_worker_named.sdk_error_of_masc_internal_error
-                       (Oas_worker_named.Oas_timeout_budget
+                    (Keeper_turn_driver.sdk_error_of_masc_internal_error
+                       (Keeper_turn_driver.Oas_timeout_budget
                           {
                             budget_sec = 0.0;
                             keeper_turn_timeout_sec = timeout_sec;
@@ -1729,8 +1729,8 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
                 ~base_path:config.base_path meta.name
                 Keeper_registry.(Packed Turn_finalizing);
               Error
-                (Oas_worker_named.sdk_error_of_masc_internal_error
-                   (Oas_worker_named.Turn_timeout
+                (Keeper_turn_driver.sdk_error_of_masc_internal_error
+                   (Keeper_turn_driver.Turn_timeout
                       { elapsed_sec = timeout_sec }))
             end))
         with
@@ -1779,12 +1779,12 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
             (Trajectory.Failed (Agent_sdk.Error.to_string err));
           let e_str = Agent_sdk.Error.to_string err in
           let is_transient = EC.is_transient_network_error err in
-          (match Oas_worker_named.classify_masc_internal_error err with
-           | Some (Oas_worker_named.Oas_timeout_budget _) ->
+          (match Keeper_turn_driver.classify_masc_internal_error err with
+           | Some (Keeper_turn_driver.Oas_timeout_budget _) ->
                Prometheus.inc_counter
                  Keeper_metrics.metric_keeper_oas_timeout_classifications
                  ~labels:[("classification", "structural_budget")] ()
-           | Some (Oas_worker_named.Turn_timeout _) ->
+           | Some (Keeper_turn_driver.Turn_timeout _) ->
                Prometheus.inc_counter
                  Keeper_metrics.metric_keeper_oas_timeout_classifications
                  ~labels:[("classification", "turn_wall_clock")] ()

--- a/lib/oas_worker.ml
+++ b/lib/oas_worker.ml
@@ -5,7 +5,7 @@
     Implementation split into:
     - {!Cascade_legacy_runner} — cascade metrics types, observation, recording
     - {!Cascade_runner} — config, build, run, run_with_masc_tools
-    - {!Oas_worker_named} — run_named, run_model_by_label, convenience wrappers
+    - {!Keeper_turn_driver} — run_named, run_model_by_label, convenience wrappers
 
     @since God file decomposition *)
 
@@ -13,4 +13,4 @@
    so the alias is available for the .mli contract. *)
 include Cascade_runner
 include Cascade_legacy_runner
-include Oas_worker_named
+include Keeper_turn_driver

--- a/lib/verifier_oas.ml
+++ b/lib/verifier_oas.ml
@@ -114,7 +114,7 @@ let verify (req : verification_request) : (verdict, string) result =
         Keeper_cascade_profile.Verifier
     in
     match
-      Oas_worker_named.run_named_with_masc_tools
+      Keeper_turn_driver.run_named_with_masc_tools
         ~cascade_name
         ~goal:prompt
         ~masc_tools:[report_verdict_schema]

--- a/test/test_approval_callback_wired.ml
+++ b/test/test_approval_callback_wired.ml
@@ -20,7 +20,7 @@
        callback (with_approval, or threads ~approval to a helper that
        does). Missing wiring → fail-open, the exact bug #7883.
     4. Structural: every MASC call site of
-       [Oas_worker.run_named] / [Oas_worker_named.run_named*] passes
+       [Oas_worker.run_named] / [Keeper_turn_driver.run_named*] passes
        [~approval:...].
 
     Detection is grep-based on source. False positives are acceptable
@@ -169,7 +169,7 @@ let test_builder_sites_wire_approval () =
     builder_sites
 
 (** Every MASC call site of [Oas_worker.run_named] or
-    [Oas_worker_named.run_named*] must pass [~approval:...]. The
+    [Keeper_turn_driver.run_named*] must pass [~approval:...]. The
     regex matches any argument value so callers may install
     auto_approve, reject_by_default, or a governance callback. *)
 let run_named_sites = [

--- a/test/test_keeper_cascade_auto_pause_task074.ml
+++ b/test/test_keeper_cascade_auto_pause_task074.ml
@@ -26,7 +26,7 @@
 
 open Alcotest
 module EC = Masc_mcp.Keeper_error_classify
-module Owne = Masc_mcp.Oas_worker_named
+module Owne = Masc_mcp.Keeper_turn_driver
 module KT = Masc_mcp.Keeper_types
 module Regime = Masc_mcp.Keeper_behavioral_regime
 module UT = Masc_mcp.Keeper_unified_turn

--- a/test/test_keeper_error_classify_recoverable.ml
+++ b/test/test_keeper_error_classify_recoverable.ml
@@ -17,7 +17,7 @@
 
 open Alcotest
 module KEC = Masc_mcp.Keeper_error_classify
-module Owne = Masc_mcp.Oas_worker_named
+module Owne = Masc_mcp.Keeper_turn_driver
 module KT = Masc_mcp.Keeper_types
 module Retry = Llm_provider.Retry
 

--- a/test/test_keeper_exec_status.ml
+++ b/test/test_keeper_exec_status.ml
@@ -8,7 +8,7 @@ module KT = Masc_mcp.Keeper_types
 module KMP = Masc_mcp.Keeper_memory_policy
 module KTS = Masc_mcp.Keeper_types_support
 module Coord = Masc_mcp.Coord
-module OWN = Masc_mcp.Oas_worker_named
+module OWN = Masc_mcp.Keeper_turn_driver
 module Prom = Masc_mcp.Prometheus
 
 let keeper_health_testable : KT.keeper_health Alcotest.testable =

--- a/test/test_keeper_terminal_reason.ml
+++ b/test/test_keeper_terminal_reason.ml
@@ -264,8 +264,8 @@ let test_structured_required_tool_no_tool_call () =
 
 let test_structured_oas_timeout_budget () =
   let err =
-    Masc_mcp.Oas_worker_named.sdk_error_of_masc_internal_error
-      (Masc_mcp.Oas_worker_named.Oas_timeout_budget
+    Masc_mcp.Keeper_turn_driver.sdk_error_of_masc_internal_error
+      (Masc_mcp.Keeper_turn_driver.Oas_timeout_budget
          {
            budget_sec = 90.0;
            keeper_turn_timeout_sec = 1200.0;
@@ -286,8 +286,8 @@ let test_structured_oas_timeout_budget () =
 
 let test_structured_turn_wall_clock_timeout () =
   let err =
-    Masc_mcp.Oas_worker_named.sdk_error_of_masc_internal_error
-      (Masc_mcp.Oas_worker_named.Turn_timeout { elapsed_sec = 1200.0 })
+    Masc_mcp.Keeper_turn_driver.sdk_error_of_masc_internal_error
+      (Masc_mcp.Keeper_turn_driver.Turn_timeout { elapsed_sec = 1200.0 })
   in
   let terminal =
     KT.of_failure ~raw_error:(Agent_sdk.Error.to_string err) err

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -24,7 +24,7 @@ module OMR = Masc_mcp.Cascade_runtime
 module AQ = Masc_mcp.Keeper_approval_queue
 module Keeper_types = Masc_mcp.Keeper_types
 
-let oas_error_cascade_name = Masc_mcp.Oas_worker_named.cascade_name_of_string
+let oas_error_cascade_name = Masc_mcp.Keeper_turn_driver.cascade_name_of_string
 
 let has_prompt_root path =
   Sys.file_exists (Filename.concat path "config/prompts/keeper.unified.system.md")
@@ -4621,8 +4621,8 @@ let wrapped_claude_max_turns_error () =
        })
 
 let wrapped_cascade_max_turns_error () =
-  Masc_mcp.Oas_worker_named.sdk_error_of_masc_internal_error
-    (Masc_mcp.Oas_worker_named.Cascade_exhausted
+  Masc_mcp.Keeper_turn_driver.sdk_error_of_masc_internal_error
+    (Masc_mcp.Keeper_turn_driver.Cascade_exhausted
        {
          cascade_name =
            oas_error_cascade_name Masc_mcp.Keeper_config.default_cascade_name;
@@ -4659,8 +4659,8 @@ let test_degraded_retry_after_recoverable_error_uses_local_recovery_for_resumabl
     EC.degraded_retry_after_recoverable_error
       ~effective_cascade:"underdog"
       ~tool_requirement:Masc_mcp.Keeper_agent_tool_surface.Optional
-      (Masc_mcp.Oas_worker_named.sdk_error_of_masc_internal_error
-         (Masc_mcp.Oas_worker_named.Resumable_cli_session
+      (Masc_mcp.Keeper_turn_driver.sdk_error_of_masc_internal_error
+         (Masc_mcp.Keeper_turn_driver.Resumable_cli_session
             {
               cascade_name = oas_error_cascade_name "kimi_cli_keeper";
               detail =
@@ -4676,8 +4676,8 @@ let test_degraded_retry_after_recoverable_error_includes_admission_queue_timeout
     EC.degraded_retry_after_recoverable_error
       ~effective_cascade:"underdog"
       ~tool_requirement:Masc_mcp.Keeper_agent_tool_surface.Optional
-      (Masc_mcp.Oas_worker_named.sdk_error_of_masc_internal_error
-         (Masc_mcp.Oas_worker_named.Admission_queue_timeout
+      (Masc_mcp.Keeper_turn_driver.sdk_error_of_masc_internal_error
+         (Masc_mcp.Keeper_turn_driver.Admission_queue_timeout
             {
               keeper_name = "nick0cave";
               cascade_name = oas_error_cascade_name "big_three";
@@ -4692,8 +4692,8 @@ let test_degraded_retry_after_recoverable_error_includes_turn_timeout () =
     EC.degraded_retry_after_recoverable_error
       ~effective_cascade:"underdog"
       ~tool_requirement:Masc_mcp.Keeper_agent_tool_surface.Optional
-      (Masc_mcp.Oas_worker_named.sdk_error_of_masc_internal_error
-         (Masc_mcp.Oas_worker_named.Turn_timeout { elapsed_sec = 180.0 }))
+      (Masc_mcp.Keeper_turn_driver.sdk_error_of_masc_internal_error
+         (Masc_mcp.Keeper_turn_driver.Turn_timeout { elapsed_sec = 180.0 }))
   in
   expect_degraded_retry "turn timeout degraded retry"
     KC.local_recovery_cascade_name "turn_timeout" degraded_retry
@@ -4703,8 +4703,8 @@ let test_degraded_retry_after_recoverable_error_includes_oas_timeout_budget () =
     EC.degraded_retry_after_recoverable_error
       ~effective_cascade:"underdog"
       ~tool_requirement:Masc_mcp.Keeper_agent_tool_surface.Optional
-      (Masc_mcp.Oas_worker_named.sdk_error_of_masc_internal_error
-         (Masc_mcp.Oas_worker_named.Oas_timeout_budget
+      (Masc_mcp.Keeper_turn_driver.sdk_error_of_masc_internal_error
+         (Masc_mcp.Keeper_turn_driver.Oas_timeout_budget
             {
               budget_sec = 273.0;
               keeper_turn_timeout_sec = 1200.0;
@@ -5251,8 +5251,8 @@ let test_metrics_failure_response () =
 
 let test_metrics_failure_timeout_increments_proactive_backoff () =
   let sdk_error =
-    Masc_mcp.Oas_worker_named.sdk_error_of_masc_internal_error
-      (Masc_mcp.Oas_worker_named.Oas_timeout_budget
+    Masc_mcp.Keeper_turn_driver.sdk_error_of_masc_internal_error
+      (Masc_mcp.Keeper_turn_driver.Oas_timeout_budget
          {
            budget_sec = 90.0;
            keeper_turn_timeout_sec = 90.0;
@@ -5281,8 +5281,8 @@ let test_metrics_failure_response_redacts_resumable_cli_session_detail () =
     Masc_mcp.Cascade_runner.Kimi_cli_transport_local.resumable_session_detail
   in
   let sdk_error =
-    Masc_mcp.Oas_worker_named.sdk_error_of_masc_internal_error
-      (Masc_mcp.Oas_worker_named.Resumable_cli_session
+    Masc_mcp.Keeper_turn_driver.sdk_error_of_masc_internal_error
+      (Masc_mcp.Keeper_turn_driver.Resumable_cli_session
          {
            cascade_name = oas_error_cascade_name "kimi_cli_keeper";
            detail = canonical_detail;
@@ -5777,8 +5777,8 @@ let test_should_cap_rotation_ignores_non_contract_violation_error () =
 
 let test_cascade_exhausted_error_detected_from_structured_internal_error () =
   let err =
-    Masc_mcp.Oas_worker_named.sdk_error_of_masc_internal_error
-      (Masc_mcp.Oas_worker_named.Cascade_exhausted
+    Masc_mcp.Keeper_turn_driver.sdk_error_of_masc_internal_error
+      (Masc_mcp.Keeper_turn_driver.Cascade_exhausted
          {
            cascade_name =
              oas_error_cascade_name Masc_mcp.Keeper_config.default_cascade_name;
@@ -5819,8 +5819,8 @@ let test_auto_recoverable_turn_error_excludes_persistent_errors () =
 
 let test_auto_recoverable_turn_error_includes_wrapped_cascade_exhausted_hard_quota () =
   let err =
-    Masc_mcp.Oas_worker_named.sdk_error_of_masc_internal_error
-      (Masc_mcp.Oas_worker_named.Cascade_exhausted
+    Masc_mcp.Keeper_turn_driver.sdk_error_of_masc_internal_error
+      (Masc_mcp.Keeper_turn_driver.Cascade_exhausted
          {
            cascade_name =
              oas_error_cascade_name Masc_mcp.Keeper_config.default_cascade_name;
@@ -5838,8 +5838,8 @@ let test_auto_recoverable_turn_error_includes_wrapped_cascade_max_turns () =
 
 let test_auto_recoverable_turn_error_includes_filtered_candidates_cascade_exhaustion () =
   let err =
-    Masc_mcp.Oas_worker_named.sdk_error_of_masc_internal_error
-      (Masc_mcp.Oas_worker_named.Cascade_exhausted
+    Masc_mcp.Keeper_turn_driver.sdk_error_of_masc_internal_error
+      (Masc_mcp.Keeper_turn_driver.Cascade_exhausted
          {
            cascade_name =
              oas_error_cascade_name Masc_mcp.Keeper_config.default_cascade_name;
@@ -5851,8 +5851,8 @@ let test_auto_recoverable_turn_error_includes_filtered_candidates_cascade_exhaus
 
 let test_auto_recoverable_turn_error_includes_resumable_cli_session_error () =
   let err =
-    Masc_mcp.Oas_worker_named.sdk_error_of_masc_internal_error
-      (Masc_mcp.Oas_worker_named.Resumable_cli_session
+    Masc_mcp.Keeper_turn_driver.sdk_error_of_masc_internal_error
+      (Masc_mcp.Keeper_turn_driver.Resumable_cli_session
          {
            cascade_name = oas_error_cascade_name "kimi_cli_keeper";
            detail =
@@ -5865,8 +5865,8 @@ let test_auto_recoverable_turn_error_includes_resumable_cli_session_error () =
 
 let test_cascade_exhausted_error_includes_resumable_cli_session_error () =
   let err =
-    Masc_mcp.Oas_worker_named.sdk_error_of_masc_internal_error
-      (Masc_mcp.Oas_worker_named.Resumable_cli_session
+    Masc_mcp.Keeper_turn_driver.sdk_error_of_masc_internal_error
+      (Masc_mcp.Keeper_turn_driver.Resumable_cli_session
          {
            cascade_name = oas_error_cascade_name "kimi_cli_keeper";
            detail =
@@ -6031,9 +6031,9 @@ let test_oas_timeout_reclassifies_only_current_attempt_budget () =
           err
       in
       (match
-         Masc_mcp.Oas_worker_named.classify_masc_internal_error classified
+         Masc_mcp.Keeper_turn_driver.classify_masc_internal_error classified
        with
-       | Some (Masc_mcp.Oas_worker_named.Oas_timeout_budget budget) ->
+       | Some (Masc_mcp.Keeper_turn_driver.Oas_timeout_budget budget) ->
            check int "estimated tokens preserved" 2_000
              budget.estimated_input_tokens;
            check string "source preserved" timeout_budget.source budget.source;
@@ -6057,11 +6057,11 @@ let test_pre_retry_timeout_helper_does_not_reuse_stale_budget () =
   in
   check bool "plain helper call without budget stays raw timeout" true
     (Option.is_none
-       (Masc_mcp.Oas_worker_named.classify_masc_internal_error classified))
+       (Masc_mcp.Keeper_turn_driver.classify_masc_internal_error classified))
 
 let oas_timeout_budget_error () =
-  Masc_mcp.Oas_worker_named.sdk_error_of_masc_internal_error
-    (Masc_mcp.Oas_worker_named.Oas_timeout_budget
+  Masc_mcp.Keeper_turn_driver.sdk_error_of_masc_internal_error
+    (Masc_mcp.Keeper_turn_driver.Oas_timeout_budget
        {
          budget_sec = 273.0;
          keeper_turn_timeout_sec = 1200.0;

--- a/test/test_oas_error_kind_counter.ml
+++ b/test/test_oas_error_kind_counter.ml
@@ -1,13 +1,13 @@
 (* test/test_oas_error_kind_counter.ml
 
-   #9933: verify that [Oas_worker_named.sdk_error_of_masc_internal_error]
+   #9933: verify that [Keeper_turn_driver.sdk_error_of_masc_internal_error]
    emits [masc_oas_error_total{kind}] once per constructed error so
    Grafana can alert on per-kind rates without parsing the
    free-form BDI blocker string.  Exercises all 9 variants of
    [masc_internal_error] (the single production source of
    [masc_oas_error] payloads). *)
 
-module OWN = Masc_mcp.Oas_worker_named
+module OWN = Masc_mcp.Keeper_turn_driver
 module Prom = Masc_mcp.Prometheus
 
 let typed_cascade_name = OWN.cascade_name_of_string

--- a/test/test_oas_worker.ml
+++ b/test/test_oas_worker.ml
@@ -51,8 +51,8 @@ open Masc_mcp
 
 module Oas = Agent_sdk
 
-let internal_cascade_name = Oas_worker_named.cascade_name_of_string
-let internal_cascade_name_to_string = Oas_worker_named.cascade_name_to_string
+let internal_cascade_name = Keeper_turn_driver.cascade_name_of_string
+let internal_cascade_name_to_string = Keeper_turn_driver.cascade_name_to_string
 
 let ctx_messages = Keeper_exec_context.messages_of_context
 let ctx_system_prompt = Keeper_exec_context.system_prompt_of_context
@@ -920,7 +920,7 @@ let test_sdk_error_is_hard_quota_detects_gemini_cli_network_wrapper () =
          })
   in
   Alcotest.(check bool) "Gemini CLI quota wrapper counts as hard quota" true
-    (Oas_worker_named.sdk_error_is_hard_quota err)
+    (Keeper_turn_driver.sdk_error_is_hard_quota err)
 
 let test_sdk_error_is_hard_quota_detects_claude_cli_limit_wrapper () =
   let err =
@@ -933,7 +933,7 @@ let test_sdk_error_is_hard_quota_detects_claude_cli_limit_wrapper () =
          })
   in
   Alcotest.(check bool) "Claude CLI limit wrapper counts as hard quota" true
-    (Oas_worker_named.sdk_error_is_hard_quota err)
+    (Keeper_turn_driver.sdk_error_is_hard_quota err)
 
 let test_sdk_error_is_hard_quota_detects_claude_org_monthly_limit_wrapper () =
   let err =
@@ -946,7 +946,7 @@ let test_sdk_error_is_hard_quota_detects_claude_org_monthly_limit_wrapper () =
          })
   in
   Alcotest.(check bool) "Claude org monthly usage limit counts as hard quota" true
-    (Oas_worker_named.sdk_error_is_hard_quota err)
+    (Keeper_turn_driver.sdk_error_is_hard_quota err)
 
 (* 2026-04-29: Anthropic console started returning the user-set monthly cap
    as HTTP 400 [invalid_request_error] instead of a 429.  The CLI wrapper
@@ -968,7 +968,7 @@ let test_sdk_error_is_hard_quota_detects_claude_specified_limit_cli_wrapper () =
   in
   Alcotest.(check bool)
     "Claude CLI 400-wrapped specified-limit counts as hard quota" true
-    (Oas_worker_named.sdk_error_is_hard_quota err)
+    (Keeper_turn_driver.sdk_error_is_hard_quota err)
 
 let test_sdk_error_is_hard_quota_detects_anthropic_invalid_request_specified_limit () =
   let err =
@@ -982,7 +982,7 @@ let test_sdk_error_is_hard_quota_detects_anthropic_invalid_request_specified_lim
   in
   Alcotest.(check bool)
     "Direct Anthropic InvalidRequest specified-limit counts as hard quota" true
-    (Oas_worker_named.sdk_error_is_hard_quota err)
+    (Keeper_turn_driver.sdk_error_is_hard_quota err)
 
 let test_sdk_error_is_max_turns_detects_claude_cli_wrapper () =
   let err =
@@ -995,9 +995,9 @@ let test_sdk_error_is_max_turns_detects_claude_cli_wrapper () =
          })
   in
   Alcotest.(check bool) "Claude CLI max turns counts as max-turns" true
-    (Oas_worker_named.sdk_error_is_max_turns_exceeded err);
+    (Keeper_turn_driver.sdk_error_is_max_turns_exceeded err);
   Alcotest.(check bool) "Claude CLI max turns is not hard quota" false
-    (Oas_worker_named.sdk_error_is_hard_quota err)
+    (Keeper_turn_driver.sdk_error_is_hard_quota err)
 
 let test_sdk_error_is_hard_quota_keeps_transient_network_errors_false () =
   let err =
@@ -1009,7 +1009,7 @@ let test_sdk_error_is_hard_quota_keeps_transient_network_errors_false () =
          })
   in
   Alcotest.(check bool) "transient network error stays transient" false
-    (Oas_worker_named.sdk_error_is_hard_quota err)
+    (Keeper_turn_driver.sdk_error_is_hard_quota err)
 
 let test_sdk_error_is_hard_quota_preserves_rate_limited_detection () =
   let err =
@@ -1018,7 +1018,7 @@ let test_sdk_error_is_hard_quota_preserves_rate_limited_detection () =
          { retry_after = None; message = "resource exhausted" })
   in
   Alcotest.(check bool) "existing RateLimited hard quota still works" true
-    (Oas_worker_named.sdk_error_is_hard_quota err)
+    (Keeper_turn_driver.sdk_error_is_hard_quota err)
 
 let test_sdk_error_is_hard_quota_keeps_not_found_false () =
   let err =
@@ -1027,7 +1027,7 @@ let test_sdk_error_is_hard_quota_keeps_not_found_false () =
          { message = {|{"detail":"Not Found"}|} })
   in
   Alcotest.(check bool) "404-like InvalidRequest stays non-hard-quota" false
-    (Oas_worker_named.sdk_error_is_hard_quota err)
+    (Keeper_turn_driver.sdk_error_is_hard_quota err)
 
 let test_sdk_error_to_cascade_outcome_maps_not_found_to_404 () =
   let err =
@@ -1035,7 +1035,7 @@ let test_sdk_error_to_cascade_outcome_maps_not_found_to_404 () =
       (Llm_provider.Retry.InvalidRequest
          { message = {|{"detail":"Not Found"}|} })
   in
-  match Oas_worker_named.sdk_error_to_cascade_outcome err with
+  match Keeper_turn_driver.sdk_error_to_cascade_outcome err with
   | Some
       (Cascade_fsm.Call_err
          (Llm_provider.Http_client.HttpError
@@ -1051,7 +1051,7 @@ let test_sdk_error_to_cascade_outcome_keeps_invalid_request_as_400 () =
       (Llm_provider.Retry.InvalidRequest
          { message = {|{"detail":"Bad Request"}|} })
   in
-  match Oas_worker_named.sdk_error_to_cascade_outcome err with
+  match Keeper_turn_driver.sdk_error_to_cascade_outcome err with
   | Some
       (Cascade_fsm.Call_err
          (Llm_provider.Http_client.HttpError
@@ -1066,7 +1066,7 @@ let test_sdk_error_to_cascade_outcome_cascades_model_access_denied () =
   let err =
     Agent_sdk.Error.Api (Llm_provider.Retry.InvalidRequest { message })
   in
-  match Oas_worker_named.sdk_error_to_cascade_outcome err with
+  match Keeper_turn_driver.sdk_error_to_cascade_outcome err with
   | Some
       (Cascade_fsm.Call_err
          (Llm_provider.Http_client.ProviderFailure
@@ -1100,10 +1100,10 @@ let test_sdk_error_is_model_access_denied_predicate () =
       (Llm_provider.Retry.InvalidRequest { message = {|{"detail":"Bad Request"}|} })
   in
   Alcotest.(check bool) "model access denied is detected" true
-    (Oas_worker_named.sdk_error_is_model_access_denied denied);
+    (Keeper_turn_driver.sdk_error_is_model_access_denied denied);
   Alcotest.(check bool) "ordinary invalid request is not model access denial"
     false
-    (Oas_worker_named.sdk_error_is_model_access_denied ordinary)
+    (Keeper_turn_driver.sdk_error_is_model_access_denied ordinary)
 
 let test_sdk_error_to_cascade_outcome_cascades_runtime_mcp_auth_config () =
   let detail = "codex_cli runtime MCP cannot carry keeper-bound auth headers" in
@@ -1111,7 +1111,7 @@ let test_sdk_error_to_cascade_outcome_cascades_runtime_mcp_auth_config () =
     Agent_sdk.Error.Config
       (Agent_sdk.Error.InvalidConfig { field = "runtime_mcp_auth"; detail })
   in
-  match Oas_worker_named.sdk_error_to_cascade_outcome err with
+  match Keeper_turn_driver.sdk_error_to_cascade_outcome err with
   | Some
       (Cascade_fsm.Call_err
          (Llm_provider.Http_client.AcceptRejected { reason })) ->
@@ -1134,18 +1134,18 @@ let test_sdk_error_to_cascade_outcome_cascades_resumable_cli_session () =
   in
   let structured =
     match
-      Oas_worker_named.sdk_error_to_resumable_cli_session
+      Keeper_turn_driver.sdk_error_to_resumable_cli_session
         ~cascade_name:(internal_cascade_name "tool_use_strict") sdk_error
     with
     | Some structured -> structured
     | None -> Alcotest.fail "expected structured resumable CLI session"
   in
-  match Oas_worker_named.sdk_error_to_cascade_outcome structured with
+  match Keeper_turn_driver.sdk_error_to_cascade_outcome structured with
   | Some
       (Cascade_fsm.Call_err
          (Llm_provider.Http_client.NetworkError { message; kind })) ->
       Alcotest.(check bool) "detail remains resumable marker" true
-        (Oas_worker_named.message_looks_like_resumable_cli_session message);
+        (Keeper_turn_driver.message_looks_like_resumable_cli_session message);
       Alcotest.(check bool) "unknown network kind" true
         (kind = Llm_provider.Http_client.Unknown)
   | outcome ->
@@ -1155,8 +1155,8 @@ let test_sdk_error_to_cascade_outcome_cascades_resumable_cli_session () =
 
 let test_sdk_error_is_resumable_cli_session_detects_structured_error () =
   let err =
-    Oas_worker_named.sdk_error_of_masc_internal_error
-      (Oas_worker_named.Resumable_cli_session
+    Keeper_turn_driver.sdk_error_of_masc_internal_error
+      (Keeper_turn_driver.Resumable_cli_session
          {
            cascade_name = internal_cascade_name "governance_judge";
            detail =
@@ -1166,9 +1166,9 @@ let test_sdk_error_is_resumable_cli_session_detects_structured_error () =
          })
   in
   Alcotest.(check bool) "structured resumable CLI session detected" true
-    (Oas_worker_named.sdk_error_is_resumable_cli_session err);
+    (Keeper_turn_driver.sdk_error_is_resumable_cli_session err);
   Alcotest.(check bool) "resumable CLI session is not hard quota" false
-    (Oas_worker_named.sdk_error_is_hard_quota err)
+    (Keeper_turn_driver.sdk_error_is_hard_quota err)
 
 let test_sdk_error_is_resumable_cli_session_detects_raw_kimi_hint () =
   let raw_message =
@@ -1180,12 +1180,12 @@ let test_sdk_error_is_resumable_cli_session_detects_raw_kimi_hint () =
          { message = raw_message; kind = Llm_provider.Http_client.Unknown })
   in
   Alcotest.(check bool) "raw Kimi resume hint detected" true
-    (Oas_worker_named.sdk_error_is_resumable_cli_session err)
+    (Keeper_turn_driver.sdk_error_is_resumable_cli_session err)
 
 let test_fallback_class_labels_resumable_cli_session () =
   let err =
-    Oas_worker_named.sdk_error_of_masc_internal_error
-      (Oas_worker_named.Resumable_cli_session
+    Keeper_turn_driver.sdk_error_of_masc_internal_error
+      (Keeper_turn_driver.Resumable_cli_session
          {
            cascade_name = internal_cascade_name "tier_fast";
            detail =
@@ -1196,7 +1196,7 @@ let test_fallback_class_labels_resumable_cli_session () =
   in
   Alcotest.(check (option string))
     "resumable session fallback class" (Some "resumable_cli_session")
-    (Oas_worker_named.sdk_error_cascade_fallback_class err)
+    (Keeper_turn_driver.sdk_error_cascade_fallback_class err)
 
 let make_openai_compat_provider_cfg ?(model_id = "mock-model")
     ?(base_url = "http://127.0.0.1:18080/v1")
@@ -1233,7 +1233,7 @@ let test_enrich_sdk_error_for_moonshot_auth_includes_env_hint () =
          { message = "Invalid Authentication" })
   in
   let rendered =
-    Oas_worker_named.enrich_sdk_error
+    Keeper_turn_driver.enrich_sdk_error
       ~cascade_name:(internal_cascade_name "keeper_unified")
       ~provider_cfg
       err
@@ -1257,7 +1257,7 @@ let test_enrich_sdk_error_for_openai_not_found_includes_endpoint_hint () =
          { message = {|{"detail":"Not Found"}|} })
   in
   let rendered =
-    Oas_worker_named.enrich_sdk_error
+    Keeper_turn_driver.enrich_sdk_error
       ~cascade_name:(internal_cascade_name "keeper_unified")
       ~provider_cfg
       err
@@ -1362,7 +1362,7 @@ let test_run_named_per_provider_timeout_uses_clock_fallback_and_exempts_last_pro
        upward, letting the first provider succeed instead of timing out. *)
     with_liveness_off @@ fun () ->
     match
-      Oas_worker_named.run_named
+      Keeper_turn_driver.run_named
         ~cascade_name:"timeout_probe"
         ~goal:"say hello"
         ~system_prompt:"system"
@@ -1483,7 +1483,7 @@ let test_run_named_skips_cooldown_primary_and_falls_back () =
       0
       (primary_calls ());
     match
-      Oas_worker_named.run_named
+      Keeper_turn_driver.run_named
         ~cascade_name:"breaker_probe_13318"
         ~goal:"say hello"
         ~system_prompt:"system"
@@ -1537,7 +1537,7 @@ let test_run_named_default_accept_allows_empty_content () =
          provider_url)
     @@ fun () ->
     match
-      Oas_worker_named.run_named
+      Keeper_turn_driver.run_named
         ~cascade_name:"empty_content_probe"
         ~goal:"return empty content"
         ~system_prompt:"system"
@@ -1589,7 +1589,7 @@ let test_run_named_accept_rejected_does_not_replay_rejected_checkpoint () =
          first_url second_url)
     @@ fun () ->
     match
-      Oas_worker_named.run_named
+      Keeper_turn_driver.run_named
         ~cascade_name:"accept_replay_probe"
         ~goal:"fallback without rejected checkpoint replay"
         ~system_prompt:"system"
@@ -1643,7 +1643,7 @@ let test_zero_turn_attempt_preserves_checkpoint () =
     ~finally:(fun () -> Agent_sdk.Agent.close agent)
     (fun () ->
       match
-        Oas_worker_named.For_testing.checkpoint_after_attempt ~agent_ref
+        Keeper_turn_driver.For_testing.checkpoint_after_attempt ~agent_ref
           (Some agent)
       with
       | Some checkpoint ->
@@ -1773,12 +1773,12 @@ let test_oas_worker_exec_build_applies_stream_idle_timeout () =
 
 let test_apply_stream_idle_timeout_default_passes_through_caller_value () =
   let provided = Some 7.5 in
-  let result = Oas_worker_named.apply_stream_idle_timeout_default provided in
+  let result = Keeper_turn_driver.apply_stream_idle_timeout_default provided in
   Alcotest.(check (option (float 0.0001)))
     "explicit Some passes through unchanged" provided result
 
 let test_apply_stream_idle_timeout_default_injects_keepalive_default () =
-  let result = Oas_worker_named.apply_stream_idle_timeout_default None in
+  let result = Keeper_turn_driver.apply_stream_idle_timeout_default None in
   let expected =
     Some Env_config_keeper.KeeperKeepalive.stream_idle_timeout_sec
   in
@@ -2119,16 +2119,16 @@ let test_make_per_call_switch_transport_releases_cli_fd_resources () =
 
 let test_classify_masc_internal_error_roundtrip () =
   let cascade_err =
-    Oas_worker_named.sdk_error_of_masc_internal_error
-      (Oas_worker_named.Cascade_exhausted
+    Keeper_turn_driver.sdk_error_of_masc_internal_error
+      (Keeper_turn_driver.Cascade_exhausted
          {
            cascade_name =
              internal_cascade_name Masc_mcp.Keeper_config.default_cascade_name;
            reason = Keeper_types.All_providers_failed;
          })
   in
-  (match Oas_worker_named.classify_masc_internal_error cascade_err with
-   | Some (Oas_worker_named.Cascade_exhausted { cascade_name; reason }) ->
+  (match Keeper_turn_driver.classify_masc_internal_error cascade_err with
+   | Some (Keeper_turn_driver.Cascade_exhausted { cascade_name; reason }) ->
        Alcotest.(check string) "cascade name"
          Masc_mcp.Keeper_config.default_cascade_name
          (internal_cascade_name_to_string cascade_name);
@@ -2137,16 +2137,16 @@ let test_classify_masc_internal_error_roundtrip () =
          (Keeper_types.cascade_exhaustion_summary reason)
    | _ -> Alcotest.fail "expected structured cascade exhaustion");
   let accept_err =
-    Oas_worker_named.sdk_error_of_masc_internal_error
-      (Oas_worker_named.Accept_rejected
+    Keeper_turn_driver.sdk_error_of_masc_internal_error
+      (Keeper_turn_driver.Accept_rejected
          {
            scope = Masc_mcp.Keeper_config.default_cascade_name;
            model = Some "mock-model";
            reason = "response rejected by accept (model=mock-model)";
          })
   in
-  (match Oas_worker_named.classify_masc_internal_error accept_err with
-   | Some (Oas_worker_named.Accept_rejected { scope; model; reason }) ->
+  (match Keeper_turn_driver.classify_masc_internal_error accept_err with
+   | Some (Keeper_turn_driver.Accept_rejected { scope; model; reason }) ->
        Alcotest.(check string) "accept scope" Masc_mcp.Keeper_config.default_cascade_name scope;
        Alcotest.(check (option string)) "accept model"
          (Some "mock-model") model;
@@ -2154,16 +2154,16 @@ let test_classify_masc_internal_error_roundtrip () =
          (contains_substring ~needle:"response rejected by accept" reason)
    | _ -> Alcotest.fail "expected structured accept rejection");
   let resumable_err =
-    Oas_worker_named.sdk_error_of_masc_internal_error
-      (Oas_worker_named.Resumable_cli_session
+    Keeper_turn_driver.sdk_error_of_masc_internal_error
+      (Keeper_turn_driver.Resumable_cli_session
          {
            cascade_name = internal_cascade_name "kimi_cli_keeper";
            detail = Cascade_runner.Kimi_cli_transport_local.resumable_session_detail;
            exit_code = Some 75;
          })
   in
-  match Oas_worker_named.classify_masc_internal_error resumable_err with
-  | Some (Oas_worker_named.Resumable_cli_session { cascade_name; detail; exit_code }) ->
+  match Keeper_turn_driver.classify_masc_internal_error resumable_err with
+  | Some (Keeper_turn_driver.Resumable_cli_session { cascade_name; detail; exit_code }) ->
       Alcotest.(check string) "resumable cascade" "kimi_cli_keeper"
         (internal_cascade_name_to_string cascade_name);
       Alcotest.(check string) "resumable detail redacted"
@@ -2265,7 +2265,7 @@ let check_timeout_opt label expected actual =
   Alcotest.(check (option (float 0.001))) label expected actual
 
 let provider_timeout ?(is_last = false) ?configured provider_cfg =
-  Oas_worker_named.effective_provider_attempt_timeout_s
+  Keeper_turn_driver.effective_provider_attempt_timeout_s
     ~is_last
     ~configured_timeout_s:configured
     provider_cfg
@@ -2745,7 +2745,7 @@ let test_filter_candidate_providers_for_tool_support_normalizes_codex_headers ()
       ~agent_name:"keeper-sangsu-agent" [ "masc_status" ]
   in
   let filtered =
-    Masc_mcp.Oas_worker_named.filter_candidate_providers_for_tool_support
+    Masc_mcp.Keeper_turn_driver.filter_candidate_providers_for_tool_support
       ~keeper_name:"sangsu"
       ?runtime_mcp_policy
       ~require_tool_choice_support:true
@@ -2773,7 +2773,7 @@ let test_filter_candidate_providers_for_tool_support_drops_codex_cli_keeper_boun
      the production [log_codex_keeper_bound_skip] emission path
      uncovered (removing it / changing its level / suppressing the
      first emission would still pass) and forced the helper to be
-     part of [Oas_worker_named]'s public API.  Drive the actual
+     part of [Keeper_turn_driver]'s public API.  Drive the actual
      emission from [filter_candidate_providers_for_tool_support]
      and observe it via [Log.Ring].
 
@@ -2787,7 +2787,7 @@ let test_filter_candidate_providers_for_tool_support_drops_codex_cli_keeper_boun
     | [] -> None
   in
   let filtered =
-    Masc_mcp.Oas_worker_named.filter_candidate_providers_for_tool_support
+    Masc_mcp.Keeper_turn_driver.filter_candidate_providers_for_tool_support
       ~keeper_name:"sangsu"
       ?runtime_mcp_policy
       ~require_tool_choice_support:true
@@ -2839,7 +2839,7 @@ let test_filter_candidate_providers_for_tool_support_keeps_codex_with_per_keeper
       ~agent_name:"keeper-sangsu-agent" [ "masc_status"; "masc_claim_next" ]
   in
   let filtered =
-    Masc_mcp.Oas_worker_named.filter_candidate_providers_for_tool_support
+    Masc_mcp.Keeper_turn_driver.filter_candidate_providers_for_tool_support
       ~keeper_name:"sangsu"
       ?runtime_mcp_policy
       ~require_tool_choice_support:true
@@ -2860,11 +2860,11 @@ let test_filter_candidate_providers_for_tool_support_keeps_header_capable_cli_fo
   with_temp_masc_base_path "codex-header-capable-no-token" @@ fun _base_path ->
   let tools = [ make_named_noop_tool "keeper_bash" ] in
   let runtime_mcp_policy =
-    Masc_mcp.Oas_worker_named.runtime_mcp_policy_for_tools
+    Masc_mcp.Keeper_turn_driver.runtime_mcp_policy_for_tools
       ~keeper_name:"sangsu" tools
   in
   let filtered =
-    Masc_mcp.Oas_worker_named.filter_candidate_providers_for_tool_support
+    Masc_mcp.Keeper_turn_driver.filter_candidate_providers_for_tool_support
       ~keeper_name:"sangsu"
       ?runtime_mcp_policy
       ~tools
@@ -2887,18 +2887,18 @@ let test_keeper_internal_tools_force_materialized_runtime_surface () =
   with_env "MASC_MCP_TOKEN" "" @@ fun () ->
   let tools = [ make_named_noop_tool "keeper_pr_review_comment" ] in
   let require_tool_support =
-    Masc_mcp.Oas_worker_named.keeper_internal_tools_require_materialized_runtime_surface
+    Masc_mcp.Keeper_turn_driver.keeper_internal_tools_require_materialized_runtime_surface
       ~keeper_name:"issue_king" tools
   in
   Alcotest.(check bool)
     "keeper PR-review tools require a materialized runtime surface"
     true require_tool_support;
   let runtime_mcp_policy =
-    Masc_mcp.Oas_worker_named.runtime_mcp_policy_for_tools
+    Masc_mcp.Keeper_turn_driver.runtime_mcp_policy_for_tools
       ~keeper_name:"issue_king" tools
   in
   let filtered =
-    Masc_mcp.Oas_worker_named.filter_candidate_providers_for_tool_support
+    Masc_mcp.Keeper_turn_driver.filter_candidate_providers_for_tool_support
       ~keeper_name:"issue_king"
       ?runtime_mcp_policy
       ~tools
@@ -2922,11 +2922,11 @@ let test_filter_candidate_providers_for_tool_support_secondary_preserves_priorit
   with_temp_masc_base_path "codex-secondary-priority" @@ fun () ->
   let tools = [ make_named_noop_tool "keeper_bash" ] in
   let runtime_mcp_policy =
-    Masc_mcp.Oas_worker_named.runtime_mcp_policy_for_tools
+    Masc_mcp.Keeper_turn_driver.runtime_mcp_policy_for_tools
       ~keeper_name:"sangsu" tools
   in
   let filtered =
-    Masc_mcp.Oas_worker_named.filter_candidate_providers_for_tool_support
+    Masc_mcp.Keeper_turn_driver.filter_candidate_providers_for_tool_support
       ~keeper_name:"sangsu"
       ?runtime_mcp_policy
       ~tools
@@ -2953,11 +2953,11 @@ let test_filter_candidate_providers_for_tool_support_secondary_uses_candidate_in
   with_temp_masc_base_path "codex-secondary-index" @@ fun () ->
   let tools = [ make_named_noop_tool "keeper_bash" ] in
   let runtime_mcp_policy =
-    Masc_mcp.Oas_worker_named.runtime_mcp_policy_for_tools
+    Masc_mcp.Keeper_turn_driver.runtime_mcp_policy_for_tools
       ~keeper_name:"sangsu" tools
   in
   let filtered =
-    Masc_mcp.Oas_worker_named.filter_candidate_providers_for_tool_support
+    Masc_mcp.Keeper_turn_driver.filter_candidate_providers_for_tool_support
       ~keeper_name:"sangsu"
       ?runtime_mcp_policy
       ~tools
@@ -2998,12 +2998,12 @@ let test_dual_track_swap_emits_secondary_kind_label_on_success () =
   with_temp_masc_base_path "codex-secondary-metric-success" @@ fun () ->
   let tools = [ make_named_noop_tool "keeper_bash" ] in
   let runtime_mcp_policy =
-    Masc_mcp.Oas_worker_named.runtime_mcp_policy_for_tools
+    Masc_mcp.Keeper_turn_driver.runtime_mcp_policy_for_tools
       ~keeper_name:"sangsu" tools
   in
   let before = count_swap_metric ~detail:"swapped:claude_code" in
   let _ =
-    Masc_mcp.Oas_worker_named.filter_candidate_providers_for_tool_support
+    Masc_mcp.Keeper_turn_driver.filter_candidate_providers_for_tool_support
       ~keeper_name:"sangsu"
       ?runtime_mcp_policy
       ~tools
@@ -3028,7 +3028,7 @@ let test_dual_track_swap_emits_secondary_kind_label_on_rejection () =
   with_temp_masc_base_path "codex-secondary-metric-rejection" @@ fun () ->
   let tools = [ make_named_noop_tool "keeper_bash" ] in
   let runtime_mcp_policy =
-    Masc_mcp.Oas_worker_named.runtime_mcp_policy_for_tools
+    Masc_mcp.Keeper_turn_driver.runtime_mcp_policy_for_tools
       ~keeper_name:"sangsu" tools
   in
   (* Rejected primary, secondary that *also* fails the gate (another
@@ -3037,7 +3037,7 @@ let test_dual_track_swap_emits_secondary_kind_label_on_rejection () =
   let detail = "rejected:codex_cli:codex_keeper_bound_actor_required" in
   let before = count_swap_metric ~detail in
   let _ =
-    Masc_mcp.Oas_worker_named.filter_candidate_providers_for_tool_support
+    Masc_mcp.Keeper_turn_driver.filter_candidate_providers_for_tool_support
       ~keeper_name:"sangsu"
       ?runtime_mcp_policy
       ~tools
@@ -3078,7 +3078,7 @@ let test_classify_filter_rejection_codex_keeper_bound_actor () =
          (Cascade_runner.runtime_mcp_tool_requires_bound_actor "masc_claim_next")
    | None -> Alcotest.fail "expected public MCP runtime policy");
   let reason =
-    Masc_mcp.Oas_worker_named.classify_filter_rejection
+    Masc_mcp.Keeper_turn_driver.classify_filter_rejection
       ~keeper_name:"sangsu"
       ?runtime_mcp_policy
       ~require_tool_choice_support:true
@@ -3089,7 +3089,7 @@ let test_classify_filter_rejection_codex_keeper_bound_actor () =
     "codex_cli with bound-actor policy classified as keeper_bound_actor"
     (Some "codex_keeper_bound_actor_required")
     (Option.map
-       Masc_mcp.Oas_worker_named.filter_rejection_reason_label reason)
+       Masc_mcp.Keeper_turn_driver.filter_rejection_reason_label reason)
 
 let test_classify_filter_rejection_codex_keeper_bound_actor_passes_with_per_keeper_token
     () =
@@ -3101,11 +3101,11 @@ let test_classify_filter_rejection_codex_keeper_bound_actor_passes_with_per_keep
   seed_raw_token base_path "keeper-sangsu-agent" "keeper-bearer-xyz";
   let tools = [ make_named_noop_tool "keeper_bash" ] in
   let runtime_mcp_policy =
-    Masc_mcp.Oas_worker_named.runtime_mcp_policy_for_tools
+    Masc_mcp.Keeper_turn_driver.runtime_mcp_policy_for_tools
       ~keeper_name:"sangsu" tools
   in
   let reason =
-    Masc_mcp.Oas_worker_named.classify_filter_rejection
+    Masc_mcp.Keeper_turn_driver.classify_filter_rejection
       ~keeper_name:"sangsu"
       ?runtime_mcp_policy
       ~tools
@@ -3117,7 +3117,7 @@ let test_classify_filter_rejection_codex_keeper_bound_actor_passes_with_per_keep
     "codex_cli passes keeper-bound policy when per-keeper bearer exists"
     None
     (Option.map
-       Masc_mcp.Oas_worker_named.filter_rejection_reason_label reason)
+       Masc_mcp.Keeper_turn_driver.filter_rejection_reason_label reason)
 
 let test_classify_filter_rejection_passes_when_provider_supported () =
   with_env "MASC_HTTP_BASE_URL" "http://127.0.0.1:8935" @@ fun () ->
@@ -3127,7 +3127,7 @@ let test_classify_filter_rejection_passes_when_provider_supported () =
       ~agent_name:"keeper-sangsu-agent" [ "masc_status" ]
   in
   let reason =
-    Masc_mcp.Oas_worker_named.classify_filter_rejection
+    Masc_mcp.Keeper_turn_driver.classify_filter_rejection
       ~keeper_name:"sangsu"
       ?runtime_mcp_policy
       ~require_tool_choice_support:true
@@ -3896,13 +3896,13 @@ let test_kimi_cli_resumable_invalid_request_reclassifies_as_structured () =
     Agent_sdk.Error.Api (Llm_provider.Retry.InvalidRequest { message = detail })
   in
   match
-    Oas_worker_named.sdk_error_to_resumable_cli_session
+    Keeper_turn_driver.sdk_error_to_resumable_cli_session
       ~cascade_name:(internal_cascade_name "kimi_cli_keeper") sdk_error
   with
   | Some structured -> (
-      match Oas_worker_named.classify_masc_internal_error structured with
+      match Keeper_turn_driver.classify_masc_internal_error structured with
       | Some
-          (Oas_worker_named.Resumable_cli_session
+          (Keeper_turn_driver.Resumable_cli_session
              { cascade_name; detail = structured_detail; exit_code }) ->
           Alcotest.(check string) "cascade" "kimi_cli_keeper"
             (internal_cascade_name_to_string cascade_name);
@@ -3971,7 +3971,7 @@ let test_sdk_error_terminal_provider_runtime_detects_kimi_unicode_crash () =
   in
   Alcotest.(check bool)
     "Kimi startup UnicodeDecodeError is terminal provider runtime" true
-    (Oas_worker_named.sdk_error_is_terminal_provider_runtime_failure err)
+    (Keeper_turn_driver.sdk_error_is_terminal_provider_runtime_failure err)
 
 let test_sdk_error_terminal_provider_runtime_detects_jsonrpc_sse_parse_storm () =
   let err =
@@ -3985,7 +3985,7 @@ let test_sdk_error_terminal_provider_runtime_detects_jsonrpc_sse_parse_storm () 
   in
   Alcotest.(check bool)
     "JSON-RPC SSE parse storm is terminal provider runtime" true
-    (Oas_worker_named.sdk_error_is_terminal_provider_runtime_failure err)
+    (Keeper_turn_driver.sdk_error_is_terminal_provider_runtime_failure err)
 
 let test_codex_cli_prompt_preflight_uses_pipeline_context_window_fallback () =
   let provider_cfg = make_codex_cli_provider_cfg () in
@@ -3997,7 +3997,7 @@ let test_codex_cli_prompt_preflight_uses_pipeline_context_window_fallback () =
       ~tools:[]
   in
   let huge_goal = String.make 600_000 'a' in
-  match Oas_worker_named.codex_cli_prompt_preflight ~config ~goal:huge_goal with
+  match Keeper_turn_driver.codex_cli_prompt_preflight ~config ~goal:huge_goal with
   | Some preflight ->
       Alcotest.(check bool) "argv limit hit" true preflight.hits_argv_limit;
       Alcotest.(check bool) "context limit hit" true preflight.hits_context_window;
@@ -4018,7 +4018,7 @@ let test_codex_cli_prompt_preflight_scales_retry_limit_for_argv_only_overflow ()
       ~tools:[]
   in
   let huge_goal = String.make 600_000 'a' in
-  match Oas_worker_named.codex_cli_prompt_preflight ~config ~goal:huge_goal with
+  match Keeper_turn_driver.codex_cli_prompt_preflight ~config ~goal:huge_goal with
   | Some preflight ->
       Alcotest.(check bool) "argv limit hit" true preflight.hits_argv_limit;
       Alcotest.(check bool) "context limit not hit" false preflight.hits_context_window;
@@ -5307,7 +5307,7 @@ let test_run_named_circuit_breaker_skips_open_provider () =
     @@ fun () ->
     (* 4. Run the named cascade. *)
     (match
-       Oas_worker_named.run_named
+       Keeper_turn_driver.run_named
          ~cascade_name:"cb_probe"
          ~goal:"circuit breaker test"
          ~system_prompt:"system"

--- a/test/test_provider_error.ml
+++ b/test/test_provider_error.ml
@@ -4,7 +4,7 @@ module P = Provider_error
 module Oas = Agent_sdk
 module Prom = Masc_mcp.Prometheus
 module Retry = Llm_provider.Retry
-module OWN = Masc_mcp.Oas_worker_named
+module OWN = Masc_mcp.Keeper_turn_driver
 
 let cascade_name raw = OWN.cascade_name_of_string raw
 


### PR DESCRIPTION
## Summary

RFC-0047 Phase 4: rename the largest hotspot file (`oas_worker_named.ml`, 1459 LOC) to `keeper_turn_driver.ml`. **Rename only — A/B/C split deferred to Phase 4b.**

## Renames

| From | To | LOC |
|---|---|---|
| `lib/oas_worker_named.ml` (+`.mli`) | `lib/keeper/keeper_turn_driver.ml` (+`.mli`) | 1459 + 211 |

## Scope correction (vs original RFC)

Original RFC §6 Phase 4 proposed an A/B/C split:
- **A.** agent_sdk call sites → `agent_sdk_call` augment
- **B.** cascade orchestration → `cascade_runner` augment
- **C.** keeper bookkeeping → `keeper_turn_driver` (new file)

Inspection found A/B/C concerns are **interleaved within single function bodies** (`Oas_worker_named.run`, `run_named`, etc). A mechanical split would require tracing each callsite individually — a real refactor, not a rename.

The **C concern (keeper bookkeeping) is dominant** based on caller analysis: most callers live in `lib/keeper/`. Renaming the whole file to `keeper_turn_driver` aligns the name with the dominant concern while preserving file structure and behavior.

**Phase 4b** will perform the A/B/C split as a separate PR with:
- Production canary via `keeper_bound_safe` (24h) per RFC §6
- RFC-0045 regression fixture replay
- Pre-merge user review (no auto-merge)

This PR (rename only) is revert-safe and behavior-identical.

## `oas_worker.ml` facade

Unchanged in this PR. Now reads:

```ocaml
include Cascade_runner
include Cascade_legacy_runner
include Keeper_turn_driver
```

Dissolution deferred to Phase 4b alongside the split, since 68 callers of `Oas_worker.X` need careful redirection to the correct sub-module.

## Caller updates

33 files via `perl -i` rename (`Oas_worker_named` → `Keeper_turn_driver`).

## lib/dune

- Removed: `oas_worker_named`
- Added: `keeper_turn_driver` (private, consistent with `keeper_agent_*` convention)

## Verification

- [x] `dune build lib/`: exit 0.
- [ ] `dune runtest`: deferred to CI.

## Status

**Draft.** Awaiting `human-approved-ready` label per draft-guard policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
