### PR TITLE
feat(dashboard): RFC-0041 cascade_ref exposure (Phase B6 partial)

### DIFF
--- a/dashboard/src/keeper-store-normalize.ts
+++ b/dashboard/src/keeper-store-normalize.ts
@@ -14,6 +14,16 @@ import { isOfflineStatus } from './lib/status-utils'
 import { keeperDisplayStatus } from './lib/keeper-runtime-display'
 import { contextThresholds } from './config/context-thresholds'
 import { normalizeKeeperDiagnostic } from './keeper-state'
+import type { CascadeRef } from './types'
+
+/** Normalize a raw cascade_ref JSON object into a typed CascadeRef. */
+function normalizeCascadeRef(raw: unknown): CascadeRef | null {
+  if (!isRecord(raw)) return null
+  const group = asString(raw.group)
+  if (!group) return null
+  const item = asString(raw.item) ?? null
+  return { group, item }
+}
 
 /** Maps lowercase backend phase strings to PascalCase KeeperPhase values.
  *  Backend (keeper_state_machine.ml) emits lowercase: "offline", "running", "handing_off", etc.
@@ -518,6 +528,7 @@ export function normalizeKeepers(raw: unknown): Keeper[] {
         last_model_used_label: asString(row.last_model_used_label) ?? null,
         next_model_hint: asString(row.next_model_hint) ?? null,
         cascade_name: asString(row.cascade_name) ?? null,
+        cascade_ref: normalizeCascadeRef(row.cascade_ref),
         cascade_canonical: asString(row.cascade_canonical) ?? asString(row.selected_cascade_canonical) ?? null,
         selected_cascade_canonical: asString(row.selected_cascade_canonical) ?? null,
         status: normalizeKeeperAgentStatus(statusRaw),

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -837,6 +837,7 @@ export interface Keeper {
   last_model_used_label?: string | null
   next_model_hint?: string | null
   cascade_name?: string | null
+  cascade_ref?: CascadeRef | null
   cascade_canonical?: string | null
   selected_cascade_canonical?: string | null
   status: string
@@ -1117,6 +1118,7 @@ interface KeeperConfigExecution {
   verify: boolean
   selected_cascade_name: string
   selected_cascade_canonical: string
+  cascade_ref?: CascadeRef | null
 }
 
 interface KeeperConfigCompaction {
@@ -1131,6 +1133,11 @@ interface KeeperConfigProactive {
   enabled: boolean
   idle_sec: number
   cooldown_sec: number
+}
+
+export interface CascadeRef {
+  group: string
+  item: string | null
 }
 
 export type KeeperFeatureStatus = 'wired' | 'source_only' | 'unwired'

--- a/lib/dashboard/dashboard_http_keeper.ml
+++ b/lib/dashboard/dashboard_http_keeper.ml
@@ -283,12 +283,21 @@ let keeper_trust_json ?(include_receipt = false)
     | None -> `Assoc [ ("profile", `Null); ("derived", `Bool false) ]
   in
   let cascade_json =
+    let cascade_ref_json =
+      match meta.cascade_ref with
+      | Some ref_ -> Cascade_ref.cascade_ref_to_json ref_
+      | None -> `Null
+    in
     match latest_receipt with
-    | Some receipt -> Yojson.Safe.Util.member "cascade" receipt
+    | Some receipt ->
+      (match Yojson.Safe.Util.member "cascade" receipt with
+       | `Assoc fields -> `Assoc (("cascade_ref", cascade_ref_json) :: fields)
+       | other -> other)
     | None ->
       `Assoc
         [
           ("name", `String meta.cascade_name);
+          ("cascade_ref", cascade_ref_json);
           ("selected_model", `Null);
           ("attempt_count", `Int 0);
           ("fallback_applied", `Bool false);
@@ -1111,6 +1120,10 @@ let keepers_dashboard_json ?(compact = false) (config : Coord.config) : Yojson.S
               ("models", `List (List.map (fun s -> `String s) cascade_models));
               ("models_resolved", models_resolved);
               ("primary_model", `String primary_model);
+              ( "cascade_ref",
+                (match m.cascade_ref with
+                 | Some ref_ -> Cascade_ref.cascade_ref_to_json ref_
+                 | None -> `Null) );
               ("active_model", `String active_model);
               ("next_model_hint", Json_util.string_opt_to_json next_model_hint);
               ("sandbox_profile",
@@ -1646,6 +1659,10 @@ let keeper_config_json (config : Coord.config) (name : string)
           ("selected_cascade_name", `String m.cascade_name);
           ( "selected_cascade_canonical",
             `String effective_cascade_name );
+          ( "cascade_ref",
+            (match m.cascade_ref with
+             | Some ref_ -> Cascade_ref.cascade_ref_to_json ref_
+             | None -> `Null) );
           ( "models",
             `List
               (List.map (fun s -> `String s)


### PR DESCRIPTION
## Summary

RFC-0041 Phase B6 부분 구현: keeper의 cascade_ref(group/item) 정보를 dashboard에 노출.

PR #14266에서 cascade_ref 타입과 라우팅 와이어링은 머지됐으나, dashboard 가시성이 빠졌습니다. 이 PR은 그 갭을 채웁니다.

## Changes

### OCaml (lib/dashboard/dashboard_http_keeper.ml)
- \`keeper_config_json\` execution section에 \`cascade_ref\` 추가
- \`keeper_trust_json\` cascade section에 \`cascade_ref\` 추가
- \`keepers_dashboard_json\` overview list에 \`cascade_ref\` 추가

### TypeScript
- \`dashboard/src/types/core.ts\`: \`CascadeRef\` interface 정의, \`Keeper\`/\`KeeperConfigExecution\`에 옵션 필드 추가
- \`dashboard/src/keeper-store-normalize.ts\`: \`normalizeCascadeRef\` 헬퍼, overview 정규화에 \`cascade_ref\` 전파

## Out of scope

- **B6 완전 완료**: turn-level execution_summary에 cascade_ref 추가 (별도 PR)
- **B7 레거시 제거**: \`cascade_name\` 필드 제거 (50+ 파일 수정 필요, 별도 sprint)
- **하드코딩 \"big_three\" 제거**: \`cascade_routes\` ↔ \`keeper_cascade_profile\` 순환 의존성 해결 선행 필요 (별도 sprint)

## RFC

RFC-0041: Cascade Routing Architecture — Group/Item Hierarchy with Health-Aware Fallback
\`docs/rfc/RFC-0041-cascade-routing-architecture.md\`

## Test plan

- [ ] dashboard 빌드 통과
- [ ] OCaml \`@check\` 통과
- [ ] TypeScript 타입 체크 통과 (CI)
- [ ] dashboard에서 keeper detail / overview에 cascade_ref 표시 확인 (수동)

🤖 Generated with [Claude Code](https://claude.com/claude-code)