### PR TITLE
docs(rfc): caller-context integration for 0052/0053/0038-P2 + P3 design

### DIFF
--- a/docs/design/pr-axis-cross-check-and-rfc-enforcer.md
+++ b/docs/design/pr-axis-cross-check-and-rfc-enforcer.md
@@ -1,0 +1,254 @@
+# P3 Process Tools Design: PR Axis Cross-Check + RFC §1 Enforcer
+
+> **Status**: Draft sketch
+> **Created**: 2026-05-09
+> **Author**: jeong-sik
+> **Related**: RFC-0052, RFC-0053, RFC-0038 Phase 2
+
+## §0 Summary
+
+masc-mcp 개발에서 반복적으로 발생하는 두 가지 프로세스 실패:
+
+1. **Wave-pattern PR stale**: 단일 main merge(예: #14179 metric refactor)가 병렬로 열린 4-5개 Draft PR을 동시에 stale하게 만듦. 각 PR author는 자신의 PR만 보고 cross-axis 영향을 인식하지 못함.
+2. **RFC §1 caller-context 누락**: RFC sketch 작성 시 §1 Problem 섹션에 TODO 주석만 남기고 caller-context 수집을 미룸. 나중에 sub-agent가 수집하더라도 RFC 본문과 `.tmp/` 파일이 분리되어 drift 발생.
+
+본 설계는 두 가지 프로세스 도구를 제안:
+- **PR Axis Cross-Check**: PR 병렬 스택의 cross-axis stale 위험을 pre-merge에 탐지
+- **RFC §1 Enforcer**: RFC draft의 §1 섹션이 caller-context 기준을 충족하는지 CI에서 강제
+
+## §1 PR Axis Cross-Check
+
+### §1.1 Problem
+
+`feedback_main_blocker_chain_4x_session.md` (2026-05-05):
+> admin-merge가 IN_PROGRESS Build CI 우회 → main 깨짐 → 보충 fix 4회 반복
+
+`feedback_wave_pattern_60_80_stale_resolved.md` (2026-05-05):
+> wave-style multi-issue roadmap는 60~80% pre-resolved. static audit 기반 wave LOC plan을 검증하면 이미 main에 fix되어 있다.
+
+`feedback_check_open_prs_before_fixing_pasted_build_error.md` (2026-05-05, **3rd recidivism**):
+> pasted build error가 이미 flight 중인 fix와 중복되어 3회 반복.
+
+**근본 원인**: PR author는 자신의 axis만 보고, 다른 axis의 main 변화가 자신의 PR을 invalid하게 만들 가능성을 체크하지 않음.
+
+### §1.2 Design
+
+#### Trigger
+- PR push 시 GitHub Actions workflow
+- 또는 `/loop` cron이 10분마다 open PR 스택 스캔
+
+#### Algorithm
+
+```python
+def check_pr_axis_stale(pr_number: int, repo: str) -> List[AxisRisk]:
+    pr = fetch_pr(pr_number)
+    changed_files = pr.changed_files
+
+    # 1. Find recently merged PRs (last 24h)
+    recently_merged = fetch_merged_prs(since=now() - 24h, limit=20)
+
+    risks = []
+    for merged in recently_merged:
+        # 2. Check file overlap
+        overlap = changed_files & merged.changed_files
+        if overlap:
+            # 3. Check if merged PR's changes make this PR's logic stale
+            if is_logic_superseded(pr, merged, overlap):
+                risks.append(AxisRisk(
+                    type="SUPERSEDED",
+                    merged_pr=merged.number,
+                    overlap_files=overlap,
+                    confidence=compute_confidence(pr, merged)
+                ))
+
+        # 4. Check build dependency: if merged PR changed dune/libraries
+        if merged.touches_dune_deps() and pr.depends_on(merged):
+            risks.append(AxisRisk(
+                type="BUILD_DEP_BREAK",
+                merged_pr=merged.number,
+                confidence="HIGH"
+            ))
+
+    return risks
+```
+
+#### Risk Types
+
+| Type | Description | Example |
+|------|-------------|---------|
+| `SUPERSEDED` | Merged PR's fix makes this PR's change unnecessary | PR A fixes bug X, PR B (merged) also fixes bug X |
+| `BUILD_DEP_BREAK` | Merged PR changed dune deps, this PR's build may fail | cdal_runtime migration adds new library |
+| `TYPE_CONFLICT` | Merged PR changed type definitions this PR uses | `Cascade_ref.cascade_item` field change |
+| `API_SIGNATURE_CHANGE` | Merged PR changed function signature this PR calls | `run_keeper_cycle` added `unit` param |
+
+#### Output
+
+PR에 코멘트로 자동 포스팅:
+
+```markdown
+🔄 **PR Axis Cross-Check Alert**
+
+Recent merges that may affect this PR:
+
+| Merged PR | Risk Type | Overlap Files | Confidence |
+|-----------|-----------|---------------|------------|
+| #14241 | `BUILD_DEP_BREAK` | `lib/cdal_runtime/dune` | HIGH |
+| #14255 | `TYPE_CONFLICT` | `lib/cascade/cascade_ref.mli` | MEDIUM |
+
+**Recommended action**: Rebase on latest main and run `dune build @check`.
+```
+
+### §1.3 Implementation Plan
+
+**PR-A: GitHub Actions workflow**
+- `.github/workflows/pr-axis-check.yml`
+- Python script using `gh api` (no external dependencies)
+- Runs on `pull_request` synchronize + cron schedule (every 10 min)
+
+**PR-B: Risk detection heuristics**
+- File overlap: simple path prefix matching
+- dune dep change: parse `dune` file diff for `(libraries ...)` changes
+- Type/function signature change: OCaml `cmt` file comparison (advanced)
+
+**PR-C: Confidence scoring**
+- HIGH: direct file overlap + function signature change
+- MEDIUM: file overlap in same directory
+- LOW: transitive dependency overlap
+
+## §2 RFC §1 Enforcer
+
+### §2.1 Problem
+
+RFC sketch 작성 시 §1에 다음 anti-pattern 반복:
+
+```markdown
+## §1 Problem
+
+**caller-context (sub-agent Topic X 결과 통합 영역)**:
+<!-- TODO: Topic X — 호출 사이트 N건의 file:line + 30-50줄 발췌 -->
+```
+
+→ TODO만 남기고 커밋. 나중에 sub-agent가 수집하더라도:
+1. RFC 본문에 통합되지 않음 (drift)
+2. `.tmp/` 파일은 ephemeral, 세션 종료 시 사라짐
+3. RFC 리뷰어는 §1이 비어있는 것을 모름
+
+### §2.2 Design
+
+#### Rule Set
+
+RFC §1 section은 다음 기준을 충족해야 함:
+
+| # | Rule | Enforcement |
+|---|------|-------------|
+| 1 | `<!-- TODO` 주석 0개 | grep 실패 시 CI fail |
+| 2 | `file:line` 인용 최소 3건 | grep `\.ml:` 패턴 3개 미만 시 fail |
+| 3 | code block 최소 1개 | markdown code block (```) 1개 미만 시 fail |
+| 4 | "sub-agent" 미통합 표시 없음 | "sub-agent ... 결과 통합 영역" 문구 금지 |
+| 5 | caller-context 파일 생성 | `.tmp/rfc-NNNN-caller-context.md` 존재 확인 |
+
+#### CI Integration
+
+```yaml
+# .github/workflows/rfc-enforcer.yml
+name: RFC §1 Enforcer
+on:
+  pull_request:
+    paths:
+      - 'docs/rfc/**'
+
+jobs:
+  enforce:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check RFC §1 completeness
+        run: python scripts/rfc_enforcer.py --check docs/rfc/
+```
+
+#### Python Script
+
+```python
+# scripts/rfc_enforcer.py
+import re
+from pathlib import Path
+from dataclasses import dataclass
+
+@dataclass
+class Violation:
+    file: Path
+    line: int
+    rule: str
+    message: str
+
+def check_rfc_section1(file: Path) -> List[Violation]:
+    content = file.read_text()
+    violations = []
+
+    # Rule 1: No TODO comments in §1
+    todo_matches = list(re.finditer(r'<!--\s*TODO', content))
+    for m in todo_matches:
+        violations.append(Violation(file, content[:m.start()].count('\n') + 1,
+            "R1_NO_TODO", "TODO comment found in §1"))
+
+    # Rule 2: At least 3 file:line citations
+    file_line_pattern = re.compile(r'`?[\w/]+\.ml[i]?:(\d+)`?')
+    citations = file_line_pattern.findall(content)
+    if len(citations) < 3:
+        violations.append(Violation(file, 0, "R2_MIN_CITATIONS",
+            f"Only {len(citations)} file:line citations found (minimum 3)"))
+
+    # Rule 3: At least 1 code block
+    code_blocks = re.findall(r'```[\w]*\n', content)
+    if len(code_blocks) < 1:
+        violations.append(Violation(file, 0, "R3_MIN_CODE_BLOCK",
+            "No code block found in §1"))
+
+    # Rule 4: No "sub-agent ... 통합 영역" placeholder
+    if re.search(r'sub-agent.*통합 영역|sub-agent.*pending|sub-agent.*TODO', content):
+        violations.append(Violation(file, 0, "R4_NO_PLACEHOLDER",
+            "Sub-agent placeholder text found"))
+
+    return violations
+```
+
+### §2.3 Graceful Degradation
+
+- **Draft PR**: 경고만 (comment), block 아님
+- **Ready for review**: required check로 block
+- **RFC-WAIVED label**: 특정 rule skip 가능 (예: 신규 도메인 RFC는 citation이 적을 수 있음)
+
+## §3 Alternatives
+
+| 접근법 | 강점 | 약점 | 적합도 |
+|--------|------|------|--------|
+| GitHub Actions | Native integration, free for public repos | 2000 min/month limit | **높음** |
+| Pre-commit hook | Local, fast feedback | Developer discipline 필요 | **중간** — 보조 |
+| Dedicated bot | Rich formatting, stateful | Maintenance cost | **낮음** — overkill |
+| Manual checklist | Human judgment | Inconsistent, forgotten | **낮음** — 현재 실패 중 |
+
+## §4 Implementation Plan
+
+### PR-A: PR Axis Cross-Check (MVP)
+- [ ] `.github/workflows/pr-axis-check.yml` 생성
+- [ ] `scripts/pr_axis_check.py` — file overlap + recent merged PR scan
+- [ ] 1개 repo에서 2주간 pilot 운영
+- [ ] false positive rate 측정 (목표: <20%)
+
+### PR-B: RFC §1 Enforcer (MVP)
+- [ ] `scripts/rfc_enforcer.py` — 5 rule check
+- [ ] `.github/workflows/rfc-enforcer.yml` 생성
+- [ ] 기존 RFC에 소급 적용 ( grandfathering: 기존 RFC는 skip )
+- [ ] 실패 시 PR 코멘트에 구체적인 수정 가이드 제공
+
+### PR-C: Integration
+- [ ] 두 도구를 `masc-mcp` repo에 배포
+- [ ] 다른 repo(`me`, kidsnote)에 재사용 가능하도록 config 외부화
+
+## §5 References
+
+- `memory/feedback_main_blocker_chain_4x_session.md` (2026-05-05)
+- `memory/feedback_wave_pattern_60_80_stale_resolved.md` (2026-05-05)
+- `memory/feedback_check_open_prs_before_fixing_pasted_build_error.md` (2026-05-05, 3rd recidivism)
+- `instructions/workflow-pr.md` — PR 운영 체크리스트
+- `instructions/software-development.md` — 워크어라운드 거부 기준

--- a/docs/rfc/RFC-0038-phase-2-keeper-identity-canonical.md
+++ b/docs/rfc/RFC-0038-phase-2-keeper-identity-canonical.md
@@ -27,38 +27,81 @@ RFC-0038 Phase 1이 opaque identifier types (`Provider_id.t = private string`, `
 
 ## §1 Problem (caller-context inventory)
 
-### §1.1 `coord_task.ml` `same_task_actor` 함수
+### §1.1 Core ownership comparison — raw `String.equal` everywhere
 
-**현재 main 코드** (`origin/main` `3904e285b8`, `lib/coord/coord_task.ml` line 109):
+**sub-agent 발견: `same_task_actor`는 현재 코드베이스에 존재하지 않음.**
+
+RFC 초안에서 인용한 `coord_task.ml:109`의 `same_task_actor`는 과거 commit(`3904e285b8`)의 코드로, 현재 HEAD에서는 리팩토링되어 `Coord_task_lifecycle.decide` 낙에 `same_agent` closure로 이동:
 
 ```ocaml
-let same_task_actor ~caller ~assignee =
-  (* 14038 PR이 제안: canonical form 비교 + alias-equivalent 확인 *)
-  String.equal caller assignee
-  (* → nick0cave != keeper-nick0cave-agent reject *)
+(* lib/coord/coord_task_lifecycle.ml:48 *)
+let same_agent assignee = String.equal assignee agent_name in
 ```
 
-**PR #14038 reference fix** (head commit):
-- `same_task_actor`에 alias-equivalent 매칭 추가
-- codex-connector P1 review (05-07 05:34Z):
-  > "`same_task_actor` alias 매칭으로 transition이 통과하는데 후속 `transition_task_r`이 caller string 그대로 agent state를 갱신하면, canonical assignee의 `current_task` 클리어 + status update가 발생하지 않아"
+이 `same_agent`가 FSM 전이 10개 이상의 지점에서 사용됨(lifecycle.ml:54,62,67,75,79,92,103,116,152,174). 모든 지점이 **raw `String.equal`**.
 
-**caller-context (sub-agent Topic C 결과 통합 영역)**:
-<!-- TODO: Topic C.1 — same_task_actor caller 전수 + transition_task_r 연결 -->
-<!-- TODO: Topic C.2 — alias 생성 사이트 (nick0cave, keeper-nick0cave-agent, generated nickname) -->
+**Task FSM의 identity 비교 전수 (sub-agent Topic C.1 결과)**:
 
-### §1.2 identity 생성 경로
+| 파일 | 라인 | 패턴 | 역할 |
+|------|------|------|------|
+| `coord_task_lifecycle.ml` | 48 | `String.equal assignee agent_name` | **FSM ownership core** |
+| `coord_task.ml` | 129 | `a <> agent_name` | assignee mismatch hint |
+| `coord_task.ml` | 149 | `a = agent_name` | remediation ownership |
+| `coord_task.ml` | 841 | `assignee = agent_name` | cancel_task_r guard |
+| `coord_task_schedule.ml` | 293, 423 | `String.equal assignee agent_name` | scheduling match |
+| `tool_task.ml` | 235, 379 | `String.equal assignee agent_name` | tool-layer check |
+
+→ **0개 typed identity comparison**. `Keeper_identity.canonical_keeper_name_from_agent_name` 등 canonicalization helper가 존재하나 task FSM에서는 전혀 사용되지 않음.
+
+**PR #14038 / codex-connector P1 review에서 지적한 버그**:
+> "`transition_task_r`이 caller string 그대로 agent state를 갱신하면, canonical assignee의 `current_task` 클리어 + status update가 발생하지 않아"
+
+실제 코드 확인: `transition_task_r` line 48에서 `resolve_agent_name_strict`로 caller를 canonicalize한 뒤 `update_local_agent_state`를 호출. 이는 **caller 측** state는 올바르게 갱신하나, task가 **다른 alias**로 claim된 경우 assignee 측 state 파일은 건드리지 않음.
+
+### §1.2 이미 존재하는 workaround들 — diagnosis 확인
+
+sub-agent가 3개의 dual-name matching workaround를 발견:
+
+```ocaml
+(* lib/tool_task.ml:145 *)
+let matches_you assignee =
+  String.equal assignee ctx.agent_name || String.equal assignee actual_name
+
+(* lib/tool_coord.ml:424 *)
+let matches_you assignee =
+  String.equal assignee ctx.agent_name || String.equal assignee actual_name
+
+(* lib/keeper/keeper_current_task_reconcile.ml:41 *)
+let matches assignee = List.mem assignee names in
+(* names = [agent_name; resolved_name] *)
+```
+
+→ 코드베이스가 이미 alias 문제를 **현장에서 workaround**로 해결하고 있다. 이는 RFC의 diagnosis가 정확함을 증명.
+
+### §1.3 Alias 생성 경로
 
 **메모리 `feedback_blocker_class_stamp_gap_completion_contract.md` 연관**: "blocker class stamp gap — text는 있는데 enum null"
 → text identity가 존재하나 typed identity가 없는 같은 근본 문제 (type이 없으면 normalize 불가).
 
-**생성 경로 (sub-agent Topic C.2 결과로 확정)**:
-<!-- TODO: keeper alias 생성 사이트 -->
-1. `config/keepers/*.toml` — `name = "nick0cave"` (canonical form)
-2. `keeper_heartbeat_loop.ml` — transport alias: `keeper-<name>-agent` (derived)
-3. `keeper_nickname_generator.ml` — generated nickname (volatile)
+**Alias 생성 경로 (sub-agent Topic C.2 결과)**:
 
-→ 모두 같은 canonical name(`nick0cave`)에서 derive되나 현재는 독립적 string으로 처리됨.
+| 경로 | 파일 | 형태 | 예시 |
+|------|------|------|------|
+| toml config | `config/keepers/*.toml` | canonical | `persona_name = "sangsu"` |
+| transport | `keeper_heartbeat_loop.ml` | derived | `keeper-sangsu-agent` |
+| generated | `keeper_nickname_generator.ml` | volatile | `swift-fox-a3b2` |
+| parsed | `keeper_identity.ml:50-88` | 4-way prefix/suffix | `keeper_<name>_agent` 등 |
+
+`keeper_identity.ml:50-88`의 파서가 4가지 조합 처리:
+```ocaml
+let keeper_name_from_agent_name agent_name =
+  match parse_keeper_agent_name ~prefix:"keeper-" ~suffix:"-agent" agent_name with
+  | Some keeper_name -> Some keeper_name
+  | None -> match parse_keeper_agent_name ~prefix:"keeper_" ~suffix:"_agent" agent_name with
+  ...
+```
+
+→ 모든 경로가 같은 canonical name(`sangsu`)에서 derive되나 현재는 **독립적 string으로 처리**됨. `keeper_meta`는 `name`과 `agent_name`을 둘 다 보유하나 비교 시점에서 어떤 필드를 쓸지 caller가 결정.
 
 ### §1.3 RFC-0038 Phase 1과의 격차
 
@@ -147,15 +190,23 @@ let transition_task_r ~identity ~task_state =
 
 ## §5 Alternatives
 
-<!-- TODO: research/2026-05-09-identity-canonicalization-patterns.md 의 비교 표 통합 -->
+| 접근법 | Canonical Form | Stability | Uniqueness | masc-mcp 적합도 |
+|---|---|---|---|---|
+| ActivityPub `id` | HTTPS URI | ✅ Stable | ✅ Global (URI) | **높음** — `keeper_name`을 canonical ID로, `agent_name`을 alias로 |
+| OIDC `iss`+`sub` | issuer-scoped string | ✅ Immutable | ✅ Global (iss+sub) | **높음** — `keeper_name`을 immutable `sub`로 취급 |
+| WebFinger `acct` | `acct:user@domain` | ✅ Stable | ✅ Global (domain-scoped) | **중간** — URI-like 식별자 도입 시 참고 |
+| DID | `did:method:specific` | ✅ Self-sovereign | ✅ Global | **낮음** — over-engineering, single-domain 시스템 |
+| RFC 5321 Mailbox | `local@domain` | ⚠️ Case-sensitive | ⚠️ Local-part ambiguous | **낮음** — delivery vs identity 목적 불일치 |
+| DNS Punycode/IDNA | Punycode ASCII | ✅ Stable | ✅ Global | **낮음** — internationalization 문제 없음, overkill |
 
-- DNS canonicalization (Punycode/IDNA) — 긴 canonical name 처리
-- ActivityPub `id` vs `preferredUsername` — canonical URL vs display name
-- OIDC `sub` claim (immutable) vs `preferred_username` (변경 가능)
-- DID (Decentralized Identifier) — 너무 과함
-- WebFinger `acct:` URI — email-like scheme
+### 권장 방향
 
-→ **권장**: ActivityPub `id` + `preferredUsername` 패턴 (canonical form + display alias)
+**채택: ActivityPub + OIDC Hybrid Model**
+- `keeper_name`을 canonical identifier로 명시. 속성: immutable, never reassigned, locally unique within masc instance.
+- `agent_name`을 display/handle로 분리. `preferredUsername`처럼 mutable, non-unique. UI 표시용.
+- `persona_name` = `keeper_name` (1:1). `credential_stem` = `keeper_name` (1:1). 이 관계를 타입으로 보증.
+- `canonical_keeper_name`의 4가지 prefix/suffix 조합 처리를 "legacy alias resolution"으로 재명명. 새 코드는 canonical `keeper_name`만 사용.
+- 단점: 기존 `agent_name`과 `keeper_name`이 다른 keeper들의 마이그레이션 필요. `keeper_name_from_agent_name`의 4-way match는 deprecation path 필요.
 
 ## §6 Open Questions
 
@@ -167,14 +218,22 @@ let transition_task_r ~identity ~task_state =
 
 ## §7 References
 
-<!-- TODO: ~/me/knowledge/research/2026-05-09-identity-canonicalization-patterns.md 인용 -->
+### 외부
 
-- (sub-agent Topic C) ActivityPub actor identity (id vs preferredUsername)
-- (sub-agent Topic C) OIDC sub claim + preferred_username
-- (sub-agent Topic C) DID W3C (overkill 검증)
-- (sub-agent Topic C) Git commit identity canonicalization
-- (사내) RFC-0038 Phase 1 (opaque identifier types)
-- (사내) PR #14038 — reference fix + codex-connector P1 review
+- W3C ActivityPub Specification — actor `id` as canonical identifier (https://www.w3.org/TR/activitypub/)
+- ActivityPub and WebFinger CG Final Report 2024 — "SHOULD NOT treat usernames as stable identifiers" (https://www.w3.org/community/reports/socialcg/CG-FINAL-apwf-20240608/)
+- OpenID Connect Core 1.0 — `sub` claim immutability (https://openid.net/specs/openid-connect-core-1_0.html)
+- WebFinger RFC 7033 + `acct` URI RFC 7565 (https://www.rfc-editor.org/rfc/rfc7033)
+- RFC 5321 Section 4.1.2 — local-part case sensitivity (https://datatracker.ietf.org/doc/html/rfc5321)
+- DID W3C Specification — over-engineering verification (https://www.w3.org/TR/did-resolution/)
+
+### 사내
+
+- RFC-0038 Phase 1 (opaque identifier types — `Provider_id.t`, `Cascade_name.t`)
+- PR #14038 — reference fix + codex-connector P1 review
+- `instructions/software-development.md` §2 Unknown → Permissive Default anti-pattern
+- (sub-agent Topic C.1) `same_task_actor` caller 전수 + `transition_task_r` 연결 — `.tmp/rfc-0038-p2-caller-context.md`
+- (sub-agent Topic C.2) alias 생성 사이트 분석 — `.tmp/rfc-0038-p2-caller-context.md`
 - (사내) memory `feedback_blocker_class_stamp_gap_completion_contract.md` (type 없는 identity 관련)
 
 ---

--- a/docs/rfc/RFC-0052-boot-time-required-invariants.md
+++ b/docs/rfc/RFC-0052-boot-time-required-invariants.md
@@ -37,23 +37,56 @@ in
 
 → clock=None 시 advertised structural timeout이 우회됨. always-on runtime에서 silent liveness 위반.
 
-**caller-context (sub-agent Topic A.2 결과 통합 영역)**:
-<!-- TODO: Topic A.2 — Masc_eio_env.get () 호출 사이트 N건의 file:line + 30-50줄 발췌 -->
-<!-- TODO: Topic A.5 — Keeper_health_probe.start_probe wiring 결과 (PR #14246 후) -->
+**caller-context (sub-agent Topic A.2 결과)**:
 
-### §1.2 PR #14246 (`fix(keeper): wire health probe + permissive Unknown for auto-resume`) 후속
+`Masc_eio_env`는 server startup 시 1회 초기화되는 module-level atomic(`lib/server/server_runtime_bootstrap.ml:1414`). 8개 호출 사이트:
 
-PR #14246 본문 자기 인용 (`docs/rfc/RFC-0052-source-pr14246-quote.md`):
-> This is the `Unknown → Permissive Default` anti-pattern from `instructions/software-development.md` §1, applied with the wrong polarity (Unknown → Restrictive). Same root: compressing a tri-valued health state into a boolean.
+| 파일 | 라인 | 패턴 |
+|------|------|------|
+| `lib/masc_oas_bridge.ml` | 26 | `get_opt ()` → `None -> None` fallback |
+| `lib/cascade/cascade_catalog_runtime.ml` | 463 | `get_opt ()` → `None -> Eio_context.get_clock_opt ()` |
+| `lib/oas_worker_named.ml` | 591 | `get_opt ()` → `None -> Eio_context.get_clock_opt ()` cascade fallback |
+| `lib/keeper/keeper_llm_bridge.ml` | 14 | **`get ()` (raising)** — `clock_opt` 추출 후 `None -> fn ()` |
 
-**같은 root**:
-- `Masc_eio_env.clock` — `option` 타입이 boot-time 미초기화 가능성을 표현하나 caller가 `None` branch를 silent하게 처리
-- `Keeper_health_probe` — `start_probe` 호출 누락 시 cache cold forever
-- 둘 다: **boot-time required invariant가 type level로 강제되지 않음**
+→ **Dual global Eio context systems**: `Masc_eio_env`와 `Eio_context`가 병존. 같은 bootstrap 시점(`server_runtime_bootstrap.ml:308-314`)에 각각 `init`/`set_*` 되나 서로 다른 atomic store. Drift 가능.
 
-### §1.3 시그니처 검색 — 같은 패턴 다른 모듈
+→ `keeper_llm_bridge.ml:14`는 `get ()` (uninitialized 시 예외)를 사용하고, 대부분의 keeper 코드는 `Eio_context.get_clock_opt ()` (non-raising)를 사용. 두 시스템이 섞여 있어서 한쪽이 초기화되고 다른 쪽이 안 된 상태를 컴파일러가 감지 못함.
 
-<!-- TODO: Topic A.4 — `match X.get ().none -> 우회` 패턴 시그니처 -->
+### §1.2 `Keeper_health_probe.start_probe` — 정의되었으나 0회 호출
+
+```ocaml
+(* lib/keeper/keeper_health_probe.ml:171-177 *)
+let start_probe ~sw ~base_path ~interval_sec =
+  if interval_sec <= 0.0 then ()
+  else Eio.Fiber.fork ~sw (fun () -> ...)
+```
+
+**mli 주석**: "Currently unused — the supervisor calls `run_once` inline."
+
+**실제 호출**: 0건. 대신 `run_once`가 `keeper_supervisor.ml:1271`에서 30s sweep마다 inline 호출.
+
+→ `start_probe`는 boot-time에 한 번 호출되어야 할 함수인데, 정의만 되고 호출되지 않음. 이는 `Initialized.t` phantom type이 있었다면 `start_probe`가 `[`Initialized]` 상태에서만 호출 가능하도록 설계되었을 것이고, 그 설계가 없으니 "안 써도 되는 함수"로 방치됨.
+
+### §1.3 시그니처 검색 — 같은 패턴 다른 모듈 (sub-agent Topic A.4)
+
+`Eio_context.get_clock_opt ()` 사용처 12건:
+
+| 파일 | 라인 | 패턴 |
+|------|------|------|
+| `keeper_turn_slot.ml` | 848, 896, 956 | `Some clock -> sleep/timeout` / `None -> yield/sleep 0.005` |
+| `keeper_tag_dispatch.ml` | 20, 155 | `Some -> Ok clock` / `None -> Error "requires Eio clock"` |
+| `keeper_exec_voice.ml` | 26 | switch/net/clock triple destructuring |
+| `keeper_unified_turn.ml` | 402, 730, 886 | `Some -> sleep` / `None -> ()` |
+| `keeper_turn_cascade_budget.ml` | 754 | `Some -> sleep` / `None -> ()` |
+| `keeper_shell_bash.ml` | 748 | conditional clock access |
+| `keeper_agent_run.ml` | 478 | optional arg to OAS callback |
+
+**핵심**: 모든 keeper 모듈이 개별적으로 `match Some/None`을 처리. 중앙 집중식 enforcement 없음.
+
+**Silent fallthrough 심각도**:
+- `keeper_llm_bridge.ml:28` `None -> fn ()` — **timeout 완전 우회** (Medium)
+- `keeper_turn_slot.ml:848` `None -> Time_compat.sleep 0.005` — **busy-wait degradation** (Low-Medium)
+- `keeper_unified_turn.ml:402` `None -> ()` — **sleep skip** (Low)
 
 ## §2 Goals / Non-goals
 
@@ -121,12 +154,21 @@ type init_error =
 
 ## §5 Alternatives
 
-<!-- TODO: research/2026-05-09-boot-time-typed-invariants.md 의 비교 표 통합 -->
+| 접근법 | 강점 | 약점 | masc-mcp 적합도 |
+|---|---|---|---|
+| OCaml Phantom Types | Zero runtime cost, 익숙한 문법, Jane Street 검증 | Move semantics 없음, signature 추상화 필수 | **높음** — boot phase 2-3 상태에 최적 |
+| Parse Don't Validate (newtype) | 정보 보존, 중복 검증 제거 | OCaml은 typeclass 없어 string-like 사용 불편 | **높음** — `Keeper_identity` canonicalization에 직접 적용 |
+| Rust Typestate | Move semantics로 강제, IDE 지원 | OCaml에 없는 언어 기능 의존 | **중간** — 개념 참고, 직접 적용은 phantom type으로 대체 |
+| GADTs | Exhaustive match, 타입 학습 | 복잡도, onboarding cost | **중간** — composite lifecycle 등 복잡한 경우만 |
+| Idris Dependent Types | 완전한 타입 수준 보증 | OCaml 미지원, 학습 곡선 극단적 | **낮음** — 개념 참고만 |
+| Erlang OTP `init/1` | Runtime supervisor, recovery | Type level 보증 없음, silent failure 가능 | **낮음** — 본 RFC가 대체하는 대상 |
 
-- Idris dependent types (proof-carrying initialization) — OCaml 미지원
-- Rust typestate pattern (newtype + builder) — OCaml에서는 phantom type으로 흉내
-- "Parse, don't validate" (Alexis King) — 본 RFC의 핵심 원칙
-- Erlang OTP `init/1` callback — runtime check, type level X
+### 권장 방향
+
+**채택: Phantom Type + Parse-Don't-Validate 조합**
+- `Keeper_identity`에 `Validated_keeper_name` 모듈 추가. `type t`는 abstract, 생성자는 `normalize_all_names` 통과 시에만 노출.
+- `Masc_eio_env`에 `[`Uninit]` / `[`Initialized]` phantom type 도입. `clock` 접근은 `[`Initialized]`에서만.
+- 단점: 기존 `string` 기반 코드와의 경계에서 projection 함수가 필요. 타입 안전성의 대가로 수용.
 
 ## §6 Open Questions
 
@@ -137,15 +179,21 @@ type init_error =
 
 ## §7 References
 
-<!-- TODO: ~/me/knowledge/research/2026-05-09-boot-time-typed-invariants.md 인용 -->
+### 외부
 
-- (sub-agent Topic A) OCaml phantom type / GADT 패턴
-- (sub-agent Topic A) "Parse, don't validate" Alexis King
-- (sub-agent Topic A) Rust typestate pattern
-- (sub-agent Topic A) Idris dependent types
-- (사내) `instructions/software-development.md` §1 Unknown → Permissive Default anti-pattern
-- (사내) PR #13980 — reference implementation (Masc_eio_env.get_opt + fail_without_clock)
-- (사내) PR #14246 — same root, tri-valued health_status fix
+- Jane Street — "HOWTO: Static access control using phantom types" (https://blog.janestreet.com/howto-static-access-control-using-phantom-types/)
+- Alexis King — "Parse, Don't Validate" (https://lexi-lambda.github.io/blog/2019/11/05/parse-don-t-validate/)
+- Rust Typestate Pattern — Farazdagi (https://farazdagi.com/posts/2024-04-07-typestate-pattern/)
+- Real World OCaml — GADTs (https://dev.realworldocaml.org/gadts.html)
+- Eio Fiber API — "prefer passing arguments around explicitly" (https://ocaml-multicore.github.io/eio/eio/Eio/Fiber/index.html)
+
+### 사내
+
+- `instructions/software-development.md` §1 Unknown → Permissive Default anti-pattern
+- PR #13980 — reference implementation (Masc_eio_env.get_opt + fail_without_clock)
+- PR #14246 — same root, tri-valued health_status fix
+- (sub-agent Topic A.2) `Masc_eio_env` 호출 사이트 인벤토리 — `.tmp/rfc-0052-caller-context.md`
+- (sub-agent Topic A.4) `None ->` silent fallthrough 패턴 검색 결과 — `.tmp/rfc-0052-caller-context.md`
 
 ---
 

--- a/docs/rfc/RFC-0053-tool-dispatch-session-local-handles.md
+++ b/docs/rfc/RFC-0053-tool-dispatch-session-local-handles.md
@@ -1,5 +1,5 @@
 ---
-rfc: RFC-0051
+rfc: RFC-0053
 title: Tool Dispatch Session-Local Handles
 author: jeong-sik
 created: 2026-05-09
@@ -11,7 +11,7 @@ related:
   - PR #13987 (fix: remove global tool hook fallbacks — reference fix)
 ---
 
-# RFC-0051: Tool Dispatch Session-Local Handles
+# RFC-0053: Tool Dispatch Session-Local Handles
 
 > **Status**: Draft sketch. §1 caller-context inventory at `.tmp/rfc-0051-caller-context.md` pending sub-agent.
 
@@ -44,12 +44,54 @@ let set_tool_search_fn (f : tool_searcher) =
 
 **이 문제의 핵심**: `search_fn` 인자를 session 단위로 전달하는 caller와 그렇지 않은 caller가 공존할 때, 후자는 silent no-op 경로로 빠짐. 디버깅 불가.
 
-**caller-context (sub-agent Topic B 결과 통합 영역)**:
-<!-- TODO: Topic B.1 — default_tool_search_fn / set_tool_search_fn 호출 사이트 N건 -->
-<!-- TODO: Topic B.2 — 같은 패턴 다른 모듈 (keeper_tool_hooks, Tool_registry Config 의존) -->
-<!-- TODO: Topic B.3 — process-global setter 시그니처 검색 lib/keeper/ 전수 -->
-<!-- TODO: Topic B.4 — 각 setter 호출 site와 unset/reset 사이트 -->
-<!-- TODO: Topic B.5 — 이미 session-local handle로 전환된 모듈 (RFC-0046 keeper_detail FSM hub 등) -->
+**caller-context (sub-agent Topic B 결과)**:
+
+#### B.1 `keeper_exec_tools.ml` — `set_tool_search_fn`가 dead code
+
+| 심볼 | 라인 | 상태 |
+|------|------|------|
+| `default_tool_search_fn` | 103 | static schema fallback, 외부 호출 0건 |
+| `default_tool_searcher` | 165 | `default_tool_search_fn` alias |
+| `tool_searcher` ref | 168 | global mutable ref |
+| `set_tool_search_fn` | 170 | **정의되었으나 코드베이스 전체에서 0회 호출** |
+
+→ setter는 존재하지만 아묏도 호출하지 않는다. 실제 데이터 흐름은 `~search_fn` optional parameter를 통해 전달됨. global ref는 **죽은 패턴**.
+
+#### B.2 이미 존재하는 session-local pattern (canonical example)
+
+`keeper_run_tools.ml:202-237,322`:
+```ocaml
+let local_search_fn_ref : (query:string -> max_results:int -> Yojson.Safe.t) ref =
+  ref (fun ~query:_ ~max_results:_ -> `Assoc [ "results", `List [] ])
+
+(* line 237: explicit parameter 전달 *)
+~search_fn:(fun ~query ~max_results -> !local_search_fn_ref ~query ~max_results)
+
+(* line 322: initialization 후 재할당 *)
+local_search_fn_ref := fun ~query ~max_results -> ...
+```
+
+→ closure-scope local ref + explicit `~search_fn` parameter + reassignment after init. 이것이 RFC-0053이 추구하는 패턴이며 **이미 작동 중**.
+
+`.mli:122-124` 주석:
+> "Prefer passing `~search_fn` to `execute_keeper_tool_call` for session-scoped search."
+
+→ 인터페이스 주석이 이미 session-local을 권장. 코드가 주석을 따라잡지 못한 상태.
+
+#### B.3 Global setter 전수 검색 (lib/keeper/ 8개 모듈)
+
+| 모듈 | 심볼 | 사용 여부 | RFC-0053 관련 |
+|------|------|----------|--------------|
+| `keeper_exec_tools` | `tool_searcher` ref | **Dead** (fallback only) | **Primary target** |
+| `keeper_exec_tools` | `keeper_tool_call_recorder` ref | Used (`mcp_server_eio.ml:130`) | Secondary |
+| `keeper_tool_registry` | `masc_schemas_state` ref | Used | Out of scope |
+| `keeper_exec_shared` | `tag_dispatch_fn` ref | Used | Out of scope |
+| `keeper_admission_runtime` | `policy_lookup_ref` | Used (PR-E-1.6) | Out of scope |
+| `keeper_event_bus` | `bus_ref` | Used | Out of scope |
+| `keeper_keepalive_signal` | `grpc_client_ref` | Used | Out of scope |
+| `keeper_compact_audit` | `store_ref` | Used | Out of scope |
+
+→ RFC-0053 Phase A 범위는 `keeper_exec_tools`의 `tool_searcher` / `set_tool_search_fn` 제거에 집중.
 
 ### §1.2 같은 root의 다른 현상
 
@@ -57,7 +99,7 @@ PR #13987 본문:
 > remove process-global no-op keeper tool callbacks from `Keeper_exec_tools`
 > make `keeper_tool_search` fail explicitly when direct dispatch omits a session `search_fn`
 
-→ PR #13987의 fix가 이 RFC의 Phase A 수준. 본 RFC는 그것을 확장: process-global setter **자체를 제거**, session handle **메커니즘을 도입**.
+→ PR #13987의 fix가 이 RFC의 Phase A 수준. 본 RFC는 그것을 확장: process-global setter **자체를 제거**, session handle **메커니즘을 도입**. 특히 `set_tool_search_fn`이 dead code임이 확인되어, 제거가 breaking change가 아님.
 
 ### §1.3 `Unknown → Permissive Default` + `Global → Silent Default` 스택
 
@@ -137,13 +179,21 @@ end
 
 ## §5 Alternatives
 
-<!-- TODO: research/2026-05-09-process-global-state-alternatives.md 의 비교 표 통합 -->
+| 접근법 | 강점 | 약점 | masc-mcp 적합도 |
+|---|---|---|---|
+| Eio Capability Passing | Idiomatic OCaml 5, zero-cost, 공식 권장 | Compile-time 보증 없음, runtime convention | **높음** — 즉시 적용 가능, `ref` → capability 객체 |
+| Erlang OTP Supervision | Process isolation, fault containment | Eio fiber는 cooperative, true isolation 없음 | **중간** — supervisor 패턴 참고, fiber isolation은 convention |
+| Object-Capability (Joe-E) | 강력한 보증, least privilege | OCaml은 static verifier 없음, taming cost | **중간** — 개념 참고, module boundary로 approximate |
+| Algebraic Effects (Koka) | 타입 수준 effect tracking | OCaml 5는 static tracking 미지원 | **낮음** — 개념 참고, explicit capability로 대체 |
+| OCaml First-Class Modules | Compile-time DI, testability | Syntactic weight, 대규모 적용 churn | **중간** — policy/config 모듈에 점진적 적용 |
+| Spring/ZIO Layer DI | 런타임 wire-up, 유연성 | 런타임 오버헤드, 복잡도, 언어 mismatch | **낮음** — OCaml ecosystem 미지원 |
 
-- Erlang OTP actor model — 각 keeper를 actor로, global state 없음 (아키텍처 변화 큼)
-- Akka Behavior + Context — message-driven tool dispatch (앱 언어 mismatch)
-- OCaml first-class module / functor — compile-time DI (main 선호)
-- Algebraic effects (Eio) — context handler로 tool search 제공 (연구 중)
-- Dependency injection framework (Spring/ZIO Layer) — 런타임 오버헤드 + 복잡도
+### 권장 방향
+
+**채택: Eio Capability Passing + Explicit Record Passing**
+- `keeper_run_tools.ml`의 10+ `ref` 필드를 `Tool_execution_context.t` record로 통합. 실행 시작 시 생성, 완료 후 immutable snapshot으로 freeze.
+- `keeper_tool_policy.ml`의 `policy_config ref`를 `Policy_capability.t`로 변환. 필요한 함수는 capability를 명시적 인자로 받음.
+- 단점: 함수 시그니처가 길어짐. `~tool_context` labeled argument로 완화. explicitness의 대가로 수용.
 
 ## §6 Open Questions
 
@@ -154,14 +204,21 @@ end
 
 ## §7 References
 
-<!-- TODO: ~/me/knowledge/research/2026-05-09-process-global-state-alternatives.md 인용 -->
+### 외부
 
-- (sub-agent Topic B) capability-based security, Joe-E, E language
-- (sub-agent Topic B) Erlang OTP supervision tree
-- (sub-agent Topic B) OCaml first-class modules / functors
-- (sub-agent Topic B) Algebraic effects (Eio context handler)
-- (사내) `instructions/software-development.md` §2 process-global setter anti-pattern
-- (사내) PR #13987 — reference fix (global no-op 제거)
+- Eio Fiber API — "prefer passing arguments around explicitly" (https://ocaml-multicore.github.io/eio/eio/Eio/Fiber/index.html)
+- Eio 1.0 paper — capability-passing style (https://kcsrk.info/papers/eio_ocaml23a.pdf)
+- Erlang OTP Supervision Trees (https://adoptingerlang.org/docs/development/supervision_trees/)
+- Joe-E NDSS 2010 — object-capability discipline (https://people.eecs.berkeley.edu/~daw/papers/joe-e-ndss10.pdf)
+- Algebraic Handler Lookup Comparison — Koka vs OCaml 5 (https://interjectedfuture.com/algebraic-handler-lookup-in-koka-eff-ocaml-and-unison/)
+- OCaml First-Class Modules (https://ocaml.org/manual/5.4/firstclassmodules.html)
+
+### 사내
+
+- `instructions/software-development.md` §2 process-global setter anti-pattern
+- PR #13987 — reference fix (global no-op 제거)
+- (sub-agent Topic B.1) `default_tool_search_fn` / `set_tool_search_fn` 호출 사이트 — `.tmp/rfc-0053-caller-context.md`
+- (sub-agent Topic B.3) process-global setter 시그니처 검색 결과 — `.tmp/rfc-0053-caller-context.md`
 
 ---
 


### PR DESCRIPTION
## Summary

Integrates sub-agent collected caller-context data into three RFC drafts and adds P3 process tools design.

### RFC-0052 (Boot-time Required Invariants)
- §1: `Masc_eio_env` 8 call sites, `Keeper_health_probe.start_probe` 0 calls (dead code), `clock_opt` 12+ sites, silent fallthrough patterns
- §5: research comparison table (phantom type / parse-don't-validate / GADT / dependent types)
- §7: Evidence Record with external references

### RFC-0053 (Tool Dispatch Session-Local Handles)
- §1: `set_tool_search_fn` dead code confirmation, 8 global setter inventory, existing session-local pattern in `keeper_run_tools.ml`
- Fix: RFC number 0051 → 0053 (was mislabeled)
- §5/§7: research comparison table (capability passing / OTP / object-capability / effects / first-class modules)

### RFC-0038 Phase 2 (Keeper Identity Canonicalization)
- §1: `same_task_actor` removed (refactored to `same_agent`), 3 existing workarounds found, 0 typed comparisons, alias creation paths
- §5/§7: ActivityPub + OIDC hybrid model comparison table

### P3 Process Tools Design
- `docs/design/pr-axis-cross-check-and-rfc-enforcer.md`
- PR Axis Cross-Check: pre-merge stale PR detection from recent main changes
- RFC §1 Enforcer: CI gate ensuring caller-context completeness

## Test Plan

- [x] All RFC files render correctly as markdown
- [x] Sub-agent caller-context files saved to `.tmp/rfc-*.md`
- [ ] RFC §1 TODO count = 0 (verify no remaining placeholders)

## Related Feedback

- `feedback_main_blocker_chain_4x_session.md` (2026-05-05)
- `feedback_wave_pattern_60_80_stale_resolved.md` (2026-05-05)
- `feedback_check_open_prs_before_fixing_pasted_build_error.md` (2026-05-05, 3rd recidivism)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)