### PR TITLE
chore(dashboard): delete 3 dead memory* re-export shims

### DIFF
--- a/dashboard/src/components/memory-post-detail.ts
+++ b/dashboard/src/components/memory-post-detail.ts
@@ -1,1 +1,0 @@
-export * from './board/post-detail'

--- a/dashboard/src/components/memory-state.ts
+++ b/dashboard/src/components/memory-state.ts
@@ -1,1 +1,0 @@
-export * from './board/board-state'

--- a/dashboard/src/components/memory.ts
+++ b/dashboard/src/components/memory.ts
@@ -1,1 +1,0 @@
-export { BoardSurface as Memory } from './board'


### PR DESCRIPTION
## Summary

Three single-line re-export shims left over from a prior board↔memory module rename. Zero importers in src/.

## What

| File | Content |
|---|---|
| \`src/components/memory.ts\` | \`export { BoardSurface as Memory } from './board'\` |
| \`src/components/memory-state.ts\` | \`export * from './board/board-state'\` |
| \`src/components/memory-post-detail.ts\` | \`export * from './board/post-detail'\` |

## Verification

- Detected by \`npx knip --reporter compact\` (Unused files section).
- Verified individually:
  - \`rg \"from ['\\\"].*memory['\\\"]\" src/\` — 0 importers of these specific paths.
  - The route key \`view: 'memory'\` in \`cockpit-entrypoints.ts\` is a routing string label, not a file import (verified via grep).
  - Real consumers (\`cognition-plane\`, \`agent-detail\`, \`keeper-detail\`) import \`memory-subsystems\`, \`agent-detail-memory\`, \`keeper-memory-tier-panel\` directly — not through these shims.

## Knip false-positive check (per memory \`feedback_explore_agent_dead_code_triage_oversells\`)

Knip's \"Unused exports\" section reports 239 items. Sampled 3 (\`barPercent\`, \`chipAriaLabel\`, \`resolveVariant\`) and all are imported by \`*.test.ts\` — knip doesn't count test imports. **Not deleted**. Only the 3 file-level shims with verified-zero importers are touched here.

## Test plan

- vite build: 11.81s green.
- vitest \`cognition-plane.test.ts\` + \`cockpit-entrypoints.test.ts\` (route key consumers): 20/20 pass.

Net: **-3 LoC, -3 files**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)