### PR TITLE
docs(rfc): RFC-0054 §5.3.1 empirical block — PPX PR-1 attempt findings

### DIFF
--- a/docs/rfc/RFC-0054-shell-ir-ppx-deriving.md
+++ b/docs/rfc/RFC-0054-shell-ir-ppx-deriving.md
@@ -1,8 +1,8 @@
 # RFC-0054 — `[@@deriving shell_ir]` PPX for Typed Capability Substrate Phase 2
 
-Status: Draft
+Status: Draft · PR-1 attempted 2026-05-09 · blocked on §5.3.1 empirical finding
 Author: jeong-sik (with Claude Opus 4.7)
-Date: 2026-05-09
+Date: 2026-05-09 (drafted) · 2026-05-09 (PR-1 amendment with empirical evidence)
 Supersedes: —
 Related: RFC-0005 §3.2 (Phase 2 PPX, listed but unsourced),
 progress_report.md 2026-05-09 §3.2
@@ -232,6 +232,56 @@ ppxlib version requires a specific Ast_helper invocation), PR-1 falls
 back to scope-A: emit `to_simple_explicit` with manual type
 annotations and document the workaround. The deriver still ships;
 just doesn't claim universal type abstraction in PR-1.
+
+#### 5.3.1 Empirical finding (RFC-0054 PR-1 attempt, 2026-05-09)
+
+The `Ast_builder.Default` path *does* hit a non-trivial OCaml 5.4
+interaction. PR-1 attempted the natural generalisation
+(`pexp_newtype` × N nested + `ptyp_poly` over N univ vars +
+`pexp_constraint` or `ppat_constraint`-typed argument) under three
+naming conventions:
+
+1. Same names for universal & locally-abstract (`'a, a`) — works for
+   N=1 (Tier I8) but raises `variable 'a is reserved for the local
+   type a` at N≥2.
+2. Disjoint names (`'a, pa`) — bypasses the reserved-name error but
+   the GADT match still narrows: `This pattern matches values of
+   type (string, unit) edge but a pattern was expected which
+   matches values of type (unit, string) edge`.
+3. Argument-pattern annotation (`fun (arg : (pa, pb) edge) -> match
+   arg with …`) — same narrowing failure.
+
+The decisive observation: dumping the failing AST back to source
+text via `ocamlfind ocamlc -dsource -i` produces OCaml that compiles
+and runs cleanly when fed to `ocaml` directly. So the generated
+*text* is valid; the *AST node tree* `Ast_builder.Default`
+constructs contains some metadata divergent from what the parser
+produces for the same source — and that divergence triggers GADT
+narrowing during the typechecker pass.
+
+`test/ppx_tla/test_typed_param.ml` (added by PR-1, **not registered
+in the dune file**) carries the failing 2-param and 4-param GADT
+cases as commented-out evidence + the diagnosis above. It serves as
+a regression marker: when Tier I8b lands, the file's
+`[@@deriving tla]` blocks should compile and the file gets
+registered in dune.
+
+#### 5.3.2 Fallback paths (one of these, separate PR)
+
+- **Source-template approach.** Use `Ppxlib.Parse.expression` on a
+  hand-written template string with type-name + constructor-list
+  placeholders. Brittle (escaping, hygiene) but guaranteed to match
+  what the parser produces.
+- **ppxlib-internals approach.** Investigate Astlib / Migrate
+  transforms to discover which Parsetree node attribute the source
+  path attaches that the Ast_builder path omits. Requires deep
+  ppxlib knowledge.
+
+Until one of those lands, `[@@deriving tla]` continues to raise the
+existing "not yet supported" error for non-phantom N-param GADT
+existentials. `shell_ir_typed.ml`'s hand-written walkers stay. PR-2
+through PR-5 of this RFC are blocked on this fallback being
+selected and implemented.
 
 ### 5.4 Fail-closed preservation
 

--- a/test/ppx_tla/test_typed_param.ml
+++ b/test/ppx_tla/test_typed_param.ml
@@ -1,0 +1,113 @@
+(* RFC-0054 PR-1 / Tier I8b — investigation evidence.
+
+   This file is intentionally NOT registered in test/ppx_tla/dune.
+   It documents the empirical OCaml 5.4 / ppxlib AST inequivalence
+   that blocks straightforward [@@deriving tla] generalisation to
+   non-phantom N-parameter GADT existentials.
+
+   Background (RFC-0054 §1, §5.3):
+     ppx_tla.ml currently raises an explicit error for
+       type (_, _) edge =
+         | E1 : (unit, string) edge
+         | E2 : (string, unit) edge
+       [@@deriving tla]
+     because emitting [let f : type a b. … = function …] via ppxlib
+     [Ast_builder.Default] hit "non-trivial" interaction with OCaml
+     5.4 scoped-type rules in a previous attempt.
+
+   Investigation findings (2026-05-09 PR-1 attempt):
+
+   1. Generalising [make_to_tla_symbol_impl_gadt_one_param] to N
+      parameters via the natural pattern (List.fold_right over
+      pexp_newtype, ptyp_poly with N univ vars, pexp_constraint with
+      ptyp_constr (Lident var) []) produces an AST whose
+      pretty-printed form matches working hand-written OCaml
+      byte-for-byte. Yet the generated AST fails the typechecker
+      with:
+        Error: This pattern matches values of type (string, unit) edge
+               but a pattern was expected which matches values of type
+                 (unit, string) edge
+
+   2. The hand-written equivalent compiles and runs cleanly:
+        let to_sym : 'a 'b. ('a, 'b) edge -> string =
+          fun (type pa) -> fun (type pb) ->
+            fun (arg : (pa, pb) edge) ->
+              match arg with
+              | E1 -> "e1"
+              | E2 -> "e2"
+
+   3. Extracting the dumped source from the failing AST and feeding
+      it to [ocaml] directly compiles AND runs. So the generated
+      *text* is valid OCaml, but the *AST node tree* ppxlib produces
+      contains some metadata or location-attribute that diverges
+      from what the parser produces for the same source — and that
+      divergence triggers GADT narrowing.
+
+   Diagnosis attempts that did NOT resolve the issue (PR-1):
+   - Disjoint universal vs locally-abstract names ('a vs pa).
+   - Dropping the outer ptyp_poly and relying on inference.
+   - Replacing pexp_constraint on the function with a typed
+     argument pattern (ppat_constraint).
+
+   None of these produced a working deriver for N ≥ 2.
+
+   Path forward (proposed RFC-0054 amendment):
+
+   Two viable workaround tracks. Both deferred to a separate PR:
+
+   A. Source-template approach. Use [Ppxlib.Parse.expression] on a
+      hand-written template string with type-name + constructor-list
+      placeholders. Brittle (escaping, hygiene) but guaranteed to
+      match what the parser produces.
+
+   B. ppxlib internals approach. Investigate Astlib / Migrate
+      transforms to discover which Parsetree node attribute the
+      source path attaches that the Ast_builder path omits.
+      Requires deep ppxlib knowledge.
+
+   Until one of those lands, [@@deriving tla] continues to raise
+   the existing "not yet supported" error for non-phantom N-param
+   GADT existentials. shell_ir_typed.ml's hand-written walkers stay.
+
+   This file remains in the tree as a regression marker — when
+   Tier I8b lands, the body below should compile under [@@deriving tla]
+   and the file gets registered in dune. *)
+
+(* ─── 2-parameter non-phantom GADT (the smallest I8b case) ──────────
+   Currently raises:
+     [@@deriving tla]: GADT existential with type parameters is not yet
+     supported. Add [@@tla.phantom_param] if the type parameters are
+     phantom (not specialised in constructor bodies). Otherwise,
+     hand-write to_tla_symbol_any for this type. *)
+
+(*
+module Two_param = struct
+  type (_, _) edge =
+    | E_a_to_b : (unit, string) edge
+    | E_b_to_a : (string, unit) edge
+    | E_self : (int, int) edge
+  [@@deriving tla]
+end
+*)
+
+(* ─── 4-parameter non-phantom GADT (shell_ir_typed shape) ──────────
+   The end goal of RFC-0054. Mirrors lib/exec/shell_ir_typed.ml's
+   ('input, 'output, 'risk, 'sandbox) command. *)
+
+(*
+module Four_param = struct
+  type (_, _, _, _) command =
+    | C_ls :
+        { path : string option }
+        -> (unit, string, [ `Safe ], [ `Host ]) command
+    | C_git_status :
+        { short : bool }
+        -> (unit, string, [ `Audited ], [ `Host ]) command
+    | C_rm :
+        { path : string }
+        -> (unit, unit, [ `Privileged ], [ `Host ]) command
+  [@@deriving tla]
+end
+*)
+
+let () = ()


### PR DESCRIPTION
## Summary

PR-1 (Tier I8b unblocking — `[@@deriving tla]` for non-phantom N-param GADT existentials) attempted but **blocked** on a deeper OCaml 5.4 / ppxlib AST-vs-source inequivalence than RFC-0054 §5.3 budgeted. This PR records the empirical evidence and proposes fallback paths for a separate PR — does **not** ship a half-working deriver.

## Why honest deferral, not workaround

Per memory `feedback_workaround_rejection_bar`: don't ship workarounds. The "scope-A fallback" RFC-0054 §5.3 originally permitted (separately-named function) didn't fit — the bug isn't naming, it's the AST-vs-source construction divergence. Need either a source-template approach or deep ppxlib-internals investigation, both of which deserve their own PR with proper scope.

## Decisive empirical observation

Three different AST construction strategies all produce code that:

- **Pretty-prints to OCaml that compiles and runs cleanly under `ocaml`**.
- **Fails the typechecker when consumed as the original AST**.

```bash
$ ocamlfind ocamlc -dsource -i <ppxlib-output>.pp.ml > /tmp/extracted.ml
$ ocaml /tmp/extracted.ml
e_a_to_b   # works
$ # but the original AST: Error: pattern matches values of type (string, unit) edge but expected (unit, string) edge
```

So the *text* is valid OCaml; the *AST tree* contains some Parsetree metadata divergent from the parser's output, and that triggers GADT narrowing.

## What's in this PR

- `docs/rfc/RFC-0054-shell-ir-ppx-deriving.md`:
  - **New §5.3.1** "Empirical finding (PR-1 attempt)" with all three failed approaches.
  - **New §5.3.2** "Fallback paths" — source-template OR ppxlib-internals investigation.
  - Updated Status header reflecting the block.
- `test/ppx_tla/test_typed_param.ml`:
  - Regression marker, **NOT registered in dune**.
  - 2-param and 4-param GADT cases commented out.
  - Same diagnosis as §5.3.1 inline as comments.
  - When Tier I8b lands, the `[@@deriving tla]` blocks should compile and the file gets registered.

`ppx_tla.ml` is **unchanged from origin/main** — no half-working deriver shipped.

## Three failed approaches (preserved in §5.3.1)

1. Same names for universal & locally-abstract (`'a`, `a`). Works for N=1 but raises `variable 'a is reserved for the local type a` at N≥2.
2. Disjoint names (`'a`, `pa`). Bypasses the reserved-name error but GADT match still narrows.
3. Argument-pattern annotation (`fun (arg : (pa, pb) edge) -> match arg with …`). Same narrowing failure.

## What's blocked

PR-2 through PR-5 of RFC-0054 (deriving `risk`/`sandbox`, `to_simple`, `of_simple`, cleanup) all depend on PR-1's deriver. They're now blocked on §5.3.2 fallback selection.

`shell_ir_typed.ml`'s hand-written walkers stay until then.

## Next step proposed

Pick a §5.3.2 fallback path:

- **Source-template** (`Ppxlib.Parse.expression`): brittle, parser-equivalent. Cheap exploratory PR.
- **ppxlib-internals**: deeper investigation, multi-day. May not yield a clean answer.

Recommend source-template first as a 1-day proof-of-concept; if it works, that's PR-1' replacement.

Net +165 / -3, docs + 1 commented-out test file. No code change.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>