### PR TITLE
refactor(cdal_runtime): empty default_tool_entries (RFC-OAS-012)

### DIFF
--- a/lib/cdal_runtime/mode_enforcer.ml
+++ b/lib/cdal_runtime/mode_enforcer.ml
@@ -86,68 +86,17 @@ type token_snapshot =
     tool requires extending [Tool_id] and the compiler then flags every
     site that needs to acknowledge it. The runtime registry below stays
     string-keyed because plugin tools register at runtime by name. *)
-let default_tool_entries : (Tool_id.t * tool_effect_class) list =
-  [ (* ── Read-only tools ─────────────────────────────────────── *)
-    (* File & code navigation *)
-    `Read, Read_only
-  ; `Glob, Read_only
-  ; `Grep, Read_only
-  ; `Search, Read_only
-  ; `List_dir, Read_only
-  ; `Find_file, Read_only
-  ; `Read_file, Read_only
-  ; `Find_symbol, Read_only
-  ; `Get_symbols_overview, Read_only
-  ; `Find_referencing_symbols, Read_only
-  ; `Search_for_pattern, Read_only
-  ; (* Notebook *)
-    `Notebook_read, Read_only
-  ; (* Browser observation *)
-    `Read_console_messages, Read_only
-  ; `Read_network_requests, Read_only
-  ; `Get_page_text, Read_only
-  ; `Read_page, Read_only
-  ; `Tabs_context_mcp, Read_only
-  ; (* Task queries *)
-    `Task_list, Read_only
-  ; `Task_get, Read_only
-  ; `Task_output, Read_only
-  ; (* ── Local-mutation tools ────────────────────────────────── *)
-    (* File editing *)
-    `Write, Local_mutation
-  ; `Edit, Local_mutation
-  ; `Create_text_file, Local_mutation
-  ; `Replace_content, Local_mutation
-  ; `Rename_symbol, Local_mutation
-  ; `Insert_after_symbol, Local_mutation
-  ; `Insert_before_symbol, Local_mutation
-  ; `Replace_symbol_body, Local_mutation
-  ; `Notebook_edit, Local_mutation
-  ; (* Task & team management *)
-    `Task_create, Local_mutation
-  ; `Task_update, Local_mutation
-  ; `Task_stop, Local_mutation
-  ; `Team_create, Local_mutation
-  ; `Team_delete, Local_mutation
-  ; (* ── External-effect tools ───────────────────────────────── *)
-    (* HITL *)
-    `Ask_user_question, External_effect
-  ; (* Web & research *)
-    `Web_fetch, External_effect
-  ; `Web_search, External_effect
-  ; (* Browser interaction *)
-    `Navigate, External_effect
-  ; `Computer, External_effect
-  ; `Find, External_effect
-  ; `Form_input, External_effect
-  ; `Javascript_tool, External_effect
-  ; `Tabs_create_mcp, External_effect
-  ; `Upload_image, External_effect
-  ; (* ── Shell-dynamic tools (require input analysis at runtime) *)
-    `Bash, Shell_dynamic
-  ; `Execute_shell_command, Shell_dynamic
-  ]
-;;
+(* RFC-OAS-012: emptied. Hardcoded consumer-side tool names (Claude Code /
+   Serena / claude-in-chrome MCP / Team_*) were a layering violation —
+   masc_mcp.cdal_runtime is a generic governance framework and should not
+   pre-classify particular consumer tool catalogues. Consumers now register
+   their tools via [register_tool_class] or supply [Tool.descriptor.mutation_class]
+   at construction; classify_tool returns External_effect (fail-closed) for
+   anything not registered. The 46 hardcoded entries that lived here were
+   originally the closest-to-OAS surface and were migrated verbatim from
+   OAS in MM-2; their cleanup was the original intent of RFC-OAS-009 v1
+   and is finished here, post-migration. *)
+let default_tool_entries : (Tool_id.t * tool_effect_class) list = []
 
 (** Global mutable registry seeded from [default_tool_entries].
     Supports runtime extension via [register_tool_class].
@@ -543,64 +492,23 @@ let hooks st =
 (* ── Inline tests ──────────────────────────────────────────────── *)
 [@@@coverage off]
 
-let%test "builtin_descriptor returns Some for read-only tools" =
-  match builtin_descriptor "read" with
-  | Some d ->
-    d.mutation_class = Some "read_only"
-    && d.concurrency_class = Some Tool.Parallel_read
-    && d.permission = Some Tool.ReadOnly
-  | None -> false
-;;
-
-let%test "builtin_descriptor returns Some for mutation tools" =
-  match builtin_descriptor "edit" with
-  | Some d ->
-    d.mutation_class = Some "local_mutation"
-    && d.concurrency_class = Some Tool.Sequential_workspace
-    && d.permission = Some Tool.Write
-  | None -> false
-;;
-
-let%test "builtin_descriptor returns Some for external tools" =
-  match builtin_descriptor "web_fetch" with
-  | Some d ->
-    d.mutation_class = Some "external_effect"
-    && d.concurrency_class = Some Tool.Exclusive_external
-    && d.permission = Some Tool.Destructive
-  | None -> false
-;;
-
-let%test "builtin_descriptor returns Some for ask_user_question" =
-  match builtin_descriptor "ask_user_question" with
-  | Some d -> d.concurrency_class = Some Tool.Exclusive_external
-  | None -> false
-;;
-
-let%test "builtin_descriptor returns Some for task tools" =
-  match builtin_descriptor "task_list" with
-  | Some d -> d.concurrency_class = Some Tool.Parallel_read
-  | None -> false
-;;
-
-let%test "builtin_descriptor returns Some for task_create" =
-  match builtin_descriptor "task_create" with
-  | Some d -> d.concurrency_class = Some Tool.Sequential_workspace
-  | None -> false
-;;
-
-let%test "builtin_descriptor returns Some for shell tools" =
-  match builtin_descriptor "bash" with
-  | Some d -> d.mutation_class = Some "external_effect" && d.shell <> None
-  | None -> false
-;;
-
-let%test "builtin_descriptor returns None for unknown tools" =
-  builtin_descriptor "nonexistent_tool_xyz" = None
-;;
+(* RFC-OAS-012: removed 8 builtin_descriptor inline tests that pinned
+   the 46 hardcoded consumer tool names ("read"/"edit"/"web_fetch"/
+   "ask_user_question"/"task_list"/"task_create"/"bash"/"nonexistent")
+   into the boundary classifier. With default_tool_entries now empty,
+   builtin_descriptor returns None for every name — the tests had no
+   ground truth left and were the inverse statement of the layering
+   violation RFC-OAS-009 v1 set out to fix. *)
 
 let%test "register_tool_class extends registry" =
   register_tool_class "my_custom_tool" Read_only;
   match builtin_descriptor "my_custom_tool" with
   | Some d -> d.mutation_class = Some "read_only"
   | None -> false
+;;
+
+let%test "builtin_descriptor returns None for unregistered tools" =
+  (* Empty default_tool_entries means every name without an explicit
+     register_tool_class call returns None. Fail-closed by design. *)
+  builtin_descriptor "nonexistent_tool_xyz" = None
 ;;

--- a/lib/cdal_runtime/tool_id.mli
+++ b/lib/cdal_runtime/tool_id.mli
@@ -1,10 +1,13 @@
-(** Typed tool identifier for the CDAL runtime's built-in classification
-    table (RFC-0005 Phase 1 §3.1 follow-up).
+(** Typed tool identifier for the CDAL runtime (RFC-0005 Phase 1 §3.1
+    follow-up).
 
-    Each constructor is a tool that ships with masc-mcp's default
-    classification in [Mode_enforcer.default_tool_entries]. Adding a new
-    built-in tool requires extending this variant — the compiler then
-    flags every site that needs to acknowledge the new entry.
+    Each constructor names a tool the CDAL runtime can recognise without
+    a string lookup. [Mode_enforcer.default_tool_entries] used to seed
+    classifications for these names but was emptied by RFC-OAS-012 — the
+    Variant is kept because future register-side APIs may take
+    [Tool_id.t] for compile-time exhaustiveness, and because a closed
+    Variant remains the cheapest way to ensure the registry never silently
+    diverges from a known catalogue.
 
     Public APIs of [Mode_enforcer] (e.g. [classify_tool],
     [register_tool_class]) remain string-typed because plugin tools


### PR DESCRIPTION
## 요약

RFC-OAS-009 v1의 *원의도*가 이주 후 마무리. `masc_mcp.cdal_runtime/mode_enforcer.ml`의 `default_tool_entries`가 *46 hardcoded 외부 builtin 이름* (Claude Code/Serena/claude-in-chrome MCP/Team_*)을 가지고 있던 것을 **빈 리스트**로. masc_mcp.cdal_runtime은 *generic governance framework*이고 *consumer-supplied catalogue*만 인식해야 한다는 RFC-OAS-009 v2 정신과 일관.

## 변경 (2 files / +33 / -122)

| 파일 | 변경 |
|---|---|
| `lib/cdal_runtime/mode_enforcer.ml` | `default_tool_entries` 46 → 0 entries. 8 inline tests (builtin_descriptor 가정) 제거. `register_tool_class` test 유지 + 1 fail-closed test 추가 |
| `lib/cdal_runtime/tool_id.mli` | docstring 갱신: default_tool_entries 비어있음 + 미래 typed register API용 Variant 유지 명시 |

## Behaviour change

```
Mode_enforcer.classify_tool name
  →  External_effect (fail-closed) for any unregistered name
```

CDAL runtime은 *어떤 tool이 read-only / mutating / external인지를 consumer 대신 가정하지 않음*.

## 외부 영향 = 0 검증

```bash
$ rg -l 'Mode_enforcer\.(classify_tool|builtin_descriptor|default_tool_entries|\
       all_read_only|all_workspace_only|register_tool_class)' \
       lib/ bin/ | grep -v '^lib/cdal_runtime/'
# (empty)
```

masc-mcp 본체에서 이 APIs 호출 0건 — empty화로 깨질 caller 없음.

## RFC 연쇄

| RFC | 의도 | 상태 |
|---|---|---|
| RFC-OAS-009 v1 (#1478, MERGED) | default_tool_entries 정리 | superseded by v2 — 의도가 본 RFC로 이동 |
| RFC-OAS-009 v2 (#1480, MERGED) | core → CDAL 의존 끊기 | DONE |
| RFC-OAS-011 (#14247-#14267) | CDAL → masc-mcp 이주 | DONE |
| **RFC-OAS-012 (this)** | 이주 후 default_tool_entries 정리 | OPEN |
| RFC-OAS-013 (next) | Guardrails 3 redundant copy 제거 | TBD |

## Tool_id 정리는 별 작업

`Tool_id.t` 사용처가 *empty list type annotation 1건*만 남음. 그러나 *closed Variant* 자체는 *미래 typed register API*용으로 유지 (`register_tool_class : Tool_id.t -> ...` 같은 강타입 진입점). 즉 *지금* 제거해도 *별 가치 없고*, 유지해도 *비용 ≈ 0*. 문서로만 의도 명시.

## Test plan

- [ ] CI green — `register_tool_class` test + `returns None for unregistered tools` test 모두 통과
- [ ] `human-approved-ready` 라벨 부착 후 머지

🤖 Generated with [Claude Code](https://claude.com/claude-code)