### PR TITLE
chore(opam): bump agent_sdk pin to 0.193.0 (RFC-OAS-011 follow-up)

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -41,7 +41,7 @@
   (cmdliner (>= 1.1))
   (cohttp (>= 5.0))
   (cohttp-eio (>= 6.0))
-  (agent_sdk (>= 0.192.1))
+  (agent_sdk (>= 0.193.0))
   (uri (>= 4.4))
   (tls (>= 2.0))
   (tls-eio (>= 2.0))

--- a/masc_mcp.opam
+++ b/masc_mcp.opam
@@ -25,7 +25,7 @@ depends: [
   "cmdliner" {>= "1.1"}
   "cohttp" {>= "5.0"}
   "cohttp-eio" {>= "6.0"}
-  "agent_sdk" {>= "0.192.1"}
+  "agent_sdk" {>= "0.193.0"}
   "uri" {>= "4.4"}
   "tls" {>= "2.0"}
   "tls-eio" {>= "2.0"}

--- a/scripts/oas-agent-sdk-pin.sh
+++ b/scripts/oas-agent-sdk-pin.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 readonly OAS_AGENT_SDK_URL="https://github.com/jeong-sik/oas.git"
-readonly OAS_AGENT_SDK_BASE_VERSION="v0.192.1"
+readonly OAS_AGENT_SDK_BASE_VERSION="v0.193.0"
 readonly OAS_AGENT_SDK_TRACK_REF="main"
-readonly OAS_AGENT_SDK_SHA="57ee93e1a889fa2b74a43a1436593b3db21f144e"
-readonly OAS_AGENT_SDK_MIN_VERSION="0.192.1"
+readonly OAS_AGENT_SDK_SHA="137979e55d94e894d9b708e6115e40c802f3d779"
+readonly OAS_AGENT_SDK_MIN_VERSION="0.193.0"


### PR DESCRIPTION
## 요약 — RFC-OAS-011의 *진짜 마지막* 한 줄

OAS PR #1490 (manual 0.193.0 release) 머지 후, masc-mcp 측 *version floor + SHA*를 정렬. **3 files / +5 / -5** (one-line each).

## 변경

```diff
# scripts/oas-agent-sdk-pin.sh
-readonly OAS_AGENT_SDK_BASE_VERSION="v0.192.1"
+readonly OAS_AGENT_SDK_BASE_VERSION="v0.193.0"
-readonly OAS_AGENT_SDK_SHA="57ee93e1a889fa2b74a43a1436593b3db21f144e"
+readonly OAS_AGENT_SDK_SHA="137979e55d94e894d9b708e6115e40c802f3d779"
-readonly OAS_AGENT_SDK_MIN_VERSION="0.192.1"
+readonly OAS_AGENT_SDK_MIN_VERSION="0.193.0"

# dune-project
-  (agent_sdk (>= 0.192.1))
+  (agent_sdk (>= 0.193.0))

# masc_mcp.opam
-  "agent_sdk" {>= "0.192.1"}
+  "agent_sdk" {>= "0.193.0"}
```

## masc-mcp 빌드 영향 = 0

MM-3-rewire (#14267)에서 모든 consumer를 `Agent_sdk.X` → `Masc_mcp_cdal_runtime.X`로 *atomic flip* 완료. agent_sdk 0.193.0이 *제거된 모듈을 export 안 함*은 *사용 안 하는 symbol이라 무관*.

## RFC-OAS-011 종결

| Phase | 상태 |
|---|---|
| MM-1~MM-2-top (cdal_runtime 23 modules migration) | MERGED |
| #14257 hotfix (include_subdirs no) | MERGED |
| MM-3-rewire (atomic flip 38 files) | MERGED |
| OAS-E PR-1~6 (boundary lint + dead removal + 23 modules + façade + Sessions trim) | MERGED |
| MM-4 (opam SHA pin bump) | MERGED |
| OAS 0.193.0 release (#1490) | MERGED |
| RFC-OAS-012 (default_tool_entries cleanup) | MERGED |
| RFC-OAS-013 (Guardrails redundant copies) | MERGED |
| **이 follow-up (BASE/MIN/SHA bump)** | OPEN, Draft |

## Cross-repo 누적 stat

- **+7,531 LoC** migrated → `masc_mcp.cdal_runtime`
- **-18,237 LoC** removed from `agent_sdk` (OAS-E sweep)
- **net -10,706 LoC** (대부분 over-tested dead surface)

## Test plan

- [ ] CI green — agent_sdk 0.193.0 floor 명시 후 빌드
- [ ] `human-approved-ready` 라벨 부착 후 머지

🤖 Generated with [Claude Code](https://claude.com/claude-code)