### PR TITLE
fix+refactor(keeper): unblock main + type final wire-string classifiers

### DIFF
--- a/lib/keeper/keeper_composite_observer.ml
+++ b/lib/keeper/keeper_composite_observer.ml
@@ -306,8 +306,10 @@ let check_phase_turn_alignment
       (phase = Keeper_state_machine.Compacting)
   | Keeper_registry.Packed Turn_idle
   | Keeper_registry.Packed Turn_prompting
+  | Keeper_registry.Packed Turn_routing
   | Keeper_registry.Packed Turn_executing
-  | Keeper_registry.Packed Turn_finalizing ->
+  | Keeper_registry.Packed Turn_finalizing
+  | Keeper_registry.Packed Turn_exhausted ->
       not (phase = Keeper_state_machine.Compacting)
 
 let check_compaction_atomicity

--- a/lib/keeper/keeper_passive_loop_detector.ml
+++ b/lib/keeper/keeper_passive_loop_detector.ml
@@ -31,12 +31,21 @@ let threshold () =
 let required_tool_no_call_progress_class = "required_tool_no_call"
 let required_tool_unsatisfied_progress_class = "required_tool_unsatisfied"
 
-let progress_class_of_terminal_reason_code = function
-  | "required_tool_use_no_tool_call" ->
+(* RFC-0047 follow-up: take a typed [Keeper_turn_disposition.t] instead
+   of pattern-matching on the wire string. The two relevant arms
+   ([Required_tool_use_no_tool_call] and [Required_tool_use_unsatisfied])
+   are dispositions known at construction time; everything else returns
+   [None] without ever needing to introspect the [code] string. *)
+let progress_class_of_disposition (d : Keeper_turn_disposition.t) =
+  match d with
+  | Required_tool_use_no_tool_call ->
       Some required_tool_no_call_progress_class
-  | "required_tool_use_unsatisfied" ->
+  | Required_tool_use_unsatisfied ->
       Some required_tool_unsatisfied_progress_class
-  | _ -> None
+  | Success | External_cancel | Turn_wall_clock_timeout | Oas_timeout_budget
+  | Gh_repo_context_missing_worktree | Post_commit_ambiguous
+  | Provider_error _ | Unknown _ ->
+      None
 
 type keeper_state = {
   mutable streak : int;

--- a/lib/keeper/keeper_passive_loop_detector.mli
+++ b/lib/keeper/keeper_passive_loop_detector.mli
@@ -14,10 +14,13 @@
 
     @since #12799 *)
 
-val progress_class_of_terminal_reason_code : string -> string option
-(** Map typed terminal-reason codes into detector progress classes. Returns
-    [Some _] only for required-tool failures that should count toward an
-    inter-turn no-progress loop. *)
+val progress_class_of_disposition :
+  Keeper_turn_disposition.t -> string option
+(** Map a typed [Keeper_turn_disposition.t] into a detector progress class.
+    Returns [Some _] only for required-tool failure dispositions
+    ([Required_tool_use_no_tool_call] and [Required_tool_use_unsatisfied])
+    that should count toward an inter-turn no-progress loop; every other
+    disposition variant returns [None]. *)
 
 val record_turn :
   keeper_name:string ->

--- a/lib/keeper/keeper_registry.ml
+++ b/lib/keeper/keeper_registry.ml
@@ -209,35 +209,66 @@ let witness_to_turn_phase : packed_turn_phase -> turn_phase = function
   | Packed Turn_exhausted -> Turn_exhausted
 
 module Turn_phase_transition = struct
+  (* Mirrors [validate_turn_phase_transition] (below): every constructor
+     here corresponds to a [true] arm in the runtime transition matrix.
+     Adding a new variant therefore requires extending both this GADT
+     and the runtime validator at the same time so the type-level and
+     runtime stories stay in lockstep. *)
   type ('from, 'to_) t =
     | Idle_to_idle : (turn_idle, turn_idle) t
     | Idle_to_prompting : (turn_idle, turn_prompting) t
     | Prompting_to_prompting : (turn_prompting, turn_prompting) t
+    | Prompting_to_routing : (turn_prompting, turn_routing) t
     | Prompting_to_executing : (turn_prompting, turn_executing) t
     | Prompting_to_finalizing : (turn_prompting, turn_finalizing) t
+    | Routing_to_prompting : (turn_routing, turn_prompting) t
+    | Routing_to_routing : (turn_routing, turn_routing) t
+    | Routing_to_executing : (turn_routing, turn_executing) t
     | Executing_to_prompting : (turn_executing, turn_prompting) t
+    | Executing_to_routing : (turn_executing, turn_routing) t
     | Executing_to_executing : (turn_executing, turn_executing) t
     | Executing_to_compacting : (turn_executing, turn_compacting) t
     | Executing_to_finalizing : (turn_executing, turn_finalizing) t
+    | Executing_to_exhausted : (turn_executing, turn_exhausted) t
     | Compacting_to_prompting : (turn_compacting, turn_prompting) t
     | Compacting_to_compacting : (turn_compacting, turn_compacting) t
     | Compacting_to_finalizing : (turn_compacting, turn_finalizing) t
+    | Finalizing_to_prompting : (turn_finalizing, turn_prompting) t
+    | Finalizing_to_routing : (turn_finalizing, turn_routing) t
+    | Finalizing_to_executing : (turn_finalizing, turn_executing) t
     | Finalizing_to_finalizing : (turn_finalizing, turn_finalizing) t
+    | Exhausted_to_prompting : (turn_exhausted, turn_prompting) t
+    | Exhausted_to_routing : (turn_exhausted, turn_routing) t
+    | Exhausted_to_executing : (turn_exhausted, turn_executing) t
+    | Exhausted_to_exhausted : (turn_exhausted, turn_exhausted) t
 
   let to_tag : type a b. (a, b) t -> string = function
     | Idle_to_idle -> "idle->idle"
     | Idle_to_prompting -> "idle->prompting"
     | Prompting_to_prompting -> "prompting->prompting"
+    | Prompting_to_routing -> "prompting->routing"
     | Prompting_to_executing -> "prompting->executing"
     | Prompting_to_finalizing -> "prompting->finalizing"
+    | Routing_to_prompting -> "routing->prompting"
+    | Routing_to_routing -> "routing->routing"
+    | Routing_to_executing -> "routing->executing"
     | Executing_to_prompting -> "executing->prompting"
+    | Executing_to_routing -> "executing->routing"
     | Executing_to_executing -> "executing->executing"
     | Executing_to_compacting -> "executing->compacting"
     | Executing_to_finalizing -> "executing->finalizing"
+    | Executing_to_exhausted -> "executing->exhausted"
     | Compacting_to_prompting -> "compacting->prompting"
     | Compacting_to_compacting -> "compacting->compacting"
     | Compacting_to_finalizing -> "compacting->finalizing"
+    | Finalizing_to_prompting -> "finalizing->prompting"
+    | Finalizing_to_routing -> "finalizing->routing"
+    | Finalizing_to_executing -> "finalizing->executing"
     | Finalizing_to_finalizing -> "finalizing->finalizing"
+    | Exhausted_to_prompting -> "exhausted->prompting"
+    | Exhausted_to_routing -> "exhausted->routing"
+    | Exhausted_to_executing -> "exhausted->executing"
+    | Exhausted_to_exhausted -> "exhausted->exhausted"
 end
 
 type decision_stage =
@@ -898,17 +929,17 @@ let mark_sdk_turn_started ~base_path name =
     match e.current_turn_observation with
     | None -> e
     | Some obs ->
-      if obs.turn_phase = Turn_prompting
-         && obs.cascade_state = Cascade_idle
-         && obs.decision_stage = Decision_undecided
+      if obs.turn_phase = Packed Turn_prompting
+         && obs.cascade_state = Packed Cascade_idle
+         && obs.decision_stage = Packed Decision_undecided
       then e
       else (
         changed := true;
         let new_obs = {
           obs with
-          turn_phase = Turn_prompting;
-          cascade_state = Cascade_idle;
-          decision_stage = Decision_undecided;
+          turn_phase = Packed Turn_prompting;
+          cascade_state = Packed Cascade_idle;
+          decision_stage = Packed Decision_undecided;
         } in
         { e with current_turn_observation = Some new_obs }));
   if !changed then broadcast_composite_changed ~name ~ts_unix:now

--- a/lib/keeper/keeper_runtime_trust_snapshot.ml
+++ b/lib/keeper/keeper_runtime_trust_snapshot.ml
@@ -176,29 +176,43 @@ let terminal_reason_from_receipt receipt =
            "required_tool_use_unsatisfied")
   | None -> None
 
-let terminal_reason_code_of_runtime_blocker_class = function
+(* JSON-deserialization boundary: maps a runtime_blocker_class wire
+   string into a typed [Keeper_turn_disposition.t]. The previous
+   variant returned a [terminal_reason_code] wire string that the
+   caller then passed back through [Keeper_turn_terminal.of_code]
+   for a wire→typed roundtrip; emitting the typed value here removes
+   that detour and lets the consumer use [of_disposition] directly.
+   The provider-runtime classes preserve their originating blocker
+   string in the typed payload instead of collapsing to a single
+   "provider_error" literal. *)
+let disposition_of_runtime_blocker_class
+    : string -> Keeper_turn_disposition.t = function
   | "completion_contract_violation" | "tool_required_unsatisfied" ->
-      "required_tool_use_unsatisfied"
+      Keeper_turn_disposition.Required_tool_use_unsatisfied
   | "oas_timeout_budget" ->
-      "oas_timeout_budget"
+      Keeper_turn_disposition.Oas_timeout_budget
   | "turn_timeout" | "turn_timeout_after_queue_wait" | "stale_turn_timeout" ->
-      "turn_wall_clock_timeout"
+      Keeper_turn_disposition.Turn_wall_clock_timeout
   | "ambiguous_post_commit_timeout" | "ambiguous_post_commit_failure" ->
-      "post_commit_ambiguous"
-  | "cascade_exhausted" | "no_tool_capable_provider"
-  | "provider_runtime_error" ->
-      "provider_error"
+      Keeper_turn_disposition.Post_commit_ambiguous
+  | ("cascade_exhausted" | "no_tool_capable_provider"
+     | "provider_runtime_error") as cls ->
+      Keeper_turn_disposition.Provider_error
+        (Keeper_turn_terminal_code.Provider_runtime_error cls)
   | _ ->
-      "unknown_error"
+      Keeper_turn_disposition.Unknown { raw_error = "" }
 
 let terminal_reason_from_runtime_blocker_fields runtime_blocker_fields =
   match assoc_string_opt "runtime_blocker_class" runtime_blocker_fields with
   | None -> None
   | Some blocker_class ->
-      let code = terminal_reason_code_of_runtime_blocker_class blocker_class in
+      let disposition = disposition_of_runtime_blocker_class blocker_class in
       let summary = assoc_string_opt "runtime_blocker_summary" runtime_blocker_fields in
       Some
-        (Keeper_turn_terminal.of_code ~source:"runtime_blocker" ?summary code)
+        (Keeper_turn_terminal.of_disposition
+           ~source:"runtime_blocker"
+           ?summary
+           disposition)
 
 let receipt_ended_at_unix receipt =
   match json_string_opt_member "ended_at" receipt with

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -1940,8 +1940,8 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
             | None -> ()
           end;
           (match
-             Keeper_passive_loop_detector.progress_class_of_terminal_reason_code
-               (Keeper_turn_terminal.code terminal_reason)
+             Keeper_passive_loop_detector.progress_class_of_disposition
+               terminal_reason.disposition
            with
            | Some progress_class ->
                Keeper_passive_loop_detector.record_turn

--- a/test/test_keeper_passive_loop_detector.ml
+++ b/test/test_keeper_passive_loop_detector.ml
@@ -36,17 +36,18 @@ let test_claim_context_increments_streak () =
     (PLD.current_streak ~keeper_name:"k1")
 
 let test_terminal_reason_maps_required_tool_failures () =
+  let module D = Masc_mcp.Keeper_turn_disposition in
+  let module Code = Masc_mcp.Keeper_turn_terminal_code in
   check (option string) "no tool call maps to detector class"
     (Some "required_tool_no_call")
-    (PLD.progress_class_of_terminal_reason_code
-       "required_tool_use_no_tool_call");
+    (PLD.progress_class_of_disposition D.Required_tool_use_no_tool_call);
   check (option string) "unsatisfied maps to detector class"
     (Some "required_tool_unsatisfied")
-    (PLD.progress_class_of_terminal_reason_code
-       "required_tool_use_unsatisfied");
+    (PLD.progress_class_of_disposition D.Required_tool_use_unsatisfied);
   check (option string) "provider errors do not count"
     None
-    (PLD.progress_class_of_terminal_reason_code "provider_error")
+    (PLD.progress_class_of_disposition
+       (D.Provider_error (Code.Provider_runtime_error "provider_error")))
 
 let test_required_tool_no_call_fires_metric_at_three () =
   Eio_main.run @@ fun _env ->


### PR DESCRIPTION
## Summary

Three commits in one branch — first unblocks main, the next two close the last two wire-string classifiers in keeper:

| # | Commit | Theme |
|---|--------|-------|
| 1 | \`fix(keeper): complete #14279 GADT — add 13 missing transitions + Packed wrappers\` | Main blocker hotfix (origin/main \`dune build\` was failing on \`Turn_phase_transition\` mli/ml gap and \`mark_sdk_turn_started\` field-type mismatch) |
| 2 | \`refactor(keeper): type progress_class detector — disposition match instead of wire string\` | RFC-0047 follow-up: \`Keeper_passive_loop_detector\` |
| 3 | \`refactor(keeper): type runtime_blocker → disposition mapping\` | RFC-0047 follow-up: \`Keeper_runtime_trust_snapshot\` |

## Why bundled

(1) is a hard prerequisite — without it, \`dune build --root . lib/\` cannot run, which means (2) and (3) cannot be verified. Splitting (1) into a separate PR is also valid; reviewer can choose to land (1) standalone if they prefer the smallest-possible-hotfix shape, then rebase (2)+(3).

## (1) Main blocker hotfix

Two sub-fixes for #14279 (RFC-0045 GADT promotion) and #14252 (turn_phase 5→7 expansion):

| Sub | File:line | Issue |
|---|---|---|
| 1a | \`lib/keeper/keeper_registry.ml\` (\`Turn_phase_transition\` module) | \`.mli\` declared 26 GADT constructors; \`.ml\` had only 13. Added the 13 missing constructors + their \`to_tag\` arms. The runtime validator already enumerates all valid transitions as \`true\` arms — the GADT was meant to mirror that matrix at the type level for compile-time safety, but the \`.ml\` stopped at the pre-routing/exhausted set. |
| 1b | \`lib/keeper/keeper_registry.ml:901\` (\`mark_sdk_turn_started\`) | Compared and assigned \`obs.turn_phase\` / \`.cascade_state\` / \`.decision_stage\` using un-packed constructor names; those fields are typed \`packed_X\`. Wrapped with \`Packed Turn_prompting\` / \`Packed Cascade_idle\` / \`Packed Decision_undecided\`. |
| 1c | \`lib/keeper/keeper_composite_observer.ml\` (\`check_phase_turn_alignment\`) | Match was non-exhaustive — #14252 added \`Turn_routing\` + \`Turn_exhausted\` to \`turn_phase\` but this match still listed only 5 phases. Added the two arms to the not-Compacting branch. |

**No behaviour change** — GADT additions are purely compile-time metadata; runtime validation matrix unchanged. Packed wrappers make the assignments type-check; runtime values were already in the packed form everywhere else.

## (2) progress_class typing — \`Keeper_passive_loop_detector\`

\`progress_class_of_terminal_reason_code : string -> string option\` →
\`progress_class_of_disposition : Keeper_turn_disposition.t -> string option\`.

- Caller in \`keeper_unified_turn.ml:1943\` passes \`terminal_reason.disposition\` instead of \`Keeper_turn_terminal.code terminal_reason\`. No wire→typed roundtrip.
- Test reconstructs typed dispositions directly.
- Catch-all removed; every disposition variant enumerated.

## (3) runtime_blocker → disposition typing — \`Keeper_runtime_trust_snapshot\`

\`terminal_reason_code_of_runtime_blocker_class : string -> string\` →
\`disposition_of_runtime_blocker_class : string -> Keeper_turn_disposition.t\`.

Pre-fix: \`runtime_blocker_class -> wire -> of_code -> of_wire -> Unknown { raw_error = "provider_error" }\` (lossy collapse).

Post-fix: \`runtime_blocker_class -> Keeper_turn_disposition.t (typed)\` directly. Caller uses \`Keeper_turn_terminal.of_disposition\` (introduced in #14294) instead of \`of_code\`.

**Behaviour delta worth calling out**: the three provider-runtime classes (\`cascade_exhausted / no_tool_capable_provider / provider_runtime_error\`) now produce \`Provider_error (Provider_runtime_error <class>)\` typed, preserving the originating blocker class as the typed payload (was lossy-collapsed to a single \`"provider_error"\` literal). Severity moves from \`Unknown_bad\` to \`Bad\` — both render as \`"bad"\` via \`severity_to_string\` so dashboard chips and Prometheus labels are unchanged.

## Anti-pattern self-check (\`software-development.md\` workaround rejection bar)

For commits (2) and (3):
- ❌ **String/substring classifier** — both wire-string functions replaced with typed counterparts; consumer-side uses are exhaustive disposition matches.
- ❌ **N-of-M patch** — every call site verified single (\`rg -n\` confirmed); no other in-tree references.
- ❌ **Telemetry-as-fix** — no counter / instrumentation diff.

## Verification

| Check | Result |
|---|---|
| \`dune build --root . lib/\` | exit 0 (was failing pre-PR) |
| \`test_keeper_passive_loop_detector\` | 19/19 ✅ |
| \`test_keeper_turn_terminal_disposition_field\` | 3/3 ✅ |
| \`test_keeper_turn_disposition\` | 7/7 ✅ |
| \`test_keeper_terminal_reason\` | 32/32 ✅ |

## RFC-0047 follow-up sequence

| PR | Role |
|---|---|
| #14232 | docs |
| #14234 | PR-1 — \`Keeper_turn_disposition.t\` inert sum |
| #14237 | PR-2 — additive \`disposition\` field |
| #14271 | PR-3 — substring classifier removal + \`code: string\` field removal |
| #14290 | PR-4 — \`normalize_code\` retirement, producer typing for "completed" wire |
| #14294 | followup — \`registry_failure_reason\` typed, SDK fallback typed, \`of_disposition\` introduced |
| THIS | followup — main unblock + \`progress_class\` + \`runtime_blocker\` typed |

🤖 Generated with [Claude Code](https://claude.com/claude-code)