### PR TITLE
refactor(supervisor): typed dispatch for blocker string classification

### DIFF
--- a/lib/cascade/cascade_error_classify.ml
+++ b/lib/cascade/cascade_error_classify.ml
@@ -369,7 +369,7 @@ let admission_wait_timeout_error
     (sdk_error_of_masc_internal_error
        (Admission_queue_timeout { keeper_name; cascade_name; wait_sec }))
 
-let classify_masc_internal_error (err : Agent_sdk.Error.sdk_error) :
+let parse_masc_internal_error_json (json : Yojson.Safe.t) :
     masc_internal_error option =
   let int_opt_of_assoc key = function
     | `Assoc fields -> (
@@ -389,168 +389,187 @@ let classify_masc_internal_error (err : Agent_sdk.Error.sdk_error) :
         | _ -> None)
     | _ -> None
   in
+  match json with
+  | `Assoc fields -> (
+      match List.assoc_opt "kind" fields with
+      | Some (`String "cascade_exhausted") -> (
+          match string_opt_of_assoc "cascade_name" json with
+          | Some cascade_name ->
+            let reason =
+              match List.assoc_opt "reason" (match json with `Assoc fields -> fields | _ -> []) with
+              | Some json_val ->
+                  (match Keeper_types.cascade_exhaustion_reason_of_json json_val with
+                   | Some r -> r
+                   | None -> Other_detail "unknown_cascade_reason")
+              | None -> Other_detail "missing_reason_field"
+            in
+            Some
+              (Cascade_exhausted
+                 {
+                   cascade_name = cascade_name_of_string cascade_name;
+                   reason;
+                 })
+          | None -> None)
+      | Some (`String "resumable_cli_session") -> (
+          match string_opt_of_assoc "cascade_name" json, string_opt_of_assoc "detail" json with
+          | Some cascade_name, Some detail ->
+            Some
+              (Resumable_cli_session
+                 {
+                   cascade_name = cascade_name_of_string cascade_name;
+                   detail;
+                   exit_code = int_opt_of_assoc "exit_code" json;
+                 })
+          | _ -> None)
+      | Some (`String "no_tool_capable_provider") -> (
+          match string_opt_of_assoc "cascade_name" json with
+          | Some cascade_name ->
+            Some
+              (No_tool_capable_provider
+                 {
+                   cascade_name = cascade_name_of_string cascade_name;
+                   configured_labels =
+                     string_list_of_assoc "configured_labels" json;
+                   required_tool_names =
+                     string_list_of_assoc "required_tool_names" json;
+                   provider_rejections =
+                     provider_rejections_of_assoc "provider_rejections"
+                       json;
+                 })
+          | None -> None)
+      | Some (`String "accept_rejected") -> (
+          match string_opt_of_assoc "scope" json, string_opt_of_assoc "reason" json with
+          | Some scope, Some reason ->
+            Some
+              (Accept_rejected
+                 {
+                   scope;
+                   model = string_opt_of_assoc "model" json;
+                   reason;
+                 })
+          | _ -> None)
+      | Some (`String "admission_queue_timeout") -> (
+          match string_opt_of_assoc "keeper_name" json,
+                string_opt_of_assoc "cascade_name" json
+          with
+          | Some keeper_name, Some cascade_name ->
+            let wait_sec =
+              match json with
+              | `Assoc fields -> (
+                  match List.assoc_opt "wait_sec" fields with
+                  | Some (`Float v) -> v
+                  | _ -> 0.0)
+              | _ -> 0.0
+            in
+            Some
+              (Admission_queue_timeout
+                 {
+                   keeper_name;
+                   cascade_name = cascade_name_of_string cascade_name;
+                   wait_sec;
+                 })
+          | _ -> None)
+      | Some (`String "admission_queue_rejected") -> (
+          match string_opt_of_assoc "keeper_name" json,
+                string_opt_of_assoc "reason" json
+          with
+          | Some keeper_name, Some reason ->
+            Some (Admission_queue_rejected { keeper_name; reason })
+          | _ -> None)
+      | Some (`String "turn_timeout") -> (
+          match json with
+          | `Assoc fields -> (
+              match List.assoc_opt "elapsed_sec" fields with
+              | Some (`Float v) ->
+                Some (Turn_timeout { elapsed_sec = v })
+              | _ -> None)
+          | _ -> None)
+      | Some (`String "oas_timeout_budget") -> (
+          match json with
+          | `Assoc fields -> (
+              match
+                List.assoc_opt "budget_sec" fields,
+                List.assoc_opt "keeper_turn_timeout_sec" fields,
+                List.assoc_opt "estimated_input_tokens" fields,
+                List.assoc_opt "source" fields
+              with
+              | Some (`Float budget_sec),
+                Some (`Float keeper_turn_timeout_sec),
+                Some (`Int estimated_input_tokens),
+                Some (`String source) ->
+                  Some
+                    (Oas_timeout_budget
+                       {
+                         budget_sec;
+                         keeper_turn_timeout_sec;
+                         estimated_input_tokens;
+                         source;
+                         remaining_turn_budget_sec =
+                           float_opt_of_assoc
+                             "remaining_turn_budget_sec" json;
+                         min_required_sec =
+                           Option.value ~default:0.0
+                             (float_opt_of_assoc "min_required_sec" json);
+                         phase =
+                           Option.value ~default:"unknown"
+                             (string_opt_of_assoc "phase" json);
+                       })
+              | _ -> None)
+          | _ -> None)
+      | Some (`String "ambiguous_post_commit") -> (
+          match string_opt_of_assoc "original_error" json with
+          | Some original_error ->
+            let is_timeout =
+              match json with
+              | `Assoc fields -> (
+                  match List.assoc_opt "is_timeout" fields with
+                  | Some (`Bool b) -> b
+                  | _ -> false)
+              | _ -> false
+            in
+            let tools =
+              match json with
+              | `Assoc fields -> (
+                  match List.assoc_opt "tools" fields with
+                  | Some (`List values) ->
+                    values
+                    |> List.filter_map (function
+                         | `String value -> Some value
+                         | _ -> None)
+                  | _ -> [])
+              | _ -> []
+            in
+            Some (Ambiguous_post_commit { is_timeout; tools; original_error })
+          | _ -> None)
+      | _ -> None)
+  | _ -> None
+
+let classify_masc_internal_error_of_string (raw : string) :
+    masc_internal_error option =
+  let prefix = masc_internal_error_prefix in
+  let prefix_len = String.length prefix in
+  let raw_len = String.length raw in
+  let rec find_prefix start =
+    if start + prefix_len > raw_len then None
+    else if String.sub raw start prefix_len = prefix then Some start
+    else find_prefix (start + 1)
+  in
+  match find_prefix 0 with
+  | None -> None
+  | Some prefix_start ->
+    let payload_start = prefix_start + prefix_len in
+    let payload = String.sub raw payload_start (raw_len - payload_start) in
+    (try parse_masc_internal_error_json (Yojson.Safe.from_string payload)
+     with Yojson.Json_error _ -> None)
+
+let classify_masc_internal_error (err : Agent_sdk.Error.sdk_error) :
+    masc_internal_error option =
   match err with
   | Agent_sdk.Error.Internal msg when String.starts_with ~prefix:masc_internal_error_prefix msg ->
-    let payload =
-      String.sub msg
-        (String.length masc_internal_error_prefix)
-        (String.length msg - String.length masc_internal_error_prefix)
-    in
-    (try
-       match Yojson.Safe.from_string payload with
-       | `Assoc fields as json -> (
-           match List.assoc_opt "kind" fields with
-           | Some (`String "cascade_exhausted") -> (
-               match string_opt_of_assoc "cascade_name" json with
-               | Some cascade_name ->
-                 let reason =
-                   match List.assoc_opt "reason" (match json with `Assoc fields -> fields | _ -> []) with
-                   | Some json_val ->
-                       (match Keeper_types.cascade_exhaustion_reason_of_json json_val with
-                        | Some r -> r
-                        | None -> Other_detail "unknown_cascade_reason")
-                   | None -> Other_detail "missing_reason_field"
-                 in
-                 Some
-                   (Cascade_exhausted
-                      {
-                        cascade_name = cascade_name_of_string cascade_name;
-                        reason;
-                      })
-               | None -> None)
-           | Some (`String "resumable_cli_session") -> (
-               match string_opt_of_assoc "cascade_name" json, string_opt_of_assoc "detail" json with
-               | Some cascade_name, Some detail ->
-                 Some
-                   (Resumable_cli_session
-                      {
-                        cascade_name = cascade_name_of_string cascade_name;
-                        detail;
-                        exit_code = int_opt_of_assoc "exit_code" json;
-                      })
-               | _ -> None)
-           | Some (`String "no_tool_capable_provider") -> (
-               match string_opt_of_assoc "cascade_name" json with
-               | Some cascade_name ->
-                 Some
-                   (No_tool_capable_provider
-                      {
-                        cascade_name = cascade_name_of_string cascade_name;
-                        configured_labels =
-                          string_list_of_assoc "configured_labels" json;
-                        required_tool_names =
-                          string_list_of_assoc "required_tool_names" json;
-                        provider_rejections =
-                          provider_rejections_of_assoc "provider_rejections"
-                            json;
-                      })
-               | None -> None)
-           | Some (`String "accept_rejected") -> (
-               match string_opt_of_assoc "scope" json, string_opt_of_assoc "reason" json with
-               | Some scope, Some reason ->
-                 Some
-                   (Accept_rejected
-                      {
-                        scope;
-                        model = string_opt_of_assoc "model" json;
-                        reason;
-                      })
-               | _ -> None)
-           | Some (`String "admission_queue_timeout") -> (
-               match string_opt_of_assoc "keeper_name" json,
-                     string_opt_of_assoc "cascade_name" json
-               with
-               | Some keeper_name, Some cascade_name ->
-                 let wait_sec =
-                   match json with
-                   | `Assoc fields -> (
-                       match List.assoc_opt "wait_sec" fields with
-                       | Some (`Float v) -> v
-                       | _ -> 0.0)
-                   | _ -> 0.0
-                 in
-                 Some
-                   (Admission_queue_timeout
-                      {
-                        keeper_name;
-                        cascade_name = cascade_name_of_string cascade_name;
-                        wait_sec;
-                      })
-               | _ -> None)
-           | Some (`String "admission_queue_rejected") -> (
-               match string_opt_of_assoc "keeper_name" json,
-                     string_opt_of_assoc "reason" json
-               with
-               | Some keeper_name, Some reason ->
-                 Some (Admission_queue_rejected { keeper_name; reason })
-               | _ -> None)
-           | Some (`String "turn_timeout") -> (
-               match json with
-               | `Assoc fields -> (
-                   match List.assoc_opt "elapsed_sec" fields with
-                   | Some (`Float v) ->
-                     Some (Turn_timeout { elapsed_sec = v })
-                   | _ -> None)
-               | _ -> None)
-           | Some (`String "oas_timeout_budget") -> (
-               match json with
-               | `Assoc fields -> (
-                   match
-                     List.assoc_opt "budget_sec" fields,
-                     List.assoc_opt "keeper_turn_timeout_sec" fields,
-                     List.assoc_opt "estimated_input_tokens" fields,
-                     List.assoc_opt "source" fields
-                   with
-                   | Some (`Float budget_sec),
-                     Some (`Float keeper_turn_timeout_sec),
-                     Some (`Int estimated_input_tokens),
-                     Some (`String source) ->
-                       Some
-                         (Oas_timeout_budget
-                            {
-                              budget_sec;
-                              keeper_turn_timeout_sec;
-                              estimated_input_tokens;
-                              source;
-                              remaining_turn_budget_sec =
-                                float_opt_of_assoc
-                                  "remaining_turn_budget_sec" json;
-                              min_required_sec =
-                                Option.value ~default:0.0
-                                  (float_opt_of_assoc "min_required_sec" json);
-                              phase =
-                                Option.value ~default:"unknown"
-                                  (string_opt_of_assoc "phase" json);
-                            })
-                   | _ -> None)
-               | _ -> None)
-           | Some (`String "ambiguous_post_commit") -> (
-               match string_opt_of_assoc "original_error" json with
-               | Some original_error ->
-                 let is_timeout =
-                   match json with
-                   | `Assoc fields -> (
-                       match List.assoc_opt "is_timeout" fields with
-                       | Some (`Bool b) -> b
-                       | _ -> false)
-                   | _ -> false
-                 in
-                 let tools =
-                   match json with
-                   | `Assoc fields -> (
-                       match List.assoc_opt "tools" fields with
-                       | Some (`List values) ->
-                         values
-                         |> List.filter_map (function
-                              | `String value -> Some value
-                              | _ -> None)
-                       | _ -> [])
-                   | _ -> []
-                 in
-                 Some (Ambiguous_post_commit { is_timeout; tools; original_error })
-               | _ -> None)
-           | _ -> None)
-       | _ -> None
+    (try parse_masc_internal_error_json (Yojson.Safe.from_string
+         (String.sub msg
+            (String.length masc_internal_error_prefix)
+            (String.length msg - String.length masc_internal_error_prefix)))
      with Yojson.Json_error _ -> None)
   | _ -> None
 

--- a/lib/cascade/cascade_error_classify.mli
+++ b/lib/cascade/cascade_error_classify.mli
@@ -86,6 +86,13 @@ val classify_masc_internal_error :
     originally produced by [sdk_error_of_masc_internal_error].  Returns
     [None] for errors that do not carry the [masc_oas_error] prefix. *)
 
+val classify_masc_internal_error_of_string :
+  string -> masc_internal_error option
+(** Parse a [masc_internal_error] from a raw string that may contain
+    the [[masc_oas_error]] prefix anywhere (e.g. in a blocker text with
+    "Internal error: [masc_oas_error] ..." wrapper).  Returns [None]
+    when the prefix is absent or the JSON payload is malformed. *)
+
 val kind_of_masc_internal_error : masc_internal_error -> string
 (** Short label for each variant, used as the [kind] Prometheus label. *)
 

--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -121,26 +121,9 @@ let paused_meta_requires_reconcile_recovery (meta : keeper_meta) =
 
 let committed_tools_of_ambiguous_blocker (blocker : string) =
   let trimmed = String.trim blocker in
-  (* Try structured JSON extraction first (new masc_internal_error format) *)
-  if String.starts_with ~prefix:"[masc_oas_error]" trimmed then
-    let payload =
-      String.sub trimmed
-        (String.length "[masc_oas_error]")
-        (String.length trimmed - String.length "[masc_oas_error]")
-    in
-    (try
-       match Yojson.Safe.from_string payload with
-       | `Assoc fields ->
-           (match List.assoc_opt "tools" fields with
-            | Some (`List values) ->
-                values
-                |> List.filter_map (function
-                     | `String value -> Some value
-                     | _ -> None)
-            | _ -> [])
-       | _ -> []
-     with Yojson.Json_error _ -> [])
-  else
+  match Cascade_error_classify.classify_masc_internal_error_of_string trimmed with
+  | Some (Cascade_error_classify.Ambiguous_post_commit { tools; _ }) -> tools
+  | _ ->
     (* Legacy: extract from bracket notation "prefix: [tool1, tool2]; ..." *)
     match String.index_opt trimmed '[' with
     | None -> []


### PR DESCRIPTION
## Summary
- Extract JSON parsing from `classify_masc_internal_error` into reusable `parse_masc_internal_error_json`
- Add `classify_masc_internal_error_of_string` that locates `[masc_oas_error]` prefix anywhere in a raw string (fixes a bug where `String.starts_with` never matched due to `"Internal error: "` wrapper)
- Rewrite `committed_tools_of_ambiguous_blocker` in `keeper_supervisor.ml` to use typed variant matching instead of manual string/Yojson parsing

## Bug fix
The old `String.starts_with ~prefix:"[masc_oas_error]"` check on `last_blocker` could **never match** in production because `Agent_sdk.Error.to_string` wraps the prefix with `"Internal error: "`, producing `"Internal error: [masc_oas_error] {...}"`. The new `find_prefix` loop locates the tag at any position.

## Test plan
- [x] `dune build` passes
- [x] `test_dashboard_goals` 25/25 passes
- [x] `test_keeper_unified` 352/353 passes (1 pre-existing failure on main, unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)