### PR TITLE
feat(keeper): cascade_name_of_meta helper + read-site migration step 1 (RFC-0041 B7)

### DIFF
--- a/lib/dashboard/dashboard_goals.ml
+++ b/lib/dashboard/dashboard_goals.ml
@@ -1604,7 +1604,7 @@ let goal_detail_keeper_json (detail : goal_detail_keeper) =
       ( "sandbox_profile",
         `String (Keeper_types.sandbox_profile_to_string meta.sandbox_profile) );
       ("network_mode", `String (Keeper_types.network_mode_to_string meta.network_mode));
-      ("cascade_name", `String meta.cascade_name);
+      ("cascade_name", `String (Keeper_types.cascade_name_of_meta meta));
       ( "approval_profile",
         match latest_receipt with
         | Some receipt ->
@@ -1830,7 +1830,7 @@ let build_goal_timeline node linked_keepers approvals goal_events =
                               (Printf.sprintf "%s · %s"
                                  outcome
                                  (receipt_cascade_name receipt
-                                  |> Option.value ~default:detail.meta.cascade_name))
+                                  |> Option.value ~default:(Keeper_types.cascade_name_of_meta detail.meta)))
                             ~severity)))
   in
   let goal_events = List.map goal_event_timeline_json goal_events in

--- a/lib/dashboard/dashboard_http_keeper.ml
+++ b/lib/dashboard/dashboard_http_keeper.ml
@@ -296,7 +296,7 @@ let keeper_trust_json ?(include_receipt = false)
     | None ->
       `Assoc
         [
-          ("name", `String meta.cascade_name);
+          ("name", `String (Keeper_types.cascade_name_of_meta meta));
           ("cascade_ref", cascade_ref_json);
           ("selected_model", `Null);
           ("attempt_count", `Int 0);
@@ -591,7 +591,7 @@ let keepers_dashboard_json ?(compact = false) (config : Coord.config) : Yojson.S
           let trace_history_count = List.length m.runtime.trace_history in
           let active_model = Keeper_exec_status.active_model_of_meta m in
           let next_model_hint = Keeper_exec_status.next_model_hint_of_meta m in
-          let effective_cascade_name = live_keeper_cascade_name m.cascade_name in
+          let effective_cascade_name = live_keeper_cascade_name (Keeper_types.cascade_name_of_meta m) in
           let cascade_models =
             Cascade_runtime.models_of_cascade_name
               (Keeper_cascade_profile.Runtime_name effective_cascade_name)
@@ -900,7 +900,7 @@ let keepers_dashboard_json ?(compact = false) (config : Coord.config) : Yojson.S
                   ("message_count", `Int (Safe_ops.json_int "message_count" metrics));
                 ]
             | None ->
-                (let effective_cascade_name = live_keeper_cascade_name m.cascade_name in
+                (let effective_cascade_name = live_keeper_cascade_name (Keeper_types.cascade_name_of_meta m) in
                  let effective_models =
                    Cascade_runtime.models_of_cascade_name
                      (Keeper_cascade_profile.Runtime_name effective_cascade_name)
@@ -1653,10 +1653,11 @@ let keeper_config_json (config : Coord.config) (name : string)
           ("effective_system_prompt", `String effective_system_prompt);
         ]
       in
-      let effective_cascade_name = live_keeper_cascade_name m.cascade_name in
+      let cascade_name = Keeper_types.cascade_name_of_meta m in
+      let effective_cascade_name = live_keeper_cascade_name cascade_name in
       let execution =
         `Assoc [
-          ("selected_cascade_name", `String m.cascade_name);
+          ("selected_cascade_name", `String cascade_name);
           ( "selected_cascade_canonical",
             `String effective_cascade_name );
           ( "cascade_ref",

--- a/lib/dashboard_cascade.ml
+++ b/lib/dashboard_cascade.ml
@@ -171,7 +171,7 @@ let keeper_profile_json (entry : Keeper_registry.registry_entry) : Yojson.Safe.t
   `Assoc
     (keeper_profile_fields
        ~keeper:entry.name
-       ~cascade_name:entry.meta.cascade_name)
+       ~cascade_name:(Keeper_types.cascade_name_of_meta entry.meta))
 
 let invalid_name_set = function
   | None -> StringSet.empty
@@ -276,7 +276,7 @@ let config_json () =
         let names, _ =
           List.fold_left
             (fun (acc, seen) (e : Keeper_registry.registry_entry) ->
-               add_profile_name (acc, seen) e.meta.cascade_name)
+               add_profile_name (acc, seen) (Keeper_types.cascade_name_of_meta e.meta))
             (acc_after_catalog, seen_after_catalog)
             keeper_entries
         in

--- a/lib/keeper/keeper_meta_contract.ml
+++ b/lib/keeper/keeper_meta_contract.ml
@@ -322,6 +322,13 @@ type keeper_meta =
   ; meta_version : int
   }
 
+let cascade_name_of_meta (m : keeper_meta) : string =
+  match m.cascade_ref with
+  | Some ref_ when not (String.equal ref_.Cascade_ref.group "") ->
+    ref_.Cascade_ref.group
+  | _ -> m.cascade_name
+;;
+
 let proactive_cycle_outcome_to_string = function
   | Proactive_never_started -> "never_started"
   | Proactive_unknown -> "unknown"

--- a/lib/keeper/keeper_meta_contract.mli
+++ b/lib/keeper/keeper_meta_contract.mli
@@ -290,6 +290,21 @@ type keeper_meta = {
   meta_version : int;
 }
 
+(** {1 Cascade name derivation} *)
+
+val cascade_name_of_meta : keeper_meta -> string
+(** [cascade_name_of_meta m] is the canonical cascade name for the keeper.
+
+    Resolution order (RFC-0041 transition phase):
+    1. If [m.cascade_ref] is [Some] and [.group] is non-empty, return [.group].
+    2. Otherwise return [m.cascade_name].
+
+    During the migration phase both fields coexist and may diverge if a
+    caller writes only one. New code MUST set [cascade_ref] when changing
+    routing — read sites should use this helper instead of touching
+    [m.cascade_name] directly. The plain [m.cascade_name] field will be
+    removed once all read sites migrate. *)
+
 (** {1 Outcome <-> string} *)
 
 val proactive_cycle_outcome_to_string :

--- a/lib/keeper/keeper_types.mli
+++ b/lib/keeper/keeper_types.mli
@@ -275,6 +275,18 @@ type keeper_meta = {
 
 val now_iso : unit -> string
 
+val cascade_name_of_meta : keeper_meta -> string
+(** [cascade_name_of_meta m] is the canonical cascade name for the keeper.
+
+    Resolution order (RFC-0041 transition phase):
+    1. If [m.cascade_ref] is [Some] and [.group] is non-empty, return [.group].
+    2. Otherwise return [m.cascade_name].
+
+    During the migration phase both fields coexist and may diverge if a
+    caller writes only one. New code MUST set [cascade_ref] when changing
+    routing — read sites should use this helper instead of touching
+    [m.cascade_name] directly. *)
+
 val tool_preset_to_string : tool_preset -> string
 val tool_preset_of_string : string -> tool_preset option
 

--- a/lib/mcp_server_eio_call_tool.ml
+++ b/lib/mcp_server_eio_call_tool.ml
@@ -188,7 +188,7 @@ let runtime_mcp_keeper_log_context_of_entry
   let model =
     let last_model_used = String.trim entry.meta.runtime.usage.last_model_used in
     if last_model_used <> "" then last_model_used
-    else String.trim entry.meta.cascade_name
+    else String.trim (Keeper_types.cascade_name_of_meta entry.meta)
   in
   let session_id =
     match json_nonempty_string_opt "session_id" arguments with
@@ -251,7 +251,7 @@ let runtime_mcp_keeper_log_context_of_entry
     visible_tool_count = Some (List.length allowed_tool_names);
     required_tools = Some required_tools;
     missing_required_tools = Some missing_required_tools;
-    cascade_profile = Some entry.meta.cascade_name;
+    cascade_profile = Some (Keeper_types.cascade_name_of_meta entry.meta);
   }
 
 let runtime_mcp_keeper_error_preview message =

--- a/lib/operator/operator_control_snapshot.ml
+++ b/lib/operator/operator_control_snapshot.ml
@@ -112,8 +112,9 @@ let non_empty_trimmed_string_opt value =
   if trimmed = "" then None else Some trimmed
 
 let keeper_runtime_identity_fields (meta : Keeper_types.keeper_meta) =
+  let cascade_name = Keeper_types.cascade_name_of_meta meta in
   let effective_cascade =
-    Keeper_cascade_profile.resolve_live meta.cascade_name
+    Keeper_cascade_profile.resolve_live cascade_name
   in
   let primary_model =
     match
@@ -136,7 +137,7 @@ let keeper_runtime_identity_fields (meta : Keeper_types.keeper_meta) =
     else active_model_label
   in
   [
-    ("cascade_name", string_option_to_json (non_empty_trimmed_string_opt meta.cascade_name));
+    ("cascade_name", string_option_to_json (non_empty_trimmed_string_opt cascade_name));
     ("cascade_canonical", `String effective_cascade);
     ("selected_cascade_canonical", `String effective_cascade);
     ("primary_model", string_option_to_json primary_model);

--- a/lib/server/server_dashboard_http_keeper_api.ml
+++ b/lib/server/server_dashboard_http_keeper_api.ml
@@ -1421,7 +1421,7 @@ let handle_keeper_get_subroutes state req request reqd =
         | Ok (Some m) ->
           let routing =
             Keeper_cascade_routing.select_cascade
-              ~base_cascade:m.cascade_name ~phase:current
+              ~base_cascade:(Keeper_types.cascade_name_of_meta m) ~phase:current
           in
           let models =
             Cascade_runtime.models_of_cascade_name
@@ -1468,7 +1468,7 @@ let handle_keeper_get_subroutes state req request reqd =
         match meta with
         | Ok (Some m) ->
           Cascade_runtime.models_of_cascade_name
-            (Keeper_cascade_profile.Runtime_name m.cascade_name)
+            (Keeper_cascade_profile.Runtime_name (Keeper_types.cascade_name_of_meta m))
         | _ -> ["(unknown)"]
       in
       let last_provider =

--- a/lib/tool_keeper.ml
+++ b/lib/tool_keeper.ml
@@ -321,7 +321,7 @@ let keeper_list_row_json ~runtime_class config name =
             ("proactive_idle_sec", `Int meta.proactive.idle_sec);
             ("proactive_cooldown_sec", `Int meta.proactive.cooldown_sec);
             ("skill_route", keeper_list_skill_route_json config meta);
-            ("cascade_name", `String meta.cascade_name);
+            ("cascade_name", `String (Keeper_types.cascade_name_of_meta meta));
             ("created_at", `String meta.created_at);
             ("updated_at", `String meta.updated_at);
           ]
@@ -524,7 +524,7 @@ let default_keeper_model_label (meta : keeper_meta) =
   | "" -> (
       match
         Cascade_runtime.models_of_cascade_name
-          (Keeper_cascade_profile.Runtime_name meta.cascade_name)
+          (Keeper_cascade_profile.Runtime_name (Keeper_types.cascade_name_of_meta meta))
       with
       | first :: _ when not (String.equal (String.trim first) "") -> first
       | _ -> Env_config.Local_runtime.default_model)


### PR DESCRIPTION
## Summary

RFC-0041 Phase B7 step 1: introduce `Keeper_types.cascade_name_of_meta` as the canonical reader for keeper cascade names, and migrate read sites in 8 files outside `lib/keeper/`.

The helper resolves `cascade_ref.group` first and falls back to the legacy `cascade_name` field, so the migration phase can let both fields coexist without divergence in read paths.

## Changes

### Helper (3 files)
- `lib/keeper/keeper_meta_contract.mli` / `.ml` — `cascade_name_of_meta : keeper_meta -> string`
- `lib/keeper/keeper_types.mli` — public re-export

### Read-site migration outside `lib/keeper/` (8 files, ~17 sites)
- `lib/operator/operator_control_snapshot.ml` (2)
- `lib/server/server_dashboard_http_keeper_api.ml` (2)
- `lib/dashboard/dashboard_http_keeper.ml` (5)
- `lib/dashboard/dashboard_goals.ml` (2)
- `lib/dashboard_cascade.ml` (2)
- `lib/mcp_server_eio_call_tool.ml` (2)
- `lib/tool_keeper.ml` (2)

The legacy `cascade_name : string` record field stays intact — removal will follow once `lib/keeper/` (24 files, ~80 sites) read sites are also migrated and write sites converge on `cascade_ref` as SSOT.

## Out of scope

- `lib/keeper/` 24 files (separate PR after main blocker resolves)
- Write-site convergence on `cascade_ref` (separate PR)
- `keeper_meta` record field removal (final PR after all readers migrate)

## Build status

⚠️ **main is currently blocked** by post-#14311 fallout (`Oas_worker` / `Keeper_turn_driver.response` unbound in ~10 caller sites). This change adds **no new build errors** — verified by error-list diff before/after.

PR #14315 (typed dispatch for blocker string classification) may resolve part of this; if not, a hotfix PR for the RFC-0047 caller breakage is still pending.

## Refs

- RFC-0041 (cascade routing group/item hierarchy)
- Follows PR #14266 (B1-B4 wiring)
- Follows PR #14302 (B6 dashboard exposure, merged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>