### PR TITLE
feat(exec): RFC-0005 A4a batch 1+2 — Exec_gate cutover (11 sites)

### DIFF
--- a/lib/coord/playground_repo_cache.ml
+++ b/lib/coord/playground_repo_cache.ml
@@ -15,7 +15,7 @@ let env_float name default =
 let git_meta_timeout_sec = env_float "MASC_KEEPER_GIT_META_TIMEOUT_SEC" 5.0
 
 let git_meta repo_path args =
-  Process_eio.run_argv_with_status ~timeout_sec:git_meta_timeout_sec
+  Masc_exec.Exec_gate.run_argv_with_status ~actor:"Coord_git" ~raw_source:("git -C " ^ repo_path ^ " " ^ String.concat " " args) ~summary:"git metadata query" ~timeout_sec:git_meta_timeout_sec
     ("git" :: "-C" :: repo_path :: args)
 
 let cache_update_mu = Stdlib.Mutex.create ()

--- a/lib/operator/operator_control.ml
+++ b/lib/operator/operator_control.ml
@@ -126,7 +126,7 @@ let run_gh_auth_status ~gh_config_dir =
   try
     let env = gh_process_env_for_config_dir gh_config_dir in
     Ok
-      (Process_eio.run_argv_with_status ~env
+      (Masc_exec.Exec_gate.run_argv_with_status ~actor:"Coord_git" ~raw_source:"gh auth status --hostname github.com" ~summary:"gh auth status check" ~env
          [ "gh"; "auth"; "status"; "--hostname"; "github.com" ])
   with
   | Unix.Unix_error (Unix.ENOENT, _, _) ->

--- a/lib/server/server_routes_http_routes_sidecar.ml
+++ b/lib/server/server_routes_http_routes_sidecar.ml
@@ -777,7 +777,7 @@ let handle_stop state request reqd =
                   (`Assoc [ ("ok", `Bool false); ("error", `String msg) ])
             | Ok desired ->
                 let (_status, stdout) =
-                  Process_eio.run_argv_with_status
+                  Masc_exec.Exec_gate.run_argv_with_status ~actor:"System_spawn" ~raw_source:(script ^ " stop") ~summary:"sidecar stop script"
                     ~timeout_sec:Env_config_runtime.Sidecar.control_command_timeout_sec
                     [ script; "stop" ]
                 in
@@ -833,7 +833,7 @@ let handle_logs state request reqd =
            ])
       else
         let (_status, stdout) =
-          Process_eio.run_argv_with_status
+          Masc_exec.Exec_gate.run_argv_with_status ~actor:"System_runtime_info" ~raw_source:("tail -n " ^ string_of_int lines ^ " " ^ path) ~summary:"tail sidecar logs"
             ~timeout_sec:Env_config_runtime.Sidecar.control_command_timeout_sec
             [ "tail"; "-n"; string_of_int lines; path ]
         in
@@ -881,7 +881,7 @@ let fetch_schema ?base_path id =
        | Ok sidecar_dir ->
            let argv = python_argv_for sidecar_dir in
            let (status, stdout) =
-             Process_eio.run_argv_with_status
+             Masc_exec.Exec_gate.run_argv_with_status ~actor:"System_spawn" ~raw_source:(String.concat " " argv) ~summary:"python schema dump"
                ~timeout_sec:Env_config_runtime.Sidecar.schema_generation_timeout_sec
                ~cwd:sidecar_dir argv
            in

--- a/lib/tool_code.ml
+++ b/lib/tool_code.ml
@@ -362,7 +362,7 @@ let handle_code_search ctx args =
     in
     let cmd = "rg" :: rg_args in
 
-    match Process_eio.run_argv_with_status ~timeout_sec:(Env_config_exec_timeout.timeout_sec ~caller:Shell ()) cmd with
+    match Masc_exec.Exec_gate.run_argv_with_status ~actor:"Tool_local_runtime" ~raw_source:(String.concat " " cmd) ~summary:"rg search in workspace" ~timeout_sec:(Env_config_exec_timeout.timeout_sec ~caller:Shell ()) cmd with
     | Unix.WEXITED 0, output ->
         (* Parse rg JSON output *)
         let lines = String.split_on_char '\n' output in

--- a/lib/tool_code_write.ml
+++ b/lib/tool_code_write.ml
@@ -67,7 +67,7 @@ let validate_code_shell_command (command : string) : (unit, string) Result.t =
 let git_common_root path =
   try
     match
-      Process_eio.run_argv_with_status
+      Masc_exec.Exec_gate.run_argv_with_status ~actor:"Coord_git" ~raw_source:("git -C " ^ path ^ " rev-parse --git-common-dir") ~summary:"git common root lookup"
         ~timeout_sec:(Env_config_exec_timeout.timeout_sec ~caller:(Unknown "misc") ())
         [ "git"; "-C"; path; "rev-parse"; "--git-common-dir" ]
     with
@@ -652,7 +652,7 @@ let handle_code_shell ctx args =
                    [ "sh"; "-c"; Printf.sprintf "cd %s && %s"
                        (Filename.quote dir) command ]
              in
-             match Process_eio.run_argv_with_status ~timeout_sec:safe_timeout full_cmd with
+             match Masc_exec.Exec_gate.run_argv_with_status ~actor:"Tool_local_runtime" ~raw_source:(String.concat " " full_cmd) ~summary:"shell command execution" ~timeout_sec:safe_timeout full_cmd with
              | Unix.WEXITED code, output ->
                  let response = `Assoc [
                    ("status", `String (if code = 0 then "ok" else "error"));
@@ -736,7 +736,7 @@ let handle_code_git ctx args =
                        depth_flag
                        (Filename.quote clone_url)]
           in
-          match Process_eio.run_argv_with_status ~timeout_sec:timeout cmd with
+          match Masc_exec.Exec_gate.run_argv_with_status ~actor:"Coord_git" ~raw_source:(String.concat " " cmd) ~summary:"git clone" ~timeout_sec:timeout cmd with
           | Unix.WEXITED code, output ->
             let response =
               `Assoc
@@ -790,7 +790,7 @@ let handle_code_git ctx args =
             Some (Keeper_identity.git_env_for_keeper ~keeper_name:ctx.agent_name)
           else None
         in
-        match Process_eio.run_argv_with_status ~timeout_sec:(Env_config_exec_timeout.timeout_sec ~caller:Shell ()) ?env:env_opt cmd with
+        match Masc_exec.Exec_gate.run_argv_with_status ~actor:"Coord_git" ~raw_source:(String.concat " " cmd) ~summary:"git action execution" ~timeout_sec:(Env_config_exec_timeout.timeout_sec ~caller:Shell ()) ?env:env_opt cmd with
         | Unix.WEXITED code, output ->
           let response =
             `Assoc

--- a/lib/tool_inline_dispatch_types.ml
+++ b/lib/tool_inline_dispatch_types.ml
@@ -52,6 +52,6 @@ type context = {
 
 (** Helper: run subprocess — uses [Dispatch] caller (default 120s) *)
 let safe_exec args =
-  match Process_eio.run_argv_with_status ~timeout_sec:(Env_config_exec_timeout.timeout_sec ~caller:Dispatch ()) args with
+  match Masc_exec.Exec_gate.run_argv_with_status ~actor:"Tool_local_runtime" ~raw_source:(String.concat " " args) ~summary:"inline dispatch safe exec" ~timeout_sec:(Env_config_exec_timeout.timeout_sec ~caller:Dispatch ()) args with
   | Unix.WEXITED 0, output -> (true, output)
   | _, output -> (false, if String.equal output "" then "Command failed" else output)


### PR DESCRIPTION
## Summary
- [RFC-0005 §A4a](docs/rfc/RFC-0005-TYPED-CAPABILITY-SUBSTRATE.md) typed `Exec_gate` cutover, batch 1+2.
- Converts 11 legacy `Process_eio.run_argv*` call sites across 6 files to `Masc_exec.Exec_gate.run_argv_with_status` wrappers.
- No functional change; purely structural migration to typed capability substrate.

## Files changed
| File | Sites | Actor |
|------|-------|-------|
| `lib/tool_code.ml` | 1 | `Tool_local_runtime` |
| `lib/tool_inline_dispatch_types.ml` | 1 | `Tool_local_runtime` |
| `lib/coord/playground_repo_cache.ml` | 1 | `Coord_git` |
| `lib/server/server_routes_http_routes_sidecar.ml` | 3 | `System_spawn`, `System_runtime_info` |
| `lib/operator/operator_control.ml` | 1 | `Coord_git` |
| `lib/tool_code_write.ml` | 4 | `Coord_git`, `Tool_local_runtime` |

## Verification
- `dune build --root . @check` passes (A4a files only; pre-existing test failures on `main` at `c211e38540` are unrelated).
- All actors map to existing `Agent_id.t` variants wired in `lib/exec_gate.ml`.

## Remaining work
- Batch 3: keeper internal sites (~36).
- Batch 4: coord remaining sites.
- A4b/A4c: typed approval policy + capability IR rollout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)