### PR TITLE
feat(sse): wire 3 dead Prometheus counters to existing log sites

### DIFF
--- a/lib/server/server_mcp_transport_http.ml
+++ b/lib/server/server_mcp_transport_http.ml
@@ -584,6 +584,8 @@ let handle_get_mcp ~deps ?legacy_messages_endpoint ?(profile = Full)
             ~reason ~retry_after_s reqd
       | Ok () ->
           stop_sse_session session_id;
+          if Option.is_some last_event_id then
+            Transport_metrics.inc_sse_reconnect ();
           let headers =
             Httpun.Headers.of_list
               (legacy_headers

--- a/lib/server/server_mcp_transport_http_agui.ml
+++ b/lib/server/server_mcp_transport_http_agui.ml
@@ -61,6 +61,8 @@ let handle_ag_ui_events ~deps request reqd =
         ~reason ~retry_after_s reqd
   | Ok () ->
       stop_sse_session_preserve_guard session_id;
+      if Option.is_some last_event_id then
+        Transport_metrics.inc_sse_reconnect ();
       let headers =
         Httpun.Headers.of_list
           (sse_stream_headers ~deps session_id protocol_version origin)

--- a/lib/server/server_mcp_transport_http_respond.ml
+++ b/lib/server/server_mcp_transport_http_respond.ml
@@ -112,6 +112,7 @@ let respond_not_ready ~(deps : Server_mcp_transport_http_types.deps) request req
 
 let respond_sse_rate_limited ~(deps : Server_mcp_transport_http_types.deps) ~origin ~session_id ~protocol_version
     ~reason ~retry_after_s reqd =
+  Transport_metrics.inc_sse_reject ~reason;
   let retry_after_s = Float.max retry_after_s 0.001 in
   let retry_after_header =
     retry_after_s |> Float.ceil |> int_of_float |> max 1 |> string_of_int

--- a/lib/sse.ml
+++ b/lib/sse.ml
@@ -893,6 +893,7 @@ let cleanup_stale ?(max_age_s=1800.0) () =
   (* Remove under lock, one by one *)
   List.iter (fun (sid, last_seen) ->
     Log.Server.info "idle evict: %s (idle %.0fs)" sid (now -. last_seen);
+    Transport_metrics.inc_sse_idle_evicted ();
     unregister sid
   ) stale;
   List.map fst stale

--- a/lib/transport_metrics.ml
+++ b/lib/transport_metrics.ml
@@ -81,6 +81,16 @@ let set_sse_external_subscribers count =
 let inc_sse_client_evicted () =
   Prometheus.inc_counter Prometheus.metric_sse_client_evictions ()
 
+let inc_sse_idle_evicted () =
+  Prometheus.inc_counter Prometheus.metric_sse_idle_evictions ()
+
+let inc_sse_reject ~reason =
+  Prometheus.inc_counter Prometheus.metric_sse_rejects
+    ~labels:[("reason", reason)] ()
+
+let inc_sse_reconnect () =
+  Prometheus.inc_counter Prometheus.metric_sse_reconnects ()
+
 (** {1 gRPC Metrics} *)
 
 let set_grpc_active_streams count =

--- a/lib/transport_metrics.mli
+++ b/lib/transport_metrics.mli
@@ -93,6 +93,28 @@ val inc_sse_client_evicted : unit -> unit
     with the [Evicting oldest client] log line so operators can see
     eviction storms in metrics. *)
 
+val inc_sse_idle_evicted : unit -> unit
+(** Increments [masc_sse_idle_evictions_total] for each session
+    {!Sse.cleanup_stale} reaps for being idle past [max_age_s].
+    Paired with the [idle evict] log line so the idle-reaper rate
+    is observable without log scraping. *)
+
+val inc_sse_reject : reason:string -> unit
+(** [inc_sse_reject ~reason] increments [masc_sse_rejects_total]
+    labelled with [reason] when the SSE connect storm guard
+    rejects a request (HTTP 429). [reason] mirrors the JSON body
+    field — currently ["session_cooldown"] or ["window_limit"].
+    Paired with the existing rate-limit response so operators
+    can rate-alert on storm conditions instead of grepping access
+    logs. *)
+
+val inc_sse_reconnect : unit -> unit
+(** Increments [masc_sse_reconnects_total] whenever an SSE client
+    arrives with a [Last-Event-Id] header, i.e. is asking the
+    server to replay events from a prior connection.  Distinct
+    from a fresh connect — useful for rate-alerting on disconnect
+    flapping (network instability, client buggy retry loops). *)
+
 (** {1 gRPC metrics} *)
 
 val set_grpc_active_streams : int -> unit

--- a/test/test_transport_metrics.ml
+++ b/test/test_transport_metrics.ml
@@ -101,6 +101,38 @@ let test_broadcast_events_counter () =
     "masc_sse_broadcast_events_total" () in
   check bool "broadcast events incremented" true (after > before)
 
+let test_sse_idle_evicted () =
+  let before = Prometheus.metric_value_or_zero
+    "masc_sse_idle_evictions_total" () in
+  TM.inc_sse_idle_evicted ();
+  TM.inc_sse_idle_evicted ();
+  let after = Prometheus.metric_value_or_zero
+    "masc_sse_idle_evictions_total" () in
+  check (float 0.01) "idle evicted delta" 2.0 (after -. before)
+
+let test_sse_reject_labelled () =
+  let before_cooldown = Prometheus.metric_value_or_zero
+    "masc_sse_rejects_total" ~labels:[("reason", "session_cooldown")] () in
+  let before_window = Prometheus.metric_value_or_zero
+    "masc_sse_rejects_total" ~labels:[("reason", "window_limit")] () in
+  TM.inc_sse_reject ~reason:"session_cooldown";
+  TM.inc_sse_reject ~reason:"window_limit";
+  TM.inc_sse_reject ~reason:"session_cooldown";
+  let after_cooldown = Prometheus.metric_value_or_zero
+    "masc_sse_rejects_total" ~labels:[("reason", "session_cooldown")] () in
+  let after_window = Prometheus.metric_value_or_zero
+    "masc_sse_rejects_total" ~labels:[("reason", "window_limit")] () in
+  check (float 0.01) "session_cooldown delta" 2.0 (after_cooldown -. before_cooldown);
+  check (float 0.01) "window_limit delta" 1.0 (after_window -. before_window)
+
+let test_sse_reconnect () =
+  let before = Prometheus.metric_value_or_zero
+    "masc_sse_reconnects_total" () in
+  TM.inc_sse_reconnect ();
+  let after = Prometheus.metric_value_or_zero
+    "masc_sse_reconnects_total" () in
+  check (float 0.01) "reconnect delta" 1.0 (after -. before)
+
 (* ============================================================
    gRPC Metrics
    ============================================================ *)
@@ -448,6 +480,9 @@ let () =
       test_case "set_sse_sessions by kind" `Quick test_sse_sessions;
       test_case "observe_broadcast_duration accumulates" `Quick test_broadcast_duration;
       test_case "broadcast events counter increments" `Quick test_broadcast_events_counter;
+      test_case "inc_sse_idle_evicted increments" `Quick test_sse_idle_evicted;
+      test_case "inc_sse_reject by reason label" `Quick test_sse_reject_labelled;
+      test_case "inc_sse_reconnect increments" `Quick test_sse_reconnect;
     ]);
     ("grpc", [
       test_case "set_grpc_active_streams" `Quick test_grpc_active_streams;


### PR DESCRIPTION
## 목표

`lib/prometheus.ml` 에 선언만 되고 *어디에서도 카운터 증가 없이* 등록만 된 SSE 메트릭 3개를 실제 신호 위치에 와이어링.

## 발견

전체 메트릭 audit (declared 97개 vs `set_gauge`/`inc_counter`/`observe_histogram`/`observe_summary` 호출 사이트 전수 대조):

- `metric_sse_idle_evictions` — `Sse.cleanup_stale` 의 `Log.Server.info "idle evict"` 라인만 있고 metric 0
- `metric_sse_rejects` — `respond_sse_rate_limited` (HTTP 429, storm guard) 가 응답만 하고 metric 0
- `metric_sse_reconnects` — `Sse.register` 가 `Last-Event-Id` 헤더 받고도 reconnect 신호 0

3개 모두 dashboard / Prometheus consumer 측에서 0 으로 보였음. SSE storm 도, 유휴 reaper 비율도, reconnect flapping 도 metric 으로 alert 불가.

## 변경

| 파일 | 변경 |
|------|------|
| `lib/transport_metrics.ml/.mli` | `inc_sse_idle_evicted ()`, `inc_sse_reject ~reason`, `inc_sse_reconnect ()` 헬퍼 3개 추가 |
| `lib/sse.ml` | `cleanup_stale` 의 `idle evict` 로그 옆에 `inc_sse_idle_evicted` |
| `lib/server/server_mcp_transport_http_respond.ml` | `respond_sse_rate_limited` 진입 시 `inc_sse_reject ~reason` (3 caller 모두 이 helper 통과) |
| `lib/server/server_mcp_transport_http.ml`, `_agui.ml` | `Sse.register` 직전 `Option.is_some last_event_id` 일 때만 `inc_sse_reconnect` |
| `test/test_transport_metrics.ml` | 3 new before/after delta tests (labeled counter assertion 포함) |

73 insertions, 7 files.

## Audit 보존 (의도적 미접촉)

- `metric_inference_queue_cancelled`, `metric_inference_queue_depth` — RFC-0026 dormant scaffolding (admission_queue.ml §3.2 audit response, "Do not delete")
- `metric_sse_capacity_evictions`, `metric_sse_connections_active`, `metric_sse_write_failures` — alive 메트릭 (`client_evictions`, `sessions{kind}`, `broadcast_failures`) 으로 superseded → 별도 cleanup PR
- `metric_cascade_*` × 4, `metric_oas_bus_*` × 3 — `cascade_metrics.ml` / `agent_sdk_metrics_bridge.ml` 에 sister 정의 존재 (Scattered Hardcoded Defaults 패턴) → 같은 cleanup PR

## RFC-0043 (#14184) 정렬

- 본 PR 은 *wiring*, RFC-0043 PR-3 는 *ownership 이동*. 직교
- 마이그레이션 중 alias 유지 정책으로 conflict 0
- RFC-0043 PR-3 머지 시 본 3 헬퍼는 `Sse_metrics` 로 mechanical move

## 검증

- 로컬 `dune build` 는 origin/main 자체가 RFC-0047 oas_worker dissolve cascade (#14320 fix pending) 로 빨간 상태. 본 PR diff 가 추가하는 에러 0건 (모든 컴파일 에러가 keeper / Oas_worker 관련 — 본 PR 미접촉 영역). git stash 로 cross-check 완료
- CI clean 환경에서 `test_transport_metrics` 3 신규 케이스 통과 확인 필요

## Best Programmer self-review

- 워크어라운드 시그니처 (counter-as-fix / string classifier / N-of-M / catch-all 추가) 모두 미해당
- 카운터-as-fix 자가 점검: 카운터가 *visible 만들고 fix 안 함*? — 아님. 이벤트 (idle 추방 / 429 reject / reconnect) 는 *정상 운영 이벤트*, 버그 아님. 카운터는 정량화만. silent failure fix 가 아니라 *signal exposure*
- N-of-M 자가 점검: 28 dead 메트릭 중 3 개만 fix → 나머지는 의도적 분리 (dormant scaffold / 별도 cleanup / RFC-0043). PR body 에 명시

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>