### PR TITLE
feat(exec): RFC-0005 A4a batch 3a — keeper shell core Exec_gate cutover

### DIFF
--- a/lib/exec/exec_gate.ml
+++ b/lib/exec/exec_gate.ml
@@ -59,6 +59,7 @@ let rollout_config : Approval_config.t =
         (`Tool_local_runtime, internal_observer_overlay);
         (`Tool_local_runtime_bench, internal_observer_overlay);
         (`Tool_autoresearch_cycle, internal_git_admin_overlay);
+        (`Keeper_shell, internal_observer_overlay);
       ];
   }
 

--- a/lib/keeper/keeper_shell_bash.ml
+++ b/lib/keeper/keeper_shell_bash.ml
@@ -758,7 +758,9 @@ let handle_keeper_bash
                        | None ->
                          let t0 = Unix.gettimeofday () in
                          let st, out =
-                           Process_eio.run_argv_with_status
+                           Masc_exec.Exec_gate.run_argv_with_status ~actor:"Keeper_shell"
+                             ~raw_source:(String.concat " " argv_merged)
+                             ~summary:"keeper bash command"
                              ~cwd ~timeout_sec argv_merged
                          in
                          let elapsed_ms =
@@ -806,7 +808,9 @@ let handle_keeper_bash
                     | None ->
                    let t0 = Unix.gettimeofday () in
                    let st, out =
-                     Process_eio.run_argv_with_status
+                     Masc_exec.Exec_gate.run_argv_with_status ~actor:"Keeper_shell"
+                       ~raw_source:(String.concat " " argv_merged)
+                       ~summary:"keeper bash command"
                        ~cwd ~timeout_sec argv_merged
                    in
                    let elapsed_ms =

--- a/lib/keeper/keeper_shell_docker.ml
+++ b/lib/keeper/keeper_shell_docker.ml
@@ -790,7 +790,10 @@ let run_docker_shell_command_with_status
       (try
          let status, output =
            Fun.protect ~finally:restore_gitdirs @@ fun () ->
-           Process_eio.run_argv_with_status ~env:(Unix.environment ())
+           Masc_exec.Exec_gate.run_argv_with_status ~actor:"Keeper_shell"
+             ~raw_source:(String.concat " " argv)
+             ~summary:"keeper docker command"
+             ~env:(Unix.environment ())
              ~cwd:(Sys.getcwd ()) ~timeout_sec argv
          in
          if status <> Unix.WEXITED 0 then

--- a/lib/keeper/keeper_shell_ops.ml
+++ b/lib/keeper/keeper_shell_ops.ml
@@ -564,7 +564,10 @@ let handle_keeper_shell
                      ]))
           | None ->
             let st, out =
-              Process_eio.run_argv_with_status ~timeout_sec:Keeper_shell_shared.read_timeout_sec argv
+              Masc_exec.Exec_gate.run_argv_with_status ~actor:"Keeper_shell"
+                ~raw_source:(String.concat " " argv)
+                ~summary:"keeper shell op"
+                ~timeout_sec:Keeper_shell_shared.read_timeout_sec argv
             in
             Yojson.Safe.to_string
               (`Assoc
@@ -942,11 +945,16 @@ let handle_keeper_shell
            match Keeper_gh_env.keeper_process_env config ~keeper_name:meta.name with
            | Error err -> (Unix.WEXITED 127, err)
            | Ok env ->
-               Process_eio.run_argv_with_status ?env ~cwd ~timeout_sec argv
+               Masc_exec.Exec_gate.run_argv_with_status ~actor:"Coord_git"
+                 ~raw_source:(String.concat " " argv)
+                 ~summary:"keeper brokered git command"
+                 ?env ~cwd ~timeout_sec argv
          in
          let normalize_existing_origin_to_https clone_path =
            match
-             Process_eio.run_argv_with_status
+             Masc_exec.Exec_gate.run_argv_with_status ~actor:"Coord_git"
+               ~raw_source:("git -C " ^ clone_path ^ " remote get-url origin")
+               ~summary:"keeper git remote get-url"
                ~timeout_sec:(Env_config_exec_timeout.timeout_sec ~caller:Git_meta ())
                [ "git"; "-C"; clone_path; "remote"; "get-url"; "origin" ]
            with
@@ -956,7 +964,9 @@ let handle_keeper_shell
              if String.equal origin normalized then None
              else
                (match
-                  Process_eio.run_argv_with_status
+                  Masc_exec.Exec_gate.run_argv_with_status ~actor:"Coord_git"
+                    ~raw_source:("git -C " ^ clone_path ^ " remote set-url origin " ^ normalized)
+                    ~summary:"keeper git remote set-url"
                     ~timeout_sec:(Env_config_exec_timeout.timeout_sec ~caller:Git_meta ())
                     [ "git"; "-C"; clone_path; "remote"; "set-url"; "origin"; normalized ]
                 with
@@ -1008,7 +1018,10 @@ let handle_keeper_shell
                     | Ok result -> (result.status, result.output)
                     | Error msg -> (Unix.WEXITED 127, msg)
                   else
-                    Process_eio.run_argv_with_status ~timeout_sec:(Env_config_exec_timeout.timeout_sec ~caller:Shell ())
+                    Masc_exec.Exec_gate.run_argv_with_status ~actor:"Coord_git"
+                      ~raw_source:("git -C " ^ clone_path ^ " pull --ff-only")
+                      ~summary:"keeper git pull"
+                      ~timeout_sec:(Env_config_exec_timeout.timeout_sec ~caller:Shell ())
                       [ "git"; "-C"; clone_path; "pull"; "--ff-only" ]
                 in
                 if st = Unix.WEXITED 0 then
@@ -1059,7 +1072,9 @@ let handle_keeper_shell
                | Ok result -> (result.status, result.output)
                | Error msg -> (Unix.WEXITED 127, msg)
              else
-               Process_eio.run_argv_with_status
+               Masc_exec.Exec_gate.run_argv_with_status ~actor:"Coord_git"
+                 ~raw_source:("git clone " ^ String.concat " " depth_args ^ " " ^ clone_url ^ " " ^ clone_path)
+                 ~summary:"keeper git clone"
                  ~timeout_sec:(Keeper_tool_policy.clone_timeout_sec ())
                  ("git" :: "clone" :: depth_args @ [ clone_url; clone_path ])
            in
@@ -1210,7 +1225,10 @@ let handle_keeper_shell
                    let gh_argv =
                      "gh" :: Keeper_gh_shared.gh_simple_command_argv parsed_command
                    in
-                   Ok (Process_eio.run_argv_with_status ?env ~cwd ~timeout_sec gh_argv))
+                   Ok (Masc_exec.Exec_gate.run_argv_with_status ~actor:"Keeper_shell"
+                         ~raw_source:(String.concat " " gh_argv)
+                         ~summary:"keeper gh command"
+                         ?env ~cwd ~timeout_sec gh_argv))
           in
           match gh_process with
           | Error msg ->

--- a/lib/keeper/keeper_shell_shared.ml
+++ b/lib/keeper/keeper_shell_shared.ml
@@ -345,7 +345,11 @@ let rewrite_docker_host_paths_to_container
 let run_argv_with_status_retry_eintr ?cwd ~timeout_sec argv =
   let max_eintr_retries = 8 in
   let rec loop attempts_left =
-    let result = Process_eio.run_argv_with_status ?cwd ~timeout_sec argv in
+    let result =
+      Masc_exec.Exec_gate.run_argv_with_status ~actor:"Keeper_shell"
+        ~raw_source:(String.concat " " argv)
+        ~summary:"keeper shell command" ?cwd ~timeout_sec argv
+    in
     match result with
     | Unix.WEXITED 127, out
       when attempts_left > 0


### PR DESCRIPTION
## Summary
- [RFC-0005 §A4a](docs/rfc/RFC-0005-TYPED-CAPABILITY-SUBSTRATE.md) keeper shell core cutover.
- Converts keeper shell subsystem (5 files, ~12 direct sites + retry wrapper) to `Masc_exec.Exec_gate`.
- `keeper_shell_shared.ml` internal wrapper changed; upper callers automatically routed through gate without signature changes.

## Files changed
| File | Change |
|------|--------|
| `lib/exec/exec_gate.ml` | Add `Keeper_shell` actor to `rollout_config` |
| `lib/keeper/keeper_shell_shared.ml` | Convert retry wrapper internal call to `Exec_gate` |
| `lib/keeper/keeper_shell_ops.ml` | Convert 7 direct `Process_eio` sites |
| `lib/keeper/keeper_shell_bash.ml` | Convert 2 direct sites |
| `lib/keeper/keeper_shell_docker.ml` | Convert 1 direct site |

## Actor assignment
- `Keeper_shell` (new): shell/bash/docker ops, gh commands
- `Coord_git` (existing): git clone/pull/remote inside keeper context

## Verification
- `dune build --root . @check` library compiles clean.
- Pre-existing test failures on `main` at `6f75e277` are unrelated.

## Remaining batches
- 3b: keeper sandbox/runtime (keeper_sandbox_runtime, keeper_sandbox_control, keeper_turn_sandbox_runtime)
- 3c: keeper tools/GitHub (keeper_gh_shared, keeper_tool_github_pr, keeper_tool_pr_review, etc.)
- 4: config + credential_materializer

🤖 Generated with [Claude Code](https://claude.com/claude-code)