### PR TITLE
fix(coord): Cancel-safe mention-dedup hook catches (3 sites)

### DIFF
--- a/lib/coord/coord_broadcast.ml
+++ b/lib/coord/coord_broadcast.ml
@@ -136,9 +136,9 @@ let broadcast ?trace_context ?(msg_type = "broadcast")
             Mention_dedup.should_skip ~from_agent ~target ~content_hash
               ~now:(Time_compat.now ())
         | _ ->
-            (try (Atomic.get Coord_hooks.mention_dedup_decision_fn)
-                   ~outcome:(if bypass_dedup then "bypassed" else "no_target")
-             with _ -> ());
+            Safe_ops.protect ~default:() (fun () ->
+              (Atomic.get Coord_hooks.mention_dedup_decision_fn)
+                ~outcome:(if bypass_dedup then "bypassed" else "no_target"));
             false)
   in
   if dedup_skipped then begin
@@ -152,9 +152,9 @@ let broadcast ?trace_context ?(msg_type = "broadcast")
   end else
   let () =
     if bypass_dedup then
-      try (Atomic.get Coord_hooks.mention_dedup_decision_fn)
-            ~outcome:"bypassed"
-      with _ -> ()
+      Safe_ops.protect ~default:() (fun () ->
+        (Atomic.get Coord_hooks.mention_dedup_decision_fn)
+          ~outcome:"bypassed")
   in
   let seq = Coord_state.next_seq config in
   let mention = pre_extract_mention in

--- a/lib/coord/mention_dedup.ml
+++ b/lib/coord/mention_dedup.ml
@@ -14,8 +14,11 @@ let table : (string * string * string, float) Hashtbl.t = Hashtbl.create 256
 let mu : Mutex.t = Mutex.create ()
 
 let inc_outcome outcome =
-  try (Atomic.get Coord_hooks.mention_dedup_decision_fn) ~outcome
-  with _ -> ()
+  (* [Safe_ops.protect] re-raises [Eio.Cancel.Cancelled] so a cancel
+     racing with the surrounding fiber still propagates instead of
+     being silently swallowed by the previous [with _ -> ()] catch. *)
+  Safe_ops.protect ~default:() (fun () ->
+    (Atomic.get Coord_hooks.mention_dedup_decision_fn) ~outcome)
 
 let content_topic_hash content =
   let normalized = String.lowercase_ascii (String.trim content) in


### PR DESCRIPTION
## 발견

`mention_dedup_decision_fn` 호출 3 site 가 raw `try ... with _ -> ()` 패턴으로 감싸짐. 이 catch 가 `Eio.Cancel.Cancelled` 까지 swallow 해서 surrounding fiber 의 cooperative-cancel 이 끊김.

같은 모듈 패밀리 (`lib/coord/coord_hooks.ml:314`) 의 fix-observation hook 은 이미 `Safe_ops.protect ~default:()` 패턴으로 처리되어 있음 — 같은 shape, 같은 module, 같은 안전 요건.

## 변경

| 파일 | 위치 | 변경 |
|------|------|------|
| `lib/coord/mention_dedup.ml` | 17 (`inc_outcome`) | `with _ -> ()` → `Safe_ops.protect ~default:()` |
| `lib/coord/coord_broadcast.ml` | 139 (`broadcast` no-target/bypass branch) | 동일 |
| `lib/coord/coord_broadcast.ml` | 155 (`broadcast` post-skip bypass branch) | 동일 |

11 net inserted lines, 2 files.

## 행동 변화

- 이전: `with _ ->` 가 모든 예외 swallow → `Eio.Cancel.Cancelled` 도 흡수 → cancel 전파 끊김
- 이후: `Safe_ops.protect` 가 `Cancelled` 만 re-raise (원래 backtrace 유지), 나머지 예외는 `()` 로 흡수

Metric-hook 의 \"never throw\" 계약은 동일하게 유지. cancel safety 만 회복.

## 왜 `Telemetry_observe.observe_silent` 가 아닌가

이상적으로는 `Telemetry_observe.observe_silent` (Cancel-safe + `masc_telemetry_observe_failures_total{kind}` 증가) 를 쓰는 것이 맞음. 하지만:

- `Telemetry_observe` 는 top-level `masc_mcp` 라이브러리 소속
- 본 call site 들은 하위 `masc_coord` sublibrary
- 의존 방향이 반대 — 가져오려면 cross-library 이동 필요
- 그건 RFC-0043 (#14184, prometheus 메트릭 ownership 분산) scope. 본 PR 은 단순 Cancel-safety fix 로 contained
- `Safe_ops.protect` 는 이미 `masc_coord` dependency closure (`masc_core`) 에 있음

## 검증

- 로컬 `dune build _build/default/lib/coord/masc_coord.cma` 통과 (no errors)
- 본 변경 외 영역 에러 (FSM constructor / Keeper_turn_driver) 는 *origin/main 의 in-flight refactor* 잔여, 본 PR 미관련

## Best Programmer self-review

- 워크어라운드 시그니처 모두 미해당:
  - 카운터-as-fix? **No** — 카운터 추가 0
  - String 분류기? **No**
  - N-of-M? **No** — 같은 hook 의 3/3 site 모두 처리
  - catch-all 추가? **No** — 오히려 *unsafe catch-all 제거*
- 같은 파일 패밀리에 이미 채택된 `Safe_ops.protect` 패턴 일관 적용

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>