### PR TITLE
fix(agent_id): add missing `Keeper_shell constructor

### DIFF
--- a/lib/exec/agent_id.ml
+++ b/lib/exec/agent_id.ml
@@ -20,6 +20,7 @@ type t =
   | `Tool_local_runtime
   | `Tool_local_runtime_bench
   | `Tool_autoresearch_cycle
+  | `Keeper_shell
   | `Other_agent
   ]
 
@@ -45,6 +46,7 @@ let of_string = function
   | "tool/local_runtime" -> `Tool_local_runtime
   | "tool/local_runtime_bench" -> `Tool_local_runtime_bench
   | "tool/autoresearch_cycle" -> `Tool_autoresearch_cycle
+  | "keeper/shell" -> `Keeper_shell
   | _ -> `Other_agent
 
 let to_string = function
@@ -69,4 +71,5 @@ let to_string = function
   | `Tool_local_runtime -> "tool/local_runtime"
   | `Tool_local_runtime_bench -> "tool/local_runtime_bench"
   | `Tool_autoresearch_cycle -> "tool/autoresearch_cycle"
+  | `Keeper_shell -> "keeper/shell"
   | `Other_agent -> "other"

--- a/lib/exec/agent_id.mli
+++ b/lib/exec/agent_id.mli
@@ -27,6 +27,7 @@ type t =
   | `Tool_local_runtime
   | `Tool_local_runtime_bench
   | `Tool_autoresearch_cycle
+  | `Keeper_shell
   | `Other_agent
   ]
 


### PR DESCRIPTION
## Summary

`Agent_id.t` closed polymorphic variant에 `` `Keeper_shell `` constructor가 누락되어 `exec_gate.ml`의 `rollout_config` 및 관련 테스트에서 컴파일 에러가 발생했습니다.

## Changes

- `lib/exec/agent_id.mli`: `` `Keeper_shell `` 추가
- `lib/exec/agent_id.ml`: type definition, `of_string`, `to_string`에 `` `Keeper_shell `` / `"keeper/shell"` 매핑 추가

## Verification

- `dune build --root . @check` PASS
- `dune runtest test/test_keeper_sub_fsm_guards.exe` PASS (10/10)

## Related

- PR #14227 (typed agent_id)에서 `` `Keeper_shell `` 누락
- `exec_gate.ml:62`에서 이미 `` `Keeper_shell `` 키를 참조하고 있었음

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>