### PR TITLE
fix+test: unblock #14326 + fix 3 pre-existing flakes

### DIFF
--- a/lib/exec/agent_id.ml
+++ b/lib/exec/agent_id.ml
@@ -20,6 +20,7 @@ type t =
   | `Tool_local_runtime
   | `Tool_local_runtime_bench
   | `Tool_autoresearch_cycle
+  | `Keeper_shell
   | `Other_agent
   ]
 
@@ -45,6 +46,7 @@ let of_string = function
   | "tool/local_runtime" -> `Tool_local_runtime
   | "tool/local_runtime_bench" -> `Tool_local_runtime_bench
   | "tool/autoresearch_cycle" -> `Tool_autoresearch_cycle
+  | "keeper/shell" -> `Keeper_shell
   | _ -> `Other_agent
 
 let to_string = function
@@ -69,4 +71,5 @@ let to_string = function
   | `Tool_local_runtime -> "tool/local_runtime"
   | `Tool_local_runtime_bench -> "tool/local_runtime_bench"
   | `Tool_autoresearch_cycle -> "tool/autoresearch_cycle"
+  | `Keeper_shell -> "keeper/shell"
   | `Other_agent -> "other"

--- a/lib/exec/agent_id.mli
+++ b/lib/exec/agent_id.mli
@@ -27,6 +27,7 @@ type t =
   | `Tool_local_runtime
   | `Tool_local_runtime_bench
   | `Tool_autoresearch_cycle
+  | `Keeper_shell
   | `Other_agent
   ]
 

--- a/lib/http_server_eio.ml
+++ b/lib/http_server_eio.ml
@@ -139,8 +139,8 @@ let safe_respond_with_string reqd response body =
       | Some msg ->
           Log.Http.warn
             "[http-eio] respond_with_string skipped (reqd already in \
-             error-handling state; classifier match — 2026-05-05 OAS \
-             cancellation race): %s" msg
+             error-handling state; classifier match — \
+             2026-05-05 OAS cancellation race): %s" msg
       | None ->
           Log.Http.warn
             "[http-eio] respond_with_string unexpected exception: %s"

--- a/lib/server/server_ws_standalone.ml
+++ b/lib/server/server_ws_standalone.ml
@@ -316,8 +316,8 @@ let make_websocket_handler ~sw ~clock ~on_message _client_addr
                  with
                  | Some _ ->
                      Log.Server.debug
-                       "[ws-standalone] send_pong skipped (writer closed during \
-                        cancel race)"
+                       "[ws-standalone] send_pong skipped \
+                        (writer closed during cancel race)"
                  | None ->
                      Log.Server.warn
                        "[ws-standalone] send_pong failed: %s"

--- a/test/test_auth_token_uniqueness_audit.ml
+++ b/test/test_auth_token_uniqueness_audit.ml
@@ -42,7 +42,7 @@ let write_cred ~base ~agent_name ~token_hash =
   let path = Filename.concat agents_dir (agent_name ^ ".json") in
   let json =
     Printf.sprintf
-      "{\"agent_name\":%S,\"token\":%S,\"role\":\"agent\",\"created_at\":\"2026-04-25T00:00:00Z\"}"
+      "{\"agent_name\":%S,\"token\":%S,\"role\":\"worker\",\"created_at\":\"2026-04-25T00:00:00Z\"}"
       agent_name token_hash
   in
   let oc = open_out path in

--- a/test/test_keeper_pause_silent_failure_source.ml
+++ b/test/test_keeper_pause_silent_failure_source.ml
@@ -61,15 +61,23 @@ let count_occurrences ~needle haystack =
     loop 0 0
 
 let test_metric_registered () =
-  let prom = load_source "lib/prometheus.ml" in
+  (* The metric literal moved out of [lib/prometheus.ml] and into
+     [lib/keeper/keeper_metrics.ml] in #14179 (RFC-0043 distribute
+     metric ownership). [lib/prometheus.ml] now only references
+     [Keeper_metrics.metric_keeper_paused_state_persist_errors] by
+     symbol, so the structural guard checks both files: the literal
+     must live somewhere, and the registration site (by symbol) must
+     still be in [lib/prometheus.ml]. *)
+  let metrics = load_source "lib/keeper/keeper_metrics.ml" in
   check bool "paused-state persist-errors metric declared" true
     (count_occurrences
        ~needle:"masc_keeper_paused_state_persist_errors_total"
-       prom
+       metrics
      >= 1);
+  let prom = load_source "lib/prometheus.ml" in
   check bool "paused-state persist-errors metric registered with HELP"
     true
-    (count_occurrences ~needle:metric_name prom >= 2)
+    (count_occurrences ~needle:metric_name prom >= 1)
 
 let test_happy_path_preserved () =
   let src = load_source target_file in
@@ -149,7 +157,7 @@ let test_counter_inc_calls () =
   check bool "Prometheus.inc_counter called for new metric >= 6 times"
     true
     (count_occurrences
-       ~needle:"Masc_mcp.Keeper_metrics.metric_keeper_paused_state_persist_errors"
+       ~needle:"Keeper_metrics.metric_keeper_paused_state_persist_errors"
        src
      >= 6)
 

--- a/test/test_reqd_invalid_state_swallow.ml
+++ b/test/test_reqd_invalid_state_swallow.ml
@@ -131,11 +131,14 @@ let () =
     main_src
     "Re-raise cancellation so Eio structured concurrency propagates cleanly";
 
-  (* Anchor M3: defence-in-depth guard on the error fallback. *)
+  (* Anchor M3: defence-in-depth guard on the error fallback. The
+     [safe_reqd_respond] doc comment must keep the "guards" anchor so a
+     future refactor that drops the wrapper is forced to update this
+     test rather than silently re-introducing the cycle9 race. *)
   assert_contains
     ~label:"M3: defence-in-depth guard on error fallback"
     main_src
-    "guards against any future refactoring that bypasses safe_respond";
+    "safe_reqd_respond reqd response body] guards all direct";
 
   (* ---- lib/server/server_mcp_transport_http_respond.ml ------------------ *)
   let mcp_respond_src =
@@ -222,10 +225,13 @@ let () =
     ws_src
     "try Ws.Wsd.send_pong wsd";
 
-  (* Anchor W2: closed wsd race comment is present. *)
+  (* Anchor W2: writer-closed-during-cancel race comment is present
+     (the wsd-race incident reference travels with the [send_pong]
+     wrapper, so a future refactor that drops the comment is forced
+     to update this anchor). *)
   assert_contains
-    ~label:"W2: closed wsd race comment"
+    ~label:"W2: writer closed during cancel race comment"
     ws_src
-    "closed wsd race";
+    "writer closed during cancel race";
 
   print_endline "test_reqd_invalid_state_swallow: OK"


### PR DESCRIPTION
## Summary

Two commits:

| # | Commit | Theme |
|---|--------|-------|
| 1 | \`fix(exec): add Keeper_shell to Agent_id.t — #14326 straggler\` | Main blocker hotfix from RFC-0005 A4a batch 3a |
| 2 | \`test(stale): fix 3 pre-existing flakes — metric move / role fixture / source-grep anchors\` | Three failing tests on main, each caused by an upstream refactor that left a structural-grep behind |

## (1) Main blocker hotfix

PR #14326 registered \`\`\`Keeper_shell\`\`\` in \`Exec_gate\` but did not extend the closed poly-variant \`Agent_id.t\`. Build broken at \`lib/exec/exec_gate.ml:62\` with type clash.

Added the variant + \`of_string\`/\`to_string\` mapping (\`"keeper/shell"\` ↔ \`\`\`Keeper_shell\`\`\`).

## (2) Three pre-existing flakes fixed

### \`test_keeper_pause_silent_failure_source\` (was 2 fails)
- "metric declared" check: literal \`"masc_keeper_paused_state_persist_errors_total"\` moved from \`lib/prometheus.ml\` to \`lib/keeper/keeper_metrics.ml\` in #14179 (RFC-0043 distribute metric ownership). Updated test to grep \`keeper_metrics.ml\` for the literal.
- "counter inc calls present" check: removed the \`Masc_mcp.\` prefix from the needle (production code in same lib doesn't use it).

### \`test_auth_token_uniqueness_audit\` (was 2 fails)
Fixture wrote \`role:"agent"\`; the typed parser \`Types_auth.agent_role_of_string\` only accepts \`"worker"\` / \`"admin"\`. Audit silently dropped both entries → "0 duplicate groups". Changed fixture to \`role:"worker"\`.

### \`test_reqd_invalid_state_swallow\` (was Fatal failure)
Three structural anchors searched for literal substrings that OCaml string \`\\<newline><indent>\` continuations had split across lines:
- \`http_server_eio.ml\`: moved the line break before "2026-05-05" so "2026-05-05 OAS cancellation race" stays contiguous in raw source
- \`server_ws_standalone.ml\`: moved the line break before "(writer" so "writer closed during cancel race" stays contiguous
- \`bin/main_eio.ml\` M3 anchor: doc comment was rephrased; test now searches for the current "guards all direct" phrasing

## Verification

| Check | Result |
|---|---|
| \`dune build --root .\` (full) | exit 0 (was failing with #14326 type clash) |
| \`test_keeper_pause_silent_failure_source\` | 7/7 ✅ (was 2 fails) |
| \`test_auth_token_uniqueness_audit\` | 4/4 ✅ (was 2 fails) |
| \`test_reqd_invalid_state_swallow\` | passes (was Fatal) |
| RFC-0047 / disposition tests (sample) | 42/42 ✅ no regression |

🤖 Generated with [Claude Code](https://claude.com/claude-code)