### PR TITLE
fix(exec): register `Keeper_shell in Agent_id.t — unblock main from PR #14326

### DIFF
--- a/lib/exec/agent_id.ml
+++ b/lib/exec/agent_id.ml
@@ -20,6 +20,7 @@ type t =
   | `Tool_local_runtime
   | `Tool_local_runtime_bench
   | `Tool_autoresearch_cycle
+  | `Keeper_shell
   | `Other_agent
   ]
 
@@ -45,6 +46,7 @@ let of_string = function
   | "tool/local_runtime" -> `Tool_local_runtime
   | "tool/local_runtime_bench" -> `Tool_local_runtime_bench
   | "tool/autoresearch_cycle" -> `Tool_autoresearch_cycle
+  | "keeper/shell" -> `Keeper_shell
   | _ -> `Other_agent
 
 let to_string = function
@@ -69,4 +71,5 @@ let to_string = function
   | `Tool_local_runtime -> "tool/local_runtime"
   | `Tool_local_runtime_bench -> "tool/local_runtime_bench"
   | `Tool_autoresearch_cycle -> "tool/autoresearch_cycle"
+  | `Keeper_shell -> "keeper/shell"
   | `Other_agent -> "other"

--- a/lib/exec/agent_id.mli
+++ b/lib/exec/agent_id.mli
@@ -27,6 +27,7 @@ type t =
   | `Tool_local_runtime
   | `Tool_local_runtime_bench
   | `Tool_autoresearch_cycle
+  | `Keeper_shell
   | `Other_agent
   ]
 


### PR DESCRIPTION
## Summary

PR #14326 (RFC-0005 A4a batch 3a — keeper shell core Exec_gate cutover) added `(\`Keeper_shell, internal_observer_overlay)` to `lib/exec/exec_gate.ml`'s `rollout_config` but did **not** register `\`Keeper_shell` in `Agent_id.t` / `of_string` / `to_string`. Result on `main` after that merge:

```
File "lib/exec/exec_gate.ml", line 62, characters 9-22:
62 |         (\`Keeper_shell, internal_observer_overlay);
              ^^^^^^^^^^^^^
Error: The constructor \`Keeper_shell has type [> \`Keeper_shell ]
       but an expression was expected of type Agent_id.t
```

This PR adds the variant + the canonical `"keeper/shell"` string mapping. No other behaviour change.

## Verification

- `MASC_SKIP_PIN_CHECK=1 bash scripts/dune-local.sh build` — `lib/` builds clean (was failing on `main` before this fix).
- 1-line addition × 3 sites (`type t`, `of_string`, `to_string`), in lock-step with the existing variant table.

## Out of scope

`test/test_keeper_{registry,sub_fsm_guards,fsm_joints}.ml` also fail to build on current `main` against the new `packed_cascade_state` / `turn_phase_witness` GADT shape from PR #14279. That is a **separate** follow-up unrelated to this fix and will be tracked in its own PR.

## Why a separate, narrow PR

Per `feedback_main_blocker_chain_4x_session` — surgical unblock with explicit attribution to the source PR is preferred over piggy-backing on unrelated work, so the `Agent_id` regression and the `keeper_registry` GADT regression do not get conflated in the next review pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>