### PR TITLE
feat(prometheus): register HELP text for 8 actively-used metrics

### DIFF
--- a/lib/cascade/cascade_attempt_fsm.ml
+++ b/lib/cascade/cascade_attempt_fsm.ml
@@ -489,6 +489,18 @@ let sdk_error_to_provider_error ~provider err =
 
 let provider_error_total_metric = "masc_provider_error_total"
 
+let () =
+  Prometheus.register_counter
+    ~name:provider_error_total_metric
+    ~help:
+      "Total provider-level errors classified during cascade \
+       attempts (rate limit, auth failure, capacity exhaustion, \
+       server error, invalid request). Labels: kind \
+       (Provider_error.to_error_kind), provider (provider debug \
+       label), cascade_name (originating cascade), capacity_scope \
+       (CapacityExhausted scope or \"none\")."
+    ()
+
 let provider_error_capacity_scope_label = function
   | Provider_error.CapacityExhausted { scope; _ } ->
       Provider_error.scope_to_string scope

--- a/lib/cascade/cascade_error_classify.ml
+++ b/lib/cascade/cascade_error_classify.ml
@@ -295,6 +295,30 @@ let masc_oas_error_total_metric = "masc_oas_error_total"
 
 let cross_cascade_fallback_metric = "masc_cross_cascade_fallback_total"
 
+let () =
+  Prometheus.register_counter
+    ~name:masc_oas_error_total_metric
+    ~help:
+      "Total MASC-internal errors emitted as Agent_sdk.Error.Internal \
+       payloads, classified by structured error kind. Labels: \
+       kind (cascade_exhausted | resumable_cli_session | \
+       no_tool_capable_provider | accept_rejected | \
+       admission_queue_timeout | admission_queue_rejected | \
+       turn_timeout | oas_timeout_budget | ambiguous_post_commit), \
+       cascade_name (originating cascade or \"unknown\" for \
+       cascade-less variants)."
+    ();
+  Prometheus.register_counter
+    ~name:cross_cascade_fallback_metric
+    ~help:
+      "Total times a keeper turn could not find a tool-capable \
+       provider in its own cascade and was driven by an upper layer \
+       to a different cascade. Labels: from_cascade (cascade the \
+       keeper was configured for), to_cascade (cascade that \
+       supplied the working provider), provider (debug label of \
+       the resolved provider)."
+    ()
+
 let kind_of_masc_internal_error = function
   | Cascade_exhausted _ -> "cascade_exhausted"
   | Resumable_cli_session _ -> "resumable_cli_session"

--- a/lib/coord.ml
+++ b/lib/coord.ml
@@ -253,6 +253,18 @@ let () = Atomic.set Coord_hooks.force_release_task_fn (fun config ~agent_name ~t
    in the library dep graph. *)
 let fsm_drift_metric = "masc_task_fsm_drift_total"
 
+let () =
+  Prometheus.register_counter
+    ~name:fsm_drift_metric
+    ~help:
+      "Total task FSM drift transitions observed by \
+       Coord_task_lifecycle.decide (e.g. InProgress -> Done \
+       skipping the verifier path). Labels: variant (drift \
+       variant tag from Coord_task_lifecycle), force (true | \
+       false — was the transition forced past the soft gate). \
+       #9795 fleet-wide ratchet-readiness signal."
+    ()
+
 let record_fsm_drift ~variant ~force =
   Prometheus.inc_counter fsm_drift_metric
     ~labels:[ ("variant", variant);
@@ -266,6 +278,17 @@ let record_fsm_drift ~variant ~force =
    the variant-only counter alongside so existing dashboards keep
    working — the new metric is purely additive. *)
 let fsm_drift_per_agent_metric = "masc_task_fsm_drift_per_agent_total"
+
+let () =
+  Prometheus.register_counter
+    ~name:fsm_drift_per_agent_metric
+    ~help:
+      "Per-agent breakout of task FSM drift transitions \
+       (companion to masc_task_fsm_drift_total — purely \
+       additive). Lets operators identify which keepers most \
+       often skip [in_progress] before [done]. Labels: variant, \
+       agent_name, force. Cardinality bounded by fleet size."
+    ()
 
 let record_fsm_drift_with_agent ~variant ~force ~agent_name =
   record_fsm_drift ~variant ~force;
@@ -285,6 +308,21 @@ let () = Atomic.set Coord_hooks.fsm_drift_observer_fn record_fsm_drift_with_agen
    (missing contracts) vs. the gate-side (verifier-redirect not
    firing). Cardinality bounded at ~4 × 3 × fleet_size. *)
 let task_completion_path_metric = "masc_task_completion_path_total"
+
+let () =
+  Prometheus.register_counter
+    ~name:task_completion_path_metric
+    ~help:
+      "Total task Done emits classified by completion path and \
+       contract presence. Lets operators attribute bypass-rate \
+       to creation-side (missing contracts) vs. gate-side \
+       (verifier-redirect not firing). Labels: path \
+       (claimed_to_done_skip | in_progress_to_done | \
+       via_verification | forced_done), contract_state \
+       (no_contract | empty_contract | with_contract), \
+       agent_name. Cardinality bounded at ~4 x 3 x fleet_size \
+       (#10449)."
+    ()
 
 let record_task_completion_path ~path ~contract_state ~agent_name =
   Prometheus.inc_counter task_completion_path_metric
@@ -306,6 +344,19 @@ let () =
    churn) is separable from [Claimed → Todo] (just-claimed
    churn).  Cardinality bounded at ~fleet × 2. *)
 let task_auto_release_metric = "masc_task_auto_release_total"
+
+let () =
+  Prometheus.register_counter
+    ~name:task_auto_release_metric
+    ~help:
+      "Total implicit task auto-releases triggered by \
+       [task_claim_next] (mid-work churn or just-claimed churn). \
+       Labels: agent_name, from_status (separates [InProgress -> \
+       Todo] from [Claimed -> Todo]). Field log motivation: \
+       observed 179% release/claim ratio with task hot-potatoed \
+       up to 5x in one day (#10421). Cardinality bounded at \
+       ~fleet x 2."
+    ()
 
 let record_task_auto_release ~agent_name ~from_status =
   Prometheus.inc_counter task_auto_release_metric

--- a/lib/keeper/keeper_exec_context.ml
+++ b/lib/keeper/keeper_exec_context.ml
@@ -194,6 +194,17 @@ let dispatch_keeper_phase_event ~(config : Coord.config) ~keeper_name event =
    profile or hand off". *)
 let compaction_outcome_metric = "masc_keeper_compaction_outcome_total"
 
+let () =
+  Prometheus.register_counter
+    ~name:compaction_outcome_metric
+    ~help:
+      "Total Compaction_completed dispatches classified by token \
+       savings. Labels: keeper, outcome (ok = saved_tokens > 0, \
+       noop = before == after or after > before). Rising noop \
+       rate is the operational signal for \"reducer has nothing \
+       to strip, switch profile or hand off\" (#9988)."
+    ()
+
 (* Observability-only: bump the outcome counter and log the warn
    when saved_tokens <= 0.  Split from [dispatch_compaction_completed]
    so unit tests can verify classification without needing a full


### PR DESCRIPTION
## 발견

전체 메트릭 audit (declared masc_* literal × `register_*` / `add` 호출 cross-check):

8 metric 이 도메인 모듈에서 **활발히 inc_counter 호출**되지만 `register_counter ~help` 등록 0. 메트릭이 first-write 시 `inc_counter` 의 auto-register fallback 으로 등록되는데, 그 fallback 은 `help = name` 으로 채움 — 즉 `/metrics` 출력은:

```
# HELP masc_task_fsm_drift_total masc_task_fsm_drift_total
# TYPE masc_task_fsm_drift_total counter
...
```

이름이 곧 설명이라 운영자에게 무가치.

## 메커니즘

`Prometheus.to_prometheus_text` 의 render 경로 (line 2675-2690) 는 *unlabeled parent row* 의 `help` 필드를 찾아서 HELP 라인을 채움. 부팅 시 `let () = Prometheus.register_counter ~name ~help ()` (라벨 없이) 한 줄이 그 unlabeled parent 슬롯을 채우고, labeled `inc_counter` 콜은 모두 그 HELP 를 상속.

## 변경

| 파일 | metric | label 셰이프 |
|------|--------|------|
| `cascade/cascade_error_classify.ml` | `masc_oas_error_total` | kind, cascade_name |
| ↑ | `masc_cross_cascade_fallback_total` | from_cascade, to_cascade, provider |
| `cascade/cascade_attempt_fsm.ml` | `masc_provider_error_total` | kind, provider, cascade_name, capacity_scope |
| `keeper/keeper_exec_context.ml` | `masc_keeper_compaction_outcome_total` | keeper, outcome=ok\|noop |
| `coord.ml` | `masc_task_fsm_drift_total` | variant, force |
| ↑ | `masc_task_fsm_drift_per_agent_total` | variant, agent_name, force |
| ↑ | `masc_task_completion_path_total` | path, contract_state, agent_name |
| ↑ | `masc_task_auto_release_total` | agent_name, from_status |

98 net inserted lines, 4 files. HELP 텍스트는 각 binding decl 위 comment 블록에서 추출 (새 도메인 지식 0).

## 패턴 일치

이미 같은 코드베이스의:
- `keeper_accountability.ml:113-123` — `register_counter ~name:accountability_emit_skip_metric ~help`
- `keeper_guards.ml:259-262` — `register_counter ~name:gate_rejected_terminal_metric ~help`
- `keeper_execution_receipt.ml:241-247` — `register_counter ~name:metric_keeper_receipt_unmapped_disposition ~help`

모두 동일한 *부팅 시 1회 등록* 패턴. 본 PR 은 같은 패턴을 8 개 더 추가.

## RFC-0043 (#14184) 정렬

\"각 도메인 모듈이 자기 metric 의 owner\" 방향과 동일. `prometheus.ml` 자체는 미변경 (godfile 크기 유지). RFC-0043 PR-3 (cascade/oas/sse/llm/ws metric 이동) 시 본 등록도 그대로 따라감.

## 멱등성

`register_counter` 는 `if not (Hashtbl.mem metrics key)` 로 가드 (`prometheus.ml:112`). 부팅 시 중복 호출 안전.

## 검증

- 로컬 `dune build _build/default/lib/masc_mcp.cma` 통과
- `@check` 에러는 `lib/exec/exec_gate.ml` (RFC-0005 A4a 진행 중) 1건 — 본 PR 미접촉
- `to_prometheus_text` 렌더 경로 (line 2675-2690) 가 unlabeled parent 의 help 를 우선 사용 — 본 PR 의 register 호출 셰이프와 정확히 일치

## Best Programmer self-review

- 워크어라운드 시그니처 모두 미해당:
  - 카운터-as-fix? **No** — 카운터 추가 0, 기존 카운터의 HELP만 채움
  - String 분류기? **No**
  - N-of-M? **No** — 8/8 모두 처리, 자가 인정 회피
  - catch-all 추가? **No**
  - test backdoor? **No**
- 새 인프라 0, 기존 idempotent API 사용

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>