### PR TITLE
feat(keeper): migrate lib/keeper read sites to cascade_name_of_meta (RFC-0041 B7 step 2)

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -645,7 +645,7 @@ let run_turn
            Keeper_metrics.metric_keeper_contract_violations
            ~labels:[("keeper_name", meta.name); ("kind", "tool_surface_violation"); ("signal", "unexpected_tool_names")]
            ();
-         Log.Keeper.error "keeper:%s cascade=%s %s" meta.name meta.cascade_name reason;
+         Log.Keeper.error "keeper:%s cascade=%s %s" meta.name (Keeper_types.cascade_name_of_meta meta) reason;
          Error (Agent_sdk.Error.Internal reason)
        else (
          let should_log_unexpected_tool_partial =
@@ -936,7 +936,7 @@ let run_turn
                 | Error e ->
                   Log.Keeper.error
                     "keeper:%s cascade=%s OAS checkpoint save failed: %s"
-                    meta.name meta.cascade_name e;
+                    meta.name (Keeper_types.cascade_name_of_meta meta) e;
                   Prometheus.inc_counter
                     Keeper_metrics.metric_keeper_checkpoint_failures
                     ~labels:[("keeper", meta.name); ("site", "save")]
@@ -948,7 +948,7 @@ let run_turn
              | None ->
                Log.Keeper.error
                  "keeper:%s cascade=%s missing OAS checkpoint after run"
-                 meta.name meta.cascade_name;
+                 meta.name (Keeper_types.cascade_name_of_meta meta);
                  Prometheus.inc_counter
                    Keeper_metrics.metric_keeper_checkpoint_failures
                    ~labels:[("keeper", meta.name); ("site", "missing")]
@@ -1117,7 +1117,7 @@ let run_turn
                   ~labels:[("keeper", meta.name); ("site", "compaction")]
                   ();
                 Log.Keeper.warn "keeper:%s cascade=%s compaction failed: %s" meta.name
-                  meta.cascade_name (Printexc.to_string exn));
+                  (Keeper_types.cascade_name_of_meta meta) (Printexc.to_string exn));
            (* Post-turn quality metrics — goal alignment + memory recall.
              Logged to decisions.jsonl for feedback loop analysis. *)
            (try

--- a/lib/keeper/keeper_compact_policy.ml
+++ b/lib/keeper/keeper_compact_policy.ml
@@ -132,7 +132,7 @@ let compact_if_needed_typed
           | _ :: _ as explicit -> explicit
           | [] ->
               Cascade_runtime.models_of_cascade_name
-                (Keeper_cascade_profile.Runtime_name meta.cascade_name)
+                (Keeper_cascade_profile.Runtime_name (cascade_name_of_meta meta))
         in
         let primary_id = match Cascade_config.parse_model_strings model_labels with
           | c :: _ -> c.Llm_provider.Provider_config.model_id | [] -> "auto" in

--- a/lib/keeper/keeper_health_probe.ml
+++ b/lib/keeper/keeper_health_probe.ml
@@ -124,7 +124,7 @@ let check_cascade_health ~base_path =
   let by_cascade = Hashtbl.create 8 in
   List.iter
     (fun (entry : Keeper_registry.registry_entry) ->
-       let cascade = entry.meta.cascade_name in
+       let cascade = Keeper_types.cascade_name_of_meta entry.meta in
        let total, failed =
          match Hashtbl.find_opt by_cascade cascade with
          | Some pair -> pair

--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -561,7 +561,7 @@ let handle_semaphore_wait_timeout ~ctx ~meta_after_triage
        reactive_available=%d turn_available=%d)"
       timeout.timeout_wait_sec
       phase_label
-      meta_after_triage.cascade_name
+      (cascade_name_of_meta meta_after_triage)
       queue_ahead_text
       timeout.timeout_queue_depth
       timeout.timeout_autonomous_available
@@ -872,11 +872,7 @@ let run_keepalive_unified_turn
            Load cascade_profile from config and select the healthiest
            available item before turn dispatch. *)
         let selected_item_opt =
-          let cascade_name =
-            match meta_after_triage.cascade_ref with
-            | Some ref when not (String.equal ref.group "") -> ref.group
-            | _ -> meta_after_triage.cascade_name
-          in
+          let cascade_name = cascade_name_of_meta meta_after_triage in
           let config_path =
             Filename.concat ctx.config.base_path ".masc/config/cascade.json"
           in
@@ -925,7 +921,7 @@ let run_keepalive_unified_turn
                Preserve all existing telemetry and error handling. *)
             (match
               Keeper_turn_slot.with_keeper_turn_slot_control
-                ~cascade_profile:meta_after_triage.cascade_name
+                ~cascade_profile:(cascade_name_of_meta meta_after_triage)
                 ~keeper_name:meta_after_triage.name
                 ~channel:turn_decision.channel (fun ~semaphore_wait_ms ~slot_control ->
                 run_keeper_cycle_with_slot ~ctx ~meta_after_cursor_persist ~stop ~obs

--- a/lib/keeper/keeper_heartbeat_snapshot.ml
+++ b/lib/keeper/keeper_heartbeat_snapshot.ml
@@ -70,7 +70,7 @@ let write_heartbeat_snapshot
   let metrics_store = keeper_metrics_store ctx.config meta_current.name in
   let cascade_models =
     Cascade_runtime.models_of_cascade_name
-      (Keeper_cascade_profile.Runtime_name meta_current.cascade_name)
+      (Keeper_cascade_profile.Runtime_name (Keeper_types.cascade_name_of_meta meta_current))
   in
   let max_cascade_context =
     let resolution =

--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -62,7 +62,7 @@ let is_keeper_board_write_tool_name tool_name =
 
 let current_keeper_model meta =
   let m = meta.Keeper_types.runtime.usage.last_model_used in
-  if m = "" then meta.Keeper_types.cascade_name else m
+  if m = "" then Keeper_types.cascade_name_of_meta meta else m
 
 let stop_reason_to_label = function
   | Agent_sdk.Types.EndTurn -> "end_turn"
@@ -2183,7 +2183,7 @@ let make_hooks
         in
         let model =
           let m = (!meta_ref).runtime.usage.last_model_used in
-          if m = "" then (!meta_ref).cascade_name else m
+          if m = "" then (Keeper_types.cascade_name_of_meta !meta_ref) else m
         in
         let summary =
           tool_execution_summary
@@ -2235,7 +2235,7 @@ let make_hooks
                ~tool_name ~input ~output_text
                ~success:(outcome = "ok") ~duration_ms
                ~model:(let m = (!meta_ref).runtime.usage.last_model_used in
-                       if m = "" then (!meta_ref).cascade_name else m)
+                       if m = "" then (Keeper_types.cascade_name_of_meta !meta_ref) else m)
                ?lane ?tool_choice ?thinking_enabled ?thinking_budget
                ?prompt_fingerprint
                ?trace_id ?session_id ?turn ?keeper_turn_id ?task_id ?goal_ids

--- a/lib/keeper/keeper_meta_json.ml
+++ b/lib/keeper/keeper_meta_json.ml
@@ -37,7 +37,7 @@ let meta_to_json (m : keeper_meta) : Yojson.Safe.t =
      ; "mid_goal", `String m.mid_goal
      ; "long_goal", `String m.long_goal
      ; "social_model", `String m.social_model
-     ; "cascade_name", `String m.cascade_name
+     ; "cascade_name", `String (cascade_name_of_meta m)
      ; (match m.cascade_ref with
         | Some ref -> "cascade_ref", Cascade_ref.cascade_ref_to_json ref
         | None -> "cascade_ref", `Null)

--- a/lib/keeper/keeper_model_labels.ml
+++ b/lib/keeper/keeper_model_labels.ml
@@ -6,7 +6,7 @@ let configured_model_labels_of_meta (m : keeper_meta) : string list =
   | [] ->
       let configured =
         Cascade_runtime.models_of_cascade_name
-          (Keeper_cascade_profile.Runtime_name m.cascade_name)
+          (Keeper_cascade_profile.Runtime_name (cascade_name_of_meta m))
       in
       match Keeper_benchmark_canary.recommended_model_label_for_keeper ~keeper_name:m.name with
       | Some model_label when String.trim model_label <> "" ->

--- a/lib/keeper/keeper_runtime.ml
+++ b/lib/keeper/keeper_runtime.ml
@@ -175,7 +175,7 @@ let effective_declarative_cascade_name
       Keeper_cascade_profile.normalize_declared_name cascade_name
   | None, Some _ -> Keeper_config.default_cascade_name
   | None, None ->
-      Keeper_cascade_profile.normalize_declared_name meta.cascade_name
+      Keeper_cascade_profile.normalize_declared_name (cascade_name_of_meta meta)
 
 let resynced_tool_access
     (defaults : Keeper_types_profile.keeper_profile_defaults)
@@ -258,7 +258,7 @@ let ensure_keeper_meta config name =
           match defaults.cascade_name, defaults.manifest_path with
           | Some cascade_name, _ -> cascade_name
           | None, Some _ -> Keeper_config.default_cascade_name
-          | None, None -> meta.cascade_name
+          | None, None -> cascade_name_of_meta meta
         in
         let msg =
           Printf.sprintf
@@ -393,7 +393,7 @@ let ensure_keeper_meta config name =
        name. Normalize the meta side only so alias cleanup does not
        register as a semantic change. *)
     let cascade_changed =
-      Keeper_cascade_profile.normalize_declared_name meta.cascade_name
+      Keeper_cascade_profile.normalize_declared_name (cascade_name_of_meta meta)
       <> resolved_target_cascade_name
     in
     (* #10061: persisted state vs TOML source can differ by a single

--- a/lib/keeper/keeper_stale_watchdog.ml
+++ b/lib/keeper/keeper_stale_watchdog.ml
@@ -514,7 +514,7 @@ let fork_stale_watchdog (ctx : _ context) (meta : keeper_meta)
                      ~agent_name:meta.agent_name
                      ~cascade_name:
                        (Keeper_execution_receipt.cascade_name_of_string
-                          meta.cascade_name)
+                          (Keeper_types.cascade_name_of_meta meta))
                      ~trace_id:
                        (Keeper_id.Trace_id.to_string
                           entry.meta.runtime.trace_id)
@@ -552,7 +552,7 @@ let fork_stale_watchdog (ctx : _ context) (meta : keeper_meta)
                    ();
                  Log.Keeper.error
                    "%s: watchdog terminating fiber (oas_timeout_budget unresolved after idle %.0fs; count=%d; preserving provider timeout root cause) [cascade=%s]"
-                   meta.name stall_seconds count meta.cascade_name;
+                   meta.name stall_seconds count (Keeper_types.cascade_name_of_meta meta);
                  emit_watchdog_broadcast ~failure_reason:(Some failure_reason)
                    ~stall_seconds
                | _ ->
@@ -646,14 +646,14 @@ let fork_stale_watchdog (ctx : _ context) (meta : keeper_meta)
                  ();
                Log.Keeper.error
                  "%s: stale watchdog terminating fiber (%s) [cascade=%s window_count=%d/6h]"
-                 meta.name reason_desc meta.cascade_name window_count;
+                 meta.name reason_desc (Keeper_types.cascade_name_of_meta meta) window_count;
                if window_count >= escalation_threshold then begin
                  let cascade_recovered () =
                    match ctx.net with
                    | None -> false
                    | Some net ->
                        (match Cascade_catalog_runtime.resolve_named_providers_strict
-                                ~sw:ctx.sw ~net ~cascade_name:meta.cascade_name () with
+                                ~sw:ctx.sw ~net ~cascade_name:(Keeper_types.cascade_name_of_meta meta) () with
                         | Error _ -> false
                         | Ok candidates ->
                             let healthy =
@@ -683,7 +683,7 @@ let fork_stale_watchdog (ctx : _ context) (meta : keeper_meta)
                             List.exists has_recovery_evidence healthy)
                  in
                  if cascade_recovered () then
-                   Log.Keeper.info "%s: stale threshold reached, but cascade %s appears healthy. Skipping auto-pause." meta.name meta.cascade_name
+                   Log.Keeper.info "%s: stale threshold reached, but cascade %s appears healthy. Skipping auto-pause." meta.name (Keeper_types.cascade_name_of_meta meta)
                  else begin
                  Prometheus.inc_counter
                    Keeper_metrics.metric_keeper_stale_termination_threshold_breached

--- a/lib/keeper/keeper_status_bridge.ml
+++ b/lib/keeper/keeper_status_bridge.ml
@@ -36,7 +36,7 @@ let effective_declarative_cascade_name
       Keeper_cascade_profile.normalize_declared_name cascade_name
   | None, Some _ -> Keeper_config.default_cascade_name
   | None, None ->
-      Keeper_cascade_profile.normalize_declared_name meta.cascade_name
+      Keeper_cascade_profile.normalize_declared_name (cascade_name_of_meta meta)
 
 type override_field_detail = {
   field : string;
@@ -107,10 +107,11 @@ let live_override_details (meta : keeper_meta)
   |> maybe_string_list_override "tools.tool_denylist" defaults.tool_denylist
        meta.tool_denylist
   |> (fun acc ->
-       if effective_cascade_name <> meta.cascade_name then
+       let cascade_name = cascade_name_of_meta meta in
+       if effective_cascade_name <> cascade_name then
          override_field "model.cascade_name"
            ~default_value:(`String effective_cascade_name)
-           ~live_value:(`String meta.cascade_name)
+           ~live_value:(`String cascade_name)
          :: acc
        else acc)
   |> maybe_bool_override "proactive.enabled" defaults.proactive_enabled

--- a/lib/keeper/keeper_status_detail.ml
+++ b/lib/keeper/keeper_status_detail.ml
@@ -579,7 +579,7 @@ let handle_keeper_status ctx args : tool_result =
                |> List.find_opt (function
                     | `Assoc fields ->
                         List.assoc_opt "cascade_name" fields
-                        = Some (`String m.cascade_name)
+                        = Some (`String (cascade_name_of_meta m))
                     | _ -> false)
                |> Option.value ~default:`Null
            | _ -> `Null
@@ -982,7 +982,7 @@ let handle_keeper_status ctx args : tool_result =
            latest_metrics_json ~metrics_store ~metrics_path ~tail_bytes
          in
          let model_observability =
-           model_observability_json ~current_cascade_name:m.cascade_name
+           model_observability_json ~current_cascade_name:(cascade_name_of_meta m)
              ~configured_labels:models
              ~active_model ~runtime_blocker_fields latest_metrics
          in

--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -1656,9 +1656,10 @@ let sweep_and_recover (ctx : _ context) =
                                  && not (paused_meta_requires_reconcile_recovery meta)
                                  && not (Keeper_approval_queue.has_pending_for_keeper
                                            ~keeper_name:meta.name) ->
+               let cascade_name = Keeper_types.cascade_name_of_meta meta in
                let cascade_status =
                  Keeper_health_probe.get_cascade_status
-                   ~cascade_name:meta.cascade_name
+                   ~cascade_name
                in
                (* Three-valued admission:
                     Unhealthy   — block, the probe saw restart pressure.
@@ -1676,11 +1677,11 @@ let sweep_and_recover (ctx : _ context) =
                 | Keeper_health_probe.Unhealthy reason ->
                     Log.Keeper.info
                       "%s: auto-resume blocked; cascade %s is unhealthy (%s)"
-                      name meta.cascade_name reason;
+                      name cascade_name reason;
                     Prometheus.inc_counter
                       Keeper_metrics.metric_keeper_auto_resume_blocked_total
                       ~labels:[("keeper", name);
-                               ("cascade", meta.cascade_name)]
+                               ("cascade", cascade_name)]
                       ()
                 | Keeper_health_probe.Unknown
                 | Keeper_health_probe.Healthy ->

--- a/lib/keeper/keeper_tools_oas.ml
+++ b/lib/keeper/keeper_tools_oas.ml
@@ -189,7 +189,7 @@ let transient_mutex_contention_tool_error
 
 let current_keeper_model (meta : Keeper_types.keeper_meta) =
   let m = meta.runtime.usage.last_model_used in
-  if m = "" then meta.cascade_name else m
+  if m = "" then Keeper_types.cascade_name_of_meta meta else m
 
 let persist_tool_call_io_from_handler
     ~(meta : Keeper_types.keeper_meta)

--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -144,7 +144,7 @@ let direct_turn_observation (meta : keeper_meta) :
   }
 
 let resolve_turn_cascade_name (meta : keeper_meta) =
-  let raw_name = String.trim meta.cascade_name in
+  let raw_name = String.trim (Keeper_types.cascade_name_of_meta meta) in
   match Cascade_catalog_runtime.resolve_declared_name ~raw_name () with
   | Ok cascade_name -> Ok cascade_name
   | Error detail ->

--- a/lib/keeper/keeper_turn_up_create.ml
+++ b/lib/keeper/keeper_turn_up_create.ml
@@ -654,7 +654,7 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
           ("needs", `String meta.needs);
           ("desires", `String meta.desires);
           ("instructions", `String meta.instructions);
-          ("cascade_name", `String meta.cascade_name);
+          ("cascade_name", `String (cascade_name_of_meta meta));
           ("voice_enabled", `Bool meta.voice_enabled);
           ("voice_channel", `String meta.voice_channel);
           ("voice_agent_id", `String meta.voice_agent_id);

--- a/lib/keeper/keeper_unified_metrics.ml
+++ b/lib/keeper/keeper_unified_metrics.ml
@@ -563,7 +563,7 @@ let provider_context_json ~(meta : keeper_meta)
               observation.selected_model,
               observation.candidate_models )
         | None ->
-            ( meta.cascade_name,
+            ( (cascade_name_of_meta meta),
               Some (Keeper_agent_run.surface_model_used r),
               [] )
       in
@@ -576,7 +576,7 @@ let provider_context_json ~(meta : keeper_meta)
         ]
   | None ->
       `Assoc
-        [ ("cascade_name", `String meta.cascade_name)
+        [ ("cascade_name", `String (cascade_name_of_meta meta))
         ; ("selected_model", `Null)
         ; ( "candidate_models",
             `List
@@ -1022,7 +1022,7 @@ let append_decision_record
                 error_category_of_no_result_outcome ~outcome ~error
               in
               `Assoc [
-                ("cascade_name", `String meta.cascade_name);
+                ("cascade_name", `String (cascade_name_of_meta meta));
                 ("candidate_models", `List (List.map (fun s -> `String s) cascade_models));
                 ( "error_category",
                   match error_category with
@@ -1384,7 +1384,7 @@ let append_metrics_snapshot ~(config : Coord.config) ~(meta : keeper_meta)
     | Some observation ->
       Keeper_cascade_profile.runtime_name_to_string
         observation.Cascade_legacy_runner.cascade_name
-    | None -> meta.cascade_name
+    | None -> (cascade_name_of_meta meta)
   in
   (* #9933: same latency bucket, split by provider/model/cascade.
      This keeps the existing keeper-only counter stable while making

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -207,7 +207,7 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
       ~meta
       ~generation
       ~cascade_name:
-        (Keeper_execution_receipt.cascade_name_of_string meta.cascade_name)
+        (Keeper_execution_receipt.cascade_name_of_string (cascade_name_of_meta meta))
       ~outcome:"cancelled"
       ~terminal_reason_code:"supervisor_stop"
       ~activity_kind:"keeper.turn_cancelled"
@@ -236,7 +236,7 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
         ~meta
         ~generation
         ~cascade_name:
-          (Keeper_execution_receipt.cascade_name_of_string meta.cascade_name)
+          (Keeper_execution_receipt.cascade_name_of_string (cascade_name_of_meta meta))
         ~outcome:"skipped"
         ~terminal_reason_code
         ~activity_kind:"keeper.turn_skipped"
@@ -256,7 +256,7 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
         ~prev:Keeper_turn_fsm.Phase_gating
         Keeper_turn_fsm.Cascade_routing;
       (* RFC-0041 Phase B4: when a specific item was selected by the
-         proactive router, override meta.cascade_name so downstream
+         proactive router, override (cascade_name_of_meta meta) so downstream
          cascade resolution uses the item's group. *)
       let meta =
         match selected_item with
@@ -274,7 +274,7 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
               Keeper_state_machine.Failing
         in
         let routing = Keeper_cascade_routing.select_cascade
-          ~base_cascade:meta.cascade_name ~phase
+          ~base_cascade:(cascade_name_of_meta meta) ~phase
         in
         Prometheus.inc_counter Keeper_metrics.metric_keeper_fsm_edge_transitions
           ~labels:[("edge", "ksm_to_kcl_routing")] ();
@@ -284,12 +284,12 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
         in
         let resolved_cascade =
           fail_open_local_only_when_unavailable
-            ~base_cascade:meta.cascade_name
+            ~base_cascade:(cascade_name_of_meta meta)
             ~effective_cascade:routing.effective_cascade
             routed_labels
         in
         Log.Keeper.debug "%s: cascade routing: %s -> %s (reason: %s)"
-          meta.name meta.cascade_name routing.effective_cascade routing.reason;
+          meta.name (cascade_name_of_meta meta) routing.effective_cascade routing.reason;
         if not (String.equal resolved_cascade routing.effective_cascade) then
           Log.Keeper.warn
             "%s: local_only unavailable for labels [%s]; falling back to base cascade %s"
@@ -311,7 +311,7 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
               (float_of_int remaining_sec);
             (match
                EC.fallback_cascade_for_unavailable_profile
-                 ~base_cascade:meta.cascade_name
+                 ~base_cascade:(cascade_name_of_meta meta)
                  ~effective_cascade:effective_cascade_name
              with
              | Some fallback_cascade
@@ -1342,7 +1342,7 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
                   match
                     next_fail_open_cascade_for_turn_with_budget
                       ?rotation_cascades:fail_open_rotation_cascades
-                      ~base_cascade:meta.cascade_name
+                      ~base_cascade:(cascade_name_of_meta meta)
                       ~effective_cascade:execution_cascade_name
                       ~tool_requirement:initial_tool_requirement
                       ~attempted_cascades

--- a/lib/keeper/keeper_world_observation.ml
+++ b/lib/keeper/keeper_world_observation.ml
@@ -1290,19 +1290,20 @@ let keeper_cycle_decision
                   || backlog_elapsed
                   || (idle_gate_elapsed && cooldown_elapsed)))
         in
+        let cascade_name = cascade_name_of_meta meta in
         let provider_cooldown_remaining_sec =
           if should_run
           then
             provider_cooldown_remaining_sec
-              ~cascade_name:(Keeper_cascade_profile.runtime_name_of_string meta.cascade_name)
+              ~cascade_name:(Keeper_cascade_profile.runtime_name_of_string cascade_name)
           else None
         in
         let provider_cooldown_fail_open =
           match provider_cooldown_remaining_sec with
           | Some _ ->
               fallback_cascade_for_provider_cooldown
-                ~base_cascade:meta.cascade_name
-                ~effective_cascade:meta.cascade_name
+                ~base_cascade:cascade_name
+                ~effective_cascade:cascade_name
           | None -> None
         in
         let verdict =


### PR DESCRIPTION
## Summary

Continues PR #14316 by migrating read sites inside `lib/keeper/` from direct field access (`m.cascade_name`) to the canonical helper `Keeper_types.cascade_name_of_meta`.

After this PR all keeper-meta read sites in the OCaml codebase use the helper, leaving only:
- write sites (record literal/update with `cascade_name = X`) — separate PR
- the legacy `cascade_name : string` record field itself — final PR

## Changes (19 files, ~50 sites)

| File | Sites |
|------|-------|
| `keeper_agent_run` | 4 |
| `keeper_compact_policy` | 1 |
| `keeper_health_probe` | 1 |
| `keeper_heartbeat_loop` | 3 (also collapses inline `cascade_ref`->fallback match into a single helper call) |
| `keeper_heartbeat_snapshot` | 1 |
| `keeper_hooks_oas` | 3 |
| `keeper_meta_json` | 1 |
| `keeper_model_labels` | 1 |
| `keeper_runtime` | 3 |
| `keeper_stale_watchdog` | 5 |
| `keeper_status_bridge` | 3 |
| `keeper_status_detail` | 2 |
| `keeper_supervisor` | 3 |
| `keeper_tools_oas` | 1 |
| `keeper_turn` | 1 |
| `keeper_turn_up_create` | 1 |
| `keeper_unified_metrics` | 4 |
| `keeper_unified_turn` | 7 |
| `keeper_world_observation` | 3 |

## Out of scope

- write sites (record literal/update with `cascade_name = X`) — separate PR will converge them on `cascade_ref` as SSOT
- `keeper_meta` record field removal — final PR after write sites migrate
- Comments/string literals referencing the legacy field name kept intact for documentation

## Verification

```
$ dune build --root . @lib/check 2>&1 | grep -E "^File |^Error"
(empty — clean build)
```

## Refs

- RFC-0041 (cascade routing group/item hierarchy)
- Follows PR #14316 (helper introduction + 8 file read sites outside lib/keeper, merged)
- Stacked on PR #14320 (main blocker hotfix, merged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>