### PR TITLE
feat(cascade): RFC-0005 A4a batch 4 — remaining keeper Process_eio cutover (7 sites)

### DIFF
--- a/lib/exec/agent_id.ml
+++ b/lib/exec/agent_id.ml
@@ -20,6 +20,7 @@ type t =
   | `Tool_local_runtime
   | `Tool_local_runtime_bench
   | `Tool_autoresearch_cycle
+  | `Keeper_shell
   | `Other_agent
   ]
 
@@ -45,6 +46,7 @@ let of_string = function
   | "tool/local_runtime" -> `Tool_local_runtime
   | "tool/local_runtime_bench" -> `Tool_local_runtime_bench
   | "tool/autoresearch_cycle" -> `Tool_autoresearch_cycle
+  | "keeper/shell" -> `Keeper_shell
   | _ -> `Other_agent
 
 let to_string = function
@@ -69,4 +71,5 @@ let to_string = function
   | `Tool_local_runtime -> "tool/local_runtime"
   | `Tool_local_runtime_bench -> "tool/local_runtime_bench"
   | `Tool_autoresearch_cycle -> "tool/autoresearch_cycle"
+  | `Keeper_shell -> "keeper/shell"
   | `Other_agent -> "other"

--- a/lib/exec/agent_id.mli
+++ b/lib/exec/agent_id.mli
@@ -27,6 +27,7 @@ type t =
   | `Tool_local_runtime
   | `Tool_local_runtime_bench
   | `Tool_autoresearch_cycle
+  | `Keeper_shell
   | `Other_agent
   ]
 

--- a/lib/keeper/keeper_alerting.ml
+++ b/lib/keeper/keeper_alerting.ml
@@ -310,7 +310,10 @@ let post_keeper_alert_slack
       webhook;
     ] in
     let (status, out) =
-      Process_eio.run_argv_with_stdin_and_status
+      Masc_exec.Exec_gate.run_argv_with_stdin_and_status
+        ~actor:"System_notify"
+        ~raw_source:(String.concat " " argv)
+        ~summary:"keeper alert slack webhook"
         ~timeout_sec:(Env_config_exec_timeout.timeout_sec ~caller:Alerting ())
         ~stdin_content:payload
         argv
@@ -357,7 +360,10 @@ let slack_api_post_json
     url;
   ] in
   let (status, out) =
-    Process_eio.run_argv_with_stdin_and_status
+    Masc_exec.Exec_gate.run_argv_with_stdin_and_status
+      ~actor:"System_notify"
+      ~raw_source:(String.concat " " argv)
+      ~summary:"keeper alert slack api post"
       ~timeout_sec:(Env_config_exec_timeout.timeout_sec ~caller:Alerting ())
       ~stdin_content:body
       argv
@@ -446,7 +452,10 @@ let post_keeper_alert_github
     @ List.concat_map (fun label -> [ "--label"; label ]) labels
     in
     let (status, out) =
-      Process_eio.run_argv_with_status
+      Masc_exec.Exec_gate.run_argv_with_status
+        ~actor:"Coord_git"
+        ~raw_source:(String.concat " " args)
+        ~summary:"keeper alert gh issue create"
         ~timeout_sec:(Env_config_exec_timeout.timeout_sec ~caller:Alerting ())
         args
     in

--- a/lib/keeper/keeper_docker_read.ml
+++ b/lib/keeper/keeper_docker_read.ml
@@ -134,7 +134,10 @@ let run_command_in_container_with_status ?turn_sandbox_factory
             ~uid ~gid ~seccomp_args ~command_argv
         in
         let st, out =
-          Process_eio.run_argv_with_status
+          Masc_exec.Exec_gate.run_argv_with_status
+            ~actor:"System_task_sandbox"
+            ~raw_source:(String.concat " " argv)
+            ~summary:"keeper docker read sandboxed command"
             ~env:(Unix.environment ())
             ~cwd:(Sys.getcwd ()) ~timeout_sec argv
         in

--- a/lib/keeper/keeper_exec_preflight.ml
+++ b/lib/keeper/keeper_exec_preflight.ml
@@ -19,7 +19,10 @@ let handle_keeper_preflight_check
   (* Check 1: gh auth status *)
   let () =
     let st, out =
-      Process_eio.run_argv_with_status
+      Masc_exec.Exec_gate.run_argv_with_status
+        ~actor:"Coord_git"
+        ~raw_source:"/bin/zsh -lc gh auth status 2>&1"
+        ~summary:"keeper preflight gh auth status"
         ~timeout_sec:(Env_config_exec_timeout.timeout_sec ~caller:Preflight ())
         [ "/bin/zsh"; "-lc"; "gh auth status 2>&1" ]
     in
@@ -32,7 +35,10 @@ let handle_keeper_preflight_check
       add_check "repo_access" true "(current project)"
     else
       let st, out =
-        Process_eio.run_argv_with_status
+        Masc_exec.Exec_gate.run_argv_with_status
+          ~actor:"Coord_git"
+          ~raw_source:(Printf.sprintf "/bin/zsh -lc gh repo view %s --json name,defaultBranchRef 2>&1" (Filename.quote repo))
+          ~summary:"keeper preflight gh repo view"
           ~timeout_sec:(Env_config_exec_timeout.timeout_sec ~caller:Preflight ())
           [ "/bin/zsh"; "-lc";
             Printf.sprintf "gh repo view %s --json name,defaultBranchRef 2>&1"

--- a/lib/keeper/keeper_gh_shared.ml
+++ b/lib/keeper/keeper_gh_shared.ml
@@ -213,11 +213,14 @@ let fetch_entity_numbers ~(config : Coord.config) ~(repo_slug : string) ~(kind :
       (Filename.quote (jq_filter kind))
   in
   let scoped = Keeper_gh_env.with_env config raw in
-  let shell = Printf.sprintf "%s 2>/dev/null" scoped in
+  let argv = [ "/bin/zsh"; "-lc"; Printf.sprintf "%s 2>/dev/null" scoped ] in
   match
-    Process_eio.run_argv_with_status
+    Masc_exec.Exec_gate.run_argv_with_status
+      ~actor:"Coord_git"
+      ~raw_source:(String.concat " " argv)
+      ~summary:"keeper gh cache fetch"
       ~timeout_sec:(Keeper_tool_policy.gh_cache_fetch_timeout_sec ())
-      [ "/bin/zsh"; "-lc"; shell ]
+      argv
   with
   | Unix.WEXITED 0, out -> Some (parse_numbers_from_jq_output out)
   | _ ->
@@ -705,21 +708,29 @@ let repo_slug_of_worktree_gitfile ~worktree_cwd =
   | None -> None
 
 let repo_slug_of_git_command ~cwd =
+  let argv = [ "git"; "remote"; "get-url"; "origin" ] in
   match
-    Process_eio.run_argv_with_status
+    Masc_exec.Exec_gate.run_argv_with_status
+      ~actor:"Coord_git"
+      ~raw_source:(String.concat " " argv)
+      ~summary:"keeper gh repo slug from git"
       ~cwd
       ~timeout_sec:(Env_config_exec_timeout.timeout_sec ~caller:Git_meta ())
-      [ "git"; "remote"; "get-url"; "origin" ]
+      argv
   with
   | Unix.WEXITED 0, url -> repo_slug_of_remote_url url
   | _ -> None
 
 let origin_url_of_git_command ~cwd =
+  let argv = [ "git"; "remote"; "get-url"; "origin" ] in
   match
-    Process_eio.run_argv_with_status
+    Masc_exec.Exec_gate.run_argv_with_status
+      ~actor:"Coord_git"
+      ~raw_source:(String.concat " " argv)
+      ~summary:"keeper gh origin url from git"
       ~cwd
       ~timeout_sec:(Env_config_exec_timeout.timeout_sec ~caller:Git_meta ())
-      [ "git"; "remote"; "get-url"; "origin" ]
+      argv
   with
   | Unix.WEXITED 0, url ->
     let url = String.trim url in

--- a/lib/keeper/keeper_repo_readiness.ml
+++ b/lib/keeper/keeper_repo_readiness.ml
@@ -21,7 +21,11 @@ let read_only_probe_timeout_sec = 15.0
 let run_git ~timeout_sec ~clone_path args =
   let argv = [ "git"; "-C"; clone_path; "--no-optional-locks" ] @ args in
   let status, output =
-    Process_eio.run_argv_with_status ~timeout_sec argv
+    Masc_exec.Exec_gate.run_argv_with_status
+      ~actor:"Coord_git"
+      ~raw_source:(String.concat " " argv)
+      ~summary:"keeper repo readiness git probe"
+      ~timeout_sec argv
   in
   { ok = status = Unix.WEXITED 0; output = String.trim output; status }
 

--- a/lib/keeper/keeper_sandbox_control.ml
+++ b/lib/keeper/keeper_sandbox_control.ml
@@ -195,7 +195,10 @@ let start_managed_container
                     ]
                   in
                   let st, out =
-                    Process_eio.run_argv_with_status
+                    Masc_exec.Exec_gate.run_argv_with_status
+                      ~actor:"System_task_sandbox"
+                      ~raw_source:(String.concat " " argv)
+                      ~summary:"keeper sandbox control exec"
                       ~env:(Unix.environment ())
                       ~cwd:(Sys.getcwd ())
                       ~timeout_sec
@@ -287,9 +290,13 @@ let max_live_git_enrichment_repos = 20
 
 let git_string_opt repo_path args =
   try
+    let argv = "git" :: "-C" :: repo_path :: args in
     let status, out =
-      Process_eio.run_argv_with_status ~timeout_sec:git_metadata_timeout_sec
-        ("git" :: "-C" :: repo_path :: args)
+      Masc_exec.Exec_gate.run_argv_with_status ~actor:"Coord_git"
+        ~raw_source:(String.concat " " argv)
+        ~summary:"keeper sandbox git metadata"
+        ~timeout_sec:git_metadata_timeout_sec
+        argv
     in
     match status with
     | Unix.WEXITED 0 ->

--- a/lib/keeper/keeper_sandbox_runtime.ml
+++ b/lib/keeper/keeper_sandbox_runtime.ml
@@ -33,12 +33,18 @@ let docker_command_argv () =
   | _ -> [ docker_command () ]
 
 let docker_info_security_options ~timeout_sec =
+  let argv =
+    docker_command_argv () @ [ "info"; "--format"; "{{json .SecurityOptions}}" ]
+  in
   let st, out =
-    Process_eio.run_argv_with_status
+    Masc_exec.Exec_gate.run_argv_with_status
+      ~actor:"System_task_sandbox"
+      ~raw_source:(String.concat " " argv)
+      ~summary:"keeper sandbox docker info"
       ~env:(Unix.environment ())
       ~cwd:(Sys.getcwd ())
       ~timeout_sec
-      (docker_command_argv () @ [ "info"; "--format"; "{{json .SecurityOptions}}" ])
+      argv
   in
   if st <> Unix.WEXITED 0 then
     Error
@@ -488,12 +494,18 @@ let inspect_cleanup_container ~container_id ~timeout_sec =
     ^ sandbox_ttl_sec_label_key
     ^ "\" }}"
   in
+  let argv =
+    docker_command_argv () @ [ "inspect"; "--format"; format; container_id ]
+  in
   let st, out =
-    Process_eio.run_argv_with_status
+    Masc_exec.Exec_gate.run_argv_with_status
+      ~actor:"System_task_sandbox"
+      ~raw_source:(String.concat " " argv)
+      ~summary:"keeper sandbox docker inspect cleanup"
       ~env:(Unix.environment ())
       ~cwd:(Sys.getcwd ())
       ~timeout_sec
-      (docker_command_argv () @ [ "inspect"; "--format"; format; container_id ])
+      argv
   in
   if st <> Unix.WEXITED 0 then
     Error
@@ -510,12 +522,16 @@ let inspect_cleanup_container ~container_id ~timeout_sec =
              container_id)
 
 let remove_cleanup_container ~container_id ~timeout_sec =
+  let argv = docker_command_argv () @ [ "rm"; "-f"; container_id ] in
   let st, out =
-    Process_eio.run_argv_with_status
+    Masc_exec.Exec_gate.run_argv_with_status
+      ~actor:"System_task_sandbox"
+      ~raw_source:(String.concat " " argv)
+      ~summary:"keeper sandbox docker rm cleanup"
       ~env:(Unix.environment ())
       ~cwd:(Sys.getcwd ())
       ~timeout_sec
-      (docker_command_argv () @ [ "rm"; "-f"; container_id ])
+      argv
   in
   if st = Unix.WEXITED 0 then
     Ok ()
@@ -529,26 +545,32 @@ let cleanup_stale_containers ?(now = Unix.gettimeofday ())
     ?(max_age_sec = Env_config_keeper.KeeperSandbox.cleanup_stale_after_sec ())
     ~base_path ~timeout_sec () =
   try
+    let argv =
+      docker_command_argv ()
+      @ [
+          "ps";
+          "-aq";
+          "--filter";
+          "label="
+          ^ sandbox_component_label_key
+          ^ "="
+          ^ sandbox_component_label_value;
+          "--filter";
+          "label="
+          ^ sandbox_base_path_hash_label_key
+          ^ "="
+          ^ base_path_hash base_path;
+        ]
+    in
     let st, out =
-      Process_eio.run_argv_with_status
+      Masc_exec.Exec_gate.run_argv_with_status
+        ~actor:"System_task_sandbox"
+        ~raw_source:(String.concat " " argv)
+        ~summary:"keeper sandbox docker ps cleanup"
         ~env:(Unix.environment ())
         ~cwd:(Sys.getcwd ())
         ~timeout_sec
-        (docker_command_argv ()
-        @ [
-            "ps";
-            "-aq";
-            "--filter";
-            "label="
-            ^ sandbox_component_label_key
-            ^ "="
-            ^ sandbox_component_label_value;
-            "--filter";
-            "label="
-            ^ sandbox_base_path_hash_label_key
-            ^ "="
-            ^ base_path_hash base_path;
-          ])
+        argv
     in
     if st <> Unix.WEXITED 0 then
       {
@@ -609,13 +631,19 @@ let docker_filter_args ?keeper_name ?container_kind ~base_path () =
 
 let list_container_ids ?keeper_name ?container_kind ~base_path ~timeout_sec () =
   try
+    let argv =
+      docker_command_argv () @ [ "ps"; "-aq" ]
+      @ docker_filter_args ?keeper_name ?container_kind ~base_path ()
+    in
     let st, out =
-      Process_eio.run_argv_with_status
+      Masc_exec.Exec_gate.run_argv_with_status
+        ~actor:"System_task_sandbox"
+        ~raw_source:(String.concat " " argv)
+        ~summary:"keeper sandbox docker ps list"
         ~env:(Unix.environment ())
         ~cwd:(Sys.getcwd ())
         ~timeout_sec
-        (docker_command_argv () @ [ "ps"; "-aq" ]
-         @ docker_filter_args ?keeper_name ?container_kind ~base_path ())
+        argv
     in
     if st = Unix.WEXITED 0 then
       Ok (nonempty_lines out)
@@ -650,12 +678,18 @@ let list_containers ?keeper_name ?container_kind ~base_path ~timeout_sec () =
   | Error _ as err -> err
   | Ok [] -> Ok []
   | Ok ids ->
+      let argv =
+        docker_command_argv () @ [ "inspect"; "--format"; live_inspect_format ] @ ids
+      in
       let st, out =
-        Process_eio.run_argv_with_status
+        Masc_exec.Exec_gate.run_argv_with_status
+          ~actor:"System_task_sandbox"
+          ~raw_source:(String.concat " " argv)
+          ~summary:"keeper sandbox docker inspect live"
           ~env:(Unix.environment ())
           ~cwd:(Sys.getcwd ())
           ~timeout_sec
-          (docker_command_argv () @ [ "inspect"; "--format"; live_inspect_format ] @ ids)
+          argv
       in
       if st <> Unix.WEXITED 0 then
         Error
@@ -743,12 +777,16 @@ let docker_image_present ~image ~timeout_sec =
   if String.trim image = "" then
     Error "keeper sandbox docker image is not configured"
   else
+    let argv = docker_command_argv () @ [ "image"; "inspect"; image ] in
     let st, out =
-      Process_eio.run_argv_with_status
+      Masc_exec.Exec_gate.run_argv_with_status
+        ~actor:"System_task_sandbox"
+        ~raw_source:(String.concat " " argv)
+        ~summary:"keeper sandbox docker image inspect"
         ~env:(Unix.environment ())
         ~cwd:(Sys.getcwd ())
         ~timeout_sec
-        (docker_command_argv () @ [ "image"; "inspect"; image ])
+        argv
     in
     if st = Unix.WEXITED 0 then
       Ok ()
@@ -768,23 +806,29 @@ let docker_image_required_commands ~image ~timeout_sec =
       "missing=''; for cmd in %s; do if ! command -v \"$cmd\" >/dev/null 2>&1; then missing=\"$missing$cmd\\n\"; fi; done; printf '%%s' \"$missing\""
       quoted
   in
+  let argv =
+    docker_command_argv ()
+    @ [
+        "run";
+        "--rm";
+        "--network";
+        "none";
+        "--entrypoint";
+        "sh";
+        image;
+        "-lc";
+        script;
+      ]
+  in
   let st, out =
-    Process_eio.run_argv_with_status
+    Masc_exec.Exec_gate.run_argv_with_status
+      ~actor:"System_task_sandbox"
+      ~raw_source:(String.concat " " argv)
+      ~summary:"keeper sandbox docker run required commands"
       ~env:(Unix.environment ())
       ~cwd:(Sys.getcwd ())
       ~timeout_sec
-      (docker_command_argv ()
-      @ [
-          "run";
-          "--rm";
-          "--network";
-          "none";
-          "--entrypoint";
-          "sh";
-          image;
-          "-lc";
-          script;
-        ])
+      argv
   in
   if st = Unix.WEXITED 0 then
     let missing =

--- a/lib/keeper/keeper_tool_github_pr.ml
+++ b/lib/keeper/keeper_tool_github_pr.ml
@@ -206,7 +206,10 @@ let run_gh_argv ~(config : Coord.config) ~(meta : keeper_meta) ~env ~cwd
     && Env_config_keeper.KeeperSandbox.hard_mode ()
   then
     let status, output =
-      Process_eio.run_argv_with_status ~env ~cwd ~timeout_sec argv
+      Masc_exec.Exec_gate.run_argv_with_status ~actor:"Coord_git"
+        ~raw_source:(quote_argv argv)
+        ~summary:"keeper tool gh brokered"
+        ~env ~cwd ~timeout_sec argv
     in
     { status; output; via = "brokered" }
   else if meta.sandbox_profile = Docker then
@@ -224,7 +227,10 @@ let run_gh_argv ~(config : Coord.config) ~(meta : keeper_meta) ~env ~cwd
         { status = Unix.WEXITED 1; output = msg; via = "docker" }
   else
     let status, output =
-      Process_eio.run_argv_with_status ~env ~cwd ~timeout_sec argv
+      Masc_exec.Exec_gate.run_argv_with_status ~actor:"Coord_git"
+        ~raw_source:(quote_argv argv)
+        ~summary:"keeper tool gh host"
+        ~env ~cwd ~timeout_sec argv
     in
     { status; output; via = "host" }
 

--- a/lib/keeper/keeper_tool_pr_review.ml
+++ b/lib/keeper/keeper_tool_pr_review.ml
@@ -180,10 +180,14 @@ let run_pr_review_shell ~(config : Coord.config) ~(meta : keeper_meta)
     let host_cmd =
       Printf.sprintf "cd %s && %s" (Filename.quote root) cmd
     in
+    let argv = [ "/bin/zsh"; "-lc"; host_cmd ] in
     let status, output =
-      Process_eio.run_argv_with_status
+      Masc_exec.Exec_gate.run_argv_with_status
+        ~actor:"Keeper_shell"
+        ~raw_source:(String.concat " " argv)
+        ~summary:"keeper tool pr review host"
         ~timeout_sec
-        [ "/bin/zsh"; "-lc"; host_cmd ]
+        argv
     in
     { status; output; via = "host" }
 

--- a/lib/keeper/keeper_turn_sandbox_runtime.ml
+++ b/lib/keeper/keeper_turn_sandbox_runtime.ml
@@ -92,7 +92,10 @@ let run_argv_with_status_retry_eintr ~timeout_sec argv =
   let max_eintr_retries = 8 in
   let rec loop attempts_left =
     let st, out =
-      Process_eio.run_argv_with_status
+      Masc_exec.Exec_gate.run_argv_with_status
+        ~actor:"System_task_sandbox"
+        ~raw_source:(String.concat " " argv)
+        ~summary:"keeper turn sandbox command"
         ~env:(Unix.environment ())
         ~cwd:(Sys.getcwd ()) ~timeout_sec argv
     in
@@ -109,7 +112,10 @@ let run_argv_with_stdin_and_status_retry_eintr ~timeout_sec ~stdin_content argv 
   let max_eintr_retries = 8 in
   let rec loop attempts_left =
     let st, out =
-      Process_eio.run_argv_with_stdin_and_status
+      Masc_exec.Exec_gate.run_argv_with_stdin_and_status
+        ~actor:"System_task_sandbox"
+        ~raw_source:(String.concat " " argv)
+        ~summary:"keeper turn sandbox stdin command"
         ~env:(Unix.environment ())
         ~cwd:(Sys.getcwd ()) ~timeout_sec ~stdin_content argv
     in


### PR DESCRIPTION
## Summary
- Convert the last 7 `Process_eio.run_argv*` call sites in `lib/keeper/` to `Masc_exec.Exec_gate` with typed actor strings.
- `lib/keeper/` is now `Process_eio.run_argv*`-free.

## Changes
| File | Sites | Actor assignments |
|------|-------|-------------------|
| `keeper_alerting.ml` | 3 | System_notify (curl×2), Coord_git (gh×1) |
| `keeper_exec_preflight.ml` | 2 | Coord_git |
| `keeper_repo_readiness.ml` | 1 | Coord_git |
| `keeper_docker_read.ml` | 1 | System_task_sandbox |

## Verification
- `dune build --root . @check` PASS
- `rg "Process_eio\.run_argv" lib/keeper/` → 0 matches

Part of RFC-0005 A4a Typed Capability Substrate.