### PR TITLE
refactor(keeper): align last_blocker to blocker_info option

### DIFF
--- a/lib/dashboard/dashboard_http_keeper.ml
+++ b/lib/dashboard/dashboard_http_keeper.ml
@@ -1488,10 +1488,17 @@ let keeper_bdi_snapshot_json (config : Coord.config) (name : string)
       let belief =
         match metric_field "belief_summary" with
         | Some value -> Some value
-        | None -> (
-            match nonempty_string_opt m.runtime.last_blocker with
-            | Some blocker -> Some ("blocked: " ^ blocker)
-            | None -> None)
+        | None ->
+            (match m.runtime.last_blocker with
+             | Some info ->
+                 let trimmed = String.trim info.detail in
+                 let label =
+                   if trimmed = "" then
+                     Keeper_types.blocker_class_to_string info.klass
+                   else trimmed
+                 in
+                 Some ("blocked: " ^ label)
+             | None -> None)
       in
       let desire =
         match metric_field "active_desire" with

--- a/lib/dashboard/dashboard_safe_autonomy.ml
+++ b/lib/dashboard/dashboard_safe_autonomy.ml
@@ -842,11 +842,10 @@ let keeper_snapshot_json ~(config : Coord.config) (snapshot : keeper_snapshot) =
       ("approval_pending_count", `Int snapshot.approval.count);
       ("recent_activity_count", `Int snapshot.activity.count);
       ("last_activity_ts", float_opt_to_json snapshot.activity.last_ts);
-      ("last_blocker", string_opt_to_json (non_empty_string_opt meta.runtime.last_blocker));
-      ( "last_blocker_class",
-        string_opt_to_json
-          (Option.map Keeper_types.blocker_class_to_string
-             meta.runtime.last_blocker_class) );
+      ( "last_blocker"
+      , match meta.runtime.last_blocker with
+        | Some info -> Keeper_types.blocker_info_to_json info
+        | None -> `Null );
       ( "benchmark_recommendation",
         match snapshot.bench_recommendation with
         | None -> `Null
@@ -931,7 +930,13 @@ let timeline_entries_json
   List.iter
     (fun snapshot ->
       let blocker =
-        non_empty_string_opt snapshot.meta.runtime.last_blocker
+        match snapshot.meta.runtime.last_blocker with
+        | Some info ->
+          let trimmed = String.trim info.detail in
+          if trimmed = "" then
+            Some (Keeper_types.blocker_class_to_string info.klass)
+          else Some trimmed
+        | None -> None
       in
       match blocker with
       | None -> ()

--- a/lib/governance_pipeline.ml
+++ b/lib/governance_pipeline.ml
@@ -219,29 +219,26 @@ let destructive_tool_or_op ~tool_name ~input =
 let runtime_auto_approval_blocked = function
   | None -> false
   | Some (meta : Keeper_types.keeper_meta) ->
-      let continue_gate =
-        match meta.runtime.last_blocker_class with
-        | Some blocker_class ->
-            Keeper_types.blocker_class_continue_gate blocker_class
-        | None -> false
-      in
-      let blocker_class =
-        Option.map Keeper_types.blocker_class_to_string
-          meta.runtime.last_blocker_class
-      in
-      let blocker_summary = nonempty_trimmed meta.runtime.last_blocker in
-      continue_gate
-      ||
-      match blocker_class with
-      | Some "completion_contract_violation"
-      | Some "cascade_exhausted" ->
-          true
-      | _ ->
-          (match blocker_summary with
-          | Some summary ->
-              String_util.contains_substring_ci summary "manual block"
-              || String_util.contains_substring_ci summary "sandbox"
-          | None -> false)
+      (match meta.runtime.last_blocker with
+       | None -> false
+       | Some info ->
+         let continue_gate =
+           Keeper_types.blocker_class_continue_gate info.klass
+         in
+         let typed_blocked =
+           match info.klass with
+           | Keeper_types.Completion_contract_violation
+           | Keeper_types.Cascade_exhausted _ -> true
+           | _ -> false
+         in
+         let detail_blocked =
+           match nonempty_trimmed info.detail with
+           | Some summary ->
+               String_util.contains_substring_ci summary "manual block"
+               || String_util.contains_substring_ci summary "sandbox"
+           | None -> false
+         in
+         continue_gate || typed_blocked || detail_blocked)
 
 let auto_approval_forbidden ~tool_name ~input ~risk meta =
   risk = Critical

--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -592,8 +592,9 @@ let handle_semaphore_wait_timeout ~ctx ~meta_after_triage
   Keeper_types.map_runtime
     (fun rt ->
       { rt with
-        last_blocker = persisted_blocker;
-        last_blocker_class = Some blocker_class;
+        last_blocker =
+          Some (Keeper_meta_contract.blocker_info_of_class
+                  ~detail:persisted_blocker blocker_class);
       })
     meta_after_triage
 
@@ -761,10 +762,13 @@ let run_keepalive_unified_turn
           if meta_after_triage.paused
           then
             let blocker_str =
-              let trimmed =
-                String.trim meta_after_triage.runtime.last_blocker
-              in
-              if String.equal trimmed "" then "unknown" else trimmed
+              match meta_after_triage.runtime.last_blocker with
+              | Some info ->
+                let trimmed = String.trim info.detail in
+                if String.equal trimmed "" then
+                  Keeper_types.blocker_class_to_string info.klass
+                else trimmed
+              | None -> "unknown"
             in
             let paused_since_sec =
               match
@@ -947,8 +951,10 @@ let run_keepalive_unified_turn
             Keeper_types.map_runtime
               (fun rt ->
                 { rt with
-                  last_blocker = blocker_text;
-                  last_blocker_class = Some Keeper_types.Admission_wait_wfq;
+                  last_blocker =
+                    Some (Keeper_meta_contract.blocker_info_of_class
+                            ~detail:blocker_text
+                            Keeper_types.Admission_wait_wfq);
                 })
               meta_after_triage
         | Keeper_admission_runtime.Live_surface reason ->
@@ -967,8 +973,10 @@ let run_keepalive_unified_turn
             Keeper_types.map_runtime
               (fun rt ->
                 { rt with
-                  last_blocker = reason_str;
-                  last_blocker_class = Some Keeper_types.Admission_surface;
+                  last_blocker =
+                    Some (Keeper_meta_contract.blocker_info_of_class
+                            ~detail:reason_str
+                            Keeper_types.Admission_surface);
                 })
               meta_after_triage
         | Keeper_admission_runtime.Live_dispatch { candidate; drift; bucket } ->

--- a/lib/keeper/keeper_meta_contract.ml
+++ b/lib/keeper/keeper_meta_contract.ml
@@ -204,6 +204,70 @@ let cascade_exhaustion_reason_of_json = function
   | _ -> None
 ;;
 
+(* ── Unified blocker_info: typed klass + free-form detail ───────
+   Replaces the historic [last_blocker: string] +
+   [last_blocker_class: blocker_class option] pair.  The string-only
+   field was used by [blocker_class_of_string] (substring classifier)
+   to recover a typed class — exactly the workaround pattern called
+   out in CLAUDE.md "워크어라운드 거부 기준 #2 String/Substring
+   분류기 보강".  Making [blocker_class] the only authoritative class
+   eliminates that recovery path; [detail] carries free-form context
+   for UI / Prometheus labels (no classification semantics). *)
+type blocker_info = {
+  klass : blocker_class;
+  detail : string;
+}
+
+let blocker_info_of_class ?(detail = "") klass = { klass; detail }
+
+let blocker_info_to_json (info : blocker_info) : Yojson.Safe.t =
+  let klass_payload = match info.klass with
+    | Cascade_exhausted reason ->
+      `Assoc [ "name", `String "cascade_exhausted"
+             ; "reason", cascade_exhaustion_reason_to_json reason
+             ]
+    | _ -> `String (blocker_class_to_string info.klass)
+  in
+  `Assoc
+    [ "klass", klass_payload
+    ; "detail", `String info.detail
+    ]
+;;
+
+let blocker_info_of_json (json : Yojson.Safe.t) : blocker_info option =
+  match json with
+  | `Null -> None
+  | `Assoc fields ->
+    let klass =
+      match List.assoc_opt "klass" fields with
+      | Some (`String s) -> blocker_class_of_serialized_string s
+      | Some (`Assoc kfields) ->
+        (match List.assoc_opt "name" kfields with
+         | Some (`String "cascade_exhausted") ->
+           let reason =
+             match List.assoc_opt "reason" kfields with
+             | Some r ->
+               (match cascade_exhaustion_reason_of_json r with
+                | Some r -> r
+                | None -> Other_detail "cascade_exhausted")
+             | None -> Other_detail "cascade_exhausted"
+           in
+           Some (Cascade_exhausted reason)
+         | Some (`String s) -> blocker_class_of_serialized_string s
+         | _ -> None)
+      | _ -> None
+    in
+    (match klass with
+     | None -> None
+     | Some klass ->
+       let detail = match List.assoc_opt "detail" fields with
+         | Some (`String s) -> s
+         | _ -> ""
+       in
+       Some { klass; detail })
+  | _ -> None
+;;
+
 type usage_metrics =
   { total_turns : int
   ; total_input_tokens : int

--- a/lib/keeper/keeper_meta_contract.ml
+++ b/lib/keeper/keeper_meta_contract.ml
@@ -304,8 +304,7 @@ type agent_runtime_state =
   ; last_social_transition_reason : string
   ; last_active_desire : string
   ; last_current_intention : string
-  ; last_blocker : string
-  ; last_blocker_class : blocker_class option
+  ; last_blocker : blocker_info option
   ; last_need : string
   }
 

--- a/lib/keeper/keeper_meta_contract.mli
+++ b/lib/keeper/keeper_meta_contract.mli
@@ -238,8 +238,7 @@ type agent_runtime_state = {
   last_social_transition_reason : string;
   last_active_desire : string;
   last_current_intention : string;
-  last_blocker : string;
-  last_blocker_class : blocker_class option;
+  last_blocker : blocker_info option;
   last_need : string;
 }
 

--- a/lib/keeper/keeper_meta_contract.mli
+++ b/lib/keeper/keeper_meta_contract.mli
@@ -185,6 +185,35 @@ val blocker_class_of_serialized_string :
     {!Keeper_meta_json_parse} to decode persisted blocker
     state. *)
 
+(** {1 Unified blocker_info} *)
+
+type blocker_info = {
+  klass : blocker_class;
+  detail : string;
+}
+(** Authoritative blocker representation: a typed [blocker_class]
+    paired with optional free-form [detail] (UI / Prometheus label).
+    Replaces the deprecated [last_blocker: string] +
+    [last_blocker_class: blocker_class option] pair so substring
+    classification (the [blocker_class_of_string] workaround) is
+    no longer load-bearing.  When there is no blocker, the runtime
+    state holds [None]; when there is a blocker, [klass] is always
+    populated and [detail] may be ["" ]. *)
+
+val blocker_info_of_class : ?detail:string -> blocker_class -> blocker_info
+(** [blocker_info_of_class ?detail klass] constructs a [blocker_info]
+    for [klass].  [detail] defaults to [""]. *)
+
+val blocker_info_to_json : blocker_info -> Yojson.Safe.t
+(** Round-trippable JSON encoding.  [Cascade_exhausted reason] uses
+    a structured object so the inner [cascade_exhaustion_reason] is
+    preserved across read/write cycles. *)
+
+val blocker_info_of_json : Yojson.Safe.t -> blocker_info option
+(** Parses the JSON shape emitted by {!blocker_info_to_json}.
+    Returns [None] for [`Null] or any value whose [klass] field is
+    absent / not recognisable. *)
+
 (** {1 Agent runtime state record} *)
 
 type agent_runtime_state = {

--- a/lib/keeper/keeper_meta_json.ml
+++ b/lib/keeper/keeper_meta_json.ml
@@ -121,10 +121,9 @@ let meta_to_json (m : keeper_meta) : Yojson.Safe.t =
     ; "last_social_transition_reason", `String rt.last_social_transition_reason
     ; "last_active_desire", `String rt.last_active_desire
     ; "last_current_intention", `String rt.last_current_intention
-    ; "last_blocker", `String rt.last_blocker
-    ; ( "last_blocker_class"
-      , match rt.last_blocker_class with
-        | Some bc -> `String (blocker_class_to_string bc)
+    ; ( "last_blocker"
+      , match rt.last_blocker with
+        | Some info -> blocker_info_to_json info
         | None -> `Null )
     ; "last_need", `String rt.last_need
     ; "paused", `Bool m.paused
@@ -244,7 +243,6 @@ let fallback_canonical_keeper_meta_key_names =
   ; "last_active_desire"
   ; "last_current_intention"
   ; "last_blocker"
-  ; "last_blocker_class"
   ; "last_need"
   ; "paused"
   ; "auto_resume_after_sec"
@@ -293,13 +291,24 @@ let canonical_keeper_meta_key_names =
     fallback_canonical_keeper_meta_key_names
 ;;
 
+(* Keys that the writer no longer emits but legacy on-disk JSON may
+   still carry.  The reader handles them (one-shot migration); we
+   suppress the unknown-keys warning so legacy reads stay quiet on
+   the way to first re-write. *)
+let deprecated_keeper_meta_key_names =
+  [ "last_blocker_class"
+  ]
+
 let warn_unknown_keeper_meta_keys ~path (json : Yojson.Safe.t) =
   match json with
   | `Assoc fields ->
     let unknown =
       fields
       |> List.filter_map (fun (key, _) ->
-        if List.mem key canonical_keeper_meta_key_names then None else Some key)
+        if List.mem key canonical_keeper_meta_key_names
+           || List.mem key deprecated_keeper_meta_key_names
+        then None
+        else Some key)
       |> dedupe_keep_order
     in
     (match unknown with

--- a/lib/keeper/keeper_meta_json_parse.ml
+++ b/lib/keeper/keeper_meta_json_parse.ml
@@ -484,14 +484,28 @@ let parse_keeper_state
      masc_oas_error_max_chars and falls through to the narrative
      budget for plain text. Symmetric with the write side in
      Keeper_social_model_types.cap_social_state. *)
+  (* New format: last_blocker is a structured object (blocker_info_to_json
+     output) or `Null.  Legacy format had two fields: last_blocker:string
+     and last_blocker_class:string|null.  We accept both shapes for one-shot
+     read migration; the next write upgrades to the new format. *)
   let last_blocker =
-    Keeper_social_model_types.cap_blocker
-      (Safe_ops.json_string ~default:"" "last_blocker" json)
-  in
-  let last_blocker_class =
-    match Safe_ops.json_string_opt "last_blocker_class" json with
-    | Some raw -> blocker_class_of_serialized_string raw
-    | None -> None
+    let raw_field = Yojson.Safe.Util.member "last_blocker" json in
+    match raw_field with
+    | `Null -> None
+    | `Assoc _ -> blocker_info_of_json raw_field
+    | `String legacy_text ->
+      let detail =
+        Keeper_social_model_types.cap_blocker (String.trim legacy_text)
+      in
+      let klass_from_pair =
+        match Safe_ops.json_string_opt "last_blocker_class" json with
+        | Some raw -> blocker_class_of_serialized_string raw
+        | None -> None
+      in
+      (match klass_from_pair with
+       | Some klass -> Some { klass; detail }
+       | None -> None)
+    | _ -> None
   in
   let last_need = cap_loaded (Safe_ops.json_string ~default:"" "last_need" json) in
   let ps_paused = Safe_ops.json_bool ~default:false "paused" json in
@@ -538,7 +552,6 @@ let parse_keeper_state
       ; last_active_desire
       ; last_current_intention
       ; last_blocker
-      ; last_blocker_class
       ; last_need
       }
   }

--- a/lib/keeper/keeper_rollover.ml
+++ b/lib/keeper/keeper_rollover.ml
@@ -198,7 +198,10 @@ let maybe_rollover_oas_handoff
           ~ratio
           ~handoff_threshold:base_meta.handoff_threshold
           ~last_outcome:base_meta.runtime.proactive_rt.last_outcome
-          ~last_blocker:base_meta.runtime.last_blocker
+          ~last_blocker:
+            (match base_meta.runtime.last_blocker with
+             | Some info -> info.detail
+             | None -> "")
           ~current_turn_overflow_blocker
           ()
       in

--- a/lib/keeper/keeper_social_model.ml
+++ b/lib/keeper/keeper_social_model.ml
@@ -101,7 +101,11 @@ let previous_state_of_meta (meta : Keeper_types.keeper_meta) =
   in
   let active_desire = nonempty_opt runtime.last_active_desire in
   let current_intention = nonempty_opt runtime.last_current_intention in
-  let blocker = nonempty_opt runtime.last_blocker in
+  let blocker =
+    match runtime.last_blocker with
+    | Some info -> nonempty_opt info.detail
+    | None -> None
+  in
   let need = nonempty_opt runtime.last_need in
   match speech_act, active_desire, current_intention, blocker, need with
   | None, None, None, None, None -> None

--- a/lib/keeper/keeper_stale_watchdog.ml
+++ b/lib/keeper/keeper_stale_watchdog.ml
@@ -337,8 +337,9 @@ let stamp_stale_fleet_batch_meta ~config ~keeper_name ~distinct_count
       { entry.meta with
         runtime =
           { entry.meta.runtime with
-            last_blocker = blocker;
-            last_blocker_class = Some Stale_fleet_batch;
+            last_blocker =
+              Some (blocker_info_of_class
+                      ~detail:blocker Stale_fleet_batch);
           };
       }
     in

--- a/lib/keeper/keeper_status_bridge.ml
+++ b/lib/keeper/keeper_status_bridge.ml
@@ -597,12 +597,11 @@ let proactive_runtime_reason_is_current (meta : keeper_meta) =
 let runtime_blocker_surface_opt (config : Coord_utils.config)
     (meta : keeper_meta) =
   let derived =
-    match meta.runtime.last_blocker_class with
-    | Some cls ->
+    match meta.runtime.last_blocker with
+    | Some info ->
         Some (runtime_blocker_surface_of_typed_class
-                ~summary:meta.runtime.last_blocker cls)
+                ~summary:info.detail info.klass)
     | None ->
-        (* Fallback: legacy string-based classification *)
         match runtime_registry_entry config meta.name with
         | Some entry -> (
             match entry.last_failure_reason with
@@ -613,19 +612,19 @@ let runtime_blocker_surface_opt (config : Coord_utils.config)
   let derived =
     match derived with
     | Some blocker -> Some blocker
-    | None -> (
-        match blocker_class_of_string meta.runtime.last_blocker with
-        | Some cls ->
-            Some (runtime_blocker_surface_of_legacy_string
-                    meta.runtime.last_blocker cls)
-        | None
-          when proactive_runtime_reason_is_current meta ->
-            (match blocker_class_of_string meta.runtime.proactive_rt.last_reason with
-             | Some cls ->
-                 Some (runtime_blocker_surface_of_legacy_string
-                         meta.runtime.proactive_rt.last_reason cls)
-             | None -> None)
-        | None -> runtime_blocker_surface_of_progress_narrative config meta)
+    | None
+      when proactive_runtime_reason_is_current meta ->
+        (* proactive_rt.last_reason is a separate string-source from
+           cycle outcomes; the substring matcher remains here as a
+           legacy recovery path for that source only.  The keeper
+           runtime blocker has already moved to typed [blocker_info]. *)
+        (match blocker_class_of_string meta.runtime.proactive_rt.last_reason with
+         | Some cls ->
+             Some (runtime_blocker_surface_of_legacy_string
+                     meta.runtime.proactive_rt.last_reason cls)
+         | None -> runtime_blocker_surface_of_progress_narrative config meta)
+    | None ->
+        runtime_blocker_surface_of_progress_narrative config meta
   in
   derived
 
@@ -786,7 +785,11 @@ let social_runtime_fields_json (meta : keeper_meta) =
         Json_util.string_opt_to_json delivery_surface_view_source );
       ( "last_social_transition_reason",
         trimmed_string_json meta.runtime.last_social_transition_reason );
-      ("last_blocker", trimmed_string_json meta.runtime.last_blocker);
+      ( "last_blocker"
+      , match meta.runtime.last_blocker with
+        | Some info ->
+            blocker_info_to_json info
+        | None -> `Null );
       ("last_need", trimmed_string_json meta.runtime.last_need);
     ]
 

--- a/lib/keeper/keeper_status_detail.ml
+++ b/lib/keeper/keeper_status_detail.ml
@@ -1160,9 +1160,9 @@ let handle_keeper_status ctx args : tool_result =
                then `Null
                else `String m.runtime.last_social_transition_reason);
              ("last_blocker",
-               if String.trim m.runtime.last_blocker = ""
-               then `Null
-               else `String m.runtime.last_blocker);
+               match m.runtime.last_blocker with
+               | Some info -> Keeper_types.blocker_info_to_json info
+               | None -> `Null);
              ("last_need",
                if String.trim m.runtime.last_need = ""
                then `Null

--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -111,13 +111,9 @@ let is_stale_paused_meta ~now ~paused_ttl_sec (meta : keeper_meta) =
 
 let paused_meta_requires_reconcile_recovery (meta : keeper_meta) =
   meta.paused
-  && (match meta.runtime.last_blocker_class with
-      | Some cls -> blocker_class_continue_gate cls
-      | None ->
-          (match Keeper_status_bridge.blocker_class_of_string
-                  meta.runtime.last_blocker with
-           | Some cls -> blocker_class_continue_gate cls
-           | None -> false))
+  && (match meta.runtime.last_blocker with
+      | Some info -> blocker_class_continue_gate info.klass
+      | None -> false)
 
 let committed_tools_of_ambiguous_blocker (blocker : string) =
   let trimmed = String.trim blocker in
@@ -412,8 +408,8 @@ let launch_supervised_fiber ~proactive_warmup_sec ctx (meta : keeper_meta)
               Keeper_registry.set_failure_reason ~base_path meta.name
                 (Some Keeper_registry.Fiber_unresolved);
               (* 2026-05-05 fleet-stuck cycle: keeper meta runtime
-                 [last_blocker]/[last_blocker_class] stayed null for 5+ hours
-                 while supervisor self-preservation suppressed restarts under
+                 [last_blocker] stayed null for 5+ hours while supervisor
+                 self-preservation suppressed restarts under
                  [cohort=fiber_unresolved].  The diagnosis was buried in the
                  crash registry but invisible on the per-keeper meta surface
                  dashboards read.  Stamp the same cohort onto runtime so
@@ -426,8 +422,9 @@ let launch_supervised_fiber ~proactive_warmup_sec ctx (meta : keeper_meta)
                    { entry.meta with
                      runtime =
                        { entry.meta.runtime with
-                         last_blocker = "fiber_unresolved";
-                         last_blocker_class = Some Fiber_unresolved;
+                         last_blocker =
+                           Some (blocker_info_of_class
+                                   ~detail:"fiber_unresolved" Fiber_unresolved);
                        };
                    }
                  in
@@ -606,8 +603,7 @@ let resume_keeper_after_reconcile_gate (ctx : _ context) (meta : keeper_meta) =
       runtime =
         {
           latest_meta.runtime with
-          last_blocker = "";
-          last_blocker_class = None;
+          last_blocker = None;
         };
     }
   in
@@ -660,24 +656,22 @@ let resume_keeper_after_reconcile_gate (ctx : _ context) (meta : keeper_meta) =
   | None -> supervise_keepalive ~proactive_warmup_sec:0 ctx resumed_meta
 
 let restore_reconcile_continue_gate (ctx : _ context) (meta : keeper_meta) =
-  let blocker = String.trim meta.runtime.last_blocker in
-  let committed_tools = committed_tools_of_ambiguous_blocker blocker in
+  let blocker_detail, blocker_klass =
+    match meta.runtime.last_blocker with
+    | Some info -> String.trim info.detail, Some info.klass
+    | None -> "", None
+  in
+  let committed_tools = committed_tools_of_ambiguous_blocker blocker_detail in
   let failure_reason =
-    match meta.runtime.last_blocker_class with
+    match blocker_klass with
     | Some Ambiguous_post_commit_timeout ->
         "ambiguous_partial_commit(post_commit_timeout)"
     | Some Ambiguous_post_commit_failure ->
         "ambiguous_partial_commit(post_commit_failure)"
-    | None ->
-        (match Keeper_status_bridge.blocker_class_of_string blocker with
-         | Some Ambiguous_post_commit_timeout ->
-             "ambiguous_partial_commit(post_commit_timeout)"
-         | Some Ambiguous_post_commit_failure ->
-             "ambiguous_partial_commit(post_commit_failure)"
-         | Some _ -> "ambiguous_partial_commit(post_commit_failure)"
-         | None -> "ambiguous_partial_commit(post_commit_failure)")
-    | Some _ -> "ambiguous_partial_commit(post_commit_failure)"
+    | Some _ | None ->
+        "ambiguous_partial_commit(post_commit_failure)"
   in
+  let blocker = blocker_detail in
   let input =
     `Assoc
       [
@@ -1112,12 +1106,25 @@ let handle_crash_auto_pause (ctx : _ context)
            meta.auto_resume_after_sec
        in
        let blocker_text =
-         let existing = String.trim meta.runtime.last_blocker in
+         let existing =
+           match meta.runtime.last_blocker with
+           | Some info -> String.trim info.detail
+           | None -> ""
+         in
          if existing <> "" then existing
          else
            match blocker_class with
            | Some cls -> blocker_class_to_string cls
            | None -> reason_tag
+       in
+       let blocker_info_opt =
+         match blocker_class with
+         | Some klass -> Some (blocker_info_of_class ~detail:blocker_text klass)
+         | None ->
+           (* No typed class available — preserve pre-existing typed
+              info if any, otherwise drop the slot.  We refuse to
+              silently fabricate a klass from [reason_tag]. *)
+           meta.runtime.last_blocker
        in
        (* Task-138 §"Max no-task-progress 30min = release claimed":
           when the supervisor pauses a keeper because the same blocker
@@ -1127,14 +1134,13 @@ let handle_crash_auto_pause (ctx : _ context)
           up while this keeper sits in [paused=true] back-off.
 
           Without this release the diagnostic state is "executor.json:
-          current_task_id=task-147, paused=true, last_blocker_class=
+          current_task_id=task-147, paused=true, last_blocker.klass=
           oas_timeout_budget" — task is stuck forever because (a) this
           keeper cannot run while paused and (b) other keepers see the
           claim and skip.  The released task ID is not separately audited
-          here; [last_blocker_class] + [last_blocker] in [runtime] already
-          carry the pause reason, and Prometheus
-          [keeper_paused_total] is incremented below.
-          Discovered 2026-05-05 fleet-stuck. *)
+          here; [last_blocker] in [runtime] already carries the pause
+          reason, and Prometheus [keeper_paused_total] is incremented
+          below.  Discovered 2026-05-05 fleet-stuck. *)
        (match
           write_meta_with_merge
             ~merge:Keeper_meta_merge.heartbeat_fields_from_disk
@@ -1146,8 +1152,7 @@ let handle_crash_auto_pause (ctx : _ context)
               current_task_id = None;
               runtime =
                 { meta.runtime with
-                  last_blocker = blocker_text;
-                  last_blocker_class = blocker_class;
+                  last_blocker = blocker_info_opt;
                 };
             }
         with
@@ -1369,8 +1374,8 @@ let sweep_and_recover (ctx : _ context) =
             { current.meta with
               runtime =
                 { current.meta.runtime with
-                  last_blocker = msg;
-                  last_blocker_class = Some bc;
+                  last_blocker =
+                    Some (blocker_info_of_class ~detail:msg bc);
                 };
             }
           in
@@ -1701,8 +1706,7 @@ let sweep_and_recover (ctx : _ context) =
                        updated_at = now_iso ();
                        runtime =
                          { meta.runtime with
-                           last_blocker = "";
-                           last_blocker_class = None;
+                           last_blocker = None;
                          };
                      }
                    in
@@ -1893,8 +1897,7 @@ let liveness_recovery_scan (ctx : _ context) =
                      updated_at = now_iso ();
                      runtime =
                        { meta.runtime with
-                         last_blocker = "";
-                         last_blocker_class = None;
+                         last_blocker = None;
                        };
                    }
                  in

--- a/lib/keeper/keeper_turn_up_create.ml
+++ b/lib/keeper/keeper_turn_up_create.ml
@@ -570,8 +570,7 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
           last_social_transition_reason = "";
           last_active_desire = "";
           last_current_intention = "";
-          last_blocker = "";
-          last_blocker_class = None;
+          last_blocker = None;
           last_need = "";
         };
       keeper_id = None;

--- a/lib/keeper/keeper_turn_up_update.ml
+++ b/lib/keeper/keeper_turn_up_update.ml
@@ -30,12 +30,9 @@ let resolve_active_goal_ids config p old_ids =
              (String.concat ", " missing))
 
 let blocker_requires_continue_gate (old : keeper_meta) =
-  match old.runtime.last_blocker_class with
-  | Some cls -> blocker_class_continue_gate cls
-  | None -> (
-      match Keeper_status_bridge.blocker_class_of_string old.runtime.last_blocker with
-      | Some cls -> blocker_class_continue_gate cls
-      | None -> false)
+  match old.runtime.last_blocker with
+  | Some info -> blocker_class_continue_gate info.klass
+  | None -> false
 
 let paused_state_requires_approval (old : keeper_meta) =
   Keeper_approval_queue.has_pending_for_keeper ~keeper_name:old.name
@@ -211,10 +208,10 @@ let update_keeper (ctx : _ context) (p : parsed_args) (old : keeper_meta) : tool
     old.paused && not (paused_state_requires_approval old)
   in
   if resume_paused_keeper then (
-    let blocker_class =
-      old.runtime.last_blocker_class
-      |> Option.map blocker_class_to_string
-      |> Option.value ~default:"none"
+    let blocker_class, blocker_detail =
+      match old.runtime.last_blocker with
+      | Some info -> blocker_class_to_string info.klass, info.detail
+      | None -> "none", ""
     in
     let auto_resume_after_sec =
       old.auto_resume_after_sec
@@ -223,8 +220,8 @@ let update_keeper (ctx : _ context) (p : parsed_args) (old : keeper_meta) : tool
     in
     Log.Keeper.warn
       "update_keeper resumed paused keeper %s; clearing \
-       auto_resume_after_sec=%s last_blocker_class=%s last_blocker=%S"
-      old.name auto_resume_after_sec blocker_class old.runtime.last_blocker);
+       auto_resume_after_sec=%s last_blocker.klass=%s last_blocker.detail=%S"
+      old.name auto_resume_after_sec blocker_class blocker_detail);
   if old.paused && not resume_paused_keeper then
     Log.Keeper.warn
       "update_keeper kept %s paused because an approval/reconcile gate is pending"
@@ -276,8 +273,7 @@ let update_keeper (ctx : _ context) (p : parsed_args) (old : keeper_meta) : tool
       (if resume_paused_keeper then
          {
            old.runtime with
-           last_blocker = "";
-           last_blocker_class = None;
+           last_blocker = None;
          }
        else old.runtime);
     voice_enabled =

--- a/lib/keeper/keeper_types.mli
+++ b/lib/keeper/keeper_types.mli
@@ -148,8 +148,12 @@ type usage_metrics = {
 
 (** {1 Agent runtime state} *)
 
-(** Structured blocker classification — replaces string-based error matching. *)
-type cascade_exhaustion_reason =
+(** Structured blocker classification — replaces string-based error matching.
+    These are re-exports of the canonical types from [Keeper_meta_contract];
+    the [=] type equations make sure values flow without coercion across the
+    facade boundary (so callers may freely mix [Keeper_types.blocker_class]
+    and [Keeper_meta_contract.blocker_class]). *)
+type cascade_exhaustion_reason = Keeper_meta_contract.cascade_exhaustion_reason =
   | Connection_refused
   | No_providers_available
   | All_providers_failed
@@ -157,7 +161,7 @@ type cascade_exhaustion_reason =
   | Max_turns_exceeded
   | Other_detail of string
 
-type blocker_class =
+type blocker_class = Keeper_meta_contract.blocker_class =
   | Cascade_exhausted of cascade_exhaustion_reason
   | Ambiguous_post_commit_timeout
   | Ambiguous_post_commit_failure
@@ -183,8 +187,10 @@ val cascade_exhaustion_reason_of_json : Yojson.Safe.t -> cascade_exhaustion_reas
 (** Authoritative blocker representation: typed [klass] + free-form
     [detail].  Replaces the historic [last_blocker: string] +
     [last_blocker_class: blocker_class option] pair so substring
-    classification is no longer load-bearing. *)
-type blocker_info = {
+    classification is no longer load-bearing.  Re-exported via type
+    equation from [Keeper_meta_contract] so values flow without
+    coercion across the facade boundary. *)
+type blocker_info = Keeper_meta_contract.blocker_info = {
   klass : blocker_class;
   detail : string;
 }
@@ -215,8 +221,7 @@ type agent_runtime_state = {
   last_social_transition_reason: string;
   last_active_desire: string;
   last_current_intention: string;
-  last_blocker: string;
-  last_blocker_class: blocker_class option;
+  last_blocker: blocker_info option;
   last_need: string;
 }
 

--- a/lib/keeper/keeper_types.mli
+++ b/lib/keeper/keeper_types.mli
@@ -180,6 +180,19 @@ val blocker_class_continue_gate : blocker_class -> bool
 val cascade_exhaustion_reason_to_json : cascade_exhaustion_reason -> Yojson.Safe.t
 val cascade_exhaustion_reason_of_json : Yojson.Safe.t -> cascade_exhaustion_reason option
 
+(** Authoritative blocker representation: typed [klass] + free-form
+    [detail].  Replaces the historic [last_blocker: string] +
+    [last_blocker_class: blocker_class option] pair so substring
+    classification is no longer load-bearing. *)
+type blocker_info = {
+  klass : blocker_class;
+  detail : string;
+}
+
+val blocker_info_of_class : ?detail:string -> blocker_class -> blocker_info
+val blocker_info_to_json : blocker_info -> Yojson.Safe.t
+val blocker_info_of_json : Yojson.Safe.t -> blocker_info option
+
 type agent_runtime_state = {
   usage: usage_metrics;
   compaction_rt: compaction_runtime;

--- a/lib/keeper/keeper_unified_metrics.ml
+++ b/lib/keeper/keeper_unified_metrics.ml
@@ -1293,8 +1293,7 @@ let update_metrics_from_result (meta : keeper_meta) ~(latency_ms : int)
          dashboard into showing BLOCKED status.  The social model's
          blocker field is a protocol-level signal; runtime last_blocker
          tracks whether the keeper can make progress. *)
-      last_blocker = "";
-      last_blocker_class = None;
+      last_blocker = None;
       last_need = Option.value ~default:"" social_state.need;
     };
   } in
@@ -1734,14 +1733,26 @@ let update_metrics_from_failure (meta : keeper_meta) ~(latency_ms : int)
              Option.value ~default:"" state.current_intention
          | None -> meta.runtime.last_current_intention);
       last_blocker =
-        (match social_state with
-         | Some (state : Social.social_state) ->
-             Option.value ~default:"" state.blocker
-         | None -> short_preview public_reason);
-      last_blocker_class =
+        (* Merge: typed klass from sdk_error becomes authoritative;
+           detail picks up the social-state blocker text or a public-
+           reason preview as observability context.  When the SDK
+           error carries no typed mapping we refuse to fabricate a
+           class — the previous string-only stamp is the substring
+           anti-pattern this refactor closes (CLAUDE.md
+           "워크어라운드 거부 기준 #2"). *)
         (match sdk_error with
          | Some err ->
-             Keeper_status_bridge.blocker_class_of_sdk_error err
+             (match Keeper_status_bridge.blocker_class_of_sdk_error err with
+              | Some klass ->
+                  let detail =
+                    match social_state with
+                    | Some (state : Social.social_state) ->
+                        Option.value ~default:"" state.blocker
+                    | None -> short_preview public_reason
+                  in
+                  Some (Keeper_meta_contract.blocker_info_of_class
+                          ~detail klass)
+              | None -> None)
          | None -> None);
       last_need =
         (match social_state with

--- a/lib/keeper/social_model/keeper_social_model_bdi_speech_v1.ml
+++ b/lib/keeper/social_model/keeper_social_model_bdi_speech_v1.ml
@@ -267,7 +267,12 @@ let should_dedupe_request_help ~(meta : keeper_meta) ~(blocker : string option) 
   match blocker with
   | None -> false
   | Some blocker ->
-      String.equal blocker (String.trim meta.runtime.last_blocker)
+      let last_blocker_detail =
+        match meta.runtime.last_blocker with
+        | Some info -> String.trim info.detail
+        | None -> ""
+      in
+      String.equal blocker last_blocker_detail
       && String.equal meta.runtime.last_speech_act "request_help"
       && meta.runtime.proactive_rt.last_ts > 0.0
       && Time_compat.now () -. meta.runtime.proactive_rt.last_ts

--- a/lib/operator/operator_control_snapshot.ml
+++ b/lib/operator/operator_control_snapshot.ml
@@ -952,10 +952,10 @@ let keepers_json ?keeper_names ?(include_recent_activity = false)
                          string_option_to_json
                            (let value = String.trim meta.runtime.proactive_rt.last_preview in
                             if value = "" then None else Some value));
-                       ("last_blocker",
-                         string_option_to_json
-                           (let value = String.trim meta.runtime.last_blocker in
-                            if value = "" then None else Some value));
+                       ( "last_blocker"
+                       , match meta.runtime.last_blocker with
+                         | Some info -> Keeper_types.blocker_info_to_json info
+                         | None -> `Null );
                        ("updated_at", `String meta.updated_at);
                        ("created_at", `String meta.created_at);
                        ("recent_activity",

--- a/lib/server/server_routes_http_routes_provider_runs.ml
+++ b/lib/server/server_routes_http_routes_provider_runs.ml
@@ -20,8 +20,13 @@ let o5_agent_board_inputs (config : Coord.config) =
        match Keeper_types.read_meta config name with
        | Ok (Some meta) ->
            let blocked_on =
-             let value = String.trim meta.runtime.last_blocker in
-             if value = "" then None else Some value
+             match meta.runtime.last_blocker with
+             | Some info ->
+               let value = String.trim info.detail in
+               if value = "" then
+                 Some (Keeper_types.blocker_class_to_string info.klass)
+               else Some value
+             | None -> None
            in
            Some {
              Agent_stress.agent = meta.name;

--- a/test/test_dashboard_goals.ml
+++ b/test/test_dashboard_goals.ml
@@ -910,8 +910,9 @@ let test_goal_detail_does_not_promote_synthetic_blocker_over_receipt () =
       runtime =
         {
           base.runtime with
-          last_blocker = "turn timed out";
-          last_blocker_class = Some Keeper_types.Turn_timeout;
+          last_blocker =
+            Some (Keeper_types.blocker_info_of_class
+                    ~detail:"turn timed out" Keeper_types.Turn_timeout);
         };
     }
   in
@@ -969,8 +970,9 @@ let test_goal_detail_promotes_newer_runtime_blocker_over_stale_receipt () =
               last_turn_ts = Unix.gettimeofday () +. 60.0;
             };
           last_blocker =
-            "Internal error: [masc_oas_error] {\"kind\":\"oas_timeout_budget\"}";
-          last_blocker_class = Some Keeper_types.Oas_timeout_budget;
+            Some (Keeper_types.blocker_info_of_class
+                    ~detail:"Internal error: [masc_oas_error] {\"kind\":\"oas_timeout_budget\"}"
+                    Keeper_types.Oas_timeout_budget);
         };
     }
   in
@@ -1035,8 +1037,9 @@ let test_goal_detail_keeps_decision_terminal_reason_over_newer_blocker () =
               last_turn_ts = Unix.gettimeofday () +. 60.0;
             };
           last_blocker =
-            "Internal error: [masc_oas_error] {\"kind\":\"oas_timeout_budget\"}";
-          last_blocker_class = Some Keeper_types.Oas_timeout_budget;
+            Some (Keeper_types.blocker_info_of_class
+                    ~detail:"Internal error: [masc_oas_error] {\"kind\":\"oas_timeout_budget\"}"
+                    Keeper_types.Oas_timeout_budget);
         };
     }
   in

--- a/test/test_keeper_auto_pause_blocker_persist_12683.ml
+++ b/test/test_keeper_auto_pause_blocker_persist_12683.ml
@@ -66,8 +66,9 @@ let test_meta_json_roundtrip_with_auto_pause_blocker () =
     paused = true;
     auto_resume_after_sec = Some 3600.0;
     runtime = { meta.runtime with
-      last_blocker = blocker_text;
-      last_blocker_class = Some KT.Oas_timeout_budget;
+      last_blocker =
+        Some (KT.blocker_info_of_class
+                ~detail:blocker_text KT.Oas_timeout_budget);
     };
   } in
   let json = KT.meta_to_json paused_meta in
@@ -78,10 +79,13 @@ let test_meta_json_roundtrip_with_auto_pause_blocker () =
   check bool "paused" true reparsed.paused;
   check (option (float 0.1)) "auto_resume_after_sec"
     (Some 3600.0) reparsed.auto_resume_after_sec;
-  check string "last_blocker preserved"
-    blocker_text reparsed.runtime.last_blocker;
-  check bool "last_blocker_class is Some"
-    true (Option.is_some reparsed.runtime.last_blocker_class)
+  (match reparsed.runtime.last_blocker with
+   | Some info ->
+     check string "last_blocker.detail preserved" blocker_text info.detail;
+     (match info.klass with
+      | KT.Oas_timeout_budget -> ()
+      | _ -> fail "blocker klass not Oas_timeout_budget after roundtrip")
+   | None -> fail "last_blocker should be Some after roundtrip")
 
 let test_meta_json_roundtrip_with_stale_storm_blocker () =
   let base_json = `Assoc [
@@ -101,8 +105,9 @@ let test_meta_json_roundtrip_with_stale_storm_blocker () =
     paused = true;
     auto_resume_after_sec = Some 7200.0;
     runtime = { meta.runtime with
-      last_blocker = blocker_text;
-      last_blocker_class = Some KT.Turn_timeout;
+      last_blocker =
+        Some (KT.blocker_info_of_class
+                ~detail:blocker_text KT.Turn_timeout);
     };
   } in
   let json = KT.meta_to_json paused_meta in
@@ -110,10 +115,13 @@ let test_meta_json_roundtrip_with_stale_storm_blocker () =
     | Ok m -> m
     | Error err -> fail ("roundtrip: " ^ err)
   in
-  check string "last_blocker"
-    blocker_text reparsed.runtime.last_blocker;
-  check bool "last_blocker_class is Some"
-    true (Option.is_some reparsed.runtime.last_blocker_class)
+  (match reparsed.runtime.last_blocker with
+   | Some info ->
+     check string "last_blocker.detail" blocker_text info.detail;
+     (match info.klass with
+      | KT.Turn_timeout -> ()
+      | _ -> fail "blocker klass not Turn_timeout after roundtrip")
+   | None -> fail "last_blocker should be Some after roundtrip")
 
 let () =
   run "keeper_auto_pause_blocker_persist_12683"

--- a/test/test_keeper_exec_status.ml
+++ b/test/test_keeper_exec_status.ml
@@ -495,7 +495,9 @@ let test_runtime_surface_derives_autonomous_slot_wait_timeout_from_meta () =
       runtime =
         {
           base.runtime with
-          last_blocker = reason;
+          last_blocker =
+            Some (KT.blocker_info_of_class ~detail:reason
+                    KT.Autonomous_slot_wait_timeout);
         };
     }
   in
@@ -525,7 +527,9 @@ let test_runtime_surface_derives_cascade_exhausted_from_meta () =
       runtime =
         {
           base.runtime with
-          last_blocker = reason;
+          last_blocker =
+            Some (KT.blocker_info_of_class ~detail:reason
+                    (KT.Cascade_exhausted KT.Connection_refused));
         };
     }
   in
@@ -574,8 +578,9 @@ let test_runtime_surface_names_no_tool_provider_details () =
       runtime =
         {
           base.runtime with
-          last_blocker = summary;
-          last_blocker_class = Some KT.No_tool_capable_provider;
+          last_blocker =
+            Some (KT.blocker_info_of_class ~detail:summary
+                    KT.No_tool_capable_provider);
         };
     }
   in
@@ -607,8 +612,10 @@ let test_runtime_surface_routes_oas_timeout_to_timeout_action () =
             {
               base.runtime with
               last_blocker =
-                "OAS budget timeout fired before the keeper hard timeout.";
-              last_blocker_class = Some KT.Oas_timeout_budget;
+                Some
+                  (KT.blocker_info_of_class
+                     ~detail:"OAS budget timeout fired before the keeper hard timeout."
+                     KT.Oas_timeout_budget);
             };
         }
       in
@@ -641,8 +648,10 @@ let test_runtime_surface_routes_paused_timeout_to_paused_action () =
             {
               base.runtime with
               last_blocker =
-                "OAS budget timeout fired before the keeper hard timeout.";
-              last_blocker_class = Some KT.Oas_timeout_budget;
+                Some
+                  (KT.blocker_info_of_class
+                     ~detail:"OAS budget timeout fired before the keeper hard timeout."
+                     KT.Oas_timeout_budget);
             };
         }
       in
@@ -674,9 +683,9 @@ let test_runtime_surface_exposes_redacted_resumable_cli_session_blocker () =
       runtime =
         {
           base.runtime with
-          last_blocker = reason;
-          last_blocker_class =
-            Some (KT.Cascade_exhausted (KT.Other_detail reason));
+          last_blocker =
+            Some (KT.blocker_info_of_class ~detail:reason
+                    (KT.Cascade_exhausted (KT.Other_detail reason)));
         };
     }
   in
@@ -754,7 +763,9 @@ let test_runtime_surface_derives_continue_gate_from_persisted_ambiguous_blocker 
       runtime =
         {
           base.runtime with
-          last_blocker = reason;
+          last_blocker =
+            Some (KT.blocker_info_of_class ~detail:reason
+                    KT.Ambiguous_post_commit_timeout);
         };
     }
   in
@@ -1005,8 +1016,10 @@ let test_runtime_surface_prefers_typed_blocker_over_progress_narrative () =
       runtime =
         {
           base.runtime with
-          last_blocker = "turn wall-clock timeout exceeded";
-          last_blocker_class = Some KT.Turn_timeout;
+          last_blocker =
+            Some (KT.blocker_info_of_class
+                    ~detail:"turn wall-clock timeout exceeded"
+                    KT.Turn_timeout);
         };
     }
   in
@@ -1030,7 +1043,7 @@ let test_runtime_surface_exposes_social_model_resolution_fields () =
             Masc_mcp.Keeper_social_model.speech_act_to_string
               Masc_mcp.Keeper_social_model.Stay_silent;
           last_social_transition_reason = "tool_only:stay_silent";
-          last_blocker = "waiting_for_delta";
+          last_blocker = None;
           last_need = "";
         };
     }

--- a/test/test_keeper_supervisor.ml
+++ b/test/test_keeper_supervisor.ml
@@ -480,7 +480,10 @@ let test_sweep_restores_reconcile_gate_for_paused_keeper () =
             {
               base.runtime with
               last_blocker =
-                "turn outcome ambiguous after committed mutating tool call(s): [keeper_board_cleanup]; retry disabled to avoid duplicate mutation; original_error=Completion contract [require_tool_use] violated";
+                Some
+                  (KT.blocker_info_of_class
+                     ~detail:"turn outcome ambiguous after committed mutating tool call(s): [keeper_board_cleanup]; retry disabled to avoid duplicate mutation; original_error=Completion contract [require_tool_use] violated"
+                     KT.Ambiguous_post_commit_timeout);
             };
         }
       in
@@ -529,7 +532,8 @@ let test_sweep_restores_reconcile_gate_for_paused_keeper () =
         | Error err -> fail err
       in
       check bool "paused cleared after approval" false resumed_meta.paused;
-      check string "blocker cleared after approval" "" resumed_meta.runtime.last_blocker;
+      check bool "blocker cleared after approval" true
+        (Option.is_none resumed_meta.runtime.last_blocker);
       check bool "keeper registered after approval" true
         (Reg.is_registered ~base_path:config.base_path meta.name))
 
@@ -932,8 +936,13 @@ let test_stale_fleet_batch_pause_skips_restart () =
        | Ok (Some m) ->
            check bool "meta.paused = true after fleet batch pause"
              true m.paused;
+           let blocker_detail =
+             match m.runtime.last_blocker with
+             | Some b -> b.detail
+             | None -> ""
+           in
            check string "last_blocker records fleet batch"
-             "stale_fleet_batch" m.runtime.last_blocker
+             "stale_fleet_batch" blocker_detail
        | Ok None -> fail "meta missing after fleet batch pause"
        | Error err -> fail ("read_meta failed: " ^ err));
       check bool "registry entry unregistered after fleet batch pause"
@@ -985,9 +994,13 @@ let test_stale_fleet_batch_latch_marks_batch_members () =
       (match KT.read_meta config "batch-provider" with
        | Ok (Some m) ->
            check bool "provider root cause remains in blocker text" true
-             (contains_substring m.runtime.last_blocker "provider_runtime_error");
+             (match m.runtime.last_blocker with
+              | Some b -> contains_substring b.detail "provider_runtime_error"
+              | None -> false);
            check bool "provider blocker class is fleet batch" true
-             (m.runtime.last_blocker_class = Some KT.Stale_fleet_batch)
+             (match m.runtime.last_blocker with
+              | Some b -> b.klass = KT.Stale_fleet_batch
+              | None -> false)
        | Ok None -> fail "batch-provider meta missing"
        | Error err -> fail ("read_meta failed: " ^ err)))
 
@@ -1095,7 +1108,10 @@ let test_unresolved_watchdog_stopped_budget_loop_is_reaped () =
            check bool "meta.paused = true after unresolved watchdog stop"
              true m.paused;
            check bool "budget loop blocker class preserved"
-             true (m.runtime.last_blocker_class = Some KT.Oas_timeout_budget)
+             true
+             (match m.runtime.last_blocker with
+              | Some b -> b.klass = KT.Oas_timeout_budget
+              | None -> false)
        | Ok None -> fail "meta missing after unresolved watchdog stop"
        | Error err -> fail ("read_meta failed: " ^ err));
       check bool "unresolved watchdog-stopped entry reaped"
@@ -1475,7 +1491,16 @@ let test_persisted_blocker_survives_unregister () =
       ignore (Masc_mcp.Coord.init config ~agent_name:(Some "supervisor"));
       let name = "auto-pause-blocker-keeper" in
       let meta = make_meta name in
-      let meta = { meta with runtime = { meta.runtime with last_blocker = "test-blocker"; last_blocker_class = Some KT.Turn_timeout } } in
+      let meta =
+        {
+          meta with
+          runtime =
+            {
+              meta.runtime with
+              last_blocker = Some (KT.blocker_info_of_class ~detail:"test-blocker" KT.Turn_timeout);
+            };
+        }
+      in
       (match KT.write_meta config meta with
        | Ok () -> ()
        | Error err -> fail err);
@@ -1493,8 +1518,11 @@ let test_persisted_blocker_survives_unregister () =
       (* Check if blocker is persisted *)
       (match KT.read_meta config name with
        | Ok (Some m) ->
-           check string "meta.runtime.last_blocker" "test-blocker" m.runtime.last_blocker;
-           check bool "meta.runtime.last_blocker_class" true (m.runtime.last_blocker_class = Some KT.Turn_timeout)
+           (match m.runtime.last_blocker with
+            | Some b ->
+                check string "meta.runtime.last_blocker" "test-blocker" b.detail;
+                check bool "meta.runtime.last_blocker_class" true (b.klass = KT.Turn_timeout)
+            | None -> fail "expected blocker after storm pause");
        | Ok None -> fail "meta missing after storm pause"
        | Error err -> fail ("read_meta failed: " ^ err));
       
@@ -1504,8 +1532,11 @@ let test_persisted_blocker_survives_unregister () =
       (* Read again and verify *)
       (match KT.read_meta config name with
        | Ok (Some m) ->
-           check string "meta.runtime.last_blocker after unregister" "test-blocker" m.runtime.last_blocker;
-           check bool "meta.runtime.last_blocker_class after unregister" true (m.runtime.last_blocker_class = Some KT.Turn_timeout)
+           (match m.runtime.last_blocker with
+            | Some b ->
+                check string "meta.runtime.last_blocker after unregister" "test-blocker" b.detail;
+                check bool "meta.runtime.last_blocker_class after unregister" true (b.klass = KT.Turn_timeout)
+            | None -> fail "expected blocker after unregister")
        | Ok None -> fail "meta missing after unregister"
        | Error err -> fail ("read_meta failed: " ^ err)))
 

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -5206,7 +5206,7 @@ let test_metrics_persist_social_state_fields () =
         updated.runtime.last_speech_act;
       check string "transition reason tracked" "headers:explicit_social_headers"
         updated.runtime.last_social_transition_reason;
-      check string "no blocker tracked" "" updated.runtime.last_blocker;
+      check bool "no blocker tracked" true (Option.is_none updated.runtime.last_blocker);
       check string "no need tracked" "" updated.runtime.last_need)
 
 let test_metrics_failure_response () =
@@ -5300,15 +5300,19 @@ let test_metrics_failure_response_redacts_resumable_cli_session_detail () =
   check string "last preview is redacted"
     canonical_detail
     updated.runtime.proactive_rt.last_preview;
-  check string "last blocker is redacted"
-    canonical_detail
-    updated.runtime.last_blocker;
+  let blocker_detail =
+    match updated.runtime.last_blocker with
+    | Some b -> b.detail
+    | None -> ""
+  in
+  check string "last blocker is redacted" canonical_detail blocker_detail;
   check bool "raw resume hint removed from last blocker" false
-    (contains_substring updated.runtime.last_blocker "To resume this session:");
+    (contains_substring blocker_detail "To resume this session:");
   check bool "raw session token removed from last reason" false
     (contains_substring updated.runtime.proactive_rt.last_reason "kimi -r");
-  match updated.runtime.last_blocker_class with
-  | Some (Keeper_types.Cascade_exhausted (Keeper_types.Other_detail detail)) ->
+  match updated.runtime.last_blocker with
+  | Some { klass = Keeper_types.Cascade_exhausted (Keeper_types.Other_detail detail); _ }
+    ->
       check string "blocker class detail preserved as canonical detail"
         canonical_detail detail
   | _ -> fail "expected resumable CLI session blocker class"
@@ -7129,7 +7133,11 @@ let test_social_model_previous_state_of_meta_restores_runtime_fields () =
           last_social_transition_reason = "headers:explicit_social_headers";
           last_active_desire = "seek_help";
           last_current_intention = "recover_tool_route";
-          last_blocker = "tool route unavailable";
+          last_blocker =
+            Some
+              (Keeper_types.blocker_info_of_class
+                 ~detail:"tool route unavailable"
+                 Keeper_types.No_tool_capable_provider);
           last_need = "operator guidance";
         };
     }
@@ -7351,7 +7359,11 @@ let test_social_model_previous_state_of_meta_falls_back_for_unknown_model () =
           last_speech_act = "request_help";
           last_active_desire = "seek_help";
           last_current_intention = "recover_tool_route";
-          last_blocker = "tool route unavailable";
+          last_blocker =
+            Some
+              (Keeper_types.blocker_info_of_class
+                 ~detail:"tool route unavailable"
+                 Keeper_types.No_tool_capable_provider);
           last_need = "operator guidance";
         };
     }

--- a/test/test_operator_control_keeper.ml
+++ b/test/test_operator_control_keeper.ml
@@ -1364,8 +1364,9 @@ let test_keeper_up_resumes_auto_paused_keeper () =
           runtime =
             {
               meta.runtime with
-              last_blocker = blocker_text;
-              last_blocker_class = Some Keeper_types.Turn_timeout;
+              last_blocker =
+                Some (Keeper_types.blocker_info_of_class
+                        ~detail:blocker_text Keeper_types.Turn_timeout);
             };
         }
       in
@@ -1390,10 +1391,8 @@ let test_keeper_up_resumes_auto_paused_keeper () =
       Alcotest.(check bool) "meta paused false" false resumed.paused;
       Alcotest.(check bool) "auto resume delay cleared" true
         (Option.is_none resumed.auto_resume_after_sec);
-      Alcotest.(check string) "runtime blocker cleared" ""
-        resumed.runtime.last_blocker;
-      Alcotest.(check bool) "runtime blocker class cleared" true
-        (Option.is_none resumed.runtime.last_blocker_class))
+      Alcotest.(check bool) "runtime blocker cleared" true
+        (Option.is_none resumed.runtime.last_blocker))
 
 let test_keeper_up_keeps_paused_keeper_with_continue_gate_blocker () =
   Eio_main.run @@ fun env ->
@@ -1436,8 +1435,15 @@ let test_keeper_up_keeps_paused_keeper_with_continue_gate_blocker () =
           runtime =
             {
               meta.runtime with
-              last_blocker = blocker_text;
-              last_blocker_class = None;
+              (* Pre-refactor this test stamped only [last_blocker = blocker_text]
+                 with [last_blocker_class = None] and relied on the substring
+                 [blocker_class_of_string] matcher to recover the typed class.
+                 After the unified [blocker_info] migration the typed class is
+                 the only authoritative source — set it directly. *)
+              last_blocker =
+                Some (Keeper_types.blocker_info_of_class
+                        ~detail:blocker_text
+                        Keeper_types.Ambiguous_post_commit_timeout);
             };
         }
       in
@@ -1462,8 +1468,10 @@ let test_keeper_up_keeps_paused_keeper_with_continue_gate_blocker () =
       Alcotest.(check bool) "meta remains paused" true still_paused.paused;
       Alcotest.(check bool) "auto resume delay preserved" true
         (Option.is_some still_paused.auto_resume_after_sec);
-      Alcotest.(check string) "runtime blocker preserved" blocker_text
-        still_paused.runtime.last_blocker)
+      (match still_paused.runtime.last_blocker with
+       | Some info ->
+         Alcotest.(check string) "runtime blocker preserved" blocker_text info.detail
+       | None -> Alcotest.fail "runtime blocker should be preserved"))
 
 let test_keeper_up_keeps_paused_keeper_with_pending_approval () =
   Eio_main.run @@ fun env ->
@@ -1511,8 +1519,9 @@ let test_keeper_up_keeps_paused_keeper_with_pending_approval () =
           runtime =
             {
               meta.runtime with
-              last_blocker = blocker_text;
-              last_blocker_class = Some Keeper_types.Turn_timeout;
+              last_blocker =
+                Some (Keeper_types.blocker_info_of_class
+                        ~detail:blocker_text Keeper_types.Turn_timeout);
             };
         }
       in
@@ -1549,8 +1558,10 @@ let test_keeper_up_keeps_paused_keeper_with_pending_approval () =
       Alcotest.(check bool) "meta remains paused" true still_paused.paused;
       Alcotest.(check bool) "auto resume delay preserved" true
         (Option.is_some still_paused.auto_resume_after_sec);
-      Alcotest.(check string) "runtime blocker preserved" blocker_text
-        still_paused.runtime.last_blocker)
+      (match still_paused.runtime.last_blocker with
+       | Some info ->
+         Alcotest.(check string) "runtime blocker preserved" blocker_text info.detail
+       | None -> Alcotest.fail "runtime blocker should be preserved"))
 
 let test_keeper_status_defaults_name_to_caller () =
   Eio_main.run @@ fun env ->

--- a/test/test_operator_control_snapshot.ml
+++ b/test/test_operator_control_snapshot.ml
@@ -399,9 +399,10 @@ let test_lightweight_snapshot_surfaces_paused_keeper_runtime_trust () =
             {
               meta.runtime with
               last_blocker =
-                "Completion contract [require_tool_use] violated: actionable keeper signal was present, but the model called no keeper tools";
-              last_blocker_class =
-                Some Keeper_types.Completion_contract_violation;
+                Some
+                  (Keeper_types.blocker_info_of_class
+                     ~detail:"Completion contract [require_tool_use] violated: actionable keeper signal was present, but the model called no keeper tools"
+                     Keeper_types.Completion_contract_violation);
             };
         }
       in


### PR DESCRIPTION
## Summary

Consolidates `agent_runtime_state.last_blocker: string` + `last_blocker_class: blocker_class option` into a single structured field `last_blocker: blocker_info option` where `blocker_info = { klass : blocker_class; detail : string }`.

This eliminates string-based substring classification of blocker errors and ensures the blocker class is always present when a blocker is set.

## Changes

- **Core types** (`keeper_meta_contract.mli/ml`, `keeper_types.mli`):
  - Remove `last_blocker_class` field from `agent_runtime_state`
  - Change `last_blocker` from `string` to `blocker_info option`
  - Re-export `blocker_info` via type equation for cross-facade compatibility

- **Lib call sites** (15 files):
  - Replace raw string assignments with `Some (blocker_info_of_class ~detail:... Klass)`
  - Replace `last_blocker_class` accesses with pattern matching on `last_blocker.klass`

- **Tests** (8 files):
  - Convert `check string "last_blocker" ...` to `match` on `Option.map` or `Option.is_none`
  - Convert `last_blocker_class` assertions to record pattern matches on `blocker_info`

- **Dashboard JSON** (`dashboard_safe_autonomy.ml`):
  - Remove redundant `last_blocker_class` serialization; `last_blocker` already outputs full `blocker_info`

- **Legacy migration** (`keeper_meta_json_parse.ml`):
  - Preserve one-shot read path: when `last_blocker` is a plain string, read optional `last_blocker_class` to construct `blocker_info`

## Pre-existing build errors (out of scope)

The following 3 test files have unrelated type errors on `main`:

- `test_keeper_sub_fsm_guards.ml:15` — `Turn_prompting` witness mismatch
- `test_keeper_fsm_joints.ml:205` — `Obs.cascade_state` vs `packed_cascade_state`
- `test_keeper_registry.ml:1360` — `R.Cascade_selecting` variant mismatch

## Verification

- `dune build --root . @check` passes except for the 3 pre-existing errors above.
- All `last_blocker`/`last_blocker_class` type mismatches resolved (28 files, +384/-233).

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>