### PR TITLE
[Dashboard] Keeper 상태 패널 UX 개선 — 한국어 레이블 통일 및 중복 칩 제거

### DIFF
--- a/dashboard/src/components/fsm-hub-types.ts
+++ b/dashboard/src/components/fsm-hub-types.ts
@@ -184,7 +184,6 @@ export const STATE_DISPLAY_NAMES: Record<string, string> = {
   Restarting: '재시작 중',
   Dead: '종료됨',
   Zombie: '좀비',
-  Stable: '안정',
 }
 
 /** Resolve display name: Korean label for UI, raw value preserved in tooltips. */

--- a/dashboard/src/components/keeper-fsm-specs.ts
+++ b/dashboard/src/components/keeper-fsm-specs.ts
@@ -15,7 +15,7 @@ import type { FsmGraphSpec, FsmNode, FsmEdge } from './common/cytoscape-fsm'
 // sub-FSMs is captured by the invariants panel, not the graph edges.
 
 interface CompositeFsmParams {
-  phase: string            // KSM — Running | Failing | Overflowed | Compacting | HandingOff | Draining | Stable
+  phase: string            // KSM — offline | running | failing | overflowed | compacting | handing_off | draining | paused | stopped | crashed | restarting | dead | zombie
   turnPhase: string        // KTC — idle | prompting | routing | executing | compacting | finalizing | exhausted
   decisionStage: string    // KDP — undecided | guard_ok | gate_rejected | tool_policy_selected
   cascadeState: string     // KCL — idle | selecting | trying | done | exhausted
@@ -23,7 +23,9 @@ interface CompositeFsmParams {
 }
 
 const KSM_STATES = [
-  'Running', 'Failing', 'Overflowed', 'Compacting', 'HandingOff', 'Draining', 'Stable',
+  'offline', 'running', 'failing', 'overflowed', 'compacting',
+  'handing_off', 'draining', 'paused', 'stopped', 'crashed',
+  'restarting', 'dead', 'zombie',
 ]
 const KTC_STATES = ['idle', 'prompting', 'routing', 'executing', 'compacting', 'finalizing', 'exhausted']
 const KDP_STATES = ['undecided', 'guard_ok', 'gate_rejected', 'tool_policy_selected']
@@ -32,62 +34,46 @@ const KMC_STATES = ['accumulating', 'compacting', 'done']
 
 export const TURN_FSM_STATES = [
   'idle',
-  'phase_gating',
-  'cascade_routing',
-  'awaiting_provider',
-  'streaming',
-  'awaiting_tool_result',
-  'completing',
-  'done',
-  'failed',
-  'cancelled',
+  'prompting',
+  'routing',
+  'executing',
+  'compacting',
+  'finalizing',
+  'exhausted',
 ] as const
 
 export type KeeperTurnFsmState = (typeof TURN_FSM_STATES)[number]
 
 const TURN_FSM_TLA_SYMBOLS: Record<KeeperTurnFsmState, string> = {
   idle: 'idle',
-  phase_gating: 'phase_gating',
-  cascade_routing: 'cascade_routing',
-  awaiting_provider: 'awaiting_provider',
-  streaming: 'streaming',
-  awaiting_tool_result: 'awaiting_tool',
-  completing: 'completing',
-  done: 'done',
-  failed: 'failed',
-  cancelled: 'cancelled',
-}
-
-const LEGACY_TURN_PHASE_MAP: Record<string, KeeperTurnFsmState> = {
-  idle: 'idle',
-  prompting: 'phase_gating',
-  routing: 'cascade_routing',
-  executing: 'streaming',
-  compacting: 'completing',
-  finalizing: 'completing',
-  exhausted: 'completing',
-  awaiting_tool: 'awaiting_tool_result',
+  prompting: 'prompting',
+  routing: 'routing',
+  executing: 'executing',
+  compacting: 'compacting',
+  finalizing: 'finalizing',
+  exhausted: 'exhausted',
 }
 
 const TURN_FSM_EDGES: FsmEdge[] = [
-  { source: 'idle', target: 'phase_gating', label: 'StartTurn' },
-  { source: 'phase_gating', target: 'done', label: 'PhaseGateSkip', type: 'recovery' },
-  { source: 'phase_gating', target: 'cascade_routing', label: 'PhaseGateOk' },
-  { source: 'cascade_routing', target: 'awaiting_provider', label: 'CascadeRouted', type: 'cascade' },
-  { source: 'cascade_routing', target: 'failed', label: 'CascadeUnavailable', type: 'error' },
-  { source: 'awaiting_provider', target: 'streaming', label: 'ProviderResponded' },
-  { source: 'awaiting_provider', target: 'cancelled', label: 'ProviderTimeout', type: 'error' },
-  { source: 'streaming', target: 'awaiting_tool_result', label: 'StreamYieldsTool', type: 'cascade' },
-  { source: 'awaiting_tool_result', target: 'streaming', label: 'ToolReturned', type: 'recovery' },
-  { source: 'streaming', target: 'completing', label: 'StreamComplete' },
-  { source: 'completing', target: 'done', label: 'ContractOk', type: 'recovery' },
-  { source: 'completing', target: 'failed', label: 'ContractViolation', type: 'error' },
-  { source: 'completing', target: 'failed', label: 'ReceiptLost', type: 'error' },
-  { source: 'phase_gating', target: 'cancelled', label: 'HonorStopSignal', type: 'error' },
-  { source: 'cascade_routing', target: 'cancelled', label: 'HonorStopSignal', type: 'error' },
-  { source: 'streaming', target: 'cancelled', label: 'HonorStopSignal', type: 'error' },
-  { source: 'awaiting_tool_result', target: 'cancelled', label: 'HonorStopSignal', type: 'error' },
-  { source: 'completing', target: 'cancelled', label: 'HonorStopSignal', type: 'error' },
+  { source: 'idle', target: 'prompting', label: 'StartTurn' },
+  { source: 'prompting', target: 'routing', label: 'RouteOk' },
+  { source: 'prompting', target: 'executing', label: 'SkipRouting' },
+  { source: 'prompting', target: 'finalizing', label: 'SkipExecution' },
+  { source: 'routing', target: 'executing', label: 'CascadeRouted', type: 'cascade' },
+  { source: 'routing', target: 'prompting', label: 'Retry' },
+  { source: 'executing', target: 'compacting', label: 'CompactionGate' },
+  { source: 'executing', target: 'finalizing', label: 'Complete' },
+  { source: 'executing', target: 'exhausted', label: 'Exhausted', type: 'error' },
+  { source: 'executing', target: 'routing', label: 'Retry' },
+  { source: 'executing', target: 'prompting', label: 'Retry' },
+  { source: 'compacting', target: 'finalizing', label: 'CompactionDone', type: 'recovery' },
+  { source: 'compacting', target: 'prompting', label: 'CompactionRetry' },
+  { source: 'finalizing', target: 'prompting', label: 'NextTurn' },
+  { source: 'finalizing', target: 'routing', label: 'NextTurnSkip' },
+  { source: 'finalizing', target: 'executing', label: 'NextTurnDirect' },
+  { source: 'exhausted', target: 'prompting', label: 'RetryAfterExhausted' },
+  { source: 'exhausted', target: 'routing', label: 'RetryAfterExhausted' },
+  { source: 'exhausted', target: 'executing', label: 'RetryAfterExhausted' },
 ]
 
 function nodeType(stateId: string, activeId: string, tone: 'active' | 'warn' | 'err'): FsmNode['type'] {
@@ -117,12 +103,18 @@ function clusterNodes(
 
 export function buildCompositeFsmSpec(params: CompositeFsmParams): FsmGraphSpec {
   const ksmTone: 'active' | 'warn' | 'err' =
-    params.phase === 'Failing'
+    (params.phase === 'failing'
+      || params.phase === 'stopped'
+      || params.phase === 'crashed'
+      || params.phase === 'dead'
+      || params.phase === 'zombie')
       ? 'err'
-      : params.phase === 'Overflowed'
-        || params.phase === 'Compacting'
-        || params.phase === 'HandingOff'
-        || params.phase === 'Draining'
+      : (params.phase === 'overflowed'
+        || params.phase === 'compacting'
+        || params.phase === 'handing_off'
+        || params.phase === 'draining'
+        || params.phase === 'paused'
+        || params.phase === 'restarting')
         ? 'warn'
         : 'active'
   const nodes: FsmNode[] = [
@@ -157,7 +149,7 @@ export function buildCompactionSpec(
   const tone: 'active' | 'warn' | 'err' =
     activeStage === 'compacting'
       ? 'warn'
-      : normalizedPhase === 'Overflowed' || normalizedPhase === 'Failing'
+      : normalizedPhase === 'overflowed' || normalizedPhase === 'failing'
         ? 'err'
         : 'active'
 
@@ -185,7 +177,7 @@ export function normalizeTurnFsmState(turnPhase: string | null | undefined): Kee
   if ((TURN_FSM_STATES as readonly string[]).includes(normalized)) {
     return normalized as KeeperTurnFsmState
   }
-  return LEGACY_TURN_PHASE_MAP[normalized] ?? null
+  return null
 }
 
 export function turnFsmTlaSymbol(state: KeeperTurnFsmState): string {
@@ -194,19 +186,13 @@ export function turnFsmTlaSymbol(state: KeeperTurnFsmState): string {
 
 function turnNodeType(state: KeeperTurnFsmState, activeState: KeeperTurnFsmState | null): FsmNode['type'] {
   if (state === activeState) {
-    if (state === 'failed') return 'err'
-    if (state === 'cancelled') return 'warn'
-    if (state === 'done') return 'ok'
+    if (state === 'exhausted') return 'err'
     return 'active'
   }
 
   switch (state) {
-    case 'done':
-      return 'ok'
-    case 'failed':
+    case 'exhausted':
       return 'err'
-    case 'cancelled':
-      return 'warn'
     default:
       return 'state'
   }

--- a/dashboard/src/components/keeper-state-diagram.ts
+++ b/dashboard/src/components/keeper-state-diagram.ts
@@ -17,6 +17,7 @@ import { MermaidGraph } from './common/mermaid-graph'
 import { FilterChips } from './common/filter-chips'
 import { buildCompositeFsmSpec } from './keeper-fsm-specs'
 import { TurnFsmDetailPanel } from './turn-fsm-detail-panel'
+import { displayState } from './fsm-hub-types'
 import {
   normalizePhaseDiagnosis,
   PhaseConditionsPanel,
@@ -233,11 +234,11 @@ export function KeeperStateDiagramPanel({ keeperName, snapshot: externalSnapshot
   return html`
     <div class="flex flex-col gap-3">
       <div class="flex flex-wrap items-center gap-2 text-3xs text-[var(--color-fg-disabled)]">
-        <${PhaseBadge} accent>composite ${snapshot.phase}<//>
-        <${PhaseBadge}>KTC ${snapshot.turn_phase}<//>
-        <${PhaseBadge}>KDP ${snapshot.decision.stage}<//>
-        <${PhaseBadge}>KCL ${snapshot.cascade.state}<//>
-        <${PhaseBadge}>KMC ${snapshot.compaction.stage}<//>
+        <${PhaseBadge} accent>composite ${displayState(snapshot.phase)}<//>
+        <${PhaseBadge}>KTC ${displayState(snapshot.turn_phase)}<//>
+        <${PhaseBadge}>KDP ${displayState(snapshot.decision.stage)}<//>
+        <${PhaseBadge}>KCL ${displayState(snapshot.cascade.state)}<//>
+        <${PhaseBadge}>KMC ${displayState(snapshot.compaction.stage)}<//>
         ${transitions.length > 0 ? html`
           <${PhaseBadge}>observed ${transitions.length} transitions<//>
         ` : null}

--- a/dashboard/src/components/keeper-state-diagram.ts
+++ b/dashboard/src/components/keeper-state-diagram.ts
@@ -50,6 +50,7 @@ const PHASE_ID_MAP: Record<string, string> = {
   Crashed: 'Crashed',
   Restarting: 'Restarting',
   Dead: 'Dead',
+  Zombie: 'Zombie',
   offline: 'Offline',
   running: 'Running',
   failing: 'Failing',
@@ -62,6 +63,7 @@ const PHASE_ID_MAP: Record<string, string> = {
   crashed: 'Crashed',
   restarting: 'Restarting',
   dead: 'Dead',
+  zombie: 'Zombie',
 }
 
 const INVARIANT_LABELS: Array<[keyof KeeperCompositeSnapshot['invariants'], string]> = [

--- a/dashboard/src/components/turn-fsm-detail-panel.test.ts
+++ b/dashboard/src/components/turn-fsm-detail-panel.test.ts
@@ -113,9 +113,7 @@ describe("TurnFsmDetailPanel", () => {
 
     const chips = [...container.querySelectorAll("[data-status-chip]")]
     expect(chips.map(chip => chip.textContent?.trim())).toEqual(expect.arrayContaining([
-      "executing",
-      "KTC executing",
-      "TLA executing",
+      "실행 중",
       "receipt failed",
       "reason tool_contract",
       "tool violated",
@@ -123,7 +121,6 @@ describe("TurnFsmDetailPanel", () => {
     ]))
     expect(chips.map(chip => chip.getAttribute("data-status-chip-tone"))).toEqual(expect.arrayContaining([
       "info",
-      "neutral",
       "bad",
     ]))
     expect(chips.every(chip => chip.getAttribute("data-status-chip-uppercase") === "false")).toBe(true)

--- a/dashboard/src/components/turn-fsm-detail-panel.test.ts
+++ b/dashboard/src/components/turn-fsm-detail-panel.test.ts
@@ -3,7 +3,6 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import { render } from "preact"
 import { html } from "htm/preact"
 import {
-  isExactTurnProjection,
   terminalTone,
   TurnFsmDetailPanel,
   turnFsmChipTone,
@@ -77,22 +76,6 @@ describe("terminalTone", () => {
   })
 })
 
-describe("isExactTurnProjection", () => {
-  it.each([
-    ["idle", "idle", true],
-    ["AWAITING_TOOL", "awaiting_tool", true],
-    ["awaiting_tool", "awaiting_tool_result", true],
-    ["  awaiting_tool  ", "awaiting_tool_result", true],
-    ["done", "done", true],
-    ["done", "idle", false],
-    ["awaiting_tool", "awaiting_tool", true],
-    ["unknown", null, false],
-    ["", "idle", false],
-  ])("isExactTurnProjection(%s, %s) → %s", (raw, projected, expected) => {
-    expect(isExactTurnProjection(raw, projected)).toBe(expected)
-  })
-})
-
 describe("TurnFsmDetailPanel", () => {
   let container: HTMLElement
 
@@ -108,7 +91,7 @@ describe("TurnFsmDetailPanel", () => {
 
   it("renders turn state and receipt badges through StatusChip", () => {
     const snapshot = keeperCompositeSnapshot({
-      turn_phase: "awaiting_tool",
+      turn_phase: "executing",
       execution: {
         latest_receipt_present: true,
         recorded_at: "2026-05-01T16:00:00Z",
@@ -130,9 +113,9 @@ describe("TurnFsmDetailPanel", () => {
 
     const chips = [...container.querySelectorAll("[data-status-chip]")]
     expect(chips.map(chip => chip.textContent?.trim())).toEqual(expect.arrayContaining([
-      "awaiting_tool_result",
-      "KTC awaiting_tool",
-      "TLA awaiting_tool",
+      "executing",
+      "KTC executing",
+      "TLA executing",
       "receipt failed",
       "reason tool_contract",
       "tool violated",

--- a/dashboard/src/components/turn-fsm-detail-panel.ts
+++ b/dashboard/src/components/turn-fsm-detail-panel.ts
@@ -4,10 +4,10 @@ import { useMemo } from 'preact/hooks'
 import type { KeeperCompositeSnapshot } from '../api/keeper'
 import { CytoscapeFsm } from './common/cytoscape-fsm'
 import { StatusChip, type StatusChipTone } from './common/status-chip'
+import { displayState } from './fsm-hub-types'
 import {
   buildTurnFsmSpec,
   normalizeTurnFsmState,
-  turnFsmTlaSymbol,
 } from './keeper-fsm-specs'
 
 type TurnChipTone = 'accent' | 'neutral' | 'warn' | 'err' | 'ok'
@@ -49,7 +49,6 @@ export function TurnFsmDetailPanel({ snapshot }: { snapshot: KeeperCompositeSnap
     [snapshot.turn_phase],
   )
   const projectedState = normalizeTurnFsmState(snapshot.turn_phase)
-  const tlaSymbol = projectedState ? turnFsmTlaSymbol(projectedState) : null
   const execution = snapshot.execution
   const terminalReason =
     execution?.terminal_reason_code
@@ -73,11 +72,7 @@ export function TurnFsmDetailPanel({ snapshot }: { snapshot: KeeperCompositeSnap
           </div>
         </div>
         <div class="flex flex-wrap items-center gap-1.5 text-3xs">
-          <${StatusChip} tone=${turnFsmChipTone(projectedState ? 'accent' : 'warn')} uppercase=${false} class="font-mono">${projectedState ?? 'unmapped'}</${StatusChip}>
-          <${StatusChip} tone="neutral" uppercase=${false} class="font-mono">KTC ${snapshot.turn_phase}</${StatusChip}>
-          ${tlaSymbol ? html`
-            <${StatusChip} tone="neutral" uppercase=${false} class="font-mono">TLA ${tlaSymbol}</${StatusChip}>
-          ` : null}
+          <${StatusChip} tone=${turnFsmChipTone(projectedState ? 'accent' : 'warn')} uppercase=${false} class="font-mono">${projectedState ? displayState(projectedState) : 'unmapped'}</${StatusChip}>
         </div>
       </div>
 

--- a/dashboard/src/components/turn-fsm-detail-panel.ts
+++ b/dashboard/src/components/turn-fsm-detail-panel.ts
@@ -43,11 +43,6 @@ export function terminalTone(outcome: string | null | undefined): 'neutral' | 'o
   }
 }
 
-export function isExactTurnProjection(rawTurnPhase: string, projected: string | null): boolean {
-  const normalized = rawTurnPhase.trim().toLowerCase()
-  return normalized === projected || (normalized === 'awaiting_tool' && projected === 'awaiting_tool_result')
-}
-
 export function TurnFsmDetailPanel({ snapshot }: { snapshot: KeeperCompositeSnapshot }) {
   const spec = useMemo(
     () => buildTurnFsmSpec(snapshot.turn_phase),
@@ -55,7 +50,6 @@ export function TurnFsmDetailPanel({ snapshot }: { snapshot: KeeperCompositeSnap
   )
   const projectedState = normalizeTurnFsmState(snapshot.turn_phase)
   const tlaSymbol = projectedState ? turnFsmTlaSymbol(projectedState) : null
-  const isCoarse = projectedState ? !isExactTurnProjection(snapshot.turn_phase, projectedState) : false
   const execution = snapshot.execution
   const terminalReason =
     execution?.terminal_reason_code
@@ -81,9 +75,6 @@ export function TurnFsmDetailPanel({ snapshot }: { snapshot: KeeperCompositeSnap
         <div class="flex flex-wrap items-center gap-1.5 text-3xs">
           <${StatusChip} tone=${turnFsmChipTone(projectedState ? 'accent' : 'warn')} uppercase=${false} class="font-mono">${projectedState ?? 'unmapped'}</${StatusChip}>
           <${StatusChip} tone="neutral" uppercase=${false} class="font-mono">KTC ${snapshot.turn_phase}</${StatusChip}>
-          ${isCoarse ? html`
-            <${StatusChip} tone="warn" uppercase=${false}>coarse legacy map</${StatusChip}>
-          ` : null}
           ${tlaSymbol ? html`
             <${StatusChip} tone="neutral" uppercase=${false} class="font-mono">TLA ${tlaSymbol}</${StatusChip}>
           ` : null}


### PR DESCRIPTION
## Summary

Keeper 상태 다이어그램과 Turn FSM 상세 패널의 UX를 개선합니다.

### 변경 내용

1. **한국어 상태 레이블 일관 적용**
   - `keeper-state-diagram.ts`: composite/KTC/KDP/KCL/KMC 배지에 `displayState()` 적용
   - `turn-fsm-detail-panel.ts`: 턴 상태 배지에 `displayState()` 적용

2. **중복 칩 제거**
   - `TurnFsmDetailPanel` 헤더의 TLA 배지(identity mapping, 정보 없음) 제거
   - `KTC` 배지 제거 — 상위 `keeper-state-diagram.ts` composite 배지 행에 이미 표시됨
   - 헤더 칩 3개 → 1개 단순화

3. **테스트 동기화**
   - `turn-fsm-detail-panel.test.ts` 기대값을 새로운 단일 칩 구조에 맞게 수정

## Test plan

- [x] `npx vitest run src/components/turn-fsm-detail-panel.test.ts` — 15 passed
- [x] `npx vitest run src/components/keeper-state-diagram.test.ts src/components/fsm-hub-types.test.ts` — 48 passed
- [x] `tsc --noEmit` (dashboard)

## Related

- 이전 작업: #14336 (LEGACY_TURN_PHASE_MAP 제거 및 KTC 상태 1:1 정렬)