### PR TITLE
refactor: eliminate 8 hardcoding patterns across lib/

### DIFF
--- a/lib/coord/coord_gc.ml
+++ b/lib/coord/coord_gc.ml
@@ -7,6 +7,12 @@ open Masc_domain
 open Coord_utils
 open Coord_state
 
+(** Structured result of zombie cleanup to eliminate string-based parsing at call sites. *)
+type cleanup_zombie_result =
+  | No_agents_dir
+  | No_zombies
+  | Cleaned of { count : int; names : string list; released_tasks : int; skipped : int }
+
 (* Callback refs and types are now in Coord_hooks. *)
 
 (* Board artifact cleanup is wired via Coord_hooks callbacks at startup. *)
@@ -48,7 +54,7 @@ let cleanup_zombies
     if Sys.file_exists agents_path then [ agents_path ] else []
   in
   if scan_paths = [] then
-    "No agents directory"
+    No_agents_dir
   else begin
     (* Phase 1: Detect zombie agents (no side effects) *)
     let zombie_entries = ref [] in (* (name, path) list *)
@@ -99,7 +105,7 @@ let cleanup_zombies
     ) scan_paths;
 
     if !zombie_entries = [] then
-      "No zombie agents found"
+      No_zombies
     else begin
       (* Phase 2: Transition status to Inactive + stop heartbeats + stop keeper fibers.
          Note: If later phases fail (task release or file deletion), the agent
@@ -181,15 +187,12 @@ let cleanup_zombies
       let total = List.length !zombie_entries in
       let cleaned = List.length !successfully_cleaned in
       let skipped = total - cleaned in
-      let task_note = if !released_tasks = [] then ""
-        else Printf.sprintf ", released %d orphan task(s)" (List.length !released_tasks)
-      in
-      if skipped > 0 then
-        Printf.sprintf "Cleaned %d/%d zombie(s): %s%s (%d skipped due to errors)"
-          cleaned total (String.concat ", " !successfully_cleaned) task_note skipped
-      else
-        Printf.sprintf "Cleaned up %d zombie agent(s): %s%s"
-          cleaned (String.concat ", " !successfully_cleaned) task_note
+      Cleaned
+        { count = cleaned
+        ; names = !successfully_cleaned
+        ; released_tasks = List.length !released_tasks
+        ; skipped
+        }
     end
   end
 
@@ -202,7 +205,27 @@ let gc config ?(days=7) () =
 
   (* 1. Cleanup zombies *)
   let zombie_result = cleanup_zombies config in
-  results := zombie_result :: !results;
+  let zombie_str =
+    match zombie_result with
+    | No_agents_dir -> "No agents directory"
+    | No_zombies -> "No zombie agents found"
+    | Cleaned { count; names; released_tasks; skipped } ->
+      let task_note =
+        if released_tasks = 0 then ""
+        else Printf.sprintf ", released %d orphan task(s)" released_tasks
+      in
+      if skipped > 0 then
+        Printf.sprintf
+          "Cleaned %d/%d zombie(s): %s%s (%d skipped due to errors)"
+          count
+          (count + skipped)
+          (String.concat ", " names)
+          task_note
+          skipped
+      else
+        Printf.sprintf "Cleaned up %d zombie agent(s): %s%s" count (String.concat ", " names) task_note
+  in
+  results := zombie_str :: !results;
 
   (* 2. Archive stale tasks (older than N days, not completed) *)
   let cutoff_time =

--- a/lib/coord/coord_gc.mli
+++ b/lib/coord/coord_gc.mli
@@ -20,19 +20,23 @@
 val heartbeat :
   Coord_utils_backend_setup.config -> agent_name:string -> string
 
+type cleanup_zombie_result =
+  | No_agents_dir
+  | No_zombies
+  | Cleaned of { count : int; names : string list; released_tasks : int; skipped : int }
+(** Structured result of zombie cleanup to eliminate string-based parsing at call sites. *)
+
 (** Sweep [.masc/agents/] and remove agents that have not heartbeated
     within the threshold.
 
     [keeper_threshold_sec] applies to keeper agents and defaults to
     {!Env_config.Zombie.keeper_threshold_seconds}; [agent_threshold_sec]
     applies to all other agents and defaults to
-    {!Env_config.Zombie.threshold_seconds}.
-
-    Returns a human-readable summary of what was cleaned. *)
+    {!Env_config.Zombie.threshold_seconds}. *)
 val cleanup_zombies :
   ?keeper_threshold_sec:float ->
   ?agent_threshold_sec:float ->
-  Coord_utils_backend_setup.config -> string
+  Coord_utils_backend_setup.config -> cleanup_zombie_result
 
 (** Run the full coord garbage-collection pass:
     {ol

--- a/lib/eval_calibration.ml
+++ b/lib/eval_calibration.ml
@@ -45,17 +45,12 @@ let verdict_to_string = function
   | Anti_rationalization.Reject reason -> "reject:" ^ reason
 
 let verdict_of_string raw =
-  if String.equal raw "approve" then
-    Some Anti_rationalization.Approve
-  else if String.equal raw "reject" then
-    Some (Anti_rationalization.Reject "")
-  else if String.starts_with ~prefix:"reject:" raw then
-    let prefix_len = String.length "reject:" in
-    Some
-      (Anti_rationalization.Reject
-         (String.sub raw prefix_len (String.length raw - prefix_len)))
-  else
-    None
+  match String.split_on_char ':' raw with
+  | ["approve"] -> Some Anti_rationalization.Approve
+  | ["reject"] -> Some (Anti_rationalization.Reject "")
+  | "reject" :: reason_parts ->
+      Some (Anti_rationalization.Reject (String.concat ":" reason_parts))
+  | _ -> None
 
 let label_verdict_of_verdict = function
   | Anti_rationalization.Approve -> Approve_label

--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -257,7 +257,7 @@ let empty_response_model_metric =
 let alias_response_model_metric =
   Prometheus.metric_after_turn_response_model_alias
 
-let unknown_model_sentinel = "unknown_provider"
+let unknown_model_sentinel = Provider_adapter.cn_unknown_provider
 
 let zero_usage : Agent_sdk.Types.api_usage =
   {

--- a/lib/keeper/keeper_status_detail.ml
+++ b/lib/keeper/keeper_status_detail.ml
@@ -186,6 +186,8 @@ let latest_metrics_json ~metrics_store ~metrics_path ~tail_bytes =
       | json :: _ -> Some json
       | [] -> None)
 
+type provider_scope = Local | Unknown | Non_local
+
 let provider_scope_of_model_label model_label =
   let prefix =
     Option.bind (Option.bind model_label nonempty_trimmed) (fun label ->
@@ -197,12 +199,12 @@ let provider_scope_of_model_label model_label =
         | _ -> None)
   in
   match prefix with
-  | None -> "unknown"
+  | None -> Unknown
   | Some name
     when String.equal name Provider_adapter.cn_llama
       || String.equal name Provider_adapter.cn_ollama ->
-      "local"
-  | Some _ -> "non_local"
+      Local
+  | Some _ -> Non_local
 
 let single_string_or_none values =
   match List.sort_uniq String.compare values with
@@ -219,28 +221,41 @@ let lightweight_runtime_contract_json ~selected_model ~runtime_blocker_class =
   let proof_note =
     "Lightweight status only. Use masc_runtime_verify for proof."
   in
-  if provider_scope <> "local" then
-    `Assoc
-      [
-        ("source", `String "none");
-        ("verified", `Bool false);
-        ("provider_scope", `String provider_scope);
-        ("provider_reachable", `Null);
-        ("healthy_runtime_count", `Null);
-        ("actual_model_id", `Null);
-        ("actual_slots", `Null);
-        ("actual_ctx", `Null);
-        ("chat_completion_compatible", `Null);
-        ("runtime_blocker", Json_util.string_opt_to_json runtime_blocker_class);
-        ( "note",
-          `String
-            (if provider_scope = "non_local" then
-               "Selected model is not a local llama/ollama runtime. "
-               ^ proof_note
-             else
-               "Selected model is unknown. " ^ proof_note) );
-      ]
-  else
+  match provider_scope with
+  | Unknown ->
+      `Assoc
+        [
+          ("source", `String "none");
+          ("verified", `Bool false);
+          ("provider_scope", `String "unknown");
+          ("provider_reachable", `Null);
+          ("healthy_runtime_count", `Null);
+          ("actual_model_id", `Null);
+          ("actual_slots", `Null);
+          ("actual_ctx", `Null);
+          ("chat_completion_compatible", `Null);
+          ("runtime_blocker", Json_util.string_opt_to_json runtime_blocker_class);
+          ("note", `String ("Selected model is unknown. " ^ proof_note));
+        ]
+  | Non_local ->
+      `Assoc
+        [
+          ("source", `String "none");
+          ("verified", `Bool false);
+          ("provider_scope", `String "non_local");
+          ("provider_reachable", `Null);
+          ("healthy_runtime_count", `Null);
+          ("actual_model_id", `Null);
+          ("actual_slots", `Null);
+          ("actual_ctx", `Null);
+          ("chat_completion_compatible", `Null);
+          ("runtime_blocker", Json_util.string_opt_to_json runtime_blocker_class);
+          ("note",
+           `String
+             ("Selected model is not a local llama/ollama runtime. "
+              ^ proof_note));
+        ]
+  | Local ->
     let endpoints_opt =
       try Some (Discovery_cache.get_cached_or_refresh ())
       with

--- a/lib/keeper/keeper_tool_guidance.ml
+++ b/lib/keeper/keeper_tool_guidance.ml
@@ -65,7 +65,10 @@ let hints =
     ; description = "look up current public context before time-sensitive claims"
     }
   ; { name = "masc_web_fetch"
-    ; call = "`masc_web_fetch` { url: \"<page-url>\", timeout: 15 }"
+    ; call =
+        Printf.sprintf
+          "`masc_web_fetch` { url: \"<page-url>\", timeout: %d }"
+          Tool_misc_web_fetch.default_timeout_sec
     ; description = "fetch and read a web page before citing it"
     }
   ; { name = "masc_worktree_create"

--- a/lib/model_inference_metrics.ml
+++ b/lib/model_inference_metrics.ml
@@ -528,10 +528,11 @@ let read_hw_decode_tok_per_sec (fields : (string * Yojson.Safe.t) list) =
 let canonical_cost_model_id ~(provider : string option) model =
   let module PK = Llm_provider.Provider_kind in
   let provider_kind = Option.bind provider PK.of_string in
+  let ollama_prefix = Provider_adapter.cn_ollama ^ ":" in
   match provider_kind with
   | Some PK.Ollama
-    when not (String.starts_with ~prefix:"ollama:" model) ->
-      "ollama:" ^ model
+    when not (String.starts_with ~prefix:ollama_prefix model) ->
+      ollama_prefix ^ model
   | _ -> model
 
 let parse_cost_entry (json : Yojson.Safe.t) ~since_unix : raw_entry option =
@@ -1119,24 +1120,29 @@ let group_entries_by_model (entries : raw_entry list)
   StringMap.fold (fun model es acc -> (model, es) :: acc) tbl []
 
 let latency_histogram (entries : raw_entry list) : latency_bucket list =
-  let bins = [| 0; 0; 0; 0 |] in
+  let boundaries = [1000; 4000; 16000] in
+  let n = List.length boundaries in
+  let bins = Array.make (n + 1) 0 in
   List.iter
     (fun e ->
       match e.latency_ms with
       | None -> ()
       | Some ms ->
           let ms = int_of_float ms in
-          if ms < 1000 then bins.(0) <- bins.(0) + 1
-          else if ms < 4000 then bins.(1) <- bins.(1) + 1
-          else if ms < 16000 then bins.(2) <- bins.(2) + 1
-          else bins.(3) <- bins.(3) + 1)
+          let idx =
+            match List.find_index (fun b -> ms < b) boundaries with
+            | Some i -> i
+            | None -> n
+          in
+          bins.(idx) <- bins.(idx) + 1)
     entries;
-  [
-    { lo_ms = 0; hi_ms = Some 1000; count = bins.(0) };
-    { lo_ms = 1000; hi_ms = Some 4000; count = bins.(1) };
-    { lo_ms = 4000; hi_ms = Some 16000; count = bins.(2) };
-    { lo_ms = 16000; hi_ms = None; count = bins.(3) };
-  ]
+  let rec build i lo = function
+    | [] -> [{ lo_ms = lo; hi_ms = None; count = bins.(i) }]
+    | hi :: rest ->
+        { lo_ms = lo; hi_ms = Some hi; count = bins.(i) }
+        :: build (i + 1) hi rest
+  in
+  build 0 0 boundaries
 
 (* ── Public API ─────────────────────────────────────────── *)
 

--- a/lib/orchestrator.ml
+++ b/lib/orchestrator.ml
@@ -189,20 +189,15 @@ let make_zero_zombie_consumer ~sw ~room_config
          cleanup_zombies I/O. See RFC #3646 M5 / #3626. *)
       Eio.Fiber.fork ~sw (fun () ->
         try
-          let status = Coord.cleanup_zombies room_config in
-          let status_trimmed = String.trim status in
-          if String.length status_trimmed > 0 then begin
-            let has_zombie_indicator =
-              try
-                String.starts_with status_trimmed ~prefix:"\xf0\x9f\xa7\x9f" ||
-                String.starts_with status_trimmed ~prefix:"Cleaned"
-              with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
-                Log.Orchestrator.warn "zombie indicator check failed: %s" (Printexc.to_string exn);
-                false
-            in
-            if has_zombie_indicator then
-              Log.Orchestrator.info "[zombie] %s" status_trimmed
-          end;
+          let zombie_result = Coord.cleanup_zombies room_config in
+          (match zombie_result with
+           | Coord.Cleaned { count; names; _ } when count > 0 ->
+               let status =
+                 Printf.sprintf "Cleaned up %d zombie agent(s): %s"
+                   count (String.concat ", " names)
+               in
+               Log.Orchestrator.info "[zombie] %s" status
+           | _ -> ());
           let ttl = Env_config_runtime.Claim.ttl_seconds in
           (try
             let released = Coord_task_schedule.release_stale_claims room_config ~ttl_seconds:ttl in

--- a/lib/provider_adapter.ml
+++ b/lib/provider_adapter.ml
@@ -152,6 +152,7 @@ let telemetry_usage_missing_runtime_reported =
 
 let cn_llama = "llama"
 let cn_ollama = "ollama"
+let cn_unknown_provider = "unknown_provider"
 let cn_claude = "claude"
 let cn_codex = "codex"
 let cn_gemini = "gemini"

--- a/lib/provider_adapter.mli
+++ b/lib/provider_adapter.mli
@@ -122,6 +122,7 @@ type auth_detail = {
 
 val cn_llama : string
 val cn_ollama : string
+val cn_unknown_provider : string
 val cn_claude : string
 val cn_codex : string
 val cn_gemini : string

--- a/lib/tool_local_runtime_http.ml
+++ b/lib/tool_local_runtime_http.ml
@@ -17,6 +17,8 @@ module Float = Stdlib.Float
 
 (** Tool_local_runtime_http -- HTTP helpers for local runtime probing. *)
 
+let default_timeout_sec = 10
+
 include Tool_local_runtime_core
 
 let trim_to_option raw =
@@ -44,7 +46,7 @@ let append_headers args headers =
   in
   List.rev_append header_args_rev args
 
-let http_get_text_with_status_with_headers ?(timeout_sec = 10) ?(headers = []) url =
+let http_get_text_with_status_with_headers ?(timeout_sec = default_timeout_sec) ?(headers = []) url =
   let argv =
     append_headers
       [
@@ -81,7 +83,7 @@ let http_get_text_with_status_with_headers ?(timeout_sec = 10) ?(headers = []) u
 let http_get_text_with_status ?timeout_sec url =
   http_get_text_with_status_with_headers ?timeout_sec url
 
-let http_get_json_with_status ?(timeout_sec = 10) url =
+let http_get_json_with_status ?(timeout_sec = default_timeout_sec) url =
   match http_get_text_with_status ~timeout_sec url with
   | Error _ as err -> err
   | Ok (http_status, payload) -> (

--- a/lib/tool_misc.ml
+++ b/lib/tool_misc.ml
@@ -70,7 +70,29 @@ let handle_gc ctx args =
   (true, gc_result ^ decision_note)
 
 let handle_cleanup_zombies ctx _args =
-  (true, Coord.cleanup_zombies ctx.config)
+  let result = Coord.cleanup_zombies ctx.config in
+  let msg =
+    match result with
+    | Coord.No_agents_dir -> "No agents directory"
+    | Coord.No_zombies -> "No zombie agents found"
+    | Coord.Cleaned { count; names; released_tasks; skipped } ->
+        let task_note =
+          if released_tasks = 0 then ""
+          else Printf.sprintf ", released %d orphan task(s)" released_tasks
+        in
+        if skipped > 0 then
+          Printf.sprintf
+            "Cleaned %d/%d zombie(s): %s%s (%d skipped due to errors)"
+            count
+            (count + skipped)
+            (String.concat ", " names)
+            task_note
+            skipped
+        else
+          Printf.sprintf "Cleaned up %d zombie agent(s): %s%s"
+            count (String.concat ", " names) task_note
+  in
+  (true, msg)
 
 let handle_tool_stats _ctx args =
   let top_n = max 1 (min 100 (get_int args "top_n" 20)) in

--- a/lib/tool_misc_web_fetch.ml
+++ b/lib/tool_misc_web_fetch.ml
@@ -17,6 +17,8 @@ module Float = Stdlib.Float
 
 open Tool_args
 
+let default_timeout_sec = 15
+
 (** JSON response helpers — same pattern as Tool_misc_web_search *)
 let json_error message =
   Yojson.Safe.to_string
@@ -182,7 +184,7 @@ let fetch_impl ~url ~timeout_sec =
 
 let handle args =
   let url = get_string args "url" "" in
-  let timeout = max 1 (min 60 (get_int args "timeout" 15)) in
+  let timeout = max 1 (min 60 (get_int args "timeout" default_timeout_sec)) in
   if not (valid_url url) then
     (false, json_error "url must be a valid http or https URL")
   else

--- a/lib/tool_misc_web_fetch.mli
+++ b/lib/tool_misc_web_fetch.mli
@@ -8,10 +8,13 @@
     web_search) and optional [<title>] / [<meta name="description">]
     extraction. *)
 
+val default_timeout_sec : int
+(** Default timeout for HTTP fetch operations (seconds). *)
+
 val handle : Yojson.Safe.t -> bool * string
 (** [handle args] handles [masc_web_fetch] tool dispatch.
     Required: [url] (string, http/https only).
-    Optional: [timeout] (int, clamped to [\[1, 60\]], default 15).
+    Optional: [timeout] (int, clamped to [\[1, 60\]], default {!default_timeout_sec}).
 
     Returns [(true, json)] with fields:
     - [url]: the requested URL

--- a/test/test_room.ml
+++ b/test/test_room.ml
@@ -992,9 +992,15 @@ let test_get_agents_status () =
 
 let test_cleanup_zombies_empty () =
   with_test_env (fun config ->
-    (* Cleanup with no zombies *)
+    (* Cleanup with no zombies returns a structured result *)
     let result = Coord.cleanup_zombies config in
-    Alcotest.(check bool) "cleanup result" true (String.length result > 0)
+    let has_result =
+      match result with
+      | Coord.No_agents_dir -> true
+      | Coord.No_zombies -> true
+      | Coord.Cleaned _ -> true
+    in
+    Alcotest.(check bool) "cleanup result" true has_result
   )
 
 (** Return ISO8601 timestamp offset by seconds from now *)
@@ -1023,8 +1029,11 @@ let test_cleanup_zombies_detects_regular () =
     (* Create a regular agent idle for 10 minutes (> 300s threshold) *)
     make_stale_agent config ~name:"stale-regular-agent" ~age_seconds:700.0;
     let result = Coord.cleanup_zombies config in
-    Alcotest.(check bool) "regular zombie detected"
-      true (str_contains result "stale-regular-agent")
+    let found = match result with
+      | Coord.Cleaned { names; _ } -> List.mem "stale-regular-agent" names
+      | _ -> false
+    in
+    Alcotest.(check bool) "regular zombie detected" true found
   )
 
 let test_cleanup_zombies_detects_keeper () =
@@ -1032,8 +1041,11 @@ let test_cleanup_zombies_detects_keeper () =
     (* Create a keeper agent idle for 2 hours (> 3600s keeper threshold) *)
     make_stale_agent config ~name:"keeper-longplay-agent" ~age_seconds:7200.0;
     let result = Coord.cleanup_zombies config in
-    Alcotest.(check bool) "keeper zombie detected after keeper threshold"
-      true (str_contains result "keeper-longplay-agent")
+    let found = match result with
+      | Coord.Cleaned { names; _ } -> List.mem "keeper-longplay-agent" names
+      | _ -> false
+    in
+    Alcotest.(check bool) "keeper zombie detected after keeper threshold" true found
   )
 
 let test_cleanup_zombies_spares_recent_keeper () =
@@ -1041,8 +1053,11 @@ let test_cleanup_zombies_spares_recent_keeper () =
     (* Create a keeper agent idle for 10 minutes (< 3600s keeper threshold) *)
     make_stale_agent config ~name:"keeper-active-agent" ~age_seconds:600.0;
     let result = Coord.cleanup_zombies config in
-    Alcotest.(check bool) "recent keeper spared"
-      true (not (str_contains result "keeper-active-agent"))
+    let spared = match result with
+      | Coord.Cleaned { names; _ } -> not (List.mem "keeper-active-agent" names)
+      | _ -> true
+    in
+    Alcotest.(check bool) "recent keeper spared" true spared
   )
 
 let test_cleanup_zombies_spares_type_keeper () =
@@ -1054,8 +1069,11 @@ let test_cleanup_zombies_spares_type_keeper () =
       ~name:"regular-keeper-runtime"
       ~age_seconds:600.0;
     let result = Coord.cleanup_zombies config in
-    Alcotest.(check bool) "agent_type=keeper spared below keeper threshold"
-      true (not (str_contains result "regular-keeper-runtime"))
+    let spared = match result with
+      | Coord.Cleaned { names; _ } -> not (List.mem "regular-keeper-runtime" names)
+      | _ -> true
+    in
+    Alcotest.(check bool) "agent_type=keeper spared below keeper threshold" true spared
   )
 
 let test_cleanup_zombies_removes_broken_agent_file () =
@@ -1491,7 +1509,11 @@ let test_cleanup_zombies_releases_tasks () =
     Coord.write_json config agent_file updated_json;
     (* Run cleanup — should remove zombie agent AND release its tasks *)
     let result = Coord.cleanup_zombies config in
-    Alcotest.(check bool) "cleanup ran" true (String.length result > 0);
+    Alcotest.(check bool) "cleanup ran" true
+      (match result with
+       | Coord.No_agents_dir -> true
+       | Coord.No_zombies -> true
+       | Coord.Cleaned _ -> true);
     (* Verify task is released (back to Todo) *)
     let tasks = Coord.list_tasks config in
     Alcotest.(check bool) "task released to todo" true


### PR DESCRIPTION
## Summary

SSOT 상수 추출 + 타입 variant 도입으로 8개 하드코딩 패턴을 제거합니다.

| # | 파일 | 변경 내용 |
|---|------|----------|
| 1 | `coord_gc` | `cleanup_zombie_result` variant로 string 분류 제거 |
| 2 | `eval_calibration` | `split_on_char ':'` 구조 분해로 prefix match 제거 |
| 3 | `keeper_status_detail` | `provider_scope` variant로 string classifier 제거 |
| 4 | `model_inference_metrics` | `canonical_cost_model_id`에 `Provider_adapter.cn_ollama` 사용 |
| 5 | `tool_local_runtime_http` | `default_timeout_sec = 10` 상수 추출 |
| 6 | `tool_misc_web_fetch` | `default_timeout_sec = 15` 상수 추출, `.mli` 노출 |
| 7 | `keeper_tool_guidance` | web_fetch timeout을 `%d` + `default_timeout_sec`로 유도 |
| 8 | `model_inference_metrics` | `latency_histogram` bin boundary를 단일 리스트로 SSOT화 |

## 검증

- `dune build --root . @check` 통과
- `test_room.ml` zombie cleanup 테스트 variant match로 업데이트

🤖 Generated with [Claude Code](https://claude.com/claude-code)