### PR TITLE
style(config): add @category/@ops_class to degraded_retry_slot_phase_budget_sec

### DIFF
--- a/lib/config/env_config_keeper.ml
+++ b/lib/config/env_config_keeper.ml
@@ -956,6 +956,8 @@ module KeeperRetryBackoff = struct
 
       Env: [MASC_KEEPER_DEGRADED_RETRY_SLOT_PHASE_BUDGET_SEC].
       Default: 180.0.
+      @category Timeouts
+      @ops_class operator
 
       Calibrated to match [Cascade_attempt_liveness.local_27b.ttft_max]
       (180 s) so that slow-but-honest Ollama 27B/70B streams are not


### PR DESCRIPTION
Fixes Env knob classification CI failure from PR #14346.

Adds required metadata annotations to `MASC_KEEPER_DEGRADED_RETRY_SLOT_PHASE_BUDGET_SEC` getter:
- `@category Timeouts`
- `@ops_class operator`

No functional change. Pure annotation fix.

Refs: PR #14346