### PR TITLE
fix(keeper): raise batch_threshold 3→5 and window 30→60 to prevent false fleet latch

### DIFF
--- a/lib/config/env_config_keeper.ml
+++ b/lib/config/env_config_keeper.ml
@@ -660,14 +660,14 @@ module KeeperWatchdog = struct
     max 1 (get_int ~default:5 "MASC_KEEPER_ESCALATION_THRESHOLD")
 
   (** Fleet batch-termination detection window in seconds.
-      Default: 30. *)
+      Default: 60. *)
   let batch_window_sec =
-    Float.max 1.0 (get_float ~default:30.0 "MASC_KEEPER_BATCH_WINDOW_SEC")
+    Float.max 1.0 (get_float ~default:60.0 "MASC_KEEPER_BATCH_WINDOW_SEC")
 
   (** Number of distinct keepers terminating within [batch_window_sec] before
-      emitting a fleet batch alert. Default: 3. *)
+      emitting a fleet batch alert. Default: 5. *)
   let batch_threshold =
-    max 1 (get_int ~default:3 "MASC_KEEPER_BATCH_THRESHOLD")
+    max 1 (get_int ~default:5 "MASC_KEEPER_BATCH_THRESHOLD")
 end
 
 (** {1 gRPC Heartbeat Reconnect} *)


### PR DESCRIPTION
## Summary

A single slow provider (e.g., qwen 300 s timeout) could trigger a `Stale_fleet_batch` alert because the old threshold (**3 keepers in 30 s**) was too sensitive.  The entire fleet of 13 keepers would then latch into auto-pause even though only one provider was stalled.

## Changes

- `MASC_KEEPER_BATCH_WINDOW_SEC` default: 30 → **60**
- `MASC_KEEPER_BATCH_THRESHOLD` default: 3 → **5**

## Why

The stale watchdog records each keeper termination in an atomic list with a 30-second sliding window.  When qwen exceeded its 300-second OAS timeout, the first keeper hit `in_turn_stale`.  Within the next 30 seconds, two other keepers independently completed their turns (or retried) and also terminated, reaching the threshold of 3.  The `batch_terminations` logic then classified this as a fleet-wide event (`Cascade_unhealthy` or `Mixed`) and auto-paused all remaining keepers.

Raising the threshold to **5 in 60 seconds** means:
- Genuine fleet-wide failures (auth expiry, FD exhaustion, cascade collapse) still trigger alerts quickly.
- Isolated provider latency is ignored because it is unlikely that 5+ keepers terminate within 60 s due to a single slow provider.

## Test Plan

- [x] `dune build --root . @check` passes
- [ ] Deploy to staging and verify qwen timeout no longer cascades to fleet pause
- [ ] Monitor `masc_keeper_batch_termination_total` Prometheus counter for 24 h

## Related

Observed in server logs: 13 keepers terminated simultaneously after qwen HTTP timeout.  Root cause traced to `lib/keeper/keeper_stale_watchdog.ml` batch detection logic.