### PR TITLE
refactor(keeper): extract try_provider to standalone module (RFC-0051 PR-3a)

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -117,6 +117,7 @@
   keeper_oas_checkpoint
   keeper_turn_driver
   keeper_turn_driver_helpers
+  keeper_turn_driver_try_provider
   keeper_turn_driver_wrappers
   keeper_exec_context
   keeper_guards

--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -258,260 +258,69 @@ let run_named
     Option.value priority ~default:Llm_provider.Request_priority.Proactive
   in
   (* MASC-driven cascade FSM: try each provider, decide on failure.
-     Mid-turn resume: when a provider fails after completing some turns,
-     the next provider resumes from the failed agent's checkpoint instead
-     of restarting from scratch.
-
-     Immutable checkpoint threading: try_provider returns both the result
-     and the agent's checkpoint (if progress was made). try_cascade
-     threads this checkpoint to the next provider without mutable state. *)
-  let try_provider ?resume_checkpoint ?per_provider_timeout_s (provider_cfg : Llm_provider.Provider_config.t) =
-    let config_result =
-      Cascade_runner.resolve_tool_lane_for_oas_tools
-        ?agent_name:(keeper_agent_name_opt keeper_name)
-        ~tool_requirement:
-          (if require_tool_choice_support || require_tool_support
-           then `Required
-           else `Optional)
-        ~provider_cfg ~tools ()
-      |> Result.map
-           (fun (effective_tools, runtime_mcp_policy) ->
-             let runtime_mcp_policy =
-               match runtime_mcp_policy, String.trim keeper_name with
-               | Some policy, keeper_name when keeper_name <> "" ->
-                   Cascade_runner.runtime_mcp_policy_for_provider
-                     ~provider_cfg
-                     ~agent_name:(Keeper_types.keeper_agent_name keeper_name)
-                     (Some policy)
-                | _ -> runtime_mcp_policy
-             in
-             {
-               (Cascade_runner.default_config ~name ~provider_cfg
-                  ~system_prompt ~tools:effective_tools)
-               with
-                 priority;
-                 max_turns;
-                 max_tokens;
-                 max_input_tokens;
-                 max_cost_usd;
-                 stream_idle_timeout_s =
-                   (match per_provider_timeout_s with
-                    | Some _ as timeout_s -> timeout_s
-                    | None ->
-                        Some
-                          (Option.value
-                             ~default:
-                               Env_config_keeper.KeeperKeepalive
-                               .stream_idle_timeout_sec
-                             stream_idle_timeout_s));
-                 max_execution_time_s =
-                   (* Bound a single OAS call (one [Agent.run]/[run_stream])
-                      so a hung provider falls into [Retry.Timeout] instead
-                      of blocking until the whole-keeper [turn_timeout].
-                      Scale = per-OAS-call (default 300 s, env override via
-                      [MASC_KEEPER_OAS_TIMEOUT_SEC]); the input-token arg
-                      is currently ignored by the resolver (#10008 fm2). *)
-                   Some
-                     (Keeper_runtime_resolved
-                      .oas_timeout_for_estimated_input_tokens
-                        ~estimated_input_tokens:0);
-                 temperature;
-                 max_idle_turns;
-                 guardrails;
-                 hooks;
-                 context_reducer;
-                 memory;
-                 tool_retry_policy;
-                 required_tool_satisfaction;
-                 description =
-                   Some
-                     (Printf.sprintf "cascade:%s/%s" cascade_name
-                        provider_cfg.model_id);
-                 transport = transport_resolved;
-                 allowed_paths;
-                 checkpoint_sidecar;
-                 session_id;
-                 cache_system_prompt;
-                 compact_ratio;
-                 contract;
-                 checkpoint_dir;
-                 context_injector;
-                 context;
-                 slot_id;
-                 enable_thinking;
-                 event_bus;
-                 approval;
-                 exit_condition;
-                 exit_condition_result;
-                 summarizer;
-                 initial_messages;
-                 raw_trace;
-                 yield_on_tool;
-                 runtime_mcp_policy;
-                 cli_transport_overrides;
-             })
-    in
-    let local_agent_ref : Agent_sdk.Agent.t option ref = ref None in
-    match config_result with
-    | Error err ->
-      (Error err, None)
-    | Ok config ->
-      (* RFC-0022 PR-2 §4 — attempt-liveness observer.
-
-         Mode is captured once per attempt. Off short-circuits before
-         observer construction so the wrapper is bit-identical to the
-         baseline. Observe and Enforce wrap on_event, start a tick fiber
-         under the provider-attempt switch, and finalize the per-attempt
-         outcome counter when the run returns. Enforce additionally calls
-         [Eio.Switch.fail] on the first Outcome to tear down only the current
-         [Cascade_runner.run] attempt; the outer keeper/cascade switch must
-         stay alive so the FSM can fall through to the next provider. *)
-      let liveness_mode = Cascade_attempt_liveness_config.current_mode () in
-      let liveness_observer_opt =
-        match liveness_mode with
-        | Cascade_attempt_liveness_config.Off -> None
-        | Cascade_attempt_liveness_config.Observe
-        | Cascade_attempt_liveness_config.Enforce ->
-            let budget =
-              Cascade_attempt_liveness_config.budget_for_label
-                provider_cfg.model_id
-            in
-            let obs =
-              Cascade_attempt_liveness_observer.create
-                ~mode:liveness_mode ~budget ~cascade_label:cascade_name
-                ~provider_label:provider_cfg.model_id
-                ~started_at:(Time_compat.now ())
-            in
-            Some obs
-      in
-      let finalize_liveness () =
-        match liveness_observer_opt with
-        | None -> ()
-        | Some obs -> Cascade_attempt_liveness_observer.finalize obs
-      in
-      let liveness_timeout_error failure =
-        let kind = Cascade_attempt_liveness.failure_kind_label failure in
-        Agent_sdk.Error.Api
-          (Timeout
-             {
-               message =
-                 Printf.sprintf
-                   "Cascade attempt liveness guard killed provider %s/%s: %s"
-                   cascade_name provider_cfg.model_id kind;
-             })
-      in
-      let with_liveness_attempt f =
-        let run_attempt () =
-          try
-            Eio.Switch.run (fun attempt_sw ->
-                (match liveness_observer_opt with
-                 | Some obs ->
-                     Cascade_attempt_liveness_observer.register_attempt_switch
-                       obs ~sw:attempt_sw
-                 | None -> ());
-                (match liveness_observer_opt, Eio_context.get_clock_opt () with
-                 | Some obs, Some clock ->
-                     Cascade_attempt_liveness_observer.start_tick_fiber obs
-                       ~sw:attempt_sw ~clock
-                 | Some _, None ->
-                     (* No clock available — wrapper still emits counters
-                        via on_event but TTFT/wall checks won't fire. *)
-                     ()
-                 | None, _ -> ());
-                let liveness_on_event =
-                  match liveness_observer_opt with
-                  | None -> on_event
-                  | Some obs ->
-                      Cascade_attempt_liveness_observer.wrap_on_event obs
-                        on_event
-                in
-                f ~attempt_sw ~liveness_on_event)
-          with
-          | Cascade_attempt_liveness_observer.Liveness_kill failure ->
-              Error (liveness_timeout_error failure)
-          | Eio.Cancel.Cancelled _ as e -> raise e
-        in
-        match run_attempt () with
-        | result ->
-            finalize_liveness ();
-            result
-        | exception exn ->
-            let bt = Printexc.get_raw_backtrace () in
-            finalize_liveness ();
-            Printexc.raise_with_backtrace exn bt
-      in
-      match
-        with_codex_cli_preflight
-          ~scope:(Printf.sprintf "cascade:%s/%s" cascade_name provider_cfg.model_id)
-          ~config ~goal
-          (fun () ->
-            let result =
-              with_liveness_attempt
-                (fun ~attempt_sw ~liveness_on_event ->
-                   let effective_checkpoint = match resume_checkpoint with
-                     | Some _ -> resume_checkpoint
-                     | None -> oas_checkpoint
-                   in
-                   let run_fn () =
-                     Cascade_runner.run ~sw:attempt_sw ~net ~config
-                       ?oas_checkpoint:effective_checkpoint
-                       ?on_event:liveness_on_event
-                       ?on_yield ?on_resume ~agent_ref:local_agent_ref ?proof_ref
-                       ?contract goal
-                   in
-                   (* RFC-0022 §1 (in-attempt liveness layer): see
-                      [Cascade_attempt_liveness_config.outer_wall_for_attempt]
-                      for the rule. The legacy [per_provider_timeout_s] is
-                      clipped to the profile's wall budget so slow-but-honest
-                      streams (local Ollama 27B / 70B+) are not pre-empted
-                      before the observer would consider them stalled. *)
-                   let outer_wall_for_provider =
-                     Cascade_attempt_liveness_config.outer_wall_for_attempt
-                       ~mode:liveness_mode
-                       ~observer_attached:(Option.is_some liveness_observer_opt)
-                       ~per_provider_timeout_s
-                       ~provider_label:provider_cfg.model_id
-                   in
-                   match outer_wall_for_provider with
-                   | None -> run_fn ()
-                   | Some t ->
-                       let clock_opt =
-                         match Masc_eio_env.get_opt () with
-                         | Some env -> (
-                             match env.clock with
-                             | Some _ as clock_opt -> clock_opt
-                             | None -> Eio_context.get_clock_opt ())
-                         | None -> Eio_context.get_clock_opt ()
-                       in
-                       (match clock_opt with
-                        | Some clock ->
-                            (try Eio.Time.with_timeout_exn clock t run_fn
-                             with Eio.Time.Timeout ->
-                               Log.Misc.info
-                                 "[cascade-fallback] cascade %s: provider %s per-provider timeout after %.1fs, falling back"
-                                 cascade_name provider_cfg.model_id t;
-                               Error (Agent_sdk.Error.Api (Timeout { message = Printf.sprintf "Per-provider timeout after %.1fs" t })))
-                        | None -> run_fn ()))
-            in
-            Ok result)
-    with
-    | Error err ->
-      finalize_liveness ();
-      (Error err, None)
-    | Ok result ->
-      finalize_liveness ();
-      let result =
-        Result.map_error
-          (enrich_sdk_error ~cascade_name:error_cascade_name ~provider_cfg)
-          result
-      in
-      (* Extract checkpoint from the agent even when no turn completed.
-         A zero-turn agent still carries built context, initial messages,
-         and sidecar state needed by cancel-before-start recovery. *)
-      let checkpoint_after =
-        checkpoint_after_attempt ?agent_ref !local_agent_ref
-      in
-      (result, checkpoint_after)
+     Extracted to [Keeper_turn_driver_try_provider.run_try_provider] via
+     explicit [try_provider_ctx] record (RFC-0051 PR-3a). *)
+  let try_provider_ctx : Keeper_turn_driver_try_provider.try_provider_ctx = {
+    cascade_name;
+    error_cascade_name;
+    keeper_name;
+    name;
+    goal;
+    require_tool_choice_support;
+    require_tool_support;
+    priority;
+    session_id;
+    system_prompt;
+    tools;
+    initial_messages;
+    max_turns;
+    max_idle_turns;
+    stream_idle_timeout_s;
+    temperature;
+    max_tokens;
+    max_input_tokens;
+    max_cost_usd;
+    guardrails;
+    hooks;
+    context_reducer;
+    memory;
+    tool_retry_policy;
+    required_tool_satisfaction;
+    raw_trace;
+    transport_resolved;
+    cli_transport_overrides;
+    runtime_mcp_policy;
+    allowed_paths;
+    checkpoint_sidecar;
+    cache_system_prompt;
+    yield_on_tool;
+    compact_ratio;
+    checkpoint_dir;
+    context_injector;
+    context;
+    slot_id;
+    enable_thinking;
+    approval;
+    exit_condition;
+    exit_condition_result;
+    summarizer;
+    oas_checkpoint;
+    contract;
+    sw;
+    net;
+    on_event;
+    on_yield;
+    on_resume;
+    agent_ref;
+    proof_ref;
+    event_bus;
+  } in
+  let try_provider ?resume_checkpoint ?per_provider_timeout_s provider_cfg =
+    Keeper_turn_driver_try_provider.run_try_provider
+      try_provider_ctx
+      ?resume_checkpoint
+      ?per_provider_timeout_s
+      provider_cfg
   in
   let rec try_cascade
       ?(on_success = fun ~provider_key:_ -> ())

--- a/lib/keeper/keeper_turn_driver_try_provider.ml
+++ b/lib/keeper/keeper_turn_driver_try_provider.ml
@@ -1,0 +1,337 @@
+(** Keeper_turn_driver_try_provider — extracted [try_provider] closure.
+
+    RFC-0051 PR-3a: closure-to-toplevel-fn conversion with explicit ctx record.
+    The [try_provider] closure was defined inside [Keeper_turn_driver.run_named]
+    and captured ~51 variables from the enclosing scope. This module makes
+    that boundary explicit via a record, so the compiler verifies every
+    dependency and the function body is independently testable.
+
+    @since RFC-0051 PR-3a *)
+
+open Result.Syntax
+
+(** Explicit context record for the extracted [try_provider] function.
+
+    Each field corresponds to a variable captured by the original closure.
+    Fields are grouped by role: cascade identity, agent config, transport,
+    session/checkpoint, Eio primitives, callbacks, and event bus. *)
+type try_provider_ctx =
+  { (* Cascade identity *)
+    cascade_name : string
+  ; error_cascade_name : Cascade_error_classify.cascade_name
+  ; keeper_name : string
+  ; name : string
+  ; (* Agent config — fields passed to [Cascade_runner.default_config] *)
+    goal : string
+  ; require_tool_choice_support : bool
+  ; require_tool_support : bool
+  ; priority : Llm_provider.Request_priority.t option
+  ; session_id : string option
+  ; system_prompt : string
+  ; tools : Agent_sdk.Tool.t list
+  ; initial_messages : Agent_sdk.Types.message list
+  ; max_turns : int
+  ; max_idle_turns : int
+  ; stream_idle_timeout_s : float option
+  ; temperature : float
+  ; max_tokens : int
+  ; max_input_tokens : int option
+  ; max_cost_usd : float option
+  ; guardrails : Agent_sdk.Guardrails.t option
+  ; hooks : Agent_sdk.Hooks.hooks option
+  ; context_reducer : Agent_sdk.Context_reducer.t option
+  ; memory : Agent_sdk.Memory.t option
+  ; tool_retry_policy : Agent_sdk.Tool_retry_policy.t option
+  ; required_tool_satisfaction : Agent_sdk.Completion_contract.required_tool_satisfaction
+  ; raw_trace : Agent_sdk.Raw_trace.t option
+  ; (* Transport *)
+    transport_resolved : Masc_grpc_transport.t
+  ; cli_transport_overrides : Cascade_runner.cli_transport_overrides option
+  ; runtime_mcp_policy : Llm_provider.Llm_transport.runtime_mcp_policy option
+  ; (* Session / checkpoint *)
+    allowed_paths : string list
+  ; checkpoint_sidecar : Yojson.Safe.t option
+  ; cache_system_prompt : bool
+  ; yield_on_tool : bool
+  ; compact_ratio : float option
+  ; checkpoint_dir : string option
+  ; context_injector : Agent_sdk.Hooks.context_injector option
+  ; context : Agent_sdk.Context.t option
+  ; slot_id : int option
+  ; enable_thinking : bool option
+  ; approval : Agent_sdk.Hooks.approval_callback option
+  ; exit_condition : (int -> bool) option
+  ; exit_condition_result : (int -> Cascade_runner.stop_reason * string option) option
+  ; summarizer : (Agent_sdk.Types.message list -> string) option
+  ; oas_checkpoint : Agent_sdk.Checkpoint.t option
+  ; contract : Masc_mcp_cdal_runtime.Risk_contract.t option
+  ; (* Eio concurrency *)
+    sw : Eio.Switch.t
+  ; net : [ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t
+  ; (* Callbacks *)
+    on_event : (Agent_sdk.Types.sse_event -> unit) option
+  ; on_yield : (unit -> unit) option
+  ; on_resume : (unit -> unit) option
+  ; agent_ref : Agent_sdk.Agent.t option ref option
+  ; proof_ref : Masc_mcp_cdal_runtime.Cdal_proof.t option ref option
+  ; (* Event bus *)
+    event_bus : Agent_sdk.Event_bus.t option
+  }
+
+(** Run a single provider attempt within the cascade.
+
+    This is the extracted body of the [try_provider] closure that was
+    defined inside [Keeper_turn_driver.run_named]. The [ctx] record
+    makes all captured dependencies explicit.
+
+    @param ctx Explicit closure context (captures from [run_named]).
+    @param resume_checkpoint Checkpoint from a previous failed provider.
+    @param per_provider_timeout_s Per-provider wall-clock timeout.
+    @param provider_cfg The provider configuration to attempt.
+    @return [(result, checkpoint_after)] tuple. *)
+let run_try_provider
+      (ctx : try_provider_ctx)
+      ?resume_checkpoint
+      ?per_provider_timeout_s
+      (provider_cfg : Llm_provider.Provider_config.t)
+  =
+  let config_result =
+    Cascade_runner.resolve_tool_lane_for_oas_tools
+      ?agent_name:(Cascade_oas_runner.keeper_agent_name_opt ctx.keeper_name)
+      ~tool_requirement:
+        (if ctx.require_tool_choice_support || ctx.require_tool_support
+         then `Required
+         else `Optional)
+      ~provider_cfg
+      ~tools:ctx.tools
+      ()
+    |> Result.map (fun (effective_tools, runtime_mcp_policy) ->
+      let runtime_mcp_policy =
+        match runtime_mcp_policy, String.trim ctx.keeper_name with
+        | Some policy, keeper_name when keeper_name <> "" ->
+          Cascade_runner.runtime_mcp_policy_for_provider
+            ~provider_cfg
+            ~agent_name:(Keeper_types.keeper_agent_name ctx.keeper_name)
+            (Some policy)
+        | _ -> runtime_mcp_policy
+      in
+      { (Cascade_runner.default_config
+           ~name:ctx.name
+           ~provider_cfg
+           ~system_prompt:ctx.system_prompt
+           ~tools:effective_tools)
+        with
+        priority = ctx.priority
+      ; max_turns = ctx.max_turns
+      ; max_tokens = ctx.max_tokens
+      ; max_input_tokens = ctx.max_input_tokens
+      ; max_cost_usd = ctx.max_cost_usd
+      ; stream_idle_timeout_s =
+          (match per_provider_timeout_s with
+           | Some _ as timeout_s -> timeout_s
+           | None ->
+             Some
+               (Option.value
+                  ~default:Env_config_keeper.KeeperKeepalive.stream_idle_timeout_sec
+                  ctx.stream_idle_timeout_s))
+      ; max_execution_time_s =
+          Some
+            (Keeper_runtime_resolved.oas_timeout_for_estimated_input_tokens
+               ~estimated_input_tokens:0)
+      ; temperature = ctx.temperature
+      ; max_idle_turns = ctx.max_idle_turns
+      ; guardrails = ctx.guardrails
+      ; hooks = ctx.hooks
+      ; context_reducer = ctx.context_reducer
+      ; memory = ctx.memory
+      ; tool_retry_policy = ctx.tool_retry_policy
+      ; required_tool_satisfaction = ctx.required_tool_satisfaction
+      ; description =
+          Some (Printf.sprintf "cascade:%s/%s" ctx.cascade_name provider_cfg.model_id)
+      ; transport = ctx.transport_resolved
+      ; allowed_paths = ctx.allowed_paths
+      ; checkpoint_sidecar = ctx.checkpoint_sidecar
+      ; session_id = ctx.session_id
+      ; cache_system_prompt = ctx.cache_system_prompt
+      ; compact_ratio = ctx.compact_ratio
+      ; contract = ctx.contract
+      ; checkpoint_dir = ctx.checkpoint_dir
+      ; context_injector = ctx.context_injector
+      ; context = ctx.context
+      ; slot_id = ctx.slot_id
+      ; enable_thinking = ctx.enable_thinking
+      ; event_bus = ctx.event_bus
+      ; approval = ctx.approval
+      ; exit_condition = ctx.exit_condition
+      ; exit_condition_result = ctx.exit_condition_result
+      ; summarizer = ctx.summarizer
+      ; initial_messages = ctx.initial_messages
+      ; raw_trace = ctx.raw_trace
+      ; yield_on_tool = ctx.yield_on_tool
+      ; runtime_mcp_policy
+      ; cli_transport_overrides = ctx.cli_transport_overrides
+      })
+  in
+  let local_agent_ref : Agent_sdk.Agent.t option ref = ref None in
+  match config_result with
+  | Error err -> Error err, None
+  | Ok config ->
+    let liveness_mode = Cascade_attempt_liveness_config.current_mode () in
+    let liveness_observer_opt =
+      match liveness_mode with
+      | Cascade_attempt_liveness_config.Off -> None
+      | Cascade_attempt_liveness_config.Observe | Cascade_attempt_liveness_config.Enforce
+        ->
+        let budget =
+          Cascade_attempt_liveness_config.budget_for_label provider_cfg.model_id
+        in
+        let obs =
+          Cascade_attempt_liveness_observer.create
+            ~mode:liveness_mode
+            ~budget
+            ~cascade_label:ctx.cascade_name
+            ~provider_label:provider_cfg.model_id
+            ~started_at:(Time_compat.now ())
+        in
+        Some obs
+    in
+    let finalize_liveness () =
+      match liveness_observer_opt with
+      | None -> ()
+      | Some obs -> Cascade_attempt_liveness_observer.finalize obs
+    in
+    let liveness_timeout_error failure =
+      let kind = Cascade_attempt_liveness.failure_kind_label failure in
+      Agent_sdk.Error.Api
+        (Timeout
+           { message =
+               Printf.sprintf
+                 "Cascade attempt liveness guard killed provider %s/%s: %s"
+                 ctx.cascade_name
+                 provider_cfg.model_id
+                 kind
+           })
+    in
+    let with_liveness_attempt f =
+      let run_attempt () =
+        try
+          Eio.Switch.run (fun attempt_sw ->
+            (match liveness_observer_opt with
+             | Some obs ->
+               Cascade_attempt_liveness_observer.register_attempt_switch
+                 obs
+                 ~sw:attempt_sw
+             | None -> ());
+            (match liveness_observer_opt, Eio_context.get_clock_opt () with
+             | Some obs, Some clock ->
+               Cascade_attempt_liveness_observer.start_tick_fiber
+                 obs
+                 ~sw:attempt_sw
+                 ~clock
+             | Some _, None -> ()
+             | None, _ -> ());
+            let liveness_on_event =
+              match liveness_observer_opt with
+              | None -> ctx.on_event
+              | Some obs ->
+                Cascade_attempt_liveness_observer.wrap_on_event obs ctx.on_event
+            in
+            f ~attempt_sw ~liveness_on_event)
+        with
+        | Cascade_attempt_liveness_observer.Liveness_kill failure ->
+          Error (liveness_timeout_error failure)
+        | Eio.Cancel.Cancelled _ as e -> raise e
+      in
+      match run_attempt () with
+      | result ->
+        finalize_liveness ();
+        result
+      | exception exn ->
+        let bt = Printexc.get_raw_backtrace () in
+        finalize_liveness ();
+        Printexc.raise_with_backtrace exn bt
+    in
+    (match
+       Cascade_error_classify.with_codex_cli_preflight
+         ~scope:(Printf.sprintf "cascade:%s/%s" ctx.cascade_name provider_cfg.model_id)
+         ~config
+         ~goal:ctx.goal
+         (fun () ->
+            let result =
+              with_liveness_attempt (fun ~attempt_sw ~liveness_on_event ->
+                let effective_checkpoint =
+                  match resume_checkpoint with
+                  | Some _ -> resume_checkpoint
+                  | None -> ctx.oas_checkpoint
+                in
+                let run_fn () =
+                  Cascade_runner.run
+                    ~sw:attempt_sw
+                    ~net:ctx.net
+                    ~config
+                    ?oas_checkpoint:effective_checkpoint
+                    ?on_event:liveness_on_event
+                    ?on_yield:ctx.on_yield
+                    ?on_resume:ctx.on_resume
+                    ~agent_ref:local_agent_ref
+                    ?proof_ref:ctx.proof_ref
+                    ?contract:ctx.contract
+                    ctx.goal
+                in
+                let outer_wall_for_provider =
+                  Cascade_attempt_liveness_config.outer_wall_for_attempt
+                    ~mode:liveness_mode
+                    ~observer_attached:(Option.is_some liveness_observer_opt)
+                    ~per_provider_timeout_s
+                    ~provider_label:provider_cfg.model_id
+                in
+                match outer_wall_for_provider with
+                | None -> run_fn ()
+                | Some t ->
+                  let clock_opt =
+                    match Masc_eio_env.get_opt () with
+                    | Some env ->
+                      (match env.clock with
+                       | Some _ as clock_opt -> clock_opt
+                       | None -> Eio_context.get_clock_opt ())
+                    | None -> Eio_context.get_clock_opt ()
+                  in
+                  (match clock_opt with
+                   | Some clock ->
+                     (try Eio.Time.with_timeout_exn clock t run_fn with
+                      | Eio.Time.Timeout ->
+                        Log.Misc.info
+                          "[cascade-fallback] cascade %s: provider %s per-provider \
+                           timeout after %.1fs, falling back"
+                          ctx.cascade_name
+                          provider_cfg.model_id
+                          t;
+                        Error
+                          (Agent_sdk.Error.Api
+                             (Timeout
+                                { message =
+                                    Printf.sprintf "Per-provider timeout after %.1fs" t
+                                })))
+                   | None -> run_fn ()))
+            in
+            Ok result)
+     with
+     | Error err ->
+       finalize_liveness ();
+       Error err, None
+     | Ok result ->
+       finalize_liveness ();
+       let result =
+         Result.map_error
+           (Cascade_attempt_fsm.enrich_sdk_error
+              ~cascade_name:ctx.error_cascade_name
+              ~provider_cfg)
+           result
+       in
+       let checkpoint_after =
+         Keeper_turn_driver_helpers.checkpoint_after_attempt
+           ?agent_ref:ctx.agent_ref
+           !local_agent_ref
+       in
+       result, checkpoint_after)
+;;


### PR DESCRIPTION
## Summary

Extract the 248 LOC `try_provider` closure from `Keeper_turn_driver.run_named` into a standalone module `Keeper_turn_driver_try_provider`, making all ~51 captured variables explicit via a `try_provider_ctx` record.

- **New module**: `lib/keeper/keeper_turn_driver_try_provider.ml` — `try_provider_ctx` type + `run_try_provider` function
- **Facade change**: `keeper_turn_driver.ml` 1147→955 LOC (-192 net). Inline closure replaced with ctx record construction + module call
- **No behavioral change**: `try_provider` signature unchanged, `try_cascade` and downstream code untouched

### Dependency direction
```
keeper_turn_driver (facade)
  → keeper_turn_driver_try_provider
    → Cascade_oas_runner, Cascade_error_classify, Cascade_attempt_fsm
    → Keeper_turn_driver_helpers, Keeper_types
```
No circular references.

### RFC-0051 §3.2 pre-measurement
Capture inventory: [rfc-0051-pr-3a-capture-inventory.md](https://github.com/jeong-sik/masc-mcp/compare/rfc-0051-pr-3a-try-provider) (4-way classification of 51 captured variables)

## Test plan
- [x] `dune build --root .` passes (exit 0)
- [ ] `dune runtest` (queued for CI)
- [ ] No keeper_turn_driver unit tests exist — type-level correctness verified by compiler
- [ ] Integration verification: existing keeper lifecycle tests exercise this path

🤖 Generated with [Claude Code](https://claude.com/claude-code)