### PR TITLE
fix(tools_oas): remove call to deleted record_keeper_tool_call

### DIFF
--- a/lib/keeper/keeper_tools_oas.ml
+++ b/lib/keeper/keeper_tools_oas.ml
@@ -514,10 +514,6 @@ let make_keeper_tool_handler
         meta.name
         ~tool_name:name
         ~success:false;
-      Keeper_exec_tools.record_keeper_tool_call
-        ~tool_name:name
-        ~success:false
-        ~duration_ms;
       ignore (Tool_dispatch.run_post_hooks validation_result);
       broadcast_keeper_tool_call_event
         ~keeper_name:meta.name


### PR DESCRIPTION
## Summary

`Keeper_exec_tools.record_keeper_tool_call` was removed during the
keeper_exec_tools refactoring in #14351, but one call site in
`lib/keeper/keeper_tools_oas.ml` (input-validation error path) was
left behind, causing an **Unbound value** build error.

## Changes

- Remove the orphaned call to `Keeper_exec_tools.record_keeper_tool_call`
  in `keeper_tools_oas.ml:517`.

## Verification

- [x] `dune build --root . @check` passes
- [x] `dune build --root . test/test_keeper_exec_status.exe` passes

## Context

This was discovered while auditing pending last_blocker / build-error
tasks from a previous session.  The three originally flagged items
(test_keeper_exec_status sites, remaining test build errors, lib
last_blocker_class references) were already resolved in main; this
orphaned call was the only remaining issue.