### PR TITLE
RFC-0041 follow-up step 2 — drop Big_three/Tool_rerank enum (catalog SSOT only)

### DIFF
--- a/lib/cascade/cascade_catalog_runtime.ml
+++ b/lib/cascade/cascade_catalog_runtime.ml
@@ -621,10 +621,8 @@ let runtime_required_profile_names ?config_path () =
         | Some path -> path
         | None -> "")
   in
-  if String.equal config_path "" then
-    Keeper_cascade_profile.known_cascades |> List.sort_uniq String.compare
-  else
-    runtime_required_profiles ~config_path
+  if String.equal config_path "" then []
+  else runtime_required_profiles ~config_path
 
 let validate_path_result ?sw ?net ~config_path () =
   let checked_at = Unix.gettimeofday () in

--- a/lib/keeper/keeper_cascade_profile.ml
+++ b/lib/keeper/keeper_cascade_profile.ml
@@ -1,36 +1,16 @@
 (** See {!Keeper_cascade_profile} interface for rationale. *)
 
-(** See {!Keeper_cascade_profile} interface for rationale. *)
-
 open Cascade_ref
 
-(** SSOT variant for the 1+1 cascade model.
-
-    One keeper-assignable bootstrap profile ({!Big_three}) and one system-only
-    profile ({!Tool_rerank}). Historical phase-routing, judge, evaluator, and
-    local names are logical route keys, not live catalog profiles.
-
-    Adding a new profile is a compile-time event: add a variant here, then
-    exhaustive [match] sites flag every consumer that needs to handle it.
-    Personal/playground-only cascades must NOT be added here — they live in
-    [$MASC_BASE_PATH/.masc/playground/.../cascade.json] only. *)
-type t =
-  | Big_three
-  | Tool_rerank
-
-let to_string = function
-  | Big_three -> "big_three"
-  | Tool_rerank -> "tool_rerank"
-
-let all = [ Big_three; Tool_rerank ]
-
-(** All known cascade profile names, derived from the variant. Consumers
-    that still operate on strings can use this list; new code should
-    take {!t} directly. *)
-let known_cascades = List.map to_string all
-
-let default = Big_three
-let default_name = to_string default
+(** Per RFC-0041 cascade routing SSOT, the live cascade catalog
+    (cascade.json) is the only source of truth for cascade profile
+    names.  There is no compile-time enum here — anything that needs to
+    know "what profiles are available" reads them from
+    [Cascade_config_loader.load_catalog] / [catalog_names_*] below.  If
+    the catalog is empty at runtime,
+    [Cascade_catalog_runtime.validate_path_result] is the boot-time
+    gate that rejects keeper boot, so a missing catalog never reaches
+    these helpers. *)
 
 type logical_use = Cascade_ref.logical_use =
   | Keeper_turn
@@ -61,18 +41,6 @@ let cascade_name_for_use = Cascade_routes.cascade_name_for_use
 type runtime_name = Runtime_name of string
 
 let runtime_name_to_string (Runtime_name value) = value
-
-let of_string_opt (raw : string) : t option =
-  match String.trim raw |> String.lowercase_ascii with
-  | "" -> Some default
-  | "big_three" -> Some Big_three
-  | "tool_rerank" -> Some Tool_rerank
-  | _ -> None
-
-let canonical (raw : string) : t =
-  match of_string_opt raw with
-  | Some t -> t
-  | None -> default
 
 let catalog_entries ?config_path () =
   let path_opt =
@@ -259,44 +227,30 @@ let fallback_cascade_for ?config_path name =
 let canonicalize_with_catalog ~catalog raw =
   match String.trim raw with
   | "" -> Cascade_routes.fallback_name_for_catalog Keeper_turn ~catalog
-  | trimmed -> (
+  | trimmed ->
       if List.mem trimmed catalog then trimmed
-      else match of_string_opt trimmed with
-      | Some profile ->
-          let name = to_string profile in
-          if catalog = [] || List.mem name catalog then name
-          else Cascade_routes.fallback_name_for_catalog Keeper_turn ~catalog
-      | None ->
-          match logical_use_of_string_opt trimmed with
-          | Some use -> Cascade_routes.fallback_name_for_catalog use ~catalog
-          | None -> Cascade_routes.fallback_name_for_catalog Keeper_turn ~catalog)
+      else (
+        match logical_use_of_string_opt trimmed with
+        | Some use -> Cascade_routes.fallback_name_for_catalog use ~catalog
+        | None -> trimmed)
 
 let normalize_declared_name (raw : string) : string =
   let trimmed = String.trim raw in
   if String.equal trimmed "" then
     cascade_name_for_use Keeper_turn
   else
-    match of_string_opt trimmed with
-    | Some t -> to_string t
-    | None -> (
-        match logical_use_of_string_opt trimmed with
-        | Some use -> cascade_name_for_use use
-        | None -> trimmed)
+    match logical_use_of_string_opt trimmed with
+    | Some use -> cascade_name_for_use use
+    | None -> trimmed
 
 let resolve_live_with_catalog ~catalog raw =
   let trimmed = String.trim raw in
   let normalized =
     if List.mem trimmed catalog then trimmed
     else
-      match of_string_opt trimmed with
-      | Some t ->
-          let name = to_string t in
-          if catalog = [] || List.mem name catalog then name
-          else Cascade_routes.fallback_name_for_catalog Keeper_turn ~catalog
-      | None -> (
-          match logical_use_of_string_opt trimmed with
-          | Some use -> Cascade_routes.fallback_name_for_catalog use ~catalog
-          | None -> trimmed)
+      match logical_use_of_string_opt trimmed with
+      | Some use -> Cascade_routes.fallback_name_for_catalog use ~catalog
+      | None -> trimmed
   in
   if List.mem normalized catalog then normalized
   else Cascade_routes.fallback_name_for_catalog Keeper_turn ~catalog
@@ -308,10 +262,6 @@ let canonicalize (raw : string) : string =
   canonicalize_with_catalog ~catalog:(catalog_names ()) raw
 
 let runtime_name_of_string raw = Runtime_name (canonicalize raw)
-
-let models_key_t t = to_string t ^ "_models"
-let temperature_key_t t = to_string t ^ "_temperature"
-let max_tokens_key_t t = to_string t ^ "_max_tokens"
 
 let models_key name = canonicalize name ^ "_models"
 let temperature_key name = canonicalize name ^ "_temperature"

--- a/lib/keeper/keeper_cascade_profile.mli
+++ b/lib/keeper/keeper_cascade_profile.mli
@@ -1,47 +1,16 @@
-(** Canonical keeper cascade profile names and config-driven route lookup.
+(** Config-driven cascade profile name resolution.
 
-    Keepers historically used stringly-typed cascade names in TOML, runtime
-    metadata, telemetry labels, and cascade.json lookups. This module is the
-    SSOT for the small built-in profile vocabulary and the logical route keys
-    that resolve through [cascade.json]/[cascade.toml].
-
-    One keeper-assignable bootstrap profile (Big_three) and one system-only
-    profile (Tool_rerank). Historical routing, judge, evaluator, and local names
-    are logical uses, not live catalog profiles.
+    Per RFC-0041 cascade routing SSOT, the live cascade catalog
+    (cascade.json) is the only source of truth for cascade profile
+    names — there is no compile-time enum here.  Code that needs to
+    know "what profiles are available" reads them through
+    {!catalog_names} / {!catalog_names_result} /
+    {!catalog_names_with_toml_fallback}; the boot-time gate at
+    [Cascade_catalog_runtime.validate_path_result] rejects keeper boot
+    when the catalog is empty so a missing catalog never reaches the
+    helpers below.
 
     @since 0.9.5 *)
-
-(** SSOT variant for the 1+1 cascade model.
-
-    One keeper-assignable bootstrap profile ({!Big_three}) and one system-only
-    profile ({!Tool_rerank}).
-
-    Adding a new profile is a compile-time event: add a variant here, then
-    exhaustive [match] sites flag every consumer that needs to handle it.
-    Personal/playground-only cascades must NOT be added here — they live in
-    [$MASC_BASE_PATH/.masc/playground/.../cascade.json] only. *)
-type t =
-  | Big_three
-  | Tool_rerank
-
-val all : t list
-(** [all] is exhaustive: every variant constructor of {!t} appears
-    exactly once. *)
-
-val to_string : t -> string
-(** Canonical lowercase-snake-case name. *)
-
-val of_string_opt : string -> t option
-(** Parse a raw cascade profile name into the built-in variant. Logical route
-    names and legacy aliases return [None]; use {!cascade_name_for_use} for
-    call sites that mean "governance judge", "operator judge", etc. *)
-
-val canonical : string -> t
-(** [canonical raw] = [of_string_opt raw |> Option.value ~default]. *)
-
-val default : t
-val default_name : string
-(** [default_name = to_string default = "big_three"]. *)
 
 type logical_use = Cascade_ref.logical_use =
   | Keeper_turn
@@ -68,8 +37,8 @@ val logical_use_key : logical_use -> string
 (** Stable config key under [routes]. *)
 
 val logical_use_of_string_opt : string -> logical_use option
-(** Parse a logical route key or historical alias. Concrete profile names such
-    as [big_three] and [tool_rerank] are not logical route keys. *)
+(** Parse a logical route key or historical alias.  Concrete cascade
+    profile names are not logical route keys — they live in the catalog. *)
 
 val cascade_name_for_use : ?config_path:string -> logical_use -> string
 (** Runtime cascade profile for a logical call site.
@@ -77,9 +46,9 @@ val cascade_name_for_use : ?config_path:string -> logical_use -> string
     Resolution order:
     1. [routes.<logical_use_key>] from the active cascade config, when it points
        at a live catalog profile.
-    2. A catalog-derived fallback based on route policy: keeper work prefers a
-       keeper-assignable profile; system work prefers a system-only profile.
-    3. The two-profile seed names only when no catalog is available.
+    2. The first catalog entry from the live catalog.
+    Raises [Failure] when the catalog is empty — boot-time validation is
+    the upstream gate that prevents this state at runtime.
 
     This is the boundary for code that used to hardcode profile names such as
     ["governance_judge"], ["operator_judge"], ["local_recovery"], or
@@ -88,19 +57,15 @@ val cascade_name_for_use : ?config_path:string -> logical_use -> string
 val configured_route_targets : ?config_path:string -> unit -> string list
 (** Unique non-empty profile names referenced from [routes]. *)
 
-val known_cascades : string list
-(** [known_cascades = List.map to_string all]. Provided for consumers
-    that still operate on strings; new code should take {!t} directly. *)
-
 type runtime_name = Runtime_name of string
-(** Catalog-aware cascade name after point-of-use runtime normalization.
-    Unlike {!t}, this can carry dynamic cascade catalog names. *)
+(** Catalog-aware cascade name after point-of-use runtime normalization. *)
 
 val runtime_name_to_string : runtime_name -> string
 val runtime_name_of_string : string -> runtime_name
 (** Canonicalizes legacy aliases and live catalog names for runtime
-    telemetry/admission labels. Unknown nonblank values fall back to
-    {!default_name}, matching {!canonicalize}. *)
+    telemetry/admission labels.  Raw names that match a logical route key are
+    resolved through {!cascade_name_for_use}; everything else passes through
+    after [String.trim]. *)
 
 val catalog_names : ?config_path:string -> unit -> string list
 (** Live profile catalog discovered from the active [cascade.json].
@@ -172,29 +137,28 @@ val canonicalize_with_catalog : catalog:string list -> string -> string
 val resolve_live_with_catalog : catalog:string list -> string -> string
 (** Resolves a keeper-declared cascade against an explicit live catalog.
 
-    Compile-time built-in names absent from the runtime catalog are treated
-    as drift and fall back to {!default_name}. *)
+    Names already present in the catalog pass through; logical route
+    aliases collapse via [routes]; otherwise the input is returned
+    trimmed and the catalog membership is the caller's responsibility. *)
 
 val resolve_live : ?config_path:string -> string -> string
 (** Like {!resolve_live_with_catalog}, but reads the active catalog from the
     resolved cascade config path. *)
 
 val canonicalize : string -> string
-(** [canonicalize raw = to_string (canonical raw)]. Legacy aliases collapse
-    to their canonical name, live catalog names pass through, unknown values
-    fall back to {!default_name}. *)
+(** Catalog-aware normalization: legacy aliases collapse to their canonical
+    name through [routes], live catalog names pass through, otherwise
+    [String.trim] is applied and the name is returned as-is.  Raises
+    [Failure] when the catalog is empty (boot-time gate is upstream). *)
 
 val normalize_declared_name : string -> string
 (** Normalizes keeper-side implicit default and legacy aliases.
-    Unknown nonblank names are preserved (trimmed). *)
+    Logical route aliases resolve through {!cascade_name_for_use}; otherwise
+    the trimmed input is returned. *)
 
 (** {1 cascade.json key helpers} *)
 
-val models_key_t : t -> string
-val temperature_key_t : t -> string
-val max_tokens_key_t : t -> string
-
-(** String-based wrappers; first canonicalize, then build the key. *)
+(** First canonicalize, then build the key. *)
 val models_key : string -> string
 val temperature_key : string -> string
 val max_tokens_key : string -> string

--- a/lib/keeper/keeper_persona_authoring.ml
+++ b/lib/keeper/keeper_persona_authoring.ml
@@ -402,8 +402,7 @@ let normalize_cascade_name raw =
     | _ -> []
   in
   let known =
-    Keeper_cascade_profile.known_cascades
-    @ Keeper_config.phase_routing_cascade_names
+    Keeper_config.phase_routing_cascade_names
     @ catalog
   in
   if List.mem (String.lowercase_ascii normalized) known

--- a/lib/keeper/keeper_types_profile.ml
+++ b/lib/keeper/keeper_types_profile.ml
@@ -46,8 +46,7 @@ let sandbox_profile_to_string = function
 
 let reserved_cascade_names =
   List.sort_uniq String.compare
-    (Keeper_cascade_profile.known_cascades
-     @ phase_routing_cascade_names
+    (phase_routing_cascade_names
      @ [ tool_use_strict_cascade_name ])
 
 (** Parse a sandbox profile string. Canonical values are ["local"] and

--- a/test/test_dashboard_cascade.ml
+++ b/test/test_dashboard_cascade.ml
@@ -878,9 +878,9 @@ let lookup fields key =
   | None -> fail (Printf.sprintf "%s missing" key)
 
 let test_keeper_profile_preserves_raw_unknown_cascade () =
-  (* Genuinely unknown cascade — not in [Keeper_cascade_profile.t] and
-     not a registered legacy alias. Typical sources: typos, personal
-     playground profiles, vendor drift. The raw string must survive so
+  (* Genuinely unknown cascade — not in the live catalog and not a
+     registered logical alias.  Typical sources: typos, personal
+     playground profiles, vendor drift.  The raw string must survive so
      the dashboard [canonical] column renders the mismatch. *)
   let fs =
     Masc_mcp.Dashboard_cascade.keeper_profile_fields

--- a/test/test_keeper_cascade_profile.ml
+++ b/test/test_keeper_cascade_profile.ml
@@ -2,9 +2,10 @@ open Alcotest
 
 module Profile = Masc_mcp.Keeper_cascade_profile
 
-(* Only concrete profile variants round-trip through [of_string_opt] ->
-   [to_string]. Legacy aliases are logical route names, not profile names. *)
-let variant_names = [ "big_three"; "tool_rerank" ]
+(* RFC-0041: catalog (cascade.json) is the only source of truth for cascade
+   profile names.  This suite exercises the catalog-driven resolution paths
+   and the boot-time invariant that the catalog must not be empty when the
+   helpers are reached at runtime. *)
 
 let write_file path contents =
   let oc = open_out path in
@@ -24,64 +25,6 @@ let with_temp_config contents f =
       try Unix.rmdir dir with _ -> ())
     (fun () -> f path)
 
-let test_round_trip () =
-  List.iter
-    (fun name ->
-      let canon = Profile.canonicalize name in
-      check string ("round-trip " ^ name) name canon)
-    variant_names
-
-let test_known_cascades_covers_variants () =
-  List.iter
-    (fun name ->
-      let listed = List.mem name Profile.known_cascades in
-      check bool ("known_cascades contains " ^ name) true listed)
-    variant_names
-
-let test_legacy_aliases_follow_keeper_fallback_without_catalog () =
-  let aliases = [ "oas-keeper_unified"; "coding_first"; "oas-coding_first";
-                  "keeper_turn"; "keeper_reply"; "default"; "keeper_unified";
-                  "sangsu"; "local_mlx_vlm_qwen36";
-                  "nick0cave"; "capacity_queue_trio"; "vendor_mix_balanced";
-                  "cost_tier_ladder"; "oauth_cli_rotate"; "quality_sticky_glm51";
-                  "tool_use_strict"; "resilient_breaker"; "" ] in
-  List.iter
-    (fun raw ->
-      let canon = Profile.canonicalize_with_catalog ~catalog:[] raw in
-      check string ("alias " ^ raw ^ " -> fallback") "big_three" canon)
-    aliases
-
-let test_logical_route_names_are_not_profile_variants () =
-  check (option (testable (fun fmt _ -> Format.fprintf fmt "<profile>") (=)))
-    "keeper_unified is not a built-in profile"
-    None
-    (Profile.of_string_opt "keeper_unified");
-  check (option (testable (fun fmt _ -> Format.fprintf fmt "<profile>") (=)))
-    "tool_use_strict is not a built-in profile"
-    None
-    (Profile.of_string_opt "tool_use_strict");
-  check (option (testable (fun fmt _ -> Format.fprintf fmt "<profile>") (=)))
-    "resilient_breaker is not a built-in profile"
-    None
-    (Profile.of_string_opt "resilient_breaker");
-  check (option (testable (fun fmt _ -> Format.fprintf fmt "<profile>") (=)))
-    "local_only is not a built-in profile"
-    None
-    (Profile.of_string_opt "local_only");
-  check (option (testable (fun fmt _ -> Format.fprintf fmt "<profile>") (=)))
-    "local_recovery is not a built-in profile"
-    None
-    (Profile.of_string_opt "local_recovery")
-
-let test_unknown_falls_back_to_default () =
-  check (option (testable (fun fmt _ -> Format.fprintf fmt "<profile>") (=)))
-    "unknown returns None from of_string_opt"
-    None
-    (Profile.of_string_opt "definitely_not_a_real_cascade_xyz");
-  check string "canonicalize forces fallback to big_three"
-    "big_three"
-    (Profile.canonicalize "definitely_not_a_real_cascade_xyz")
-
 let test_catalog_names_follow_live_config () =
   with_temp_config
     {|
@@ -100,10 +43,7 @@ let test_catalog_names_follow_live_config () =
     (fun path ->
       let catalog = Profile.catalog_names ~config_path:path () in
       check (list string) "catalog_names follows cascade schema keys"
-        [
-          "custom_live";
-          "tool_rerank";
-        ]
+        [ "custom_live"; "tool_rerank" ]
         catalog;
       check (list string) "keeper catalog excludes system-only cascades"
         [ "custom_live" ]
@@ -111,20 +51,14 @@ let test_catalog_names_follow_live_config () =
       check (list string) "system catalog follows explicit metadata"
         [ "tool_rerank" ]
         (Profile.system_catalog_names ~config_path:path ());
-      check string "dynamic live profile survives canonicalization"
+      check string "exact catalog name passes through canonicalize"
         "custom_live"
         (Profile.canonicalize_with_catalog ~catalog "custom_live");
-      check string "keeper_unified is a logical alias, not profile"
+      check string "logical alias resolves through routes"
         "custom_live"
         (Profile.canonicalize_with_catalog ~catalog "keeper_unified");
-      check string "tool_use_strict is a logical alias, not profile"
-        "custom_live"
-        (Profile.canonicalize_with_catalog ~catalog "tool_use_strict");
-      check string "dynamic live profile requires exact match"
-        "custom_live"
-        (Profile.canonicalize_with_catalog ~catalog "Custom_Live");
-      check string "unknown live profile still falls back"
-        "custom_live"
+      check string "operator-defined raw passes through trimmed"
+        "missing_profile"
         (Profile.canonicalize_with_catalog ~catalog "missing_profile"))
 
 let test_resolve_live_with_catalog_requires_active_membership () =
@@ -132,9 +66,7 @@ let test_resolve_live_with_catalog_requires_active_membership () =
     {|
       {
         "default_models": ["ollama:auto"],
-        "custom_live_models": ["ollama:auto"],
-        "keeper_unified_models": ["ollama:auto"],
-        "tool_use_strict_models": ["ollama:auto"]
+        "custom_live_models": ["ollama:auto"]
       }
     |}
     (fun path ->
@@ -142,19 +74,10 @@ let test_resolve_live_with_catalog_requires_active_membership () =
       check string "active custom profile survives live resolution"
         "custom_live"
         (Profile.resolve_live_with_catalog ~catalog "custom_live");
-      check string "keeper_unified resolves through catalog fallback"
+      check string "logical alias resolves through catalog fallback"
         "custom_live"
         (Profile.resolve_live_with_catalog ~catalog "keeper_unified");
-      check string "tool_use_strict resolves through catalog fallback"
-        "custom_live"
-        (Profile.resolve_live_with_catalog ~catalog "tool_use_strict");
-      check string "legacy alias resolves through active catalog fallback"
-        "custom_live"
-        (Profile.resolve_live_with_catalog ~catalog "oas-keeper_unified");
-      check string "inactive built-in profile falls back to default"
-        "custom_live"
-        (Profile.resolve_live_with_catalog ~catalog "vendor_mix_balanced");
-      check string "unknown profile falls back to default"
+      check string "absent profile falls to first catalog entry"
         "custom_live"
         (Profile.resolve_live_with_catalog ~catalog "missing_profile"))
 
@@ -162,14 +85,14 @@ let test_routes_resolve_logical_uses_to_configured_profiles () =
   with_temp_config
     {|
       {
-        "big_three_models": ["codex_cli:auto"],
+        "alpha_models": ["codex_cli:auto"],
         "custom_live_models": ["gemini_cli:auto"],
-        "tool_rerank_models": ["codex_cli:auto"],
-        "tool_rerank_keeper_assignable": false,
+        "beta_models": ["codex_cli:auto"],
+        "beta_keeper_assignable": false,
         "routes": {
           "governance_judge": "custom_live",
-          "operator_judge": "big_three",
-          "llm_rerank": "tool_rerank"
+          "operator_judge": "alpha",
+          "llm_rerank": "beta"
         }
       }
     |}
@@ -178,16 +101,16 @@ let test_routes_resolve_logical_uses_to_configured_profiles () =
         "custom_live"
         (Profile.cascade_name_for_use ~config_path:path Profile.Governance_judge);
       check string "operator route target"
-        "big_three"
+        "alpha"
         (Profile.cascade_name_for_use ~config_path:path Profile.Operator_judge);
       check string "tool rerank route target"
-        "tool_rerank"
+        "beta"
         (Profile.cascade_name_for_use ~config_path:path Profile.Tool_rerank_use);
       check (list string) "route targets are discovered"
-        [ "big_three"; "custom_live"; "tool_rerank" ]
+        [ "alpha"; "beta"; "custom_live" ]
         (Profile.configured_route_targets ~config_path:path ()))
 
-let test_missing_route_uses_catalog_fallback_not_logical_name () =
+let test_missing_route_falls_back_to_first_catalog_entry () =
   with_temp_config
     {|
       {
@@ -197,46 +120,11 @@ let test_missing_route_uses_catalog_fallback_not_logical_name () =
       }
     |}
     (fun path ->
-      check string "missing governance route uses keeper-assignable profile"
+      check string "missing governance route falls to first catalog entry"
         "alpha"
-        (Profile.cascade_name_for_use ~config_path:path Profile.Governance_judge);
-      check string "missing rerank route still prefers tool_rerank when present"
-        "tool_rerank"
-        (Profile.cascade_name_for_use ~config_path:path Profile.Tool_rerank_use))
+        (Profile.cascade_name_for_use ~config_path:path Profile.Governance_judge))
 
-let test_routes_do_not_use_unvalidated_targets_without_catalog () =
-  with_temp_config
-    {|
-      {
-        "routes": {
-          "governance_judge": "missing_profile",
-          "llm_rerank": "missing_rerank"
-        }
-      }
-    |}
-    (fun path ->
-      check string "keeper logical route falls to safe keeper default"
-        "big_three"
-        (Profile.cascade_name_for_use ~config_path:path Profile.Governance_judge);
-      check string "system logical route falls to safe system default"
-        "tool_rerank"
-        (Profile.cascade_name_for_use ~config_path:path Profile.Tool_rerank_use))
-
-let test_missing_system_route_prefers_system_only_catalog_profile () =
-  with_temp_config
-    {|
-      {
-        "alpha_models": ["gemini_cli:auto"],
-        "short_scoring_models": ["codex_cli:auto"],
-        "short_scoring_keeper_assignable": false
-      }
-    |}
-    (fun path ->
-      check string "system route uses system-only catalog profile"
-        "short_scoring"
-        (Profile.cascade_name_for_use ~config_path:path Profile.Tool_rerank_use))
-
-let test_catalog_read_failures_do_not_fallback_to_hardcoded_names () =
+let test_catalog_read_failures_stay_empty () =
   let missing = Filename.concat (Filename.get_temp_dir_name ()) "missing-cascade.json" in
   check (list string) "catalog_names stays empty on read failure"
     []
@@ -248,27 +136,34 @@ let test_catalog_read_failures_do_not_fallback_to_hardcoded_names () =
     []
     (Profile.system_catalog_names ~config_path:missing ())
 
+let test_empty_catalog_raises_boot_invariant () =
+  (* RFC-0041: when the catalog is empty, runtime callers must never reach
+     [fallback_name_for_catalog] — boot-time validation is the upstream
+     gate. The helper raises [Failure] to surface the invariant violation
+     loudly when the gate is bypassed. *)
+  check_raises "fallback_name_for_catalog raises on empty catalog"
+    (Failure
+       "cascade catalog empty when resolving logical use \"keeper_turn\" — \
+        Cascade_catalog_runtime.validate_path_result should have rejected \
+        keeper boot before this is reached")
+    (fun () ->
+      let _ =
+        Profile.canonicalize_with_catalog ~catalog:[] "" in
+      ())
+
 let () =
   run "keeper_cascade_profile"
-    [ ( "ssot",
-        [ test_case "active names round-trip" `Quick test_round_trip;
-          test_case "known_cascades covers active" `Quick test_known_cascades_covers_variants;
-          test_case "legacy aliases follow fallback" `Quick
-            test_legacy_aliases_follow_keeper_fallback_without_catalog;
-          test_case "logical route names are not profile variants" `Quick
-            test_logical_route_names_are_not_profile_variants;
-          test_case "unknown falls back to default" `Quick test_unknown_falls_back_to_default;
-          test_case "catalog_names follow live config" `Quick test_catalog_names_follow_live_config;
+    [ ( "catalog_ssot",
+        [ test_case "catalog_names follow live config" `Quick
+            test_catalog_names_follow_live_config;
           test_case "resolve_live_with_catalog requires active membership" `Quick
             test_resolve_live_with_catalog_requires_active_membership;
           test_case "routes resolve logical uses" `Quick
             test_routes_resolve_logical_uses_to_configured_profiles;
-          test_case "missing route uses catalog fallback" `Quick
-            test_missing_route_uses_catalog_fallback_not_logical_name;
-          test_case "routes require validated catalog targets" `Quick
-            test_routes_do_not_use_unvalidated_targets_without_catalog;
-          test_case "missing system route uses system-only fallback" `Quick
-            test_missing_system_route_prefers_system_only_catalog_profile;
+          test_case "missing route falls to first catalog entry" `Quick
+            test_missing_route_falls_back_to_first_catalog_entry;
           test_case "catalog read failures stay empty" `Quick
-            test_catalog_read_failures_do_not_fallback_to_hardcoded_names ] )
+            test_catalog_read_failures_stay_empty;
+          test_case "empty catalog raises boot invariant" `Quick
+            test_empty_catalog_raises_boot_invariant ] )
     ]

--- a/test/test_keeper_toml_config_validation.ml
+++ b/test/test_keeper_toml_config_validation.ml
@@ -271,9 +271,7 @@ keeper_assignable = false
       | Ok _ -> fail "missing_profile cascade_name should be rejected"
       | Error e ->
           check bool "error lists live catalog profile" true
-            (contains ~needle:"custom_live" e);
-          check bool "error lists reserved bootstrap profile" true
-            (contains ~needle:Masc_mcp.Keeper_cascade_profile.default_name e))
+            (contains ~needle:"custom_live" e))
 
 let test_cascade_name_accepts_catalog_entry () =
   (* "tool_use_strict" is a known catalog entry in cascade.json,
@@ -288,12 +286,12 @@ let test_cascade_name_accepts_catalog_entry () =
     with _ -> []
   in
   let test_name =
-    (* Pick an assignable catalog entry that is NOT a compile-time variant *)
+    (* Pick any keeper-assignable catalog entry that isn't a phase-routing
+       reserved alias — the validator now treats catalog membership as the
+       only acceptance criterion. *)
     match
       List.find_opt
-        (fun n ->
-           not (List.mem n Masc_mcp.Keeper_cascade_profile.known_cascades)
-           && not (List.mem n [ "local_only"; "local_recovery" ]))
+        (fun n -> not (List.mem n [ "local_only"; "local_recovery" ]))
         catalog
     with
     | Some name -> name


### PR DESCRIPTION
## 목표
사용자 통찰 적용: \`Big_three | Tool_rerank\`는 *configuration*이지 *code*가 아니다. 운영자가 cascade.json에서 자유롭게 정의/이름변경할 수 있어야 하는데, 코드 enum이 그 자유를 hardcode로 박아둠. enum 자체와 관련 helper(default, default_name, known_cascades 등)를 모두 제거하고 cascade.json catalog를 단일 SSOT로 정착.

## 변경 요약
**\`Keeper_cascade_profile\` 제거 항목:**
- \`type t = Big_three | Tool_rerank\` + 생성자
- \`to_string\`, \`of_string_opt\`, \`canonical\`, \`default\`, \`default_name\`, \`all\`, \`known_cascades\`
- \`models_key_t\` / \`temperature_key_t\` / \`max_tokens_key_t\` (caller 0)

**helper 의미 변경 (시그니처는 보존):**
- \`canonicalize_with_catalog\`, \`normalize_declared_name\`, \`resolve_live_with_catalog\`이 더 이상 unknown raw를 enum으로 collapse하지 않음. catalog membership + logical route alias로 처리, 그 외 trim된 raw 그대로 통과 (catalog 검증은 caller 책임).
- \`runtime_name_of_string\`은 catalog-aware \`canonicalize\`를 거치는 \`Runtime_name\` wrapper로 단순화.

**caller cleanup (~5 lib + 2 test):**
- \`cascade_catalog_runtime.runtime_required_profile_names\`: config_path 없으면 \`[]\` (boot validation gate가 upstream).
- \`keeper_persona_authoring\`의 known list: phase routing + catalog만 (known_cascades 제거).
- \`keeper_types_profile.reserved_cascade_names\`: phase_routing + tool_use_strict.
- \`test_keeper_cascade_profile.ml\` 재작성: catalog SSOT 시나리오 + boot invariant violation 테스트.
- \`test_keeper_toml_config_validation.ml\`: \`default_name\` assertion / \`known_cascades\` filter 제거.

**Net -195 LOC.**

## 컨텍스트
RFC-0041 cascade routing 리뉴얼의 마지막 enum 잔재. 사용자: "Big_three라는 건 그냥 configuration에서 맘대로 정하는 거잖아 / 이게 왜 코드 안으로 들어오냐고 / Cascade 기능 리뉴얼을 한 이유가 이런 거 안 하려고인데..."

이번 PR로 \`Keeper_cascade_profile.{t, Big_three, Tool_rerank, default, default_name, known_cascades, of_string_opt, canonical, to_string, all, models_key_t, temperature_key_t, max_tokens_key_t}\` grep 0건 달성.

## 로컬 검증
- ✅ Step 1 base(36ec9c9ad5) 위에서 \`dune build --root . @check\` 클린 (commit 시점).
- ✅ 새 \`test_keeper_cascade_profile.ml\` 6/6 테스트 통과.
- ✅ enum API grep 0건.

## 남은 미검증 / Main blocker
- 본 PR rebase 시점(2026-05-09)에 main에 *우리 영역 밖의* 빌드 blocker 존재 (lib/exec/exec_gate.ml 등의 typed Agent_id.t fallout from #14350). PR이 머지 가능해지려면 그쪽 blocker 선행 fix 필요.
- 우리 변경 자체의 의미 변경 영향: keeper 코드 도처에서 사용하는 \`canonicalize\`/\`normalize_declared_name\`/\`resolve_live*\`의 enum-collapse 분기가 사라짐. 운영자가 cascade.json에 없는 raw cascade name을 keeper meta에 넣으면 silently "big_three"로 collapse하던 것이 raw 그대로 통과 → 후속 catalog membership 검증에서 explicit reject. 이는 RFC-0041 의도(silent fallback 금지) 정합.

## RFC
RFC-0041 Cascade Routing Architecture follow-up — *마지막 enum 잔재* 제거 by config-driven SSOT.

🤖 Generated with [Claude Code](https://claude.com/claude-code)