### PR TITLE
fix(build): resolve 3 unbound value / type mismatch errors in main

### DIFF
--- a/lib/keeper/keeper_tools_oas.ml
+++ b/lib/keeper/keeper_tools_oas.ml
@@ -514,10 +514,6 @@ let make_keeper_tool_handler
         meta.name
         ~tool_name:name
         ~success:false;
-      Keeper_exec_tools.record_keeper_tool_call
-        ~tool_name:name
-        ~success:false
-        ~duration_ms;
       ignore (Tool_dispatch.run_post_hooks validation_result);
       broadcast_keeper_tool_call_event
         ~keeper_name:meta.name

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -1709,7 +1709,7 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
                  meta.name;
                Keeper_registry.set_turn_phase
                  ~base_path:config.base_path meta.name
-                 Keeper_registry.Turn_finalizing;
+                 Keeper_registry.(Packed Turn_finalizing);
                Error order_err
              | None ->
             let committed_tools = committed_mutating_tools_snapshot () in

--- a/lib/mcp_server_eio_protocol.ml
+++ b/lib/mcp_server_eio_protocol.ml
@@ -761,7 +761,7 @@ let handle_request
             | Eio.Cancel.Cancelled _ as exn -> raise exn
             | exn ->
               let err = Printexc.to_string exn in
-              Log.Mcp.error "Request handling failed: method=%s: %s" method_ err;
+              Log.Mcp.error "Request handling failed: method=%s: %s" req.method_ err;
               make_error ~id (-32603) (Printf.sprintf "Internal error: %s" err)))
   with
   | Eio.Cancel.Cancelled _ as exn -> raise exn


### PR DESCRIPTION
## Summary
Fixes 3 build errors discovered in latest main:

1. **`mcp_server_eio_protocol.ml:764`** — `Unbound value method_`
   - Pattern variable `method_` from the inner `match` was out of scope in the `with` exception handler.
   - Fixed by referencing `req.method_` directly.

2. **`keeper_tools_oas.ml:517`** — `Unbound value Keeper_exec_tools.record_keeper_tool_call`
   - Orphaned call site: `record_keeper_tool_call` was removed during `keeper_exec_tools.ml` refactoring but the caller in `keeper_tools_oas.ml` was left behind.
   - Fixed by removing the dead call.

3. **`keeper_unified_turn.ml:1712`** — `Turn_finalizing` constructor type mismatch
   - `Keeper_registry.set_turn_phase` expects a `packed_turn_phase` GADT, not a bare `turn_phase` constructor.
   - Fixed by wrapping with `Packed`: `Keeper_registry.(Packed Turn_finalizing)`.

## Test plan
- [x] `dune build --root . @check` passes cleanly

## Related
- Builds on latest main (`91bae08b6f`)