### PR TITLE
feat(cascade): RFC-0041 PR-2 — hierarchical config parsing + TOML groups

### DIFF
--- a/lib/cascade/cascade_config_loader.ml
+++ b/lib/cascade/cascade_config_loader.ml
@@ -790,6 +790,25 @@ let cascade_item_of_weighted_entry (entry : weighted_entry)
       }
   | None -> None
 
+(** Load a [Cascade_ref.cascade_profile] from the hierarchical
+    [{name}_groups] format in cascade.json.  Each object in the array
+    is parsed through [Cascade_ref.cascade_group_of_json].
+
+    Returns [None] when the key is absent or no groups parse
+    successfully. *)
+let load_cascade_profile_hierarchical ~(config_path : string) ~(name : string)
+    : Cascade_ref.cascade_profile option =
+  match load_json config_path with
+  | Error _ -> None
+  | Ok json ->
+      let open Yojson.Safe.Util in
+      match json |> member (name ^ "_groups") with
+      | `List arr ->
+          let groups = List.filter_map Cascade_ref.cascade_group_of_json arr in
+          if groups = [] then None
+          else Some { Cascade_ref.name; groups }
+      | _ -> None
+
 (** Load a [Cascade_ref.cascade_profile] from the legacy cascade.json
     format.  Each profile section becomes a single-group profile;
     [models] become [cascade_item]s and [fallback_cascade] becomes
@@ -798,7 +817,7 @@ let cascade_item_of_weighted_entry (entry : weighted_entry)
     Returns [None] when the profile has no parsable model entries.
     This is the bridge between the existing flat cascade.json format
     and the RFC-0041 hierarchical profile model. *)
-let load_cascade_profile ~(config_path : string) ~(name : string)
+let load_cascade_profile_legacy ~(config_path : string) ~(name : string)
     : Cascade_ref.cascade_profile option =
   let items =
     load_profile_weighted ~config_path ~name
@@ -823,3 +842,16 @@ let load_cascade_profile ~(config_path : string) ~(name : string)
         fallback_group;
       }];
     }
+
+(** Load a [Cascade_ref.cascade_profile] from cascade.json.
+
+    Tries the hierarchical [{name}_groups] format first (RFC-0041).
+    Falls back to the legacy flat [{name}_models] format for backward
+    compatibility.
+
+    Returns [None] when neither format yields a valid profile. *)
+let load_cascade_profile ~(config_path : string) ~(name : string)
+    : Cascade_ref.cascade_profile option =
+  match load_cascade_profile_hierarchical ~config_path ~name with
+  | Some profile -> Some profile
+  | None -> load_cascade_profile_legacy ~config_path ~name

--- a/lib/cascade/cascade_toml_materializer.ml
+++ b/lib/cascade/cascade_toml_materializer.ml
@@ -293,6 +293,43 @@ let api_key_env_json ~path value =
       in
       loop [] fields
 
+(* Generic Otoml -> Yojson conversion used for namespaces that the
+   materializer should pass through verbatim instead of treating as a
+   cascade profile.  Currently used for the [admission] namespace
+   introduced by RFC-0026 PR-B (#12926, #1089).
+
+   Without this, every [admission.<keeper>] sub-table breaks the
+   materializer (treated as a profile, sub-table keys rejected as
+   "unknown field"), which fails cascade.json materialization and
+   takes down every keeper that resolves a cascade through cascade.toml
+   — not just the keepers with admission blocks.  The error is a
+   single fleet-wide regression, so the materializer needs to know
+   about the admission namespace explicitly. *)
+let rec otoml_to_yojson (value : Otoml.t) : Yojson.Safe.t =
+  match value with
+  | Otoml.TomlString s -> `String s
+  | Otoml.TomlInteger n -> `Int n
+  | Otoml.TomlFloat f -> `Float f
+  | Otoml.TomlBoolean b -> `Bool b
+  | Otoml.TomlOffsetDateTime s
+  | Otoml.TomlLocalDateTime s
+  | Otoml.TomlLocalDate s
+  | Otoml.TomlLocalTime s -> `String s
+  | Otoml.TomlArray items ->
+      `List (List.map otoml_to_yojson items)
+  | Otoml.TomlTable fields ->
+      `Assoc
+        (List.map
+           (fun (k, v) -> (k, otoml_to_yojson v))
+           fields)
+  | Otoml.TomlInlineTable fields ->
+      `Assoc
+        (List.map
+           (fun (k, v) -> (k, otoml_to_yojson v))
+           fields)
+  | Otoml.TomlTableArray items ->
+      `List (List.map otoml_to_yojson items)
+
 let routes_json ~path value =
   match table_fields ~path value with
   | Error _ as err -> err
@@ -397,9 +434,20 @@ let profile_field_json ~profile_name ~field_name field_value =
       | Ok value ->
           Ok [ (profile_name ^ "_keep_alive", `String value) ]
       | Error _ as err -> err)
+  | "groups" -> (
+      (* RFC-0041 hierarchical group/item profile format. Each element is an
+         inline table describing a [Cascade_ref.cascade_group]. The array is
+         materialized as [<profile>_groups] in JSON so the loader can use
+         [Cascade_ref.cascade_group_of_json] for parsing. *)
+      match field_value with
+      | Otoml.TomlArray items ->
+          Ok [ (profile_name ^ "_groups", `List (List.map otoml_to_yojson items)) ]
+      | _ ->
+          errorf "expected %s to be an array of group tables, found %s"
+            profile_path (toml_type_name field_value))
   | other ->
       errorf
-        "unknown field %S in profile %s; allowed fields are comment, models, temperature, max_tokens, strategy, max_cycles, backoff_base_ms, backoff_cap_ms, ollama_max_concurrent, cli_max_concurrent, tiers, sticky_ttl_ms, latency_baseline_ms, rate_limit_recency_window_s, rate_limit_decay_base, rate_limit_skip_after, server_error_recency_window_s, server_error_decay_base, server_error_skip_after, keeper_assignable, fallback_cascade, required_capability_profile, api_key_env, keep_alive, num_ctx, timeout_sec"
+        "unknown field %S in profile %s; allowed fields are comment, models, temperature, max_tokens, strategy, max_cycles, backoff_base_ms, backoff_cap_ms, ollama_max_concurrent, cli_max_concurrent, tiers, sticky_ttl_ms, latency_baseline_ms, rate_limit_recency_window_s, rate_limit_decay_base, rate_limit_skip_after, server_error_recency_window_s, server_error_decay_base, server_error_skip_after, keeper_assignable, fallback_cascade, required_capability_profile, api_key_env, keep_alive, num_ctx, timeout_sec, groups"
         other profile_name
 
 let profile_table_json_fields ~profile_name value =
@@ -414,43 +462,6 @@ let profile_table_json_fields ~profile_name value =
             | Error _ as err -> err)
       in
       loop [] fields
-
-(* Generic Otoml -> Yojson conversion used for namespaces that the
-   materializer should pass through verbatim instead of treating as a
-   cascade profile.  Currently used for the [admission] namespace
-   introduced by RFC-0026 PR-B (#12926, #1089).
-
-   Without this, every [admission.<keeper>] sub-table breaks the
-   materializer (treated as a profile, sub-table keys rejected as
-   "unknown field"), which fails cascade.json materialization and
-   takes down every keeper that resolves a cascade through cascade.toml
-   — not just the keepers with admission blocks.  The error is a
-   single fleet-wide regression, so the materializer needs to know
-   about the admission namespace explicitly. *)
-let rec otoml_to_yojson (value : Otoml.t) : Yojson.Safe.t =
-  match value with
-  | Otoml.TomlString s -> `String s
-  | Otoml.TomlInteger n -> `Int n
-  | Otoml.TomlFloat f -> `Float f
-  | Otoml.TomlBoolean b -> `Bool b
-  | Otoml.TomlOffsetDateTime s
-  | Otoml.TomlLocalDateTime s
-  | Otoml.TomlLocalDate s
-  | Otoml.TomlLocalTime s -> `String s
-  | Otoml.TomlArray items ->
-      `List (List.map otoml_to_yojson items)
-  | Otoml.TomlTable fields ->
-      `Assoc
-        (List.map
-           (fun (k, v) -> (k, otoml_to_yojson v))
-           fields)
-  | Otoml.TomlInlineTable fields ->
-      `Assoc
-        (List.map
-           (fun (k, v) -> (k, otoml_to_yojson v))
-           fields)
-  | Otoml.TomlTableArray items ->
-      `List (List.map otoml_to_yojson items)
 
 let render_toml_to_yojson toml =
   match table_fields ~path:"<root>" toml with

--- a/test/dune
+++ b/test/dune
@@ -1130,6 +1130,7 @@
 (include stanzas/test_cascade_ollama_probe.inc)
 (include stanzas/test_cascade_runtime.inc)
 (include stanzas/test_cascade_strategy.inc)
+(include stanzas/test_cascade_hierarchical_routing.inc)
 (include stanzas/test_cascade_trust_persist.inc)
 (include stanzas/test_audit_keeper_fleet_readiness.inc)
 (include stanzas/test_cdal_ledger_health_10115.inc)

--- a/test/stanzas/test_cascade_hierarchical_routing.inc
+++ b/test/stanzas/test_cascade_hierarchical_routing.inc
@@ -1,0 +1,4 @@
+(test
+ (name test_cascade_hierarchical_routing)
+ (modules test_cascade_hierarchical_routing)
+ (libraries alcotest yojson masc_mcp))

--- a/test/test_cascade_hierarchical_routing.ml
+++ b/test/test_cascade_hierarchical_routing.ml
@@ -1,0 +1,224 @@
+open Alcotest
+
+let rec rm_rf path =
+  if Sys.file_exists path then
+    if Sys.is_directory path then begin
+      Sys.readdir path
+      |> Array.iter (fun name -> rm_rf (Filename.concat path name));
+      Unix.rmdir path
+    end else
+      Sys.remove path
+
+let with_temp_dir prefix f =
+  let dir = Filename.temp_file prefix "" in
+  Sys.remove dir;
+  Unix.mkdir dir 0o755;
+  Fun.protect ~finally:(fun () -> rm_rf dir) (fun () -> f dir)
+
+let rec mkdir_p path =
+  if path = "" || path = "." || path = "/" then
+    ()
+  else if Sys.file_exists path then
+    ()
+  else begin
+    mkdir_p (Filename.dirname path);
+    Unix.mkdir path 0o755
+  end
+
+let write_file path content =
+  mkdir_p (Filename.dirname path);
+  Out_channel.with_open_bin path (fun oc -> output_string oc content)
+
+let with_env name value f =
+  let saved = Sys.getenv_opt name in
+  (match value with
+   | Some v -> Unix.putenv name v
+   | None -> Unix.putenv name "");
+  Fun.protect
+    ~finally:(fun () ->
+      match saved with
+      | Some v -> Unix.putenv name v
+      | None -> Unix.putenv name "")
+    f
+
+let with_config_dir config_dir f =
+  let reset () =
+    Masc_mcp.Config_dir_resolver.reset ();
+    Masc_mcp.Cascade_catalog_runtime.reset_cache_for_tests ()
+  in
+  with_env "MASC_BASE_PATH" None @@ fun () ->
+  with_env "MASC_CONFIG_DIR" (Some config_dir) @@ fun () ->
+  reset ();
+  Fun.protect ~finally:reset f
+
+(* -------------------------------------------------------------------------- *)
+(* Hierarchical JSON format: {name}_groups                                  *)
+(* -------------------------------------------------------------------------- *)
+
+let test_load_cascade_profile_hierarchical () =
+  with_temp_dir "cascade_hier" @@ fun config_dir ->
+  with_config_dir config_dir @@ fun () ->
+  let json_path = Filename.concat config_dir "cascade.json" in
+  let json_content =
+    {|{
+      "test_profile_groups": [
+        {
+          "name": "primary",
+          "items": [
+            {"id": "ollama-qwen", "provider": "ollama", "model": "qwen3:14b", "timeout_ms": 30000, "priority": 1},
+            {"id": "ollama-llama", "provider": "ollama", "model": "llama3:8b", "timeout_ms": 30000, "priority": 2}
+          ],
+          "strategy": "priority",
+          "fallback_group": "fallback"
+        },
+        {
+          "name": "fallback",
+          "items": [
+            {"id": "gemini-flash", "provider": "gemini_cli", "model": "gemini-2.5-flash", "timeout_ms": 60000, "priority": 1}
+          ],
+          "strategy": "priority",
+          "fallback_group": null
+        }
+      ]
+    }|}
+  in
+  write_file json_path json_content;
+  let profile_opt =
+    Masc_mcp.Cascade_config_loader.load_cascade_profile
+      ~config_path:json_path ~name:"test_profile"
+  in
+  match profile_opt with
+  | None -> fail "expected hierarchical profile to parse"
+  | Some profile ->
+      check string "profile name" "test_profile" profile.name;
+      check int "group count" 2 (List.length profile.groups);
+      let primary = List.nth profile.groups 0 in
+      check string "primary group name" "primary" primary.name;
+      check int "primary item count" 2 (List.length primary.items);
+      check (option string) "primary fallback_group" (Some "fallback")
+        primary.fallback_group;
+      let first_item = List.nth primary.items 0 in
+      check string "first item id" "ollama-qwen" first_item.id;
+      check string "first item provider" "ollama" first_item.provider;
+      check int "first item timeout" 30000 first_item.timeout_ms;
+      let fallback = List.nth profile.groups 1 in
+      check string "fallback group name" "fallback" fallback.name;
+      check (option string) "fallback fallback_group" None fallback.fallback_group
+
+(* -------------------------------------------------------------------------- *)
+(* Legacy JSON format: {name}_models (backward compatibility)                *)
+(* -------------------------------------------------------------------------- *)
+
+let test_load_cascade_profile_legacy_fallback () =
+  with_temp_dir "cascade_legacy" @@ fun config_dir ->
+  with_config_dir config_dir @@ fun () ->
+  let json_path = Filename.concat config_dir "cascade.json" in
+  let json_content =
+    {|{
+      "legacy_profile_models": [
+        {"model": "ollama:qwen3:14b", "weight": 1},
+        {"model": "gemini_cli:gemini-2.5-flash", "weight": 2}
+      ],
+      "legacy_profile_temperature": 0.7
+    }|}
+  in
+  write_file json_path json_content;
+  let profile_opt =
+    Masc_mcp.Cascade_config_loader.load_cascade_profile
+      ~config_path:json_path ~name:"legacy_profile"
+  in
+  match profile_opt with
+  | None -> fail "expected legacy profile to parse"
+  | Some profile ->
+      check string "profile name" "legacy_profile" profile.name;
+      check int "group count" 1 (List.length profile.groups);
+      let group = List.nth profile.groups 0 in
+      check string "group name" "legacy_profile" group.name;
+      check int "item count" 2 (List.length group.items);
+      let first_item = List.nth group.items 0 in
+      check string "first item id" "ollama:qwen3:14b" first_item.id;
+      check string "first item provider" "ollama" first_item.provider;
+      check string "first item model" "qwen3:14b" first_item.model;
+      let second_item = List.nth group.items 1 in
+      check string "second item id" "gemini_cli:gemini-2.5-flash" second_item.id
+
+(* -------------------------------------------------------------------------- *)
+(* TOML materializer: groups array -> JSON                                  *)
+(* -------------------------------------------------------------------------- *)
+
+let test_toml_materializer_groups () =
+  let toml_content =
+    {|[[groups]]
+name = "primary"
+strategy = "priority"
+fallback_group = "fallback"
+
+[[groups.items]]
+id = "ollama-qwen"
+provider = "ollama"
+model = "qwen3:14b"
+timeout_ms = 30000
+priority = 1
+
+[[groups.items]]
+id = "ollama-llama"
+provider = "ollama"
+model = "llama3:8b"
+timeout_ms = 30000
+priority = 2
+
+[[groups]]
+name = "fallback"
+strategy = "priority"
+
+[[groups.items]]
+id = "gemini-flash"
+provider = "gemini_cli"
+model = "gemini-2.5-flash"
+timeout_ms = 60000
+priority = 1
+|}
+  in
+  match Masc_mcp.Cascade_toml_materializer.render_toml_string_to_json_string
+          toml_content with
+  | Error msg -> fail msg
+  | Ok json_str ->
+      let json = Yojson.Safe.from_string json_str in
+      let groups = Yojson.Safe.Util.to_list
+        (Yojson.Safe.Util.member "groups" json)
+      in
+      check int "group count" 2 (List.length groups);
+      let primary_json = List.nth groups 0 in
+      check string "primary name"
+        "primary"
+        (Yojson.Safe.Util.to_string
+           (Yojson.Safe.Util.member "name" primary_json));
+      let items = Yojson.Safe.Util.to_list
+        (Yojson.Safe.Util.member "items" primary_json)
+      in
+      check int "primary item count" 2 (List.length items);
+      let fallback_json = List.nth groups 1 in
+      check string "fallback name"
+        "fallback"
+        (Yojson.Safe.Util.to_string
+           (Yojson.Safe.Util.member "name" fallback_json))
+
+(* -------------------------------------------------------------------------- *)
+(* Suite                                                                    *)
+(* -------------------------------------------------------------------------- *)
+
+let () =
+  run "Cascade Hierarchical Routing"
+    [
+      ( "loader",
+        [
+          test_case "hierarchical JSON profile" `Quick
+            test_load_cascade_profile_hierarchical;
+          test_case "legacy JSON fallback" `Quick
+            test_load_cascade_profile_legacy_fallback;
+        ] );
+      ( "materializer",
+        [
+          test_case "TOML groups to JSON" `Quick test_toml_materializer_groups;
+        ] );
+    ]


### PR DESCRIPTION
## Summary

RFC-0041 Cascade Routing Migration — PR-2: Hierarchical Config Parsing + TOML Materializer.

### Changes

1. **cascade_config_loader.ml**
   - `load_cascade_profile_hierarchical`: parses `{name}_groups` from cascade.json into `Cascade_ref.cascade_profile` (multi-group profile with items, strategy, fallback_group).
   - `load_cascade_profile`: tries hierarchical first, falls back to legacy flat `{name}_models` format. Backward compatible.

2. **cascade_toml_materializer.ml**
   - Adds `"groups"` arm in `profile_field_json` that converts TOML groups array to JSON via `otoml_to_yojson`.
   - Moves `otoml_to_yojson` above `routes_json` so `profile_field_json` can reference it (scoping fix).

3. **Tests**
   - `test_cascade_hierarchical_routing.ml` with 3 cases:
     - Hierarchical JSON profile loading (multi-group, items, fallback)
     - Legacy JSON fallback (`{name}_models` still works)
     - TOML groups materialization (`groups` array -> JSON)

### Verification

- `lib/cascade/` compiles cleanly.
- Test binary compiles (`.cmx` generated); full link blocked by pre-existing `Agent_id.t` / `Keeper_registry` breakage on main (unrelated to this PR).

### Risk

- Low: additive only. Legacy flat format untouched; fallback path preserved.

RFC-0041 PR-1 (#14351) merged 2026-05-08.