### PR TITLE
fix(exec_gate): complete Agent_id.t typed actor migration

### DIFF
--- a/lib/coord/playground_repo_cache.ml
+++ b/lib/coord/playground_repo_cache.ml
@@ -15,7 +15,7 @@ let env_float name default =
 let git_meta_timeout_sec = env_float "MASC_KEEPER_GIT_META_TIMEOUT_SEC" 5.0
 
 let git_meta repo_path args =
-  Masc_exec.Exec_gate.run_argv_with_status ~actor:"Coord_git" ~raw_source:("git -C " ^ repo_path ^ " " ^ String.concat " " args) ~summary:"git metadata query" ~timeout_sec:git_meta_timeout_sec
+  Masc_exec.Exec_gate.run_argv_with_status ~actor:`Coord_git ~raw_source:("git -C " ^ repo_path ^ " " ^ String.concat " " args) ~summary:"git metadata query" ~timeout_sec:git_meta_timeout_sec
     ("git" :: "-C" :: repo_path :: args)
 
 let cache_update_mu = Stdlib.Mutex.create ()

--- a/lib/exec/exec_dispatch.ml
+++ b/lib/exec/exec_dispatch.ml
@@ -59,7 +59,7 @@ let dispatch_simple (s : Shell_ir.simple) =
       let raw_source = String.concat " " argv in
       (match
          Exec_gate.run_argv_with_status_split
-           ~actor:"Tool_local_runtime"
+           ~actor:`Tool_local_runtime
            ~raw_source
            ~summary:"exec dispatch simple"
            ~timeout_sec ~env ?cwd argv
@@ -97,7 +97,7 @@ let rec dispatch_pipeline stages =
             (match
                let raw_source = String.concat " " argv in
                Exec_gate.run_argv_with_stdin_and_status_split
-                 ~actor:"Tool_local_runtime"
+                 ~actor:`Tool_local_runtime
                  ~raw_source
                  ~summary:"exec dispatch pipeline stage"
                  ~timeout_sec:(Env_config_exec_timeout.timeout_sec ~caller:Dispatch ()) ~env
@@ -116,7 +116,7 @@ let rec dispatch_pipeline stages =
             (match
                let raw_source = String.concat " " argv in
                Exec_gate.run_argv_with_stdin_and_status_split
-                 ~actor:"Tool_local_runtime"
+                 ~actor:`Tool_local_runtime
                  ~raw_source
                  ~summary:"exec dispatch pipeline stage"
                  ~timeout_sec:(Env_config_exec_timeout.timeout_sec ~caller:Dispatch ()) ~env

--- a/lib/exec/exec_gate.ml
+++ b/lib/exec/exec_gate.ml
@@ -150,7 +150,7 @@ let verdict_for_argv ~actor ~raw_source ~summary ~argv ?env ?cwd () =
   | Error `Parse_failed ->
     Error (`Denied Verdict.Parse_failed)
   | Ok simple ->
-    let overlay = Approval_config.lookup rollout_config ~actor:(Agent_id.of_string actor) in
+    let overlay = Approval_config.lookup rollout_config ~actor in
     let policy : Approval_policy.t = { raw_source; summary } in
     let typed = Shell_ir_typed.of_simple simple in
     let caps =

--- a/lib/exec/test/test_exec_gate_runtime.ml
+++ b/lib/exec/test/test_exec_gate_runtime.ml
@@ -87,7 +87,7 @@ let test_typed_safe_enforced_blocks () =
   with_env "MASC_EXEC_GATE" (Some "enforced") (fun () ->
     let status, out =
       Exec_gate.run_argv_with_status
-        ~actor:"unknown/strict"
+        ~actor:`Other_agent
         ~raw_source:"ls"
         ~summary:"typed ls"
         ~timeout_sec:(Env_config_exec_timeout.timeout_sec ~caller:Test ())
@@ -100,7 +100,7 @@ let test_typed_audited_internal_allows () =
   with_env "MASC_EXEC_GATE" (Some "enforced") (fun () ->
     let status, out =
       Exec_gate.run_argv_with_status
-        ~actor:"coord/git"
+        ~actor:`Coord_git
         ~raw_source:"git status"
         ~summary:"typed git status"
         ~timeout_sec:(Env_config_exec_timeout.timeout_sec ~caller:Test ())
@@ -113,7 +113,7 @@ let test_typed_safe_parallel_records_shadow_and_executes () =
     with_env "MASC_EXEC_GATE" (Some "parallel") (fun () ->
       let out =
         Exec_gate.run_argv
-          ~actor:"unknown/strict"
+          ~actor:`Other_agent
           ~raw_source:"ls"
           ~summary:"typed ls"
           ~timeout_sec:(Env_config_exec_timeout.timeout_sec ~caller:Test ())

--- a/lib/keeper/keeper_alerting.ml
+++ b/lib/keeper/keeper_alerting.ml
@@ -311,7 +311,7 @@ let post_keeper_alert_slack
     ] in
     let (status, out) =
       Masc_exec.Exec_gate.run_argv_with_stdin_and_status
-        ~actor:"System_notify"
+        ~actor:`System_notify
         ~raw_source:(String.concat " " argv)
         ~summary:"keeper alert slack webhook"
         ~timeout_sec:(Env_config_exec_timeout.timeout_sec ~caller:Alerting ())
@@ -361,7 +361,7 @@ let slack_api_post_json
   ] in
   let (status, out) =
     Masc_exec.Exec_gate.run_argv_with_stdin_and_status
-      ~actor:"System_notify"
+      ~actor:`System_notify
       ~raw_source:(String.concat " " argv)
       ~summary:"keeper alert slack api post"
       ~timeout_sec:(Env_config_exec_timeout.timeout_sec ~caller:Alerting ())
@@ -453,7 +453,7 @@ let post_keeper_alert_github
     in
     let (status, out) =
       Masc_exec.Exec_gate.run_argv_with_status
-        ~actor:"Coord_git"
+        ~actor:`Coord_git
         ~raw_source:(String.concat " " args)
         ~summary:"keeper alert gh issue create"
         ~timeout_sec:(Env_config_exec_timeout.timeout_sec ~caller:Alerting ())

--- a/lib/keeper/keeper_docker_read.ml
+++ b/lib/keeper/keeper_docker_read.ml
@@ -135,7 +135,7 @@ let run_command_in_container_with_status ?turn_sandbox_factory
         in
         let st, out =
           Masc_exec.Exec_gate.run_argv_with_status
-            ~actor:"System_task_sandbox"
+            ~actor:`System_task_sandbox
             ~raw_source:(String.concat " " argv)
             ~summary:"keeper docker read sandboxed command"
             ~env:(Unix.environment ())

--- a/lib/keeper/keeper_exec_preflight.ml
+++ b/lib/keeper/keeper_exec_preflight.ml
@@ -20,7 +20,7 @@ let handle_keeper_preflight_check
   let () =
     let st, out =
       Masc_exec.Exec_gate.run_argv_with_status
-        ~actor:"Coord_git"
+        ~actor:`Coord_git
         ~raw_source:"/bin/zsh -lc gh auth status 2>&1"
         ~summary:"keeper preflight gh auth status"
         ~timeout_sec:(Env_config_exec_timeout.timeout_sec ~caller:Preflight ())
@@ -36,7 +36,7 @@ let handle_keeper_preflight_check
     else
       let st, out =
         Masc_exec.Exec_gate.run_argv_with_status
-          ~actor:"Coord_git"
+          ~actor:`Coord_git
           ~raw_source:(Printf.sprintf "/bin/zsh -lc gh repo view %s --json name,defaultBranchRef 2>&1" (Filename.quote repo))
           ~summary:"keeper preflight gh repo view"
           ~timeout_sec:(Env_config_exec_timeout.timeout_sec ~caller:Preflight ())

--- a/lib/keeper/keeper_gh_shared.ml
+++ b/lib/keeper/keeper_gh_shared.ml
@@ -216,7 +216,7 @@ let fetch_entity_numbers ~(config : Coord.config) ~(repo_slug : string) ~(kind :
   let argv = [ "/bin/zsh"; "-lc"; Printf.sprintf "%s 2>/dev/null" scoped ] in
   match
     Masc_exec.Exec_gate.run_argv_with_status
-      ~actor:"Coord_git"
+      ~actor:`Coord_git
       ~raw_source:(String.concat " " argv)
       ~summary:"keeper gh cache fetch"
       ~timeout_sec:(Keeper_tool_policy.gh_cache_fetch_timeout_sec ())
@@ -711,7 +711,7 @@ let repo_slug_of_git_command ~cwd =
   let argv = [ "git"; "remote"; "get-url"; "origin" ] in
   match
     Masc_exec.Exec_gate.run_argv_with_status
-      ~actor:"Coord_git"
+      ~actor:`Coord_git
       ~raw_source:(String.concat " " argv)
       ~summary:"keeper gh repo slug from git"
       ~cwd
@@ -725,7 +725,7 @@ let origin_url_of_git_command ~cwd =
   let argv = [ "git"; "remote"; "get-url"; "origin" ] in
   match
     Masc_exec.Exec_gate.run_argv_with_status
-      ~actor:"Coord_git"
+      ~actor:`Coord_git
       ~raw_source:(String.concat " " argv)
       ~summary:"keeper gh origin url from git"
       ~cwd

--- a/lib/keeper/keeper_repo_readiness.ml
+++ b/lib/keeper/keeper_repo_readiness.ml
@@ -22,7 +22,7 @@ let run_git ~timeout_sec ~clone_path args =
   let argv = [ "git"; "-C"; clone_path; "--no-optional-locks" ] @ args in
   let status, output =
     Masc_exec.Exec_gate.run_argv_with_status
-      ~actor:"Coord_git"
+      ~actor:`Coord_git
       ~raw_source:(String.concat " " argv)
       ~summary:"keeper repo readiness git probe"
       ~timeout_sec argv

--- a/lib/keeper/keeper_sandbox_control.ml
+++ b/lib/keeper/keeper_sandbox_control.ml
@@ -196,7 +196,7 @@ let start_managed_container
                   in
                   let st, out =
                     Masc_exec.Exec_gate.run_argv_with_status
-                      ~actor:"System_task_sandbox"
+                      ~actor:`System_task_sandbox
                       ~raw_source:(String.concat " " argv)
                       ~summary:"keeper sandbox control exec"
                       ~env:(Unix.environment ())
@@ -292,7 +292,7 @@ let git_string_opt repo_path args =
   try
     let argv = "git" :: "-C" :: repo_path :: args in
     let status, out =
-      Masc_exec.Exec_gate.run_argv_with_status ~actor:"Coord_git"
+      Masc_exec.Exec_gate.run_argv_with_status ~actor:`Coord_git
         ~raw_source:(String.concat " " argv)
         ~summary:"keeper sandbox git metadata"
         ~timeout_sec:git_metadata_timeout_sec

--- a/lib/keeper/keeper_sandbox_runtime.ml
+++ b/lib/keeper/keeper_sandbox_runtime.ml
@@ -38,7 +38,7 @@ let docker_info_security_options ~timeout_sec =
   in
   let st, out =
     Masc_exec.Exec_gate.run_argv_with_status
-      ~actor:"System_task_sandbox"
+      ~actor:`System_task_sandbox
       ~raw_source:(String.concat " " argv)
       ~summary:"keeper sandbox docker info"
       ~env:(Unix.environment ())
@@ -499,7 +499,7 @@ let inspect_cleanup_container ~container_id ~timeout_sec =
   in
   let st, out =
     Masc_exec.Exec_gate.run_argv_with_status
-      ~actor:"System_task_sandbox"
+      ~actor:`System_task_sandbox
       ~raw_source:(String.concat " " argv)
       ~summary:"keeper sandbox docker inspect cleanup"
       ~env:(Unix.environment ())
@@ -525,7 +525,7 @@ let remove_cleanup_container ~container_id ~timeout_sec =
   let argv = docker_command_argv () @ [ "rm"; "-f"; container_id ] in
   let st, out =
     Masc_exec.Exec_gate.run_argv_with_status
-      ~actor:"System_task_sandbox"
+      ~actor:`System_task_sandbox
       ~raw_source:(String.concat " " argv)
       ~summary:"keeper sandbox docker rm cleanup"
       ~env:(Unix.environment ())
@@ -564,7 +564,7 @@ let cleanup_stale_containers ?(now = Unix.gettimeofday ())
     in
     let st, out =
       Masc_exec.Exec_gate.run_argv_with_status
-        ~actor:"System_task_sandbox"
+        ~actor:`System_task_sandbox
         ~raw_source:(String.concat " " argv)
         ~summary:"keeper sandbox docker ps cleanup"
         ~env:(Unix.environment ())
@@ -637,7 +637,7 @@ let list_container_ids ?keeper_name ?container_kind ~base_path ~timeout_sec () =
     in
     let st, out =
       Masc_exec.Exec_gate.run_argv_with_status
-        ~actor:"System_task_sandbox"
+        ~actor:`System_task_sandbox
         ~raw_source:(String.concat " " argv)
         ~summary:"keeper sandbox docker ps list"
         ~env:(Unix.environment ())
@@ -683,7 +683,7 @@ let list_containers ?keeper_name ?container_kind ~base_path ~timeout_sec () =
       in
       let st, out =
         Masc_exec.Exec_gate.run_argv_with_status
-          ~actor:"System_task_sandbox"
+          ~actor:`System_task_sandbox
           ~raw_source:(String.concat " " argv)
           ~summary:"keeper sandbox docker inspect live"
           ~env:(Unix.environment ())
@@ -780,7 +780,7 @@ let docker_image_present ~image ~timeout_sec =
     let argv = docker_command_argv () @ [ "image"; "inspect"; image ] in
     let st, out =
       Masc_exec.Exec_gate.run_argv_with_status
-        ~actor:"System_task_sandbox"
+        ~actor:`System_task_sandbox
         ~raw_source:(String.concat " " argv)
         ~summary:"keeper sandbox docker image inspect"
         ~env:(Unix.environment ())
@@ -822,7 +822,7 @@ let docker_image_required_commands ~image ~timeout_sec =
   in
   let st, out =
     Masc_exec.Exec_gate.run_argv_with_status
-      ~actor:"System_task_sandbox"
+      ~actor:`System_task_sandbox
       ~raw_source:(String.concat " " argv)
       ~summary:"keeper sandbox docker run required commands"
       ~env:(Unix.environment ())

--- a/lib/keeper/keeper_shell_bash.ml
+++ b/lib/keeper/keeper_shell_bash.ml
@@ -758,7 +758,7 @@ let handle_keeper_bash
                        | None ->
                          let t0 = Unix.gettimeofday () in
                          let st, out =
-                           Masc_exec.Exec_gate.run_argv_with_status ~actor:"Keeper_shell"
+                           Masc_exec.Exec_gate.run_argv_with_status ~actor:`Keeper_shell
                              ~raw_source:(String.concat " " argv_merged)
                              ~summary:"keeper bash command"
                              ~cwd ~timeout_sec argv_merged
@@ -808,7 +808,7 @@ let handle_keeper_bash
                     | None ->
                    let t0 = Unix.gettimeofday () in
                    let st, out =
-                     Masc_exec.Exec_gate.run_argv_with_status ~actor:"Keeper_shell"
+                     Masc_exec.Exec_gate.run_argv_with_status ~actor:`Keeper_shell
                        ~raw_source:(String.concat " " argv_merged)
                        ~summary:"keeper bash command"
                        ~cwd ~timeout_sec argv_merged

--- a/lib/keeper/keeper_shell_docker.ml
+++ b/lib/keeper/keeper_shell_docker.ml
@@ -790,7 +790,7 @@ let run_docker_shell_command_with_status
       (try
          let status, output =
            Fun.protect ~finally:restore_gitdirs @@ fun () ->
-           Masc_exec.Exec_gate.run_argv_with_status ~actor:"Keeper_shell"
+           Masc_exec.Exec_gate.run_argv_with_status ~actor:`Keeper_shell
              ~raw_source:(String.concat " " argv)
              ~summary:"keeper docker command"
              ~env:(Unix.environment ())

--- a/lib/keeper/keeper_shell_ops.ml
+++ b/lib/keeper/keeper_shell_ops.ml
@@ -564,7 +564,7 @@ let handle_keeper_shell
                      ]))
           | None ->
             let st, out =
-              Masc_exec.Exec_gate.run_argv_with_status ~actor:"Keeper_shell"
+              Masc_exec.Exec_gate.run_argv_with_status ~actor:`Keeper_shell
                 ~raw_source:(String.concat " " argv)
                 ~summary:"keeper shell op"
                 ~timeout_sec:Keeper_shell_shared.read_timeout_sec argv
@@ -945,14 +945,14 @@ let handle_keeper_shell
            match Keeper_gh_env.keeper_process_env config ~keeper_name:meta.name with
            | Error err -> (Unix.WEXITED 127, err)
            | Ok env ->
-               Masc_exec.Exec_gate.run_argv_with_status ~actor:"Coord_git"
+               Masc_exec.Exec_gate.run_argv_with_status ~actor:`Coord_git
                  ~raw_source:(String.concat " " argv)
                  ~summary:"keeper brokered git command"
                  ?env ~cwd ~timeout_sec argv
          in
          let normalize_existing_origin_to_https clone_path =
            match
-             Masc_exec.Exec_gate.run_argv_with_status ~actor:"Coord_git"
+             Masc_exec.Exec_gate.run_argv_with_status ~actor:`Coord_git
                ~raw_source:("git -C " ^ clone_path ^ " remote get-url origin")
                ~summary:"keeper git remote get-url"
                ~timeout_sec:(Env_config_exec_timeout.timeout_sec ~caller:Git_meta ())
@@ -964,7 +964,7 @@ let handle_keeper_shell
              if String.equal origin normalized then None
              else
                (match
-                  Masc_exec.Exec_gate.run_argv_with_status ~actor:"Coord_git"
+                  Masc_exec.Exec_gate.run_argv_with_status ~actor:`Coord_git
                     ~raw_source:("git -C " ^ clone_path ^ " remote set-url origin " ^ normalized)
                     ~summary:"keeper git remote set-url"
                     ~timeout_sec:(Env_config_exec_timeout.timeout_sec ~caller:Git_meta ())
@@ -1018,7 +1018,7 @@ let handle_keeper_shell
                     | Ok result -> (result.status, result.output)
                     | Error msg -> (Unix.WEXITED 127, msg)
                   else
-                    Masc_exec.Exec_gate.run_argv_with_status ~actor:"Coord_git"
+                    Masc_exec.Exec_gate.run_argv_with_status ~actor:`Coord_git
                       ~raw_source:("git -C " ^ clone_path ^ " pull --ff-only")
                       ~summary:"keeper git pull"
                       ~timeout_sec:(Env_config_exec_timeout.timeout_sec ~caller:Shell ())
@@ -1072,7 +1072,7 @@ let handle_keeper_shell
                | Ok result -> (result.status, result.output)
                | Error msg -> (Unix.WEXITED 127, msg)
              else
-               Masc_exec.Exec_gate.run_argv_with_status ~actor:"Coord_git"
+               Masc_exec.Exec_gate.run_argv_with_status ~actor:`Coord_git
                  ~raw_source:("git clone " ^ String.concat " " depth_args ^ " " ^ clone_url ^ " " ^ clone_path)
                  ~summary:"keeper git clone"
                  ~timeout_sec:(Keeper_tool_policy.clone_timeout_sec ())
@@ -1225,7 +1225,7 @@ let handle_keeper_shell
                    let gh_argv =
                      "gh" :: Keeper_gh_shared.gh_simple_command_argv parsed_command
                    in
-                   Ok (Masc_exec.Exec_gate.run_argv_with_status ~actor:"Keeper_shell"
+                   Ok (Masc_exec.Exec_gate.run_argv_with_status ~actor:`Keeper_shell
                          ~raw_source:(String.concat " " gh_argv)
                          ~summary:"keeper gh command"
                          ?env ~cwd ~timeout_sec gh_argv))

--- a/lib/keeper/keeper_shell_shared.ml
+++ b/lib/keeper/keeper_shell_shared.ml
@@ -346,7 +346,7 @@ let run_argv_with_status_retry_eintr ?cwd ~timeout_sec argv =
   let max_eintr_retries = 8 in
   let rec loop attempts_left =
     let result =
-      Masc_exec.Exec_gate.run_argv_with_status ~actor:"Keeper_shell"
+      Masc_exec.Exec_gate.run_argv_with_status ~actor:`Keeper_shell
         ~raw_source:(String.concat " " argv)
         ~summary:"keeper shell command" ?cwd ~timeout_sec argv
     in

--- a/lib/keeper/keeper_tool_github_pr.ml
+++ b/lib/keeper/keeper_tool_github_pr.ml
@@ -206,7 +206,7 @@ let run_gh_argv ~(config : Coord.config) ~(meta : keeper_meta) ~env ~cwd
     && Env_config_keeper.KeeperSandbox.hard_mode ()
   then
     let status, output =
-      Masc_exec.Exec_gate.run_argv_with_status ~actor:"Coord_git"
+      Masc_exec.Exec_gate.run_argv_with_status ~actor:`Coord_git
         ~raw_source:(quote_argv argv)
         ~summary:"keeper tool gh brokered"
         ~env ~cwd ~timeout_sec argv
@@ -227,7 +227,7 @@ let run_gh_argv ~(config : Coord.config) ~(meta : keeper_meta) ~env ~cwd
         { status = Unix.WEXITED 1; output = msg; via = "docker" }
   else
     let status, output =
-      Masc_exec.Exec_gate.run_argv_with_status ~actor:"Coord_git"
+      Masc_exec.Exec_gate.run_argv_with_status ~actor:`Coord_git
         ~raw_source:(quote_argv argv)
         ~summary:"keeper tool gh host"
         ~env ~cwd ~timeout_sec argv

--- a/lib/keeper/keeper_tool_pr_review.ml
+++ b/lib/keeper/keeper_tool_pr_review.ml
@@ -183,7 +183,7 @@ let run_pr_review_shell ~(config : Coord.config) ~(meta : keeper_meta)
     let argv = [ "/bin/zsh"; "-lc"; host_cmd ] in
     let status, output =
       Masc_exec.Exec_gate.run_argv_with_status
-        ~actor:"Keeper_shell"
+        ~actor:`Keeper_shell
         ~raw_source:(String.concat " " argv)
         ~summary:"keeper tool pr review host"
         ~timeout_sec

--- a/lib/keeper/keeper_turn_sandbox_runtime.ml
+++ b/lib/keeper/keeper_turn_sandbox_runtime.ml
@@ -93,7 +93,7 @@ let run_argv_with_status_retry_eintr ~timeout_sec argv =
   let rec loop attempts_left =
     let st, out =
       Masc_exec.Exec_gate.run_argv_with_status
-        ~actor:"System_task_sandbox"
+        ~actor:`System_task_sandbox
         ~raw_source:(String.concat " " argv)
         ~summary:"keeper turn sandbox command"
         ~env:(Unix.environment ())
@@ -113,7 +113,7 @@ let run_argv_with_stdin_and_status_retry_eintr ~timeout_sec ~stdin_content argv 
   let rec loop attempts_left =
     let st, out =
       Masc_exec.Exec_gate.run_argv_with_stdin_and_status
-        ~actor:"System_task_sandbox"
+        ~actor:`System_task_sandbox
         ~raw_source:(String.concat " " argv)
         ~summary:"keeper turn sandbox stdin command"
         ~env:(Unix.environment ())

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -1709,7 +1709,7 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
                  meta.name;
                Keeper_registry.set_turn_phase
                  ~base_path:config.base_path meta.name
-                 Keeper_registry.Turn_finalizing;
+                 (Keeper_registry.turn_phase_to_witness Keeper_registry.Turn_finalizing);
                Error order_err
              | None ->
             let committed_tools = committed_mutating_tools_snapshot () in

--- a/lib/mcp_server_eio_protocol.ml
+++ b/lib/mcp_server_eio_protocol.ml
@@ -761,7 +761,7 @@ let handle_request
             | Eio.Cancel.Cancelled _ as exn -> raise exn
             | exn ->
               let err = Printexc.to_string exn in
-              Log.Mcp.error "Request handling failed: method=%s: %s" method_ err;
+              Log.Mcp.error "Request handling failed: method=%s: %s" req.method_ err;
               make_error ~id (-32603) (Printf.sprintf "Internal error: %s" err)))
   with
   | Eio.Cancel.Cancelled _ as exn -> raise exn

--- a/lib/operator/operator_control.ml
+++ b/lib/operator/operator_control.ml
@@ -126,7 +126,7 @@ let run_gh_auth_status ~gh_config_dir =
   try
     let env = gh_process_env_for_config_dir gh_config_dir in
     Ok
-      (Masc_exec.Exec_gate.run_argv_with_status ~actor:"Coord_git" ~raw_source:"gh auth status --hostname github.com" ~summary:"gh auth status check" ~env
+      (Masc_exec.Exec_gate.run_argv_with_status ~actor:`Coord_git ~raw_source:"gh auth status --hostname github.com" ~summary:"gh auth status check" ~env
          [ "gh"; "auth"; "status"; "--hostname"; "github.com" ])
   with
   | Unix.Unix_error (Unix.ENOENT, _, _) ->

--- a/lib/server/server_routes_http_routes_sidecar.ml
+++ b/lib/server/server_routes_http_routes_sidecar.ml
@@ -777,7 +777,7 @@ let handle_stop state request reqd =
                   (`Assoc [ ("ok", `Bool false); ("error", `String msg) ])
             | Ok desired ->
                 let (_status, stdout) =
-                  Masc_exec.Exec_gate.run_argv_with_status ~actor:"System_spawn" ~raw_source:(script ^ " stop") ~summary:"sidecar stop script"
+                  Masc_exec.Exec_gate.run_argv_with_status ~actor:`System_spawn ~raw_source:(script ^ " stop") ~summary:"sidecar stop script"
                     ~timeout_sec:Env_config_runtime.Sidecar.control_command_timeout_sec
                     [ script; "stop" ]
                 in
@@ -833,7 +833,7 @@ let handle_logs state request reqd =
            ])
       else
         let (_status, stdout) =
-          Masc_exec.Exec_gate.run_argv_with_status ~actor:"System_runtime_info" ~raw_source:("tail -n " ^ string_of_int lines ^ " " ^ path) ~summary:"tail sidecar logs"
+          Masc_exec.Exec_gate.run_argv_with_status ~actor:`System_runtime_info ~raw_source:("tail -n " ^ string_of_int lines ^ " " ^ path) ~summary:"tail sidecar logs"
             ~timeout_sec:Env_config_runtime.Sidecar.control_command_timeout_sec
             [ "tail"; "-n"; string_of_int lines; path ]
         in
@@ -881,7 +881,7 @@ let fetch_schema ?base_path id =
        | Ok sidecar_dir ->
            let argv = python_argv_for sidecar_dir in
            let (status, stdout) =
-             Masc_exec.Exec_gate.run_argv_with_status ~actor:"System_spawn" ~raw_source:(String.concat " " argv) ~summary:"python schema dump"
+             Masc_exec.Exec_gate.run_argv_with_status ~actor:`System_spawn ~raw_source:(String.concat " " argv) ~summary:"python schema dump"
                ~timeout_sec:Env_config_runtime.Sidecar.schema_generation_timeout_sec
                ~cwd:sidecar_dir argv
            in

--- a/lib/tool_code.ml
+++ b/lib/tool_code.ml
@@ -362,7 +362,7 @@ let handle_code_search ctx args =
     in
     let cmd = "rg" :: rg_args in
 
-    match Masc_exec.Exec_gate.run_argv_with_status ~actor:"Tool_local_runtime" ~raw_source:(String.concat " " cmd) ~summary:"rg search in workspace" ~timeout_sec:(Env_config_exec_timeout.timeout_sec ~caller:Shell ()) cmd with
+    match Masc_exec.Exec_gate.run_argv_with_status ~actor:`Tool_local_runtime ~raw_source:(String.concat " " cmd) ~summary:"rg search in workspace" ~timeout_sec:(Env_config_exec_timeout.timeout_sec ~caller:Shell ()) cmd with
     | Unix.WEXITED 0, output ->
         (* Parse rg JSON output *)
         let lines = String.split_on_char '\n' output in

--- a/lib/tool_code_write.ml
+++ b/lib/tool_code_write.ml
@@ -67,7 +67,7 @@ let validate_code_shell_command (command : string) : (unit, string) Result.t =
 let git_common_root path =
   try
     match
-      Masc_exec.Exec_gate.run_argv_with_status ~actor:"Coord_git" ~raw_source:("git -C " ^ path ^ " rev-parse --git-common-dir") ~summary:"git common root lookup"
+      Masc_exec.Exec_gate.run_argv_with_status ~actor:`Coord_git ~raw_source:("git -C " ^ path ^ " rev-parse --git-common-dir") ~summary:"git common root lookup"
         ~timeout_sec:(Env_config_exec_timeout.timeout_sec ~caller:(Unknown "misc") ())
         [ "git"; "-C"; path; "rev-parse"; "--git-common-dir" ]
     with
@@ -652,7 +652,7 @@ let handle_code_shell ctx args =
                    [ "sh"; "-c"; Printf.sprintf "cd %s && %s"
                        (Filename.quote dir) command ]
              in
-             match Masc_exec.Exec_gate.run_argv_with_status ~actor:"Tool_local_runtime" ~raw_source:(String.concat " " full_cmd) ~summary:"shell command execution" ~timeout_sec:safe_timeout full_cmd with
+             match Masc_exec.Exec_gate.run_argv_with_status ~actor:`Tool_local_runtime ~raw_source:(String.concat " " full_cmd) ~summary:"shell command execution" ~timeout_sec:safe_timeout full_cmd with
              | Unix.WEXITED code, output ->
                  let response = `Assoc [
                    ("status", `String (if code = 0 then "ok" else "error"));
@@ -736,7 +736,7 @@ let handle_code_git ctx args =
                        depth_flag
                        (Filename.quote clone_url)]
           in
-          match Masc_exec.Exec_gate.run_argv_with_status ~actor:"Coord_git" ~raw_source:(String.concat " " cmd) ~summary:"git clone" ~timeout_sec:timeout cmd with
+          match Masc_exec.Exec_gate.run_argv_with_status ~actor:`Coord_git ~raw_source:(String.concat " " cmd) ~summary:"git clone" ~timeout_sec:timeout cmd with
           | Unix.WEXITED code, output ->
             let response =
               `Assoc
@@ -790,7 +790,7 @@ let handle_code_git ctx args =
             Some (Keeper_identity.git_env_for_keeper ~keeper_name:ctx.agent_name)
           else None
         in
-        match Masc_exec.Exec_gate.run_argv_with_status ~actor:"Coord_git" ~raw_source:(String.concat " " cmd) ~summary:"git action execution" ~timeout_sec:(Env_config_exec_timeout.timeout_sec ~caller:Shell ()) ?env:env_opt cmd with
+        match Masc_exec.Exec_gate.run_argv_with_status ~actor:`Coord_git ~raw_source:(String.concat " " cmd) ~summary:"git action execution" ~timeout_sec:(Env_config_exec_timeout.timeout_sec ~caller:Shell ()) ?env:env_opt cmd with
         | Unix.WEXITED code, output ->
           let response =
             `Assoc

--- a/lib/tool_inline_dispatch_types.ml
+++ b/lib/tool_inline_dispatch_types.ml
@@ -52,6 +52,6 @@ type context = {
 
 (** Helper: run subprocess — uses [Dispatch] caller (default 120s) *)
 let safe_exec args =
-  match Masc_exec.Exec_gate.run_argv_with_status ~actor:"Tool_local_runtime" ~raw_source:(String.concat " " args) ~summary:"inline dispatch safe exec" ~timeout_sec:(Env_config_exec_timeout.timeout_sec ~caller:Dispatch ()) args with
+  match Masc_exec.Exec_gate.run_argv_with_status ~actor:`Tool_local_runtime ~raw_source:(String.concat " " args) ~summary:"inline dispatch safe exec" ~timeout_sec:(Env_config_exec_timeout.timeout_sec ~caller:Dispatch ()) args with
   | Unix.WEXITED 0, output -> (true, output)
   | _, output -> (false, if String.equal output "" then "Command failed" else output)


### PR DESCRIPTION
## Summary

PR #14350 partially migrated `Exec_gate` to the typed `Agent_id.t` poly-variant API, but left approximately 20 call sites still passing raw string literals for the `~actor` parameter. This caused `origin/main` to fail `@check`.

Additionally fixes two unrelated compile errors that were also breaking the build.

## Changes

- **22 files**: Replace all remaining `~actor:\"...\"` string literals with typed `Agent_id.t` poly-variant constructors (e.g. `` `Coord_git ``, `` `Tool_local_runtime ``, `` `Keeper_shell ``).
- **lib/exec/exec_gate.ml**: Remove redundant `Agent_id.of_string` in `verdict_for_argv` — `actor` is already `Agent_id.t`.
- **lib/mcp_server_eio_protocol.ml**: Fix unbound `method_` in exception handler. The variable was a match-pattern shadow; use `req.method_` directly.
- **lib/keeper/keeper_unified_turn.ml**: Fix `Turn_finalizing` constructor mismatch. `set_turn_phase` expects `packed_turn_phase`; wrap with `turn_phase_to_witness`.

## Verification

```bash
dune build --root . @check   # EXIT 0
```

## References

- RFC-0005 Typed Capability Substrate
- PR #14350 (partial migration)