### PR TITLE
fix(build): resolve three residual @check failures on main

### DIFF
--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -1719,15 +1719,15 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
               ~labels:[("keeper", meta.name)]
               ();
             let _ = drain_turn_event_bus ~site:"error_path_drain" () in
-            (match tool_event_order_violation_error () with
-             | Some order_err ->
+            (match event_bus_integrity_error_snapshot () with
+             | Some integrity_err ->
                Log.Keeper.error
                  "%s: event-bus order violation during timeout path; treating turn as failed before retry/reconcile decisions"
                  meta.name;
                 Keeper_registry.set_turn_phase
                   ~base_path:config.base_path meta.name
                   Keeper_registry.(Packed Turn_finalizing);
-               Error order_err
+               Error integrity_err
              | None ->
             let committed_tools = committed_mutating_tools_snapshot () in
             if committed_tools <> []

--- a/test/stanzas/test_cascade_hierarchical_routing.inc
+++ b/test/stanzas/test_cascade_hierarchical_routing.inc
@@ -1,4 +1,4 @@
 (test
  (name test_cascade_hierarchical_routing)
  (modules test_cascade_hierarchical_routing)
- (libraries alcotest yojson masc_mcp))
+ (libraries alcotest yojson masc_mcp unix))

--- a/test/test_room_coverage.ml
+++ b/test/test_room_coverage.ml
@@ -21,7 +21,6 @@ let () = Mirage_crypto_rng_unix.use_default ()
 (* Test Helpers                                                  *)
 (* ============================================================ *)
 
-<<<<<<< HEAD
 (** Check for success emoji *)
 let contains_check result =
   String.length result >= 3 && String.sub result 0 3 = "\xE2\x9C\x85" (* ✅ *)
@@ -42,25 +41,6 @@ let _contains_cancel result =
   String.length result >= 4 && String.sub result 0 4 = "\xF0\x9F\x9A\xAB" (* 🚫 *)
 ;;
 
-||||||| parent of be7b3c468c (test(room): accept semantic coord results)
-(** Check for success emoji *)
-let contains_check result =
-  String.length result >= 3 && String.sub result 0 3 = "\xE2\x9C\x85"  (* ✅ *)
-
-(** Check for warning emoji *)
-let contains_warning result =
-  String.length result >= 3 && String.sub result 0 3 = "\xE2\x9A\xA0"  (* ⚠ *)
-
-(** Check for error emoji *)
-let contains_error result =
-  String.length result >= 3 && String.sub result 0 3 = "\xE2\x9D\x8C"  (* ❌ *)
-
-(** Check for cancel emoji *)
-let _contains_cancel result =
-  String.length result >= 4 && String.sub result 0 4 = "\xF0\x9F\x9A\xAB"  (* 🚫 *)
-
-=======
->>>>>>> be7b3c468c (test(room): accept semantic coord results)
 (** Substring check helper *)
 let str_contains s substring =
   let len_s = String.length s in


### PR DESCRIPTION
## Summary

Three residual `@check` failures on `origin/main` after recent merges.

## Fixes

1. **test/test_room_coverage.ml** — Remove orphaned git merge conflict markers (`<<<<<<< HEAD` / `||||||| parent` / `=======` / `>>>>>>> be7b3c468c`) that were committed as syntax errors.

2. **lib/keeper/keeper_unified_turn.ml:1722** — Replace stale `tool_event_order_violation_error ()` call with `event_bus_integrity_error_snapshot ()`. This call site was missed when #13989 (`44235586de`) refactored local event-bus tracking into `turn_tool_event_tracker`.

3. **test/stanzas/test_cascade_hierarchical_routing.inc** — Add missing `unix` library to `(libraries ...)` so that `Unix.rmdir` / `Unix.mkdir` resolve.

## Verification

```bash
dune build --root . @check  # EXIT 0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)