### PR TITLE
fix(ci): agent_sdk pin SHA resolves to correct .opam version + ROADMAP sync

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,8 +1,8 @@
 # masc-mcp Roadmap
 
-> Current package version: v0.19.11
-> Latest release: v0.19.11 (2026-05-06)
-> Updated: 2026-05-06
+> Current package version: v0.19.16
+> Latest release: v0.19.16 (2026-05-09)
+> Updated: 2026-05-09
 
 This roadmap is the 6-8 week operating view for `masc-mcp`.
 For the product promise and GitHub operating model, see [docs/PRODUCT-OPERATING-PLAN.md](docs/PRODUCT-OPERATING-PLAN.md).

--- a/scripts/oas-agent-sdk-pin.sh
+++ b/scripts/oas-agent-sdk-pin.sh
@@ -3,5 +3,5 @@
 readonly OAS_AGENT_SDK_URL="https://github.com/jeong-sik/oas.git"
 readonly OAS_AGENT_SDK_BASE_VERSION="v0.193.0"
 readonly OAS_AGENT_SDK_TRACK_REF="main"
-readonly OAS_AGENT_SDK_SHA="137979e55d94e894d9b708e6115e40c802f3d779"
+readonly OAS_AGENT_SDK_SHA="ca38483f999729ec7bb5975cb7dd597bfd511e31"
 readonly OAS_AGENT_SDK_MIN_VERSION="0.193.0"


### PR DESCRIPTION
## Summary
- Update agent_sdk pin SHA from `137979e5` to `ca38483f` (actual release commit where `agent_sdk.opam` has `version: "0.193.0"`)
- The previous SHA was a merge commit where `.opam` file still had `0.192.1` despite `dune-project` showing `0.193.0`. opam reads `.opam`, not `dune-project`, causing CI to resolve version `0.192.1` and fail `>= 0.193.0` requirement.
- Update ROADMAP.md version from `v0.19.11` to `v0.19.16` to fix doc-truth check

## Root Cause
OAS merge commit `137979e5` (PR #1490) merged `dune-project` version bump but left `agent_sdk.opam` stale at `0.192.1`. The subsequent commit `ca38483f` (release-please) correctly updated both files.

## Test plan
- [x] Local `opam show agent_sdk --field=version` returns `0.193.0`
- [x] Local `scripts/check-version-truth.sh` passes
- [ ] CI main-health nightly passes after merge

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>