### PR TITLE
fix(keeper): respect cascade-level thinking_enabled in adaptive override

### DIFF
--- a/lib/keeper/keeper_run_tools.ml
+++ b/lib/keeper/keeper_run_tools.ml
@@ -1170,9 +1170,12 @@ let prepare_agent_setup
                  { current_params with
                    thinking_budget = adaptive_thinking_budget
                  ; enable_thinking =
-                     (match adaptive_thinking_override with
-                      | Some _ as v -> v
-                      | None -> current_params.enable_thinking)
+                     (match cascade_seed.thinking_enabled with
+                      | Some false -> Some false
+                      | _ ->
+                        match adaptive_thinking_override with
+                        | Some _ as v -> v
+                        | None -> current_params.enable_thinking)
                  }
                in
                let ctx =


### PR DESCRIPTION
## Summary
Prevents the terminal cascade_exhausted error caused by a triple conflict on Claude models:
1. `adaptive_thinking_mode=true` forces `enable_thinking=true` for Cognitive turns
2. `preferred_tool_choice_for_required_turn` returns `Any` when an active task exists
3. `temperature=0.2` violates Claude's thinking constraint (temperature must be 1)

When `cascade.json` explicitly sets `thinking_enabled=false` for a cascade (e.g., `big_three`), the per-turn adaptive override now respects that setting instead of force-enabling thinking.

## Changes
- `lib/keeper/keeper_run_tools.ml`: BeforeTurnParams hook now checks `cascade_seed.thinking_enabled` before applying `adaptive_thinking_override`. If the cascade explicitly disables thinking, the override is skipped.
- `.masc/config/cascade.json` (runtime): `big_three_temperature` raised to 1.0 and `big_three_thinking_enabled` set to false as defensive defaults.

## Test plan
- [x] `dune build --root . @check` passes
- [ ] Monitor keeper logs for reduction in `cascade_exhausted` rate
- [ ] Verify Claude turns no longer fail with \"temperature may only be set to 1 when thinking is enabled\"

🤖 Generated with Claude Code