### PR TITLE
fix(cascade): retire gemini-2.5-flash + disable thinking on big_three

### DIFF
--- a/config/cascade.json
+++ b/config/cascade.json
@@ -31,11 +31,12 @@
   ],
   "big_three_temperature": 0.2,
   "big_three_max_tokens": 16384,
+  "big_three_thinking_enabled": false,
   "big_three_keeper_assignable": true,
   "big_three_fallback_cascade": "keeper_diverse",
   "_comment_keeper_diverse": "Fallback cascade for contract violation retry. Different model composition from big_three to break correlated failure.",
   "keeper_diverse_models": [
-    "claude_code:claude-sonnet-4-6", "gemini_cli:gemini-2.5-flash",
+    "claude_code:claude-sonnet-4-6", "gemini_cli:gemini-3-flash-preview",
     "codex_cli:gpt-5.3-codex-spark"
   ],
   "keeper_diverse_temperature": 0.3,

--- a/config/cascade.toml
+++ b/config/cascade.toml
@@ -32,6 +32,7 @@ models = [
 ]
 temperature = 0.2
 max_tokens = 16384
+thinking_enabled = false
 keeper_assignable = true
 fallback_cascade = "keeper_diverse"
 
@@ -39,7 +40,7 @@ fallback_cascade = "keeper_diverse"
 comment = "Fallback cascade for contract violation retry. Different model composition from big_three to break correlated failure."
 models = [
   "claude_code:claude-sonnet-4-6",
-  "gemini_cli:gemini-2.5-flash",
+  "gemini_cli:gemini-3-flash-preview",
   "codex_cli:gpt-5.3-codex-spark",
 ]
 temperature = 0.3


### PR DESCRIPTION
## Summary
Config-level fixes for two cascade failure modes observed in fleet logs:

1. **gemini-2.5-flash "Not found"**: `keeper_diverse` fallback lists `gemini-2.5-flash`, but Google API is returning repeated `Not found` / `no_first_token` errors. This breaks the fallback chain and leads to `cascade_exhausted` terminal failures.
   - **Fix**: Replace with `gemini-3-flash-preview`, which is already used successfully in `tier_fast`.

2. **claude thinking + tool_choice collision**: `big_three` routes keeper turns with forced `tool_choice=Any`. When adaptive thinking override enables thinking on claude-sonnet-4-6, the API rejects with "Thinking may not be enabled when tool_choice forces tool use."
   - **Fix**: Set `thinking_enabled = false` at the cascade level. This pairs with PR #14371 (code guard that respects cascade-level `thinking_enabled` in the adaptive override path).

## Files changed
- `config/cascade.json`
- `config/cascade.toml`

## Test plan
- [ ] `dune build --root . @check` passes
- [ ] Monitor keeper logs for reduction in `cascade_exhausted` rate on big_three and keeper_diverse
- [ ] Verify Claude turns no longer fail with thinking + tool_choice conflict

Pairs-with: #14371