### PR TITLE
chore(config): purge remaining gemini-2.5 references across docs, scripts, tests

### DIFF
--- a/config/cascade.json
+++ b/config/cascade.json
@@ -31,11 +31,12 @@
   ],
   "big_three_temperature": 0.2,
   "big_three_max_tokens": 16384,
+  "big_three_thinking_enabled": false,
   "big_three_keeper_assignable": true,
   "big_three_fallback_cascade": "keeper_diverse",
   "_comment_keeper_diverse": "Fallback cascade for contract violation retry. Different model composition from big_three to break correlated failure.",
   "keeper_diverse_models": [
-    "claude_code:claude-sonnet-4-6", "gemini_cli:gemini-2.5-flash",
+    "claude_code:claude-sonnet-4-6", "gemini_cli:gemini-3-flash-preview",
     "codex_cli:gpt-5.3-codex-spark"
   ],
   "keeper_diverse_temperature": 0.3,

--- a/config/cascade.toml
+++ b/config/cascade.toml
@@ -32,6 +32,7 @@ models = [
 ]
 temperature = 0.2
 max_tokens = 16384
+thinking_enabled = false
 keeper_assignable = true
 fallback_cascade = "keeper_diverse"
 
@@ -39,7 +40,7 @@ fallback_cascade = "keeper_diverse"
 comment = "Fallback cascade for contract violation retry. Different model composition from big_three to break correlated failure."
 models = [
   "claude_code:claude-sonnet-4-6",
-  "gemini_cli:gemini-2.5-flash",
+  "gemini_cli:gemini-3-flash-preview",
   "codex_cli:gpt-5.3-codex-spark",
 ]
 temperature = 0.3

--- a/docs/spec/14-configuration.md
+++ b/docs/spec/14-configuration.md
@@ -154,7 +154,7 @@ contains four sections: `tts`, `stt`, `session`, `local_playback`.
 | `ZAI_DEFAULT_MODEL` | string | `"glm-5.1"` | `glm` provider `auto` 기본 모델 (lib/cascade/cascade_model_resolve.ml:38) |
 | `ZAI_CODING_DEFAULT_MODEL` | string | `"glm-4.7"` | `glm-coding` provider `auto` 기본 모델 (lib/cascade/cascade_model_resolve.ml:43) |
 | `GEMINI_DEFAULT_MODEL` | string | `"gemini-3-flash-preview"` | `gemini` provider `auto` 기본 모델 (lib/cascade/cascade_model_resolve.ml:67) |
-| `MASC_GEMINI_CLI_AUTO_MODELS` | csv string | `"gemini-3-flash-preview,gemini-3.1-flash-lite-preview,gemini-2.5-flash,gemini-2.5-flash-lite,gemini-3.1-pro-preview,gemini-2.5-pro"` | `gemini_cli:auto`를 여러 concrete model 후보로 확장하는 순서. 설정 시 `GEMINI_DEFAULT_MODEL`보다 우선 |
+| `MASC_GEMINI_CLI_AUTO_MODELS` | csv string | `"gemini-3-flash-preview,gemini-3.1-flash-lite-preview,gemini-3.1-pro-preview"` | `gemini_cli:auto`를 여러 concrete model 후보로 확장하는 순서. 설정 시 `GEMINI_DEFAULT_MODEL`보다 우선 |
 | `MASC_CODEX_CLI_AUTO_MODELS` | csv string | `"gpt-5.2,gpt-5.3-codex-spark,gpt-5.3-codex,gpt-5.4-mini,gpt-5.4"` | `codex_cli:auto` 확장 순서. 기본은 ChatGPT-backed Codex에서 실제 호출 성공이 확인된 후보만 포함하며, 필요하면 env override로 후보를 직접 재지정 |
 | `MASC_CLAUDE_CODE_AUTO_MODELS` | csv string | `"auto"` | `claude_code:auto` 확장 순서. 기본은 Claude Code의 사용자 기본 모델에 위임 |
 | `KIMI_DEFAULT_MODEL` | string | `"kimi-k2.5"` | `kimi` provider `auto` 기본 모델 (lib/provider_adapter.ml:505) |
@@ -331,7 +331,7 @@ JSON 파일로 cascade별 설정을 정의한다. 기본 키 패턴은
 {
   "default_models": ["llama:qwen3.5", "glm:glm-5.1"],
   "keeper_turn_models": ["llama:qwen3.5", "glm:glm-5.1"],
-  "briefing_models": ["llama:qwen3.5", "glm:glm-5.1", "gemini:gemini-2.5-pro"],
+  "briefing_models": ["llama:qwen3.5", "glm:glm-5.1", "gemini:gemini-3.1-pro-preview"],
   "auto_responder_claude_models": ["claude:sonnet", "glm:glm-5.1"],
   "keeper_unified_temperature": 0.4,
   "keeper_unified_max_tokens": 2048

--- a/scripts/generate_oil_paintings.py
+++ b/scripts/generate_oil_paintings.py
@@ -51,7 +51,7 @@ def generate_image(prompt: str, output_path: Path, size: tuple[int, int]) -> boo
 
     try:
         response = client.models.generate_content(
-            model=os.getenv("MASC_IMAGE_MODEL", "gemini-2.5-flash-image"),
+            model=os.getenv("MASC_IMAGE_MODEL", "gemini-3-flash-preview"),
             contents=full_prompt,
             config=types.GenerateContentConfig(
                 response_modalities=["IMAGE", "TEXT"],

--- a/scripts/viewer-local-e2e-check.sh
+++ b/scripts/viewer-local-e2e-check.sh
@@ -64,7 +64,7 @@ viewer-local-e2e-check.sh
   scripts/viewer-local-e2e-check.sh
   scripts/viewer-local-e2e-check.sh --build-viewer
   scripts/viewer-local-e2e-check.sh --run-smoke --keeper-models "glm:auto"
-  scripts/viewer-local-e2e-check.sh --run-round --rounds 2 --keeper-models "gemini:gemini-2.5-flash"
+  scripts/viewer-local-e2e-check.sh --run-round --rounds 2 --keeper-models "gemini:gemini-3-flash-preview"
 EOF
 }
 

--- a/test/test_cascade_hierarchical_routing.ml
+++ b/test/test_cascade_hierarchical_routing.ml
@@ -74,7 +74,7 @@ let test_load_cascade_profile_hierarchical () =
         {
           "name": "fallback",
           "items": [
-            {"id": "gemini-flash", "provider": "gemini_cli", "model": "gemini-2.5-flash", "timeout_ms": 60000, "priority": 1}
+            {"id": "gemini-flash", "provider": "gemini_cli", "model": "gemini-3-flash-preview", "timeout_ms": 60000, "priority": 1}
           ],
           "strategy": "priority",
           "fallback_group": null
@@ -117,7 +117,7 @@ let test_load_cascade_profile_legacy_fallback () =
     {|{
       "legacy_profile_models": [
         {"model": "ollama:qwen3:14b", "weight": 1},
-        {"model": "gemini_cli:gemini-2.5-flash", "weight": 2}
+        {"model": "gemini_cli:gemini-3-flash-preview", "weight": 2}
       ],
       "legacy_profile_temperature": 0.7
     }|}

--- a/test/test_cascade_per_candidate_telemetry.ml
+++ b/test/test_cascade_per_candidate_telemetry.ml
@@ -79,14 +79,14 @@ let test_success_shape () =
 let test_failure_shape () =
   let json =
     Cascade_legacy_runner.cascade_attempt_terminal_event_json
-      ~model_id:"gemini_cli:gemini-2.5-pro" ~model_label:None
+      ~model_id:"gemini_cli:gemini-3.1-pro-preview" ~model_label:None
       ~latency_ms:(Some 1200)
       ~error:(Some "OAS budget timeout after 600.0s") ()
   in
   Alcotest.(check string)
     "event tag" "cascade_attempt_terminal" (assoc_string "event" json);
   Alcotest.(check string)
-    "model_id" "gemini_cli:gemini-2.5-pro" (assoc_string "model_id" json);
+    "model_id" "gemini_cli:gemini-3.1-pro-preview" (assoc_string "model_id" json);
   Alcotest.(check string) "outcome" "failure" (assoc_string "outcome" json);
   (match assoc_field "model_label" json with
   | Some `Null -> ()

--- a/test/test_observability_provider_contracts.ml
+++ b/test/test_observability_provider_contracts.ml
@@ -205,14 +205,14 @@ let test_cascade_model_resolve_hardcoded_default_provenance () =
 
 let test_cascade_model_resolve_env_default_provenance () =
   let getenv = function
-    | "GEMINI_DEFAULT_MODEL" -> Some "gemini-2.5-flash"
+    | "GEMINI_DEFAULT_MODEL" -> Some "gemini-3-flash-preview"
     | _ -> None
   in
   let resolved =
     Model_resolve.resolve_auto_model ~getenv "gemini"
       (Model_resolve.model_selector_of_string "auto")
   in
-  check string "gemini env default" "gemini-2.5-flash"
+  check string "gemini env default" "gemini-3-flash-preview"
     resolved.resolved_model_id;
   check resolution_provenance "env provenance"
     (Model_resolve.Env_default "GEMINI_DEFAULT_MODEL")

--- a/test/test_provider_kind_resolution.ml
+++ b/test/test_provider_kind_resolution.ml
@@ -1,5 +1,5 @@
 (** Tests for [Provider_kind_resolver] and the cascade parser's
-    use of it. Covers issue #8159: ["gemini:gemini-2.5-flash"] must
+    use of it. Covers issue #8159: ["gemini:gemini-3-flash-preview"] must
     resolve to [Gemini], never silently flatten to [OpenAI_compat]. *)
 
 open Alcotest
@@ -31,10 +31,10 @@ let kind_testable : Pk.provider_kind testable =
 (* ────────────────────────────────────────────────────────────────── *)
 
 let test_gemini_prefix_resolves_to_gemini () =
-  match Resolver.resolve "gemini:gemini-2.5-flash" with
+  match Resolver.resolve "gemini:gemini-3-flash-preview" with
   | Registered { provider_name; model_id; kind } ->
     check string "provider_name" "gemini" provider_name;
-    check string "model_id" "gemini-2.5-flash" model_id;
+    check string "model_id" "gemini-3-flash-preview" model_id;
     check kind_testable "kind is Gemini" Pk.Gemini kind
   | Custom_url _ -> fail "gemini: resolved to Custom_url"
   | Unknown msg -> fail ("gemini: resolved to Unknown: " ^ msg)
@@ -100,7 +100,7 @@ let test_custom_prefix_resolves_to_custom_url () =
 let test_kind_of_spec_api () =
   check (option kind_testable) "gemini kind via helper"
     (Some Pk.Gemini)
-    (Resolver.kind_of_spec "gemini:gemini-2.5-flash");
+    (Resolver.kind_of_spec "gemini:gemini-3-flash-preview");
   check (option kind_testable) "unknown returns None"
     None
     (Resolver.kind_of_spec "unknownvendor:foo")
@@ -112,7 +112,7 @@ let test_kind_of_spec_api () =
 let test_cascade_parse_gemini_preserves_kind () =
   (* End-to-end: the exact spec from issue #8159 must yield kind=Gemini
      after going through Cascade_config.parse_model_string. *)
-  match Cascade.parse_model_string "gemini:gemini-2.5-flash" with
+  match Cascade.parse_model_string "gemini:gemini-3-flash-preview" with
   | None ->
     (* parse_model_string returns None when the provider is not
        available (missing GEMINI_API_KEY env var in test env). In that
@@ -120,12 +120,12 @@ let test_cascade_parse_gemini_preserves_kind () =
        classification; accept None here. *)
     check bool "resolver confirms Gemini kind when provider unavailable"
       true
-      (Resolver.kind_of_spec "gemini:gemini-2.5-flash"
+      (Resolver.kind_of_spec "gemini:gemini-3-flash-preview"
        = Some Pk.Gemini)
   | Some cfg ->
     check kind_testable "cfg.kind is Gemini (not OpenAI_compat)"
       Pk.Gemini cfg.kind;
-    check string "cfg.model_id" "gemini-2.5-flash" cfg.model_id
+    check string "cfg.model_id" "gemini-3-flash-preview" cfg.model_id
 
 let test_cascade_parse_unknown_returns_none () =
   match Cascade.parse_model_string "unknownvendor:foo" with


### PR DESCRIPTION
## Summary
Follow-up to #14372. Removes all remaining gemini-2.5 references from docs, scripts, and test fixtures.

## Files changed
- `docs/spec/14-configuration.md` — env defaults, briefing_models example
- `scripts/viewer-local-e2e-check.sh` — example keeper model
- `scripts/generate_oil_paintings.py` — default image model
- `test/test_observability_provider_contracts.ml` — env default test
- `test/test_provider_kind_resolution.ml` — resolver/cascade integration tests
- `test/test_cascade_per_candidate_telemetry.ml` — telemetry shape test
- `test/test_cascade_hierarchical_routing.ml` — loader/materializer tests

## Test plan
- [x] `dune build --root . @check` passes