### PR TITLE
fix(dashboard): close incomplete typecheck migration after PR #14376

### DIFF
--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -11,7 +11,7 @@ import {
   normalizePendingConfirmation,
 } from './board'
 import { normalizeKeeperTrustTerminalReason } from '../keeper-store-normalize'
-import { currentDashboardActor, get, post, patch, withRetries, NAMESPACE_TRUTH_GET_TIMEOUT_MS } from './core'
+import { currentDashboardActor, get, post, withRetries, NAMESPACE_TRUTH_GET_TIMEOUT_MS } from './core'
 import {
   parseAgentRelationsResponse,
   type AgentRelationsResponse,

--- a/dashboard/src/api/schemas/keeper-composite.ts
+++ b/dashboard/src/api/schemas/keeper-composite.ts
@@ -191,6 +191,12 @@ export const KeeperCompositeSnapshotSchema = object({
   run_id: string(),
   ts: number(),
   phase: KeeperCompositePhaseSchema,
+  // When `phase` is `Stable`, the backend may carry the underlying raw
+  // keeper phase (e.g. `paused`) so the dashboard can tell a true idle
+  // Stable from a Stable that masks a non-idle source. Absent on older
+  // backends and on non-Stable phases — `optional` + `nullable` matches
+  // both the missing-key and explicit-null shapes the backend emits.
+  collapsed_from: optional(nullable(string())),
   turn_phase: KeeperCompositeTurnPhaseSchema,
   decision: object({ stage: KeeperCompositeDecisionStageSchema }),
   cascade: object({ state: KeeperCompositeCascadeStateSchema }),

--- a/dashboard/src/components/fleet-fsm-matrix.test.ts
+++ b/dashboard/src/components/fleet-fsm-matrix.test.ts
@@ -70,6 +70,7 @@ function snapshot(
       event_priority_monotone: allHold,
       ...overrides.violate,
     },
+    fsm_guard_violations: 0,
     is_live: false,
     last_outcome: null,
     recommended_actions: [],

--- a/dashboard/src/components/fsm-hub-invariant-analysis.test.ts
+++ b/dashboard/src/components/fsm-hub-invariant-analysis.test.ts
@@ -20,6 +20,7 @@ function makeSnapshot(overrides: Partial<KeeperCompositeSnapshot> = {}): KeeperC
       compaction_atomicity: true,
       event_priority_monotone: true,
     },
+    fsm_guard_violations: 0,
     is_live: true,
     last_outcome: null,
     recommended_actions: [],

--- a/dashboard/src/components/fsm-hub-types.test.ts
+++ b/dashboard/src/components/fsm-hub-types.test.ts
@@ -32,6 +32,7 @@ function snapshot(overrides: Partial<KeeperCompositeSnapshot> = {}): KeeperCompo
       compaction_atomicity: true,
       event_priority_monotone: true,
     },
+    fsm_guard_violations: 0,
     is_live: false,
     last_outcome: null,
     recommended_actions: [],

--- a/dashboard/src/components/fsm-hub-types.ts
+++ b/dashboard/src/components/fsm-hub-types.ts
@@ -1,7 +1,7 @@
 import type {
   KeeperCompositeSnapshot,
   KeeperCompositeInvariants,
-} from '../api/keeper'
+} from '../api/schemas/keeper-composite'
 
 export type CompositeObservation = {
   ts: number

--- a/dashboard/src/components/fsm-hub.integration.test.ts
+++ b/dashboard/src/components/fsm-hub.integration.test.ts
@@ -54,6 +54,7 @@ const REAL_COMPOSITE_SHAPE: KeeperCompositeSnapshot = {
     compaction_atomicity: true,
     event_priority_monotone: true,
   },
+  fsm_guard_violations: 0,
   is_live: false,
   last_outcome: {
     turn_id: 353,

--- a/dashboard/src/components/fsm-hub.test.ts
+++ b/dashboard/src/components/fsm-hub.test.ts
@@ -56,6 +56,7 @@ function snapshot(
       compaction_atomicity: true,
       event_priority_monotone: true,
     },
+    fsm_guard_violations: 0,
     is_live: false,
     last_outcome: null,
     recommended_actions: [],

--- a/dashboard/src/components/keeper-fsm-specs.ts
+++ b/dashboard/src/components/keeper-fsm-specs.ts
@@ -37,6 +37,11 @@ export const TURN_FSM_STATES = [
   'prompting',
   'routing',
   'executing',
+  // UI-side surface for the TLA `awaiting_tool` symbol — the SDK turn
+  // sits here after invoking a tool until the tool result arrives.
+  // `normalizeTurnFsmState` maps the raw `awaiting_tool` backend phase
+  // onto this UI state, and `turnFsmTlaSymbol` translates it back.
+  'awaiting_tool_result',
   'compacting',
   'finalizing',
   'exhausted',
@@ -49,9 +54,18 @@ const TURN_FSM_TLA_SYMBOLS: Record<KeeperTurnFsmState, string> = {
   prompting: 'prompting',
   routing: 'routing',
   executing: 'executing',
+  awaiting_tool_result: 'awaiting_tool',
   compacting: 'compacting',
   finalizing: 'finalizing',
   exhausted: 'exhausted',
+}
+
+// Raw backend turn-phase values that should collapse onto a canonical
+// UI state. Currently only the TLA `awaiting_tool` symbol is renamed
+// for the dashboard surface; leave additional aliases here when the
+// backend introduces new raw phases that map onto an existing UI state.
+const TURN_FSM_STATE_ALIASES: Readonly<Record<string, KeeperTurnFsmState>> = {
+  awaiting_tool: 'awaiting_tool_result',
 }
 
 const TURN_FSM_EDGES: FsmEdge[] = [
@@ -174,6 +188,8 @@ export function normalizeTurnFsmState(turnPhase: string | null | undefined): Kee
   if (!turnPhase) return null
   const normalized = turnPhase.trim().toLowerCase()
   if (!normalized) return null
+  const aliased = TURN_FSM_STATE_ALIASES[normalized]
+  if (aliased) return aliased
   if ((TURN_FSM_STATES as readonly string[]).includes(normalized)) {
     return normalized as KeeperTurnFsmState
   }

--- a/dashboard/src/components/keeper-memory-tier-panel.test.ts
+++ b/dashboard/src/components/keeper-memory-tier-panel.test.ts
@@ -109,6 +109,7 @@ function mockMemoryTierFetches(usage: MemoryKindUsageEntry[]) {
       compaction_atomicity: true,
       event_priority_monotone: true,
     },
+    fsm_guard_violations: 0,
     is_live: true,
     last_outcome: null,
     recommended_actions: [],

--- a/dashboard/src/components/turn-fsm-detail-panel.test.ts
+++ b/dashboard/src/components/turn-fsm-detail-panel.test.ts
@@ -32,6 +32,7 @@ function keeperCompositeSnapshot(
       compaction_atomicity: true,
       event_priority_monotone: true,
     },
+    fsm_guard_violations: 0,
     is_live: false,
     last_outcome: null,
     recommended_actions: [],

--- a/dashboard/src/config/navigation.ts
+++ b/dashboard/src/config/navigation.ts
@@ -41,7 +41,7 @@ type SurfaceSectionId =
   // code (Stage 5 IDE plane — shell only in PR-1, 4-pane content in PR-2+)
   | 'ide-shell'
 
-type NonHomeTabId = Exclude<TabId, 'overview' | 'logs'>
+export type NonHomeTabId = Exclude<TabId, 'overview' | 'logs'>
 
 interface DashboardNavGroup {
   id: SurfaceId
@@ -62,7 +62,7 @@ interface DashboardNavItem {
   defaultParams?: Record<string, string>
 }
 
-interface DashboardSectionNavItem {
+export interface DashboardSectionNavItem {
   id: SurfaceSectionId
   label: string
   description: string

--- a/dashboard/src/types.ts
+++ b/dashboard/src/types.ts
@@ -8,3 +8,7 @@ export * from './types/dashboard-execution'
 export * from './types/dashboard-mission'
 export * from './types/sse'
 export * from './types/oas'
+
+// Navigation types live next to the route table in `config/navigation.ts`,
+// but tests and downstream code expect them on the `./types` barrel.
+export type { NonHomeTabId, DashboardSectionNavItem } from './config/navigation'


### PR DESCRIPTION
## Goal

Unblock the **Dashboard / TypeScript typecheck** required check on `main` (currently failing with 25+ TS errors on `5da417aa`).

## Why this is on the main blocker chain

\`gh api .../check-runs\` for the latest \`main\` SHA shows 9 failing checks. Three groups share root causes; this PR addresses the Dashboard group only. PR #14379 covers the spec-line-refs (Meta Guards) group separately. The OCaml \`agent_sdk.0.193.0\` build group (Build and Test / Lint / Health / odoc) is *not* in this PR — see [post-mortem note] in the diagnostic above.

## Root causes (all dashboard-internal)

| # | Problem | Fix |
|---|---|---|
| 1 | \`KeeperCompositeSnapshot\` imported from \`'../api/keeper'\` in some test/component files and from \`'../api/schemas/keeper-composite'\` elsewhere → TS2719 \"Two different types with this name exist, but they are unrelated\" | Unify on the schema-derived path in \`fsm-hub-types.ts\` so the valibot schema is the single SSOT |
| 2 | \`collapsed_from\` is read from snapshots in 5 places but never declared in the schema → \"Property 'collapsed_from' does not exist on type ...\" | Add \`collapsed_from: optional(nullable(string()))\` to \`KeeperCompositeSnapshotSchema\` |
| 3 | TLA \`awaiting_tool\` symbol maps to UI state \`awaiting_tool_result\` in tests, but \`TURN_FSM_STATES\` only listed 7 states | Add \`awaiting_tool_result\` + \`TURN_FSM_STATE_ALIASES\` (no edge/label changes) |
| 4 | \`NonHomeTabId\` / \`DashboardSectionNavItem\` declared but not exported from \`config/navigation.ts\` | \`export\` both + re-export from \`types.ts\` barrel |
| 5 | \`api/dashboard.ts:14\` unused \`patch\` import (TS6133) | Drop the symbol from the destructure |
| 6 | 5 test fixtures missing the now-required \`fsm_guard_violations\` field | \`fsm_guard_violations: 0\` on each base fixture |

## Local verification

\`\`\`
$ cd dashboard && pnpm run typecheck
> masc-dashboard@1.0.0 typecheck
> tsc --noEmit
\$ echo \$?
0
\`\`\`

(Before this PR: 25+ TS errors; after: 0.)

## Files changed

- \`dashboard/src/api/dashboard.ts\` — drop unused \`patch\` import (-1)
- \`dashboard/src/api/schemas/keeper-composite.ts\` — add \`collapsed_from\` field (+6)
- \`dashboard/src/components/fsm-hub-types.ts\` — unify import path (1 line)
- \`dashboard/src/components/keeper-fsm-specs.ts\` — add \`awaiting_tool_result\` state + alias (+16)
- \`dashboard/src/config/navigation.ts\` — export \`NonHomeTabId\`, \`DashboardSectionNavItem\` (2 lines)
- \`dashboard/src/types.ts\` — re-export navigation types (+4)
- 7 test fixtures — \`fsm_guard_violations: 0\` (+1 each)

## RFC scope

Not in agent_delegation sensitive subsystem list. \`dashboard/src/components/credential-settings\` and \`keeper-repo-mapping\` are RFC-required scopes; this PR touches **neither**. \`config/navigation.ts\` is a route table, not a credential / identity / sandbox surface.

\`bash ~/me/scripts/pr-rfc-check.sh\` not run (script is in user's Second Brain, not the masc-mcp repo). The PR body documents scope.

RFC-WAIVED: dashboard-only typecheck unblock; no OCaml, no credential, no operator surface, no keeper FSM behaviour change. The new \`awaiting_tool_result\` state is pure UI surface — the corresponding TLA edges and \`turn_phase\` schema were already \`string()\`-open.

## Remaining unverified

- Did **not** run \`pnpm test\` (vitest) locally — typecheck passes and the change is fixture-additive + schema-additive, but a full unit-test run will only happen in CI.
- Did **not** address the TLA+ \`KeeperCascadeRouting\` exit-12 failure or the \`Build and Test\` agent_sdk \`Unbound module Runtime_server_worker\` failure — those are independent groups on the main blocker chain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)