### PR TITLE
fix(telemetry): deduplicate token counting from dual OAS paths

### DIFF
--- a/lib/cascade/cascade_event_bridge.ml
+++ b/lib/cascade/cascade_event_bridge.ml
@@ -55,34 +55,11 @@ let inference_model_bucket ~provider ~model =
   else if has "llama" then "llama"
   else "other"
 
-let inference_token_bucket = function
-  | None -> "missing"
-  | Some tokens when tokens <= 0 -> "0"
-  | Some tokens when tokens <= 1024 -> "1_1k"
-  | Some tokens when tokens <= 8192 -> "1k_8k"
-  | Some _ -> "over_8k"
-
 let positive_finite value =
   value > 0.0
   && match classify_float value with
   | FP_nan | FP_infinite -> false
   | FP_normal | FP_subnormal | FP_zero -> true
-
-let observe_inference_tokens ~model_bucket ~phase tokens =
-  let labels =
-    [
-      ("model_bucket", model_bucket);
-      ("phase", phase);
-      ("token_bucket", inference_token_bucket tokens);
-    ]
-  in
-  let value =
-    match tokens with
-    | Some tokens when tokens > 0 -> float_of_int tokens
-    | _ -> 0.0
-  in
-  Prometheus.observe_histogram Prometheus.metric_oas_inference_telemetry_tokens
-    ~labels value
 
 let tok_per_sec_from_ms ~tokens ~ms =
   match (tokens, ms) with
@@ -102,10 +79,11 @@ let observe_inference_telemetry ~provider ~model ~prompt_tokens
   let model_bucket =
     inference_model_bucket ~provider ~model
   in
-  observe_inference_tokens ~model_bucket ~phase:"prompt"
-    prompt_tokens;
-  observe_inference_tokens ~model_bucket ~phase:"completion"
-    completion_tokens;
+  (* Token counts are NOT emitted here.  The authoritative per-request
+     token counter is [on_token_usage] → [Llm_metric_bridge.emit_token_usage]
+     with precise {provider, model} labels.  This function retains only
+     the latency/rate metrics (prompt_tok/s, decode_tok/s) that are
+     unique to the [InferenceTelemetry] event payload. *)
   observe_inference_rate Prometheus.metric_oas_inference_prompt_tok_per_sec
     ~model_bucket
     (tok_per_sec_from_ms ~tokens:prompt_tokens ~ms:prompt_ms);


### PR DESCRIPTION
## Summary

- Remove duplicate token count observations from `observe_inference_telemetry` in `cascade_event_bridge.ml`
- Same LLM token data was counted through two independent OAS output channels with different label precision, making aggregate queries unreliable
- Token counting authority consolidated to `on_token_usage` → `llm_metric_bridge.emit_token_usage` (precise `{provider, model}` labels)
- `InferenceTelemetry` path retains latency/rate metrics (`prompt_tok/s`, `decode_tok/s`) — unique data not available from the metrics callback

## Problem

| Path | Trigger | Metric | Labels |
|------|---------|--------|--------|
| A: Metrics callback | `complete.ml:783` → `on_token_usage` | `masc_llm_provider_{input,output}_tokens_total` | `{provider="claude", model="claude-sonnet-4-6"}` |
| B: Event bus | `stage_collect.ml:68` → `InferenceTelemetry` | `metric_oas_inference_telemetry_tokens` | `{model_bucket="anthropic", phase="prompt"}` |

Both fire on the same LLM completion. Every token counted twice with incompatible label sets.

## After fix

| Data | Authoritative path | Labels |
|------|--------------------|--------|
| Token counts | `on_token_usage` (Path A) | precise `{provider, model}` |
| Prompt speed | `InferenceTelemetry` (Path B) | bucketed `{model_bucket}` |
| Decode speed | `InferenceTelemetry` (Path B) | bucketed `{model_bucket}` |
| Cost | `AgentCompleted` handler | bucketed `{model_bucket}` |

## Test plan

- [x] `dune build --root . @check` passes with zero errors/warnings
- [x] No test files reference `observe_inference_tokens`
- [ ] Grafana dashboard `metric_oas_inference_telemetry_tokens` will show no new data (expected — definition preserved for query compat)
- [ ] `masc_llm_provider_input_tokens_total` / `masc_llm_provider_output_tokens_total` remain the authoritative token counters

🤖 Generated with [Claude Code](https://claude.com/claude-code)