### PR TITLE
refactor(cascade): make cascade_routes.spec_for_use exhaustive (drop assert false)

### DIFF
--- a/lib/cascade/cascade_routes.ml
+++ b/lib/cascade/cascade_routes.ml
@@ -42,45 +42,74 @@ type route_spec = {
 
 let route use key aliases = { use; key; aliases }
 
-let route_specs =
+(* [spec_for_use] is the SSOT for the (logical_use → key/aliases) mapping.
+   Written as an exhaustive [match] so adding a new constructor to
+   [logical_use] is a compile-time error here, not a runtime
+   [assert false] surfaced by [spec_for_use] callers.  Per CLAUDE.md
+   §"FSM Sparse Match" anti-pattern: a list lookup keyed by a closed
+   sum type silently degrades when the list and the type drift apart. *)
+let spec_for_use : logical_use -> route_spec = function
+  | Keeper_turn ->
+      route Keeper_turn "keeper_turn"
+        [
+          "default";
+          "default_models";
+          "oas-keeper_unified";
+          "coding_first";
+          "oas-coding_first";
+          "keeper_reply";
+          "keeper_unified";
+        ]
+  | Phase_recovery -> route Phase_recovery "phase_recovery" [ "local_recovery" ]
+  | Phase_buffer -> route Phase_buffer "phase_buffer" [ "local_only" ]
+  | Tool_required ->
+      route Tool_required "tool_required"
+        [ "tool_use_strict"; "resilient_breaker" ]
+  | Governance_judge -> route Governance_judge "governance_judge" []
+  | Operator_judge -> route Operator_judge "operator_judge" []
+  | Cross_verifier -> route Cross_verifier "cross_verifier" []
+  | Verifier -> route Verifier "verifier" []
+  | Autoresearch -> route Autoresearch "autoresearch" []
+  | Adversarial_reviewer -> route Adversarial_reviewer "adversarial_reviewer" []
+  | Auto_responder -> route Auto_responder "auto_responder" []
+  | Routing -> route Routing "routing" [ "routing_judge" ]
+  | Openai_compat -> route Openai_compat "openai_compat" []
+  | Persona_generation -> route Persona_generation "persona_generation" []
+  | Provider_benchmark -> route Provider_benchmark "provider_benchmark" []
+  | Simple_task -> route Simple_task "simple_task" []
+  | Moderate_task -> route Moderate_task "moderate_task" []
+  | Complex_task -> route Complex_task "complex_task" []
+  | Tool_rerank_use -> route Tool_rerank_use "llm_rerank" []
+
+(* The known-uses enumeration must remain in sync with [logical_use].
+   When a new constructor is added, the [match] in [spec_for_use] will
+   refuse to compile until extended; this list still requires a manual
+   append, but downstream lookups go through [spec_for_use] so the
+   silent-runtime-failure path is closed. *)
+let all_logical_uses : logical_use list =
   [
-    route Keeper_turn "keeper_turn"
-      [
-        "default";
-        "default_models";
-        "oas-keeper_unified";
-        "coding_first";
-        "oas-coding_first";
-        "keeper_reply";
-        "keeper_unified";
-      ];
-    route Phase_recovery "phase_recovery" [ "local_recovery" ];
-    route Phase_buffer "phase_buffer" [ "local_only" ];
-    route Tool_required "tool_required"
-      [ "tool_use_strict"; "resilient_breaker" ];
-    route Governance_judge "governance_judge" [];
-    route Operator_judge "operator_judge" [];
-    route Cross_verifier "cross_verifier" [];
-    route Verifier "verifier" [];
-    route Autoresearch "autoresearch" [];
-    route Adversarial_reviewer "adversarial_reviewer" [];
-    route Auto_responder "auto_responder" [];
-    route Routing "routing" [ "routing_judge" ];
-    route Openai_compat "openai_compat" [];
-    route Persona_generation "persona_generation" [];
-    route Provider_benchmark "provider_benchmark" [];
-    route Simple_task "simple_task" [];
-    route Moderate_task "moderate_task" [];
-    route Complex_task "complex_task" [];
-    route Tool_rerank_use "llm_rerank" [];
+    Keeper_turn;
+    Phase_recovery;
+    Phase_buffer;
+    Tool_required;
+    Governance_judge;
+    Operator_judge;
+    Cross_verifier;
+    Verifier;
+    Autoresearch;
+    Adversarial_reviewer;
+    Auto_responder;
+    Routing;
+    Openai_compat;
+    Persona_generation;
+    Provider_benchmark;
+    Simple_task;
+    Moderate_task;
+    Complex_task;
+    Tool_rerank_use;
   ]
 
-let spec_for_use use =
-  match List.find_opt (fun spec -> spec.use = use) route_specs with
-  | Some spec -> spec
-  | None -> assert false
-
-let all_logical_uses = List.map (fun spec -> spec.use) route_specs
+let route_specs : route_spec list = List.map spec_for_use all_logical_uses
 
 let known_route_keys =
   route_specs


### PR DESCRIPTION
## Goal

Close \`Cascade_routes.spec_for_use\`'s runtime \`assert false\` (\`lib/cascade/cascade_routes.ml:81\` on origin/main) by replacing the \`List.find_opt\` lookup with an exhaustive \`match\`.

## Background — Cascade FSM audit P1.1

This is the first ship-now item from a 10-issue cascade FSM audit. Same audit identifies:

- P1.2 — \`filter_healthy\` strict-only (separate PR)
- P2.x — \`cascade_attempt_fsm\` string classifier → typed \`Provider_error\` variant (RFC-scope)
- P2.y — \`cascade_attempt_liveness\` cold-start budget split (RFC-scope)
- P3.x — KeeperCascadeRouting TLA exit 12 (main blocker D)
- P3.y — cascade godfile metric ownership distribution
- + test backdoor cleanup, cascade_legacy_runner deprecation

P1.1 is the lowest-risk member of the family — it eliminates one of two anti-patterns the godfile-decomposition era left behind in this module, and it does so without touching any caller.

## Anti-pattern this PR closes

CLAUDE.md \`software-development.md\` §"AI 코드 생성 안티패턴" #4 (FSM Sparse Match / \`_ -> false\` Catch-all):

> variant 기반 FSM에서 \`_ -> false\` catch-all로 전이 매트릭스를 sparse하게 정의. 새로운 상태 전이 추가 시 컴파일러가 누락을 감지하지 못하고 런타임 \`Assert_failure\`로 드러남.

The current shape:

\`\`\`ocaml
let route_specs = [ route Keeper_turn ...; route Phase_recovery ...; ... ]

let spec_for_use use =
  match List.find_opt (fun spec -> spec.use = use) route_specs with
  | Some spec -> spec
  | None -> assert false
\`\`\`

is exactly that pattern, only typed-list-shaped: \`logical_use\` is a closed sum type, but the lookup table is a list, so the compiler cannot prove the table covers every constructor. Adding a new \`logical_use\` constructor without appending to \`route_specs\` compiles cleanly, then surfaces as a deep-stack \`Assert_failure\` inside cascade routing.

## Change

Move the table into an exhaustive \`match\`:

\`\`\`ocaml
let spec_for_use : logical_use -> route_spec = function
  | Keeper_turn -> route Keeper_turn "keeper_turn" [ "default"; ... ]
  | Phase_recovery -> route Phase_recovery "phase_recovery" [ "local_recovery" ]
  | ...  (* 19 constructors total *)
\`\`\`

\`route_specs\` becomes \`List.map spec_for_use all_logical_uses\`. \`all_logical_uses\` still requires a manual list append on new variants, but it controls **listing** surfaces (\`known_route_keys\`, \`logical_use_of_string_opt\`) only; the direct lookup path is now compiler-enforced.

The repo-wide \`(env (dev (flags (:standard -warn-error +8))))\` in \`./dune\` escalates non-exhaustive \`match\` to a hard error, so a missing constructor now fails CI lint, not production runtime.

## What does not change

- All 19 existing \`logical_use\` variants keep the same \`(key, aliases)\` tuples — verified by line-by-line grep against the pre-change \`route_specs\`.
- No callers of \`spec_for_use\` / \`logical_use_key\` / \`route_specs\` change.
- No \`.mli\` change.

## Files changed

- \`lib/cascade/cascade_routes.ml\` (+65 / −36, behaviour-equivalent)

## RFC scope

Not in agent_delegation sensitive subsystem list (no credential / identity / operator / dashboard credential / hooks / workflow). \`cascade_routes\` is a pure config-resolver under \`lib/cascade/\`.

RFC-WAIVED: behaviour-equivalent refactor that closes a runtime \`assert false\` flagged by the repo's own \`software-development.md\` anti-pattern catalogue. No new public surface, no schema or wire-format change.

## Local verification not run

\`dune build\` in the worktree is currently blocked by the \`agent_sdk.0.193.0 — Unbound module Runtime_server_worker\` failure on origin/main (the same group that fails Build and Test / Lint / Health / odoc). CI will exercise the full build chain on this PR. The change is mechanical and exhaustive-match correctness reduces to "the 19 constructors of \`logical_use\` match the 19 cases listed here", which is line-by-line verifiable from the diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)