### PR TITLE
refactor(cascade): drop fail-open filter_healthy in favor of strict-only

### DIFF
--- a/lib/cascade/cascade_config.ml
+++ b/lib/cascade/cascade_config.ml
@@ -619,7 +619,6 @@ let parse_model_strings
 
 (* Health filtering (extracted to Cascade_health_filter) *)
 let is_local_provider = Cascade_health_filter.is_local_provider
-let filter_healthy = Cascade_health_filter.filter_healthy
 let filter_healthy_strict = Cascade_health_filter.filter_healthy_strict
 let health_filter_rejection_to_string = Cascade_health_filter.health_filter_rejection_to_string
 type health_filter_rejection = Cascade_health_filter.health_filter_rejection =

--- a/lib/cascade/cascade_config.mli
+++ b/lib/cascade/cascade_config.mli
@@ -384,22 +384,6 @@ val resolve_api_key_env :
 
 (** {1 Discovery-Aware Health Filtering} *)
 
-(** Filter a provider list by local endpoint health.
-
-    Probes local (llama-server) endpoints via {!Discovery}. When all
-    local endpoints are unhealthy, removes local providers from the list
-    so cloud providers serve as fallback.
-
-    When the list contains only local providers, passes through unchanged
-    (let the provider return a connection error rather than an empty list).
-
-    Cloud providers always pass through unfiltered. *)
-val filter_healthy :
-  sw:Eio.Switch.t ->
-  net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t ->
-  Llm_provider.Provider_config.t list ->
-  Llm_provider.Provider_config.t list
-
 type health_filter_rejection =
   Cascade_health_filter.health_filter_rejection =
   | All_missing_api_key of int
@@ -407,6 +391,17 @@ type health_filter_rejection =
 
 val health_filter_rejection_to_string : health_filter_rejection -> string
 
+(** Filter a provider list by local endpoint health.
+
+    Probes local (llama-server) endpoints via {!Discovery}. When all
+    local endpoints are unhealthy, removes local providers from the list
+    so cloud providers serve as fallback.
+
+    Returns [Error] when the cascade is configurationally broken
+    (all providers missing API keys) or has drifted below the
+    live-fallback threshold (all local unhealthy with no cloud
+    fallback). Callers must handle the typed rejection — the prior
+    fail-open variant is gone. *)
 val filter_healthy_strict :
   sw:Eio.Switch.t ->
   net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t ->

--- a/lib/cascade/cascade_health_filter.ml
+++ b/lib/cascade/cascade_health_filter.ml
@@ -112,9 +112,6 @@ let filter_healthy_internal ~sw ~net (providers : Llm_provider.Provider_config.t
         (cloud_providers, [])
       end
 
-let filter_healthy ~sw ~net providers =
-  fst (filter_healthy_internal ~sw ~net providers)
-
 let filter_healthy_strict ~sw ~net (providers : Llm_provider.Provider_config.t list)
     : (Llm_provider.Provider_config.t list, health_filter_rejection) result =
   let initial_count = List.length providers in

--- a/lib/cascade/cascade_health_filter.mli
+++ b/lib/cascade/cascade_health_filter.mli
@@ -60,37 +60,27 @@ val is_local_provider : Llm_provider.Provider_config.t -> bool
     LM Studio, etc.) — i.e. an endpoint that does not require an API key
     and is subject to {!filter_healthy} discovery probing. *)
 
-val filter_healthy :
-  sw:Eio.Switch.t ->
-  net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t ->
-  Llm_provider.Provider_config.t list ->
-  Llm_provider.Provider_config.t list
-(** Return the providers that should remain in the cascade after:
-
-    {ol
-      {- dropping cloud providers missing an [api_key] (kept all if the
-         filter would empty the list — a fail-open guard);}
-      {- if any local provider exists, refreshing the shared
-         [model_endpoints] index via [Llm_provider.Discovery.refresh_and_sync];}
-      {- when {b every} local endpoint is unhealthy and at least one
-         cloud provider exists, falling back to the cloud-only set
-         (logged at info via [Diag]).}}
-
-    The function is invoked at startup and on each cascade reload. *)
-
 val filter_healthy_strict :
   sw:Eio.Switch.t ->
   net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t ->
   Llm_provider.Provider_config.t list ->
   (Llm_provider.Provider_config.t list, health_filter_rejection) result
-(** Strict variant of {!filter_healthy} for execution paths.
+(** Filter providers that should remain in the cascade after:
+
+    {ol
+      {- dropping cloud providers missing an [api_key];}
+      {- if any local provider exists, refreshing the shared
+         [model_endpoints] index via [Llm_provider.Discovery.refresh_and_sync];}
+      {- when {b every} local endpoint is unhealthy and at least one
+         cloud provider exists, falling back to the cloud-only set.}}
 
     Returns [Error] when:
     {ul
       {- all providers lack required API keys ([All_missing_api_key]);}
-      {- all local endpoints are unhealthy and strict mode disallows
-         automatic cloud fallback ([All_local_unhealthy]).}}
+      {- all local endpoints are unhealthy and no cloud fallback exists
+         ([All_local_unhealthy]).}}
 
-    Use this for keeper execution paths where provider drift must be
-    surfaced as a typed blocker. Use {!filter_healthy} for diagnostic
-    and startup contexts where fail-open is acceptable. *)
+    Replaces the prior fail-open [filter_healthy] variant: provider drift
+    is now surfaced as a typed blocker on every call site instead of
+    being silently dropped. The function is invoked at startup and on
+    each cascade reload as well as on the keeper execution path. *)

--- a/lib/keeper/keeper_stale_watchdog.ml
+++ b/lib/keeper/keeper_stale_watchdog.ml
@@ -657,10 +657,20 @@ let fork_stale_watchdog (ctx : _ context) (meta : keeper_meta)
                                 ~sw:ctx.sw ~net ~cascade_name:(Keeper_types.cascade_name_of_meta meta) () with
                         | Error _ -> false
                         | Ok candidates ->
-                            let healthy =
-                              Cascade_health_filter.filter_healthy ~sw:ctx.sw
-                                ~net candidates
-                            in
+                            (* Strict variant returns a typed rejection
+                               (All_missing_api_key / All_local_unhealthy)
+                               instead of silently emptying the candidate
+                               list.  Either rejection means the cascade
+                               is configurationally broken or has drifted
+                               below the live-fallback threshold, so the
+                               recovery probe should not declare the
+                               cascade healthy. *)
+                            (match
+                               Cascade_health_filter.filter_healthy_strict
+                                 ~sw:ctx.sw ~net candidates
+                             with
+                             | Error _rejection -> false
+                             | Ok healthy ->
                             let has_recovery_evidence
                                 (p : Llm_provider.Provider_config.t) =
                               let provider_key =
@@ -681,7 +691,7 @@ let fork_stale_watchdog (ctx : _ context) (meta : keeper_meta)
                                           Cascade_health_tracker.global
                                           ~provider_key)
                             in
-                            List.exists has_recovery_evidence healthy)
+                            List.exists has_recovery_evidence healthy))
                  in
                  if cascade_recovered () then
                    Log.Keeper.info "%s: stale threshold reached, but cascade %s appears healthy. Skipping auto-pause." meta.name (Keeper_types.cascade_name_of_meta meta)


### PR DESCRIPTION
## Goal

Close the silent-drop call site in \`Cascade_health_filter.filter_healthy\` (lib/cascade/cascade_health_filter.ml:115 on origin/main) by removing the fail-open variant entirely and routing the only real caller through the typed-rejection \`filter_healthy_strict\`.

## Background — Cascade FSM audit P1.2

Sibling PR to #14382 (P1.1, \`cascade_routes\` exhaustive match). Same audit. P1.2 closes a different anti-pattern in the same family.

## What was wrong

\`Cascade_health_filter.filter_healthy\` was implemented as:

\`\`\`ocaml
let filter_healthy ~sw ~net providers =
  fst (filter_healthy_internal ~sw ~net providers)
\`\`\`

\`filter_healthy_internal\` computes \`(filtered_list, discovery_status)\`, but the public \`filter_healthy\` discards the status with \`fst\`. The mli docstring framed this as a deliberate "fail-open guard" for diagnostic / startup contexts.

A repo-wide grep finds **exactly one** real caller — \`lib/keeper/keeper_stale_watchdog.ml:661\` — and it is **not** a diagnostic. It runs inside \`fork_stale_watchdog\`'s escalation gate:

\`\`\`ocaml
let cascade_recovered () = ... filter_healthy ~sw ~net candidates ...
if cascade_recovered () then
  Log.Keeper.info \"... cascade %s appears healthy. Skipping auto-pause.\" ...
else begin
  (* trigger storm-pattern keeper auto-pause *)
\`\`\`

A configurationally broken cascade (no API keys, all local unhealthy with no cloud fallback) was being treated as recovered, **suppressing legitimate auto-pause**. The fail-open guard was protecting the wrong layer.

CLAUDE.md \`software-development.md\` flags this exact shape twice:

- §"워크어라운드 거부 기준 시그니처 #1 텔레메트리-as-fix" — silent drop made 'noticeable' through \`Diag.debug \"dropped %d provider(s)\"\` instead of fixed
- §"Symptom 억제 패턴 — Fallback Resolution" — two semantic concepts (configuration-broken vs runtime-degraded) compressed into one untyped path

## Change

| File | Edit |
|---|---|
| \`lib/cascade/cascade_health_filter.{ml,mli}\` | Drop the non-strict \`filter_healthy\`. \`filter_healthy_strict\` is the only public entry. mli docstring on \`_strict\` now carries the discovery / fallback semantics |
| \`lib/cascade/cascade_config.{ml,mli}\` | Drop the \`filter_healthy\` re-export (caller count: 0). \`filter_healthy_strict\` re-export stays |
| \`lib/keeper/keeper_stale_watchdog.ml\` | Route the recovery probe through \`filter_healthy_strict\`. Both \`All_missing_api_key\` and \`All_local_unhealthy\` reduce to "cascade not recovered" (return \`false\`); the typed rejection sits at the call site so future callers cannot regress to silent drop |

## Why not keep the fail-open variant for "future use"

The mli docstring claimed *"Use \`filter_healthy\` for diagnostic and startup contexts where fail-open is acceptable."* No such caller exists in the repo. Keeping a typed dead-surface API on the rationale of *future callers* is the dual of CLAUDE.md §"backwards-compatibility hacks" — it preserves a footgun for new code to step on. Removing it forces every new call site to confront the typed rejection.

## Files changed

\`\`\`
 lib/cascade/cascade_config.ml         |  1 -
 lib/cascade/cascade_config.mli        | 27 +++++++++++----------------
 lib/cascade/cascade_health_filter.ml  |  3 ---
 lib/cascade/cascade_health_filter.mli | 32 +++++++++++---------------------
 lib/keeper/keeper_stale_watchdog.ml   | 20 +++++++++++++++-----
 5 files changed, 37 insertions(+), 46 deletions(-)
\`\`\`

## RFC scope

Not in agent_delegation sensitive subsystem list. \`keeper_stale_watchdog\` is the supervisor escalation gate, not credential / identity / sandbox / operator-control surface. \`cascade_health_filter\` is provider-list pruning, not the credential plane.

RFC-WAIVED: behaviour change is fail-open → fail-closed in **one** caller and the pre-existing one-liner that surfaces it. Auto-pause that was previously suppressed by the silent-drop guard will now fire. This is a fix, not a regression — the suppression was the bug.

## Local verification not run

\`dune build\` in the worktree blocked by the same \`agent_sdk.0.193.0 — Unbound module Runtime_server_worker\` failure on origin/main. CI exercises the full chain. Type-level correctness on this PR is closed: 0 remaining callers of the deleted symbol post-commit (verified by grep against the worktree).

## Possible behavioural follow-ups not in scope

\`keeper_stale_watchdog\` currently maps both \`All_missing_api_key\` and \`All_local_unhealthy\` to a flat \`false\`. A follow-up could differentiate (configurationally broken → never auto-recoverable, escalate immediately; transient unhealthy → keep current escalation_threshold path). That is a runbook decision, not a typing decision; out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)