### PR TITLE
fix(fs_compat): include full path in malformed JSONL warning

### DIFF
--- a/lib/fs_compat/fs_compat.ml
+++ b/lib/fs_compat/fs_compat.ml
@@ -369,7 +369,7 @@ let load_jsonl_diagnostics (path : string) : Yojson.Safe.t list * int =
   else
     let content = load_file path in
     let lines = String.split_on_char '\n' content in
-    parse_jsonl_lines ~source:(Stdlib.Filename.basename path) lines
+    parse_jsonl_lines ~source:path lines
 
 (** Load JSONL file as list of JSON values.
     Malformed lines are logged and dropped. *)

--- a/test/test_fs_compat.ml
+++ b/test/test_fs_compat.ml
@@ -67,6 +67,62 @@ let test_save_file_atomic_overwrites_existing () =
    | Error msg -> fail msg);
   check string "overwrite succeeded" "new" (Fs_compat.load_file target)
 
+let with_redirected_stderr (f : unit -> 'a) : 'a * string =
+  let tmp = Filename.temp_file "masc_stderr_" ".log" in
+  let saved = Unix.dup Unix.stderr in
+  let fd = Unix.openfile tmp [Unix.O_WRONLY; Unix.O_TRUNC] 0o600 in
+  Unix.dup2 fd Unix.stderr;
+  Unix.close fd;
+  let result =
+    Fun.protect
+      ~finally:(fun () ->
+        flush stderr;
+        Unix.dup2 saved Unix.stderr;
+        Unix.close saved)
+      f
+  in
+  let captured =
+    let ic = open_in tmp in
+    let len = in_channel_length ic in
+    let s = really_input_string ic len in
+    close_in ic;
+    Sys.remove tmp;
+    s
+  in
+  (result, captured)
+
+let test_load_jsonl_diagnostics_counts_malformed_lines () =
+  Fs_compat.clear_fs ();
+  with_tmp_dir @@ fun base ->
+  let path = Filename.concat base "broken.jsonl" in
+  Fs_compat.save_file path "{\"ok\":1}\nnot-json\n{\"ok\":2}\n";
+  let (parsed, malformed), _ =
+    with_redirected_stderr (fun () -> Fs_compat.load_jsonl_diagnostics path)
+  in
+  check int "parsed count" 2 (List.length parsed);
+  check int "malformed count" 1 malformed
+
+let test_load_jsonl_diagnostics_warn_includes_full_path () =
+  Fs_compat.clear_fs ();
+  with_tmp_dir @@ fun base ->
+  let path = Filename.concat base "broken.jsonl" in
+  Fs_compat.save_file path "garbage\n";
+  let _, captured =
+    with_redirected_stderr (fun () -> Fs_compat.load_jsonl_diagnostics path)
+  in
+  let contains hay needle =
+    let nlen = String.length needle in
+    let hlen = String.length hay in
+    let rec loop i =
+      if i + nlen > hlen then false
+      else if String.sub hay i nlen = needle then true
+      else loop (i + 1)
+    in
+    loop 0
+  in
+  check bool "warn message contains full path (not just basename)" true
+    (contains captured path)
+
 let () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
@@ -84,6 +140,14 @@ let () =
           test_save_file_atomic_leaves_no_tmp_on_success;
         test_case "overwrites existing target" `Quick
           test_save_file_atomic_overwrites_existing;
+      ]
+    );
+    ( "load_jsonl_diagnostics"
+    , [
+        test_case "counts malformed lines" `Quick
+          test_load_jsonl_diagnostics_counts_malformed_lines;
+        test_case "warn includes full path" `Quick
+          test_load_jsonl_diagnostics_warn_includes_full_path;
       ]
     );
   ]


### PR DESCRIPTION
## 동기

오늘 dashboard 로그에서 다음 경고가 떨어졌다:

```
[fs_compat] malformed JSONL (history.jsonl): Line 1, bytes 114690-114724:
Expected ',' or '}' but found 'generated_at":"2026-05-08T13:19:3'
[fs_compat] malformed JSONL (history.jsonl): Line 1, bytes 0-34:
Invalid token 'r/me/.masc/traces/trace-177693164'
```

`history.jsonl`이라는 basename은 `~/.masc/traces/<id>/` 수십 개와 `~/.masc/audits/safe_autonomy/` 양쪽에 모두 존재한다. 어떤 파일이 깨졌는지 식별하려면 후보 디렉토리를 모두 grep해야 했다. 결국 `audits/safe_autonomy/history.jsonl` (33MB, line 257이 `r/me/.masc/traces/...`로 시작하는 fragment)이라는 사실을 수동으로 찾아내고 비울 수 있었다.

## 변경

`load_jsonl_diagnostics`가 `parse_jsonl_lines`에 넘기는 `~source` 인자를 `Filename.basename path` → `path`로 변경. 다음 발생 시 경고에 어떤 파일이 깨졌는지 즉시 표시된다.

`parse_jsonl_lines`의 직접 caller는 `tool_task.ml`(논리적 source `task_events` 사용) 뿐이라 영향 없음.

## 변경 파일

- `lib/fs_compat/fs_compat.ml`: 1 line (basename → path)
- `test/test_fs_compat.ml`: `load_jsonl_diagnostics` 그룹 추가 (malformed counter, stderr 경고에 full path 포함 여부)

## 로컬 검증

```
$ dune build --root . test/test_fs_compat.exe
$ dune exec --root . test/test_fs_compat.exe
Test Successful in 0.005s. 6 tests run.
```

ocamlformat clean.

## 미검증

- 다른 caller(`load_jsonl`, `load_jsonl_safe` 래퍼)의 stderr 출력 변화는 manual로만 확인. 변경 내용이 logging cosmetic이라 정상 코드 경로에는 영향 없음.

## 후속

- `audits/safe_autonomy/history.jsonl`이 깨진 근본 원인(write race로 line 256↔257 사이 prefix truncate)은 별도 작업. 이 PR은 진단 가시성만 개선한다.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>