### PR TITLE
refactor(keeper): FSM transition rejection 메시지에 from/to 라벨 포함

### DIFF
--- a/lib/keeper/keeper_fsm_guard_runtime.ml
+++ b/lib/keeper/keeper_fsm_guard_runtime.ml
@@ -12,6 +12,6 @@ let bump_counter ~action ~stage =
 
 let wrap_unit ~action ~stage thunk =
   try thunk ()
-  with Assert_failure _ as exn ->
+  with (Assert_failure _ | Invalid_argument _) as exn ->
     bump_counter ~action ~stage;
     raise exn

--- a/lib/keeper/keeper_fsm_guard_runtime.mli
+++ b/lib/keeper/keeper_fsm_guard_runtime.mli
@@ -6,7 +6,9 @@
     the function body.
 
     [wrap_unit] runs a [unit -> unit] thunk under that contract:
-    catches [Assert_failure], bumps the
+    catches [Assert_failure] (legacy [@@fsm_guard]-injected asserts)
+    and [Invalid_argument] (explicit [invalid_arg] from validators that
+    embed the rejected ([from], [to]) pair in the message), bumps the
     [Prometheus.metric_fsm_guard_violation] counter labelled with
     [action] / [stage], and re-raises.  FSM contract violations are
     fail-closed in production and tests; [MASC_FSM_GUARD_ASSERT] is no
@@ -14,9 +16,9 @@
 
     The thunk is expected to call an identity helper of return type
     [unit] (a function whose only purpose is to carry the
-    [@@fsm_guard] attribute). Non-[Assert_failure] exceptions
-    propagate unchanged — only the spec-violation channel is
-    intercepted. *)
+    [@@fsm_guard] attribute). Exceptions other than [Assert_failure] and
+    [Invalid_argument] propagate unchanged — only the spec-violation
+    channel is intercepted. *)
 
 val wrap_unit :
   action:string ->

--- a/lib/keeper/keeper_registry.ml
+++ b/lib/keeper/keeper_registry.ml
@@ -208,6 +208,19 @@ let witness_to_turn_phase : packed_turn_phase -> turn_phase = function
   | Packed Turn_finalizing -> Turn_finalizing
   | Packed Turn_exhausted -> Turn_exhausted
 
+(* Diagnostic label for invalid-transition error messages.  Must stay in
+   sync with the [turn_phase] variant — adding a constructor will fail
+   compilation here, which forces the operator to extend
+   [validate_turn_phase_transition] at the same time. *)
+let packed_turn_phase_label : packed_turn_phase -> string = function
+  | Packed Turn_idle -> "Turn_idle"
+  | Packed Turn_prompting -> "Turn_prompting"
+  | Packed Turn_routing -> "Turn_routing"
+  | Packed Turn_executing -> "Turn_executing"
+  | Packed Turn_compacting -> "Turn_compacting"
+  | Packed Turn_finalizing -> "Turn_finalizing"
+  | Packed Turn_exhausted -> "Turn_exhausted"
+
 module Turn_phase_transition = struct
   (* Mirrors [validate_turn_phase_transition] (below): every constructor
      here corresponds to a [true] arm in the runtime transition matrix.
@@ -303,6 +316,14 @@ let stage_to_witness : decision_stage -> packed_decision_stage = function
   | Decision_gate_rejected -> Packed Decision_gate_rejected
   | Decision_tool_policy_selected -> Packed Decision_tool_policy_selected
 
+(* Diagnostic label for invalid-transition error messages.  Mirrors
+   [decision_stage]; constructor changes will fail compilation here. *)
+let packed_decision_stage_label : packed_decision_stage -> string = function
+  | Packed Decision_undecided -> "Decision_undecided"
+  | Packed Decision_guard_ok -> "Decision_guard_ok"
+  | Packed Decision_gate_rejected -> "Decision_gate_rejected"
+  | Packed Decision_tool_policy_selected -> "Decision_tool_policy_selected"
+
 module Decision_transition = struct
   type ('from, 'to_) t =
     | Undecided_to_guard_ok : (decision_undecided, decision_guard_ok) t
@@ -347,7 +368,11 @@ let validate_decision_transition ~from ~to_ =
   | Packed Decision_guard_ok, Packed Decision_undecided
   | Packed Decision_gate_rejected, Packed Decision_undecided
   | Packed Decision_tool_policy_selected, Packed Decision_undecided ->
-      assert false
+      invalid_arg
+        (Printf.sprintf
+           "validate_decision_transition: invalid transition %s -> %s"
+           (packed_decision_stage_label from_packed)
+           (packed_decision_stage_label to_packed))
 
 type cascade_state =
   | Cascade_idle [@tla.idle]
@@ -387,6 +412,15 @@ let witness_to_cascade_state : packed_cascade_state -> cascade_state = function
   | Packed Cascade_trying -> Cascade_trying
   | Packed Cascade_done -> Cascade_done
   | Packed Cascade_exhausted -> Cascade_exhausted
+
+(* Diagnostic label for invalid-transition error messages.  Mirrors
+   [cascade_state]; constructor changes will fail compilation here. *)
+let packed_cascade_state_label : packed_cascade_state -> string = function
+  | Packed Cascade_idle -> "Cascade_idle"
+  | Packed Cascade_selecting -> "Cascade_selecting"
+  | Packed Cascade_trying -> "Cascade_trying"
+  | Packed Cascade_done -> "Cascade_done"
+  | Packed Cascade_exhausted -> "Cascade_exhausted"
 
 type compaction_stage =
   | Compaction_accumulating [@tla.idle]
@@ -990,7 +1024,11 @@ let validate_cascade_transition ~from ~to_ =
   | Packed Cascade_selecting, (Packed Cascade_done | Packed Cascade_exhausted)
   | Packed Cascade_done, Packed Cascade_exhausted
   | Packed Cascade_exhausted, Packed Cascade_done ->
-      assert false
+      invalid_arg
+        (Printf.sprintf
+           "validate_cascade_transition: invalid transition %s -> %s"
+           (packed_cascade_state_label from)
+           (packed_cascade_state_label to_))
 
 let validate_turn_phase_transition ~from ~to_ =
   let (_ : packed_turn_phase) = from in
@@ -999,7 +1037,7 @@ let validate_turn_phase_transition ~from ~to_ =
     ~action:"turn_phase_transition"
     ~stage:"guard"
     (fun () ->
-       assert (
+       let valid =
          match from, to_ with
          (* from Turn_idle *)
          | Packed Turn_idle, Packed Turn_idle -> true
@@ -1057,7 +1095,13 @@ let validate_turn_phase_transition ~from ~to_ =
          | Packed Turn_exhausted, Packed Turn_compacting -> false
          | Packed Turn_exhausted, Packed Turn_finalizing -> false
          | Packed Turn_exhausted, Packed Turn_exhausted -> true
-       ))
+       in
+       if not valid then
+         invalid_arg
+           (Printf.sprintf
+              "validate_turn_phase_transition: invalid transition %s -> %s"
+              (packed_turn_phase_label from)
+              (packed_turn_phase_label to_)))
 
 let set_turn_decision_stage ~base_path name decision_stage =
   let target_packed = stage_to_witness decision_stage in

--- a/lib/keeper/keeper_registry.mli
+++ b/lib/keeper/keeper_registry.mli
@@ -143,6 +143,13 @@ type packed_turn_phase = Packed : 'a turn_phase_witness -> packed_turn_phase
 val witness_to_turn_phase : packed_turn_phase -> turn_phase
 val turn_phase_to_witness : turn_phase -> packed_turn_phase
 
+(** Diagnostic label using the constructor name (e.g. ["Turn_routing"]).
+    Used by [validate_turn_phase_transition] to embed the rejected pair
+    in [Invalid_argument] messages.  Distinct from
+    [Keeper_composite_observer.turn_phase_to_string] which emits a
+    snake_case form for dashboards. *)
+val packed_turn_phase_label : packed_turn_phase -> string
+
 val validate_turn_phase_transition : from:packed_turn_phase -> to_:packed_turn_phase -> unit
 
 module Turn_phase_transition : sig
@@ -202,6 +209,11 @@ type packed_decision_stage = Packed : 'a decision_stage_witness -> packed_decisi
 val witness_to_stage : 'a decision_stage_witness -> decision_stage
 val stage_to_witness : decision_stage -> packed_decision_stage
 
+(** Diagnostic label using the constructor name (e.g.
+    ["Decision_guard_ok"]).  Used by [validate_decision_transition] for
+    [Invalid_argument] messages. *)
+val packed_decision_stage_label : packed_decision_stage -> string
+
 val validate_decision_transition : from:decision_stage -> to_:decision_stage -> unit
 
 module Decision_transition : sig
@@ -247,6 +259,11 @@ type packed_cascade_state =
 
 val cascade_state_to_witness : cascade_state -> packed_cascade_state
 val witness_to_cascade_state : packed_cascade_state -> cascade_state
+
+(** Diagnostic label using the constructor name (e.g.
+    ["Cascade_exhausted"]).  Used by [validate_cascade_transition] for
+    [Invalid_argument] messages. *)
+val packed_cascade_state_label : packed_cascade_state -> string
 
 val validate_cascade_transition : from:packed_cascade_state -> to_:packed_cascade_state -> unit
 
@@ -461,7 +478,7 @@ val mark_turn_started : base_path:string -> string -> unit
     Without this boundary signal, the second-and-later SDK turn writes
     transition from the previous SDK turn's terminal phase
     ([Turn_finalizing] after [Cascade_done]/[Cascade_exhausted]), which
-    [validate_turn_phase_transition] rejects with [Assert_failure].
+    [validate_turn_phase_transition] rejects with [Invalid_argument].
 
     This function resets the in-turn FSM fields ([turn_phase],
     [cascade_state], [decision_stage]) on the existing observation, the
@@ -496,7 +513,8 @@ val set_turn_phase :
 
 (** Runtime transition guards for the 4 sub-FSM axes.
     Each validates a (from, to) pair against the TLA+ transition matrix.
-    Invalid transitions raise [Assert_failure] and bump
+    Invalid transitions raise [Invalid_argument] with a message of the
+    form ["<validator>: invalid transition <from> -> <to>"] and bump
     [Prometheus.metric_fsm_guard_violation]. *)
 val validate_turn_phase_transition :
   from:packed_turn_phase -> to_:packed_turn_phase -> unit

--- a/test/test_keeper_sub_fsm_guards.ml
+++ b/test/test_keeper_sub_fsm_guards.ml
@@ -1,7 +1,10 @@
 (** Tests for sub-FSM runtime transition guards (PR #14153).
     Mirrors the TLA+ transition matrix in executable form.
-    Valid transitions must pass; invalid transitions must raise
-    [Assert_failure] and bump [masc_fsm_guard_violation_total]. *)
+    Valid transitions must pass; invalid transitions for turn_phase,
+    decision_stage and cascade_state must raise [Invalid_argument] with
+    a message that names both endpoints, and bump
+    [masc_fsm_guard_violation_total].  [compaction_stage] still raises
+    [Assert_failure] (untouched by the diagnostic-message PR). *)
 
 open Masc_mcp.Keeper_registry
 module Obs = Masc_mcp.Keeper_composite_observer
@@ -50,7 +53,7 @@ let test_valid_turn_phase_transitions () =
   List.iter
     (fun (from, to_) ->
        try validate_turn_phase_transition ~from ~to_ with
-       | Assert_failure _ ->
+       | (Assert_failure _ | Invalid_argument _) ->
          Alcotest.fail
            (Printf.sprintf
               "valid turn_phase %s -> %s rejected"
@@ -101,7 +104,7 @@ let test_invalid_turn_phase_transitions () =
               (Obs.turn_phase_to_string from)
               (Obs.turn_phase_to_string to_))
        with
-       | Assert_failure _ -> ())
+       | Invalid_argument _ -> ())
     cases
 ;;
 
@@ -131,7 +134,7 @@ let test_valid_decision_transitions () =
   List.iter
     (fun (from, to_) ->
        try validate_decision_transition ~from ~to_ with
-       | Assert_failure _ ->
+       | (Assert_failure _ | Invalid_argument _) ->
          Alcotest.fail
            (Printf.sprintf
               "valid decision %s -> %s rejected"
@@ -158,7 +161,7 @@ let test_invalid_decision_transitions () =
               (Obs.decision_stage_to_string (stage_to_witness from))
               (Obs.decision_stage_to_string (stage_to_witness to_)))
        with
-       | Assert_failure _ -> ())
+       | Invalid_argument _ -> ())
     cases
 ;;
 
@@ -194,7 +197,7 @@ let test_valid_cascade_transitions () =
   List.iter
     (fun (from, to_) ->
        try validate_cascade_transition ~from ~to_ with
-       | Assert_failure _ ->
+       | (Assert_failure _ | Invalid_argument _) ->
          Alcotest.fail
            (Printf.sprintf
               "valid cascade %s -> %s rejected"
@@ -234,7 +237,7 @@ let test_invalid_cascade_transitions () =
               (Obs.cascade_state_to_string from)
               (Obs.cascade_state_to_string to_))
        with
-       | Assert_failure _ -> ())
+       | Invalid_argument _ -> ())
     cases
 ;;
 
@@ -257,7 +260,7 @@ let walk_cascade_sequence label seq =
   List.iter
     (fun (from, to_) ->
        try validate_cascade_transition ~from ~to_
-       with Assert_failure _ ->
+       with (Assert_failure _ | Invalid_argument _) ->
          Alcotest.fail
            (Printf.sprintf
               "%s step %s -> %s should pass"
@@ -335,6 +338,82 @@ let test_invalid_compaction_transitions () =
     cases
 ;;
 
+(* ── Diagnostic message format ──────────────────────────── *)
+
+let contains haystack needle =
+  let h_len = String.length haystack in
+  let n_len = String.length needle in
+  if n_len = 0 then true
+  else if n_len > h_len then false
+  else
+    let rec loop i =
+      if i + n_len > h_len then false
+      else if String.sub haystack i n_len = needle then true
+      else loop (i + 1)
+    in
+    loop 0
+;;
+
+let capture_invalid_arg thunk =
+  try thunk (); None
+  with Invalid_argument msg -> Some msg
+;;
+
+let assert_msg_contains ~msg ~needle =
+  Alcotest.(check bool)
+    (Printf.sprintf "message %S contains %S" msg needle)
+    true
+    (contains msg needle)
+;;
+
+let test_turn_phase_message_includes_labels () =
+  (* Turn_routing -> Turn_exhausted is the rejected pair from the
+     2026-05-09 qa-king crash (cascade-fallback exhausted from the
+     selecting/routing slice). Future occurrences of the same crash
+     class will surface from/to labels in the message instead of a
+     bare line:character anchor. *)
+  let from : packed_turn_phase = Packed Turn_routing in
+  let to_ : packed_turn_phase = Packed Turn_exhausted in
+  match
+    capture_invalid_arg (fun () -> validate_turn_phase_transition ~from ~to_)
+  with
+  | None -> Alcotest.fail "validator should have raised Invalid_argument"
+  | Some msg ->
+    assert_msg_contains ~msg ~needle:"validate_turn_phase_transition";
+    assert_msg_contains ~msg ~needle:(packed_turn_phase_label from);
+    assert_msg_contains ~msg ~needle:(packed_turn_phase_label to_)
+;;
+
+let test_decision_message_includes_labels () =
+  let from : decision_stage = Decision_guard_ok in
+  let to_ : decision_stage = Decision_undecided in
+  match
+    capture_invalid_arg (fun () -> validate_decision_transition ~from ~to_)
+  with
+  | None -> Alcotest.fail "validator should have raised Invalid_argument"
+  | Some msg ->
+    assert_msg_contains ~msg ~needle:"validate_decision_transition";
+    assert_msg_contains
+      ~msg
+      ~needle:(packed_decision_stage_label (stage_to_witness from));
+    assert_msg_contains
+      ~msg
+      ~needle:(packed_decision_stage_label (stage_to_witness to_))
+;;
+
+let test_cascade_message_includes_labels () =
+  let from : packed_cascade_state = Packed Cascade_idle in
+  let to_ : packed_cascade_state = Packed Cascade_exhausted in
+  match
+    capture_invalid_arg (fun () -> validate_cascade_transition ~from ~to_)
+  with
+  | None -> Alcotest.fail "validator should have raised Invalid_argument"
+  | Some msg ->
+    assert_msg_contains ~msg ~needle:"validate_cascade_transition";
+    assert_msg_contains ~msg ~needle:(packed_cascade_state_label from);
+    assert_msg_contains ~msg ~needle:(packed_cascade_state_label to_)
+;;
+
 (* ── Test runner ────────────────────────────────────────── *)
 
 let () =
@@ -389,6 +468,20 @@ let () =
             "invalid transitions"
             `Quick
             test_invalid_compaction_transitions
+        ] )
+    ; ( "diagnostic_messages"
+      , [ Alcotest.test_case
+            "turn_phase rejection includes from/to labels"
+            `Quick
+            test_turn_phase_message_includes_labels
+        ; Alcotest.test_case
+            "decision rejection includes from/to labels"
+            `Quick
+            test_decision_message_includes_labels
+        ; Alcotest.test_case
+            "cascade rejection includes from/to labels"
+            `Quick
+            test_cascade_message_includes_labels
         ] )
     ]
 ;;


### PR DESCRIPTION
## 배경

2026-05-09 21:39:30 qa-king keeper가 `keeper_registry.ml:1002`에서 `Assertion failed`로 죽었습니다. stack trace에는 file:line만 남고 어떤 (from, to) 페어가 거부됐는지 정보가 없어, 운영자가 turn 로그를 거꾸로 추적해 추정해야 했습니다.

같은 문제 ("내 keeper 또 죽었는데 어떤 transition인지 모르겠다 → enable 한 줄 패치 PR")가 최근 14일간 5회 반복됐습니다:

- 8f6ae71 (`Turn_compacting/Turn_finalizing -> Turn_exhausted` enable)
- 805fc51 (`Turn_finalizing -> Turn_prompting` enable)
- 18f2a13 (`Decision_gate_rejected -> Decision_tool_policy_selected` enable)
- d2bd963 (`Decision_undecided -> Decision_tool_policy_selected` enable)
- 1762d22 (GADT validator merge conflicts)

이번 PR은 **다음 occurrence가 어떤 페어인지 즉시 보이도록** 진단 메시지를 보강합니다. **transition matrix의 false 셀 자체는 손대지 않습니다** (그건 production이 보내준 로그가 정확한 페어를 알려준 다음 별도 PR로 처리).

## 변경

- `packed_turn_phase_label` / `packed_decision_stage_label` / `packed_cascade_state_label`을 `keeper_registry`에 추가. 각 변형의 컨스트럭터 이름을 그대로 반환합니다 (`Turn_routing` 등). 변형이 추가되면 컴파일 단계에서 누락이 잡힙니다 (`composite_observer`의 snake_case `turn_phase_to_string`과는 별개의 컨벤션 — 에러 메시지 전용).
- 3개 validator의 invalid arm을 명시적 `invalid_arg` 메시지로 교체:
  - `validate_decision_transition`: `assert false` → `invalid_arg "validate_decision_transition: invalid transition <from> -> <to>"`
  - `validate_cascade_transition`: 동일 패턴
  - `validate_turn_phase_transition`: `assert (match ... -> bool)` → `match ... -> bool` + `if not valid then invalid_arg "..."` (모든 valid arm은 그대로 유지)
- `Keeper_fsm_guard_runtime.wrap_unit`을 확장해 `Assert_failure | Invalid_argument` 모두에서 `metric_fsm_guard_violation` 카운터를 올리고 그대로 re-raise. 두 패턴은 disjoint이므로 double-bump 없음.
- `keeper_registry.mli` / `keeper_fsm_guard_runtime.mli` doc을 새 exception 타입에 맞게 업데이트.
- 기존 `test_keeper_sub_fsm_guards`의 `Assert_failure _` catch를 `Invalid_argument _`로 변경 (turn_phase / decision / cascade). compaction validator는 이번 PR scope 외라 `Assert_failure` 그대로.
- 새 진단-메시지 검증 테스트 3개 추가: invalid transition 메시지가 validator 이름과 from/to 라벨을 모두 포함하는지 확인.

## Scope 외 (별도 처리)

- **transition matrix의 false 셀 enable**: `Turn_routing -> Turn_exhausted`, `Turn_prompting -> Turn_exhausted` 등 누락된 셀은 production 로그가 다음 occurrence에서 정확한 페어를 알려준 후 별도 PR.
- **근본 fix**: `Cascade_exhausted`는 모든 phase에서 도달 가능한 terminal escape — 매트릭스 외부의 helper로 분리하는 RFC급 작업이 5번째 fix 이후 누적된 부채. 이번 PR과 분리.
- **테스트 자체 실행**: `test_keeper_sub_fsm_guards`는 `cascade catalog empty when resolving keeper_turn`로 main(`origin/main` 8986ac11f0)에서도 동일하게 실패합니다. 이건 사전 결함 (catalog 초기화가 테스트 셋업에 없음)이며 본 PR과 무관 — 별도 이슈로 추적 필요.

## 검증

- ✅ `dune build --root . @check` (전체 type check 통과)
- ✅ `dune build --root . test/test_keeper_sub_fsm_guards.exe` (테스트 컴파일)
- ⚠️  `dune exec test_keeper_sub_fsm_guards.exe`는 main과 동일하게 catalog 미초기화로 실행 실패 (사전 결함)

## 다음 occurrence가 어떻게 보일까

기존:
```
keeper cycle exception: File "lib/keeper/keeper_registry.ml", line 1002, characters 7-13: Assertion failed
```

변경 후:
```
keeper cycle exception: Invalid_argument("validate_turn_phase_transition: invalid transition Turn_routing -> Turn_exhausted")
```

운영자는 더 이상 turn 로그를 거꾸로 재구성하지 않아도 됩니다.

## RFC

`RFC-WAIVED: keeper FSM observability change, no credential / identity / sandbox / dashboard credential surface touched.`

🤖 Generated with [Claude Code](https://claude.com/claude-code)