### PR TITLE
feat(core): RFC-0057 Phase 0 — extend Provider_error.t with CLI variants

### DIFF
--- a/lib/core/provider_error.ml
+++ b/lib/core/provider_error.ml
@@ -20,6 +20,27 @@ type provider_error =
       provider : string;
       reason : string;
     }
+  | CliWrappedHardQuota of {
+      provider : string;
+      detail : string;
+    }
+  | CliWrappedMaxTurns of {
+      provider : string;
+      detail : string;
+    }
+  | CliWrappedResumableSession of {
+      provider : string;
+      detail : string;
+      exit_code : int option;
+    }
+  | PermissionDenied of {
+      provider : string;
+      resource : string option;
+    }
+  | ModelNotFound of {
+      provider : string;
+      model_name : string;
+    }
 
 type t = provider_error
 
@@ -33,6 +54,11 @@ let to_error_kind = function
   | AuthError _ -> "auth_error"
   | ServerError _ -> "server_error"
   | InvalidRequest _ -> "invalid_request"
+  | CliWrappedHardQuota _ -> "cli_wrapped_hard_quota"
+  | CliWrappedMaxTurns _ -> "cli_wrapped_max_turns"
+  | CliWrappedResumableSession _ -> "cli_wrapped_resumable_session"
+  | PermissionDenied _ -> "permission_denied"
+  | ModelNotFound _ -> "model_not_found"
 
 let string_list_to_yojson values =
   `List (List.map (fun value -> `String value) values)
@@ -76,11 +102,58 @@ let to_yojson = function
           ("provider", `String provider);
           ("reason", `String reason);
         ]
+  | CliWrappedHardQuota { provider; detail } ->
+      `Assoc
+        [
+          ("kind", `String "cli_wrapped_hard_quota");
+          ("provider", `String provider);
+          ("detail", `String detail);
+        ]
+  | CliWrappedMaxTurns { provider; detail } ->
+      `Assoc
+        [
+          ("kind", `String "cli_wrapped_max_turns");
+          ("provider", `String provider);
+          ("detail", `String detail);
+        ]
+  | CliWrappedResumableSession { provider; detail; exit_code } ->
+      `Assoc
+        [
+          ("kind", `String "cli_wrapped_resumable_session");
+          ("provider", `String provider);
+          ("detail", `String detail);
+          ("exit_code",
+           match exit_code with
+           | Some code -> `Int code
+           | None -> `Null);
+        ]
+  | PermissionDenied { provider; resource } ->
+      `Assoc
+        [
+          ("kind", `String "permission_denied");
+          ("provider", `String provider);
+          ("resource",
+           match resource with
+           | Some r -> `String r
+           | None -> `Null);
+        ]
+  | ModelNotFound { provider; model_name } ->
+      `Assoc
+        [
+          ("kind", `String "model_not_found");
+          ("provider", `String provider);
+          ("model_name", `String model_name);
+        ]
 
 let affected_providers = function
   | RateLimit { provider; _ }
   | AuthError { provider }
-  | InvalidRequest { provider; _ } ->
+  | InvalidRequest { provider; _ }
+  | CliWrappedHardQuota { provider; _ }
+  | CliWrappedMaxTurns { provider; _ }
+  | CliWrappedResumableSession { provider; _ }
+  | PermissionDenied { provider; _ }
+  | ModelNotFound { provider; _ } ->
       [ provider ]
   | CapacityExhausted { affected; _ } -> affected
   | ServerError _ -> []
@@ -90,5 +163,10 @@ let is_capacity_exhausted = function
   | RateLimit _
   | AuthError _
   | ServerError _
-  | InvalidRequest _ ->
+  | InvalidRequest _
+  | CliWrappedHardQuota _
+  | CliWrappedMaxTurns _
+  | CliWrappedResumableSession _
+  | PermissionDenied _
+  | ModelNotFound _ ->
       false

--- a/lib/core/provider_error.mli
+++ b/lib/core/provider_error.mli
@@ -25,6 +25,31 @@ type provider_error =
       provider : string;
       reason : string;
     }
+  (* RFC-0057 Phase 0: CLI-specific error variants that were previously
+     reconstructed through string matching in cascade_attempt_fsm.ml.
+     These carry the structured information lost when the CLI adapter
+     compressed them into InvalidRequest { message }. *)
+  | CliWrappedHardQuota of {
+      provider : string;
+      detail : string;
+    }
+  | CliWrappedMaxTurns of {
+      provider : string;
+      detail : string;
+    }
+  | CliWrappedResumableSession of {
+      provider : string;
+      detail : string;
+      exit_code : int option;
+    }
+  | PermissionDenied of {
+      provider : string;
+      resource : string option;
+    }
+  | ModelNotFound of {
+      provider : string;
+      model_name : string;
+    }
 
 type t = provider_error
 


### PR DESCRIPTION
## Goal

RFC-0057 Phase 0: Extend `Provider_error.t` (in `lib/core/provider_error.{ml,mli}`) with CLI-specific variant constructors so cascade can replace the 13 substring classifiers with typed pattern matches.

## Files Changed

- `lib/core/provider_error.ml` (+82/-2)
- `lib/core/provider_error.mli` (+25/-0)

## Verification

- Additive variants only — existing pattern matches still exhaustive (no `_ ->` removal in this PR).
- Phase 2 PR will rewire `cascade_attempt_fsm` to consume the new variants.

## Related

- RFC: docs/rfc/RFC-0057-cascade-error-typing-boundary.md (#14386)
- Phase 2: feat/rfc-0057-phase2-prep
- Phase 3: feat/rfc-0057-phase3-tla-spec

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>