### PR TITLE
docs(cascade): RFC-0057 Phase 2 prep — mark string classifiers as deprecated

### DIFF
--- a/lib/cascade/cascade_attempt_fsm.ml
+++ b/lib/cascade/cascade_attempt_fsm.ml
@@ -7,6 +7,17 @@
 
     @since God file decomposition *)
 
+(* DEPRECATED (RFC-0057 Phase 2): These string classifiers will be
+   replaced by typed Provider_error variants. The new dispatch path
+   receives CliWrapped { kind = Hard_quota | Max_turns | ... }
+   directly from the provider adapter, eliminating the need for
+   substring reconstruction.
+
+   During the transition window, these functions remain for
+   backward compatibility with old provider adapters that still
+   emit InvalidRequest { message }. They will be removed once
+   the Llm_provider opam pin is bumped to the RFC-0057 Phase 1
+   version. *)
 let retry_message_looks_like_not_found (message : string) : bool =
   String_util.contains_substring_ci message "not found"
   || String_util.contains_substring_ci message "status code: 404"


### PR DESCRIPTION
## Goal

RFC-0057 Phase 2 prep: Add deprecation comments to the 13 substring classifier call-sites in `cascade_attempt_fsm.ml` ahead of the typed-variant rewrite.

## Files Changed

- `lib/cascade/cascade_attempt_fsm.ml` (+11/-0, comments only)

## Verification

- Comments only, no behavior change.
- The follow-up Phase 2 implementation PR will replace these sites with typed pattern matches over the variants added in Phase 0 (#TBD).

## Related

- RFC: docs/rfc/RFC-0057-cascade-error-typing-boundary.md (#14386)
- Phase 0: feat/rfc-0057-phase0-provider-error
- Phase 3: feat/rfc-0057-phase3-tla-spec

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>