### PR TITLE
docs(tla): RFC-0057 Phase 3 — stub error variant extension in KeeperCascadeRouting

### DIFF
--- a/specs/INDEX.md
+++ b/specs/INDEX.md
@@ -5,7 +5,7 @@ Edit the generator, not this file. Re-run: scripts/gen-tla-index.sh > specs/INDE
 
 # TLA+ Spec Index
 
-Generated: 2026-05-09T09:59:52Z (HEAD: 0faae69bf6)
+Generated: 2026-05-09T13:43:03Z (HEAD: 1eafa3d9ea)
 
 Source of truth: `specs/`. Run `scripts/gen-tla-index.sh > specs/INDEX.md` to refresh.
 
@@ -119,7 +119,7 @@ Source of truth: `specs/`. Run `scripts/gen-tla-index.sh > specs/INDEX.md` to re
 | KeeperAdmissionLiveness.tla | KeeperAdmissionLiveness | manual | 3 | 2 | clean={inv:TypeOK, inv:RateRespect, inv:TokensInRange, inv:QueueWellFormed, inv:TokenInflightConservation} buggy-2={inv:TypeOK, inv:RateRespect, inv:TokensInRange, inv:QueueWellFormed, inv:TokenInflightConservation} buggy={inv:TypeOK, inv:RateRespect, inv:TokensInRange, inv:QueueWellFormed, inv:TokenInflightConservation} | d0de975d7f83 |
 | KeeperApprovalQueue.tla | KeeperApprovalQueue | manual | 2 | 1 | clean={inv:TypeOK, inv:SafetyInvariant} buggy={inv:TypeOK, inv:SafetyInvariant} | a18102f83db7 |
 | KeeperCascadeLifecycle.tla | KeeperCascadeLifecycle | manual | 2 | 1 | clean={inv:Safety, prop:TryingEventuallyTerminates, prop:FinalizingEventuallyClears} buggy={inv:CascadeSelectionRequiresMeasurement} | e305638eb658 |
-| KeeperCascadeRouting.tla | KeeperCascadeRouting | manual | 2 | 1 | clean={inv:TypeOK, inv:KeeperNeverBlockedByCascade, inv:TurnProceedsIfHealthyItemExists, inv:NoGroupCycle, inv:HealthStateConsistent, inv:FallbackCountBounded, inv:SelectedItemInPath} buggy={inv:TypeOK, inv:KeeperNeverBlockedByCascade, inv:TurnProceedsIfHealthyItemExists, inv:NoGroupCycle, inv:HealthStateConsistent, inv:FallbackCountBounded, inv:SelectedItemInPath} | 304a4b08e1ee |
+| KeeperCascadeRouting.tla | KeeperCascadeRouting | manual | 2 | 1 | clean={inv:TypeOK, inv:KeeperNeverBlockedByCascade, inv:TurnProceedsIfHealthyItemExists, inv:NoGroupCycle, inv:HealthStateConsistent, inv:FallbackCountBounded, inv:SelectedItemInPath} buggy={inv:TypeOK, inv:KeeperNeverBlockedByCascade, inv:TurnProceedsIfHealthyItemExists, inv:NoGroupCycle, inv:HealthStateConsistent, inv:FallbackCountBounded, inv:SelectedItemInPath} | e3392c1c6fab |
 | KeeperCircuitBreaker.tla | KeeperCircuitBreaker | manual | 2 | 1 | clean={inv:SafetyInvariant} buggy={inv:TripOnlyWithStreak} | 1d4d87f2bb68 |
 | KeeperCompactionLifecycle.tla | KeeperCompactionLifecycle | manual | 2 | 1 | clean={inv:Safety, prop:OverflowEventuallyLeavesOverflow, prop:CompactingEventuallyStops} buggy={inv:CompactingAlignsAll} | ae32b2f6ae60 |
 | KeeperCompositeLifecycle.tla | KeeperCompositeLifecycle | manual | 3 | 2 | clean={inv:SafetyInvariant, prop:EventualMeasurementResolves, prop:RecoveryEventuallyCompletes, prop:OverflowedEventuallyResolves} buggy-cascade={inv:NoCascadeBeforeMeasurement} buggy-compaction={inv:CompactionAtomicity, inv:PhaseTurnAlignment} | 40f62be554b0 |

--- a/specs/keeper-state-machine/KeeperCascadeRouting.tla
+++ b/specs/keeper-state-machine/KeeperCascadeRouting.tla
@@ -305,6 +305,28 @@ BugNoGroupFallback(keeper) ==
     /\ UNCHANGED <<keeper_state, item_health, consecutive_failures,
                     selected_item, fallback_count, group_path>>
 
+(* ── Error variant extension (RFC-0057 Phase 3) ────────────
+
+   The cascade_attempt_fsm.ml string classifier anti-pattern
+   (13 contains_substring_ci calls) is replaced by typed variants.
+   This spec section documents the intended TLA+ model for the
+   extended error surface.
+
+   New error kinds (previously reconstructed from message strings):
+
+   - CliWrappedHardQuota   : CLI exit with hard quota (e.g. 403)
+   - CliWrappedMaxTurns    : CLI exit with max-turns exceeded
+   - CliWrappedResumable   : CLI exit with resumable session signal
+   - PermissionDenied      : 401/403 from API or CLI
+   - ModelNotFound         : 404 from API or CLI
+
+   These extend the http_error type that Call_err carries.
+   The classify_failure invariant must handle each kind.
+
+   NOTE: This is a documentation stub. Full TLA+ type extension
+   requires Phase 2 implementation merge to keep spec and code
+   in sync. *)
+
 (* BUG-3: Global health cache — one keeper's failure affects all keepers.
    Models the current (pre-RFC-0041) global shared state.
    When an item is degraded for one keeper, it becomes degraded for ALL keepers. *)


### PR DESCRIPTION
## Goal

RFC-0057 Phase 3: Extend the `KeeperCascadeRouting` TLA+ spec with a stub for the new `Provider_error.t` error variants so the model checker can be expanded incrementally as Phase 2 lands.

## Files Changed

- `tla/keeper-state-machine/KeeperCascadeRouting.tla` (+22/-0)

## Verification

- Stub only — no new TLC properties enforced yet.
- Follow-up PR will tighten invariants once Phase 2 wires typed variants into the cascade FSM.

## Related

- RFC: docs/rfc/RFC-0057-cascade-error-typing-boundary.md (#14386)
- Phase 0: feat/rfc-0057-phase0-provider-error
- Phase 2: feat/rfc-0057-phase2-prep

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>