### PR TITLE
fix(keeper): allow Turn_exhausted from Turn_prompting/Turn_routing

### DIFF
--- a/lib/keeper/keeper_registry.ml
+++ b/lib/keeper/keeper_registry.ml
@@ -234,9 +234,11 @@ module Turn_phase_transition = struct
     | Prompting_to_routing : (turn_prompting, turn_routing) t
     | Prompting_to_executing : (turn_prompting, turn_executing) t
     | Prompting_to_finalizing : (turn_prompting, turn_finalizing) t
+    | Prompting_to_exhausted : (turn_prompting, turn_exhausted) t
     | Routing_to_prompting : (turn_routing, turn_prompting) t
     | Routing_to_routing : (turn_routing, turn_routing) t
     | Routing_to_executing : (turn_routing, turn_executing) t
+    | Routing_to_exhausted : (turn_routing, turn_exhausted) t
     | Executing_to_prompting : (turn_executing, turn_prompting) t
     | Executing_to_routing : (turn_executing, turn_routing) t
     | Executing_to_executing : (turn_executing, turn_executing) t
@@ -246,10 +248,12 @@ module Turn_phase_transition = struct
     | Compacting_to_prompting : (turn_compacting, turn_prompting) t
     | Compacting_to_compacting : (turn_compacting, turn_compacting) t
     | Compacting_to_finalizing : (turn_compacting, turn_finalizing) t
+    | Compacting_to_exhausted : (turn_compacting, turn_exhausted) t
     | Finalizing_to_prompting : (turn_finalizing, turn_prompting) t
     | Finalizing_to_routing : (turn_finalizing, turn_routing) t
     | Finalizing_to_executing : (turn_finalizing, turn_executing) t
     | Finalizing_to_finalizing : (turn_finalizing, turn_finalizing) t
+    | Finalizing_to_exhausted : (turn_finalizing, turn_exhausted) t
     | Exhausted_to_prompting : (turn_exhausted, turn_prompting) t
     | Exhausted_to_routing : (turn_exhausted, turn_routing) t
     | Exhausted_to_executing : (turn_exhausted, turn_executing) t
@@ -262,9 +266,11 @@ module Turn_phase_transition = struct
     | Prompting_to_routing -> "prompting->routing"
     | Prompting_to_executing -> "prompting->executing"
     | Prompting_to_finalizing -> "prompting->finalizing"
+    | Prompting_to_exhausted -> "prompting->exhausted"
     | Routing_to_prompting -> "routing->prompting"
     | Routing_to_routing -> "routing->routing"
     | Routing_to_executing -> "routing->executing"
+    | Routing_to_exhausted -> "routing->exhausted"
     | Executing_to_prompting -> "executing->prompting"
     | Executing_to_routing -> "executing->routing"
     | Executing_to_executing -> "executing->executing"
@@ -274,10 +280,12 @@ module Turn_phase_transition = struct
     | Compacting_to_prompting -> "compacting->prompting"
     | Compacting_to_compacting -> "compacting->compacting"
     | Compacting_to_finalizing -> "compacting->finalizing"
+    | Compacting_to_exhausted -> "compacting->exhausted"
     | Finalizing_to_prompting -> "finalizing->prompting"
     | Finalizing_to_routing -> "finalizing->routing"
     | Finalizing_to_executing -> "finalizing->executing"
     | Finalizing_to_finalizing -> "finalizing->finalizing"
+    | Finalizing_to_exhausted -> "finalizing->exhausted"
     | Exhausted_to_prompting -> "exhausted->prompting"
     | Exhausted_to_routing -> "exhausted->routing"
     | Exhausted_to_executing -> "exhausted->executing"
@@ -1054,7 +1062,7 @@ let validate_turn_phase_transition ~from ~to_ =
          | Packed Turn_prompting, Packed Turn_executing -> true  (* via set_turn_phase *)
          | Packed Turn_prompting, Packed Turn_compacting -> false
          | Packed Turn_prompting, Packed Turn_finalizing -> true  (* via mark_turn_gate_rejected_by_name *)
-         | Packed Turn_prompting, Packed Turn_exhausted -> false
+         | Packed Turn_prompting, Packed Turn_exhausted -> true  (* via set_turn_cascade_state: Cascade_exhausted before any cascade attempt (e.g. all candidates filtered out at admission) *)
          (* from Turn_routing *)
          | Packed Turn_routing, Packed Turn_idle -> false  (* new turn init is reset, not transition *)
          | Packed Turn_routing, Packed Turn_prompting -> true  (* via set_turn_cascade_state: Cascade_idle on retry *)
@@ -1062,7 +1070,7 @@ let validate_turn_phase_transition ~from ~to_ =
          | Packed Turn_routing, Packed Turn_executing -> true  (* via set_turn_cascade_state: Cascade_trying *)
          | Packed Turn_routing, Packed Turn_compacting -> false
          | Packed Turn_routing, Packed Turn_finalizing -> false
-         | Packed Turn_routing, Packed Turn_exhausted -> false
+         | Packed Turn_routing, Packed Turn_exhausted -> true  (* via set_turn_cascade_state: Cascade_exhausted during model selection (cascade-fallback exhausted before Cascade_trying) *)
          (* from Turn_executing *)
          | Packed Turn_executing, Packed Turn_idle -> false  (* new turn init is reset, not transition *)
          | Packed Turn_executing, Packed Turn_prompting -> true  (* via set_turn_cascade_state: Cascade_idle retry *)

--- a/lib/keeper/keeper_registry.mli
+++ b/lib/keeper/keeper_registry.mli
@@ -160,9 +160,11 @@ module Turn_phase_transition : sig
     | Prompting_to_routing : (turn_prompting, turn_routing) t
     | Prompting_to_executing : (turn_prompting, turn_executing) t
     | Prompting_to_finalizing : (turn_prompting, turn_finalizing) t
+    | Prompting_to_exhausted : (turn_prompting, turn_exhausted) t
     | Routing_to_prompting : (turn_routing, turn_prompting) t
     | Routing_to_routing : (turn_routing, turn_routing) t
     | Routing_to_executing : (turn_routing, turn_executing) t
+    | Routing_to_exhausted : (turn_routing, turn_exhausted) t
     | Executing_to_prompting : (turn_executing, turn_prompting) t
     | Executing_to_routing : (turn_executing, turn_routing) t
     | Executing_to_executing : (turn_executing, turn_executing) t
@@ -172,10 +174,12 @@ module Turn_phase_transition : sig
     | Compacting_to_prompting : (turn_compacting, turn_prompting) t
     | Compacting_to_compacting : (turn_compacting, turn_compacting) t
     | Compacting_to_finalizing : (turn_compacting, turn_finalizing) t
+    | Compacting_to_exhausted : (turn_compacting, turn_exhausted) t
     | Finalizing_to_prompting : (turn_finalizing, turn_prompting) t
     | Finalizing_to_routing : (turn_finalizing, turn_routing) t
     | Finalizing_to_executing : (turn_finalizing, turn_executing) t
     | Finalizing_to_finalizing : (turn_finalizing, turn_finalizing) t
+    | Finalizing_to_exhausted : (turn_finalizing, turn_exhausted) t
     | Exhausted_to_prompting : (turn_exhausted, turn_prompting) t
     | Exhausted_to_routing : (turn_exhausted, turn_routing) t
     | Exhausted_to_executing : (turn_exhausted, turn_executing) t

--- a/test/test_keeper_sub_fsm_guards.ml
+++ b/test/test_keeper_sub_fsm_guards.ml
@@ -21,10 +21,12 @@ let test_valid_turn_phase_transitions () =
     ; Packed Turn_prompting, Packed Turn_routing
     ; Packed Turn_prompting, Packed Turn_executing
     ; Packed Turn_prompting, Packed Turn_finalizing
+    ; Packed Turn_prompting, Packed Turn_exhausted  (* mark_terminal_error before any cascade attempt *)
       (* from Turn_routing *)
     ; Packed Turn_routing, Packed Turn_prompting
     ; Packed Turn_routing, Packed Turn_routing
     ; Packed Turn_routing, Packed Turn_executing
+    ; Packed Turn_routing, Packed Turn_exhausted  (* mark_terminal_error during cascade-fallback model selection *)
       (* from Turn_executing *)
     ; Packed Turn_executing, Packed Turn_prompting
     ; Packed Turn_executing, Packed Turn_routing
@@ -73,12 +75,10 @@ let test_invalid_turn_phase_transitions () =
       (* from Turn_prompting *)
     ; Packed Turn_prompting, Packed Turn_idle
     ; Packed Turn_prompting, Packed Turn_compacting
-    ; Packed Turn_prompting, Packed Turn_exhausted
       (* from Turn_routing *)
     ; Packed Turn_routing, Packed Turn_idle
     ; Packed Turn_routing, Packed Turn_compacting
     ; Packed Turn_routing, Packed Turn_finalizing
-    ; Packed Turn_routing, Packed Turn_exhausted
       (* from Turn_executing *)
     ; Packed Turn_executing, Packed Turn_idle
       (* from Turn_compacting *)


### PR DESCRIPTION
## 배경

PR #14389 (진단 메시지 보강)의 후속. 2026-05-09 21:39:30 qa-king crash의 원인 페어 후보 중 cascade lifecycle 분석상 가장 그럴듯한 두 셀을 enable합니다.

`mark_terminal_error`(`keeper_unified_turn.ml:1113`)는 cascade가 어느 단계에 있든 `set_turn_cascade_state(Cascade_exhausted)`를 발사할 수 있는데, 매트릭스는 cascade가 `Cascade_trying`까지 도달한 케이스(`Turn_executing -> Turn_exhausted`)만 valid로 표시하고 있었습니다. 그러나 다음 두 진입점은 모두 합법적입니다:

- **`Turn_prompting -> Turn_exhausted`** (`Cascade_idle -> Cascade_exhausted`): 모든 후보가 admission 단계에서 필터링되어 cascade attempt 자체가 시작되지 않은 경우.
- **`Turn_routing -> Turn_exhausted`** (`Cascade_selecting -> Cascade_exhausted`): cascade-fallback이 모든 모델을 timeout/error로 소진해 `Cascade_trying`까지 도달하지 못한 경우. 21:39:30 qa-king이 정확히 이 path였습니다 (`glm-5-turbo` timeout → cascade 소진 → cycle budget 만료로 degraded retry 포기 → `mark_terminal_error`).

## 변경

### 1. 매트릭스 두 셀 flip (`keeper_registry.ml`)

```diff
- | Packed Turn_prompting, Packed Turn_exhausted -> false
+ | Packed Turn_prompting, Packed Turn_exhausted -> true  (* via set_turn_cascade_state: Cascade_exhausted before any cascade attempt (e.g. all candidates filtered out at admission) *)

- | Packed Turn_routing, Packed Turn_exhausted -> false
+ | Packed Turn_routing, Packed Turn_exhausted -> true  (* via set_turn_cascade_state: Cascade_exhausted during model selection (cascade-fallback exhausted before Cascade_trying) *)
```

### 2. `Turn_phase_transition` GADT mirror sync

GADT는 매트릭스의 모든 valid arm을 enumerate한다고 docstring에 명시되어 있는데, 이번 두 edge 외에도 PR 8f6ae71 시점에 추가됐던 두 edge(`Compacting_to_exhausted`, `Finalizing_to_exhausted`)도 GADT에 누락되어 있었습니다. 이번 PR에서 네 constructor를 한 번에 추가해 lockstep 회복:

- `Prompting_to_exhausted`
- `Routing_to_exhausted`
- `Compacting_to_exhausted` (8f6ae71 backfill)
- `Finalizing_to_exhausted` (8f6ae71 backfill)

`to_tag` 매핑도 같은 4개 추가. 외부 caller가 0이라 동작 영향 없음, 미래 GADT 사용자를 위한 invariant 유지.

### 3. 테스트 (`test/test_keeper_sub_fsm_guards.ml`)

두 페어를 invalid case에서 valid case로 이동.

## 검증

- ✅ `dune build --root . @check`
- ✅ `dune build test/test_keeper_sub_fsm_guards.exe`
- ⚠️  `dune exec test_keeper_sub_fsm_guards.exe`는 main과 동일하게 catalog 미초기화로 실행 실패 (PR #14389에서 보고한 사전 결함)

## 다음 occurrence 시 차이

이전 (PR #14389 머지 후, 이 PR 머지 전):
```
Invalid_argument("validate_turn_phase_transition: invalid transition Turn_routing -> Turn_exhausted")
```
→ keeper cycle 죽음, supervisor restart 필요.

이 PR 머지 후:
```
(nothing — Cascade_exhausted is accepted from Turn_prompting/Turn_routing)
```
→ keeper가 정상적으로 `mark_terminal_error` 처리 후 idle로 복귀.

## 한계

이 PR은 `Turn_idle -> Turn_exhausted`(line 1049)는 여전히 false 유지합니다 — turn이 시작되지 않은 상태에서 cascade 소진은 의미상 의문이라, 실제 발생하면 그게 진짜 invariant 위반의 신호가 되도록 둡니다. 운영 중 이 페어가 production 진단 메시지에 떴다면 별개 이슈로 추적합니다.

## 구조적 부채 (별도 RFC)

PR #14389의 진단 메시지 + 이 PR의 한 줄 fix 조합이 매번 occurrence를 잡아내는 데에는 효과적이지만, 본질은 여전히 **매트릭스의 false 셀이 production에 의해 발견되는 누적 패턴**입니다. 5번째 fix(8f6ae71)에 이어 6번째 fix(이 PR). RFC-level 근본 해결 후보:

- `Cascade_exhausted` 같은 terminal escape를 매트릭스 외부의 helper(`set_turn_terminal_exhausted` 등)로 분리
- GADT mirror를 매트릭스 generator로 통합 (single source of truth)

CLAUDE.md `software-development.md` §워크어라운드 거부 기준에서 명시한 누적 안티패턴이라, 다음 occurrence 시점에 RFC 작성을 권장합니다.

## RFC

`RFC-WAIVED: keeper FSM validator change, no credential / identity / sandbox / dashboard credential surface touched.`

🤖 Generated with [Claude Code](https://claude.com/claude-code)