### PR TITLE
fix(build): clean stale Dune lock and dead RPC sockets (#13258)

### DIFF
--- a/scripts/dune-local.sh
+++ b/scripts/dune-local.sh
@@ -265,6 +265,48 @@ if [[ "${GITHUB_ACTIONS:-}" != "true" \
 fi
 # -----------------------------------------------------------------------
 
+# --- auto-clean stale _build on agent_sdk pin change -------------------
+# Dune does not track opam pin identity in its incremental cache.  When
+# agent_sdk is repinned (e.g. by another worktree's build), the .cmx
+# artifacts in _build/ still reference the old pin's CMI signatures.
+# This produces "inconsistent assumptions over implementation" errors.
+#
+# Compare the SSOT pin SHA against a marker file in _build/.  On
+# mismatch, auto-clean before the build proceeds.  The marker is written
+# after every successful pin guard pass so it stays current.
+#
+# Skipped when:
+#   GITHUB_ACTIONS=true     – CI builds are clean-room
+#   MASC_DUNE_DRY_RUN=1     – dry-run never mutates _build
+#   subcommand == clean     – clean already removes everything
+#   MASC_SKIP_PIN_CHECK=1   – without pin check, marker is meaningless
+if [[ "${GITHUB_ACTIONS:-}" != "true" \
+      && "${MASC_DUNE_DRY_RUN:-0}" != "1" \
+      && "${MASC_SKIP_PIN_CHECK:-0}" != "1" \
+      && "${_subcommand}" != "clean" ]]; then
+  _pin_sha_source="${repo_root}/scripts/oas-agent-sdk-pin.sh"
+  if [[ -f "${_pin_sha_source}" ]]; then
+    # shellcheck source=/dev/null
+    source "${_pin_sha_source}" 2>/dev/null || true
+    if [[ -n "${OAS_AGENT_SDK_SHA:-}" ]]; then
+      _build_marker="${DUNE_BUILD_DIR:-$repo_root/_build}/.last-agent-sdk-sha"
+      if [[ -f "${_build_marker}" ]]; then
+        _last_sha="$(cat "${_build_marker}")"
+        if [[ "${_last_sha}" != "${OAS_AGENT_SDK_SHA}" ]]; then
+          printf '[dune-local] agent_sdk pin changed (%.8s → %.8s) — cleaning stale _build artifacts\n' \
+            "${_last_sha}" "${OAS_AGENT_SDK_SHA}" >&2
+          if [[ -d "${DUNE_BUILD_DIR:-$repo_root/_build}" ]]; then
+            rm -rf "${DUNE_BUILD_DIR:-$repo_root/_build}"
+          fi
+        fi
+      fi
+      mkdir -p "$(dirname "${_build_marker}")" 2>/dev/null || true
+      printf '%s' "${OAS_AGENT_SDK_SHA}" > "${_build_marker}"
+    fi
+  fi
+fi
+# -----------------------------------------------------------------------
+
 # --- core opam-deps installed guard ------------------------------------
 # Catch the "deps declared but not installed" failure mode before Dune
 # emits a wall of cryptic abstract-cmi errors:

--- a/scripts/dune-local.sh
+++ b/scripts/dune-local.sh
@@ -233,6 +233,58 @@ if [[ "${GITHUB_ACTIONS:-}" != "true" ]]; then
   export DUNE_BUILD_DIR="${DUNE_BUILD_DIR:-$repo_root/_build}"
 fi
 
+# --- stale Dune lock/RPC cleanup ----------------------------------------
+# Dune uses `_build/.lock` (0-byte) for exclusive build-dir access and
+# `~/.local/share/dune/rpc/<pid>.csexp` sockets for RPC daemon
+# communication.  When Dune crashes or is killed, both can linger and
+# cause subsequent builds to hang (scheduler event-loop wait on a dead
+# socket, or exclusive-lock spin on a stale file).
+#
+# This guard removes stale artifacts when no live Dune process holds them.
+# It runs after the machine-wide dune-local lock is acquired, so no other
+# dune-local.sh wrapper is active — but a bare `dune` invocation outside
+# the wrapper could still hold them.
+#
+# Skipped when:
+#   GITHUB_ACTIONS=true     – CI builds are clean-room
+#   MASC_DUNE_DRY_RUN=1     – dry-run never mutates state
+#   subcommand == clean     – clean removes everything anyway
+#   MASC_SKIP_STALE_CLEANUP=1 – operator opt-out
+if [[ "${GITHUB_ACTIONS:-}" != "true" \
+      && "${MASC_DUNE_DRY_RUN:-0}" != "1" \
+      && "${MASC_SKIP_STALE_CLEANUP:-0}" != "1" \
+      && "${_subcommand}" != "clean" ]]; then
+  _build_lock="${DUNE_BUILD_DIR:-$repo_root/_build}/.lock"
+  if [[ -f "${_build_lock}" ]]; then
+    _has_dune=0
+    if command -v pgrep >/dev/null 2>&1; then
+      if pgrep -x dune >/dev/null 2>&1; then _has_dune=1; fi
+    elif command -v ps >/dev/null 2>&1; then
+      if ps aux 2>/dev/null | grep -q '[d]une'; then _has_dune=1; fi
+    fi
+    if [[ "${_has_dune}" -eq 0 ]]; then
+      printf '[dune-local] removing stale _build/.lock (no dune process running)\n' >&2
+      rm -f "${_build_lock}"
+    fi
+  fi
+  # Stale RPC daemon sockets: ~/.local/share/dune/rpc/<pid>.csexp
+  # If the PID in the filename is not a running process, the daemon is dead.
+  _rpc_dir="${HOME}/.local/share/dune/rpc"
+  if [[ -d "${_rpc_dir}" ]]; then
+    for _socket in "${_rpc_dir}"/*.csexp; do
+      [[ -f "${_socket}" ]] || continue
+      _rpc_pid="${_socket##*/}"
+      _rpc_pid="${_rpc_pid%.csexp}"
+      if [[ -n "${_rpc_pid}" ]] && ! kill -0 "${_rpc_pid}" 2>/dev/null; then
+        printf '[dune-local] removing stale RPC socket %s (pid %s dead)\n' \
+          "${_socket}" "${_rpc_pid}" >&2
+        rm -f "${_socket}"
+      fi
+    done
+  fi
+fi
+# -----------------------------------------------------------------------
+
 # --- agent_sdk pin guard -----------------------------------------------
 # Assert the local opam switch is pinned to the SSOT SHA before each local
 # build.  Multiple concurrent sessions that share one opam switch can


### PR DESCRIPTION
## Summary
- Add guard to `dune-local.sh` that removes stale `_build/.lock` (0-byte exclusive lockfile) when no Dune process is running
- Clean dead RPC daemon sockets (`~/.local/share/dune/rpc/<pid>.csexp`) whose PID is no longer alive
- Both artifacts can linger after Dune crashes, causing subsequent builds to hang (scheduler event-loop wait on dead socket, or lock spin on stale file)

## Root Cause (#13258)
Dune build hangs after acquiring `/tmp/me-dune-local.lock`. Dune process sleeps in `Dune_scheduler__Event.wait` / RPC event-loop paths. The lock file `_build/.lock` (0 bytes) and RPC sockets from dead daemons (April 21, 3+ weeks old) prevent new builds from starting.

## Test Plan
- [x] Verified `_build/.lock` exists at 0 bytes with no holder process
- [x] Verified stale RPC sockets `12958.csexp` and `66314.csexp` from April 21
- [x] Guard is skipped in CI (`GITHUB_ACTIONS`), dry-run, clean subcommand, and via `MASC_SKIP_STALE_CLEANUP=1`
- [ ] Local smoke test: `dune-local.sh build` after removing stale artifacts

Follow-up to #14390 (auto-clean on agent_sdk pin change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)