### PR TITLE
fix(cascade): handle TomlTableArray in groups field + early reject empty catalog

### DIFF
--- a/lib/cascade/cascade_catalog_runtime.ml
+++ b/lib/cascade/cascade_catalog_runtime.ml
@@ -648,12 +648,19 @@ let validate_path_result ?sw ?net ~config_path () =
              ~profiles:[])
     | Ok json ->
         let profiles = discover_profiles json in
-        let required_default_profile =
-          Cascade_routes.cascade_name_for_use
-            ~config_path
-            Cascade_routes.Keeper_turn
-        in
-        let route_target_errors =
+        if profiles = [] then
+          Error
+            (rejection_of_path ~config_path:source_path ~attempted_mtime
+               ~checked_at
+               ~errors:[ "active cascade catalog has no <name>_models profiles" ]
+               ~profiles:[])
+        else
+          let required_default_profile =
+            Cascade_routes.cascade_name_for_use
+              ~config_path
+              Cascade_routes.Keeper_turn
+          in
+          let route_target_errors =
           Cascade_routes.configured_route_targets ~config_path ()
           |> List.filter_map (fun target ->
                  if List.mem target profiles then None

--- a/lib/cascade/cascade_toml_materializer.ml
+++ b/lib/cascade/cascade_toml_materializer.ml
@@ -438,9 +438,14 @@ let profile_field_json ~profile_name ~field_name field_value =
       (* RFC-0041 hierarchical group/item profile format. Each element is an
          inline table describing a [Cascade_ref.cascade_group]. The array is
          materialized as [<profile>_groups] in JSON so the loader can use
-         [Cascade_ref.cascade_group_of_json] for parsing. *)
+         [Cascade_ref.cascade_group_of_json] for parsing.
+
+         Accept both [TomlArray] (inline array of tables) and
+         [TomlTableArray] (TOML [[...]] syntax) so operators are not forced
+         into one concrete TOML style. *)
       match field_value with
-      | Otoml.TomlArray items ->
+      | Otoml.TomlArray items
+      | Otoml.TomlTableArray items ->
           Ok [ (profile_name ^ "_groups", `List (List.map otoml_to_yojson items)) ]
       | _ ->
           errorf "expected %s to be an array of group tables, found %s"


### PR DESCRIPTION
## Summary
- `cascade_toml_materializer.ml`: `profile_field_json`의 `groups` 필드 처리에서 `Otoml.TomlTableArray`를 추가 매칭. TOML `[[...]]` (table array) 문법이 `TomlArray`가 아닌 `TomlTableArray`로 파싱되는데, 기존 코드는 `TomlArray`만 매칭해서 materializer가 `Error`를 반환하고 이것이 연쇄적으로 `cascade catalog empty` crash로 이어졌음.
- `cascade_catalog_runtime.ml`: `validate_path_result`에서 `profiles = []`일 때 `cascade_name_for_use`를 호출하기 전에 early return으로 `Error`를 반환. 이 함수가 예외를 던지면 graceful rejection이 불가능했음.

## 검증
- `dune build --root . @check` 통과
- `bin/main_eio.exe` 빌드는 기존 코드(`dashboard_oas_bridge.ml`, `cascade_attempt_fsm.ml`)의 unrelated partial-match warning으로 실패 — 본 PR 범위 외

## Test plan
- [ ] `start-masc-mcp.sh --base-path ~/me`로 서버가 정상 부팅하는지 확인