### PR TITLE
fix(build): exhaust Provider_error.t partial-match in 3 sites (post #14391)

### DIFF
--- a/lib/cascade/cascade_attempt_fsm.ml
+++ b/lib/cascade/cascade_attempt_fsm.ml
@@ -518,7 +518,12 @@ let provider_error_capacity_scope_label = function
   | Provider_error.RateLimit _
   | Provider_error.AuthError _
   | Provider_error.ServerError _
-  | Provider_error.InvalidRequest _ ->
+  | Provider_error.InvalidRequest _
+  | Provider_error.CliWrappedHardQuota _
+  | Provider_error.CliWrappedMaxTurns _
+  | Provider_error.CliWrappedResumableSession _
+  | Provider_error.PermissionDenied _
+  | Provider_error.ModelNotFound _ ->
       "none"
 
 let emit_provider_error_metric ~cascade_name ~provider error =

--- a/lib/dashboard/dashboard_oas_bridge.ml
+++ b/lib/dashboard/dashboard_oas_bridge.ml
@@ -252,7 +252,12 @@ let provider_error_capacity_scope_label = function
   | Provider_error.RateLimit _
   | Provider_error.AuthError _
   | Provider_error.ServerError _
-  | Provider_error.InvalidRequest _ ->
+  | Provider_error.InvalidRequest _
+  | Provider_error.CliWrappedHardQuota _
+  | Provider_error.CliWrappedMaxTurns _
+  | Provider_error.CliWrappedResumableSession _
+  | Provider_error.PermissionDenied _
+  | Provider_error.ModelNotFound _ ->
       "none"
 
 let record_provider_error ~cascade_name ~provider_id error =

--- a/test/test_provider_error.ml
+++ b/test/test_provider_error.ml
@@ -54,7 +54,12 @@ let typed_health_decision err =
       (P.CapacityExhausted { scope = `Model; _ }
       | P.AuthError _
       | P.ServerError _
-      | P.InvalidRequest _) ->
+      | P.InvalidRequest _
+      | P.CliWrappedHardQuota _
+      | P.CliWrappedMaxTurns _
+      | P.CliWrappedResumableSession _
+      | P.PermissionDenied _
+      | P.ModelNotFound _) ->
       Failure
   | None -> Failure
 


### PR DESCRIPTION
## Summary

PR #14391 (`5ae686426c`)이 `Provider_error.t`에 5개 CLI-specific variant를 추가했지만 3개 explicit-alternation match site를 업데이트하지 않아 main 빌드가 `partial-match` warning 8 (treated as error)로 깨진 상태입니다.

추가된 variant:
- `CliWrappedHardQuota`
- `CliWrappedMaxTurns`
- `CliWrappedResumableSession`
- `PermissionDenied`
- `ModelNotFound`

깨진 site (각 7줄짜리 동일 fix):
1. `lib/cascade/cascade_attempt_fsm.ml:515-522` — `provider_error_capacity_scope_label`
2. `lib/dashboard/dashboard_oas_bridge.ml:249-256` — 동일 함수 (Prometheus label)
3. `test/test_provider_error.ml:50-59` — `typed_health_decision`

## Why this fix shape (not a catch-all)

CLAUDE.md `software-development.md` §AI 코드 생성 안티패턴 #4 "FSM Sparse Match / `_ -> false` Catch-all"에 정확히 해당하는 상황이라, **catch-all `_ -> "none"`을 넣지 않고** 5개를 명시적으로 추가했습니다. 원래 site들은 이미 explicit alternation 패턴을 따르고 있었고, 그게 OCaml의 exhaustive match 검증이 새 variant 추가 시 컴파일 타임에 누락을 잡는 메커니즘 — PR #14391이 그 메커니즘이 의도대로 작동한 결과로 잡힌 셈입니다.

5개 CLI-wrapped 에러는 capacity scope가 없으므로 기존 `"none"` / `Failure` branch로 매핑하는 게 의미적으로 정확합니다.

## Test plan

- [x] `dune build --root . @check` — exit 0, output 없음
- [ ] CI required checks (Build and Test, ocamlformat-check) — push 후 관찰

## Note: 같은 RFC-0057 충돌

PR #14391의 commit subject도 "RFC-0057 Phase 0"인데 우리 PR #14396도 "RFC-0057 Phase 0"입니다. 같은 번호 두 도메인 (Provider_error CLI variants vs tool descriptor codegen). 이 race가 main 안에서 정착된 상태가 됐고 별도 메모리(`feedback_rfc_number_reservation_needed.md`)에 기록했습니다 — 본 PR 범위는 빌드 fix에 한정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)