### PR TITLE
test(cdal_runtime): pin tests for Mode_enforcer + Mode_resolver (#14323)

### DIFF
--- a/test/dune
+++ b/test/dune
@@ -718,6 +718,8 @@
         test_cdal_eval_v1
         test_cdal_friction_projection
         test_cdal_verdict_gate
+        test_cdal_mode_enforcer
+        test_cdal_mode_resolver
         test_verification_fsm
         test_task_sandbox
         test_governance_yojson_roundtrip
@@ -922,6 +924,8 @@
         test_cdal_eval_v1
         test_cdal_friction_projection
         test_cdal_verdict_gate
+        test_cdal_mode_enforcer
+        test_cdal_mode_resolver
         test_verification_fsm
         test_task_sandbox
         test_governance_yojson_roundtrip

--- a/test/test_cdal_mode_enforcer.ml
+++ b/test/test_cdal_mode_enforcer.ml
@@ -1,0 +1,185 @@
+(** Pin tests for Mode_enforcer — tool classification and enforcement.
+
+    These tests lock the behavior of [classify_tool], [classify_shell_command],
+    [all_read_only], [all_workspace_only], violation serialization, and
+    [tool_effect_class_of_string] against regressions.
+
+    Part of #14323: restoring CDAL unit test coverage. *)
+
+open Alcotest
+module Me = Masc_mcp_cdal_runtime.Mode_enforcer
+
+let check_bool = check bool
+let check_string = check string
+let check_int = check int
+
+(* ── classify_tool (registry-driven, fail-closed) ─────────────── *)
+
+let test_classify_unknown_is_external () =
+  check_bool
+    "unknown tool -> External_effect"
+    true
+    (Me.classify_tool "totally_unknown_tool" = Me.External_effect)
+;;
+
+let test_classify_mcp_prefix_is_external () =
+  check_bool
+    "mcp__ prefix -> External_effect"
+    true
+    (Me.classify_tool "mcp__some_server" = Me.External_effect)
+;;
+
+let test_register_and_classify () =
+  Me.register_tool_class "test_read_tool" Me.Read_only;
+  check_bool "registered read tool" true (Me.classify_tool "test_read_tool" = Me.Read_only);
+  Me.register_tool_class "Test_Read_Tool" Me.Local_mutation;
+  check_bool
+    "case-insensitive lookup"
+    true
+    (Me.classify_tool "test_read_tool" = Me.Local_mutation)
+;;
+
+(* ── classify_tool (fail-closed default) ────────────────────────── *)
+
+let test_classify_bash_dynamic_via_effective () =
+  (* Register bash as Shell_dynamic, then test effective_class via input *)
+  Me.register_tool_class "bash" Me.Shell_dynamic;
+  check_bool
+    "bash registered as Shell_dynamic"
+    true
+    (Me.classify_tool "bash" = Me.Shell_dynamic)
+;;
+
+(* ── all_read_only / all_workspace_only ────────────────────────── *)
+
+let test_all_read_only_empty () =
+  check_bool "empty list is read-only" true (Me.all_read_only [])
+;;
+
+let test_all_workspace_only_empty () =
+  check_bool "empty list is workspace-only" true (Me.all_workspace_only [])
+;;
+
+let test_all_workspace_only_with_registered () =
+  Me.register_tool_class "ws_read" Me.Read_only;
+  Me.register_tool_class "ws_mut" Me.Local_mutation;
+  check_bool
+    "read + mutation = workspace"
+    true
+    (Me.all_workspace_only [ "ws_read"; "ws_mut" ]);
+  check_bool
+    "read + mutation is not all-read"
+    true
+    (not (Me.all_read_only [ "ws_read"; "ws_mut" ]))
+;;
+
+let test_all_workspace_rejects_external () =
+  Me.register_tool_class "ws_ext" Me.External_effect;
+  check_bool
+    "external tool is not workspace"
+    true
+    (not (Me.all_workspace_only [ "ws_ext" ]))
+;;
+
+(* ── violation_kind round-trip ─────────────────────────────────── *)
+
+let test_violation_kind_round_trip () =
+  let all_kinds = [ Me.Mutating_in_diagnose; Me.External_in_draft; Me.Scope_violation ] in
+  List.iter
+    (fun kind ->
+       let json = Me.violation_kind_to_yojson kind in
+       match Me.violation_kind_of_yojson json with
+       | Ok k -> check_bool (Me.violation_kind_to_string kind) true (k = kind)
+       | Error e ->
+         failf "round-trip failed for %s: %s" (Me.violation_kind_to_string kind) e)
+    all_kinds
+;;
+
+let test_violation_kind_rejects_unknown () =
+  match Me.violation_kind_of_yojson (`String "unknown_kind") with
+  | Ok _ -> fail "expected error for unknown violation_kind"
+  | Error _ -> ()
+;;
+
+let test_violation_kind_rejects_non_string () =
+  match Me.violation_kind_of_yojson (`Int 42) with
+  | Ok _ -> fail "expected error for non-string violation_kind"
+  | Error _ -> ()
+;;
+
+(* ── violation record round-trip ───────────────────────────────── *)
+
+let test_violation_round_trip () =
+  let v =
+    { Me.ts = 1715250000.0
+    ; tool_name = "Write"
+    ; input_summary = "{\"path\":\"/etc/passwd\"}"
+    ; effective_mode = Masc_mcp_cdal_runtime.Execution_mode.Diagnose
+    ; violation_kind = Me.Mutating_in_diagnose
+    }
+  in
+  let json = Me.violation_to_yojson v in
+  match Me.violation_of_yojson json with
+  | Ok v' ->
+    check_string "tool_name" v.Me.tool_name v'.Me.tool_name;
+    check_string "input_summary" v.Me.input_summary v'.Me.input_summary;
+    check_bool "violation_kind" true (v.Me.violation_kind = v'.Me.violation_kind)
+  | Error e -> failf "violation round-trip failed: %s" e
+;;
+
+(* ── tool_effect_class_of_string ───────────────────────────────── *)
+
+let test_effect_class_of_string_all () =
+  let cases =
+    [ "read_only", Some Me.Read_only
+    ; "workspace", Some Me.Local_mutation
+    ; "workspace_mutating", Some Me.Local_mutation
+    ; "local_mutation", Some Me.Local_mutation
+    ; "external", Some Me.External_effect
+    ; "external_effect", Some Me.External_effect
+    ; "shell_dynamic", Some Me.Shell_dynamic
+    ; "garbage", None
+    ]
+  in
+  List.iter
+    (fun (input, expected) ->
+       check_bool
+         (Printf.sprintf "of_string %S" input)
+         true
+         (Me.tool_effect_class_of_string input = expected))
+    cases
+;;
+
+let () =
+  Alcotest.run
+    "cdal_mode_enforcer"
+    [ ( "classify_tool"
+      , [ test_case "unknown -> External_effect" `Quick test_classify_unknown_is_external
+        ; test_case "mcp__ prefix -> External" `Quick test_classify_mcp_prefix_is_external
+        ; test_case "register + classify" `Quick test_register_and_classify
+        ] )
+    ; ( "classify_bash"
+      , [ test_case
+            "bash is Shell_dynamic"
+            `Quick
+            test_classify_bash_dynamic_via_effective
+        ] )
+    ; ( "tool_lists"
+      , [ test_case "empty read-only" `Quick test_all_read_only_empty
+        ; test_case "empty workspace" `Quick test_all_workspace_only_empty
+        ; test_case
+            "read+mutation workspace"
+            `Quick
+            test_all_workspace_only_with_registered
+        ; test_case "external not workspace" `Quick test_all_workspace_rejects_external
+        ] )
+    ; ( "violation_kind"
+      , [ test_case "round-trip" `Quick test_violation_kind_round_trip
+        ; test_case "rejects unknown" `Quick test_violation_kind_rejects_unknown
+        ; test_case "rejects non-string" `Quick test_violation_kind_rejects_non_string
+        ] )
+    ; "violation", [ test_case "record round-trip" `Quick test_violation_round_trip ]
+    ; ( "effect_class_of_string"
+      , [ test_case "all variants" `Quick test_effect_class_of_string_all ] )
+    ]
+;;

--- a/test/test_cdal_mode_resolver.ml
+++ b/test/test_cdal_mode_resolver.ml
@@ -1,0 +1,202 @@
+(** Pin tests for Mode_resolver — deterministic downgrade logic.
+
+    These tests lock the behavior of [resolve]: the effective mode is the
+    minimum of requested, risk_class.max_mode, and capability_cap derived
+    from the tool list. Never upgrades beyond requested.
+
+    Part of #14323: restoring CDAL unit test coverage. *)
+
+open Alcotest
+module Mr = Masc_mcp_cdal_runtime.Mode_resolver
+module Em = Masc_mcp_cdal_runtime.Execution_mode
+module Rc = Masc_mcp_cdal_runtime.Risk_class
+module Cp = Masc_mcp_cdal_runtime.Cdal_proof
+module Me = Masc_mcp_cdal_runtime.Mode_enforcer
+
+let check_string = check string
+let check_bool = check bool
+
+let read_only_caps =
+  Cp.
+    { tools = [ "resolver_test_read1"; "resolver_test_read2" ]
+    ; mcp_servers = []
+    ; max_turns = 10
+    ; max_tokens = None
+    ; thinking_enabled = None
+    }
+;;
+
+let workspace_caps =
+  Cp.
+    { tools = [ "resolver_test_read1"; "resolver_test_mut1" ]
+    ; mcp_servers = []
+    ; max_turns = 10
+    ; max_tokens = None
+    ; thinking_enabled = None
+    }
+;;
+
+let full_caps =
+  Cp.
+    { tools = [ "resolver_test_ext1" ]
+    ; mcp_servers = [ "serena" ]
+    ; max_turns = 200
+    ; max_tokens = Some 8192
+    ; thinking_enabled = Some true
+    }
+;;
+
+let () =
+  (* Register test tools for deterministic capability classification *)
+  Me.register_tool_class "resolver_test_read1" Me.Read_only;
+  Me.register_tool_class "resolver_test_read2" Me.Read_only;
+  Me.register_tool_class "resolver_test_mut1" Me.Local_mutation;
+  Me.register_tool_class "resolver_test_ext1" Me.External_effect
+;;
+
+(* ── Passthrough: no downgrade ─────────────────────────────────── *)
+
+let test_passthrough_low_risk_execute () =
+  match Mr.resolve ~requested:Em.Execute ~risk_class:Rc.Low ~capabilities:full_caps with
+  | Ok d ->
+    check_bool "effective = Execute" true (Em.equal d.effective_mode Em.Execute);
+    check_string "source" "passthrough" d.source
+  | Error e -> failf "resolve failed: %s" e
+;;
+
+let test_passthrough_medium_risk_draft () =
+  match
+    Mr.resolve ~requested:Em.Draft ~risk_class:Rc.Medium ~capabilities:workspace_caps
+  with
+  | Ok d ->
+    check_bool "effective = Draft" true (Em.equal d.effective_mode Em.Draft);
+    check_string "source" "passthrough" d.source
+  | Error e -> failf "resolve failed: %s" e
+;;
+
+(* ── Risk-driven downgrade ─────────────────────────────────────── *)
+
+let test_risk_downgrade_medium_is_passthrough () =
+  (* Medium risk has max_mode = Execute, so no downgrade *)
+  match
+    Mr.resolve ~requested:Em.Execute ~risk_class:Rc.Medium ~capabilities:full_caps
+  with
+  | Ok d ->
+    check_bool "effective = Execute" true (Em.equal d.effective_mode Em.Execute);
+    check_string "source" "passthrough" d.source
+  | Error e -> failf "resolve failed: %s" e
+;;
+
+let test_risk_downgrade_high () =
+  (* High risk has max_mode = Draft *)
+  match Mr.resolve ~requested:Em.Execute ~risk_class:Rc.High ~capabilities:full_caps with
+  | Ok d ->
+    check_bool "effective = Draft" true (Em.equal d.effective_mode Em.Draft);
+    check_string "source" "risk_class_downgrade" d.source
+  | Error e -> failf "resolve failed: %s" e
+;;
+
+let test_risk_forbids_critical () =
+  match
+    Mr.resolve ~requested:Em.Execute ~risk_class:Rc.Critical ~capabilities:full_caps
+  with
+  | Ok _ -> fail "expected Error for Critical risk"
+  | Error e -> check_bool "error mentions risk" true (String.contains e 'r')
+;;
+
+(* ── Capability-driven downgrade ───────────────────────────────── *)
+
+let test_capability_limit_read_only_tools () =
+  match
+    Mr.resolve ~requested:Em.Execute ~risk_class:Rc.Low ~capabilities:read_only_caps
+  with
+  | Ok d ->
+    check_bool
+      "effective = Diagnose (read-only tools)"
+      true
+      (Em.equal d.effective_mode Em.Diagnose);
+    check_string "source" "capability_limit" d.source
+  | Error e -> failf "resolve failed: %s" e
+;;
+
+let test_capability_limit_workspace_tools () =
+  (* workspace_caps has read + mutation -> capability_cap = Draft *)
+  match
+    Mr.resolve ~requested:Em.Execute ~risk_class:Rc.Low ~capabilities:workspace_caps
+  with
+  | Ok d ->
+    check_bool
+      "effective = Draft (workspace tools)"
+      true
+      (Em.equal d.effective_mode Em.Draft);
+    check_string "source" "capability_limit" d.source
+  | Error e -> failf "resolve failed: %s" e
+;;
+
+(* ── Never upgrades beyond requested ───────────────────────────── *)
+
+let test_never_upgrades_diagnose () =
+  match Mr.resolve ~requested:Em.Diagnose ~risk_class:Rc.Low ~capabilities:full_caps with
+  | Ok d ->
+    check_bool
+      "effective = Diagnose (requested)"
+      true
+      (Em.equal d.effective_mode Em.Diagnose)
+  | Error e -> failf "resolve failed: %s" e
+;;
+
+let test_never_upgrades_draft () =
+  match Mr.resolve ~requested:Em.Draft ~risk_class:Rc.Low ~capabilities:full_caps with
+  | Ok d ->
+    check_bool "effective = Draft (requested)" true (Em.equal d.effective_mode Em.Draft)
+  | Error e -> failf "resolve failed: %s" e
+;;
+
+(* ── Determinism ────────────────────────────────────────────────── *)
+
+let test_deterministic () =
+  let r1 =
+    Mr.resolve ~requested:Em.Execute ~risk_class:Rc.Medium ~capabilities:full_caps
+  in
+  let r2 =
+    Mr.resolve ~requested:Em.Execute ~risk_class:Rc.Medium ~capabilities:full_caps
+  in
+  match r1, r2 with
+  | Ok d1, Ok d2 ->
+    check_bool "same mode" true (Em.equal d1.effective_mode d2.effective_mode);
+    check_string "same source" d1.source d2.source
+  | _ -> fail "resolve failed"
+;;
+
+let () =
+  Alcotest.run
+    "cdal_mode_resolver"
+    [ ( "passthrough"
+      , [ test_case "low risk execute" `Quick test_passthrough_low_risk_execute
+        ; test_case "medium risk draft" `Quick test_passthrough_medium_risk_draft
+        ] )
+    ; ( "risk_downgrade"
+      , [ test_case
+            "medium risk passthrough"
+            `Quick
+            test_risk_downgrade_medium_is_passthrough
+        ; test_case "high risk -> draft" `Quick test_risk_downgrade_high
+        ; test_case "critical risk forbids" `Quick test_risk_forbids_critical
+        ] )
+    ; ( "capability_limit"
+      , [ test_case
+            "read-only tools -> diagnose"
+            `Quick
+            test_capability_limit_read_only_tools
+        ; test_case
+            "workspace tools -> draft"
+            `Quick
+            test_capability_limit_workspace_tools
+        ] )
+    ; ( "no_upgrade"
+      , [ test_case "diagnose stays diagnose" `Quick test_never_upgrades_diagnose
+        ; test_case "draft stays draft" `Quick test_never_upgrades_draft
+        ] )
+    ; "determinism", [ test_case "same inputs, same output" `Quick test_deterministic ]
+    ]
+;;


### PR DESCRIPTION
## Summary
- Add 13 pin tests for Mode_enforcer: classify_tool (fail-closed registry), all_read_only/all_workspace_only predicates, violation_kind + violation record JSON round-trips, tool_effect_class_of_string variants
- Add 10 pin tests for Mode_resolver: passthrough, risk-driven downgrade, capability-driven downgrade, never-upgrade-beyond-requested, determinism
- Uses test-specific tool names to avoid dependency on empty default registry (RFC-OAS-012)

## Test plan
- [x] dune build passes
- [x] All 23 tests pass locally (10 resolver + 13 enforcer)
- [ ] CI green

Part of #14323.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>