### PR TITLE
feat(keeper): proactive tool surface restriction for passive streaks

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -172,6 +172,15 @@ let run_turn
   let history_messages = prompt_ctx.Keeper_run_prompt.history_messages in
   let estimated_input_tokens = prompt_ctx.Keeper_run_prompt.estimated_input_tokens in
   let ctx_work = prompt_ctx.Keeper_run_prompt.ctx_work in
+  let actionable_signal =
+    match world_observation with
+    | None -> false
+    | Some wo ->
+      wo
+      |> Keeper_contract_classifier.of_keeper_world_observation
+      |> Keeper_contract_classifier.classify_actionable_signal
+      |> Keeper_contract_classifier.is_actionable
+  in
   (* 7. Set up agent — delegated to Keeper_run_tools *)
   let setup =
     Keeper_run_tools.prepare_agent_setup
@@ -199,6 +208,7 @@ let run_turn
       ~gemini_mcp_disabled
       ~approval_mode_effective
       ~approval_mode_derived
+      ~actionable_signal
       ?max_cost_usd
       ~trajectory_acc
       ~tool_overlay

--- a/lib/keeper/keeper_exec_shared.ml
+++ b/lib/keeper/keeper_exec_shared.ml
@@ -1,11 +1,8 @@
 open Keeper_types
 open Keeper_alerting
-
 module StringMap = Map.Make (String)
 
-let count_context_tokens (ctx : working_context) =
-  Keeper_exec_context.token_count ctx
-;;
+let count_context_tokens (ctx : working_context) = Keeper_exec_context.token_count ctx
 
 let error_json ?(fields = []) (message : string) =
   Yojson.Safe.to_string (`Assoc (("error", `String message) :: fields))
@@ -15,6 +12,7 @@ let tool_result_or_error (tr : Tool_result.t) =
   let ok = tr.success in
   let msg = Tool_result.message tr in
   if ok then msg else error_json msg
+;;
 
 (** Phase B PR-5 precursor (2026-04-28): the action mapping itself,
     parameterised by the typed [Keeper_failure_circuit_breaker.error_class].
@@ -25,19 +23,30 @@ let tool_result_or_error (tr : Tool_result.t) =
 let actionable_path_action_for_class
       ~(playground : string)
       ~(raw_path : string)
-      (cls : Keeper_failure_circuit_breaker.error_class) : string =
-  if String.length raw_path = 0 then
-    "Provide a path. Your playground root is " ^ playground
-  else
+      (cls : Keeper_failure_circuit_breaker.error_class)
+  : string
+  =
+  if String.length raw_path = 0
+  then "Provide a path. Your playground root is " ^ playground
+  else (
     match cls with
     | Path_not_found ->
-      Printf.sprintf "File does not exist. Run `keeper_shell op=ls path=%s` first to see available files." playground
+      Printf.sprintf
+        "File does not exist. Run `keeper_shell op=ls path=%s` first to see available \
+         files."
+        playground
     | Path_not_allowed ->
-      Printf.sprintf "Path is outside your allowed roots. Stay inside %s or use keeper_context_status to see allowed paths." playground
+      Printf.sprintf
+        "Path is outside your allowed roots. Stay inside %s or use keeper_context_status \
+         to see allowed paths."
+        playground
     | Cwd_not_directory ->
-      "The cwd is not a directory. Omit cwd to use your default playground root, or create/repair the repo worktree first (keeper_shell op=git_clone, then git_worktree/masc_worktree_create for repos/<repo>/.worktrees/<task>)."
+      "The cwd is not a directory. Omit cwd to use your default playground root, or \
+       create/repair the repo worktree first (keeper_shell op=git_clone, then \
+       git_worktree/masc_worktree_create for repos/<repo>/.worktrees/<task>)."
     | Shell_exit_nonzero | Other ->
-      Printf.sprintf "Check the path. Your playground: %s" playground
+      Printf.sprintf "Check the path. Your playground: %s" playground)
+;;
 
 (** Actionable error for path resolution failures.
     Follows Samchon harness pattern: field-level diagnostics with
@@ -55,60 +64,49 @@ let actionable_path_action_for_class
     entry point (for callers that only have a raw error message) but
     exposes the typed mapping so Phase B PR-5 can route typed callers
     directly without a redundant classify pass. *)
-let actionable_path_error ~(op : string) ~(meta : keeper_meta)
-      ~(raw_path : string) ~(error : string) =
+let actionable_path_error
+      ~(op : string)
+      ~(meta : keeper_meta)
+      ~(raw_path : string)
+      ~(error : string)
+  =
   let playground = Keeper_sandbox.allowed_root_rel_of_meta ~meta in
   let cls = Keeper_failure_circuit_breaker.classify_error error in
   let action = actionable_path_action_for_class ~playground ~raw_path cls in
-  Yojson.Safe.to_string (`Assoc [
-    "ok", `Bool false;
-    "op", `String op;
-    "error", `String error;
-    "tried", `String raw_path;
-    "your_playground", `String playground;
-    "action", `String action;
-  ])
-
-let max_suggested_entries = 12
+  Yojson.Safe.to_string
+    (`Assoc
+        [ "ok", `Bool false
+        ; "op", `String op
+        ; "error", `String error
+        ; "tried", `String raw_path
+        ; "your_playground", `String playground
+        ; "action", `String action
+        ])
+;;
 
 let file_not_found_prefix = "File not found:"
 
-let missing_file_error_json ~(config : Coord.config) ~(target : string)
-      ~(fallback_dir : string) ~(error : string) =
-  ignore config;
-  let parent = Filename.dirname target in
-  let suggestion_dir =
-    if Fs_compat.file_exists parent && Sys.is_directory parent then parent
-    else fallback_dir
-  in
-  let suggested_entries =
-    match Safe_ops.list_dir_safe suggestion_dir with
-    | Ok entries ->
-      entries
-      |> List.sort String.compare
-      |> List.filteri (fun i _ -> i < max_suggested_entries)
-    | Error _ -> []
-  in
-  let message =
-    match suggested_entries with
-    | [] -> error
-    | entries ->
-      Printf.sprintf "%s\nAvailable entries in %s: %s"
-        error suggestion_dir (String.concat ", " entries)
-  in
+let missing_file_error_json
+      ~(config : Coord.config)
+      ~(target : string)
+      ~(fallback_dir : string)
+      ~(error : string)
+  =
+  ignore (config, fallback_dir);
+  (* #10349: do NOT echo directory entries back to the LLM.  When keeper
+     identity drifts, the resolved parent may belong to a sibling sandbox,
+     and listing its contents leaks its directory layout (oracle leak).
+     The generic error string already contains the path that was tried,
+     which is sufficient for the LLM to self-correct. *)
   Yojson.Safe.to_string
-    (`Assoc
-        [ "error", `String message
-        ; "path", `String target
-        ; "suggestion_dir", `String suggestion_dir
-        ; ( "suggested_entries"
-          , `List (List.map (fun entry -> `String entry) suggested_entries) )
-        ])
+    (`Assoc [ "ok", `Bool false; "error", `String error; "path", `String target ])
 ;;
 
 let lowercase_shell_words text =
   text
-  |> String.map (function '\t' | '\r' | '\n' -> ' ' | c -> c)
+  |> String.map (function
+    | '\t' | '\r' | '\n' -> ' '
+    | c -> c)
   |> String.lowercase_ascii
   |> String.split_on_char ' '
   |> List.filter (fun token -> token <> "")
@@ -154,15 +152,15 @@ let safe_is_dir path =
 
 let keeper_sandbox_repo_names ~(config : Coord.config) ~(meta : keeper_meta) =
   let repos_dir = Filename.concat (keeper_playground_root ~config ~meta) "repos" in
-  if not (safe_is_dir repos_dir) then []
+  if not (safe_is_dir repos_dir)
+  then []
   else
     Sys.readdir repos_dir
     |> Array.to_list
     |> List.sort String.compare
     |> List.filter (fun entry ->
       let candidate = Filename.concat repos_dir entry in
-      safe_is_dir candidate
-      && safe_file_exists (Filename.concat candidate ".git"))
+      safe_is_dir candidate && safe_file_exists (Filename.concat candidate ".git"))
 ;;
 
 let relative_path_targets_allowed_root ~(meta : keeper_meta) (raw : string) =
@@ -174,43 +172,43 @@ let relative_path_targets_allowed_root ~(meta : keeper_meta) (raw : string) =
   keeper_effective_allowed_paths ~meta
   |> List.filter Filename.is_relative
   |> List.exists boundary
+;;
 
 let is_playground_lane_relative_path (raw : string) =
   List.exists
     (fun prefix ->
-       String.equal raw prefix
-       || String.starts_with ~prefix:(prefix ^ "/") raw)
+       String.equal raw prefix || String.starts_with ~prefix:(prefix ^ "/") raw)
     [ "mind"; "repos" ]
+;;
 
 let strip_keeper_playground_prefix ~(meta : keeper_meta) (raw : string) =
   let try_strip ~prefix text =
-    if Filename.is_relative text
-       && String.length text >= String.length prefix
-       && String.starts_with ~prefix text
-    then
+    if
+      Filename.is_relative text
+      && String.length text >= String.length prefix
+      && String.starts_with ~prefix text
+    then (
       let rest =
-        String.sub text (String.length prefix)
-          (String.length text - String.length prefix)
+        String.sub text (String.length prefix) (String.length text - String.length prefix)
       in
-      Some (if rest = "" then "." else rest)
+      Some (if rest = "" then "." else rest))
     else None
   in
   let sandbox_root = Keeper_sandbox.allowed_root_rel_of_meta ~meta in
   let legacy_bundle_root = Playground_paths.bundle_root meta.name in
   let short_root =
     let rel = Keeper_alerting_path.strip_trailing_slashes sandbox_root in
-    if String.starts_with ~prefix:(Common.masc_dirname ^ "/") rel then
-      String.sub rel 6 (String.length rel - 6)
+    if String.starts_with ~prefix:(Common.masc_dirname ^ "/") rel
+    then String.sub rel 6 (String.length rel - 6)
     else rel
   in
   let prefixes =
-    [
-      sandbox_root;
-      Keeper_alerting_path.strip_trailing_slashes sandbox_root;
-      legacy_bundle_root;
-      Keeper_alerting_path.strip_trailing_slashes legacy_bundle_root;
-      short_root ^ "/";
-      short_root;
+    [ sandbox_root
+    ; Keeper_alerting_path.strip_trailing_slashes sandbox_root
+    ; legacy_bundle_root
+    ; Keeper_alerting_path.strip_trailing_slashes legacy_bundle_root
+    ; short_root ^ "/"
+    ; short_root
     ]
   in
   List.find_map (fun prefix -> try_strip ~prefix raw) prefixes
@@ -225,15 +223,22 @@ let repo_relative_path_candidate ~(meta : keeper_meta) (raw : string) =
   Filename.is_relative raw
   && raw <> ""
   && String.contains raw '/'
-  && not (is_playground_lane_relative_path raw)
-  && not (relative_path_targets_allowed_root ~meta raw)
-  && not (List.mem first_segment [ Common.masc_dirname; "playground"; "workspace"; ".worktrees" ])
+  && (not (is_playground_lane_relative_path raw))
+  && (not (relative_path_targets_allowed_root ~meta raw))
+  && not
+       (List.mem
+          first_segment
+          [ Common.masc_dirname; "playground"; "workspace"; ".worktrees" ])
 ;;
 
-let rewrite_single_repo_relative_path ~(config : Coord.config) ~(meta : keeper_meta)
-      (raw : string) =
-  if not (repo_relative_path_candidate ~meta raw) then Ok None
-  else
+let rewrite_single_repo_relative_path
+      ~(config : Coord.config)
+      ~(meta : keeper_meta)
+      (raw : string)
+  =
+  if not (repo_relative_path_candidate ~meta raw)
+  then Ok None
+  else (
     let first_segment =
       match String.split_on_char '/' raw with
       | segment :: _ -> segment
@@ -245,54 +250,52 @@ let rewrite_single_repo_relative_path ~(config : Coord.config) ~(meta : keeper_m
       let rewritten =
         Filename.concat (keeper_playground_root ~config ~meta) sandbox_relative
       in
-      Log.Keeper.debug "playground_relative: explicit repo rewrite %S → %S"
-        raw rewritten;
+      Log.Keeper.debug "playground_relative: explicit repo rewrite %S → %S" raw rewritten;
       Ok (Some rewritten)
     | [ repo_name ] ->
-      let sandbox_relative =
-        Filename.concat ("repos/" ^ repo_name) raw
-      in
+      let sandbox_relative = Filename.concat ("repos/" ^ repo_name) raw in
       let rewritten =
         Filename.concat (keeper_playground_root ~config ~meta) sandbox_relative
       in
-      Log.Keeper.debug "playground_relative: single-repo rewrite %S → %S"
-        raw rewritten;
+      Log.Keeper.debug "playground_relative: single-repo rewrite %S → %S" raw rewritten;
       Ok (Some rewritten)
     | [] -> Ok None
     | repo_names ->
       Error
         (Printf.sprintf
-           "ambiguous_repo_relative_path: %s (sandbox repos: [%s]). \
-            Use repos/<repo>/%s or <repo>/%s explicitly."
+           "ambiguous_repo_relative_path: %s (sandbox repos: [%s]). Use repos/<repo>/%s \
+            or <repo>/%s explicitly."
            raw
            (String.concat ", " repo_names)
            raw
-           raw)
+           raw))
 ;;
 
-let host_path_of_own_container_path ~(config : Coord.config) ~(meta : keeper_meta)
-      (raw : string) =
-  if Filename.is_relative raw || meta.sandbox_profile <> Keeper_types.Docker then
-    None
-  else
+let host_path_of_own_container_path
+      ~(config : Coord.config)
+      ~(meta : keeper_meta)
+      (raw : string)
+  =
+  if Filename.is_relative raw || meta.sandbox_profile <> Keeper_types.Docker
+  then None
+  else (
     let strip = Keeper_alerting_path.strip_trailing_slashes in
-    let normalize path =
-      Keeper_alerting_path.normalize_path_for_check_stripped path
-    in
+    let normalize path = Keeper_alerting_path.normalize_path_for_check_stripped path in
     let container_root = Keeper_sandbox.container_root meta.name |> normalize in
     let raw_norm = normalize raw in
     let host_root = keeper_playground_root ~config ~meta |> strip in
-    if String.equal raw_norm container_root then
-      Some host_root
-    else if String.starts_with ~prefix:(container_root ^ "/") raw_norm then
+    if String.equal raw_norm container_root
+    then Some host_root
+    else if String.starts_with ~prefix:(container_root ^ "/") raw_norm
+    then (
       let suffix =
-        String.sub raw_norm
+        String.sub
+          raw_norm
           (String.length container_root + 1)
           (String.length raw_norm - String.length container_root - 1)
       in
-      Some (Filename.concat host_root suffix)
-    else
-      None
+      Some (Filename.concat host_root suffix))
+    else None)
 ;;
 
 (* Bare filenames and canonical sandbox lanes default to the keeper sandbox,
@@ -305,22 +308,27 @@ let host_path_of_own_container_path ~(config : Coord.config) ~(meta : keeper_met
    "<base>/.masc/playground/<name>/.masc/playground/<name>/repos" (absolute,
    doubled).  Stripping early
    prevents the downstream resolver from doubling the prefix again. *)
-let playground_relative_unless_allowed_root ~(config : Coord.config)
-    ~(meta : keeper_meta) (raw : string) : (string, string) result =
+let playground_relative_unless_allowed_root
+      ~(config : Coord.config)
+      ~(meta : keeper_meta)
+      (raw : string)
+  : (string, string) result
+  =
   let trimmed = String.trim raw in
   let trimmed =
     match host_path_of_own_container_path ~config ~meta trimmed with
     | Some host_path ->
-      Log.Keeper.debug "playground_relative: mapped container path %S → %S"
-        trimmed host_path;
+      Log.Keeper.debug
+        "playground_relative: mapped container path %S → %S"
+        trimmed
+        host_path;
       host_path
     | None -> trimmed
   in
   let trimmed =
     match strip_keeper_playground_prefix ~meta trimmed with
     | Some stripped ->
-      Log.Keeper.debug "playground_relative: stripped prefix %S → %S"
-        trimmed stripped;
+      Log.Keeper.debug "playground_relative: stripped prefix %S → %S" trimmed stripped;
       stripped
     | None -> trimmed
   in
@@ -328,39 +336,47 @@ let playground_relative_unless_allowed_root ~(config : Coord.config)
      E.g. "/base/.masc/playground/X/.masc/playground/X/repos" →
           "/base/.masc/playground/X/repos" *)
   let trimmed =
-    if not (Filename.is_relative trimmed) then
+    if not (Filename.is_relative trimmed)
+    then (
       let pg_root =
         keeper_playground_root ~config ~meta
         |> Keeper_alerting_path.strip_trailing_slashes
       in
       let pg_bundle = Keeper_sandbox.allowed_root_rel_of_meta ~meta in
       let doubled_prefix = pg_root ^ "/" ^ pg_bundle in
-      if String.starts_with ~prefix:doubled_prefix trimmed then
-        let rest = String.sub trimmed
-                     (String.length doubled_prefix)
-                     (String.length trimmed - String.length doubled_prefix) in
+      if String.starts_with ~prefix:doubled_prefix trimmed
+      then (
+        let rest =
+          String.sub
+            trimmed
+            (String.length doubled_prefix)
+            (String.length trimmed - String.length doubled_prefix)
+        in
         let fixed = Filename.concat pg_root rest in
-        Log.Keeper.debug "playground_relative: fixed doubled abs %S → %S"
-          trimmed fixed;
-        fixed
-      else trimmed
+        Log.Keeper.debug "playground_relative: fixed doubled abs %S → %S" trimmed fixed;
+        fixed)
+      else trimmed)
     else trimmed
   in
   match rewrite_single_repo_relative_path ~config ~meta trimmed with
   | Error _ as err -> err
   | Ok (Some rewritten) -> Ok rewritten
   | Ok None ->
-    if trimmed = ""
-       || not (Filename.is_relative trimmed)
-       || (String.contains trimmed '/'
-           && not (is_playground_lane_relative_path trimmed))
-       || relative_path_targets_allowed_root ~meta trimmed
+    if
+      trimmed = ""
+      || (not (Filename.is_relative trimmed))
+      || (String.contains trimmed '/' && not (is_playground_lane_relative_path trimmed))
+      || relative_path_targets_allowed_root ~meta trimmed
     then Ok trimmed
-    else
+    else (
       let pg = keeper_playground_root ~config ~meta in
-      Ok (Filename.concat pg trimmed)
+      Ok (Filename.concat pg trimmed))
+;;
 
-let resolve_keeper_path ~(config : Coord.config) ~(meta : keeper_meta) ~(raw_path : string)
+let resolve_keeper_path
+      ~(config : Coord.config)
+      ~(meta : keeper_meta)
+      ~(raw_path : string)
   =
   match playground_relative_unless_allowed_root ~config ~meta raw_path with
   | Error _ as err -> err
@@ -371,8 +387,11 @@ let resolve_keeper_path ~(config : Coord.config) ~(meta : keeper_meta) ~(raw_pat
       ~raw_path:normalized
 ;;
 
-let resolve_keeper_read_path ~(config : Coord.config) ~(meta : keeper_meta)
-      ~(raw_path : string) =
+let resolve_keeper_read_path
+      ~(config : Coord.config)
+      ~(meta : keeper_meta)
+      ~(raw_path : string)
+  =
   match playground_relative_unless_allowed_root ~config ~meta raw_path with
   | Error _ as err -> err
   | Ok normalized ->
@@ -382,8 +401,7 @@ let resolve_keeper_read_path ~(config : Coord.config) ~(meta : keeper_meta)
       ~raw_path:normalized
 ;;
 
-let keeper_agent_sender ~(meta : keeper_meta) =
-  meta.agent_name
+let keeper_agent_sender ~(meta : keeper_meta) = meta.agent_name
 
 let shell_readonly_limit args =
   max 1 (min 200 (Safe_ops.json_int ~default:40 "limit" args))
@@ -393,7 +411,8 @@ let shell_readonly_cat_max_bytes args =
   max 256 (min 100000 (Safe_ops.json_int ~default:4000 "max_bytes" args))
 ;;
 
-let lines_to_json ?(limit = max_int) ?(max_bytes = 32_000) (text : string) : Yojson.Safe.t =
+let lines_to_json ?(limit = max_int) ?(max_bytes = 32_000) (text : string) : Yojson.Safe.t
+  =
   let all_lines =
     String.split_on_char '\n' text
     |> List.filter (fun line -> line <> "")
@@ -405,14 +424,25 @@ let lines_to_json ?(limit = max_int) ?(max_bytes = 32_000) (text : string) : Yoj
   let rec collect acc bytes_used = function
     | [] -> List.rev acc, 0
     | line :: rest ->
-      let line_len = String.length line + 4 (* JSON overhead: quotes, comma *) in
+      let line_len =
+        String.length line + 4
+        (* JSON overhead: quotes, comma *)
+      in
       if bytes_used + line_len > max_bytes && acc <> []
       then List.rev acc, List.length rest + 1
       else collect (`String line :: acc) (bytes_used + line_len) rest
   in
   let kept, omitted = collect [] 0 all_lines in
   if omitted > 0
-  then `List (kept @ [ `String (Printf.sprintf "...[%d more lines omitted — narrow your search pattern or add --glob/--type filter]" omitted) ])
+  then
+    `List
+      (kept
+       @ [ `String
+             (Printf.sprintf
+                "...[%d more lines omitted — narrow your search pattern or add \
+                 --glob/--type filter]"
+                omitted)
+         ])
   else `List kept
 ;;
 
@@ -436,9 +466,7 @@ let tag_dispatch_fn
       ref
   =
   ref (fun ~config:_ ~agent_name:_ ~tag:_ ~name:_ ~args:_ -> None)
-
-
-
+;;
 
 let keeper_tools_list_json ~(meta : keeper_meta) =
   let names = Keeper_tool_policy.keeper_allowed_tool_names meta in
@@ -454,15 +482,13 @@ let keeper_tools_list_json ~(meta : keeper_meta) =
     | Tool_name.Keeper.Board_post
     | Tool_name.Keeper.Board_search
     | Tool_name.Keeper.Board_stats
-    | Tool_name.Keeper.Board_vote ->
-      "board"
+    | Tool_name.Keeper.Board_vote -> "board"
     | Tool_name.Keeper.Voice_agent
     | Tool_name.Keeper.Voice_listen
     | Tool_name.Keeper.Voice_session_end
     | Tool_name.Keeper.Voice_session_start
     | Tool_name.Keeper.Voice_sessions
-    | Tool_name.Keeper.Voice_speak ->
-      "voice"
+    | Tool_name.Keeper.Voice_speak -> "voice"
     | Tool_name.Keeper.Task_claim
     | Tool_name.Keeper.Task_create
     | Tool_name.Keeper.Task_done
@@ -470,41 +496,30 @@ let keeper_tools_list_json ~(meta : keeper_meta) =
     | Tool_name.Keeper.Task_force_release
     | Tool_name.Keeper.Task_submit_for_verification
     | Tool_name.Keeper.Tasks_audit
-    | Tool_name.Keeper.Tasks_list ->
-      "coordination"
+    | Tool_name.Keeper.Tasks_list -> "coordination"
     | Tool_name.Keeper.Bash
     | Tool_name.Keeper.Bash_kill
     | Tool_name.Keeper.Bash_output
-    | Tool_name.Keeper.Shell ->
-      "shell"
-    | Tool_name.Keeper.Fs_edit
-    | Tool_name.Keeper.Fs_read
-    | Tool_name.Keeper.Write ->
-      "fs"
+    | Tool_name.Keeper.Shell -> "shell"
+    | Tool_name.Keeper.Fs_edit | Tool_name.Keeper.Fs_read | Tool_name.Keeper.Write -> "fs"
     | Tool_name.Keeper.Library_read
     | Tool_name.Keeper.Library_search
-    | Tool_name.Keeper.Memory_search ->
-      "memory"
-    | Tool_name.Keeper.Broadcast
-    | Tool_name.Keeper.Handoff ->
-      "coordination"
+    | Tool_name.Keeper.Memory_search -> "memory"
+    | Tool_name.Keeper.Broadcast | Tool_name.Keeper.Handoff -> "coordination"
     | Tool_name.Keeper.Pr_create
     | Tool_name.Keeper.Pr_list
     | Tool_name.Keeper.Pr_review_comment
     | Tool_name.Keeper.Pr_review_read
     | Tool_name.Keeper.Pr_review_reply
-    | Tool_name.Keeper.Pr_status ->
-      "vcs"
-    | Tool_name.Keeper.Code_read ->
-      "fs"
+    | Tool_name.Keeper.Pr_status -> "vcs"
+    | Tool_name.Keeper.Code_read -> "fs"
     | Tool_name.Keeper.Context_status
     | Tool_name.Keeper.Discovery
     | Tool_name.Keeper.Preflight_check
     | Tool_name.Keeper.Stay_silent
     | Tool_name.Keeper.Time_now
     | Tool_name.Keeper.Tool_search
-    | Tool_name.Keeper.Tools_list ->
-      "meta"
+    | Tool_name.Keeper.Tools_list -> "meta"
   in
   let categorize n =
     match Tool_name.of_string n with
@@ -516,13 +531,19 @@ let keeper_tools_list_json ~(meta : keeper_meta) =
     | None -> "core"
   in
   let map =
-    List.fold_left (fun acc n ->
-      let cat = categorize n in
-      let list = StringMap.find_opt cat acc |> Option.value ~default:[] in
-      StringMap.add cat (n :: list) acc)
-      StringMap.empty names
+    List.fold_left
+      (fun acc n ->
+         let cat = categorize n in
+         let list = StringMap.find_opt cat acc |> Option.value ~default:[] in
+         StringMap.add cat (n :: list) acc)
+      StringMap.empty
+      names
   in
-  let assoc = StringMap.fold (fun cat list acc ->
-    (cat, `List (List.map (fun s -> `String s) list)) :: acc
-  ) map [] in
+  let assoc =
+    StringMap.fold
+      (fun cat list acc -> (cat, `List (List.map (fun s -> `String s) list)) :: acc)
+      map
+      []
+  in
   Yojson.Safe.to_string (`Assoc assoc)
+;;

--- a/lib/keeper/keeper_exec_shared.mli
+++ b/lib/keeper/keeper_exec_shared.mli
@@ -8,8 +8,7 @@ module StringMap : Map.S with type key = string
 val count_context_tokens : Keeper_types.working_context -> int
 
 (** Render an error JSON envelope: [{"error": <message>; ...fields}]. *)
-val error_json :
-  ?fields:(string * Yojson.Safe.t) list -> string -> string
+val error_json : ?fields:(string * Yojson.Safe.t) list -> string -> string
 
 (** [Tool_result.t] passes [msg] through on success; wraps it
     in [error_json] on failure. *)
@@ -17,73 +16,77 @@ val tool_result_or_error : Tool_result.t -> string
 
 (** Phase B PR-5 precursor: typed dispatch from the path error
     class to a concrete remediation hint. *)
-val actionable_path_action_for_class :
-  playground:string ->
-  raw_path:string ->
-  Keeper_failure_circuit_breaker.error_class ->
-  string
+val actionable_path_action_for_class
+  :  playground:string
+  -> raw_path:string
+  -> Keeper_failure_circuit_breaker.error_class
+  -> string
 
 (** Render the canonical path-rejection JSON envelope: classifies
     [error] via [Keeper_failure_circuit_breaker.classify_error]
     and routes to [actionable_path_action_for_class]. *)
-val actionable_path_error :
-  op:string ->
-  meta:Keeper_types.keeper_meta ->
-  raw_path:string ->
-  error:string ->
-  string
+val actionable_path_error
+  :  op:string
+  -> meta:Keeper_types.keeper_meta
+  -> raw_path:string
+  -> error:string
+  -> string
 
-val max_suggested_entries : int
 val file_not_found_prefix : string
 
-(** Render a missing-file JSON envelope with up-to-12 sibling
-    suggestions sourced from the closest existing parent. *)
-val missing_file_error_json :
-  config:Coord.config ->
-  target:string ->
-  fallback_dir:string ->
-  error:string ->
-  string
+(** Render a missing-file JSON envelope with the error and path.
+    #10349: directory entries are intentionally excluded to prevent
+    sandbox oracle leaks when keeper identity drifts. *)
+val missing_file_error_json
+  :  config:Coord.config
+  -> target:string
+  -> fallback_dir:string
+  -> error:string
+  -> string
 
 (** Lowercase + collapse whitespace + split on space + drop blanks. *)
 val lowercase_shell_words : string -> string list
 
 (** Replace the [`Assoc] field [key] with [`String value], moving
     it to the front. Non-assoc values pass through unchanged. *)
-val assoc_override_string :
-  string -> string -> Yojson.Safe.t -> Yojson.Safe.t
+val assoc_override_string : string -> string -> Yojson.Safe.t -> Yojson.Safe.t
 
 (** Re-export of [Keeper_alerting_path.effective_allowed_paths]. *)
-val keeper_effective_allowed_paths :
-  meta:Keeper_types.keeper_meta -> string list
+val keeper_effective_allowed_paths : meta:Keeper_types.keeper_meta -> string list
 
 (** Re-export of [Keeper_alerting_path.effective_write_allowed_paths]. *)
-val keeper_effective_write_allowed_paths :
-  meta:Keeper_types.keeper_meta -> string list
+val keeper_effective_write_allowed_paths : meta:Keeper_types.keeper_meta -> string list
 
 (** Sandbox playground root for [meta]; ensures the bundle dirs
     exist as a side effect. *)
-val keeper_playground_root :
-  config:Coord.config -> meta:Keeper_types.keeper_meta -> string
+val keeper_playground_root
+  :  config:Coord.config
+  -> meta:Keeper_types.keeper_meta
+  -> string
 
-val keeper_default_write_root :
-  config:Coord.config -> meta:Keeper_types.keeper_meta -> string
+val keeper_default_write_root
+  :  config:Coord.config
+  -> meta:Keeper_types.keeper_meta
+  -> string
 
-val keeper_default_read_root :
-  config:Coord.config -> meta:Keeper_types.keeper_meta -> string
+val keeper_default_read_root
+  :  config:Coord.config
+  -> meta:Keeper_types.keeper_meta
+  -> string
 
 val safe_file_exists : string -> bool
 val safe_is_dir : string -> bool
 
 (** Names of git-clone subdirectories under the keeper sandbox
     [repos/] lane. *)
-val keeper_sandbox_repo_names :
-  config:Coord.config -> meta:Keeper_types.keeper_meta -> string list
+val keeper_sandbox_repo_names
+  :  config:Coord.config
+  -> meta:Keeper_types.keeper_meta
+  -> string list
 
 (** [true] iff [raw] is a relative path that lies under one of the
     keeper's relative allowed_paths roots. *)
-val relative_path_targets_allowed_root :
-  meta:Keeper_types.keeper_meta -> string -> bool
+val relative_path_targets_allowed_root : meta:Keeper_types.keeper_meta -> string -> bool
 
 (** [true] iff [raw] starts with [mind] or [repos] (the canonical
     sandbox lanes for keeper-relative paths). *)
@@ -92,49 +95,50 @@ val is_playground_lane_relative_path : string -> bool
 (** Strip the keeper's legacy / sandbox playground prefix from
     [raw] when present, returning the rest (or ["."] for an empty
     rest). [None] otherwise. *)
-val strip_keeper_playground_prefix :
-  meta:Keeper_types.keeper_meta -> string -> string option
+val strip_keeper_playground_prefix
+  :  meta:Keeper_types.keeper_meta
+  -> string
+  -> string option
 
 (** [true] iff [raw] is a relative path whose first segment looks
     like a repo name (not a sandbox lane / project root marker). *)
-val repo_relative_path_candidate :
-  meta:Keeper_types.keeper_meta -> string -> bool
+val repo_relative_path_candidate : meta:Keeper_types.keeper_meta -> string -> bool
 
 (** Rewrite a repo-relative path to its sandbox-clone absolute
     form. Returns [Ok None] when no rewrite applies, [Ok (Some _)]
     on a successful rewrite, [Error _] on ambiguity. *)
-val rewrite_single_repo_relative_path :
-  config:Coord.config ->
-  meta:Keeper_types.keeper_meta ->
-  string ->
-  (string option, string) result
+val rewrite_single_repo_relative_path
+  :  config:Coord.config
+  -> meta:Keeper_types.keeper_meta
+  -> string
+  -> (string option, string) result
 
 (** Default-route a relative path under the keeper's playground
     unless it already targets an explicit allowed_paths root.
     Strips legacy/doubled playground prefixes, applies single-repo
     rewrite, then resolves. *)
-val playground_relative_unless_allowed_root :
-  config:Coord.config ->
-  meta:Keeper_types.keeper_meta ->
-  string ->
-  (string, string) result
+val playground_relative_unless_allowed_root
+  :  config:Coord.config
+  -> meta:Keeper_types.keeper_meta
+  -> string
+  -> (string, string) result
 
 (** Resolve a write target path: playground default + sandbox
     boundary check via [Keeper_alerting_path.resolve_keeper_target_path]. *)
-val resolve_keeper_path :
-  config:Coord.config ->
-  meta:Keeper_types.keeper_meta ->
-  raw_path:string ->
-  (string, string) result
+val resolve_keeper_path
+  :  config:Coord.config
+  -> meta:Keeper_types.keeper_meta
+  -> raw_path:string
+  -> (string, string) result
 
 (** Resolve a read target path: playground default + sandbox
     boundary check via [Keeper_alerting_path.resolve_keeper_read_path]
     (with missing-leaf fallback search). *)
-val resolve_keeper_read_path :
-  config:Coord.config ->
-  meta:Keeper_types.keeper_meta ->
-  raw_path:string ->
-  (string, string) result
+val resolve_keeper_read_path
+  :  config:Coord.config
+  -> meta:Keeper_types.keeper_meta
+  -> raw_path:string
+  -> (string, string) result
 
 val keeper_agent_sender : meta:Keeper_types.keeper_meta -> string
 
@@ -149,27 +153,24 @@ val shell_readonly_cat_max_bytes : Yojson.Safe.t -> int
 (** Project [text] to a JSON array of lines, capped by [limit]
     lines and [max_bytes] total payload. The omitted-tail line
     surfaces a hint for the LLM to narrow its search. *)
-val lines_to_json :
-  ?limit:int -> ?max_bytes:int -> string -> Yojson.Safe.t
+val lines_to_json : ?limit:int -> ?max_bytes:int -> string -> Yojson.Safe.t
 
 (** Build the [text_fallback] response for a voice agent that
     chose to emit text instead of audio. *)
-val keeper_text_fallback_json :
-  agent_id:string -> message:string -> Yojson.Safe.t
+val keeper_text_fallback_json : agent_id:string -> message:string -> Yojson.Safe.t
 
 (** Hook used by [Keeper_exec_tools] to dispatch into module-tagged
     sub-handlers. Default is a no-op fallback. *)
-val tag_dispatch_fn :
-  (config:Coord.config ->
-   agent_name:string ->
-   tag:Tool_dispatch.module_tag ->
-   name:string ->
-   args:Yojson.Safe.t ->
-   (bool * string) option)
-  ref
+val tag_dispatch_fn
+  : (config:Coord.config
+     -> agent_name:string
+     -> tag:Tool_dispatch.module_tag
+     -> name:string
+     -> args:Yojson.Safe.t
+     -> (bool * string) option)
+      ref
 
 (** Render the keeper-tools-list JSON envelope: tool names grouped
     by category (board / voice / coordination / shell / fs / memory
     / core). *)
-val keeper_tools_list_json :
-  meta:Keeper_types.keeper_meta -> string
+val keeper_tools_list_json : meta:Keeper_types.keeper_meta -> string

--- a/lib/keeper/keeper_run_tools.ml
+++ b/lib/keeper/keeper_run_tools.ml
@@ -54,6 +54,7 @@ let freeze (acc : hook_accumulator) : hook_outputs =
   ; out_requested_tool_names = acc.requested_tool_names
   ; out_receipt_tool_contract_result = acc.receipt_tool_contract_result
   }
+;;
 
 type tool_search_hit_partition =
   { visible_core_hits : (string * float) list
@@ -61,11 +62,8 @@ type tool_search_hit_partition =
   ; filtered_by_policy : int
   }
 
-let partition_tool_search_hits ~core ~core_always ~allowed ~retrieved
-    ~max_results =
-  let allowed =
-    allowed |> Keeper_tool_alias.expand_universe
-  in
+let partition_tool_search_hits ~core ~core_always ~allowed ~retrieved ~max_results =
+  let allowed = allowed |> Keeper_tool_alias.expand_universe in
   let allowed_set =
     let tbl = Hashtbl.create (List.length allowed) in
     List.iter (fun n -> Hashtbl.replace tbl n ()) allowed;
@@ -75,9 +73,7 @@ let partition_tool_search_hits ~core ~core_always ~allowed ~retrieved
   let allowed_retrieved =
     retrieved |> List.filter (fun (name, _) -> Hashtbl.mem allowed_set name)
   in
-  let is_core name =
-    List.mem name core || List.mem name core_always
-  in
+  let is_core name = List.mem name core || List.mem name core_always in
   let visible_core_hits =
     allowed_retrieved |> List.filter (fun (name, _) -> is_core name)
   in
@@ -90,6 +86,7 @@ let partition_tool_search_hits ~core ~core_always ~allowed ~retrieved
   ; discoverable_hits
   ; filtered_by_policy = List.length retrieved - List.length allowed_retrieved
   }
+;;
 
 (** Agent setup produced by Step 7.
 
@@ -151,9 +148,7 @@ let prepare_agent_setup
       ()
   : (agent_setup, Agent_sdk.Error.sdk_error) result
   =
-  let cascade_name_string =
-    Keeper_cascade_profile.runtime_name_to_string cascade_name
-  in
+  let cascade_name_string = Keeper_cascade_profile.runtime_name_to_string cascade_name in
   let ctx_snapshot = ctx_work in
   let agent_name = meta.agent_name in
   let acc : hook_accumulator =
@@ -163,23 +158,28 @@ let prepare_agent_setup
     ; completion_contract = Keeper_tool_disclosure.Allow_text_or_tool
     ; required_tool_use_seen = false
     ; keeper_surface_tool_used = false
-    ; discovered = Keeper_discovered_tools.create ~decay_turns:(begin
-        match Sys.getenv_opt "MASC_KEEPER_TOOL_DECAY_TURNS" with
-        | Some s ->
-          (match int_of_string_opt s with
-           | Some n -> max 1 n
-           | None ->
-             Log.Keeper.warn
-               "keeper: MASC_KEEPER_TOOL_DECAY_TURNS=%S is not a valid integer, using default 5"
-               s;
-             Prometheus.inc_counter
-               Keeper_metrics.metric_keeper_config_env_parse_failures
-               ~labels:[("var", "MASC_KEEPER_TOOL_DECAY_TURNS")]
-               ();
-             5)
-        | None -> 5
-      end)
-    ; tool_overlay = (match tool_overlay with Some r -> !r | None -> Agent_sdk.Tool_op.Keep_all)
+    ; discovered =
+        Keeper_discovered_tools.create
+          ~decay_turns:
+            (match Sys.getenv_opt "MASC_KEEPER_TOOL_DECAY_TURNS" with
+             | Some s ->
+               (match int_of_string_opt s with
+                | Some n -> max 1 n
+                | None ->
+                  Log.Keeper.warn
+                    "keeper: MASC_KEEPER_TOOL_DECAY_TURNS=%S is not a valid integer, \
+                     using default 5"
+                    s;
+                  Prometheus.inc_counter
+                    Keeper_metrics.metric_keeper_config_env_parse_failures
+                    ~labels:[ "var", "MASC_KEEPER_TOOL_DECAY_TURNS" ]
+                    ();
+                  5)
+             | None -> 5)
+    ; tool_overlay =
+        (match tool_overlay with
+         | Some r -> !r
+         | None -> Agent_sdk.Tool_op.Keep_all)
     ; tool_surface =
         { turn_lane = "text_only"
         ; tool_surface_class = "none"
@@ -244,7 +244,9 @@ let prepare_agent_setup
   let extend_turns_tool = Keeper_extend_turns.make ~agent_ref ~max_turns () in
   let tools = extend_turns_tool :: keeper_tools in
   let tool_usage_before =
-    Keeper_tool_disclosure.keeper_tool_usage_snapshot ~base_path:config.base_path ~keeper_name:meta.name
+    Keeper_tool_disclosure.keeper_tool_usage_snapshot
+      ~base_path:config.base_path
+      ~keeper_name:meta.name
   in
   let tool_index_config =
     { Agent_sdk.Tool_index.default_config with
@@ -254,9 +256,7 @@ let prepare_agent_setup
   let tool_entries = List.map tool_index_entry_of_tool keeper_tools in
   let search_index = Agent_sdk.Tool_index.build ~config:tool_index_config tool_entries in
   let load_preset_selection_context () =
-    let preset_names =
-      Keeper_tool_policy.keeper_preset_universe_tool_names meta
-    in
+    let preset_names = Keeper_tool_policy.keeper_preset_universe_tool_names meta in
     let preset_set = Hashtbl.create (List.length preset_names) in
     List.iter (fun n -> Hashtbl.replace preset_set n true) preset_names;
     let preset_tools =
@@ -266,12 +266,13 @@ let prepare_agent_setup
     in
     let progressive_tool_index_config =
       { Agent_sdk.Tool_index.default_config with
-        top_k = keeper_selection_bm25_prefilter_n }
+        top_k = keeper_selection_bm25_prefilter_n
+      }
     in
     let preset_tool_entries = List.map tool_index_entry_of_tool preset_tools in
-    (preset_tools,
-     Agent_sdk.Tool_index.build ~config:progressive_tool_index_config
-       preset_tool_entries)
+    ( preset_tools
+    , Agent_sdk.Tool_index.build ~config:progressive_tool_index_config preset_tool_entries
+    )
   in
   let oas_description_map =
     let tbl = Hashtbl.create (List.length keeper_tools) in
@@ -333,9 +334,7 @@ let prepare_agent_setup
             ~max_results
         in
         let raw_hit_count = List.length retrieved in
-        let matched_core_names =
-          List.map fst partition.visible_core_hits
-        in
+        let matched_core_names = List.map fst partition.visible_core_hits in
         let core_hit_count = List.length matched_core_names in
         let filtered_by_core = 0 in
         let new_discoveries = partition.discoverable_hits in
@@ -347,49 +346,46 @@ let prepare_agent_setup
           ~names:discovered_names;
         let masc_schemas = Keeper_exec_tools.masc_schemas_snapshot () in
         let result_json ~already_visible (name, score) =
-               let help_opt = Tool_help_registry.find_entry masc_schemas name in
-               let desc =
-                 match help_opt with
-                 | Some e -> `String e.short_description
-                 | None ->
-                   (match Hashtbl.find_opt oas_description_map name with
-                    | Some d -> `String d
-                    | None -> `Null)
-               in
-               let when_to_use =
-                 match help_opt with
-                 | Some e -> `String e.when_to_use
-                 | None -> `Null
-               in
-               let input_schema =
-                 match
-                   List.find_opt
-                     (fun (s : Masc_domain.tool_schema) -> s.name = name)
-                     masc_schemas
-                 with
-                 | Some s -> s.input_schema
-                 | None ->
-                   (match Hashtbl.find_opt oas_input_schema_map name with
-                    | Some j -> j
-                    | None -> `Null)
-               in
-               `Assoc
-                 [ "name", `String name
-                 ; "score", `Float score
-                 ; "description", desc
-                 ; "when_to_use", when_to_use
-                 ; "input_schema", input_schema
-                 ; "already_visible", `Bool already_visible
-                 ]
+          let help_opt = Tool_help_registry.find_entry masc_schemas name in
+          let desc =
+            match help_opt with
+            | Some e -> `String e.short_description
+            | None ->
+              (match Hashtbl.find_opt oas_description_map name with
+               | Some d -> `String d
+               | None -> `Null)
+          in
+          let when_to_use =
+            match help_opt with
+            | Some e -> `String e.when_to_use
+            | None -> `Null
+          in
+          let input_schema =
+            match
+              List.find_opt
+                (fun (s : Masc_domain.tool_schema) -> s.name = name)
+                masc_schemas
+            with
+            | Some s -> s.input_schema
+            | None ->
+              (match Hashtbl.find_opt oas_input_schema_map name with
+               | Some j -> j
+               | None -> `Null)
+          in
+          `Assoc
+            [ "name", `String name
+            ; "score", `Float score
+            ; "description", desc
+            ; "when_to_use", when_to_use
+            ; "input_schema", input_schema
+            ; "already_visible", `Bool already_visible
+            ]
         in
         let matched_core_results =
-          partition.visible_core_hits
-          |> List.map (result_json ~already_visible:true)
+          partition.visible_core_hits |> List.map (result_json ~already_visible:true)
         in
         let discovery_results =
-          List.map
-            (result_json ~already_visible:false)
-            new_discoveries
+          List.map (result_json ~already_visible:false) new_discoveries
         in
         let results = matched_core_results @ discovery_results in
         let hint =
@@ -454,7 +450,8 @@ let prepare_agent_setup
   in
   let allowed_exec_set =
     let base = Keeper_tool_policy.tool_name_set allowed_exec_names_with_aliases in
-    Keeper_tool_policy.StringSet.union base
+    Keeper_tool_policy.StringSet.union
+      base
       (Keeper_tool_policy.tool_name_set Keeper_tool_registry.core_always_tools)
   in
   let max_tools_per_turn =
@@ -462,9 +459,7 @@ let prepare_agent_setup
     then Keeper_config.keeper_retry_max_tools_per_turn ()
     else Keeper_config.keeper_max_tools_per_turn ()
   in
-  let visible_always_include_tools =
-    always_include_tools
-  in
+  let visible_always_include_tools = always_include_tools in
   (* Receipt refs: written sequentially after OAS execution, kept as refs
      because the facade (keeper_agent_run.ml) writes them post-run. *)
   let reported_tool_names_ref : string list ref = ref [] in
@@ -475,7 +470,9 @@ let prepare_agent_setup
   let receipt_turn_count_ref : int option ref = ref None in
   let receipt_model_used_ref : string option ref = ref None in
   let receipt_stop_reason_ref : string option ref = ref None in
-  let receipt_cascade_observation_ref : Cascade_legacy_runner.cascade_observation option ref =
+  let receipt_cascade_observation_ref
+    : Cascade_legacy_runner.cascade_observation option ref
+    =
     ref None
   in
   let receipt_response_text_present_ref = ref false in
@@ -488,13 +485,12 @@ let prepare_agent_setup
     | Some task_id ->
       let task_id = Keeper_id.Task_id.to_string task_id in
       let tasks =
-        try Coord.get_tasks_raw config
-        with
+        try Coord.get_tasks_raw config with
         | Eio.Cancel.Cancelled _ as e -> raise e
         | exn ->
           Prometheus.inc_counter
             Keeper_metrics.metric_keeper_task_load_failures
-            ~labels:[("keeper", meta.name); ("phase", "task_contract_load")]
+            ~labels:[ "keeper", meta.name; "phase", "task_contract_load" ]
             ();
           Log.Keeper.warn
             "keeper:%s failed to load current task contract for %s: %s"
@@ -503,15 +499,16 @@ let prepare_agent_setup
             (Printexc.to_string exn);
           []
       in
-      match
-        List.find_opt (fun (task : Masc_domain.task) -> String.equal task.id task_id)
-          tasks
-      with
-      | Some (task : Masc_domain.task) -> (
-        match task.contract with
-        | Some contract -> Keeper_types.dedupe_keep_order contract.required_tools
-        | None -> [])
-      | None -> []
+      (match
+         List.find_opt
+           (fun (task : Masc_domain.task) -> String.equal task.id task_id)
+           tasks
+       with
+       | Some (task : Masc_domain.task) ->
+         (match task.contract with
+          | Some contract -> Keeper_types.dedupe_keep_order contract.required_tools
+          | None -> [])
+       | None -> [])
   in
   let validate_allow_list ~turn raw =
     let raw = raw in
@@ -545,33 +542,40 @@ let prepare_agent_setup
     let repo_probe =
       fallback_repo_probe_tool_names
       |> List.find_opt (fun name ->
-           Keeper_tool_policy.StringSet.mem name universe_set
-           && Keeper_tool_policy.StringSet.mem name allowed_exec_set)
+        Keeper_tool_policy.StringSet.mem name universe_set
+        && Keeper_tool_policy.StringSet.mem name allowed_exec_set)
       |> Option.to_list
     in
     validate_allow_list ~turn (fallback_floor_tool_names @ repo_probe)
   in
-  let tool_gate_requested_for_turn
-      ~current_tool_choice ~is_last_turn ~allowed_tool_names =
+  let tool_gate_requested_for_turn ~current_tool_choice ~is_last_turn ~allowed_tool_names =
     let caller_requires_tools =
       match current_tool_choice with
       | Some (Agent_sdk.Types.Any | Agent_sdk.Types.Tool _) -> true
       | _ -> false
     in
     max_turns > 1
-    && not is_last_turn
+    && (not is_last_turn)
     && (caller_requires_tools
         || turn_affordances_require_tool_gate_with_allowed
-             ~record_suppression_metric:true ~allowed_tool_names turn_affordances)
+             ~record_suppression_metric:true
+             ~allowed_tool_names
+             turn_affordances)
   in
   let satisfied_required_tool_names () =
     acc.tool_calls
-    |> List.map (fun (detail : tool_call_detail) ->
-      detail.tool_name, detail.outcome)
+    |> List.map (fun (detail : tool_call_detail) -> detail.tool_name, detail.outcome)
     |> satisfied_required_tool_names_of_outcomes
   in
-  let compute_tool_surface ~turn ~messages ~current_tool_choice
-      ~decay_discovered ?(actionable_signal = false) () : computed_tool_surface =
+  let compute_tool_surface
+        ~turn
+        ~messages
+        ~current_tool_choice
+        ~decay_discovered
+        ?(actionable_signal = false)
+        ()
+    : computed_tool_surface
+    =
     let last_user_text =
       List.fold_left
         (fun acc (m : Agent_sdk.Types.message) ->
@@ -590,16 +594,12 @@ let prepare_agent_setup
       Keeper_exec_tools.effective_core_tools ()
       |> List.filter (fun name -> Keeper_tool_policy.StringSet.mem name allowed_exec_set)
     in
-    let discovered =
-      Keeper_discovered_tools.active_names acc.discovered ~turn
-    in
+    let discovered = Keeper_discovered_tools.active_names acc.discovered ~turn in
     let () =
       if decay_discovered then ignore (Keeper_discovered_tools.decay acc.discovered ~turn)
     in
     let selection_limit = min max_tools keeper_selection_top_k in
-    let preset_tools, preset_search_index =
-      load_preset_selection_context ()
-    in
+    let preset_tools, preset_search_index = load_preset_selection_context () in
     let deterministic_prefilter =
       Keeper_tool_disclosure.deterministic_prefilter_names
         ~search_index:preset_search_index
@@ -609,109 +609,114 @@ let prepare_agent_setup
     in
     let llm_rerank_enabled = Keeper_config.keeper_llm_rerank_enabled () in
     let llm_selected =
-      if llm_rerank_enabled then
-        (match Eio_context.get_switch_opt (), Eio_context.get_net_opt () with
-         | Some sw, Some net ->
-             let rerank_cascade =
-               Keeper_config.keeper_llm_rerank_cascade ()
-             in
-             (match
-                Cascade_catalog_runtime.resolve_named_providers_strict
-                  ~sw ~net
-                  ~cascade_name:rerank_cascade
-                  ()
-              with
-              | Error detail ->
-                  Prometheus.inc_counter
-                    Keeper_metrics.metric_keeper_tool_selection_failures
-                    ~labels:[("keeper", meta.name); ("phase", "cascade_resolve")]
-                    ();
-                  Log.Keeper.warn
-                    "keeper:%s TopK_llm: strict cascade resolution failed for '%s' (%s), falling back to core+prefilter+discovered"
-                    meta.name
-                    rerank_cascade
-                    detail;
-                  []
-              | Ok providers ->
-                  (match Cascade_config.filter_healthy_strict ~sw ~net providers with
-                   | Error rejection ->
-                       Prometheus.inc_counter
-                         Keeper_metrics.metric_keeper_tool_selection_failures
-                         ~labels:[("keeper", meta.name); ("phase", "cascade_health")]
-                         ();
-                       Log.Keeper.warn
-                         "keeper:%s TopK_llm: strict health filter rejected cascade '%s' (%s), falling back to core+prefilter+discovered"
-                         meta.name
-                         rerank_cascade
-                         (Cascade_config.health_filter_rejection_to_string rejection);
-                       []
-                   | Ok [] ->
-                       Prometheus.inc_counter
-                         Keeper_metrics.metric_keeper_tool_selection_failures
-                         ~labels:[("keeper", meta.name); ("phase", "cascade_no_provider")]
-                         ();
-                       Log.Keeper.warn
-                         "keeper:%s TopK_llm: no healthy provider for cascade '%s', falling back to core+prefilter+discovered"
-                         meta.name
-                         rerank_cascade;
-                       []
-                   | Ok (first_provider :: _) ->
-                       let rerank_fn =
-                         Agent_sdk.Tool_selector.default_rerank_fn
-                           ~sw
-                           ~net
-                           ~provider:first_provider
-                           ~k:selection_limit
-                           ()
-                       in
-                       let strategy =
-                         Agent_sdk.Tool_selector.TopK_llm
-                           { k = selection_limit
-                           ; bm25_prefilter_n =
-                               min
-                                 keeper_selection_bm25_prefilter_n
-                                 (List.length preset_tools)
-                           ; always_include = core
-                           ; confidence_threshold = 0.3
-                           ; rerank_fn
-                           }
-                       in
-                       (try
-                          let selected =
-                            Agent_sdk.Tool_selector.select_names
-                              ~strategy
-                              ~context:query_text
-                              ~tools:preset_tools
-                          in
-                          if Keeper_types_profile.keeper_debug then
-                            Log.Keeper.info
-                              "keeper:%s TopK_llm selected %d tools (query_len=%d, candidates=%d)"
-                              meta.name
-                              (List.length selected)
-                              (String.length query_text)
-                              (List.length preset_tools);
-                          selected
-                        with
-                        | Eio.Cancel.Cancelled _ as e -> raise e
-                        | exn ->
-                            Prometheus.inc_counter
-                              Keeper_metrics.metric_keeper_tool_selection_failures
-                              ~labels:[("keeper", meta.name); ("phase", "topk_llm")]
-                              ();
-                            Log.Keeper.warn
-                              "keeper:%s TopK_llm failed (%s), falling back to core+prefilter+discovered"
-                              meta.name
-                              (Printexc.to_string exn);
-                            [])))
-         | _ ->
-           Prometheus.inc_counter
-             Keeper_metrics.metric_keeper_tool_selection_failures
-             ~labels:[("keeper", meta.name); ("phase", "topk_llm_no_eio")]
-             ();
-           Log.Keeper.warn
-             "keeper:%s TopK_llm: Eio context unavailable, falling back to core+prefilter+discovered"
-             meta.name;
-           [])
+      if llm_rerank_enabled
+      then (
+        match Eio_context.get_switch_opt (), Eio_context.get_net_opt () with
+        | Some sw, Some net ->
+          let rerank_cascade = Keeper_config.keeper_llm_rerank_cascade () in
+          (match
+             Cascade_catalog_runtime.resolve_named_providers_strict
+               ~sw
+               ~net
+               ~cascade_name:rerank_cascade
+               ()
+           with
+           | Error detail ->
+             Prometheus.inc_counter
+               Keeper_metrics.metric_keeper_tool_selection_failures
+               ~labels:[ "keeper", meta.name; "phase", "cascade_resolve" ]
+               ();
+             Log.Keeper.warn
+               "keeper:%s TopK_llm: strict cascade resolution failed for '%s' (%s), \
+                falling back to core+prefilter+discovered"
+               meta.name
+               rerank_cascade
+               detail;
+             []
+           | Ok providers ->
+             (match Cascade_config.filter_healthy_strict ~sw ~net providers with
+              | Error rejection ->
+                Prometheus.inc_counter
+                  Keeper_metrics.metric_keeper_tool_selection_failures
+                  ~labels:[ "keeper", meta.name; "phase", "cascade_health" ]
+                  ();
+                Log.Keeper.warn
+                  "keeper:%s TopK_llm: strict health filter rejected cascade '%s' (%s), \
+                   falling back to core+prefilter+discovered"
+                  meta.name
+                  rerank_cascade
+                  (Cascade_config.health_filter_rejection_to_string rejection);
+                []
+              | Ok [] ->
+                Prometheus.inc_counter
+                  Keeper_metrics.metric_keeper_tool_selection_failures
+                  ~labels:[ "keeper", meta.name; "phase", "cascade_no_provider" ]
+                  ();
+                Log.Keeper.warn
+                  "keeper:%s TopK_llm: no healthy provider for cascade '%s', falling \
+                   back to core+prefilter+discovered"
+                  meta.name
+                  rerank_cascade;
+                []
+              | Ok (first_provider :: _) ->
+                let rerank_fn =
+                  Agent_sdk.Tool_selector.default_rerank_fn
+                    ~sw
+                    ~net
+                    ~provider:first_provider
+                    ~k:selection_limit
+                    ()
+                in
+                let strategy =
+                  Agent_sdk.Tool_selector.TopK_llm
+                    { k = selection_limit
+                    ; bm25_prefilter_n =
+                        min keeper_selection_bm25_prefilter_n (List.length preset_tools)
+                    ; always_include = core
+                    ; confidence_threshold = 0.3
+                    ; rerank_fn
+                    }
+                in
+                (try
+                   let selected =
+                     Agent_sdk.Tool_selector.select_names
+                       ~strategy
+                       ~context:query_text
+                       ~tools:preset_tools
+                   in
+                   if Keeper_types_profile.keeper_debug
+                   then
+                     Log.Keeper.info
+                       "keeper:%s TopK_llm selected %d tools (query_len=%d, \
+                        candidates=%d)"
+                       meta.name
+                       (List.length selected)
+                       (String.length query_text)
+                       (List.length preset_tools);
+                   selected
+                 with
+                 | Eio.Cancel.Cancelled _ as e -> raise e
+                 | exn ->
+                   Prometheus.inc_counter
+                     Keeper_metrics.metric_keeper_tool_selection_failures
+                     ~labels:[ "keeper", meta.name; "phase", "topk_llm" ]
+                     ();
+                   Log.Keeper.warn
+                     "keeper:%s TopK_llm failed (%s), falling back to \
+                      core+prefilter+discovered"
+                     meta.name
+                     (Printexc.to_string exn);
+                   [])))
+        | _ ->
+          Prometheus.inc_counter
+            Keeper_metrics.metric_keeper_tool_selection_failures
+            ~labels:[ "keeper", meta.name; "phase", "topk_llm_no_eio" ]
+            ();
+          Log.Keeper.warn
+            "keeper:%s TopK_llm: Eio context unavailable, falling back to \
+             core+prefilter+discovered"
+            meta.name;
+          [])
       else []
     in
     let merged =
@@ -720,7 +725,6 @@ let prepare_agent_setup
         ~deterministic_prefilter
         ~llm_selected
         ~discovered
-
     in
     let required_tool_names_raw =
       required_tool_names_for_turn
@@ -737,15 +741,11 @@ let prepare_agent_setup
     let current_tool_choice =
       match current_tool_choice with
       | Some (Agent_sdk.Types.Any | Agent_sdk.Types.Tool _)
-        when required_tool_names_raw <> [] && required_tool_names = [] ->
-        None
+        when required_tool_names_raw <> [] && required_tool_names = [] -> None
       | _ -> current_tool_choice
     in
     let visible_required_tool_names =
-      required_tool_names
-
-      |> validate_allow_list ~turn
-      |> Keeper_types.dedupe_keep_order
+      required_tool_names |> validate_allow_list ~turn |> Keeper_types.dedupe_keep_order
     in
     let visible_affordance_tool_names =
       preferred_tool_names_for_turn_affordances turn_affordances
@@ -767,16 +767,12 @@ let prepare_agent_setup
     in
     let llm_only_count =
       List.length
-        (List.filter
-           (fun n -> not (List.mem n deterministic_floor_set))
-           llm_selected)
+        (List.filter (fun n -> not (List.mem n deterministic_floor_set)) llm_selected)
     in
     let all_allowed =
       Agent_sdk.Tool_op.apply
         (Agent_sdk.Tool_op.compose
-           [ Agent_sdk.Tool_op.Replace_with merged
-           ; acc.tool_overlay
-           ])
+           [ Agent_sdk.Tool_op.Replace_with merged; acc.tool_overlay ])
         all_tool_names
       |> validate_allow_list ~turn
     in
@@ -788,23 +784,22 @@ let prepare_agent_setup
     let is_last_turn = per_call_turn >= max_turns in
     let is_warning_zone = per_call_turn >= max_turns - 1 in
     let all_allowed, tool_surface_fallback_used =
-      if all_allowed = [] then
+      if all_allowed = []
+      then (
         let fallback_allowed = fallback_tool_surface ~turn in
-        if fallback_allowed <> [] then fallback_allowed, true else all_allowed, false
-      else
-        all_allowed, false
+        if fallback_allowed <> [] then fallback_allowed, true else all_allowed, false)
+      else all_allowed, false
     in
     let safe_last_turn_tools =
-      Keeper_tool_policy.last_turn_safe_tool_names ()
-      |> Keeper_tool_alias.expand_universe
+      Keeper_tool_policy.last_turn_safe_tool_names () |> Keeper_tool_alias.expand_universe
     in
     let all_allowed =
-      if is_last_turn && required_tool_names = [] then
+      if is_last_turn && required_tool_names = []
+      then
         Agent_sdk.Tool_op.apply
           (Agent_sdk.Tool_op.Intersect_with safe_last_turn_tools)
           all_allowed
-      else
-        all_allowed
+      else all_allowed
     in
     let all_allowed =
       let passive_streak =
@@ -818,29 +813,35 @@ let prepare_agent_setup
     in
     let tool_gate_requested =
       required_tool_names <> []
-      || tool_gate_requested_for_turn ~current_tool_choice ~is_last_turn
+      || tool_gate_requested_for_turn
+           ~current_tool_choice
+           ~is_last_turn
            ~allowed_tool_names:all_allowed
     in
     let all_allowed =
       tool_names_for_required_gate_surface
-        ~tool_gate_requested ~required_tool_names all_allowed
+        ~tool_gate_requested
+        ~required_tool_names
+        all_allowed
     in
     let all_allowed =
-      if List.length all_allowed > max_tools then (
+      if List.length all_allowed > max_tools
+      then (
         Log.Keeper.info
           "context overflow guard: %d tools > max %d, truncating"
           (List.length all_allowed)
           max_tools;
         let required_turn_essential_tool_names =
-          if required_tool_names <> [] then visible_required_tool_names
-          else if tool_gate_requested then
+          if required_tool_names <> []
+          then visible_required_tool_names
+          else if tool_gate_requested
+          then (
             let claim_tools =
               if has_task_claim_affordance turn_affordances
               then [ "keeper_task_claim" ]
               else []
             in
-            Keeper_types.dedupe_keep_order
-              (visible_affordance_tool_names @ claim_tools)
+            Keeper_types.dedupe_keep_order (visible_affordance_tool_names @ claim_tools))
           else []
         in
         let essential_names =
@@ -857,36 +858,37 @@ let prepare_agent_setup
         in
         let budget = max_tools - List.length essential in
         essential @ List.filteri (fun i _ -> i < budget) non_essential)
-      else
-        all_allowed
+      else all_allowed
     in
     let missing_required_tool_names =
-      List.filter
-        (fun name -> not (List.mem name all_allowed))
-        required_tool_names
+      List.filter (fun name -> not (List.mem name all_allowed)) required_tool_names
     in
     let visible_tool_count = List.length all_allowed in
     let tool_surface_class =
-      if visible_tool_count = 0 then "none"
-      else if List.for_all Tool_catalog.is_public_mcp all_allowed then
-        "public_only"
-      else
-        "mixed"
+      if visible_tool_count = 0
+      then "none"
+      else if List.for_all Tool_catalog.is_public_mcp all_allowed
+      then "public_only"
+      else "mixed"
     in
     let tool_requirement =
-      if visible_tool_count = 0 then No_tools
-      else if tool_gate_requested then Required
+      if visible_tool_count = 0
+      then No_tools
+      else if tool_gate_requested
+      then Required
       else Optional
     in
     let lane =
-      if is_retry then "retry"
-      else match tool_requirement with
+      if is_retry
+      then "retry"
+      else (
+        match tool_requirement with
         | Required -> "tool_required"
         | Optional -> "tool_optional"
         | No_tools ->
-            (match current_tool_choice with
-             | Some Agent_sdk.Types.None_ -> "tool_disabled"
-             | _ -> "text_only")
+          (match current_tool_choice with
+           | Some Agent_sdk.Types.None_ -> "tool_disabled"
+           | _ -> "text_only"))
     in
     { all_allowed
     ; absolute_turn = turn
@@ -919,205 +921,206 @@ let prepare_agent_setup
       ~actionable_signal
       ()
   in
-  acc.tool_surface <-
-    { turn_lane = initial_tool_surface.lane
-    ; tool_surface_class = initial_tool_surface.tool_surface_class
-    ; tool_requirement = initial_tool_surface.tool_requirement
-    ; visible_tool_count = List.length initial_tool_surface.all_allowed
-    ; tool_gate_enabled = initial_tool_surface.tool_gate_requested
-    ; tool_surface_fallback_used = initial_tool_surface.tool_surface_fallback_used
-    ; required_tool_names = initial_tool_surface.required_tool_names
-    ; missing_required_tool_names =
-        initial_tool_surface.missing_required_tool_names
-    ; config_root
-    ; cascade_config_path
-    ; gemini_mcp_disabled
-    ; approval_mode_effective
-    ; approval_mode_derived
-    };
+  acc.tool_surface
+  <- { turn_lane = initial_tool_surface.lane
+     ; tool_surface_class = initial_tool_surface.tool_surface_class
+     ; tool_requirement = initial_tool_surface.tool_requirement
+     ; visible_tool_count = List.length initial_tool_surface.all_allowed
+     ; tool_gate_enabled = initial_tool_surface.tool_gate_requested
+     ; tool_surface_fallback_used = initial_tool_surface.tool_surface_fallback_used
+     ; required_tool_names = initial_tool_surface.required_tool_names
+     ; missing_required_tool_names = initial_tool_surface.missing_required_tool_names
+     ; config_root
+     ; cascade_config_path
+     ; gemini_mcp_disabled
+     ; approval_mode_effective
+     ; approval_mode_derived
+     };
   let initial_tool_surface_blocker = ref None in
   let initial_tool_surface_result =
-    if initial_tool_surface.missing_required_tool_names <> [] then (
+    if initial_tool_surface.missing_required_tool_names <> []
+    then (
       acc.receipt_tool_contract_result <- "tool_surface_mismatch";
-      initial_tool_surface_blocker :=
-        Some
-          (sdk_error_of_keeper_internal_error
-             (Keeper_tool_surface_mismatch
-                { keeper_name = meta.name
-                ; required_tools = initial_tool_surface.required_tool_names
-                ; missing_required_tools =
-                    initial_tool_surface.missing_required_tool_names
-                ; visible_tools = initial_tool_surface.all_allowed
-                }));
+      initial_tool_surface_blocker
+      := Some
+           (sdk_error_of_keeper_internal_error
+              (Keeper_tool_surface_mismatch
+                 { keeper_name = meta.name
+                 ; required_tools = initial_tool_surface.required_tool_names
+                 ; missing_required_tools =
+                     initial_tool_surface.missing_required_tool_names
+                 ; visible_tools = initial_tool_surface.all_allowed
+                 }));
       Ok initial_tool_surface)
-    else if initial_tool_surface.tool_gate_requested
-            && initial_tool_surface.all_allowed = []
+    else if
+      initial_tool_surface.tool_gate_requested && initial_tool_surface.all_allowed = []
     then (
       acc.receipt_tool_contract_result <- "no_tool_capable_provider";
       Prometheus.inc_counter
         Prometheus.metric_empty_tool_universe_observed
         ~labels:
-          [ ("keeper_name", meta.name);
-            ("turn_lane", initial_tool_surface.lane);
-            ( "fallback_used",
-              string_of_bool initial_tool_surface.tool_surface_fallback_used );
+          [ "keeper_name", meta.name
+          ; "turn_lane", initial_tool_surface.lane
+          ; ( "fallback_used"
+            , string_of_bool initial_tool_surface.tool_surface_fallback_used )
           ]
         ();
-      initial_tool_surface_blocker :=
-        Some
-          (sdk_error_of_keeper_internal_error
-             (Keeper_tool_surface_empty
-                { keeper_name = meta.name
-                ; turn_lane = initial_tool_surface.lane
-                ; affordances = turn_affordances
-                ; fallback_used = initial_tool_surface.tool_surface_fallback_used
-                }));
+      initial_tool_surface_blocker
+      := Some
+           (sdk_error_of_keeper_internal_error
+              (Keeper_tool_surface_empty
+                 { keeper_name = meta.name
+                 ; turn_lane = initial_tool_surface.lane
+                 ; affordances = turn_affordances
+                 ; fallback_used = initial_tool_surface.tool_surface_fallback_used
+                 }));
       Ok initial_tool_surface)
-    else
-      Ok initial_tool_surface
+    else Ok initial_tool_surface
   in
   match initial_tool_surface_result with
   | Error err -> Error err
   | Ok initial_tool_surface ->
-  acc.requested_tool_names <- initial_tool_surface.all_allowed;
-  let discover_work_nudge () : string option =
-    let meta = acc.meta in
-    match meta.work_discovery_enabled with
-    | Some false -> None
-    | _ ->
-      let interval =
-        Option.value ~default:600 meta.work_discovery_interval_sec in
-      let since_last =
-        Time_compat.now ()
-        -. meta.runtime.proactive_rt.last_work_discovery_ts
-      in
-      if since_last < float_of_int interval then None
-      else
-        let sources =
-          Option.value ~default:[] meta.work_discovery_sources in
-        let chunks =
-          List.filter_map
-            (fun src ->
-               match src with
-               | "stale_tasks" | "unclaimed_tasks" ->
-                 (try
-                    let backlog = Coord.read_backlog config in
-                    let unclaimed =
-                      List.filter
-                        (fun (t : Masc_domain.task) ->
-                          t.task_status = Masc_domain.Todo)
-                        backlog.tasks
-                    in
-                    match unclaimed with
-                    | [] -> None
-                    | tasks ->
-                      let n = min 5 (List.length tasks) in
-                      let preview =
-                        List.filteri (fun i _ -> i < n) tasks
-                        |> List.map (fun (t : Masc_domain.task) ->
-                             Printf.sprintf "  - %s (p%d): %s"
-                               t.id t.priority
-                               (String_util.utf8_safe
-                                  ~max_bytes:83 ~suffix:"…" t.title
-                                |> String_util.to_string))
-                        |> String.concat "\n"
+    acc.requested_tool_names <- initial_tool_surface.all_allowed;
+    let discover_work_nudge () : string option =
+      let meta = acc.meta in
+      match meta.work_discovery_enabled with
+      | Some false -> None
+      | _ ->
+        let interval = Option.value ~default:600 meta.work_discovery_interval_sec in
+        let since_last =
+          Time_compat.now () -. meta.runtime.proactive_rt.last_work_discovery_ts
+        in
+        if since_last < float_of_int interval
+        then None
+        else (
+          let sources = Option.value ~default:[] meta.work_discovery_sources in
+          let chunks =
+            List.filter_map
+              (fun src ->
+                 match src with
+                 | "stale_tasks" | "unclaimed_tasks" ->
+                   (try
+                      let backlog = Coord.read_backlog config in
+                      let unclaimed =
+                        List.filter
+                          (fun (t : Masc_domain.task) -> t.task_status = Masc_domain.Todo)
+                          backlog.tasks
                       in
-                      Some (Printf.sprintf
-                        "**Unclaimed tasks (%d total, showing %d):**\n%s"
-                        (List.length tasks) n preview)
-                  with
-                  | Eio.Cancel.Cancelled _ as e -> raise e
-                  | exn ->
-                    Keeper_callback_failure.record
-                      ~base_dir:config.base_path
-                      ~meta
-                      ~callback:"work_discovery_nudge"
-                      exn;
-                    None)
-               | _ -> None)
-            sources
-        in
-        let guidance_section =
-          match meta.work_discovery_guidance with
-          | Some g when String.trim g <> "" ->
-            Some (Printf.sprintf "**Operator guidance:** %s" (String.trim g))
-          | _ -> None
-        in
-        let sections =
-          chunks
-          @ (match guidance_section with Some s -> [s] | None -> [])
-        in
-        let active_schema_guard =
-          "Use only tool schemas currently shown by the runtime. If an \
-           execution tool is absent from the active schema list, do not name \
-           or call it; emit [STATE] or use a visible handoff/status tool."
-        in
-        let unknown_tool_guard =
-          Keeper_tool_guidance.render_unknown_tool_guard ()
-        in
-        (match sections with
-         | [] -> None
-         | _ ->
-           Some (Printf.sprintf
-             "## Discovered Work (auto, %ds interval)\n\n%s\n\n\
-              ### Use the smallest real action now\n\
-              %s\n\n\
-              %s\n\n\
-              Do not print fenced pseudo-calls. Pick the smallest viable \
-              action and emit one or more structured tool calls now."
-             interval (String.concat "\n\n" sections) active_schema_guard
-             unknown_tool_guard))
-  in
-  let meta_ref = ref acc.meta in
-  let base_hooks =
-    Keeper_hooks_oas.make_hooks
-      ~config
-      ~meta_ref
-      ~generation
-      ?max_cost_usd
-      ?trajectory_acc
-      ~on_tool_executed:(fun
-          ~tool_name
-          ~input
-          ~output_text
-          ~success
-          ~duration_ms
-          ~provider ->
-        let route_evidence =
-          Keeper_tool_call_log.route_evidence_json_of_tool_io
-            ~tool_name
-            ~input
-            ~output_text
-        in
-        (match Keeper_registry.get ~base_path:config.base_path meta.name with
-         | Some entry ->
-           acc.meta <- entry.meta;
-           meta_ref := entry.meta
-         | None -> ());
-        acc.tool_calls <-
-          { tool_name
-          ; provider
-          ; outcome = if success then "ok" else "error"
-          ; latency_ms = duration_ms
-          ; route_evidence
-          }
-          :: acc.tool_calls)
-      ~discover_work_nudge
-      ~passive_loop_nudge:(fun () ->
-        Keeper_passive_loop_detector.nudge_message ~keeper_name:acc.meta.name)
-      ()
-  in
-  let before_turn_hook : Agent_sdk.Hooks.hooks =
-    { Agent_sdk.Hooks.empty with
-      before_turn_params =
-        Some
-          (fun event ->
-             match event with
-             | Agent_sdk.Hooks.BeforeTurnParams
-                 { turn; current_params; messages; last_tool_results; _ } ->
-               let hook_t0 = Time_compat.now () in
-               acc.current_turn <- turn;
-               (* RFC-0045: signal an SDK-turn boundary so the in-turn FSM
+                      match unclaimed with
+                      | [] -> None
+                      | tasks ->
+                        let n = min 5 (List.length tasks) in
+                        let preview =
+                          List.filteri (fun i _ -> i < n) tasks
+                          |> List.map (fun (t : Masc_domain.task) ->
+                            Printf.sprintf
+                              "  - %s (p%d): %s"
+                              t.id
+                              t.priority
+                              (String_util.utf8_safe ~max_bytes:83 ~suffix:"…" t.title
+                               |> String_util.to_string))
+                          |> String.concat "\n"
+                        in
+                        Some
+                          (Printf.sprintf
+                             "**Unclaimed tasks (%d total, showing %d):**\n%s"
+                             (List.length tasks)
+                             n
+                             preview)
+                    with
+                    | Eio.Cancel.Cancelled _ as e -> raise e
+                    | exn ->
+                      Keeper_callback_failure.record
+                        ~base_dir:config.base_path
+                        ~meta
+                        ~callback:"work_discovery_nudge"
+                        exn;
+                      None)
+                 | _ -> None)
+              sources
+          in
+          let guidance_section =
+            match meta.work_discovery_guidance with
+            | Some g when String.trim g <> "" ->
+              Some (Printf.sprintf "**Operator guidance:** %s" (String.trim g))
+            | _ -> None
+          in
+          let sections =
+            chunks
+            @
+            match guidance_section with
+            | Some s -> [ s ]
+            | None -> []
+          in
+          let active_schema_guard =
+            "Use only tool schemas currently shown by the runtime. If an execution tool \
+             is absent from the active schema list, do not name or call it; emit [STATE] \
+             or use a visible handoff/status tool."
+          in
+          let unknown_tool_guard = Keeper_tool_guidance.render_unknown_tool_guard () in
+          match sections with
+          | [] -> None
+          | _ ->
+            Some
+              (Printf.sprintf
+                 "## Discovered Work (auto, %ds interval)\n\n\
+                  %s\n\n\
+                  ### Use the smallest real action now\n\
+                  %s\n\n\
+                  %s\n\n\
+                  Do not print fenced pseudo-calls. Pick the smallest viable action and \
+                  emit one or more structured tool calls now."
+                 interval
+                 (String.concat "\n\n" sections)
+                 active_schema_guard
+                 unknown_tool_guard))
+    in
+    let meta_ref = ref acc.meta in
+    let base_hooks =
+      Keeper_hooks_oas.make_hooks
+        ~config
+        ~meta_ref
+        ~generation
+        ?max_cost_usd
+        ?trajectory_acc
+        ~on_tool_executed:
+          (fun
+            ~tool_name ~input ~output_text ~success ~duration_ms ~provider ->
+          let route_evidence =
+            Keeper_tool_call_log.route_evidence_json_of_tool_io
+              ~tool_name
+              ~input
+              ~output_text
+          in
+          (match Keeper_registry.get ~base_path:config.base_path meta.name with
+           | Some entry ->
+             acc.meta <- entry.meta;
+             meta_ref := entry.meta
+           | None -> ());
+          acc.tool_calls
+          <- { tool_name
+             ; provider
+             ; outcome = (if success then "ok" else "error")
+             ; latency_ms = duration_ms
+             ; route_evidence
+             }
+             :: acc.tool_calls)
+        ~discover_work_nudge
+        ~passive_loop_nudge:(fun () ->
+          Keeper_passive_loop_detector.nudge_message ~keeper_name:acc.meta.name)
+        ()
+    in
+    let before_turn_hook : Agent_sdk.Hooks.hooks =
+      { Agent_sdk.Hooks.empty with
+        before_turn_params =
+          Some
+            (fun event ->
+              match event with
+              | Agent_sdk.Hooks.BeforeTurnParams
+                  { turn; current_params; messages; last_tool_results; _ } ->
+                let hook_t0 = Time_compat.now () in
+                acc.current_turn <- turn;
+                (* RFC-0045: signal an SDK-turn boundary so the in-turn FSM
                   fields ([turn_phase], [cascade_state], [decision_stage])
                   are reset before the hook writes [Cascade_selecting] /
                   [Decision_tool_policy_selected] / [Turn_prompting] below.
@@ -1126,336 +1129,339 @@ let prepare_agent_setup
                   SDK turn inside that loop must use this entry point or
                   [validate_turn_phase_transition] rejects the transition
                   from the previous SDK turn's [Turn_finalizing] terminal. *)
-               Keeper_registry.mark_sdk_turn_started
-                 ~base_path:config.base_path meta.name;
-               let intent =
-                 if Keeper_config.keeper_adaptive_thinking_mode () then
-                   let last_tool_calls =
-                     let rev = List.rev messages in
-                     let rec scan = function
-                       | [] -> []
-                       | (msg : Agent_sdk.Types.message) :: rest ->
-                         let names =
-                           List.filter_map
-                             (function
-                               | Agent_sdk.Types.ToolUse { name; _ } -> Some name
-                               | _ -> None)
-                             msg.content
-                         in
-                         if names <> [] then names else scan rest
-                     in
-                     scan rev
-                   in
-                   let retry_count = if is_retry then 1 else 0 in
-                   Some
-                     (Keeper_turn_intent.classify
-                        ~last_tool_calls
-                        ~last_user_message:(Some user_message)
-                        ~retry_count)
-                 else
-                   None
-               in
-               let cascade_seed =
-                 Cascade_inference.for_cascade ~name:cascade_name_string
-               in
-               let current_budget =
-                 match cascade_seed.thinking_budget with
-                 | Some _ as v -> v
-                 | None -> current_params.thinking_budget
-               in
-               let adaptive_thinking_budget =
-                 adaptive_thinking_budget
-                   ~enabled:(Keeper_config.keeper_adaptive_thinking_enabled ())
-                   ~is_retry
-                   ~last_tool_results
-                   ~user_message
-                   ~dynamic_context
-                   ~current_budget
-                   ~intent
-               in
-               let adaptive_thinking_override =
-                 match intent with
-                 | Some i ->
-                   Some (Keeper_turn_intent.equal i Keeper_turn_intent.Cognitive)
-                 | None -> None
-               in
-               let current_params =
-                 { current_params with
-                   thinking_budget = adaptive_thinking_budget
-                 ; enable_thinking =
-                     (match cascade_seed.thinking_enabled with
-                      | Some false -> Some false
-                      | _ ->
-                        match adaptive_thinking_override with
-                        | Some _ as v -> v
-                        | None -> current_params.enable_thinking)
-                 }
-               in
-               let ctx =
-                 if String.trim dynamic_context = ""
-                 then current_params.extra_system_context
-                 else (
-                   match current_params.extra_system_context with
-                   | None -> Some dynamic_context
-                   | Some existing -> Some (existing ^ "\n\n" ^ dynamic_context))
-               in
-               let ctx =
-                 match Masc_context_injector.render_temporal_summary shared_context with
-                 | None -> ctx
-                 | Some temporal ->
-                   (match ctx with
-                    | None -> Some temporal
-                    | Some existing -> Some (existing ^ "\n\n" ^ temporal))
-               in
-               let ctx =
-                 match acc.meta.current_task_id with
-                 | Some task_id ->
-                     let last_tool_names =
-                       let rev = List.rev messages in
-                       let rec scan = function
-                         | [] -> []
-                         | (msg : Agent_sdk.Types.message) :: rest ->
-                           let names =
-                             List.filter_map
-                               (function
-                                 | Agent_sdk.Types.ToolUse { name; _ } -> Some name
-                                 | _ -> None)
-                               msg.content
-                           in
-                           if names <> [] then names else scan rest
-                       in
-                       scan rev
-                     in
-                     let is_claim_only_turn =
-                       List.exists is_claim_tool_name last_tool_names
-                       && List.for_all is_claim_context_tool_name last_tool_names
-                     in
-                     if is_claim_only_turn then
-                       let nudge =
-                         Printf.sprintf
-                           "[CLAIMED TASK] You hold %s. Do NOT call claim_next again. \
-                            Use an execution tool visible in your active runtime schema \
-                            to start working on it now. If no execution tool is visible, \
-                            emit [STATE] with the blocker instead of inventing a tool \
-                            name."
-                           (Keeper_id.Task_id.to_string task_id)
-                       in
-                       (match ctx with
-                        | None -> Some nudge
-                        | Some existing -> Some (existing ^ "\n\n" ^ nudge))
-                     else
-                       ctx
-                 | None -> ctx
-               in
-               let computed_surface =
-                 compute_tool_surface
-                   ~turn
-                   ~messages
-                   ~current_tool_choice:current_params.tool_choice
-                   ~decay_discovered:true
-                   ~actionable_signal
-                   ()
-               in
-               if Keeper_types_profile.keeper_debug
-               then
-                 Log.Keeper.info
-                   "tool_disclosure keeper=%s core=%d deterministic_prefilter=%d \
-                    discovered=%d llm_selected=%d llm_rerank=%b allowed=%d query_len=%d \
-                    mode=%s"
-                   meta.name
-                   computed_surface.core_count
-                   computed_surface.deterministic_prefilter_count
-                   computed_surface.discovered_count
-                   computed_surface.llm_selected_count
-                   (Keeper_config.keeper_llm_rerank_enabled ())
-                   (List.length computed_surface.all_allowed)
-                   (String.length computed_surface.query_text)
-                   computed_surface.selection_mode;
-               let append_ctx ctx text =
-                 Some
-                   (match ctx with
-                    | None -> text
-                    | Some e -> e ^ "\n\n" ^ text)
-               in
-               let ctx =
-                 if computed_surface.is_last_turn
+                Keeper_registry.mark_sdk_turn_started
+                  ~base_path:config.base_path
+                  meta.name;
+                let intent =
+                  if Keeper_config.keeper_adaptive_thinking_mode ()
+                  then (
+                    let last_tool_calls =
+                      let rev = List.rev messages in
+                      let rec scan = function
+                        | [] -> []
+                        | (msg : Agent_sdk.Types.message) :: rest ->
+                          let names =
+                            List.filter_map
+                              (function
+                                | Agent_sdk.Types.ToolUse { name; _ } -> Some name
+                                | _ -> None)
+                              msg.content
+                          in
+                          if names <> [] then names else scan rest
+                      in
+                      scan rev
+                    in
+                    let retry_count = if is_retry then 1 else 0 in
+                    Some
+                      (Keeper_turn_intent.classify
+                         ~last_tool_calls
+                         ~last_user_message:(Some user_message)
+                         ~retry_count))
+                  else None
+                in
+                let cascade_seed =
+                  Cascade_inference.for_cascade ~name:cascade_name_string
+                in
+                let current_budget =
+                  match cascade_seed.thinking_budget with
+                  | Some _ as v -> v
+                  | None -> current_params.thinking_budget
+                in
+                let adaptive_thinking_budget =
+                  adaptive_thinking_budget
+                    ~enabled:(Keeper_config.keeper_adaptive_thinking_enabled ())
+                    ~is_retry
+                    ~last_tool_results
+                    ~user_message
+                    ~dynamic_context
+                    ~current_budget
+                    ~intent
+                in
+                let adaptive_thinking_override =
+                  match intent with
+                  | Some i ->
+                    Some (Keeper_turn_intent.equal i Keeper_turn_intent.Cognitive)
+                  | None -> None
+                in
+                let current_params =
+                  { current_params with
+                    thinking_budget = adaptive_thinking_budget
+                  ; enable_thinking =
+                      (match cascade_seed.thinking_enabled with
+                       | Some false -> Some false
+                       | _ ->
+                         (match adaptive_thinking_override with
+                          | Some _ as v -> v
+                          | None -> current_params.enable_thinking))
+                  }
+                in
+                let ctx =
+                  if String.trim dynamic_context = ""
+                  then current_params.extra_system_context
+                  else (
+                    match current_params.extra_system_context with
+                    | None -> Some dynamic_context
+                    | Some existing -> Some (existing ^ "\n\n" ^ dynamic_context))
+                in
+                let ctx =
+                  match Masc_context_injector.render_temporal_summary shared_context with
+                  | None -> ctx
+                  | Some temporal ->
+                    (match ctx with
+                     | None -> Some temporal
+                     | Some existing -> Some (existing ^ "\n\n" ^ temporal))
+                in
+                let ctx =
+                  match acc.meta.current_task_id with
+                  | Some task_id ->
+                    let last_tool_names =
+                      let rev = List.rev messages in
+                      let rec scan = function
+                        | [] -> []
+                        | (msg : Agent_sdk.Types.message) :: rest ->
+                          let names =
+                            List.filter_map
+                              (function
+                                | Agent_sdk.Types.ToolUse { name; _ } -> Some name
+                                | _ -> None)
+                              msg.content
+                          in
+                          if names <> [] then names else scan rest
+                      in
+                      scan rev
+                    in
+                    let is_claim_only_turn =
+                      List.exists is_claim_tool_name last_tool_names
+                      && List.for_all is_claim_context_tool_name last_tool_names
+                    in
+                    if is_claim_only_turn
+                    then (
+                      let nudge =
+                        Printf.sprintf
+                          "[CLAIMED TASK] You hold %s. Do NOT call claim_next again. Use \
+                           an execution tool visible in your active runtime schema to \
+                           start working on it now. If no execution tool is visible, \
+                           emit [STATE] with the blocker instead of inventing a tool \
+                           name."
+                          (Keeper_id.Task_id.to_string task_id)
+                      in
+                      match ctx with
+                      | None -> Some nudge
+                      | Some existing -> Some (existing ^ "\n\n" ^ nudge))
+                    else ctx
+                  | None -> ctx
+                in
+                let computed_surface =
+                  compute_tool_surface
+                    ~turn
+                    ~messages
+                    ~current_tool_choice:current_params.tool_choice
+                    ~decay_discovered:true
+                    ~actionable_signal
+                    ()
+                in
+                if Keeper_types_profile.keeper_debug
+                then
+                  Log.Keeper.info
+                    "tool_disclosure keeper=%s core=%d deterministic_prefilter=%d \
+                     discovered=%d llm_selected=%d llm_rerank=%b allowed=%d query_len=%d \
+                     mode=%s"
+                    meta.name
+                    computed_surface.core_count
+                    computed_surface.deterministic_prefilter_count
+                    computed_surface.discovered_count
+                    computed_surface.llm_selected_count
+                    (Keeper_config.keeper_llm_rerank_enabled ())
+                    (List.length computed_surface.all_allowed)
+                    (String.length computed_surface.query_text)
+                    computed_surface.selection_mode;
+                let append_ctx ctx text =
+                  Some
+                    (match ctx with
+                     | None -> text
+                     | Some e -> e ^ "\n\n" ^ text)
+                in
+                let ctx =
+                  if
+                    computed_surface.is_last_turn
                     && computed_surface.required_tool_names <> []
-                 then
-                   append_ctx
-                     ctx
-                     (Printf.sprintf
-                        "[REQUIRED TOOLS - FINAL TURN] This Agent.run call is on \
-                         its final turn, but this message has explicit \
-                                 required_tools: %s. You MUST either use every \
-                                 required tool now or return a concise blocker naming \
-                         the missing policy/tool/runtime condition."
-                        (String.concat ", " computed_surface.required_tool_names))
-                 else if computed_surface.is_last_turn
-                 then
-                   append_ctx
-                     ctx
-                     (Printf.sprintf
-                        "[LAST TURN] Per-call turn %d/%d. This is your final turn in this \
-                         Agent.run call. You MUST emit a \
-                         [STATE]...[/STATE] block now summarizing what you accomplished \
-                         and what the next generation should do. Do NOT start new tool \
-                         work. Three escape hatches, in priority order: \
-                         (1) call extend_turns if the task is almost finished and more \
-                         turns will close it out; \
-                         (2) call keeper_board_post to hand off the current task and ask \
-                         another keeper or operator for judgment when the work needs a \
-                         decision you cannot make alone; \
-                         (3) if you claimed a task, close it NOW before session ends \
-                         with keeper_task_done or keeper_task_submit_for_verification."
-                        computed_surface.per_call_turn
-                        computed_surface.per_call_max_turns)
-                 else if computed_surface.required_tool_names <> []
-                 then
-                   append_ctx
-                     ctx
-                     (Printf.sprintf
-                        "[REQUIRED TOOLS] This Agent.run call has explicit \
-                         required_tools: %s. You MUST use these exact runtime \
-                         tools before answering in natural language. Do not \
-                         substitute a shell command or status read for a \
-                         listed required tool."
-                        (String.concat ", " computed_surface.required_tool_names))
-                 else if is_retry
-                 then
-                   append_ctx
-                     ctx
-                     (Printf.sprintf
-                         "[RETRY] The previous attempt overflowed the model context. Stay \
-                         concise, prefer already-loaded context, and only use the \
-                         smallest essential tool set if a tool call is strictly \
-                         necessary. Current tool budget: %d."
-                        max_tools_per_turn)
-                 else if computed_surface.is_warning_zone
-                 then
-                   append_ctx
-                     ctx
-                     (Printf.sprintf
-                        "[BUDGET] %d/%d turns used in this Agent.run call. Wrap up current \
-                         work and emit a \
-                         [STATE] block. If more turns will genuinely finish the task, \
-                         call extend_turns. If you are blocked on a decision or \
-                         external input, post a question to the board via \
-                         keeper_board_post rather than burning turns retrying — that is \
-                         the intended judgment-escalation path."
-                        computed_surface.per_call_turn
-                        computed_surface.per_call_max_turns)
-                 else ctx
-               in
-               if computed_surface.is_warning_zone
-               then
-                 Log.Keeper.info
-                   "keeper:%s per_call_turn_budget absolute_turn=%d checkpoint_start_turn=%d \
-                    per_call_turn=%d/%d last_turn=%b"
+                  then
+                    append_ctx
+                      ctx
+                      (Printf.sprintf
+                         "[REQUIRED TOOLS - FINAL TURN] This Agent.run call is on its \
+                          final turn, but this message has explicit required_tools: %s. \
+                          You MUST either use every required tool now or return a \
+                          concise blocker naming the missing policy/tool/runtime \
+                          condition."
+                         (String.concat ", " computed_surface.required_tool_names))
+                  else if computed_surface.is_last_turn
+                  then
+                    append_ctx
+                      ctx
+                      (Printf.sprintf
+                         "[LAST TURN] Per-call turn %d/%d. This is your final turn in \
+                          this Agent.run call. You MUST emit a [STATE]...[/STATE] block \
+                          now summarizing what you accomplished and what the next \
+                          generation should do. Do NOT start new tool work. Three escape \
+                          hatches, in priority order: (1) call extend_turns if the task \
+                          is almost finished and more turns will close it out; (2) call \
+                          keeper_board_post to hand off the current task and ask another \
+                          keeper or operator for judgment when the work needs a decision \
+                          you cannot make alone; (3) if you claimed a task, close it NOW \
+                          before session ends with keeper_task_done or \
+                          keeper_task_submit_for_verification."
+                         computed_surface.per_call_turn
+                         computed_surface.per_call_max_turns)
+                  else if computed_surface.required_tool_names <> []
+                  then
+                    append_ctx
+                      ctx
+                      (Printf.sprintf
+                         "[REQUIRED TOOLS] This Agent.run call has explicit \
+                          required_tools: %s. You MUST use these exact runtime tools \
+                          before answering in natural language. Do not substitute a \
+                          shell command or status read for a listed required tool."
+                         (String.concat ", " computed_surface.required_tool_names))
+                  else if is_retry
+                  then
+                    append_ctx
+                      ctx
+                      (Printf.sprintf
+                         "[RETRY] The previous attempt overflowed the model context. \
+                          Stay concise, prefer already-loaded context, and only use the \
+                          smallest essential tool set if a tool call is strictly \
+                          necessary. Current tool budget: %d."
+                         max_tools_per_turn)
+                  else if computed_surface.is_warning_zone
+                  then
+                    append_ctx
+                      ctx
+                      (Printf.sprintf
+                         "[BUDGET] %d/%d turns used in this Agent.run call. Wrap up \
+                          current work and emit a [STATE] block. If more turns will \
+                          genuinely finish the task, call extend_turns. If you are \
+                          blocked on a decision or external input, post a question to \
+                          the board via keeper_board_post rather than burning turns \
+                          retrying — that is the intended judgment-escalation path."
+                         computed_surface.per_call_turn
+                         computed_surface.per_call_max_turns)
+                  else ctx
+                in
+                if computed_surface.is_warning_zone
+                then
+                  Log.Keeper.info
+                    "keeper:%s per_call_turn_budget absolute_turn=%d \
+                     checkpoint_start_turn=%d per_call_turn=%d/%d last_turn=%b"
+                    meta.name
+                    computed_surface.absolute_turn
+                    computed_surface.checkpoint_start_turn
+                    computed_surface.per_call_turn
+                    computed_surface.per_call_max_turns
+                    computed_surface.is_last_turn;
+                let all_allowed = computed_surface.all_allowed in
+                let tool_filter = Agent_sdk.Guardrails.AllowList all_allowed in
+                let tool_choice =
+                  if computed_surface.required_tool_names <> [] && all_allowed <> []
+                  then
+                    Some
+                      (preferred_tool_choice_for_required_tool_names
+                         ~required_tool_names:computed_surface.required_tool_names
+                         ~allowed_tool_names:all_allowed)
+                  else if computed_surface.is_last_turn
+                  then current_params.tool_choice
+                  else if computed_surface.tool_gate_requested && all_allowed <> []
+                  then
+                    Some
+                      (preferred_tool_choice_for_required_turn
+                         ~has_current_task:(keeper_has_owned_active_task ())
+                         ~turn_affordances
+                         ~allowed_tool_names:all_allowed)
+                  else current_params.tool_choice
+                in
+                let turn_completion_contract =
+                  match computed_surface.tool_gate_requested, tool_choice with
+                  | true, Some Agent_sdk.Types.Auto ->
+                    Keeper_tool_disclosure.completion_contract_of_tool_choice tool_choice
+                  | true, _ -> Keeper_tool_disclosure.Require_tool_use
+                  | false, _ ->
+                    Keeper_tool_disclosure.completion_contract_of_tool_choice tool_choice
+                in
+                acc.completion_contract <- turn_completion_contract;
+                if turn_completion_contract = Keeper_tool_disclosure.Require_tool_use
+                then acc.required_tool_use_seen <- true;
+                let lane = computed_surface.lane in
+                acc.requested_tool_names <- all_allowed;
+                acc.tool_surface
+                <- { turn_lane = lane
+                   ; tool_surface_class = computed_surface.tool_surface_class
+                   ; tool_requirement = computed_surface.tool_requirement
+                   ; visible_tool_count = List.length all_allowed
+                   ; tool_gate_enabled = computed_surface.tool_gate_requested
+                   ; tool_surface_fallback_used =
+                       computed_surface.tool_surface_fallback_used
+                   ; required_tool_names = computed_surface.required_tool_names
+                   ; missing_required_tool_names =
+                       computed_surface.missing_required_tool_names
+                   ; config_root
+                   ; cascade_config_path
+                   ; gemini_mcp_disabled
+                   ; approval_mode_effective
+                   ; approval_mode_derived
+                   };
+                let thinking_enabled_effective =
+                  match current_params.enable_thinking with
+                  | Some b -> b
+                  | None -> Keeper_config.keeper_enable_thinking ()
+                in
+                Keeper_tool_call_log.set_turn_context
+                  ~keeper_name:meta.name
+                  ~agent_name:meta.agent_name
+                  ~lane
+                  ?tool_choice:
+                    (Option.map
+                       (fun choice ->
+                          Yojson.Safe.to_string
+                            (Agent_sdk.Types.tool_choice_to_json choice))
+                       tool_choice)
+                  ~thinking_enabled:thinking_enabled_effective
+                  ?thinking_budget:current_params.thinking_budget
+                  ~prompt_fingerprint:prompt_metrics.fingerprint
+                  ~trace_id:(Keeper_id.Trace_id.to_string meta.runtime.trace_id)
+                  ~session_id:(Keeper_id.Trace_id.to_string meta.runtime.trace_id)
+                  ~generation
+                  ~turn
+                  ~keeper_turn_id:turn
+                  ?task_id:
+                    (Option.map Keeper_id.Task_id.to_string acc.meta.current_task_id)
+                  ~goal_ids:meta.active_goal_ids
+                  ~sandbox_profile:
+                    (Keeper_types.sandbox_profile_to_string meta.sandbox_profile)
+                  ~sandbox_root:
+                    (Keeper_sandbox.keeper_visible_root_abs_of_meta ~config meta)
+                  ~allowed_paths:(Keeper_alerting_path.effective_allowed_paths ~meta)
+                  ~network_mode:(Keeper_types.network_mode_to_string meta.network_mode)
+                  ?approval_mode:approval_mode_effective
+                  ~tool_surface_class:computed_surface.tool_surface_class
+                  ~visible_tool_count:(List.length all_allowed)
+                  ~required_tools:computed_surface.required_tool_names
+                  ~missing_required_tools:computed_surface.missing_required_tool_names
+                  ~cascade_profile:cascade_name_string
+                  ();
+                (let now = Time_compat.now () in
+                 let hook_elapsed_ms =
+                   Keeper_timing.round1 ((now -. hook_t0) *. 1000.0)
+                 in
+                 Keeper_registry.set_turn_decision_stage
+                   ~base_path:config.base_path
                    meta.name
-                   computed_surface.absolute_turn
-                   computed_surface.checkpoint_start_turn
-                   computed_surface.per_call_turn
-                   computed_surface.per_call_max_turns
-                   computed_surface.is_last_turn;
-               let all_allowed = computed_surface.all_allowed in
-               let tool_filter = Agent_sdk.Guardrails.AllowList all_allowed in
-               let tool_choice =
-                 if computed_surface.required_tool_names <> []
-                    && all_allowed <> []
-                 then
-                   Some
-                     (preferred_tool_choice_for_required_tool_names
-                        ~required_tool_names:computed_surface.required_tool_names
-                        ~allowed_tool_names:all_allowed)
-                 else if computed_surface.is_last_turn
-                 then current_params.tool_choice
-                 else if computed_surface.tool_gate_requested && all_allowed <> []
-                 then
-                   Some
-                     (preferred_tool_choice_for_required_turn
-                        ~has_current_task:(keeper_has_owned_active_task ())
-                        ~turn_affordances ~allowed_tool_names:all_allowed)
-                 else current_params.tool_choice
-               in
-               let turn_completion_contract =
-                 match computed_surface.tool_gate_requested, tool_choice with
-                 | true, Some Agent_sdk.Types.Auto ->
-                   Keeper_tool_disclosure.completion_contract_of_tool_choice
-                     tool_choice
-                 | true, _ ->
-                   Keeper_tool_disclosure.Require_tool_use
-                 | false, _ ->
-                   Keeper_tool_disclosure.completion_contract_of_tool_choice
-                     tool_choice
-               in
-               acc.completion_contract <- turn_completion_contract;
-               if turn_completion_contract = Keeper_tool_disclosure.Require_tool_use
-               then acc.required_tool_use_seen <- true;
-               let lane = computed_surface.lane in
-               acc.requested_tool_names <- all_allowed;
-               acc.tool_surface <-
-                 { turn_lane = lane
-                 ; tool_surface_class = computed_surface.tool_surface_class
-                 ; tool_requirement = computed_surface.tool_requirement
-                 ; visible_tool_count = List.length all_allowed
-                 ; tool_gate_enabled = computed_surface.tool_gate_requested
-                 ; tool_surface_fallback_used = computed_surface.tool_surface_fallback_used
-                 ; required_tool_names = computed_surface.required_tool_names
-                 ; missing_required_tool_names =
-                     computed_surface.missing_required_tool_names
-                 ; config_root
-                 ; cascade_config_path
-                 ; gemini_mcp_disabled
-                 ; approval_mode_effective
-                 ; approval_mode_derived
-                 };
-               let thinking_enabled_effective =
-                 match current_params.enable_thinking with
-                 | Some b -> b
-                 | None -> Keeper_config.keeper_enable_thinking ()
-               in
-               Keeper_tool_call_log.set_turn_context
-                 ~keeper_name:meta.name
-                 ~agent_name:meta.agent_name
-                 ~lane
-                 ?tool_choice:(Option.map
-                   (fun choice ->
-                     Yojson.Safe.to_string
-                       (Agent_sdk.Types.tool_choice_to_json choice))
-                   tool_choice)
-                 ~thinking_enabled:thinking_enabled_effective
-                 ?thinking_budget:current_params.thinking_budget
-                 ~prompt_fingerprint:prompt_metrics.fingerprint
-                 ~trace_id:(Keeper_id.Trace_id.to_string meta.runtime.trace_id)
-                 ~session_id:(Keeper_id.Trace_id.to_string meta.runtime.trace_id)
-                 ~generation
-                 ~turn
-                 ~keeper_turn_id:turn
-                 ?task_id:(Option.map Keeper_id.Task_id.to_string acc.meta.current_task_id)
-                 ~goal_ids:meta.active_goal_ids
-                 ~sandbox_profile:
-                   (Keeper_types.sandbox_profile_to_string meta.sandbox_profile)
-                 ~sandbox_root:
-                   (Keeper_sandbox.keeper_visible_root_abs_of_meta ~config meta)
-                 ~allowed_paths:(Keeper_alerting_path.effective_allowed_paths ~meta)
-                 ~network_mode:
-                   (Keeper_types.network_mode_to_string meta.network_mode)
-                 ?approval_mode:approval_mode_effective
-                 ~tool_surface_class:computed_surface.tool_surface_class
-                 ~visible_tool_count:(List.length all_allowed)
-                 ~required_tools:computed_surface.required_tool_names
-                 ~missing_required_tools:computed_surface.missing_required_tool_names
-                 ~cascade_profile:cascade_name_string
-                 ();
-               (let now = Time_compat.now () in
-                let hook_elapsed_ms = Keeper_timing.round1 ((now -. hook_t0) *. 1000.0) in
-                Keeper_registry.set_turn_decision_stage
-                  ~base_path:config.base_path meta.name
-                  Keeper_registry.Decision_tool_policy_selected;
-                Keeper_registry.set_turn_cascade_state
-                  ~base_path:config.base_path meta.name
-                  (Keeper_registry.Packed Keeper_registry.Cascade_selecting : Keeper_registry.packed_cascade_state);
-                (* Spec atomic group: SelectToolPolicy(idle->selecting)
+                   Keeper_registry.Decision_tool_policy_selected;
+                 Keeper_registry.set_turn_cascade_state
+                   ~base_path:config.base_path
+                   meta.name
+                   (Keeper_registry.Packed Keeper_registry.Cascade_selecting
+                    : Keeper_registry.packed_cascade_state);
+                 (* Spec atomic group: SelectToolPolicy(idle->selecting)
                    is immediately followed by CascadeTrying(selecting->
                    trying).  Both transitions are materialised inside
                    the disclosure hook because the spec invariant
@@ -1471,134 +1477,140 @@ let prepare_agent_setup
                    re-entry sequence becomes [trying -> selecting ->
                    trying] which is admitted by
                    [validate_cascade_transition]. *)
-                Keeper_registry.set_turn_cascade_state
-                  ~base_path:config.base_path meta.name
-                  (Keeper_registry.Packed Keeper_registry.Cascade_trying : Keeper_registry.packed_cascade_state);
-                let disclosure_json =
-                  `Assoc
-                    [ "ts_unix", `Float now
-                    ; "event", `String "tool_disclosure"
-                    ; "keeper_name", `String meta.name
-                    ; "turn", `Int turn
-                    ; "checkpoint_start_turn", `Int computed_surface.checkpoint_start_turn
-                    ; "per_call_turn", `Int computed_surface.per_call_turn
-                    ; "per_call_max_turns", `Int computed_surface.per_call_max_turns
-                    ; "selection_mode", `String computed_surface.selection_mode
-                    ; "core_count", `Int computed_surface.core_count
-                    ; "deterministic_prefilter_count", `Int computed_surface.deterministic_prefilter_count
-                    ; "discovered_count", `Int computed_surface.discovered_count
-                    ; "llm_selected_count", `Int computed_surface.llm_selected_count
-                    ; "final_visible", `Int (List.length all_allowed)
-                    ; "turn_lane", `String lane
-                    ; "tool_surface_class", `String computed_surface.tool_surface_class
-                    ; "tool_requirement", tool_requirement_to_yojson computed_surface.tool_requirement
-                    ; "tool_gate_enabled", `Bool computed_surface.tool_gate_requested
-                    ; "tool_surface_fallback_used", `Bool computed_surface.tool_surface_fallback_used
-                    ; "hook_ms", `Float hook_elapsed_ms
-                    ]
-                in
-                try
-                  Keeper_types_support.append_jsonl_line
-                    (Keeper_types_support.keeper_decision_log_path config meta.name)
-                    disclosure_json
-                with
-                | Eio.Cancel.Cancelled _ as e -> raise e
-                | exn ->
-                  Prometheus.inc_counter
-                    Keeper_metrics.metric_keeper_decision_audit_flush_failures
-                    ~labels:[("keeper", meta.name)]
-                    ();
-                  Log.Keeper.warn
-                    "keeper:%s tool_disclosure jsonl append failed: %s"
-                    meta.name
-                    (Printexc.to_string exn));
-               Eio.Fiber.yield ();
-               Agent_sdk.Hooks.AdjustParams
-                 { current_params with
-                   extra_system_context = ctx
-                 ; tool_choice
-                 ; tool_filter_override = Some tool_filter
-                 }
-             | _ -> Agent_sdk.Hooks.Continue)
-    }
-  in
-  let hooks = Agent_sdk.Hooks.compose ~outer:before_turn_hook ~inner:base_hooks in
-  let base_dir = Coord.masc_root_dir config in
-  let memory_session_id = Keeper_id.Trace_id.to_string meta.runtime.trace_id in
-  let memory_backend =
-    Memory_oas_bridge.make_backend
-      ~agent_name
-      ~base_dir
-      ~session_id:memory_session_id
-      ()
-  in
-  let memory =
-    Agent_sdk.Memory.create ~long_term:memory_backend ()
-  in
-  let hooks =
-    let mem_hooks =
-      Memory_hooks.make
-        ~agent_name ~config ~memory
-        ~world_backend:memory_backend
-        ~episode_limit:30
-        ~procedure_limit:10 ()
+                 Keeper_registry.set_turn_cascade_state
+                   ~base_path:config.base_path
+                   meta.name
+                   (Keeper_registry.Packed Keeper_registry.Cascade_trying
+                    : Keeper_registry.packed_cascade_state);
+                 let disclosure_json =
+                   `Assoc
+                     [ "ts_unix", `Float now
+                     ; "event", `String "tool_disclosure"
+                     ; "keeper_name", `String meta.name
+                     ; "turn", `Int turn
+                     ; ( "checkpoint_start_turn"
+                       , `Int computed_surface.checkpoint_start_turn )
+                     ; "per_call_turn", `Int computed_surface.per_call_turn
+                     ; "per_call_max_turns", `Int computed_surface.per_call_max_turns
+                     ; "selection_mode", `String computed_surface.selection_mode
+                     ; "core_count", `Int computed_surface.core_count
+                     ; ( "deterministic_prefilter_count"
+                       , `Int computed_surface.deterministic_prefilter_count )
+                     ; "discovered_count", `Int computed_surface.discovered_count
+                     ; "llm_selected_count", `Int computed_surface.llm_selected_count
+                     ; "final_visible", `Int (List.length all_allowed)
+                     ; "turn_lane", `String lane
+                     ; "tool_surface_class", `String computed_surface.tool_surface_class
+                     ; ( "tool_requirement"
+                       , tool_requirement_to_yojson computed_surface.tool_requirement )
+                     ; "tool_gate_enabled", `Bool computed_surface.tool_gate_requested
+                     ; ( "tool_surface_fallback_used"
+                       , `Bool computed_surface.tool_surface_fallback_used )
+                     ; "hook_ms", `Float hook_elapsed_ms
+                     ]
+                 in
+                 try
+                   Keeper_types_support.append_jsonl_line
+                     (Keeper_types_support.keeper_decision_log_path config meta.name)
+                     disclosure_json
+                 with
+                 | Eio.Cancel.Cancelled _ as e -> raise e
+                 | exn ->
+                   Prometheus.inc_counter
+                     Keeper_metrics.metric_keeper_decision_audit_flush_failures
+                     ~labels:[ "keeper", meta.name ]
+                     ();
+                   Log.Keeper.warn
+                     "keeper:%s tool_disclosure jsonl append failed: %s"
+                     meta.name
+                     (Printexc.to_string exn));
+                Eio.Fiber.yield ();
+                Agent_sdk.Hooks.AdjustParams
+                  { current_params with
+                    extra_system_context = ctx
+                  ; tool_choice
+                  ; tool_filter_override = Some tool_filter
+                  }
+              | _ -> Agent_sdk.Hooks.Continue)
+      }
     in
-    Memory_hooks.compose_with_inner ~memory_hooks:mem_hooks ~inner:hooks
-  in
-  (* Tier K4b/K4c: install the tool-emission PostToolUse hook so
+    let hooks = Agent_sdk.Hooks.compose ~outer:before_turn_hook ~inner:base_hooks in
+    let base_dir = Coord.masc_root_dir config in
+    let memory_session_id = Keeper_id.Trace_id.to_string meta.runtime.trace_id in
+    let memory_backend =
+      Memory_oas_bridge.make_backend
+        ~agent_name
+        ~base_dir
+        ~session_id:memory_session_id
+        ()
+    in
+    let memory = Agent_sdk.Memory.create ~long_term:memory_backend () in
+    let hooks =
+      let mem_hooks =
+        Memory_hooks.make
+          ~agent_name
+          ~config
+          ~memory
+          ~world_backend:memory_backend
+          ~episode_limit:30
+          ~procedure_limit:10
+          ()
+      in
+      Memory_hooks.compose_with_inner ~memory_hooks:mem_hooks ~inner:hooks
+    in
+    (* Tier K4b/K4c: install the tool-emission PostToolUse hook so
      tagged tool results flow into this keeper's own accumulator
      during Agent.run. The drain happens in keeper_post_turn.ml
      [apply_tool_emission_wirein] BEFORE [apply_multimodal_wirein],
      keyed by the SAME keeper name (stable across turns).
      When [MASC_TOOL_EMISSION] is off the hook is a no-op (see
      [Keeper_tool_emission_hook] for the gating). *)
-  let hooks =
-    let acc =
-      Keeper_tool_emission_hook.accumulator_for_keeper agent_name
+    let hooks =
+      let acc = Keeper_tool_emission_hook.accumulator_for_keeper agent_name in
+      Keeper_tool_emission_hook.install_into_hooks acc hooks
     in
-    Keeper_tool_emission_hook.install_into_hooks acc hooks
-  in
-  let reducer =
-    let hydrator_steps =
-      match Keeper_artifact_hydrator.reducer_from_env () with
-      | Some r -> [ r ]
-      | None -> []
+    let reducer =
+      let hydrator_steps =
+        match Keeper_artifact_hydrator.reducer_from_env () with
+        | Some r -> [ r ]
+        | None -> []
+      in
+      Agent_sdk.Context_reducer.compose
+        (hydrator_steps
+         @ [ Agent_sdk.Context_reducer.drop_thinking
+           ; Agent_sdk.Context_reducer.stub_tool_results ~keep_recent:3
+           ; Agent_sdk.Context_reducer.prune_tool_outputs ~max_output_len:4000
+           ; Agent_sdk.Context_reducer.cap_message_tokens
+               ~max_tokens:Env_config_keeper.KeeperReducer.cap_message_tokens
+               ~keep_recent:Env_config_keeper.KeeperReducer.cap_message_keep_recent
+           ; Agent_sdk.Context_reducer.repair_dangling_tool_calls
+           ; { Agent_sdk.Context_reducer.strategy =
+                 Agent_sdk.Context_reducer.Custom
+                   Keeper_context_core.repair_broken_tool_call_pairs
+             }
+           ; Agent_sdk.Context_reducer.merge_contiguous
+           ])
     in
-    Agent_sdk.Context_reducer.compose (
-      hydrator_steps @ [
-      Agent_sdk.Context_reducer.drop_thinking;
-      Agent_sdk.Context_reducer.stub_tool_results ~keep_recent:3;
-      Agent_sdk.Context_reducer.prune_tool_outputs ~max_output_len:4000;
-      Agent_sdk.Context_reducer.cap_message_tokens
-        ~max_tokens:Env_config_keeper.KeeperReducer.cap_message_tokens
-        ~keep_recent:Env_config_keeper.KeeperReducer.cap_message_keep_recent;
-      Agent_sdk.Context_reducer.repair_dangling_tool_calls;
-      {
-        Agent_sdk.Context_reducer.strategy =
-          Agent_sdk.Context_reducer.Custom
-            Keeper_context_core.repair_broken_tool_call_pairs;
-      };
-      Agent_sdk.Context_reducer.merge_contiguous;
-    ])
-  in
-  Ok { tools
-     ; cleanup = keeper_tool_bundle.cleanup
-     ; hooks
-     ; reducer
-     ; memory
-     ; acc
-     ; initial_tool_surface
-     ; initial_tool_surface_blocker
-     ; all_tool_names
-     ; tool_usage_before
-     ; receipt_turn_count_ref
-     ; receipt_model_used_ref
-     ; receipt_stop_reason_ref
-     ; receipt_cascade_observation_ref
-     ; receipt_response_text_present_ref
-     ; reported_tool_names_ref
-     ; observed_tool_names_ref
-     ; canonical_tool_names_ref
-     ; unexpected_tool_names_ref
-     ; actual_keeper_tool_names_ref
-     }
+    Ok
+      { tools
+      ; cleanup = keeper_tool_bundle.cleanup
+      ; hooks
+      ; reducer
+      ; memory
+      ; acc
+      ; initial_tool_surface
+      ; initial_tool_surface_blocker
+      ; all_tool_names
+      ; tool_usage_before
+      ; receipt_turn_count_ref
+      ; receipt_model_used_ref
+      ; receipt_stop_reason_ref
+      ; receipt_cascade_observation_ref
+      ; receipt_response_text_present_ref
+      ; reported_tool_names_ref
+      ; observed_tool_names_ref
+      ; canonical_tool_names_ref
+      ; unexpected_tool_names_ref
+      ; actual_keeper_tool_names_ref
+      }
+;;

--- a/lib/keeper/keeper_run_tools.ml
+++ b/lib/keeper/keeper_run_tools.ml
@@ -144,6 +144,7 @@ let prepare_agent_setup
       ~(gemini_mcp_disabled : bool)
       ~(approval_mode_effective : string option)
       ~(approval_mode_derived : bool)
+      ?(actionable_signal = false)
       ?max_cost_usd
       ~(trajectory_acc : Trajectory.accumulator option)
       ~(tool_overlay : Agent_sdk.Tool_op.t ref option)
@@ -569,8 +570,8 @@ let prepare_agent_setup
       detail.tool_name, detail.outcome)
     |> satisfied_required_tool_names_of_outcomes
   in
-  let compute_tool_surface ~turn ~messages ~current_tool_choice ~decay_discovered
-      : computed_tool_surface =
+  let compute_tool_surface ~turn ~messages ~current_tool_choice
+      ~decay_discovered ?(actionable_signal = false) () : computed_tool_surface =
     let last_user_text =
       List.fold_left
         (fun acc (m : Agent_sdk.Types.message) ->
@@ -805,6 +806,16 @@ let prepare_agent_setup
       else
         all_allowed
     in
+    let all_allowed =
+      let passive_streak =
+        Keeper_passive_loop_detector.current_streak ~keeper_name:meta.name
+      in
+      Keeper_tool_disclosure.contract_enforcement_filter
+        ~passive_streak
+        ~streak_threshold:3
+        ~actionable_signal
+        all_allowed
+    in
     let tool_gate_requested =
       required_tool_names <> []
       || tool_gate_requested_for_turn ~current_tool_choice ~is_last_turn
@@ -905,6 +916,8 @@ let prepare_agent_setup
       ~messages:history_messages
       ~current_tool_choice:None
       ~decay_discovered:false
+      ~actionable_signal
+      ()
   in
   acc.tool_surface <-
     { turn_lane = initial_tool_surface.lane
@@ -1240,6 +1253,8 @@ let prepare_agent_setup
                    ~messages
                    ~current_tool_choice:current_params.tool_choice
                    ~decay_discovered:true
+                   ~actionable_signal
+                   ()
                in
                if Keeper_types_profile.keeper_debug
                then

--- a/lib/keeper/keeper_run_tools.mli
+++ b/lib/keeper/keeper_run_tools.mli
@@ -50,8 +50,8 @@ type tool_search_hit_partition =
   ; filtered_by_policy : int
   }
 
-val partition_tool_search_hits :
-     core:string list
+val partition_tool_search_hits
+  :  core:string list
   -> core_always:string list
   -> allowed:string list
   -> retrieved:(string * float) list
@@ -65,7 +65,7 @@ val partition_tool_search_hits :
     at the OAS call site. *)
 type agent_setup =
   { tools : Agent_sdk.Tool.t list
-  (** Release resources owned by the prepared keeper tool bundle.
+    (** Release resources owned by the prepared keeper tool bundle.
       Callers should invoke this once after the turn consumes the setup,
       on both success and exception paths.  Implementations must be
       idempotent and should not raise; callers defensively catch and log
@@ -91,8 +91,8 @@ type agent_setup =
   ; actual_keeper_tool_names_ref : string list ref
   }
 
-val prepare_agent_setup :
-     config:Coord.config
+val prepare_agent_setup
+  :  config:Coord.config
   -> meta:Keeper_types.keeper_meta
   -> ctx_work:working_context
   -> session:Keeper_types.session_context

--- a/lib/keeper/keeper_run_tools.mli
+++ b/lib/keeper/keeper_run_tools.mli
@@ -116,6 +116,7 @@ val prepare_agent_setup :
   -> gemini_mcp_disabled:bool
   -> approval_mode_effective:string option
   -> approval_mode_derived:bool
+  -> ?actionable_signal:bool
   -> ?max_cost_usd:float
   -> trajectory_acc:Trajectory.accumulator option
   -> tool_overlay:Agent_sdk.Tool_op.t ref option

--- a/lib/keeper/keeper_tool_disclosure.ml
+++ b/lib/keeper/keeper_tool_disclosure.ml
@@ -572,3 +572,24 @@ let merge_tool_selection_boundary
       (deterministic_prefilter @ sorted_discovered @ core)
   in
   Keeper_types.dedupe_keep_order (deterministic_floor @ llm_selected)
+
+let contract_enforcement_filter
+      ~(passive_streak : int)
+      ~(streak_threshold : int)
+      ~(actionable_signal : bool)
+      (tool_names : string list)
+  : string list =
+  if passive_streak < streak_threshold || not actionable_signal then tool_names
+  else
+    let preserved, removed =
+      List.partition
+        (fun name ->
+           match classify_tool_progress name with
+           | Passive_status -> false
+           | Claim_context | Execution | Completion -> true)
+        tool_names
+    in
+    (* stay_silent is Completion-class, already in [preserved].
+       This filter removes only Passive_status tools (Read, Grep, List, etc.)
+       that contribute nothing to owned tasks during streaks. *)
+    preserved

--- a/lib/keeper/keeper_tool_disclosure.ml
+++ b/lib/keeper/keeper_tool_disclosure.ml
@@ -33,23 +33,24 @@ let merge_observed_tool_names
   let hook_counts = Hashtbl.create 16 in
   List.iter
     (fun tool_name ->
-      let count = Option.value ~default:0 (Hashtbl.find_opt hook_counts tool_name) in
-      Hashtbl.replace hook_counts tool_name (count + 1))
+       let count = Option.value ~default:0 (Hashtbl.find_opt hook_counts tool_name) in
+       Hashtbl.replace hook_counts tool_name (count + 1))
     hook_observed_tool_names;
   let emitted_extra = Hashtbl.create 16 in
   hook_observed_tool_names
   @ List.filter
       (fun tool_name ->
-        let hook_count =
-          Option.value ~default:0 (Hashtbl.find_opt hook_counts tool_name)
-        in
-        let already_emitted =
-          Option.value ~default:0 (Hashtbl.find_opt emitted_extra tool_name)
-        in
-        if already_emitted < hook_count then (
-          Hashtbl.replace emitted_extra tool_name (already_emitted + 1);
-          false)
-        else true)
+         let hook_count =
+           Option.value ~default:0 (Hashtbl.find_opt hook_counts tool_name)
+         in
+         let already_emitted =
+           Option.value ~default:0 (Hashtbl.find_opt emitted_extra tool_name)
+         in
+         if already_emitted < hook_count
+         then (
+           Hashtbl.replace emitted_extra tool_name (already_emitted + 1);
+           false)
+         else true)
       registry_observed_tool_names
 ;;
 
@@ -75,16 +76,12 @@ let final_keeper_tool_names
       ~(allowed_tool_names : string list)
   : string list
   =
-  merge_reported_and_observed_tool_names
-    ~reported_tool_names
-    ~observed_tool_names
+  merge_reported_and_observed_tool_names ~reported_tool_names ~observed_tool_names
   |> Keeper_tool_alias.canonicalize_observed
   |> List.filter (fun tool_name -> List.mem tool_name allowed_tool_names)
 ;;
 
-let unexpected_tool_names
-      ~(allowed_tool_names : string list)
-      ~(tool_names : string list)
+let unexpected_tool_names ~(allowed_tool_names : string list) ~(tool_names : string list)
   : string list
   =
   let allowed = Hashtbl.create (List.length allowed_tool_names) in
@@ -92,11 +89,11 @@ let unexpected_tool_names
   List.iter (fun tool_name -> Hashtbl.replace allowed tool_name ()) allowed_tool_names;
   tool_names
   |> List.filter (fun tool_name ->
-       if Hashtbl.mem allowed tool_name || Hashtbl.mem seen tool_name
-       then false
-       else (
-         Hashtbl.replace seen tool_name ();
-         true))
+    if Hashtbl.mem allowed tool_name || Hashtbl.mem seen tool_name
+    then false
+    else (
+      Hashtbl.replace seen tool_name ();
+      true))
 ;;
 
 (** [has_valid_tool_call ~unexpected_tool_names ~tool_names] returns
@@ -105,9 +102,7 @@ let unexpected_tool_names
     surface. Used by [Keeper_agent_run] (#8471) to decide whether a
     turn mixing unknown tools with valid ones should hard-fail or
     continue with a partial-tolerance WARN. *)
-let has_valid_tool_call
-      ~(unexpected_tool_names : string list)
-      ~(tool_names : string list)
+let has_valid_tool_call ~(unexpected_tool_names : string list) ~(tool_names : string list)
   : bool
   =
   let unexpected = Hashtbl.create (List.length unexpected_tool_names) in
@@ -125,9 +120,9 @@ let merge_completion_contract
   : completion_contract
   =
   match previous, current with
-  | Require_tool_use, _
-  | _, Require_tool_use -> Require_tool_use
+  | Require_tool_use, _ | _, Require_tool_use -> Require_tool_use
   | Allow_text_or_tool, Allow_text_or_tool -> Allow_text_or_tool
+;;
 
 (** Issue #8696: exhaustive match against [Agent_sdk.Types.tool_choice].
     Previous catch-all silently mapped any future SDK constructor to
@@ -135,14 +130,14 @@ let merge_completion_contract
     (e.g. requiring tool use under new conditions) the keeper would
     silently degrade. Listing every variant turns SDK drift into a
     compile error here so it is reviewed at the boundary. *)
-let completion_contract_of_tool_choice
-      (tool_choice : Agent_sdk.Types.tool_choice option)
+let completion_contract_of_tool_choice (tool_choice : Agent_sdk.Types.tool_choice option)
   : completion_contract
   =
   match tool_choice with
   | Some (Agent_sdk.Types.Any | Agent_sdk.Types.Tool _) -> Require_tool_use
   | Some (Agent_sdk.Types.Auto | Agent_sdk.Types.None_) -> Allow_text_or_tool
   | None -> Allow_text_or_tool
+;;
 
 let run_completion_contract
       ~(turn_contract : completion_contract)
@@ -150,6 +145,7 @@ let run_completion_contract
   : completion_contract
   =
   if required_tool_use_seen then Require_tool_use else turn_contract
+;;
 
 let validate_completion_contract_presence
       ~(contract : completion_contract)
@@ -164,6 +160,7 @@ let validate_completion_contract_presence
     else
       Error
         "keeper turn violated required tool contract: no keeper-surface tools were called"
+;;
 
 let validate_completion_contract
       ~(contract : completion_contract)
@@ -176,9 +173,8 @@ let validate_completion_contract
   | Require_tool_use ->
     (match tool_names with
      | _ :: _ -> Ok ()
-     | [] ->
-       Error
-         "keeper turn violated required tool contract: no tools were called")
+     | [] -> Error "keeper turn violated required tool contract: no tools were called")
+;;
 
 (** Keeper tool progress classes are the shared contract between prompt
     disclosure, required-tool validation, runtime receipts, and liveness
@@ -196,16 +192,18 @@ let tool_progress_class_to_string = function
   | Claim_context -> "claim_context"
   | Execution -> "execution"
   | Completion -> "completion"
+;;
 
 let canonical_tool_name name =
   match Keeper_tool_alias.canonicalize_observed [ name ] with
   | canonical :: _ -> canonical
   | [] -> name
+;;
 
 let claim_context_tool_names : string list =
-  Tool_name.
-    [ Masc Claim_next; Masc Claim_task; Keeper Task_claim ]
+  Tool_name.[ Masc Claim_next; Masc Claim_task; Keeper Task_claim ]
   |> List.map Tool_name.to_string
+;;
 
 let completion_tool_names : string list =
   (* Stay_silent is the explicit "no work for me this turn" decisive no-op.
@@ -217,25 +215,25 @@ let completion_tool_names : string list =
      even though the LLM had decided no fit (sangsu/janitor/taskmaster on
      2026-04-27 00:17-00:58 UTC, idle_seconds 28-40h, claimable_count 44-46). *)
   Tool_name.
-    [
-      Masc Cancel_task;
-      Masc Complete_task;
-      Masc Deliver;
-      Masc Release_task;
-      Keeper Stay_silent;
-      Keeper Task_done;
-      Keeper Task_force_done;
-      Keeper Task_force_release;
-      Keeper Task_submit_for_verification;
+    [ Masc Cancel_task
+    ; Masc Complete_task
+    ; Masc Deliver
+    ; Masc Release_task
+    ; Keeper Stay_silent
+    ; Keeper Task_done
+    ; Keeper Task_force_done
+    ; Keeper Task_force_release
+    ; Keeper Task_submit_for_verification
     ]
   |> List.map Tool_name.to_string
+;;
 
 let is_claim_tool_name name =
   let name = canonical_tool_name name in
   match Tool_name.of_string name with
-  | Some (Keeper Task_claim) | Some (Masc Claim_next) | Some (Masc Claim_task) ->
-    true
+  | Some (Keeper Task_claim) | Some (Masc Claim_next) | Some (Masc Claim_task) -> true
   | _ -> false
+;;
 
 let is_claim_context_tool_name name =
   let name = canonical_tool_name name in
@@ -245,6 +243,7 @@ let is_claim_context_tool_name name =
     | None -> name
   in
   List.mem canonical_name claim_context_tool_names
+;;
 
 let is_completion_tool_name name =
   let name = canonical_tool_name name in
@@ -254,12 +253,14 @@ let is_completion_tool_name name =
     | None -> name
   in
   List.mem canonical_name completion_tool_names
+;;
 
 let is_stay_silent_tool_name name =
   let name = canonical_tool_name name in
   match Tool_name.of_string name with
   | Some (Keeper Stay_silent) -> true
   | _ -> false
+;;
 
 let tool_name_can_satisfy_required_contract name =
   let name = canonical_tool_name name in
@@ -269,39 +270,41 @@ let tool_name_can_satisfy_required_contract name =
      call keeper_stay_silent alongside status reads trigger false
      contract violations — observed 2026-04-28 when codex-spark
      returned stay_silent + keeper_task_list on an actionable signal. *)
-  if is_completion_tool_name name then true
-  else
+  if is_completion_tool_name name
+  then true
+  else (
     match Tool_catalog.effect_domain name with
     | Some Tool_catalog.Read_only -> false
     | Some
         ( Tool_catalog.Masc_coordination
         | Tool_catalog.Playground_write
-        | Tool_catalog.Main_worktree_write ) ->
-        true
-    | None -> not (Tool_dispatch.is_read_only name)
+        | Tool_catalog.Main_worktree_write ) -> true
+    | None -> not (Tool_dispatch.is_read_only name))
+;;
 
-let required_tool_satisfaction
-      (call : Agent_sdk.Completion_contract.tool_call)
+let required_tool_satisfaction (call : Agent_sdk.Completion_contract.tool_call)
   : (unit, string) result
   =
   let tool_name = canonical_tool_name call.name in
   (* Completion tools intentionally satisfy the contract.  See
      tool_name_can_satisfy_required_contract for the same exemption. *)
-  if is_completion_tool_name tool_name then Ok ()
-  else
+  if is_completion_tool_name tool_name
+  then Ok ()
+  else (
     let mutates =
       match Tool_catalog.effect_domain tool_name with
       | Some Tool_catalog.Read_only -> false
       | _ ->
-        Keeper_exec_tools.has_mutating_side_effect_with_input
-          ~tool_name ~input:call.input
+        Keeper_exec_tools.has_mutating_side_effect_with_input ~tool_name ~input:call.input
     in
-    if mutates then Ok ()
+    if mutates
+    then Ok ()
     else
       Error
         (Printf.sprintf
            "tool '%s' is read-only/passive and cannot satisfy a required-tool contract"
-           tool_name)
+           tool_name))
+;;
 
 let required_tool_satisfaction_for_required_names
       ~(required_tool_names : string list)
@@ -309,13 +312,13 @@ let required_tool_satisfaction_for_required_names
   : (unit, string) result
   =
   let required_tool_names =
-    required_tool_names
-    |> List.map canonical_tool_name
-    |> Keeper_types.dedupe_keep_order
+    required_tool_names |> List.map canonical_tool_name |> Keeper_types.dedupe_keep_order
   in
   let tool_name = canonical_tool_name call.name in
-  if List.mem tool_name required_tool_names then Ok ()
+  if List.mem tool_name required_tool_names
+  then Ok ()
   else required_tool_satisfaction call
+;;
 
 let classify_tool_progress name =
   let name = canonical_tool_name name in
@@ -326,23 +329,28 @@ let classify_tool_progress name =
   else if tool_name_can_satisfy_required_contract name
   then Execution
   else Passive_status
+;;
 
 let is_owned_task_progress_tool_name name =
-  if is_stay_silent_tool_name name then false
-  else
+  if is_stay_silent_tool_name name
+  then false
+  else (
     match classify_tool_progress name with
     | Execution | Completion -> true
-    | Passive_status | Claim_context -> false
+    | Passive_status | Claim_context -> false)
+;;
 
 let is_passive_status_tool_name name =
   match classify_tool_progress name with
   | Passive_status -> true
   | Claim_context | Execution | Completion -> false
+;;
 
 let is_execution_progress_tool_name name =
   match classify_tool_progress name with
   | Execution | Completion -> true
   | Passive_status | Claim_context -> false
+;;
 
 (* #10091: record a [require_tool_use] contract violation with
    the labels the operator needs to fix the underlying cause
@@ -356,14 +364,18 @@ let is_execution_progress_tool_name name =
 let record_require_tool_use_violation
       ~(keeper_name : string)
       ~(has_current_task : bool)
-      ~(contract_status : string) : unit =
+      ~(contract_status : string)
+  : unit
+  =
   Prometheus.inc_counter
     Keeper_metrics.metric_keeper_require_tool_use_violations
-    ~labels:[
-      ("keeper", keeper_name);
-      ("has_current_task", if has_current_task then "true" else "false");
-      ("contract_status", contract_status);
-    ] ()
+    ~labels:
+      [ "keeper", keeper_name
+      ; ("has_current_task", if has_current_task then "true" else "false")
+      ; "contract_status", contract_status
+      ]
+    ()
+;;
 
 let actionable_tool_contract_violation_reason
       ~(claim_context_allowed : bool)
@@ -371,42 +383,45 @@ let actionable_tool_contract_violation_reason
       ~(tool_names : string list)
   : string option
   =
-  if not actionable_signal_context then None
-  else
+  if not actionable_signal_context
+  then None
+  else (
     match tool_names with
     | [] ->
-      Some
-        "actionable keeper signal was present, but the model called no keeper tools"
+      Some "actionable keeper signal was present, but the model called no keeper tools"
     | names when List.exists is_owned_task_progress_tool_name names -> None
     | names
       when (not claim_context_allowed)
            && not (List.exists is_owned_task_progress_tool_name names) ->
       Some
         (Printf.sprintf
-           "actionable keeper signal was present for an owned active task, but the model only used passive/claim/stay_silent tools without execution progress: %s"
+           "actionable keeper signal was present for an owned active task, but the model \
+            only used passive/claim/stay_silent tools without execution progress: %s"
            (String.concat ", " names))
     | names when List.exists is_stay_silent_tool_name names ->
       Some
         (Printf.sprintf
-           "actionable keeper signal was present, but the model used keeper_stay_silent without typed no-work proof: %s"
+           "actionable keeper signal was present, but the model used keeper_stay_silent \
+            without typed no-work proof: %s"
            (String.concat ", " names))
     | names
       when List.for_all
-             (fun name ->
-                not (tool_name_can_satisfy_required_contract name))
+             (fun name -> not (tool_name_can_satisfy_required_contract name))
              names ->
       Some
         (Printf.sprintf
-           "actionable keeper signal was present, but the model only used passive status/read tools: %s"
+           "actionable keeper signal was present, but the model only used passive \
+            status/read tools: %s"
            (String.concat ", " names))
     | names
-      when (not claim_context_allowed)
-           && List.for_all is_claim_context_tool_name names ->
+      when (not claim_context_allowed) && List.for_all is_claim_context_tool_name names ->
       Some
         (Printf.sprintf
-           "actionable keeper signal was present, but the model only used claim/context tools without execution progress: %s"
+           "actionable keeper signal was present, but the model only used claim/context \
+            tools without execution progress: %s"
            (String.concat ", " names))
-    | _ -> None
+    | _ -> None)
+;;
 
 let normalize_response_text ~(text : string) ~(tool_names : string list) ()
   : (string, string) result
@@ -467,38 +482,89 @@ let contains_any_ci (text : string) (needles : string list) : bool =
   let haystack = String.lowercase_ascii text in
   List.exists
     (fun needle ->
-      let needle = String.lowercase_ascii needle in
-      let hay_len = String.length haystack in
-      let needle_len = String.length needle in
-      let rec loop idx =
-        if needle_len = 0 then true
-        else if idx + needle_len > hay_len then false
-        else if String.sub haystack idx needle_len = needle then true
-        else loop (idx + 1)
-      in
-      loop 0)
+       let needle = String.lowercase_ascii needle in
+       let hay_len = String.length haystack in
+       let needle_len = String.length needle in
+       let rec loop idx =
+         if needle_len = 0
+         then true
+         else if idx + needle_len > hay_len
+         then false
+         else if String.sub haystack idx needle_len = needle
+         then true
+         else loop (idx + 1)
+       in
+       loop 0)
     needles
 ;;
 
 let code_context_needles =
-  [ "code"; "codebase"; "source code"; "source file"; "repo"; "repository";
-    "symbol"; "function"; "class"; "method"; "module"; "implementation";
-    "snippet";
-    "코드"; "소스코드"; "소스 파일"; "심볼"; "함수"; "클래스"; "모듈";
-    "구현" ]
+  [ "code"
+  ; "codebase"
+  ; "source code"
+  ; "source file"
+  ; "repo"
+  ; "repository"
+  ; "symbol"
+  ; "function"
+  ; "class"
+  ; "method"
+  ; "module"
+  ; "implementation"
+  ; "snippet"
+  ; "코드"
+  ; "소스코드"
+  ; "소스 파일"
+  ; "심볼"
+  ; "함수"
+  ; "클래스"
+  ; "모듈"
+  ; "구현"
+  ]
 ;;
 
 let contains_code_path_hint (query_text : string) : bool =
-  contains_any_ci query_text
-    [ ".ml"; ".mli"; ".py"; ".ts"; ".tsx"; ".js"; ".jsx"; ".rs"; ".go";
-      ".java"; ".kt"; ".c"; ".cc"; ".cpp"; ".h"; ".hpp";
-      "lib/"; "src/"; "test/"; "tests/"; "app/"; "bin/" ]
+  contains_any_ci
+    query_text
+    [ ".ml"
+    ; ".mli"
+    ; ".py"
+    ; ".ts"
+    ; ".tsx"
+    ; ".js"
+    ; ".jsx"
+    ; ".rs"
+    ; ".go"
+    ; ".java"
+    ; ".kt"
+    ; ".c"
+    ; ".cc"
+    ; ".cpp"
+    ; ".h"
+    ; ".hpp"
+    ; "lib/"
+    ; "src/"
+    ; "test/"
+    ; "tests/"
+    ; "app/"
+    ; "bin/"
+    ]
 ;;
 
 let query_requests_code_search (query_text : string) : bool =
   let search_needles =
-    [ "search"; "find"; "grep"; "lookup"; "query"; "where is"; "locate";
-      "검색"; "찾"; "grep"; "조회" ]
+    [ "search"
+    ; "find"
+    ; "grep"
+    ; "lookup"
+    ; "query"
+    ; "where is"
+    ; "locate"
+    ; "검색"
+    ; "찾"
+    ; "grep"
+    ; "조회"
+    ]
   in
   contains_any_ci query_text search_needles
   && contains_any_ci query_text code_context_needles
@@ -506,15 +572,44 @@ let query_requests_code_search (query_text : string) : bool =
 
 let query_requests_code_read (query_text : string) : bool =
   let read_needles =
-    [ "read"; "view"; "open"; "inspect"; "contents"; "content";
-      "implementation"; "snippet"; "cat";
-      "읽"; "열"; "확인"; "내용" ]
+    [ "read"
+    ; "view"
+    ; "open"
+    ; "inspect"
+    ; "contents"
+    ; "content"
+    ; "implementation"
+    ; "snippet"
+    ; "cat"
+    ; "읽"
+    ; "열"
+    ; "확인"
+    ; "내용"
+    ]
   in
   let read_context_needles =
-    [ "source"; "source code"; "source file"; "code"; "function"; "class";
-      "method"; "module"; "implementation"; "snippet"; "line";
-      "소스"; "소스코드"; "소스 파일"; "코드"; "함수"; "클래스"; "메서드";
-      "모듈"; "라인"; "구현" ]
+    [ "source"
+    ; "source code"
+    ; "source file"
+    ; "code"
+    ; "function"
+    ; "class"
+    ; "method"
+    ; "module"
+    ; "implementation"
+    ; "snippet"
+    ; "line"
+    ; "소스"
+    ; "소스코드"
+    ; "소스 파일"
+    ; "코드"
+    ; "함수"
+    ; "클래스"
+    ; "메서드"
+    ; "모듈"
+    ; "라인"
+    ; "구현"
+    ]
   in
   contains_any_ci query_text read_needles
   && (contains_any_ci query_text read_context_needles
@@ -523,10 +618,26 @@ let query_requests_code_read (query_text : string) : bool =
 
 let query_requests_code_symbols (query_text : string) : bool =
   let symbol_needles =
-    [ "symbol"; "symbols"; "function"; "functions"; "class"; "classes";
-      "method"; "methods"; "definition"; "definitions"; "outline";
-      "structure"; "api surface";
-      "심볼"; "함수"; "클래스"; "메서드"; "정의"; "구조" ]
+    [ "symbol"
+    ; "symbols"
+    ; "function"
+    ; "functions"
+    ; "class"
+    ; "classes"
+    ; "method"
+    ; "methods"
+    ; "definition"
+    ; "definitions"
+    ; "outline"
+    ; "structure"
+    ; "api surface"
+    ; "심볼"
+    ; "함수"
+    ; "클래스"
+    ; "메서드"
+    ; "정의"
+    ; "구조"
+    ]
   in
   contains_any_ci query_text symbol_needles
 ;;
@@ -540,26 +651,32 @@ let allow_deterministic_tool ~(query_text : string) (name : string) : bool =
 ;;
 
 let deterministic_prefilter_names
-    ~(search_index : Agent_sdk.Tool_index.t)
-    ~(query_text : string)
-    ~(selection_limit : int)
-    ~(core : string list) : string list =
-  if selection_limit <= 0 then []
+      ~(search_index : Agent_sdk.Tool_index.t)
+      ~(query_text : string)
+      ~(selection_limit : int)
+      ~(core : string list)
+  : string list
+  =
+  if selection_limit <= 0
+  then []
   else
     Agent_sdk.Tool_index.retrieve search_index query_text
     |> List.filter_map (fun (name, _) ->
-         if List.mem name core then None
-         else if not (allow_deterministic_tool ~query_text name)
-         then None
-         else Some name)
+      if List.mem name core
+      then None
+      else if not (allow_deterministic_tool ~query_text name)
+      then None
+      else Some name)
     |> List.filteri (fun i _ -> i < selection_limit)
 ;;
 
 let merge_tool_selection_boundary
-    ~(core : string list)
-    ~(deterministic_prefilter : string list)
-    ~(llm_selected : string list)
-    ~(discovered : string list) : string list =
+      ~(core : string list)
+      ~(deterministic_prefilter : string list)
+      ~(llm_selected : string list)
+      ~(discovered : string list)
+  : string list
+  =
   let sorted_discovered = List.sort String.compare discovered in
   (* BM25-relevant tools first: when downstream truncation caps at
      max_tools, the tail is dropped.  Placing deterministic_prefilter
@@ -568,19 +685,21 @@ let merge_tool_selection_boundary
      Core tools that also appear in deterministic_prefilter are deduped
      (first occurrence wins), so they naturally keep their BM25 rank. *)
   let deterministic_floor =
-    Keeper_types.dedupe_keep_order
-      (deterministic_prefilter @ sorted_discovered @ core)
+    Keeper_types.dedupe_keep_order (deterministic_prefilter @ sorted_discovered @ core)
   in
   Keeper_types.dedupe_keep_order (deterministic_floor @ llm_selected)
+;;
 
 let contract_enforcement_filter
       ~(passive_streak : int)
       ~(streak_threshold : int)
       ~(actionable_signal : bool)
       (tool_names : string list)
-  : string list =
-  if passive_streak < streak_threshold || not actionable_signal then tool_names
-  else
+  : string list
+  =
+  if passive_streak < streak_threshold || not actionable_signal
+  then tool_names
+  else (
     let preserved, removed =
       List.partition
         (fun name ->
@@ -592,4 +711,5 @@ let contract_enforcement_filter
     (* stay_silent is Completion-class, already in [preserved].
        This filter removes only Passive_status tools (Read, Grep, List, etc.)
        that contribute nothing to owned tasks during streaks. *)
-    preserved
+    preserved)
+;;

--- a/lib/keeper/keeper_tool_disclosure.mli
+++ b/lib/keeper/keeper_tool_disclosure.mli
@@ -8,58 +8,60 @@
 
 (** Snapshot of [(tool_name, count)] from [Keeper_registry] for the
     given keeper, sorted by name. *)
-val keeper_tool_usage_snapshot :
-  base_path:string -> keeper_name:string -> (string * int) list
+val keeper_tool_usage_snapshot
+  :  base_path:string
+  -> keeper_name:string
+  -> (string * int) list
 
 (** Diff [(tool_name, count)] pairs between [before] and [after],
     returning the tool names invoked during that interval — one
     entry per call. *)
-val tool_usage_delta :
-  before:(string * int) list ->
-  after:(string * int) list ->
-  string list
+val tool_usage_delta
+  :  before:(string * int) list
+  -> after:(string * int) list
+  -> string list
 
 (** Merge provider hook-observed tool names with registry-observed
     deltas. The hook path is the most direct runtime signal, while
     registry deltas are retained for tools that only update the
     keeper registry. Duplicate sources are combined by max count per
     tool instead of double-counting the same execution. *)
-val merge_observed_tool_names :
-  registry_observed_tool_names:string list ->
-  hook_observed_tool_names:string list ->
-  string list
+val merge_observed_tool_names
+  :  registry_observed_tool_names:string list
+  -> hook_observed_tool_names:string list
+  -> string list
 
 (** Merge model-reported tool names with provider-observed ones.
     When [observed_tool_names] is non-empty it dominates the head
     of the result; reported-only tails are appended. *)
-val merge_reported_and_observed_tool_names :
-  reported_tool_names:string list ->
-  observed_tool_names:string list ->
-  string list
+val merge_reported_and_observed_tool_names
+  :  reported_tool_names:string list
+  -> observed_tool_names:string list
+  -> string list
 
 (** Compose [merge_reported_and_observed_tool_names] +
     [Keeper_tool_alias.canonicalize_observed] and filter to the
     keeper's [allowed_tool_names]. *)
-val final_keeper_tool_names :
-  reported_tool_names:string list ->
-  observed_tool_names:string list ->
-  allowed_tool_names:string list ->
-  string list
+val final_keeper_tool_names
+  :  reported_tool_names:string list
+  -> observed_tool_names:string list
+  -> allowed_tool_names:string list
+  -> string list
 
 (** Names called by the model that are NOT on the keeper's allowed
     surface (deduped, order preserving). *)
-val unexpected_tool_names :
-  allowed_tool_names:string list ->
-  tool_names:string list ->
-  string list
+val unexpected_tool_names
+  :  allowed_tool_names:string list
+  -> tool_names:string list
+  -> string list
 
 (** [true] iff at least one entry in [tool_names] is absent from
     [unexpected_tool_names] — i.e. some call lands on the keeper
     surface. Used by the partial-tolerance WARN path (#8471). *)
-val has_valid_tool_call :
-  unexpected_tool_names:string list ->
-  tool_names:string list ->
-  bool
+val has_valid_tool_call
+  :  unexpected_tool_names:string list
+  -> tool_names:string list
+  -> bool
 
 (** Required-tool contract carried per turn / per run. *)
 type completion_contract =
@@ -68,39 +70,40 @@ type completion_contract =
 
 (** Monotonic merge — once [Require_tool_use] enters either side,
     the result is [Require_tool_use]. *)
-val merge_completion_contract :
-  previous:completion_contract ->
-  current:completion_contract ->
-  completion_contract
+val merge_completion_contract
+  :  previous:completion_contract
+  -> current:completion_contract
+  -> completion_contract
 
 (** Map an [Agent_sdk.Types.tool_choice option] to the corresponding
     [completion_contract] (#8696: exhaustive match against
     [Agent_sdk.Types.tool_choice] so SDK drift is caught at compile time). *)
-val completion_contract_of_tool_choice :
-  Agent_sdk.Types.tool_choice option -> completion_contract
+val completion_contract_of_tool_choice
+  :  Agent_sdk.Types.tool_choice option
+  -> completion_contract
 
 (** Combine a per-turn contract with the run-level
     [required_tool_use_seen] flag — once [true], the run becomes
     [Require_tool_use]. *)
-val run_completion_contract :
-  turn_contract:completion_contract ->
-  required_tool_use_seen:bool ->
-  completion_contract
+val run_completion_contract
+  :  turn_contract:completion_contract
+  -> required_tool_use_seen:bool
+  -> completion_contract
 
 (** Validate a turn's [contract] given whether any keeper-surface
     tool was called. *)
-val validate_completion_contract_presence :
-  contract:completion_contract ->
-  tool_present:bool ->
-  (unit, string) result
+val validate_completion_contract_presence
+  :  contract:completion_contract
+  -> tool_present:bool
+  -> (unit, string) result
 
 (** Validate a turn's [contract] given the list of called tool
     names (non-empty list satisfies [Require_tool_use]). *)
-val validate_completion_contract :
-  contract:completion_contract ->
-  tool_names:string list ->
-  unit ->
-  (unit, string) result
+val validate_completion_contract
+  :  contract:completion_contract
+  -> tool_names:string list
+  -> unit
+  -> (unit, string) result
 
 (** Tool progress class — shared contract between prompt
     disclosure, required-tool validation, runtime receipts, and
@@ -135,17 +138,18 @@ val tool_name_can_satisfy_required_contract : string -> bool
 (** Validate that an observed tool call actually mutates state —
     used by the run contract to reject read-only calls under
     [Require_tool_use]. *)
-val required_tool_satisfaction :
-  Agent_sdk.Completion_contract.tool_call -> (unit, string) result
+val required_tool_satisfaction
+  :  Agent_sdk.Completion_contract.tool_call
+  -> (unit, string) result
 
 (** Variant of [required_tool_satisfaction] for an explicit
     [required_tools] contract. A read-only tool can satisfy the turn only when
     the operator/task contract named that exact tool; generic required-tool
     gates remain mutating-only. *)
-val required_tool_satisfaction_for_required_names :
-  required_tool_names:string list ->
-  Agent_sdk.Completion_contract.tool_call ->
-  (unit, string) result
+val required_tool_satisfaction_for_required_names
+  :  required_tool_names:string list
+  -> Agent_sdk.Completion_contract.tool_call
+  -> (unit, string) result
 
 (** Project a tool name to its [tool_progress_class]. *)
 val classify_tool_progress : string -> tool_progress_class
@@ -156,29 +160,29 @@ val is_execution_progress_tool_name : string -> bool
 (** Increment the [keeper_require_tool_use_violations] Prometheus
     counter with [keeper] / [has_current_task] / [contract_status]
     labels. *)
-val record_require_tool_use_violation :
-  keeper_name:string ->
-  has_current_task:bool ->
-  contract_status:string ->
-  unit
+val record_require_tool_use_violation
+  :  keeper_name:string
+  -> has_current_task:bool
+  -> contract_status:string
+  -> unit
 
 (** Build an actionable contract-violation reason describing why
     the keeper failed [Require_tool_use], or [None] when the
     actionable signal context does not apply. *)
-val actionable_tool_contract_violation_reason :
-  claim_context_allowed:bool ->
-  actionable_signal_context:bool ->
-  tool_names:string list ->
-  string option
+val actionable_tool_contract_violation_reason
+  :  claim_context_allowed:bool
+  -> actionable_signal_context:bool
+  -> tool_names:string list
+  -> string option
 
 (** Keep [text] when non-blank; otherwise synthesize a
     "Completed without a textual reply. Tools used: ..." line if
     [tool_names] is non-empty, else error. *)
-val normalize_response_text :
-  text:string ->
-  tool_names:string list ->
-  unit ->
-  (string, string) result
+val normalize_response_text
+  :  text:string
+  -> tool_names:string list
+  -> unit
+  -> (string, string) result
 
 (** Project a user-message text to the BM25 query text by keeping
     only the world-state header and a curated set of subsections. *)
@@ -200,30 +204,29 @@ val query_requests_code_symbols : string -> bool
 (** Allow a deterministic-prefilter tool only when the user's
     [query_text] passes the corresponding code-* gate; everything
     else passes through unchanged. *)
-val allow_deterministic_tool :
-  query_text:string -> string -> bool
+val allow_deterministic_tool : query_text:string -> string -> bool
 
 (** Deterministic BM25 prefilter — pull tools from [search_index]
     that are NOT in [core], pass [allow_deterministic_tool], and
     cap at [selection_limit]. *)
-val deterministic_prefilter_names :
-  search_index:Agent_sdk.Tool_index.t ->
-  query_text:string ->
-  selection_limit:int ->
-  core:string list ->
-  string list
+val deterministic_prefilter_names
+  :  search_index:Agent_sdk.Tool_index.t
+  -> query_text:string
+  -> selection_limit:int
+  -> core:string list
+  -> string list
 
 (** Merge the four tool selection layers (core /
     deterministic_prefilter / discovered / llm_selected) into a
     single ordered, deduped list. BM25-relevant tools are placed
     ahead of generic core to survive downstream max_tools
     truncation. *)
-val merge_tool_selection_boundary :
-  core:string list ->
-  deterministic_prefilter:string list ->
-  llm_selected:string list ->
-  discovered:string list ->
-  string list
+val merge_tool_selection_boundary
+  :  core:string list
+  -> deterministic_prefilter:string list
+  -> llm_selected:string list
+  -> discovered:string list
+  -> string list
 
 (** Proactive contract enforcement — when a keeper has accumulated
     [passive_streak] >= [streak_threshold] consecutive passive turns AND
@@ -233,9 +236,9 @@ val merge_tool_selection_boundary :
 
     Completion tools (stay_silent, release, done, etc.) are never stripped
     because they are the keeper's intentional exit valve. *)
-val contract_enforcement_filter :
-  passive_streak:int ->
-  streak_threshold:int ->
-  actionable_signal:bool ->
-  string list ->
-  string list
+val contract_enforcement_filter
+  :  passive_streak:int
+  -> streak_threshold:int
+  -> actionable_signal:bool
+  -> string list
+  -> string list

--- a/lib/keeper/keeper_tool_disclosure.mli
+++ b/lib/keeper/keeper_tool_disclosure.mli
@@ -224,3 +224,18 @@ val merge_tool_selection_boundary :
   llm_selected:string list ->
   discovered:string list ->
   string list
+
+(** Proactive contract enforcement — when a keeper has accumulated
+    [passive_streak] >= [streak_threshold] consecutive passive turns AND
+    there is an [actionable_signal] (unclaimed tasks, board activity, or
+    discovered work), strip [Passive_status] tools from the surface so the
+    model is forced toward Execution or Completion tools.
+
+    Completion tools (stay_silent, release, done, etc.) are never stripped
+    because they are the keeper's intentional exit valve. *)
+val contract_enforcement_filter :
+  passive_streak:int ->
+  streak_threshold:int ->
+  actionable_signal:bool ->
+  string list ->
+  string list

--- a/test/test_keeper_tool_surface_guard.ml
+++ b/test/test_keeper_tool_surface_guard.ml
@@ -1,47 +1,60 @@
 open Alcotest
-
 module KTD = Masc_mcp.Keeper_tool_disclosure
 
 let test_unexpected_tool_names_accepts_keeper_surface () =
-  check (list string) "no unexpected tools" []
+  check
+    (list string)
+    "no unexpected tools"
+    []
     (KTD.unexpected_tool_names
-       ~allowed_tool_names:
-         [ "keeper_task_claim"; "keeper_board_comment"; "extend_turns" ]
+       ~allowed_tool_names:[ "keeper_task_claim"; "keeper_board_comment"; "extend_turns" ]
        ~tool_names:[ "keeper_task_claim"; "extend_turns" ])
+;;
 
 let test_unexpected_tool_names_reports_foreign_surface () =
-  check (list string) "foreign tools flagged"
+  check
+    (list string)
+    "foreign tools flagged"
     [ "Skill"; "Bash"; "Agent" ]
     (KTD.unexpected_tool_names
-       ~allowed_tool_names:
-         [ "keeper_task_claim"; "keeper_board_comment"; "extend_turns" ]
-       ~tool_names:
-         [ "keeper_task_claim"; "Skill"; "Bash"; "Skill"; "Agent" ])
+       ~allowed_tool_names:[ "keeper_task_claim"; "keeper_board_comment"; "extend_turns" ]
+       ~tool_names:[ "keeper_task_claim"; "Skill"; "Bash"; "Skill"; "Agent" ])
+;;
 
 (* #8471 partial tolerance: mixed turn (valid + unexpected) must not
    hard-fail — the valid tool call is real work and should survive. *)
 let test_has_valid_tool_call_true_when_mixed () =
-  check bool "mixed turn keeps valid tool call" true
+  check
+    bool
+    "mixed turn keeps valid tool call"
+    true
     (KTD.has_valid_tool_call
        ~unexpected_tool_names:[ "Bash"; "Skill" ]
        ~tool_names:[ "keeper_task_claim"; "Bash"; "Skill" ])
+;;
 
 (* Pure hallucination: every call is outside the surface — no valid
    work in this turn, so keeper_agent_run correctly hard-fails. *)
 let test_has_valid_tool_call_false_when_all_unexpected () =
-  check bool "pure hallucination turn has no valid tool" false
+  check
+    bool
+    "pure hallucination turn has no valid tool"
+    false
     (KTD.has_valid_tool_call
        ~unexpected_tool_names:[ "Bash"; "Skill"; "Read" ]
        ~tool_names:[ "Bash"; "Skill"; "Read" ])
+;;
 
 (* Empty turn (text-only response, no tool calls): has_valid returns
    false. The caller's outer `unexpected_tool_names <> []` guard still
    prevents this case from being treated as a partial-tolerance success. *)
 let test_has_valid_tool_call_false_when_empty () =
-  check bool "empty tool list returns false" false
-    (KTD.has_valid_tool_call
-       ~unexpected_tool_names:[]
-       ~tool_names:[])
+  check
+    bool
+    "empty tool list returns false"
+    false
+    (KTD.has_valid_tool_call ~unexpected_tool_names:[] ~tool_names:[])
+;;
 
 (* --- contract_enforcement_filter tests --- *)
 
@@ -56,77 +69,115 @@ let passive_tool_alt = "keeper_pr_status"
 let execution_tool = "keeper_task_claim"
 let completion_tool = "keeper_stay_silent"
 let claim_tool = "masc_claim_next"
-
-let mixed_tools =
-  [ passive_tool; execution_tool; completion_tool; claim_tool ]
+let mixed_tools = [ passive_tool; execution_tool; completion_tool; claim_tool ]
 
 (* Streak below threshold: no filtering regardless of signal. *)
 let test_contract_filter_below_threshold () =
-  check (list string) "all tools preserved" mixed_tools
+  check
+    (list string)
+    "all tools preserved"
+    mixed_tools
     (KTD.contract_enforcement_filter
-       ~passive_streak:2 ~streak_threshold:3 ~actionable_signal:true mixed_tools)
+       ~passive_streak:2
+       ~streak_threshold:3
+       ~actionable_signal:true
+       mixed_tools)
+;;
 
 (* At threshold but no actionable signal: no filtering. *)
 let test_contract_filter_no_signal () =
-  check (list string) "all tools preserved" mixed_tools
+  check
+    (list string)
+    "all tools preserved"
+    mixed_tools
     (KTD.contract_enforcement_filter
-       ~passive_streak:5 ~streak_threshold:3 ~actionable_signal:false mixed_tools)
+       ~passive_streak:5
+       ~streak_threshold:3
+       ~actionable_signal:false
+       mixed_tools)
+;;
 
 (* At threshold WITH actionable signal: passive tools stripped. *)
 let test_contract_filter_strips_passive () =
   let filtered =
     KTD.contract_enforcement_filter
-      ~passive_streak:5 ~streak_threshold:3 ~actionable_signal:true mixed_tools
+      ~passive_streak:5
+      ~streak_threshold:3
+      ~actionable_signal:true
+      mixed_tools
   in
   check bool "passive tool removed" false (List.mem passive_tool filtered);
   check bool "execution preserved" true (List.mem execution_tool filtered);
   check bool "completion preserved" true (List.mem completion_tool filtered);
   check bool "claim preserved" true (List.mem claim_tool filtered);
   check int "3 tools remain" 3 (List.length filtered)
+;;
 
 (* Only passive tools in input: filter returns empty. *)
 let test_contract_filter_all_passive () =
-  check (list string) "empty result" []
+  check
+    (list string)
+    "empty result"
+    []
     (KTD.contract_enforcement_filter
-       ~passive_streak:5 ~streak_threshold:3 ~actionable_signal:true
+       ~passive_streak:5
+       ~streak_threshold:3
+       ~actionable_signal:true
        [ passive_tool; passive_tool_alt ])
+;;
 
 (* Empty input: empty output. *)
 let test_contract_filter_empty_input () =
-  check (list string) "empty in empty out" []
+  check
+    (list string)
+    "empty in empty out"
+    []
     (KTD.contract_enforcement_filter
-       ~passive_streak:5 ~streak_threshold:3 ~actionable_signal:true [])
+       ~passive_streak:5
+       ~streak_threshold:3
+       ~actionable_signal:true
+       [])
+;;
 
 let () =
-  run "keeper_tool_surface_guard"
-    [
-      ( "surface_guard",
-        [
-          test_case "accepts keeper surface" `Quick
-            test_unexpected_tool_names_accepts_keeper_surface;
-          test_case "reports foreign surface" `Quick
-            test_unexpected_tool_names_reports_foreign_surface;
-        ] );
-      ( "partial_tolerance",
-        [
-          test_case "mixed turn keeps valid call" `Quick
-            test_has_valid_tool_call_true_when_mixed;
-          test_case "pure hallucination has no valid" `Quick
-            test_has_valid_tool_call_false_when_all_unexpected;
-          test_case "empty tool list returns false" `Quick
-            test_has_valid_tool_call_false_when_empty;
-        ] );
-      ( "contract_enforcement_filter",
-        [
-          test_case "below threshold: no filtering" `Quick
-            test_contract_filter_below_threshold;
-          test_case "no signal: no filtering" `Quick
-            test_contract_filter_no_signal;
-          test_case "strips passive at threshold with signal" `Quick
-            test_contract_filter_strips_passive;
-          test_case "all passive: returns empty" `Quick
-            test_contract_filter_all_passive;
-          test_case "empty input: empty output" `Quick
-            test_contract_filter_empty_input;
-        ] );
+  run
+    "keeper_tool_surface_guard"
+    [ ( "surface_guard"
+      , [ test_case
+            "accepts keeper surface"
+            `Quick
+            test_unexpected_tool_names_accepts_keeper_surface
+        ; test_case
+            "reports foreign surface"
+            `Quick
+            test_unexpected_tool_names_reports_foreign_surface
+        ] )
+    ; ( "partial_tolerance"
+      , [ test_case
+            "mixed turn keeps valid call"
+            `Quick
+            test_has_valid_tool_call_true_when_mixed
+        ; test_case
+            "pure hallucination has no valid"
+            `Quick
+            test_has_valid_tool_call_false_when_all_unexpected
+        ; test_case
+            "empty tool list returns false"
+            `Quick
+            test_has_valid_tool_call_false_when_empty
+        ] )
+    ; ( "contract_enforcement_filter"
+      , [ test_case
+            "below threshold: no filtering"
+            `Quick
+            test_contract_filter_below_threshold
+        ; test_case "no signal: no filtering" `Quick test_contract_filter_no_signal
+        ; test_case
+            "strips passive at threshold with signal"
+            `Quick
+            test_contract_filter_strips_passive
+        ; test_case "all passive: returns empty" `Quick test_contract_filter_all_passive
+        ; test_case "empty input: empty output" `Quick test_contract_filter_empty_input
+        ] )
     ]
+;;

--- a/test/test_keeper_tool_surface_guard.ml
+++ b/test/test_keeper_tool_surface_guard.ml
@@ -43,6 +43,60 @@ let test_has_valid_tool_call_false_when_empty () =
        ~unexpected_tool_names:[]
        ~tool_names:[])
 
+(* --- contract_enforcement_filter tests --- *)
+
+(* Use real canonical tool names. Passive_status tools must have
+   Tool_catalog.effect_domain = Some Read_only so classify_tool_progress
+   classifies them correctly even when Tool_dispatch.read_only_set is
+   uninitialised (test environment).  keeper_tasks_list and
+   keeper_pr_status both have Read_only effect_domain in Tool_catalog. *)
+
+let passive_tool = "keeper_tasks_list"
+let passive_tool_alt = "keeper_pr_status"
+let execution_tool = "keeper_task_claim"
+let completion_tool = "keeper_stay_silent"
+let claim_tool = "masc_claim_next"
+
+let mixed_tools =
+  [ passive_tool; execution_tool; completion_tool; claim_tool ]
+
+(* Streak below threshold: no filtering regardless of signal. *)
+let test_contract_filter_below_threshold () =
+  check (list string) "all tools preserved" mixed_tools
+    (KTD.contract_enforcement_filter
+       ~passive_streak:2 ~streak_threshold:3 ~actionable_signal:true mixed_tools)
+
+(* At threshold but no actionable signal: no filtering. *)
+let test_contract_filter_no_signal () =
+  check (list string) "all tools preserved" mixed_tools
+    (KTD.contract_enforcement_filter
+       ~passive_streak:5 ~streak_threshold:3 ~actionable_signal:false mixed_tools)
+
+(* At threshold WITH actionable signal: passive tools stripped. *)
+let test_contract_filter_strips_passive () =
+  let filtered =
+    KTD.contract_enforcement_filter
+      ~passive_streak:5 ~streak_threshold:3 ~actionable_signal:true mixed_tools
+  in
+  check bool "passive tool removed" false (List.mem passive_tool filtered);
+  check bool "execution preserved" true (List.mem execution_tool filtered);
+  check bool "completion preserved" true (List.mem completion_tool filtered);
+  check bool "claim preserved" true (List.mem claim_tool filtered);
+  check int "3 tools remain" 3 (List.length filtered)
+
+(* Only passive tools in input: filter returns empty. *)
+let test_contract_filter_all_passive () =
+  check (list string) "empty result" []
+    (KTD.contract_enforcement_filter
+       ~passive_streak:5 ~streak_threshold:3 ~actionable_signal:true
+       [ passive_tool; passive_tool_alt ])
+
+(* Empty input: empty output. *)
+let test_contract_filter_empty_input () =
+  check (list string) "empty in empty out" []
+    (KTD.contract_enforcement_filter
+       ~passive_streak:5 ~streak_threshold:3 ~actionable_signal:true [])
+
 let () =
   run "keeper_tool_surface_guard"
     [
@@ -61,5 +115,18 @@ let () =
             test_has_valid_tool_call_false_when_all_unexpected;
           test_case "empty tool list returns false" `Quick
             test_has_valid_tool_call_false_when_empty;
+        ] );
+      ( "contract_enforcement_filter",
+        [
+          test_case "below threshold: no filtering" `Quick
+            test_contract_filter_below_threshold;
+          test_case "no signal: no filtering" `Quick
+            test_contract_filter_no_signal;
+          test_case "strips passive at threshold with signal" `Quick
+            test_contract_filter_strips_passive;
+          test_case "all passive: returns empty" `Quick
+            test_contract_filter_all_passive;
+          test_case "empty input: empty output" `Quick
+            test_contract_filter_empty_input;
         ] );
     ]


### PR DESCRIPTION
## Summary

- **Proactive contract enforcement**: when a keeper accumulates N consecutive passive turns AND actionable signals exist (unclaimed tasks, board activity, discovered work), strip `Passive_status` tools from the API surface so the model is forced toward Execution or Completion tools
- Completion tools (`stay_silent`, `release`, `done`) are never stripped — they are the keeper's intentional exit valve
- `Keeper_tool_disclosure.contract_enforcement_filter` — pure function, easily testable
- `actionable_signal` threaded through `prepare_agent_setup` from `Keeper_contract_classifier`
- Passive streak tracked via `Keeper_passive_loop_detector.current_streak`

## Test plan
- [x] 10 Alcotest tests: surface_guard (2) + partial_tolerance (3) + contract_enforcement_filter (5)
- [x] `dune build --root . @check` passes
- [x] All tests use real `Tool_catalog` canonical names (`keeper_tasks_list`, `keeper_pr_status`) — no environment-dependent fallbacks
- [ ] CI green

Closes #13631
Refs #11083

🤖 Generated with [Claude Code](https://claude.com/claude-code)