### PR TITLE
feat(cascade): RFC-0058 Phase 1 — Local_inline profile + terminal exemption

### DIFF
--- a/lib/cascade/cascade_capability_profile.ml
+++ b/lib/cascade/cascade_capability_profile.ml
@@ -2,22 +2,25 @@ type profile =
   | Tool_strict
   | Inline_tools
   | Lite
+  | Local_inline
   | Local
 
 let profile_to_string = function
   | Tool_strict -> "tool_strict"
   | Inline_tools -> "inline_tools"
   | Lite -> "lite"
+  | Local_inline -> "local_inline"
   | Local -> "local"
 
 let profile_of_string = function
   | "tool_strict" -> Some Tool_strict
   | "inline_tools" -> Some Inline_tools
   | "lite" -> Some Lite
+  | "local_inline" -> Some Local_inline
   | "local" -> Some Local
   | _ -> None
 
-let all_profiles = [ Tool_strict; Inline_tools; Lite; Local ]
+let all_profiles = [ Tool_strict; Inline_tools; Lite; Local_inline; Local ]
 
 type requirement =
   | Required
@@ -59,6 +62,17 @@ let required_capabilities_of = function
         inline_tool_choice = Optional;
         runtime_mcp_tools = Required;
         runtime_tool_events = Required;
+        runtime_mcp_http_headers = Optional;
+      }
+  | Local_inline ->
+      (* RFC-0058: Ollama-style providers with inline tool calling but no
+         runtime MCP or tool_choice enforcement. Used as terminal fallback
+         capability encoding. *)
+      {
+        inline_tools = Required;
+        inline_tool_choice = Optional;
+        runtime_mcp_tools = Optional;
+        runtime_tool_events = Optional;
         runtime_mcp_http_headers = Optional;
       }
   | Local ->

--- a/lib/cascade/cascade_capability_profile.mli
+++ b/lib/cascade/cascade_capability_profile.mli
@@ -30,6 +30,12 @@ type profile =
           Suitable for [gemini_cli] (static MCP via
           [~/.gemini/settings.json]) and other CLI runtimes that
           carry tools through stdio MCP. *)
+  | Local_inline
+      (** RFC-0058: Ollama-style providers with inline tool calling but
+          no runtime MCP or tool_choice enforcement. Encodes the actual
+          capability set of local LLM providers (inline_tools=Required,
+          everything else Optional). Used as terminal fallback capability
+          where graceful degradation is intentional. *)
   | Local
       (** No capability requirements — accepts any provider including
           ollama-only profiles.  Used by [local_recovery]-like lanes

--- a/lib/cascade/cascade_config_loader.ml
+++ b/lib/cascade/cascade_config_loader.ml
@@ -400,12 +400,16 @@ let detect_fallback_cycles (entries : catalog_entry list) :
   |> snd
   |> List.rev
 
-(* RFC-0055: capability monotonicity on fallback edges.
+(* RFC-0055 + RFC-0058: capability monotonicity on fallback edges.
 
    A fallback edge source -> target is valid only if:
    1. target's capability profile is a superset of source's profile.
    2. An assignable cascade cannot fall back to a non-assignable (sink)
-      cascade. *)
+      cascade.
+   3. (RFC-0058) Terminal fallbacks (fallback_cascade=null) are exempt
+      from monotonicity, since they represent degraded last-resort
+      operation. Runtime filter rejects per-turn if capabilities
+      insufficient. *)
 let detect_capability_mismatches (entries : catalog_entry list) :
     (string * string * string) list =
   let by_name =
@@ -437,14 +441,23 @@ let detect_capability_mismatches (entries : catalog_entry list) :
                 with
                 | Some src_p, Some dst_p ->
                     if not (Cascade_tier.is_subset_profile src_p dst_p) then
-                      Some
-                        ( entry.name,
-                          target_name,
-                          Printf.sprintf
-                            "capability profile %s is not a subset of target \
-                             profile %s"
-                            (Cascade_capability_profile.profile_to_string src_p)
-                            (Cascade_capability_profile.profile_to_string dst_p) )
+                      (* RFC-0058: exempt terminal fallbacks from monotonicity.
+                         Terminal targets (fallback_cascade=null) are last-resort
+                         degraded operation; runtime filter handles per-turn
+                         acceptance. *)
+                      (match target.fallback_cascade with
+                       | None -> None
+                       | Some _ ->
+                         Some
+                           ( entry.name,
+                             target_name,
+                             Printf.sprintf
+                               "capability profile %s is not a subset of target \
+                                profile %s"
+                               (Cascade_capability_profile.profile_to_string
+                                  src_p)
+                               (Cascade_capability_profile.profile_to_string
+                                  dst_p) ))
                     else None
                 | _ -> None
               in


### PR DESCRIPTION
## Summary
- Add `Local_inline` capability profile variant encoding Ollama-style providers (`inline_tools=Required`, everything else `Optional`)
- Exempt terminal fallback cascades (`fallback_cascade=null`) from capability monotonicity in `detect_capability_mismatches` — runtime filter still enforces per-turn
- 3 files, +44/-11, no new test regressions (5 pre-existing failures on main unchanged)

## RFC
- **RFC-0058**: `docs/rfc/RFC-0058-terminal-fallback-capability-exemption.md` (merged in #14403)
- **RFC-0055**: capability monotonicity (fallback edges require target ⊇ source)

## Test Verification
| Test Suite | Result | Notes |
|---|---|---|
| `test_cascade_config_validity` | ✅ all pass | |
| `test_cascade_catalog_runtime` | ⚠️ 2 fail | pre-existing on main |
| `test_keeper_cascade_routing` | ✅ 17/17 pass | |
| `test_cascade_runtime` | ⚠️ 3 fail | pre-existing on main (`gemini_cli` capability mismatch) |

All failures are identical on `origin/main` — **0 new regressions**.

## Remaining Phases (separate PRs)
- **Phase 2**: Config rollout — declare `"local_inline"` for `local_recovery`, `local_test`, `ollama_only`, `ollama_bench` in `cascade.json`
- **Phase 3**: Property tests for terminal exemption edge cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)