### PR TITLE
fix(cascade): provider_filter bypass in dual-track secondary swap (#13132 B)

### DIFF
--- a/lib/cascade/cascade_catalog_runtime.mli
+++ b/lib/cascade/cascade_catalog_runtime.mli
@@ -137,6 +137,15 @@ val resolve_secondary_provider_for_primary :
     state — secondary resolution is invoked only after the primary has
     been rejected by the tool-use gate. *)
 
+val provider_filter_allows_single :
+  provider_filter:string list option ->
+  label:string ->
+  Llm_provider.Provider_config.t ->
+  bool
+(** [true] when [provider] passes the provider-kind allowlist, or when
+    [provider_filter] is [None]/empty (no filter declared). Uses
+    [Cascade_config.apply_provider_filter_strict] internally. *)
+
 val resolve_inference_params :
   ?sw:Eio.Switch.t ->
   ?net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t ->

--- a/lib/cascade/cascade_oas_runner.ml
+++ b/lib/cascade/cascade_oas_runner.ml
@@ -320,7 +320,7 @@ let cascade_empty_should_emit_first ~label ~signature =
     The function is total and never raises; secondary parsing errors are
     surfaced as [None] by the resolver. *)
 let attempt_secondary_swap
-    ~keeper_name ?runtime_mcp_policy ~tools
+    ~keeper_name ?provider_filter ?runtime_mcp_policy ~tools
     ~require_tool_choice_support ~require_tool_support
     ~(secondary_resolver :
         int ->
@@ -332,7 +332,15 @@ let attempt_secondary_swap
      Llm_provider.Provider_config.t * filter_rejection_reason) Either.t =
   match secondary_resolver provider_index primary with
   | None -> Either.Right (primary, primary_reason)
-  | Some secondary -> (
+  | Some secondary ->
+    (* #13132 B: reject secondary when provider_filter excludes its kind.
+       Without this gate, a keeper restricted to one provider kind can be
+       swapped onto a disallowed kind, bypassing the caller's explicit
+       filter entirely. *)
+    if not (Cascade_catalog_runtime.provider_filter_allows_single
+              ~provider_filter ~label:"secondary_swap" secondary)
+    then Either.Right (primary, primary_reason)
+    else (
       (* RFC-0027 PR-9c: per-secondary accounting label.
          The secondary's [provider_kind] is a closed enum from
          [Llm_provider.Provider_config.string_of_provider_kind] so
@@ -378,6 +386,7 @@ let attempt_secondary_swap
 
 let filter_candidate_providers_for_tool_support
     ~(keeper_name : string)
+    ?provider_filter
     ?runtime_mcp_policy
     ?(tools = [])
     ~require_tool_choice_support
@@ -406,7 +415,7 @@ let filter_candidate_providers_for_tool_support
                  | None -> Either.Right (provider_cfg, reason)
                  | Some resolver ->
                      attempt_secondary_swap
-                       ~keeper_name ?runtime_mcp_policy ~tools
+                       ~keeper_name ?provider_filter ?runtime_mcp_policy ~tools
                        ~require_tool_choice_support ~require_tool_support
                        ~secondary_resolver:resolver
                        ~provider_index
@@ -473,6 +482,7 @@ let filter_candidate_providers_for_tool_support
 let resolve_tool_capable_provider_across_cascades
     ~sw ~net
     ~(keeper_name : string)
+    ?provider_filter
     ?runtime_mcp_policy
     ?(tools = [])
     ~require_tool_choice_support
@@ -507,7 +517,7 @@ let resolve_tool_capable_provider_across_cascades
                  in
                  let filtered =
                    filter_candidate_providers_for_tool_support
-                     ~keeper_name ?runtime_mcp_policy ~tools
+                     ~keeper_name ?provider_filter ?runtime_mcp_policy ~tools
                      ~require_tool_choice_support ~require_tool_support
                      ~secondary_resolver
                      ~label:cascade_name providers

--- a/lib/cascade/cascade_oas_runner.mli
+++ b/lib/cascade/cascade_oas_runner.mli
@@ -111,6 +111,7 @@ val classify_filter_rejection :
 
 val filter_candidate_providers_for_tool_support :
   keeper_name:string ->
+  ?provider_filter:string list ->
   ?runtime_mcp_policy:Llm_provider.Llm_transport.runtime_mcp_policy ->
   ?tools:Agent_sdk.Tool.t list ->
   require_tool_choice_support:bool ->
@@ -141,6 +142,7 @@ val resolve_tool_capable_provider_across_cascades :
   sw:Eio.Switch.t ->
   net:Eio_context.eio_net ->
   keeper_name:string ->
+  ?provider_filter:string list ->
   ?runtime_mcp_policy:Llm_provider.Llm_transport.runtime_mcp_policy ->
   ?tools:Agent_sdk.Tool.t list ->
   require_tool_choice_support:bool ->

--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -150,6 +150,7 @@ let run_named
   let candidate_cfgs =
     filter_candidate_providers_for_tool_support
       ~keeper_name
+      ?provider_filter
       ?runtime_mcp_policy
       ~tools
       ~require_tool_choice_support
@@ -177,7 +178,7 @@ let run_named
     match candidate_cfgs with
     | [] ->
         (match resolve_tool_capable_provider_across_cascades
-                ~sw ~net ~keeper_name ?runtime_mcp_policy ~tools
+                ~sw ~net ~keeper_name ?provider_filter ?runtime_mcp_policy ~tools
                 ~require_tool_choice_support ~require_tool_support
                 ~exclude_cascade:cascade_name ()
          with


### PR DESCRIPTION
## Summary

Fixes #13132 (Track B): `attempt_secondary_swap` resolved secondaries without re-applying the caller's `provider_filter` (provider-kind allowlist). A keeper restricted to one provider kind could be silently swapped onto a disallowed kind via the secondary path.

## Root Cause

The `provider_filter` was applied at provider resolution time but not at the secondary swap point. The defence was single-layer: once past the initial filter, no re-validation occurred on the alternative path.

## Changes

- `attempt_secondary_swap`: accepts `?provider_filter`, rejects secondaries that fail `provider_filter_allows_single`
- `filter_candidate_providers_for_tool_support`: threads `?provider_filter` to `attempt_secondary_swap`
- `resolve_tool_capable_provider_across_cascades`: threads `?provider_filter` through cross-cascade fallback
- `keeper_turn_driver.run_named`: passes its `?provider_filter` to both filter and cross-cascade paths
- Exports `provider_filter_allows_single` from `cascade_catalog_runtime.mli`

## Test plan

- [x] `dune build --root . @check` passes
- [ ] `dune runtest` passes (running)
- [ ] Issue #13132 F: regression test coverage for secondary swap path (follow-up)

## Remaining tracks from #13132

| Track | Description | Status |
|-------|-------------|--------|
| B | provider_filter bypass | **This PR** |
| C | secondary lookup ambiguity by kind+model_id | Separate PR |
| D | model_strings mode leakage | Separate PR |
| F | regression test coverage | Follow-up |

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>