### PR TITLE
[RFC-0057] Phase 2 — spec library extraction + masc_tool_help codegen

### DIFF
--- a/bin/dune
+++ b/bin/dune
@@ -113,14 +113,13 @@
  (name gen_shell_ir_walkers)
  (modules gen_shell_ir_walkers))
 
-; RFC-0057 Phase 0 — tool descriptor codegen for lib/tool_schemas/.
-; Self-contained (no library deps) to avoid the dune cycle between
-; this executable and masc_tool_schemas, which consumes the emitted
-; tool_descriptors_gen.ml. Same self-containment pattern as
-; gen_shell_ir_walkers above. Phase 1 lifts the spec records into a
-; sibling library lib/tool_schemas_specs/ once a 2nd tool lands.
+; RFC-0057 Phase 2 — tool descriptor codegen for lib/tool_schemas/.
+; Depends on tool_schemas_specs (types-only sibling library) to share
+; spec records with future schema-lint / doc-gen tooling. The cycle is
+; avoided because tool_schemas_specs does not depend on masc_tool_schemas.
 (executable
  (name gen_tool_descriptors)
- (modules gen_tool_descriptors))
+ (modules gen_tool_descriptors)
+ (libraries tool_schemas_specs))
 
 ; Executable for MASC MCP

--- a/bin/gen_tool_descriptors.ml
+++ b/bin/gen_tool_descriptors.ml
@@ -1,4 +1,4 @@
-(* RFC-0057 Phase 1 — tool descriptor codegen.
+(* RFC-0057 Phase 2 — tool descriptor codegen.
 
    Mirrors bin/gen_shell_ir_walkers.ml: spec-as-OCaml-value -> Buffer.emit
    -> stdout. The dune rule in lib/tool_schemas/ captures stdout into
@@ -6,39 +6,13 @@
    generated schemas live alongside the hand-written ones in the same
    module namespace.
 
-   Phase 1 scope: masc_config + masc_code_read. The regression test
-   (test/test_tool_descriptors_gen.ml) compares emitted schemas against
-   hand-written ones field-by-field on Yojson values. tool_schemas_misc.ml
-   drops the hand-written masc_config entry and concatenates
-   Tool_descriptors_gen.schemas so generated schemas are the SSOT.
+   Phase 2 lifted spec types into lib/tool_schemas_specs/ to share
+   between the generator and any future tooling (schema lint, doc
+   generation). The executable now depends on tool_schemas_specs (types
+   only), avoiding the cycle because that library does not depend on
+   masc_tool_schemas. *)
 
-   Why self-contained (no library deps)?
-   bin/gen_shell_ir_walkers.ml (RFC-0054 PR-3) sets the precedent: the
-   generator carries its own spec to avoid a dune cycle between
-   (executable) and (library) when the library would consume the
-   generated file. Phase 2 lifts the spec records into a sibling
-   library lib/tool_schemas_specs/ once a 3rd tool lands. *)
-
-(* === Spec types (local; will move to lib/tool_schemas_specs in Phase 1). *)
-
-type param_type =
-  | T_string of { enum : string list option }
-  | T_int of { min : int option; max : int option }
-  | T_bool
-
-type param =
-  { p_name : string
-  ; p_type : param_type
-  ; p_description : string
-  ; p_required : bool
-  }
-
-type tool_spec =
-  { name : string
-  ; description : string
-  ; parameters : param list
-  ; additional_properties : bool
-  }
+open Tool_schemas_specs_types
 
 (* === Phase 0 spec data ==============================================
 
@@ -98,7 +72,22 @@ Use when inspecting source code during task execution without loading the entire
   ; additional_properties = false
   }
 
-let phase1_specs : tool_spec list = [ masc_config_spec; masc_code_read_spec ]
+let masc_tool_help_spec : tool_spec =
+  { name = "masc_tool_help"
+  ; description =
+      "Return canonical help text, parameters, and metadata for a specific MASC tool by name."
+  ; parameters =
+      [ { p_name = "tool_name"
+        ; p_type = T_string { enum = None }
+        ; p_description = "Exact MCP tool name to explain"
+        ; p_required = true
+        }
+      ]
+  ; additional_properties = false
+  }
+
+let phase2_specs : tool_spec list =
+  [ masc_config_spec; masc_code_read_spec; masc_tool_help_spec ]
 
 (* === Emit helpers ==================================================== *)
 
@@ -181,5 +170,5 @@ let emit_schemas_list buf specs =
 let () =
   let buf = Buffer.create 4096 in
   emit_header buf;
-  emit_schemas_list buf phase1_specs;
+  emit_schemas_list buf phase2_specs;
   print_string (Buffer.contents buf)

--- a/bin/gen_tool_descriptors.ml
+++ b/bin/gen_tool_descriptors.ml
@@ -24,19 +24,36 @@ open Tool_schemas_specs_types
    SSOT. *)
 
 let config_category_enum_strings =
-  [ "server"; "auth"; "transport"; "storage"; "runtime"
-  ; "rate_limiting"; "inference"; "keeper"; "keeper_execution"
-  ; "keeper_guardrails"; "autonomy"; "level2"; "dashboard"
-  ; "economy"; "governance"; "channel"; "process"; "worker"
-  ; "web_search"; "session"
+  [ "server"
+  ; "auth"
+  ; "transport"
+  ; "storage"
+  ; "runtime"
+  ; "rate_limiting"
+  ; "inference"
+  ; "keeper"
+  ; "keeper_execution"
+  ; "keeper_guardrails"
+  ; "autonomy"
+  ; "level2"
+  ; "dashboard"
+  ; "economy"
+  ; "governance"
+  ; "channel"
+  ; "process"
+  ; "worker"
+  ; "web_search"
+  ; "session"
   ]
+;;
 
 let masc_config_spec : tool_spec =
   { name = "masc_config"
   ; description =
-      "Return the effective runtime configuration with source attribution (env var or default) for each setting. \
-Sensitive values (tokens, passwords) are masked. Use to inspect or verify the server config without restarting. \
-Pass category to filter results to a single section."
+      "Return the effective runtime configuration with source attribution (env var or \
+       default) for each setting. Sensitive values (tokens, passwords) are masked. Use \
+       to inspect or verify the server config without restarting. Pass category to \
+       filter results to a single section."
   ; parameters =
       [ { p_name = "category"
         ; p_type = T_string { enum = Some config_category_enum_strings }
@@ -46,12 +63,13 @@ Pass category to filter results to a single section."
       ]
   ; additional_properties = false
   }
+;;
 
 let masc_code_read_spec : tool_spec =
   { name = "masc_code_read"
   ; description =
-      "Read a file with offset/limit pagination for large files. \
-Use when inspecting source code during task execution without loading the entire file into context."
+      "Read a file with offset/limit pagination for large files. Use when inspecting \
+       source code during task execution without loading the entire file into context."
   ; parameters =
       [ { p_name = "path"
         ; p_type = T_string { enum = None }
@@ -71,11 +89,13 @@ Use when inspecting source code during task execution without loading the entire
       ]
   ; additional_properties = false
   }
+;;
 
 let masc_tool_help_spec : tool_spec =
   { name = "masc_tool_help"
   ; description =
-      "Return canonical help text, parameters, and metadata for a specific MASC tool by name."
+      "Return canonical help text, parameters, and metadata for a specific MASC tool by \
+       name."
   ; parameters =
       [ { p_name = "tool_name"
         ; p_type = T_string { enum = None }
@@ -85,33 +105,38 @@ let masc_tool_help_spec : tool_spec =
       ]
   ; additional_properties = false
   }
+;;
 
 let phase2_specs : tool_spec list =
   [ masc_config_spec; masc_code_read_spec; masc_tool_help_spec ]
+;;
 
 (* === Emit helpers ==================================================== *)
 
 let buf_addf buf fmt = Printf.ksprintf (Buffer.add_string buf) fmt
 
 let emit_header buf =
-  Buffer.add_string buf
+  Buffer.add_string
+    buf
     "(* GENERATED - DO NOT EDIT.\n\
     \   Source: bin/gen_tool_descriptors.ml (RFC-0057 Phase 1).\n\
-    \   To regenerate: dune build *)\n\
-     \n\
-     open Masc_domain\n\
-     \n"
+    \   To regenerate: dune build *)\n\n\
+     open Masc_domain\n\n"
+;;
 
 let emit_enum_list buf strings =
   Buffer.add_string buf "`List [";
-  List.iteri (fun i s ->
-    if i > 0 then Buffer.add_string buf "; ";
-    buf_addf buf "`String %S" s
-  ) strings;
+  List.iteri
+    (fun i s ->
+       if i > 0 then Buffer.add_string buf "; ";
+       buf_addf buf "`String %S" s)
+    strings;
   Buffer.add_string buf "]"
+;;
 
 let emit_param_property buf p =
-  let type_label = match p.p_type with
+  let type_label =
+    match p.p_type with
     | T_string _ -> "string"
     | T_int _ -> "integer"
     | T_bool -> "boolean"
@@ -126,20 +151,23 @@ let emit_param_property buf p =
    | _ -> ());
   buf_addf buf "          (\"description\", `String %S);\n" p.p_description;
   Buffer.add_string buf "        ]);\n"
+;;
 
 let emit_required buf params =
-  let req = List.filter_map
-    (fun p -> if p.p_required then Some p.p_name else None) params
+  let req =
+    List.filter_map (fun p -> if p.p_required then Some p.p_name else None) params
   in
   match req with
   | [] -> ()
   | _ ->
     Buffer.add_string buf "      (\"required\", `List [";
-    List.iteri (fun i name ->
-      if i > 0 then Buffer.add_string buf "; ";
-      buf_addf buf "`String %S" name
-    ) req;
+    List.iteri
+      (fun i name ->
+         if i > 0 then Buffer.add_string buf "; ";
+         buf_addf buf "`String %S" name)
+      req;
     Buffer.add_string buf "]);\n"
+;;
 
 let emit_tool_schema buf spec =
   Buffer.add_string buf "  {\n";
@@ -148,22 +176,22 @@ let emit_tool_schema buf spec =
   Buffer.add_string buf "    input_schema = `Assoc [\n";
   Buffer.add_string buf "      (\"type\", `String \"object\");\n";
   (match spec.parameters with
-   | [] ->
-     Buffer.add_string buf "      (\"properties\", `Assoc []);\n"
+   | [] -> Buffer.add_string buf "      (\"properties\", `Assoc []);\n"
    | params ->
      Buffer.add_string buf "      (\"properties\", `Assoc [\n";
      List.iter (emit_param_property buf) params;
      Buffer.add_string buf "      ]);\n");
   emit_required buf spec.parameters;
-  buf_addf buf "      (\"additionalProperties\", `Bool %b);\n"
-    spec.additional_properties;
+  buf_addf buf "      (\"additionalProperties\", `Bool %b);\n" spec.additional_properties;
   Buffer.add_string buf "    ];\n";
   Buffer.add_string buf "  };\n"
+;;
 
 let emit_schemas_list buf specs =
   Buffer.add_string buf "let schemas : tool_schema list = [\n";
   List.iter (emit_tool_schema buf) specs;
   Buffer.add_string buf "]\n"
+;;
 
 (* === Entry point ===================================================== *)
 
@@ -172,3 +200,4 @@ let () =
   emit_header buf;
   emit_schemas_list buf phase2_specs;
   print_string (Buffer.contents buf)
+;;

--- a/lib/tool_schemas/tool_schemas_misc.ml
+++ b/lib/tool_schemas/tool_schemas_misc.ml
@@ -147,21 +147,6 @@ Use from the answering side after a prior masc_webrtc_offer call.";
     ];
   };
   {
-    name = "masc_tool_help";
-    description = "Return canonical help text, parameters, and metadata for a specific MASC tool by name.";
-    input_schema = `Assoc [
-      ("type", `String "object");
-      ("properties", `Assoc [
-        ("tool_name", `Assoc [
-          ("type", `String "string");
-          ("description", `String "Exact MCP tool name to explain");
-        ]);
-      ]);
-      ("required", `List [`String "tool_name"]);
-      ("additionalProperties", `Bool false);
-    ];
-  };
-  {
     name = "masc_web_search";
     description = "Search the public web and return top result titles, URLs, and snippets. \
 Read-only helper for current-information lookups before deeper file or repo work. \

--- a/lib/tool_schemas/tool_schemas_misc.ml
+++ b/lib/tool_schemas/tool_schemas_misc.ml
@@ -24,238 +24,329 @@ let dashboard_scope_enum_strings = [ "all"; "current" ]
     sync test in [test/test_types.ml :: config_category_ssot] keeps this
     mirror aligned with the producer-side SSOT. *)
 let config_category_enum_strings =
-  [
-    "server"; "auth"; "transport"; "storage"; "runtime";
-    "rate_limiting"; "inference"; "keeper"; "keeper_execution";
-    "keeper_guardrails"; "autonomy"; "level2"; "dashboard";
-    "economy"; "governance"; "channel"; "process"; "worker";
-    "web_search"; "session";
+  [ "server"
+  ; "auth"
+  ; "transport"
+  ; "storage"
+  ; "runtime"
+  ; "rate_limiting"
+  ; "inference"
+  ; "keeper"
+  ; "keeper_execution"
+  ; "keeper_guardrails"
+  ; "autonomy"
+  ; "level2"
+  ; "dashboard"
+  ; "economy"
+  ; "governance"
+  ; "channel"
+  ; "process"
+  ; "worker"
+  ; "web_search"
+  ; "session"
   ]
+;;
 
-let schemas : tool_schema list = [
-  {
-    name = "masc_webrtc_offer";
-    description = "Create a WebRTC signaling offer in the server registry and return an offer_id. \
-Use from the initiating side before calling masc_webrtc_answer from the answering side.";
-    input_schema = `Assoc [
-      ("type", `String "object");
-      ("properties", `Assoc [
-        ("agent_name", `Assoc [
-          ("type", `String "string");
-          ("description", `String "Name of the agent creating the offer");
-        ]);
-        ("ice_candidates", `Assoc [
-          ("type", `String "array");
-          ("items", `Assoc [("type", `String "string")]);
-          ("description", `String "ICE candidates gathered by the offering peer");
-          ("default", `List []);
-        ]);
-        ("dtls_fingerprint", `Assoc [
-          ("type", `String "string");
-          ("description", `String "Optional DTLS fingerprint for the offering peer");
-        ]);
-      ]);
-      ("required", `List [`String "agent_name"]);
-      ("additionalProperties", `Bool false);
-    ];
-  };
-  {
-    name = "masc_webrtc_answer";
-    description = "Accept a pending WebRTC signaling offer by offer_id and return the peer_id plus server-side ICE credentials. \
-Use from the answering side after a prior masc_webrtc_offer call.";
-    input_schema = `Assoc [
-      ("type", `String "object");
-      ("properties", `Assoc [
-        ("offer_id", `Assoc [
-          ("type", `String "string");
-          ("description", `String "Offer identifier returned by masc_webrtc_offer");
-        ]);
-        ("agent_name", `Assoc [
-          ("type", `String "string");
-          ("description", `String "Name of the agent accepting the offer");
-        ]);
-        ("ice_candidates", `Assoc [
-          ("type", `String "array");
-          ("items", `Assoc [("type", `String "string")]);
-          ("description", `String "Optional ICE candidates gathered by the answering peer");
-          ("default", `List []);
-        ]);
-      ]);
-      ("required", `List [`String "offer_id"; `String "agent_name"]);
-      ("additionalProperties", `Bool false);
-    ];
-  };
-  {
-    name = "masc_dashboard";
-    description = "Render the MASC dashboard summarizing rooms, agents, and tasks. Set scope='current' for this room only.";
-    input_schema = `Assoc [
-      ("type", `String "object");
-      ("properties", `Assoc [
-        ("compact", `Assoc [
-          ("type", `String "boolean");
-          ("description", `String "If true, show compact single-line summary instead of full dashboard");
-        ]);
-        ("scope", `Assoc [
-          ("type", `String "string");
-          ("enum", `List (List.map (fun s -> `String s) dashboard_scope_enum_strings));
-          ("description", `String "Dashboard scope (default: all)");
-          ("default", `String "all");
-        ]);
-      ]);
-      ("additionalProperties", `Bool false);
-    ];
-  };
-  {
-    name = "masc_gc";
-    description = "Run garbage collection: remove zombie agents, archive stale tasks, delete old messages (default: 7-day threshold).";
-    input_schema = `Assoc [
-      ("type", `String "object");
-      ("properties", `Assoc [
-        ("days", `Assoc [
-          ("type", `String "integer");
-          ("default", `Int 7);
-          ("description", `String "Age threshold in days (default: 7)");
-        ]);
-      ]);
-      ("additionalProperties", `Bool false);
-    ];
-  };
-  {
-    name = "masc_cleanup_zombies";
-    description = "Remove zombie agents (no heartbeat for 5+ min) and release their file locks.";
-    input_schema = `Assoc [
-      ("type", `String "object");
-      ("properties", `Assoc []);
-      ("additionalProperties", `Bool false);
-    ];
-  };
-  {
-    name = "masc_tool_stats";
-    description = "In-memory tool usage stats: top calls, stale (30+ days), never-called. Resets on server restart.";
-    input_schema = `Assoc [
-      ("type", `String "object");
-      ("properties", `Assoc [
-        ("top_n", `Assoc [
-          ("type", `String "integer");
-          ("description", `String "Number of top tools to return (default: 20)");
-          ("default", `Int 20);
-          ("minimum", `Int 1);
-          ("maximum", `Int 100);
-        ]);
-      ]);
-      ("additionalProperties", `Bool false);
-    ];
-  };
-  {
-    name = "masc_web_search";
-    description = "Search the public web and return top result titles, URLs, and snippets. \
-Read-only helper for current-information lookups before deeper file or repo work. \
-Uses configured web-search providers with structured fallback behavior and returns structured JSON.";
-    input_schema = `Assoc [
-      ("type", `String "object");
-      ("properties", `Assoc [
-        ("query", `Assoc [
-          ("type", `String "string");
-          ("description", `String "Search query text");
-        ]);
-        ("limit", `Assoc [
-          ("type", `String "integer");
-          ("description", `String "Maximum number of results to return (default 5, max 10)");
-          ("default", `Int 5);
-          ("minimum", `Int 1);
-          ("maximum", `Int 10);
-        ]);
-      ]);
-      ("required", `List [`String "query"]);
-      ("additionalProperties", `Bool false);
-    ];
-  };
-  {
-    name = "masc_web_fetch";
-    description = "Fetch a web page by URL and return cleaned text content. \
-Read-only helper for reading selected sources after web search before citing them. \
-Strips HTML tags, decodes entities, normalizes whitespace, and optionally extracts \
-<title> and <meta name=\"description\">. Returns structured JSON with the cleaned text.";
-    input_schema = `Assoc [
-      ("type", `String "object");
-      ("properties", `Assoc [
-        ("url", `Assoc [
-          ("type", `String "string");
-          ("description", `String "URL to fetch (http or https only)");
-        ]);
-        ("timeout", `Assoc [
-          ("type", `String "integer");
-          ("description", `String "Request timeout in seconds (default 15, max 60)");
-          ("default", `Int 15);
-          ("minimum", `Int 1);
-          ("maximum", `Int 60);
-        ]);
-      ]);
-      ("required", `List [`String "url"]);
-      ("additionalProperties", `Bool false);
-    ];
-  };
-  {
-    name = "masc_tool_admin_snapshot";
-    description = "Return a unified admin snapshot of tool inventory, auth/RBAC, and command-plane surfaces.";
-    input_schema = `Assoc [
-      ("type", `String "object");
-      ("properties", `Assoc [
-        ("include_hidden", `Assoc [
-          ("type", `String "boolean");
-          ("description", `String "Include hidden tools in tool_inventory (default: true)");
-          ("default", `Bool true);
-        ]);
-        ("include_deprecated", `Assoc [
-          ("type", `String "boolean");
-          ("description", `String "Include deprecated tools in tool_inventory (default: true)");
-          ("default", `Bool true);
-        ]);
-      ]);
-      ("additionalProperties", `Bool false);
-    ];
-  };
-  {
-    name = "masc_tool_admin_update";
-    description = "Apply auth updates through a single admin entrypoint. \
-Use after masc_tool_admin_snapshot to review current state before making changes. \
-Additional sections (unit_policy, keeper_policy) are not yet implemented and \
-will be added here when their handlers land.";
-    input_schema = `Assoc [
-      ("type", `String "object");
-      ("properties", `Assoc [
-        ("section", `Assoc [
-          ("type", `String "string");
-          ("enum", `List (List.map (fun s -> `String s) admin_section_enum_strings));
-          ("description", `String "Config section to update (currently only auth is implemented)");
-        ]);
-        ("enabled", `Assoc [
-          ("type", `String "boolean");
-          ("description", `String "Enable or disable auth for section=auth");
-        ]);
-        ("require_token", `Assoc [
-          ("type", `String "boolean");
-          ("description", `String "Require tokens for section=auth");
-        ]);
-        ("token_expiry_hours", `Assoc [
-          ("type", `String "integer");
-          ("description", `String "Token expiry in hours for section=auth");
-        ]);
-        ("unit_id", `Assoc [
-          ("type", `String "string");
-          ("description", `String "Managed unit id for section=unit_policy");
-        ]);
-        ("policy", `Assoc [
-          ("type", `String "object");
-          ("description", `String "Unit policy envelope for section=unit_policy");
-        ]);
-        ("budget", `Assoc [
-          ("type", `String "object");
-          ("description", `String "Unit budget envelope for section=unit_policy");
-        ]);
-      ]);
-      ("required", `List [`String "section"]);
-      ("additionalProperties", `Bool false);
-    ];
-  };
-] @ Tool_descriptors_gen.schemas
+let schemas : tool_schema list =
+  [ { name = "masc_webrtc_offer"
+    ; description =
+        "Create a WebRTC signaling offer in the server registry and return an offer_id. \
+         Use from the initiating side before calling masc_webrtc_answer from the \
+         answering side."
+    ; input_schema =
+        `Assoc
+          [ "type", `String "object"
+          ; ( "properties"
+            , `Assoc
+                [ ( "agent_name"
+                  , `Assoc
+                      [ "type", `String "string"
+                      ; "description", `String "Name of the agent creating the offer"
+                      ] )
+                ; ( "ice_candidates"
+                  , `Assoc
+                      [ "type", `String "array"
+                      ; "items", `Assoc [ "type", `String "string" ]
+                      ; ( "description"
+                        , `String "ICE candidates gathered by the offering peer" )
+                      ; "default", `List []
+                      ] )
+                ; ( "dtls_fingerprint"
+                  , `Assoc
+                      [ "type", `String "string"
+                      ; ( "description"
+                        , `String "Optional DTLS fingerprint for the offering peer" )
+                      ] )
+                ] )
+          ; "required", `List [ `String "agent_name" ]
+          ; "additionalProperties", `Bool false
+          ]
+    }
+  ; { name = "masc_webrtc_answer"
+    ; description =
+        "Accept a pending WebRTC signaling offer by offer_id and return the peer_id plus \
+         server-side ICE credentials. Use from the answering side after a prior \
+         masc_webrtc_offer call."
+    ; input_schema =
+        `Assoc
+          [ "type", `String "object"
+          ; ( "properties"
+            , `Assoc
+                [ ( "offer_id"
+                  , `Assoc
+                      [ "type", `String "string"
+                      ; ( "description"
+                        , `String "Offer identifier returned by masc_webrtc_offer" )
+                      ] )
+                ; ( "agent_name"
+                  , `Assoc
+                      [ "type", `String "string"
+                      ; "description", `String "Name of the agent accepting the offer"
+                      ] )
+                ; ( "ice_candidates"
+                  , `Assoc
+                      [ "type", `String "array"
+                      ; "items", `Assoc [ "type", `String "string" ]
+                      ; ( "description"
+                        , `String "Optional ICE candidates gathered by the answering peer"
+                        )
+                      ; "default", `List []
+                      ] )
+                ] )
+          ; "required", `List [ `String "offer_id"; `String "agent_name" ]
+          ; "additionalProperties", `Bool false
+          ]
+    }
+  ; { name = "masc_dashboard"
+    ; description =
+        "Render the MASC dashboard summarizing rooms, agents, and tasks. Set \
+         scope='current' for this room only."
+    ; input_schema =
+        `Assoc
+          [ "type", `String "object"
+          ; ( "properties"
+            , `Assoc
+                [ ( "compact"
+                  , `Assoc
+                      [ "type", `String "boolean"
+                      ; ( "description"
+                        , `String
+                            "If true, show compact single-line summary instead of full \
+                             dashboard" )
+                      ] )
+                ; ( "scope"
+                  , `Assoc
+                      [ "type", `String "string"
+                      ; ( "enum"
+                        , `List
+                            (List.map (fun s -> `String s) dashboard_scope_enum_strings) )
+                      ; "description", `String "Dashboard scope (default: all)"
+                      ; "default", `String "all"
+                      ] )
+                ] )
+          ; "additionalProperties", `Bool false
+          ]
+    }
+  ; { name = "masc_gc"
+    ; description =
+        "Run garbage collection: remove zombie agents, archive stale tasks, delete old \
+         messages (default: 7-day threshold)."
+    ; input_schema =
+        `Assoc
+          [ "type", `String "object"
+          ; ( "properties"
+            , `Assoc
+                [ ( "days"
+                  , `Assoc
+                      [ "type", `String "integer"
+                      ; "default", `Int 7
+                      ; "description", `String "Age threshold in days (default: 7)"
+                      ] )
+                ] )
+          ; "additionalProperties", `Bool false
+          ]
+    }
+  ; { name = "masc_cleanup_zombies"
+    ; description =
+        "Remove zombie agents (no heartbeat for 5+ min) and release their file locks."
+    ; input_schema =
+        `Assoc
+          [ "type", `String "object"
+          ; "properties", `Assoc []
+          ; "additionalProperties", `Bool false
+          ]
+    }
+  ; { name = "masc_tool_stats"
+    ; description =
+        "In-memory tool usage stats: top calls, stale (30+ days), never-called. Resets \
+         on server restart."
+    ; input_schema =
+        `Assoc
+          [ "type", `String "object"
+          ; ( "properties"
+            , `Assoc
+                [ ( "top_n"
+                  , `Assoc
+                      [ "type", `String "integer"
+                      ; ( "description"
+                        , `String "Number of top tools to return (default: 20)" )
+                      ; "default", `Int 20
+                      ; "minimum", `Int 1
+                      ; "maximum", `Int 100
+                      ] )
+                ] )
+          ; "additionalProperties", `Bool false
+          ]
+    }
+  ; { name = "masc_web_search"
+    ; description =
+        "Search the public web and return top result titles, URLs, and snippets. \
+         Read-only helper for current-information lookups before deeper file or repo \
+         work. Uses configured web-search providers with structured fallback behavior \
+         and returns structured JSON."
+    ; input_schema =
+        `Assoc
+          [ "type", `String "object"
+          ; ( "properties"
+            , `Assoc
+                [ ( "query"
+                  , `Assoc
+                      [ "type", `String "string"
+                      ; "description", `String "Search query text"
+                      ] )
+                ; ( "limit"
+                  , `Assoc
+                      [ "type", `String "integer"
+                      ; ( "description"
+                        , `String
+                            "Maximum number of results to return (default 5, max 10)" )
+                      ; "default", `Int 5
+                      ; "minimum", `Int 1
+                      ; "maximum", `Int 10
+                      ] )
+                ] )
+          ; "required", `List [ `String "query" ]
+          ; "additionalProperties", `Bool false
+          ]
+    }
+  ; { name = "masc_web_fetch"
+    ; description =
+        "Fetch a web page by URL and return cleaned text content. Read-only helper for \
+         reading selected sources after web search before citing them. Strips HTML tags, \
+         decodes entities, normalizes whitespace, and optionally extracts <title> and \
+         <meta name=\"description\">. Returns structured JSON with the cleaned text."
+    ; input_schema =
+        `Assoc
+          [ "type", `String "object"
+          ; ( "properties"
+            , `Assoc
+                [ ( "url"
+                  , `Assoc
+                      [ "type", `String "string"
+                      ; "description", `String "URL to fetch (http or https only)"
+                      ] )
+                ; ( "timeout"
+                  , `Assoc
+                      [ "type", `String "integer"
+                      ; ( "description"
+                        , `String "Request timeout in seconds (default 15, max 60)" )
+                      ; "default", `Int 15
+                      ; "minimum", `Int 1
+                      ; "maximum", `Int 60
+                      ] )
+                ] )
+          ; "required", `List [ `String "url" ]
+          ; "additionalProperties", `Bool false
+          ]
+    }
+  ; { name = "masc_tool_admin_snapshot"
+    ; description =
+        "Return a unified admin snapshot of tool inventory, auth/RBAC, and command-plane \
+         surfaces."
+    ; input_schema =
+        `Assoc
+          [ "type", `String "object"
+          ; ( "properties"
+            , `Assoc
+                [ ( "include_hidden"
+                  , `Assoc
+                      [ "type", `String "boolean"
+                      ; ( "description"
+                        , `String "Include hidden tools in tool_inventory (default: true)"
+                        )
+                      ; "default", `Bool true
+                      ] )
+                ; ( "include_deprecated"
+                  , `Assoc
+                      [ "type", `String "boolean"
+                      ; ( "description"
+                        , `String
+                            "Include deprecated tools in tool_inventory (default: true)" )
+                      ; "default", `Bool true
+                      ] )
+                ] )
+          ; "additionalProperties", `Bool false
+          ]
+    }
+  ; { name = "masc_tool_admin_update"
+    ; description =
+        "Apply auth updates through a single admin entrypoint. Use after \
+         masc_tool_admin_snapshot to review current state before making changes. \
+         Additional sections (unit_policy, keeper_policy) are not yet implemented and \
+         will be added here when their handlers land."
+    ; input_schema =
+        `Assoc
+          [ "type", `String "object"
+          ; ( "properties"
+            , `Assoc
+                [ ( "section"
+                  , `Assoc
+                      [ "type", `String "string"
+                      ; ( "enum"
+                        , `List (List.map (fun s -> `String s) admin_section_enum_strings)
+                        )
+                      ; ( "description"
+                        , `String
+                            "Config section to update (currently only auth is \
+                             implemented)" )
+                      ] )
+                ; ( "enabled"
+                  , `Assoc
+                      [ "type", `String "boolean"
+                      ; "description", `String "Enable or disable auth for section=auth"
+                      ] )
+                ; ( "require_token"
+                  , `Assoc
+                      [ "type", `String "boolean"
+                      ; "description", `String "Require tokens for section=auth"
+                      ] )
+                ; ( "token_expiry_hours"
+                  , `Assoc
+                      [ "type", `String "integer"
+                      ; "description", `String "Token expiry in hours for section=auth"
+                      ] )
+                ; ( "unit_id"
+                  , `Assoc
+                      [ "type", `String "string"
+                      ; "description", `String "Managed unit id for section=unit_policy"
+                      ] )
+                ; ( "policy"
+                  , `Assoc
+                      [ "type", `String "object"
+                      ; ( "description"
+                        , `String "Unit policy envelope for section=unit_policy" )
+                      ] )
+                ; ( "budget"
+                  , `Assoc
+                      [ "type", `String "object"
+                      ; ( "description"
+                        , `String "Unit budget envelope for section=unit_policy" )
+                      ] )
+                ] )
+          ; "required", `List [ `String "section" ]
+          ; "additionalProperties", `Bool false
+          ]
+    }
+  ]
+  @ Tool_descriptors_gen.schemas
+;;

--- a/lib/tool_schemas_specs/dune
+++ b/lib/tool_schemas_specs/dune
@@ -1,0 +1,6 @@
+(include_subdirs no)
+
+(library
+ (name tool_schemas_specs)
+ (wrapped false)
+ (modules tool_schemas_specs_types))

--- a/lib/tool_schemas_specs/tool_schemas_specs_types.ml
+++ b/lib/tool_schemas_specs/tool_schemas_specs_types.ml
@@ -1,0 +1,28 @@
+(* RFC-0057 Phase 2 — spec types extracted into a standalone library.
+
+   Why standalone? The generator executable (bin/gen_tool_descriptors.ml)
+   must not depend on masc_tool_schemas (the consumer of the generated
+   file), otherwise dune sees a cycle: exe -> lib -> generated file -> exe.
+
+   Keeping these types in a tiny sibling library breaks the cycle:
+   exe depends on tool_schemas_specs (types only), and masc_tool_schemas
+   depends on nothing new — it just receives the generated ml. *)
+
+type param_type =
+  | T_string of { enum : string list option }
+  | T_int of { min : int option; max : int option }
+  | T_bool
+
+type param =
+  { p_name : string
+  ; p_type : param_type
+  ; p_description : string
+  ; p_required : bool
+  }
+
+type tool_spec =
+  { name : string
+  ; description : string
+  ; parameters : param list
+  ; additional_properties : bool
+  }

--- a/lib/tool_schemas_specs/tool_schemas_specs_types.ml
+++ b/lib/tool_schemas_specs/tool_schemas_specs_types.ml
@@ -10,7 +10,10 @@
 
 type param_type =
   | T_string of { enum : string list option }
-  | T_int of { min : int option; max : int option }
+  | T_int of
+      { min : int option
+      ; max : int option
+      }
   | T_bool
 
 type param =

--- a/test/test_tool_descriptors_gen.ml
+++ b/test/test_tool_descriptors_gen.ml
@@ -1,15 +1,13 @@
-(** RFC-0057 Phase 1 regression test.
+(** RFC-0057 Phase 2 regression test.
 
     Guards [bin/gen_tool_descriptors.ml] output against the
-    effective schema exposed by [Tool_schemas_misc] for [masc_config]
-    and [masc_code_read].
+    effective schema exposed by [Tool_schemas_misc] for [masc_config],
+    [masc_code_read], and [masc_tool_help].
 
-    Phase 1 removed the hand-written [masc_config] entry from
-    [Tool_schemas_misc] and appended [Tool_descriptors_gen.schemas]
-    so the generated schemas are the SSOT. The test still pins
-    generated vs effective field-for-field to catch drift in
-    description text, enum ordering, additionalProperties, or any
-    nested Yojson value before it reaches an LLM client.
+    Phase 2 lifted spec types into [lib/tool_schemas_specs/] and added
+    the 3rd generated tool. Hand-written entries for all three tools
+    were removed from [Tool_schemas_misc]; generated schemas are the
+    SSOT. The test pins generated vs effective field-for-field.
 
     Same pattern as RFC-0054 PR-3's [test_shell_ir_typed_walkers_gen]. *)
 
@@ -75,6 +73,28 @@ let test_masc_code_read_input_schema_matches () =
     gen.input_schema
 ;;
 
+let test_masc_tool_help_name_matches () =
+  let gen = find_by_name "masc_tool_help" Tool_descriptors_gen.schemas in
+  let hand = find_by_name "masc_tool_help" Tool_schemas_misc.schemas in
+  Alcotest.(check string) "masc_tool_help name" hand.name gen.name
+;;
+
+let test_masc_tool_help_description_matches () =
+  let gen = find_by_name "masc_tool_help" Tool_descriptors_gen.schemas in
+  let hand = find_by_name "masc_tool_help" Tool_schemas_misc.schemas in
+  Alcotest.(check string) "masc_tool_help description" hand.description gen.description
+;;
+
+let test_masc_tool_help_input_schema_matches () =
+  let gen = find_by_name "masc_tool_help" Tool_descriptors_gen.schemas in
+  let hand = find_by_name "masc_tool_help" Tool_schemas_misc.schemas in
+  Alcotest.check
+    yojson_testable
+    "masc_tool_help input_schema (Yojson.Safe.equal)"
+    hand.input_schema
+    gen.input_schema
+;;
+
 let () =
   Alcotest.run
     "tool_descriptors_gen"
@@ -93,6 +113,14 @@ let () =
             "input_schema"
             `Quick
             test_masc_code_read_input_schema_matches
+        ] )
+    ; ( "masc_tool_help field-by-field"
+      , [ Alcotest.test_case "name" `Quick test_masc_tool_help_name_matches
+        ; Alcotest.test_case "description" `Quick test_masc_tool_help_description_matches
+        ; Alcotest.test_case
+            "input_schema"
+            `Quick
+            test_masc_tool_help_input_schema_matches
         ] )
     ]
 ;;

--- a/test/test_tool_descriptors_gen.ml
+++ b/test/test_tool_descriptors_gen.ml
@@ -101,10 +101,7 @@ let () =
     [ ( "masc_config field-by-field"
       , [ Alcotest.test_case "name" `Quick test_masc_config_name_matches
         ; Alcotest.test_case "description" `Quick test_masc_config_description_matches
-        ; Alcotest.test_case
-            "input_schema"
-            `Quick
-            test_masc_config_input_schema_matches
+        ; Alcotest.test_case "input_schema" `Quick test_masc_config_input_schema_matches
         ] )
     ; ( "masc_code_read field-by-field"
       , [ Alcotest.test_case "name" `Quick test_masc_code_read_name_matches


### PR DESCRIPTION
## Summary

RFC-0057 Phase 2: Extract codegen spec types into `lib/tool_schemas_specs/` and generate the 3rd tool (`masc_tool_help`).

## Changes

| File | Action |
|------|--------|
| `lib/tool_schemas_specs/dune` | NEW — standalone library with `(include_subdirs no)` |
| `lib/tool_schemas_specs/tool_schemas_specs_types.ml` | NEW — extracted `param_type`, `param`, `tool_spec` |
| `bin/gen_tool_descriptors.ml` | EDIT — drop local types, `open Tool_schemas_specs_types`, add `masc_tool_help_spec` |
| `bin/dune` | EDIT — add `(libraries tool_schemas_specs)` to generator executable |
| `lib/tool_schemas/tool_schemas_misc.ml` | EDIT — remove hand-written `masc_tool_help` entry |
| `test/test_tool_descriptors_gen.ml` | EDIT — 6 → 9 tests (add `masc_tool_help` field-by-field) |

## Why a sibling library?

The generator must not depend on `masc_tool_schemas` (the consumer of the generated file). A tiny types-only library breaks the cycle without introducing new constraints.

## Verification

- `dune build --root . @check` → exit 0
- `_build/default/test/test_tool_descriptors_gen.exe` → 9/9 PASS

## Phase 3 plan

- Add `default` value support to `param_type`.
- Collapse `dashboard_scope_enum_strings` mirror by generating `masc_dashboard`.
- Collapse `admin_section_enum_strings` mirror by generating `masc_tool_admin_update`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)