### PR TITLE
fix(keeper): reject absolute paths at read-path gate (#10349 follow-up)

### DIFF
--- a/lib/keeper/keeper_alerting_path.ml
+++ b/lib/keeper/keeper_alerting_path.ml
@@ -382,9 +382,20 @@ let resolve_keeper_read_path
   let raw = String.trim raw_path in
   if raw = ""
   then Error "path_required"
+  else if not (Filename.is_relative raw)
+  then (
+    (* #10349 follow-up: absolute paths bypass the sandbox-relative
+       contract and let the LLM observe host filesystem layout.
+       Reject at the gate; the keeper should use sandbox-relative
+       paths such as 'repos/X/lib/foo.ml'. *)
+    Prometheus.inc_counter
+      Keeper_metrics.metric_keeper_path_rejection
+      ~labels:[ "kind", "absolute_path_rejected" ]
+      ();
+    Error (Printf.sprintf "path_outside_project_root: %s (absolute paths are not allowed; use sandbox-relative paths like 'repos/X/lib/foo.ml')" raw))
   else (
     let root = project_root_of_config config in
-    let candidate = if Filename.is_relative raw then Filename.concat root raw else raw in
+    let candidate = Filename.concat root raw in
     let root_norm = normalize_path_for_check root in
     let target_norm = normalize_path_for_check candidate in
     let within_root =

--- a/lib/tool_shard.ml
+++ b/lib/tool_shard.ml
@@ -133,12 +133,10 @@ Use to timestamp events, check elapsed time, or include current time in reports.
     name = "keeper_context_status";
     description = "Check your own context window usage and session state. Returns: \
 name (your keeper name), context_ratio (0.0-1.0), context_tokens, context_max, \
-message_count, generation, last_model_used, continuity_summary, and canonical \
-sandbox paths (sandbox_root, sandbox_mind, sandbox_repos) plus backend/profile \
-metadata. sandbox paths are tool-ready and can be passed \
-directly as path or cwd to keeper tools without prefix. Use when deciding whether to compact context, \
-extend turns, hand off to the next generation, or resolve a path without \
-string-interpolating your own keeper name.";
+message_count, generation, last_model_used, continuity_summary, and sandbox \
+metadata (profile, backend, allowed paths). All paths are sandbox-relative; use \
+'repos/<repo>', 'mind/<note>', or '.' without host prefixes. Use when deciding whether to compact context, \
+extend turns, hand off to the next generation, or verify your current working directory.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc []);
@@ -391,7 +389,7 @@ For multi-file search, use keeper_shell with op=rg.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
-        ("path", `Assoc [("type", `String "string"); ("description", `String "Relative or absolute file path")]);
+        ("path", `Assoc [("type", `String "string"); ("description", `String "Sandbox-relative file path. Use 'repos/<repo>/lib/foo.ml', 'mind/note.md', or 'lib/foo.ml'. Absolute paths are rejected.")]);
         ("max_bytes", `Assoc [("type", `String "integer"); ("description", `String ("Max bytes to return (default: " ^ Tool_shard_limits.keeper_fs_read_default_max_bytes_string ^ ")"))]);
       ]);
       ("required", `List [`String "path"]);
@@ -408,7 +406,7 @@ Creates parent dirs.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
-        ("path", `Assoc [("type", `String "string"); ("description", `String "Relative or absolute file path to write")]);
+        ("path", `Assoc [("type", `String "string"); ("description", `String "Sandbox-relative file path to write. Absolute paths are rejected.")]);
         ("content", `Assoc [("type", `String "string"); ("description", `String "File content to write")]);
         (* Issue #8490: derive from local mirror that tracks
            [Keeper_exec_fs.valid_fs_write_mode_strings]. *)
@@ -425,7 +423,7 @@ let shell_tools : Masc_domain.tool_schema list = [
     description = "Run a structured project shell operation. \
 ops: pwd, ls, cat, rg, git_status, find, head, tail, wc, tree, git_log, git_diff, git_worktree, git_clone, gh. \
 Structured ops default to the keeper sandbox. \
-IMPORTANT: paths resolve automatically — use 'repos/X' or 'mind/X'. Never include host paths like '.masc/playground/your-name/repos/X' in path or cwd. \
+IMPORTANT: paths resolve automatically — use 'repos/X' or 'mind/X'. Only sandbox-relative paths are accepted. \
 Use cwd to target an explicit allowed directory or cloned repo. \
 find REQUIRES pattern param (e.g. pattern=\"*.ml\"). \
 No generic bash execution: use Bash/keeper_bash for command execution. \
@@ -464,7 +462,7 @@ Pipelines and fd-only redirects are accepted only when the active preset validat
 Good: cmd='dune build', cmd='ls -la lib/'. \
 Bad: cmd='cd x && dune build', cmd='echo hi > out.txt'. \
 Runs in the keeper sandbox by default; use cwd to target an explicit allowed directory. \
-Paths resolve automatically — never include host storage prefixes such as '.masc/playground/your-name/' in cwd. Use 'repos/X' instead. \
+Paths resolve automatically — only sandbox-relative paths are accepted. Use 'repos/X' instead of absolute paths. \
 Sandbox root is NOT a git repository: git/gh calls require cwd='repos/<REPO_NAME>' (or the worktree path under it). 'not a git repository' or 'path_outside_sandbox' from the sandbox root means you forgot the cwd. \
 For read-only ops use keeper_shell, for file edits use keeper_fs_edit. \
 Set run_in_background=true for long-running tasks (returns background_task_id; \

--- a/test/test_keeper_path_roots_leak_10349.ml
+++ b/test/test_keeper_path_roots_leak_10349.ml
@@ -127,19 +127,21 @@ let test_out_of_roots_no_leak () =
       let config = Coord.default_config dir in
       let labels = [ ("kind", "out_of_roots") ] in
       let before = counter_value labels in
-      (* Absolute path inside root with trailing slash and a
+      (* Relative path inside root with trailing slash and a
          missing leaf → bypasses [allows_missing_leaf_read]
          (which only forgives parent-exists/non-slash paths)
-         and falls into the out_of_roots branch. *)
-      let target = Filename.concat dir "lib/never_exists_10349/" in
+         and falls into the out_of_roots branch because the path
+         is outside the explicit allowed_paths. *)
+      let target = "lib/never_exists_10349/" in
       let result =
         Keeper_alerting_path.resolve_keeper_read_path ~config
-          ~allowed_paths:[ "lib" ] ~raw_path:target
+          ~allowed_paths:[ "src" ] ~raw_path:target
       in
       check bool "rejection occurred" true (Result.is_error result);
       let err = Result.get_error result in
       assert_no_roots_leak "out_of_roots" err;
-      assert_legacy_not_found_prefix "out_of_roots" err;
+      check bool "out_of_roots: path_outside_sandbox prefix" true
+        (Astring.String.is_prefix ~affix:"path_outside_sandbox:" err);
       check (float 0.0001) "out_of_roots counter +1"
         (before +. 1.0)
         (counter_value labels))
@@ -169,7 +171,36 @@ let test_not_found_relative_no_leak () =
         (before +. 1.0)
         (counter_value labels))
 
-(* --- 4. counter labels are isolated per kind ------------- *)
+(* --- 4. absolute path rejected at gate: opaque + counter --- *)
+
+let test_absolute_path_rejected () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  with_clean_env @@ fun () ->
+  let dir = mk_dir "kpath_abs" in
+  Fun.protect
+    ~finally:(fun () -> rm_rf dir)
+    (fun () ->
+      let config = Coord.default_config dir in
+      let labels = [ ("kind", "absolute_path_rejected") ] in
+      let before = counter_value labels in
+      let target = Filename.concat dir "lib/foo.ml" in
+      let result =
+        Keeper_alerting_path.resolve_keeper_read_path ~config
+          ~allowed_paths:[] ~raw_path:target
+      in
+      check bool "rejection occurred" true (Result.is_error result);
+      let err = Result.get_error result in
+      assert_no_roots_leak "absolute_path_rejected" err;
+      (* Legacy prefix is NOT preserved for absolute paths — they hit a
+         different gate.  The important invariant is no host roots leak. *)
+      check bool "absolute_path_rejected: no '(roots=' substring" false
+        (Astring.String.is_infix ~affix:"(roots=" err);
+      check (float 0.0001) "absolute_path_rejected counter +1"
+        (before +. 1.0)
+        (counter_value labels))
+
+(* --- 5. counter labels are isolated per kind ------------- *)
 
 let test_counter_labels_isolated () =
   Eio_main.run @@ fun env ->
@@ -202,6 +233,11 @@ let () =
             test_out_of_roots_no_leak;
           test_case "not_found_relative error is opaque" `Quick
             test_not_found_relative_no_leak;
+        ] );
+      ( "absolute-path-gate",
+        [
+          test_case "absolute paths rejected without roots leak" `Quick
+            test_absolute_path_rejected;
         ] );
       ( "counter-labels",
         [


### PR DESCRIPTION
## Summary
- keeper가 Docker sandbox 낸에서 host 절대 경로(`/Users/dancer/me/...`)를 요청하는 side-channel을 차단한다.
- `resolve_keeper_read_path`에 absolute path 거부 gate를 추가하고 Prometheus counter(`absolute_path_rejected`)를 도입한다.
- keeper tool schema description에서 host 경로 예시와 "absolute paths accepted" 문구를 모두 제거하고, sandbox-relative path 사용만 가이드한다.
- `test_keeper_path_roots_leak_10349`에 새 gate를 커버하는 테스트를 추가한다.

## Test plan
- [x] `test_keeper_path_roots_leak_10349` 5/5 pass
- [x] `test_keeper_exec_tools` 18/18 pass
- [ ] Full test suite (pre-existing `Agent_sdk.Risk_contract` build issue blocks `@check`)

## Risk
Low — 변경 영역은 path resolution gate와 tool description 문자엿뿐. 기존 상대 경로 사용 흐름은 그대로 유지된다.

## RFC
lib/keeper/ 변경에 해당하나, 본 PR은 #10349 follow-up hot-fix로 sandbox containment 패치다. 기존 RFC-0008 (keeper sandbox contract) 범위 내.