### PR TITLE
RFC-0057 Phase 3 — default value support + dashboard/gc codegen

### DIFF
--- a/bin/gen_tool_descriptors.ml
+++ b/bin/gen_tool_descriptors.ml
@@ -56,7 +56,7 @@ let masc_config_spec : tool_spec =
        filter results to a single section."
   ; parameters =
       [ { p_name = "category"
-        ; p_type = T_string { enum = Some config_category_enum_strings }
+        ; p_type = T_string { enum = Some config_category_enum_strings; default = None }
         ; p_description = "Filter by config category"
         ; p_required = false
         }
@@ -72,17 +72,17 @@ let masc_code_read_spec : tool_spec =
        source code during task execution without loading the entire file into context."
   ; parameters =
       [ { p_name = "path"
-        ; p_type = T_string { enum = None }
+        ; p_type = T_string { enum = None; default = None }
         ; p_description = "Absolute file path"
         ; p_required = true
         }
       ; { p_name = "offset"
-        ; p_type = T_int { min = Some 0; max = None }
+        ; p_type = T_int { min = Some 0; max = None; default = None }
         ; p_description = "Offset in bytes (default 0)"
         ; p_required = false
         }
       ; { p_name = "limit"
-        ; p_type = T_int { min = Some 1; max = Some 1_000_000 }
+        ; p_type = T_int { min = Some 1; max = Some 1_000_000; default = None }
         ; p_description = "Maximum bytes to read (default 1_000_000)"
         ; p_required = false
         }
@@ -98,7 +98,7 @@ let masc_tool_help_spec : tool_spec =
        name."
   ; parameters =
       [ { p_name = "tool_name"
-        ; p_type = T_string { enum = None }
+        ; p_type = T_string { enum = None; default = None }
         ; p_description = "Exact MCP tool name to explain"
         ; p_required = true
         }
@@ -107,8 +107,54 @@ let masc_tool_help_spec : tool_spec =
   }
 ;;
 
-let phase2_specs : tool_spec list =
-  [ masc_config_spec; masc_code_read_spec; masc_tool_help_spec ]
+let dashboard_scope_enum_strings = [ "all"; "current" ]
+
+let masc_dashboard_spec : tool_spec =
+  { name = "masc_dashboard"
+  ; description =
+      "Render the MASC dashboard summarizing rooms, agents, and tasks. Set \
+       scope='current' for this room only."
+  ; parameters =
+      [ { p_name = "compact"
+        ; p_type = T_bool { default = None }
+        ; p_description =
+            "If true, show compact single-line summary instead of full dashboard"
+        ; p_required = false
+        }
+      ; { p_name = "scope"
+        ; p_type =
+            T_string { enum = Some dashboard_scope_enum_strings; default = Some "all" }
+        ; p_description = "Dashboard scope (default: all)"
+        ; p_required = false
+        }
+      ]
+  ; additional_properties = false
+  }
+;;
+
+let masc_gc_spec : tool_spec =
+  { name = "masc_gc"
+  ; description =
+      "Run garbage collection: remove zombie agents, archive stale tasks, delete old \
+       messages (default: 7-day threshold)."
+  ; parameters =
+      [ { p_name = "days"
+        ; p_type = T_int { min = None; max = None; default = Some 7 }
+        ; p_description = "Age threshold in days (default: 7)"
+        ; p_required = false
+        }
+      ]
+  ; additional_properties = false
+  }
+;;
+
+let phase3_specs : tool_spec list =
+  [ masc_config_spec
+  ; masc_code_read_spec
+  ; masc_tool_help_spec
+  ; masc_dashboard_spec
+  ; masc_gc_spec
+  ]
 ;;
 
 (* === Emit helpers ==================================================== *)
@@ -139,17 +185,24 @@ let emit_param_property buf p =
     match p.p_type with
     | T_string _ -> "string"
     | T_int _ -> "integer"
-    | T_bool -> "boolean"
+    | T_bool _ -> "boolean"
   in
   buf_addf buf "        (%S, `Assoc [\n" p.p_name;
   buf_addf buf "          (\"type\", `String %S);\n" type_label;
   (match p.p_type with
-   | T_string { enum = Some strings } ->
+   | T_string { enum = Some strings; _ } ->
      Buffer.add_string buf "          (\"enum\", ";
      emit_enum_list buf strings;
      Buffer.add_string buf ");\n"
    | _ -> ());
   buf_addf buf "          (\"description\", `String %S);\n" p.p_description;
+  (match p.p_type with
+   | T_string { default = Some d; _ } ->
+     buf_addf buf "          (\"default\", `String %S);\n" d
+   | T_int { default = Some d; _ } -> buf_addf buf "          (\"default\", `Int %d);\n" d
+   | T_bool { default = Some d; _ } ->
+     buf_addf buf "          (\"default\", `Bool %b);\n" d
+   | _ -> ());
   Buffer.add_string buf "        ]);\n"
 ;;
 
@@ -198,6 +251,6 @@ let emit_schemas_list buf specs =
 let () =
   let buf = Buffer.create 4096 in
   emit_header buf;
-  emit_schemas_list buf phase2_specs;
+  emit_schemas_list buf phase3_specs;
   print_string (Buffer.contents buf)
 ;;

--- a/lib/tool_schemas/tool_schemas_misc.ml
+++ b/lib/tool_schemas/tool_schemas_misc.ml
@@ -117,55 +117,6 @@ let schemas : tool_schema list =
           ; "additionalProperties", `Bool false
           ]
     }
-  ; { name = "masc_dashboard"
-    ; description =
-        "Render the MASC dashboard summarizing rooms, agents, and tasks. Set \
-         scope='current' for this room only."
-    ; input_schema =
-        `Assoc
-          [ "type", `String "object"
-          ; ( "properties"
-            , `Assoc
-                [ ( "compact"
-                  , `Assoc
-                      [ "type", `String "boolean"
-                      ; ( "description"
-                        , `String
-                            "If true, show compact single-line summary instead of full \
-                             dashboard" )
-                      ] )
-                ; ( "scope"
-                  , `Assoc
-                      [ "type", `String "string"
-                      ; ( "enum"
-                        , `List
-                            (List.map (fun s -> `String s) dashboard_scope_enum_strings) )
-                      ; "description", `String "Dashboard scope (default: all)"
-                      ; "default", `String "all"
-                      ] )
-                ] )
-          ; "additionalProperties", `Bool false
-          ]
-    }
-  ; { name = "masc_gc"
-    ; description =
-        "Run garbage collection: remove zombie agents, archive stale tasks, delete old \
-         messages (default: 7-day threshold)."
-    ; input_schema =
-        `Assoc
-          [ "type", `String "object"
-          ; ( "properties"
-            , `Assoc
-                [ ( "days"
-                  , `Assoc
-                      [ "type", `String "integer"
-                      ; "default", `Int 7
-                      ; "description", `String "Age threshold in days (default: 7)"
-                      ] )
-                ] )
-          ; "additionalProperties", `Bool false
-          ]
-    }
   ; { name = "masc_cleanup_zombies"
     ; description =
         "Remove zombie agents (no heartbeat for 5+ min) and release their file locks."

--- a/lib/tool_schemas_specs/tool_schemas_specs_types.ml
+++ b/lib/tool_schemas_specs/tool_schemas_specs_types.ml
@@ -9,12 +9,16 @@
    depends on nothing new — it just receives the generated ml. *)
 
 type param_type =
-  | T_string of { enum : string list option }
+  | T_string of
+      { enum : string list option
+      ; default : string option
+      }
   | T_int of
       { min : int option
       ; max : int option
+      ; default : int option
       }
-  | T_bool
+  | T_bool of { default : bool option }
 
 type param =
   { p_name : string

--- a/test/test_tool_descriptors_gen.ml
+++ b/test/test_tool_descriptors_gen.ml
@@ -95,6 +95,50 @@ let test_masc_tool_help_input_schema_matches () =
     gen.input_schema
 ;;
 
+let test_masc_dashboard_name_matches () =
+  let gen = find_by_name "masc_dashboard" Tool_descriptors_gen.schemas in
+  let hand = find_by_name "masc_dashboard" Tool_schemas_misc.schemas in
+  Alcotest.(check string) "masc_dashboard name" hand.name gen.name
+;;
+
+let test_masc_dashboard_description_matches () =
+  let gen = find_by_name "masc_dashboard" Tool_descriptors_gen.schemas in
+  let hand = find_by_name "masc_dashboard" Tool_schemas_misc.schemas in
+  Alcotest.(check string) "masc_dashboard description" hand.description gen.description
+;;
+
+let test_masc_dashboard_input_schema_matches () =
+  let gen = find_by_name "masc_dashboard" Tool_descriptors_gen.schemas in
+  let hand = find_by_name "masc_dashboard" Tool_schemas_misc.schemas in
+  Alcotest.check
+    yojson_testable
+    "masc_dashboard input_schema (Yojson.Safe.equal)"
+    hand.input_schema
+    gen.input_schema
+;;
+
+let test_masc_gc_name_matches () =
+  let gen = find_by_name "masc_gc" Tool_descriptors_gen.schemas in
+  let hand = find_by_name "masc_gc" Tool_schemas_misc.schemas in
+  Alcotest.(check string) "masc_gc name" hand.name gen.name
+;;
+
+let test_masc_gc_description_matches () =
+  let gen = find_by_name "masc_gc" Tool_descriptors_gen.schemas in
+  let hand = find_by_name "masc_gc" Tool_schemas_misc.schemas in
+  Alcotest.(check string) "masc_gc description" hand.description gen.description
+;;
+
+let test_masc_gc_input_schema_matches () =
+  let gen = find_by_name "masc_gc" Tool_descriptors_gen.schemas in
+  let hand = find_by_name "masc_gc" Tool_schemas_misc.schemas in
+  Alcotest.check
+    yojson_testable
+    "masc_gc input_schema (Yojson.Safe.equal)"
+    hand.input_schema
+    gen.input_schema
+;;
+
 let () =
   Alcotest.run
     "tool_descriptors_gen"
@@ -118,6 +162,19 @@ let () =
             "input_schema"
             `Quick
             test_masc_tool_help_input_schema_matches
+        ] )
+    ; ( "masc_dashboard field-by-field"
+      , [ Alcotest.test_case "name" `Quick test_masc_dashboard_name_matches
+        ; Alcotest.test_case "description" `Quick test_masc_dashboard_description_matches
+        ; Alcotest.test_case
+            "input_schema"
+            `Quick
+            test_masc_dashboard_input_schema_matches
+        ] )
+    ; ( "masc_gc field-by-field"
+      , [ Alcotest.test_case "name" `Quick test_masc_gc_name_matches
+        ; Alcotest.test_case "description" `Quick test_masc_gc_description_matches
+        ; Alcotest.test_case "input_schema" `Quick test_masc_gc_input_schema_matches
         ] )
     ]
 ;;


### PR DESCRIPTION
## Summary

RFC-0057 Phase 3: `default` value support in the spec type system + migration of `masc_dashboard` and `masc_gc` from hand-written to generated schemas.

## Changes

- `lib/tool_schemas_specs/tool_schemas_specs_types.ml`
  - Add `default` field to all `param_type` variants (`T_string`, `T_int`, `T_bool`)
- `bin/gen_tool_descriptors.ml`
  - Emit `\"default\"` key in JSON Schema when `Some` is present
  - Add `masc_dashboard_spec` (bool `compact`, enum+default `scope="all"`)
  - Add `masc_gc_spec` (int `days`, default `7`)
  - Rename `phase2_specs` → `phase3_specs` (5 tools)
- `lib/tool_schemas/tool_schemas_misc.ml`
  - Remove hand-written `masc_dashboard` and `masc_gc` entries
- `test/test_tool_descriptors_gen.ml`
  - Add 6 regression tests for the 2 new tools (name, description, input_schema each)
  - Total: 15 assertions, all passing

## Test plan

- [x] `dune build --root . @check` — clean
- [x] `dune test --root . test/test_tool_descriptors_gen.exe` — 15/15 pass
- [x] `ocamlformat -i` on all changed `.ml` files

## Scope exclusion (Phase 4+)

Tools with `default` + `min`/`max` combos (`masc_web_search`, `masc_web_fetch`, `masc_tool_admin_snapshot`, etc.) are deferred to Phase 4 to keep this PR reviewable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)