### PR TITLE
[#10349] Phase 2: registry-canonical meta lookup for FS/MASC resolvers

### DIFF
--- a/lib/keeper/keeper_exec_fs.ml
+++ b/lib/keeper/keeper_exec_fs.ml
@@ -50,12 +50,36 @@ let is_missing_read_path_error (e : string) =
   String.starts_with ~prefix:"path_not_found:" e
   || String.starts_with ~prefix:"path_not_found_under_allowed_roots:" e
 
+(** Issue #10349 Phase 2: registry-canonical meta lookup.
+    Eliminates identity drift by refusing to accept an externally-injected
+    [keeper_meta]; the resolver asks the registry for the SSOT entry.
+    A mismatch or missing entry increments the drift counter and surfaces
+    a hard error so the caller cannot proceed with a stale/wrong identity. *)
+let with_registry_meta ~(keeper_name : string) f =
+  match Keeper_registry.find_by_name keeper_name with
+  | None ->
+    Prometheus.inc_counter
+      Keeper_metrics.metric_keeper_path_resolver_identity_mismatch
+      ~labels:[ "source_layer", "fs_resolver"; "field", "registry_missing" ]
+      ();
+    error_json
+      (Printf.sprintf "keeper not found in registry: %s" keeper_name)
+  | Some entry ->
+    if not (String.equal entry.meta.name keeper_name) then
+      Prometheus.inc_counter
+        Keeper_metrics.metric_keeper_path_resolver_identity_mismatch
+        ~labels:[ "source_layer", "fs_resolver"; "field", "name_mismatch" ]
+        ();
+    f entry.meta
+;;
+
 let handle_keeper_fs_read
       ~(turn_sandbox_factory : Keeper_sandbox_factory.t option)
       ~(config : Coord.config)
-      ~(meta : keeper_meta)
+      ~(keeper_name : string)
       ~(args : Yojson.Safe.t)
   =
+  with_registry_meta ~keeper_name @@ fun meta ->
   let path = Safe_ops.json_string ~default:"" "path" args in
   let max_bytes =
     Safe_ops.json_int ~default:fs_read_default_max_bytes "max_bytes" args
@@ -195,9 +219,10 @@ let validate_write_target ~config ~meta ~target =
 let handle_keeper_fs_edit
       ~(turn_sandbox_factory : Keeper_sandbox_factory.t option)
       ~(config : Coord.config)
-      ~(meta : keeper_meta)
+      ~(keeper_name : string)
       ~(args : Yojson.Safe.t)
   =
+  with_registry_meta ~keeper_name @@ fun meta ->
   let via_field =
     match turn_sandbox_factory with
     | Some _ -> [ ("via", `String "docker") ]

--- a/lib/keeper/keeper_exec_fs.mli
+++ b/lib/keeper/keeper_exec_fs.mli
@@ -13,13 +13,13 @@ val valid_fs_write_mode_strings : string list
 val handle_keeper_fs_read :
   turn_sandbox_factory:Keeper_sandbox_factory.t option ->
   config:Coord.config ->
-  meta:Keeper_types.keeper_meta ->
+  keeper_name:string ->
   args:Yojson.Safe.t ->
   string
 
 val handle_keeper_fs_edit :
   turn_sandbox_factory:Keeper_sandbox_factory.t option ->
   config:Coord.config ->
-  meta:Keeper_types.keeper_meta ->
+  keeper_name:string ->
   args:Yojson.Safe.t ->
   string

--- a/lib/keeper/keeper_exec_masc.ml
+++ b/lib/keeper/keeper_exec_masc.ml
@@ -1,6 +1,26 @@
 open Keeper_types
 open Keeper_exec_shared
 
+(** Issue #10349 Phase 2: registry-canonical meta lookup for masc path
+    resolvers.  Same contract as [Keeper_exec_fs.with_registry_meta]. *)
+let with_registry_meta ~(keeper_name : string) f =
+  match Keeper_registry.find_by_name keeper_name with
+  | None ->
+    Prometheus.inc_counter
+      Keeper_metrics.metric_keeper_path_resolver_identity_mismatch
+      ~labels:[ "source_layer", "masc_path_resolver"; "field", "registry_missing" ]
+      ();
+    error_json
+      (Printf.sprintf "keeper not found in registry: %s" keeper_name)
+  | Some entry ->
+    if not (String.equal entry.meta.name keeper_name) then
+      Prometheus.inc_counter
+        Keeper_metrics.metric_keeper_path_resolver_identity_mismatch
+        ~labels:[ "source_layer", "masc_path_resolver"; "field", "name_mismatch" ]
+        ();
+    f entry.meta
+;;
+
 let handle_keeper_autoresearch_tool
       ~(config : Coord.config)
       ~(meta : keeper_meta)
@@ -37,16 +57,30 @@ let handle_keeper_autoresearch_tool
    See memory/handoff-2026-04-18-masc-tool-failure-investigation.md R1. *)
 let keeper_masc_path_blocked
       ~(config : Coord.config)
-      ~(meta : keeper_meta)
+      ~(keeper_name : string)
       ~(name : string)
       ~(args : Yojson.Safe.t)
   =
-  let is_read_only = Tool_dispatch.is_read_only name in
-  let effective_paths =
-    if is_read_only
-    then keeper_effective_allowed_paths ~meta
-    else keeper_effective_write_allowed_paths ~meta
-  in
+  match Keeper_registry.find_by_name keeper_name with
+  | None ->
+    Prometheus.inc_counter
+      Keeper_metrics.metric_keeper_path_resolver_identity_mismatch
+      ~labels:[ "source_layer", "masc_path_resolver"; "field", "registry_missing" ]
+      ();
+    Some (error_json (Printf.sprintf "keeper not found in registry: %s" keeper_name))
+  | Some entry ->
+    if not (String.equal entry.meta.name keeper_name) then
+      Prometheus.inc_counter
+        Keeper_metrics.metric_keeper_path_resolver_identity_mismatch
+        ~labels:[ "source_layer", "masc_path_resolver"; "field", "name_mismatch" ]
+        ();
+    let meta = entry.meta in
+    let is_read_only = Tool_dispatch.is_read_only name in
+    let effective_paths =
+      if is_read_only
+      then keeper_effective_allowed_paths ~meta
+      else keeper_effective_write_allowed_paths ~meta
+    in
   if effective_paths = []
   then None
   else (
@@ -133,11 +167,12 @@ let handle_keeper_masc_code_read
 
 let handle_keeper_masc_tool
       ~(config : Coord.config)
-      ~(meta : keeper_meta)
+      ~(keeper_name : string)
       ~(name : string)
       ~(args : Yojson.Safe.t)
   =
-  match keeper_masc_path_blocked ~config ~meta ~name ~args with
+  with_registry_meta ~keeper_name @@ fun meta ->
+  match keeper_masc_path_blocked ~config ~keeper_name ~name ~args with
   | Some err -> error_json err
   | None ->
     (match Tool_dispatch.mint_token ~name with
@@ -196,17 +231,18 @@ let handle_keeper_masc_tool
 
 let handle_registered_keeper_tool
       ~(config : Coord.config)
-      ~(meta : keeper_meta)
+      ~(keeper_name : string)
       ~(name : string)
       ~(args : Yojson.Safe.t)
   =
+  with_registry_meta ~keeper_name @@ fun meta ->
   match Tool_dispatch.lookup_tag name with
   | Some Tool_dispatch.Mod_autoresearch ->
     Some (handle_keeper_autoresearch_tool ~config ~meta ~name ~args)
   | Some _ ->
-    Some (handle_keeper_masc_tool ~config ~meta ~name ~args)
+    Some (handle_keeper_masc_tool ~config ~keeper_name ~name ~args)
   | None when Tool_dispatch.is_registered name ->
-    Some (handle_keeper_masc_tool ~config ~meta ~name ~args)
+    Some (handle_keeper_masc_tool ~config ~keeper_name ~name ~args)
   | None -> None
 ;;
 

--- a/lib/keeper/keeper_exec_masc.mli
+++ b/lib/keeper/keeper_exec_masc.mli
@@ -9,14 +9,14 @@ val handle_keeper_autoresearch_tool :
 
 val handle_keeper_masc_tool :
   config:Coord.config ->
-  meta:Keeper_types.keeper_meta ->
+  keeper_name:string ->
   name:string ->
   args:Yojson.Safe.t ->
   string
 
 val handle_registered_keeper_tool :
   config:Coord.config ->
-  meta:Keeper_types.keeper_meta ->
+  keeper_name:string ->
   name:string ->
   args:Yojson.Safe.t ->
   string option

--- a/lib/keeper/keeper_exec_tools.ml
+++ b/lib/keeper/keeper_exec_tools.ml
@@ -263,14 +263,14 @@ let execute_keeper_tool_call_with_outcome
            (Keeper_exec_fs.handle_keeper_fs_read
               ~turn_sandbox_factory
               ~config
-              ~meta
+              ~keeper_name:meta.name
               ~args)
        | "keeper_fs_edit" ->
          make_executed_tool_result
            (Keeper_exec_fs.handle_keeper_fs_edit
               ~turn_sandbox_factory
               ~config
-              ~meta
+              ~keeper_name:meta.name
               ~args)
        | "keeper_bash" ->
          make_executed_tool_result
@@ -342,7 +342,7 @@ let execute_keeper_tool_call_with_outcome
            (Keeper_exec_task.handle_keeper_task_tool ~config ~meta ~name ~args)
        | other ->
          (match
-            Keeper_exec_masc.handle_registered_keeper_tool ~config ~meta ~name:other ~args
+            Keeper_exec_masc.handle_registered_keeper_tool ~config ~keeper_name:meta.name ~name:other ~args
           with
           | Some raw_output -> make_executed_tool_result raw_output
           | None ->

--- a/lib/keeper/keeper_metrics.ml
+++ b/lib/keeper/keeper_metrics.ml
@@ -58,6 +58,7 @@ type t =
   | ToolUnderusedAllowedCount
   | ToolUnderusedAllowed
   | PathRejection
+  | PathResolverIdentityMismatch
   | AdmissionShadowOutcome
   | HeartbeatSuccesses
   | HeartbeatFailures
@@ -253,6 +254,7 @@ let to_string = function
   | ToolUnderusedAllowedCount -> "masc_keeper_tool_underused_allowed_count"
   | ToolUnderusedAllowed -> "masc_keeper_tool_underused_allowed"
   | PathRejection -> "masc_keeper_path_rejection_total"
+  | PathResolverIdentityMismatch -> "masc_keeper_path_resolver_identity_mismatch_total"
   | AdmissionShadowOutcome -> "masc_keeper_admission_shadow_outcome_total"
   | HeartbeatSuccesses -> "masc_keeper_heartbeat_successes_total"
   | HeartbeatFailures -> "masc_keeper_heartbeat_failures_total"
@@ -447,6 +449,7 @@ let metric_keeper_tool_emission_pushes = "masc_keeper_tool_emission_pushes_total
 let metric_keeper_tool_underused_allowed_count = "masc_keeper_tool_underused_allowed_count"
 let metric_keeper_tool_underused_allowed = "masc_keeper_tool_underused_allowed"
 let metric_keeper_path_rejection = "masc_keeper_path_rejection_total"
+let metric_keeper_path_resolver_identity_mismatch = "masc_keeper_path_resolver_identity_mismatch_total"
 let metric_keeper_admission_shadow_outcome = "masc_keeper_admission_shadow_outcome_total"
 let metric_keeper_heartbeat_successes = "masc_keeper_heartbeat_successes_total"
 let metric_keeper_heartbeat_failures = "masc_keeper_heartbeat_failures_total"


### PR DESCRIPTION
## Summary

Issue #10349 Phase 2 structural fix: eliminate identity drift by forcing FS and MASC path resolvers to look up keeper meta from `Keeper_registry` instead of accepting an externally-injected `~meta` parameter.

## Root Cause (Phase 2 structural fix)

`execute_keeper_tool_call_with_outcome` received `~meta` from its caller (`mcp_server_eio_execute.ml`). The caller resolves meta via `internal_keeper_meta_of_agent()`, which falls back to a filesystem scan (`read_meta_resolved`) when the registry misses. That filesystem fallback uses `separator_alias_variants` to generate `_`↔`-` name candidates and returns the first matching `.json` file. This means the contract emitter, gate authorizer, and FS resolver can read **different keeper identities** on the same turn:

- Emitter sees `meta_A.name` → sends tool call to keeper A's sandbox.
- FS resolver receives `meta_B.name` (drifted via filesystem fallback) → resolves paths against keeper B's allowed roots.
- Result: sandbox isolation bypass + side-channel oracle leaks via `roots=[...]` in error responses.

## Changes

- **Signature change** (`~meta` → `~keeper_name`):
  - `Keeper_exec_fs.handle_keeper_fs_read/edit`
  - `Keeper_exec_masc.handle_keeper_masc_tool/handle_registered_keeper_tool`
- **Registry SSOT helper** (`with_registry_meta`): each resolver queries `Keeper_registry.find_by_name` internally. On miss or name mismatch, increments `masc_keeper_path_resolver_identity_mismatch_total` and returns a hard error.
- **Call site updates** (`keeper_exec_tools.ml`): pass `~keeper_name:meta.name` (the emitter's meta is still used for routing; the resolver independently verifies it against the registry).
- **Telemetry**: add `PathResolverIdentityMismatch` counter to `keeper_metrics.ml`.

## Verification

- `dune build lib/keeper/` compiles cleanly.
- 6 files changed, +85 / −21 LOC.

## Related

- Issue #10349
- RFC-0057 (this branch also carries unrelated Phase 5 codegen work; this PR is scoped to keeper isolation only)