### PR TITLE
feat(ide): foundational backend for observational IDE

### DIFF
--- a/dashboard/src/api/ide.ts
+++ b/dashboard/src/api/ide.ts
@@ -1,0 +1,102 @@
+import { get, post, fetchWithTimeout, type GetOptions } from './core'
+import {
+  parseIdeAnnotations,
+  parseIdeCodeRegions,
+  type IdeAnnotation,
+  type IdeCodeRegion,
+  type AnnotationKind,
+} from './schemas/ide-annotations'
+
+export type { IdeAnnotation, IdeCodeRegion, AnnotationKind } from './schemas/ide-annotations'
+
+export interface IdeApiOptions extends GetOptions {
+  readonly keeper?: string
+}
+
+export interface IdeAnnotationFilter {
+  readonly file_path?: string
+  readonly keeper_id?: string
+  readonly goal_id?: string
+}
+
+export interface CreateAnnotationInput {
+  readonly file_path: string
+  readonly line_start: number
+  readonly line_end: number
+  readonly keeper_id: string
+  readonly kind: AnnotationKind
+  readonly content: string
+  readonly goal_id?: string
+  readonly task_id?: string
+}
+
+function appendFilterParams(
+  params: URLSearchParams,
+  filter: IdeAnnotationFilter,
+): void {
+  if (filter.file_path) params.set('file_path', filter.file_path)
+  if (filter.keeper_id) params.set('keeper_id', filter.keeper_id)
+  if (filter.goal_id) params.set('goal_id', filter.goal_id)
+}
+
+function appendWorkspaceParams(
+  params: URLSearchParams,
+  opts: IdeApiOptions,
+): void {
+  if (opts.keeper) params.set('keeper', opts.keeper)
+}
+
+export async function fetchIdeAnnotations(
+  filter: IdeAnnotationFilter = {},
+  opts: IdeApiOptions = {},
+): Promise<ReadonlyArray<IdeAnnotation>> {
+  const params = new URLSearchParams()
+  appendFilterParams(params, filter)
+  appendWorkspaceParams(params, opts)
+  const query = params.size > 0 ? `?${params.toString()}` : ''
+  const raw = await get<unknown>(`/api/v1/ide/annotations${query}`, opts)
+  if (!isRecord(raw) || raw.ok !== true) return []
+  return parseIdeAnnotations(raw.data)
+}
+
+export async function createIdeAnnotation(
+  input: CreateAnnotationInput,
+  _opts: IdeApiOptions = {},
+): Promise<IdeAnnotation | null> {
+  const raw = await post<unknown>('/api/v1/ide/annotations', input)
+  if (!isRecord(raw) || raw.ok !== true) return null
+  return parseIdeAnnotations([raw.data])[0] ?? null
+}
+
+export async function deleteIdeAnnotation(
+  id: string,
+  keeperId: string,
+  opts: IdeApiOptions = {},
+): Promise<boolean> {
+  const params = new URLSearchParams()
+  params.set('keeper_id', keeperId)
+  appendWorkspaceParams(params, opts)
+  const path = `/api/v1/ide/annotations/${encodeURIComponent(id)}?${params.toString()}`
+  try {
+    const res = await fetchWithTimeout(path, { method: 'DELETE' }, 15_000)
+    return res.ok
+  } catch {
+    return false
+  }
+}
+
+export async function fetchIdeRegions(
+  filePath: string,
+  opts: IdeApiOptions = {},
+): Promise<ReadonlyArray<IdeCodeRegion>> {
+  const params = new URLSearchParams()
+  params.set('file_path', filePath)
+  appendWorkspaceParams(params, opts)
+  const raw = await get<unknown>(`/api/v1/ide/regions?${params.toString()}`, opts)
+  if (!isRecord(raw) || raw.ok !== true) return []
+  return parseIdeCodeRegions(raw.data)
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}

--- a/dashboard/src/api/schemas/ide-annotations.ts
+++ b/dashboard/src/api/schemas/ide-annotations.ts
@@ -1,0 +1,87 @@
+import { isRecord, asString, asInt, asNullableString, asNumber } from '../../components/common/normalize'
+
+export type AnnotationKind = 'Comment' | 'Decision' | 'Question' | 'Bookmark'
+
+export interface IdeAnnotation {
+  readonly id: string
+  readonly file_path: string
+  readonly line_start: number
+  readonly line_end: number
+  readonly keeper_id: string
+  readonly kind: AnnotationKind
+  readonly content: string
+  readonly goal_id: string | null
+  readonly task_id: string | null
+  readonly created_at_ms: number
+  readonly updated_at_ms: number
+}
+
+export type RegionSourceType = 'tool_call' | 'manual'
+
+export interface IdeCodeRegion {
+  readonly file_path: string
+  readonly line_start: number
+  readonly line_end: number
+  readonly keeper_id: string
+  readonly source_type: RegionSourceType
+  readonly source_tool_name: string | null
+  readonly source_turn: number | null
+  readonly source_note: string | null
+  readonly timestamp_ms: number
+}
+
+function asAnnotationKind(value: unknown): AnnotationKind {
+  const s = asString(value, '')
+  switch (s) {
+    case 'Decision':
+    case 'Question':
+    case 'Bookmark':
+      return s
+    default:
+      return 'Comment'
+  }
+}
+
+export function parseIdeAnnotation(value: unknown): IdeAnnotation | null {
+  if (!isRecord(value)) return null
+  return {
+    id: asString(value.id, ''),
+    file_path: asString(value.file_path, ''),
+    line_start: (asInt(value.line_start) ?? 0),
+    line_end: (asInt(value.line_end) ?? 0),
+    keeper_id: asString(value.keeper_id, ''),
+    kind: asAnnotationKind(value.kind),
+    content: asString(value.content, ''),
+    goal_id: asNullableString(value.goal_id),
+    task_id: asNullableString(value.task_id),
+    created_at_ms: asNumber(value.created_at_ms, 0),
+    updated_at_ms: asNumber(value.updated_at_ms, 0),
+  }
+}
+
+export function parseIdeAnnotations(value: unknown): ReadonlyArray<IdeAnnotation> {
+  if (!Array.isArray(value)) return []
+  return value.map(parseIdeAnnotation).filter((a): a is IdeAnnotation => a !== null)
+}
+
+export function parseIdeCodeRegion(value: unknown): IdeCodeRegion | null {
+  if (!isRecord(value)) return null
+  const source = isRecord(value.source) ? value.source : {}
+  const sourceType = asString(source.type, '')
+  return {
+    file_path: asString(value.file_path, ''),
+    line_start: (asInt(value.line_start) ?? 0),
+    line_end: (asInt(value.line_end) ?? 0),
+    keeper_id: asString(value.keeper_id, ''),
+    source_type: sourceType === 'tool_call' || sourceType === 'manual' ? sourceType : 'manual',
+    source_tool_name: asNullableString(source.tool_name),
+    source_turn: sourceType === 'tool_call' ? (asInt(source.turn) ?? 0) : null,
+    source_note: sourceType === 'manual' ? asNullableString(source.note) : null,
+    timestamp_ms: asNumber(value.timestamp_ms, 0),
+  }
+}
+
+export function parseIdeCodeRegions(value: unknown): ReadonlyArray<IdeCodeRegion> {
+  if (!Array.isArray(value)) return []
+  return value.map(parseIdeCodeRegion).filter((r): r is IdeCodeRegion => r !== null)
+}

--- a/lib/dune
+++ b/lib/dune
@@ -181,6 +181,10 @@
   tool_task_schemas
   board_core_classify
   board_core_payload
+  ide_annotation_types
+  ide_annotations
+  ide_region_tracker
+  server_ide_http
   )
  (libraries
    mcp_protocol

--- a/lib/ide/ide_annotation_types.ml
+++ b/lib/ide/ide_annotation_types.ml
@@ -1,0 +1,193 @@
+(** IDE annotation types — shared across [ide_annotations], [ide_region_tracker],
+    and [server_ide_http].
+
+    These types model the observational IDE overlay: Keeper-authored
+    annotations bound to file + line ranges, plus code regions extracted
+    from Keeper tool_calls. *)
+
+type annotation_kind =
+  | Comment
+  | Decision
+  | Question
+  | Bookmark
+[@@deriving show, eq]
+
+type annotation = {
+  id : string;
+  file_path : string;
+  line_start : int;
+  line_end : int;
+  keeper_id : string;
+  kind : annotation_kind;
+  content : string;
+  goal_id : string option;
+  task_id : string option;
+  created_at_ms : int64;
+  updated_at_ms : int64;
+}
+[@@deriving show, eq]
+
+type code_region = {
+  file_path : string;
+  line_start : int;
+  line_end : int;
+  keeper_id : string;
+  source : region_source;
+  timestamp_ms : int64;
+}
+
+and region_source =
+  | Tool_call of { tool_name : string; turn : int }
+  | Manual of { note : string }
+[@@deriving show, eq]
+
+type annotation_filter = {
+  file_path : string option;
+  keeper_id : string option;
+  goal_id : string option;
+}
+
+let annotation_to_json (a : annotation) : Yojson.Safe.t =
+  `Assoc
+    [
+      ("id", `String a.id);
+      ("file_path", `String a.file_path);
+      ("line_start", `Int a.line_start);
+      ("line_end", `Int a.line_end);
+      ("keeper_id", `String a.keeper_id);
+      ("kind", `String (show_annotation_kind a.kind));
+      ("content", `String a.content);
+      ("goal_id", match a.goal_id with None -> `Null | Some g -> `String g);
+      ("task_id", match a.task_id with None -> `Null | Some t -> `String t);
+      ("created_at_ms", `Intlit (Int64.to_string a.created_at_ms));
+      ("updated_at_ms", `Intlit (Int64.to_string a.updated_at_ms));
+    ]
+
+let annotation_of_json (json : Yojson.Safe.t) : (annotation, string) result =
+  match json with
+  | `Assoc fields ->
+      let find_string key default =
+        match List.assoc_opt key fields with
+        | Some (`String s) -> s
+        | _ -> default
+      in
+      let find_int key default =
+        match List.assoc_opt key fields with
+        | Some (`Int i) -> i
+        | Some (`Intlit s) -> (try int_of_string s with _ -> default)
+        | _ -> default
+      in
+      let find_int64 key default =
+        match List.assoc_opt key fields with
+        | Some (`Intlit s) -> (try Int64.of_string s with _ -> default)
+        | Some (`Int i) -> Int64.of_int i
+        | _ -> default
+      in
+      let find_opt_string key =
+        match List.assoc_opt key fields with
+        | Some (`String s) when s <> "" -> Some s
+        | _ -> None
+      in
+      let kind_str = find_string "kind" "Comment" in
+      let kind =
+        match kind_str with
+        | "Comment" -> Comment
+        | "Decision" -> Decision
+        | "Question" -> Question
+        | "Bookmark" -> Bookmark
+        | _ -> Comment
+      in
+      Ok
+        {
+          id = find_string "id" "";
+          file_path = find_string "file_path" "";
+          line_start = find_int "line_start" 1;
+          line_end = find_int "line_end" 1;
+          keeper_id = find_string "keeper_id" "";
+          kind;
+          content = find_string "content" "";
+          goal_id = find_opt_string "goal_id";
+          task_id = find_opt_string "task_id";
+          created_at_ms = find_int64 "created_at_ms" 0L;
+          updated_at_ms = find_int64 "updated_at_ms" 0L;
+        }
+  | _ -> Error "Expected JSON object for annotation"
+
+let region_to_json (r : code_region) : Yojson.Safe.t =
+  `Assoc
+    [
+      ("file_path", `String r.file_path);
+      ("line_start", `Int r.line_start);
+      ("line_end", `Int r.line_end);
+      ("keeper_id", `String r.keeper_id);
+      ( "source",
+        match r.source with
+        | Tool_call { tool_name; turn } ->
+            `Assoc
+              [
+                ("type", `String "tool_call");
+                ("tool_name", `String tool_name);
+                ("turn", `Int turn);
+              ]
+        | Manual { note } ->
+            `Assoc [ ("type", `String "manual"); ("note", `String note) ] );
+      ("timestamp_ms", `Intlit (Int64.to_string r.timestamp_ms));
+    ]
+
+let region_of_json (json : Yojson.Safe.t) : (code_region, string) result =
+  match json with
+  | `Assoc fields ->
+      let find_string key default =
+        match List.assoc_opt key fields with
+        | Some (`String s) -> s
+        | _ -> default
+      in
+      let find_int key default =
+        match List.assoc_opt key fields with
+        | Some (`Int i) -> i
+        | Some (`Intlit s) -> (try int_of_string s with _ -> default)
+        | _ -> default
+      in
+      let find_int64 key default =
+        match List.assoc_opt key fields with
+        | Some (`Intlit s) -> (try Int64.of_string s with _ -> default)
+        | Some (`Int i) -> Int64.of_int i
+        | _ -> default
+      in
+      let source =
+        match List.assoc_opt "source" fields with
+        | Some (`Assoc src_fields) -> (
+            match List.assoc_opt "type" src_fields with
+            | Some (`String "tool_call") ->
+                Tool_call
+                  {
+                    tool_name =
+                      (match List.assoc_opt "tool_name" src_fields with
+                      | Some (`String s) -> s
+                      | _ -> "");
+                    turn =
+                      (match List.assoc_opt "turn" src_fields with
+                      | Some (`Int i) -> i
+                      | _ -> 0);
+                  }
+            | Some (`String "manual") ->
+                Manual
+                  {
+                    note =
+                      (match List.assoc_opt "note" src_fields with
+                      | Some (`String s) -> s
+                      | _ -> "");
+                  }
+            | _ -> Manual { note = "" })
+        | _ -> Manual { note = "" }
+      in
+      Ok
+        {
+          file_path = find_string "file_path" "";
+          line_start = find_int "line_start" 1;
+          line_end = find_int "line_end" 1;
+          keeper_id = find_string "keeper_id" "";
+          source;
+          timestamp_ms = find_int64 "timestamp_ms" 0L;
+        }
+  | _ -> Error "Expected JSON object for code_region"

--- a/lib/ide/ide_annotations.ml
+++ b/lib/ide/ide_annotations.ml
@@ -1,0 +1,152 @@
+(** IDE annotation storage — CRUD backed by [.masc-ide/annotations.jsonl].
+
+    Uses {!Dated_jsonl} for concurrent-safe append-only writes.
+    In-memory compaction rewrites the store when tombstones exceed
+    [COMPACT_THRESHOLD]. *)
+
+open Ide_annotation_types
+
+let store_path ~base_dir = Filename.concat base_dir ".masc-ide"
+
+let annotations_file ~base_dir =
+  Filename.concat (store_path ~base_dir) "annotations.jsonl"
+
+let ensure_store ~base_dir =
+  let path = store_path ~base_dir in
+  if not (Sys.file_exists path && Sys.is_directory path) then
+    Unix.mkdir path 0o755
+
+let compact_threshold = 0.2
+
+let generate_id () = Uuidm.v4_gen (Random.get_state ()) () ;;
+Uuidm.to_string (Uuidm.v4_gen (Random.get_state ()) ())
+
+let now_ms () =
+  let ns = Mtime.to_uint64_ns (Mtime_clock.now ()) in
+  Int64.div ns 1_000_000L
+
+let annotation_kind_of_string = function
+  | "Decision" -> Decision
+  | "Question" -> Question
+  | "Bookmark" -> Bookmark
+  | _ -> Comment
+
+let tombstone_json id keeper_id ts =
+  `Assoc
+    [
+      ("__tombstone", `Bool true);
+      ("id", `String id);
+      ("keeper_id", `String keeper_id);
+      ("deleted_at_ms", `Intlit (Int64.to_string ts));
+    ]
+
+let is_tombstone json =
+  match json with
+  | `Assoc fields -> (
+      match List.assoc_opt "__tombstone" fields with
+      | Some (`Bool true) -> true
+      | _ -> false)
+  | _ -> false
+
+let annotation_id json =
+  match json with
+  | `Assoc fields -> (
+      match List.assoc_opt "id" fields with
+      | Some (`String s) -> Some s
+      | _ -> None)
+  | _ -> None
+
+let load_all ~base_dir =
+  let path = annotations_file ~base_dir in
+  if not (Sys.file_exists path) then []
+  else
+    let lines = Fs_compat.load_jsonl path in
+    let non_tombstones = List.filter (fun j -> not (is_tombstone j)) lines in
+    List.filter_map
+      (fun j ->
+        match annotation_of_json j with
+        | Ok a -> Some a
+        | Error _ -> None)
+      non_tombstones
+
+let write_all ~base_dir annotations =
+  let path = annotations_file ~base_dir in
+  let jsons = List.map annotation_to_json annotations in
+  let lines = List.map Yojson.Safe.to_string jsons in
+  let tmp_path = path ^ ".tmp" in
+  let oc = open_out_bin tmp_path in
+  List.iter
+    (fun line ->
+      output_string oc line;
+      output_char oc '\n')
+    lines;
+  close_out oc;
+  Sys.rename tmp_path path
+
+let create ~base_dir ~keeper_id ~file_path ~line_start ~line_end ~kind ~content
+    ?goal_id ?task_id () =
+  ensure_store ~base_dir;
+  if file_path = "" then Error "file_path is required"
+  else if line_start < 1 || line_end < line_start then
+    Error "invalid line range"
+  else if content = "" then Error "content is required"
+  else
+    let ts = now_ms () in
+    let annotation =
+      {
+        id = Uuidm.to_string (Uuidm.v4_gen (Random.get_state ()) ());
+        file_path;
+        line_start;
+        line_end;
+        keeper_id;
+        kind;
+        content;
+        goal_id;
+        task_id;
+        created_at_ms = ts;
+        updated_at_ms = ts;
+      }
+    in
+    let store = Dated_jsonl.create ~base_dir:(store_path ~base_dir) () in
+    Dated_jsonl.append store (annotation_to_json annotation);
+    Ok annotation
+
+let list ~base_dir ~filter =
+  ensure_store ~base_dir;
+  let all = load_all ~base_dir in
+  let by_file =
+    match filter.file_path with
+    | Some fp -> List.filter (fun a -> a.file_path = fp) all
+    | None -> all
+  in
+  let by_keeper =
+    match filter.keeper_id with
+    | Some k -> List.filter (fun a -> a.keeper_id = k) by_file
+    | None -> by_file
+  in
+  let by_goal =
+    match filter.goal_id with
+    | Some g -> List.filter (fun a -> a.goal_id = Some g) by_keeper
+    | None -> by_keeper
+  in
+  List.sort (fun a b -> Int64.compare b.created_at_ms a.created_at_ms) by_goal
+
+let delete ~base_dir ~id ~keeper_id =
+  ensure_store ~base_dir;
+  let all = load_all ~base_dir in
+  match List.find_opt (fun a -> a.id = id && a.keeper_id = keeper_id) all with
+  | None -> Error "annotation not found or keeper mismatch"
+  | Some _ ->
+      let ts = now_ms () in
+      let store = Dated_jsonl.create ~base_dir:(store_path ~base_dir) () in
+      Dated_jsonl.append store (tombstone_json id keeper_id ts);
+      let raw_lines = Fs_compat.load_jsonl (annotations_file ~base_dir) in
+      let tombstones = List.filter is_tombstone raw_lines in
+      let total = List.length all + List.length tombstones in
+      if total > 0 && float_of_int (List.length tombstones) /. float_of_int total >= compact_threshold
+      then compact ~base_dir;
+      Ok ()
+
+let compact ~base_dir =
+  let all = load_all ~base_dir in
+  write_all ~base_dir all

--- a/lib/ide/ide_annotations.mli
+++ b/lib/ide/ide_annotations.mli
@@ -1,0 +1,48 @@
+(** IDE annotation storage — CRUD backed by [.masc-ide/annotations.jsonl].
+
+    Each project base maintains its own annotation store under
+    [base_dir/.masc-ide/].  The JSONL format is append-only with
+    in-memory compaction on read: deleted annotations are filtered out
+    and the file is rewritten when the tombstone ratio exceeds a threshold.
+
+    Thread-safety is provided by {!Dated_jsonl} mutex per [base_dir]. *)
+
+open Ide_annotation_types
+
+val store_path : base_dir:string -> string
+(** [store_path ~base_dir] returns [base_dir/.masc-ide/]. *)
+
+val ensure_store : base_dir:string -> unit
+(** Create [.masc-ide/] directory if absent. Idempotent. *)
+
+val create :
+  base_dir:string ->
+  keeper_id:string ->
+  file_path:string ->
+  line_start:int ->
+  line_end:int ->
+  kind:annotation_kind ->
+  content:string ->
+  ?goal_id:string ->
+  ?task_id:string ->
+  unit ->
+  (annotation, string) result
+(** Append a new annotation. Returns the created record with a fresh UUID [id]
+    and [created_at_ms] = [updated_at_ms] = current time. *)
+
+val list :
+  base_dir:string -> filter:annotation_filter -> annotation list
+(** Read all annotations for the given filter. Tombstoned entries are excluded.
+    Results are sorted by [created_at_ms] descending (newest first). *)
+
+val delete :
+  base_dir:string -> id:string -> keeper_id:string -> (unit, string) result
+(** Soft-delete: append a tombstone record. Only the original [keeper_id] may
+    delete its own annotation. *)
+
+val compact : base_dir:string -> unit
+(** Rewrite the annotation file excluding tombstones. Called automatically
+    when the tombstone ratio exceeds [COMPACT_THRESHOLD]. *)
+
+val annotation_kind_of_string : string -> annotation_kind
+(** Parse kind string, defaulting to [Comment] on unknown input. *)

--- a/lib/ide/ide_region_tracker.ml
+++ b/lib/ide/ide_region_tracker.ml
@@ -1,0 +1,160 @@
+(** IDE region tracker — extract code regions from Keeper tool_calls. *)
+
+open Ide_annotation_types
+
+let parse_hunk_header line =
+  if not (String.starts_with ~prefix:"@@" line) then None
+  else
+    let parts = String.split_on_char ' ' line in
+    let old_part =
+      try List.nth parts 1 with
+      | _ -> ""
+    in
+    let new_part =
+      try List.nth parts 2 with
+      | _ -> ""
+    in
+    let parse_start s =
+      let s =
+        if String.length s > 0 && (s.[0] = '-' || s.[0] = '+') then
+          String.sub s 1 (max 0 (String.length s - 1))
+        else s
+      in
+      let comma = String.index_opt s ',' in
+      match comma with
+      | Some idx -> (
+          match int_of_string_opt (String.sub s 0 idx) with
+          | Some n -> Some n
+          | None -> None)
+      | None -> (
+          match int_of_string_opt s with
+          | Some n -> Some n
+          | None -> None)
+    in
+    match parse_start old_part with
+    | Some start -> Some (max 1 start)
+    | None -> None
+
+let count_lines s =
+  if s = "" then 0
+  else
+    let n = ref 1 in
+    for i = 0 to String.length s - 1 do
+      if s.[i] = '\n' then incr n
+    done;
+    if s.[String.length s - 1] = '\n' then !n - 1 else !n
+
+let line_range_of_hunk ~start ~lines =
+  let count =
+    List.fold_left
+      (fun acc line ->
+        if String.starts_with ~prefix:"+" line then acc + 1
+        else if String.starts_with ~prefix:" " line then acc + 1
+        else acc)
+      0 lines
+  in
+  (start, start + count - 1)
+
+let extract_regions_from_diff ~keeper_id ~file_path ~turn diff_text =
+  let lines = String.split_on_char '\n' diff_text in
+  let rec collect start_line acc remaining =
+    match remaining with
+    | [] -> List.rev acc
+    | hd :: tl ->
+        match parse_hunk_header hd with
+        | Some start ->
+            let hunk_lines, rest =
+              let rec take_hunk acc' = function
+                | [] -> (List.rev acc', [])
+                | x :: xs when String.starts_with ~prefix:"@@" x ->
+                    (List.rev acc', x :: xs)
+                | x :: xs -> take_hunk (x :: acc') xs
+              in
+              take_hunk [] tl
+            in
+            let s, e = line_range_of_hunk ~start ~lines:hunk_lines in
+            let region =
+              {
+                file_path;
+                line_start = s;
+                line_end = e;
+                keeper_id;
+                source = Tool_call { tool_name = "edit_file"; turn };
+                timestamp_ms = Int64.of_float (Unix.gettimeofday () *. 1000.0);
+              }
+            in
+            collect start_line (region :: acc) rest
+        | None -> collect start_line acc tl
+  in
+  collect 1 [] lines
+
+let extract_region_from_full_file ~keeper_id ~file_path ~turn content =
+  let n = count_lines content in
+  {
+    file_path;
+    line_start = 1;
+    line_end = max 1 n;
+    keeper_id;
+    source = Tool_call { tool_name = "write_file"; turn };
+    timestamp_ms = Int64.of_float (Unix.gettimeofday () *. 1000.0);
+  }
+
+let is_file_write_tool name =
+  name = "write_file" || name = "edit_file" || name = "apply_patch"
+
+let json_string_field key json =
+  match json with
+  | `Assoc fields -> (
+      match List.assoc_opt key fields with
+      | Some (`String s) when s <> "" -> Some s
+      | _ -> None)
+  | _ -> None
+
+let ingest_tool_call ~base_dir ~keeper_id ~turn json =
+  let tool_name =
+    match json with
+    | `Assoc fields -> (
+        match List.assoc_opt "name" fields with
+        | Some (`String n) -> n
+        | _ -> "")
+    | _ -> ""
+  in
+  if not (is_file_write_tool tool_name) then ()
+  else
+    let arguments =
+      match json with
+      | `Assoc fields -> (
+          match List.assoc_opt "arguments" fields with
+          | Some (`Assoc args) -> args
+          | _ -> [])
+      | _ -> []
+    in
+    let file_path =
+      match List.assoc_opt "path" arguments with
+      | Some (`String s) when s <> "" -> Some s
+      | _ -> (
+          match List.assoc_opt "file_path" arguments with
+          | Some (`String s) when s <> "" -> Some s
+          | _ -> None)
+    in
+    match file_path with
+    | None -> ()
+    | Some fp ->
+        let regions =
+          if tool_name = "write_file" then
+            match List.assoc_opt "content" arguments with
+            | Some (`String content) -> [extract_region_from_full_file ~keeper_id ~file_path:fp ~turn content]
+            | _ -> []
+          else
+            match List.assoc_opt "diff" arguments with
+            | Some (`String diff_text) -> extract_regions_from_diff ~keeper_id ~file_path:fp ~turn diff_text
+            | _ -> (
+                match List.assoc_opt "patch" arguments with
+                | Some (`String patch_text) -> extract_regions_from_diff ~keeper_id ~file_path:fp ~turn patch_text
+                | _ -> [])
+        in
+        let store_dir = Filename.concat base_dir ".masc-ide" in
+        if not (Sys.file_exists store_dir && Sys.is_directory store_dir) then
+          Unix.mkdir store_dir 0o755;
+        let store = Dated_jsonl.create ~base_dir:store_dir () in
+        List.iter (fun r -> Dated_jsonl.append store (region_to_json r)) regions

--- a/lib/ide/ide_region_tracker.mli
+++ b/lib/ide/ide_region_tracker.mli
@@ -1,0 +1,39 @@
+(** IDE region tracker — extract code regions from Keeper tool_calls.
+
+    Parses [write_file], [edit_file], and [apply_patch] tool_call
+    arguments into line-range records.  A region represents the set of
+    lines a Keeper touched in a single tool invocation.
+
+    Regions are stored in [.masc-ide/regions.jsonl] and surfaced by
+    the IDE as overlay hints (who owns this code?). *)
+
+open Ide_annotation_types
+
+val parse_hunk_header : string -> int option
+(** [parse_hunk_header line] extracts start_line from a
+    unified diff hunk header like [@@ -1,5 +2,7 @@].  Returns [None]
+    if the line does not match the hunk pattern. *)
+
+val extract_regions_from_diff :
+  keeper_id:string ->
+  file_path:string ->
+  turn:int ->
+  diff_text:string ->
+  code_region list
+(** Parse unified diff text into one [code_region] per hunk.
+    [turn] is the keeper turn number for provenance. *)
+
+val extract_region_from_full_file :
+  keeper_id:string ->
+  file_path:string ->
+  turn:int ->
+  content:string ->
+  code_region
+(** When a Keeper uses [write_file] with full content, the region is
+    the entire file (lines 1 to line count of [content]). *)
+
+val ingest_tool_call :
+  base_dir:string -> keeper_id:string -> turn:int -> Yojson.Safe.t -> unit
+(** Inspect a tool_call JSON record.  If it is a file-writing tool,
+    extract regions and append them to [.masc-ide/regions.jsonl].
+    Non-matching tool_calls are silently ignored. *)

--- a/lib/server/server_ide_http.ml
+++ b/lib/server/server_ide_http.ml
@@ -1,0 +1,189 @@
+(** Server IDE HTTP — REST endpoints for observational IDE annotations
+    and code regions.
+
+    Reads/writes are scoped to the workspace base resolved by
+    {!Server_routes_http_routes_workspace.classify_workspace_query}. *)
+
+open Server_auth
+open Server_utils
+
+module Http = Http_server_eio
+
+let base_path_of_state state = state.Mcp_server.room_config.base_path
+
+let resolve_workspace_base ~state ~uri =
+  let project_base = base_path_of_state state in
+  let config = state.Mcp_server.room_config in
+  let lookup_repository repo_id =
+    match Repo_store.find ~base_path:project_base repo_id with
+    | Ok repo -> Some (Repo_store.local_path ~base_path:project_base repo)
+    | Error _ -> None
+  in
+  let lookup_playground name =
+    match Keeper_types.read_meta config name with
+    | Ok (Some m) -> Some (Keeper_sandbox.host_root_abs_of_meta ~config m)
+    | _ -> None
+  in
+  let exists_dir p = Sys.file_exists p && Sys.is_directory p in
+  Server_routes_http_routes_workspace.classify_workspace_query
+    ~project_base
+    ~lookup_repository
+    ~lookup_playground
+    ~exists_dir
+    ~repo_param:(Uri.get_query_param uri "repo_id")
+    ~keeper_param:(Uri.get_query_param uri "keeper")
+
+let json_error message =
+  `Assoc [("ok", `Bool false); ("error", `String message)]
+
+let json_ok data =
+  `Assoc [("ok", `Bool true); ("data", data)]
+
+let add_routes router =
+  let router1 =
+    Http.Router.get "/api/v1/ide/annotations" (fun request reqd ->
+      with_public_read
+        (fun state _req reqd ->
+          let uri = Uri.of_string request.target in
+          let base, _source = resolve_workspace_base ~state ~uri in
+          let file_path =
+            match Uri.get_query_param uri "file_path" with
+            | Some p when p <> "" -> Some p
+            | _ -> None
+          in
+          let keeper_id =
+            match Uri.get_query_param uri "keeper_id" with
+            | Some k when k <> "" -> Some k
+            | _ -> None
+          in
+          let goal_id =
+            match Uri.get_query_param uri "goal_id" with
+            | Some g when g <> "" -> Some g
+            | _ -> None
+          in
+          let filter = { Ide_annotation_types.file_path; keeper_id; goal_id } in
+          let annotations = Ide_annotations.list ~base_dir:base ~filter in
+          let json = `List (List.map Ide_annotation_types.annotation_to_json annotations) in
+          Http.Response.json ~compress:true ~request:request
+            (Yojson.Safe.to_string (json_ok json)) reqd)
+        request reqd)
+    router
+  in
+  let router2 =
+    Http.Router.post "/api/v1/ide/annotations" (fun request reqd ->
+      with_public_read
+        (fun state req reqd ->
+          let uri = Uri.of_string request.target in
+          let base, _source = resolve_workspace_base ~state ~uri in
+          Http.Request.read_body_async reqd (fun body_str ->
+            let json =
+              try Yojson.Safe.from_string body_str
+              with _ -> `Assoc []
+            in
+            let find_string key =
+              match json with
+              | `Assoc fields -> (
+                  match List.assoc_opt key fields with
+                  | Some (`String s) when s <> "" -> Some s
+                  | _ -> None)
+              | _ -> None
+            in
+            let find_int key =
+              match json with
+              | `Assoc fields -> (
+                  match List.assoc_opt key fields with
+                  | Some (`Int i) -> Some i
+                  | Some (`Intlit s) -> int_of_string_opt s
+                  | _ -> None)
+              | _ -> None
+            in
+            match
+              ( find_string "file_path",
+                find_int "line_start",
+                find_int "line_end",
+                find_string "keeper_id",
+                find_string "content" )
+            with
+            | Some file_path, Some line_start, Some line_end, Some keeper_id, Some content ->
+                let kind_str = Option.value (find_string "kind") ~default:"Comment" in
+                let kind = Ide_annotations.annotation_kind_of_string kind_str in
+                let goal_id = find_string "goal_id" in
+                let task_id = find_string "task_id" in
+                (match
+                   Ide_annotations.create ~base_dir:base ~keeper_id ~file_path
+                     ~line_start ~line_end ~kind ~content ?goal_id ?task_id ()
+                 with
+                 | Ok annotation ->
+                     Http.Response.json ~status:`Created ~request:request
+                       (Yojson.Safe.to_string
+                          (json_ok (Ide_annotation_types.annotation_to_json annotation)))
+                       reqd
+                 | Error msg ->
+                     Http.Response.json ~status:`Bad_request ~request:request
+                       (Yojson.Safe.to_string (json_error msg)) reqd)
+            | _ ->
+                Http.Response.json ~status:`Bad_request ~request:request
+                  (Yojson.Safe.to_string (json_error "Missing required fields"))
+                  reqd))
+        request reqd)
+    router1
+  in
+  let router3 =
+    Http.Router.delete "/api/v1/ide/annotations/:id" (fun request reqd ->
+      with_public_read
+        (fun state _req reqd ->
+          let uri = Uri.of_string request.target in
+          let base, _source = resolve_workspace_base ~state ~uri in
+          let id =
+            match Http.Router.param request "id" with
+            | Some s when s <> "" -> s
+            | _ -> ""
+          in
+          let keeper_id =
+            match Uri.get_query_param uri "keeper_id" with
+            | Some k when k <> "" -> k
+            | _ -> ""
+          in
+          if id = "" || keeper_id = "" then
+            Http.Response.json ~status:`Bad_request ~request:request
+              (Yojson.Safe.to_string (json_error "Missing id or keeper_id"))
+              reqd
+          else
+            match Ide_annotations.delete ~base_dir:base ~id ~keeper_id with
+            | Ok () ->
+                Http.Response.json ~status:`No_content ~request:request "{}" reqd
+            | Error msg ->
+                Http.Response.json ~status:`Forbidden ~request:request
+                  (Yojson.Safe.to_string (json_error msg)) reqd)
+        request reqd)
+    router2
+  in
+  Http.Router.get "/api/v1/ide/regions" (fun request reqd ->
+    with_public_read
+      (fun state _req reqd ->
+        let uri = Uri.of_string request.target in
+        let base, _source = resolve_workspace_base ~state ~uri in
+        let file_path =
+          match Uri.get_query_param uri "file_path" with
+          | Some p when p <> "" -> p
+          | _ -> ""
+        in
+        let store_dir = Filename.concat base ".masc-ide" in
+        let path = Filename.concat store_dir "regions.jsonl" in
+        let raw =
+          if not (Sys.file_exists path) then []
+          else Fs_compat.load_jsonl path
+        in
+        let regions =
+          List.filter_map
+            (fun j ->
+              match Ide_annotation_types.region_of_json j with
+              | Ok r when file_path = "" || r.file_path = file_path -> Some r
+              | _ -> None)
+            raw
+        in
+        let json = `List (List.map Ide_annotation_types.region_to_json regions) in
+        Http.Response.json ~compress:true ~request:request
+          (Yojson.Safe.to_string (json_ok json)) reqd)
+      request reqd)
+    router3

--- a/lib/server/server_ide_http.mli
+++ b/lib/server/server_ide_http.mli
@@ -1,0 +1,16 @@
+(** Server IDE HTTP — REST endpoints for observational IDE annotations
+    and code regions.
+
+    Routes:
+    - GET  /api/v1/ide/annotations
+    - POST /api/v1/ide/annotations
+    - DELETE /api/v1/ide/annotations/:id
+    - GET  /api/v1/ide/regions
+
+    All routes use the workspace base resolution from
+    {!Server_routes_http_routes_workspace} so the IDE reads/writes
+    from the correct project or keeper playground. *)
+
+module Http = Http_server_eio
+
+val add_routes : Http.Router.t -> Http.Router.t

--- a/lib/server/server_routes_http.ml
+++ b/lib/server/server_routes_http.ml
@@ -35,5 +35,6 @@ let make_routes ~port ~host ~sw ~clock =
   |> Server_routes_http_routes_sidecar.add_routes ~sw ~clock
   |> Server_routes_http_routes_repositories.add_routes
   |> Server_routes_http_routes_workspace.add_routes
+  |> Server_ide_http.add_routes
   |> Server_routes_http_routes_credentials.add_routes
   |> Server_routes_http_routes_keeper_repos.add_routes


### PR DESCRIPTION
Implement the core backend infrastructure for the observational IDE
as outlined in planning/ide.md:

- lib/ide/ide_annotation_types.ml: shared types for annotations and code regions
- lib/ide/ide_annotations.ml: CRUD for annotations backed by .masc-ide/annotations.jsonl
- lib/ide/ide_region_tracker.ml: extract code regions from keeper tool_calls
- lib/server/server_ide_http.ml: REST endpoints for annotations and regions
- dashboard/src/api/ide.ts: typed frontend API client
- dashboard/src/api/schemas/ide-annotations.ts: response parsers

Routes wired into server_routes_http.ml:
  GET  /api/v1/ide/annotations
  POST /api/v1/ide/annotations
  DELETE /api/v1/ide/annotations/:id
  GET  /api/v1/ide/regions

All endpoints use workspace base resolution (project/keeper playground)
so reads/writes are scoped correctly. Annotations support filtering by
file_path, keeper_id, and goal_id. Regions are extracted from write_file,
edit_file, and apply_patch tool_calls.

## Summary

<!-- What changed? Keep this short and factual. -->

## Product impact

- User-visible change:

## Evidence

<!-- Tests, harness runs, screenshots, logs, or other proof. -->
- If tool-call behavior or provider tool support changed: include replay-harness or `ToolCallContract` evidence.

## GOAL LOOP ACT checklist

<!-- Complete this section for operational/runtime fixes. Leave unchecked items with a brief N/A reason. -->

- [ ] Observe — metric/log/trace evidence for the failure or drift is linked or pasted above
- [ ] Orient — mapped to a finding, live-log pattern, audit item, or explicit new finding
- [ ] Decide — priority/risk rationale is stated, including why this scope is the next action
- [ ] Act — code/config/docs changed in the smallest bounded scope; rollback path is clear
- [ ] Verify — regression test, focused local command, CI job, or production-log check proves PASS/FAIL
- [ ] Loop — remaining follow-up is linked as an issue/PR/handoff, or explicitly marked none

## Review evidence

<!-- Cross-model review result, reviewer model, and fallback reason if any. -->

## Linked issue

- Closes #
- Relates #

## Variant addition checklist

<!-- Complete this section if you added, removed, or renamed any OCaml variant,
     TypeScript union member, TLA+ domain literal, or JSON schema enum value.
     Leave unchecked boxes with a brief justification comment if not applicable. -->

- [ ] **OCaml** — variant added/removed in `.ml`/`.mli` and exhaustive `match` updated (no silent `_` wildcard without justification comment)
- [ ] **TypeScript** — corresponding union type in `dashboard/src/types/core.ts` updated (e.g. `KeeperPhase`, `KeeperHealth`, etc.)
- [ ] **TLA+ spec** — matching domain literal or `DOMAIN` set in the relevant `.tla` file updated
- [ ] **Event / JSON schema** — event type string, JSON schema enum, or `canonical_keeper_toml_key_names` updated if applicable
- [ ] **`make check-variants` passes** — run `bash scripts/check-variants.sh` locally and confirm PASS
