### PR TITLE
fix(discord-bot): resolve doctor env token reading and python path

### DIFF
--- a/sidecars/discord-bot/run.sh
+++ b/sidecars/discord-bot/run.sh
@@ -45,7 +45,7 @@ case "$cmd" in
     mkdir -p "$LOG_DIR"
     printf 'Starting Discord sidecar\n  MASC_BASE_PATH=%s\n  log file:      %s\n' \
       "$BASE_PATH" "$LOG_FILE" >&2
-    python -m src 2>&1 | tee -a "$LOG_FILE"
+    .venv/bin/python -m src 2>&1 | tee -a "$LOG_FILE"
     ;;
   tail)
     if [[ ! -f "$LOG_FILE" ]]; then
@@ -70,7 +70,7 @@ case "$cmd" in
   doctor)
     cd "$(script_dir)"
     shift || true
-    python -m src doctor "$@"
+    .venv/bin/python -m src doctor "$@"
     ;;
   stop)
     # Match by absolute script_dir path so we never hit another sidecar.

--- a/sidecars/discord-bot/src/config.py
+++ b/sidecars/discord-bot/src/config.py
@@ -62,7 +62,7 @@ class BotConfig(BaseSettings):
     model_config = SettingsConfigDict(
         env_prefix="",
         case_sensitive=True,
-        env_file=".env",
+        env_file=str(Path(__file__).parent.parent / ".env"),
         extra="ignore",
     )
 

--- a/sidecars/discord-bot/src/doctor.py
+++ b/sidecars/discord-bot/src/doctor.py
@@ -138,7 +138,14 @@ async def check_discord_py_version() -> Check:
 
 
 async def check_env_token() -> Check:
-    raw = os.getenv("DISCORD_BOT_TOKEN", "").strip()
+    cfg = _config_or_none()
+    if cfg is None:
+        return Check(
+            name="DISCORD_BOT_TOKEN",
+            severity=Severity.skip,
+            message="config 로드 실패로 검증을 걸어 뜀",
+        )
+    raw = cfg.discord_bot_token.strip()
     if not raw:
         return Check(
             name="DISCORD_BOT_TOKEN",


### PR DESCRIPTION
## Summary
Discord sidecar `./run.sh doctor` 가 `.env` 파일의 `DISCORD_BOT_TOKEN`을 읽지 못하던 문제를 수정합니다.

## Changes
- `src/doctor.py`: `check_env_token()`이 `os.getenv` 대신 `BotConfig`를 통해 토큰을 읽도록 변경 (`.env` 파일 실제 로딩)
- `src/config.py`: `env_file`을 상대 경로에서 절대 경로로 변경 (CWD 의존성 제거)
- `run.sh`: system `python` 대신 `.venv/bin/python` 사용 (가상환경 일관성)

## Test plan
- [x] `./run.sh doctor` 실행 시 11개 체크 중 10개 정상, 1개 선택사항 경고만 출력
- [x] `DISCORD_BOT_TOKEN`이 `.env` 파일만으로 인식됨 (수동 export 불필요)

🤖 Generated with [Claude Code](https://claude.com/claude-code)