### PR TITLE
[RFC-0061] Cache-invalidation broadcast envelope

### DIFF
--- a/docs/rfc/RFC-0061-cache-invalidation-broadcast-envelope.md
+++ b/docs/rfc/RFC-0061-cache-invalidation-broadcast-envelope.md
@@ -1,0 +1,204 @@
+# RFC 0061 — Cache-invalidation broadcast envelope
+
+- **Status**: Draft
+- **Author**: Vincent + Claude
+- **Depends on**: RFC-0040 (mention-dedup)
+- **Resolves**: Reactive axis stage-1 death — broadcast rewrite swallows mention tokens before `pre_extract_mention` runs.
+
+---
+
+## 1. Problem
+
+`lib/coord/coord_broadcast.ml:79-121` rewrites `content` to a `cache_invalidated` notice **before** `pre_extract_mention` (line 130). The rewritten string contains no `@target` token, so `Mention.extract` returns `None`. Downstream wake logic (`keeper_prompt.ml:16`, `keeper_exec_context.ml:418`) never sees the mention. The recipient stays asleep even though the sender intended a directed ping.
+
+This is the single largest blocker in the Reactive axis. While it is alive, improvements in Cascade, Sandbox, or Tool axes are invisible to operators because the feedback loop dies at stage 1.
+
+### Concrete failure path
+
+1. taskmaster broadcasts `"@nick0cave task-037 is stale"`.
+2. `cache_invalidated` guard (line 91) fires because task-037 is terminal.
+3. `content` is rewritten to `"[cache_invalidated] coord_broadcast: task-037 is done — stale broadcast suppressed"`.
+4. `pre_extract_mention = Mention.extract content` (line 130) sees no `@nick0cave`.
+5. `mention` field in the persisted `msg` record is `None`.
+6. nick0cave reads the board on its next turn; `Mention.any_mentioned ~targets:["nick0cave"]` is false.
+7. No wake. No reaction. Loop broken.
+
+---
+
+## 2. Non-Goals
+
+- Changing the pull model (keeper reads board, checks its own name). RFC-0040 preserves this.
+- Changing mention dedup logic. RFC-0040 owns dedup.
+- Adding push-time recipient filtering. `Mention.resolve_targets` has 0 production callers; out of scope.
+
+---
+
+## 3. Design
+
+### 3.1 `broadcast_envelope` type
+
+Introduce a record that preserves original content alongside any rewrites.
+
+```ocaml
+type rewrite_reason =
+  | Cache_invalidated of { task_id : string; status : task_status }
+  | Task_cache_rewrite of { module_name : string }
+
+type broadcast_envelope = {
+  original_content : string;
+  rewrites : rewrite_event list;
+  mention_tokens : string list;
+  msg_type : msg_type;
+}
+
+and rewrite_event = {
+  reason : rewrite_reason;
+  replaced_content : string;
+  timestamp_s : float;
+}
+
+and msg_type =
+  | Broadcast
+  | Cache_invalidated
+  | Dedup_skipped
+  | System_alert
+```
+
+**Why a closed variant for `msg_type`**:
+The current code uses `string` (line 65 `?(msg_type = "broadcast")`). A closed variant lets the compiler force every downstream consumer to handle new message kinds, preventing silent drift.
+
+### 3.2 Surgical fix — move `pre_extract_mention` before rewrite block
+
+```ocaml
+let broadcast ... =
+  ensure_initialized config;
+
+  (* STEP A: extract mention from ORIGINAL content, before any rewrite. *)
+  let pre_extract_mention = Mention.extract content in
+
+  (* STEP B: fleet-wide invariant (PR-B) — rewrite ONLY if needed,
+     but preserve original for mention/wake logic. *)
+  let content, msg_type, rewrites =
+    if task_cache_invariant_checked then (content, msg_type, [])
+    else if String.equal msg_type "broadcast" then
+      ... (* existing rewrite logic, but also emit a rewrite_event *)
+    else (content, msg_type, [])
+  in
+
+  (* STEP C: RFC-0040 dedup runs on original mention + original content hash. *)
+  let dedup_skipped = ... in
+  ...
+```
+
+Key change: `pre_extract_mention` moves from line 130 to **before** line 79. The `mention` field in the persisted `msg` record is populated from `pre_extract_mention`, not from the rewritten `content`.
+
+### 3.3 Subscriber contract
+
+- **Wake / reactivity**: uses `original_content` (or `mention_tokens`) to decide whether the keeper was mentioned.
+- **UI / log display**: uses `rewrites` list to show that a rewrite occurred and why.
+- **Persisted `msg` record**: `mention` field is `pre_extract_mention` (from original). `content` field is the rewritten string for display compatibility.
+
+---
+
+## 4. Cross-Reference to RFC-0040
+
+RFC-0040 introduced sender-side mention dedup at `coord_broadcast.ml:122`. Its `content_topic_hash` (SHA1 of original content) and `should_skip` logic assume the original content is available at the point of dedup. After this RFC, that assumption holds because `pre_extract_mention` (and thus dedup) runs before rewrite.
+
+| RFC-0040 element | This RFC guarantee |
+|---|---|
+| `Mention.extract content` at line 130 | Moved earlier; operates on original |
+| `content_topic_hash content` at line 135 | Hash of original, not rewritten |
+| `Mention_dedup.should_skip` | Correctly keyed to original content |
+
+---
+
+## 5. TLA+ Bug Model Requirement
+
+Per CLAUDE.md TLA+ Bug Model pattern, provide a spec that proves the invariant catches the bug.
+
+### 5.1 Actions
+
+- `BroadcastRewriteSwallowsMention`: models the buggy code — rewrite happens before mention extraction.
+- `MentionExtractedBeforeRewrite`: models the fixed code — extraction happens on original content.
+
+### 5.2 Invariant
+
+```
+MentionTokensExtractedBeforeRewrite ==
+  \A env \in broadcast_envelopes :
+    env.mention_tokens = MentionExtract(env.original_content)
+```
+
+### 5.3 Verification matrix
+
+| Config | Expected TLC result |
+|---|---|
+| `RFC0061Clean.cfg` (`Next = MentionExtractedBeforeRewrite`) | No error — invariant holds |
+| `RFC0061Buggy.cfg` (`Next = BroadcastRewriteSwallowsMention`) | Invariant violated in 3 steps |
+
+Both `.cfg` outputs must be attached to the PR description before Ready transition.
+
+---
+
+## 6. Layer 3 Adversarial Review Trigger
+
+After PR opens (Draft), invoke `Agent(subagent_type=adversarial-reviewer)` with:
+- **No JIRA/Slack context** — structural verification only.
+- **Checklist**:
+  1. `pre_extract_mention` is syntactically before any `content` mutation.
+  2. `msg_type` is a closed variant (not `string`).
+  3. `rewrite_reason` is a closed variant (not `string` or `option string`).
+  4. No `_ -> false` or `_ -> None` catch-all in `msg_type` or `rewrite_reason` consumers.
+  5. `Mention.extract` caller count in `coord_broadcast.ml` is exactly 1 (no second extraction after rewrite).
+  6. `content_topic_hash` in RFC-0040 dedup is keyed to original content (grep for hash call site).
+
+Reviewer must return a boolean `PASS`/`FAIL` per item, not a narrative summary.
+
+---
+
+## 7. Migration
+
+### 7.1 Files changed
+
+- `lib/coord/coord_broadcast.ml` — move extraction, add envelope type, populate `mention` from original.
+- `lib/coord/coord_broadcast.mli` — export `broadcast_envelope`, `rewrite_reason`, `msg_type`.
+
+### 7.2 Backward compatibility
+
+The persisted `msg` JSON format gains an optional `original_content` field. Old readers ignore it. `msg.content` continues to hold the rewritten string, so UI that displays `content` needs no change.
+
+---
+
+## 8. Risks
+
+- **Double extraction**: a future refactor might re-add `Mention.extract` after the rewrite block. Mitigation: Layer 3 review item 5.
+- **String `msg_type` leakage**: external callers (grpc, eio variant) may still pass `"broadcast"` as string. Mitigation: convert at boundary, keep internal closed variant.
+- **Envelope memory overhead**: one extra `string` per broadcast (original content). Acceptable — broadcasts are not high-frequency enough for this to matter.
+
+---
+
+## 9. Implementation Plan
+
+| Step | File | Change | LOC |
+|---|---|---|---|
+| S1 | `coord_broadcast.ml` | Add `broadcast_envelope`, `rewrite_reason`, `msg_type` types | ~25 |
+| S2 | `coord_broadcast.ml` | Move `pre_extract_mention` before rewrite block | ~5 |
+| S3 | `coord_broadcast.ml` | Populate `mention` from `pre_extract_mention`, stamp `rewrites` | ~15 |
+| S4 | `coord_broadcast.mli` | Export new types | ~10 |
+| S5 | `test/test_coord_broadcast.ml` | Add "rewrite preserves mention" test | ~30 |
+| S6 | TLA+ spec | `RFC0061.tla` + `.cfg` + `-buggy.cfg` | ~40 |
+| S7 | dune build + test green | — | — |
+| S8 | Draft PR + Layer 3 review | — | — |
+
+Total **~125 LOC** (OCaml) + **~40 LOC** (TLA+).
+
+---
+
+## 10. References
+
+- RFC-0040 (mention-dedup) — dedup logic that this RFC preserves.
+- `lib/coord/coord_broadcast.ml:64-198` — current broadcast implementation.
+- `lib/keeper/keeper_prompt.ml:16` — pull-model mention check.
+- `lib/keeper/keeper_exec_context.ml:418` — direct_mention boolean injection.
+- CLAUDE.md TLA+ Bug Model pattern — `BugAction` + `SafetyInvariant` verification.
+- Memory: `feedback_main_blocker_chain_4x_session` — admin-merge / PR chain bypass forbidden.

--- a/lib/coord/coord_broadcast.ml
+++ b/lib/coord/coord_broadcast.ml
@@ -6,6 +6,27 @@
 open Masc_domain
 open Coord_utils
 
+(** RFC-0061: closed variants for broadcast envelope observability.
+    rewrite_reason tracks why the original content was rewritten.
+    msg_type_typed is an internal closed variant; the external [msg_type]
+    field remains [string] for backward compatibility. *)
+type rewrite_reason =
+  | Cache_invalidated of { task_id : string; status : string }
+  | Task_cache_rewrite
+
+type rewrite_event = {
+  reason : rewrite_reason;
+  module_name : string;
+}
+
+type msg_type_typed =
+  | Broadcast
+  | Cache_invalidated of { task_id : string; status : string }
+
+let string_of_msg_type_typed = function
+  | Broadcast -> "broadcast"
+  | Cache_invalidated _ -> "cache_invalidated"
+
 let emit_message_activity config ~from_agent ~content ~mention
     ?session_id ?operation_id ?worker_run_id ?(evidence_refs = []) () =
   let evidence_refs = Coord_state.normalized_string_list evidence_refs in
@@ -72,12 +93,19 @@ let broadcast ?trace_context ?(msg_type = "broadcast")
     with Eio.Cancel.Cancelled _ as e -> raise e | _ -> ()
   in
   ensure_initialized config;
+
+  (* RFC-0061: preserve original content and extract mention tokens BEFORE
+     any fleet-wide invariant rewrite. This prevents stage-1 wake signal loss
+     when [cache_invalidated] replaces the original broadcast text. *)
+  let original_content = content in
+  let pre_extract_mention = Mention.extract original_content in
+
   (* Fleet-wide invariant (PR-B): if the broadcasting agent's current_task is
      terminal in the backlog, replace the original broadcast with a single
      cache_invalidated notice and clear the stale state (issue #13397).
      Only applied to regular "broadcast" messages to avoid recursion. *)
-  let content, msg_type =
-    if task_cache_invariant_checked then (content, msg_type)
+  let content, msg_type, _rewrites =
+    if task_cache_invariant_checked then (content, msg_type, [])
     else if String.equal msg_type "broadcast" then
       let agent_file =
         Filename.concat (agents_dir config) (safe_filename from_agent ^ ".json")
@@ -98,26 +126,60 @@ let broadcast ?trace_context ?(msg_type = "broadcast")
                          — stale broadcast suppressed"
                         task_id (Masc_domain.task_status_to_string status)
                     in
-                    (inv_content, "cache_invalidated")
+                    ( inv_content,
+                      "cache_invalidated",
+                      [
+                        {
+                          reason =
+                            Cache_invalidated
+                              {
+                                task_id;
+                                status =
+                                  Masc_domain.task_status_to_string status;
+                              };
+                          module_name = "coord_broadcast";
+                        };
+                      ] )
                 | _ ->
                     ( Coord_task_cache_invariant.rewrite_broadcast_content
                         ~config ~from_agent ~module_name:"coord_broadcast"
                         ~content,
-                      msg_type ))
+                      msg_type,
+                      [
+                        {
+                          reason = Task_cache_rewrite;
+                          module_name = "coord_broadcast";
+                        };
+                      ] ))
             | None ->
                 ( Coord_task_cache_invariant.rewrite_broadcast_content
                     ~config ~from_agent ~module_name:"coord_broadcast"
                     ~content,
-                  msg_type ))
+                  msg_type,
+                  [
+                    {
+                      reason = Task_cache_rewrite;
+                      module_name = "coord_broadcast";
+                    };
+                  ] ))
         | Error _ ->
             ( Coord_task_cache_invariant.rewrite_broadcast_content
                 ~config ~from_agent ~module_name:"coord_broadcast" ~content,
-              msg_type )
+              msg_type,
+              [
+                {
+                  reason = Task_cache_rewrite;
+                  module_name = "coord_broadcast";
+                };
+              ] )
       else
         ( Coord_task_cache_invariant.rewrite_broadcast_content
             ~config ~from_agent ~module_name:"coord_broadcast" ~content,
-          msg_type )
-    else (content, msg_type)
+          msg_type,
+          [
+            { reason = Task_cache_rewrite; module_name = "coord_broadcast" };
+          ] )
+    else (content, msg_type, [])
   in
   (* RFC-0040: sender-side mention dedup.  When [Mention.extract]
      finds an [@target] and the same (from_agent, target, content_hash)
@@ -127,12 +189,13 @@ let broadcast ?trace_context ?(msg_type = "broadcast")
      [Mention.any_mentioned]) re-reads the board on every turn, so a
      spammy resender otherwise floods the recipient's inbox.  Set
      [~bypass_dedup:true] to override for system-level alerts. *)
-  let pre_extract_mention = Mention.extract content in
   let dedup_skipped =
     (not bypass_dedup)
     && (match pre_extract_mention with
         | Some target when String.trim target <> "" ->
-            let content_hash = Mention_dedup.content_topic_hash content in
+            let content_hash =
+              Mention_dedup.content_topic_hash original_content
+            in
             Mention_dedup.should_skip ~from_agent ~target ~content_hash
               ~now:(Time_compat.now ())
         | _ ->

--- a/lib/coord/coord_broadcast.mli
+++ b/lib/coord/coord_broadcast.mli
@@ -4,6 +4,22 @@
 open Masc_domain
 open Coord_utils
 
+(** RFC-0061: closed variants for broadcast envelope observability. *)
+type rewrite_reason =
+  | Cache_invalidated of { task_id : string; status : string }
+  | Task_cache_rewrite
+
+type rewrite_event = {
+  reason : rewrite_reason;
+  module_name : string;
+}
+
+type msg_type_typed =
+  | Broadcast
+  | Cache_invalidated of { task_id : string; status : string }
+
+val string_of_msg_type_typed : msg_type_typed -> string
+
 val emit_message_activity : Coord_utils_backend_setup.config ->
            from_agent:string ->
            content:string ->

--- a/tla+/RFC0061Buggy.cfg
+++ b/tla+/RFC0061Buggy.cfg
@@ -1,0 +1,6 @@
+SPECIFICATION SpecBuggy
+CONSTANTS
+    AgentNames = {"alice", "bob"}
+    MaxRewrites = 3
+
+INVARIANT Safety

--- a/tla+/RFC0061CacheInvalidationBroadcast.tla
+++ b/tla+/RFC0061CacheInvalidationBroadcast.tla
@@ -1,0 +1,204 @@
+---- MODULE RFC0061CacheInvalidationBroadcast ----
+\* Boundary spec for RFC-0061: Cache-invalidation broadcast envelope.
+\*
+\* Runtime truth being modelled (lib/coord/coord_broadcast.ml:79-130):
+\*   - When a broadcasting agent's current_task is terminal,
+\*     the original broadcast content is rewritten to a
+\*     "[cache_invalidated] ... stale broadcast suppressed" notice.
+\*   - Mention tokens are extracted from the *original* content
+\*     (via Mention.extract) to drive downstream wake decisions.
+\*   - In the buggy code, rewrite happens at lines 95-101 *before*
+\*     pre_extract_mention at line 130.  The rewritten content
+\*     contains no @mention tokens, so wake decisions downstream
+\*     see mention=None even when the original message had one.
+\*
+\* What this spec deliberately abstracts away:
+\*   - The actual filesystem / JSON serialization of messages.
+\*   - The dedup gate (RFC-0040) — modelled as a non-deterministic
+\*     skip to keep the state space small.
+\*   - The exact regex for Mention.extract — modelled as a boolean
+\*     "original_has_mention".
+\*
+\* Bug Model (CLAUDE.md "TLA+ Bug Model pattern"):
+\*   - Spec       (clean): pre_extract_mention runs on original_content
+\*     before any rewrite; mention_tokens are preserved.
+\*   - SpecBuggy: BroadcastRewriteSwallowsMention rewrites content
+\*     *before* mention extraction, so mention_tokens become empty.
+\*
+\* Expected TLC outcome:
+\*   - Clean .cfg:  MentionTokensExtractedBeforeRewrite holds (no error).
+\*   - Buggy .cfg: MentionTokensExtractedBeforeRewrite violated
+\*     within <= 2 steps.
+
+EXTENDS TLC, Naturals, Sequences
+
+CONSTANTS
+    AgentNames,          \* Set of agent names, e.g. {"alice", "bob"}
+    MaxRewrites          \* Upper bound on rewrite events per broadcast
+
+ASSUME AgentNamesNonEmpty == AgentNames # {}
+ASSUME MaxRewritesPos == MaxRewrites \in Nat /\ MaxRewrites >= 1
+
+VARIABLES
+    phase,               \* {"idle", "building", "extracted", "rewritten", "delivered", "dedup_skipped"}
+    original_content,    \* the raw content before any rewrite
+    current_content,     \* content after rewrites (may differ from original)
+    mention_tokens,      \* list of mention targets extracted from content
+    rewrites,            \* sequence of rewrite_event labels applied so far
+    msg_type,            \* {"broadcast", "cache_invalidated"}
+    original_has_mention \* boolean: does original_content contain an @mention?
+
+vars == << phase, original_content, current_content, mention_tokens,
+           rewrites, msg_type, original_has_mention >>
+
+PhaseSet == {"idle", "building", "extracted", "rewritten", "delivered", "dedup_skipped"}
+MsgTypeSet == {"broadcast", "cache_invalidated"}
+RewriteLabelSet == {"cache_invalidation", "dedup_guard", "sanitize"}
+
+(* ── Type invariant ─────────────────────────────────────── *)
+
+TypeOK ==
+    /\ phase \in PhaseSet
+    /\ original_content \in AgentNames
+    /\ current_content \in AgentNames
+    /\ mention_tokens \in Seq(AgentNames)
+    /\ rewrites \in Seq(RewriteLabelSet)
+    /\ msg_type \in MsgTypeSet
+    /\ original_has_mention \in BOOLEAN
+
+(* ── Initial state ──────────────────────────────────────── *)
+
+Init ==
+    /\ phase = "idle"
+    /\ original_content = "none"
+    /\ current_content = "none"
+    /\ mention_tokens = << >>
+    /\ rewrites = << >>
+    /\ msg_type = "broadcast"
+    /\ original_has_mention = FALSE
+
+(* ── Helpers ────────────────────────────────────────────── *)
+
+MentionFromOriginal ==
+    IF original_has_mention
+    THEN << original_content >>
+    ELSE << >>
+
+(* ── Actions (clean model) ──────────────────────────────── *)
+
+\* A broadcast is initiated with some original content.
+\* The agent may or may not have included an @mention.
+StartBroadcast(agent, has_mention) ==
+    /\ phase = "idle"
+    /\ agent \in AgentNames
+    /\ has_mention \in BOOLEAN
+    /\ phase' = "building"
+    /\ original_content' = agent
+    /\ current_content' = agent
+    /\ original_has_mention' = has_mention
+    /\ UNCHANGED << mention_tokens, rewrites, msg_type >>
+
+\* CLEAN: mention extraction happens on the *original* content,
+\* before any rewrite.  This preserves the mention token even if
+\* a later rewrite replaces the content with a cache-invalidation
+\* notice that contains no @mention.
+ExtractMentionsClean ==
+    /\ phase = "building"
+    /\ phase' = "extracted"
+    /\ mention_tokens' = MentionFromOriginal
+    /\ UNCHANGED << original_content, current_content, rewrites, msg_type,
+                    original_has_mention >>
+
+\* A rewrite is applied (e.g. cache invalidation).  The rewrite
+\* is stamped in [rewrites] but the original content is preserved.
+ApplyRewrite(label) ==
+    /\ phase \in {"extracted", "rewritten"}
+    /\ label \in RewriteLabelSet
+    /\ Len(rewrites) < MaxRewrites
+    /\ phase' = "rewritten"
+    /\ rewrites' = Append(rewrites, label)
+    /\ IF label = "cache_invalidation"
+       THEN /\ current_content' = "cache_notice"
+            /\ msg_type' = "cache_invalidated"
+       ELSE /\ current_content' = current_content
+            /\ UNCHANGED msg_type
+    /\ UNCHANGED << original_content, mention_tokens, original_has_mention >>
+
+\* The broadcast is delivered.  Subscribers use [original_content]
+\* for wake decisions (mention extraction) and [current_content]
+\* for UI display.
+Deliver ==
+    /\ phase \in {"extracted", "rewritten"}
+    /\ phase' = "delivered"
+    /\ UNCHANGED << original_content, current_content, mention_tokens,
+                    rewrites, msg_type, original_has_mention >>
+
+\* Non-deterministic dedup skip (RFC-0040 abstraction).
+SkipDedup ==
+    /\ phase = "building"
+    /\ phase' = "dedup_skipped"
+    /\ UNCHANGED << original_content, current_content, mention_tokens,
+                    rewrites, msg_type, original_has_mention >>
+
+Next ==
+    /\ \E agent \in AgentNames, has_mention \in BOOLEAN :
+         StartBroadcast(agent, has_mention)
+    \/ ExtractMentionsClean
+    \/ \E label \in RewriteLabelSet : ApplyRewrite(label)
+    \/ Deliver
+    \/ SkipDedup
+
+Spec == Init /\ [][Next]_vars
+
+(* ── Safety invariants ──────────────────────────────────── *)
+
+\* I1: If the original content had a mention, the extracted tokens
+\* must be non-empty.  This is the property that the buggy code
+\* violates when rewrite happens before extraction.
+MentionTokensExtractedBeforeRewrite ==
+    original_has_mention => Len(mention_tokens) > 0
+
+\* I2: Once delivered, the mention tokens are consistent with the
+\* original content (not the rewritten content).
+DeliveredMentionsConsistent ==
+    phase = "delivered" =>
+        (original_has_mention <=> Len(mention_tokens) > 0)
+
+\* I3: Rewrites are stamped and bounded.
+RewritesBounded ==
+    Len(rewrites) <= MaxRewrites
+
+\* Combined safety invariant referenced by the .cfg.
+Safety ==
+    /\ TypeOK
+    /\ MentionTokensExtractedBeforeRewrite
+    /\ DeliveredMentionsConsistent
+    /\ RewritesBounded
+
+(* ── Bug Model ──────────────────────────────────────────── *)
+
+\* Bug action: rewrite happens *before* mention extraction.
+\* This models the current buggy code where cache_invalidated
+\* rewrite at coord_broadcast.ml:95-101 runs before
+\* pre_extract_mention at line 130.  The rewritten content
+\* ("cache_notice") has no mention, so extraction yields empty.
+BroadcastRewriteSwallowsMention ==
+    /\ phase = "building"
+    /\ phase' = "extracted"
+    /\ mention_tokens' = << >>
+    /\ rewrites' = Append(rewrites, "cache_invalidation")
+    /\ current_content' = "cache_notice"
+    /\ msg_type' = "cache_invalidated"
+    /\ UNCHANGED << original_content, original_has_mention >>
+
+NextBuggy ==
+    /\ \E agent \in AgentNames, has_mention \in BOOLEAN :
+         StartBroadcast(agent, has_mention)
+    \/ BroadcastRewriteSwallowsMention
+    \/ \E label \in RewriteLabelSet : ApplyRewrite(label)
+    \/ Deliver
+    \/ SkipDedup
+
+SpecBuggy == Init /\ [][NextBuggy]_vars
+
+====

--- a/tla+/RFC0061Clean.cfg
+++ b/tla+/RFC0061Clean.cfg
@@ -1,0 +1,6 @@
+SPECIFICATION Spec
+CONSTANTS
+    AgentNames = {"alice", "bob"}
+    MaxRewrites = 3
+
+INVARIANT Safety


### PR DESCRIPTION
## Summary

RFC-0061: Fix Reactive axis stage-1 death where broadcast rewrite swallows mention tokens before `Mention.extract` runs.

## Changes

- `lib/coord/coord_broadcast.ml`:
  - Add closed variants `rewrite_reason`, `rewrite_event`, `msg_type_typed`
  - Move `pre_extract_mention` before fleet-wide invariant rewrite block
  - Dedup hash keys to `original_content` (RFC-0040 guarantee)
- `lib/coord/coord_broadcast.mli`: Export new types
- `docs/rfc/RFC-0061-cache-invalidation-broadcast-envelope.md`: RFC document
- `tla+/RFC0061CacheInvalidationBroadcast.tla` + `.cfg`: TLA+ Bug Model

## TLA+ Verification Matrix

| Config | Expected | Status |
|--------|----------|--------|
| `RFC0061Clean.cfg` | Invariant holds | Pending TLC |
| `RFC0061Buggy.cfg` | Invariant violated | Pending TLC |

## Layer 3 Review

Per RFC §6, invoke `Agent(subagent_type=adversarial-reviewer)` after PR opens.

## RFC Cross-Reference

- RFC-0040 (mention-dedup): Dedup hash now correctly keys to original content