### PR TITLE
fix(auth): register sidecar tool in legacy permission map

### DIFF
--- a/lib/tool_permission_map.ml
+++ b/lib/tool_permission_map.ml
@@ -127,6 +127,7 @@ let legacy_permission_entries : (string * permission) list =
     ("masc_portal_send", CanSendPortal);
     ("masc_worktree_create", CanCreateWorktree);
     ("masc_worktree_remove", CanRemoveWorktree);
+    ("sidecar", CanBroadcast);
   ]
 
 let legacy_permission_for_tool tool_name =


### PR DESCRIPTION
## Summary

`POST /api/v1/sidecar/start?name=discord` (and stop/logs/config) returned **403 Forbidden** because the `sidecar` tool name was not registered in `Tool_permission_map.legacy_permission_entries`.

Under strict auth mode (default), an unmapped tool name that does not match `masc_*` prefixes or keeper-internal surfaces is rejected as an "unknown non-masc tool". The dashboard Connectors tab uses `with_tool_auth ~tool_name:\"sidecar\"`, so the backend refused the request.

## Change

Add `(&quot;sidecar&quot;, CanBroadcast)` to `legacy_permission_entries` in `lib/tool_permission_map.ml`.

`CanBroadcast` aligns with the sidecar lifecycle endpoints (start/stop/logs/config) which are operator-level actions.

## Verification

- `dune build --root . lib/tool_permission_map.ml` passes
- `dune build --root . lib/auth.ml` passes
- `dune build --root . lib/server/server_routes_http_routes_sidecar.ml` passes

## Post-merge requirement

**Server restart required** — the auth cache is evaluated at request time but the compiled binary must be rebuilt and the running server process (main_eio.exe) replaced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)