### PR TITLE
refactor(dashboard): move memory entries to Keeper tab, drop Episodes tab

### DIFF
--- a/dashboard/src/components/cognition-plane.ts
+++ b/dashboard/src/components/cognition-plane.ts
@@ -6,9 +6,9 @@ import { FilterChips } from './common/filter-chips'
 import { KeeperDecisionsStream } from './keeper-decisions-stream'
 import { KeeperCognitionInspector } from './keeper-cognition-inspector'
 import { KeeperTokenStats } from './keeper-token-stats'
-import { MemorySubsystems, type MemorySubsystemsFocus } from './memory-subsystems'
+import { MemorySubsystems } from './memory-subsystems'
 
-type CognitionView = 'overview' | 'keeper' | 'token-stats' | 'decisions' | 'memory' | 'episodes' | 'autoresearch'
+type CognitionView = 'overview' | 'keeper' | 'token-stats' | 'decisions' | 'memory' | 'autoresearch'
 
 const COGNITION_VIEWS: CognitionView[] = [
   'overview',
@@ -16,7 +16,6 @@ const COGNITION_VIEWS: CognitionView[] = [
   'token-stats',
   'decisions',
   'memory',
-  'episodes',
   'autoresearch',
 ]
 
@@ -26,7 +25,6 @@ const VIEW_CHIPS: Array<{ key: CognitionView; label: string; title?: string }> =
   { key: 'token-stats', label: 'Token Stats' },
   { key: 'decisions', label: 'Decisions' },
   { key: 'memory', label: 'Memory' },
-  { key: 'episodes', label: 'Episodes' },
   { key: 'autoresearch', label: 'Autoresearch' },
 ]
 
@@ -49,14 +47,8 @@ function updateViewParam(view: CognitionView): void {
   navigate('monitoring', next)
 }
 
-function currentMemoryFocus(view: CognitionView): MemorySubsystemsFocus {
-  if (view === 'episodes') return 'episodes'
-  return route.value.params.focus === 'entries' ? 'entries' : 'overview'
-}
-
 export function CognitionPlane() {
   const view = currentView()
-  const memoryFocus = currentMemoryFocus(view)
 
   return html`
     <div class="flex flex-col gap-5">
@@ -74,8 +66,8 @@ export function CognitionPlane() {
         <${KeeperTokenStats} />
       ` : view === 'decisions' ? html`
         <${KeeperDecisionsStream} />
-      ` : view === 'memory' || view === 'episodes' ? html`
-        <${MemorySubsystems} focus=${memoryFocus} />
+      ` : view === 'memory' ? html`
+        <${MemorySubsystems} />
       ` : view === 'autoresearch' ? html`
         <${Autoresearch} />
       ` : html`

--- a/dashboard/src/components/keeper-cognition-inspector.ts
+++ b/dashboard/src/components/keeper-cognition-inspector.ts
@@ -7,9 +7,10 @@ import { FilterChips } from './common/filter-chips'
 import { PanelCard } from './common/panel-card'
 import { KeeperBadge } from './keeper-badge'
 import { KeeperBDIPanel } from './keeper-bdi-panel'
+import { KeeperMemoryPanel } from './memory-subsystems'
 import { formatDuration } from './mission-utils'
 
-type KeeperInspectorFocus = 'bdi' | 'tool-access'
+type KeeperInspectorFocus = 'bdi' | 'tool-access' | 'memory'
 
 interface ToolAccessRow {
   label: string
@@ -19,6 +20,7 @@ interface ToolAccessRow {
 const FOCUS_CHIPS: Array<{ key: KeeperInspectorFocus; label: string; title: string }> = [
   { key: 'bdi', label: 'BDI', title: 'Will, needs, desires, and goal horizons' },
   { key: 'tool-access', label: 'Tool Access', title: 'Runtime tool and execution access snapshot' },
+  { key: 'memory', label: 'Memory', title: 'Keeper memory bank entries (memory.jsonl)' },
 ]
 
 function keeperKeys(keeper: Keeper): string[] {
@@ -114,7 +116,10 @@ export function toolAccessRowsForKeeper(keeper: Keeper): ToolAccessRow[] {
 }
 
 function currentFocus(): KeeperInspectorFocus {
-  return route.value.params.focus === 'tool-access' ? 'tool-access' : 'bdi'
+  const f = route.value.params.focus
+  if (f === 'tool-access') return 'tool-access'
+  if (f === 'memory') return 'memory'
+  return 'bdi'
 }
 
 function navigateFocus(focus: KeeperInspectorFocus): void {
@@ -261,7 +266,9 @@ export function KeeperCognitionInspector() {
 
       ${focus === 'tool-access'
         ? html`<${ToolAccessSnapshot} keeper=${selected} />`
-        : html`<${BdiSnapshot} keeper=${selected} />`}
+        : focus === 'memory'
+          ? html`<${KeeperMemoryPanel} keeperName=${selected.name} />`
+          : html`<${BdiSnapshot} keeper=${selected} />`}
     </section>
   `
 }

--- a/dashboard/src/components/memory-subsystems.ts
+++ b/dashboard/src/components/memory-subsystems.ts
@@ -24,7 +24,6 @@ import { ringFocusClasses } from './common/ring'
 
 const REFRESH_MS = 30_000
 
-export type MemorySubsystemsFocus = 'overview' | 'entries' | 'episodes'
 
 export const ARCHITECTURE_FLOW = `graph LR
     subgraph Keeper["키퍼 턴"]
@@ -502,7 +501,7 @@ function MemoryEntryRow({ entry }: { readonly entry: MemorySubsystemsMemoryEntry
   `
 }
 
-function MemoryEntriesPanel({
+export function MemoryEntriesPanel({
   entries,
   visibleEntries,
   total,
@@ -571,17 +570,12 @@ function MemoryEntriesPanel({
   `
 }
 
-export function MemorySubsystems({ focus = 'overview' }: { readonly focus?: MemorySubsystemsFocus }) {
+export function MemorySubsystems() {
   const resource = useManagedAsyncResource<MemorySubsystemsResponse>(null)
-  const includeMemoryEntries = focus === 'entries'
 
   const keeperFilter = useSignal<string>('')
   const outcomeFilter = useSignal<string>('')
   const searchQuery = useSignal<string>('')
-  const memoryKindFilter = useSignal<string>('all')
-  // Client-side substring filter for the Hebbian synapses table. Independent
-  // from the episodes filter bar above — the synapses table is N² in fleet
-  // size and needs its own needle.
   const synapseQuery = useSignal<string>('')
 
   useEffect(() => {
@@ -592,7 +586,6 @@ export function MemorySubsystems({ focus = 'overview' }: { readonly focus?: Memo
           keeper: keeperFilter.value || undefined,
           outcome: outcomeFilter.value || undefined,
           q: searchQuery.value || undefined,
-          includeMemoryEntries,
           signal,
         }),
       )
@@ -603,7 +596,7 @@ export function MemorySubsystems({ focus = 'overview' }: { readonly focus?: Memo
       resource.cancel()
       cleanup()
     }
-  }, [keeperFilter.value, outcomeFilter.value, searchQuery.value, includeMemoryEntries, resource])
+  }, [keeperFilter.value, outcomeFilter.value, searchQuery.value, resource])
 
   const { loading, error, data } = resource.state.value
   if (loading && !data) return html`<${LoadingState} label="기억 서브시스템 로드 중..." />`
@@ -621,16 +614,8 @@ export function MemorySubsystems({ focus = 'overview' }: { readonly focus?: Memo
   const episodes = data?.episodes?.items ?? []
   const totalEpisodes = data?.episodes?.total ?? 0
   const filteredTotal = data?.episodes?.filtered ?? episodes.length
-  const memoryEntries = data?.memory_entries?.items ?? []
-  const memoryEntryTotal = data?.memory_entries?.total ?? memoryEntries.length
-  const memoryEntryFiltered = data?.memory_entries?.filtered ?? memoryEntries.length
   const knownKeepers = data?.filters?.keepers ?? []
   const knownOutcomes = data?.filters?.outcomes ?? ['success', 'partial', 'failure']
-  const knownMemoryKinds = data?.filters?.memory_kinds ?? Array.from(new Set(memoryEntries.map(entry => entry.kind))).sort()
-  const visibleMemoryEntries = useMemo(
-    () => filterMemoryEntries(memoryEntries, memoryKindFilter.value),
-    [memoryEntries, memoryKindFilter.value],
-  )
 
   const onSearchInput = (e: Event) => {
     const v = (e.target as HTMLInputElement).value
@@ -642,7 +627,6 @@ export function MemorySubsystems({ focus = 'overview' }: { readonly focus?: Memo
     outcomeFilter.value = ''
     searchQuery.value = ''
     synapsePairFilter.value = null
-    memoryKindFilter.value = 'all'
   }
 
   const pairFilter = synapsePairFilter.value
@@ -662,25 +646,10 @@ export function MemorySubsystems({ focus = 'overview' }: { readonly focus?: Memo
     : episodes
 
   const showArch = useSignal(false)
-  const focusEntries = focus === 'entries'
-  const showMemoryEntries = focusEntries || memoryEntries.length > 0
 
   return html`
     <div class="space-y-6">
-      ${showMemoryEntries ? html`
-        <${MemoryEntriesPanel}
-          entries=${memoryEntries}
-          visibleEntries=${visibleMemoryEntries}
-          total=${memoryEntryTotal}
-          filtered=${memoryEntryFiltered}
-          knownKinds=${knownMemoryKinds}
-          activeKind=${memoryKindFilter.value}
-          onKindChange=${(kind: string) => { memoryKindFilter.value = kind }}
-          focused=${focusEntries}
-        />
-      ` : null}
-
-      ${focusEntries ? null : html`
+      ${html`
 
       <!-- Architecture Flow (collapsible) -->
       <section aria-label="아키텍처 데이터 흐름도">
@@ -874,11 +843,7 @@ export function MemorySubsystems({ focus = 'overview' }: { readonly focus?: Memo
       <${DecisionsStream} />
       `}
 
-      ${
-        error
-          ? html`<div class="text-xs text-[var(--color-status-warn)] mt-2">refresh error: ${error}</div>`
-          : null
-      }
+      ${error ? html`<div class="text-xs text-[var(--color-status-warn)] mt-2">refresh error: ${error}</div>` : null}
     </div>
   `
 }
@@ -1045,5 +1010,53 @@ function DecisionsStream() {
               </div>
             `}
     </section>
+  `
+}
+
+export function KeeperMemoryPanel({ keeperName }: { readonly keeperName: string }) {
+  const resource = useManagedAsyncResource<MemorySubsystemsResponse>(null)
+  const memoryKindFilter = useSignal<string>('all')
+
+  useEffect(() => {
+    const run = () => {
+      void resource.load(async (signal) =>
+        fetchMemorySubsystems({ keeper: keeperName, includeMemoryEntries: true, limit: 200, signal }),
+      )
+    }
+    run()
+    const cleanup = setupVisibleAutoRefresh(run, REFRESH_MS)
+    return () => {
+      resource.cancel()
+      cleanup()
+    }
+  }, [keeperName, resource])
+
+  const { loading, error, data } = resource.state.value
+  if (loading && !data) return html`<${LoadingState} label="memory entries 로드 중..." />`
+  if (error && !data) return html`<div class="p-4 text-[var(--bad-light)]">오류: ${error}</div>`
+
+  const entries = data?.memory_entries?.items ?? []
+  const total = data?.memory_entries?.total ?? entries.length
+  const filtered = data?.memory_entries?.filtered ?? entries.length
+  const knownKinds = data?.filters?.memory_kinds ?? Array.from(new Set(entries.map(e => e.kind))).sort()
+  const visibleEntries = useMemo(
+    () => filterMemoryEntries(entries, memoryKindFilter.value),
+    [entries, memoryKindFilter.value],
+  )
+
+  return html`
+    <div class="space-y-3">
+      <${MemoryEntriesPanel}
+        entries=${entries}
+        visibleEntries=${visibleEntries}
+        total=${total}
+        filtered=${filtered}
+        knownKinds=${knownKinds}
+        activeKind=${memoryKindFilter.value}
+        onKindChange=${(kind: string) => { memoryKindFilter.value = kind }}
+        focused=${true}
+      />
+      ${error ? html`<div class="text-xs text-[var(--color-status-warn)]">refresh error: ${error}</div>` : null}
+    </div>
   `
 }


### PR DESCRIPTION
## Summary

- **Episodes 탭 제거**: `focus='episodes'`가 `focus='overview'`와 동일 렌더링이었던 버그 수정 — 중복 탭 자체를 제거
- **Memory 탭 정리**: fleet-wide 데이터(Hebbian 시냅스 + 에피소드)만 담당
- **Keeper 탭 Memory 서브탭 추가**: `KeeperMemoryPanel` 컴포넌트로 해당 Keeper의 `memory.jsonl` entries를 per-keeper 필터로 조회

## Before / After

| | Before | After |
|---|---|---|
| Cognition 탭 수 | 7개 (episodes 중복) | 6개 |
| Memory entries | Memory 탭에 혼재 | Keeper 탭 › Memory 서브탭 |
| Memory 탭 | Hebbian + episodes + entries | Hebbian + episodes |
| Keeper 탭 | BDI, Tool Access | BDI, Tool Access, **Memory** |

## Test plan
- [ ] Cognition › Memory 탭: Hebbian 매트릭스 + 에피소드만 표시 확인
- [ ] Cognition › Keeper 탭 › Memory: 선택 Keeper 메모리 entries 표시 확인
- [ ] Episodes 탭 없어진 것 확인
- [ ] `tsc --noEmit` 에러 없음 ✅
- [ ] `vite build` 성공 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)