### PR TITLE
fix(cascade,test): remove conflict markers from main (hotfix)

### DIFF
--- a/lib/cascade/cascade_capability_profile.mli
+++ b/lib/cascade/cascade_capability_profile.mli
@@ -1,26 +1,10 @@
-<<<<<<< HEAD
 (** RFC-0058: Declarative capability profile (v2).
-||||||| parent of bfa5059839 (feat(cascade): RFC-0058 Phase 1 — TOML-declared capability profiles + provider_filter)
-(** Cascade_capability_profile — declarative capability requirement
-    for cascade profiles.  RFC-0027.
-=======
-(** Cascade_capability_profile — declarative capability requirement
-    for cascade profiles.  RFC-0027 (built-in) + RFC-0058 (TOML-defined).
->>>>>>> bfa5059839 (feat(cascade): RFC-0058 Phase 1 — TOML-declared capability profiles + provider_filter)
 
-<<<<<<< HEAD
     Profiles are string-named, resolved via
     {!Cascade_capability_schema}.  The previous closed variant
     [Tool_strict | Inline_tools | Lite | Local] has been removed;
-    callers use profile name strings directly. *)
-||||||| parent of bfa5059839 (feat(cascade): RFC-0058 Phase 1 — TOML-declared capability profiles + provider_filter)
-    Each cascade in [cascade.toml] may declare a
-    [required_capability_profile = "<name>"] field (added in PR #2).
-    This module owns the closed enumeration of supported profile
-    names, the capability-requirement table that defines each profile,
-    and the predicate used by the validator to decide whether a
-    given provider satisfies a profile.
-=======
+    callers use profile name strings directly.
+
     Each cascade in [cascade.toml] may declare a
     [required_capability_profile = "<name>"] field (added in PR #2).
     This module owns the closed enumeration of built-in profile
@@ -28,157 +12,50 @@
     the capability-requirement table that defines each profile,
     and the predicate used by the validator to decide whether a
     given provider satisfies a profile.
->>>>>>> bfa5059839 (feat(cascade): RFC-0058 Phase 1 — TOML-declared capability profiles + provider_filter)
 
-<<<<<<< HEAD
+    See: docs/rfc/RFC-0027-capability-typed-cascade.md,
+         docs/rfc/RFC-0058-declarative-cascade-config.md *)
+
 val profile_to_string : string -> string
 (** Identity function (profile names are already strings).
     Kept for API compatibility with callers that format profile names. *)
-||||||| parent of bfa5059839 (feat(cascade): RFC-0058 Phase 1 — TOML-declared capability profiles + provider_filter)
-    See: docs/rfc/RFC-0027-capability-typed-cascade.md *)
-=======
-    See: docs/rfc/RFC-0027-capability-typed-cascade.md,
-         docs/rfc/RFC-0058-declarative-cascade-config.md *)
->>>>>>> bfa5059839 (feat(cascade): RFC-0058 Phase 1 — TOML-declared capability profiles + provider_filter)
 
-<<<<<<< HEAD
 val profile_of_string : string -> string option
 (** [profile_of_string s] returns [Some s] if [s] is a known profile
     name in {!Cascade_capability_schema.builtin_profiles}, [None]
     otherwise.  Unknown profile strings should be treated as a hard
     configuration error by callers. *)
-||||||| parent of bfa5059839 (feat(cascade): RFC-0058 Phase 1 — TOML-declared capability profiles + provider_filter)
-(** Closed enumeration of named capability profiles.  New variants
-    require an explicit PR (deliberate — avoids silent string-typed
-    drift between cascade.toml and code). *)
-type profile =
-  | Tool_strict
-      (** Keeper-bound runtime MCP requires per-request HTTP headers.
-          Only providers with [supports_runtime_mcp_http_headers]
-          (claude_code / kimi_cli / HTTP-based) qualify.  Used by
-          keepers that must dispatch keeper-scoped MCP tools (e.g.
-          [keeper_bash], [masc_worktree_create]). *)
-  | Inline_tools
-      (** Direct-API path: provider must support [supports_inline_tools]
-          and [supports_inline_tool_choice].  CLI runtimes
-          (claude_code / codex_cli / gemini_cli / kimi_cli) all fail
-          this — they expose tools through runtime MCP, not inline. *)
-  | Lite
-      (** Runtime-MCP-capable but does not require HTTP headers.
-          Suitable for [gemini_cli] (static MCP via
-          [~/.gemini/settings.json]) and other CLI runtimes that
-          carry tools through stdio MCP. *)
-  | Local_inline
-      (** RFC-0058: Ollama-style providers with inline tool calling but
-          no runtime MCP or tool_choice enforcement. Encodes the actual
-          capability set of local LLM providers (inline_tools=Required,
-          everything else Optional). Used as terminal fallback capability
-          where graceful degradation is intentional. *)
-  | Local
-      (** No capability requirements — accepts any provider including
-          ollama-only profiles.  Used by [local_recovery]-like lanes
-          that exist purely for liveness fallback. *)
-=======
-(** Closed enumeration of built-in capability profiles.  New variants
-    require an explicit PR (deliberate — avoids silent string-typed
-    drift between cascade.toml and code).  User-defined profiles
-    added via TOML [profiles.<name>] sections bypass this variant. *)
-type profile =
-  | Tool_strict
-  | Inline_tools
-  | Lite
-  | Local_inline
-  | Local
->>>>>>> bfa5059839 (feat(cascade): RFC-0058 Phase 1 — TOML-declared capability profiles + provider_filter)
 
-<<<<<<< HEAD
 val all_profiles : string list
 (** All builtin profile names from the schema registry. *)
-||||||| parent of bfa5059839 (feat(cascade): RFC-0058 Phase 1 — TOML-declared capability profiles + provider_filter)
-val profile_to_string : profile -> string
-(** Stable lowercase snake_case label.
-    [Tool_strict] -> ["tool_strict"], etc.  Used as the cascade.toml
-    field value and the Prometheus label. *)
-
-val profile_of_string : string -> profile option
-(** Inverse of {!profile_to_string}.  Returns [None] for unknown
-    strings — caller must treat that as a hard configuration error
-    (no silent fallback). *)
-
-val all_profiles : profile list
-(** Every variant of {!profile} in declaration order.  Used by tests
-    and by the validator to enumerate the catalog. *)
-
-(** Per-capability requirement.  Mirrors the field set of
-    {!Provider_tool_support.capabilities} but lifts each [bool] to
-    a tri-state [requirement] so a profile can declare "I require
-    this" vs. "I do not care". *)
-type requirement =
-  | Required
-      (** Provider must have the capability set to [true]. *)
-  | Optional
-      (** Profile does not constrain this capability — provider may
-          or may not have it. *)
-
-type required_capabilities = {
-  inline_tools : requirement;
-  inline_tool_choice : requirement;
-  runtime_mcp_tools : requirement;
-  runtime_tool_events : requirement;
-  runtime_mcp_http_headers : requirement;
-}
-(** The capability-requirement matrix for one profile.  Field names
-    match {!Provider_tool_support.capabilities} (with the [supports_]
-    prefix stripped) so satisfaction can be checked field-by-field. *)
-
-val required_capabilities_of : profile -> required_capabilities
-(** [required_capabilities_of p] returns the capability matrix that
-    defines profile [p].  Pure function — see RFC-0027 §3.1 for the
-    matrix definition. *)
-=======
-val profile_to_string : profile -> string
-val profile_of_string : string -> profile option
-val all_profiles : profile list
-
-type requirement =
-  | Required
-  | Optional
-
-type required_capabilities = {
-  inline_tools : requirement;
-  inline_tool_choice : requirement;
-  runtime_mcp_tools : requirement;
-  runtime_tool_events : requirement;
-  runtime_mcp_http_headers : requirement;
-}
-
-val required_capabilities_of : profile -> required_capabilities
-(** Built-in profile → capability matrix. *)
->>>>>>> bfa5059839 (feat(cascade): RFC-0058 Phase 1 — TOML-declared capability profiles + provider_filter)
 
 val provider_satisfies_profile :
-<<<<<<< HEAD
   string -> Provider_tool_support.capabilities -> bool
 (** [provider_satisfies_profile name caps] is [true] iff every
     capability required by profile [name] is [true] in [caps].
-    Returns [false] for unknown profile names. *)
-||||||| parent of bfa5059839 (feat(cascade): RFC-0058 Phase 1 — TOML-declared capability profiles + provider_filter)
-  profile -> Provider_tool_support.capabilities -> bool
-(** [provider_satisfies_profile p caps] is [true] iff every
-    [Required] field of {!required_capabilities_of}[ p] is [true]
-    in [caps].  [Optional] fields are unconstrained. *)
-=======
-  profile -> Provider_tool_support.capabilities -> bool
+    Returns [false] for unknown profile names.
 
-(** {2 RFC-0058: TOML-defined profiles} *)
+    Checks built-in profiles only (via {!Cascade_capability_schema}).
+    For declared profiles, use {!provider_satisfies_named_profile}. *)
+
+(** {2 RFC-0058 Phase 1: TOML-declared profiles} *)
+
+type requirement =
+  | Required
+  | Optional
+
+type required_capabilities = {
+  inline_tools : requirement;
+  inline_tool_choice : requirement;
+  runtime_mcp_tools : requirement;
+  runtime_tool_events : requirement;
+  runtime_mcp_http_headers : requirement;
+}
 
 type declared_profile = {
   required_capabilities_list : string list;
   provider_filter : string option;
 }
-(** A profile parsed from TOML [profiles.<name>] section.
-    [required_capabilities_list] names must appear in
-    [known_capability_fields]. *)
 
 val known_capability_fields : string list
 (** Canonical field names matching {!Provider_tool_support.capabilities}
@@ -216,30 +93,9 @@ val declared_profile_names : unit -> string list
 (** Names of TOML-declared profiles currently in the runtime registry. *)
 
 (** {2 System cascades} *)
->>>>>>> bfa5059839 (feat(cascade): RFC-0058 Phase 1 — TOML-declared capability profiles + provider_filter)
 
 val safe_lane_cascade_name : string
-<<<<<<< HEAD
 (** System-only cascade name: ["__safe_lane"]. *)
 
-||||||| parent of bfa5059839 (feat(cascade): RFC-0058 Phase 1 — TOML-declared capability profiles + provider_filter)
-(** RFC-0027 PR-4 system-only cascade name, ["__safe_lane"].  This
-    cascade is shipped in the seed [config/cascade.toml] and contains
-    only providers that satisfy {!Tool_strict}.  Used as the absolute
-    last-resort fallback target by the cross-cascade resolver.
-    Operators must not assign this cascade to keepers — the [__]
-    prefix marks it as system-internal and the seed sets
-    [keeper_assignable = false]. *)
-
-=======
->>>>>>> bfa5059839 (feat(cascade): RFC-0058 Phase 1 — TOML-declared capability profiles + provider_filter)
 val is_system_cascade_name : string -> bool
-<<<<<<< HEAD
 (** [is_system_cascade_name name] is [true] iff [name] starts with ["__"]. *)
-||||||| parent of bfa5059839 (feat(cascade): RFC-0058 Phase 1 — TOML-declared capability profiles + provider_filter)
-(** [is_system_cascade_name name] is [true] iff [name] is a
-    system-reserved cascade name (currently: anything starting with
-    ["__"]).  Operator-authored cascades must not collide with this
-    namespace. *)
-=======
->>>>>>> bfa5059839 (feat(cascade): RFC-0058 Phase 1 — TOML-declared capability profiles + provider_filter)

--- a/test/test_goal_loop_completion_audit.py
+++ b/test/test_goal_loop_completion_audit.py
@@ -1099,13 +1099,7 @@ class GoalLoopCompletionAuditTest(unittest.TestCase):
             checklist_evidence["requirements_with_tracking_issue_refs"],
             10,
         )
-<<<<<<< HEAD
-        self.assertEqual(checklist_evidence["tracking_issue_refs_total"], 7)
-||||||| parent of 3f641fd33d (test(goal-loop): close startup policy checklist rows)
-        self.assertEqual(checklist_evidence["tracking_issue_refs_total"], 8)
-=======
         self.assertEqual(checklist_evidence["tracking_issue_refs_total"], 6)
->>>>>>> 3f641fd33d (test(goal-loop): close startup policy checklist rows)
         self.assertEqual(checklist_evidence["missing_tracking_issue_refs"], [])
         self.assertEqual(checklist_evidence["invalid_tracking_issue_refs"], [])
         self.assertEqual(
@@ -1114,22 +1108,10 @@ class GoalLoopCompletionAuditTest(unittest.TestCase):
         )
         self.assertEqual(checklist_evidence["implementation_pr_refs_total"], 11)
         self.assertEqual(checklist_evidence["invalid_implementation_pr_refs"], [])
-<<<<<<< HEAD
-        self.assertEqual(checklist_evidence["artifact_refs_total"], 96)
-        self.assertEqual(checklist_evidence["artifact_refs_resolved"], 96)
-        self.assertEqual(checklist_evidence["artifact_ref_anchors_total"], 32)
-        self.assertEqual(checklist_evidence["artifact_ref_anchors_resolved"], 32)
-||||||| parent of 3f641fd33d (test(goal-loop): close startup policy checklist rows)
-        self.assertEqual(checklist_evidence["artifact_refs_total"], 88)
-        self.assertEqual(checklist_evidence["artifact_refs_resolved"], 88)
-        self.assertEqual(checklist_evidence["artifact_ref_anchors_total"], 22)
-        self.assertEqual(checklist_evidence["artifact_ref_anchors_resolved"], 22)
-=======
         self.assertEqual(checklist_evidence["artifact_refs_total"], 102)
         self.assertEqual(checklist_evidence["artifact_refs_resolved"], 102)
         self.assertEqual(checklist_evidence["artifact_ref_anchors_total"], 36)
         self.assertEqual(checklist_evidence["artifact_ref_anchors_resolved"], 36)
->>>>>>> 3f641fd33d (test(goal-loop): close startup policy checklist rows)
         self.assertTrue(checklist_evidence["artifact_refs_all_resolved"])
         self.assertEqual(checklist_evidence["missing_artifact_refs"], [])
         self.assertEqual(checklist_evidence["missing_artifact_ref_anchors"], [])
@@ -1389,16 +1371,8 @@ class GoalLoopCompletionAuditTest(unittest.TestCase):
         checklist_evidence = by_id["prompt_to_artifact_checklist_recorded"].evidence
         self.assertFalse(checklist_evidence["recorded"])
         self.assertFalse(checklist_evidence["artifact_refs_all_resolved"])
-<<<<<<< HEAD
-        self.assertEqual(checklist_evidence["artifact_refs_total"], 93)
-        self.assertEqual(checklist_evidence["artifact_refs_resolved"], 92)
-||||||| parent of 3f641fd33d (test(goal-loop): close startup policy checklist rows)
-        self.assertEqual(checklist_evidence["artifact_refs_total"], 85)
-        self.assertEqual(checklist_evidence["artifact_refs_resolved"], 84)
-=======
         self.assertEqual(checklist_evidence["artifact_refs_total"], 99)
         self.assertEqual(checklist_evidence["artifact_refs_resolved"], 98)
->>>>>>> 3f641fd33d (test(goal-loop): close startup policy checklist rows)
         self.assertEqual(
             checklist_evidence["missing_artifact_refs"],
             [
@@ -1432,22 +1406,10 @@ class GoalLoopCompletionAuditTest(unittest.TestCase):
         checklist_evidence = by_id["prompt_to_artifact_checklist_recorded"].evidence
         self.assertFalse(checklist_evidence["recorded"])
         self.assertFalse(checklist_evidence["artifact_refs_all_resolved"])
-<<<<<<< HEAD
-        self.assertEqual(checklist_evidence["artifact_refs_total"], 92)
-        self.assertEqual(checklist_evidence["artifact_refs_resolved"], 91)
-        self.assertEqual(checklist_evidence["artifact_ref_anchors_total"], 30)
-        self.assertEqual(checklist_evidence["artifact_ref_anchors_resolved"], 29)
-||||||| parent of 3f641fd33d (test(goal-loop): close startup policy checklist rows)
-        self.assertEqual(checklist_evidence["artifact_refs_total"], 84)
-        self.assertEqual(checklist_evidence["artifact_refs_resolved"], 83)
-        self.assertEqual(checklist_evidence["artifact_ref_anchors_total"], 20)
-        self.assertEqual(checklist_evidence["artifact_ref_anchors_resolved"], 19)
-=======
         self.assertEqual(checklist_evidence["artifact_refs_total"], 98)
         self.assertEqual(checklist_evidence["artifact_refs_resolved"], 97)
         self.assertEqual(checklist_evidence["artifact_ref_anchors_total"], 34)
         self.assertEqual(checklist_evidence["artifact_ref_anchors_resolved"], 33)
->>>>>>> 3f641fd33d (test(goal-loop): close startup policy checklist rows)
         self.assertEqual(
             checklist_evidence["missing_artifact_ref_anchors"],
             [
@@ -1496,16 +1458,8 @@ class GoalLoopCompletionAuditTest(unittest.TestCase):
         checklist_evidence = by_id["prompt_to_artifact_checklist_recorded"].evidence
         self.assertFalse(checklist_evidence["recorded"])
         self.assertFalse(checklist_evidence["artifact_refs_all_resolved"])
-<<<<<<< HEAD
-        self.assertEqual(checklist_evidence["artifact_ref_anchors_total"], 30)
-        self.assertEqual(checklist_evidence["artifact_ref_anchors_resolved"], 29)
-||||||| parent of 3f641fd33d (test(goal-loop): close startup policy checklist rows)
-        self.assertEqual(checklist_evidence["artifact_ref_anchors_total"], 20)
-        self.assertEqual(checklist_evidence["artifact_ref_anchors_resolved"], 19)
-=======
         self.assertEqual(checklist_evidence["artifact_ref_anchors_total"], 34)
         self.assertEqual(checklist_evidence["artifact_ref_anchors_resolved"], 33)
->>>>>>> 3f641fd33d (test(goal-loop): close startup policy checklist rows)
         self.assertEqual(
             checklist_evidence["artifact_ref_read_errors"],
             [


### PR DESCRIPTION
## Summary
Emergency hotfix for conflict markers committed to `main` via PR #14419.

## Files
- `lib/cascade/cascade_capability_profile.mli`: resolved string-based profile API + RFC-0058 Phase 1 additions
- `test/test_goal_loop_completion_audit.py`: adopted merged branch test counts

## Verification
- `grep` confirms zero conflict markers remain in both files.