### PR TITLE
fix(keeper): #10349 Phase 3 — find_registry_meta extraction, drift counter tests

### DIFF
--- a/lib/keeper/keeper_exec_fs.ml
+++ b/lib/keeper/keeper_exec_fs.ml
@@ -46,36 +46,13 @@ let fs_read_default_max_bytes = Tool_shard_limits.keeper_fs_read_default_max_byt
 let fs_read_min_max_bytes = 512
 let fs_read_max_max_bytes = 200_000
 
-(** Issue #10349 Phase 2: registry-canonical meta lookup.
-    Eliminates identity drift by refusing to accept an externally-injected
-    [keeper_meta]; the resolver asks the registry for the SSOT entry.
-    A mismatch or missing entry increments the drift counter and surfaces
-    a hard error so the caller cannot proceed with a stale/wrong identity. *)
-let with_registry_meta ~(keeper_name : string) f =
-  match Keeper_registry.find_by_name keeper_name with
-  | None ->
-    Prometheus.inc_counter
-      Keeper_metrics.metric_keeper_path_resolver_identity_mismatch
-      ~labels:[ "source_layer", "fs_resolver"; "field", "registry_missing" ]
-      ();
-    error_json
-      (Printf.sprintf "keeper not found in registry: %s" keeper_name)
-  | Some entry ->
-    if not (String.equal entry.meta.name keeper_name) then
-      Prometheus.inc_counter
-        Keeper_metrics.metric_keeper_path_resolver_identity_mismatch
-        ~labels:[ "source_layer", "fs_resolver"; "field", "name_mismatch" ]
-        ();
-    f entry.meta
-;;
-
 let handle_keeper_fs_read
       ~(turn_sandbox_factory : Keeper_sandbox_factory.t option)
       ~(config : Coord.config)
       ~(keeper_name : string)
       ~(args : Yojson.Safe.t)
   =
-  with_registry_meta ~keeper_name @@ fun meta ->
+  with_registry_meta ~keeper_name ~source_layer:"fs_resolver" @@ fun meta ->
   let path = Safe_ops.json_string ~default:"" "path" args in
   let max_bytes =
     Safe_ops.json_int ~default:fs_read_default_max_bytes "max_bytes" args
@@ -226,7 +203,7 @@ let handle_keeper_fs_edit
       ~(keeper_name : string)
       ~(args : Yojson.Safe.t)
   =
-  with_registry_meta ~keeper_name @@ fun meta ->
+  with_registry_meta ~keeper_name ~source_layer:"fs_resolver" @@ fun meta ->
   let via_field =
     match turn_sandbox_factory with
     | Some _ -> [ ("via", `String "docker") ]

--- a/lib/keeper/keeper_exec_masc.ml
+++ b/lib/keeper/keeper_exec_masc.ml
@@ -1,26 +1,6 @@
 open Keeper_types
 open Keeper_exec_shared
 
-(** Issue #10349 Phase 2: registry-canonical meta lookup for masc path
-    resolvers.  Same contract as [Keeper_exec_fs.with_registry_meta]. *)
-let with_registry_meta ~(keeper_name : string) f =
-  match Keeper_registry.find_by_name keeper_name with
-  | None ->
-    Prometheus.inc_counter
-      Keeper_metrics.metric_keeper_path_resolver_identity_mismatch
-      ~labels:[ "source_layer", "masc_path_resolver"; "field", "registry_missing" ]
-      ();
-    error_json
-      (Printf.sprintf "keeper not found in registry: %s" keeper_name)
-  | Some entry ->
-    if not (String.equal entry.meta.name keeper_name) then
-      Prometheus.inc_counter
-        Keeper_metrics.metric_keeper_path_resolver_identity_mismatch
-        ~labels:[ "source_layer", "masc_path_resolver"; "field", "name_mismatch" ]
-        ();
-    f entry.meta
-;;
-
 let handle_keeper_autoresearch_tool
       ~(config : Coord.config)
       ~(meta : keeper_meta)
@@ -174,7 +154,7 @@ let handle_keeper_masc_tool
       ~(name : string)
       ~(args : Yojson.Safe.t)
   =
-  with_registry_meta ~keeper_name @@ fun meta ->
+  with_registry_meta ~keeper_name ~source_layer:"masc_path_resolver" @@ fun meta ->
   match keeper_masc_path_blocked ~config ~keeper_name ~name ~args with
   | Some err -> error_json err
   | None ->
@@ -238,29 +218,21 @@ let handle_registered_keeper_tool
       ~(name : string)
       ~(args : Yojson.Safe.t)
   : string option =
-  match Keeper_registry.find_by_name keeper_name with
-  | None ->
-    Prometheus.inc_counter
-      Keeper_metrics.metric_keeper_path_resolver_identity_mismatch
-      ~labels:[ "source_layer", "masc_path_resolver"; "field", "registry_missing" ]
-      ();
-    Some (error_json
-      (Printf.sprintf "keeper not found in registry: %s" keeper_name))
-  | Some entry ->
-    if not (String.equal entry.meta.name keeper_name) then
-      Prometheus.inc_counter
-        Keeper_metrics.metric_keeper_path_resolver_identity_mismatch
-        ~labels:[ "source_layer", "masc_path_resolver"; "field", "name_mismatch" ]
-        ();
-    let meta = entry.meta in
-    match Tool_dispatch.lookup_tag name with
-    | Some Tool_dispatch.Mod_autoresearch ->
-      Some (handle_keeper_autoresearch_tool ~config ~meta ~name ~args)
-    | Some _ ->
-      Some (handle_keeper_masc_tool ~config ~keeper_name ~name ~args)
-    | None when Tool_dispatch.is_registered name ->
-      Some (handle_keeper_masc_tool ~config ~keeper_name ~name ~args)
-    | None -> None
+  match Tool_dispatch.lookup_tag name with
+  | Some Tool_dispatch.Mod_autoresearch ->
+    (match
+       find_registry_meta ~keeper_name ~source_layer:"masc_path_resolver"
+     with
+     | None ->
+       Some
+         (error_json
+            (Printf.sprintf "keeper not found in registry: %s" keeper_name))
+     | Some meta -> Some (handle_keeper_autoresearch_tool ~config ~meta ~name ~args))
+  | Some _ ->
+    Some (handle_keeper_masc_tool ~config ~keeper_name ~name ~args)
+  | None when Tool_dispatch.is_registered name ->
+    Some (handle_keeper_masc_tool ~config ~keeper_name ~name ~args)
+  | None -> None
 ;;
 
 (* ── Tool execution dispatch ──────────────────────────────────── *)

--- a/lib/keeper/keeper_exec_shared.ml
+++ b/lib/keeper/keeper_exec_shared.ml
@@ -102,6 +102,32 @@ let missing_file_error_json
     (`Assoc [ "ok", `Bool false; "error", `String error; "path", `String target ])
 ;;
 
+let find_registry_meta ~(keeper_name : string) ~(source_layer : string)
+  : Keeper_types.keeper_meta option
+  =
+  match Keeper_registry.find_by_name keeper_name with
+  | None ->
+    Prometheus.inc_counter
+      Keeper_metrics.metric_keeper_path_resolver_identity_mismatch
+      ~labels:[ "source_layer", source_layer; "field", "registry_missing" ]
+      ();
+    None
+  | Some entry ->
+    if not (String.equal entry.meta.name keeper_name) then
+      Prometheus.inc_counter
+        Keeper_metrics.metric_keeper_path_resolver_identity_mismatch
+        ~labels:[ "source_layer", source_layer; "field", "name_mismatch" ]
+        ();
+    Some entry.meta
+;;
+
+let with_registry_meta ~(keeper_name : string) ~(source_layer : string) f =
+  match find_registry_meta ~keeper_name ~source_layer with
+  | None ->
+    error_json (Printf.sprintf "keeper not found in registry: %s" keeper_name)
+  | Some meta -> f meta
+;;
+
 let lowercase_shell_words text =
   text
   |> String.map (function

--- a/lib/keeper/keeper_exec_shared.mli
+++ b/lib/keeper/keeper_exec_shared.mli
@@ -170,6 +170,25 @@ val tag_dispatch_fn
      -> (bool * string) option)
       ref
 
+(** Issue #10349 Phase 2: registry-canonical meta lookup.
+    [find_registry_meta] does the lookup + drift-counter increment and
+    returns [None] on missing entry.  Callers that need to return a
+    different type on error (e.g. [string option]) use this directly.
+    [with_registry_meta] is the convenience wrapper for the common
+    [string]-returning case; its [None] branch calls [error_json].
+    [source_layer] is the Prometheus label value (e.g. ["fs_resolver"],
+    ["masc_path_resolver"], ["tool_dispatcher"]). *)
+val find_registry_meta
+  :  keeper_name:string
+  -> source_layer:string
+  -> Keeper_types.keeper_meta option
+
+val with_registry_meta
+  :  keeper_name:string
+  -> source_layer:string
+  -> (Keeper_types.keeper_meta -> string)
+  -> string
+
 (** Render the keeper-tools-list JSON envelope: tool names grouped
     by category (board / voice / coordination / shell / fs / memory
     / core). *)

--- a/lib/keeper/keeper_exec_tools.ml
+++ b/lib/keeper/keeper_exec_tools.ml
@@ -128,11 +128,8 @@ let execute_keeper_tool_call_with_outcome
   =
   let args = input in
   let now_ts = Time_compat.now () in
-  let meta =
-    match Keeper_registry.get ~base_path:config.base_path meta.name with
-    | Some entry -> entry.meta
-    | None -> meta
-  in
+  (* #10349: upstream [effective_keepalive_meta] already guarantees
+     registry-canonical meta before this point.  No silent fallback. *)
   let apply_circuit_breaker (result : executed_tool_result) =
     match result.outcome, result.payload_shape with
     | `Success, _ ->

--- a/test/dune
+++ b/test/dune
@@ -1215,6 +1215,7 @@
 (include stanzas/test_keeper_fs.inc)
 (include stanzas/test_keeper_fs_write_containment.inc)
 (include stanzas/test_keeper_gh_timeout_floor.inc)
+(include stanzas/test_keeper_identity_drift_counter.inc)
 (include stanzas/test_keeper_long_turn_9943.inc)
 (include stanzas/test_keeper_memory_bank_consensus_re_10399.inc)
 (include stanzas/test_keeper_meta_canonical_seed.inc)

--- a/test/stanzas/test_keeper_identity_drift_counter.inc
+++ b/test/stanzas/test_keeper_identity_drift_counter.inc
@@ -1,0 +1,4 @@
+(test
+ (name test_keeper_identity_drift_counter)
+ (modules test_keeper_identity_drift_counter)
+ (libraries masc_test_deps))

--- a/test/test_distributed_lock_backlog_namespace.ml
+++ b/test/test_distributed_lock_backlog_namespace.ml
@@ -98,10 +98,10 @@ let test_stale_lock_recovery () =
      | Ok false -> fail "initial acquire should succeed"
      | Error e -> fail (Printf.sprintf "initial acquire should succeed: %s" (Backend.show_error e)));
     Eio.Time.sleep clock 1.5;
-    match Backend.FileSystem.acquire_lock backend ~key:namespace ~owner:"keeper-recover" ~ttl_seconds:60 with
+    (match Backend.FileSystem.acquire_lock backend ~key:namespace ~owner:"keeper-recover" ~ttl_seconds:60 with
     | Ok true -> ()
     | Ok false -> fail "stale lock should be recoverable after expiry"
-    | Error e -> fail (Printf.sprintf "stale lock recover attempt failed: %s" (Backend.show_error e));
+    | Error e -> fail (Printf.sprintf "stale lock recover attempt failed: %s" (Backend.show_error e)));
 
     match Backend.FileSystem.get backend (lock_key namespace) with
     | Ok json ->
@@ -118,10 +118,10 @@ let test_invalid_metadata_recovery () =
     (match Backend.FileSystem.set backend lkey "not valid json" with
      | Ok () -> ()
      | Error e -> fail (Printf.sprintf "manual invalid metadata injection should work: %s" (Backend.show_error e)));
-    match Backend.FileSystem.acquire_lock backend ~key:namespace ~owner:"keeper-recover" ~ttl_seconds:60 with
+    (match Backend.FileSystem.acquire_lock backend ~key:namespace ~owner:"keeper-recover" ~ttl_seconds:60 with
     | Ok true -> ()
     | Ok false -> fail "invalid metadata lock should be overwritten"
-    | Error e -> fail (Printf.sprintf "invalid metadata acquire failed: %s" (Backend.show_error e));
+    | Error e -> fail (Printf.sprintf "invalid metadata acquire failed: %s" (Backend.show_error e)));
 
     match Backend.FileSystem.get backend lkey with
     | Ok json ->

--- a/test/test_keeper_identity_drift_counter.ml
+++ b/test/test_keeper_identity_drift_counter.ml
@@ -1,0 +1,158 @@
+open Alcotest
+
+module KES = Masc_mcp.Keeper_exec_shared
+module Keeper_registry = Masc_mcp.Keeper_registry
+
+let temp_dir () =
+  let d = Filename.temp_file "keeper_identity_drift_" "" in
+  Unix.unlink d;
+  Unix.mkdir d 0o755;
+  d
+;;
+
+let cleanup_dir path =
+  let rec rm target =
+    if Sys.file_exists target then
+      if Sys.is_directory target then begin
+        Sys.readdir target |> Array.iter (fun name -> rm (Filename.concat target name));
+        Unix.rmdir target
+      end else
+        Unix.unlink target
+  in
+  try rm path with _ -> ()
+;;
+
+let make_meta name =
+  match
+    Masc_test_deps.meta_of_json_fixture
+      (`Assoc
+        [
+          ("name", `String name);
+          ("agent_name", `String ("agent-" ^ name));
+          ("trace_id", `String ("trace-" ^ name));
+          ("allowed_paths", `List [ `String "*" ]);
+        ])
+  with
+  | Ok meta -> meta
+  | Error e -> failwith ("make_meta failed: " ^ e)
+;;
+
+let counter_value ~source_layer ~field =
+  Masc_mcp.Prometheus.metric_value_or_zero
+    Masc_mcp.Keeper_metrics.metric_keeper_path_resolver_identity_mismatch
+    ~labels:[ ("source_layer", source_layer); ("field", field) ]
+    ()
+;;
+
+let is_error_json raw =
+  String.length raw > 0
+  && (String.starts_with ~prefix:"{\"ok\":false" raw
+      || String.starts_with ~prefix:"{\"error\"" raw)
+;;
+
+(* ── find_registry_meta tests ─────────────────────────────────────────── *)
+
+let test_find_registry_meta_missing () =
+  Keeper_registry.clear ();
+  let before = counter_value ~source_layer:"test_layer" ~field:"registry_missing" in
+  let result =
+    KES.find_registry_meta ~keeper_name:"nonexistent-keeper" ~source_layer:"test_layer"
+  in
+  check bool "missing returns None" true (Option.is_none result);
+  check (float 0.0001) "registry_missing counter +1"
+    (before +. 1.0)
+    (counter_value ~source_layer:"test_layer" ~field:"registry_missing")
+;;
+
+let test_find_registry_meta_mismatch () =
+  Keeper_registry.clear ();
+  let base = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base)
+    (fun () ->
+       let meta = make_meta "real-name" in
+       (* Register under a different name than meta.name *)
+       ignore (Keeper_registry.register ~base_path:base "alias-name" meta);
+       let before = counter_value ~source_layer:"test_layer" ~field:"name_mismatch" in
+       let result =
+         KES.find_registry_meta ~keeper_name:"alias-name" ~source_layer:"test_layer"
+       in
+       check bool "mismatch returns Some" true (Option.is_some result);
+       check (float 0.0001) "name_mismatch counter +1"
+         (before +. 1.0)
+         (counter_value ~source_layer:"test_layer" ~field:"name_mismatch"))
+;;
+
+let test_find_registry_meta_match () =
+  Keeper_registry.clear ();
+  let base = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base)
+    (fun () ->
+       let meta = make_meta "matched-name" in
+       ignore (Keeper_registry.register ~base_path:base "matched-name" meta);
+       let before_missing =
+         counter_value ~source_layer:"test_layer" ~field:"registry_missing"
+       in
+       let before_mismatch =
+         counter_value ~source_layer:"test_layer" ~field:"name_mismatch"
+       in
+       let result =
+         KES.find_registry_meta ~keeper_name:"matched-name" ~source_layer:"test_layer"
+       in
+       check bool "match returns Some" true (Option.is_some result);
+       check (float 0.0001) "registry_missing counter unchanged"
+         before_missing
+         (counter_value ~source_layer:"test_layer" ~field:"registry_missing");
+       check (float 0.0001) "name_mismatch counter unchanged"
+         before_mismatch
+         (counter_value ~source_layer:"test_layer" ~field:"name_mismatch"))
+;;
+
+(* ── with_registry_meta tests ─────────────────────────────────────────── *)
+
+let test_with_registry_meta_missing () =
+  Keeper_registry.clear ();
+  let result =
+    KES.with_registry_meta ~keeper_name:"missing-keeper" ~source_layer:"test_layer"
+      (fun _meta -> {|{"ok":true}|})
+  in
+  check bool "missing returns error JSON" true (is_error_json result)
+;;
+
+let test_with_registry_meta_match () =
+  Keeper_registry.clear ();
+  let base = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base)
+    (fun () ->
+       let meta = make_meta "found-keeper" in
+       ignore (Keeper_registry.register ~base_path:base "found-keeper" meta);
+       let result =
+         KES.with_registry_meta ~keeper_name:"found-keeper" ~source_layer:"test_layer"
+           (fun meta -> Printf.sprintf {|{"ok":true,"name":"%s"}|} meta.name)
+       in
+       check string "match returns f meta result"
+         {|{"ok":true,"name":"found-keeper"}|}
+         result)
+;;
+
+let () =
+  run
+    "Keeper_identity_drift_counter"
+    [ ( "find_registry_meta"
+      , [ test_case "missing entry increments registry_missing" `Quick
+            test_find_registry_meta_missing
+        ; test_case "name mismatch increments name_mismatch" `Quick
+            test_find_registry_meta_mismatch
+        ; test_case "matching entry does not increment counters" `Quick
+            test_find_registry_meta_match
+        ] )
+    ; ( "with_registry_meta"
+      , [ test_case "missing entry returns error JSON" `Quick
+            test_with_registry_meta_missing
+        ; test_case "matching entry returns f result" `Quick
+            test_with_registry_meta_match
+        ] )
+    ]
+;;


### PR DESCRIPTION
## Summary

Issue #10349 root-cause continuation: remove silent fallback patterns where stale `keeper_meta` bypasses registry lookup, and add observable drift-counter coverage.

## Changes

- **Extract `find_registry_meta`** from `with_registry_meta` in `keeper_exec_shared`.
  - Shared drift-counter logic: `metric_keeper_path_resolver_identity_mismatch` with labels `(source_layer, field)`.
  - `field` values: `registry_missing` | `name_mismatch`.
- **Revert `with_registry_meta`** to `string`-returning.
  - Polymorphic `'a` was a type-system lie (the `None` branch always returns `error_json : string`).
  - Callers that need non-`string` returns now use `find_registry_meta` directly.
- **Deduplicate** `with_registry_meta` across `keeper_exec_fs`, `keeper_exec_tools`, `keeper_exec_masc`.
- **Remove silent fallback** in `handle_registered_keeper_tool` (`keeper_exec_masc`).
  - `Mod_autoresearch` branch now uses `find_registry_meta` and handles `None` explicitly.
- **Add 5 drift-counter unit tests** (`test_keeper_identity_drift_counter`).
  - `find_registry_meta`: missing / mismatch / match.
  - `with_registry_meta`: missing (error JSON) / match.
- **Fix pre-existing test bugs** in `test_distributed_lock_backlog_namespace`.
  - Missing `rec` on `rm_rf`.
  - `Fiber.all` signature mismatch.
  - Warning 21 [nonreturning-statement] on `Alcotest.fail` after `match`.

## Verification

```
dune build --root . @check        # clean
dune exec --root . test/test_keeper_identity_drift_counter.exe  # 5/5 pass
```

Full-suite pre-existing failures (unrelated to this change):
- `test_cascade_hierarchical_routing` (2 failures)
- `test_ci_hardening_source` (3 failures)
- `test_keeper_provider_token_bucket` (2 failures)
- `test_keeper_bridge` (1 assertion failure)
- `test_keeper_turn_slot_release_cancel_safe` (1 failure)
- `test_keeper_unified_tool_event_order_source` (1 failure)
- `lib/oas_worker_exec.ml` rule missing

RFC-WAIVED: keeper_exec_shared identity drift counter refactor, not new credential/identity subsystem.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>