### PR TITLE
fix(auth): register sidecar tool in Tool_catalog explicit metadata

### DIFF
--- a/lib/tool_catalog.ml
+++ b/lib/tool_catalog.ml
@@ -311,6 +311,13 @@ let explicit_metadata : (string * metadata) list =
        signaling endpoints in server_h2_gateway.ml — kept for now. *)
     ("masc_webrtc_offer", deprecated "Pruned from all surfaces in #4999");
     ("masc_webrtc_answer", deprecated "Pruned from all surfaces in #4999");
+    ( "sidecar",
+      {
+        destructive_tool with
+        visibility = Hidden;
+        required_permission = Some Masc_domain.CanBroadcast;
+        effect_domain = Some Masc_coordination;
+      } );
   ]
 
 (* ================================================================ *)


### PR DESCRIPTION
## Summary

Registers the `sidecar` tool in `Tool_catalog.explicit_metadata` so that `POST /api/v1/sidecar/start` and related endpoints resolve authorization through the canonical catalog path instead of requiring a legacy fallback.

## Background

PR #14425 added a legacy `tool_permission_map` entry as a stop-gap. This change moves the registration to the canonical location (`Tool_catalog.explicit_metadata`) where all tool metadata lives.

## Changes

- `lib/tool_catalog.ml`: add `sidecar` to `explicit_metadata` with:
  - `visibility = Hidden` (not an MCP surface tool)
  - `required_permission = Some CanBroadcast`
  - `effect_domain = Some Masc_coordination`

## Verification

- `dune build --root . lib/tool_catalog.ml` compiles
- `permission_for_tool "sidecar"` now resolves via `declared_permission_for_tool` → `Tool_catalog.registered_metadata`

## Related

- Follow-up to PR #14425 (legacy fallback)
- Unblocks dashboard Connectors tab start/stop for Discord sidecar

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>