### PR TITLE
refactor(dashboard): remove dead memory-subsystems section and duplicate DecisionsStream

### DIFF
--- a/dashboard/src/components/memory-subsystems.ts
+++ b/dashboard/src/components/memory-subsystems.ts
@@ -8,15 +8,12 @@ import { MermaidGraph } from './common/mermaid-graph'
 import { Select } from './common/select'
 import {
   fetchMemorySubsystems,
-  fetchKeeperDecisions,
   type MemorySubsystemsResponse,
   type MemorySubsystemsSynapse,
   type MemorySubsystemsEpisode,
   type MemorySubsystemsMemoryEntry,
-  type KeeperDecision,
 } from '../api/dashboard'
 import { formatTimeAgo } from '../lib/format-time'
-import { isAbortError } from '../lib/async-state'
 import { useManagedAsyncResource } from '../lib/use-managed-async-resource'
 import { setupVisibleAutoRefresh } from '../lib/auto-refresh'
 import { openAgentDetail } from './agent-detail-state'
@@ -840,176 +837,10 @@ export function MemorySubsystems() {
         }
       </section>
 
-      <${DecisionsStream} />
       `}
 
       ${error ? html`<div class="text-xs text-[var(--color-status-warn)] mt-2">refresh error: ${error}</div>` : null}
     </div>
-  `
-}
-
-const DECISION_REFRESH_MS = 30_000
-
-function DecisionsStream() {
-  const state = useSignal<{
-    loading: boolean
-    error: string | null
-    data: KeeperDecision[] | null
-  }>({ loading: true, error: null, data: null })
-
-  const keeperFilter = useSignal<string>('')
-  const eventFilter = useSignal<string>('')
-  const outcomeFilter = useSignal<string>('')
-  const limit = useSignal<number>(50)
-
-  async function refresh(sig?: AbortSignal) {
-    try {
-      const resp = await fetchKeeperDecisions(limit.value, { signal: sig })
-      state.value = { loading: false, error: null, data: resp.events }
-    } catch (err) {
-      if (isAbortError(err)) return
-      state.value = {
-        loading: false,
-        error: err instanceof Error ? err.message : String(err),
-        data: state.value.data,
-      }
-    }
-  }
-
-  useEffect(() => {
-    const ac = new AbortController()
-    refresh(ac.signal)
-    const cleanup = setupVisibleAutoRefresh(() => refresh(), DECISION_REFRESH_MS)
-    return () => {
-      ac.abort()
-      cleanup()
-    }
-  }, [limit.value])
-
-  const { loading, error, data } = state.value
-  const events = data ?? []
-
-  const knownKeepers = Array.from(new Set(events.map(e => e.keeper_name))).sort()
-  const knownEvents = Array.from(new Set(events.map(e => e.event_type))).sort()
-  const knownOutcomes = Array.from(new Set(events.map(e => e.outcome).filter((o): o is string => o != null))).sort()
-
-  const visible = events.filter(ev => {
-    if (keeperFilter.value && ev.keeper_name !== keeperFilter.value) return false
-    if (eventFilter.value && ev.event_type !== eventFilter.value) return false
-    if (outcomeFilter.value && ev.outcome !== outcomeFilter.value) return false
-    return true
-  })
-
-  const hasFilter = Boolean(keeperFilter.value || eventFilter.value || outcomeFilter.value)
-
-  return html`
-    <section class="flex flex-col gap-3" aria-label="Keeper decisions stream">
-      <div class="flex flex-wrap items-center gap-2">
-        <h3 class="text-sm font-semibold text-text-strong">Decisions Stream</h3>
-        <span class="text-2xs text-text-muted">${visible.length} / ${events.length} events</span>
-        <div class="ml-auto flex items-center gap-2">
-          <${Select}
-            class="px-2 py-1 text-2xs"
-            ariaLabel="Keeper"
-            value=${keeperFilter.value}
-            options=${[
-              { value: '', label: 'all keepers' },
-              ...knownKeepers.map(k => ({ value: k, label: k })),
-            ]}
-            onInput=${(v: string) => { keeperFilter.value = v }}
-          />
-          <${Select}
-            class="px-2 py-1 text-2xs"
-            ariaLabel="Event"
-            value=${eventFilter.value}
-            options=${[
-              { value: '', label: 'all events' },
-              ...knownEvents.map(e => ({ value: e, label: e })),
-            ]}
-            onInput=${(v: string) => { eventFilter.value = v }}
-          />
-          <${Select}
-            class="px-2 py-1 text-2xs"
-            ariaLabel="Outcome"
-            value=${outcomeFilter.value}
-            options=${[
-              { value: '', label: 'all outcomes' },
-              ...knownOutcomes.map(o => ({ value: o, label: o })),
-            ]}
-            onInput=${(v: string) => { outcomeFilter.value = v }}
-          />
-          ${hasFilter
-            ? html`<button
-                class="text-2xs text-text-muted hover:text-text-strong px-2 py-1 border border-card-border/40 rounded-[var(--r-1)]"
-                onClick=${() => {
-                  keeperFilter.value = ''
-                  eventFilter.value = ''
-                  outcomeFilter.value = ''
-                }}
-              >clear</button>`
-            : null}
-        </div>
-      </div>
-
-      ${loading && !data
-        ? html`<${LoadingState} label="decisions 로드 중..." />`
-        : error && !data
-          ? html`<div class="text-sm text-[var(--color-status-err)]">decisions 오류: ${error}</div>`
-          : html`
-              <div class="overflow-x-auto rounded-[var(--r-1)] border border-card-border/60 bg-[var(--backdrop-deep)]">
-                <table class="w-full text-2xs" aria-label="decision events">
-                  <thead>
-                    <tr class="border-b border-[var(--color-border-default)] text-text-muted uppercase tracking-1">
-                      <th class="px-2 py-1.5 text-left">time</th>
-                      <th class="px-2 py-1.5 text-left">keeper</th>
-                      <th class="px-2 py-1.5 text-left">event</th>
-                      <th class="px-2 py-1.5 text-left">outcome</th>
-                      <th class="px-2 py-1.5 text-left">model</th>
-                      <th class="px-2 py-1.5 text-right">latency</th>
-                      <th class="px-2 py-1.5 text-right">cost</th>
-                      <th class="px-2 py-1.5 text-right">tokens</th>
-                      <th class="px-2 py-1.5 text-left">stop / error</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    ${visible.map((ev: KeeperDecision) => {
-                      const ts = ev.ts_unix ? formatTimeAgo(ev.ts_unix * 1000) : '—'
-                      const latency = ev.latency_ms != null ? `${Math.round(ev.latency_ms)}ms` : '—'
-                      const cost = ev.cost_usd != null ? `$${ev.cost_usd.toFixed(4)}` : '—'
-                      const tokens = ev.input_tokens != null || ev.output_tokens != null
-                        ? `${ev.input_tokens ?? 0} / ${ev.output_tokens ?? 0}`
-                        : '—'
-                      const stopErr = ev.error_category ?? ev.stop_reason ?? '—'
-                      const rowTone = ev.outcome === 'failure' || ev.error_category
-                        ? 'text-[var(--color-status-err)]'
-                        : ev.outcome === 'partial'
-                          ? 'text-[var(--color-status-warn)]'
-                          : ''
-                      return html`
-                        <tr key=${`${ev.keeper_name}-${ev.ts_unix ?? 0}-${ev.event_type}`}
-                          class="border-b border-[var(--color-border-default)]/40 align-baseline ${rowTone}">
-                          <td class="px-2 py-1.5 font-mono whitespace-nowrap">${ts}</td>
-                          <td class="px-2 py-1.5 font-mono text-[var(--color-accent-fg)]">${ev.keeper_name}</td>
-                          <td class="px-2 py-1.5">
-                            <span class="rounded-[var(--r-1)] px-1 py-0.5 bg-[var(--color-bg-hover)] text-text-muted">${ev.event_type}</span>
-                          </td>
-                          <td class="px-2 py-1.5">${ev.outcome ?? '—'}</td>
-                          <td class="px-2 py-1.5 font-mono text-text-muted">${ev.model_used ?? '—'}</td>
-                          <td class="px-2 py-1.5 text-right font-mono">${latency}</td>
-                          <td class="px-2 py-1.5 text-right font-mono">${cost}</td>
-                          <td class="px-2 py-1.5 text-right font-mono">${tokens}</td>
-                          <td class="px-2 py-1.5 font-mono text-text-muted">${stopErr}</td>
-                        </tr>
-                      `
-                    })}
-                  </tbody>
-                </table>
-                ${visible.length === 0
-                  ? html`<div class="p-4 text-center text-text-muted">필터에 맞는 결정이 없습니다.</div>`
-                  : null}
-              </div>
-            `}
-    </section>
   `
 }
 

--- a/dashboard/src/components/status.ts
+++ b/dashboard/src/components/status.ts
@@ -1,6 +1,6 @@
 // MASC Dashboard — Status Surface (Phase 2+4: fleet-health + runtime unified)
 // Read-only observability surfaces: journey, agents, runtime, fleet-health,
-// plus hidden diagnostic observatory/memory-subsystems routes.
+// plus hidden diagnostic observatory route.
 
 import { html } from 'htm/preact'
 import { lazy, Suspense } from 'preact/compat'
@@ -9,16 +9,13 @@ import { LoadingState } from './common/feedback-state'
 
 export type StatusSection =
   | 'observatory' | 'journey' | 'agents' | 'runtime' | 'goal-loop' | 'fleet-health'
-  | 'memory-subsystems' | 'cognition'
+  | 'cognition'
 
 const LazyAgentsUnified = lazy(async () => ({
   default: (await import('./agents-unified')).AgentsUnified,
 }))
 const LazyRuntimePanel = lazy(async () => ({
   default: (await import('./runtime-panel')).RuntimePanel,
-}))
-const LazyMemorySubsystems = lazy(async () => ({
-  default: (await import('./memory-subsystems')).MemorySubsystems,
 }))
 const LazyFleetHealthPanel = lazy(async () => ({
   default: (await import('./fleet-health-panel')).FleetHealthPanel,
@@ -52,8 +49,6 @@ export function sectionLabel(section: StatusSection): string {
       return 'GOAL LOOP'
     case 'fleet-health':
       return 'Fleet Health'
-    case 'memory-subsystems':
-      return 'Memory Subsystems'
     case 'cognition':
       return 'Cognition'
     case 'agents':
@@ -73,8 +68,6 @@ function renderSection(section: StatusSection) {
       return html`<${LazyGoalLoopPanel} />`
     case 'fleet-health':
       return html`<${LazyFleetHealthPanel} />`
-    case 'memory-subsystems':
-      return html`<${LazyMemorySubsystems} />`
     case 'cognition':
       return html`<${LazyCognitionPlane} />`
     case 'agents':
@@ -90,7 +83,6 @@ function currentSection(): StatusSection {
     || section === 'runtime'
     || section === 'goal-loop'
     || section === 'fleet-health'
-    || section === 'memory-subsystems'
     || section === 'cognition'
     || section === 'agents'
   ) return section

--- a/dashboard/src/config/navigation.ts
+++ b/dashboard/src/config/navigation.ts
@@ -20,7 +20,6 @@ type SurfaceSectionId =
   | 'runtime'
   | 'goal-loop'
   | 'fleet-health'   // Phase 1: absorbs telemetry + fleet + tool-quality + monitoring governance
-  | 'memory-subsystems'
   // command
   | 'operations'     // Phase 1+6: absorbs intervene + governance + inspector (Phase 7: connectors split out)
   // connectors (Phase 7: top-level surface — sidecar-driven channel bridges)
@@ -206,13 +205,6 @@ export const DASHBOARD_SECTION_ITEMS: Record<NonHomeTabId, DashboardSectionNavIt
       description: 'Event log, keeper comparison, tool quality, governance, and attribution signals.',
       params: { section: 'fleet-health' },
     },
-    {
-      id: 'memory-subsystems',
-      label: 'Memory Subsystems',
-      description: 'Hebbian graph, episodes, and compaction state.',
-      params: { section: 'memory-subsystems' },
-      hidden: true,
-    },
   ],
   command: [
     {
@@ -356,6 +348,9 @@ export const SECTION_REDIRECTS: Record<TabSectionKey, SectionRedirect> = {
   'command:governance':   { section: 'operations' },
   'command:connectors':   { section: 'operations', view: 'connectors' },
   'command:inspector':    { section: 'operations', view: 'inspector' },
+
+  // Cognition UX cleanup: memory-subsystems merged into cognition > memory tab
+  'monitoring:memory-subsystems': { section: 'cognition', params: { view: 'memory' } },
 
   // Dashboard consolidation Phase 1: workspace surface
   'workspace:goals': { section: 'planning' },


### PR DESCRIPTION
## Summary

- **Fix 1**: `monitoring:memory-subsystems` section이 `cognition > memory` tab으로 merge된 후에도 직접 URL 접근이 가능했음. `SECTION_REDIRECTS`에 redirect entry 추가 + `StatusSection` type과 nav item 제거.
- **Fix 3**: `MemorySubsystems` 컴포넌트 내부의 `DecisionsStream` 함수(~165줄)가 이미 `cognition > decisions` tab(`KeeperDecisionsStream`)으로 분리된 이후에도 남아있어 중복 표시 발생. 함수 본체 및 관련 import 제거.

## Changes

- `navigation.ts`: `'memory-subsystems'` from `SurfaceSectionId` type 제거, hidden nav item 제거, `SECTION_REDIRECTS` entry 추가
- `status.ts`: `StatusSection` union에서 `'memory-subsystems'` 제거, `LazyMemorySubsystems` lazy import 및 `sectionLabel`/`renderSection`/`currentSection` case 제거
- `memory-subsystems.ts`: `DecisionsStream()` 함수 본체, `DECISION_REFRESH_MS` 상수, `isAbortError` import 제거

## Test plan

- [ ] `?section=memory-subsystems` URL로 직접 접근 시 `?section=cognition&view=memory`로 redirect 되는지 확인
- [ ] `cognition > memory` tab 정상 렌더링
- [ ] `cognition > decisions` tab 정상 렌더링 (DecisionsStream 표시)
- [ ] `MemorySubsystems`에 decisions 테이블이 더 이상 표시되지 않는지 확인

RFC-WAIVED: Dashboard UX cleanup, no credential/identity/auth changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)