### PR TITLE
fix(cascade): repair syntax error in config loader

### DIFF
--- a/lib/cascade/cascade_config_loader.ml
+++ b/lib/cascade/cascade_config_loader.ml
@@ -502,6 +502,7 @@ let load_catalog ~config_path =
         |> List.filter (fun (name, builder) ->
                builder.has_schema_field
                && not (is_deprecated_logical_profile_name name))
+      in
       let invalid_profile_errors =
         List.filter_map
           (fun (name, builder) ->
@@ -516,8 +517,6 @@ let load_catalog ~config_path =
                       |> String.concat ", ")
                      (Cascade_capability_profile.declared_profile_names ()
                       |> String.concat ", "))
-            | _ -> None)
-          active_builders
             | _ -> None)
           active_builders
       in


### PR DESCRIPTION
## Summary

`lib/cascade/cascade_config_loader.ml`에 origin/main에 이미 존재하던 syntax error 2건을 수정합니다.

- `active_builders` 정의 뒤 누락된 `in` 추가
- `List.filter_map` 인자로 중복되어 있던 `| _ -> None) active_builders` 제거

## 검증

```bash
dune build --root . @check
```

✅ 빌드 통과

## 영향 범위

- `lib/cascade/cascade_config_loader.ml`만 수정
- 런타임 동작 변경 없음 (syntax error로 이미 컴파일 불가능했음)

🤖 Generated with [Claude Code](https://claude.com/claude-code)