### PR TITLE
refactor(dashboard): 5-item UX cleanup — nav, cognition overview, routing

### DIFF
--- a/dashboard/src/components/cognition-plane.ts
+++ b/dashboard/src/components/cognition-plane.ts
@@ -71,12 +71,8 @@ export function CognitionPlane() {
       ` : view === 'autoresearch' ? html`
         <${Autoresearch} />
       ` : html`
-        <div class="grid grid-cols-1 gap-4 xl:grid-cols-[minmax(0,0.9fr)_minmax(0,1.1fr)]">
-          <${KeeperTokenStats} />
-          <${Autoresearch} />
-        </div>
         <${AgentsUnified} />
-        <${MemorySubsystems} />
+        <${KeeperTokenStats} />
       `}
     </div>
   `

--- a/dashboard/src/components/dashboard-shell.ts
+++ b/dashboard/src/components/dashboard-shell.ts
@@ -476,7 +476,7 @@ export function SideRail({ collapsed, onToggle }: { collapsed?: boolean; onToggl
                   </div>
                 <//>
 
-                ${sections.length > 0 ? html`
+                ${sections.length > 1 ? html`
                   <div class="ml-2.5 flex flex-col gap-px border-l border-[var(--color-border-divider)] pl-2.5" role="list">
                     ${sections.map(item => {
                       const isSectionActive = isSurfaceActive && currentSection?.id === item.id

--- a/dashboard/src/components/status.ts
+++ b/dashboard/src/components/status.ts
@@ -6,6 +6,7 @@ import { html } from 'htm/preact'
 import { lazy, Suspense } from 'preact/compat'
 import { route } from '../router'
 import { LoadingState } from './common/feedback-state'
+import { JourneyPanel } from './journey-panel'
 
 export type StatusSection =
   | 'observatory' | 'journey' | 'agents' | 'runtime' | 'goal-loop' | 'fleet-health'
@@ -25,9 +26,6 @@ const LazyGoalLoopPanel = lazy(async () => ({
 }))
 const LazyObservatory = lazy(async () => ({
   default: (await import('./observatory/observatory')).Observatory,
-}))
-const LazyJourneyPanel = lazy(async () => ({
-  default: (await import('./journey-panel')).JourneyPanel,
 }))
 const LazyCognitionPlane = lazy(async () => ({
   default: (await import('./cognition-plane')).CognitionPlane,
@@ -61,7 +59,7 @@ function renderSection(section: StatusSection) {
     case 'observatory':
       return html`<${LazyObservatory} />`
     case 'journey':
-      return html`<${LazyJourneyPanel} />`
+      return html`<${JourneyPanel} />`
     case 'runtime':
       return html`<${LazyRuntimePanel} />`
     case 'goal-loop':

--- a/dashboard/src/config/navigation.ts
+++ b/dashboard/src/config/navigation.ts
@@ -173,6 +173,9 @@ export const DASHBOARD_SECTION_ITEMS: Record<NonHomeTabId, DashboardSectionNavIt
       label: 'Observatory',
       description: 'Live collaboration and investigative timelines remain drill-down surfaces.',
       params: { section: 'observatory' },
+      // RFC-MASC-006 Phase 2a: kept as a hidden diagnostic surface, not yet promoted to main nav.
+      // Reachable via legacy redirects (monitoring:activity, monitoring:live) and direct URL.
+      // Remove hidden:true when Phase 2b drill-down is complete.
       hidden: true,
     },
     {
@@ -403,6 +406,15 @@ export function normalizeRouteParams(tabId: TabId, params: Record<string, string
   delete next.surface
   delete next.operation
   delete next.run_id
+
+  // Sections that use the `view` sub-param for internal navigation.
+  // For all other sections, `view` is meaningless and must not leak in from prior navigation.
+  const SECTIONS_WITH_VIEW = new Set([
+    'fleet-health', 'runtime', 'agents', 'cognition', 'observatory',
+  ])
+  if (!next.section || !SECTIONS_WITH_VIEW.has(next.section)) {
+    delete next.view
+  }
 
   return next
 }


### PR DESCRIPTION
## Summary

- **#1 Observatory 주석** — `hidden: true` 이유를 RFC-MASC-006 Phase 2a 컨텍스트로 명시. Phase 2b 완료 시 제거 조건 기록.
- **#2 1-섹션 탭 숨김** — `command`, `connectors`, `code` surface는 섹션이 1개뿐이므로 sub-nav를 숨김. `sections.length > 1` 조건.
- **#3 Cognition overview 축소** — overview 탭에서 4개 동시 렌더링(KeeperTokenStats + Autoresearch + AgentsUnified + MemorySubsystems) → 2개(AgentsUnified + KeeperTokenStats). Autoresearch/Memory는 각자 전용 탭 보유.
- **#4 Journey eager load** — 기본 경로(`section=journey`)는 lazy 청크 대신 main bundle에 포함.
- **#5 view param 정리** — `normalizeRouteParams`에서 sub-view를 사용하지 않는 섹션으로 이동 시 stale `?view=` param 제거. 5개 섹션(fleet-health, runtime, agents, cognition, observatory)만 view 보존.

## Test plan

- [ ] `command`, `connectors`, `code` surface 진입 시 sub-nav 미표시 확인
- [ ] cognition > overview에 AgentsUnified + KeeperTokenStats만 표시
- [ ] cognition > decisions 진입 → journey 이동 후 URL에 `view` param 없는지 확인
- [ ] monitoring 첫 진입 시 journey 즉시 렌더링 (loading 없음)
- [ ] `?section=observatory` 직접 URL 접근 시 Observatory 렌더링 정상

RFC-WAIVED: Dashboard UX cleanup, no credential/identity/auth changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)