### PR TITLE
refactor(keeper): fold remaining inline registry lookups into find_registry_meta

### DIFF
--- a/lib/keeper/keeper_exec_masc.ml
+++ b/lib/keeper/keeper_exec_masc.ml
@@ -41,20 +41,10 @@ let keeper_masc_path_blocked
       ~(name : string)
       ~(args : Yojson.Safe.t)
   =
-  match Keeper_registry.find_by_name keeper_name with
+  match find_registry_meta ~keeper_name ~source_layer:"masc_path_resolver" with
   | None ->
-    Prometheus.inc_counter
-      Keeper_metrics.metric_keeper_path_resolver_identity_mismatch
-      ~labels:[ "source_layer", "masc_path_resolver"; "field", "registry_missing" ]
-      ();
     Some (error_json (Printf.sprintf "keeper not found in registry: %s" keeper_name))
-  | Some entry ->
-    if not (String.equal entry.meta.name keeper_name) then
-      Prometheus.inc_counter
-        Keeper_metrics.metric_keeper_path_resolver_identity_mismatch
-        ~labels:[ "source_layer", "masc_path_resolver"; "field", "name_mismatch" ]
-        ();
-    let meta = entry.meta in
+  | Some meta ->
     let is_read_only = Tool_dispatch.is_read_only name in
     let effective_paths =
       if is_read_only

--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -186,8 +186,11 @@ let process_directive ~agent_name directive =
       match Keeper_registry.find_by_agent_name agent_name with
       | Some e -> e.meta.paused
       | None ->
-        (match Keeper_registry.find_by_name agent_name with
-         | Some e -> e.meta.paused
+        (match Keeper_exec_shared.find_registry_meta
+                 ~keeper_name:agent_name
+                 ~source_layer:"keepalive"
+         with
+         | Some meta -> meta.paused
          | None -> false)
     in
     if entry_paused


### PR DESCRIPTION
## Summary

`find_registry_meta` 추출 (#14429) 이후에도 인라인으로 `Keeper_registry.find_by_name`을 호출하며 counter 로직을 복제하던 두 곳을 정리합니다.

## Changes

| 파일 | 변경 |
|------|------|
| `lib/keeper/keeper_exec_masc.ml` | `keeper_masc_path_blocked`의 인라인 registry 조회 + counter 증가 로직을 `find_registry_meta`로 교체 |
| `lib/keeper/keeper_keepalive.ml` | `entry_paused`의 `find_by_name` fallback을 `find_registry_meta`로 교체 |

## 검증

```bash
dune build --root . @check
```

✅ 빌드 통과

## 의도적으로 남겨둔 것

`with_keeper_entry_by_identity` (`keeper_keepalive.ml`)은 `registry_entry` 전체를 콜백 `f`에 전달해야 하므로 `find_registry_meta`(`keeper_meta option` 반환)의 추상화 범위 밖입니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)