### PR TITLE
feat(ide): critical wiring — region tracker hook + masc_ide_annotate tool + .masc-ide gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,9 @@ Thumbs.db
 # MASC runtime data (not part of source)
 .masc/
 
+
+# IDE annotation/region metadata (observational IDE overlay)
+.masc-ide/
 # Git worktrees (local only, never tracked)
 .worktrees/
 

--- a/lib/dune
+++ b/lib/dune
@@ -66,6 +66,7 @@
   keeper_exec_shared
    keeper_exec_board
    keeper_exec_fs
+   keeper_exec_ide
    keeper_shell_docker
    keeper_egress_audit
    keeper_mcp_provider_audit

--- a/lib/keeper/keeper_exec_fs.ml
+++ b/lib/keeper/keeper_exec_fs.ml
@@ -1,5 +1,6 @@
 open Keeper_types
 open Keeper_exec_shared
+open Ide_region_tracker
 
 (* Issue #8490: Variant SSOT for fs write mode. Adding a constructor
    forces compilation in [fs_write_mode_to_string] and
@@ -213,6 +214,37 @@ exception Fs_edit_error of string
 let raise_fs_edit_error ?fields message =
   raise (Fs_edit_error (error_json ?fields message))
 
+(** After a successful file write, record the code region in [.masc-ide/].
+    Fire-and-forget: errors are logged but never block the write path.
+    Uses [Ide_region_tracker.ingest_tool_call] which silently ignores
+    non-file-write tools. *)
+let track_write_region ~config ~keeper_name ~file_path ~content ~mode_raw ~old_string ~new_string () =
+  let base_dir = Keeper_alerting_path.project_root_of_config config in
+  let tool_name =
+    match fs_write_mode_of_string_opt mode_raw with
+    | Some Patch -> "edit_file"
+    | _ -> "write_file"
+  in
+  let arguments =
+    let fields = [("path", `String file_path); ("content", `String content)] in
+    match fs_write_mode_of_string_opt mode_raw with
+    | Some Patch ->
+      `Assoc (
+        fields
+        @ [("old_string", `String old_string); ("new_string", `String new_string)]
+      )
+    | _ -> `Assoc fields
+  in
+  let tool_call_json = `Assoc [
+    ("name", `String tool_name);
+    ("arguments", arguments);
+  ] in
+  (try Ide_region_tracker.ingest_tool_call
+     ~base_dir ~keeper_id:keeper_name ~turn:0 tool_call_json
+   with exn ->
+     Log.Keeper.warn "IDE region tracking failed for keeper=%s path=%s: %s"
+       keeper_name file_path (Printexc.to_string exn))
+
 let validate_write_target ~config ~meta ~target =
   match
     Keeper_sandbox_containment.check_write_target ~config ~meta ~target
@@ -305,6 +337,10 @@ let handle_keeper_fs_edit
                         replace_all=%b occurrences=%d bytes=%d"
                        meta.name target replace_all occurrences
                        (String.length updated);
+                     (* IDE: record code region after successful patch write *)
+                     track_write_region ~config ~keeper_name:meta.name
+                       ~file_path:target ~content:updated
+                       ~mode_raw:"patch" ~old_string ~new_string ();
                      Yojson.Safe.to_string
                        (`Assoc
                            ([ "ok", `Bool true
@@ -372,6 +408,10 @@ let handle_keeper_fs_edit
            Log.Keeper.info "WRITE_AUDIT: keeper=%s fs_edit path=%s mode=%s bytes=%d"
              meta.name target mode_label
              (String.length content);
+           (* IDE: record code region after successful overwrite/append write *)
+           track_write_region ~config ~keeper_name:meta.name
+             ~file_path:target ~content
+             ~mode_raw:(fs_write_mode_to_string mode) ~old_string:"" ~new_string:"" ();
            Yojson.Safe.to_string
              (`Assoc
                  ([ "ok", `Bool true

--- a/lib/keeper/keeper_exec_ide.ml
+++ b/lib/keeper/keeper_exec_ide.ml
@@ -1,0 +1,50 @@
+(** Keeper_exec_ide — MCP tool handler for masc_ide_annotate.
+
+    Allows keepers to leave line-bound annotations on code files,
+    stored in [.masc-ide/annotations.jsonl] and surfaced by the
+    observational IDE dashboard.
+
+    @since 0.6.0 — observational IDE Phase 1 *)
+
+open Keeper_types
+open Keeper_exec_shared
+open Ide_annotation_types
+
+let handle_keeper_ide_annotate
+      ~(config : Coord.config)
+      ~(keeper_name : string)
+      ~(args : Yojson.Safe.t)
+  : string
+  =
+  let base_dir = Keeper_alerting_path.project_root_of_config config in
+  let file_path = Safe_ops.json_string ~default:"" "file_path" args in
+  let line_start = Safe_ops.json_int ~default:1 "line_start" args in
+  let line_end = Safe_ops.json_int ~default:line_start "line_end" args in
+  let kind_str = Safe_ops.json_string ~default:"Comment" "kind" args in
+  let content = Safe_ops.json_string ~default:"" "content" args in
+  let goal_id = Safe_ops.json_string_opt "goal_id" args in
+  let task_id = Safe_ops.json_string_opt "task_id" args in
+  if String.trim file_path = "" then
+    error_json "file_path is required for ide_annotate"
+  else if line_start < 1 then
+    error_json "line_start must be >= 1"
+  else if line_end < line_start then
+    error_json "line_end must be >= line_start"
+  else if String.trim content = "" then
+    error_json "content is required for ide_annotate"
+  else
+    let kind = Ide_annotations.annotation_kind_of_string kind_str in
+    (match Ide_annotations.create ~base_dir ~keeper_id:keeper_name
+             ~file_path ~line_start ~line_end ~kind ~content
+             ?goal_id ?task_id ()
+     with
+     | Ok annotation ->
+       Yojson.Safe.to_string (`Assoc [
+         "ok", `Bool true;
+         "id", `String annotation.id;
+         "file_path", `String annotation.file_path;
+         "line_start", `Int annotation.line_start;
+         "line_end", `Int annotation.line_end;
+       ])
+     | Error msg ->
+       error_json msg)

--- a/lib/keeper/keeper_exec_ide.mli
+++ b/lib/keeper/keeper_exec_ide.mli
@@ -1,0 +1,12 @@
+(** Keeper_exec_ide — MCP tool handler for masc_ide_annotate.
+
+    @since 0.6.0 — observational IDE Phase 1 *)
+
+val handle_keeper_ide_annotate :
+  config:Coord.config ->
+  keeper_name:string ->
+  args:Yojson.Safe.t ->
+  string
+(** Handle [masc_ide_annotate] tool call. Creates a line-bound
+    annotation in the [.masc-ide/] store and returns the created
+    record's id and coordinates on success, or an error message. *)

--- a/lib/keeper/keeper_exec_tools.ml
+++ b/lib/keeper/keeper_exec_tools.ml
@@ -272,6 +272,12 @@ let execute_keeper_tool_call_with_outcome
               ~config
               ~keeper_name:meta.name
               ~args)
+       | "masc_ide_annotate" ->
+         make_executed_tool_result
+           (Keeper_exec_ide.handle_keeper_ide_annotate
+              ~config
+              ~keeper_name:meta.name
+              ~args)
        | "keeper_bash" ->
          make_executed_tool_result
            (Keeper_exec_shell.handle_keeper_bash

--- a/lib/keeper/keeper_metrics.mli
+++ b/lib/keeper/keeper_metrics.mli
@@ -383,3 +383,4 @@ val metric_keeper_post_turn_wirein_failures : string
 val metric_keeper_recurring_failures : string
 val metric_keeper_turn_cleanup_failures : string
 val metric_keeper_session_cleanup_failures : string
+val metric_keeper_path_resolver_identity_mismatch : string


### PR DESCRIPTION
## Summary

Critical wiring for observational IDE Phase 1 (per `ide2.md` gap analysis).

### Changes

1. **Wire `Ide_region_tracker` into keeper file-write pipeline** (`keeper_exec_fs.ml`)
   - After successful overwrite/append: `track_write_region()` constructs a `write_file` tool_call JSON and feeds it to `Ide_region_tracker.ingest_tool_call()` → `.masc-ide/regions.jsonl`
   - After successful patch edit: same hook with `edit_file` + `old_string`/`new_string` args
   - Fire-and-forget: errors logged via `Log.Keeper.warn` but never block the write path

2. **Add `masc_ide_annotate` MCP tool** (`keeper_exec_ide.ml` + `keeper_exec_ide.mli`)
   - New handler: `Keeper_exec_ide.handle_keeper_ide_annotate`
   - Creates annotations in `.masc-ide/annotations.jsonl` via `Ide_annotations.create`
   - Fields: `file_path`, `line_start`, `line_end`, `kind` (Comment/Decision/Question/Bookmark), `content`, `goal_id?`, `task_id?`
   - Dispatched from `keeper_exec_tools.ml` alongside `keeper_fs_edit`

3. **Add `.masc-ide/` to `.gitignore`** — IDE overlay metadata is runtime data, not source

4. **Add `keeper_metrics.mli` entry** for `PathResolverIdentityMismatch` (pre-existing implementation had no .mli exposure)

5. **Add `keeper_exec_ide` to `lib/dune` module list**

### Pre-existing issues (NOT from this PR)

- `ide_region_tracker.mli` has a labeled param mismatch with `.ml` (`diff_text` vs unlabeled)
- `ide_annotations.ml:119` has a type error (`fp : string` vs `string option`)
- `Http.Router.delete` is unbound (server_ide_http.ml uses an unavailable route method)
- Several test files reference old `~meta` label for `handle_keeper_fs_edit` (now `~keeper_name`)

These are from the merged PR #14422 and should be fixed in a follow-up.

### Test plan

- [ ] Build passes after pre-existing issues are fixed
- [ ] Keeper writes file → `.masc-ide/regions.jsonl` gets a region entry
- [ ] `masc_ide_annotate` tool call → `.masc-ide/annotations.jsonl` gets an annotation entry
- [ ] `.masc-ide/` is gitignored