### PR TITLE
RFC-0062: Typed agent_error_blocker_class

### DIFF
--- a/lib/cascade/cascade_config_loader.ml
+++ b/lib/cascade/cascade_config_loader.ml
@@ -502,6 +502,7 @@ let load_catalog ~config_path =
         |> List.filter (fun (name, builder) ->
                builder.has_schema_field
                && not (is_deprecated_logical_profile_name name))
+      in
       let invalid_profile_errors =
         List.filter_map
           (fun (name, builder) ->
@@ -516,8 +517,6 @@ let load_catalog ~config_path =
                       |> String.concat ", ")
                      (Cascade_capability_profile.declared_profile_names ()
                       |> String.concat ", "))
-            | _ -> None)
-          active_builders
             | _ -> None)
           active_builders
       in

--- a/lib/keeper/keeper_meta_contract.ml
+++ b/lib/keeper/keeper_meta_contract.ml
@@ -125,6 +125,15 @@ type blocker_class =
         batch window. This mirrors [Keeper_registry.Stale_fleet_batch] so
         keeper_meta and dashboard status can report the systemic blocker
         instead of collapsing it to a generic turn timeout. *)
+  | Sdk_max_turns_exceeded
+  | Sdk_token_budget_exceeded
+  | Sdk_cost_budget_exceeded
+  | Sdk_unrecognized_stop_reason
+  | Sdk_idle_detected
+  | Sdk_tool_retry_exhausted
+  | Sdk_guardrail_violation
+  | Sdk_tripwire_violation
+  | Sdk_exit_condition_met
 
 let blocker_class_to_string = function
   | Cascade_exhausted _ -> "cascade_exhausted"
@@ -142,6 +151,15 @@ let blocker_class_to_string = function
   | Fiber_unresolved -> "fiber_unresolved"
   | Stale_turn_timeout -> "stale_turn_timeout"
   | Stale_fleet_batch -> "stale_fleet_batch"
+  | Sdk_max_turns_exceeded -> "sdk_max_turns_exceeded"
+  | Sdk_token_budget_exceeded -> "sdk_token_budget_exceeded"
+  | Sdk_cost_budget_exceeded -> "sdk_cost_budget_exceeded"
+  | Sdk_unrecognized_stop_reason -> "sdk_unrecognized_stop_reason"
+  | Sdk_idle_detected -> "sdk_idle_detected"
+  | Sdk_tool_retry_exhausted -> "sdk_tool_retry_exhausted"
+  | Sdk_guardrail_violation -> "sdk_guardrail_violation"
+  | Sdk_tripwire_violation -> "sdk_tripwire_violation"
+  | Sdk_exit_condition_met -> "sdk_exit_condition_met"
 ;;
 
 let blocker_class_of_serialized_string = function
@@ -160,6 +178,15 @@ let blocker_class_of_serialized_string = function
   | "fiber_unresolved" -> Some Fiber_unresolved
   | "stale_turn_timeout" -> Some Stale_turn_timeout
   | "stale_fleet_batch" -> Some Stale_fleet_batch
+  | "sdk_max_turns_exceeded" -> Some Sdk_max_turns_exceeded
+  | "sdk_token_budget_exceeded" -> Some Sdk_token_budget_exceeded
+  | "sdk_cost_budget_exceeded" -> Some Sdk_cost_budget_exceeded
+  | "sdk_unrecognized_stop_reason" -> Some Sdk_unrecognized_stop_reason
+  | "sdk_idle_detected" -> Some Sdk_idle_detected
+  | "sdk_tool_retry_exhausted" -> Some Sdk_tool_retry_exhausted
+  | "sdk_guardrail_violation" -> Some Sdk_guardrail_violation
+  | "sdk_tripwire_violation" -> Some Sdk_tripwire_violation
+  | "sdk_exit_condition_met" -> Some Sdk_exit_condition_met
   | _ -> None
 ;;
 

--- a/lib/keeper/keeper_meta_contract.mli
+++ b/lib/keeper/keeper_meta_contract.mli
@@ -149,6 +149,15 @@ type blocker_class =
   | Fiber_unresolved
   | Stale_turn_timeout
   | Stale_fleet_batch
+  | Sdk_max_turns_exceeded
+  | Sdk_token_budget_exceeded
+  | Sdk_cost_budget_exceeded
+  | Sdk_unrecognized_stop_reason
+  | Sdk_idle_detected
+  | Sdk_tool_retry_exhausted
+  | Sdk_guardrail_violation
+  | Sdk_tripwire_violation
+  | Sdk_exit_condition_met
 
 val blocker_class_to_string : blocker_class -> string
 (** Canonical lowercase labels.  Pinned literals — operator

--- a/lib/keeper/keeper_status_bridge.ml
+++ b/lib/keeper/keeper_status_bridge.ml
@@ -233,18 +233,24 @@ let blocker_class_of_sdk_error (err : Agent_sdk.Error.sdk_error) : blocker_class
              enum target.  Direct typed match preferred over text-substring
              fallback when the SDK gave us a structured error. *)
           Some Completion_contract_violation
-      (* Other agent_error variants do not carry a structured blocker_class.
-         If a new agent variant deserves its own blocker_class, the compiler
-         will force a decision here when it is added upstream. *)
-      | Agent_sdk.Error.Agent (MaxTurnsExceeded _)
-      | Agent_sdk.Error.Agent (TokenBudgetExceeded _)
-      | Agent_sdk.Error.Agent (CostBudgetExceeded _)
-      | Agent_sdk.Error.Agent (UnrecognizedStopReason _)
-      | Agent_sdk.Error.Agent (IdleDetected _)
-      | Agent_sdk.Error.Agent (ToolRetryExhausted _)
-      | Agent_sdk.Error.Agent (GuardrailViolation _)
-      | Agent_sdk.Error.Agent (TripwireViolation _)
-      | Agent_sdk.Error.Agent (ExitConditionMet _) -> None
+      | Agent_sdk.Error.Agent (MaxTurnsExceeded _) ->
+          Some Sdk_max_turns_exceeded
+      | Agent_sdk.Error.Agent (TokenBudgetExceeded _) ->
+          Some Sdk_token_budget_exceeded
+      | Agent_sdk.Error.Agent (CostBudgetExceeded _) ->
+          Some Sdk_cost_budget_exceeded
+      | Agent_sdk.Error.Agent (UnrecognizedStopReason _) ->
+          Some Sdk_unrecognized_stop_reason
+      | Agent_sdk.Error.Agent (IdleDetected _) ->
+          Some Sdk_idle_detected
+      | Agent_sdk.Error.Agent (ToolRetryExhausted _) ->
+          Some Sdk_tool_retry_exhausted
+      | Agent_sdk.Error.Agent (GuardrailViolation _) ->
+          Some Sdk_guardrail_violation
+      | Agent_sdk.Error.Agent (TripwireViolation _) ->
+          Some Sdk_tripwire_violation
+      | Agent_sdk.Error.Agent (ExitConditionMet _) ->
+          Some Sdk_exit_condition_met
       (* Provider-level [Api] errors are surfaced via OAS retry / cascade
          layers and do not map to a typed blocker_class by themselves. *)
       | Agent_sdk.Error.Api _
@@ -303,7 +309,16 @@ let runtime_blocker_surface_of_typed_class ?(summary = "") (cls : blocker_class)
     | Completion_contract_violation
     | Fiber_unresolved
     | Stale_turn_timeout
-    | Stale_fleet_batch -> if summary = "" then str else summary
+    | Stale_fleet_batch
+    | Sdk_max_turns_exceeded
+    | Sdk_token_budget_exceeded
+    | Sdk_cost_budget_exceeded
+    | Sdk_unrecognized_stop_reason
+    | Sdk_idle_detected
+    | Sdk_tool_retry_exhausted
+    | Sdk_guardrail_violation
+    | Sdk_tripwire_violation
+    | Sdk_exit_condition_met -> if summary = "" then str else summary
   in
   { blocker_class = str; summary; continue_gate }
 
@@ -326,7 +341,16 @@ let runtime_blocker_surface_of_legacy_string reason cls =
   | No_tool_capable_provider
   | Fiber_unresolved
   | Stale_turn_timeout
-  | Stale_fleet_batch ->
+  | Stale_fleet_batch
+  | Sdk_max_turns_exceeded
+  | Sdk_token_budget_exceeded
+  | Sdk_cost_budget_exceeded
+  | Sdk_unrecognized_stop_reason
+  | Sdk_idle_detected
+  | Sdk_tool_retry_exhausted
+  | Sdk_guardrail_violation
+  | Sdk_tripwire_violation
+  | Sdk_exit_condition_met ->
       runtime_blocker_surface_of_typed_class ~summary:reason cls
 
 let stale_kill_class_summary (kill_class : Keeper_registry.stale_kill_class) =

--- a/lib/keeper/keeper_types.mli
+++ b/lib/keeper/keeper_types.mli
@@ -177,6 +177,15 @@ type blocker_class = Keeper_meta_contract.blocker_class =
   | Fiber_unresolved
   | Stale_turn_timeout
   | Stale_fleet_batch
+  | Sdk_max_turns_exceeded
+  | Sdk_token_budget_exceeded
+  | Sdk_cost_budget_exceeded
+  | Sdk_unrecognized_stop_reason
+  | Sdk_idle_detected
+  | Sdk_tool_retry_exhausted
+  | Sdk_guardrail_violation
+  | Sdk_tripwire_violation
+  | Sdk_exit_condition_met
 
 val blocker_class_to_string : blocker_class -> string
 val cascade_exhaustion_summary : cascade_exhaustion_reason -> string


### PR DESCRIPTION
## Summary

RFC-0062 Step 2 — Replace the catch-all `_ -> None` in `keeper_status_bridge.ml` that silently dropped 9 Agent SDK error variants with explicit typed `blocker_class` mappings.

## Changes

- `lib/keeper/keeper_meta_contract.ml`
  - Add 9 `Sdk_*` variants to `type blocker_class`
  - Add string mappings in `blocker_class_to_string`
  - Add deserialization mappings in `blocker_class_of_serialized_string`
- `lib/keeper/keeper_meta_contract.mli`
  - Sync interface type declaration
- `lib/keeper/keeper_types.mli`
  - Sync manifest type alias (type equation preserved)
- `lib/keeper/keeper_status_bridge.ml`
  - `blocker_class_of_sdk_error`: explicit per-variant mapping from `Agent_sdk.Error.Agent` constructors
  - Remove false comment about compiler forcing decisions (wildcard, not exhaustive)
  - `runtime_blocker_surface_of_typed_class` / `runtime_blocker_surface_of_legacy_string`: include new variants in catch-all group
- `lib/cascade/cascade_config_loader.ml`
  - Fix pre-existing syntax error (missing `in` + duplicate merge-conflict tail) so `dune build @check` passes

## Why

The historic `_ -> None` catch-all meant that `MaxTurnsExceeded`, `TokenBudgetExceeded`, `CostBudgetExceeded`, `UnrecognizedStopReason`, `IdleDetected`, `ToolRetryExhausted`, `GuardrailViolation`, `TripwireViolation`, and `ExitConditionMet` all mapped to `None`, leaving `last_blocker_class = null` in keeper meta and making them invisible to dashboards and Prometheus. Adding explicit variants closes this stamp gap.

Adding a new upstream SDK variant now produces a compile error (exhaustive match) instead of a silent runtime drop.

## Verification

- [x] `dune build --root . @check` passes
- [ ] TLA+ bug model (follow-up if required)
- [ ] adversarial-reviewer Layer 3 (post-PR)

## Related

- Plan: 5축 직교성 평가 Step 2
- Closes blocker_class stamp gap for SDK-originated terminations