### PR TITLE
refactor(dashboard): reform JourneyPanel from card grid to table + drawer

### DIFF
--- a/dashboard/src/components/journey-panel.ts
+++ b/dashboard/src/components/journey-panel.ts
@@ -23,10 +23,12 @@ import type {
 import { formatPct, formatTokens } from '../lib/format-number'
 import { trimText, truncate } from '../lib/truncate'
 import { Card } from './common/card'
+import { Drawer } from './common/drawer'
 import { EmptyState } from './common/empty-state'
 import { TextInput } from './common/input'
 import { RouteLink } from './common/route-link'
 import { StatusChip, keeperStateTone } from './common/status-chip'
+import { Table, type TableColumn } from './common/table'
 import { TimeAgo } from './common/time-ago'
 import { formatTimeAgoEn } from '../lib/format-time'
 import { keeperActivityDisplay, keeperDisplayModel } from '../lib/keeper-runtime-display'
@@ -809,8 +811,130 @@ function JourneyCard({ record }: { record: JourneyRecord }) {
   `
 }
 
+function JourneyTable({
+  records,
+  selectedKey,
+  onSelect,
+}: {
+  records: readonly JourneyRecord[]
+  selectedKey: string | null
+  onSelect: (key: string | null) => void
+}) {
+  const columns: TableColumn<JourneyRecord>[] = [
+    {
+      key: 'task',
+      header: 'Task',
+      sortable: false,
+      width: 'min-w-[240px]',
+      render: (record) => html`
+        <div class="flex flex-col gap-1">
+          <span class="font-medium text-[var(--color-fg-primary)]">${record.title}</span>
+          ${record.subtitle ? html`<span class="text-2xs text-[var(--color-fg-muted)] truncate">${record.subtitle}</span>` : null}
+        </div>
+      `,
+    },
+    {
+      key: 'keeper',
+      header: 'Keeper',
+      sortable: false,
+      width: 'min-w-[140px]',
+      render: (record) => {
+        const name = record.keeper?.name ?? '-'
+        return html`<span class="font-mono text-2xs text-[var(--color-fg-secondary)]">${name}</span>`
+      },
+    },
+    {
+      key: 'status',
+      header: 'Status',
+      sortable: false,
+      width: 'min-w-[120px]',
+      render: (record) => {
+        if (record.task?.status) {
+          return html`<${StatusChip} tone=${record.task.status === 'done' ? 'ok' : record.task.status === 'awaiting_verification' ? 'select' : 'neutral'}>
+            ${taskStatusLabel(record.task.status)}
+          <//>`
+        }
+        if (record.keeper?.status) {
+          return html`<${StatusChip} tone=${keeperStateTone(record.keeper.status)}>${record.keeper.status}<//>`
+        }
+        return html`<span class="text-2xs text-[var(--color-fg-muted)]">-</span>`
+      },
+    },
+    {
+      key: 'activity',
+      header: 'Last activity',
+      sortable: false,
+      width: 'min-w-[120px]',
+      render: (record) => {
+        const age = record.keeper
+          ? keeperActivityDisplay(record.keeper, record.keeper.agent?.last_seen).ageSeconds
+          : null
+        if (age != null) {
+          return html`<span class="text-2xs text-[var(--color-fg-muted)]">${formatAgeSeconds(age)}</span>`
+        }
+        if (record.task?.updated_at) {
+          return html`<${TimeAgo} timestamp=${record.task.updated_at} />`
+        }
+        return html`<span class="text-2xs text-[var(--color-fg-muted)]">-</span>`
+      },
+    },
+    {
+      key: 'blocked',
+      header: 'Blocked',
+      sortable: false,
+      width: 'min-w-[100px]',
+      render: (record) => {
+        const blocked = record.keeper?.runtime_blocker_class != null
+          || (record.task?.gate?.done?.status === 'blocked')
+        return blocked
+          ? html`<${StatusChip} tone="bad">blocked<//>`
+          : html`<span class="text-2xs text-[var(--color-fg-muted)]">-</span>`
+      },
+    },
+  ]
+
+  if (records.length === 0) {
+    return html`<${EmptyState} message="No journeys match the current filters." compact />`
+  }
+
+  return html`
+    <div class="overflow-x-auto rounded-[var(--r-0)] border border-[var(--color-border-default)] bg-[var(--color-bg-page)]">
+      <${Table}
+        columns=${columns}
+        rows=${records}
+        getRowId=${(row: JourneyRecord) => row.key}
+        selectedIds=${selectedKey ? [selectedKey] : []}
+        onSelect=${(ids: string[]) => onSelect(ids[0] ?? null)}
+        aria-label="Journey records"
+      />
+    </div>
+  `
+}
+
+function JourneyDetailDrawer({
+  record,
+  onClose,
+}: {
+  record: JourneyRecord | null
+  onClose: () => void
+}) {
+  if (!record) return null
+  return html`
+    <${Drawer}
+      open=${true}
+      onClose=${onClose}
+      title=${record.title}
+      position="right"
+      class="w-96 max-w-[calc(100vw-1rem)]"
+    >
+      <${JourneyCard} record=${record} />
+    <//>
+  `
+}
+
 export function JourneyPanel() {
   const query = useSignal('')
+  const selectedKey = useSignal<string | null>(null)
   const missionSessions = Array.isArray(missionSnapshot.value?.sessions)
     ? missionSnapshot.value.sessions as JourneyMissionSession[]
     : []
@@ -823,39 +947,37 @@ export function JourneyPanel() {
     missionSessions,
     journalEntries: journal.value,
   })
+  // Standalone keeper records are delegated to the agents section.
+  const taskRecords = records.filter((record) => record.kind === 'task')
   const priorityItems = executionQueue.value.filter((item) => item.kind === 'keeper' || item.severity === 'bad')
-  const visible = filterJourneyRecords(records, query.value)
-  const taskCount = records.filter((record) => record.kind === 'task').length
-  const keeperCount = records.filter((record) => record.kind === 'keeper').length
-  const blockedCount = records.filter((record) =>
+  const visible = filterJourneyRecords(taskRecords, query.value)
+  const blockedCount = visible.filter((record) =>
     record.keeper?.runtime_blocker_class != null || (record.task?.gate?.done?.status === 'blocked'),
   ).length
-  const thinkingCount = records.filter((record) => record.keeper?.pipeline_stage === 'thinking').length
-  const memoryHotCount = records.filter((record) =>
-    Boolean(record.keeper?.memory_recent_note) || (record.keeper?.compaction_count ?? 0) > 0,
-  ).length
-  const taskRecords = visible.filter((record) => record.kind === 'task')
-  const keeperRecords = visible.filter((record) => record.kind === 'keeper')
+  const thinkingCount = visible.filter((record) => record.keeper?.pipeline_stage === 'thinking').length
+
+  const selectedRecord = selectedKey.value
+    ? visible.find((r) => r.key === selectedKey.value) ?? null
+    : null
 
   return html`
     <div class="flex flex-col gap-4">
       <${Card} class="flex flex-col gap-4">
         <div class="flex flex-col gap-2">
           <div class="flex flex-wrap items-center gap-2">
-            <h2 class="m-0 text-lg font-semibold tracking-normal text-[var(--color-fg-secondary)]">Task / Run / Contract / Keeper / Thinking / Memory / Turn / Life / Cascade</h2>
+            <h2 class="m-0 text-lg font-semibold tracking-normal text-[var(--color-fg-secondary)]">Active Journeys</h2>
             <${StatusChip} tone="info">beta<//>
           </div>
           <div class="text-sm leading-relaxed text-[var(--color-fg-muted)]">
-            Read task-centered work and standalone keeper continuity with one card grammar.
+            Task-centered work linked across keeper, session, and contract context.
           </div>
         </div>
 
-        <div class="grid gap-3 md:grid-cols-5">
-          <${MetricChip} label="journeys" value=${records.length} tone="info" />
-          <${MetricChip} label="tasks" value=${taskCount} />
-          <${MetricChip} label="keepers" value=${keeperCount} />
+        <div class="grid gap-3 md:grid-cols-4">
+          <${MetricChip} label="journeys" value=${visible.length} tone="info" />
           <${MetricChip} label="blocked" value=${blockedCount} tone=${blockedCount > 0 ? 'bad' : 'ok'} />
-          <${MetricChip} label="thinking/memory" value=${`${thinkingCount} / ${memoryHotCount}`} tone="warn" />
+          <${MetricChip} label="thinking" value=${thinkingCount} tone="warn" />
+          <${MetricChip} label="in queue" value=${priorityItems.length} tone=${priorityItems.some(i => i.severity === 'bad') ? 'bad' : 'warn'} />
         </div>
 
         <${ExecutionQueuePanel} items=${priorityItems} />
@@ -872,32 +994,21 @@ export function JourneyPanel() {
             }}
           />
           <div class="text-xs text-[var(--color-fg-muted)]">
-            ${query.value.trim() !== '' ? `${visible.length} / ${records.length} shown` : `${records.length} flows`}
+            ${query.value.trim() !== '' ? `${visible.length} / ${taskRecords.length} shown` : `${taskRecords.length} flows`}
           </div>
         </div>
       <//>
 
-      ${visible.length === 0
-        ? html`<${EmptyState} message="No journeys match the current filters." compact />`
-        : html`
-            ${taskRecords.length > 0
-              ? html`
-                  <div class="flex flex-col gap-3">
-                    <div class="font-mono text-2xs font-semibold uppercase tracking-[var(--track-caps)] text-[var(--color-fg-muted)]">Task Journeys</div>
-                    ${taskRecords.map((record) => html`<${JourneyCard} key=${record.key} record=${record} />`)}
-                  </div>
-                `
-              : null}
+      <${JourneyTable}
+        records=${visible}
+        selectedKey=${selectedKey.value}
+        onSelect=${(key: string | null) => { selectedKey.value = key }}
+      />
 
-            ${keeperRecords.length > 0
-              ? html`
-                  <div class="flex flex-col gap-3">
-                    <div class="font-mono text-2xs font-semibold uppercase tracking-[var(--track-caps)] text-[var(--color-fg-muted)]">Keeper Journeys</div>
-                    ${keeperRecords.map((record) => html`<${JourneyCard} key=${record.key} record=${record} />`)}
-                  </div>
-                `
-              : null}
-          `}
+      <${JourneyDetailDrawer}
+        record=${selectedRecord}
+        onClose=${() => { selectedKey.value = null }}
+      />
     </div>
   `
 }


### PR DESCRIPTION
## Summary

Reforms the JourneyPanel component (903 LOC) from a dense 9-tile card grid to a Master-Detail (Table + Drawer) pattern. This addresses the information density problem where the previous UI presented ~9 simultaneous chunks, exceeding Cowan's working-memory limit of ~4 chunks.

## Changes

- **JourneyTable**: New table view using the shared `Table<T>` component (`dashboard/src/components/common/table.ts`) with 5 columns:
  - Task (title + subtitle)
  - Keeper (name)
  - Status (task or keeper state chip)
  - Last activity (age or time-ago)
  - Blocked (blocked indicator chip)
- **JourneyDetailDrawer**: New slide-over detail using the shared `Drawer` component (`dashboard/src/components/common/drawer.ts`). Renders the existing `JourneyCard` inside the drawer, preserving all existing detail rendering.
- **Metrics reduced**: From 9 chunks to 4 (journeys, blocked, thinking, in queue).
- **Standalone keeper removal**: Keeper-only records are now delegated to the agents-unified section, removing duplication.
- **Header simplified**: "Task / Run / Contract / Keeper / Thinking / Memory / Turn / Life / Cascade" → "Active Journeys".

## Preserved

All type definitions (`JourneyRecord`, `JourneyBuildInput`, `JourneyMissionSession`, `JourneyLifeEntry`), helper functions (`buildJourneyRecords`, `filterJourneyRecords`, etc.), `MetricChip`, `JourneyTile`, `JourneyCard`, `ExecutionQueuePanel`, and `EmptyState` are untouched.

## Verification

- `pnpm typecheck` (tsc --noEmit): **No new errors** in `journey-panel.ts`. 4 pre-existing errors in `ide-editor.ts` (unrelated).
- `pnpm vitest run src/components/status.test.ts`: 1 pre-existing failure (`memory-subsystems` → `Memory Subsystems` mapping missing in `sectionLabel`), unrelated to this change.

## Why

The previous card grid displayed 9 tiles per record (Task, Run, Contract, Keeper, Thinking, Memory, Turn, Life, Cascade). This exceeded cognitive load limits for quick scanning. The table format reduces each row to 5 scannable cells, and the drawer reveals full detail on demand (Progressive Disclosure, NN/g). The pattern follows Linear, Datadog, and LangSmith conventions.

## Test plan

- [ ] Open Journey panel in dashboard
- [ ] Verify table renders with columns: Task, Keeper, Status, Last activity, Blocked
- [ ] Click a row → detail drawer opens from right
- [ ] Verify drawer contains full JourneyCard detail
- [ ] Press Escape or click backdrop → drawer closes
- [ ] Verify metrics strip shows: journeys, blocked, thinking, in queue
- [ ] Verify search/filter still works
- [ ] Verify ExecutionQueuePanel still renders below metrics

🤖 Generated with [Claude Code](https://claude.com/claude-code)