### PR TITLE
fix(test): correct filesystem_safe path traversal expectation (#14433 follow-up)

### DIFF
--- a/test/test_gate_keeper_backend.ml
+++ b/test/test_gate_keeper_backend.ml
@@ -93,7 +93,7 @@ let test_filesystem_safe_normal () =
 
 let test_filesystem_safe_strips_path_traversal () =
   let result = Gate_keeper_backend.filesystem_safe_or_unknown "../../etc/passwd" in
-  check string "path traversal sanitized" "___etc_passwd" result
+  check string "path traversal sanitized" "______etc_passwd" result
 
 let test_filesystem_safe_empty_to_unknown () =
   let result = Gate_keeper_backend.filesystem_safe_or_unknown "" in


### PR DESCRIPTION
## Summary
- PR #14433에서 `filesystem_safe_or_unknown` path traversal 테스트의 기대값이 틀림
- 입력 `"../../etc/passwd"` → 6개 비안전문자(4 dots + 2 slashes) → `"______etc_passwd"`
- 기대값이 `"___etc_passwd"`(3개)로 잘못 작성되어 있었음

## Test plan
- [x] `dune exec --root . test/test_gate_keeper_backend.exe` → 15/15 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)