### PR TITLE
feat(cascade): TOML materializer thinking fields + JSON profiles sync (RFC-0058)

### DIFF
--- a/config/cascade.json
+++ b/config/cascade.json
@@ -1,5 +1,20 @@
 {
   "_comment": "Checked-in seed for cascade authoring. Repo defaults expose exactly two profiles: big_three for keeper/workflow calls and tool_rerank for short rerank calls. Logical usage names are configured under [routes] instead of being profile names.",
+  "profiles": {
+    "tool_strict": {
+      "required_capabilities": [
+        "runtime_mcp_tools", "runtime_tool_events",
+        "runtime_mcp_http_headers"
+      ]
+    },
+    "inline_tools": {
+      "required_capabilities": [ "inline_tools", "inline_tool_choice" ]
+    },
+    "lite": {
+      "required_capabilities": [ "runtime_mcp_tools", "runtime_tool_events" ]
+    },
+    "local": { "required_capabilities": [] }
+  },
   "routes": {
     "keeper_turn": "big_three",
     "phase_recovery": "big_three",

--- a/lib/cascade/cascade_toml_materializer.ml
+++ b/lib/cascade/cascade_toml_materializer.ml
@@ -420,7 +420,8 @@ let profile_field_json ~profile_name ~field_name field_value =
   | "sticky_ttl_ms"
   | "num_ctx"
   | "rate_limit_skip_after"
-  | "server_error_skip_after" -> (
+  | "server_error_skip_after"
+  | "thinking_budget" -> (
       match int_value ~path:profile_path field_value with
       | Ok value -> Ok [ (profile_name ^ "_" ^ field_name, `Int value) ]
       | Error _ as err -> err)
@@ -459,10 +460,11 @@ let profile_field_json ~profile_name ~field_name field_value =
       | Ok value ->
           Ok [ (profile_name ^ "_required_capability_profile", `String value) ]
       | Error _ as err -> err)
-  | "keeper_assignable" -> (
+  | "keeper_assignable"
+  | "thinking_enabled" -> (
       match bool_value ~path:profile_path field_value with
       | Ok value ->
-          Ok [ (profile_name ^ "_keeper_assignable", `Bool value) ]
+          Ok [ (profile_name ^ "_" ^ field_name, `Bool value) ]
       | Error _ as err -> err)
   | "tiers" -> (
       match string_matrix_value ~path:profile_path field_value with
@@ -505,7 +507,7 @@ let profile_field_json ~profile_name ~field_name field_value =
             profile_path (toml_type_name field_value))
   | other ->
       errorf
-        "unknown field %S in profile %s; allowed fields are comment, models, temperature, max_tokens, strategy, max_cycles, backoff_base_ms, backoff_cap_ms, ollama_max_concurrent, cli_max_concurrent, tiers, sticky_ttl_ms, latency_baseline_ms, rate_limit_recency_window_s, rate_limit_decay_base, rate_limit_skip_after, server_error_recency_window_s, server_error_decay_base, server_error_skip_after, keeper_assignable, fallback_cascade, required_capability_profile, api_key_env, keep_alive, num_ctx, timeout_sec, groups"
+        "unknown field %S in profile %s; allowed fields are comment, models, temperature, max_tokens, strategy, max_cycles, backoff_base_ms, backoff_cap_ms, ollama_max_concurrent, cli_max_concurrent, tiers, sticky_ttl_ms, latency_baseline_ms, rate_limit_recency_window_s, rate_limit_decay_base, rate_limit_skip_after, server_error_recency_window_s, server_error_decay_base, server_error_skip_after, keeper_assignable, thinking_enabled, thinking_budget, fallback_cascade, required_capability_profile, api_key_env, keep_alive, num_ctx, timeout_sec, groups"
         other profile_name
 
 let profile_table_json_fields ~profile_name value =


### PR DESCRIPTION
## Summary

- Add `thinking_enabled` (bool) and `thinking_budget` (int) to the TOML materializer field whitelist, resolving "unknown field" errors when `cascade.toml` contains thinking configuration
- Generalize the bool field handler to use `field_name` instead of hardcoded suffix (preserves backward compat)
- Update `cascade.json` with the `"profiles"` section to maintain TOML/JSON round-trip sync

## Context

Phase 1 merged in #14419 added `[profiles.*]` sections to `cascade.toml` and the `Profile_registry` runtime. The TOML materializer's explicit field whitelist didn't include `thinking_enabled`/`thinking_budget`, so any profile section with these fields (e.g., `[big_three]` which has `thinking_enabled = false`) would fail materialization.

## Test plan

- [x] `dune build` passes
- [x] `test_cascade_toml_materialization` — 22/22 tests pass (including round-trip repo_sync)
- [x] `test_cascade_phase1_smoke` — 5/5 tests pass
- [x] `test_cascade_capability_profile` — all pass
- [x] `test_cascade_required_capability_profile` — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)