### PR TITLE
fix(ide): complete Phase 2 dashboard wiring

### DIFF
--- a/dashboard/src/api/ide.ts
+++ b/dashboard/src/api/ide.ts
@@ -97,6 +97,16 @@ export async function fetchIdeRegions(
   return parseIdeCodeRegions(raw.data)
 }
 
+export async function fetchIdePresence(
+  opts: IdeApiOptions = {},
+): Promise<unknown> {
+  const params = new URLSearchParams()
+  appendWorkspaceParams(params, opts)
+  const raw = await get<unknown>(`/api/v1/ide/presence?${params.toString()}`, opts)
+  if (!isRecord(raw) || raw.ok !== true) return null
+  return raw.data
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value)
 }

--- a/dashboard/src/components/ide/code-document-store.test.ts
+++ b/dashboard/src/components/ide/code-document-store.test.ts
@@ -1,4 +1,8 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('../../api/ide', () => ({
+  fetchIdeRegions: vi.fn().mockResolvedValue([]),
+}))
 import { createCodeDocumentStore } from './code-document-store'
 
 describe('createCodeDocumentStore', () => {

--- a/dashboard/src/components/ide/code-document-store.ts
+++ b/dashboard/src/components/ide/code-document-store.ts
@@ -1,4 +1,5 @@
 import { signal } from '@preact/signals'
+import { fetchIdeRegions, type IdeCodeRegion } from '../../api/ide'
 
 export interface CodeDocumentSource {
   readonly file_path: string
@@ -21,6 +22,9 @@ export interface CodeDocumentStore {
   readonly document: () => CodeDocumentSnapshot
   readonly lines: () => ReadonlyArray<CodeDocumentLine>
   readonly line: (lineNumber: number) => CodeDocumentLine | null
+  readonly regions: () => ReadonlyArray<IdeCodeRegion>
+  readonly regionsLoading: () => boolean
+  readonly loadRegions: (filePath: string, opts?: { keeper?: string; signal?: AbortSignal }) => Promise<void>
   readonly subscribe: (listener: () => void) => () => void
 }
 
@@ -38,12 +42,25 @@ export function createCodeDocumentStore(
   const maxLines = normalizeMaxLines(opts.maxLines)
   const initial = normalizeSource(initialSource, maxLines) ?? EMPTY_DOCUMENT
   const snapshot = signal<CodeDocumentSnapshot>(initial)
+  const regionsSignal = signal<ReadonlyArray<IdeCodeRegion>>([])
+  const regionsLoadingSignal = signal<boolean>(false)
 
   const load = (source: unknown): boolean => {
     const next = normalizeSource(source, maxLines)
     if (!next) return false
     snapshot.value = next
     return true
+  }
+
+  const loadRegions = async (filePath: string, opts?: { keeper?: string; signal?: AbortSignal }): Promise<void> => {
+    regionsLoadingSignal.value = true
+    try {
+      const fetched = await fetchIdeRegions(filePath, opts ?? {})
+      if (opts?.signal?.aborted) return
+      regionsSignal.value = fetched
+    } finally {
+      regionsLoadingSignal.value = false
+    }
   }
 
   const subscribe = (listener: () => void): (() => void) => {
@@ -62,6 +79,9 @@ export function createCodeDocumentStore(
     document: () => snapshot.value,
     lines: () => snapshot.value.lines,
     line: lineNumber => snapshot.value.lines[lineNumber - 1] ?? null,
+    regions: () => regionsSignal.value,
+    regionsLoading: () => regionsLoadingSignal.value,
+    loadRegions,
     subscribe,
   }
 }

--- a/dashboard/src/components/ide/ide-data-coordinator.ts
+++ b/dashboard/src/components/ide/ide-data-coordinator.ts
@@ -27,6 +27,10 @@ import {
   createFileTreeStore,
   type FileTreeStore,
 } from './file-tree-store'
+import {
+  fetchIdeAnnotations,
+  type IdeAnnotation,
+} from '../../api/ide'
 
 export interface IdeDataCoordinator {
   readonly documentStore: CodeDocumentStore
@@ -42,6 +46,8 @@ export interface IdeDataCoordinator {
   readonly subscribeActiveRepositoryId: (listener: () => void) => () => void
   readonly scanRepositories: () => Promise<ReadonlyArray<Repository>>
   readonly subscribeRepositories: (listener: () => void) => () => void
+  readonly annotations: () => ReadonlyArray<IdeAnnotation>
+  readonly subscribeAnnotations: (listener: () => void) => () => void
   readonly dispose: () => void
 }
 
@@ -105,6 +111,7 @@ export function createIdeDataCoordinator(): IdeDataCoordinator {
   const workspaceSourceSignal = signal<WorkspaceSource>({ kind: 'project' })
   const repositoriesSignal = signal<ReadonlyArray<Repository>>([])
   const activeRepositoryIdSignal = signal<string | null>(null)
+  const annotationsSignal = signal<ReadonlyArray<IdeAnnotation>>([])
 
   let abortController = new AbortController()
 
@@ -171,6 +178,9 @@ export function createIdeDataCoordinator(): IdeDataCoordinator {
       }
     }).catch(() => {})
 
+    // Load regions
+    documentStore.loadRegions(filePath, opts).catch(() => {})
+
     // Load blame → ownership
     fetchGitBlame(filePath, opts).then(blocks => {
       if (signal.aborted) return
@@ -190,6 +200,12 @@ export function createIdeDataCoordinator(): IdeDataCoordinator {
     fetchGitDiff(filePath, { ...opts, baseRef: 'HEAD' }).then(rows => {
       if (signal.aborted) return
       diffRowsSignal.value = rows
+    }).catch(() => {})
+
+    // Load annotations
+    fetchIdeAnnotations({ file_path: filePath }, opts).then(annotations => {
+      if (signal.aborted) return
+      annotationsSignal.value = annotations
     }).catch(() => {})
   })
 
@@ -217,6 +233,9 @@ export function createIdeDataCoordinator(): IdeDataCoordinator {
     scanRepositories,
     subscribeRepositories: (listener: () => void) =>
       repositoriesSignal.subscribe(listener),
+    annotations: () => annotationsSignal.value,
+    subscribeAnnotations: (listener: () => void) =>
+      annotationsSignal.subscribe(listener),
     dispose: () => {
       abortController.abort()
       disposeEffect()

--- a/dashboard/src/components/ide/ide-editor.ts
+++ b/dashboard/src/components/ide/ide-editor.ts
@@ -151,7 +151,7 @@ export function IdeEditor({
         ` : null}
       </div>
       ${activeLayerKinds.length > 0
-        ? LayerOverlaySummary(activeLayerKinds, ownership, keepers)
+        ? LayerOverlaySummary(activeLayerKinds, ownership, keepers, annotations)
         : null}
       ${findOpen
         ? html`<${IdeFindPanel}
@@ -546,7 +546,7 @@ function CodeMirrorEditor({
 
   return html`
     <div class="ide-codemirror-shell" data-view=${showBlame ? 'blame' : 'source'}>
-      ${showBlame ? BlameTimeline(ownership, keepers, annotations) : null}
+      ${showBlame ? BlameTimeline(ownership, keepers) : null}
       <div ref=${containerRef} class="ide-codemirror-host" />
     </div>
   `
@@ -567,9 +567,7 @@ function syncEditorDocument(view: EditorView, content: string): void {
 function BlameTimeline(
   ownership: ReadonlyMap<number, LineOwnership>,
   keepers: ReadonlyArray<string>,
-  annotations: ReadonlyArray<IdeAnnotation>,
 ) {
-  const annotationCount = annotations.length
   const latestEdit = latestEditMs(ownership)
   const stats = keeperOwnershipStats(ownership, keepers)
   return html`

--- a/dashboard/src/components/ide/ide-shell.ts
+++ b/dashboard/src/components/ide/ide-shell.ts
@@ -227,6 +227,7 @@ export function IdeShell() {
             onFindOpen=${handleFindOpen}
             onFindClose=${handleFindClose}
             onKeeperLineSelect=${pinInspectorKeeper}
+            annotations=${coordinator.annotations}
           />
           <${OverlayKeeperTrace} active=${activeLayers.has('keeper-trace')} />
         </div>

--- a/dashboard/src/sse.ts
+++ b/dashboard/src/sse.ts
@@ -959,6 +959,26 @@ function handleEvent(event: SSEEvent): void {
       })
       break
     }
+    case 'ide:presence': {
+      const p = (event.payload ?? {}) as Record<string, unknown>
+      const runtimeId = asString(p.runtime_id) ?? 'unknown'
+      const branch = asString(p.branch) ?? 'unknown'
+      const supervisor = asString(p.supervisor) ?? 'unknown'
+      const connected = p.connected === true
+      const entries = Array.isArray(p.entries) ? p.entries.length : 0
+      addTypedJournalEntry(
+        agent,
+        `IDE presence · ${runtimeId} · ${branch} · ${entries} keepers`,
+        'system',
+        'unknown',
+        {
+          severity: event.severity,
+          source: event.source,
+          narrativeText: `IDE presence snapshot ${runtimeId}/${branch} (${entries} keepers, connected=${connected})`,
+        },
+      )
+      break
+    }
     default:
       addTypedJournalEntry(agent, type, 'system', 'unknown', {
         narrativeText: `${actorLabel(agent)} 이벤트: ${type}`,

--- a/lib/server/server_ide_http.ml
+++ b/lib/server/server_ide_http.ml
@@ -189,3 +189,18 @@ let add_routes router =
           (Yojson.Safe.to_string (json_ok json)) reqd)
       request reqd)
     router3
+  in
+  Http.Router.get "/api/v1/ide/presence" (fun request reqd ->
+    with_public_read
+      (fun state _req reqd ->
+        let snapshot = `Assoc [
+          ("runtime_id", `String "runtime");
+          ("branch", `String "main");
+          ("supervisor", `String "local");
+          ("connected", `Bool true);
+          ("entries", `List []);
+        ] in
+        Http.Response.json ~compress:true ~request:request
+          (Yojson.Safe.to_string (json_ok snapshot)) reqd)
+      request reqd)
+    router4


### PR DESCRIPTION
- Fix ide-editor.ts compilation errors (annotations prop mismatch)
- Add regions/regionsLoading/loadRegions to code-document-store
- Add fetchIdeAnnotations + annotations signal to ide-data-coordinator
- Wire annotations from coordinator through ide-shell to IdeEditor
- Add fetchIdePresence API stub and /api/v1/ide/presence REST endpoint
- Add ide:presence SSE handler in sse.ts
- Mock fetchIdeRegions in code-document-store.test.ts