### PR TITLE
feat(dashboard): reform goal-loop-panel to table + drawer + collapsible pattern

### DIFF
--- a/dashboard/src/components/goal-loop-panel.test.ts
+++ b/dashboard/src/components/goal-loop-panel.test.ts
@@ -66,12 +66,11 @@ describe('GoalLoopPanel', () => {
     cleanup()
   })
 
-  it('renders phase status, next action, and the strict corpus blocker', () => {
+  it('renders phase table, audit, next action, and the strict corpus blocker', () => {
     render(html`<${GoalLoopPanel} initialStatus=${blockedStatus()} />`)
 
     expect(screen.getByTestId('goal-loop-panel')).toBeTruthy()
-    expect(screen.getByTestId('goal-loop-phase-observe').textContent).toContain('critical')
-    expect(screen.getByTestId('goal-loop-phase-verify').textContent).toContain('FAIL')
+    expect(screen.getByRole('grid', { name: /goal loop phases/i })).toBeTruthy()
     expect(screen.getByTestId('goal-loop-audit-catalog').textContent).toContain('INCOMPLETE')
     expect(screen.getByTestId('goal-loop-corpus-missing').textContent).toContain('187')
     expect(screen.getByTestId('goal-loop-next-action').textContent).toContain('D-EMERGENCY-2')

--- a/dashboard/src/components/goal-loop-panel.ts
+++ b/dashboard/src/components/goal-loop-panel.ts
@@ -4,6 +4,9 @@ import { RefreshCw } from 'lucide-preact'
 import { SectionCard } from './common/card'
 import { LoadingState } from './common/feedback-state'
 import { ActionButton } from './common/button'
+import { Table, type TableColumn } from './common/table'
+import { Drawer } from './common/drawer'
+import { CollapsibleSection } from './common/collapsible'
 import { fetchGoalLoopStatus } from '../api/goal-loop'
 import {
   GOAL_LOOP_PHASES,
@@ -240,17 +243,129 @@ function VerifyEvidenceBlock({ status }: { status: GoalLoopStatusResponse }) {
   `
 }
 
+interface GoalLoopTableRow {
+  phase: GoalLoopPhaseName
+  status: string
+  metrics: PhaseMetricSchema[]
+}
+
+function GoalLoopTable({
+  status,
+  selectedPhase,
+  onSelectPhase,
+}: {
+  status: GoalLoopStatusResponse
+  selectedPhase: GoalLoopPhaseName | null
+  onSelectPhase: (phase: GoalLoopPhaseName | null) => void
+}) {
+  const rows: GoalLoopTableRow[] = GOAL_LOOP_PHASES.map((phase) => ({
+    phase,
+    status: status.phases[phase].status,
+    metrics: PHASE_SCHEMA[phase],
+  }))
+
+  const columns: TableColumn<GoalLoopTableRow>[] = [
+    {
+      key: 'phase',
+      header: 'Phase',
+      render: (row) => html`
+        <span class="font-mono text-xs font-semibold uppercase tracking-[var(--track-caps)]">
+          ${phaseLabel(row.phase)}
+        </span>
+      `,
+    },
+    {
+      key: 'status',
+      header: 'Status',
+      render: (row) => statusChip(row.status),
+    },
+    {
+      key: 'summary',
+      header: 'Key metrics',
+      render: (row) => {
+        const m0 = row.metrics[0]
+        const m1 = row.metrics[1]
+        return html`
+          <div class="flex flex-col gap-0.5 text-xs">
+            ${m0
+              ? html`
+                  <span class="text-[var(--color-fg-muted)]">
+                    ${m0.label}:
+                    <span class="font-mono text-[var(--color-fg-secondary)]">
+                      ${formatValue(phaseSummaryValue(status, row.phase, m0.key), m0.format)}
+                    </span>
+                  </span>
+                `
+              : null}
+            ${m1
+              ? html`
+                  <span class="text-[var(--color-fg-muted)]">
+                    ${m1.label}:
+                    <span class="font-mono text-[var(--color-fg-secondary)]">
+                      ${formatValue(phaseSummaryValue(status, row.phase, m1.key), m1.format)}
+                    </span>
+                  </span>
+                `
+              : null}
+          </div>
+        `
+      },
+    },
+  ]
+
+  return html`
+    <div class="overflow-x-auto rounded-[var(--r-1)] border border-[var(--color-border-default)]">
+      <${Table}
+        columns=${columns}
+        rows=${rows}
+        getRowId=${(row: GoalLoopTableRow) => row.phase}
+        selectedIds=${selectedPhase ? [selectedPhase] : []}
+        onSelect=${(ids: string[]) => {
+          const next = ids.length > 0 ? (ids[ids.length - 1] as GoalLoopPhaseName) : null
+          onSelectPhase(next)
+        }}
+        aria-label="Goal loop phases"
+      />
+    </div>
+  `
+}
+
+function GoalLoopDetailDrawer({
+  phase,
+  status,
+  onClose,
+}: {
+  phase: GoalLoopPhaseName | null
+  status: GoalLoopStatusResponse
+  onClose: () => void
+}) {
+  if (!phase) return null
+  return html`
+    <${Drawer}
+      open=${true}
+      onClose=${onClose}
+      title=${`${phaseLabel(phase)} Detail`}
+    >
+      <${PhaseBlock} status=${status} phase=${phase} />
+      ${phase === 'verify'
+        ? html`<div class="mt-4"><${VerifyEvidenceBlock} status=${status} /></div>`
+        : null}
+    <//>
+  `
+}
+
 export function GoalLoopPanel({ initialStatus }: GoalLoopPanelProps) {
   const [status, setStatus] = useState<GoalLoopStatusResponse | null>(initialStatus ?? null)
   const [loading, setLoading] = useState(initialStatus === undefined)
   const [error, setError] = useState<string | null>(null)
+  const [selectedPhase, setSelectedPhase] = useState<GoalLoopPhaseName | null>(null)
 
   const refresh = useCallback(() => {
     setLoading(true)
     setError(null)
     void fetchGoalLoopStatus()
       .then(setStatus)
-      .catch(err => {
+      .catch((err) => {
         setError(err instanceof Error ? err.message : String(err))
       })
       .finally(() => setLoading(false))
@@ -308,16 +423,26 @@ export function GoalLoopPanel({ initialStatus }: GoalLoopPanelProps) {
         `
         : null}
 
-      <div class="grid grid-cols-5 gap-3 max-[1180px]:grid-cols-3 max-[760px]:grid-cols-1">
-        ${GOAL_LOOP_PHASES.map(phase => html`<${PhaseBlock} status=${status} phase=${phase} />`)}
-      </div>
+      <${GoalLoopTable}
+        status=${status}
+        selectedPhase=${selectedPhase}
+        onSelectPhase=${setSelectedPhase}
+      />
 
-      <div class="grid grid-cols-2 gap-4 max-[980px]:grid-cols-1">
-        <${AuditCatalogBlock} status=${status} />
-        <${VerifyEvidenceBlock} status=${status} />
-      </div>
+      <${CollapsibleSection} title="Audit & Verify" open=${false}>
+        <div class="flex flex-col gap-4">
+          <${AuditCatalogBlock} status=${status} />
+          <${VerifyEvidenceBlock} status=${status} />
+        </div>
+      <//>
 
       <${NextActionBlock} status=${status} />
+
+      <${GoalLoopDetailDrawer}
+        phase=${selectedPhase}
+        status=${status}
+        onClose=${() => setSelectedPhase(null)}
+      />
     </div>
   `
 }


### PR DESCRIPTION
## Summary

Progressive disclosure reform of `GoalLoopPanel` to reduce simultaneous visual chunks from 8+ to ~4 (Cowan's working memory limit).

- **Table**: 3-column sortable list of phases (Phase, Status, Key metrics) replaces dense 5-column `PhaseBlock` tile grid.
- **Drawer**: `PhaseBlock` detail rendered on row selection. Escape key or backdrop click closes. Reuses existing `Drawer` component from `common/`.
- **CollapsibleSection**: `AuditCatalogBlock` + `VerifyEvidenceBlock` wrapped in default-closed `<CollapsibleSection title="Audit & Verify">`. Reuses existing `CollapsibleSection` from `common/`.
- **NextActionBlock**: Preserved as always-visible summary at bottom.

## Test plan

- [x] `pnpm vitest run goal-loop` passes (9/9 tests).
- [x] `pnpm typecheck` — no new errors in `goal-loop-panel.ts`.
- [x] Test updated: phase tile `data-testid` assertions removed (tiles now inside Drawer); replaced with ARIA grid query.

## Scope

- `dashboard/src/components/goal-loop-panel.ts` (+134 / −10 LOC)
- `dashboard/src/components/goal-loop-panel.test.ts` (+1 / −1 LOC)

No backend, API, or credential changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)