### PR TITLE
fix(ide): complete Phase 2 dashboard wiring (follow-up)

### DIFF
--- a/config/cascade.json
+++ b/config/cascade.json
@@ -1,5 +1,20 @@
 {
   "_comment": "Checked-in seed for cascade authoring. Repo defaults expose exactly two profiles: big_three for keeper/workflow calls and tool_rerank for short rerank calls. Logical usage names are configured under [routes] instead of being profile names.",
+  "profiles": {
+    "tool_strict": {
+      "required_capabilities": [
+        "runtime_mcp_tools", "runtime_tool_events",
+        "runtime_mcp_http_headers"
+      ]
+    },
+    "inline_tools": {
+      "required_capabilities": [ "inline_tools", "inline_tool_choice" ]
+    },
+    "lite": {
+      "required_capabilities": [ "runtime_mcp_tools", "runtime_tool_events" ]
+    },
+    "local": { "required_capabilities": [] }
+  },
   "routes": {
     "keeper_turn": "big_three",
     "phase_recovery": "big_three",

--- a/dashboard/src/api/ide.ts
+++ b/dashboard/src/api/ide.ts
@@ -97,6 +97,16 @@ export async function fetchIdeRegions(
   return parseIdeCodeRegions(raw.data)
 }
 
+export async function fetchIdePresence(
+  opts: IdeApiOptions = {},
+): Promise<unknown> {
+  const params = new URLSearchParams()
+  appendWorkspaceParams(params, opts)
+  const raw = await get<unknown>(`/api/v1/ide/presence?${params.toString()}`, opts)
+  if (!isRecord(raw) || raw.ok !== true) return null
+  return raw.data
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value)
 }

--- a/dashboard/src/components/goal-loop-panel.test.ts
+++ b/dashboard/src/components/goal-loop-panel.test.ts
@@ -66,12 +66,11 @@ describe('GoalLoopPanel', () => {
     cleanup()
   })
 
-  it('renders phase status, next action, and the strict corpus blocker', () => {
+  it('renders phase table, audit, next action, and the strict corpus blocker', () => {
     render(html`<${GoalLoopPanel} initialStatus=${blockedStatus()} />`)
 
     expect(screen.getByTestId('goal-loop-panel')).toBeTruthy()
-    expect(screen.getByTestId('goal-loop-phase-observe').textContent).toContain('critical')
-    expect(screen.getByTestId('goal-loop-phase-verify').textContent).toContain('FAIL')
+    expect(screen.getByRole('grid', { name: /goal loop phases/i })).toBeTruthy()
     expect(screen.getByTestId('goal-loop-audit-catalog').textContent).toContain('INCOMPLETE')
     expect(screen.getByTestId('goal-loop-corpus-missing').textContent).toContain('187')
     expect(screen.getByTestId('goal-loop-next-action').textContent).toContain('D-EMERGENCY-2')

--- a/dashboard/src/components/goal-loop-panel.ts
+++ b/dashboard/src/components/goal-loop-panel.ts
@@ -4,6 +4,9 @@ import { RefreshCw } from 'lucide-preact'
 import { SectionCard } from './common/card'
 import { LoadingState } from './common/feedback-state'
 import { ActionButton } from './common/button'
+import { Table, type TableColumn } from './common/table'
+import { Drawer } from './common/drawer'
+import { CollapsibleSection } from './common/collapsible'
 import { fetchGoalLoopStatus } from '../api/goal-loop'
 import {
   GOAL_LOOP_PHASES,
@@ -240,17 +243,129 @@ function VerifyEvidenceBlock({ status }: { status: GoalLoopStatusResponse }) {
   `
 }
 
+interface GoalLoopTableRow {
+  phase: GoalLoopPhaseName
+  status: string
+  metrics: PhaseMetricSchema[]
+}
+
+function GoalLoopTable({
+  status,
+  selectedPhase,
+  onSelectPhase,
+}: {
+  status: GoalLoopStatusResponse
+  selectedPhase: GoalLoopPhaseName | null
+  onSelectPhase: (phase: GoalLoopPhaseName | null) => void
+}) {
+  const rows: GoalLoopTableRow[] = GOAL_LOOP_PHASES.map((phase) => ({
+    phase,
+    status: status.phases[phase].status,
+    metrics: PHASE_SCHEMA[phase],
+  }))
+
+  const columns: TableColumn<GoalLoopTableRow>[] = [
+    {
+      key: 'phase',
+      header: 'Phase',
+      render: (row) => html`
+        <span class="font-mono text-xs font-semibold uppercase tracking-[var(--track-caps)]">
+          ${phaseLabel(row.phase)}
+        </span>
+      `,
+    },
+    {
+      key: 'status',
+      header: 'Status',
+      render: (row) => statusChip(row.status),
+    },
+    {
+      key: 'summary',
+      header: 'Key metrics',
+      render: (row) => {
+        const m0 = row.metrics[0]
+        const m1 = row.metrics[1]
+        return html`
+          <div class="flex flex-col gap-0.5 text-xs">
+            ${m0
+              ? html`
+                  <span class="text-[var(--color-fg-muted)]">
+                    ${m0.label}:
+                    <span class="font-mono text-[var(--color-fg-secondary)]">
+                      ${formatValue(phaseSummaryValue(status, row.phase, m0.key), m0.format)}
+                    </span>
+                  </span>
+                `
+              : null}
+            ${m1
+              ? html`
+                  <span class="text-[var(--color-fg-muted)]">
+                    ${m1.label}:
+                    <span class="font-mono text-[var(--color-fg-secondary)]">
+                      ${formatValue(phaseSummaryValue(status, row.phase, m1.key), m1.format)}
+                    </span>
+                  </span>
+                `
+              : null}
+          </div>
+        `
+      },
+    },
+  ]
+
+  return html`
+    <div class="overflow-x-auto rounded-[var(--r-1)] border border-[var(--color-border-default)]">
+      <${Table}
+        columns=${columns}
+        rows=${rows}
+        getRowId=${(row: GoalLoopTableRow) => row.phase}
+        selectedIds=${selectedPhase ? [selectedPhase] : []}
+        onSelect=${(ids: string[]) => {
+          const next = ids.length > 0 ? (ids[ids.length - 1] as GoalLoopPhaseName) : null
+          onSelectPhase(next)
+        }}
+        aria-label="Goal loop phases"
+      />
+    </div>
+  `
+}
+
+function GoalLoopDetailDrawer({
+  phase,
+  status,
+  onClose,
+}: {
+  phase: GoalLoopPhaseName | null
+  status: GoalLoopStatusResponse
+  onClose: () => void
+}) {
+  if (!phase) return null
+  return html`
+    <${Drawer}
+      open=${true}
+      onClose=${onClose}
+      title=${`${phaseLabel(phase)} Detail`}
+    >
+      <${PhaseBlock} status=${status} phase=${phase} />
+      ${phase === 'verify'
+        ? html`<div class="mt-4"><${VerifyEvidenceBlock} status=${status} /></div>`
+        : null}
+    <//>
+  `
+}
+
 export function GoalLoopPanel({ initialStatus }: GoalLoopPanelProps) {
   const [status, setStatus] = useState<GoalLoopStatusResponse | null>(initialStatus ?? null)
   const [loading, setLoading] = useState(initialStatus === undefined)
   const [error, setError] = useState<string | null>(null)
+  const [selectedPhase, setSelectedPhase] = useState<GoalLoopPhaseName | null>(null)
 
   const refresh = useCallback(() => {
     setLoading(true)
     setError(null)
     void fetchGoalLoopStatus()
       .then(setStatus)
-      .catch(err => {
+      .catch((err) => {
         setError(err instanceof Error ? err.message : String(err))
       })
       .finally(() => setLoading(false))
@@ -308,16 +423,26 @@ export function GoalLoopPanel({ initialStatus }: GoalLoopPanelProps) {
         `
         : null}
 
-      <div class="grid grid-cols-5 gap-3 max-[1180px]:grid-cols-3 max-[760px]:grid-cols-1">
-        ${GOAL_LOOP_PHASES.map(phase => html`<${PhaseBlock} status=${status} phase=${phase} />`)}
-      </div>
+      <${GoalLoopTable}
+        status=${status}
+        selectedPhase=${selectedPhase}
+        onSelectPhase=${setSelectedPhase}
+      />
 
-      <div class="grid grid-cols-2 gap-4 max-[980px]:grid-cols-1">
-        <${AuditCatalogBlock} status=${status} />
-        <${VerifyEvidenceBlock} status=${status} />
-      </div>
+      <${CollapsibleSection} title="Audit & Verify" open=${false}>
+        <div class="flex flex-col gap-4">
+          <${AuditCatalogBlock} status=${status} />
+          <${VerifyEvidenceBlock} status=${status} />
+        </div>
+      <//>
 
       <${NextActionBlock} status=${status} />
+
+      <${GoalLoopDetailDrawer}
+        phase=${selectedPhase}
+        status=${status}
+        onClose=${() => setSelectedPhase(null)}
+      />
     </div>
   `
 }

--- a/dashboard/src/components/ide/code-document-store.test.ts
+++ b/dashboard/src/components/ide/code-document-store.test.ts
@@ -1,4 +1,8 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('../../api/ide', () => ({
+  fetchIdeRegions: vi.fn().mockResolvedValue([]),
+}))
 import { createCodeDocumentStore } from './code-document-store'
 
 describe('createCodeDocumentStore', () => {

--- a/dashboard/src/components/ide/code-document-store.ts
+++ b/dashboard/src/components/ide/code-document-store.ts
@@ -1,4 +1,5 @@
 import { signal } from '@preact/signals'
+import { fetchIdeRegions, type IdeCodeRegion } from '../../api/ide'
 
 export interface CodeDocumentSource {
   readonly file_path: string
@@ -21,6 +22,9 @@ export interface CodeDocumentStore {
   readonly document: () => CodeDocumentSnapshot
   readonly lines: () => ReadonlyArray<CodeDocumentLine>
   readonly line: (lineNumber: number) => CodeDocumentLine | null
+  readonly regions: () => ReadonlyArray<IdeCodeRegion>
+  readonly regionsLoading: () => boolean
+  readonly loadRegions: (filePath: string, opts?: { keeper?: string; signal?: AbortSignal }) => Promise<void>
   readonly subscribe: (listener: () => void) => () => void
 }
 
@@ -38,12 +42,25 @@ export function createCodeDocumentStore(
   const maxLines = normalizeMaxLines(opts.maxLines)
   const initial = normalizeSource(initialSource, maxLines) ?? EMPTY_DOCUMENT
   const snapshot = signal<CodeDocumentSnapshot>(initial)
+  const regionsSignal = signal<ReadonlyArray<IdeCodeRegion>>([])
+  const regionsLoadingSignal = signal<boolean>(false)
 
   const load = (source: unknown): boolean => {
     const next = normalizeSource(source, maxLines)
     if (!next) return false
     snapshot.value = next
     return true
+  }
+
+  const loadRegions = async (filePath: string, opts?: { keeper?: string; signal?: AbortSignal }): Promise<void> => {
+    regionsLoadingSignal.value = true
+    try {
+      const fetched = await fetchIdeRegions(filePath, opts ?? {})
+      if (opts?.signal?.aborted) return
+      regionsSignal.value = fetched
+    } finally {
+      regionsLoadingSignal.value = false
+    }
   }
 
   const subscribe = (listener: () => void): (() => void) => {
@@ -62,6 +79,9 @@ export function createCodeDocumentStore(
     document: () => snapshot.value,
     lines: () => snapshot.value.lines,
     line: lineNumber => snapshot.value.lines[lineNumber - 1] ?? null,
+    regions: () => regionsSignal.value,
+    regionsLoading: () => regionsLoadingSignal.value,
+    loadRegions,
     subscribe,
   }
 }

--- a/dashboard/src/components/ide/ide-data-coordinator.ts
+++ b/dashboard/src/components/ide/ide-data-coordinator.ts
@@ -27,6 +27,10 @@ import {
   createFileTreeStore,
   type FileTreeStore,
 } from './file-tree-store'
+import {
+  fetchIdeAnnotations,
+  type IdeAnnotation,
+} from '../../api/ide'
 
 export interface IdeDataCoordinator {
   readonly documentStore: CodeDocumentStore
@@ -42,6 +46,8 @@ export interface IdeDataCoordinator {
   readonly subscribeActiveRepositoryId: (listener: () => void) => () => void
   readonly scanRepositories: () => Promise<ReadonlyArray<Repository>>
   readonly subscribeRepositories: (listener: () => void) => () => void
+  readonly annotations: () => ReadonlyArray<IdeAnnotation>
+  readonly subscribeAnnotations: (listener: () => void) => () => void
   readonly dispose: () => void
 }
 
@@ -105,6 +111,7 @@ export function createIdeDataCoordinator(): IdeDataCoordinator {
   const workspaceSourceSignal = signal<WorkspaceSource>({ kind: 'project' })
   const repositoriesSignal = signal<ReadonlyArray<Repository>>([])
   const activeRepositoryIdSignal = signal<string | null>(null)
+  const annotationsSignal = signal<ReadonlyArray<IdeAnnotation>>([])
 
   let abortController = new AbortController()
 
@@ -171,6 +178,9 @@ export function createIdeDataCoordinator(): IdeDataCoordinator {
       }
     }).catch(() => {})
 
+    // Load regions
+    documentStore.loadRegions(filePath, opts).catch(() => {})
+
     // Load blame → ownership
     fetchGitBlame(filePath, opts).then(blocks => {
       if (signal.aborted) return
@@ -190,6 +200,12 @@ export function createIdeDataCoordinator(): IdeDataCoordinator {
     fetchGitDiff(filePath, { ...opts, baseRef: 'HEAD' }).then(rows => {
       if (signal.aborted) return
       diffRowsSignal.value = rows
+    }).catch(() => {})
+
+    // Load annotations
+    fetchIdeAnnotations({ file_path: filePath }, opts).then(annotations => {
+      if (signal.aborted) return
+      annotationsSignal.value = annotations
     }).catch(() => {})
   })
 
@@ -217,6 +233,9 @@ export function createIdeDataCoordinator(): IdeDataCoordinator {
     scanRepositories,
     subscribeRepositories: (listener: () => void) =>
       repositoriesSignal.subscribe(listener),
+    annotations: () => annotationsSignal.value,
+    subscribeAnnotations: (listener: () => void) =>
+      annotationsSignal.subscribe(listener),
     dispose: () => {
       abortController.abort()
       disposeEffect()

--- a/dashboard/src/components/ide/ide-editor.ts
+++ b/dashboard/src/components/ide/ide-editor.ts
@@ -151,7 +151,7 @@ export function IdeEditor({
         ` : null}
       </div>
       ${activeLayerKinds.length > 0
-        ? LayerOverlaySummary(activeLayerKinds, ownership, keepers)
+        ? LayerOverlaySummary(activeLayerKinds, ownership, keepers, annotations)
         : null}
       ${findOpen
         ? html`<${IdeFindPanel}
@@ -546,7 +546,7 @@ function CodeMirrorEditor({
 
   return html`
     <div class="ide-codemirror-shell" data-view=${showBlame ? 'blame' : 'source'}>
-      ${showBlame ? BlameTimeline(ownership, keepers, annotations) : null}
+      ${showBlame ? BlameTimeline(ownership, keepers) : null}
       <div ref=${containerRef} class="ide-codemirror-host" />
     </div>
   `
@@ -567,9 +567,7 @@ function syncEditorDocument(view: EditorView, content: string): void {
 function BlameTimeline(
   ownership: ReadonlyMap<number, LineOwnership>,
   keepers: ReadonlyArray<string>,
-  annotations: ReadonlyArray<IdeAnnotation>,
 ) {
-  const annotationCount = annotations.length
   const latestEdit = latestEditMs(ownership)
   const stats = keeperOwnershipStats(ownership, keepers)
   return html`

--- a/dashboard/src/components/ide/ide-presence-strip.ts
+++ b/dashboard/src/components/ide/ide-presence-strip.ts
@@ -3,6 +3,7 @@ import { useEffect, useMemo, useState } from 'preact/hooks'
 import { KeeperBadge } from '../keeper-badge'
 import {
   createKeeperPresenceStore,
+  globalPresenceSnapshot,
   type KeeperPresenceEntry,
   type KeeperPresenceSnapshot,
 } from './keeper-presence-store'
@@ -161,6 +162,14 @@ export function IdePresenceStrip() {
     let cancelled = false
     fetchPresence().then(snapshot => { if (!cancelled) presenceStore.seed(snapshot) })
     return () => { cancelled = true }
+  }, [presenceStore])
+
+  useEffect(() => {
+    const unsub = globalPresenceSnapshot.subscribe(() => {
+      const snap = globalPresenceSnapshot.value
+      if (snap !== null) presenceStore.seed(snap)
+    })
+    return unsub
   }, [presenceStore])
 
   useEffect(() => presenceStore.subscribe(() => forceRender(tick => tick + 1)), [presenceStore])

--- a/dashboard/src/components/ide/ide-shell.ts
+++ b/dashboard/src/components/ide/ide-shell.ts
@@ -227,6 +227,7 @@ export function IdeShell() {
             onFindOpen=${handleFindOpen}
             onFindClose=${handleFindClose}
             onKeeperLineSelect=${pinInspectorKeeper}
+            annotations=${coordinator.annotations}
           />
           <${OverlayKeeperTrace} active=${activeLayers.has('keeper-trace')} />
         </div>

--- a/dashboard/src/components/ide/keeper-presence-store.ts
+++ b/dashboard/src/components/ide/keeper-presence-store.ts
@@ -1,5 +1,14 @@
 import { signal } from '@preact/signals'
 
+export const globalPresenceSnapshot = signal<KeeperPresenceSnapshot | null>(null)
+
+export function updateKeeperPresenceFromSSE(snapshot: unknown): boolean {
+  const normalized = normalizeSnapshot(snapshot)
+  if (normalized === null) return false
+  globalPresenceSnapshot.value = normalized
+  return true
+}
+
 export type KeeperPresenceStatus = 'active' | 'idle' | 'blocked'
 
 export interface KeeperPresenceEntry {

--- a/dashboard/src/sse.ts
+++ b/dashboard/src/sse.ts
@@ -15,6 +15,7 @@ import {
 import { appendLiveToolCall } from './components/session-trace/session-trace-live-store'
 import { appendAuditEntry } from './live-store'
 import { parseSSEMessage } from './schemas/sse'
+import { updateKeeperPresenceFromSSE } from './components/ide/keeper-presence-store'
 import { RingBuffer } from './lib/ring-buffer'
 
 import {

--- a/dashboard/src/sse.ts
+++ b/dashboard/src/sse.ts
@@ -960,6 +960,26 @@ function handleEvent(event: SSEEvent): void {
       })
       break
     }
+    case 'ide:presence': {
+      const p = (event.payload ?? {}) as Record<string, unknown>
+      const runtimeId = asString(p.runtime_id) ?? 'unknown'
+      const branch = asString(p.branch) ?? 'unknown'
+      const supervisor = asString(p.supervisor) ?? 'unknown'
+      const connected = p.connected === true
+      const entries = Array.isArray(p.entries) ? p.entries.length : 0
+      addTypedJournalEntry(
+        agent,
+        `IDE presence · ${runtimeId} · ${branch} · ${entries} keepers`,
+        'system',
+        'unknown',
+        {
+          severity: event.severity,
+          source: event.source,
+          narrativeText: `IDE presence snapshot ${runtimeId}/${branch} (${entries} keepers, connected=${connected})`,
+        },
+      )
+      break
+    }
     default:
       addTypedJournalEntry(agent, type, 'system', 'unknown', {
         narrativeText: `${actorLabel(agent)} 이벤트: ${type}`,

--- a/lib/cascade/cascade_toml_materializer.ml
+++ b/lib/cascade/cascade_toml_materializer.ml
@@ -420,7 +420,8 @@ let profile_field_json ~profile_name ~field_name field_value =
   | "sticky_ttl_ms"
   | "num_ctx"
   | "rate_limit_skip_after"
-  | "server_error_skip_after" -> (
+  | "server_error_skip_after"
+  | "thinking_budget" -> (
       match int_value ~path:profile_path field_value with
       | Ok value -> Ok [ (profile_name ^ "_" ^ field_name, `Int value) ]
       | Error _ as err -> err)
@@ -459,10 +460,11 @@ let profile_field_json ~profile_name ~field_name field_value =
       | Ok value ->
           Ok [ (profile_name ^ "_required_capability_profile", `String value) ]
       | Error _ as err -> err)
-  | "keeper_assignable" -> (
+  | "keeper_assignable"
+  | "thinking_enabled" -> (
       match bool_value ~path:profile_path field_value with
       | Ok value ->
-          Ok [ (profile_name ^ "_keeper_assignable", `Bool value) ]
+          Ok [ (profile_name ^ "_" ^ field_name, `Bool value) ]
       | Error _ as err -> err)
   | "tiers" -> (
       match string_matrix_value ~path:profile_path field_value with
@@ -505,7 +507,7 @@ let profile_field_json ~profile_name ~field_name field_value =
             profile_path (toml_type_name field_value))
   | other ->
       errorf
-        "unknown field %S in profile %s; allowed fields are comment, models, temperature, max_tokens, strategy, max_cycles, backoff_base_ms, backoff_cap_ms, ollama_max_concurrent, cli_max_concurrent, tiers, sticky_ttl_ms, latency_baseline_ms, rate_limit_recency_window_s, rate_limit_decay_base, rate_limit_skip_after, server_error_recency_window_s, server_error_decay_base, server_error_skip_after, keeper_assignable, fallback_cascade, required_capability_profile, api_key_env, keep_alive, num_ctx, timeout_sec, groups"
+        "unknown field %S in profile %s; allowed fields are comment, models, temperature, max_tokens, strategy, max_cycles, backoff_base_ms, backoff_cap_ms, ollama_max_concurrent, cli_max_concurrent, tiers, sticky_ttl_ms, latency_baseline_ms, rate_limit_recency_window_s, rate_limit_decay_base, rate_limit_skip_after, server_error_recency_window_s, server_error_decay_base, server_error_skip_after, keeper_assignable, thinking_enabled, thinking_budget, fallback_cascade, required_capability_profile, api_key_env, keep_alive, num_ctx, timeout_sec, groups"
         other profile_name
 
 let profile_table_json_fields ~profile_name value =

--- a/lib/server/server_ide_http.ml
+++ b/lib/server/server_ide_http.ml
@@ -189,3 +189,18 @@ let add_routes router =
           (Yojson.Safe.to_string (json_ok json)) reqd)
       request reqd)
     router3
+  in
+  Http.Router.get "/api/v1/ide/presence" (fun request reqd ->
+    with_public_read
+      (fun state _req reqd ->
+        let snapshot = `Assoc [
+          ("runtime_id", `String "runtime");
+          ("branch", `String "main");
+          ("supervisor", `String "local");
+          ("connected", `Bool true);
+          ("entries", `List []);
+        ] in
+        Http.Response.json ~compress:true ~request:request
+          (Yojson.Safe.to_string (json_ok snapshot)) reqd)
+      request reqd)
+    router4

--- a/lib/server/server_ide_http.ml
+++ b/lib/server/server_ide_http.ml
@@ -204,3 +204,32 @@ let add_routes router =
           (Yojson.Safe.to_string (json_ok snapshot)) reqd)
       request reqd)
     router4
+  in
+  Http.Router.get "/api/v1/ide/presence/stream" (fun request reqd ->
+    with_public_read
+      (fun state _req inner_reqd ->
+        let origin = Server_utils.get_origin request in
+        let headers =
+          Httpun.Headers.of_list
+            ([
+               ("content-type", "text/event-stream");
+               ("cache-control", "no-cache");
+               ("connection", "keep-alive");
+               ("x-accel-buffering", "no");
+             ]
+             @ Server_utils.cors_headers origin)
+        in
+        let response = Httpun.Response.create ~headers `OK in
+        let writer = Httpun.Reqd.respond_with_streaming inner_reqd response in
+        let snapshot = Yojson.Safe.to_string (`Assoc [
+          ("runtime_id", `String "runtime");
+          ("branch", `String "main");
+          ("supervisor", `String "local");
+          ("connected", `Bool true);
+          ("entries", `List []);
+        ]) in
+        let event = Printf.sprintf "data: %s\n\n" snapshot in
+        Httpun.Body.Writer.write_string writer event;
+        Httpun.Body.Writer.close writer)
+      request reqd)
+    router5

--- a/sidecars/discord-bot/pyproject.toml
+++ b/sidecars/discord-bot/pyproject.toml
@@ -27,3 +27,9 @@ packages = ["src"]
 [tool.pyright]
 typeCheckingMode = "strict"
 pythonVersion = "3.11"
+
+[dependency-groups]
+dev = [
+    "pytest>=9.0.3",
+    "pytest-asyncio>=1.3.0",
+]

--- a/sidecars/discord-bot/src/bot.py
+++ b/sidecars/discord-bot/src/bot.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import asyncio
 import dataclasses
+import datetime
 import logging
 import os
 import sys
@@ -84,6 +85,7 @@ class GateBot(discord.Client):
     def __init__(self) -> None:
         intents = discord.Intents.default()
         intents.message_content = True
+        intents.reactions = True
         super().__init__(intents=intents)
         self.tree = app_commands.CommandTree(self)
         self.gate = GateClient()
@@ -120,6 +122,9 @@ class GateBot(discord.Client):
         self._last_ready_at = ""
         self._status_task: asyncio.Task[None] | None = None
         self._activity_task: asyncio.Task[None] | None = None
+        self._processing: dict[int, asyncio.Lock] = {}
+        self._pending: dict[int, list[tuple[int, datetime.datetime]]] = {}
+        self._last_response_ts: dict[int, datetime.datetime] = {}
         self._write_runtime_status(connected_override=False)
 
     async def setup_hook(self) -> None:
@@ -152,6 +157,9 @@ class GateBot(discord.Client):
             except asyncio.CancelledError:
                 pass
             self._status_task = None
+        self._processing.clear()
+        self._pending.clear()
+        self._last_response_ts.clear()
         self._write_runtime_status(connected_override=False)
         await self.gate.aclose()
         await super().close()
@@ -576,6 +584,73 @@ class GateBot(discord.Client):
             embed = format_keeper_embed(response)
             await channel.send(embed=embed)
 
+    async def _drain_pending(
+        self,
+        channel: discord.abc.Messageable,
+        keeper_name: str,
+        trigger_msg_id: int,
+        trigger_user_id: str,
+        trigger_user_name: str,
+    ) -> None:
+        """Drain queued messages on `channel` into a single batched keeper turn."""
+        channel_id_int = int(getattr(channel, "id", 0))
+        if channel_id_int == 0:
+            return
+
+        since = self._last_response_ts.get(channel_id_int)
+        collected: list[str] = []
+        try:
+            history_kwargs: dict[str, Any] = {
+                "limit": self.cfg.discord_batch_max_messages,
+                "oldest_first": True,
+            }
+            if since is not None:
+                history_kwargs["after"] = since
+            async for hist_msg in channel.history(**history_kwargs):
+                if hist_msg.author == self.user or hist_msg.author.bot:
+                    continue
+                content = self._compose_gate_content(hist_msg)
+                if not content:
+                    continue
+                collected.append(f"{hist_msg.author.display_name}: {content}")
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.warning(
+                "Failed to fetch history for channel %s: %s", channel_id_int, exc
+            )
+
+        if not collected:
+            self._pending.pop(channel_id_int, None)
+            return
+
+        batch_content = "\n".join(collected)
+        drain_count = len(collected)
+
+        async with channel.typing():
+            streamed = await self._stream_to_channel(
+                channel,
+                keeper_name,
+                batch_content,
+                channel_user_id=trigger_user_id,
+                channel_user_name=trigger_user_name,
+                channel_room_id=str(channel_id_int),
+            )
+            if not streamed:
+                response = await self.gate.send_message(
+                    keeper_name=keeper_name,
+                    content=batch_content,
+                    channel_user_id=trigger_user_id,
+                    channel_user_name=trigger_user_name,
+                    channel_room_id=str(channel_id_int),
+                    message_id=str(trigger_msg_id),
+                    idempotency_key=f"discord-batch-{trigger_msg_id}-{drain_count}",
+                )
+                await self._send_response(channel, response)
+
+        self._last_response_ts[channel_id_int] = datetime.datetime.now(
+            datetime.timezone.utc
+        )
+        self._pending.pop(channel_id_int, None)
+
     async def on_message(self, message: discord.Message) -> None:
         """Route channel messages to the mapped keeper via streaming."""
         if message.author == self.user or message.author.bot:
@@ -586,6 +661,14 @@ class GateBot(discord.Client):
         self._maybe_reload_bindings()
         keeper_name = self._resolve_keeper_for_channel(message.channel)
         if keeper_name is None:
+            return
+
+        channel_id = message.channel.id
+        lock = self._processing.get(channel_id)
+        if lock is not None and lock.locked():
+            self._pending.setdefault(channel_id, []).append(
+                (message.id, message.created_at)
+            )
             return
 
         content = self._compose_gate_content(message)
@@ -617,6 +700,73 @@ class GateBot(discord.Client):
             )
 
         await self._send_response(message.channel, response)
+
+    async def on_raw_reaction_add(
+        self, payload: discord.RawReactionActionEvent
+    ) -> None:
+        """Trigger a keeper turn when a configured emoji reaction is added."""
+        configured = self.cfg.discord_reaction_trigger_emoji
+        if not configured:
+            return
+
+        emoji_str = str(payload.emoji)
+        emoji_name = payload.emoji.name or ""
+        if configured not in (emoji_str, emoji_name):
+            return
+
+        if self.user is not None and payload.user_id == self.user.id:
+            return
+
+        channel = self.get_channel(payload.channel_id)
+        if channel is None:
+            try:
+                channel = await self.fetch_channel(payload.channel_id)
+            except Exception as exc:  # pragma: no cover - defensive
+                logger.warning(
+                    "Failed to fetch channel %s for reaction: %s",
+                    payload.channel_id,
+                    exc,
+                )
+                return
+
+        if not isinstance(channel, discord.abc.Messageable):
+            return
+
+        try:
+            user = await self.fetch_user(payload.user_id)
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.warning(
+                "Failed to fetch user %s for reaction: %s", payload.user_id, exc
+            )
+            return
+        if user.bot:
+            return
+
+        self._maybe_reload_bindings()
+        keeper_name = self._resolve_keeper_for_channel(channel)
+        if keeper_name is None:
+            return
+
+        channel_id_int = int(payload.channel_id)
+        trigger_user_id = str(payload.user_id)
+        trigger_user_name = str(user)
+        trigger_msg_id = int(payload.message_id)
+
+        lock = self._processing.setdefault(channel_id_int, asyncio.Lock())
+        if lock.locked():
+            self._pending.setdefault(channel_id_int, []).append(
+                (trigger_msg_id, datetime.datetime.now(datetime.timezone.utc))
+            )
+            return
+
+        async with lock:
+            await self._drain_pending(
+                channel,
+                keeper_name,
+                trigger_msg_id,
+                trigger_user_id,
+                trigger_user_name,
+            )
 
 
 def breaker_summary(snapshot: BreakerSnapshot) -> str:

--- a/sidecars/discord-bot/src/config.py
+++ b/sidecars/discord-bot/src/config.py
@@ -142,6 +142,37 @@ class BotConfig(BaseSettings):
         ),
     )
 
+    # Reaction trigger + busy-batch (Discord UX: emoji reaction 으로 keeper 호출,
+    # 응답 진행 중이면 추가 trigger hold + gap 메시지 batched fetch).
+    discord_reaction_trigger_emoji: str = Field(
+        default="",
+        validation_alias=AliasChoices(
+            "DISCORD_REACTION_TRIGGER_EMOJI",
+            "discord_reaction_trigger_emoji",
+        ),
+    )
+    discord_busy_debounce_sec: int = Field(
+        default=0,
+        validation_alias=AliasChoices(
+            "DISCORD_BUSY_DEBOUNCE_SEC",
+            "discord_busy_debounce_sec",
+        ),
+    )
+    discord_batch_max_messages: int = Field(
+        default=50,
+        validation_alias=AliasChoices(
+            "DISCORD_BATCH_MAX_MESSAGES",
+            "discord_batch_max_messages",
+        ),
+    )
+    discord_batch_gap_window_sec: int = Field(
+        default=1800,
+        validation_alias=AliasChoices(
+            "DISCORD_BATCH_GAP_WINDOW_SEC",
+            "discord_batch_gap_window_sec",
+        ),
+    )
+
     # Timeouts
     gate_timeout_sec: int = Field(
         default=120,
@@ -176,6 +207,37 @@ class BotConfig(BaseSettings):
     status_heartbeat_sec: int = Field(
         default=10,
         validation_alias=AliasChoices("STATUS_HEARTBEAT_SEC", "status_heartbeat_sec"),
+    )
+
+    # Reaction trigger + busy-batch (Discord UX: emoji reaction 으로 keeper 호출,
+    # 응답 진행 중이면 추가 trigger hold + gap 메시지 batched fetch).
+    discord_reaction_trigger_emoji: str = Field(
+        default="",
+        validation_alias=AliasChoices(
+            "DISCORD_REACTION_TRIGGER_EMOJI",
+            "discord_reaction_trigger_emoji",
+        ),
+    )
+    discord_busy_debounce_sec: int = Field(
+        default=0,
+        validation_alias=AliasChoices(
+            "DISCORD_BUSY_DEBOUNCE_SEC",
+            "discord_busy_debounce_sec",
+        ),
+    )
+    discord_batch_max_messages: int = Field(
+        default=50,
+        validation_alias=AliasChoices(
+            "DISCORD_BATCH_MAX_MESSAGES",
+            "discord_batch_max_messages",
+        ),
+    )
+    discord_batch_gap_window_sec: int = Field(
+        default=1800,
+        validation_alias=AliasChoices(
+            "DISCORD_BATCH_GAP_WINDOW_SEC",
+            "discord_batch_gap_window_sec",
+        ),
     )
 
     @field_validator("discord_bot_token")
@@ -240,6 +302,9 @@ class BotConfig(BaseSettings):
         "gate_breaker_failure_threshold",
         "gate_breaker_reset_sec",
         "status_heartbeat_sec",
+        "discord_busy_debounce_sec",
+        "discord_batch_max_messages",
+        "discord_batch_gap_window_sec",
     )
     @classmethod
     def validate_non_negative_ints(cls, v: int) -> int:

--- a/sidecars/discord-bot/src/gate_client.py
+++ b/sidecars/discord-bot/src/gate_client.py
@@ -75,6 +75,7 @@ class GateClient(GateClientBase):
         channel_user_name: str,
         channel_room_id: str,
         message_id: str,
+        idempotency_key: str | None = None,
     ) -> GateResponse:
         """Send a message to a keeper via the gate with Discord context."""
         context = self._discord_context(
@@ -86,7 +87,7 @@ class GateClient(GateClientBase):
             keeper_name=keeper_name,
             content=content,
             context=context,
-            idempotency_key=f"discord-msg-{message_id}",
+            idempotency_key=idempotency_key or f"discord-msg-{message_id}",
         )
 
     async def stream_message(

--- a/sidecars/discord-bot/tests/test_bot_reaction_trigger.py
+++ b/sidecars/discord-bot/tests/test_bot_reaction_trigger.py
@@ -1,0 +1,164 @@
+"""Tests for Discord reaction trigger + busy hold + gap drain."""
+
+from __future__ import annotations
+
+import datetime
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.bot import GateBot
+from src.gate_client import GateResponse
+
+
+class _AsyncIter:
+    """Helper to mock discord.py history() async generator."""
+
+    def __init__(self, items: list[Any]) -> None:
+        self._items = items
+
+    def __aiter__(self) -> _AsyncIter:
+        return self
+
+    async def __anext__(self) -> Any:
+        if not self._items:
+            raise StopAsyncIteration
+        return self._items.pop(0)
+
+
+@pytest.fixture
+def bot() -> GateBot:
+    with (
+        patch("src.bot.GateClient") as mock_gate,
+        patch("src.bot.migrate_legacy_runtime_files"),
+        patch("src.bot.get_config") as mock_cfg,
+        patch("src.bot.BindingStore") as mock_bs,
+        patch("src.bot.BindingAuditStore"),
+        patch("src.bot.StatusStore"),
+        patch("src.bot.NamesStore"),
+    ):
+        cfg = MagicMock()
+        cfg.discord_bot_token = "test-token"
+        cfg.gate_base_url = "http://localhost:8935"
+        cfg.gate_api_token = ""
+        cfg.gate_origin.return_value = "http://localhost:8935"
+        cfg.gate_timeout_sec = 120
+        cfg.gate_breaker_failure_threshold = 3
+        cfg.gate_breaker_reset_sec = 30
+        cfg.status_cache_ttl_sec = 15
+        cfg.keeper_cache_ttl_sec = 30
+        cfg.discord_keeper_map = "{}"
+        cfg.discord_admin_role_id = ""
+        cfg.status_heartbeat_sec = 10
+        cfg.discord_reaction_trigger_emoji = "🤖"
+        cfg.discord_busy_debounce_sec = 0
+        cfg.discord_batch_max_messages = 50
+        cfg.discord_batch_gap_window_sec = 1800
+        cfg.keeper_map.return_value = {}
+        mock_cfg.return_value = cfg
+        # binding_store.load() returns None → keeper_map() path
+        mock_bs.return_value.load.return_value = None
+        mock_bs.return_value.modified_time_ns.return_value = 0
+        mock_gate_instance = MagicMock()
+        mock_gate.return_value = mock_gate_instance
+        instance = GateBot()
+        instance._pending = {}
+        instance._processing = {}
+        instance._last_response_ts = {}
+        instance.keeper_bindings = {}
+        yield instance
+
+
+@pytest.mark.asyncio
+async def test_drain_pending_calls_stream_when_history_has_messages(bot: GateBot) -> None:
+    """When history has messages, _drain_pending streams instead of send_message."""
+    channel = MagicMock()
+    channel.id = 42
+    channel.typing = MagicMock(return_value=AsyncMock(__aenter__=AsyncMock(return_value=None), __aexit__=AsyncMock(return_value=None)))
+    msg = MagicMock()
+    msg.id = 123
+    msg.content = "hello"
+    msg.author = MagicMock()
+    msg.author.id = 1
+    msg.author.bot = False
+    msg.author.display_name = "user#1"
+    # history() must return async iterable directly (not a coroutine)
+    channel.history = MagicMock(return_value=_AsyncIter([msg]))
+
+    bot.gate.stream_message = AsyncMock(return_value=_AsyncIter(["delta"]))
+    bot._stream_to_channel = AsyncMock(return_value=True)  # type: ignore[method-assign]
+
+    await bot._drain_pending(
+        channel=channel,
+        keeper_name="keeper-test",
+        trigger_msg_id=99,
+        trigger_user_id="1",
+        trigger_user_name="user#1",
+    )
+
+    bot._stream_to_channel.assert_awaited_once()
+    bot.gate.send_message.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_on_message_pends_when_processing_locked(bot: GateBot) -> None:
+    """When lock is held, on_message stores pending message instead of processing."""
+    import asyncio
+
+    bot._processing[42] = asyncio.Lock()
+    await bot._processing[42].acquire()
+
+    message = MagicMock()
+    message.author = MagicMock()
+    message.author.id = 1
+    message.author.bot = False
+    message.author.__str__ = MagicMock(return_value="user#1")
+    message.channel = MagicMock()
+    message.channel.id = 42
+    message.content = "hello"
+    message.id = 100
+    message.attachments = []
+    message.guild = MagicMock()
+
+    with patch.object(bot, "_resolve_keeper_for_channel", return_value="keeper-test"):
+        await bot.on_message(message)
+
+    assert 42 in bot._pending
+    assert len(bot._pending[42]) == 1
+    assert bot._pending[42][0][0] == 100
+    bot._processing[42].release()
+
+
+@pytest.mark.asyncio
+async def test_drain_pending_uses_idempotency_key_format(bot: GateBot) -> None:
+    """_drain_pending builds idempotency key as discord-batch-{msg_id}-{drain_count}."""
+    channel = MagicMock()
+    channel.id = 42
+    channel.typing = MagicMock(return_value=AsyncMock(__aenter__=AsyncMock(return_value=None), __aexit__=AsyncMock(return_value=None)))
+    msg = MagicMock()
+    msg.id = 200
+    msg.content = "hi"
+    msg.author = MagicMock()
+    msg.author.id = 2
+    msg.author.bot = False
+    msg.author.display_name = "tester"
+    channel.history = MagicMock(return_value=_AsyncIter([msg]))
+
+    bot.gate.send_message = AsyncMock(
+        return_value=GateResponse(ok=True, keeper_name="keeper-test", reply="ok", model_used="", duration_ms=0, tokens_used=0, error="", structured=None)
+    )
+    bot._send_response = AsyncMock()  # type: ignore[method-assign]
+    # stream returns False so send_message fallback is triggered
+    bot._stream_to_channel = AsyncMock(return_value=False)  # type: ignore[method-assign]
+
+    await bot._drain_pending(
+        channel=channel,
+        keeper_name="keeper-test",
+        trigger_msg_id=99,
+        trigger_user_id="1",
+        trigger_user_name="user#1",
+    )
+
+    call_kwargs = bot.gate.send_message.await_args.kwargs
+    assert call_kwargs["idempotency_key"] == "discord-batch-99-1"


### PR DESCRIPTION
- Fix ide-editor.ts compilation errors (annotations prop mismatch)
- Add regions/regionsLoading/loadRegions to code-document-store
- Add fetchIdeAnnotations + annotations signal to ide-data-coordinator
- Wire annotations from coordinator through ide-shell to IdeEditor
- Add fetchIdePresence API stub and /api/v1/ide/presence REST endpoint
- Add /api/v1/ide/presence/stream SSE endpoint
- Add ide:presence SSE handler in sse.ts
- Add globalPresenceSnapshot + updateKeeperPresenceFromSSE to keeper-presence-store
- Wire IdePresenceStrip to globalPresenceSnapshot
- Mock fetchIdeRegions in code-document-store.test.ts