### PR TITLE
feat(cascade): RFC-0058 TOML-only cascade config with thinking fields

### DIFF
--- a/config/cascade.json
+++ b/config/cascade.json
@@ -1,5 +1,20 @@
 {
   "_comment": "Checked-in seed for cascade authoring. Repo defaults expose exactly two profiles: big_three for keeper/workflow calls and tool_rerank for short rerank calls. Logical usage names are configured under [routes] instead of being profile names.",
+  "profiles": {
+    "tool_strict": {
+      "required_capabilities": [
+        "runtime_mcp_tools", "runtime_tool_events",
+        "runtime_mcp_http_headers"
+      ]
+    },
+    "inline_tools": {
+      "required_capabilities": [ "inline_tools", "inline_tool_choice" ]
+    },
+    "lite": {
+      "required_capabilities": [ "runtime_mcp_tools", "runtime_tool_events" ]
+    },
+    "local": { "required_capabilities": [] }
+  },
   "routes": {
     "keeper_turn": "big_three",
     "phase_recovery": "big_three",

--- a/docs/CASCADE-TOML.md
+++ b/docs/CASCADE-TOML.md
@@ -1,90 +1,325 @@
 # `cascade.toml` Manual
 
-Authoring guide for the checked-in cascade seed and live per-base-path config.
+Authoring guide for the cascade configuration. When `cascade.toml` exists, the
+runtime loads it directly into memory — no intermediate `cascade.json` is
+written to disk (TOML-only mode, RFC-0058).
 
 ## Start Here
 
 - Live config root: `$MASC_BASE_PATH/.masc/config/cascade.toml`
 - Repo seed/fallback: [`config/cascade.toml`](../config/cascade.toml)
-- Materialized runtime artifact: [`config/cascade.json`](../config/cascade.json)
+- If only `cascade.json` exists (legacy), it is read directly
 
-`config/cascade.toml` is the supported human-authored source when present. The
-runtime materializes sibling `cascade.json` before loading.
+`config/cascade.toml` is the supported human-authored source. The runtime
+parses TOML and converts to JSON in memory. No sibling `cascade.json` is
+needed or generated.
 
-## Checked-In Seed Policy
+## TOML-Only Mode (RFC-0058)
 
-The repo seed should stay intentionally small.
+When `cascade.toml` is present alongside `cascade.json`:
 
-- Keep the checked-in keeper-assignable set explicit and boring:
-  `big_three` for keeper/general turns.
-- Keep system-only lanes explicit and minimal: `tool_rerank` for short
-  rerank/scoring calls.
-- Put logical usages such as `governance_judge`, `operator_judge`,
-  `local_recovery`, `tool_use_strict`, `cross_verifier`, and `autoresearch`
-  under `[routes]`. They are route keys, not profile names.
-- Put personal experiments, vendor mixes, and machine-specific profiles in
-  live config under `$MASC_BASE_PATH/.masc/config/cascade.toml`, not in the
-  repo seed
+| Behavior | Description |
+|----------|-------------|
+| **TOML loaded in-memory** | TOML is parsed, converted to JSON string, fed to Yojson |
+| **JSON NOT written** | No `cascade.json` file is created or updated on disk |
+| **JSON left untouched** | If a stale JSON exists, it remains as-is |
+| **TOML is source of truth** | All edits go to TOML; JSON is ignored |
 
-This keeps bootstrap defaults reviewable and avoids turning repo config into a
-graveyard of personal cascade variants.
+Legacy `cascade.json`-only mode remains supported for backward compatibility.
 
-## Seed Profiles
+## TOML Schema Reference
 
-- `big_three`: canonical keeper/workflow profile.
-- `tool_rerank`: system-only short-output profile.
+### Top-Level Comment
 
-## Routes
+```toml
+comment = "Description of this configuration."
+```
 
-`[routes]` maps logical call-site names to concrete profiles:
+### `[profiles.<name>]` — Capability Profiles
+
+Declare named capability requirement sets. Used by profiles with
+`required_capability_profile = "<name>"` to filter models at load time.
+
+```toml
+[profiles.tool_strict]
+required_capabilities = [
+  "runtime_mcp_tools",
+  "runtime_tool_events",
+  "runtime_mcp_http_headers",
+]
+
+[profiles.inline_tools]
+required_capabilities = ["inline_tools", "inline_tool_choice"]
+
+[profiles.lite]
+required_capabilities = ["runtime_mcp_tools", "runtime_tool_events"]
+
+[profiles.local]
+required_capabilities = []
+```
+
+Valid capability names (must match `Cascade_capability_schema.known_capability_fields`):
+
+| Capability | Description |
+|-----------|-------------|
+| `runtime_mcp_tools` | Provider supports MCP tool calling at runtime |
+| `runtime_tool_events` | Provider emits tool use events |
+| `runtime_mcp_http_headers` | Provider passes MCP HTTP headers |
+| `inline_tools` | Provider supports inline tool definitions |
+| `inline_tool_choice` | Provider supports tool_choice parameter |
+
+### `[routes]` — Logical Route Mapping
+
+Maps logical call-site names to concrete cascade profiles.
 
 ```toml
 [routes]
+keeper_turn = "big_three"
+phase_recovery = "big_three"
+tool_required = "big_three"
 governance_judge = "big_three"
-operator_judge = "big_three"
-cross_verifier = "big_three"
 llm_rerank = "tool_rerank"
+simple_task = "tier_small"
+moderate_task = "tier_medium"
 ```
 
-Runtime code must use the logical route key and let config choose the concrete
-profile. Do not add a new checked-in profile just because one call site needs a
-name.
+Runtime code uses the logical route key; config chooses the concrete profile.
+Unknown route keys are rejected as config/code drift.
 
-The runtime validates `[routes]` against the code route registry. Unknown route
-keys are rejected as config/code drift, and route targets must name an active
-profile in the same catalog.
+### Cascade Profile Sections `[<name>]`
 
-Use `keeper_assignable = false` for profiles that must exist in the catalog but
-must not appear as normal keeper choices.
+Each cascade profile is a top-level TOML table. The table name becomes the
+profile name.
+
+```toml
+[my_profile]
+comment = "Description of this profile."
+models = [
+  "claude_code:auto",
+  "gemini_cli:auto",
+  { model = "glm-coding:auto", supports_tool_choice = true },
+]
+temperature = 0.2
+max_tokens = 16384
+keeper_assignable = true
+fallback_cascade = "other_profile"
+```
+
+#### All Allowed Fields
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `comment` | string | — | Human-readable description; stored as `_comment_<name>` in JSON |
+| `models` | array | `[]` | Model list. Entries: `"provider:model"` or `{ model = "...", weight = N, supports_tool_choice = bool }` |
+| `temperature` | float | — | Sampling temperature |
+| `max_tokens` | int | — | Maximum output tokens |
+| `thinking_enabled` | bool | `false` | Enable extended thinking |
+| `thinking_budget` | int | — | Token budget for thinking (when `thinking_enabled = true`) |
+| `keeper_assignable` | bool | `false` | Whether keepers can be assigned to this profile |
+| `strategy` | string | `"failover"` | Cascade strategy: `failover`, `weighted_random`, `priority_tier`, etc. |
+| `fallback_cascade` | string | — | Profile name to fall back to when all models exhausted |
+| `required_capability_profile` | string | — | Name from `[profiles]` for capability filtering |
+| `max_cycles` | int | — | Maximum retry cycles |
+| `backoff_base_ms` | int | — | Exponential backoff base in milliseconds |
+| `backoff_cap_ms` | int | — | Backoff cap in milliseconds |
+| `ollama_max_concurrent` | int | — | Max concurrent Ollama requests |
+| `cli_max_concurrent` | int | — | Max concurrent CLI provider requests |
+| `sticky_ttl_ms` | int | — | Sticky model selection TTL |
+| `num_ctx` | int | — | Ollama context window size |
+| `latency_baseline_ms` | float | — | Baseline latency for priority calculations |
+| `rate_limit_skip_after` | int | — | Skip model after N rate-limit errors |
+| `rate_limit_recency_window_s` | float | — | Rate-limit error recency window |
+| `rate_limit_decay_base` | float | — | Rate-limit decay factor |
+| `server_error_skip_after` | int | — | Skip model after N server errors |
+| `server_error_recency_window_s` | float | — | Server error recency window |
+| `server_error_decay_base` | float | — | Server error decay factor |
+| `tiers` | array of arrays | — | Priority tier groups: `[["model_a"], ["model_b", "model_c"]]` |
+| `api_key_env` | string or table | — | API key environment variable or `{ provider = "env_var" }` |
+| `keep_alive` | string | — | Ollama keep_alive duration (e.g., `"5m"`, `"24h"`) |
+| `timeout_sec` | float | — | **Legacy** — accepted but ignored. Use runtime timeout knobs. |
+
+Unknown fields cause a load error. This is intentional: typos and stale fields
+are caught at config load time, not at runtime.
+
+### Model Entry Formats
+
+```toml
+# Simple string
+models = ["claude_code:auto", "gemini_cli:gemini-3-flash-preview"]
+
+# Extended with weight (for weighted_random strategy)
+models = [
+  { model = "claude_code:auto", weight = 3 },
+  { model = "gemini_cli:auto", weight = 1 },
+]
+
+# Extended with tool choice support flag
+models = [
+  { model = "glm-coding:auto", supports_tool_choice = true },
+]
+
+# Combined
+models = [
+  "claude_code:auto",
+  { model = "glm-coding:auto", supports_tool_choice = true, weight = 2 },
+]
+```
+
+## Checked-In Seed Policy
+
+The repo seed stays intentionally small.
+
+- Keeper-assignable set: `big_three` for general turns.
+- System-only lanes: `tool_rerank` for short rerank/scoring calls.
+- Logical usages (`governance_judge`, `cross_verifier`, etc.) go under
+  `[routes]` — they are route keys, not profile names.
+- Personal experiments and machine-specific profiles go in live config
+  (`$MASC_BASE_PATH/.masc/config/cascade.toml`), not the repo seed.
 
 ## Edit Workflow
 
 1. Edit [`config/cascade.toml`](../config/cascade.toml).
-2. Materialize the runtime artifact:
+2. Run focused checks:
+
+```bash
+dune runtest --root . test/test_cascade_toml_materialization.exe
+dune runtest --root . test/test_cascade_phase1_smoke.exe
+dune exec --root . ./test/test_keeper_cascade_profile.exe
+```
+
+Optionally verify JSON output:
 
 ```bash
 dune exec --root . ./bin/cascade_materialize.exe -- config/cascade.json
 ```
 
-The materializer takes the runtime JSON path/candidate and uses sibling
-`cascade.toml` when present.
+## Examples
 
-3. Run focused checks:
+### Minimal Profile
 
-```bash
-dune runtest --root . test/test_cascade_config_validity.exe
-dune exec --root . ./test/test_keeper_cascade_profile.exe
+```toml
+[my_local]
+models = ["ollama:qwen3:8b"]
+temperature = 0.7
+max_tokens = 2000
+keeper_assignable = false
 ```
 
-## What Belongs In Repo vs Live Config
+### Profile with Thinking
 
-Add a checked-in profile only when at least one of these is true:
+```toml
+[reasoning]
+models = ["claude_code:claude-sonnet-4-6"]
+temperature = 1.0
+max_tokens = 32768
+thinking_enabled = true
+thinking_budget = 16000
+keeper_assignable = true
+fallback_cascade = "big_three"
+```
 
-- a checked-in keeper depends on it
-- the profile has materially different model/parameter behavior from the two
-  defaults
+### Weighted Random Strategy
 
-Otherwise, put it in live config or a private/local cookbook-derived setup.
+```toml
+[diverse_sampling]
+models = [
+  { model = "claude_code:auto", weight = 3 },
+  { model = "gemini_cli:auto", weight = 2 },
+  { model = "codex_cli:gpt-5.3-codex-spark", weight = 1 },
+]
+temperature = 0.5
+max_tokens = 4096
+strategy = "weighted_random"
+keeper_assignable = true
+```
+
+### Tiered Priority
+
+```toml
+[tiered_cascade]
+models = [
+  "claude_code:claude-sonnet-4-6",
+  "gemini_cli:gemini-3-flash-preview",
+  "ollama:qwen3:8b",
+]
+temperature = 0.3
+max_tokens = 8192
+strategy = "priority_tier"
+tiers = [
+  ["claude_code:claude-sonnet-4-6"],
+  ["gemini_cli:gemini-3-flash-preview"],
+  ["ollama:qwen3:8b"],
+]
+keeper_assignable = false
+```
+
+### Capability-Filtered Profile
+
+```toml
+[profiles.my_strict]
+required_capabilities = ["runtime_mcp_tools", "runtime_mcp_http_headers"]
+
+[cloud_tools]
+models = ["claude_code:auto", "kimi_cli:kimi-for-coding"]
+temperature = 0.2
+max_tokens = 16384
+required_capability_profile = "my_strict"
+keeper_assignable = true
+```
+
+### Fallback Chain
+
+```toml
+[primary]
+models = ["claude_code:auto", "gemini_cli:auto"]
+temperature = 0.2
+max_tokens = 16384
+fallback_cascade = "secondary"
+
+[secondary]
+models = ["codex_cli:gpt-5.3-codex-spark", "kimi_cli:kimi-for-coding"]
+temperature = 0.3
+max_tokens = 8192
+fallback_cascade = "big_three"
+```
+
+### Local-Only with Keep Alive
+
+```toml
+[local_fast]
+models = ["ollama:qwen3:8b", "ollama:phi-3-mini"]
+temperature = 0.5
+max_tokens = 1000
+ollama_max_concurrent = 2
+keep_alive = "5m"
+num_ctx = 8192
+keeper_assignable = false
+```
+
+### Route Mapping with Tier Fallback
+
+```toml
+[routes]
+keeper_turn = "tier_fast"
+simple_task = "tier_small"
+moderate_task = "tier_medium"
+complex_task = "big_three"
+llm_rerank = "tool_rerank"
+
+[tier_small]
+models = ["ollama:qwen3:8b"]
+temperature = 0.3
+max_tokens = 1000
+keeper_assignable = false
+fallback_cascade = "tier_medium"
+
+[tier_medium]
+models = ["glm-coding:glm-4.7-flashx"]
+temperature = 0.2
+max_tokens = 4096
+keeper_assignable = false
+fallback_cascade = "big_three"
+```
 
 ## Related Docs
 

--- a/lib/cascade/cascade_config_loader.ml
+++ b/lib/cascade/cascade_config_loader.ml
@@ -66,64 +66,84 @@ let read_json_file path =
   in
   Yojson.Safe.from_string content
 
+let load_toml_in_memory config_path =
+  match Cascade_toml_materializer.render_toml_to_json_string ~config_path with
+  | Error msg -> Error msg
+  | Ok (source, json_string) ->
+    let mtime = (Unix.stat source.source_path).Unix.st_mtime in
+    let cache_key = source.source_path in
+    (match with_cache_lock (fun () ->
+          match Hashtbl.find_opt config_cache cache_key with
+          | Some (cached_mtime, _) when Float.equal cached_mtime mtime ->
+            `Cache_hit
+          | _ -> `Cache_miss)
+     with
+     | `Cache_hit ->
+       Ok (Yojson.Safe.from_string json_string)
+     | `Cache_miss ->
+       let json = Yojson.Safe.from_string json_string in
+       with_cache_lock (fun () ->
+           Hashtbl.replace config_cache cache_key (mtime, json));
+       Eio.traceln
+         "[CascadeConfig] loaded TOML %s mtime=%.0f (in-memory)"
+         source.source_path mtime;
+       Ok json)
+
 let load_json path =
-  let rec load_current () =
-    let mtime = (Unix.stat path).Unix.st_mtime in
-    match with_cache_lock (fun () ->
-        match Hashtbl.find_opt config_cache path with
-        | Some (cached_mtime, json) when Float.equal cached_mtime mtime ->
-          Some json
-        | _ -> None)
-    with
-    | Some json -> Ok json
-    | None ->
-      let json = read_json_file path in
-      let refreshed_mtime = (Unix.stat path).Unix.st_mtime in
-      if not (Float.equal refreshed_mtime mtime) then
-        load_current ()
-      else
-        (* Keep the critical section to Hashtbl access only. Any Eio-aware
-           work (traceln in particular) must run OUTSIDE the Stdlib.Mutex
-           because traceln can suspend the fiber while the lock is held,
-           blocking unrelated fibers on the domain.
-           Ref: memory/feedback_eio-traceln-outside-critical-section.md *)
-        let outcome =
-          with_cache_lock (fun () ->
-              match Hashtbl.find_opt config_cache path with
-              | Some (cached_mtime, cached_json)
-                when Float.equal cached_mtime refreshed_mtime ->
-                `Returning_cached cached_json
-              | prior ->
-                Hashtbl.replace config_cache path (refreshed_mtime, json);
-                `Installed_new (Option.map fst prior))
-        in
-        (match outcome with
-         | `Returning_cached cached_json -> Ok cached_json
-         | `Installed_new prior_mtime ->
-             (* Observability: trace first-load vs reload so operators
-                editing cascade.json can verify their change took effect.
-                Keeping this at traceln (stderr) matches existing OAS
-                convention (see Cascade_config.apply_provider_filter). *)
-             (match prior_mtime with
-              | None ->
-                  Eio.traceln
-                    "[CascadeConfig] loaded %s mtime=%.0f"
-                    path refreshed_mtime
-              | Some old_mtime ->
-                  Eio.traceln
-                    "[CascadeConfig] reloaded %s old_mtime=%.0f new_mtime=%.0f"
-                    path old_mtime refreshed_mtime);
-             Ok json)
-  in
-  match ensure_materialized_json path with
-  | Error _ as err -> err
-  | Ok () ->
-      (try load_current () with
-       | Sys_error msg -> Error msg
-       | Unix.Unix_error (err, fn, arg) ->
-           Error (Printf.sprintf "%s(%s): %s" fn arg (Unix.error_message err))
-       | Yojson.Json_error msg -> Error (Printf.sprintf "JSON error: %s" msg)
-       | End_of_file -> Error "unexpected end of file")
+  let source = Cascade_toml_materializer.source_info ~config_path:path in
+  match source.kind with
+  | Cascade_toml_materializer.Toml ->
+    (try load_toml_in_memory path with
+     | Sys_error msg -> Error msg
+     | Unix.Unix_error (err, fn, arg) ->
+         Error (Printf.sprintf "%s(%s): %s" fn arg (Unix.error_message err))
+     | Yojson.Json_error msg -> Error (Printf.sprintf "JSON error: %s" msg))
+  | Cascade_toml_materializer.Json ->
+    let rec load_current () =
+      let mtime = (Unix.stat path).Unix.st_mtime in
+      match with_cache_lock (fun () ->
+          match Hashtbl.find_opt config_cache path with
+          | Some (cached_mtime, json) when Float.equal cached_mtime mtime ->
+            Some json
+          | _ -> None)
+      with
+      | Some json -> Ok json
+      | None ->
+        let json = read_json_file path in
+        let refreshed_mtime = (Unix.stat path).Unix.st_mtime in
+        if not (Float.equal refreshed_mtime mtime) then
+          load_current ()
+        else
+          let outcome =
+            with_cache_lock (fun () ->
+                match Hashtbl.find_opt config_cache path with
+                | Some (cached_mtime, cached_json)
+                  when Float.equal cached_mtime refreshed_mtime ->
+                  `Returning_cached cached_json
+                | prior ->
+                  Hashtbl.replace config_cache path (refreshed_mtime, json);
+                  `Installed_new (Option.map fst prior))
+          in
+          (match outcome with
+           | `Returning_cached cached_json -> Ok cached_json
+           | `Installed_new prior_mtime ->
+               (match prior_mtime with
+                | None ->
+                    Eio.traceln
+                      "[CascadeConfig] loaded %s mtime=%.0f"
+                      path refreshed_mtime
+                | Some old_mtime ->
+                    Eio.traceln
+                      "[CascadeConfig] reloaded %s old_mtime=%.0f new_mtime=%.0f"
+                      path old_mtime refreshed_mtime);
+               Ok json)
+    in
+    (try load_current () with
+     | Sys_error msg -> Error msg
+     | Unix.Unix_error (err, fn, arg) ->
+         Error (Printf.sprintf "%s(%s): %s" fn arg (Unix.error_message err))
+     | Yojson.Json_error msg -> Error (Printf.sprintf "JSON error: %s" msg)
+     | End_of_file -> Error "unexpected end of file")
 
 (** A model entry with an optional weight for weighted cascade selection.
     Weight defaults to 1 when not specified (backward compatible).

--- a/lib/cascade/cascade_toml_materializer.ml
+++ b/lib/cascade/cascade_toml_materializer.ml
@@ -635,6 +635,19 @@ let toml_section_names_result ~config_path =
       with
       | Sys_error msg -> Error msg)
 
+let render_toml_to_json_string ~config_path =
+  let source = source_info ~config_path in
+  match source.kind with
+  | Json -> Error "render_toml_to_json_string: source is JSON, not TOML"
+  | Toml -> (
+      match render_toml_file_to_json_string source.source_path with
+      | Ok json -> Ok (source, json)
+      | Error msg ->
+          Error
+            (Printf.sprintf
+               "failed to materialize from %s: %s"
+               source.source_path msg))
+
 let ensure_materialized_json ~config_path =
   let source = source_info ~config_path in
   match source.kind with

--- a/lib/cascade/cascade_toml_materializer.ml
+++ b/lib/cascade/cascade_toml_materializer.ml
@@ -420,7 +420,8 @@ let profile_field_json ~profile_name ~field_name field_value =
   | "sticky_ttl_ms"
   | "num_ctx"
   | "rate_limit_skip_after"
-  | "server_error_skip_after" -> (
+  | "server_error_skip_after"
+  | "thinking_budget" -> (
       match int_value ~path:profile_path field_value with
       | Ok value -> Ok [ (profile_name ^ "_" ^ field_name, `Int value) ]
       | Error _ as err -> err)
@@ -459,10 +460,11 @@ let profile_field_json ~profile_name ~field_name field_value =
       | Ok value ->
           Ok [ (profile_name ^ "_required_capability_profile", `String value) ]
       | Error _ as err -> err)
-  | "keeper_assignable" -> (
+  | "keeper_assignable"
+  | "thinking_enabled" -> (
       match bool_value ~path:profile_path field_value with
       | Ok value ->
-          Ok [ (profile_name ^ "_keeper_assignable", `Bool value) ]
+          Ok [ (profile_name ^ "_" ^ field_name, `Bool value) ]
       | Error _ as err -> err)
   | "tiers" -> (
       match string_matrix_value ~path:profile_path field_value with
@@ -505,7 +507,7 @@ let profile_field_json ~profile_name ~field_name field_value =
             profile_path (toml_type_name field_value))
   | other ->
       errorf
-        "unknown field %S in profile %s; allowed fields are comment, models, temperature, max_tokens, strategy, max_cycles, backoff_base_ms, backoff_cap_ms, ollama_max_concurrent, cli_max_concurrent, tiers, sticky_ttl_ms, latency_baseline_ms, rate_limit_recency_window_s, rate_limit_decay_base, rate_limit_skip_after, server_error_recency_window_s, server_error_decay_base, server_error_skip_after, keeper_assignable, fallback_cascade, required_capability_profile, api_key_env, keep_alive, num_ctx, timeout_sec, groups"
+        "unknown field %S in profile %s; allowed fields are comment, models, temperature, max_tokens, strategy, max_cycles, backoff_base_ms, backoff_cap_ms, ollama_max_concurrent, cli_max_concurrent, tiers, sticky_ttl_ms, latency_baseline_ms, rate_limit_recency_window_s, rate_limit_decay_base, rate_limit_skip_after, server_error_recency_window_s, server_error_decay_base, server_error_skip_after, keeper_assignable, thinking_enabled, thinking_budget, fallback_cascade, required_capability_profile, api_key_env, keep_alive, num_ctx, timeout_sec, groups"
         other profile_name
 
 let profile_table_json_fields ~profile_name value =

--- a/lib/cascade/cascade_toml_materializer.mli
+++ b/lib/cascade/cascade_toml_materializer.mli
@@ -83,6 +83,13 @@ val toml_section_names_result :
 
 (** {1 Materialisation} *)
 
+val render_toml_to_json_string :
+  config_path:string -> (source_info * string, string) result
+(** Render the TOML source into a JSON string without writing to disk.
+    Returns the {!source_info} and the rendered JSON string.
+    [Error] when the source is JSON-only or rendering fails.
+    This is the TOML-only entry point that skips the JSON file entirely. *)
+
 val ensure_materialized_json :
   config_path:string -> (materialize_result, string) result
 (** Idempotent: when the source is TOML and the rendered JSON

--- a/test/test_cascade_toml_materialization.ml
+++ b/test/test_cascade_toml_materialization.ml
@@ -450,9 +450,9 @@ let test_runtime_materializes_missing_json_on_load () =
   with_config_dir config_dir @@ fun () ->
   match Masc_mcp.Cascade_catalog_runtime.inspect_active () with
   | Ok (Masc_mcp.Cascade_catalog_runtime.Validated _) ->
-      check bool "json materialized on load" true (Sys.file_exists json_path);
-      check bool "generated json contains profile key" true
-        (contains_substring (read_file json_path) "big_three_models")
+      (* TOML-only mode: no JSON file written to disk *)
+      check bool "json NOT materialized in TOML-only mode" false
+        (Sys.file_exists json_path)
   | Ok _ -> fail "expected fully validated catalog"
   | Error rejection ->
       failf "unexpected validation failure: %s"
@@ -466,12 +466,19 @@ let test_runtime_rewrites_drifted_json_from_toml () =
   let toml_path = Filename.concat config_dir "cascade.toml" in
   let json_path = Filename.concat config_dir "cascade.json" in
   write_file toml_path minimal_toml;
-  write_file json_path {|{"alpha_models":["ollama:qwen3.5:35b-a3b-nvfp4"]}|};
-  let expected_json = render_or_fail toml_path in
+  let stale_json = {|{"alpha_models":["ollama:qwen3.5:35b-a3b-nvfp4"]}|} in
+  write_file json_path stale_json;
   with_config_dir config_dir @@ fun () ->
-  ignore (Masc_mcp.Cascade_catalog_runtime.inspect_active ());
-  check string "drifted runtime json rewritten from toml"
-    expected_json (read_file json_path)
+  match Masc_mcp.Cascade_catalog_runtime.inspect_active () with
+  | Ok (Masc_mcp.Cascade_catalog_runtime.Validated _) ->
+      (* TOML-only mode: stale JSON left untouched on disk, TOML loaded in-memory *)
+      check string "stale json NOT rewritten in TOML-only mode"
+        stale_json (read_file json_path)
+  | Ok _ -> fail "expected fully validated catalog"
+  | Error rejection ->
+      failf "unexpected validation failure: %s"
+        (Yojson.Safe.to_string
+           (Masc_mcp.Cascade_catalog_runtime.rejection_to_yojson rejection))
 
 let test_invalid_toml_blocks_runtime_without_using_stale_json () =
   with_temp_dir "cascade-toml-invalid" @@ fun dir ->


### PR DESCRIPTION
## Summary

- Add `thinking_enabled` (bool) and `thinking_budget` (int) fields to TOML materializer whitelist
- Add `render_toml_to_json_string` entry point for TOML-only in-memory loading
- Rewrite `cascade_config_loader.load_json` to branch on source kind: TOML sources load in-memory without writing JSON to disk; JSON-only sources continue using existing file-based path
- Update runtime materialization tests to verify TOML-only behavior (no JSON disk writes)
- `ensure_materialized_json` preserved for dashboard consumers

## Test plan

- [x] `dune build --root .` passes
- [x] 22/22 materialization tests pass (including updated TOML-only runtime tests)
- [x] 5/5 Phase 1 smoke tests pass
- [x] Capability profile tests pass
- [ ] Manual: start server with TOML-only config, verify no `cascade.json` generated

🤖 Generated with [Claude Code](https://claude.com/claude-code)