### PR TITLE
feat(discord-sidecar): reaction trigger + lock-based busy-hold + gap drain

### DIFF
--- a/sidecars/discord-bot/src/config.py
+++ b/sidecars/discord-bot/src/config.py
@@ -151,13 +151,6 @@ class BotConfig(BaseSettings):
             "discord_reaction_trigger_emoji",
         ),
     )
-    discord_busy_debounce_sec: int = Field(
-        default=0,
-        validation_alias=AliasChoices(
-            "DISCORD_BUSY_DEBOUNCE_SEC",
-            "discord_busy_debounce_sec",
-        ),
-    )
     discord_batch_max_messages: int = Field(
         default=50,
         validation_alias=AliasChoices(
@@ -216,13 +209,6 @@ class BotConfig(BaseSettings):
         validation_alias=AliasChoices(
             "DISCORD_REACTION_TRIGGER_EMOJI",
             "discord_reaction_trigger_emoji",
-        ),
-    )
-    discord_busy_debounce_sec: int = Field(
-        default=0,
-        validation_alias=AliasChoices(
-            "DISCORD_BUSY_DEBOUNCE_SEC",
-            "discord_busy_debounce_sec",
         ),
     )
     discord_batch_max_messages: int = Field(
@@ -302,7 +288,6 @@ class BotConfig(BaseSettings):
         "gate_breaker_failure_threshold",
         "gate_breaker_reset_sec",
         "status_heartbeat_sec",
-        "discord_busy_debounce_sec",
         "discord_batch_max_messages",
         "discord_batch_gap_window_sec",
     )

--- a/sidecars/discord-bot/tests/test_bot_reaction_trigger.py
+++ b/sidecars/discord-bot/tests/test_bot_reaction_trigger.py
@@ -52,7 +52,6 @@ def bot() -> GateBot:
         cfg.discord_admin_role_id = ""
         cfg.status_heartbeat_sec = 10
         cfg.discord_reaction_trigger_emoji = "🤖"
-        cfg.discord_busy_debounce_sec = 0
         cfg.discord_batch_max_messages = 50
         cfg.discord_batch_gap_window_sec = 1800
         cfg.keeper_map.return_value = {}


### PR DESCRIPTION
## Summary

- `on_raw_reaction_add`: emoji reaction이 설정된 `DISCORD_REACTION_TRIGGER_EMOJI`와 일치하면 keeper turn 발동
- Lock-based busy-hold: 응답 진행 중(`asyncio.Lock` 보유 시) 들어오는 메시지를 `_pending` 큐에 보관
- `_drain_pending`: lock 해제 후 채널 히스토리를 배치 조회하여 누락된 컨텍스트 포함 스트리밍 또는 `send_message` fallback
- idempotency key: `discord-batch-{trigger_msg_id}-{drain_count}` 형식으로 중복 keeper turn 방지
- `discord_busy_debounce_sec` 제거: 시스템은 이진 lock 기반이므로 debounce(시간 윈도우 억제) 개념이 잘못됨

## New config fields

| 필드 | 기본값 | 설명 |
|------|--------|------|
| `DISCORD_REACTION_TRIGGER_EMOJI` | `""` (비활성) | 트리거 이모지 |
| `DISCORD_BATCH_MAX_MESSAGES` | `50` | 배치 최대 메시지 수 |
| `DISCORD_BATCH_GAP_WINDOW_SEC` | `1800` | 갭 조회 윈도우(초) |

## Test plan

- [x] `test_drain_pending_calls_stream_when_history_has_messages`
- [x] `test_on_message_pends_when_processing_locked`
- [x] `test_drain_pending_uses_idempotency_key_format`
- [x] 전체 40 tests 통과

RFC-WAIVED: Discord sidecar bot UX extension, no credential/identity/operator/sandbox subsystem touched.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
