### PR TITLE
fix(gate): harden agent_name sanitizer + expand filesystem_safe tests

### DIFF
--- a/lib/gate_keeper_backend.ml
+++ b/lib/gate_keeper_backend.ml
@@ -76,9 +76,9 @@ let filesystem_safe_or_unknown value =
 
 let agent_name_for_channel_actor ~channel ~channel_room_id ~channel_user_id =
   Printf.sprintf "gate:%s:%s:%s"
-    (normalized_or_unknown channel)
-    (normalized_or_unknown channel_room_id)
-    (normalized_or_unknown channel_user_id)
+    (filesystem_safe_or_unknown channel)
+    (filesystem_safe_or_unknown channel_room_id)
+    (filesystem_safe_or_unknown channel_user_id)
 
 let contextualize_message ~channel ~channel_user_id ~channel_user_name
     ~channel_room_id ~content =

--- a/test/test_gate_keeper_backend.ml
+++ b/test/test_gate_keeper_backend.ml
@@ -103,6 +103,64 @@ let test_filesystem_safe_all_special_to_unknown () =
   let result = Gate_keeper_backend.filesystem_safe_or_unknown "@@@!!!" in
   check string "all special becomes unknown" "unknown" result
 
+let test_filesystem_safe_whitespace_only () =
+  let result = Gate_keeper_backend.filesystem_safe_or_unknown "   " in
+  check string "whitespace only becomes unknown" "unknown" result
+
+let test_filesystem_safe_with_spaces () =
+  let result = Gate_keeper_backend.filesystem_safe_or_unknown "my channel" in
+  check string "spaces replaced with underscore" "my_channel" result
+
+let test_filesystem_safe_with_dots () =
+  let result = Gate_keeper_backend.filesystem_safe_or_unknown "channel.name" in
+  check string "dots replaced with underscore" "channel_name" result
+
+let test_filesystem_safe_newline_and_tab () =
+  let result =
+    Gate_keeper_backend.filesystem_safe_or_unknown
+      ("chan" ^ "\n" ^ "nel" ^ "\t" ^ "name")
+  in
+  check string "newline and tab replaced" "chan_nel_name" result
+
+let test_filesystem_safe_underscore_only () =
+  let result = Gate_keeper_backend.filesystem_safe_or_unknown "___" in
+  check string "underscore only becomes unknown" "unknown" result
+
+let test_filesystem_safe_mixed_safe_unsafe () =
+  let result = Gate_keeper_backend.filesystem_safe_or_unknown "a-b.c/d e" in
+  check string "mixed safe and unsafe chars" "a-b_c_d_e" result
+
+(* ── Agent name security ──────────────────────────────────────────── *)
+
+let test_agent_name_blocks_path_traversal () =
+  let agent_name =
+    Gate_keeper_backend.agent_name_for_channel_actor
+      ~channel:"../etc"
+      ~channel_room_id:"../../../tmp"
+      ~channel_user_id:"attack"
+  in
+  let has_slash = String.contains agent_name '/' in
+  let has_dot = String.contains agent_name '.' in
+  check bool "no slash in agent name" false has_slash;
+  check bool "no dot in agent name" false has_dot
+
+let test_agent_name_normal_values_unchanged () =
+  let agent_name =
+    Gate_keeper_backend.agent_name_for_channel_actor
+      ~channel:"discord" ~channel_room_id:"123" ~channel_user_id:"456"
+  in
+  check string "normal values pass through" "gate:discord:123:456" agent_name
+
+let test_agent_name_special_chars_sanitized () =
+  let agent_name =
+    Gate_keeper_backend.agent_name_for_channel_actor
+      ~channel:"my chan"
+      ~channel_room_id:"thread#1"
+      ~channel_user_id:"user@2"
+  in
+  check string "special chars become underscore"
+    "gate:my_chan:thread_1:user_2" agent_name
+
 (* ── Response parsing ────────────────────────────────────────────── *)
 
 let test_extract_reply_from_reply_field () =
@@ -161,6 +219,27 @@ let () =
             test_filesystem_safe_empty_to_unknown;
           test_case "all special becomes unknown" `Quick
             test_filesystem_safe_all_special_to_unknown;
+          test_case "whitespace only becomes unknown" `Quick
+            test_filesystem_safe_whitespace_only;
+          test_case "spaces replaced with underscore" `Quick
+            test_filesystem_safe_with_spaces;
+          test_case "dots replaced with underscore" `Quick
+            test_filesystem_safe_with_dots;
+          test_case "newline and tab replaced" `Quick
+            test_filesystem_safe_newline_and_tab;
+          test_case "underscore only becomes unknown" `Quick
+            test_filesystem_safe_underscore_only;
+          test_case "mixed safe and unsafe chars" `Quick
+            test_filesystem_safe_mixed_safe_unsafe;
+        ] );
+      ( "agent_name_security",
+        [
+          test_case "blocks path traversal" `Quick
+            test_agent_name_blocks_path_traversal;
+          test_case "normal values unchanged" `Quick
+            test_agent_name_normal_values_unchanged;
+          test_case "special chars sanitized" `Quick
+            test_agent_name_special_chars_sanitized;
         ] );
       ( "response_parsing",
         [


### PR DESCRIPTION
## Summary

- Replace `normalized_or_unknown` with `filesystem_safe_or_unknown` in `agent_name_for_channel_actor` — the former only strips newlines/tabs, allowing path traversal characters (`/`, `..`) through agent names that become filesystem path components
- Add 9 test cases: 6 for `filesystem_safe_or_unknown` edge cases (whitespace-only, dots, newlines/tabs, underscore-only, mixed safe/unsafe), 3 for `agent_name` security (path traversal blocking, normal passthrough, special char sanitization)

## Why

`agent_name_for_channel_actor` generated identifiers like `gate:discord:room-9:user-42` that flow into `Tool_keeper.context.agent_name` → `resolve_playground_working_dir` → filesystem paths. While downstream `sanitize_keeper_name` provides defense-in-depth, the upstream sanitizer was the weaker `normalized_or_unknown` which permits `/` and `.` characters. Using the strict sanitizer at both layers eliminates the single point of failure.

`normalized_or_unknown` is still used by `contextualize_message` (intentional — log output preserves readable text).

## Test plan

- [x] 6 new `filesystem_safe` edge case tests (whitespace-only → unknown, spaces → underscore, dots → underscore, newlines → underscore, underscore-only → unknown, mixed)
- [x] 3 new `agent_name_security` tests (path traversal blocked, normal values unchanged, special chars sanitized)
- [x] All 15 existing tests pass unchanged (Discord numeric IDs are already safe characters)
- [ ] `rg "normalized_or_unknown" lib/gate_keeper_backend.ml` confirms only `contextualize_message` uses it (intentional)

🤖 Generated with [Claude Code](https://claude.com/claude-code)