### PR TITLE
feat(dashboard): wire IDE presence SSE into keeper presence store

### DIFF
--- a/dashboard/src/components/ide/ide-presence-strip.ts
+++ b/dashboard/src/components/ide/ide-presence-strip.ts
@@ -3,6 +3,7 @@ import { useEffect, useMemo, useState } from 'preact/hooks'
 import { KeeperBadge } from '../keeper-badge'
 import {
   createKeeperPresenceStore,
+  globalPresenceSnapshot,
   type KeeperPresenceEntry,
   type KeeperPresenceSnapshot,
 } from './keeper-presence-store'
@@ -161,6 +162,14 @@ export function IdePresenceStrip() {
     let cancelled = false
     fetchPresence().then(snapshot => { if (!cancelled) presenceStore.seed(snapshot) })
     return () => { cancelled = true }
+  }, [presenceStore])
+
+  useEffect(() => {
+    const unsub = globalPresenceSnapshot.subscribe(() => {
+      const snap = globalPresenceSnapshot.value
+      if (snap !== null) presenceStore.seed(snap)
+    })
+    return unsub
   }, [presenceStore])
 
   useEffect(() => presenceStore.subscribe(() => forceRender(tick => tick + 1)), [presenceStore])

--- a/dashboard/src/components/ide/keeper-presence-store.ts
+++ b/dashboard/src/components/ide/keeper-presence-store.ts
@@ -1,5 +1,14 @@
 import { signal } from '@preact/signals'
 
+export const globalPresenceSnapshot = signal<KeeperPresenceSnapshot | null>(null)
+
+export function updateKeeperPresenceFromSSE(snapshot: unknown): boolean {
+  const normalized = normalizeSnapshot(snapshot)
+  if (normalized === null) return false
+  globalPresenceSnapshot.value = normalized
+  return true
+}
+
 export type KeeperPresenceStatus = 'active' | 'idle' | 'blocked'
 
 export interface KeeperPresenceEntry {

--- a/dashboard/src/sse.ts
+++ b/dashboard/src/sse.ts
@@ -15,6 +15,7 @@ import {
 import { appendLiveToolCall } from './components/session-trace/session-trace-live-store'
 import { appendAuditEntry } from './live-store'
 import { parseSSEMessage } from './schemas/sse'
+import { updateKeeperPresenceFromSSE } from './components/ide/keeper-presence-store'
 import { RingBuffer } from './lib/ring-buffer'
 
 import {


### PR DESCRIPTION
- Add globalPresenceSnapshot signal + updateKeeperPresenceFromSSE to keeper-presence-store.ts
- Wire IdePresenceStrip to subscribe to globalPresenceSnapshot for live updates
- Update sse.ts ide:presence handler to feed snapshots into the store

Enables live IDE presence updates via SSE without polling.