### PR TITLE
docs(compact): fix stale comments and remove duplicate mli declarations

### DIFF
--- a/lib/context_compact_oas.ml
+++ b/lib/context_compact_oas.ml
@@ -254,7 +254,7 @@ let oas_strategy_of (s : strategy) : Agent_sdk.Context_reducer.t =
     MASC's Dynamic takes a {i world-state} observation (context ratio,
     active agent count, model family, task topology) and returns a
     {i composed} list of MASC strategies.  Each strategy is then mapped
-    to an OAS [Custom] closure and applied in sequence.
+    to an OAS built-in reducer and applied in sequence.
 
     {2 Why both exist}
 
@@ -268,7 +268,7 @@ let oas_strategy_of (s : strategy) : Agent_sdk.Context_reducer.t =
     - MASC Dynamic: per-keeper-turn, strategy list, before [compact]
 
     MASC Dynamic resolves to concrete MASC strategies, which are then
-    mapped to OAS [Custom] closures.  OAS Dynamic is not called.
+    mapped to OAS built-in reducers.  OAS Dynamic is not called.
     The two do not interact at runtime. *)
 
 (* ================================================================ *)

--- a/lib/context_compact_oas.mli
+++ b/lib/context_compact_oas.mli
@@ -13,10 +13,10 @@
     role weights, tool-presence weights, [anchor_boost],
     [drop_importance_threshold], [summarize_keep_recent]),
     \[tool_output_prune_limit\] env constant, 4 dynamic-context
-    thresholds, [first_sentence] / [tool_names_by_id] /
-    [summarize_chunk] / [mask_tool_*] /
-    [oas_strategy_of] / [summarize_old_messages] helpers — all
-    consumed only inside {!compact}'s pipeline. *)
+    thresholds, [first_sentence] / [summarize_chunk] /
+    [extractive_summarizer] / [score_message] / [score_messages] /
+    [oas_strategy_of] helpers — all consumed only inside
+    {!compact}'s pipeline. *)
 
 (** {1 Observation context} *)
 
@@ -149,17 +149,3 @@ val score_message :
     [0.0, 1.0].  Pinned for behaviour-tests and for injecting into
     OAS {!Agent_sdk.Context_reducer.importance_scored}. *)
 
-val score_messages :
-  Agent_sdk.Types.message list -> (int * float) list
-(** [score_messages msgs] returns
-    [(message_index, importance_score)] pairs for the input
-    message list.  Importance combines recency (quadratic ramp
-    over the message list) with role / tool weights.  Pinned for
-    behaviour-tests under {!test/test_context_compact_oas_coverage}. *)
-
-val small_local_ctx_floor : int
-(** [small_local_ctx_floor] is the env-driven context-window
-    floor (read once at module init) below which a local-model
-    keeper is treated as "small local" by
-    {!default_dynamic_selector}.  Pinned for behaviour-tests
-    under {!test/test_context_compact_oas_coverage}. *)


### PR DESCRIPTION
## Summary
`/simplify` Phase 3 follow-up for #14465:

- `.mli` 내부 문서: 삭제된 helper(`tool_names_by_id`, `mask_tool_*`, `summarize_old_messages`) 참조를 현재 helper(`extractive_summarizer`, `score_message`)로 교체.
- `.mli` 중복 선언 제거: `score_messages`와 `small_local_ctx_floor`가 두 번 선언되어 있었음.
- `.ml` 주석 업데이트: Phase C 리팩토링 이후 여전히 "OAS [Custom] closures"로 남아 있던 문구를 "OAS built-in reducers"로 수정.

## 변경 파일
- `lib/context_compact_oas.ml` (2줄 주석)
- `lib/context_compact_oas.mli` (14줄 삭제, 4줄 수정)

## 검증
- 기능 변경 없음 (주석 + 중복 선언 제거만).
- `context_compact_oas` 관련 빌드 에러/경고 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)