### PR TITLE
fix(build): resolve OCaml compilation errors on main branch

### DIFF
--- a/lib/keeper/keeper_exec_shared.ml
+++ b/lib/keeper/keeper_exec_shared.ml
@@ -536,7 +536,8 @@ let keeper_tools_list_json ~(meta : keeper_meta) =
     | Tool_name.Keeper.Fs_edit | Tool_name.Keeper.Fs_read | Tool_name.Keeper.Write -> "fs"
     | Tool_name.Keeper.Library_read
     | Tool_name.Keeper.Library_search
-    | Tool_name.Keeper.Memory_search -> "memory"
+    | Tool_name.Keeper.Memory_search
+    | Tool_name.Keeper.Memory_write -> "memory"
     | Tool_name.Keeper.Broadcast | Tool_name.Keeper.Handoff -> "coordination"
     | Tool_name.Keeper.Pr_create
     | Tool_name.Keeper.Pr_list

--- a/lib/keeper/keeper_exec_tools.ml
+++ b/lib/keeper/keeper_exec_tools.ml
@@ -427,14 +427,14 @@ let execute_keeper_tool_call_with_outcome
            (Keeper_exec_fs.handle_keeper_fs_read
               ~turn_sandbox_factory
               ~config
-              ~meta
+              ~keeper_name:meta.name
               ~args)
        | "keeper_fs_edit" ->
          make_executed_tool_result
            (Keeper_exec_fs.handle_keeper_fs_edit
               ~turn_sandbox_factory
               ~config
-              ~meta
+              ~keeper_name:meta.name
               ~args)
        | "keeper_bash" ->
          make_executed_tool_result
@@ -506,7 +506,7 @@ let execute_keeper_tool_call_with_outcome
            (Keeper_exec_task.handle_keeper_task_tool ~config ~meta ~name ~args)
        | other ->
          (match
-            Keeper_exec_masc.handle_registered_keeper_tool ~config ~meta ~name:other ~args
+            Keeper_exec_masc.handle_registered_keeper_tool ~config ~keeper_name:meta.name ~name:other ~args
           with
           | Some raw_output -> make_executed_tool_result raw_output
           | None ->

--- a/lib/server/server_ide_http.ml
+++ b/lib/server/server_ide_http.ml
@@ -203,7 +203,8 @@ let add_routes router =
         request reqd)
     router2
   in
-  Http.Router.get "/api/v1/ide/regions" (fun request reqd ->
+  let router4 =
+    Http.Router.get "/api/v1/ide/regions" (fun request reqd ->
     with_public_read
       (fun state _req reqd ->
         let uri = Uri.of_string request.target in
@@ -233,19 +234,20 @@ let add_routes router =
       request reqd)
     router3
   in
-  Http.Router.get "/api/v1/ide/presence" (fun request reqd ->
-    with_public_read
-      (fun state _req reqd ->
-        let snapshot = build_presence_snapshot state in
-        Http.Response.json ~compress:true ~request:request
-          (Yojson.Safe.to_string (json_ok snapshot)) reqd)
-      request reqd)
+  let router5 =
+    Http.Router.get "/api/v1/ide/presence" (fun request reqd ->
+      with_public_read
+        (fun state _req reqd ->
+          let snapshot = build_presence_snapshot state in
+          Http.Response.json ~compress:true ~request:request
+            (Yojson.Safe.to_string (json_ok snapshot)) reqd)
+        request reqd)
     router4
   in
   Http.Router.get "/api/v1/ide/presence/stream" (fun request reqd ->
     with_public_read
       (fun state _req inner_reqd ->
-        let origin = Server_utils.get_origin request in
+        let origin = get_origin request in
         let headers =
           Httpun.Headers.of_list
             ([
@@ -254,7 +256,7 @@ let add_routes router =
                ("connection", "keep-alive");
                ("x-accel-buffering", "no");
              ]
-             @ Server_utils.cors_headers origin)
+             @ cors_headers origin)
         in
         let response = Httpun.Response.create ~headers `OK in
         let writer = Httpun.Reqd.respond_with_streaming inner_reqd response in

--- a/lib/tool_catalog.ml
+++ b/lib/tool_catalog.ml
@@ -457,6 +457,8 @@ let inferred_effect_domain_of_typed_tool_name = function
   | TN.Keeper TK.Fs_edit
   | TN.Keeper TK.Write ->
       Some Playground_write
+  | TN.Keeper TK.Memory_write ->
+      Some Masc_coordination
   | TN.Keeper TK.Board_cleanup
   | TN.Keeper TK.Board_comment
   | TN.Keeper TK.Board_comment_vote
@@ -627,7 +629,7 @@ let tool_group_of_typed_tool_name = function
       | TK.Board_stats
       | TK.Board_vote ) ->
       Some Board
-  | TN.Keeper (TK.Memory_search | TK.Library_read | TK.Library_search) ->
+  | TN.Keeper (TK.Memory_search | TK.Memory_write | TK.Library_read | TK.Library_search) ->
       Some Knowledge
   | TN.Keeper
       ( TK.Task_claim

--- a/test/stanzas/test_keeper_memory_write.inc
+++ b/test/stanzas/test_keeper_memory_write.inc
@@ -6,4 +6,4 @@
 (test
  (name test_keeper_memory_write)
  (modules test_keeper_memory_write)
- (libraries masc_test_deps alcotest))
+ (libraries masc_test_deps masc_mcp alcotest))

--- a/test/test_keeper_memory_write.ml
+++ b/test/test_keeper_memory_write.ml
@@ -15,6 +15,8 @@
     pure-validation pin here plus the helper-mapping pin is sufficient
     coverage for the new code paths. *)
 
+module Keeper_exec_memory = Masc_mcp.Keeper_exec_memory
+
 (* --- helpers ------------------------------------------------------- *)
 
 let make_args ~kind ~title ~content : Yojson.Safe.t =


### PR DESCRIPTION
## Summary

Fixes 6 OCaml compilation errors on main branch that cause `dune build @check` to fail.

### Changes

- **server_ide_http.ml**: add missing `let router4 =` / `let router5 =` bindings around `regions` and `presence` endpoints; restore accidentally dropped `Http.Router.get` for `/api/v1/ide/presence`; fix `Server_utils.get_origin` → `get_origin` and `Server_utils.cors_headers` → `cors_headers` (both live in `Server_auth`, already opened).
- **keeper_exec_tools.ml**: align `~meta` label with `~keeper_name:meta.name` for `handle_keeper_fs_read`, `handle_keeper_fs_edit`, and `handle_registered_keeper_tool`.
- **tool_catalog.ml**: add `Memory_write` to `inferred_effect_domain_of_typed_tool_name` (`Masc_coordination`) and `tool_group_of_typed_tool_name` (`Knowledge`).
- **keeper_exec_shared.ml**: add `Memory_write -> \"memory\"` category mapping.
- **test/stanzas/test_keeper_memory_write.inc**: add `masc_mcp` to `(libraries ...)` so the test can resolve `Keeper_exec_memory`.
- **test/test_keeper_memory_write.ml**: add `module Keeper_exec_memory = Masc_mcp.Keeper_exec_memory` alias (wrapped library requires namespaced access).

### Verification

- `dune build --root . @check` passes with zero errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)