### PR TITLE
refactor(dashboard): reduce panel density across runtime-monitor, fleet-telemetry, cascade-config

### DIFF
--- a/dashboard/src/components/cascade-config-panel.ts
+++ b/dashboard/src/components/cascade-config-panel.ts
@@ -902,7 +902,7 @@ function SloCard({ slo }: { slo: CascadeSloResponse }) {
           ? html`<span class="text-xs text-[var(--bad-light)]">violating: ${slo.violations.join(', ')}</span>`
           : null}
       </div>
-      <div class="grid grid-cols-3 gap-3">
+      <div class="grid grid-cols-1 gap-3 md:grid-cols-2">
         <${StatCell}
           label="정렬 비율"
           value=${`${ratioPct}%`}
@@ -1274,7 +1274,7 @@ export function CascadeConfigPanel() {
               )
               return html`
                 <${CascadeValidationBanner} config=${config} />
-                <div class="grid grid-cols-3 gap-3 mb-3">
+                <div class="grid grid-cols-1 gap-3 md:grid-cols-2 mb-3">
                   <${StatCell}
                     label="프로파일"
                     value=${config.profiles.length}
@@ -1322,7 +1322,7 @@ export function CascadeConfigPanel() {
       <${Card} title="헬스 트래커">
         ${health
           ? html`
-            <div class="grid grid-cols-3 gap-3 mb-3">
+            <div class="grid grid-cols-1 gap-3 md:grid-cols-2 mb-3">
               <${StatCell}
                 label="윈도우"
                 value=${`${health.window_sec}s`}

--- a/dashboard/src/components/fleet-telemetry-panel.ts
+++ b/dashboard/src/components/fleet-telemetry-panel.ts
@@ -742,7 +742,7 @@ export function FleetTelemetryPanel() {
 
       <${WarningBanner} warnings=${value.warnings} />
 
-      <div class="grid grid-cols-1 gap-3 md:grid-cols-2 xl:grid-cols-5">
+      <div class="grid grid-cols-1 gap-3 md:grid-cols-2">
         <${SummaryCard}
           title="키퍼 가동률"
           value=${`${counts.live}/${value.rows.length || 0}`}
@@ -755,6 +755,9 @@ export function FleetTelemetryPanel() {
           detail=${counts.stale > 0 ? `${counts.stale}개 키퍼가 ${Math.round(STALE_ACTIVITY_SEC / 60)}분 이상 정체 중입니다.` : '정체된 키퍼가 활동 임계값을 넘기지 않았습니다.'}
           tone=${toneForPressure(counts.hot, counts.warn)}
         />
+      </div>
+
+      <div class="grid grid-cols-1 gap-3 md:grid-cols-3">
         <${SummaryCard}
           title="차단된 키퍼"
           value=${counts.blocked.toString()}

--- a/dashboard/src/components/runtime-monitor.ts
+++ b/dashboard/src/components/runtime-monitor.ts
@@ -17,6 +17,7 @@ import { Select } from './common/select'
 import { StatTile } from './common/stat-tile'
 import { StatusChip } from './common/status-chip'
 import { TextInput } from './common/input'
+import { Table, type TableColumn } from './common/table'
 import type { ManagedAsyncResource } from '../lib/async-state'
 import { useManagedAsyncResource } from '../lib/use-managed-async-resource'
 import { formatCost, formatNumber, formatPct1 } from '../lib/format-number'
@@ -288,6 +289,34 @@ function recentEntryDetail(
   ].filter((value): value is string => Boolean(value))
   return parts.length > 0 ? parts.join(' · ') : null
 }
+
+type RecentEntry = NonNullable<DashboardRuntimeModelMetric['recent_entries']>[number]
+
+const recentEntryColumns: TableColumn<RecentEntry>[] = [
+  {
+    key: 'time',
+    header: 'time',
+    render: (re) => {
+      const detail = recentEntryDetail(re)
+      return html`
+        <div>
+          <div>${re.ts_unix > 0 ? formatTimeHms(re.ts_unix) : '--'}</div>
+          ${detail ? html`<div class="text-3xs text-[var(--color-fg-muted)] mt-0.5">${detail}</div>` : null}
+        </div>
+      `
+    },
+  },
+  { key: 'input_tokens', header: 'in tok', render: (re) => fmtRecentEntryNumber(re, re.input_tokens) },
+  { key: 'output_tokens', header: 'out tok', render: (re) => fmtRecentEntryNumber(re, re.output_tokens) },
+  {
+    key: 'latency_ms',
+    header: 'latency',
+    render: (re) => re.latency_ms == null ? recentEntryMissingLabel(re) : `${formatNumber(re.latency_ms, 0)}ms`,
+  },
+  { key: 'prompt_tok_per_sec', header: 'prefill tok/s', render: (re) => fmtRecentEntryNumber(re, re.prompt_tok_per_sec, 1) },
+  { key: 'cost_usd', header: 'cost', render: (re) => fmtRecentEntryCost(re, re.cost_usd) },
+  { key: 'tools_count', header: 'tools', render: (re) => String(re.tools_count) },
+]
 
 function metricCoverageText(metric: DashboardRuntimeModelMetric): string | null {
   if (metric.coverage_status === 'full' && metric.primary_coverage_reason == null) return null
@@ -579,28 +608,11 @@ export function RuntimeMonitor() {
                       </button>
                       ${expandedModel.value === metric.model_id
                         ? html`<div class="mt-1 border-t border-card-border/50 pt-2">
-                            <div class="grid grid-cols-7 gap-1 text-3xs text-[var(--color-fg-muted)] font-medium mb-1">
-                              <div>time</div><div>in tok</div><div>out tok</div><div>latency</div><div>prefill tok/s</div><div>cost</div><div>tools</div>
-                            </div>
-                            ${metric.recent_entries?.map(re => {
-                              const detail = recentEntryDetail(re)
-                              return html`
-                                <div class="mb-1">
-                                  <div class="grid grid-cols-7 gap-1 text-2xs text-[var(--color-fg-primary)]">
-                                    <div>${re.ts_unix > 0 ? formatTimeHms(re.ts_unix) : '--'}</div>
-                                    <div>${fmtRecentEntryNumber(re, re.input_tokens)}</div>
-                                    <div>${fmtRecentEntryNumber(re, re.output_tokens)}</div>
-                                    <div>${re.latency_ms == null ? recentEntryMissingLabel(re) : `${formatNumber(re.latency_ms, 0)}ms`}</div>
-                                    <div>${fmtRecentEntryNumber(re, re.prompt_tok_per_sec, 1)}</div>
-                                    <div>${fmtRecentEntryCost(re, re.cost_usd)}</div>
-                                    <div>${re.tools_count}</div>
-                                  </div>
-                                  ${detail
-                                    ? html`<div class="text-3xs text-[var(--color-fg-muted)]">${detail}</div>`
-                                    : null}
-                                </div>
-                              `
-                            })}
+                            <${Table}
+                              columns=${recentEntryColumns}
+                              rows=${metric.recent_entries ?? []}
+                              getRowId=${(re: RecentEntry) => `${metric.model_id}-${re.ts_unix}`}
+                            />
                           </div>`
                         : null}
                     `


### PR DESCRIPTION
## Summary
밀도 높은 grid 레이아웃을 점진적 공개(progressive disclosure) 친화적 패턴으로 전환합니다.

- `runtime-monitor.ts`: `grid-cols-7` 최근 항목 수동 그리드 → `Table` 컴포넌트
- `fleet-telemetry-panel.ts`: `xl:grid-cols-5` 요약 카드 → 2단 분할 레이아웃
- `cascade-config-panel.ts`: 3× `grid-cols-3` 통계 섹션 → `grid-cols-1 md:grid-cols-2`

## 검증
- `runtime-monitor.test.ts`: 17 passed
- `fleet-telemetry-panel.test.ts`: 21 passed
- `cascade-config-panel.test.ts`: 전용 테스트 파일 없음

## Test plan
- [ ] Dashboard에서 런타임 모니터 확장 시 Table 렌더링 확인
- [ ] Fleet Telemetry 요약 카드 2단 배치 확인
- [ ] Cascade Config SLO/Profile/Health 섹션 반응형 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)