### PR TITLE
feat(ide): wire selectedTask goal_id and task_id into annotation fetch

### DIFF
--- a/dashboard/src/components/ide/ide-data-coordinator.ts
+++ b/dashboard/src/components/ide/ide-data-coordinator.ts
@@ -1,6 +1,7 @@
 import { signal, effect } from '@preact/signals'
 import { activeIdeFile } from './ide-shell'
 import { activeKeeperName } from '../../keeper-state'
+import { selectedTask } from '../goals/task-detail-selection'
 import {
   discoverRepositories,
   fetchRepositoriesList,
@@ -143,6 +144,7 @@ export function createIdeDataCoordinator(): IdeDataCoordinator {
     const filePath = activeIdeFile.value
     const keeper = activeKeeperName.value
     const repoId = activeRepositoryIdSignal.value
+    const task = selectedTask.value
 
     // Cancel in-flight requests for previous file
     abortController.abort()
@@ -203,7 +205,7 @@ export function createIdeDataCoordinator(): IdeDataCoordinator {
     }).catch(() => {})
 
     // Load annotations
-    fetchIdeAnnotations({ file_path: filePath }, opts).then(annotations => {
+    fetchIdeAnnotations({ file_path: filePath, goal_id: task?.goal_id ?? undefined, task_id: task?.id ?? undefined }, opts).then(annotations => {
       if (signal.aborted) return
       annotationsSignal.value = annotations
     }).catch(() => {})


### PR DESCRIPTION
- Subscribe to selectedTask in IdeDataCoordinator effect\n- Pass goal_id and task_id to fetchIdeAnnotations when a task is selected\n- Enables goal/task-scoped annotation filtering in the IDE