### PR TITLE
fix(ide): expose hearth in board API, prefer hearth over text heuristic for conversation kind

### DIFF
--- a/dashboard/src/components/ide/ide-conversation-rail-mock.ts
+++ b/dashboard/src/components/ide/ide-conversation-rail-mock.ts
@@ -96,6 +96,15 @@ function unixishToMs(ts: number | null): number {
 }
 
 function boardKindFromPost(post: BoardPost): ThreadKind {
+  if (post.hearth) {
+    switch (post.hearth.toLowerCase()) {
+      case 'approve': return 'approve'
+      case 'flag': return 'flag'
+      case 'question': return 'question'
+      case 'suggest': return 'suggest'
+      case 'note': return 'note'
+    }
+  }
   const body = (post.body ?? '').toLowerCase()
   const title = (post.title ?? '').toLowerCase()
   const text = `${title} ${body}`

--- a/lib/server/server_utils.ml
+++ b/lib/server/server_utils.ml
@@ -336,6 +336,7 @@ let board_post_dashboard_json ?(include_moderation = false)
           ("comment_count", `Int p.reply_count);
           ("created_at_iso", `String (iso8601_of_unix p.created_at));
           ("updated_at_iso", `String (iso8601_of_unix p.updated_at));
+          ("hearth", match p.hearth with Some h -> `String h | None -> `Null);
           ("hearth_count", `Int (match p.hearth with Some _ -> 1 | None -> 0));
           ("author_identity", board_actor_identity_json author);
         ]


### PR DESCRIPTION
- Add 'hearth' field to board_post_dashboard_json response\n- Update boardKindFromPost to check hearth before falling back to text heuristic\n- Reduces fake hardcoding in IdeConversationRailMock