### PR TITLE
refactor(tool): RFC-0062 Phase 2 — typed dispatch returns (bool * string) → Tool_result.t

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -87,7 +87,6 @@
    keeper_exec_task
    keeper_exec_voice
    keeper_exec_masc
-   keeper_exec_memory
    keeper_exec_tools
   keeper_exec_status_metrics
   keeper_exec_status

--- a/lib/keeper/keeper_exec_masc.ml
+++ b/lib/keeper/keeper_exec_masc.ml
@@ -17,8 +17,9 @@ let handle_keeper_autoresearch_tool
     }
   in
   match Tool_autoresearch.dispatch ctx ~name ~args with
-  | Some (true, msg) -> msg
-  | Some (false, msg) -> error_json msg
+  | Some result ->
+      if result.success then Tool_result.message result
+      else error_json (Tool_result.message result)
   | None -> error_json ~fields:[ "tool", `String name ] "unknown_autoresearch_tool"
 ;;
 
@@ -184,8 +185,10 @@ let handle_keeper_masc_tool
                     ~name
                     ~args
                 with
-                | Some (true, msg) -> msg
-                | Some (false, msg) -> error_json msg
+                | Some tr when tr.Tool_result.success ->
+                  tr.Tool_result.legacy_message
+                | Some tr ->
+                  error_json tr.Tool_result.legacy_message
                 | None ->
                   Yojson.Safe.to_string
                     (`Assoc

--- a/lib/keeper/keeper_exec_shared.ml
+++ b/lib/keeper/keeper_exec_shared.ml
@@ -494,7 +494,7 @@ let tag_dispatch_fn
      -> tag:Tool_dispatch.module_tag
      -> name:string
      -> args:Yojson.Safe.t
-     -> (bool * string) option)
+     -> Tool_result.t option)
       ref
   =
   ref (fun ~config:_ ~agent_name:_ ~tag:_ ~name:_ ~args:_ -> None)
@@ -536,7 +536,8 @@ let keeper_tools_list_json ~(meta : keeper_meta) =
     | Tool_name.Keeper.Fs_edit | Tool_name.Keeper.Fs_read | Tool_name.Keeper.Write -> "fs"
     | Tool_name.Keeper.Library_read
     | Tool_name.Keeper.Library_search
-    | Tool_name.Keeper.Memory_search -> "memory"
+    | Tool_name.Keeper.Memory_search
+    | Tool_name.Keeper.Memory_write -> "memory"
     | Tool_name.Keeper.Broadcast | Tool_name.Keeper.Handoff -> "coordination"
     | Tool_name.Keeper.Pr_create
     | Tool_name.Keeper.Pr_list

--- a/lib/keeper/keeper_exec_shared.mli
+++ b/lib/keeper/keeper_exec_shared.mli
@@ -167,7 +167,7 @@ val tag_dispatch_fn
      -> tag:Tool_dispatch.module_tag
      -> name:string
      -> args:Yojson.Safe.t
-     -> (bool * string) option)
+     -> Tool_result.t option)
       ref
 
 (** Issue #10349 Phase 2: registry-canonical meta lookup.

--- a/lib/keeper/keeper_exec_tools.ml
+++ b/lib/keeper/keeper_exec_tools.ml
@@ -427,14 +427,14 @@ let execute_keeper_tool_call_with_outcome
            (Keeper_exec_fs.handle_keeper_fs_read
               ~turn_sandbox_factory
               ~config
-              ~meta
+              ~keeper_name:meta.name
               ~args)
        | "keeper_fs_edit" ->
          make_executed_tool_result
            (Keeper_exec_fs.handle_keeper_fs_edit
               ~turn_sandbox_factory
               ~config
-              ~meta
+              ~keeper_name:meta.name
               ~args)
        | "keeper_bash" ->
          make_executed_tool_result
@@ -506,7 +506,7 @@ let execute_keeper_tool_call_with_outcome
            (Keeper_exec_task.handle_keeper_task_tool ~config ~meta ~name ~args)
        | other ->
          (match
-            Keeper_exec_masc.handle_registered_keeper_tool ~config ~meta ~name:other ~args
+            Keeper_exec_masc.handle_registered_keeper_tool ~config ~keeper_name:meta.name ~name:other ~args
           with
           | Some raw_output -> make_executed_tool_result raw_output
           | None ->

--- a/lib/keeper/keeper_tag_dispatch.ml
+++ b/lib/keeper/keeper_tag_dispatch.ml
@@ -47,7 +47,7 @@ let get_fs_opt () = Fs_compat.get_fs_opt ()
     @param name     Tool name
     @param args     Tool arguments JSON
 
-    Returns [Some (success, message)] or [None] if module dispatch
+    Returns [Some result] or [None] if module dispatch
     does not recognize the tool name (should not happen when tag is correct). *)
 let dispatch
     ~(config : Coord.config)
@@ -55,8 +55,11 @@ let dispatch
     ~(tag : Tool_dispatch.module_tag)
     ~(name : string)
     ~(args : Yojson.Safe.t)
-  : (bool * string) option =
-  (* Wrap dispatch in try-catch to normalize exceptions into error tuples.
+  : Tool_result.t option =
+  let start_time = Time_compat.now () in
+  let ok msg = Tool_result.ok ~tool_name:name ~start_time msg in
+  let err msg = Tool_result.error ~tool_name:name ~start_time msg in
+  (* Wrap dispatch in try-catch to normalize exceptions into error results.
      Tool_*.dispatch functions may raise on unexpected JSON shapes or
      backend failures. Without this, exceptions escape to the keeper loop
      and may crash the agent turn. *)
@@ -69,6 +72,8 @@ let dispatch
   | Mod_local_runtime ->
       Tool_local_runtime.dispatch { Tool_local_runtime.config; agent_name }
         ~name ~args
+      |> Option.map (fun (success, message) ->
+        if success then ok message else err message)
   | Mod_worktree ->
       Tool_worktree.dispatch { Tool_worktree.config; agent_name } ~name ~args
   | Mod_code ->
@@ -76,27 +81,22 @@ let dispatch
   | Mod_code_write ->
       Tool_code_write.dispatch { Tool_code_write.config; agent_name }
         ~name ~args
-  (* Mod_auth removed: tools pruned *)
   | Mod_run ->
       Tool_run.dispatch { Tool_run.config } ~name ~args
   | Mod_agent ->
-      (* Review #4579: Mod_agent includes masc_agent_update, masc_register_capabilities etc.
-         Tool_agent.dispatch already validates per-tool; keeper agent_name is passed so
-         self-mutation is gated by the module's own checks. Observation-only tools
-         (masc_get_metrics) are safe. *)
       Tool_agent.dispatch { Tool_agent.config; agent_name } ~name ~args
+      |> Option.map (fun (success, message) ->
+        if success then ok message else err message)
   | Mod_room ->
       Tool_coord.dispatch { Tool_coord.config; agent_name } ~name ~args
-      |> Option.map (fun { Coord_types.success; message } -> (success, message))
+      |> Option.map (fun { Coord_types.success; message } ->
+        if success then ok message else err message)
   | Mod_control ->
-      (* masc_pause_status is read-only — safe for keeper dispatch.
-         masc_pause/masc_resume modify room lifecycle — blocked. *)
       if name = "masc_pause_status" then
         Tool_control.dispatch { Tool_control.config; agent_name } ~name ~args
       else
-        Some (false,
-          Printf.sprintf
-            "tool '%s' is blocked in keeper context (lifecycle-mutating Mod_control tools are operator-only)" name)
+        Some (err (Printf.sprintf
+          "tool '%s' is blocked in keeper context (lifecycle-mutating Mod_control tools are operator-only)" name))
   | Mod_agent_timeline ->
       Tool_agent_timeline.dispatch { Tool_agent_timeline.config; agent_name }
         ~name ~args
@@ -105,18 +105,19 @@ let dispatch
   | Mod_suspend ->
       Tool_suspend.dispatch { Tool_suspend.config; caller_agent = Some agent_name }
         ~name ~args
+      |> Option.map (fun (success, message) ->
+        if success then ok message else err message)
   | Mod_library ->
       Tool_library.dispatch { Tool_library.agent_name } ~name ~args
 
   (* ── Tier A special: Tool_shard returns Yojson.Safe.t ──────── *)
 
   | Mod_shard ->
-      let (ok, json) = Tool_shard.execute name args in
-      Some (ok, Yojson.Safe.to_string json)
+      let (success, json) = Tool_shard.execute name args in
+      let message = Yojson.Safe.to_string json in
+      Some (if success then ok message else err message)
 
   (* ── Tier B: Eio-dependent ─────────────────────────────────── *)
-
-  (* Mod_heartbeat removed: tools pruned *)
 
   | Mod_task ->
       Tool_task.dispatch
@@ -124,27 +125,15 @@ let dispatch
           sw = Eio_context.get_switch_opt () }
         ~name ~args
 
-  (* Mod_handover, Mod_repair_loop removed: tools pruned *)
-
   | Mod_keeper ->
-      (* Tool_keeper depends on Keeper_exec_status — dispatching it here
-         creates a dependency cycle. Keeper already handles keeper_* tools
-         inline; masc_keeper_* tools route through the MCP server path. *)
-      Some (false,
-        Printf.sprintf
-          "tool '%s' is a keeper management tool (use MCP client)" name)
+      Some (err (Printf.sprintf
+        "tool '%s' is a keeper management tool (use MCP client)" name))
 
   | Mod_operator ->
-      (* Operator control was retired from the keeper front door.
-         Keepers stay on the OAS Agent.run path only. *)
-      Some (false,
-        Printf.sprintf
-          "tool '%s' belongs to the removed operator surface; keeper runtime stays on OAS Agent.run" name)
+      Some (err (Printf.sprintf
+        "tool '%s' belongs to the removed operator surface; keeper runtime stays on OAS Agent.run" name))
 
   | Mod_autoresearch ->
-      (* Registered keeper dispatch handles autoresearch explicitly when
-         possible. This fallback still provides a minimal context for tools
-         that reach the generic tag dispatcher. *)
       let ctx : Tool_autoresearch.context =
         {
           base_path = config.base_path;
@@ -155,40 +144,29 @@ let dispatch
           clock = Eio_context.get_clock_opt ();
         }
       in
-      Tool_autoresearch.dispatch
-        ctx ~name ~args
+      Tool_autoresearch.dispatch ctx ~name ~args
 
   (* ── Tier C: MCP-state-dependent ───────────────────────────── *)
 
   | Mod_inline when String.equal name "masc_approval_pending" ->
       let json = Keeper_approval_queue.list_pending_json () in
-      Some (true, Yojson.Safe.to_string json)
+      Some (ok (Yojson.Safe.to_string json))
 
   | Mod_inline ->
-      (* Handler registry catches masc_board_* before we reach here.
-         masc_approval_pending is handled above as a keeper-safe inline read.
-         Remaining Mod_inline tools need full MCP session context
-         (registry, state, SSE callbacks) that keepers do not have.
-         Return actionable error. *)
-      Some (false,
-        Printf.sprintf
-          "tool '%s' requires MCP session context (not available in keeper)" name)
+      Some (err (Printf.sprintf
+        "tool '%s' requires MCP session context (not available in keeper)" name))
 
   (* ── Tier D: Cycle-breaking — modules that back-reference Keeper_exec_* *)
 
   | Mod_compact ->
-      (* Tool_compact depends on Keeper_exec_context. *)
-      Some (false,
-        Printf.sprintf
-          "tool '%s' is an internal context tool (use MCP client)" name)
+      Some (err (Printf.sprintf
+        "tool '%s' is an internal context tool (use MCP client)" name))
 
   with
   | Eio.Cancel.Cancelled _ as e -> raise e
   | exn ->
       let exn_type =
         let raw = Printexc.to_string exn in
-        (* Sanitize: expose exception type but not internal paths/details
-           that may leak server internals to tool callers. *)
         match String.index_opt raw '(' with
         | Some i -> String.sub raw 0 i
         | None -> if String.length raw > 80 then String.sub raw 0 80 else raw
@@ -199,5 +177,4 @@ let dispatch
         ();
       Log.Keeper.warn "tag dispatch exception for %s: %s"
         name (Printexc.to_string exn);
-      Some (false,
-        Printf.sprintf "keeper dispatch error for %s: %s" name exn_type)
+      Some (err (Printf.sprintf "keeper dispatch error for %s: %s" name exn_type))

--- a/lib/keeper/keeper_tag_dispatch.mli
+++ b/lib/keeper/keeper_tag_dispatch.mli
@@ -33,4 +33,4 @@ val dispatch :
   tag:Tool_dispatch.module_tag ->
   name:string ->
   args:Yojson.Safe.t ->
-  (bool * string) option
+  Tool_result.t option

--- a/lib/mcp_server_eio_call_tool.ml
+++ b/lib/mcp_server_eio_call_tool.ml
@@ -28,8 +28,34 @@ let contains_casefold haystack needle =
 
 (* Failure classification delegates to [Tool_result] — the SSOT closed-sum
    type with compiler-enforced exhaustive handling at every match site.
-   See {!Tool_result.tool_failure_class} for the 4 constructors and
-   {!Tool_result.classify_from_dispatch_failure} for the heuristic. *)
+   See {!Tool_result.tool_failure_class} for the 4 constructors.
+
+   Local heuristic for classifying failure messages at the MCP protocol
+   level where only the message string is available (not a [Tool_result.t]).
+   Mirrors the logic that was in [Tool_result.classify_from_dispatch_failure]
+   before it was made internal in Phase 2. *)
+let classify_failure_message (message : string) : Tool_result.tool_failure_class =
+  if contains_casefold message "awaiting_approval"
+     || contains_casefold message "join required"
+  then Tool_result.Workflow_rejection
+  else if
+    contains_casefold message "egress_blocked"
+    || contains_casefold message "path_outside_sandbox"
+  then Tool_result.Policy_rejection
+  else if contains_casefold message "Tool timed out" then
+    Tool_result.Runtime_failure
+  else if
+    contains_casefold message "timeout"
+    || contains_casefold message "temporary"
+    || contains_casefold message "temporarily"
+    || contains_casefold message "econn"
+    || contains_casefold message "connection"
+    || contains_casefold message "unavailable"
+    || contains_casefold message "rate limit"
+    || contains_casefold message "502"
+    || contains_casefold message "503"
+  then Tool_result.Transient_error
+  else Tool_result.Runtime_failure
 
 let parse_status_from_message ~success ~message =
   if not success then
@@ -444,7 +470,7 @@ let read_only_retry_limit () =
   Env_config.Tools.readonly_retry_limit
 
 let is_retryable_failure message =
-  Tool_result.is_retryable (Tool_result.classify_from_dispatch_failure message)
+  Tool_result.is_retryable (classify_failure_message message)
 
 let read_only_retry_wait ~attempt =
   let attempt = float_of_int attempt in
@@ -718,7 +744,7 @@ let handle_call_tool_eio ~execute_tool_eio ~maybe_emit_resource_notifications
     ?trace_id:otel_trace_id ();
   if not success then (
     let failure_class =
-      Tool_result.classify_from_dispatch_failure
+      classify_failure_message
         (Option.value ~default:"" error_detail)
     in
     Log.Mcp.emit (Tool_result.log_level_of_failure_class failure_class)

--- a/lib/mcp_server_eio_execute.ml
+++ b/lib/mcp_server_eio_execute.ml
@@ -799,42 +799,53 @@ let execute_tool_eio ~sw ~clock ?(profile = Mcp_server_eio_tool_profile.Full)
     | (None, coerced_args) -> match tag with
     | Mod_plan ->
         Tool_plan.dispatch { config } ~name ~args:coerced_args
+        |> Option.map tuple_of_tool_result
     | Mod_operator ->
         let ctx = { Tool_operator.config; agent_name; sw; clock;
                     proc_mgr = state.Mcp_server.proc_mgr;
                     net = state.Mcp_server.net; mcp_session_id } in
         Tool_operator.dispatch ctx ~name ~args:coerced_args
+        |> Option.map tuple_of_tool_result
     | Mod_local_runtime ->
         Tool_local_runtime.dispatch { Tool_local_runtime.config; agent_name } ~name ~args:coerced_args
     | Mod_worktree ->
         Tool_worktree.dispatch { Tool_worktree.config; agent_name } ~name ~args:coerced_args
+        |> Option.map tuple_of_tool_result
     | Mod_code ->
         Tool_code.dispatch { Tool_code.config; agent_name } ~name ~args:coerced_args
+        |> Option.map tuple_of_tool_result
     | Mod_code_write ->
         Tool_code_write.dispatch { Tool_code_write.config; agent_name } ~name ~args:coerced_args
+        |> Option.map tuple_of_tool_result
     (* Mod_handover, Mod_heartbeat, Mod_auth removed: tools pruned *)
     | Mod_compact -> None
     | Mod_run ->
         Tool_run.dispatch { Tool_run.config } ~name ~args:coerced_args
+        |> Option.map tuple_of_tool_result
     | Mod_agent ->
         Tool_agent.dispatch { Tool_agent.config; agent_name } ~name ~args:coerced_args
     | Mod_task ->
         Tool_task.dispatch ?agent_tool_names:caller_tool_names
           { Tool_task.config; agent_name; sw = Some sw } ~name
           ~args:coerced_args
+        |> Option.map tuple_of_tool_result
     | Mod_room ->
         Tool_coord.dispatch { Tool_coord.config; agent_name } ~name ~args:coerced_args
         |> Option.map (fun { Coord_types.success; message } -> (success, message))
     | Mod_control ->
         Tool_control.dispatch { Tool_control.config; agent_name } ~name ~args:coerced_args
+        |> Option.map tuple_of_tool_result
     | Mod_agent_timeline ->
         Tool_agent_timeline.dispatch { Tool_agent_timeline.config; agent_name } ~name ~args:coerced_args
+        |> Option.map tuple_of_tool_result
     | Mod_misc ->
         Tool_misc.dispatch { Tool_misc.config; agent_name } ~name ~args:coerced_args
+        |> Option.map tuple_of_tool_result
     | Mod_suspend ->
         Tool_suspend.dispatch { Tool_suspend.config; caller_agent = Some agent_name } ~name ~args:coerced_args
     | Mod_library ->
         Tool_library.dispatch { Tool_library.agent_name } ~name ~args:coerced_args
+        |> Option.map tuple_of_tool_result
     | Mod_keeper ->
         Keeper_tool_boundary.dispatch (make_keeper_tool_ctx ()) ~name
           ~args:coerced_args
@@ -844,6 +855,7 @@ let execute_tool_eio ~sw ~clock ?(profile = Mcp_server_eio_tool_profile.Full)
           agent_name = Some agent_name; start_operation = None;
           config = Some config; sw = Some sw; clock = Some clock } in
         Tool_autoresearch.dispatch ctx ~name ~args:coerced_args
+        |> Option.map tuple_of_tool_result
     | Mod_shard ->
         let (ok, json) = Tool_shard.execute name coerced_args in
         Some (ok, Yojson.Safe.to_string json)
@@ -859,6 +871,7 @@ let execute_tool_eio ~sw ~clock ?(profile = Mcp_server_eio_tool_profile.Full)
           save_mcp_sessions = Mcp_server_eio_governance.save_mcp_sessions;
         } in
         Tool_inline_dispatch.dispatch inline_ctx ~name
+        |> Option.map tuple_of_tool_result
   in
 
   (* #9784: enrich Unknown tool errors with closest-name suggestions so the

--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -534,8 +534,7 @@ let start_keeper_loops ~sw ~clock ~net ~domain_mgr ~proc_mgr
               (false, "masc_status: dispatch failed"))
     | "masc_tasks" -> (
         match Tool_task.dispatch ctx_task ~name ~args with
-        | Some result ->
-            Tool_result.wrap ~tool_name:name ~start_time result
+        | Some result -> result
         | None ->
             Tool_result.wrap ~tool_name:name ~start_time
               (false, "masc_tasks: dispatch failed"))

--- a/lib/server/server_ide_http.ml
+++ b/lib/server/server_ide_http.ml
@@ -160,7 +160,8 @@ let add_routes router =
         request reqd)
     router2
   in
-  Http.Router.get "/api/v1/ide/regions" (fun request reqd ->
+  let router4 =
+    Http.Router.get "/api/v1/ide/regions" (fun request reqd ->
     with_public_read
       (fun state _req reqd ->
         let uri = Uri.of_string request.target in
@@ -190,7 +191,8 @@ let add_routes router =
       request reqd)
     router3
   in
-  Http.Router.get "/api/v1/ide/presence" (fun request reqd ->
+  let router5 =
+    Http.Router.get "/api/v1/ide/presence" (fun request reqd ->
     with_public_read
       (fun state _req reqd ->
         let base = base_path_of_state state in
@@ -239,10 +241,11 @@ let add_routes router =
       request reqd)
     router4
   in
-  Http.Router.get "/api/v1/ide/presence/stream" (fun request reqd ->
+  let router6 =
+    Http.Router.get "/api/v1/ide/presence/stream" (fun request reqd ->
     with_public_read
       (fun state _req inner_reqd ->
-        let origin = Server_utils.get_origin request in
+        let origin = get_origin request in
         let headers =
           Httpun.Headers.of_list
             ([
@@ -251,7 +254,7 @@ let add_routes router =
                ("connection", "keep-alive");
                ("x-accel-buffering", "no");
              ]
-             @ Server_utils.cors_headers origin)
+             @ cors_headers origin)
         in
         let response = Httpun.Response.create ~headers `OK in
         let writer = Httpun.Reqd.respond_with_streaming inner_reqd response in
@@ -301,3 +304,5 @@ let add_routes router =
         Httpun.Body.Writer.close writer)
       request reqd)
     router5
+  in
+  router6

--- a/lib/tool_agent_timeline.ml
+++ b/lib/tool_agent_timeline.ml
@@ -30,6 +30,10 @@ open Tool_args
 
 type tool_result = bool * string
 
+let wrap_result ~name ~start (success, message) =
+  if success then Tool_result.ok ~tool_name:name ~start_time:start message
+  else Tool_result.error ~tool_name:name ~start_time:start message
+
 type context = {
   config : Coord.config;
   agent_name : string;
@@ -642,9 +646,10 @@ let handle_agent_timeline (ctx : context) args : tool_result =
     (true, Yojson.Safe.to_string json)
 
 (* Dispatch *)
-let dispatch (ctx : context) ~name ~args : tool_result option =
+let dispatch (ctx : context) ~name ~args : Tool_result.t option =
+  let start = Time_compat.now () in
   match name with
-  | "masc_agent_timeline" -> Some (handle_agent_timeline ctx args)
+  | "masc_agent_timeline" -> Some (wrap_result ~name ~start (handle_agent_timeline ctx args))
   | _ -> None
 
 (* ================================================================ *)

--- a/lib/tool_agent_timeline.mli
+++ b/lib/tool_agent_timeline.mli
@@ -74,7 +74,7 @@ val dispatch :
   context ->
   name:string ->
   args:Yojson.Safe.t ->
-  tool_result option
+  Tool_result.t option
 (** [dispatch ctx ~name ~args] routes by tool name.  Returns
     [None] when [name] is not [masc_agent_timeline] — caller
     treats that as "not my tool". *)

--- a/lib/tool_autoresearch.ml
+++ b/lib/tool_autoresearch.ml
@@ -436,6 +436,10 @@ let wrap_result json =
   in
   (not is_error, s)
 
+let wrap_dispatch_result ~name ~start (success, message) =
+  if success then Tool_result.ok ~tool_name:name ~start_time:start message
+  else Tool_result.error ~tool_name:name ~start_time:start message
+
 let arg_member key = function
   | `Assoc fields -> List.assoc_opt key fields
   | _ -> None
@@ -583,17 +587,18 @@ let handle_search_findings (ctx : context) args =
         ]
 
 (** Dispatch an autoresearch tool call (standard MCP pattern). *)
-let dispatch (ctx : context) ~name ~args : tool_result option =
+let dispatch (ctx : context) ~name ~args : Tool_result.t option =
+  let start = Time_compat.now () in
   match name with
-  | "masc_autoresearch_start" -> Some (wrap_result (handle_start ctx args))
-  | "masc_autoresearch_status" -> Some (wrap_result (handle_status ctx args))
-  | "masc_autoresearch_stop" -> Some (wrap_result (handle_stop ctx args))
-  | "masc_autoresearch_inject" -> Some (wrap_result (handle_inject ctx args))
-  | "masc_autoresearch_cycle" -> Some (wrap_result (Tool_autoresearch_cycle.handle_cycle ctx args))
+  | "masc_autoresearch_start" -> Some (wrap_dispatch_result ~name ~start (wrap_result (handle_start ctx args)))
+  | "masc_autoresearch_status" -> Some (wrap_dispatch_result ~name ~start (wrap_result (handle_status ctx args)))
+  | "masc_autoresearch_stop" -> Some (wrap_dispatch_result ~name ~start (wrap_result (handle_stop ctx args)))
+  | "masc_autoresearch_inject" -> Some (wrap_dispatch_result ~name ~start (wrap_result (handle_inject ctx args)))
+  | "masc_autoresearch_cycle" -> Some (wrap_dispatch_result ~name ~start (wrap_result (Tool_autoresearch_cycle.handle_cycle ctx args)))
   | "masc_autoresearch_record_finding" ->
-      Some (wrap_result (handle_record_finding ctx args))
+      Some (wrap_dispatch_result ~name ~start (wrap_result (handle_record_finding ctx args)))
   | "masc_autoresearch_search_findings" ->
-      Some (wrap_result (handle_search_findings ctx args))
+      Some (wrap_dispatch_result ~name ~start (wrap_result (handle_search_findings ctx args)))
   | _ -> None
 
 (* ================================================================ *)

--- a/lib/tool_autoresearch.mli
+++ b/lib/tool_autoresearch.mli
@@ -82,7 +82,7 @@ val persisted_summary_target_reached :
     [target_reached = true] while the core loop remains incomplete. *)
 
 val dispatch :
-  context -> name:string -> args:Yojson.Safe.t -> tool_result option
+  context -> name:string -> args:Yojson.Safe.t -> Tool_result.t option
 (** Routes every [masc_autoresearch_*] tool name to its
     internal handler:
     - [masc_autoresearch_start] → {!handle_start}

--- a/lib/tool_board.ml
+++ b/lib/tool_board.ml
@@ -93,8 +93,6 @@ let strip_state_blocks_text (s : string) : string =
   loop 0 buf;
   Buffer.contents buf
 
-type tool_result = bool * string
-
 
 (** {1 Helpers} *)
 
@@ -1433,7 +1431,7 @@ let register () =
   let handler =
     fun ~name ~args ->
       let result = handle_tool name args in
-      Some (result.success, Tool_result.message result)
+      Some result
   in
   let tool_required_permission = function
     | "masc_board_list" | "masc_board_get" | "masc_board_stats"

--- a/lib/tool_board.mli
+++ b/lib/tool_board.mli
@@ -24,7 +24,7 @@
     Internal helpers stay private at this boundary
     ([board_list_cache] type + the cache cell, the
     [cached_board_list] adapter, [strip_state_blocks_text],
-    [tool_result] type alias, [format_ttl_remaining],
+    [format_ttl_remaining],
     [agent_lookup_hook] atomic ref,
     [resolve_board_post_kind], [format_post] /
     [format_post_compact] / [format_comment] /

--- a/lib/tool_catalog.ml
+++ b/lib/tool_catalog.ml
@@ -479,6 +479,7 @@ let inferred_effect_domain_of_typed_tool_name = function
   | TN.Keeper TK.Voice_listen
   | TN.Keeper TK.Voice_session_end
   | TN.Keeper TK.Voice_session_start
+  | TN.Keeper TK.Memory_write
   | TN.Keeper TK.Voice_speak ->
       Some Masc_coordination
   | TN.Masc TM.Autoresearch_inject
@@ -627,7 +628,7 @@ let tool_group_of_typed_tool_name = function
       | TK.Board_stats
       | TK.Board_vote ) ->
       Some Board
-  | TN.Keeper (TK.Memory_search | TK.Library_read | TK.Library_search) ->
+  | TN.Keeper (TK.Memory_search | TK.Memory_write | TK.Library_read | TK.Library_search) ->
       Some Knowledge
   | TN.Keeper
       ( TK.Task_claim

--- a/lib/tool_code.ml
+++ b/lib/tool_code.ml
@@ -37,6 +37,10 @@ type context = {
 
 type tool_result = bool * string
 
+let wrap_result ~name ~start (success, message) =
+  if success then Tool_result.ok ~tool_name:name ~start_time:start message
+  else Tool_result.error ~tool_name:name ~start_time:start message
+
 (* Security: Binary file extensions *)
 let binary_extensions = [
   ".so"; ".a"; ".lib"; ".dll"; ".dylib";
@@ -579,11 +583,12 @@ let handle_code_read ctx args =
   end
 
 (* Dispatch function - returns None if tool not handled *)
-let dispatch ctx ~name ~args : tool_result option =
+let dispatch ctx ~name ~args : Tool_result.t option =
+  let start = Time_compat.now () in
   match name with
-  | "masc_code_search" -> Some (handle_code_search ctx args)
-  | "masc_code_symbols" -> Some (handle_code_symbols ctx args)
-  | "masc_code_read" -> Some (handle_code_read ctx args)
+  | "masc_code_search" -> Some (wrap_result ~name ~start (handle_code_search ctx args))
+  | "masc_code_symbols" -> Some (wrap_result ~name ~start (handle_code_symbols ctx args))
+  | "masc_code_read" -> Some (wrap_result ~name ~start (handle_code_read ctx args))
   | _ -> None
 
 let schemas : Masc_domain.tool_schema list = [

--- a/lib/tool_code.mli
+++ b/lib/tool_code.mli
@@ -118,7 +118,7 @@ val dispatch :
   context ->
   name:string ->
   args:Yojson.Safe.t ->
-  tool_result option
+  Tool_result.t option
 (** [dispatch ctx ~name ~args] routes by tool name to the
     private handlers ([handle_code_search],
     [handle_code_symbols], [handle_code_read]).  Returns [None]

--- a/lib/tool_code_write.ml
+++ b/lib/tool_code_write.ml
@@ -38,6 +38,10 @@ type context = {
 
 type tool_result = bool * string
 
+let wrap_result ~name ~start (success, message) =
+  if success then Tool_result.ok ~tool_name:name ~start_time:start message
+  else Tool_result.error ~tool_name:name ~start_time:start message
+
 let max_write_size = 1024 * 1024  (* 1 MiB *)
 
 let normalize_dir_prefix path =
@@ -810,13 +814,14 @@ let handle_code_git ctx args =
   end
 
 (* Dispatch *)
-let dispatch ctx ~name ~args : tool_result option =
+let dispatch ctx ~name ~args : Tool_result.t option =
+  let start = Time_compat.now () in
   match name with
-  | "masc_code_write" -> Some (handle_code_write ctx args)
-  | "masc_code_edit" -> Some (handle_code_edit ctx args)
-  | "masc_code_delete" -> Some (handle_code_delete ctx args)
-  | "masc_code_shell" -> Some (handle_code_shell ctx args)
-  | "masc_code_git" -> Some (handle_code_git ctx args)
+  | "masc_code_write" -> Some (wrap_result ~name ~start (handle_code_write ctx args))
+  | "masc_code_edit" -> Some (wrap_result ~name ~start (handle_code_edit ctx args))
+  | "masc_code_delete" -> Some (wrap_result ~name ~start (handle_code_delete ctx args))
+  | "masc_code_shell" -> Some (wrap_result ~name ~start (handle_code_shell ctx args))
+  | "masc_code_git" -> Some (wrap_result ~name ~start (handle_code_git ctx args))
   | _ -> None
 
 (* Tool schemas *)

--- a/lib/tool_code_write.mli
+++ b/lib/tool_code_write.mli
@@ -222,7 +222,7 @@ val dispatch :
   context ->
   name:string ->
   args:Yojson.Safe.t ->
-  tool_result option
+  Tool_result.t option
 (** [dispatch ctx ~name ~args] routes [name] to the appropriate
     private handler ([handle_code_write], [handle_code_edit],
     [handle_code_delete], [handle_code_shell],

--- a/lib/tool_control.ml
+++ b/lib/tool_control.ml
@@ -24,6 +24,10 @@ open Tool_args
 
 type tool_result = bool * string
 
+let wrap_result ~name ~start (success, message) =
+  if success then Tool_result.ok ~tool_name:name ~start_time:start message
+  else Tool_result.error ~tool_name:name ~start_time:start message
+
 type context = {
   config: Coord.config;
   agent_name: string;
@@ -97,11 +101,12 @@ let handle_pause_status ctx _args =
 let schemas = Tool_schemas_control.schemas
 
 (* Dispatch function *)
-let dispatch ctx ~name ~args : tool_result option =
+let dispatch ctx ~name ~args : Tool_result.t option =
+  let start = Time_compat.now () in
   match name with
-  | "masc_pause" -> Some (handle_pause ctx args)
-  | "masc_resume" -> Some (handle_resume ctx args)
-  | "masc_pause_status" -> Some (handle_pause_status ctx args)
+  | "masc_pause" -> Some (wrap_result ~name ~start (handle_pause ctx args))
+  | "masc_resume" -> Some (wrap_result ~name ~start (handle_resume ctx args))
+  | "masc_pause_status" -> Some (wrap_result ~name ~start (handle_pause_status ctx args))
   | _ -> None
 
 (* ================================================================ *)

--- a/lib/tool_control.mli
+++ b/lib/tool_control.mli
@@ -27,4 +27,4 @@ val dispatch :
   context ->
   name:string ->
   args:Yojson.Safe.t ->
-  tool_result option
+  Tool_result.t option

--- a/lib/tool_dispatch.ml
+++ b/lib/tool_dispatch.ml
@@ -27,7 +27,7 @@ module Float = Stdlib.Float
 (** Unified handler type: every tool call is [name * args -> result option].
     [None] means "this handler does not know this tool" (should not happen
     when lookups go through the registry, but kept for compatibility). *)
-type handler = name:string -> args:Yojson.Safe.t -> (bool * string) option
+type handler = name:string -> args:Yojson.Safe.t -> Tool_result.t option
 
 (** Central registry — populated once during server initialisation. *)
 let registry : (string, handler) Hashtbl.t = Hashtbl.create 256
@@ -106,9 +106,9 @@ let run_pre_hooks ~name ~args =
 let run_post_hooks result =
   List.fold_left (fun r hook -> hook r) result !post_hooks
 
-(** O(1) dispatch.  Returns [Some (success, message)] when a handler is
-    found, [None] when the tool name is unknown to the registry.
-    Handler exceptions are caught and returned as error tuples so the
+(** O(1) dispatch.  Returns [Some result] when a handler is found,
+    [None] when the tool name is unknown to the registry.
+    Handler exceptions are caught and returned as error results so the
     caller gets a consistent result shape.
 
     Post-hooks fire as a side-effect after the handler completes,
@@ -122,15 +122,10 @@ let dispatch ~(token : Tool_token.t) ~args : Tool_result.t option =
     let result =
       try handler ~name ~args
       with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
-        Some
-          ( false,
-            Printf.sprintf "dispatch_v2 handler error for %s: %s" name
-              (Stdlib.Printexc.to_string exn) )
+        Some (Tool_result.of_exn ~tool_name:name ~start_time exn)
     in
     (match result with
-     | Some (success, message) ->
-       let tr = Tool_result.wrap ~tool_name:name ~start_time (success, message) in
-       Some (run_post_hooks tr)
+     | Some tr -> Some (run_post_hooks tr)
      | None -> None)
   | None -> None
 

--- a/lib/tool_dispatch.mli
+++ b/lib/tool_dispatch.mli
@@ -7,7 +7,7 @@
 
 (** Unified handler type: every tool call is [name * args -> tool_result option].
     [None] means "this handler does not know this tool". *)
-type handler = name:string -> args:Yojson.Safe.t -> (bool * string) option
+type handler = name:string -> args:Yojson.Safe.t -> Tool_result.t option
 
 (** {1 Registration} *)
 

--- a/lib/tool_inline_dispatch.ml
+++ b/lib/tool_inline_dispatch.ml
@@ -55,10 +55,15 @@ type context = Tool_inline_dispatch_types.context = {
 
 let safe_exec = Tool_inline_dispatch_types.safe_exec
 
+let wrap_result ~name ~start (success, message) =
+  if success then Tool_result.ok ~tool_name:name ~start_time:start message
+  else Tool_result.error ~tool_name:name ~start_time:start message
+
 (** Dispatch a tool call.
-    Returns [Some (success, message)] if the tool name is handled,
+    Returns [Some (Tool_result.t)] if the tool name is handled,
     [None] if the tool name is not recognized by this module. *)
-let dispatch (ctx : context) ~(name : string) : tool_result option =
+let dispatch (ctx : context) ~(name : string) : Tool_result.t option =
+  let start = Time_compat.now () in
   let config = ctx.config in
   let agent_name = ctx.agent_name in
   let state = ctx.state in
@@ -94,34 +99,46 @@ let dispatch (ctx : context) ~(name : string) : tool_result option =
 
   match name with
   (* ── Coord lifecycle (delegated) ─────────────────────────────── *)
-  | "masc_start" -> Tool_inline_dispatch_coord.handle_start ctx
-  | "masc_join" -> Tool_inline_dispatch_coord.handle_join ctx
-  | "masc_leave" -> Tool_inline_dispatch_coord.handle_leave ctx
+  | "masc_start" ->
+      Tool_inline_dispatch_coord.handle_start ctx
+      |> Option.map (wrap_result ~name ~start)
+  | "masc_join" ->
+      Tool_inline_dispatch_coord.handle_join ctx
+      |> Option.map (wrap_result ~name ~start)
+  | "masc_leave" ->
+      Tool_inline_dispatch_coord.handle_leave ctx
+      |> Option.map (wrap_result ~name ~start)
 
   (* ── Communication (delegated) ──────────────────────────────── *)
-  | "masc_broadcast" -> Tool_inline_dispatch_comm.handle_broadcast ctx
-  | "masc_messages" -> Tool_inline_dispatch_comm.handle_messages ctx
-  | "masc_who" -> Tool_inline_dispatch_comm.handle_who ctx
+  | "masc_broadcast" ->
+      Tool_inline_dispatch_comm.handle_broadcast ctx
+      |> Option.map (wrap_result ~name ~start)
+  | "masc_messages" ->
+      Tool_inline_dispatch_comm.handle_messages ctx
+      |> Option.map (wrap_result ~name ~start)
+  | "masc_who" ->
+      Tool_inline_dispatch_comm.handle_who ctx
+      |> Option.map (wrap_result ~name ~start)
 
   (* ── HITL Approval Queue (#5907) ─────────────────────────────── *)
   | "masc_approval_pending" ->
       let json = Keeper_approval_queue.list_pending_json () in
-      Some (true, Yojson.Safe.to_string json)
+      Some (wrap_result ~name ~start (true, Yojson.Safe.to_string json))
   | "masc_approval_get" ->
       let id = arg_get_string "id" "" in
-      if String.equal id "" then Some (false, "id is required")
+      if String.equal id "" then Some (wrap_result ~name ~start (false, "id is required"))
       else
         (match Keeper_approval_queue.get_pending_json ~id with
-         | Some json -> Some (true, Yojson.Safe.to_string json)
+         | Some json -> Some (wrap_result ~name ~start (true, Yojson.Safe.to_string json))
          | None ->
-           Some (false,
+           Some (wrap_result ~name ~start (false,
              Printf.sprintf
                "approval %s is no longer pending or was not found. Refresh with masc_approval_pending before approving/rejecting."
-               id))
+               id)))
   | "masc_approval_resolve" ->
       let id = arg_get_string "id" "" in
       let decision_str = arg_get_string "decision" "approve" in
-      if String.equal id "" then Some (false, "id is required")
+      if String.equal id "" then Some (wrap_result ~name ~start (false, "id is required"))
       else
         let decision = match String.lowercase_ascii decision_str with
           | "approve" -> Agent_sdk.Hooks.Approve
@@ -132,9 +149,9 @@ let dispatch (ctx : context) ~(name : string) : tool_result option =
         in
         (match Keeper_approval_queue.resolve ~id ~decision with
          | Ok () ->
-           Some (true, Printf.sprintf "{\"resolved\":\"%s\",\"decision\":\"%s\"}" id decision_str)
+           Some (wrap_result ~name ~start (true, Printf.sprintf "{\"resolved\":\"%s\",\"decision\":\"%s\"}" id decision_str))
          | Error err ->
-           Some (false, Keeper_approval_queue.resolve_error_to_string err))
+           Some (wrap_result ~name ~start (false, Keeper_approval_queue.resolve_error_to_string err)))
 
   (* Verification tools removed: pruned *)
 
@@ -146,10 +163,10 @@ let dispatch (ctx : context) ~(name : string) : tool_result option =
       let raw = arg_get_string "action" "" in
       (match Mcp_session.action_of_string_opt raw with
        | None ->
-         Some (false,
+         Some (wrap_result ~name ~start (false,
            Printf.sprintf
              "action must be one of [%s]; got %S"
-             (String.concat "|" Mcp_session.valid_action_strings) raw)
+             (String.concat "|" Mcp_session.valid_action_strings) raw))
        | Some action ->
       let now = Time_compat.now () in
       let sessions = ctx.load_mcp_sessions config in
@@ -207,8 +224,8 @@ let dispatch (ctx : context) ~(name : string) : tool_result option =
             end
       in
       (match response with
-       | Ok json -> Some (true, Yojson.Safe.to_string json)
-       | Error e -> Some (false, e)))
+       | Ok json -> Some (wrap_result ~name ~start (true, Yojson.Safe.to_string json))
+       | Error e -> Some (wrap_result ~name ~start (false, e))))
 
   (* Infrastructure tools: cancellation, subscription, progress,
      governance_set removed — pruned from surfaces *)
@@ -216,7 +233,7 @@ let dispatch (ctx : context) ~(name : string) : tool_result option =
   | "masc_spawn" ->
       let spawn_agent_name = arg_get_string "agent_name" "" in
       let prompt = arg_get_string "prompt" "" in
-      if String.equal prompt "" then Some (false, "prompt is required")
+      if String.equal prompt "" then Some (wrap_result ~name ~start (false, "prompt is required"))
       else
       let timeout_seconds = arg_get_int "timeout_seconds" 300 in
       let model_name =
@@ -245,21 +262,21 @@ let dispatch (ctx : context) ~(name : string) : tool_result option =
         | _ -> None
       in
        (match runtime_model_valid with
-       | Error e -> Some (false, e)
+       | Error e -> Some (wrap_result ~name ~start (false, e))
        | Ok () ->
            ignore (sw, state);
            let result =
              Spawn.spawn ~agent_name:spawn_agent_name
                ~prompt ~timeout_seconds ?working_dir ()
            in
-           Some (result.Spawn.success, Spawn.result_to_string result))
+           Some (wrap_result ~name ~start (result.Spawn.success, Spawn.result_to_string result)))
 
   (* ── Tool discovery ─────────────────────────────────────────── *)
   | "masc_discover_tools" ->
       let query = String.lowercase_ascii (arg_get_string "query" "") in
       let limit = arg_get_int "limit" 20 in
       if String.equal query "" then
-        Some (false, "query is required")
+        Some (wrap_result ~name ~start (false, "query is required"))
       else
         let all_schemas = Config.visible_tool_schemas ~include_hidden:true ~include_deprecated:false () in
         let words = String.split_on_char ' ' query |> List.filter (fun w -> String.length w > 0) in
@@ -279,12 +296,14 @@ let dispatch (ctx : context) ~(name : string) : tool_result option =
             ("description", `String schema.description);
           ]
         ) matches in
-        Some (true, Yojson.Safe.to_string (`Assoc [
+        Some (wrap_result ~name ~start (true, Yojson.Safe.to_string (`Assoc [
           ("query", `String query);
           ("count", `Int (List.length results));
           ("tools", `List results);
           ("hint", `String "These tools are callable via tools/call even if not in the default tools/list.");
-        ]))
+        ])))
 
   (* ── Fallthrough to extra dispatch ──────────────────────────── *)
-  | _ -> Tool_inline_dispatch_extra.dispatch ~config ~agent_name ~arguments ~state ~sw ~clock ~name
+  | _ ->
+      Tool_inline_dispatch_extra.dispatch ~config ~agent_name ~arguments ~state ~sw ~clock ~name
+      |> Option.map (wrap_result ~name ~start)

--- a/lib/tool_inline_dispatch.mli
+++ b/lib/tool_inline_dispatch.mli
@@ -38,4 +38,4 @@ type context = Tool_inline_dispatch_types.context = {
 
 val safe_exec : string list -> tool_result
 
-val dispatch : context -> name:string -> tool_result option
+val dispatch : context -> name:string -> Tool_result.t option

--- a/lib/tool_library.ml
+++ b/lib/tool_library.ml
@@ -83,6 +83,10 @@ let string_contains ~sub s =
 
 type tool_result = bool * string
 
+let wrap_result ~name ~start (success, message) =
+  if success then Tool_result.ok ~tool_name:name ~start_time:start message
+  else Tool_result.error ~tool_name:name ~start_time:start message
+
 type context = {
   agent_name: string;
 }
@@ -346,13 +350,14 @@ let handle_search _ctx args =
   end
 
 (* Dispatch *)
-let dispatch ctx ~name ~args : tool_result option =
+let dispatch ctx ~name ~args : Tool_result.t option =
+  let start = Time_compat.now () in
   match name with
-  | "masc_library_list" -> Some (handle_list ctx args)
-  | "masc_library_read" -> Some (handle_read ctx args)
-  | "masc_library_add" -> Some (handle_add ctx args)
-  | "masc_library_promote" -> Some (handle_promote ctx args)
-  | "masc_library_search" -> Some (handle_search ctx args)
+  | "masc_library_list" -> Some (wrap_result ~name ~start (handle_list ctx args))
+  | "masc_library_read" -> Some (wrap_result ~name ~start (handle_read ctx args))
+  | "masc_library_add" -> Some (wrap_result ~name ~start (handle_add ctx args))
+  | "masc_library_promote" -> Some (wrap_result ~name ~start (handle_promote ctx args))
+  | "masc_library_search" -> Some (wrap_result ~name ~start (handle_search ctx args))
   | _ -> None
 
 (* Tool definitions for MCP protocol *)

--- a/lib/tool_library.mli
+++ b/lib/tool_library.mli
@@ -117,7 +117,7 @@ val dispatch :
   context ->
   name:string ->
   args:Yojson.Safe.t ->
-  tool_result option
+  Tool_result.t option
 (** [dispatch ctx ~name ~args] routes by tool name to the
     private handlers ([handle_list], [handle_add],
     [handle_promote]) plus {!handle_read} / {!handle_search}.

--- a/lib/tool_misc.ml
+++ b/lib/tool_misc.ml
@@ -30,6 +30,10 @@ open Tool_args
 
 type tool_result = bool * string
 
+let wrap_result ~name ~start (success, message) =
+  if success then Tool_result.ok ~tool_name:name ~start_time:start message
+  else Tool_result.error ~tool_name:name ~start_time:start message
+
 type context = {
   config: Coord.config;
   agent_name: string;
@@ -142,24 +146,25 @@ let tool_inventory_json ctx ~include_hidden ~include_deprecated =
 (* Dispatch (facade)                                                *)
 (* ================================================================ *)
 
-let dispatch ctx ~name ~args : tool_result option =
+let dispatch ctx ~name ~args : Tool_result.t option =
+  let start = Time_compat.now () in
   let admin_ctx : Tool_misc_admin.context =
     { config = ctx.config; agent_name = ctx.agent_name }
   in
   match name with
-  | "masc_config" -> Some (Tool_misc_admin.handle_config args)
-  | "masc_webrtc_offer" -> Some (Tool_misc_transport.handle_webrtc_offer args)
-  | "masc_webrtc_answer" -> Some (Tool_misc_transport.handle_webrtc_answer args)
-  | "masc_dashboard" -> Some (handle_dashboard ctx args)
-  | "masc_gc" -> Some (handle_gc ctx args)
-  | "masc_cleanup_zombies" -> Some (handle_cleanup_zombies ctx args)
-  | "masc_tool_stats" -> Some (handle_tool_stats ctx args)
-  | "masc_tool_help" -> Some (handle_tool_help ctx args)
-  | "masc_web_search" -> Some (handle_web_search ctx args)
-  | "masc_web_fetch" -> Some (handle_web_fetch ctx args)
-  | "masc_tool_admin_snapshot" -> Some (Tool_misc_admin.handle_tool_admin_snapshot admin_ctx args)
-  | "masc_tool_admin_update" -> Some (Tool_misc_admin.handle_tool_admin_update admin_ctx args)
-  | "masc_deep_review" -> Some (Tool_deep_review.handle_deep_review ctx.config args)
+  | "masc_config" -> Some (wrap_result ~name ~start (Tool_misc_admin.handle_config args))
+  | "masc_webrtc_offer" -> Some (wrap_result ~name ~start (Tool_misc_transport.handle_webrtc_offer args))
+  | "masc_webrtc_answer" -> Some (wrap_result ~name ~start (Tool_misc_transport.handle_webrtc_answer args))
+  | "masc_dashboard" -> Some (wrap_result ~name ~start (handle_dashboard ctx args))
+  | "masc_gc" -> Some (wrap_result ~name ~start (handle_gc ctx args))
+  | "masc_cleanup_zombies" -> Some (wrap_result ~name ~start (handle_cleanup_zombies ctx args))
+  | "masc_tool_stats" -> Some (wrap_result ~name ~start (handle_tool_stats ctx args))
+  | "masc_tool_help" -> Some (wrap_result ~name ~start (handle_tool_help ctx args))
+  | "masc_web_search" -> Some (wrap_result ~name ~start (handle_web_search ctx args))
+  | "masc_web_fetch" -> Some (wrap_result ~name ~start (handle_web_fetch ctx args))
+  | "masc_tool_admin_snapshot" -> Some (wrap_result ~name ~start (Tool_misc_admin.handle_tool_admin_snapshot admin_ctx args))
+  | "masc_tool_admin_update" -> Some (wrap_result ~name ~start (Tool_misc_admin.handle_tool_admin_update admin_ctx args))
+  | "masc_deep_review" -> Some (wrap_result ~name ~start (Tool_deep_review.handle_deep_review ctx.config args))
   | _ -> None
 
 let schemas = Tool_schemas_misc.schemas

--- a/lib/tool_misc.mli
+++ b/lib/tool_misc.mli
@@ -35,7 +35,7 @@ val web_search_simulate_for_test :
   list ->
   tool_result
 
-val dispatch : context -> name:string -> args:Yojson.Safe.t -> tool_result option
+val dispatch : context -> name:string -> args:Yojson.Safe.t -> Tool_result.t option
 
 val tool_inventory_json :
   context -> include_hidden:bool -> include_deprecated:bool -> Yojson.Safe.t

--- a/lib/tool_operator.ml
+++ b/lib/tool_operator.ml
@@ -30,6 +30,10 @@ type 'a context = {
 
 type tool_result = bool * string
 
+let wrap_result ~name ~start (success, message) =
+  if success then Tool_result.ok ~tool_name:name ~start_time:start message
+  else Tool_result.error ~tool_name:name ~start_time:start message
+
 let schema_properties entries = `Assoc entries
 
 let strict_action_enums =
@@ -261,7 +265,8 @@ let json_string_of_result = function
   | Ok json -> (true, Yojson.Safe.to_string json)
   | Error message -> (false, Yojson.Safe.to_string (`Assoc [ ("status", `String "error"); ("message", `String message) ]))
 
-let dispatch (ctx : 'a context) ~name ~args : tool_result option =
+let dispatch (ctx : 'a context) ~name ~args : Tool_result.t option =
+  let start = Time_compat.now () in
   let control_ctx : 'a Operator_control.context =
     {
       config = ctx.config;
@@ -280,29 +285,32 @@ let dispatch (ctx : 'a context) ~name ~args : tool_result option =
       let include_messages = get_bool args "include_messages" true in
       let include_keepers = get_bool args "include_keepers" true in
       Some
-        ( true,
-          Yojson.Safe.to_string
-            (Operator_control.snapshot_json ?actor ?view ~include_messages
-               ~include_keepers control_ctx) )
+        (wrap_result ~name ~start
+           ( true,
+             Yojson.Safe.to_string
+               (Operator_control.snapshot_json ?actor ?view ~include_messages
+                  ~include_keepers control_ctx) ))
   | "masc_operator_digest" ->
       let actor = get_string_opt args "actor" in
       let target_type = get_string_opt args "target_type" in
       let target_id = get_string_opt args "target_id" in
       let include_workers = get_bool args "include_workers" true in
       Some
-        (json_string_of_result
-           (Operator_control.digest_json ?actor ?target_type ?target_id
-              ~include_workers control_ctx))
+        (wrap_result ~name ~start
+           (json_string_of_result
+              (Operator_control.digest_json ?actor ?target_type ?target_id
+                 ~include_workers control_ctx)))
   | "masc_operator_action" ->
-      Some (json_string_of_result (Operator_control.action_json control_ctx args))
+      Some (wrap_result ~name ~start (json_string_of_result (Operator_control.action_json control_ctx args)))
   | "masc_operator_confirm" ->
-      Some (json_string_of_result (Operator_control.confirm_json control_ctx args))
+      Some (wrap_result ~name ~start (json_string_of_result (Operator_control.confirm_json control_ctx args)))
   | "masc_surface_audit" ->
       let surface_id = get_string_opt args "surface_id" in
-      Some (true, Yojson.Safe.to_string (Dashboard_surface_readiness.json ?surface_id ()))
+      Some (wrap_result ~name ~start (true, Yojson.Safe.to_string (Dashboard_surface_readiness.json ?surface_id ())))
   | "masc_operator_judgment_write" ->
       Some
-        (json_string_of_result (Operator_control.judgment_write_json control_ctx args))
+        (wrap_result ~name ~start
+           (json_string_of_result (Operator_control.judgment_write_json control_ctx args)))
   | _ -> None
 
 let schemas : tool_schema list =

--- a/lib/tool_operator.mli
+++ b/lib/tool_operator.mli
@@ -44,7 +44,7 @@ val dispatch :
   float Eio.Time.clock_ty context ->
   name:string ->
   args:Yojson.Safe.t ->
-  tool_result option
+  Tool_result.t option
 (** [dispatch ctx ~name ~args] dispatches the named MCP tool call.
     Returns [None] for unrecognised names so callers can fall
     through to other dispatchers.

--- a/lib/tool_plan.ml
+++ b/lib/tool_plan.ml
@@ -30,6 +30,11 @@ type context = {
 (** Tool result type *)
 type tool_result = bool * string
 
+(** Wrap a [(bool * string)] result into a structured [Tool_result.t]. *)
+let wrap_result ~name ~start (success, message) =
+  if success then Tool_result.ok ~tool_name:name ~start_time:start message
+  else Tool_result.error ~tool_name:name ~start_time:start message
+
 open Tool_args
 
 (** {1 Individual Handlers} *)
@@ -154,16 +159,17 @@ let handle_plan_clear_task ctx _args : tool_result =
 
 (** {1 Dispatcher} *)
 
-let dispatch ctx ~name ~args : tool_result option =
+let dispatch ctx ~name ~args : Tool_result.t option =
+  let start = Time_compat.now () in
   match name with
-  | "masc_plan_init" -> Some (handle_plan_init ctx args)
-  | "masc_plan_update" -> Some (handle_plan_update ctx args)
-  | "masc_note_add" -> Some (handle_note_add ctx args)
-  | "masc_deliver" -> Some (handle_deliver ctx args)
-  | "masc_plan_get" -> Some (handle_plan_get ctx args)
-  | "masc_plan_set_task" -> Some (handle_plan_set_task ctx args)
-  | "masc_plan_get_task" -> Some (handle_plan_get_task ctx args)
-  | "masc_plan_clear_task" -> Some (handle_plan_clear_task ctx args)
+  | "masc_plan_init" -> Some (wrap_result ~name ~start (handle_plan_init ctx args))
+  | "masc_plan_update" -> Some (wrap_result ~name ~start (handle_plan_update ctx args))
+  | "masc_note_add" -> Some (wrap_result ~name ~start (handle_note_add ctx args))
+  | "masc_deliver" -> Some (wrap_result ~name ~start (handle_deliver ctx args))
+  | "masc_plan_get" -> Some (wrap_result ~name ~start (handle_plan_get ctx args))
+  | "masc_plan_set_task" -> Some (wrap_result ~name ~start (handle_plan_set_task ctx args))
+  | "masc_plan_get_task" -> Some (wrap_result ~name ~start (handle_plan_get_task ctx args))
+  | "masc_plan_clear_task" -> Some (wrap_result ~name ~start (handle_plan_clear_task ctx args))
   | _ -> None
 
 let schemas = Tool_schemas_plan.schemas

--- a/lib/tool_plan.mli
+++ b/lib/tool_plan.mli
@@ -28,6 +28,6 @@ val handle_plan_clear_task : context -> Yojson.Safe.t -> tool_result
 (** {1 Dispatcher} *)
 
 (** Dispatch plan tool by name. Returns None if not a plan tool. *)
-val dispatch : context -> name:string -> args:Yojson.Safe.t -> tool_result option
+val dispatch : context -> name:string -> args:Yojson.Safe.t -> Tool_result.t option
 
 val schemas : Masc_domain.tool_schema list

--- a/lib/tool_result.ml
+++ b/lib/tool_result.ml
@@ -171,3 +171,65 @@ let message t = t.legacy_message
 let failure_class t = t.failure_class
 
 let to_legacy_compat t = (t.success, message t)
+
+(** Handler constructors — used by Tool_*.dispatch functions
+    to build structured results directly without going through [wrap]. *)
+
+let ok ~tool_name ~start_time message =
+  let end_time = Time_compat.now () in
+  let duration_ms = (end_time -. start_time) *. 1000.0 in
+  let data =
+    match structured_payload_of_message message with
+    | Some json -> json
+    | None -> `String message
+  in
+  { success = true; data; legacy_message = message; tool_name; duration_ms; failure_class = None }
+
+let error ?(failure_class = None) ~tool_name ~start_time message =
+  let end_time = Time_compat.now () in
+  let duration_ms = (end_time -. start_time) *. 1000.0 in
+  let data =
+    match structured_payload_of_message message with
+    | Some json -> json
+    | None -> `String message
+  in
+  let failure_class =
+    match failure_class with
+    | Some _ -> failure_class
+    | None -> Some (classify_from_dispatch_failure message)
+  in
+  { success = false; data; legacy_message = message; tool_name; duration_ms; failure_class }
+
+let of_exn ~tool_name ~start_time exn =
+  let end_time = Time_compat.now () in
+  let duration_ms = (end_time -. start_time) *. 1000.0 in
+  let cls = classify_from_exception exn in
+  let message =
+    Printf.sprintf "dispatch handler error for %s: %s" tool_name
+      (Stdlib.Printexc.to_string exn)
+  in
+  { success = false
+  ; data = `String message
+  ; legacy_message = message
+  ; tool_name
+  ; duration_ms
+  ; failure_class = Some cls
+  }
+
+let quick_ok ?(tool_name = "") message =
+  { success = true
+  ; data = `String message
+  ; legacy_message = message
+  ; tool_name
+  ; duration_ms = 0.0
+  ; failure_class = None
+  }
+
+let quick_error ?(tool_name = "") message =
+  { success = false
+  ; data = `String message
+  ; legacy_message = message
+  ; tool_name
+  ; duration_ms = 0.0
+  ; failure_class = Some Runtime_failure
+  }

--- a/lib/tool_result.mli
+++ b/lib/tool_result.mli
@@ -35,11 +35,6 @@ val classify_from_exception : exn -> tool_failure_class
     Typed exception inspection — no string matching on exception messages
     except for [Failure] where the message carries the diagnostic. *)
 
-val classify_from_dispatch_failure : string -> tool_failure_class
-(** Classify a tool failure from a [(false, message)] dispatch result.
-    SSOT for Phase 1 string-based classification at catch boundaries.
-    Phase 2 replaces this with typed propagation from [Tool_*.dispatch]. *)
-
 (** {1 Structured result} *)
 
 type t = {
@@ -67,8 +62,7 @@ val wrap :
     tuple into a structured result.
 
     When [failure_class] is not provided and the result is a failure,
-    {!classify_from_dispatch_failure} is called on the message to
-    determine the class automatically. *)
+    the message is classified by an internal heuristic. *)
 
 val to_json : t -> Yojson.Safe.t
 
@@ -85,3 +79,33 @@ val to_legacy_compat : t -> bool * string
 [@@alert legacy_tuple
   "This function exists for migration only. \
    Migrate the call site to use Tool_result.t directly."]
+
+(** {1 Handler constructors}
+
+    Direct constructors for [Tool_*.dispatch] functions to build
+    structured results without the legacy [wrap] intermediary. *)
+
+val ok : tool_name:string -> start_time:float -> string -> t
+(** Successful result. [failure_class] is [None]. *)
+
+val error :
+  ?failure_class:tool_failure_class option ->
+  tool_name:string ->
+  start_time:float ->
+  string -> t
+(** Failure result.  When [failure_class] is not provided,
+    the message is classified by an internal heuristic. *)
+
+val of_exn : tool_name:string -> start_time:float -> exn -> t
+(** Build a failure result from an exception caught during dispatch.
+    Uses {!classify_from_exception} for typed classification. *)
+
+(** {1 Test helpers}
+
+    Quick constructors for tests and one-liner handlers.
+    [duration_ms] is set to [0.0] and [tool_name] defaults to [""].
+
+    @since 2.260.0 *)
+
+val quick_ok : ?tool_name:string -> string -> t
+val quick_error : ?tool_name:string -> string -> t

--- a/lib/tool_run.ml
+++ b/lib/tool_run.ml
@@ -29,6 +29,10 @@ type context = {
 (** Tool result type *)
 type tool_result = bool * string
 
+let wrap_result ~name ~start (success, message) =
+  if success then Tool_result.ok ~tool_name:name ~start_time:start message
+  else Tool_result.error ~tool_name:name ~start_time:start message
+
 open Tool_args
 
 (** {1 Individual Handlers} *)
@@ -96,14 +100,15 @@ let handle_run_list ctx _args : tool_result =
 
 (** {1 Dispatcher} *)
 
-let dispatch ctx ~name ~args : tool_result option =
+let dispatch ctx ~name ~args : Tool_result.t option =
+  let start = Time_compat.now () in
   match name with
-  | "masc_run_init" -> Some (handle_run_init ctx args)
-  | "masc_run_plan" -> Some (handle_run_plan ctx args)
-  | "masc_run_log" -> Some (handle_run_log ctx args)
-  | "masc_run_deliverable" -> Some (handle_run_deliverable ctx args)
-  | "masc_run_get" -> Some (handle_run_get ctx args)
-  | "masc_run_list" -> Some (handle_run_list ctx args)
+  | "masc_run_init" -> Some (wrap_result ~name ~start (handle_run_init ctx args))
+  | "masc_run_plan" -> Some (wrap_result ~name ~start (handle_run_plan ctx args))
+  | "masc_run_log" -> Some (wrap_result ~name ~start (handle_run_log ctx args))
+  | "masc_run_deliverable" -> Some (wrap_result ~name ~start (handle_run_deliverable ctx args))
+  | "masc_run_get" -> Some (wrap_result ~name ~start (handle_run_get ctx args))
+  | "masc_run_list" -> Some (wrap_result ~name ~start (handle_run_list ctx args))
   | _ -> None
 
 let schemas : Masc_domain.tool_schema list = [

--- a/lib/tool_run.mli
+++ b/lib/tool_run.mli
@@ -28,4 +28,4 @@ val handle_run_list : context -> Yojson.Safe.t -> tool_result
 (** Tool schemas for MCP tools/list *)
 val schemas : Masc_domain.tool_schema list
 
-val dispatch : context -> name:string -> args:Yojson.Safe.t -> tool_result option
+val dispatch : context -> name:string -> args:Yojson.Safe.t -> Tool_result.t option

--- a/lib/tool_task.ml
+++ b/lib/tool_task.ml
@@ -25,6 +25,10 @@ open Yojson.Safe.Util
 
 type tool_result = bool * string
 
+let wrap_result ~name ~start (success, message) =
+  if success then Tool_result.ok ~tool_name:name ~start_time:start message
+  else Tool_result.error ~tool_name:name ~start_time:start message
+
 type context = {
   config: Coord.config;
   agent_name: string;
@@ -1159,16 +1163,17 @@ let handle_task_history ctx args =
 
 include Tool_task_schemas
 (* Dispatch function *)
-let dispatch ?agent_tool_names ctx ~name ~args : tool_result option =
+let dispatch ?agent_tool_names ctx ~name ~args : Tool_result.t option =
+  let start = Time_compat.now () in
   match name with
-  | "masc_add_task" -> Some (handle_add_task ctx args)
-  | "masc_batch_add_tasks" -> Some (handle_batch_add_tasks ctx args)
-  | "masc_claim_task" -> Some (handle_claim ?agent_tool_names ctx args)
-  | "masc_claim_next" -> Some (handle_claim_next ?agent_tool_names ctx args)
-  | "masc_transition" -> Some (handle_transition ?agent_tool_names ctx args)
-  | "masc_update_priority" -> Some (handle_update_priority ctx args)
-  | "masc_tasks" -> Some (handle_tasks ctx args)
-  | "masc_task_history" -> Some (handle_task_history ctx args)
+  | "masc_add_task" -> Some (wrap_result ~name ~start (handle_add_task ctx args))
+  | "masc_batch_add_tasks" -> Some (wrap_result ~name ~start (handle_batch_add_tasks ctx args))
+  | "masc_claim_task" -> Some (wrap_result ~name ~start (handle_claim ?agent_tool_names ctx args))
+  | "masc_claim_next" -> Some (wrap_result ~name ~start (handle_claim_next ?agent_tool_names ctx args))
+  | "masc_transition" -> Some (wrap_result ~name ~start (handle_transition ?agent_tool_names ctx args))
+  | "masc_update_priority" -> Some (wrap_result ~name ~start (handle_update_priority ctx args))
+  | "masc_tasks" -> Some (wrap_result ~name ~start (handle_tasks ctx args))
+  | "masc_task_history" -> Some (wrap_result ~name ~start (handle_task_history ctx args))
   | _ -> None
 
 (* ================================================================ *)

--- a/lib/tool_task.mli
+++ b/lib/tool_task.mli
@@ -28,7 +28,7 @@ val dispatch :
   context ->
   name:string ->
   args:Yojson.Safe.t ->
-  tool_result option
+  Tool_result.t option
 
 val schemas : Masc_domain.tool_schema list
 

--- a/lib/tool_worktree.ml
+++ b/lib/tool_worktree.ml
@@ -27,6 +27,10 @@ type context = {
 
 type tool_result = bool * string
 
+let wrap_result ~name ~start (success, message) =
+  if success then Tool_result.ok ~tool_name:name ~start_time:start message
+  else Tool_result.error ~tool_name:name ~start_time:start message
+
 let default_base_branch = "auto"
 
 (* Individual handlers *)
@@ -128,11 +132,12 @@ let handle_worktree_list ctx _args =
   (true, Yojson.Safe.to_string json)
 
 (* Dispatch function - returns None if tool not handled *)
-let dispatch ctx ~name ~args : tool_result option =
+let dispatch ctx ~name ~args : Tool_result.t option =
+  let start = Time_compat.now () in
   match name with
-  | "masc_worktree_create" -> Some (handle_worktree_create ctx args)
-  | "masc_worktree_remove" -> Some (handle_worktree_remove ctx args)
-  | "masc_worktree_list" -> Some (handle_worktree_list ctx args)
+  | "masc_worktree_create" -> Some (wrap_result ~name ~start (handle_worktree_create ctx args))
+  | "masc_worktree_remove" -> Some (wrap_result ~name ~start (handle_worktree_remove ctx args))
+  | "masc_worktree_list" -> Some (wrap_result ~name ~start (handle_worktree_list ctx args))
   | _ -> None
 
 let schemas = Tool_schemas_worktree.schemas

--- a/lib/tool_worktree.mli
+++ b/lib/tool_worktree.mli
@@ -14,6 +14,6 @@ val handle_worktree_create : context -> Yojson.Safe.t -> tool_result
 val handle_worktree_remove : context -> Yojson.Safe.t -> tool_result
 val handle_worktree_list : context -> Yojson.Safe.t -> tool_result
 
-val dispatch : context -> name:string -> args:Yojson.Safe.t -> tool_result option
+val dispatch : context -> name:string -> args:Yojson.Safe.t -> Tool_result.t option
 
 val schemas : Masc_domain.tool_schema list

--- a/lib/typed_tool_masc.ml
+++ b/lib/typed_tool_masc.ml
@@ -26,10 +26,11 @@ let create ~name ~description ~module_tag ~params ~parse ~handler ~encode
     The handler is registered via [Tool_spec.Direct] for a specific tool name,
     so the [name] parameter will always match — no guard needed. *)
 let make_dispatch_handler (tool : (_, _) t) : Tool_dispatch.handler =
-  fun ~name:_ ~args ->
+  fun ~name ~args ->
+    let start_time = Time_compat.now () in
     match Agent_sdk.Typed_tool.execute tool.oas_tool args with
-    | Ok { content } -> Some (true, content)
-    | Error { message; _ } -> Some (false, message)
+    | Ok { content } -> Some (Tool_result.ok ~tool_name:name ~start_time content)
+    | Error { message; _ } -> Some (Tool_result.error ~tool_name:name ~start_time message)
 
 let to_spec tool =
   let schema = Agent_sdk.Typed_tool.schema tool.oas_tool in

--- a/test/test_autoresearch_knowledge.ml
+++ b/test/test_autoresearch_knowledge.ml
@@ -118,14 +118,15 @@ let make_ctx base_path : Tool_autoresearch.context =
 let dispatch_json ctx ~name ~args =
   match Tool_autoresearch.dispatch ctx ~name ~args with
   | None -> fail ("dispatch missing for " ^ name)
-  | Some (false, body) -> fail (name ^ " failed: " ^ body)
-  | Some (true, body) -> Yojson.Safe.from_string body
+  | Some result when not result.success -> fail (name ^ " failed: " ^ result.legacy_message)
+  | Some result -> Yojson.Safe.from_string result.legacy_message
 
 let dispatch_error label ctx ~name ~args =
   match Tool_autoresearch.dispatch ctx ~name ~args with
   | None -> fail ("dispatch missing for " ^ name)
-  | Some (true, body) -> fail (name ^ " unexpectedly succeeded: " ^ body)
-  | Some (false, body) ->
+  | Some result when result.success -> fail (name ^ " unexpectedly succeeded: " ^ result.legacy_message)
+  | Some result ->
+    let body = result.legacy_message in
     let json = Yojson.Safe.from_string body in
     let error =
       Yojson.Safe.Util.(member "error" json |> to_string_option)

--- a/test/test_autoresearch_oas_primitives.ml
+++ b/test/test_autoresearch_oas_primitives.ml
@@ -356,8 +356,8 @@ let test_start_seeds_source_only_target_file_into_managed_worktree () =
           ])
   with
   | None -> fail "dispatch returned None"
-  | Some (false, msg) -> fail msg
-  | Some (true, payload) ->
+  | Some result when not result.success -> fail result.legacy_message
+  | Some result -> let payload = result.legacy_message in
       let open Yojson.Safe.Util in
       let json = Yojson.Safe.from_string payload in
       let managed_workdir = json |> member "workdir" |> to_string in

--- a/test/test_governance_pipeline.ml
+++ b/test/test_governance_pipeline.ml
@@ -614,7 +614,7 @@ let test_hook_development_allows () =
   setup ();
   Tool_dispatch.register
     ~tool_name:"__gov_test_delete"
-    ~handler:(fun ~name:_ ~args:_ -> Some (true, "ok"));
+    ~handler:(fun ~name:_ ~args:_ -> Some (Tool_result.quick_ok "ok"));
   let tmpdir = make_tmpdir () in
   let config = Coord.default_config tmpdir in
   let hook = Gp.make_pre_hook ~config ~governance_level:"development" in
@@ -630,7 +630,7 @@ let test_hook_production_blocks_critical () =
   setup ();
   Tool_dispatch.register
     ~tool_name:"__gov_test_delete2"
-    ~handler:(fun ~name:_ ~args:_ -> Some (true, "should not reach"));
+    ~handler:(fun ~name:_ ~args:_ -> Some (Tool_result.quick_ok "should not reach"));
   let tmpdir = make_tmpdir () in
   let config = Coord.default_config tmpdir in
   let hook = Gp.make_pre_hook ~config ~governance_level:"production" in

--- a/test/test_keeper_exec_tools.ml
+++ b/test/test_keeper_exec_tools.ml
@@ -337,13 +337,13 @@ let register_registered_dispatch_probe () =
     ~tool_name:registered_dispatch_probe_tool
     ~handler:(fun ~name ~args:_ ->
       Some
-        ( true
-        , Yojson.Safe.to_string
-            (`Assoc
-              [ ("ok", `Bool true)
-              ; ("tool", `String name)
-              ; ("route", `String "registered")
-              ]) ))
+        (Masc_mcp.Tool_result.quick_ok ~tool_name:name
+           (Yojson.Safe.to_string
+              (`Assoc
+                [ ("ok", `Bool true)
+                ; ("tool", `String name)
+                ; ("route", `String "registered")
+                ]))))
 
 let test_registered_tool_dispatch_without_masc_prefix () =
   register_registered_dispatch_probe ();

--- a/test/test_keeper_memory_write.ml
+++ b/test/test_keeper_memory_write.ml
@@ -15,6 +15,8 @@
     pure-validation pin here plus the helper-mapping pin is sufficient
     coverage for the new code paths. *)
 
+module Keeper_exec_memory = Masc_mcp.Keeper_exec_memory
+
 (* --- helpers ------------------------------------------------------- *)
 
 let make_args ~kind ~title ~content : Yojson.Safe.t =

--- a/test/test_keeper_tag_dispatch.ml
+++ b/test/test_keeper_tag_dispatch.ml
@@ -56,9 +56,10 @@ let dispatch_inline config name =
 let test_pause_status_allowed () =
   with_room (fun config ->
     match dispatch config "masc_pause_status" with
-    | Some (true, _msg) -> ()
-    | Some (false, msg) ->
-        fail (Printf.sprintf "masc_pause_status should succeed, got error: %s" msg)
+    | Some tr when tr.Tool_result.success -> ()
+    | Some tr ->
+        fail (Printf.sprintf "masc_pause_status should succeed, got error: %s"
+          tr.Tool_result.legacy_message)
     | None ->
         fail "masc_pause_status returned None (tool not recognized)")
 
@@ -66,10 +67,10 @@ let test_pause_status_allowed () =
 let test_pause_blocked () =
   with_room (fun config ->
     match dispatch config "masc_pause" with
-    | Some (false, msg) ->
+    | Some tr when not tr.Tool_result.success ->
         check bool "error mentions blocked" true
-          (contains_substring msg "blocked")
-    | Some (true, _) ->
+          (contains_substring tr.Tool_result.legacy_message "blocked")
+    | Some _tr ->
         fail "masc_pause should be blocked in keeper context"
     | None ->
         fail "masc_pause returned None")
@@ -78,10 +79,10 @@ let test_pause_blocked () =
 let test_resume_blocked () =
   with_room (fun config ->
     match dispatch config "masc_resume" with
-    | Some (false, msg) ->
+    | Some tr when not tr.Tool_result.success ->
         check bool "error mentions blocked" true
-          (contains_substring msg "blocked")
-    | Some (true, _) ->
+          (contains_substring tr.Tool_result.legacy_message "blocked")
+    | Some _tr ->
         fail "masc_resume should be blocked in keeper context"
     | None ->
         fail "masc_resume returned None")
@@ -89,22 +90,23 @@ let test_resume_blocked () =
 let test_approval_pending_inline_allowed () =
   with_room (fun config ->
     match dispatch_inline config "masc_approval_pending" with
-    | Some (true, msg) ->
-        (match Yojson.Safe.from_string msg with
+    | Some tr when tr.Tool_result.success ->
+        (match Yojson.Safe.from_string tr.Tool_result.legacy_message with
          | `List _ -> ()
          | _ -> fail "masc_approval_pending should return a JSON list")
-    | Some (false, msg) ->
-        fail (Printf.sprintf "masc_approval_pending should succeed: %s" msg)
+    | Some tr ->
+        fail (Printf.sprintf "masc_approval_pending should succeed: %s"
+          tr.Tool_result.legacy_message)
     | None ->
         fail "masc_approval_pending returned None")
 
 let test_other_inline_blocked () =
   with_room (fun config ->
     match dispatch_inline config "masc_who" with
-    | Some (false, msg) ->
+    | Some tr when not tr.Tool_result.success ->
         check bool "error mentions MCP context" true
-          (contains_substring msg "requires MCP session context")
-    | Some (true, _) ->
+          (contains_substring tr.Tool_result.legacy_message "requires MCP session context")
+    | Some _tr ->
         fail "masc_who should remain blocked in keeper context"
     | None ->
         fail "masc_who returned None")

--- a/test/test_telemetry_task_transition_10358.ml
+++ b/test/test_telemetry_task_transition_10358.ml
@@ -46,8 +46,8 @@ let run_transition ctx ~task_id ~action ?(notes = "") () =
       ]
   in
   match Tool_task.dispatch ctx ~name:"masc_transition" ~args with
-  | Some (true, _) -> ()
-  | Some (false, msg) -> Alcotest.fail msg
+  | Some result ->
+      if not result.success then Alcotest.fail (Tool_result.message result)
   | None -> Alcotest.fail "masc_transition dispatch returned None"
 
 let event_exists predicate config =

--- a/test/test_tool_code_coverage.ml
+++ b/test/test_tool_code_coverage.ml
@@ -62,7 +62,7 @@ let make_ctx () =
 
 let dispatch_exn ctx ~name ~args =
   match Tool_code.dispatch ctx ~name ~args with
-  | Some result -> result
+  | Some result -> (result.success, result.legacy_message)
   | None -> failwith ("dispatch returned None for " ^ name)
 
 (* ============================================================

--- a/test/test_tool_code_write_coverage.ml
+++ b/test/test_tool_code_write_coverage.ml
@@ -192,7 +192,7 @@ let make_ctx () : Tool_code_write.context =
 
 let dispatch_exn ctx ~name ~args =
   match Tool_code_write.dispatch ctx ~name ~args with
-  | Some result -> result
+  | Some result -> (result.success, result.legacy_message)
   | None -> fail ("dispatch returned None for " ^ name)
 
 let test_allowed_org () =

--- a/test/test_tool_control_coverage.ml
+++ b/test/test_tool_control_coverage.ml
@@ -71,9 +71,9 @@ let () =
         Tool_control.dispatch ctx ~name:"masc_pause"
           ~args:(`Assoc [ ("reason", `String "Test pause") ])
       with
-      | Some (success, result) ->
-          assert success;
-          assert (String.length result > 0)
+      | Some result ->
+          assert result.success;
+          assert (String.length result.legacy_message > 0)
       | None -> failwith "dispatch returned None")
 
 let () =
@@ -84,9 +84,9 @@ let () =
           (`Assoc [ ("reason", `String "For status test") ])
       in
       match Tool_control.dispatch ctx ~name:"masc_pause_status" ~args:(`Assoc []) with
-      | Some (success, result) ->
-          assert success;
-          let json = parse_json result in
+      | Some result ->
+          assert result.success;
+          let json = parse_json result.legacy_message in
           assert (Yojson.Safe.Util.member "paused" json = `Bool true);
           assert (Yojson.Safe.Util.member "status" json = `String "paused")
       | None -> failwith "dispatch returned None")
@@ -99,18 +99,18 @@ let () =
           (`Assoc [ ("reason", `String "For resume test") ])
       in
       match Tool_control.dispatch ctx ~name:"masc_resume" ~args:(`Assoc []) with
-      | Some (success, result) ->
-          assert success;
-          assert (String.length result > 0)
+      | Some result ->
+          assert result.success;
+          assert (String.length result.legacy_message > 0)
       | None -> failwith "dispatch returned None")
 
 let () =
   test "dispatch_pause_status_running" (fun () ->
       with_ctx @@ fun ctx ->
       match Tool_control.dispatch ctx ~name:"masc_pause_status" ~args:(`Assoc []) with
-      | Some (success, result) ->
-          assert success;
-          let json = parse_json result in
+      | Some result ->
+          assert result.success;
+          let json = parse_json result.legacy_message in
           assert (Yojson.Safe.Util.member "paused" json = `Bool false);
           assert (Yojson.Safe.Util.member "status" json = `String "running")
       | None -> failwith "dispatch returned None")
@@ -122,9 +122,9 @@ let () =
         Tool_control.dispatch ctx ~name:"masc_pause_status"
           ~args:(`Assoc [ ("namespace_id", `String "focus-room") ])
       with
-      | Some (success, result) ->
-          assert success;
-          let json = parse_json result in
+      | Some result ->
+          assert result.success;
+          let json = parse_json result.legacy_message in
           assert (Yojson.Safe.Util.member "namespace_id" json = `Null);
           assert (Yojson.Safe.Util.member "namespace" json = `Null);
           assert (Yojson.Safe.Util.member "requested_namespace_id" json = `Null)
@@ -134,9 +134,9 @@ let () =
   test "dispatch_pause_status_uninitialized_room_is_safe" (fun () ->
       with_ctx ~initialize:false @@ fun ctx ->
       match Tool_control.dispatch ctx ~name:"masc_pause_status" ~args:(`Assoc []) with
-      | Some (success, result) ->
-          assert success;
-          let json = parse_json result in
+      | Some result ->
+          assert result.success;
+          let json = parse_json result.legacy_message in
           assert (Yojson.Safe.Util.member "status" json = `String "initializing");
           assert (Yojson.Safe.Util.member "initializing" json = `Bool true);
           assert (Yojson.Safe.Util.member "paused" json = `Null)

--- a/test/test_tool_dispatch.ml
+++ b/test/test_tool_dispatch.ml
@@ -11,11 +11,11 @@ let make_schema name =
   { Masc_domain.name; description = "test tool " ^ name;
     input_schema = `Assoc [("type", `String "object")] }
 
-(** Helper: a handler that returns (true, "ok:<name>"). *)
-let echo_handler ~name ~args:_ = Some (true, "ok:" ^ name)
+(** Helper: a handler that returns a successful result with "ok:<name>". *)
+let echo_handler ~name ~args:_ = Some (Tool_result.quick_ok ~tool_name:name ("ok:" ^ name))
 
 (** Helper: a handler that returns (false, "fail"). *)
-let fail_handler ~name:_ ~args:_ = Some (false, "fail")
+let fail_handler ~name:_ ~args:_ = Some (Tool_result.quick_error "fail")
 
 (** Helper: register a tool in both handler and tag registries.
     mint_token validates against tag_registry, so tests that mint
@@ -202,7 +202,7 @@ let () =
               let received_args = ref `Null in
               let capture_handler ~name:_ ~args =
                 received_args := args;
-                Some (true, "captured")
+                Some (Tool_result.quick_ok "captured")
               in
               register_full ~tool_name:tool ~handler:capture_handler;
               let test_args = `Assoc [("key", `String "value")] in

--- a/test/test_tool_hooks.ml
+++ b/test/test_tool_hooks.ml
@@ -21,7 +21,7 @@ let test_pre_hook_observes () =
     ~tool_name:"__hook_test"
     ~handler:(fun ~name:_ ~args:_ ->
       log_call "handler";
-      Some (true, "ok"));
+      Some (Tool_result.quick_ok "ok"));
   Tool_dispatch.register_name_tag ~tool_name:"__hook_test" ~tag:Mod_misc;
   Tool_dispatch.register_pre_hook (fun ~name:_ ~args:_ ->
     log_call "pre";
@@ -39,7 +39,7 @@ let test_pre_hook_short_circuits () =
     ~tool_name:"__hook_blocked"
     ~handler:(fun ~name:_ ~args:_ ->
       log_call "handler";
-      Some (true, "should not reach"));
+      Some (Tool_result.quick_ok "should not reach"));
   Tool_dispatch.register_name_tag ~tool_name:"__hook_blocked" ~tag:Mod_misc;
   Tool_dispatch.register_pre_hook (fun ~name ~args:_ ->
     log_call "pre_block";
@@ -65,7 +65,7 @@ let test_multiple_pre_hooks_first_wins () =
     ~tool_name:"__hook_multi"
     ~handler:(fun ~name:_ ~args:_ ->
       log_call "handler";
-      Some (true, "ok"));
+      Some (Tool_result.quick_ok "ok"));
   Tool_dispatch.register_name_tag ~tool_name:"__hook_multi" ~tag:Mod_misc;
   (* First hook: observe only *)
   Tool_dispatch.register_pre_hook (fun ~name:_ ~args:_ ->
@@ -98,7 +98,7 @@ let test_post_hook_observes () =
     ~tool_name:"__hook_post"
     ~handler:(fun ~name:_ ~args:_ ->
       log_call "handler";
-      Some (true, "original"));
+      Some (Tool_result.quick_ok "original"));
   Tool_dispatch.register_name_tag ~tool_name:"__hook_post" ~tag:Mod_misc;
   Tool_dispatch.register_post_hook (fun r ->
     log_call "post";
@@ -116,7 +116,7 @@ let test_post_hook_transforms () =
   Tool_dispatch.register
     ~tool_name:"__hook_transform"
     ~handler:(fun ~name:_ ~args:_ ->
-      Some (true, "original"));
+      Some (Tool_result.quick_ok "original"));
   Tool_dispatch.register_name_tag ~tool_name:"__hook_transform" ~tag:Mod_misc;
   Tool_dispatch.register_post_hook (fun r ->
     { r with Tool_result.data = `String "transformed" });
@@ -133,7 +133,7 @@ let test_post_hooks_chain () =
   Tool_dispatch.register
     ~tool_name:"__hook_chain"
     ~handler:(fun ~name:_ ~args:_ ->
-      Some (true, "0"));
+      Some (Tool_result.quick_ok "0"));
   Tool_dispatch.register_name_tag ~tool_name:"__hook_chain" ~tag:Mod_misc;
   Tool_dispatch.register_post_hook (fun r ->
     log_call "post1";
@@ -158,7 +158,7 @@ let test_full_lifecycle () =
     ~tool_name:"__hook_full"
     ~handler:(fun ~name:_ ~args:_ ->
       log_call "handler";
-      Some (true, "data"));
+      Some (Tool_result.quick_ok "data"));
   Tool_dispatch.register_name_tag ~tool_name:"__hook_full" ~tag:Mod_misc;
   Tool_dispatch.register_pre_hook (fun ~name:_ ~args:_ ->
     log_call "pre";
@@ -176,7 +176,7 @@ let test_no_hooks_default () =
   (* No hooks registered *)
   Tool_dispatch.register
     ~tool_name:"__hook_none"
-    ~handler:(fun ~name:_ ~args:_ -> Some (true, "plain"));
+    ~handler:(fun ~name:_ ~args:_ -> Some (Tool_result.quick_ok "plain"));
   Tool_dispatch.register_name_tag ~tool_name:"__hook_none" ~tag:Mod_misc;
   let token = match Tool_dispatch.mint_token ~name:"__hook_none" with Ok t -> t | Error e -> Alcotest.fail e in
   match Tool_dispatch.dispatch_structured ~token ~args:`Null with

--- a/test/test_tool_library_coverage.ml
+++ b/test/test_tool_library_coverage.ml
@@ -65,7 +65,7 @@ let with_temp_home f =
 
 let dispatch_exn ctx ~name ~args =
   match Tool_library.dispatch ctx ~name ~args with
-  | Some result -> result
+  | Some result -> (result.success, result.legacy_message)
   | None -> failwith ("dispatch returned None for " ^ name)
 
 (* ============================================================

--- a/test/test_tool_misc_coverage.ml
+++ b/test/test_tool_misc_coverage.ml
@@ -86,11 +86,11 @@ let () = test "dispatch_dashboard" (fun () ->
   ignore (Coord.add_task second_room ~title:"second task" ~priority:1 ~description:"");
   let args = `Assoc [] in
   match Tool_misc.dispatch ctx ~name:"masc_dashboard" ~args with
-  | Some (success, result) ->
-      assert success;
-      assert (str_contains result "MASC Dashboard");
-      assert (str_contains result "Namespace: default (flattened)");
-      assert (not (str_contains result "second-room"));
+  | Some result ->
+      assert result.success;
+      assert (str_contains result.legacy_message "MASC Dashboard");
+      assert (str_contains result.legacy_message "Namespace: default (flattened)");
+      assert (not (str_contains result.legacy_message "second-room"));
   | None -> failwith "dispatch returned None"
   | exception Effect.Unhandled _ ->
       Printf.printf "  (skipped: Eio runtime not available)\n"
@@ -101,10 +101,10 @@ let () = test "dispatch_dashboard_compact" (fun () ->
   let ctx = make_test_ctx () in
   let args = `Assoc [("compact", `Bool true)] in
   match Tool_misc.dispatch ctx ~name:"masc_dashboard" ~args with
-  | Some (success, result) ->
-      assert success;
-      assert (str_contains result "MASC [");
-      assert (str_contains result "ATTENTION:");
+  | Some result ->
+      assert result.success;
+      assert (str_contains result.legacy_message "MASC [");
+      assert (str_contains result.legacy_message "ATTENTION:");
   | None -> failwith "dispatch returned None"
   | exception Effect.Unhandled _ ->
       Printf.printf "  (skipped: Eio runtime not available)\n"
@@ -117,11 +117,11 @@ let () = test "dispatch_dashboard_current_scope" (fun () ->
   ignore (Coord.add_task focused ~title:"focus task" ~priority:2 ~description:"");
   let args = `Assoc [("scope", `String "current")] in
   match Tool_misc.dispatch ctx ~name:"masc_dashboard" ~args with
-  | Some (success, result) ->
-      assert success;
-      assert (str_contains result "MASC Dashboard");
-      assert (str_contains result "Namespace: default (flattened)");
-      assert (not (str_contains result "focus-room"))
+  | Some result ->
+      assert result.success;
+      assert (str_contains result.legacy_message "MASC Dashboard");
+      assert (str_contains result.legacy_message "Namespace: default (flattened)");
+      assert (not (str_contains result.legacy_message "focus-room"))
   | None -> failwith "dispatch returned None"
   | exception Effect.Unhandled _ ->
       Printf.printf "  (skipped: Eio runtime not available)\n"
@@ -131,9 +131,9 @@ let () = test "dispatch_dashboard_invalid_scope" (fun () ->
   let ctx = make_test_ctx () in
   let args = `Assoc [("scope", `String "everywhere")] in
   match Tool_misc.dispatch ctx ~name:"masc_dashboard" ~args with
-  | Some (success, result) ->
-      assert (not success);
-      assert (str_contains result "Invalid dashboard scope")
+  | Some result ->
+      assert (not result.success);
+      assert (str_contains result.legacy_message "Invalid dashboard scope")
   | None -> failwith "dispatch returned None"
 )
 
@@ -142,9 +142,9 @@ let () = test "dispatch_gc" (fun () ->
   let ctx = make_test_ctx () in
   let args = `Assoc [("days", `Int 7)] in
   match Tool_misc.dispatch ctx ~name:"masc_gc" ~args with
-  | Some (success, result) ->
-      assert success;
-      assert (String.length result > 0)
+  | Some result ->
+      assert result.success;
+      assert (String.length result.legacy_message > 0)
   | None -> failwith "dispatch returned None"
 )
 
@@ -153,9 +153,9 @@ let () = test "dispatch_gc_default" (fun () ->
   let ctx = make_test_ctx () in
   let args = `Assoc [] in
   match Tool_misc.dispatch ctx ~name:"masc_gc" ~args with
-  | Some (success, result) ->
-      assert success;
-      assert (String.length result > 0)
+  | Some result ->
+      assert result.success;
+      assert (String.length result.legacy_message > 0)
   | None -> failwith "dispatch returned None"
 )
 
@@ -164,9 +164,9 @@ let () = test "dispatch_cleanup_zombies" (fun () ->
   let ctx = make_test_ctx () in
   let args = `Assoc [] in
   match Tool_misc.dispatch ctx ~name:"masc_cleanup_zombies" ~args with
-  | Some (success, result) ->
-      assert success;
-      assert (String.length result > 0)
+  | Some result ->
+      assert result.success;
+      assert (String.length result.legacy_message > 0)
   | None -> failwith "dispatch returned None"
 )
 
@@ -174,9 +174,9 @@ let () = test "dispatch_web_search_requires_query" (fun () ->
   let ctx = make_test_ctx () in
   let args = `Assoc [] in
   match Tool_misc.dispatch ctx ~name:"masc_web_search" ~args with
-  | Some (success, result) ->
-      assert (not success);
-      let json = parse_json result in
+  | Some result ->
+      assert (not result.success);
+      let json = parse_json result.legacy_message in
       assert (Yojson.Safe.Util.member "status" json = `String "error");
       assert (Yojson.Safe.Util.member "message" json = `String "query is required")
   | None -> failwith "dispatch returned None"
@@ -187,9 +187,9 @@ let () = test "dispatch_web_search_rejects_long_query" (fun () ->
   let query = String.make 501 'a' in
   let args = `Assoc [ ("query", `String query) ] in
   match Tool_misc.dispatch ctx ~name:"masc_web_search" ~args with
-  | Some (success, result) ->
-      assert (not success);
-      let json = parse_json result in
+  | Some result ->
+      assert (not result.success);
+      let json = parse_json result.legacy_message in
       assert (Yojson.Safe.Util.member "status" json = `String "error");
       assert
         (Yojson.Safe.Util.member "message" json
@@ -201,9 +201,9 @@ let () = test "dispatch_web_search_rejects_secret_like_query" (fun () ->
   let ctx = make_test_ctx () in
   let args = `Assoc [ ("query", `String "Authorization: Bearer secret-token") ] in
   match Tool_misc.dispatch ctx ~name:"masc_web_search" ~args with
-  | Some (success, result) ->
-      assert (not success);
-      let json = parse_json result in
+  | Some result ->
+      assert (not result.success);
+      let json = parse_json result.legacy_message in
       assert (Yojson.Safe.Util.member "status" json = `String "error");
       assert
         (Yojson.Safe.Util.member "message" json
@@ -463,9 +463,9 @@ let () = test "dispatch_webrtc_offer" (fun () ->
       ]
   in
   match Tool_misc.dispatch ctx ~name:"masc_webrtc_offer" ~args with
-  | Some (success, result) ->
-      assert success;
-      let json = parse_json result in
+  | Some result ->
+      assert result.success;
+      let json = parse_json result.legacy_message in
       let offer_id = Yojson.Safe.Util.(json |> member "offer_id" |> to_string) in
       assert (String.length offer_id > 0);
       ignore (Server_webrtc_transport.cleanup_expired_offers ~max_age_s:0.0 ())
@@ -483,8 +483,8 @@ let () = test "dispatch_webrtc_answer" (fun () ->
   in
   let offer_result =
     match Tool_misc.dispatch ctx ~name:"masc_webrtc_offer" ~args:offer_args with
-    | Some (true, result) -> parse_json result
-    | Some (false, result) -> failwith result
+    | Some result when result.success -> parse_json result.legacy_message
+    | Some result -> failwith result.legacy_message
     | None -> failwith "offer dispatch returned None"
   in
   let offer_id =
@@ -499,9 +499,9 @@ let () = test "dispatch_webrtc_answer" (fun () ->
       ]
   in
   match Tool_misc.dispatch ctx ~name:"masc_webrtc_answer" ~args:answer_args with
-  | Some (success, result) ->
-      assert success;
-      let json = parse_json result in
+  | Some result ->
+      assert result.success;
+      let json = parse_json result.legacy_message in
       let peer_id = Yojson.Safe.Util.(json |> member "peer_id" |> to_string) in
       assert (String.length peer_id > 0);
       Server_webrtc_transport.remove_peer peer_id
@@ -519,9 +519,9 @@ let () = test "dispatch_webrtc_offer_disabled" (fun () ->
         ]
     in
     match Tool_misc.dispatch ctx ~name:"masc_webrtc_offer" ~args with
-    | Some (success, result) ->
-        assert (not success);
-        assert (str_contains result "webrtc transport disabled")
+    | Some result ->
+        assert (not result.success);
+        assert (str_contains result.legacy_message "webrtc transport disabled")
     | None -> failwith "dispatch returned None"))
 
 let () = test "dispatch_webrtc_answer_disabled" (fun () ->
@@ -536,18 +536,18 @@ let () = test "dispatch_webrtc_answer_disabled" (fun () ->
         ]
     in
     match Tool_misc.dispatch ctx ~name:"masc_webrtc_answer" ~args with
-    | Some (success, result) ->
-        assert (not success);
-        assert (str_contains result "webrtc transport disabled")
+    | Some result ->
+        assert (not result.success);
+        assert (str_contains result.legacy_message "webrtc transport disabled")
     | None -> failwith "dispatch returned None"))
 
 let () = test "dispatch_tool_admin_snapshot" (fun () ->
   let ctx = make_test_ctx () in
   let args = `Assoc [] in
   match Tool_misc.dispatch ctx ~name:"masc_tool_admin_snapshot" ~args with
-  | Some (success, result) ->
-      assert success;
-      let json = parse_json result in
+  | Some result ->
+      assert result.success;
+      let json = parse_json result.legacy_message in
       assert (Yojson.Safe.Util.member "tool_inventory" json <> `Null);
       assert (Yojson.Safe.Util.member "auth" json <> `Null);
       assert (Yojson.Safe.Util.member "http_auth_strict" (Yojson.Safe.Util.member "auth" json) <> `Null);
@@ -570,8 +570,8 @@ let () = test "dispatch_tool_admin_update_rejects_mode" (fun () ->
       ]
   in
   match Tool_misc.dispatch ctx ~name:"masc_tool_admin_update" ~args with
-  | Some (success, _result) ->
-      assert (not success)
+  | Some result ->
+      assert (not result.success)
   | None -> failwith "dispatch returned None"
 )
 
@@ -587,9 +587,9 @@ let () = test "dispatch_tool_admin_update_auth" (fun () ->
       ]
   in
   match Tool_misc.dispatch ctx ~name:"masc_tool_admin_update" ~args with
-  | Some (success, result) ->
-      assert success;
-      let json = parse_json result in
+  | Some result ->
+      assert result.success;
+      let json = parse_json result.legacy_message in
       assert (Yojson.Safe.Util.(json |> member "section" |> to_string) = "auth");
       let cfg = Auth.load_auth_config ctx.config.base_path in
       assert cfg.enabled;
@@ -610,9 +610,9 @@ let () = test "dispatch_tool_admin_update_auth_rejects_removed_default_role" (fu
       ]
   in
   match Tool_misc.dispatch ctx ~name:"masc_tool_admin_update" ~args with
-  | Some (success, result) ->
-      assert (not success);
-      assert (str_contains result "default_role is no longer supported");
+  | Some result ->
+      assert (not result.success);
+      assert (str_contains result.legacy_message "default_role is no longer supported");
       let after = Auth.load_auth_config ctx.config.base_path in
       assert (after.enabled = before.enabled);
       assert (after.require_token = before.require_token);
@@ -662,8 +662,8 @@ let () = test "dispatch_tool_admin_update_keeper_policy" (fun () ->
               ]
           in
           match Tool_misc.dispatch ctx ~name:"masc_tool_admin_update" ~args with
-          | Some (false, _msg) -> () (* expected: section no longer supported *)
-          | Some (true, _) -> failwith "keeper_policy section should be rejected"
+          | Some inner when not inner.success -> () (* expected: section no longer supported *)
+          | Some _ -> failwith "keeper_policy section should be rejected"
           | None -> failwith "dispatch returned None")
       | Some (false, err) -> failwith err
       | None -> failwith "keeper up dispatch returned None")

--- a/test/test_tool_plan_coverage.ml
+++ b/test/test_tool_plan_coverage.ml
@@ -56,38 +56,37 @@ let test_dispatch_plan_init () =
   let ctx = make_ctx () in
   let args = `Assoc [("task_id", `String "task-001")] in
   match Tool_plan.dispatch ctx ~name:"masc_plan_init" ~args with
-  | Some (success, msg) ->
-      (* Will fail due to no fs initialization, just check dispatch works *)
-      check bool "dispatches to plan_init" true (String.length msg > 0);
-      ignore success
+  | Some result ->
+      check bool "dispatches to plan_init" true (String.length result.legacy_message > 0);
+      ignore result.success
   | None -> fail "expected Some"
 
 let test_dispatch_plan_update () =
   let ctx = make_ctx () in
   let args = `Assoc [("task_id", `String "task-001"); ("content", `String "test")] in
   match Tool_plan.dispatch ctx ~name:"masc_plan_update" ~args with
-  | Some (_, msg) -> check bool "has message" true (String.length msg > 0)
+  | Some result -> check bool "has message" true (String.length result.legacy_message > 0)
   | None -> fail "expected Some"
 
 let test_dispatch_note_add () =
   let ctx = make_ctx () in
   let args = `Assoc [("task_id", `String "task-001"); ("note", `String "test note")] in
   match Tool_plan.dispatch ctx ~name:"masc_note_add" ~args with
-  | Some (_, msg) -> check bool "has message" true (String.length msg > 0)
+  | Some result -> check bool "has message" true (String.length result.legacy_message > 0)
   | None -> fail "expected Some"
 
 let test_dispatch_deliver () =
   let ctx = make_ctx () in
   let args = `Assoc [("task_id", `String "task-001"); ("content", `String "deliverable")] in
   match Tool_plan.dispatch ctx ~name:"masc_deliver" ~args with
-  | Some (_, msg) -> check bool "has message" true (String.length msg > 0)
+  | Some result -> check bool "has message" true (String.length result.legacy_message > 0)
   | None -> fail "expected Some"
 
 let test_dispatch_plan_get () =
   let ctx = make_ctx () in
   let args = `Assoc [("task_id", `String "task-001")] in
   match Tool_plan.dispatch ctx ~name:"masc_plan_get" ~args with
-  | Some (_, msg) -> check bool "has message" true (String.length msg > 0)
+  | Some result -> check bool "has message" true (String.length result.legacy_message > 0)
   | None -> fail "expected Some"
 
 let test_dispatch_error_add () =
@@ -114,26 +113,26 @@ let test_dispatch_plan_set_task () =
   let ctx = make_ctx () in
   let args = `Assoc [("task_id", `String "task-001")] in
   match Tool_plan.dispatch ctx ~name:"masc_plan_set_task" ~args with
-  | Some (success, _) -> check bool "succeeds" true success
+  | Some result -> check bool "succeeds" true result.success
   | None -> fail "expected Some"
 
 let test_dispatch_plan_set_task_empty () =
   let ctx = make_ctx () in
   let args = `Assoc [("task_id", `String "")] in
   match Tool_plan.dispatch ctx ~name:"masc_plan_set_task" ~args with
-  | Some (success, _) -> check bool "fails on empty" false success
+  | Some result -> check bool "fails on empty" false result.success
   | None -> fail "expected Some"
 
 let test_dispatch_plan_get_task () =
   let ctx = make_ctx () in
   match Tool_plan.dispatch ctx ~name:"masc_plan_get_task" ~args:(`Assoc []) with
-  | Some (success, _) -> check bool "succeeds" true success
+  | Some result -> check bool "succeeds" true result.success
   | None -> fail "expected Some"
 
 let test_dispatch_plan_clear_task () =
   let ctx = make_ctx () in
   match Tool_plan.dispatch ctx ~name:"masc_plan_clear_task" ~args:(`Assoc []) with
-  | Some (success, _) -> check bool "succeeds" true success
+  | Some result -> check bool "succeeds" true result.success
   | None -> fail "expected Some"
 
 let test_dispatch_unknown_tool () =

--- a/test/test_tool_result.ml
+++ b/test/test_tool_result.ml
@@ -118,7 +118,7 @@ let test_dispatch_structured () =
   (* Register a test handler *)
   Tool_dispatch.register
     ~tool_name:"__test_tool"
-    ~handler:(fun ~name:_ ~args:_ -> Some (true, {|{"result":"ok"}|}));
+    ~handler:(fun ~name:_ ~args:_ -> Some (Tool_result.quick_ok {|{"result":"ok"}|}));
   Tool_dispatch.register_name_tag ~tool_name:"__test_tool" ~tag:Mod_misc;
   let token = match Tool_dispatch.mint_token ~name:"__test_tool" with Ok t -> t | Error e -> Alcotest.fail e in
   match Tool_dispatch.dispatch_structured ~token ~args:`Null with

--- a/test/test_tool_spec.ml
+++ b/test/test_tool_spec.ml
@@ -317,7 +317,7 @@ let () =
                 ~description:"direct handler test"
                 ~module_tag:Tool_dispatch.Mod_misc
                 ~input_schema:empty_schema
-                ~handler_binding:(Direct (fun ~name:_ ~args:_ -> Some (true, "ok")))
+                ~handler_binding:(Direct (fun ~name:_ ~args:_ -> Some (Masc_mcp.Tool_result.quick_ok "ok")))
                 ()
             in
             Tool_spec.register spec;

--- a/test/test_tool_task_coverage.ml
+++ b/test/test_tool_task_coverage.ml
@@ -143,7 +143,7 @@ let () = test "dispatch_add_task" (fun () ->
   let ctx = make_test_ctx () in
   let args = `Assoc [("title", `String "Test task"); ("priority", `Int 2)] in
   match Tool_task.dispatch ctx ~name:"masc_add_task" ~args with
-  | Some (success, _result) -> assert success
+  | Some result -> assert result.success
   | None -> failwith "dispatch returned None"
 )
 
@@ -152,7 +152,7 @@ let () = test "dispatch_tasks" (fun () ->
   let ctx = make_test_ctx () in
   let args = `Assoc [] in
   match Tool_task.dispatch ctx ~name:"masc_tasks" ~args with
-  | Some (success, _result) -> assert success
+  | Some result -> assert result.success
   | None -> failwith "dispatch returned None"
 )
 
@@ -235,7 +235,7 @@ let () = test "dispatch_transition_claim" (fun () ->
   let _ = Tool_task.handle_add_task ctx (`Assoc [("title", `String "Claim test")]) in
   let args = `Assoc [("task_id", `String "task-001"); ("action", `String "claim")] in
   match Tool_task.dispatch ctx ~name:"masc_transition" ~args with
-  | Some (_success, _result) -> () (* May fail if task doesn't exist *)
+  | Some _ -> () (* May fail if task doesn't exist *)
   | None -> failwith "dispatch returned None"
 )
 
@@ -244,7 +244,7 @@ let () = test "dispatch_claim_next" (fun () ->
   let ctx = make_test_ctx () in
   let args = `Assoc [] in
   match Tool_task.dispatch ctx ~name:"masc_claim_next" ~args with
-  | Some (_success, _result) -> ()
+  | Some _ -> ()
   | None -> failwith "dispatch returned None"
 )
 
@@ -1142,9 +1142,9 @@ let () = test "dispatch_claim_task_uses_server_surface_not_payload_surface" (fun
             ("agent_tool_names", `List [ `String "keeper_bash" ]);
           ])
   with
-  | Some (success, result) ->
-      assert (not success);
-      assert (str_contains result "requires tool(s) unavailable");
+  | Some result ->
+      assert (not result.success);
+      assert (str_contains result.legacy_message "requires tool(s) unavailable");
       assert_task_todo ctx
   | None -> failwith "dispatch returned None"
 )
@@ -1306,7 +1306,7 @@ let () = test "dispatch_transition_release" (fun () ->
   let ctx = make_test_ctx () in
   let args = `Assoc [("task_id", `String "task-001"); ("action", `String "release")] in
   match Tool_task.dispatch ctx ~name:"masc_transition" ~args with
-  | Some (_success, _result) -> ()
+  | Some _ -> ()
   | None -> failwith "dispatch returned None"
 )
 
@@ -1315,7 +1315,7 @@ let () = test "dispatch_transition" (fun () ->
   let ctx = make_test_ctx () in
   let args = `Assoc [("task_id", `String "task-001"); ("action", `String "start")] in
   match Tool_task.dispatch ctx ~name:"masc_transition" ~args with
-  | Some (_success, _result) -> ()
+  | Some _ -> ()
   | None -> failwith "dispatch returned None"
 )
 
@@ -1324,7 +1324,7 @@ let () = test "dispatch_update_priority" (fun () ->
   let ctx = make_test_ctx () in
   let args = `Assoc [("task_id", `String "task-001"); ("priority", `Int 1)] in
   match Tool_task.dispatch ctx ~name:"masc_update_priority" ~args with
-  | Some (_success, _result) -> ()
+  | Some _ -> ()
   | None -> failwith "dispatch returned None"
 )
 
@@ -1333,7 +1333,7 @@ let () = test "dispatch_task_history" (fun () ->
   let ctx = make_test_ctx () in
   let args = `Assoc [("task_id", `String "task-001")] in
   match Tool_task.dispatch ctx ~name:"masc_task_history" ~args with
-  | Some (success, _result) -> assert success
+  | Some result -> assert result.success
   | None -> failwith "dispatch returned None"
 )
 

--- a/test/test_tool_token.ml
+++ b/test/test_tool_token.ml
@@ -81,7 +81,7 @@ let test_token_name_readable () =
 let test_mint_token_registered () =
   let tool = "__test_token_registered" in
   Tool_dispatch.register ~tool_name:tool
-    ~handler:(fun ~name:_ ~args:_ -> Some (true, "ok"));
+    ~handler:(fun ~name:_ ~args:_ -> Some (Masc_mcp.Tool_result.quick_ok "ok"));
   Tool_dispatch.register_name_tag ~tool_name:tool ~tag:Mod_misc;
   match Tool_dispatch.mint_token ~name:tool with
   | Ok token -> check string "name" tool token.name
@@ -95,7 +95,7 @@ let test_mint_token_unregistered () =
 let test_dispatch_with_token () =
   let tool = "__test_token_dispatch" in
   Tool_dispatch.register ~tool_name:tool
-    ~handler:(fun ~name ~args:_ -> Some (true, "dispatched:" ^ name));
+    ~handler:(fun ~name ~args:_ -> Some (Tool_result.quick_ok ~tool_name:name ("dispatched:" ^ name)));
   Tool_dispatch.register_name_tag ~tool_name:tool ~tag:Mod_misc;
   match Tool_dispatch.mint_token ~name:tool with
   | Error e -> fail e

--- a/test/test_tool_worktree_coverage.ml
+++ b/test/test_tool_worktree_coverage.ml
@@ -264,8 +264,9 @@ let test_dispatch_worktree_create_spoofed_agent_blocked () =
   ] in
   match Tool_worktree.dispatch ctx ~name:"masc_worktree_create" ~args with
   | None -> fail "dispatch returned None for masc_worktree_create"
-  | Some (true, _) -> fail "spoofed agent_name should have been rejected"
-  | Some (false, msg) ->
+  | Some result when result.success -> fail "spoofed agent_name should have been rejected"
+  | Some result ->
+    let msg = result.legacy_message in
     check bool "error mentions agent_name mismatch" true
       (contains "agent_name mismatch" msg);
     check bool "error mentions the caller ctx agent" true
@@ -288,7 +289,8 @@ let test_dispatch_worktree_create_matching_agent_passes_check () =
   ] in
   match Tool_worktree.dispatch ctx ~name:"masc_worktree_create" ~args with
   | None -> fail "dispatch returned None for masc_worktree_create"
-  | Some (_ok, msg) ->
+  | Some result ->
+    let msg = result.legacy_message in
     check bool "matching agent_name does not trip spoof gate" false
       (contains "agent_name mismatch" msg)
 
@@ -304,7 +306,8 @@ let test_dispatch_worktree_create_empty_agent_falls_back () =
   ] in
   match Tool_worktree.dispatch ctx ~name:"masc_worktree_create" ~args with
   | None -> fail "dispatch returned None for masc_worktree_create"
-  | Some (_ok, msg) ->
+  | Some result ->
+    let msg = result.legacy_message in
     check bool "empty agent_name arg does not trip spoof gate" false
       (contains "agent_name mismatch" msg)
 
@@ -321,7 +324,8 @@ let test_dispatch_worktree_create_whitespace_agent_trimmed () =
   ] in
   match Tool_worktree.dispatch ctx ~name:"masc_worktree_create" ~args with
   | None -> fail "dispatch returned None for masc_worktree_create"
-  | Some (_ok, msg) ->
+  | Some result ->
+    let msg = result.legacy_message in
     check bool "whitespace agent_name trimmed to fallback" false
       (contains "agent_name mismatch" msg)
 
@@ -341,9 +345,10 @@ let test_dispatch_worktree_create_reports_missing_sandbox_clone () =
   ] in
   match Tool_worktree.dispatch ctx ~name:"masc_worktree_create" ~args with
   | None -> fail "dispatch returned None for masc_worktree_create"
-  | Some (true, msg) ->
-    fail ("expected missing_sandbox_clone error, got success: " ^ msg)
-  | Some (false, msg) ->
+  | Some result when result.success ->
+    fail ("expected missing_sandbox_clone error, got success: " ^ result.legacy_message)
+  | Some result ->
+    let msg = result.legacy_message in
     if not (contains "missing_sandbox_clone:" msg) then
       fail (Printf.sprintf "expected missing_sandbox_clone in: %s" msg);
     if not (contains "keeper_shell op=git_clone" msg) then
@@ -378,9 +383,10 @@ let test_dispatch_worktree_create_auto_provisions_workspace_repo () =
   in
   match Tool_worktree.dispatch ctx ~name:"masc_worktree_create" ~args with
   | None -> fail "dispatch returned None for masc_worktree_create"
-  | Some (false, msg) ->
-      fail (Printf.sprintf "expected auto-provision success, got error: %s" msg)
-  | Some (true, msg) ->
+  | Some result when not result.success ->
+      fail (Printf.sprintf "expected auto-provision success, got error: %s" result.legacy_message)
+  | Some result ->
+      let msg = result.legacy_message in
       check bool "message mentions auto-provision" true
         (contains "auto-provisioned" msg);
       check bool "sandbox clone created" true (Sys.file_exists sandbox_clone);
@@ -416,11 +422,11 @@ let test_dispatch_worktree_create_refreshes_playground_repo_cache () =
   in
   match Tool_worktree.dispatch ctx ~name:"masc_worktree_create" ~args with
   | None -> fail "dispatch returned None for masc_worktree_create"
-  | Some (false, msg) ->
+  | Some result when not result.success ->
       fail
         (Printf.sprintf
-           "expected worktree create to refresh cache, got error: %s" msg)
-  | Some (true, _msg) ->
+           "expected worktree create to refresh cache, got error: %s" result.legacy_message)
+  | Some result ->
       let repo =
         playground_cache_repo ~base_path ~agent_name:"test-agent"
           ~repo_name:"masc-mcp"
@@ -494,11 +500,11 @@ let test_dispatch_worktree_create_auto_provisions_after_file_storm () =
   ] in
   match Tool_worktree.dispatch ctx ~name:"masc_worktree_create" ~args with
   | None -> fail "dispatch returned None for masc_worktree_create"
-  | Some (false, msg) ->
-      fail (Printf.sprintf "expected auto-provision success after file storm, got error: %s" msg)
-  | Some (true, msg) ->
+  | Some result when not result.success ->
+      fail (Printf.sprintf "expected auto-provision success after file storm, got error: %s" result.legacy_message)
+  | Some result ->
       check bool "message mentions auto-provision" true
-        (contains "auto-provisioned" msg)
+        (contains "auto-provisioned" result.legacy_message)
 
 let test_dispatch_worktree_create_auto_provisions_before_hidden_dir_storm () =
   let base_path = temp_dir () in
@@ -522,14 +528,14 @@ let test_dispatch_worktree_create_auto_provisions_before_hidden_dir_storm () =
   ] in
   match Tool_worktree.dispatch ctx ~name:"masc_worktree_create" ~args with
   | None -> fail "dispatch returned None for masc_worktree_create"
-  | Some (false, msg) ->
+  | Some result when not result.success ->
       fail
         (Printf.sprintf
            "expected auto-provision success before hidden dir storm, got error: %s"
-           msg)
-  | Some (true, msg) ->
+           result.legacy_message)
+  | Some result ->
       check bool "message mentions auto-provision" true
-        (contains "auto-provisioned" msg)
+        (contains "auto-provisioned" result.legacy_message)
 
 let test_dispatch_worktree_create_auto_provisions_before_wide_workspace_storm ()
     =
@@ -554,14 +560,14 @@ let test_dispatch_worktree_create_auto_provisions_before_wide_workspace_storm ()
   ] in
   match Tool_worktree.dispatch ctx ~name:"masc_worktree_create" ~args with
   | None -> fail "dispatch returned None for masc_worktree_create"
-  | Some (false, msg) ->
+  | Some result when not result.success ->
       fail
         (Printf.sprintf
            "expected auto-provision success before wide workspace storm, got error: %s"
-           msg)
-  | Some (true, msg) ->
+           result.legacy_message)
+  | Some result ->
       check bool "message mentions auto-provision" true
-        (contains "auto-provisioned" msg)
+        (contains "auto-provisioned" result.legacy_message)
 
 let test_dispatch_worktree_create_and_remove_use_docker_keeper_lane () =
   let base_path = temp_dir () in
@@ -610,12 +616,13 @@ let test_dispatch_worktree_create_and_remove_use_docker_keeper_lane () =
   in
   match Tool_worktree.dispatch ctx ~name:"masc_worktree_create" ~args:create_args with
   | None -> fail "dispatch returned None for masc_worktree_create"
-  | Some (false, msg) ->
+  | Some result when not result.success ->
       fail
         (Printf.sprintf
            "expected docker keeper auto-provision success, got error: %s"
-           msg)
-  | Some (true, msg) ->
+           result.legacy_message)
+  | Some result ->
+      let msg = result.legacy_message in
       check bool "message mentions auto-provision" true
         (contains "auto-provisioned" msg);
       check bool "message contains docker-visible worktree path" true
@@ -633,12 +640,12 @@ let test_dispatch_worktree_create_and_remove_use_docker_keeper_lane () =
       let remove_args = `Assoc [ ("task_id", `String task_id) ] in
       match Tool_worktree.dispatch ctx ~name:"masc_worktree_remove" ~args:remove_args with
       | None -> fail "dispatch returned None for masc_worktree_remove"
-      | Some (false, remove_msg) ->
+      | Some remove_result when not remove_result.success ->
           fail
             (Printf.sprintf
                "expected docker keeper remove success, got error: %s"
-               remove_msg)
-      | Some (true, _remove_msg) ->
+               remove_result.legacy_message)
+      | Some _ ->
           check bool "docker worktree removed" false
             (Sys.file_exists docker_worktree)
 
@@ -680,12 +687,13 @@ let test_dispatch_worktree_create_repairs_existing_sandbox_clone_checkout () =
   in
   match Tool_worktree.dispatch ctx ~name:"masc_worktree_create" ~args with
   | None -> fail "dispatch returned None for masc_worktree_create"
-  | Some (false, msg) ->
+  | Some result when not result.success ->
       fail
         (Printf.sprintf
            "expected broken sandbox clone checkout to be repaired, got error: %s"
-           msg)
-  | Some (true, msg) ->
+           result.legacy_message)
+  | Some result ->
+      let msg = result.legacy_message in
       check bool "message mentions checkout restore" true
         (contains "restored from HEAD" msg);
       check bool "sandbox clone checkout restored" true
@@ -717,12 +725,13 @@ let test_dispatch_worktree_create_cleans_failed_auto_clone () =
   in
   match Tool_worktree.dispatch ctx ~name:"masc_worktree_create" ~args with
   | None -> fail "dispatch returned None for masc_worktree_create"
-  | Some (true, msg) ->
+  | Some result when result.success ->
       fail
         (Printf.sprintf
            "expected auto-provision clone failure, got success: %s"
-           msg)
-  | Some (false, msg) ->
+           result.legacy_message)
+  | Some result ->
+      let msg = result.legacy_message in
       check_contains "message mentions auto-provision failure"
         "auto_provision_clone_failed" msg;
       check bool "partial sandbox clone was cleaned" false
@@ -749,12 +758,13 @@ let test_dispatch_worktree_create_rejects_invalid_sandbox_clone () =
   ] in
   match Tool_worktree.dispatch ctx ~name:"masc_worktree_create" ~args with
   | None -> fail "dispatch returned None for masc_worktree_create"
-  | Some (true, msg) ->
+  | Some result when result.success ->
       fail
         (Printf.sprintf
            "expected invalid sandbox clone failure, got success: %s"
-           msg)
-  | Some (false, msg) ->
+           result.legacy_message)
+  | Some result ->
+      let msg = result.legacy_message in
       check_contains "message mentions invalid sandbox clone"
         "sandbox_clone_invalid" msg;
       check bool "invalid sandbox clone was preserved" true
@@ -810,12 +820,13 @@ let test_worktree_create_rejects_existing_non_git_worktree_path () =
   ] in
   match Tool_worktree.dispatch ctx ~name:"masc_worktree_create" ~args with
   | None -> fail "dispatch returned None for masc_worktree_create"
-  | Some (true, msg) ->
+  | Some result when result.success ->
       fail
         (Printf.sprintf
            "expected existing non-git worktree path failure, got success: %s"
-           msg)
-  | Some (false, msg) ->
+           result.legacy_message)
+  | Some result ->
+      let msg = result.legacy_message in
       check_contains "message mentions worktree path conflict"
         "worktree_path_conflict" msg;
       check bool "plain directory conflict was preserved" true


### PR DESCRIPTION
## Summary

RFC-0062 Phase 2 Big Bang migration: all `Tool_*.dispatch` return types migrated from `(bool * string) option` (Phase 0 unstructured) to `Tool_result.t option` (Phase 1 structured record).

- **50+ dispatch function signatures** updated to return `Tool_result.t option`
- All callers use structured accessors (`success`, `message`, `failure_class`, etc.)
- Exhaustive match fixes in `tool_catalog.ml` and `keeper_exec_shared.ml` (added `Memory_write`)
- `keeper_exec_memory` removed from `private_modules` (needed by tests)
- Test files updated for wrapped library module access pattern

## Test plan

- [x] `dune build --root . @check` passes (type-check only)
- [x] `dune build --root .` passes (full build)
- [ ] CI green on GitHub Actions

🤖 Generated with [Claude Code](https://claude.com/claude-code)