### PR TITLE
refactor(ide): simplify HTTP router composition and fix LSP proxy build

### DIFF
--- a/lib/server/server_ide_http.ml
+++ b/lib/server/server_ide_http.ml
@@ -85,8 +85,8 @@ let build_presence_snapshot state =
   ]
 
 let add_routes router =
-  let router1 =
-    Http.Router.get "/api/v1/ide/annotations" (fun request reqd ->
+  router
+  |> Http.Router.get "/api/v1/ide/annotations" (fun request reqd ->
       with_public_read
         (fun state _req reqd ->
           let uri = Uri.of_string request.target in
@@ -117,10 +117,7 @@ let add_routes router =
           Http.Response.json ~compress:true ~request:request
             (Yojson.Safe.to_string (json_ok json)) reqd)
         request reqd)
-    router
-  in
-  let router2 =
-    Http.Router.post "/api/v1/ide/annotations" (fun request reqd ->
+  |> Http.Router.post "/api/v1/ide/annotations" (fun request reqd ->
       with_public_read
         (fun state req reqd ->
           let uri = Uri.of_string request.target in
@@ -176,10 +173,7 @@ let add_routes router =
                   (Yojson.Safe.to_string (json_error "Missing required fields"))
                   reqd))
         request reqd)
-    router1
-  in
-  let router3 =
-    Http.Router.any "/api/v1/ide/annotations/:id" (fun request reqd ->
+  |> Http.Router.any "/api/v1/ide/annotations/:id" (fun request reqd ->
       with_public_read
         (fun state _req reqd ->
           let uri = Uri.of_string request.target in
@@ -206,10 +200,7 @@ let add_routes router =
                 Http.Response.json ~status:`Forbidden ~request:request
                   (Yojson.Safe.to_string (json_error msg)) reqd)
         request reqd)
-    router2
-  in
-  let router4 =
-    Http.Router.get "/api/v1/ide/regions" (fun request reqd ->
+  |> Http.Router.get "/api/v1/ide/regions" (fun request reqd ->
     with_public_read
       (fun state _req reqd ->
         let uri = Uri.of_string request.target in
@@ -237,20 +228,16 @@ let add_routes router =
         Http.Response.json ~compress:true ~request:request
           (Yojson.Safe.to_string (json_ok json)) reqd)
       request reqd)
-    router3
-  in
-  let router5 =
-    Http.Router.get "/api/v1/ide/presence" (fun request reqd ->
+  (* [build_presence_snapshot] extracted in main — conflict resolved by taking
+     main's helper call instead of our inline construction. *)
+  |> Http.Router.get "/api/v1/ide/presence" (fun request reqd ->
       with_public_read
         (fun state _req reqd ->
           let snapshot = build_presence_snapshot state in
           Http.Response.json ~compress:true ~request:request
             (Yojson.Safe.to_string (json_ok snapshot)) reqd)
         request reqd)
-    router4
-  in
-  let router6 =
-    Http.Router.get "/api/v1/ide/presence/stream" (fun request reqd ->
+  |> Http.Router.get "/api/v1/ide/presence/stream" (fun request reqd ->
     with_public_read
       (fun state _req inner_reqd ->
         let origin = get_origin request in
@@ -297,6 +284,3 @@ let add_routes router =
         | _ ->
             Httpun.Body.Writer.close writer)
       request reqd)
-    router5
-  in
-  router6

--- a/lib/server/server_ide_lsp_proxy.mli
+++ b/lib/server/server_ide_lsp_proxy.mli
@@ -1,0 +1,6 @@
+(** Server IDE LSP Proxy — WebSocket bridge for Language Server Protocol
+    with MASC observational overlays. *)
+
+(** Add LSP proxy routes to the router.
+    Exposes [/api/v1/ide/lsp] WebSocket endpoint for LSP traffic. *)
+val add_routes : Http_server_eio.Router.t -> Http_server_eio.Router.t


### PR DESCRIPTION
## Summary

* Stubs the missing WebSocket implementation in the WIP `server_ide_lsp_proxy.ml` to resolve compilation errors.
* Fixes duplicate `task_id` field in `ide_annotation_types.ml`.
* Refactors the HTTP router composition in `server_ide_http.ml` to use the OCaml pipeline operator (`|>`), eliminating the anti-pattern of intermediate router variables (`router1`, `router2`, etc.).

## Motivation

This cleans up the IDE-related codebase which had broken builds and poorly structured code, aligning it with the cleaner middleware pattern used in the rest of the server.
