### PR TITLE
feat(cascade_decl): RFC-0058 v2 declarative TOML parser + validator

### DIFF
--- a/lib/cascade_decl/cascade_declarative_parser.ml
+++ b/lib/cascade_decl/cascade_declarative_parser.ml
@@ -306,6 +306,31 @@ let strategy_of_string (s : string) :
           round_robin"
          s)
 
+let parse_cycle_policy (tbl : Otoml.t) : cascade_cycle_policy option =
+  let max_cycles = Otoml.find_opt tbl Otoml.get_integer [ "max-cycles" ] in
+  let backoff_base = Otoml.find_opt tbl Otoml.get_integer [ "backoff-base-ms" ] in
+  let backoff_cap = Otoml.find_opt tbl Otoml.get_integer [ "backoff-cap-ms" ] in
+  match max_cycles, backoff_base, backoff_cap with
+  | Some mc, Some bb, Some bc ->
+    Some { max_cycles = mc; backoff_base_ms = bb; backoff_cap_ms = bc }
+  | _ -> None
+
+let parse_scoring_params (tbl : Otoml.t) : cascade_scoring_params option =
+  let lat = Otoml.find_opt tbl Otoml.get_float [ "latency-baseline-ms" ] in
+  let rlw = Otoml.find_opt tbl Otoml.get_float [ "rate-limit-recency-window-s" ] in
+  let rld = Otoml.find_opt tbl Otoml.get_float [ "rate-limit-decay-base" ] in
+  let rls = Otoml.find_opt tbl Otoml.get_integer [ "rate-limit-skip-after" ] in
+  let sew = Otoml.find_opt tbl Otoml.get_float [ "server-error-recency-window-s" ] in
+  let sed = Otoml.find_opt tbl Otoml.get_float [ "server-error-decay-base" ] in
+  let ses = Otoml.find_opt tbl Otoml.get_integer [ "server-error-skip-after" ] in
+  match lat, rlw, rld, rls, sew, sed, ses with
+  | Some a, Some b, Some c, Some d, Some e, Some f, Some g ->
+    Some { latency_baseline_ms = a; rate_limit_recency_window_s = b;
+           rate_limit_decay_base = c; rate_limit_skip_after = d;
+           server_error_recency_window_s = e; server_error_decay_base = f;
+           server_error_skip_after = g }
+  | _ -> None
+
 let parse_tier (name : string) (tbl : Otoml.t) :
     (cascade_tier, parse_error list) result =
   let path = Printf.sprintf "tier.%s" name in
@@ -323,7 +348,11 @@ let parse_tier (name : string) (tbl : Otoml.t) :
   | Error e -> Error (error (path ^ ".strategy") e)
   | Ok strategy ->
     let max_concurrent = Otoml.find_opt tbl Otoml.get_integer [ "max-concurrent" ] in
-    Ok { name; members; strategy; max_concurrent }
+    let cycle_policy = parse_cycle_policy tbl in
+    let sticky_ttl_ms = Otoml.find_opt tbl Otoml.get_integer [ "sticky-ttl-ms" ] in
+    let scoring_params = parse_scoring_params tbl in
+    Ok { name; members; strategy; max_concurrent;
+         cycle_policy; sticky_ttl_ms; scoring_params }
 
 let parse_tiers (toml : Otoml.t) :
     (cascade_tier list, parse_error list) result =

--- a/lib/cascade_decl/cascade_declarative_types.ml
+++ b/lib/cascade_decl/cascade_declarative_types.ml
@@ -80,11 +80,32 @@ type cascade_strategy =
   | Round_robin
 [@@deriving show, eq]
 
+type cascade_cycle_policy = {
+  max_cycles : int;
+  backoff_base_ms : int;
+  backoff_cap_ms : int;
+}
+[@@deriving show, eq]
+
+type cascade_scoring_params = {
+  latency_baseline_ms : float;
+  rate_limit_recency_window_s : float;
+  rate_limit_decay_base : float;
+  rate_limit_skip_after : int;
+  server_error_recency_window_s : float;
+  server_error_decay_base : float;
+  server_error_skip_after : int;
+}
+[@@deriving show, eq]
+
 type cascade_tier = {
   name : string;
   members : string list;
   strategy : cascade_strategy;
   max_concurrent : int option;
+  cycle_policy : cascade_cycle_policy option;
+  sticky_ttl_ms : int option;
+  scoring_params : cascade_scoring_params option;
 }
 [@@deriving show, eq]
 

--- a/lib/cascade_decl/cascade_declarative_types.mli
+++ b/lib/cascade_decl/cascade_declarative_types.mli
@@ -103,6 +103,26 @@ type cascade_strategy =
 [@@deriving show, eq]
 
 
+(** {1 Strategy-specific parameter types} *)
+
+type cascade_cycle_policy = {
+  max_cycles : int;
+  backoff_base_ms : int;
+  backoff_cap_ms : int;
+}
+[@@deriving show, eq]
+
+type cascade_scoring_params = {
+  latency_baseline_ms : float;
+  rate_limit_recency_window_s : float;
+  rate_limit_decay_base : float;
+  rate_limit_skip_after : int;
+  server_error_recency_window_s : float;
+  server_error_decay_base : float;
+  server_error_skip_after : int;
+}
+[@@deriving show, eq]
+
 (** {1 Layer 5: Tiers, Tier-Groups, Routes} *)
 
 type cascade_tier = {
@@ -110,6 +130,9 @@ type cascade_tier = {
   members : string list;
   strategy : cascade_strategy;
   max_concurrent : int option;
+  cycle_policy : cascade_cycle_policy option;
+  sticky_ttl_ms : int option;
+  scoring_params : cascade_scoring_params option;
 }
 [@@deriving show, eq]
 

--- a/lib/cascade_decl/cascade_declarative_validator.ml
+++ b/lib/cascade_decl/cascade_declarative_validator.ml
@@ -1,6 +1,6 @@
 (** Declarative cascade config cross-reference validator (RFC-0058 v2).
 
-    Validates 9 load-time invariants on a parsed [cascade_config]:
+    Validates 10 load-time invariants on a parsed [cascade_config]:
     R1: Every binding references an existing provider
     R2: Every binding references an existing model
     R3: Every alias references an existing binding
@@ -9,7 +9,8 @@
     R6: Tier-group tiers reference existing tiers
     R7: Route targets reference existing tier-groups, tiers, or bindings
     R8: System targets reference existing bindings or aliases
-    R9: At most one is-default=true per provider *)
+    R9: At most one is-default=true per provider
+    R10: Strategy-specific fields match the declared strategy *)
 
 open Cascade_declarative_types
 
@@ -230,6 +231,40 @@ let validate_single_default (cfg : cascade_config) :
          "provider %S has multiple bindings with is-default=true" pid))
     counts
 
+(* --- R10: Strategy-specific fields match declared strategy --- *)
+
+let validate_strategy_fields (cfg : cascade_config) :
+    validation_error list =
+  List.concat_map (fun (t : cascade_tier) ->
+    let path = Printf.sprintf "tier.%s" t.name in
+    let mismatch_errors field_name expected_strategy =
+      err "R10" (Printf.sprintf "%s.%s" path field_name)
+        (Printf.sprintf
+           "%s is only valid with strategy %S, but tier uses %s"
+           field_name expected_strategy
+           (show_cascade_strategy t.strategy))
+    in
+    let cycle_errs =
+      match t.cycle_policy, t.strategy with
+      | Some _, Circuit_breaker_cycling -> []
+      | Some _, _ -> mismatch_errors "cycle-policy" "circuit_breaker_cycling"
+      | None, _ -> []
+    in
+    let sticky_errs =
+      match t.sticky_ttl_ms, t.strategy with
+      | Some _, Sticky -> []
+      | Some _, _ -> mismatch_errors "sticky-ttl-ms" "sticky"
+      | None, _ -> []
+    in
+    let scoring_errs =
+      match t.scoring_params, t.strategy with
+      | Some _, Weighted_random -> []
+      | Some _, _ -> mismatch_errors "scoring-params" "weighted_random"
+      | None, _ -> []
+    in
+    cycle_errs @ sticky_errs @ scoring_errs)
+    cfg.tiers
+
 (* --- Top-level validation --- *)
 
 let validate (cfg : cascade_config) : validation_error list =
@@ -242,3 +277,4 @@ let validate (cfg : cascade_config) : validation_error list =
   @ validate_route_targets cfg
   @ validate_system_targets cfg
   @ validate_single_default cfg
+  @ validate_strategy_fields cfg

--- a/test/test_cascade_declarative_parser.ml
+++ b/test/test_cascade_declarative_parser.ml
@@ -411,6 +411,184 @@ strategy = "%s"
     | _ -> failwith "expected exactly one tier")
     strategies
 
+(* --- Strategy-specific field tests --- *)
+
+let test_cycle_policy () =
+  let toml = {|
+[providers.p]
+protocol = "anthropic-cli"
+command = "c"
+
+[models.m]
+max-context = 4096
+
+[p.m]
+
+[tier.t]
+members = ["p.m"]
+strategy = "circuit_breaker_cycling"
+max-cycles = 3
+backoff-base-ms = 500
+backoff-cap-ms = 10000
+|} in
+  let cfg = ok_config (parse_string toml) in
+  match cfg.tiers with
+  | [ t ] ->
+    (match t.cycle_policy with
+     | Some cp ->
+       check int "max_cycles" 3 cp.max_cycles;
+       check int "backoff_base_ms" 500 cp.backoff_base_ms;
+       check int "backoff_cap_ms" 10000 cp.backoff_cap_ms
+     | None -> failwith "expected cycle_policy")
+  | _ -> failwith "expected exactly one tier"
+
+let test_cycle_policy_absent () =
+  let toml = {|
+[providers.p]
+protocol = "anthropic-cli"
+command = "c"
+
+[models.m]
+max-context = 4096
+
+[p.m]
+
+[tier.t]
+members = ["p.m"]
+strategy = "failover"
+|} in
+  let cfg = ok_config (parse_string toml) in
+  match cfg.tiers with
+  | [ t ] ->
+    check bool "no cycle_policy" true (t.cycle_policy = None)
+  | _ -> failwith "expected exactly one tier"
+
+let test_cycle_policy_partial_ignored () =
+  let toml = {|
+[providers.p]
+protocol = "anthropic-cli"
+command = "c"
+
+[models.m]
+max-context = 4096
+
+[p.m]
+
+[tier.t]
+members = ["p.m"]
+strategy = "circuit_breaker_cycling"
+max-cycles = 3
+backoff-base-ms = 500
+|} in
+  let cfg = ok_config (parse_string toml) in
+  match cfg.tiers with
+  | [ t ] ->
+    check bool "partial yields None" true (t.cycle_policy = None)
+  | _ -> failwith "expected exactly one tier"
+
+let test_sticky_ttl_ms () =
+  let toml = {|
+[providers.p]
+protocol = "anthropic-cli"
+command = "c"
+
+[models.m]
+max-context = 4096
+
+[p.m]
+
+[tier.t]
+members = ["p.m"]
+strategy = "sticky"
+sticky-ttl-ms = 600000
+|} in
+  let cfg = ok_config (parse_string toml) in
+  match cfg.tiers with
+  | [ t ] ->
+    check opt_int "sticky_ttl_ms" (Some 600000) t.sticky_ttl_ms
+  | _ -> failwith "expected exactly one tier"
+
+let test_sticky_ttl_ms_absent () =
+  let toml = {|
+[providers.p]
+protocol = "anthropic-cli"
+command = "c"
+
+[models.m]
+max-context = 4096
+
+[p.m]
+
+[tier.t]
+members = ["p.m"]
+strategy = "sticky"
+|} in
+  let cfg = ok_config (parse_string toml) in
+  match cfg.tiers with
+  | [ t ] ->
+    check opt_int "no sticky_ttl_ms" None t.sticky_ttl_ms
+  | _ -> failwith "expected exactly one tier"
+
+let test_scoring_params () =
+  let toml = {|
+[providers.p]
+protocol = "anthropic-cli"
+command = "c"
+
+[models.m]
+max-context = 4096
+
+[p.m]
+
+[tier.t]
+members = ["p.m"]
+strategy = "weighted_random"
+latency-baseline-ms = 200.0
+rate-limit-recency-window-s = 60.0
+rate-limit-decay-base = 0.5
+rate-limit-skip-after = 3
+server-error-recency-window-s = 120.0
+server-error-decay-base = 0.3
+server-error-skip-after = 5
+|} in
+  let cfg = ok_config (parse_string toml) in
+  match cfg.tiers with
+  | [ t ] ->
+    (match t.scoring_params with
+     | Some sp ->
+       check float_testable "latency_baseline" 200.0 sp.latency_baseline_ms;
+       check float_testable "rl_recency" 60.0 sp.rate_limit_recency_window_s;
+       check float_testable "rl_decay" 0.5 sp.rate_limit_decay_base;
+       check int "rl_skip" 3 sp.rate_limit_skip_after;
+       check float_testable "se_recency" 120.0 sp.server_error_recency_window_s;
+       check float_testable "se_decay" 0.3 sp.server_error_decay_base;
+       check int "se_skip" 5 sp.server_error_skip_after
+     | None -> failwith "expected scoring_params")
+  | _ -> failwith "expected exactly one tier"
+
+let test_scoring_params_partial_ignored () =
+  let toml = {|
+[providers.p]
+protocol = "anthropic-cli"
+command = "c"
+
+[models.m]
+max-context = 4096
+
+[p.m]
+
+[tier.t]
+members = ["p.m"]
+strategy = "weighted_random"
+latency-baseline-ms = 200.0
+rate-limit-recency-window-s = 60.0
+|} in
+  let cfg = ok_config (parse_string toml) in
+  match cfg.tiers with
+  | [ t ] ->
+    check bool "partial scoring yields None" true (t.scoring_params = None)
+  | _ -> failwith "expected exactly one tier"
+
 (* --- Test suite --- *)
 
 let () =
@@ -457,5 +635,18 @@ let () =
       ];
       "strategies", [
         test_case "all 7 strategies parse" `Quick test_all_strategies_parse;
+      ];
+      "cycle_policy", [
+        test_case "parses all-or-nothing" `Quick test_cycle_policy;
+        test_case "absent yields None" `Quick test_cycle_policy_absent;
+        test_case "partial yields None" `Quick test_cycle_policy_partial_ignored;
+      ];
+      "sticky_ttl", [
+        test_case "parses sticky-ttl-ms" `Quick test_sticky_ttl_ms;
+        test_case "absent yields None" `Quick test_sticky_ttl_ms_absent;
+      ];
+      "scoring_params", [
+        test_case "parses all 7 fields" `Quick test_scoring_params;
+        test_case "partial yields None" `Quick test_scoring_params_partial_ignored;
       ];
     ]

--- a/test/test_cascade_declarative_validator.ml
+++ b/test/test_cascade_declarative_validator.ml
@@ -437,6 +437,180 @@ target = "no.such.binding"
   has_rule "R8" errs;
   check bool "multiple errors" true (List.length errs >= 3)
 
+(* --- R10: Strategy-field consistency --- *)
+
+let test_r10_cycle_policy_on_wrong_strategy () =
+  let toml = {|
+[providers.p]
+protocol = "anthropic-cli"
+command = "c"
+
+[models.m]
+max-context = 4096
+
+[p.m]
+
+[tier.t]
+members = ["p.m"]
+strategy = "failover"
+max-cycles = 3
+backoff-base-ms = 500
+backoff-cap-ms = 10000
+|} in
+  let errs = validate_toml toml in
+  has_rule_at "R10" "tier.t.cycle-policy" errs
+
+let test_r10_cycle_policy_on_correct_strategy () =
+  let toml = {|
+[providers.p]
+protocol = "anthropic-cli"
+command = "c"
+
+[models.m]
+max-context = 4096
+
+[p.m]
+
+[tier.t]
+members = ["p.m"]
+strategy = "circuit_breaker_cycling"
+max-cycles = 3
+backoff-base-ms = 500
+backoff-cap-ms = 10000
+|} in
+  let errs = validate_toml toml in
+  no_errors errs
+
+let test_r10_sticky_ttl_on_wrong_strategy () =
+  let toml = {|
+[providers.p]
+protocol = "anthropic-cli"
+command = "c"
+
+[models.m]
+max-context = 4096
+
+[p.m]
+
+[tier.t]
+members = ["p.m"]
+strategy = "failover"
+sticky-ttl-ms = 600000
+|} in
+  let errs = validate_toml toml in
+  has_rule_at "R10" "tier.t.sticky-ttl-ms" errs
+
+let test_r10_sticky_ttl_on_correct_strategy () =
+  let toml = {|
+[providers.p]
+protocol = "anthropic-cli"
+command = "c"
+
+[models.m]
+max-context = 4096
+
+[p.m]
+
+[tier.t]
+members = ["p.m"]
+strategy = "sticky"
+sticky-ttl-ms = 600000
+|} in
+  let errs = validate_toml toml in
+  no_errors errs
+
+let test_r10_scoring_on_wrong_strategy () =
+  let toml = {|
+[providers.p]
+protocol = "anthropic-cli"
+command = "c"
+
+[models.m]
+max-context = 4096
+
+[p.m]
+
+[tier.t]
+members = ["p.m"]
+strategy = "failover"
+latency-baseline-ms = 200.0
+rate-limit-recency-window-s = 60.0
+rate-limit-decay-base = 0.5
+rate-limit-skip-after = 3
+server-error-recency-window-s = 120.0
+server-error-decay-base = 0.3
+server-error-skip-after = 5
+|} in
+  let errs = validate_toml toml in
+  has_rule_at "R10" "tier.t.scoring-params" errs
+
+let test_r10_scoring_on_correct_strategy () =
+  let toml = {|
+[providers.p]
+protocol = "anthropic-cli"
+command = "c"
+
+[models.m]
+max-context = 4096
+
+[p.m]
+
+[tier.t]
+members = ["p.m"]
+strategy = "weighted_random"
+latency-baseline-ms = 200.0
+rate-limit-recency-window-s = 60.0
+rate-limit-decay-base = 0.5
+rate-limit-skip-after = 3
+server-error-recency-window-s = 120.0
+server-error-decay-base = 0.3
+server-error-skip-after = 5
+|} in
+  let errs = validate_toml toml in
+  no_errors errs
+
+let test_r10_no_strategy_fields_is_ok () =
+  let toml = {|
+[providers.p]
+protocol = "anthropic-cli"
+command = "c"
+
+[models.m]
+max-context = 4096
+
+[p.m]
+
+[tier.t]
+members = ["p.m"]
+strategy = "failover"
+|} in
+  let errs = validate_toml toml in
+  no_errors errs
+
+let test_r10_multiple_mismatches () =
+  let toml = {|
+[providers.p]
+protocol = "anthropic-cli"
+command = "c"
+
+[models.m]
+max-context = 4096
+
+[p.m]
+
+[tier.t]
+members = ["p.m"]
+strategy = "failover"
+max-cycles = 3
+backoff-base-ms = 500
+backoff-cap-ms = 10000
+sticky-ttl-ms = 600000
+|} in
+  let errs = validate_toml toml in
+  has_rule "R10" errs;
+  check bool "multiple R10 errors" true
+    (List.length (List.filter (fun e -> e.rule = "R10") errs) >= 2)
+
 (* --- Test suite --- *)
 
 let () =
@@ -479,5 +653,15 @@ let () =
       ];
       "multi", [
         test_case "multiple errors at once" `Quick test_multiple_errors;
+      ];
+      "R10_strategy_fields", [
+        test_case "cycle_policy on wrong strategy" `Quick test_r10_cycle_policy_on_wrong_strategy;
+        test_case "cycle_policy on correct strategy" `Quick test_r10_cycle_policy_on_correct_strategy;
+        test_case "sticky_ttl on wrong strategy" `Quick test_r10_sticky_ttl_on_wrong_strategy;
+        test_case "sticky_ttl on correct strategy" `Quick test_r10_sticky_ttl_on_correct_strategy;
+        test_case "scoring on wrong strategy" `Quick test_r10_scoring_on_wrong_strategy;
+        test_case "scoring on correct strategy" `Quick test_r10_scoring_on_correct_strategy;
+        test_case "no strategy fields is ok" `Quick test_r10_no_strategy_fields_is_ok;
+        test_case "multiple mismatches" `Quick test_r10_multiple_mismatches;
       ];
     ]


### PR DESCRIPTION
## Summary

- 5-layer declarative TOML schema: Providers → Models → Bindings → Aliases → Tiers/Tier-Groups/Routes
- TOML parser (`cascade_declarative_parser.ml`) with 7 strategy variants and strategy-specific fields (cycle_policy, sticky_ttl_ms, scoring_params)
- Cross-reference validator (`cascade_declarative_validator.ml`) with 10 load-time invariants (R1-R10)
- R10 validates strategy-field consistency: cycle_policy→circuit_breaker_cycling, sticky_ttl_ms→sticky, scoring_params→weighted_random
- 53 unit tests (28 parser + 25 validator) covering valid configs, each rule in isolation, and multi-error scenarios
- TOML-only hotpath: config loader skips JSON file I/O entirely

## Test plan

- [x] `dune build --root .` passes
- [x] `dune exec --root . test/test_cascade_declarative_parser.exe` — 28/28 pass
- [x] `dune exec --root . test/test_cascade_declarative_validator.exe` — 25/25 pass
- [x] Valid TOML config produces zero validation errors
- [x] Each rule (R1-R10) tested with both positive and negative cases
- [x] Multiple errors in single config correctly accumulated
- [ ] Integration with existing cascade_catalog adapter (Phase 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)