### PR TITLE
refactor(config): eradicate hardcoded model IDs to enforce Model-Free architecture

### DIFF
--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -494,10 +494,8 @@ let pricing_model_leaf model =
   | Some idx ->
       String.sub trimmed (idx + 1) (String.length trimmed - idx - 1)
 
-let is_known_non_catalog_pricing_model model =
-  match pricing_model_leaf model with
-  | "gpt-5.3-codex-spark" -> true
-  | _ -> false
+let is_known_non_catalog_pricing_model _model =
+  false
 
 let pricing_model_for_ledger ~model ~telemetry =
   match canonical_model_id_opt telemetry with

--- a/lib/provider_adapter.ml
+++ b/lib/provider_adapter.ml
@@ -329,12 +329,12 @@ let direct_adapters =
       model_policy =
         {
           default_model_env = None;
-          default_model_fallback = Some "auto";
+          default_model_fallback = None;
           auto_models =
             Env_csv_or_default
               {
                 env_var = "MASC_CLAUDE_CODE_AUTO_MODELS";
-                defaults = [ "auto" ];
+                defaults = [];
                 prefer_default_model_env = false;
               };
           expand_auto = true;
@@ -356,20 +356,13 @@ let direct_adapters =
       model_policy =
         {
           default_model_env = None;
-          default_model_fallback = Some "auto";
+          default_model_fallback = None;
           auto_models =
             Env_csv_or_default
               {
                 env_var = "MASC_CODEX_CLI_AUTO_MODELS";
                 defaults =
-                  [
-                    "gpt-5.2";
-                    "gpt-5.3-codex-spark";
-                    "gpt-5.3-codex";
-                    "gpt-5.4-mini";
-                    "gpt-5.4";
-                    "gpt-5.5";
-                  ];
+                  [];
                 prefer_default_model_env = false;
               };
           expand_auto = true;
@@ -391,17 +384,13 @@ let direct_adapters =
       model_policy =
         {
           default_model_env = Some "GEMINI_DEFAULT_MODEL";
-          default_model_fallback = Some "gemini-3-flash-preview";
+          default_model_fallback = None;
           auto_models =
             Env_csv_or_default
               {
                 env_var = "MASC_GEMINI_CLI_AUTO_MODELS";
                 defaults =
-                  [
-                    "gemini-3-flash-preview";
-                    "gemini-3.1-flash-lite-preview";
-                    "gemini-3.1-pro-preview";
-                  ];
+                  [];
                 prefer_default_model_env = true;
               };
           expand_auto = true;
@@ -435,12 +424,12 @@ let direct_adapters =
       model_policy =
         {
           default_model_env = None;
-          default_model_fallback = Some "kimi-for-coding";
+          default_model_fallback = None;
           auto_models =
             Env_csv_or_default
               {
                 env_var = "MASC_KIMI_CLI_AUTO_MODELS";
-                defaults = [ "kimi-for-coding" ];
+                defaults = [];
                 prefer_default_model_env = false;
               };
           expand_auto = true;
@@ -462,7 +451,7 @@ let direct_adapters =
       model_policy =
         {
           default_model_env = Some "ANTHROPIC_DEFAULT_MODEL";
-          default_model_fallback = Some "claude-sonnet-4-6-20250514";
+          default_model_fallback = None;
           auto_models = No_auto_models;
           expand_auto = false;
           family = Generic;
@@ -483,7 +472,7 @@ let direct_adapters =
       model_policy =
         {
           default_model_env = Some "OPENAI_DEFAULT_MODEL";
-          default_model_fallback = Some "gpt-4.1";
+          default_model_fallback = None;
           auto_models = No_auto_models;
           expand_auto = false;
           family = Generic;
@@ -509,7 +498,7 @@ let direct_adapters =
       model_policy =
         {
           default_model_env = Some "GEMINI_DEFAULT_MODEL";
-          default_model_fallback = Some "gemini-3-flash-preview";
+          default_model_fallback = None;
           auto_models = No_auto_models;
           expand_auto = false;
           family = Generic;
@@ -530,7 +519,7 @@ let direct_adapters =
       model_policy =
         {
           default_model_env = Some "KIMI_DEFAULT_MODEL";
-          default_model_fallback = Some "kimi-k2.5";
+          default_model_fallback = None;
           auto_models = No_auto_models;
           expand_auto = false;
           family = Kimi_api_family;
@@ -551,7 +540,7 @@ let direct_adapters =
       model_policy =
         {
           default_model_env = Some "KIMI_CODING_DEFAULT_MODEL";
-          default_model_fallback = Some "kimi-coding-auto";
+          default_model_fallback = None;
           auto_models = No_auto_models;
           expand_auto = false;
           family = Kimi_api_family;
@@ -572,7 +561,7 @@ let direct_adapters =
       model_policy =
         {
           default_model_env = Some "ZAI_DEFAULT_MODEL";
-          default_model_fallback = Some "glm-5.1";
+          default_model_fallback = None;
           auto_models = Zai_general_auto_models;
           expand_auto = true;
           family = Glm_general;
@@ -593,7 +582,7 @@ let direct_adapters =
       model_policy =
         {
           default_model_env = Some "ZAI_CODING_DEFAULT_MODEL";
-          default_model_fallback = Some "glm-5.1";
+          default_model_fallback = None;
           auto_models = Zai_coding_auto_models;
           expand_auto = true;
           family = Glm_coding;


### PR DESCRIPTION
## Summary

* Removed hardcoded model fallbacks (`default_model_fallback`) and static model lists (`Env_csv_or_default` / `Env_or_hardcoded`) from `provider_adapter.ml`.
* Removed the hardcoded `gpt-5.3-codex-spark` string check from `keeper_hooks_oas.ml`.

## Motivation

To align with the **Model-Free architecture** defined in **RFC-0058 (Declarative Cascade Config)**, we must eliminate vendor-specific model strings hardcoded directly into the OCaml binaries. All fallback and default model routing is now driven strictly by the external `cascade.toml` configuration, allowing us to swap models without recompiling the server.