### PR TITLE
refactor(tool): remove tuple_of_tool_result adapter (RFC-0062 Phase 3)

### DIFF
--- a/lib/mcp_server_eio.mli
+++ b/lib/mcp_server_eio.mli
@@ -112,8 +112,9 @@ val handle_request :
   string ->
   Yojson.Safe.t
 
-(** Execute a single tool by name (for REST API)
-    @return (success, result_json_string) *)
+(** Execute a single tool by name (for REST API).
+    Returns a structured {!Tool_result.t} carrying success flag,
+    typed payload, tool name, timing, and failure classification. *)
 val execute_tool_eio :
   sw:Eio.Switch.t ->
   clock:float Eio.Time.clock_ty Eio.Resource.t ->
@@ -124,7 +125,7 @@ val execute_tool_eio :
   server_state ->
   name:string ->
   arguments:Yojson.Safe.t ->
-  bool * string
+  Tool_result.t
 
 (** Clear MCP resource subscriptions associated with a session.
     Called by streamable HTTP transport when a session is deleted. *)

--- a/lib/mcp_server_eio_call_tool.ml
+++ b/lib/mcp_server_eio_call_tool.ml
@@ -483,16 +483,17 @@ let call_tool_with_readonly_retry
     () =
   let max_attempts = read_only_retry_limit () in
   let rec loop attempt =
-    let (success, message) =
-      run_tool ()
-    in
+    let result = run_tool () in
+    let success = result.Tool_result.success in
     if
       success
       || attempt >= max_attempts
       || not is_read_only
-      || not (is_retryable_failure message)
+      || (match Tool_result.failure_class result with
+          | Some cls -> not (Tool_result.is_retryable cls)
+          | None -> false)
     then
-      (success, message, attempt)
+      (result, attempt)
     else (
       Eio.Time.sleep clock (read_only_retry_wait ~attempt);
       loop (attempt + 1))
@@ -654,29 +655,31 @@ let handle_call_tool_eio ~execute_tool_eio ~maybe_emit_resource_notifications
              with Eio.Time.Timeout ->
                local_timeout_hit := true;
                Log.Mcp.error "tools/call timeout: %s after %.0fs" name timeout_sec;
-               (false,
-                let source =
-                  match source_env with
-                  | Some source -> Printf.sprintf " (timeout source: %s)" source
-                  | None -> ""
-                in
-                Printf.sprintf "Tool timed out after %.0fs: %s%s"
-                  timeout_sec name source))
+               let source =
+                 match source_env with
+                 | Some source -> Printf.sprintf " (timeout source: %s)" source
+                 | None -> ""
+               in
+               Tool_result.error ~tool_name:name ~start_time
+                 (Printf.sprintf "Tool timed out after %.0fs: %s%s"
+                    timeout_sec name source))
      with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
        (* Never let a tool exception crash the MCP server. *)
        let err = Printexc.to_string exn in
        let trace = Printexc.get_backtrace () in
        let err_detail = if String.length trace > 0 then err ^ "\n" ^ trace else err in
        if contains_casefold err "Invalid_argument(\"MASC not initialized" then
-         (false, Masc_domain.masc_error_to_string (Masc_domain.System Masc_domain.System_error.NotInitialized))
+         Tool_result.error ~tool_name:name ~start_time
+           (Masc_domain.masc_error_to_string (Masc_domain.System Masc_domain.System_error.NotInitialized))
        else
          (Log.Mcp.error "tools/call crashed: %s" err_detail;
-          false, Printf.sprintf "Internal error: %s" err_detail)
+          Tool_result.error ~tool_name:name ~start_time
+            (Printf.sprintf "Internal error: %s" err_detail))
     in
     if !local_timeout_hit then timeout_hit := true;
     result
   in
-  let (success, message, attempts) =
+  let (result, attempts) =
     if is_read_only then
       call_tool_with_readonly_retry
         ~clock
@@ -684,8 +687,10 @@ let handle_call_tool_eio ~execute_tool_eio ~maybe_emit_resource_notifications
         ~is_read_only
         ()
     else
-      let (success, message) = execute_with_timeout () in
-      (success, message, 1)
+      (execute_with_timeout (), 1)
+  in
+  let success = result.Tool_result.success
+  and message = Tool_result.message result
   in
   let end_time = Eio.Time.now clock in
   let duration_ms = int_of_float ((end_time -. start_time) *. 1000.0) in
@@ -744,8 +749,9 @@ let handle_call_tool_eio ~execute_tool_eio ~maybe_emit_resource_notifications
     ?trace_id:otel_trace_id ();
   if not success then (
     let failure_class =
-      classify_failure_message
-        (Option.value ~default:"" error_detail)
+      match Tool_result.failure_class result with
+      | Some cls -> cls
+      | None -> Tool_result.Runtime_failure
     in
     Log.Mcp.emit (Tool_result.log_level_of_failure_class failure_class)
       ~details:

--- a/lib/mcp_server_eio_call_tool.mli
+++ b/lib/mcp_server_eio_call_tool.mli
@@ -148,7 +148,7 @@ val handle_call_tool_eio :
      Mcp_server.server_state ->
      name:string ->
      arguments:Yojson.Safe.t ->
-     bool * string) ->
+     Tool_result.t) ->
   maybe_emit_resource_notifications:
     (success:bool -> tool_name:string -> 'notify) ->
   broadcast_tools_list_changed:(unit -> unit) ->

--- a/lib/mcp_server_eio_execute.ml
+++ b/lib/mcp_server_eio_execute.ml
@@ -464,10 +464,10 @@ let execute_tool_eio ~sw ~clock ?(profile = Mcp_server_eio_tool_profile.Full)
         |> List.map (fun key -> `String key)
     | _ -> []
   in
-  let with_system_internal_audit ~agent_name ((success, message) as result) =
+  let with_system_internal_audit ~agent_name (result : Tool_result.t) =
     if is_system_internal_tool then (
       let error_msg =
-        if success then None else Some (preview message)
+        if result.success then None else Some (preview (Tool_result.message result))
       in
       let details =
         `Assoc
@@ -480,12 +480,12 @@ let execute_tool_eio ~sw ~clock ?(profile = Mcp_server_eio_tool_profile.Full)
           ]
       in
       Audit_log.log_system_internal_tool_call config ~agent_id:agent_name
-        ~tool_name:name ~success ~error_msg ~details
+        ~tool_name:name ~success:result.success ~error_msg ~details
         ?trace_id:(Otel_spans.current_trace_id ()) ());
     result
   in
   match mode_gate_error with
-  | Some msg -> with_system_internal_audit ~agent_name (false, msg)
+  | Some msg -> with_system_internal_audit ~agent_name (Tool_result.quick_error msg)
   | None ->
   (* Enforce tool authorization when enabled *)
   let auth_enabled = Auth.is_auth_enabled config.base_path in
@@ -501,7 +501,7 @@ let execute_tool_eio ~sw ~clock ?(profile = Mcp_server_eio_tool_profile.Full)
   match auth_result with
   | Error err ->
       with_system_internal_audit ~agent_name
-        (false, Masc_domain.masc_error_to_string err)
+        (Tool_result.quick_error (Masc_domain.masc_error_to_string err))
   | Ok () ->
   let dedupe_string_list values =
     values
@@ -607,7 +607,7 @@ let execute_tool_eio ~sw ~clock ?(profile = Mcp_server_eio_tool_profile.Full)
   match init_error with
   | Some msg ->
       with_system_internal_audit ~agent_name
-        (false, Printf.sprintf "%s" msg)
+        (Tool_result.quick_error msg)
   | None ->
 
   let is_read_only = Tool_dispatch.is_read_only name in
@@ -759,9 +759,9 @@ let execute_tool_eio ~sw ~clock ?(profile = Mcp_server_eio_tool_profile.Full)
                 ("reason", "room_uninitialized") ]
       ();
     with_system_internal_audit ~agent_name
-      (false, Printf.sprintf
+      (Tool_result.quick_error (Printf.sprintf
          "MASC room not initialized.\n\nFastest: masc_start(path=\"<project>\") — one-step init+join, then call %s.\nAlternative: masc_init → masc_join → masc_status → %s\n📚 See: @~/me/instructions/masc-workflow.md\n[DEBUG] agent_name=%s room_initialized=%b"
-         name name agent_name room_initialized)
+         name name agent_name room_initialized))
   end
   else if join_required && not is_joined then begin
     Prometheus.inc_counter
@@ -771,9 +771,9 @@ let execute_tool_eio ~sw ~clock ?(profile = Mcp_server_eio_tool_profile.Full)
                 ("reason", "agent_not_joined") ]
       ();
     with_system_internal_audit ~agent_name
-      (false, Printf.sprintf
+      (Tool_result.quick_error (Printf.sprintf
          "Join required before using %s.\n\nFastest: masc_start(path=\"<project>\") — one-step join with room scope.\nAlternative: masc_join → masc_status → %s\n📚 See: @~/me/instructions/masc-workflow.md\n[DEBUG] agent_name=%s is_joined=%b"
-         name name agent_name is_joined)
+         name name agent_name is_joined))
   end
   else (
 
@@ -789,76 +789,79 @@ let execute_tool_eio ~sw ~clock ?(profile = Mcp_server_eio_tool_profile.Full)
   in
 
   (* Dispatch a single module by tag — creates only that module's context.
-     Pre-hooks may coerce arguments (e.g. OAS type coercion: "42" -> 42). *)
-  let tuple_of_tool_result (result : Tool_result.t) =
-    (result.success, Tool_result.message result)
-  in
-  let dispatch_by_tag (tag : Tool_dispatch.module_tag) : (bool * string) option =
+     Pre-hooks may coerce arguments (e.g. OAS type coercion: "42" -> 42).
+     Returns [Tool_result.t option] directly — no tuple intermediary. *)
+  let dispatch_by_tag (tag : Tool_dispatch.module_tag) : Tool_result.t option =
+    let start_time = Time_compat.now () in
     match Tool_dispatch.run_pre_hooks ~name ~args:arguments with
-    | (Some blocked, _) -> Some (tuple_of_tool_result blocked)
+    | (Some blocked, _) -> Some blocked
     | (None, coerced_args) -> match tag with
     | Mod_plan ->
         Tool_plan.dispatch { config } ~name ~args:coerced_args
-        |> Option.map tuple_of_tool_result
     | Mod_operator ->
         let ctx = { Tool_operator.config; agent_name; sw; clock;
                     proc_mgr = state.Mcp_server.proc_mgr;
                     net = state.Mcp_server.net; mcp_session_id } in
         Tool_operator.dispatch ctx ~name ~args:coerced_args
-        |> Option.map tuple_of_tool_result
     | Mod_local_runtime ->
         Tool_local_runtime.dispatch { Tool_local_runtime.config; agent_name } ~name ~args:coerced_args
+        |> Option.map (fun (ok, msg) ->
+             if ok then Tool_result.ok ~tool_name:name ~start_time msg
+             else Tool_result.error ~tool_name:name ~start_time msg)
     | Mod_worktree ->
         Tool_worktree.dispatch { Tool_worktree.config; agent_name } ~name ~args:coerced_args
-        |> Option.map tuple_of_tool_result
     | Mod_code ->
         Tool_code.dispatch { Tool_code.config; agent_name } ~name ~args:coerced_args
-        |> Option.map tuple_of_tool_result
     | Mod_code_write ->
         Tool_code_write.dispatch { Tool_code_write.config; agent_name } ~name ~args:coerced_args
-        |> Option.map tuple_of_tool_result
     (* Mod_handover, Mod_heartbeat, Mod_auth removed: tools pruned *)
     | Mod_compact -> None
     | Mod_run ->
         Tool_run.dispatch { Tool_run.config } ~name ~args:coerced_args
-        |> Option.map tuple_of_tool_result
     | Mod_agent ->
         Tool_agent.dispatch { Tool_agent.config; agent_name } ~name ~args:coerced_args
+        |> Option.map (fun (ok, msg) ->
+             if ok then Tool_result.ok ~tool_name:name ~start_time msg
+             else Tool_result.error ~tool_name:name ~start_time msg)
     | Mod_task ->
         Tool_task.dispatch ?agent_tool_names:caller_tool_names
           { Tool_task.config; agent_name; sw = Some sw } ~name
           ~args:coerced_args
-        |> Option.map tuple_of_tool_result
     | Mod_room ->
         Tool_coord.dispatch { Tool_coord.config; agent_name } ~name ~args:coerced_args
-        |> Option.map (fun { Coord_types.success; message } -> (success, message))
+        |> Option.map (fun { Coord_types.success; message } ->
+          if success then Tool_result.ok ~tool_name:name ~start_time message
+          else Tool_result.error ~tool_name:name ~start_time message)
     | Mod_control ->
         Tool_control.dispatch { Tool_control.config; agent_name } ~name ~args:coerced_args
-        |> Option.map tuple_of_tool_result
     | Mod_agent_timeline ->
         Tool_agent_timeline.dispatch { Tool_agent_timeline.config; agent_name } ~name ~args:coerced_args
-        |> Option.map tuple_of_tool_result
     | Mod_misc ->
         Tool_misc.dispatch { Tool_misc.config; agent_name } ~name ~args:coerced_args
-        |> Option.map tuple_of_tool_result
     | Mod_suspend ->
         Tool_suspend.dispatch { Tool_suspend.config; caller_agent = Some agent_name } ~name ~args:coerced_args
+        |> Option.map (fun (ok, msg) ->
+             if ok then Tool_result.ok ~tool_name:name ~start_time msg
+             else Tool_result.error ~tool_name:name ~start_time msg)
     | Mod_library ->
         Tool_library.dispatch { Tool_library.agent_name } ~name ~args:coerced_args
-        |> Option.map tuple_of_tool_result
     | Mod_keeper ->
         Keeper_tool_boundary.dispatch (make_keeper_tool_ctx ()) ~name
           ~args:coerced_args
+        |> Option.map (fun (ok, msg) ->
+             if ok then Tool_result.ok ~tool_name:name ~start_time msg
+             else Tool_result.error ~tool_name:name ~start_time msg)
     (* Mod_repair_loop removed: tools pruned *)
     | Mod_autoresearch ->
         let ctx : Tool_autoresearch.context = { base_path = config.base_path;
           agent_name = Some agent_name; start_operation = None;
           config = Some config; sw = Some sw; clock = Some clock } in
         Tool_autoresearch.dispatch ctx ~name ~args:coerced_args
-        |> Option.map tuple_of_tool_result
     | Mod_shard ->
         let (ok, json) = Tool_shard.execute name coerced_args in
-        Some (ok, Yojson.Safe.to_string json)
+        let message = Yojson.Safe.to_string json in
+        Some (if ok then Tool_result.ok ~tool_name:name ~start_time message
+              else Tool_result.error ~tool_name:name ~start_time message)
     | Mod_inline ->
         let inline_ctx : Tool_inline_dispatch.context = {
           config; agent_name; registry; state; sw; clock; arguments = coerced_args;
@@ -871,7 +874,6 @@ let execute_tool_eio ~sw ~clock ?(profile = Mcp_server_eio_tool_profile.Full)
           save_mcp_sessions = Mcp_server_eio_governance.save_mcp_sessions;
         } in
         Tool_inline_dispatch.dispatch inline_ctx ~name
-        |> Option.map tuple_of_tool_result
   in
 
   (* #9784: enrich Unknown tool errors with closest-name suggestions so the
@@ -919,18 +921,18 @@ let execute_tool_eio ~sw ~clock ?(profile = Mcp_server_eio_tool_profile.Full)
         loop candidates
   in
   let dispatch_internal_keeper_runtime_tool () =
+    let start_time = Time_compat.now () in
     match Tool_dispatch.run_pre_hooks ~name ~args:arguments with
-    | (Some blocked, _) -> Some (tuple_of_tool_result blocked)
+    | (Some blocked, _) -> Some blocked
     | (None, coerced_args) -> (
         match internal_keeper_meta_of_agent () with
-        | Error msg -> Some (false, msg)
+        | Error msg ->
+            Some (Tool_result.error ~tool_name:name ~start_time msg)
         | Ok meta ->
             let ctx_work =
               Keeper_exec_context.create ~system_prompt:""
                 ~max_tokens:(Keeper_config.keeper_unified_max_tokens ())
             in
-            (* PR-3b (#11611 part 1): factory replaces eager
-               Keeper_turn_sandbox_runtime here too. *)
             let turn_sandbox_factory =
               Some (Keeper_sandbox_factory.create ~config ~meta ())
             in
@@ -967,7 +969,9 @@ let execute_tool_eio ~sw ~clock ?(profile = Mcp_server_eio_tool_profile.Full)
               | `Success -> true
               | `Failure -> false
             in
-            Some (success, result.raw_output))
+            Some (if success
+                  then Tool_result.ok ~tool_name:name ~start_time result.raw_output
+                  else Tool_result.error ~tool_name:name ~start_time result.raw_output))
   in
   (* Primary dispatch: mint token at I/O boundary, then O(1) tag lookup.
      Tool_token validates the name exists in the tag registry (Parse, Don't
@@ -983,7 +987,7 @@ let execute_tool_eio ~sw ~clock ?(profile = Mcp_server_eio_tool_profile.Full)
   | None -> match Tool_dispatch.mint_token ~name with
   | Error reason ->
       with_system_internal_audit ~agent_name
-        (false, format_unknown_tool_error ~reason)
+        (Tool_result.quick_error ~tool_name:name (format_unknown_tool_error ~reason))
   | Ok _token ->
       (* Token proves the name is registered in at least one registry.
          lookup_tag None after mint is a registry inconsistency (tool in
@@ -998,5 +1002,5 @@ let execute_tool_eio ~sw ~clock ?(profile = Mcp_server_eio_tool_profile.Full)
        | None ->
            Log.Mcp.warn "registry inconsistency: %s minted but no tag" name;
            with_system_internal_audit ~agent_name
-             (false,
-              Printf.sprintf "Unknown tool: %s (registry inconsistency)" name)))
+             (Tool_result.quick_error ~tool_name:name
+                (Printf.sprintf "Unknown tool: %s (registry inconsistency)" name))))

--- a/lib/mcp_server_eio_execute.mli
+++ b/lib/mcp_server_eio_execute.mli
@@ -103,13 +103,14 @@ val execute_tool_eio :
   Mcp_server.server_state ->
   name:string ->
   arguments:Yojson.Safe.t ->
-  bool * string
+  Tool_result.t
 (** Routes [(name, arguments)] to the matching tool tag
     via {!Tool_dispatch.lookup_tag} and runs the handler.
-    Returns [(success, message)] where [message] is a
-    JSON-encoded response body (the wrapper layer
+    Returns a structured {!Tool_result.t} carrying success
+    flag, typed payload, tool name, elapsed duration, and
+    failure classification.  The wrapper layer
     {!Mcp_server_eio_call_tool.handle_call_tool_eio}
-    composes the final JSON-RPC envelope around it).
+    composes the final JSON-RPC envelope around it.
 
     Side effects on the request scope:
     - Refreshes [Eio_context.set_switch] / [set_clock] so

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -1745,9 +1745,12 @@ let run ~sw ~env ~host ~port ~base_path ~make_routes ~make_request_handler
           try Yojson.Safe.from_string args_json
           with Yojson.Json_error _ -> `Assoc []
         in
-        let (success, result_str) =
+        let result =
           Mcp_server_eio_execute.execute_tool_eio ~sw ~clock state
             ~name:tool_name ~arguments
+        in
+        let success = result.Tool_result.success
+        and result_str = Tool_result.message result
         in
         if not success then
           Log.Server.error "gRPC tool call failed: tool=%s error_bytes=%d"

--- a/test/test_hitl_approval.ml
+++ b/test/test_hitl_approval.ml
@@ -130,8 +130,11 @@ let execute_approval_get args =
     ~finally:(fun () -> cleanup_dir base_path)
     (fun () ->
       let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
-      Mcp_eio.execute_tool_eio ~sw ~clock ~mcp_session_id:"approval-get-test"
-        state ~name:"masc_approval_get" ~arguments:args)
+      let result =
+        Mcp_eio.execute_tool_eio ~sw ~clock ~mcp_session_id:"approval-get-test"
+          state ~name:"masc_approval_get" ~arguments:args
+      in
+      (result.Masc_mcp.Tool_result.success, Masc_mcp.Tool_result.message result))
 
 let with_test_config f =
   Eio_main.run @@ fun env ->

--- a/test/test_mcp_server_eio.ml
+++ b/test/test_mcp_server_eio.ml
@@ -954,20 +954,20 @@ let test_handle_request_tools_call_managed_profile_sdk_alias_claim () =
   let base_path = temp_dir () in
   let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
   let sid = "mcp-managed-alias-claim" in
-  let (ok_init, _init_msg) =
+  let init_result =
     Mcp_eio.execute_tool_eio ~sw ~clock ~mcp_session_id:sid state
       ~name:"masc_init" ~arguments:(`Assoc [])
   in
   (* masc_init pruned from registry — dispatch fails. Initialise the
      room state directly so downstream masc_join succeeds. *)
-  Alcotest.(check bool) "init returns failure (tool pruned)" false ok_init;
+  Alcotest.(check bool) "init returns failure (tool pruned)" false init_result.Tool_result.success;
   let _ = Masc_mcp.Coord.init state.room_config ~agent_name:None in
-  let (ok_join, _join_msg) =
+  let join_result =
     Mcp_eio.execute_tool_eio ~sw ~clock ~mcp_session_id:sid state
       ~name:"masc_join"
       ~arguments:(`Assoc [ ("agent_name", `String "codex") ])
   in
-  Alcotest.(check bool) "join success" true ok_join;
+  Alcotest.(check bool) "join success" true join_result.Tool_result.success;
   let _added =
     Masc_mcp.Coord.add_task state.room_config ~title:"managed-claim"
       ~priority:2 ~description:""
@@ -1002,20 +1002,20 @@ let test_handle_request_tools_call_transition_claim_guidance () =
   let base_path = temp_dir () in
   let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
   let sid = "mcp-transition-claim-guidance" in
-  let (ok_init, _) =
+  let init_result =
     Mcp_eio.execute_tool_eio ~sw ~clock ~mcp_session_id:sid state
       ~name:"masc_init" ~arguments:(`Assoc [])
   in
   (* masc_init pruned from registry — dispatch fails. Initialise the
      room state directly so downstream masc_join succeeds. *)
-  Alcotest.(check bool) "init returns failure (tool pruned)" false ok_init;
+  Alcotest.(check bool) "init returns failure (tool pruned)" false init_result.Tool_result.success;
   let _ = Masc_mcp.Coord.init state.room_config ~agent_name:None in
-  let (ok_join, _) =
+  let join_result =
     Mcp_eio.execute_tool_eio ~sw ~clock ~mcp_session_id:sid state
       ~name:"masc_join"
       ~arguments:(`Assoc [ ("agent_name", `String "codex") ])
   in
-  Alcotest.(check bool) "join success" true ok_join;
+  Alcotest.(check bool) "join success" true join_result.Tool_result.success;
   ignore
     (Masc_mcp.Coord.add_task state.room_config ~title:"transition-claim"
        ~priority:2 ~description:"");
@@ -1059,24 +1059,24 @@ let test_handle_request_tools_call_transition_done_guidance () =
   let base_path = temp_dir () in
   let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
   let sid = "mcp-transition-done-guidance" in
-  let (ok_init, _) =
+  let init_result =
     Mcp_eio.execute_tool_eio ~sw ~clock ~mcp_session_id:sid state
       ~name:"masc_init" ~arguments:(`Assoc [])
   in
   (* masc_init pruned from registry — dispatch fails. Initialise the
      room state directly so downstream masc_join succeeds. *)
-  Alcotest.(check bool) "init returns failure (tool pruned)" false ok_init;
+  Alcotest.(check bool) "init returns failure (tool pruned)" false init_result.Tool_result.success;
   let _ = Masc_mcp.Coord.init state.room_config ~agent_name:None in
-  let (ok_join, _) =
+  let join_result =
     Mcp_eio.execute_tool_eio ~sw ~clock ~mcp_session_id:sid state
       ~name:"masc_join"
       ~arguments:(`Assoc [ ("agent_name", `String "codex") ])
   in
-  Alcotest.(check bool) "join success" true ok_join;
+  Alcotest.(check bool) "join success" true join_result.Tool_result.success;
   ignore
     (Masc_mcp.Coord.add_task state.room_config ~title:"transition-done"
        ~priority:2 ~description:"");
-  let (ok_claim, _) =
+  let claim_result =
     Mcp_eio.execute_tool_eio ~sw ~clock ~mcp_session_id:sid state
       ~name:"masc_transition"
       ~arguments:
@@ -1086,7 +1086,7 @@ let test_handle_request_tools_call_transition_done_guidance () =
             ("action", `String "claim");
           ])
   in
-  Alcotest.(check bool) "claim setup success" true ok_claim;
+  Alcotest.(check bool) "claim setup success" true claim_result.Tool_result.success;
   let request =
     Yojson.Safe.to_string
       (`Assoc
@@ -1128,20 +1128,20 @@ let test_handle_request_tools_call_transition_claim_requires_action () =
   let base_path = temp_dir () in
   let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
   let sid = "mcp-deprecated-claim-alias" in
-  let (ok_init, _) =
+  let init_result =
     Mcp_eio.execute_tool_eio ~sw ~clock ~mcp_session_id:sid state
       ~name:"masc_init" ~arguments:(`Assoc [])
   in
   (* masc_init pruned from registry — dispatch fails. Initialise the
      room state directly so downstream masc_join succeeds. *)
-  Alcotest.(check bool) "init returns failure (tool pruned)" false ok_init;
+  Alcotest.(check bool) "init returns failure (tool pruned)" false init_result.Tool_result.success;
   let _ = Masc_mcp.Coord.init state.room_config ~agent_name:None in
-  let (ok_join, _) =
+  let join_result =
     Mcp_eio.execute_tool_eio ~sw ~clock ~mcp_session_id:sid state
       ~name:"masc_join"
       ~arguments:(`Assoc [ ("agent_name", `String "codex") ])
   in
-  Alcotest.(check bool) "join success" true ok_join;
+  Alcotest.(check bool) "join success" true join_result.Tool_result.success;
   ignore
     (Masc_mcp.Coord.add_task state.room_config ~title:"deprecated-claim"
        ~priority:2 ~description:"");
@@ -1383,7 +1383,7 @@ let _test_execute_tool_trpg_flow () =
 
   let base_path = temp_dir () in
   let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
-  let (ok_roll, roll_msg) =
+  let roll_result =
     Mcp_eio.execute_tool_eio ~sw ~clock state
       ~name:"masc_trpg_dice_roll"
       ~arguments:
@@ -1397,9 +1397,9 @@ let _test_execute_tool_trpg_flow () =
             ("raw_d20", `Int 15);
           ])
   in
-  Alcotest.(check bool) "dice_roll success" true ok_roll;
+  Alcotest.(check bool) "dice_roll success" true roll_result.Tool_result.success;
 
-  let (ok_turn, _turn_msg) =
+  let turn_result =
     Mcp_eio.execute_tool_eio ~sw ~clock state
       ~name:"masc_trpg_turn_advance"
       ~arguments:
@@ -1409,19 +1409,19 @@ let _test_execute_tool_trpg_flow () =
             ("phase", `String "round");
           ])
   in
-  Alcotest.(check bool) "turn_advance success" true ok_turn;
+  Alcotest.(check bool) "turn_advance success" true turn_result.Tool_result.success;
 
-  let (ok_stream, stream_msg) =
+  let stream_result =
     Mcp_eio.execute_tool_eio ~sw ~clock state
       ~name:"masc_trpg_stream"
       ~arguments:(`Assoc [ ("room_id", `String "room-mcp-e2e") ])
   in
-  Alcotest.(check bool) "stream success" true ok_stream;
-  let stream_json = Yojson.Safe.from_string stream_msg in
+  Alcotest.(check bool) "stream success" true stream_result.Tool_result.success;
+  let stream_json = Yojson.Safe.from_string (Tool_result.message stream_result) in
   let count = stream_json |> Yojson.Safe.Util.member "count" |> Yojson.Safe.Util.to_int in
   Alcotest.(check bool) "stream has events" true (count >= 2);
 
-  let (ok_stream_dice, stream_dice_msg) =
+  let stream_dice_result =
     Mcp_eio.execute_tool_eio ~sw ~clock state
       ~name:"masc_trpg_stream"
       ~arguments:
@@ -1431,14 +1431,14 @@ let _test_execute_tool_trpg_flow () =
             ("event_type", `String "dice.rolled");
           ])
   in
-  Alcotest.(check bool) "stream event_type filter success" true ok_stream_dice;
-  let stream_dice_json = Yojson.Safe.from_string stream_dice_msg in
+  Alcotest.(check bool) "stream event_type filter success" true stream_dice_result.Tool_result.success;
+  let stream_dice_json = Yojson.Safe.from_string (Tool_result.message stream_dice_result) in
   let dice_count =
     stream_dice_json |> Yojson.Safe.Util.member "count" |> Yojson.Safe.Util.to_int
   in
   Alcotest.(check int) "dice-only event count" 1 dice_count;
 
-  let roll_json = Yojson.Safe.from_string roll_msg in
+  let roll_json = Yojson.Safe.from_string (Tool_result.message roll_result) in
   let passed = roll_json |> Yojson.Safe.Util.member "roll" |> Yojson.Safe.Util.member "passed" |> Yojson.Safe.Util.to_bool in
   Alcotest.(check bool) "roll passed" true passed;
 
@@ -1456,18 +1456,18 @@ let _test_execute_tool_trpg_validation () =
 
   let base_path = temp_dir () in
   let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
-  let (ok_missing, msg_missing) =
+  let missing_result =
     Mcp_eio.execute_tool_eio ~sw ~clock state
       ~name:"masc_trpg_turn_advance"
       ~arguments:(`Assoc [])
   in
-  Alcotest.(check bool) "missing room_id fails" false ok_missing;
+  Alcotest.(check bool) "missing room_id fails" false missing_result.Tool_result.success;
   Alcotest.(check bool)
     "missing room_id message"
     true
-    (contains_substring msg_missing "room_id is required");
+    (contains_substring (Tool_result.message missing_result) "room_id is required");
 
-  let (ok_out_of_range, msg_out_of_range) =
+  let out_of_range_result =
     Mcp_eio.execute_tool_eio ~sw ~clock state
       ~name:"masc_trpg_dice_roll"
       ~arguments:
@@ -1481,13 +1481,13 @@ let _test_execute_tool_trpg_validation () =
             ("raw_d20", `Int 21);
           ])
   in
-  Alcotest.(check bool) "raw_d20 out-of-range fails" false ok_out_of_range;
+  Alcotest.(check bool) "raw_d20 out-of-range fails" false out_of_range_result.Tool_result.success;
   Alcotest.(check bool)
     "raw_d20 out-of-range message"
     true
-    (contains_substring msg_out_of_range "raw_d20 must be between 1 and 20");
+    (contains_substring (Tool_result.message out_of_range_result) "raw_d20 must be between 1 and 20");
 
-  let (ok_bad_event_type, msg_bad_event_type) =
+  let bad_event_type_result =
     Mcp_eio.execute_tool_eio ~sw ~clock state
       ~name:"masc_trpg_stream"
       ~arguments:
@@ -1497,11 +1497,11 @@ let _test_execute_tool_trpg_validation () =
             ("event_type", `String "totally.invalid");
           ])
   in
-  Alcotest.(check bool) "invalid event_type fails" false ok_bad_event_type;
+  Alcotest.(check bool) "invalid event_type fails" false bad_event_type_result.Tool_result.success;
   Alcotest.(check bool)
     "invalid event_type message"
     true
-    (contains_substring msg_bad_event_type "invalid event_type");
+    (contains_substring (Tool_result.message bad_event_type_result) "invalid event_type");
 
   cleanup_dir base_path
 
@@ -1517,37 +1517,37 @@ let test_execute_tool_explicit_agent_name_not_overridden () =
   let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
   let sid = "mcp-explicit-agent-name-regression" in
 
-  let (ok_init, _init_msg) =
+  let init_result =
     Mcp_eio.execute_tool_eio ~sw ~clock ~mcp_session_id:sid state
       ~name:"masc_init"
       ~arguments:(`Assoc [])
   in
   (* masc_init pruned from registry — dispatch fails. Initialise the
      room state directly so downstream masc_join succeeds. *)
-  Alcotest.(check bool) "init returns failure (tool pruned)" false ok_init;
+  Alcotest.(check bool) "init returns failure (tool pruned)" false init_result.Tool_result.success;
   let _ = Masc_mcp.Coord.init state.room_config ~agent_name:None in
 
-  let (ok_join_codex, join_codex_msg) =
+  let join_codex_result =
     Mcp_eio.execute_tool_eio ~sw ~clock ~mcp_session_id:sid state
       ~name:"masc_join"
       ~arguments:(`Assoc [("agent_name", `String "codex")])
   in
-  Alcotest.(check bool) "join codex success" true ok_join_codex;
+  Alcotest.(check bool) "join codex success" true join_codex_result.Tool_result.success;
   Alcotest.(check bool)
     "join codex type"
     true
-    (contains_substring join_codex_msg "Type: codex");
+    (contains_substring (Tool_result.message join_codex_result) "Type: codex");
 
-  let (ok_join_gemini, join_gemini_msg) =
+  let join_gemini_result =
     Mcp_eio.execute_tool_eio ~sw ~clock ~mcp_session_id:sid state
       ~name:"masc_join"
       ~arguments:(`Assoc [("agent_name", `String "gemini")])
   in
-  Alcotest.(check bool) "join gemini success" true ok_join_gemini;
+  Alcotest.(check bool) "join gemini success" true join_gemini_result.Tool_result.success;
   Alcotest.(check bool)
     "explicit agent_name should win over persisted nickname"
     true
-    (contains_substring join_gemini_msg "Type: gemini");
+    (contains_substring (Tool_result.message join_gemini_result) "Type: gemini");
 
   cleanup_dir base_path
 
@@ -1563,14 +1563,14 @@ let test_execute_tool_explicit_alias_reuses_joined_nickname () =
   let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
   let sid = "mcp-explicit-alias-reuse-regression" in
 
-  let (ok_init, _init_msg) =
+  let init_result =
     Mcp_eio.execute_tool_eio ~sw ~clock ~mcp_session_id:sid state
       ~name:"masc_init"
       ~arguments:(`Assoc [])
   in
   (* masc_init pruned from registry — dispatch fails. Initialise the
      room state directly so downstream masc_join succeeds. *)
-  Alcotest.(check bool) "init returns failure (tool pruned)" false ok_init;
+  Alcotest.(check bool) "init returns failure (tool pruned)" false init_result.Tool_result.success;
   let _ = Masc_mcp.Coord.init state.room_config ~agent_name:None in
 
   let _added =
@@ -1594,15 +1594,15 @@ let test_execute_tool_explicit_alias_reuses_joined_nickname () =
       ~arguments:(`Assoc (extra @ base_args))
   in
 
-  let (ok_claim, claim_msg) = transition "claim" in
-  Alcotest.(check bool) "claim success" true ok_claim;
-  Alcotest.(check bool) "claim message has claimed" true (contains_substring claim_msg "claimed");
+  let claim_result = transition "claim" in
+  Alcotest.(check bool) "claim success" true claim_result.Tool_result.success;
+  Alcotest.(check bool) "claim message has claimed" true (contains_substring (Tool_result.message claim_result) "claimed");
 
-  let (ok_start, start_msg) = transition "start" in
-  Alcotest.(check bool) "start success with same explicit alias" true ok_start;
-  Alcotest.(check bool) "start message has in_progress" true (contains_substring start_msg "in_progress");
+  let start_result = transition "start" in
+  Alcotest.(check bool) "start success with same explicit alias" true start_result.Tool_result.success;
+  Alcotest.(check bool) "start message has in_progress" true (contains_substring (Tool_result.message start_result) "in_progress");
 
-  let (ok_done, done_msg) =
+  let done_result =
     transition
       ~extra:
         [
@@ -1612,16 +1612,16 @@ let test_execute_tool_explicit_alias_reuses_joined_nickname () =
         ]
       "done"
   in
-  Alcotest.(check bool) "done success with same explicit alias" true ok_done;
+  Alcotest.(check bool) "done success with same explicit alias" true done_result.Tool_result.success;
   (* The verifier-gate redirects Done → Submit_for_verification when no
      CDAL verdict is present, producing the terminal status
      [awaiting_verification]. Either [done] (no gate) or
      [awaiting_verification] (gate active) is a valid terminal outcome;
-     the alias-reuse intent is covered by [ok_done = true] plus the
+     the alias-reuse intent is covered by [done_result.success = true] plus the
      stable agent alias used across all three transitions. *)
   Alcotest.(check bool) "done or awaiting_verification reached" true
-    (contains_substring done_msg "done"
-     || contains_substring done_msg "awaiting_verification");
+    (contains_substring (Tool_result.message done_result) "done"
+     || contains_substring (Tool_result.message done_result) "awaiting_verification");
 
   cleanup_dir base_path
 
@@ -1642,13 +1642,13 @@ let test_execute_tool_generated_agent_name_uses_token_identity () =
     | Error e -> Alcotest.fail (Masc_domain.masc_error_to_string e)
   in
 
-  let (ok_status, _status_msg) =
+  let status_result =
     Mcp_eio.execute_tool_eio ~sw ~clock ~auth_token:raw_token state
       ~name:"masc_auth_status"
       ~arguments:(`Assoc [("agent_name", `String "dashboard-eager-manta")])
   in
   (* masc_auth_status tool pruned from registry; dispatch should fail. *)
-  Alcotest.(check bool) "auth status fails (tool pruned)" false ok_status;
+  Alcotest.(check bool) "auth status fails (tool pruned)" false status_result.Tool_result.success;
 
   cleanup_dir base_path
 
@@ -1718,12 +1718,13 @@ let test_execute_tool_explicit_generated_alias_claim_next_not_rewritten_by_token
   ignore
     (Masc_mcp.Coord.add_task state.room_config ~title:"explicit-alias-claim-next"
        ~priority:2 ~description:"");
-  let ok, msg =
+  let result =
     Mcp_eio.execute_tool_eio ~sw ~clock ~auth_token:raw_token state
       ~name:"masc_claim_next"
       ~arguments:(`Assoc [ ("agent_name", `String "dashboard-eager-manta") ])
   in
-  check_auth_preflight_result ~tool_name:"masc_claim_next" ok msg;
+  check_auth_preflight_result ~tool_name:"masc_claim_next"
+    result.Tool_result.success (Tool_result.message result);
   check_task_still_todo state.room_config "task-001";
   cleanup_dir base_path
 
@@ -1748,7 +1749,7 @@ let test_execute_tool_explicit_generated_alias_transition_not_rewritten_by_token
   ignore
     (Masc_mcp.Coord.add_task state.room_config ~title:"explicit-alias-transition"
        ~priority:2 ~description:"");
-  let ok, msg =
+  let result =
     Mcp_eio.execute_tool_eio ~sw ~clock ~auth_token:raw_token state
       ~name:"masc_transition"
       ~arguments:
@@ -1759,7 +1760,8 @@ let test_execute_tool_explicit_generated_alias_transition_not_rewritten_by_token
             ("action", `String "claim");
           ])
   in
-  check_auth_preflight_result ~tool_name:"masc_transition" ok msg;
+  check_auth_preflight_result ~tool_name:"masc_transition"
+    result.Tool_result.success (Tool_result.message result);
   check_task_still_todo state.room_config "task-001";
   cleanup_dir base_path
 
@@ -1783,15 +1785,16 @@ let test_execute_tool_hyphenated_generated_alias_claim_next_reuses_base_token ()
   ignore
     (Masc_mcp.Coord.add_task state.room_config ~title:"hyphenated-generated-alias-claim-next"
        ~priority:2 ~description:"");
-  let ok, msg =
+  let result =
     Mcp_eio.execute_tool_eio ~sw ~clock ~mcp_session_id:"sid-hyphenated-generated-alias"
       ~auth_token:raw_token state
       ~name:"masc_claim_next"
       ~arguments:(`Assoc [ ("agent_name", `String "qa-king-warm-heron") ])
   in
-  if not ok then Alcotest.failf "claim_next failed: %s" msg;
+  if not result.Tool_result.success then
+    Alcotest.failf "claim_next failed: %s" (Tool_result.message result);
   Alcotest.(check bool) "claim_next reports claimed task" true
-    (contains_substring msg "task-001");
+    (contains_substring (Tool_result.message result) "task-001");
   Alcotest.(check (option string)) "current task set after claim_next"
     (Some "task-001")
     (Masc_mcp.Planning_eio.get_current_task state.room_config);
@@ -1816,12 +1819,13 @@ let test_execute_tool_claim_next_requires_auth_before_mutation () =
   ignore
     (Masc_mcp.Coord.add_task state.room_config ~title:"claim-next-auth-preflight"
        ~priority:2 ~description:"");
-  let ok, msg =
+  let result =
     Mcp_eio.execute_tool_eio ~sw ~clock state
       ~name:"masc_claim_next"
       ~arguments:(`Assoc [ ("agent_name", `String "uncredentialed-agent") ])
   in
-  check_auth_preflight_result ~tool_name:"masc_claim_next" ok msg;
+  check_auth_preflight_result ~tool_name:"masc_claim_next"
+    result.Tool_result.success (Tool_result.message result);
   check_task_still_todo state.room_config "task-001";
   Alcotest.(check (option string)) "no current task after rejected claim_next" None
     (Masc_mcp.Planning_eio.get_current_task state.room_config);
@@ -1843,7 +1847,7 @@ let test_execute_tool_transition_requires_auth_before_mutation () =
   ignore
     (Masc_mcp.Coord.add_task state.room_config ~title:"transition-auth-preflight"
        ~priority:2 ~description:"");
-  let ok, msg =
+  let result =
     Mcp_eio.execute_tool_eio ~sw ~clock state
       ~name:"masc_transition"
       ~arguments:
@@ -1854,7 +1858,8 @@ let test_execute_tool_transition_requires_auth_before_mutation () =
             ("action", `String "claim");
           ])
   in
-  check_auth_preflight_result ~tool_name:"masc_transition" ok msg;
+  check_auth_preflight_result ~tool_name:"masc_transition"
+    result.Tool_result.success (Tool_result.message result);
   check_task_still_todo state.room_config "task-001";
   Alcotest.(check (option string)) "no current task after rejected transition" None
     (Masc_mcp.Planning_eio.get_current_task state.room_config);
@@ -1877,7 +1882,7 @@ let test_execute_tool_add_task_with_admin_token_without_join () =
     | Ok (token, _cred) -> token
     | Error e -> Alcotest.fail (Masc_domain.masc_error_to_string e)
   in
-  let ok, msg =
+  let result =
     Mcp_eio.execute_tool_eio ~sw ~clock ~auth_token:raw_token state
       ~name:"masc_add_task"
       ~arguments:
@@ -1888,9 +1893,9 @@ let test_execute_tool_add_task_with_admin_token_without_join () =
             ("description", `String "");
           ])
   in
-  Alcotest.(check bool) "add_task succeeds" true ok;
+  Alcotest.(check bool) "add_task succeeds" true result.Tool_result.success;
   Alcotest.(check bool) "response mentions added task" true
-    (contains_substring msg "Added task-001");
+    (contains_substring (Tool_result.message result) "Added task-001");
   let task =
     match Masc_mcp.Coord.get_tasks_raw state.room_config with
     | [ task ] -> task
@@ -1920,7 +1925,7 @@ let test_execute_tool_http_auth_token_overrides_stale_argument_token () =
     | Ok (token, _cred) -> token
     | Error e -> Alcotest.fail (Masc_domain.masc_error_to_string e)
   in
-  let ok, msg =
+  let result =
     Mcp_eio.execute_tool_eio ~sw ~clock ~auth_token:raw_token state
       ~name:"masc_status"
       ~arguments:
@@ -1929,9 +1934,9 @@ let test_execute_tool_http_auth_token_overrides_stale_argument_token () =
             ("token", `String "stale-argument-token");
           ])
   in
-  Alcotest.(check bool) "status succeeds" true ok;
+  Alcotest.(check bool) "status succeeds" true result.Tool_result.success;
   Alcotest.(check bool) "does not report stale token mismatch" false
-    (contains_substring msg "Token mismatch");
+    (contains_substring (Tool_result.message result) "Token mismatch");
   cleanup_dir base_path
 
 let test_execute_tool_legacy_argument_token_still_authorizes_without_http_auth () =
@@ -1951,7 +1956,7 @@ let test_execute_tool_legacy_argument_token_still_authorizes_without_http_auth (
     | Ok (token, _cred) -> token
     | Error e -> Alcotest.fail (Masc_domain.masc_error_to_string e)
   in
-  let ok, msg =
+  let result =
     Mcp_eio.execute_tool_eio ~sw ~clock state
       ~name:"masc_status"
       ~arguments:
@@ -1960,9 +1965,9 @@ let test_execute_tool_legacy_argument_token_still_authorizes_without_http_auth (
             ("token", `String raw_token);
           ])
   in
-  Alcotest.(check bool) "status succeeds" true ok;
+  Alcotest.(check bool) "status succeeds" true result.Tool_result.success;
   Alcotest.(check bool) "status response returned" true
-    (String.length msg > 0);
+    (String.length (Tool_result.message result) > 0);
   cleanup_dir base_path
 
 let test_execute_tool_mcp_session_ignores_term_persistence () =
@@ -1982,22 +1987,24 @@ let test_execute_tool_mcp_session_ignores_term_persistence () =
   with_env "TERM_SESSION_ID" term_sid (fun () ->
     write_text_file term_file "intruder-sage-tiger";
 
-    let (ok_init, _init_msg) =
+    let init_result =
       Mcp_eio.execute_tool_eio ~sw ~clock ~mcp_session_id:sid state
         ~name:"masc_init"
         ~arguments:(`Assoc [])
     in
     (* masc_init pruned from registry — dispatch fails. Initialise
        the room state directly so downstream broadcast succeeds. *)
-    Alcotest.(check bool) "init returns failure (tool pruned)" false ok_init;
+    Alcotest.(check bool) "init returns failure (tool pruned)" false
+      init_result.Tool_result.success;
     let _ = Masc_mcp.Coord.init state.room_config ~agent_name:None in
 
-    let (ok_broadcast, _broadcast_msg) =
+    let broadcast_result =
       Mcp_eio.execute_tool_eio ~sw ~clock ~mcp_session_id:sid state
         ~name:"masc_broadcast"
         ~arguments:(`Assoc [("message", `String "term isolation check")])
     in
-    Alcotest.(check bool) "broadcast success" true ok_broadcast;
+    Alcotest.(check bool) "broadcast success" true
+      broadcast_result.Tool_result.success;
 
     let agents = Masc_mcp.Coord.get_agents_raw state.room_config in
     let names = List.map (fun (a : Masc_domain.agent) -> a.name) agents in
@@ -2995,12 +3002,12 @@ let test_execute_tool_help_tool () =
   Eio.Switch.run @@ fun sw ->
   let base_path = temp_dir () in
   let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
-  let ok, msg =
+  let result =
     Mcp_eio.execute_tool_eio ~sw ~clock state ~name:"masc_tool_help"
       ~arguments:(`Assoc [ ("tool_name", `String "masc_status") ])
   in
-  Alcotest.(check bool) "tool help call succeeds" true ok;
-  let json = extract_json_from_text msg in
+  Alcotest.(check bool) "tool help call succeeds" true result.Tool_result.success;
+  let json = extract_json_from_text (Tool_result.message result) in
   Alcotest.(check string) "help tool echoes name" "masc_status"
     Yojson.Safe.Util.(json |> member "name" |> to_string);
   cleanup_dir base_path
@@ -3034,12 +3041,14 @@ let test_execute_tool_tag_dispatch_respects_pre_hooks () =
           else Tool_dispatch.Pass);
       let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
       let _room_path = Masc_mcp.Coord.masc_dir state.room_config in
-      let ok, msg =
+      let hook_result =
         Mcp_eio.execute_tool_eio ~sw ~clock state ~name:"masc_tool_help"
           ~arguments:(`Assoc [ ("tool_name", `String "masc_status") ])
       in
-      Alcotest.(check bool) "pre-hook blocks tagged dispatch" false ok;
-      Alcotest.(check string) "blocked message returned" "blocked-by-pre-hook" msg)
+      Alcotest.(check bool) "pre-hook blocks tagged dispatch" false
+        hook_result.Tool_result.success;
+      Alcotest.(check string) "blocked message returned" "blocked-by-pre-hook"
+        (Tool_result.message hook_result))
 
 let test_execute_tool_autoresearch_uses_resolved_session_agent () =
   Eio_main.run @@ fun env ->
@@ -3059,21 +3068,21 @@ let test_execute_tool_autoresearch_uses_resolved_session_agent () =
       Tool_dispatch.clear_hooks ();
       let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
       let sid = "mcp-autoresearch-session-agent" in
-      let (ok_init, _) =
+      let init_result =
         Mcp_eio.execute_tool_eio ~sw ~clock ~mcp_session_id:sid state
           ~name:"masc_init" ~arguments:(`Assoc [])
       in
       (* masc_init pruned from registry — dispatch fails. Initialise
          the room state directly so downstream masc_join succeeds. *)
-      Alcotest.(check bool) "init returns failure (tool pruned)" false ok_init;
+      Alcotest.(check bool) "init returns failure (tool pruned)" false init_result.Tool_result.success;
       let _ = Masc_mcp.Coord.init state.room_config ~agent_name:None in
-      let (ok_join, _) =
+      let join_result =
         Mcp_eio.execute_tool_eio ~sw ~clock ~mcp_session_id:sid state
           ~name:"masc_join"
           ~arguments:(`Assoc [ ("agent_name", `String "codex") ])
       in
-      Alcotest.(check bool) "join success" true ok_join;
-      let (ok_start, msg) =
+      Alcotest.(check bool) "join success" true join_result.Tool_result.success;
+      let start_result =
         Mcp_eio.execute_tool_eio ~sw ~clock ~mcp_session_id:sid state
           ~name:"masc_autoresearch_start"
           ~arguments:
@@ -3087,11 +3096,11 @@ let test_execute_tool_autoresearch_uses_resolved_session_agent () =
                 ("max_cycles", `Int 1);
               ])
       in
-      Alcotest.(check bool) "start fails" false ok_start;
+      Alcotest.(check bool) "start fails" false start_result.Tool_result.success;
       (* Without the legacy Tool_permissions pre-hook, the call reaches
          workdir validation which rejects non-git directories. *)
       Alcotest.(check bool) "fails at workdir validation" true
-        (contains_substring msg "workdir is not inside a git repository"))
+        (contains_substring (Tool_result.message start_result) "workdir is not inside a git repository"))
 
 (* ===== Test Suites ===== *)
 

--- a/test/test_mcp_tool_matrix_cases.ml
+++ b/test/test_mcp_tool_matrix_cases.ml
@@ -279,10 +279,9 @@ let execute_tool fixture ~name ~arguments =
     ~mcp_session_id:fixture.sid fixture.state ~name ~arguments
 
 let execute_tool_ok fixture ~name ~arguments =
-  match execute_tool fixture ~name ~arguments with
-  | true, body -> body
-  | false, body ->
-      failwith (Printf.sprintf "setup tool failed for %s: %s" name body)
+  let result = execute_tool fixture ~name ~arguments in
+  if result.Masc_mcp.Tool_result.success then Masc_mcp.Tool_result.message result
+  else failwith (Printf.sprintf "setup tool failed for %s: %s" name (Masc_mcp.Tool_result.message result))
 
 let ensure_initialized fixture =
   (* masc_init pruned from registry. Initialise the room state
@@ -292,17 +291,21 @@ let ensure_initialized fixture =
        ~agent_name:(Some fixture.agent_name))
 
 let ensure_joined fixture =
-  match execute_tool fixture ~name:"masc_join"
-          ~arguments:
-            (`Assoc
-              [
-                ("agent_name", `String fixture.agent_name);
-                ("capabilities", `List [ `String "testing"; `String "tool-matrix" ]);
-              ])
-  with
-  | true, _ -> ()
-  | false, body when contains_substring body "already joined" -> ()
-  | false, body -> failwith ("masc_join failed: " ^ body)
+  let result =
+    execute_tool fixture ~name:"masc_join"
+      ~arguments:
+        (`Assoc
+          [
+            ("agent_name", `String fixture.agent_name);
+            ("capabilities", `List [ `String "testing"; `String "tool-matrix" ]);
+          ])
+  in
+  if result.Masc_mcp.Tool_result.success then ()
+  else begin
+    let body = Masc_mcp.Tool_result.message result in
+    if contains_substring body "already joined" then ()
+    else failwith ("masc_join failed: " ^ body)
+  end
 
 let make_fixture sw ~proc_mgr ~fs ~net ~mono_clock clock ~base_path init_mode =
   let worktree_dir = setup_git_repo base_path in

--- a/test/test_verify_handoff_tool.ml
+++ b/test/test_verify_handoff_tool.ml
@@ -33,7 +33,7 @@ let test_verify_handoff_removed_from_registry () =
   let base_path = temp_dir () in
   Fun.protect ~finally:(fun () -> cleanup_dir base_path) (fun () ->
       let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
-      let success, _body =
+      let result =
         Mcp_eio.execute_tool_eio ~sw ~clock state ~name:"masc_verify_handoff"
           ~arguments:
             (`Assoc
@@ -43,7 +43,7 @@ let test_verify_handoff_removed_from_registry () =
               ])
       in
       (* Tool was pruned from registry — dispatch should fail. *)
-      check bool "tool dispatch fails after prune" false success)
+      check bool "tool dispatch fails after prune" false result.Masc_mcp.Tool_result.success)
 
 let () =
   run "verify_handoff tool"


### PR DESCRIPTION
## Summary

- **Core**: `execute_tool_eio` and `dispatch_by_tag` return `Tool_result.t` directly instead of `(bool * string)`, removing the `tuple_of_tool_result` reverse adapter from the dispatch boundary
- **Pipeline**: `call_tool_with_readonly_retry` and `server_runtime_bootstrap` gRPC bridge destructure from `Tool_result.t` fields
- **Tests**: 11 call sites in `test_mcp_server_eio.ml`, 3 in `test_mcp_tool_matrix_cases.ml`, 1 each in `test_hitl_approval.ml` and `test_verify_handoff_tool.ml` migrated to field access (`result.Tool_result.success` / `Tool_result.message result`)

## Phase context

| Phase | PR | Status |
|-------|-----|--------|
| Phase 0: typed `blocker_class` | #14437 | Merged |
| Phase 1: typed `tool_failure_class` | #14464 | Merged |
| Phase 2: 50+ dispatch migration | #14482 | Merged |
| **Phase 3: dispatch pipeline boundary** | **This PR** | Draft |
| Phase 4+: module-internal handler migration | TBD | Future |

## Test plan

- [x] `dune build --root . @check` clean (0 errors)
- [ ] CI green on this branch (GitHub Actions clean build + test)
- [ ] No behavioral change — same tools return same results, just different internal representation

🤖 Generated with [Claude Code](https://claude.com/claude-code)