### PR TITLE
fix(server): align server_ide_lsp_proxy.mli add_routes signature

### DIFF
--- a/lib/server/server_ide_lsp_proxy.mli
+++ b/lib/server/server_ide_lsp_proxy.mli
@@ -3,4 +3,7 @@
 
 (** Add LSP proxy routes to the router.
     Exposes [/api/v1/ide/lsp] WebSocket endpoint for LSP traffic. *)
-val add_routes : Http_server_eio.Router.t -> Http_server_eio.Router.t
+val add_routes :
+  sw:Eio.Switch.t ->
+  clock:float Eio.Time.clock_ty Eio.Resource.t ->
+  Http_server_eio.Router.t -> Http_server_eio.Router.t


### PR DESCRIPTION
## Summary
\`server_ide_lsp_proxy.mli\`의 \`add_routes\` 선언이 실제 구현과 불일치하여 빌드가 실패했습니다.

- **원인:** \`.ml\`에서는 \`add_routes ~sw ~clock router\`로 라벨led 인자를 받지만, \`.mli\`에는 \`Http_server_eio.Router.t -> Http_server_eio.Router.t\`로 단일 인자만 선언되어 있었습니다.
- **수정:** \`.mli\`를 \`~sw:Eio.Switch.t -> ~clock:float Eio.Time.clock_ty Eio.Resource.t -> ...\`로 업데이트하여 구현과 일치시켰습니다.
- **호출자:** \`server_routes_http.ml:39\` \`|> Server_ide_lsp_proxy.add_routes ~sw ~clock\`는 기존 코드 그대로 컴파일됩니다.

## Test plan
- [x] \`dune build\` local verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)