### PR TITLE
feat(ide-lsp): hover enrichment, cache invalidation, expanded capabilities

### DIFF
--- a/lib/server/lsp_overlay_provider.ml
+++ b/lib/server/lsp_overlay_provider.ml
@@ -118,3 +118,46 @@ let diagnostics ~base_dir ~file_path ~(lsp_diagnostics : Yojson.Safe.t list) :
 let invalidate_cache ~base_dir ~file_path = Cache.invalidate ~base_dir ~file_path
 
 let clear_cache () = Cache.clear ()
+
+(** Find annotations overlapping a given LSP position (0-based line).
+    An annotation covers lines [line_start, line_end] (1-based internally),
+    so it overlaps LSP line [l] when [line_start - 1 <= l <= line_end - 1]. *)
+let annotations_at_line ~base_dir ~file_path ~line =
+  let annotations = Cache.get ~base_dir ~file_path in
+  List.filter (fun (a : annotation) ->
+    a.line_start - 1 <= line && line <= a.line_end - 1
+  ) annotations
+
+(** Append MASC annotation context to an LSP Hover response.
+    If the hover response is a MarkupContent, appends annotation summaries.
+    Returns the enriched response unchanged if no annotations overlap. *)
+let enrich_hover ~base_dir ~file_path ~line (result : Yojson.Safe.t) =
+  let matching = annotations_at_line ~base_dir ~file_path ~line in
+  if matching = [] then result
+  else
+    let masc_section =
+      String.concat "\n" (List.map (fun (a : annotation) ->
+        let kind = show_annotation_kind a.kind in
+        match (a.goal_id, a.task_id) with
+        | Some g, Some t ->
+          Printf.sprintf "- **[%s]** %s (goal:%s task:%s)" kind a.content g t
+        | Some g, None ->
+          Printf.sprintf "- **[%s]** %s (goal:%s)" kind a.content g
+        | None, Some t ->
+          Printf.sprintf "- **[%s]** %s (task:%s)" kind a.content t
+        | None, None ->
+          Printf.sprintf "- **[%s]** %s" kind a.content
+      ) matching)
+    in
+    let masc_suffix = "\n---\n**MASC Annotations:**\n" ^ masc_section in
+    match result with
+    | `Assoc fields ->
+      (match List.assoc_opt "contents" fields with
+       | Some (`Assoc [ ("kind", `String k); ("value", `String v) ]) ->
+         `Assoc (List.map (fun (key, value) ->
+           if String.equal key "contents"
+           then ("contents", `Assoc [ ("kind", `String k); ("value", `String (v ^ masc_suffix)) ])
+           else (key, value)
+         ) fields)
+       | _ -> result)
+    | _ -> result

--- a/lib/server/lsp_overlay_provider.mli
+++ b/lib/server/lsp_overlay_provider.mli
@@ -22,3 +22,9 @@ val invalidate_cache : base_dir:string -> file_path:string -> unit
 
 val clear_cache : unit -> unit
 (** Remove all cached annotations. *)
+
+val enrich_hover :
+  base_dir:string -> file_path:string -> line:int -> Yojson.Safe.t -> Yojson.Safe.t
+(** Append MASC annotation context to an LSP Hover response.
+    If annotations overlap the given line, appends summaries to the hover contents.
+    Returns the original response unchanged if no annotations overlap. *)

--- a/lib/server/server_ide_lsp_proxy.ml
+++ b/lib/server/server_ide_lsp_proxy.ml
@@ -165,6 +165,19 @@ let extract_id fields =
   | _ -> None
 ;;
 
+(** Extract line (0-based) from LSP position params. *)
+let extract_line params =
+  match params with
+  | `Assoc fields ->
+    (match List.assoc_opt "position" fields with
+     | Some (`Assoc pos) ->
+       (match List.assoc_opt "line" pos with
+        | Some (`Int n) -> Some n
+        | _ -> None)
+     | _ -> None)
+  | _ -> None
+;;
+
 (** Ensure LSP process exists for a language.
     Spawns + initializes on first use, blocking until ready. *)
 let ensure_lsp_process cs lang_id =
@@ -358,6 +371,54 @@ let handle_diagnostic cs params id =
          | Error msg -> send_error cs id (-32603) msg))
 ;;
 
+(** Handle textDocument/hover — enrich LSP response with MASC annotations. *)
+let handle_hover cs params id =
+  match extract_uri params with
+  | None -> send_response cs id `Null
+  | Some uri ->
+    let base = cs.base_path in
+    let relative = resolve_relative ~base uri |> Option.value ~default:"" in
+    let line = extract_line params |> Option.value ~default:(-1) in
+    let lang_id = Lsp_process_manager.lang_of_path relative in
+    if lang_id = "unknown"
+    then (
+      if line >= 0
+      then (
+        let enriched =
+          Lsp_overlay_provider.enrich_hover
+            ~base_dir:base
+            ~file_path:relative
+            ~line
+            (`Assoc [ ("contents", `Assoc [ ("kind", `String "markdown"); ("value", `String "") ]) ])
+        in
+        send_response cs id enriched)
+      else send_response cs id `Null)
+    else (
+      match ensure_lsp_process cs lang_id with
+      | Error msg -> send_error cs id (-32603) msg
+      | Ok proc ->
+        let promise =
+          Lsp_message_router.send_request
+            cs.router
+            proc
+            ~method_:"textDocument/hover"
+            ~params
+            ~client_id:id
+        in
+        (match Eio.Promise.await promise with
+         | Ok result ->
+           if line >= 0
+           then
+             send_response cs id
+               (Lsp_overlay_provider.enrich_hover
+                  ~base_dir:base
+                  ~file_path:relative
+                  ~line
+                  result)
+           else send_response cs id result
+         | Error msg -> send_error cs id (-32603) msg))
+;;
+
 (** Dispatch an incoming LSP message to the appropriate handler. *)
 let dispatch_message cs msg =
   try
@@ -395,10 +456,15 @@ let dispatch_message cs msg =
                [ ( "capabilities"
                  , `Assoc
                      [ "textDocumentSync", `Int 2
+                     ; "completionProvider", `Assoc [ "resolveProvider", `Bool true ]
                      ; "hoverProvider", `Bool true
                      ; "definitionProvider", `Bool true
                      ; "referencesProvider", `Bool true
+                     ; "documentHighlightProvider", `Bool true
                      ; "documentSymbolProvider", `Bool true
+                     ; "foldingRangeProvider", `Bool true
+                     ; "selectionRangeProvider", `Bool true
+                     ; "documentLinkProvider", `Bool true
                      ; "codeLensProvider", `Assoc [ "resolveProvider", `Bool false ]
                      ; "inlayHintProvider", `Bool true
                      ; "diagnosticProvider", `Bool true
@@ -408,6 +474,7 @@ let dispatch_message cs msg =
        | Some "shutdown", Some n -> send_response cs n `Null
        | Some "exit", _ -> disconnect cs
        (* MASC-overlay-aware handlers *)
+       | Some "textDocument/hover", Some n -> handle_hover cs params n
        | Some "textDocument/codeLens", Some n -> handle_codelens cs params n
        | Some "textDocument/inlayHint", Some n -> handle_inlay_hint cs params n
        | Some "textDocument/diagnostic", Some n -> handle_diagnostic cs params n
@@ -418,6 +485,10 @@ let dispatch_message cs msg =
             let relative =
               resolve_relative ~base:cs.base_path uri |> Option.value ~default:""
             in
+            if String.equal m "textDocument/didSave" then
+              Lsp_overlay_provider.invalidate_cache
+                ~base_dir:cs.base_path
+                ~file_path:relative;
             let lang_id = Lsp_process_manager.lang_of_path relative in
             if lang_id <> "unknown" then forward_notification cs lang_id m params
           | None -> ())

--- a/lib/server/server_ide_lsp_proxy.mli
+++ b/lib/server/server_ide_lsp_proxy.mli
@@ -3,4 +3,7 @@
 
 (** Add LSP proxy routes to the router.
     Exposes [/api/v1/ide/lsp] WebSocket endpoint for LSP traffic. *)
-val add_routes : Http_server_eio.Router.t -> Http_server_eio.Router.t
+val add_routes :
+  sw:Eio.Switch.t ->
+  clock:float Eio.Time.clock_ty Eio.Resource.t ->
+  Http_server_eio.Router.t -> Http_server_eio.Router.t


### PR DESCRIPTION
## Summary
- Add MASC annotation context to `textDocument/hover` responses via `Lsp_overlay_provider.enrich_hover`
- Wire `textDocument/didSave` notification to invalidate annotation cache on file save
- Expand `initialize` response with 5 additional provider capabilities: `completionProvider`, `documentHighlightProvider`, `foldingRangeProvider`, `selectionRangeProvider`, `documentLinkProvider`
- Sync `server_ide_lsp_proxy.mli` with ml signature (build regression fix from #14483)

## Test plan
- [x] `dune build --root . @check` passes
- [ ] Manual: connect IDE LSP client, hover over annotated line, verify MASC section appended
- [ ] Manual: save annotated file, verify stale annotations cleared on next request

🤖 Generated with [Claude Code](https://claude.com/claude-code)