### PR TITLE
feat(dashboard): add multi-transport abstraction layer

### DIFF
--- a/dashboard/src/transports/http-streamable-transport.ts
+++ b/dashboard/src/transports/http-streamable-transport.ts
@@ -1,0 +1,96 @@
+import type { Transport, TransportEvent, TransportOptions } from './transport'
+
+const DEFAULT_RETRY_BASE_MS = 1000
+const DEFAULT_RETRY_MAX_MS = 30000
+
+export function createHttpStreamableTransport(url: string, opts: TransportOptions = {}): Transport {
+  let abortController: AbortController | null = null
+  let listeners: Array<(event: TransportEvent) => void> = []
+  let retryMs = opts.retryBaseMs ?? DEFAULT_RETRY_BASE_MS
+  let reconnectTimer: ReturnType<typeof setTimeout> | null = null
+  let connected = false
+
+  const notify = (event: TransportEvent) => {
+    listeners.forEach((l) => l(event))
+  }
+
+  const connect = () => {
+    if (abortController) return
+    abortController = new AbortController()
+    const { signal } = abortController
+
+    fetch(url, {
+      method: 'GET',
+      headers: {
+        Accept: 'application/x-ndjson',
+        ...(opts.headers ?? {}),
+      },
+      signal,
+    })
+      .then(async (res) => {
+        if (!res.ok || !res.body) {
+          throw new Error(`HTTP ${res.status}`)
+        }
+        connected = true
+        retryMs = opts.retryBaseMs ?? DEFAULT_RETRY_BASE_MS
+        notify({ type: 'open' })
+        const reader = res.body.getReader()
+        const decoder = new TextDecoder()
+        let buffer = ''
+        while (!signal.aborted) {
+          const { done, value } = await reader.read()
+          if (done) break
+          buffer += decoder.decode(value, { stream: true })
+          const lines = buffer.split('\n')
+          buffer = lines.pop() ?? ''
+          for (const line of lines) {
+            if (!line.trim()) continue
+            try {
+              notify({ type: 'message', data: JSON.parse(line) })
+            } catch {
+              notify({ type: 'message', data: line })
+            }
+          }
+        }
+      })
+      .catch((err) => {
+        if (signal.aborted) return
+        connected = false
+        notify({ type: 'error', error: err instanceof Error ? err : new Error(String(err)) })
+      })
+      .finally(() => {
+        abortController = null
+        if (!signal.aborted) {
+          const maxMs = opts.retryMaxMs ?? DEFAULT_RETRY_MAX_MS
+          reconnectTimer = setTimeout(connect, Math.min(retryMs, maxMs))
+          retryMs = Math.min(retryMs * 2, maxMs)
+        }
+      })
+  }
+
+  const disconnect = () => {
+    if (reconnectTimer) {
+      clearTimeout(reconnectTimer)
+      reconnectTimer = null
+    }
+    connected = false
+    abortController?.abort()
+    abortController = null
+    notify({ type: 'close' })
+  }
+
+  const subscribe = (listener: (event: TransportEvent) => void) => {
+    listeners = [...listeners, listener]
+    return () => {
+      listeners = listeners.filter((l) => l !== listener)
+    }
+  }
+
+  return {
+    url,
+    connect,
+    disconnect,
+    subscribe,
+    isConnected: () => connected,
+  }
+}

--- a/dashboard/src/transports/index.ts
+++ b/dashboard/src/transports/index.ts
@@ -1,0 +1,4 @@
+export type { Transport, TransportEvent, TransportOptions, TransportFactory } from './transport'
+export { createSseTransport } from './sse-transport'
+export { createHttpStreamableTransport } from './http-streamable-transport'
+export { createWebSocketTransport } from './websocket-transport'

--- a/dashboard/src/transports/sse-transport.ts
+++ b/dashboard/src/transports/sse-transport.ts
@@ -1,0 +1,73 @@
+import type { Transport, TransportEvent, TransportOptions } from './transport'
+
+const DEFAULT_RETRY_BASE_MS = 1000
+const DEFAULT_RETRY_MAX_MS = 30000
+
+export function createSseTransport(url: string, opts: TransportOptions = {}): Transport {
+  let source: EventSource | null = null
+  let listeners: Array<(event: TransportEvent) => void> = []
+  let retryMs = opts.retryBaseMs ?? DEFAULT_RETRY_BASE_MS
+  let reconnectTimer: ReturnType<typeof setTimeout> | null = null
+  let connected = false
+
+  const notify = (event: TransportEvent) => {
+    listeners.forEach((l) => l(event))
+  }
+
+  const connect = () => {
+    if (source) return
+    try {
+      source = new EventSource(url)
+      source.onopen = () => {
+        connected = true
+        retryMs = opts.retryBaseMs ?? DEFAULT_RETRY_BASE_MS
+        notify({ type: 'open' })
+      }
+      source.onmessage = (ev) => {
+        try {
+          const data = JSON.parse(ev.data)
+          notify({ type: 'message', data })
+        } catch {
+          notify({ type: 'message', data: ev.data })
+        }
+      }
+      source.onerror = () => {
+        connected = false
+        notify({ type: 'error', error: new Error('SSE transport error') })
+        source?.close()
+        source = null
+        const maxMs = opts.retryMaxMs ?? DEFAULT_RETRY_MAX_MS
+        reconnectTimer = setTimeout(connect, Math.min(retryMs, maxMs))
+        retryMs = Math.min(retryMs * 2, maxMs)
+      }
+    } catch (err) {
+      notify({ type: 'error', error: err instanceof Error ? err : new Error(String(err)) })
+    }
+  }
+
+  const disconnect = () => {
+    if (reconnectTimer) {
+      clearTimeout(reconnectTimer)
+      reconnectTimer = null
+    }
+    connected = false
+    source?.close()
+    source = null
+    notify({ type: 'close' })
+  }
+
+  const subscribe = (listener: (event: TransportEvent) => void) => {
+    listeners = [...listeners, listener]
+    return () => {
+      listeners = listeners.filter((l) => l !== listener)
+    }
+  }
+
+  return {
+    url,
+    connect,
+    disconnect,
+    subscribe,
+    isConnected: () => connected,
+  }
+}

--- a/dashboard/src/transports/transport.ts
+++ b/dashboard/src/transports/transport.ts
@@ -1,0 +1,31 @@
+/** Multi-transport abstraction for keeper tool results and real-time events.
+ *
+ * Supports SSE, HTTP streamable, WebSocket, and gRPC transports.
+ * Consumers subscribe to a typed event stream without caring about the
+ * underlying transport.
+ */
+
+export type TransportEvent =
+  | { readonly type: 'message'; readonly data: unknown }
+  | { readonly type: 'error'; readonly error: Error }
+  | { readonly type: 'close' }
+  | { readonly type: 'open' }
+
+export interface Transport {
+  readonly url: string
+  readonly connect: () => void
+  readonly disconnect: () => void
+  readonly subscribe: (listener: (event: TransportEvent) => void) => () => void
+  readonly isConnected: () => boolean
+}
+
+export interface TransportFactory {
+  readonly create: (url: string, opts?: TransportOptions) => Transport
+}
+
+export interface TransportOptions {
+  readonly retryBaseMs?: number
+  readonly retryMaxMs?: number
+  readonly heartbeatIntervalMs?: number
+  readonly headers?: Record<string, string>
+}

--- a/dashboard/src/transports/websocket-transport.ts
+++ b/dashboard/src/transports/websocket-transport.ts
@@ -1,0 +1,94 @@
+import type { Transport, TransportEvent, TransportOptions } from './transport'
+
+const DEFAULT_RETRY_BASE_MS = 1000
+const DEFAULT_RETRY_MAX_MS = 30000
+const DEFAULT_HEARTBEAT_MS = 30000
+
+export function createWebSocketTransport(url: string, opts: TransportOptions = {}): Transport {
+  let ws: WebSocket | null = null
+  let listeners: Array<(event: TransportEvent) => void> = []
+  let retryMs = opts.retryBaseMs ?? DEFAULT_RETRY_BASE_MS
+  let reconnectTimer: ReturnType<typeof setTimeout> | null = null
+  let heartbeatTimer: ReturnType<typeof setInterval> | null = null
+  let connected = false
+
+  const notify = (event: TransportEvent) => {
+    listeners.forEach((l) => l(event))
+  }
+
+  const connect = () => {
+    if (ws) return
+    try {
+      ws = new WebSocket(url)
+      ws.onopen = () => {
+        connected = true
+        retryMs = opts.retryBaseMs ?? DEFAULT_RETRY_BASE_MS
+        notify({ type: 'open' })
+        const heartbeat = opts.heartbeatIntervalMs ?? DEFAULT_HEARTBEAT_MS
+        if (heartbeat > 0) {
+          heartbeatTimer = setInterval(() => {
+            if (ws?.readyState === WebSocket.OPEN) {
+              ws.send(JSON.stringify({ type: 'ping' }))
+            }
+          }, heartbeat)
+        }
+      }
+      ws.onmessage = (ev) => {
+        try {
+          const data = JSON.parse(ev.data)
+          notify({ type: 'message', data })
+        } catch {
+          notify({ type: 'message', data: ev.data })
+        }
+      }
+      ws.onerror = () => {
+        connected = false
+        notify({ type: 'error', error: new Error('WebSocket transport error') })
+      }
+      ws.onclose = () => {
+        connected = false
+        if (heartbeatTimer) {
+          clearInterval(heartbeatTimer)
+          heartbeatTimer = null
+        }
+        ws = null
+        notify({ type: 'close' })
+        const maxMs = opts.retryMaxMs ?? DEFAULT_RETRY_MAX_MS
+        reconnectTimer = setTimeout(connect, Math.min(retryMs, maxMs))
+        retryMs = Math.min(retryMs * 2, maxMs)
+      }
+    } catch (err) {
+      notify({ type: 'error', error: err instanceof Error ? err : new Error(String(err)) })
+    }
+  }
+
+  const disconnect = () => {
+    if (reconnectTimer) {
+      clearTimeout(reconnectTimer)
+      reconnectTimer = null
+    }
+    if (heartbeatTimer) {
+      clearInterval(heartbeatTimer)
+      heartbeatTimer = null
+    }
+    connected = false
+    ws?.close()
+    ws = null
+    notify({ type: 'close' })
+  }
+
+  const subscribe = (listener: (event: TransportEvent) => void) => {
+    listeners = [...listeners, listener]
+    return () => {
+      listeners = listeners.filter((l) => l !== listener)
+    }
+  }
+
+  return {
+    url,
+    connect,
+    disconnect,
+    subscribe,
+    isConnected: () => connected,
+  }
+}


### PR DESCRIPTION
- Add Transport interface with SSE, HTTP streamable, and WebSocket implementations\n- Reconnect with exponential backoff for all transports\n- Unified event type for message/error/close/open\n- Pluggable transport factory for future gRPC support