### PR TITLE
fix(keeper): yield in telemetry consumer drain loop (boot hang fix for #14491)

### DIFF
--- a/lib/keeper/keeper_telemetry_consumer.ml
+++ b/lib/keeper/keeper_telemetry_consumer.ml
@@ -15,7 +15,11 @@
 let telemetry_event_counter = "masc_keeper_telemetry_events_consumed_total"
 let telemetry_event_drop_counter = "masc_keeper_telemetry_events_dropped_total"
 
-let spawn_subscriber ~sw ~bus =
+(* drain is non-blocking; loop must yield or it pins the Eio domain and
+   starves co-located fibers (HTTP handlers, lazy startup tasks). *)
+let drain_interval_s = 0.1
+
+let spawn_subscriber ~sw ~clock ~bus =
   let sub =
     Agent_sdk_metrics_bridge.subscribe
       ~purpose:"telemetry_consumer"
@@ -58,6 +62,7 @@ let spawn_subscriber ~sw ~bus =
            Log.Keeper.warn
              "telemetry_consumer: drain iteration failed: %s"
              (Printexc.to_string exn));
+      Eio.Time.sleep clock drain_interval_s;
       loop ()
     in
     loop ())

--- a/lib/keeper/keeper_telemetry_consumer.mli
+++ b/lib/keeper/keeper_telemetry_consumer.mli
@@ -6,5 +6,6 @@
 
 val spawn_subscriber
   :  sw:Eio.Switch.t
+  -> clock:[> float Eio.Time.clock_ty ] Eio.Std.r
   -> bus:Agent_sdk.Event_bus.t
   -> unit

--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -321,7 +321,7 @@ let start_keeper_loops ~sw ~clock ~net ~domain_mgr ~proc_mgr
      per-(provider,model) EWMA health state.  See
      lib/keeper/keeper_provider_health.ml for the aggregator and
      lib/keeper/keeper_telemetry_consumer.ml for the subscriber. *)
-  Keeper_telemetry_consumer.spawn_subscriber ~sw ~bus:event_bus;
+  Keeper_telemetry_consumer.spawn_subscriber ~sw ~clock ~bus:event_bus;
   let keeper_lifecycle_sub =
     Agent_sdk_metrics_bridge.subscribe
       ~purpose:"lifecycle_listener"


### PR DESCRIPTION
## 증상

`./start-masc-mcp.sh` 실행 시 부팅 마지막에 다음 로그를 마지막으로 모든 진행 정지:

```
[Server] lazy_task: starting restore_sessions
```

- 8935/8936/8937 모두 LISTEN
- 단일 OS thread CPU 99%
- `curl /health` 3초 timeout
- 후속 lazy task (`reconcile_active_agents`, `prompt_bootstrap`, ...) 모두 미실행
- HTTP handler 영원히 starvation

## Root cause

`#14491` (`feat(keeper): wire OAS telemetry into provider health, livelock gate, and supervisor`, 머지 2026-05-10 14:34Z)이 도입한 `Keeper_telemetry_consumer.spawn_subscriber`의 drain fiber가 yield를 호출하지 않습니다.

`lib/keeper/keeper_telemetry_consumer.ml:30-62` (수정 전):

```ocaml
Eio.Fiber.fork ~sw (fun () ->
  let rec loop () =
    (try
       let events = Agent_sdk_metrics_bridge.drain sub in   (* non-blocking *)
       List.iter ... events
     with ...);
    loop ()                                                  (* yield 없이 즉시 재귀 *)
  in
  loop ())
```

`drain`은 non-blocking → 빈 큐면 즉시 `[]` 반환 → `List.iter` no-op → 즉시 재귀. Eio cooperative scheduler 특성상 fiber가 IO/sleep/yield를 호출해야 다른 fiber에 turn을 넘기는데, 이 loop에는 yield가 전무. 같은 도메인의 모든 fiber가 starvation.

`restore_sessions`가 마지막 로그인 이유: 직전 fork된 telemetry fiber에 도메인이 잡혀 후속 lazy task와 HTTP handler 모두 starve. **로그 위치 ≠ 멈춘 위치**.

### 진단 증거 (sample)

```
1193 Keeper_telemetry_consumer.loop_1477
  + 1193 Agent_sdk_metrics_bridge.drain_1636
  +   1193 Agent_sdk.Event_bus.collect_1612
  +     Eio.Stream.take_nonblocking → caml_ml_mutex_lock/unlock 무한 반복
```

## 수정

코드베이스의 다른 4개 drain loop는 모두 `Eio.Time.sleep clock <interval>`로 yield합니다:

| 파일 | yield |
|------|-------|
| `cascade/cascade_event_bridge.ml:1170` | `Eio.Time.sleep clock interval_s` |
| `keeper/keeper_compact_audit.ml:432` | `Eio.Time.sleep clock drain_interval_s` |
| `server/server_bootstrap_loops.ml:391` | `Eio.Time.sleep clock keeper_listener_retry_interval_sec` |
| `cascade/cascade_event_bridge.ml:1170` | `Eio.Time.sleep clock interval_s` |
| **`keeper/keeper_telemetry_consumer.ml`** | **누락 (이 PR이 추가)** |

sibling `keeper_compact_audit.spawn_subscriber` 시그니처를 그대로 mirror:
- `~clock` 인자 추가
- `drain_interval_s = 0.1` named constant
- 단일 caller (`server_bootstrap_loops.ml:324`)는 같은 함수 안에 이미 `clock` in-scope이라 인자 추가만으로 wire 완료

## Workaround Rejection Bar self-check

CLAUDE.md `software-development.md` §워크어라운드 거부 기준 7항목 모두 비대상:

1. ❌ telemetry-as-fix (counter 추가 아님)
2. ❌ string/substring 분류기 보강 아님
3. ❌ N-of-M 패치 — 반대로, 코드베이스의 합의된 sleep 패턴이 4사이트에 이미 존재하고 누락된 1사이트를 통일
4. ❌ catch-all `_ ->` 추가 아님
5. ❌ cap/cooldown/dedup/repair symptom 억제 아님
6. ❌ test backdoor 노출 아님
7. ❌ 동일 typo N사이트 N번 fix 아님

→ 구조적 unification fix.

## 검증

- `dune build --root .` PASS (worktree 안)
- 시그니처가 sibling `keeper_compact_audit.mli`와 동일 형식
- 단일 caller 컴파일 OK

## 미검증 (reviewer 확인 권장)

- 실제 서버 재기동 후 hang 해소 확인 — `lazy_task: finished restore_sessions` 이후 모든 lazy task 진행 + `curl /health` 200 응답 확인 필요
- Telemetry latency 영향: 100ms polling이라 EWMA / livelock gate 응답성 영향 거의 없을 것으로 예상하나, env-tunable 만들지 여부는 별도 follow-up

## 배경

Eio cooperative scheduling에서 non-blocking primitive를 yield 없이 loop하는 안티패턴 사례. 향후 회귀 차단을 위한 정적 분석 룰 (drain loop는 반드시 sleep/yield 호출 포함) 또는 TLA+ Bug Model 패턴 (`software-development.md` §TLA+ Bug Model)을 고려해볼 만함.

🤖 Generated with [Claude Code](https://claude.com/claude-code)