### PR TITLE
fix(ide-lsp): string ID support, spec compliance, and overlay hardening

### DIFF
--- a/lib/server/lsp_overlay_provider.ml
+++ b/lib/server/lsp_overlay_provider.ml
@@ -8,25 +8,30 @@ open Ide_annotation_types
 
 module Cache = struct
   let tbl : (string, annotation list) Hashtbl.t = Hashtbl.create 32
+  let mutex = Eio.Mutex.create ()
 
   let key ~base_dir ~file_path = base_dir ^ "/" ^ file_path
 
   let get ~base_dir ~file_path =
-    let k = key ~base_dir ~file_path in
-    match Hashtbl.find_opt tbl k with
-    | Some annotations -> annotations
-    | None ->
-      let filter : annotation_filter =
-        { file_path = Some file_path; keeper_id = None; goal_id = None; task_id = None }
-      in
-      let annotations = Ide_annotations.list ~base_dir ~filter in
-      Hashtbl.replace tbl k annotations;
-      annotations
+    Eio.Mutex.use_rw ~protect:true mutex (fun () ->
+      let k = key ~base_dir ~file_path in
+      match Hashtbl.find_opt tbl k with
+      | Some annotations -> annotations
+      | None ->
+        let filter : annotation_filter =
+          { file_path = Some file_path; keeper_id = None; goal_id = None; task_id = None }
+        in
+        let annotations = Ide_annotations.list ~base_dir ~filter in
+        Hashtbl.replace tbl k annotations;
+        annotations)
 
   let invalidate ~base_dir ~file_path =
-    Hashtbl.remove tbl (key ~base_dir ~file_path)
+    Eio.Mutex.use_rw ~protect:true mutex (fun () ->
+      Hashtbl.remove tbl (key ~base_dir ~file_path))
 
-  let clear () = Hashtbl.clear tbl
+  let clear () =
+    Eio.Mutex.use_rw ~protect:true mutex (fun () ->
+      Hashtbl.clear tbl)
 end
 
 (** LSP CodeLens entry as JSON. *)
@@ -128,8 +133,37 @@ let annotations_at_line ~base_dir ~file_path ~line =
     a.line_start - 1 <= line && line <= a.line_end - 1
   ) annotations
 
+let has_annotations_at_line ~base_dir ~file_path ~line =
+  annotations_at_line ~base_dir ~file_path ~line <> []
+
+(** Normalize Hover.contents to MarkupContent (kind, value).
+    Handles MarkupContent, MarkedString, and MarkedString[]. *)
+let contents_to_markup = function
+  | `Assoc fields ->
+    (match List.assoc_opt "kind" fields, List.assoc_opt "value" fields with
+     | Some (`String k), Some (`String v) -> Some (k, v)
+     | _ ->
+       (match List.assoc_opt "language" fields, List.assoc_opt "value" fields with
+        | Some (`String lang), Some (`String v) ->
+          Some ("markdown", "```" ^ lang ^ "\n" ^ v ^ "\n```")
+        | _ -> None))
+  | `String s -> Some ("plaintext", s)
+  | `List items ->
+    let parts = List.filter_map (function
+      | `String s -> Some s
+      | `Assoc fs ->
+        (match List.assoc_opt "language" fs, List.assoc_opt "value" fs with
+         | Some (`String lang), Some (`String v) ->
+           Some ("```" ^ lang ^ "\n" ^ v ^ "\n```")
+         | _, Some (`String v) -> Some v
+         | _ -> None)
+      | _ -> None
+    ) items in
+    Some ("markdown", String.concat "\n\n" parts)
+  | _ -> None
+
 (** Append MASC annotation context to an LSP Hover response.
-    If the hover response is a MarkupContent, appends annotation summaries.
+    Handles all LSP Hover.contents forms: MarkupContent, MarkedString, MarkedString[].
     Returns the enriched response unchanged if no annotations overlap. *)
 let enrich_hover ~base_dir ~file_path ~line (result : Yojson.Safe.t) =
   let matching = annotations_at_line ~base_dir ~file_path ~line in
@@ -153,11 +187,17 @@ let enrich_hover ~base_dir ~file_path ~line (result : Yojson.Safe.t) =
     match result with
     | `Assoc fields ->
       (match List.assoc_opt "contents" fields with
-       | Some (`Assoc [ ("kind", `String k); ("value", `String v) ]) ->
-         `Assoc (List.map (fun (key, value) ->
-           if String.equal key "contents"
-           then ("contents", `Assoc [ ("kind", `String k); ("value", `String (v ^ masc_suffix)) ])
-           else (key, value)
-         ) fields)
-       | _ -> result)
+       | Some contents ->
+         (match contents_to_markup contents with
+          | Some (k, v) ->
+            let enriched =
+              `Assoc [ ("kind", `String k); ("value", `String (v ^ masc_suffix)) ]
+            in
+            `Assoc (List.map (fun (key, value) ->
+              if String.equal key "contents"
+              then ("contents", enriched)
+              else (key, value)
+            ) fields)
+          | None -> result)
+       | None -> result)
     | _ -> result

--- a/lib/server/lsp_overlay_provider.mli
+++ b/lib/server/lsp_overlay_provider.mli
@@ -26,5 +26,8 @@ val clear_cache : unit -> unit
 val enrich_hover :
   base_dir:string -> file_path:string -> line:int -> Yojson.Safe.t -> Yojson.Safe.t
 (** Append MASC annotation context to an LSP Hover response.
-    If annotations overlap the given line, appends summaries to the hover contents.
+    Handles all Hover.contents forms: MarkupContent, MarkedString, MarkedString[].
     Returns the original response unchanged if no annotations overlap. *)
+
+val has_annotations_at_line : base_dir:string -> file_path:string -> line:int -> bool
+(** Check if any MASC annotations overlap the given LSP position (0-based line). *)

--- a/lib/server/server_ide_lsp_proxy.ml
+++ b/lib/server/server_ide_lsp_proxy.ml
@@ -79,9 +79,20 @@ let send cs msg =
   Eio.Mutex.use_rw ~protect:true cs.send_mutex (fun () -> send_text cs.wsd msg)
 ;;
 
+(** JSON-RPC request ID — LSP spec allows integer or string. *)
+type req_id = Id_int of int | Id_string of string
+
+let id_to_json = function
+  | Id_int n -> `Int n
+  | Id_string s -> `String s
+
+let req_id_to_int = function
+  | Id_int n -> n
+  | Id_string s -> Hashtbl.hash s
+
 (** Send JSON-RPC response. *)
 let send_response cs id result =
-  let resp = `Assoc [ "jsonrpc", `String "2.0"; "id", `Int id; "result", result ] in
+  let resp = `Assoc [ "jsonrpc", `String "2.0"; "id", id_to_json id; "result", result ] in
   send cs (Yojson.Safe.to_string resp)
 ;;
 
@@ -90,7 +101,7 @@ let send_error cs id code msg =
   let resp =
     `Assoc
       [ "jsonrpc", `String "2.0"
-      ; "id", `Int id
+      ; "id", id_to_json id
       ; "error", `Assoc [ "code", `Int code; "message", `String msg ]
       ]
   in
@@ -137,31 +148,35 @@ let pct_decode s =
   done;
   Buffer.contents buf
 
-(** Resolve file:// URI to relative path from base. *)
+(** Resolve file:// URI to relative path from base.
+    Strips trailing slash from base and checks directory boundary. *)
 let resolve_relative ~base uri =
   let prefix = "file://" in
-  if String.starts_with ~prefix uri
-  then (
-    let full =
-      let raw =
-        String.sub uri (String.length prefix) (String.length uri - String.length prefix)
-      in
-      pct_decode raw
+  if not (String.starts_with ~prefix uri) then Some uri
+  else
+    let raw = String.sub uri (String.length prefix) (String.length uri - String.length prefix) in
+    let full = pct_decode raw in
+    let base =
+      let len = String.length base in
+      if len > 1 && String.get base (len - 1) = '/'
+      then String.sub base 0 (len - 1)
+      else base
     in
-    if String.starts_with ~prefix:base full
-    then (
-      let start = String.length base in
-      if start < String.length full
-      then Some (String.sub full (start + 1) (String.length full - start - 1))
-      else Some "")
-    else Some full)
-  else Some uri
+    let base_len = String.length base in
+    let full_len = String.length full in
+    if not (String.starts_with ~prefix:base full) then Some full
+    else if base_len = full_len then Some ""
+    else if full_len > base_len && String.get full base_len = '/' then
+      Some (String.sub full (base_len + 1) (full_len - base_len - 1))
+    else
+      Some full
 ;;
 
 (** Extract client request ID from JSON-RPC message fields. *)
 let extract_id fields =
   match List.assoc_opt "id" fields with
-  | Some (`Int n) -> Some n
+  | Some (`Int n) -> Some (Id_int n)
+  | Some (`String s) -> Some (Id_string s)
   | _ -> None
 ;;
 
@@ -245,7 +260,7 @@ let forward_request cs lang_id method_ params id =
   | Error msg -> send_error cs id (-32603) msg
   | Ok proc ->
     let promise =
-      Lsp_message_router.send_request cs.router proc ~method_ ~params ~client_id:id
+      Lsp_message_router.send_request cs.router proc ~method_ ~params ~client_id:(req_id_to_int id)
     in
     (match Eio.Promise.await promise with
      | Ok result -> send_response cs id result
@@ -280,7 +295,7 @@ let handle_codelens cs params id =
             proc
             ~method_:"textDocument/codeLens"
             ~params
-            ~client_id:id
+            ~client_id:(req_id_to_int id)
         in
         (match Eio.Promise.await promise with
          | Ok (`List items) -> send_response cs id (`List (items @ masc))
@@ -309,7 +324,7 @@ let handle_inlay_hint cs params id =
             proc
             ~method_:"textDocument/inlayHint"
             ~params
-            ~client_id:id
+            ~client_id:(req_id_to_int id)
         in
         (match Eio.Promise.await promise with
          | Ok (`List items) -> send_response cs id (`List (items @ masc))
@@ -351,7 +366,7 @@ let handle_diagnostic cs params id =
             proc
             ~method_:"textDocument/diagnostic"
             ~params
-            ~client_id:id
+            ~client_id:(req_id_to_int id)
         in
         (match Eio.Promise.await promise with
          | Ok (`Assoc rfields) ->
@@ -382,7 +397,7 @@ let handle_hover cs params id =
     let lang_id = Lsp_process_manager.lang_of_path relative in
     if lang_id = "unknown"
     then (
-      if line >= 0
+      if line >= 0 && Lsp_overlay_provider.has_annotations_at_line ~base_dir:base ~file_path:relative ~line
       then (
         let enriched =
           Lsp_overlay_provider.enrich_hover
@@ -403,7 +418,7 @@ let handle_hover cs params id =
             proc
             ~method_:"textDocument/hover"
             ~params
-            ~client_id:id
+            ~client_id:(req_id_to_int id)
         in
         (match Eio.Promise.await promise with
          | Ok result ->
@@ -467,7 +482,7 @@ let dispatch_message cs msg =
                      ; "documentLinkProvider", `Bool true
                      ; "codeLensProvider", `Assoc [ "resolveProvider", `Bool false ]
                      ; "inlayHintProvider", `Bool true
-                     ; "diagnosticProvider", `Bool true
+                     ; "diagnosticProvider", `Assoc [ "interFileDependencies", `Bool false; "workspaceDiagnostics", `Bool false ]
                      ] )
                ])
        | Some "initialized", _ -> ()


### PR DESCRIPTION
## Summary
- **P1**: Support string JSON-RPC IDs (VS Code sends these). Add `req_id` variant with `Hashtbl.hash` routing for internal message router.
- **P2**: `enrich_hover` now handles all LSP `Hover.contents` forms (MarkupContent, MarkedString, MarkedString[]). Cache module protected with `Eio.Mutex`. Unknown-language hover returns `Null` when no MASC annotations exist.
- **P3**: `diagnosticProvider` changed to spec-compliant `DiagnosticOptions` object. `resolve_relative` normalizes trailing slashes and validates directory boundary.

## Files changed
- `lib/server/server_ide_lsp_proxy.ml` — req_id type, req_id_to_int, resolve_relative, diagnosticProvider, handle_hover guard
- `lib/server/lsp_overlay_provider.ml` — contents_to_markup, has_annotations_at_line, Cache Mutex
- `lib/server/lsp_overlay_provider.mli` — expose has_annotations_at_line

## Test plan
- [x] `dune build --root .` passes with no errors
- [ ] Manual: connect VS Code LSP client, verify string IDs in request/response cycle
- [ ] Manual: hover over file with MASC annotations, verify enrichment
- [ ] Manual: hover over file without annotations (unknown lang), verify Null response