### PR TITLE
perf(server): Tier A — SSE backpressure + holder_table atomic + fs_compat fd cache + costs Dated_jsonl + dashboard param cache

### DIFF
--- a/lib/fs_compat/fs_compat.ml
+++ b/lib/fs_compat/fs_compat.ml
@@ -127,11 +127,121 @@ let save_file_unix (path : string) (content : string) : unit =
     Stdlib.output_string oc content
   )
 
+(** LRU fd cache for [append_file_unix].
+
+    Tier-A perf change: previously every [append_file] call did
+    [open_out_gen] + [output_string] + [close_out] — three syscalls
+    per JSONL line.  Under 64+ keepers each emitting telemetry every
+    turn, that fd churn dominated kernel time and gated keeper
+    progress on file I/O.
+
+    Cache up to [fd_cache_max_size] open append channels keyed by
+    absolute path.  On hit, re-use the cached channel and [flush] so
+    bytes reach the kernel buffer before the call returns (preserves
+    durability semantics for crash-after-append scenarios — without
+    the flush, OCaml's per-channel buffer would coalesce writes and
+    a SIGKILL between [output_string] and the next [flush] could lose
+    data).  On miss, open the file and insert; if the cache is full,
+    evict the least-recently-used entry first (closing its channel).
+
+    Uses [Stdlib.Mutex] (not [Eio.Mutex]) because [append_file] is
+    callable from non-Eio contexts (init, [at_exit], pure-Unix
+    fallback paths).  Single-domain assumption holds — multi-domain
+    rollout is gated on RFC-Domain-Split (out-of-scope here); when
+    that lands, the cache should become domain-local.
+
+    The [at_exit] handler closes every cached channel so normal
+    shutdown flushes all pending bytes; abnormal termination
+    (SIGKILL) still loses any kernel-buffered writes that haven't
+    been [fsync]'d, but that was already true before this change. *)
+let fd_cache_max_size = 16
+
+module Append_fd_cache = struct
+  type entry = {
+    mutable channel : Stdlib.out_channel;
+    mutable last_used : int;
+  }
+
+  let cache : (string, entry) Hashtbl.t = Hashtbl.create 17
+  let counter = ref 0
+  let mutex = Mutex.create ()
+
+  let with_lock f =
+    Mutex.lock mutex;
+    Fun.protect ~finally:(fun () -> Mutex.unlock mutex) f
+
+  let evict_lru_if_needed_locked () =
+    if Hashtbl.length cache >= fd_cache_max_size then begin
+      let victim_path = ref None in
+      let victim_use = ref max_int in
+      Hashtbl.iter
+        (fun path entry ->
+           if entry.last_used < !victim_use
+           then begin
+             victim_path := Some path;
+             victim_use := entry.last_used
+           end)
+        cache;
+      match !victim_path with
+      | None -> ()
+      | Some path ->
+          (match Hashtbl.find_opt cache path with
+           | Some entry ->
+               Stdlib.close_out_noerr entry.channel;
+               Hashtbl.remove cache path
+           | None -> ())
+    end
+
+  let get_or_open_locked path =
+    match Hashtbl.find_opt cache path with
+    | Some entry ->
+        incr counter;
+        entry.last_used <- !counter;
+        entry.channel
+    | None ->
+        evict_lru_if_needed_locked ();
+        let oc =
+          Stdlib.open_out_gen
+            [ Stdlib.Open_append; Stdlib.Open_creat ]
+            0o644 path
+        in
+        incr counter;
+        let entry = { channel = oc; last_used = !counter } in
+        Hashtbl.add cache path entry;
+        oc
+
+  let invalidate path =
+    with_lock (fun () ->
+      match Hashtbl.find_opt cache path with
+      | None -> ()
+      | Some entry ->
+          Stdlib.close_out_noerr entry.channel;
+          Hashtbl.remove cache path)
+
+  let close_all () =
+    with_lock (fun () ->
+      Hashtbl.iter
+        (fun _ entry -> Stdlib.close_out_noerr entry.channel)
+        cache;
+      Hashtbl.clear cache)
+end
+
+let () = Stdlib.at_exit Append_fd_cache.close_all
+
 let append_file_unix (path : string) (content : string) : unit =
-  let oc = Stdlib.open_out_gen [Stdlib.Open_append; Stdlib.Open_creat] 0o644 path in
-  Stdlib.Fun.protect ~finally:(fun () -> Stdlib.close_out_noerr oc) (fun () ->
-    Stdlib.output_string oc content
-  )
+  let write_with_cached () =
+    Append_fd_cache.with_lock (fun () ->
+      let oc = Append_fd_cache.get_or_open_locked path in
+      Stdlib.output_string oc content;
+      Stdlib.flush oc)
+  in
+  try write_with_cached ()
+  with exn ->
+    (* On I/O error invalidate the cached fd so the next call re-opens
+       fresh.  Re-raise so callers see the same error class as before
+       (Sys_error wrapping Unix_error). *)
+    Append_fd_cache.invalidate path;
+    raise exn
 
 let mkdir_p_unix (path : string) : unit =
   let rec ensure_dir (p : string) : unit =

--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -919,6 +919,10 @@ let cost_event_payload
      ?telemetry
      ()).payload
 
+(** Date-split cost ledger root inside [masc_root].  See
+    [Dated_jsonl] for the [costs/YYYY-MM/DD.jsonl] layout. *)
+let costs_dated_dir masc_root = Filename.concat masc_root "costs"
+
 let emit_cost_event
     ~(masc_root : string)
     ~(agent_name : string)
@@ -931,7 +935,19 @@ let emit_cost_event
     ?usage_trust
     ?(telemetry : Agent_sdk.Types.inference_telemetry option)
     () : unit =
-  let path = Filename.concat masc_root "costs.jsonl" in
+  (* Tier-A perf change: previously appended to a single unbounded
+     [masc_root/costs.jsonl] (14k lines, 7.5MB observed in [~/me/.masc]),
+     so every emit grew a hot single-writer file and the reader scanned
+     the entire blob.  Migrated to [Dated_jsonl] under
+     [masc_root/costs/YYYY-MM/DD.jsonl] — same per-day mutex registry
+     used by tracing / coverage_gap / audit appenders, so concurrent
+     keepers serialise on a per-day file rather than a single global
+     one.  Legacy [costs.jsonl] is left in place for read compatibility
+     ([Model_inference_metrics.read_cost_entries] reads both sources
+     until operators archive the legacy file). *)
+  let store =
+    Dated_jsonl.create ~base_dir:(costs_dated_dir masc_root) ()
+  in
   let assembled =
     assemble_cost_event_payload
       ~agent_name
@@ -956,8 +972,7 @@ let emit_cost_event
     ();
   record_cost_emit_source assembled.cost_usd_source;
   let entry = assembled.payload in
-  let line = Yojson.Safe.to_string entry ^ "\n" in
-  (try Fs_compat.append_file path line
+  (try Dated_jsonl.append store entry
    with Eio.Cancel.Cancelled _ as e -> raise e
       | exn ->
         Prometheus.inc_counter
@@ -965,7 +980,7 @@ let emit_cost_event
           ~labels:[("keeper", agent_name); ("site", "cost_event_write")]
           ();
         Log.Keeper.error "emit_cost_event: failed to write %s: %s"
-          path (Printexc.to_string exn))
+          (Dated_jsonl.base_dir store) (Printexc.to_string exn))
 
 (** Build OAS hooks for a keeper agent.
 

--- a/lib/keeper/keeper_turn_slot.ml
+++ b/lib/keeper/keeper_turn_slot.ml
@@ -93,7 +93,34 @@ type holder_key =
   ; holder_acquisition_id : int
   }
 
-let holder_table : (holder_key, float) Hashtbl.t = Hashtbl.create 32
+module Holder_key = struct
+  type t = holder_key
+  let compare = Stdlib.compare
+end
+
+module Holder_map = Map.Make (Holder_key)
+
+(** Active-holder table.
+
+    Tier-A perf change: previously [(holder_key, float) Hashtbl.t]
+    behind [holder_mutex] for both reads and writes.  [snapshot_holders]
+    is a hot read path — every acquire / release / timeout-log call
+    walks it — so 64+ concurrent keepers contend on the mutex on every
+    turn boundary.  Move to a persistent [Holder_map.t] behind
+    [Atomic.t]: writers still hold the mutex (so they remain serialised
+    with [force_released_holders] mutations), but readers do
+    [Atomic.get] without locking.
+
+    Writes are CAS-free in practice — they happen inside
+    [with_holder_lock], so no concurrent writer races them; we use
+    plain [Atomic.set] for the new state.  Stale reads are bounded by
+    the mutex hold time of a single writer (microseconds), and
+    [snapshot_holders] consumers (timeout attribution) are already
+    lagging by design (see memory
+    [feedback_keeper_freeze_diagnosis_requires_timeseries_window]). *)
+let holder_table_atomic : float Holder_map.t Atomic.t =
+  Atomic.make Holder_map.empty
+
 let force_released_holders : (holder_key, float) Hashtbl.t = Hashtbl.create 32
 let next_holder_acquisition_id = ref 0
 let holder_mutex = Eio.Mutex.create ()
@@ -142,7 +169,8 @@ let record_holder ~label ~keeper_name ~acquired_at =
       ; holder_acquisition_id = acquisition_id
       }
     in
-    Hashtbl.replace holder_table key acquired_at;
+    Atomic.set holder_table_atomic
+      (Holder_map.add key acquired_at (Atomic.get holder_table_atomic));
     acquisition_id)
 ;;
 
@@ -150,19 +178,25 @@ let mark_holder_force_released ~label ~keeper_name =
   with_holder_lock (fun () ->
     let now = Time_compat.now () in
     purge_expired_force_released_holders_locked ~now;
+    let table = Atomic.get holder_table_atomic in
     let keys =
-      Hashtbl.fold
+      Holder_map.fold
         (fun key _ acc ->
            if key.holder_label = label && String.equal key.holder_keeper_name keeper_name
            then key :: acc
            else acc)
-        holder_table
+        table
         []
     in
+    let next_table =
+      List.fold_left
+        (fun acc key -> Holder_map.remove key acc)
+        table
+        keys
+    in
+    Atomic.set holder_table_atomic next_table;
     List.iter
-      (fun key ->
-         Hashtbl.remove holder_table key;
-         Hashtbl.replace force_released_holders key now)
+      (fun key -> Hashtbl.replace force_released_holders key now)
       keys;
     List.length keys)
 ;;
@@ -180,23 +214,30 @@ let consume_force_release ~label ~keeper_name ~acquisition_id =
       Hashtbl.remove force_released_holders key;
       true
     | None ->
-      Hashtbl.remove holder_table key;
+      Atomic.set holder_table_atomic
+        (Holder_map.remove key (Atomic.get holder_table_atomic));
       false)
 ;;
 
 (** [snapshot_holders ~label ~now] returns [(keeper_name, held_for_sec)]
     pairs for the given [label] sorted by descending hold time.  Used
     by [acquire_bounded] to attribute timeouts to the longest-held
-    peer.  Pure read, no mutation. *)
+    peer.  Pure read, no mutation.
+
+    Tier-A perf change: previously serialised on [holder_mutex] for
+    every read; now does a lock-free [Atomic.get] of the persistent
+    [Holder_map.t] and folds over the snapshot.  Stale reads are
+    bounded by a single writer's mutex hold time (microseconds) and
+    callers (timeout attribution) are already lagging by design. *)
 let snapshot_holders ~label ~now =
-  with_holder_lock (fun () ->
-    Hashtbl.fold
-      (fun key ts acc ->
-         if key.holder_label = label
-         then (key.holder_keeper_name, now -. ts) :: acc
-         else acc)
-      holder_table
-      [])
+  let table = Atomic.get holder_table_atomic in
+  Holder_map.fold
+    (fun key ts acc ->
+       if key.holder_label = label
+       then (key.holder_keeper_name, now -. ts) :: acc
+       else acc)
+    table
+    []
   |> List.sort (fun (_, a) (_, b) -> compare b a)
 ;;
 
@@ -314,25 +355,26 @@ let format_slot_holders ?(limit = 5) holders =
     "[" ^ String.concat ", " items ^ "]"
 ;;
 
-(** [snapshot_all_holders ~now] reads every pool inside ONE
-    [holder_mutex] critical section and returns the three lists in
-    the same instant.  Calling [turn_slot_holders] / [autonomous_slot_holders]
-    / [reactive_slot_holders] back-to-back from the summary builder
-    would release and re-take the mutex three times — an interleaved
-    [record_holder] / [drop_holder] could then leave the summary
-    reporting contradictory states (e.g. empty turn_holders next to
-    [turn_available=0]).  This helper closes that race. *)
+(** [snapshot_all_holders ~now] reads every pool from a single
+    [Atomic.get] of [holder_table_atomic] and returns the three lists
+    consistent with that snapshot.  Previously held [holder_mutex] for
+    the whole fold to defend against an interleaved
+    [record_holder] / [drop_holder] producing contradictory pool
+    counts; the persistent [Holder_map.t] gives us that consistency
+    for free — every writer publishes a complete map atomically, so
+    the snapshot is guaranteed to be a coherent point-in-time view
+    of {b some} writer-acknowledged state.  Lock-free by design. *)
 let snapshot_all_holders ~now =
-  with_holder_lock (fun () ->
-    Hashtbl.fold
-      (fun key ts (turn, auto, reactive) ->
-         let held = now -. ts in
-         match key.holder_label with
-         | Turn_pool -> (key.holder_keeper_name, held) :: turn, auto, reactive
-         | Autonomous_pool -> turn, (key.holder_keeper_name, held) :: auto, reactive
-         | Reactive_pool -> turn, auto, (key.holder_keeper_name, held) :: reactive)
-      holder_table
-      ([], [], []))
+  let table = Atomic.get holder_table_atomic in
+  Holder_map.fold
+    (fun key ts (turn, auto, reactive) ->
+       let held = now -. ts in
+       match key.holder_label with
+       | Turn_pool -> (key.holder_keeper_name, held) :: turn, auto, reactive
+       | Autonomous_pool -> turn, (key.holder_keeper_name, held) :: auto, reactive
+       | Reactive_pool -> turn, auto, (key.holder_keeper_name, held) :: reactive)
+    table
+    ([], [], [])
   |> fun (t, a, r) ->
   let by_held = List.sort (fun (_, x) (_, y) -> compare y x) in
   by_held t, by_held a, by_held r
@@ -767,21 +809,27 @@ let force_release_holder_for ~keeper_name : (string * float) list =
     let snapshots =
       with_holder_lock (fun () ->
         purge_expired_force_released_holders_locked ~now;
+        let table = Atomic.get holder_table_atomic in
         let matching =
-          Hashtbl.fold
+          Holder_map.fold
             (fun key acquired_at acc ->
                if
                  key.holder_label = label
                  && String.equal key.holder_keeper_name keeper_name
                then (key, acquired_at) :: acc
                else acc)
-            holder_table
+            table
             []
         in
+        let next_table =
+          List.fold_left
+            (fun acc (key, _) -> Holder_map.remove key acc)
+            table
+            matching
+        in
+        Atomic.set holder_table_atomic next_table;
         List.iter
-          (fun (key, _) ->
-             Hashtbl.remove holder_table key;
-             Hashtbl.replace force_released_holders key now)
+          (fun (key, _) -> Hashtbl.replace force_released_holders key now)
           matching;
         matching)
     in

--- a/lib/model_inference_metrics.ml
+++ b/lib/model_inference_metrics.ml
@@ -704,7 +704,7 @@ let read_all_decisions ~base_path ~since_unix : raw_entry list =
       | _ -> []
     ) files
 
-let read_cost_entries ~base_path ~since_unix : raw_entry list =
+let read_cost_entries_legacy ~base_path ~since_unix : raw_entry list =
   let path =
     Filename.concat (Common.masc_dir_from_base_path ~base_path) "costs.jsonl"
   in
@@ -735,6 +735,49 @@ let read_cost_entries ~base_path ~since_unix : raw_entry list =
         let bt = Printexc.get_raw_backtrace () in
         Printexc.raise_with_backtrace exn bt
     | _ -> []
+
+(** Format a Unix timestamp (UTC) as ["YYYY-MM-DD"] for [Dated_jsonl.read_range]. *)
+let date_string_of_unix ts =
+  let open Unix in
+  let tm = gmtime ts in
+  Printf.sprintf "%04d-%02d-%02d"
+    (tm.tm_year + 1900) (tm.tm_mon + 1) tm.tm_mday
+
+let read_cost_entries_dated ~base_path ~since_unix : raw_entry list =
+  let dir =
+    Filename.concat
+      (Common.masc_dir_from_base_path ~base_path) "costs"
+  in
+  if not (Sys.file_exists dir) then []
+  else
+    let store = Dated_jsonl.create ~base_dir:dir () in
+    let now = Unix.gettimeofday () in
+    let since = date_string_of_unix since_unix in
+    let until = date_string_of_unix now in
+    try
+      Dated_jsonl.read_range store ~since ~until
+      |> List.filter_map (fun json ->
+        try parse_cost_entry json ~since_unix
+        with Eio.Cancel.Cancelled _ as e -> raise e | _ -> None)
+    with
+    | Eio.Cancel.Cancelled _ as exn ->
+        let bt = Printexc.get_raw_backtrace () in
+        Printexc.raise_with_backtrace exn bt
+    | _ -> []
+
+(** Read cost ledger entries from both the legacy single-file
+    [masc_root/costs.jsonl] and the date-split
+    [masc_root/costs/YYYY-MM/DD.jsonl] tree, merging the two streams.
+
+    The migration to [Dated_jsonl] (Tier A T4) keeps the legacy file
+    readable so historic 14k+ entries are not dropped from
+    cost-summary reports.  Operators may archive the legacy file at
+    any time once they are satisfied that all queries that mattered to
+    them only touch dates after the cut-over. *)
+let read_cost_entries ~base_path ~since_unix : raw_entry list =
+  let legacy = read_cost_entries_legacy ~base_path ~since_unix in
+  let dated = read_cost_entries_dated ~base_path ~since_unix in
+  legacy @ dated
 
 let same_int_opt a b =
   match a, b with

--- a/lib/server/server_dashboard_http_core.ml
+++ b/lib/server/server_dashboard_http_core.ml
@@ -420,41 +420,64 @@ let operator_snapshot_http_json ~state ~sw ~clock request =
     let mode =
       if lightweight_summary then Inline_shared else Offloaded_readonly
     in
-    match Eio.Time.with_timeout clock dashboard_request_timeout_s (fun () ->
-      Ok
-        (run_dashboard_compute ~mode ?net ?mono_clock ~sw ~clock
-           ~config:state.Mcp_server.room_config
-           (fun ~config ~sw ->
-             let ctx : _ Operator_control.context =
-               {
-                 config;
-                 agent_name = Option.value ~default:"dashboard" actor;
-                 sw;
-                 clock;
-                 proc_mgr = state.Mcp_server.proc_mgr;
-                 net = state.Mcp_server.net;
-                 mcp_session_id = None;
-               }
-             in
-            Operator_control.snapshot_json ?actor ?view
-               ~include_messages ~include_keepers
-               ~include_summary_fields:(not lightweight_summary)
-               ~lightweight_summary
-               ctx))
-    ) with
-    | Ok json ->
-        with_projection_diagnostics ~surface:"operator_snapshot" ~started_at
-          ~extra:
-            [
-              ("readonly_pool", Coord_utils.domain_local_pg_backend_diagnostics_json ());
-            ]
-          json
-    | Error `Timeout ->
-        `Assoc [
-          ("error", `String "timeout");
-          ("message", `String "Operator snapshot timed out after 30s");
-          ("generated_at", `String (Masc_domain.now_iso ()));
-        ]
+    let compute () =
+      match Eio.Time.with_timeout clock dashboard_request_timeout_s (fun () ->
+        Ok
+          (run_dashboard_compute ~mode ?net ?mono_clock ~sw ~clock
+             ~config:state.Mcp_server.room_config
+             (fun ~config ~sw ->
+               let ctx : _ Operator_control.context =
+                 {
+                   config;
+                   agent_name = Option.value ~default:"dashboard" actor;
+                   sw;
+                   clock;
+                   proc_mgr = state.Mcp_server.proc_mgr;
+                   net = state.Mcp_server.net;
+                   mcp_session_id = None;
+                 }
+               in
+              Operator_control.snapshot_json ?actor ?view
+                 ~include_messages ~include_keepers
+                 ~include_summary_fields:(not lightweight_summary)
+                 ~lightweight_summary
+                 ctx))
+      ) with
+      | Ok json ->
+          with_projection_diagnostics ~surface:"operator_snapshot" ~started_at
+            ~extra:
+              [
+                ("readonly_pool", Coord_utils.domain_local_pg_backend_diagnostics_json ());
+              ]
+            json
+      | Error `Timeout ->
+          `Assoc [
+            ("error", `String "timeout");
+            ("message", `String "Operator snapshot timed out after 30s");
+            ("generated_at", `String (Masc_domain.now_iso ()));
+          ]
+    in
+    (* Tier-A perf: parameterized [/api/v1/dashboard/operator/snapshot]
+       requests previously bypassed the cache entirely — every keeper
+       filter / actor view triggered a fresh [run_dashboard_compute]
+       with a 30s timeout.  Under multi-tab dashboard load this was
+       the single largest dashboard-side compute fan-out.  Wrap with
+       a 5s SWR cache keyed on the full parameter tuple so rapid
+       polling (Bond-Web 3s default) hits the cache; mutations
+       continue to invalidate via the existing
+       [Coord_hooks.on_task_mutation_fn] path. *)
+    let cache_key =
+      Printf.sprintf "operator_snapshot:param:%s|%s|%b|%b|%b"
+        (Option.value ~default:"" actor)
+        (Option.value ~default:"" view)
+        include_messages
+        include_keepers
+        lightweight_summary
+    in
+    Dashboard_cache.get_or_compute_with_timeout cache_key
+      ~ttl:5.0 ~clock
+      ~timeout_sec:dashboard_request_timeout_s
+      compute
   end
 
 let operator_digest_http_json ~state ~sw ~clock request =
@@ -490,53 +513,71 @@ let operator_digest_http_json ~state ~sw ~clock request =
     let effective_target_type =
       Option.value ~default:"root" target_type
     in
-    match Eio.Time.with_timeout clock dashboard_request_timeout_s (fun () ->
-      Ok
-        (run_dashboard_compute ~mode:Offloaded_readonly ?net ?mono_clock ~sw
-           ~clock
-           ~config:state.Mcp_server.room_config
-           (fun ~config ~sw ->
-             let ctx : _ Operator_control.context =
-               {
-                 config;
-                 agent_name = Option.value ~default:"dashboard" actor;
-                 sw;
-                 clock;
-                 proc_mgr = state.Mcp_server.proc_mgr;
-                 net = state.Mcp_server.net;
-                 mcp_session_id = None;
-               }
-             in
-             match
-               Operator_control.digest_json ?actor ~target_type:effective_target_type
-                 ?target_id ?include_workers
-                 ctx
-             with
-             | Ok json -> json
-             | Error err ->
-                 `Assoc
-                   [
-                     ("error", `String "validation_error");
-                     ("message", `String err);
-                     ("generated_at", `String (Masc_domain.now_iso ()));
-                   ]))
-    ) with
-    | Ok json ->
+    let compute () =
+      match Eio.Time.with_timeout clock dashboard_request_timeout_s (fun () ->
         Ok
-          (with_projection_diagnostics ~surface:"operator_digest" ~started_at
-             ~extra:
-               [
-                 ("readonly_pool", Coord_utils.domain_local_pg_backend_diagnostics_json ());
-               ]
-             json)
-    | Error `Timeout ->
-        Ok
-          (`Assoc
+          (run_dashboard_compute ~mode:Offloaded_readonly ?net ?mono_clock ~sw
+             ~clock
+             ~config:state.Mcp_server.room_config
+             (fun ~config ~sw ->
+               let ctx : _ Operator_control.context =
+                 {
+                   config;
+                   agent_name = Option.value ~default:"dashboard" actor;
+                   sw;
+                   clock;
+                   proc_mgr = state.Mcp_server.proc_mgr;
+                   net = state.Mcp_server.net;
+                   mcp_session_id = None;
+                 }
+               in
+               match
+                 Operator_control.digest_json ?actor ~target_type:effective_target_type
+                   ?target_id ?include_workers
+                   ctx
+               with
+               | Ok json -> json
+               | Error err ->
+                   `Assoc
+                     [
+                       ("error", `String "validation_error");
+                       ("message", `String err);
+                       ("generated_at", `String (Masc_domain.now_iso ()));
+                     ]))
+      ) with
+      | Ok json ->
+          with_projection_diagnostics ~surface:"operator_digest" ~started_at
+            ~extra:
+              [
+                ("readonly_pool", Coord_utils.domain_local_pg_backend_diagnostics_json ());
+              ]
+            json
+      | Error `Timeout ->
+          `Assoc
             [
               ("error", `String "timeout");
               ("message", `String "Operator digest timed out after 30s");
               ("generated_at", `String (Masc_domain.now_iso ()));
-            ])
+            ]
+    in
+    (* See [operator_snapshot_http_json] above for the parameterized-cache
+       rationale.  Same 5s SWR window applies to operator/digest views. *)
+    let cache_key =
+      Printf.sprintf "operator_digest:param:%s|%s|%s|%s|%s"
+        (Option.value ~default:"" actor)
+        effective_target_type
+        (Option.value ~default:"" target_id)
+        (match include_workers with
+         | None -> ""
+         | Some true -> "1"
+         | Some false -> "0")
+        ""
+    in
+    Ok
+      (Dashboard_cache.get_or_compute_with_timeout cache_key
+         ~ttl:5.0 ~clock
+         ~timeout_sec:dashboard_request_timeout_s
+         compute)
 
 (* --- Mission proactive refresh ----------------------------------------
    A background fiber recomputes the mission snapshot periodically.

--- a/lib/server/server_mcp_transport_http.ml
+++ b/lib/server/server_mcp_transport_http.ml
@@ -614,6 +614,14 @@ let handle_get_mcp ~deps ?legacy_messages_endpoint ?(profile = Full)
           in
           info_ref := Some info;
           register_sse_conn ~session_id ~info;
+          (* Wake the drain fiber when [Sse.unregister] fires (queue
+             overflow disconnect or eviction).  Without this, the drain
+             fiber stays blocked on [Eio.Stream.take] holding [info.stop]
+             at false, the HTTP body writer stays open, and the browser
+             EventSource sees no error indication — this was the silent
+             half of the broadcast-skip bug. *)
+          Sse.set_disconnect_hook session_id (fun () ->
+            stop_sse_session session_id);
           if not (send_raw info (sse_prime_event ())) then
             Log.Server.debug "SSE prime send failed for session %s" info.session_id;
           (match legacy_messages_endpoint with

--- a/lib/server/server_mcp_transport_http_agui.ml
+++ b/lib/server/server_mcp_transport_http_agui.ml
@@ -90,6 +90,10 @@ let handle_ag_ui_events ~deps request reqd =
       in
       info_ref := Some info;
       register_sse_conn ~session_id ~info;
+      (* See [server_mcp_transport_http.ml] for hook rationale — drain
+         wakeup on [Sse.unregister]. *)
+      Sse.set_disconnect_hook session_id (fun () ->
+        stop_sse_session session_id);
       let prime =
         Ag_ui.(
           make_event ~thread_id:default_thread_id ~run_id:(Some session_id) Run_started
@@ -199,6 +203,12 @@ let handle_presence_events ~deps request reqd =
             }
           in
           register_sse_conn ~session_id ~info;
+          (* Presence streams use the preserve-guard variant of stop, so
+             the disconnect hook delegates to [stop_sse_session_preserve_guard]
+             instead of [stop_sse_session] to keep the connect-rate guard
+             across reconnects (see this module's docstring for why). *)
+          Sse.set_disconnect_hook session_id (fun () ->
+            stop_sse_session_preserve_guard session_id);
           if not (send_raw info ": presence-stream\nretry: 3000\n\n") then
             Log.Server.debug "presence prime send failed for session %s"
               info.session_id;

--- a/lib/sse.ml
+++ b/lib/sse.ml
@@ -204,8 +204,20 @@ let event_counter = Atomic.make 0
     [event_buffer] is written by every [broadcast_impl] / [send_to] and
     drained by the periodic [cleanup_expired_events] background fiber.
     The buffer is a newest-first persistent list behind [Atomic.t];
-    all mutations are pure list rewrites committed via CAS. *)
-let max_buffer_size = 100
+    all mutations are pure list rewrites committed via CAS.
+
+    Read from [MASC_SSE_REPLAY_BUFFER_SIZE] (default 1000, clamped 50..1000).
+    Sized to bound replay work for clients reconnecting with [Last-Event-Id]
+    after a network blip; previously fixed at 100, which was too small to
+    cover transient disconnects under 64+ keeper broadcast load and forced
+    operators to manually refresh the dashboard.  The upper bound matches
+    [test/test_sse_coverage.ml] expectations. *)
+let max_buffer_size =
+  let default = 1000 in
+  let lower = 50 and upper = 1000 in
+  let clamp n = max lower (min upper n) in
+  clamp
+    (Env_config_core.get_int ~default "MASC_SSE_REPLAY_BUFFER_SIZE")
 let buffer_ttl_seconds = Env_config.InternalTimers.sse_buffer_ttl_sec
 let event_buffer : (int * string * float) list Atomic.t = Atomic.make []
 
@@ -362,6 +374,59 @@ let next_id () =
   (* Atomic fetch_and_add: returns old value, we want new value so +1 *)
   Atomic.fetch_and_add event_counter 1 + 1
 
+(** Per-session disconnect hook registry.
+
+    A disconnect hook fires when [unregister] / [unregister_if_current]
+    removes a session from [clients].  Its purpose is to wake the
+    transport-layer drain fiber that is otherwise blocked on
+    [Eio.Stream.take]: removing the session from the broadcast registry
+    stops new events from arriving, but the drain fiber holds the HTTP
+    connection's [info.stop] flag and must be signalled separately.
+
+    Without this hook, queue-overflow [unregister] calls (broadcast skip
+    fixup at [broadcast_impl]) leak HTTP connections with stale drain
+    fibers — manifesting as "WS events stop arriving but the browser
+    still shows connected" until keep-alive timeout reaps the socket
+    minutes later.  This was the silent half of the
+    [Transport_metrics.inc_broadcast_failure] path.
+
+    The hook is invoked exactly once: it is removed from the registry
+    inside the same atomic update that observes its presence, so even
+    racing [unregister] / [unregister_if_current] calls cannot double-fire.
+    Hook callbacks are wrapped in try/with — exceptions are logged and
+    swallowed (except [Eio.Cancel.Cancelled]) so a misbehaving callback
+    cannot strand the broadcast fan-out. *)
+let session_disconnect_hooks : (unit -> unit) SMap.t Atomic.t =
+  Atomic.make SMap.empty
+
+let set_disconnect_hook session_id hook =
+  Lockfree_atomic.update_with_commit session_disconnect_hooks (fun map ->
+    { next_state = SMap.add session_id hook map; result = () })
+
+let clear_disconnect_hook session_id =
+  Lockfree_atomic.update_with_commit session_disconnect_hooks (fun map ->
+    { next_state = SMap.remove session_id map; result = () })
+
+let take_disconnect_hook session_id =
+  let hook_ref = ref None in
+  Lockfree_atomic.update_with_commit session_disconnect_hooks (fun map ->
+    match SMap.find_opt session_id map with
+    | None -> { next_state = map; result = () }
+    | Some hook ->
+        hook_ref := Some hook;
+        { next_state = SMap.remove session_id map; result = () });
+  !hook_ref
+
+let invoke_disconnect_hook_for session_id =
+  match take_disconnect_hook session_id with
+  | None -> ()
+  | Some hook ->
+      (try hook () with
+       | Eio.Cancel.Cancelled _ as e -> raise e
+       | exn ->
+           Log.Server.error "SSE disconnect hook failed for %s: %s"
+             session_id (Printexc.to_string exn))
+
 (** Register a new SSE client.
     Returns (client_id, event_stream, evicted_session_id option).
     The caller should spawn a fiber that drains [event_stream] and
@@ -424,7 +489,14 @@ let register ?(kind = Coordinator) session_id ~last_event_id =
   (match evicted with
    | Some sid ->
        Transport_metrics.inc_sse_client_evicted ();
-       Log.Server.info "Evicting oldest client %s (at cap %d)" sid max_clients
+       Log.Server.info "Evicting oldest client %s (at cap %d)" sid max_clients;
+       (* Eviction is a form of disconnect: the broadcast-registry entry
+          is gone, so the evicted session's drain fiber will block on
+          [Eio.Stream.take] forever unless we wake it.  Callers also
+          invoke [stop_sse_session evicted_sid] explicitly today (legacy
+          path); that double-invocation is idempotent because
+          [close_sse_conn] guards on [info.closed]. *)
+       invoke_disconnect_hook_for sid
    | None ->
        ());
   sync_transport_snapshot ();
@@ -456,8 +528,20 @@ let unregister session_id =
           result = false;
         })
   in
-  if removed then
+  if removed then begin
+    (* Invoke the per-session disconnect hook BEFORE [sync_transport_snapshot].
+       The hook typically calls back into [Server_mcp_transport_http_conn.
+       stop_sse_session], which closes the HTTP body writer and re-enters
+       [unregister_if_current].  That re-entry is a no-op here because we
+       already removed the entry above, so there is no double-decrement risk
+       and no infinite-loop risk.  Snapshot recording is sequenced AFTER the
+       hook so observers see [info.closed = true] in the same tick. *)
+    invoke_disconnect_hook_for session_id;
     sync_transport_snapshot ()
+  end else
+    (* Even on no-op unregister we still clear any orphaned hook to avoid
+       slow leaks across reconnects.  [clear_disconnect_hook] is idempotent. *)
+    clear_disconnect_hook session_id
 
 (** Unregister only if the current client matches the given client_id.
     Prevents an old connection's cleanup from unregistering a newer connection
@@ -483,8 +567,11 @@ let unregister_if_current session_id client_id =
             result = false;
           })
   in
-  if removed then
+  if removed then begin
+    (* See [unregister] for the hook ordering rationale. *)
+    invoke_disconnect_hook_for session_id;
     sync_transport_snapshot ()
+  end
 
 (** Check if client exists *)
 let exists session_id =
@@ -750,11 +837,23 @@ let broadcast_impl ?(buffer = true) ?(notify_external = true)
          See TLA+ SSEBroadcastBlock spec. *)
       (let queue_len = Eio.Stream.length client.event_stream in
        if queue_len >= stream_capacity then begin
-         (* P1 silent-failure fix: previously only logged.  Counter
-            lets operators see "all clients backlogged" as a Prometheus
-            rate, distinct from successful broadcasts. *)
+         (* Tier-A perf fix: queue overflow is now a {b disconnect}
+            signal, not a silent drop.  The session is added to
+            [failed] (so [unregister] runs below); the disconnect hook
+            installed at register-time wakes the drain fiber via
+            [stop_sse_session], closing the HTTP writer.  The client's
+            EventSource will reconnect with [Last-Event-Id]; the bumped
+            [max_buffer_size] (1000 vs. previous 100) covers the gap.
+
+            Previously the [unregister] removed the broadcast entry but
+            left the drain fiber blocked on [Eio.Stream.take], holding
+            the HTTP socket open until keep-alive timeout — operators
+            saw "WS events stop arriving" with no error indication and
+            had to manually refresh.  See plan
+            [planning/claude-plans/me-workspace-yousleepwhen-masc-mcp-radiant-piglet.md]. *)
          Transport_metrics.inc_broadcast_failure ~target:target_label ();
-         Log.Server.warn "Broadcast skip: session %s stream full (%d/%d)"
+         Log.Server.warn
+           "Broadcast skip: session %s stream full (%d/%d) — disconnecting"
            session_id queue_len stream_capacity;
          failed := session_id :: !failed
        end else

--- a/lib/sse.mli
+++ b/lib/sse.mli
@@ -56,6 +56,26 @@ val register :
   int * string Eio.Stream.t * string option
 val unregister : string -> unit
 val unregister_if_current : string -> int -> unit
+
+(** [set_disconnect_hook session_id hook] arranges for [hook ()] to fire
+    exactly once when the session is removed from the broadcast registry
+    (via [unregister] or [unregister_if_current]).  The hook is the
+    transport layer's wakeup signal for its drain fiber; without it, a
+    queue-overflow [unregister] from [broadcast_impl] leaves the drain
+    fiber blocked on [Eio.Stream.take] and the HTTP body writer open
+    until socket keep-alive timeout reaps it.
+
+    Callers MUST invoke this immediately after a successful [register]
+    and SHOULD invoke [clear_disconnect_hook] before re-registering the
+    same session_id so a stale hook from a prior connection does not
+    fire against the new one. *)
+val set_disconnect_hook : string -> (unit -> unit) -> unit
+
+(** [clear_disconnect_hook session_id] removes any hook previously
+    installed for [session_id].  Idempotent — safe to call when no hook
+    exists. *)
+val clear_disconnect_hook : string -> unit
+
 val exists : string -> bool
 val touch : string -> unit
 val update_last_event_id : string -> int -> unit


### PR DESCRIPTION
## Summary

Tier A 퍼포먼스 quick wins (single Draft PR per `feedback_user_rejects_cron_pr_loop` 정착 패턴).
Plan: `planning/claude-plans/me-workspace-yousleepwhen-masc-mcp-radiant-piglet.md`.

사용자 호소: 64+ keeper 시 SSE 이벤트가 거의 안 들어오고, 대시보드 가니 너무 느려짐, 수동 새로고침 강제됨.

## Commits

| | Subject | LoC |
|--|--|--|
| T1 | `perf(sse)`: convert queue overflow to disconnect, raise replay buffer 100→1000 | +146/-9 |
| T3 | `perf(keeper_turn_slot)`: make holder_table reads lock-free via Atomic snapshot | +88/-40 |
| T5 | `perf(fs_compat)`: cache open fds for append_file_unix to cut syscall churn | +114/-4 |
| T4 | `perf(costs)`: migrate cost ledger writes to Dated_jsonl, keep legacy reads | +63/-5 |
| T6 | `perf(dashboard)`: cache parameterized operator snapshot/digest endpoints (5s SWR) | +118/-77 |

총 ~370 LoC, 8 파일.

## What each fix actually addresses

### T1 — SSE silent loss → disconnect
`lib/sse.ml` broadcast가 client per-session Eio.Stream queue 가득 시 silent drop했고 (`Transport_metrics.inc_broadcast_failure` + `warn` 로그만), `unregister`가 broadcast registry 제거만 했지 transport-layer drain fiber를 깨우지 않아 HTTP body writer가 keep-alive timeout까지 열린 채로 stuck. 사용자는 "WS 안 옴 + 수동 refresh"로 체감.

수정: 세션별 disconnect hook 도입 (`set_disconnect_hook` / `clear_disconnect_hook` 공개 API). `unregister` / `unregister_if_current` / `register`의 eviction 분기 모두 hook을 정확히 한 번 발화 (`take_disconnect_hook` atomic remove). Transport register 사이트 3곳(MCP coordinator / AG-UI observer / presence)에서 hook을 `stop_sse_session`(또는 `_preserve_guard`)로 등록 → drain wakeup. 추가로 `max_buffer_size` 100→1000 (`MASC_SSE_REPLAY_BUFFER_SIZE` env, 50..1000 클램프) — Last-Event-Id replay 완전성.

### T3 — holder_table read 경로 lock-free
`lib/keeper/keeper_turn_slot.ml`의 `snapshot_holders` / `snapshot_all_holders`는 매 acquire / release / timeout-log에서 호출되는 hot path인데 모두 `holder_mutex` 잡고 Hashtbl.fold. 64+ keeper에서 turn boundary마다 contention.

수정: `holder_table`을 `(holder_key, float) Hashtbl.t` → `float Holder_map.t Atomic.t` (Map.Make over the holder_key record). Writers는 mutex 유지 (force_released_holders Hashtbl과 직렬화 필요), 각 write 끝에 `Atomic.set`으로 immutable map publish. Readers는 `Atomic.get`으로 lock-free.

Stale-read window는 single writer mutex hold time (microseconds) — consumer (timeout attribution)는 `feedback_keeper_freeze_diagnosis_requires_timeseries_window`에 따라 이미 lagging by design.

### T5 — fs_compat append_file fd cache
`open_out_gen` + `output_string` + `close_out` per call → 64+ keeper × telemetry/audit/coverage_gap appends당 3 syscall.

수정: `Append_fd_cache` LRU(16) — open append channel 재사용 + 매 호출 `flush`로 kernel buffer 도달 보장 (crash-after-append 안전성 유지). Stdlib.Mutex 사용 (Eio context 외부에서도 호출됨), `at_exit`로 모든 fd 정리. Single-domain 가정은 명시.

### T4 — costs.jsonl Dated_jsonl
`~/me/.masc/costs.jsonl` 14,519 lines (7.5MB) unbounded growth. `lib/keeper/keeper_hooks_oas.ml` `emit_cost_event`를 `Dated_jsonl.append`로 마이그레이션 → `masc_root/costs/YYYY-MM/DD.jsonl`. `Model_inference_metrics.read_cost_entries`는 legacy 단일 파일 + dated 디렉토리 모두 읽도록 분리(`read_cost_entries_legacy` + `read_cost_entries_dated`) — historic 14k row 보존.

### T6 — Dashboard parameterized 캐시
`operator_snapshot_http_json` / `operator_digest_http_json`은 default summary 경로(`cached_surface_json`)는 빠르지만 actor / view / include_messages / target_id 등 어떤 파라미터라도 들어오면 cache 우회 → 매 polling마다 30s timeout `run_dashboard_compute`. 사용자가 keeper별 필터링하는 시나리오에서 read pool 폭주.

수정: 파라미터 튜플로 cache key 생성 후 `Dashboard_cache.get_or_compute_with_timeout ~ttl:5.0` 적용. 5초는 dashboard polling 주기(3s)와 일치 — 첫 poll 후엔 100% cache hit. Mutation invalidation은 기존 `Coord_hooks.on_task_mutation_fn` 경로 그대로 유지.

대부분 다른 dashboard 엔드포인트는 이미 정교한 cache 아키텍처(`cached_surface` + `Proactive_refresh` + `Dashboard_cache.get_or_compute_with_timeout`)를 갖추고 있어 추가 wrapping은 churn. 가장 명백히 비어있던 두 경로만 수정 — `software-development.md` "Surgical Changes".

## What was scoped and skipped

### T2 (Streamable HTTP /mcp wiring) — SKIPPED
실행 중 발견: `/mcp` POST/GET/DELETE는 이미 `Server_mcp_transport_http.handle_post_mcp` / `handle_get_mcp` / `handle_delete_mcp`가 처리하며, `Mcp_transport_protocol.Http_negotiation.classify_mcp_accept`가 MCP 2025-03 spec Accept 헤더 협상(`application/json, text/event-stream` 요구)을 구현. test 커버리지는 `test/test_http_negotiation.ml`.

`lib/streamable_http.ml`(203 LoC)은 `lib/http_server_eio.ml` `default_routes`에만 wiring된 parallel scaffolding. 프로덕션 바이너리(`bin/main_eio.ml`)는 `server_routes_http_routes_*`로 라우터를 따로 빌드함.

`Streamable_http.handle_post` / `handle_get` 스텁을 프로덕션 `/mcp` 라우트에 wiring하면 spec 준수도가 **downgrade** (production handler는 auth, version validation, SSE replay, reconnect-rate guard 다 처리; stub은 안 함). CLAUDE.md "workaround rejection bar §N-of-M-patch" + "Surgical Changes"에 따라 churn 거부, follow-up issue로 분리.

### Out-of-scope (deferred to RFC)
- **Multi-domain split** (`bin/main_eio.ml` 단일 `Eio_main.run` → N domain) — RFC-Domain-Split 별도 작성. 현재 단일 domain의 multicore 미활용이 진짜 root cause지만 keeper_registry 샤딩 + cross-domain communication 설계 필요해 Tier A 범위 초과.
- **3-tier Semaphore admission redesign** (`keeper_turn_slot` `turn_semaphore=32` + `autonomous=3` + `reactive=5` + 60s timeout). 메모리 `feedback_semaphore_tier_is_architectural_anti_pattern.md`에 이미 root identified — token bucket / WFQ 별도 RFC.
- **Board persist mutex SPOF** (`board_core.ml:38` persist_mutex가 disk I/O 동안 다른 keeper 블록). async background flush + WAL — 별도 issue.
- **`~/me/.masc/playground` 18GB / `keeper/.atomic_*.tmp` 14 orphans** — retention/rotation 별도 issue.

## Verification

### Build
- `dune build --root . @check` ✅ green
- `dune build --root .` (full build) ✅ green

### Targeted tests
```
dune test test/test_sse.exe test/test_sse_coverage.exe \
  test/test_sse_external_sub.exe \
  test/test_keeper_turn_slot_holders.exe \
  test/test_keeper_turn_slot_force_release.exe \
  test/test_keeper_turn_slot_release_cancel_safe.exe \
  test/test_dated_jsonl_mutex_registry_10372.exe \
  test/test_fs_compat.exe
```
✅ 모두 GREEN.

### Load (수동 follow-up 필요 — 테스트 환경 없음)
- 64 keeper concurrent 시 `transport_broadcast_failure_total` 0 유지 검증
- `dashboard_http_request_duration_ms_bucket` p95 비교
- `curl http://127.0.0.1:8935/health`로 runtime build commit이 PR HEAD와 일치 확인 (`feedback_server_runtime_commit_from_executable_dir_git`)

### MCP spec
기존 `/mcp` 핸들러가 spec 준수하므로 추가 변경 없음 (T2 SKIPPED 참고).

## Workaround Rejection Bar self-check (CLAUDE.md §)

| 시그니처 | 해당? |
|---|---|
| 텔레메트리-as-fix | ❌ T1은 drop을 *제거* (silent loss → disconnect), 단순 visible 처리 아님 |
| String/substring 분류기 보강 | ❌ |
| N-of-M 패치 | ⚠️→✅ T2를 NO-OP로 빼면서 N-of-M 회피 |
| catch-all `_ ->` 추가 | ❌ |
| cap/cooldown/dedup/repair | ❌ T1은 cap 제거 방향 |
| test backdoor | ❌ |
| 같은 typo N번 fix | ❌ |

## RFC-WAIVED

이 PR은 `lib/server/`, `lib/keeper/keeper_turn_slot.ml`, `lib/sse.ml` 등을 건드리지만 credential/identity/auth 또는 sandbox subsystem이 아니라 RFC 발견 게이트(`<agent_delegation>` 항목 1-2) 대상이 아님. `lib/streamable_http.ml`은 이번 PR에서 수정 0 (T2 SKIP).

`RFC-WAIVED: Tier A perf quick wins on transport / keeper turn slot / fs append / dashboard cache. No protocol design or credential/identity changes.`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
