### PR TITLE
chore(release): bump to 0.19.17 (keeper telemetry yield fix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
 
+## [0.19.17] - 2026-05-11
+
+### Fixed
+- `lib/keeper/keeper_telemetry_consumer.ml`: drain loop now yields between iterations (`Eio.Time.sleep clock 0.1`). The fiber introduced by #14491 saturated a single Eio domain at ~100% CPU because `Agent_sdk_metrics_bridge.drain` is non-blocking and the loop recursed without sleeping. Co-located fibers (HTTP handlers, lazy startup tasks) starved — server boot stalled at `lazy_task: starting restore_sessions`, `/health` timed out, and HTTP handlers never responded despite ports being LISTEN. Mirrors the sibling drain loops in `keeper_compact_audit`, `cascade_event_bridge`, and `server_bootstrap_loops` keeper-lifecycle, all of which already sleep between drains. PR #14499.
+
 ## [0.19.16] - 2026-05-07
 
 ### Added

--- a/dune-project
+++ b/dune-project
@@ -3,7 +3,7 @@
 (using menhir 3.0)
 
 (name masc_mcp)
-(version 0.19.16)
+(version 0.19.17)
 
 (generate_opam_files true)
 (implicit_transitive_deps false)


### PR DESCRIPTION
## 목적

PR #14499 (`fix(keeper): yield in telemetry consumer drain loop`)에 대한 release hygiene — `dune-project` version bump + CHANGELOG entry.

## 변경

- `dune-project`: `0.19.16` → `0.19.17`
- `CHANGELOG.md`: 새 `[0.19.17] - 2026-05-11` 섹션 추가, fix 설명 + 재현 시나리오 + 인접 sibling 패턴 인용

## Scope 결정

| 옵션 | 결정 |
|------|------|
| Patch (0.19.16 → 0.19.17) | ✅ 선택 — bug fix only |
| Minor | ❌ no API addition |
| Major | ❌ no breaking change |

## 검증

- `dune build --root .` PASS (worktree 안)
- diff 2 파일 +6/-1
- generate_opam_files 트리거 없음 (opam 파일에 version 필드 미포함)

## 미반영 (별도 작업)

- **Tag drift**: 마지막 git tag `v0.19.10-505`, dune-project `0.19.17` (이번 PR 머지 후), CHANGELOG는 0.19.11~0.19.17 누적. 984 commits / 7 minor 밀림. tag는 운영 결정 사이클이라 이 PR 범위 밖. 머지 후 별도 단계에서 `git tag v0.19.17-511 && git push origin v0.19.17-511` 권장.

🤖 Generated with [Claude Code](https://claude.com/claude-code)