### PR TITLE
simplify(perf-tier-a): fold disconnect-hook into Sse.register, dedupe date format

### DIFF
--- a/lib/model_inference_metrics.ml
+++ b/lib/model_inference_metrics.ml
@@ -736,13 +736,6 @@ let read_cost_entries_legacy ~base_path ~since_unix : raw_entry list =
         Printexc.raise_with_backtrace exn bt
     | _ -> []
 
-(** Format a Unix timestamp (UTC) as ["YYYY-MM-DD"] for [Dated_jsonl.read_range]. *)
-let date_string_of_unix ts =
-  let open Unix in
-  let tm = gmtime ts in
-  Printf.sprintf "%04d-%02d-%02d"
-    (tm.tm_year + 1900) (tm.tm_mon + 1) tm.tm_mday
-
 let read_cost_entries_dated ~base_path ~since_unix : raw_entry list =
   let dir =
     Filename.concat
@@ -752,8 +745,8 @@ let read_cost_entries_dated ~base_path ~since_unix : raw_entry list =
   else
     let store = Dated_jsonl.create ~base_dir:dir () in
     let now = Unix.gettimeofday () in
-    let since = date_string_of_unix since_unix in
-    let until = date_string_of_unix now in
+    let since = Log.format_utc_date_of since_unix in
+    let until = Log.format_utc_date_of now in
     try
       Dated_jsonl.read_range store ~since ~until
       |> List.filter_map (fun json ->

--- a/lib/server/server_mcp_transport_http.ml
+++ b/lib/server/server_mcp_transport_http.ml
@@ -598,6 +598,7 @@ let handle_get_mcp ~deps ?legacy_messages_endpoint ?(profile = Full)
           let client_id, event_stream, evicted =
             Sse.register ~kind:sse_kind session_id
               ~last_event_id:(Option.value ~default:0 last_event_id)
+              ~on_disconnect:(fun () -> stop_sse_session session_id)
           in
           (match evicted with
           | Some evicted_sid -> stop_sse_session evicted_sid
@@ -614,14 +615,6 @@ let handle_get_mcp ~deps ?legacy_messages_endpoint ?(profile = Full)
           in
           info_ref := Some info;
           register_sse_conn ~session_id ~info;
-          (* Wake the drain fiber when [Sse.unregister] fires (queue
-             overflow disconnect or eviction).  Without this, the drain
-             fiber stays blocked on [Eio.Stream.take] holding [info.stop]
-             at false, the HTTP body writer stays open, and the browser
-             EventSource sees no error indication — this was the silent
-             half of the broadcast-skip bug. *)
-          Sse.set_disconnect_hook session_id (fun () ->
-            stop_sse_session session_id);
           if not (send_raw info (sse_prime_event ())) then
             Log.Server.debug "SSE prime send failed for session %s" info.session_id;
           (match legacy_messages_endpoint with

--- a/lib/server/server_mcp_transport_http_agui.ml
+++ b/lib/server/server_mcp_transport_http_agui.ml
@@ -74,6 +74,7 @@ let handle_ag_ui_events ~deps request reqd =
       let client_id, event_stream, evicted =
         Sse.register ~kind:Sse.Observer session_id
           ~last_event_id:(Option.value ~default:0 last_event_id)
+          ~on_disconnect:(fun () -> stop_sse_session session_id)
       in
       (match evicted with
       | Some evicted_sid -> stop_sse_session evicted_sid
@@ -90,10 +91,6 @@ let handle_ag_ui_events ~deps request reqd =
       in
       info_ref := Some info;
       register_sse_conn ~session_id ~info;
-      (* See [server_mcp_transport_http.ml] for hook rationale — drain
-         wakeup on [Sse.unregister]. *)
-      Sse.set_disconnect_hook session_id (fun () ->
-        stop_sse_session session_id);
       let prime =
         Ag_ui.(
           make_event ~thread_id:default_thread_id ~run_id:(Some session_id) Run_started
@@ -188,6 +185,8 @@ let handle_presence_events ~deps request reqd =
           let mutex = Eio.Mutex.create () in
           let client_id, event_stream, evicted =
             Sse.register ~kind:Sse.Presence session_id ~last_event_id:0
+              ~on_disconnect:(fun () ->
+                stop_sse_session_preserve_guard session_id)
           in
           (match evicted with
           | Some evicted_sid -> stop_sse_session evicted_sid
@@ -203,12 +202,6 @@ let handle_presence_events ~deps request reqd =
             }
           in
           register_sse_conn ~session_id ~info;
-          (* Presence streams use the preserve-guard variant of stop, so
-             the disconnect hook delegates to [stop_sse_session_preserve_guard]
-             instead of [stop_sse_session] to keep the connect-rate guard
-             across reconnects (see this module's docstring for why). *)
-          Sse.set_disconnect_hook session_id (fun () ->
-            stop_sse_session_preserve_guard session_id);
           if not (send_raw info ": presence-stream\nretry: 3000\n\n") then
             Log.Server.debug "presence prime send failed for session %s"
               info.session_id;

--- a/lib/sse.ml
+++ b/lib/sse.ml
@@ -429,15 +429,15 @@ let invoke_disconnect_hook_for session_id =
 
 (** Register a new SSE client.
     Returns (client_id, event_stream, evicted_session_id option).
-    The caller should spawn a fiber that drains [event_stream] and
-    writes events to the transport.  Evicts the oldest client when at
-    capacity.  The client stream/id are allocated once; map installation
-    is linearized via CAS over the immutable registry state.
-    [kind] defaults to [Coordinator] for backward compatibility. *)
-let register ?(kind = Coordinator) session_id ~last_event_id =
+    [?on_disconnect], if supplied, is installed BEFORE the client is
+    published to [clients] — closes the race window where a concurrent
+    [broadcast] could observe the new entry, hit queue overflow, fire
+    [unregister], and find no hook to wake the drain fiber. *)
+let register ?(kind = Coordinator) ?on_disconnect session_id ~last_event_id =
   let client_id = Atomic.fetch_and_add client_id_counter 1 + 1 in
   let last_event_id = Atomic.make last_event_id in
   let event_stream = Eio.Stream.create stream_capacity in
+  Option.iter (fun hook -> set_disconnect_hook session_id hook) on_disconnect;
   let base_client = {
     id = client_id;
     kind;

--- a/lib/sse.mli
+++ b/lib/sse.mli
@@ -52,8 +52,13 @@ val buffer_ttl_seconds : float
 (** {1 Session Management} *)
 
 val register :
-  ?kind:session_kind -> string -> last_event_id:int ->
+  ?kind:session_kind -> ?on_disconnect:(unit -> unit) ->
+  string -> last_event_id:int ->
   int * string Eio.Stream.t * string option
+(** [?on_disconnect] is installed atomically with registration via
+    {!set_disconnect_hook} before the client becomes broadcast-visible,
+    so a concurrent queue-overflow [unregister] always finds the hook. *)
+
 val unregister : string -> unit
 val unregister_if_current : string -> int -> unit
 


### PR DESCRIPTION
## Summary

`/simplify` 리뷰가 Tier A merge(#14502) 직후 발견한 3가지 미세 개선사항.

3개 에이전트 병렬 리뷰 (재사용/품질/효율) 결과 중 **High severity 2건 + Low cost dedup 1건**만 채택. 나머지(과도한 주석, stringly-typed cache_key, close_out_noerr 3 copy 등)는 churn cost > value 또는 false positive로 판단해 skip.

## Changes

| | What | Why |
|--|--|--|
| 1 | `Sse.register`에 `?on_disconnect` 추가, 3 call site 통합 | **Race fix**: register와 set_disconnect_hook 사이 broadcast가 끼면 hook 없이 unregister 발생 가능 — 이 window가 정확히 hook이 닫으려던 silent-loss 시나리오 |
| 2 | `date_string_of_unix` 제거, `Log.format_utc_date_of` 사용 | 100% 동일 구현 중복 (이미 `lib/masc_log/log.mli:48`에 노출돼 있음) |
| 3 | 후속 set_disconnect_hook 호출과 인접 주석 제거 | `?on_disconnect` 인자가 동일 정보를 call site에서 전달 |

Net: **-16 LoC** (5 files: +18/-34).

## Race fix detail (#1)

머지된 PR의 패턴:
```ocaml
let client_id, event_stream, evicted = Sse.register ... in   (* (a) *)
... evicted handling, info construction, register_sse_conn ...
Sse.set_disconnect_hook session_id (fun () -> stop_sse_session session_id);  (* (b) *)
```

`(a)`와 `(b)` 사이에 broadcast fiber가 가로채면:
- broadcast가 클라이언트 발견 (registered)
- queue overflow (이론적으로 capacity≤256이라 즉시 가능)
- `unregister` → hook registry 조회 → **hook 없음** → drain fiber 안 깨움
- = T1이 닫으려던 silent-loss 시나리오 그대로 재발

`?on_disconnect`로 register 진입 직후, client publish 전에 hook 설치 → race 차단.

```ocaml
let register ?(kind = Coordinator) ?on_disconnect session_id ~last_event_id =
  let client_id = ... in
  let event_stream = Eio.Stream.create stream_capacity in
  Option.iter (fun hook -> set_disconnect_hook session_id hook) on_disconnect;
  ... CAS publish to clients ...
```

## Dedup detail (#2)

```ocaml
(* model_inference_metrics.ml:740 (BEFORE) *)
let date_string_of_unix ts =
  let open Unix in
  let tm = gmtime ts in
  Printf.sprintf "%04d-%02d-%02d"
    (tm.tm_year + 1900) (tm.tm_mon + 1) tm.tm_mday

(* lib/masc_log/log.ml:172 (EXISTING) *)
let format_utc_date_of (t : float) =
  let tm = Unix.gmtime t in
  Printf.sprintf "%04d-%02d-%02d"
    (tm.Unix.tm_year + 1900) (tm.Unix.tm_mon + 1) tm.Unix.tm_mday
```

토큰 단위로 동일. `Log.format_utc_date_of`가 `lib/masc_log/log.mli:48`에 이미 export됨.

## What was reviewed and skipped

| Finding | Reason for skip |
|--|--|
| 과도한 주석 다듬기 (Quality #7) | Subjective — Tier A 주석은 invariant + race semantics 문서화로 의도. CLAUDE.md "WHY > WHAT" 위반 아님. Churn cost > value. |
| `Dated_jsonl.create` 매 emit_cost_event 호출 (Eff Major) | `create` 본체는 mutex_registry Hashtbl lookup만 (cheap). measurable이지만 marginal. 캐시 추가가 race 위험 도입. |
| stringly-typed cache_key (Quality #4) | 다른 dashboard endpoint들이 모두 동일 Printf 패턴. 일관성 우선. |
| `close_out_noerr` 3-copy (Quality #6) | premature abstraction (각 호출처 컨텍스트 다름). |
| fd_cache size 16 (Eff #8) | 현재 active append 파일 ~5개로 충분. dynamic resizing 추가가 overkill. |
| hook 직렬화 (Eff #5) | hook callback은 atomic remove + 1 syscall. 64 disconnect 시도 < 1ms. |
| Holder_map .mli expose (Quality #3) | Internal abstraction 의도적 캡슐화. 노출은 leak. |

## Verification

- `dune build --root . @check` ✅
- `dune test --root . test/test_sse*.exe` (lifecycle / broadcast / external subscribers) ✅ 9/9 green

## Workaround Rejection Bar self-check

| 시그니처 | 해당? |
|--|--|
| 텔레메트리-as-fix | ❌ |
| string/substring 분류기 보강 | ❌ |
| N-of-M 패치 | ⚠️ 이 PR 자체가 #14502의 follow-up이라 N-of-M 의심 가능. 단 race fix는 머지 후 review에서 발견된 진짜 정합성 결함이고, 같은 PR에 안 들어간 건 발견 시점 차이 (review가 머지 후) — 일반화된 추상화나 별도 RFC 대상 아님. |
| catch-all `_ ->` 추가 | ❌ |
| cap/cooldown/dedup/repair | ❌ |
| test backdoor | ❌ |
| 같은 typo N번 fix | ❌ |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
