### PR TITLE
test(keeper): cooperative-scheduling regression harness for telemetry consumer (RFC-0063 §7-D)

### DIFF
--- a/test/dune
+++ b/test/dune
@@ -670,6 +670,7 @@
         test_transport_metrics
         test_adaptive_cache_ttl
         test_keeper_compact_audit
+        test_keeper_telemetry_consumer
         test_oas_bus_instrument
         test_trajectory
         test_eval_gate
@@ -878,6 +879,7 @@
         test_transport_metrics
         test_adaptive_cache_ttl
         test_keeper_compact_audit
+        test_keeper_telemetry_consumer
         test_oas_bus_instrument
         test_trajectory
         test_eval_gate

--- a/test/test_keeper_telemetry_consumer.ml
+++ b/test/test_keeper_telemetry_consumer.ml
@@ -1,0 +1,64 @@
+(** Cooperative-scheduling regression test for [Keeper_telemetry_consumer].
+
+    The drain fiber forked by [spawn_subscriber] consumes a non-blocking
+    primitive ([Agent_sdk_metrics_bridge.drain]). Without an explicit
+    yield it pins its Eio domain at ~100% CPU and starves every
+    co-located fiber on the same domain — including timer fibers, so a
+    [Eio.Time.sleep] in a sibling fiber never fires.
+
+    This test runs [spawn_subscriber] under a switch and then asks the
+    main fiber to perform a short sleep loop. If the drain fiber yields
+    (the contract from RFC-0063 §6, encoded by PR #14499 as
+    [Eio.Time.sleep clock drain_interval_s]), the main fiber's sleeps
+    fire and the counter reaches its target. If a future change drops
+    the yield, the main fiber's first sleep never wakes up and the test
+    hangs — the CI wall-clock cutoff catches it.
+
+    Regression context: PR #14491 introduced [spawn_subscriber] without
+    a yield; PR #14499 restored cooperative behaviour; RFC-0063 §7-D
+    classifies this style of harness as "partial coverage, low cost". *)
+
+module KTC = Masc_mcp.Keeper_telemetry_consumer
+
+let target_iters = 5
+let inter_sleep_s = 0.02
+let total_expected_wall_clock_s = float_of_int target_iters *. inter_sleep_s
+
+(* Sentinel used to break out of [Switch.run] once the assertion data is
+   collected. Using [Switch.fail] would propagate as the switch's
+   failure exception; raising [Exit] is the simpler shape because
+   [Switch.run] re-raises and the outer [try] cleans up. *)
+exception Test_done
+
+let test_drain_loop_yields_to_co_located_fiber () =
+  let counter = ref 0 in
+  Eio_main.run @@ fun env ->
+    let clock = Eio.Stdenv.clock env in
+    let bus = Agent_sdk.Event_bus.create () in
+    (try
+      Eio.Switch.run (fun sw ->
+        KTC.spawn_subscriber ~sw ~clock ~bus;
+        for _ = 1 to target_iters do
+          Eio.Time.sleep clock inter_sleep_s;
+          incr counter
+        done;
+        raise Test_done)
+    with Test_done -> ());
+  Alcotest.(check int)
+    (Printf.sprintf
+       "co-located fiber completed %d sleeps (~%.2fs wall-clock); \
+        drain fiber must have yielded"
+       target_iters total_expected_wall_clock_s)
+    target_iters !counter
+
+let () =
+  Alcotest.run "keeper_telemetry_consumer"
+    [
+      ( "cooperative_scheduling",
+        [
+          Alcotest.test_case
+            "drain loop yields to co-located fiber"
+            `Quick
+            test_drain_loop_yields_to_co_located_fiber;
+        ] );
+    ]


### PR DESCRIPTION
## 목적

RFC-0063 §6의 drain-loop yield contract를 Alcotest 케이스로 인코딩 — RFC §8 \"enforcement: not started\" 항목의 첫 단계 (RFC §7-D MVP).

## 무엇을 검증하나

`Keeper_telemetry_consumer.spawn_subscriber`를 switch 아래 fork하고, main fiber가 5×20ms sleep을 시도. drain fiber가 yield하면 main fiber의 timer가 fire되어 counter==5로 도달. yield가 사라지면 drain fiber가 Eio domain을 점유해 main fiber의 첫 20ms sleep조차 wake-up 못 함 → test hang.

## 실패 모드

| 시나리오 | 결과 | 검출 |
|----------|------|------|
| Fix 코드 (현재 main) | 0.105s 내 PASS | alcotest 정상 |
| Yield 누락 regression | hang | **CI wall-clock cutoff** |

이 실패 모드는 RFC §7-D가 명시적으로 \"low cost, partial coverage\"로 분류한 것과 정확히 일치합니다 — assertion failure가 아니라 hang으로 catch. 더 강한 검출은 §7-B(lint rule) 또는 §7-C(TLA+ Bug Model)이 별도 RFC follow-up.

## 검증

- `dune build --root . test/test_keeper_telemetry_consumer.exe`: PASS
- `_build/default/test/test_keeper_telemetry_consumer.exe`: 1 test, **PASS in 0.105s** (= 5 × 0.02s baseline)
- 0.105s precise match가 contract 위반 시 hang 메커니즘의 정량 증거 — drain fiber가 yield 안 하면 0.02s timer도 fire 못 함

## 등록 위치

`test/dune` 두 곳 `(tests (names ...))` 블록의 `test_keeper_compact_audit` 인접 위치에 등록 (sibling drain-loop test와 인접 배치).

## Workaround Rejection Bar self-check

7항목 모두 비대상. 본 PR은:
- counter 추가 아님 (alcotest assertion)
- string classifier 아님
- N-of-M 아님 (단일 site 대상의 contract enforcement)
- catch-all 추가 아님
- cap/cooldown/dedup/repair 아님
- test backdoor 노출 아님 (production API 그대로 사용)
- typo N-fix 아님

→ 구조적 enforcement (테스트가 contract의 implementation).

## 미반영 (별도 작업 후보)

- **RFC §7-A**: PR review 시 sibling pattern grep checklist (process change). `instructions/workflow-pr.md` 또는 `software-development.md` 한 줄 추가. 사용자 결정 후 진행 권장.
- **RFC §7-B**: ocaml-lint / 커스텀 dune rule. medium cost, 별도 RFC.
- **RFC §7-C**: TLA+ Bug Model (cooperative scheduler + bounded queue + drain fiber 모델). high cost, 별도 RFC.

## 관련

- RFC-0063: docs/rfc/RFC-0063-telemetry-feedback-loop.md (PR #14506, Draft)
- 회귀 fix: PR #14499 (`93489c1d2e`)
- Release bump: PR #14503 (`f3737b9815`)
- Memory: `feedback_eio_drain_loop_must_yield`

🤖 Generated with [Claude Code](https://claude.com/claude-code)