### PR TITLE
fix(sandbox): verify container cleanup and warn on docker rm failure

### DIFF
--- a/lib/keeper/keeper_turn_sandbox_runtime.ml
+++ b/lib/keeper/keeper_turn_sandbox_runtime.ml
@@ -342,10 +342,21 @@ let cleanup (t : t) =
         Keeper_sandbox_runtime.docker_command_argv ()
         @ [ "rm"; "-f"; container_name ]
       in
-      let _st, _out =
+      let st, out =
         run_argv_with_status_retry_eintr
           ~timeout_sec:(Env_config_sandbox.Shell_timeout.timeout_sec
                           ~bucket:Cleanup_rm ())
           argv
       in
+      (match st with
+      | Unix.WEXITED 0 -> ()
+      | _ ->
+          Log.Keeper.warn
+            "%s: docker rm -f %s failed (status=%s, out=%s)" t.meta.name
+            container_name
+            (match st with Unix.WEXITED n -> Printf.sprintf "exited(%d)" n | Unix.WSIGNALED n -> Printf.sprintf "signaled(%d)" n | Unix.WSTOPPED n -> Printf.sprintf "stopped(%d)" n)
+            out;
+          Prometheus.inc_counter
+            Keeper_metrics.metric_keeper_turn_cleanup_failures
+            ~labels:[("keeper", t.meta.name); ("site", "docker_rm")]);
       ()


### PR DESCRIPTION
## Problem\n\n ignored the exit status of `docker rm -f`, making container cleanup best-effort with no observability on failure.\n\n## Fix\n\n- Replace ignored `_st, _out` with explicit pattern match on `Unix.WEXITED 0`\n- Log `Log.Keeper.warn` with keeper name, container name, status, and output on non-zero exit\n- Increment `masc_keeper_turn_cleanup_failures_total` counter with `site=docker_rm` label\n\n## Verification\n\n```ocaml\n(* Before: silent failure *)\nlet _st, _out = run_argv_with_status_retry_eintr ~timeout_sec argv in\n()\n\n(* After: explicit warning + metric *)\nmatch st with\n| Unix.WEXITED 0 -> ()\n| _ ->\n  Log.Keeper.warn "..." ...;\n  Prometheus.inc_counter ...\n```