### PR TITLE
ci(lint): static check that drain loops yield (RFC-0063 §7-B)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -391,6 +391,7 @@ jobs:
           bash scripts/ci/check-actor-consumer-wired.sh
           bash scripts/ci/check-log-severity-anti-patterns.sh
           bash scripts/ci/check-stream-create-bounded.sh
+          bash scripts/ci/check-drain-loop-yields.sh
 
   health:
     name: Health

--- a/scripts/ci/check-drain-loop-yields.sh
+++ b/scripts/ci/check-drain-loop-yields.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# CI gate: every Eio fiber that drains a non-blocking primitive must
+# yield between iterations.
+#
+# Background
+#   PR #14491 introduced Keeper_telemetry_consumer.spawn_subscriber
+#   with a drain loop that called the non-blocking
+#   [Agent_sdk_metrics_bridge.drain] and recursed without
+#   [Eio.Time.sleep] / [Eio.Fiber.yield]. On a quiet bus the fiber
+#   pinned its Eio domain at ~100% CPU, starving every co-located
+#   fiber on the same domain — including HTTP handlers and lazy
+#   startup tasks. Server boot stalled at
+#   "lazy_task: starting restore_sessions" while ports remained
+#   LISTEN; /health timed out. PR #14499 restored the yield, RFC-0063
+#   §6 codified the contract, PR #14508 added a test-harness probe
+#   (RFC §7-D), this lint is RFC §7-B.
+#
+# Contract (RFC-0063 §6.1)
+#   Every .ml file under lib/ that calls a non-blocking drain
+#   primitive must also call a cooperative yield in the same file —
+#   either an explicit yield or a blocking IO primitive that yields
+#   by construction.
+#
+# Heuristic (file-level)
+#   1. Find every .ml in lib/ that mentions a non-blocking drain.
+#   2. For each, check it ALSO mentions a yield primitive.
+#   3. File-level granularity is sufficient because all eleven known
+#      drain-callers on origin/main keep the drain and the yield in
+#      the same file (verified 2026-05-11). A future change that
+#      splits them across files would itself be a structural smell.
+#
+# Known false negatives (acceptable)
+#   - A file with two functions where one drains and the other
+#     (unrelated) sleeps: the lint passes but the drain loop is
+#     still starved. Mitigations:
+#       * test/test_keeper_telemetry_consumer.ml (RFC-0063 §7-D)
+#       * PR review checklist (RFC-0063 §7-A)
+#       * AST-based lint (RFC-0063 §7 candidate follow-up)
+#
+# Known false positives (none currently)
+#   - All eleven current drain-caller files match. New sites that
+#     legitimately one-shot drain without looping (e.g. shutdown
+#     drain) will pass as long as they touch any yield primitive in
+#     the same file — which is almost always true.
+#
+# Output
+#   Exit 0 — every drain-caller file has at least one yield.
+#   Exit 1 — at least one drains without yielding; emit the file path.
+
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+# Patterns that indicate a non-blocking drain. Recurses immediately on
+# empty queue, so the loop body must yield before the next iteration.
+DRAIN_RE='Agent_sdk_metrics_bridge\.drain|Agent_sdk\.Event_bus\.drain|Eio\.Stream\.take_nonblocking'
+
+# Patterns that count as a cooperative yield. Narrow on purpose:
+#   - Eio.Time.sleep        explicit timed wait
+#   - Eio.Fiber.yield       explicit scheduling point
+#   - Eio.Time.with_timeout wraps an inner blocking op with a deadline
+#   - Eio.Stream.take       blocking take on an Eio stream (yields
+#                            cooperatively when the stream is empty)
+# The trailing [^_] on take excludes take_nonblocking, which is the
+# very primitive we are guarding against.
+YIELD_RE='Eio\.Time\.sleep|Eio\.Fiber\.yield|Eio\.Time\.with_timeout|Eio\.Stream\.take[^_]'
+
+failed=0
+checked=0
+ok=0
+
+drain_files=$(rg -l "${DRAIN_RE}" lib/ 2>/dev/null || true)
+
+if [ -z "$drain_files" ]; then
+  echo "check-drain-loop-yields: no non-blocking drains found in lib/"
+  exit 0
+fi
+
+while IFS= read -r file; do
+  [ -z "$file" ] && continue
+  checked=$((checked + 1))
+
+  if rg -q "${YIELD_RE}" "$file" 2>/dev/null; then
+    ok=$((ok + 1))
+  else
+    echo "  FAIL  ${file}"
+    echo "        drains a non-blocking primitive but no cooperative"
+    echo "        yield call (Eio.Time.sleep / Eio.Fiber.yield /"
+    echo "        Eio.Time.with_timeout / blocking Eio.Stream.take)"
+    echo "        in the same file."
+    echo "        Contract: RFC-0063 §6.1 — drain loops must yield"
+    echo "        before recursing, otherwise they pin the Eio domain"
+    echo "        and starve co-located fibers."
+    failed=1
+  fi
+done <<< "$drain_files"
+
+if [ "$failed" -ne 0 ]; then
+  echo ""
+  echo "check-drain-loop-yields: at least one drain caller lacks a yield."
+  echo "Reference: PR #14491 (regression source) → PR #14499 (fix)"
+  echo "           docs/rfc/RFC-0063-telemetry-feedback-loop.md §6"
+  exit 1
+fi
+
+echo "check-drain-loop-yields: ok (${ok}/${checked} drain-caller file(s) verified)"


### PR DESCRIPTION
## 목적

RFC-0063 §7-B (\"ocaml-lint or custom dune rule, medium/high coverage\")의 첫 구현. PR #14491이 boot hang을 도입한 클래스의 회귀를 CI 단계에서 자동 차단.

## 무엇을 검증하나

`lib/` 안의 모든 `.ml` 파일 중 **non-blocking drain primitive**를 호출하는 파일은 같은 파일에 **cooperative yield**도 호출해야 함.

| Non-blocking drain (대상) | Cooperative yield (요건) |
|---------------------------|--------------------------|
| `Agent_sdk_metrics_bridge.drain` | `Eio.Time.sleep` |
| `Agent_sdk.Event_bus.drain` | `Eio.Fiber.yield` |
| `Eio.Stream.take_nonblocking` | `Eio.Time.with_timeout` |
| | 블로킹 `Eio.Stream.take` (empty 시 yield) |

## 휴리스틱 선택 근거

**파일 단위 grep**, AST 분석 없음.

- baseline 11/11 drain-caller 파일 모두 같은 파일에 yield 보유 → false positive 0
- false negative 가능 (같은 파일 다른 함수에 sleep) — RFC §7-D test harness (PR #14508)와 §7-A PR review가 보완 layer
- AST 정교화는 RFC §7 follow-up RFC 후보로 명시

## 검증

| 시나리오 | 결과 |
|----------|------|
| Baseline (origin/main) | 11/11 PASS, exit 0 |
| Fake violation 주입 (lib/tmp_lint_violation_for_test.ml) | FAIL with file path + 컨트랙트 인용, exit 1 |
| Cleanup 후 재실행 | 11/11 PASS, exit 0 |

## CI 위치

`.github/workflows/ci.yml` lint job line 393 다음에 한 줄 추가. Sibling `check-actor-consumer-wired.sh`, `check-stream-create-bounded.sh`와 인접 — 둘 다 같은 카테고리(런타임 안전 컨트랙트 정적 검증).

## Workaround Rejection Bar self-check

7항목 모두 비대상. 본 PR은:
- counter 추가 아님 (lint exit code)
- string classifier 보강 아님 — 이건 *컨트랙트 enforcement*, 분류기 아님 (특정 prefix/literal 화이트리스트가 아니라 \"drain은 yield와 같은 파일\"이라는 구조 룰)
- N-of-M 아님 (모든 drain-caller에 동시 적용)
- catch-all 추가 아님
- cap/cooldown/dedup/repair 아님
- test backdoor 아님
- typo N-fix 아님

→ 구조적 enforcement (정적 lint).

## 한계 (known false negatives, RFC §7-B \"high coverage\"에 대한 진실)

- 같은 파일 안의 두 함수 — 한 함수가 drain하고 다른 함수가 sleep하면 lint는 PASS, 실제는 starvation. 현재 11 file 모두 해당 패턴 없음. AST 기반 검사는 별도 RFC 후보.
- 새 파일이 한 함수에서 drain 호출 + cleanup 함수에서 sleep만 호출하는 경우. 정적 grep으로는 구분 불가. PR review가 catch.

## 관련

- RFC-0063: docs/rfc/RFC-0063-telemetry-feedback-loop.md (PR #14506, Draft)
- 회귀 fix: PR #14499 (`93489c1d2e`)
- Release bump: PR #14503 (`f3737b9815`)
- Test harness (§7-D): PR #14508 (merged)
- 메모리: `feedback_eio_drain_loop_must_yield`

🤖 Generated with [Claude Code](https://claude.com/claude-code)