### PR TITLE
fix(keeper): unblock main — Prometheus.inc_counter trailing unit in #14509

### DIFF
--- a/lib/keeper/keeper_turn_sandbox_runtime.ml
+++ b/lib/keeper/keeper_turn_sandbox_runtime.ml
@@ -358,5 +358,6 @@ let cleanup (t : t) =
             out;
           Prometheus.inc_counter
             Keeper_metrics.metric_keeper_turn_cleanup_failures
-            ~labels:[("keeper", t.meta.name); ("site", "docker_rm")]);
+            ~labels:[("keeper", t.meta.name); ("site", "docker_rm")]
+            ());
       ()


### PR DESCRIPTION
## Summary

PR #14509 (`32212379e7`) added `Prometheus.inc_counter ... ~labels:[...]` inside the docker cleanup error branch but omitted the trailing `()` required by the curried signature `?delta:float -> unit -> unit`. `dune build @check` fails on origin/main:

\`\`\`
File "lib/keeper/keeper_turn_sandbox_runtime.ml", lines 359-361:
Error: This expression has type ?delta:float -> unit -> unit
       but an expression was expected of type unit
\`\`\`

Single-character fix — append `()` to invoke. The counter previously incremented 0 times (partial application was discarded with `;` continuation); it now increments by 1 per `docker rm` failure as PR #14509 intended.

## Pattern check

Recurs `feedback_main_blocker_chain_4x_session` (admin-merge bypasses CI → main breaks). Pre-fix 3-channel check confirmed no in-flight fix PR before opening this one (`feedback_check_open_prs_before_fixing_pasted_build_error`).

## Verification

\`\`\`
dune build --root . @check  # now passes
\`\`\`

## RFC-WAIVED

\`RFC-WAIVED: 1-character build unblock, no protocol/credential change.\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)