### PR TITLE
spec(tla): CooperativeDrainYield bug model (RFC-0063 §7-C)

### DIFF
--- a/specs/bug-models/CooperativeDrainYield-buggy.cfg
+++ b/specs/bug-models/CooperativeDrainYield-buggy.cfg
@@ -1,0 +1,14 @@
+\* Buggy model: drain fiber recurses without yielding (PR #14491 regression).
+\* Expected: NoStarvation VIOLATED in SafetyBound + 1 = 7 steps.
+SPECIFICATION SpecBuggy
+
+CONSTANTS
+    TargetProgress = 2
+    SafetyBound    = 6
+    MaxDrainIters  = 10
+
+INVARIANTS
+    TypeOK
+    NoStarvation
+
+CHECK_DEADLOCK FALSE

--- a/specs/bug-models/CooperativeDrainYield.cfg
+++ b/specs/bug-models/CooperativeDrainYield.cfg
@@ -1,0 +1,14 @@
+\* Clean model: drain fiber yields after each iteration (RFC-0063 §6 contract).
+\* Expected: NoStarvation holds; TLC reports no error.
+SPECIFICATION SpecClean
+
+CONSTANTS
+    TargetProgress = 2
+    SafetyBound    = 6
+    MaxDrainIters  = 10
+
+INVARIANTS
+    TypeOK
+    NoStarvation
+
+CHECK_DEADLOCK FALSE

--- a/specs/bug-models/CooperativeDrainYield.tla
+++ b/specs/bug-models/CooperativeDrainYield.tla
@@ -1,0 +1,136 @@
+---- MODULE CooperativeDrainYield ----
+\* Bug model: Eio drain loop without cooperative yield starves co-located fibers.
+\*
+\* Models the regression introduced by PR #14491 (Keeper_telemetry_consumer
+\* drain loop) and fixed by PR #14499. RFC-0063 §6 codifies the contract;
+\* this spec is the §7-C ("TLA+ Bug Model") layer of enforcement.
+\*
+\* Cooperative scheduling premise
+\*   A single Eio domain runs at most one fiber at a time. A fiber retains
+\*   the domain until it explicitly yields (Eio.Time.sleep / Eio.Fiber.yield
+\*   / blocking IO). A co-located fiber receives turns only while the drain
+\*   fiber is in the "yielded" state.
+\*
+\* Two scheduler models
+\*   Clean (NextClean):
+\*     drain runs one iteration -> yields -> co-fiber may step -> drain
+\*     resumes -> ... Co-fiber receives turns; co_progress reaches the
+\*     target within a bounded number of drain iterations.
+\*
+\*   Buggy (NextBuggy):
+\*     drain runs an iteration but never yields. drain_state stays
+\*     "running" forever. Co-fiber's enabling guard (drain_state =
+\*     "yielded") never holds; co_progress stays 0 while drain_iters
+\*     grows without bound.
+\*
+\* Safety invariant
+\*   NoStarvation: it is never the case that drain has run more than
+\*   SafetyBound iterations while co_progress remains zero. Holds under
+\*   NextClean; violated under NextBuggy in SafetyBound + 1 steps.
+
+EXTENDS Naturals
+
+CONSTANTS
+    TargetProgress,    \* number of co-fiber iterations the harness expects
+    SafetyBound,       \* drain iteration count beyond which co-fiber must
+                       \* have made some progress
+    MaxDrainIters      \* hard cap on drain_iters to keep TLC's state space
+                       \* finite. Must be > SafetyBound so the buggy spec
+                       \* can reach the invariant-violating state.
+
+VARIABLES
+    drain_state,   \* "running" | "yielded"
+    co_progress,   \* 0 .. TargetProgress
+    drain_iters    \* 0 .. MaxDrainIters (bounded for finite model checking)
+
+vars == <<drain_state, co_progress, drain_iters>>
+
+Init ==
+    /\ drain_state  = "running"
+    /\ co_progress  = 0
+    /\ drain_iters  = 0
+
+\* ── Clean drain fiber ────────────────────────────────────────
+
+\* The drain body executes one iteration and then yields. This
+\* corresponds to [Eio.Time.sleep clock drain_interval_s] at the end
+\* of the loop body.
+DrainIterAndYield ==
+    /\ drain_state  = "running"
+    /\ drain_iters  < MaxDrainIters
+    /\ drain_state' = "yielded"
+    /\ drain_iters' = drain_iters + 1
+    /\ UNCHANGED co_progress
+
+\* When the drain fiber's sleep elapses, the scheduler resumes it.
+\* The co-fiber must have had a chance to run in between (CoFiberStep).
+DrainResume ==
+    /\ drain_state  = "yielded"
+    /\ co_progress  > 0           \* progress is observed before drain re-runs
+    /\ drain_state' = "running"
+    /\ UNCHANGED <<co_progress, drain_iters>>
+
+\* ── Buggy drain fiber ────────────────────────────────────────
+
+\* The drain body recurses without yielding. drain_state stays
+\* "running"; the scheduler has no opportunity to switch fibers.
+DrainSpinNoYield ==
+    /\ drain_state  = "running"
+    /\ drain_iters  < MaxDrainIters
+    /\ drain_state' = "running"
+    /\ drain_iters' = drain_iters + 1
+    /\ UNCHANGED co_progress
+
+\* ── Co-located fiber ─────────────────────────────────────────
+
+\* The co-located fiber can step only when the drain fiber has
+\* yielded the domain.
+CoFiberStep ==
+    /\ drain_state = "yielded"
+    /\ co_progress < TargetProgress
+    /\ co_progress' = co_progress + 1
+    /\ UNCHANGED <<drain_state, drain_iters>>
+
+\* Stutter once the co-fiber has reached its target. Avoids TLC
+\* deadlock errors at the natural terminal state.
+CoFiberDone ==
+    /\ co_progress = TargetProgress
+    /\ UNCHANGED vars
+
+\* ── Spec variants ────────────────────────────────────────────
+
+NextClean ==
+    \/ DrainIterAndYield
+    \/ DrainResume
+    \/ CoFiberStep
+    \/ CoFiberDone
+
+NextBuggy ==
+    \/ DrainSpinNoYield
+    \/ CoFiberStep            \* enabled in theory but drain_state never
+                              \* becomes "yielded", so this branch never
+                              \* fires under NextBuggy
+    \/ CoFiberDone
+
+SpecClean == Init /\ [][NextClean]_vars
+SpecBuggy == Init /\ [][NextBuggy]_vars
+
+\* ── Safety invariant ─────────────────────────────────────────
+
+\* If drain has run more than SafetyBound times, co_progress must be
+\* nonzero. Equivalent to "the drain fiber cannot starve the co-fiber
+\* indefinitely". Holds under NextClean (DrainResume requires
+\* co_progress > 0, which forces a CoFiberStep before the drain can
+\* iterate again past the very first cycle). Violated under NextBuggy
+\* once drain_iters exceeds SafetyBound.
+NoStarvation ==
+    ~ (drain_iters > SafetyBound /\ co_progress = 0)
+
+\* ── Type invariant (defensive) ───────────────────────────────
+
+TypeOK ==
+    /\ drain_state \in {"running", "yielded"}
+    /\ co_progress \in 0 .. TargetProgress
+    /\ drain_iters \in 0 .. MaxDrainIters
+
+====


### PR DESCRIPTION
## 목적

RFC-0063 §7-C (\"TLA+ Bug Model, high cost / precise\")의 첫 구현. PR #14491 boot hang을 cooperative scheduling 모델 위에서 formal하게 specify, clean spec PASS + buggy spec violated 양방향 입증.

## 모델

3개 변수, 2개 spec 변형:

| Var | Domain | Meaning |
|-----|--------|---------|
| `drain_state` | `\"running\" | \"yielded\"` | 도메인 보유 상태 |
| `co_progress` | `0..TargetProgress` | co-located fiber 진행 |
| `drain_iters` | `0..MaxDrainIters` | drain loop body 실행 수 (bounded for finite TLC) |

| Spec | Drain action | 결과 |
|------|--------------|------|
| `NextClean` | `DrainIterAndYield` → `DrainResume`은 `co_progress > 0` 시에만 | co-fiber가 매 cycle마다 turn 받음 |
| `NextBuggy` | `DrainSpinNoYield`만 (state stays \"running\") | co-fiber 영영 turn 못 받음 |

`NoStarvation` invariant: `~(drain_iters > SafetyBound /\\ co_progress = 0)`

## 검증 결과

| Run | States | Depth | TLC exit | 결과 |
|-----|--------|-------|----------|------|
| Clean cfg | 71 generated, 42 distinct | 23 | 0 | \"Model checking completed. No error has been found.\" |
| Buggy cfg | 8 generated, 8 distinct | 8 | **12 (safety violation)** | \"Error: Invariant NoStarvation is violated.\" |

Buggy counterexample: 7 consecutive `DrainSpinNoYield` steps while `co_progress` stays 0 → state 8에서 `drain_iters=7 > SafetyBound=6 /\\ co_progress=0` → violation. TLC가 정확히 RFC §6에 적은 starvation 시나리오를 reproduce.

## CI Wiring

`scripts/tla-check.sh:267-282`이 `specs/bug-models/*.tla` glob loop으로 auto-discover. 우리 spec은 자동 등록 — `tla-check.sh` 편집 불필요. clean cfg는 `run_tlc`로, buggy cfg는 `run_tlc_buggy`로 (exit 12/13 기대). 둘 다 PASS.

## RFC §7 enforcement matrix 완성도

| Option | 상태 | Coverage 특성 |
|--------|------|--------------|
| A — PR review checklist | not started (process) | low, manual |
| B — lint script | MERGED #14511 | high (file-level), zero false positives on baseline |
| C — TLA+ Bug Model | **이 PR** | precise (formal proof), bounded |
| D — Eio test harness | MERGED #14508 | partial (hang-based, CI wall-clock) |

C가 B의 known false negative(\"same-file but different function\")를 close합니다 — formal model에서 drain fiber와 co-fiber가 *동일 도메인*을 공유한다는 사실 자체를 axiom으로 갖고 있어 분리 시도가 모델에 표현될 수 없음.

## Workaround Rejection Bar self-check

7항목 모두 비대상. Formal verification은 categorically non-workaround.

## 한계 / 미반영

- **Liveness 미검증**: NoStarvation은 safety invariant이지 liveness property 아님. \"co-fiber가 결국 진행한다\"는 `<>(co_progress = TargetProgress)` formula로 표현하면 추가 검증 가능. fairness assumption이 필요해 별도 follow-up 후보.
- **Multi-fiber 모델 단순화**: 실제 Eio 도메인에는 여러 co-located fiber가 있을 수 있음. 본 모델은 1 drain + 1 co로 단순화. 일반화는 별도 RFC.
- **bounded MaxDrainIters=10**: TLC 무한 state space를 막기 위한 cap. SafetyBound + 4 = 10이라 buggy invariant violation 검증에는 충분, 더 많은 iter 검증은 cap 증가 필요.

## 관련

- RFC-0063: docs/rfc/RFC-0063-telemetry-feedback-loop.md (PR #14506, **여전히 Draft** — 별도 머지 필요)
- 회귀 fix: PR #14499 → bump #14503 → test #14508 → lint #14511
- TLA+ Bug Model 표준: `~/me/instructions/software-development.md` §TLA+ Bug Model 패턴
- Sibling models: `specs/bug-models/AtomicFileWrite.tla`, `CascadeCrossFallback.tla`

🤖 Generated with [Claude Code](https://claude.com/claude-code)