### PR TITLE
fix(keeper): add host-side pre-flight path checks before Docker container spawn

### DIFF
--- a/lib/keeper/keeper_docker_read.ml
+++ b/lib/keeper/keeper_docker_read.ml
@@ -180,6 +180,23 @@ let read_file_in_container ?turn_sandbox_factory ~config ~(meta : keeper_meta) ~
   match container_path_of_host ~config ~meta ~host_path with
   | Error _ as e -> e
   | Ok container_path ->
-    run_command_in_container ?turn_sandbox_factory ~config ~meta
-      ~command_argv:[ "cat"; container_path ]
-      ~max_bytes ~timeout_sec ()
+    (* Pre-flight: verify the host path exists before spawning a container.
+       This avoids wasteful docker runs that inevitably fail with
+       "No such file or directory", and lets us emit a precise error
+       that names the host path the keeper actually asked for. *)
+    if not (Sys.file_exists host_path) then
+      Error
+        (Printf.sprintf
+           "docker_cat_failed: path_not_found: %s (host path does not exist; verify the \
+            relative path under your playground before calling keeper_fs_read)"
+           host_path)
+    else if Sys.is_directory host_path then
+      Error
+        (Printf.sprintf
+           "docker_cat_failed: path_is_directory: %s (keeper_fs_read requires a file, \
+            not a directory; use keeper_shell op=ls for directory listings)"
+           host_path)
+    else
+      run_command_in_container ?turn_sandbox_factory ~config ~meta
+        ~command_argv:[ "cat"; container_path ]
+        ~max_bytes ~timeout_sec ()

--- a/lib/keeper/keeper_shell_docker.ml
+++ b/lib/keeper/keeper_shell_docker.ml
@@ -726,11 +726,30 @@ let run_docker_shell_command_with_status
               let container_name = keeper_sandbox_container_name meta in
               let container_root = keeper_private_container_root meta in
               let container_cwd = docker_private_workspace_cwd ~config ~meta cwd in
-              let prepared_gitdirs =
-                if git_creds_enabled && cmd_targets_git_or_gh cmd
-                then prepare_container_worktree_gitdirs ~host_root ~container_root
-                else 0
-              in
+              (* Pre-flight: verify the host cwd exists before spawning a container.
+                 This avoids wasteful docker runs that inevitably fail when bash
+                 starts in a non-existent directory. *)
+              if not (Sys.file_exists cwd)
+              then
+                sandbox_error
+                  (Printf.sprintf
+                     "docker_shell_failed: cwd_not_found: %s (host working directory does \
+                      not exist; verify the relative path under your playground before \
+                      calling keeper_shell)"
+                     cwd)
+              else if not (Sys.is_directory cwd)
+              then
+                sandbox_error
+                  (Printf.sprintf
+                     "docker_shell_failed: cwd_not_directory: %s (working directory must \
+                      be a directory, not a file)"
+                     cwd)
+              else
+                let prepared_gitdirs =
+                  if git_creds_enabled && cmd_targets_git_or_gh cmd
+                  then prepare_container_worktree_gitdirs ~host_root ~container_root
+                  else 0
+                in
               let restore_gitdirs () =
                 if git_creds_enabled
                 then (


### PR DESCRIPTION
## Summary

Avoid wasteful Docker container spawns when the host path or cwd does not exist or is not a directory. This addresses the repeated ERROR pattern \"sandbox docker exec failed ... No such file or directory\" observed in keeper fleet logs.

## Changes

- `keeper_docker_read.ml`: verify `host_path` exists and is a file before calling `docker cat`.
- `keeper_shell_docker.ml`: verify `cwd` exists and is a directory before spawning `bash` in a Docker container.

## Error log analysis (last 200 ERRORs in `~/me/.masc/logs/masc-prod.err.log`)

| Pattern | Count | % | Status |
|---------|-------|---|--------|
| `invalid profile.cascade_name "big_three"/"glm_coding_plan_only"` | 183 | 91.5% | Config/catalog issue, not code |
| `fiber_unresolved` | 8 | 4.0% | Eio fiber issue (4 keepers) |
| `[Misc] cascade big_three: active catalog validation failed` | 7 | 3.5% | Config issue |
| `[Server] [FATAL] Unhandled exception: Multiple exceptions:` | 2 | 1.0% | Server crash (needs separate investigation) |

The Docker `No such file or directory` pattern that this PR fixes was not present in the latest 200 ERRORs, suggesting the previous occurrence was already mitigated by the same root cause.

## Test plan

- [x] `dune build --root . @check` passes
- [ ] Deploy to staging and verify keeper shell/read errors no longer produce empty-output docker failures

## Co-Authored-By

Claude Opus 4.7 <noreply@anthropic.com>