### PR TITLE
feat(core): RFC-0059 Phase 2 PR-5 — Actor mailbox + types primitives

### DIFF
--- a/lib/core/actor_mailbox.ml
+++ b/lib/core/actor_mailbox.ml
@@ -1,0 +1,33 @@
+type 'msg t = 'msg Actor_types.t
+
+let default_capacity = 64
+
+let create ?(capacity = default_capacity) name =
+  if capacity < 1 then
+    invalid_arg
+      (Printf.sprintf
+         "Actor_mailbox.create: capacity must be >= 1, got %d" capacity);
+  let inbox = Eio.Stream.create capacity in
+  { Actor_types.name; inbox; stop_signal = Atomic.make false }
+
+let send (t : 'msg t) (msg : 'msg) : unit =
+  Eio.Stream.add t.Actor_types.inbox msg
+
+let length (t : 'msg t) : int =
+  Eio.Stream.length t.Actor_types.inbox
+
+let stop (t : 'msg t) : unit =
+  Atomic.set t.Actor_types.stop_signal true
+
+let run (t : 'msg t) ~init
+    ~(handle : 'state -> 'msg -> 'state * Actor_types.handler_outcome) : unit =
+  let rec loop state =
+    if Atomic.get t.Actor_types.stop_signal then ()
+    else
+      let msg = Eio.Stream.take t.Actor_types.inbox in
+      let state', outcome = handle state msg in
+      match outcome with
+      | Actor_types.Continue -> loop state'
+      | Actor_types.Stop -> ()
+  in
+  loop init

--- a/lib/core/actor_mailbox.mli
+++ b/lib/core/actor_mailbox.mli
@@ -1,0 +1,63 @@
+(** Actor mailbox + loop driver for the actor model introduced in
+    RFC-0059 Phase 2 (PR-5).
+
+    Single-Domain only — PR-6 wraps these in a [Domain_pool] for
+    parallel dispatch.  In a single Domain the loop is cooperative:
+    [Eio.Stream.take] yields to peer fibers when the inbox is empty,
+    and bounded inbox capacity provides backpressure to the producer
+    when the consumer falls behind. *)
+
+type 'msg t = 'msg Actor_types.t
+
+val default_capacity : int
+(** Default inbox capacity passed to {!Eio.Stream.create} when
+    [?capacity] is omitted from {!create}.  Currently [64] — wide
+    enough that a 10×/sec producer / 1×/sec consumer can absorb a
+    six-second hiccup before [send] starts blocking, narrow enough
+    that a stalled consumer does not silently buffer minutes of
+    work. *)
+
+val create : ?capacity:int -> string -> 'msg t
+(** [create ~capacity name] allocates a fresh actor handle with a
+    bounded inbox.  Raises [Invalid_argument] if [capacity < 1] —
+    [Eio.Stream.create 0] yields rendez-vous semantics that this
+    module deliberately does not expose. *)
+
+val send : 'msg t -> 'msg -> unit
+(** [send t msg] enqueues [msg] in the inbox.  Blocks the calling
+    fiber when the inbox is full, propagating backpressure.  A
+    non-blocking variant ([try_send]) is deferred — it requires
+    tracking capacity on the actor record because [Eio.Stream] does
+    not expose its bound after construction.  Add it when the first
+    actor needs saturation-as-signal rather than backpressure. *)
+
+val length : 'msg t -> int
+(** Current inbox depth.  Snapshot only — the value can change before
+    the caller acts on it.  Suitable for metrics, not for control
+    flow. *)
+
+val stop : 'msg t -> unit
+(** Set the actor's stop signal.  The next iteration of {!run} that
+    reaches the [stop_signal] check exits without taking another
+    message.  In-flight handler invocations complete first.  This
+    does {b not} wake a fiber blocked on [Eio.Stream.take] — to
+    unblock a quiescent inbox the caller must also send a sentinel
+    message that the handler routes to a [Stop] outcome. *)
+
+val run :
+  'msg t ->
+  init:'state ->
+  handle:('state -> 'msg -> 'state * Actor_types.handler_outcome) ->
+  unit
+(** [run t ~init ~handle] runs the actor loop in the {b current}
+    fiber, threading [state] through successive messages.
+
+    The handler returns a tuple of [(new_state, outcome)]; the loop
+    follows [outcome]:
+    - {!Actor_types.Continue}: recurse with [new_state].
+    - {!Actor_types.Stop}: exit cleanly.
+
+    The loop also exits when {!stop} has set [stop_signal] and the
+    next iteration observes it (between message takes), or when the
+    surrounding switch is cancelled and propagates
+    [Eio.Cancel.Cancelled] up through [Eio.Stream.take]. *)

--- a/lib/core/actor_types.ml
+++ b/lib/core/actor_types.ml
@@ -1,0 +1,11 @@
+type 'msg mailbox = 'msg Eio.Stream.t
+
+type 'msg t = {
+  name : string;
+  inbox : 'msg mailbox;
+  stop_signal : bool Atomic.t;
+}
+
+type handler_outcome =
+  | Continue
+  | Stop

--- a/lib/core/actor_types.mli
+++ b/lib/core/actor_types.mli
@@ -1,0 +1,40 @@
+(** Actor types — generic actor abstraction over Eio fibers.
+
+    Single-Domain only.  RFC-0059 Phase 2 PR-5: primitive types for
+    the actor model.  PR-6 (Domain pool) introduces parallel
+    dispatch, PR-7 migrates the keeper heartbeat loop to actors.
+
+    The actor record is parameterised by message type {b ['msg]}.
+    Internal state is owned by the actor's own loop fiber
+    (closure-captured) — deliberately {i not} exposed in the type —
+    to enforce the "messages are the only inputs" invariant of the
+    actor model.  External code interacts via {!Actor_mailbox.send};
+    reading internal state requires sending a query message that
+    responds via a callback or {!Eio.Promise}.
+
+    {b Why ['msg] and not [unit]}: a stub iteration of this module
+    used [unit mailbox], erasing the message type.  That makes the
+    queue convey only "wake up" with no payload, which is not the
+    actor model — it is a semaphore.  The typed queue lets the
+    handler exhaustively pattern-match on a closed sum type, which
+    is the OCaml way of catching "forgot to handle new message
+    variant" at compile time. *)
+
+type 'msg mailbox = 'msg Eio.Stream.t
+(** Bounded message queue.  See {!Actor_mailbox.create} for capacity. *)
+
+type 'msg t = {
+  name : string;
+  inbox : 'msg mailbox;
+  stop_signal : bool Atomic.t;
+}
+(** An actor handle.  Externally observable surface: the [name] (for
+    log attribution), the [inbox] for [send], and a [stop_signal]
+    flag the loop checks at the top of each iteration. *)
+
+type handler_outcome =
+  | Continue
+  | Stop
+(** Return value of an actor message handler.  [Continue] re-enters
+    the loop with the new state; [Stop] exits cleanly without
+    waiting for the [stop_signal]. *)

--- a/lib/core/dune
+++ b/lib/core/dune
@@ -3,5 +3,5 @@
  (name masc_core)
  (public_name masc_mcp.masc_core)
  (wrapped false)
- (modules json_util safe_ops common validation circuit_breaker eio_guard executor_pool_ref masc_runtime_events provider_error text_similarity string_util list_util read_drop_reason)
+ (modules json_util safe_ops common validation circuit_breaker eio_guard executor_pool_ref masc_runtime_events provider_error text_similarity string_util list_util read_drop_reason actor_types actor_mailbox)
  (libraries yojson unix re re.pcre eio eio.unix time_compat fs_compat masc_log runtime_events))

--- a/lib/keeper/keeper_turn_sandbox_runtime.ml
+++ b/lib/keeper/keeper_turn_sandbox_runtime.ml
@@ -358,5 +358,6 @@ let cleanup (t : t) =
             out;
           Prometheus.inc_counter
             Keeper_metrics.metric_keeper_turn_cleanup_failures
-            ~labels:[("keeper", t.meta.name); ("site", "docker_rm")]);
+            ~labels:[("keeper", t.meta.name); ("site", "docker_rm")]
+            ());
       ()

--- a/test/dune
+++ b/test/dune
@@ -32,6 +32,7 @@
         test_keeper_turn_disposition
         test_keeper_turn_terminal_disposition_field
         test_attempt_state
+        test_actor_mailbox
         test_sse test_graphql_api
         test_graphql_endpoint
         test_subscriptions test_session test_progress test_spawn
@@ -269,6 +270,7 @@
           test_keeper_turn_disposition
           test_keeper_turn_terminal_disposition_field
           test_attempt_state
+          test_actor_mailbox
           test_sse test_graphql_api
           test_graphql_endpoint
           test_subscriptions test_session test_progress test_spawn

--- a/test/test_actor_mailbox.ml
+++ b/test/test_actor_mailbox.ml
@@ -1,0 +1,124 @@
+open Alcotest
+
+(** Unit tests for [Actor_mailbox] — RFC-0059 Phase 2 PR-5.
+
+    Tests run inside [Eio_main.run] because [Actor_mailbox.run]
+    consumes from an [Eio.Stream.t] which only makes sense inside an
+    Eio scheduler.  Each test runs in its own [Eio.Switch.run] so a
+    cancellation in one test does not leak fibers into the next. *)
+
+module M = Actor_mailbox
+module T = Actor_types
+
+(* ── create ────────────────────────────────────────────── *)
+
+let test_create_default_capacity () =
+  Eio_main.run (fun _env ->
+    let actor = M.create "default" in
+    check int "starts empty" 0 (M.length actor))
+
+let test_create_explicit_capacity () =
+  Eio_main.run (fun _env ->
+    let actor = M.create ~capacity:1 "tiny" in
+    check int "starts empty" 0 (M.length actor))
+
+let test_create_zero_capacity_rejected () =
+  Eio_main.run (fun _env ->
+    check_raises "zero capacity raises Invalid_argument"
+      (Invalid_argument
+         "Actor_mailbox.create: capacity must be >= 1, got 0")
+      (fun () -> ignore (M.create ~capacity:0 "rejected")))
+
+let test_create_negative_capacity_rejected () =
+  Eio_main.run (fun _env ->
+    check_raises "negative capacity raises Invalid_argument"
+      (Invalid_argument
+         "Actor_mailbox.create: capacity must be >= 1, got -3")
+      (fun () -> ignore (M.create ~capacity:(-3) "rejected")))
+
+(* ── send / length / run ───────────────────────────────── *)
+
+let test_send_increments_length () =
+  Eio_main.run (fun _env ->
+    let actor = M.create ~capacity:8 "buffer" in
+    M.send actor "a";
+    M.send actor "b";
+    check int "two messages enqueued" 2 (M.length actor))
+
+let test_run_processes_messages_and_stops () =
+  Eio_main.run (fun _env ->
+    Eio.Switch.run (fun sw ->
+      let actor = M.create ~capacity:8 "echo" in
+      let received = ref [] in
+      Eio.Fiber.fork ~sw (fun () ->
+        M.run actor ~init:()
+          ~handle:(fun () msg ->
+            received := msg :: !received;
+            if String.equal msg "STOP" then ((), T.Stop)
+            else ((), T.Continue)));
+      M.send actor "first";
+      M.send actor "second";
+      M.send actor "STOP"));
+  ()
+
+let test_run_threads_state () =
+  let final_count = ref 0 in
+  Eio_main.run (fun _env ->
+    Eio.Switch.run (fun sw ->
+      let actor = M.create ~capacity:8 "counter" in
+      Eio.Fiber.fork ~sw (fun () ->
+        M.run actor ~init:0
+          ~handle:(fun count msg ->
+            match msg with
+            | `Inc -> (count + 1, T.Continue)
+            | `Snapshot ->
+                final_count := count;
+                (count, T.Stop)));
+      M.send actor `Inc;
+      M.send actor `Inc;
+      M.send actor `Inc;
+      M.send actor `Snapshot));
+  check int "state threaded across messages" 3 !final_count
+
+(* ── stop_signal ────────────────────────────────────────── *)
+
+let test_stop_observed_between_messages () =
+  let processed = ref 0 in
+  Eio_main.run (fun _env ->
+    Eio.Switch.run (fun sw ->
+      let actor = M.create ~capacity:8 "stoppable" in
+      Eio.Fiber.fork ~sw (fun () ->
+        M.run actor ~init:()
+          ~handle:(fun () _msg ->
+            incr processed;
+            ((), T.Continue)));
+      M.send actor "one";
+      Eio.Fiber.yield ();
+      M.stop actor;
+      M.send actor "two"));
+  (* The actor processed at least the first message; [stop] flips the
+     signal between iterations so the loop exits after the in-flight
+     handler returns.  The contract is "post-message observation" —
+     we do not assert exact count because the second message may or
+     may not be drained depending on fiber scheduling. *)
+  check bool "actor exited" true (!processed >= 1)
+
+(* ── Suite ──────────────────────────────────────────────── *)
+
+let () =
+  Alcotest.run "Actor_mailbox" [
+    "create", [
+      test_case "default capacity" `Quick test_create_default_capacity;
+      test_case "explicit capacity" `Quick test_create_explicit_capacity;
+      test_case "zero capacity rejected" `Quick test_create_zero_capacity_rejected;
+      test_case "negative capacity rejected" `Quick test_create_negative_capacity_rejected;
+    ];
+    "send_run", [
+      test_case "send increments length" `Quick test_send_increments_length;
+      test_case "run processes and stops" `Quick test_run_processes_messages_and_stops;
+      test_case "run threads state" `Quick test_run_threads_state;
+    ];
+    "stop_signal", [
+      test_case "stop observed between messages" `Quick test_stop_observed_between_messages;
+    ];
+  ]


### PR DESCRIPTION
## Summary

RFC-0059 Phase 2 **PR-5 (Actor Primitives)** — actor model 위한 두 모듈을 `masc_core`에 추가. PR-6(Domain pool)/PR-7(Keeper migration) foundation. 코드 변경: `lib/core/actor_types.ml(i)` + `lib/core/actor_mailbox.ml(i)` + `lib/core/dune` 등록 + `test/test_actor_mailbox.ml` 8 cases.

## Modules

### `Actor_types`
- `'msg mailbox = 'msg Eio.Stream.t` — **typed** bounded queue (이전 stub iteration의 `unit mailbox` anti-pattern 회피)
- `'msg t = { name; inbox; stop_signal : bool Atomic.t }` — 외부 surface만 노출, 내부 state는 actor loop closure에 owned
- `handler_outcome = Continue | Stop` — exhaustive match로 닫힌 sum

### `Actor_mailbox`
- `create ?capacity name` — bounded inbox (default 64). `capacity < 1` → `Invalid_argument` (Eio.Stream.create 0 은 rendez-vous 의미라 의도적 거부)
- `send` / `length` / `stop`
- `run t ~init ~handle` — current fiber에서 loop, state threading, `Stop` outcome / `stop_signal` / switch 취소 시 청정 exit

`try_send`(non-blocking 변형)는 capacity 추적이 record 추가 필요해서 의도적 deferred — saturation-as-signal 사용처가 첫 등장할 때 추가.

## Why typed messages

기존 untracked stub (`lib/core/actor_*.ml` local-only, dune 미등록, caller 0)이 `inbox : unit mailbox`였음 → payload erasure로 단순 wake-up 시그널, 즉 semaphore (actor 모델 아님). 사용자 결정으로 fresh impl 진행. CLAUDE.md "타입 시스템을 무시하는 건 타입 시스템을 안 쓰는것과 똑같음" 원칙 준수.

## Tests

```
$ dune test test/test_actor_mailbox.exe
[OK]  create       0   default capacity.
[OK]  create       1   explicit capacity.
[OK]  create       2   zero capacity rejected.
[OK]  create       3   negative capacity rejected.
[OK]  send_run     0   send increments length.
[OK]  send_run     1   run processes and stops.
[OK]  send_run     2   run threads state.
[OK]  stop_signal  0   stop observed between messages.
Test Successful in 0.004s. 8 tests run.
```

## Dependency: PR #14514 (hotfix)

원래 origin/main 빌드가 PR #14509에서 도입된 `Prometheus.inc_counter` trailing-unit missing으로 깨져있었음. 본 PR에는 #14514 hotfix가 cherry-pick으로 포함되어 있어 standalone build green. **#14514 머지 후 자동 rebase에서 중복 commit이 깨끗이 떨어짐** — squash merge 시 단일 PR-5 commit만 남습니다. 만약 #14514가 먼저 머지된다면 본 PR 머지 시 충돌 없이 처리됨.

## File inventory (RFC §8 vs actual)

| File | RFC 추정 | 실제 |
|--|--|--|
| `lib/core/actor_mailbox.ml(i)` | 80+20 = 100 | 32+~70 = ~102 |
| `lib/core/actor_types.ml(i)` | 60+15 = 75 | 9+45 = 54 |
| `test/test_actor_mailbox.ml` | (별도) | ~120 |
| `lib/core/dune`, `test/dune` | +2 | +2 |

총 **+274 insertions / -1 deletion** (commit 통계). RFC 추정과 일치.

## Out-of-scope

- **`Actor_supervisor`** — RFC §8에 listed but PR-5 description은 mailbox+types만 명시. PR-7(Keeper migration)에서 supervisor 패턴이 필요해질 때 도입. 사전 추상화 회피.
- **`Domain_pool`** — PR-6 scope.
- **`try_send`** — capacity tracking 필요, 첫 사용처 등장 시 추가.

## Workaround Rejection Bar self-check

| 시그니처 | 해당? |
|--|--|
| 텔레메트리-as-fix | ❌ |
| string/substring 분류기 보강 | ❌ |
| N-of-M 패치 | ⚠️ stub 파일이 이미 untracked로 존재해서 N-of-M처럼 보일 수 있음. 그러나 stub은 `unit mailbox` 타입 erasure로 unsalvageable, 사용자가 "fresh 구현" 선택. PR body에 명시. |
| catch-all `_ ->` 추가 | ❌ |
| cap/cooldown/dedup/repair | ❌ |
| test backdoor | ❌ |
| 같은 typo N번 fix | ❌ |

## RFC

이 PR 자체가 **RFC-0059 Phase 2 PR-5의 구현체**. `RFC-WAIVED` 불필요 — RFC-0059이 이미 design source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
