### PR TITLE
feat(dashboard): IDE file tree icons + TOML/YAML/Rust/Go syntax highlighting

### DIFF
--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -23,11 +23,13 @@
   "dependencies": {
     "@codemirror/commands": "^6.10.3",
     "@codemirror/lang-css": "^6.3.1",
+    "@codemirror/lang-go": "^6.0.1",
     "@codemirror/lang-html": "^6.4.11",
     "@codemirror/lang-javascript": "^6.2.5",
     "@codemirror/lang-json": "^6.0.2",
     "@codemirror/lang-markdown": "^6.5.0",
     "@codemirror/lang-python": "^6.2.1",
+    "@codemirror/lang-rust": "^6.0.2",
     "@codemirror/language": "^6.12.3",
     "@codemirror/merge": "^6.12.1",
     "@codemirror/state": "^6.6.0",
@@ -38,6 +40,8 @@
     "cytoscape": "^3.33.3",
     "dompurify": "^3.4.2",
     "downshift": "^9.3.2",
+    "google-protobuf": "^3.21.4",
+    "grpc-web": "^1.5.0",
     "htm": "^3.1.1",
     "lucide-preact": "^1.14.0",
     "marked": "^18.0.3",
@@ -52,9 +56,7 @@
     "vis-timeline": "^8.5.0",
     "y-websocket": "^3.0.0",
     "yjs": "^13.6.30",
-    "zod": "^4.4.3",
-    "grpc-web": "^1.5.0",
-    "google-protobuf": "^3.21.4"
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.4",
@@ -63,6 +65,7 @@
     "@tailwindcss/vite": "^4.2.4",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/preact": "^3.2.4",
+    "@types/google-protobuf": "^3.15.12",
     "@types/hammerjs": "^2.0.46",
     "@types/jest-axe": "^3.5.9",
     "@types/node": "^22.19.17",
@@ -80,8 +83,7 @@
     "typescript-eslint": "^8.59.2",
     "vite": "^7.3.2",
     "vite-plugin-solid": "^2.11.12",
-    "vitest": "^4.1.5",
-    "@types/google-protobuf": "^3.15.12"
+    "vitest": "^4.1.5"
   },
   "pnpm": {
     "overrides": {

--- a/dashboard/pnpm-lock.yaml
+++ b/dashboard/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       '@codemirror/lang-css':
         specifier: ^6.3.1
         version: 6.3.1
+      '@codemirror/lang-go':
+        specifier: ^6.0.1
+        version: 6.0.1
       '@codemirror/lang-html':
         specifier: ^6.4.11
         version: 6.4.11
@@ -32,6 +35,9 @@ importers:
       '@codemirror/lang-python':
         specifier: ^6.2.1
         version: 6.2.1
+      '@codemirror/lang-rust':
+        specifier: ^6.0.2
+        version: 6.0.2
       '@codemirror/language':
         specifier: ^6.12.3
         version: 6.12.3
@@ -326,6 +332,9 @@ packages:
   '@codemirror/lang-css@6.3.1':
     resolution: {integrity: sha512-kr5fwBGiGtmz6l0LSJIbno9QrifNMUusivHbnA1H6Dmqy4HZFte3UAICix1VuKo0lMPKQr2rqB+0BkKi/S3Ejg==}
 
+  '@codemirror/lang-go@6.0.1':
+    resolution: {integrity: sha512-7fNvbyNylvqCphW9HD6WFnRpcDjr+KXX/FgqXy5H5ZS0eC5edDljukm/yNgYkwTsgp2busdod50AOTIy6Jikfg==}
+
   '@codemirror/lang-html@6.4.11':
     resolution: {integrity: sha512-9NsXp7Nwp891pQchI7gPdTwBuSuT3K65NGTHWHNJ55HjYcHLllr0rbIZNdOzas9ztc1EUVBlHou85FFZS4BNnw==}
 
@@ -340,6 +349,9 @@ packages:
 
   '@codemirror/lang-python@6.2.1':
     resolution: {integrity: sha512-IRjC8RUBhn9mGR9ywecNhB51yePWCGgvHfY1lWN/Mrp3cKuHr0isDKia+9HnvhiWNnMpbGhWrkhuWOc09exRyw==}
+
+  '@codemirror/lang-rust@6.0.2':
+    resolution: {integrity: sha512-EZaGjCUegtiU7kSMvOfEZpaCReowEf3yNidYu7+vfuGTm9ow4mthAparY5hisJqOHmJowVH3Upu+eJlUji6qqA==}
 
   '@codemirror/language@6.12.3':
     resolution: {integrity: sha512-QwCZW6Tt1siP37Jet9Tb02Zs81TQt6qQrZR2H+eGMcFsL1zMrk2/b9CLC7/9ieP1fjIUMgviLWMmgiHoJrj+ZA==}
@@ -636,6 +648,9 @@ packages:
   '@lezer/css@1.3.3':
     resolution: {integrity: sha512-RzBo8r+/6QJeow7aPHIpGVIH59xTcJXp399820gZoMo9noQDRVpJLheIBUicYwKcsbOYoBRoLZlf2720dG/4Tg==}
 
+  '@lezer/go@1.0.1':
+    resolution: {integrity: sha512-xToRsYxwsgJNHTgNdStpcvmbVuKxTapV0dM0wey1geMMRc9aggoVyKgzYp41D2/vVOx+Ii4hmE206kvxIXBVXQ==}
+
   '@lezer/highlight@1.2.3':
     resolution: {integrity: sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g==}
 
@@ -656,6 +671,9 @@ packages:
 
   '@lezer/python@1.1.18':
     resolution: {integrity: sha512-31FiUrU7z9+d/ElGQLJFXl+dKOdx0jALlP3KEOsGTex8mvj+SoE1FgItcHWK/axkxCHGUSpqIHt6JAWfWu9Rhg==}
+
+  '@lezer/rust@1.0.2':
+    resolution: {integrity: sha512-Lz5sIPBdF2FUXcWeCu1//ojFAZqzTQNRga0aYv6dYXqJqPfMdCAI0NzajWUd4Xijj1IKJLtjoXRPMvTKWBcqKg==}
 
   '@lit-labs/ssr-dom-shim@1.5.1':
     resolution: {integrity: sha512-Aou5UdlSpr5whQe8AA/bZG0jMj96CoJIWbGfZ91qieWu5AWUMKw8VR/pAkQkJYvBNhmCcWnZlyyk5oze8JIqYA==}
@@ -3336,6 +3354,14 @@ snapshots:
       '@lezer/common': 1.5.2
       '@lezer/css': 1.3.3
 
+  '@codemirror/lang-go@6.0.1':
+    dependencies:
+      '@codemirror/autocomplete': 6.20.1
+      '@codemirror/language': 6.12.3
+      '@codemirror/state': 6.6.0
+      '@lezer/common': 1.5.2
+      '@lezer/go': 1.0.1
+
   '@codemirror/lang-html@6.4.11':
     dependencies:
       '@codemirror/autocomplete': 6.20.1
@@ -3380,6 +3406,11 @@ snapshots:
       '@codemirror/state': 6.6.0
       '@lezer/common': 1.5.2
       '@lezer/python': 1.1.18
+
+  '@codemirror/lang-rust@6.0.2':
+    dependencies:
+      '@codemirror/language': 6.12.3
+      '@lezer/rust': 1.0.2
 
   '@codemirror/language@6.12.3':
     dependencies:
@@ -3634,6 +3665,12 @@ snapshots:
       '@lezer/highlight': 1.2.3
       '@lezer/lr': 1.4.10
 
+  '@lezer/go@1.0.1':
+    dependencies:
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+
   '@lezer/highlight@1.2.3':
     dependencies:
       '@lezer/common': 1.5.2
@@ -3666,6 +3703,12 @@ snapshots:
       '@lezer/highlight': 1.2.3
 
   '@lezer/python@1.1.18':
+    dependencies:
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+
+  '@lezer/rust@1.0.2':
     dependencies:
       '@lezer/common': 1.5.2
       '@lezer/highlight': 1.2.3

--- a/dashboard/src/components/ide/ide-editor-extensions.ts
+++ b/dashboard/src/components/ide/ide-editor-extensions.ts
@@ -378,6 +378,161 @@ const ocamlStreamParser: StreamParser<OcamlStreamState> = {
 
 const ocamlLanguage = StreamLanguage.define(ocamlStreamParser)
 
+// ── TOML StreamLanguage ──────────────────────────────
+
+interface TomlStreamState {
+  readonly inSection: boolean
+}
+
+const tomlStreamParser: StreamParser<TomlStreamState> = {
+  name: 'toml',
+  startState: () => ({ inSection: false }),
+  copyState: state => ({ ...state }),
+  languageData: {
+    name: 'toml',
+    commentTokens: { line: '#' },
+  },
+  token(stream, state) {
+    if (stream.eatSpace()) return null
+
+    if (stream.sol() && stream.peek() === '#') {
+      stream.skipToEnd()
+      return 'comment'
+    }
+
+    if (stream.sol() && stream.peek() === '[') {
+      stream.skipToEnd()
+      return 'heading'
+    }
+
+    if (stream.peek() === '=') {
+      stream.next()
+      return 'operator'
+    }
+
+    if (stream.peek() === '"' || stream.peek() === '\'') {
+      const quote = stream.next()!
+      let escaped = false
+      while (!stream.eol()) {
+        const ch = stream.next()!
+        if (escaped) { escaped = false; continue }
+        if (ch === '\\') { escaped = true; continue }
+        if (ch === quote) break
+      }
+      return 'string'
+    }
+
+    if (/[0-9\-]/.test(stream.peek() ?? '') && stream.match(/^-?(?:0|[1-9]\d*)(?:\.\d+)?(?:[eE][+-]?\d+)?/)) {
+      return 'number'
+    }
+
+    if (stream.match(/^true\b/) || stream.match(/^false\b/)) {
+      return 'atom'
+    }
+
+    if (stream.match(/^\d{4}-\d{2}-\d{2}/)) {
+      stream.eatWhile(/[T :\d.Z]/)
+      return 'number'
+    }
+
+    if (/[A-Za-z_]/.test(stream.peek() ?? '')) {
+      stream.eatWhile(/[A-Za-z0-9_.\-]/)
+      return state.inSection ? 'propertyName' : 'variableName'
+    }
+
+    stream.next()
+    return null
+  },
+}
+
+const tomlLanguage = StreamLanguage.define(tomlStreamParser)
+
+// ── YAML StreamLanguage ──────────────────────────────
+
+interface YamlStreamState {
+  inKey: boolean
+}
+
+const YAML_KEYWORDS = new Set(['true', 'false', 'null', '~', 'yes', 'no', 'on', 'off'])
+
+const yamlStreamParser: StreamParser<YamlStreamState> = {
+  name: 'yaml',
+  startState: () => ({ inKey: true }),
+  copyState: state => ({ ...state }),
+  languageData: {
+    name: 'yaml',
+    commentTokens: { line: '#' },
+  },
+  token(stream, state) {
+    if (stream.eatSpace()) return null
+
+    if (stream.peek() === '#') {
+      stream.skipToEnd()
+      return 'comment'
+    }
+
+    if (stream.sol() && (stream.match(/^---/) || stream.match(/^\.\.\./))) {
+      stream.eatSpace()
+      return 'operator'
+    }
+
+    if (stream.sol() && stream.peek() === '-') {
+      stream.next()
+      if (stream.eatSpace()) return 'operator'
+    }
+
+    if (stream.peek() === '"' || stream.peek() === '\'') {
+      const quote = stream.next()!
+      let escaped = false
+      while (!stream.eol()) {
+        const ch = stream.next()!
+        if (escaped) { escaped = false; continue }
+        if (ch === '\\') { escaped = true; continue }
+        if (ch === quote) break
+      }
+      state.inKey = false
+      return 'string'
+    }
+
+    if (stream.peek() === ':') {
+      stream.next()
+      if (stream.eatSpace()) {
+        state.inKey = true
+        return 'operator'
+      }
+      return null
+    }
+
+    if (/[0-9\-]/.test(stream.peek() ?? '') && stream.match(/^-?(?:0|[1-9]\d*)(?:\.\d+)?(?:[eE][+-]?\d+)?/)) {
+      state.inKey = false
+      return 'number'
+    }
+
+    if (/[A-Za-z_]/.test(stream.peek() ?? '')) {
+      stream.eatWhile(/[A-Za-z0-9_.\-]/)
+      const word = stream.current()
+      if (YAML_KEYWORDS.has(word)) {
+        state.inKey = false
+        return 'atom'
+      }
+      if (state.inKey) return 'propertyName'
+      state.inKey = false
+      return 'string'
+    }
+
+    if (stream.peek() === '[' || stream.peek() === ']' || stream.peek() === '{' || stream.peek() === '}' || stream.peek() === ',') {
+      stream.next()
+      return 'operator'
+    }
+
+    stream.next()
+    state.inKey = false
+    return null
+  },
+}
+
+const yamlLanguage = StreamLanguage.define(yamlStreamParser)
+
 function readOcamlComment(stream: StringStream, state: OcamlStreamState): string {
   while (!stream.eol()) {
     if (stream.match('(*')) {
@@ -426,9 +581,11 @@ const LANGUAGE_MAP: Readonly<Record<string, LanguageEntry>> = {
   '.ocaml': { id: 'ocaml', load: () => Promise.resolve(ocamlLanguage) },
   '.ml': { id: 'ocaml', load: () => Promise.resolve(ocamlLanguage) },
   '.mli': { id: 'ocaml', load: () => Promise.resolve(ocamlLanguage) },
-  '.toml': { id: 'json', load: () => import('@codemirror/lang-json').then(m => m.json()) },
-  '.yaml': { id: 'json', load: () => import('@codemirror/lang-json').then(m => m.json()) },
-  '.yml': { id: 'json', load: () => import('@codemirror/lang-json').then(m => m.json()) },
+  '.rs': { id: 'rust', load: () => import('@codemirror/lang-rust').then(m => m.rust()) },
+  '.go': { id: 'go', load: () => import('@codemirror/lang-go').then(m => m.go()) },
+  '.toml': { id: 'toml', load: () => Promise.resolve(tomlLanguage) },
+  '.yaml': { id: 'yaml', load: () => Promise.resolve(yamlLanguage) },
+  '.yml': { id: 'yaml', load: () => Promise.resolve(yamlLanguage) },
 }
 
 export function languageIdForFilePath(filePath: string): string | null {

--- a/dashboard/src/components/ide/ide-explorer.ts
+++ b/dashboard/src/components/ide/ide-explorer.ts
@@ -317,6 +317,23 @@ function SourceHint(source: WorkspaceSource) {
   `
 }
 
+function fileIcon(node: FileTreeNode, expanded: boolean): string {
+  if (node.hasChildren) return expanded ? '📂' : '📁'
+  const dot = node.label.lastIndexOf('.')
+  const ext = dot >= 0 ? node.label.slice(dot) : ''
+  const ICONS: Readonly<Record<string, string>> = {
+    '.ts': '🟦', '.tsx': '🟦',
+    '.js': '🟨', '.jsx': '🟨',
+    '.py': '🐍',
+    '.ml': '🐫', '.mli': '🐫',
+    '.rs': '🦀', '.go': '🔵',
+    '.json': '📋', '.md': '📝',
+    '.html': '🌐', '.css': '🎨',
+    '.toml': '⚙️', '.yaml': '⚙️', '.yml': '⚙️',
+  }
+  return ICONS[ext] ?? '📄'
+}
+
 function TreeRow(node: FileTreeNode, expanded: boolean, selected: boolean, onClick: () => void) {
   const indent = node.depth * 12
   const chevron = node.hasChildren ? (expanded ? '▾' : '▸') : ''
@@ -342,7 +359,7 @@ function TreeRow(node: FileTreeNode, expanded: boolean, selected: boolean, onCli
       <span aria-hidden="true" style=${{ color: 'var(--color-fg-muted)', width: '12px', textAlign: 'center' }}>${chevron}</span>
       ${node.keeperId
         ? html`<${KeeperBadge} id=${node.keeperId} variant="sigil" size="sm" />`
-        : html`<span aria-hidden="true" style=${{ width: '14px', height: '14px' }} />`}
+        : html`<span aria-hidden="true" style=${{ width: '14px', height: '14px', textAlign: 'center', fontSize: '12px', lineHeight: '14px' }}>${fileIcon(node, expanded)}</span>`}
       <span class="ide-explorer-row-label">${node.label}</span>
       ${node.diff !== null
         ? html`<span style=${{ color: 'var(--color-fg-muted)', font: 'var(--fs-11)' }}>${node.diff}</span>`


### PR DESCRIPTION
## Summary
- 파일 트리 탐색기에 확장자별 이모지 아이콘 추가 (`.ts`→🟦, `.rs`→🦀 등)
- TOML/YAML 커스텀 StreamLanguage 파서 추가 (기존 JSON 폴백 교체)
- `@codemirror/lang-rust`, `@codemirror/lang-go` 패키지 추가로 Rust/Go 하이라이팅 지원

## Test plan
- [ ] `tsc --noEmit` 통과 (우리 변경에 의한 에러 0건, pre-existing 에러는 별도)
- [ ] 브라우저에서 `.ml`, `.rs`, `.go`, `.toml`, `.yaml` 파일 오픈 시 syntax highlighting 동작
- [ ] 파일 트리에서 확장자별 아이콘 표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)