### PR TITLE
feat(core): RFC-0059 Phase 2 PR-6 — Domain pool policy layer

### DIFF
--- a/lib/core/domain_pool.ml
+++ b/lib/core/domain_pool.ml
@@ -1,0 +1,37 @@
+type t = {
+  pool : Eio.Executor_pool.t;
+  domain_count : int;
+}
+
+let recommended_domain_count () =
+  max 2 (Domain.recommended_domain_count () - 1)
+
+let weight_io = 0.05
+let weight_cpu = 1.0
+
+let create ~sw ?domain_count dm =
+  let domain_count =
+    match domain_count with
+    | None -> recommended_domain_count ()
+    | Some n when n >= 1 -> n
+    | Some n ->
+        invalid_arg
+          (Printf.sprintf
+             "Domain_pool.create: domain_count must be >= 1, got %d" n)
+  in
+  let pool = Eio.Executor_pool.create ~sw ~domain_count dm in
+  { pool; domain_count }
+
+let domain_count t = t.domain_count
+
+let submit_io t f = Eio.Executor_pool.submit_exn t.pool ~weight:weight_io f
+
+let submit_cpu t f = Eio.Executor_pool.submit_exn t.pool ~weight:weight_cpu f
+
+let submit_io_async ~sw t f =
+  Eio.Executor_pool.submit_fork ~sw t.pool ~weight:weight_io f
+
+let submit_cpu_async ~sw t f =
+  Eio.Executor_pool.submit_fork ~sw t.pool ~weight:weight_cpu f
+
+let executor_pool t = t.pool

--- a/lib/core/domain_pool.mli
+++ b/lib/core/domain_pool.mli
@@ -1,0 +1,88 @@
+(** Domain_pool — masc-mcp policy layer over [Eio.Executor_pool].
+
+    Wraps [Eio.Executor_pool] with three pieces of policy that the raw
+    library leaves up to each caller:
+
+    {ol
+    {- A default [domain_count] that reserves one core for the Eio
+       scheduler driving HTTP / SSE / fiber dispatch on the main
+       domain.}
+    {- Named submit variants for IO-bound vs CPU-bound work, fixing
+       the [~weight] argument that [Eio.Executor_pool] requires per
+       call.  Centralising weight policy here keeps it consistent
+       across keeper, dashboard, and repo-sync callers.}
+    {- Async ([Promise]-returning) submit variants alongside blocking
+       ones, so callers don't have to remember which Eio entry point
+       to use for each shape.}}
+
+    PR-6 of RFC-0059 introduces this module as a primitive.  PR-7
+    (keeper actor migration) and PR-8 (repo sync async) consume it for
+    parallel actor dispatch and parallel git command execution.
+
+    [Executor_pool_ref] (global atomic holder + inline fallback) is
+    orthogonal: it serves dashboard compute that must work in tests
+    where no pool exists.  [Domain_pool] is for code paths that hold
+    an explicit pool handle. *)
+
+type t
+(** Opaque pool handle.  Carries the underlying [Eio.Executor_pool.t]
+    plus the resolved [domain_count] for telemetry. *)
+
+val recommended_domain_count : unit -> int
+(** [max 2 (Domain.recommended_domain_count () - 1)].
+
+    The [-1] reserves the original main domain for the Eio scheduler
+    so HTTP listeners, SSE drains, and fiber dispatch don't compete
+    with worker domains for OS-thread time.  The floor of [2] keeps
+    the default sensible on 1- or 2-core systems where the
+    recommendation can be [1]. *)
+
+val create :
+  sw:Eio.Switch.t ->
+  ?domain_count:int ->
+  _ Eio.Domain_manager.t ->
+  t
+(** [create ~sw ?domain_count dm] spawns worker domains via
+    [Eio.Executor_pool.create].
+
+    [domain_count] defaults to {!recommended_domain_count}.  Raises
+    [Invalid_argument] if an explicit value is [< 1].
+
+    The pool's lifetime is bound to [sw] — when [sw] finishes, all
+    worker domains and in-flight jobs are cancelled (per
+    [Eio.Executor_pool] semantics). *)
+
+val domain_count : t -> int
+(** Resolved worker count.  Matches the value passed to [create] (or
+    {!recommended_domain_count} when omitted). *)
+
+val submit_io : t -> (unit -> 'a) -> 'a
+(** Blocking submit for IO-bound work (HTTP calls, disk I/O, network
+    syscalls).
+
+    Uses [~weight:0.05], so each worker domain admits ~20
+    concurrently-running IO-bound jobs before queueing.  Re-raises
+    exceptions thrown by [f]. *)
+
+val submit_cpu : t -> (unit -> 'a) -> 'a
+(** Blocking submit for CPU-bound work (JSON encode/decode, hashing,
+    text similarity, embedding compute).
+
+    Uses [~weight:1.0], so each worker domain admits one CPU-bound
+    job at a time.  Re-raises exceptions thrown by [f]. *)
+
+val submit_io_async :
+  sw:Eio.Switch.t -> t -> (unit -> 'a) -> 'a Eio.Promise.or_exn
+(** Async variant of {!submit_io}.  Returns immediately with a
+    promise the caller awaits via [Eio.Promise.await_exn].  Cancelling
+    [sw] cancels the in-flight job. *)
+
+val submit_cpu_async :
+  sw:Eio.Switch.t -> t -> (unit -> 'a) -> 'a Eio.Promise.or_exn
+(** Async variant of {!submit_cpu}. *)
+
+val executor_pool : t -> Eio.Executor_pool.t
+(** Escape hatch for callers that need a non-default [~weight] (e.g.
+    a job that occupies half a core, [~weight:0.5]).  Prefer
+    {!submit_io} / {!submit_cpu} so the weight policy stays
+    centralised here. *)

--- a/lib/core/dune
+++ b/lib/core/dune
@@ -3,5 +3,5 @@
  (name masc_core)
  (public_name masc_mcp.masc_core)
  (wrapped false)
- (modules json_util safe_ops common validation circuit_breaker eio_guard executor_pool_ref masc_runtime_events provider_error text_similarity string_util list_util read_drop_reason actor_types actor_mailbox)
+ (modules json_util safe_ops common validation circuit_breaker eio_guard executor_pool_ref masc_runtime_events provider_error text_similarity string_util list_util read_drop_reason actor_types actor_mailbox domain_pool)
  (libraries yojson unix re re.pcre eio eio.unix time_compat fs_compat masc_log runtime_events))

--- a/test/dune
+++ b/test/dune
@@ -33,6 +33,7 @@
         test_keeper_turn_terminal_disposition_field
         test_attempt_state
         test_actor_mailbox
+        test_domain_pool
         test_sse test_graphql_api
         test_graphql_endpoint
         test_subscriptions test_session test_progress test_spawn
@@ -271,6 +272,7 @@
           test_keeper_turn_terminal_disposition_field
           test_attempt_state
           test_actor_mailbox
+          test_domain_pool
           test_sse test_graphql_api
           test_graphql_endpoint
           test_subscriptions test_session test_progress test_spawn

--- a/test/test_domain_pool.ml
+++ b/test/test_domain_pool.ml
@@ -1,0 +1,187 @@
+open Alcotest
+
+(** Unit tests for [Domain_pool] — RFC-0059 Phase 2 PR-6.
+
+    Each test runs inside [Eio_main.run] + [Eio.Switch.run] because
+    [Domain_pool.create] requires an active switch and a real
+    [Eio.Domain_manager.t] from [Eio.Stdenv].  Worker domains are torn
+    down when the switch finishes — every test is isolated. *)
+
+module D = Domain_pool
+
+(* ── recommended_domain_count ──────────────────────────── *)
+
+let test_recommended_domain_count_floor () =
+  let n = D.recommended_domain_count () in
+  check bool "floor of 2 holds even on 1-core systems" true (n >= 2)
+
+let test_recommended_domain_count_reserves_main () =
+  (* Sanity: on any host with >= 3 recommended domains we expect
+     [recommended_domain_count] to subtract one for the main fiber.
+     On a 1- or 2-core system the floor of 2 dominates and this
+     property reduces to [n >= 2], which the prior test covers. *)
+  let raw = Domain.recommended_domain_count () in
+  let ours = D.recommended_domain_count () in
+  if raw >= 3 then
+    check int "subtract one main domain" (raw - 1) ours
+  else
+    check bool "floor applies on small hosts" true (ours = 2)
+
+(* ── create ────────────────────────────────────────────── *)
+
+let test_create_default () =
+  Eio_main.run (fun env ->
+    Eio.Switch.run (fun sw ->
+      let dm = Eio.Stdenv.domain_mgr env in
+      let pool = D.create ~sw dm in
+      check int "default count matches recommended"
+        (D.recommended_domain_count ()) (D.domain_count pool)))
+
+let test_create_explicit () =
+  Eio_main.run (fun env ->
+    Eio.Switch.run (fun sw ->
+      let dm = Eio.Stdenv.domain_mgr env in
+      let pool = D.create ~sw ~domain_count:1 dm in
+      check int "explicit count honoured" 1 (D.domain_count pool)))
+
+let test_create_zero_rejected () =
+  Eio_main.run (fun env ->
+    Eio.Switch.run (fun sw ->
+      let dm = Eio.Stdenv.domain_mgr env in
+      check_raises "zero domain_count raises Invalid_argument"
+        (Invalid_argument
+           "Domain_pool.create: domain_count must be >= 1, got 0")
+        (fun () -> ignore (D.create ~sw ~domain_count:0 dm))))
+
+let test_create_negative_rejected () =
+  Eio_main.run (fun env ->
+    Eio.Switch.run (fun sw ->
+      let dm = Eio.Stdenv.domain_mgr env in
+      check_raises "negative domain_count raises Invalid_argument"
+        (Invalid_argument
+           "Domain_pool.create: domain_count must be >= 1, got -2")
+        (fun () -> ignore (D.create ~sw ~domain_count:(-2) dm))))
+
+(* ── submit ────────────────────────────────────────────── *)
+
+let test_submit_cpu_returns_value () =
+  Eio_main.run (fun env ->
+    Eio.Switch.run (fun sw ->
+      let dm = Eio.Stdenv.domain_mgr env in
+      let pool = D.create ~sw ~domain_count:1 dm in
+      let result = D.submit_cpu pool (fun () -> 1 + 2) in
+      check int "blocking cpu submit returns value" 3 result))
+
+let test_submit_io_returns_value () =
+  Eio_main.run (fun env ->
+    Eio.Switch.run (fun sw ->
+      let dm = Eio.Stdenv.domain_mgr env in
+      let pool = D.create ~sw ~domain_count:1 dm in
+      let result = D.submit_io pool (fun () -> "hello") in
+      check string "blocking io submit returns value" "hello" result))
+
+let test_submit_cpu_propagates_exception () =
+  Eio_main.run (fun env ->
+    Eio.Switch.run (fun sw ->
+      let dm = Eio.Stdenv.domain_mgr env in
+      let pool = D.create ~sw ~domain_count:1 dm in
+      check_raises "cpu submit re-raises handler exception"
+        (Failure "boom")
+        (fun () -> D.submit_cpu pool (fun () -> failwith "boom"))))
+
+(* ── async submit ──────────────────────────────────────── *)
+
+let test_submit_cpu_async_resolves () =
+  Eio_main.run (fun env ->
+    Eio.Switch.run (fun sw ->
+      let dm = Eio.Stdenv.domain_mgr env in
+      let pool = D.create ~sw ~domain_count:1 dm in
+      let promise = D.submit_cpu_async ~sw pool (fun () -> 42) in
+      check int "async cpu promise resolves" 42
+        (Eio.Promise.await_exn promise)))
+
+let test_submit_io_async_resolves () =
+  Eio_main.run (fun env ->
+    Eio.Switch.run (fun sw ->
+      let dm = Eio.Stdenv.domain_mgr env in
+      let pool = D.create ~sw ~domain_count:1 dm in
+      let promise = D.submit_io_async ~sw pool (fun () -> "ok") in
+      check string "async io promise resolves" "ok"
+        (Eio.Promise.await_exn promise)))
+
+let test_submit_async_propagates_exception () =
+  Eio_main.run (fun env ->
+    Eio.Switch.run (fun sw ->
+      let dm = Eio.Stdenv.domain_mgr env in
+      let pool = D.create ~sw ~domain_count:1 dm in
+      let promise = D.submit_cpu_async ~sw pool (fun () -> failwith "boom") in
+      check_raises "async submit propagates exception"
+        (Failure "boom")
+        (fun () -> ignore (Eio.Promise.await_exn promise))))
+
+(* ── multi-domain dispatch ──────────────────────────────── *)
+
+let test_jobs_run_on_worker_domains () =
+  (* The submitting fiber runs on the main Domain.  Jobs submitted to
+     a 2-domain pool must execute on a different Domain.  We don't
+     assert which worker (Eio chooses), only that it is not the
+     main. *)
+  Eio_main.run (fun env ->
+    Eio.Switch.run (fun sw ->
+      let dm = Eio.Stdenv.domain_mgr env in
+      let pool = D.create ~sw ~domain_count:2 dm in
+      let main_domain = (Domain.self () :> int) in
+      let worker_domain =
+        D.submit_cpu pool (fun () -> (Domain.self () :> int))
+      in
+      check bool "worker job runs off main domain" true
+        (worker_domain <> main_domain)))
+
+(* ── escape hatch ──────────────────────────────────────── *)
+
+let test_executor_pool_accessor () =
+  Eio_main.run (fun env ->
+    Eio.Switch.run (fun sw ->
+      let dm = Eio.Stdenv.domain_mgr env in
+      let pool = D.create ~sw ~domain_count:1 dm in
+      let raw = D.executor_pool pool in
+      let result =
+        Eio.Executor_pool.submit_exn raw ~weight:0.5 (fun () -> "via_raw")
+      in
+      check string "executor_pool exposes underlying pool" "via_raw" result))
+
+(* ── Suite ──────────────────────────────────────────────── *)
+
+let () =
+  Alcotest.run "Domain_pool" [
+    "recommended", [
+      test_case "floor 2" `Quick test_recommended_domain_count_floor;
+      test_case "reserves main" `Quick
+        test_recommended_domain_count_reserves_main;
+    ];
+    "create", [
+      test_case "default count" `Quick test_create_default;
+      test_case "explicit count" `Quick test_create_explicit;
+      test_case "zero rejected" `Quick test_create_zero_rejected;
+      test_case "negative rejected" `Quick test_create_negative_rejected;
+    ];
+    "submit_blocking", [
+      test_case "cpu returns value" `Quick test_submit_cpu_returns_value;
+      test_case "io returns value" `Quick test_submit_io_returns_value;
+      test_case "cpu propagates exn" `Quick
+        test_submit_cpu_propagates_exception;
+    ];
+    "submit_async", [
+      test_case "cpu promise resolves" `Quick test_submit_cpu_async_resolves;
+      test_case "io promise resolves" `Quick test_submit_io_async_resolves;
+      test_case "async propagates exn" `Quick
+        test_submit_async_propagates_exception;
+    ];
+    "multi_domain", [
+      test_case "jobs run off main domain" `Quick
+        test_jobs_run_on_worker_domains;
+    ];
+    "escape_hatch", [
+      test_case "executor_pool accessor" `Quick test_executor_pool_accessor;
+    ];
+  ]


### PR DESCRIPTION
## Summary

Thin wrapper over `Eio.Executor_pool` that owns three masc-mcp
policy decisions the raw library leaves up to each caller:

1. **Default `domain_count`** = `max 2 (Domain.recommended_domain_count () - 1)`. Reserves one core for the main Eio scheduler so HTTP / SSE / fiber dispatch don't compete with workers. Floor of 2 keeps 1- or 2-core hosts sensible.
2. **IO vs CPU `~weight`** — `submit_io` (`~weight:0.05`, ~20 concurrent IO jobs per domain) vs `submit_cpu` (`~weight:1.0`, one CPU job per domain). Centralised so call sites can't drift on weight values.
3. **Async (Promise) variants** alongside blocking ones — `submit_io_async` / `submit_cpu_async` return `Eio.Promise.or_exn`.

PR-6 introduces the primitive; PR-7 (keeper actor migration) and PR-8 (repo sync async) consume it later. No caller wiring in this PR.

## Why a facade?

`Eio.Executor_pool` is already idiomatic in masc-mcp (`server_runtime_bootstrap.ml:1736`). A facade buys:

- Single instrumentation point for PR-7 metrics (currently 0 instrumentation on Executor_pool calls)
- Drift prevention for `~weight` constants — masc-mcp's own anti-pattern catalog calls this out (CLAUDE.md "AI 코드 생성 안티패턴" §1, Hardcoded Scattered Defaults)
- Default-size policy (reserve main domain) the raw library can't express

`Executor_pool_ref` (global atomic holder + inline fallback for tests) stays — orthogonal to `Domain_pool` (explicit handle for code paths that own one).

## Test plan

- [x] `dune build --root . @check` green
- [x] `dune exec test/test_domain_pool.exe` 14/14 tests green:
  - `recommended_domain_count` floor of 2 + reserves main domain
  - `create` default / explicit / 0 rejected / negative rejected
  - blocking `submit_cpu`/`submit_io` return value + propagate exception
  - async `submit_cpu_async`/`submit_io_async` resolve + propagate exception
  - multi-domain: job runs on a non-main domain
  - `executor_pool` escape hatch returns underlying pool

## Files

- `lib/core/domain_pool.mli` (+92 LoC) — public API + docstrings
- `lib/core/domain_pool.ml` (+38 LoC) — implementation
- `lib/core/dune` — module added to (modules ...) list
- `test/test_domain_pool.ml` (+170 LoC) — Alcotest suite
- `test/dune` — test added to (names ...) and (modules ...)

Total: +315 / −1 LoC.

## Refs

- RFC-0059 §3.2 PR-6 (Domain Pool)
- Stacks on top of #14517 (PR-5 Actor primitives, merged)
- Next: PR-7 (Keeper actor migration) — uses both `Actor_mailbox` + `Domain_pool`

## RFC waiver

`RFC-WAIVED: PR-6 implements primitives within RFC-0059 Phase 2 §3.2; no protocol or credential subsystem touched.`

🤖 Generated with [Claude Code](https://claude.com/claude-code)