### PR TITLE
feat(cascade_decl): RFC-0058 Phase 2+3 — runtime adapter + hotpath snapshot

### DIFF
--- a/lib/cascade/cascade_catalog_runtime.ml
+++ b/lib/cascade/cascade_catalog_runtime.ml
@@ -729,6 +729,31 @@ let validate_path_result ?sw ?net ~config_path () =
             }
           in
           record_probe_metrics profile_snapshots;
+          (* RFC-0058 Phase 3: parallel declarative validation *)
+          (match Cascade_declarative_hotpath.try_load_declarative config_path with
+           | Some (Ok decl_snap) ->
+             let json_names =
+               List.map (fun (p : profile_build) -> p.name)
+                 profile_snapshots
+             in
+             let decl_names =
+               Cascade_declarative_hotpath.decl_snapshot_profile_names decl_snap
+             in
+             if json_names <> decl_names then
+               Log.Misc.warn
+                 "[CascadeDeclarative] profile name mismatch: \
+                  json=[%s] decl=[%s]"
+                 (String.concat ", " json_names)
+                 (String.concat ", " decl_names)
+             else
+               Log.Misc.info
+                 "[CascadeDeclarative] parallel validation OK, %d profiles"
+                 (List.length decl_names)
+           | Some (Error errs) ->
+             List.iter (fun e ->
+               Log.Misc.warn "[CascadeDeclarative] adapter error: %s"
+                 (Cascade_declarative_adapter.show_adapter_error e)) errs
+           | None -> ());
           if rejected_profiles = [] then
             Ok { snapshot; rejected_update = None }
           else

--- a/lib/cascade/cascade_catalog_runtime.mli
+++ b/lib/cascade/cascade_catalog_runtime.mli
@@ -23,7 +23,30 @@ type candidate_probe = {
   status : candidate_probe_status;
 }
 
-type snapshot
+type candidate_runtime = {
+  model_string : string;
+  provider_cfg : Llm_provider.Provider_config.t;
+}
+
+type profile_build = {
+  name : string;
+  weighted_entries : Cascade_config_loader.weighted_entry list;
+  inference_params : Cascade_config_loader.inference_params;
+  api_key_env_overrides : (string * string) list;
+  strategy : Cascade_strategy.t;
+  ollama_max_concurrent : int option;
+  cli_max_concurrent : int option;
+  candidates : candidate_runtime list;
+  probes : candidate_probe list;
+}
+
+type snapshot = {
+  source_path : string;
+  mtime : float;
+  validated_at : float;
+  profiles : profile_build list;
+}
+
 type rejection
 
 type state =

--- a/lib/cascade/cascade_declarative_hotpath.ml
+++ b/lib/cascade/cascade_declarative_hotpath.ml
@@ -1,0 +1,156 @@
+(** Declarative catalog → runtime snapshot conversion (RFC-0058 Phase 3).
+
+    Converts an {!adapted_catalog} into a lightweight declarative snapshot
+    that {!Cascade_catalog_runtime} can compare against its own snapshot for
+    parallel validation.
+
+    This module deliberately does NOT depend on {!Cascade_catalog_runtime}
+    to avoid a dependency cycle.  It defines its own mirror types and
+    {!Cascade_catalog_runtime} bridges them at the call site.
+
+    Phase 3 is a **parallel validation path**: the hotpath still reads
+    from the legacy materialized JSON. This module proves the declarative
+    config can produce valid runtime types. Phase 5 will switch the hotpath.
+
+    @stability Internal *)
+
+open Cascade_declarative_adapter
+module Loader = Cascade_config_loader
+
+(* --- Lightweight mirror types (no Cascade_catalog_runtime dependency) --- *)
+
+type candidate = {
+  model_string : string;
+  provider_cfg : Llm_provider.Provider_config.t;
+}
+
+type profile = {
+  name : string;
+  weighted_entries : Loader.weighted_entry list;
+  inference_params : Loader.inference_params;
+  strategy : Cascade_strategy.t;
+  ollama_max_concurrent : int option;
+  cli_max_concurrent : int option;
+  candidates : candidate list;
+}
+
+type decl_snapshot = {
+  source_path : string;
+  mtime : float;
+  validated_at : float;
+  profiles : profile list;
+}
+
+(* --- Low-level helpers --- *)
+
+let provider_config_to_model_string (cfg : Llm_provider.Provider_config.t) :
+    string =
+  Printf.sprintf "%s:%s"
+    (Llm_provider.Provider_kind.to_string cfg.Llm_provider.Provider_config.kind)
+    cfg.Llm_provider.Provider_config.model_id
+
+(* --- Synthetic weighted_entry reconstruction --- *)
+
+let make_weighted_entry (cfg : Llm_provider.Provider_config.t) :
+    Loader.weighted_entry =
+  {
+    Loader.model = provider_config_to_model_string cfg;
+    weight = 1;
+    supports_tool_choice = None;
+    secondary = None;
+    secondary_supports_tool_choice = None;
+  }
+
+(* --- Inference params extraction --- *)
+
+let extract_inference_params (configs : Llm_provider.Provider_config.t list) :
+    Loader.inference_params =
+  match configs with
+  | [] ->
+    { Loader.temperature = None; max_tokens = None; keep_alive = None;
+      num_ctx = None; thinking_enabled = None; thinking_budget = None }
+  | first :: _ ->
+    { Loader.temperature = first.Llm_provider.Provider_config.temperature;
+      max_tokens = first.Llm_provider.Provider_config.max_tokens;
+      keep_alive = None;
+      num_ctx = None;
+      thinking_enabled = first.Llm_provider.Provider_config.enable_thinking;
+      thinking_budget = first.Llm_provider.Provider_config.thinking_budget }
+
+(* --- candidate from Provider_config.t --- *)
+
+let make_candidate (cfg : Llm_provider.Provider_config.t) : candidate =
+  { model_string = provider_config_to_model_string cfg;
+    provider_cfg = cfg }
+
+(* --- Profile conversion --- *)
+
+let adapted_profile_to_profile (ap : adapted_profile) : profile option =
+  match ap.provider_configs with
+  | [] -> None
+  | configs ->
+    let weighted_entries = List.map make_weighted_entry configs in
+    let inference_params = extract_inference_params configs in
+    let candidates = List.map make_candidate configs in
+    Some {
+      name = ap.name;
+      weighted_entries;
+      inference_params;
+      strategy = ap.strategy;
+      ollama_max_concurrent = ap.ollama_max_concurrent;
+      cli_max_concurrent = ap.cli_max_concurrent;
+      candidates;
+    }
+
+(* --- Catalog conversion --- *)
+
+let adapted_catalog_to_snapshot ~source_path (ac : adapted_catalog) :
+    decl_snapshot option =
+  let profiles =
+    List.filter_map adapted_profile_to_profile ac.profiles
+  in
+  match profiles with
+  | [] -> None
+  | _ ->
+    let stat =
+      try Unix.stat source_path
+      with Unix.Unix_error _ ->
+        { Unix.st_dev = 0; st_ino = 0; st_kind = S_REG;
+          st_perm = 0o644; st_nlink = 1; st_uid = 0; st_gid = 0;
+          st_rdev = 0; st_size = 0; st_atime = 0.0; st_mtime = 0.0;
+          st_ctime = 0.0 }
+    in
+    Some {
+      source_path;
+      mtime = stat.Unix.st_mtime;
+      validated_at = Unix.gettimeofday ();
+      profiles;
+    }
+
+(* --- TOML loading --- *)
+
+let try_load_declarative (config_path : string) :
+    (decl_snapshot, adapter_error list) result option =
+  match Cascade_declarative_parser.parse_file config_path with
+  | Error _ -> None  (* not a 5-layer TOML *)
+  | Ok cfg ->
+    let catalog = adapt_config cfg in
+    match adapted_catalog_to_snapshot ~source_path:config_path catalog with
+    | Some snapshot ->
+      if List.length catalog.errors > 0 then
+        Some (Error catalog.errors)
+      else
+        Some (Ok snapshot)
+    | None ->
+      Some (Error catalog.errors)
+
+(* --- Route bindings --- *)
+
+let declarative_route_bindings (ac : adapted_catalog) :
+    (string * string) list =
+  ac.routes
+
+(* --- Snapshot introspection (for parallel validation) --- *)
+
+let decl_snapshot_profile_names (snap : decl_snapshot) : string list =
+  List.map (fun (p : profile) -> p.name) snap.profiles

--- a/lib/cascade/cascade_declarative_hotpath.mli
+++ b/lib/cascade/cascade_declarative_hotpath.mli
@@ -1,0 +1,86 @@
+(** Declarative catalog → runtime snapshot conversion (RFC-0058 Phase 3).
+
+    Converts an {!Cascade_declarative_adapter.adapted_catalog} into a
+    lightweight {!decl_snapshot} that can be compared against the legacy
+    JSON hotpath snapshot for parallel validation.
+
+    This module does NOT depend on {!Cascade_catalog_runtime} to avoid
+    a dependency cycle.  Mirror types are defined locally and the runtime
+    module bridges them at the call site.
+
+    @stability Internal *)
+
+(** {1 Mirror types} *)
+
+type candidate = {
+  model_string : string;
+  provider_cfg : Llm_provider.Provider_config.t;
+}
+
+type profile = {
+  name : string;
+  weighted_entries : Cascade_config_loader.weighted_entry list;
+  inference_params : Cascade_config_loader.inference_params;
+  strategy : Cascade_strategy.t;
+  ollama_max_concurrent : int option;
+  cli_max_concurrent : int option;
+  candidates : candidate list;
+}
+
+type decl_snapshot = {
+  source_path : string;
+  mtime : float;
+  validated_at : float;
+  profiles : profile list;
+}
+
+(** {1 Low-level helpers} *)
+
+val provider_config_to_model_string :
+  Llm_provider.Provider_config.t -> string
+(** Reconstruct a "prefix:model_id" string from a resolved provider config.
+    The result is parseable by [Cascade_config.parse_model_string] and
+    matches the format stored in {!Cascade_config_loader.weighted_entry.model}. *)
+
+(** {1 Profile conversion} *)
+
+val adapted_profile_to_profile :
+  Cascade_declarative_adapter.adapted_profile ->
+  profile option
+(** [None] when [provider_configs] is empty (invalid profile). *)
+
+(** {1 Catalog conversion} *)
+
+val adapted_catalog_to_snapshot :
+  source_path:string ->
+  Cascade_declarative_adapter.adapted_catalog ->
+  decl_snapshot option
+(** [None] when [profiles] is empty or all profiles fail conversion.
+    Errors in the adapted catalog are logged but do not prevent snapshot
+    creation for the valid subset. *)
+
+(** {1 TOML loading} *)
+
+val try_load_declarative :
+  string ->
+  (decl_snapshot,
+    Cascade_declarative_adapter.adapter_error list)
+  result option
+(** [try_load_declarative config_path] attempts to parse a 5-layer TOML
+    and convert it to a snapshot.
+
+    Returns:
+    - [Some (Ok snapshot)] — 5-layer TOML found and fully converted
+    - [Some (Error errors)] — 5-layer TOML found but conversion failed
+    - [None] — not a 5-layer TOML (parse failed) *)
+
+(** {1 Route bindings} *)
+
+val declarative_route_bindings :
+  Cascade_declarative_adapter.adapted_catalog ->
+  (string * string) list
+(** Extract [(route_name, profile_name)] pairs from the adapted catalog. *)
+
+val decl_snapshot_profile_names :
+  decl_snapshot -> string list
+(** Extract profile names from a declarative snapshot for comparison. *)

--- a/lib/dune
+++ b/lib/dune
@@ -190,6 +190,7 @@
   lsp_message_router
   lsp_overlay_provider
   server_ide_lsp_proxy
+  cascade_declarative_hotpath
   )
  (libraries
    mcp_protocol

--- a/test/dune
+++ b/test/dune
@@ -222,6 +222,7 @@
         test_cascade_declarative_parser
         test_cascade_declarative_validator
         test_cascade_declarative_adapter
+        test_cascade_declarative_hotpath
         test_doctor_dispatch
         test_disk_hygiene_script
         test_run_local_script
@@ -462,6 +463,7 @@
           test_cascade_declarative_parser
           test_cascade_declarative_validator
           test_cascade_declarative_adapter
+          test_cascade_declarative_hotpath
           test_doctor_dispatch
           test_disk_hygiene_script
           test_run_local_script

--- a/test/test_cascade_declarative_hotpath.ml
+++ b/test/test_cascade_declarative_hotpath.ml
@@ -1,0 +1,267 @@
+(** RFC-0058 Phase 3: Declarative hotpath unit tests.
+
+    Tests the conversion of {!Adapter.adapted_catalog} into
+    {!Hotpath.decl_snapshot} for parallel validation against the legacy
+    JSON hotpath.
+
+    Uses the hotpath's own mirror types, NOT {!Cascade_catalog_runtime}
+    types, to stay consistent with the dependency-cycle-free design.
+
+    @stability Internal *)
+
+open Alcotest
+open Cascade_declarative_types
+open Cascade_declarative_parser
+
+module Adapter = Masc_mcp.Cascade_declarative_adapter
+module Hotpath = Masc_mcp.Cascade_declarative_hotpath
+module Cascade_strategy = Masc_mcp.Cascade_strategy
+
+(* --- Helpers --- *)
+
+let adapt_toml (toml : string) : Adapter.adapted_catalog =
+  match parse_string toml with
+  | Ok cfg -> Adapter.adapt_config cfg
+  | Error (errs : parse_error list) ->
+    failwith
+      (Printf.sprintf "parse failed: %s"
+         (String.concat "; "
+            (List.map (fun (e : parse_error) ->
+              Printf.sprintf "%s: %s" e.path e.message) errs)))
+
+let no_errors (errs : Adapter.adapter_error list) =
+  check int "no errors" 0 (List.length errs)
+
+let get_snapshot (toml : string) : Hotpath.decl_snapshot =
+  let catalog = adapt_toml toml in
+  no_errors catalog.errors;
+  match Hotpath.adapted_catalog_to_snapshot ~source_path:"/test" catalog with
+  | None -> failwith "expected Some snapshot, got None"
+  | Some snapshot -> snapshot
+
+let find_profile (snapshot : Hotpath.decl_snapshot) (name : string) :
+    Hotpath.profile =
+  List.find
+    (fun (p : Hotpath.profile) -> p.Hotpath.name = name)
+    snapshot.Hotpath.profiles
+
+(* --- TOML fixture --- *)
+
+let valid_toml = {|
+[providers.claude_code]
+protocol = "anthropic-cli"
+command = "claude"
+
+[providers.ollama]
+protocol = "ollama-http"
+endpoint = "http://localhost:11434"
+
+[models.haiku]
+max-context = 200000
+api-name = "claude-haiku-4-5-20251001"
+tools-support = true
+
+[models.sonnet]
+max-context = 200000
+api-name = "claude-sonnet-4-6"
+tools-support = true
+
+[models.qwen3]
+max-context = 32768
+api-name = "qwen3:8b"
+tools-support = true
+
+[claude_code.haiku]
+is-default = true
+max-concurrent = 3
+
+[claude_code.sonnet]
+max-concurrent = 2
+
+[claude_code.haiku.for-tool-rerank]
+max-input = 4096
+
+[ollama.qwen3]
+
+[tier.rerank]
+members = ["claude_code.haiku.for-tool-rerank"]
+strategy = "failover"
+
+[tier.primary]
+members = ["claude_code.sonnet", "claude_code.haiku"]
+strategy = "failover"
+
+[tier.local]
+members = ["ollama.qwen3"]
+strategy = "failover"
+
+[tier-group.big-three]
+tiers = ["primary", "local"]
+strategy = "priority_tier"
+
+[routes.default]
+target = "tier-group.big-three"
+
+[system.governance]
+target = "claude_code.haiku.for-tool-rerank"
+|}
+
+(* --- Tests: snapshot conversion --- *)
+
+let test_snapshot_basic () =
+  let snapshot = get_snapshot valid_toml in
+  check bool "has profiles" true (List.length snapshot.Hotpath.profiles > 0);
+  check string "source_path" "/test" snapshot.Hotpath.source_path;
+  check bool "validated_at > 0" true (snapshot.Hotpath.validated_at > 0.0)
+
+let test_profile_names () =
+  let snapshot = get_snapshot valid_toml in
+  let names =
+    List.map
+      (fun (p : Hotpath.profile) -> p.Hotpath.name)
+      snapshot.Hotpath.profiles
+  in
+  check bool "has tier.rerank" true (List.mem "tier.rerank" names);
+  check bool "has tier.primary" true (List.mem "tier.primary" names);
+  check bool "has tier.local" true (List.mem "tier.local" names);
+  check bool "has tier-group.big-three" true
+    (List.mem "tier-group.big-three" names)
+
+let test_candidates () =
+  let snapshot = get_snapshot valid_toml in
+  let rerank = find_profile snapshot "tier.rerank" in
+  check int "rerank has 1 candidate" 1
+    (List.length rerank.Hotpath.candidates);
+  let big_three = find_profile snapshot "tier-group.big-three" in
+  check int "big-three has 3 candidates" 3
+    (List.length big_three.Hotpath.candidates)
+
+let test_model_string_format () =
+  let snapshot = get_snapshot valid_toml in
+  let local = find_profile snapshot "tier.local" in
+  let candidate = List.hd local.Hotpath.candidates in
+  check bool "model_string contains colon" true
+    (String.contains candidate.Hotpath.model_string ':')
+
+let test_weighted_entries_count () =
+  let snapshot = get_snapshot valid_toml in
+  List.iter
+    (fun (p : Hotpath.profile) ->
+      check int
+        ("candidates = weighted_entries for " ^ p.Hotpath.name)
+        (List.length p.Hotpath.candidates)
+        (List.length p.Hotpath.weighted_entries))
+    snapshot.Hotpath.profiles
+
+let test_strategy_preserved () =
+  let snapshot = get_snapshot valid_toml in
+  let rerank = find_profile snapshot "tier.rerank" in
+  let big_three = find_profile snapshot "tier-group.big-three" in
+  check string "rerank strategy" "failover"
+    (Cascade_strategy.kind_to_string
+       rerank.Hotpath.strategy.Cascade_strategy.kind);
+  check string "big-three strategy" "priority_tier"
+    (Cascade_strategy.kind_to_string
+       big_three.Hotpath.strategy.Cascade_strategy.kind)
+
+let test_probes_field_absent () =
+  (* Mirror type has no probes field — this test verifies the type shape *)
+  let snapshot = get_snapshot valid_toml in
+  check bool "has profiles" true (List.length snapshot.Hotpath.profiles > 0)
+
+let test_ollama_max_concurrent () =
+  let snapshot = get_snapshot valid_toml in
+  let local = find_profile snapshot "tier.local" in
+  check bool "ollama_max_concurrent is None" true
+    (local.Hotpath.ollama_max_concurrent = None)
+
+(* --- Tests: edge cases --- *)
+
+let test_empty_catalog () =
+  let catalog =
+    {
+      Adapter.profiles = [];
+      routes = [];
+      system_targets = [];
+      default_profile = None;
+      errors = [];
+    }
+  in
+  let result =
+    Hotpath.adapted_catalog_to_snapshot ~source_path:"/test" catalog
+  in
+  check bool "empty catalog -> None" true (result = None)
+
+let test_errors_catalog_snapshot () =
+  let toml = {|
+[providers.claude_code]
+protocol = "anthropic-cli"
+command = "claude"
+
+[models.haiku]
+max-context = 200000
+api-name = "claude-haiku-4-5-20251001"
+tools-support = true
+
+[claude_code.haiku]
+is-default = true
+
+[bad-provider.haiku]
+is-default = true
+
+[tier.primary]
+members = ["claude_code.haiku"]
+strategy = "failover"
+|} in
+  let catalog = adapt_toml toml in
+  check bool "has errors" true (List.length catalog.errors > 0);
+  let snapshot =
+    Hotpath.adapted_catalog_to_snapshot ~source_path:"/test" catalog
+  in
+  (* Valid tier.primary should still produce a snapshot even with errors *)
+  check bool "snapshot produced despite errors" true (snapshot <> None)
+
+(* --- Tests: route bindings --- *)
+
+let test_route_bindings () =
+  let catalog = adapt_toml valid_toml in
+  let bindings = Hotpath.declarative_route_bindings catalog in
+  check bool "has routes" true (List.length bindings > 0);
+  let route_names = List.map fst bindings in
+  check bool "has 'default' route" true (List.mem "default" route_names)
+
+(* --- Tests: snapshot introspection --- *)
+
+let test_decl_snapshot_profile_names () =
+  let snapshot = get_snapshot valid_toml in
+  let names = Hotpath.decl_snapshot_profile_names snapshot in
+  check int "4 profiles" 4 (List.length names);
+  check bool "has tier.rerank" true (List.mem "tier.rerank" names)
+
+(* --- Test suite --- *)
+
+let () =
+  run
+    "RFC-0058 Phase 3: Declarative Hotpath"
+    [
+      "snapshot",
+      [
+        test_case "basic conversion" `Quick test_snapshot_basic;
+        test_case "profile names" `Quick test_profile_names;
+        test_case "candidates" `Quick test_candidates;
+        test_case "model_string format" `Quick test_model_string_format;
+        test_case "weighted_entries count" `Quick test_weighted_entries_count;
+        test_case "strategy preserved" `Quick test_strategy_preserved;
+        test_case "probes field absent" `Quick test_probes_field_absent;
+        test_case "ollama_max_concurrent" `Quick test_ollama_max_concurrent;
+      ];
+      "edge_cases",
+      [
+        test_case "empty catalog -> None" `Quick test_empty_catalog;
+        test_case "errors catalog snapshot" `Quick test_errors_catalog_snapshot;
+      ];
+      "routes",
+      [ test_case "route bindings" `Quick test_route_bindings ];
+      "introspection",
+      [ test_case "decl_snapshot_profile_names" `Quick test_decl_snapshot_profile_names ];
+    ]


### PR DESCRIPTION
## Summary

- **Phase 2**: Runtime adapter converting 5-layer TOML parsed config into `adapted_catalog` with resolved `Provider_config.t` entries, strategy mapping, and error accumulation
- **Phase 3**: Hotpath snapshot conversion (`adapted_catalog` → `decl_snapshot`) with mirror types for dependency-cycle-free parallel validation against the legacy JSON hotpath

### Key design decisions

- **Mirror types pattern**: `cascade_declarative_hotpath` defines its own `decl_snapshot`/`profile`/`candidate` types instead of depending on `Cascade_catalog_runtime`, breaking the dependency cycle
- **Unidirectional dependency**: `runtime → hotpath` only; hotpath has zero knowledge of runtime types
- **Parallel validation (Strangler Fig)**: Legacy JSON hotpath remains the production path; declarative path runs alongside for validation, logging profile name mismatches as warnings

### Files changed

| File | Change |
|------|--------|
| `lib/cascade/cascade_declarative_hotpath.ml` | New — mirror types + snapshot conversion |
| `lib/cascade/cascade_declarative_hotpath.mli` | New — public interface |
| `lib/cascade/cascade_declarative_adapter.ml` | Phase 2 — runtime adapter |
| `lib/cascade/cascade_declarative_adapter.mli` | Phase 2 — adapter interface |
| `lib/cascade/cascade_catalog_runtime.ml` | Modified — parallel validation wiring (~25 LOC) |
| `lib/cascade/cascade_catalog_runtime.mli` | Modified — expose snapshot/profile_build types |
| `lib/dune` | Modified — add hotpath to private_modules |
| `test/test_cascade_declarative_hotpath.ml` | New — 12 test cases |
| `test/test_cascade_declarative_adapter.ml` | Phase 2 — 17 test cases |

## Test plan

- [x] `dune build --root .` compiles clean
- [x] Phase 3 tests (12) pass: snapshot conversion, profile names, candidates, model_string format, weighted_entries, strategy, edge cases, route bindings, introspection
- [x] Phase 2 tests (17) pass (no regression)
- [x] Parallel validation wiring logs OK on existing flat TOML (graceful `None` path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)