### PR TITLE
fix(ide): suppress LSP WebSocket race condition on rapid mount/unmount

### DIFF
--- a/dashboard/src/components/ide/ide-lsp-client.ts
+++ b/dashboard/src/components/ide/ide-lsp-client.ts
@@ -222,6 +222,7 @@ class LspConnection {
     this.ws = ws
 
     ws.onopen = () => {
+      if (this.disposed) { ws.close(); return }
       console.log('[LSP] WebSocket connected')
       this.initialize()
     }
@@ -313,7 +314,9 @@ class LspConnection {
       this.initialized = true
       console.log('[LSP] initialized')
     } catch (err) {
-      console.error('[LSP] initialize failed:', err)
+      if (!this.disposed) {
+        console.error('[LSP] initialize failed:', err)
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- `ws.onopen` 콜백에 `disposed` 가드 추가 — dispose 이후 onopen이 발화하면 즉시 close 후 return
- `initialize()` catch 블록에서 disposed 상태일 때 에러 로그 억제

## Problem
IDE 에디터 컴포넌트가 빠르게 mount/unmount를 반복할 때, WebSocket onopen 콜백이 `dispose()` 이후에 비동기로 발화됨. 이때 `initialize()` 내부의 `sendRequest()`가 이미 reject된 pending promise를 만나 `Error: Connection disposed` 콘솔 에러를 뿜음.

## Test plan
- [x] `tsc --noEmit` 통과 (ide-lsp-client.ts 관련 에러 0건)
- [ ] 브라우저에서 IDE 탭 빠르게 전환 시 `[LSP] initialize failed: Error: Connection disposed` 더 이상 발생하지 않는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)