### PR TITLE
feat(ide): CodeLens click to annotation detail popover

### DIFF
--- a/dashboard/src/components/ide/ide-editor.ts
+++ b/dashboard/src/components/ide/ide-editor.ts
@@ -23,7 +23,7 @@ import {
   internalDocumentSync,
   syntaxHighlightExt,
 } from './ide-editor-extensions'
-import { lspExtension } from './ide-lsp-client'
+import { lspExtension, getSelectedAnnotation, clearSelectedAnnotation, type SelectedAnnotation } from './ide-lsp-client'
 import { SplitDiffView, UnifiedDiffView } from './ide-diff-view'
 import { KeeperBadge } from '../keeper-badge'
 
@@ -465,6 +465,8 @@ function CodeMirrorEditor({
   const containerRef = useRef<HTMLElement>(null)
   const editorRef = useRef<EditorView | null>(null)
   const [ready, setReady] = useState(false)
+  const [selectedAnn, setSelectedAnn] = useState<SelectedAnnotation | null>(null)
+  const prevAnnRef = useRef<SelectedAnnotation | null>(null)
 
   const document = documentStore.document()
   const ownership = ownershipStore.ownership()
@@ -491,6 +493,13 @@ function CodeMirrorEditor({
           syntaxHighlightExt(),
           lang,
           lspExtension({ filePath: mountDocument.file_path }),
+          EditorView.updateListener.of((update) => {
+            const sel = getSelectedAnnotation(update.view)
+            if (sel !== prevAnnRef.current) {
+              prevAnnRef.current = sel
+              setSelectedAnn(sel)
+            }
+          }),
           ...(onKeeperLineSelect
             ? [keeperLineSelectExt(() => ownershipStore.ownership(), onKeeperLineSelect)]
             : []),
@@ -550,6 +559,17 @@ function CodeMirrorEditor({
     <div class="ide-codemirror-shell" data-view=${showBlame ? 'blame' : 'source'}>
       ${showBlame ? BlameTimeline(ownership, keepers) : null}
       <div ref=${containerRef} class="ide-codemirror-host" />
+      ${selectedAnn && editorRef.current ? AnnotationPopover({
+        annotation: selectedAnn,
+        view: editorRef.current,
+        onClose: () => {
+          if (editorRef.current) {
+            clearSelectedAnnotation(editorRef.current)
+            prevAnnRef.current = null
+            setSelectedAnn(null)
+          }
+        },
+      }) : null}
     </div>
   `
 }
@@ -711,4 +731,119 @@ function layerSummary(kind: IdeLayerKind, latestEdit: number | null, keepers: Re
   if (kind === 'keeper-trace') return 'stitched trace'
   if (kind === 'explode') return 'exclusive ghost view'
   return ''
+}
+
+// ── Annotation Popover ────────────────────────────────────────────
+
+const KIND_LABEL: Record<string, string> = {
+  Comment: 'comment',
+  Decision: 'decision',
+  Question: 'question',
+  Bookmark: 'bookmark',
+}
+
+const KIND_COLOR: Record<string, string> = {
+  Comment: 'var(--color-accent-fg)',
+  Decision: 'var(--color-success-fg)',
+  Question: 'var(--color-fg-warning)',
+  Bookmark: 'var(--color-fg-muted)',
+}
+
+function AnnotationPopover({
+  annotation,
+  view,
+  onClose,
+}: {
+  readonly annotation: SelectedAnnotation
+  readonly view: EditorView
+  readonly onClose: () => void
+}) {
+  const line = annotation.line_start
+  const lineInfo = line >= 1 && line <= view.state.doc.lines
+    ? view.state.doc.line(line)
+    : null
+  const coords = lineInfo
+    ? view.coordsAtPos(lineInfo.from)
+    : null
+
+  if (!coords) return null
+
+  const shellRect = view.dom.closest('.ide-codemirror-shell')?.getBoundingClientRect()
+  if (!shellRect) return null
+
+  const top = coords.bottom - shellRect.top + 4
+  const left = Math.max(8, coords.left - shellRect.left)
+
+  return html`
+    <div
+      class="ide-annotation-popover"
+      role="dialog"
+      aria-label="Annotation detail"
+      style=${{
+        position: 'absolute',
+        top: top + 'px',
+        left: left + 'px',
+        zIndex: 40,
+        minWidth: '240px',
+        maxWidth: '380px',
+        background: 'var(--color-bg-elevated)',
+        border: '1px solid var(--color-border-default)',
+        borderRadius: 'var(--r-2)',
+        boxShadow: '0 4px 16px rgba(0,0,0,0.12)',
+        padding: 'var(--sp-3)',
+        fontFamily: 'var(--font-sans)',
+        fontSize: '13px',
+        lineHeight: 1.5,
+      }}
+    >
+      <div style=${{ display: 'flex', alignItems: 'center', gap: 'var(--sp-2)', marginBottom: 'var(--sp-2)' }}>
+        <span style=${{
+          padding: '1px 6px',
+          borderRadius: 'var(--r-1)',
+          fontSize: '11px',
+          fontWeight: 600,
+          textTransform: 'uppercase',
+          color: KIND_COLOR[annotation.kind] ?? 'var(--color-fg-muted)',
+          background: 'var(--color-bg-muted)',
+        }}>${KIND_LABEL[annotation.kind] ?? annotation.kind}</span>
+        <span style=${{ color: 'var(--color-fg-muted)', fontSize: '11px', flex: 1 }}>
+          L${annotation.line_start}${annotation.line_start !== annotation.line_end ? `-${annotation.line_end}` : ''}
+        </span>
+        <button
+          type="button"
+          aria-label="Close annotation"
+          onClick=${onClose}
+          style=${{
+            background: 'none',
+            border: 'none',
+            color: 'var(--color-fg-muted)',
+            cursor: 'pointer',
+            fontSize: '14px',
+            lineHeight: 1,
+            padding: '2px 4px',
+          }}
+        >&times;</button>
+      </div>
+      <div style=${{ color: 'var(--color-fg-primary)', whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}>
+        ${annotation.content}
+      </div>
+      <div style=${{ display: 'flex', gap: 'var(--sp-2)', marginTop: 'var(--sp-2)', flexWrap: 'wrap' }}>
+        ${annotation.keeper_id ? html`
+          <span style=${{ color: 'var(--color-fg-muted)', fontSize: '11px' }}>
+            keeper: <strong>${annotation.keeper_id}</strong>
+          </span>
+        ` : null}
+        ${annotation.goal_id ? html`
+          <span style=${{ color: 'var(--color-fg-muted)', fontSize: '11px' }}>
+            goal: ${annotation.goal_id}
+          </span>
+        ` : null}
+        ${annotation.task_id ? html`
+          <span style=${{ color: 'var(--color-fg-muted)', fontSize: '11px' }}>
+            task: ${annotation.task_id}
+          </span>
+        ` : null}
+      </div>
+    </div>
+  `
 }

--- a/dashboard/src/components/ide/ide-lsp-client.ts
+++ b/dashboard/src/components/ide/ide-lsp-client.ts
@@ -47,11 +47,24 @@ export interface LspDiagnostic {
   message: string
 }
 
+export interface SelectedAnnotation {
+  readonly id: string
+  readonly keeper_id: string
+  readonly kind: string
+  readonly content: string
+  readonly goal_id: string | null
+  readonly task_id: string | null
+  readonly file_path: string
+  readonly line_start: number
+  readonly line_end: number
+}
+
 // ── State Effects ────────────────────────────────────────────────
 
 const setCodeLenses = StateEffect.define<ReadonlyMap<number, LspCodeLens[]>>()
 const setInlayHints = StateEffect.define<ReadonlyMap<number, LspInlayHint[]>>()
 const setDiagnostics = StateEffect.define<ReadonlyMap<number, LspDiagnostic[]>>()
+const setSelectedAnnotation = StateEffect.define<SelectedAnnotation | null>()
 
 // ── State Fields ─────────────────────────────────────────────────
 
@@ -85,6 +98,16 @@ const diagnosticField = StateField.define<ReadonlyMap<number, LspDiagnostic[]>>(
   },
 })
 
+const selectedAnnotationField = StateField.define<SelectedAnnotation | null>({
+  create() { return null },
+  update(state, tr) {
+    for (const eff of tr.effects) {
+      if (eff.is(setSelectedAnnotation)) return eff.value
+    }
+    return state
+  },
+})
+
 // ── CodeLens Gutter ──────────────────────────────────────────────
 
 class CodeLensMarker extends GutterMarker {
@@ -107,7 +130,11 @@ class CodeLensMarker extends GutterMarker {
         el.addEventListener('click', (e) => {
           e.preventDefault()
           e.stopPropagation()
-          console.log('[LSP] annotation:', lens.command!.arguments)
+          const detail = lens.command!.arguments![0] as SelectedAnnotation
+          el.dispatchEvent(new CustomEvent('masc-annotation-select', {
+            bubbles: true,
+            detail,
+          }))
         })
       }
       container.appendChild(el)
@@ -452,6 +479,7 @@ const lspViewPlugin = ViewPlugin.fromClass(
     private conn: LspConnection
     private filePath: string
     private refreshTimer: ReturnType<typeof setTimeout> | null = null
+    private onAnnotationSelect: ((e: Event) => void) | null = null
 
     constructor(private readonly view: EditorView) {
       const filePath = view.state.field(lspConfigField).filePath
@@ -461,6 +489,11 @@ const lspViewPlugin = ViewPlugin.fromClass(
         (err) => console.error('[LSP] connection error:', err),
       )
       this.conn.connect()
+      this.onAnnotationSelect = (e: Event) => {
+        const detail = (e as CustomEvent).detail as SelectedAnnotation
+        this.dispatch(setSelectedAnnotation.of(detail))
+      }
+      this.view.dom.addEventListener('masc-annotation-select', this.onAnnotationSelect)
       this.scheduleRefresh()
     }
 
@@ -500,6 +533,9 @@ const lspViewPlugin = ViewPlugin.fromClass(
 
     destroy() {
       if (this.refreshTimer) clearTimeout(this.refreshTimer)
+      if (this.onAnnotationSelect) {
+        this.view.dom.removeEventListener('masc-annotation-select', this.onAnnotationSelect)
+      }
       this.conn.notifyDidClose(this.filePath)
       this.conn.dispose()
     }
@@ -524,6 +560,7 @@ export function lspExtension(opts: LspExtensionOpts): Extension {
     codeLensField,
     inlayHintField,
     diagnosticField,
+    selectedAnnotationField,
     codeLensGutter,
     diagnosticGutter,
     inlayHintTheme,
@@ -533,4 +570,12 @@ export function lspExtension(opts: LspExtensionOpts): Extension {
 
 export function updateLspFilePath(view: EditorView, filePath: string): void {
   view.dispatch({ effects: [setLspConfig.of({ filePath })] })
+}
+
+export function getSelectedAnnotation(view: EditorView): SelectedAnnotation | null {
+  return view.state.field(selectedAnnotationField)
+}
+
+export function clearSelectedAnnotation(view: EditorView): void {
+  view.dispatch({ effects: [setSelectedAnnotation.of(null)] })
 }


### PR DESCRIPTION
## Summary
- CodeLens gutter markers dispatch `CustomEvent('masc-annotation-select')` on click with full annotation payload
- LSP ViewPlugin captures click events and stores selected annotation in CM6 `selectedAnnotationField`
- `EditorView.updateListener` bridges CM6 state changes to Preact re-render
- `AnnotationPopover` component renders positioned popover with kind badge, content, line range, keeper/goal/task bindings

## Technical approach
3-stage event bridge: CM6 GutterMarker `toDOM()` → `CustomEvent(bubbles:true)` → ViewPlugin listener → `setSelectedAnnotation` StateEffect → `updateListener` → Preact `setState`.

Server already serializes full annotation data into `lens.command.arguments` via `lsp_overlay_provider.ml:annotation_to_json`, so no additional API call on click.

## Test plan
- [x] `cd dashboard && tsc --noEmit` passes (zero new errors)
- [ ] Browser: click CodeLens marker → popover appears at correct position
- [ ] Browser: popover shows annotation kind, content, line range, keeper/goal/task
- [ ] Browser: close button and click-outside dismiss popover
- [ ] Browser: switching files clears popover state

🤖 Generated with [Claude Code](https://claude.com/claude-code)