### PR TITLE
fix(cascade): add ?on_telemetry to complete_stream call sites

### DIFF
--- a/lib/cascade/cascade_transport.ml
+++ b/lib/cascade/cascade_transport.ml
@@ -1310,7 +1310,7 @@ module Kimi_cli_transport_local = struct
                 latency_ms = Some latency_ms;
               });
       complete_stream =
-        (fun ~on_event (req : Llm_provider.Llm_transport.completion_request) ->
+        (fun ?on_telemetry:_ ~on_event (req : Llm_provider.Llm_transport.completion_request) ->
           warn_external_tools_once warned req.tools;
           let messages =
             Llm_provider.Cli_common_prompt.non_system_messages req.messages
@@ -1428,7 +1428,7 @@ let make_per_call_switch_transport
       (fun req ->
         with_call_switch (fun transport -> transport.complete_sync req));
     complete_stream =
-      (fun ~on_event req ->
+      (fun ?on_telemetry:_ ~on_event req ->
         with_call_switch (fun transport ->
             transport.complete_stream ~on_event req));
   }
@@ -1494,7 +1494,7 @@ let make_cli_argv_sanitizing_transport
       (fun req ->
         transport.complete_sync (sanitize_cli_completion_request_for_argv req));
     complete_stream =
-      (fun ~on_event req ->
+      (fun ?on_telemetry:_ ~on_event req ->
         transport.complete_stream ~on_event
           (sanitize_cli_completion_request_for_argv req));
   }

--- a/test/test_oas_worker.ml
+++ b/test/test_oas_worker.ml
@@ -2074,7 +2074,7 @@ let leaking_test_transport_factory ~sw : Llm_provider.Llm_transport.t =
         leak_one_pipe ();
         { Llm_provider.Llm_transport.response; latency_ms = Some 0 });
     complete_stream =
-      (fun ~on_event:_ _req ->
+      (fun ?on_telemetry:_ ~on_event:_ _req ->
         leak_one_pipe ();
         response);
   }


### PR DESCRIPTION
## Summary
- agent_sdk 0.193.1 (telemetry-design branch) added `?on_telemetry` as the first optional parameter of `Llm_transport.complete_stream`
- 3 call sites in `cascade_transport.ml` and 1 in `test_oas_worker.ml` were using the old `fun ~on_event` signature
- Adds `?on_telemetry:_` to all 4 lambda definitions to match the updated type signature

## Test plan
- [x] `dune build --root . @check` passes with 0 errors (was 2 before)

🤖 Generated with [Claude Code](https://claude.com/claude-code)