### PR TITLE
refactor(tool): migrate core handlers to Tool_result.t (RFC-0062 Phase 4c-1)

### DIFF
--- a/lib/keeper/keeper_exec_task.ml
+++ b/lib/keeper/keeper_exec_task.ml
@@ -306,13 +306,15 @@ let handle_keeper_task_tool
     (match result with
      | Coord.Claim_next_claimed { task_id; _ } ->
        sync_keeper_meta_current_task ~config ~meta ~task_id;
-       let ok, _msg =
+       let start_result =
          Tool_task.handle_transition
+           ~tool_name:"keeper_auto_start"
+           ~start_time:0.0
            { Tool_task.config; agent_name = keeper_agent_sender ~meta;
              sw = Eio_context.get_switch_opt () }
            (`Assoc ["task_id", `String task_id; "action", `String "start"])
        in
-       auto_started_ok := ok
+       auto_started_ok := start_result.Tool_result.success
      | Coord.Claim_next_no_unclaimed
      | Coord.Claim_next_no_eligible _
      | Coord.Claim_next_error _ -> ());
@@ -394,8 +396,10 @@ let handle_keeper_task_tool
     if task_id = ""
     then error_json "task_id is required. Use the task_id you got from keeper_task_claim."
     else (
-      let ok, message =
+      let transition_result =
         Tool_task.handle_transition
+          ~tool_name:"keeper_task_done"
+          ~start_time:0.0
           {
             Tool_task.config;
             agent_name = keeper_agent_sender ~meta;
@@ -408,7 +412,7 @@ let handle_keeper_task_tool
                "notes", `String result_text;
              ])
       in
-      keeper_tool_result_json ~ok ~message)
+      keeper_tool_result_json ~ok:transition_result.Tool_result.success ~message:transition_result.Tool_result.legacy_message)
   | "keeper_task_submit_for_verification" ->
     let task_id = Safe_ops.json_string ~default:"" "task_id" args |> String.trim in
     let notes = Safe_ops.json_string ~default:"" "notes" args |> String.trim in
@@ -420,8 +424,10 @@ let handle_keeper_task_tool
     else if pr_url = ""
     then error_json "pr_url is required. Include the PR opened for this task."
     else (
-      let ok, message =
+      let transition_result =
         Tool_task.handle_transition
+          ~tool_name:"keeper_task_submit_for_verification"
+          ~start_time:0.0
           {
             Tool_task.config;
             agent_name = keeper_agent_sender ~meta;
@@ -434,6 +440,6 @@ let handle_keeper_task_tool
                "notes", `String (notes ^ "\nPR: " ^ pr_url);
              ])
       in
-      keeper_tool_result_json ~ok ~message)
+      keeper_tool_result_json ~ok:transition_result.Tool_result.success ~message:transition_result.Tool_result.legacy_message)
   | other -> error_json ~fields:[ "tool", `String other ] "unknown_task_tool"
 ;;

--- a/lib/keeper/keeper_exec_tools.ml
+++ b/lib/keeper/keeper_exec_tools.ml
@@ -410,18 +410,18 @@ let execute_keeper_tool_call_with_outcome
          success_tool_result
            (Keeper_exec_memory.keeper_memory_write_json ~config ~meta ~args)
        | "keeper_library_search" ->
-         let ok, msg =
-           Tool_library.handle_search Tool_library.{ agent_name = meta.name } args
+         let result =
+           Tool_library.handle_search ~tool_name:"keeper_library_search" ~start_time:0.0 Tool_library.{ agent_name = meta.name } args
          in
-         if ok
-         then success_tool_result msg
+         if result.Tool_result.success
+         then success_tool_result result.Tool_result.legacy_message
          else
-           failure_tool_result (Yojson.Safe.to_string (`Assoc [ "error", `String msg ]))
+           failure_tool_result (Yojson.Safe.to_string (`Assoc [ "error", `String result.Tool_result.legacy_message ]))
        | "keeper_library_read" ->
-         let ok, msg =
-           Tool_library.handle_read Tool_library.{ agent_name = meta.name } args
+         let result =
+           Tool_library.handle_read ~tool_name:"keeper_library_read" ~start_time:0.0 Tool_library.{ agent_name = meta.name } args
          in
-         if ok then success_tool_result msg else failure_tool_result (error_json msg)
+         if result.Tool_result.success then success_tool_result result.Tool_result.legacy_message else failure_tool_result (error_json result.Tool_result.legacy_message)
        | "keeper_fs_read" ->
          make_executed_tool_result
            (Keeper_exec_fs.handle_keeper_fs_read

--- a/lib/keeper/keeper_tag_dispatch.ml
+++ b/lib/keeper/keeper_tag_dispatch.ml
@@ -85,8 +85,6 @@ let dispatch
       Tool_run.dispatch { Tool_run.config } ~name ~args
   | Mod_agent ->
       Tool_agent.dispatch { Tool_agent.config; agent_name } ~name ~args
-      |> Option.map (fun (success, message) ->
-        if success then ok message else err message)
   | Mod_room ->
       Tool_coord.dispatch { Tool_coord.config; agent_name } ~name ~args
       |> Option.map (fun { Coord_types.success; message } ->
@@ -105,8 +103,6 @@ let dispatch
   | Mod_suspend ->
       Tool_suspend.dispatch { Tool_suspend.config; caller_agent = Some agent_name }
         ~name ~args
-      |> Option.map (fun (success, message) ->
-        if success then ok message else err message)
   | Mod_library ->
       Tool_library.dispatch { Tool_library.agent_name } ~name ~args
 

--- a/lib/mcp_server_eio_execute.ml
+++ b/lib/mcp_server_eio_execute.ml
@@ -820,9 +820,6 @@ let execute_tool_eio ~sw ~clock ?(profile = Mcp_server_eio_tool_profile.Full)
         Tool_run.dispatch { Tool_run.config } ~name ~args:coerced_args
     | Mod_agent ->
         Tool_agent.dispatch { Tool_agent.config; agent_name } ~name ~args:coerced_args
-        |> Option.map (fun (ok, msg) ->
-             if ok then Tool_result.ok ~tool_name:name ~start_time msg
-             else Tool_result.error ~tool_name:name ~start_time msg)
     | Mod_task ->
         Tool_task.dispatch ?agent_tool_names:caller_tool_names
           { Tool_task.config; agent_name; sw = Some sw } ~name
@@ -840,9 +837,6 @@ let execute_tool_eio ~sw ~clock ?(profile = Mcp_server_eio_tool_profile.Full)
         Tool_misc.dispatch { Tool_misc.config; agent_name } ~name ~args:coerced_args
     | Mod_suspend ->
         Tool_suspend.dispatch { Tool_suspend.config; caller_agent = Some agent_name } ~name ~args:coerced_args
-        |> Option.map (fun (ok, msg) ->
-             if ok then Tool_result.ok ~tool_name:name ~start_time msg
-             else Tool_result.error ~tool_name:name ~start_time msg)
     | Mod_library ->
         Tool_library.dispatch { Tool_library.agent_name } ~name ~args:coerced_args
     | Mod_keeper ->

--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -540,8 +540,7 @@ let start_keeper_loops ~sw ~clock ~net ~domain_mgr ~proc_mgr
               (false, "masc_tasks: dispatch failed"))
     | "masc_agents" -> (
         match Tool_agent.dispatch ctx_agent ~name ~args with
-        | Some result ->
-            Tool_result.wrap ~tool_name:name ~start_time result
+        | Some result -> result
         | None ->
             Tool_result.wrap ~tool_name:name ~start_time
               (false, "masc_agents: dispatch failed"))

--- a/lib/tool_agent.ml
+++ b/lib/tool_agent.ml
@@ -24,10 +24,10 @@ type context = {
   agent_name: string;
 }
 
-(** Helper: result to response *)
+(** Helper: result to Tool_result.t *)
 let result_to_response = function
-  | Ok msg -> (true, msg)
-  | Error e -> (false, Masc_domain.masc_error_to_string e)
+  | Ok msg -> Tool_result.quick_ok msg
+  | Error e -> Tool_result.quick_error (Masc_domain.masc_error_to_string e)
 
 (* Issue #8501: Variant SSOT for masc_agent_card.action.  Adding a
    new constructor forces compilation in [agent_card_action_to_string]
@@ -62,12 +62,12 @@ let handle_agents ctx args =
     | `List items -> `List (List.filteri (fun i _ -> i < limit) items)
     | other -> other
   in
-  (true, Yojson.Safe.to_string json)
+  Tool_result.quick_ok (Yojson.Safe.to_string json)
 
 (** Handle masc_register_capabilities *)
 let handle_register_capabilities ctx args =
   let capabilities = get_string_list args "capabilities" in
-  (true, Coord.register_capabilities ctx.config ~agent_name:ctx.agent_name ~capabilities)
+  Tool_result.quick_ok (Coord.register_capabilities ctx.config ~agent_name:ctx.agent_name ~capabilities)
 
 (** Handle masc_agent_update *)
 let handle_agent_update ctx args =
@@ -87,7 +87,7 @@ let handle_get_metrics ctx args =
   let days = get_int args "days" 7 in
   match Metrics_store_eio.calculate_agent_metrics ctx.config ~agent_id:target ~days with
   | Some metrics ->
-      (true, Yojson.Safe.to_string (Metrics_store_eio.agent_metrics_to_yojson metrics))
+      Tool_result.quick_ok (Yojson.Safe.to_string (Metrics_store_eio.agent_metrics_to_yojson metrics))
   | None ->
       error_result_typed ~code:Not_found
         (Printf.sprintf "no metrics found for agent: %s" target)
@@ -233,7 +233,7 @@ let handle_agent_fitness ctx args =
       List.sort_uniq String.compare (metrics_agents @ room_agents)
   in
   if Stdlib.List.length agents = 0 then
-    (true, Yojson.Safe.to_string (`Assoc [("count", `Int 0); ("agents", `List [])]))
+    Tool_result.quick_ok (Yojson.Safe.to_string (`Assoc [("count", `Int 0); ("agents", `List [])]))
   else
     let metrics_list = List.map (fun a -> (a, metrics_for ctx ~days a)) agents in
     let min_avg = min_avg_time metrics_list in
@@ -268,9 +268,8 @@ let handle_agent_fitness ctx args =
       ("count", `Int (List.length agents_json));
       ("agents", `List agents_json);
     ] in
-    (true, Yojson.Safe.to_string json)
+    Tool_result.quick_ok (Yojson.Safe.to_string json)
 
-(** Handle masc_collaboration_graph *)
 (** Handle masc_agent_card *)
 let handle_agent_card ctx args =
   let action_raw = get_string args "action" "get" in
@@ -324,9 +323,9 @@ let handle_agent_card ctx args =
                  ]) );
         ]
       in
-      (true, Yojson.Safe.to_string json)
+      Tool_result.quick_ok (Yojson.Safe.to_string json)
 
-(** Dispatch handler. Returns Some (success, result) if handled, None otherwise *)
+(** Dispatch handler. Returns Some (Tool_result.t) if handled, None otherwise *)
 let dispatch ctx ~name ~args =
   match name with
   | "masc_agents" -> Some (handle_agents ctx args)

--- a/lib/tool_agent.mli
+++ b/lib/tool_agent.mli
@@ -20,27 +20,27 @@ val valid_agent_card_action_strings : string list
     Mirror in [Tool_schemas_agent.collaboration_format_enum_strings]. *)
 val valid_collaboration_format_strings : string list
 
-(** Dispatch handler. Returns Some (success, result) if handled, None otherwise *)
-val dispatch : context -> name:string -> args:Yojson.Safe.t -> (bool * string) option
+(** Dispatch handler. Returns Some Tool_result.t if handled, None otherwise *)
+val dispatch : context -> name:string -> args:Yojson.Safe.t -> Tool_result.t option
 
 val schemas : Masc_domain.tool_schema list
 
 (** Handle masc_agents *)
-val handle_agents : context -> Yojson.Safe.t -> bool * string
+val handle_agents : context -> Yojson.Safe.t -> Tool_result.t
 
 (** Handle masc_register_capabilities *)
-val handle_register_capabilities : context -> Yojson.Safe.t -> bool * string
+val handle_register_capabilities : context -> Yojson.Safe.t -> Tool_result.t
 
 (** Handle masc_agent_update *)
-val handle_agent_update : context -> Yojson.Safe.t -> bool * string
+val handle_agent_update : context -> Yojson.Safe.t -> Tool_result.t
 
 (** Handle masc_get_metrics *)
-val handle_get_metrics : context -> Yojson.Safe.t -> bool * string
+val handle_get_metrics : context -> Yojson.Safe.t -> Tool_result.t
 
 (** Handle masc_agent_fitness *)
-val handle_agent_fitness : context -> Yojson.Safe.t -> bool * string
+val handle_agent_fitness : context -> Yojson.Safe.t -> Tool_result.t
 
 (** Handle masc_collaboration_graph *)
 
 (** Handle masc_agent_card *)
-val handle_agent_card : context -> Yojson.Safe.t -> bool * string
+val handle_agent_card : context -> Yojson.Safe.t -> Tool_result.t

--- a/lib/tool_args.ml
+++ b/lib/tool_args.ml
@@ -85,10 +85,10 @@ let error_code_to_string = function
   | Internal_error -> "internal_error"
   | Precondition_failed -> "precondition_failed"
 
-(** {1 Canonical Error/OK Response Helpers}
+(** {1 Raw JSON String Builders}
 
-    New tool handlers should use these instead of defining local helpers.
-    Returns [(bool * string)] matching the standard tool dispatch signature. *)
+    These produce plain JSON strings without [Tool_result.t] wrapping.
+    Used by [get_string_required] error paths and legacy callers. *)
 
 (** Build a JSON error response string: [\{"status":"error","message":"..."\}] *)
 let error_response message =
@@ -96,9 +96,7 @@ let error_response message =
     (`Assoc [ ("status", `String "error"); ("message", `String message) ])
 
 (** Build a JSON error response string with machine-readable error code:
-    [\{"status":"error","error_code":"validation_error","message":"..."\}]
-
-    Preferred over [error_response] for new tool handlers. *)
+    [\{"status":"error","error_code":"validation_error","message":"..."\}] *)
 let error_response_typed ~code message =
   Yojson.Safe.to_string
     (`Assoc [
@@ -111,14 +109,43 @@ let error_response_typed ~code message =
 let ok_response fields =
   Yojson.Safe.to_string (`Assoc (("status", `String "ok") :: fields))
 
-(** Convenience: [(false, error_response msg)] *)
-let error_result msg = (false, error_response msg)
+(** {1 Tool_result.t Helpers}
 
-(** Convenience: [(false, error_response_typed ~code msg)] *)
-let error_result_typed ~code msg = (false, error_response_typed ~code msg)
+    These return structured [Tool_result.t] instead of [(bool * string)].
+    Handlers should use these directly — the dispatch boundary no longer
+    needs [wrap_result] conversion. *)
 
-(** Convenience: [(true, ok_response fields)] *)
-let ok_result fields = (true, ok_response fields)
+(** [Tool_result.t] error from a plain message string. *)
+let error_result ?tool_name ?start_time msg =
+  match (tool_name, start_time) with
+  | Some name, Some t ->
+    Tool_result.error ~tool_name:name ~start_time:t msg
+  | Some name, None ->
+    Tool_result.quick_error ~tool_name:name msg
+  | None, _ ->
+    Tool_result.quick_error msg
+
+(** [Tool_result.t] error with machine-readable error code. *)
+let error_result_typed ?tool_name ?start_time ~code msg =
+  let msg_with_code = error_response_typed ~code msg in
+  match (tool_name, start_time) with
+  | Some name, Some t ->
+    Tool_result.error ~tool_name:name ~start_time:t msg_with_code
+  | Some name, None ->
+    Tool_result.quick_error ~tool_name:name msg_with_code
+  | None, _ ->
+    Tool_result.quick_error msg_with_code
+
+(** [Tool_result.t] success with additional JSON fields. *)
+let ok_result ?tool_name ?start_time fields =
+  let msg = ok_response fields in
+  match (tool_name, start_time) with
+  | Some name, Some t ->
+    Tool_result.ok ~tool_name:name ~start_time:t msg
+  | Some name, None ->
+    Tool_result.quick_ok ~tool_name:name msg
+  | None, _ ->
+    Tool_result.quick_ok msg
 
 (** {1 Parse, Don't Validate — Required Field Extractors}
 
@@ -141,9 +168,9 @@ let get_int_required args key =
   | Some i -> Ok i
   | None -> Error (error_response (Printf.sprintf "%s is required" key))
 
-(** Monadic bind for [(ok, string) Result.t] → [(bool * string)].
+(** Monadic bind for [('a, string) Result.t] → [Tool_result.t].
     Chains required field extractions with early error return. *)
-let ( let*! ) r f = match r with Ok v -> f v | Error e -> (false, e)
+let ( let*! ) r f = match r with Ok v -> f v | Error e -> Tool_result.quick_error e
 
 (** {1 Structured Field Validation}
 
@@ -208,8 +235,16 @@ let validation_error_response (errors : field_error list) : string =
       ("message", `String (Printf.sprintf "%d field error(s)" (List.length errors)));
     ])
 
-(** Convenience: [(false, validation_error_response errors)] *)
-let validation_error_result errors = (false, validation_error_response errors)
+(** Convenience: [Tool_result.t] validation error. *)
+let validation_error_result ?tool_name ?start_time errors =
+  let msg = validation_error_response errors in
+  match (tool_name, start_time) with
+  | Some name, Some t ->
+    Tool_result.error ~tool_name:name ~start_time:t msg
+  | Some name, None ->
+    Tool_result.quick_error ~tool_name:name msg
+  | None, _ ->
+    Tool_result.quick_error msg
 
 (** {2 Field Validators}
 

--- a/lib/tool_args.mli
+++ b/lib/tool_args.mli
@@ -57,31 +57,35 @@ type error_code =
 
 val error_code_to_string : error_code -> string
 
-(** {1 Canonical error / OK response helpers}
+(** {1 Raw JSON String Builders}
 
-    New tool handlers should use these instead of local helpers.
-    These functions return [(bool * string)] tuples — the pre-dispatch
-    handler-level contract.  The dispatch boundary ({!Tool_dispatch.dispatch})
-    wraps these tuples into a {!Tool_result.t} automatically via
-    {!Tool_result.wrap}.
-
-    Handlers producing results via these helpers do {e not} need to
-    import [Tool_result] directly. *)
+    These produce plain JSON strings without [Tool_result.t] wrapping.
+    Used by [get_string_required] error paths and other low-level callers. *)
 
 (** [{"status":"error","message":"…"}] *)
 val error_response : string -> string
 
-(** [{"status":"error","error_code":"…","message":"…"}] — preferred. *)
+(** [{"status":"error","error_code":"…","message":"…"}] *)
 val error_response_typed : code:error_code -> string -> string
 
 (** [{"status":"ok", <fields>}] *)
 val ok_response : (string * Yojson.Safe.t) list -> string
 
-val error_result : string -> bool * string
+(** {1 Tool_result.t Helpers}
 
-val error_result_typed : code:error_code -> string -> bool * string
+    These return structured {!Tool_result.t} directly, eliminating the
+    need for [wrap_result] at the dispatch boundary.  Optional
+    [~tool_name] and [~start_time] are forwarded to [Tool_result]
+    constructors; when absent, [quick_ok]/[quick_error] variants are
+    used. *)
 
-val ok_result : (string * Yojson.Safe.t) list -> bool * string
+val error_result : ?tool_name:string -> ?start_time:float -> string -> Tool_result.t
+
+val error_result_typed :
+  ?tool_name:string -> ?start_time:float -> code:error_code -> string -> Tool_result.t
+
+val ok_result :
+  ?tool_name:string -> ?start_time:float -> (string * Yojson.Safe.t) list -> Tool_result.t
 
 (** {1 Required field extractors (Parse, Don't Validate)}
 
@@ -93,10 +97,10 @@ val get_string_required : Yojson.Safe.t -> string -> (string, string) Result.t
 
 val get_int_required : Yojson.Safe.t -> string -> (int, string) Result.t
 
-(** Monadic bind for [(value, error_json) Result.t] → [(bool * string)].
+(** Monadic bind for [('a, string) Result.t] → [Tool_result.t].
     Chains required field extractions with early error return. *)
 val ( let*! ) :
-  ('a, string) Result.t -> ('a -> bool * string) -> bool * string
+  ('a, string) Result.t -> ('a -> Tool_result.t) -> Tool_result.t
 
 (** {1 Structured field validation}
 
@@ -134,7 +138,8 @@ val field_error_to_yojson : field_error -> Yojson.Safe.t
     "field_errors":[…],"message":"N field error(s)"}] *)
 val validation_error_response : field_error list -> string
 
-val validation_error_result : field_error list -> bool * string
+val validation_error_result :
+  ?tool_name:string -> ?start_time:float -> field_error list -> Tool_result.t
 
 (** {1 Field validators}
 

--- a/lib/tool_code.ml
+++ b/lib/tool_code.ml
@@ -35,11 +35,6 @@ type context = {
   agent_name: string;
 }
 
-type tool_result = bool * string
-
-let wrap_result ~name ~start (success, message) =
-  if success then Tool_result.ok ~tool_name:name ~start_time:start message
-  else Tool_result.error ~tool_name:name ~start_time:start message
 
 (* Security: Binary file extensions *)
 let binary_extensions = [
@@ -336,7 +331,7 @@ let validate_read_path ~agent_name config path =
 
 
 (* Handler: masc_code_search - Search code using ripgrep *)
-let handle_code_search ctx args =
+let handle_code_search ~tool_name ~start_time ctx args =
   let query = get_string args "query" "" in
   let path = get_string args "path" "" in
   let file_pattern = get_string args "file_pattern" "" in
@@ -345,16 +340,16 @@ let handle_code_search ctx args =
   let max_results = get_int args "max_results" 50 in
 
   if String.equal query "" then
-    (false, "Query required: 'query' parameter")
+    Tool_result.error ~tool_name ~start_time "Query required: 'query' parameter"
   else if String.equal (String.trim path) "" then
-    (false, "Path required: 'path' parameter")
+    Tool_result.error ~tool_name ~start_time "Path required: 'path' parameter"
   else begin
     (* Validate path first *)
     let search_path_result =
       validate_read_path ~agent_name:ctx.agent_name ctx.config path
     in
     match search_path_result with
-    | Error e -> (false, Masc_domain.masc_error_to_string e)
+    | Error e -> Tool_result.error ~tool_name ~start_time (Masc_domain.masc_error_to_string e)
     | Ok search_path ->
 
     let rg_args =
@@ -398,14 +393,14 @@ let handle_code_search ctx args =
           ("count", `Int (List.length matches));
           ("results", `List matches);
         ] in
-        (true, Yojson.Safe.to_string response)
+        Tool_result.ok ~tool_name ~start_time (Yojson.Safe.to_string response)
     | Unix.WEXITED 1, _ ->
         (* No matches *)
         let response = `Assoc [
           ("count", `Int 0);
           ("results", `List []);
         ] in
-        (true, Yojson.Safe.to_string response)
+        Tool_result.ok ~tool_name ~start_time (Yojson.Safe.to_string response)
     | Unix.WEXITED 2, output ->
         (* rg error: invalid regex, missing file, etc. Pick the right hint
            by scanning the rg output, since exit-2 is overloaded. *)
@@ -436,7 +431,7 @@ let handle_code_search ctx args =
             "Literal search failed. If your query contains regex chars (*+?[](){}^$|.\\), \
              try simplifying the query or set is_regex=true with a valid regex."
         in
-        (false, Printf.sprintf "%s\nrg output: %s" hint
+        Tool_result.error ~tool_name ~start_time (Printf.sprintf "%s\nrg output: %s" hint
            (if String.equal trimmed_out "" then "(empty)"
             else String_util.utf8_safe ~max_bytes:303 ~suffix:"..." trimmed_out |> String_util.to_string))
     | status, output ->
@@ -445,30 +440,30 @@ let handle_code_search ctx args =
           | Unix.WSIGNALED n -> Printf.sprintf "signal %d" n
           | Unix.WSTOPPED n -> Printf.sprintf "stopped %d" n
         in
-        (false, Printf.sprintf "ripgrep failed (%s): %s" code
+        Tool_result.error ~tool_name ~start_time (Printf.sprintf "ripgrep failed (%s): %s" code
            (if String.equal output "" then "(no output — check rg is in PATH and query is valid)"
             else output))
   end
 
 (* Handler: masc_code_symbols - Extract file symbols using heuristics *)
-let handle_code_symbols ctx args =
+let handle_code_symbols ~tool_name ~start_time ctx args =
   let path = get_string args "path" "" in
 
   if String.equal path "" then
-    (false, "Path required: 'path' parameter")
+    Tool_result.error ~tool_name ~start_time "Path required: 'path' parameter"
   else begin
     match validate_read_path ~agent_name:ctx.agent_name ctx.config path with
-    | Error e -> (false, Masc_domain.masc_error_to_string e)
+    | Error e -> Tool_result.error ~tool_name ~start_time (Masc_domain.masc_error_to_string e)
     | Ok validated_path ->
         if not (Sys.file_exists validated_path) then
-          (false, Printf.sprintf "File not found: %s" path)
+          Tool_result.error ~tool_name ~start_time (Printf.sprintf "File not found: %s" path)
         else if is_binary_file validated_path then
-          (false, "Binary file detected")
+          Tool_result.error ~tool_name ~start_time "Binary file detected"
         else begin
           (* Read file and extract symbols *)
           let file_size = (Unix.stat validated_path).Unix.st_size in
           if file_size > max_file_size then
-            (false, Printf.sprintf "File too large: %d bytes (max: %d)" file_size max_file_size)
+            Tool_result.error ~tool_name ~start_time (Printf.sprintf "File too large: %d bytes (max: %d)" file_size max_file_size)
           else begin
             try
               let content = In_channel.with_open_text validated_path In_channel.input_all in
@@ -520,33 +515,33 @@ let handle_code_symbols ctx args =
                 ("count", `Int (List.length symbols));
                 ("symbols", `List symbols_json);
               ] in
-              (true, Yojson.Safe.to_string response)
+              Tool_result.ok ~tool_name ~start_time (Yojson.Safe.to_string response)
             with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
-              (false, Printf.sprintf "Failed to read file: %s" (Stdlib.Printexc.to_string exn))
+              Tool_result.error ~tool_name ~start_time (Printf.sprintf "Failed to read file: %s" (Stdlib.Printexc.to_string exn))
           end
         end
   end
 
 (* Handler: masc_code_read - Read file with offset/limit *)
-let handle_code_read ctx args =
+let handle_code_read ~tool_name ~start_time ctx args =
   let path = get_string args "path" "" in
   let offset = get_int args "offset" 0 in
   let limit = get_int args "limit" 100 in
 
   if String.equal path "" then
-    (false, "Path required: 'path' parameter")
+    Tool_result.error ~tool_name ~start_time "Path required: 'path' parameter"
   else begin
     match validate_read_path ~agent_name:ctx.agent_name ctx.config path with
-    | Error e -> (false, Masc_domain.masc_error_to_string e)
+    | Error e -> Tool_result.error ~tool_name ~start_time (Masc_domain.masc_error_to_string e)
     | Ok validated_path ->
         if not (Sys.file_exists validated_path) then
-          (false, Printf.sprintf "File not found: %s" path)
+          Tool_result.error ~tool_name ~start_time (Printf.sprintf "File not found: %s" path)
         else if is_binary_file validated_path then
-          (false, "Binary file detected")
+          Tool_result.error ~tool_name ~start_time "Binary file detected"
         else begin
           let file_size = (Unix.stat validated_path).Unix.st_size in
           if file_size > max_file_size then
-            (false, Printf.sprintf "File too large: %d bytes (max: %d)" file_size max_file_size)
+            Tool_result.error ~tool_name ~start_time (Printf.sprintf "File too large: %d bytes (max: %d)" file_size max_file_size)
           else begin
             try
               let content = In_channel.with_open_text validated_path In_channel.input_all in
@@ -575,9 +570,9 @@ let handle_code_read ctx args =
                 ("total_lines", `Int total_lines);
                 ("lines", `List (List.map (fun s -> `String s) result_lines));
               ] in
-              (true, Yojson.Safe.to_string response)
+              Tool_result.ok ~tool_name ~start_time (Yojson.Safe.to_string response)
             with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
-              (false, Printf.sprintf "Failed to read file: %s" (Stdlib.Printexc.to_string exn))
+              Tool_result.error ~tool_name ~start_time (Printf.sprintf "Failed to read file: %s" (Stdlib.Printexc.to_string exn))
           end
         end
   end
@@ -586,9 +581,9 @@ let handle_code_read ctx args =
 let dispatch ctx ~name ~args : Tool_result.t option =
   let start = Time_compat.now () in
   match name with
-  | "masc_code_search" -> Some (wrap_result ~name ~start (handle_code_search ctx args))
-  | "masc_code_symbols" -> Some (wrap_result ~name ~start (handle_code_symbols ctx args))
-  | "masc_code_read" -> Some (wrap_result ~name ~start (handle_code_read ctx args))
+  | "masc_code_search" -> Some (handle_code_search ~tool_name:name ~start_time:start ctx args)
+  | "masc_code_symbols" -> Some (handle_code_symbols ~tool_name:name ~start_time:start ctx args)
+  | "masc_code_read" -> Some (handle_code_read ~tool_name:name ~start_time:start ctx args)
   | _ -> None
 
 let schemas : Masc_domain.tool_schema list = [

--- a/lib/tool_code.mli
+++ b/lib/tool_code.mli
@@ -34,7 +34,6 @@ type context = {
 (** Per-call context.  Concrete record because callers
     construct it field-by-field at the dispatch site. *)
 
-type tool_result = bool * string
 
 (** {1 Security primitives} *)
 

--- a/lib/tool_code_write.ml
+++ b/lib/tool_code_write.ml
@@ -36,12 +36,6 @@ type context = {
   agent_name : string;
 }
 
-type tool_result = bool * string
-
-let wrap_result ~name ~start (success, message) =
-  if success then Tool_result.ok ~tool_name:name ~start_time:start message
-  else Tool_result.error ~tool_name:name ~start_time:start message
-
 let max_write_size = 1024 * 1024  (* 1 MiB *)
 
 let normalize_dir_prefix path =
@@ -443,21 +437,21 @@ let validate_clone_cwd ~(agent_name : string) config cwd =
           agent_name)))
 
 (* Handler: masc_code_write — Create or overwrite a file *)
-let handle_code_write ctx args =
+let handle_code_write ~tool_name ~start_time ctx args =
   let path = get_string args "path" "" in
   let content = get_string args "content" "" in
   let create_dirs = get_bool args "create_dirs" false in
 
   if String.equal path "" then
-    (false, "path parameter required")
+    Tool_result.error ~tool_name ~start_time "path parameter required"
   else if String.length content > max_write_size then
-    (false, Printf.sprintf "Content too large: %d bytes (max: %d)"
+    Tool_result.error ~tool_name ~start_time (Printf.sprintf "Content too large: %d bytes (max: %d)"
        (String.length content) max_write_size)
   else if Tool_code.is_binary_file path then
-    (false, "Binary file extension not allowed for write")
+    Tool_result.error ~tool_name ~start_time "Binary file extension not allowed for write"
   else begin
     match validate_writable_path ~agent_name:ctx.agent_name ctx.config path with
-    | Error e -> (false, Masc_domain.masc_error_to_string e)
+    | Error e -> Tool_result.error ~tool_name ~start_time (Masc_domain.masc_error_to_string e)
     | Ok abs_path ->
       try
         if create_dirs then begin
@@ -471,27 +465,27 @@ let handle_code_write ctx args =
           ("bytes_written", `Int (String.length content));
           ("agent", `String ctx.agent_name);
         ] in
-        (true, Yojson.Safe.to_string response)
+        Tool_result.ok ~tool_name ~start_time (Yojson.Safe.to_string response)
       with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
-        (false, Printf.sprintf "Write failed: %s" (Stdlib.Printexc.to_string exn))
+        Tool_result.error ~tool_name ~start_time (Printf.sprintf "Write failed: %s" (Stdlib.Printexc.to_string exn))
   end
 
 (* Handler: masc_code_edit — Replace old_string with new_string in a file *)
-let handle_code_edit ctx args =
+let handle_code_edit ~tool_name ~start_time ctx args =
   let path = get_string args "path" "" in
   let old_string = get_string args "old_string" "" in
   let new_string = get_string args "new_string" "" in
   let replace_all = get_bool args "replace_all" false in
 
-  if String.equal path "" then (false, "path parameter required")
-  else if String.equal old_string "" then (false, "old_string parameter required")
-  else if String.equal old_string new_string then (false, "old_string and new_string are identical")
+  if String.equal path "" then Tool_result.error ~tool_name ~start_time "path parameter required"
+  else if String.equal old_string "" then Tool_result.error ~tool_name ~start_time "old_string parameter required"
+  else if String.equal old_string new_string then Tool_result.error ~tool_name ~start_time "old_string and new_string are identical"
   else begin
     match validate_writable_path ~agent_name:ctx.agent_name ctx.config path with
-    | Error e -> (false, Masc_domain.masc_error_to_string e)
+    | Error e -> Tool_result.error ~tool_name ~start_time (Masc_domain.masc_error_to_string e)
     | Ok abs_path ->
       if not (Sys.file_exists abs_path) then
-        (false, Printf.sprintf "File not found: %s" path)
+        Tool_result.error ~tool_name ~start_time (Printf.sprintf "File not found: %s" path)
       else begin
         try
           let content = Fs_compat.load_file abs_path in
@@ -524,7 +518,7 @@ let handle_code_edit ctx args =
             in
             let needle = String.trim first_line in
             if String.length needle < 8 then
-              (false, "old_string not found in file")
+              Tool_result.error ~tool_name ~start_time "old_string not found in file"
             else
               let matches =
                 String.split_on_char '\n' content
@@ -540,9 +534,9 @@ let handle_code_edit ctx args =
                    old_string (check whitespace/indent):\n  "
                   ^ String.concat "\n  " samples
               in
-              (false, "old_string not found in file." ^ hint)
+              Tool_result.error ~tool_name ~start_time ("old_string not found in file." ^ hint)
           else if !count > 1 && not replace_all then
-            (false, Printf.sprintf
+            Tool_result.error ~tool_name ~start_time (Printf.sprintf
                "old_string found %d times. Use replace_all=true or provide more context"
                !count)
           else begin
@@ -591,26 +585,26 @@ let handle_code_edit ctx args =
               ("replacements", `Int !count);
               ("agent", `String ctx.agent_name);
             ] in
-            (true, Yojson.Safe.to_string response)
+            Tool_result.ok ~tool_name ~start_time (Yojson.Safe.to_string response)
           end
         with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
-          (false, Printf.sprintf "Edit failed: %s" (Stdlib.Printexc.to_string exn))
+          Tool_result.error ~tool_name ~start_time (Printf.sprintf "Edit failed: %s" (Stdlib.Printexc.to_string exn))
       end
   end
 
 (* Handler: masc_code_delete — Delete a file *)
-let handle_code_delete ctx args =
+let handle_code_delete ~tool_name ~start_time ctx args =
   let path = get_string args "path" "" in
 
-  if String.equal path "" then (false, "path parameter required")
+  if String.equal path "" then Tool_result.error ~tool_name ~start_time "path parameter required"
   else begin
     match validate_writable_path ~agent_name:ctx.agent_name ctx.config path with
-    | Error e -> (false, Masc_domain.masc_error_to_string e)
+    | Error e -> Tool_result.error ~tool_name ~start_time (Masc_domain.masc_error_to_string e)
     | Ok abs_path ->
       if not (Sys.file_exists abs_path) then
-        (false, Printf.sprintf "File not found: %s" path)
+        Tool_result.error ~tool_name ~start_time (Printf.sprintf "File not found: %s" path)
       else if Sys.is_directory abs_path then
-        (false, "Cannot delete directories, only files")
+        Tool_result.error ~tool_name ~start_time "Cannot delete directories, only files"
       else begin
         try
           Sys.remove abs_path;
@@ -619,22 +613,22 @@ let handle_code_delete ctx args =
             ("path", `String path);
             ("agent", `String ctx.agent_name);
           ] in
-          (true, Yojson.Safe.to_string response)
+          Tool_result.ok ~tool_name ~start_time (Yojson.Safe.to_string response)
         with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
-          (false, Printf.sprintf "Delete failed: %s" (Stdlib.Printexc.to_string exn))
+          Tool_result.error ~tool_name ~start_time (Printf.sprintf "Delete failed: %s" (Stdlib.Printexc.to_string exn))
       end
   end
 
 (* Handler: masc_code_shell — Bounded shell execution *)
-let handle_code_shell ctx args =
+let handle_code_shell ~tool_name ~start_time ctx args =
   let command = get_string args "command" "" in
   let cwd = get_string args "cwd" "" in
   let timeout = get_int args "timeout" 30 in
 
-  if String.equal command "" then (false, "command parameter required")
+  if String.equal command "" then Tool_result.error ~tool_name ~start_time "command parameter required"
   else
     match validate_code_shell_command command with
-    | Error reason -> (false, reason)
+    | Error reason -> Tool_result.error ~tool_name ~start_time reason
     | Ok () ->
         (* Validate cwd if provided *)
         let cwd_result =
@@ -645,7 +639,7 @@ let handle_code_shell ctx args =
             | Error e -> Error e
         in
         (match cwd_result with
-         | Error e -> (false, Masc_domain.masc_error_to_string e)
+         | Error e -> Tool_result.error ~tool_name ~start_time (Masc_domain.masc_error_to_string e)
          | Ok cwd_opt ->
              let safe_timeout = Float.of_int (max 5 (min 120 timeout)) in
              let cmd_parts = ["sh"; "-c"; command] in
@@ -665,9 +659,12 @@ let handle_code_shell ctx args =
                    ("command", `String command);
                    ("agent", `String ctx.agent_name);
                  ] in
-                 (code = 0, Yojson.Safe.pretty_to_string response)
+                 (if code = 0
+                  then fun msg -> Tool_result.ok ~tool_name ~start_time msg
+                  else fun msg -> Tool_result.error ~tool_name ~start_time msg)
+                   (Yojson.Safe.pretty_to_string response)
              | _, output ->
-                 (false, Printf.sprintf "Command failed: %s" (truncate_output output)))
+                 Tool_result.error ~tool_name ~start_time (Printf.sprintf "Command failed: %s" (truncate_output output)))
 
 (* Handler: masc_code_git — Git operations *)
 let code_git_route_fields (ctx : context) =
@@ -686,7 +683,7 @@ let code_git_route_fields (ctx : context) =
     ("route_via", `String route_via);
   ]
 
-let handle_code_git ctx args =
+let handle_code_git ~tool_name ~start_time ctx args =
   let action = get_string args "action" "" in
   let git_args = match args with
     | `Assoc fields ->
@@ -698,9 +695,9 @@ let handle_code_git ctx args =
   in
   let cwd = get_string args "cwd" "" in
 
-  if String.equal action "" then (false, "action parameter required")
+  if String.equal action "" then Tool_result.error ~tool_name ~start_time "action parameter required"
   else if not (List.mem action allowed_git_actions) then
-    (false, Printf.sprintf "Git action '%s' not allowed. Allowed: %s"
+    Tool_result.error ~tool_name ~start_time (Printf.sprintf "Git action '%s' not allowed. Allowed: %s"
        action (String.concat ", " allowed_git_actions))
   else if String.equal action "clone" then begin
     (* Clone: validate org allowlist + cwd within .worktrees/.
@@ -708,17 +705,17 @@ let handle_code_git ctx args =
     let url = match git_args with url :: _ -> url | [] -> "" in
     let has_flag_args = List.exists (fun a -> String.length a > 0 && Char.equal a.[0] '-') git_args in
     if String.equal url "" then
-      (false, "clone requires a repository URL as first argument")
+      Tool_result.error ~tool_name ~start_time "clone requires a repository URL as first argument"
     else if has_flag_args then
-      (false, "clone does not accept flags (security: --upload-pack injection blocked)")
+      Tool_result.error ~tool_name ~start_time "clone does not accept flags (security: --upload-pack injection blocked)"
     else if String.equal cwd "" then
-      (false, "cwd parameter required for clone")
+      Tool_result.error ~tool_name ~start_time "cwd parameter required for clone"
     else
       match validate_clone_url ~base_path:ctx.config.Coord.base_path url with
-      | Error msg -> (false, msg)
+      | Error msg -> Tool_result.error ~tool_name ~start_time msg
       | Ok () ->
         match validate_clone_cwd ~agent_name:ctx.agent_name ctx.config cwd with
-        | Error e -> (false, Masc_domain.masc_error_to_string e)
+        | Error e -> Tool_result.error ~tool_name ~start_time (Masc_domain.masc_error_to_string e)
         | Ok abs_cwd ->
           let clone_url = normalize_github_clone_url url in
           (* Only pass the validated URL — no extra args allowed.
@@ -754,9 +751,12 @@ let handle_code_git ctx args =
                  ]
                  @ code_git_route_fields ctx)
             in
-            (code = 0, Yojson.Safe.pretty_to_string response)
+            (if code = 0
+                  then fun msg -> Tool_result.ok ~tool_name ~start_time msg
+                  else fun msg -> Tool_result.error ~tool_name ~start_time msg)
+                   (Yojson.Safe.pretty_to_string response)
           | _, output ->
-            (false, Printf.sprintf "Git clone failed: %s" (truncate_output output))
+            Tool_result.error ~tool_name ~start_time (Printf.sprintf "Git clone failed: %s" (truncate_output output))
   end
   else begin
     (* Non-clone actions: existing validation *)
@@ -770,17 +770,17 @@ let handle_code_git ctx args =
        List.mem "." git_args)
     in
     if is_dangerous then
-      (false, "Dangerous git operation blocked (force push, main push, or checkout .)")
+      Tool_result.error ~tool_name ~start_time "Dangerous git operation blocked (force push, main push, or checkout .)"
     else begin
       let cwd_result =
-        if String.equal cwd "" then (false, "cwd parameter required for git operations") |> fun (ok, msg) ->
-          if ok then Ok None else Error (System (System_error.IoError msg))
+        if String.equal cwd "" then
+          Error (System (System_error.IoError "cwd parameter required for git operations"))
         else match validate_writable_path ~agent_name:ctx.agent_name ctx.config cwd with
           | Ok abs_cwd -> Ok (Some abs_cwd)
           | Error e -> Error e
       in
       match cwd_result with
-      | Error e -> (false, Masc_domain.masc_error_to_string e)
+      | Error e -> Tool_result.error ~tool_name ~start_time (Masc_domain.masc_error_to_string e)
       | Ok cwd_opt ->
         let dir = match cwd_opt with Some d -> d | None -> "." in
         let cmd = ["sh"; "-c";
@@ -807,9 +807,12 @@ let handle_code_git ctx args =
                ]
                @ code_git_route_fields ctx)
           in
-          (code = 0, Yojson.Safe.pretty_to_string response)
+          (if code = 0
+                  then fun msg -> Tool_result.ok ~tool_name ~start_time msg
+                  else fun msg -> Tool_result.error ~tool_name ~start_time msg)
+                   (Yojson.Safe.pretty_to_string response)
         | _, output ->
-          (false, Printf.sprintf "Git command failed: %s" (truncate_output output))
+          Tool_result.error ~tool_name ~start_time (Printf.sprintf "Git command failed: %s" (truncate_output output))
     end
   end
 
@@ -817,11 +820,11 @@ let handle_code_git ctx args =
 let dispatch ctx ~name ~args : Tool_result.t option =
   let start = Time_compat.now () in
   match name with
-  | "masc_code_write" -> Some (wrap_result ~name ~start (handle_code_write ctx args))
-  | "masc_code_edit" -> Some (wrap_result ~name ~start (handle_code_edit ctx args))
-  | "masc_code_delete" -> Some (wrap_result ~name ~start (handle_code_delete ctx args))
-  | "masc_code_shell" -> Some (wrap_result ~name ~start (handle_code_shell ctx args))
-  | "masc_code_git" -> Some (wrap_result ~name ~start (handle_code_git ctx args))
+  | "masc_code_write" -> Some (handle_code_write ~tool_name:name ~start_time:start ctx args)
+  | "masc_code_edit" -> Some (handle_code_edit ~tool_name:name ~start_time:start ctx args)
+  | "masc_code_delete" -> Some (handle_code_delete ~tool_name:name ~start_time:start ctx args)
+  | "masc_code_shell" -> Some (handle_code_shell ~tool_name:name ~start_time:start ctx args)
+  | "masc_code_git" -> Some (handle_code_git ~tool_name:name ~start_time:start ctx args)
   | _ -> None
 
 (* Tool schemas *)

--- a/lib/tool_code_write.mli
+++ b/lib/tool_code_write.mli
@@ -50,8 +50,6 @@ type context = {
     via [{ Tool_code_write.config; agent_name }] at the
     dispatch site. *)
 
-type tool_result = bool * string
-
 (** {1 Git action SSOT (issue #8522)} *)
 
 (** Variant SSOT for git actions.  Adding a constructor forces

--- a/lib/tool_control.ml
+++ b/lib/tool_control.ml
@@ -22,12 +22,6 @@ module Float = Stdlib.Float
 
 open Tool_args
 
-type tool_result = bool * string
-
-let wrap_result ~name ~start (success, message) =
-  if success then Tool_result.ok ~tool_name:name ~start_time:start message
-  else Tool_result.error ~tool_name:name ~start_time:start message
-
 type context = {
   config: Coord.config;
   agent_name: string;
@@ -35,17 +29,20 @@ type context = {
 
 (* Handlers *)
 
-let handle_pause ctx args =
+let handle_pause ~tool_name ~start_time ctx args =
   let reason = get_string args "reason" "Manual pause" in
   Coord.pause ctx.config ~by:ctx.agent_name ~reason;
-  (true, Printf.sprintf "Paused by %s: %s" ctx.agent_name reason)
+  Tool_result.ok ~tool_name ~start_time
+    (Printf.sprintf "Paused by %s: %s" ctx.agent_name reason)
 
-let handle_resume ctx _args =
+let handle_resume ~tool_name ~start_time ctx _args =
   match Coord.resume ctx.config ~by:ctx.agent_name with
-  | `Resumed -> (true, Printf.sprintf "Resumed by %s" ctx.agent_name)
-  | `Already_running -> (true, "Default project scope is not paused")
+  | `Resumed -> Tool_result.ok ~tool_name ~start_time
+        (Printf.sprintf "Resumed by %s" ctx.agent_name)
+  | `Already_running -> Tool_result.ok ~tool_name ~start_time
+        "Default project scope is not paused"
 
-let handle_pause_status ctx _args =
+let handle_pause_status ~tool_name ~start_time ctx _args =
   let pause_state =
     if not (Coord.is_initialized ctx.config) then `Initializing
     else
@@ -96,7 +93,7 @@ let handle_pause_status ctx _args =
                 "Server is initializing; pause state is not available yet" );
           ]
   in
-  (true, Yojson.Safe.to_string payload)
+  Tool_result.ok ~tool_name ~start_time (Yojson.Safe.to_string payload)
 
 let schemas = Tool_schemas_control.schemas
 
@@ -104,9 +101,9 @@ let schemas = Tool_schemas_control.schemas
 let dispatch ctx ~name ~args : Tool_result.t option =
   let start = Time_compat.now () in
   match name with
-  | "masc_pause" -> Some (wrap_result ~name ~start (handle_pause ctx args))
-  | "masc_resume" -> Some (wrap_result ~name ~start (handle_resume ctx args))
-  | "masc_pause_status" -> Some (wrap_result ~name ~start (handle_pause_status ctx args))
+  | "masc_pause" -> Some (handle_pause ~tool_name:name ~start_time:start ctx args)
+  | "masc_resume" -> Some (handle_resume ~tool_name:name ~start_time:start ctx args)
+  | "masc_pause_status" -> Some (handle_pause_status ~tool_name:name ~start_time:start ctx args)
   | _ -> None
 
 (* ================================================================ *)

--- a/lib/tool_control.mli
+++ b/lib/tool_control.mli
@@ -4,8 +4,6 @@
 
     Dispatches [masc_pause], [masc_resume], [masc_pause_status]. *)
 
-type tool_result = bool * string
-
 type context = {
   config : Coord.config;
   agent_name : string;
@@ -13,11 +11,14 @@ type context = {
 
 (** {1 Handlers} *)
 
-val handle_pause : context -> Yojson.Safe.t -> tool_result
+val handle_pause :
+  tool_name:string -> start_time:float -> context -> Yojson.Safe.t -> Tool_result.t
 
-val handle_resume : context -> Yojson.Safe.t -> tool_result
+val handle_resume :
+  tool_name:string -> start_time:float -> context -> Yojson.Safe.t -> Tool_result.t
 
-val handle_pause_status : context -> Yojson.Safe.t -> tool_result
+val handle_pause_status :
+  tool_name:string -> start_time:float -> context -> Yojson.Safe.t -> Tool_result.t
 
 (** {1 Dispatch} *)
 

--- a/lib/tool_keeper.ml
+++ b/lib/tool_keeper.ml
@@ -1038,9 +1038,9 @@ let handle_keeper_persona_audit ctx args : tool_result =
   let names = keeper_persona_audit_requested_names ctx args in
   let invalid_names = List.filter (fun name -> not (validate_name name)) names in
   if Stdlib.List.length invalid_names > 0 then
-    error_result_typed ~code:Validation_error
+    (false, error_response_typed ~code:Validation_error
       (Printf.sprintf "invalid keeper name(s): %s"
-         (String.concat ", " invalid_names))
+         (String.concat ", " invalid_names)))
   else
     let limit = get_int args "limit" 100 |> max 0 |> min 500 in
     let include_ok = get_bool args "include_ok" true in
@@ -1240,7 +1240,7 @@ let handle_keeper_sandbox_stop ctx args : tool_result =
     | name -> Some name
   in
   match Keeper_sandbox_control.parse_stop_scope container_kind_raw with
-  | Error err -> error_result_typed ~code:Validation_error err
+  | Error err -> (false, error_response_typed ~code:Validation_error err)
   | Ok scope ->
       let stop_result =
         Keeper_sandbox_control.stop_containers
@@ -1358,8 +1358,8 @@ let handle_keeper_compact ctx args : tool_result =
     | None ->
       Prometheus.inc_counter Keeper_metrics.metric_keeper_operator_compact
         ~labels:[("keeper", name); ("result", "not_found")] ();
-      error_result_typed ~code:Validation_error
-        (Printf.sprintf "keeper %s is not in the registry" name)
+      (false, error_response_typed ~code:Validation_error
+        (Printf.sprintf "keeper %s is not in the registry" name))
     | Some entry ->
     let phase_before = Keeper_state_machine.phase_to_string entry.phase in
     (* Phase precondition: Overflowed, Paused, or (Running/Failing with force).
@@ -1374,10 +1374,10 @@ let handle_keeper_compact ctx args : tool_result =
     if not allowed then begin
       Prometheus.inc_counter Keeper_metrics.metric_keeper_operator_compact
         ~labels:[("keeper", name); ("result", "precondition")] ();
-      error_result_typed ~code:Validation_error
+      (false, error_response_typed ~code:Validation_error
         (Printf.sprintf
            "keeper %s is in phase %s; compaction requires Overflowed, Paused, or force=true"
-           name phase_before)
+           name phase_before))
     end
     else begin
       (* Dispatch FSM event *)
@@ -1450,16 +1450,16 @@ let handle_keeper_clear ctx args : tool_result =
   | Ok name ->
     let reason = String.trim (get_string args "reason" "") in
     if String.equal reason "" then
-      error_result_typed ~code:Validation_error
-        "reason is required for masc_keeper_clear (audit trail)"
+      (false, error_response_typed ~code:Validation_error
+        "reason is required for masc_keeper_clear (audit trail)")
     else
     (* Same registry race guard as [handle_keeper_compact]: if the keeper
        disappeared between [resolve_keeper_name] and [get], abort cleanly
        rather than silently proceed with a half-applied clear. *)
     match Keeper_registry.get ~base_path:ctx.config.base_path name with
     | None ->
-      error_result_typed ~code:Validation_error
-        (Printf.sprintf "keeper %s is not in the registry" name)
+      (false, error_response_typed ~code:Validation_error
+        (Printf.sprintf "keeper %s is not in the registry" name))
     | Some entry ->
       let preserve_system = get_bool args "preserve_system_prompt" true in
       let phase_before = Keeper_state_machine.phase_to_string entry.phase in

--- a/lib/tool_library.ml
+++ b/lib/tool_library.ml
@@ -81,12 +81,6 @@ let string_contains ~sub s =
     in
     check 0
 
-type tool_result = bool * string
-
-let wrap_result ~name ~start (success, message) =
-  if success then Tool_result.ok ~tool_name:name ~start_time:start message
-  else Tool_result.error ~tool_name:name ~start_time:start message
-
 type context = {
   agent_name: string;
 }
@@ -176,7 +170,7 @@ let list_documents ?(include_candidates=false) () =
   in
   main_docs @ candidate_docs
 
-let handle_list _ctx args =
+let handle_list ~tool_name ~start_time _ctx args =
   let include_candidates =
     match Yojson.Safe.Util.member "include_candidates" args with
     | `Bool b -> b
@@ -201,13 +195,13 @@ let handle_list _ctx args =
   let output = if Stdlib.List.length entries = 0 then "No documents in library"
     else sprintf "## Library Documents (%d)\n\n%s" (List.length entries) (String.concat "\n" entries)
   in
-  (true, output)
+  Tool_result.ok ~tool_name ~start_time output
 
 (* Read document *)
-let handle_read _ctx args =
+let handle_read ~tool_name ~start_time _ctx args =
   let topic = Yojson.Safe.Util.(member "topic" args |> to_string_option)
     |> Option.value ~default:"" in
-  if String.equal topic "" then (false, "topic is required")
+  if String.equal topic "" then Tool_result.error ~tool_name ~start_time "topic is required"
   else begin
     (* Find matching file *)
     let files = list_documents ~include_candidates:true () in
@@ -216,16 +210,16 @@ let handle_read _ctx args =
       string_contains ~sub:topic (String.lowercase_ascii base)
     ) files in
     match matching with
-    | [] -> (false, sprintf "No document matching '%s'" topic)
+    | [] -> Tool_result.error ~tool_name ~start_time (sprintf "No document matching '%s'" topic)
     | path :: _ ->
         try
           let content = In_channel.with_open_text path In_channel.input_all in
-          (true, sprintf "## %s\n\n%s" (Filename.basename path) content)
-        with Eio.Cancel.Cancelled _ as e -> raise e | exn -> (false, sprintf "Read error: %s" (Stdlib.Printexc.to_string exn))
+          Tool_result.ok ~tool_name ~start_time (sprintf "## %s\n\n%s" (Filename.basename path) content)
+        with Eio.Cancel.Cancelled _ as e -> raise e | exn -> Tool_result.error ~tool_name ~start_time (sprintf "Read error: %s" (Stdlib.Printexc.to_string exn))
   end
 
 (* Add document *)
-let handle_add ctx args =
+let handle_add ~tool_name ~start_time ctx args =
   let module U = Yojson.Safe.Util in
   let title = U.member "title" args |> U.to_string_option |> Option.value ~default:"" in
   let source = U.member "source" args |> U.to_string_option |> Option.value ~default:"direct_experience" in
@@ -234,8 +228,8 @@ let handle_add ctx args =
     with Yojson.Safe.Util.Type_error (_, _) -> [] in
   let content = U.member "content" args |> U.to_string_option |> Option.value ~default:"" in
 
-  if String.equal title "" then (false, "title is required")
-  else if String.equal content "" then (false, "content is required")
+  if String.equal title "" then Tool_result.error ~tool_name ~start_time "title is required"
+  else if String.equal content "" then Tool_result.error ~tool_name ~start_time "content is required"
   else begin
     (* Issue #8601: validate via Variant SSOT instead of List.mem on a
        hand-rolled string list. source_of_string_opt returns None for
@@ -244,8 +238,8 @@ let handle_add ctx args =
        automatically. *)
     match source_of_string_opt source with
     | None ->
-      (false,
-       sprintf "Invalid source. Must be one of: %s"
+      Tool_result.error ~tool_name ~start_time
+       (sprintf "Invalid source. Must be one of: %s"
          (String.concat ", " valid_source_strings))
     | Some _ -> begin
       (* Determine destination based on confidence *)
@@ -283,20 +277,20 @@ verified_by: []
       try
         Out_channel.with_open_text filepath (fun oc -> Out_channel.output_string oc full_content);
         let status = if Stdlib.Float.compare confidence 0.5 < 0 then "candidate (needs verification)" else "library" in
-        (true, sprintf "Document added to %s: %s" status filepath)
-      with Eio.Cancel.Cancelled _ as e -> raise e | exn -> (false, sprintf "Write error: %s" (Stdlib.Printexc.to_string exn))
+        Tool_result.ok ~tool_name ~start_time (sprintf "Document added to %s: %s" status filepath)
+      with Eio.Cancel.Cancelled _ as e -> raise e | exn -> Tool_result.error ~tool_name ~start_time (sprintf "Write error: %s" (Stdlib.Printexc.to_string exn))
     end
   end
 
 (* Promote candidate to library *)
-let handle_promote ctx args =
+let handle_promote ~tool_name ~start_time ctx args =
   let topic = Yojson.Safe.Util.(member "topic" args |> to_string_option)
     |> Option.value ~default:"" in
   let new_confidence = Yojson.Safe.Util.(member "confidence" args |> to_float_option)
     |> Option.value ~default:0.7 in
 
-  if String.equal topic "" then (false, "topic is required")
-  else if Stdlib.Float.compare new_confidence 0.5 < 0 then (false, "confidence must be >= 0.5 to promote")
+  if String.equal topic "" then Tool_result.error ~tool_name ~start_time "topic is required"
+  else if Stdlib.Float.compare new_confidence 0.5 < 0 then Tool_result.error ~tool_name ~start_time "confidence must be >= 0.5 to promote"
   else begin
     let topic_lower = String.lowercase_ascii topic in
     let candidates = list_documents ~include_candidates:true () |> List.filter (fun f ->
@@ -304,7 +298,7 @@ let handle_promote ctx args =
       string_contains ~sub:topic_lower (String.lowercase_ascii (Filename.basename f))
     ) in
     match candidates with
-    | [] -> (false, sprintf "No candidate matching '%s'" topic)
+    | [] -> Tool_result.error ~tool_name ~start_time (sprintf "No candidate matching '%s'" topic)
     | src_path :: _ ->
         try
           let content = In_channel.with_open_text src_path In_channel.input_all in
@@ -322,15 +316,15 @@ let handle_promote ctx args =
           let dest_path = Filename.concat (library_root ()) (Filename.basename src_path) in
           Out_channel.with_open_text dest_path (fun oc -> Out_channel.output_string oc with_verifier);
           Sys.remove src_path;
-          (true, sprintf "Promoted to library: %s (confidence: %.2f)" dest_path new_confidence)
-        with Eio.Cancel.Cancelled _ as e -> raise e | exn -> (false, sprintf "Promote error: %s" (Stdlib.Printexc.to_string exn))
+          Tool_result.ok ~tool_name ~start_time (sprintf "Promoted to library: %s (confidence: %.2f)" dest_path new_confidence)
+        with Eio.Cancel.Cancelled _ as e -> raise e | exn -> Tool_result.error ~tool_name ~start_time (sprintf "Promote error: %s" (Stdlib.Printexc.to_string exn))
   end
 
 (* Search documents *)
-let handle_search _ctx args =
+let handle_search ~tool_name ~start_time _ctx args =
   let query = Yojson.Safe.Util.(member "query" args |> to_string_option)
     |> Option.value ~default:"" in
-  if String.equal query "" then (false, "query is required")
+  if String.equal query "" then Tool_result.error ~tool_name ~start_time "query is required"
   else begin
     let query_lower = String.lowercase_ascii query in
     let docs = list_documents ~include_candidates:true () in
@@ -345,19 +339,19 @@ let handle_search _ctx args =
         else None
       with Sys_error _ -> None
     ) docs in
-    if Stdlib.List.length matches = 0 then (true, sprintf "No documents matching '%s'" query)
-    else (true, sprintf "## Search Results (%d)\n\n%s" (List.length matches) (String.concat "\n" matches))
+    if Stdlib.List.length matches = 0 then Tool_result.ok ~tool_name ~start_time (sprintf "No documents matching '%s'" query)
+    else Tool_result.ok ~tool_name ~start_time (sprintf "## Search Results (%d)\n\n%s" (List.length matches) (String.concat "\n" matches))
   end
 
 (* Dispatch *)
 let dispatch ctx ~name ~args : Tool_result.t option =
   let start = Time_compat.now () in
   match name with
-  | "masc_library_list" -> Some (wrap_result ~name ~start (handle_list ctx args))
-  | "masc_library_read" -> Some (wrap_result ~name ~start (handle_read ctx args))
-  | "masc_library_add" -> Some (wrap_result ~name ~start (handle_add ctx args))
-  | "masc_library_promote" -> Some (wrap_result ~name ~start (handle_promote ctx args))
-  | "masc_library_search" -> Some (wrap_result ~name ~start (handle_search ctx args))
+  | "masc_library_list" -> Some (handle_list ~tool_name:name ~start_time:start ctx args)
+  | "masc_library_read" -> Some (handle_read ~tool_name:name ~start_time:start ctx args)
+  | "masc_library_add" -> Some (handle_add ~tool_name:name ~start_time:start ctx args)
+  | "masc_library_promote" -> Some (handle_promote ~tool_name:name ~start_time:start ctx args)
+  | "masc_library_search" -> Some (handle_search ~tool_name:name ~start_time:start ctx args)
   | _ -> None
 
 (* Tool definitions for MCP protocol *)

--- a/lib/tool_library.mli
+++ b/lib/tool_library.mli
@@ -71,11 +71,7 @@ val string_contains : sub:string -> string -> bool
     lowercase both inputs when case-insensitive matching is
     required (see {!handle_read} / {!handle_search}). *)
 
-(** {1 Tool result + context} *)
-
-type tool_result = bool * string
-(** [(success, message)] return shape used by every dispatch
-    handler. *)
+(** {1 Context} *)
 
 type context = {
   agent_name : string;
@@ -97,15 +93,15 @@ val candidates_dir : unit -> string
 
 (** {1 Direct handlers} *)
 
-val handle_read : 'ctx -> Yojson.Safe.t -> tool_result
-(** [handle_read _ctx args] handles [masc_library_read].
+val handle_read : tool_name:string -> start_time:float -> 'ctx -> Yojson.Safe.t -> Tool_result.t
+(** [handle_read ~tool_name ~start_time _ctx args] handles [masc_library_read].
     Required arg: [topic] (string, partial-match against
-    Markdown filename).  Returns [(false, _)] when [topic] is
-    missing or no document matches; otherwise [(true,
-    "## <basename>\n\n<content>")]. *)
+    Markdown filename).  Returns error when [topic] is
+    missing or no document matches; otherwise ok with
+    ["## <basename>\n\n<content>"]. *)
 
-val handle_search : 'ctx -> Yojson.Safe.t -> tool_result
-(** [handle_search _ctx args] handles [masc_library_search].
+val handle_search : tool_name:string -> start_time:float -> 'ctx -> Yojson.Safe.t -> Tool_result.t
+(** [handle_search ~tool_name ~start_time _ctx args] handles [masc_library_search].
     Required arg: [query] (string, lowercase substring matched
     against document content).  Returns a Markdown bullet list
     when matches exist, or a plain ["No documents matching

--- a/lib/tool_misc.ml
+++ b/lib/tool_misc.ml
@@ -153,8 +153,8 @@ let dispatch ctx ~name ~args : Tool_result.t option =
   in
   match name with
   | "masc_config" -> Some (wrap_result ~name ~start (Tool_misc_admin.handle_config args))
-  | "masc_webrtc_offer" -> Some (wrap_result ~name ~start (Tool_misc_transport.handle_webrtc_offer args))
-  | "masc_webrtc_answer" -> Some (wrap_result ~name ~start (Tool_misc_transport.handle_webrtc_answer args))
+  | "masc_webrtc_offer" -> Some (Tool_misc_transport.handle_webrtc_offer args)
+  | "masc_webrtc_answer" -> Some (Tool_misc_transport.handle_webrtc_answer args)
   | "masc_dashboard" -> Some (wrap_result ~name ~start (handle_dashboard ctx args))
   | "masc_gc" -> Some (wrap_result ~name ~start (handle_gc ctx args))
   | "masc_cleanup_zombies" -> Some (wrap_result ~name ~start (handle_cleanup_zombies ctx args))

--- a/lib/tool_misc_transport.ml
+++ b/lib/tool_misc_transport.ml
@@ -24,7 +24,7 @@ module Float = Stdlib.Float
 
 open Tool_args
 
-type tool_result = bool * string
+type tool_result = Tool_result.t
 
 (* ================================================================ *)
 (* Local helpers (duplicated from tool_misc to avoid circular deps) *)
@@ -54,7 +54,7 @@ let handle_transport_status _args : tool_result =
       ~allow_legacy_accept:(env_flag_enabled "MASC_ALLOW_LEGACY_ACCEPT") ()
   in
   let json = Transport_read_model.transport_status_json ctx in
-  (true, Yojson.Safe.to_string json)
+  Tool_result.quick_ok (Yojson.Safe.to_string json)
 
 let handle_websocket_discovery _args : tool_result =
   let ctx =
@@ -62,7 +62,7 @@ let handle_websocket_discovery _args : tool_result =
       ~allow_legacy_accept:(env_flag_enabled "MASC_ALLOW_LEGACY_ACCEPT") ()
   in
   let json = Transport_read_model.websocket_discovery_json ctx in
-  (true, Yojson.Safe.to_string json)
+  Tool_result.quick_ok (Yojson.Safe.to_string json)
 
 let handle_webrtc_offer args : tool_result =
   if not (Server_webrtc_transport.is_enabled ()) then
@@ -85,7 +85,7 @@ let handle_webrtc_offer args : tool_result =
     Server_webrtc_transport.handle_offer_request
       (Yojson.Safe.to_string (`Assoc fields))
   with
-  | Ok body -> (true, pretty_json_string body)
+  | Ok body -> Tool_result.quick_ok (pretty_json_string body)
   | Error msg -> error_result msg
 
 let handle_webrtc_answer args : tool_result =
@@ -105,5 +105,5 @@ let handle_webrtc_answer args : tool_result =
     |> Yojson.Safe.to_string
   in
   match Server_webrtc_transport.handle_answer_request body with
-  | Ok response -> (true, pretty_json_string response)
+  | Ok response -> Tool_result.quick_ok (pretty_json_string response)
   | Error msg -> error_result msg

--- a/lib/tool_misc_transport.mli
+++ b/lib/tool_misc_transport.mli
@@ -7,7 +7,7 @@
 
     @since 2.188.0 *)
 
-type tool_result = bool * string
+type tool_result = Tool_result.t
 
 (** {1 Transport status} *)
 

--- a/lib/tool_plan.ml
+++ b/lib/tool_plan.ml
@@ -27,19 +27,11 @@ type context = {
   config: Coord.config;
 }
 
-(** Tool result type *)
-type tool_result = bool * string
-
-(** Wrap a [(bool * string)] result into a structured [Tool_result.t]. *)
-let wrap_result ~name ~start (success, message) =
-  if success then Tool_result.ok ~tool_name:name ~start_time:start message
-  else Tool_result.error ~tool_name:name ~start_time:start message
-
 open Tool_args
 
 (** {1 Individual Handlers} *)
 
-let handle_plan_init ctx args : tool_result =
+let handle_plan_init ~tool_name ~start_time ctx args =
   let task_id = get_string args "task_id" "" in
   let result = Planning_eio.init ctx.config ~task_id in
   match result with
@@ -49,11 +41,11 @@ let handle_plan_init ctx args : tool_result =
         ("task_id", `String task_id);
         ("message", `String (Printf.sprintf "Planning context created for %s" task_id));
       ] in
-      (true, Yojson.Safe.to_string response)
+      Tool_result.ok ~tool_name ~start_time (Yojson.Safe.to_string response)
   | Error e ->
-      (false, Printf.sprintf "Failed to init planning: %s" e)
+      Tool_result.error ~tool_name ~start_time (Printf.sprintf "Failed to init planning: %s" e)
 
-let handle_plan_update ctx args : tool_result =
+let handle_plan_update ~tool_name ~start_time ctx args =
   let task_id = get_string args "task_id" "" in
   let content = get_string args "content" "" in
   let result = Planning_eio.update_plan ctx.config ~task_id ~content in
@@ -64,11 +56,11 @@ let handle_plan_update ctx args : tool_result =
         ("task_id", `String task_id);
         ("updated_at", `String plan_ctx.Planning_eio.updated_at);
       ] in
-      (true, Yojson.Safe.to_string response)
+      Tool_result.ok ~tool_name ~start_time (Yojson.Safe.to_string response)
   | Error e ->
-      (false, Printf.sprintf "Failed to update plan: %s" e)
+      Tool_result.error ~tool_name ~start_time (Printf.sprintf "Failed to update plan: %s" e)
 
-let handle_note_add ctx args : tool_result =
+let handle_note_add ~tool_name ~start_time ctx args =
   let task_id = get_string args "task_id" "" in
   let note = get_string args "note" "" in
   let result = Planning_eio.add_note ctx.config ~task_id ~note in
@@ -79,18 +71,18 @@ let handle_note_add ctx args : tool_result =
         ("task_id", `String task_id);
         ("note_count", `Int (List.length plan_ctx.Planning_eio.notes));
       ] in
-      (true, Yojson.Safe.to_string response)
+      Tool_result.ok ~tool_name ~start_time (Yojson.Safe.to_string response)
   | Error e ->
-      (false, Printf.sprintf "Failed to add note: %s" e)
+      Tool_result.error ~tool_name ~start_time (Printf.sprintf "Failed to add note: %s" e)
 
-let handle_deliver ctx args : tool_result =
+let handle_deliver ~tool_name ~start_time ctx args =
   let task_id_input = get_string args "task_id" "" in
   match Planning_eio.resolve_task_id ctx.config ~task_id:task_id_input with
-  | Error e -> (false, Printf.sprintf "%s" e)
+  | Error e -> Tool_result.error ~tool_name ~start_time (Printf.sprintf "%s" e)
   | Ok task_id ->
   let content = get_string args "content" "" in
   if String.equal (String.trim content) "" then
-    (false, "content is required for masc_deliver")
+    Tool_result.error ~tool_name ~start_time "content is required for masc_deliver"
   else
   let result = Planning_eio.set_deliverable ctx.config ~task_id ~content in
   match result with
@@ -100,14 +92,14 @@ let handle_deliver ctx args : tool_result =
         ("task_id", `String task_id);
         ("updated_at", `String plan_ctx.Planning_eio.updated_at);
       ] in
-      (true, Yojson.Safe.to_string response)
+      Tool_result.ok ~tool_name ~start_time (Yojson.Safe.to_string response)
   | Error e ->
-      (false, Printf.sprintf "Failed to set deliverable: %s" e)
+      Tool_result.error ~tool_name ~start_time (Printf.sprintf "Failed to set deliverable: %s" e)
 
-let handle_plan_get ctx args : tool_result =
+let handle_plan_get ~tool_name ~start_time ctx args =
   let task_id_input = get_string args "task_id" "" in
   match Planning_eio.resolve_task_id ctx.config ~task_id:task_id_input with
-  | Error e -> (false, Printf.sprintf "%s" e)
+  | Error e -> Tool_result.error ~tool_name ~start_time (Printf.sprintf "%s" e)
   | Ok task_id ->
       let result = Planning_eio.load ctx.config ~task_id in
       match result with
@@ -118,58 +110,58 @@ let handle_plan_get ctx args : tool_result =
             ("context", Planning_eio.planning_context_to_yojson plan_ctx);
             ("markdown", `String markdown);
           ] in
-          (true, Yojson.Safe.to_string response)
+          Tool_result.ok ~tool_name ~start_time (Yojson.Safe.to_string response)
       | Error e ->
-          (false, Printf.sprintf "Planning context not found: %s" e)
+          Tool_result.error ~tool_name ~start_time (Printf.sprintf "Planning context not found: %s" e)
 
-let handle_plan_set_task ctx args : tool_result =
+let handle_plan_set_task ~tool_name ~start_time ctx args =
   let task_id = get_string args "task_id" "" in
   if String.equal task_id "" then
-    (false, "task_id is required")
+    Tool_result.error ~tool_name ~start_time "task_id is required"
   else begin
     Planning_eio.set_current_task ctx.config ~task_id;
     let response = `Assoc [
       ("status", `String "set");
       ("current_task", `String task_id);
     ] in
-    (true, Yojson.Safe.to_string response)
+    Tool_result.ok ~tool_name ~start_time (Yojson.Safe.to_string response)
   end
 
-let handle_plan_get_task ctx _args : tool_result =
+let handle_plan_get_task ~tool_name ~start_time ctx _args =
   match Planning_eio.get_current_task ctx.config with
   | Some task_id ->
       let response = `Assoc [
         ("current_task", `String task_id);
       ] in
-      (true, Yojson.Safe.to_string response)
+      Tool_result.ok ~tool_name ~start_time (Yojson.Safe.to_string response)
   | None ->
       let response = `Assoc [
         ("current_task", `Null);
         ("message", `String "No current task set. Use masc_plan_set_task first.");
       ] in
-      (true, Yojson.Safe.to_string response)
+      Tool_result.ok ~tool_name ~start_time (Yojson.Safe.to_string response)
 
-let handle_plan_clear_task ctx _args : tool_result =
+let handle_plan_clear_task ~tool_name ~start_time ctx _args =
   Planning_eio.clear_current_task ctx.config;
   let response = `Assoc [
     ("status", `String "cleared");
     ("message", `String "Current task cleared");
   ] in
-  (true, Yojson.Safe.to_string response)
+  Tool_result.ok ~tool_name ~start_time (Yojson.Safe.to_string response)
 
 (** {1 Dispatcher} *)
 
 let dispatch ctx ~name ~args : Tool_result.t option =
   let start = Time_compat.now () in
   match name with
-  | "masc_plan_init" -> Some (wrap_result ~name ~start (handle_plan_init ctx args))
-  | "masc_plan_update" -> Some (wrap_result ~name ~start (handle_plan_update ctx args))
-  | "masc_note_add" -> Some (wrap_result ~name ~start (handle_note_add ctx args))
-  | "masc_deliver" -> Some (wrap_result ~name ~start (handle_deliver ctx args))
-  | "masc_plan_get" -> Some (wrap_result ~name ~start (handle_plan_get ctx args))
-  | "masc_plan_set_task" -> Some (wrap_result ~name ~start (handle_plan_set_task ctx args))
-  | "masc_plan_get_task" -> Some (wrap_result ~name ~start (handle_plan_get_task ctx args))
-  | "masc_plan_clear_task" -> Some (wrap_result ~name ~start (handle_plan_clear_task ctx args))
+  | "masc_plan_init" -> Some (handle_plan_init ~tool_name:name ~start_time:start ctx args)
+  | "masc_plan_update" -> Some (handle_plan_update ~tool_name:name ~start_time:start ctx args)
+  | "masc_note_add" -> Some (handle_note_add ~tool_name:name ~start_time:start ctx args)
+  | "masc_deliver" -> Some (handle_deliver ~tool_name:name ~start_time:start ctx args)
+  | "masc_plan_get" -> Some (handle_plan_get ~tool_name:name ~start_time:start ctx args)
+  | "masc_plan_set_task" -> Some (handle_plan_set_task ~tool_name:name ~start_time:start ctx args)
+  | "masc_plan_get_task" -> Some (handle_plan_get_task ~tool_name:name ~start_time:start ctx args)
+  | "masc_plan_clear_task" -> Some (handle_plan_clear_task ~tool_name:name ~start_time:start ctx args)
   | _ -> None
 
 let schemas = Tool_schemas_plan.schemas

--- a/lib/tool_plan.mli
+++ b/lib/tool_plan.mli
@@ -2,7 +2,7 @@
 (** Plan Tool Handlers
 
     Extracted from mcp_server_eio.ml for testability.
-    9 tools: plan_init, plan_update, note_add, deliver, plan_get,
+    8 tools: plan_init, plan_update, note_add, deliver, plan_get,
              plan_set_task, plan_get_task, plan_clear_task
 *)
 
@@ -11,19 +11,16 @@ type context = {
   config: Coord.config;
 }
 
-(** Tool result type *)
-type tool_result = bool * string
-
 (** {1 Individual Handlers} *)
 
-val handle_plan_init : context -> Yojson.Safe.t -> tool_result
-val handle_plan_update : context -> Yojson.Safe.t -> tool_result
-val handle_note_add : context -> Yojson.Safe.t -> tool_result
-val handle_deliver : context -> Yojson.Safe.t -> tool_result
-val handle_plan_get : context -> Yojson.Safe.t -> tool_result
-val handle_plan_set_task : context -> Yojson.Safe.t -> tool_result
-val handle_plan_get_task : context -> Yojson.Safe.t -> tool_result
-val handle_plan_clear_task : context -> Yojson.Safe.t -> tool_result
+val handle_plan_init : tool_name:string -> start_time:float -> context -> Yojson.Safe.t -> Tool_result.t
+val handle_plan_update : tool_name:string -> start_time:float -> context -> Yojson.Safe.t -> Tool_result.t
+val handle_note_add : tool_name:string -> start_time:float -> context -> Yojson.Safe.t -> Tool_result.t
+val handle_deliver : tool_name:string -> start_time:float -> context -> Yojson.Safe.t -> Tool_result.t
+val handle_plan_get : tool_name:string -> start_time:float -> context -> Yojson.Safe.t -> Tool_result.t
+val handle_plan_set_task : tool_name:string -> start_time:float -> context -> Yojson.Safe.t -> Tool_result.t
+val handle_plan_get_task : tool_name:string -> start_time:float -> context -> Yojson.Safe.t -> Tool_result.t
+val handle_plan_clear_task : tool_name:string -> start_time:float -> context -> Yojson.Safe.t -> Tool_result.t
 
 (** {1 Dispatcher} *)
 

--- a/lib/tool_run.ml
+++ b/lib/tool_run.ml
@@ -26,89 +26,82 @@ type context = {
   config: Coord.config;
 }
 
-(** Tool result type *)
-type tool_result = bool * string
-
-let wrap_result ~name ~start (success, message) =
-  if success then Tool_result.ok ~tool_name:name ~start_time:start message
-  else Tool_result.error ~tool_name:name ~start_time:start message
-
 open Tool_args
 
 (** {1 Individual Handlers} *)
 
-let handle_run_init ctx args : tool_result =
+let handle_run_init ~tool_name ~start_time ctx args =
   let task_id = get_string args "task_id" "" in
   if String.equal task_id "" then
-    (false, "task_id is required")
+    Tool_result.error ~tool_name ~start_time "task_id is required"
   else
     let agent = get_string_opt args "agent_name" in
     match Run_eio.init ctx.config ~task_id ~agent_name:agent with
   | Ok run ->
-      (true, Yojson.Safe.to_string (Run_eio.run_record_to_json run))
+      Tool_result.ok ~tool_name ~start_time (Yojson.Safe.to_string (Run_eio.run_record_to_json run))
   | Error e ->
-      (false, Printf.sprintf "Failed to init run: %s" e)
+      Tool_result.error ~tool_name ~start_time (Printf.sprintf "Failed to init run: %s" e)
 
-let handle_run_plan ctx args : tool_result =
+let handle_run_plan ~tool_name ~start_time ctx args =
   let task_id = get_string args "task_id" "" in
   if String.equal task_id "" then
-    (false, "task_id is required")
+    Tool_result.error ~tool_name ~start_time "task_id is required"
   else
     let plan = get_string args "plan" "" in
     match Run_eio.update_plan ctx.config ~task_id ~content:plan with
   | Ok run ->
-      (true, Yojson.Safe.to_string (Run_eio.run_record_to_json run))
+      Tool_result.ok ~tool_name ~start_time (Yojson.Safe.to_string (Run_eio.run_record_to_json run))
   | Error e ->
-      (false, Printf.sprintf "Failed to update run plan: %s" e)
+      Tool_result.error ~tool_name ~start_time (Printf.sprintf "Failed to update run plan: %s" e)
 
-let handle_run_log ctx args : tool_result =
+let handle_run_log ~tool_name ~start_time ctx args =
   let task_id = get_string args "task_id" "" in
   if String.equal task_id "" then
-    (false, "task_id is required")
+    Tool_result.error ~tool_name ~start_time "task_id is required"
   else
     let note = get_string args "note" "" in
     match Run_eio.append_log ctx.config ~task_id ~note with
   | Ok entry ->
-      (true, Yojson.Safe.to_string (Run_eio.log_entry_to_json entry))
+      Tool_result.ok ~tool_name ~start_time (Yojson.Safe.to_string (Run_eio.log_entry_to_json entry))
   | Error e ->
-      (false, Printf.sprintf "Failed to append run log: %s" e)
+      Tool_result.error ~tool_name ~start_time (Printf.sprintf "Failed to append run log: %s" e)
 
-let handle_run_deliverable ctx args : tool_result =
+let handle_run_deliverable ~tool_name ~start_time ctx args =
   let task_id = get_string args "task_id" "" in
   if String.equal task_id "" then
-    (false, "task_id is required")
+    Tool_result.error ~tool_name ~start_time "task_id is required"
   else
     let deliverable = get_string args "deliverable" "" in
     match Run_eio.set_deliverable ctx.config ~task_id ~content:deliverable with
   | Ok run ->
-      (true, Yojson.Safe.to_string (Run_eio.run_record_to_json run))
+      Tool_result.ok ~tool_name ~start_time (Yojson.Safe.to_string (Run_eio.run_record_to_json run))
   | Error e ->
-      (false, Printf.sprintf "Failed to set run deliverable: %s" e)
+      Tool_result.error ~tool_name ~start_time (Printf.sprintf "Failed to set run deliverable: %s" e)
 
-let handle_run_get ctx args : tool_result =
+let handle_run_get ~tool_name ~start_time ctx args =
   let task_id = get_string args "task_id" "" in
   if String.equal task_id "" then
-    (false, "task_id is required")
+    Tool_result.error ~tool_name ~start_time "task_id is required"
   else
     match Run_eio.get ctx.config ~task_id with
-    | Ok json -> (true, Yojson.Safe.to_string json)
-    | Error e -> (false, Printf.sprintf "Failed to get run: %s" e)
+    | Ok json -> Tool_result.ok ~tool_name ~start_time (Yojson.Safe.to_string json)
+    | Error e -> Tool_result.error ~tool_name ~start_time (Printf.sprintf "Failed to get run: %s" e)
 
-let handle_run_list ctx _args : tool_result =
+let handle_run_list ~tool_name ~start_time ctx _args =
   let json = Run_eio.list ctx.config in
-  (true, Yojson.Safe.to_string json)
+  Tool_result.ok ~tool_name ~start_time (Yojson.Safe.to_string json)
 
 (** {1 Dispatcher} *)
 
 let dispatch ctx ~name ~args : Tool_result.t option =
   let start = Time_compat.now () in
   match name with
-  | "masc_run_init" -> Some (wrap_result ~name ~start (handle_run_init ctx args))
-  | "masc_run_plan" -> Some (wrap_result ~name ~start (handle_run_plan ctx args))
-  | "masc_run_log" -> Some (wrap_result ~name ~start (handle_run_log ctx args))
-  | "masc_run_deliverable" -> Some (wrap_result ~name ~start (handle_run_deliverable ctx args))
-  | "masc_run_get" -> Some (wrap_result ~name ~start (handle_run_get ctx args))
-  | "masc_run_list" -> Some (wrap_result ~name ~start (handle_run_list ctx args))
+  | "masc_run_init" -> Some (handle_run_init ~tool_name:name ~start_time:start ctx args)
+  | "masc_run_plan" -> Some (handle_run_plan ~tool_name:name ~start_time:start ctx args)
+  | "masc_run_log" -> Some (handle_run_log ~tool_name:name ~start_time:start ctx args)
+  | "masc_run_deliverable" -> Some (handle_run_deliverable ~tool_name:name ~start_time:start ctx args)
+  | "masc_run_get" -> Some (handle_run_get ~tool_name:name ~start_time:start ctx args)
+  | "masc_run_list" -> Some (handle_run_list ~tool_name:name ~start_time:start ctx args)
   | _ -> None
 
 let schemas : Masc_domain.tool_schema list = [

--- a/lib/tool_run.mli
+++ b/lib/tool_run.mli
@@ -10,17 +10,14 @@ type context = {
   config: Coord.config;
 }
 
-(** Tool result type *)
-type tool_result = bool * string
-
 (** {1 Individual Handlers} *)
 
-val handle_run_init : context -> Yojson.Safe.t -> tool_result
-val handle_run_plan : context -> Yojson.Safe.t -> tool_result
-val handle_run_log : context -> Yojson.Safe.t -> tool_result
-val handle_run_deliverable : context -> Yojson.Safe.t -> tool_result
-val handle_run_get : context -> Yojson.Safe.t -> tool_result
-val handle_run_list : context -> Yojson.Safe.t -> tool_result
+val handle_run_init : tool_name:string -> start_time:float -> context -> Yojson.Safe.t -> Tool_result.t
+val handle_run_plan : tool_name:string -> start_time:float -> context -> Yojson.Safe.t -> Tool_result.t
+val handle_run_log : tool_name:string -> start_time:float -> context -> Yojson.Safe.t -> Tool_result.t
+val handle_run_deliverable : tool_name:string -> start_time:float -> context -> Yojson.Safe.t -> Tool_result.t
+val handle_run_get : tool_name:string -> start_time:float -> context -> Yojson.Safe.t -> Tool_result.t
+val handle_run_list : tool_name:string -> start_time:float -> context -> Yojson.Safe.t -> Tool_result.t
 
 (** {1 Dispatcher} *)
 

--- a/lib/tool_suspend.mli
+++ b/lib/tool_suspend.mli
@@ -64,7 +64,7 @@ val schemas : Masc_domain.tool_schema list
     blacklist + circuit-breaker behaviours used by the join guard. *)
 
 val dispatch :
-  context -> name:string -> args:Yojson.Safe.t -> (bool * string) option
+  context -> name:string -> args:Yojson.Safe.t -> Tool_result.t option
 (** [dispatch ctx ~name ~args] is the JSON-RPC dispatch hook.
     Currently always returns [None] (no tools dispatched here)
     because {!schemas} is empty.  The function is kept for the

--- a/lib/tool_task.ml
+++ b/lib/tool_task.ml
@@ -23,12 +23,6 @@ module Float = Stdlib.Float
 
 open Yojson.Safe.Util
 
-type tool_result = bool * string
-
-let wrap_result ~name ~start (success, message) =
-  if success then Tool_result.ok ~tool_name:name ~start_time:start message
-  else Tool_result.error ~tool_name:name ~start_time:start message
-
 type context = {
   config: Coord.config;
   agent_name: string;
@@ -37,9 +31,9 @@ type context = {
 
 open Tool_args
 
-let result_to_response = function
-  | Ok msg -> (true, msg)
-  | Error e -> (false, Masc_domain.masc_error_to_string e)
+let result_to_response ~tool_name ~start_time = function
+  | Ok msg -> Tool_result.ok ~tool_name ~start_time msg
+  | Error e -> Tool_result.error ~tool_name ~start_time (Masc_domain.masc_error_to_string e)
 
 let build_claim_observation_payload ~(now : float) ~(agent_name : string)
     ~(task_id : string) : Yojson.Safe.t =
@@ -449,15 +443,15 @@ let persisted_contract_rejection ~(ctx : context)
 
 (* Handlers *)
 
-let handle_add_task ctx args =
+let handle_add_task ~tool_name ~start_time ctx args =
   let valid_keys = [ "title"; "priority"; "description"; "goal_id"; "contract" ] in
   let unknown = unknown_args ~valid_keys args in
   if Stdlib.List.length unknown > 0 then
-    ( false
-    , Printf.sprintf
+    Tool_result.error ~tool_name ~start_time
+      (Printf.sprintf
         "Unknown argument(s): %s. Valid: %s"
         (String.concat ", " unknown)
-        (String.concat ", " valid_keys) )
+        (String.concat ", " valid_keys))
   else
   let title = get_string args "title" "" in
   let priority = get_int args "priority" 3 in
@@ -471,37 +465,33 @@ let handle_add_task ctx args =
   (* BUG-009/010: Validate title and priority *)
   let trimmed_title = String.trim title in
   if String.equal trimmed_title "" then
-    (false, "Task title cannot be empty or whitespace-only")
+    Tool_result.error ~tool_name ~start_time "Task title cannot be empty or whitespace-only"
   else if priority < 1 || priority > 5 then
-    (false, Printf.sprintf "Priority must be between 1 and 5, got %d" priority)
+    Tool_result.error ~tool_name ~start_time (Printf.sprintf "Priority must be between 1 and 5, got %d" priority)
   else if Option.is_some goal_id
           && not
                (Goal_store.list_goals ctx.config ()
                 |> List.exists (fun (goal : Goal_store.goal) ->
                        String.equal goal.id (Option.value ~default:"" goal_id)))
   then
-    (false, Printf.sprintf "Unknown goal_id '%s'" (Option.value ~default:"" goal_id))
+    Tool_result.error ~tool_name ~start_time (Printf.sprintf "Unknown goal_id '%s'" (Option.value ~default:"" goal_id))
   else
     match contract_result with
-    | Error error -> (false, error)
+    | Error error -> Tool_result.error ~tool_name ~start_time error
     | Ok contract ->
-        (* RFC-0034.v2: per-goal cap via [reject_if]. Add_task surfaces a
-           rejection as "Error: <msg>" string, kept consistent with the
-           pre-existing dedup rejection path. With [goal_id = None] the
-           guard is a no-op. *)
-        ( true,
-          Coord.add_task ?contract ?goal_id
+        Tool_result.ok ~tool_name ~start_time
+          (Coord.add_task ?contract ?goal_id
             ~reject_if:(Coord_task_capacity.rejection_for_add_task ?goal_id)
             ~created_by:ctx.agent_name ctx.config ~title:trimmed_title
-            ~priority ~description )
+            ~priority ~description)
 
-let handle_batch_add_tasks ctx args =
+let handle_batch_add_tasks ~tool_name ~start_time ctx args =
   let tasks_json = match args |> member "tasks" with
     | `List l -> l
     | _ -> []
   in
   if Stdlib.List.length tasks_json = 0 then
-    (false, "tasks array is empty or missing")
+    Tool_result.error ~tool_name ~start_time "tasks array is empty or missing"
   else
   let validated = List.mapi (fun idx t ->
     let title = String.trim (t |> member "title" |> to_string) in
@@ -549,23 +539,23 @@ let handle_batch_add_tasks ctx args =
   ) tasks_json in
   let errors = List.filter_map (function Error e -> Some e | Ok _ -> None) validated in
   if Stdlib.List.length errors > 0 then
-    (false, Printf.sprintf "Validation failed:\n%s" (String.concat "\n" errors))
+    Tool_result.error ~tool_name ~start_time (Printf.sprintf "Validation failed:\n%s" (String.concat "\n" errors))
   else
     let tasks =
       List.filter_map (function Ok t -> Some t | Error _ -> None) validated
     in
-    (true, Coord.batch_add_tasks_with_contracts
+    Tool_result.ok ~tool_name ~start_time (Coord.batch_add_tasks_with_contracts
       ~created_by:ctx.agent_name ctx.config tasks)
 
-let handle_claim ?agent_tool_names ctx args =
+let handle_claim ?agent_tool_names ~tool_name ~start_time ctx args =
   if not (try Coord.is_agent_joined ctx.config ~agent_name:ctx.agent_name with Sys_error _ | Stdlib.Not_found -> false) then
-    result_to_response (Error (Masc_domain.Agent (Masc_domain.Agent_error.NotJoined ctx.agent_name)))
+    result_to_response ~tool_name ~start_time (Error (Masc_domain.Agent (Masc_domain.Agent_error.NotJoined ctx.agent_name)))
   else if not ((=) (args |> member "agent_role") `Null) then
-    (false, "agent_role is no longer supported")
+    Tool_result.error ~tool_name ~start_time "agent_role is no longer supported"
   else
   let task_id = get_string args "task_id" "" in
   match validate_task_id task_id with
-  | Error e -> result_to_response (Error e)
+  | Error e -> result_to_response ~tool_name ~start_time (Error e)
   | Ok task_id ->
   let agent_tool_names =
     match agent_tool_names with
@@ -587,11 +577,11 @@ let handle_claim ?agent_tool_names ctx args =
          ("timestamp", `Float (Time_compat.now ()));
        ])
    | Error e -> Log.Task.warn "task claim failed for %s: %s" task_id (Masc_domain.masc_error_to_string e));
-  result_to_response result
+  result_to_response ~tool_name ~start_time result
 
-let handle_claim_next ?agent_tool_names ctx _args =
+let handle_claim_next ?agent_tool_names ~tool_name ~start_time ctx _args =
   if not (try Coord.is_agent_joined ctx.config ~agent_name:ctx.agent_name with Sys_error _ | Stdlib.Not_found -> false) then
-    (false, Printf.sprintf "Agent '%s' is not a member of this room" ctx.agent_name)
+    Tool_result.error ~tool_name ~start_time (Printf.sprintf "Agent '%s' is not a member of this room" ctx.agent_name)
   else
   let agent_tool_names =
     match agent_tool_names with
@@ -612,23 +602,23 @@ let handle_claim_next ?agent_tool_names ctx _args =
         Printf.sprintf "No eligible tasks available (blocked/excluded: %d)" excluded_count
     | Coord.Claim_next_error e -> Printf.sprintf "Error: %s" e
   in
-  (true, message)
+  Tool_result.ok ~tool_name ~start_time message
 
-let handle_release ctx args =
+let handle_release ~tool_name ~start_time ctx args =
   let task_id = get_string args "task_id" "" in
   match validate_task_id task_id with
-  | Error e -> result_to_response (Error e)
+  | Error e -> result_to_response ~tool_name ~start_time (Error e)
   | Ok task_id ->
   let expected_version = get_int_opt args "expected_version" in
   let tasks = Coord.get_tasks_raw ctx.config in
   let task_opt = List.find_opt (fun (t : Masc_domain.task) -> String.equal t.id task_id) tasks in
   let handoff_context = parse_handoff_context ~agent_name:ctx.agent_name args in
   (match handoff_context with
-   | Error error -> (false, error)
+   | Error error -> Tool_result.error ~tool_name ~start_time error
    | Ok handoff_context ->
        if strict_release_requires_handoff task_opt && Option.is_none handoff_context
        then
-         (false, "Strict task release requires handoff_context.summary")
+         Tool_result.error ~tool_name ~start_time "Strict task release requires handoff_context.summary"
        else
          let result =
            Coord.release_task_r ctx.config ~agent_name:ctx.agent_name ~task_id
@@ -639,7 +629,7 @@ let handle_release ctx args =
             sync_keeper_current_task_binding ctx;
             sync_planning_current_task_with_owned_task ctx
           | Error _ -> ());
-         result_to_response result)
+         result_to_response ~tool_name ~start_time result)
 
 let transition_known_args =
   [
@@ -655,9 +645,9 @@ let transition_known_args =
     "handoff_context";
   ]
 
-let rec handle_done ctx args =
+let rec handle_done ~tool_name ~start_time ctx args =
   let notes = get_string args "notes" "" in
-  handle_transition ctx
+  handle_transition ~tool_name ~start_time ctx
     (`Assoc
        [
          ("task_id", args |> member "task_id");
@@ -665,10 +655,10 @@ let rec handle_done ctx args =
          ("notes", `String notes);
        ])
 
-and handle_cancel_task ctx args =
+and handle_cancel_task ~tool_name ~start_time ctx args =
   let task_id = get_string args "task_id" "" in
   match validate_task_id task_id with
-  | Error e -> result_to_response (Error e)
+  | Error e -> result_to_response ~tool_name ~start_time (Error e)
   | Ok task_id ->
   let reason = get_string args "reason" "" in
   let tasks = Coord.get_tasks_raw ctx.config in
@@ -719,9 +709,9 @@ and handle_cancel_task ctx args =
        ])
    | Error err ->
        Log.Task.error "metrics record failed: %s" (Masc_domain.masc_error_to_string err));
-  result_to_response result
+  result_to_response ~tool_name ~start_time result
 
-and handle_transition ?agent_tool_names ctx args =
+and handle_transition ?agent_tool_names ~tool_name ~start_time ctx args =
   (* Underscore-prefixed keys (e.g. "_agent_name") are internal protocol markers
      injected by the HTTP transport and dashboard client for identity
      propagation. They are consumed upstream in Agent_identity and must not
@@ -785,19 +775,19 @@ and handle_transition ?agent_tool_names ctx args =
   in
   if Stdlib.List.length unknown > 0 then
     let names = String.concat ", " (List.map fst unknown) in
-    (false, Printf.sprintf "Unknown argument(s): %s. Valid: %s"
+    Tool_result.error ~tool_name ~start_time (Printf.sprintf "Unknown argument(s): %s. Valid: %s"
       names (String.concat ", " transition_known_args))
   else
   let task_id = get_string args "task_id" "" in
   match validate_task_id task_id with
-  | Error e -> result_to_response (Error e)
+  | Error e -> result_to_response ~tool_name ~start_time (Error e)
   | Ok task_id ->
   let action_raw = get_string args "action" "" in
   if String.equal action_raw "" then
-    (false, Printf.sprintf "action is required (%s)" (String.concat ", " Masc_domain.valid_task_action_strings))
+    Tool_result.error ~tool_name ~start_time (Printf.sprintf "action is required (%s)" (String.concat ", " Masc_domain.valid_task_action_strings))
   else
   match Masc_domain.task_action_of_string_lenient action_raw with
-  | Error msg -> (false, msg)
+  | Error msg -> Tool_result.error ~tool_name ~start_time msg
   | Ok action ->
   let action_s = Masc_domain.task_action_to_string action in
   let notes = get_string args "notes" "" in
@@ -825,12 +815,12 @@ and handle_transition ?agent_tool_names ctx args =
   let tasks = Coord.get_tasks_raw ctx.config in
   let task_opt = List.find_opt (fun (t : Masc_domain.task) -> String.equal t.id task_id) tasks in
   match handoff_context with
-  | Error error -> (false, error)
+  | Error error -> Tool_result.error ~tool_name ~start_time error
   | Ok handoff_context ->
   if (=) action Masc_domain.Release && strict_release_requires_handoff task_opt
      && Option.is_none handoff_context
   then
-    (false, "Strict task release requires handoff_context.summary")
+    Tool_result.error ~tool_name ~start_time "Strict task release requires handoff_context.summary"
   else
   let completion_state_error =
     if (=) action Masc_domain.Done_action && not force then
@@ -841,7 +831,7 @@ and handle_transition ?agent_tool_names ctx args =
   match completion_state_error with
   | Some err ->
     Log.Task.error "task transition failed: %s" (Masc_domain.masc_error_to_string err);
-    result_to_response (Error err)
+    result_to_response ~tool_name ~start_time (Error err)
   | None ->
   let completion_owned_by_caller =
     force || can_review_completion ~task_opt ~agent_name:ctx.agent_name
@@ -859,7 +849,7 @@ and handle_transition ?agent_tool_names ctx args =
   in
   match persisted_gate_rejection with
   | Some reason ->
-    (false, reason)
+    Tool_result.error ~tool_name ~start_time reason
   | None ->
   let review_gate_rejection =
     if (=) action Masc_domain.Done_action && not force then
@@ -883,7 +873,7 @@ and handle_transition ?agent_tool_names ctx args =
   in
   match review_gate_rejection with
   | Some reason ->
-    (false, completion_rejection_message ~allow_force:true reason)
+    Tool_result.error ~tool_name ~start_time (completion_rejection_message ~allow_force:true reason)
   | None ->
   (* Verifier gate: if the task has a completion_contract and the
      verification FSM is enabled, redirect Done → Submit_for_verification
@@ -1116,14 +1106,14 @@ and handle_transition ?agent_tool_names ctx args =
             | Masc_domain.Submit_pr_evidence
             | Masc_domain.Approve_verification | Masc_domain.Reject_verification | Masc_domain.Release)
    | Error _, _ -> ());
-  result_to_response result
+  result_to_response ~tool_name ~start_time result
 
-let handle_update_priority ctx args =
+let handle_update_priority ~tool_name ~start_time ctx args =
   let task_id = get_string args "task_id" "" in
   let priority = get_int args "priority" 3 in
-  (true, Coord.update_priority ctx.config ~task_id ~priority)
+  Tool_result.ok ~tool_name ~start_time (Coord.update_priority ctx.config ~task_id ~priority)
 
-let handle_tasks ctx args =
+let handle_tasks ~tool_name ~start_time ctx args =
   let include_done = get_bool args "include_done" false in
   let include_cancelled = get_bool args "include_cancelled" false in
   let status =
@@ -1131,7 +1121,7 @@ let handle_tasks ctx args =
     | `String s when not (String.equal s "") -> Some s
     | _ -> None
   in
-  (true, Coord.list_tasks ctx.config ~include_done ~include_cancelled ?status)
+  Tool_result.ok ~tool_name ~start_time (Coord.list_tasks ctx.config ~include_done ~include_cancelled ?status)
 
 let task_history_events_json (config : Coord.config) ~task_id ~limit =
   let scan_limit = min 500 (limit * 5) in
@@ -1156,24 +1146,24 @@ let task_history_events_json (config : Coord.config) ~task_id ~limit =
   let events = parsed |> List.filter matches_task |> take limit in
   `List events
 
-let handle_task_history ctx args =
+let handle_task_history ~tool_name ~start_time ctx args =
   let task_id = get_string args "task_id" "" in
   let limit = get_int args "limit" 50 in
-  (true, Yojson.Safe.to_string (task_history_events_json ctx.config ~task_id ~limit))
+  Tool_result.ok ~tool_name ~start_time (Yojson.Safe.to_string (task_history_events_json ctx.config ~task_id ~limit))
 
 include Tool_task_schemas
 (* Dispatch function *)
 let dispatch ?agent_tool_names ctx ~name ~args : Tool_result.t option =
   let start = Time_compat.now () in
   match name with
-  | "masc_add_task" -> Some (wrap_result ~name ~start (handle_add_task ctx args))
-  | "masc_batch_add_tasks" -> Some (wrap_result ~name ~start (handle_batch_add_tasks ctx args))
-  | "masc_claim_task" -> Some (wrap_result ~name ~start (handle_claim ?agent_tool_names ctx args))
-  | "masc_claim_next" -> Some (wrap_result ~name ~start (handle_claim_next ?agent_tool_names ctx args))
-  | "masc_transition" -> Some (wrap_result ~name ~start (handle_transition ?agent_tool_names ctx args))
-  | "masc_update_priority" -> Some (wrap_result ~name ~start (handle_update_priority ctx args))
-  | "masc_tasks" -> Some (wrap_result ~name ~start (handle_tasks ctx args))
-  | "masc_task_history" -> Some (wrap_result ~name ~start (handle_task_history ctx args))
+  | "masc_add_task" -> Some (handle_add_task ~tool_name:name ~start_time:start ctx args)
+  | "masc_batch_add_tasks" -> Some (handle_batch_add_tasks ~tool_name:name ~start_time:start ctx args)
+  | "masc_claim_task" -> Some (handle_claim ?agent_tool_names ~tool_name:name ~start_time:start ctx args)
+  | "masc_claim_next" -> Some (handle_claim_next ?agent_tool_names ~tool_name:name ~start_time:start ctx args)
+  | "masc_transition" -> Some (handle_transition ?agent_tool_names ~tool_name:name ~start_time:start ctx args)
+  | "masc_update_priority" -> Some (handle_update_priority ~tool_name:name ~start_time:start ctx args)
+  | "masc_tasks" -> Some (handle_tasks ~tool_name:name ~start_time:start ctx args)
+  | "masc_task_history" -> Some (handle_task_history ~tool_name:name ~start_time:start ctx args)
   | _ -> None
 
 (* ================================================================ *)

--- a/lib/tool_task.mli
+++ b/lib/tool_task.mli
@@ -1,25 +1,23 @@
 
 (** Tool_task - Core task CRUD operations *)
 
-type tool_result = bool * string
-
 type context = {
   config: Coord.config;
   agent_name: string;
   sw: Eio.Switch.t option;
 }
 
-val handle_add_task : context -> Yojson.Safe.t -> tool_result
-val handle_batch_add_tasks : context -> Yojson.Safe.t -> tool_result
-val handle_claim : ?agent_tool_names:string list -> context -> Yojson.Safe.t -> tool_result
-val handle_claim_next : ?agent_tool_names:string list -> context -> Yojson.Safe.t -> tool_result
-val handle_release : context -> Yojson.Safe.t -> tool_result
-val handle_done : context -> Yojson.Safe.t -> tool_result
-val handle_cancel_task : context -> Yojson.Safe.t -> tool_result
-val handle_transition : ?agent_tool_names:string list -> context -> Yojson.Safe.t -> tool_result
-val handle_update_priority : context -> Yojson.Safe.t -> tool_result
-val handle_tasks : context -> Yojson.Safe.t -> tool_result
-val handle_task_history : context -> Yojson.Safe.t -> tool_result
+val handle_add_task : tool_name:string -> start_time:float -> context -> Yojson.Safe.t -> Tool_result.t
+val handle_batch_add_tasks : tool_name:string -> start_time:float -> context -> Yojson.Safe.t -> Tool_result.t
+val handle_claim : ?agent_tool_names:string list -> tool_name:string -> start_time:float -> context -> Yojson.Safe.t -> Tool_result.t
+val handle_claim_next : ?agent_tool_names:string list -> tool_name:string -> start_time:float -> context -> Yojson.Safe.t -> Tool_result.t
+val handle_release : tool_name:string -> start_time:float -> context -> Yojson.Safe.t -> Tool_result.t
+val handle_done : tool_name:string -> start_time:float -> context -> Yojson.Safe.t -> Tool_result.t
+val handle_cancel_task : tool_name:string -> start_time:float -> context -> Yojson.Safe.t -> Tool_result.t
+val handle_transition : ?agent_tool_names:string list -> tool_name:string -> start_time:float -> context -> Yojson.Safe.t -> Tool_result.t
+val handle_update_priority : tool_name:string -> start_time:float -> context -> Yojson.Safe.t -> Tool_result.t
+val handle_tasks : tool_name:string -> start_time:float -> context -> Yojson.Safe.t -> Tool_result.t
+val handle_task_history : tool_name:string -> start_time:float -> context -> Yojson.Safe.t -> Tool_result.t
 val task_history_events_json :
   Coord.config -> task_id:string -> limit:int -> Yojson.Safe.t
 

--- a/lib/tool_worktree.ml
+++ b/lib/tool_worktree.ml
@@ -25,16 +25,10 @@ type context = {
   agent_name: string;
 }
 
-type tool_result = bool * string
-
-let wrap_result ~name ~start (success, message) =
-  if success then Tool_result.ok ~tool_name:name ~start_time:start message
-  else Tool_result.error ~tool_name:name ~start_time:start message
-
 let default_base_branch = "auto"
 
 (* Individual handlers *)
-let handle_worktree_create ctx args =
+let handle_worktree_create ~tool_name ~start_time ctx args =
   (* LLM may omit agent_name in args; fall back to context agent_name.
      This prevents Validation.Agent_id failures when the 9B model
      sends empty or missing agent_name.
@@ -68,7 +62,7 @@ let handle_worktree_create ctx args =
           from_args ctx.agent_name)
   in
   match agent_name_result with
-  | Error msg -> (false, msg)
+  | Error msg -> Tool_result.error ~tool_name ~start_time msg
   | Ok agent_name ->
   let raw_task_id = get_string args "task_id" "" in
   let base_branch = get_string args "base_branch" default_base_branch in
@@ -100,13 +94,14 @@ let handle_worktree_create ctx args =
            path traversal, no '.'/'..' specials." bad) )
   in
   match repo_name_error with
-  | Some err -> (false, err)
+  | Some err -> Tool_result.error ~tool_name ~start_time err
   | None ->
   if String.equal raw_task_id "" then
-    (false, "task_id is required. Example: task_id='fix-login', \
-             task_id='add-auth'. Allowed characters: a-z, 0-9, hyphen, \
-             underscore. Slashes and backslashes are auto-normalized \
-             to hyphens, so 'feature/auth' becomes 'feature-auth'.")
+    Tool_result.error ~tool_name ~start_time
+      "task_id is required. Example: task_id='fix-login', \
+       task_id='add-auth'. Allowed characters: a-z, 0-9, hyphen, \
+       underscore. Slashes and backslashes are auto-normalized \
+       to hyphens, so 'feature/auth' becomes 'feature-auth'."
   else
   (* Normalize: replace / and \ with - so LLMs can use branch-style names *)
   let task_id =
@@ -115,29 +110,30 @@ let handle_worktree_create ctx args =
     |> String.of_seq
   in
   match Coord.worktree_create_r ?repo_name ctx.config ~agent_name ~task_id ~base_branch with
-  | Ok msg -> (true, msg)
-  | Error e -> (false, Masc_domain.masc_error_to_string e)
+  | Ok msg -> Tool_result.ok ~tool_name ~start_time msg
+  | Error e -> Tool_result.error ~tool_name ~start_time (Masc_domain.masc_error_to_string e)
 
-let handle_worktree_remove ctx args =
+let handle_worktree_remove ~tool_name ~start_time ctx args =
   let task_id = get_string args "task_id" "" in
   if String.equal task_id "" then
-    (false, "task_id is required. Use the same task_id you passed to masc_worktree_create.")
+    Tool_result.error ~tool_name ~start_time
+      "task_id is required. Use the same task_id you passed to masc_worktree_create."
   else
   match Coord.worktree_remove_r ctx.config ~agent_name:ctx.agent_name ~task_id with
-  | Ok msg -> (true, msg)
-  | Error e -> (false, Masc_domain.masc_error_to_string e)
+  | Ok msg -> Tool_result.ok ~tool_name ~start_time msg
+  | Error e -> Tool_result.error ~tool_name ~start_time (Masc_domain.masc_error_to_string e)
 
-let handle_worktree_list ctx _args =
+let handle_worktree_list ~tool_name ~start_time ctx _args =
   let json = Coord.worktree_list ctx.config in
-  (true, Yojson.Safe.to_string json)
+  Tool_result.ok ~tool_name ~start_time (Yojson.Safe.to_string json)
 
 (* Dispatch function - returns None if tool not handled *)
 let dispatch ctx ~name ~args : Tool_result.t option =
   let start = Time_compat.now () in
   match name with
-  | "masc_worktree_create" -> Some (wrap_result ~name ~start (handle_worktree_create ctx args))
-  | "masc_worktree_remove" -> Some (wrap_result ~name ~start (handle_worktree_remove ctx args))
-  | "masc_worktree_list" -> Some (wrap_result ~name ~start (handle_worktree_list ctx args))
+  | "masc_worktree_create" -> Some (handle_worktree_create ~tool_name:name ~start_time:start ctx args)
+  | "masc_worktree_remove" -> Some (handle_worktree_remove ~tool_name:name ~start_time:start ctx args)
+  | "masc_worktree_list" -> Some (handle_worktree_list ~tool_name:name ~start_time:start ctx args)
   | _ -> None
 
 let schemas = Tool_schemas_worktree.schemas

--- a/lib/tool_worktree.mli
+++ b/lib/tool_worktree.mli
@@ -6,13 +6,14 @@ type context = {
   agent_name: string;
 }
 
-type tool_result = bool * string
-
 val default_base_branch : string
 
-val handle_worktree_create : context -> Yojson.Safe.t -> tool_result
-val handle_worktree_remove : context -> Yojson.Safe.t -> tool_result
-val handle_worktree_list : context -> Yojson.Safe.t -> tool_result
+val handle_worktree_create :
+  tool_name:string -> start_time:float -> context -> Yojson.Safe.t -> Tool_result.t
+val handle_worktree_remove :
+  tool_name:string -> start_time:float -> context -> Yojson.Safe.t -> Tool_result.t
+val handle_worktree_list :
+  tool_name:string -> start_time:float -> context -> Yojson.Safe.t -> Tool_result.t
 
 val dispatch : context -> name:string -> args:Yojson.Safe.t -> Tool_result.t option
 

--- a/test/test_error_logging_coverage.ml
+++ b/test/test_error_logging_coverage.ml
@@ -110,7 +110,7 @@ let test_tool_task_done_nonexistent_logs () =
     ("notes", `String "");
   ] in
   let output = capture_stderr (fun () ->
-    ignore (Tool_task.handle_done ctx args)
+    ignore (Tool_task.handle_done ~tool_name:"test_tool" ~start_time:0.0 ctx args)
   ) in
   check bool "stderr contains [Task] prefix for done on missing task"
     true (str_contains output "[Task]")
@@ -124,7 +124,7 @@ let test_tool_task_cancel_nonexistent_logs () =
     ("reason", `String "test cancel");
   ] in
   let output = capture_stderr (fun () ->
-    ignore (Tool_task.handle_cancel_task ctx args)
+    ignore (Tool_task.handle_cancel_task ~tool_name:"test_tool" ~start_time:0.0 ctx args)
   ) in
   check bool "stderr contains [Task] prefix for cancel on missing task"
     true (str_contains output "[Task]")

--- a/test/test_keeper_task_dispatch.ml
+++ b/test/test_keeper_task_dispatch.ml
@@ -413,8 +413,9 @@ let test_release_clears_keeper_current_task_id () =
       let task_id =
         Yojson.Safe.Util.(json |> member "claimed_task" |> member "task_id" |> to_string)
       in
-      let ok, message =
+      let release_result =
         Tool_task.handle_transition
+          ~tool_name:"test_tool" ~start_time:0.0
           { Tool_task.config; agent_name = meta.agent_name; sw = None }
           (`Assoc
               [ "task_id", `String task_id
@@ -422,7 +423,7 @@ let test_release_clears_keeper_current_task_id () =
               ; "reason", `String "scope changed"
               ])
       in
-      if not ok then fail message;
+      if not release_result.Tool_result.success then fail release_result.Tool_result.legacy_message;
       let registry_meta =
         match Keeper_registry.get ~base_path:config.Coord.base_path meta.name with
         | Some entry -> entry.meta
@@ -501,8 +502,9 @@ let test_release_clears_task_worktree_metadata () =
              "worktree linked before release"
              true
              (Option.is_some (only_task config).worktree);
-           let ok, message =
+           let result =
              Tool_task.handle_transition
+               ~tool_name:"test_tool" ~start_time:0.0
                { Tool_task.config; agent_name = meta.agent_name; sw = None }
                (`Assoc
                    [ "task_id", `String task_id
@@ -510,7 +512,7 @@ let test_release_clears_task_worktree_metadata () =
                    ; "reason", `String "handoff to another keeper"
                    ])
            in
-           if not ok then fail message;
+           if not result.Tool_result.success then fail result.Tool_result.legacy_message;
            check
              bool
              "worktree cleared on release"

--- a/test/test_keeper_tools_oas.ml
+++ b/test/test_keeper_tools_oas.ml
@@ -837,41 +837,41 @@ let test_library_search_returns_results () =
     (fun () ->
        let ctx = Tool_library.{ agent_name = "test-keeper" } in
        (* Search *)
-       let ok, msg =
-         Tool_library.handle_search ctx (`Assoc [ "query", `String "mlfq" ])
+       let search_result =
+         Tool_library.handle_search ~tool_name:"test_tool" ~start_time:0.0 ctx (`Assoc [ "query", `String "mlfq" ])
        in
-       check bool "search succeeds" true ok;
+       check bool "search succeeds" true search_result.Tool_result.success;
        check
          bool
          "search finds mlfq doc"
          true
-         (let low = String.lowercase_ascii msg in
+         (let low = String.lowercase_ascii search_result.Tool_result.legacy_message in
           String.length low > 0
           && not (Tool_library.string_contains ~sub:"no documents" low));
        (* Read *)
-       let ok2, msg2 =
-         Tool_library.handle_read ctx (`Assoc [ "topic", `String "test-mlfq" ])
+       let read_result =
+         Tool_library.handle_read ~tool_name:"test_tool" ~start_time:0.0 ctx (`Assoc [ "topic", `String "test-mlfq" ])
        in
-       check bool "read succeeds" true ok2;
+       check bool "read succeeds" true read_result.Tool_result.success;
        check
          bool
          "read contains MLFQ content"
          true
-         (Tool_library.string_contains ~sub:"Multi-Level Feedback Queue" msg2))
+         (Tool_library.string_contains ~sub:"Multi-Level Feedback Queue" read_result.Tool_result.legacy_message))
 ;;
 
 let test_library_search_empty_query () =
   let ctx = Tool_library.{ agent_name = "test-keeper" } in
-  let ok, _msg = Tool_library.handle_search ctx (`Assoc [ "query", `String "" ]) in
-  check bool "empty query fails" false ok
+  let result = Tool_library.handle_search ~tool_name:"test_tool" ~start_time:0.0 ctx (`Assoc [ "query", `String "" ]) in
+  check bool "empty query fails" false result.Tool_result.success
 ;;
 
 let test_library_read_missing_topic () =
   let ctx = Tool_library.{ agent_name = "test-keeper" } in
-  let ok, _msg =
-    Tool_library.handle_read ctx (`Assoc [ "topic", `String "nonexistent-topic-xyz-999" ])
+  let result =
+    Tool_library.handle_read ~tool_name:"test_tool" ~start_time:0.0 ctx (`Assoc [ "topic", `String "nonexistent-topic-xyz-999" ])
   in
-  check bool "missing topic fails" false ok
+  check bool "missing topic fails" false result.Tool_result.success
 ;;
 
 (* ── normalize_tool_result tests ──────────────────────────── *)

--- a/test/test_telemetry_task_transition_10358.ml
+++ b/test/test_telemetry_task_transition_10358.ml
@@ -68,10 +68,10 @@ let test_masc_transition_claim_done_emits_task_lifecycle () =
     in
     Unix.mkdir base_path 0o755;
     let ctx = make_ctx base_path in
-    let ok, result =
-      Tool_task.handle_add_task ctx (`Assoc [ ("title", `String "Telemetry task") ])
+    let result =
+      Tool_task.handle_add_task ~tool_name:"test_tool" ~start_time:0.0 ctx (`Assoc [ ("title", `String "Telemetry task") ])
     in
-    if not ok then Alcotest.fail result;
+    if not result.Tool_result.success then Alcotest.fail result.Tool_result.legacy_message;
     run_transition ctx ~task_id:"task-001" ~action:"claim" ();
     run_transition ctx ~task_id:"task-001" ~action:"done"
       ~notes:"Telemetry lifecycle regression proof completed." ();

--- a/test/test_tool_agent_coverage.ml
+++ b/test/test_tool_agent_coverage.ml
@@ -6,6 +6,7 @@
     masc_agent_card
 *)
 module Tool_args = Masc_mcp.Tool_args
+module Tool_result = Masc_mcp.Tool_result
 module Meta_cognition = Masc_mcp.Meta_cognition
 
 module Tool_agent = Masc_mcp.Tool_agent
@@ -152,16 +153,16 @@ let test_dispatch_agent_card () =
 
 let test_handle_agents () =
   with_ctx (fun ctx ->
-  let (ok, msg) = Tool_agent.handle_agents ctx (`Assoc []) in
-  Alcotest.(check bool) "agents succeeds" true ok;
-  Alcotest.(check bool) "has response" true (String.length msg > 0);
+  let result = Tool_agent.handle_agents ctx (`Assoc []) in
+  Alcotest.(check bool) "agents succeeds" true result.Tool_result.success;
+  Alcotest.(check bool) "has response" true (String.length result.Tool_result.legacy_message > 0);
   )
 
 let test_handle_agent_card () =
   with_ctx (fun ctx ->
-  let (ok, msg) = Tool_agent.handle_agent_card ctx (`Assoc []) in
-  Alcotest.(check bool) "agent card succeeds" true ok;
-  let json = Yojson.Safe.from_string msg in
+  let result = Tool_agent.handle_agent_card ctx (`Assoc []) in
+  Alcotest.(check bool) "agent card succeeds" true result.Tool_result.success;
+  let json = Yojson.Safe.from_string result.Tool_result.legacy_message in
   let open Yojson.Safe.Util in
   Alcotest.(check string) "card name" "MASC-MCP"
     (json |> member "name" |> to_string);
@@ -171,12 +172,12 @@ let test_handle_agent_card () =
 
 let test_handle_agent_card_rejects_unknown_action () =
   with_ctx (fun ctx ->
-  let (ok, msg) =
+  let result =
     Tool_agent.handle_agent_card ctx (`Assoc [("action", `String "bogus")])
   in
-  Alcotest.(check bool) "agent card rejects" false ok;
+  Alcotest.(check bool) "agent card rejects" false result.Tool_result.success;
   Alcotest.(check bool) "mentions invalid action" true
-    (String.contains msg 'b');
+    (String.contains result.Tool_result.legacy_message 'b');
   )
 
 (* ============================================================
@@ -186,8 +187,8 @@ let test_handle_agent_card_rejects_unknown_action () =
 let test_register_capabilities () =
   with_ctx (fun ctx ->
   let args = `Assoc [("capabilities", `List [`String "test"; `String "code"])] in
-  let (ok, _msg) = Tool_agent.handle_register_capabilities ctx args in
-  Alcotest.(check bool) "registers capabilities" true ok;
+  let result = Tool_agent.handle_register_capabilities ctx args in
+  Alcotest.(check bool) "registers capabilities" true result.Tool_result.success;
   )
 
 (* ============================================================
@@ -197,15 +198,15 @@ let test_register_capabilities () =
 let test_agent_update_status () =
   with_ctx (fun ctx ->
   let args = `Assoc [("status", `String "busy")] in
-  let (_ok, msg) = Tool_agent.handle_agent_update ctx args in
-  Alcotest.(check bool) "has response" true (String.length msg > 0);
+  let result = Tool_agent.handle_agent_update ctx args in
+  Alcotest.(check bool) "has response" true (String.length result.Tool_result.legacy_message > 0);
   )
 
 let test_agent_update_capabilities () =
   with_ctx (fun ctx ->
   let args = `Assoc [("capabilities", `List [`String "review"; `String "refactor"])] in
-  let (_ok, msg) = Tool_agent.handle_agent_update ctx args in
-  Alcotest.(check bool) "has response" true (String.length msg > 0);
+  let result = Tool_agent.handle_agent_update ctx args in
+  Alcotest.(check bool) "has response" true (String.length result.Tool_result.legacy_message > 0);
   )
 
 (* ============================================================
@@ -215,10 +216,10 @@ let test_agent_update_capabilities () =
 let test_get_metrics_no_data () =
   with_ctx (fun ctx ->
   let args = `Assoc [("agent_name", `String "nonexistent"); ("days", `Int 7)] in
-  let (ok, msg) = dispatch_exn ctx ~name:"masc_get_metrics" ~args in
-  Alcotest.(check bool) "no data fails" false ok;
+  let result = dispatch_exn ctx ~name:"masc_get_metrics" ~args in
+  Alcotest.(check bool) "no data fails" false result.Tool_result.success;
   let open Yojson.Safe.Util in
-  let json = Yojson.Safe.from_string msg in
+  let json = Yojson.Safe.from_string result.Tool_result.legacy_message in
   Alcotest.(check string) "error_code" "not_found"
     (json |> member "error_code" |> to_string);
   Alcotest.(check string) "message" "no metrics found for agent: nonexistent"
@@ -227,10 +228,10 @@ let test_get_metrics_no_data () =
 
 let test_get_metrics_missing_agent_name () =
   with_ctx (fun ctx ->
-  let (ok, msg) = dispatch_exn ctx ~name:"masc_get_metrics" ~args:(`Assoc []) in
-  Alcotest.(check bool) "missing agent_name fails" false ok;
+  let result = dispatch_exn ctx ~name:"masc_get_metrics" ~args:(`Assoc []) in
+  Alcotest.(check bool) "missing agent_name fails" false result.Tool_result.success;
   let open Yojson.Safe.Util in
-  let json = Yojson.Safe.from_string msg in
+  let json = Yojson.Safe.from_string result.Tool_result.legacy_message in
   Alcotest.(check string) "status" "error"
     (json |> member "status" |> to_string);
   Alcotest.(check string) "message" "agent_name is required"
@@ -243,17 +244,17 @@ let test_get_metrics_missing_agent_name () =
 
 let test_agent_fitness_no_agents () =
   with_ctx (fun ctx ->
-  let (ok, msg) = Tool_agent.handle_agent_fitness ctx (`Assoc []) in
-  Alcotest.(check bool) "fitness succeeds" true ok;
-  Alcotest.(check bool) "has response" true (String.length msg > 0);
+  let result = Tool_agent.handle_agent_fitness ctx (`Assoc []) in
+  Alcotest.(check bool) "fitness succeeds" true result.Tool_result.success;
+  Alcotest.(check bool) "has response" true (String.length result.Tool_result.legacy_message > 0);
   )
 
 let test_agent_fitness_specific () =
   with_ctx (fun ctx ->
   let args = `Assoc [("agent_name", `String "test-agent"); ("days", `Int 7)] in
-  let (ok, msg) = Tool_agent.handle_agent_fitness ctx args in
-  Alcotest.(check bool) "fitness with agent" true ok;
-  Alcotest.(check bool) "has response" true (String.length msg > 0);
+  let result = Tool_agent.handle_agent_fitness ctx args in
+  Alcotest.(check bool) "fitness with agent" true result.Tool_result.success;
+  Alcotest.(check bool) "has response" true (String.length result.Tool_result.legacy_message > 0);
   )
 
 (* ============================================================

--- a/test/test_tool_control_coverage.ml
+++ b/test/test_tool_control_coverage.ml
@@ -80,7 +80,7 @@ let () =
   test "dispatch_pause_status_paused" (fun () ->
       with_ctx @@ fun ctx ->
       let _ =
-        Tool_control.handle_pause ctx
+        Tool_control.handle_pause ~tool_name:"test" ~start_time:0.0 ctx
           (`Assoc [ ("reason", `String "For status test") ])
       in
       match Tool_control.dispatch ctx ~name:"masc_pause_status" ~args:(`Assoc []) with
@@ -95,7 +95,7 @@ let () =
   test "dispatch_resume" (fun () ->
       with_ctx @@ fun ctx ->
       let _ =
-        Tool_control.handle_pause ctx
+        Tool_control.handle_pause ~tool_name:"test" ~start_time:0.0 ctx
           (`Assoc [ ("reason", `String "For resume test") ])
       in
       match Tool_control.dispatch ctx ~name:"masc_resume" ~args:(`Assoc []) with

--- a/test/test_tool_coord_coverage.ml
+++ b/test/test_tool_coord_coverage.ml
@@ -422,11 +422,13 @@ let () =
     in
     let _ =
       Tool_task.handle_add_task
+        ~tool_name:"test_tool" ~start_time:0.0
         task_ctx
         (`Assoc [ "title", `String "Check transition claim" ])
     in
-    let _success, _result =
+    let _ =
       Tool_task.handle_transition
+        ~tool_name:"test_tool" ~start_time:0.0
         task_ctx
         (`Assoc [ "task_id", `String "task-001"; "action", `String "claim" ])
     in
@@ -459,9 +461,9 @@ let () =
       { Tool_task.config = ctx.config; agent_name = ctx.agent_name; sw = None }
     in
     let _ =
-      Tool_task.handle_add_task task_ctx (`Assoc [ "title", `String "Check claim next" ])
+      Tool_task.handle_add_task ~tool_name:"test_tool" ~start_time:0.0 task_ctx (`Assoc [ "title", `String "Check claim next" ])
     in
-    let _success, _result = Tool_task.handle_claim_next task_ctx (`Assoc []) in
+    let _ = Tool_task.handle_claim_next ~tool_name:"test_tool" ~start_time:0.0 task_ctx (`Assoc []) in
     match
       Tool_coord.dispatch
         ctx

--- a/test/test_tool_suspend_coverage.ml
+++ b/test/test_tool_suspend_coverage.ml
@@ -180,8 +180,8 @@ let test_blacklist_replace () =
 let test_dispatch_unknown () =
   let ctx = make_ctx () in
   let args = `Assoc [] in
-  check (option (pair bool string)) "unknown tool returns None" None
-    (Tool_suspend.dispatch ctx ~name:"masc_unknown" ~args)
+  check bool "unknown tool returns None" true
+    (Tool_suspend.dispatch ctx ~name:"masc_unknown" ~args = None)
 
 (* ============================================================
    check_can_join Tests

--- a/test/test_tool_task_coverage.ml
+++ b/test/test_tool_task_coverage.ml
@@ -82,8 +82,8 @@ let contract_requiring_tools tools =
   `Assoc [ ("required_tools", `List (List.map (fun tool -> `String tool) tools)) ]
 
 let add_task_requiring_tools ctx ~title tools =
-  let success, result =
-    Tool_task.handle_add_task ctx
+  let result =
+    Tool_task.handle_add_task ~tool_name:"test_tool" ~start_time:0.0 ctx
       (`Assoc
         [
           ("title", `String title);
@@ -91,7 +91,7 @@ let add_task_requiring_tools ctx ~title tools =
           ("contract", contract_requiring_tools tools);
         ])
   in
-  if not success then failwith result
+  if not result.Tool_result.success then failwith result.Tool_result.legacy_message
 
 let set_only_task_do_not_reclaim_reason ctx reason =
   let config = ctx.Tool_task.config in
@@ -232,7 +232,7 @@ let () = test "masc_oas_bridge_runs_without_eio_env" (fun () ->
 let () = test "dispatch_transition_claim" (fun () ->
   let ctx = make_test_ctx () in
   (* First add a task *)
-  let _ = Tool_task.handle_add_task ctx (`Assoc [("title", `String "Claim test")]) in
+  let _ = Tool_task.handle_add_task ~tool_name:"test_tool" ~start_time:0.0 ctx (`Assoc [("title", `String "Claim test")]) in
   let args = `Assoc [("task_id", `String "task-001"); ("action", `String "claim")] in
   match Tool_task.dispatch ctx ~name:"masc_transition" ~args with
   | Some _ -> () (* May fail if task doesn't exist *)
@@ -252,20 +252,20 @@ let () = test "dispatch_claim_next" (fun () ->
 let () = test "handle_done_records_calibration_verdict" (fun () ->
   let ctx = make_test_ctx () in
   (* Setup: add task, claim it *)
-  let _ = Tool_task.handle_add_task ctx
+  let _ = Tool_task.handle_add_task ~tool_name:"test_tool" ~start_time:0.0 ctx
     (`Assoc [("title", `String "Calibration test task")]) in
-  let _ = Tool_task.handle_claim ctx
+  let _ = Tool_task.handle_claim ~tool_name:"test_tool" ~start_time:0.0 ctx
     (`Assoc [("task_id", `String "task-001")]) in
   let verdict_dir = make_temp_dir "masc-verdict-test" in
   Eval_calibration.set_store_for_testing ~base_dir:verdict_dir;
   (* Trigger done with short notes (< 10 chars) to hit length gate *)
-  let (success, result) = Tool_task.handle_done ctx
+  let result = Tool_task.handle_done ~tool_name:"test_tool" ~start_time:0.0 ctx
     (`Assoc [
       ("task_id", `String "task-001");
       ("notes", `String "x")
     ]) in
-  assert (not success);
-  assert (str_contains result "Completion rejected by anti-rationalization gate");
+  assert (not result.Tool_result.success);
+  assert (str_contains result.Tool_result.legacy_message "Completion rejected by anti-rationalization gate");
   (* Verify: verdict was recorded in the store *)
   let store = Eval_calibration.get_store () in
   let records = Dated_jsonl.read_recent store 10 in
@@ -283,18 +283,18 @@ let () = test "handle_done_records_calibration_verdict" (fun () ->
 
 let () = test "handle_done_records_approved_calibration_verdict" (fun () ->
   let ctx = make_test_ctx () in
-  let _ = Tool_task.handle_add_task ctx
+  let _ = Tool_task.handle_add_task ~tool_name:"test_tool" ~start_time:0.0 ctx
     (`Assoc [("title", `String "Approved calibration task")]) in
-  let _ = Tool_task.handle_claim ctx
+  let _ = Tool_task.handle_claim ~tool_name:"test_tool" ~start_time:0.0 ctx
     (`Assoc [("task_id", `String "task-001")]) in
   let verdict_dir = make_temp_dir "masc-verdict-approve-test" in
   Eval_calibration.set_store_for_testing ~base_dir:verdict_dir;
-  let success, result = Tool_task.handle_done ctx
+  let result = Tool_task.handle_done ~tool_name:"test_tool" ~start_time:0.0 ctx
     (`Assoc [
       ("task_id", `String "task-001");
       ("notes", `String "Implemented the calibration coverage path, verified the JSONL verdict store, and completed the task cleanly.")
     ]) in
-  if not success then failwith result;
+  if not result.Tool_result.success then failwith result.Tool_result.legacy_message;
   let store = Eval_calibration.get_store () in
   let records = Dated_jsonl.read_recent store 10 in
   assert (List.length records >= 1);
@@ -315,13 +315,13 @@ let () = test "handle_transition_respects_completion_contract_and_records_custom
      test_verification_fsm.ml. *)
   with_env "MASC_VERIFICATION_FSM_ENABLED" (Some "false") (fun () ->
     let ctx = make_test_ctx () in
-    let _ = Tool_task.handle_add_task ctx
+    let _ = Tool_task.handle_add_task ~tool_name:"test_tool" ~start_time:0.0 ctx
       (`Assoc [("title", `String "Contract calibration task")]) in
-    let _ = Tool_task.handle_claim ctx
+    let _ = Tool_task.handle_claim ~tool_name:"test_tool" ~start_time:0.0 ctx
       (`Assoc [("task_id", `String "task-001")]) in
     let verdict_dir = make_temp_dir "masc-verdict-contract-test" in
     Eval_calibration.set_store_for_testing ~base_dir:verdict_dir;
-    let success, result = Tool_task.handle_transition ctx
+    let result = Tool_task.handle_transition ~tool_name:"test_tool" ~start_time:0.0 ctx
       (`Assoc [
         ("task_id", `String "task-001");
         ("action", `String "done");
@@ -329,8 +329,8 @@ let () = test "handle_transition_respects_completion_contract_and_records_custom
         ("completion_contract", `List [ `String "test coverage"; `String "migration" ]);
         ("evaluator_cascade", `String "glm:auto");
       ]) in
-    assert (not success);
-    assert (str_contains result "completion contract not satisfied");
+    assert (not result.Tool_result.success);
+    assert (str_contains result.Tool_result.legacy_message "completion contract not satisfied");
     let store = Eval_calibration.get_store () in
     let records = Dated_jsonl.read_recent store 10 in
     assert (List.length records >= 1);
@@ -346,8 +346,8 @@ let () = test "handle_transition_respects_completion_contract_and_records_custom
 
 let () = test "handle_add_task_persists_contract" (fun () ->
   let ctx = make_test_ctx () in
-  let (success, result) =
-    Tool_task.handle_add_task ctx
+  let result =
+    Tool_task.handle_add_task ~tool_name:"test_tool" ~start_time:0.0 ctx
       (`Assoc
         [
           ("title", `String "Strict task");
@@ -361,7 +361,7 @@ let () = test "handle_add_task_persists_contract" (fun () ->
               ] );
         ])
   in
-  if not success then failwith result;
+  if not result.Tool_result.success then failwith result.Tool_result.legacy_message;
   match Coord.get_tasks_raw ctx.config with
   | [ task ] -> (
       match task.contract with
@@ -374,15 +374,15 @@ let () = test "handle_add_task_persists_contract" (fun () ->
 
 let () = test "handle_add_task_injects_default_verification_contract" (fun () ->
   let ctx = make_test_ctx () in
-  let (success, result) =
-    Tool_task.handle_add_task ctx
+  let result =
+    Tool_task.handle_add_task ~tool_name:"test_tool" ~start_time:0.0 ctx
       (`Assoc
         [
           ("title", `String "Default verification task");
           ("description", `String "Need verifier-visible evidence.");
         ])
   in
-  if not success then failwith result;
+  if not result.Tool_result.success then failwith result.Tool_result.legacy_message;
   match Coord.get_tasks_raw ctx.config with
   | [ task ] -> (
       match task.contract with
@@ -401,8 +401,8 @@ let () = test "handle_add_task_injects_default_verification_contract" (fun () ->
 
 let () = test "handle_batch_add_tasks_injects_default_verification_contracts" (fun () ->
   let ctx = make_test_ctx () in
-  let (success, result) =
-    Tool_task.handle_batch_add_tasks ctx
+  let result =
+    Tool_task.handle_batch_add_tasks ~tool_name:"test_tool" ~start_time:0.0 ctx
       (`Assoc
         [
           ( "tasks",
@@ -413,7 +413,7 @@ let () = test "handle_batch_add_tasks_injects_default_verification_contracts" (f
               ] );
         ])
   in
-  if not success then failwith result;
+  if not result.Tool_result.success then failwith result.Tool_result.legacy_message;
   let tasks = Coord.get_tasks_raw ctx.config in
   assert (List.length tasks = 2);
   List.iter
@@ -432,7 +432,7 @@ let () = test "handle_done_uses_persisted_contract_gate" (fun () ->
      must be blocked with a gate rejection message. *)
   let ctx = make_test_ctx () in
   let _ =
-    Tool_task.handle_add_task ctx
+    Tool_task.handle_add_task ~tool_name:"test_tool" ~start_time:0.0 ctx
       (`Assoc
         [
           ("title", `String "Strict deliverable task");
@@ -446,20 +446,20 @@ let () = test "handle_done_uses_persisted_contract_gate" (fun () ->
               ] );
         ])
   in
-  let _ = Tool_task.handle_claim ctx (`Assoc [ ("task_id", `String "task-001") ]) in
-  let success_done, result_done =
-    Tool_task.handle_done ctx
+  let _ = Tool_task.handle_claim ~tool_name:"test_tool" ~start_time:0.0 ctx (`Assoc [ ("task_id", `String "task-001") ]) in
+  let result_done =
+    Tool_task.handle_done ~tool_name:"test_tool" ~start_time:0.0 ctx
       (`Assoc
         [
           ("task_id", `String "task-001");
           ("notes", `String "deliverable-ready");
         ])
   in
-  if success_done then
+  if result_done.Tool_result.success then
     failwith "expected gate to reject handle_done for strict task without verdict";
-  if not (str_contains result_done "CDAL verdict") then
+  if not (str_contains result_done.Tool_result.legacy_message "CDAL verdict") then
     failwith
-      (Printf.sprintf "expected CDAL gate rejection message, got: %s" result_done)
+      (Printf.sprintf "expected CDAL gate rejection message, got: %s" result_done.Tool_result.legacy_message)
 )
 
 (* Advisory contract (strict=false): CDAL gate must still record an attribution
@@ -471,7 +471,7 @@ let () = test "handle_done_advisory_contract_records_attribution" (fun () ->
   Dashboard_attribution.reset ();
   let ctx = make_test_ctx_with_agent "advisory-agent" in
   let _ =
-    Tool_task.handle_add_task ctx
+    Tool_task.handle_add_task ~tool_name:"test_tool" ~start_time:0.0 ctx
       (`Assoc
         [
           ("title", `String "Advisory deliverable task");
@@ -484,16 +484,16 @@ let () = test "handle_done_advisory_contract_records_attribution" (fun () ->
               ] );
         ])
   in
-  let _ = Tool_task.handle_claim ctx (`Assoc [ ("task_id", `String "task-001") ]) in
-  let success_done, _result_done =
-    Tool_task.handle_done ctx
+  let _ = Tool_task.handle_claim ~tool_name:"test_tool" ~start_time:0.0 ctx (`Assoc [ ("task_id", `String "task-001") ]) in
+  let result_done =
+    Tool_task.handle_done ~tool_name:"test_tool" ~start_time:0.0 ctx
       (`Assoc
         [
           ("task_id", `String "task-001");
           ("notes", `String "deliverable-ready");
         ])
   in
-  if not success_done then
+  if not result_done.Tool_result.success then
     failwith "advisory contract (strict=false) must not block handle_done";
   (* Advisory contracts record under the dedicated advisory gate bucket so
      dashboards can count "allowed through under advisory" separately from
@@ -519,26 +519,26 @@ let () = test "handle_done_advisory_contract_records_attribution" (fun () ->
 let () = test "handle_transition_release_requires_handoff_for_strict_task" (fun () ->
   let ctx = make_test_ctx () in
   let _ =
-    Tool_task.handle_add_task ctx
+    Tool_task.handle_add_task ~tool_name:"test_tool" ~start_time:0.0 ctx
       (`Assoc
         [
           ("title", `String "Strict release task");
           ("contract", `Assoc [ ("strict", `Bool true) ]);
         ])
   in
-  let _ = Tool_task.handle_claim ctx (`Assoc [ ("task_id", `String "task-001") ]) in
-  let success_missing, result_missing =
-    Tool_task.handle_transition ctx
+  let _ = Tool_task.handle_claim ~tool_name:"test_tool" ~start_time:0.0 ctx (`Assoc [ ("task_id", `String "task-001") ]) in
+  let result_missing =
+    Tool_task.handle_transition ~tool_name:"test_tool" ~start_time:0.0 ctx
       (`Assoc
         [
           ("task_id", `String "task-001");
           ("action", `String "release");
         ])
   in
-  assert (not success_missing);
-  assert (str_contains result_missing "handoff_context.summary");
-  let success_release, result_release =
-    Tool_task.handle_transition ctx
+  assert (not result_missing.Tool_result.success);
+  assert (str_contains result_missing.Tool_result.legacy_message "handoff_context.summary");
+  let result_release =
+    Tool_task.handle_transition ~tool_name:"test_tool" ~start_time:0.0 ctx
       (`Assoc
         [
           ("task_id", `String "task-001");
@@ -553,7 +553,7 @@ let () = test "handle_transition_release_requires_handoff_for_strict_task" (fun 
               ] );
         ])
   in
-  if not success_release then failwith result_release;
+  if not result_release.Tool_result.success then failwith result_release.Tool_result.legacy_message;
   match Coord.get_tasks_raw ctx.config with
   | [ task ] -> (
       assert (task.do_not_reclaim_reason = None);
@@ -573,22 +573,22 @@ let () = test "handle_transition_start_on_todo_points_at_claim_first" (fun () ->
      action=claim as the next concrete call. *)
   let ctx = make_test_ctx () in
   let _ =
-    Tool_task.handle_add_task ctx
+    Tool_task.handle_add_task ~tool_name:"test_tool" ~start_time:0.0 ctx
       (`Assoc [ ("title", `String "Start-without-claim") ])
   in
-  let success, result =
-    Tool_task.handle_transition ctx
+  let result =
+    Tool_task.handle_transition ~tool_name:"test_tool" ~start_time:0.0 ctx
       (`Assoc
         [
           ("task_id", `String "task-001");
           ("action", `String "start");
         ])
   in
-  assert (not success);
-  assert (str_contains result "Invalid transition");
-  assert (str_contains result "todo");
-  assert (str_contains result "Remediation");
-  assert (str_contains result "action=claim")
+  assert (not result.Tool_result.success);
+  assert (str_contains result.Tool_result.legacy_message "Invalid transition");
+  assert (str_contains result.Tool_result.legacy_message "todo");
+  assert (str_contains result.Tool_result.legacy_message "Remediation");
+  assert (str_contains result.Tool_result.legacy_message "action=claim")
 )
 
 let () = test "handle_transition_release_by_nonowner_redirects_to_board_post"
@@ -598,11 +598,11 @@ let () = test "handle_transition_release_by_nonowner_redirects_to_board_post"
      and redirect to masc_board_post rather than reflexive retry. *)
   let ctx_owner = make_test_ctx_with_agent "owner-agent" in
   let _ =
-    Tool_task.handle_add_task ctx_owner
+    Tool_task.handle_add_task ~tool_name:"test_tool" ~start_time:0.0 ctx_owner
       (`Assoc [ ("title", `String "Owned-by-other") ])
   in
   let _ =
-    Tool_task.handle_claim ctx_owner
+    Tool_task.handle_claim ~tool_name:"test_tool" ~start_time:0.0 ctx_owner
       (`Assoc [ ("task_id", `String "task-001") ])
   in
   (* A separate context for a different agent against the SAME config,
@@ -610,18 +610,18 @@ let () = test "handle_transition_release_by_nonowner_redirects_to_board_post"
   let ctx_other =
     { ctx_owner with Tool_task.agent_name = "other-agent" }
   in
-  let success, result =
-    Tool_task.handle_transition ctx_other
+  let result =
+    Tool_task.handle_transition ~tool_name:"test_tool" ~start_time:0.0 ctx_other
       (`Assoc
         [
           ("task_id", `String "task-001");
           ("action", `String "release");
         ])
   in
-  assert (not success);
-  assert (str_contains result "Invalid transition");
-  assert (str_contains result "Remediation");
-  assert (str_contains result "masc_board_post")
+  assert (not result.Tool_result.success);
+  assert (str_contains result.Tool_result.legacy_message "Invalid transition");
+  assert (str_contains result.Tool_result.legacy_message "Remediation");
+  assert (str_contains result.Tool_result.legacy_message "masc_board_post")
 )
 
 let () = test "handle_transition_release_synthesizes_summary_from_notes" (fun () ->
@@ -632,19 +632,19 @@ let () = test "handle_transition_release_synthesizes_summary_from_notes" (fun ()
      keeper LLM to retry the exact same payload shape. *)
   let ctx = make_test_ctx () in
   let _ =
-    Tool_task.handle_add_task ctx
+    Tool_task.handle_add_task ~tool_name:"test_tool" ~start_time:0.0 ctx
       (`Assoc
         [
           ("title", `String "Strict release with notes only");
           ("contract", `Assoc [ ("strict", `Bool true) ]);
         ])
   in
-  let _ = Tool_task.handle_claim ctx (`Assoc [ ("task_id", `String "task-001") ]) in
+  let _ = Tool_task.handle_claim ~tool_name:"test_tool" ~start_time:0.0 ctx (`Assoc [ ("task_id", `String "task-001") ]) in
   let synthesized_note =
     "blocked on fixture reproduction; hand off to fixture-capable keeper"
   in
-  let success_release, result_release =
-    Tool_task.handle_transition ctx
+  let result_release =
+    Tool_task.handle_transition ~tool_name:"test_tool" ~start_time:0.0 ctx
       (`Assoc
         [
           ("task_id", `String "task-001");
@@ -653,7 +653,7 @@ let () = test "handle_transition_release_synthesizes_summary_from_notes" (fun ()
           ("handoff_context", `Assoc []);
         ])
   in
-  if not success_release then failwith ("unexpected rejection: " ^ result_release);
+  if not result_release.Tool_result.success then failwith ("unexpected rejection: " ^ result_release.Tool_result.legacy_message);
   match Coord.get_tasks_raw ctx.config with
   | [ task ] -> (
       match task.handoff_context with
@@ -669,17 +669,17 @@ let () = test "handle_transition_release_prefers_notes_then_reason_for_synthesis
      collapses to the first line only. *)
   let ctx = make_test_ctx () in
   let _ =
-    Tool_task.handle_add_task ctx
+    Tool_task.handle_add_task ~tool_name:"test_tool" ~start_time:0.0 ctx
       (`Assoc
         [
           ("title", `String "Strict release with both notes and reason");
           ("contract", `Assoc [ ("strict", `Bool true) ]);
         ])
   in
-  let _ = Tool_task.handle_claim ctx (`Assoc [ ("task_id", `String "task-001") ]) in
+  let _ = Tool_task.handle_claim ~tool_name:"test_tool" ~start_time:0.0 ctx (`Assoc [ ("task_id", `String "task-001") ]) in
   let notes_line = "notes-line-should-win" in
-  let success_release, result_release =
-    Tool_task.handle_transition ctx
+  let result_release =
+    Tool_task.handle_transition ~tool_name:"test_tool" ~start_time:0.0 ctx
       (`Assoc
         [
           ("task_id", `String "task-001");
@@ -689,7 +689,7 @@ let () = test "handle_transition_release_prefers_notes_then_reason_for_synthesis
           ("handoff_context", `Assoc []);
         ])
   in
-  if not success_release then failwith ("unexpected rejection: " ^ result_release);
+  if not result_release.Tool_result.success then failwith ("unexpected rejection: " ^ result_release.Tool_result.legacy_message);
   match Coord.get_tasks_raw ctx.config with
   | [ task ] -> (
       match task.handoff_context with
@@ -702,18 +702,18 @@ let () = test "handle_transition_release_prefers_notes_then_reason_for_synthesis
 let () = test "handle_transition_release_empty_summary_error_includes_example" (fun () ->
   let ctx = make_test_ctx () in
   let _ =
-    Tool_task.handle_add_task ctx
+    Tool_task.handle_add_task ~tool_name:"test_tool" ~start_time:0.0 ctx
       (`Assoc
         [
           ("title", `String "Strict release task");
           ("contract", `Assoc [ ("strict", `Bool true) ]);
         ])
   in
-  let _ = Tool_task.handle_claim ctx (`Assoc [ ("task_id", `String "task-001") ]) in
+  let _ = Tool_task.handle_claim ~tool_name:"test_tool" ~start_time:0.0 ctx (`Assoc [ ("task_id", `String "task-001") ]) in
   (* Empty-string summary must also fail, and error must include a payload example
      so the keeper LLM can self-correct instead of retrying the same partial payload. *)
-  let success_empty, result_empty =
-    Tool_task.handle_transition ctx
+  let result_empty =
+    Tool_task.handle_transition ~tool_name:"test_tool" ~start_time:0.0 ctx
       (`Assoc
         [
           ("task_id", `String "task-001");
@@ -726,16 +726,16 @@ let () = test "handle_transition_release_empty_summary_error_includes_example" (
               ] );
         ])
   in
-  assert (not success_empty);
-  assert (str_contains result_empty "handoff_context.summary is required");
-  assert (str_contains result_empty "Example");
-  assert (str_contains result_empty "\"summary\"")
+  assert (not result_empty.Tool_result.success);
+  assert (str_contains result_empty.Tool_result.legacy_message "handoff_context.summary is required");
+  assert (str_contains result_empty.Tool_result.legacy_message "Example");
+  assert (str_contains result_empty.Tool_result.legacy_message "\"summary\"")
 )
 
 let () = test "handle_transition_done_prefers_ownership_error_over_cdal_gate" (fun () ->
   let ctx = make_test_ctx () in
   let _ =
-    Tool_task.handle_add_task ctx
+    Tool_task.handle_add_task ~tool_name:"test_tool" ~start_time:0.0 ctx
       (`Assoc
         [
           ("title", `String "Strict owned task");
@@ -748,8 +748,8 @@ let () = test "handle_transition_done_prefers_ownership_error_over_cdal_gate" (f
         ])
   in
   let _ = Coord.claim_task ctx.config ~agent_name:"other-agent" ~task_id:"task-001" in
-  let success, result =
-    Tool_task.handle_transition ctx
+  let result =
+    Tool_task.handle_transition ~tool_name:"test_tool" ~start_time:0.0 ctx
       (`Assoc
         [
           ("task_id", `String "task-001");
@@ -757,16 +757,16 @@ let () = test "handle_transition_done_prefers_ownership_error_over_cdal_gate" (f
           ("notes", `String "deliverable-ready");
         ])
   in
-  assert (not success);
-  assert (str_contains result "currently owned by other-agent");
-  assert (not (str_contains result "CDAL verdict"))
+  assert (not result.Tool_result.success);
+  assert (str_contains result.Tool_result.legacy_message "currently owned by other-agent");
+  assert (not (str_contains result.Tool_result.legacy_message "CDAL verdict"))
 )
 
 let () = test "handle_transition_done_on_awaiting_verification_is_explicit" (fun () ->
   with_env "MASC_VERIFICATION_FSM_ENABLED" (Some "true") (fun () ->
     let ctx = make_test_ctx () in
     let _ =
-      Tool_task.handle_add_task ctx
+      Tool_task.handle_add_task ~tool_name:"test_tool" ~start_time:0.0 ctx
         (`Assoc
           [
             ("title", `String "Awaiting verification task");
@@ -783,8 +783,8 @@ let () = test "handle_transition_done_on_awaiting_verification_is_explicit" (fun
       Coord.transition_task_r ctx.config ~agent_name:"test-agent"
         ~task_id:"task-001" ~action:Masc_domain.Submit_for_verification ()
     in
-    let success, result =
-      Tool_task.handle_transition ctx
+    let result =
+      Tool_task.handle_transition ~tool_name:"test_tool" ~start_time:0.0 ctx
         (`Assoc
           [
             ("task_id", `String "task-001");
@@ -792,32 +792,32 @@ let () = test "handle_transition_done_on_awaiting_verification_is_explicit" (fun
             ("notes", `String "tests pass");
           ])
     in
-    assert (not success);
-    assert (str_contains result "awaiting verification");
-    assert (str_contains result "approve or reject")))
+    assert (not result.Tool_result.success);
+    assert (str_contains result.Tool_result.legacy_message "awaiting verification");
+    assert (str_contains result.Tool_result.legacy_message "approve or reject")))
 let () = test "handle_claim_sets_planning_current_task" (fun () ->
   let ctx = make_test_ctx () in
-  let _ = Tool_task.handle_add_task ctx (`Assoc [("title", `String "Claim direct")]) in
-  let (success, _result) =
-    Tool_task.handle_claim ctx (`Assoc [("task_id", `String "task-001")])
+  let _ = Tool_task.handle_add_task ~tool_name:"test_tool" ~start_time:0.0 ctx (`Assoc [("title", `String "Claim direct")]) in
+  let result =
+    Tool_task.handle_claim ~tool_name:"test_tool" ~start_time:0.0 ctx (`Assoc [("task_id", `String "task-001")])
   in
-  assert success;
+  assert result.Tool_result.success;
   assert (Planning_eio.get_current_task ctx.config = Some "task-001")
 )
 
 let () = test "handle_claim_blocks_required_tools_without_server_surface" (fun () ->
   let ctx = make_test_ctx () in
   add_task_requiring_tools ctx ~title:"Needs bash" [ "keeper_bash" ];
-  let success, result =
-    Tool_task.handle_claim ~agent_tool_names:[ "masc_status" ] ctx
+  let result =
+    Tool_task.handle_claim ~agent_tool_names:[ "masc_status" ] ~tool_name:"test_tool" ~start_time:0.0 ctx
       (`Assoc
         [
           ("task_id", `String "task-001");
           ("agent_tool_names", `List [ `String "keeper_bash" ]);
         ])
   in
-  assert (not success);
-  assert (str_contains result "requires tool(s) unavailable");
+  assert (not result.Tool_result.success);
+  assert (str_contains result.Tool_result.legacy_message "requires tool(s) unavailable");
   assert_task_todo ctx;
   assert (Planning_eio.get_current_task ctx.config = None)
 )
@@ -825,11 +825,11 @@ let () = test "handle_claim_blocks_required_tools_without_server_surface" (fun (
 let () = test "handle_claim_allows_required_tools_with_server_surface" (fun () ->
   let ctx = make_test_ctx () in
   add_task_requiring_tools ctx ~title:"Needs bash" [ "keeper_bash" ];
-  let success, result =
-    Tool_task.handle_claim ~agent_tool_names:[ "masc_status"; "keeper_bash" ] ctx
+  let result =
+    Tool_task.handle_claim ~agent_tool_names:[ "masc_status"; "keeper_bash" ] ~tool_name:"test_tool" ~start_time:0.0 ctx
       (`Assoc [ ("task_id", `String "task-001") ])
   in
-  if not success then failwith result;
+  if not result.Tool_result.success then failwith result.Tool_result.legacy_message;
   assert_task_claimed_by ctx ctx.agent_name;
   assert (Planning_eio.get_current_task ctx.config = Some "task-001")
 )
@@ -837,17 +837,17 @@ let () = test "handle_claim_allows_required_tools_with_server_surface" (fun () -
 let () = test "handle_add_task_rejects_removed_required_preset_argument" (fun () ->
   let agent_name = "test-agent" in
   let ctx = make_test_ctx_with_agent agent_name in
-  let success, result =
-    Tool_task.handle_add_task ctx
+  let result =
+    Tool_task.handle_add_task ~tool_name:"test_tool" ~start_time:0.0 ctx
       (`Assoc
         [
           ("title", `String "Needs social");
           ("required_preset", `String "social");
         ])
   in
-  assert (not success);
-  assert (str_contains result "required_preset");
-  assert (str_contains result "Unknown argument")
+  assert (not result.Tool_result.success);
+  assert (str_contains result.Tool_result.legacy_message "required_preset");
+  assert (str_contains result.Tool_result.legacy_message "Unknown argument")
 )
 
 let () = test "add_task_schema_omits_removed_required_preset_argument" (fun () ->
@@ -869,44 +869,44 @@ let () = test "add_task_schema_omits_removed_required_preset_argument" (fun () -
 let () = test "handle_claim_rejects_removed_agent_role_argument" (fun () ->
   let ctx = make_test_ctx () in
   let _ =
-    Tool_task.handle_add_task ctx (`Assoc [ ("title", `String "Claim role arg") ])
+    Tool_task.handle_add_task ~tool_name:"test_tool" ~start_time:0.0 ctx (`Assoc [ ("title", `String "Claim role arg") ])
   in
-  let success, result =
-    Tool_task.handle_claim ctx
+  let result =
+    Tool_task.handle_claim ~tool_name:"test_tool" ~start_time:0.0 ctx
       (`Assoc
         [
           ("task_id", `String "task-001");
           ("agent_role", `String "worker");
         ])
   in
-  assert (not success);
-  assert (str_contains result "agent_role is no longer supported")
+  assert (not result.Tool_result.success);
+  assert (str_contains result.Tool_result.legacy_message "agent_role is no longer supported")
 )
 
 let () = test "handle_claim_next_sets_planning_current_task" (fun () ->
   let ctx = make_test_ctx () in
-  let _ = Tool_task.handle_add_task ctx (`Assoc [("title", `String "Claim next")]) in
-  let (success, _result) = Tool_task.handle_claim_next ctx (`Assoc []) in
-  assert success;
+  let _ = Tool_task.handle_add_task ~tool_name:"test_tool" ~start_time:0.0 ctx (`Assoc [("title", `String "Claim next")]) in
+  let result = Tool_task.handle_claim_next ~tool_name:"test_tool" ~start_time:0.0 ctx (`Assoc []) in
+  assert result.Tool_result.success;
   assert (Planning_eio.get_current_task ctx.config = Some "task-001")
 )
 
 let () = test "handle_claim_next_returns_claim_observation" (fun () ->
   let ctx = make_test_ctx () in
   let _ =
-    Tool_task.handle_add_task ctx (`Assoc [ ("title", `String "Claim observed") ])
+    Tool_task.handle_add_task ~tool_name:"test_tool" ~start_time:0.0 ctx (`Assoc [ ("title", `String "Claim observed") ])
   in
-  let success, result = Tool_task.handle_claim_next ctx (`Assoc []) in
-  if not success then failwith result;
+  let claim_result = Tool_task.handle_claim_next ~tool_name:"test_tool" ~start_time:0.0 ctx (`Assoc []) in
+  if not claim_result.Tool_result.success then failwith claim_result.Tool_result.legacy_message;
   let prefix = "claim_observation=" in
   let line =
     match
       List.find_opt
         (fun line -> str_starts_with ~prefix line)
-        (String.split_on_char '\n' result)
+        (String.split_on_char '\n' claim_result.Tool_result.legacy_message)
     with
     | Some line -> line
-    | None -> failwith ("missing claim observation in result: " ^ result)
+    | None -> failwith ("missing claim observation in result: " ^ claim_result.Tool_result.legacy_message)
   in
   let payload =
     String.sub line (String.length prefix) (String.length line - String.length prefix)
@@ -927,12 +927,12 @@ let () =
   test "handle_claim_next_blocks_required_tools_without_server_surface" (fun () ->
     let ctx = make_test_ctx () in
     add_task_requiring_tools ctx ~title:"Needs bash" [ "keeper_bash" ];
-    let success, result =
-      Tool_task.handle_claim_next ~agent_tool_names:[ "masc_status" ] ctx
+    let result =
+      Tool_task.handle_claim_next ~agent_tool_names:[ "masc_status" ] ~tool_name:"test_tool" ~start_time:0.0 ctx
         (`Assoc [])
     in
-    assert success;
-    assert (str_contains result "No eligible tasks available");
+    assert result.Tool_result.success;
+    assert (str_contains result.Tool_result.legacy_message "No eligible tasks available");
     assert_task_todo ctx;
     assert (Planning_eio.get_current_task ctx.config = None))
 
@@ -940,12 +940,13 @@ let () =
   test "handle_claim_next_allows_required_tools_with_server_surface" (fun () ->
     let ctx = make_test_ctx () in
     add_task_requiring_tools ctx ~title:"Needs bash" [ "keeper_bash" ];
-    let success, result =
+    let result =
       Tool_task.handle_claim_next
         ~agent_tool_names:[ "masc_status"; "keeper_bash" ]
+        ~tool_name:"test_tool" ~start_time:0.0
         ctx (`Assoc [])
     in
-    if not success then failwith result;
+    if not result.Tool_result.success then failwith result.Tool_result.legacy_message;
     assert_task_claimed_by ctx ctx.agent_name;
     assert (Planning_eio.get_current_task ctx.config = Some "task-001"))
 
@@ -984,35 +985,35 @@ let () = test "handle_claim_next_ignores_keeper_preset_for_open_claims" (fun () 
   | Ok _ -> ()
   | Error e -> failwith (Masc_domain.masc_error_to_string e));
   let _ =
-    Tool_task.handle_add_task ctx
+    Tool_task.handle_add_task ~tool_name:"test_tool" ~start_time:0.0 ctx
       (`Assoc [ ("title", `String "Open claim task") ])
   in
-  let success, result = Tool_task.handle_claim_next ctx (`Assoc []) in
-  assert success;
+  let result = Tool_task.handle_claim_next ~tool_name:"test_tool" ~start_time:0.0 ctx (`Assoc []) in
+  assert result.Tool_result.success;
   match Coord.get_tasks_raw ctx.config with
   | [ task ] -> (
       match task.task_status with
       | Masc_domain.Claimed { assignee; _ } -> assert (assignee = agent_name)
-      | _ -> failwith ("expected task to be claimed: " ^ result))
-  | _ -> failwith ("expected exactly one task: " ^ result)
+      | _ -> failwith ("expected task to be claimed: " ^ result.Tool_result.legacy_message))
+  | _ -> failwith ("expected exactly one task: " ^ result.Tool_result.legacy_message)
 )
 
 let () = test "transition_claim_sets_planning_current_task" (fun () ->
   let ctx = make_test_ctx () in
-  let _ = Tool_task.handle_add_task ctx (`Assoc [("title", `String "Transition claim")]) in
-  let (success, _result) =
-    Tool_task.handle_transition ctx
+  let _ = Tool_task.handle_add_task ~tool_name:"test_tool" ~start_time:0.0 ctx (`Assoc [("title", `String "Transition claim")]) in
+  let result =
+    Tool_task.handle_transition ~tool_name:"test_tool" ~start_time:0.0 ctx
       (`Assoc [("task_id", `String "task-001"); ("action", `String "claim")])
   in
-  assert success;
+  assert result.Tool_result.success;
   assert (Planning_eio.get_current_task ctx.config = Some "task-001")
 )
 
 let () = test "transition_claim_blocks_required_tools_even_with_force" (fun () ->
   let ctx = make_test_ctx () in
   add_task_requiring_tools ctx ~title:"Needs bash" [ "keeper_bash" ];
-  let success, result =
-    Tool_task.handle_transition ~agent_tool_names:[ "masc_status" ] ctx
+  let result =
+    Tool_task.handle_transition ~tool_name:"test_tool" ~start_time:0.0 ~agent_tool_names:[ "masc_status" ] ctx
       (`Assoc
         [
           ("task_id", `String "task-001");
@@ -1020,8 +1021,8 @@ let () = test "transition_claim_blocks_required_tools_even_with_force" (fun () -
           ("force", `Bool true);
         ])
   in
-  assert (not success);
-  assert (str_contains result "requires tool(s) unavailable");
+  assert (not result.Tool_result.success);
+  assert (str_contains result.Tool_result.legacy_message "requires tool(s) unavailable");
   assert_task_todo ctx;
   assert (Planning_eio.get_current_task ctx.config = None)
 )
@@ -1030,9 +1031,10 @@ let () = test "transition_submit_for_verification_rejects_todo_pr_evidence" (fun
   with_env "MASC_VERIFICATION_FSM_ENABLED" (Some "true") (fun () ->
     let ctx = make_test_ctx_with_agent "codex-mcp-client" in
     add_task_requiring_tools ctx ~title:"Codex CLI approval follow-up" [ "keeper_bash" ];
-    let success, result =
+    let result =
       Tool_task.handle_transition
         ~agent_tool_names:[ "masc_status"; "masc_transition" ]
+        ~tool_name:"test_tool" ~start_time:0.0
         ctx
         (`Assoc
           [
@@ -1044,8 +1046,8 @@ let () = test "transition_submit_for_verification_rejects_todo_pr_evidence" (fun
                 "Implementation is already merged; submit PR evidence for independent verification." );
           ])
     in
-    assert (not success);
-    assert (str_contains result "Invalid transition: todo -> submit_for_verification");
+    assert (not result.Tool_result.success);
+    assert (str_contains result.Tool_result.legacy_message "Invalid transition: todo -> submit_for_verification");
     assert_task_todo ctx)
 )
 
@@ -1053,9 +1055,10 @@ let () = test "transition_submit_pr_evidence_accepts_todo_pr_evidence_without_re
   with_env "MASC_VERIFICATION_FSM_ENABLED" (Some "true") (fun () ->
     let ctx = make_test_ctx_with_agent "codex-mcp-client" in
     add_task_requiring_tools ctx ~title:"Codex CLI approval follow-up" [ "keeper_bash" ];
-    let claim_success, claim_result =
+    let claim_result =
       Tool_task.handle_transition
         ~agent_tool_names:[ "masc_status"; "masc_transition" ]
+        ~tool_name:"test_tool" ~start_time:0.0
         ctx
         (`Assoc
           [
@@ -1063,12 +1066,13 @@ let () = test "transition_submit_pr_evidence_accepts_todo_pr_evidence_without_re
             ("action", `String "claim");
           ])
     in
-    assert (not claim_success);
-    assert (str_contains claim_result "requires tool(s) unavailable");
+    assert (not claim_result.Tool_result.success);
+    assert (str_contains claim_result.Tool_result.legacy_message "requires tool(s) unavailable");
     assert_task_todo ctx;
-    let submit_success, submit_result =
+    let submit_result =
       Tool_task.handle_transition
         ~agent_tool_names:[ "masc_status"; "masc_transition" ]
+        ~tool_name:"test_tool" ~start_time:0.0
         ctx
         (`Assoc
           [
@@ -1080,7 +1084,7 @@ let () = test "transition_submit_pr_evidence_accepts_todo_pr_evidence_without_re
                 "Implementation is already merged; submit PR evidence for independent verification." );
           ])
     in
-    if not submit_success then failwith submit_result;
+    if not submit_result.Tool_result.success then failwith submit_result.Tool_result.legacy_message;
     assert_task_awaiting_verification_by ctx "codex-mcp-client";
     assert (Planning_eio.get_current_task ctx.config = None))
 )
@@ -1088,31 +1092,32 @@ let () = test "transition_submit_pr_evidence_accepts_todo_pr_evidence_without_re
 let () = test "transition_submit_pr_evidence_accepts_todo_pr_evidence_with_stale_do_not_reclaim_reason" (fun () ->
   with_env "MASC_VERIFICATION_FSM_ENABLED" (Some "true") (fun () ->
     let ctx = make_test_ctx_with_agent "codex-mcp-client" in
-    let success, result =
-      Tool_task.handle_add_task ctx
+    let result =
+      Tool_task.handle_add_task ~tool_name:"test_tool" ~start_time:0.0 ctx
         (`Assoc
           [
             ("title", `String "Strict accessor PR evidence");
             ("priority", `Int 1);
           ])
     in
-    if not success then failwith result;
+    if not result.Tool_result.success then failwith result.Tool_result.legacy_message;
     set_only_task_do_not_reclaim_reason ctx
       "Auto-claimed via auto_goal_fallback by issue_king without repo write tools";
-    let claim_success, claim_result =
-      Tool_task.handle_transition ctx
+    let claim_result =
+      Tool_task.handle_transition ~tool_name:"test_tool" ~start_time:0.0 ctx
         (`Assoc
           [
             ("task_id", `String "task-001");
             ("action", `String "claim");
           ])
     in
-    assert (not claim_success);
-    assert (str_contains claim_result "blocked from re-claim");
+    assert (not claim_result.Tool_result.success);
+    assert (str_contains claim_result.Tool_result.legacy_message "blocked from re-claim");
     assert_task_todo ctx;
-    let submit_success, submit_result =
+    let submit_result =
       Tool_task.handle_transition
         ~agent_tool_names:[ "masc_status"; "masc_transition" ]
+        ~tool_name:"test_tool" ~start_time:0.0
         ctx
         (`Assoc
           [
@@ -1124,7 +1129,7 @@ let () = test "transition_submit_pr_evidence_accepts_todo_pr_evidence_with_stale
                 "A stale do_not_reclaim_reason blocks claim, but merged PR evidence can still enter verification." );
           ])
     in
-    if not submit_success then failwith submit_result;
+    if not submit_result.Tool_result.success then failwith submit_result.Tool_result.legacy_message;
     assert_task_awaiting_verification_by ctx "codex-mcp-client";
     assert (Planning_eio.get_current_task ctx.config = None))
 )
@@ -1156,8 +1161,8 @@ let () = test "submit_pr_evidence_bypasses_required_tool_gate_on_todo_task" (fun
   with_env "MASC_VERIFICATION_FSM_ENABLED" (Some "true") (fun () ->
     let ctx = make_test_ctx_with_agent "codex-mcp-client" in
     add_task_requiring_tools ctx ~title:"Needs bash" [ "keeper_bash" ];
-    let success, result =
-      Tool_task.handle_transition ~agent_tool_names:[ "masc_status" ] ctx
+    let result =
+      Tool_task.handle_transition ~tool_name:"test_tool" ~start_time:0.0 ~agent_tool_names:[ "masc_status" ] ctx
         (`Assoc
           [
             ("task_id", `String "task-001");
@@ -1165,8 +1170,8 @@ let () = test "submit_pr_evidence_bypasses_required_tool_gate_on_todo_task" (fun
             ("notes", `String "PR jeong-sik/masc-mcp#13169 merged 2026-05-05");
           ])
     in
-    if not success then
-      failwith (Printf.sprintf "expected submit_pr_evidence to succeed, got: %s" result);
+    if not result.Tool_result.success then
+      failwith (Printf.sprintf "expected submit_pr_evidence to succeed, got: %s" result.Tool_result.legacy_message);
     match (only_task ctx).Masc_domain.task_status with
     | Masc_domain.AwaitingVerification _ -> ()
     | other ->
@@ -1177,30 +1182,30 @@ let () = test "submit_pr_evidence_bypasses_required_tool_gate_on_todo_task" (fun
 
 let () = test "transition_release_clears_planning_current_task" (fun () ->
   let ctx = make_test_ctx () in
-  let _ = Tool_task.handle_add_task ctx (`Assoc [("title", `String "Transition release")]) in
-  let (success_claim, _result) =
-    Tool_task.handle_transition ctx
+  let _ = Tool_task.handle_add_task ~tool_name:"test_tool" ~start_time:0.0 ctx (`Assoc [("title", `String "Transition release")]) in
+  let claim_result =
+    Tool_task.handle_transition ~tool_name:"test_tool" ~start_time:0.0 ctx
       (`Assoc [("task_id", `String "task-001"); ("action", `String "claim")])
   in
-  assert success_claim;
-  let (success_release, _result) =
-    Tool_task.handle_transition ctx
+  assert claim_result.Tool_result.success;
+  let release_result =
+    Tool_task.handle_transition ~tool_name:"test_tool" ~start_time:0.0 ctx
       (`Assoc [("task_id", `String "task-001"); ("action", `String "release")])
   in
-  assert success_release;
+  assert release_result.Tool_result.success;
   assert (Planning_eio.get_current_task ctx.config = None)
 )
 
 let () = test "transition_done_redirects_to_verification_and_clears_planning_current_task" (fun () ->
   let ctx = make_test_ctx () in
-  let _ = Tool_task.handle_add_task ctx (`Assoc [("title", `String "Transition done")]) in
-  let (success_claim, _result) =
-    Tool_task.handle_transition ctx
+  let _ = Tool_task.handle_add_task ~tool_name:"test_tool" ~start_time:0.0 ctx (`Assoc [("title", `String "Transition done")]) in
+  let claim_result =
+    Tool_task.handle_transition ~tool_name:"test_tool" ~start_time:0.0 ctx
       (`Assoc [("task_id", `String "task-001"); ("action", `String "claim")])
   in
-  assert success_claim;
-  let (success_done, result) =
-    Tool_task.handle_transition ctx
+  assert claim_result.Tool_result.success;
+  let done_result =
+    Tool_task.handle_transition ~tool_name:"test_tool" ~start_time:0.0 ctx
       (`Assoc
         [
           ("task_id", `String "task-001");
@@ -1208,8 +1213,8 @@ let () = test "transition_done_redirects_to_verification_and_clears_planning_cur
           ("notes", `String "Implemented the transport parity checks and verified the result.");
         ])
   in
-  assert success_done;
-  assert (not (str_contains result "rejected"));
+  assert done_result.Tool_result.success;
+  assert (not (str_contains done_result.Tool_result.legacy_message "rejected"));
   assert (Planning_eio.get_current_task ctx.config = None);
   match Coord.get_tasks_raw ctx.config with
   | [ task ] -> (
@@ -1221,9 +1226,9 @@ let () = test "transition_done_redirects_to_verification_and_clears_planning_cur
 
 let () = test "transition_accepts_underscore_prefixed_internal_markers" (fun () ->
   let ctx = make_test_ctx () in
-  let _ = Tool_task.handle_add_task ctx (`Assoc [("title", `String "Marker test")]) in
-  let (success, result) =
-    Tool_task.handle_transition ctx
+  let _ = Tool_task.handle_add_task ~tool_name:"test_tool" ~start_time:0.0 ctx (`Assoc [("title", `String "Marker test")]) in
+  let result =
+    Tool_task.handle_transition ~tool_name:"test_tool" ~start_time:0.0 ctx
       (`Assoc [
         ("task_id", `String "task-001");
         ("action", `String "claim");
@@ -1231,74 +1236,74 @@ let () = test "transition_accepts_underscore_prefixed_internal_markers" (fun () 
         ("_session_marker", `String "sess-xyz");
       ])
   in
-  assert success;
-  assert (not (str_contains result "Unknown argument"))
+  assert result.Tool_result.success;
+  assert (not (str_contains result.Tool_result.legacy_message "Unknown argument"))
 )
 
 let () = test "transition_still_rejects_plain_unknown_arguments" (fun () ->
   let ctx = make_test_ctx () in
-  let _ = Tool_task.handle_add_task ctx (`Assoc [("title", `String "Reject test")]) in
-  let (success, result) =
-    Tool_task.handle_transition ctx
+  let _ = Tool_task.handle_add_task ~tool_name:"test_tool" ~start_time:0.0 ctx (`Assoc [("title", `String "Reject test")]) in
+  let result =
+    Tool_task.handle_transition ~tool_name:"test_tool" ~start_time:0.0 ctx
       (`Assoc [
         ("task_id", `String "task-001");
         ("action", `String "claim");
         ("totally_bogus", `String "no");
       ])
   in
-  assert (not success);
-  assert (str_contains result "Unknown argument(s): totally_bogus")
+  assert (not result.Tool_result.success);
+  assert (str_contains result.Tool_result.legacy_message "Unknown argument(s): totally_bogus")
 )
 
 (* Test handle_done returns owner guidance when another agent owns the task *)
 let () = test "handle_done_owned_by_other_guidance" (fun () ->
   let ctx = make_test_ctx () in
-  let _ = Tool_task.handle_add_task ctx (`Assoc [("title", `String "Done test")]) in
+  let _ = Tool_task.handle_add_task ~tool_name:"test_tool" ~start_time:0.0 ctx (`Assoc [("title", `String "Done test")]) in
   let _ = Coord.claim_task ctx.config ~agent_name:"other-agent" ~task_id:"task-001" in
-  let success, result =
-    Tool_task.handle_done ctx (`Assoc [("task_id", `String "task-001"); ("notes", `String "")])
+  let result =
+    Tool_task.handle_done ~tool_name:"test_tool" ~start_time:0.0 ctx (`Assoc [("task_id", `String "task-001"); ("notes", `String "")])
   in
-  assert (not success);
-  assert (str_contains result "currently owned by other-agent")
+  assert (not result.Tool_result.success);
+  assert (str_contains result.Tool_result.legacy_message "currently owned by other-agent")
 )
 
 (* Test handle_done on todo task recommends claim/start first *)
 let () = test "handle_done_todo_guidance" (fun () ->
   let ctx = make_test_ctx () in
-  let _ = Tool_task.handle_add_task ctx (`Assoc [("title", `String "Todo test")]) in
-  let success, result =
-    Tool_task.handle_done ctx (`Assoc [("task_id", `String "task-001"); ("notes", `String "")])
+  let _ = Tool_task.handle_add_task ~tool_name:"test_tool" ~start_time:0.0 ctx (`Assoc [("title", `String "Todo test")]) in
+  let result =
+    Tool_task.handle_done ~tool_name:"test_tool" ~start_time:0.0 ctx (`Assoc [("task_id", `String "task-001"); ("notes", `String "")])
   in
-  assert (not success);
-  assert (str_contains result "Claim/start it first")
+  assert (not result.Tool_result.success);
+  assert (str_contains result.Tool_result.legacy_message "Claim/start it first")
 )
 
 (* Test handle_done reports already-done guidance instead of generic not-claimed *)
 let () = test "handle_done_already_done_guidance" (fun () ->
   let ctx = make_test_ctx () in
-  let _ = Tool_task.handle_add_task ctx (`Assoc [("title", `String "Done test")]) in
+  let _ = Tool_task.handle_add_task ~tool_name:"test_tool" ~start_time:0.0 ctx (`Assoc [("title", `String "Done test")]) in
   let _ = Coord.claim_task ctx.config ~agent_name:"other-agent" ~task_id:"task-001" in
   let _ =
     Coord.transition_task_r ctx.config ~agent_name:"other-agent"
       ~task_id:"task-001" ~action:Masc_domain.Done_action ~notes:"done" ()
   in
-  let success, result =
-    Tool_task.handle_done ctx (`Assoc [("task_id", `String "task-001"); ("notes", `String "")])
+  let result =
+    Tool_task.handle_done ~tool_name:"test_tool" ~start_time:0.0 ctx (`Assoc [("task_id", `String "task-001"); ("notes", `String "")])
   in
-  assert (not success);
-  assert (str_contains result "already done by other-agent")
+  assert (not result.Tool_result.success);
+  assert (str_contains result.Tool_result.legacy_message "already done by other-agent")
 )
 
 (* Test handle_done reports cancelled-task guidance instead of generic not-claimed *)
 let () = test "handle_done_cancelled_guidance" (fun () ->
   let ctx = make_test_ctx () in
-  let _ = Tool_task.handle_add_task ctx (`Assoc [("title", `String "Cancelled test")]) in
+  let _ = Tool_task.handle_add_task ~tool_name:"test_tool" ~start_time:0.0 ctx (`Assoc [("title", `String "Cancelled test")]) in
   let _ = Coord.cancel_task_r ctx.config ~agent_name:"test-agent" ~task_id:"task-001" ~reason:"stop" in
-  let success, result =
-    Tool_task.handle_done ctx (`Assoc [("task_id", `String "task-001"); ("notes", `String "")])
+  let result =
+    Tool_task.handle_done ~tool_name:"test_tool" ~start_time:0.0 ctx (`Assoc [("task_id", `String "task-001"); ("notes", `String "")])
   in
-  assert (not success);
-  assert (str_contains result "was cancelled by test-agent")
+  assert (not result.Tool_result.success);
+  assert (str_contains result.Tool_result.legacy_message "was cancelled by test-agent")
 )
 
 (* Test dispatch transition release *)
@@ -1346,8 +1351,8 @@ let () = test "handle_batch_add_tasks" (fun () ->
       `Assoc [("title", `String "Task 2"); ("priority", `Int 2)];
     ])
   ] in
-  let (success, _) = Tool_task.handle_batch_add_tasks ctx args in
-  assert success
+  let batch_result = Tool_task.handle_batch_add_tasks ~tool_name:"test_tool" ~start_time:0.0 ctx args in
+  assert batch_result.Tool_result.success
 )
 
 let () = test "handle_batch_add_tasks_rejects_removed_role_fields" (fun () ->
@@ -1366,9 +1371,9 @@ let () = test "handle_batch_add_tasks_rejects_removed_role_fields" (fun () ->
             ] );
       ]
   in
-  let success, result = Tool_task.handle_batch_add_tasks ctx args in
-  assert (not success);
-  assert (str_contains result "required_role is no longer supported")
+  let result = Tool_task.handle_batch_add_tasks ~tool_name:"test_tool" ~start_time:0.0 ctx args in
+  assert (not result.Tool_result.success);
+  assert (str_contains result.Tool_result.legacy_message "required_role is no longer supported")
 )
 
 (* Test helper functions *)
@@ -1517,32 +1522,32 @@ let () = test "build_verdict_sse_payload: fallback_reason serialized" (fun () ->
 let () = test "claim_next_returns_no_unclaimed_when_all_tasks_terminal" (fun () ->
   let ctx = make_test_ctx () in
   (* Create a task, mark it as done *)
-  let _ = Tool_task.handle_add_task ctx (`Assoc [("title", `String "Done task")]) in
-  let _ = Tool_task.handle_transition ctx (`Assoc [
+  let _ = Tool_task.handle_add_task ~tool_name:"test_tool" ~start_time:0.0 ctx (`Assoc [("title", `String "Done task")]) in
+  let _ = Tool_task.handle_transition ~tool_name:"test_tool" ~start_time:0.0 ctx (`Assoc [
     ("task_id", `String "task-001");
     ("action", `String "done");
     ("notes", `String "Completed");
   ]) in
   (* Now try to claim next from a different agent in same room *)
   let agent2_ctx = make_test_ctx_with_agent "agent-2" in
-  let (_success, msg) = Tool_task.handle_claim_next agent2_ctx (`Assoc []) in
+  let msg_result = Tool_task.handle_claim_next ~tool_name:"test_tool" ~start_time:0.0 agent2_ctx (`Assoc []) in
   (* Should report no unclaimed tasks (success=true, message contains "No") *)
-  assert (String.length msg > 0);
-  match String.index_opt msg 'N' with
+  assert (String.length msg_result.Tool_result.legacy_message > 0);
+  match String.index_opt msg_result.Tool_result.legacy_message 'N' with
   | Some _ -> () (* Found "No unclaimed" message *)
-  | None -> failwith (Printf.sprintf "Expected 'No unclaimed' message, got: %s" msg)
+  | None -> failwith (Printf.sprintf "Expected 'No unclaimed' message, got: %s" msg_result.Tool_result.legacy_message)
 )
 
 (* Regression: claim_next should properly skip cancelled tasks and only claim todo *)
 let () = test "claim_next_filters_out_cancelled_tasks" (fun () ->
   let ctx = make_test_ctx () in
-  let _ = Tool_task.handle_add_task ctx (`Assoc [("title", `String "Cancelled task")]) in
+  let _ = Tool_task.handle_add_task ~tool_name:"test_tool" ~start_time:0.0 ctx (`Assoc [("title", `String "Cancelled task")]) in
   let _ = Coord.cancel_task_r ctx.config ~agent_name:ctx.agent_name ~task_id:"task-001" ~reason:"not needed" in
   let agent2_ctx = make_test_ctx_with_agent "agent-claim-2" in
-  let (_success, msg) = Tool_task.handle_claim_next agent2_ctx (`Assoc []) in
-  match String.index_opt msg 'N' with
+  let msg_result = Tool_task.handle_claim_next ~tool_name:"test_tool" ~start_time:0.0 agent2_ctx (`Assoc []) in
+  match String.index_opt msg_result.Tool_result.legacy_message 'N' with
   | Some _ -> () (* "No unclaimed" is correct *)
-  | None -> failwith (Printf.sprintf "Expected no tasks available, got: %s" msg)
+  | None -> failwith (Printf.sprintf "Expected no tasks available, got: %s" msg_result.Tool_result.legacy_message)
 )
 
 (* ===========================================================================
@@ -1569,8 +1574,8 @@ let () = test "rfc_0034_v2_masc_add_task_caps_per_goal" (fun () ->
     | Error msg -> failwith msg
   in
   for i = 1 to 3 do
-    let success, msg =
-      Tool_task.handle_add_task ctx
+    let msg_result =
+      Tool_task.handle_add_task ~tool_name:"test_tool" ~start_time:0.0 ctx
         (`Assoc
           [
             ("title", `String (Printf.sprintf "Goal task %d" i));
@@ -1579,16 +1584,16 @@ let () = test "rfc_0034_v2_masc_add_task_caps_per_goal" (fun () ->
             ("goal_id", `String goal.id);
           ])
     in
-    if not success
+    if not msg_result.Tool_result.success
     then
       failwith
         (Printf.sprintf
            "expected goal-bound add_task #%d to succeed, got: %s"
            i
-           msg)
+           msg_result.Tool_result.legacy_message)
   done;
-  let _success, message =
-    Tool_task.handle_add_task ctx
+  let message_result =
+    Tool_task.handle_add_task ~tool_name:"test_tool" ~start_time:0.0 ctx
       (`Assoc
         [
           ("title", `String "Fourth goal task — should be rejected");
@@ -1602,18 +1607,18 @@ let () = test "rfc_0034_v2_masc_add_task_caps_per_goal" (fun () ->
      surface, so [handle_add_task] still returns [(true, "Error: ...")].
      The cap is enforced at persistence time — pin both the message
      content and the persisted backlog size. *)
-  if not (str_starts_with ~prefix:"Error:" message)
+  if not (str_starts_with ~prefix:"Error:" message_result.Tool_result.legacy_message)
   then
     failwith
       (Printf.sprintf
          "expected fourth task to be rejected with an \"Error:\" message, got: %s"
-         message);
-  if not (str_contains message "goal_task_limit_exceeded")
+         message_result.Tool_result.legacy_message);
+  if not (str_contains message_result.Tool_result.legacy_message "goal_task_limit_exceeded")
   then
     failwith
       (Printf.sprintf
          "expected rejection message to mention goal_task_limit_exceeded, got: %s"
-         message);
+         message_result.Tool_result.legacy_message);
   let backlog = Coord.read_backlog ctx.config in
   if List.length backlog.tasks <> 3
   then


### PR DESCRIPTION
## Summary

RFC-0062 Phase 4c-1: Deep Migration of 8 core tool module handlers from `(bool * string)` tuple returns to `Tool_result.t` structured records.

**Scope**: tool_args, tool_code, tool_code_write, tool_control, tool_library, tool_plan, tool_run, tool_task, tool_worktree + keeper dispatch (keeper_exec_tools, keeper_exec_task) + server_bootstrap_loops

**Changes**:
- Handler signatures: `(bool * string)` → `Tool_result.t` with `~tool_name` `~start_time` labeled params
- Keeper dispatch: tuple destructuring → `Tool_result.success` / `.legacy_message` field access
- `keeper_tool_result_json` calls: `~ok:bool ~message:string` → `~ok:result.Tool_result.success ~message:result.Tool_result.legacy_message`
- Test coverage: all test tuple destructuring updated to Tool_result field access
- Removed dead `wrap_result` calls from `keeper_tag_dispatch` and `mcp_server_eio_execute`

**Build**: `dune build --root . @check` passes. `dune test` blocked by pre-existing `cascade_transport.ml` type mismatch (unrelated).

**Follow-up PRs**:
- 4c-2: Remove `wrap_result` from remaining modules (tool_operator, tool_misc + sub-modules, tool_autoresearch, tool_agent_timeline, tool_inline_dispatch)
- 4d: Standalone handlers + cleanup (progress.ml, session.ml, subscriptions.ml, tool_deep_review.ml, tool_bridge.ml; remove `Tool_result.wrap`, `Tool_result.to_legacy_compat`, `Coord_types.tool_result`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)