### PR TITLE
fix(dashboard): resolve pre-existing TS errors

### DIFF
--- a/dashboard/src/api/ide.ts
+++ b/dashboard/src/api/ide.ts
@@ -29,7 +29,6 @@ export interface CreateAnnotationInput {
   readonly content: string
   readonly goal_id?: string
   readonly task_id?: string
-  readonly task_id?: string
 }
 
 function appendFilterParams(

--- a/dashboard/src/components/ide/keeper-cursor-overlay.ts
+++ b/dashboard/src/components/ide/keeper-cursor-overlay.ts
@@ -5,7 +5,6 @@
 
 import { html } from 'htm/preact'
 import { signal } from '@preact/signals'
-import type { KeeperPresenceEntry } from './keeper-presence-store'
 
 // ── Types ─────────────────────────────────────────────────────────
 
@@ -56,7 +55,7 @@ const KEEPER_COLORS = [
 
 export function getKeeperColor(keeperId: string, index?: number): { cursor: string; selection: string } {
   const idx = index ?? (keeperId.charCodeAt(0) + (keeperId.charCodeAt(1) || 0)) % KEEPER_COLORS.length
-  return KEEPER_COLORS[idx] ?? KEEPER_COLORS[0]
+  return KEEPER_COLORS[idx] ?? { cursor: KEEPER_COLORS[0]!.cursor, selection: KEEPER_COLORS[0]!.selection }
 }
 
 // ── Collision Detection ─────────────────────────────────────────
@@ -361,7 +360,6 @@ export function updateCursorFromToolCall(
   toolName: string,
   turn: number,
 ): KeeperCursorOverlay {
-  const existing = overlay.cursors.get(keeperId)
   const now = Date.now()
   
   const updated: KeeperCursor = {

--- a/dashboard/src/components/transport-health.ts
+++ b/dashboard/src/components/transport-health.ts
@@ -1,7 +1,6 @@
 import { html } from 'htm/preact'
 import { useEffect } from 'preact/hooks'
 import { signal } from '@preact/signals'
-import type { ComponentChildren } from 'preact'
 import { lastEvent } from '../sse'
 import type { SSEEvent } from '../types'
 import { FetchScheduler } from '../lib/fetch-scheduler'

--- a/dashboard/src/sse.ts
+++ b/dashboard/src/sse.ts
@@ -15,14 +15,12 @@ import {
 import { appendLiveToolCall } from './components/session-trace/session-trace-live-store'
 import { appendAuditEntry } from './live-store'
 import { parseSSEMessage } from './schemas/sse'
-import { updateKeeperPresenceFromSSE } from './components/ide/keeper-presence-store'
 import { RingBuffer } from './lib/ring-buffer'
 import { createSseTransport } from './transports/sse-transport'
 import type { Transport } from './transports/transport'
 
 import {
   RECONNECT_BASE_MS,
-  RECONNECT_JITTER_MS,
   RECONNECT_MAX_MS,
   MAX_JOURNAL_ENTRIES,
 } from './config/constants'
@@ -261,7 +259,6 @@ export function connectSSE(): void {
         // parsed JSON when possible; fall back to ignoring plain strings.
         return
       }
-      const rawRecord = raw as { jsonrpc?: unknown; params?: { type?: unknown } }
       const candidate: unknown =
         raw && (raw as { jsonrpc?: unknown }).jsonrpc && (raw as { params?: { type?: unknown } }).params?.type
           ? (raw as { params?: unknown }).params
@@ -923,7 +920,7 @@ function handleEvent(event: SSEEvent): void {
       const p = (event.payload ?? {}) as Record<string, unknown>
       const runtimeId = asString(p.runtime_id) ?? 'unknown'
       const branch = asString(p.branch) ?? 'unknown'
-      const supervisor = asString(p.supervisor) ?? 'unknown'
+      // supervisor extracted for future use
       const connected = p.connected === true
       const entries = Array.isArray(p.entries) ? p.entries.length : 0
       addTypedJournalEntry(


### PR DESCRIPTION
## 요약

Dashboard TypeScript typecheck 게이트를 차단하던 기존 TS 에러 수정.

### 변경 내용

- `ide.ts`: 중복 `task_id` 속성 제거 (TS2300)
- `keeper-cursor-overlay.ts`: 미사용 `KeeperPresenceEntry` import 제거, `KEEPER_COLORS[idx]` possibly-undefined 수정, 미사용 `existing` var 제거
- `transport-health.ts`: 미사용 `ComponentChildren` import 제거
- `sse.ts`: 미사용 `updateKeeperPresenceFromSSE`, `RECONNECT_JITTER_MS` import 제거, 미사용 `rawRecord` 할당 제거, 미사용 `supervisor` 제거

### 비고

- grpc-transport.ts 에러는 PR #14530 에서 별도 수정
- `@codemirror/lang-rust`, `@codemirror/lang-go` 모듈 누락은 패키지 설치 문제로 코드 수정 없음 (CI에서는 정상 설치됨)