### PR TITLE
feat(keeper): invariant tests, turn_id wiring, sandbox isolation guard in fs edit

### DIFF
--- a/lib/keeper/keeper_exec_fs.ml
+++ b/lib/keeper/keeper_exec_fs.ml
@@ -229,6 +229,17 @@ let validate_write_target ~config ~meta ~target =
   | Ok () -> Ok ()
   | Error e -> Error (error_json ~fields:[ "path", `String target ] e)
 
+
+let check_invariant_sandbox_isolation ~(turn_sandbox_factory : Keeper_sandbox_factory.t option) ~target =
+  match turn_sandbox_factory with
+  | None -> Ok ()
+  | Some factory ->
+    let cwd = Filename.dirname target in
+    (match Keeper_sandbox_factory.resolve_opt (Some factory) ~cwd with
+     | None -> Ok ()
+     | Some runtime ->
+       let host_root = Keeper_turn_sandbox_runtime.host_root runtime in
+       Keeper_invariant.sandbox_isolation ~sandbox_roots:[host_root] ~sandbox_paths:[target])
 let handle_keeper_fs_edit
       ~(turn_sandbox_factory : Keeper_sandbox_factory.t option)
       ~(config : Coord.config)
@@ -269,6 +280,9 @@ let handle_keeper_fs_edit
        | Ok target ->
          (match validate_write_target ~config ~meta ~target with
           | Error json -> json
+          | Ok () ->
+         (match check_invariant_sandbox_isolation ~turn_sandbox_factory ~target with
+          | Error msg -> error_json ~fields:[ "path", `String target ] msg
           | Ok () ->
          (match Keeper_repo_mapping.validate_path_access ~keeper_id:meta.name
             ~base_path:(Keeper_alerting_path.project_root_of_config config)
@@ -335,7 +349,7 @@ let handle_keeper_fs_edit
           | Sys_error e -> error_json ~fields:[ "path", `String target ] e
           | Unix.Unix_error (err, _, _) ->
             error_json ~fields:[ "path", `String target ]
-              (Unix.error_message err)))))
+              (Unix.error_message err))))))
   | Some ((Overwrite | Append) as mode) ->
   let mode_label = fs_write_mode_to_string mode in
   if String.trim content = "" then
@@ -346,6 +360,9 @@ let handle_keeper_fs_edit
   | Ok target ->
     (match validate_write_target ~config ~meta ~target with
      | Error json -> json
+     | Ok () ->
+    (match check_invariant_sandbox_isolation ~turn_sandbox_factory ~target with
+     | Error msg -> error_json ~fields:[ "path", `String target ] msg
      | Ok () ->
     (match Keeper_repo_mapping.validate_path_access ~keeper_id:meta.name
        ~base_path:(Keeper_alerting_path.project_root_of_config config)
@@ -402,5 +419,4 @@ let handle_keeper_fs_edit
     | Invalid_argument e -> error_json ~fields:[ "path", `String target ] e
      | Sys_error e -> error_json ~fields:[ "path", `String target ] e
      | Unix.Unix_error (err, _, _) ->
-       error_json ~fields:[ "path", `String target ] (Unix.error_message err))))
-;;
+       error_json ~fields:[ "path", `String target ] (Unix.error_message err)))))

--- a/lib/keeper/keeper_invariant.ml
+++ b/lib/keeper/keeper_invariant.ml
@@ -1,4 +1,4 @@
-open Base
+module StringSet = Set.Make(String)
 
 type turn_id = string
 
@@ -8,56 +8,68 @@ type credential_scope = {
   keeper_id : string;
   github_account : string;
 }
-[@@deriving sexp, equal]
+[@@deriving eq]
 
 type tool_name = string
 
-let sandbox_isolation ~turn ~sandbox_paths =
-  let expected_prefixes =
-    [ "/tmp/masc_sandbox_" ^ turn ^ "/"; "/var/lib/masc/sandbox/" ^ turn ^ "/" ]
+let normalize_path path =
+  let rec collapse acc = function
+    | [] -> List.rev acc
+    | ".." :: rest when acc <> [] -> collapse (List.tl acc) rest
+    | "." :: rest -> collapse acc rest
+    | "" :: rest -> collapse acc rest
+    | segment :: rest -> collapse (segment :: acc) rest
   in
-  List.find sandbox_paths ~f:(fun path ->
-    let norm = Filename.normalize path in
-    not
-      (List.exists expected_prefixes ~f:(fun prefix ->
-         String.is_prefix norm ~prefix)))
-  |> Option.map ~f:(fun violating_path ->
-       Result.Error
-         (Printf.sprintf
-            "Sandbox isolation violation: path %s is outside turn %s sandbox"
-            violating_path turn))
-  |> Option.value ~default:(Result.Ok ())
+  let parts = String.split_on_char '/' path in
+  "/" ^ String.concat "/" (collapse [] parts)
+
+let sandbox_isolation ~sandbox_roots ~sandbox_paths =
+  if sandbox_roots = [] then
+    Error "Sandbox isolation: no sandbox roots configured"
+  else
+    match List.find_opt (fun path ->
+      let norm = normalize_path path in
+      not (List.exists (fun root ->
+        let root_norm = normalize_path root in
+        String.starts_with ~prefix:(root_norm ^ "/") norm) sandbox_roots)
+    ) sandbox_paths with
+    | Some violating_path ->
+      Error (Printf.sprintf
+        "Sandbox isolation violation: path %s is outside all configured sandbox roots"
+        violating_path)
+    | None -> Ok ()
 
 let credential_isolation ~keeper ~credential ~other_keepers =
-  List.find other_keepers ~f:(fun other ->
+  match List.find_opt (fun other ->
     String.equal other.keeper_id keeper
-    && String.equal other.github_account credential.github_account)
-  |> Option.map ~f:(fun conflicting ->
-       Result.Error
-         (Printf.sprintf
-            "Credential isolation violation: keeper %s shares GitHub account %s with \
-             keeper %s"
-            keeper credential.github_account conflicting.keeper_id))
-  |> Option.value ~default:(Result.Ok ())
+    && String.equal other.github_account credential.github_account
+  ) other_keepers with
+  | Some conflicting ->
+    Error (Printf.sprintf
+      "Credential isolation violation: keeper %s shares GitHub account %s with keeper %s"
+      keeper credential.github_account conflicting.keeper_id)
+  | None -> Ok ()
 
 let tool_surface_monotonicity ~before ~after =
-  let before_set = String.Set.of_list before in
-  let after_set = String.Set.of_list after in
-  let diff = Set.diff after_set before_set in
-  if Set.is_empty diff then Result.Ok ()
+  let before_set = StringSet.of_list before in
+  let after_set = StringSet.of_list after in
+  let diff = StringSet.diff after_set before_set in
+  if StringSet.is_empty diff then Ok ()
   else
-    let added = Set.to_list diff in
-    Result.Error
-      (Printf.sprintf
-         "Tool surface monotonicity violation: tools added without explicit \
-          configuration: %s"
-         (String.concat ~sep:", " added))
+    let added = StringSet.elements diff in
+    Error (Printf.sprintf
+      "Tool surface monotonicity violation: tools added without explicit configuration: %s"
+      (String.concat ", " added))
 
-let check_all ~turn ~sandbox_paths ~keeper ~credential ~other_keepers ~before_tools
-  ~after_tools
+let check_all ~sandbox_roots ~sandbox_paths ~keeper ~credential ~other_keepers
+  ~before_tools ~after_tools
   =
-  let ( let* ) = Result.( >>= ) in
-  let* () = sandbox_isolation ~turn ~sandbox_paths in
-  let* () = credential_isolation ~keeper ~credential ~other_keepers in
-  let* () = tool_surface_monotonicity ~before:before_tools ~after:after_tools in
-  Result.Ok ()
+  match sandbox_isolation ~sandbox_roots ~sandbox_paths with
+  | Error _ as e -> e
+  | Ok () ->
+  match credential_isolation ~keeper ~credential ~other_keepers with
+  | Error _ as e -> e
+  | Ok () ->
+  match tool_surface_monotonicity ~before:before_tools ~after:after_tools with
+  | Error _ as e -> e
+  | Ok () -> Ok ()

--- a/lib/keeper/keeper_invariant.mli
+++ b/lib/keeper/keeper_invariant.mli
@@ -6,8 +6,6 @@
     - Tool surface monotonicity: Available tools only shrink when explicitly configured
 *)
 
-open Base
-
 (** Unique identifier for a keeper turn. *)
 type turn_id = string
 
@@ -19,18 +17,18 @@ type credential_scope = {
   keeper_id : string;
   github_account : string;
 }
-[@@deriving sexp, equal]
+[@@deriving eq]
 
 (** Normalised tool identifier. *)
 type tool_name = string
 
 (** {1 Sandbox Isolation} *)
 
-(** [sandbox_isolation ~turn ~sandbox_paths] checks that every path in
-    [sandbox_paths] is strictly prefixed by the sandbox root assigned to
-    [turn].  Violations indicate a potential container escape or mount
-    misconfiguration. *)
-val sandbox_isolation : turn:turn_id -> sandbox_paths:sandbox_path list -> (unit, string) Result.t
+(** [sandbox_isolation ~sandbox_roots ~sandbox_paths] checks that every path in
+    [sandbox_paths] is strictly prefixed by at least one root in [sandbox_roots].
+    Violations indicate a potential container escape or mount misconfiguration. *)
+val sandbox_isolation :
+  sandbox_roots:sandbox_path list -> sandbox_paths:sandbox_path list -> (unit, string) Result.t
 
 (** {1 Credential Isolation} *)
 
@@ -54,7 +52,7 @@ val tool_surface_monotonicity :
 
 (** Run all three invariants and return the first error, if any. *)
 val check_all :
-  turn:turn_id ->
+  sandbox_roots:sandbox_path list ->
   sandbox_paths:sandbox_path list ->
   keeper:string ->
   credential:credential_scope ->

--- a/lib/keeper/keeper_sandbox_factory.ml
+++ b/lib/keeper/keeper_sandbox_factory.ml
@@ -1,6 +1,7 @@
 type t = {
   config : Coord.config;
   meta : Keeper_types.keeper_meta;
+  turn_id : int;
   default_network_override : Keeper_types.network_mode option;
   cache :
     ((bool * string), Keeper_turn_sandbox_runtime.t) Hashtbl.t;
@@ -8,10 +9,11 @@ type t = {
 }
 
 let create ?default_network_override
-    ~(config : Coord.config) ~(meta : Keeper_types.keeper_meta) () =
+    ~(config : Coord.config) ~(meta : Keeper_types.keeper_meta) ?(turn_id = 0) () =
   {
     config;
     meta;
+    turn_id;
     default_network_override;
     cache = Hashtbl.create 4;
     mutex = Eio.Mutex.create ();
@@ -64,6 +66,7 @@ let resolve (t : t) ~cwd =
             ~config:t.config
             ~meta:t.meta
             ~network_mode:actual_network
+            ~turn_id:t.turn_id
             ()
         in
         Hashtbl.add t.cache key r;

--- a/lib/keeper/keeper_sandbox_factory.mli
+++ b/lib/keeper/keeper_sandbox_factory.mli
@@ -28,6 +28,7 @@ val create :
   ?default_network_override:Keeper_types.network_mode ->
   config:Coord.config ->
   meta:Keeper_types.keeper_meta ->
+  ?turn_id:int ->
   unit ->
   t
 (** Create an empty factory.  [default_network_override], when supplied,

--- a/lib/keeper/keeper_turn_sandbox_runtime.ml
+++ b/lib/keeper/keeper_turn_sandbox_runtime.ml
@@ -8,6 +8,7 @@ type t =
   {
     config : Coord.config;
     meta : keeper_meta;
+    turn_id : int;
     host_root : string;
     container_root : string;
     uid : int;
@@ -16,11 +17,14 @@ type t =
     mutable state : state;
   }
 
+let turn_id t = t.turn_id
+let host_root t = t.host_root
+
 let normalize_path path =
   Keeper_alerting_path.normalize_path_for_check_stripped path
 
 let create ~(config : Coord.config) ~(meta : keeper_meta)
-    ?(network_mode = Network_none) () =
+    ?(network_mode = Network_none) ~turn_id () =
   let network_mode =
     if Env_config_keeper.KeeperSandbox.hard_mode () then
       Network_none
@@ -30,6 +34,7 @@ let create ~(config : Coord.config) ~(meta : keeper_meta)
   {
     config;
     meta;
+    turn_id;
     host_root = Keeper_sandbox.host_root_abs_of_meta ~config meta |> normalize_path;
     container_root =
       Keeper_sandbox.container_root meta.name

--- a/lib/keeper/keeper_turn_sandbox_runtime.mli
+++ b/lib/keeper/keeper_turn_sandbox_runtime.mli
@@ -10,8 +10,12 @@ val create :
   config:Coord.config ->
   meta:Keeper_types.keeper_meta ->
   ?network_mode:Keeper_types.network_mode ->
+  turn_id:int ->
   unit ->
   t
+
+val turn_id : t -> int
+val host_root : t -> string
 
 val cleanup : t -> unit
 (** Best-effort teardown. Safe to call multiple times. *)

--- a/test/dune
+++ b/test/dune
@@ -1226,6 +1226,7 @@
 (include stanzas/test_keeper_fs_write_containment.inc)
 (include stanzas/test_keeper_gh_timeout_floor.inc)
 (include stanzas/test_keeper_identity_drift_counter.inc)
+(include stanzas/test_keeper_invariant.inc)
 (include stanzas/test_keeper_long_turn_9943.inc)
 (include stanzas/test_keeper_memory_bank_consensus_re_10399.inc)
 (include stanzas/test_keeper_meta_canonical_seed.inc)

--- a/test/stanzas/test_keeper_invariant.inc
+++ b/test/stanzas/test_keeper_invariant.inc
@@ -1,0 +1,4 @@
+(test
+ (name test_keeper_invariant)
+ (modules test_keeper_invariant)
+ (libraries masc_test_deps))

--- a/test/test_keeper_invariant.ml
+++ b/test/test_keeper_invariant.ml
@@ -1,0 +1,140 @@
+open Alcotest
+
+module Inv = Masc_mcp.Keeper_invariant
+
+let require_ok label = function
+  | Ok () -> ()
+  | Error msg -> failf "%s: %s" label msg
+
+let require_error label = function
+  | Ok () -> failf "%s: expected error but got Ok" label
+  | Error _ -> ()
+
+(* ================================================================ *)
+(* sandbox_isolation tests                                          *)
+(* ================================================================ *)
+
+let test_sandbox_isolation_ok () =
+  let roots = ["/tmp/masc_sandbox_turn_1"] in
+  let paths =
+    ["/tmp/masc_sandbox_turn_1/foo.ml"; "/tmp/masc_sandbox_turn_1/bar/baz.ml"]
+  in
+  require_ok "sandbox ok" (Inv.sandbox_isolation ~sandbox_roots:roots ~sandbox_paths:paths)
+
+let test_sandbox_isolation_violation () =
+  let roots = ["/tmp/masc_sandbox_turn_1"] in
+  let paths = ["/tmp/masc_sandbox_turn_1/foo.ml"; "/etc/passwd"] in
+  require_error "sandbox violation" (Inv.sandbox_isolation ~sandbox_roots:roots ~sandbox_paths:paths)
+
+let test_sandbox_isolation_multi_root () =
+  let roots = ["/tmp/masc_sandbox_turn_1"; "/var/lib/masc/sandbox/turn_2"] in
+  let paths = ["/var/lib/masc/sandbox/turn_2/file.ml"] in
+  require_ok "multi root" (Inv.sandbox_isolation ~sandbox_roots:roots ~sandbox_paths:paths)
+
+let test_sandbox_isolation_empty_roots () =
+  let roots = [] in
+  let paths = ["/tmp/masc_sandbox_turn_1/foo.ml"] in
+  require_error "empty roots" (Inv.sandbox_isolation ~sandbox_roots:roots ~sandbox_paths:paths)
+
+(* ================================================================ *)
+(* credential_isolation tests                                         *)
+(* ================================================================ *)
+
+let test_credential_isolation_ok () =
+  let credential = { Inv.keeper_id = "keeper_a"; github_account = "gh_a" } in
+  let others = [{ Inv.keeper_id = "keeper_b"; github_account = "gh_b" }] in
+  require_ok "credential ok"
+    (Inv.credential_isolation ~keeper:"keeper_a" ~credential ~other_keepers:others)
+
+let test_credential_isolation_violation () =
+  let credential = { Inv.keeper_id = "keeper_a"; github_account = "gh_a" } in
+  let others = [{ Inv.keeper_id = "keeper_a"; github_account = "gh_a" }] in
+  require_error "credential violation"
+    (Inv.credential_isolation ~keeper:"keeper_a" ~credential ~other_keepers:others)
+
+let test_credential_isolation_same_keeper_diff_account () =
+  let credential = { Inv.keeper_id = "keeper_a"; github_account = "gh_a" } in
+  let others = [{ Inv.keeper_id = "keeper_a"; github_account = "gh_b" }] in
+  require_ok "same keeper diff account"
+    (Inv.credential_isolation ~keeper:"keeper_a" ~credential ~other_keepers:others)
+
+(* ================================================================ *)
+(* tool_surface_monotonicity tests                                    *)
+(* ================================================================ *)
+
+let test_tool_monotonicity_ok () =
+  let before = ["tool_a"; "tool_b"; "tool_c"] in
+  let after = ["tool_a"; "tool_b"] in
+  require_ok "tool ok" (Inv.tool_surface_monotonicity ~before ~after)
+
+let test_tool_monotonicity_equal () =
+  let before = ["tool_a"; "tool_b"] in
+  let after = ["tool_b"; "tool_a"] in
+  require_ok "tool equal" (Inv.tool_surface_monotonicity ~before ~after)
+
+let test_tool_monotonicity_violation () =
+  let before = ["tool_a"; "tool_b"] in
+  let after = ["tool_a"; "tool_b"; "tool_c"] in
+  require_error "tool violation" (Inv.tool_surface_monotonicity ~before ~after)
+
+(* ================================================================ *)
+(* check_all tests                                                    *)
+(* ================================================================ *)
+
+let test_check_all_ok () =
+  let roots = ["/tmp/masc_sandbox_turn_1"] in
+  let paths = ["/tmp/masc_sandbox_turn_1/foo.ml"] in
+  let credential = { Inv.keeper_id = "keeper_a"; github_account = "gh_a" } in
+  let others = [{ Inv.keeper_id = "keeper_b"; github_account = "gh_b" }] in
+  let before_tools = ["tool_a"] in
+  let after_tools = ["tool_a"] in
+  require_ok "check_all ok"
+    (Inv.check_all ~sandbox_roots:roots ~sandbox_paths:paths ~keeper:"keeper_a"
+       ~credential ~other_keepers:others ~before_tools ~after_tools)
+
+let test_check_all_first_error () =
+  let roots = ["/tmp/masc_sandbox_turn_1"] in
+  let paths = ["/etc/passwd"] in
+  let credential = { Inv.keeper_id = "keeper_a"; github_account = "gh_a" } in
+  let others = [] in
+  let before_tools = ["tool_a"] in
+  let after_tools = ["tool_a"] in
+  let result =
+    Inv.check_all ~sandbox_roots:roots ~sandbox_paths:paths ~keeper:"keeper_a"
+      ~credential ~other_keepers:others ~before_tools ~after_tools
+  in
+  match result with
+  | Ok () -> failf "check_all first error: expected sandbox error"
+  | Error msg ->
+    if String.starts_with ~prefix:"Sandbox isolation" msg then ()
+    else failf "check_all first error: expected sandbox error, got: %s" msg
+
+let () =
+  run "Keeper Invariant"
+    [
+      ( "sandbox_isolation",
+        [
+          test_case "ok" `Quick test_sandbox_isolation_ok;
+          test_case "violation" `Quick test_sandbox_isolation_violation;
+          test_case "multi_root" `Quick test_sandbox_isolation_multi_root;
+          test_case "empty_roots" `Quick test_sandbox_isolation_empty_roots;
+        ] );
+      ( "credential_isolation",
+        [
+          test_case "ok" `Quick test_credential_isolation_ok;
+          test_case "violation" `Quick test_credential_isolation_violation;
+          test_case "same_keeper_diff_account" `Quick
+            test_credential_isolation_same_keeper_diff_account;
+        ] );
+      ( "tool_surface_monotonicity",
+        [
+          test_case "ok" `Quick test_tool_monotonicity_ok;
+          test_case "equal" `Quick test_tool_monotonicity_equal;
+          test_case "violation" `Quick test_tool_monotonicity_violation;
+        ] );
+      ( "check_all",
+        [
+          test_case "ok" `Quick test_check_all_ok;
+          test_case "first_error" `Quick test_check_all_first_error;
+        ] );
+    ]


### PR DESCRIPTION
## Summary\nPhase 2 follow-up: add tests for keeper_invariant, wire sandbox isolation into fs edit, and add turn_id to sandbox runtime.\n\n## Changes\n- `lib/keeper/keeper_invariant.ml` / `.mli`: rewrite with stdlib only (remove Base dep); accept `sandbox_roots` list\n- `lib/keeper/keeper_turn_sandbox_runtime.ml` / `.mli`: add `turn_id` field + accessors\n- `lib/keeper/keeper_sandbox_factory.ml` / `.mli`: optional `turn_id` argument\n- `lib/keeper/keeper_exec_fs.ml`: add `check_invariant_sandbox_isolation` guard before writes\n- `test/test_keeper_invariant.ml`: 12 alcotest tests covering sandbox/credential/tool monotonicity\n- `test/stanzas/test_keeper_invariant.inc` + `test/dune`: test stanza\n\n## Verification\n- Local dune build passes (`test/test_keeper_invariant.exe`)\n- All 12 tests pass\n\n## Related\n- Phase 2 of PLAN.md (feat/keeper-invariant-framework #14527)