### PR TITLE
fix(keeper): replace Eio_unix.sleep with Eio.Time.sleep in health probe

### DIFF
--- a/lib/keeper/keeper_health_probe.ml
+++ b/lib/keeper/keeper_health_probe.ml
@@ -159,19 +159,19 @@ let run_once ~base_path =
     results
 ;;
 
-let rec probe_loop ~base_path ~interval_sec () =
+let rec probe_loop ~base_path ~interval_sec ~clock () =
   (* Cancel-aware: Safe_ops.protect re-raises Eio.Cancel.Cancelled and swallows
      other exceptions so a transient registry I/O failure cannot kill the fiber
      and freeze [is_healthy] at [false] forever. *)
   Safe_ops.protect ~default:() (fun () -> run_once ~base_path);
-  Eio_unix.sleep interval_sec;
-  probe_loop ~base_path ~interval_sec ()
+  Eio.Time.sleep clock interval_sec;
+  probe_loop ~base_path ~interval_sec ~clock ()
 ;;
 
-let start_probe ~sw ~base_path ~interval_sec =
+let start_probe ~sw ~base_path ~interval_sec ~clock =
   if interval_sec <= 0.0
   then ()
   else
     Eio.Fiber.fork ~sw (fun () ->
-      Eio.Switch.run (fun _sw -> probe_loop ~base_path ~interval_sec ()))
+      Eio.Switch.run (fun _sw -> probe_loop ~base_path ~interval_sec ~clock ()))
 ;;

--- a/lib/keeper/keeper_health_probe.mli
+++ b/lib/keeper/keeper_health_probe.mli
@@ -82,10 +82,11 @@ val run_once : base_path:string -> unit
 
 (** {1 Background probe fiber} *)
 
-(** [start_probe ~sw ~base_path ~interval_sec] spawns a background Eio
+(** [start_probe ~sw ~base_path ~interval_sec ~clock] spawns a background Eio
     fiber that runs [check_cascade_health] every [interval_sec] seconds
     and updates the internal cache.  The fiber exits when [sw] is
     cancelled.  Currently unused — the supervisor calls [run_once]
-    inline.  Retained for future use when a faster cadence than the
-    30 s sweep is needed. *)
-val start_probe : sw:Eio.Switch.t -> base_path:string -> interval_sec:float -> unit
+    inline.  [clock] must be an Eio time clock (typically from the
+    fiber's environment).  Retained for future use when a faster cadence
+    than the 30 s sweep is needed. *)
+val start_probe : sw:Eio.Switch.t -> base_path:string -> interval_sec:float -> clock:float Eio.Time.clock_ty Eio.Resource.t -> unit


### PR DESCRIPTION
## Summary

Fix CI Lint/Eio convention gate failure: `Eio_unix.sleep` in `lib/keeper/keeper_health_probe.ml:167` is forbidden by `scripts/check-eio-conventions.sh`.

### Changes

- Add `~clock` param to `probe_loop` and `start_probe`
- Replace `Eio_unix.sleep interval_sec` with `Eio.Time.sleep clock interval_sec` (cooperative, scheduler-aware)
- Update `.mli` signature and docstring

### Notes

- `start_probe` is currently unused (supervisor calls `run_once` inline). No live callers affected by the signature change.
- Eio convention check: `lib/Eio_unix.sleep: 0` (was 1)