### PR TITLE
test(keeper_invariant): regression guards for sibling-prefix + path-traversal, drop unused deriver

### DIFF
--- a/lib/keeper/keeper_invariant.ml
+++ b/lib/keeper/keeper_invariant.ml
@@ -8,7 +8,6 @@ type credential_scope = {
   keeper_id : string;
   github_account : string;
 }
-[@@deriving eq]
 
 type tool_name = string
 

--- a/lib/keeper/keeper_invariant.mli
+++ b/lib/keeper/keeper_invariant.mli
@@ -17,7 +17,6 @@ type credential_scope = {
   keeper_id : string;
   github_account : string;
 }
-[@@deriving eq]
 
 (** Normalised tool identifier. *)
 type tool_name = string

--- a/test/test_keeper_invariant.ml
+++ b/test/test_keeper_invariant.ml
@@ -92,6 +92,27 @@ let test_check_all_ok () =
     (Inv.check_all ~sandbox_roots:roots ~sandbox_paths:paths ~keeper:"keeper_a"
        ~credential ~other_keepers:others ~before_tools ~after_tools)
 
+(* Sibling-prefix safety: /srv/.../alice-evil/ must NOT satisfy root
+   /srv/.../alice/. This is what the trailing-slash trick on the root
+   protects against. Without it, a hostile sibling directory whose name
+   shares a literal prefix with a legitimate keeper's root would slip
+   through the prefix check. *)
+let test_sandbox_isolation_sibling_prefix_rejected () =
+  let roots = ["/srv/masc/keepers/alice"] in
+  let paths = ["/srv/masc/keepers/alice-evil/leak.txt"] in
+  require_error "sibling prefix rejected"
+    (Inv.sandbox_isolation ~sandbox_roots:roots ~sandbox_paths:paths)
+
+(* Path-traversal safety: `..` segments are collapsed before the prefix
+   check, so /srv/.../alice/../../etc/passwd cannot escape its root.
+   This guards [normalize_path] from being quietly removed in a future
+   refactor. *)
+let test_sandbox_isolation_path_traversal_rejected () =
+  let roots = ["/srv/masc/keepers/alice"] in
+  let paths = ["/srv/masc/keepers/alice/../../etc/passwd"] in
+  require_error "path traversal rejected"
+    (Inv.sandbox_isolation ~sandbox_roots:roots ~sandbox_paths:paths)
+
 let test_check_all_first_error () =
   let roots = ["/tmp/masc_sandbox_turn_1"] in
   let paths = ["/etc/passwd"] in
@@ -118,6 +139,10 @@ let () =
           test_case "violation" `Quick test_sandbox_isolation_violation;
           test_case "multi_root" `Quick test_sandbox_isolation_multi_root;
           test_case "empty_roots" `Quick test_sandbox_isolation_empty_roots;
+          test_case "sibling_prefix_rejected" `Quick
+            test_sandbox_isolation_sibling_prefix_rejected;
+          test_case "path_traversal_rejected" `Quick
+            test_sandbox_isolation_path_traversal_rejected;
         ] );
       ( "credential_isolation",
         [


### PR DESCRIPTION
Follow-up to #14532 (merged 2026-05-10 23:18 UTC). Captures the two
items from the parallel-exploration review comment that did not make
the 4-minute Draft → Merge window:
https://github.com/jeong-sik/masc-mcp/pull/14532#issuecomment-4416617507

## Summary

* **`lib/keeper/keeper_invariant.{ml,mli}`** — drop `[@@deriving eq]`.
  `equal_credential_scope` has zero callers across `lib/` and `test/`
  post-merge (verified: `rg "equal_credential_scope" lib/ test/` → 0
  hits). The annotation generates dead code. Per CLAUDE.md
  software-development.md §"Don't add features beyond what task
  requires", removing it now is cleaner than keeping it as scaffolding
  for a hypothetical future caller.

* **`test/test_keeper_invariant.ml`** — two regression guards for
  safety properties already implemented but not yet pinned by tests:
  - `sandbox_isolation_sibling_prefix_rejected`:
    `/srv/.../alice-evil/` must NOT satisfy root `/srv/.../alice/`.
    Guarded by `root_norm ^ "/"`. Catches future removal of the
    trailing-slash trick.
  - `sandbox_isolation_path_traversal_rejected`:
    `/srv/.../alice/../../etc/passwd` must not satisfy root
    `/srv/.../alice/`. Guarded by `normalize_path` collapsing `..`.
    Catches future bypass / removal of `normalize_path`.

  A third proposed test (`check_all` short-circuit ordering) turned
  out to be already covered by `test_check_all_first_error` in #14532,
  so dropped.

Net diff: **+25 / −2 across 3 files**. All in keeper_invariant scope.

## Related RFCs

- RFC-0006 (keeper surface and sandbox)
- RFC-0019 (keeper credential unification)
- RFC-0052 (boot-time required invariants)

## Test plan

- [x] `dune build lib/` PASS
- [x] `dune exec test/test_keeper_invariant.exe` — 14/14 PASS,
      including the two new cases
- [x] `rg "equal_credential_scope" lib/ test/` — still 0 hits

## CI note (unrelated pre-existing main blocker)

`dune build` on origin/main currently fails on
`test/test_response_model_empty_10083.ml` with
`Some record fields are undefined: ttfrc_ms prefill_ms`. This is an
`agent_sdk` (telemetry-design pin) gap unrelated to this PR — the
record literal in that test wasn't updated when those fields were
added to `Agent_sdk.Types.api_response`. The keeper_invariant test
target itself builds and passes; main-level CI may show this
unrelated failure until that record literal is repaired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)