### PR TITLE
fix(test): add ttfrc_ms/prefill_ms to inference_telemetry literals (unblock main)

### DIFF
--- a/test/test_cost_ledger_pricing_model_10318.ml
+++ b/test/test_cost_ledger_pricing_model_10318.ml
@@ -40,6 +40,8 @@ let make_telemetry ?canonical_model_id () : Agent_sdk.Types.inference_telemetry 
   ; canonical_model_id
   ; effective_context_window   = None
   ; provider_internal_action_count = None
+  ; ttfrc_ms                   = None
+  ; prefill_ms                 = None
   }
 
 (* ------------------------------------------------------------------ *)

--- a/test/test_dashboard_oas_bridge.ml
+++ b/test/test_dashboard_oas_bridge.ml
@@ -67,6 +67,8 @@ let make_telemetry ?timings ?(request_latency_ms = 0) ()
     canonical_model_id = None;
     effective_context_window = None;
     provider_internal_action_count = None;
+    ttfrc_ms = None;
+    prefill_ms = None;
   }
 
 let make_response ?usage ?telemetry ?(model = "claude-opus-4-7") ()

--- a/test/test_keeper_hooks_oas_telemetry.ml
+++ b/test/test_keeper_hooks_oas_telemetry.ml
@@ -106,6 +106,8 @@ let test_emit_cost_event_writes_inference_telemetry () =
     canonical_model_id = Some "gpt-4";
     effective_context_window = Some 128000;
     provider_internal_action_count = None;
+    ttfrc_ms = None;
+    prefill_ms = None;
   } in
   Hooks.emit_cost_event ~masc_root:root ~agent_name:"keeper"
     ~task_id:(Some "task-1") ~model:"glm-coding:glm-5.1"
@@ -152,6 +154,8 @@ let test_emit_cost_event_uses_typed_provider_kind_for_bare_model () =
       canonical_model_id = None;
       effective_context_window = None;
       provider_internal_action_count = None;
+      ttfrc_ms = None;
+      prefill_ms = None;
     }
   in
   Hooks.emit_cost_event ~masc_root:root ~agent_name:"keeper"
@@ -178,6 +182,8 @@ let test_emit_cost_event_writes_wall_tok_s_without_provider_timings () =
     canonical_model_id = Some "auto";
     effective_context_window = Some 128000;
     provider_internal_action_count = None;
+    ttfrc_ms = None;
+    prefill_ms = None;
   } in
   Hooks.emit_cost_event ~masc_root:root ~agent_name:"keeper"
     ~task_id:None ~model:"ollama:qwen3.6:27b-coding-nvfp4"
@@ -208,6 +214,8 @@ let test_emit_cost_event_marks_untrusted_usage () =
       canonical_model_id = Some "ollama:qwen3.6:27b-coding-nvfp4";
       effective_context_window = Some 128000;
       provider_internal_action_count = None;
+      ttfrc_ms = None;
+      prefill_ms = None;
     }
   in
   Hooks.emit_cost_event ~masc_root:root ~agent_name:"keeper"
@@ -256,6 +264,8 @@ let test_emit_cost_event_marks_unpriced_paid_model () =
       canonical_model_id = Some "future-openai-model-v9";
       effective_context_window = Some 128000;
       provider_internal_action_count = None;
+      ttfrc_ms = None;
+      prefill_ms = None;
     }
   in
   Hooks.emit_cost_event ~masc_root:root ~agent_name:"keeper"
@@ -288,6 +298,8 @@ let test_emit_cost_event_records_auto_resolution_source () =
       canonical_model_id = Some "gpt-4.1";
       effective_context_window = Some 128000;
       provider_internal_action_count = None;
+      ttfrc_ms = None;
+      prefill_ms = None;
     }
   in
   Hooks.emit_cost_event ~masc_root:root ~agent_name:"keeper"
@@ -320,6 +332,8 @@ let test_emit_cost_event_records_provider_prefixed_auto_resolution_source () =
       canonical_model_id = Some "kimi-for-coding";
       effective_context_window = Some 128000;
       provider_internal_action_count = None;
+      ttfrc_ms = None;
+      prefill_ms = None;
     }
   in
   Hooks.emit_cost_event ~masc_root:root ~agent_name:"keeper"
@@ -464,6 +478,8 @@ let make_telemetry
     canonical_model_id = None;
     effective_context_window = None;
     provider_internal_action_count = None;
+    ttfrc_ms = None;
+    prefill_ms = None;
   }
 
 let make_response ?(stop_reason = Agent_sdk.Types.EndTurn) ?telemetry () =

--- a/test/test_response_model_empty_10083.ml
+++ b/test/test_response_model_empty_10083.ml
@@ -69,6 +69,8 @@ let make_telemetry ?canonical_model_id () : Agent_sdk.Types.inference_telemetry 
     canonical_model_id;
     effective_context_window = None;
     provider_internal_action_count = None;
+    ttfrc_ms = None;
+    prefill_ms = None;
   }
 
 (* Raw model is non-empty — resolver must return it verbatim and


### PR DESCRIPTION
## Summary

Unblocks `dune build` on origin/main, which has been failing with:

```
Error: Some record fields are undefined: ttfrc_ms prefill_ms
```

The installed `agent_sdk` opam pin (telemetry-design branch, 0.193.1) extended `Llm_provider.Types.inference_telemetry` with two new optional fields (`ttfrc_ms : float option`, `prefill_ms : float option`); four masc-mcp test files that construct the record literal directly were not updated to match.

## Changes

Each affected file gets `ttfrc_ms = None; prefill_ms = None` appended to its `inference_telemetry` record literal:

| File | Literals patched |
|------|-----------------|
| `test/test_response_model_empty_10083.ml` | 1 |
| `test/test_dashboard_oas_bridge.ml` | 1 |
| `test/test_cost_ledger_pricing_model_10318.ml` | 1 |
| `test/test_keeper_hooks_oas_telemetry.ml` | 8 |

Net diff: **+22 / 0 across 4 files**, all in `test/`.

The values are `None` because the tests don't depend on TTFRC or prefill-latency timing — they exercise telemetry resolution, cost-ledger pricing, and dashboard bridge behaviour where these fields have no semantic role.

## Caveat (worth flagging, not blocking)

The `agent_sdk` worktree source at `~/me/workspace/yousleepwhen/oas/.worktrees/telemetry-design` is *one snapshot behind* what's currently installed in opam:

| | `inference_telemetry` has `ttfrc_ms`/`prefill_ms`? |
|--|--|
| Worktree HEAD `764c6f52` source | ❌ no |
| `~/.opam/5.4.1/lib/agent_sdk/llm_provider/types.ml` (installed) | ✅ yes |

Same `source-hash`, different content — the installed copy was rebuilt from a later snapshot than the worktree HEAD. This is an OAS-side pin/build-cache question and out of scope for this PR; this PR only restores `dune build` parity with the installed binary.

## Test plan

- [x] `dune build` (full lib + tests) PASS
- [x] `dune build test/test_response_model_empty_10083.exe test/test_keeper_hooks_oas_telemetry.exe test/test_dashboard_oas_bridge.exe test/test_cost_ledger_pricing_model_10318.exe` PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)