### PR TITLE
chore: regenerate OCaml structure baseline for new modules

### DIFF
--- a/scripts/ocaml-structure-baseline.json
+++ b/scripts/ocaml-structure-baseline.json
@@ -1,10 +1,10 @@
 {
   "_comment": "OCaml structural-debt baseline. Regenerate with scripts/ocaml-structure-ratchet.sh --regenerate.",
   "_metrics": "See scripts/ocaml-structure-ratchet.sh METRICS array.",
-  "keeper_mli_missing": 1,
+  "keeper_mli_missing": 2,
   "coord_mli_missing": 0,
   "godsplit_count": 0,
-  "lib_dune_lines": 1000,
+  "lib_dune_lines": 360,
   "inferred_dump_headers": 0,
-  "lib_other_mli_missing": 1
+  "lib_other_mli_missing": 4
 }


### PR DESCRIPTION
## Summary

Regenerate the OCaml structure ratchet baseline to reflect new modules added by recent PRs.

### Changes

- `keeper_mli_missing`: 1 → 2 (new keeper modules without .mli)
- `lib_other_mli_missing`: 1 → 4 (ide_annotation_types, types_core, cascade_tier, etc.)
- `lib_dune_lines`: 1000 → 360 (lowered to actual count)

### Context

The ratchet started failing on main because recent PRs added new .ml modules without corresponding .mli files. Per the ratchet script guidance: "if intentional, run scripts/ocaml-structure-ratchet.sh --regenerate and pair the regenerate commit with a follow-up issue."

Follow-up: consider adding .mli stubs for the new modules to reduce structural debt.