### PR TITLE
feat(ide): presence strip file focus, PR status, click-to-navigate

### DIFF
--- a/dashboard/src/components/ide/ide-presence-strip.test.ts
+++ b/dashboard/src/components/ide/ide-presence-strip.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import {
   parseWorktreeSSE,
+  prLabel,
   workspaceLabelForAgent,
   type WorktreeEntry,
 } from './ide-presence-strip'
@@ -88,5 +89,29 @@ describe('parseWorktreeSSE', () => {
     // Verify that the parsed entries carry enough information to derive workspace labels
     const label = workspaceLabelForAgent('nick0cave', entries)
     expect(label).toBe('wt-run-47')
+  })
+})
+
+describe('prLabel', () => {
+  it('formats open PR with no decoration', () => {
+    expect(prLabel(123, 'open')).toBe('#123')
+  })
+
+  it('formats closed PR with ✕ suffix', () => {
+    expect(prLabel(456, 'closed')).toBe('#456✕')
+  })
+
+  it('formats merged PR with ✓ suffix', () => {
+    expect(prLabel(789, 'merged')).toBe('#789✓')
+  })
+
+  it('falls back to plain "#N" for unknown state strings', () => {
+    expect(prLabel(42, 'draft')).toBe('#42')
+    expect(prLabel(42, 'unknown')).toBe('#42')
+    expect(prLabel(42, '')).toBe('#42')
+  })
+
+  it('falls back to plain "#N" when state is null', () => {
+    expect(prLabel(7, null)).toBe('#7')
   })
 })

--- a/dashboard/src/components/ide/ide-presence-strip.ts
+++ b/dashboard/src/components/ide/ide-presence-strip.ts
@@ -191,9 +191,15 @@ export function IdePresenceStrip() {
     return unsub
   }, [presenceStore])
 
-  useEffect(() => presenceStore.subscribe(() => forceRender(tick => tick + 1)), [presenceStore])
+  useEffect(() => {
+    const unsub = presenceStore.subscribe(() => forceRender(tick => tick + 1))
+    return unsub
+  }, [presenceStore])
 
-  useEffect(() => cursorOverlaySignal.subscribe(() => forceRender(tick => tick + 1)), [])
+  useEffect(() => {
+    const unsub = cursorOverlaySignal.subscribe(() => forceRender(tick => tick + 1))
+    return unsub
+  }, [])
 
   const current = presenceStore.snapshot()
   const entries = presenceStore.entries()
@@ -252,18 +258,23 @@ function PresenceChip({ entry, worktrees }: PresenceChipProps) {
     ? prLabel(wt.pr_number, wt.pr_state)
     : null
 
+  const canNavigate = cursor?.file_path != null
   const navigate = (): void => {
     if (cursor?.file_path) activeIdeFile.value = cursor.file_path
   }
+  const onKeyDown = canNavigate
+    ? (e: KeyboardEvent) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); navigate() } }
+    : undefined
 
   return html`
     <li
       title=${`${entry.keeper_id} · ${entry.role} · ${focusLabel ?? 'no file focus'}${prBadge ? ` · ${prBadge}` : ''}`}
       aria-label=${`${entry.keeper_id} ${entry.status} in ${entry.workspace_label}${focusLabel ? ` editing ${focusLabel}` : ''}`}
-      role="button"
-      tabIndex=${cursor?.file_path ? 0 : undefined}
-      onClick=${navigate}
-      onKeyDown=${(e: KeyboardEvent) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); navigate() } }}
+      role=${canNavigate ? 'button' : undefined}
+      aria-disabled=${canNavigate ? undefined : 'true'}
+      tabIndex=${canNavigate ? 0 : undefined}
+      onClick=${canNavigate ? navigate : undefined}
+      onKeyDown=${onKeyDown}
       style=${{
         display: 'inline-flex',
         alignItems: 'center',
@@ -311,7 +322,7 @@ function PresenceChip({ entry, worktrees }: PresenceChipProps) {
   `
 }
 
-function prLabel(prNumber: number, prState: string | null): string {
+export function prLabel(prNumber: number, prState: string | null): string {
   if (prState === 'open') return `#${prNumber}`
   if (prState === 'closed') return `#${prNumber}✕`
   if (prState === 'merged') return `#${prNumber}✓`

--- a/dashboard/src/components/ide/ide-presence-strip.ts
+++ b/dashboard/src/components/ide/ide-presence-strip.ts
@@ -7,6 +7,8 @@ import {
   type KeeperPresenceEntry,
   type KeeperPresenceSnapshot,
 } from './keeper-presence-store'
+import { cursorOverlaySignal } from './keeper-cursor-overlay'
+import { activeIdeFile } from './ide-shell'
 
 const FALLBACK_PRESENCE: KeeperPresenceSnapshot = {
   runtime_id: 'local',
@@ -136,31 +138,48 @@ async function fetchWorktreeEntries(): Promise<WorktreeEntry[]> {
   }
 }
 
-async function fetchPresence(): Promise<KeeperPresenceSnapshot> {
+interface PresenceData {
+  readonly snapshot: KeeperPresenceSnapshot
+  readonly worktrees: ReadonlyArray<WorktreeEntry>
+}
+
+const FALLBACK_DATA: PresenceData = {
+  snapshot: FALLBACK_PRESENCE,
+  worktrees: [],
+}
+
+async function fetchPresence(): Promise<PresenceData> {
   try {
     const [agentsRes, statusRes, worktrees] = await Promise.all([
       fetch('/api/v1/agents?limit=20'),
       fetch('/api/v1/status'),
       fetchWorktreeEntries(),
     ])
-    if (!agentsRes.ok || !statusRes.ok) return FALLBACK_PRESENCE
+    if (!agentsRes.ok || !statusRes.ok) return { snapshot: FALLBACK_PRESENCE, worktrees }
     const agentsData = await agentsRes.json()
     const statusData = await statusRes.json()
     const agents: ApiAgent[] = Array.isArray(agentsData.agents) ? agentsData.agents : []
-    if (agents.length === 0) return FALLBACK_PRESENCE
-    return agentsToPresence(agents, statusData as ApiStatus, worktrees)
+    if (agents.length === 0) return { snapshot: FALLBACK_PRESENCE, worktrees }
+    const snapshot = agentsToPresence(agents, statusData as ApiStatus, worktrees)
+    return { snapshot, worktrees }
   } catch {
-    return FALLBACK_PRESENCE
+    return FALLBACK_DATA
   }
 }
 
 export function IdePresenceStrip() {
   const presenceStore = useMemo(() => createKeeperPresenceStore(FALLBACK_PRESENCE), [])
   const [, forceRender] = useState(0)
+  const [worktrees, setWorktrees] = useState<ReadonlyArray<WorktreeEntry>>([])
 
   useEffect(() => {
     let cancelled = false
-    fetchPresence().then(snapshot => { if (!cancelled) presenceStore.seed(snapshot) })
+    fetchPresence().then(data => {
+      if (!cancelled) {
+        presenceStore.seed(data.snapshot)
+        setWorktrees(data.worktrees)
+      }
+    })
     return () => { cancelled = true }
   }, [presenceStore])
 
@@ -173,6 +192,8 @@ export function IdePresenceStrip() {
   }, [presenceStore])
 
   useEffect(() => presenceStore.subscribe(() => forceRender(tick => tick + 1)), [presenceStore])
+
+  useEffect(() => cursorOverlaySignal.subscribe(() => forceRender(tick => tick + 1)), [])
 
   const current = presenceStore.snapshot()
   const entries = presenceStore.entries()
@@ -207,31 +228,77 @@ export function IdePresenceStrip() {
           overflow: 'hidden',
         }}
       >
-        ${entries.map(entry => html`<${PresenceChip} entry=${entry} />`)}
+        ${entries.map(entry => html`<${PresenceChip} entry=${entry} worktrees=${worktrees} />`)}
       </ul>
     </div>
   `
 }
 
-function PresenceChip({ entry }: { readonly entry: KeeperPresenceEntry }) {
+interface PresenceChipProps {
+  readonly entry: KeeperPresenceEntry
+  readonly worktrees: ReadonlyArray<WorktreeEntry>
+}
+
+function PresenceChip({ entry, worktrees }: PresenceChipProps) {
   const isActive = entry.status === 'active'
+  const cursor = cursorOverlaySignal.value.cursors.get(entry.keeper_id)
+  const wt = worktrees.find(w => w.branch.startsWith(entry.keeper_id + '/'))
+
+  const focusLabel = cursor?.file_path
+    ? `${cursor.file_path.split('/').pop()}:${cursor.line}`
+    : null
+
+  const prBadge = wt?.pr_number != null && wt.pr_state != null
+    ? prLabel(wt.pr_number, wt.pr_state)
+    : null
+
+  const navigate = (): void => {
+    if (cursor?.file_path) activeIdeFile.value = cursor.file_path
+  }
+
   return html`
     <li
-      title=${`${entry.keeper_id} · ${entry.role} · ${entry.branch}`}
-      aria-label=${`${entry.keeper_id} ${entry.status} in ${entry.workspace_label}`}
+      title=${`${entry.keeper_id} · ${entry.role} · ${focusLabel ?? 'no file focus'}${prBadge ? ` · ${prBadge}` : ''}`}
+      aria-label=${`${entry.keeper_id} ${entry.status} in ${entry.workspace_label}${focusLabel ? ` editing ${focusLabel}` : ''}`}
+      role="button"
+      tabIndex=${cursor?.file_path ? 0 : undefined}
+      onClick=${navigate}
+      onKeyDown=${(e: KeyboardEvent) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); navigate() } }}
       style=${{
         display: 'inline-flex',
         alignItems: 'center',
         gap: 'var(--sp-1)',
-        maxWidth: '180px',
+        maxWidth: '260px',
         color: 'var(--color-fg-secondary)',
         whiteSpace: 'nowrap',
+        cursor: cursor?.file_path ? 'pointer' : 'default',
+        borderRadius: 'var(--r-1)',
+        padding: '0 var(--sp-1)',
+        transition: 'background 0.15s',
       }}
     >
       <${KeeperBadge} id=${entry.keeper_id} variant="sigil" size="sm" beat=${isActive} />
       <span style=${{ overflow: 'hidden', textOverflow: 'ellipsis' }}>
         ${entry.keeper_id}@${entry.workspace_label}
       </span>
+      ${focusLabel ? html`
+        <span style=${{
+          color: 'var(--color-accent-fg)',
+          fontSize: 'var(--fs-10)',
+          maxWidth: '90px',
+          overflow: 'hidden',
+          textOverflow: 'ellipsis',
+        }}>${focusLabel}</span>
+      ` : null}
+      ${prBadge ? html`
+        <span style=${{
+          fontSize: 'var(--fs-9)',
+          padding: '0 3px',
+          borderRadius: 'var(--r-0)',
+          background: wt?.pr_state === 'open' ? 'var(--color-status-ok)' : 'var(--color-bg-muted)',
+          color: wt?.pr_state === 'open' ? '#fff' : 'var(--color-fg-muted)',
+        }}>${prBadge}</span>
+      ` : null}
       <span
         style=${{
           color: isActive ? 'var(--color-status-ok)' : 'var(--color-fg-muted)',
@@ -242,4 +309,11 @@ function PresenceChip({ entry }: { readonly entry: KeeperPresenceEntry }) {
       </span>
     </li>
   `
+}
+
+function prLabel(prNumber: number, prState: string | null): string {
+  if (prState === 'open') return `#${prNumber}`
+  if (prState === 'closed') return `#${prNumber}✕`
+  if (prState === 'merged') return `#${prNumber}✓`
+  return `#${prNumber}`
 }


### PR DESCRIPTION
## Summary
- PresenceChip reads `cursorOverlaySignal` to show the file and line each keeper is editing (e.g. `file.ts:42`)
- Worktree PR status displayed as a badge (`#123` open / closed / merged)
- Clicking a chip with an active file focus navigates the IDE editor to that file via `activeIdeFile` signal
- `fetchPresence()` refactored to return `{ snapshot, worktrees }` so PR data is available in the strip

## Test plan
- [ ] Open IDE dashboard with keepers active
- [ ] Verify each chip shows `keeper@workspace` + file:line when cursor overlay has data
- [ ] Verify PR badge appears for keepers with open PRs
- [ ] Click a chip with file focus → editor navigates to that file
- [ ] Click a chip without file focus → no-op (no cursor)

🤖 Generated with [Claude Code](https://claude.com/claude-code)