### PR TITLE
feat(ide): BDI inspector file focus label

### DIFF
--- a/dashboard/src/components/ide/ide-shell.ts
+++ b/dashboard/src/components/ide/ide-shell.ts
@@ -1,6 +1,6 @@
 import { html } from 'htm/preact'
-import { signal } from '@preact/signals'
 import { useEffect, useMemo, useState } from 'preact/hooks'
+import { activeIdeFile } from './ide-state'
 import { createIdeDataCoordinator } from './ide-data-coordinator'
 import { IdeExplorer } from './ide-explorer'
 import { IdeEditor, type IdeEditorView } from './ide-editor'
@@ -23,7 +23,9 @@ import {
   serializeActive,
 } from '../../../design-system/headless-core/layered-overlay'
 
-export const activeIdeFile = signal<string>('package.json')
+// Re-export to preserve the public path used by existing callers. The
+// canonical source now lives in `./ide-state` to avoid circular imports.
+export { activeIdeFile }
 
 type ViewTab = IdeEditorView
 type IdeFocus = 'review'

--- a/dashboard/src/components/ide/ide-state.ts
+++ b/dashboard/src/components/ide/ide-state.ts
@@ -1,0 +1,15 @@
+/**
+ * IDE shared signals — minimal state module.
+ *
+ * Extracted from `ide-shell.ts` to break a circular dependency:
+ * `ide-shell` already imports `InspectorKeeperBDI` (and other heavy IDE
+ * components), so importing `activeIdeFile` from `ide-shell` inside those
+ * children re-enters the shell module at evaluation time and pulls
+ * `router` (window-touching at module-eval) into every importer.
+ *
+ * Keep this module side-effect free: only signals/types live here.
+ */
+
+import { signal } from '@preact/signals'
+
+export const activeIdeFile = signal<string>('package.json')

--- a/dashboard/src/components/ide/inspector-keeper-bdi.test.ts
+++ b/dashboard/src/components/ide/inspector-keeper-bdi.test.ts
@@ -10,6 +10,8 @@ import {
 } from './inspector-keeper-bdi'
 import { clearPins } from './multi-keeper-pin-store'
 import { clearTraces, pushTrace } from './keeper-trace-store'
+import { cursorOverlaySignal, type KeeperCursor } from './keeper-cursor-overlay'
+import { activeIdeFile } from './ide-state'
 
 const snapshot = {
   keeper: 'scholar',
@@ -55,8 +57,35 @@ afterEach(() => {
   activeKeeperName.value = ''
   clearPins()
   clearTraces()
+  cursorOverlaySignal.value = {
+    cursors: new Map(),
+    heatmap: new Map(),
+    collisions: [],
+    active_file: null,
+  }
+  activeIdeFile.value = 'package.json'
   void inspectorKeeperPin.value
 })
+
+function setCursorFor(keeperId: string, cursor: Partial<KeeperCursor> & { file_path: string; line: number }): void {
+  const full: KeeperCursor = {
+    keeper_id: keeperId,
+    file_path: cursor.file_path,
+    line: cursor.line,
+    column: cursor.column ?? 0,
+    focus_mode: cursor.focus_mode ?? 'editing',
+    last_update: cursor.last_update ?? Date.now(),
+    ...(cursor.tool_name !== undefined ? { tool_name: cursor.tool_name } : {}),
+    ...(cursor.turn !== undefined ? { turn: cursor.turn } : {}),
+    ...(cursor.selection_end !== undefined ? { selection_end: cursor.selection_end } : {}),
+  }
+  const next = new Map(cursorOverlaySignal.value.cursors)
+  next.set(keeperId, full)
+  cursorOverlaySignal.value = {
+    ...cursorOverlaySignal.value,
+    cursors: next,
+  }
+}
 
 describe('normalizeKeeperBdiSnapshot', () => {
   it('normalizes BDI fields, token spend, and the latest tool call', () => {
@@ -197,6 +226,84 @@ describe('InspectorKeeperBDI', () => {
     const overlay = container.querySelector('[data-overlay="keeper-trace"]')
     expect(overlay).not.toBeNull()
     expect(overlay?.querySelector('[data-keeper="scholar"]')).not.toBeNull()
+
+    render(null, container)
+  })
+
+  it('does not render the file focus label when no cursor is present for the keeper', async () => {
+    const fetchMock = vi.fn(async () => new Response(JSON.stringify(snapshot)))
+    vi.stubGlobal('fetch', fetchMock)
+    activeKeeperName.value = 'scholar'
+
+    const container = createContainer()
+    render(html`<${InspectorKeeperBDI} pollMs=${60_000} />`, container)
+    await vi.waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith('/api/v1/keepers/scholar/bdi-snapshot', expect.any(Object))
+    })
+
+    expect(container.querySelector('[data-testid="bdi-focus-label"]')).toBeNull()
+
+    render(null, container)
+  })
+
+  it('renders the file focus label when the cursor overlay has a valid 1-based line', async () => {
+    const fetchMock = vi.fn(async () => new Response(JSON.stringify(snapshot)))
+    vi.stubGlobal('fetch', fetchMock)
+    activeKeeperName.value = 'scholar'
+    setCursorFor('scholar', { file_path: 'src/components/ide/inspector-keeper-bdi.ts', line: 42 })
+
+    const container = createContainer()
+    render(html`<${InspectorKeeperBDI} pollMs=${60_000} />`, container)
+    await vi.waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith('/api/v1/keepers/scholar/bdi-snapshot', expect.any(Object))
+    })
+
+    const focusButton = container.querySelector('[data-testid="bdi-focus-label"]')
+    expect(focusButton).not.toBeNull()
+    expect(focusButton?.tagName.toLowerCase()).toBe('button')
+    expect(focusButton?.getAttribute('type')).toBe('button')
+    expect(focusButton?.textContent).toContain('inspector-keeper-bdi.ts:42')
+
+    render(null, container)
+  })
+
+  it('hides the file focus label when the overlay only carries a placeholder line (0)', async () => {
+    const fetchMock = vi.fn(async () => new Response(JSON.stringify(snapshot)))
+    vi.stubGlobal('fetch', fetchMock)
+    activeKeeperName.value = 'scholar'
+    // Mirrors the SSE adapter default (`line: entry.line || 0`) when the
+    // producer didn't ship a real line number.
+    setCursorFor('scholar', { file_path: 'src/components/ide/inspector-keeper-bdi.ts', line: 0 })
+
+    const container = createContainer()
+    render(html`<${InspectorKeeperBDI} pollMs=${60_000} />`, container)
+    await vi.waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith('/api/v1/keepers/scholar/bdi-snapshot', expect.any(Object))
+    })
+
+    expect(container.querySelector('[data-testid="bdi-focus-label"]')).toBeNull()
+
+    render(null, container)
+  })
+
+  it('updates activeIdeFile when the focus label is clicked', async () => {
+    const fetchMock = vi.fn(async () => new Response(JSON.stringify(snapshot)))
+    vi.stubGlobal('fetch', fetchMock)
+    activeKeeperName.value = 'scholar'
+    setCursorFor('scholar', { file_path: 'src/components/ide/inspector-keeper-bdi.ts', line: 42 })
+
+    const container = createContainer()
+    render(html`<${InspectorKeeperBDI} pollMs=${60_000} />`, container)
+    await vi.waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith('/api/v1/keepers/scholar/bdi-snapshot', expect.any(Object))
+    })
+
+    const focusButton = container.querySelector('[data-testid="bdi-focus-label"]') as HTMLButtonElement | null
+    expect(focusButton).not.toBeNull()
+    expect(activeIdeFile.value).toBe('package.json')
+
+    focusButton!.click()
+    expect(activeIdeFile.value).toBe('src/components/ide/inspector-keeper-bdi.ts')
 
     render(null, container)
   })

--- a/dashboard/src/components/ide/inspector-keeper-bdi.ts
+++ b/dashboard/src/components/ide/inspector-keeper-bdi.ts
@@ -6,7 +6,11 @@ import { bridgeBdiSnapshotsToTrace } from './bdi-snapshot-trace-bridge'
 import { asBoolean, asNumber, asString, isRecord, toIsoTimestamp } from '../common/normalize'
 import { clearPins, headPinnedKeeper, pinKeeper } from './multi-keeper-pin-store'
 import { cursorOverlaySignal } from './keeper-cursor-overlay'
-import { activeIdeFile } from './ide-shell'
+// Imported from `./ide-state` rather than `./ide-shell` to avoid the
+// circular dependency `ide-shell -> inspector-keeper-bdi -> ide-shell`
+// (which also drags `router` and other window-touching side effects
+// into this module's tests).
+import { activeIdeFile } from './ide-state'
 import { OverlayKeeperTrace } from './overlay-keeper-trace'
 
 export interface KeeperBdiTokenSpend {
@@ -229,14 +233,20 @@ export function InspectorKeeperBDI({
   }, [snapshot])
 
   const cursor = cursorOverlaySignal.value.cursors.get(keeperName)
-  const focusLabel = cursor?.file_path
-    ? `${cursor.file_path.split('/').pop()}:${cursor.line}`
+  // The SSE adapter defaults a missing `line` to 0 (see
+  // `keeper-cursor-overlay.ts::connectKeeperCursorStream` —
+  // `line: entry.line || 0`), so requiring a 1-based line here avoids
+  // labels like `foo.ts:0` and prevents click-to-navigate firing for
+  // placeholder cursors.
+  const hasValidFocus = !!cursor?.file_path && typeof cursor.line === 'number' && cursor.line >= 1
+  const focusLabel = hasValidFocus
+    ? `${cursor!.file_path.split('/').pop()}:${cursor!.line}`
     : null
   const tokenRows = snapshot?.recent_token_spend ?? []
   const lastTool = snapshot?.last_tool_call ?? null
 
   const navigateToFocus = (): void => {
-    if (cursor?.file_path) activeIdeFile.value = cursor.file_path
+    if (hasValidFocus && cursor) activeIdeFile.value = cursor.file_path
   }
 
   return html`
@@ -260,11 +270,10 @@ export function InspectorKeeperBDI({
           ${keeperName || '—'}
         </span>
         ${focusLabel ? html`
-          <span
-            role="button"
-            tabIndex=${0}
+          <button
+            type="button"
+            data-testid="bdi-focus-label"
             onClick=${navigateToFocus}
-            onKeyDown=${(e: KeyboardEvent) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); navigateToFocus() } }}
             title=${cursor?.file_path ?? ''}
             style=${{
               color: 'var(--color-accent-fg)',
@@ -277,8 +286,13 @@ export function InspectorKeeperBDI({
               borderRadius: 'var(--r-0)',
               padding: '0 var(--sp-1)',
               transition: 'background 0.15s',
+              background: 'transparent',
+              border: 'none',
+              font: 'inherit',
+              lineHeight: 'inherit',
+              textAlign: 'left',
             }}
-          >${focusLabel}</span>
+          >${focusLabel}</button>
         ` : null}
         ${pin?.line
           ? html`<span style=${{ marginLeft: 'auto', color: 'var(--color-fg-muted)', fontSize: 'var(--fs-11)' }}>L${pin.line}</span>`

--- a/dashboard/src/components/ide/inspector-keeper-bdi.ts
+++ b/dashboard/src/components/ide/inspector-keeper-bdi.ts
@@ -5,6 +5,8 @@ import { activeKeeperName } from '../../keeper-state'
 import { bridgeBdiSnapshotsToTrace } from './bdi-snapshot-trace-bridge'
 import { asBoolean, asNumber, asString, isRecord, toIsoTimestamp } from '../common/normalize'
 import { clearPins, headPinnedKeeper, pinKeeper } from './multi-keeper-pin-store'
+import { cursorOverlaySignal } from './keeper-cursor-overlay'
+import { activeIdeFile } from './ide-shell'
 import { OverlayKeeperTrace } from './overlay-keeper-trace'
 
 export interface KeeperBdiTokenSpend {
@@ -226,8 +228,16 @@ export function InspectorKeeperBDI({
     knownBdiKeys.current = bridgeBdiSnapshotsToTrace([snapshot], knownBdiKeys.current)
   }, [snapshot])
 
+  const cursor = cursorOverlaySignal.value.cursors.get(keeperName)
+  const focusLabel = cursor?.file_path
+    ? `${cursor.file_path.split('/').pop()}:${cursor.line}`
+    : null
   const tokenRows = snapshot?.recent_token_spend ?? []
   const lastTool = snapshot?.last_tool_call ?? null
+
+  const navigateToFocus = (): void => {
+    if (cursor?.file_path) activeIdeFile.value = cursor.file_path
+  }
 
   return html`
     <section
@@ -242,13 +252,34 @@ export function InspectorKeeperBDI({
         minHeight: '180px',
       }}
     >
-      <header style=${{ display: 'flex', alignItems: 'baseline', gap: 'var(--sp-2)' }}>
+      <header style=${{ display: 'flex', alignItems: 'baseline', gap: 'var(--sp-2)', flexWrap: 'wrap' }}>
         <h3 style=${{ margin: 0, font: 'var(--type-eyebrow)', color: 'var(--color-fg-primary)' }}>
           Keeper BDI
         </h3>
         <span style=${{ color: 'var(--color-accent-fg)', fontSize: 'var(--fs-12)' }}>
           ${keeperName || '—'}
         </span>
+        ${focusLabel ? html`
+          <span
+            role="button"
+            tabIndex=${0}
+            onClick=${navigateToFocus}
+            onKeyDown=${(e: KeyboardEvent) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); navigateToFocus() } }}
+            title=${cursor?.file_path ?? ''}
+            style=${{
+              color: 'var(--color-accent-fg)',
+              fontSize: 'var(--fs-11)',
+              maxWidth: '160px',
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              whiteSpace: 'nowrap',
+              cursor: 'pointer',
+              borderRadius: 'var(--r-0)',
+              padding: '0 var(--sp-1)',
+              transition: 'background 0.15s',
+            }}
+          >${focusLabel}</span>
+        ` : null}
         ${pin?.line
           ? html`<span style=${{ marginLeft: 'auto', color: 'var(--color-fg-muted)', fontSize: 'var(--fs-11)' }}>L${pin.line}</span>`
           : null}


### PR DESCRIPTION
## Summary
- Add the keeper's current file:line from `cursorOverlaySignal` to the BDI inspector header
- Click-to-navigate: clicking the label sets `activeIdeFile` to open the file in the editor
- Follows the same `cursorOverlaySignal` + `activeIdeFile` pattern established in the presence strip (PR #14543)

## Test plan
- [ ] Open dashboard IDE, select a keeper with active cursor overlay
- [ ] Verify file:line label appears in BDI inspector header next to keeper name
- [ ] Click the label → editor navigates to that file
- [ ] Verify no label when keeper has no file focus
- [ ] `tsc --noEmit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)