### PR TITLE
fix(keeper,dashboard,server): stop swallowing warnings/errors in bare catch-all handlers

### DIFF
--- a/lib/build_identity.ml
+++ b/lib/build_identity.ml
@@ -46,7 +46,7 @@ let executable_path () =
   in
   try Unix.realpath path with
   | exn ->
-    Log.Core.warn
+    Log.Identity.warn
       "build_identity: Unix.realpath failed for %s: %s"
       path
       (Printexc.to_string exn);

--- a/lib/build_identity.ml
+++ b/lib/build_identity.ml
@@ -1,49 +1,59 @@
 (** Build identity for the running server process. *)
 
-type t = {
-  release_version : string;
-  commit : string option [@default None];
-  commit_unix_ts : float option [@default None];
-  commit_age_seconds : int option [@default None];
-  executable_path : string [@default ""];
-  executable_dir : string [@default ""];
-  repo_root : string option [@default None];
-  started_at : string;
-  uptime_seconds : int;
-} [@@deriving yojson { strict = false }]
+type t =
+  { release_version : string
+  ; commit : string option [@default None]
+  ; commit_unix_ts : float option [@default None]
+  ; commit_age_seconds : int option [@default None]
+  ; executable_path : string [@default ""]
+  ; executable_dir : string [@default ""]
+  ; repo_root : string option [@default None]
+  ; started_at : string
+  ; uptime_seconds : int
+  }
+[@@deriving yojson { strict = false }]
 
 let iso8601_of_unix ts =
   let tm = Unix.gmtime ts in
-  Printf.sprintf "%04d-%02d-%02dT%02d:%02d:%02dZ"
-    (tm.Unix.tm_year + 1900) (tm.Unix.tm_mon + 1) tm.Unix.tm_mday
-    tm.Unix.tm_hour tm.Unix.tm_min tm.Unix.tm_sec
+  Printf.sprintf
+    "%04d-%02d-%02dT%02d:%02d:%02dZ"
+    (tm.Unix.tm_year + 1900)
+    (tm.Unix.tm_mon + 1)
+    tm.Unix.tm_mday
+    tm.Unix.tm_hour
+    tm.Unix.tm_min
+    tm.Unix.tm_sec
+;;
 
 let trim_to_option raw =
   let trimmed = String.trim raw in
   if trimmed = "" then None else Some trimmed
+;;
 
 let rec find_git_root dir =
   let git_marker = Filename.concat dir ".git" in
-  if Sys.file_exists git_marker then
-    Some dir
-  else
+  if Sys.file_exists git_marker
+  then Some dir
+  else (
     let parent = Filename.dirname dir in
-    if String.equal parent dir then None else find_git_root parent
+    if String.equal parent dir then None else find_git_root parent)
+;;
 
 let executable_path () =
-  let argv0 =
-    if Array.length Sys.argv > 0 then Sys.argv.(0) else Sys.getcwd ()
-  in
+  let argv0 = if Array.length Sys.argv > 0 then Sys.argv.(0) else Sys.getcwd () in
   let path =
-    if Filename.is_relative argv0 then
-      Filename.concat (Sys.getcwd ()) argv0
-    else
-      argv0
+    if Filename.is_relative argv0 then Filename.concat (Sys.getcwd ()) argv0 else argv0
   in
-  try Unix.realpath path with _ -> path
+  try Unix.realpath path with
+  | exn ->
+    Log.Core.warn
+      "build_identity: Unix.realpath failed for %s: %s"
+      path
+      (Printexc.to_string exn);
+    path
+;;
 
-let executable_dir () =
-  Filename.dirname (executable_path ())
+let executable_dir () = Filename.dirname (executable_path ())
 
 let git_capture_output_result ~repo_root args =
   let argv = [ "git"; "-C"; repo_root ] @ args in
@@ -58,43 +68,50 @@ let git_capture_output_result ~repo_root args =
   with
   | Unix.WEXITED 0, output -> Ok output
   | status, _ -> Error status
+;;
 
 let git_capture_output ~repo_root args =
   match git_capture_output_result ~repo_root args with
   | Ok output -> Some output
   | Error _ -> None
+;;
 
 let string_of_process_status = function
   | Unix.WEXITED code -> Printf.sprintf "exit %d" code
   | Unix.WSIGNALED signal -> Printf.sprintf "signal %d" signal
   | Unix.WSTOPPED signal -> Printf.sprintf "stopped %d" signal
+;;
 
 let git_probe_from_root repo_root =
   let output =
     try git_capture_output ~repo_root [ "rev-parse"; "--short"; "HEAD" ] with
     | Sys_error msg ->
-        Log.Identity.warn "git_probe_from_root read failed: %s" msg;
-        None
+      Log.Identity.warn "git_probe_from_root read failed: %s" msg;
+      None
     | Unix.Unix_error (code, fn, arg) ->
-        Log.Identity.warn "git_probe_from_root unix error: %s (%s %s)"
-          (Unix.error_message code) fn arg;
-        None
+      Log.Identity.warn
+        "git_probe_from_root unix error: %s (%s %s)"
+        (Unix.error_message code)
+        fn
+        arg;
+      None
     | exn ->
-        Log.Identity.warn "git_probe_from_root unexpected: %s" (Printexc.to_string exn);
-        None
+      Log.Identity.warn "git_probe_from_root unexpected: %s" (Printexc.to_string exn);
+      None
   in
   Option.bind output trim_to_option
+;;
 
 let observe_probe_failure ~site exn =
   match exn with
   | Eio.Cancel.Cancelled _ as e -> raise e
   | exn ->
-      Prometheus.inc_counter
-        Prometheus.metric_build_identity_probe_failures
-        ~labels:[("site", site)]
-        ();
-      Log.Identity.warn "build_identity %s failed: %s"
-        site (Printexc.to_string exn)
+    Prometheus.inc_counter
+      Prometheus.metric_build_identity_probe_failures
+      ~labels:[ "site", site ]
+      ();
+    Log.Identity.warn "build_identity %s failed: %s" site (Printexc.to_string exn)
+;;
 
 (** Pick the ordered list of directories to probe for a git repo,
     executable_dir first so the binary's own source tree wins over
@@ -108,25 +125,24 @@ let observe_probe_failure ~site exn =
     Pure — exposed for unit testing. *)
 let pick_repo_candidates ~exe_dir ~cwd =
   if String.equal exe_dir cwd then [ exe_dir ] else [ exe_dir; cwd ]
+;;
 
 let probe_git_commit () =
-  pick_repo_candidates
-    ~exe_dir:(executable_dir ())
-    ~cwd:(Sys.getcwd ())
+  pick_repo_candidates ~exe_dir:(executable_dir ()) ~cwd:(Sys.getcwd ())
   |> List.find_map (fun dir ->
-         match find_git_root dir with
-         | Some root -> git_probe_from_root root
-         | None -> None)
+    match find_git_root dir with
+    | Some root -> git_probe_from_root root
+    | None -> None)
+;;
 
 let probe_repo_root () =
-  pick_repo_candidates
-    ~exe_dir:(executable_dir ())
-    ~cwd:(Sys.getcwd ())
+  pick_repo_candidates ~exe_dir:(executable_dir ()) ~cwd:(Sys.getcwd ())
   |> List.find_map find_git_root
+;;
 
 let decimal_digits_only s =
-  String.length s > 0
-  && String.for_all (fun c -> c >= '0' && c <= '9') s
+  String.length s > 0 && String.for_all (fun c -> c >= '0' && c <= '9') s
+;;
 
 (* 2100-01-01T00:00:00Z.  This keeps obviously corrupt/far-future git
    output out of /health while leaving enough room for normal source history
@@ -137,13 +153,14 @@ let parse_commit_unix_ts_output raw =
   match trim_to_option raw with
   | None -> None
   | Some s when not (decimal_digits_only s) -> None
-  | Some s -> (
-      match Int64.of_string_opt s with
-      | Some ts
-        when Int64.compare ts 0L >= 0
-             && Int64.compare ts max_reasonable_commit_unix_ts <= 0 ->
-          Some (Int64.to_float ts)
-      | _ -> None)
+  | Some s ->
+    (match Int64.of_string_opt s with
+     | Some ts
+       when Int64.compare ts 0L >= 0
+            && Int64.compare ts max_reasonable_commit_unix_ts <= 0 ->
+       Some (Int64.to_float ts)
+     | _ -> None)
+;;
 
 (** Probe the unix timestamp of [commit] from the same git repo we
     resolved [commit] against.  Best-effort: returns [None] if [commit]
@@ -162,13 +179,12 @@ let probe_commit_unix_ts commit_hash_opt =
   | None -> None
   | Some commit_hash ->
     let repo_roots =
-      pick_repo_candidates
-        ~exe_dir:(executable_dir ())
-        ~cwd:(Sys.getcwd ())
+      pick_repo_candidates ~exe_dir:(executable_dir ()) ~cwd:(Sys.getcwd ())
       |> List.filter_map find_git_root
       |> List.fold_left
            (fun roots repo_root ->
-              if List.exists (String.equal repo_root) roots then roots
+              if List.exists (String.equal repo_root) roots
+              then roots
               else repo_root :: roots)
            []
       |> List.rev
@@ -177,17 +193,21 @@ let probe_commit_unix_ts commit_hash_opt =
       let raw_opt =
         try
           match
-            git_capture_output_result ~repo_root
+            git_capture_output_result
+              ~repo_root
               [ "log"; "-1"; "--format=%ct"; commit_hash ]
           with
           | Ok raw -> Some raw
           | Error status ->
-              observe_probe_failure ~site:"commit_ts_git_status"
-                (Failure
-                   (Printf.sprintf "git log failed with %s"
-                      (string_of_process_status status)));
-              None
-        with exn ->
+            observe_probe_failure
+              ~site:"commit_ts_git_status"
+              (Failure
+                 (Printf.sprintf
+                    "git log failed with %s"
+                    (string_of_process_status status)));
+            None
+        with
+        | exn ->
           observe_probe_failure ~site:"commit_ts_git_capture" exn;
           None
       in
@@ -197,20 +217,22 @@ let probe_commit_unix_ts commit_hash_opt =
         (match parse_commit_unix_ts_output raw with
          | Some ts -> Some ts
          | None ->
-             observe_probe_failure ~site:"commit_ts_parse"
-               (Failure
-                  (Printf.sprintf "invalid commit timestamp output %S" raw));
-             None)
+           observe_probe_failure
+             ~site:"commit_ts_parse"
+             (Failure (Printf.sprintf "invalid commit timestamp output %S" raw));
+           None)
     in
     List.find_map probe_one repo_roots
+;;
 
 let resolve_commit ~env_value ~probe =
   match env_value with
-  | Some raw -> (
-      match trim_to_option raw with
-      | Some commit -> Some commit
-      | None -> probe ())
+  | Some raw ->
+    (match trim_to_option raw with
+     | Some commit -> Some commit
+     | None -> probe ())
   | None -> probe ()
+;;
 
 let started_at_unix = Unix.gettimeofday ()
 let started_at_iso = iso8601_of_unix started_at_unix
@@ -224,11 +246,10 @@ let commit =
   resolve_commit
     ~env_value:(Env_config_core.build_git_commit_opt ())
     ~probe:probe_git_commit
+;;
 
 let resolved_repo_root = probe_repo_root ()
-
 let repo_root () = resolved_repo_root
-
 let commit_unix_ts = probe_commit_unix_ts commit
 
 let current () =
@@ -240,17 +261,17 @@ let current () =
       let age = now -. ts in
       if Float.is_finite age then Some (max 0 (int_of_float age)) else None
   in
-  {
-    release_version = Version.version;
-    commit;
-    commit_unix_ts;
-    commit_age_seconds;
-    executable_path = resolved_executable_path;
-    executable_dir = resolved_executable_dir;
-    repo_root = resolved_repo_root;
-    started_at = started_at_iso;
-    uptime_seconds = max 0 (int_of_float (now -. started_at_unix));
+  { release_version = Version.version
+  ; commit
+  ; commit_unix_ts
+  ; commit_age_seconds
+  ; executable_path = resolved_executable_path
+  ; executable_dir = resolved_executable_dir
+  ; repo_root = resolved_repo_root
+  ; started_at = started_at_iso
+  ; uptime_seconds = max 0 (int_of_float (now -. started_at_unix))
   }
+;;
 
 module For_testing = struct
   let observe_probe_failure = observe_probe_failure

--- a/lib/dashboard/dashboard_worktree_status.ml
+++ b/lib/dashboard/dashboard_worktree_status.ml
@@ -227,7 +227,7 @@ let list_entries ~base_path =
          try Some (build_entry path branch) with
          | Eio.Cancel.Cancelled _ as e -> raise e
          | exn ->
-           Log.Core.warn
+           Log.Dashboard.warn
              "dashboard_worktree_status: build_entry failed for %s/%s: %s"
              path
              branch

--- a/lib/dashboard/dashboard_worktree_status.ml
+++ b/lib/dashboard/dashboard_worktree_status.ml
@@ -8,8 +8,7 @@
 (* Internal git helpers                                                 *)
 (* ------------------------------------------------------------------ *)
 
-let exec_gate_raw_source argv =
-  String.concat " " (List.map Filename.quote argv)
+let exec_gate_raw_source argv = String.concat " " (List.map Filename.quote argv)
 
 let run_in_worktree path argv =
   let full_argv = [ "git"; "-C"; path ] @ argv in
@@ -19,12 +18,14 @@ let run_in_worktree path argv =
     ~summary:"dashboard_worktree_status git"
     ~timeout_sec:Env_config_runtime.Coord_git.local_op_timeout_sec
     full_argv
+;;
 
 let first_nonempty_line output =
   output
   |> String.split_on_char '\n'
   |> List.map String.trim
   |> List.find_opt (fun s -> s <> "")
+;;
 
 (* ------------------------------------------------------------------ *)
 (* git status --porcelain parsing                                       *)
@@ -36,26 +37,26 @@ let first_nonempty_line output =
     '?' = untracked, ' ' = unmodified, '!' = ignored. *)
 let count_porcelain_lines output =
   let lines =
-    String.split_on_char '\n' output
-    |> List.filter (fun s -> String.length s >= 2)
+    String.split_on_char '\n' output |> List.filter (fun s -> String.length s >= 2)
   in
   let staged =
     List.length
       (List.filter
          (fun line ->
-           let x = line.[0] in
-           x <> ' ' && x <> '?' && x <> '!')
+            let x = line.[0] in
+            x <> ' ' && x <> '?' && x <> '!')
          lines)
   in
   let changed =
     List.length
       (List.filter
          (fun line ->
-           let y = line.[1] in
-           y <> ' ' && y <> '?' && y <> '!')
+            let y = line.[1] in
+            y <> ' ' && y <> '?' && y <> '!')
          lines)
   in
-  (staged, changed)
+  staged, changed
+;;
 
 (* ------------------------------------------------------------------ *)
 (* git status / HEAD for one worktree                                   *)
@@ -64,10 +65,12 @@ let count_porcelain_lines output =
 let get_worktree_counts path =
   let output = run_in_worktree path [ "status"; "--porcelain" ] in
   count_porcelain_lines output
+;;
 
 let get_head_sha path =
   let output = run_in_worktree path [ "rev-parse"; "--short"; "HEAD" ] in
   Option.value ~default:"" (first_nonempty_line output)
+;;
 
 (* ------------------------------------------------------------------ *)
 (* gh pr list (best-effort)                                             *)
@@ -77,21 +80,12 @@ let get_head_sha path =
     Returns [(pr_number, pr_state)] on success; both [None] on failure
     (gh not installed, auth missing, not a GitHub repo). *)
 let query_pr_for_branch branch =
-  if branch = "" then (None, None)
-  else
+  if branch = ""
+  then None, None
+  else (
     try
       let argv =
-        [
-          "gh";
-          "pr";
-          "list";
-          "--head";
-          branch;
-          "--json";
-          "number,state";
-          "--limit";
-          "1";
-        ]
+        [ "gh"; "pr"; "list"; "--head"; branch; "--json"; "number,state"; "--limit"; "1" ]
       in
       let output =
         Masc_exec.Exec_gate.run_argv
@@ -102,21 +96,23 @@ let query_pr_for_branch branch =
           argv
       in
       (* Output is a JSON array: [{"number":42,"state":"OPEN"}] or [] *)
-      (match Yojson.Safe.from_string (String.trim output) with
-      | `List ((`Assoc fields) :: _) ->
-          let number =
-            match List.assoc_opt "number" fields with
-            | Some (`Int n) -> Some n
-            | _ -> None
-          in
-          let state =
-            match List.assoc_opt "state" fields with
-            | Some (`String s) -> Some (String.lowercase_ascii s)
-            | _ -> None
-          in
-          (number, state)
-      | _ -> (None, None))
-    with _ -> (None, None)
+      match Yojson.Safe.from_string (String.trim output) with
+      | `List (`Assoc fields :: _) ->
+        let number =
+          match List.assoc_opt "number" fields with
+          | Some (`Int n) -> Some n
+          | _ -> None
+        in
+        let state =
+          match List.assoc_opt "state" fields with
+          | Some (`String s) -> Some (String.lowercase_ascii s)
+          | _ -> None
+        in
+        number, state
+      | _ -> None, None
+    with
+    | _ -> None, None)
+;;
 
 (* ------------------------------------------------------------------ *)
 (* Keeper-attached detection                                            *)
@@ -128,42 +124,46 @@ let task_id_of_branch branch =
   match String.split_on_char '/' branch with
   | _ :: rest when rest <> [] -> Some (String.concat "/" rest)
   | _ -> None
+;;
 
 let keeper_task_ids () =
   Keeper_registry.all ()
   |> List.filter_map (fun (entry : Keeper_registry.registry_entry) ->
-         match entry.meta.current_task_id with
-         | Some task_id -> Some (Keeper_id.Task_id.to_string task_id)
-         | None -> None)
+    match entry.meta.current_task_id with
+    | Some task_id -> Some (Keeper_id.Task_id.to_string task_id)
+    | None -> None)
+;;
 
 let is_keeper_attached branch =
   match task_id_of_branch branch with
   | None -> false
   | Some task_id ->
-      let active_tasks = keeper_task_ids () in
-      List.mem task_id active_tasks
+    let active_tasks = keeper_task_ids () in
+    List.mem task_id active_tasks
+;;
 
 (* ------------------------------------------------------------------ *)
 (* Worktree entry assembly                                              *)
 (* ------------------------------------------------------------------ *)
 
-type worktree_entry = {
-  worktree_path : string;
-  branch : string;
-  changed_count : int;
-  staged_count : int;
-  head_sha : string;
-  pr_number : int option;
-  pr_state : string option;
-  keeper_attached : bool;
-}
+type worktree_entry =
+  { worktree_path : string
+  ; branch : string
+  ; changed_count : int
+  ; staged_count : int
+  ; head_sha : string
+  ; pr_number : int option
+  ; pr_state : string option
+  ; keeper_attached : bool
+  }
 
 let strip_refs_heads branch =
   let prefix = "refs/heads/" in
-  if String.starts_with ~prefix branch then
-    String.sub branch (String.length prefix)
-      (String.length branch - String.length prefix)
+  if String.starts_with ~prefix branch
+  then
+    String.sub branch (String.length prefix) (String.length branch - String.length prefix)
   else branch
+;;
 
 let build_entry path branch =
   let branch = strip_refs_heads branch in
@@ -171,16 +171,16 @@ let build_entry path branch =
   let head_sha = get_head_sha path in
   let pr_number, pr_state = query_pr_for_branch branch in
   let keeper_attached = is_keeper_attached branch in
-  {
-    worktree_path = path;
-    branch;
-    changed_count;
-    staged_count;
-    head_sha;
-    pr_number;
-    pr_state;
-    keeper_attached;
+  { worktree_path = path
+  ; branch
+  ; changed_count
+  ; staged_count
+  ; head_sha
+  ; pr_number
+  ; pr_state
+  ; keeper_attached
   }
+;;
 
 (* ------------------------------------------------------------------ *)
 (* Public: list_entries                                                 *)
@@ -189,33 +189,34 @@ let build_entry path branch =
 (** Extract worktrees from the JSON returned by {!Coord_git.list}. *)
 let extract_worktrees json =
   match json with
-  | `Assoc fields -> (
-      match List.assoc_opt "worktrees" fields with
-      | Some (`List items) ->
-          List.filter_map
-            (fun item ->
-              match item with
-              | `Assoc wt_fields ->
-                  let path =
-                    match List.assoc_opt "path" wt_fields with
-                    | Some (`String s) -> s
-                    | _ -> ""
-                  in
-                  let branch =
-                    match List.assoc_opt "branch" wt_fields with
-                    | Some (`String s) -> s
-                    | _ -> ""
-                  in
-                  let is_masc =
-                    match List.assoc_opt "is_masc" wt_fields with
-                    | Some (`Bool b) -> b
-                    | _ -> false
-                  in
-                  if is_masc && path <> "" then Some (path, branch) else None
-              | _ -> None)
-            items
-      | _ -> [])
+  | `Assoc fields ->
+    (match List.assoc_opt "worktrees" fields with
+     | Some (`List items) ->
+       List.filter_map
+         (fun item ->
+            match item with
+            | `Assoc wt_fields ->
+              let path =
+                match List.assoc_opt "path" wt_fields with
+                | Some (`String s) -> s
+                | _ -> ""
+              in
+              let branch =
+                match List.assoc_opt "branch" wt_fields with
+                | Some (`String s) -> s
+                | _ -> ""
+              in
+              let is_masc =
+                match List.assoc_opt "is_masc" wt_fields with
+                | Some (`Bool b) -> b
+                | _ -> false
+              in
+              if is_masc && path <> "" then Some (path, branch) else None
+            | _ -> None)
+         items
+     | _ -> [])
   | _ -> []
+;;
 
 let list_entries ~base_path =
   let worktrees_json = Coord_git.list ~base_path in
@@ -223,13 +224,19 @@ let list_entries ~base_path =
   let entries =
     List.filter_map
       (fun (path, branch) ->
-        try Some (build_entry path branch)
-        with _ -> None)
+         try Some (build_entry path branch) with
+         | Eio.Cancel.Cancelled _ as e -> raise e
+         | exn ->
+           Log.Core.warn
+             "dashboard_worktree_status: build_entry failed for %s/%s: %s"
+             path
+             branch
+             (Printexc.to_string exn);
+           None)
       pairs
   in
-  List.sort_uniq
-    (fun a b -> String.compare a.worktree_path b.worktree_path)
-    entries
+  List.sort_uniq (fun a b -> String.compare a.worktree_path b.worktree_path) entries
+;;
 
 (* ------------------------------------------------------------------ *)
 (* JSON serialisation                                                   *)
@@ -237,35 +244,35 @@ let list_entries ~base_path =
 
 let entry_to_json entry =
   `Assoc
-    [
-      ("worktree_path", `String entry.worktree_path);
-      ("branch", `String entry.branch);
-      ("changed_count", `Int entry.changed_count);
-      ("staged_count", `Int entry.staged_count);
-      ("head_sha", `String entry.head_sha);
-      ("pr_number", Json_util.int_opt_to_json entry.pr_number);
-      ("pr_state", Json_util.string_opt_to_json entry.pr_state);
-      ("keeper_attached", `Bool entry.keeper_attached);
+    [ "worktree_path", `String entry.worktree_path
+    ; "branch", `String entry.branch
+    ; "changed_count", `Int entry.changed_count
+    ; "staged_count", `Int entry.staged_count
+    ; "head_sha", `String entry.head_sha
+    ; "pr_number", Json_util.int_opt_to_json entry.pr_number
+    ; "pr_state", Json_util.string_opt_to_json entry.pr_state
+    ; "keeper_attached", `Bool entry.keeper_attached
     ]
+;;
 
 let json ~base_path =
   let entries = list_entries ~base_path in
   `Assoc
-    [
-      ("generated_at", `String (Masc_domain.now_iso ()));
-      ("count", `Int (List.length entries));
-      ("entries", `List (List.map entry_to_json entries));
+    [ "generated_at", `String (Masc_domain.now_iso ())
+    ; "count", `Int (List.length entries)
+    ; "entries", `List (List.map entry_to_json entries)
     ]
+;;
 
 (* ------------------------------------------------------------------ *)
 (* SSE helpers                                                          *)
 (* ------------------------------------------------------------------ *)
 
-let format_sse_event value =
-  Printf.sprintf "data: %s\n\n" (Yojson.Safe.to_string value)
+let format_sse_event value = Printf.sprintf "data: %s\n\n" (Yojson.Safe.to_string value)
 
 let sse_events ~base_path =
   let entries = list_entries ~base_path in
   let data_events = List.map (fun e -> format_sse_event (entry_to_json e)) entries in
   let done_event = "event: done\ndata: {}\n\n" in
   data_events @ [ done_event ]
+;;

--- a/lib/dashboard/dashboard_worktree_status.ml
+++ b/lib/dashboard/dashboard_worktree_status.ml
@@ -111,7 +111,13 @@ let query_pr_for_branch branch =
         number, state
       | _ -> None, None
     with
-    | _ -> None, None)
+    | Eio.Cancel.Cancelled _ as e -> raise e
+    | exn ->
+      Log.Dashboard.warn
+        "dashboard_worktree_status.query_pr_for_branch: failed to parse `gh pr \
+         view` output: %s"
+        (Printexc.to_string exn);
+      None, None)
 ;;
 
 (* ------------------------------------------------------------------ *)

--- a/lib/dashboard_cascade.ml
+++ b/lib/dashboard_cascade.ml
@@ -26,59 +26,60 @@ module StringSet = Set.Make (String)
 let now_iso () = Masc_domain.now_iso ()
 
 let candidate_to_json (c : CC.candidate_info) : Yojson.Safe.t =
-  `Assoc [
-    ("model", `String c.model_string);
-    ("display_model", `String c.display_model_string);
-    ("provider_name", Json_util.string_opt_to_json c.provider_name);
-    ("display_provider_name", Json_util.string_opt_to_json c.display_provider_name);
-    ("runtime_kind", Json_util.string_opt_to_json c.runtime_kind);
-    ("expanded_models", `List (List.map (fun model -> `String model) c.expanded_models));
-    ("config_weight", `Int c.config_weight);
-    ("effective_weight", `Int c.effective_weight);
-    ("success_rate", `Float c.success_rate);
-    ("in_cooldown", `Bool c.in_cooldown);
-  ]
+  `Assoc
+    [ "model", `String c.model_string
+    ; "display_model", `String c.display_model_string
+    ; "provider_name", Json_util.string_opt_to_json c.provider_name
+    ; "display_provider_name", Json_util.string_opt_to_json c.display_provider_name
+    ; "runtime_kind", Json_util.string_opt_to_json c.runtime_kind
+    ; "expanded_models", `List (List.map (fun model -> `String model) c.expanded_models)
+    ; "config_weight", `Int c.config_weight
+    ; "effective_weight", `Int c.effective_weight
+    ; "success_rate", `Float c.success_rate
+    ; "in_cooldown", `Bool c.in_cooldown
+    ]
+;;
 
 let source_to_string = function
   | CC.Named -> "named"
   | CC.Default_fallback -> "default_fallback"
   | CC.Hardcoded_defaults -> "hardcoded_defaults"
   | CC.Load_failed _ -> "load_failed"
+;;
 
-let string_list_to_json values =
-  `List (List.map (fun value -> `String value) values)
+let string_list_to_json values = `List (List.map (fun value -> `String value) values)
 
-let invalid_profile_to_json (name, errors : string * string list) =
-  `Assoc
-    [
-      ("name", `String name);
-      ("errors", string_list_to_json errors);
-    ]
+let invalid_profile_to_json ((name, errors) : string * string list) =
+  `Assoc [ "name", `String name; "errors", string_list_to_json errors ]
+;;
 
 let json_assoc_member key = function
   | `Assoc fields -> Option.value (List.assoc_opt key fields) ~default:`Null
   | _ -> `Null
+;;
 
 let json_string_list = function
   | `List values ->
-      List.filter_map
-        (function
-          | `String value -> Some value
-          | _ -> None)
-        values
+    List.filter_map
+      (function
+        | `String value -> Some value
+        | _ -> None)
+      values
   | _ -> []
+;;
 
 let invalid_profiles_of_rejection_json rejection_json =
   match json_assoc_member "profiles" rejection_json with
   | `List profiles ->
-      List.filter_map
-        (fun profile_json ->
-           match json_assoc_member "name" profile_json with
-           | `String name ->
-               Some (name, json_string_list (json_assoc_member "errors" profile_json))
-           | _ -> None)
-        profiles
+    List.filter_map
+      (fun profile_json ->
+         match json_assoc_member "name" profile_json with
+         | `String name ->
+           Some (name, json_string_list (json_assoc_member "errors" profile_json))
+         | _ -> None)
+      profiles
   | _ -> []
+;;
 
 let source_info ?config_path () =
   let config_path =
@@ -87,14 +88,13 @@ let source_info ?config_path () =
     | None -> Config_dir_resolver.cascade_path_candidate ()
   in
   Cascade_toml_materializer.source_info ~config_path
+;;
 
 let source_json_fields (source : Cascade_toml_materializer.source_info) =
-  [
-    ( "source_kind",
-      `String
-        (Cascade_toml_materializer.source_kind_to_string source.kind) );
-    ("source_path", `String source.source_path);
+  [ "source_kind", `String (Cascade_toml_materializer.source_kind_to_string source.kind)
+  ; "source_path", `String source.source_path
   ]
+;;
 
 (* ── Config projection ──────────────────────────────── *)
 
@@ -104,47 +104,48 @@ let source_json_fields (source : Cascade_toml_materializer.source_info) =
     before first successful validation), fall back to the active
     [cascade.json] catalog so the dashboard still renders a best-effort
     raw projection instead of failing hard. *)
-let live_profiles ?config_path () =
-  Keeper_cascade_profile.catalog_names ?config_path ()
+let live_profiles ?config_path () = Keeper_cascade_profile.catalog_names ?config_path ()
 
 let keeper_assignable_name_set ?config_path () =
   Keeper_cascade_profile.keeper_catalog_names ?config_path ()
-  |> List.fold_left
-       (fun acc name -> StringSet.add name acc)
-       StringSet.empty
+  |> List.fold_left (fun acc name -> StringSet.add name acc) StringSet.empty
+;;
 
 let profile_json_of_trace ~keeper_assignable name (trace : CC.selection_trace) =
-  `Assoc [
-    ("name", `String name);
-    ("source", `String (source_to_string trace.source));
-    ("keeper_assignable", `Bool keeper_assignable);
-    ("candidates", `List (List.map candidate_to_json trace.candidates));
-  ]
+  `Assoc
+    [ "name", `String name
+    ; "source", `String (source_to_string trace.source)
+    ; "keeper_assignable", `Bool keeper_assignable
+    ; "candidates", `List (List.map candidate_to_json trace.candidates)
+    ]
+;;
 
 let profile_json_runtime ~keeper_assignable_names name =
   match Cascade_catalog_runtime.resolve_selection_trace ~name () with
   | Ok trace ->
-      Some
-        (profile_json_of_trace
-           ~keeper_assignable:(StringSet.mem name keeper_assignable_names)
-           name trace)
+    Some
+      (profile_json_of_trace
+         ~keeper_assignable:(StringSet.mem name keeper_assignable_names)
+         name
+         trace)
   | Error detail ->
-      Log.Keeper.warn
-        "dashboard cascade config: skipping profile %s: %s"
-        name detail;
-      None
+    Log.Keeper.warn "dashboard cascade config: skipping profile %s: %s" name detail;
+    None
+;;
 
 let profile_json_raw ~config_path ~keeper_assignable_names name =
   let defaults =
     Cascade_runtime.default_model_strings
       ~cascade_name:(Keeper_cascade_profile.Runtime_name name)
   in
-  let (_models, trace) =
+  let _models, trace =
     CC.resolve_model_strings_with_trace ?config_path ~name ~defaults ()
   in
   profile_json_of_trace
     ~keeper_assignable:(StringSet.mem name keeper_assignable_names)
-    name trace
+    name
+    trace
+;;
 
 (* Two-column contract consumed by the dashboard's "Keeper → Cascade
    Mapping" table:
@@ -162,28 +163,30 @@ let profile_json_raw ~config_path ~keeper_assignable_names name =
    Exposed as a pure helper so the contract can be exercised without
    synthesizing a full [Keeper_registry.registry_entry]. *)
 let keeper_profile_fields ~keeper ~cascade_name : (string * Yojson.Safe.t) list =
-  [ ("keeper", `String keeper);
-    ("cascade_name", `String cascade_name);
-    ("canonical", `String (Keeper_cascade_profile.resolve_live cascade_name));
+  [ "keeper", `String keeper
+  ; "cascade_name", `String cascade_name
+  ; "canonical", `String (Keeper_cascade_profile.resolve_live cascade_name)
   ]
+;;
 
 let keeper_profile_json (entry : Keeper_registry.registry_entry) : Yojson.Safe.t =
   `Assoc
     (keeper_profile_fields
        ~keeper:entry.name
        ~cascade_name:(Keeper_types.cascade_name_of_meta entry.meta))
+;;
 
 let invalid_name_set = function
   | None -> StringSet.empty
   | Some path ->
-      Cascade_catalog_validator.error_messages_by_profile ~config_path:path
-      |> List.fold_left
-           (fun acc (name, _reasons) -> StringSet.add name acc)
-           StringSet.empty
+    Cascade_catalog_validator.error_messages_by_profile ~config_path:path
+    |> List.fold_left (fun acc (name, _reasons) -> StringSet.add name acc) StringSet.empty
+;;
 
 let invalid_profiles_of_config_path = function
   | None -> []
   | Some path -> Cascade_catalog_validator.error_messages_by_profile ~config_path:path
+;;
 
 let validation_summary_json ?config_path () =
   let fallback_invalid_profiles = invalid_profiles_of_config_path config_path in
@@ -194,129 +197,127 @@ let validation_summary_json ?config_path () =
       | [] -> fallback_invalid_profiles
       | profiles -> profiles
     in
-    [
-      ("validation_status", `String status);
-      ("validation_errors",
-       string_list_to_json (json_string_list (json_assoc_member "errors" rejection_json)));
-      ("invalid_profiles", `List (List.map invalid_profile_to_json invalid_profiles));
+    [ "validation_status", `String status
+    ; ( "validation_errors"
+      , string_list_to_json (json_string_list (json_assoc_member "errors" rejection_json))
+      )
+    ; "invalid_profiles", `List (List.map invalid_profile_to_json invalid_profiles)
     ]
   in
   match Cascade_catalog_runtime.inspect_active () with
   | Ok (Cascade_catalog_runtime.Validated _) ->
-      [
-        ("validation_status", `String "validated");
-        ("validation_errors", `List []);
-        ("invalid_profiles", `List []);
-      ]
-  | Ok
-      (Cascade_catalog_runtime.Validated_with_rejections
-         { rejected_update; _ }) ->
-      of_rejection ~status:"validated" rejected_update
-  | Ok
-      (Cascade_catalog_runtime.Serving_last_known_good
-         { rejected_update; _ }) ->
-      of_rejection ~status:"serving_last_known_good" rejected_update
-  | Error rejection ->
-      of_rejection ~status:"invalid" rejection
+    [ "validation_status", `String "validated"
+    ; "validation_errors", `List []
+    ; "invalid_profiles", `List []
+    ]
+  | Ok (Cascade_catalog_runtime.Validated_with_rejections { rejected_update; _ }) ->
+    of_rejection ~status:"validated" rejected_update
+  | Ok (Cascade_catalog_runtime.Serving_last_known_good { rejected_update; _ }) ->
+    of_rejection ~status:"serving_last_known_good" rejected_update
+  | Error rejection -> of_rejection ~status:"invalid" rejection
+;;
 
 let config_json () =
   let config_path = Cascade_runtime.cascade_config_path () in
-  let source : Cascade_toml_materializer.source_info =
-    source_info ?config_path ()
-  in
+  let source : Cascade_toml_materializer.source_info = source_info ?config_path () in
   let keeper_assignable_names = keeper_assignable_name_set ?config_path () in
   let keeper_entries =
     (* Issue #8619: was [with _ -> []] which silently swallowed
        Eio.Cancel.Cancelled. Re-raise cancellation; only fall back
        to empty for non-cancel exceptions (e.g. registry not yet
        initialised). *)
-    try Keeper_registry.all ()
-    with
+    try Keeper_registry.all () with
     | Eio.Cancel.Cancelled _ as e -> raise e
     | _ -> []
   in
   let active_names =
-    List.fold_left (fun acc (e : Keeper_registry.registry_entry) -> StringSet.add e.name acc) StringSet.empty keeper_entries
+    List.fold_left
+      (fun acc (e : Keeper_registry.registry_entry) -> StringSet.add e.name acc)
+      StringSet.empty
+      keeper_entries
   in
   let offline_keepers_json =
     try
       Config_dir_resolver.keepers_dir ()
       |> Keeper_types_profile.discover_keepers_toml
       |> List.filter_map (fun (name, doc) ->
-             if StringSet.mem name active_names then None
-             else
-               let cascade_name =
-                 match doc.Keeper_types_profile.cascade_name with
-                 | Some c -> c
-                 | None -> Keeper_config.default_cascade_name
-               in
-               Some (`Assoc (keeper_profile_fields ~keeper:name ~cascade_name)))
-    with _ -> []
+        if StringSet.mem name active_names
+        then None
+        else (
+          let cascade_name =
+            match doc.Keeper_types_profile.cascade_name with
+            | Some c -> c
+            | None -> Keeper_config.default_cascade_name
+          in
+          Some (`Assoc (keeper_profile_fields ~keeper:name ~cascade_name))))
+    with
+    | Eio.Cancel.Cancelled _ as e -> raise e
+    | exn ->
+      Log.Core.warn
+        "dashboard_cascade: offline_keepers_json failed: %s"
+        (Printexc.to_string exn);
+      []
   in
   let profiles =
     match Cascade_catalog_runtime.known_profile_names () with
-    | Ok names ->
-        List.filter_map
-          (profile_json_runtime ~keeper_assignable_names)
-          names
+    | Ok names -> List.filter_map (profile_json_runtime ~keeper_assignable_names) names
     | Error detail ->
-        Log.Keeper.warn
-          "dashboard cascade config: validated catalog unavailable: %s"
-          detail;
-        let invalid_names = invalid_name_set config_path in
-        let add_profile_name (acc, seen) name =
-          let canonical = Keeper_cascade_profile.canonicalize name in
-          if StringSet.mem canonical invalid_names || StringSet.mem canonical seen
-          then (acc, seen)
-          else (canonical :: acc, StringSet.add canonical seen)
-        in
-        let acc_after_catalog, seen_after_catalog =
-          List.fold_left add_profile_name ([], StringSet.empty) (live_profiles ?config_path ())
-        in
-        let names, _ =
-          List.fold_left
-            (fun (acc, seen) (e : Keeper_registry.registry_entry) ->
-               add_profile_name (acc, seen) (Keeper_types.cascade_name_of_meta e.meta))
-            (acc_after_catalog, seen_after_catalog)
-            keeper_entries
-        in
-        let names = List.rev names in
-        List.map
-          (profile_json_raw ~config_path ~keeper_assignable_names)
-          names
+      Log.Keeper.warn "dashboard cascade config: validated catalog unavailable: %s" detail;
+      let invalid_names = invalid_name_set config_path in
+      let add_profile_name (acc, seen) name =
+        let canonical = Keeper_cascade_profile.canonicalize name in
+        if StringSet.mem canonical invalid_names || StringSet.mem canonical seen
+        then acc, seen
+        else canonical :: acc, StringSet.add canonical seen
+      in
+      let acc_after_catalog, seen_after_catalog =
+        List.fold_left
+          add_profile_name
+          ([], StringSet.empty)
+          (live_profiles ?config_path ())
+      in
+      let names, _ =
+        List.fold_left
+          (fun (acc, seen) (e : Keeper_registry.registry_entry) ->
+             add_profile_name (acc, seen) (Keeper_types.cascade_name_of_meta e.meta))
+          (acc_after_catalog, seen_after_catalog)
+          keeper_entries
+      in
+      let names = List.rev names in
+      List.map (profile_json_raw ~config_path ~keeper_assignable_names) names
   in
   let fields =
-    [
-      ("updated_at", `String (now_iso ()));
-      ("config_path",
-       match config_path with
-       | Some p -> `String p
-       | None -> `Null);
+    [ "updated_at", `String (now_iso ())
+    ; ( "config_path"
+      , match config_path with
+        | Some p -> `String p
+        | None -> `Null )
     ]
     @ source_json_fields source
     @ validation_summary_json ?config_path ()
-    @ [
-        ("profiles", `List profiles);
-        ("keeper_profiles", `List (List.map keeper_profile_json keeper_entries @ offline_keepers_json));
+    @ [ "profiles", `List profiles
+      ; ( "keeper_profiles"
+        , `List (List.map keeper_profile_json keeper_entries @ offline_keepers_json) )
       ]
   in
   `Assoc fields
+;;
 
 let default_raw_config_json = "{}\n"
 
 let load_raw_config_string path =
-  if Fs_compat.file_exists path then
-    Fs_compat.load_file path
-  else
-    default_raw_config_json
+  if Fs_compat.file_exists path then Fs_compat.load_file path else default_raw_config_json
+;;
 
 let invalidate_cascade_config config_path =
   Cascade_config_loader.invalidate_cache_entry config_path;
   Cascade_catalog_runtime.invalidate_path config_path
+;;
 
 let save_config_file path content =
   Fs_compat.mkdir_p (Filename.dirname path);
   Fs_compat.save_file_atomic path content
+;;
 
 let raw_config_json () =
   Config_dir_resolver.log_warnings ~context:"DashboardCascade" ();
@@ -332,45 +333,44 @@ let raw_config_json () =
     with
     | Ok _ -> None
     | Error msg ->
-        Log.Keeper.warn "DashboardCascade: materialization failed for %s: %s" source.json_path msg;
-        Some msg
+      Log.Keeper.warn
+        "DashboardCascade: materialization failed for %s: %s"
+        source.json_path
+        msg;
+      Some msg
   in
   let source_text =
     try load_raw_config_string source.source_path with
     | Eio.Cancel.Cancelled _ as exn -> raise exn
     | Sys_error msg ->
-        Log.Keeper.warn
-          "dashboard cascade source config: failed to read %s: %s"
-          source.source_path msg;
-        ""
+      Log.Keeper.warn
+        "dashboard cascade source config: failed to read %s: %s"
+        source.source_path
+        msg;
+      ""
   in
   let raw_json =
     match config_path with
     | None -> ""
-    | Some path -> (
-        try load_raw_config_string path with
-        | Eio.Cancel.Cancelled _ as exn -> raise exn
-        | Sys_error msg ->
-            Log.Keeper.warn
-              "dashboard cascade raw config: failed to read %s: %s"
-              path msg;
-            "")
+    | Some path ->
+      (try load_raw_config_string path with
+       | Eio.Cancel.Cancelled _ as exn -> raise exn
+       | Sys_error msg ->
+         Log.Keeper.warn "dashboard cascade raw config: failed to read %s: %s" path msg;
+         "")
   in
   `Assoc
-    [
-      ("updated_at", `String (now_iso ()));
-      ("config_path", Json_util.string_opt_to_json config_path);
-      ( "source_kind",
-        `String
-          (Cascade_toml_materializer.source_kind_to_string source.kind) );
-      ("source_path", `String source.source_path);
-      ("source_editable", `Bool true);
-      ("source_text", `String source_text);
-      ("raw_json_editable", `Bool source.raw_json_editable);
-      ("raw_json", `String raw_json);
-      ("materialization_error",
-        Json_util.string_opt_to_json materialization_error);
+    [ "updated_at", `String (now_iso ())
+    ; "config_path", Json_util.string_opt_to_json config_path
+    ; "source_kind", `String (Cascade_toml_materializer.source_kind_to_string source.kind)
+    ; "source_path", `String source.source_path
+    ; "source_editable", `Bool true
+    ; "source_text", `String source_text
+    ; "raw_json_editable", `Bool source.raw_json_editable
+    ; "raw_json", `String raw_json
+    ; "materialization_error", Json_util.string_opt_to_json materialization_error
     ]
+;;
 
 let save_raw_config_json raw_json =
   Config_dir_resolver.log_warnings ~context:"DashboardCascade" ();
@@ -378,50 +378,45 @@ let save_raw_config_json raw_json =
   let config_path = source.json_path in
   match source.kind with
   | Cascade_toml_materializer.Json ->
-      let parse_result =
-        try
-          let (_ : Yojson.Safe.t) = Yojson.Safe.from_string raw_json in
-          Ok ()
+    let parse_result =
+      try
+        let (_ : Yojson.Safe.t) = Yojson.Safe.from_string raw_json in
+        Ok ()
+      with
+      | Eio.Cancel.Cancelled _ as exn -> raise exn
+      | Yojson.Json_error msg -> Error (Printf.sprintf "invalid JSON: %s" msg)
+      | exn ->
+        Error (Printf.sprintf "failed to parse JSON: %s" (Stdlib.Printexc.to_string exn))
+    in
+    (match parse_result with
+     | Error _ as err -> err
+     | Ok () ->
+       (try
+          match save_config_file config_path raw_json with
+          | Error msg -> Error msg
+          | Ok () ->
+            invalidate_cascade_config config_path;
+            Ok (config_json ())
         with
         | Eio.Cancel.Cancelled _ as exn -> raise exn
-        | Yojson.Json_error msg ->
-            Error (Printf.sprintf "invalid JSON: %s" msg)
-        | exn ->
-            Error
-              (Printf.sprintf "failed to parse JSON: %s" (Stdlib.Printexc.to_string exn))
-      in
-      (match parse_result with
-       | Error _ as err -> err
-       | Ok () -> (
-           try
-             match save_config_file config_path raw_json with
+        | Sys_error msg -> Error msg))
+  | Cascade_toml_materializer.Toml ->
+    (match Cascade_toml_materializer.render_toml_string_to_json_string raw_json with
+     | Error msg -> Error (Printf.sprintf "invalid TOML: %s" msg)
+     | Ok _rendered_json ->
+       (try
+          match save_config_file source.source_path raw_json with
+          | Error msg -> Error msg
+          | Ok () ->
+            (match Cascade_toml_materializer.ensure_materialized_json ~config_path with
              | Error msg -> Error msg
-             | Ok () ->
-                 invalidate_cascade_config config_path;
-                 Ok (config_json ())
-           with
-           | Eio.Cancel.Cancelled _ as exn -> raise exn
-           | Sys_error msg -> Error msg))
-  | Cascade_toml_materializer.Toml -> (
-      match Cascade_toml_materializer.render_toml_string_to_json_string raw_json with
-      | Error msg ->
-          Error (Printf.sprintf "invalid TOML: %s" msg)
-      | Ok _rendered_json -> (
-          try
-            match save_config_file source.source_path raw_json with
-            | Error msg -> Error msg
-            | Ok () -> (
-                match
-                  Cascade_toml_materializer.ensure_materialized_json
-                    ~config_path:config_path
-                with
-                | Error msg -> Error msg
-                | Ok _ ->
-                    invalidate_cascade_config config_path;
-                    Ok (config_json ()))
-          with
-          | Eio.Cancel.Cancelled _ as exn -> raise exn
-          | Sys_error msg -> Error msg))
+             | Ok _ ->
+               invalidate_cascade_config config_path;
+               Ok (config_json ()))
+        with
+        | Eio.Cancel.Cancelled _ as exn -> raise exn
+        | Sys_error msg -> Error msg))
+;;
 
 (* ── Health projection ──────────────────────────────── *)
 
@@ -439,9 +434,12 @@ let save_raw_config_json raw_json =
     would live here too, but currently we have no per-provider health
     tracker entry for that condition. *)
 let provider_status (info : Health.provider_info) : string =
-  if info.in_cooldown then "cooldown"
-  else if info.events_in_window > 0 then "active"
+  if info.in_cooldown
+  then "cooldown"
+  else if info.events_in_window > 0
+  then "active"
   else "configured"
+;;
 
 (** Synthesise a provider_info with optimistic defaults for a
     cascade-declared provider that has not been observed by the tracker
@@ -466,6 +464,7 @@ let zero_provider_info (key : string) : Health.provider_info =
   ; cost_samples = 0
   ; health_score = 1.0
   }
+;;
 
 (** [provider_entry_to_json ~declared info] serialises a provider_info
     together with two derived fields:
@@ -478,10 +477,16 @@ let zero_provider_info (key : string) : Health.provider_info =
 
     Existing callers (tests, UI) read the previous 7 behavioural fields
     unchanged; the two new keys are strictly additive. *)
-let provider_entry_to_json ~(declared : bool)
-    ?(perf : Model_inference_metrics.provider_stats option)
-    (info : Health.provider_info) : Yojson.Safe.t =
-  let opt_float = function Some f -> `Float f | None -> `Null in
+let provider_entry_to_json
+      ~(declared : bool)
+      ?(perf : Model_inference_metrics.provider_stats option)
+      (info : Health.provider_info)
+  : Yojson.Safe.t
+  =
+  let opt_float = function
+    | Some f -> `Float f
+    | None -> `Null
+  in
   let trust_score = Cascade_trust.trust_score info in
   let health_score =
     let score = Float.max 0.0 (Float.min 1.0 trust_score) in
@@ -496,68 +501,67 @@ let provider_entry_to_json ~(declared : bool)
          the sibling [request_count] to tell them apart: [null] with
          [request_count = null] means no aggregator; [null] with
          [request_count = 0] means aggregator ran and found nothing. *)
-      [ ("avg_prompt_tok_per_sec", `Null)
-      ; ("avg_decode_tok_per_sec", `Null)
-      ; ("avg_tok_per_sec", `Null)
-      ; ("avg_latency_ms", `Null)
-      ; ("p50_latency_ms", `Null)
-      ; ("p95_latency_ms", `Null)
-      ; ("request_count", `Null)
+      [ "avg_prompt_tok_per_sec", `Null
+      ; "avg_decode_tok_per_sec", `Null
+      ; "avg_tok_per_sec", `Null
+      ; "avg_latency_ms", `Null
+      ; "p50_latency_ms", `Null
+      ; "p95_latency_ms", `Null
+      ; "request_count", `Null
       ]
     | Some (stats : Model_inference_metrics.provider_stats) ->
-      [ ("avg_prompt_tok_per_sec",
-         opt_float stats.ps_avg_prompt_tok_per_sec)
-      ; ("avg_decode_tok_per_sec",
-         opt_float stats.ps_avg_decode_tok_per_sec)
-      ; ("avg_tok_per_sec", opt_float stats.ps_avg_tok_per_sec)
-      ; ("avg_latency_ms", opt_float stats.ps_avg_latency_ms)
-      ; ("p50_latency_ms", opt_float stats.ps_p50_latency_ms)
-      ; ("p95_latency_ms", opt_float stats.ps_p95_latency_ms)
-      ; ("request_count", `Int stats.ps_entry_count)
+      [ "avg_prompt_tok_per_sec", opt_float stats.ps_avg_prompt_tok_per_sec
+      ; "avg_decode_tok_per_sec", opt_float stats.ps_avg_decode_tok_per_sec
+      ; "avg_tok_per_sec", opt_float stats.ps_avg_tok_per_sec
+      ; "avg_latency_ms", opt_float stats.ps_avg_latency_ms
+      ; "p50_latency_ms", opt_float stats.ps_p50_latency_ms
+      ; "p95_latency_ms", opt_float stats.ps_p95_latency_ms
+      ; "request_count", `Int stats.ps_entry_count
       ]
   in
   let top_fingerprints_json =
     `List
       (List.map
-         (fun (fp, count) ->
-           `Assoc
-             [ ("fingerprint", `String fp); ("count", `Int count) ])
+         (fun (fp, count) -> `Assoc [ "fingerprint", `String fp; "count", `Int count ])
          info.top_fingerprints)
   in
-  `Assoc ([
-    ("provider_key", `String info.provider_key);
-    ("success_rate", `Float info.success_rate);
-    ("consecutive_failures", `Int info.consecutive_failures);
-    ("in_cooldown", `Bool info.in_cooldown);
-    ("cooldown_expires_at",
-     match info.cooldown_expires_at with
-     | Some t -> `Float t
-     | None -> `Null);
-    ("events_in_window", `Int info.events_in_window);
-    ("trust_score", `Float trust_score);
-    ("health_score", `Int health_score);
-    (* rejected_in_window ⊆ events_in_window: responses that arrived
+  `Assoc
+    ([ "provider_key", `String info.provider_key
+     ; "success_rate", `Float info.success_rate
+     ; "consecutive_failures", `Int info.consecutive_failures
+     ; "in_cooldown", `Bool info.in_cooldown
+     ; ( "cooldown_expires_at"
+       , match info.cooldown_expires_at with
+         | Some t -> `Float t
+         | None -> `Null )
+     ; "events_in_window", `Int info.events_in_window
+     ; "trust_score", `Float trust_score
+     ; "health_score", `Int health_score
+     ; (* rejected_in_window ⊆ events_in_window: responses that arrived
        but were rejected by the cascade's accept predicate.  Split out
        so dashboards can distinguish "provider down" from "provider
        returns unusable output". *)
-    ("rejected_in_window", `Int info.rejected_in_window);
-    (* top_fingerprints / last_failure_at are Phase 0 trust observability
+       "rejected_in_window", `Int info.rejected_in_window
+     ; (* top_fingerprints / last_failure_at are Phase 0 trust observability
        anchors (cumulative, not window-bounded).  Surfaced so dashboards
        can show "which error keeps recurring" alongside the existing
        success-rate snapshot. *)
-    ("top_fingerprints", top_fingerprints_json);
-    ("last_failure_at", opt_float info.last_failure_at);
-    ("declared", `Bool declared);
-    ("status", `String (provider_status info));
-    ("avg_confidence", opt_float info.avg_confidence);
-    ("confidence_samples", `Int info.confidence_samples);
-  ] @ perf_fields)
+       "top_fingerprints", top_fingerprints_json
+     ; "last_failure_at", opt_float info.last_failure_at
+     ; "declared", `Bool declared
+     ; "status", `String (provider_status info)
+     ; "avg_confidence", opt_float info.avg_confidence
+     ; "confidence_samples", `Int info.confidence_samples
+     ]
+     @ perf_fields)
+;;
 
 (** Back-compat alias: older call sites may still reference the previous
     serializer name.  Keeping it as a thin wrapper keeps the diff in
     this PR focused on the health_json merge. *)
 let provider_info_to_json (info : Health.provider_info) : Yojson.Safe.t =
   provider_entry_to_json ~declared:false info
+;;
 
 (* ── Phase 2a: low-trust operator recommendations ─────────────────────
 
@@ -567,59 +571,71 @@ let provider_info_to_json (info : Health.provider_info) : Yojson.Safe.t =
    self-applying, and it is gated by [MASC_CASCADE_TRUST_PERSIST]. *)
 
 type recommendation_action =
-  | Reduce_weight  (* unreliable but partially working *)
-  | Disable        (* effectively dead *)
-  | Investigate    (* high-volume same-fingerprint failures — config bug *)
+  | Reduce_weight (* unreliable but partially working *)
+  | Disable (* effectively dead *)
+  | Investigate (* high-volume same-fingerprint failures — config bug *)
 
 let recommendation_action_to_string = function
   | Reduce_weight -> "reduce_weight"
   | Disable -> "disable"
   | Investigate -> "investigate"
+;;
 
-type recommendation = {
-  rec_provider_key : string;
-  rec_trust_score : float;
-  rec_same_fingerprint_count : int;
-  rec_events_in_window : int;
-  rec_top_fingerprint : string option;
-  rec_action : recommendation_action;
-  rec_rationale : string;
-}
+type recommendation =
+  { rec_provider_key : string
+  ; rec_trust_score : float
+  ; rec_same_fingerprint_count : int
+  ; rec_events_in_window : int
+  ; rec_top_fingerprint : string option
+  ; rec_action : recommendation_action
+  ; rec_rationale : string
+  }
 
 let top_failure_fingerprint (info : Health.provider_info) =
   match info.top_fingerprints with
   | [] -> None
   | (fingerprint, count) :: _ -> Some (fingerprint, count)
+;;
 
-let recommendation_rationale ~provider_key ~trust_score ~events ~top_count
-    action =
+let recommendation_rationale ~provider_key ~trust_score ~events ~top_count action =
   match action with
   | Investigate when top_count >= 5 ->
     Printf.sprintf
-      "Provider %s has repeated the same failure fingerprint %d times; inspect config/auth before changing weights."
-      provider_key top_count
+      "Provider %s has repeated the same failure fingerprint %d times; inspect \
+       config/auth before changing weights."
+      provider_key
+      top_count
   | Investigate ->
     Printf.sprintf
-      "Provider %s has very low trust %.2f across %d recent events; inspect quota/auth before disabling it."
-      provider_key trust_score events
+      "Provider %s has very low trust %.2f across %d recent events; inspect quota/auth \
+       before disabling it."
+      provider_key
+      trust_score
+      events
   | Disable ->
     Printf.sprintf
-      "Provider %s trust %.2f is below 0.10 after %d recent events; disable until recovery is confirmed."
-      provider_key trust_score events
+      "Provider %s trust %.2f is below 0.10 after %d recent events; disable until \
+       recovery is confirmed."
+      provider_key
+      trust_score
+      events
   | Reduce_weight ->
     Printf.sprintf
-      "Provider %s trust %.2f is below 0.30; reduce its routing weight while monitoring recovery."
-      provider_key trust_score
+      "Provider %s trust %.2f is below 0.30; reduce its routing weight while monitoring \
+       recovery."
+      provider_key
+      trust_score
+;;
 
 (* Classifier — see RFC-0009 §"Phase 2a".
 
    The provider_info record no longer stores a raw [trust_score], so this
    derives it from the live tracker snapshot using [Cascade_trust.trust_score].
    Recommendations stay observation-only: this module never mutates config. *)
-let classify_recommendation (info : Health.provider_info) :
-    recommendation option =
-  if info.events_in_window <= 0 then None
-  else
+let classify_recommendation (info : Health.provider_info) : recommendation option =
+  if info.events_in_window <= 0
+  then None
+  else (
     let trust_score = Cascade_trust.trust_score info in
     let top_fingerprint, same_fingerprint_count =
       match top_failure_fingerprint info with
@@ -638,16 +654,17 @@ let classify_recommendation (info : Health.provider_info) :
        recommendation responsive to the live signal without losing
        the stuck-fingerprint detection it was built for. *)
     let stuck_fingerprint =
-      same_fingerprint_count >= 5
-      && info.events_in_window >= 5
-      && trust_score < 0.50
+      same_fingerprint_count >= 5 && info.events_in_window >= 5 && trust_score < 0.50
     in
     let action =
-      if stuck_fingerprint then Some Investigate
-      else if trust_score < 0.10 && info.events_in_window >= 30 then
-        Some Investigate
-      else if trust_score < 0.10 then Some Disable
-      else if trust_score < 0.30 then Some Reduce_weight
+      if stuck_fingerprint
+      then Some Investigate
+      else if trust_score < 0.10 && info.events_in_window >= 30
+      then Some Investigate
+      else if trust_score < 0.10
+      then Some Disable
+      else if trust_score < 0.30
+      then Some Reduce_weight
       else None
     in
     match action with
@@ -661,35 +678,39 @@ let classify_recommendation (info : Health.provider_info) :
         ; rec_top_fingerprint = top_fingerprint
         ; rec_action
         ; rec_rationale =
-            recommendation_rationale ~provider_key:info.provider_key
-              ~trust_score ~events:info.events_in_window
-              ~top_count:same_fingerprint_count rec_action
-        }
+            recommendation_rationale
+              ~provider_key:info.provider_key
+              ~trust_score
+              ~events:info.events_in_window
+              ~top_count:same_fingerprint_count
+              rec_action
+        })
+;;
 
-let low_trust_recommendations (infos : Health.provider_info list) :
-    recommendation list =
+let low_trust_recommendations (infos : Health.provider_info list) : recommendation list =
   List.filter_map classify_recommendation infos
-  |> List.sort (fun a b ->
-      Float.compare a.rec_trust_score b.rec_trust_score)
+  |> List.sort (fun a b -> Float.compare a.rec_trust_score b.rec_trust_score)
+;;
 
 let recommendation_to_json (r : recommendation) : Yojson.Safe.t =
   `Assoc
-    [ ("provider_key", `String r.rec_provider_key)
-    ; ("trust_score", `Float r.rec_trust_score)
-    ; ("same_fingerprint_count", `Int r.rec_same_fingerprint_count)
-    ; ("events_in_window", `Int r.rec_events_in_window)
+    [ "provider_key", `String r.rec_provider_key
+    ; "trust_score", `Float r.rec_trust_score
+    ; "same_fingerprint_count", `Int r.rec_same_fingerprint_count
+    ; "events_in_window", `Int r.rec_events_in_window
     ; ( "top_fingerprint"
       , match r.rec_top_fingerprint with
         | Some fp -> `String fp
         | None -> `Null )
-    ; ("action", `String (recommendation_action_to_string r.rec_action))
-    ; ("rationale", `String r.rec_rationale)
+    ; "action", `String (recommendation_action_to_string r.rec_action)
+    ; "rationale", `String r.rec_rationale
     ]
+;;
 
 let recommendations_json () : Yojson.Safe.t =
   let infos = Health.all_providers Health.global in
-  `List
-    (List.map recommendation_to_json (low_trust_recommendations infos))
+  `List (List.map recommendation_to_json (low_trust_recommendations infos))
+;;
 
 (** [provider_scheme_of_model_string s] returns the text before the first
     [:] in [s], or [s] itself if no colon is present.  The scheme
@@ -701,6 +722,7 @@ let provider_scheme_of_model_string (s : string) : string =
   match String.index_opt s ':' with
   | Some i -> String.sub s 0 i
   | None -> s
+;;
 
 (** Collect the set of provider scheme prefixes declared by any cascade
     profile in [config_path].  Reads the typed catalog (so invalid
@@ -708,8 +730,7 @@ let provider_scheme_of_model_string (s : string) : string =
     are swallowed into an empty set — a missing/malformed [cascade.json]
     is already surfaced by [config_json]; we do not want the health
     endpoint to disappear just because the catalog loader fails. *)
-let declared_provider_schemes_set
-    ?(config_path : string option) () : StringSet.t =
+let declared_provider_schemes_set ?(config_path : string option) () : StringSet.t =
   match config_path with
   | None -> StringSet.empty
   | Some path ->
@@ -719,14 +740,15 @@ let declared_provider_schemes_set
        List.fold_left
          (fun acc (entry : Cascade_config_loader.catalog_entry) ->
             let models =
-              Cascade_config_loader.load_profile
-                ~config_path:path ~name:entry.name
+              Cascade_config_loader.load_profile ~config_path:path ~name:entry.name
             in
             List.fold_left
-              (fun acc m ->
-                 StringSet.add (provider_scheme_of_model_string m) acc)
-              acc models)
-         StringSet.empty entries)
+              (fun acc m -> StringSet.add (provider_scheme_of_model_string m) acc)
+              acc
+              models)
+         StringSet.empty
+         entries)
+;;
 
 (** Public list version of {!declared_provider_schemes_set}.  Sorted and
     deduplicated for stable dashboard rendering and easy test assertions
@@ -734,6 +756,7 @@ let declared_provider_schemes_set
     .mli boundary. *)
 let declared_provider_schemes_of_config ?config_path () : string list =
   StringSet.elements (declared_provider_schemes_set ?config_path ())
+;;
 
 (** When [?base_path] is supplied, [health_json] augments each provider
     entry with performance fields (see {!provider_entry_to_json}) sourced
@@ -746,16 +769,15 @@ let declared_provider_schemes_of_config ?config_path () : string list =
     Errors from the aggregator (corrupt jsonl, missing directory) are
     caught and the perf fields fall back to [null]; a broken log must
     not take down the dashboard. *)
-let health_json ?(window_minutes = 30)
-    ?(base_path : string option) () =
+let health_json ?(window_minutes = 30) ?(base_path : string option) () =
   let config_path = Cascade_runtime.cascade_config_path () in
   let declared = declared_provider_schemes_set ?config_path () in
   let tracked = Health.all_providers Health.global in
   let tracked_keys =
     List.fold_left
-      (fun acc (p : Health.provider_info) ->
-        StringSet.add p.provider_key acc)
-      StringSet.empty tracked
+      (fun acc (p : Health.provider_info) -> StringSet.add p.provider_key acc)
+      StringSet.empty
+      tracked
   in
   let perf_by_provider : (string, Model_inference_metrics.provider_stats) Hashtbl.t =
     Hashtbl.create 8
@@ -764,9 +786,7 @@ let health_json ?(window_minutes = 30)
    | None -> ()
    | Some base_path ->
      (try
-        let agg =
-          Model_inference_metrics.compute ~base_path ~window_minutes
-        in
+        let agg = Model_inference_metrics.compute ~base_path ~window_minutes in
         let rollup = Model_inference_metrics.provider_rollup agg in
         List.iter
           (fun (s : Model_inference_metrics.provider_stats) ->
@@ -786,48 +806,50 @@ let health_json ?(window_minutes = 30)
   let tracked_entries =
     List.map
       (fun (info : Health.provider_info) ->
-        provider_entry_to_json
-          ~declared:(StringSet.mem info.provider_key declared)
-          ?perf:(perf_for info.provider_key)
-          info)
+         provider_entry_to_json
+           ~declared:(StringSet.mem info.provider_key declared)
+           ?perf:(perf_for info.provider_key)
+           info)
       tracked
   in
   let declared_only = StringSet.diff declared tracked_keys in
   let untouched_entries =
     StringSet.fold
       (fun key acc ->
-        provider_entry_to_json ~declared:true
-          ?perf:(perf_for key)
-          (zero_provider_info key)
-        :: acc)
-      declared_only []
+         provider_entry_to_json
+           ~declared:true
+           ?perf:(perf_for key)
+           (zero_provider_info key)
+         :: acc)
+      declared_only
+      []
   in
-  `Assoc [
-    ("updated_at", `String (now_iso ()));
-    (* Health tracker is the SSOT for these values; reading env here would
+  `Assoc
+    [ "updated_at", `String (now_iso ())
+    ; (* Health tracker is the SSOT for these values; reading env here would
        diverge from what the tracker actually applied (e.g. if the operator
        sets a malformed value that falls back to the default, the tracker
        has the fallback but a second env read would pick up the malformed
        string). *)
-    ("window_sec", `Float Health.window_sec);
-    ("cooldown_threshold", `Int Health.cooldown_threshold);
-    ("cooldown_sec", `Float Health.cooldown_sec);
-    ("hard_quota_cooldown_sec", `Float Health.hard_quota_cooldown_sec);
-    ("perf_window_minutes",
-     match base_path with
-     | Some _ -> `Int window_minutes
-     | None -> `Null);
-    ("providers", `List (tracked_entries @ untouched_entries));
-    (* Phase 2a: low-trust recommendations attached to health_json so
+      "window_sec", `Float Health.window_sec
+    ; "cooldown_threshold", `Int Health.cooldown_threshold
+    ; "cooldown_sec", `Float Health.cooldown_sec
+    ; "hard_quota_cooldown_sec", `Float Health.hard_quota_cooldown_sec
+    ; ( "perf_window_minutes"
+      , match base_path with
+        | Some _ -> `Int window_minutes
+        | None -> `Null )
+    ; "providers", `List (tracked_entries @ untouched_entries)
+    ; (* Phase 2a: low-trust recommendations attached to health_json so
        operators can see action items next to the raw trust scores.
        The recommendation list reads the same [Health.global] snapshot
        that produced [tracked] above; we recompute from [tracked] rather
        than re-scanning the tracker so both views are temporally
        consistent under concurrent updates. *)
-    ("recommendations",
-     `List (List.map recommendation_to_json
-              (low_trust_recommendations tracked)));
-  ]
+      ( "recommendations"
+      , `List (List.map recommendation_to_json (low_trust_recommendations tracked)) )
+    ]
+;;
 
 (* ── Client capacity projection ─────────────────────── *)
 
@@ -840,19 +862,24 @@ let health_json ?(window_minutes = 30)
     spot surprise registrations (e.g. a manually-registered HTTP
     slot). *)
 let classify_capacity_key url =
-  if Masc_network_defaults.is_cli_sentinel_url url then "cli"
-  else if Masc_network_defaults.is_ollama_url url then "ollama"
+  if Masc_network_defaults.is_cli_sentinel_url url
+  then "cli"
+  else if Masc_network_defaults.is_ollama_url url
+  then "ollama"
   else "other"
+;;
 
-let client_capacity_entry_to_json (url, info : string * Cascade_throttle.capacity_info)
-  : Yojson.Safe.t =
-  `Assoc [
-    ("key", `String url);
-    ("kind", `String (classify_capacity_key url));
-    ("total", `Int info.total);
-    ("active", `Int info.process_active);
-    ("available", `Int info.process_available);
-  ]
+let client_capacity_entry_to_json ((url, info) : string * Cascade_throttle.capacity_info)
+  : Yojson.Safe.t
+  =
+  `Assoc
+    [ "key", `String url
+    ; "kind", `String (classify_capacity_key url)
+    ; "total", `Int info.total
+    ; "active", `Int info.process_active
+    ; "available", `Int info.process_available
+    ]
+;;
 
 let client_capacity_json () =
   let entries = Cascade_client_capacity.snapshot () in
@@ -869,10 +896,11 @@ let client_capacity_json () =
          | n -> n)
       entries
   in
-  `Assoc [
-    ("updated_at", `String (now_iso ()));
-    ("entries", `List (List.map client_capacity_entry_to_json sorted));
-  ]
+  `Assoc
+    [ "updated_at", `String (now_iso ())
+    ; "entries", `List (List.map client_capacity_entry_to_json sorted)
+    ]
+;;
 
 (* ── Client capacity history projection ─────────────────── *)
 
@@ -880,57 +908,59 @@ let event_kind_to_string = function
   | Cascade_client_capacity_history.Acquired -> "acquired"
   | Released -> "released"
   | Rejected_full -> "rejected_full"
+;;
 
-let history_event_to_json (ev : Cascade_client_capacity_history.event)
-  : Yojson.Safe.t =
-  `Assoc [
-    ("ts", `Float ev.ts);
-    ("key", `String ev.key);
-    ("kind", `String (event_kind_to_string ev.kind));
-    ("active_after", `Int ev.active_after);
-  ]
+let history_event_to_json (ev : Cascade_client_capacity_history.event) : Yojson.Safe.t =
+  `Assoc
+    [ "ts", `Float ev.ts
+    ; "key", `String ev.key
+    ; "kind", `String (event_kind_to_string ev.kind)
+    ; "active_after", `Int ev.active_after
+    ]
+;;
 
 let client_capacity_history_json ?limit ?kind ?since_ts () =
-  let events =
-    Cascade_client_capacity_history.snapshot ?limit ?kind ?since_ts ()
-  in
-  `Assoc [
-    ("updated_at", `String (now_iso ()));
-    ("total_events", `Int (List.length events));
-    ("events", `List (List.map history_event_to_json events));
-  ]
+  let events = Cascade_client_capacity_history.snapshot ?limit ?kind ?since_ts () in
+  `Assoc
+    [ "updated_at", `String (now_iso ())
+    ; "total_events", `Int (List.length events)
+    ; "events", `List (List.map history_event_to_json events)
+    ]
+;;
 
-let strategy_trace_event_to_json (ev : Cascade_strategy_trace.event)
-  : Yojson.Safe.t =
-  let opt_float = function Some f -> `Float f | None -> `Null in
-  let cascade_name =
-    Keeper_cascade_profile.runtime_name_to_string ev.cascade_name
+let strategy_trace_event_to_json (ev : Cascade_strategy_trace.event) : Yojson.Safe.t =
+  let opt_float = function
+    | Some f -> `Float f
+    | None -> `Null
   in
+  let cascade_name = Keeper_cascade_profile.runtime_name_to_string ev.cascade_name in
   let trace_id_json =
     match ev.trace_id with
     | None -> `Null
     | Some id -> `String id
   in
-  `Assoc [
-    ("ts", `Float ev.ts);
-    ("cascade_name", `String cascade_name);
-    ("strategy", `String ev.strategy);
-    ("cycle", `Int ev.cycle);
-    ("candidates_in", `Int ev.candidates_in);
-    ("candidates_out", `Int ev.candidates_out);
-    ("backoff_ms", `Int ev.backoff_ms);
-    ("kind", `String (Cascade_strategy_trace.kind_to_string ev.kind));
-    ("trace_id", trace_id_json);
-    ("confidence_score", opt_float ev.confidence_score);
-  ]
+  `Assoc
+    [ "ts", `Float ev.ts
+    ; "cascade_name", `String cascade_name
+    ; "strategy", `String ev.strategy
+    ; "cycle", `Int ev.cycle
+    ; "candidates_in", `Int ev.candidates_in
+    ; "candidates_out", `Int ev.candidates_out
+    ; "backoff_ms", `Int ev.backoff_ms
+    ; "kind", `String (Cascade_strategy_trace.kind_to_string ev.kind)
+    ; "trace_id", trace_id_json
+    ; "confidence_score", opt_float ev.confidence_score
+    ]
+;;
 
 let strategy_trace_json ?limit ?cascade () =
   let events = Cascade_strategy_trace.snapshot ?limit ?cascade () in
-  `Assoc [
-    ("updated_at", `String (now_iso ()));
-    ("total_events", `Int (List.length events));
-    ("events", `List (List.map strategy_trace_event_to_json events));
-  ]
+  `Assoc
+    [ "updated_at", `String (now_iso ())
+    ; "total_events", `Int (List.length events)
+    ; "events", `List (List.map strategy_trace_event_to_json events)
+    ]
+;;
 
 (* ── Cascade inspector projection (O1) ─────────────────────────────
 
@@ -944,71 +974,80 @@ let json_string_member key json =
   match json_assoc_member key json with
   | `String value -> Some value
   | _ -> None
+;;
 
 let json_float_member key json =
   match json_assoc_member key json with
   | `Float value -> Some value
   | `Int value -> Some (float_of_int value)
   | _ -> None
+;;
 
 let json_int_member key json =
   match json_assoc_member key json with
   | `Int value -> Some value
   | `Float value -> Some (int_of_float value)
   | _ -> None
+;;
 
 let json_list_member key json =
   match json_assoc_member key json with
   | `List values -> values
   | _ -> []
+;;
 
 let nonempty_string value =
   match value with
   | Some raw ->
-      let trimmed = String.trim raw in
-      if String.equal trimmed "" then None else Some trimmed
+    let trimmed = String.trim raw in
+    if String.equal trimmed "" then None else Some trimmed
   | None -> None
+;;
 
-let first_nonempty values =
-  List.find_map nonempty_string values
-
-let json_string_opt_member key json =
-  json_string_member key json |> nonempty_string
+let first_nonempty values = List.find_map nonempty_string values
+let json_string_opt_member key json = json_string_member key json |> nonempty_string
 
 let audit_store_dir ~base_path =
-  Filename.concat
-    (Common.masc_dir_from_base_path ~base_path)
-    "cascade_audit"
+  Filename.concat (Common.masc_dir_from_base_path ~base_path) "cascade_audit"
+;;
 
 let cascade_audit_store ~base_path =
   Dated_jsonl.create ~base_dir:(audit_store_dir ~base_path) ()
+;;
 
 let stable_audit_run_id json =
-  "cascade-audit-" ^ String.sub (Digest.to_hex (Digest.string (Yojson.Safe.to_string json))) 0 16
+  "cascade-audit-"
+  ^ String.sub (Digest.to_hex (Digest.string (Yojson.Safe.to_string json))) 0 16
+;;
 
 let model_display_of_attempt attempt =
   first_nonempty
-    [
-      json_string_member "model_label" attempt;
-      json_string_member "model_id" attempt;
-    ]
+    [ json_string_member "model_label" attempt; json_string_member "model_id" attempt ]
   |> Option.value ~default:"unknown"
+;;
 
 let fallback_reason_for_model ~model_id ~model_label fallback_events =
   let matches value =
     match nonempty_string value with
     | None -> false
     | Some value ->
-        (match model_id with Some id -> String.equal value id | None -> false)
-        || (match model_label with Some label -> String.equal value label | None -> false)
+      (match model_id with
+       | Some id -> String.equal value id
+       | None -> false)
+      ||
+        (match model_label with
+        | Some label -> String.equal value label
+        | None -> false)
   in
   List.find_map
     (fun event ->
-      if matches (json_string_member "from_model_id" event)
+       if
+         matches (json_string_member "from_model_id" event)
          || matches (json_string_member "from_model_label" event)
-      then json_string_opt_member "reason" event
-      else None)
+       then json_string_opt_member "reason" event
+       else None)
     fallback_events
+;;
 
 let audit_hop_json ~selected_model ~fallback_events attempt =
   let model_id = json_string_opt_member "model_id" attempt in
@@ -1024,9 +1063,14 @@ let audit_hop_json ~selected_model ~fallback_events attempt =
   let selected =
     match selected_model with
     | Some selected ->
-        String.equal selected model
-        || (match model_id with Some id -> String.equal selected id | None -> false)
-        || (match model_label with Some label -> String.equal selected label | None -> false)
+      String.equal selected model
+      || (match model_id with
+          | Some id -> String.equal selected id
+          | None -> false)
+      ||
+        (match model_label with
+        | Some label -> String.equal selected label
+        | None -> false)
     | None -> false
   in
   let status =
@@ -1037,35 +1081,43 @@ let audit_hop_json ~selected_model ~fallback_events attempt =
     | None, None, _ -> "attempted"
   in
   let base =
-    [
-      ("i", `Int (Option.value ~default:0 (json_int_member "attempt_index" attempt)));
-      ("model", `String model);
-      ("status", `String status);
-      ("ms", `Int (Option.value ~default:0 latency_ms));
-      ("ms_source",
-       `String (if Option.is_some latency_ms then "oas_metrics_callbacks" else "unavailable"));
+    [ "i", `Int (Option.value ~default:0 (json_int_member "attempt_index" attempt))
+    ; "model", `String model
+    ; "status", `String status
+    ; "ms", `Int (Option.value ~default:0 latency_ms)
+    ; ( "ms_source"
+      , `String
+          (if Option.is_some latency_ms then "oas_metrics_callbacks" else "unavailable") )
     ]
   in
   let fields =
     match reason with
-    | Some value -> base @ [("reason", `String value)]
+    | Some value -> base @ [ "reason", `String value ]
     | None -> base
   in
   `Assoc fields
+;;
 
 let attempt_latency_total attempts =
   List.fold_left
     (fun acc attempt ->
-      acc + Option.value ~default:0 (json_int_member "latency_ms" attempt))
-    0 attempts
+       acc + Option.value ~default:0 (json_int_member "latency_ms" attempt))
+    0
+    attempts
+;;
 
 let last_attempt_error attempts =
   List.rev attempts |> List.find_map (json_string_opt_member "error")
+;;
 
 let audit_run_json_of_record json =
   let observation = json_assoc_member "observation" json in
-  let configured_labels = json_string_list (json_assoc_member "configured_labels" observation) in
-  let candidate_models = json_string_list (json_assoc_member "candidate_models" observation) in
+  let configured_labels =
+    json_string_list (json_assoc_member "configured_labels" observation)
+  in
+  let candidate_models =
+    json_string_list (json_assoc_member "candidate_models" observation)
+  in
   let configured =
     match configured_labels with
     | [] -> candidate_models
@@ -1075,24 +1127,21 @@ let audit_run_json_of_record json =
   let fallback_events = json_list_member "fallback_events" observation in
   let selected =
     first_nonempty
-      [
-        json_string_member "selected_model" observation;
-        json_string_member "selected_model_raw" observation;
+      [ json_string_member "selected_model" observation
+      ; json_string_member "selected_model_raw" observation
       ]
   in
   let primary =
     first_nonempty
-      [
-        json_string_member "primary_model" observation;
-        List.nth_opt configured 0;
-        List.nth_opt candidate_models 0;
+      [ json_string_member "primary_model" observation
+      ; List.nth_opt configured 0
+      ; List.nth_opt candidate_models 0
       ]
   in
   let cascade =
     first_nonempty
-      [
-        json_string_member "cascade_name" json;
-        json_string_member "cascade_name" observation;
+      [ json_string_member "cascade_name" json
+      ; json_string_member "cascade_name" observation
       ]
     |> Option.value ~default:"unknown"
   in
@@ -1104,43 +1153,47 @@ let audit_run_json_of_record json =
     | None -> last_attempt_error attempts
   in
   let base =
-    [
-      ("id", `String (stable_audit_run_id json));
-      ("cascade", `String cascade);
-      ( "trigger",
-        `String
-          (json_string_opt_member "keeper_name" json
-           |> Option.value ~default:"unknown") );
-      ("at", `Float ts);
-      ( "outcome",
-        `String
-          (json_string_member "outcome" json |> Option.value ~default:"unknown") );
-      ("configured", `List (List.map (fun value -> `String value) configured));
-      ("primary", Json_util.string_opt_to_json primary);
-      ("selected", Json_util.string_opt_to_json selected);
-      ("total_ms", `Int (attempt_latency_total attempts));
-      ( "total_ms_source",
-        `String
-          (if List.exists (fun attempt -> Option.is_some (json_int_member "latency_ms" attempt)) attempts
+    [ "id", `String (stable_audit_run_id json)
+    ; "cascade", `String cascade
+    ; ( "trigger"
+      , `String
+          (json_string_opt_member "keeper_name" json |> Option.value ~default:"unknown") )
+    ; "at", `Float ts
+    ; ( "outcome"
+      , `String (json_string_member "outcome" json |> Option.value ~default:"unknown") )
+    ; "configured", `List (List.map (fun value -> `String value) configured)
+    ; "primary", Json_util.string_opt_to_json primary
+    ; "selected", Json_util.string_opt_to_json selected
+    ; "total_ms", `Int (attempt_latency_total attempts)
+    ; ( "total_ms_source"
+      , `String
+          (if
+             List.exists
+               (fun attempt -> Option.is_some (json_int_member "latency_ms" attempt))
+               attempts
            then "attempt_latency_sum"
-           else "unavailable") );
-      ("hops", `List (List.map (audit_hop_json ~selected_model:selected ~fallback_events) attempts));
+           else "unavailable") )
+    ; ( "hops"
+      , `List
+          (List.map (audit_hop_json ~selected_model:selected ~fallback_events) attempts) )
     ]
   in
   let fields =
     match error_category with
-    | Some value -> base @ [("error_category", `String value)]
+    | Some value -> base @ [ "error_category", `String value ]
     | None -> base
   in
   `Assoc fields
+;;
 
 let audit_run_cascade_matches cascade_filter run =
   match cascade_filter with
   | None -> true
   | Some expected ->
-      (match json_string_member "cascade" run with
-      | Some actual -> String.equal actual expected
-      | None -> false)
+    (match json_string_member "cascade" run with
+     | Some actual -> String.equal actual expected
+     | None -> false)
+;;
 
 let audit_runs_json ~base_path ?limit ?cascade () =
   let limit = Option.value ~default:100 limit |> max 1 |> min 1024 in
@@ -1157,11 +1210,12 @@ let audit_runs_json ~base_path ?limit ?cascade () =
     | x :: xs -> x :: take (n - 1) xs
   in
   let runs = take limit runs in
-  `Assoc [
-    ("updated_at", `String (now_iso ()));
-    ("total_runs", `Int (List.length runs));
-    ("audit_runs", `List runs);
-  ]
+  `Assoc
+    [ "updated_at", `String (now_iso ())
+    ; "total_runs", `Int (List.length runs)
+    ; "audit_runs", `List runs
+    ]
+;;
 
 (* ── SLO projection (LT-11) ─────────────────────────────────
 
@@ -1178,50 +1232,55 @@ let compute_slo_counts (events : Cascade_strategy_trace.event list) =
   List.fold_left
     (fun (total, ordered, exhausted) (ev : Cascade_strategy_trace.event) ->
        match ev.kind with
-       | Ordered -> (total + 1, ordered + 1, exhausted)
-       | Filtered_empty -> (total + 1, ordered, exhausted)
-       | Exhausted -> (total + 1, ordered, exhausted + 1))
-    (0, 0, 0) events
+       | Ordered -> total + 1, ordered + 1, exhausted
+       | Filtered_empty -> total + 1, ordered, exhausted
+       | Exhausted -> total + 1, ordered, exhausted + 1)
+    (0, 0, 0)
+    events
+;;
 
 let slo_json () =
   let events = Cascade_strategy_trace.snapshot ~limit:slo_sample_limit () in
   let total, ordered, exhausted = compute_slo_counts events in
   let ordered_ratio =
-    if total = 0 then 1.0
-    else Stdlib.Float.of_int ordered /. Stdlib.Float.of_int total
+    if total = 0 then 1.0 else Stdlib.Float.of_int ordered /. Stdlib.Float.of_int total
   in
   let burn_rate = (1.0 -. ordered_ratio) /. 0.01 in
   let ratio_violated = Stdlib.Float.compare ordered_ratio slo_target_ordered_ratio < 0 in
   let exhaustion_violated = exhausted > slo_target_exhaustion_count in
   let burn_violated = Stdlib.Float.compare burn_rate slo_target_burn_rate > 0 in
   let violations =
-    List.filter_map (fun (name, violated) ->
-      if violated then Some (`String name) else None)
-      [
-        "ordered_ratio", ratio_violated;
-        "exhaustion_count", exhaustion_violated;
-        "burn_rate", burn_violated;
+    List.filter_map
+      (fun (name, violated) -> if violated then Some (`String name) else None)
+      [ "ordered_ratio", ratio_violated
+      ; "exhaustion_count", exhaustion_violated
+      ; "burn_rate", burn_violated
       ]
   in
   let status =
-    if ratio_violated || exhaustion_violated then "violated"
-    else if burn_violated then "warn"
+    if ratio_violated || exhaustion_violated
+    then "violated"
+    else if burn_violated
+    then "warn"
     else "ok"
   in
-  `Assoc [
-    "updated_at", `String (now_iso ());
-    "window_sample_size", `Int slo_sample_limit;
-    "targets", `Assoc [
-      "ordered_ratio_min", `Float slo_target_ordered_ratio;
-      "exhaustion_count_max", `Int slo_target_exhaustion_count;
-      "burn_rate_max", `Float slo_target_burn_rate;
-    ];
-    "current", `Assoc [
-      "ordered_ratio", `Float ordered_ratio;
-      "exhaustion_count", `Int exhausted;
-      "burn_rate", `Float burn_rate;
-      "total_events", `Int total;
-    ];
-    "status", `String status;
-    "violations", `List violations;
-  ]
+  `Assoc
+    [ "updated_at", `String (now_iso ())
+    ; "window_sample_size", `Int slo_sample_limit
+    ; ( "targets"
+      , `Assoc
+          [ "ordered_ratio_min", `Float slo_target_ordered_ratio
+          ; "exhaustion_count_max", `Int slo_target_exhaustion_count
+          ; "burn_rate_max", `Float slo_target_burn_rate
+          ] )
+    ; ( "current"
+      , `Assoc
+          [ "ordered_ratio", `Float ordered_ratio
+          ; "exhaustion_count", `Int exhausted
+          ; "burn_rate", `Float burn_rate
+          ; "total_events", `Int total
+          ] )
+    ; "status", `String status
+    ; "violations", `List violations
+    ]
+;;

--- a/lib/dashboard_cascade.ml
+++ b/lib/dashboard_cascade.ml
@@ -253,7 +253,7 @@ let config_json () =
     with
     | Eio.Cancel.Cancelled _ as e -> raise e
     | exn ->
-      Log.Core.warn
+      Log.Keeper.warn
         "dashboard_cascade: offline_keepers_json failed: %s"
         (Printexc.to_string exn);
       []

--- a/lib/dashboard_cascade.ml
+++ b/lib/dashboard_cascade.ml
@@ -228,7 +228,12 @@ let config_json () =
        initialised). *)
     try Keeper_registry.all () with
     | Eio.Cancel.Cancelled _ as e -> raise e
-    | _ -> []
+    | exn ->
+      Log.Keeper.warn
+        "dashboard_cascade.config_json: Keeper_registry.all failed (treating \
+         as empty): %s"
+        (Printexc.to_string exn);
+      []
   in
   let active_names =
     List.fold_left

--- a/lib/keeper/keeper_admission_runtime.ml
+++ b/lib/keeper/keeper_admission_runtime.ml
@@ -65,7 +65,9 @@ let read_provider_rate_config ~provider json =
   | Eio.Cancel.Cancelled _ as e -> raise e
   | exn ->
     Log.Keeper.warn
-      "keeper_admission_runtime: admission config parse failed: %s"
+      "keeper_admission_runtime: admission.provider_rates parse failed for \
+       provider=%s: %s"
+      provider
       (Printexc.to_string exn);
     None
 ;;

--- a/lib/keeper/keeper_admission_runtime.ml
+++ b/lib/keeper/keeper_admission_runtime.ml
@@ -107,39 +107,6 @@ let make_lazy_bucket_lookup ~cascade_json_opt () =
         Some b)
 ;;
 
-let make_lazy_bucket_lookup ~cascade_json_opt () =
-  let table : (string, Keeper_provider_token_bucket.t) Hashtbl.t = Hashtbl.create 16 in
-  let table_mutex = Stdlib.Mutex.create () in
-  fun provider ->
-    Stdlib.Mutex.protect table_mutex (fun () ->
-      match Hashtbl.find_opt table provider with
-      | Some b -> Some b
-      | None ->
-        let capacity, refill_rate =
-          match cascade_json_opt with
-          | Some json ->
-            (match read_provider_rate_config ~provider json with
-             | Some (c, r) -> c, r
-             | None -> default_bucket_capacity, default_bucket_refill_rate)
-          | None -> default_bucket_capacity, default_bucket_refill_rate
-        in
-        let b =
-          Keeper_provider_token_bucket.create ~provider ~capacity ~refill_rate ~now
-        in
-        (* Register WFQ wake hook: when this provider's bucket refills
-             from < 1.0 to >= 1.0, try to wake one waiting keeper. *)
-        Keeper_provider_token_bucket.add_on_refill b (fun () ->
-          match Keeper_wfq_overflow.wake_one wfq_queue with
-          | None -> ()
-          | Some _entry ->
-            (* Woken keeper will be reconsidered on its next heartbeat
-                   tick; we do NOT synchronously dispatch here to avoid
-                   nested admission decisions inside the refill callback. *)
-            ());
-        Hashtbl.add table provider b;
-        Some b)
-;;
-
 (* Try to claim the init slot.  Returns [true] if this fiber should
    run the load now; [false] if another fiber is already running or
    has already finished.  Mutex is held only for the state read and

--- a/lib/keeper/keeper_admission_runtime.ml
+++ b/lib/keeper/keeper_admission_runtime.ml
@@ -13,8 +13,11 @@ let wfq_queue : Keeper_wfq_overflow.t = Keeper_wfq_overflow.create ()
    release/acquire semantics we want for cross-fiber callback swaps. *)
 let policy_lookup_ref : Keeper_admission_glue.policy_lookup Atomic.t =
   Atomic.make no_policy
+;;
+
 let bucket_lookup_ref : Keeper_admission_router.bucket_lookup Atomic.t =
   Atomic.make no_bucket
+;;
 
 (* Three-state init flag.  We hold [init_mutex] only while transitioning
    between states — never across the file I/O step.
@@ -24,10 +27,13 @@ let bucket_lookup_ref : Keeper_admission_router.bucket_lookup Atomic.t =
                    fibers see this and skip without blocking.
      Done      : registry installed (or load failed and we logged).
                  Subsequent calls are no-ops. *)
-type init_state = Idle | In_progress | Done
+type init_state =
+  | Idle
+  | In_progress
+  | Done
+
 let init_mutex = Stdlib.Mutex.create ()
 let init_state = ref Idle
-
 let set_policy_lookup f = Atomic.set policy_lookup_ref f
 let set_bucket_lookup f = Atomic.set bucket_lookup_ref f
 
@@ -45,93 +51,92 @@ let read_provider_rate_config ~provider json =
     let rates = member "admission" json |> member "provider_rates" in
     let provider_obj = member provider rates in
     let capacity =
-      member "capacity" provider_obj |> to_int_option
+      member "capacity" provider_obj
+      |> to_int_option
       |> Option.value ~default:default_bucket_capacity
     in
     let refill_rate =
-      member "refill_rate" provider_obj |> to_float_option
+      member "refill_rate" provider_obj
+      |> to_float_option
       |> Option.value ~default:default_bucket_refill_rate
     in
     Some (capacity, refill_rate)
-  with _ -> None
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | exn ->
+    Log.Keeper.warn
+      "keeper_admission_runtime: admission config parse failed: %s"
+      (Printexc.to_string exn);
+    None
+;;
 
 (* Build a lazy bucket lookup that reads per-provider rates from
    cascade.json when available. *)
 let make_lazy_bucket_lookup ~cascade_json_opt () =
-  let table : (string, Keeper_provider_token_bucket.t) Hashtbl.t =
-    Hashtbl.create 16
-  in
+  let table : (string, Keeper_provider_token_bucket.t) Hashtbl.t = Hashtbl.create 16 in
   let table_mutex = Stdlib.Mutex.create () in
   fun provider ->
     Stdlib.Mutex.protect table_mutex (fun () ->
       match Hashtbl.find_opt table provider with
       | Some b -> Some b
       | None ->
-          let capacity, refill_rate =
-            match cascade_json_opt with
-            | Some json ->
-                (match read_provider_rate_config ~provider json with
-                 | Some (c, r) -> (c, r)
-                 | None -> (default_bucket_capacity, default_bucket_refill_rate))
-            | None -> (default_bucket_capacity, default_bucket_refill_rate)
-          in
-          let b =
-            Keeper_provider_token_bucket.create
-              ~provider
-              ~capacity
-              ~refill_rate
-              ~now
-          in
-          (* Register WFQ wake hook: when this provider's bucket refills
+        let capacity, refill_rate =
+          match cascade_json_opt with
+          | Some json ->
+            (match read_provider_rate_config ~provider json with
+             | Some (c, r) -> c, r
+             | None -> default_bucket_capacity, default_bucket_refill_rate)
+          | None -> default_bucket_capacity, default_bucket_refill_rate
+        in
+        let b =
+          Keeper_provider_token_bucket.create ~provider ~capacity ~refill_rate ~now
+        in
+        (* Register WFQ wake hook: when this provider's bucket refills
              from < 1.0 to >= 1.0, try to wake one waiting keeper. *)
-          Keeper_provider_token_bucket.add_on_refill b (fun () ->
-            match Keeper_wfq_overflow.wake_one wfq_queue with
-            | None -> ()
-            | Some _entry ->
-                (* Woken keeper will be reconsidered on its next heartbeat
+        Keeper_provider_token_bucket.add_on_refill b (fun () ->
+          match Keeper_wfq_overflow.wake_one wfq_queue with
+          | None -> ()
+          | Some _entry ->
+            (* Woken keeper will be reconsidered on its next heartbeat
                    tick; we do NOT synchronously dispatch here to avoid
                    nested admission decisions inside the refill callback. *)
-                ());
-          Hashtbl.add table provider b;
-          Some b)
+            ());
+        Hashtbl.add table provider b;
+        Some b)
+;;
 
 let make_lazy_bucket_lookup ~cascade_json_opt () =
-  let table : (string, Keeper_provider_token_bucket.t) Hashtbl.t =
-    Hashtbl.create 16
-  in
+  let table : (string, Keeper_provider_token_bucket.t) Hashtbl.t = Hashtbl.create 16 in
   let table_mutex = Stdlib.Mutex.create () in
   fun provider ->
     Stdlib.Mutex.protect table_mutex (fun () ->
       match Hashtbl.find_opt table provider with
       | Some b -> Some b
       | None ->
-          let capacity, refill_rate =
-            match cascade_json_opt with
-            | Some json ->
-                (match read_provider_rate_config ~provider json with
-                 | Some (c, r) -> (c, r)
-                 | None -> (default_bucket_capacity, default_bucket_refill_rate))
-            | None -> (default_bucket_capacity, default_bucket_refill_rate)
-          in
-          let b =
-            Keeper_provider_token_bucket.create
-              ~provider
-              ~capacity
-              ~refill_rate
-              ~now
-          in
-          (* Register WFQ wake hook: when this provider's bucket refills
+        let capacity, refill_rate =
+          match cascade_json_opt with
+          | Some json ->
+            (match read_provider_rate_config ~provider json with
+             | Some (c, r) -> c, r
+             | None -> default_bucket_capacity, default_bucket_refill_rate)
+          | None -> default_bucket_capacity, default_bucket_refill_rate
+        in
+        let b =
+          Keeper_provider_token_bucket.create ~provider ~capacity ~refill_rate ~now
+        in
+        (* Register WFQ wake hook: when this provider's bucket refills
              from < 1.0 to >= 1.0, try to wake one waiting keeper. *)
-          Keeper_provider_token_bucket.add_on_refill b (fun () ->
-            match Keeper_wfq_overflow.wake_one wfq_queue with
-            | None -> ()
-            | Some _entry ->
-                (* Woken keeper will be reconsidered on its next heartbeat
+        Keeper_provider_token_bucket.add_on_refill b (fun () ->
+          match Keeper_wfq_overflow.wake_one wfq_queue with
+          | None -> ()
+          | Some _entry ->
+            (* Woken keeper will be reconsidered on its next heartbeat
                    tick; we do NOT synchronously dispatch here to avoid
                    nested admission decisions inside the refill callback. *)
-                ());
-          Hashtbl.add table provider b;
-          Some b)
+            ());
+        Hashtbl.add table provider b;
+        Some b)
+;;
 
 (* Try to claim the init slot.  Returns [true] if this fiber should
    run the load now; [false] if another fiber is already running or
@@ -143,63 +148,61 @@ let try_claim_init () =
     | Done -> false
     | In_progress -> false
     | Idle ->
-        init_state := In_progress;
-        true)
+      init_state := In_progress;
+      true)
+;;
 
-let mark_init_done () =
-  Stdlib.Mutex.protect init_mutex (fun () -> init_state := Done)
+let mark_init_done () = Stdlib.Mutex.protect init_mutex (fun () -> init_state := Done)
 
 (* Failure path: revert to Idle so a future heartbeat tick can retry.
    Without this, a transient I/O hiccup at startup would pin the
    process in legacy mode for its lifetime. *)
 let revert_init_to_idle () =
   Stdlib.Mutex.protect init_mutex (fun () -> init_state := Idle)
+;;
 
 let init_once_from_base_path ~base_path =
-  if not (try_claim_init ()) then ()
-  else begin
+  if not (try_claim_init ())
+  then ()
+  else (
     (* I/O outside the critical section.  [Cascade_config_loader.load_json]
        can call [Eio.traceln] and may block on disk — holding [init_mutex]
        across that risks domain-wide stalls of any other fiber that hits
        this code. *)
     let cascade_json_path =
-      Filename.concat (Filename.concat base_path ".masc/config")
-        "cascade.json"
+      Filename.concat (Filename.concat base_path ".masc/config") "cascade.json"
     in
     match Cascade_config_loader.load_json cascade_json_path with
     | Error msg ->
-        (* Transient or permanent read failure — leave registry empty,
+      (* Transient or permanent read failure — leave registry empty,
            revert to Idle so the next heartbeat tick can retry. *)
-        revert_init_to_idle ();
-        Log.Keeper.warn
-          "RFC-0026 PR-E-1.6: cascade.json load failed (%s); \
-           admission registry stays empty, observe will return \
-           Legacy_path (will retry on next tick)"
-          msg
+      revert_init_to_idle ();
+      Log.Keeper.warn
+        "RFC-0026 PR-E-1.6: cascade.json load failed (%s); admission registry stays \
+         empty, observe will return Legacy_path (will retry on next tick)"
+        msg
     | Ok json ->
-        let registry, errors =
-          Keeper_admission_registry.load_from_json json
-        in
-        List.iter
-          (fun (e : Keeper_admission_registry.load_error) ->
-            Log.Keeper.warn
-              "RFC-0026 PR-E-1.6: admission policy parse failed for \
-               keeper=%s"
-              e.keeper_id)
-          errors;
-        let registered = Keeper_admission_registry.size registry in
-        (* Install lookups via Atomic.set, then mark Done.  Order
+      let registry, errors = Keeper_admission_registry.load_from_json json in
+      List.iter
+        (fun (e : Keeper_admission_registry.load_error) ->
+           Log.Keeper.warn
+             "RFC-0026 PR-E-1.6: admission policy parse failed for keeper=%s"
+             e.keeper_id)
+        errors;
+      let registered = Keeper_admission_registry.size registry in
+      (* Install lookups via Atomic.set, then mark Done.  Order
            matters: a parallel fiber reading [policy_lookup] should
            never observe Done with the default [no_policy]. *)
-        set_policy_lookup (fun id ->
-          Keeper_admission_registry.lookup registry id);
-        set_bucket_lookup (make_lazy_bucket_lookup ~cascade_json_opt:(Some json) ());
-        mark_init_done ();
-        Log.Keeper.info
-          "RFC-0026 PR-E-1.6: admission runtime initialised \
-           (policies=%d, errors=%d, base_path=%s)"
-          registered (List.length errors) base_path
-  end
+      set_policy_lookup (fun id -> Keeper_admission_registry.lookup registry id);
+      set_bucket_lookup (make_lazy_bucket_lookup ~cascade_json_opt:(Some json) ());
+      mark_init_done ();
+      Log.Keeper.info
+        "RFC-0026 PR-E-1.6: admission runtime initialised (policies=%d, errors=%d, \
+         base_path=%s)"
+        registered
+        (List.length errors)
+        base_path)
+;;
 
 let policy_lookup keeper_id = (Atomic.get policy_lookup_ref) keeper_id
 let bucket_lookup provider = (Atomic.get bucket_lookup_ref) provider
@@ -208,10 +211,11 @@ let outcome_label (outcome : Keeper_admission_glue.outcome) : string =
   match outcome with
   | Keeper_admission_glue.Legacy_path -> "legacy"
   | Keeper_admission_glue.New_admission decision ->
-      (match decision with
-       | Keeper_admission_router.Dispatch _ -> "dispatch"
-       | Keeper_admission_router.Wait -> "wait"
-       | Keeper_admission_router.Surface _ -> "surface")
+    (match decision with
+     | Keeper_admission_router.Dispatch _ -> "dispatch"
+     | Keeper_admission_router.Wait -> "wait"
+     | Keeper_admission_router.Surface _ -> "surface")
+;;
 
 let observe ~keeper_id =
   (* Use [decide_shadow] (not [decide]): we want the would-be outcome
@@ -226,8 +230,10 @@ let observe ~keeper_id =
   in
   Prometheus.inc_counter
     Keeper_metrics.metric_keeper_admission_shadow_outcome
-    ~labels:[("keeper", keeper_id); ("outcome", outcome_label outcome)] ();
+    ~labels:[ "keeper", keeper_id; "outcome", outcome_label outcome ]
+    ();
   outcome
+;;
 
 (** Live admission decision (Phase A1).  Consumes tokens on Dispatch,
     enqueues on Wait, surfaces on Surface, falls through to legacy on
@@ -236,11 +242,11 @@ let observe ~keeper_id =
     Returns the decision + the acquired bucket (if Dispatch) so the
     caller can release it after the turn completes. *)
 type live_result =
-  | Live_dispatch of {
-      candidate : Keeper_admission_policy.candidate;
-      drift : Keeper_admission_router.drift_record;
-      bucket : Keeper_provider_token_bucket.t;
-    }
+  | Live_dispatch of
+      { candidate : Keeper_admission_policy.candidate
+      ; drift : Keeper_admission_router.drift_record
+      ; bucket : Keeper_provider_token_bucket.t
+      }
   | Live_wait
   | Live_surface of Keeper_admission_router.surface_reason
   | Live_legacy
@@ -250,54 +256,51 @@ let live_result_label = function
   | Live_wait -> "wait"
   | Live_surface _ -> "surface"
   | Live_legacy -> "legacy"
+;;
 
 let decide_live ~keeper_id =
   let outcome =
-    Keeper_admission_glue.decide
-      ~keeper_id
-      ~policies:policy_lookup
-      ~buckets:bucket_lookup
+    Keeper_admission_glue.decide ~keeper_id ~policies:policy_lookup ~buckets:bucket_lookup
   in
   Prometheus.inc_counter
     Keeper_metrics.metric_keeper_admission_shadow_outcome
-    ~labels:[("keeper", keeper_id); ("outcome", outcome_label outcome)] ();
+    ~labels:[ "keeper", keeper_id; "outcome", outcome_label outcome ]
+    ();
   match outcome with
   | Keeper_admission_glue.Legacy_path -> Live_legacy
   | Keeper_admission_glue.New_admission decision ->
-      (match decision with
-       | Keeper_admission_router.Dispatch { candidate; drift } ->
-           (* Look up the bucket again to return it for release. *)
-           (match bucket_lookup candidate.Keeper_admission_policy.provider with
-            | Some bucket -> Live_dispatch { candidate; drift; bucket }
-            | None ->
-                (* Should not happen: decide already acquired from this
+    (match decision with
+     | Keeper_admission_router.Dispatch { candidate; drift } ->
+       (* Look up the bucket again to return it for release. *)
+       (match bucket_lookup candidate.Keeper_admission_policy.provider with
+        | Some bucket -> Live_dispatch { candidate; drift; bucket }
+        | None ->
+          (* Should not happen: decide already acquired from this
                    bucket.  Fall back to legacy for safety. *)
-                Log.Keeper.warn
-                  "%s: admission dispatch bucket disappeared after acquire; \
-                   falling back to legacy"
-                  keeper_id;
-                Live_legacy)
-       | Keeper_admission_router.Wait ->
-           (* Enqueue in WFQ overflow for wake on refill. *)
-           let policy_opt = policy_lookup keeper_id in
-           let weight =
-             match policy_opt with
-             | Some p -> Keeper_admission_policy.weight p
-             | None -> 1
-           in
-           Keeper_wfq_overflow.enqueue wfq_queue
-             { keeper_id; weight; enqueued_at = now () };
-           Live_wait
-       | Keeper_admission_router.Surface reason -> Live_surface reason)
+          Log.Keeper.warn
+            "%s: admission dispatch bucket disappeared after acquire; falling back to \
+             legacy"
+            keeper_id;
+          Live_legacy)
+     | Keeper_admission_router.Wait ->
+       (* Enqueue in WFQ overflow for wake on refill. *)
+       let policy_opt = policy_lookup keeper_id in
+       let weight =
+         match policy_opt with
+         | Some p -> Keeper_admission_policy.weight p
+         | None -> 1
+       in
+       Keeper_wfq_overflow.enqueue wfq_queue { keeper_id; weight; enqueued_at = now () };
+       Live_wait
+     | Keeper_admission_router.Surface reason -> Live_surface reason)
+;;
 
 (** Release a bucket token after turn completion.  Idempotent — safe
     to call even if the token was never acquired (e.g. after exception
     paths that short-circuit before dispatch). *)
-let release_bucket bucket =
-  Keeper_provider_token_bucket.release bucket
+let release_bucket bucket = Keeper_provider_token_bucket.release bucket
 
 let wfq_depth () = Keeper_wfq_overflow.depth wfq_queue
-
 let wfq_snapshot () = Keeper_wfq_overflow.snapshot wfq_queue
 
 let reset_for_test () =
@@ -305,3 +308,4 @@ let reset_for_test () =
     Atomic.set policy_lookup_ref no_policy;
     Atomic.set bucket_lookup_ref no_bucket;
     init_state := Idle)
+;;

--- a/lib/server/lsp_process_manager.ml
+++ b/lib/server/lsp_process_manager.ml
@@ -207,6 +207,7 @@ let spawn ~sw ~lang_id ~workspace_root (proc_mgr : Eio_unix.Process.mgr_ty Eio.R
                 Buffer.clear buf)
             done
           with
+          | Eio.Cancel.Cancelled _ as e -> raise e
           | exn ->
             Log.Server.debug
               "LSP %s stderr reader ended: %s"
@@ -214,5 +215,6 @@ let spawn ~sw ~lang_id ~workspace_root (proc_mgr : Eio_unix.Process.mgr_ty Eio.R
               (Printexc.to_string exn));
         Ok { lang_id; proc; stdin_w; stdout_r; next_id = 1 }
       with
+      | Eio.Cancel.Cancelled _ as e -> raise e
       | exn -> Error (Process_error (Printexc.to_string exn)))
 ;;

--- a/lib/server/lsp_process_manager.ml
+++ b/lib/server/lsp_process_manager.ml
@@ -42,7 +42,7 @@ let lang_of_path file_path =
   let ext =
     try Filename.extension file_path |> String.lowercase_ascii with
     | exn ->
-      Log.Core.warn
+      Log.Server.warn
         "lsp_process_manager: Filename.extension failed for %s: %s"
         file_path
         (Printexc.to_string exn);

--- a/lib/server/lsp_process_manager.ml
+++ b/lib/server/lsp_process_manager.ml
@@ -6,13 +6,13 @@
     - Structured cleanup via [Eio.Switch]
     - Per-language command resolution *)
 
-type lsp_process = {
-  lang_id : string;
-  proc : Eio_unix.Process.ty Eio.Std.r;
-  stdin_w : [ Eio.Flow.sink_ty | Eio.Resource.close_ty ] Eio.Std.r;
-  stdout_r : [ Eio.Flow.source_ty | Eio.Resource.close_ty ] Eio.Std.r;
-  mutable next_id : int;
-}
+type lsp_process =
+  { lang_id : string
+  ; proc : Eio_unix.Process.ty Eio.Std.r
+  ; stdin_w : [ Eio.Flow.sink_ty | Eio.Resource.close_ty ] Eio.Std.r
+  ; stdout_r : [ Eio.Flow.source_ty | Eio.Resource.close_ty ] Eio.Std.r
+  ; mutable next_id : int
+  }
 
 type spawn_error =
   | Command_not_found of string
@@ -20,30 +20,33 @@ type spawn_error =
   | Process_error of string
 
 let pp_spawn_error fmt = function
-  | Command_not_found cmd ->
-      Fmt.pf fmt "LSP server not found: %s" cmd
-  | Startup_timeout lang ->
-      Fmt.pf fmt "LSP server startup timeout for %s" lang
-  | Process_error msg ->
-      Fmt.pf fmt "LSP process error: %s" msg
+  | Command_not_found cmd -> Fmt.pf fmt "LSP server not found: %s" cmd
+  | Startup_timeout lang -> Fmt.pf fmt "LSP server startup timeout for %s" lang
+  | Process_error msg -> Fmt.pf fmt "LSP process error: %s" msg
+;;
 
 (** Language → command mapping. Returns [(executable, argv)] or [None]. *)
 let command_for_lang lang_id =
   match lang_id with
   | "ocaml" -> Some ("ocaml-lsp-server", [ "ocaml-lsp-server" ])
   | "typescript" | "javascript" ->
-      Some ("typescript-language-server",
-            [ "typescript-language-server"; "--stdio" ])
+    Some ("typescript-language-server", [ "typescript-language-server"; "--stdio" ])
   | "python" -> Some ("pylsp", [ "pylsp" ])
   | "rust" -> Some ("rust-analyzer", [ "rust-analyzer" ])
   | "go" -> Some ("gopls", [ "gopls" ])
   | _ -> None
+;;
 
 (** Detect language from file extension. *)
 let lang_of_path file_path =
   let ext =
-    try Filename.extension file_path |> String.lowercase_ascii
-    with _ -> ""
+    try Filename.extension file_path |> String.lowercase_ascii with
+    | exn ->
+      Log.Core.warn
+        "lsp_process_manager: Filename.extension failed for %s: %s"
+        file_path
+        (Printexc.to_string exn);
+      ""
   in
   match ext with
   | ".ml" | ".mli" -> "ocaml"
@@ -53,23 +56,28 @@ let lang_of_path file_path =
   | ".rs" -> "rust"
   | ".go" -> "go"
   | _ -> "unknown"
+;;
 
 (** Check that an executable exists on [PATH]. *)
 let command_exists cmd =
   try
     let _ = Unix.getenv "PATH" in
     let paths = String.split_on_char ':' (Unix.getenv "PATH") in
-    List.exists (fun dir ->
-      let full = Filename.concat dir cmd in
-      Sys.file_exists full
-    ) paths
-  with Not_found -> false
+    List.exists
+      (fun dir ->
+         let full = Filename.concat dir cmd in
+         Sys.file_exists full)
+      paths
+  with
+  | Not_found -> false
+;;
 
 (** Allocate a fresh JSON-RPC request ID for this process. *)
 let alloc_id (proc : lsp_process) : int =
   let id = proc.next_id in
   proc.next_id <- id + 1;
   id
+;;
 
 (** Write a JSON-RPC message to the process stdin with Content-Length framing.
 
@@ -77,17 +85,17 @@ let alloc_id (proc : lsp_process) : int =
     {[ Content-Length: <N>\r\n\r\n<payload> ]} *)
 let write_message (proc : lsp_process) (json : string) =
   let payload = Bytes.unsafe_of_string json in
-  let header =
-    Printf.sprintf "Content-Length: %d\r\n\r\n" (Bytes.length payload)
-  in
+  let header = Printf.sprintf "Content-Length: %d\r\n\r\n" (Bytes.length payload) in
   Eio.Flow.copy_string header proc.stdin_w;
   Eio.Flow.copy_string json proc.stdin_w
+;;
 
 (** Read exactly [n] bytes from a flow into a string. *)
 let read_exact (flow : [ Eio.Flow.source_ty | Eio.Resource.close_ty ] Eio.Std.r) n =
   let buf = Cstruct.create n in
   Eio.Flow.read_exact flow buf;
   Cstruct.to_string buf
+;;
 
 (** Read a single header line (terminated by [\r\n]) from the flow.
     Returns the line content without the trailing [\r\n]. *)
@@ -97,31 +105,31 @@ let read_header_line (flow : [ Eio.Flow.source_ty | Eio.Resource.close_ty ] Eio.
     let ch = Cstruct.create 1 in
     Eio.Flow.read_exact flow ch;
     let c = Cstruct.get ch 0 in
-    if c = '\n' && prev = '\r' then begin
+    if c = '\n' && prev = '\r'
+    then (
       let s = Buffer.contents buf in
       let len = String.length s in
-      if len > 0 && String.get s (len - 1) = '\r' then
-        String.sub s 0 (len - 1)
-      else
-        s
-    end else begin
+      if len > 0 && String.get s (len - 1) = '\r' then String.sub s 0 (len - 1) else s)
+    else (
       Buffer.add_char buf c;
-      loop c
-    end
+      loop c)
   in
   loop '\000'
+;;
 
 (** Parse [Content-Length] value from a header line.
     Returns [Some n] if the header matches, [None] otherwise. *)
 let parse_content_length line =
   let prefix = "Content-Length: " in
-  if String.starts_with ~prefix line then
-    let raw = String.sub line (String.length prefix)
-              (String.length line - String.length prefix) in
-    (try Some (int_of_string (String.trim raw))
-     with Failure _ -> None)
-  else
-    None
+  if String.starts_with ~prefix line
+  then (
+    let raw =
+      String.sub line (String.length prefix) (String.length line - String.length prefix)
+    in
+    try Some (int_of_string (String.trim raw)) with
+    | Failure _ -> None)
+  else None
+;;
 
 (** Read one complete LSP message from stdout.
 
@@ -130,72 +138,81 @@ let parse_content_length line =
 let read_message (flow : [ Eio.Flow.source_ty | Eio.Resource.close_ty ] Eio.Std.r) =
   let rec read_headers content_length =
     let line = read_header_line flow in
-    if String.length line = 0 then
+    if String.length line = 0
+    then (
       (* Empty line signals end of headers *)
-      (match content_length with
-       | Some n -> read_exact flow n
-       | None ->
-           (* No Content-Length found; protocol violation.
+      match content_length with
+      | Some n -> read_exact flow n
+      | None ->
+        (* No Content-Length found; protocol violation.
               Return empty string so caller can detect and handle. *)
-           "")
-    else begin
+        "")
+    else (
       let len = parse_content_length line in
-      read_headers (match len with Some n -> Some n | None -> content_length)
-    end
+      read_headers
+        (match len with
+         | Some n -> Some n
+         | None -> content_length))
   in
   read_headers None
+;;
 
 (** Spawn an LSP server process for the given language.
 
     The process is bound to [sw] — when the switch is turned off,
     the process is terminated automatically via [on_release]. *)
-let spawn ~sw ~lang_id ~workspace_root
-    (proc_mgr : Eio_unix.Process.mgr_ty Eio.Resource.t) :
-  (lsp_process, spawn_error) result =
+let spawn ~sw ~lang_id ~workspace_root (proc_mgr : Eio_unix.Process.mgr_ty Eio.Resource.t)
+  : (lsp_process, spawn_error) result
+  =
   match command_for_lang lang_id with
-  | None ->
-      Error (Command_not_found lang_id)
+  | None -> Error (Command_not_found lang_id)
   | Some (cmd, argv) ->
-      if not (command_exists cmd) then
-        Error (Command_not_found cmd)
-      else begin
-        try
-          let stdin_r, stdin_w = Eio.Process.pipe ~sw proc_mgr in
-          let stdout_r, stdout_w = Eio.Process.pipe ~sw proc_mgr in
-          let stderr_r, stderr_w = Eio.Process.pipe ~sw proc_mgr in
-          let proc =
-            Eio.Process.spawn ~sw proc_mgr
-              ~stdin:stdin_r
-              ~stdout:stdout_w
-              ~stderr:stderr_w
-              argv
-          in
-          Eio.Flow.close stdin_r;
-          Eio.Flow.close stdout_w;
-          Eio.Flow.close stderr_w;
-          Eio.Switch.on_release sw (fun () ->
-            (try Eio.Process.signal proc Sys.sigterm
-             with exn ->
-               Log.Server.debug "LSP process signal failed for %s: %s"
-                 lang_id (Printexc.to_string exn)));
-          (* Drain stderr to a log — prevents pipe stall *)
-          Eio.Fiber.fork ~sw (fun () ->
-            let buf = Buffer.create 256 in
-            (try
-               while true do
-                 let line = read_header_line stderr_r in
-                 Buffer.add_string buf line;
-                 Buffer.add_char buf '\n';
-                 if Buffer.length buf > 4096 then begin
-                   Log.Server.debug "LSP %s stderr: %s" lang_id
-                     (Buffer.contents buf);
-                   Buffer.clear buf
-                 end
-               done
-             with exn ->
-               Log.Server.debug "LSP %s stderr reader ended: %s" lang_id
-                 (Printexc.to_string exn)));
-          Ok { lang_id; proc; stdin_w; stdout_r; next_id = 1 }
-        with exn ->
-          Error (Process_error (Printexc.to_string exn))
-      end
+    if not (command_exists cmd)
+    then Error (Command_not_found cmd)
+    else (
+      try
+        let stdin_r, stdin_w = Eio.Process.pipe ~sw proc_mgr in
+        let stdout_r, stdout_w = Eio.Process.pipe ~sw proc_mgr in
+        let stderr_r, stderr_w = Eio.Process.pipe ~sw proc_mgr in
+        let proc =
+          Eio.Process.spawn
+            ~sw
+            proc_mgr
+            ~stdin:stdin_r
+            ~stdout:stdout_w
+            ~stderr:stderr_w
+            argv
+        in
+        Eio.Flow.close stdin_r;
+        Eio.Flow.close stdout_w;
+        Eio.Flow.close stderr_w;
+        Eio.Switch.on_release sw (fun () ->
+          try Eio.Process.signal proc Sys.sigterm with
+          | exn ->
+            Log.Server.debug
+              "LSP process signal failed for %s: %s"
+              lang_id
+              (Printexc.to_string exn));
+        (* Drain stderr to a log — prevents pipe stall *)
+        Eio.Fiber.fork ~sw (fun () ->
+          let buf = Buffer.create 256 in
+          try
+            while true do
+              let line = read_header_line stderr_r in
+              Buffer.add_string buf line;
+              Buffer.add_char buf '\n';
+              if Buffer.length buf > 4096
+              then (
+                Log.Server.debug "LSP %s stderr: %s" lang_id (Buffer.contents buf);
+                Buffer.clear buf)
+            done
+          with
+          | exn ->
+            Log.Server.debug
+              "LSP %s stderr reader ended: %s"
+              lang_id
+              (Printexc.to_string exn));
+        Ok { lang_id; proc; stdin_w; stdout_r; next_id = 1 }
+      with
+      | exn -> Error (Process_error (Printexc.to_string exn)))
+;;


### PR DESCRIPTION
Audit: find and fix bare catch-all handlers that silently swallow exceptions (including Eio.Cancel.Cancelled) without logging.

Changes:
- dashboard_cascade.ml: re-raise Cancelled, warn plus return empty list for others
- dashboard_worktree_status.ml: re-raise Cancelled, warn plus return None for others
- keeper_admission_runtime.ml: re-raise Cancelled, warn plus return None for others
- lsp_process_manager.ml: warn plus return empty string for Filename.extension failures
- build_identity.ml: warn plus return original path for Unix.realpath failures

Verification:
- scripts/dune-local.sh build lib/dashboard_cascade.ml lib/dashboard/dashboard_worktree_status.ml lib/keeper/keeper_admission_runtime.ml lib/server/lsp_process_manager.ml lib/build_identity.ml passes

Closes Phase 6: Ensure warnings/errors are not swallowed