### PR TITLE
feat(ide): add memory tier panel to IDE right-side

### DIFF
--- a/dashboard/src/components/ide/ide-shell.ts
+++ b/dashboard/src/components/ide/ide-shell.ts
@@ -14,6 +14,7 @@ import { IDE_LAYERS, IdeToolbar } from './ide-toolbar'
 import { InspectorKeeperBDI, pinInspectorKeeper } from './inspector-keeper-bdi'
 import { OverlayKeeperTrace } from './overlay-keeper-trace'
 import { IdePersistencePanel } from './ide-persistence-panel'
+import { KeeperMemoryTierPanel } from '../keeper-memory-tier-panel'
 import { IdeBranchContextPanel } from './ide-branch-context-panel'
 import { navigate, route } from '../../router'
 import { activeKeeperName } from '../../keeper-state'
@@ -238,7 +239,7 @@ export function IdeShell() {
               class="ide-plane-conversation"
               style=${{
                 display: 'grid',
-                gridTemplateRows: 'auto auto auto auto 1fr',
+                gridTemplateRows: 'auto auto auto auto auto 1fr',
                 minHeight: 0,
                 overflow: 'auto',
               }}
@@ -251,6 +252,7 @@ export function IdeShell() {
               <${IdePersistencePanel} keeperName=${terminalKeeper} />
               <${InspectorKeeperBDI} traceActive=${activeLayers.has('keeper-trace')} />
               <${IdeConversationRailMock} />
+              ${terminalKeeper.trim() ? html`<${KeeperMemoryTierPanel} keeperName=${terminalKeeper} />` : null}
             </div>
           `}
         ${railsCollapsed


### PR DESCRIPTION
Adds KeeperMemoryTierPanel to the IDE shell right-side conversation area, showing keeper memory usage alongside the existing conversation rail, BDI inspector, and persistence panels.

Changes:
- Import KeeperMemoryTierPanel in ide-shell.ts
- Render below IdeConversationRailMock in the right-side grid

Closes Phase 5: IDE right-side memory component