### PR TITLE
feat(ide-interject): enrich interject bar with keeper presence and cursor

### DIFF
--- a/dashboard/src/components/ide/ide-interject-mock.ts
+++ b/dashboard/src/components/ide/ide-interject-mock.ts
@@ -40,25 +40,41 @@ export const IdeInterjectMock: FunctionComponent<IdeInterjectMockProps> = ({ kee
     }))
   const [, forceRender] = useState(0)
 
-  useEffect(() => interjectStore.subscribe(() => forceRender(tick => tick + 1)), [interjectStore])
-  useEffect(() => activeKeeperName.subscribe(name => {
-    interjectStore.setActiveKeeper(keeperName?.trim() || name)
-  }), [interjectStore, keeperName])
+  useEffect(() => {
+    const unsub = interjectStore.subscribe(() => forceRender(tick => tick + 1))
+    return () => unsub()
+  }, [interjectStore])
+  useEffect(() => {
+    const unsub = activeKeeperName.subscribe(name => {
+      interjectStore.setActiveKeeper(keeperName?.trim() || name)
+    })
+    return () => unsub()
+  }, [interjectStore, keeperName])
   useEffect(() => {
     interjectStore.setActiveKeeper(resolveActiveKeeper(keeperName))
   }, [interjectStore, keeperName])
 
   const [presence, setPresence] = useState(globalPresenceSnapshot.value)
-  useEffect(() => globalPresenceSnapshot.subscribe(v => setPresence(v)), [])
+  useEffect(() => {
+    const unsub = globalPresenceSnapshot.subscribe(v => setPresence(v))
+    return () => unsub()
+  }, [])
 
   const [overlay, setOverlay] = useState(cursorOverlaySignal.value)
-  useEffect(() => cursorOverlaySignal.subscribe(v => setOverlay(v)), [])
+  useEffect(() => {
+    const unsub = cursorOverlaySignal.subscribe(v => setOverlay(v))
+    return () => unsub()
+  }, [])
 
   const snapshot = interjectStore.snapshot()
   const actions = interjectStore.actions()
   const keeperId = snapshot.active_keeper_id ?? ''
-  const presenceEntry = keeperId
-    ? presence?.entries.find(e => e.keeper_id === keeperId) ?? null
+  // InterjectStore only .trim()s keeper IDs; route keeper names may differ
+  // in casing. Compare on lowercase+trim so a presence entry from the route
+  // matches the (cased) interject keeper id.
+  const keeperIdNorm = keeperId.trim().toLowerCase()
+  const presenceEntry = keeperIdNorm
+    ? presence?.entries.find(e => e.keeper_id.trim().toLowerCase() === keeperIdNorm) ?? null
     : null
   const cursor = keeperId
     ? resolveCursor(keeperId, overlay.cursors)
@@ -200,7 +216,13 @@ function KeeperPresencePill(status: KeeperPresenceStatus) {
   `
 }
 
-function CursorLocation(cursor: { file_path: string; line: number; focus_mode: string; tool_name?: string }) {
+function CursorLocation(cursor: {
+  keeper_id: string
+  file_path: string
+  line: number
+  focus_mode: string
+  tool_name?: string
+}) {
   const fileName = cursor.file_path.split('/').pop() ?? cursor.file_path
   const color = getKeeperColor(cursor.keeper_id)
   return html`

--- a/dashboard/src/components/ide/ide-interject-mock.ts
+++ b/dashboard/src/components/ide/ide-interject-mock.ts
@@ -8,6 +8,8 @@ import {
   type InterjectActionState,
   type InterjectDispatchRequest,
 } from './interject-store'
+import { globalPresenceSnapshot, type KeeperPresenceStatus } from './keeper-presence-store'
+import { cursorOverlaySignal, getKeeperColor } from './keeper-cursor-overlay'
 
 // The input and button states flow through the same store/dispatch boundary
 // that live active-keeper wiring uses. Send remains disabled until a concrete
@@ -46,8 +48,21 @@ export const IdeInterjectMock: FunctionComponent<IdeInterjectMockProps> = ({ kee
     interjectStore.setActiveKeeper(resolveActiveKeeper(keeperName))
   }, [interjectStore, keeperName])
 
+  const [presence, setPresence] = useState(globalPresenceSnapshot.value)
+  useEffect(() => globalPresenceSnapshot.subscribe(v => setPresence(v)), [])
+
+  const [overlay, setOverlay] = useState(cursorOverlaySignal.value)
+  useEffect(() => cursorOverlaySignal.subscribe(v => setOverlay(v)), [])
+
   const snapshot = interjectStore.snapshot()
   const actions = interjectStore.actions()
+  const keeperId = snapshot.active_keeper_id ?? ''
+  const presenceEntry = keeperId
+    ? presence?.entries.find(e => e.keeper_id === keeperId) ?? null
+    : null
+  const cursor = keeperId
+    ? resolveCursor(keeperId, overlay.cursors)
+    : null
 
   return html`
     <div
@@ -74,9 +89,13 @@ export const IdeInterjectMock: FunctionComponent<IdeInterjectMockProps> = ({ kee
         }}
       >
         <span>INTERJECT</span>
-        <span style=${{ fontSize: 'var(--fs-11)', color: 'var(--color-fg-secondary)' }}>
-          ${snapshot.active_keeper_id ?? 'No active keeper'}
-        </span>
+        <div style=${{ display: 'flex', alignItems: 'center', gap: 'var(--sp-1)' }}>
+          <span style=${{ fontSize: 'var(--fs-11)', color: 'var(--color-fg-secondary)' }}>
+            ${keeperId || 'No active keeper'}
+          </span>
+          ${presenceEntry ? KeeperPresencePill(presenceEntry.status) : null}
+        </div>
+        ${cursor ? CursorLocation(cursor) : null}
       </div>
       <input
         class="ide-interject-input"
@@ -138,4 +157,93 @@ function InterjectButton(action: InterjectActionState, onClick: () => void) {
       }}
     >${action.label}</button>
   `
+}
+
+const PRESENCE_STYLES: Record<KeeperPresenceStatus, { color: string; bg: string; label: string }> = {
+  active: { color: 'var(--color-status-ok)', bg: 'rgba(46, 160, 67, 0.15)', label: 'ACTIVE' },
+  blocked: { color: 'var(--color-status-err)', bg: 'rgba(248, 81, 73, 0.15)', label: 'BLOCKED' },
+  idle: { color: 'var(--color-fg-muted)', bg: 'var(--color-bg-surface)', label: 'IDLE' },
+}
+
+function KeeperPresencePill(status: KeeperPresenceStatus) {
+  const style = PRESENCE_STYLES[status]
+  return html`
+    <span
+      role="status"
+      aria-label=${`Keeper status: ${style.label}`}
+      style=${{
+        display: 'inline-flex',
+        alignItems: 'center',
+        gap: '3px',
+        padding: '1px 5px',
+        fontSize: 'var(--fs-10)',
+        fontWeight: 600,
+        letterSpacing: '0.04em',
+        color: style.color,
+        background: style.bg,
+        borderRadius: 'var(--r-1)',
+        lineHeight: 1,
+      }}
+    >
+      <span
+        aria-hidden="true"
+        style=${{
+          width: '5px',
+          height: '5px',
+          borderRadius: '50%',
+          background: style.color,
+          display: 'inline-block',
+        }}
+      />
+      ${style.label}
+    </span>
+  `
+}
+
+function CursorLocation(cursor: { file_path: string; line: number; focus_mode: string; tool_name?: string }) {
+  const fileName = cursor.file_path.split('/').pop() ?? cursor.file_path
+  const color = getKeeperColor(cursor.keeper_id)
+  return html`
+    <div
+      style=${{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 'var(--sp-1)',
+        fontSize: 'var(--fs-10)',
+        fontFamily: 'var(--font-mono)',
+        color: 'var(--color-fg-muted)',
+        overflow: 'hidden',
+        textOverflow: 'ellipsis',
+        whiteSpace: 'nowrap',
+      }}
+      title=${cursor.file_path}
+    >
+      <span
+        aria-hidden="true"
+        style=${{
+          width: '4px',
+          height: '4px',
+          borderRadius: '50%',
+          background: color.cursor,
+          display: 'inline-block',
+          flexShrink: 0,
+        }}
+      />
+      <span>${fileName}:${cursor.line}</span>
+      ${cursor.tool_name
+        ? html`<span style=${{ color: 'var(--color-fg-disabled)' }}>· ${cursor.tool_name}</span>`
+        : null}
+    </div>
+  `
+}
+
+function resolveCursor(
+  keeperId: string,
+  cursors: Map<string, { keeper_id: string; file_path: string; line: number; focus_mode: string; tool_name?: string }>,
+) {
+  const target = keeperId.toLowerCase().trim()
+  for (const [id, cursor] of cursors) {
+    if (id.toLowerCase() === target) return cursor
+  }
+  return null
 }


### PR DESCRIPTION
## Summary
- Wire `globalPresenceSnapshot` and `cursorOverlaySignal` into `IdeInterjectMock` so the active keeper's status (active/idle/blocked) and cursor position (file:line + tool) render alongside the keeper name
- Add `KeeperPresencePill` (colored dot + status text) and `CursorLocation` (filename:line + tool_name) helper components
- Case-insensitive keeper resolution matching `IdeKeeperWorkPanel` pattern

## Test plan
- [x] `tsc --noEmit` passes
- [ ] Browser: interject bar shows ACTIVE/BLOCKED/IDLE pill when SSE feeds presence data
- [ ] Browser: cursor location updates when keeper moves between files

🤖 Generated with [Claude Code](https://claude.com/claude-code)