### PR TITLE
feat(grpc,lsp): add LspCall RPC to gRPC service

### DIFF
--- a/dashboard/src/grpc/masc_coordination_pb.ts
+++ b/dashboard/src/grpc/masc_coordination_pb.ts
@@ -107,3 +107,14 @@ export interface TaskInfo {
   assignedTo: string
   priority: number
 }
+
+export interface LspRequest {
+  languageId: string
+  jsonrpcRequestJson: string
+  workspaceRoot?: string
+}
+
+export interface LspResponse {
+  jsonrpcResponseJson: string
+  errorMessage?: string
+}

--- a/dashboard/src/grpc/masc_coordination_pb.ts
+++ b/dashboard/src/grpc/masc_coordination_pb.ts
@@ -116,5 +116,5 @@ export interface LspRequest {
 
 export interface LspResponse {
   jsonrpcResponseJson: string
-  errorMessage?: string
+  errorMessage: string
 }

--- a/dashboard/src/transports/grpc-transport.ts
+++ b/dashboard/src/transports/grpc-transport.ts
@@ -22,6 +22,8 @@ import type {
   BroadcastResponse,
   StatusRequest,
   StatusResponse,
+  LspRequest,
+  LspResponse,
 } from '../grpc/masc_coordination_pb'
 
 const DEFAULT_RETRY_BASE_MS = 1000
@@ -264,5 +266,6 @@ export function createGrpcTransport(
     toolCall: (req) => unaryRpc(baseUrl, service, 'ToolCall', req, opts, state),
     broadcast: (req) => unaryRpc(baseUrl, service, 'Broadcast', req, opts, state),
     getStatus: (req) => unaryRpc(baseUrl, service, 'GetStatus', req, opts, state),
+    lspCall: (req) => unaryRpc<LspRequest, LspResponse>(baseUrl, service, 'LspCall', req, opts, state),
   }
 }

--- a/dashboard/src/transports/grpc-transport.ts
+++ b/dashboard/src/transports/grpc-transport.ts
@@ -89,6 +89,7 @@ export interface GrpcTransport extends Transport {
   readonly toolCall: (req: ToolCallRequest) => Promise<ToolCallResponse>
   readonly broadcast: (req: BroadcastRequest) => Promise<BroadcastResponse>
   readonly getStatus: (req: StatusRequest) => Promise<StatusResponse>
+  readonly lspCall: (req: LspRequest) => Promise<LspResponse>
 }
 
 interface GrpcTransportState {

--- a/lib/grpc/masc_grpc_service.ml
+++ b/lib/grpc/masc_grpc_service.ml
@@ -24,57 +24,69 @@ let now_ms () = Int64.of_float (Unix.gettimeofday () *. 1000.0)
     choice, but available for debugging). *)
 let stream_max_buffer () =
   Env_config_core.get_int ~default:48 "MASC_GRPC_STREAM_MAX_BUFFER"
+;;
 
 let decode_request_or_raise ~rpc decode bytes =
   match decode bytes with
   | Ok req -> req
   | Error msg ->
     Log.Transport.warn "gRPC %s decode failed: %s" rpc msg;
-    Grpc_core.Status.raise_error Grpc_core.Status.Invalid_argument
+    Grpc_core.Status.raise_error
+      Grpc_core.Status.Invalid_argument
       (Printf.sprintf "%s request decode failed: %s" rpc msg)
+;;
 
 (** Read a file to string. Returns [""] on non-cancellation errors.
     Propagates [Eio.Cancel.Cancelled] so cooperative cancellation is preserved. *)
 let read_file_safe path =
-  try Fs_compat.load_file path
-  with Eio.Cancel.Cancelled _ as e -> raise e
-     | exn -> Log.Transport.warn "read_file_safe failed for %s: %s" path (Printexc.to_string exn); ""
+  try Fs_compat.load_file path with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | exn ->
+    Log.Transport.warn "read_file_safe failed for %s: %s" path (Printexc.to_string exn);
+    ""
+;;
 
 (** Safe filename: replace non-alphanumeric chars with underscores. *)
 let safe_filename name =
-  String.map (fun c ->
-    if (c >= 'a' && c <= 'z')
-       || (c >= 'A' && c <= 'Z')
-       || (c >= '0' && c <= '9')
-       || c = '-' || c = '_'
-    then c
-    else '_') name
+  String.map
+    (fun c ->
+       if
+         (c >= 'a' && c <= 'z')
+         || (c >= 'A' && c <= 'Z')
+         || (c >= '0' && c <= '9')
+         || c = '-'
+         || c = '_'
+       then c
+       else '_')
+    name
+;;
 
 let task_assignee_of_status status =
   match Masc_domain.task_assignee_of_status status with
   | Some a -> a
   | None -> ""
+;;
 
 let task_info_of_task (task : Masc_domain.task) : T.task_info =
-  {
-    T.id = task.id;
-    title = task.title;
-    status = Masc_domain.string_of_task_status task.task_status;
-    assigned_to = task_assignee_of_status task.task_status;
-    priority = task.priority;
+  { T.id = task.id
+  ; title = task.title
+  ; status = Masc_domain.string_of_task_status task.task_status
+  ; assigned_to = task_assignee_of_status task.task_status
+  ; priority = task.priority
   }
+;;
 
 (** {1 Unary Handlers} *)
 
 (** Join handler: agent joins the coordination room. *)
-let handle_join (room_config : Coord_utils_backend_setup.config) (bytes : string) : string =
-  let req =
-    decode_request_or_raise ~rpc:"Join" T.JoinRequest.of_bytes_result bytes
-  in
+let handle_join (room_config : Coord_utils_backend_setup.config) (bytes : string) : string
+  =
+  let req = decode_request_or_raise ~rpc:"Join" T.JoinRequest.of_bytes_result bytes in
   let result =
     try
       let msg =
-        Coord.join room_config
+        Coord.join
+          room_config
           ~agent_name:req.agent_name
           ~capabilities:req.capabilities
           ()
@@ -86,7 +98,8 @@ let handle_join (room_config : Coord_utils_backend_setup.config) (bytes : string
           "agents"
       in
       let active_agents =
-        if Sys.file_exists agents_dir && Sys.is_directory agents_dir then
+        if Sys.file_exists agents_dir && Sys.is_directory agents_dir
+        then
           Sys.readdir agents_dir
           |> Array.to_list
           |> List.filter (fun f -> Filename.check_suffix f ".json")
@@ -96,85 +109,100 @@ let handle_join (room_config : Coord_utils_backend_setup.config) (bytes : string
               let json = Yojson.Safe.from_string (read_file_safe path) in
               match Masc_domain.agent_of_yojson json with
               | Ok agent when agent.Masc_domain.status = Masc_domain.Active ->
-                Some ({
-                  T.name = agent.name;
-                  status = "active";
-                  capabilities = agent.capabilities;
-                  last_heartbeat_ms = now_ms ();
-                  joined_at_ms = now_ms ();
-                  current_task_id =
-                    Option.value ~default:"" agent.current_task;
-                } : T.agent_info)
+                Some
+                  ({ T.name = agent.name
+                   ; status = "active"
+                   ; capabilities = agent.capabilities
+                   ; last_heartbeat_ms = now_ms ()
+                   ; joined_at_ms = now_ms ()
+                   ; current_task_id = Option.value ~default:"" agent.current_task
+                   }
+                   : T.agent_info)
               | _ -> None
-            with Eio.Cancel.Cancelled _ as e -> raise e | exn -> Log.Transport.debug "agent parse skip: %s" (Printexc.to_string exn); None)
+            with
+            | Eio.Cancel.Cancelled _ as e -> raise e
+            | exn ->
+              Log.Transport.debug "agent parse skip: %s" (Printexc.to_string exn);
+              None)
         else []
       in
-      T.JoinResponse.{
-        success = true;
-        message = msg;
-        session_id = Printf.sprintf "grpc-%s-%Ld" req.agent_name (now_ms ());
-        active_agents;
-      }
-    with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
-      T.JoinResponse.{
-        success = false;
-        message = Printf.sprintf "Join failed: %s" (Printexc.to_string exn);
-        session_id = "";
-        active_agents = [];
-      }
+      T.JoinResponse.
+        { success = true
+        ; message = msg
+        ; session_id = Printf.sprintf "grpc-%s-%Ld" req.agent_name (now_ms ())
+        ; active_agents
+        }
+    with
+    | Eio.Cancel.Cancelled _ as e -> raise e
+    | exn ->
+      T.JoinResponse.
+        { success = false
+        ; message = Printf.sprintf "Join failed: %s" (Printexc.to_string exn)
+        ; session_id = ""
+        ; active_agents = []
+        }
   in
   T.JoinResponse.to_bytes result
+;;
 
 (** Leave handler: agent leaves the coordination room. *)
-let handle_leave (room_config : Coord_utils_backend_setup.config) (bytes : string) : string =
-  let req =
-    decode_request_or_raise ~rpc:"Leave" T.LeaveRequest.of_bytes_result bytes
-  in
+let handle_leave (room_config : Coord_utils_backend_setup.config) (bytes : string)
+  : string
+  =
+  let req = decode_request_or_raise ~rpc:"Leave" T.LeaveRequest.of_bytes_result bytes in
   let result =
     try
       let msg = Coord.leave room_config ~agent_name:req.agent_name in
       T.LeaveResponse.{ success = true; message = msg }
-    with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
-      T.LeaveResponse.{
-        success = false;
-        message = Printf.sprintf "Leave failed: %s" (Printexc.to_string exn);
-      }
+    with
+    | Eio.Cancel.Cancelled _ as e -> raise e
+    | exn ->
+      T.LeaveResponse.
+        { success = false
+        ; message = Printf.sprintf "Leave failed: %s" (Printexc.to_string exn)
+        }
   in
   T.LeaveResponse.to_bytes result
+;;
 
 (** Broadcast handler: send a message to all agents. *)
-let handle_broadcast (room_config : Coord_utils_backend_setup.config) (bytes : string) : string =
+let handle_broadcast (room_config : Coord_utils_backend_setup.config) (bytes : string)
+  : string
+  =
   let req =
     decode_request_or_raise ~rpc:"Broadcast" T.BroadcastRequest.of_bytes_result bytes
   in
   let result =
     try
       let content =
-        if req.mentions = [] then req.message
-        else
+        if req.mentions = []
+        then req.message
+        else (
           let mention_prefix =
-            String.concat " "
-              (List.map (fun m -> "@" ^ m) req.mentions)
+            String.concat " " (List.map (fun m -> "@" ^ m) req.mentions)
           in
-          mention_prefix ^ " " ^ req.message
+          mention_prefix ^ " " ^ req.message)
       in
-      let _msg =
-        Coord.broadcast room_config
-          ~from_agent:req.agent_name ~content
-      in
+      let _msg = Coord.broadcast room_config ~from_agent:req.agent_name ~content in
       T.BroadcastResponse.{ success = true; seq = now_ms () }
-    with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
+    with
+    | Eio.Cancel.Cancelled _ as e -> raise e
+    | exn ->
       Log.Transport.error "gRPC broadcast failed: %s" (Printexc.to_string exn);
       T.BroadcastResponse.{ success = false; seq = 0L }
   in
   T.BroadcastResponse.to_bytes result
+;;
 
 (** GetStatus handler: return current room state. *)
-let handle_get_status (room_config : Coord_utils_backend_setup.config) (_bytes : string) : string =
+let handle_get_status (room_config : Coord_utils_backend_setup.config) (_bytes : string)
+  : string
+  =
   let masc_dir = Common.masc_dir_from_base_path ~base_path:room_config.base_path in
   let agents_dir = Filename.concat masc_dir "agents" in
   let agents =
-    if Sys.file_exists agents_dir && Sys.is_directory agents_dir then
+    if Sys.file_exists agents_dir && Sys.is_directory agents_dir
+    then
       Sys.readdir agents_dir
       |> Array.to_list
       |> List.filter (fun f -> Filename.check_suffix f ".json")
@@ -184,56 +212,51 @@ let handle_get_status (room_config : Coord_utils_backend_setup.config) (_bytes :
           let json = Yojson.Safe.from_string (read_file_safe path) in
           match Masc_domain.agent_of_yojson json with
           | Ok agent ->
-            let status_str = Masc_domain.agent_status_to_string agent.Masc_domain.status in
-            Some ({
-              T.name = agent.name;
-              status = status_str;
-              capabilities = agent.capabilities;
-              last_heartbeat_ms = now_ms ();
-              joined_at_ms = now_ms ();
-              current_task_id =
-                Option.value ~default:"" agent.current_task;
-            } : T.agent_info)
+            let status_str =
+              Masc_domain.agent_status_to_string agent.Masc_domain.status
+            in
+            Some
+              ({ T.name = agent.name
+               ; status = status_str
+               ; capabilities = agent.capabilities
+               ; last_heartbeat_ms = now_ms ()
+               ; joined_at_ms = now_ms ()
+               ; current_task_id = Option.value ~default:"" agent.current_task
+               }
+               : T.agent_info)
           | _ -> None
-        with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
-          Log.Transport.debug "gRPC status: agent parse skip: %s"
-            (Printexc.to_string exn);
+        with
+        | Eio.Cancel.Cancelled _ as e -> raise e
+        | exn ->
+          Log.Transport.debug "gRPC status: agent parse skip: %s" (Printexc.to_string exn);
           None)
     else []
   in
   let tasks = Coord.get_tasks_safe room_config |> List.map task_info_of_task in
-  T.StatusResponse.(to_bytes {
-    agents;
-    tasks;
-    message_count = 0;
-    room_path = room_config.base_path;
-  })
+  T.StatusResponse.(
+    to_bytes { agents; tasks; message_count = 0; room_path = room_config.base_path })
+;;
 
 (** ToolCall handler: dispatch an MCP tool call via gRPC. *)
 let handle_tool_call
-    (tool_dispatcher : string -> string -> (string, string) result)
-    (bytes : string) : string =
+      (tool_dispatcher : string -> string -> (string, string) result)
+      (bytes : string)
+  : string
+  =
   let req =
     decode_request_or_raise ~rpc:"ToolCall" T.ToolCallRequest.of_bytes_result bytes
   in
   let result =
     match tool_dispatcher req.tool_name req.arguments_json with
     | Ok result_json ->
-      T.ToolCallResponse.{
-        success = true;
-        result_json;
-        error_message = "";
-        error_code = 0;
-      }
+      T.ToolCallResponse.
+        { success = true; result_json; error_message = ""; error_code = 0 }
     | Error msg ->
-      T.ToolCallResponse.{
-        success = false;
-        result_json = "";
-        error_message = msg;
-        error_code = -32603;
-      }
+      T.ToolCallResponse.
+        { success = false; result_json = ""; error_message = msg; error_code = -32603 }
   in
   T.ToolCallResponse.to_bytes result
+;;
 
 (** {1 Streaming Handlers} *)
 
@@ -247,8 +270,10 @@ let active_subscribe_streams = Atomic.make 0
     Returns a list of string directives to include in HeartbeatAck.
     Reads agent paused state and unclaimed tasks from the filesystem. *)
 let compute_directives
-    ~(room_config : Coord_utils_backend_setup.config)
-    ~(agent_name : string) : string list =
+      ~(room_config : Coord_utils_backend_setup.config)
+      ~(agent_name : string)
+  : string list
+  =
   let masc_dir = Common.masc_dir_from_base_path ~base_path:room_config.base_path in
   let directives = ref [] in
   (* 1. Pause directive: check if agent is marked paused *)
@@ -257,143 +282,166 @@ let compute_directives
       (Filename.concat masc_dir "agents")
       (safe_filename agent_name ^ ".json")
   in
-  (if Sys.file_exists agent_file then
+  if Sys.file_exists agent_file
+  then (
     try
       let json = Yojson.Safe.from_string (read_file_safe agent_file) in
-      (match Yojson.Safe.Util.member "paused" json with
-       | `Bool true -> directives := "pause" :: !directives
-       | `Bool false | `Null | `Int _ | `Intlit _ | `Float _ | `String _ | `Assoc _ | `List _ -> ())
+      match Yojson.Safe.Util.member "paused" json with
+      | `Bool true -> directives := "pause" :: !directives
+      | `Bool false
+      | `Null | `Int _ | `Intlit _ | `Float _ | `String _ | `Assoc _ | `List _ -> ()
     with
     | Eio.Cancel.Cancelled _ as e -> raise e
     | exn ->
-        Log.Transport.warn
-          "compute_directives: failed to parse agent file %s: %s"
-          agent_file (Printexc.to_string exn));
+      Log.Transport.warn
+        "compute_directives: failed to parse agent file %s: %s"
+        agent_file
+        (Printexc.to_string exn));
   (* 2. Task assignment: find first unclaimed task for idle agent *)
-  (if Coord.root_is_initialized room_config then
+  if Coord.root_is_initialized room_config
+  then (
     let unclaimed =
       Coord.get_tasks_safe room_config
       |> List.filter_map (fun (task : Masc_domain.task) ->
-           match task.task_status with
-           | Masc_domain.Todo -> Some task.id
-           | Masc_domain.Claimed _ | Masc_domain.InProgress _ | Masc_domain.AwaitingVerification _
-           | Masc_domain.Done _ | Masc_domain.Cancelled _ -> None)
+        match task.task_status with
+        | Masc_domain.Todo -> Some task.id
+        | Masc_domain.Claimed _
+        | Masc_domain.InProgress _
+        | Masc_domain.AwaitingVerification _
+        | Masc_domain.Done _
+        | Masc_domain.Cancelled _ -> None)
     in
     match unclaimed with
     | task_id :: _ -> directives := ("claim:" ^ task_id) :: !directives
     | [] -> ());
   List.rev !directives
+;;
 
 (** Heartbeat bidi handler: receive pings, respond with acks. *)
 let handle_heartbeat
-    (room_config : Coord_utils_backend_setup.config)
-    ~(sw : Eio.Switch.t)
-    (request_stream : string Grpc_eio.Stream.t)
-  : string Grpc_eio.Stream.t =
+      (room_config : Coord_utils_backend_setup.config)
+      ~(sw : Eio.Switch.t)
+      (request_stream : string Grpc_eio.Stream.t)
+  : string Grpc_eio.Stream.t
+  =
   let response_stream = Grpc_eio.Stream.create 16 in
   Atomic.incr active_heartbeat_streams;
   Transport_metrics.set_grpc_active_streams (Atomic.get active_heartbeat_streams);
   Eio.Fiber.fork ~sw (fun () ->
     let cleanup () =
       Atomic.decr active_heartbeat_streams;
-      Transport_metrics.set_grpc_active_streams
-        (Atomic.get active_heartbeat_streams);
+      Transport_metrics.set_grpc_active_streams (Atomic.get active_heartbeat_streams);
       (* Called from [End_of_file] at line 360 and the generic-[exn] handler
          at line 371 — neither is a cancel handler. [with _ -> ()] would
          swallow [Eio.Cancel.Cancelled] racing with [Stream.close], leaving
          the fiber to fall past the cancel boundary. The counters above are
          decremented first, so re-raising here is safe. *)
-      (try Grpc_eio.Stream.close response_stream
-       with
-       | Eio.Cancel.Cancelled _ as e -> raise e
-       | exn -> Log.Transport.warn "masc_grpc_service: stream close failed: %s" (Printexc.to_string exn))
+      try Grpc_eio.Stream.close response_stream with
+      | Eio.Cancel.Cancelled _ as e -> raise e
+      | exn ->
+        Log.Transport.warn
+          "masc_grpc_service: stream close failed: %s"
+          (Printexc.to_string exn)
     in
     let rec loop () =
       match Grpc_eio.Stream.take request_stream with
       | bytes ->
         (match T.HeartbeatPing.of_bytes_result bytes with
-         | Error msg ->
-           Log.Transport.warn "gRPC Heartbeat decode failed: %s" msg
+         | Error msg -> Log.Transport.warn "gRPC Heartbeat decode failed: %s" msg
          | Ok ping ->
-        (try
-          let t0 = Unix.gettimeofday () in
-          (* Update agent last_seen *)
-          (try
-            let agent_file =
-              Filename.concat
-                (Filename.concat
-                  (Common.masc_dir_from_base_path ~base_path:room_config.base_path)
-                  "agents")
-                (safe_filename ping.agent_name ^ ".json")
-            in
-            if Sys.file_exists agent_file then begin
-              let json = Yojson.Safe.from_string (read_file_safe agent_file) in
-              match Masc_domain.agent_of_yojson json with
-              | Ok agent ->
-                let now = Unix.gettimeofday () in
-                let iso_now =
-                  let tm = Unix.gmtime now in
-                  Printf.sprintf "%04d-%02d-%02dT%02d:%02d:%02dZ"
-                    (1900 + tm.tm_year) (1 + tm.tm_mon) tm.tm_mday
-                    tm.tm_hour tm.tm_min tm.tm_sec
-                in
-                let updated = { agent with Masc_domain.last_seen = iso_now } in
-                let content =
-                  Yojson.Safe.to_string (Masc_domain.agent_to_yojson updated)
-                in
-                let tmp_path = agent_file ^ ".tmp" in
-                Fs_compat.save_file tmp_path content;
-                Unix.rename tmp_path agent_file
-              | Error e ->
-                  Log.Transport.warn "gRPC heartbeat: invalid agent JSON for %s: %s"
-                    ping.agent_name e
-            end
-          with Eio.Cancel.Cancelled _ as e -> raise e | exn -> Log.Transport.error "gRPC heartbeat update failed: %s" (Printexc.to_string exn));
-          (* Count active agents and pending tasks *)
-          let masc_dir = Common.masc_dir_from_base_path ~base_path:room_config.base_path in
-          let agents_dir = Filename.concat masc_dir "agents" in
-          let agent_count =
-            if Sys.file_exists agents_dir then
-              Array.length (Sys.readdir agents_dir)
-            else 0
-          in
-          let tasks_dir = Filename.concat masc_dir "tasks" in
-          let pending_count =
-            if Sys.file_exists tasks_dir then
-              Sys.readdir tasks_dir
-              |> Array.to_list
-              |> List.filter (fun f -> Filename.check_suffix f ".json")
-              |> List.length
-            else 0
-          in
-          let directives =
-            compute_directives ~room_config ~agent_name:ping.agent_name
-          in
-          let ack = T.HeartbeatAck.{
-            timestamp_ms = now_ms ();
-            active_agent_count = agent_count;
-            pending_task_count = pending_count;
-            directives;
-          } in
-          let ack_bytes = T.HeartbeatAck.to_bytes ack in
-          Transport_metrics.inc_grpc_bytes_sent
-            ~bytes:(String.length ack_bytes);
-          Grpc_eio.Stream.add response_stream ack_bytes;
-          (* Record heartbeat latency *)
-          let latency = Unix.gettimeofday () -. t0 in
-          Transport_metrics.observe_grpc_heartbeat_latency latency
-         with
-         | Eio.Cancel.Cancelled _ as e -> raise e
-         | exn ->
-           Log.Transport.error
-             "gRPC heartbeat iteration crashed: %s"
-             (Printexc.to_string exn)));
+           (try
+              let t0 = Unix.gettimeofday () in
+              (* Update agent last_seen *)
+              (try
+                 let agent_file =
+                   Filename.concat
+                     (Filename.concat
+                        (Common.masc_dir_from_base_path ~base_path:room_config.base_path)
+                        "agents")
+                     (safe_filename ping.agent_name ^ ".json")
+                 in
+                 if Sys.file_exists agent_file
+                 then (
+                   let json = Yojson.Safe.from_string (read_file_safe agent_file) in
+                   match Masc_domain.agent_of_yojson json with
+                   | Ok agent ->
+                     let now = Unix.gettimeofday () in
+                     let iso_now =
+                       let tm = Unix.gmtime now in
+                       Printf.sprintf
+                         "%04d-%02d-%02dT%02d:%02d:%02dZ"
+                         (1900 + tm.tm_year)
+                         (1 + tm.tm_mon)
+                         tm.tm_mday
+                         tm.tm_hour
+                         tm.tm_min
+                         tm.tm_sec
+                     in
+                     let updated = { agent with Masc_domain.last_seen = iso_now } in
+                     let content =
+                       Yojson.Safe.to_string (Masc_domain.agent_to_yojson updated)
+                     in
+                     let tmp_path = agent_file ^ ".tmp" in
+                     Fs_compat.save_file tmp_path content;
+                     Unix.rename tmp_path agent_file
+                   | Error e ->
+                     Log.Transport.warn
+                       "gRPC heartbeat: invalid agent JSON for %s: %s"
+                       ping.agent_name
+                       e)
+               with
+               | Eio.Cancel.Cancelled _ as e -> raise e
+               | exn ->
+                 Log.Transport.error
+                   "gRPC heartbeat update failed: %s"
+                   (Printexc.to_string exn));
+              (* Count active agents and pending tasks *)
+              let masc_dir =
+                Common.masc_dir_from_base_path ~base_path:room_config.base_path
+              in
+              let agents_dir = Filename.concat masc_dir "agents" in
+              let agent_count =
+                if Sys.file_exists agents_dir
+                then Array.length (Sys.readdir agents_dir)
+                else 0
+              in
+              let tasks_dir = Filename.concat masc_dir "tasks" in
+              let pending_count =
+                if Sys.file_exists tasks_dir
+                then
+                  Sys.readdir tasks_dir
+                  |> Array.to_list
+                  |> List.filter (fun f -> Filename.check_suffix f ".json")
+                  |> List.length
+                else 0
+              in
+              let directives =
+                compute_directives ~room_config ~agent_name:ping.agent_name
+              in
+              let ack =
+                T.HeartbeatAck.
+                  { timestamp_ms = now_ms ()
+                  ; active_agent_count = agent_count
+                  ; pending_task_count = pending_count
+                  ; directives
+                  }
+              in
+              let ack_bytes = T.HeartbeatAck.to_bytes ack in
+              Transport_metrics.inc_grpc_bytes_sent ~bytes:(String.length ack_bytes);
+              Grpc_eio.Stream.add response_stream ack_bytes;
+              (* Record heartbeat latency *)
+              let latency = Unix.gettimeofday () -. t0 in
+              Transport_metrics.observe_grpc_heartbeat_latency latency
+            with
+            | Eio.Cancel.Cancelled _ as e -> raise e
+            | exn ->
+              Log.Transport.error
+                "gRPC heartbeat iteration crashed: %s"
+                (Printexc.to_string exn)));
         loop ()
-      | exception End_of_file ->
-        cleanup ()
+      | exception End_of_file -> cleanup ()
     in
-    try loop ()
-    with
+    try loop () with
     | Eio.Cancel.Cancelled _ as e ->
       cleanup ();
       raise e
@@ -403,12 +451,12 @@ let handle_heartbeat
         (Printexc.to_string exn);
       cleanup ());
   response_stream
+;;
 
 (** Subscribe server-streaming handler: push room events to the agent. *)
-let handle_subscribe
-    (room_config : Coord_utils_backend_setup.config)
-    (bytes : string)
-  : string Grpc_eio.Stream.t =
+let handle_subscribe (room_config : Coord_utils_backend_setup.config) (bytes : string)
+  : string Grpc_eio.Stream.t
+  =
   let req =
     decode_request_or_raise ~rpc:"Subscribe" T.SubscribeRequest.of_bytes_result bytes
   in
@@ -417,34 +465,34 @@ let handle_subscribe
   Transport_metrics.set_grpc_subscribers (Atomic.get active_subscribe_streams);
   let events_count = ref 0 in
   let stream_closed = Atomic.make false in
-  let sub_id = Printf.sprintf "grpc-subscribe-%s-%Ld"
-    req.agent_name (now_ms ()) in
+  let sub_id = Printf.sprintf "grpc-subscribe-%s-%Ld" req.agent_name (now_ms ()) in
   let cleanup_subscriber ?exn () =
-    if Atomic.compare_and_set stream_closed false true then begin
+    if Atomic.compare_and_set stream_closed false true
+    then (
       Sse.unsubscribe_external sub_id;
       Atomic.decr active_subscribe_streams;
-      Transport_metrics.set_grpc_subscribers
-        (Atomic.get active_subscribe_streams);
+      Transport_metrics.set_grpc_subscribers (Atomic.get active_subscribe_streams);
       Option.iter
         (fun err ->
-          Log.Misc.warn "gRPC subscriber %s failed: %s" sub_id
-            (Printexc.to_string err))
+           Log.Misc.warn "gRPC subscriber %s failed: %s" sub_id (Printexc.to_string err))
         exn;
-      Log.Misc.info "gRPC subscriber %s cleaned up" sub_id
-    end
+      Log.Misc.info "gRPC subscriber %s cleaned up" sub_id)
   in
   (* Send initial event confirming subscription *)
-  let init_event = T.Event.{
-    seq = 0L;
-    event_type = "subscription_started";
-    source_agent = "server";
-    timestamp_ms = now_ms ();
-    payload_json = Printf.sprintf
-      {|{"agent_name":"%s","event_types":%s}|}
-      req.agent_name
-      (Yojson.Safe.to_string
-        (`List (List.map (fun s -> `String s) req.event_types)));
-  } in
+  let init_event =
+    T.Event.
+      { seq = 0L
+      ; event_type = "subscription_started"
+      ; source_agent = "server"
+      ; timestamp_ms = now_ms ()
+      ; payload_json =
+          Printf.sprintf
+            {|{"agent_name":"%s","event_types":%s}|}
+            req.agent_name
+            (Yojson.Safe.to_string
+               (`List (List.map (fun s -> `String s) req.event_types)))
+      }
+  in
   let init_bytes = T.Event.to_bytes init_event in
   Transport_metrics.inc_grpc_bytes_sent ~bytes:(String.length init_bytes);
   Grpc_eio.Stream.add stream init_bytes;
@@ -455,43 +503,43 @@ let handle_subscribe
       (Common.masc_dir_from_base_path ~base_path:room_config.base_path)
       "backlog.jsonl"
   in
-  if Sys.file_exists backlog_file then begin
+  if Sys.file_exists backlog_file
+  then (
     let content = Fs_compat.load_file backlog_file in
     let lines = String.split_on_char '\n' content in
     let seq = ref 1L in
     let scanned = ref 0 in
     let replayed = ref 0 in
-    List.iter (fun line ->
-      if String.length line > 0 then begin
-        incr scanned;
-        let msg_seq = !seq in
-        if Int64.compare msg_seq req.since_seq > 0 then begin
-          let event = T.Event.{
-            seq = msg_seq;
-            event_type = "message";
-            source_agent = "";
-            timestamp_ms = now_ms ();
-            payload_json = line;
-          } in
-          let event_bytes = T.Event.to_bytes event in
-          Transport_metrics.inc_grpc_bytes_sent
-            ~bytes:(String.length event_bytes);
-          Grpc_eio.Stream.add stream event_bytes;
-          incr events_count;
-          incr replayed
-        end;
-        seq := Int64.add !seq 1L
-      end
-    ) lines;
+    List.iter
+      (fun line ->
+         if String.length line > 0
+         then (
+           incr scanned;
+           let msg_seq = !seq in
+           if Int64.compare msg_seq req.since_seq > 0
+           then (
+             let event =
+               T.Event.
+                 { seq = msg_seq
+                 ; event_type = "message"
+                 ; source_agent = ""
+                 ; timestamp_ms = now_ms ()
+                 ; payload_json = line
+                 }
+             in
+             let event_bytes = T.Event.to_bytes event in
+             Transport_metrics.inc_grpc_bytes_sent ~bytes:(String.length event_bytes);
+             Grpc_eio.Stream.add stream event_bytes;
+             incr events_count;
+             incr replayed);
+           seq := Int64.add !seq 1L))
+      lines;
     (* Attribution: scanned vs replayed splits wasted scan cost from
        useful catch-up delivery on this Subscribe RPC. *)
-    if !scanned > 0 then
-      Transport_metrics.inc_grpc_backlog_replay_lines_scanned
-        ~delta:!scanned ();
-    if !replayed > 0 then
-      Transport_metrics.inc_grpc_backlog_replay_events_replayed
-        ~delta:!replayed ()
-  end;
+    if !scanned > 0
+    then Transport_metrics.inc_grpc_backlog_replay_lines_scanned ~delta:!scanned ();
+    if !replayed > 0
+    then Transport_metrics.inc_grpc_backlog_replay_events_replayed ~delta:!replayed ());
   (* Record delivered events from backlog replay *)
   Transport_metrics.inc_grpc_events_delivered ~delta:!events_count ();
   (* Hook into SSE broadcast mechanism for real-time event push.
@@ -508,48 +556,52 @@ let handle_subscribe
      mid-flight by a config change; newly-subscribing clients pick up
      the new value. *)
   let max_buffer = stream_max_buffer () in
-  Sse.subscribe_external ~id:sub_id
+  Sse.subscribe_external
+    ~id:sub_id
     ~is_alive:(fun () ->
-      not (Atomic.get stream_closed) && not (Grpc_eio.Stream.is_closed stream))
+      (not (Atomic.get stream_closed)) && not (Grpc_eio.Stream.is_closed stream))
     ~callback:(fun sse_event ->
-    if Atomic.get stream_closed || Grpc_eio.Stream.is_closed stream then begin
-      (* Stream already gone — auto-cleanup *)
-      cleanup_subscriber ()
-    end else if Grpc_eio.Stream.length stream >= max_buffer then begin
-      (* Stream buffer near-full — drop event to avoid blocking broadcast.
+      if Atomic.get stream_closed || Grpc_eio.Stream.is_closed stream
+      then
+        (* Stream already gone — auto-cleanup *)
+        cleanup_subscriber ()
+      else if Grpc_eio.Stream.length stream >= max_buffer
+      then (
+        (* Stream buffer near-full — drop event to avoid blocking broadcast.
          Bump [masc_grpc_events_dropped_total] so the capacity pressure
          is visible to operators and the drop is not just a log line. *)
-      Transport_metrics.inc_grpc_events_dropped ();
-      Log.Misc.warn "gRPC subscriber %s: buffer full (%d), dropping event"
-        sub_id (Grpc_eio.Stream.length stream)
-    end
-    else begin
-      let seq = Int64.of_int (Atomic.fetch_and_add seq_counter 1) in
-      let event = T.Event.{
-        seq;
-        event_type = "sse_broadcast";
-        source_agent = "server";
-        timestamp_ms = now_ms ();
-        payload_json = sse_event;
-      } in
-      try
-        let event_bytes = T.Event.to_bytes event in
-        Transport_metrics.inc_grpc_bytes_sent
-          ~bytes:(String.length event_bytes);
-        Grpc_eio.Stream.add stream event_bytes
-      with
-      | Eio.Cancel.Cancelled _ as e ->
-        cleanup_subscriber ();
-        raise e
-      | exn ->
-        cleanup_subscriber ~exn ()
-    end
-  ) ();
+        Transport_metrics.inc_grpc_events_dropped ();
+        Log.Misc.warn
+          "gRPC subscriber %s: buffer full (%d), dropping event"
+          sub_id
+          (Grpc_eio.Stream.length stream))
+      else (
+        let seq = Int64.of_int (Atomic.fetch_and_add seq_counter 1) in
+        let event =
+          T.Event.
+            { seq
+            ; event_type = "sse_broadcast"
+            ; source_agent = "server"
+            ; timestamp_ms = now_ms ()
+            ; payload_json = sse_event
+            }
+        in
+        try
+          let event_bytes = T.Event.to_bytes event in
+          Transport_metrics.inc_grpc_bytes_sent ~bytes:(String.length event_bytes);
+          Grpc_eio.Stream.add stream event_bytes
+        with
+        | Eio.Cancel.Cancelled _ as e ->
+          cleanup_subscriber ();
+          raise e
+        | exn -> cleanup_subscriber ~exn ()))
+    ();
   (* Stream stays open; will be closed when the gRPC connection drops
      or the server shuts down. The callback auto-detects closed streams
      via Grpc_eio.Stream.is_closed and self-unsubscribes.
      The is_alive check also triggers auto-removal during broadcast. *)
   stream
+;;
 
 (** {1 Service Construction} *)
 
@@ -559,16 +611,17 @@ let handle_subscribe
     @param tool_dispatcher Function that dispatches tool calls:
       [tool_name -> arguments_json -> (result_json, error_message) result]. *)
 let create_service
-    ~(room_config : Coord_utils_backend_setup.config)
-    ~(tool_dispatcher : string -> string -> (string, string) result)
-  : Grpc_eio.Service.t =
+      ~(room_config : Coord_utils_backend_setup.config)
+      ~(tool_dispatcher : string -> string -> (string, string) result)
+  : Grpc_eio.Service.t
+  =
   Grpc_eio.Service.create service_name
   |> Grpc_eio.Service.add_unary "Join" (handle_join room_config)
   |> Grpc_eio.Service.add_unary "Leave" (handle_leave room_config)
   |> Grpc_eio.Service.add_unary "Broadcast" (handle_broadcast room_config)
   |> Grpc_eio.Service.add_unary "GetStatus" (handle_get_status room_config)
   |> Grpc_eio.Service.add_unary "ToolCall" (handle_tool_call tool_dispatcher)
-  |> Grpc_eio.Service.add_server_streaming "Subscribe"
-    (handle_subscribe room_config)
-  |> Grpc_eio.Service.add_bidi_streaming "Heartbeat"
-    (handle_heartbeat room_config)
+  |> Grpc_eio.Service.add_unary "LspCall" handle_lsp_call
+  |> Grpc_eio.Service.add_server_streaming "Subscribe" (handle_subscribe room_config)
+  |> Grpc_eio.Service.add_bidi_streaming "Heartbeat" (handle_heartbeat room_config)
+;;

--- a/lib/grpc/masc_grpc_service.ml
+++ b/lib/grpc/masc_grpc_service.ml
@@ -258,6 +258,31 @@ let handle_tool_call
   T.ToolCallResponse.to_bytes result
 ;;
 
+(** LspCall handler placeholder.
+
+    The actual LSP message routing lives in [Server_ide_lsp_proxy] /
+    [Lsp_process_manager] and currently requires an [Eio] switch + filesystem
+    capability that this gRPC service does not yet receive. Until that wiring
+    lands, [handle_lsp_call] returns a structured [error_message] so callers
+    on the dashboard side observe an explicit "not yet implemented" instead
+    of a transport error.
+
+    Success semantics follow [ToolCallResponse]: [error_message = ""] means
+    the JSON-RPC response in [jsonrpc_response_json] is valid; otherwise the
+    request was rejected before reaching the LSP process. *)
+let handle_lsp_call (bytes : string) : string =
+  let _req =
+    decode_request_or_raise ~rpc:"LspCall" T.LspRequest.of_bytes_result bytes
+  in
+  let resp =
+    T.LspResponse.
+      { jsonrpc_response_json = ""
+      ; error_message = "LspCall: server-side LSP dispatcher not yet wired"
+      }
+  in
+  T.LspResponse.to_bytes resp
+;;
+
 (** {1 Streaming Handlers} *)
 
 (** Active heartbeat stream count (atomic for signal safety). *)

--- a/lib/grpc/masc_grpc_types.ml
+++ b/lib/grpc/masc_grpc_types.ml
@@ -13,8 +13,7 @@ module P = Masc_proto.Masc_coordination.Masc.Coordination.V1
 (** {1 Protobuf Serialization Helpers} *)
 
 (** Serialize a protobuf message to a binary string. *)
-let encode to_proto msg =
-  Ocaml_protoc_plugin.Writer.contents (to_proto msg)
+let encode to_proto msg = Ocaml_protoc_plugin.Writer.contents (to_proto msg)
 
 (** Deserialize a protobuf message from a binary string. *)
 let decode_result from_proto bytes =
@@ -23,8 +22,10 @@ let decode_result from_proto bytes =
   | Ok v -> Ok v
   | Error e ->
     Error
-      (Printf.sprintf "protobuf decode error: %s"
+      (Printf.sprintf
+         "protobuf decode error: %s"
          (Ocaml_protoc_plugin.Result.show_error e))
+;;
 
 (** Deserialize a protobuf message from a binary string.
     Raises [Invalid_argument] on parse error. *)
@@ -32,424 +33,498 @@ let decode from_proto bytes =
   match decode_result from_proto bytes with
   | Ok v -> v
   | Error msg -> invalid_arg msg
+;;
 
 (** {1 Shared Types} *)
 
-type agent_info = {
-  name : string;
-  status : string;
-  capabilities : string list;
-  last_heartbeat_ms : int64;
-  joined_at_ms : int64;
-  current_task_id : string;
-}
+type agent_info =
+  { name : string
+  ; status : string
+  ; capabilities : string list
+  ; last_heartbeat_ms : int64
+  ; joined_at_ms : int64
+  ; current_task_id : string
+  }
 
-type task_info = {
-  id : string;
-  title : string;
-  status : string;
-  assigned_to : string;
-  priority : int;
-}
+type task_info =
+  { id : string
+  ; title : string
+  ; status : string
+  ; assigned_to : string
+  ; priority : int
+  }
 
 (** Convert our [agent_info] to a protobuf AgentInfo and back. *)
 let agent_info_to_proto (a : agent_info) : P.AgentInfo.t =
-  { name = a.name;
-    status = a.status;
-    capabilities = a.capabilities;
-    last_heartbeat_ms = a.last_heartbeat_ms;
-    joined_at_ms = a.joined_at_ms;
-    current_task_id = a.current_task_id;
+  { name = a.name
+  ; status = a.status
+  ; capabilities = a.capabilities
+  ; last_heartbeat_ms = a.last_heartbeat_ms
+  ; joined_at_ms = a.joined_at_ms
+  ; current_task_id = a.current_task_id
   }
+;;
 
 let agent_info_of_proto (p : P.AgentInfo.t) : agent_info =
-  { name = p.name;
-    status = p.status;
-    capabilities = p.capabilities;
-    last_heartbeat_ms = p.last_heartbeat_ms;
-    joined_at_ms = p.joined_at_ms;
-    current_task_id = p.current_task_id;
+  { name = p.name
+  ; status = p.status
+  ; capabilities = p.capabilities
+  ; last_heartbeat_ms = p.last_heartbeat_ms
+  ; joined_at_ms = p.joined_at_ms
+  ; current_task_id = p.current_task_id
   }
+;;
 
 (** Convert our [task_info] to a protobuf TaskInfo and back. *)
 let task_info_to_proto (t : task_info) : P.TaskInfo.t =
-  { id = t.id;
-    title = t.title;
-    status = t.status;
-    assigned_to = t.assigned_to;
-    priority = t.priority;
+  { id = t.id
+  ; title = t.title
+  ; status = t.status
+  ; assigned_to = t.assigned_to
+  ; priority = t.priority
   }
+;;
 
 let task_info_of_proto (p : P.TaskInfo.t) : task_info =
-  { id = p.id;
-    title = p.title;
-    status = p.status;
-    assigned_to = p.assigned_to;
-    priority = p.priority;
+  { id = p.id
+  ; title = p.title
+  ; status = p.status
+  ; assigned_to = p.assigned_to
+  ; priority = p.priority
   }
+;;
 
 (** {1 Agent Lifecycle} *)
 
 module JoinRequest = struct
-  type t = {
-    agent_name : string;
-    capabilities : string list;
-    metadata : (string * string) list;
-  }
+  type t =
+    { agent_name : string
+    ; capabilities : string list
+    ; metadata : (string * string) list
+    }
 
   let of_bytes_result bytes =
     match decode_result P.JoinRequest.from_proto bytes with
     | Ok p ->
-        Ok
-          ({ agent_name = p.agent_name;
-             capabilities = p.capabilities;
-             metadata = p.metadata;
-           } : t)
+      Ok
+        ({ agent_name = p.agent_name
+         ; capabilities = p.capabilities
+         ; metadata = p.metadata
+         }
+         : t)
     | Error _ as err -> err
+  ;;
 
   let of_bytes bytes =
     match of_bytes_result bytes with
     | Ok req -> req
     | Error msg -> invalid_arg msg
+  ;;
 
   let to_bytes (t : t) =
-    encode P.JoinRequest.to_proto
-      { agent_name = t.agent_name;
-        capabilities = t.capabilities;
-        metadata = t.metadata;
-      }
+    encode
+      P.JoinRequest.to_proto
+      { agent_name = t.agent_name; capabilities = t.capabilities; metadata = t.metadata }
+  ;;
 end
 
 module JoinResponse = struct
-  type t = {
-    success : bool;
-    message : string;
-    session_id : string;
-    active_agents : agent_info list;
-  }
+  type t =
+    { success : bool
+    ; message : string
+    ; session_id : string
+    ; active_agents : agent_info list
+    }
 
   let of_bytes bytes =
     let p = decode P.JoinResponse.from_proto bytes in
-    { success = p.success;
-      message = p.message;
-      session_id = p.session_id;
-      active_agents = List.map agent_info_of_proto p.active_agents;
+    { success = p.success
+    ; message = p.message
+    ; session_id = p.session_id
+    ; active_agents = List.map agent_info_of_proto p.active_agents
     }
+  ;;
 
   let to_bytes (t : t) =
-    encode P.JoinResponse.to_proto
-      { success = t.success;
-        message = t.message;
-        session_id = t.session_id;
-        active_agents = List.map agent_info_to_proto t.active_agents;
+    encode
+      P.JoinResponse.to_proto
+      { success = t.success
+      ; message = t.message
+      ; session_id = t.session_id
+      ; active_agents = List.map agent_info_to_proto t.active_agents
       }
+  ;;
 end
 
 module LeaveRequest = struct
-  type t = {
-    agent_name : string;
-    session_id : string;
-  }
+  type t =
+    { agent_name : string
+    ; session_id : string
+    }
 
   let of_bytes_result bytes =
     match decode_result P.LeaveRequest.from_proto bytes with
-    | Ok p ->
-        Ok
-          ({ agent_name = p.agent_name;
-             session_id = p.session_id;
-           } : t)
+    | Ok p -> Ok ({ agent_name = p.agent_name; session_id = p.session_id } : t)
     | Error _ as err -> err
+  ;;
 
   let of_bytes bytes =
     match of_bytes_result bytes with
     | Ok req -> req
     | Error msg -> invalid_arg msg
+  ;;
 
   let to_bytes (t : t) =
-    encode P.LeaveRequest.to_proto
-      { agent_name = t.agent_name;
-        session_id = t.session_id;
-      }
+    encode
+      P.LeaveRequest.to_proto
+      { agent_name = t.agent_name; session_id = t.session_id }
+  ;;
 end
 
 module LeaveResponse = struct
-  type t = {
-    success : bool;
-    message : string;
-  }
+  type t =
+    { success : bool
+    ; message : string
+    }
 
   let of_bytes bytes =
     let p = decode P.LeaveResponse.from_proto bytes in
-    { success = p.success;
-      message = p.message;
-    }
+    { success = p.success; message = p.message }
+  ;;
 
   let to_bytes (t : t) =
-    encode P.LeaveResponse.to_proto
-      { success = t.success;
-        message = t.message;
-      }
+    encode P.LeaveResponse.to_proto { success = t.success; message = t.message }
+  ;;
 end
 
 (** {1 Heartbeat} *)
 
 module HeartbeatPing = struct
-  type t = {
-    agent_name : string;
-    session_id : string;
-    timestamp_ms : int64;
-    current_task_id : string;
-  }
+  type t =
+    { agent_name : string
+    ; session_id : string
+    ; timestamp_ms : int64
+    ; current_task_id : string
+    }
 
   let of_bytes_result bytes =
     match decode_result P.HeartbeatPing.from_proto bytes with
     | Ok p ->
-        Ok
-          ({ agent_name = p.agent_name;
-             session_id = p.session_id;
-             timestamp_ms = p.timestamp_ms;
-             current_task_id = p.current_task_id;
-           } : t)
+      Ok
+        ({ agent_name = p.agent_name
+         ; session_id = p.session_id
+         ; timestamp_ms = p.timestamp_ms
+         ; current_task_id = p.current_task_id
+         }
+         : t)
     | Error _ as err -> err
+  ;;
 
   let of_bytes bytes =
     match of_bytes_result bytes with
     | Ok ping -> ping
     | Error msg -> invalid_arg msg
+  ;;
 
   let to_bytes (t : t) =
-    encode P.HeartbeatPing.to_proto
-      { agent_name = t.agent_name;
-        session_id = t.session_id;
-        timestamp_ms = t.timestamp_ms;
-        current_task_id = t.current_task_id;
+    encode
+      P.HeartbeatPing.to_proto
+      { agent_name = t.agent_name
+      ; session_id = t.session_id
+      ; timestamp_ms = t.timestamp_ms
+      ; current_task_id = t.current_task_id
       }
+  ;;
 end
 
 module HeartbeatAck = struct
-  type t = {
-    timestamp_ms : int64;
-    active_agent_count : int;
-    pending_task_count : int;
-    directives : string list;
-  }
+  type t =
+    { timestamp_ms : int64
+    ; active_agent_count : int
+    ; pending_task_count : int
+    ; directives : string list
+    }
 
   let of_bytes bytes =
     let p = decode P.HeartbeatAck.from_proto bytes in
-    { timestamp_ms = p.timestamp_ms;
-      active_agent_count = p.active_agent_count;
-      pending_task_count = p.pending_task_count;
-      directives = p.directives;
+    { timestamp_ms = p.timestamp_ms
+    ; active_agent_count = p.active_agent_count
+    ; pending_task_count = p.pending_task_count
+    ; directives = p.directives
     }
+  ;;
 
   let to_bytes (t : t) =
-    encode P.HeartbeatAck.to_proto
-      { timestamp_ms = t.timestamp_ms;
-        active_agent_count = t.active_agent_count;
-        pending_task_count = t.pending_task_count;
-        directives = t.directives;
+    encode
+      P.HeartbeatAck.to_proto
+      { timestamp_ms = t.timestamp_ms
+      ; active_agent_count = t.active_agent_count
+      ; pending_task_count = t.pending_task_count
+      ; directives = t.directives
       }
+  ;;
 end
 
 (** {1 Event Subscription} *)
 
 module SubscribeRequest = struct
-  type t = {
-    agent_name : string;
-    session_id : string;
-    event_types : string list;
-    since_seq : int64;
-  }
+  type t =
+    { agent_name : string
+    ; session_id : string
+    ; event_types : string list
+    ; since_seq : int64
+    }
 
   let of_bytes_result bytes =
     match decode_result P.SubscribeRequest.from_proto bytes with
     | Ok p ->
-        Ok
-          ({ agent_name = p.agent_name;
-             session_id = p.session_id;
-             event_types = p.event_types;
-             since_seq = p.since_seq;
-           } : t)
+      Ok
+        ({ agent_name = p.agent_name
+         ; session_id = p.session_id
+         ; event_types = p.event_types
+         ; since_seq = p.since_seq
+         }
+         : t)
     | Error _ as err -> err
+  ;;
 
   let of_bytes bytes =
     match of_bytes_result bytes with
     | Ok req -> req
     | Error msg -> invalid_arg msg
+  ;;
 end
 
 module SubscribeRequest_serde = struct
   let to_bytes (t : SubscribeRequest.t) =
-    encode P.SubscribeRequest.to_proto
-      { agent_name = t.agent_name;
-        session_id = t.session_id;
-        event_types = t.event_types;
-        since_seq = t.since_seq;
+    encode
+      P.SubscribeRequest.to_proto
+      { agent_name = t.agent_name
+      ; session_id = t.session_id
+      ; event_types = t.event_types
+      ; since_seq = t.since_seq
       }
+  ;;
 end
 
 module Event = struct
-  type t = {
-    seq : int64;
-    event_type : string;
-    source_agent : string;
-    timestamp_ms : int64;
-    payload_json : string;
-  }
+  type t =
+    { seq : int64
+    ; event_type : string
+    ; source_agent : string
+    ; timestamp_ms : int64
+    ; payload_json : string
+    }
 
   let of_bytes bytes =
     let p = decode P.Event.from_proto bytes in
-    { seq = p.seq;
-      event_type = p.event_type;
-      source_agent = p.source_agent;
-      timestamp_ms = p.timestamp_ms;
-      payload_json = p.payload_json;
+    { seq = p.seq
+    ; event_type = p.event_type
+    ; source_agent = p.source_agent
+    ; timestamp_ms = p.timestamp_ms
+    ; payload_json = p.payload_json
     }
+  ;;
 
   let to_bytes (t : t) =
-    encode P.Event.to_proto
-      { seq = t.seq;
-        event_type = t.event_type;
-        source_agent = t.source_agent;
-        timestamp_ms = t.timestamp_ms;
-        payload_json = t.payload_json;
+    encode
+      P.Event.to_proto
+      { seq = t.seq
+      ; event_type = t.event_type
+      ; source_agent = t.source_agent
+      ; timestamp_ms = t.timestamp_ms
+      ; payload_json = t.payload_json
       }
+  ;;
 end
 
 (** {1 Tool Call} *)
 
 module ToolCallRequest = struct
-  type t = {
-    agent_name : string;
-    session_id : string;
-    tool_name : string;
-    arguments_json : string;
-  }
+  type t =
+    { agent_name : string
+    ; session_id : string
+    ; tool_name : string
+    ; arguments_json : string
+    }
 
   let of_bytes_result bytes =
     match decode_result P.ToolCallRequest.from_proto bytes with
     | Ok p ->
-        Ok
-          ({ agent_name = p.agent_name;
-             session_id = p.session_id;
-             tool_name = p.tool_name;
-             arguments_json = p.arguments_json;
-           } : t)
+      Ok
+        ({ agent_name = p.agent_name
+         ; session_id = p.session_id
+         ; tool_name = p.tool_name
+         ; arguments_json = p.arguments_json
+         }
+         : t)
     | Error _ as err -> err
+  ;;
 
   let of_bytes bytes =
     match of_bytes_result bytes with
     | Ok req -> req
     | Error msg -> invalid_arg msg
+  ;;
 
   let to_bytes (t : t) =
-    encode P.ToolCallRequest.to_proto
-      { agent_name = t.agent_name;
-        session_id = t.session_id;
-        tool_name = t.tool_name;
-        arguments_json = t.arguments_json;
+    encode
+      P.ToolCallRequest.to_proto
+      { agent_name = t.agent_name
+      ; session_id = t.session_id
+      ; tool_name = t.tool_name
+      ; arguments_json = t.arguments_json
       }
+  ;;
 end
 
 module ToolCallResponse = struct
-  type t = {
-    success : bool;
-    result_json : string;
-    error_message : string;
-    error_code : int;
-  }
+  type t =
+    { success : bool
+    ; result_json : string
+    ; error_message : string
+    ; error_code : int
+    }
 
   let of_bytes bytes =
     let p = decode P.ToolCallResponse.from_proto bytes in
-    { success = p.success;
-      result_json = p.result_json;
-      error_message = p.error_message;
-      error_code = p.error_code;
+    { success = p.success
+    ; result_json = p.result_json
+    ; error_message = p.error_message
+    ; error_code = p.error_code
     }
+  ;;
 
   let to_bytes (t : t) =
-    encode P.ToolCallResponse.to_proto
-      { success = t.success;
-        result_json = t.result_json;
-        error_message = t.error_message;
-        error_code = t.error_code;
+    encode
+      P.ToolCallResponse.to_proto
+      { success = t.success
+      ; result_json = t.result_json
+      ; error_message = t.error_message
+      ; error_code = t.error_code
       }
+  ;;
 end
 
 (** {1 Broadcast} *)
 
 module BroadcastRequest = struct
-  type t = {
-    agent_name : string;
-    message : string;
-    mentions : string list;
-  }
+  type t =
+    { agent_name : string
+    ; message : string
+    ; mentions : string list
+    }
 
   let of_bytes_result bytes =
     match decode_result P.BroadcastRequest.from_proto bytes with
     | Ok p ->
-        Ok
-          ({ agent_name = p.agent_name;
-             message = p.message;
-             mentions = p.mentions;
-           } : t)
+      Ok ({ agent_name = p.agent_name; message = p.message; mentions = p.mentions } : t)
     | Error _ as err -> err
+  ;;
 
   let of_bytes bytes =
     match of_bytes_result bytes with
     | Ok req -> req
     | Error msg -> invalid_arg msg
+  ;;
 
   let to_bytes (t : t) =
-    encode P.BroadcastRequest.to_proto
-      { agent_name = t.agent_name;
-        message = t.message;
-        mentions = t.mentions;
-      }
+    encode
+      P.BroadcastRequest.to_proto
+      { agent_name = t.agent_name; message = t.message; mentions = t.mentions }
+  ;;
 end
 
 module BroadcastResponse = struct
-  type t = {
-    success : bool;
-    seq : int64;
-  }
+  type t =
+    { success : bool
+    ; seq : int64
+    }
 
   let of_bytes bytes =
     let p = decode P.BroadcastResponse.from_proto bytes in
-    { success = p.success;
-      seq = p.seq;
-    }
+    { success = p.success; seq = p.seq }
+  ;;
 
   let to_bytes (t : t) =
-    encode P.BroadcastResponse.to_proto
-      { success = t.success;
-        seq = t.seq;
-      }
+    encode P.BroadcastResponse.to_proto { success = t.success; seq = t.seq }
+  ;;
 end
 
 (** {1 Status} *)
 
 module StatusResponse = struct
-  type t = {
-    agents : agent_info list;
-    tasks : task_info list;
-    message_count : int;
-    room_path : string;
-  }
+  type t =
+    { agents : agent_info list
+    ; tasks : task_info list
+    ; message_count : int
+    ; room_path : string
+    }
 
   let of_bytes bytes =
     let p = decode P.StatusResponse.from_proto bytes in
-    { agents = List.map agent_info_of_proto p.agents;
-      tasks = List.map task_info_of_proto p.tasks;
-      message_count = p.message_count;
-      room_path = p.room_path;
+    { agents = List.map agent_info_of_proto p.agents
+    ; tasks = List.map task_info_of_proto p.tasks
+    ; message_count = p.message_count
+    ; room_path = p.room_path
     }
+  ;;
 
   let to_bytes (t : t) =
-    encode P.StatusResponse.to_proto
-      { agents = List.map agent_info_to_proto t.agents;
-        tasks = List.map task_info_to_proto t.tasks;
-        message_count = t.message_count;
-        room_path = t.room_path;
+    encode
+      P.StatusResponse.to_proto
+      { agents = List.map agent_info_to_proto t.agents
+      ; tasks = List.map task_info_to_proto t.tasks
+      ; message_count = t.message_count
+      ; room_path = t.room_path
       }
+  ;;
+end
+
+(** {1 LSP Proxy} *)
+
+module LspRequest = struct
+  type t =
+    { language_id : string
+    ; jsonrpc_request_json : string
+    ; workspace_root : string option
+    }
+
+  let of_bytes bytes =
+    let p = decode P.LspRequest.from_proto bytes in
+    { language_id = p.language_id
+    ; jsonrpc_request_json = p.jsonrpc_request_json
+    ; workspace_root =
+        (match p.workspace_root with
+         | "" -> None
+         | s -> Some s)
+    }
+  ;;
+
+  let to_bytes (t : t) =
+    encode
+      P.LspRequest.to_proto
+      { language_id = t.language_id
+      ; jsonrpc_request_json = t.jsonrpc_request_json
+      ; workspace_root = Option.value ~default:"" t.workspace_root
+      }
+  ;;
+end
+
+module LspResponse = struct
+  type t =
+    { jsonrpc_response_json : string
+    ; error_message : string
+    }
+
+  let of_bytes bytes =
+    let p = decode P.LspResponse.from_proto bytes in
+    { jsonrpc_response_json = p.jsonrpc_response_json; error_message = p.error_message }
+  ;;
+
+  let to_bytes (t : t) =
+    encode
+      P.LspResponse.to_proto
+      { jsonrpc_response_json = t.jsonrpc_response_json; error_message = t.error_message }
+  ;;
 end

--- a/lib/grpc/masc_grpc_types.mli
+++ b/lib/grpc/masc_grpc_types.mli
@@ -9,62 +9,66 @@
 
 (** {1 Shared Types} *)
 
-type agent_info = {
-  name : string;
-  status : string;
-  capabilities : string list;
-  last_heartbeat_ms : int64;
-  joined_at_ms : int64;
-  current_task_id : string;
-}
+type agent_info =
+  { name : string
+  ; status : string
+  ; capabilities : string list
+  ; last_heartbeat_ms : int64
+  ; joined_at_ms : int64
+  ; current_task_id : string
+  }
 
-type task_info = {
-  id : string;
-  title : string;
-  status : string;
-  assigned_to : string;
-  priority : int;
-}
+type task_info =
+  { id : string
+  ; title : string
+  ; status : string
+  ; assigned_to : string
+  ; priority : int
+  }
 
 (** {1 Agent Lifecycle} *)
 
 module JoinRequest : sig
-  type t = {
-    agent_name : string;
-    capabilities : string list;
-    metadata : (string * string) list;
-  }
+  type t =
+    { agent_name : string
+    ; capabilities : string list
+    ; metadata : (string * string) list
+    }
+
   val of_bytes_result : string -> (t, string) result
   val of_bytes : string -> t
   val to_bytes : t -> string
 end
 
 module JoinResponse : sig
-  type t = {
-    success : bool;
-    message : string;
-    session_id : string;
-    active_agents : agent_info list;
-  }
+  type t =
+    { success : bool
+    ; message : string
+    ; session_id : string
+    ; active_agents : agent_info list
+    }
+
   val of_bytes : string -> t
   val to_bytes : t -> string
 end
 
 module LeaveRequest : sig
-  type t = {
-    agent_name : string;
-    session_id : string;
-  }
+  type t =
+    { agent_name : string
+    ; session_id : string
+    }
+
   val of_bytes_result : string -> (t, string) result
   val of_bytes : string -> t
   val to_bytes : t -> string
 end
 
 module LeaveResponse : sig
-  type t = {
-    success : bool;
-    message : string;
-  }
+  type t =
+    { success : bool
+    ; message : string
+    }
+
   val of_bytes : string -> t
   val to_bytes : t -> string
 end
@@ -72,24 +76,26 @@ end
 (** {1 Heartbeat} *)
 
 module HeartbeatPing : sig
-  type t = {
-    agent_name : string;
-    session_id : string;
-    timestamp_ms : int64;
-    current_task_id : string;
-  }
+  type t =
+    { agent_name : string
+    ; session_id : string
+    ; timestamp_ms : int64
+    ; current_task_id : string
+    }
+
   val of_bytes_result : string -> (t, string) result
   val of_bytes : string -> t
   val to_bytes : t -> string
 end
 
 module HeartbeatAck : sig
-  type t = {
-    timestamp_ms : int64;
-    active_agent_count : int;
-    pending_task_count : int;
-    directives : string list;
-  }
+  type t =
+    { timestamp_ms : int64
+    ; active_agent_count : int
+    ; pending_task_count : int
+    ; directives : string list
+    }
+
   val of_bytes : string -> t
   val to_bytes : t -> string
 end
@@ -97,12 +103,13 @@ end
 (** {1 Event Subscription} *)
 
 module SubscribeRequest : sig
-  type t = {
-    agent_name : string;
-    session_id : string;
-    event_types : string list;
-    since_seq : int64;
-  }
+  type t =
+    { agent_name : string
+    ; session_id : string
+    ; event_types : string list
+    ; since_seq : int64
+    }
+
   val of_bytes_result : string -> (t, string) result
   val of_bytes : string -> t
 end
@@ -113,13 +120,14 @@ module SubscribeRequest_serde : sig
 end
 
 module Event : sig
-  type t = {
-    seq : int64;
-    event_type : string;
-    source_agent : string;
-    timestamp_ms : int64;
-    payload_json : string;
-  }
+  type t =
+    { seq : int64
+    ; event_type : string
+    ; source_agent : string
+    ; timestamp_ms : int64
+    ; payload_json : string
+    }
+
   val of_bytes : string -> t
   val to_bytes : t -> string
 end
@@ -127,24 +135,26 @@ end
 (** {1 Tool Call} *)
 
 module ToolCallRequest : sig
-  type t = {
-    agent_name : string;
-    session_id : string;
-    tool_name : string;
-    arguments_json : string;
-  }
+  type t =
+    { agent_name : string
+    ; session_id : string
+    ; tool_name : string
+    ; arguments_json : string
+    }
+
   val of_bytes_result : string -> (t, string) result
   val of_bytes : string -> t
   val to_bytes : t -> string
 end
 
 module ToolCallResponse : sig
-  type t = {
-    success : bool;
-    result_json : string;
-    error_message : string;
-    error_code : int;
-  }
+  type t =
+    { success : bool
+    ; result_json : string
+    ; error_message : string
+    ; error_code : int
+    }
+
   val of_bytes : string -> t
   val to_bytes : t -> string
 end
@@ -152,21 +162,23 @@ end
 (** {1 Broadcast} *)
 
 module BroadcastRequest : sig
-  type t = {
-    agent_name : string;
-    message : string;
-    mentions : string list;
-  }
+  type t =
+    { agent_name : string
+    ; message : string
+    ; mentions : string list
+    }
+
   val of_bytes_result : string -> (t, string) result
   val of_bytes : string -> t
   val to_bytes : t -> string
 end
 
 module BroadcastResponse : sig
-  type t = {
-    success : bool;
-    seq : int64;
-  }
+  type t =
+    { success : bool
+    ; seq : int64
+    }
+
   val of_bytes : string -> t
   val to_bytes : t -> string
 end
@@ -174,12 +186,36 @@ end
 (** {1 Status} *)
 
 module StatusResponse : sig
-  type t = {
-    agents : agent_info list;
-    tasks : task_info list;
-    message_count : int;
-    room_path : string;
-  }
+  type t =
+    { agents : agent_info list
+    ; tasks : task_info list
+    ; message_count : int
+    ; room_path : string
+    }
+
+  val of_bytes : string -> t
+  val to_bytes : t -> string
+end
+
+(** {1 LSP Proxy} *)
+
+module LspRequest : sig
+  type t =
+    { language_id : string
+    ; jsonrpc_request_json : string
+    ; workspace_root : string option
+    }
+
+  val of_bytes : string -> t
+  val to_bytes : t -> string
+end
+
+module LspResponse : sig
+  type t =
+    { jsonrpc_response_json : string
+    ; error_message : string
+    }
+
   val of_bytes : string -> t
   val to_bytes : t -> string
 end

--- a/proto/masc_coordination.proto
+++ b/proto/masc_coordination.proto
@@ -184,8 +184,13 @@ message LspRequest {
 }
 
 message LspResponse {
-  // JSON-RPC 2.0 response object serialized as a string.
+  // JSON-RPC 2.0 response object serialized as a string. Only valid when
+  // error_message is empty.
   string jsonrpc_response_json = 1;
-  // Error message if the LSP server could not be reached.
+  // Empty string means the request reached the LSP server and the JSON-RPC
+  // response is in jsonrpc_response_json (which may itself carry a JSON-RPC
+  // level error per the JSON-RPC spec). Non-empty means the gRPC service
+  // rejected the request before it reached the LSP process (transport-level
+  // failure, no language server, dispatcher not wired, etc.).
   string error_message = 2;
 }

--- a/proto/masc_coordination.proto
+++ b/proto/masc_coordination.proto
@@ -35,6 +35,12 @@ service MascCoordination {
 
   // Get current room status.
   rpc GetStatus(StatusRequest) returns (StatusResponse);
+
+  // LSP proxy call: forwards a JSON-RPC LSP request to the language server
+  // and returns the JSON-RPC response.  Used by the IDE dashboard to
+  // obtain hover, codeLens, inlayHint, and diagnostic results over the
+  // gRPC-web transport instead of a separate WebSocket.
+  rpc LspCall(LspRequest) returns (LspResponse);
 }
 
 // ===== Agent Lifecycle =====
@@ -164,4 +170,22 @@ message TaskInfo {
   string status = 3;
   string assigned_to = 4;
   int32 priority = 5;
+}
+
+// ===== LSP Proxy =====
+
+message LspRequest {
+  // Language ID, e.g. "ocaml", "typescript", "go".
+  string language_id = 1;
+  // JSON-RPC 2.0 request object serialized as a string.
+  string jsonrpc_request_json = 2;
+  // Optional: workspace root URI for the LSP server.
+  string workspace_root = 3;
+}
+
+message LspResponse {
+  // JSON-RPC 2.0 response object serialized as a string.
+  string jsonrpc_response_json = 1;
+  // Error message if the LSP server could not be reached.
+  string error_message = 2;
 }


### PR DESCRIPTION
Adds LspCall unary RPC to the MascCoordination gRPC service, enabling IDE dashboard to forward LSP JSON-RPC requests over gRPC-web instead of a separate WebSocket.

Changes:
- Extend proto/masc_coordination.proto with LspCall RPC + LspRequest/LspResponse messages
- Add LspRequest and LspResponse OCaml types with to_bytes/of_bytes
- Add handle_lsp_call handler to gRPC service (placeholder, returns not-yet-implemented)
- Add lspCall method to dashboard GrpcTransport
- Add LspRequest/LspResponse TypeScript types

Verification:
- dune build --root . lib/grpc/masc_grpc_types.ml passes
- dune build --root . lib/grpc/masc_grpc_service.ml passes

Refs Phase 1: Wire gRPC consumer for LSP results