### PR TITLE
fix(cascade): RFC-0058 Phase 4 cleanup — teach declarative consumers about sub-table routes

### DIFF
--- a/config/cascade.json
+++ b/config/cascade.json
@@ -1,5 +1,236 @@
 {
-  "_comment": "Checked-in seed for cascade authoring. Repo defaults expose exactly two profiles: big_three for keeper/workflow calls and tool_rerank for short rerank calls. Logical usage names are configured under [routes] instead of being profile names.",
+  "providers": {
+    "claude_code": {
+      "display-name": "Anthropic Claude Code CLI",
+      "protocol": "anthropic-cli",
+      "command": "claude",
+      "is-non-interactive": true,
+      "credentials": { "type": "env", "key": "ANTHROPIC_API_KEY" }
+    },
+    "codex_cli": {
+      "display-name": "OpenAI Codex CLI",
+      "protocol": "openai-http",
+      "command": "codex",
+      "is-non-interactive": true,
+      "credentials": { "type": "env", "key": "OPENAI_API_KEY" }
+    },
+    "gemini_cli": {
+      "display-name": "Google Gemini CLI",
+      "protocol": "google-cli",
+      "command": "gemini",
+      "is-non-interactive": true,
+      "credentials": { "type": "env", "key": "GEMINI_API_KEY" }
+    },
+    "kimi_cli": {
+      "display-name": "Moonshot Kimi CLI",
+      "protocol": "kimi-cli",
+      "command": "kimi",
+      "is-non-interactive": true,
+      "credentials": { "type": "env", "key": "MOONSHOT_API_KEY" }
+    },
+    "glm-coding": {
+      "display-name": "Zhipu GLM Coding",
+      "protocol": "openai-http",
+      "endpoint": "https://api.z.ai/api/coding/paas/v4",
+      "credentials": { "type": "env", "key": "ZAI_API_KEY" }
+    },
+    "ollama": {
+      "display-name": "Ollama Local",
+      "protocol": "ollama-http",
+      "endpoint": "http://localhost:11434"
+    }
+  },
+  "models": {
+    "codex-spark": {
+      "api-name": "gpt-5.3-codex-spark",
+      "max-context": 128000,
+      "tools-support": true,
+      "streaming": true
+    },
+    "kimi-coding": {
+      "api-name": "kimi-for-coding",
+      "max-context": 128000,
+      "tools-support": true,
+      "streaming": true
+    },
+    "sonnet": {
+      "api-name": "claude-sonnet-4-6",
+      "max-context": 200000,
+      "tools-support": true,
+      "thinking-support": true,
+      "max-thinking-budget": 16000,
+      "streaming": true
+    },
+    "haiku": {
+      "api-name": "claude-haiku-4-5-20251001",
+      "max-context": 200000,
+      "tools-support": true,
+      "streaming": true
+    },
+    "gemini-flash": {
+      "api-name": "gemini-3-flash-preview",
+      "max-context": 128000,
+      "tools-support": true,
+      "streaming": true
+    },
+    "gemini-flash-lite": {
+      "api-name": "gemini-3.1-flash-lite-preview",
+      "max-context": 128000,
+      "tools-support": true,
+      "streaming": true
+    },
+    "glm-5-turbo": {
+      "api-name": "glm-5-turbo",
+      "max-context": 128000,
+      "tools-support": true,
+      "streaming": true
+    },
+    "glm-flashx": {
+      "api-name": "glm-4.7-flashx",
+      "max-context": 128000,
+      "tools-support": true,
+      "streaming": true
+    }
+  },
+  "codex_cli": {
+    "codex-spark": {
+      "is-default": true,
+      "max-concurrent": 1,
+      "for-tool-rerank": { "max-output": 1024, "temperature": 0.1 }
+    }
+  },
+  "kimi_cli": { "kimi-coding": { "is-default": true, "max-concurrent": 1 } },
+  "claude_code": {
+    "sonnet": {
+      "is-default": true,
+      "max-concurrent": 1,
+      "price-input": 3.0,
+      "price-output": 15.0
+    },
+    "haiku": {
+      "is-default": false,
+      "max-concurrent": 2,
+      "price-input": 0.8,
+      "price-output": 4.0,
+      "for-tool-rerank": { "max-output": 1024, "temperature": 0.1 },
+      "for-governance": {
+        "max-input": 8192,
+        "max-output": 2048,
+        "temperature": 0.1
+      }
+    }
+  },
+  "gemini_cli": {
+    "gemini-flash": { "is-default": true, "max-concurrent": 1 },
+    "gemini-flash-lite": { "is-default": false, "max-concurrent": 1 }
+  },
+  "glm-coding": {
+    "glm-5-turbo": { "is-default": true, "max-concurrent": 2 },
+    "glm-flashx": { "is-default": false, "max-concurrent": 2 }
+  },
+  "tier": {
+    "big_three": {
+      "members": [ "codex_cli.codex-spark", "kimi_cli.kimi-coding" ],
+      "strategy": "failover"
+    },
+    "keeper_diverse": {
+      "members": [
+        "claude_code.sonnet", "gemini_cli.gemini-flash",
+        "codex_cli.codex-spark"
+      ],
+      "strategy": "failover"
+    },
+    "tool_rerank": {
+      "members": [
+        "codex_cli.codex-spark.for-tool-rerank",
+        "claude_code.haiku.for-tool-rerank"
+      ],
+      "strategy": "failover"
+    },
+    "governance": {
+      "members": [ "claude_code.haiku.for-governance" ],
+      "strategy": "failover"
+    },
+    "tier_small": { "members": [], "strategy": "failover" },
+    "tier_medium": {
+      "members": [ "glm-coding.glm-flashx" ],
+      "strategy": "failover"
+    },
+    "__safe_lane": {
+      "members": [ "kimi_cli.kimi-coding" ],
+      "strategy": "failover"
+    },
+    "local_recovery": {
+      "members": [ "codex_cli.codex-spark" ],
+      "strategy": "failover"
+    },
+    "tier_fast": {
+      "members": [
+        "claude_code.haiku", "codex_cli.codex-spark",
+        "gemini_cli.gemini-flash", "gemini_cli.gemini-flash-lite",
+        "glm-coding.glm-5-turbo", "glm-coding.glm-flashx"
+      ],
+      "strategy": "failover"
+    }
+  },
+  "tier-group": {
+    "big_three": {
+      "tiers": [ "big_three", "keeper_diverse", "__safe_lane" ],
+      "strategy": "priority_tier",
+      "fallback": true
+    },
+    "tier_small": {
+      "tiers": [ "tier_small", "tier_medium", "big_three" ],
+      "strategy": "priority_tier",
+      "fallback": true
+    },
+    "tier_medium": {
+      "tiers": [ "tier_medium", "big_three" ],
+      "strategy": "priority_tier",
+      "fallback": true
+    },
+    "local_recovery": {
+      "tiers": [ "local_recovery", "big_three" ],
+      "strategy": "priority_tier",
+      "fallback": true
+    },
+    "tier_fast": {
+      "tiers": [ "tier_fast", "big_three" ],
+      "strategy": "priority_tier",
+      "fallback": true
+    },
+    "tool_rerank": {
+      "tiers": [ "tool_rerank", "__safe_lane" ],
+      "strategy": "priority_tier",
+      "fallback": true
+    },
+    "governance": {
+      "tiers": [ "governance", "__safe_lane" ],
+      "strategy": "priority_tier",
+      "fallback": true
+    }
+  },
+  "routes": {
+    "keeper_turn": { "target": "tier-group.big_three" },
+    "phase_recovery": { "target": "tier-group.big_three" },
+    "phase_buffer": { "target": "tier-group.big_three" },
+    "tool_required": { "target": "tier-group.big_three" },
+    "governance_judge": { "target": "tier-group.governance" },
+    "operator_judge": { "target": "tier-group.governance" },
+    "cross_verifier": { "target": "tier-group.big_three" },
+    "verifier": { "target": "tier-group.big_three" },
+    "autoresearch": { "target": "tier-group.big_three" },
+    "adversarial_reviewer": { "target": "tier-group.big_three" },
+    "auto_responder": { "target": "tier-group.big_three" },
+    "routing": { "target": "tier-group.big_three" },
+    "openai_compat": { "target": "tier-group.big_three" },
+    "persona_generation": { "target": "tier-group.big_three" },
+    "provider_benchmark": { "target": "tier-group.big_three" },
+    "llm_rerank": { "target": "tier-group.tool_rerank" },
+    "simple_task": { "target": "tier-group.tier_small" },
+    "moderate_task": { "target": "tier-group.tier_medium" },
+    "complex_task": { "target": "tier-group.big_three" }
+  },
   "profiles": {
     "tool_strict": {
       "required_capabilities": [
@@ -14,98 +245,5 @@
       "required_capabilities": [ "runtime_mcp_tools", "runtime_tool_events" ]
     },
     "local": { "required_capabilities": [] }
-  },
-  "routes": {
-    "keeper_turn": "big_three",
-    "phase_recovery": "big_three",
-    "phase_buffer": "big_three",
-    "tool_required": "big_three",
-    "governance_judge": "big_three",
-    "operator_judge": "big_three",
-    "cross_verifier": "big_three",
-    "verifier": "big_three",
-    "autoresearch": "big_three",
-    "adversarial_reviewer": "big_three",
-    "auto_responder": "big_three",
-    "routing": "big_three",
-    "openai_compat": "big_three",
-    "persona_generation": "big_three",
-    "provider_benchmark": "big_three",
-    "llm_rerank": "tool_rerank",
-    "simple_task": "tier_small",
-    "moderate_task": "tier_medium",
-    "complex_task": "big_three"
-  },
-  "_comment_big_three": "Canonical keeper/workflow profile. Keep operator-chosen providers here; code must route logical usages through [routes] instead of hardcoding extra profile names.",
-  "big_three_models": [
-    "codex_cli:gpt-5.3-codex-spark",
-    "gemini_cli:auto",
-    "kimi_cli:kimi-for-coding",
-    { "model": "glm-coding:auto", "supports_tool_choice": true },
-    "claude_code:auto"
-  ],
-  "big_three_temperature": 0.2,
-  "big_three_max_tokens": 16384,
-  "big_three_thinking_enabled": false,
-  "big_three_keeper_assignable": true,
-  "big_three_fallback_cascade": "keeper_diverse",
-  "_comment_keeper_diverse": "Fallback cascade for contract violation retry. Different model composition from big_three to break correlated failure.",
-  "keeper_diverse_models": [
-    "claude_code:claude-sonnet-4-6", "gemini_cli:gemini-3-flash-preview",
-    "codex_cli:gpt-5.3-codex-spark"
-  ],
-  "keeper_diverse_temperature": 0.3,
-  "keeper_diverse_max_tokens": 16384,
-  "keeper_diverse_keeper_assignable": true,
-  "_comment_tool_rerank": "System-only short-output profile for rerank/scoring calls.",
-  "tool_rerank_models": [
-    "codex_cli:gpt-5.3-codex-spark", "gemini_cli:auto",
-    "kimi_cli:kimi-for-coding", "glm-coding:auto", "claude_code:auto"
-  ],
-  "tool_rerank_temperature": 0.0,
-  "tool_rerank_max_tokens": 200,
-  "tool_rerank_keeper_assignable": false,
-  "_comment_tier_small": "Operator opt-in slot for 4B-class local models. Empty by default; routes fall through to tier_medium.",
-  "tier_small_models": [],
-  "tier_small_temperature": 0.3,
-  "tier_small_max_tokens": 1000,
-  "tier_small_keeper_assignable": false,
-  "tier_small_fallback_cascade": "tier_medium",
-  "_comment_tier_medium": "9B-class models for moderate tasks (extraction, reformat, medium-length generation). Falls back to big_three on exhaustion.",
-  "tier_medium_models": [ "glm-coding:glm-4.7-flashx" ],
-  "tier_medium_temperature": 0.2,
-  "tier_medium_max_tokens": 4096,
-  "tier_medium_keeper_assignable": false,
-  "tier_medium_fallback_cascade": "big_three",
-  "_comment___safe_lane": "System-only baseline cascade. Satisfies every capability profile. Used as last-resort fallback target. Not keeper-assignable.",
-  "__safe_lane_models": [
-    "claude_code:auto",
-    { "model": "glm-coding:auto", "supports_tool_choice": true },
-    "kimi_cli:kimi-for-coding"
-  ],
-  "__safe_lane_temperature": 0.2,
-  "__safe_lane_max_tokens": 16384,
-  "__safe_lane_keeper_assignable": false,
-  "__safe_lane_required_capability_profile": "tool_strict",
-  "_comment_local_recovery": "P1-2 fix: recovery profile for fallback_cascade = \"local_recovery\". Uses a curated local/CLI primary list, then falls back to big_three on exhaustion. Not keeper-assignable.",
-  "local_recovery_models": [
-    "codex_cli:gpt-5.3-codex-spark", "gemini_cli:auto", "claude_code:auto"
-  ],
-  "local_recovery_temperature": 0.2,
-  "local_recovery_max_tokens": 16384,
-  "local_recovery_keeper_assignable": false,
-  "local_recovery_fallback_cascade": "big_three",
-  "_comment_tier_fast": "Cheap+fast tool-capable cloud models for keeper turns. Bias toward latency and cost over reasoning depth. All entries support tool calling. Falls back to big_three on exhaustion.",
-  "tier_fast_models": [
-    "claude_code:claude-haiku-4-5-20251001",
-    "codex_cli:gpt-5.3-codex-spark",
-    "gemini_cli:gemini-3-flash-preview",
-    "gemini_cli:gemini-3.1-flash-lite-preview",
-    { "model": "glm-coding:glm-5-turbo", "supports_tool_choice": true },
-    { "model": "glm-coding:glm-4.7-flashx", "supports_tool_choice": true }
-  ],
-  "tier_fast_temperature": 0.2,
-  "tier_fast_max_tokens": 8192,
-  "tier_fast_keeper_assignable": true,
-  "tier_fast_fallback_cascade": "big_three"
+  }
 }

--- a/lib/cascade/cascade_routes.ml
+++ b/lib/cascade/cascade_routes.ml
@@ -130,17 +130,33 @@ let logical_use_of_string_opt raw =
              then Some spec.use
              else None)
 
+(* RFC-0058 v2 supports two route encodings in the materialized JSON:
+   - legacy:    {"routes": {"X": "tier_or_group"}}            (string value)
+   - declarative: {"routes": {"X": {"target": "tier-..."}}}   (object value)
+   The Phase 4 materializer (lib/cascade/cascade_toml_materializer.ml)
+   passes sub-tables through verbatim, so this consumer must extract
+   the [target] field instead of filtering non-string values to None —
+   otherwise every declarative route silently disappears from the
+   runtime view (Cascade_routes.configured_route_targets returns []).
+   See PR #14550 review thread #DUH/#DUN for the regression report. *)
+let target_of_route_value : Yojson.Safe.t -> string option = function
+  | `String raw -> Some (String.trim raw)
+  | `Assoc obj ->
+      (match List.assoc_opt "target" obj with
+       | Some (`String raw) -> Some (String.trim raw)
+       | _ -> None)
+  | _ -> None
+
 let route_bindings_from_json = function
   | `Assoc fields -> (
       match List.assoc_opt "routes" fields with
       | Some (`Assoc routes) ->
           routes
           |> List.filter_map (fun (key, value) ->
-                 match value with
-                 | `String raw_target ->
-                     let target = String.trim raw_target in
-                     if String.equal key "" || String.equal target "" then None
-                     else Some (key, target)
+                 match target_of_route_value value with
+                 | Some target
+                   when not (String.equal key "" || String.equal target "") ->
+                     Some (key, target)
                  | _ -> None)
       | _ -> [])
   | _ -> []

--- a/lib/cascade/cascade_routes.mli
+++ b/lib/cascade/cascade_routes.mli
@@ -45,9 +45,9 @@ val cascade_name_for_use : ?config_path:string -> logical_use -> string
 val route_bindings_from_json : Yojson.Safe.t -> (string * string) list
 (** Decode the [routes] object of a materialized cascade JSON into a
     [(key, target)] association list. Accepts both the legacy
-    encoding ({{!t}[routes.X = "Y"]}) and the RFC-0058 sub-table
-    encoding ({{!t}[routes.X.target = "Y"]}). Exposed for regression
-    testing of the dual-form decoder. *)
+    encoding [routes.X = "Y"] and the RFC-0058 sub-table encoding
+    [\[routes.X\] target = "Y"]. Exposed for regression testing of
+    the dual-form decoder. *)
 
 val configured_route_targets : ?config_path:string -> unit -> string list
 (** Unique non-empty profile names referenced by [routes]. *)

--- a/lib/cascade/cascade_routes.mli
+++ b/lib/cascade/cascade_routes.mli
@@ -42,6 +42,13 @@ val cascade_name_for_use : ?config_path:string -> logical_use -> string
     empty — [Cascade_catalog_runtime.validate_path_result] is the boot-time
     boundary that prevents this state from being reached at runtime. *)
 
+val route_bindings_from_json : Yojson.Safe.t -> (string * string) list
+(** Decode the [routes] object of a materialized cascade JSON into a
+    [(key, target)] association list. Accepts both the legacy
+    encoding ({{!t}[routes.X = "Y"]}) and the RFC-0058 sub-table
+    encoding ({{!t}[routes.X.target = "Y"]}). Exposed for regression
+    testing of the dual-form decoder. *)
+
 val configured_route_targets : ?config_path:string -> unit -> string list
 (** Unique non-empty profile names referenced by [routes]. *)
 

--- a/lib/cascade/cascade_toml_materializer.ml
+++ b/lib/cascade/cascade_toml_materializer.ml
@@ -659,11 +659,33 @@ let toml_section_names_result ~config_path =
               String.equal key "routes"
               || String.equal key "profiles"
               || String.equal key "admission"
+              (* RFC-0058 v2 declarative namespaces: these describe
+                 providers, models, tiers, and tier-groups, not legacy
+                 cascade profiles. Without this filter the degraded
+                 fallback validator would treat e.g. "providers" or
+                 "tier" as a cascade name and expand them into bogus
+                 profile names. *)
+              || String.equal key "providers"
+              || String.equal key "models"
+              || String.equal key "tier"
+              || String.equal key "tier-group"
             in
+            (* Top-level provider-alias binding tables (e.g. [claude_code.haiku]
+               appears as a top-level "claude_code" key with sub-table
+               "haiku"). Identify them by checking the [providers]
+               namespace declared earlier so they are not surfaced as
+               cascade profile names either. *)
+            let provider_ids =
+              match List.assoc_opt "providers" fields with
+              | Some (Otoml.TomlTable inner) | Some (Otoml.TomlInlineTable inner) ->
+                List.map fst inner
+              | _ -> []
+            in
+            let is_provider_binding key = List.mem key provider_ids in
             let names =
               fields
               |> List.filter_map (fun (key, value) ->
-                if is_meta_key key || is_reserved_table key
+                if is_meta_key key || is_reserved_table key || is_provider_binding key
                 then None
                 else (
                   match value with

--- a/test/dune
+++ b/test/dune
@@ -218,6 +218,7 @@
         test_observability_provider_contracts
         test_config_doctor
         test_cascade_toml_materialization
+        test_cascade_routes_decoder
         test_cascade_toml_section_fallback_10259
         test_cascade_declarative_parser
         test_cascade_declarative_validator
@@ -459,6 +460,7 @@
           test_observability_provider_contracts
           test_config_doctor
           test_cascade_toml_materialization
+          test_cascade_routes_decoder
           test_cascade_toml_section_fallback_10259
           test_cascade_declarative_parser
           test_cascade_declarative_validator

--- a/test/test_cascade_routes_decoder.ml
+++ b/test/test_cascade_routes_decoder.ml
@@ -1,0 +1,72 @@
+(** Regression test for [Cascade_routes.route_bindings_from_json] — RFC-0058
+    Phase 4 follow-up.
+
+    PR #14550 introduced the declarative sub-table form for routes
+    ([routes.X] target = "Y") but the materializer passes those sub-tables
+    through verbatim. The legacy consumer here used to filter every
+    non-string value to [None], silently dropping every declarative route.
+    These tests guard against that regression and confirm that the two
+    encodings — legacy string and declarative sub-table — both decode to
+    the same [(key, target)] binding list. *)
+
+open Alcotest
+
+let bindings = testable
+    (fun fmt (k, t) -> Format.fprintf fmt "(%s, %s)" k t)
+    (fun (a, b) (c, d) -> String.equal a c && String.equal b d)
+
+let parse_routes_json src =
+  let j = Yojson.Safe.from_string src in
+  Masc_mcp.Cascade_routes.route_bindings_from_json j
+  |> List.sort (fun (a, _) (b, _) -> String.compare a b)
+
+let test_legacy_string_form () =
+  check (list bindings) "legacy routes decode to (key, target)"
+    [ "keeper_turn", "big_three"; "llm_rerank", "tool_rerank" ]
+    (parse_routes_json
+       {|{"routes": {"keeper_turn": "big_three", "llm_rerank": "tool_rerank"}}|})
+
+let test_declarative_sub_table_form () =
+  check (list bindings)
+    "declarative sub-table routes decode by reading target"
+    [ "keeper_turn", "tier-group.big_three"
+    ; "llm_rerank", "tier-group.tool_rerank"
+    ]
+    (parse_routes_json
+       {|{"routes": {
+          "keeper_turn": {"target": "tier-group.big_three"},
+          "llm_rerank": {"target": "tier-group.tool_rerank"}
+        }}|})
+
+let test_mixed_form_decodes_both () =
+  check (list bindings) "mixed legacy+declarative entries both surface"
+    [ "modern", "tier-group.modern"; "old", "big_three" ]
+    (parse_routes_json
+       {|{"routes": {
+          "old": "big_three",
+          "modern": {"target": "tier-group.modern"}
+        }}|})
+
+let test_empty_target_dropped () =
+  check (list bindings) "empty target string is filtered"
+    []
+    (parse_routes_json
+       {|{"routes": {"X": {"target": "   "}}}|})
+
+let test_missing_target_dropped () =
+  check (list bindings) "sub-table without target is filtered"
+    []
+    (parse_routes_json
+       {|{"routes": {"X": {"other": "value"}}}|})
+
+let () =
+  Alcotest.run "cascade_routes_decoder"
+    [ ( "route_bindings_from_json"
+      , [ test_case "legacy string form" `Quick test_legacy_string_form
+        ; test_case "declarative sub-table form" `Quick
+            test_declarative_sub_table_form
+        ; test_case "mixed forms decode both" `Quick test_mixed_form_decodes_both
+        ; test_case "empty target is filtered" `Quick test_empty_target_dropped
+        ; test_case "missing target is filtered" `Quick test_missing_target_dropped
+        ] )
+    ]


### PR DESCRIPTION
## Summary

Phase 4 (PR #14550) shipped the declarative cascade.toml schema and a materializer that passes the RFC-0058 namespaces through, but three legacy consumers were not updated and silently dropped declarative data. This PR teaches them about the new form.

| Symptom | Status |
|---------|--------|
| `Cascade_routes.configured_route_targets` / `_keys` return `[]` because the sub-table encoding `{X: {target: "Y"}}` is filtered by the legacy string-only decoder | **FIXED** |
| `Cascade_toml_materializer.toml_section_names_result` surfaces `providers`/`models`/`tier`/`tier-group` and provider-alias binding tables as cascade profile names in degraded fallback | **FIXED** |
| `config/cascade.json` carries legacy schema and drifts from `cascade.toml` (toml↔json sync gate) | **FIXED** (regenerated via `bin/cascade_materialize.exe`) |
| Catalog discovery still walks legacy `<profile>_models` keys; declarative `tier.<n>.members` not bridged | Out of scope (Phase 5 loader switchover) |

## What changed

- `lib/cascade/cascade_routes.ml` — `route_bindings_from_json` now accepts both encodings via a `target_of_route_value` helper. Empty / missing targets still filter out.
- `lib/cascade/cascade_routes.mli` — `route_bindings_from_json` exposed so the regression test can pin the dual-form contract.
- `lib/cascade/cascade_toml_materializer.ml` — `toml_section_names_result` excludes RFC-0058 namespaces and any top-level table that matches a declared provider id.
- `config/cascade.json` — regenerated to match `config/cascade.toml`.
- `test/test_cascade_routes_decoder.ml` (new) — 5 alcotest cases: legacy string form, declarative sub-table form, mixed forms, empty target, missing target. Wired into `test/dune`.

## Why split out from PR #14550

PR #14550 (squashed as 1fbedc450c) shipped the producer side of the declarative schema. After merge, copilot-pull-request-reviewer flagged the consumer-side silent regression in four new review threads (#DT9/#DUH/#DUN/#DUU). This PR closes #DUH/#DUN/#DUU and partially #DT9 (sections fallback). The remaining piece of #DT9 (catalog discovery `<profile>_models` → declarative `tier.<n>.members` bridge) is the Phase 5 loader switchover.

## Test plan

- [x] `dune build --root . lib/cascade/` clean
- [x] `bin/cascade_materialize.exe config/cascade.json` regenerates cascade.json without errors
- [x] 98 tests pass across affected suites:
  - `test_cascade_routes_decoder` — 5/5 (new)
  - `test_cascade_declarative_parser` — 28/28
  - `test_cascade_declarative_validator` — 25/25
  - `test_cascade_declarative_adapter` — 17/17
  - `test_cascade_declarative_hotpath` — 12/12
  - `test_cascade_toml_section_fallback_10259` — 8/8
  - `test_cascade_toml_materializer_admission` — 3/3
- [ ] CI: full `dune test`
- [ ] CI: ocamlformat / lint

🤖 Generated with [Claude Code](https://claude.com/claude-code)