### PR TITLE
fix(keeper): link_task idempotency cache + session_id (follow-up to merged #14564)

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -16,17 +16,41 @@ include Keeper_agent_checkpoint_hygiene
    The link call writes the backlog file and emits a Task.Linked activity
    event each invocation. Keying on (keeper_name, task_id, trace_id) means
    we only call link once per (task, trace) pair instead of once per turn.
-   Memory footprint is bounded by the keeper × task fan-out, which is
-   small (1 keeper writes 1 task at a time today). *)
+
+   trace_id rotates on every keeper run, and task_id grows over the
+   lifetime of a long-lived process, so the entry count is unbounded
+   in principle. A bounded FIFO eviction keeps the table at a fixed
+   ceiling — losing the oldest entry only forces one extra link call,
+   which costs one backlog write but never breaks correctness. *)
+
+let link_task_cache_max_entries = 4096
+
 let link_task_cache : (string * string * string, unit) Hashtbl.t =
-  Hashtbl.create 32
+  Hashtbl.create link_task_cache_max_entries
 ;;
 
+(* FIFO order so we know which entry to evict when the table is full. *)
+let link_task_cache_order : (string * string * string) Queue.t = Queue.create ()
 let link_task_cache_mutex = Stdlib.Mutex.create ()
 
+let evict_oldest_locked () =
+  match Queue.take_opt link_task_cache_order with
+  | None -> ()
+  | Some key -> Hashtbl.remove link_task_cache key
+;;
+
 let mark_task_link ~keeper ~task_id ~trace_id =
+  let key = keeper, task_id, trace_id in
   Stdlib.Mutex.protect link_task_cache_mutex (fun () ->
-    Hashtbl.replace link_task_cache (keeper, task_id, trace_id) ())
+    if Hashtbl.mem link_task_cache key
+    then ()
+    else begin
+      while Hashtbl.length link_task_cache >= link_task_cache_max_entries do
+        evict_oldest_locked ()
+      done;
+      Hashtbl.add link_task_cache key ();
+      Queue.add key link_task_cache_order
+    end)
 ;;
 
 let task_link_already_recorded ~keeper ~task_id ~trace_id =

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -12,6 +12,28 @@ include Keeper_agent_checkpoint_hygiene
 
 (* Post-turn telemetry logging — extracted to Keeper_turn_telemetry (#5732) *)
 
+(* Idempotency cache for link_task_execution_artifacts (PR #14564 review).
+   The link call writes the backlog file and emits a Task.Linked activity
+   event each invocation. Keying on (keeper_name, task_id, trace_id) means
+   we only call link once per (task, trace) pair instead of once per turn.
+   Memory footprint is bounded by the keeper × task fan-out, which is
+   small (1 keeper writes 1 task at a time today). *)
+let link_task_cache : (string * string * string, unit) Hashtbl.t =
+  Hashtbl.create 32
+;;
+
+let link_task_cache_mutex = Stdlib.Mutex.create ()
+
+let mark_task_link ~keeper ~task_id ~trace_id =
+  Stdlib.Mutex.protect link_task_cache_mutex (fun () ->
+    Hashtbl.replace link_task_cache (keeper, task_id, trace_id) ())
+;;
+
+let task_link_already_recorded ~keeper ~task_id ~trace_id =
+  Stdlib.Mutex.protect link_task_cache_mutex (fun () ->
+    Hashtbl.mem link_task_cache (keeper, task_id, trace_id))
+;;
+
 let per_provider_timeout_for_turn
       ~(meta : Keeper_types.keeper_meta)
       ?oas_timeout_s
@@ -1559,45 +1581,63 @@ let run_turn
           Link execution artifacts to the current task if one exists.
 
           NOTE: moved after receipt append so receipt persistence is not
-          delayed by backlog lock contention (review comment on PR #14564).
-          This still runs every turn while current_task_id is set; root fix
-          is to make the link call idempotent by checking whether the
-          trace_id is already on the task contract. Tracked as follow-up. *)
+          delayed by backlog lock contention (review on PR #14564).
+          Skipped when this (keeper, task, trace_id) tuple has already
+          been linked — Coord.link_task_execution_artifacts_r writes the
+          backlog and emits a Task.Linked event unconditionally, so
+          calling it every turn for an unchanged trace produced lock
+          contention and event-feed noise. *)
        let () =
          match acc.meta.current_task_id with
          | None -> ()
          | Some task_id ->
            let task_id_str = Keeper_id.Task_id.to_string task_id in
-           let operation_id =
-             Some (Keeper_id.Trace_id.to_string meta.runtime.trace_id)
-           in
-           let result =
-             try
-               Coord.link_task_execution_artifacts_r
-                 config
-                 ~task_id:task_id_str
-                 ?operation_id
-                 ()
-             with
-             | Eio.Cancel.Cancelled _ as e -> raise e
-             | exn ->
-               (* link takes a backlog file lock; an OS-level lock
-                  contention or transient I/O hiccup can raise before
-                  the function gets a chance to return Error. Convert
-                  that into a normal Error so the warn path below logs
-                  it instead of unwinding the whole keeper turn. *)
-               Error
-                 (Masc_domain.System
-                    (Masc_domain.System_error.IoError (Printexc.to_string exn)))
-           in
-           (match result with
-            | Ok _ -> ()
-            | Error err ->
-              Log.Keeper.warn
-                "keeper:%s link_task_execution_artifacts failed for task=%s: %s"
-                meta.name
-                task_id_str
-                (Masc_domain.masc_error_to_string err))
+           let trace_id_str = Keeper_id.Trace_id.to_string meta.runtime.trace_id in
+           if task_link_already_recorded
+                ~keeper:meta.name
+                ~task_id:task_id_str
+                ~trace_id:trace_id_str
+           then ()
+           else begin
+             (* Pass trace_id as both session_id and operation_id to match
+                the existing keeper_run_tools.ml convention (session_id
+                fields elsewhere are populated from trace_id). *)
+             let session_id = Some trace_id_str in
+             let operation_id = Some trace_id_str in
+             let result =
+               try
+                 Coord.link_task_execution_artifacts_r
+                   config
+                   ~task_id:task_id_str
+                   ?session_id
+                   ?operation_id
+                   ()
+               with
+               | Eio.Cancel.Cancelled _ as e -> raise e
+               | exn ->
+                 (* link takes a backlog file lock; an OS-level lock
+                    contention or transient I/O hiccup can raise before
+                    the function gets a chance to return Error. Convert
+                    that into a normal Error so the warn path below logs
+                    it instead of unwinding the whole keeper turn. *)
+                 Error
+                   (Masc_domain.System
+                      (Masc_domain.System_error.IoError (Printexc.to_string exn)))
+             in
+             (match result with
+              | Ok _ ->
+                mark_task_link
+                  ~keeper:meta.name
+                  ~task_id:task_id_str
+                  ~trace_id:trace_id_str
+              | Error err ->
+                Log.Keeper.warn
+                  "keeper:%s link_task_execution_artifacts failed for \
+                   task=%s: %s"
+                  meta.name
+                  task_id_str
+                  (Masc_domain.masc_error_to_string err))
+           end
        in
        (match turn_result, receipt_append_outcome with
         | Error _, _ ->


### PR DESCRIPTION
## Summary

Follow-up to merged PR #14564. Two CodeRabbit/Copilot review comments arrived after squash-merge so the fix could not land on that PR. Filing as a fresh PR off `origin/main`.

- Pass `session_id = trace_id` alongside `operation_id` (existing convention in `keeper_run_tools.ml:1431`/`:1539`).
- Memoise `(keeper, task_id, trace_id)` so `Coord.link_task_execution_artifacts_r` does not rewrite the backlog and emit a `Task.Linked` activity event every turn for an unchanged trace.

## Why a separate PR

PR #14564 was already MERGED when I pushed the follow-up commit. Per repo policy (`feedback masc-mcp#5303` — post-merge pushes to squash-merged branches do not reach `main`), the commit was cherry-picked onto a new branch off `origin/main`.

## Test plan

- [ ] `dune build` clean
- [ ] Manual: confirm only one `task_linked` event per (keeper, task, trace) tuple over multiple turns
