### PR TITLE
fix(cascade): regen cascade.json with Phase 5.2a liveness sub-tables

### DIFF
--- a/config/cascade.json
+++ b/config/cascade.json
@@ -5,39 +5,45 @@
       "protocol": "anthropic-cli",
       "command": "claude",
       "is-non-interactive": true,
-      "credentials": { "type": "env", "key": "ANTHROPIC_API_KEY" }
+      "credentials": { "type": "env", "key": "ANTHROPIC_API_KEY" },
+      "liveness": { "class": "cloud_fast" }
     },
     "codex_cli": {
       "display-name": "OpenAI Codex CLI",
       "protocol": "openai-http",
       "command": "codex",
       "is-non-interactive": true,
-      "credentials": { "type": "env", "key": "OPENAI_API_KEY" }
+      "credentials": { "type": "env", "key": "OPENAI_API_KEY" },
+      "liveness": { "class": "cloud_fast" }
     },
     "gemini_cli": {
       "display-name": "Google Gemini CLI",
       "protocol": "google-cli",
       "command": "gemini",
       "is-non-interactive": true,
-      "credentials": { "type": "env", "key": "GEMINI_API_KEY" }
+      "credentials": { "type": "env", "key": "GEMINI_API_KEY" },
+      "liveness": { "class": "cloud_fast" }
     },
     "kimi_cli": {
       "display-name": "Moonshot Kimi CLI",
       "protocol": "kimi-cli",
       "command": "kimi",
       "is-non-interactive": true,
-      "credentials": { "type": "env", "key": "MOONSHOT_API_KEY" }
+      "credentials": { "type": "env", "key": "MOONSHOT_API_KEY" },
+      "liveness": { "class": "cloud_thinking" }
     },
     "glm-coding": {
       "display-name": "Zhipu GLM Coding",
       "protocol": "openai-http",
       "endpoint": "https://api.z.ai/api/coding/paas/v4",
-      "credentials": { "type": "env", "key": "ZAI_API_KEY" }
+      "credentials": { "type": "env", "key": "ZAI_API_KEY" },
+      "liveness": { "class": "cloud_thinking" }
     },
     "ollama": {
       "display-name": "Ollama Local",
       "protocol": "ollama-http",
-      "endpoint": "http://localhost:11434"
+      "endpoint": "http://localhost:11434",
+      "liveness": { "class": "local_27b" }
     }
   },
   "models": {


### PR DESCRIPTION
## Summary

PR #14558 added `[providers.X.liveness] class = \"...\"` to `cascade.toml` but did not regenerate the committed `cascade.json`. As a result `test_committed_json_matches_toml_materializer` has been failing on `main` since 5.2a merged — committed JSON missing the `liveness` sub-table for all 6 providers.

This regenerates `cascade.json` from `cascade.toml` via `Cascade_toml_materializer.render_toml_file_to_json_string`, restoring the SSOT invariant that committed JSON matches TOML materialization byte-for-byte.

## Diff scope

```
config/cascade.json | 18 ++++++++++++------
```

6 providers each gain a `\"liveness\": { \"class\": \"...\" }` field — exactly the data the parser added in PR #14558 (RFC-0058 §3.2.1 Phase 5.2a).

## Verification

```bash
MASC_CASCADE_JSON_PATH=config/cascade.json \
  dune exec test/test_cascade_config_validity.exe
# Test Successful in 0.004s. 6 tests run.
```

Round-trip property restored: \`render_toml_file_to_json_string(cascade.toml) == read(cascade.json)\` byte-for-byte.

## Why this slipped through

The test that catches this (`test_committed_json_matches_toml_materializer`) was added in `test/test_cascade_config_validity.ml` but is only triggered when `MASC_CASCADE_JSON_PATH` is set — the dune env block does not inject it for the default test run. PR #14558 CI did not exercise this path. A follow-up PR could wire the env var into the dune stanza so CI catches future drift, but the immediate fix is to restore the JSON to match the TOML.

## RFC

RFC-0058 §3.2.1 Phase 5.2a — provider liveness class schema.

🤖 Generated with [Claude Code](https://claude.com/claude-code)