### PR TITLE
fix(grpc): add LspRequest.of_bytes_result (main blocker)

### DIFF
--- a/lib/grpc/masc_grpc_types.ml
+++ b/lib/grpc/masc_grpc_types.ml
@@ -490,15 +490,25 @@ module LspRequest = struct
     ; workspace_root : string option
     }
 
+  let of_bytes_result bytes =
+    match decode_result P.LspRequest.from_proto bytes with
+    | Ok p ->
+      Ok
+        ({ language_id = p.language_id
+         ; jsonrpc_request_json = p.jsonrpc_request_json
+         ; workspace_root =
+             (match p.workspace_root with
+              | "" -> None
+              | s -> Some s)
+         }
+         : t)
+    | Error _ as err -> err
+  ;;
+
   let of_bytes bytes =
-    let p = decode P.LspRequest.from_proto bytes in
-    { language_id = p.language_id
-    ; jsonrpc_request_json = p.jsonrpc_request_json
-    ; workspace_root =
-        (match p.workspace_root with
-         | "" -> None
-         | s -> Some s)
-    }
+    match of_bytes_result bytes with
+    | Ok req -> req
+    | Error msg -> invalid_arg msg
   ;;
 
   let to_bytes (t : t) =

--- a/lib/grpc/masc_grpc_types.mli
+++ b/lib/grpc/masc_grpc_types.mli
@@ -206,6 +206,7 @@ module LspRequest : sig
     ; workspace_root : string option
     }
 
+  val of_bytes_result : string -> (t, string) result
   val of_bytes : string -> t
   val to_bytes : t -> string
 end


### PR DESCRIPTION
## Summary

PR #14573 (LspCall RPC) wired the LSP request decoder in `lib/grpc/masc_grpc_service.ml:275`:

\`\`\`ocaml
decode_request_or_raise ~rpc:\"LspCall\" T.LspRequest.of_bytes_result bytes
\`\`\`

But the \`LspRequest\` module in \`lib/grpc/masc_grpc_types.ml\` only exported \`of_bytes\` — leaving \`main\` with an **unresolved value error** since the merge:

\`\`\`
Error: Unbound value T.LspRequest.of_bytes_result
\`\`\`

## Fix

Add the \`Result\`-returning decoder to match the pattern used by every other request module (\`JoinRequest\`, \`LeaveRequest\`, \`BroadcastRequest\`, \`ToolCallRequest\`, \`SubscribeRequest\`, \`HeartbeatPing\`). \`of_bytes\` is now expressed in terms of \`of_bytes_result\` for consistency. Signature mirrored in \`.mli\`.

## Verification

\`\`\`
dune build --root .
# exit 0
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)