### PR TITLE
feat(cascade): RFC-0058 §9 Phase 9.2 — dashboard renders cascade JSON in memory

### DIFF
--- a/lib/cascade/cascade_config_loader.ml
+++ b/lib/cascade/cascade_config_loader.ml
@@ -48,13 +48,10 @@ let cycle_set_key (cycles : string list list) : string =
   |> String.concat "|"
 ;;
 
-let ensure_materialized_json path =
-  match Cascade_toml_materializer.ensure_materialized_json ~config_path:path with
-  | Ok { wrote_json; _ } ->
-    if wrote_json then invalidate_cache_entry path;
-    Ok ()
-  | Error _ as err -> err
-;;
+(* RFC-0058 §9 Phase 9.2: previous [ensure_materialized_json] wrapper
+   removed — it was private (not in [.mli]) and had zero call sites.
+   In-process callers route through [load_toml_in_memory] which never
+   touches the JSON sibling on disk. *)
 
 let read_json_file path =
   let ic = open_in path in

--- a/lib/dashboard_cascade.ml
+++ b/lib/dashboard_cascade.ml
@@ -328,22 +328,6 @@ let raw_config_json () =
   Config_dir_resolver.log_warnings ~context:"DashboardCascade" ();
   let source : Cascade_toml_materializer.source_info = source_info () in
   let config_path = Some source.json_path in
-  (* Capture the materialization error so the dashboard response can
-     surface it.  Previously the failure was logged and the response
-     silently served the stale [raw_json] file, hiding cascade.toml
-     parse failures from operators viewing the dashboard. *)
-  let materialization_error =
-    match
-      Cascade_toml_materializer.ensure_materialized_json ~config_path:source.json_path
-    with
-    | Ok _ -> None
-    | Error msg ->
-      Log.Keeper.warn
-        "DashboardCascade: materialization failed for %s: %s"
-        source.json_path
-        msg;
-      Some msg
-  in
   let source_text =
     try load_raw_config_string source.source_path with
     | Eio.Cancel.Cancelled _ as exn -> raise exn
@@ -354,15 +338,38 @@ let raw_config_json () =
         msg;
       ""
   in
-  let raw_json =
-    match config_path with
-    | None -> ""
-    | Some path ->
-      (try load_raw_config_string path with
-       | Eio.Cancel.Cancelled _ as exn -> raise exn
-       | Sys_error msg ->
-         Log.Keeper.warn "dashboard cascade raw config: failed to read %s: %s" path msg;
-         "")
+  (* RFC-0058 §9 Phase 9.2: render JSON in memory instead of materialising
+     it to disk and re-reading. [render_toml_to_json_string] returns the
+     same byte-for-byte content that [ensure_materialized_json] would have
+     written, so the dashboard response is identical without growing a
+     committed [cascade.json] sibling. Falls back to the on-disk JSON only
+     when the source is JSON-native (no TOML alongside) — that branch
+     persists until Phase 9.3 retires source_kind = Json. *)
+  let raw_json, materialization_error =
+    match source.kind with
+    | Cascade_toml_materializer.Toml ->
+      (match
+         Cascade_toml_materializer.render_toml_file_to_json_string source.source_path
+       with
+       | Ok json -> json, None
+       | Error msg ->
+         Log.Keeper.warn
+           "DashboardCascade: in-memory materialization failed for %s: %s"
+           source.source_path
+           msg;
+         "", Some msg)
+    | Cascade_toml_materializer.Json ->
+      (match config_path with
+       | None -> "", None
+       | Some path ->
+         (try load_raw_config_string path, None with
+          | Eio.Cancel.Cancelled _ as exn -> raise exn
+          | Sys_error msg ->
+            Log.Keeper.warn
+              "dashboard cascade raw config: failed to read %s: %s"
+              path
+              msg;
+            "", Some msg))
   in
   `Assoc
     [ "updated_at", `String (now_iso ())
@@ -409,15 +416,17 @@ let save_raw_config_json raw_json =
     (match Cascade_toml_materializer.render_toml_string_to_json_string raw_json with
      | Error msg -> Error (Printf.sprintf "invalid TOML: %s" msg)
      | Ok _rendered_json ->
+       (* RFC-0058 §9 Phase 9.2: dashboard save writes only the TOML
+          source; the JSON sibling is no longer persisted. The next
+          [raw_config_json] (and any cascade reader) re-renders in
+          memory from the updated TOML via
+          [load_toml_in_memory] / [render_toml_to_json_string]. *)
        (try
           match save_config_file source.source_path raw_json with
           | Error msg -> Error msg
           | Ok () ->
-            (match Cascade_toml_materializer.ensure_materialized_json ~config_path with
-             | Error msg -> Error msg
-             | Ok _ ->
-               invalidate_cascade_config config_path;
-               Ok (config_json ()))
+            invalidate_cascade_config config_path;
+            Ok (config_json ())
         with
         | Eio.Cancel.Cancelled _ as exn -> raise exn
         | Sys_error msg -> Error msg))

--- a/lib/dashboard_cascade.ml
+++ b/lib/dashboard_cascade.ml
@@ -230,8 +230,8 @@ let config_json () =
     | Eio.Cancel.Cancelled _ as e -> raise e
     | exn ->
       Log.Keeper.warn
-        "dashboard_cascade.config_json: Keeper_registry.all failed (treating \
-         as empty): %s"
+        "dashboard_cascade.config_json: Keeper_registry.all failed (treating as empty): \
+         %s"
         (Printexc.to_string exn);
       []
   in
@@ -328,6 +328,7 @@ let raw_config_json () =
   Config_dir_resolver.log_warnings ~context:"DashboardCascade" ();
   let source : Cascade_toml_materializer.source_info = source_info () in
   let config_path = Some source.json_path in
+  let source_read_error = ref None in
   let source_text =
     try load_raw_config_string source.source_path with
     | Eio.Cancel.Cancelled _ as exn -> raise exn
@@ -336,28 +337,32 @@ let raw_config_json () =
         "dashboard cascade source config: failed to read %s: %s"
         source.source_path
         msg;
+      source_read_error := Some msg;
       ""
   in
   (* RFC-0058 §9 Phase 9.2: render JSON in memory instead of materialising
-     it to disk and re-reading. [render_toml_to_json_string] returns the
-     same byte-for-byte content that [ensure_materialized_json] would have
-     written, so the dashboard response is identical without growing a
-     committed [cascade.json] sibling. Falls back to the on-disk JSON only
-     when the source is JSON-native (no TOML alongside) — that branch
-     persists until Phase 9.3 retires source_kind = Json. *)
+     it to disk and re-reading. We reuse [source_text] (loaded once above)
+     and pipe it through [render_toml_string_to_json_string], so the
+     dashboard response is byte-for-byte identical to the old
+     [ensure_materialized_json] output without a second disk read or a
+     committed [cascade.json] sibling. The on-disk JSON branch only runs
+     for source_kind = Json and is retired in Phase 9.3. *)
   let raw_json, materialization_error =
     match source.kind with
     | Cascade_toml_materializer.Toml ->
-      (match
-         Cascade_toml_materializer.render_toml_file_to_json_string source.source_path
-       with
-       | Ok json -> json, None
-       | Error msg ->
-         Log.Keeper.warn
-           "DashboardCascade: in-memory materialization failed for %s: %s"
-           source.source_path
-           msg;
-         "", Some msg)
+      (match !source_read_error with
+       | Some msg -> "", Some msg
+       | None ->
+         (match
+            Cascade_toml_materializer.render_toml_string_to_json_string source_text
+          with
+          | Ok json -> json, None
+          | Error msg ->
+            Log.Keeper.warn
+              "DashboardCascade: in-memory materialization failed for %s: %s"
+              source.source_path
+              msg;
+            "", Some msg))
     | Cascade_toml_materializer.Json ->
       (match config_path with
        | None -> "", None
@@ -365,10 +370,7 @@ let raw_config_json () =
          (try load_raw_config_string path, None with
           | Eio.Cancel.Cancelled _ as exn -> raise exn
           | Sys_error msg ->
-            Log.Keeper.warn
-              "dashboard cascade raw config: failed to read %s: %s"
-              path
-              msg;
+            Log.Keeper.warn "dashboard cascade raw config: failed to read %s: %s" path msg;
             "", Some msg))
   in
   `Assoc
@@ -407,7 +409,11 @@ let save_raw_config_json raw_json =
           match save_config_file config_path raw_json with
           | Error msg -> Error msg
           | Ok () ->
-            invalidate_cascade_config config_path;
+            (* JSON-native source: [source.source_path] equals
+               [config_path] here, but key on [source_path] so this call
+               stays symmetric with the TOML arm below and with the
+               loader cache contract. *)
+            invalidate_cascade_config source.source_path;
             Ok (config_json ())
         with
         | Eio.Cancel.Cancelled _ as exn -> raise exn
@@ -425,7 +431,12 @@ let save_raw_config_json raw_json =
           match save_config_file source.source_path raw_json with
           | Error msg -> Error msg
           | Ok () ->
-            invalidate_cascade_config config_path;
+            (* [Cascade_config_loader.load_toml_in_memory] and
+               [Cascade_catalog_runtime] both key their caches on
+               [source.source_path] (the TOML path). Invalidating
+               [json_path] here would silently no-op and dashboard reads
+               would return stale data until the next mtime tick. *)
+            invalidate_cascade_config source.source_path;
             Ok (config_json ())
         with
         | Eio.Cancel.Cancelled _ as exn -> raise exn


### PR DESCRIPTION
## Summary

**Phase 9.2** of RFC-0058 §9 (cascade.json elimination). Stacks on top of #14578 (Phase 9.1 — untrack the committed JSON).

After Phase 9.1 the dashboard still depended on `ensure_materialized_json` writing a JSON sibling to disk and re-reading it. This PR removes that round-trip and replaces it with `Cascade_toml_materializer.render_toml_file_to_json_string` (in-memory render).

### Changes

- `lib/dashboard_cascade.ml` `raw_config_json`:
  - When source is TOML, `raw_json` now comes from `render_toml_file_to_json_string`. Same bytes as the previous materialise + disk-read pattern, no JSON file written.
  - JSON-native sources still read from disk — that branch retires in Phase 9.3.
- `lib/dashboard_cascade.ml` `update_config_file`:
  - No longer calls `ensure_materialized_json` after saving the TOML. Subsequent reads hit the in-memory materialiser.
- `lib/cascade/cascade_config_loader.ml`:
  - Removed the private `ensure_materialized_json` wrapper (zero call sites, not in `.mli`).

### Out of scope (Phase 9.3)

- `bin/cascade_materialize.ml` — explicit disk-materialise CLI; retires when the API is deleted.
- `test/test_cascade_toml_section_fallback_10259.ml` — regression test for the API itself.
- `Cascade_toml_materializer.ensure_materialized_json` + `source_kind = Json` — deleted alongside the CLI and test in Phase 9.3.

## Test plan

- [ ] `dune build` clean.
- [ ] Boot the server and open `/dashboard/cascade` — JSON view should show the same content as before.
- [ ] Save an edited cascade through the dashboard — TOML file updated, no new `config/cascade.json` on disk.
- [ ] Existing `test_cascade_config_validity` keeps passing (Phase 9.1's untrack test enforces the no-JSON invariant).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
