### PR TITLE
feat(cascade): RFC-0058 Phase 5 catalog discovery bridge

### DIFF
--- a/lib/cascade/cascade_catalog_runtime.ml
+++ b/lib/cascade/cascade_catalog_runtime.ml
@@ -647,12 +647,28 @@ let validate_path_result ?sw ?net ~config_path () =
                ]
              ~profiles:[])
     | Ok json ->
-        let profiles = discover_profiles json in
+        let legacy_profiles = discover_profiles json in
+        (* RFC-0058 Phase 5 catalog discovery bridge: augment the legacy
+           [<name>_models] walk with declarative [tier.<X>]/[tier-group.<X>]
+           profile names so the runtime catalog reflects the full
+           5-layer schema, not just legacy keys. *)
+        let declarative_profiles =
+          Cascade_declarative_legacy_bridge.declarative_profile_names
+            ~config_path
+        in
+        let profiles =
+          List.sort_uniq String.compare
+            (legacy_profiles @ declarative_profiles)
+        in
         if profiles = [] then
           Error
             (rejection_of_path ~config_path:source_path ~attempted_mtime
                ~checked_at
-               ~errors:[ "active cascade catalog has no <name>_models profiles" ]
+               ~errors:[
+                 "active cascade catalog has no <name>_models profiles \
+                  (legacy) and no [tier.<X>]/[tier-group.<X>] profiles \
+                  (RFC-0058)"
+               ]
                ~profiles:[])
         else
           let required_default_profile =

--- a/lib/cascade/cascade_config_loader.ml
+++ b/lib/cascade/cascade_config_loader.ml
@@ -150,8 +150,13 @@ let load_json path =
 (** A model entry with an optional weight for weighted cascade selection.
     Weight defaults to 1 when not specified (backward compatible).
     [secondary] is the RFC-0027 PR-9 dual-track fallback (CLI primary +
-    direct-API secondary), [None] for legacy entries. *)
-type weighted_entry =
+    direct-API secondary), [None] for legacy entries.
+
+    The record itself lives in [Cascade_weighted_entry] so downstream
+    bridges (e.g. RFC-0058 declarative-legacy bridge) can produce values
+    of the same type without depending on this loader and creating a
+    cycle. *)
+type weighted_entry = Cascade_weighted_entry.t =
   { model : string
   ; weight : int
   ; supports_tool_choice : bool option
@@ -547,7 +552,7 @@ let load_catalog ~config_path =
     if invalid_profile_errors <> []
     then Error (String.concat "; " invalid_profile_errors)
     else (
-      let entries =
+      let legacy_entries =
         List.map
           (fun (name, builder) ->
              let required_capability_profile =
@@ -563,6 +568,31 @@ let load_catalog ~config_path =
              })
           active_builders
       in
+      (* RFC-0058 Phase 5 catalog discovery bridge: augment legacy
+         [<name>_models]-derived entries with declarative tier/tier-group
+         names so route targets like [tier-group.big_three] resolve in
+         [Cascade_routes.cascade_name_for_use].  Declarative entries
+         default to [keeper_assignable=true] / [fallback_cascade=None]
+         because the declarative schema has no equivalent knob yet (Phase
+         5.x follow-up).  Names already present in [legacy_entries] win
+         to preserve any legacy [_keeper_assignable]/[_fallback_cascade]
+         overrides during the transition. *)
+      let declarative_entries =
+        Cascade_declarative_legacy_bridge.declarative_profile_names
+          ~config_path
+        |> List.filter_map (fun name ->
+          if List.exists (fun (e : catalog_entry) -> String.equal e.name name)
+               legacy_entries
+          then None
+          else
+            Some
+              { name
+              ; keeper_assignable = true
+              ; fallback_cascade = None
+              ; required_capability_profile = None
+              })
+      in
+      let entries = legacy_entries @ declarative_entries in
       let cycles = detect_fallback_cycles entries in
       let key = cycle_set_key cycles in
       let should_warn =
@@ -630,7 +660,20 @@ let load_profile_weighted ~config_path ~name =
     let open Yojson.Safe.Util in
     (match json |> member key with
      | `List items -> List.filter_map parse_weighted_item items
-     | _ -> [])
+     | _ ->
+       (* RFC-0058 Phase 5 catalog discovery bridge: when the legacy
+          [<name>_models] key is absent, fall back to the declarative
+          tier/tier-group adapter so profiles defined under
+          [[tier.<X>]]/[[tier-group.<X>]] resolve to the same
+          [weighted_entry] shape the caller expects.  Returns [] when
+          the name is unknown to the declarative catalog — matching the
+          prior legacy behaviour on absent profiles. *)
+       (match
+          Cascade_declarative_legacy_bridge.weighted_entries_for_profile
+            ~config_path ~name
+        with
+        | Some entries -> entries
+        | None -> []))
 ;;
 
 let load_profile ~config_path ~name =

--- a/lib/cascade/cascade_config_loader.ml
+++ b/lib/cascade/cascade_config_loader.ml
@@ -571,11 +571,14 @@ let load_catalog ~config_path =
       (* RFC-0058 Phase 5 catalog discovery bridge: augment legacy
          [<name>_models]-derived entries with declarative tier/tier-group
          names so route targets like [tier-group.big_three] resolve in
-         [Cascade_routes.cascade_name_for_use].  Declarative entries
-         default to [keeper_assignable=true] / [fallback_cascade=None]
-         because the declarative schema has no equivalent knob yet (Phase
-         5.x follow-up).  Names already present in [legacy_entries] win
-         to preserve any legacy [_keeper_assignable]/[_fallback_cascade]
+         [Cascade_routes.cascade_name_for_use].  [keeper_assignable] is
+         derived from route usage (fail-closed): a declarative entry is
+         keeper-assignable iff it is targeted by some [routes.X] entry.
+         Profiles reachable only via [system_targets.X] (governance,
+         dispatch, etc.) stay [keeper_assignable=false] — matching the
+         spirit of legacy [<name>_keeper_assignable] overrides without
+         hard-coding [true] for every system-only tier.  Names already
+         present in [legacy_entries] win to preserve any legacy
          overrides during the transition. *)
       let declarative_entries =
         Cascade_declarative_legacy_bridge.declarative_profile_names
@@ -587,7 +590,9 @@ let load_catalog ~config_path =
           else
             Some
               { name
-              ; keeper_assignable = true
+              ; keeper_assignable =
+                  Cascade_declarative_legacy_bridge.is_keeper_routable
+                    ~config_path ~name
               ; fallback_cascade = None
               ; required_capability_profile = None
               })

--- a/lib/cascade/cascade_declarative_legacy_bridge.ml
+++ b/lib/cascade/cascade_declarative_legacy_bridge.ml
@@ -19,7 +19,18 @@
     directly against [cascade_binding]/[cascade_alias]/[cascade_model_spec]
     to emit [cascade_prefix:api_name] strings, deliberately avoiding
     [Cascade_declarative_adapter] (which depends on [Cascade_config]
-    and would create a cycle with [Cascade_config_loader]). *)
+    and would create a cycle with [Cascade_config_loader]).
+
+    Tier-group strategy limitation: tier-groups with
+    [strategy = "priority_tier"] (see config/cascade.toml) flatten into
+    a single weighted_entry list here — tier boundaries are lost.  The
+    legacy loader represents priority_tier via [<name>_tiers] +
+    [<name>_strategy], which is not bridged yet.  Callers that need
+    priority_tier semantics for a declarative tier-group must wire
+    [Cascade_declarative_adapter] (with cycle-safe access) into
+    [Cascade_strategy.resolve] in a follow-up; for now this bridge
+    surfaces only the union of candidates, which is correct for
+    round_robin / failover but loses ordering for priority_tier. *)
 
 open Cascade_declarative_types
 
@@ -78,25 +89,48 @@ let member_to_model_string (cfg : cascade_config) (member : string)
        Some (Printf.sprintf "%s:%s" prefix spec.api_name)
      | _ -> None)
 
-let weighted_entry_of_model_string (model : string) : Cascade_weighted_entry.t =
-  {
-    Cascade_weighted_entry.model;
-    weight = 1;
-    supports_tool_choice = None;
-    secondary = None;
-    secondary_supports_tool_choice = None;
-  }
+(* Resolve members and surface drops as a single bounded warning per
+   call site.  Silent drops can mask config typos (unknown binding,
+   missing provider/model row); the legacy loader hard-fails on the
+   equivalent, so the bridge logs at WARN.  The dropped names are
+   inlined in the message — bounded by the tier/tier-group member list
+   length, which is in the single digits in practice. *)
+let resolve_members ~profile_name (cfg : cascade_config) (members : string list)
+    : Cascade_weighted_entry.t list =
+  let resolved, dropped =
+    List.partition_map
+      (fun member ->
+        match member_to_model_string cfg member with
+        | Some s -> Left s
+        | None -> Right member)
+      members
+  in
+  (match dropped with
+   | [] -> ()
+   | _ ->
+     Log.warn ~ctx:"CascadeDeclLegacyBridge"
+       "profile=%s dropped %d unresolvable member(s): [%s]"
+       profile_name
+       (List.length dropped)
+       (String.concat "; " dropped));
+  List.map
+    (fun model ->
+      { Cascade_weighted_entry.model
+      ; weight = 1
+      ; supports_tool_choice = None
+      ; secondary = None
+      ; secondary_supports_tool_choice = None
+      })
+    resolved
 
 let entries_of_tier (cfg : cascade_config) (tier : cascade_tier)
     : (string * Cascade_weighted_entry.t list) =
-  let entries =
-    List.filter_map (member_to_model_string cfg) tier.members
-    |> List.map weighted_entry_of_model_string
-  in
-  Printf.sprintf "tier.%s" tier.name, entries
+  let profile_name = Printf.sprintf "tier.%s" tier.name in
+  profile_name, resolve_members ~profile_name cfg tier.members
 
 let entries_of_tier_group (cfg : cascade_config) (tg : cascade_tier_group)
     : (string * Cascade_weighted_entry.t list) =
+  let profile_name = Printf.sprintf "tier-group.%s" tg.name in
   let tier_members =
     List.concat_map
       (fun tier_name ->
@@ -109,17 +143,46 @@ let entries_of_tier_group (cfg : cascade_config) (tg : cascade_tier_group)
         | None -> [])
       tg.tiers
   in
-  let entries =
-    List.filter_map (member_to_model_string cfg) tier_members
-    |> List.map weighted_entry_of_model_string
-  in
-  Printf.sprintf "tier-group.%s" tg.name, entries
+  profile_name, resolve_members ~profile_name cfg tier_members
 
+(* Parsed-config cache keyed by (config_path, mtime).  Mirrors the
+   pattern in [Cascade_config_loader] — declarative bridge is consulted
+   on every [load_profile_weighted] / [discover_profiles] call, so
+   reparsing the TOML each time would amplify boot + dashboard refresh
+   cost.  Cache invalidates automatically when the file mtime moves. *)
+let cache_lock = Mutex.create ()
+let cache : (string, float * cascade_config) Hashtbl.t = Hashtbl.create 4
+
+let read_mtime (path : string) : float option =
+  try Some (Unix.stat path).Unix.st_mtime
+  with _ -> None
+
+let parse_cached (config_path : string) : cascade_config option =
+  let current_mtime = read_mtime config_path in
+  let cached =
+    Mutex.protect cache_lock (fun () -> Hashtbl.find_opt cache config_path)
+  in
+  match current_mtime, cached with
+  | Some mt, Some (cmt, cfg) when Float.equal mt cmt -> Some cfg
+  | _ ->
+    (match Cascade_declarative_parser.parse_file config_path with
+     | Error _ -> None
+     | Ok cfg ->
+       (match current_mtime with
+        | Some mt ->
+          Mutex.protect cache_lock (fun () ->
+            Hashtbl.replace cache config_path (mt, cfg))
+        | None -> ());
+       Some cfg)
+
+(* Names of declarative tier/tier-group profiles that the runtime
+   should expose, in the order [(tiers, tier_groups)] — same shape the
+   parser emits. *)
 let all_declarative_entries ~config_path :
     (string * Cascade_weighted_entry.t list) list option =
-  match Cascade_declarative_parser.parse_file config_path with
-  | Error _ -> None
-  | Ok cfg ->
+  match parse_cached config_path with
+  | None -> None
+  | Some cfg ->
     let tier_entries = List.map (entries_of_tier cfg) cfg.tiers in
     let group_entries = List.map (entries_of_tier_group cfg) cfg.tier_groups in
     Some (tier_entries @ group_entries)
@@ -137,3 +200,17 @@ let declarative_profile_names ~config_path : string list =
   match all_declarative_entries ~config_path with
   | None -> []
   | Some all -> List.map fst all
+
+(* Whether a declarative profile name is reachable from any
+   [routes.X] target (vs only [system_targets.X]).  Used by the
+   catalog loader to default [keeper_assignable] fail-closed: a
+   declarative tier-group only flips to [keeper_assignable=true] when
+   it is wired into a keeper-facing route, mirroring the legacy
+   [<name>_keeper_assignable] override semantics. *)
+let is_keeper_routable ~config_path ~name : bool =
+  match parse_cached config_path with
+  | None -> false
+  | Some cfg ->
+    List.exists
+      (fun (r : cascade_route) -> String.equal r.target name)
+      cfg.routes

--- a/lib/cascade/cascade_declarative_legacy_bridge.ml
+++ b/lib/cascade/cascade_declarative_legacy_bridge.ml
@@ -1,0 +1,139 @@
+(** RFC-0058 Phase 5 catalog discovery bridge.
+
+    The legacy catalog runtime walks JSON top-level keys for
+    [<name>_models] LIST values. After PR #14550 cascade.toml is fully
+    declarative ([providers.X], [models.X], [tier.X], [tier-group.X]) and
+    the materialised cascade.json no longer emits the legacy
+    [<name>_models] shape — so [discover_profiles] returns [] and the
+    boot path falls into degraded mode (see [server_runtime_bootstrap]).
+
+    This module is the data-only bridge: given a config path it returns
+    [(profile_name, weighted_entries)] pairs derived from the declarative
+    cascade — surfacing [tier.<X>] and [tier-group.<X>] under the same
+    [weighted_entry] shape the legacy loader produces, so the existing
+    [validate_profile_static] pipeline keeps working unchanged.
+
+    Implementation note: depends only on [Cascade_declarative_parser]
+    (in the sibling [cascade_decl] sub-library) plus [Provider_adapter]
+    for the cascade-prefix lookup.  Resolves tier/tier-group members
+    directly against [cascade_binding]/[cascade_alias]/[cascade_model_spec]
+    to emit [cascade_prefix:api_name] strings, deliberately avoiding
+    [Cascade_declarative_adapter] (which depends on [Cascade_config]
+    and would create a cycle with [Cascade_config_loader]). *)
+
+open Cascade_declarative_types
+
+let normalize_id (s : string) : string =
+  String.trim s |> String.lowercase_ascii
+  |> String.map (fun c -> if c = '-' then '_' else c)
+
+let resolve_provider_prefix (provider_id : string) : string option =
+  match Provider_adapter.resolve_adapter_by_cascade_prefix provider_id with
+  | Some adapter -> Some adapter.Provider_adapter.cascade_prefix
+  | None ->
+    let normalized = normalize_id provider_id in
+    (match Provider_adapter.resolve_adapter_by_cascade_prefix normalized with
+     | Some adapter -> Some adapter.Provider_adapter.cascade_prefix
+     | None -> None)
+
+let find_model (cfg : cascade_config) (model_id : string) :
+    cascade_model_spec option =
+  List.find_opt
+    (fun (m : cascade_model_spec) -> String.equal m.id model_id)
+    cfg.models
+
+(* Resolve a tier/tier-group member like "codex_cli.codex-spark" or
+   "claude_code.haiku.for-tool-rerank" to a [cascade_prefix:api_name]
+   model string.  Aliases override the binding shape but share the
+   underlying [provider_id]/[model_id], so the model_string itself is
+   identical — alias param overrides (max_input, temperature, etc.)
+   are runtime-only and do not affect catalog discovery. *)
+let member_to_model_string (cfg : cascade_config) (member : string)
+    : string option =
+  let alias =
+    List.find_opt
+      (fun (a : cascade_alias) ->
+        String.equal (Cascade_declarative_types.alias_key a) member)
+      cfg.aliases
+  in
+  let binding =
+    match alias with
+    | Some a ->
+      List.find_opt
+        (fun (b : cascade_binding) ->
+          String.equal b.provider_id a.provider_id
+          && String.equal b.model_id a.model_id)
+        cfg.bindings
+    | None ->
+      List.find_opt
+        (fun (b : cascade_binding) ->
+          String.equal (Cascade_declarative_types.binding_key b) member)
+        cfg.bindings
+  in
+  match binding with
+  | None -> None
+  | Some b ->
+    (match resolve_provider_prefix b.provider_id, find_model cfg b.model_id with
+     | Some prefix, Some spec ->
+       Some (Printf.sprintf "%s:%s" prefix spec.api_name)
+     | _ -> None)
+
+let weighted_entry_of_model_string (model : string) : Cascade_weighted_entry.t =
+  {
+    Cascade_weighted_entry.model;
+    weight = 1;
+    supports_tool_choice = None;
+    secondary = None;
+    secondary_supports_tool_choice = None;
+  }
+
+let entries_of_tier (cfg : cascade_config) (tier : cascade_tier)
+    : (string * Cascade_weighted_entry.t list) =
+  let entries =
+    List.filter_map (member_to_model_string cfg) tier.members
+    |> List.map weighted_entry_of_model_string
+  in
+  Printf.sprintf "tier.%s" tier.name, entries
+
+let entries_of_tier_group (cfg : cascade_config) (tg : cascade_tier_group)
+    : (string * Cascade_weighted_entry.t list) =
+  let tier_members =
+    List.concat_map
+      (fun tier_name ->
+        match
+          List.find_opt
+            (fun (t : cascade_tier) -> String.equal t.name tier_name)
+            cfg.tiers
+        with
+        | Some tier -> tier.members
+        | None -> [])
+      tg.tiers
+  in
+  let entries =
+    List.filter_map (member_to_model_string cfg) tier_members
+    |> List.map weighted_entry_of_model_string
+  in
+  Printf.sprintf "tier-group.%s" tg.name, entries
+
+let all_declarative_entries ~config_path :
+    (string * Cascade_weighted_entry.t list) list option =
+  match Cascade_declarative_parser.parse_file config_path with
+  | Error _ -> None
+  | Ok cfg ->
+    let tier_entries = List.map (entries_of_tier cfg) cfg.tiers in
+    let group_entries = List.map (entries_of_tier_group cfg) cfg.tier_groups in
+    Some (tier_entries @ group_entries)
+
+let weighted_entries_for_profile ~config_path ~name :
+    Cascade_weighted_entry.t list option =
+  match all_declarative_entries ~config_path with
+  | None -> None
+  | Some all ->
+    (match List.find_opt (fun (n, _) -> String.equal n name) all with
+     | Some (_, entries) -> Some entries
+     | None -> None)
+
+let declarative_profile_names ~config_path : string list =
+  match all_declarative_entries ~config_path with
+  | None -> []
+  | Some all -> List.map fst all

--- a/lib/cascade/cascade_declarative_legacy_bridge.mli
+++ b/lib/cascade/cascade_declarative_legacy_bridge.mli
@@ -1,0 +1,21 @@
+(** RFC-0058 Phase 5 catalog discovery bridge — declarative cascade
+    config rendered as legacy [weighted_entry] lists keyed by tier /
+    tier-group profile name. *)
+
+val weighted_entries_for_profile :
+  config_path:string ->
+  name:string ->
+  Cascade_weighted_entry.t list option
+(** [weighted_entries_for_profile ~config_path ~name] resolves
+    [tier.<X>] or [tier-group.<X>] names from the declarative cascade
+    config and returns the matching legacy [weighted_entry] list, or
+    [None] when the profile is unknown / the parse fails.  Each entry's
+    [model] field is the reconstructed [cascade_prefix:model_id] string
+    so the existing legacy parser at
+    [Cascade_config.parse_model_string] keeps working unchanged. *)
+
+val declarative_profile_names : config_path:string -> string list
+(** [declarative_profile_names ~config_path] returns the
+    [tier.<X>]/[tier-group.<X>] names produced by the declarative
+    adapter, in the order [Cascade_declarative_adapter.adapt_config]
+    emits them.  Empty list when the parse fails. *)

--- a/lib/cascade/cascade_declarative_legacy_bridge.mli
+++ b/lib/cascade/cascade_declarative_legacy_bridge.mli
@@ -12,10 +12,25 @@ val weighted_entries_for_profile :
     [None] when the profile is unknown / the parse fails.  Each entry's
     [model] field is the reconstructed [cascade_prefix:model_id] string
     so the existing legacy parser at
-    [Cascade_config.parse_model_string] keeps working unchanged. *)
+    [Cascade_config.parse_model_string] keeps working unchanged.
+    Unresolvable members emit a single bounded WARN log per call and
+    are dropped from the returned list.  Reads are cached
+    by [(config_path, mtime)] — repeated invocations during boot /
+    dashboard refresh do not re-parse the TOML. *)
 
 val declarative_profile_names : config_path:string -> string list
-(** [declarative_profile_names ~config_path] returns the
-    [tier.<X>]/[tier-group.<X>] names produced by the declarative
-    adapter, in the order [Cascade_declarative_adapter.adapt_config]
-    emits them.  Empty list when the parse fails. *)
+(** [declarative_profile_names ~config_path] returns the profile names
+    surfaced by the bridge in [(tiers, tier_groups)] order — i.e. the
+    parser's own table order, [tier.<X>] entries first followed by
+    [tier-group.<X>] entries.  Empty list when the parse fails.  This
+    is the legacy-shape view; route metadata (keeper_assignable
+    derivation) lives in [is_keeper_routable]. *)
+
+val is_keeper_routable : config_path:string -> name:string -> bool
+(** [is_keeper_routable ~config_path ~name] returns [true] iff the
+    declarative profile [name] is the [target] of any [routes.X]
+    entry.  Used by the catalog loader to default
+    [keeper_assignable] fail-closed: declarative entries only flip
+    to keeper-assignable when wired into a keeper-facing route, so a
+    system-only tier (e.g. [tier-group.governance], reachable only via
+    [system_targets.X]) stays sandboxed by default. *)

--- a/lib/cascade/cascade_weighted_entry.ml
+++ b/lib/cascade/cascade_weighted_entry.ml
@@ -1,0 +1,14 @@
+(** Shared record type for cascade weighted entries.
+
+    Extracted from [Cascade_config_loader] so that downstream resolvers
+    (e.g. [Cascade_declarative_legacy_bridge]) can produce values of the
+    same type without re-importing the loader — preventing a dependency
+    cycle since the loader itself now consumes the bridge as a fallback. *)
+
+type t =
+  { model : string
+  ; weight : int
+  ; supports_tool_choice : bool option
+  ; secondary : string option
+  ; secondary_supports_tool_choice : bool option
+  }

--- a/test/dune
+++ b/test/dune
@@ -225,6 +225,7 @@
         test_cascade_declarative_validator
         test_cascade_declarative_adapter
         test_cascade_declarative_hotpath
+        test_cascade_declarative_legacy_bridge
         test_doctor_dispatch
         test_disk_hygiene_script
         test_run_local_script
@@ -468,6 +469,7 @@
           test_cascade_declarative_validator
           test_cascade_declarative_adapter
           test_cascade_declarative_hotpath
+          test_cascade_declarative_legacy_bridge
           test_doctor_dispatch
           test_disk_hygiene_script
           test_run_local_script

--- a/test/test_cascade_declarative_legacy_bridge.ml
+++ b/test/test_cascade_declarative_legacy_bridge.ml
@@ -1,0 +1,192 @@
+(** Regression coverage for [Cascade_declarative_legacy_bridge] —
+    RFC-0058 Phase 5 catalog discovery bridge. *)
+
+open Alcotest
+
+let tmpfile content =
+  let path = Filename.temp_file "cascade-bridge-" ".toml" in
+  let oc = open_out path in
+  output_string oc content;
+  close_out oc;
+  path
+
+(* Minimal 5-layer declarative TOML covering provider, model, binding,
+   alias, tier, tier-group.  Mirrors the production cascade.toml shape
+   but trimmed to the two providers needed for the bridge assertions
+   (cloud_fast + cloud_thinking). *)
+let minimal_toml =
+  {|
+[providers.claude_code]
+display-name = "Claude Code CLI"
+protocol = "anthropic-cli"
+command = "claude"
+is-non-interactive = true
+[providers.claude_code.credentials]
+type = "env"
+key = "ANTHROPIC_API_KEY"
+[providers.claude_code.liveness]
+class = "cloud_fast"
+
+[providers.codex_cli]
+display-name = "OpenAI Codex CLI"
+protocol = "openai-http"
+command = "codex"
+is-non-interactive = true
+[providers.codex_cli.credentials]
+type = "env"
+key = "OPENAI_API_KEY"
+[providers.codex_cli.liveness]
+class = "cloud_fast"
+
+[models.sonnet]
+api-name = "claude-sonnet-4-5"
+tools-support = true
+max-context = 200000
+[models.haiku]
+api-name = "claude-haiku-4-5"
+tools-support = true
+max-context = 200000
+[models.codex-spark]
+api-name = "gpt-5-codex"
+tools-support = true
+max-context = 256000
+
+[claude_code.sonnet]
+max-concurrent = 4
+[claude_code.haiku]
+max-concurrent = 6
+[codex_cli.codex-spark]
+max-concurrent = 8
+
+[claude_code.haiku.for-tool-rerank]
+temperature = 0.0
+
+[tier.big_three]
+members = ["codex_cli.codex-spark", "claude_code.sonnet"]
+strategy = "failover"
+
+[tier.tool_rerank]
+members = ["claude_code.haiku.for-tool-rerank"]
+strategy = "failover"
+
+[tier-group.big_three]
+tiers = ["big_three"]
+strategy = "failover"
+fallback = false
+
+[tier-group.tool_rerank]
+tiers = ["tool_rerank"]
+strategy = "failover"
+fallback = false
+
+[routes.keeper_turn]
+target = "tier-group.big_three"
+[routes.tool_rerank_use]
+target = "tier-group.tool_rerank"
+|}
+
+let with_cascade body =
+  let path = tmpfile minimal_toml in
+  Fun.protect ~finally:(fun () -> try Sys.remove path with _ -> ()) (fun () -> body path)
+
+let test_declarative_profile_names_surfaces_tier_and_tier_group () =
+  with_cascade @@ fun config_path ->
+  let names =
+    Masc_mcp.Cascade_declarative_legacy_bridge.declarative_profile_names
+      ~config_path
+  in
+  check bool "discovers tier.big_three" true
+    (List.mem "tier.big_three" names);
+  check bool "discovers tier-group.big_three" true
+    (List.mem "tier-group.big_three" names);
+  check bool "discovers tier-group.tool_rerank" true
+    (List.mem "tier-group.tool_rerank" names)
+
+let test_declarative_profile_names_returns_empty_when_unparseable () =
+  let path = tmpfile "this is not valid TOML at all !!!" in
+  Fun.protect ~finally:(fun () -> try Sys.remove path with _ -> ())
+  @@ fun () ->
+  let names =
+    Masc_mcp.Cascade_declarative_legacy_bridge.declarative_profile_names
+      ~config_path:path
+  in
+  check (list string) "empty list on parse failure" [] names
+
+let test_weighted_entries_for_tier_returns_model_strings () =
+  with_cascade @@ fun config_path ->
+  let entries =
+    Masc_mcp.Cascade_declarative_legacy_bridge.weighted_entries_for_profile
+      ~config_path ~name:"tier.big_three"
+  in
+  match entries with
+  | None -> Alcotest.fail "expected Some entries for tier.big_three"
+  | Some es ->
+    let models = List.map (fun (e : Masc_mcp.Cascade_weighted_entry.t) -> e.model) es in
+    (* Bridge emits cascade_prefix:api_name per RFC-0058 §2.4 *)
+    check bool "tier.big_three contains codex_cli model" true
+      (List.exists (fun m -> String.equal m "codex_cli:gpt-5-codex") models);
+    check bool "tier.big_three contains claude_code sonnet" true
+      (List.exists (fun m -> String.equal m "claude_code:claude-sonnet-4-5") models);
+    check int "tier.big_three has exactly 2 entries" 2 (List.length es)
+
+let test_weighted_entries_for_tier_group_expands_member_tiers () =
+  with_cascade @@ fun config_path ->
+  let entries =
+    Masc_mcp.Cascade_declarative_legacy_bridge.weighted_entries_for_profile
+      ~config_path ~name:"tier-group.big_three"
+  in
+  match entries with
+  | None -> Alcotest.fail "expected Some entries for tier-group.big_three"
+  | Some es ->
+    let models = List.map (fun (e : Masc_mcp.Cascade_weighted_entry.t) -> e.model) es in
+    check bool "tier-group.big_three contains codex_cli model" true
+      (List.exists (fun m -> String.equal m "codex_cli:gpt-5-codex") models);
+    check bool "tier-group.big_three contains claude_code sonnet" true
+      (List.exists (fun m -> String.equal m "claude_code:claude-sonnet-4-5") models)
+
+let test_weighted_entries_for_unknown_returns_none () =
+  with_cascade @@ fun config_path ->
+  let entries =
+    Masc_mcp.Cascade_declarative_legacy_bridge.weighted_entries_for_profile
+      ~config_path ~name:"tier.does_not_exist"
+  in
+  check bool "None for unknown profile" true (Option.is_none entries)
+
+let test_alias_member_resolves_to_underlying_binding () =
+  with_cascade @@ fun config_path ->
+  let entries =
+    Masc_mcp.Cascade_declarative_legacy_bridge.weighted_entries_for_profile
+      ~config_path ~name:"tier.tool_rerank"
+  in
+  match entries with
+  | None -> Alcotest.fail "expected Some entries for tier.tool_rerank"
+  | Some es ->
+    let models = List.map (fun (e : Masc_mcp.Cascade_weighted_entry.t) -> e.model) es in
+    (* Alias [claude_code.haiku.for-tool-rerank] resolves to the underlying
+       binding [claude_code.haiku] — alias overrides don't change the
+       model_string, only runtime params. *)
+    check (list string) "alias collapses to underlying model_string"
+      [ "claude_code:claude-haiku-4-5" ] models
+
+let () =
+  Alcotest.run "Cascade_declarative_legacy_bridge"
+    [
+      ( "discovery",
+        [
+          test_case "declarative_profile_names surfaces tier and tier-group"
+            `Quick test_declarative_profile_names_surfaces_tier_and_tier_group;
+          test_case "declarative_profile_names empty on unparseable" `Quick
+            test_declarative_profile_names_returns_empty_when_unparseable;
+        ] );
+      ( "resolution",
+        [
+          test_case "weighted_entries_for tier emits model strings" `Quick
+            test_weighted_entries_for_tier_returns_model_strings;
+          test_case "weighted_entries_for tier-group expands member tiers"
+            `Quick test_weighted_entries_for_tier_group_expands_member_tiers;
+          test_case "weighted_entries_for unknown returns None" `Quick
+            test_weighted_entries_for_unknown_returns_none;
+          test_case "alias member resolves to underlying binding" `Quick
+            test_alias_member_resolves_to_underlying_binding;
+        ] );
+    ]


### PR DESCRIPTION
## Problem

After PR #14550 (Phase 4) the cascade.toml SSOT is fully 5-layer declarative ([providers.X], [models.X], [<provider>.<model>], [<p>.<m>.<a>], [tier.X], [tier-group.X]), but the runtime catalog discovery path still walks legacy [<name>_models] LIST keys — which the materialised cascade.json no longer emits.

Result: `discover_profiles` returns `[]` on every boot, `validate_path_result` rejects with **"no <name>_models profiles"**, and `server_runtime_bootstrap.ml:1534` falls into **degraded mode**. The system runs because routing has its own fallback, but the declarative `[tier.X]` blocks from #14550 are *parsed but invisible* to the runtime catalog.

Phase 3 declarative parsing (`Cascade_declarative_hotpath.try_load_declarative`) already exists in main but only runs as **parallel validation** — the result is dropped after a `json_names vs decl_names` diff log.

## Fix — Loader switchover

Wire declarative output into the legacy catalog so `[tier.X]` / `[tier-group.X]` profiles flow through `validate_profile_static` unchanged.

### New module: `Cascade_declarative_legacy_bridge`

160 LoC total. Reads cascade.toml via `Cascade_declarative_parser`, walks each `[tier.X]` and `[tier-group.X]` member resolving `\"provider.model\"` or `\"provider.model.alias\"` through `cfg.bindings`/`aliases`/`models`, and emits `cascade_prefix:api_name` model strings wrapped in `Cascade_weighted_entry.t`.

Depends only on `Cascade_declarative_parser` + `Cascade_declarative_types` (sibling cascade_decl sub-library) + `Provider_adapter` — deliberately avoiding `Cascade_declarative_adapter`, which uses `Cascade_config` and would close a cycle with `Cascade_config_loader`.

### Call-site wiring (3 places)

1. `Cascade_config_loader.load_profile_weighted` — when legacy `<name>_models` absent, fall back to `Cascade_declarative_legacy_bridge.weighted_entries_for_profile`.
2. `Cascade_config_loader.load_catalog` — augment legacy entries with declarative tier/tier-group names so route targets like `tier-group.big_three` resolve in `Cascade_routes.cascade_name_for_use`.
3. `Cascade_catalog_runtime.discover_profiles` callsite — union legacy walk with `Cascade_declarative_legacy_bridge.declarative_profile_names`.

### Type extraction

`weighted_entry` record extracted into a leaf `Cascade_weighted_entry.t` module (14 LoC) to break the otherwise-inevitable cycle between `Cascade_config_loader` (now consumer of bridge) and any future producer that wants to return weighted_entries.

`Cascade_config_loader.weighted_entry` is now an alias `= Cascade_weighted_entry.t = { ... }` — fully backward-compatible structurally.

## Verification

```bash
dune build --root .
# exit 0

dune exec test/test_cascade_declarative_legacy_bridge.exe
# 6/6 OK
```

Full cascade test suite (all green):

| suite | result |
|---|---|
| declarative_parser | 30/30 |
| declarative_validator | 25/25 |
| declarative_adapter | 17/17 |
| declarative_hotpath | 12/12 |
| **declarative_legacy_bridge** | **6/6** (this PR) |
| routes_decoder | 5/5 |
| phase1_smoke | 5/5 |
| config_validity | 6/6 |

`test_cascade_toml_materialization` has 2 **pre-existing** failures (`repo_sync.0`, `repo_sync.1`) on origin/main — unrelated to this PR (legacy profile names that the RFC-0058 migration removed). Confirmed by checking out origin/main and re-running.

## New tests (6)

`test/test_cascade_declarative_legacy_bridge.ml` covers:

- `discovery / declarative_profile_names surfaces tier and tier-group` — finds `tier.big_three`, `tier-group.big_three`, `tier-group.tool_rerank` in a minimal 5-layer TOML.
- `discovery / declarative_profile_names empty on unparseable` — returns `[]` (not raise) when TOML is malformed, so callers fall back to legacy safely.
- `resolution / weighted_entries_for tier emits model strings` — `tier.big_three` returns `codex_cli:gpt-5-codex` + `claude_code:claude-sonnet-4-5`.
- `resolution / weighted_entries_for tier-group expands member tiers` — tier-group walks through tier and returns the same model strings.
- `resolution / weighted_entries_for unknown returns None` — unknown profile name doesn't accidentally return `[]` (lets caller distinguish parse-failure from missing-profile).
- `resolution / alias member resolves to underlying binding` — `[claude_code.haiku.for-tool-rerank]` (alias) collapses to `claude_code:claude-haiku-4-5` (parent binding's model string). Alias overrides are runtime params, not catalog identity.

Tests use temp-file TOML so they don't depend on the repo cascade.toml shifting.

## Prerequisites

This branch is built on top of (cherry-picked):

- PR #14577 — \`fix(cascade): regen cascade.json with Phase 5.2a liveness sub-tables\` (silent regression on main)
- PR #14579 — \`fix(grpc): add LspRequest.of_bytes_result (main blocker)\` (#14573 follow-up)

Both cherry-picks will collapse to no-op once those PRs merge into main.

## RFC

RFC-0058 Phase 5 §catalog discovery bridge. This is the **loader switchover** that completes RFC §2.4 declarative SSOT for catalog discovery — without it the declarative `[tier.X]` data ships to TOML but never reaches the runtime, leaving two SSOTs in active use.

Remaining Phase 5 work (separate PRs):

- 5.1 — variant erasure (`Claude_code | Codex_cli | Kimi_cli | Gemini_cli` in 19 files)
- 5.2b — liveness caller migration (\`budget_for_label\` → \`budget_for_provider_id ~cfg\`)
- 5.3 — `cascade_prefix` literal erasure (12 files)
- 5.4 — Prometheus label generalisation (`metric_codex_cli_mcp_tool_omission` → `masc_provider_mcp_tool_omission_total{provider=\"<id>\"}`)
- 5.5 — `validate_strict` global promotion

🤖 Generated with [Claude Code](https://claude.com/claude-code)