### PR TITLE
test(cascade): drop JSON↔TOML byte-equality invariant (RFC-0058 §9)

### DIFF
--- a/test/test_cascade_toml_materialization.ml
+++ b/test/test_cascade_toml_materialization.ml
@@ -75,15 +75,16 @@ let init_config_root config_dir =
   mkdir_p (Filename.concat config_dir "keepers");
   mkdir_p (Filename.concat config_dir "personas")
 
-let repo_toml_path () =
-  match Sys.getenv_opt "MASC_CASCADE_TOML_PATH" with
-  | Some path when String.trim path <> "" -> path
-  | _ -> failwith "MASC_CASCADE_TOML_PATH not set"
-
-let repo_json_path () =
-  match Sys.getenv_opt "MASC_CASCADE_JSON_PATH" with
-  | Some path when String.trim path <> "" -> path
-  | _ -> failwith "MASC_CASCADE_JSON_PATH not set"
+(* Removed alongside the JSON-match invariant tests (RFC-0058 §9):
+   - [repo_toml_path] / [repo_json_path] helpers
+   - [render_or_fail], [model_names_for_profile],
+     [model_entry_for_profile], [supports_tool_choice_for_profile]
+   These keyed off the pre-RFC-0058 cascade.json shape
+   ([<name>_models] arrays) and the [MASC_CASCADE_JSON_PATH] env var
+   that the now-deleted byte-equality stanza injected. Note that
+   [MASC_CASCADE_TOML_PATH] still exists project-wide (e.g.
+   [test_cascade_config_validity.inc] uses it) — only the JSON-keyed
+   helpers and the JSON env var are gone from this suite. *)
 
 let minimal_toml =
   {|
@@ -91,105 +92,14 @@ let minimal_toml =
 models = ["ollama:qwen3.5:35b-a3b-nvfp4"]
 |}
 
-let render_or_fail toml_path =
-  match Masc_mcp.Cascade_toml_materializer.render_toml_file_to_json_string toml_path with
-  | Ok rendered -> rendered
-  | Error msg -> failf "unexpected TOML render failure: %s" msg
-
-let model_names_for_profile json profile_name =
-  json
-  |> member (profile_name ^ "_models")
-  |> to_list
-  |> List.map (function
-       | `String model -> model
-       | value -> value |> member "model" |> to_string)
-
-let model_entry_for_profile json profile_name model_name =
-  json
-  |> member (profile_name ^ "_models")
-  |> to_list
-  |> List.find_opt (function
-       | `String model -> String.equal model model_name
-       | value -> String.equal (value |> member "model" |> to_string) model_name)
-
-let supports_tool_choice_for_profile json profile_name model_name =
-  match model_entry_for_profile json profile_name model_name with
-  | None -> failf "%s missing from %s models" model_name profile_name
-  | Some (`String _) -> None
-  | Some value -> (
-      match value |> member "supports_tool_choice" with
-      | `Null -> None
-      | `Bool enabled -> Some enabled
-      | other ->
-          failf "unexpected supports_tool_choice value for %s/%s: %s"
-            profile_name model_name (Yojson.Safe.to_string other))
-
-let test_repo_seed_uses_two_profiles_plus_routes () =
-  let rendered = render_or_fail (repo_toml_path ()) |> Yojson.Safe.from_string in
-  let expect_profile_models profile_name expected =
-    check (list string) (profile_name ^ " models")
-      expected
-      (model_names_for_profile rendered profile_name)
-  in
-  expect_profile_models "big_three"
-    [
-      "codex_cli:gpt-5.3-codex-spark";
-      "gemini_cli:auto";
-      "kimi_cli:kimi-for-coding";
-      "glm-coding:auto";
-      "claude_code:auto";
-    ];
-  expect_profile_models "tool_rerank"
-    [
-      "codex_cli:gpt-5.3-codex-spark";
-      "gemini_cli:auto";
-      "kimi_cli:kimi-for-coding";
-      "glm-coding:auto";
-      "claude_code:auto";
-    ];
-  check (option bool) "big_three GLM declares tool choice support"
-    (Some true)
-    (supports_tool_choice_for_profile rendered "big_three" "glm-coding:auto");
-  check (option bool) "__safe_lane GLM declares tool choice support"
-    (Some true)
-    (supports_tool_choice_for_profile rendered "__safe_lane" "glm-coding:auto");
-  check (option bool) "tier_fast GLM 5 turbo declares tool choice support"
-    (Some true)
-    (supports_tool_choice_for_profile rendered "tier_fast"
-       "glm-coding:glm-5-turbo");
-  check (option bool) "tier_fast GLM 4.7 flashx declares tool choice support"
-    (Some true)
-    (supports_tool_choice_for_profile rendered "tier_fast"
-       "glm-coding:glm-4.7-flashx");
-  check bool "default profile removed" true
-    (match rendered |> member "default_models" with `Null -> true | _ -> false);
-  check bool "governance profile removed" true
-    (match rendered |> member "governance_judge_models" with `Null -> true | _ -> false);
-  check bool "operator profile removed" true
-    (match rendered |> member "operator_judge_models" with `Null -> true | _ -> false);
-  let routes = rendered |> member "routes" in
-  let route_keys =
-    match routes with
-    | `Assoc fields -> fields |> List.map fst |> List.sort String.compare
-    | _ -> []
-  in
-  check (list string) "repo seed routes cover known logical uses"
-    (Masc_mcp.Cascade_routes.known_route_keys |> List.sort String.compare)
-    route_keys;
-  check string "governance route" "big_three"
-    (routes |> member "governance_judge" |> to_string);
-  check string "operator route" "big_three"
-    (routes |> member "operator_judge" |> to_string);
-  check string "rerank route" "tool_rerank"
-    (routes |> member "llm_rerank" |> to_string);
-  check string "simple task route" "tier_small"
-    (routes |> member "simple_task" |> to_string);
-  check string "moderate task route" "tier_medium"
-    (routes |> member "moderate_task" |> to_string);
-  check string "complex task route" "big_three"
-    (routes |> member "complex_task" |> to_string);
-  check bool "tool_rerank is system-only" false
-    (rendered |> member "tool_rerank_keeper_assignable" |> to_bool)
+(* RFC-0058 §9: legacy profile-shape assertions on the repo seed
+   (big_three / tool_rerank / __safe_lane / tier_fast / default_models)
+   referred to the pre-RFC-0058 flat cascade.json shape.  After PR #14550
+   migrated cascade.toml to the 5-layer declarative schema those names
+   no longer exist as top-level [<name>] tables in TOML.  The legacy
+   assertion was dropped along with the JSON-match invariant — the
+   declarative parser/validator/adapter test suites cover the same
+   ground for the new schema. *)
 
 let test_routes_table_is_parsed () =
   match
@@ -243,11 +153,12 @@ models = ["gemini_cli:auto"]
              | Ok names -> names
              | Error msg -> failf "section fallback failed: %s" msg))
 
-let test_repo_toml_renders_to_committed_json () =
-  let rendered = render_or_fail (repo_toml_path ()) in
-  check string "repo cascade json stays in sync with toml"
-    (read_file (repo_json_path ()))
-    rendered
+(* RFC-0058 §9: the JSON↔TOML byte-equality round-trip was the SSOT
+   anchor for the pre-RFC-0058 cascade.json file.  §9 declares that
+   "cascade.json [is] no longer generated or consumed"; re-asserting the
+   round-trip would re-anchor the to-be-removed file as ground truth.
+   Consumer migration to in-memory materialization continues in follow-up
+   PRs; this drop unblocks main without committing a JSON regen. *)
 
 let test_fallback_cascade_field_is_parsed () =
   match
@@ -634,13 +545,6 @@ models = [
 let () =
   run "cascade_toml_materialization"
     [
-      ( "repo_sync",
-        [
-          test_case "repo toml renders to committed json" `Quick
-            test_repo_toml_renders_to_committed_json;
-          test_case "repo seed uses two profiles plus routes" `Quick
-            test_repo_seed_uses_two_profiles_plus_routes;
-        ] );
       ( "validation",
         [
           test_case "unknown profile field is rejected" `Quick


### PR DESCRIPTION
## Why

Per **PR #14577 closeout** (your closing comment):

> Closing per RFC-0058 §9 (Acceptance Criteria): \"cascade.json no longer generated or consumed\". Regenerating committed cascade.json with the Phase 5.2a liveness sub-tables moves in the opposite direction — it re-anchors the to-be-removed JSON file as the matched ground truth. The right fix is to advance RFC-0058 §9: drop the committed cascade.json, remove the test_committed_json_matches_toml_materializer test that enforces the JSON↔TOML byte-equality invariant, and migrate the ~20 consumers in lib/cascade/, lib/dashboard/, etc. to in-memory materialization via Cascade_toml_materializer. Filing as a multi-PR track. First PR will drop the JSON-match invariant (so main is green without committing JSON regen); follow-up PRs migrate consumers and delete the file.

This **is** that first PR.

## What

Three stale tests dropped:

| Test | Location | Why |
|---|---|---|
| \`test_committed_json_matches_toml_materializer\` | \`test/test_cascade_config_validity.ml\` | Exactly the JSON↔TOML byte-equality invariant §9 retires |
| \`test_repo_toml_renders_to_committed_json\` | \`test/test_cascade_toml_materialization.ml\` | Same byte-equality check via different helpers |
| \`test_repo_seed_uses_two_profiles_plus_routes\` | \`test/test_cascade_toml_materialization.ml\` | Asserted the **pre-RFC-0058 flat-profile shape** (\`big_three\`, \`tool_rerank\`, \`__safe_lane\`, \`tier_fast\`, \`default_models\`) survives materialization — PR #14550 migrated to the 5-layer declarative schema so those names no longer exist as top-level tables |

Dead helpers removed alongside them in \`test_cascade_toml_materialization.ml\`:

- \`repo_toml_path\` / \`repo_json_path\` (\`MASC_CASCADE_TOML_PATH\` / \`MASC_CASCADE_JSON_PATH\` env-var lookups)
- \`model_names_for_profile\` / \`model_entry_for_profile\` / \`supports_tool_choice_for_profile\` (all keyed on legacy \`<name>_models\`)
- \`render_or_fail\` (only called by removed tests)

Stanza docstring in \`test/stanzas/test_cascade_config_validity.inc\` updated to reference §9 and note remaining checks are profile parse-level only.

## Diff scope

\`\`\`
test/stanzas/test_cascade_config_validity.inc |   8 +-
test/test_cascade_config_validity.ml          |  42 ++-----
test/test_cascade_toml_materialization.ml     | 141 +++++---------------------
3 files changed, 33 insertions(+), 158 deletions(-)
\`\`\`

## Verification

- \`dune build --root .\` — green
- \`test_cascade_config_validity\` — **5/5 OK** (was 5/6 with byte-equality FAIL)
- \`test_cascade_toml_materialization\` — **20/20 OK** (was 20/22 with two stale FAILs)

Main now green on these two suites without committing a JSON regen.

## What stays for now

- \`config/cascade.json\` file — kept in repo
- \`Cascade_toml_materializer.render_toml_to_json_string\` / \`ensure_materialized_json\` — kept
- \`MASC_CASCADE_JSON_PATH\` env var in \`test_cascade_config_validity.inc\` — kept (still used by the profile-parse tests)
- \`cascade_path()\` / \`discover_profiles()\` helpers in \`test_cascade_config_validity.ml\` — kept (still used by dynamic profile_cases generation; harmless when \`<name>_models\` keys are absent because the resulting test list is empty)

The next PRs in the §9 track migrate the ~20 consumers in \`lib/cascade/\`, \`lib/dashboard/\`, \`lib/keeper/\`, etc. off \`cascade.json\` to in-memory materialization, then delete the file as the final step.

## RFC

RFC-0058 §9 Acceptance Criteria, line 542:

> \`[ ] cascade.json no longer generated or consumed\`

This advances that gate by retiring the test contract that anchored \`cascade.json\` as ground truth.

## Prerequisite

Includes cherry-pick of PR #14579 (\`grpc LspRequest.of_bytes_result\` main blocker) — will collapse to no-op once that merges into main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)