### PR TITLE
chore(cascade): drop MASC_OLLAMA_* env vars (RFC-0058 §2.4 cleanup)

### DIFF
--- a/lib/cascade/cascade_client_capacity.ml
+++ b/lib/cascade/cascade_client_capacity.ml
@@ -144,9 +144,6 @@ let int_of_env ?(default = 0) name =
     Log.Misc.warn "Invalid int for %s=%S, using default %d" name raw default;
     default
 
-let ollama_default_max () =
-  max 1 (int_of_env ~default:1 "MASC_OLLAMA_MAX_CONCURRENT")
-
 let cli_default_max () =
   max 1 (int_of_env ~default:1 "MASC_CLI_MAX_CONCURRENT")
 
@@ -222,7 +219,7 @@ let looks_like_ollama = Masc_network_defaults.is_ollama_url
 let looks_like_cli_sentinel = Masc_network_defaults.is_cli_sentinel_url
 
 let auto_register_for_candidates ~base_urls =
-  let max_concurrent = ollama_default_max () in
+  let max_concurrent = 1 in
   List.iter
     (fun url ->
        if looks_like_ollama url && not (is_registered url) then begin

--- a/lib/cascade/cascade_client_capacity.mli
+++ b/lib/cascade/cascade_client_capacity.mli
@@ -63,8 +63,7 @@ val auto_register_for_candidates :
   unit
 (** For each base URL that looks like an ollama HTTP endpoint
     (heuristic: host/port contains [:11434]) and is not yet
-    registered, register it with the default ollama concurrency
-    (env [MASC_OLLAMA_MAX_CONCURRENT], fallback [1]).
+    registered, register it with concurrency [1].
 
     Idempotent.  Safe to call on every cascade attempt; already-
     registered URLs are left alone. *)

--- a/lib/cascade/cascade_config.mli
+++ b/lib/cascade/cascade_config.mli
@@ -569,8 +569,7 @@ val resolve_ollama_max_concurrent :
   int option
 (** Per-cascade override for the ollama client-capacity registration
     default ({!Cascade_client_capacity.auto_register_for_candidates}).
-    [None] means "use the env-var default
-    ([MASC_OLLAMA_MAX_CONCURRENT] or 1)". *)
+    [None] means "use the literal default of 1". *)
 
 val resolve_cli_max_concurrent :
   ?config_path:string ->

--- a/lib/cascade/cascade_http_probe.ml
+++ b/lib/cascade/cascade_http_probe.ml
@@ -95,56 +95,19 @@ let probe_endpoint_of base_url =
   stripped ^ Masc_network_defaults.ollama_api_ps_path
 ;;
 
-(* Operator-tunable default for the probe timeout.
+(* Probe HTTP timeout.
 
-   Was a literal [0.5] embedded twice (in [try_probe] and
-   [refresh_many]).  Operators reported that 0.5s is fine for ollama
-   serving small models on a fast box but is tight when the box is
-   loading a big model (the [/api/ps] handler shares the same lock
-   as model load) — in those cases the probe times out, the cache
-   stays cold, and the cascade backs off to a non-local provider
-   even though ollama is healthy and only briefly busy.
-
-   Resolution order (process env > literal default):
-   - [MASC_OLLAMA_PROBE_TIMEOUT_SEC]  (float)
-
-   Range [0.05, 30.0]; out-of-range or unparseable values fall back
-   to the literal default with a one-shot WARN.
-
-   Read at every call site so operator changes via runtime tooling
-   take effect without a process restart.  The cost is one
-   [Sys.getenv_opt] per probe attempt, which is negligible compared
-   to the HTTP round-trip the probe makes. *)
+   0.5s suits a fast box serving small models; a box loading a large
+   model shares the same lock as [/api/ps] and can briefly exceed
+   this. Caller may override via the optional [?timeout_s] argument
+   when a longer ceiling is needed. *)
 let probe_timeout_default_s = 0.5
-let probe_timeout_env_var = "MASC_OLLAMA_PROBE_TIMEOUT_SEC"
-let probe_timeout_warned = Atomic.make false
-
-let probe_timeout_resolved () =
-  match Sys.getenv_opt probe_timeout_env_var with
-  | None -> probe_timeout_default_s
-  | Some raw ->
-    let trimmed = String.trim raw in
-    if trimmed = ""
-    then probe_timeout_default_s
-    else (
-      match float_of_string_opt trimmed with
-      | Some v when v >= 0.05 && v <= 30.0 -> v
-      | Some _ | None ->
-        if not (Atomic.exchange probe_timeout_warned true)
-        then
-          Log.Misc.warn
-            "Ignoring %s=%S (expected float in [0.05, 30.0]); using default %.2fs."
-            probe_timeout_env_var
-            raw
-            probe_timeout_default_s;
-        probe_timeout_default_s)
-;;
 
 let try_probe ~sw ~net ?clock ?timeout_s ?now url =
   let timeout_s =
     match timeout_s with
     | Some v -> v
-    | None -> probe_timeout_resolved ()
+    | None -> probe_timeout_default_s
   in
   let _ = sw in
   let now =
@@ -179,7 +142,7 @@ let refresh_many ~sw ~net ?timeout_s urls =
   let timeout_s =
     match timeout_s with
     | Some v -> v
-    | None -> probe_timeout_resolved ()
+    | None -> probe_timeout_default_s
   in
   List.iter
     (fun url ->

--- a/lib/cascade/cascade_http_probe.mli
+++ b/lib/cascade/cascade_http_probe.mli
@@ -56,9 +56,8 @@ val cached_capacity : ?now:float -> string -> Cascade_throttle.capacity_info opt
     (and does not touch the cache) on timeout, non-200, or parse
     failure.
 
-    Default [timeout_s] is read from [MASC_OLLAMA_PROBE_TIMEOUT_SEC]
-    on every call (range [0.05, 30.0], literal fallback [0.5]).
-    Pass an explicit [?timeout_s] argument to override per-call.
+    Default [timeout_s] is [0.5] seconds; pass an explicit
+    [?timeout_s] argument to override per-call.
 
     Caller is responsible for picking [url]s that look like ollama
     (use {!is_ollama_url}); calling on a non-ollama URL will fail


### PR DESCRIPTION
## Summary

RFC-0058 §2.4 cleanup. \`MASC_OLLAMA_MAX_CONCURRENT\` 과 \`MASC_OLLAMA_PROBE_TIMEOUT_SEC\` env var를 제거. cascade.toml을 모델/프로바이더 config의 SSOT로 통일.

## Rationale

- cascade.toml의 binding-level \`max-concurrent\`가 이미 SSOT. env-var override는 RFC-0058 §2.4 ("code dispatches by api_format, never by provider name")와 충돌.
- probe timeout 은 실전에서 operator-tunable로 운영된 적 거의 없고, 0.5s 리터럴 기본값 + per-call \`?timeout_s\` override로 충분.
- 새 TOML 필드를 추가하지 않음. cascade.toml은 \"OpenAI Compat 여부 + 추가 파라미터 정도\"로 가벼움 유지.

## Changes

- \`lib/cascade/cascade_client_capacity.ml\`: \`ollama_default_max\` 함수 + caller 정리. \`auto_register_for_candidates\`는 literal \`1\` 사용.
- \`lib/cascade/cascade_http_probe.ml\`: \`probe_timeout_resolved\`, \`probe_timeout_env_var\`, \`probe_timeout_warned\` 제거. 두 caller (\`try_probe\`, \`refresh_many\`)는 \`probe_timeout_default_s\` literal 직접 참조.
- \`.mli\` 3개: env-var 인용 docstring 정리.

## Verification

- \`rg MASC_OLLAMA lib/ bin/\` → empty (no remaining env var refs in code)
- \`dune build lib/cascade\` → clean
- Unrelated \`lib/grpc/masc_grpc_service.ml:275\` LspCall error exists on main, pre-dates this change

## Follow-ups (separate PRs)

- Phase B: \`Tool_local_runtime_probe\` (57 ollama mentions) — vendor-specific module 흡수/삭제
- Phase C: \`docs/spec/*\`, \`lib/dashboard_cascade.*\` wording 정리

🤖 Generated with [Claude Code](https://claude.com/claude-code)