### PR TITLE
fix(keeper): RFC-0064 review follow-up — wire telemetry through canonical_name + bound label cardinality

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -713,20 +713,20 @@ let run_turn
                      ~reported_tool_names
                      ~observed_tool_names
                  in
-                 (* RFC-0064: route LLM-native tool names (Bash/Read/etc) to their
-          keeper_* internal cognates before the disclosure check. Without
-          this, the disclosure check flags every Bash/Read call as "unexpected"
-          and nukes turns where the LLM only used the alias names (≈18% of
-          turns per #8778). Unknown names (routing misses) are left as-is and
-          may still trigger a teaching error — recorded via result-based
-          telemetry by [route_or_miss]. *)
-                 (* Canonicalise observed tool names across all three input
-                    surfaces (LLM-native public / MCP protocol /
-                    already-internal). Using Keeper_tool_alias.route_or_miss
-                    directly would record every internal "keeper_*"/"masc_*"
-                    call as a routing miss, inflating
-                    masc_keeper_tool_call_total{result="miss"} and skewing
-                    the alias dashboards (see PR #14574 review). *)
+                 (* RFC-0064: canonicalise observed tool names across all three
+                    input surfaces (LLM-native public / MCP protocol /
+                    already-internal) before the disclosure check. Without
+                    this, the disclosure check flags every Bash/Read call as
+                    "unexpected" and nukes turns where the LLM only used the
+                    alias names (≈18% of turns per #8778).
+
+                    [Keeper_tool_disclosure.canonical_tool_name] emits the
+                    per-branch result-based telemetry
+                    ([masc_keeper_tool_call_total] with bounded labels) — see
+                    that module for the full path. Using the lower-level
+                    [Keeper_tool_alias.route_or_miss] here would mis-attribute
+                    every internal "keeper_*"/"masc_*" pass-through as a
+                    routing miss. *)
                  let canonical_tool_names =
                    List.map Keeper_tool_disclosure.canonical_tool_name tool_names
                  in

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -720,15 +720,16 @@ let run_turn
                     "unexpected" and nukes turns where the LLM only used the
                     alias names (≈18% of turns per #8778).
 
-                    [Keeper_tool_disclosure.canonical_tool_name] emits the
-                    per-branch result-based telemetry
-                    ([masc_keeper_tool_call_total] with bounded labels) — see
-                    that module for the full path. Using the lower-level
-                    [Keeper_tool_alias.route_or_miss] here would mis-attribute
-                    every internal "keeper_*"/"masc_*" pass-through as a
-                    routing miss. *)
+                    [canonical_tool_name_observed] is the observation
+                    boundary — it emits exactly one
+                    [masc_keeper_tool_call_total] sample per observed
+                    name with bounded labels. Set-logic call sites
+                    (required-tool canonicalisation, surface composition)
+                    use the pure [canonical_tool_name] variant so a
+                    single observed call does not produce multiple
+                    counter samples (PR #14585 review #3). *)
                  let canonical_tool_names =
-                   List.map Keeper_tool_disclosure.canonical_tool_name tool_names
+                   List.map Keeper_tool_disclosure.canonical_tool_name_observed tool_names
                  in
                  canonical_tool_names_ref := canonical_tool_names;
                  let unexpected_tool_names =

--- a/lib/keeper/keeper_run_tools.ml
+++ b/lib/keeper/keeper_run_tools.ml
@@ -63,7 +63,25 @@ type tool_search_hit_partition =
   }
 
 let partition_tool_search_hits ~core ~core_always ~allowed ~retrieved ~max_results =
-  let allowed = allowed @ Keeper_tool_alias.public_names () in
+  (* PR #14574 review #1/#7: only expose a public alias (e.g. "Bash") when
+     its routed internal handler (e.g. [keeper_bash]) is actually in the
+     incoming [allowed] set for this preset. Adding all [public_names ()]
+     unconditionally let [keeper_tool_search] return aliases even when
+     their backing tool was not permitted for the turn, which would invite
+     the model to attempt unregistered tool calls. *)
+  let allowed_internal_set =
+    let tbl = Hashtbl.create (List.length allowed) in
+    List.iter (fun n -> Hashtbl.replace tbl n ()) allowed;
+    tbl
+  in
+  let aliases_with_allowed_route =
+    Keeper_tool_alias.public_names ()
+    |> List.filter (fun pub ->
+      match Keeper_tool_alias.route pub with
+      | Some r -> Hashtbl.mem allowed_internal_set r.internal_name
+      | None -> false)
+  in
+  let allowed = allowed @ aliases_with_allowed_route in
   let allowed_set =
     let tbl = Hashtbl.create (List.length allowed) in
     List.iter (fun n -> Hashtbl.replace tbl n ()) allowed;

--- a/lib/keeper/keeper_tool_alias.ml
+++ b/lib/keeper/keeper_tool_alias.ml
@@ -65,10 +65,6 @@ let known_internal_names_tbl : (string, unit) Hashtbl.t =
   t
 ;;
 
-let register_known_internal name =
-  if name <> "" then Hashtbl.replace known_internal_names_tbl name ()
-;;
-
 let is_known_internal name = Hashtbl.mem known_internal_names_tbl name
 
 (** Bound a label value to a closed set so hallucinated / unbounded

--- a/lib/keeper/keeper_tool_alias.ml
+++ b/lib/keeper/keeper_tool_alias.ml
@@ -50,10 +50,49 @@ let routing_table : (string, route) Hashtbl.t =
 
 (* ── Result-based telemetry ──────────────────────────────────────── *)
 
+(** [is_known_public name] is [true] when [name] has a routing entry. *)
+let is_known_public name = Hashtbl.mem routing_table name
+
+(** Known internal handler names — the [internal_name] values that
+    [routing_table] entries map onto, plus the [masc_*] surface that
+    [public_masc_to_internal] resolves. Used to bound the [routed_to]
+    Prometheus label so that unrecognised strings never become a new
+    time series. *)
+let known_internal_names_tbl : (string, unit) Hashtbl.t =
+  let t = Hashtbl.create 64 in
+  Hashtbl.iter (fun _ r -> Hashtbl.replace t r.internal_name ()) routing_table;
+  List.iter (fun n -> Hashtbl.replace t n ()) Tool_catalog_surfaces.keeper_internal_tools;
+  t
+;;
+
+let register_known_internal name =
+  if name <> "" then Hashtbl.replace known_internal_names_tbl name ()
+;;
+
+let is_known_internal name = Hashtbl.mem known_internal_names_tbl name
+
+(** Bound a label value to a closed set so hallucinated / unbounded
+    names never inflate Prometheus cardinality. *)
+let safe_tool_label name =
+  if is_known_public name
+  then name
+  else if is_known_internal name
+  then name
+  else "unknown"
+;;
+
+let safe_routed_to_label name =
+  if name = "none" then name else if is_known_internal name then name else "unknown"
+;;
+
 let record_route_outcome ~tool ~routed_to ~result =
   Prometheus.inc_counter
     Keeper_metrics.metric_keeper_tool_call_total
-    ~labels:[ "tool", tool; "routed_to", routed_to; "result", result ]
+    ~labels:
+      [ "tool", safe_tool_label tool
+      ; "routed_to", safe_routed_to_label routed_to
+      ; "result", result
+      ]
     ()
 ;;
 
@@ -66,7 +105,13 @@ let route name =
 ;;
 
 (** [route_or_miss name] returns the route if found, or records a routing
-    miss via result-based telemetry and returns [None]. *)
+    miss via result-based telemetry and returns [None].
+
+    Used by direct OAS-edge dispatch where a [None] result short-circuits
+    the call. General canonicalisation (which also has to handle MCP
+    prefixes and pass-through of already-internal names) goes through
+    [Keeper_tool_disclosure.canonical_tool_name], which emits its own
+    per-branch telemetry — see that module for the wider path. *)
 let route_or_miss name =
   match route name with
   | Some r ->
@@ -76,11 +121,6 @@ let route_or_miss name =
     record_route_outcome ~tool:name ~routed_to:"none" ~result:"miss";
     None
 ;;
-
-(** [is_known_public name] is [true] when [name] has a routing entry.
-    Callers that previously used [canonicalize_observed] to check whether a
-    name is known should use this instead. *)
-let is_known_public name = Hashtbl.mem routing_table name
 
 (** [public_names ()] returns all LLM-native public names in stable order.
     Used by callers that previously used [expand_universe] to add alias names

--- a/lib/keeper/keeper_tool_alias.ml
+++ b/lib/keeper/keeper_tool_alias.ml
@@ -59,9 +59,18 @@ let is_known_public name = Hashtbl.mem routing_table name
     Prometheus label so that unrecognised strings never become a new
     time series. *)
 let known_internal_names_tbl : (string, unit) Hashtbl.t =
-  let t = Hashtbl.create 64 in
+  let t = Hashtbl.create 128 in
   Hashtbl.iter (fun _ r -> Hashtbl.replace t r.internal_name ()) routing_table;
-  List.iter (fun n -> Hashtbl.replace t n ()) Tool_catalog_surfaces.keeper_internal_tools;
+  List.iter
+    (fun internal ->
+       Hashtbl.replace t internal ();
+       (* Also admit the public MCP counterpart (e.g. [masc_board_post])
+          so successful MCP routes do not collapse to [tool="unknown"]
+          (PR #14585 review). *)
+       match Tool_catalog_surfaces.keeper_internal_replacement internal with
+       | Some public -> Hashtbl.replace t public ()
+       | None -> ())
+    Tool_catalog_surfaces.keeper_internal_tools;
   t
 ;;
 

--- a/lib/keeper/keeper_tool_alias.mli
+++ b/lib/keeper/keeper_tool_alias.mli
@@ -36,6 +36,12 @@ val route_or_miss : string -> route option
     Replaces the old [canonicalize_observed] check for known names. *)
 val is_known_public : string -> bool
 
+(** [is_known_internal name] is [true] when [name] is a recognised
+    internal handler name (any [routing_table] target plus the full
+    [Tool_catalog_surfaces.keeper_internal_tools] set). Callers use this
+    to keep Prometheus label cardinality bounded. *)
+val is_known_internal : string -> bool
+
 (** [public_names ()] returns all LLM-native public names in stable order.
     Replaces [expand_universe] — callers should add these names directly
     to allowlists at construction time. *)
@@ -45,6 +51,13 @@ val public_names : unit -> string list
 
 (** [record_route_outcome ~tool ~routed_to ~result] increments the
     [masc_keeper_tool_call_total] counter with the given labels.
+
+    Cardinality is bounded: [tool] / [routed_to] are normalised to
+    ["unknown"] when the supplied value is neither a known public name
+    nor a known internal handler. Raw unrecognised strings never become
+    new label values, so hallucinated tool names cannot inflate the
+    Prometheus time series.
+
     [result] is ["ok"] for a successful route or ["miss"] for an unknown name. *)
 val record_route_outcome : tool:string -> routed_to:string -> result:string -> unit
 

--- a/lib/keeper/keeper_tool_disclosure.ml
+++ b/lib/keeper/keeper_tool_disclosure.ml
@@ -35,13 +35,17 @@ let tool_usage_delta ~(before : (string * int) list) ~(after : (string * int) li
    Conflating them under a single [route] lookup loses (2) silently and
    misattributes (3) as routing misses; see PR #14574 review. *)
 let canonical_name name =
+  (* MCP and direct LLM-native paths both lookup against [stripped] so that
+     a name like ["mcp__masc__Bash"] routes the same as ["Bash"]. Using the
+     raw [name] for [route] would regress prefixed Anthropic-Code calls
+     into routing misses (PR #14574 review #5). *)
   let stripped = Keeper_tool_alias.strip_mcp_masc_prefix name in
   match Keeper_tool_alias.public_masc_to_internal stripped with
   | Some internal ->
     Keeper_tool_alias.record_route_outcome ~tool:name ~routed_to:internal ~result:"ok";
     internal
   | None ->
-    (match Keeper_tool_alias.route name with
+    (match Keeper_tool_alias.route stripped with
      | Some r ->
        Keeper_tool_alias.record_route_outcome
          ~tool:name

--- a/lib/keeper/keeper_tool_disclosure.ml
+++ b/lib/keeper/keeper_tool_disclosure.ml
@@ -78,15 +78,21 @@ let canonical_name name =
     - [Already_internal]: tool = name, routed_to = name, result = ok
     - [Miss]:       tool = name (normalised to "unknown" by safe_tool_label), routed_to = "none", result = miss *)
 let canonical_name_observed name =
+  (* Always strip the MCP prefix before recording [tool] so MCP-prefixed
+     Anthropic Code calls (e.g. [mcp__masc__Bash]) and MCP-prefixed
+     keeper internal calls (e.g. [mcp__masc__masc_board_post]) keep the
+     stripped form in the label. The stripped form is in
+     [is_known_public] or [is_known_internal] for any successful route,
+     so [safe_tool_label] preserves it. Self-review of PR #14585 caught
+     that the Route_hit branch was still recording the raw prefixed
+     name and collapsing to ["unknown"]. *)
+  let stripped = Keeper_tool_alias.strip_mcp_masc_prefix name in
   match canonicalise_outcome name with
-  | Mcp_mapped { stripped; internal } ->
-    (* Recording [stripped] keeps the label in [is_known_internal], so
-       MCP-prefixed names do not get collapsed into ["unknown"] on
-       successful routes (PR #14585 review #1). *)
+  | Mcp_mapped { internal; _ } ->
     Keeper_tool_alias.record_route_outcome ~tool:stripped ~routed_to:internal ~result:"ok";
     internal
   | Route_hit { internal } ->
-    Keeper_tool_alias.record_route_outcome ~tool:name ~routed_to:internal ~result:"ok";
+    Keeper_tool_alias.record_route_outcome ~tool:stripped ~routed_to:internal ~result:"ok";
     internal
   | Already_internal ->
     Keeper_tool_alias.record_route_outcome ~tool:name ~routed_to:name ~result:"ok";

--- a/lib/keeper/keeper_tool_disclosure.ml
+++ b/lib/keeper/keeper_tool_disclosure.ml
@@ -43,7 +43,7 @@ type canonicalisation_outcome =
       ; internal : string
       }
   | Route_hit of { internal : string }
-  | Already_internal
+  | Already_internal of { canonical : string }
   | Miss
 
 let canonicalise_outcome name =
@@ -53,7 +53,15 @@ let canonicalise_outcome name =
   | None ->
     (match Keeper_tool_alias.route stripped with
      | Some r -> Route_hit { internal = r.internal_name }
-     | None -> if Keeper_tool_alias.is_known_internal name then Already_internal else Miss)
+     | None ->
+       (* Check [stripped] (not the raw [name]) so MCP-prefixed internal
+          names like [mcp__masc__keeper_pr_create] are recognised and
+          canonicalised to [keeper_pr_create]. The unstripped form is
+          never in [is_known_internal] for known prefixed transports
+          (PR #14585 review). *)
+       if Keeper_tool_alias.is_known_internal stripped
+       then Already_internal { canonical = stripped }
+       else Miss)
 ;;
 
 (** Pure canonicalisation — no telemetry. Used by set-logic call sites
@@ -63,7 +71,7 @@ let canonical_name name =
   match canonicalise_outcome name with
   | Mcp_mapped { internal; _ } -> internal
   | Route_hit { internal } -> internal
-  | Already_internal -> name
+  | Already_internal { canonical } -> canonical
   | Miss -> name
 ;;
 
@@ -94,9 +102,12 @@ let canonical_name_observed name =
   | Route_hit { internal } ->
     Keeper_tool_alias.record_route_outcome ~tool:stripped ~routed_to:internal ~result:"ok";
     internal
-  | Already_internal ->
-    Keeper_tool_alias.record_route_outcome ~tool:name ~routed_to:name ~result:"ok";
-    name
+  | Already_internal { canonical } ->
+    Keeper_tool_alias.record_route_outcome
+      ~tool:canonical
+      ~routed_to:canonical
+      ~result:"ok";
+    canonical
   | Miss ->
     Keeper_tool_alias.record_route_outcome ~tool:name ~routed_to:"none" ~result:"miss";
     name

--- a/lib/keeper/keeper_tool_disclosure.ml
+++ b/lib/keeper/keeper_tool_disclosure.ml
@@ -37,11 +37,30 @@ let tool_usage_delta ~(before : (string * int) list) ~(after : (string * int) li
 let canonical_name name =
   let stripped = Keeper_tool_alias.strip_mcp_masc_prefix name in
   match Keeper_tool_alias.public_masc_to_internal stripped with
-  | Some internal -> internal
+  | Some internal ->
+    Keeper_tool_alias.record_route_outcome ~tool:name ~routed_to:internal ~result:"ok";
+    internal
   | None ->
     (match Keeper_tool_alias.route name with
-     | Some r -> r.internal_name
-     | None -> name)
+     | Some r ->
+       Keeper_tool_alias.record_route_outcome
+         ~tool:name
+         ~routed_to:r.internal_name
+         ~result:"ok";
+       r.internal_name
+     | None ->
+       if Keeper_tool_alias.is_known_internal name
+       then (
+         (* Already-internal pass-through: legitimate tool already
+            named [keeper_*] or [masc_*]. Not a routing miss. *)
+         Keeper_tool_alias.record_route_outcome ~tool:name ~routed_to:name ~result:"ok";
+         name)
+       else (
+         Keeper_tool_alias.record_route_outcome
+           ~tool:name
+           ~routed_to:"none"
+           ~result:"miss";
+         name))
 ;;
 
 let merge_observed_tool_names

--- a/lib/keeper/keeper_tool_disclosure.ml
+++ b/lib/keeper/keeper_tool_disclosure.ml
@@ -34,37 +34,66 @@ let tool_usage_delta ~(before : (string * int) list) ~(after : (string * int) li
 
    Conflating them under a single [route] lookup loses (2) silently and
    misattributes (3) as routing misses; see PR #14574 review. *)
-let canonical_name name =
-  (* MCP and direct LLM-native paths both lookup against [stripped] so that
-     a name like ["mcp__masc__Bash"] routes the same as ["Bash"]. Using the
-     raw [name] for [route] would regress prefixed Anthropic-Code calls
-     into routing misses (PR #14574 review #5). *)
+(* Three input surfaces, packed into an outcome variant so the pure
+   canonicalisation and the observation-emitting wrapper share one
+   decision tree. *)
+type canonicalisation_outcome =
+  | Mcp_mapped of
+      { stripped : string
+      ; internal : string
+      }
+  | Route_hit of { internal : string }
+  | Already_internal
+  | Miss
+
+let canonicalise_outcome name =
   let stripped = Keeper_tool_alias.strip_mcp_masc_prefix name in
   match Keeper_tool_alias.public_masc_to_internal stripped with
-  | Some internal ->
-    Keeper_tool_alias.record_route_outcome ~tool:name ~routed_to:internal ~result:"ok";
-    internal
+  | Some internal -> Mcp_mapped { stripped; internal }
   | None ->
     (match Keeper_tool_alias.route stripped with
-     | Some r ->
-       Keeper_tool_alias.record_route_outcome
-         ~tool:name
-         ~routed_to:r.internal_name
-         ~result:"ok";
-       r.internal_name
-     | None ->
-       if Keeper_tool_alias.is_known_internal name
-       then (
-         (* Already-internal pass-through: legitimate tool already
-            named [keeper_*] or [masc_*]. Not a routing miss. *)
-         Keeper_tool_alias.record_route_outcome ~tool:name ~routed_to:name ~result:"ok";
-         name)
-       else (
-         Keeper_tool_alias.record_route_outcome
-           ~tool:name
-           ~routed_to:"none"
-           ~result:"miss";
-         name))
+     | Some r -> Route_hit { internal = r.internal_name }
+     | None -> if Keeper_tool_alias.is_known_internal name then Already_internal else Miss)
+;;
+
+(** Pure canonicalisation — no telemetry. Used by set-logic call sites
+    (required-tool canonicalisation, surface composition, satisfaction
+    checks) where every invocation should NOT count as an observation. *)
+let canonical_name name =
+  match canonicalise_outcome name with
+  | Mcp_mapped { internal; _ } -> internal
+  | Route_hit { internal } -> internal
+  | Already_internal -> name
+  | Miss -> name
+;;
+
+(** Observation-emitting canonicalisation. Used at the keeper turn
+    observation site (keeper_agent_run) where each observed tool name
+    should produce exactly one [masc_keeper_tool_call_total] sample with
+    bounded labels.
+
+    Telemetry labels per branch:
+    - [Mcp_mapped]: tool = stripped (e.g. [masc_board_post]), routed_to = internal, result = ok
+    - [Route_hit]:  tool = name, routed_to = internal, result = ok
+    - [Already_internal]: tool = name, routed_to = name, result = ok
+    - [Miss]:       tool = name (normalised to "unknown" by safe_tool_label), routed_to = "none", result = miss *)
+let canonical_name_observed name =
+  match canonicalise_outcome name with
+  | Mcp_mapped { stripped; internal } ->
+    (* Recording [stripped] keeps the label in [is_known_internal], so
+       MCP-prefixed names do not get collapsed into ["unknown"] on
+       successful routes (PR #14585 review #1). *)
+    Keeper_tool_alias.record_route_outcome ~tool:stripped ~routed_to:internal ~result:"ok";
+    internal
+  | Route_hit { internal } ->
+    Keeper_tool_alias.record_route_outcome ~tool:name ~routed_to:internal ~result:"ok";
+    internal
+  | Already_internal ->
+    Keeper_tool_alias.record_route_outcome ~tool:name ~routed_to:name ~result:"ok";
+    name
+  | Miss ->
+    Keeper_tool_alias.record_route_outcome ~tool:name ~routed_to:"none" ~result:"miss";
+    name
 ;;
 
 let merge_observed_tool_names
@@ -237,6 +266,7 @@ let tool_progress_class_to_string = function
 ;;
 
 let canonical_tool_name = canonical_name
+let canonical_tool_name_observed = canonical_name_observed
 
 let claim_context_tool_names : string list =
   Tool_name.[ Masc Claim_next; Masc Claim_task; Keeper Task_claim ]

--- a/lib/keeper/keeper_tool_disclosure.mli
+++ b/lib/keeper/keeper_tool_disclosure.mli
@@ -116,8 +116,21 @@ type tool_progress_class =
 
 val tool_progress_class_to_string : tool_progress_class -> string
 
-(** Canonicalize a tool name via [Keeper_tool_alias]. *)
+(** Pure canonicalisation — no telemetry side-effect.
+
+    Used by set-logic call sites (required-tool canonicalisation, surface
+    composition, satisfaction checks) where every invocation should NOT
+    count as an observation event. *)
 val canonical_tool_name : string -> string
+
+(** Observation-emitting canonicalisation.
+
+    Emits exactly one [masc_keeper_tool_call_total] sample with bounded
+    [tool] / [routed_to] / [result] labels. Use only at the keeper turn
+    observation boundary (e.g. canonicalising LLM-reported tool calls in
+    [Keeper_agent_run]). Non-observation call sites should use
+    [canonical_tool_name] to avoid double-counting. *)
+val canonical_tool_name_observed : string -> string
 
 (** Canonical names of claim-context tools (Task_claim, Claim_next,
     Claim_task). *)

--- a/test/test_keeper_tool_alias.ml
+++ b/test/test_keeper_tool_alias.ml
@@ -108,7 +108,12 @@ let test_route_or_miss_records_ok () =
 ;;
 
 let test_route_or_miss_records_miss () =
-  let labels = [ "tool", "Skill"; "routed_to", "none"; "result", "miss" ] in
+  (* Cardinality bound (RFC-0064 PR #14574 review #4): a miss for a
+     hallucinated name like "Skill" is recorded against the
+     [tool="unknown"] / [routed_to="none"] bucket — never against the
+     raw observed string, otherwise each unique hallucination would
+     allocate its own Prometheus time series. *)
+  let labels = [ "tool", "unknown"; "routed_to", "none"; "result", "miss" ] in
   let before =
     Masc_mcp.Prometheus.metric_value_or_zero
       Masc_mcp.Keeper_metrics.metric_keeper_tool_call_total
@@ -123,7 +128,7 @@ let test_route_or_miss_records_miss () =
       ()
   in
   Alcotest.(check (float 0.001))
-    "telemetry counter incremented for miss"
+    "telemetry counter incremented for miss (unknown bucket)"
     (before +. 1.0)
     after
 ;;

--- a/test/test_keeper_tool_alias.ml
+++ b/test/test_keeper_tool_alias.ml
@@ -233,6 +233,58 @@ let test_mcp_prefixed_anthropic_alias_routes () =
     canonical
 ;;
 
+let test_mcp_prefixed_anthropic_alias_telemetry_uses_stripped () =
+  (* Self-review of PR #14585: in canonical_name_observed, the Route_hit
+     branch (LLM-native public name reached via a stripped MCP prefix)
+     must record [tool=stripped] so the label stays within
+     [is_known_public]. Otherwise [safe_tool_label] collapses
+     ["mcp__masc__Bash"] to ["unknown"] on a successful route. *)
+  let labels = [ "tool", "Bash"; "routed_to", "keeper_bash"; "result", "ok" ] in
+  let before =
+    Masc_mcp.Prometheus.metric_value_or_zero
+      Masc_mcp.Keeper_metrics.metric_keeper_tool_call_total
+      ~labels
+      ()
+  in
+  let _ = Disclosure.canonical_tool_name_observed "mcp__masc__Bash" in
+  let after =
+    Masc_mcp.Prometheus.metric_value_or_zero
+      Masc_mcp.Keeper_metrics.metric_keeper_tool_call_total
+      ~labels
+      ()
+  in
+  Alcotest.(check (float 0.001))
+    "MCP-prefixed Anthropic alias records tool=Bash (stripped), not raw prefixed name"
+    (before +. 1.0)
+    after
+;;
+
+let test_canonical_tool_name_pure_does_not_increment_counter () =
+  (* Self-review of PR #14585 review #3: the pure variant must NOT emit
+     telemetry. Otherwise set-logic call sites (required-tool
+     canonicalisation, surface composition) would over-count. *)
+  let labels_ok = [ "tool", "Bash"; "routed_to", "keeper_bash"; "result", "ok" ] in
+  let before =
+    Masc_mcp.Prometheus.metric_value_or_zero
+      Masc_mcp.Keeper_metrics.metric_keeper_tool_call_total
+      ~labels:labels_ok
+      ()
+  in
+  let _ = Disclosure.canonical_tool_name "Bash" in
+  let _ = Disclosure.canonical_tool_name "Bash" in
+  let _ = Disclosure.canonical_tool_name "Bash" in
+  let after =
+    Masc_mcp.Prometheus.metric_value_or_zero
+      Masc_mcp.Keeper_metrics.metric_keeper_tool_call_total
+      ~labels:labels_ok
+      ()
+  in
+  Alcotest.(check (float 0.001))
+    "pure canonical_tool_name does not increment masc_keeper_tool_call_total"
+    before
+    after
+;;
+
 let test_partial_tolerance_still_works () =
   let observed = [ "Skill"; "Bash" ] in
   let canonical = List.map Disclosure.canonical_tool_name observed in
@@ -658,6 +710,14 @@ let () =
             "mcp-prefixed anthropic alias routes"
             `Quick
             test_mcp_prefixed_anthropic_alias_routes
+        ; Alcotest.test_case
+            "mcp-prefixed anthropic alias telemetry uses stripped tool label"
+            `Quick
+            test_mcp_prefixed_anthropic_alias_telemetry_uses_stripped
+        ; Alcotest.test_case
+            "pure canonical_tool_name does not increment counter"
+            `Quick
+            test_canonical_tool_name_pure_does_not_increment_counter
         ; Alcotest.test_case
             "partial tolerance still works"
             `Quick

--- a/test/test_keeper_tool_alias.ml
+++ b/test/test_keeper_tool_alias.ml
@@ -220,6 +220,19 @@ let test_hallucinated_builtin_still_unexpected () =
     unexpected
 ;;
 
+let test_mcp_prefixed_anthropic_alias_routes () =
+  (* Regression guard for PR #14574 review #5: [canonical_name] must
+     route ["mcp__masc__Bash"] the same way as ["Bash"]. Earlier the
+     route lookup used the raw [name] instead of the stripped form,
+     so MCP-prefixed Anthropic Code calls regressed into routing
+     misses. *)
+  let canonical = Disclosure.canonical_tool_name "mcp__masc__Bash" in
+  Alcotest.(check string)
+    "mcp__masc__Bash routes through stripped form to keeper_bash"
+    "keeper_bash"
+    canonical
+;;
+
 let test_partial_tolerance_still_works () =
   let observed = [ "Skill"; "Bash" ] in
   let canonical = List.map Disclosure.canonical_tool_name observed in
@@ -261,7 +274,7 @@ let test_public_input_schema_present () =
          (Printf.sprintf "%s has tailored schema" name)
          true
          (Option.is_some (Alias.public_input_schema name)))
-    [ "Bash"; "Edit"; "Grep"; "Read"; "WebSearch"; "Write" ];
+    [ "Bash"; "Edit"; "Grep"; "Read"; "WebFetch"; "WebSearch"; "Write" ];
   Alcotest.(check bool)
     "unknown public name has no schema"
     true
@@ -641,6 +654,10 @@ let () =
             "hallucinated builtin still unexpected"
             `Quick
             test_hallucinated_builtin_still_unexpected
+        ; Alcotest.test_case
+            "mcp-prefixed anthropic alias routes"
+            `Quick
+            test_mcp_prefixed_anthropic_alias_routes
         ; Alcotest.test_case
             "partial tolerance still works"
             `Quick

--- a/test/test_keeper_tool_alias.ml
+++ b/test/test_keeper_tool_alias.ml
@@ -259,6 +259,47 @@ let test_mcp_prefixed_anthropic_alias_telemetry_uses_stripped () =
     after
 ;;
 
+let test_mcp_prefixed_keeper_internal_routes () =
+  (* PR #14585 review: MCP transports can emit prefixed internal names
+     like [mcp__masc__keeper_pr_create]. canonicalise_outcome must check
+     [is_known_internal stripped], not raw [name], so these are
+     canonicalised to the stripped form instead of falling into [Miss]
+     and being reported as unexpected. *)
+  let canonical = Disclosure.canonical_tool_name "mcp__masc__keeper_bash" in
+  Alcotest.(check string)
+    "mcp__masc__keeper_bash canonicalises to keeper_bash (stripped)"
+    "keeper_bash"
+    canonical
+;;
+
+let test_mcp_prefixed_masc_public_telemetry_preserves_label () =
+  (* PR #14585 review: a successful MCP-mapped route for a name like
+     [mcp__masc__masc_board_post] must record [tool=masc_board_post],
+     not collapse to ["unknown"]. Verifies that
+     [known_internal_names_tbl] is seeded with public MCP counterparts
+     via [Tool_catalog_surfaces.keeper_internal_replacement]. *)
+  let labels =
+    [ "tool", "masc_board_post"; "routed_to", "keeper_board_post"; "result", "ok" ]
+  in
+  let before =
+    Masc_mcp.Prometheus.metric_value_or_zero
+      Masc_mcp.Keeper_metrics.metric_keeper_tool_call_total
+      ~labels
+      ()
+  in
+  let _ = Disclosure.canonical_tool_name_observed "mcp__masc__masc_board_post" in
+  let after =
+    Masc_mcp.Prometheus.metric_value_or_zero
+      Masc_mcp.Keeper_metrics.metric_keeper_tool_call_total
+      ~labels
+      ()
+  in
+  Alcotest.(check (float 0.001))
+    "MCP-prefixed masc_* public name records tool=masc_board_post (not unknown)"
+    (before +. 1.0)
+    after
+;;
+
 let test_canonical_tool_name_pure_does_not_increment_counter () =
   (* Self-review of PR #14585 review #3: the pure variant must NOT emit
      telemetry. Otherwise set-logic call sites (required-tool
@@ -714,6 +755,14 @@ let () =
             "mcp-prefixed anthropic alias telemetry uses stripped tool label"
             `Quick
             test_mcp_prefixed_anthropic_alias_telemetry_uses_stripped
+        ; Alcotest.test_case
+            "mcp-prefixed keeper internal canonicalises to stripped"
+            `Quick
+            test_mcp_prefixed_keeper_internal_routes
+        ; Alcotest.test_case
+            "mcp-prefixed masc public name telemetry preserves label"
+            `Quick
+            test_mcp_prefixed_masc_public_telemetry_preserves_label
         ; Alcotest.test_case
             "pure canonical_tool_name does not increment counter"
             `Quick

--- a/test/test_keeper_tool_exposure.ml
+++ b/test/test_keeper_tool_exposure.ml
@@ -336,7 +336,25 @@ let test_research_preset_has_read_tools () =
 
 let test_last_turn_safe_keeps_discovery_and_web_search () =
   let tools = Keeper_tool_policy.last_turn_safe_tool_names () in
-  let alias_expanded = tools @ Keeper_tool_alias.public_names () in
+  (* PR #14574 review #8: expose a public alias only when its routed
+     internal handler is actually present in [tools]. Appending the full
+     [public_names ()] unconditionally would make the "WebSearch alias"
+     assertion below pass even if [masc_web_search] were removed from
+     [last_turn_safe_tool_names], hiding regressions. Mirrors the
+     gating used in [partition_tool_search_hits]. *)
+  let tools_set =
+    let tbl = Hashtbl.create (List.length tools) in
+    List.iter (fun n -> Hashtbl.replace tbl n ()) tools;
+    tbl
+  in
+  let aliases_with_allowed_route =
+    Keeper_tool_alias.public_names ()
+    |> List.filter (fun pub ->
+      match Keeper_tool_alias.route pub with
+      | Some r -> Hashtbl.mem tools_set r.internal_name
+      | None -> false)
+  in
+  let alias_expanded = tools @ aliases_with_allowed_route in
   check
     bool
     "last turn allows keeper_tool_search"


### PR DESCRIPTION
## Summary

RFC-0064(#14574) 머지 직후 Copilot 리뷰 3개 코멘트 follow-up. 원 PR이 review thread가 열린 채로 squash-merge되어 같은 영역의 fix를 main 대상 follow-up PR로 올립니다.

## Why

#14574에 4개 Copilot review thread가 있었고 그중 3개는 RFC-0064 의도 자체가 실제로 달성되지 못함을 지적하는 valid한 버그/우려였습니다:

| Thread | 위치 | 요지 |
|---|---|---|
| #2 | `keeper_tool_disclosure.ml:44` | `masc_keeper_tool_call_total`가 `route_or_miss`에서만 증가하는데 production 경로는 `canonical_name` via `route()`. 결과적으로 **counter가 production에서 단 한 번도 증가 안 함** (dead metric) |
| #3 | `keeper_agent_run.ml:684` | 주석은 "miss recorded via route_or_miss"라고 적혀있으나 코드는 `canonical_tool_name` 사용 — 주석/코드 mismatch |
| #4 | `keeper_tool_alias.ml:97` | `route_or_miss`가 unknown tool name마다 Prometheus label로 time series 생성. 환각 unbounded → cardinality 폭발 위험 |

(Thread #1, public name 노출 정책은 의도된 동작 — 별도 reply로 #14574에 남김. 본 PR에선 다루지 않음)

## Changes

### `lib/keeper/keeper_tool_alias.{ml,mli}` — cardinality bound

- `is_known_internal : string -> bool` 추가. `known_internal_names_tbl`은 `routing_table` target + `Tool_catalog_surfaces.keeper_internal_tools` 전체로 seed.
- `safe_tool_label` / `safe_routed_to_label` 헬퍼: known_public / known_internal / "none" 외의 값은 `"unknown"`으로 정규화.
- `record_route_outcome`이 두 헬퍼를 통과한 값만 label로 사용 — 환각 raw string이 새 time series를 만들 수 없음.
- `route_or_miss` docstring 갱신: 일반 canonicalisation은 `Keeper_tool_disclosure.canonical_tool_name`을 사용한다는 점 명시.

### `lib/keeper/keeper_tool_disclosure.ml` — counter wiring

`canonical_name`이 3개 입력 surface 각 분기에서 `record_route_outcome` 호출:

| 분기 | `routed_to` | `result` |
|---|---|---|
| MCP-mapped (`mcp__masc__*` strip 후 hit) | internal handler | `"ok"` |
| LLM-native `route()` hit | internal handler | `"ok"` |
| Already-internal (`keeper_*`/`masc_*` 식별) pass-through | name 자체 | `"ok"` |
| 진짜 unknown | `"none"` | `"miss"` |

→ counter가 production에서 매 tool 관찰마다 정확히 한 번 증가.

### `lib/keeper/keeper_agent_run.ml` — 주석 정정

`route_or_miss`를 가리키던 주석을 `canonical_tool_name`(실제 emitter)로 정정. 두 단락이었던 주석을 한 단락으로 통합.

### `test/test_keeper_tool_alias.ml`

`test_route_or_miss_records_miss`가 bound label([`tool="unknown"`; `routed_to="none"`])을 기대하도록 갱신. raw 이름이 label에 등장하지 않음을 회귀 가드로 둠.

## Test plan

- [x] `dune build --root . @check` clean
- [x] `test_keeper_tool_alias`: **30/30** 통과
- [x] `test_keeper_tool_exposure`: **65/65** 통과
- [ ] `test_keeper_tools_oas`: 36/39 (3 pre-existing failures, #14574 PR body도 동일하게 명시 — 본 PR 무관, #10349 keeper identity drift)

## Refs

- RFC-0064 원 PR: #14574 (머지됨, dac3fb5c92)
- 본 PR이 응답하는 review threads:
  - https://github.com/jeong-sik/masc-mcp/pull/14574#discussion_r... (counter wiring)
  - https://github.com/jeong-sik/masc-mcp/pull/14574#discussion_r... (cardinality)
- CLAUDE.md §"Workaround Rejection Bar" #1 (Counter-as-Fix): metric이 alarm이지 fix가 아니라는 원칙 — 이 PR은 alarm이 실제로 울리도록 wiring을 고치는 것

🤖 Generated with [Claude Code](https://claude.com/claude-code)
