### PR TITLE
docs(rfc-0058): correct §9.1 runtime-impact wording (follow-up to #14578)

### DIFF
--- a/docs/rfc/RFC-0058-declarative-cascade-config.md
+++ b/docs/rfc/RFC-0058-declarative-cascade-config.md
@@ -530,9 +530,16 @@ binding/alias path.
 ### Phase 9: `cascade.json` elimination (split into 3 PRs)
 
 The acceptance criterion "*`cascade.json` no longer generated or consumed*"
-unwinds in three steps because ~20 files in `lib/cascade/`,
-`lib/dashboard/`, and `lib/server/` still consume the materialised JSON.
-Doing it as one PR risks breaking runtime callers during the migration.
+unwinds in three steps. The work splits not because there are many
+*readers* (most readers go through `Cascade_config_loader.load_json`,
+which is already in-memory — see Phase 9.1) but because there are two
+remaining *writers* that materialise `config/cascade.json` on disk:
+`lib/dashboard_cascade.ml` (two `ensure_materialized_json` call sites)
+and the standalone `bin/cascade_materialize` CLI. Eliminating those
+writers in the same change that also drops the source-tracked JSON
+would couple a docs/test cleanup (9.1) with two behavioural rewrites
+(9.2) and the type-system shrink that follows (9.3), so each phase
+ships independently.
 
 - **Phase 9.1 — Stop tracking the committed JSON** *(landed in #14578)*:
   drop the committed `config/cascade.json` and the byte-equality test
@@ -551,11 +558,16 @@ Doing it as one PR risks breaking runtime callers during the migration.
     `bin/cascade_materialize` CLI. Both keep working after Phase 9.1 —
     the JSON they emit is now a runtime artefact rather than a tracked
     source.
-  Net effect of Phase 9.1: nothing in the runtime read path changes;
-  the only behavioural delta is that `git status` no longer reports the
-  regenerated JSON because the source-tracked copy is gone (and
-  ignoring it would be premature — Phase 9.3 deletes the write path
-  outright).
+  Net effect of Phase 9.1: nothing in the runtime read path changes.
+  The source-tracked copy is gone, so `git status` no longer shows a
+  tracked diff when the regenerated file drifts from the old committed
+  bytes. The runtime-materialised copy that the dashboard / CLI write
+  *will* keep appearing as an **untracked** file in `git status` until
+  Phase 9.2 stops the disk write and Phase 9.3 removes the write path
+  entirely. Phase 9.1 intentionally does not add `config/cascade.json`
+  to `.gitignore` — silencing the untracked entry would advertise the
+  disk artefact as permanent, which is the opposite of the §9
+  acceptance criterion.
 - **Phase 9.2 — Migrate the remaining disk writers off JSON**: rework
   `lib/dashboard_cascade.ml` and `bin/cascade_materialize` to serve /
   emit the rendered JSON in memory via

--- a/docs/rfc/RFC-0058-declarative-cascade-config.md
+++ b/docs/rfc/RFC-0058-declarative-cascade-config.md
@@ -534,29 +534,42 @@ unwinds in three steps because ~20 files in `lib/cascade/`,
 `lib/dashboard/`, and `lib/server/` still consume the materialised JSON.
 Doing it as one PR risks breaking runtime callers during the migration.
 
-- **Phase 9.1 — Stop tracking the committed JSON** *(this PR)*: drop the
-  committed `config/cascade.json` and the byte-equality test that pinned
-  it to the TOML render, add `.gitignore` so any runtime-materialised
-  copy stays out of source control. Runtime behaviour is unchanged
-  because the loaders that hit disk (`Cascade_config_loader.load_json`
-  and the dashboard's explicit
-  `Cascade_toml_materializer.ensure_materialized_json` call) still
-  recreate `config/cascade.json` on demand; in-memory consumers that go
-  through `render_toml_to_json_string` already never opened the JSON
-  file, so this PR neither helps nor hurts them. Phase 9.2 migrates the
-  remaining on-disk readers onto the in-memory path.
-- **Phase 9.2 — Migrate consumers to in-memory render**: replace
-  `Cascade_config_loader.load_json (json_path)` plus
-  `ensure_materialized_json` call sites with
-  `Cascade_toml_materializer.render_toml_to_json_string` followed by
-  `Yojson` parsing — no disk write. Each migrated module is one focused
-  PR. Disk JSON keeps working as a fallback for the few remaining
-  callers.
+- **Phase 9.1 — Stop tracking the committed JSON** *(landed in #14578)*:
+  drop the committed `config/cascade.json` and the byte-equality test
+  that pinned it to the TOML render. Runtime behaviour is unchanged
+  because the disk JSON has only two writers, and consumers that read
+  the cascade do not depend on its presence on disk:
+  - `Cascade_config_loader.load_json` (lib/cascade/cascade_config_loader.ml:96)
+    branches on `source_info.kind`. Under the current TOML SSOT the
+    branch is always `Toml`, which routes through
+    `load_toml_in_memory` → `Cascade_toml_materializer.render_toml_to_json_string`
+    and never opens the JSON sibling. The `Json` branch (which would
+    `read_json_file`) is unreachable until someone removes the TOML.
+  - The two writers that *do* materialise `config/cascade.json` on disk
+    are `lib/dashboard_cascade.ml` (two `ensure_materialized_json` call
+    sites, kept so the dashboard can serve the rendered file) and the
+    `bin/cascade_materialize` CLI. Both keep working after Phase 9.1 —
+    the JSON they emit is now a runtime artefact rather than a tracked
+    source.
+  Net effect of Phase 9.1: nothing in the runtime read path changes;
+  the only behavioural delta is that `git status` no longer reports the
+  regenerated JSON because the source-tracked copy is gone (and
+  ignoring it would be premature — Phase 9.3 deletes the write path
+  outright).
+- **Phase 9.2 — Migrate the remaining disk writers off JSON**: rework
+  `lib/dashboard_cascade.ml` and `bin/cascade_materialize` to serve /
+  emit the rendered JSON in memory via
+  `Cascade_toml_materializer.render_toml_to_json_string`. After this
+  phase no production code calls `ensure_materialized_json`. (The
+  earlier framing of "migrate ~20 consumers off `load_json`" was based
+  on the incorrect assumption that `load_json` still hit disk; it does
+  not, so this phase shrinks to the two real writers.)
 - **Phase 9.3 — Delete the JSON path entirely**: remove
   `ensure_materialized_json`, drop the `Json` variant from
-  `Cascade_toml_materializer.source_kind`, retire the disk
-  `cascade.json` write, and audit-grep `lib/` for any residual
-  `cascade.json` references.
+  `Cascade_toml_materializer.source_kind` (now unreachable), retire the
+  `read_json_file` branch in `Cascade_config_loader.load_json`, and
+  audit-grep `lib/` + `bin/` for any residual `cascade.json`
+  references.
 
 ## 9. Acceptance Criteria
 


### PR DESCRIPTION
## Summary

Follow-up to merged PR #14578. Corrects a documentation error in RFC-0058 §9.1
that survived two passes (original PR body + review-response edit).

## What was wrong

#14578 landed with §9.1 prose claiming that
`Cascade_config_loader.load_json` is one of the loaders that "hits disk"
alongside the dashboard's explicit `ensure_materialized_json` call.
That implies most cascade reads still depend on the JSON sibling being
materialised. It is not true.

## What is actually true

Verified against `origin/main` today:

- `Cascade_config_loader.load_json` (`lib/cascade/cascade_config_loader.ml:96`)
  dispatches on `source_info.kind`. Under the current TOML SSOT the live
  branch is always `Toml` → `load_toml_in_memory` →
  `Cascade_toml_materializer.render_toml_to_json_string`. **No JSON file
  is opened.** The `Json` branch (which would call `read_json_file`) is
  unreachable until someone deletes `cascade.toml`.
- The only callers that actually write `config/cascade.json` are:
  - `lib/dashboard_cascade.ml:337` and `:416` — dashboard explicit
    `ensure_materialized_json` calls so the dashboard can serve the
    rendered file.
  - `bin/cascade_materialize.ml:18` — standalone CLI for operators.

Original Copilot review on #14578 flagged exactly this
([thread](https://github.com/jeong-sik/masc-mcp/pull/14578#discussion_r…));
the review-response edit (commit `000527aa35`) acknowledged the
symptom but introduced a different incorrect claim — that `load_json`
is a disk-touching caller — instead of fixing the root issue.

## What this PR changes

`docs/rfc/RFC-0058-declarative-cascade-config.md` §9 only. No code.

- §9.1: replaces the inaccurate "loaders that hit disk include
  `load_json`" framing with the actual call graph (live `Toml` branch
  is in-memory; only dashboard + `cascade_materialize` write the JSON).
- §9.2: shrinks the migration scope from "~20 consumers in
  `lib/cascade/`, `lib/dashboard/`, `lib/server/`" to "the two real
  writers" (dashboard + `cascade_materialize`). The earlier "~20"
  estimate was inflated by the same wrong assumption that `load_json`
  hits disk.
- §9.3: explicit "drop the `read_json_file` branch" added so the dead
  `Json` source-kind path is removed alongside `ensure_materialized_json`.

## Test plan

- [ ] No code change — no build/test impact.
- [ ] §9 reads truthfully against `git grep -n 'ensure_materialized_json\|read_json_file' lib/ bin/`.

## Related

- Original PR: #14578 (merged)
- Original Copilot thread that was correct: thread 3 on test_cascade_config_validity.ml RFC section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)