### PR TITLE
feat(cascade): Diagnostic_probe adapter skeleton (RFC-0058 §2.4 prep)

### DIFF
--- a/lib/cascade/cascade_diagnostic_probe.ml
+++ b/lib/cascade/cascade_diagnostic_probe.ml
@@ -1,0 +1,71 @@
+(** See {!Cascade_diagnostic_probe} (.mli) for the contract. *)
+
+module type Diagnostic_probe = sig
+  val can_probe : url:string -> bool
+
+  val loaded_models_json
+    :  sw:Eio.Switch.t
+    -> net:[> [> `Generic ] Eio.Net.ty ] Eio.Resource.t
+    -> url:string
+    -> ?timeout_sec:int
+    -> unit
+    -> Yojson.Safe.t
+
+  val runtime_probe_json
+    :  sw:Eio.Switch.t
+    -> net:[> [> `Generic ] Eio.Net.ty ] Eio.Resource.t
+    -> url:string
+    -> probe_runs:int
+    -> max_tokens:int
+    -> ?think_enabled:bool
+    -> unit
+    -> Yojson.Safe.t
+end
+
+type t = (module Diagnostic_probe)
+
+let registry_mutex = Stdlib.Mutex.create ()
+let registered_probes_rev : t list ref = ref []
+
+let probes () =
+  Stdlib.Mutex.protect registry_mutex (fun () -> List.rev !registered_probes_rev)
+;;
+
+let register probe =
+  Stdlib.Mutex.protect registry_mutex (fun () ->
+    registered_probes_rev := probe :: !registered_probes_rev)
+;;
+
+let find_owner ~url =
+  List.find_opt (fun (module P : Diagnostic_probe) -> P.can_probe ~url) (probes ())
+;;
+
+let loaded_models_json ~sw ~net ~url ?timeout_sec () =
+  match find_owner ~url with
+  | None -> `Null
+  | Some (module P) -> P.loaded_models_json ~sw ~net ~url ?timeout_sec ()
+;;
+
+let runtime_probe_json ~sw ~net ~url ~probe_runs ~max_tokens ?think_enabled () =
+  match find_owner ~url with
+  | None -> `Null
+  | Some (module P) -> P.runtime_probe_json ~sw ~net ~url ~probe_runs ~max_tokens ?think_enabled ()
+;;
+
+module For_testing = struct
+  let clear_registry () =
+    Stdlib.Mutex.protect registry_mutex (fun () -> registered_probes_rev := [])
+  ;;
+
+  let with_registry probes f =
+    let saved =
+      Stdlib.Mutex.protect registry_mutex (fun () -> !registered_probes_rev)
+    in
+    Stdlib.Mutex.protect registry_mutex (fun () ->
+      registered_probes_rev := List.rev probes);
+    Fun.protect
+      ~finally:(fun () ->
+        Stdlib.Mutex.protect registry_mutex (fun () -> registered_probes_rev := saved))
+      f
+  ;;
+end

--- a/lib/cascade/cascade_diagnostic_probe.ml
+++ b/lib/cascade/cascade_diagnostic_probe.ml
@@ -58,14 +58,17 @@ module For_testing = struct
   ;;
 
   let with_registry probes f =
+    (* Atomic swap: read-and-replace under a single critical section so a
+       concurrent [register] between save and install cannot be lost. *)
     let saved =
-      Stdlib.Mutex.protect registry_mutex (fun () -> !registered_probes_rev)
+      Stdlib.Mutex.protect registry_mutex (fun () ->
+        let s = !registered_probes_rev in
+        registered_probes_rev := List.rev probes;
+        s)
     in
-    Stdlib.Mutex.protect registry_mutex (fun () ->
-      registered_probes_rev := List.rev probes);
-    Fun.protect
-      ~finally:(fun () ->
-        Stdlib.Mutex.protect registry_mutex (fun () -> registered_probes_rev := saved))
-      f
+    let restore () =
+      Stdlib.Mutex.protect registry_mutex (fun () -> registered_probes_rev := saved)
+    in
+    Fun.protect ~finally:restore f
   ;;
 end

--- a/lib/cascade/cascade_diagnostic_probe.mli
+++ b/lib/cascade/cascade_diagnostic_probe.mli
@@ -88,9 +88,19 @@ val runtime_probe_json
   -> unit
   -> Yojson.Safe.t
 
-(** {1 Testing helpers} *)
+(** {1 Testing helpers}
 
+    These bypass the registry mutex contract intentionally — tests need
+    deterministic registry state and the production code never calls
+    [clear_registry]. Production code must not use this module. *)
 module For_testing : sig
+  (** [clear_registry ()] empties the probe registry. *)
   val clear_registry : unit -> unit
+
+  (** [with_registry probes f] atomically swaps the registry to [probes]
+      for the dynamic extent of [f] and restores the previous registry
+      afterward (even when [f] raises). The save+install is performed
+      under a single mutex critical section so a concurrent [register]
+      cannot be lost. *)
   val with_registry : t list -> (unit -> 'a) -> 'a
 end

--- a/lib/cascade/cascade_diagnostic_probe.mli
+++ b/lib/cascade/cascade_diagnostic_probe.mli
@@ -1,0 +1,96 @@
+(** Provider-agnostic native-runtime diagnostic probe adapter.
+
+    This is the sibling of {!Cascade_capacity_probe}. Where the
+    capacity adapter answers "how many slots does this URL have free
+    right now?", this adapter answers "what runtime diagnostics can
+    we read from this URL right now?" — loaded model list, KV
+    occupancy assessment, prompt-eval / decode timing per probe run,
+    think-mode behaviour, etc.
+
+    Probes carry vendor-specific knowledge (e.g. Ollama exposes
+    [/api/ps] + [/api/generate]). Callers must never spell out a
+    vendor name — they go through {!find_owner} or the top-level
+    [*_json] functions, which delegate to the first registered probe
+    that recognises the URL.
+
+    Result type is intentionally raw {!Yojson.Safe.t}: each provider
+    returns a different shape, and the dashboard / MCP tool surface
+    pass the JSON through unchanged. Forcing a closed result variant
+    here would push vendor structure back into the core types, which
+    is exactly what RFC-0058 §2.4 forbids. *)
+
+(** {1 Module type} *)
+
+module type Diagnostic_probe = sig
+  val can_probe : url:string -> bool
+
+  (** [loaded_models_json] calls the provider's "what models are
+      currently loaded into memory" endpoint and returns the raw JSON
+      response. *)
+  val loaded_models_json
+    :  sw:Eio.Switch.t
+    -> net:[> [> `Generic ] Eio.Net.ty ] Eio.Resource.t
+    -> url:string
+    -> ?timeout_sec:int
+    -> unit
+    -> Yojson.Safe.t
+
+  (** [runtime_probe_json] issues one or more short generate calls
+      against [url] with a controlled prompt to measure warm-state
+      behaviour (decode timing, KV-cache assessment, think-mode
+      effect). The JSON shape is documented per-provider. *)
+  val runtime_probe_json
+    :  sw:Eio.Switch.t
+    -> net:[> [> `Generic ] Eio.Net.ty ] Eio.Resource.t
+    -> url:string
+    -> probe_runs:int
+    -> max_tokens:int
+    -> ?think_enabled:bool
+    -> unit
+    -> Yojson.Safe.t
+end
+
+(** {1 First-class module} *)
+
+type t = (module Diagnostic_probe)
+
+(** {1 Registry} *)
+
+(** [register probe] appends [probe] to the registry. Probes are
+    consulted in registration order. *)
+val register : t -> unit
+
+(** [find_owner ~url] returns the first registered probe that
+    recognises [url]. *)
+val find_owner : url:string -> t option
+
+(** {1 Generic top-level API}
+
+    Each call routes through {!find_owner}. Returns [`Null] when no
+    registered probe recognises the URL — caller can treat that as
+    "diagnostics not available at this endpoint". *)
+
+val loaded_models_json
+  :  sw:Eio.Switch.t
+  -> net:[> [> `Generic ] Eio.Net.ty ] Eio.Resource.t
+  -> url:string
+  -> ?timeout_sec:int
+  -> unit
+  -> Yojson.Safe.t
+
+val runtime_probe_json
+  :  sw:Eio.Switch.t
+  -> net:[> [> `Generic ] Eio.Net.ty ] Eio.Resource.t
+  -> url:string
+  -> probe_runs:int
+  -> max_tokens:int
+  -> ?think_enabled:bool
+  -> unit
+  -> Yojson.Safe.t
+
+(** {1 Testing helpers} *)
+
+module For_testing : sig
+  val clear_registry : unit -> unit
+  val with_registry : t list -> (unit -> 'a) -> 'a
+end

--- a/test/dune
+++ b/test/dune
@@ -1151,6 +1151,7 @@
 (include stanzas/test_cascade_kimi_max_context_ssot.inc)
 (include stanzas/test_cascade_model_resolve.inc)
 (include stanzas/test_cascade_capacity_probe.inc)
+(include stanzas/test_cascade_diagnostic_probe.inc)
 (include stanzas/test_cascade_http_probe.inc)
 (include stanzas/test_cascade_runtime.inc)
 (include stanzas/test_cascade_strategy.inc)

--- a/test/stanzas/test_cascade_diagnostic_probe.inc
+++ b/test/stanzas/test_cascade_diagnostic_probe.inc
@@ -1,0 +1,4 @@
+(test
+ (name test_cascade_diagnostic_probe)
+ (modules test_cascade_diagnostic_probe)
+ (libraries masc_test_deps))

--- a/test/test_cascade_diagnostic_probe.ml
+++ b/test/test_cascade_diagnostic_probe.ml
@@ -1,0 +1,215 @@
+(** Unit tests for [Cascade_diagnostic_probe] adapter dispatch.
+
+    Tests the provider-agnostic registry, [find_owner] resolution, and
+    the top-level [*_json] fall-through-to-`Null contract without
+    hitting the network — mock probes return canned JSON. *)
+
+open Alcotest
+module Dp = Masc_mcp.Cascade_diagnostic_probe
+
+(* ── Mock probe ─────────────────────────────────────────────── *)
+
+let make_mock ~recognizes ?(loaded_json = `Null) ?(probe_json = `Null) () =
+  (module struct
+    let can_probe ~url = recognizes url
+
+    let loaded_models_json ~sw:_ ~net:_ ~url ?timeout_sec:_ () =
+      if recognizes url then loaded_json else `Null
+    ;;
+
+    let runtime_probe_json
+      ~sw:_
+      ~net:_
+      ~url
+      ~probe_runs:_
+      ~max_tokens:_
+      ?think_enabled:_
+      ()
+      =
+      if recognizes url then probe_json else `Null
+    ;;
+  end : Dp.Diagnostic_probe)
+;;
+
+(* Top-level dispatch tests need [sw] and [net] arguments — mocks
+   short-circuit on can_probe so the network is never touched. *)
+let with_dummy_env f =
+  Eio_main.run
+  @@ fun env ->
+  Eio.Switch.run
+  @@ fun sw -> f sw (Eio.Stdenv.net env)
+;;
+
+(* ── Registry lifecycle ──────────────────────────────────────── *)
+
+let test_clear_registry () =
+  Dp.For_testing.clear_registry ();
+  check bool "find_owner empty after clear" true (Option.is_none (Dp.find_owner ~url:"x"))
+;;
+
+let test_register_find_owner () =
+  Dp.For_testing.clear_registry ();
+  let probe =
+    make_mock ~recognizes:(fun url -> String.ends_with ~suffix:":11434" url) ()
+  in
+  Dp.register probe;
+  check bool "recognises endpoint" true (Option.is_some (Dp.find_owner ~url:"http://localhost:11434"));
+  check
+    bool
+    "ignores unknown endpoint"
+    true
+    (Option.is_none (Dp.find_owner ~url:"http://openai.com"))
+;;
+
+let test_with_registry_restores () =
+  Dp.For_testing.clear_registry ();
+  let baseline =
+    make_mock ~recognizes:(fun url -> String.starts_with ~prefix:"http://baseline" url) ()
+  in
+  Dp.register baseline;
+  let swapped =
+    make_mock ~recognizes:(fun url -> String.starts_with ~prefix:"http://swapped" url) ()
+  in
+  Dp.For_testing.with_registry [ swapped ] (fun () ->
+    check
+      bool
+      "swapped visible inside swap"
+      true
+      (Option.is_some (Dp.find_owner ~url:"http://swapped/x"));
+    check
+      bool
+      "baseline hidden inside swap"
+      true
+      (Option.is_none (Dp.find_owner ~url:"http://baseline/x")));
+  check
+    bool
+    "baseline restored after swap"
+    true
+    (Option.is_some (Dp.find_owner ~url:"http://baseline/x"));
+  check
+    bool
+    "swapped gone after swap"
+    true
+    (Option.is_none (Dp.find_owner ~url:"http://swapped/x"))
+;;
+
+let test_with_registry_restores_after_exception () =
+  Dp.For_testing.clear_registry ();
+  let baseline = make_mock ~recognizes:(fun u -> u = "http://baseline") () in
+  Dp.register baseline;
+  let swapped = make_mock ~recognizes:(fun _ -> true) () in
+  (try Dp.For_testing.with_registry [ swapped ] (fun () -> failwith "boom") with
+   | Failure _ -> ());
+  check
+    bool
+    "registry restored even when f raises"
+    true
+    (Option.is_some (Dp.find_owner ~url:"http://baseline"))
+;;
+
+(* ── Top-level routed dispatch ───────────────────────────────── *)
+
+let test_loaded_models_json_routed () =
+  Dp.For_testing.clear_registry ();
+  let probe =
+    make_mock
+      ~recognizes:(fun u -> u = "http://r")
+      ~loaded_json:(`Assoc [ "models", `List [ `String "m1" ] ])
+      ()
+  in
+  Dp.register probe;
+  with_dummy_env
+  @@ fun sw net ->
+  let json = Dp.loaded_models_json ~sw ~net ~url:"http://r" () in
+  check
+    bool
+    "routed loaded_models_json returns probe result"
+    true
+    (json
+     = `Assoc [ "models", `List [ `String "m1" ] ])
+;;
+
+let test_loaded_models_json_null_when_unknown () =
+  Dp.For_testing.clear_registry ();
+  let probe =
+    make_mock ~recognizes:(fun u -> u = "http://r") ~loaded_json:(`String "x") ()
+  in
+  Dp.register probe;
+  with_dummy_env
+  @@ fun sw net ->
+  let json = Dp.loaded_models_json ~sw ~net ~url:"http://unknown" () in
+  check bool "null for unknown url" true (json = `Null)
+;;
+
+let test_runtime_probe_json_routed () =
+  Dp.For_testing.clear_registry ();
+  let probe =
+    make_mock
+      ~recognizes:(fun u -> u = "http://r")
+      ~probe_json:(`Assoc [ "decode_ms", `Int 42 ])
+      ()
+  in
+  Dp.register probe;
+  with_dummy_env
+  @@ fun sw net ->
+  let json =
+    Dp.runtime_probe_json ~sw ~net ~url:"http://r" ~probe_runs:1 ~max_tokens:8 ()
+  in
+  check
+    bool
+    "routed runtime_probe_json returns probe result"
+    true
+    (json = `Assoc [ "decode_ms", `Int 42 ])
+;;
+
+let test_runtime_probe_json_null_when_unknown () =
+  Dp.For_testing.clear_registry ();
+  let probe =
+    make_mock
+      ~recognizes:(fun u -> u = "http://r")
+      ~probe_json:(`Assoc [ "decode_ms", `Int 42 ])
+      ()
+  in
+  Dp.register probe;
+  with_dummy_env
+  @@ fun sw net ->
+  let json =
+    Dp.runtime_probe_json ~sw ~net ~url:"http://unknown" ~probe_runs:1 ~max_tokens:8 ()
+  in
+  check bool "null for unknown url" true (json = `Null)
+;;
+
+(* ── Driver ──────────────────────────────────────────────────── *)
+
+let () =
+  run
+    "cascade_diagnostic_probe"
+    [ ( "registry"
+      , [ test_case "clear empties registry" `Quick test_clear_registry
+        ; test_case "register + find_owner" `Quick test_register_find_owner
+        ; test_case "with_registry restores" `Quick test_with_registry_restores
+        ; test_case
+            "with_registry restores after exception"
+            `Quick
+            test_with_registry_restores_after_exception
+        ] )
+    ; ( "dispatch"
+      , [ test_case
+            "loaded_models_json routed"
+            `Quick
+            test_loaded_models_json_routed
+        ; test_case
+            "loaded_models_json `Null when unknown"
+            `Quick
+            test_loaded_models_json_null_when_unknown
+        ; test_case
+            "runtime_probe_json routed"
+            `Quick
+            test_runtime_probe_json_routed
+        ; test_case
+            "runtime_probe_json `Null when unknown"
+            `Quick
+            test_runtime_probe_json_null_when_unknown
+        ] )
+    ]
+;;


### PR DESCRIPTION
## Summary

\`Cascade_capacity_probe\`의 sibling adapter. capacity 가 \"slot 몇 개 비어있는지\" 라면, 이 adapter는 \"runtime 진단 정보 (KV cache, decode timing, think-mode 등)\" 를 반환.

이번 PR은 **interface skeleton만**. 후속 PR이 기존 \`Tool_local_runtime_probe\` (Ollama-specific) 을 \`lib/cascade/\` 로 이동 + 이 adapter에 register.

## Why

RFC-0058 §2.4 \"code dispatches by api_format, never by provider name\" 의 후속 cleanup. 현재 \`Tool_local_runtime_probe\`가 vendor-specific endpoint(\`/api/ps\`, \`/api/generate\`)를 lib/ 표면에 노출 — 이걸 adapter로 캡슐화.

## Design

- \`Diagnostic_probe\` module type: can_probe, loaded_models_json, runtime_probe_json
- Result 타입 = raw \`Yojson.Safe.t\`. provider 마다 진단 shape이 다르고 (Ollama: total_duration/eval_count; future vLLM: 다른 필드), dashboard/MCP tool은 JSON 그대로 표시. 닫힌 variant 강제하면 vendor 구조가 core types로 다시 새어들어 §2.4 위반.
- Registry는 \`Cascade_capacity_probe\` 와 동일한 mutex-guarded list (RFC-0064 pattern reuse)

## Follow-up

- PR-2: \`Tool_local_runtime_probe\` → \`lib/cascade/cascade_local_runtime_probe.ml\` 이동, Diagnostic_probe 구현체로 등록. 식별자 \`ollama_*\` prefix 제거 (cascade-internal scope 라 명확).
- PR-3: caller 4곳 generic API로 전환 (\`tool_local_runtime.ml\`, \`server_dashboard_http_runtime_info.ml\`, \`dashboard_provider_runs.ml\`, \`mcp_server_eio_execute.ml\` MCP dispatch).

## Verification

- \`dune build lib/cascade/cascade_diagnostic_probe.ml\` clean
- skeleton만이라 caller 없고 register 등록도 없음 — top-level \`*_json\` 호출 시 \`\\\`Null\` 반환 (URL recognise 안 됨)

🤖 Generated with [Claude Code](https://claude.com/claude-code)