### PR TITLE
test(cascade): tighten removed-helpers comment (follow-up to #14583)

### DIFF
--- a/test/test_cascade_toml_materialization.ml
+++ b/test/test_cascade_toml_materialization.ml
@@ -76,15 +76,17 @@ let init_config_root config_dir =
   mkdir_p (Filename.concat config_dir "personas")
 
 (* Removed alongside the JSON-match invariant tests (RFC-0058 §9):
-   - [repo_toml_path] / [repo_json_path] helpers
+   - [repo_toml_path] / [repo_json_path] env-var helpers
    - [render_or_fail], [model_names_for_profile],
      [model_entry_for_profile], [supports_tool_choice_for_profile]
-   These keyed off the pre-RFC-0058 cascade.json shape
-   ([<name>_models] arrays) and the [MASC_CASCADE_JSON_PATH] env var
-   that the now-deleted byte-equality stanza injected. Note that
-   [MASC_CASCADE_TOML_PATH] still exists project-wide (e.g.
-   [test_cascade_config_validity.inc] uses it) — only the JSON-keyed
-   helpers and the JSON env var are gone from this suite. *)
+   These keyed off the pre-RFC-0058 flat cascade.json shape
+   ([<name>_models] arrays at the top level), which PR #14550 retired
+   when cascade.toml moved to the 5-layer declarative schema. This
+   suite no longer touches either cascade env var; for context,
+   [MASC_CASCADE_TOML_PATH] is still in use elsewhere
+   ([test_cascade_config_validity.inc] injects it as of #14578) and
+   [MASC_CASCADE_JSON_PATH] is no longer injected by any dune stanza
+   in the repo. *)
 
 let minimal_toml =
   {|


### PR DESCRIPTION
## Summary

Comment-only fix-up to PR #14583 (merged). Copilot flagged the removed-helpers comment as imprecise on three counts; this PR rewrites it.

## What was wrong on main (after #14583 squash)

Lines 78-87 of `test/test_cascade_toml_materialization.ml` said:

> These keyed off the pre-RFC-0058 cascade.json shape (`[<name>_models]` arrays) and the `MASC_CASCADE_JSON_PATH` env var **that the now-deleted byte-equality stanza injected**.

Three problems:

1. **"now-deleted" is wrong** — the stanza in `test/stanzas/test_cascade_config_validity.inc` was rewritten in #14578, not deleted. The byte-equality *test* was deleted; the stanza persists.
2. **Implies *this* file had a stanza injecting `MASC_CASCADE_JSON_PATH`** — it never did. This file's helpers `failwith`'d when the env var was unset; they didn't rely on dune injection.
3. **Implies the JSON env var lived in `test_cascade_toml_materialization.ml`'s stanza** — the only repo-wide injection ever lived in `test_cascade_config_validity.inc`, and that was changed to `MASC_CASCADE_TOML_PATH` in #14578.

Verified `grep -RIn MASC_CASCADE_JSON_PATH --include='*.inc' --include='dune'` returns nothing in the repo as of `origin/main` (`fd6c9951d1`).

## What this PR changes

`test/test_cascade_toml_materialization.ml` lines 78-87 only. No code.

Rewords the block to:
- Attribute the schema retirement to PR #14550 (declarative 5-layer schema), which is the actual cause.
- State that this suite no longer touches either cascade env var.
- Document precisely where each env var lives now: `MASC_CASCADE_TOML_PATH` is injected by `test_cascade_config_validity.inc` (as of #14578); `MASC_CASCADE_JSON_PATH` is not injected by any dune stanza in the repo.

## Test plan

- [ ] No code change. `grep -RIn MASC_CASCADE_JSON_PATH --include='*.inc' --include='dune' --include='*.yml'` returns no stanza-side injection.

## Related

- Original PR: #14583 (merged) — drop JSON↔TOML byte-equality invariant.
- Copilot review thread that prompted this: https://github.com/jeong-sik/masc-mcp/pull/14583#discussion_r…

🤖 Generated with [Claude Code](https://claude.com/claude-code)