### PR TITLE
fix(test): align dashboard_cascade tests with Phase 9.2 in-memory render (#14581 follow-up)

### DIFF
--- a/test/test_dashboard_cascade.ml
+++ b/test/test_dashboard_cascade.ml
@@ -399,7 +399,11 @@ models = ["ollama:qwen3.5:35b-a3b-nvfp4"]
         (contains_substring
            Yojson.Safe.Util.(j |> member "raw_json" |> to_string)
            "big_three_models");
-      check bool "runtime json materialized on read" true
+      (* RFC-0058 §9 Phase 9.2 (#14581): raw_config_json now renders
+         the JSON in memory and does NOT write the cascade.json sibling.
+         The runtime JSON is observable only through the [raw_json]
+         field above; the disk file must stay absent. *)
+      check bool "runtime json not materialized on disk (Phase 9.2)" false
         (Sys.file_exists json_path))
 
 let test_save_raw_config_json_rejects_invalid_json () =
@@ -492,8 +496,17 @@ models = ["ollama:qwen3.5:35b-a3b-nvfp4"]
           check string "toml source persisted verbatim"
             next_toml
             (read_file toml_path);
-          check bool "materialized json refreshed" true
-            (contains_substring (read_file json_path) "beta_editor_models"))
+          (* RFC-0058 §9 Phase 9.2 (#14581): save_raw_config_json no
+             longer materialises the cascade.json sibling. The
+             dashboard exposes the refreshed render through the
+             [raw_json] field of [raw_config_json ()] (in-memory). *)
+          let after = Masc_mcp.Dashboard_cascade.raw_config_json () in
+          check bool "refreshed json visible in-memory via raw_config_json" true
+            (contains_substring
+               Yojson.Safe.Util.(after |> member "raw_json" |> to_string)
+               "beta_editor_models");
+          check bool "cascade.json sibling stays absent (Phase 9.2)" false
+            (Sys.file_exists json_path))
 
 (* ── health_json ───────────────────────────────────── *)
 


### PR DESCRIPTION
## Why this exists

PR #14581 (RFC-0058 §9 Phase 9.2) removed `ensure_materialized_json` from `Dashboard_cascade.raw_config_json` and `save_raw_config_json`, so the `cascade.json` sibling is no longer materialised on disk for TOML sources. Two tests in `test/test_dashboard_cascade.ml` still asserted the *old* behaviour and break on the current `origin/main`:

| Test | Asserted | Now |
|------|----------|-----|
| `test_raw_config_toml_source_exposes_editable_source_and_preview:402` | `Sys.file_exists json_path = true` | File is intentionally absent; render is in-memory via `raw_json` field |
| `test_save_raw_config_json_persists_toml_source_and_materializes_json:494` | `read_file json_path` contains new profile | `read_file` throws `Sys_error` (no file); refreshed render is in `raw_config_json ()` `raw_json` field |

CI for #14581 (`Build and Test`) was CANCELLED at squash-merge time and never reported the failure, so it landed on main unnoticed. Confirmed locally on rebased-to-current-main:
```
[FAIL] raw_config_json 2 ... materialized on read (before fix)
[FAIL] raw_config_json 8 ... materialized json refreshed (before fix)
```

## What this PR changes

`test/test_dashboard_cascade.ml` only. 16+/3-.

- `raw_config_json 2`: flips the assertion to "runtime json **not** materialized on disk (Phase 9.2)" + comment pointing at the invariant. The pre-existing "generated runtime json visible" assertion against the `raw_json` field stays — that's now the only observation path.
- `raw_config_json 8`: replaces the disk read with a fresh `raw_config_json ()` call and checks `raw_json` contains `beta_editor_models`. Asserts the sibling stays absent.

## Verified

Locally with `dune runtest test/test_dashboard_cascade.exe` after rebase onto current main:
```
[OK] raw_config_json 2 toml source exposes editable...
[OK] raw_config_json 8 toml source save persists + ...
```

## Out of scope (separate main blockers, NOT fixed here)

Surfaced while running the suite — pre-existing on origin/main, unrelated to RFC-0058 §9:

- `keeper_profile_json 0/1/3` — canonical cascade name resolution returns `"default"` instead of `"big_three"` / `"keeper_unified"`.
- `recommendations 3` — stuck fingerprint suggests instead of expected output.

Will file separately so the Phase 9.2 fix doesn't get blocked on unrelated work.

## Test plan

- [ ] `dune runtest test/test_dashboard_cascade.exe` — `raw_config_json` group all green (modulo the 4 unrelated failures above).
- [ ] No production code touched.

## Related

- PR #14581 (merged): RFC-0058 §9 Phase 9.2 dashboard in-memory render.
- PR #14586 (merged): RFC-0058 §9.1 wording fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)