### PR TITLE
chore(test): register orphan bg_task_cleanup tests + fix 3 tautological metric-registered checks

### DIFF
--- a/test/dune
+++ b/test/dune
@@ -233,6 +233,7 @@
         test_keeper_state_machine_correspondence
         test_keeper_lifecycle_hooks
         test_keeper_subprocess_registry
+        test_keeper_bg_task_cleanup
         test_keeper_social_model_magentic_ledger_fsm
         test_keeper_overflow_recovery
         test_telemetry_unified
@@ -478,6 +479,7 @@
           test_keeper_sub_fsm_guards
           test_keeper_cascade_tla_mirror
           test_keeper_subprocess_registry
+          test_keeper_bg_task_cleanup
           test_keeper_social_model_magentic_ledger_fsm
           test_keeper_overflow_recovery
           test_telemetry_unified

--- a/test/test_governance_response_model_empty_9880.ml
+++ b/test/test_governance_response_model_empty_9880.ml
@@ -10,11 +10,12 @@
 
 let () =
   let dir =
-    Filename.concat (Filename.get_temp_dir_name ())
-      (Printf.sprintf "masc-test-governance-empty-model-9880-%06x"
-         (Random.bits ()))
+    Filename.concat
+      (Filename.get_temp_dir_name ())
+      (Printf.sprintf "masc-test-governance-empty-model-9880-%06x" (Random.bits ()))
   in
   Unix.putenv "MASC_BASE_PATH" dir
+;;
 
 module Prom = Masc_mcp.Prometheus
 module Judge = Masc_mcp.Dashboard_governance_judge
@@ -22,29 +23,32 @@ module Judge = Masc_mcp.Dashboard_governance_judge
 let metric_name = "masc_governance_response_model_empty_total"
 
 let count_for ~source =
-  Prom.metric_value_or_zero metric_name
-    ~labels:[ ("source", source) ]
-    ()
+  Prom.metric_value_or_zero metric_name ~labels:[ "source", source ] ()
+;;
 
-(* Metric is registered at module load via the
-   [let () = Prometheus.register_counter ...] block in
-   [dashboard_governance_judge.ml]. *)
+(* Metric is registered at module load via [Prometheus.register_counter
+   ~labels:[]] in [dashboard_governance_judge.ml]. [get_metric_value
+   ~labels:[] ()] returns [Some 0.0] when registration ran, [None]
+   otherwise.
+
+   [metric_total] cannot distinguish "not registered" from "registered
+   but no observations yet" — both return [0.0]. *)
 let test_metric_registered () =
-  let _ = Prom.metric_total metric_name in
-  Alcotest.(check pass) "metric registered" () ()
+  let registered = Prom.get_metric_value metric_name () in
+  Alcotest.(check bool) "metric registered" true (Option.is_some registered)
+;;
 
 (* Direct increment using the documented label shape.  Mirrors
    the call in [compute_judgments] when [response.model] is
    empty and telemetry's [canonical_model_id] resolves it. *)
 let test_telemetry_resolved_branch () =
   let before = count_for ~source:"telemetry_resolved" in
-  Prom.inc_counter metric_name
-    ~labels:[ ("source", "telemetry_resolved") ]
-    ();
+  Prom.inc_counter metric_name ~labels:[ "source", "telemetry_resolved" ] ();
   Alcotest.(check (float 0.0001))
     "telemetry_resolved row +1"
     (before +. 1.0)
     (count_for ~source:"telemetry_resolved")
+;;
 
 (* When neither [response.model] nor telemetry resolves the
    model, the writer falls back to the [unknown_provider]
@@ -54,13 +58,12 @@ let test_telemetry_resolved_branch () =
    no recovery available". *)
 let test_unknown_sentinel_branch () =
   let before = count_for ~source:"unknown_sentinel" in
-  Prom.inc_counter metric_name
-    ~labels:[ ("source", "unknown_sentinel" ) ]
-    ();
+  Prom.inc_counter metric_name ~labels:[ "source", "unknown_sentinel" ] ();
   Alcotest.(check (float 0.0001))
     "unknown_sentinel row +1"
     (before +. 1.0)
     (count_for ~source:"unknown_sentinel")
+;;
 
 (* Distinct sources land on distinct counter rows.  Necessary
    because operators want to attribute leaks to either
@@ -69,19 +72,19 @@ let test_unknown_sentinel_branch () =
 let test_distinct_sources_separate_rows () =
   let before_t = count_for ~source:"telemetry_resolved" in
   let before_u = count_for ~source:"unknown_sentinel" in
-  Prom.inc_counter metric_name
-    ~labels:[ ("source", "telemetry_resolved") ]
-    ();
-  Prom.inc_counter metric_name
-    ~labels:[ ("source", "unknown_sentinel") ]
-    ();
-  Alcotest.(check (float 0.0001)) "telemetry_resolved +1"
-    (before_t +. 1.0) (count_for ~source:"telemetry_resolved");
-  Alcotest.(check (float 0.0001)) "unknown_sentinel +1"
-    (before_u +. 1.0) (count_for ~source:"unknown_sentinel")
+  Prom.inc_counter metric_name ~labels:[ "source", "telemetry_resolved" ] ();
+  Prom.inc_counter metric_name ~labels:[ "source", "unknown_sentinel" ] ();
+  Alcotest.(check (float 0.0001))
+    "telemetry_resolved +1"
+    (before_t +. 1.0)
+    (count_for ~source:"telemetry_resolved");
+  Alcotest.(check (float 0.0001))
+    "unknown_sentinel +1"
+    (before_u +. 1.0)
+    (count_for ~source:"unknown_sentinel")
+;;
 
-let check_resolution ~msg ~raw_model ~canonical_model_id ~expected_model
-    ~expected_source =
+let check_resolution ~msg ~raw_model ~canonical_model_id ~expected_model ~expected_source =
   let model, source =
     Judge.resolve_governance_model_used ~raw_model ~canonical_model_id
   in
@@ -90,87 +93,96 @@ let check_resolution ~msg ~raw_model ~canonical_model_id ~expected_model
     (msg ^ " source")
     expected_source
     (Judge.governance_model_source_to_string source)
+;;
 
 let test_non_empty_raw_model_wins () =
-  check_resolution ~msg:"raw model"
+  check_resolution
+    ~msg:"raw model"
     ~raw_model:"claude-code:auto"
     ~canonical_model_id:(Some "anthropic:claude-opus-4-7")
     ~expected_model:"claude-code:auto"
     ~expected_source:"response_model"
+;;
 
 let test_empty_raw_falls_back_to_telemetry () =
-  check_resolution ~msg:"telemetry fallback"
+  check_resolution
+    ~msg:"telemetry fallback"
     ~raw_model:""
     ~canonical_model_id:(Some " anthropic:claude-opus-4-7 ")
     ~expected_model:"anthropic:claude-opus-4-7"
     ~expected_source:"telemetry_resolved"
+;;
 
 let test_empty_everywhere_uses_unknown_sentinel () =
-  check_resolution ~msg:"unknown sentinel"
+  check_resolution
+    ~msg:"unknown sentinel"
     ~raw_model:""
     ~canonical_model_id:None
     ~expected_model:"unknown_provider"
     ~expected_source:"unknown_sentinel"
+;;
 
 let test_empty_canonical_id_uses_unknown_sentinel () =
-  check_resolution ~msg:"empty canonical"
+  check_resolution
+    ~msg:"empty canonical"
     ~raw_model:""
     ~canonical_model_id:(Some "")
     ~expected_model:"unknown_provider"
     ~expected_source:"unknown_sentinel"
+;;
 
 (* Prometheus text export must include the metric name and
    the [source] label key — PromQL queries depend on this. *)
 let test_export () =
-  Prom.inc_counter metric_name
-    ~labels:[ ("source", "telemetry_resolved") ]
-    ();
+  Prom.inc_counter metric_name ~labels:[ "source", "telemetry_resolved" ] ();
   let text = Prom.to_prometheus_text () in
   let contains s sub =
-    let n = String.length s and m = String.length sub in
+    let n = String.length s
+    and m = String.length sub in
     let rec loop i =
-      if i + m > n then false
-      else if String.sub s i m = sub then true
-      else loop (i + 1)
+      if i + m > n then false else if String.sub s i m = sub then true else loop (i + 1)
     in
     loop 0
   in
-  Alcotest.(check bool) "metric name in export"
-    true (contains text metric_name);
-  Alcotest.(check bool) "source label key in export"
-    true (contains text "source=")
+  Alcotest.(check bool) "metric name in export" true (contains text metric_name);
+  Alcotest.(check bool) "source label key in export" true (contains text "source=")
+;;
 
 let () =
-  Alcotest.run "governance_response_model_empty_9880"
-    [
-      ( "registration",
-        [
-          Alcotest.test_case "metric registered at module load" `Quick
-            test_metric_registered;
-        ] );
-      ( "label-shape",
-        [
-          Alcotest.test_case "telemetry_resolved branch" `Quick
-            test_telemetry_resolved_branch;
-          Alcotest.test_case "unknown_sentinel branch" `Quick
-            test_unknown_sentinel_branch;
-          Alcotest.test_case "distinct sources distinct rows" `Quick
-            test_distinct_sources_separate_rows;
-        ] );
-      ( "fallback-tiers",
-        [
-          Alcotest.test_case "raw model wins" `Quick
-            test_non_empty_raw_model_wins;
-          Alcotest.test_case "empty raw -> telemetry canonical" `Quick
-            test_empty_raw_falls_back_to_telemetry;
-          Alcotest.test_case "empty everywhere -> sentinel" `Quick
-            test_empty_everywhere_uses_unknown_sentinel;
-          Alcotest.test_case "empty canonical_model_id -> sentinel" `Quick
-            test_empty_canonical_id_uses_unknown_sentinel;
-        ] );
-      ( "export",
-        [
-          Alcotest.test_case "metric + label key in /metrics" `Quick
-            test_export;
-        ] );
+  Alcotest.run
+    "governance_response_model_empty_9880"
+    [ ( "registration"
+      , [ Alcotest.test_case
+            "metric registered at module load"
+            `Quick
+            test_metric_registered
+        ] )
+    ; ( "label-shape"
+      , [ Alcotest.test_case
+            "telemetry_resolved branch"
+            `Quick
+            test_telemetry_resolved_branch
+        ; Alcotest.test_case "unknown_sentinel branch" `Quick test_unknown_sentinel_branch
+        ; Alcotest.test_case
+            "distinct sources distinct rows"
+            `Quick
+            test_distinct_sources_separate_rows
+        ] )
+    ; ( "fallback-tiers"
+      , [ Alcotest.test_case "raw model wins" `Quick test_non_empty_raw_model_wins
+        ; Alcotest.test_case
+            "empty raw -> telemetry canonical"
+            `Quick
+            test_empty_raw_falls_back_to_telemetry
+        ; Alcotest.test_case
+            "empty everywhere -> sentinel"
+            `Quick
+            test_empty_everywhere_uses_unknown_sentinel
+        ; Alcotest.test_case
+            "empty canonical_model_id -> sentinel"
+            `Quick
+            test_empty_canonical_id_uses_unknown_sentinel
+        ] )
+    ; "export", [ Alcotest.test_case "metric + label key in /metrics" `Quick test_export ]
     ]
+;;

--- a/test/test_keeper_compaction_noop_counter_9943.ml
+++ b/test/test_keeper_compaction_noop_counter_9943.ml
@@ -17,27 +17,37 @@
 
 let () =
   let dir =
-    Filename.concat (Filename.get_temp_dir_name ())
-      (Printf.sprintf "masc-test-keeper-compaction-noop-9943-%06x"
-         (Random.bits ()))
+    Filename.concat
+      (Filename.get_temp_dir_name ())
+      (Printf.sprintf "masc-test-keeper-compaction-noop-9943-%06x" (Random.bits ()))
   in
   Unix.putenv "MASC_BASE_PATH" dir
+;;
 
 module Prom = Masc_mcp.Prometheus
 
 let noop_for ~keeper ~trigger =
   Prom.metric_value_or_zero
     Masc_mcp.Keeper_metrics.metric_keeper_compaction_noop
-    ~labels:[ ("keeper", keeper); ("trigger", trigger) ]
+    ~labels:[ "keeper", keeper; "trigger", trigger ]
     ()
+;;
 
-(* Metric is registered at module init.  If a future refactor
-   accidentally drops the [add metric_keeper_compaction_noop ...]
-   call, the dashboard would silently flatten this signal — pin
-   the registration. *)
+(* Metric is registered at module init via [Prometheus.add ~labels:[]],
+   so [get_metric_value ~labels:[] ()] returns [Some 0.0] iff the
+   registration ran. If a future refactor accidentally drops the
+   [add metric_keeper_compaction_noop ...] call, this returns [None]
+   and the dashboard silently flattens — pin the registration.
+
+   [metric_total] is unsuitable as a check: it folds across all
+   labelled variants and returns [0.0] for both "not registered" and
+   "registered but no observations yet". *)
 let test_metric_registered () =
-  let _ = Prom.metric_total Masc_mcp.Keeper_metrics.metric_keeper_compaction_noop in
-  Alcotest.(check pass) "metric registered at init" () ()
+  let registered =
+    Prom.get_metric_value Masc_mcp.Keeper_metrics.metric_keeper_compaction_noop ()
+  in
+  Alcotest.(check bool) "metric registered at init" true (Option.is_some registered)
+;;
 
 (* Direct increment using the same call shape
    [append_metrics_snapshot] uses.  Verifies the counter advances
@@ -48,12 +58,13 @@ let test_counter_advances_for_noop_pattern () =
   let before = noop_for ~keeper ~trigger in
   Prom.inc_counter
     Masc_mcp.Keeper_metrics.metric_keeper_compaction_noop
-    ~labels:[ ("keeper", keeper); ("trigger", trigger) ]
+    ~labels:[ "keeper", keeper; "trigger", trigger ]
     ();
   Alcotest.(check (float 0.0001))
     "noop counter +1 with correct labels"
     (before +. 1.0)
     (noop_for ~keeper ~trigger)
+;;
 
 (* Different triggers land on different counter rows so dashboards
    can attribute noops to the source trigger.  Pre-fix the only
@@ -64,19 +75,21 @@ let test_distinct_triggers_separate_rows () =
   let before_proactive = noop_for ~keeper ~trigger:"proactive_warmup" in
   Prom.inc_counter
     Masc_mcp.Keeper_metrics.metric_keeper_compaction_noop
-    ~labels:[ ("keeper", keeper);
-              ("trigger", "context_overflow_imminent") ]
+    ~labels:[ "keeper", keeper; "trigger", "context_overflow_imminent" ]
     ();
   Prom.inc_counter
     Masc_mcp.Keeper_metrics.metric_keeper_compaction_noop
-    ~labels:[ ("keeper", keeper); ("trigger", "proactive_warmup") ]
+    ~labels:[ "keeper", keeper; "trigger", "proactive_warmup" ]
     ();
-  Alcotest.(check (float 0.0001)) "overflow row +1"
+  Alcotest.(check (float 0.0001))
+    "overflow row +1"
     (before_overflow +. 1.0)
     (noop_for ~keeper ~trigger:"context_overflow_imminent");
-  Alcotest.(check (float 0.0001)) "proactive row +1"
+  Alcotest.(check (float 0.0001))
+    "proactive row +1"
     (before_proactive +. 1.0)
     (noop_for ~keeper ~trigger:"proactive_warmup")
+;;
 
 (* Per-keeper isolation — keeper A's noops do not leak into
    keeper B's row.  Necessary because a fleet has 9-15 keepers
@@ -89,16 +102,17 @@ let test_per_keeper_isolation () =
   let before_b = noop_for ~keeper:b ~trigger in
   Prom.inc_counter
     Masc_mcp.Keeper_metrics.metric_keeper_compaction_noop
-    ~labels:[ ("keeper", a); ("trigger", trigger) ]
+    ~labels:[ "keeper", a; "trigger", trigger ]
     ();
   Prom.inc_counter
     Masc_mcp.Keeper_metrics.metric_keeper_compaction_noop
-    ~labels:[ ("keeper", a); ("trigger", trigger) ]
+    ~labels:[ "keeper", a; "trigger", trigger ]
     ();
   Alcotest.(check (float 0.0001))
     "keeper B unaffected by keeper A increments"
     before_b
     (noop_for ~keeper:b ~trigger)
+;;
 
 (* Prometheus text export must include the metric name and the
    keeper / trigger label keys — PromQL queries depend on this. *)
@@ -107,45 +121,46 @@ let test_prometheus_text_export () =
   let trigger = "context_overflow_imminent" in
   Prom.inc_counter
     Masc_mcp.Keeper_metrics.metric_keeper_compaction_noop
-    ~labels:[ ("keeper", keeper); ("trigger", trigger) ]
+    ~labels:[ "keeper", keeper; "trigger", trigger ]
     ();
   let text = Prom.to_prometheus_text () in
   let contains s sub =
-    let n = String.length s and m = String.length sub in
+    let n = String.length s
+    and m = String.length sub in
     let rec loop i =
-      if i + m > n then false
-      else if String.sub s i m = sub then true
-      else loop (i + 1)
+      if i + m > n then false else if String.sub s i m = sub then true else loop (i + 1)
     in
     loop 0
   in
-  Alcotest.(check bool) "metric name in export"
-    true (contains text Masc_mcp.Keeper_metrics.metric_keeper_compaction_noop);
-  Alcotest.(check bool) "keeper label key in export"
-    true (contains text "keeper=");
-  Alcotest.(check bool) "trigger label key in export"
-    true (contains text "trigger=")
+  Alcotest.(check bool)
+    "metric name in export"
+    true
+    (contains text Masc_mcp.Keeper_metrics.metric_keeper_compaction_noop);
+  Alcotest.(check bool) "keeper label key in export" true (contains text "keeper=");
+  Alcotest.(check bool) "trigger label key in export" true (contains text "trigger=")
+;;
 
 let () =
-  Alcotest.run "keeper_compaction_noop_counter_9943"
-    [
-      ( "registration",
-        [
-          Alcotest.test_case "metric registered at init" `Quick
-            test_metric_registered;
-        ] );
-      ( "label-shape",
-        [
-          Alcotest.test_case "counter advances with (keeper, trigger)"
-            `Quick test_counter_advances_for_noop_pattern;
-          Alcotest.test_case "distinct triggers → distinct rows"
-            `Quick test_distinct_triggers_separate_rows;
-          Alcotest.test_case "per-keeper isolation" `Quick
-            test_per_keeper_isolation;
-        ] );
-      ( "export",
-        [
-          Alcotest.test_case "metric + labels appear in /metrics"
-            `Quick test_prometheus_text_export;
-        ] );
+  Alcotest.run
+    "keeper_compaction_noop_counter_9943"
+    [ ( "registration"
+      , [ Alcotest.test_case "metric registered at init" `Quick test_metric_registered ] )
+    ; ( "label-shape"
+      , [ Alcotest.test_case
+            "counter advances with (keeper, trigger)"
+            `Quick
+            test_counter_advances_for_noop_pattern
+        ; Alcotest.test_case
+            "distinct triggers → distinct rows"
+            `Quick
+            test_distinct_triggers_separate_rows
+        ; Alcotest.test_case "per-keeper isolation" `Quick test_per_keeper_isolation
+        ] )
+    ; ( "export"
+      , [ Alcotest.test_case
+            "metric + labels appear in /metrics"
+            `Quick
+            test_prometheus_text_export
+        ] )
     ]
+;;

--- a/test/test_keeper_supervisor_observability_10125.ml
+++ b/test/test_keeper_supervisor_observability_10125.ml
@@ -28,11 +28,12 @@
 
 let () =
   let dir =
-    Filename.concat (Filename.get_temp_dir_name ())
-      (Printf.sprintf "masc-test-keeper-supervisor-obs-10125-%06x"
-         (Random.bits ()))
+    Filename.concat
+      (Filename.get_temp_dir_name ())
+      (Printf.sprintf "masc-test-keeper-supervisor-obs-10125-%06x" (Random.bits ()))
   in
   Unix.putenv "MASC_BASE_PATH" dir
+;;
 
 module R = Masc_mcp.Keeper_runtime
 module Prom = Masc_mcp.Prometheus
@@ -40,24 +41,38 @@ module Prom = Masc_mcp.Prometheus
 let starts_for ~base_path =
   Prom.metric_value_or_zero
     Masc_mcp.Keeper_metrics.metric_keeper_supervisor_sweep_starts
-    ~labels:[ ("base_path", base_path) ]
+    ~labels:[ "base_path", base_path ]
     ()
+;;
 
 let last_sweep_for ~base_path =
   Prom.get_metric_value
     Masc_mcp.Keeper_metrics.metric_keeper_supervisor_last_sweep_unixtime
-    ~labels:[ ("base_path", base_path) ]
+    ~labels:[ "base_path", base_path ]
     ()
+;;
 
-(* Both metrics are declared at init, so [metric_total]
-   returns a finite total even before any keeper runs.
-   This pins that the registration block actually runs —
-   if either name is missing the whole #10125 dashboard
-   becomes invisible on a fresh install. *)
+(* Both metrics are declared at init via [Prometheus.add ~labels:[]],
+   so [get_metric_value ~labels:[] ()] returns [Some 0.0] if and only
+   if the registration block actually ran. Pins that the #10125
+   dashboard wiring is present — if either name is missing the whole
+   dashboard becomes invisible on a fresh install.
+
+   Note: [metric_total] cannot be used as a registration check because
+   it folds across all labelled variants and returns [0.0] for both
+   "not registered" and "registered but no observations yet". *)
 let test_metrics_registered () =
-  let _ = Prom.metric_total Masc_mcp.Keeper_metrics.metric_keeper_supervisor_sweep_starts in
-  let _ = Prom.metric_total Masc_mcp.Keeper_metrics.metric_keeper_supervisor_last_sweep_unixtime in
-  Alcotest.(check pass) "both supervisor metrics are registered" () ()
+  let starts =
+    Prom.get_metric_value Masc_mcp.Keeper_metrics.metric_keeper_supervisor_sweep_starts ()
+  in
+  let last_sweep =
+    Prom.get_metric_value
+      Masc_mcp.Keeper_metrics.metric_keeper_supervisor_last_sweep_unixtime
+      ()
+  in
+  Alcotest.(check bool) "sweep_starts registered" true (Option.is_some starts);
+  Alcotest.(check bool) "last_sweep_unixtime registered" true (Option.is_some last_sweep)
+;;
 
 (* Helper returns [None] before the sweep gauge is set in
    this process.  Dashboards must distinguish "never set"
@@ -74,6 +89,7 @@ let test_age_helper_returns_none_before_first_sweep () =
     "age helper agrees: None"
     None
     (R.supervisor_sweep_age_seconds ~base_path)
+;;
 
 (* Setting the gauge to "now" makes the helper return a
    small positive age (read-after-write).  This exercises
@@ -83,14 +99,16 @@ let test_age_helper_advances_after_gauge_set () =
   let base_path = "/tmp/test-supervisor-obs-advances-10125" in
   Prom.set_gauge
     Masc_mcp.Keeper_metrics.metric_keeper_supervisor_last_sweep_unixtime
-    ~labels:[ ("base_path", base_path) ]
+    ~labels:[ "base_path", base_path ]
     (Unix.gettimeofday ());
   match R.supervisor_sweep_age_seconds ~base_path with
   | None -> Alcotest.fail "expected Some age after gauge set"
   | Some age ->
     Alcotest.(check bool)
       "age is small (< 5s) and non-negative"
-      true (age >= 0.0 && age < 5.0)
+      true
+      (age >= 0.0 && age < 5.0)
+;;
 
 (* Setting the gauge to a deliberately old timestamp
    reproduces the #10125 "stalled sweep" condition.  The
@@ -101,14 +119,12 @@ let test_age_helper_reports_stale_when_gauge_old () =
   let stale_ts = Unix.gettimeofday () -. 3600.0 in
   Prom.set_gauge
     Masc_mcp.Keeper_metrics.metric_keeper_supervisor_last_sweep_unixtime
-    ~labels:[ ("base_path", base_path) ]
+    ~labels:[ "base_path", base_path ]
     stale_ts;
   match R.supervisor_sweep_age_seconds ~base_path with
   | None -> Alcotest.fail "expected Some age"
-  | Some age ->
-    Alcotest.(check bool)
-      "stale gauge: age >= 1 hour"
-      true (age >= 3599.0)
+  | Some age -> Alcotest.(check bool) "stale gauge: age >= 1 hour" true (age >= 3599.0)
+;;
 
 (* Counter increments are per-base_path so a bench harness
    that exercises multiple base paths in one process can
@@ -119,11 +135,11 @@ let test_counter_per_base_path_isolation () =
   let before_b = starts_for ~base_path:b in
   Prom.inc_counter
     Masc_mcp.Keeper_metrics.metric_keeper_supervisor_sweep_starts
-    ~labels:[ ("base_path", a) ]
+    ~labels:[ "base_path", a ]
     ();
   Prom.inc_counter
     Masc_mcp.Keeper_metrics.metric_keeper_supervisor_sweep_starts
-    ~labels:[ ("base_path", a) ]
+    ~labels:[ "base_path", a ]
     ();
   Alcotest.(check (float 0.0001))
     "base_path B unaffected by base_path A increments"
@@ -133,6 +149,7 @@ let test_counter_per_base_path_isolation () =
     "base_path A counter advanced by 2"
     2.0
     (starts_for ~base_path:a)
+;;
 
 (* The textual export uses [base_path] as the label key
    for both metrics, so PromQL queries can join them on
@@ -141,57 +158,69 @@ let test_prometheus_text_export_includes_metrics () =
   let base_path = "/tmp/test-supervisor-obs-export-10125" in
   Prom.inc_counter
     Masc_mcp.Keeper_metrics.metric_keeper_supervisor_sweep_starts
-    ~labels:[ ("base_path", base_path) ]
+    ~labels:[ "base_path", base_path ]
     ();
   Prom.set_gauge
     Masc_mcp.Keeper_metrics.metric_keeper_supervisor_last_sweep_unixtime
-    ~labels:[ ("base_path", base_path) ]
+    ~labels:[ "base_path", base_path ]
     (Unix.gettimeofday ());
   let text = Prom.to_prometheus_text () in
   let contains s sub =
-    let n = String.length s and m = String.length sub in
+    let n = String.length s
+    and m = String.length sub in
     let rec loop i =
-      if i + m > n then false
-      else if String.sub s i m = sub then true
-      else loop (i + 1)
+      if i + m > n then false else if String.sub s i m = sub then true else loop (i + 1)
     in
     loop 0
   in
   Alcotest.(check bool)
     "counter name appears in export"
-    true (contains text Masc_mcp.Keeper_metrics.metric_keeper_supervisor_sweep_starts);
+    true
+    (contains text Masc_mcp.Keeper_metrics.metric_keeper_supervisor_sweep_starts);
   Alcotest.(check bool)
     "gauge name appears in export"
-    true (contains text Masc_mcp.Keeper_metrics.metric_keeper_supervisor_last_sweep_unixtime);
+    true
+    (contains text Masc_mcp.Keeper_metrics.metric_keeper_supervisor_last_sweep_unixtime);
   Alcotest.(check bool)
     "base_path label appears for export"
-    true (contains text "base_path=")
+    true
+    (contains text "base_path=")
+;;
 
 let () =
-  Alcotest.run "keeper_supervisor_observability_10125"
-    [
-      ( "metrics-registered",
-        [
-          Alcotest.test_case "both metrics registered at init" `Quick
-            test_metrics_registered;
-        ] );
-      ( "age-helper",
-        [
-          Alcotest.test_case "None before first sweep" `Quick
-            test_age_helper_returns_none_before_first_sweep;
-          Alcotest.test_case "advances after gauge set" `Quick
-            test_age_helper_advances_after_gauge_set;
-          Alcotest.test_case "stale gauge reports large age" `Quick
-            test_age_helper_reports_stale_when_gauge_old;
-        ] );
-      ( "counter-isolation",
-        [
-          Alcotest.test_case "per-base_path label isolation" `Quick
-            test_counter_per_base_path_isolation;
-        ] );
-      ( "export",
-        [
-          Alcotest.test_case "metrics appear in /metrics text" `Quick
-            test_prometheus_text_export_includes_metrics;
-        ] );
+  Alcotest.run
+    "keeper_supervisor_observability_10125"
+    [ ( "metrics-registered"
+      , [ Alcotest.test_case
+            "both metrics registered at init"
+            `Quick
+            test_metrics_registered
+        ] )
+    ; ( "age-helper"
+      , [ Alcotest.test_case
+            "None before first sweep"
+            `Quick
+            test_age_helper_returns_none_before_first_sweep
+        ; Alcotest.test_case
+            "advances after gauge set"
+            `Quick
+            test_age_helper_advances_after_gauge_set
+        ; Alcotest.test_case
+            "stale gauge reports large age"
+            `Quick
+            test_age_helper_reports_stale_when_gauge_old
+        ] )
+    ; ( "counter-isolation"
+      , [ Alcotest.test_case
+            "per-base_path label isolation"
+            `Quick
+            test_counter_per_base_path_isolation
+        ] )
+    ; ( "export"
+      , [ Alcotest.test_case
+            "metrics appear in /metrics text"
+            `Quick
+            test_prometheus_text_export_includes_metrics
+        ] )
     ]
+;;


### PR DESCRIPTION
## Summary

#14591 머지 후 dead-test sweep. 두 종류의 죽은 테스트를 정리.

### 1) Orphan: `test/test_keeper_bg_task_cleanup.ml`

5개의 의미있는 Alcotest case가 `Keeper_bg_task_cleanup` 모듈(RFC-0036 Phase A.3.3 Tombstone_reaped→Bg_task drain bridge)을 테스트하지만 `test/dune`에 등록되지 않아 `dune runtest`가 **빌드도 실행도 하지 않음**. production 모듈은 살아있고 `Server_bootstrap_loops:508`에 wired up.

해결: `(tests names ...)` Group-1(build)과 Group-3(runtest) 두 블록에 등록.

### 2) Provably tautological: 3개 "metric registered" 테스트

세 파일이 동일 패턴 사용:

```ocaml
let _ = Prom.metric_total <metric_name> in
Alcotest.(check pass) "metric registered" () ()
```

`Prometheus.metric_total`은 `Hashtbl.metrics`를 name으로 fold하여 `0.0`을 반환합니다 (`lib/prometheus.ml:180`). 미등록 metric → 0 entries × 0.0 = 0.0. 등록됐지만 관찰 없음 → 1 entry × 0.0 = 0.0. **두 경우 구분 불가**. 후속 `check pass () ()`는 무조건 통과 — 테스트가 **이론상 실패할 수 없음**.

```
File "lib/prometheus.ml", line 180:
let metric_total name =
  with_lock (fun () ->
    Hashtbl.fold
      (fun _ (m : metric) acc -> if String.equal m.name name then acc +. m.value else acc)
      metrics
      0.0)
```

해결: `get_metric_value name ()`로 전환. `Prometheus.add ~labels:[]`로 등록된 metric은 `(name, [])` 키로 들어가므로 `get_metric_value name ~labels:[] ()`은 `Some 0.0`(등록됨) vs `None`(미등록)을 구분합니다. `Option.is_some`이 실제 검증.

영향 파일:

- `test/test_keeper_supervisor_observability_10125.ml::test_metrics_registered` (2 metrics)
- `test/test_keeper_compaction_noop_counter_9943.ml::test_metric_registered`
- `test/test_governance_response_model_empty_9880.ml::test_metric_registered`

각 테스트가 작성될 때 명시한 의도("dashboard becomes invisible on fresh install if registration block is dropped")는 보존하면서 이제 **실제로 검증**합니다.

## Test plan

- [x] `dune build --root . @check` clean
- [x] `test_keeper_bg_task_cleanup`: 0→5 (새로 실행됨)
- [x] `test_keeper_supervisor_observability_10125`: 6/6 통과 (registration check는 이제 2개 Option.is_some)
- [x] `test_keeper_compaction_noop_counter_9943`: 5/5 통과
- [x] `test_governance_response_model_empty_9880`: 9/9 통과

## Why this matters

CLAUDE.md §"테스트 항상 작성" + Anti-Hype rules가 *동작*을 검증하는 테스트를 요구합니다. `check pass () ()` 위 `let _ = metric_total ...`는 *주장*("registered")만 있고 *검증*은 없는 dead assertion이었습니다 — 본 PR이 그 격차를 닫습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
