### PR TITLE
refactor(cascade-liveness): budget_for_label → budget_for_provider_id ~provider_id (RFC-0058 Phase 5.2b)

### DIFF
--- a/lib/cascade/cascade_attempt_liveness_config.ml
+++ b/lib/cascade/cascade_attempt_liveness_config.ml
@@ -48,8 +48,9 @@ let reset_cache_for_test () = mode_cache := None
    Local providers stay on the larger [local_27b] / [local_70b_plus]
    budgets to avoid killing slow local models. *)
 
-let budget_for_label (label : string) : Cascade_attempt_liveness.budget =
-  let canon = String.lowercase_ascii (String.trim label) in
+let budget_for_provider_id ~(provider_id : string) :
+    Cascade_attempt_liveness.budget =
+  let canon = String.lowercase_ascii (String.trim provider_id) in
   match canon with
   | "codex_cli" | "claude_code" | "claude" | "gemini_cli" | "gemini" ->
       Cascade_attempt_liveness.cloud_fast
@@ -64,12 +65,12 @@ let budget_for_label (label : string) : Cascade_attempt_liveness.budget =
 
 (* RFC-0022 §1 — see .mli for contract. *)
 let outer_wall_for_attempt
-    ~mode ~observer_attached ~per_provider_timeout_s ~provider_label =
+    ~mode ~observer_attached ~per_provider_timeout_s ~provider_id =
   match mode, observer_attached with
   | Enforce, true -> None
   | _, true ->
       let budget_wall =
-        (budget_for_label provider_label).Cascade_attempt_liveness.attempt_wall_max
+        (budget_for_provider_id ~provider_id).Cascade_attempt_liveness.attempt_wall_max
       in
       Option.map
         (fun t -> Float.max t budget_wall)

--- a/lib/cascade/cascade_attempt_liveness_config.mli
+++ b/lib/cascade/cascade_attempt_liveness_config.mli
@@ -32,13 +32,20 @@ val mode_label : mode -> string
 (** Stable label for telemetry / Prometheus counter values. One of
     [off | observe | enforce]. *)
 
-val budget_for_label : string -> Cascade_attempt_liveness.budget
-(** Map a cascade provider label (e.g. [codex_cli], [claude_code],
+val budget_for_provider_id :
+  provider_id:string -> Cascade_attempt_liveness.budget
+(** Map a cascade [provider_id] (e.g. [codex_cli], [claude_code],
     [gemini_cli], [glm-coding], [ollama_only], [llama-server]) to a
     per-profile budget.
 
-    Unknown labels fall back to {!Cascade_attempt_liveness.cloud_fast}
-    which is the conservative cloud-streaming default. *)
+    The argument is the {b provider} dispatch key — not a model id.
+    Callers should pass the value from
+    [Provider_adapter.provider_label_of_config provider_cfg] or an
+    equivalent provider-level identifier.
+
+    Unknown provider ids fall back to
+    {!Cascade_attempt_liveness.cloud_fast} which is the conservative
+    cloud-streaming default. *)
 
 val reset_cache_for_test : unit -> unit
 (** Test-only: reset the cached flag read so a new value of
@@ -49,7 +56,7 @@ val outer_wall_for_attempt
   :  mode:mode
   -> observer_attached:bool
   -> per_provider_timeout_s:float option
-  -> provider_label:string
+  -> provider_id:string
   -> float option
 (** RFC-0022 §1 — backstop wall for the legacy [per_provider_timeout_s]
     knob.
@@ -63,7 +70,7 @@ val outer_wall_for_attempt
       attempt wall budget breach. The legacy outer wall must not
       pre-empt it.
     - [Off] / [Observe], or no observer: returns
-      [Some (max t (budget_for_label provider_label).attempt_wall_max)]
+      [Some (max t (budget_for_provider_id ~provider_id).attempt_wall_max)]
       when [per_provider_timeout_s = Some t]. Slow-but-legitimate
       streams (local Ollama 27B / 70B+) get the profile's attempt wall
       so the legacy 120s knob cannot prematurely fall back the cascade.

--- a/lib/cascade/cascade_attempt_liveness_config.mli
+++ b/lib/cascade/cascade_attempt_liveness_config.mli
@@ -69,11 +69,14 @@ val outer_wall_for_attempt
       the authority and drives [Switch.fail] on TTFT, inter-chunk, or
       attempt wall budget breach. The legacy outer wall must not
       pre-empt it.
-    - [Off] / [Observe], or no observer: returns
+    - [Off] / [Observe] + observer attached: returns
       [Some (max t (budget_for_provider_id ~provider_id).attempt_wall_max)]
       when [per_provider_timeout_s = Some t]. Slow-but-legitimate
       streams (local Ollama 27B / 70B+) get the profile's attempt wall
       so the legacy 120s knob cannot prematurely fall back the cascade.
+    - No observer attached (any mode): returns [per_provider_timeout_s]
+      unchanged. Without an observer there is no per-provider budget
+      to clamp against, so the caller's legacy knob is honored as-is.
     - No legacy timeout configured ([per_provider_timeout_s = None]):
       returns [None] (no outer wall).
 

--- a/lib/keeper/keeper_turn_driver_try_provider.ml
+++ b/lib/keeper/keeper_turn_driver_try_provider.ml
@@ -177,12 +177,15 @@ let run_try_provider
   | Error err -> Error err, None
   | Ok config ->
     let liveness_mode = Cascade_attempt_liveness_config.current_mode () in
+    (* Compute provider_id once so the liveness budget lookup and the
+       [outer_wall_for_attempt] dispatch key cannot diverge if
+       [provider_label_of_config] ever changes behavior. *)
+    let provider_id = Provider_adapter.provider_label_of_config provider_cfg in
     let liveness_observer_opt =
       match liveness_mode with
       | Cascade_attempt_liveness_config.Off -> None
       | Cascade_attempt_liveness_config.Observe | Cascade_attempt_liveness_config.Enforce
         ->
-        let provider_id = Provider_adapter.provider_label_of_config provider_cfg in
         let budget =
           Cascade_attempt_liveness_config.budget_for_provider_id ~provider_id
         in
@@ -284,8 +287,7 @@ let run_try_provider
                     ~mode:liveness_mode
                     ~observer_attached:(Option.is_some liveness_observer_opt)
                     ~per_provider_timeout_s
-                    ~provider_id:
-                      (Provider_adapter.provider_label_of_config provider_cfg)
+                    ~provider_id
                 in
                 match outer_wall_for_provider with
                 | None -> run_fn ()

--- a/lib/keeper/keeper_turn_driver_try_provider.ml
+++ b/lib/keeper/keeper_turn_driver_try_provider.ml
@@ -182,8 +182,9 @@ let run_try_provider
       | Cascade_attempt_liveness_config.Off -> None
       | Cascade_attempt_liveness_config.Observe | Cascade_attempt_liveness_config.Enforce
         ->
+        let provider_id = Provider_adapter.provider_label_of_config provider_cfg in
         let budget =
-          Cascade_attempt_liveness_config.budget_for_label provider_cfg.model_id
+          Cascade_attempt_liveness_config.budget_for_provider_id ~provider_id
         in
         let obs =
           Cascade_attempt_liveness_observer.create
@@ -283,7 +284,8 @@ let run_try_provider
                     ~mode:liveness_mode
                     ~observer_attached:(Option.is_some liveness_observer_opt)
                     ~per_provider_timeout_s
-                    ~provider_label:provider_cfg.model_id
+                    ~provider_id:
+                      (Provider_adapter.provider_label_of_config provider_cfg)
                 in
                 match outer_wall_for_provider with
                 | None -> run_fn ()

--- a/test/test_cascade_attempt_liveness_config.ml
+++ b/test/test_cascade_attempt_liveness_config.ml
@@ -97,7 +97,7 @@ let test_mode_labels () =
   Alcotest.(check string) "observe" "observe" (mode_label Observe);
   Alcotest.(check string) "enforce" "enforce" (mode_label Enforce)
 
-(* -- budget_for_label ---------------------------------------------- *)
+(* -- budget_for_provider_id ---------------------------------------- *)
 
 let budget_eq (a : L.budget) (b : L.budget) =
   Float.equal a.ttft_max b.ttft_max
@@ -109,37 +109,37 @@ let check_budget label expected actual =
 
 let test_budget_codex_cli () =
   check_budget "codex_cli -> cloud_fast" L.cloud_fast
-    (Cfg.budget_for_label "codex_cli")
+    (Cfg.budget_for_provider_id ~provider_id:"codex_cli")
 
 let test_budget_claude_code () =
   check_budget "claude_code -> cloud_fast" L.cloud_fast
-    (Cfg.budget_for_label "claude_code")
+    (Cfg.budget_for_provider_id ~provider_id:"claude_code")
 
 let test_budget_glm_coding () =
   check_budget "glm-coding -> cloud_thinking" L.cloud_thinking
-    (Cfg.budget_for_label "glm-coding")
+    (Cfg.budget_for_provider_id ~provider_id:"glm-coding")
 
 let test_budget_kimi () =
   check_budget "kimi-for-coding -> cloud_thinking" L.cloud_thinking
-    (Cfg.budget_for_label "kimi-for-coding")
+    (Cfg.budget_for_provider_id ~provider_id:"kimi-for-coding")
 
 let test_budget_local () =
   check_budget "ollama_only -> local_27b" L.local_27b
-    (Cfg.budget_for_label "ollama_only");
+    (Cfg.budget_for_provider_id ~provider_id:"ollama_only");
   check_budget "llama-server -> local_27b" L.local_27b
-    (Cfg.budget_for_label "llama-server")
+    (Cfg.budget_for_provider_id ~provider_id:"llama-server")
 
 let test_budget_local_70b () =
   check_budget "local_70b_plus -> local_70b_plus" L.local_70b_plus
-    (Cfg.budget_for_label "local_70b_plus")
+    (Cfg.budget_for_provider_id ~provider_id:"local_70b_plus")
 
 let test_budget_unknown_default () =
   check_budget "unknown -> cloud_fast" L.cloud_fast
-    (Cfg.budget_for_label "weird_provider_xyz")
+    (Cfg.budget_for_provider_id ~provider_id:"weird_provider_xyz")
 
 let test_budget_case_insensitive () =
   check_budget "GLM-CODING -> cloud_thinking" L.cloud_thinking
-    (Cfg.budget_for_label "GLM-CODING")
+    (Cfg.budget_for_provider_id ~provider_id:"GLM-CODING")
 
 let () =
   Alcotest.run "cascade_attempt_liveness_config"
@@ -165,7 +165,7 @@ let () =
         ] );
       ( "mode_label",
         [ Alcotest.test_case "stable labels" `Quick test_mode_labels ] );
-      ( "budget_for_label",
+      ( "budget_for_provider_id",
         [
           Alcotest.test_case "codex_cli" `Quick test_budget_codex_cli;
           Alcotest.test_case "claude_code" `Quick test_budget_claude_code;

--- a/test/test_cascade_attempt_outer_wall.ml
+++ b/test/test_cascade_attempt_outer_wall.ml
@@ -30,7 +30,7 @@ let test_enforce_with_observer_returns_none () =
       ~mode:Cfg.Enforce
       ~observer_attached:true
       ~per_provider_timeout_s:(Some 120.0)
-      ~provider_label:"codex_cli"
+      ~provider_id:"codex_cli"
   in
   Alcotest.(check opt_f) "Enforce + observer → None" None actual
 
@@ -40,7 +40,7 @@ let test_enforce_with_observer_ollama_returns_none () =
       ~mode:Cfg.Enforce
       ~observer_attached:true
       ~per_provider_timeout_s:(Some 120.0)
-      ~provider_label:"ollama_only"
+      ~provider_id:"ollama_only"
   in
   Alcotest.(check opt_f)
     "Enforce + observer + ollama → None (observer is authority)"
@@ -54,7 +54,7 @@ let test_observe_ollama_clips_to_local_27b_wall () =
       ~mode:Cfg.Observe
       ~observer_attached:true
       ~per_provider_timeout_s:(Some 120.0)
-      ~provider_label:"ollama_only"
+      ~provider_id:"ollama_only"
   in
   Alcotest.(check opt_f)
     "Observe + ollama → local_27b wall 900s (not 120s)"
@@ -67,7 +67,7 @@ let test_off_ollama_clips_to_local_27b_wall () =
       ~mode:Cfg.Off
       ~observer_attached:true
       ~per_provider_timeout_s:(Some 120.0)
-      ~provider_label:"llama-server"
+      ~provider_id:"llama-server"
   in
   Alcotest.(check opt_f)
     "Off + llama-server → local_27b wall 900s"
@@ -80,7 +80,7 @@ let test_observe_ollama_70b_clips_to_local_70b_plus_wall () =
       ~mode:Cfg.Observe
       ~observer_attached:true
       ~per_provider_timeout_s:(Some 120.0)
-      ~provider_label:"ollama_70b"
+      ~provider_id:"ollama_70b"
   in
   Alcotest.(check opt_f)
     "Observe + ollama_70b → local_70b_plus wall 1800s"
@@ -95,7 +95,7 @@ let test_observe_cloud_fast_keeps_user_t_when_larger () =
       ~mode:Cfg.Observe
       ~observer_attached:true
       ~per_provider_timeout_s:(Some 600.0)
-      ~provider_label:"codex_cli"
+      ~provider_id:"codex_cli"
   in
   Alcotest.(check opt_f)
     "Observe + codex_cli + user 600s → 600s (>cloud_fast 180s)"
@@ -108,7 +108,7 @@ let test_observe_cloud_fast_clips_when_user_smaller () =
       ~mode:Cfg.Observe
       ~observer_attached:true
       ~per_provider_timeout_s:(Some 120.0)
-      ~provider_label:"codex_cli"
+      ~provider_id:"codex_cli"
   in
   Alcotest.(check opt_f)
     "Observe + codex_cli + user 120s → cloud_fast 180s"
@@ -123,7 +123,7 @@ let test_no_observer_passes_through_user_value () =
       ~mode:Cfg.Off
       ~observer_attached:false
       ~per_provider_timeout_s:(Some 120.0)
-      ~provider_label:"ollama_only"
+      ~provider_id:"ollama_only"
   in
   Alcotest.(check opt_f)
     "Off + no observer → unchanged 120s (legacy)"
@@ -138,7 +138,7 @@ let test_enforce_without_observer_passes_through () =
       ~mode:Cfg.Enforce
       ~observer_attached:false
       ~per_provider_timeout_s:(Some 120.0)
-      ~provider_label:"codex_cli"
+      ~provider_id:"codex_cli"
   in
   Alcotest.(check opt_f)
     "Enforce + no observer → unchanged 120s (no silent drop)"
@@ -152,7 +152,7 @@ let test_none_input_stays_none_observe_with_observer () =
       ~mode:Cfg.Observe
       ~observer_attached:true
       ~per_provider_timeout_s:None
-      ~provider_label:"ollama_only"
+      ~provider_id:"ollama_only"
   in
   Alcotest.(check opt_f) "None input → None output" None actual
 
@@ -162,7 +162,7 @@ let test_none_input_stays_none_off_no_observer () =
       ~mode:Cfg.Off
       ~observer_attached:false
       ~per_provider_timeout_s:None
-      ~provider_label:"codex_cli"
+      ~provider_id:"codex_cli"
   in
   Alcotest.(check opt_f) "None + no observer → None" None actual
 
@@ -174,7 +174,7 @@ let test_unknown_label_falls_back_to_cloud_fast () =
       ~mode:Cfg.Observe
       ~observer_attached:true
       ~per_provider_timeout_s:(Some 60.0)
-      ~provider_label:"some-future-provider"
+      ~provider_id:"some-future-provider"
   in
   Alcotest.(check opt_f)
     "Observe + unknown → cloud_fast 180s"

--- a/test/test_oas_worker_named_liveness_integration.ml
+++ b/test/test_oas_worker_named_liveness_integration.ml
@@ -84,7 +84,7 @@ let test_e2e_observe_finalize_emits_observed_total () =
       let cascade = "integ_observe_cascade" in
       let provider = "integ_observe_provider" in
       let mode = Cfg.current_mode () in
-      let budget = Cfg.budget_for_label provider in
+      let budget = Cfg.budget_for_provider_id ~provider_id:provider in
       let obs =
         Obs.create ~mode ~budget ~cascade_label:cascade
           ~provider_label:provider ~started_at:0.0
@@ -106,7 +106,7 @@ let test_e2e_off_no_observed_total () =
       let cascade = "integ_off_cascade" in
       let provider = "integ_off_provider" in
       let mode = Cfg.current_mode () in
-      let budget = Cfg.budget_for_label provider in
+      let budget = Cfg.budget_for_provider_id ~provider_id:provider in
       let obs =
         Obs.create ~mode ~budget ~cascade_label:cascade
           ~provider_label:provider ~started_at:0.0
@@ -126,7 +126,7 @@ let test_enforce_registered_switch_kills_attempt_without_tick_clock () =
           try
             Eio.Switch.run (fun attempt_sw ->
                 let mode = Cfg.current_mode () in
-                let budget = Cfg.budget_for_label provider in
+                let budget = Cfg.budget_for_provider_id ~provider_id:provider in
                 let obs =
                   Obs.create ~mode ~budget ~cascade_label:cascade
                     ~provider_label:provider ~started_at:0.0


### PR DESCRIPTION
## Why

`budget_for_label : string -> budget` accepted free-form strings, conflating `provider_id` (claude_code, codex_cli) with `model_id` (claude-haiku-4-5, gemini-3-flash-preview). The prod caller in `keeper_turn_driver_try_provider.ml:186` was passing `provider_cfg.model_id` — wrong dispatch key for a provider-level liveness budget.

This PR is the type-level cleanup. Internal match logic unchanged; only parameter semantics tighten.

Plan reference: RFC-0058 Phase 5.2b, Batch B1.

## What changed

- `lib/cascade/cascade_attempt_liveness_config.{ml,mli}`: rename `budget_for_label` → `budget_for_provider_id` (named arg `~provider_id`), rename `outer_wall_for_attempt`'s `~provider_label` → `~provider_id`.
- `lib/keeper/keeper_turn_driver_try_provider.ml`: pass `Provider_adapter.provider_label_of_config provider_cfg` at the call site (was `provider_cfg.model_id` — semantic bug fix). Uses the canonical provider-label SSOT.
- `test/test_cascade_attempt_liveness_config.ml`: 8 fixtures updated to named arg + group renamed.
- `test/test_cascade_attempt_outer_wall.ml`: 12 named-arg call-site renames (`~provider_label:` → `~provider_id:`).
- `test/test_oas_worker_named_liveness_integration.ml`: 3 callers updated.

## Verification

```
$ opam exec -- dune build --root . @check
(clean)
$ opam exec -- dune exec --root . test/test_cascade_attempt_liveness_config.exe
Test Successful in 0.002s. 19 tests run.
$ opam exec -- dune exec --root . test/test_cascade_attempt_outer_wall.exe
Test Successful in 0.001s. 12 tests run.
```

## Notes

- Provider_cfg has no `provider_id` field directly. Used `Provider_adapter.provider_label_of_config provider_cfg` (the existing SSOT for stable provider label / cascade prefix) — semantically equivalent to "provider_id" for dispatch purposes.
- Discovered 2 additional test callers beyond the plan: `test_cascade_attempt_outer_wall.ml` (12 sites) and `test_oas_worker_named_liveness_integration.ml` (3 sites). Both updated.
- Docstring refs in `lib/cascade_decl/cascade_declarative_types.{ml,mli}` left as-is (out-of-scope comment text).

## Follow-up

RFC-0058 Phase 5 future: move budget class to `cascade.toml [providers.X]` metadata. This PR is the type-level prep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)