### PR TITLE
fix(keeper): eliminate dual-registration, public-first tool surface (RFC-0064)

### DIFF
--- a/lib/keeper/keeper_run_tools.ml
+++ b/lib/keeper/keeper_run_tools.ml
@@ -463,9 +463,16 @@ let prepare_agent_setup
   in
   let universe_set = Keeper_tool_policy.tool_name_set all_tool_names in
   let allowed_exec_names = Keeper_exec_tools.keeper_allowed_tool_names meta in
-  (* RFC-0064 Phase 2: Remove aliased internal names from the policy
-     surface. Public aliases are the LLM-visible names; internal
-     counterparts are implementation details. *)
+  (* RFC-0064 Phase 2: Remove aliased internal names from the LLM-visible
+     policy surface. Public aliases are the LLM-visible names; internal
+     counterparts are implementation details.
+
+     Order matters: compute [aliased_public_names] against the UNFILTERED
+     internal allowlist, because tool_policy.toml / presets still express
+     allowlists in internal names (keeper_bash, keeper_fs_read, ...).
+     Stripping internals before the alias-expansion check would leave
+     [aliased_public_names] empty and drop "Bash"/"Read"/... from the
+     visible surface. See PR #14596 review. *)
   let aliased_internal_names =
     List.filter_map
       (fun public ->
@@ -473,11 +480,6 @@ let prepare_agent_setup
          | Some r -> Some r.internal_name
          | None -> None)
       (Keeper_tool_alias.public_names ())
-  in
-  let allowed_exec_names =
-    List.filter
-      (fun name -> not (List.mem name aliased_internal_names))
-      allowed_exec_names
   in
   (* Only include a public alias name when its routed internal target is
      itself in [allowed_exec_names]. Otherwise the public name (e.g. "Bash")
@@ -495,6 +497,13 @@ let prepare_agent_setup
            Keeper_tool_policy.StringSet.mem r.internal_name allowed_set_for_alias_filter
          | None -> false)
       (Keeper_tool_alias.public_names ())
+  in
+  (* Now strip the aliased internal names from the LLM-visible surface,
+     after [aliased_public_names] has been computed. *)
+  let allowed_exec_names =
+    List.filter
+      (fun name -> not (List.mem name aliased_internal_names))
+      allowed_exec_names
   in
   let allowed_exec_names_with_aliases = allowed_exec_names @ aliased_public_names in
   let allowed_exec_set =

--- a/lib/keeper/keeper_run_tools.ml
+++ b/lib/keeper/keeper_run_tools.ml
@@ -463,6 +463,20 @@ let prepare_agent_setup
   in
   let universe_set = Keeper_tool_policy.tool_name_set all_tool_names in
   let allowed_exec_names = Keeper_exec_tools.keeper_allowed_tool_names meta in
+  (* RFC-0064 Phase 2: Remove aliased internal names from the policy
+     surface. Public aliases are the LLM-visible names; internal
+     counterparts are implementation details. *)
+  let aliased_internal_names =
+    List.filter_map
+      (fun public ->
+         match Keeper_tool_alias.route public with
+         | Some r -> Some r.internal_name
+         | None -> None)
+      (Keeper_tool_alias.public_names ())
+  in
+  let allowed_exec_names =
+    List.filter (fun name -> not (List.mem name aliased_internal_names)) allowed_exec_names
+  in
   (* Only include a public alias name when its routed internal target is
      itself in [allowed_exec_names]. Otherwise the public name (e.g. "Bash")
      could let the LLM invoke a tool whose internal handler the current

--- a/lib/keeper/keeper_run_tools.ml
+++ b/lib/keeper/keeper_run_tools.ml
@@ -475,7 +475,9 @@ let prepare_agent_setup
       (Keeper_tool_alias.public_names ())
   in
   let allowed_exec_names =
-    List.filter (fun name -> not (List.mem name aliased_internal_names)) allowed_exec_names
+    List.filter
+      (fun name -> not (List.mem name aliased_internal_names))
+      allowed_exec_names
   in
   (* Only include a public alias name when its routed internal target is
      itself in [allowed_exec_names]. Otherwise the public name (e.g. "Bash")

--- a/lib/keeper/keeper_tool_registry.ml
+++ b/lib/keeper/keeper_tool_registry.ml
@@ -74,9 +74,6 @@ let core_discovery_tools =
         ; Keeper Task_done
         ; Keeper Task_create
         ; Keeper Memory_search
-        ; (* Filesystem: read + write (action symmetry) *)
-          Keeper Fs_read
-        ; Keeper Fs_edit
         ; (* Board: core interaction *)
           Keeper Board_get
         ; Keeper Board_post
@@ -85,19 +82,26 @@ let core_discovery_tools =
         ; Keeper Board_list
         ; Keeper Board_curation_read
         ; Keeper Board_curation_submit
-        ; (* Shell + VCS *)
-          Keeper Shell
-        ; Keeper Bash
-        ; Keeper Preflight_check
+        ; (* VCS + misc *)
+          Keeper Preflight_check
         ; (* Review *)
           Keeper Pr_review_read
         ; Keeper Pr_review_comment
         ; Keeper Pr_review_reply
         ; (* Discovery fallback for meta/admin tools *)
           Keeper Tools_list
-        ; (* External search *)
-          Masc Web_search
         ]
+  @ [ (* RFC-0064 Phase 2: Public aliases replace internal names in
+         the LLM-facing discovery surface. Dual-registration cleanup
+         means internal names (keeper_bash, keeper_fs_read, etc.)
+         are no longer registered as OAS tools. *)
+        "Bash"
+      ; "Edit"
+      ; "Grep"
+      ; "Read"
+      ; "WebSearch"
+      ; "Write"
+      ]
 ;;
 
 let effective_core_tools () = core_discovery_tools

--- a/lib/keeper/keeper_tool_registry.ml
+++ b/lib/keeper/keeper_tool_registry.ml
@@ -95,13 +95,13 @@ let core_discovery_tools =
          the LLM-facing discovery surface. Dual-registration cleanup
          means internal names (keeper_bash, keeper_fs_read, etc.)
          are no longer registered as OAS tools. *)
-        "Bash"
-      ; "Edit"
-      ; "Grep"
-      ; "Read"
-      ; "WebSearch"
-      ; "Write"
-      ]
+      "Bash"
+    ; "Edit"
+    ; "Grep"
+    ; "Read"
+    ; "WebSearch"
+    ; "Write"
+    ]
 ;;
 
 let effective_core_tools () = core_discovery_tools

--- a/lib/keeper/keeper_tools_oas.ml
+++ b/lib/keeper/keeper_tools_oas.ml
@@ -998,8 +998,37 @@ let make_tool_bundle
          not (List.mem td.name aliased_internal_names))
       tool_defs
   in
+  (* Pass B public alias names that will actually materialize as tools.
+     Mirrors the filter logic in [alias_tools] below: a public alias is
+     provisioned only when (a) routing exists, (b) the routed internal name
+     is in [universe_names], and (c) a tool_def for it exists. Computing
+     this up front lets telemetry report the full assembled surface
+     (Pass A internal names + Pass B public alias names) rather than
+     Pass A alone, which under-reported the agent-visible toolset. *)
+  let pass_b_public_alias_names =
+    List.filter_map
+      (fun public ->
+         match Keeper_tool_alias.route public with
+         | None -> None
+         | Some r ->
+           if not (List.mem r.internal_name universe_names)
+           then None
+           else if
+             List.exists
+               (fun (td : Masc_domain.tool_schema) ->
+                  String.equal td.name r.internal_name)
+               tool_defs
+           then Some public
+           else None)
+      (Keeper_tool_alias.public_names ())
+  in
+  let assembled_tool_surface =
+    universe_names_for_pass_a @ pass_b_public_alias_names
+  in
   (* Record tool assignment telemetry for causal tracing.
-     assignment_id links Assigned → Called → Completed events. *)
+     assignment_id links Assigned → Called → Completed events.
+     [tool_list] reflects the final agent-visible surface so assignment
+     reporting matches what the LLM actually sees. *)
   let (_assignment_id : Tool_assignment_telemetry.assignment_id) =
     let lookup = Keeper_tool_policy.tool_access_lookup_of_meta meta in
     let preset =
@@ -1012,7 +1041,7 @@ let make_tool_bundle
       ~agent_id:meta.agent_name
       ~profile:"keeper"
       ?preset
-      ~tool_list:universe_names_for_pass_a
+      ~tool_list:assembled_tool_surface
       ~allow_set:(Keeper_tool_policy.StringSet.elements lookup.allow_set)
       ~deny_set:(Keeper_tool_policy.StringSet.elements lookup.deny_set)
       ~reason:"keeper tool bundle assembly"

--- a/lib/keeper/keeper_tools_oas.ml
+++ b/lib/keeper/keeper_tools_oas.ml
@@ -976,7 +976,11 @@ let make_tool_bundle
   let tool_defs = Keeper_exec_tools.keeper_universe_model_tools meta in
   (* RFC-0064 Phase 2: Remove aliased internal names from Pass A to
      eliminate dual-registration. Aliased tools appear ONLY under their
-     public name in the LLM-facing surface. *)
+     public name in the LLM-facing surface.
+
+     Preserve originals for Pass B alias-tool construction:
+     alias_tools needs [universe_names] membership and [tool_defs] lookup
+     for the routed internal names (keeper_bash, keeper_fs_read, etc.). *)
   let aliased_internal_names =
     List.filter_map
       (fun public ->
@@ -985,10 +989,10 @@ let make_tool_bundle
          | None -> None)
       (Keeper_tool_alias.public_names ())
   in
-  let universe_names =
+  let universe_names_for_pass_a =
     List.filter (fun name -> not (List.mem name aliased_internal_names)) universe_names
   in
-  let tool_defs =
+  let tool_defs_for_pass_a =
     List.filter
       (fun (td : Masc_domain.tool_schema) ->
          not (List.mem td.name aliased_internal_names))
@@ -1008,7 +1012,7 @@ let make_tool_bundle
       ~agent_id:meta.agent_name
       ~profile:"keeper"
       ?preset
-      ~tool_list:universe_names
+      ~tool_list:universe_names_for_pass_a
       ~allow_set:(Keeper_tool_policy.StringSet.elements lookup.allow_set)
       ~deny_set:(Keeper_tool_policy.StringSet.elements lookup.deny_set)
       ~reason:"keeper tool bundle assembly"
@@ -1019,7 +1023,7 @@ let make_tool_bundle
   let internal_tools =
     List.filter_map
       (fun (td : Masc_domain.tool_schema) ->
-         if List.mem td.name universe_names
+         if List.mem td.name universe_names_for_pass_a
          then (
            let h =
              make_keeper_tool_handler
@@ -1045,7 +1049,7 @@ let make_tool_bundle
                    let start_time = Time_compat.now () in
                    Tool_result.wrap ~tool_name:td.name ~start_time (h input))))
          else None)
-      tool_defs
+      tool_defs_for_pass_a
   in
   (* Pass B: RFC-0064 — register LLM-native surface names (Bash/Read/etc)
      via the flat routing table. The handler dispatches with

--- a/lib/keeper/keeper_tools_oas.ml
+++ b/lib/keeper/keeper_tools_oas.ml
@@ -974,6 +974,26 @@ let make_tool_bundle
      execute_keeper_tool_call uses can_execute for the execution gate. *)
   let universe_names = Keeper_exec_tools.keeper_universe_tool_names meta in
   let tool_defs = Keeper_exec_tools.keeper_universe_model_tools meta in
+  (* RFC-0064 Phase 2: Remove aliased internal names from Pass A to
+     eliminate dual-registration. Aliased tools appear ONLY under their
+     public name in the LLM-facing surface. *)
+  let aliased_internal_names =
+    List.filter_map
+      (fun public ->
+         match Keeper_tool_alias.route public with
+         | Some r -> Some r.internal_name
+         | None -> None)
+      (Keeper_tool_alias.public_names ())
+  in
+  let universe_names =
+    List.filter (fun name -> not (List.mem name aliased_internal_names)) universe_names
+  in
+  let tool_defs =
+    List.filter
+      (fun (td : Masc_domain.tool_schema) ->
+         not (List.mem td.name aliased_internal_names))
+      tool_defs
+  in
   (* Record tool assignment telemetry for causal tracing.
      assignment_id links Assigned → Called → Completed events. *)
   let (_assignment_id : Tool_assignment_telemetry.assignment_id) =


### PR DESCRIPTION
## Summary

RFC-0064 Phase 2 구현: dual-registration 제거 후 public name을 primary identifier로 승격.

### 변경 내용

**Phase 1 (OAS registration)** — `keeper_tools_oas.ml`
- Pass A에서 aliased internal names (`keeper_bash`, `keeper_fs_read`, `keeper_fs_edit`, `keeper_shell`, `masc_web_search`)를 필터링하여 OAS 등록 대상에서 제외.
- Aliased 도구는 Pass B의 public alias (`Bash`, `Read`, `Edit`, `Write`, `Grep`, `WebSearch`, `WebFetch`)로만 LLM에 노출.

**Phase 2 (Discovery & Policy)** — `keeper_tool_registry.ml`, `keeper_run_tools.ml`
- `core_discovery_tools`에서 aliased 내부 이름을 public alias 문자열로 교체.
- `allowed_exec_names`에서 aliased 내부 이름을 제거하고 public alias만 남김.

**Phase 3-4 (Canonicalization & Dispatch)**
- `Keeper_tool_alias.record_route_outcome`이 telemetry에서 이미 public name을 기록하므로 추가 변경 불필요.
- `keeper_exec_tools.ml` dispatch boundary는 내부 이름 기반으로 유지; `route`를 통해 변환된 이름만 전달됨.

### 검증

- [x] `dune build --root . @check` passes
- [x] `dune test --root . lib/keeper/` passes (exit 0)

### 관련 RFC

- RFC-0064: Two-surface tool naming model (flat `route` type)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>