### PR TITLE
refactor(cascade): closed-variant dispatch in cascade_oas_runner (RFC-0058 Phase 5.1)

### DIFF
--- a/lib/cascade/cascade_oas_runner.ml
+++ b/lib/cascade/cascade_oas_runner.ml
@@ -13,7 +13,6 @@ let default_config_path = Cascade_runtime.cascade_config_path
 let default_model_strings ~cascade_name =
   Cascade_runtime.default_model_strings
     ~cascade_name:(Keeper_cascade_profile.Runtime_name cascade_name)
-;;
 
 (* Named model execution *)
 
@@ -32,16 +31,13 @@ let require_eio ?sw ?net () =
   | Some sw, Some net -> Ok (sw, net)
   | None, _ -> Error "Eio switch not available (running outside server context)"
   | _, None -> Error "Eio net not available (running outside server context)"
-;;
 
 let eio_context_error_to_sdk_error detail =
   Agent_sdk.Error.Config (Agent_sdk.Error.InvalidConfig { field = "eio_context"; detail })
-;;
 
 let cascade_catalog_error_to_sdk_error detail =
   Agent_sdk.Error.Config
     (Agent_sdk.Error.InvalidConfig { field = "cascade_name"; detail })
-;;
 
 (** Resolve cascade provider configs via MASC Cascade_config.
     Returns Provider_config.t list for the downstream OAS runtime,
@@ -61,7 +57,6 @@ let resolve_cascade_providers
     ~require_tool_support
     ~cascade_name
     ()
-;;
 
 (** Resolve from an explicit model string list (user-declared in keeper TOML).
     MASC parses the strings via its local [Cascade_config] and passes the
@@ -79,12 +74,10 @@ let resolve_providers_from_model_strings
     ~require_tool_choice_support
     ~require_tool_support
     model_strings
-;;
 
 let keeper_agent_name_opt (keeper_name : string) =
   let keeper_name = String.trim keeper_name in
   if keeper_name = "" then None else Some (Keeper_types.keeper_agent_name keeper_name)
-;;
 
 let runtime_mcp_policy_for_tools ~(keeper_name : string) (tools : Agent_sdk.Tool.t list) =
   let agent_name = keeper_agent_name_opt keeper_name in
@@ -112,7 +105,6 @@ let runtime_mcp_policy_for_tools ~(keeper_name : string) (tools : Agent_sdk.Tool
     Some (Cascade_runner.runtime_mcp_policy_with_masc_agent_name ~agent_name policy)
   | Some policy, None -> Some policy
   | None, _ -> None
-;;
 
 let keeper_internal_tool_names_for_runtime_surface
       ~(keeper_name : string)
@@ -126,14 +118,12 @@ let keeper_internal_tool_names_for_runtime_surface
       Tool_catalog.is_on_surface Tool_catalog.Keeper_internal tool.schema.name)
     |> List.map (fun (tool : Agent_sdk.Tool.t) -> tool.schema.name)
     |> List.sort_uniq String.compare
-;;
 
 let keeper_internal_tools_require_materialized_runtime_surface
       ~(keeper_name : string)
       (tools : Agent_sdk.Tool.t list)
   =
   keeper_internal_tool_names_for_runtime_surface ~keeper_name tools <> []
-;;
 
 let runtime_mcp_policy_for_provider
       ~(keeper_name : string)
@@ -142,7 +132,6 @@ let runtime_mcp_policy_for_provider
   =
   let agent_name = keeper_agent_name_opt keeper_name |> Option.value ~default:"" in
   Cascade_runner.runtime_mcp_policy_for_provider ~provider_cfg ~agent_name policy_opt
-;;
 
 let codex_cli_cannot_carry_keeper_bound_runtime_mcp
       ~(keeper_name : string)
@@ -165,7 +154,6 @@ let codex_cli_cannot_carry_keeper_bound_runtime_mcp
            Cascade_runner.runtime_mcp_tool_requires_bound_actor
            policy.allowed_tool_names
     | _ -> false)
-;;
 
 (* #10681: per-provider rejection reason produced by the cascade filter.
    When the filter empties the cascade, operators previously saw only a
@@ -193,7 +181,6 @@ let filter_rejection_reason_label = function
   | Codex_keeper_bound_actor_required -> "codex_keeper_bound_actor_required"
   | Tool_lane_unsupported -> "tool_lane_unsupported"
   | Required_tool_use r -> Provider_tool_support.rejection_reason_label r
-;;
 
 let codex_keeper_bound_skip_seen : (string, float) Hashtbl.t = Hashtbl.create 16
 let codex_keeper_bound_skip_seen_mutex = Mutex.create ()
@@ -211,7 +198,6 @@ let codex_keeper_bound_skip_should_emit ~label ~provider_label ~keeper_name ~rea
   if first then Hashtbl.replace codex_keeper_bound_skip_seen key now;
   Mutex.unlock codex_keeper_bound_skip_seen_mutex;
   first
-;;
 
 let codex_keeper_bound_skip_log_message ~label ~keeper_name provider_cfg reason =
   match reason with
@@ -224,7 +210,6 @@ let codex_keeper_bound_skip_log_message ~label ~keeper_name provider_cfg reason 
          keeper_name
          (filter_rejection_reason_label reason))
   | Tool_lane_unsupported | Required_tool_use _ -> None
-;;
 
 let log_codex_keeper_bound_skip ~label ~keeper_name provider_cfg reason =
   match codex_keeper_bound_skip_log_message ~label ~keeper_name provider_cfg reason with
@@ -244,7 +229,6 @@ let log_codex_keeper_bound_skip ~label ~keeper_name provider_cfg reason =
         message
         codex_keeper_bound_skip_restate_sec
     else Log.Misc.debug "%s" message
-;;
 
 let classify_filter_rejection
       ~(keeper_name : string)
@@ -295,7 +279,6 @@ let classify_filter_rejection
       with
       | Some reason -> Some (Required_tool_use reason)
       | None -> None))
-;;
 
 (* #11060: cascade-empty WARN dedupe.
 
@@ -329,7 +312,6 @@ let signature_of_rejected_providers rejected =
       (filter_rejection_reason_label reason))
   |> List.sort String.compare
   |> String.concat ","
-;;
 
 let cascade_empty_should_emit_first ~label ~signature =
   let key = label ^ "|" ^ signature in
@@ -343,7 +325,6 @@ let cascade_empty_should_emit_first ~label ~signature =
   if first then Hashtbl.replace cascade_empty_warn_seen key now;
   Mutex.unlock cascade_empty_warn_seen_mutex;
   first
-;;
 
 (** RFC-0027 PR-9b dual-track swap. When the tool-use gate rejects a
     primary provider and the caller supplied a [secondary_resolver],
@@ -423,7 +404,6 @@ let attempt_secondary_swap
               secondary_kind_label
               (filter_rejection_reason_label secondary_reason));
        Either.Right (primary, primary_reason))
-;;
 
 let filter_candidate_providers_for_tool_support
       ~(keeper_name : string)
@@ -518,7 +498,6 @@ let filter_candidate_providers_for_tool_support
           label
           signature);
     kept)
-;;
 
 (* Cross-cascade health-aware fallback.
    When the current cascade has no tool-capable providers after filtering,
@@ -611,4 +590,3 @@ let resolve_tool_capable_provider_across_cascades
       scored_candidates
     |> Option.map (fun (sp : Cascade_inventory.scored_provider) ->
       Keeper_cascade_profile.runtime_name_to_string sp.cascade_name, sp.provider)
-;;

--- a/lib/cascade/cascade_oas_runner.ml
+++ b/lib/cascade/cascade_oas_runner.ml
@@ -121,16 +121,23 @@ let codex_cli_cannot_carry_keeper_bound_runtime_mcp
     ~(keeper_name : string)
     ~(provider_cfg : Llm_provider.Provider_config.t)
     (policy_opt : Llm_provider.Llm_transport.runtime_mcp_policy option) =
-  match provider_cfg.kind, keeper_agent_name_opt keeper_name, policy_opt with
-  | Llm_provider.Provider_config.Codex_cli, Some agent_name, Some policy
-    when Option.is_some (Keeper_identity.keeper_name_from_agent_name agent_name)
-    ->
-      (not
-         (Cascade_runner.codex_cli_can_auth_keeper_bound_runtime_mcp
-            ~agent_name policy))
-      && List.exists Cascade_runner.runtime_mcp_tool_requires_bound_actor
-           policy.allowed_tool_names
-  | _ -> false
+  (* RFC-0058 §2.4: dispatch by adapter capability, not provider name. *)
+  if not
+       (Provider_adapter
+        .requires_per_keeper_bridging_for_bound_actor_tools_for_config
+          provider_cfg)
+  then false
+  else
+    match keeper_agent_name_opt keeper_name, policy_opt with
+    | Some agent_name, Some policy
+      when Option.is_some
+             (Keeper_identity.keeper_name_from_agent_name agent_name) ->
+        (not
+           (Cascade_runner.codex_cli_can_auth_keeper_bound_runtime_mcp
+              ~agent_name policy))
+        && List.exists Cascade_runner.runtime_mcp_tool_requires_bound_actor
+             policy.allowed_tool_names
+    | _ -> false
 
 (* #10681: per-provider rejection reason produced by the cascade filter.
    When the filter empties the cascade, operators previously saw only a

--- a/lib/cascade/cascade_oas_runner.ml
+++ b/lib/cascade/cascade_oas_runner.ml
@@ -9,68 +9,91 @@
 (* Cascade profile defaults (moved from Cascade module) *)
 
 let default_config_path = Cascade_runtime.cascade_config_path
+
 let default_model_strings ~cascade_name =
   Cascade_runtime.default_model_strings
     ~cascade_name:(Keeper_cascade_profile.Runtime_name cascade_name)
+;;
 
 (* Named model execution *)
 
 let require_eio ?sw ?net () =
-  let sw = match sw with Some s -> Some s | None -> Eio_context.get_switch_opt () in
-  let net = match net with Some n -> Some n | None -> Eio_context.get_net_opt () in
+  let sw =
+    match sw with
+    | Some s -> Some s
+    | None -> Eio_context.get_switch_opt ()
+  in
+  let net =
+    match net with
+    | Some n -> Some n
+    | None -> Eio_context.get_net_opt ()
+  in
   match sw, net with
   | Some sw, Some net -> Ok (sw, net)
   | None, _ -> Error "Eio switch not available (running outside server context)"
   | _, None -> Error "Eio net not available (running outside server context)"
+;;
 
 let eio_context_error_to_sdk_error detail =
-  Agent_sdk.Error.Config
-    (Agent_sdk.Error.InvalidConfig { field = "eio_context"; detail })
+  Agent_sdk.Error.Config (Agent_sdk.Error.InvalidConfig { field = "eio_context"; detail })
+;;
 
 let cascade_catalog_error_to_sdk_error detail =
   Agent_sdk.Error.Config
     (Agent_sdk.Error.InvalidConfig { field = "cascade_name"; detail })
+;;
 
 (** Resolve cascade provider configs via MASC Cascade_config.
     Returns Provider_config.t list for the downstream OAS runtime,
     bypassing the old Model_spec facade. *)
-let resolve_cascade_providers ?provider_filter
-    ?(require_tool_choice_support = false)
-    ?(require_tool_support = false)
+let resolve_cascade_providers
+      ?provider_filter
+      ?(require_tool_choice_support = false)
+      ?(require_tool_support = false)
+      ?runtime_mcp_policy
+      ~cascade_name
+      ()
+  =
+  Cascade_runtime.resolve_named_providers_result_strict
+    ?provider_filter
     ?runtime_mcp_policy
-    ~cascade_name () =
-  Cascade_runtime.resolve_named_providers_result_strict ?provider_filter
-    ?runtime_mcp_policy
-    ~require_tool_choice_support ~require_tool_support ~cascade_name ()
+    ~require_tool_choice_support
+    ~require_tool_support
+    ~cascade_name
+    ()
+;;
 
 (** Resolve from an explicit model string list (user-declared in keeper TOML).
     MASC parses the strings via its local [Cascade_config] and passes the
     resulting provider configs into OAS execution. *)
-let resolve_providers_from_model_strings ?provider_filter
-    ?(require_tool_choice_support = false)
-    ?(require_tool_support = false)
+let resolve_providers_from_model_strings
+      ?provider_filter
+      ?(require_tool_choice_support = false)
+      ?(require_tool_support = false)
+      ?runtime_mcp_policy
+      model_strings
+  =
+  Cascade_runtime.resolve_providers_from_model_strings
+    ?provider_filter
     ?runtime_mcp_policy
-    model_strings =
-  Cascade_runtime.resolve_providers_from_model_strings ?provider_filter
-    ?runtime_mcp_policy
-    ~require_tool_choice_support ~require_tool_support model_strings
+    ~require_tool_choice_support
+    ~require_tool_support
+    model_strings
+;;
 
 let keeper_agent_name_opt (keeper_name : string) =
   let keeper_name = String.trim keeper_name in
-  if keeper_name = "" then None
-  else Some (Keeper_types.keeper_agent_name keeper_name)
+  if keeper_name = "" then None else Some (Keeper_types.keeper_agent_name keeper_name)
+;;
 
-let runtime_mcp_policy_for_tools ~(keeper_name : string) (tools : Agent_sdk.Tool.t list)
-    =
+let runtime_mcp_policy_for_tools ~(keeper_name : string) (tools : Agent_sdk.Tool.t list) =
   let agent_name = keeper_agent_name_opt keeper_name in
   let runtime_tool_names =
     tools
     |> List.filter (fun (tool : Agent_sdk.Tool.t) ->
-           Tool_catalog.is_public_mcp tool.schema.name
-           ||
-           (Option.is_some agent_name
-            && Tool_catalog.is_on_surface Tool_catalog.Keeper_internal
-                 tool.schema.name))
+      Tool_catalog.is_public_mcp tool.schema.name
+      || (Option.is_some agent_name
+          && Tool_catalog.is_on_surface Tool_catalog.Keeper_internal tool.schema.name))
     |> List.map (fun (tool : Agent_sdk.Tool.t) -> tool.schema.name)
   in
   let has_keeper_internal =
@@ -79,65 +102,70 @@ let runtime_mcp_policy_for_tools ~(keeper_name : string) (tools : Agent_sdk.Tool
       runtime_tool_names
   in
   match
-    Cascade_runner.runtime_mcp_policy_of_tool_names
-      ?agent_name
-      ~allow_keeper_internal:has_keeper_internal runtime_tool_names,
-    agent_name
+    ( Cascade_runner.runtime_mcp_policy_of_tool_names
+        ?agent_name
+        ~allow_keeper_internal:has_keeper_internal
+        runtime_tool_names
+    , agent_name )
   with
   | Some policy, Some agent_name ->
-      Some
-        (Cascade_runner.runtime_mcp_policy_with_masc_agent_name
-           ~agent_name policy)
+    Some (Cascade_runner.runtime_mcp_policy_with_masc_agent_name ~agent_name policy)
   | Some policy, None -> Some policy
   | None, _ -> None
+;;
 
-let keeper_internal_tool_names_for_runtime_surface ~(keeper_name : string)
-    (tools : Agent_sdk.Tool.t list) =
+let keeper_internal_tool_names_for_runtime_surface
+      ~(keeper_name : string)
+      (tools : Agent_sdk.Tool.t list)
+  =
   match keeper_agent_name_opt keeper_name with
   | None -> []
   | Some _ ->
-      tools
-      |> List.filter (fun (tool : Agent_sdk.Tool.t) ->
-             Tool_catalog.is_on_surface Tool_catalog.Keeper_internal
-               tool.schema.name)
-      |> List.map (fun (tool : Agent_sdk.Tool.t) -> tool.schema.name)
-      |> List.sort_uniq String.compare
+    tools
+    |> List.filter (fun (tool : Agent_sdk.Tool.t) ->
+      Tool_catalog.is_on_surface Tool_catalog.Keeper_internal tool.schema.name)
+    |> List.map (fun (tool : Agent_sdk.Tool.t) -> tool.schema.name)
+    |> List.sort_uniq String.compare
+;;
 
 let keeper_internal_tools_require_materialized_runtime_surface
-    ~(keeper_name : string) (tools : Agent_sdk.Tool.t list) =
+      ~(keeper_name : string)
+      (tools : Agent_sdk.Tool.t list)
+  =
   keeper_internal_tool_names_for_runtime_surface ~keeper_name tools <> []
+;;
 
 let runtime_mcp_policy_for_provider
-    ~(keeper_name : string)
-    ~(provider_cfg : Llm_provider.Provider_config.t)
-    (policy_opt : Llm_provider.Llm_transport.runtime_mcp_policy option) =
-  let agent_name =
-    keeper_agent_name_opt keeper_name |> Option.value ~default:""
-  in
-  Cascade_runner.runtime_mcp_policy_for_provider
-    ~provider_cfg ~agent_name policy_opt
+      ~(keeper_name : string)
+      ~(provider_cfg : Llm_provider.Provider_config.t)
+      (policy_opt : Llm_provider.Llm_transport.runtime_mcp_policy option)
+  =
+  let agent_name = keeper_agent_name_opt keeper_name |> Option.value ~default:"" in
+  Cascade_runner.runtime_mcp_policy_for_provider ~provider_cfg ~agent_name policy_opt
+;;
 
 let codex_cli_cannot_carry_keeper_bound_runtime_mcp
-    ~(keeper_name : string)
-    ~(provider_cfg : Llm_provider.Provider_config.t)
-    (policy_opt : Llm_provider.Llm_transport.runtime_mcp_policy option) =
+      ~(keeper_name : string)
+      ~(provider_cfg : Llm_provider.Provider_config.t)
+      (policy_opt : Llm_provider.Llm_transport.runtime_mcp_policy option)
+  =
   (* RFC-0058 §2.4: dispatch by adapter capability, not provider name. *)
-  if not
-       (Provider_adapter
-        .requires_per_keeper_bridging_for_bound_actor_tools_for_config
-          provider_cfg)
+  if
+    not
+      (Provider_adapter.requires_per_keeper_bridging_for_bound_actor_tools_for_config
+         provider_cfg)
   then false
-  else
+  else (
     match keeper_agent_name_opt keeper_name, policy_opt with
     | Some agent_name, Some policy
-      when Option.is_some
-             (Keeper_identity.keeper_name_from_agent_name agent_name) ->
-        (not
-           (Cascade_runner.codex_cli_can_auth_keeper_bound_runtime_mcp
-              ~agent_name policy))
-        && List.exists Cascade_runner.runtime_mcp_tool_requires_bound_actor
-             policy.allowed_tool_names
-    | _ -> false
+      when Option.is_some (Keeper_identity.keeper_name_from_agent_name agent_name) ->
+      (not
+         (Cascade_runner.codex_cli_can_auth_keeper_bound_runtime_mcp ~agent_name policy))
+      && List.exists
+           Cascade_runner.runtime_mcp_tool_requires_bound_actor
+           policy.allowed_tool_names
+    | _ -> false)
+;;
 
 (* #10681: per-provider rejection reason produced by the cascade filter.
    When the filter empties the cascade, operators previously saw only a
@@ -164,21 +192,15 @@ type filter_rejection_reason =
 let filter_rejection_reason_label = function
   | Codex_keeper_bound_actor_required -> "codex_keeper_bound_actor_required"
   | Tool_lane_unsupported -> "tool_lane_unsupported"
-  | Required_tool_use r ->
-      Provider_tool_support.rejection_reason_label r
+  | Required_tool_use r -> Provider_tool_support.rejection_reason_label r
+;;
 
-let codex_keeper_bound_skip_seen : (string, float) Hashtbl.t =
-  Hashtbl.create 16
-
+let codex_keeper_bound_skip_seen : (string, float) Hashtbl.t = Hashtbl.create 16
 let codex_keeper_bound_skip_seen_mutex = Mutex.create ()
-
 let codex_keeper_bound_skip_restate_sec = 3600.0
 
-let codex_keeper_bound_skip_should_emit ~label ~provider_label ~keeper_name
-    ~reason_label =
-  let key =
-    Printf.sprintf "%s|%s|%s|%s" label provider_label keeper_name reason_label
-  in
+let codex_keeper_bound_skip_should_emit ~label ~provider_label ~keeper_name ~reason_label =
+  let key = Printf.sprintf "%s|%s|%s|%s" label provider_label keeper_name reason_label in
   let now = Unix.gettimeofday () in
   Mutex.lock codex_keeper_bound_skip_seen_mutex;
   let first =
@@ -189,80 +211,91 @@ let codex_keeper_bound_skip_should_emit ~label ~provider_label ~keeper_name
   if first then Hashtbl.replace codex_keeper_bound_skip_seen key now;
   Mutex.unlock codex_keeper_bound_skip_seen_mutex;
   first
+;;
 
-let codex_keeper_bound_skip_log_message
-    ~label ~keeper_name provider_cfg reason =
+let codex_keeper_bound_skip_log_message ~label ~keeper_name provider_cfg reason =
   match reason with
   | Codex_keeper_bound_actor_required ->
-      Some
-        (Printf.sprintf "cascade %s: skipped provider=%s for keeper=%s reason=%s"
-           label
-           (Provider_tool_support.provider_debug_label provider_cfg)
-           keeper_name
-           (filter_rejection_reason_label reason))
+    Some
+      (Printf.sprintf
+         "cascade %s: skipped provider=%s for keeper=%s reason=%s"
+         label
+         (Provider_tool_support.provider_debug_label provider_cfg)
+         keeper_name
+         (filter_rejection_reason_label reason))
   | Tool_lane_unsupported | Required_tool_use _ -> None
+;;
 
 let log_codex_keeper_bound_skip ~label ~keeper_name provider_cfg reason =
-  match
-    codex_keeper_bound_skip_log_message ~label ~keeper_name provider_cfg reason
-  with
+  match codex_keeper_bound_skip_log_message ~label ~keeper_name provider_cfg reason with
   | None -> ()
   | Some message ->
-      let provider_label =
-        Provider_tool_support.provider_debug_label provider_cfg
-      in
-      let reason_label = filter_rejection_reason_label reason in
-      if
-        codex_keeper_bound_skip_should_emit ~label ~provider_label ~keeper_name
-          ~reason_label
-      then
-        Log.Misc.info
-          "%s; repeated identical skip decisions demoted to DEBUG for the next %.0fs"
-          message codex_keeper_bound_skip_restate_sec
-      else Log.Misc.debug "%s" message
+    let provider_label = Provider_tool_support.provider_debug_label provider_cfg in
+    let reason_label = filter_rejection_reason_label reason in
+    if
+      codex_keeper_bound_skip_should_emit
+        ~label
+        ~provider_label
+        ~keeper_name
+        ~reason_label
+    then
+      Log.Misc.info
+        "%s; repeated identical skip decisions demoted to DEBUG for the next %.0fs"
+        message
+        codex_keeper_bound_skip_restate_sec
+    else Log.Misc.debug "%s" message
+;;
 
 let classify_filter_rejection
-    ~(keeper_name : string)
-    ?runtime_mcp_policy
-    ?(tools = [])
-    ~require_tool_choice_support
-    ~require_tool_support
-    (provider_cfg : Llm_provider.Provider_config.t)
-  : filter_rejection_reason option =
-  if codex_cli_cannot_carry_keeper_bound_runtime_mcp
-       ~keeper_name ~provider_cfg runtime_mcp_policy
+      ~(keeper_name : string)
+      ?runtime_mcp_policy
+      ?(tools = [])
+      ~require_tool_choice_support
+      ~require_tool_support
+      (provider_cfg : Llm_provider.Provider_config.t)
+  : filter_rejection_reason option
+  =
+  if
+    codex_cli_cannot_carry_keeper_bound_runtime_mcp
+      ~keeper_name
+      ~provider_cfg
+      runtime_mcp_policy
   then Some Codex_keeper_bound_actor_required
-  else
+  else (
     let normalized_runtime_mcp_policy =
-      runtime_mcp_policy_for_provider
-        ~keeper_name ~provider_cfg runtime_mcp_policy
+      runtime_mcp_policy_for_provider ~keeper_name ~provider_cfg runtime_mcp_policy
     in
     let tool_lane_supported =
       match tools with
       | [] -> true
-      | _ -> (
-          match
-            Cascade_runner.resolve_tool_lane_for_oas_tools
-              ?agent_name:(keeper_agent_name_opt keeper_name)
-              ~tool_requirement:
-                (if require_tool_choice_support || require_tool_support
-                 then `Required
-                 else `Optional)
-              ~provider_cfg ~tools ()
-          with
-          | Ok _ -> true
-          | Error _ -> false)
+      | _ ->
+        (match
+           Cascade_runner.resolve_tool_lane_for_oas_tools
+             ?agent_name:(keeper_agent_name_opt keeper_name)
+             ~tool_requirement:
+               (if require_tool_choice_support || require_tool_support
+                then `Required
+                else `Optional)
+             ~provider_cfg
+             ~tools
+             ()
+         with
+         | Ok _ -> true
+         | Error _ -> false)
     in
-    if not tool_lane_supported then Some Tool_lane_unsupported
-    else
+    if not tool_lane_supported
+    then Some Tool_lane_unsupported
+    else (
       match
         Provider_tool_support.classify_rejection
           ?runtime_mcp_policy:normalized_runtime_mcp_policy
-          ~require_tool_choice_support ~require_tool_support
+          ~require_tool_choice_support
+          ~require_tool_support
           provider_cfg
       with
       | Some reason -> Some (Required_tool_use reason)
-      | None -> None
+      | None -> None))
+;;
 
 (* #11060: cascade-empty WARN dedupe.
 
@@ -283,21 +316,20 @@ let classify_filter_rejection
    alert still sees the gap. The signature is sorted so the same
    rejection set in different argument order does not bypass the
    cache. *)
-let cascade_empty_warn_seen : (string, float) Hashtbl.t =
-  Hashtbl.create 16
-
+let cascade_empty_warn_seen : (string, float) Hashtbl.t = Hashtbl.create 16
 let cascade_empty_warn_seen_mutex = Mutex.create ()
-
 let cascade_empty_warn_restate_sec = 3600.0
 
 let signature_of_rejected_providers rejected =
   rejected
   |> List.map (fun (cfg, reason) ->
-       Printf.sprintf "%s:%s"
-         (Provider_tool_support.provider_debug_label cfg)
-         (filter_rejection_reason_label reason))
+    Printf.sprintf
+      "%s:%s"
+      (Provider_tool_support.provider_debug_label cfg)
+      (filter_rejection_reason_label reason))
   |> List.sort String.compare
   |> String.concat ","
+;;
 
 let cascade_empty_should_emit_first ~label ~signature =
   let key = label ^ "|" ^ signature in
@@ -311,6 +343,7 @@ let cascade_empty_should_emit_first ~label ~signature =
   if first then Hashtbl.replace cascade_empty_warn_seen key now;
   Mutex.unlock cascade_empty_warn_seen_mutex;
   first
+;;
 
 (** RFC-0027 PR-9b dual-track swap. When the tool-use gate rejects a
     primary provider and the caller supplied a [secondary_resolver],
@@ -327,20 +360,23 @@ let cascade_empty_should_emit_first ~label ~signature =
     The function is total and never raises; secondary parsing errors are
     surfaced as [None] by the resolver. *)
 let attempt_secondary_swap
-    ~keeper_name ?runtime_mcp_policy ~tools
-    ~require_tool_choice_support ~require_tool_support
-    ~(secondary_resolver :
-        int ->
-        Llm_provider.Provider_config.t ->
-        Llm_provider.Provider_config.t option)
-    ~(provider_index : int)
-    (primary, primary_reason)
-  : (Llm_provider.Provider_config.t,
-     Llm_provider.Provider_config.t * filter_rejection_reason) Either.t =
+      ~keeper_name
+      ?runtime_mcp_policy
+      ~tools
+      ~require_tool_choice_support
+      ~require_tool_support
+      ~(secondary_resolver :
+         int -> Llm_provider.Provider_config.t -> Llm_provider.Provider_config.t option)
+      ~(provider_index : int)
+      (primary, primary_reason)
+  : ( Llm_provider.Provider_config.t
+      , Llm_provider.Provider_config.t * filter_rejection_reason )
+      Either.t
+  =
   match secondary_resolver provider_index primary with
   | None -> Either.Right (primary, primary_reason)
-  | Some secondary -> (
-      (* RFC-0027 PR-9c: per-secondary accounting label.
+  | Some secondary ->
+    (* RFC-0027 PR-9c: per-secondary accounting label.
          The secondary's [provider_kind] is a closed enum from
          [Llm_provider.Provider_config.string_of_provider_kind] so
          label cardinality stays bounded (≤ kind count). This lets
@@ -353,22 +389,25 @@ let attempt_secondary_swap
          distinct bucket per concrete provider — so accounting
          already separates primary and secondary draws as a
          consequence of [provider_kind] differing. *)
-      let secondary_kind_label =
-        Llm_provider.Provider_config.string_of_provider_kind secondary.kind
-      in
-      match
-        classify_filter_rejection
-          ~keeper_name ?runtime_mcp_policy ~tools
-          ~require_tool_choice_support ~require_tool_support
-          secondary
-      with
-      | None ->
-          Llm_metric_bridge.emit_fallback_triggered
-            ~kind:"dual_track_swap"
-            ~detail:(Printf.sprintf "swapped:%s" secondary_kind_label);
-          Either.Left secondary
-      | Some secondary_reason ->
-          (* Both primary and secondary rejected: keep the primary in
+    let secondary_kind_label =
+      Llm_provider.Provider_config.string_of_provider_kind secondary.kind
+    in
+    (match
+       classify_filter_rejection
+         ~keeper_name
+         ?runtime_mcp_policy
+         ~tools
+         ~require_tool_choice_support
+         ~require_tool_support
+         secondary
+     with
+     | None ->
+       Llm_metric_bridge.emit_fallback_triggered
+         ~kind:"dual_track_swap"
+         ~detail:(Printf.sprintf "swapped:%s" secondary_kind_label);
+       Either.Left secondary
+     | Some secondary_reason ->
+       (* Both primary and secondary rejected: keep the primary in
              rejected so the cascade-empty WARN signature stays anchored
              on the user-declared model. The secondary's rejection is
              surfaced as a separate metric so operators can audit which
@@ -376,60 +415,69 @@ let attempt_secondary_swap
              rides on the rejection detail too, so the same
              [secondary_kind] series is queryable across swap success /
              swap failure outcomes. *)
-          Llm_metric_bridge.emit_fallback_triggered
-            ~kind:"dual_track_swap"
-            ~detail:(Printf.sprintf "rejected:%s:%s"
-                       secondary_kind_label
-                       (filter_rejection_reason_label secondary_reason));
-          Either.Right (primary, primary_reason))
+       Llm_metric_bridge.emit_fallback_triggered
+         ~kind:"dual_track_swap"
+         ~detail:
+           (Printf.sprintf
+              "rejected:%s:%s"
+              secondary_kind_label
+              (filter_rejection_reason_label secondary_reason));
+       Either.Right (primary, primary_reason))
+;;
 
 let filter_candidate_providers_for_tool_support
-    ~(keeper_name : string)
-    ?runtime_mcp_policy
-    ?(tools = [])
-    ~require_tool_choice_support
-    ~require_tool_support
-    ?secondary_resolver
-    ~label
-    (provider_cfgs : Llm_provider.Provider_config.t list) =
-  if not require_tool_choice_support && not require_tool_support then
-    provider_cfgs
-  else
+      ~(keeper_name : string)
+      ?runtime_mcp_policy
+      ?(tools = [])
+      ~require_tool_choice_support
+      ~require_tool_support
+      ?secondary_resolver
+      ~label
+      (provider_cfgs : Llm_provider.Provider_config.t list)
+  =
+  if (not require_tool_choice_support) && not require_tool_support
+  then provider_cfgs
+  else (
     let kept_rev, rejected_rev, _ =
       List.fold_left
         (fun (kept, rejected, provider_index) provider_cfg ->
            match
              classify_filter_rejection
-               ~keeper_name ?runtime_mcp_policy ~tools
-               ~require_tool_choice_support ~require_tool_support
+               ~keeper_name
+               ?runtime_mcp_policy
+               ~tools
+               ~require_tool_choice_support
+               ~require_tool_support
                provider_cfg
            with
-           | None -> (provider_cfg :: kept, rejected, provider_index + 1)
+           | None -> provider_cfg :: kept, rejected, provider_index + 1
            | Some reason ->
-               log_codex_keeper_bound_skip ~label ~keeper_name provider_cfg
-                 reason;
-               let swap =
-                 match secondary_resolver with
-                 | None -> Either.Right (provider_cfg, reason)
-                 | Some resolver ->
-                     attempt_secondary_swap
-                       ~keeper_name ?runtime_mcp_policy ~tools
-                       ~require_tool_choice_support ~require_tool_support
-                       ~secondary_resolver:resolver
-                       ~provider_index
-                       (provider_cfg, reason)
-               in
-               (match swap with
-                | Either.Left secondary ->
-                    (secondary :: kept, rejected, provider_index + 1)
-                | Either.Right rejected_provider ->
-                    (kept, rejected_provider :: rejected, provider_index + 1)))
+             log_codex_keeper_bound_skip ~label ~keeper_name provider_cfg reason;
+             let swap =
+               match secondary_resolver with
+               | None -> Either.Right (provider_cfg, reason)
+               | Some resolver ->
+                 attempt_secondary_swap
+                   ~keeper_name
+                   ?runtime_mcp_policy
+                   ~tools
+                   ~require_tool_choice_support
+                   ~require_tool_support
+                   ~secondary_resolver:resolver
+                   ~provider_index
+                   (provider_cfg, reason)
+             in
+             (match swap with
+              | Either.Left secondary -> secondary :: kept, rejected, provider_index + 1
+              | Either.Right rejected_provider ->
+                kept, rejected_provider :: rejected, provider_index + 1))
         ([], [], 0)
         provider_cfgs
     in
     let kept = List.rev kept_rev in
     let rejected = List.rev rejected_rev in
-    if kept = [] && provider_cfgs <> [] then begin
+    if kept = [] && provider_cfgs <> []
+    then (
       let signature = signature_of_rejected_providers rejected in
       (* Forward each rejection to the Prometheus capability_drop counter so
          operators can alert on cascade-empty silently dropping requests.
@@ -438,36 +486,39 @@ let filter_candidate_providers_for_tool_support
          which provider/reason combination drove the drop. *)
       List.iter
         (fun (provider_cfg, reason) ->
-          let reason_label = filter_rejection_reason_label reason in
-          Llm_metric_bridge.emit_capability_drop
-            ~model_id:provider_cfg.Llm_provider.Provider_config.model_id
-            ~field:(Printf.sprintf "cascade_empty:%s" reason_label);
-          (* §7.3.2 Zero Silent Failure: also feed the unified
+           let reason_label = filter_rejection_reason_label reason in
+           Llm_metric_bridge.emit_capability_drop
+             ~model_id:provider_cfg.Llm_provider.Provider_config.model_id
+             ~field:(Printf.sprintf "cascade_empty:%s" reason_label);
+           (* §7.3.2 Zero Silent Failure: also feed the unified
              fallback counter so the dashboard panel sees a single
              numerator across all fallback classes. *)
-          Llm_metric_bridge.emit_fallback_triggered
-            ~kind:"cascade_empty"
-            ~detail:reason_label)
+           Llm_metric_bridge.emit_fallback_triggered
+             ~kind:"cascade_empty"
+             ~detail:reason_label)
         rejected;
-      if cascade_empty_should_emit_first ~label ~signature then
+      if cascade_empty_should_emit_first ~label ~signature
+      then
         Log.Misc.error
-          "[#11060/#11356] cascade %s: provider-normalized tool-use gate \
-           removed all providers (rejections=[%s]) — operator action: add a \
-           runtime-MCP-capable fallback provider to this cascade in \
-           cascade.toml. Verified-capable providers: claude_code, kimi_cli, \
-           anthropic, glm, openrouter (any non-cli direct API). Note: \
-           gemini_cli and codex_cli reject request-scoped runtime MCP HTTP \
-           headers (gemini-cli upstream lacks --mcp-config flag; codex_cli \
-           strips most per-request headers) — they cannot satisfy this gate. \
-           Alternatively detach the keeper from this cascade. Subsequent \
-           identical-signature rejections demoted to DEBUG for the next %.0fs"
-          label signature cascade_empty_warn_restate_sec
+          "[#11060/#11356] cascade %s: provider-normalized tool-use gate removed all \
+           providers (rejections=[%s]) — operator action: add a runtime-MCP-capable \
+           fallback provider to this cascade in cascade.toml. Verified-capable \
+           providers: claude_code, kimi_cli, anthropic, glm, openrouter (any non-cli \
+           direct API). Note: gemini_cli and codex_cli reject request-scoped runtime MCP \
+           HTTP headers (gemini-cli upstream lacks --mcp-config flag; codex_cli strips \
+           most per-request headers) — they cannot satisfy this gate. Alternatively \
+           detach the keeper from this cascade. Subsequent identical-signature \
+           rejections demoted to DEBUG for the next %.0fs"
+          label
+          signature
+          cascade_empty_warn_restate_sec
       else
         Log.Misc.debug
           "[#11060] cascade %s: repeated all-providers-rejected (rejections=[%s])"
-          label signature
-    end;
-    kept
+          label
+          signature);
+    kept)
+;;
 
 (* Cross-cascade health-aware fallback.
    When the current cascade has no tool-capable providers after filtering,
@@ -478,68 +529,75 @@ let filter_candidate_providers_for_tool_support
    Depth: 1 level only (no cross-cascade-of-cross-cascade).
    Scope: excludes the current cascade to avoid revisiting. *)
 let resolve_tool_capable_provider_across_cascades
-    ~sw ~net
-    ~(keeper_name : string)
-    ?runtime_mcp_policy
-    ?(tools = [])
-    ~require_tool_choice_support
-    ~require_tool_support
-    ~(exclude_cascade : string)
-    () =
+      ~sw
+      ~net
+      ~(keeper_name : string)
+      ?runtime_mcp_policy
+      ?(tools = [])
+      ~require_tool_choice_support
+      ~require_tool_support
+      ~(exclude_cascade : string)
+      ()
+  =
   match Cascade_catalog_runtime.known_profile_names ~sw ~net () with
   | Error _ -> None
   | Ok all_names ->
-      let assignable_names =
-        Keeper_cascade_profile.keeper_catalog_names ()
-      in
-      let assignable_set =
-        List.fold_left (fun acc n -> n :: acc) [] assignable_names
-      in
-      let is_keeper_assignable name = List.mem name assignable_set in
-      let scored_candidates =
-        all_names
-        |> List.filter (fun name -> name <> exclude_cascade)
-        |> List.filter_map (fun cascade_name ->
-             match Cascade_catalog_runtime.resolve_named_providers ~sw ~net
-                     ~require_tool_choice_support ~require_tool_support
-                     ?runtime_mcp_policy
-                     ~cascade_name ()
-             with
-             | Error _ -> None
-             | Ok providers ->
-                 let secondary_resolver _provider_index primary =
-                   Cascade_catalog_runtime
-                   .resolve_secondary_provider_for_primary
-                     ~sw ~net ~cascade_name ~primary ()
-                 in
-                 let filtered =
-                   filter_candidate_providers_for_tool_support
-                     ~keeper_name ?runtime_mcp_policy ~tools
-                     ~require_tool_choice_support ~require_tool_support
-                     ~secondary_resolver
-                     ~label:cascade_name providers
-                 in
-                 match filtered with
-                 | [] -> None
-                 | _ -> Some (cascade_name, filtered))
-        |> List.concat_map (fun (cascade_name, providers) ->
-             let keeper_assignable = is_keeper_assignable cascade_name in
-             let inventory_cascade_name =
-               Keeper_cascade_profile.Runtime_name cascade_name
-             in
-             providers
-             |> List.map (fun (provider : Llm_provider.Provider_config.t) ->
-                  let score =
-                    Cascade_inventory.score_provider
-                      Cascade_health_tracker.global
-                      ~exclude:[]
-                      ~keeper_assignable
-                      provider
-                  in
-                  Cascade_inventory.
-                    { cascade_name = inventory_cascade_name; provider; score }))
-      in
-      (* The score_provider helper already collapses cooldown,
+    let assignable_names = Keeper_cascade_profile.keeper_catalog_names () in
+    let assignable_set = List.fold_left (fun acc n -> n :: acc) [] assignable_names in
+    let is_keeper_assignable name = List.mem name assignable_set in
+    let scored_candidates =
+      all_names
+      |> List.filter (fun name -> name <> exclude_cascade)
+      |> List.filter_map (fun cascade_name ->
+        match
+          Cascade_catalog_runtime.resolve_named_providers
+            ~sw
+            ~net
+            ~require_tool_choice_support
+            ~require_tool_support
+            ?runtime_mcp_policy
+            ~cascade_name
+            ()
+        with
+        | Error _ -> None
+        | Ok providers ->
+          let secondary_resolver _provider_index primary =
+            Cascade_catalog_runtime.resolve_secondary_provider_for_primary
+              ~sw
+              ~net
+              ~cascade_name
+              ~primary
+              ()
+          in
+          let filtered =
+            filter_candidate_providers_for_tool_support
+              ~keeper_name
+              ?runtime_mcp_policy
+              ~tools
+              ~require_tool_choice_support
+              ~require_tool_support
+              ~secondary_resolver
+              ~label:cascade_name
+              providers
+          in
+          (match filtered with
+           | [] -> None
+           | _ -> Some (cascade_name, filtered)))
+      |> List.concat_map (fun (cascade_name, providers) ->
+        let keeper_assignable = is_keeper_assignable cascade_name in
+        let inventory_cascade_name = Keeper_cascade_profile.Runtime_name cascade_name in
+        providers
+        |> List.map (fun (provider : Llm_provider.Provider_config.t) ->
+          let score =
+            Cascade_inventory.score_provider
+              Cascade_health_tracker.global
+              ~exclude:[]
+              ~keeper_assignable
+              provider
+          in
+          Cascade_inventory.{ cascade_name = inventory_cascade_name; provider; score }))
+    in
+    (* The score_provider helper already collapses cooldown,
          keeper_assignable, and the success × latency composition into a
          single [0.0–1.0] number; best_runner_among picks the strict
          positive max with deterministic tie-break.  This replaces the
@@ -547,10 +605,10 @@ let resolve_tool_capable_provider_across_cascades
          slow-but-alive providers indistinguishable from fast ones, and
          did not exclude non-keeper-assignable cascades like
          [governance_judge] from a regular keeper's fallback pool). *)
-      Cascade_inventory.best_runner_among
-        ~health:Cascade_health_tracker.global
-        ~exclude:[]
-        scored_candidates
-      |> Option.map (fun (sp : Cascade_inventory.scored_provider) ->
-           ( Keeper_cascade_profile.runtime_name_to_string sp.cascade_name,
-             sp.provider ))
+    Cascade_inventory.best_runner_among
+      ~health:Cascade_health_tracker.global
+      ~exclude:[]
+      scored_candidates
+    |> Option.map (fun (sp : Cascade_inventory.scored_provider) ->
+      Keeper_cascade_profile.runtime_name_to_string sp.cascade_name, sp.provider)
+;;

--- a/lib/provider_adapter.ml
+++ b/lib/provider_adapter.ml
@@ -150,8 +150,10 @@ let runtime_mcp_http_headers =
   }
 (* Codex CLI quirk: its cached login cannot natively inject per-keeper auth
    headers, so any runtime MCP policy that uses bound-actor tools requires
-   per-keeper bridging via [Cascade_runner.codex_cli_can_auth_keeper_bound_runtime_mcp].
-   The cascade filter relies on this flag to gate codex_cli entries. *)
+   per-keeper bridging at the cascade layer. The
+   [Cascade_runner.codex_cli_can_auth_keeper_bound_runtime_mcp] predicate is
+   what the cascade filter consults to decide whether such bridging is in
+   place for a given keeper before admitting codex_cli for runtime MCP. *)
 let codex_cli_tool_policy =
   { supports_runtime_mcp_http_headers = false;
     requires_per_keeper_bridging_for_bound_actor_tools = true;

--- a/lib/provider_adapter.ml
+++ b/lib/provider_adapter.ml
@@ -44,6 +44,7 @@ type model_policy = {
 
 type tool_policy = {
   supports_runtime_mcp_http_headers : bool;
+  requires_per_keeper_bridging_for_bound_actor_tools : bool;
 }
 
 type telemetry_policy = {
@@ -139,8 +140,22 @@ let csv_items raw =
   |> List.map String.trim
   |> List.filter (fun s -> s <> "")
 
-let no_tool_http_headers = { supports_runtime_mcp_http_headers = false }
-let runtime_mcp_http_headers = { supports_runtime_mcp_http_headers = true }
+let no_tool_http_headers =
+  { supports_runtime_mcp_http_headers = false;
+    requires_per_keeper_bridging_for_bound_actor_tools = false;
+  }
+let runtime_mcp_http_headers =
+  { supports_runtime_mcp_http_headers = true;
+    requires_per_keeper_bridging_for_bound_actor_tools = false;
+  }
+(* Codex CLI quirk: its cached login cannot natively inject per-keeper auth
+   headers, so any runtime MCP policy that uses bound-actor tools requires
+   per-keeper bridging via [Cascade_runner.codex_cli_can_auth_keeper_bound_runtime_mcp].
+   The cascade filter relies on this flag to gate codex_cli entries. *)
+let codex_cli_tool_policy =
+  { supports_runtime_mcp_http_headers = false;
+    requires_per_keeper_bridging_for_bound_actor_tools = true;
+  }
 let telemetry_reported = { usage_reporting = Reported; runtime_reporting = Reported }
 let telemetry_unknown = { usage_reporting = Unknown; runtime_reporting = Unknown }
 let telemetry_usage_missing =
@@ -375,7 +390,7 @@ let direct_adapters =
           expand_auto = true;
           family = Generic;
         };
-      tool_policy = no_tool_http_headers;
+      tool_policy = codex_cli_tool_policy;
       telemetry_policy = telemetry_usage_missing_runtime_reported;
     };
     {
@@ -1495,6 +1510,13 @@ let supports_runtime_mcp_http_headers_for_config
     (cfg : Llm_provider.Provider_config.t) =
   match adapter_of_provider_config cfg with
   | Some adapter -> adapter.tool_policy.supports_runtime_mcp_http_headers
+  | None -> false
+
+let requires_per_keeper_bridging_for_bound_actor_tools_for_config
+    (cfg : Llm_provider.Provider_config.t) =
+  match adapter_of_provider_config cfg with
+  | Some adapter ->
+      adapter.tool_policy.requires_per_keeper_bridging_for_bound_actor_tools
   | None -> false
 
 (* ── Generic provider auth detail ─────────────────────────────── *)

--- a/lib/provider_adapter.mli
+++ b/lib/provider_adapter.mli
@@ -61,7 +61,7 @@ type tool_policy = {
           filter must reject the policy for this provider.
 
           Codex CLI is currently the only adapter that sets this to [true]:
-          it cached login does not allow per-keeper authorization headers
+          its cached login does not allow per-keeper authorization headers
           to be injected on each request without bridging. *)
 }
 

--- a/lib/provider_adapter.mli
+++ b/lib/provider_adapter.mli
@@ -54,6 +54,15 @@ type model_policy = {
 
 type tool_policy = {
   supports_runtime_mcp_http_headers : bool;
+  requires_per_keeper_bridging_for_bound_actor_tools : bool;
+      (** When true, this provider's runtime cannot inject per-keeper auth
+          headers natively. Bound-actor runtime MCP tools therefore require
+          explicit per-keeper bridging at the cascade layer; otherwise the
+          filter must reject the policy for this provider.
+
+          Codex CLI is currently the only adapter that sets this to [true]:
+          it cached login does not allow per-keeper authorization headers
+          to be injected on each request without bridging. *)
 }
 
 type telemetry_policy = {
@@ -392,6 +401,14 @@ val model_label_of_config :
 
 (** Whether the resolved adapter declares runtime MCP HTTP header support. *)
 val supports_runtime_mcp_http_headers_for_config :
+  Llm_provider.Provider_config.t -> bool
+
+(** Whether the resolved adapter requires explicit per-keeper bridging in
+    order to carry a runtime MCP policy that uses bound-actor tools.
+
+    Currently only [codex_cli] returns [true]; the cascade filter uses this
+    flag to gate entries without dispatching on provider name. *)
+val requires_per_keeper_bridging_for_bound_actor_tools_for_config :
   Llm_provider.Provider_config.t -> bool
 
 (** {1 Misc} *)


### PR DESCRIPTION
## Why

RFC-0058 §2.4 — eliminate `match Llm_provider.Provider_config.provider_kind with` in `cascade_oas_runner.ml:125`. Single dispatch site, 3-tuple match `(Codex_cli, Some agent_name, Some policy)`.

Plan: `/Users/dancer/.claude/plans/glimmering-strolling-corbato.md` Batch B2 PR-E.

## What changed

Option (a) — adapter capability lookup (preferred over string-prefix dispatch).

- `lib/provider_adapter.{ml,mli}`: extend `tool_policy` record with `requires_per_keeper_bridging_for_bound_actor_tools : bool`. Default `false` for the two existing constants (`no_tool_http_headers`, `runtime_mcp_http_headers`). New `codex_cli_tool_policy` constant (only codex entry uses it) sets `true`. Public helper `requires_per_keeper_bridging_for_bound_actor_tools_for_config` mirrors the existing `supports_runtime_mcp_http_headers_for_config` shape.
- `lib/cascade/cascade_oas_runner.ml`: `codex_cli_cannot_carry_keeper_bound_runtime_mcp` now early-exits on the capability check, then keeps the unchanged keeper-name + policy presence check. No behavioral change for any other adapter (all default `false`).

### Why option (a), not (b)

The original predicate's *meaning* is "this runtime cannot inject per-keeper auth headers natively", not "the provider name happens to be codex". String-prefix dispatch (`provider_label_of_config |> String.equal "codex_cli"`) would replace one anti-pattern with another (Workaround Rejection Bar §2: string/substring classifier). Capability field makes the property a first-class adapter row attribute — additional providers with the same quirk become a one-line entry change instead of an enum expansion.

The `tool_policy` record is the natural home: it already carries `supports_runtime_mcp_http_headers`, which is the same shape of "what auth/transport tricks does this runtime support".

## Verification

- `opam exec -- dune build --root . @check` — clean
- `test_per_keeper_token_fallback`: 5/5 pass (covers `codex_cli_can_auth_keeper_bound_runtime_mcp`)
- `test_provider_adapter`: 36/36 pass
- Pre-existing main failures unchanged: `test_filter_rejection_10474` (1 fail, also on `origin/main` 26a84cad5), `test_oas_worker` resume_config 26/35/40/48 (also on main). Confirmed by running same tests against unmodified main worktree.

## Out of scope

- `provider_kind` variant type itself (B4 scope).
- Other dispatch files (provider_tool_support, cascade_error_classify, keeper_usage_trust, cascade_transport, dashboard_provider_runs) untouched.
- ocamlformat (advisory; not run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)