### PR TITLE
refactor(provider): closed-variant dispatch in cascade_error_classify + keeper_usage_trust (RFC-0058 Phase 5.1)

### DIFF
--- a/lib/cascade/cascade_error_classify.ml
+++ b/lib/cascade/cascade_error_classify.ml
@@ -673,8 +673,19 @@ let codex_cli_prompt_bytes_to_token_limit ~prompt_bytes ~prompt_tokens =
 
 let codex_cli_prompt_preflight ~(config : Cascade_runner.config) ~(goal : string)
     : codex_cli_prompt_preflight option =
-  match config.provider_cfg.kind with
-  | Llm_provider.Provider_config.Codex_cli ->
+  (* RFC-0058 §2.4 — dispatch by adapter capability flag
+     ([tool_policy.argv_prompt_preflight]), never by provider variant.
+     argv/context-window preflight currently applies only to the
+     [codex exec] subprocess transport (single-argv-vector prompt).
+     Adding a new vendor that needs the same preflight is now a TOML/
+     adapter registry change, not a code change here. *)
+  let requires_preflight =
+    match Provider_adapter.adapter_of_provider_config config.provider_cfg with
+    | Some adapter -> adapter.tool_policy.argv_prompt_preflight
+    | None -> false
+  in
+  if not requires_preflight then None
+  else
     let messages =
       Agent_sdk.Agent_turn.prepare_messages
         ~messages:(config.initial_messages @ [ Agent_sdk.Types.user_msg goal ])
@@ -736,16 +747,6 @@ let codex_cli_prompt_preflight ~(config : Cascade_runner.config) ~(goal : string
           hits_argv_limit;
           hits_context_window;
         }
-  (* Other provider kinds: argv-limit + context-window preflight only
-     applies to the [codex exec] subprocess transport (it serialises the
-     full prompt onto a single argv vector).  Other transports either
-     stream over HTTP (no argv limit) or have their own preflight in
-     their adapter — return [None] here so the caller skips preflight
-     wrapping.  Enumerated explicitly so adding a new
-     [Llm_provider.Provider_config.provider_kind] forces a decision on
-     whether it needs codex-style prompt preflight. *)
-  | Anthropic | Kimi | OpenAI_compat | Ollama | Gemini | Glm
-  | DashScope | Claude_code | Gemini_cli | Kimi_cli -> None
 
 let codex_cli_preflight_error ~(scope : string)
     ~(provider_cfg : Llm_provider.Provider_config.t)

--- a/lib/keeper/keeper_usage_trust.ml
+++ b/lib/keeper/keeper_usage_trust.ml
@@ -26,13 +26,15 @@ let absurd_token_threshold = 1_000_000
    prompts running 5K-30K tokens. *)
 let anthropic_cache_min_input_tokens = 1024
 
+(* RFC-0058 §2.4 — dispatch by adapter capability flag
+   ([tool_policy.uses_anthropic_caching]), never by provider variant.
+   Adding a new vendor whose wire format supports Anthropic-style
+   prompt caching is now a registry/TOML change, not a code change here. *)
 let provider_kind_uses_anthropic_caching
     (kind : Llm_provider.Provider_config.provider_kind) : bool =
-  match kind with
-  | Anthropic | Claude_code -> true
-  | OpenAI_compat | Ollama | Gemini | Gemini_cli | Kimi | Kimi_cli | Glm
-  | Codex_cli | DashScope ->
-      false
+  match Provider_adapter.adapter_of_provider_kind kind with
+  | Some adapter -> adapter.tool_policy.uses_anthropic_caching
+  | None -> false
 
 let model_label_provider_kind label =
   Provider_kind_resolver.kind_of_spec label

--- a/lib/provider_adapter.ml
+++ b/lib/provider_adapter.ml
@@ -46,6 +46,8 @@ type tool_policy = {
   supports_runtime_mcp_http_headers : bool;
   requires_per_keeper_bridging_for_bound_actor_tools : bool;
   identity_runtime_mcp_header_keys : string list;
+  argv_prompt_preflight : bool;
+  uses_anthropic_caching : bool;
 }
 
 type telemetry_policy = {
@@ -142,15 +144,23 @@ let csv_items raw =
   |> List.filter (fun s -> s <> "")
 
 let no_tool_http_headers =
-  { supports_runtime_mcp_http_headers = false;
+  {
+    supports_runtime_mcp_http_headers = false;
     requires_per_keeper_bridging_for_bound_actor_tools = false;
     identity_runtime_mcp_header_keys = [];
+    argv_prompt_preflight = false;
+    uses_anthropic_caching = false;
   }
+
 let runtime_mcp_http_headers =
-  { supports_runtime_mcp_http_headers = true;
+  {
+    supports_runtime_mcp_http_headers = true;
     requires_per_keeper_bridging_for_bound_actor_tools = false;
     identity_runtime_mcp_header_keys = [];
+    argv_prompt_preflight = false;
+    uses_anthropic_caching = false;
   }
+
 (* Codex CLI quirk: its cached login cannot natively inject per-keeper auth
    headers, so any runtime MCP policy that uses bound-actor tools requires
    per-keeper bridging at the cascade layer. The
@@ -164,10 +174,13 @@ let runtime_mcp_http_headers =
    [identity_runtime_mcp_header_keys] enumerates the keys accepted via this
    carve-out even with [supports_runtime_mcp_http_headers = false]. *)
 let codex_cli_tool_policy =
-  { supports_runtime_mcp_http_headers = false;
+  {
+    supports_runtime_mcp_http_headers = false;
     requires_per_keeper_bridging_for_bound_actor_tools = true;
     identity_runtime_mcp_header_keys =
       [ "authorization"; "x-masc-agent-name"; "x-masc-keeper-name" ];
+    argv_prompt_preflight = true;
+    uses_anthropic_caching = false;
   }
 let telemetry_reported = { usage_reporting = Reported; runtime_reporting = Reported }
 let telemetry_unknown = { usage_reporting = Unknown; runtime_reporting = Unknown }
@@ -368,7 +381,8 @@ let direct_adapters =
           expand_auto = true;
           family = Generic;
         };
-      tool_policy = runtime_mcp_http_headers;
+      tool_policy =
+        { runtime_mcp_http_headers with uses_anthropic_caching = true };
       telemetry_policy = telemetry_usage_missing_runtime_reported;
     };
     {
@@ -495,7 +509,8 @@ let direct_adapters =
           expand_auto = false;
           family = Generic;
         };
-      tool_policy = no_tool_http_headers;
+      tool_policy =
+        { no_tool_http_headers with uses_anthropic_caching = true };
       telemetry_policy = telemetry_reported;
     };
     {
@@ -1493,6 +1508,18 @@ let adapter_of_provider_config (cfg : Llm_provider.Provider_config.t) =
   | Glm
   | OpenAI_compat ->
       resolve_adapter_by_cascade_prefix (provider_label_from_registry cfg)
+
+(* RFC-0058 §2.4 boundary: callers with only the typed [provider_kind]
+   (no full provider config) resolve to an adapter through the same
+   registry lookup as [adapter_of_provider_config]. Returns [None] for
+   kinds that need a [cascade_prefix] string to disambiguate (Glm /
+   OpenAI_compat) — those callers must use [adapter_of_provider_config]
+   or a label-based resolver instead. *)
+let adapter_of_provider_kind
+    (kind : Llm_provider.Provider_config.provider_kind) =
+  match kind with
+  | Glm | OpenAI_compat -> None
+  | _ -> resolve_direct_adapter (adapter_canonical_name_of_provider_kind kind)
 
 let provider_label_of_config (cfg : Llm_provider.Provider_config.t) =
   match adapter_of_provider_config cfg with

--- a/lib/provider_adapter.mli
+++ b/lib/provider_adapter.mli
@@ -70,6 +70,19 @@ type tool_policy = {
           [bearer_token_env_var]) plus the non-secret MASC identity
           headers ([x-masc-agent-name], [x-masc-keeper-name]).
           Keys are matched case-insensitively after trimming. *)
+  argv_prompt_preflight : bool;
+      (** When true, callers must run a prompt argv/context-window preflight
+          before spawning a turn (the runtime serialises the full prompt on
+          a single argv vector and rejects oversize input). Codex CLI's
+          [codex exec] subprocess transport is the canonical case.
+          RFC-0058 §2.4: capability flag, not a vendor match. *)
+  uses_anthropic_caching : bool;
+      (** When true, the provider's wire format supports Anthropic-style
+          prompt caching via [cache_control] blocks, so usage telemetry
+          should report [cache_creation_input_tokens] /
+          [cache_read_input_tokens] above the cacheable input threshold.
+          Used by [Keeper_usage_trust] to flag caching-likely-disabled
+          anomalies. RFC-0058 §2.4: capability flag, not a vendor match. *)
 }
 
 type telemetry_policy = {
@@ -382,6 +395,12 @@ val gemini_vertex_openai_base_url : project:string -> location:string -> string
 (** Resolve the concrete provider adapter for a provider config. *)
 val adapter_of_provider_config :
   Llm_provider.Provider_config.t -> adapter option
+
+(** Resolve the concrete provider adapter for an OAS [provider_kind].
+    Used by call sites that only have the typed kind (no full config)
+    and need adapter-level capability flags. RFC-0058 §2.4 boundary. *)
+val adapter_of_provider_kind :
+  Llm_provider.Provider_config.provider_kind -> adapter option
 
 (** Stable provider label/cascade prefix for a provider config. *)
 val provider_label_of_config :


### PR DESCRIPTION
## Why

RFC-0058 §2.4 — eliminate `match Llm_provider.Provider_config.provider_kind with` patterns in masc-mcp consumer code. Two small sites:

- `lib/cascade/cascade_error_classify.ml:677` (Codex prompt argv/context-window preflight entry)
- `lib/keeper/keeper_usage_trust.ml:30` (telemetry trust predicate for Anthropic-style prompt caching)

Plan: `~/.claude/plans/glimmering-strolling-corbato.md` Batch B2 PR-D.

## What changed

**Adapter registry (`lib/provider_adapter.ml` + `.mli`)**

- `tool_policy` record extended with two boolean capability fields:
  - `argv_prompt_preflight` — runtime serialises the full prompt on a single argv vector (Codex CLI `codex exec`).
  - `uses_anthropic_caching` — wire format supports Anthropic `cache_control` prompt caching.
- Both default to `false` via the named templates (`no_tool_http_headers`, `runtime_mcp_http_headers`). Three adapters override per-entry:
  - `cn_codex` → `argv_prompt_preflight = true`
  - `cn_claude` → `uses_anthropic_caching = true`
  - `cn_claude_api` → `uses_anthropic_caching = true`
- New helper `adapter_of_provider_kind : provider_kind -> adapter option` for consumers that only have the typed kind (returns `None` for `Glm` / `OpenAI_compat` which need a cascade-prefix string to disambiguate).

**Consumer dispatch sites**

- `cascade_error_classify.ml`: replaced `match config.provider_cfg.kind with | Codex_cli -> ... | _ -> None` with a single `adapter_of_provider_config` lookup checking the new flag.
- `keeper_usage_trust.ml`: replaced `match kind with | Anthropic | Claude_code -> true | ... -> false` with `adapter_of_provider_kind` lookup.

## OAS boundary

`Llm_provider.Provider_config.provider_kind` is OAS-owned. masc-mcp's match patterns are downstream — this PR only removes them on the consumer side. The type definition itself stays in OAS upstream (B4 territory).

## Verification

- `dune build --root . @check` clean.
- Relevant tests pass:
  - `test_keeper_usage_trust_anthropic_cache_9959` (9 tests)
  - `test_keeper_usage_trust_counter` (5 tests)
  - `test_keeper_hooks_oas_pricing` (13 tests)
  - `test_oas_worker` codex preflight subtests (`resume_config` 20/21/22)
- 4 pre-existing `Eio` cancel-context failures in `test_oas_worker` are unrelated to this change (no test code or Eio path touched).

## RFC-0058 §7.2 note

The RFC's Open Question §7.2 asks whether Codex's argv preflight should live as a TOML `[providers.<p>.preflight]` policy. This PR is a half-step: the policy is now a typed adapter flag in the OCaml registry (single source of truth, no code change at consumer sites for new vendors). The TOML migration can happen as a follow-up that swaps the registry literals for a parser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)