### PR TITLE
chore(dashboard): RFC-0058 §9.3 FE cleanup — drop dead JSON-authoring surface (rescue of stranded #14592 commit)

### DIFF
--- a/dashboard/src/api/dashboard-cascade.ts
+++ b/dashboard/src/api/dashboard-cascade.ts
@@ -62,8 +62,6 @@ export type CascadeValidationStatus =
 
 export interface CascadeConfigResponse {
   updated_at: string
-  config_path: string | null
-  source_kind: 'json' | 'toml'
   source_path: string
   validation_status: CascadeValidationStatus
   validation_errors: string[]
@@ -74,20 +72,9 @@ export interface CascadeConfigResponse {
 
 export interface CascadeRawConfigResponse {
   updated_at: string
-  config_path: string | null
-  source_kind: 'json' | 'toml'
   source_path: string
   source_editable: boolean
   source_text: string
-  raw_json_editable: boolean
-  raw_json: string
-  /** Surfaced when ensure_materialized_json fails (cascade.toml parse
-   *  error / IO error / unknown field).  Non-null means [raw_json]
-   *  may be a stale snapshot; the latest source_text edit was rejected
-   *  by the strict-field validator.  Backend always emits the field
-   *  (null on success) — frontend may treat undefined as null for
-   *  forward compat. */
-  materialization_error?: string | null
 }
 
 /** Operational state reported next to [provider_key] on the dashboard.

--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -2235,12 +2235,6 @@ function normalizeKeeperConfig(raw: unknown, requestedName: string): KeeperConfi
         normalizeCascadeCatalogSourceKind(sources.cascade_catalog_source_kind),
       cascade_catalog_source_path:
         asNullableString(sources.cascade_catalog_source_path),
-      cascade_runtime_json_path:
-        asNullableString(sources.cascade_runtime_json_path),
-      cascade_runtime_json_editable:
-        typeof sources.cascade_runtime_json_editable === 'boolean'
-          ? sources.cascade_runtime_json_editable
-          : asLooseBoolean(sources.cascade_runtime_json_editable),
     },
     metrics: {
       generation: asInt(metrics.generation) ?? 0,

--- a/dashboard/src/components/cascade-config-panel.ts
+++ b/dashboard/src/components/cascade-config-panel.ts
@@ -114,13 +114,8 @@ function sourceTone(source: CascadeProfile['source']): string {
 }
 
 function catalogSourceSummary(config: CascadeConfigResponse): string {
-  if (config.source_kind === 'toml') {
-    const sourcePath = config.source_path ?? 'cascade.toml'
-    const jsonPath = config.config_path ?? 'cascade.json'
-    return `SSOT: ${sourcePath} → generated ${jsonPath}`
-  }
-  const path = config.source_path ?? config.config_path ?? 'config 없음'
-  return `SSOT: ${path} (direct runtime edit)`
+  const sourcePath = config.source_path ?? 'cascade.toml'
+  return `SSOT: ${sourcePath}`
 }
 
 interface RawConfigModeSummary {
@@ -128,38 +123,23 @@ interface RawConfigModeSummary {
   primary: string
   secondary: string
   saveLabel: string
-  previewTitle: string | null
 }
 
 function rawConfigModeSummary(
   raw: Pick<
     CascadeRawConfigResponse,
-    'source_kind' | 'source_path' | 'config_path'
+    'source_path'
   > | null,
 ): RawConfigModeSummary {
-  const sourcePath = raw?.source_path ?? raw?.config_path ?? 'unresolved'
-  const jsonPath = raw?.config_path ?? 'unresolved'
-  if (raw?.source_kind !== 'toml') {
-    return {
-      title: 'Active Cascade Source Editor',
-      primary:
-        `dashboard에서 직접 ${sourcePath} 를 수정합니다. 저장 경로는 ${jsonPath} 이고, ` +
-        '저장 후 current cascade snapshot 을 다시 읽습니다.',
-      secondary:
-        'semantics invalid profile 도 저장은 허용됩니다. 저장 후 위의 validation banner 에서 invalid/last-known-good 상태를 바로 확인하면 됩니다.',
-      saveLabel: 'Save cascade.json',
-      previewTitle: null,
-    }
-  }
+  const sourcePath = raw?.source_path ?? 'cascade.toml'
   return {
     title: 'Active Cascade Source Editor (TOML SSOT)',
     primary:
       `현재 active source는 ${sourcePath} 이고, 이 editor에서 직접 cascade.toml SSOT 를 수정합니다. ` +
-      '저장 시 TOML parse 검증 뒤 generated runtime JSON을 다시 materialize 합니다.',
+      '저장 시 TOML parse 검증 뒤 cascade snapshot 을 다시 읽습니다.',
     secondary:
-      `아래 preview는 ${jsonPath} 에 기록되는 generated cascade.json runtime artifact 입니다.`,
+      'semantics invalid profile 도 저장은 허용됩니다. 저장 후 위의 validation banner 에서 invalid/last-known-good 상태를 바로 확인하면 됩니다.',
     saveLabel: 'cascade.toml 저장',
-    previewTitle: '생성된 cascade.json 미리보기',
   }
 }
 
@@ -205,12 +185,10 @@ function availableKeeperAssignments(
 }
 
 function validateSourceConfigText(
-  raw: Pick<CascadeRawConfigResponse, 'source_kind'> | null,
-  sourceText: string,
+  _raw: unknown,
+  _sourceText: string,
 ): string | null {
-  if (!raw) return null
-  if (raw?.source_kind === 'toml') return null
-  return validateJsonText(sourceText)
+  return null
 }
 
 function validationTone(status: CascadeValidationStatus): 'ok' | 'warn' | 'bad' {
@@ -1037,15 +1015,6 @@ function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error)
 }
 
-function validateJsonText(raw: string): string | null {
-  try {
-    JSON.parse(raw)
-    return null
-  } catch (error) {
-    return errorMessage(error)
-  }
-}
-
 function CascadeRawConfigEditor({
   raw,
   onRefresh,
@@ -1053,7 +1022,7 @@ function CascadeRawConfigEditor({
   raw: CascadeRawConfigResponse | null
   onRefresh: () => Promise<void>
 }) {
-  const editorText = useSignal(raw?.source_text ?? raw?.raw_json ?? '')
+  const editorText = useSignal(raw?.source_text ?? '')
   const editorDirty = useSignal(false)
   const saving = useSignal(false)
   const saveMessage = useSignal<string | null>(null)
@@ -1063,17 +1032,16 @@ function CascadeRawConfigEditor({
   useEffect(() => {
     if (!raw || editorDirty.value) return
     editorText.value = raw.source_text
-  }, [raw?.config_path, raw?.updated_at, raw?.source_path, raw?.source_text])
+  }, [raw?.updated_at, raw?.source_path, raw?.source_text])
 
   const syntaxError = validateSourceConfigText(raw, editorText.value)
   const saveDisabled = saving.value
     || !editorDirty.value
     || !sourceEditable
-    || raw?.config_path == null
     || syntaxError != null
 
   const handleReset = () => {
-    editorText.value = raw?.source_text ?? raw?.raw_json ?? ''
+    editorText.value = raw?.source_text ?? ''
     editorDirty.value = false
     saveMessage.value = 'Latest source snapshot restored in the editor.'
   }
@@ -1082,15 +1050,12 @@ function CascadeRawConfigEditor({
     event.preventDefault()
     const currentSyntaxError = validateSourceConfigText(raw, editorText.value)
     if (currentSyntaxError) {
-      saveMessage.value = `Invalid JSON: ${currentSyntaxError}`
+      saveMessage.value = `Invalid TOML: ${currentSyntaxError}`
       return
     }
-    if (raw?.config_path == null) {
-      saveMessage.value = 'Resolved cascade config path is unavailable.'
-      return
-    }
+
     if (!sourceEditable) {
-      saveMessage.value = `Active source is not editable: ${raw?.source_path ?? raw?.config_path ?? 'unresolved'}`
+      saveMessage.value = `Active source is not editable: ${raw?.source_path ?? 'unresolved'}`
       return
     }
     saving.value = true
@@ -1112,8 +1077,6 @@ function CascadeRawConfigEditor({
     }
   }
 
-  const materializationError = raw?.materialization_error ?? null
-
   return html`
     <${Card} title=${mode.title}>
       <div class="flex flex-col gap-3 p-4">
@@ -1121,21 +1084,6 @@ function CascadeRawConfigEditor({
         <p class="text-xs text-[var(--color-fg-muted)]">
           ${mode.secondary}
         </p>
-
-        ${materializationError
-          ? html`
-            <div
-              role="alert"
-              class="rounded-[var(--r-1)] border border-[var(--bad-light)] bg-[var(--bad-bg-soft, var(--color-bg-page))] px-3 py-2 text-xs text-[var(--bad-light)]"
-            >
-              <strong class="font-semibold">cascade.toml 적용 실패:</strong>
-              <span class="ml-1 font-mono break-all">${materializationError}</span>
-              <p class="mt-1 text-[var(--color-fg-muted)]">
-                아래 표시되는 raw_json 은 마지막으로 정상 머터리얼라이즈된 스냅샷입니다.
-                source_text 의 변경분은 strict-field 검증에 의해 거절되어 적용되지 않았습니다.
-              </p>
-            </div>`
-          : ''}
 
         <form class="flex flex-col gap-3" onSubmit=${handleSave}>
           <textarea
@@ -1159,7 +1107,7 @@ function CascadeRawConfigEditor({
               ? html`<span class="text-[var(--bad-light)]">syntax: ${syntaxError}</span>`
               : html`
                 <span class="text-[var(--color-status-ok)]">
-                  ${raw?.source_kind === 'toml' ? 'syntax: validated on save (TOML)' : 'syntax: valid JSON'}
+                  syntax: validated on save (TOML)
                 </span>
               `}
             ${saveMessage.value
@@ -1196,25 +1144,7 @@ function CascadeRawConfigEditor({
             <//>
           </div>
         </form>
-        ${mode.previewTitle
-          ? html`
-            <div class="flex flex-col gap-2">
-              <div class="text-xs font-medium text-[var(--color-fg-primary)]">
-                ${mode.previewTitle}
-              </div>
-              <div class="text-xs text-[var(--color-fg-muted)]">
-                ${raw?.config_path ?? 'unresolved'}
-              </div>
-              <textarea
-                aria-label="설정 미리보기"
-                class="h-72 w-full rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-page)] px-3 py-2 font-mono text-xs text-[var(--color-fg-primary)]"
-                spellcheck="false"
-                readonly
-                value=${raw?.raw_json ?? ''}
-              />
-            </div>
-          `
-          : null}
+
       </div>
     <//>
   `

--- a/dashboard/src/components/keeper-config-panel.ts
+++ b/dashboard/src/components/keeper-config-panel.ts
@@ -874,11 +874,6 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
         <${SectionHeader} size="xs" class="mt-2 mb-0.5">캐스케이드 카탈로그 출처</${SectionHeader}>
         <${LongText} text=${c.sources.cascade_catalog_source_path} />
       ` : null}
-      ${c.sources.cascade_runtime_json_path ? html`
-        <${SectionHeader} size="xs" class="mt-2 mb-0.5">생성된 런타임 JSON</${SectionHeader}>
-        <${LongText} text=${c.sources.cascade_runtime_json_path} />
-      ` : null}
-      <${BoolRow} label="cascade.json 직접 수정 가능" value=${c.sources.cascade_runtime_json_editable} />
       <div class="mt-1.5">
         <${SectionHeader} size="xs" class="mb-1">우선순위</${SectionHeader}>
         <${ModelList} models=${c.sources.precedence} />

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -1228,8 +1228,6 @@ interface KeeperConfigSources {
   override_fields: string[]
   cascade_catalog_source_kind: 'json' | 'toml' | null
   cascade_catalog_source_path: string | null
-  cascade_runtime_json_path: string | null
-  cascade_runtime_json_editable: boolean
 }
 
 interface KeeperConfigMetrics {

--- a/test/test_dashboard_cascade.ml
+++ b/test/test_dashboard_cascade.ml
@@ -803,7 +803,7 @@ let test_declared_provider_schemes_reads_all_profiles () =
      contributes to the declared provider scheme set. *)
   let cascade_contents =
     {|
-_comment = "Fixture for declared_provider_schemes_of_config"
+comment = "Fixture for declared_provider_schemes_of_config"
 
 [primary_route]
 models = [

--- a/test/test_operator_control_keeper.ml
+++ b/test/test_operator_control_keeper.ml
@@ -2879,13 +2879,6 @@ proactive_enabled = true
         (Filename.concat config_dir "cascade.json")
         (json |> member "sources" |> member "cascade_catalog_source_path"
        |> to_string);
-      Alcotest.(check string) "cascade runtime json path"
-        (Filename.concat config_dir "cascade.json")
-        (json |> member "sources" |> member "cascade_runtime_json_path"
-       |> to_string);
-      Alcotest.(check bool) "cascade runtime json editable" true
-        (json |> member "sources" |> member "cascade_runtime_json_editable"
-       |> to_bool);
       Alcotest.(check string) "active config root" config_dir
         (json |> member "sources" |> member "active_config_root" |> to_string);
       Alcotest.(check string) "active config root source" "env"


### PR DESCRIPTION
## Context

PR #14592 (RFC-0058 §9.3 — delete cascade.json API surface) was merged before the FE follow-up commit landed. This PR rescues the stranded commit `3ba423f5f` (cherry-picked here as `997c26a1c`) so it actually reaches main.

The commit addresses Copilot review threads 1/2/3 from #14592, which surfaced after the backend deletion of the JSON authoring surface left dead fields in the dashboard FE.

## What this PR changes

7 files, +18/-121 (mostly deletion of dead fields).

| File | Change |
|---|---|
| `dashboard/src/api/dashboard.ts` | Drop `cascade_runtime_json_path` / `cascade_runtime_json_editable` normalizer fields (backend no longer emits them; the `string\|null + asLooseBoolean` fallthrough was a deprecation shim violating "no fallback resolution") |
| `dashboard/src/types/core.ts` | Remove the two fields from `KeeperConfigSources` |
| `dashboard/src/components/keeper-config-panel.ts` | Drop the runtime-json LongText row + cascade.json editability BoolRow |
| `dashboard/src/api/dashboard-cascade.ts` | Drop `config_path`, `source_kind`, `raw_json_editable`, `raw_json`, `materialization_error` from `CascadeConfigResponse` / `CascadeRawConfigResponse`. cascade.toml is now the only authoring surface — the dual-mode `JSON \| TOML` discriminator is dead |
| `dashboard/src/components/cascade-config-panel.ts` | Collapse source-kind branching in `catalogSourceSummary` / `rawConfigModeSummary` / `validateSourceConfigText`; drop materialization_error alert + generated-cascade.json preview pane (no on-disk JSON sibling exists). `validateSourceConfigText` becomes a no-op (TOML syntax is validated server-side on save) |
| `test/test_operator_control_keeper.ml` | Drop assertions on the removed fields; fix stray `\|> to_bool);` |
| `test/test_dashboard_cascade.ml` | Fixture: `_comment` → `comment` (strict materializer rejects underscore-prefixed scalars as profile tables, which was collapsing `declared_provider_schemes` to `Ok []`) |

## Verified

- `dune build --root . @check` clean.
- `dune exec test/test_dashboard_cascade.exe`: `declared_provider_schemes` test 6 now PASSES (was FAIL).
- 4 other pre-existing failures (keeper_profile_json 0/1/3, recommendations 3) fail identically on `origin/main` without these edits — out of scope.

## Why not amend #14592

#14592 already merged to main. Stranded commit `3ba423f5f` on the dead branch `feat/rfc-0058-phase9-3-delete-json-api` would never reach main without this rescue PR. See PR #14592 issue comment for the trail.

## Out of scope

- New Copilot thread on `lib/cascade/cascade_config_loader.ml::load_json` (`End_of_file` not caught around `really_input_string`) — legitimate follow-up bug, deserves its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)