### PR TITLE
fix(cascade): catch End_of_file in load_json (follow-up to #14592)

### DIFF
--- a/lib/cascade/cascade_config_loader.ml
+++ b/lib/cascade/cascade_config_loader.ml
@@ -101,6 +101,13 @@ let load_json path =
   | Unix.Unix_error (err, fn, arg) ->
     Error (Printf.sprintf "%s(%s): %s" fn arg (Unix.error_message err))
   | Yojson.Json_error msg -> Error (Printf.sprintf "JSON error: %s" msg)
+  | End_of_file ->
+    (* [Fs_compat.load_file_unix] reads [in_channel_length] first, then
+       [really_input_string len]. If the file is truncated between the
+       two calls (concurrent writer, atomic-rename mid-flight), the
+       second call raises [End_of_file]. Surface as an [Error] instead
+       of crashing the loader. *)
+    Error (Printf.sprintf "cascade source truncated mid-read: %s" path)
 ;;
 
 (** A model entry with an optional weight for weighted cascade selection.


### PR DESCRIPTION
## Why

Copilot review on #14592 (RFC-0058 §9.3) flagged that `Cascade_config_loader.load_json` does not catch `End_of_file`:

```ocaml
let load_json path =
  try load_toml_in_memory path with
  | Sys_error msg -> Error msg
  | Unix.Unix_error (err, fn, arg) -> Error (...)
  | Yojson.Json_error msg -> Error (...)
;;
```

`load_toml_in_memory` ultimately routes through `Fs_compat.load_file_unix`:

```ocaml
let load_file_unix path =
  let ic = open_in path in
  let len = in_channel_length ic in
  really_input_string ic len
```

If the file is truncated between `in_channel_length` and `really_input_string` — concurrent writer, atomic-rename mid-flight while the reader has the fd open — `really_input_string` raises `End_of_file`. The existing handlers don't catch it, so the exception bubbles past the loader and crashes the caller.

This is a real race: `cascade.toml` is atomically rewritten by the dashboard `save_raw_config_json` path and the `bin/cascade_materialize` CLI, while the reader-side hot path runs through `load_json` on every `Cascade_catalog_runtime.validate_path_result` (i.e. every cascade snapshot refresh).

## What changes

`lib/cascade/cascade_config_loader.ml:98-103`. Adds one `with` branch:

```ocaml
  | End_of_file ->
    Error (Printf.sprintf "cascade source truncated mid-read: %s" path)
```

Plus a 4-line comment block explaining the truncate race so the next reader doesn't see the branch as cargo-culted.

7 lines total, no other behaviour change.

## Test plan

- [x] `dune build @check` clean
- [x] `ocamlformat --check` clean (only the changed file)
- Behavioural: hard to fuzz the race deterministically, but the change is purely defensive — `Error` return is strictly safer than uncaught `End_of_file`. Cascade catalog reload picks up the error on the next mtime tick and retries.

## Related

- #14592 Copilot thread `lib/cascade/cascade_config_loader.ml:102`.
- `lib/fs_compat/fs_compat.ml:117-122` `load_file_unix` (the actual raising site).
- CLAUDE.md `software-development.md` — "Silent Failure 사전 방지" / explicit `Result` over uncaught exceptions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)