### PR TITLE
fix(dashboard): RFC-0058 §9.3 follow-up — Vitest fixture cleanup + editor null-guard (#14601 follow-up)

### DIFF
--- a/dashboard/src/api/dashboard-cascade.test.ts
+++ b/dashboard/src/api/dashboard-cascade.test.ts
@@ -103,8 +103,6 @@ describe('dashboard cascade split', () => {
     const fetchMock = vi.fn().mockResolvedValue(
       new Response(JSON.stringify({
         updated_at: '2026-04-22T00:00:00Z',
-        config_path: '/tmp/config/cascade.json',
-        source_kind: 'toml',
         source_path: '/tmp/config/cascade.toml',
         validation_status: 'validated',
         validation_errors: [],

--- a/dashboard/src/api/dashboard.test.ts
+++ b/dashboard/src/api/dashboard.test.ts
@@ -919,8 +919,6 @@ describe('fetchKeeperConfig', () => {
         override_fields: 'goal',
         cascade_catalog_source_kind: 'toml',
         cascade_catalog_source_path: '/tmp/config/cascade.toml',
-        cascade_runtime_json_path: '/tmp/config/cascade.json',
-        cascade_runtime_json_editable: 'false',
       },
       metrics: {
         generation: '3',
@@ -979,8 +977,6 @@ describe('fetchKeeperConfig', () => {
     expect(result.sources.precedence).toEqual(['live_meta'])
     expect(result.sources.cascade_catalog_source_kind).toBe('toml')
     expect(result.sources.cascade_catalog_source_path).toBe('/tmp/config/cascade.toml')
-    expect(result.sources.cascade_runtime_json_path).toBe('/tmp/config/cascade.json')
-    expect(result.sources.cascade_runtime_json_editable).toBe(false)
     expect(result.metrics.total_cost_usd).toBe(0.12)
     expect(result.runtime.presence_keepalive_sec).toBe(30)
     expect(result.runtime.runtime_blocker_class).toBe('stale_fleet_batch')

--- a/dashboard/src/components/cascade-config-panel.ts
+++ b/dashboard/src/components/cascade-config-panel.ts
@@ -1027,7 +1027,7 @@ function CascadeRawConfigEditor({
   const saving = useSignal(false)
   const saveMessage = useSignal<string | null>(null)
   const mode = rawConfigModeSummary(raw)
-  const sourceEditable = raw?.source_editable !== false
+  const sourceEditable = raw !== null && raw.source_editable !== false
 
   useEffect(() => {
     if (!raw || editorDirty.value) return

--- a/dashboard/src/components/keeper-config-panel.test.ts
+++ b/dashboard/src/components/keeper-config-panel.test.ts
@@ -134,8 +134,6 @@ function makeKeeperConfig(overrides: Partial<KeeperConfig> = {}): KeeperConfig {
       override_fields: ['goal', 'instructions'],
       cascade_catalog_source_kind: 'toml',
       cascade_catalog_source_path: '/tmp/config/cascade.toml',
-      cascade_runtime_json_path: '/tmp/config/cascade.json',
-      cascade_runtime_json_editable: false,
     },
     tools: {
       tool_access: { kind: 'preset', preset: 'coding' },
@@ -525,7 +523,6 @@ describe('KeeperConfigPanel', () => {
     expect(container.textContent).toContain('broken_profile')
     expect(container.textContent).toContain('/tmp/config/keepers/default.toml')
     expect(container.textContent).toContain('/tmp/config/cascade.toml')
-    expect(container.textContent).toContain('/tmp/config/cascade.json')
     expect(container.textContent).toContain('런타임 설정')
     expect(container.textContent).toContain('active_goal_ids')
     expect(container.textContent).toContain('Ship runtime clarity')


### PR DESCRIPTION
## Context

Follow-up to PR #14601 (RFC-0058 §9.3 FE cleanup). #14601 removed cascade.json authoring fields from `CascadeConfigResponse` / `CascadeRawConfigResponse` / `KeeperConfigSources` in production code but left Vitest fixtures + assertions referencing the deleted fields. Copilot review on #14601 surfaced 3 unresolved threads after merge.

The original `End_of_file` concern (on `cascade_config_loader.ml::load_json`) was a false alarm — the catch was already added in `f41eb4d638` (2026-05-10) at line 147. Copilot's diff snapshot was stale relative to main.

## What this PR changes

| Thread | File | Change |
|---|---|---|
| 1 | `dashboard/src/api/dashboard.test.ts` | Drop `cascade_runtime_json_path` / `cascade_runtime_json_editable` from raw fixture (922-923) and result assertions (982-983). |
| 1 | `dashboard/src/components/keeper-config-panel.test.ts` | Drop the same two fields from sources fixture (137-138) and the `/tmp/config/cascade.json` textContent assertion (line 526). |
| 2 | `dashboard/src/api/dashboard-cascade.test.ts` | Drop `config_path` / `source_kind` from POST mock response (106-107) — fields no longer exist on `CascadeConfigResponse`. |
| 3 | `dashboard/src/components/cascade-config-panel.ts:1030` | Editor null-guard: tighten `sourceEditable = raw?.source_editable !== false` → `raw !== null && raw.source_editable !== false`. Prevents empty editor from appearing editable during initial load (when `raw` is null, `editorText` defaults to `''` and the previous expression evaluated to `true`, letting a user dirty + Save the doc before data arrives). |

## Verified

```
pnpm exec vitest run --config vitest.config.ts \
  src/api/dashboard.test.ts \
  src/api/dashboard-cascade.test.ts \
  src/components/keeper-config-panel.test.ts
```

3 files / 59 tests / **0 failed**.

Pre-existing `pnpm typecheck` errors in `src/components/ide/ide-shell.ts:321` exist on `origin/main` (unrelated to this PR — see `git show origin/main:dashboard/src/components/ide/ide-shell.ts`).

## Out of scope

- ide-shell.ts pre-existing TS strict errors (3 instances of `'fileName' is possibly 'undefined'`) — separate cleanup PR.
- End_of_file false-alarm thread on `cascade_config_loader.ml` — already fixed in `f41eb4d638`. No action needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)