### PR TITLE
style(): apply ocamlformat to keeper_tools_oas.ml (#14596 follow-up)

### DIFF
--- a/lib/keeper/keeper_tools_oas.ml
+++ b/lib/keeper/keeper_tools_oas.ml
@@ -1022,9 +1022,7 @@ let make_tool_bundle
            else None)
       (Keeper_tool_alias.public_names ())
   in
-  let assembled_tool_surface =
-    universe_names_for_pass_a @ pass_b_public_alias_names
-  in
+  let assembled_tool_surface = universe_names_for_pass_a @ pass_b_public_alias_names in
   (* Record tool assignment telemetry for causal tracing.
      assignment_id links Assigned → Called → Completed events.
      [tool_list] reflects the final agent-visible surface so assignment


### PR DESCRIPTION
## Summary
Follow-up to #14596 (RFC-0064 Phase 2). The squash merge of #14596 included all functional changes (dual-registration cleanup, telemetry assembly fix) but missed the post-review `ocamlformat` fix pushed as `cb0f590c1` after merge.

This PR applies only the formatting delta (1 insertion, 3 deletions) to `lib/keeper/keeper_tools_oas.ml`.

## Test plan
- [ ] `ocamlformat-check` CI green
- [ ] `dune build --root . @check` passes

## No functional changes