### PR TITLE
refactor(cascade-decl): reserve provider.capabilities + provider.headers schema fields (RFC-0058 Phase 5.6 prep)

### DIFF
--- a/lib/cascade_decl/cascade_declarative_parser.ml
+++ b/lib/cascade_decl/cascade_declarative_parser.ml
@@ -71,6 +71,43 @@ let parse_credential (tbl : Otoml.t) (path : string)
   | t -> Error (error (path ^ ".type") (Printf.sprintf "unknown credential type %S" t))
 ;;
 
+let parse_capabilities (tbl : Otoml.t) : cascade_capabilities =
+  let b key = Otoml.find_or ~default:false tbl Otoml.get_boolean [ key ] in
+  {
+    supports_inline_tools = b "supports-inline-tools";
+    supports_runtime_mcp_tools = b "supports-runtime-mcp-tools";
+    supports_runtime_tool_events = b "supports-runtime-tool-events";
+    supports_runtime_mcp_http_headers = b "supports-runtime-mcp-http-headers";
+  }
+;;
+
+let parse_headers (tbl : Otoml.t) (path : string)
+  : (string * string) list option
+  =
+  let entries =
+    try Otoml.get_table tbl with
+    | _ -> []
+  in
+  let pairs =
+    List.filter_map
+      (fun (k, v) ->
+        match Otoml.get_string v with
+        | s -> Some (k, s)
+        | exception _ ->
+          Logs.warn (fun m ->
+            m
+              "cascade_declarative_parser: %s.%s — non-string header value, \
+               ignoring"
+              path
+              k);
+          None)
+      entries
+  in
+  match pairs with
+  | [] -> None
+  | _ -> Some (List.sort (fun (a, _) (b, _) -> String.compare a b) pairs)
+;;
+
 let parse_provider (id : string) (tbl : Otoml.t)
   : (cascade_provider, parse_error list) result
   =
@@ -131,8 +168,17 @@ let parse_provider (id : string) (tbl : Otoml.t)
                   path other);
               None))
     in
+    let capabilities =
+      Otoml.find_opt tbl Fun.id [ "capabilities" ]
+      |> Option.map parse_capabilities
+    in
+    let headers =
+      match Otoml.find_opt tbl Fun.id [ "headers" ] with
+      | None -> None
+      | Some h_tbl -> parse_headers h_tbl (path ^ ".headers")
+    in
     Ok { id; display_name; api_format; transport; is_non_interactive;
-         credentials; liveness_class }
+         credentials; liveness_class; capabilities; headers }
 ;;
 
 let parse_providers (toml : Otoml.t) : (cascade_provider list, parse_error list) result =

--- a/lib/cascade_decl/cascade_declarative_parser.ml
+++ b/lib/cascade_decl/cascade_declarative_parser.ml
@@ -81,31 +81,42 @@ let parse_capabilities (tbl : Otoml.t) : cascade_capabilities =
   }
 ;;
 
+(** Parse a [providers.<id>.headers] sub-table into a sorted association
+    list. Caller invokes only when the sub-table key exists, so the
+    returned list distinguishes "declared but empty / all entries rejected"
+    (empty list) from "no sub-table" (caller passes [None]).
+
+    Non-table values at the sub-table position emit a WARN and yield an
+    empty list. Non-string header values emit a per-entry WARN and are
+    dropped. The result is sorted by key for deterministic show/eq. *)
 let parse_headers (tbl : Otoml.t) (path : string)
-  : (string * string) list option
+  : (string * string) list
   =
-  let entries =
-    try Otoml.get_table tbl with
-    | _ -> []
-  in
-  let pairs =
-    List.filter_map
-      (fun (k, v) ->
-        match Otoml.get_string v with
-        | s -> Some (k, s)
-        | exception _ ->
-          Logs.warn (fun m ->
-            m
-              "cascade_declarative_parser: %s.%s — non-string header value, \
-               ignoring"
-              path
-              k);
-          None)
-      entries
-  in
-  match pairs with
-  | [] -> None
-  | _ -> Some (List.sort (fun (a, _) (b, _) -> String.compare a b) pairs)
+  match Otoml.get_table tbl with
+  | exception _ ->
+    Logs.warn (fun m ->
+      m
+        "cascade_declarative_parser: %s — expected TOML table, got non-table \
+         value; treating as empty"
+        path);
+    []
+  | entries ->
+    let pairs =
+      List.filter_map
+        (fun (k, v) ->
+          match Otoml.get_string v with
+          | s -> Some (k, s)
+          | exception _ ->
+            Logs.warn (fun m ->
+              m
+                "cascade_declarative_parser: %s.%s — non-string header value, \
+                 ignoring"
+                path
+                k);
+            None)
+        entries
+    in
+    List.sort (fun (a, _) (b, _) -> String.compare a b) pairs
 ;;
 
 let parse_provider (id : string) (tbl : Otoml.t)
@@ -175,7 +186,7 @@ let parse_provider (id : string) (tbl : Otoml.t)
     let headers =
       match Otoml.find_opt tbl Fun.id [ "headers" ] with
       | None -> None
-      | Some h_tbl -> parse_headers h_tbl (path ^ ".headers")
+      | Some h_tbl -> Some (parse_headers h_tbl (path ^ ".headers"))
     in
     Ok { id; display_name; api_format; transport; is_non_interactive;
          credentials; liveness_class; capabilities; headers }

--- a/lib/cascade_decl/cascade_declarative_types.ml
+++ b/lib/cascade_decl/cascade_declarative_types.ml
@@ -39,6 +39,14 @@ type cascade_liveness_class =
   | Local_70b_plus
 [@@deriving show, eq]
 
+type cascade_capabilities = {
+  supports_inline_tools : bool;
+  supports_runtime_mcp_tools : bool;
+  supports_runtime_tool_events : bool;
+  supports_runtime_mcp_http_headers : bool;
+}
+[@@deriving show, eq]
+
 type cascade_provider = {
   id : string;
   display_name : string;
@@ -47,6 +55,8 @@ type cascade_provider = {
   is_non_interactive : bool;
   credentials : cascade_credential option;
   liveness_class : cascade_liveness_class option;
+  capabilities : cascade_capabilities option;
+  headers : (string * string) list option;
 }
 [@@deriving show, eq]
 

--- a/lib/cascade_decl/cascade_declarative_types.mli
+++ b/lib/cascade_decl/cascade_declarative_types.mli
@@ -48,9 +48,9 @@ type cascade_liveness_class =
   | Local_70b_plus
 [@@deriving show, eq]
 
-(** Per-provider runtime capabilities — RFC-0058 §3.2 + Phase 5.1 caller
-    cutover prerequisite. Reserved as schema-only here: a follow-up phase
-    will replace the hardcoded variant match in
+(** Per-provider runtime capabilities — RFC-0058 §3.2. Schema-only at this
+    phase: a Phase 5.1 follow-up will replace the hardcoded variant match
+    in
     [Llm_provider.Capabilities.{claude_code,gemini_cli,kimi_cli,codex_cli}_capabilities]
     with a cascade.toml lookup. Boolean defaults are [false] — explicit
     declaration in TOML is required for any non-false capability. *)
@@ -71,12 +71,17 @@ type cascade_provider = {
   credentials : cascade_credential option;
   liveness_class : cascade_liveness_class option;
   capabilities : cascade_capabilities option;
-  (** Reserved (Phase 5.6) — caller cutover in follow-up. *)
+  (** Reserved schema (Phase 5.1 prep). Caller cutover follows in a
+      separate PR that replaces the [Llm_provider.Capabilities.*]
+      variant defaults. *)
   headers : (string * string) list option;
-  (** Reserved (Phase 5.6) — additional HTTP headers per provider,
-      e.g. [("anthropic-version", "2023-06-01")] for Anthropic HTTP API.
-      Sorted by key for deterministic show/eq. Caller cutover in follow-up
-      replaces [Cascade_config.headers_with_auth] variant match. *)
+  (** Reserved schema (Phase 5.6 prep). Additional HTTP headers per
+      provider, e.g. [("anthropic-version", "2023-06-01")] for Anthropic
+      HTTP API. Sorted by key for deterministic show/eq. [None] means
+      no [\[providers.<id>.headers\]] sub-table; [Some \[\]] means
+      declared but empty (or all entries rejected as non-string).
+      Caller cutover follows in a separate PR that replaces
+      [Cascade_config.headers_with_auth] variant match. *)
 }
 [@@deriving show, eq]
 

--- a/lib/cascade_decl/cascade_declarative_types.mli
+++ b/lib/cascade_decl/cascade_declarative_types.mli
@@ -48,6 +48,20 @@ type cascade_liveness_class =
   | Local_70b_plus
 [@@deriving show, eq]
 
+(** Per-provider runtime capabilities — RFC-0058 §3.2 + Phase 5.1 caller
+    cutover prerequisite. Reserved as schema-only here: a follow-up phase
+    will replace the hardcoded variant match in
+    [Llm_provider.Capabilities.{claude_code,gemini_cli,kimi_cli,codex_cli}_capabilities]
+    with a cascade.toml lookup. Boolean defaults are [false] — explicit
+    declaration in TOML is required for any non-false capability. *)
+type cascade_capabilities = {
+  supports_inline_tools : bool;
+  supports_runtime_mcp_tools : bool;
+  supports_runtime_tool_events : bool;
+  supports_runtime_mcp_http_headers : bool;
+}
+[@@deriving show, eq]
+
 type cascade_provider = {
   id : string;
   display_name : string;
@@ -56,6 +70,13 @@ type cascade_provider = {
   is_non_interactive : bool;
   credentials : cascade_credential option;
   liveness_class : cascade_liveness_class option;
+  capabilities : cascade_capabilities option;
+  (** Reserved (Phase 5.6) — caller cutover in follow-up. *)
+  headers : (string * string) list option;
+  (** Reserved (Phase 5.6) — additional HTTP headers per provider,
+      e.g. [("anthropic-version", "2023-06-01")] for Anthropic HTTP API.
+      Sorted by key for deterministic show/eq. Caller cutover in follow-up
+      replaces [Cascade_config.headers_with_auth] variant match. *)
 }
 [@@deriving show, eq]
 

--- a/test/test_cascade_declarative_adapter.ml
+++ b/test/test_cascade_declarative_adapter.ml
@@ -216,6 +216,8 @@ let test_alias_parent_missing () =
       is_non_interactive = false;
       credentials = None;
       liveness_class = None;
+      capabilities = None;
+      headers = None;
     }];
     models = [{
       id = "m";
@@ -455,6 +457,8 @@ let test_duplicate_routes () =
       is_non_interactive = false;
       credentials = None;
       liveness_class = None;
+      capabilities = None;
+      headers = None;
     }];
     models = [{
       id = "haiku";

--- a/test/test_cascade_declarative_parser.ml
+++ b/test/test_cascade_declarative_parser.ml
@@ -630,6 +630,78 @@ command = "c"
       (Option.map show_cascade_liveness_class p.liveness_class)
   | _ -> failwith "expected exactly one provider"
 
+let test_capabilities_present () =
+  let toml = {|
+[providers.p]
+protocol = "anthropic-cli"
+command = "c"
+
+[providers.p.capabilities]
+supports-inline-tools = true
+supports-runtime-mcp-tools = true
+supports-runtime-tool-events = false
+|} in
+  let cfg = ok_config (parse_string toml) in
+  match cfg.providers with
+  | [ p ] ->
+    (match p.capabilities with
+     | Some c ->
+       check bool "inline tools" true c.supports_inline_tools;
+       check bool "runtime mcp tools" true c.supports_runtime_mcp_tools;
+       check bool "runtime tool events" false c.supports_runtime_tool_events;
+       (* Unspecified field defaults to false *)
+       check bool "runtime mcp http headers default false" false
+         c.supports_runtime_mcp_http_headers
+     | None -> failwith "expected capabilities to be parsed")
+  | _ -> failwith "expected exactly one provider"
+
+let test_capabilities_absent () =
+  let toml = {|
+[providers.p]
+protocol = "anthropic-cli"
+command = "c"
+|} in
+  let cfg = ok_config (parse_string toml) in
+  match cfg.providers with
+  | [ p ] ->
+    check (option string) "no capabilities sub-table → None" None
+      (Option.map show_cascade_capabilities p.capabilities)
+  | _ -> failwith "expected exactly one provider"
+
+let test_headers_present () =
+  let toml = {|
+[providers.p]
+protocol = "anthropic-http"
+endpoint = "https://api.anthropic.com"
+
+[providers.p.headers]
+anthropic-version = "2023-06-01"
+anthropic-beta = "prompt-caching-2024-07-31"
+|} in
+  let cfg = ok_config (parse_string toml) in
+  match cfg.providers with
+  | [ p ] ->
+    (match p.headers with
+     | Some hs ->
+       (* Sorted by key for determinism *)
+       check (list (pair string string)) "headers sorted"
+         [ ("anthropic-beta", "prompt-caching-2024-07-31");
+           ("anthropic-version", "2023-06-01") ]
+         hs
+     | None -> failwith "expected headers to be parsed")
+  | _ -> failwith "expected exactly one provider"
+
+let test_headers_absent () =
+  let toml = {|
+[providers.p]
+protocol = "anthropic-cli"
+command = "c"
+|} in
+  let cfg = ok_config (parse_string toml) in
+  match cfg.providers with
+  | [ p ] -> check bool "no headers sub-table → None" true (p.headers = None)
+  | _ -> failwith "expected exactly one provider"
+
 (* --- Test suite --- *)
 
 let () =
@@ -693,5 +765,13 @@ let () =
       "liveness_class", [
         test_case "unknown value yields None" `Quick test_liveness_class_unknown;
         test_case "absent yields None" `Quick test_liveness_class_absent;
+      ];
+      "capabilities", [
+        test_case "present parses with defaults" `Quick test_capabilities_present;
+        test_case "absent yields None" `Quick test_capabilities_absent;
+      ];
+      "headers", [
+        test_case "present sorted by key" `Quick test_headers_present;
+        test_case "absent yields None" `Quick test_headers_absent;
       ];
     ]

--- a/test/test_cascade_declarative_parser.ml
+++ b/test/test_cascade_declarative_parser.ml
@@ -702,6 +702,23 @@ command = "c"
   | [ p ] -> check bool "no headers sub-table → None" true (p.headers = None)
   | _ -> failwith "expected exactly one provider"
 
+let test_headers_declared_but_empty () =
+  (* [providers.p.headers] declared but contains zero entries.
+     Must distinguish from "absent": result is Some [], not None. *)
+  let toml = {|
+[providers.p]
+protocol = "anthropic-cli"
+command = "c"
+
+[providers.p.headers]
+|} in
+  let cfg = ok_config (parse_string toml) in
+  match cfg.providers with
+  | [ p ] ->
+    check (option (list (pair string string)))
+      "declared but empty → Some []" (Some []) p.headers
+  | _ -> failwith "expected exactly one provider"
+
 (* --- Test suite --- *)
 
 let () =
@@ -773,5 +790,7 @@ let () =
       "headers", [
         test_case "present sorted by key" `Quick test_headers_present;
         test_case "absent yields None" `Quick test_headers_absent;
+        test_case "declared but empty yields Some []" `Quick
+          test_headers_declared_but_empty;
       ];
     ]


### PR DESCRIPTION
## Summary

Schema-only reservation for `cascade_provider` in `lib/cascade_decl/`. Adds two optional fields parsed from `[providers.<id>.capabilities]` and `[providers.<id>.headers]` TOML sub-tables. **Zero behavior change** — G1/G2 grep gates unchanged.

This is **Wave 1 / step A1** in the 4-PR sequence to make `cascade.toml` the SSOT for provider runtime configuration (RFC-0058 Phase 5.6).

## Why

`config/cascade.toml` currently has `0/6` providers with `[providers.<id>.capabilities]` and `0/6` with `[providers.<id>.headers]` sub-tables — these RFC-0058 §2.3 schema concepts are defined in the docs but not in the OCaml types. Code paths fall back to:

- `Llm_provider.Capabilities.{claude_code,gemini_cli,kimi_cli,codex_cli}_capabilities` (hardcoded variant defaults)
- `Cascade_config.headers_with_auth` variant match at `lib/cascade/cascade_config.ml:46` (`anthropic-version = "2023-06-01"` literal)

This PR reserves the schema fields so the follow-up Phase 5.6 cutover PR can populate `cascade.toml` entries and replace the variant match with a `cascade_provider` lookup.

## Changes

| File | Δ | Purpose |
|------|---|---------|
| `lib/cascade_decl/cascade_declarative_types.mli` | +21 | Add `cascade_capabilities` type + 2 fields on `cascade_provider` |
| `lib/cascade_decl/cascade_declarative_types.ml` | +10 | Same in implementation |
| `lib/cascade_decl/cascade_declarative_parser.ml` | +48 | `parse_capabilities`/`parse_headers` helpers; extend `parse_provider` |
| `test/test_cascade_declarative_parser.ml` | +80 | 4 new tests (present/absent for each field, sorted-by-key) |
| `test/test_cascade_declarative_adapter.ml` | +4 | Two existing record literals get `capabilities = None; headers = None;` (compiler-enforced) |

**Total**: 5 files, +162/-1.

## Field semantics

```ocaml
type cascade_capabilities = {
  supports_inline_tools : bool;            (* default false *)
  supports_runtime_mcp_tools : bool;       (* default false *)
  supports_runtime_tool_events : bool;     (* default false *)
  supports_runtime_mcp_http_headers : bool; (* default false *)
}

(* on cascade_provider *)
capabilities : cascade_capabilities option;   (* None = no sub-table declared *)
headers : (string * string) list option;     (* sorted by key for deterministic show/eq *)
```

TOML shape:

```toml
[providers.claude_api]
protocol = "anthropic-http"
endpoint = "https://api.anthropic.com"

[providers.claude_api.capabilities]
supports-inline-tools = true
supports-runtime-mcp-tools = true

[providers.claude_api.headers]
anthropic-version = "2023-06-01"
anthropic-beta = "prompt-caching-2024-07-31"
```

## Tests

```
$ dune exec test/test_cascade_declarative_parser.exe
... 34 tests run. Test Successful.

$ dune exec test/test_cascade_declarative_adapter.exe
... 17 tests run. Test Successful.
```

New test cases:
- `capabilities present parses with defaults` — explicit true/false + unspecified field defaults to false
- `capabilities absent yields None`
- `headers present sorted by key` — verifies determinism contract
- `headers absent yields None`

## Risk analysis

| Axis | Status |
|------|--------|
| G1 grep (Provider variant) | unchanged (82, no caller swap) |
| G2 grep (cascade prefix literal) | unchanged (19) |
| Runtime hot path | untouched — `Cascade_declarative_hotpath`/adapter does not consume the new fields yet |
| Schema breaking | no — fields are optional, existing `cascade.toml` parses unchanged |
| Build | `dune build --root . @check` exit 0 |

## Follow-ups (separate PRs)

1. **Phase 5.6 caller cutover** — `headers_with_auth` re-design + delete `cascade_config.ml:46` variant match (G1 grep -5)
2. **Direct API 8 provider entries** — populate `cascade.toml` with `claude_api`, `codex_api`, etc. + their `aliases`/`headers`/`credentials`/`capabilities`
3. **`validate_strict` R-rule** — warn when shipped providers omit `capabilities`/`headers`/`credentials`

## RFC

RFC-0058 §2.3 (provider schema) + §3.2 (TOML layer-1 spec)

🤖 Generated with [Claude Code](https://claude.com/claude-code)