### PR TITLE
config(cascade): [providers.<p>.capabilities] data fill (RFC-0058 Phase 5.1 A.2)

### DIFF
--- a/config/cascade.toml
+++ b/config/cascade.toml
@@ -23,6 +23,15 @@ key = "ANTHROPIC_API_KEY"
 [providers.claude_code.liveness]
 class = "cloud_fast"
 
+# Behavioral capabilities — RFC-0058 §2.4 Phase 5.1.
+# Replaces the OCaml `tool_policy` record and per-kind matches in
+# cascade_transport / provider_tool_support / keeper_usage_trust.
+# Field defaults (when omitted) are all false / [] / None.
+[providers.claude_code.capabilities]
+supports-runtime-mcp-http-headers = true
+uses-anthropic-caching = true
+max-turns-per-attempt = 30
+
 [providers.codex_cli]
 display-name = "OpenAI Codex CLI"
 protocol = "openai-http"
@@ -35,6 +44,14 @@ key = "OPENAI_API_KEY"
 
 [providers.codex_cli.liveness]
 class = "cloud_fast"
+
+[providers.codex_cli.capabilities]
+# Codex CLI's cached login cannot inject arbitrary per-request headers,
+# so keeper-bound actor tools must be bridged via argv (per-keeper auth
+# token routed through bearer_token_env_var) — see masc-mcp#10097.
+requires-per-keeper-bridging-for-bound-actor-tools = true
+identity-runtime-mcp-header-keys = ["authorization", "x-masc-agent-name", "x-masc-keeper-name"]
+argv-prompt-preflight = true
 
 [providers.gemini_cli]
 display-name = "Google Gemini CLI"
@@ -49,6 +66,11 @@ key = "GEMINI_API_KEY"
 [providers.gemini_cli.liveness]
 class = "cloud_fast"
 
+# Gemini CLI ships no [capabilities] sub-table — needs none of the
+# behavioral quirks (no runtime MCP HTTP headers, no anthropic caching,
+# no max-turns cap). Parser yields `capabilities = None`; A.3 callers
+# treat `None` as the conservative defaults (all-false / empty / None).
+
 [providers.kimi_cli]
 display-name = "Moonshot Kimi CLI"
 protocol = "kimi-cli"
@@ -62,6 +84,9 @@ key = "MOONSHOT_API_KEY"
 [providers.kimi_cli.liveness]
 class = "cloud_thinking"
 
+[providers.kimi_cli.capabilities]
+supports-runtime-mcp-http-headers = true
+
 [providers.glm-coding]
 display-name = "Zhipu GLM Coding"
 protocol = "openai-http"
@@ -74,6 +99,10 @@ key = "ZAI_API_KEY"
 [providers.glm-coding.liveness]
 class = "cloud_thinking"
 
+# glm-coding ships no [capabilities] sub-table — no runtime MCP HTTP
+# headers, no anthropic caching. Parser yields `capabilities = None`;
+# A.3 callers treat `None` as the conservative defaults.
+
 # Provider liveness class (RFC-0058 §3.2.1) feeds attempt-wall budgets
 # in Cascade_attempt_liveness_config. Values: cloud_fast | cloud_thinking
 # | local_27b | local_70b_plus.
@@ -85,6 +114,9 @@ endpoint = "http://localhost:11434"
 
 [providers.ollama.liveness]
 class = "local_27b"
+
+# Ollama ships no [capabilities] sub-table. Parser yields
+# `capabilities = None`; A.3 callers treat `None` as defaults.
 
 # ── Layer 2: Models ────────────────────────────────────────────
 

--- a/lib/cascade_decl/cascade_declarative_parser.ml
+++ b/lib/cascade_decl/cascade_declarative_parser.ml
@@ -71,13 +71,50 @@ let parse_credential (tbl : Otoml.t) (path : string)
   | t -> Error (error (path ^ ".type") (Printf.sprintf "unknown credential type %S" t))
 ;;
 
-let parse_capabilities (tbl : Otoml.t) : cascade_capabilities =
+let parse_capabilities ~(path : string) (tbl : Otoml.t) : cascade_capabilities =
   let b key = Otoml.find_or ~default:false tbl Otoml.get_boolean [ key ] in
+  let string_list_field key =
+    match Otoml.find_opt tbl Fun.id [ key ] with
+    | None -> []
+    | Some v ->
+      (try Otoml.get_array Otoml.get_string v
+       with _ ->
+         Logs.warn (fun m ->
+           m
+             "cascade_declarative_parser: %s.capabilities.%s — \
+              expected string array, ignoring"
+             path
+             key);
+         [])
+  in
+  let positive_int_opt_field key =
+    (* Reject non-positive values at parse time: a cap of 0 or -N would
+       clamp every cascade attempt to a meaningless budget downstream. *)
+    match Otoml.find_opt tbl Otoml.get_integer [ key ] with
+    | None -> None
+    | Some n when n > 0 -> Some n
+    | Some n ->
+      Logs.warn (fun m ->
+        m
+          "cascade_declarative_parser: %s.capabilities.%s = %d — \
+           expected positive integer, ignoring"
+          path
+          key
+          n);
+      None
+  in
   {
     supports_inline_tools = b "supports-inline-tools";
     supports_runtime_mcp_tools = b "supports-runtime-mcp-tools";
     supports_runtime_tool_events = b "supports-runtime-tool-events";
     supports_runtime_mcp_http_headers = b "supports-runtime-mcp-http-headers";
+    requires_per_keeper_bridging_for_bound_actor_tools =
+      b "requires-per-keeper-bridging-for-bound-actor-tools";
+    identity_runtime_mcp_header_keys =
+      string_list_field "identity-runtime-mcp-header-keys";
+    argv_prompt_preflight = b "argv-prompt-preflight";
+    uses_anthropic_caching = b "uses-anthropic-caching";
+    max_turns_per_attempt = positive_int_opt_field "max-turns-per-attempt";
   }
 ;;
 
@@ -181,7 +218,7 @@ let parse_provider (id : string) (tbl : Otoml.t)
     in
     let capabilities =
       Otoml.find_opt tbl Fun.id [ "capabilities" ]
-      |> Option.map parse_capabilities
+      |> Option.map (parse_capabilities ~path)
     in
     let headers =
       match Otoml.find_opt tbl Fun.id [ "headers" ] with

--- a/lib/cascade_decl/cascade_declarative_types.ml
+++ b/lib/cascade_decl/cascade_declarative_types.ml
@@ -39,14 +39,50 @@ type cascade_liveness_class =
   | Local_70b_plus
 [@@deriving show, eq]
 
+(** Per-provider runtime + behavioral capabilities — RFC-0058 §2.4 +
+    Phase 5.1 (capability fields) + §3.2 Phase 5.6 (tool/event support).
+
+    Declarative SSOT for cascade-dispatch quirks that historically lived
+    as closed-variant matches in OCaml code. Schema-additive: A.1 ships
+    the type + parser; A.3 migrates cascade_transport, Provider_tool_support,
+    Cascade_error_classify, and Keeper_usage_trust to read these fields
+    instead of matching on provider name. *)
 type cascade_capabilities = {
+  (* Tool/event support — #14608 Phase 5.6 prep *)
   supports_inline_tools : bool;
   supports_runtime_mcp_tools : bool;
   supports_runtime_tool_events : bool;
   supports_runtime_mcp_http_headers : bool;
+  (* Dispatch axes — A.1 Phase 5.1 caller cutover prep *)
+  requires_per_keeper_bridging_for_bound_actor_tools : bool;
+      (** A.3 will route [Cascade_transport.resolve_tool_lane_for_oas_tools]
+          through this flag instead of matching on [Codex_cli]. *)
+  identity_runtime_mcp_header_keys : string list;
+      (** Header keys honored by the runtime's auth surface even when
+          [supports_runtime_mcp_http_headers] is false. A.3 will have
+          [Provider_tool_support] read this list for Codex CLI. *)
+  argv_prompt_preflight : bool;
+      (** Runtime needs prompt length / argv-byte preflight before
+          invocation to avoid silent OS-level argv overflow. *)
+  uses_anthropic_caching : bool;
+      (** Runtime sends Anthropic-style prompt caching usage fields. *)
+  max_turns_per_attempt : int option;
+      (** Optional per-attempt cap on [max_turns]. Parser rejects
+          non-positive values (warn + None). *)
 }
 [@@deriving show, eq]
 
+let cascade_capabilities_default = {
+  supports_inline_tools = false;
+  supports_runtime_mcp_tools = false;
+  supports_runtime_tool_events = false;
+  supports_runtime_mcp_http_headers = false;
+  requires_per_keeper_bridging_for_bound_actor_tools = false;
+  identity_runtime_mcp_header_keys = [];
+  argv_prompt_preflight = false;
+  uses_anthropic_caching = false;
+  max_turns_per_attempt = None;
+}
 type cascade_provider = {
   id : string;
   display_name : string;

--- a/lib/cascade_decl/cascade_declarative_types.mli
+++ b/lib/cascade_decl/cascade_declarative_types.mli
@@ -48,19 +48,29 @@ type cascade_liveness_class =
   | Local_70b_plus
 [@@deriving show, eq]
 
-(** Per-provider runtime capabilities — RFC-0058 §3.2. Schema-only at this
-    phase: a Phase 5.1 follow-up will replace the hardcoded variant match
-    in
-    [Llm_provider.Capabilities.{claude_code,gemini_cli,kimi_cli,codex_cli}_capabilities]
-    with a cascade.toml lookup. Boolean defaults are [false] — explicit
-    declaration in TOML is required for any non-false capability. *)
+(** Per-provider runtime + behavioral capabilities — RFC-0058 §2.4 +
+    Phase 5.1 (caller cutover prep, A.1) + §3.2 Phase 5.6 (tool/event support).
+
+    Schema-additive in this PR; no callers consume the fields yet.
+    Phase 5.1 caller cutover follows in A.3 (cascade_transport,
+    Provider_tool_support, Cascade_error_classify, Keeper_usage_trust);
+    Phase 5.6 caller cutover replaces [Cascade_config.headers_with_auth]
+    variant match. *)
 type cascade_capabilities = {
   supports_inline_tools : bool;
   supports_runtime_mcp_tools : bool;
   supports_runtime_tool_events : bool;
   supports_runtime_mcp_http_headers : bool;
+  requires_per_keeper_bridging_for_bound_actor_tools : bool;
+  identity_runtime_mcp_header_keys : string list;
+  argv_prompt_preflight : bool;
+  uses_anthropic_caching : bool;
+  max_turns_per_attempt : int option;
 }
 [@@deriving show, eq]
+
+val cascade_capabilities_default : cascade_capabilities
+
 
 type cascade_provider = {
   id : string;
@@ -71,17 +81,17 @@ type cascade_provider = {
   credentials : cascade_credential option;
   liveness_class : cascade_liveness_class option;
   capabilities : cascade_capabilities option;
-  (** Reserved schema (Phase 5.1 prep). Caller cutover follows in a
-      separate PR that replaces the [Llm_provider.Capabilities.*]
-      variant defaults. *)
+  (** Caller cutover (A.3) replaces:
+      - [Llm_provider.Capabilities.*] variant defaults (Phase 5.6, tool/event fields)
+      - [Cascade_transport] / [Provider_tool_support] / [Cascade_error_classify] /
+        [Keeper_usage_trust] closed-variant matches (Phase 5.1, dispatch fields) *)
   headers : (string * string) list option;
   (** Reserved schema (Phase 5.6 prep). Additional HTTP headers per
       provider, e.g. [("anthropic-version", "2023-06-01")] for Anthropic
       HTTP API. Sorted by key for deterministic show/eq. [None] means
       no [\[providers.<id>.headers\]] sub-table; [Some \[\]] means
       declared but empty (or all entries rejected as non-string).
-      Caller cutover follows in a separate PR that replaces
-      [Cascade_config.headers_with_auth] variant match. *)
+      Caller cutover replaces [Cascade_config.headers_with_auth] variant match. *)
 }
 [@@deriving show, eq]
 

--- a/test/test_cascade_declarative_parser.ml
+++ b/test/test_cascade_declarative_parser.ml
@@ -630,6 +630,8 @@ command = "c"
       (Option.map show_cascade_liveness_class p.liveness_class)
   | _ -> failwith "expected exactly one provider"
 
+(* --- Capabilities tests (#14608 tool/event fields + RFC-0058 §2.4 Phase 5.1 dispatch fields) --- *)
+
 let test_capabilities_present () =
   let toml = {|
 [providers.p]
@@ -666,6 +668,107 @@ command = "c"
   | [ p ] ->
     check (option string) "no capabilities sub-table → None" None
       (Option.map show_cascade_capabilities p.capabilities)
+  | _ -> failwith "expected exactly one provider"
+
+let test_capabilities_full () =
+  (* All 9 fields (4 from #14608 + 5 from A.1) populated. *)
+  let toml = {|
+[providers.p]
+protocol = "anthropic-cli"
+command = "c"
+
+[providers.p.capabilities]
+supports-inline-tools = true
+supports-runtime-mcp-tools = true
+supports-runtime-tool-events = true
+supports-runtime-mcp-http-headers = true
+requires-per-keeper-bridging-for-bound-actor-tools = true
+identity-runtime-mcp-header-keys = ["authorization", "x-masc-agent-name"]
+argv-prompt-preflight = true
+uses-anthropic-caching = true
+max-turns-per-attempt = 30
+|} in
+  let cfg = ok_config (parse_string toml) in
+  match cfg.providers with
+  | [ p ] ->
+    (match p.capabilities with
+     | None -> failwith "expected capabilities record"
+     | Some c ->
+       check bool "supports_inline_tools" true c.supports_inline_tools;
+       check bool "supports_runtime_mcp_tools" true c.supports_runtime_mcp_tools;
+       check bool "supports_runtime_tool_events" true c.supports_runtime_tool_events;
+       check bool "supports_runtime_mcp_http_headers" true c.supports_runtime_mcp_http_headers;
+       check bool "requires_per_keeper_bridging" true
+         c.requires_per_keeper_bridging_for_bound_actor_tools;
+       check (list string) "identity_runtime_mcp_header_keys"
+         [ "authorization"; "x-masc-agent-name" ]
+         c.identity_runtime_mcp_header_keys;
+       check bool "argv_prompt_preflight" true c.argv_prompt_preflight;
+       check bool "uses_anthropic_caching" true c.uses_anthropic_caching;
+       check (option int) "max_turns_per_attempt" (Some 30) c.max_turns_per_attempt)
+  | _ -> failwith "expected exactly one provider"
+
+let test_capabilities_partial_defaults () =
+  (* Only uses-anthropic-caching declared; the rest fall back to schema defaults. *)
+  let toml = {|
+[providers.p]
+protocol = "anthropic-cli"
+command = "c"
+
+[providers.p.capabilities]
+uses-anthropic-caching = true
+|} in
+  let cfg = ok_config (parse_string toml) in
+  match cfg.providers with
+  | [ p ] ->
+    (match p.capabilities with
+     | None -> failwith "expected capabilities record"
+     | Some c ->
+       check bool "uses_anthropic_caching set" true c.uses_anthropic_caching;
+       check bool "supports_runtime_mcp_http_headers default false"
+         false c.supports_runtime_mcp_http_headers;
+       check (list string) "identity_runtime_mcp_header_keys default []"
+         [] c.identity_runtime_mcp_header_keys;
+       check (option int) "max_turns_per_attempt default None"
+         None c.max_turns_per_attempt)
+  | _ -> failwith "expected exactly one provider"
+
+let test_capabilities_max_turns_zero_rejected () =
+  let toml = {|
+[providers.p]
+protocol = "anthropic-cli"
+command = "c"
+
+[providers.p.capabilities]
+max-turns-per-attempt = 0
+|} in
+  let cfg = ok_config (parse_string toml) in
+  match cfg.providers with
+  | [ p ] ->
+    (match p.capabilities with
+     | None -> failwith "expected capabilities record"
+     | Some c ->
+       check (option int) "non-positive max_turns_per_attempt ignored"
+         None c.max_turns_per_attempt)
+  | _ -> failwith "expected exactly one provider"
+
+let test_capabilities_max_turns_negative_rejected () =
+  let toml = {|
+[providers.p]
+protocol = "anthropic-cli"
+command = "c"
+
+[providers.p.capabilities]
+max-turns-per-attempt = -5
+|} in
+  let cfg = ok_config (parse_string toml) in
+  match cfg.providers with
+  | [ p ] ->
+    (match p.capabilities with
+     | None -> failwith "expected capabilities record"
+     | Some c ->
+       check (option int) "negative max_turns_per_attempt ignored"
+         None c.max_turns_per_attempt)
   | _ -> failwith "expected exactly one provider"
 
 let test_headers_present () =
@@ -718,6 +821,7 @@ command = "c"
     check (option (list (pair string string)))
       "declared but empty → Some []" (Some []) p.headers
   | _ -> failwith "expected exactly one provider"
+
 
 (* --- Test suite --- *)
 
@@ -786,6 +890,12 @@ let () =
       "capabilities", [
         test_case "present parses with defaults" `Quick test_capabilities_present;
         test_case "absent yields None" `Quick test_capabilities_absent;
+        test_case "full parse (all 9 fields)" `Quick test_capabilities_full;
+        test_case "partial defaults" `Quick test_capabilities_partial_defaults;
+        test_case "max-turns 0 rejected" `Quick
+          test_capabilities_max_turns_zero_rejected;
+        test_case "max-turns negative rejected" `Quick
+          test_capabilities_max_turns_negative_rejected;
       ];
       "headers", [
         test_case "present sorted by key" `Quick test_headers_present;


### PR DESCRIPTION
Populates capabilities sub-table for 4 vendors with current dispatch truth. Depends on #14609 (A.1 schema). Pure data PR — no caller change. A.3 migrates callers to read provider_cfg.capabilities; until then data is parsed but unused.