### PR TITLE
refactor(tool-result): RFC-0062 Phase 4d — replace Tool_result.wrap callers with typed ok/error

### DIFF
--- a/lib/anti_rationalization.ml
+++ b/lib/anti_rationalization.ml
@@ -554,16 +554,15 @@ let review
     let verdict_ref = ref None in
     let dispatch ~name ~args =
       let start_time = Time_compat.now () in
-      let result : bool * string =
-        match parse_review_verdict_from_json args with
-        | Ok v ->
-          verdict_ref := Some v;
-          (false, match v with Approve -> "Approved" | Reject r -> "Rejected: " ^ r)
-        | Error msg ->
-          Log.Task.warn "[anti-rationalization] structured verdict parse failed: %s" msg;
-          (false, sprintf "Invalid verdict format: %s" msg)
-      in
-      Tool_result.wrap ~tool_name:name ~start_time result
+      match parse_review_verdict_from_json args with
+      | Ok v ->
+        verdict_ref := Some v;
+        let msg = match v with Approve -> "Approved" | Reject r -> "Rejected: " ^ r in
+        Tool_result.error ~tool_name:name ~start_time msg
+      | Error msg ->
+        Log.Task.warn "[anti-rationalization] structured verdict parse failed: %s" msg;
+        Tool_result.error ~tool_name:name ~start_time
+          (sprintf "Invalid verdict format: %s" msg)
     in
     (match
        Masc_oas_bridge.run_with_caller

--- a/lib/keeper/keeper_tools_oas.ml
+++ b/lib/keeper/keeper_tools_oas.ml
@@ -1074,7 +1074,11 @@ let make_tool_bundle
                 ~input_schema:td.input_schema
                 (fun input ->
                    let start_time = Time_compat.now () in
-                   Tool_result.wrap ~tool_name:td.name ~start_time (h input))))
+                   let (success, message) = h input in
+                   if success then
+                     Tool_result.ok ~tool_name:td.name ~start_time message
+                   else
+                     Tool_result.error ~tool_name:td.name ~start_time message)))
          else None)
       tool_defs_for_pass_a
   in
@@ -1140,7 +1144,11 @@ let make_tool_bundle
                     ~input_schema
                     (fun input ->
                        let start_time = Time_compat.now () in
-                       Tool_result.wrap ~tool_name:public ~start_time (h input)))))
+                       let (success, message) = h input in
+                       if success then
+                         Tool_result.ok ~tool_name:public ~start_time message
+                       else
+                         Tool_result.error ~tool_name:public ~start_time message))))
       (Keeper_tool_alias.public_names ())
   in
   { tools = internal_tools @ alias_tools

--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -533,27 +533,28 @@ let start_keeper_loops ~sw ~clock ~net ~domain_mgr ~proc_mgr
     | "masc_status" -> (
         match Tool_coord.dispatch ctx_room ~name ~args with
         | Some { Coord_types.success; message } ->
-            Tool_result.wrap ~tool_name:name ~start_time (success, message)
+            if success then Tool_result.ok ~tool_name:name ~start_time message
+            else Tool_result.error ~tool_name:name ~start_time message
         | None ->
-            Tool_result.wrap ~tool_name:name ~start_time
-              (false, "masc_status: dispatch failed"))
+            Tool_result.error ~tool_name:name ~start_time
+              "masc_status: dispatch failed")
     | "masc_tasks" -> (
         match Tool_task.dispatch ctx_task ~name ~args with
         | Some result -> result
         | None ->
-            Tool_result.wrap ~tool_name:name ~start_time
-              (false, "masc_tasks: dispatch failed"))
+            Tool_result.error ~tool_name:name ~start_time
+              "masc_tasks: dispatch failed")
     | "masc_agents" -> (
         match Tool_agent.dispatch ctx_agent ~name ~args with
         | Some result -> result
         | None ->
-            Tool_result.wrap ~tool_name:name ~start_time
-              (false, "masc_agents: dispatch failed"))
+            Tool_result.error ~tool_name:name ~start_time
+              "masc_agents: dispatch failed")
     | "masc_board_list" ->
         Tool_board.handle_tool name args
     | _ ->
-        Tool_result.wrap ~tool_name:name ~start_time
-          (false, Printf.sprintf "judge: tool '%s' not allowed" name)
+        Tool_result.error ~tool_name:name ~start_time
+          (Printf.sprintf "judge: tool '%s' not allowed" name)
   in
   let governance_judge_dispatch = make_judge_dispatch ~actor:"governance-judge" in
   let operator_judge_dispatch = make_judge_dispatch ~actor:"operator-judge" in

--- a/lib/tool_board.ml
+++ b/lib/tool_board.ml
@@ -1414,7 +1414,9 @@ let handle_tool name args =
       result
     | _ -> (false, Printf.sprintf "Unknown tool: %s" name)
   in
-  Tool_result.wrap ~tool_name:name ~start_time result
+  let (success, message) = result in
+  if success then Tool_result.ok ~tool_name:name ~start_time message
+  else Tool_result.error ~tool_name:name ~start_time message
 
 let tool_spec_read_only =
   [

--- a/lib/verifier_oas.ml
+++ b/lib/verifier_oas.ml
@@ -98,16 +98,15 @@ let verify (req : verification_request) : (verdict, string) result =
     let verdict_ref = ref None in
     let dispatch ~name ~args =
       let start_time = Time_compat.now () in
-      let result : bool * string =
-        match parse_verdict_from_json args with
-        | Ok v ->
-          verdict_ref := Some v;
-          (false, sprintf "Verdict recorded: %s" (verdict_to_string v))
-        | Error msg ->
-          Log.Verifier.warn "Structured verdict parse failed: %s" msg;
-          (false, sprintf "Invalid verdict format: %s" msg)
-      in
-      Tool_result.wrap ~tool_name:name ~start_time result
+      match parse_verdict_from_json args with
+      | Ok v ->
+        verdict_ref := Some v;
+        Tool_result.error ~tool_name:name ~start_time
+          (sprintf "Verdict recorded: %s" (verdict_to_string v))
+      | Error msg ->
+        Log.Verifier.warn "Structured verdict parse failed: %s" msg;
+        Tool_result.error ~tool_name:name ~start_time
+          (sprintf "Invalid verdict format: %s" msg)
     in
     let cascade_name =
       Keeper_cascade_profile.cascade_name_for_use


### PR DESCRIPTION
## Summary

Replaces 10 `Tool_result.wrap` call sites across 5 modules with direct `Tool_result.ok` / `Tool_result.error` invocation. The `wrap` function (legacy `(bool * string) -> t` adapter) is now unused inside `lib/`.

Plan: `~/me/planning/claude-plans/polished-juggling-galaxy.md` — Stage 1 PR-A. RFC-0062.

## Call sites converted

| File | Sites | Pattern |
|------|-------|---------|
| `lib/verifier_oas.ml` | 1 | verdict dispatch always `success=false` → `Tool_result.error` |
| `lib/anti_rationalization.ml` | 1 | review verdict dispatch, same pattern |
| `lib/server/server_bootstrap_loops.ml` | 5 | `make_judge_dispatch` tool branches — `if success then ok else error` |
| `lib/tool_board.ml` | 1 | `handle_tool` match tail — same if/else pattern |
| `lib/keeper/keeper_tools_oas.ml` | 2 | `oas_tool_of_masc` bridges (Pass A + alias path) — `h input` returns `(bool * string)`, inline branch |

## Gate (G3)

\`\`\`
$ rg 'Tool_result\\.(wrap|to_legacy_compat)' lib/ -t ocaml | wc -l
0
\`\`\`

The `Tool_result.wrap` and `to_legacy_compat` definitions remain in `tool_result.ml(.mli)` — those are removed in the PR-B follow-up that closes RFC-0062 Phase 4d.

## Pattern notes

The migration is intentionally **inline** (`if success then ok else error`) rather than introducing a `wrap_legacy` helper:
- A local helper would reproduce the `(bool * string)` tuple anti-pattern.
- The two verdict-dispatch sites (`verifier_oas`, `anti_rationalization`) emit `success=false` unconditionally — verdict capture is a side-effect via `verdict_ref := Some v`, so the dispatch return itself signals \"observed but not actionable\". This semantic is preserved by always using `Tool_result.error`.

Deeper typed migration of `handle_tool` (returning `Tool_result.t` directly from each handler instead of `(bool * string)`) is out-of-scope for PR-A and tracked as future work.

## Test plan

- [x] `dune build --root . @check` green
- [ ] CI: `dune test --root .` passes
- [ ] Smoke: `masc_status` / `masc_tasks` / `masc_agents` judge dispatch still returns the same logical result

🤖 Generated with [Claude Code](https://claude.com/claude-code)