### PR TITLE
test(cascade): repair stale Pattern C expectations after #14356 / #13194

### DIFF
--- a/test/test_cascade_catalog_runtime.ml
+++ b/test/test_cascade_catalog_runtime.ml
@@ -511,8 +511,14 @@ let test_valid_catalog_records_probe_error_without_eio_caps () =
     require_ok
       (Cascade_catalog_runtime.resolve_declared_name ~raw_name:"" ())
   in
-  check string "blank name defaults to big_three"
-    Keeper_config.default_cascade_name blank_name;
+  (* [Keeper_config.default_cascade_name] is evaluated at module init
+     when no catalog is loaded, so it freezes to the
+     [first_alias_or_key] fallback ("default").  After the fixture
+     installs a catalog whose first profile is "big_three",
+     [resolve_declared_name ""] returns "big_three" — the live answer.
+     Pin against the fixture's first profile, not the init-time cache. *)
+  check string "blank name defaults to first catalog profile"
+    "big_three" blank_name;
   let custom_exec_name =
     require_ok
       (Cascade_catalog_runtime.resolve_declared_name
@@ -535,13 +541,15 @@ let test_valid_catalog_records_probe_error_without_eio_caps () =
     [ strict_model ]
     (require_ok
        (Cascade_catalog_runtime.models_of_cascade_name "strict_exec"));
+  (* Same init-time-cache issue: pin against the fixture's first
+     profile name. *)
   check string "keeper_unified logical alias falls back to big_three"
-    Keeper_config.default_cascade_name
+    "big_three"
     (require_ok
        (Cascade_catalog_runtime.resolve_declared_name
           ~raw_name:"keeper_unified" ()));
   check string "tool_use_strict logical alias falls back to big_three"
-    Keeper_config.default_cascade_name
+    "big_three"
     (require_ok
        (Cascade_catalog_runtime.resolve_declared_name
           ~raw_name:"tool_use_strict" ()));
@@ -806,8 +814,11 @@ let test_partial_catalog_keeps_validated_subset_available () =
   check bool "rejected invalid candidate is surfaced" true
     (contains_substring rejection_json
        "__nonexistent_provider_sentinel__:fake");
+  (* Same caveat as test_valid_catalog_records_probe_error_without_eio_caps:
+     [Keeper_config.default_cascade_name] is module-init-cached; assert
+     against the fixture's first profile name directly. *)
   check (list string) "dashboard only advertises validated profiles"
-    [ Keeper_config.default_cascade_name; "tool_rerank" ]
+    [ "big_three"; "tool_rerank" ]
     (Masc_mcp.Server_routes_http_routes_dashboard.available_cascade_profiles ());
   let invalid_profiles =
     Masc_mcp.Server_routes_http_routes_dashboard.invalid_cascade_profiles ()
@@ -833,7 +844,7 @@ let test_partial_catalog_keeps_validated_subset_available () =
     |> List.map (json_string_field "name")
   in
   check (list string) "dashboard config_json only renders validated profiles"
-    [ Keeper_config.default_cascade_name; "tool_rerank" ]
+    [ "big_three"; "tool_rerank" ]
     profile_names;
   check bool "dashboard config_json keeps rejected profile metadata" true
     (contains_substring (Yojson.Safe.to_string config_json) "broken_profile")

--- a/test/test_dashboard_cascade.ml
+++ b/test/test_dashboard_cascade.ml
@@ -1124,6 +1124,15 @@ let lookup fields key =
   | None -> fail (Printf.sprintf "%s missing" key)
 ;;
 
+(* RFC-0058 §9 / #14356: with no live catalog installed in the test
+   environment, [Keeper_cascade_profile.resolve_live] falls back to
+   [Cascade_routes.first_alias_or_key Keeper_turn], whose first alias is
+   ["default"].  These tests verify the raw-vs-canonical drift surface,
+   which is independent of the specific canonical name — what matters is
+   that an unknown raw collapses to *some* known fallback that differs
+   from the raw value. *)
+let canonical_empty_catalog_fallback = "default"
+
 let test_keeper_profile_preserves_raw_unknown_cascade () =
   (* Genuinely unknown cascade — not in the live catalog and not a
      registered logical alias.  Typical sources: typos, personal
@@ -1142,8 +1151,8 @@ let test_keeper_profile_preserves_raw_unknown_cascade () =
     (lookup fs "cascade_name");
   check
     string
-    "canonical collapses unknown → keeper_unified"
-    "big_three"
+    "canonical collapses unknown → keeper_turn fallback"
+    canonical_empty_catalog_fallback
     (lookup fs "canonical");
   check
     bool
@@ -1165,8 +1174,8 @@ let test_keeper_profile_preserves_raw_legacy_alias () =
     (lookup fs "cascade_name");
   check
     string
-    "legacy alias canonicalizes to keeper_unified"
-    "big_three"
+    "legacy alias canonicalizes via routes table"
+    canonical_empty_catalog_fallback
     (lookup fs "canonical");
   check
     bool
@@ -1176,13 +1185,18 @@ let test_keeper_profile_preserves_raw_legacy_alias () =
 ;;
 
 let test_keeper_profile_canonical_matches_when_raw_is_canonical () =
+  (* With no test catalog installed, the canonical name surfaces as the
+     [Keeper_turn] alias fallback ([default]).  Passing that same name
+     as the raw should round-trip — raw == canonical. *)
   let fs =
     Masc_mcp.Dashboard_cascade.keeper_profile_fields
       ~keeper:"verdict"
-      ~cascade_name:"big_three"
+      ~cascade_name:canonical_empty_catalog_fallback
   in
-  check string "cascade_name stays canonical" "big_three" (lookup fs "cascade_name");
-  check string "canonical matches" "big_three" (lookup fs "canonical");
+  check string "cascade_name stays canonical"
+    canonical_empty_catalog_fallback (lookup fs "cascade_name");
+  check string "canonical matches"
+    canonical_empty_catalog_fallback (lookup fs "canonical");
   check
     bool
     "raw == canonical → UI renders —"
@@ -1306,21 +1320,35 @@ let test_recommendation_disable_for_decayed_provider () =
 ;;
 
 let test_recommendation_investigate_for_stuck_streak () =
-  let info =
+  (* Reviewer #13194 added a [trust_score < 0.50] clause to the
+     stuck-fingerprint gate: a busy provider with a lifetime artifact
+     should not trigger Investigate when the recent window is healthy.
+     Verify both directions: high-trust + stuck → no recommendation;
+     low-trust + stuck → investigate. *)
+  let healthy_stuck =
     mk_info
-      "p"
+      "p_healthy"
       ~success_rate:0.8
-        (* trust above the disable/reduce
-                                      thresholds, so the stuck-streak
-                                      branch is what trips the rule *)
       ~events_in_window:8
       ~top_fingerprints:[ "runtime_mcp_auth|cafed00d", 6 ]
   in
-  match DC.classify_recommendation info with
+  (match DC.classify_recommendation healthy_stuck with
+   | None -> ()
+   | Some _ ->
+     failwith
+       "high trust + stuck fingerprint should not recommend investigate");
+  let unhealthy_stuck =
+    mk_info
+      "p_unhealthy"
+      ~success_rate:0.4
+      ~events_in_window:8
+      ~top_fingerprints:[ "runtime_mcp_auth|cafed00d", 6 ]
+  in
+  match DC.classify_recommendation unhealthy_stuck with
   | Some r ->
     check
       string
-      "investigate (stuck streak)"
+      "investigate (low trust + stuck streak)"
       "investigate"
       (DC.recommendation_action_to_string r.rec_action)
   | None -> failwith "expected investigate recommendation"


### PR DESCRIPTION
Follow-up to #14616 (Phase 9.3 fixture sweep). Pattern C 6 failures 완전 제거.

## Pattern C 3-way split

총 6 failures, 모두 stale tests (intent-shifting PR 뒤 업데이트 누락). 세 개 서로 다른 근본 원인 → 각각 수술적 fix.

### C1 — dashboard `keeper_profile_json` ×3
**PR ⏪**: #14356 \"refactor(cascade): drop Big_three/Tool_rerank enum\" (May 9 2026)

#14356이 `Keeper_cascade_profile.Big_three` enum + \"unknown raw → collapse to big_three\" 휴리스틱을 제거했음. 이제 `resolve_live_with_catalog`는 unknown을 그대로 통과시키고, catalog에도 없으면 `Cascade_routes.first_alias_or_key Keeper_turn` = `\"default\"` 로 fallback. 테스트는 여전히 `\"big_three\"` 기대, 코멘트만 \"keeper_unified\"로 수정되고 어설프션은 그대로 남아있었음.

**Fix**: 어설프션을 \"default\"로 갱신. drift 계약 (raw ≠ canonical) 은 그대로 유지.

### C2 — catalog_runtime #0, #9
**근본**: `Keeper_config.default_cascade_name` 은 module-init 시점에 평가되어 `Cascade_routes.first_alias_or_key Keeper_turn` = `\"default\"`로 고정. 테스트가 이후 catalog (first profile = `\"big_three\"`) 을 install 해도 이 상수는 업데이트 안 됨.

Test 의 expected = `Keeper_config.default_cascade_name` (= `\"default\"`), runtime의 actual = first catalog name (= `\"big_three\"`). 계어적 cache vs live snapshot 불일치.

**Fix**: 테스트의 expected를 fixture가 설정한 first profile (`\"big_three\"` literal) 로 교체. 3 사이트 (line 514, 552, 810, 836). 다른 `Keeper_config.default_cascade_name` 사용은 해당 경로를 타지 않아 유지.

### C3 — recommendations `stuck_streak`
**PR ⏪**: #13194 (리뷰어 의견 반영) 가 stuck-fingerprint gate 에 `trust_score < 0.50` 추가. \"busy provider 의 lifetime artifact 가 healthy window 에서는 investigate 안 해야\" 의도.

기존 테스트는 trust=0.8 (healthy) + stuck 시나리오로 `Investigate` 기대, 새 gate 와 정대로 충돌.

**Fix**: 두 방향 모두 테스트. high-trust + stuck → None / low-trust + stuck → Investigate. #13194 gate 의 양쪽 보장.

## 검증

모든 cascade suite GREEN:
- `test_dashboard_cascade`: 38/42 → **42/42**
- `test_cascade_catalog_runtime`: 21/23 → **23/23**
- 다른 cascade suite 이전 상태 유지

남은 전체 cascade-area failure: `test_config_dir_resolver personas_dirs #2` (1 개, cascade 와 무관).

## 관련

- 선행 PR: #14611 (RFC-0058 §9.4), #14616 (#14612 fixture sweep)
- 참조 PR: #14356, #13194

🤖 Generated with [Claude Code](https://claude.com/claude-code)