### PR TITLE
refactor(tool-result): RFC-0062 Phase 4d closeout — delete Tool_result.wrap and to_legacy_compat

### DIFF
--- a/lib/tool_result.ml
+++ b/lib/tool_result.ml
@@ -135,23 +135,6 @@ let structured_payload_of_message (message : string) : Yojson.Safe.t option =
       in
       loop 0
 
-let wrap ?(failure_class = None) ~tool_name ~start_time (success, message) =
-  let end_time = Time_compat.now () in
-  let duration_ms = (end_time -. start_time) *. 1000.0 in
-  let data =
-    match structured_payload_of_message message with
-    | Some json -> json
-    | None -> `String message
-  in
-  let failure_class =
-    match failure_class with
-    | Some _ -> failure_class
-    | None ->
-        if success then None
-        else Some (classify_from_dispatch_failure message)
-  in
-  { success; data; legacy_message = message; tool_name; duration_ms; failure_class }
-
 let to_json t =
   let base =
     [ ("success", `Bool t.success)
@@ -170,10 +153,8 @@ let message t = t.legacy_message
 
 let failure_class t = t.failure_class
 
-let to_legacy_compat t = (t.success, message t)
-
 (** Handler constructors — used by Tool_*.dispatch functions
-    to build structured results directly without going through [wrap]. *)
+    to build structured results directly. *)
 
 let ok ~tool_name ~start_time message =
   let end_time = Time_compat.now () in

--- a/lib/tool_result.mli
+++ b/lib/tool_result.mli
@@ -52,33 +52,12 @@ type t = {
 
 val structured_payload_of_message : string -> Yojson.Safe.t option
 
-val wrap :
-  ?failure_class:tool_failure_class option ->
-  tool_name:string ->
-  start_time:float ->
-  (bool * string) ->
-  t
-(** [wrap ~tool_name ~start_time raw] converts a legacy [(bool * string)]
-    tuple into a structured result.
-
-    When [failure_class] is not provided and the result is a failure,
-    the message is classified by an internal heuristic. *)
-
 val to_json : t -> Yojson.Safe.t
 
 val message : t -> string
 
 val failure_class : t -> tool_failure_class option
 (** Accessor for the typed failure classification. *)
-
-val to_legacy_compat : t -> bool * string
-(** Converts back to [(bool * string)] for callers that have not yet
-    migrated to the typed result interface.
-
-    @deprecated Prefer consuming {!t} directly. *)
-[@@alert legacy_tuple
-  "This function exists for migration only. \
-   Migrate the call site to use Tool_result.t directly."]
 
 (** {1 Handler constructors}
 

--- a/test/test_oas_worker.ml
+++ b/test/test_oas_worker.ml
@@ -2300,7 +2300,7 @@ let test_run_model_with_masc_tools_rejects_invalid_explicit_label () =
       ~goal:"test goal"
       ~masc_tools:[]
       ~dispatch:(fun ~name ~args:_ ->
-        Tool_result.wrap ~tool_name:name ~start_time:(Time_compat.now ()) (true, "ok"))
+        Tool_result.ok ~tool_name:name ~start_time:(Time_compat.now ()) "ok")
       ()
   with
   | Ok _ -> Alcotest.fail "expected invalid explicit model label to fail before execution"

--- a/test/test_tool_result.ml
+++ b/test/test_tool_result.ml
@@ -4,85 +4,9 @@ module Tool_result = Masc_mcp.Tool_result
 module Tool_dispatch = Masc_mcp.Tool_dispatch
 module Time_compat = Time_compat
 
-let to_legacy_compat_for_test =
-  (Tool_result.to_legacy_compat [@alert "-legacy_tuple"])
-
-let test_wrap_json_response () =
-  let start = 1000.0 in
-  let raw = (true, {|{"status":"ok","count":42}|}) in
-  let r = Tool_result.wrap ~tool_name:"masc_status" ~start_time:start raw in
-  Alcotest.(check bool) "success" true r.success;
-  Alcotest.(check string) "tool_name" "masc_status" r.tool_name;
-  (* data should be parsed JSON, not a string *)
-  (match r.data with
-   | `Assoc fields ->
-     Alcotest.(check bool) "has status field"
-       true
-       (List.exists (fun (k, _) -> k = "status") fields)
-   | _ -> Alcotest.fail "expected Assoc");
-  Alcotest.(check bool) "duration >= 0" true (r.duration_ms >= 0.0)
-
-let test_wrap_plain_string () =
-  let start = Time_compat.now () in
-  let raw = (false, "Something went wrong") in
-  let r = Tool_result.wrap ~tool_name:"masc_transition" ~start_time:start raw in
-  Alcotest.(check bool) "failure" false r.success;
-  Alcotest.(check string) "tool_name" "masc_transition" r.tool_name;
-  (* Non-JSON string should be wrapped as `String *)
-  (match r.data with
-   | `String s ->
-     Alcotest.(check string) "plain string preserved" "Something went wrong" s
-   | _ -> Alcotest.fail "expected String for non-JSON input")
-
-let test_wrap_prefixed_json_response () =
-  let start = 1000.0 in
-  let raw =
-    ( true,
-      "✅ Post created:\n{\"id\":\"post-1\",\"content\":\"hello\",\"ok\":true}" )
-  in
-  let r = Tool_result.wrap ~tool_name:"masc_board_post" ~start_time:start raw in
-  match r.data with
-  | `Assoc fields ->
-      Alcotest.(check string) "id parsed" "post-1"
-        Yojson.Safe.Util.(List.assoc "id" fields |> to_string);
-      Alcotest.(check string) "content parsed" "hello"
-        Yojson.Safe.Util.(List.assoc "content" fields |> to_string)
-  | _ -> Alcotest.fail "expected parsed JSON from prefixed payload"
-
-let test_prefixed_json_legacy_message_roundtrip () =
-  let start = 1000.0 in
-  let message =
-    "Post created:\n{\"id\":\"post-1\",\"content\":\"hello\",\"ok\":true}"
-  in
-  let r =
-    Tool_result.wrap ~tool_name:"masc_board_post" ~start_time:start
-      (true, message)
-  in
-  Alcotest.(check bool) "success preserved" true r.success;
-  let legacy_success, legacy = to_legacy_compat_for_test r in
-  Alcotest.(check bool) "legacy success preserved" true legacy_success;
-  Alcotest.(check string) "legacy prefix preserved" message legacy
-
-let test_empty_legacy_message_is_preserved () =
-  let r =
-    {
-      Tool_result.success = true;
-      data = `Assoc [ ("status", `String "ok") ];
-      legacy_message = "";
-      tool_name = "direct";
-      duration_ms = 0.0;
-      failure_class = None;
-    }
-  in
-  Alcotest.(check string) "message remains empty" "" (Tool_result.message r);
-  let legacy_success, legacy = to_legacy_compat_for_test r in
-  Alcotest.(check bool) "legacy success preserved" true legacy_success;
-  Alcotest.(check string) "legacy message remains empty" "" legacy
-
 let test_to_json () =
   let start = Time_compat.now () in
-  let raw = (true, "done") in
-  let r = Tool_result.wrap ~tool_name:"masc_transition" ~start_time:start raw in
+  let r = Tool_result.ok ~tool_name:"masc_transition" ~start_time:start "done" in
   let json = Tool_result.to_json r in
   match json with
   | `Assoc fields ->
@@ -95,8 +19,7 @@ let test_to_json () =
 
 let test_message_roundtrip () =
   let start = Time_compat.now () in
-  let original = (true, "hello world") in
-  let r = Tool_result.wrap ~tool_name:"test" ~start_time:start original in
+  let r = Tool_result.ok ~tool_name:"test" ~start_time:start "hello world" in
   let success = r.success in
   let message = Tool_result.message r in
   Alcotest.(check bool) "success preserved" true success;
@@ -105,8 +28,7 @@ let test_message_roundtrip () =
 let test_message_json_roundtrip () =
   let start = Time_compat.now () in
   let json_str = {|{"key":"value"}|} in
-  let original = (true, json_str) in
-  let r = Tool_result.wrap ~tool_name:"test" ~start_time:start original in
+  let r = Tool_result.ok ~tool_name:"test" ~start_time:start json_str in
   let message = Tool_result.message r in
   (* JSON roundtrip may normalize formatting *)
   let reparsed = Yojson.Safe.from_string message in
@@ -135,16 +57,6 @@ let test_dispatch_structured_unknown () =
 
 let () =
   Alcotest.run "Tool_result" [
-    "wrap", [
-      Alcotest.test_case "json response" `Quick test_wrap_json_response;
-      Alcotest.test_case "plain string" `Quick test_wrap_plain_string;
-      Alcotest.test_case "prefixed json response" `Quick
-        test_wrap_prefixed_json_response;
-      Alcotest.test_case "prefixed json legacy message roundtrip" `Quick
-        test_prefixed_json_legacy_message_roundtrip;
-      Alcotest.test_case "empty legacy message preserved" `Quick
-        test_empty_legacy_message_is_preserved;
-    ];
     "to_json", [
       Alcotest.test_case "fields present" `Quick test_to_json;
     ];


### PR DESCRIPTION
## Summary

Plan PR-B (Stage 1). Deletes `Tool_result.wrap` and `Tool_result.to_legacy_compat` — the legacy `(bool * string)` ↔ `Tool_result.t` adapter that became unused after PR #14617.

Plan: `~/me/planning/claude-plans/polished-juggling-galaxy.md` — Stage 1 PR-B. Closes RFC-0062 Phase 4d.

Depends on: **#14617 (merged)**. Caller 0 was already established before merge; this PR removes the definitions.

## Changes

| File | Δ | What |
|------|---|------|
| `lib/tool_result.mli` | -21 | `val wrap` + `val to_legacy_compat` signatures + `[@@alert legacy_tuple]` attribute |
| `lib/tool_result.ml` | -16 | `let wrap` (16 lines) + `let to_legacy_compat` (1 line) |
| `test/test_tool_result.ml` | -94 +5 | 5 wrap-only tests removed + 3 setup-only tests migrated to `Tool_result.ok` + the `\"wrap\"` Alcotest group removed |
| `test/test_oas_worker.ml` | -1 +1 | 1 `wrap (true, \"ok\")` → `Tool_result.ok ... \"ok\"` |

Total: **+5 / -133**.

## Gate (G3)

\`\`\`
$ rg 'Tool_result\.(wrap|to_legacy_compat)' lib/ test/ -t ocaml | wc -l
0
\`\`\`

End-to-end the dispatch surface uses `Tool_result.t` with no legacy tuple intermediary.

## Test plan

- [x] `dune build --root . @check` green
- [ ] CI: `dune test --root .` — remaining tests (`to_json`, `message`, `dispatch_structured`) preserve coverage of the typed surface
- [ ] Smoke: existing `Tool_result.ok` callers (PR #14617) continue dispatching correctly

## RFC-0062 follow-up

Phase 4d is closed by this PR. RFC §9 open question (5th `Infrastructure_failure` variant) is deferred to a separate supplement RFC once production telemetry surfaces the case (~1-2 weeks post-merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)