### PR TITLE
fix(resolver): honor MASC_PERSONAS_DIR override when config root is missing

### DIFF
--- a/lib/config_dir_resolver.ml
+++ b/lib/config_dir_resolver.ml
@@ -495,21 +495,32 @@ let personas_dirs_with inputs resolution =
      happens to be true (e.g. [default_missing_root] pointing at a repo-local
      config/ tree). Without this gate, callers can silently load personas from
      a fallback root the resolver explicitly disowned. *)
-  let primary =
-    match resolution.config_root.source with
-    | Invalid_env | Missing -> []
-    | Env | Local_masc | Home_masc | Exe_relative | Cwd ->
-      if resolution.personas.exists then [ resolution.personas.path ] else []
-  in
   let explicit_personas_dir_override = trim_opt inputs.env_personas_dir in
   (* Persona resolution is intentionally single-source:
-     - MASC_PERSONAS_DIR when explicitly set
+     - MASC_PERSONAS_DIR when explicitly set (bypasses config-root gating;
+       operator-declared persona roots stand on their own — a user may
+       legitimately want personas without a full MASC config directory)
      - otherwise the resolved config root's personas/
      Hidden secondary searches (~/.masc/personas, $MASC_BASE_PATH/.masc/personas)
      make the dashboard/config panel lie about the actual source of truth. *)
   match explicit_personas_dir_override with
-  | Some _ -> dedupe_paths primary
-  | None -> dedupe_paths primary
+  | Some _ ->
+    (* The env override path is captured in [resolution.personas] by
+       [personas_item] when MASC_PERSONAS_DIR is set; honor its exists
+       flag regardless of [config_root.source].  If the env path is
+       invalid the source comes back as [Invalid_env] and we still
+       suppress to keep the no-silent-fallback contract. *)
+    (match resolution.personas.source with
+     | Env when resolution.personas.exists -> [ resolution.personas.path ]
+     | _ -> [])
+  | None ->
+    let primary =
+      match resolution.config_root.source with
+      | Invalid_env | Missing -> []
+      | Env | Local_masc | Home_masc | Exe_relative | Cwd ->
+        if resolution.personas.exists then [ resolution.personas.path ] else []
+    in
+    dedupe_paths primary
 
 let personas_dirs () =
   let resolution = resolve () in


### PR DESCRIPTION
Pre-existing failure on origin/main: `test_personas_dirs_env_override_is_sole_source` (`test_config_dir_resolver` personas_dirs #2). Discovered during the Pattern C investigation (#14620).

## 증상

Operator 가 `MASC_PERSONAS_DIR` 만 설정하고 `MASC_CONFIG_DIR` 미설정 시:
- `resolution.config_root.source = Missing` (config dir 못 찾음)
- `personas_dirs_with` 는 `primary = []` (Missing 게이트로)
- env override 가 캡쳐만 되고 사용 안 됨 → `[]` 반환

테스트가 기대: `[env_personas]`. 실제: `[]`.

## 근본 원인

```ocaml
match explicit_personas_dir_override with
| Some _ -> dedupe_paths primary    (* same as next branch *)
| None   -> dedupe_paths primary
```

두 분기가 동일 — env override 가 의도적으로 빈 hole. 컴파일러 경고 없이 dead branch.

## Fix

`personas_item` 가 이미 env override path 를 `resolution.personas` 에 `source = Env` 또는 `Invalid_env` 로 인코딩해 둠. `personas_dirs_with` 가 그 source 를 보고 결정하도록 변경:

- `personas.source = Env` AND `personas.exists` → `[path]` 반환
- 그 외 → `[]` (silent fallback 차단 계약 유지)

config-root-rooted 경로 (override 없을 때) 는 무변경.

## 검증

- `test_config_dir_resolver`: 22/23 → **23/23**
- Cascade-area 모든 suite regression 없음 (#14611 / #14616 / #14620 후 baseline 유지)

## 관련

본 PR 은 cascade 와 무관 — Pattern C 청소 중 우연히 cascade-adjacent test 인벤토리에서 발견. 별도 PR 로 분리.

🤖 Generated with [Claude Code](https://claude.com/claude-code)