### PR TITLE
feat(tool-scope): Tool_scope module + surface/keeper_internal helpers (RFC-Tools Stage 2 infra)

### DIFF
--- a/lib/config.ml
+++ b/lib/config.ml
@@ -106,3 +106,14 @@ let visible_tool_schemas ?(include_hidden = false) ?(include_deprecated = false)
     Masc_domain.tool_schema list =
   Capability_registry.visible_public_tool_schemas_from ~include_hidden
     ~include_deprecated raw_all_tool_schemas
+
+let surface_tool_schemas ?(include_hidden = false) ?(include_deprecated = false) () :
+    Masc_domain.tool_schema list =
+  visible_tool_schemas ~include_hidden ~include_deprecated ()
+  |> List.filter (fun (s : Masc_domain.tool_schema) ->
+       Tool_scope.classify ~name:s.name = Tool_scope.Surface)
+
+let keeper_internal_tool_schemas () : Masc_domain.tool_schema list =
+  visible_tool_schemas ~include_hidden:true ~include_deprecated:true ()
+  |> List.filter (fun (s : Masc_domain.tool_schema) ->
+       Tool_scope.classify ~name:s.name = Tool_scope.Keeper_internal)

--- a/lib/config.mli
+++ b/lib/config.mli
@@ -24,3 +24,18 @@ val visible_tool_schemas :
   ?include_deprecated:bool ->
   unit -> Masc_domain.tool_schema list
 (** Get visible tool schemas. *)
+
+val surface_tool_schemas :
+  ?include_hidden:bool ->
+  ?include_deprecated:bool ->
+  unit -> Masc_domain.tool_schema list
+(** Subset of [visible_tool_schemas] whose [Tool_scope.classify] is
+    [Surface]. Initial keeper-internal list is empty, so on PR-N0
+    merge this returns the same set as [visible_tool_schemas]. PR-N1+
+    populate the keeper-internal list, narrowing this surface. *)
+
+val keeper_internal_tool_schemas : unit -> Masc_domain.tool_schema list
+(** Subset whose [Tool_scope.classify] is [Keeper_internal]. Includes
+    hidden + deprecated by default since keeper personas may reach
+    tools the external MCP surface does not expose. Empty until PR-N1
+    populates the keeper-internal list. *)

--- a/lib/tool_scope.ml
+++ b/lib/tool_scope.ml
@@ -1,0 +1,17 @@
+type scope =
+  | Surface
+  | Keeper_internal
+
+(* Initial classification is empty. Subsequent PRs (PR-N1+) add specific
+   tool names here as they are migrated from the orchestrator MCP surface
+   into the keeper-internal dispatch table. *)
+let keeper_internal_list : string list = []
+
+let keeper_internal_names () = keeper_internal_list
+
+let classify ~name =
+  if List.mem name keeper_internal_list then Keeper_internal else Surface
+
+let scope_to_string = function
+  | Surface -> "surface"
+  | Keeper_internal -> "keeper_internal"

--- a/lib/tool_scope.mli
+++ b/lib/tool_scope.mli
@@ -1,0 +1,33 @@
+(** Tool scope classification — orchestrator MCP surface vs keeper-internal.
+
+    The masc-mcp tool catalog mixes two audiences:
+    - [Surface]: tools exposed to external MCP clients (supervisor agents,
+      humans via dashboard). These are the goal/board/task/broadcast +
+      admin lifecycle/observability primitives.
+    - [Keeper_internal]: tools that a keeper persona invokes during its
+      own work loop (code/web/worktree/autoresearch/plan/run/coord/inline
+      helpers). These should not be reachable from the external MCP
+      surface — only via the keeper dispatch table.
+
+    This module supplies the classification *without* requiring every
+    tool record (codegen [tool_spec] + manual [Masc_domain.tool_schema])
+    to grow a new field. Classification is a name-keyed lookup; the
+    initial keeper-internal list is empty so all tools default to
+    [Surface] until subsequent PRs (PR-N1+) move them.
+
+    Plan: ~/me/planning/claude-plans/polished-juggling-galaxy.md §2 Stage 2. *)
+
+type scope =
+  | Surface
+  | Keeper_internal
+
+val classify : name:string -> scope
+(** [classify ~name] returns the scope for the named tool. Default
+    [Surface] unless [name] appears in the keeper-internal list. *)
+
+val keeper_internal_names : unit -> string list
+(** [keeper_internal_names ()] is the explicit list of tool names whose
+    scope is [Keeper_internal]. Returned as a fresh list each call. *)
+
+val scope_to_string : scope -> string
+(** [scope_to_string s] returns ["surface"] or ["keeper_internal"]. *)


### PR DESCRIPTION
## Summary

Plan PR-N0 (Stage 2). Introduces the infrastructure for the orchestrator MCP surface trim — without changing tool behavior in this PR.

Plan: `~/me/planning/claude-plans/polished-juggling-galaxy.md` §2 Stage 2.

## What's new

| File | Δ | Role |
|------|---|------|
| `lib/tool_scope.ml` | +14 | `type scope = Surface \| Keeper_internal`, lookup by tool name |
| `lib/tool_scope.mli` | +30 | Public surface + docs |
| `lib/config.ml` | +13 | `surface_tool_schemas` / `keeper_internal_tool_schemas` helpers |
| `lib/config.mli` | +14 | Signatures + docstrings |

Total: **+76 / -0**.

## Architecture note

Scope is **not** a field on `tool_spec` or `Masc_domain.tool_schema` — both record types are left untouched.

Instead `Tool_scope.classify ~name` does a name-keyed lookup against an explicit list. This avoids:
- A ripple through every codegen `tool_spec` declaration (13 tools, growing)
- A ripple through every manual `Masc_domain.tool_schema` declaration (46 tools)
- Two divergent fields to keep in sync

This mirrors the RFC-0058 Phase 5 principle ("code is alias only, metadata in TOML") applied to the tool domain — the tool record does not know its scope; an external module classifies by name.

## No behavior change this PR

The keeper-internal list ships empty:

\`\`\`ocaml
let keeper_internal_list : string list = []
\`\`\`

Hence:
- `surface_tool_schemas () = visible_tool_schemas ()` (every tool defaults to `Surface`)
- `keeper_internal_tool_schemas () = []`

Subsequent PRs populate the list:
- **PR-N1** (Wave 1): `masc_code_*` (4), `masc_web_*` (2), `masc_worktree_*` (3) — 9 names
- **PR-N2** (Wave 2): autoresearch/plan/run/+ 5 coord-internal (per PR-N5 audit verdict)
- **PR-N3** (Board): Theory B → `masc_board_*` aliased through `keeper_board_*`
- **PR-N4** (alias dedup)

## Test plan

- [x] `dune build --root . @check` green
- [ ] CI: `dune test --root .` — no test changes; existing `visible_tool_schemas` assertions still pass
- [ ] Smoke: `Config.surface_tool_schemas ()` size = `visible_tool_schemas ()` size on this PR (no narrowing yet)

## Stage 2 follow-up readiness

- PR-N1 prerequisite check: `Tool_scope.keeper_internal_list` is the single mutation point.
- PR-N5 audit (PR #14618) verdict narrows PR-N2's coord/inline scope: 7 of 21, not 21 of 21.

🤖 Generated with [Claude Code](https://claude.com/claude-code)