### PR TITLE
feat(tool-scope): Surface trim Wave 1 — move 8 code/web/worktree tools to keeper-internal

### DIFF
--- a/lib/tool_scope.ml
+++ b/lib/tool_scope.ml
@@ -2,10 +2,22 @@ type scope =
   | Surface
   | Keeper_internal
 
-(* Initial classification is empty. Subsequent PRs (PR-N1+) add specific
-   tool names here as they are migrated from the orchestrator MCP surface
-   into the keeper-internal dispatch table. *)
-let keeper_internal_list : string list = []
+(* Wave 1 (PR-N1): 8 universal tools that keeper personas invoke during
+   their own work but that the external MCP orchestrator surface should
+   not expose. code_* helpers, web_* fetchers, worktree management. *)
+let keeper_internal_list : string list =
+  [ (* code helpers *)
+    "masc_code_read"
+  ; "masc_code_search"
+  ; "masc_code_symbols"
+    (* web fetchers *)
+  ; "masc_web_fetch"
+  ; "masc_web_search"
+    (* worktree management *)
+  ; "masc_worktree_create"
+  ; "masc_worktree_list"
+  ; "masc_worktree_remove"
+  ]
 
 let keeper_internal_names () = keeper_internal_list
 


### PR DESCRIPTION
## Summary

Plan PR-N1 (Stage 2 Wave 1). Populates `Tool_scope.keeper_internal_list` with 8 universal tools that keeper personas invoke during their own work but that the external MCP orchestrator surface should not expose.

Plan: `~/me/planning/claude-plans/polished-juggling-galaxy.md` §2 PR-N1.
Depends on: **#14625 (PR-N0 infrastructure, merged)**.

## Changes

`lib/tool_scope.ml` — keeper_internal_list 8 entries:

| Group | Tools |
|-------|-------|
| code helpers | `masc_code_read`, `masc_code_search`, `masc_code_symbols` |
| web fetchers | `masc_web_fetch`, `masc_web_search` |
| worktree management | `masc_worktree_create`, `masc_worktree_list`, `masc_worktree_remove` |

**+16/-4 LOC**.

## Effect

| | Before PR-N1 | After PR-N1 |
|---|---|---|
| `visible_tool_schemas ()` | 131 | 131 (unchanged) |
| `surface_tool_schemas ()` | 131 | **123** (-8) |
| `keeper_internal_tool_schemas ()` | 0 | 8 |

The full visible set is unchanged — this PR only narrows the orchestrator MCP surface, not the keeper dispatch surface. Keeper personas can still invoke these tools through `make_keeper_tool_handler` / `Keeper_tool_alias` routing.

## Plan accuracy note

Plan v4 §1.8 assumed Wave 1 = 9 tools (`code_*: 4` including `shell`/`write`). Actual measurement in main:

\`\`\`
$ rg -oN '"masc_code_[a-z_]+"' lib/tool_code.ml | sort -u
masc_code_read
masc_code_search
masc_code_symbols
\`\`\`

No `masc_code_shell` or `masc_code_write`. Wave 1 total **= 8**, not 9.

## Test plan

- [x] `dune build --root . @check` green
- [ ] CI: `dune test --root .` — existing tests assert on `visible_tool_schemas`, which is unchanged. New `surface_tool_schemas` has no existing assertions; a follow-up test PR could lock in `123` as the post-Wave-1 surface count
- [ ] Smoke: keeper persona dispatch of `masc_code_read` still works through internal handler routing

## Stage 2 progression

- PR-N1 (this) ✅ — Wave 1 (code/web/worktree, 8 tools)
- PR-N2 (next): Wave 2 — coord/inline 5 (per PR-N5 audit verdict #14618) + autoresearch/plan/run/etc

🤖 Generated with [Claude Code](https://claude.com/claude-code)