### PR TITLE
feat(cascade-decl): capabilities_for_provider_id lookup helper (RFC-0058 Phase 5.1 A.3 prep)

### DIFF
--- a/lib/cascade_decl/cascade_declarative_types.ml
+++ b/lib/cascade_decl/cascade_declarative_types.ml
@@ -202,6 +202,12 @@ let provider_of_id (cfg : cascade_config) (id : string) :
     cascade_provider option =
   List.find_opt (fun (p : cascade_provider) -> p.id = id) cfg.providers
 
+let capabilities_for_provider_id (cfg : cascade_config) (id : string) :
+    cascade_capabilities option =
+  match provider_of_id cfg id with
+  | Some p -> p.capabilities
+  | None -> None
+
 let model_of_id (cfg : cascade_config) (id : string) :
     cascade_model_spec option =
   List.find_opt (fun (m : cascade_model_spec) -> m.id = id) cfg.models

--- a/lib/cascade_decl/cascade_declarative_types.mli
+++ b/lib/cascade_decl/cascade_declarative_types.mli
@@ -220,6 +220,25 @@ type cascade_config = {
 
 val provider_of_id : cascade_config -> string -> cascade_provider option
 
+val capabilities_for_provider_id :
+  cascade_config -> string -> cascade_capabilities option
+(** [capabilities_for_provider_id cfg id] returns the cascade-declared
+    capabilities for the provider with id [id]. Resolves [None] in two
+    distinct cases collapsed into one option:
+    - The provider id is not declared in [cfg.providers].
+    - The provider is declared but ships no [\[providers.<id>.capabilities\]]
+      sub-table (parser yields [capabilities = None]).
+
+    A.3 callers treat [None] as "use defaults" — equivalent to
+    {!cascade_capabilities_default}. The two cases are not distinguished
+    here because A.3 callers cannot remediate either: an id misspelled
+    in code is a static bug, and a provider that opts out of declaring
+    capabilities relies on runtime defaults.
+
+    Phase 5.1 A.3 caller cutover uses this lookup to replace closed-variant
+    [match provider_kind with PK.Codex_cli | PK.Claude_code | ... -> ...]
+    patterns. *)
+
 val model_of_id : cascade_config -> string -> cascade_model_spec option
 
 val binding_of_key : cascade_config -> string -> string -> cascade_binding option

--- a/test/test_cascade_declarative_parser.ml
+++ b/test/test_cascade_declarative_parser.ml
@@ -875,6 +875,52 @@ command = "c"
   | _ -> failwith "expected exactly one provider"
 
 
+(* --- capabilities_for_provider_id lookup helper (Phase 5.1 A.3 prep) --- *)
+
+let test_capabilities_for_provider_id_present () =
+  (* Provider declares capabilities sub-table → lookup returns Some caps. *)
+  let toml = {|
+[providers.p]
+protocol = "anthropic-cli"
+command = "c"
+
+[providers.p.capabilities]
+requires-per-keeper-bridging-for-bound-actor-tools = true
+|} in
+  let cfg = ok_config (parse_string toml) in
+  match capabilities_for_provider_id cfg "p" with
+  | Some c ->
+    check bool "requires per-keeper bridging" true
+      c.requires_per_keeper_bridging_for_bound_actor_tools
+  | None -> failwith "expected Some capabilities"
+
+let test_capabilities_for_provider_id_absent () =
+  (* Provider exists but ships no capabilities sub-table → None. *)
+  let toml = {|
+[providers.p]
+protocol = "anthropic-cli"
+command = "c"
+|} in
+  let cfg = ok_config (parse_string toml) in
+  check (option string) "provider without capabilities → None" None
+    (Option.map show_cascade_capabilities
+       (capabilities_for_provider_id cfg "p"))
+
+let test_capabilities_for_provider_id_unknown_provider () =
+  (* Provider id not in cfg.providers → None.
+     Collapsed with the "declared without caps" case by design — A.3
+     callers treat both as "use defaults". *)
+  let toml = {|
+[providers.p]
+protocol = "anthropic-cli"
+command = "c"
+|} in
+  let cfg = ok_config (parse_string toml) in
+  check (option string) "unknown provider id → None" None
+    (Option.map show_cascade_capabilities
+       (capabilities_for_provider_id cfg "does-not-exist"))
+
+
 (* --- Test suite --- *)
 
 let () =
@@ -958,5 +1004,13 @@ let () =
         test_case "absent yields None" `Quick test_headers_absent;
         test_case "declared but empty yields Some []" `Quick
           test_headers_declared_but_empty;
+      ];
+      "capabilities_for_provider_id (A.3 prep)", [
+        test_case "present provider with caps returns Some" `Quick
+          test_capabilities_for_provider_id_present;
+        test_case "present provider without caps returns None" `Quick
+          test_capabilities_for_provider_id_absent;
+        test_case "unknown provider id returns None" `Quick
+          test_capabilities_for_provider_id_unknown_provider;
       ];
     ]


### PR DESCRIPTION
## Summary

Phase 5.1 A.3 caller cutover 시퀀스의 첫 PR. 변경 0 행동, 인프라만.

`Cascade_declarative_types`에 명명된 lookup helper 추가:

```ocaml
val capabilities_for_provider_id :
  cascade_config -> string -> cascade_capabilities option
```

A.3에서 swap할 caller들 (`auth_resolve.ml:92`, `cascade_catalog_validator.ml:144-152`)이 `Option.bind`를 인라인하는 대신 단일 tested entry point를 갖도록 함.

## Why

`provider_of_id cfg id |> Option.bind (fun p -> p.capabilities)`를 호출자마다 인라인하면:
- A.3 호출자별 패턴 drift 위험
- 문서화 위치 분산 (None 두 케이스 collapse 이유)
- Test boundary가 호출자 테스트에 묻힘

명명 helper로:
- "이 lookup이 A.3 cutover의 SSOT" 명시
- None semantics 단일 docstring 위치
- 호출자 swap PR이 helper에 의존하므로 helper 변경 시 호환성 영향 한눈에

### Two collapsed None cases

| 케이스 | 의미 | A.3 호출자 처리 |
|--------|------|------------------|
| provider id 미선언 | 코드의 id literal이 cascade.toml에 없음 | static bug, defaults |
| 선언됐지만 `[providers.<id>.capabilities]` 없음 | provider opts out (e.g. gemini_cli) | runtime defaults |

호출자가 두 케이스를 구분해서 처리할 방법이 없으므로 의도적 collapse.

## What's NOT in this PR (Phase 5.1 A.3 후속)

- `auth_resolve.ml:92` Codex_cli arm swap → 별도 PR
- `cascade_catalog_validator.ml:144-152` 5-arm match swap → 별도 PR
- `keeper_turn_driver_helpers.ml` timeout helper → schema 확장 PR
- `cascade_transport.ml` 23 sites → §2.4 protocol adapter (별도 RFC)

## Test plan

- [x] `dune build --root .` green
- [x] `dune exec test/test_cascade_declarative_parser.exe` 44/44 green (신규 3 포함)
- [x] G1 baseline 65 unchanged (호출자 swap 없음)

### 신규 tests (3)
- `present provider with caps returns Some` — 라운드트립
- `present provider without caps returns None` — opt-out 케이스
- `unknown provider id returns None` — 코드 id 미스매치 케이스

## Baseline

- origin/main HEAD: `5986b5d78`
- G1: 65 (변화 없음)
- capabilities: 3/6 (claude_code/codex_cli/kimi_cli)

## Refs

- RFC-0058 §2.1 "Code never knows provider names"
- Phase 5.1 A.1 (#14609) — capabilities schema
- Phase 5.1 A.2 (#14610) — capabilities data fill
- #14614 (closed) — design 재정리 후 본 cutover 진입

🤖 Generated with [Claude Code](https://claude.com/claude-code)