### PR TITLE
refactor(dashboard): unify runtime_blocker_class boundaries via SSOT helper

### DIFF
--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -22,7 +22,7 @@ import {
   type AgentTimelineResponse,
 } from './schemas/agent-timeline'
 import { parseLogsResponse, type LogEntry, type LogsResponse } from './schemas/logs'
-import { KEEPER_RUNTIME_BLOCKER_CLASSES } from '../types'
+import { asKeeperRuntimeBlockerClass } from '../lib/runtime-blocker-class'
 import type {
   KeeperConfig,
   KeeperFeatureStatus,
@@ -2030,17 +2030,6 @@ function normalizeCascadeCatalogSourceKind(
   }
 }
 
-const RUNTIME_BLOCKER_CLASS_SET: ReadonlySet<string> = new Set(
-  KEEPER_RUNTIME_BLOCKER_CLASSES,
-)
-
-function normalizeRuntimeBlockerClass(value: unknown): KeeperConfig['runtime']['runtime_blocker_class'] {
-  const blockerClass = asNullableString(value)
-  if (blockerClass !== null && RUNTIME_BLOCKER_CLASS_SET.has(blockerClass)) {
-    return blockerClass as KeeperConfig['runtime']['runtime_blocker_class']
-  }
-  return null
-}
 
 function normalizeKeeperSandboxEnvironment(
   raw: unknown,
@@ -2176,7 +2165,7 @@ function normalizeKeeperConfig(raw: unknown, requestedName: string): KeeperConfi
       fiber_health: asNullableString(runtime.fiber_health) ?? 'unknown',
       presence_keepalive: asLooseBoolean(runtime.presence_keepalive),
       presence_keepalive_sec: asInt(runtime.presence_keepalive_sec) ?? 0,
-      runtime_blocker_class: normalizeRuntimeBlockerClass(runtime.runtime_blocker_class),
+      runtime_blocker_class: asKeeperRuntimeBlockerClass(runtime.runtime_blocker_class),
       active_model_label: asNullableString(runtime.active_model_label),
       last_model_used_label: asNullableString(runtime.last_model_used_label),
       runtime_blocker_summary: asNullableString(runtime.runtime_blocker_summary),

--- a/dashboard/src/keeper-store-normalize.ts
+++ b/dashboard/src/keeper-store-normalize.ts
@@ -13,6 +13,7 @@ import type {
 import { isRecord, asString, asNumber, asBoolean, asStringArray, toIsoTimestamp } from './components/common/normalize'
 import { isOfflineStatus } from './lib/status-utils'
 import { keeperDisplayStatus } from './lib/keeper-runtime-display'
+import { asKeeperRuntimeBlockerClass } from './lib/runtime-blocker-class'
 import { contextThresholds } from './config/context-thresholds'
 import { normalizeKeeperDiagnostic } from './keeper-state'
 import type { CascadeRef } from './types'
@@ -558,8 +559,7 @@ export function normalizeKeepers(raw: unknown): Keeper[] {
           typeof row.proactive_enabled === 'boolean' ? row.proactive_enabled : undefined,
         proactive_idle_sec: asNumber(row.proactive_idle_sec),
         proactive_cooldown_sec: asNumber(row.proactive_cooldown_sec),
-        runtime_blocker_class:
-          (asString(row.runtime_blocker_class) as Keeper['runtime_blocker_class']) ?? null,
+        runtime_blocker_class: asKeeperRuntimeBlockerClass(row.runtime_blocker_class),
         runtime_blocker_summary: asString(row.runtime_blocker_summary) ?? null,
         runtime_blocker_continue_gate:
           typeof row.runtime_blocker_continue_gate === 'boolean'

--- a/dashboard/src/lib/runtime-blocker-class.test.ts
+++ b/dashboard/src/lib/runtime-blocker-class.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest'
+import { KEEPER_RUNTIME_BLOCKER_CLASSES } from '../types'
+import {
+  asKeeperRuntimeBlockerClass,
+  isKeeperRuntimeBlockerClass,
+} from './runtime-blocker-class'
+
+describe('asKeeperRuntimeBlockerClass', () => {
+  it('accepts every literal listed in KEEPER_RUNTIME_BLOCKER_CLASSES (SSOT round-trip)', () => {
+    for (const cls of KEEPER_RUNTIME_BLOCKER_CLASSES) {
+      expect(asKeeperRuntimeBlockerClass(cls), `should accept ${cls}`).toBe(cls)
+    }
+  })
+
+  it('rejects unknown strings — the over-permissive `as` cast trap is closed', () => {
+    expect(asKeeperRuntimeBlockerClass('sdk_future_unmapped_variant')).toBeNull()
+    expect(asKeeperRuntimeBlockerClass('typoed_blocker')).toBeNull()
+    expect(asKeeperRuntimeBlockerClass('')).toBeNull()
+  })
+
+  it('rejects non-string values', () => {
+    expect(asKeeperRuntimeBlockerClass(null)).toBeNull()
+    expect(asKeeperRuntimeBlockerClass(undefined)).toBeNull()
+    expect(asKeeperRuntimeBlockerClass(42)).toBeNull()
+    expect(asKeeperRuntimeBlockerClass({})).toBeNull()
+    expect(asKeeperRuntimeBlockerClass([])).toBeNull()
+  })
+})
+
+describe('isKeeperRuntimeBlockerClass', () => {
+  it('narrows known literals to KeeperRuntimeBlockerClass', () => {
+    const candidate: string = 'cascade_exhausted'
+    if (isKeeperRuntimeBlockerClass(candidate)) {
+      const narrowed: typeof candidate = candidate
+      expect(narrowed).toBe('cascade_exhausted')
+    } else {
+      throw new Error('expected narrowing to succeed')
+    }
+  })
+
+  it('returns false for unknown strings', () => {
+    expect(isKeeperRuntimeBlockerClass('not_in_set')).toBe(false)
+  })
+})

--- a/dashboard/src/lib/runtime-blocker-class.ts
+++ b/dashboard/src/lib/runtime-blocker-class.ts
@@ -1,0 +1,18 @@
+import { KEEPER_RUNTIME_BLOCKER_CLASSES, type KeeperRuntimeBlockerClass } from '../types'
+
+const RUNTIME_BLOCKER_CLASS_SET: ReadonlySet<string> = new Set(
+  KEEPER_RUNTIME_BLOCKER_CLASSES,
+)
+
+export function isKeeperRuntimeBlockerClass(
+  value: string,
+): value is KeeperRuntimeBlockerClass {
+  return RUNTIME_BLOCKER_CLASS_SET.has(value)
+}
+
+export function asKeeperRuntimeBlockerClass(
+  value: unknown,
+): KeeperRuntimeBlockerClass | null {
+  if (typeof value !== 'string') return null
+  return isKeeperRuntimeBlockerClass(value) ? value : null
+}


### PR DESCRIPTION
## 배경

#14619 머지 후 같은 도메인(`runtime_blocker_class`)에 **반대 방향**의 silent boundary가 남아있는 걸 발견.

| 사이트 | 패턴 | 실패 모드 |
|---|---|---|
| `dashboard.ts::normalizeRuntimeBlockerClass` (#14619 fix) | case allowlist + `default: null` | **Over-strict** — 알려진 9개 누락 시 null drop |
| `keeper-store-normalize.ts:561-562` (이 PR 대상) | `asString(v) as Keeper['runtime_blocker_class']` | **Over-permissive** — 임의 string 모두 type-launder |

`asString` 은 string이면 통과시키고 `as` cast가 타입체커 우회. 백엔드가 `sdk_unknown_future_variant` 같은 신규/오타 string 을 stamp 하면 dashboard 가 *그대로* 들고 다님. `runtimeBlockerLabels[…] ?? null` 에서 null 떨어지지만 *조용한 수용* — #14619 의 SSOT regression guard 가 `as` cast 우회로 컴파일 타임에 잡지 못함.

#14619 가 OCaml 백엔드에서 RFC-0062 §3.1 이 닫은 `_ -> None` catch-all 의 *frontend 거울 이미지* 한쪽을 닫았지만, 같은 도메인의 *반대 방향* 거울 이미지가 fleet store 경로에 남아있었던 셈.

## 변경

새 SSOT helper 모듈 `dashboard/src/lib/runtime-blocker-class.ts`:

```ts
import { KEEPER_RUNTIME_BLOCKER_CLASSES, type KeeperRuntimeBlockerClass } from '../types'

const RUNTIME_BLOCKER_CLASS_SET: ReadonlySet<string> = new Set(KEEPER_RUNTIME_BLOCKER_CLASSES)

export function isKeeperRuntimeBlockerClass(value: string): value is KeeperRuntimeBlockerClass {
  return RUNTIME_BLOCKER_CLASS_SET.has(value)
}

export function asKeeperRuntimeBlockerClass(value: unknown): KeeperRuntimeBlockerClass | null {
  if (typeof value !== 'string') return null
  return isKeeperRuntimeBlockerClass(value) ? value : null
}
```

두 boundary 가 같은 helper 통해 동일 거부 기준 적용:

| 사이트 | 이전 | 이후 |
|---|---|---|
| `dashboard.ts:2032` | inline Set + `as KeeperConfig[...]` | `asKeeperRuntimeBlockerClass(...)` 직접 호출 |
| `keeper-store-normalize.ts:561` | `(asString(v) as ...) ?? null` | `asKeeperRuntimeBlockerClass(v)` |

미래 SDK variant 추가는 `core.ts` 의 `KEEPER_RUNTIME_BLOCKER_CLASSES` 배열 한 줄로 충분. type union / 두 normalizer / label `satisfies Record<>` 가 모두 propagate.

## 검증

```
pnpm typecheck   # 우리 변경 0 errors (ide-shell.ts pre-existing 3 제외)
pnpm exec vitest run --config vitest.config.ts \
  src/lib/runtime-blocker-class.test.ts \
  src/api/dashboard.test.ts \
  src/keeper-store-normalize.test.ts \
  src/lib/keeper-runtime-display.test.ts
```

→ **4 files / 100 tests / 0 failed**.

새 helper 회귀 가드 (`runtime-blocker-class.test.ts`):
- SSOT 배열을 iterate 해 모든 literal 이 round-trip (known → typed value)
- unknown string / non-string / 빈 문자열 모두 null 반환 (over-permissive 트랩이 닫혔다는 명시 증거)
- type-guard narrowing 검증

## Out of scope

- `lib/monitoring-runtime.ts` 및 `components/journey-panel.ts` 등 *`blocker_class === 'literal'` spot-check* 사용처 (단순 boolean 분기, allowlist 아님 — 잠재 갭 없음).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
