### PR TITLE
refactor(cascade): erase Provider_config closed-variant from cascade_transport behavioral dispatch (RFC-0058 Phase 5.1 A.3a)

### DIFF
--- a/lib/cascade/cascade_transport.ml
+++ b/lib/cascade/cascade_transport.ml
@@ -22,22 +22,28 @@ type cli_transport_overrides =
      to honour this field there. *)
   }
 
-let claude_code_max_turns_hard_cap = 30
+(* SSOT for the Claude Code subprocess hard cap lives in
+   [Provider_adapter] (claude adapter's [tool_policy.max_turns_per_attempt]).
+   The constant below is a backward-compat re-export for the existing test
+   suite; new code reads the cap via [provider_effective_max_turns] or
+   [Provider_adapter.adapter_of_provider_kind]. *)
+let claude_code_max_turns_hard_cap =
+  match
+    Provider_adapter.adapter_of_provider_kind
+      Llm_provider.Provider_config.Claude_code
+  with
+  | Some adapter ->
+    Option.value ~default:30 adapter.tool_policy.max_turns_per_attempt
+  | None -> 30
+;;
 
 let provider_effective_max_turns kind requested =
-  match kind with
-  | Llm_provider.Provider_config.Claude_code ->
-    min requested claude_code_max_turns_hard_cap
-  | Anthropic
-  | OpenAI_compat
-  | Ollama
-  | Gemini
-  | Glm
-  | Kimi
-  | DashScope
-  | Gemini_cli
-  | Kimi_cli
-  | Codex_cli -> requested
+  match Provider_adapter.adapter_of_provider_kind kind with
+  | Some adapter ->
+    (match adapter.tool_policy.max_turns_per_attempt with
+     | Some cap -> min requested cap
+     | None -> requested)
+  | None -> requested
 ;;
 
 (* #10097: codex_cli can only expose keeper-bound runtime MCP tools when the
@@ -416,19 +422,28 @@ let runtime_mcp_policy_for_provider
     let trimmed = String.trim agent_name in
     if String.equal trimmed "" then None else Some trimmed
   in
-  match policy_opt, provider_cfg.kind, agent_name with
-  | Some policy, Llm_provider.Provider_config.Codex_cli, Some agent_name ->
+  (* Codex CLI's [requires_per_keeper_bridging_for_bound_actor_tools = true]
+     is the capability flag that gates the legacy strip-and-bridge path; see
+     [Provider_adapter.codex_cli_tool_policy].  Other providers either carry
+     headers natively or do not need bridging. *)
+  let requires_per_keeper_bridging =
+    Provider_adapter
+    .requires_per_keeper_bridging_for_bound_actor_tools_for_config
+      provider_cfg
+  in
+  match policy_opt, requires_per_keeper_bridging, agent_name with
+  | Some policy, true, Some agent_name ->
     (* Codex CLI still cannot carry arbitrary per-request headers, but OAS
          routes [Authorization: Bearer ...] through [bearer_token_env_var].
          Keep only that auth path plus non-secret identity headers so Codex can
          pre-approve runtime MCP tools without leaking tokens through argv. *)
     Some (codex_runtime_mcp_policy_for_agent ~agent_name policy)
-  | Some policy, Llm_provider.Provider_config.Codex_cli, None ->
+  | Some policy, true, None ->
     (* No agent_name to inject — preserve the legacy strip-all behavior. *)
     Some (runtime_mcp_policy_without_http_headers policy)
-  | Some policy, _, Some agent_name ->
+  | Some policy, false, Some agent_name ->
     Some (runtime_mcp_policy_with_masc_agent_name ~agent_name policy)
-  | Some policy, _, None -> Some policy
+  | Some policy, false, None -> Some policy
   | None, _, _ -> None
 ;;
 
@@ -657,17 +672,24 @@ let resolve_tool_lane_for_oas_tools
       |> dedupe_preserve_order
     | _ -> []
   in
+  let requires_per_keeper_bridging =
+    Provider_adapter
+    .requires_per_keeper_bridging_for_bound_actor_tools_for_config
+      provider_cfg
+  in
   let codex_can_auth_keeper_bound_actor_tools =
-    match provider_cfg.kind, requested_agent_name with
-    | Llm_provider.Provider_config.Codex_cli, Some agent_name
-      when Option.is_some (keeper_name_of_agent_name agent_name) ->
+    match requested_agent_name with
+    | Some agent_name
+      when requires_per_keeper_bridging
+           && Option.is_some (keeper_name_of_agent_name agent_name) ->
       Option.is_some (per_keeper_authorization_header ~agent_name)
     | _ -> false
   in
   let codex_keeper_bound_actor_tools =
-    match provider_cfg.kind, requested_agent_name with
-    | Llm_provider.Provider_config.Codex_cli, Some agent_name
-      when Option.is_some (keeper_name_of_agent_name agent_name)
+    match requested_agent_name with
+    | Some agent_name
+      when requires_per_keeper_bridging
+           && Option.is_some (keeper_name_of_agent_name agent_name)
            && not codex_can_auth_keeper_bound_actor_tools ->
       List.filter
         runtime_mcp_tool_requires_bound_actor

--- a/lib/provider_adapter.ml
+++ b/lib/provider_adapter.ml
@@ -48,6 +48,7 @@ type tool_policy = {
   identity_runtime_mcp_header_keys : string list;
   argv_prompt_preflight : bool;
   uses_anthropic_caching : bool;
+  max_turns_per_attempt : int option;
 }
 
 type telemetry_policy = {
@@ -150,6 +151,7 @@ let no_tool_http_headers =
     identity_runtime_mcp_header_keys = [];
     argv_prompt_preflight = false;
     uses_anthropic_caching = false;
+    max_turns_per_attempt = None;
   }
 
 let runtime_mcp_http_headers =
@@ -159,6 +161,7 @@ let runtime_mcp_http_headers =
     identity_runtime_mcp_header_keys = [];
     argv_prompt_preflight = false;
     uses_anthropic_caching = false;
+    max_turns_per_attempt = None;
   }
 
 (* Codex CLI quirk: its cached login cannot natively inject per-keeper auth
@@ -181,6 +184,7 @@ let codex_cli_tool_policy =
       [ "authorization"; "x-masc-agent-name"; "x-masc-keeper-name" ];
     argv_prompt_preflight = true;
     uses_anthropic_caching = false;
+    max_turns_per_attempt = None;
   }
 let telemetry_reported = { usage_reporting = Reported; runtime_reporting = Reported }
 let telemetry_unknown = { usage_reporting = Unknown; runtime_reporting = Unknown }
@@ -382,7 +386,11 @@ let direct_adapters =
           family = Generic;
         };
       tool_policy =
-        { runtime_mcp_http_headers with uses_anthropic_caching = true };
+        {
+          runtime_mcp_http_headers with
+          uses_anthropic_caching = true;
+          max_turns_per_attempt = Some 30;
+        };
       telemetry_policy = telemetry_usage_missing_runtime_reported;
     };
     {

--- a/lib/provider_adapter.mli
+++ b/lib/provider_adapter.mli
@@ -83,6 +83,13 @@ type tool_policy = {
           [cache_read_input_tokens] above the cacheable input threshold.
           Used by [Keeper_usage_trust] to flag caching-likely-disabled
           anomalies. RFC-0058 §2.4: capability flag, not a vendor match. *)
+  max_turns_per_attempt : int option;
+      (** Hard cap on the provider-internal agent loop turn count for a
+          single subprocess attempt.  [None] means the provider does not
+          impose a sub-keeper cap; [Some n] clamps the keeper-level
+          [max_turns] to [n] before handing it to the underlying CLI.
+          Only Claude Code currently sets this (loop hard cap = 30).
+          RFC-0058 §2.4: capability flag, not a vendor match. *)
 }
 
 type telemetry_policy = {


### PR DESCRIPTION
## Summary

3 behavioral dispatch sites in `cascade_transport.ml` migrated from closed-variant `Llm_provider.Provider_config.{Claude_code,Codex_cli}` match to capability reads via `Provider_adapter`. 2 modules touched (3 files).

| Site | Before | After |
|---|---|---|
| `provider_effective_max_turns` (line 27) | `match kind with Claude_code -> min req 30 \| _ -> req` | reads `adapter.tool_policy.max_turns_per_attempt` |
| `runtime_mcp_policy_for_provider` (line 419-426) | `match _, kind, _ with _, Codex_cli, _ -> ...` | `requires_per_keeper_bridging_for_bound_actor_tools_for_config` |
| `codex_can_auth` / `codex_keeper_bound` (line 661-669, 2 sites) | same Codex_cli match | same capability helper |

SSOT duplication eliminated: `claude_code_max_turns_hard_cap = 30` literal in cascade_transport.ml no longer drifts from the cascade.toml `[capabilities] max-turns-per-attempt = 30` data row — both now derive from `Provider_adapter` claude adapter's `tool_policy.max_turns_per_attempt = Some 30`.

## Why this scope (Anthropic / OpenClaw / LiteLLM precedent)

The remaining `provider_cfg.kind` match in `transport_for_provider_config` (line 1539-1641, 4 vendor SDK instantiations) is **not** touched. It's the analog of:

- **Claude Code's own** `if (CLAUDE_CODE_USE_BEDROCK) { AnthropicBedrock } else if (CLAUDE_CODE_USE_VERTEX) { AnthropicVertex } ...` chain (`src/services/api/client.ts:153-220` in the leaked source)
- **OpenClaw's** `registerProvider(...)` plugin pattern (docs.openclaw.ai/concepts/model-providers)
- **LiteLLM's** `litellm/llms/<vendor>/` Python-module-per-vendor structure

Constructor dispatch on a closed set of vendor SDKs is the RFC-0058 §2.4 boundary that cannot be expressed in cascade.toml without a transport registry redesign. Deferred to a future A.3b track (Transport_registry pattern).

## Files

- `lib/provider_adapter.ml` + `.mli` (2 files)
  - `tool_policy` gains `max_turns_per_attempt : int option`
  - 3 base policy templates updated (`no_tool_http_headers`, `runtime_mcp_http_headers`, `codex_cli_tool_policy`) — default `None`
  - claude adapter overrides with `Some 30`
- `lib/cascade/cascade_transport.ml` (1 file)
  - `provider_effective_max_turns` reads capability via `Provider_adapter.adapter_of_provider_kind`
  - `claude_code_max_turns_hard_cap` re-derives from capability (backward-compat alias for test suite)
  - Codex CLI 3-site dispatch reads `requires_per_keeper_bridging_for_bound_actor_tools_for_config`

Net: 63 insertions, 26 deletions.

## §2.4 progress

| | Before | After |
|---|---|---|
| `cascade_transport.ml` Provider_config closed match sites | 5 | 2 (constructor instantiation + wrapper) |
| SSOT duplication for max_turns cap | 2 places | 1 place (Provider_adapter) |

## Test plan

- [x] `dune build --root . @check` clean
- [x] `test_oas_worker.exe test cascade_config 12,13` (`provider_effective_max_turns_clamps_claude_code` + `provider_effective_max_turns_keeps_ollama_budget`) — both pass
- [x] Other 5 `cascade_config` failures (`default_config_path returned None despite explicit MASC_CONFIG_DIR fixture`) reproduce on `origin/main` unchanged — pre-existing fixture issue, not introduced here
- [ ] keeper E2E (claude_code 1 turn + codex_cli runtime-MCP bridging) — pre-merge replay golden recommended

## Related

- RFC-0058 Phase 5.1 A.1 (#14609) / A.2 (#14610) — capability schema + data
- B2 PR-C/D/E (#14597/#14598/#14599) — earlier caller migrations using same `Provider_adapter._for_config` helper pattern
- Future A.3b — `Transport_registry` for line 1539-1641 vendor SDK dispatch

🤖 Generated with [Claude Code](https://claude.com/claude-code)