### PR TITLE
fix(dashboard): trim whitespace in asKeeperRuntimeBlockerClass + assert real narrowing

### DIFF
--- a/dashboard/src/lib/runtime-blocker-class.test.ts
+++ b/dashboard/src/lib/runtime-blocker-class.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { KEEPER_RUNTIME_BLOCKER_CLASSES } from '../types'
+import { KEEPER_RUNTIME_BLOCKER_CLASSES, type KeeperRuntimeBlockerClass } from '../types'
 import {
   asKeeperRuntimeBlockerClass,
   isKeeperRuntimeBlockerClass,
@@ -18,6 +18,12 @@ describe('asKeeperRuntimeBlockerClass', () => {
     expect(asKeeperRuntimeBlockerClass('')).toBeNull()
   })
 
+  it('trims surrounding whitespace before membership check — parity with asString/asNullableString', () => {
+    expect(asKeeperRuntimeBlockerClass('cascade_exhausted ')).toBe('cascade_exhausted')
+    expect(asKeeperRuntimeBlockerClass('  sdk_max_turns_exceeded\t')).toBe('sdk_max_turns_exceeded')
+    expect(asKeeperRuntimeBlockerClass('   ')).toBeNull()
+  })
+
   it('rejects non-string values', () => {
     expect(asKeeperRuntimeBlockerClass(null)).toBeNull()
     expect(asKeeperRuntimeBlockerClass(undefined)).toBeNull()
@@ -29,9 +35,12 @@ describe('asKeeperRuntimeBlockerClass', () => {
 
 describe('isKeeperRuntimeBlockerClass', () => {
   it('narrows known literals to KeeperRuntimeBlockerClass', () => {
+    // The type guard's job is to convert `string` into `KeeperRuntimeBlockerClass`
+    // inside the truthy branch. The assertion below would fail to compile if
+    // narrowing did not happen — `string` is not assignable to the union.
     const candidate: string = 'cascade_exhausted'
     if (isKeeperRuntimeBlockerClass(candidate)) {
-      const narrowed: typeof candidate = candidate
+      const narrowed: KeeperRuntimeBlockerClass = candidate
       expect(narrowed).toBe('cascade_exhausted')
     } else {
       throw new Error('expected narrowing to succeed')

--- a/dashboard/src/lib/runtime-blocker-class.ts
+++ b/dashboard/src/lib/runtime-blocker-class.ts
@@ -14,5 +14,7 @@ export function asKeeperRuntimeBlockerClass(
   value: unknown,
 ): KeeperRuntimeBlockerClass | null {
   if (typeof value !== 'string') return null
-  return isKeeperRuntimeBlockerClass(value) ? value : null
+  const trimmed = value.trim()
+  if (trimmed === '') return null
+  return isKeeperRuntimeBlockerClass(trimmed) ? trimmed : null
 }


### PR DESCRIPTION
## 배경

#14629 머지 후 Copilot 이 두 가지 valid 한 비판을 post-merge review 로 남김:

### Issue 1 — trim regression (`runtime-blocker-class.ts:17`)

`asKeeperRuntimeBlockerClass` 가 string input 을 trim 하지 않음. 그러나 #14629 가 교체한 두 call site 는 모두 `asString` / `asNullableString` 을 거쳤고 `dashboard/src/components/common/normalize.ts:13` 에서 `value.trim()` 후 empty-after-trim → undefined 처리하는 코드였음.

즉 `'cascade_exhausted '` (trailing whitespace 가 붙은 backend stamp) 같은 값이 *#14629 이전엔 허용*, *#14629 이후엔 silently null*. 실질적 behavior regression.

### Issue 2 — type-guard test 가 실제 narrowing 검증 안 함 (`runtime-blocker-class.test.ts:38`)

```ts
const candidate: string = 'cascade_exhausted'
if (isKeeperRuntimeBlockerClass(candidate)) {
  const narrowed: typeof candidate = candidate  // typeof = string, 검증 안 됨
```

`typeof candidate` 는 outer scope 의 annotation (`string`) 을 가져옴 — narrowing 이 안 일어나도 assignment 컴파일됨. type guard predicate 가 잘못 작성돼도 test pass.

## 변경

### Fix 1 — trim parity

```ts
export function asKeeperRuntimeBlockerClass(
  value: unknown,
): KeeperRuntimeBlockerClass | null {
  if (typeof value !== 'string') return null
  const trimmed = value.trim()
  if (trimmed === '') return null
  return isKeeperRuntimeBlockerClass(trimmed) ? trimmed : null
}
```

`asString` 의 trim+empty handling 과 동일 행동 복원. Set membership 검사는 trimmed value 로 수행 — over-permissive `as` cast 가 다시 열리지 않음.

### Fix 2 — real narrowing assertion

```ts
const candidate: string = 'cascade_exhausted'
if (isKeeperRuntimeBlockerClass(candidate)) {
  const narrowed: KeeperRuntimeBlockerClass = candidate  // ⬅ 진짜 narrowing 강제
  ...
}
```

`string` 을 `KeeperRuntimeBlockerClass` 로 직접 할당 — type guard predicate 가 잘못 작성되면 컴파일 타임에 깨짐. 새 trim 테스트 케이스 (`'cascade_exhausted '`, `'  sdk_max_turns_exceeded\t'`, `'   '`) 도 추가.

## 검증

```
pnpm typecheck   # 우리 변경 0 errors (ide-shell.ts pre-existing 3 제외)
pnpm exec vitest run --config vitest.config.ts \
  src/lib/runtime-blocker-class.test.ts \
  src/api/dashboard.test.ts \
  src/keeper-store-normalize.test.ts \
  src/lib/keeper-runtime-display.test.ts
```

→ **4 files / 101 tests / 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
