### PR TITLE
feat(tool-scope): PR-N3 — move 12 keeper_board_* duplicates to keeper-internal

### DIFF
--- a/lib/tool_scope.ml
+++ b/lib/tool_scope.ml
@@ -5,8 +5,9 @@ type scope =
 (* keeper-internal: tools that keeper personas invoke during their own
    work but that the external MCP orchestrator surface should not
    expose. Wave 1 (PR-N1, #14627): code/web/worktree (8). Wave 2
-   (PR-N2d): coord/inline admin observability audit verdict (5),
-   plan_* (6), run_* (6), webrtc (2). *)
+   (PR-N2d, #14633): coord/inline admin observability audit verdict
+   (5), plan_* (6), run_* (6), webrtc (2). Wave 3 (PR-N3, this PR):
+   keeper_board_* duplicates (12). *)
 let keeper_internal_list : string list =
   [ (* === Wave 1 (PR #14627) === *)
     (* code helpers *)
@@ -20,7 +21,7 @@ let keeper_internal_list : string list =
   ; "masc_worktree_create"
   ; "masc_worktree_list"
   ; "masc_worktree_remove"
-    (* === Wave 2 (this PR) === *)
+    (* === Wave 2 (PR #14633) === *)
     (* coord/inline admin observability (PR-N5 audit verdict, #14618) *)
   ; "masc_check"
   ; "masc_coordination_fsm_snapshot"
@@ -44,6 +45,25 @@ let keeper_internal_list : string list =
     (* webrtc (experimental, not in user surface definition) *)
   ; "masc_webrtc_offer"
   ; "masc_webrtc_answer"
+    (* === Wave 3 (this PR) — keeper_board_* duplicates === *)
+    (* The board domain has parallel keeper_board_* / masc_board_*
+       definitions. masc_board_* stays in the orchestrator surface
+       (user-confirmed "board" category). keeper_board_* is the
+       keeper-internal handle the keeper persona uses for its own
+       board interactions. Cleanup/dedupe of the parallel handlers
+       is a separate RFC; this PR only narrows the surface. *)
+  ; "keeper_board_cleanup"
+  ; "keeper_board_comment"
+  ; "keeper_board_comment_vote"
+  ; "keeper_board_curation_read"
+  ; "keeper_board_curation_submit"
+  ; "keeper_board_delete"
+  ; "keeper_board_get"
+  ; "keeper_board_list"
+  ; "keeper_board_post"
+  ; "keeper_board_search"
+  ; "keeper_board_stats"
+  ; "keeper_board_vote"
   ]
 
 let keeper_internal_names () = keeper_internal_list


### PR DESCRIPTION
## Summary

Plan PR-N3 (Stage 2 Wave 3). Moves 12 `keeper_board_*` duplicate tools into `Tool_scope.keeper_internal_list`. The `masc_board_*` surface stays.

Plan: `~/me/planning/claude-plans/polished-juggling-galaxy.md` §2 PR-N3.
Depends on: **#14627 (Wave 1, merged)**.
Independent of: **#14633 (Wave 2)** — same file, different entries. Trivial rebase if #14633 merges first.

## Measurement (PR-N3 audit step inline)

| prefix | count | overlap |
|--------|-------|---------|
| `masc_board_*` | 15 | hearths/profile/reaction are masc-only |
| `keeper_board_*` | 12 | all 12 are duplicates of `masc_board_*` counterparts |

12 exact-duplicate names:
`cleanup`, `comment`, `comment_vote`, `curation_read`, `curation_submit`, `delete`, `get`, `list`, `post`, `search`, `stats`, `vote`

## Changes

`lib/tool_scope.ml` — +12 entries under \"Wave 3\".

**+26/-4 LOC**.

## Effect

| | Before | After |
|---|---|---|
| `visible_tool_schemas ()` | 131 | 131 (unchanged) |
| `surface_tool_schemas ()` (only PR-N3) | 123 | **111** (-12) |
| `surface_tool_schemas ()` (cumul. w/ #14633) | 104 | **92** |
| `keeper_internal_tool_schemas ()` | 8 | 20 (or 39 stacked w/ Wave 2) |

## Theory A vs B note

Plan §2 hinted at \"Theory B\" (move `masc_board_*` to keeper-internal + alias `board_*` on the surface, dependent on PR-N4 alias infra). This PR implements **Theory A** instead: `masc_board_*` keeps the surface, `keeper_board_*` is the keeper-internal handle. Reasoning:
- The user surface definition includes \"board\" — removing all 15 `masc_board_*` while alias infra (PR-N4) isn't merged would break the external surface.
- Theory A still gains -12 surface count immediately and doesn't depend on PR-N4.
- Full deduplication of the parallel `masc_board_*` / `keeper_board_*` handlers is a separate RFC (single handler + alias).

If the user prefers Theory B once PR-N4 ships, a follow-up PR can flip the direction.

## Test plan

- [x] `dune build --root . @check` green
- [ ] CI: `dune test --root .` — existing tests assert on `visible_tool_schemas`, unchanged
- [ ] Smoke: keeper persona still dispatches `keeper_board_post` through internal routing

## Stage 2 progression

- PR-N1 ✅ #14627 (Wave 1: 8) — surface 131→123
- PR-N2a ✅ #14630 (autoresearch removal audit, docs only)
- PR-N2d #14633 (Wave 2: 19) — surface 123→104
- **PR-N3 (this)** (Wave 3: 12) — surface 111→? depending on stack order
- PR-N4 (alias dedup): pending — Theory B flip and surface name simplification
- PR-1~3 (RFC-0057 codegen swap): pending

🤖 Generated with [Claude Code](https://claude.com/claude-code)