### PR TITLE
refactor(cascade): swap Codex_cli closed-variant in auth_resolve + cascade_catalog_validator (RFC-0058 Phase 5.1 A.3b)

### DIFF
--- a/lib/auth_resolve.ml
+++ b/lib/auth_resolve.ml
@@ -87,15 +87,20 @@ let resolve ~base_path ~keeper_id ~provider_kind
         else Error (Token_hash_missing { path = hash_path })
   else
     match Provider_kind_resolver.env_var_for_kind provider_kind with
-    | None -> (
-        match provider_kind with
-        | PK.Codex_cli ->
-            Error (Bound_actor_provider_mismatch { provider_kind })
-        | _ -> (
-            match first_nonempty_env [ "MASC_MCP_TOKEN" ] with
-            | Some (raw, _) -> Ok { raw; source = Mcp_bearer_env }
-            | None ->
-                Error (Api_key_env_unset { var_name = "MASC_MCP_TOKEN" })))
+    | None ->
+        (* Providers requiring per-keeper bridging cannot accept the shared
+           [MASC_MCP_TOKEN] fallback: their bound-actor runtime MCP tools need
+           a per-keeper raw bearer. Codex CLI is the current canonical case
+           (cached login → no per-request headers), and the capability flag
+           on its adapter is the SSOT. RFC-0058 §2.4: capability, not match. *)
+        if Provider_adapter
+           .requires_per_keeper_bridging_for_bound_actor_tools_for_kind
+             provider_kind
+        then Error (Bound_actor_provider_mismatch { provider_kind })
+        else (
+          match first_nonempty_env [ "MASC_MCP_TOKEN" ] with
+          | Some (raw, _) -> Ok { raw; source = Mcp_bearer_env }
+          | None -> Error (Api_key_env_unset { var_name = "MASC_MCP_TOKEN" }))
     | Some var_name -> (
         match first_nonempty_env [ var_name ] with
         | Some (raw, _) ->

--- a/lib/cascade_catalog_validator.ml
+++ b/lib/cascade_catalog_validator.ml
@@ -141,7 +141,16 @@ let codex_with_bound_actor_only_issue ~profile model_specs =
     |> List.filter_map (fun (provider_name, _model_id) ->
            PK.of_string provider_name)
   in
-  let has_codex = List.exists (fun k -> k = PK.Codex_cli) kinds in
+  (* "Has any kind that needs per-keeper bridging?" — Codex CLI is the
+     current canonical case; reading the capability flag keeps this
+     check open for future adapters that share the cached-login quirk
+     without rewriting the validator. RFC-0058 §2.4: capability, not match. *)
+  let has_bridging_required_kind =
+    List.exists
+      Provider_adapter
+      .requires_per_keeper_bridging_for_bound_actor_tools_for_kind
+      kinds
+  in
   let has_bound_actor_tolerant_fallback =
     List.exists
       (fun k ->
@@ -152,7 +161,7 @@ let codex_with_bound_actor_only_issue ~profile model_specs =
         | _ -> false)
       kinds
   in
-  if has_codex && not has_bound_actor_tolerant_fallback then
+  if has_bridging_required_kind && not has_bound_actor_tolerant_fallback then
     Some
       {
         profile = Some profile;

--- a/lib/provider_adapter.ml
+++ b/lib/provider_adapter.ml
@@ -1567,6 +1567,13 @@ let requires_per_keeper_bridging_for_bound_actor_tools_for_config
       adapter.tool_policy.requires_per_keeper_bridging_for_bound_actor_tools
   | None -> false
 
+let requires_per_keeper_bridging_for_bound_actor_tools_for_kind
+    (kind : Llm_provider.Provider_config.provider_kind) =
+  match adapter_of_provider_kind kind with
+  | Some adapter ->
+      adapter.tool_policy.requires_per_keeper_bridging_for_bound_actor_tools
+  | None -> false
+
 (** Normalize a header key for case-insensitive comparison against
     [tool_policy.identity_runtime_mcp_header_keys]. *)
 let normalize_header_key key = String.lowercase_ascii (String.trim key)

--- a/lib/provider_adapter.mli
+++ b/lib/provider_adapter.mli
@@ -444,6 +444,15 @@ val supports_runtime_mcp_http_headers_for_config :
 val requires_per_keeper_bridging_for_bound_actor_tools_for_config :
   Llm_provider.Provider_config.t -> bool
 
+(** Same as {!requires_per_keeper_bridging_for_bound_actor_tools_for_config}
+    but takes a typed [provider_kind] directly.  Used by call sites that do
+    not have a full {!Llm_provider.Provider_config.t} (e.g. keeper-bound
+    actor authorisation resolution, cascade catalog static validation).
+    Returns [false] when no adapter resolves for [kind].
+    RFC-0058 §2.4: capability flag, not a vendor match. *)
+val requires_per_keeper_bridging_for_bound_actor_tools_for_kind :
+  Llm_provider.Provider_config.provider_kind -> bool
+
 (** OAS-level capabilities for a provider config.  SSOT for the kind →
     capability mapping; centralises what was previously a closed-variant
     [match Llm_provider.Provider_config.provider_kind] in


### PR DESCRIPTION
## Summary

Two more closed-variant dispatch sites migrated to the capability flag from A.3a (#14631). Same pattern as the prior pilot PRs (#14597/#14598/#14599): adapter's `tool_policy.requires_per_keeper_bridging_for_bound_actor_tools` is the SSOT, callers read via a typed helper.

| Site | Before | After |
|---|---|---|
| `auth_resolve.ml:91-93` | `match provider_kind with PK.Codex_cli -> Error ... \| _ -> ...` | `if Provider_adapter.requires_per_keeper_bridging_for_bound_actor_tools_for_kind provider_kind then Error ... else ...` |
| `cascade_catalog_validator.ml:144` | `List.exists (fun k -> k = PK.Codex_cli) kinds` | `List.exists Provider_adapter.requires_per_keeper_bridging_for_bound_actor_tools_for_kind kinds` |

## What's NOT in this PR

- `cascade_catalog_validator.ml:149-152` 5-arm fallback whitelist (`Claude_code / Gemini_cli / Kimi_cli / Ollama / Glm`) — its semantics is an explicit *opt-in* allow-list ("which kinds are tolerable bound-actor fallbacks"), which doesn't map cleanly to any current capability flag. A new `tolerates_bound_actor_fallback : bool` capability would cover it; deferred to a follow-up.
- `cascade_transport.ml:1562-1651` (4 vendor SDK constructor dispatch) — this is the Anthropic Claude Code / OpenClaw precedent boundary; future A.3c via `Transport_registry`.

## Files

- `lib/provider_adapter.ml` + `.mli` — new helper `requires_per_keeper_bridging_for_bound_actor_tools_for_kind` (mirrors `_for_config`)
- `lib/auth_resolve.ml` — 1 dispatch swap
- `lib/cascade_catalog_validator.ml` — 1 dispatch swap

Net: 41 insertions, 11 deletions.

## Test plan

- [x] `dune build --root . @check` clean
- [x] `test_auth_resolve_labels.exe` — 8/8 pass
- [x] `test_cascade_validator_capability_lint.exe` — 2 pre-existing failures reproduce on `origin/main` unchanged; not introduced here

## Related

- A.3a (#14631) — pattern established in `cascade_transport.ml`
- #14628 — `capabilities_for_provider_id` helper (kept available for cascade-config-direct callers; this PR uses `Provider_adapter` path since callers hold typed `provider_kind`)
- Future: A.3c (Transport_registry for vendor SDK dispatch), capability flag for `tolerates_bound_actor_fallback`

🤖 Generated with [Claude Code](https://claude.com/claude-code)