### PR TITLE
refactor(cascade): drop OpenAI_compat closed-variant from not_found error hint (RFC-0058 Phase 5.1)

### DIFF
--- a/lib/cascade/cascade_attempt_fsm.ml
+++ b/lib/cascade/cascade_attempt_fsm.ml
@@ -210,8 +210,15 @@ let enrich_sdk_error ~cascade_name
              append_hint message moonshot_auth_hint_marker detail;
          })
   | Agent_sdk.Error.Api (Llm_provider.Retry.InvalidRequest { message })
-    when provider_cfg.kind = Llm_provider.Provider_config.OpenAI_compat
-      && retry_message_looks_like_not_found message ->
+    when retry_message_looks_like_not_found message ->
+    (* Endpoint URL hint is shape-agnostic data — every provider_cfg carries
+       [base_url] / [request_path] (empty strings for CLI agents) — so the
+       not_found hint applies to any provider whose retry message matches the
+       not_found pattern.  CLI providers' not_found errors rarely surface
+       through this code path (they emit text errors, not the OpenAI-compat
+       InvalidRequest shape), so the practical effect is a no-op for CLI
+       agents while still helping HTTP providers (openai-compat, glm, etc.)
+       diagnose endpoint drift.  RFC-0058 §2.4: no closed-variant dispatch. *)
     let detail =
       Printf.sprintf "base_url=%s request_path=%s endpoint=%s"
         provider_cfg.base_url provider_cfg.request_path


### PR DESCRIPTION
## Summary

`enrich_sdk_error` previously dispatched on `provider_cfg.kind = OpenAI_compat` to attach a `base_url=... request_path=... endpoint=...` detail to `InvalidRequest` errors that looked like a not-found response. The closed-variant guard is removed: `base_url` / `request_path` are shape-agnostic fields on every `Provider_config.t`, so attaching the hint when the message text already matches `retry_message_looks_like_not_found` is safe across all providers.

| Before | After |
|---|---|
| `when provider_cfg.kind = OpenAI_compat && retry_message_looks_like_not_found message` | `when retry_message_looks_like_not_found message` |

## Why no regression

- CLI agents (`Claude_code`, `Codex_cli`, `Kimi_cli`, `Gemini_cli`) emit text errors, not the OpenAI-compat `InvalidRequest` shape — they rarely hit this branch.
- When they do hit it, `base_url` / `request_path` are empty strings → detail line still attaches but has no extra information (additive, no information loss).
- HTTP providers (openai-compat, glm, ollama) keep the existing behavior.

The hint marker name `openai_compat_not_found_hint_marker` is left unchanged for log/dashboard grep compatibility; future cleanup may rename once consumers confirm.

## §2.4 progress

| | Before | After |
|---|---|---|
| `cascade_attempt_fsm.ml` closed-variant dispatch sites | 1 | 0 |

## Test plan

- [x] `dune build --root . @check` clean
- [ ] HTTP openai-compat call to non-existent model → hint still surfaces (manual)
- [ ] CLI agent text error → hint absent (text doesn't match not_found pattern, no-op)

## Related

- A.3a (#14631) — same pattern in `cascade_transport.ml`
- A.3b (#14636) — `auth_resolve.ml` + `cascade_catalog_validator.ml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)