### PR TITLE
test(keeper): RFC-0065 §3.2.3 WireinOrderPinned — OCaml-side structural guard

### DIFF
--- a/test/dune
+++ b/test/dune
@@ -1249,6 +1249,7 @@
 (include stanzas/test_keeper_pause_silent_failure_source.inc)
 (include stanzas/test_keeper_paused_cas_retain_9733.inc)
 (include stanzas/test_keeper_personality_round_trip.inc)
+(include stanzas/test_keeper_post_turn_wirein_order.inc)
 (include stanzas/test_keeper_provider_token_bucket.inc)
 (include stanzas/test_keeper_readonly_hints.inc)
 (include stanzas/test_keeper_receipt_authoritative.inc)

--- a/test/stanzas/test_keeper_post_turn_wirein_order.inc
+++ b/test/stanzas/test_keeper_post_turn_wirein_order.inc
@@ -1,0 +1,4 @@
+(test
+ (name test_keeper_post_turn_wirein_order)
+ (modules test_keeper_post_turn_wirein_order)
+ (libraries masc_test_deps))

--- a/test/test_keeper_post_turn_wirein_order.ml
+++ b/test/test_keeper_post_turn_wirein_order.ml
@@ -1,0 +1,173 @@
+(* OCaml-side regression guard for RFC-0065 §3.2.3
+ * WireinOrderPinned invariant (PR #14632).
+ *
+ * The TLA+ spec KeeperPostTurnOrchestration.tla asserts that the
+ * post-turn wirein sequence must be exactly <A5, A6, K4b, K1>, which
+ * maps to the OCaml call order:
+ *
+ *   apply_autonomous_wirein     (A5)
+ *   apply_resilience_wirein     (A6)
+ *   apply_tool_emission_wirein  (K4b)
+ *   apply_multimodal_wirein     (K1)
+ *
+ * The TLC layer (clean + buggy cfg) regression-guards this at the
+ * model level. This test is the OCaml-side analogue: a structural
+ * scan over [lib/keeper/keeper_post_turn.ml] that confirms the four
+ * wirein calls appear in the correct order inside the body of
+ * [apply_post_turn_lifecycle_with_resilience_handles]. An accidental
+ * reorder would otherwise compile cleanly and silently violate the
+ * pinned invariant.
+ *
+ * Approach: read the source file as text, locate the function
+ * definition by header line, then within a window of lines below
+ * that header look up the first occurrence of each of the four
+ * literal call markers and assert the line numbers are strictly
+ * increasing. The window size is generous (300 lines) because the
+ * function body is long; the four markers occur exactly once each
+ * inside the body, so the window can safely overshoot.
+ *)
+
+open Alcotest
+
+let source_relpath = "lib/keeper/keeper_post_turn.ml"
+
+let function_header = "let apply_post_turn_lifecycle_with_resilience_handles"
+
+(* Literal call markers, in the order they must appear. The order
+   here is load-bearing — the test asserts the first-occurrence line
+   numbers are strictly increasing in this sequence. *)
+let wirein_markers =
+  [ "apply_autonomous_wirein";
+    "apply_resilience_wirein";
+    "apply_tool_emission_wirein";
+    "apply_multimodal_wirein" ]
+
+let window_lines = 300
+
+let read_source_lines () =
+  let root = Masc_test_deps.find_project_root () in
+  let path = Filename.concat root source_relpath in
+  let ic = open_in path in
+  Fun.protect
+    ~finally:(fun () -> close_in_noerr ic)
+    (fun () ->
+      let rec loop acc =
+        match input_line ic with
+        | line -> loop (line :: acc)
+        | exception End_of_file -> List.rev acc
+      in
+      loop [])
+
+let substring_present ~needle hay =
+  let nlen = String.length needle in
+  let hlen = String.length hay in
+  if nlen > hlen then false
+  else
+    let rec scan i =
+      if i + nlen > hlen then false
+      else if String.sub hay i nlen = needle then true
+      else scan (i + 1)
+    in
+    scan 0
+
+(* Find the first line (1-indexed) whose content contains [needle],
+   searching only within [lines] in the inclusive 1-indexed range
+   [from..to_]. Returns [None] if not found. *)
+let find_line_in_range ~lines ~needle ~from ~to_ =
+  let arr = Array.of_list lines in
+  let n = Array.length arr in
+  let lo = max 1 from in
+  let hi = min n to_ in
+  let rec scan i =
+    if i > hi then None
+    else if substring_present ~needle arr.(i - 1) then Some i
+    else scan (i + 1)
+  in
+  scan lo
+
+let find_function_header_line ~lines =
+  let arr = Array.of_list lines in
+  let n = Array.length arr in
+  let rec scan i =
+    if i > n then None
+    else if substring_present ~needle:function_header arr.(i - 1) then Some i
+    else scan (i + 1)
+  in
+  scan 1
+
+let test_wirein_order_strictly_increasing () =
+  let lines = read_source_lines () in
+  let header_line =
+    match find_function_header_line ~lines with
+    | Some i -> i
+    | None ->
+        failwith
+          (Printf.sprintf
+             "Could not locate %S in %s — function may have been \
+              renamed or removed; sync RFC-0065 WireinOrderPinned \
+              guard accordingly."
+             function_header source_relpath)
+  in
+  let from = header_line + 1 in
+  let to_ = header_line + window_lines in
+  let located =
+    List.map
+      (fun marker ->
+        match find_line_in_range ~lines ~needle:marker ~from ~to_ with
+        | Some i -> (marker, i)
+        | None ->
+            failwith
+              (Printf.sprintf
+                 "WireinOrderPinned: marker %S not found within %d \
+                  lines below %S (line %d) in %s — RFC-0065 §3.2.3 \
+                  wirein call appears to be missing."
+                 marker window_lines function_header header_line
+                 source_relpath))
+      wirein_markers
+  in
+  let rec check prev_line = function
+    | [] -> ()
+    | (marker, line) :: rest ->
+        if line <= prev_line then
+          failwith
+            (Printf.sprintf
+               "WireinOrderPinned violation: marker %S at line %d is \
+                not strictly after the preceding marker at line %d. \
+                Expected order: %s. RFC-0065 §3.2.3 pins this \
+                sequence; restore it or update the spec and this \
+                guard together."
+               marker line prev_line
+               (String.concat " → " wirein_markers))
+        else check line rest
+  in
+  check 0 located
+
+let test_wirein_all_present () =
+  (* Independent presence check: each of the four markers must be
+     present anywhere in the file at least once. Catches an accidental
+     deletion of one of the wirein passes even if the function header
+     scan logic regresses. *)
+  let lines = read_source_lines () in
+  let n = List.length lines in
+  List.iter
+    (fun marker ->
+      match find_line_in_range ~lines ~needle:marker ~from:1 ~to_:n with
+      | Some _ -> ()
+      | None ->
+          failwith
+            (Printf.sprintf
+               "WireinOrderPinned all-present: marker %S not found \
+                anywhere in %s — RFC-0065 §3.2.3 wirein pass appears \
+                to be deleted."
+               marker source_relpath))
+    wirein_markers
+
+let () =
+  run "RFC-0065 §3.2.3 WireinOrderPinned (OCaml-side guard)" [
+    "WireinOrderPinned", [
+      test_case "ordering: A5 → A6 → K4b → K1 strictly increasing"
+        `Quick test_wirein_order_strictly_increasing;
+      test_case "all-present: four wirein calls present in source"
+        `Quick test_wirein_all_present;
+    ];
+  ]


### PR DESCRIPTION
## Summary

OCaml-side regression guard for B3 `WireinOrderPinned` from RFC-0065
§3.2.3.  Companion to Phase 5.3 PR #14632 (TLC layer regression guard).
Closes memory **P5** (OCaml ↔ TLA+ correspondence) at the structural
test layer.

## What this PR adds

### `test/test_keeper_post_turn_wirein_order.ml`

- Scans `lib/keeper/keeper_post_turn.ml` as text via
  `Masc_test_deps.find_project_root` (same primitive used by
  `tla_quoted_set_from_repo_file_exn`).
- Locates the `apply_post_turn_lifecycle_with_resilience_handles`
  function definition and asserts that within its body the four
  wirein call markers appear in **strict-increasing** first-line
  order:

  `apply_autonomous_wirein < apply_resilience_wirein <
   apply_tool_emission_wirein < apply_multimodal_wirein`

- 2 tests: `WireinOrderPinned ordering` + `WireinOrderPinned all-present`.

### `test/stanzas/test_keeper_post_turn_wirein_order.inc`

- dune stanza (single-target executable).

### `test/dune`

- One-line `include` in alphabetical order, between
  `test_keeper_personality_round_trip.inc` and
  `test_keeper_provider_token_bucket.inc`.

## Verification

\`\`\`
$ dune build --root . test/test_keeper_post_turn_wirein_order.exe
(exit 0)
$ _build/default/test/test_keeper_post_turn_wirein_order.exe
Testing 'RFC-0065 §3.2.3 WireinOrderPinned (OCaml-side guard)'.
  [OK]  WireinOrderPinned  ordering: A5 → A6 → K4b → K1 strictly increasing
  [OK]  WireinOrderPinned  all-present: four wirein calls
Test Successful. 2 tests run.
$ dune build --root . @check
(PASS)
\`\`\`

## G3 acceptance gate (provider/model opacity)

\`\`\`
$ rg -ic 'anthropic|openai|claude|gpt|gemini|sonnet|opus|haiku' \\
    test/test_keeper_post_turn_wirein_order.ml
0
\`\`\`

## Why this lands now

Phase 5.3 (#14632) added the TLC-level guard.  Without an OCaml-side
guard, an accidental reorder of the wirein sequence at
`keeper_post_turn.ml:648-656` would compile cleanly and break only
the spec — which is a manual-run check, not a CI gate per default.
This PR closes that asymmetry: any reorder now fails CI at the test
layer.

## RFC-0065 migration plan — end-to-end delivery

| Phase | PR | Status |
|---|---|---|
| Track A (typed `blocker_class`) | #14613 | MERGED |
| RFC-0065 (the RFC itself) | #14615 | MERGED |
| Phase 5.1 (B1 KCAF) | #14621 | MERGED |
| Phase 5.2 (B2 KTS) | #14626 | MERGED |
| Phase 5.3 (B3 KPTO + harness) | #14632 | MERGED |
| Phase 5.1.b (composite observer) | #14637 | MERGED |
| **Implementation followup (this)** | **this** | **Draft** |

## Memory close-out

`memory/reference_keeper_state_machine_specs_consolidation_status.md`
P5 OPEN → **CLOSED** (2026-05-11). All five proposals from
`docs/tla-audit/state-fsm-gap-2026-04-13.md` are now MOOT or CLOSED.

## References

- RFC-0065 §3.2.3 (B3 WireinOrderPinned), §3.3 (correspondence
  harness pattern), §6.G3 (provider opacity).
- PR #14632 (Phase 5.3 TLC-layer guard).
- `lib/keeper/keeper_post_turn.ml:640-647` (the comment pinning the
  order — "Do not reorder").

## Test plan

- [x] `dune build --root . @check` — PASS
- [x] Test binary — 2 tests, all OK
- [x] G3 opacity grep — 0
- [x] Companion memory file updated (P5 OPEN → CLOSED)

🤖 Generated with [Claude Code](https://claude.com/claude-code)