### PR TITLE
refactor(cascade): swap codex_with_bound_actor_only whitelist to tolerates_bound_actor_fallback capability (RFC-0058 Phase 5.1)

### DIFF
--- a/lib/cascade_catalog_validator.ml
+++ b/lib/cascade_catalog_validator.ml
@@ -151,14 +151,17 @@ let codex_with_bound_actor_only_issue ~profile model_specs =
       .requires_per_keeper_bridging_for_bound_actor_tools_for_kind
       kinds
   in
+  (* The legacy whitelist hard-coded PK.Glm as tolerant, but
+     [adapter_of_provider_kind PK.Glm = None] (Glm/OpenAI_compat have no
+     single canonical adapter), so the capability-driven helper returns
+     [false] for it.  This is intentional: GLM has no CLI surface today and
+     therefore no per-keeper bound-actor auth path. If and when one lands,
+     the corresponding adapter's [tolerates_bound_actor_fallback] capability
+     becomes the SSOT — no validator edit required.
+     RFC-0058 §2.4: capability flag, not a vendor match. *)
   let has_bound_actor_tolerant_fallback =
     List.exists
-      (fun k ->
-        match k with
-        | PK.Claude_code | PK.Gemini_cli | PK.Kimi_cli
-        | PK.Ollama | PK.Glm ->
-            true
-        | _ -> false)
+      Provider_adapter.tolerates_bound_actor_fallback_for_kind
       kinds
   in
   if has_bridging_required_kind && not has_bound_actor_tolerant_fallback then

--- a/lib/provider_adapter.ml
+++ b/lib/provider_adapter.ml
@@ -49,6 +49,7 @@ type tool_policy = {
   argv_prompt_preflight : bool;
   uses_anthropic_caching : bool;
   max_turns_per_attempt : int option;
+  tolerates_bound_actor_fallback : bool;
 }
 
 type telemetry_policy = {
@@ -152,6 +153,7 @@ let no_tool_http_headers =
     argv_prompt_preflight = false;
     uses_anthropic_caching = false;
     max_turns_per_attempt = None;
+    tolerates_bound_actor_fallback = false;
   }
 
 let runtime_mcp_http_headers =
@@ -162,6 +164,7 @@ let runtime_mcp_http_headers =
     argv_prompt_preflight = false;
     uses_anthropic_caching = false;
     max_turns_per_attempt = None;
+    tolerates_bound_actor_fallback = false;
   }
 
 (* Codex CLI quirk: its cached login cannot natively inject per-keeper auth
@@ -185,6 +188,7 @@ let codex_cli_tool_policy =
     argv_prompt_preflight = true;
     uses_anthropic_caching = false;
     max_turns_per_attempt = None;
+    tolerates_bound_actor_fallback = false;
   }
 let telemetry_reported = { usage_reporting = Reported; runtime_reporting = Reported }
 let telemetry_unknown = { usage_reporting = Unknown; runtime_reporting = Unknown }
@@ -358,7 +362,8 @@ let direct_adapters =
           expand_auto = false;
           family = Generic;
         };
-      tool_policy = no_tool_http_headers;
+      tool_policy =
+        { no_tool_http_headers with tolerates_bound_actor_fallback = true };
       telemetry_policy = telemetry_usage_missing_runtime_reported;
     };
     {
@@ -390,6 +395,7 @@ let direct_adapters =
           runtime_mcp_http_headers with
           uses_anthropic_caching = true;
           max_turns_per_attempt = Some 30;
+          tolerates_bound_actor_fallback = true;
         };
       telemetry_policy = telemetry_usage_missing_runtime_reported;
     };
@@ -469,7 +475,8 @@ let direct_adapters =
          lib/llm_provider/transport_gemini_cli.ml (runtime_mcp_policy = Some
          _ branch). Keep this false until upstream adds per-invocation
          MCP config injection. See masc-mcp#11356 for full analysis. *)
-      tool_policy = no_tool_http_headers;
+      tool_policy =
+        { no_tool_http_headers with tolerates_bound_actor_fallback = true };
       telemetry_policy = telemetry_usage_missing_runtime_reported;
     };
     {
@@ -496,7 +503,8 @@ let direct_adapters =
           expand_auto = true;
           family = Generic;
         };
-      tool_policy = runtime_mcp_http_headers;
+      tool_policy =
+        { runtime_mcp_http_headers with tolerates_bound_actor_fallback = true };
       telemetry_policy = telemetry_usage_missing;
     };
     {
@@ -1572,6 +1580,12 @@ let requires_per_keeper_bridging_for_bound_actor_tools_for_kind
   match adapter_of_provider_kind kind with
   | Some adapter ->
       adapter.tool_policy.requires_per_keeper_bridging_for_bound_actor_tools
+  | None -> false
+
+let tolerates_bound_actor_fallback_for_kind
+    (kind : Llm_provider.Provider_config.provider_kind) =
+  match adapter_of_provider_kind kind with
+  | Some adapter -> adapter.tool_policy.tolerates_bound_actor_fallback
   | None -> false
 
 (** Normalize a header key for case-insensitive comparison against

--- a/lib/provider_adapter.mli
+++ b/lib/provider_adapter.mli
@@ -90,6 +90,24 @@ type tool_policy = {
           [max_turns] to [n] before handing it to the underlying CLI.
           Only Claude Code currently sets this (loop hard cap = 30).
           RFC-0058 §2.4: capability flag, not a vendor match. *)
+  tolerates_bound_actor_fallback : bool;
+      (** When true, this adapter is considered a viable fallback target
+          when the operator's catalog also contains an adapter that
+          [requires_per_keeper_bridging_for_bound_actor_tools = true]
+          (e.g. Codex CLI). Catalog static validation
+          ({!Cascade_catalog_validator.codex_with_bound_actor_only_issue})
+          uses this flag to decide whether a "Codex CLI present without a
+          bound-actor-tolerant fallback" warning should fire.
+
+          Currently set to [true] for CLI agents with native per-keeper
+          MCP support: Claude Code, Gemini CLI, Kimi CLI, and the local
+          Ollama runtime. HTTP-only adapters (glm-api, glm-coding-plan,
+          openrouter, *-api variants) currently default to [false]; the
+          legacy whitelist treated PK.Glm as tolerant but that mapping
+          is unreachable via [adapter_of_provider_kind] (PK.Glm has no
+          single canonical adapter), so the swap drops it pending an
+          explicit reinstatement when GLM gains a per-keeper auth path.
+          RFC-0058 §2.4: capability flag, not a vendor match. *)
 }
 
 type telemetry_policy = {
@@ -451,6 +469,15 @@ val requires_per_keeper_bridging_for_bound_actor_tools_for_config :
     Returns [false] when no adapter resolves for [kind].
     RFC-0058 §2.4: capability flag, not a vendor match. *)
 val requires_per_keeper_bridging_for_bound_actor_tools_for_kind :
+  Llm_provider.Provider_config.provider_kind -> bool
+
+(** Whether the resolved adapter for [kind] is a viable fallback when
+    the catalog also contains a bridging-required adapter (Codex CLI).
+    Returns [false] when no adapter resolves for [kind] (including
+    PK.Glm and PK.OpenAI_compat, which have no single canonical adapter).
+    Used by {!Cascade_catalog_validator.codex_with_bound_actor_only_issue}.
+    RFC-0058 §2.4: capability flag, not a vendor match. *)
+val tolerates_bound_actor_fallback_for_kind :
   Llm_provider.Provider_config.provider_kind -> bool
 
 (** OAS-level capabilities for a provider config.  SSOT for the kind →


### PR DESCRIPTION
## Summary

5-arm closed-variant whitelist in `Cascade_catalog_validator.codex_with_bound_actor_only_issue` → new capability `tolerates_bound_actor_fallback` on `Provider_adapter.tool_policy`.

| Before | After |
|---|---|
| `match k with PK.Claude_code \| PK.Gemini_cli \| PK.Kimi_cli \| PK.Ollama \| PK.Glm -> true \| _ -> false` | `Provider_adapter.tolerates_bound_actor_fallback_for_kind k` |

4 adapter overrides set the new capability to `true`: `cn_claude`, `cn_ollama`, `cn_gemini`, `cn_kimi`. HTTP-only adapters default to `false`.

## ⚠️ Intentional behavior change: PK.Glm drop

The legacy whitelist included `PK.Glm -> true`, but `adapter_of_provider_kind PK.Glm = None` (Glm/OpenAI_compat have no single canonical adapter — `base_url` varies per cascade entry). The capability helper therefore returns `false` for PK.Glm.

**Consequence**: a catalog containing `{codex_cli/*, glm/*}` (and no other CLI agent) will now emit the "Codex CLI present without bound-actor-tolerant fallback" warning where it previously did not.

**Why this is correct**: GLM has no CLI surface today (no per-keeper bound-actor auth path). If a GLM CLI lands and gains that capability, the corresponding adapter's `tolerates_bound_actor_fallback` flag becomes the SSOT — no validator edit required.

If a reviewer recalls a *specific operational reason* PK.Glm was tolerant beyond "GLM is an adapter", please flag before merge.

## §2.4 progress

| | Before | After |
|---|---|---|
| `cascade_catalog_validator.ml` closed-variant dispatch sites | 1 (5-arm) | 0 |

## Files

- `lib/provider_adapter.ml` + `.mli` — capability + 3 base templates + 4 overrides + 1 helper
- `lib/cascade_catalog_validator.ml` — 5-arm → helper

Net: 53 insertions, 9 deletions.

## Test plan

- [x] `dune build --root . @check` clean
- [x] `test_cascade_validator_capability_lint.exe` — 2 pre-existing failures reproduce on origin/main unchanged
- [ ] Manual: catalog with `{codex_cli, glm/*}` emits new warn (behavior change verification)

## Related

- A.3a (#14631), A.3b (#14636), PR-E (#14640) — same pattern, capability-as-SSOT

🤖 Generated with [Claude Code](https://claude.com/claude-code)