### PR TITLE
refactor(cascade): route discover_profiles through declarative adapter (RFC-0066 §3.1 Phase 1)

### DIFF
--- a/lib/cascade/cascade_catalog_runtime.ml
+++ b/lib/cascade/cascade_catalog_runtime.ml
@@ -143,7 +143,17 @@ let install_snapshot_for_tests ~source_path ~profile_names =
           rejected_update = None;
         })
 
-let discover_profiles = function
+(* RFC-0066 §3.1 Phase 1: profile name discovery flows through the
+   declarative adapter ({!Cascade_declarative_hotpath.try_load_declarative})
+   reading [cascade.toml] as the sole SSOT (RFC-0058 §9.4).
+
+   Legacy JSON [<name>_models] scan retained as fallback while RFC-0066
+   Phase 4 migrates per-profile test fixtures off the legacy materializer
+   arm.  When the active source is 5-layer declarative, the JSON path
+   would render the same key set, so the fallback never wins on real
+   production configs — it only catches per-profile fixture TOML that
+   pre-dates the declarative schema. *)
+let discover_legacy_profile_names_from_json = function
   | `Assoc fields ->
       fields
       |> List.filter_map (fun (key, value) ->
@@ -161,6 +171,20 @@ let discover_profiles = function
              | _ -> None)
       |> List.sort_uniq String.compare
   | _ -> []
+
+let discover_profile_names ~config_path ~json : string list =
+  match Cascade_declarative_hotpath.try_load_declarative config_path with
+  | Some (Ok snap) ->
+      Cascade_declarative_hotpath.decl_snapshot_profile_names snap
+      |> List.filter (fun profile ->
+             not
+               (Cascade_config_loader.is_deprecated_logical_profile_name
+                  profile))
+      |> List.sort_uniq String.compare
+  | Some (Error _) | None ->
+      (* RFC-0066 Phase 4 target: this branch goes away once test
+         fixtures migrate to 5-layer declarative TOML. *)
+      discover_legacy_profile_names_from_json json
 
 let float_opt_to_json = function
   | Some value -> `Float value
@@ -647,12 +671,12 @@ let validate_path_result ?sw ?net ~config_path () =
                ]
              ~profiles:[])
     | Ok json ->
-        let profiles = discover_profiles json in
+        let profiles = discover_profile_names ~config_path ~json in
         if profiles = [] then
           Error
             (rejection_of_path ~config_path:source_path ~attempted_mtime
                ~checked_at
-               ~errors:[ "active cascade catalog has no <name>_models profiles" ]
+               ~errors:[ "active cascade catalog declares no profiles" ]
                ~profiles:[])
         else
           let required_default_profile =
@@ -678,7 +702,7 @@ let validate_path_result ?sw ?net ~config_path () =
         let top_errors =
           let base =
             if profiles = [] then
-              [ "active cascade catalog has no <name>_models profiles" ]
+              [ "active cascade catalog declares no profiles" ]
             else
               []
           in


### PR DESCRIPTION
## Summary

First concrete migration step of **RFC-0066** (Legacy `*_models` Catalog Purge). \
`Cascade_catalog_runtime.validate_path_result` now asks the declarative adapter (`Cascade_declarative_hotpath.try_load_declarative`) for the profile list instead of scanning legacy `<name>_models` JSON keys.

The JSON scan is retained as a Phase-1 *fallback* for the ~30 per-profile test fixtures (`flat_json_to_toml` helper, listed in RFC-0066 §2.4) that still author `[<profile>]\nmodels = [...]` TOML. After RFC-0058 §9.4, production `cascade.toml` is fully 5-layer declarative — the fallback never wins on real reads.

## Change shape

```
discover_profiles json                    →   discover_profile_names ~config_path ~json
  (legacy JSON <name>_models scan)              ↓
                                               try_load_declarative → Ok ⇒ decl_snapshot_profile_names
                                                                    → Error/None ⇒ legacy JSON scan
```

Two error messages also lose the now-misleading `<name>_models` phrasing in favour of "declares no profiles".

## RFC alignment

- RFC-0066 §3.1 (Reader replacement map) — this PR addresses the *runtime* path. `load_catalog` / `load_profile_weighted` / `load_profile` API removals are RFC-0066 Phase 2+.
- RFC-0058 §9.4 (Phase 9 closeout) — established `cascade.toml` as SSOT; this PR makes the in-memory consumer follow suit.

## Risk

`중-높` per the user's own assessment (boot-path routing). Mitigated by:
1. **Same source** — both paths render from the same `cascade.toml`. The Phase 3 parallel validator at `cascade_catalog_runtime.ml:733` has been logging *parallel validation OK* in production for weeks.
2. **JSON fallback** — declarative parse failure (legacy fixtures only) keeps the legacy path alive. Production reads never hit the fallback.
3. **Error message** — only string change is the no-profiles error; downstream operators key off the `errors` field, not the message text.

## Test plan

- [x] `dune build --root .` green
- [x] `test_cascade_catalog_runtime` 23/23
- [x] `test_dashboard_cascade` 42/42
- [x] `test_cascade_required_capability_profile` 5/5
- [x] `test_cascade_toml_materialization` 20/20
- [x] `ocamlformat --check` clean

## Follow-up

RFC-0066 Phase 4 — migrate the 30 per-profile fixtures off the `flat_json_to_toml` helper, then delete the legacy `discover_legacy_profile_names_from_json` fallback.

## Why Draft

Per the operator's workflow (`feedback_masc_mcp_draft_guard_blocks_agent_ready.md`), agent-authored PRs stay Draft until the human reviewer adds `human-approved-ready`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)