### PR TITLE
feat(tool-schemas): RFC-0057 PR-2c — codegen-swap inline_infra approval/spawn (3 tools)

### DIFF
--- a/bin/gen_tool_descriptors.ml
+++ b/bin/gen_tool_descriptors.ml
@@ -516,6 +516,78 @@ let masc_deliver_spec : tool_spec =
   }
 ;;
 
+(* === PR-2c: inline_infra group (3 of 4 tools — masc_mcp_session
+   deferred because enum SSOT is locked to Tool_schemas_inline_infra
+   by test_types.ml :: mcp_session_action_ssot. Codegen needs a
+   shared enum source RFC before that can swap.) === *)
+
+let masc_approval_pending_spec : tool_spec =
+  { name = "masc_approval_pending"
+  ; description =
+      "Keeper-safe read-only view of the pending HITL approval queue. Use this to \
+       detect whether any approvals are waiting before asking an operator or using an \
+       admin-only detail/resolve path."
+  ; parameters = []
+  ; additional_properties = false
+  }
+;;
+
+let masc_approval_get_spec : tool_spec =
+  { name = "masc_approval_get"
+  ; description =
+      "Operator/admin-only detail view. Fetch one pending HITL approval by id, \
+       including the full input JSON. Use after finding an approval id in the \
+       dashboard or pending approval queue when the preview is insufficient for an \
+       operator decision. Requires the same privileged approval surface as resolving \
+       an approval."
+  ; parameters =
+      [ { p_name = "id"
+        ; p_type = T_string { enum = None; default = None }
+        ; p_description = "Pending approval id, for example appr_abc123def456"
+        ; p_required = true
+        }
+      ]
+  ; additional_properties = false
+  }
+;;
+
+let masc_spawn_spec : tool_spec =
+  { name = "masc_spawn"
+  ; description =
+      "Spawn an agent process (claude, gemini, codex, or llama) to execute a task. \
+       Use when you need another agent to work in parallel on a subtask. For llama, \
+       provide model explicitly. Pair with masc_add_task to create the task first."
+  ; parameters =
+      [ { p_name = "agent_name"
+        ; p_type = T_string { enum = None; default = None }
+        ; p_description = "Agent to spawn: 'claude', 'gemini', 'codex', or custom command"
+        ; p_required = true
+        }
+      ; { p_name = "model"
+        ; p_type = T_string { enum = None; default = None }
+        ; p_description = "Explicit model id. Required when agent_name='llama'."
+        ; p_required = false
+        }
+      ; { p_name = "prompt"
+        ; p_type = T_string { enum = None; default = None }
+        ; p_description = "The task/prompt to send to the agent"
+        ; p_required = true
+        }
+      ; { p_name = "timeout_seconds"
+        ; p_type = T_int { min = None; max = None; default = Some 300 }
+        ; p_description = "Max execution time in seconds (default: 300)"
+        ; p_required = false
+        }
+      ; { p_name = "working_dir"
+        ; p_type = T_string { enum = None; default = None }
+        ; p_description = "Working directory for the agent (optional)"
+        ; p_required = false
+        }
+      ]
+  ; additional_properties = false
+  }
+;;
+
 let phase6_specs : tool_spec list =
   [ masc_config_spec
   ; masc_code_read_spec
@@ -542,6 +614,10 @@ let phase6_specs : tool_spec list =
   ; masc_plan_clear_task_spec
   ; masc_note_add_spec
   ; masc_deliver_spec
+    (* PR-2c: inline_infra (3 of 4 — masc_mcp_session deferred) *)
+  ; masc_approval_pending_spec
+  ; masc_approval_get_spec
+  ; masc_spawn_spec
   ]
 ;;
 

--- a/lib/tool_schemas/tool_schemas_inline_infra.ml
+++ b/lib/tool_schemas/tool_schemas_inline_infra.ml
@@ -12,8 +12,22 @@ let mcp_session_action_enum_strings =
    moved to codegen (Tool_descriptors_gen via Tool_schemas_misc.schemas).
    masc_mcp_session remains here because its [action] enum is locked
    to [mcp_session_action_enum_strings] above by the SSOT regression
-   test; codegen needs a shared enum source RFC before it can swap. *)
-let schemas : tool_schema list = [
+   test; codegen needs a shared enum source RFC before it can swap.
+
+   The three codegen-emitted tools are re-included in this list so
+   downstream consumers (Tool_dispatch.mcp_context_required_set,
+   Keeper_tool_policy.is_keeper_mcp_context_required) that read
+   Tool_schemas_inline.schemas continue to see all inline_infra
+   tools. *)
+let _codegen_inline_infra_names =
+  [ "masc_approval_pending"; "masc_approval_get"; "masc_spawn" ]
+
+let _inline_infra_from_codegen =
+  List.filter
+    (fun (s : tool_schema) -> List.mem s.name _codegen_inline_infra_names)
+    Tool_schemas_misc.schemas
+
+let schemas : tool_schema list = _inline_infra_from_codegen @ [
   (* masc_mcp_session *)
   {
     name = "masc_mcp_session";

--- a/lib/tool_schemas/tool_schemas_inline_infra.ml
+++ b/lib/tool_schemas/tool_schemas_inline_infra.ml
@@ -8,6 +8,11 @@ open Masc_domain
 let mcp_session_action_enum_strings =
   [ "get"; "create"; "list"; "cleanup"; "remove" ]
 
+(* RFC-0057 PR-2c: masc_approval_pending, masc_approval_get, masc_spawn
+   moved to codegen (Tool_descriptors_gen via Tool_schemas_misc.schemas).
+   masc_mcp_session remains here because its [action] enum is locked
+   to [mcp_session_action_enum_strings] above by the SSOT regression
+   test; codegen needs a shared enum source RFC before it can swap. *)
 let schemas : tool_schema list = [
   (* masc_mcp_session *)
   {
@@ -35,76 +40,6 @@ Pair with masc_subscription to receive session-scoped event notifications.";
         ]);
       ]);
       ("required", `List [`String "action"]);
-      ("additionalProperties", `Bool false);
-    ];
-  };
-
-  (* masc_cancellation, masc_subscription, masc_progress,
-     masc_governance_set removed: pruned from surfaces *)
-
-  (* masc_approval_pending *)
-  {
-    name = "masc_approval_pending";
-    description = "Keeper-safe read-only view of the pending HITL approval queue. \
-Use this to detect whether any approvals are waiting before asking an operator or using an admin-only detail/resolve path.";
-    input_schema = `Assoc [
-      ("type", `String "object");
-      ("properties", `Assoc []);
-      ("additionalProperties", `Bool false);
-    ];
-  };
-
-  (* masc_approval_get *)
-  {
-    name = "masc_approval_get";
-    description = "Operator/admin-only detail view. Fetch one pending HITL approval by id, including the full input JSON. \
-Use after finding an approval id in the dashboard or pending approval queue when the preview is insufficient for an operator decision. \
-Requires the same privileged approval surface as resolving an approval.";
-    input_schema = `Assoc [
-      ("type", `String "object");
-      ("properties", `Assoc [
-        ("id", `Assoc [
-          ("type", `String "string");
-          ("description", `String "Pending approval id, for example appr_abc123def456");
-        ]);
-      ]);
-      ("required", `List [`String "id"]);
-      ("additionalProperties", `Bool false);
-    ];
-  };
-
-  (* masc_spawn *)
-  {
-    name = "masc_spawn";
-    description = "Spawn an agent process (claude, gemini, codex, or llama) to execute a task. \
-Use when you need another agent to work in parallel on a subtask. \
-For llama, provide model explicitly. Pair with masc_add_task to create the task first.";
-    input_schema = `Assoc [
-      ("type", `String "object");
-      ("properties", `Assoc [
-        ("agent_name", `Assoc [
-          ("type", `String "string");
-          ("description", `String "Agent to spawn: 'claude', 'gemini', 'codex', or custom command");
-        ]);
-        ("model", `Assoc [
-          ("type", `String "string");
-          ("description", `String "Explicit model id. Required when agent_name='llama'.");
-        ]);
-        ("prompt", `Assoc [
-          ("type", `String "string");
-          ("description", `String "The task/prompt to send to the agent");
-        ]);
-        ("timeout_seconds", `Assoc [
-          ("type", `String "integer");
-          ("default", `Int 300);
-          ("description", `String "Max execution time in seconds (default: 300)");
-        ]);
-        ("working_dir", `Assoc [
-          ("type", `String "string");
-          ("description", `String "Working directory for the agent (optional)");
-        ]);
-      ]);
-      ("required", `List [`String "agent_name"; `String "prompt"]);
       ("additionalProperties", `Bool false);
     ];
   };


### PR DESCRIPTION
## Summary

Plan PR-2c. Converts 3 inline_infra tools (`masc_approval_pending`, `masc_approval_get`, `masc_spawn`) to RFC-0057 codegen. `masc_mcp_session` remains hand-written.

Plan: `~/me/planning/claude-plans/polished-juggling-galaxy.md` §2 PR-2.
Depends on: **#14644 (PR-2a plan group, merged)**.

## Why not all 4?

`masc_mcp_session` has an `action` enum locked to `mcp_session_action_enum_strings` by the `test_types.ml :: mcp_session_action_ssot` regression test. The current codegen `tool_spec` record references enum *value* lists statically; the SSOT test wants the enum *source* to come from `Tool_schemas_inline_infra.mcp_session_action_enum_strings`. Codegen needs a shared enum SSOT before that swap. Tracked as a follow-up RFC-0057 extension.

## Tools swapped (3)

| Tool | Params |
|------|--------|
| `masc_approval_pending` | none |
| `masc_approval_get` | `id:string` required |
| `masc_spawn` | 5 params: `agent_name`/`prompt` required, `model`/`working_dir` optional, `timeout_seconds:int default=300` |

## Gate

- **G1 (codegen spec count)**: 23 → **26** (+3)
- **G2 (hand-written schema LOC)**: -68 in `tool_schemas_inline_infra.ml`
- **G4 (byte-equality)**: `masc_spawn` spot-check — generated JSON Schema fields match origin/main word-for-word. Object key ordering differs (description before default in codegen vs after in hand-written) but JSON Schema equality preserved — MCP clients parse JSON unordered.

## Changes (+81 / -70, 2 files)

| File | Δ |
|------|---|
| `bin/gen_tool_descriptors.ml` | +76 (3 spec records + phase6_specs entries) |
| `lib/tool_schemas/tool_schemas_inline_infra.ml` | -75 / +5 (retain masc_mcp_session + enum SSOT) |

## Test plan

- [x] `dune build --root . @check` green
- [ ] CI: `dune test --root .` — `mcp_session_action_ssot` test still references the retained enum string list
- [ ] Smoke: `masc_approval_pending` / `masc_approval_get` / `masc_spawn` MCP dispatch from a client

## RFC-0057 progress

| | Before | After PR-2c |
|---|---|---|
| codegen spec count | 23 | **26** |
| swap % | 38% | **43%** |
| hand-written schema LOC | ~941 | ~873 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)