### PR TITLE
refactor(cascade): replace transport_for_provider_config closed-variant dispatch with Hashtbl registry (RFC-0058 Phase 5.1 A.3c)

### DIFF
--- a/lib/cascade/cascade_transport.ml
+++ b/lib/cascade/cascade_transport.ml
@@ -1704,9 +1704,28 @@ let non_http_transport_of_provider
   =
   let _ = sw in
   match Hashtbl.find_opt non_http_transport_registry provider_cfg.kind with
-  | None -> Ok None
   | Some ctor ->
     (match ctor ~provider_cfg ~runtime_mcp_policy ~cli_transport_overrides with
      | Ok transport -> Ok (Some transport)
      | Error _ as e -> e)
+  | None ->
+    (* Fail-fast for subprocess CLI kinds that have no registered ctor:
+       falling through to [Ok None] would route the request to the HTTP
+       lane, which cannot serve a CLI provider. HTTP-shaped providers
+       (Anthropic / OpenAI_compat / Ollama / Gemini / Glm / Kimi /
+       DashScope) correctly return [Ok None]; they live behind a
+       different transport selector upstream. *)
+    if Llm_provider.Provider_config.is_subprocess_cli provider_cfg.kind
+    then
+      Error
+        (invalid_runtime_config
+           "non_http_transport_registry"
+           (Printf.sprintf
+              "no non-HTTP transport constructor registered for subprocess \
+               CLI kind %s — registry initializer (cascade_transport.ml \
+               top-level [let ()]) is out of sync with the \
+               Llm_provider.Provider_config.provider_kind variant"
+              (Llm_provider.Provider_config.string_of_provider_kind
+                 provider_cfg.kind)))
+    else Ok None
 ;;

--- a/lib/cascade/cascade_transport.ml
+++ b/lib/cascade/cascade_transport.ml
@@ -1544,6 +1544,156 @@ let make_cli_argv_sanitizing_transport (transport : Llm_provider.Llm_transport.t
   }
 ;;
 
+(** Registry of non-HTTP transport constructors keyed by provider kind.
+    RFC-0058 §2.4: dispatch by registry lookup, not by closed-variant match.
+    Adding a CLI vendor with an existing protocol shape is a single
+    [register_non_http_transport] call (no edit to
+    {!non_http_transport_of_provider} or any match arm). Vendor SDKs themselves
+    remain in [agent_sdk] (Claude Code's leaked `client.ts` follows the same
+    precedent — Bedrock / Vertex / Foundry / firstParty all live behind a
+    dispatch table that selects one SDK package per env-keyed kind).
+
+    Each ctor takes ownership of [Process_eio.get_proc_mgr] so the registry's
+    value type stays a plain function (no row-polymorphic Eio mgr leaks into
+    the Hashtbl). *)
+type non_http_transport_ctor =
+  provider_cfg:Llm_provider.Provider_config.t
+  -> runtime_mcp_policy:Llm_provider.Llm_transport.runtime_mcp_policy option
+  -> cli_transport_overrides:cli_transport_overrides option
+  -> (Llm_provider.Llm_transport.t, Agent_sdk.Error.sdk_error) result
+
+let non_http_transport_registry
+  : (Llm_provider.Provider_config.provider_kind, non_http_transport_ctor) Hashtbl.t
+  =
+  Hashtbl.create 8
+;;
+
+let register_non_http_transport ~kind ~ctor =
+  Hashtbl.replace non_http_transport_registry kind ctor
+;;
+
+let default_cli_transport_overrides =
+  { cwd = None
+  ; claude_mcp_config = None
+  ; claude_allowed_tools = None
+  ; claude_permission_mode = None
+  ; claude_max_turns = None
+  ; gemini_yolo = None
+  ; cli_subprocess_idle_sec = None
+  }
+;;
+
+let with_proc_mgr (f : mgr:_ -> Llm_provider.Llm_transport.t) =
+  match Process_eio.get_proc_mgr () with
+  | Error detail -> Error (invalid_runtime_config "proc_mgr" detail)
+  | Ok mgr -> Ok (f ~mgr)
+;;
+
+let claude_code_transport_ctor
+      ~(provider_cfg : Llm_provider.Provider_config.t)
+      ~runtime_mcp_policy:_
+      ~cli_transport_overrides
+  =
+  let overrides =
+    Option.value ~default:default_cli_transport_overrides cli_transport_overrides
+  in
+  let config =
+    { Llm_provider.Transport_claude_code.default_config with
+      model = cli_model_override provider_cfg.model_id
+    ; cwd = overrides.cwd
+    ; mcp_config = overrides.claude_mcp_config
+    ; allowed_tools = Option.value ~default:[] overrides.claude_allowed_tools
+    ; permission_mode = overrides.claude_permission_mode
+    ; max_turns =
+        Option.map
+          (provider_effective_max_turns provider_cfg.kind)
+          overrides.claude_max_turns
+    }
+  in
+  with_proc_mgr (fun ~mgr ->
+    make_per_call_switch_transport (fun ~sw ->
+      Llm_provider.Transport_claude_code.create ~sw ~mgr ~config))
+;;
+
+let gemini_cli_transport_ctor
+      ~(provider_cfg : Llm_provider.Provider_config.t)
+      ~runtime_mcp_policy:_
+      ~cli_transport_overrides
+  =
+  let overrides =
+    Option.value ~default:default_cli_transport_overrides cli_transport_overrides
+  in
+  let config =
+    { Llm_provider.Transport_gemini_cli.default_config with
+      model = cli_model_override provider_cfg.model_id
+    ; cwd = overrides.cwd
+    ; yolo = Option.value ~default:true overrides.gemini_yolo
+    }
+  in
+  with_proc_mgr (fun ~mgr ->
+    make_per_call_switch_transport (fun ~sw ->
+      Llm_provider.Transport_gemini_cli.create ~sw ~mgr ~config))
+;;
+
+let kimi_cli_transport_ctor
+      ~(provider_cfg : Llm_provider.Provider_config.t)
+      ~runtime_mcp_policy
+      ~cli_transport_overrides
+  =
+  let cwd = Option.bind cli_transport_overrides (fun overrides -> overrides.cwd) in
+  let stdout_idle_timeout_s =
+    Option.bind cli_transport_overrides (fun overrides ->
+      overrides.cli_subprocess_idle_sec)
+  in
+  let mcp_config_json = kimi_cli_runtime_mcp_jsons ~base:[] runtime_mcp_policy in
+  let model = kimi_cli_model_for_provider provider_cfg in
+  let config_json = kimi_cli_config_json_for_provider provider_cfg in
+  let extra_env = kimi_cli_extra_env provider_cfg in
+  let config =
+    { Kimi_cli_transport_local.default_config with
+      model
+    ; cwd
+    ; config_json
+    ; mcp_config_json
+    ; extra_env
+    ; stdout_idle_timeout_s
+    }
+  in
+  with_proc_mgr (fun ~mgr ->
+    make_per_call_switch_transport (fun ~sw ->
+      Kimi_cli_transport_local.create ~sw ~mgr ~config))
+;;
+
+let codex_cli_transport_ctor
+      ~provider_cfg:_
+      ~runtime_mcp_policy:_
+      ~cli_transport_overrides
+  =
+  let cwd = Option.bind cli_transport_overrides (fun overrides -> overrides.cwd) in
+  with_proc_mgr (fun ~mgr ->
+    make_cli_argv_sanitizing_transport
+      (make_per_call_switch_transport (fun ~sw ->
+         Llm_provider.Transport_codex_cli.create
+           ~sw
+           ~mgr
+           ~config:{ Llm_provider.Transport_codex_cli.default_config with cwd })))
+;;
+
+let () =
+  register_non_http_transport
+    ~kind:Llm_provider.Provider_config.Claude_code
+    ~ctor:claude_code_transport_ctor;
+  register_non_http_transport
+    ~kind:Llm_provider.Provider_config.Gemini_cli
+    ~ctor:gemini_cli_transport_ctor;
+  register_non_http_transport
+    ~kind:Llm_provider.Provider_config.Kimi_cli
+    ~ctor:kimi_cli_transport_ctor;
+  register_non_http_transport
+    ~kind:Llm_provider.Provider_config.Codex_cli
+    ~ctor:codex_cli_transport_ctor
+;;
+
 let non_http_transport_of_provider
       ~(sw : Eio.Switch.t)
       ~(provider_cfg : Llm_provider.Provider_config.t)
@@ -1553,113 +1703,10 @@ let non_http_transport_of_provider
   : (Llm_provider.Llm_transport.t option, Agent_sdk.Error.sdk_error) result
   =
   let _ = sw in
-  let proc_mgr_result () =
-    match Process_eio.get_proc_mgr () with
-    | Ok mgr -> Ok mgr
-    | Error detail -> Error (invalid_runtime_config "proc_mgr" detail)
-  in
-  match provider_cfg.kind with
-  | Llm_provider.Provider_config.Claude_code ->
-    (match proc_mgr_result () with
-     | Error _ as e -> e
-     | Ok mgr ->
-       let overrides =
-         Option.value
-           ~default:
-             { cwd = None
-             ; claude_mcp_config = None
-             ; claude_allowed_tools = None
-             ; claude_permission_mode = None
-             ; claude_max_turns = None
-             ; gemini_yolo = None
-             ; cli_subprocess_idle_sec = None
-             }
-           cli_transport_overrides
-       in
-       let config =
-         { Llm_provider.Transport_claude_code.default_config with
-           model = cli_model_override provider_cfg.model_id
-         ; cwd = overrides.cwd
-         ; mcp_config = overrides.claude_mcp_config
-         ; allowed_tools = Option.value ~default:[] overrides.claude_allowed_tools
-         ; permission_mode = overrides.claude_permission_mode
-         ; max_turns =
-             Option.map
-               (provider_effective_max_turns provider_cfg.kind)
-               overrides.claude_max_turns
-         }
-       in
-       Ok
-         (Some
-            (make_per_call_switch_transport (fun ~sw ->
-               Llm_provider.Transport_claude_code.create ~sw ~mgr ~config))))
-  | Llm_provider.Provider_config.Gemini_cli ->
-    (match proc_mgr_result () with
-     | Error _ as e -> e
-     | Ok mgr ->
-       let overrides =
-         Option.value
-           ~default:
-             { cwd = None
-             ; claude_mcp_config = None
-             ; claude_allowed_tools = None
-             ; claude_permission_mode = None
-             ; claude_max_turns = None
-             ; gemini_yolo = None
-             ; cli_subprocess_idle_sec = None
-             }
-           cli_transport_overrides
-       in
-       let config =
-         { Llm_provider.Transport_gemini_cli.default_config with
-           model = cli_model_override provider_cfg.model_id
-         ; cwd = overrides.cwd
-         ; yolo = Option.value ~default:true overrides.gemini_yolo
-         }
-       in
-       Ok
-         (Some
-            (make_per_call_switch_transport (fun ~sw ->
-               Llm_provider.Transport_gemini_cli.create ~sw ~mgr ~config))))
-  | Llm_provider.Provider_config.Kimi_cli ->
-    (match proc_mgr_result () with
-     | Error _ as e -> e
-     | Ok mgr ->
-       let cwd = Option.bind cli_transport_overrides (fun overrides -> overrides.cwd) in
-       let stdout_idle_timeout_s =
-         Option.bind cli_transport_overrides (fun overrides ->
-           overrides.cli_subprocess_idle_sec)
-       in
-       let mcp_config_json = kimi_cli_runtime_mcp_jsons ~base:[] runtime_mcp_policy in
-       let model = kimi_cli_model_for_provider provider_cfg in
-       let config_json = kimi_cli_config_json_for_provider provider_cfg in
-       let extra_env = kimi_cli_extra_env provider_cfg in
-       let config =
-         { Kimi_cli_transport_local.default_config with
-           model
-         ; cwd
-         ; config_json
-         ; mcp_config_json
-         ; extra_env
-         ; stdout_idle_timeout_s
-         }
-       in
-       Ok
-         (Some
-            (make_per_call_switch_transport (fun ~sw ->
-               Kimi_cli_transport_local.create ~sw ~mgr ~config))))
-  | Llm_provider.Provider_config.Codex_cli ->
-    (match proc_mgr_result () with
-     | Error _ as e -> e
-     | Ok mgr ->
-       let cwd = Option.bind cli_transport_overrides (fun overrides -> overrides.cwd) in
-       Ok
-         (Some
-            (make_cli_argv_sanitizing_transport
-               (make_per_call_switch_transport (fun ~sw ->
-                  Llm_provider.Transport_codex_cli.create
-                    ~sw
-                    ~mgr
-                    ~config:{ Llm_provider.Transport_codex_cli.default_config with cwd })))))
-  | Anthropic | OpenAI_compat | Ollama | Gemini | Glm | Kimi | DashScope -> Ok None
+  match Hashtbl.find_opt non_http_transport_registry provider_cfg.kind with
+  | None -> Ok None
+  | Some ctor ->
+    (match ctor ~provider_cfg ~runtime_mcp_policy ~cli_transport_overrides with
+     | Ok transport -> Ok (Some transport)
+     | Error _ as e -> e)
 ;;


### PR DESCRIPTION
## Summary — the big-bang dispatch erasure

`non_http_transport_of_provider` previously dispatched on `provider_cfg.kind` via a 4-arm match, each arm inlining ~30 lines of overrides handling, config building, and SDK constructor wrapping for one CLI vendor (Claude Code / Gemini CLI / Kimi CLI / Codex CLI).

Replace with a Hashtbl-keyed registry. Each vendor gets a named `*_transport_ctor` function; a top-level `let () = register_non_http_transport ...` block registers all four; `non_http_transport_of_provider` becomes a 5-line lookup.

| | Before | After |
|---|---|---|
| cascade_transport.ml dispatch arms | 4-arm `match provider_cfg.kind with | Claude_code -> ... | Gemini_cli -> ... | Kimi_cli -> ... | Codex_cli -> ... | _ -> Ok None` | `Hashtbl.find_opt non_http_transport_registry provider_cfg.kind` |
| New CLI vendor with same SDK shape | edit dispatch match | additive `register_non_http_transport` call |

## Why a Hashtbl registry — Anthropic / OpenClaw / LiteLLM precedent

Anthropic's leaked Claude Code (`src/services/api/client.ts:153-220`) uses the same architectural pattern: `if (isEnvTruthy CLAUDE_CODE_USE_BEDROCK) { await import("@anthropic-ai/bedrock-sdk") ... }` chains select one SDK package per env-keyed kind. OpenClaw's `registerProvider(...)` plugin pattern (docs.openclaw.ai/concepts/model-providers) is the same shape with a key/value table. LiteLLM keys per-vendor adapter modules by `litellm_params.custom_llm_provider`.

All three confirm: provider-specific transport instantiation is the boundary that cannot be made data-driven (TOML/YAML) without a transport-engine generic (would be a separate RFC). A Hashtbl registry is the right level of indirection — closes RFC-0058 §2.4 for dispatch *behavior* while keeping the closed `provider_kind` variant as a *data identifier*.

## OCaml constraint resolved

First attempt used `mgr:_ Eio.Resource.t` in the ctor signature, which forced row polymorphism through the Hashtbl value type and triggered `[> ` Generic | ` Platform | ` Process_mgr ]` vs `[ ` Generic ]` mismatch. Fix: each ctor calls `Process_eio.get_proc_mgr ()` internally via a shared `with_proc_mgr` helper, so the registry's value type is a plain monomorphic function.

## §2.4 progress — full closure of dispatch erasure

| Closed-variant matches in `lib/cascade/` | Before this stack | After this PR |
|---|---|---|
| `cascade_transport.ml` dispatch arms | 5 | 0 |
| `cascade_catalog_validator.ml` | 1 (5-arm whitelist) | 0 |
| `cascade_attempt_fsm.ml` | 1 (`OpenAI_compat` error hint) | 0 |
| `auth_resolve.ml` | 1 (`Codex_cli` bound-actor) | 0 |
| **Total cascade-layer dispatch sites** | **8** | **0** |

Remaining closed-variant references in `lib/cascade/cascade_transport.ml`:
- Line 33: `Provider_config.Claude_code` literal in `claude_code_max_turns_hard_cap` capability derive (single lookup, not dispatch)
- Lines 1684/1687/1690/1693: 4 `register_non_http_transport ~kind:X` calls (data, not dispatch)

→ §2.4 acceptance criterion **#11** ("adding a new provider should be a pure TOML edit") now achievable for CLI vendors that share an existing SDK shape: cascade.toml row + 1 `register` line + 1 ctor function. No diff to dispatch.

## Files

`lib/cascade/cascade_transport.ml` only. Net: +156 / -109.

## Test plan

- [x] `dune build --root . @check` clean
- [ ] keeper E2E replay golden (Claude Code 1-turn + Codex CLI runtime-MCP bridging) — recommended pre-merge

## Related

- A.3a (#14631), A.3b (#14636), PR-E (#14640), PR-W (#14642) — same series, capability-as-SSOT pattern
- B6 (#14643) — `discover_profiles` routing big-bang (merged in parallel)

🤖 Generated with [Claude Code](https://claude.com/claude-code)