### PR TITLE
refactor(keeper): typed tool_surface_class — string → closed sum type

### DIFF
--- a/lib/keeper/keeper_agent_run.mli
+++ b/lib/keeper/keeper_agent_run.mli
@@ -47,10 +47,11 @@ type ctx_composition_metrics =
   }
 
 type tool_requirement = Keeper_agent_tool_surface.tool_requirement
+type tool_surface_class = Keeper_agent_tool_surface.tool_surface_class
 
 type tool_surface_metrics =
   { turn_lane : string
-  ; tool_surface_class : string
+  ; tool_surface_class : tool_surface_class
   ; tool_requirement : tool_requirement
   ; visible_tool_count : int
   ; tool_gate_enabled : bool

--- a/lib/keeper/keeper_agent_tool_surface.ml
+++ b/lib/keeper/keeper_agent_tool_surface.ml
@@ -37,9 +37,34 @@ let tool_requirement_to_yojson = function
   | Optional -> `String "optional"
   | No_tools -> `String "none"
 
+(* Closed sum type for tool_surface_class.  Mirrors RFC-0065 §3.2.2
+   KeeperToolSurface SurfaceClassSet so the correspondence harness can
+   drop the hand-pinned label list.  [@tla.symbol "…"] fixes the wire
+   representation across JSON, Prometheus labels, dashboard surface,
+   and the .tla catalog. *)
+type tool_surface_class =
+  | Surface_none [@tla.symbol "none"]
+  | Surface_public_only [@tla.symbol "public_only"]
+  | Surface_mixed [@tla.symbol "mixed"]
+[@@deriving tla]
+
+let tool_surface_class_to_string = function
+  | Surface_none -> "none"
+  | Surface_public_only -> "public_only"
+  | Surface_mixed -> "mixed"
+
+let tool_surface_class_of_string = function
+  | "none" -> Some Surface_none
+  | "public_only" -> Some Surface_public_only
+  | "mixed" -> Some Surface_mixed
+  | _ -> None
+
+let tool_surface_class_to_yojson cls =
+  `String (tool_surface_class_to_string cls)
+
 type tool_surface_metrics =
   { turn_lane : string
-  ; tool_surface_class : string
+  ; tool_surface_class : tool_surface_class
   ; tool_requirement : tool_requirement
   ; visible_tool_count : int
   ; tool_gate_enabled : bool
@@ -66,7 +91,7 @@ type computed_tool_surface =
   ; selection_mode : string
   ; is_last_turn : bool
   ; is_warning_zone : bool
-  ; tool_surface_class : string
+  ; tool_surface_class : tool_surface_class
   ; tool_requirement : tool_requirement
   ; tool_gate_requested : bool
   ; tool_surface_fallback_used : bool

--- a/lib/keeper/keeper_agent_tool_surface.ml
+++ b/lib/keeper/keeper_agent_tool_surface.ml
@@ -48,16 +48,18 @@ type tool_surface_class =
   | Surface_mixed [@tla.symbol "mixed"]
 [@@deriving tla]
 
-let tool_surface_class_to_string = function
-  | Surface_none -> "none"
-  | Surface_public_only -> "public_only"
-  | Surface_mixed -> "mixed"
+(* [@tla.symbol] is the single source of truth for the wire form:
+   - to_tla_symbol (ppx-generated) emits the symbol attached per variant
+   - all_symbols / all_states (ppx-generated) enumerate the type
+   Defining the JSON/Prometheus surface in terms of [to_tla_symbol]
+   guarantees JSON ↔ spec parity cannot drift even if a variant or its
+   symbol changes.  Addresses the SSOT concern in PR #14647 review. *)
+let tool_surface_class_to_string = to_tla_symbol
 
-let tool_surface_class_of_string = function
-  | "none" -> Some Surface_none
-  | "public_only" -> Some Surface_public_only
-  | "mixed" -> Some Surface_mixed
-  | _ -> None
+let tool_surface_class_of_string raw =
+  List.find_opt
+    (fun cls -> String.equal (to_tla_symbol cls) raw)
+    all_states
 
 let tool_surface_class_to_yojson cls =
   `String (tool_surface_class_to_string cls)

--- a/lib/keeper/keeper_agent_tool_surface.mli
+++ b/lib/keeper/keeper_agent_tool_surface.mli
@@ -23,10 +23,26 @@ val tool_requirement_to_string : tool_requirement -> string
 val tool_requirement_of_string : string -> tool_requirement option
 val tool_requirement_to_yojson : tool_requirement -> Yojson.Safe.t
 
+(** Classification of the per-turn tool surface.  Closed sum type; the
+    OCaml side mirrors the RFC-0065 §3.2.2 KeeperToolSurface
+    SurfaceClassSet ({"none", "public_only", "mixed"}).
+    [@@deriving tla] emits [all_symbols : string list] so the
+    correspondence harness can parity-check against the spec catalog
+    without hand-pinning the label list. *)
+type tool_surface_class =
+  | Surface_none [@tla.symbol "none"]
+  | Surface_public_only [@tla.symbol "public_only"]
+  | Surface_mixed [@tla.symbol "mixed"]
+[@@deriving tla]
+
+val tool_surface_class_to_string : tool_surface_class -> string
+val tool_surface_class_of_string : string -> tool_surface_class option
+val tool_surface_class_to_yojson : tool_surface_class -> Yojson.Safe.t
+
 (** Diagnostic surface metrics emitted into trajectory entries. *)
 type tool_surface_metrics =
   { turn_lane : string
-  ; tool_surface_class : string
+  ; tool_surface_class : tool_surface_class
   ; tool_requirement : tool_requirement
   ; visible_tool_count : int
   ; tool_gate_enabled : bool
@@ -55,7 +71,7 @@ type computed_tool_surface =
   ; selection_mode : string
   ; is_last_turn : bool
   ; is_warning_zone : bool
-  ; tool_surface_class : string
+  ; tool_surface_class : tool_surface_class
   ; tool_requirement : tool_requirement
   ; tool_gate_requested : bool
   ; tool_surface_fallback_used : bool

--- a/lib/keeper/keeper_execution_receipt.ml
+++ b/lib/keeper/keeper_execution_receipt.ml
@@ -69,7 +69,7 @@ type tool_requirement = Keeper_agent_tool_surface.tool_requirement
 
 type tool_surface =
   { turn_lane : string
-  ; tool_surface_class : string
+  ; tool_surface_class : Keeper_agent_tool_surface.tool_surface_class
   ; tool_requirement : Keeper_agent_tool_surface.tool_requirement
   ; visible_tool_count : int
   ; tool_gate_enabled : bool
@@ -419,7 +419,9 @@ let to_json (receipt : t) =
       ?sandbox_root:receipt.sandbox_root
       ~network_mode:receipt.network_mode
       ?approval_mode:receipt.approval_profile
-      ~tool_surface_class:receipt.tool_surface.tool_surface_class
+      ~tool_surface_class:
+        (Keeper_agent_tool_surface.tool_surface_class_to_string
+           receipt.tool_surface.tool_surface_class)
       ~visible_tool_count:receipt.tool_surface.visible_tool_count
       ~required_tools:receipt.tool_surface.required_tools
       ~missing_required_tools:receipt.tool_surface.missing_required_tools
@@ -489,7 +491,9 @@ let to_json (receipt : t) =
         `Assoc
           [
             ("turn_lane", `String receipt.tool_surface.turn_lane);
-            ("tool_surface_class", `String receipt.tool_surface.tool_surface_class);
+            ( "tool_surface_class",
+              Keeper_agent_tool_surface.tool_surface_class_to_yojson
+                receipt.tool_surface.tool_surface_class );
             ("tool_requirement", Keeper_agent_tool_surface.tool_requirement_to_yojson receipt.tool_surface.tool_requirement);
             ("visible_tool_count", `Int receipt.tool_surface.visible_tool_count);
             ("tool_gate_enabled", `Bool receipt.tool_surface.tool_gate_enabled);
@@ -641,7 +645,9 @@ let operator_broadcast_payload (receipt : t) ~disposition ~reason =
               list_json receipt.tool_surface.missing_required_tools )
           ; "visible_tool_count", `Int receipt.tool_surface.visible_tool_count
           ; "tool_requirement", Keeper_agent_tool_surface.tool_requirement_to_yojson receipt.tool_surface.tool_requirement
-          ; "tool_surface_class", `String receipt.tool_surface.tool_surface_class
+          ; ( "tool_surface_class"
+            , Keeper_agent_tool_surface.tool_surface_class_to_yojson
+                receipt.tool_surface.tool_surface_class )
           ; "tool_gate_enabled", `Bool receipt.tool_surface.tool_gate_enabled
           ] )
     ; ( "sandbox",

--- a/lib/keeper/keeper_execution_receipt.mli
+++ b/lib/keeper/keeper_execution_receipt.mli
@@ -85,7 +85,7 @@ type tool_requirement = Keeper_agent_tool_surface.tool_requirement
 
 type tool_surface =
   { turn_lane : string
-  ; tool_surface_class : string
+  ; tool_surface_class : Keeper_agent_tool_surface.tool_surface_class
   ; tool_requirement : tool_requirement
   ; visible_tool_count : int
   ; tool_gate_enabled : bool

--- a/lib/keeper/keeper_run_tools.ml
+++ b/lib/keeper/keeper_run_tools.ml
@@ -200,7 +200,7 @@ let prepare_agent_setup
          | None -> Agent_sdk.Tool_op.Keep_all)
     ; tool_surface =
         { turn_lane = "text_only"
-        ; tool_surface_class = "none"
+        ; tool_surface_class = Keeper_agent_tool_surface.Surface_none
         ; tool_requirement = No_tools
         ; visible_tool_count = 0
         ; tool_gate_enabled = false
@@ -946,12 +946,12 @@ let prepare_agent_setup
       List.filter (fun name -> not (List.mem name all_allowed)) required_tool_names
     in
     let visible_tool_count = List.length all_allowed in
-    let tool_surface_class =
+    let tool_surface_class : Keeper_agent_tool_surface.tool_surface_class =
       if visible_tool_count = 0
-      then "none"
+      then Surface_none
       else if List.for_all Tool_catalog.is_public_mcp all_allowed
-      then "public_only"
-      else "mixed"
+      then Surface_public_only
+      else Surface_mixed
     in
     let tool_requirement =
       if visible_tool_count = 0
@@ -1524,7 +1524,9 @@ let prepare_agent_setup
                   ~allowed_paths:(Keeper_alerting_path.effective_allowed_paths ~meta)
                   ~network_mode:(Keeper_types.network_mode_to_string meta.network_mode)
                   ?approval_mode:approval_mode_effective
-                  ~tool_surface_class:computed_surface.tool_surface_class
+                  ~tool_surface_class:
+                    (Keeper_agent_tool_surface.tool_surface_class_to_string
+                       computed_surface.tool_surface_class)
                   ~visible_tool_count:(List.length all_allowed)
                   ~required_tools:computed_surface.required_tool_names
                   ~missing_required_tools:computed_surface.missing_required_tool_names
@@ -1582,7 +1584,9 @@ let prepare_agent_setup
                      ; "llm_selected_count", `Int computed_surface.llm_selected_count
                      ; "final_visible", `Int (List.length all_allowed)
                      ; "turn_lane", `String lane
-                     ; "tool_surface_class", `String computed_surface.tool_surface_class
+                     ; ( "tool_surface_class"
+                       , Keeper_agent_tool_surface.tool_surface_class_to_yojson
+                           computed_surface.tool_surface_class )
                      ; ( "tool_requirement"
                        , tool_requirement_to_yojson computed_surface.tool_requirement )
                      ; "tool_gate_enabled", `Bool computed_surface.tool_gate_requested

--- a/lib/keeper/keeper_turn_helpers.ml
+++ b/lib/keeper/keeper_turn_helpers.ml
@@ -213,7 +213,7 @@ let post_turn_complete_task ~(cycle_completed : bool ref) = ignore cycle_complet
 
 let pre_dispatch_tool_surface : Keeper_execution_receipt.tool_surface =
   { turn_lane = "pre_dispatch"
-  ; tool_surface_class = "none"
+  ; tool_surface_class = Keeper_agent_tool_surface.Surface_none
   ; tool_requirement = No_tools
   ; visible_tool_count = 0
   ; tool_gate_enabled = false

--- a/lib/keeper/keeper_unified_metrics.ml
+++ b/lib/keeper/keeper_unified_metrics.ml
@@ -897,7 +897,9 @@ let append_decision_record
               let tool_surface_fields =
                 [
                   ("turn_lane", `String r.tool_surface.turn_lane);
-                  ("tool_surface_class", `String r.tool_surface.tool_surface_class);
+                  ( "tool_surface_class"
+                  , Keeper_agent_tool_surface.tool_surface_class_to_yojson
+                      r.tool_surface.tool_surface_class );
                   ("tool_requirement", Keeper_agent_tool_surface.tool_requirement_to_yojson r.tool_surface.tool_requirement);
                   ("visible_tool_count", `Int r.tool_surface.visible_tool_count);
                   ("tool_gate_enabled", `Bool r.tool_surface.tool_gate_enabled);

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -1038,7 +1038,10 @@ let test_keeper_zombie_field_contracts () =
       tool_surface =
         {
           turn_lane = "unified";
-          tool_surface_class = "post_dispatch";
+          (* WORKAROUND: previously "post_dispatch" — invalid string never
+             emitted by producer.  Typed enum forces a real value.
+             Root: closed sum type disallows ad-hoc fixture strings. *)
+          tool_surface_class = Masc_mcp.Keeper_agent_tool_surface.Surface_mixed;
           tool_requirement = Masc_mcp.Keeper_agent_tool_surface.Required;
           visible_tool_count = 1;
           tool_gate_enabled = true;

--- a/test/test_dashboard_execution.ml
+++ b/test/test_dashboard_execution.ml
@@ -488,7 +488,7 @@ let append_execution_receipt ?(outcome = "ok")
       tool_surface =
         {
           turn_lane = "tool";
-          tool_surface_class = "mixed";
+          tool_surface_class = Masc_mcp.Keeper_agent_tool_surface.Surface_mixed;
           tool_requirement = Masc_mcp.Keeper_agent_tool_surface.Required;
           visible_tool_count = 2;
           tool_gate_enabled = true;

--- a/test/test_dashboard_goals.ml
+++ b/test/test_dashboard_goals.ml
@@ -134,7 +134,7 @@ let append_keeper_receipt ?(outcome = "ok")
       tool_surface =
         {
           turn_lane = "tool";
-          tool_surface_class = "mixed";
+          tool_surface_class = Keeper_agent_tool_surface.Surface_mixed;
           tool_requirement;
           visible_tool_count = 1;
           tool_gate_enabled = true;

--- a/test/test_dashboard_keeper_routes.ml
+++ b/test/test_dashboard_keeper_routes.ml
@@ -624,7 +624,7 @@ let append_execution_receipt ?(tool_contract_result = "satisfied")
       tool_surface =
         {
           turn_lane = "tool";
-          tool_surface_class = "mixed";
+          tool_surface_class = Masc_mcp.Keeper_agent_tool_surface.Surface_mixed;
           tool_requirement = Masc_mcp.Keeper_agent_tool_surface.Required;
           visible_tool_count = 2;
           tool_gate_enabled = true;

--- a/test/test_keeper_ocaml_tla_correspondence.ml
+++ b/test/test_keeper_ocaml_tla_correspondence.ml
@@ -219,10 +219,12 @@ let test_accept_on_exhaustion_terminal () =
 
 let test_surface_class_set_parity () =
   (* B2 spec catalog: SurfaceClassSet = {"none", "public_only", "mixed"}.
-     OCaml: keeper_run_tools.ml:949-955 emits exactly these strings.
-     There is no closed sum type on the OCaml side yet — the value
-     is a [string] field on [computed_tool_surface].  Hand-pin and
-     compare against the spec's enumerated catalog. *)
+     OCaml: now a closed sum type [tool_surface_class] with
+     [@@deriving tla] in [Keeper_agent_tool_surface].  The harness
+     drops the hand-pinned list and uses [all_symbols] directly —
+     the spec ↔ OCaml drift surface is the [@tla.symbol "…"]
+     attribute on each constructor, which the ppx serializes
+     into [all_symbols]. *)
   let spec_classes =
     Masc_test_deps.tla_quoted_set_from_repo_file_exn
       ~relpath:spec_relpath_b2
@@ -231,7 +233,7 @@ let test_surface_class_set_parity () =
   in
   let ocaml_classes =
     Masc_test_deps.sorted_strings
-      [ "none"; "public_only"; "mixed" ]
+      Masc_mcp.Keeper_agent_tool_surface.all_symbols
   in
   if ocaml_classes <> spec_classes then begin
     Printf.printf "OCaml surface classes : [%s]\n"
@@ -240,8 +242,8 @@ let test_surface_class_set_parity () =
       (String.concat "; " spec_classes);
     failwith
       "KeeperToolSurface SurfaceClassSet differs from OCaml \
-       tool_surface_class catalog — sync the spec or the OCaml-side \
-       contract list."
+       tool_surface_class all_symbols — sync the spec or the \
+       OCaml-side variant."
   end
 
 let test_requirement_set_parity () =

--- a/test/test_keeper_pause_broadcast.ml
+++ b/test/test_keeper_pause_broadcast.ml
@@ -17,7 +17,11 @@ let mk_tool_surface ?(tool_requirement = Masc_mcp.Keeper_agent_tool_surface.Requ
     R.tool_surface =
   {
     turn_lane = "unified";
-    tool_surface_class = "post_dispatch";
+    (* WORKAROUND: previously "post_dispatch" — a string the producer
+       never emits.  Typed enum forces a real value; Surface_mixed
+       matches the prior test intent of a tool-using turn.
+       Root: closed sum type now disallows ad-hoc fixture strings. *)
+    tool_surface_class = Masc_mcp.Keeper_agent_tool_surface.Surface_mixed;
     tool_requirement;
     visible_tool_count = 1;
     tool_gate_enabled = true;

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -2423,7 +2423,7 @@ let sample_ctx_composition ?(system_prompt = "You are a keeper.")
 let sample_tool_surface_metrics () : Masc_mcp.Keeper_agent_run.tool_surface_metrics =
   {
     turn_lane = "tool_optional";
-    tool_surface_class = "mixed";
+    tool_surface_class = Masc_mcp.Keeper_agent_tool_surface.Surface_mixed;
     tool_requirement = Masc_mcp.Keeper_agent_tool_surface.Optional;
     visible_tool_count = 0;
     tool_gate_enabled = false;


### PR DESCRIPTION
## Summary

Extends the Track A pattern (#14613: substring → typed `blocker_class`) to
the tool surface classification. Replaces `tool_surface_class : string`
with a closed `[@@deriving tla]` variant in `Keeper_agent_tool_surface`.
Strings remain only at JSON / Prometheus boundaries via
`tool_surface_class_to_string` / `_to_yojson`.

Closes the last hand-pinned label list in the RFC-0065 correspondence
harness — B2 `SurfaceClassSet` parity now reads `all_symbols` from
`[@@deriving tla]` directly.

## What this PR adds

### `lib/keeper/keeper_agent_tool_surface.{ml,mli}`

\`\`\`ocaml
type tool_surface_class =
  | Surface_none        [@tla.symbol \"none\"]
  | Surface_public_only [@tla.symbol \"public_only\"]
  | Surface_mixed       [@tla.symbol \"mixed\"]
[@@deriving tla]

val tool_surface_class_to_string  : t -> string
val tool_surface_class_of_string  : string -> t option
val tool_surface_class_to_yojson  : t -> Yojson.Safe.t
\`\`\`

Plus migration of `tool_surface_metrics.tool_surface_class` and
`computed_tool_surface.tool_surface_class` from `string` → typed.

### `lib/keeper/keeper_agent_run.mli` + `keeper_execution_receipt.{ml,mli}`

Type alias + field type migration. JSON emission via
`tool_surface_class_to_yojson`. Telemetry boundary
(`Keeper_runtime_contract`) converts via `tool_surface_class_to_string`.

### `lib/keeper/keeper_run_tools.ml`

Producer computes typed value (`Surface_none` / `Surface_public_only` /
`Surface_mixed`) instead of string literal. Three downstream
string boundaries call `to_string` / `to_yojson` at the wire layer.

### `test/test_keeper_ocaml_tla_correspondence.ml`

B2 `SurfaceClassSet` parity now uses
`Keeper_agent_tool_surface.all_symbols` instead of the hand-pinned
`[\"none\"; \"public_only\"; \"mixed\"]` list. Future variant additions
auto-sync without a test edit.

## Verification

\`\`\`
$ dune build --root . @check
PASS (15 files compiled cleanly)

$ _build/default/test/test_keeper_ocaml_tla_correspondence.exe
12 tests run, 11 OK + 1 SKIP, Test Successful

$ _build/default/test/test_keeper_post_turn_wirein_order.exe
2 tests run, Test Successful
\`\`\`

## Real bug caught by the typed enum (test fixtures)

Two test fixtures used `tool_surface_class = \"post_dispatch\"`, a
string the producer **never emits**. Under the old `string` field
this compiled and the tests \"passed\" but exercised a meaningless
path. The closed sum type rejected both at compile time:

- `test/test_ci_hardening_source.ml:1041`
- `test/test_keeper_pause_broadcast.ml:20`

Both reassigned to `Surface_mixed` with WORKAROUND comments
documenting the prior drift. **Root cause**: closed sum type now
disallows ad-hoc fixture strings (anti-pattern #2 elimination per
CLAUDE.md §AI 코드 생성 안티패턴).

## G3 acceptance gate (provider/model opacity)

\`\`\`
$ git diff origin/main -- <changed files> | grep '^+' \\
    | rg -ic 'anthropic|openai|claude|gpt|gemini|sonnet|opus|haiku'
0
\`\`\`

Pre-existing matches in the files (e.g. `gemini_mcp_disabled` field
name) are not introduced by this PR.

## Why this lands now

RFC-0065 §3.2.2 `SurfaceClassSet` parity test was hand-pinning the
OCaml-side label list because no closed type existed. This PR closes
that gap — the harness now reads `all_symbols` directly from the
`[@@deriving tla]` output, removing the drift risk between spec
catalog and OCaml contract.

Builds on RFC-0065 PR train (all merged):
- #14613 (Track A typed `blocker_class`)
- #14615 (RFC-0065)
- #14621 (B1 KCAF)
- #14626 (B2 KTS)
- #14632 (B3 KPTO + harness)
- #14637 (composite observer)
- #14641 (WireinOrderPinned OCaml-side guard)

## Files touched (15)

| Category | Files |
|---|---|
| Type def | `keeper_agent_tool_surface.{ml,mli}` |
| Type alias / record migration | `keeper_agent_run.mli`, `keeper_execution_receipt.{ml,mli}` |
| Producer + boundary conversion | `keeper_run_tools.ml`, `keeper_turn_helpers.ml`, `keeper_unified_metrics.ml` |
| Correspondence harness | `test/test_keeper_ocaml_tla_correspondence.ml` |
| Test fixtures | `test/test_keeper_unified.ml`, `test/test_dashboard_{goals,execution,keeper_routes}.ml`, `test/test_keeper_pause_broadcast.ml`, `test/test_ci_hardening_source.ml` |

## Test plan

- [x] `dune build --root . @check` — PASS
- [x] correspondence harness — 12 tests (B1 8 + B2 2 + B3 2 + 1 SKIP)
- [x] wirein order test — 2 tests, all OK
- [x] G3 opacity grep on added lines — 0
- [x] Real drift bugs caught: 2 invalid fixture strings rejected at compile time

🤖 Generated with [Claude Code](https://claude.com/claude-code)