### PR TITLE
refactor(prometheus): rename codex_cli_mcp_tool_omission → provider_mcp_tool_omission with provider label (RFC-0058 Phase 5.4 big-bang)

### DIFF
--- a/lib/cascade/cascade_transport.ml
+++ b/lib/cascade/cascade_transport.ml
@@ -107,8 +107,8 @@ let record_codex_cli_omission_for_agent
     List.iter
       (fun tool ->
          Prometheus.inc_counter
-           Prometheus.metric_codex_cli_mcp_tool_omission
-           ~labels:[ "tool", tool ]
+           Prometheus.metric_provider_mcp_tool_omission
+           ~labels:[ "provider", "codex_cli"; "tool", tool ]
            ())
       tools;
     let tool_fingerprint = codex_cli_omission_fingerprint tools in
@@ -120,7 +120,7 @@ let record_codex_cli_omission_for_agent
         "codex_cli omitting keeper-bound runtime MCP tool(s) that require request-scoped \
          auth headers: %s (no per-keeper bearer-token lane available for %s; subsequent \
          omissions of this same set are counted in \
-         masc_codex_cli_mcp_tool_omission_total and not re-logged)"
+         masc_provider_mcp_tool_omission_total{provider=\"codex_cli\"} and not re-logged)"
         (String.concat ", " (List.sort String.compare tools))
         agent_name_key
 ;;

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -505,15 +505,22 @@ let metric_persistence_read_drops = "masc_persistence_read_drops_total"
 let metric_persistence_utf8_repair = "masc_persistence_utf8_repair_total"
 let metric_discovery_history_failures = "masc_discovery_history_failures_total"
 
-(* #10097: codex_cli provider cannot carry keeper-bound runtime MCP
-   tools that need request-scoped auth headers.  Every time
+(* #10097: a provider cannot carry keeper-bound runtime MCP tools that
+   need request-scoped auth headers.  Every time
    oas_worker_exec_transport strips such a tool, this counter
-   increments with the tool name so dashboards can track WHICH
-   tools are being omitted and at WHAT rate.  Paired with a
-   once-per-session WARN log ([fingerprint]-deduplicated) so the
-   operator sees the structural fact exactly once while the
-   counter carries the frequency signal. *)
-let metric_codex_cli_mcp_tool_omission = "masc_codex_cli_mcp_tool_omission_total"
+   increments with the [provider] and [tool] labels so dashboards can
+   track WHICH provider strips WHICH tools and at WHAT rate.  Paired
+   with a once-per-session WARN log ([fingerprint]-deduplicated) so
+   the operator sees the structural fact exactly once while the
+   counter carries the frequency signal.
+
+   RFC-0058 §2.4 / Phase 5.4 big-bang rename: the old
+   `masc_codex_cli_mcp_tool_omission_total` time series is RETIRED.
+   Operators must point Grafana queries to the new
+   `masc_provider_mcp_tool_omission_total{provider="codex_cli"}`
+   series.  No dual-emit alias — the rename is intentional to keep
+   provider identity out of the metric name. *)
+let metric_provider_mcp_tool_omission = "masc_provider_mcp_tool_omission_total"
 
 (* #9520: durable coverage-gap records must also have an alertable
    Prometheus surface.  The labels deliberately avoid raw paths and

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -309,11 +309,14 @@ val metric_persistence_utf8_repair : string
 
 val metric_discovery_history_failures : string
 
-(** #10097: per-tool counter for codex_cli keeper-bound runtime
-    MCP omissions.  Paired with a once-per-fingerprint WARN log
-    so logs carry structural facts and Prometheus carries
-    frequency. *)
-val metric_codex_cli_mcp_tool_omission : string
+(** #10097: per-(provider, tool) counter for keeper-bound runtime MCP
+    omissions.  Paired with a once-per-fingerprint WARN log so logs
+    carry structural facts and Prometheus carries frequency.
+
+    RFC-0058 §2.4 / Phase 5.4: renamed from
+    `masc_codex_cli_mcp_tool_omission_total` to keep provider identity
+    out of the metric name; `provider` is now a label. *)
+val metric_provider_mcp_tool_omission : string
 
 (** #9520: total telemetry coverage gaps recorded. Labels:
     [source, producer, dashboard_surface, stale_reason]. This is the

--- a/test/test_codex_cli_omission_dedup_10097.ml
+++ b/test/test_codex_cli_omission_dedup_10097.ml
@@ -8,9 +8,11 @@
      - WARN logged once per distinct fingerprint (sorted,
        comma-joined tool list) — operator sees the structural
        fact the first time a given set is stripped;
-     - Prometheus counter [masc_codex_cli_mcp_tool_omission_total
-       {tool}] increments on EVERY call so dashboards retain the
-       frequency signal.
+     - Prometheus counter
+       [masc_provider_mcp_tool_omission_total{provider, tool}]
+       increments on EVERY call so dashboards retain the frequency
+       signal (RFC-0058 §2.4: provider identity is a label, not part
+       of the metric name).
 
    The test pins:
 
@@ -40,10 +42,13 @@ let () =
 module T = Masc_mcp.Cascade_transport
 module Prom = Masc_mcp.Prometheus
 
-let metric = Prom.metric_codex_cli_mcp_tool_omission
+let metric = Prom.metric_provider_mcp_tool_omission
 
 let counter_for ~tool =
-  Prom.metric_value_or_zero metric ~labels:[ ("tool", tool) ] ()
+  Prom.metric_value_or_zero
+    metric
+    ~labels:[ ("provider", "codex_cli"); ("tool", tool) ]
+    ()
 
 (* Counter must increment on every invocation, even when the
    fingerprint has been seen before (the WARN dedup is about log


### PR DESCRIPTION
## Summary — metric big-bang rename

Codex-specific Prometheus counter renamed to a provider-agnostic name with a `provider` label. Completes RFC-0058 §2.4's "provider identity is a label, not part of the metric name" invariant.

| | Before | After |
|---|---|---|
| Metric | `masc_codex_cli_mcp_tool_omission_total{tool}` | `masc_provider_mcp_tool_omission_total{provider, tool}` |
| Constant | `Prometheus.metric_codex_cli_mcp_tool_omission` | `Prometheus.metric_provider_mcp_tool_omission` |
| Call site | `~labels:[ "tool", tool ]` | `~labels:[ "provider", "codex_cli"; "tool", tool ]` |

**No dual-emit alias** — intentional. Dual emission would re-establish the vendor-named precedent we're erasing and force a second rename PR later (workaround rejection bar #2 — string classifier reinforcement).

## ⚠️ Operator action required before merge

This PR breaks external time-series continuity. The following must be coordinated:

1. **Grafana dashboards** referencing `masc_codex_cli_mcp_tool_omission_total` must be rewritten to query `masc_provider_mcp_tool_omission_total{provider="codex_cli"}` with a label filter.
2. **Alert rules** over the old metric must be rewritten.
3. **Slack `#release-deployment`** notice 24h before merge (per plan §risk b).
4. **Dashboard cutover ticket** linked from this PR before flipping to Ready.

## Migration query examples

```promql
# Before
sum by (tool) (rate(masc_codex_cli_mcp_tool_omission_total[5m]))

# After
sum by (tool) (rate(masc_provider_mcp_tool_omission_total{provider="codex_cli"}[5m]))

# New capability: aggregate across providers (was impossible before)
sum by (provider, tool) (rate(masc_provider_mcp_tool_omission_total[5m]))
```

## Files

- `lib/prometheus.ml` + `.mli` — constant rename + docstring update with rename rationale
- `lib/cascade/cascade_transport.ml` — counter call site adds `("provider", "codex_cli")` label; WARN log message references new metric syntax
- `test/test_codex_cli_omission_dedup_10097.ml` — module comment, constant ref, `counter_for` lookup all include the provider label

Net: +36 / -21.

## Verification

- [x] `dune build --root . @check` clean
- [x] `test_codex_cli_omission_dedup_10097.exe` — 5/5 pass (counter increments / per-tool isolation / fingerprint dedup / empty no-op all unchanged behaviorally; only the label set widens)
- [ ] Grafana dashboard PR linked
- [ ] Slack #release-deployment notice posted 24h pre-merge

## Related

- A.3a (#14631), A.3b (#14636), PR-E (#14640), PR-W (#14642), A.3c (#14646) — capability + registry refactor; this PR closes the metric naming half of §2.4

🤖 Generated with [Claude Code](https://claude.com/claude-code)