### PR TITLE
refactor(keeper): typed turn_lane — string → closed sum type [stacked on #14647]

### DIFF
--- a/lib/keeper/keeper_agent_run.mli
+++ b/lib/keeper/keeper_agent_run.mli
@@ -49,8 +49,10 @@ type ctx_composition_metrics =
 type tool_requirement = Keeper_agent_tool_surface.tool_requirement
 type tool_surface_class = Keeper_agent_tool_surface.tool_surface_class
 
+type turn_lane = Keeper_agent_tool_surface.turn_lane
+
 type tool_surface_metrics =
-  { turn_lane : string
+  { turn_lane : turn_lane
   ; tool_surface_class : tool_surface_class
   ; tool_requirement : tool_requirement
   ; visible_tool_count : int

--- a/lib/keeper/keeper_agent_tool_surface.ml
+++ b/lib/keeper/keeper_agent_tool_surface.ml
@@ -37,10 +37,15 @@ let tool_requirement_to_yojson = function
   | Optional -> `String "optional"
   | No_tools -> `String "none"
 
-(* Closed sum type for turn_lane.  Pins the alphabet emitted by
-   keeper_run_tools.ml:963-973.  No [@@deriving tla] because the
-   module-level all_symbols binding is reserved for tool_surface_class
-   (a future RFC spec extension can add TurnLaneSet and lift this). *)
+(* Closed sum type for turn_lane.  Two producers emit values:
+   - keeper_run_tools.ml:963-973 emits the five per-turn lanes
+     (text_only, tool_required, tool_optional, tool_disabled, retry).
+   - keeper_turn_helpers.pre_dispatch_tool_surface emits the
+     [Lane_pre_dispatch] placeholder before the per-turn lane logic
+     runs.
+   No [@@deriving tla] because the module-level all_symbols binding
+   is reserved for tool_surface_class (a future RFC spec extension
+   can add TurnLaneSet and lift this). *)
 type turn_lane =
   | Lane_pre_dispatch
   | Lane_text_only

--- a/lib/keeper/keeper_agent_tool_surface.ml
+++ b/lib/keeper/keeper_agent_tool_surface.ml
@@ -37,6 +37,37 @@ let tool_requirement_to_yojson = function
   | Optional -> `String "optional"
   | No_tools -> `String "none"
 
+(* Closed sum type for turn_lane.  Pins the alphabet emitted by
+   keeper_run_tools.ml:963-973.  No [@@deriving tla] because the
+   module-level all_symbols binding is reserved for tool_surface_class
+   (a future RFC spec extension can add TurnLaneSet and lift this). *)
+type turn_lane =
+  | Lane_pre_dispatch
+  | Lane_text_only
+  | Lane_tool_required
+  | Lane_tool_optional
+  | Lane_tool_disabled
+  | Lane_retry
+
+let turn_lane_to_string = function
+  | Lane_pre_dispatch -> "pre_dispatch"
+  | Lane_text_only -> "text_only"
+  | Lane_tool_required -> "tool_required"
+  | Lane_tool_optional -> "tool_optional"
+  | Lane_tool_disabled -> "tool_disabled"
+  | Lane_retry -> "retry"
+
+let turn_lane_of_string = function
+  | "pre_dispatch" -> Some Lane_pre_dispatch
+  | "text_only" -> Some Lane_text_only
+  | "tool_required" -> Some Lane_tool_required
+  | "tool_optional" -> Some Lane_tool_optional
+  | "tool_disabled" -> Some Lane_tool_disabled
+  | "retry" -> Some Lane_retry
+  | _ -> None
+
+let turn_lane_to_yojson lane = `String (turn_lane_to_string lane)
+
 (* Closed sum type for tool_surface_class.  Mirrors RFC-0065 §3.2.2
    KeeperToolSurface SurfaceClassSet so the correspondence harness can
    drop the hand-pinned label list.  [@tla.symbol "…"] fixes the wire
@@ -65,7 +96,7 @@ let tool_surface_class_to_yojson cls =
   `String (tool_surface_class_to_string cls)
 
 type tool_surface_metrics =
-  { turn_lane : string
+  { turn_lane : turn_lane
   ; tool_surface_class : tool_surface_class
   ; tool_requirement : tool_requirement
   ; visible_tool_count : int
@@ -99,7 +130,7 @@ type computed_tool_surface =
   ; tool_surface_fallback_used : bool
   ; required_tool_names : string list
   ; missing_required_tool_names : string list
-  ; lane : string
+  ; lane : turn_lane
   ; query_text : string
   }
 

--- a/lib/keeper/keeper_agent_tool_surface.mli
+++ b/lib/keeper/keeper_agent_tool_surface.mli
@@ -23,6 +23,29 @@ val tool_requirement_to_string : tool_requirement -> string
 val tool_requirement_of_string : string -> tool_requirement option
 val tool_requirement_to_yojson : tool_requirement -> Yojson.Safe.t
 
+(** Per-turn lane classification.  Closed sum type; the OCaml side
+    pins the alphabet emitted at keeper_run_tools.ml:963-973
+    ({"text_only", "tool_required", "tool_optional", "tool_disabled",
+    "retry"}).  Plain to_string/of_string (no [@@deriving tla] — that
+    derives module-level all_symbols which is already bound to
+    [tool_surface_class] below).  A future RFC-0065 spec extension
+    can add a TurnLaneSet catalog and lift this to deriving. *)
+type turn_lane =
+  | Lane_pre_dispatch
+      (** Pre-turn placeholder before [compute_tool_surface] runs.
+          Emitted only by [keeper_turn_helpers.pre_dispatch_tool_surface];
+          never produced by the per-turn lane logic at
+          keeper_run_tools.ml:963-973. *)
+  | Lane_text_only
+  | Lane_tool_required
+  | Lane_tool_optional
+  | Lane_tool_disabled
+  | Lane_retry
+
+val turn_lane_to_string : turn_lane -> string
+val turn_lane_of_string : string -> turn_lane option
+val turn_lane_to_yojson : turn_lane -> Yojson.Safe.t
+
 (** Classification of the per-turn tool surface.  Closed sum type; the
     OCaml side mirrors the RFC-0065 §3.2.2 KeeperToolSurface
     SurfaceClassSet ({"none", "public_only", "mixed"}).
@@ -41,7 +64,7 @@ val tool_surface_class_to_yojson : tool_surface_class -> Yojson.Safe.t
 
 (** Diagnostic surface metrics emitted into trajectory entries. *)
 type tool_surface_metrics =
-  { turn_lane : string
+  { turn_lane : turn_lane
   ; tool_surface_class : tool_surface_class
   ; tool_requirement : tool_requirement
   ; visible_tool_count : int
@@ -77,7 +100,7 @@ type computed_tool_surface =
   ; tool_surface_fallback_used : bool
   ; required_tool_names : string list
   ; missing_required_tool_names : string list
-  ; lane : string
+  ; lane : turn_lane
   ; query_text : string
   }
 

--- a/lib/keeper/keeper_execution_receipt.ml
+++ b/lib/keeper/keeper_execution_receipt.ml
@@ -68,7 +68,7 @@ let assert_receipt_authoritative ~outcome ~turn_state =
 type tool_requirement = Keeper_agent_tool_surface.tool_requirement
 
 type tool_surface =
-  { turn_lane : string
+  { turn_lane : Keeper_agent_tool_surface.turn_lane
   ; tool_surface_class : Keeper_agent_tool_surface.tool_surface_class
   ; tool_requirement : Keeper_agent_tool_surface.tool_requirement
   ; visible_tool_count : int
@@ -490,7 +490,9 @@ let to_json (receipt : t) =
       ( "tool_surface",
         `Assoc
           [
-            ("turn_lane", `String receipt.tool_surface.turn_lane);
+            ( "turn_lane",
+              Keeper_agent_tool_surface.turn_lane_to_yojson
+                receipt.tool_surface.turn_lane );
             ( "tool_surface_class",
               Keeper_agent_tool_surface.tool_surface_class_to_yojson
                 receipt.tool_surface.tool_surface_class );

--- a/lib/keeper/keeper_execution_receipt.mli
+++ b/lib/keeper/keeper_execution_receipt.mli
@@ -84,7 +84,7 @@ val assert_receipt_authoritative :
 type tool_requirement = Keeper_agent_tool_surface.tool_requirement
 
 type tool_surface =
-  { turn_lane : string
+  { turn_lane : Keeper_agent_tool_surface.turn_lane
   ; tool_surface_class : Keeper_agent_tool_surface.tool_surface_class
   ; tool_requirement : tool_requirement
   ; visible_tool_count : int

--- a/lib/keeper/keeper_run_tools.ml
+++ b/lib/keeper/keeper_run_tools.ml
@@ -199,7 +199,7 @@ let prepare_agent_setup
          | Some r -> !r
          | None -> Agent_sdk.Tool_op.Keep_all)
     ; tool_surface =
-        { turn_lane = "text_only"
+        { turn_lane = Keeper_agent_tool_surface.Lane_text_only
         ; tool_surface_class = Keeper_agent_tool_surface.Surface_none
         ; tool_requirement = No_tools
         ; visible_tool_count = 0
@@ -960,17 +960,17 @@ let prepare_agent_setup
       then Required
       else Optional
     in
-    let lane =
+    let lane : Keeper_agent_tool_surface.turn_lane =
       if is_retry
-      then "retry"
+      then Lane_retry
       else (
         match tool_requirement with
-        | Required -> "tool_required"
-        | Optional -> "tool_optional"
+        | Required -> Lane_tool_required
+        | Optional -> Lane_tool_optional
         | No_tools ->
           (match current_tool_choice with
-           | Some Agent_sdk.Types.None_ -> "tool_disabled"
-           | _ -> "text_only"))
+           | Some Agent_sdk.Types.None_ -> Lane_tool_disabled
+           | _ -> Lane_text_only))
     in
     { all_allowed
     ; absolute_turn = turn
@@ -1042,7 +1042,9 @@ let prepare_agent_setup
         Prometheus.metric_empty_tool_universe_observed
         ~labels:
           [ "keeper_name", meta.name
-          ; "turn_lane", initial_tool_surface.lane
+          ; ( "turn_lane"
+            , Keeper_agent_tool_surface.turn_lane_to_string
+                initial_tool_surface.lane )
           ; ( "fallback_used"
             , string_of_bool initial_tool_surface.tool_surface_fallback_used )
           ]
@@ -1052,7 +1054,9 @@ let prepare_agent_setup
            (sdk_error_of_keeper_internal_error
               (Keeper_tool_surface_empty
                  { keeper_name = meta.name
-                 ; turn_lane = initial_tool_surface.lane
+                 ; turn_lane =
+                     Keeper_agent_tool_surface.turn_lane_to_string
+                       initial_tool_surface.lane
                  ; affordances = turn_affordances
                  ; fallback_used = initial_tool_surface.tool_surface_fallback_used
                  }));
@@ -1499,7 +1503,8 @@ let prepare_agent_setup
                 Keeper_tool_call_log.set_turn_context
                   ~keeper_name:meta.name
                   ~agent_name:meta.agent_name
-                  ~lane
+                  ~lane:
+                    (Keeper_agent_tool_surface.turn_lane_to_string lane)
                   ?tool_choice:
                     (Option.map
                        (fun choice ->
@@ -1583,7 +1588,8 @@ let prepare_agent_setup
                      ; "discovered_count", `Int computed_surface.discovered_count
                      ; "llm_selected_count", `Int computed_surface.llm_selected_count
                      ; "final_visible", `Int (List.length all_allowed)
-                     ; "turn_lane", `String lane
+                     ; ( "turn_lane"
+                       , Keeper_agent_tool_surface.turn_lane_to_yojson lane )
                      ; ( "tool_surface_class"
                        , Keeper_agent_tool_surface.tool_surface_class_to_yojson
                            computed_surface.tool_surface_class )

--- a/lib/keeper/keeper_turn_helpers.ml
+++ b/lib/keeper/keeper_turn_helpers.ml
@@ -212,7 +212,7 @@ let post_turn_complete_task ~(cycle_completed : bool ref) = ignore cycle_complet
 ;;
 
 let pre_dispatch_tool_surface : Keeper_execution_receipt.tool_surface =
-  { turn_lane = "pre_dispatch"
+  { turn_lane = Keeper_agent_tool_surface.Lane_pre_dispatch
   ; tool_surface_class = Keeper_agent_tool_surface.Surface_none
   ; tool_requirement = No_tools
   ; visible_tool_count = 0

--- a/lib/keeper/keeper_unified_metrics.ml
+++ b/lib/keeper/keeper_unified_metrics.ml
@@ -896,7 +896,9 @@ let append_decision_record
               in
               let tool_surface_fields =
                 [
-                  ("turn_lane", `String r.tool_surface.turn_lane);
+                  ( "turn_lane"
+                  , Keeper_agent_tool_surface.turn_lane_to_yojson
+                      r.tool_surface.turn_lane );
                   ( "tool_surface_class"
                   , Keeper_agent_tool_surface.tool_surface_class_to_yojson
                       r.tool_surface.tool_surface_class );

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -1037,7 +1037,10 @@ let test_keeper_zombie_field_contracts () =
       tool_contract_result = "satisfied";
       tool_surface =
         {
-          turn_lane = "unified";
+          (* WORKAROUND: previously "unified" — invalid string never
+             emitted by producer.  Typed enum forces valid value.
+             Root: closed sum type rejects ad-hoc fixture strings. *)
+          turn_lane = Masc_mcp.Keeper_agent_tool_surface.Lane_tool_required;
           (* WORKAROUND: previously "post_dispatch" — invalid string never
              emitted by producer.  Typed enum forces a real value.
              Root: closed sum type disallows ad-hoc fixture strings. *)

--- a/test/test_dashboard_execution.ml
+++ b/test/test_dashboard_execution.ml
@@ -487,7 +487,7 @@ let append_execution_receipt ?(outcome = "ok")
       tool_contract_result;
       tool_surface =
         {
-          turn_lane = "tool";
+          turn_lane = Masc_mcp.Keeper_agent_tool_surface.Lane_tool_required;
           tool_surface_class = Masc_mcp.Keeper_agent_tool_surface.Surface_mixed;
           tool_requirement = Masc_mcp.Keeper_agent_tool_surface.Required;
           visible_tool_count = 2;

--- a/test/test_dashboard_goals.ml
+++ b/test/test_dashboard_goals.ml
@@ -133,7 +133,7 @@ let append_keeper_receipt ?(outcome = "ok")
       tool_contract_result;
       tool_surface =
         {
-          turn_lane = "tool";
+          turn_lane = Keeper_agent_tool_surface.Lane_tool_required;
           tool_surface_class = Keeper_agent_tool_surface.Surface_mixed;
           tool_requirement;
           visible_tool_count = 1;

--- a/test/test_dashboard_keeper_routes.ml
+++ b/test/test_dashboard_keeper_routes.ml
@@ -623,7 +623,7 @@ let append_execution_receipt ?(tool_contract_result = "satisfied")
       tool_contract_result;
       tool_surface =
         {
-          turn_lane = "tool";
+          turn_lane = Masc_mcp.Keeper_agent_tool_surface.Lane_tool_required;
           tool_surface_class = Masc_mcp.Keeper_agent_tool_surface.Surface_mixed;
           tool_requirement = Masc_mcp.Keeper_agent_tool_surface.Required;
           visible_tool_count = 2;

--- a/test/test_keeper_pause_broadcast.ml
+++ b/test/test_keeper_pause_broadcast.ml
@@ -16,7 +16,10 @@ let mk_tool_surface ?(tool_requirement = Masc_mcp.Keeper_agent_tool_surface.Requ
     ?(required_tools = []) ?(missing_required_tools = []) () :
     R.tool_surface =
   {
-    turn_lane = "unified";
+    (* WORKAROUND: previously "unified" — invalid string never emitted
+       by producer.  Typed enum now forces a valid value.
+       Root: closed sum type rejects ad-hoc fixture strings. *)
+    turn_lane = Masc_mcp.Keeper_agent_tool_surface.Lane_tool_required;
     (* WORKAROUND: previously "post_dispatch" — a string the producer
        never emits.  Typed enum forces a real value; Surface_mixed
        matches the prior test intent of a tool-using turn.

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -2422,7 +2422,7 @@ let sample_ctx_composition ?(system_prompt = "You are a keeper.")
 
 let sample_tool_surface_metrics () : Masc_mcp.Keeper_agent_run.tool_surface_metrics =
   {
-    turn_lane = "tool_optional";
+    turn_lane = Masc_mcp.Keeper_agent_tool_surface.Lane_tool_optional;
     tool_surface_class = Masc_mcp.Keeper_agent_tool_surface.Surface_mixed;
     tool_requirement = Masc_mcp.Keeper_agent_tool_surface.Optional;
     visible_tool_count = 0;


### PR DESCRIPTION
## Summary

**Stacked PR**: base = `feat/tool-surface-class-typed` (#14647). Land
#14647 first.

Same Track A pattern applied to the per-turn lane classification at
`keeper_run_tools.ml:963-973`. Replaces `turn_lane : string` with a
closed sum type in `Keeper_agent_tool_surface`. Strings remain only
at JSON / Prometheus / error-record boundaries via
`turn_lane_to_string` / `_to_yojson`.

## What this PR adds

### `lib/keeper/keeper_agent_tool_surface.{ml,mli}`

\`\`\`ocaml
type turn_lane =
  | Lane_pre_dispatch    (* pre-turn placeholder *)
  | Lane_text_only
  | Lane_tool_required
  | Lane_tool_optional
  | Lane_tool_disabled
  | Lane_retry

val turn_lane_to_string  : t -> string
val turn_lane_of_string  : string -> t option
val turn_lane_to_yojson  : t -> Yojson.Safe.t
\`\`\`

No `[@@deriving tla]` on `turn_lane` — module-level `all_symbols` is
reserved for `tool_surface_class` from the base PR. Lifted later
when a TurnLaneSet TLA+ catalog is added.

### Migration

- `tool_surface_metrics.turn_lane` (in `keeper_agent_tool_surface`,
  `keeper_agent_run.mli`): `string` → `turn_lane`
- `computed_tool_surface.lane`: `string` → `turn_lane`
- `keeper_execution_receipt.tool_surface.turn_lane`: `string` → typed
- Producer at `keeper_run_tools.ml:963-973` emits typed values
- String boundaries: `Keeper_agent_error.Keeper_tool_surface_empty`
  (string-typed error record), `Keeper_tool_call_log.set_turn_context`
  (string label), Prometheus labels, trajectory JSON — all convert
  via `turn_lane_to_string` / `_to_yojson`.

### `Lane_pre_dispatch` rationale

`keeper_turn_helpers.pre_dispatch_tool_surface` previously emitted
the string `\"pre_dispatch\"` as a placeholder before the per-turn
lane logic runs. This is a 6th meaningful value that the standard
producer (`keeper_run_tools.ml`) never emits. Added as a dedicated
variant to keep the sum type closed without forcing an `option`
wrapper everywhere.

## Verification

\`\`\`
$ dune build --root . @check
PASS (14 files compiled cleanly)

$ _build/default/test/test_keeper_ocaml_tla_correspondence.exe
12 tests run, Test Successful (no regression from #14647)

$ _build/default/test/test_keeper_post_turn_wirein_order.exe
2 tests run, Test Successful
\`\`\`

## Real drift bugs caught by the typed enum (5 fixtures)

Five test fixtures used invalid strings the producer never emits:

| File:line | Old (invalid) | New |
|---|---|---|
| `test/test_dashboard_goals.ml:136` | `\"tool\"` | `Lane_tool_required` |
| `test/test_keeper_pause_broadcast.ml:19` | `\"unified\"` | `Lane_tool_required` |
| `test/test_dashboard_keeper_routes.ml:626` | `\"tool\"` | `Lane_tool_required` |
| `test/test_ci_hardening_source.ml:1040` | `\"unified\"` | `Lane_tool_required` |
| `test/test_dashboard_execution.ml:490` | `\"tool\"` | `Lane_tool_required` |

The producer at `keeper_run_tools.ml:963-973` only emits the 5 lane
values (`{text_only, tool_required, tool_optional, tool_disabled, retry}`)
plus `Lane_pre_dispatch`. Under the old `string` field the fixtures
compiled and exercised a **meaningless** path. Closed sum type
rejected all five at compile time; reassigned with WORKAROUND comments
documenting the prior drift.

This is the **third batch of invalid-string fixtures** the typed-enum
pattern has caught:
- #14647 caught 2 `\"post_dispatch\"` fixtures (tool_surface_class)
- This PR caught 5 `\"tool\"` / `\"unified\"` fixtures (turn_lane)

Anti-pattern #2 (string classifier) elimination is paying off.

## G3 acceptance gate (provider/model opacity)

\`\`\`
$ git diff feat/tool-surface-class-typed -- <changed files> \\
    | grep '^+' \\
    | rg -ic 'anthropic|openai|claude|gpt|gemini|sonnet|opus|haiku'
0
\`\`\`

## Stack info

- Base: `feat/tool-surface-class-typed` (PR #14647 — Draft)
- This PR: `feat/turn-lane-typed`
- Land order: #14647 first, then this one.

GitHub will rebase this PR's diff onto main automatically once #14647
merges; no rebase needed.

## Test plan

- [x] `dune build --root . @check` — PASS
- [x] correspondence harness — 12 tests, no regression
- [x] wirein order test — 2 tests, no regression
- [x] G3 opacity grep on added lines — 0
- [x] 5 invalid fixture strings caught at compile time

🤖 Generated with [Claude Code](https://claude.com/claude-code)