### PR TITLE
refactor(keeper): typed tool_selection_mode — string → closed sum type [stacked on #14649]

### DIFF
--- a/lib/keeper/keeper_agent_tool_surface.ml
+++ b/lib/keeper/keeper_agent_tool_surface.ml
@@ -73,6 +73,27 @@ let turn_lane_of_string = function
 
 let turn_lane_to_yojson lane = `String (turn_lane_to_string lane)
 
+(* Closed sum type for tool-surface selection mode.  See .mli for
+   rationale (avoids name collision with Keeper_skill_routing and
+   Keeper_alerting, each of which owns its own selection_mode). *)
+type tool_selection_mode =
+  | Selection_deterministic_plus_llm_hint
+  | Selection_core_plus_prefilter_plus_discovered
+
+let tool_selection_mode_to_string = function
+  | Selection_deterministic_plus_llm_hint -> "deterministic_plus_llm_hint"
+  | Selection_core_plus_prefilter_plus_discovered ->
+    "core_plus_prefilter_plus_discovered"
+
+let tool_selection_mode_of_string = function
+  | "deterministic_plus_llm_hint" -> Some Selection_deterministic_plus_llm_hint
+  | "core_plus_prefilter_plus_discovered" ->
+    Some Selection_core_plus_prefilter_plus_discovered
+  | _ -> None
+
+let tool_selection_mode_to_yojson m =
+  `String (tool_selection_mode_to_string m)
+
 (* Closed sum type for tool_surface_class.  Mirrors RFC-0065 §3.2.2
    KeeperToolSurface SurfaceClassSet so the correspondence harness can
    drop the hand-pinned label list.  [@tla.symbol "…"] fixes the wire
@@ -126,7 +147,7 @@ type computed_tool_surface =
   ; deterministic_prefilter_count : int
   ; discovered_count : int
   ; llm_selected_count : int
-  ; selection_mode : string
+  ; selection_mode : tool_selection_mode
   ; is_last_turn : bool
   ; is_warning_zone : bool
   ; tool_surface_class : tool_surface_class

--- a/lib/keeper/keeper_agent_tool_surface.mli
+++ b/lib/keeper/keeper_agent_tool_surface.mli
@@ -46,6 +46,28 @@ val turn_lane_to_string : turn_lane -> string
 val turn_lane_of_string : string -> turn_lane option
 val turn_lane_to_yojson : turn_lane -> Yojson.Safe.t
 
+(** Tool-surface selection mode.  Closed sum type pinning the two
+    possible outputs of [keeper_run_tools.ml::compute_tool_surface]'s
+    [selection_mode] field:
+
+    - [Selection_deterministic_plus_llm_hint] when the keeper has
+      [llm_rerank_enabled = true] and the per-turn TopK_llm path
+      decorated the deterministic selection with an LLM-reranked hint.
+    - [Selection_core_plus_prefilter_plus_discovered] when the keeper
+      relies on the deterministic prefilter + discovered-tool union
+      only (no LLM rerank for this turn).
+
+    Disambiguated as [tool_selection_mode] (the [Keeper_skill_routing]
+    and [Keeper_alerting] modules each own their own [selection_mode]
+    sum type unrelated to tool-surface composition). *)
+type tool_selection_mode =
+  | Selection_deterministic_plus_llm_hint
+  | Selection_core_plus_prefilter_plus_discovered
+
+val tool_selection_mode_to_string : tool_selection_mode -> string
+val tool_selection_mode_of_string : string -> tool_selection_mode option
+val tool_selection_mode_to_yojson : tool_selection_mode -> Yojson.Safe.t
+
 (** Classification of the per-turn tool surface.  Closed sum type; the
     OCaml side mirrors the RFC-0065 §3.2.2 KeeperToolSurface
     SurfaceClassSet ({"none", "public_only", "mixed"}).
@@ -91,7 +113,7 @@ type computed_tool_surface =
   ; deterministic_prefilter_count : int
   ; discovered_count : int
   ; llm_selected_count : int
-  ; selection_mode : string
+  ; selection_mode : tool_selection_mode
   ; is_last_turn : bool
   ; is_warning_zone : bool
   ; tool_surface_class : tool_surface_class

--- a/lib/keeper/keeper_run_tools.ml
+++ b/lib/keeper/keeper_run_tools.ml
@@ -814,10 +814,10 @@ let prepare_agent_setup
       Keeper_types.dedupe_keep_order
         (merged @ visible_required_tool_names @ visible_affordance_tool_names)
     in
-    let selection_mode =
+    let selection_mode : Keeper_agent_tool_surface.tool_selection_mode =
       if llm_rerank_enabled
-      then "deterministic_plus_llm_hint"
-      else "core_plus_prefilter_plus_discovered"
+      then Selection_deterministic_plus_llm_hint
+      else Selection_core_plus_prefilter_plus_discovered
     in
     let deterministic_floor_set =
       Keeper_types.dedupe_keep_order
@@ -1360,7 +1360,8 @@ let prepare_agent_setup
                     (Keeper_config.keeper_llm_rerank_enabled ())
                     (List.length computed_surface.all_allowed)
                     (String.length computed_surface.query_text)
-                    computed_surface.selection_mode;
+                    (Keeper_agent_tool_surface.tool_selection_mode_to_string
+                       computed_surface.selection_mode);
                 let append_ctx ctx text =
                   Some
                     (match ctx with
@@ -1581,7 +1582,9 @@ let prepare_agent_setup
                        , `Int computed_surface.checkpoint_start_turn )
                      ; "per_call_turn", `Int computed_surface.per_call_turn
                      ; "per_call_max_turns", `Int computed_surface.per_call_max_turns
-                     ; "selection_mode", `String computed_surface.selection_mode
+                     ; ( "selection_mode"
+                       , Keeper_agent_tool_surface.tool_selection_mode_to_yojson
+                           computed_surface.selection_mode )
                      ; "core_count", `Int computed_surface.core_count
                      ; ( "deterministic_prefilter_count"
                        , `Int computed_surface.deterministic_prefilter_count )


### PR DESCRIPTION
## Summary

**Stacked PR**: base = `feat/turn-lane-typed` (#14649). Land order:
**#14647 → #14649 → this PR**.

Third typed-conversion in the RFC-0065 follow-up thread. Replaces
`selection_mode : string` (tool-surface composition mode) with a closed
sum type in `Keeper_agent_tool_surface`. Smaller scope than the previous
two PRs (3 files) because the field is internal-only.

## What this PR adds

### `lib/keeper/keeper_agent_tool_surface.{ml,mli}`

\`\`\`ocaml
type tool_selection_mode =
  | Selection_deterministic_plus_llm_hint
  | Selection_core_plus_prefilter_plus_discovered

val tool_selection_mode_to_string  : t -> string
val tool_selection_mode_of_string  : string -> t option
val tool_selection_mode_to_yojson  : t -> Yojson.Safe.t
\`\`\`

Plus migration of `computed_tool_surface.selection_mode` from `string`
to `tool_selection_mode`.

### Naming disambiguation

**Three other modules already own a `selection_mode` sum type, none related**:

| Module | Type |
|---|---|
| `Keeper_skill_routing` | `Heuristic` / `Model_selected` / `Model_rejected` |
| `Keeper_alerting` | (alerting fan-out selection) |
| `Keeper_agent_tool_surface` (this PR) | tool-surface composition |

To prevent confusion and avoid module-prefix gymnastics at call sites,
the type defined here is named `tool_selection_mode` (not bare
`selection_mode`). The record field on `computed_tool_surface` remains
named `selection_mode` — the disambiguation is in the type, not the
field.

### `lib/keeper/keeper_run_tools.ml`

Producer at lines 817-821 emits typed values:

\`\`\`ocaml
let selection_mode : Keeper_agent_tool_surface.tool_selection_mode =
  if llm_rerank_enabled
  then Selection_deterministic_plus_llm_hint
  else Selection_core_plus_prefilter_plus_discovered
in
\`\`\`

Two downstream boundaries (trajectory JSON, dashboard `Log.info` call)
convert via `tool_selection_mode_to_yojson` / `_to_string`.

## Verification

\`\`\`
$ dune build --root . @check
PASS (3 files compiled cleanly)

$ _build/default/test/test_keeper_ocaml_tla_correspondence.exe
12 tests run, Test Successful (no regression from #14647 / #14649)

$ _build/default/test/test_keeper_post_turn_wirein_order.exe
2 tests run, Test Successful
\`\`\`

## No drift caught this round

Unlike #14647 (2 invalid `\"post_dispatch\"` fixtures) and #14649
(5 invalid `\"tool\"` / `\"unified\"` fixtures), no test fixture
mis-used `selection_mode`. Either the field was never set in
fixtures, or fixtures used the valid producer output. Suggests
this field has tighter discipline than the previous two — or just
narrower test coverage.

## G3 acceptance gate (provider/model opacity)

\`\`\`
$ git diff feat/turn-lane-typed -- <changed files> | grep '^+' \\
    | rg -ic 'anthropic|openai|claude|gpt|gemini|sonnet|opus|haiku'
0
\`\`\`

## Stack info

| PR | Branch | Status |
|---|---|---|
| #14647 | `feat/tool-surface-class-typed` | Draft, base = main |
| #14649 | `feat/turn-lane-typed` | Draft, base = `feat/tool-surface-class-typed` |
| **this** | `feat/tool-selection-mode-typed` | **Draft, base = `feat/turn-lane-typed`** |

Land order: #14647 → #14649 → this. GitHub auto-rebases each as its
base merges.

## Test plan

- [x] `dune build --root . @check` — PASS
- [x] correspondence harness — 12 tests, no regression
- [x] wirein order test — 2 tests, no regression
- [x] G3 opacity grep on added lines — 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)