### PR TITLE
refactor(keeper): typed sandbox_kind — string → Keeper_types.sandbox_profile

### DIFF
--- a/lib/keeper/keeper_agent_tool_surface.ml
+++ b/lib/keeper/keeper_agent_tool_surface.ml
@@ -94,6 +94,7 @@ let tool_selection_mode_of_string = function
 let tool_selection_mode_to_yojson m =
   `String (tool_selection_mode_to_string m)
 
+
 (* Closed sum type for tool_surface_class.  Mirrors RFC-0065 §3.2.2
    KeeperToolSurface SurfaceClassSet so the correspondence harness can
    drop the hand-pinned label list.  [@tla.symbol "…"] fixes the wire

--- a/lib/keeper/keeper_agent_tool_surface.mli
+++ b/lib/keeper/keeper_agent_tool_surface.mli
@@ -68,6 +68,7 @@ val tool_selection_mode_to_string : tool_selection_mode -> string
 val tool_selection_mode_of_string : string -> tool_selection_mode option
 val tool_selection_mode_to_yojson : tool_selection_mode -> Yojson.Safe.t
 
+
 (** Classification of the per-turn tool surface.  Closed sum type; the
     OCaml side mirrors the RFC-0065 §3.2.2 KeeperToolSurface
     SurfaceClassSet ({"none", "public_only", "mixed"}).

--- a/lib/keeper/keeper_execution_receipt.ml
+++ b/lib/keeper/keeper_execution_receipt.ml
@@ -111,7 +111,7 @@ type t =
   ; tools_used : string list
   ; tool_contract_result : string
   ; tool_surface : tool_surface
-  ; sandbox_kind : string
+  ; sandbox_kind : Keeper_types.sandbox_profile
   ; sandbox_root : string option
   ; network_mode : string
   ; approval_profile : string option
@@ -143,10 +143,9 @@ let stop_reason_to_string = function
      | None ->
        Printf.sprintf "mutation_boundary:%d" turns_used)
 
-let sandbox_kind_of_meta (meta : Keeper_types.keeper_meta) =
-  match meta.sandbox_profile with
-  | Keeper_types.Docker -> "docker"
-  | Keeper_types.Local -> "local"
+let sandbox_kind_of_meta (meta : Keeper_types.keeper_meta)
+    : Keeper_types.sandbox_profile =
+  meta.sandbox_profile
 
 let list_json values =
   `List (List.map (fun value -> `String value) values)
@@ -415,7 +414,8 @@ let to_json (receipt : t) =
       ?keeper_turn_id:receipt.turn_count
       ?task_id:receipt.current_task_id
       ~goal_ids:receipt.goal_ids
-      ~sandbox_profile:receipt.sandbox_kind
+      ~sandbox_profile:
+        (Keeper_types.sandbox_profile_to_string receipt.sandbox_kind)
       ?sandbox_root:receipt.sandbox_root
       ~network_mode:receipt.network_mode
       ?approval_mode:receipt.approval_profile
@@ -445,7 +445,8 @@ let to_json (receipt : t) =
          | None -> false (* unknown outcome: fail-closed *))
       ~duration_ms:(receipt_duration_ms receipt)
       ?error:receipt.error_message
-      ~sandbox_target:receipt.sandbox_kind
+      ~sandbox_target:
+        (Keeper_types.sandbox_profile_to_string receipt.sandbox_kind)
       ()
   in
   `Assoc
@@ -508,7 +509,7 @@ let to_json (receipt : t) =
       ( "sandbox",
         `Assoc
           [
-            ("kind", `String receipt.sandbox_kind);
+            ("kind", `String (Keeper_types.sandbox_profile_to_string receipt.sandbox_kind));
             ( "sandbox_root",
               match receipt.sandbox_root with
               | Some value -> `String value
@@ -654,7 +655,7 @@ let operator_broadcast_payload (receipt : t) ~disposition ~reason =
           ] )
     ; ( "sandbox",
         `Assoc
-          [ "kind", `String receipt.sandbox_kind
+          [ "kind", `String (Keeper_types.sandbox_profile_to_string receipt.sandbox_kind)
           ; "sandbox_root", string_opt_json receipt.sandbox_root
           ; "network_mode", `String receipt.network_mode
           ] )

--- a/lib/keeper/keeper_execution_receipt.mli
+++ b/lib/keeper/keeper_execution_receipt.mli
@@ -127,7 +127,7 @@ type t =
   ; tools_used : string list
   ; tool_contract_result : string
   ; tool_surface : tool_surface
-  ; sandbox_kind : string
+  ; sandbox_kind : Keeper_types.sandbox_profile
   ; sandbox_root : string option
   ; network_mode : string
   ; approval_profile : string option
@@ -149,7 +149,8 @@ type t =
   }
 
 val stop_reason_to_string : Cascade_runner.stop_reason -> string
-val sandbox_kind_of_meta : Keeper_types.keeper_meta -> string
+val sandbox_kind_of_meta :
+  Keeper_types.keeper_meta -> Keeper_types.sandbox_profile
 val to_json : t -> Yojson.Safe.t
 
 (** Derived display pair (disposition, reason) computed from receipt fields.

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -1052,7 +1052,7 @@ let test_keeper_zombie_field_contracts () =
           required_tools = [ "Read" ];
           missing_required_tools = [];
         };
-      sandbox_kind = "local";
+      sandbox_kind = Masc_mcp.Keeper_types.Local;
       sandbox_root = None;
       network_mode = "offline";
       approval_profile = None;

--- a/test/test_keeper_pause_broadcast.ml
+++ b/test/test_keeper_pause_broadcast.ml
@@ -75,7 +75,7 @@ let mk_receipt
     tool_contract_result;
     tool_surface =
       mk_tool_surface ~tool_requirement ~required_tools ~missing_required_tools ();
-    sandbox_kind = "local";
+    sandbox_kind = Masc_mcp.Keeper_types.Local;
     sandbox_root = None;
     network_mode = "offline";
     approval_profile = None;


### PR DESCRIPTION
## Summary

Receipt 구조체의 `sandbox_kind` 필드를 free-form `string`("local"/"docker")에서 기존 typed enum `Keeper_types.sandbox_profile (Local | Docker)`로 전환. Track A typed-classifier sweep의 네 번째 PR로, `feat/tool-selection-mode-typed` 위에 stacked.

## Why

- Producer 단에서 `meta.sandbox_profile` 을 `to_string` 로 한 번 평탄화한 뒤 receipt에 string 저장 → 다시 boundary에서 사용 — 중간 string layer는 drift만 만들고 정보 추가는 없음.
- Test fixture가 `sandbox_kind = "local"` 같은 손글씨 문자열을 받았기 때문에 producer가 emit하지 않는 변종을 컴파일러가 검출 못 함.

## Changes

| File | Before | After |
|---|---|---|
| `keeper_execution_receipt.mli` | `sandbox_kind : string` | `sandbox_kind : Keeper_types.sandbox_profile` |
| `keeper_execution_receipt.ml` | `sandbox_kind_of_meta` returns `string` | returns typed; JSON/Prometheus boundary converts via `sandbox_profile_to_string` |
| `test/test_ci_hardening_source.ml` | `sandbox_kind = "local"` | `Masc_mcp.Keeper_types.Local` |
| `test/test_keeper_pause_broadcast.ml` | `sandbox_kind = "local"` | `Masc_mcp.Keeper_types.Local` |

신규 variant 0건 — 기존 `Keeper_types.sandbox_profile` 재사용.

## Verification

- `dune build --root . @check` clean
- `_build/default/test/test_keeper_ocaml_tla_correspondence.exe` → 12 tests, Test Successful
- `_build/default/test/test_keeper_post_turn_wirein_order.exe` → 2 tests, Test Successful
- G3 opacity: `git diff | rg -i "anthropic|openai|claude|gpt|gemini|sonnet|opus|haiku"` → 0 hits

## Stack

Base: `feat/tool-selection-mode-typed` (#14650)
- `feat/tool-surface-class-typed`
- `feat/turn-lane-typed`
- `feat/tool-selection-mode-typed`
- **`feat/sandbox-kind-typed`** ← this PR

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>