### PR TITLE
refactor(keeper): typed network_mode — string → Keeper_types.network_mode

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -1520,7 +1520,7 @@ let run_turn
              }
          ; sandbox_kind = Keeper_execution_receipt.sandbox_kind_of_meta meta
          ; sandbox_root = Some keeper_visible_sandbox_root
-         ; network_mode = Keeper_types.network_mode_to_string meta.network_mode
+         ; network_mode = meta.network_mode
          ; approval_profile = acc.tool_surface.approval_mode_effective
          ; approval_profile_derived = acc.tool_surface.approval_mode_derived
          ; cascade_name

--- a/lib/keeper/keeper_execution_receipt.ml
+++ b/lib/keeper/keeper_execution_receipt.ml
@@ -113,7 +113,7 @@ type t =
   ; tool_surface : tool_surface
   ; sandbox_kind : Keeper_types.sandbox_profile
   ; sandbox_root : string option
-  ; network_mode : string
+  ; network_mode : Keeper_types.network_mode
   ; approval_profile : string option
   ; approval_profile_derived : bool
   ; cascade_name : cascade_name
@@ -417,7 +417,7 @@ let to_json (receipt : t) =
       ~sandbox_profile:
         (Keeper_types.sandbox_profile_to_string receipt.sandbox_kind)
       ?sandbox_root:receipt.sandbox_root
-      ~network_mode:receipt.network_mode
+      ~network_mode:(Keeper_types.network_mode_to_string receipt.network_mode)
       ?approval_mode:receipt.approval_profile
       ~tool_surface_class:
         (Keeper_agent_tool_surface.tool_surface_class_to_string
@@ -514,7 +514,9 @@ let to_json (receipt : t) =
               match receipt.sandbox_root with
               | Some value -> `String value
               | None -> `Null );
-            ("network_mode", `String receipt.network_mode);
+            ( "network_mode"
+            , `String (Keeper_types.network_mode_to_string receipt.network_mode)
+            );
           ] );
       ( "approval",
         `Assoc
@@ -657,7 +659,9 @@ let operator_broadcast_payload (receipt : t) ~disposition ~reason =
         `Assoc
           [ "kind", `String (Keeper_types.sandbox_profile_to_string receipt.sandbox_kind)
           ; "sandbox_root", string_opt_json receipt.sandbox_root
-          ; "network_mode", `String receipt.network_mode
+          ; ( "network_mode"
+            , `String (Keeper_types.network_mode_to_string receipt.network_mode)
+            )
           ] )
     ; ( "model_used",
         match receipt.model_used with

--- a/lib/keeper/keeper_execution_receipt.mli
+++ b/lib/keeper/keeper_execution_receipt.mli
@@ -129,7 +129,7 @@ type t =
   ; tool_surface : tool_surface
   ; sandbox_kind : Keeper_types.sandbox_profile
   ; sandbox_root : string option
-  ; network_mode : string
+  ; network_mode : Keeper_types.network_mode
   ; approval_profile : string option
   ; approval_profile_derived : bool
   ; cascade_name : cascade_name

--- a/lib/keeper/keeper_turn_helpers.ml
+++ b/lib/keeper/keeper_turn_helpers.ml
@@ -274,7 +274,7 @@ let record_pre_dispatch_terminal_observation
     ; tool_surface = pre_dispatch_tool_surface
     ; sandbox_kind = Keeper_execution_receipt.sandbox_kind_of_meta meta
     ; sandbox_root = Some (Keeper_sandbox.host_root_abs_of_meta ~config meta)
-    ; network_mode = Keeper_types.network_mode_to_string meta.network_mode
+    ; network_mode = meta.network_mode
     ; approval_profile = None
     ; approval_profile_derived = false
     ; cascade_name

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -1054,7 +1054,7 @@ let test_keeper_zombie_field_contracts () =
         };
       sandbox_kind = Masc_mcp.Keeper_types.Local;
       sandbox_root = None;
-      network_mode = "offline";
+      network_mode = Masc_mcp.Keeper_types.Network_none;
       approval_profile = None;
       approval_profile_derived = false;
       cascade_name = R.cascade_name_of_string "default";

--- a/test/test_dashboard_execution.ml
+++ b/test/test_dashboard_execution.ml
@@ -499,7 +499,7 @@ let append_execution_receipt ?(outcome = "ok")
       sandbox_kind =
         Lib.Keeper_execution_receipt.sandbox_kind_of_meta meta;
       sandbox_root = Some config.base_path;
-      network_mode = Lib.Keeper_types.network_mode_to_string meta.network_mode;
+      network_mode = meta.network_mode;
       approval_profile = Some "trusted_local";
       approval_profile_derived = false;
       cascade_name =

--- a/test/test_dashboard_goals.ml
+++ b/test/test_dashboard_goals.ml
@@ -144,7 +144,7 @@ let append_keeper_receipt ?(outcome = "ok")
         };
       sandbox_kind = Keeper_execution_receipt.sandbox_kind_of_meta meta;
       sandbox_root = Some config.base_path;
-      network_mode = Keeper_types.network_mode_to_string meta.network_mode;
+      network_mode = meta.network_mode;
       approval_profile = Some "trusted_local";
       approval_profile_derived = false;
       cascade_name = Keeper_cascade_profile.Runtime_name (Keeper_types.cascade_name_of_meta meta);

--- a/test/test_dashboard_keeper_routes.ml
+++ b/test/test_dashboard_keeper_routes.ml
@@ -635,8 +635,7 @@ let append_execution_receipt ?(tool_contract_result = "satisfied")
       sandbox_kind =
         Masc_mcp.Keeper_execution_receipt.sandbox_kind_of_meta meta;
       sandbox_root = Some config.base_path;
-      network_mode =
-        Masc_mcp.Keeper_types.network_mode_to_string meta.network_mode;
+      network_mode = meta.network_mode;
       approval_profile = Some "trusted_local";
       approval_profile_derived = false;
       cascade_name =

--- a/test/test_keeper_pause_broadcast.ml
+++ b/test/test_keeper_pause_broadcast.ml
@@ -77,7 +77,7 @@ let mk_receipt
       mk_tool_surface ~tool_requirement ~required_tools ~missing_required_tools ();
     sandbox_kind = Masc_mcp.Keeper_types.Local;
     sandbox_root = None;
-    network_mode = "offline";
+    network_mode = Masc_mcp.Keeper_types.Network_none;
     approval_profile = None;
     approval_profile_derived = false;
     cascade_name = R.cascade_name_of_string "default";


### PR DESCRIPTION
## Summary

Receipt 구조체의 `network_mode : string`를 typed enum `Keeper_types.network_mode (Network_none | Network_inherit)`로 전환. Track A typed-classifier sweep 의 마지막 PR — 이전 4 stack ancestor (#14647 tool_surface_class, #14649 turn_lane, #14650 tool_selection_mode, #14653 sandbox_kind) 모두 main에 머지되어 본 PR은 main 위에 단독 rebase 완료.

## Why

5개 producer 사이트 모두 `network_mode_to_string meta.network_mode`로 한 번 평탄화한 string을 receipt에 저장. typed 값을 그대로 받고 JSON/Prometheus boundary에서만 string화하면 round-trip 제거.

## Drift caught

Test fixture 2곳에서 `network_mode = "offline"` — `network_mode_of_string`이 받지 않는 값이고 producer가 emit한 적 없는 값. closed sum type이 잡아냄. 의도(네트워크 차단)에 맞춰 `Network_none`로 정정.

## Changes (post-rebase 단독 diff: 9 files, +16/-13)

| Site | Before | After |
|---|---|---|
| `keeper_execution_receipt.{ml,mli}` | `network_mode : string` | `network_mode : Keeper_types.network_mode` |
| `keeper_turn_helpers.ml` | `network_mode_to_string meta.network_mode` | `meta.network_mode` |
| `keeper_agent_run.ml` | 동일 round-trip | `meta.network_mode` |
| `test/test_dashboard_*.ml` (3) | 동일 round-trip | `meta.network_mode` |
| `test_ci_hardening_source.ml` | `"offline"` (drift) | `Network_none` |
| `test_keeper_pause_broadcast.ml` | `"offline"` (drift) | `Network_none` |
| boundary (Prometheus + 2 JSON) | `receipt.network_mode` | `network_mode_to_string receipt.network_mode` |

신규 variant 0건.

## Verification

- 이전 verification (full stack 시점): `dune build --root . @check` clean, `test_keeper_ocaml_tla_correspondence` 12 tests Successful, `test_keeper_post_turn_wirein_order` 2 tests Successful
- Rebase 후 단독 diff: 9 files, +16/-13 (parent stack 머지 후 실제 본 PR 지분만 남음)
- G3 opacity: `git diff | rg -i "anthropic|openai|claude|gpt|gemini|sonnet|opus|haiku"` → 0 hits
- CI 결과 확인 중 (force-push 후)

## Stack (모두 머지됨)

- ~~feat/tool-surface-class-typed~~ → #14647 머지
- ~~feat/turn-lane-typed~~ → #14649 머지
- ~~feat/tool-selection-mode-typed~~ → #14650 머지
- ~~feat/sandbox-kind-typed~~ → #14653 머지
- **feat/network-mode-typed** ← this PR (main 위에 단독)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>