### PR TITLE
refactor(keeper): typed stop_reason — string option → Cascade_runner.stop_reason option

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -607,9 +607,7 @@ let run_turn
                  let model = result.response.model in
                  receipt_turn_count_ref := Some result.turns;
                  receipt_model_used_ref := Some model;
-                 receipt_stop_reason_ref
-                 := Some
-                      (Keeper_execution_receipt.stop_reason_to_string result.stop_reason);
+                 receipt_stop_reason_ref := Some result.stop_reason;
                  receipt_cascade_observation_ref := result.cascade_observation;
                  (* Extract and persist thinking blocks to trajectory JSONL.
            NOTE: turn = acc.turn stays at 0 in the keeper path because
@@ -1477,7 +1475,9 @@ let run_turn
            this defaulted to "completed", which [Keeper_turn_terminal.normalize_code]
            remapped to "success" before disposition lookup. The producer-side
            default is now the canonical wire; the normalize step is gone. *)
-           Option.value ~default:"success" !receipt_stop_reason_ref
+           (match !receipt_stop_reason_ref with
+            | Some sr -> Keeper_execution_receipt.stop_reason_to_string sr
+            | None -> "success")
          | Error err ->
            terminal_reason_code_of_sdk_error_typed err
            |> Keeper_turn_terminal_code.to_wire

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -1520,7 +1520,7 @@ let run_turn
              }
          ; sandbox_kind = Keeper_execution_receipt.sandbox_kind_of_meta meta
          ; sandbox_root = Some keeper_visible_sandbox_root
-         ; network_mode = Keeper_types.network_mode_to_string meta.network_mode
+         ; network_mode = meta.network_mode
          ; approval_profile = acc.tool_surface.approval_mode_effective
          ; approval_profile_derived = acc.tool_surface.approval_mode_derived
          ; cascade_name

--- a/lib/keeper/keeper_execution_receipt.ml
+++ b/lib/keeper/keeper_execution_receipt.ml
@@ -125,7 +125,7 @@ type t =
   ; degraded_retry_cascade : cascade_name option
   ; fallback_reason : string option
   ; cascade_rotation_attempts : cascade_rotation_attempt list
-  ; stop_reason : string option
+  ; stop_reason : Cascade_runner.stop_reason option
   ; error_kind : error_kind option
   ; error_message : string option
   ; started_at : string
@@ -554,7 +554,7 @@ let to_json (receipt : t) =
           ] );
       ( "stop_reason",
         match receipt.stop_reason with
-        | Some value -> `String value
+        | Some value -> `String (stop_reason_to_string value)
         | None -> `Null );
       ("error", error_json);
       ("started_at", `String receipt.started_at);
@@ -669,7 +669,7 @@ let operator_broadcast_payload (receipt : t) ~disposition ~reason =
         | None -> `Null )
     ; ( "stop_reason",
         match receipt.stop_reason with
-        | Some value -> `String value
+        | Some value -> `String (stop_reason_to_string value)
         | None -> `Null )
     ; ( "error_kind",
         match receipt.error_kind with

--- a/lib/keeper/keeper_execution_receipt.ml
+++ b/lib/keeper/keeper_execution_receipt.ml
@@ -113,7 +113,7 @@ type t =
   ; tool_surface : tool_surface
   ; sandbox_kind : Keeper_types.sandbox_profile
   ; sandbox_root : string option
-  ; network_mode : string
+  ; network_mode : Keeper_types.network_mode
   ; approval_profile : string option
   ; approval_profile_derived : bool
   ; cascade_name : cascade_name
@@ -417,7 +417,7 @@ let to_json (receipt : t) =
       ~sandbox_profile:
         (Keeper_types.sandbox_profile_to_string receipt.sandbox_kind)
       ?sandbox_root:receipt.sandbox_root
-      ~network_mode:receipt.network_mode
+      ~network_mode:(Keeper_types.network_mode_to_string receipt.network_mode)
       ?approval_mode:receipt.approval_profile
       ~tool_surface_class:
         (Keeper_agent_tool_surface.tool_surface_class_to_string
@@ -514,7 +514,9 @@ let to_json (receipt : t) =
               match receipt.sandbox_root with
               | Some value -> `String value
               | None -> `Null );
-            ("network_mode", `String receipt.network_mode);
+            ( "network_mode"
+            , `String (Keeper_types.network_mode_to_string receipt.network_mode)
+            );
           ] );
       ( "approval",
         `Assoc
@@ -657,7 +659,9 @@ let operator_broadcast_payload (receipt : t) ~disposition ~reason =
         `Assoc
           [ "kind", `String (Keeper_types.sandbox_profile_to_string receipt.sandbox_kind)
           ; "sandbox_root", string_opt_json receipt.sandbox_root
-          ; "network_mode", `String receipt.network_mode
+          ; ( "network_mode"
+            , `String (Keeper_types.network_mode_to_string receipt.network_mode)
+            )
           ] )
     ; ( "model_used",
         match receipt.model_used with

--- a/lib/keeper/keeper_execution_receipt.mli
+++ b/lib/keeper/keeper_execution_receipt.mli
@@ -141,7 +141,7 @@ type t =
   ; degraded_retry_cascade : cascade_name option
   ; fallback_reason : string option
   ; cascade_rotation_attempts : cascade_rotation_attempt list
-  ; stop_reason : string option
+  ; stop_reason : Cascade_runner.stop_reason option
   ; error_kind : error_kind option
   ; error_message : string option
   ; started_at : string

--- a/lib/keeper/keeper_execution_receipt.mli
+++ b/lib/keeper/keeper_execution_receipt.mli
@@ -129,7 +129,7 @@ type t =
   ; tool_surface : tool_surface
   ; sandbox_kind : Keeper_types.sandbox_profile
   ; sandbox_root : string option
-  ; network_mode : string
+  ; network_mode : Keeper_types.network_mode
   ; approval_profile : string option
   ; approval_profile_derived : bool
   ; cascade_name : cascade_name

--- a/lib/keeper/keeper_run_tools.ml
+++ b/lib/keeper/keeper_run_tools.ml
@@ -124,7 +124,7 @@ type agent_setup =
   ; tool_usage_before : (string * int) list
   ; receipt_turn_count_ref : int option ref
   ; receipt_model_used_ref : string option ref
-  ; receipt_stop_reason_ref : string option ref
+  ; receipt_stop_reason_ref : Cascade_runner.stop_reason option ref
   ; receipt_cascade_observation_ref : Cascade_legacy_runner.cascade_observation option ref
   ; receipt_response_text_present_ref : bool ref
   ; reported_tool_names_ref : string list ref
@@ -527,7 +527,9 @@ let prepare_agent_setup
   let actual_keeper_tool_names_ref : string list ref = ref [] in
   let receipt_turn_count_ref : int option ref = ref None in
   let receipt_model_used_ref : string option ref = ref None in
-  let receipt_stop_reason_ref : string option ref = ref None in
+  let receipt_stop_reason_ref : Cascade_runner.stop_reason option ref =
+    ref None
+  in
   let receipt_cascade_observation_ref
     : Cascade_legacy_runner.cascade_observation option ref
     =

--- a/lib/keeper/keeper_run_tools.mli
+++ b/lib/keeper/keeper_run_tools.mli
@@ -81,7 +81,7 @@ type agent_setup =
   ; tool_usage_before : (string * int) list
   ; receipt_turn_count_ref : int option ref
   ; receipt_model_used_ref : string option ref
-  ; receipt_stop_reason_ref : string option ref
+  ; receipt_stop_reason_ref : Cascade_runner.stop_reason option ref
   ; receipt_cascade_observation_ref : Cascade_legacy_runner.cascade_observation option ref
   ; receipt_response_text_present_ref : bool ref
   ; reported_tool_names_ref : string list ref

--- a/lib/keeper/keeper_turn_helpers.ml
+++ b/lib/keeper/keeper_turn_helpers.ml
@@ -274,7 +274,7 @@ let record_pre_dispatch_terminal_observation
     ; tool_surface = pre_dispatch_tool_surface
     ; sandbox_kind = Keeper_execution_receipt.sandbox_kind_of_meta meta
     ; sandbox_root = Some (Keeper_sandbox.host_root_abs_of_meta ~config meta)
-    ; network_mode = Keeper_types.network_mode_to_string meta.network_mode
+    ; network_mode = meta.network_mode
     ; approval_profile = None
     ; approval_profile_derived = false
     ; cascade_name

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -1054,7 +1054,7 @@ let test_keeper_zombie_field_contracts () =
         };
       sandbox_kind = Masc_mcp.Keeper_types.Local;
       sandbox_root = None;
-      network_mode = "offline";
+      network_mode = Masc_mcp.Keeper_types.Network_none;
       approval_profile = None;
       approval_profile_derived = false;
       cascade_name = R.cascade_name_of_string "default";

--- a/test/test_dashboard_execution.ml
+++ b/test/test_dashboard_execution.ml
@@ -499,7 +499,7 @@ let append_execution_receipt ?(outcome = "ok")
       sandbox_kind =
         Lib.Keeper_execution_receipt.sandbox_kind_of_meta meta;
       sandbox_root = Some config.base_path;
-      network_mode = Lib.Keeper_types.network_mode_to_string meta.network_mode;
+      network_mode = meta.network_mode;
       approval_profile = Some "trusted_local";
       approval_profile_derived = false;
       cascade_name =

--- a/test/test_dashboard_execution.ml
+++ b/test/test_dashboard_execution.ml
@@ -455,7 +455,7 @@ let create_keeper env sw config name =
 let append_execution_receipt ?(outcome = "ok")
     ?(terminal_reason_code = "completed")
     ?(tool_contract_result = "satisfied")
-    ?(stop_reason = Some "completed")
+    ?(stop_reason = Some Lib.Cascade_runner.Completed)
     config ~keeper_name =
   let meta =
     match Lib.Keeper_types.read_meta config keeper_name with
@@ -838,7 +838,7 @@ let test_dashboard_execution_queue_surfaces_keeper_runtime_trust () =
               ~outcome:"error"
               ~terminal_reason_code:"required_tool_use_unsatisfied"
               ~tool_contract_result:"violated"
-              ~stop_reason:(Some "completion_contract_violation:require_tool_use");
+              ~stop_reason:None;
             let execution_json =
               Lib.Dashboard_execution.json
                 ~config

--- a/test/test_dashboard_goals.ml
+++ b/test/test_dashboard_goals.ml
@@ -156,7 +156,7 @@ let append_keeper_receipt ?(outcome = "ok")
       degraded_retry_cascade = None;
       fallback_reason = None;
       cascade_rotation_attempts = [];
-      stop_reason = Some terminal_reason_code;
+      stop_reason = Some Cascade_runner.Completed;
       error_kind = None;
       error_message = None;
       started_at;

--- a/test/test_dashboard_goals.ml
+++ b/test/test_dashboard_goals.ml
@@ -144,7 +144,7 @@ let append_keeper_receipt ?(outcome = "ok")
         };
       sandbox_kind = Keeper_execution_receipt.sandbox_kind_of_meta meta;
       sandbox_root = Some config.base_path;
-      network_mode = Keeper_types.network_mode_to_string meta.network_mode;
+      network_mode = meta.network_mode;
       approval_profile = Some "trusted_local";
       approval_profile_derived = false;
       cascade_name = Keeper_cascade_profile.Runtime_name (Keeper_types.cascade_name_of_meta meta);

--- a/test/test_dashboard_keeper_routes.ml
+++ b/test/test_dashboard_keeper_routes.ml
@@ -635,8 +635,7 @@ let append_execution_receipt ?(tool_contract_result = "satisfied")
       sandbox_kind =
         Masc_mcp.Keeper_execution_receipt.sandbox_kind_of_meta meta;
       sandbox_root = Some config.base_path;
-      network_mode =
-        Masc_mcp.Keeper_types.network_mode_to_string meta.network_mode;
+      network_mode = meta.network_mode;
       approval_profile = Some "trusted_local";
       approval_profile_derived = false;
       cascade_name =

--- a/test/test_dashboard_keeper_routes.ml
+++ b/test/test_dashboard_keeper_routes.ml
@@ -675,7 +675,7 @@ let append_execution_receipt ?(tool_contract_result = "satisfied")
              };
            ]
          | _ -> []);
-      stop_reason = Some "completed";
+      stop_reason = Some Masc_mcp.Cascade_runner.Completed;
       error_kind = None;
       error_message = None;
       started_at;

--- a/test/test_keeper_pause_broadcast.ml
+++ b/test/test_keeper_pause_broadcast.ml
@@ -77,7 +77,7 @@ let mk_receipt
       mk_tool_surface ~tool_requirement ~required_tools ~missing_required_tools ();
     sandbox_kind = Masc_mcp.Keeper_types.Local;
     sandbox_root = None;
-    network_mode = "offline";
+    network_mode = Masc_mcp.Keeper_types.Network_none;
     approval_profile = None;
     approval_profile_derived = false;
     cascade_name = R.cascade_name_of_string "default";

--- a/test/test_keeper_pause_broadcast.ml
+++ b/test/test_keeper_pause_broadcast.ml
@@ -266,7 +266,7 @@ let test_broadcast_payload_carries_turn_diagnostics () =
       ~required_tools:[ "keeper_shell"; "masc_worktree_create" ]
       ~missing_required_tools:[ "keeper_shell" ]
       ~current_task_id:"task-102"
-      ~stop_reason:"completed"
+      ~stop_reason:Masc_mcp.Cascade_runner.Completed
       ~goal_ids:[ "goal-main" ]
       ()
   in


### PR DESCRIPTION
## Summary

Receipt 구조체의 `stop_reason : string option`을 typed enum `Cascade_runner.stop_reason option`으로 전환 (variant: `Completed | TurnBudgetExhausted { turns_used; limit } | MutationBoundaryReached { turns_used; tool_name }`). Track A typed-classifier sweep의 여섯 번째 PR, `feat/network-mode-typed` 위에 stacked.

## Why

Producer 측 `result.stop_reason`이 이미 typed인데 receipt에 저장 시 `stop_reason_to_string`으로 평탄화 — round-trip이 정보 손실 없이 typed를 유지할 수 있는데 string 단계를 거치면서 다른 카테고리 값이 슬롯에 들어갈 수 있는 통로를 열어둠.

## Drift caught

closed sum type 덕분에 다음 3종의 fixture 오용이 컴파일 타임에 발견:

1. **카테고리 conflation** — `test_dashboard_execution.ml:841`이 `Some "completion_contract_violation:require_tool_use"` (terminal_reason_code 영역의 값)을 stop_reason 슬롯에 박아둠. Producer는 error 경로에서 stop_reason을 set하지 않음(ref 초기값 None). 정정: `None`.
2. **필드 conflation** — `test_dashboard_goals.ml:159`가 `Some terminal_reason_code` (다른 typed 필드를 직접 alias)로 stop_reason 채움. 정정: `Cascade_runner.Completed`.
3. **string literal** — `~stop_reason:"completed"` (`test_keeper_pause_broadcast.ml:269`), `Some "completed"` (`test_dashboard_keeper_routes.ml:678`, `test_dashboard_execution.ml:458`) 모두 변종 없이 typed 변수로 정정.

## Changes

| Site | Before | After |
|---|---|---|
| `keeper_execution_receipt.{ml,mli}` | `stop_reason : string option` | `Cascade_runner.stop_reason option` |
| `keeper_run_tools.{ml,mli}` (ref carrier) | `string option ref` | `Cascade_runner.stop_reason option ref` |
| `keeper_agent_run.ml:610-612` producer | wrap `stop_reason_to_string result.stop_reason` | `Some result.stop_reason` |
| `keeper_agent_run.ml:1478` consumer (terminal fallback) | `Option.value ~default:"success" !ref` | `match` with `stop_reason_to_string` 변환 |
| `keeper_execution_receipt.ml:557, 672` JSON | `\`String value` | `\`String (stop_reason_to_string value)` |
| 4 test fixtures | string literal | typed variant |

신규 variant 0건.

## Verification

- `dune build --root . @check` clean
- `test_keeper_ocaml_tla_correspondence` → 12 tests Successful
- `test_keeper_post_turn_wirein_order` → 2 tests Successful
- `test_keeper_pause_broadcast` → 18 tests Successful (JSON wire 보존)
- G3 opacity: `git diff | rg -i "anthropic|openai|claude|gpt|gemini|sonnet|opus|haiku"` → 0 hits

## Stack

- `feat/tool-surface-class-typed`
- `feat/turn-lane-typed`
- `feat/tool-selection-mode-typed` (#14650)
- `feat/sandbox-kind-typed` (#14653)
- `feat/network-mode-typed` (#14654)
- **`feat/stop-reason-typed`** ← this PR

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>