### PR TITLE
refactor(keeper): typed cascade_rotation_attempt.outcome — closed sum type

### DIFF
--- a/lib/keeper/keeper_execution_receipt.ml
+++ b/lib/keeper/keeper_execution_receipt.ml
@@ -97,11 +97,31 @@ type slot_release_phase =
    Mirrors the pattern applied to tool_surface_class in PR #14647 review. *)
 let slot_release_phase_to_string = to_tla_symbol
 
+(* Terminal classification of a cascade rotation attempt.  Producer-side
+   closed set in [keeper_unified_turn.ml]; JSON wire form is the lowercase
+   string via [cascade_rotation_outcome_to_string].
+
+   No [@@deriving tla] here because [slot_release_phase] above already
+   binds module-level [all_symbols]; following the precedent in
+   [keeper_types_profile.ml] a follow-up can wrap a TLA mirror in a
+   submodule when a spec actually models rotation outcomes. *)
+type cascade_rotation_outcome =
+  | Rotation_setup_failed
+  | Rotation_retry_scheduled
+  | Rotation_budget_exhausted
+  | Rotation_slot_phase_exhausted
+
+let cascade_rotation_outcome_to_string = function
+  | Rotation_setup_failed -> "setup_failed"
+  | Rotation_retry_scheduled -> "retry_scheduled"
+  | Rotation_budget_exhausted -> "budget_exhausted"
+  | Rotation_slot_phase_exhausted -> "slot_phase_exhausted"
+
 type cascade_rotation_attempt =
   { from_cascade : cascade_name
   ; to_cascade : cascade_name
   ; reason : string
-  ; outcome : string
+  ; outcome : cascade_rotation_outcome
   ; slot_release_at_phase : slot_release_phase option
   ; productive_phase_elapsed_ms : int option
   ; retry_phase_elapsed_ms : int option
@@ -202,7 +222,8 @@ let cascade_rotation_attempt_to_json attempt =
       ("from_cascade", `String (cascade_name_to_string attempt.from_cascade));
       ("to_cascade", `String (cascade_name_to_string attempt.to_cascade));
       ("reason", `String attempt.reason);
-      ("outcome", `String attempt.outcome);
+      ( "outcome",
+        `String (cascade_rotation_outcome_to_string attempt.outcome) );
       ( "slot_release_at_phase",
         string_opt_json
           (Option.map slot_release_phase_to_string

--- a/lib/keeper/keeper_execution_receipt.mli
+++ b/lib/keeper/keeper_execution_receipt.mli
@@ -108,11 +108,21 @@ val slot_release_phase_to_string : slot_release_phase -> string
     form of every variant, used by the RFC-0065 correspondence harness. *)
 val all_symbols : string list
 
+(** Terminal classification of a cascade rotation attempt. Closed set;
+    wire form is [cascade_rotation_outcome_to_string]. *)
+type cascade_rotation_outcome =
+  | Rotation_setup_failed
+  | Rotation_retry_scheduled
+  | Rotation_budget_exhausted
+  | Rotation_slot_phase_exhausted
+
+val cascade_rotation_outcome_to_string : cascade_rotation_outcome -> string
+
 type cascade_rotation_attempt =
   { from_cascade : cascade_name
   ; to_cascade : cascade_name
   ; reason : string
-  ; outcome : string
+  ; outcome : cascade_rotation_outcome
   ; slot_release_at_phase : slot_release_phase option
   ; productive_phase_elapsed_ms : int option
   ; retry_phase_elapsed_ms : int option

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -902,7 +902,7 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
           ?retry_phase_elapsed_ms
           ~(from_cascade : Keeper_execution_receipt.cascade_name)
           ~(retry : EC.degraded_retry)
-          ~(outcome : string)
+          ~(outcome : Keeper_execution_receipt.cascade_rotation_outcome)
           (err : Agent_sdk.Error.sdk_error) =
         let attempt : Keeper_execution_receipt.cascade_rotation_attempt =
           {
@@ -1431,7 +1431,8 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
                             ?retry_phase_elapsed_ms
                             ~from_cascade:execution.cascade_name
                             ~retry:degraded_retry
-                            ~outcome:"setup_failed"
+                            ~outcome:
+                              Keeper_execution_receipt.Rotation_setup_failed
                             fail_open_err;
                           Log.Keeper.warn
                             "%s: recoverable cascade failure in %s suggested degraded retry to %s (reason=%s), but retry setup failed: %s"
@@ -1464,7 +1465,8 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
                             ?retry_phase_elapsed_ms
                             ~from_cascade:execution.cascade_name
                             ~retry:degraded_retry
-                            ~outcome:"retry_scheduled"
+                            ~outcome:
+                              Keeper_execution_receipt.Rotation_retry_scheduled
                             err;
                           degraded_retry_info := Some degraded_retry;
                           Log.Keeper.warn
@@ -1544,7 +1546,8 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
                         ?retry_phase_elapsed_ms
                         ~from_cascade:execution.cascade_name
                         ~retry:degraded_retry
-                        ~outcome:"budget_exhausted"
+                        ~outcome:
+                          Keeper_execution_receipt.Rotation_budget_exhausted
                         err;
                       Log.Keeper.warn
                         "%s: recoverable cascade failure in %s suggested degraded retry to %s (reason=%s), but remaining turn budget %.1fs is below the OAS retry guard/minimum; ending this cycle: %s"
@@ -1573,7 +1576,8 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
                         ?retry_phase_elapsed_ms
                         ~from_cascade:execution.cascade_name
                         ~retry:degraded_retry
-                        ~outcome:"slot_phase_exhausted"
+                        ~outcome:
+                          Keeper_execution_receipt.Rotation_slot_phase_exhausted
                         err;
                       Log.Keeper.warn
                         "%s: recoverable cascade failure in %s suggested degraded retry to %s (reason=%s), but productive slot phase budget %.1fs is exhausted after %.1fs; ending this cycle to release the outer turn slot: %s"

--- a/test/test_dashboard_execution.ml
+++ b/test/test_dashboard_execution.ml
@@ -524,7 +524,7 @@ let append_execution_receipt ?(outcome = "ok")
               Lib.Keeper_execution_receipt.cascade_name_of_string
                 Lib.Keeper_config.local_recovery_cascade_name;
             reason = "turn_timeout";
-            outcome = "retry_scheduled";
+            outcome = Lib.Keeper_execution_receipt.Rotation_retry_scheduled;
             slot_release_at_phase =
               Some Lib.Keeper_execution_receipt.Productive_phase_exhausted;
             productive_phase_elapsed_ms = Some 174000;

--- a/test/test_dashboard_keeper_routes.ml
+++ b/test/test_dashboard_keeper_routes.ml
@@ -662,7 +662,8 @@ let append_execution_receipt ?(tool_contract_result = "satisfied")
                  Masc_mcp.Keeper_execution_receipt.cascade_name_of_string
                    retry_cascade;
                reason;
-               outcome = "retry_scheduled";
+               outcome =
+                 Masc_mcp.Keeper_execution_receipt.Rotation_retry_scheduled;
                slot_release_at_phase = None;
                productive_phase_elapsed_ms = Some 174000;
                retry_phase_elapsed_ms = Some 0;


### PR DESCRIPTION
## Summary

`cascade_rotation_attempt.outcome : string` → 신규 closed sum type `Keeper_execution_receipt.cascade_rotation_outcome` (4 variants: `Rotation_setup_failed | Rotation_retry_scheduled | Rotation_budget_exhausted | Rotation_slot_phase_exhausted`). Track A typed-classifier sweep의 여덟 번째 PR, `feat/slot-release-phase-typed` 위에 stacked.

## Why

`keeper_unified_turn.ml` producer 4사이트에서 string literal emit:

| Line | Literal | 의미 |
|---|---|---|
| 1434 | "setup_failed" | retry setup이 next cascade 선택 전에 실패 |
| 1467 | "retry_scheduled" | rotation 수락, retry 큐잉 |
| 1547 | "budget_exhausted" | 남은 turn budget이 retry guard 미만 |
| 1576 | "slot_phase_exhausted" | productive-phase slot release |

closed set이지만 string 통로로 drift 가능. `record_cascade_rotation_attempt`의 `~outcome : string` 인자를 typed로 좁혀 컴파일러가 4 사이트 enumerate 강제.

## TLA derive deferred

`slot_release_phase` (이전 PR)가 module-level `all_symbols`를 이미 점유. 두 번째 `[@@deriving tla]`는 shadowing 야기. `keeper_types_profile.ml`의 `Sandbox_profile_tla` 서브모듈 precedent를 follow-up에서 적용 가능 — 현재는 typed enum만으로도 drift catch 가치 확보.

## Naming convention

`Rotation_` 접두사로 같은 모듈의 `slot_release_phase` 생성자(`Retry_scheduled`, `Retry_budget_exhausted` 등)와 충돌 회피.

## Changes

| Site | Before | After |
|---|---|---|
| `keeper_execution_receipt.{ml,mli}` | type 신규 + `outcome : string` | typed enum + `outcome : cascade_rotation_outcome` |
| `keeper_unified_turn.ml:905` helper sig | `~(outcome : string)` | `~(outcome : Keeper_execution_receipt.cascade_rotation_outcome)` |
| `keeper_unified_turn.ml` (4 producer sites) | string literals | `Keeper_execution_receipt.Rotation_*` variants |
| `keeper_execution_receipt.ml:223` JSON | `\`String attempt.outcome` | boundary 변환 |
| 2 test fixtures | `"retry_scheduled"` | `Rotation_retry_scheduled` |

## Verification

- `dune build --root . @check` clean
- `test_keeper_ocaml_tla_correspondence` → 12 tests Successful
- `test_keeper_post_turn_wirein_order` → 2 tests Successful
- G3 opacity: `git diff | rg -i "anthropic|openai|claude|gpt|gemini|sonnet|opus|haiku"` → 0 hits

## Stack

- `feat/tool-surface-class-typed`
- `feat/turn-lane-typed`
- `feat/tool-selection-mode-typed` (#14650)
- `feat/sandbox-kind-typed` (#14653)
- `feat/network-mode-typed` (#14654)
- `feat/stop-reason-typed` (#14655)
- `feat/slot-release-phase-typed` (#14656)
- **`feat/rotation-outcome-typed`** ← this PR

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>