### PR TITLE
refactor(keeper): typed degraded_retry.fallback_reason — closed sum type (12 variants)

### DIFF
--- a/lib/keeper/keeper_agent_run.mli
+++ b/lib/keeper/keeper_agent_run.mli
@@ -287,7 +287,7 @@ val run_turn :
   -> ?priority:Llm_provider.Request_priority.t
   -> ?degraded_retry_applied:bool
   -> ?degraded_retry_cascade:string
-  -> ?fallback_reason:string
+  -> ?fallback_reason:Keeper_error_classify.degraded_retry_reason
   -> ?cascade_rotation_attempts:
        Keeper_execution_receipt.cascade_rotation_attempt list
   -> ?is_retry:bool

--- a/lib/keeper/keeper_error_classify.ml
+++ b/lib/keeper/keeper_error_classify.ml
@@ -194,9 +194,42 @@ let is_auto_recoverable_cascade_fail_open_error
   || is_resumable_cli_session_error err
   || is_auto_recoverable_cascade_exhausted_error err
 
+(* Classification of why a degraded retry is being attempted.  Closed set
+   covering both producer paths: [local_recovery_retry] (7 narrow reasons)
+   and [recoverable_cascade_failure_reason] (broader set including raw
+   provider API failures).  Wire form is the lowercase string via
+   [degraded_retry_reason_to_string]. *)
+type degraded_retry_reason =
+  | Hard_quota
+  | Max_turns
+  | Resumable_cli_session
+  | Admission_queue_timeout
+  | Oas_timeout_budget
+  | Turn_timeout
+  | Cascade_candidates_filtered
+  | Required_tool_contract_violation
+  | Cascade_exhausted
+  | Rate_limit
+  | Server_error
+  | Auth_error
+
+let degraded_retry_reason_to_string = function
+  | Hard_quota -> "hard_quota"
+  | Max_turns -> "max_turns"
+  | Resumable_cli_session -> "resumable_cli_session"
+  | Admission_queue_timeout -> "admission_queue_timeout"
+  | Oas_timeout_budget -> "oas_timeout_budget"
+  | Turn_timeout -> "turn_timeout"
+  | Cascade_candidates_filtered -> "cascade_candidates_filtered"
+  | Required_tool_contract_violation -> "required_tool_contract_violation"
+  | Cascade_exhausted -> "cascade_exhausted"
+  | Rate_limit -> "rate_limit"
+  | Server_error -> "server_error"
+  | Auth_error -> "auth_error"
+
 type degraded_retry =
   { next_cascade : string
-  ; fallback_reason : string
+  ; fallback_reason : degraded_retry_reason
   }
 
 let fallback_cascade_for_unavailable_profile
@@ -236,32 +269,32 @@ let degraded_retry_after_recoverable_error
           Keeper_config.local_recovery_cascade_name
   then None
   else if Keeper_turn_driver.sdk_error_is_hard_quota err then
-    local_recovery_retry "hard_quota"
+    local_recovery_retry Hard_quota
   else if Keeper_turn_driver.sdk_error_is_max_turns_exceeded err then
-    local_recovery_retry "max_turns"
+    local_recovery_retry Max_turns
   else
     match Keeper_turn_driver.classify_masc_internal_error err with
     | Some (Keeper_turn_driver.Resumable_cli_session _) ->
-        local_recovery_retry "resumable_cli_session"
+        local_recovery_retry Resumable_cli_session
     | Some (Keeper_turn_driver.Admission_queue_timeout _) ->
-        local_recovery_retry "admission_queue_timeout"
+        local_recovery_retry Admission_queue_timeout
     | Some (Keeper_turn_driver.Oas_timeout_budget _) ->
-        local_recovery_retry "oas_timeout_budget"
+        local_recovery_retry Oas_timeout_budget
     | Some (Keeper_turn_driver.Turn_timeout _) ->
-        local_recovery_retry "turn_timeout"
+        local_recovery_retry Turn_timeout
     | Some
         (Keeper_turn_driver.Cascade_exhausted
            { reason = Keeper_types.Candidates_filtered_after_cycles; _ }) ->
-        local_recovery_retry "cascade_candidates_filtered"
+        local_recovery_retry Cascade_candidates_filtered
     | Some
         (Keeper_turn_driver.Cascade_exhausted
            { reason = Keeper_types.Max_turns_exceeded; _ }) ->
-        local_recovery_retry "max_turns"
+        local_recovery_retry Max_turns
     | Some
         (Keeper_turn_driver.Cascade_exhausted
            { reason = Keeper_types.Other_detail detail; _ })
       when Keeper_turn_driver.message_looks_like_cli_wrapped_hard_quota detail ->
-        local_recovery_retry "hard_quota"
+        local_recovery_retry Hard_quota
     | Some (Keeper_turn_driver.Cascade_exhausted _)
     | Some (Keeper_turn_driver.No_tool_capable_provider _)
     | Some (Keeper_turn_driver.Accept_rejected _)
@@ -272,34 +305,34 @@ let degraded_retry_after_recoverable_error
 
 let recoverable_cascade_failure_reason (err : Agent_sdk.Error.sdk_error) =
   if is_required_tool_contract_violation err then
-    Some "required_tool_contract_violation"
+    Some Required_tool_contract_violation
   else if Keeper_turn_driver.sdk_error_is_hard_quota err then
-    Some "hard_quota"
+    Some Hard_quota
   else if Keeper_turn_driver.sdk_error_is_max_turns_exceeded err then
-    Some "max_turns"
+    Some Max_turns
   else
     match Keeper_turn_driver.classify_masc_internal_error err with
     | Some (Keeper_turn_driver.Resumable_cli_session _) ->
-        Some "resumable_cli_session"
+        Some Resumable_cli_session
     | Some (Keeper_turn_driver.Admission_queue_timeout _) ->
-        Some "admission_queue_timeout"
+        Some Admission_queue_timeout
     | Some (Keeper_turn_driver.Oas_timeout_budget _) ->
-        Some "oas_timeout_budget"
+        Some Oas_timeout_budget
     | Some (Keeper_turn_driver.Turn_timeout _) ->
-        Some "turn_timeout"
+        Some Turn_timeout
     | Some
         (Keeper_turn_driver.Cascade_exhausted
            { reason = Keeper_types.Candidates_filtered_after_cycles; _ }) ->
-        Some "cascade_candidates_filtered"
+        Some Cascade_candidates_filtered
     | Some
         (Keeper_turn_driver.Cascade_exhausted
            { reason = Keeper_types.Max_turns_exceeded; _ }) ->
-        Some "max_turns"
+        Some Max_turns
     | Some
         (Keeper_turn_driver.Cascade_exhausted
            { reason = Keeper_types.Other_detail detail; _ })
       when Keeper_turn_driver.message_looks_like_cli_wrapped_hard_quota detail ->
-        Some "hard_quota"
+        Some Hard_quota
     | Some (Keeper_turn_driver.Cascade_exhausted _) ->
         (* Generic cascade exhaustion: all candidates failed without a more
            specific reason. Treat as recoverable so declarative
@@ -308,7 +341,7 @@ let recoverable_cascade_failure_reason (err : Agent_sdk.Error.sdk_error) =
            silent turns ended with [(null)] fallback_reason because this
            arm previously returned [None]. Other arms below remain
            non-recoverable to keep the surface conservative. *)
-        Some "cascade_exhausted"
+        Some Cascade_exhausted
     | Some (Keeper_turn_driver.No_tool_capable_provider _)
     | Some (Keeper_turn_driver.Accept_rejected _)
     | Some (Keeper_turn_driver.Admission_queue_rejected _)
@@ -333,12 +366,12 @@ let recoverable_cascade_failure_reason (err : Agent_sdk.Error.sdk_error) =
            so only soft (non-hard-quota) rate limits reach this arm. *)
         (match err with
          | Agent_sdk.Error.Api (Llm_provider.Retry.RateLimited _) ->
-             Some "rate_limit"
+             Some Rate_limit
          | Agent_sdk.Error.Api (Llm_provider.Retry.ServerError { status; _ })
            when status >= 500 ->
-             Some "server_error"
+             Some Server_error
          | Agent_sdk.Error.Api (Llm_provider.Retry.AuthError _) ->
-             Some "auth_error"
+             Some Auth_error
          (* Sub-500 server errors (4xx already handled above for AuthError /
             RateLimited) are not classified as recoverable cascade failures. *)
          | Agent_sdk.Error.Api (Llm_provider.Retry.ServerError _)

--- a/lib/keeper/keeper_error_classify.mli
+++ b/lib/keeper/keeper_error_classify.mli
@@ -60,9 +60,28 @@ val should_cap_rotation_for_contract_violation :
   Agent_sdk.Error.sdk_error ->
   bool
 
+(** Classification of why a degraded retry is being attempted. Closed
+    set; producer-side is [keeper_error_classify]. Wire form is the
+    lowercase string via [degraded_retry_reason_to_string]. *)
+type degraded_retry_reason =
+  | Hard_quota
+  | Max_turns
+  | Resumable_cli_session
+  | Admission_queue_timeout
+  | Oas_timeout_budget
+  | Turn_timeout
+  | Cascade_candidates_filtered
+  | Required_tool_contract_violation
+  | Cascade_exhausted
+  | Rate_limit
+  | Server_error
+  | Auth_error
+
+val degraded_retry_reason_to_string : degraded_retry_reason -> string
+
 type degraded_retry =
   { next_cascade : string
-  ; fallback_reason : string
+  ; fallback_reason : degraded_retry_reason
   }
 
 (** Opportunistically fail open to a broader cascade when the current
@@ -88,7 +107,7 @@ val fallback_cascade_for_unavailable_profile :
     [degraded_retry_after_recoverable_error] or
     [degraded_rotation_after_recoverable_error]. *)
 val recoverable_cascade_failure_reason :
-  Agent_sdk.Error.sdk_error -> string option
+  Agent_sdk.Error.sdk_error -> degraded_retry_reason option
 
 (** Returns the one-shot degraded retry lane for recoverable whole-cascade
     failures. Required-tool turns stay terminal, and already-degraded lanes

--- a/lib/keeper/keeper_execution_receipt.ml
+++ b/lib/keeper/keeper_execution_receipt.ml
@@ -120,7 +120,7 @@ let cascade_rotation_outcome_to_string = function
 type cascade_rotation_attempt =
   { from_cascade : cascade_name
   ; to_cascade : cascade_name
-  ; reason : string
+  ; reason : Keeper_error_classify.degraded_retry_reason
   ; outcome : cascade_rotation_outcome
   ; slot_release_at_phase : slot_release_phase option
   ; productive_phase_elapsed_ms : int option
@@ -162,7 +162,7 @@ type t =
   ; cascade_outcome : string
   ; degraded_retry_applied : bool
   ; degraded_retry_cascade : cascade_name option
-  ; fallback_reason : string option
+  ; fallback_reason : Keeper_error_classify.degraded_retry_reason option
   ; cascade_rotation_attempts : cascade_rotation_attempt list
   ; stop_reason : Cascade_runner.stop_reason option
   ; error_kind : error_kind option
@@ -221,7 +221,10 @@ let cascade_rotation_attempt_to_json attempt =
     [
       ("from_cascade", `String (cascade_name_to_string attempt.from_cascade));
       ("to_cascade", `String (cascade_name_to_string attempt.to_cascade));
-      ("reason", `String attempt.reason);
+      ( "reason",
+        `String
+          (Keeper_error_classify.degraded_retry_reason_to_string attempt.reason)
+      );
       ( "outcome",
         `String (cascade_rotation_outcome_to_string attempt.outcome) );
       ( "slot_release_at_phase",
@@ -588,7 +591,9 @@ let to_json (receipt : t) =
               | None -> `Null );
             ( "fallback_reason",
               match receipt.fallback_reason with
-              | Some value -> `String value
+              | Some value ->
+                `String
+                  (Keeper_error_classify.degraded_retry_reason_to_string value)
               | None -> `Null );
             ( "rotation_attempts",
               `List

--- a/lib/keeper/keeper_execution_receipt.mli
+++ b/lib/keeper/keeper_execution_receipt.mli
@@ -121,7 +121,7 @@ val cascade_rotation_outcome_to_string : cascade_rotation_outcome -> string
 type cascade_rotation_attempt =
   { from_cascade : cascade_name
   ; to_cascade : cascade_name
-  ; reason : string
+  ; reason : Keeper_error_classify.degraded_retry_reason
   ; outcome : cascade_rotation_outcome
   ; slot_release_at_phase : slot_release_phase option
   ; productive_phase_elapsed_ms : int option
@@ -163,7 +163,7 @@ type t =
   ; cascade_outcome : string
   ; degraded_retry_applied : bool
   ; degraded_retry_cascade : cascade_name option
-  ; fallback_reason : string option
+  ; fallback_reason : Keeper_error_classify.degraded_retry_reason option
   ; cascade_rotation_attempts : cascade_rotation_attempt list
   ; stop_reason : Cascade_runner.stop_reason option
   ; error_kind : error_kind option

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -1438,7 +1438,8 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
                             "%s: recoverable cascade failure in %s suggested degraded retry to %s (reason=%s), but retry setup failed: %s"
                             meta.name execution_cascade_name
                             degraded_retry.next_cascade
-                            degraded_retry.fallback_reason
+                            (EC.degraded_retry_reason_to_string
+                               degraded_retry.fallback_reason)
                             (short_preview (Agent_sdk.Error.to_string fail_open_err));
                           mark_terminal_error fail_open_err;
                           Error fail_open_err
@@ -1473,7 +1474,8 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
                             "%s: recoverable cascade failure in %s; rotation retry on cascade=%s reason=%s max_context=%d context_budget=%d primary_budget=%d requested_override=%s: %s"
                             meta.name execution_cascade_name
                             next_execution_cascade_name
-                            degraded_retry.fallback_reason
+                            (EC.degraded_retry_reason_to_string
+                               degraded_retry.fallback_reason)
                             next_execution.max_context
                             next_execution.max_context_resolution.effective_budget
                             next_execution.max_context_resolution.primary_budget
@@ -1553,7 +1555,8 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
                         "%s: recoverable cascade failure in %s suggested degraded retry to %s (reason=%s), but remaining turn budget %.1fs is below the OAS retry guard/minimum; ending this cycle: %s"
                         meta.name execution_cascade_name
                         degraded_retry.next_cascade
-                        degraded_retry.fallback_reason
+                        (EC.degraded_retry_reason_to_string
+                           degraded_retry.fallback_reason)
                         (remaining_turn_budget_s ())
                         (short_preview (Agent_sdk.Error.to_string err));
                       mark_terminal_error err;
@@ -1583,7 +1586,8 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
                         "%s: recoverable cascade failure in %s suggested degraded retry to %s (reason=%s), but productive slot phase budget %.1fs is exhausted after %.1fs; ending this cycle to release the outer turn slot: %s"
                         meta.name execution_cascade_name
                         degraded_retry.next_cascade
-                        degraded_retry.fallback_reason
+                        (EC.degraded_retry_reason_to_string
+                           degraded_retry.fallback_reason)
                         degraded_retry_slot_phase_budget_sec
                         (timeout_sec -. remaining_turn_budget_s ())
                         (short_preview (Agent_sdk.Error.to_string err));
@@ -2044,7 +2048,8 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
             ~outcome:(if is_ambiguous_partial then "partial" else "error")
             ~degraded_retry_applied
             ?degraded_retry_cascade
-            ?fallback_reason
+            ?fallback_reason:
+              (Option.map EC.degraded_retry_reason_to_string fallback_reason)
             ~social_state
             ~error:e_str
             ~terminal_reason
@@ -2527,7 +2532,8 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
             ~latency_ms ~semaphore_wait_ms ~outcome:"success"
             ~degraded_retry_applied
             ?degraded_retry_cascade
-            ?fallback_reason
+            ?fallback_reason:
+              (Option.map EC.degraded_retry_reason_to_string fallback_reason)
             ~turn_mode
             ~social_state
             ~result:(Some result) ();

--- a/test/test_dashboard_execution.ml
+++ b/test/test_dashboard_execution.ml
@@ -513,7 +513,7 @@ let append_execution_receipt ?(outcome = "ok")
         Some
           (Lib.Keeper_execution_receipt.cascade_name_of_string
              Lib.Keeper_config.local_recovery_cascade_name);
-      fallback_reason = Some "turn_timeout";
+      fallback_reason = Some Lib.Keeper_error_classify.Turn_timeout;
       cascade_rotation_attempts =
         [
           {
@@ -523,7 +523,7 @@ let append_execution_receipt ?(outcome = "ok")
             to_cascade =
               Lib.Keeper_execution_receipt.cascade_name_of_string
                 Lib.Keeper_config.local_recovery_cascade_name;
-            reason = "turn_timeout";
+            reason = Lib.Keeper_error_classify.Turn_timeout;
             outcome = Lib.Keeper_execution_receipt.Rotation_retry_scheduled;
             slot_release_at_phase =
               Some Lib.Keeper_execution_receipt.Productive_phase_exhausted;

--- a/test/test_dashboard_keeper_routes.ml
+++ b/test/test_dashboard_keeper_routes.ml
@@ -592,7 +592,8 @@ let append_execution_receipt ?(tool_contract_result = "satisfied")
     ?(degraded_retry_applied = true)
     ?(degraded_retry_cascade =
       Some Masc_mcp.Keeper_config.local_recovery_cascade_name)
-    ?(fallback_reason = Some "turn_timeout") config ~keeper_name =
+    ?(fallback_reason = Some Masc_mcp.Keeper_error_classify.Turn_timeout)
+    config ~keeper_name =
   let meta =
     match Masc_mcp.Keeper_types.read_meta config keeper_name with
     | Ok (Some meta) -> meta

--- a/test/test_keeper_error_classify_recoverable.ml
+++ b/test/test_keeper_error_classify_recoverable.ml
@@ -48,7 +48,8 @@ let test_other_detail_generic_recoverable () =
   match KEC.recoverable_cascade_failure_reason err with
   | Some reason ->
     check string "Other_detail (non-quota) -> cascade_exhausted"
-      "cascade_exhausted" reason
+      "cascade_exhausted"
+      (KEC.degraded_retry_reason_to_string reason)
   | None ->
     fail "Generic Cascade_exhausted with Other_detail should be recoverable"
 
@@ -57,7 +58,8 @@ let test_all_providers_failed_recoverable () =
   match KEC.recoverable_cascade_failure_reason err with
   | Some reason ->
     check string "All_providers_failed -> cascade_exhausted"
-      "cascade_exhausted" reason
+      "cascade_exhausted"
+      (KEC.degraded_retry_reason_to_string reason)
   | None ->
     fail "Cascade_exhausted with All_providers_failed should be recoverable"
 
@@ -66,7 +68,8 @@ let test_no_providers_available_recoverable () =
   match KEC.recoverable_cascade_failure_reason err with
   | Some reason ->
     check string "No_providers_available -> cascade_exhausted"
-      "cascade_exhausted" reason
+      "cascade_exhausted"
+      (KEC.degraded_retry_reason_to_string reason)
   | None ->
     fail "Cascade_exhausted with No_providers_available should be recoverable"
 
@@ -76,7 +79,8 @@ let test_candidates_filtered_specific_reason () =
   match KEC.recoverable_cascade_failure_reason err with
   | Some reason ->
     check string "Candidates_filtered keeps specific label"
-      "cascade_candidates_filtered" reason
+      "cascade_candidates_filtered"
+      (KEC.degraded_retry_reason_to_string reason)
   | None ->
     fail "Candidates_filtered should be recoverable"
 
@@ -84,7 +88,7 @@ let test_max_turns_specific_reason () =
   let err = make_cascade_exhausted KT.Max_turns_exceeded in
   match KEC.recoverable_cascade_failure_reason err with
   | Some reason ->
-    check string "Max_turns keeps specific label" "max_turns" reason
+    check string "Max_turns keeps specific label" "max_turns" (KEC.degraded_retry_reason_to_string reason)
   | None ->
     fail "Max_turns should be recoverable"
 
@@ -95,7 +99,7 @@ let test_no_tool_capable_non_recoverable () =
   | Some reason ->
     fail
       (Printf.sprintf "No_tool_capable_provider should stay None, got %s"
-         reason)
+         (KEC.degraded_retry_reason_to_string reason))
   | None -> ()
 
 let test_accept_rejected_non_recoverable () =
@@ -103,7 +107,8 @@ let test_accept_rejected_non_recoverable () =
   match KEC.recoverable_cascade_failure_reason err with
   | Some reason ->
     fail
-      (Printf.sprintf "Accept_rejected should stay None, got %s" reason)
+      (Printf.sprintf "Accept_rejected should stay None, got %s"
+         (KEC.degraded_retry_reason_to_string reason))
   | None -> ()
 
 (* Regression: auto-recoverable cascade exhaustion must still be
@@ -140,7 +145,8 @@ let test_catalog_rotation_preserves_order_without_base_injection () =
   with
   | Some retry ->
     check string "catalog order wins" "catalog_first" retry.next_cascade;
-    check string "fallback reason" "cascade_exhausted" retry.fallback_reason
+    check string "fallback reason" "cascade_exhausted"
+      (KEC.degraded_retry_reason_to_string retry.fallback_reason)
   | None -> fail "Expected catalog-ordered degraded retry"
 
 (* ---- Status-code-aware rotation tests ----------------------------------- *)
@@ -155,7 +161,7 @@ let test_soft_rate_limit_is_recoverable () =
   in
   match KEC.recoverable_cascade_failure_reason err with
   | Some reason ->
-    check string "soft 429 -> rate_limit" "rate_limit" reason
+    check string "soft 429 -> rate_limit" "rate_limit" (KEC.degraded_retry_reason_to_string reason)
   | None ->
     fail "Soft rate-limit should be recoverable (trigger cascade rotation)"
 
@@ -171,7 +177,7 @@ let test_soft_rate_limit_no_retry_after_is_recoverable () =
     (Owne.sdk_error_is_hard_quota err);
   (match KEC.recoverable_cascade_failure_reason err with
    | Some reason ->
-     check string "no-retry_after rate_limit -> rate_limit" "rate_limit" reason
+     check string "no-retry_after rate_limit -> rate_limit" "rate_limit" (KEC.degraded_retry_reason_to_string reason)
    | None ->
      fail "Non-hard-quota RateLimited without retry_after should be recoverable")
 
@@ -182,7 +188,7 @@ let test_server_error_500_is_recoverable () =
   in
   match KEC.recoverable_cascade_failure_reason err with
   | Some reason ->
-    check string "500 -> server_error" "server_error" reason
+    check string "500 -> server_error" "server_error" (KEC.degraded_retry_reason_to_string reason)
   | None ->
     fail "ServerError 500 should be recoverable (trigger cascade rotation)"
 
@@ -193,7 +199,7 @@ let test_server_error_503_is_recoverable () =
   in
   match KEC.recoverable_cascade_failure_reason err with
   | Some reason ->
-    check string "503 -> server_error" "server_error" reason
+    check string "503 -> server_error" "server_error" (KEC.degraded_retry_reason_to_string reason)
   | None ->
     fail "ServerError 503 should be recoverable (trigger cascade rotation)"
 
@@ -204,7 +210,7 @@ let test_server_error_502_is_recoverable () =
   in
   match KEC.recoverable_cascade_failure_reason err with
   | Some reason ->
-    check string "502 -> server_error" "server_error" reason
+    check string "502 -> server_error" "server_error" (KEC.degraded_retry_reason_to_string reason)
   | None ->
     fail "ServerError 502 should be recoverable (trigger cascade rotation)"
 
@@ -217,7 +223,7 @@ let test_auth_error_is_recoverable () =
   in
   match KEC.recoverable_cascade_failure_reason err with
   | Some reason ->
-    check string "auth error -> auth_error" "auth_error" reason
+    check string "auth error -> auth_error" "auth_error" (KEC.degraded_retry_reason_to_string reason)
   | None ->
     fail "AuthError should be recoverable (trigger cascade rotation)"
 
@@ -232,7 +238,7 @@ let test_hard_quota_not_reclassified_as_rate_limit () =
     (Owne.sdk_error_is_hard_quota err);
   (match KEC.recoverable_cascade_failure_reason err with
    | Some reason ->
-     check string "hard quota keeps hard_quota label" "hard_quota" reason
+     check string "hard quota keeps hard_quota label" "hard_quota" (KEC.degraded_retry_reason_to_string reason)
    | None ->
      fail "Hard quota should be recoverable with hard_quota label")
 
@@ -246,7 +252,7 @@ let test_server_error_400_not_recoverable_by_new_arm () =
   (* Should return None (not recoverable via server_error) unless some other
      arm catches it first — here it falls through to None. *)
   (match KEC.recoverable_cascade_failure_reason err with
-   | Some reason when reason = "server_error" ->
+   | Some KEC.Server_error ->
      fail "400 should NOT be classified as server_error by rotation arm"
    | _ -> ())
 
@@ -268,7 +274,7 @@ let test_rotation_finds_next_cascade_for_rate_limit () =
   with
   | Some retry ->
     check string "rotation goes to fallback" "fallback_cascade" retry.next_cascade;
-    check string "reason is rate_limit" "rate_limit" retry.fallback_reason
+    check string "reason is rate_limit" "rate_limit" (KEC.degraded_retry_reason_to_string retry.fallback_reason)
   | None ->
     fail "Soft rate-limit should trigger rotation to next cascade"
 
@@ -288,7 +294,7 @@ let test_rotation_finds_next_cascade_for_auth_error () =
   with
   | Some retry ->
     check string "auth rotation goes to fallback" "fallback_cascade" retry.next_cascade;
-    check string "reason is auth_error" "auth_error" retry.fallback_reason
+    check string "reason is auth_error" "auth_error" (KEC.degraded_retry_reason_to_string retry.fallback_reason)
   | None ->
     fail "AuthError should trigger rotation to next cascade"
 

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -4706,7 +4706,8 @@ let required_tool_contract_violation_error () =
 let expect_degraded_retry label expected_cascade expected_reason = function
   | Some (retry : EC.degraded_retry) ->
       check string (label ^ " cascade") expected_cascade retry.next_cascade;
-      check string (label ^ " reason") expected_reason retry.fallback_reason
+      check string (label ^ " reason") expected_reason
+        (EC.degraded_retry_reason_to_string retry.fallback_reason)
   | None -> fail (label ^ ": expected degraded retry")
 
 let test_degraded_retry_after_recoverable_error_uses_local_recovery_for_hard_quota () =
@@ -6267,7 +6268,7 @@ let test_degraded_retry_budget_gate_allows_remaining_budget () =
       check string "retry cascade" KC.local_recovery_cascade_name
         retry.next_cascade;
       check string "fallback reason" "oas_timeout_budget"
-        retry.fallback_reason
+        (EC.degraded_retry_reason_to_string retry.fallback_reason)
   | UT.Degraded_retry_slot_phase_exhausted _ ->
       fail "expected productive slot phase budget to remain"
   | UT.Degraded_retry_budget_exhausted _ ->
@@ -6290,7 +6291,7 @@ let test_degraded_retry_budget_gate_blocks_exhausted_budget () =
       check string "retry cascade candidate" KC.local_recovery_cascade_name
         retry.next_cascade;
       check string "fallback reason" "oas_timeout_budget"
-        retry.fallback_reason
+        (EC.degraded_retry_reason_to_string retry.fallback_reason)
   | UT.Degraded_retry_slot_phase_exhausted _ ->
       fail "expected exhausted retry budget, not slot phase budget"
   | UT.Degraded_retry_allowed _ -> fail "expected exhausted retry budget"
@@ -6313,7 +6314,7 @@ let test_degraded_retry_slot_phase_allows_oas_timeout_local_recovery () =
       check string "retry cascade candidate" KC.local_recovery_cascade_name
         retry.next_cascade;
       check string "fallback reason" "oas_timeout_budget"
-        retry.fallback_reason
+        (EC.degraded_retry_reason_to_string retry.fallback_reason)
   | UT.Degraded_retry_slot_phase_exhausted _ ->
       fail "expected OAS timeout budget to bypass slot phase for local recovery"
   | UT.Degraded_retry_budget_exhausted _ ->
@@ -6337,7 +6338,7 @@ let test_degraded_retry_slot_phase_allows_first_contract_rotation () =
       check string "retry cascade candidate" (KC.default_cascade_name ())
         retry.next_cascade;
       check string "fallback reason" "required_tool_contract_violation"
-        retry.fallback_reason
+        (EC.degraded_retry_reason_to_string retry.fallback_reason)
   | UT.Degraded_retry_slot_phase_exhausted _ ->
       fail "expected first contract rotation to bypass productive slot phase"
   | UT.Degraded_retry_budget_exhausted _ ->


### PR DESCRIPTION
## Summary

`degraded_retry.fallback_reason : string`을 `Keeper_error_classify.degraded_retry_reason` typed enum(12 variants)로 전환. 받은 영향: receipt의 `cascade_rotation_attempt.reason` + `t.fallback_reason` 두 필드도 동시 typed로 마이그레이션. Track A typed-classifier sweep의 아홉 번째 PR, `feat/rotation-outcome-typed` 위에 stacked.

## Why

`keeper_error_classify`에 두 producer 경로가 같은 string 필드에 다른 카테고리 값을 채워넣고 있었음:

| Producer | Values | 카테고리 |
|---|---|---|
| `local_recovery_retry` (7) | hard_quota, max_turns, resumable_cli_session, admission_queue_timeout, oas_timeout_budget, turn_timeout, cascade_candidates_filtered | 좁은 local-recovery 사유 |
| `recoverable_cascade_failure_reason` (5 추가) | required_tool_contract_violation, cascade_exhausted, rate_limit, server_error, auth_error | 넓은 cascade-failure 사유 (raw provider API 포함) |

두 set이 같은 string 슬롯에 conflated. closed sum type 12 variants로 두 producer 모두 강제 enumerate.

## Changes

| File | Before | After |
|---|---|---|
| `keeper_error_classify.{ml,mli}` | `degraded_retry.fallback_reason : string` + 12 string literals | typed enum + 12 variant binds |
| `keeper_error_classify.{ml,mli}` | `recoverable_cascade_failure_reason : ... -> string option` | `... -> degraded_retry_reason option` |
| `keeper_execution_receipt.{ml,mli}` | `cascade_rotation_attempt.reason : string`, `t.fallback_reason : string option` | typed |
| `keeper_agent_run.mli` | `?fallback_reason : string` | `?fallback_reason : degraded_retry_reason` |
| `keeper_unified_turn.ml` | 4 log statements + 2 metric call sites | boundary 변환 via `degraded_retry_reason_to_string` / `Option.map ...` |
| `keeper_execution_receipt.ml` JSON (2) | `\`String value` | `\`String (degraded_retry_reason_to_string value)` |
| Tests (4 files) | string literals, string asserts | typed variants / `degraded_retry_reason_to_string` 비교 |

## Drift caught

이번 PR은 모든 string-literal 사이트가 이미 closed set 내. forward drift defense — 향후 새 fallback_reason 값이 typed enum 외부로 새면 컴파일 에러.

## Verification

- `dune build --root . @check` clean
- `test_keeper_ocaml_tla_correspondence` → 12 tests Successful
- `test_keeper_post_turn_wirein_order` → 2 tests Successful
- `test_keeper_error_classify_recoverable` → 19 tests Successful
- G3 opacity: `git diff | rg -i "anthropic|openai|claude|gpt|gemini|sonnet|opus|haiku"` → 0 hits

## Stack

- `feat/tool-surface-class-typed`
- `feat/turn-lane-typed`
- `feat/tool-selection-mode-typed` (#14650)
- `feat/sandbox-kind-typed` (#14653)
- `feat/network-mode-typed` (#14654)
- `feat/stop-reason-typed` (#14655)
- `feat/slot-release-phase-typed` (#14656)
- `feat/rotation-outcome-typed` (#14657)
- **`feat/fallback-reason-typed`** ← this PR

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>