### PR TITLE
test(dashboard): drop stale memory-subsystems expectation from hidden-sidebar test

### DIFF
--- a/dashboard/src/config/navigation.test.ts
+++ b/dashboard/src/config/navigation.test.ts
@@ -151,7 +151,7 @@ describe('monitoring navigation labels', () => {
     const sections = sectionItemsForTab('monitoring')
     const hiddenIds = sections.filter(item => item.hidden).map(item => item.id)
 
-    expect(hiddenIds).toEqual(['observatory', 'memory-subsystems'])
+    expect(hiddenIds).toEqual(['observatory'])
   })
 
   it('monitoring sidebar labels are unique (no overloaded term like "런타임")', () => {


### PR DESCRIPTION
## Summary

PR #14431 (5/10, *remove dead memory-subsystems section and duplicate DecisionsStream*) intentionally removed the `memory-subsystems` entry from the monitoring sidebar definition. The accompanying expectation in `dashboard/src/config/navigation.test.ts:154` was not updated, so the test has been failing on main since 5/10.

The behavior under test (diagnostic routes remain navigable via redirect but are hidden from the sidebar) is still valid for the remaining hidden item (`observatory`); only the array contents are adjusted to the post-#14431 reality.

### Change

```diff
- expect(hiddenIds).toEqual(['observatory', 'memory-subsystems'])
+ expect(hiddenIds).toEqual(['observatory'])
```

## Test plan

- [x] `pnpm exec vitest run src/config/navigation.test.ts` → memory-subsystems fail removed (2 remaining fails are Phase 6 redirects handled by PR #14664)

## Pairing

Pairs with **PR #14664** (closes the remaining 12 routing fails). Together they bring main vitest from 52 → 36 fails. Split is intentional: #14664 = production code (whitelist policy), this PR = test-only.

## RFC Check

- Test-only change in `dashboard/src/config/navigation.test.ts`
- `RFC-WAIVED: test expectation alignment to PR #14431 intent; no production code change`

🤖 Generated with [Claude Code](https://claude.com/claude-code)