### PR TITLE
refactor(keeper): typed receipt.tool_contract_result — string → closed sum type

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -758,7 +758,8 @@ let run_turn
                         surface: %s"
                        (String.concat ", " unexpected_tool_names)
                    in
-                   acc.receipt_tool_contract_result <- "violated";
+                   acc.receipt_tool_contract_result <-
+                     Keeper_execution_receipt.Contract_violated;
                    Prometheus.inc_counter
                      Keeper_metrics.metric_keeper_contract_violations
                      ~labels:
@@ -849,7 +850,8 @@ let run_turn
                           ; reason
                           })
                    in
-                   let tool_contract_status () =
+                   let tool_contract_status ()
+                       : Keeper_execution_receipt.tool_contract_result =
                      let required_tool_names = acc.tool_surface.required_tool_names in
                      let missing_visible_required =
                        acc.tool_surface.missing_required_tool_names
@@ -868,35 +870,35 @@ let run_turn
                          required_tool_names
                      in
                      if missing_visible_required <> []
-                     then "tool_surface_mismatch"
+                     then Contract_tool_surface_mismatch
                      else if required_tool_names <> [] && not all_required_used
                      then
                        if actual_keeper_tool_names = []
-                       then "missing_required_tool_use"
+                       then Contract_missing_required_tool_use
                        else if
                          all_class Keeper_tool_disclosure.Claim_context
                          && had_owned_active_task_at_turn_start
-                       then "claim_only_after_owned_task"
+                       then Contract_claim_only_after_owned_task
                        else if all_class Keeper_tool_disclosure.Claim_context
-                       then "needs_execution_progress"
+                       then Contract_needs_execution_progress
                        else if all_class Keeper_tool_disclosure.Passive_status
-                       then "passive_only"
-                       else "missing_required_tool_use"
+                       then Contract_passive_only
+                       else Contract_missing_required_tool_use
                      else if actual_keeper_tool_names = []
-                     then "satisfied_completion"
+                     then Contract_satisfied_completion
                      else if
                        all_class Keeper_tool_disclosure.Claim_context
                        && had_owned_active_task_at_turn_start
-                     then "claim_only_after_owned_task"
+                     then Contract_claim_only_after_owned_task
                      else if all_class Keeper_tool_disclosure.Claim_context
-                     then "needs_execution_progress"
+                     then Contract_needs_execution_progress
                      else if all_class Keeper_tool_disclosure.Passive_status
-                     then "passive_only"
+                     then Contract_passive_only
                      else if has_class Keeper_tool_disclosure.Completion
-                     then "satisfied_completion"
+                     then Contract_satisfied_completion
                      else if has_class Keeper_tool_disclosure.Execution
-                     then "satisfied_execution"
-                     else "needs_execution_progress"
+                     then Contract_satisfied_execution
+                     else Contract_needs_execution_progress
                    in
                    (* Required-tool turns are filtered onto providers that declare
             tool support plus tool_choice support. If a text-only response
@@ -914,9 +916,10 @@ let run_turn
                        , actionable_tool_contract_violation_reason )
                      with
                      | Ok (), Some reason ->
-                       let contract_status =
+                       let contract_status
+                           : Keeper_execution_receipt.tool_contract_result =
                          if actual_keeper_tool_names = []
-                         then "missing_required_tool_use"
+                         then Contract_missing_required_tool_use
                          else tool_contract_status ()
                        in
                        acc.receipt_tool_contract_result <- contract_status;
@@ -932,7 +935,9 @@ let run_turn
                        Keeper_tool_disclosure.record_require_tool_use_violation
                          ~keeper_name:meta.name
                          ~has_current_task:(keeper_has_owned_active_task ())
-                         ~contract_status;
+                         ~contract_status:
+                           (Keeper_execution_receipt
+                            .tool_contract_result_to_string contract_status);
                        let signal_label =
                          Keeper_contract_classifier.actionable_signal_label
                            actionable_signal_kind
@@ -959,16 +964,19 @@ let run_turn
                        acc.receipt_tool_contract_result <- tool_contract_status ();
                        Ok (`Provider_text text)
                      | Error reason, _ ->
-                       let contract_status =
+                       let contract_status
+                           : Keeper_execution_receipt.tool_contract_result =
                          if actual_keeper_tool_names = []
-                         then "missing_required_tool_use"
+                         then Contract_missing_required_tool_use
                          else tool_contract_status ()
                        in
                        acc.receipt_tool_contract_result <- contract_status;
                        Keeper_tool_disclosure.record_require_tool_use_violation
                          ~keeper_name:meta.name
                          ~has_current_task:(keeper_has_owned_active_task ())
-                         ~contract_status;
+                         ~contract_status:
+                           (Keeper_execution_receipt
+                            .tool_contract_result_to_string contract_status);
                        let contract_str =
                          match effective_completion_contract with
                          | Keeper_tool_disclosure.Allow_text_or_tool ->
@@ -1459,13 +1467,14 @@ let run_turn
            ( Some (Keeper_execution_receipt.error_kind_of_string (sdk_error_kind err))
            , Some (Agent_sdk.Error.to_string err) )
        in
-       let tool_contract_result =
+       let tool_contract_result
+           : Keeper_execution_receipt.tool_contract_result =
          match turn_result with
          | Error (Agent_sdk.Error.Agent (Agent_sdk.Error.CompletionContractViolation _))
            ->
-           if String.equal acc.receipt_tool_contract_result "unknown"
-           then "violated"
-           else acc.receipt_tool_contract_result
+           (match acc.receipt_tool_contract_result with
+            | Contract_unknown -> Contract_violated
+            | other -> other)
          | _ -> acc.receipt_tool_contract_result
        in
        let terminal_reason_code =

--- a/lib/keeper/keeper_execution_receipt.ml
+++ b/lib/keeper/keeper_execution_receipt.ml
@@ -137,6 +137,63 @@ let cascade_outcome_to_string = function
   | Cascade_not_observed -> "not_observed"
   | Cascade_not_dispatched -> "not_dispatched"
 
+(* Receipt-level result of the tool-contract evaluation for the turn.
+   Closed union of three producer paths:
+     1. Initial-state sentinel from [keeper_run_tools]: [Contract_unknown].
+     2. Boundary-state overrides: [Contract_violated] (agent_run
+        CompletionContractViolation), [Contract_not_dispatched]
+        (turn_helpers pre-dispatch), [Contract_no_tool_capable_provider]
+        (run_tools no-provider escape).
+     3. Seven outcomes mirrored from
+        [Keeper_contract_classifier.contract_status_label]:
+        [Contract_tool_surface_mismatch], [Contract_missing_required_tool_use],
+        [Contract_claim_only_after_owned_task], [Contract_needs_execution_progress],
+        [Contract_passive_only], [Contract_satisfied_completion],
+        [Contract_satisfied_execution].
+   JSON wire form is the lowercase string via
+   [tool_contract_result_to_string].  No raw ["satisfied"] variant —
+   producer never emits it; closed type makes the fictional test fixture
+   string unrepresentable. *)
+type tool_contract_result =
+  | Contract_unknown
+  | Contract_not_dispatched
+  | Contract_violated
+  | Contract_tool_surface_mismatch
+  | Contract_no_tool_capable_provider
+  | Contract_missing_required_tool_use
+  | Contract_claim_only_after_owned_task
+  | Contract_needs_execution_progress
+  | Contract_passive_only
+  | Contract_satisfied_completion
+  | Contract_satisfied_execution
+
+let tool_contract_result_to_string = function
+  | Contract_unknown -> "unknown"
+  | Contract_not_dispatched -> "not_dispatched"
+  | Contract_violated -> "violated"
+  | Contract_tool_surface_mismatch -> "tool_surface_mismatch"
+  | Contract_no_tool_capable_provider -> "no_tool_capable_provider"
+  | Contract_missing_required_tool_use -> "missing_required_tool_use"
+  | Contract_claim_only_after_owned_task -> "claim_only_after_owned_task"
+  | Contract_needs_execution_progress -> "needs_execution_progress"
+  | Contract_passive_only -> "passive_only"
+  | Contract_satisfied_completion -> "satisfied_completion"
+  | Contract_satisfied_execution -> "satisfied_execution"
+
+(* Lift the typed [Keeper_contract_classifier.contract_status] into the
+   receipt-level [tool_contract_result].  Bridges the seven classifier
+   outcomes; the four boundary states are emitted only by producer sites
+   that already know they hold one of those states. *)
+let tool_contract_result_of_contract_status :
+    Keeper_contract_classifier.contract_status -> tool_contract_result = function
+  | Tool_surface_mismatch _ -> Contract_tool_surface_mismatch
+  | Missing_required_tool_use -> Contract_missing_required_tool_use
+  | Claim_only_after_owned_task -> Contract_claim_only_after_owned_task
+  | Needs_execution_progress -> Contract_needs_execution_progress
+  | Passive_only -> Contract_passive_only
+  | Satisfied_completion -> Contract_satisfied_completion
+  | Satisfied_execution -> Contract_satisfied_execution
+
 type cascade_rotation_attempt =
   { from_cascade : cascade_name
   ; to_cascade : cascade_name
@@ -168,7 +225,7 @@ type t =
   ; canonical_tools : string list
   ; unexpected_tools : string list
   ; tools_used : string list
-  ; tool_contract_result : string
+  ; tool_contract_result : tool_contract_result
   ; tool_surface : tool_surface
   ; sandbox_kind : Keeper_types.sandbox_profile
   ; sandbox_root : string option
@@ -320,9 +377,6 @@ let () =
 
 let operator_disposition (receipt : t) =
   let terminal_reason = String.lowercase_ascii receipt.terminal_reason_code in
-  let tool_contract_result =
-    String.lowercase_ascii receipt.tool_contract_result
-  in
   let error_kind =
     Option.map
       (fun kind -> String.lowercase_ascii (error_kind_to_string kind))
@@ -397,16 +451,15 @@ let operator_disposition (receipt : t) =
   then ("pause_human", "turn_livelock_blocked")
   else if
     receipt.tool_surface.tool_requirement = Required
-    && (List.mem tool_contract_result
-          [
-            "violated";
-            "unknown";
-            "needs_execution_progress";
-            "missing_required_tool_use";
-            "passive_only";
-            "claim_only_after_owned_task";
-            "tool_surface_mismatch";
-            "no_tool_capable_provider";
+    && (List.mem receipt.tool_contract_result
+          [ Contract_violated
+          ; Contract_unknown
+          ; Contract_needs_execution_progress
+          ; Contract_missing_required_tool_use
+          ; Contract_passive_only
+          ; Contract_claim_only_after_owned_task
+          ; Contract_tool_surface_mismatch
+          ; Contract_no_tool_capable_provider
           ]
         || receipt.tools_used = [])
   then ("pause_human", "tool_required_unsatisfied")
@@ -448,7 +501,7 @@ let operator_disposition (receipt : t) =
          — investigate regression of #11651 silent-path fix"
         (outcome_kind_to_string receipt.outcome)
         (cascade_outcome_to_string receipt.cascade_outcome)
-        terminal_reason tool_contract_result
+        terminal_reason (tool_contract_result_to_string receipt.tool_contract_result)
         (Option.value
            (Option.map error_kind_to_string receipt.error_kind)
            ~default:"<none>");
@@ -550,7 +603,8 @@ let to_json (receipt : t) =
       ("canonical_tools", list_json receipt.canonical_tools);
       ("unexpected_tools", list_json receipt.unexpected_tools);
       ("tools_used", list_json receipt.tools_used);
-      ("tool_contract_result", `String receipt.tool_contract_result);
+      ( "tool_contract_result",
+        `String (tool_contract_result_to_string receipt.tool_contract_result) );
       ( "tool_surface",
         `Assoc
           [
@@ -699,7 +753,8 @@ let operator_broadcast_payload (receipt : t) ~disposition ~reason =
     ; "cascade_name", `String (cascade_name_to_string receipt.cascade_name)
     ; ( "cascade_outcome"
       , `String (cascade_outcome_to_string receipt.cascade_outcome) )
-    ; "tool_contract_result", `String receipt.tool_contract_result
+    ; ( "tool_contract_result"
+      , `String (tool_contract_result_to_string receipt.tool_contract_result) )
     ; ( "last_tool_name",
         match last_tool_name receipt with
         | Some value -> `String value
@@ -707,7 +762,9 @@ let operator_broadcast_payload (receipt : t) ~disposition ~reason =
     ; "tools_used", list_json receipt.tools_used
     ; ( "tool_contract",
         `Assoc
-          [ "result", `String receipt.tool_contract_result
+          [ ( "result"
+            , `String
+                (tool_contract_result_to_string receipt.tool_contract_result) )
           ; "required_tools", list_json receipt.tool_surface.required_tools
           ; ( "missing_required_tools",
               list_json receipt.tool_surface.missing_required_tools )

--- a/lib/keeper/keeper_execution_receipt.mli
+++ b/lib/keeper/keeper_execution_receipt.mli
@@ -128,6 +128,30 @@ type cascade_outcome =
 
 val cascade_outcome_to_string : cascade_outcome -> string
 
+(** Receipt-level tool-contract evaluation result. Closed union of three
+    producer paths: (i) initial-state sentinel [Contract_unknown];
+    (ii) boundary-state overrides [Contract_not_dispatched],
+    [Contract_violated], [Contract_no_tool_capable_provider]; (iii) the
+    seven classifier outcomes mirrored from
+    [Keeper_contract_classifier.contract_status]. *)
+type tool_contract_result =
+  | Contract_unknown
+  | Contract_not_dispatched
+  | Contract_violated
+  | Contract_tool_surface_mismatch
+  | Contract_no_tool_capable_provider
+  | Contract_missing_required_tool_use
+  | Contract_claim_only_after_owned_task
+  | Contract_needs_execution_progress
+  | Contract_passive_only
+  | Contract_satisfied_completion
+  | Contract_satisfied_execution
+
+val tool_contract_result_to_string : tool_contract_result -> string
+
+val tool_contract_result_of_contract_status :
+  Keeper_contract_classifier.contract_status -> tool_contract_result
+
 type cascade_rotation_attempt =
   { from_cascade : cascade_name
   ; to_cascade : cascade_name
@@ -159,7 +183,7 @@ type t =
   ; canonical_tools : string list
   ; unexpected_tools : string list
   ; tools_used : string list
-  ; tool_contract_result : string
+  ; tool_contract_result : tool_contract_result
   ; tool_surface : tool_surface
   ; sandbox_kind : Keeper_types.sandbox_profile
   ; sandbox_root : string option

--- a/lib/keeper/keeper_run_tools.ml
+++ b/lib/keeper/keeper_run_tools.ml
@@ -25,7 +25,8 @@ type hook_accumulator =
   ; mutable tool_overlay : Agent_sdk.Tool_op.t
   ; mutable tool_surface : tool_surface_metrics
   ; mutable requested_tool_names : string list
-  ; mutable receipt_tool_contract_result : string
+  ; mutable receipt_tool_contract_result :
+      Keeper_execution_receipt.tool_contract_result
   }
 
 (** Immutable snapshot of hook outputs after OAS execution completes. *)
@@ -39,7 +40,8 @@ type hook_outputs =
   ; out_tool_overlay : Agent_sdk.Tool_op.t
   ; out_tool_surface : tool_surface_metrics
   ; out_requested_tool_names : string list
-  ; out_receipt_tool_contract_result : string
+  ; out_receipt_tool_contract_result :
+      Keeper_execution_receipt.tool_contract_result
   }
 
 let freeze (acc : hook_accumulator) : hook_outputs =
@@ -214,7 +216,8 @@ let prepare_agent_setup
         ; approval_mode_derived
         }
     ; requested_tool_names = []
-    ; receipt_tool_contract_result = "unknown"
+    ; receipt_tool_contract_result =
+        Keeper_execution_receipt.Contract_unknown
     }
   in
   let agent_ref : Agent_sdk.Agent.t option ref = ref None in
@@ -1024,7 +1027,8 @@ let prepare_agent_setup
   let initial_tool_surface_result =
     if initial_tool_surface.missing_required_tool_names <> []
     then (
-      acc.receipt_tool_contract_result <- "tool_surface_mismatch";
+      acc.receipt_tool_contract_result <-
+        Keeper_execution_receipt.Contract_tool_surface_mismatch;
       initial_tool_surface_blocker
       := Some
            (sdk_error_of_keeper_internal_error
@@ -1039,7 +1043,8 @@ let prepare_agent_setup
     else if
       initial_tool_surface.tool_gate_requested && initial_tool_surface.all_allowed = []
     then (
-      acc.receipt_tool_contract_result <- "no_tool_capable_provider";
+      acc.receipt_tool_contract_result <-
+        Keeper_execution_receipt.Contract_no_tool_capable_provider;
       Prometheus.inc_counter
         Prometheus.metric_empty_tool_universe_observed
         ~labels:

--- a/lib/keeper/keeper_run_tools.mli
+++ b/lib/keeper/keeper_run_tools.mli
@@ -25,7 +25,8 @@ type hook_accumulator =
   ; mutable tool_overlay : Agent_sdk.Tool_op.t
   ; mutable tool_surface : tool_surface_metrics
   ; mutable requested_tool_names : string list
-  ; mutable receipt_tool_contract_result : string
+  ; mutable receipt_tool_contract_result :
+      Keeper_execution_receipt.tool_contract_result
   }
 
 (** Immutable snapshot of hook outputs after OAS execution completes. *)
@@ -39,7 +40,8 @@ type hook_outputs =
   ; out_tool_overlay : Agent_sdk.Tool_op.t
   ; out_tool_surface : tool_surface_metrics
   ; out_requested_tool_names : string list
-  ; out_receipt_tool_contract_result : string
+  ; out_receipt_tool_contract_result :
+      Keeper_execution_receipt.tool_contract_result
   }
 
 val freeze : hook_accumulator -> hook_outputs

--- a/lib/keeper/keeper_turn_helpers.ml
+++ b/lib/keeper/keeper_turn_helpers.ml
@@ -270,7 +270,7 @@ let record_pre_dispatch_terminal_observation
     ; canonical_tools = []
     ; unexpected_tools = []
     ; tools_used = []
-    ; tool_contract_result = "not_dispatched"
+    ; tool_contract_result = Keeper_execution_receipt.Contract_not_dispatched
     ; tool_surface = pre_dispatch_tool_surface
     ; sandbox_kind = Keeper_execution_receipt.sandbox_kind_of_meta meta
     ; sandbox_root = Some (Keeper_sandbox.host_root_abs_of_meta ~config meta)

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -1034,7 +1034,8 @@ let test_keeper_zombie_field_contracts () =
       canonical_tools = [ "Read" ];
       unexpected_tools = [];
       tools_used = [ "Read" ];
-      tool_contract_result = "satisfied";
+      tool_contract_result =
+        Masc_mcp.Keeper_execution_receipt.Contract_satisfied_completion;
       tool_surface =
         {
           (* WORKAROUND: previously "unified" — invalid string never

--- a/test/test_dashboard_execution.ml
+++ b/test/test_dashboard_execution.ml
@@ -455,7 +455,8 @@ let create_keeper env sw config name =
 let append_execution_receipt
     ?(outcome : Lib.Keeper_execution_receipt.outcome_kind = `Ok)
     ?(terminal_reason_code = "completed")
-    ?(tool_contract_result = "satisfied")
+    ?(tool_contract_result : Lib.Keeper_execution_receipt.tool_contract_result =
+      Contract_satisfied_completion)
     ?(stop_reason = Some Lib.Cascade_runner.Completed)
     config ~keeper_name =
   let meta =
@@ -839,7 +840,7 @@ let test_dashboard_execution_queue_surfaces_keeper_runtime_trust () =
             append_execution_receipt config ~keeper_name:"sangsu"
               ~outcome:`Error
               ~terminal_reason_code:"required_tool_use_unsatisfied"
-              ~tool_contract_result:"violated"
+              ~tool_contract_result:Contract_violated
               ~stop_reason:None;
             let execution_json =
               Lib.Dashboard_execution.json

--- a/test/test_dashboard_goals.ml
+++ b/test/test_dashboard_goals.ml
@@ -106,7 +106,8 @@ let append_keeper_receipt
     ?(observed_tools = [ "keeper_fs_read" ])
     ?(canonical_tools = [ "keeper_fs_read" ])
     ?(tools_used = [ "keeper_fs_read" ])
-    ?(tool_contract_result = "satisfied")
+    ?(tool_contract_result : Keeper_execution_receipt.tool_contract_result =
+      Contract_satisfied_completion)
     ?(tool_requirement = Keeper_agent_tool_surface.Required)
     ?(cascade_outcome : Keeper_execution_receipt.cascade_outcome =
       Cascade_completed) (config : Coord.config)
@@ -844,7 +845,7 @@ let test_goal_detail_uses_receipt_disposition_for_required_tool_failure () =
    | Ok () -> ()
    | Error err -> fail ("write_meta failed: " ^ err));
   append_keeper_receipt ~reported_tools:[] ~observed_tools:[] ~canonical_tools:[]
-    ~tools_used:[] ~tool_contract_result:"missing_required_tool_use" config meta;
+    ~tools_used:[] ~tool_contract_result:Contract_missing_required_tool_use config meta;
   match Dashboard_goals.goal_detail_json ~config ~goal_id:goal.id with
   | Error msg -> fail msg
   | Ok json ->
@@ -1079,7 +1080,7 @@ let test_goal_detail_derives_attention_from_receipt_disposition () =
    | Ok () -> ()
    | Error err -> fail ("write_meta failed: " ^ err));
   append_keeper_receipt
-    ~tool_contract_result:"needs_execution_progress"
+    ~tool_contract_result:Contract_needs_execution_progress
     config meta;
   match Dashboard_goals.goal_detail_json ~config ~goal_id:goal.id with
   | Error msg -> fail msg

--- a/test/test_dashboard_keeper_routes.ml
+++ b/test/test_dashboard_keeper_routes.ml
@@ -585,7 +585,10 @@ let seed_agent_file ?(agent_type = "worker") ?(capabilities = []) config agent_n
   Masc_mcp.Coord.write_json config agent_file (Masc_domain.agent_to_yojson agent)
 ;;
 
-let append_execution_receipt ?(tool_contract_result = "satisfied")
+let append_execution_receipt
+    ?(tool_contract_result :
+       Masc_mcp.Keeper_execution_receipt.tool_contract_result =
+      Contract_satisfied_completion)
     ?(tools_used = [ "keeper_fs_read" ])
     ?(cascade_fallback_applied = true)
     ?(cascade_outcome : Masc_mcp.Keeper_execution_receipt.cascade_outcome =
@@ -1346,7 +1349,7 @@ let test_composite_routes_surface_runtime_recommended_actions () =
     run_curl_post ~body:"{}" ~token:admin_token ~port ~path:boot_path ()
   in
   require_status "boot route registers keeper before composite read" 200 boot_result;
-  append_execution_receipt ~tool_contract_result:"missing_required_tool_use"
+  append_execution_receipt ~tool_contract_result:Contract_missing_required_tool_use
     ~tools_used:[] config ~keeper_name;
   let path = Printf.sprintf "/api/v1/keepers/%s/composite" keeper_name in
   let result = run_curl_get ~port ~path () in
@@ -1449,7 +1452,7 @@ let test_composite_routes_skip_recent_successful_idle_recovery () =
     run_curl_post ~body:"{}" ~token:admin_token ~port ~path:boot_path ()
   in
   require_status "boot route registers keeper before composite read" 200 boot_result;
-  append_execution_receipt ~tool_contract_result:"satisfied_execution"
+  append_execution_receipt ~tool_contract_result:Contract_satisfied_execution
     ~tools_used:[ "keeper_fs_read" ]
     ~cascade_fallback_applied:false
     ~cascade_outcome:Masc_mcp.Keeper_execution_receipt.Cascade_completed

--- a/test/test_keeper_pause_broadcast.ml
+++ b/test/test_keeper_pause_broadcast.ml
@@ -36,7 +36,8 @@ let mk_tool_surface ?(tool_requirement = Masc_mcp.Keeper_agent_tool_surface.Requ
 let mk_receipt
     ?(outcome : R.outcome_kind = `Error)
     ?(terminal_reason_code = "")
-    ?(tool_contract_result = "satisfied")
+    ?(tool_contract_result : R.tool_contract_result =
+      Contract_satisfied_completion)
     ?(tools_used = [ "Read" ])
     ?(observed_tools = [])
     ?(canonical_tools = [])
@@ -103,23 +104,23 @@ let check_disp label receipt expected_disp expected_reason =
 
 (* === Bug class: tool_contract_result violations must pause_human ====== *)
 
-let violation_variants =
+let violation_variants : (string * R.tool_contract_result) list =
   [
-    "violated";
-    "unknown";
-    "needs_execution_progress";
-    "missing_required_tool_use";
-    "passive_only";
-    "claim_only_after_owned_task";
-    "tool_surface_mismatch";
-    "no_tool_capable_provider";
+    ("violated", Contract_violated);
+    ("unknown", Contract_unknown);
+    ("needs_execution_progress", Contract_needs_execution_progress);
+    ("missing_required_tool_use", Contract_missing_required_tool_use);
+    ("passive_only", Contract_passive_only);
+    ("claim_only_after_owned_task", Contract_claim_only_after_owned_task);
+    ("tool_surface_mismatch", Contract_tool_surface_mismatch);
+    ("no_tool_capable_provider", Contract_no_tool_capable_provider);
   ]
 
 let test_pause_human_for_each_violation () =
   List.iter
-    (fun v ->
+    (fun (label, v) ->
       let r = mk_receipt ~tool_contract_result:v () in
-      check_disp ("violation:" ^ v) r "pause_human"
+      check_disp ("violation:" ^ label) r "pause_human"
         "tool_required_unsatisfied")
     violation_variants
 
@@ -138,7 +139,7 @@ let test_pause_human_for_completion_contract_violation_with_satisfied_inner () =
   let r =
     mk_receipt
       ~terminal_reason_code:"completion_contract_violation:require_tool_use"
-      ~tool_contract_result:"satisfied_completion"
+      ~tool_contract_result:Contract_satisfied_completion
       ~error_kind:(Some (R.error_kind_of_string "agent"))
       ~tools_used:[ "keeper_board_list"; "keeper_stay_silent" ]
       ()
@@ -150,7 +151,7 @@ let test_pause_human_for_completion_contract_violation_other_subclause () =
   let r =
     mk_receipt
       ~terminal_reason_code:"completion_contract_violation:other_subclause"
-      ~tool_contract_result:"satisfied"
+      ~tool_contract_result:Contract_satisfied_completion
       ~tools_used:[ "Read" ] ()
   in
   check_disp "completion_contract_violation:other_subclause" r "pause_human"
@@ -204,7 +205,7 @@ let test_unknown_when_unmapped () =
        variant to reach the same path). *)
     mk_receipt ~outcome:`Ok
       ~cascade_outcome:R.Cascade_not_observed
-      ~tool_contract_result:"satisfied" ()
+      ~tool_contract_result:Contract_satisfied_completion ()
   in
   check_disp "unmapped" r "unknown" "unmapped_cascade_state"
 
@@ -213,7 +214,7 @@ let test_unknown_when_unmapped () =
 let test_pass_for_healthy () =
   let r =
     mk_receipt ~outcome:`Ok ~cascade_outcome:R.Cascade_completed
-      ~tool_contract_result:"satisfied" ~terminal_reason_code:"completed"
+      ~tool_contract_result:Contract_satisfied_completion ~terminal_reason_code:"completed"
       ()
   in
   check_disp "healthy" r "pass" "healthy"
@@ -222,14 +223,14 @@ let test_pass_next_for_cascade_fallback () =
   let r =
     mk_receipt ~cascade_fallback_applied:true
       ~cascade_outcome:R.Cascade_passed_to_next_model
-      ~tool_contract_result:"satisfied" ()
+      ~tool_contract_result:Contract_satisfied_completion ()
   in
   check_disp "cascade_fallback" r "pass_next_model" "cascade_fallback"
 
 let test_fail_open_for_degraded_retry () =
   let r =
     mk_receipt ~degraded_retry_applied:true
-      ~tool_contract_result:"satisfied" ()
+      ~tool_contract_result:Contract_satisfied_completion ()
   in
   check_disp "degraded_retry" r "fail_open_next_cascade" "degraded_retry"
 
@@ -250,7 +251,7 @@ let test_needs_broadcast_predicate () =
 
 let test_each_broadcast_disp_is_reachable () =
   (* pause_human via violation *)
-  let r1 = mk_receipt ~tool_contract_result:"violated" () in
+  let r1 = mk_receipt ~tool_contract_result:Contract_violated () in
   let d1, _ = R.operator_disposition r1 in
   check bool "pause_human reachable" true (R.needs_operator_broadcast d1);
   (* alert_exhausted via terminal_reason_code.  Pre-typing this was driven
@@ -269,7 +270,7 @@ let test_each_broadcast_disp_is_reachable () =
        variant to reach the same path). *)
     mk_receipt ~outcome:`Ok
       ~cascade_outcome:R.Cascade_not_observed
-      ~tool_contract_result:"satisfied" ()
+      ~tool_contract_result:Contract_satisfied_completion ()
   in
   let d3, _ = R.operator_disposition r3 in
   check bool "unknown reachable" true (R.needs_operator_broadcast d3)
@@ -281,7 +282,7 @@ let test_broadcast_payload_carries_turn_diagnostics () =
   let receipt =
     mk_receipt
       ~terminal_reason_code:"completion_contract_violation:require_tool_use"
-      ~tool_contract_result:"missing_required_tool_use"
+      ~tool_contract_result:Contract_missing_required_tool_use
       ~tools_used:[ "keeper_tasks_list"; "keeper_stay_silent" ]
       ~observed_tools:[ "keeper_tasks_list"; "keeper_stay_silent" ]
       ~required_tools:[ "keeper_shell"; "masc_worktree_create" ]


### PR DESCRIPTION
## Summary

Track A typed-enum sweep. Convert `receipt.tool_contract_result` from `string` to a closed `tool_contract_result` sum type (11 variants) defined in `Keeper_execution_receipt`.

- Producer/consumer round-tripped strings (e.g. `\"satisfied\"`, `\"satisfied_completion\"`, `\"violated\"`, `\"missing_required_tool_use\"`) are now compiler-enforced.
- Test fixtures that previously synthesized a producer-never-emitted bare `\"satisfied\"` (without completion/execution discrimination) are forced to pick a real variant — defaulted to `Contract_satisfied_completion` to preserve prior test intent.
- JSON / Prometheus boundary uses `tool_contract_result_to_string`; typed value flows through `Keeper_run_tools.acc.receipt_tool_contract_result`, `Keeper_agent_run.tool_contract_status`, `Keeper_turn_helpers.build_pending_receipt`.

## Variants

| Variant | Old string |
|---|---|
| `Contract_unknown` | `\"unknown\"` |
| `Contract_not_dispatched` | `\"not_dispatched\"` |
| `Contract_violated` | `\"violated\"` |
| `Contract_tool_surface_mismatch` | `\"tool_surface_mismatch\"` |
| `Contract_no_tool_capable_provider` | `\"no_tool_capable_provider\"` |
| `Contract_missing_required_tool_use` | `\"missing_required_tool_use\"` |
| `Contract_claim_only_after_owned_task` | `\"claim_only_after_owned_task\"` |
| `Contract_needs_execution_progress` | `\"needs_execution_progress\"` |
| `Contract_passive_only` | `\"passive_only\"` |
| `Contract_satisfied_completion` | `\"satisfied_completion\"` |
| `Contract_satisfied_execution` | `\"satisfied_execution\"` |

## Rationale

CLAUDE.md §워크어라운드 거부 기준 #2 — substring classifier anti-pattern. The producer enumerates a finite set; consumer match on `List.mem ... [\"violated\"; \"unknown\"; ...]` is exactly the pattern the compiler can enforce instead.

## Architectural Invariant

G3 opacity preserved. New enum contains zero provider literals (`anthropic`, `openai`, `claude`, `gpt`, `gemini`, `sonnet`, `opus`, `haiku`). Pre-existing SDK-boundary references (`gemini_mcp_disabled`, `claude_mcp_config`) in `keeper_agent_run.ml` are unrelated SDK-adapter wiring at the receiving edge, where provider names are permitted.

## Stack

Based on #14663 (`feat/cascade-outcome-typed`).

## Test plan

- [x] `dune build --root . @check` clean
- [ ] CI green
- [ ] G3 grep on diff: 0 hits

🤖 Generated with [Claude Code](https://claude.com/claude-code)