### PR TITLE
fix(specs): cap fallback_count in ItemDegrade — KeeperCascadeRouting TypeOK clean fix

### DIFF
--- a/specs/keeper-state-machine/KeeperCascadeRouting.tla
+++ b/specs/keeper-state-machine/KeeperCascadeRouting.tla
@@ -145,6 +145,7 @@ ItemDegrade(keeper) ==
     /\ keeper_state[keeper] = "Turning"
     /\ selected_item[keeper] /= "none"
     /\ IsHealthy(keeper, selected_item[keeper])
+    /\ fallback_count[keeper] < MaxFallbacks
     /\ LET item == selected_item[keeper]
            k_item == <<keeper, item>>
            cf == consecutive_failures[k_item] + 1


### PR DESCRIPTION
## 요약

`KeeperCascadeRouting.tla` clean spec이 5/8 도입 (#14196) 이후 main에서 계속 TLC exit=12 (Invariant TypeOK violated)로 실패하고 있었음. ItemDegrade가 `fallback_count` cap을 가드하지 않아 state 11에서 `fallback_count[k1] = 4 > MaxFallbacks (3)` 발생 → TypeOK의 `fallback_count \in [Keepers -> 0..MaxFallbacks]` 깨짐.

## 근본 원인

| Action | fallback_count cap guard |
|---|---|
| `GroupFallback` | `fallback_count[keeper] < MaxFallbacks` 있음 |
| `ItemDegrade` | **없음** — `@ + 1` 무제한 증가 |

`fallback_count`는 한 턴 내 fallback 시도 횟수를 cap하는 의미이므로, ItemDegrade도 같은 가드를 필요로 함.

## 변경

```tla
ItemDegrade(keeper) ==
    /\ keeper_state[keeper] = "Turning"
    /\ selected_item[keeper] /= "none"
    /\ IsHealthy(keeper, selected_item[keeper])
+   /\ fallback_count[keeper] < MaxFallbacks
    /\ LET item == selected_item[keeper]
       ...
```

Cap 도달 시 `ItemSuccess` (selected_item 여전히 Healthy) 또는 `KeeperRestart`가 enabled하므로 deadlock 없음. `CHECK_DEADLOCK FALSE`이기도 함.

## 검증 (local TLC 1.8.0, worktree)

**Clean**:
```
Model checking completed. No error has been found.
665211 states generated, 90601 distinct states found
exit=0
```

**Buggy**:
```
Error: Invariant KeeperNeverBlockedByCascade is violated.
2204 states generated, 590 distinct states found
exit=12 (intended)
```

TLA+ Bug Model 패턴의 양 방향 모두 holds: clean must pass, buggy must violate. RFC-0041 L1 Proactive Routing spec의 유효성이 복원됨.

## 왜 지금까지 못 잡혔나

1. PR #14196 (5/8) body는 "Clean: 407 states, No error"라고 보고했으나 실측 1818 states에서 state 11 fault. **MEMORY §feedback_keeper_hallucinated_audit_cascade**의 정량 클레임 fabrication 패턴.
2. CI의 `Detect Changed Surfaces`가 후속 PR을 모두 skip → 12:59 main run에서야 가시화.

## Workaround Rejection Bar self-check

- [ ] telemetry-as-fix → No (실제 spec 수정)
- [ ] string/substring 분류기 추가 → No
- [ ] N-of-M 패치 → No (단일 site, structural fix)
- [ ] catch-all 추가 → No
- [ ] cap/cooldown/dedup/repair으로 symptom 억제 → No (cap은 spec 의도 그대로, 누락된 가드 복원)
- [ ] test backdoor → No
- [ ] codemod 미수행 N번 fix → No

근본 fix.

## 후속

- (별개) `KNOWN_FAILURES`에 `KeeperCascadeRouting` 추가하려던 임시 회피는 채택하지 않음 — RFC-0041 L1 Proactive Routing의 *수학적 정의* 자체가 검증되지 않는 상태로 살게 됨.
- (별개) `Detect Changed Surfaces` 정책 검토: spec violation 상태에서 후속 머지가 TLA job을 skip하는 게 의도된 design인지 확인 필요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)