### PR TITLE
feat(cascade): add RunPod Qwen3.6-27B-FP8 vLLM provider

### DIFF
--- a/config/cascade.toml
+++ b/config/cascade.toml
@@ -134,6 +134,21 @@ class = "local_27b"
 # headers natively. All other capability flags default to false.
 tolerates-bound-actor-fallback = true
 
+[providers.runpod_qwen]
+display-name = "RunPod Qwen3.6-27B vLLM"
+protocol = "openai-http"
+endpoint = "https://57c7602uqm0t4w-8000.proxy.runpod.net/v1"
+
+[providers.runpod_qwen.liveness]
+class = "local_27b"
+
+[providers.runpod_qwen.capabilities]
+# RunPod-hosted vLLM serving Qwen3.6-27B-FP8 on 2× RTX 6000 Ada.
+# OpenAI-compatible /v1 endpoint with native tool_calls parser
+# (`--tool-call-parser qwen3_coder`). Self-hosted, no per-token cost.
+# Same bound-actor fallback semantics as Ollama.
+tolerates-bound-actor-fallback = true
+
 # ── Layer 2: Models ────────────────────────────────────────────
 
 [models.codex-spark]
@@ -186,6 +201,12 @@ max-context = 128000
 tools-support = true
 streaming = true
 
+[models.qwen3-6-27b-fp8]
+api-name = "Qwen/Qwen3.6-27B-FP8"
+max-context = 131072
+tools-support = true
+streaming = true
+
 # ── Layer 3: Provider×Model Bindings ───────────────────────────
 #
 # `max-concurrent` is REQUIRED (RFC-0058 §3.4). Defaults reflect
@@ -229,6 +250,13 @@ max-concurrent = 2
 [glm-coding.glm-flashx]
 is-default = false
 max-concurrent = 2
+
+[runpod_qwen.qwen3-6-27b-fp8]
+# vLLM is configured with VLLM_MAX_NUM_SEQS=4 — 4 concurrent
+# keeper turns at 128k context per sequence. Self-hosted on
+# 2× RTX 6000 Ada (96GB VRAM total); no marginal token cost.
+is-default = true
+max-concurrent = 4
 
 # ── Layer 4: Aliases (per-use overrides) ───────────────────────
 #


### PR DESCRIPTION
## Summary
- Register `runpod_qwen` provider (`openai-http`, liveness `local_27b`) pointing at RunPod pod `57c7602uqm0t4w` serving `Qwen/Qwen3.6-27B-FP8` on 2× RTX 6000 Ada (96GB VRAM total).
- Add `qwen3-6-27b-fp8` model (131072 max-context, tools-support) and `runpod_qwen.qwen3-6-27b-fp8` binding with `max-concurrent=4` to match `VLLM_MAX_NUM_SEQS`.
- **No tier members modified** — provider is registered but no keeper traffic is routed to it yet. Follow-up PR will add it to a tier's `members` list when ready to go live.

## Why
masc-mcp의 keeper LLM 백엔드용 RunPod vLLM pod를 cascade 시스템에 등록. Qwen3.6-27B는 Qwen3.6 family 중 agentic/coding 벤치(SWE-bench, Terminal-Bench, Claw-Eval Pass³)에서 35B-A3B MoE를 +4~+20점 상회 — keeper의 tool-calling 워크로드 적합. FP8 양자화는 RTX 6000 Ada가 텐서 코어로 하드웨어 가속.

## Verification
Endpoint 라이브 검증 완료 (2026-05-11):

```
$ curl https://57c7602uqm0t4w-8000.proxy.runpod.net/v1/models
→ {"data":[{"id":"Qwen/Qwen3.6-27B-FP8","max_model_len":131072,...}]}

$ curl .../v1/chat/completions -d '{... "tools": [...] ...}'
→ finish_reason: "tool_calls"
   tool_calls: [{"function":{"name":"get_weather","arguments":"{...}"}}]
```

`--tool-call-parser qwen3_coder` 활성 확인 → keeper 의 OAS `tool_call_replay_harness` 가 기대하는 구조화 `tool_calls` 배열 정확히 반환.

## Files changed
- `config/cascade.toml`: +28 lines (provider + model + binding sections)

## Test plan
- [ ] CI passes (TOML parse + Cascade_config 로드 테스트)
- [ ] 로컬 dune build / test
- [ ] Sanity: `Cascade_config` 가 새 provider/model 인식하는지 단위 테스트 또는 REPL 확인
- [ ] (별도 PR) tier 멤버 추가 후 keeper traffic 검증

## Follow-up
1. **Tier 라우팅 PR**: `[tier.tier_medium]` 또는 신규 `[tier.tier_local_27b]` 의 `members` 에 `"runpod_qwen.qwen3-6-27b-fp8"` 추가
2. **Auth tightening**: 현재 vLLM 엔드포인트는 인증 없음. 운영 라이브 직전 `--api-key` 설정 + `[providers.runpod_qwen.credentials]` 블록 추가
3. **MTP 활성화**: `--speculative-config '{"method":"qwen3_next_mtp","num_speculative_tokens":2}'` 로 decode 1.5–2× 가속 (선택)
4. **URL 안정화**: pod-ID-tied URL 대신 env-var substitution 또는 RunPod load balancer 사용 검토