### PR TITLE
ci(tla): always run TLA+ checks on main pushes — escape path-scope gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -932,7 +932,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 40
     needs: [pr-live-gate, changes]
-    if: ${{ always() && !cancelled() && needs.pr-live-gate.outputs.run_heavy == 'true' && needs.changes.result == 'success' && needs.changes.outputs.tla == 'true' }}
+    # PR mode: stay path-scoped (tla=true only when specs/keeper/oas/Makefile change).
+    # main push / schedule / workflow_dispatch: ignore path scope and always run,
+    # so a spec violation introduced by a non-tla-path PR (e.g. dashboard-only
+    # Draft via admin-merge fast-track) is detected on the next main run rather
+    # than persisting silently. See #14668 root cause analysis.
+    if: ${{ always() && !cancelled() && needs.pr-live-gate.outputs.run_heavy == 'true' && needs.changes.result == 'success' && (needs.changes.outputs.tla == 'true' || needs.pr-live-gate.outputs.live_state == 'NON_PR') }}
 
     steps:
       - name: Checkout


### PR DESCRIPTION
## 요약

#14668 root cause 분석에서 드러난 정책 gap을 닫는 minimal change. `tla-specs` job을 PR 모드에서는 기존 path-scope 그대로 두고, **main push / schedule / workflow_dispatch (NON_PR live_state) 에서는 무조건 실행**하도록 1줄 조건 추가.

## 문제

`KeeperCascadeRouting.tla` invariant violation이 PR #14196 (5/8) 머지로 도입된 후 5/12까지 4일간 main에 silently 남아 있었음. tla-specs job 조건이 두 게이트로 차단:

| 게이트 | 효과 |
|---|---|
| `run_heavy=='true'` | Draft PR은 false → TLA 안 돔 |
| `changes.outputs.tla=='true'` | path-scoped: `specs/.tla\|cfg`, `lib/keeper/`, `lib/oas_.*\.ml`, `Makefile`만 매치 |

5/8~5/12 399 main commits 중:
- **118 (30%)** 만 TLA 트리거 매치
- 나머지 **281 (70%)** 는 spec 검증 우회
- admin-merge fast-track Draft 패턴은 매치되는 PR도 PR 단계에서 우회

결과: spec violation 검출이 stochastic. 30% × non-Draft × subsequent → 거의 0.

## 변경

```yaml
# before
if: ${{ ... && needs.changes.outputs.tla == 'true' }}

# after
if: ${{ ... && (needs.changes.outputs.tla == 'true' || needs.pr-live-gate.outputs.live_state == 'NON_PR') }}
```

`pr-live-gate` line 73-77에서 non-PR 이벤트는 `live_state=NON_PR, run_heavy=true`. 즉:
- **PR mode**: 기존 path-scope 그대로 (변화 없음)
- **main push / schedule / workflow_dispatch**: path-scope 우회, 항상 실행

## 비용 분석

| 항목 | 평가 |
|---|---|
| Concurrency | `cancel-in-progress: true` on push (ci.yml line 23) — 연속 main push는 outdated CI supersede |
| Spec runtime | `TLC_STOP=180` per spec. 평균 clean run < 5분 (대부분 spec 수초, heavy spec 3분 cap) |
| Job timeout | 40분 (변화 없음) |
| PR critical path | 변경 없음 — Draft fast-track 그대로 동작 |

## 왜 Required check 승격이 아닌가

(B) Required check 승격은 branch protection 변경 + admin-merge fast-track 패턴 (MEMORY §feedback_masc_mcp_admin_merge_fast_track) 과 충돌. 별도 정책 결정 필요. 이번 PR은 admin-merge fast-track을 *허용한 채로* spec violation을 main에서 가시화하는 minimal escape hatch.

## 후속 (별도)

- (옵션) TLA fail 시 GitHub status badge / Slack alert (가시화 강화)
- (옵션) Required check 승격 RFC (Draft fast-track 정책과 충돌 검토 포함)
- (옵션) `spec_refs` axis도 동일 패턴 적용 검토

## Workaround Rejection Bar self-check

- [ ] telemetry-as-fix → No (실제 검증 빈도 증가)
- [ ] string/substring 분류기 → No
- [ ] N-of-M 패치 → No
- [ ] catch-all 추가 → No
- [ ] cap/cooldown/dedup/repair → No (path-scope 우회는 의도된 정책 전환)
- [ ] test backdoor → No
- [ ] codemod 미수행 → No

근본 정책 변경. 단일 게이트의 의도된 design을 명시적으로 변경.

🤖 Generated with [Claude Code](https://claude.com/claude-code)