### PR TITLE
fix(main-blocker): close RFC-0066 Phase 1 cycle + missing record field

### DIFF
--- a/lib/cascade/cascade_catalog_runtime.ml
+++ b/lib/cascade/cascade_catalog_runtime.ml
@@ -135,6 +135,11 @@ let install_snapshot_for_tests ~source_path ~profile_names =
       mtime;
       validated_at = Unix.gettimeofday ();
       profiles;
+      (* Test helper does not exercise default-profile resolution; an
+         empty string keeps the snapshot well-typed while preserving
+         the helper's "install these profile names verbatim" contract.
+         Field added by RFC-0066 Phase 1 (PR #14652). *)
+      default_profile_name = "";
     }
   in
   with_cache_lock (fun () ->
@@ -931,8 +936,22 @@ let require_snapshot ?sw ?net ?clock () =
       in
       Error detail
 
-let normalize_declared_name raw =
-  Keeper_cascade_profile.normalize_declared_name raw
+(* RFC-0066 cycle break: inlined the [Keeper_cascade_profile.normalize_declared_name]
+   body to avoid the [Keeper_cascade_profile → Cascade_catalog_runtime →
+   Keeper_cascade_profile] cycle that RFC-0066 Phase 1 (PR #14652)
+   completed by routing [catalog_names] through this module.
+
+   The body uses only [Cascade_routes] primitives, which this module
+   already depends on (see [Cascade_routes.configured_route_targets]
+   above), so inlining here is dependency-neutral. *)
+let normalize_declared_name (raw : string) : string =
+  let trimmed = String.trim raw in
+  if String.equal trimmed "" then
+    Cascade_routes.cascade_name_for_use Cascade_routes.Keeper_turn
+  else
+    match Cascade_routes.logical_use_of_string_opt trimmed with
+    | Some use -> Cascade_routes.cascade_name_for_use use
+    | None -> trimmed
 
 let lookup_active_profile ?sw ?net ?clock raw_name =
   match require_snapshot ?sw ?net ?clock () with

--- a/lib/cascade/cascade_ref.ml
+++ b/lib/cascade/cascade_ref.ml
@@ -50,6 +50,18 @@ type cascade_ref = {
   item : string option;
 }
 
+(** Catalog-aware cascade name after point-of-use runtime normalization.
+
+    Moved here from [Keeper_cascade_profile] to break the circular
+    dependency [Cascade_strategy → Keeper_cascade_profile →
+    Cascade_catalog_runtime → Cascade_config → Cascade_strategy]
+    introduced by RFC-0066 Phase 1 (PR #14652).  Canonicalization
+    logic still lives in [Keeper_cascade_profile.runtime_name_of_string];
+    only the type and its trivial unwrap stay at this leaf. *)
+type runtime_name = Runtime_name of string
+
+let runtime_name_to_string (Runtime_name value) = value
+
 (** Logical use cases for cascade routing.  Moved here from [Cascade_routes]
     to break the circular dependency with [Keeper_cascade_profile]. *)
 type logical_use =

--- a/lib/cascade/cascade_ref.mli
+++ b/lib/cascade/cascade_ref.mli
@@ -46,6 +46,14 @@ type cascade_ref = {
   item : string option;
 }
 
+(** Catalog-aware cascade name after point-of-use runtime normalization.
+    Lives at this leaf module so [Cascade_strategy] can carry it without
+    pulling in [Keeper_cascade_profile] (which depends on
+    [Cascade_catalog_runtime]). *)
+type runtime_name = Runtime_name of string
+
+val runtime_name_to_string : runtime_name -> string
+
 (** {1 JSON serialization} *)
 
 val traversal_strategy_to_json : traversal_strategy -> Yojson.Safe.t

--- a/lib/cascade/cascade_strategy.ml
+++ b/lib/cascade/cascade_strategy.ml
@@ -6,11 +6,11 @@ type signal_ctx = {
   now : float;
   rand_int : int -> int;
   keeper_name : string;
-  cascade_name : Keeper_cascade_profile.runtime_name;
+  cascade_name : Cascade_ref.runtime_name;
 }
 
 let signal_cascade_name ctx =
-  Keeper_cascade_profile.runtime_name_to_string ctx.cascade_name
+  Cascade_ref.runtime_name_to_string ctx.cascade_name
 
 (* ── Scoring parameters (configurable via TOML / env vars) ─────────
 

--- a/lib/cascade/cascade_strategy.mli
+++ b/lib/cascade/cascade_strategy.mli
@@ -95,7 +95,7 @@ type signal_ctx = {
 
       @since 0.9.7 *)
 
-  cascade_name : Keeper_cascade_profile.runtime_name;
+  cascade_name : Cascade_ref.runtime_name;
   (** Cascade identifier (the [<name>] in [<name>_models]).  Used by
       [Sticky] and [Round_robin] to scope their state.  Required for
       stateful kinds; tolerated as [Runtime_name "" ] for stateless kinds.

--- a/lib/keeper/keeper_cascade_profile.ml
+++ b/lib/keeper/keeper_cascade_profile.ml
@@ -38,9 +38,13 @@ let logical_use_of_string_opt = Cascade_routes.logical_use_of_string_opt
 let configured_route_targets = Cascade_routes.configured_route_targets
 let cascade_name_for_use = Cascade_routes.cascade_name_for_use
 
-type runtime_name = Runtime_name of string
+(* RFC-0066 cycle break: [runtime_name] moved to [Cascade_ref] (leaf).
+   Manifest alias preserved here so every caller written as
+   [Keeper_cascade_profile.Runtime_name x] / [.runtime_name_to_string]
+   keeps compiling unchanged. *)
+type runtime_name = Cascade_ref.runtime_name = Runtime_name of string
 
-let runtime_name_to_string (Runtime_name value) = value
+let runtime_name_to_string = Cascade_ref.runtime_name_to_string
 
 let catalog_entries ?config_path () =
   let path_opt =

--- a/lib/keeper/keeper_cascade_profile.mli
+++ b/lib/keeper/keeper_cascade_profile.mli
@@ -57,8 +57,10 @@ val cascade_name_for_use : ?config_path:string -> logical_use -> string
 val configured_route_targets : ?config_path:string -> unit -> string list
 (** Unique non-empty profile names referenced from [routes]. *)
 
-type runtime_name = Runtime_name of string
-(** Catalog-aware cascade name after point-of-use runtime normalization. *)
+type runtime_name = Cascade_ref.runtime_name = Runtime_name of string
+(** Catalog-aware cascade name after point-of-use runtime normalization.
+    Manifest alias of {!Cascade_ref.runtime_name} (leaf module) so
+    [Cascade_strategy] can carry the type without inducing a cycle. *)
 
 val runtime_name_to_string : runtime_name -> string
 val runtime_name_of_string : string -> runtime_name


### PR DESCRIPTION
## Why

PR #14652 (RFC-0066 Phase 1, admin-merge fast-track 7h ago) left main broken:

1. **Missing record field** — new mandatory \`snapshot.default_profile_name : string\` not populated in \`install_snapshot_for_tests\` (\`cascade_catalog_runtime.ml:132-138\`). Build error: \`Some record fields are undefined: default_profile_name\`.
2. **Module dependency cycle** — Phase 1 typed-name refactor introduced
   \`Cascade_strategy → Keeper_cascade_profile → Cascade_catalog_runtime → Cascade_config → Cascade_strategy\`
   plus inner cycle \`Keeper_cascade_profile ↔ Cascade_catalog_runtime\`.

\`dune build\` fails on a clean \`origin/main\` checkout. Detected during a follow-up worktree build (\`refactor/erase-ollama-cfg-leak\`). Memory \`feedback_main_blocker_chain_4x_session.md\` records this as the 5th occurrence.

## What

Structural fix, not a patch:

- Move \`runtime_name = Runtime_name of string\` from \`Keeper_cascade_profile\` to leaf module \`Cascade_ref\`. **Manifest alias** \`type runtime_name = Cascade_ref.runtime_name = Runtime_name of string\` preserved in \`Keeper_cascade_profile\`, so every caller (\`Keeper_cascade_profile.Runtime_name x\`, \`runtime_name_to_string\`) keeps compiling unchanged. 15+ call sites in lib/test untouched.
- Canonicalization helper \`runtime_name_of_string\` (depends on \`catalog_names\`) stays in \`Keeper_cascade_profile\` — only the type leaves.
- Inline \`normalize_declared_name\` body inside \`Cascade_catalog_runtime\` using \`Cascade_routes\` primitives the module already depends on, removing the re-export shim that completed the inner cycle.
- Add \`default_profile_name = \"\"\` to the test-helper record literal with comment explaining the helper does not exercise default-profile resolution.

## Verification

- ✅ \`dune build --root .\` green (origin/main currently fails)
- ✅ \`test_cascade_catalog_runtime\` 23/23
- ✅ \`test_cascade_strategy\` 71/71
- ✅ \`ocamlformat --check\` clean on all 7 modified files
- ✅ \`runtime_name\` caller surface unchanged across 15+ call sites (manifest alias)

\`test_keeper_unified\` requires a worktree-local \`config/cascade.json\` fixture not present in fresh checkouts; CI is authoritative.

## Risk

- Diff is +54/-9 across 7 files. Manifest alias keeps the public surface bit-identical.
- No behavior change: \`normalize_declared_name\` body inlined verbatim, type identity preserved through alias, record literal default chosen so test helper semantics (\"install these profile names verbatim\") are unaffected.

RFC-WAIVED: build-blocker fix, no subsystem expansion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)