### PR TITLE
docs(rfc): renumber goal-scope atomicity RFC → RFC-0067 (resolve 0057 collision)

### DIFF
--- a/docs/rfc/RFC-0067-goal-scope-observation-claim-atomicity.md
+++ b/docs/rfc/RFC-0067-goal-scope-observation-claim-atomicity.md
@@ -1,9 +1,9 @@
-# RFC-0057: Goal-Scope Observation→Claim Atomicity
+# RFC-0067: Goal-Scope Observation→Claim Atomicity
 
 **Issue**: #13738
 **Status**: Draft
 **Author**: Claude (agent)
-**Date**: 2026-05-09
+**Date**: 2026-05-09 (renumbered 2026-05-11 from RFC-0057 — number collided with RFC-0057-tool-descriptor-codegen.md, which was authored ~30 minutes earlier the same day and now has implementation PRs #14396/#14400/#14405/#14412/#14416/#14417/#14421 merged on main. The codegen RFC keeps the 0057 slot per established-precedent convention.)
 
 ## 1. Problem
 


### PR DESCRIPTION
## Summary

Pure file rename — resolve long-standing RFC-0057 number collision.

Two RFCs occupied the same number on origin/main:

| File | Status |
|------|--------|
| `docs/rfc/RFC-0057-tool-descriptor-codegen.md` | 7 impl PRs merged (#14396/#14400/#14405/#14412/#14416/#14417/#14421) |
| `docs/rfc/RFC-0057-goal-scope-observation-claim-atomicity.md` | Draft, no impl |

Codegen RFC retains 0057 (more dependent state, harder to rename).  
Goal-scope RFC moves to next free slot **RFC-0067** (0058–0066 all taken).

## Cross-reference audit

`rg "RFC-0057-goal-scope" .` → 1 match (file's own title line). No external references in docs/, planning/, lib/, or test/. Clean rename.

## What this is NOT

- Not an implementation change — file rename + self-reference update only
- Not a content edit — RFC body unchanged (2 lines diff: title + date footnote)

## Test plan

- [x] `git mv` reports rename similarity 93% (only title + date changed)
- [x] No external references to update (cross-ref grep clean)

## Refs

- Memory `feedback_rfc_number_reservation_needed` (2026-05-09): warns this collision pattern recurs without a reservation ledger. Ledger is a separate RFC candidate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)