### PR TITLE
feat(cascade): RFC-0066 Phase 3+4a — snapshot-first capability lint

### DIFF
--- a/lib/cascade/cascade_catalog_runtime.ml
+++ b/lib/cascade/cascade_catalog_runtime.ml
@@ -32,6 +32,7 @@ type profile_build = {
   cli_max_concurrent : int option;
   candidates : candidate_runtime list;
   probes : candidate_probe list;
+  required_capability_profile : string option;
 }
 
 type profile_snapshot = profile_build
@@ -127,6 +128,7 @@ let install_snapshot_for_tests ~source_path ~profile_names =
              cli_max_concurrent = None;
              candidates = [];
              probes = [];
+             required_capability_profile = None;
            })
   in
   let snapshot =
@@ -616,6 +618,18 @@ let validate_profile_static ~config_path name : (profile_build, profile_rejectio
               probes = [];
             }
         else
+          let required_capability_profile =
+            match Cascade_config_loader.load_catalog ~config_path with
+            | Ok entries ->
+                List.find_map
+                  (fun (entry : Cascade_config_loader.catalog_entry) ->
+                    if String.equal entry.name name then
+                      Some entry.required_capability_profile
+                    else None)
+                  entries
+                |> Option.value ~default:None
+            | Error _ -> None
+          in
           Ok
             {
               name;
@@ -627,6 +641,7 @@ let validate_profile_static ~config_path name : (profile_build, profile_rejectio
               cli_max_concurrent;
               candidates;
               probes = profile_probes candidates;
+              required_capability_profile;
             }
 
 let runtime_required_profiles ~config_path =

--- a/lib/cascade/cascade_catalog_runtime.ml
+++ b/lib/cascade/cascade_catalog_runtime.ml
@@ -550,7 +550,8 @@ let rejection_of_path ~config_path ~attempted_mtime ~checked_at
 let active_source_state ~config_path =
   Cascade_toml_materializer.source_state ~config_path
 
-let validate_profile_static ~config_path name : (profile_build, profile_rejection) result =
+let validate_profile_static ~config_path ~required_capability_profile name
+    : (profile_build, profile_rejection) result =
   let weighted_entries =
     Cascade_config_loader.load_profile_weighted ~config_path ~name
   in
@@ -618,18 +619,6 @@ let validate_profile_static ~config_path name : (profile_build, profile_rejectio
               probes = [];
             }
         else
-          let required_capability_profile =
-            match Cascade_config_loader.load_catalog ~config_path with
-            | Ok entries ->
-                List.find_map
-                  (fun (entry : Cascade_config_loader.catalog_entry) ->
-                    if String.equal entry.name name then
-                      Some entry.required_capability_profile
-                    else None)
-                  entries
-                |> Option.value ~default:None
-            | Error _ -> None
-          in
           Ok
             {
               name;
@@ -739,10 +728,33 @@ let validate_path_result ?sw ?net ~config_path () =
                 required_default_profile;
             ]
         in
+        (* RFC-0066 Phase 3: hoist [load_catalog] out of the per-profile
+           validator so that [required_capability_profile] hints are
+           read once per [validate_path] regardless of how many profiles
+           are being validated. load_catalog has TOML materialization +
+           fallback-cycle metric/warn side-effects; reloading per
+           profile inflated startup work. *)
+        let required_capability_profile_lookup =
+          match Cascade_config_loader.load_catalog ~config_path with
+          | Ok entries ->
+              List.fold_left
+                (fun acc (entry : Cascade_config_loader.catalog_entry) ->
+                  (entry.name, entry.required_capability_profile) :: acc)
+                []
+                entries
+          | Error _ -> []
+        in
         let built_profiles, statically_rejected_profiles =
           List.fold_left
             (fun (ok_acc, err_acc) name ->
-              match validate_profile_static ~config_path name with
+              let required_capability_profile =
+                List.assoc_opt name required_capability_profile_lookup
+                |> Option.value ~default:None
+              in
+              match
+                validate_profile_static ~config_path
+                  ~required_capability_profile name
+              with
               | Ok profile -> (profile :: ok_acc, err_acc)
               | Error rejection -> (ok_acc, rejection :: err_acc))
             ([], [])

--- a/lib/cascade/cascade_catalog_runtime.mli
+++ b/lib/cascade/cascade_catalog_runtime.mli
@@ -40,11 +40,13 @@ type profile_build = {
   probes : candidate_probe list;
   required_capability_profile : string option;
       (** RFC-0066 Phase 3 — profile-scoped capability lint hint, copied
-          from the legacy [catalog_entry] at validation time. Legacy
-          schema only: the declarative [provider]/[model]/[profile]
-          format does not expose this field, so callers see [None] under
-          fully-declarative configs. [Cascade_catalog_validator] will
-          read this in Phase 4 instead of re-invoking [load_catalog]. *)
+          from the legacy [catalog_entry] at validation time. The legacy
+          flat-JSON schema exposes this via the [<name>_required_capability_profile]
+          key; the RFC-0058 declarative namespaces ([providers], [models],
+          [tier], [tier-group] + provider binding tables) do not carry
+          this field, so callers see [None] under fully-declarative
+          configs. [Cascade_catalog_validator] consumes it via snapshot
+          read in Phase 4 instead of re-invoking [load_catalog]. *)
 }
 
 type snapshot = {

--- a/lib/cascade/cascade_catalog_runtime.mli
+++ b/lib/cascade/cascade_catalog_runtime.mli
@@ -38,6 +38,13 @@ type profile_build = {
   cli_max_concurrent : int option;
   candidates : candidate_runtime list;
   probes : candidate_probe list;
+  required_capability_profile : string option;
+      (** RFC-0066 Phase 3 — profile-scoped capability lint hint, copied
+          from the legacy [catalog_entry] at validation time. Legacy
+          schema only: the declarative [provider]/[model]/[profile]
+          format does not expose this field, so callers see [None] under
+          fully-declarative configs. [Cascade_catalog_validator] will
+          read this in Phase 4 instead of re-invoking [load_catalog]. *)
 }
 
 type snapshot = {

--- a/lib/cascade_catalog_validator.ml
+++ b/lib/cascade_catalog_validator.ml
@@ -228,23 +228,57 @@ let capability_mismatch_issues ~profile ~required_profile model_specs =
           };
         ]
 
+(* RFC-0066 Phase 4: prefer the validated runtime snapshot for
+   [required_capability_profile] and [weighted_entries] when the active
+   snapshot's [source_path] matches the caller-provided [config_path].
+   Falls through to the legacy reader when the snapshot is unrelated
+   (fixture tests with explicit path) or unavailable (early boot). *)
+let snapshot_profile_for ~config_path ~profile =
+  match Cascade_catalog_runtime.inspect_active () with
+  | Error _ -> None
+  | Ok state ->
+    let snap_opt =
+      match state with
+      | Cascade_catalog_runtime.Validated snapshot -> Some snapshot
+      | Validated_with_rejections { snapshot; _ } -> Some snapshot
+      | Serving_last_known_good { snapshot; _ } -> Some snapshot
+    in
+    (match snap_opt with
+     | Some snapshot when String.equal snapshot.source_path config_path ->
+       List.find_opt
+         (fun (p : Cascade_catalog_runtime.profile_build) ->
+           String.equal p.name profile)
+         snapshot.profiles
+     | _ -> None)
+
 let diagnose_profile ~config_path ~profile =
+  let snapshot_profile = snapshot_profile_for ~config_path ~profile in
   let model_specs =
-    Cascade_config_loader.load_profile_weighted ~config_path ~name:profile
-    |> List.map (fun (entry : Cascade_config_loader.weighted_entry) ->
-           entry.model)
+    match snapshot_profile with
+    | Some (p : Cascade_catalog_runtime.profile_build) ->
+      List.map
+        (fun (entry : Cascade_config_loader.weighted_entry) -> entry.model)
+        p.weighted_entries
+    | None ->
+      Cascade_config_loader.load_profile_weighted ~config_path ~name:profile
+      |> List.map (fun (entry : Cascade_config_loader.weighted_entry) ->
+             entry.model)
   in
   let required_profile_opt =
-    match Cascade_config_loader.load_catalog ~config_path with
-    | Error _ -> None
-    | Ok entries ->
-        List.find_map
-          (fun (e : Cascade_config_loader.catalog_entry) ->
-            if String.equal e.name profile then
-              Some e.required_capability_profile
-            else None)
-          entries
-        |> Option.value ~default:None
+    match snapshot_profile with
+    | Some (p : Cascade_catalog_runtime.profile_build) ->
+      p.required_capability_profile
+    | None ->
+      (match Cascade_config_loader.load_catalog ~config_path with
+       | Error _ -> None
+       | Ok entries ->
+           List.find_map
+             (fun (e : Cascade_config_loader.catalog_entry) ->
+               if String.equal e.name profile then
+                 Some e.required_capability_profile
+               else None)
+             entries
+           |> Option.value ~default:None)
   in
   let capability_issues =
     match required_profile_opt with


### PR DESCRIPTION
## Summary

RFC-0066 Phase 3+4a — moves the cascade validator off the legacy
`Cascade_config_loader.load_catalog` in production read paths. Two
coupled changes:

1. **Phase 3** — extend `profile_build` with
   `required_capability_profile : string option`. Populated at
   validation time from the legacy catalog entry. Pure additive
   schema change.
2. **Phase 4a** — `Cascade_catalog_validator.diagnose_profile` reads
   the runtime snapshot first (when its `source_path` matches the
   caller's `config_path`), falling back to legacy
   `load_catalog`+`load_profile_weighted` only for path-explicit
   fixture tests or pre-snapshot early boot.

## Why snapshot-vs-path matching

Tests pass explicit fixture paths unrelated to the global snapshot's
source. The validator must not crosstalk between them — it reads the
fixture when given a fixture path, the snapshot when called with the
live config path. Implementation: `snapshot_profile_for ~config_path`
matches `snapshot.source_path` before consulting.

## What does NOT change here (deferred)

- `Cascade_config.default_strategy_kind` still reads `load_catalog` —
  it runs DURING snapshot construction, so cannot consult the
  snapshot being built.
- `Cascade_routes` catalog reads — abstraction floor.
- `Keeper_cascade_profile.catalog_entries` — needs `keeper_assignable`
  + `fallback_cascade` exposed in `profile_build` first.

## Test plan

- [x] `dune build --root .` green on top of latest main.
- [x] `test_cascade_catalog_runtime.exe` — 23/23 OK.
- [x] `test_keeper_cascade_routing.exe` — 17/17 OK.
- [x] `test_keeper_lifecycle.exe` — 51/51 OK.

Pre-existing main regressions (NOT introduced by this PR — confirmed
by `git reset --hard origin/main` + same tests):
- `test_dashboard_cascade.exe` #7,#8 + 3 keeper_profile_json failures
- `test_cascade_validator_capability_lint.exe` 2 failures

These appear to date from RFC-0066 Phase 1 / Phase 2 admin-merge
(#14652 + #14671). Separate follow-up needed.

## RFC pipeline

| Phase | Status |
|---|---|
| 0 — RFC drafted | merged #14639 |
| 1 — `default_cascade_name` value→thunk | merged #14652 + #14671 |
| 2 — leaf callers | partial (autocoder fix in #14671) |
| **3+4a — schema + validator snapshot read** | **this PR** |
| 4b — `cascade_config` + `cascade_routes` deferred | pending |
| 5 — Delete loader functions | requires snapshot-direct construction (future RFC) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)