### PR TITLE
feat(cascade-decl): M1b — expand cascade_model_capabilities to 21 fields + thinking_control_format enum (depends on #14666)

### DIFF
--- a/lib/cascade_decl/cascade_declarative_parser.ml
+++ b/lib/cascade_decl/cascade_declarative_parser.ml
@@ -262,9 +262,27 @@ let parse_providers (toml : Otoml.t) : (cascade_provider list, parse_error list)
 
 (* --- Layer 2: Models --- *)
 
+let parse_thinking_control_format ~(path : string) (raw : string)
+  : cascade_thinking_control_format
+  =
+  match String.lowercase_ascii (String.trim raw) with
+  | "" | "none" | "no-thinking-control" | "no_thinking_control" -> No_thinking_control
+  | "thinking-object" | "thinking_object" -> Thinking_object
+  | "chat-template-kwargs" | "chat_template_kwargs" -> Chat_template_kwargs
+  | other ->
+    Logs.warn (fun m ->
+      m
+        "cascade_declarative_parser: %s.thinking-control-format = %S — expected one of \
+         none|thinking-object|chat-template-kwargs, defaulting to none"
+        path
+        other);
+    No_thinking_control
+;;
+
 let parse_model_capabilities ~(path : string) (tbl : Otoml.t) : cascade_model_capabilities
   =
   let b key = Otoml.find_or ~default:false tbl Otoml.get_boolean [ key ] in
+  let b_default_true key = Otoml.find_or ~default:true tbl Otoml.get_boolean [ key ] in
   let positive_int_opt_field key =
     match Otoml.find_opt tbl Otoml.get_integer [ key ] with
     | None -> None
@@ -279,12 +297,32 @@ let parse_model_capabilities ~(path : string) (tbl : Otoml.t) : cascade_model_ca
           n);
       None
   in
+  let thinking_control_format =
+    match Otoml.find_opt tbl Otoml.get_string [ "thinking-control-format" ] with
+    | None -> No_thinking_control
+    | Some raw -> parse_thinking_control_format ~path raw
+  in
   { max_output_tokens = positive_int_opt_field "max-output-tokens"
   ; supports_parallel_tool_calls = b "supports-parallel-tool-calls"
+  ; supports_tool_choice = b "supports-tool-choice"
+  ; supports_extended_thinking = b "supports-extended-thinking"
+  ; supports_reasoning_budget = b "supports-reasoning-budget"
+  ; thinking_control_format
   ; supports_image_input = b "supports-image-input"
+  ; supports_audio_input = b "supports-audio-input"
+  ; supports_video_input = b "supports-video-input"
+  ; supports_multimodal_inputs = b "supports-multimodal-inputs"
+  ; supports_response_format_json = b "supports-response-format-json"
+  ; supports_structured_output = b "supports-structured-output"
   ; supports_native_streaming = b "supports-native-streaming"
   ; supports_caching = b "supports-caching"
-  ; supports_response_format_json = b "supports-response-format-json"
+  ; supports_prompt_caching = b "supports-prompt-caching"
+  ; prompt_cache_alignment = positive_int_opt_field "prompt-cache-alignment"
+  ; supports_top_k = b "supports-top-k"
+  ; supports_min_p = b "supports-min-p"
+  ; supports_seed = b "supports-seed"
+  ; emits_usage_tokens = b_default_true "emits-usage-tokens"
+  ; supports_computer_use = b "supports-computer-use"
   }
 ;;
 

--- a/lib/cascade_decl/cascade_declarative_parser.ml
+++ b/lib/cascade_decl/cascade_declarative_parser.ml
@@ -272,8 +272,8 @@ let parse_thinking_control_format ~(path : string) (raw : string)
   | other ->
     Logs.warn (fun m ->
       m
-        "cascade_declarative_parser: %s.thinking-control-format = %S — expected one of \
-         none|thinking-object|chat-template-kwargs, defaulting to none"
+        "cascade_declarative_parser: %s.capabilities.thinking-control-format = %S — \
+         expected one of none|thinking-object|chat-template-kwargs, defaulting to none"
         path
         other);
     No_thinking_control
@@ -354,7 +354,7 @@ let parse_model (id : string) (tbl : Otoml.t)
     let streaming = Otoml.find_or ~default:true tbl Otoml.get_boolean [ "streaming" ] in
     let capabilities =
       Otoml.find_opt tbl Fun.id [ "capabilities" ]
-      |> Option.map (parse_model_capabilities ~path)
+      |> Option.map (parse_model_capabilities ~path:(path ^ ".capabilities"))
     in
     Ok
       { id

--- a/lib/cascade_decl/cascade_declarative_types.ml
+++ b/lib/cascade_decl/cascade_declarative_types.ml
@@ -120,7 +120,21 @@ type cascade_provider =
   }
 [@@deriving show, eq]
 
-(** Per-model capabilities — RFC-0058 Model axis M1 (Phase 5.3 prep).
+(** Wire-format for controlling thinking/reasoning on OpenAI-compat backends.
+    Mirrors OAS [Llm_provider.Capabilities.thinking_control_format].
+
+    Recorded per-model because the same physical model can be served by
+    backends with different thinking-control wire shapes (e.g., qwen3
+    via llama-server vs via DeepSeek's API), so the model entry pins
+    which shape the backend expects. *)
+type cascade_thinking_control_format =
+  | No_thinking_control
+  | Thinking_object (** DeepSeek-style: {"thinking":{"type":"enabled"}} *)
+  | Chat_template_kwargs
+  (** llama-server style: {"chat_template_kwargs":{"enable_thinking":bool}} *)
+[@@deriving show, eq]
+
+(** Per-model capabilities — RFC-0058 Model axis M1 + M1b (Phase 5.3 prep).
 
     Mirrors the dispatch-critical subset of OAS [Llm_provider.Capabilities.capabilities]
     so the cascade.toml [\[models.<id>.capabilities\]] sub-table becomes
@@ -131,24 +145,42 @@ type cascade_provider =
     Provider_config.model_id), not the cascade [\[models.<id>\]] key.
     M2 replaces that derivation with a cascade.toml lookup keyed on the
     cascade [<id>] (the cascade key) so OAS no longer needs to "know
-    model names".
+    model names". *)
 
-    Schema-additive in M1 (this PR): no callers consume the fields yet.
-    M2 caller cutover wires OAS [for_model_id] to read these fields.
-
-    Field selection prioritises fields that OAS callers branch on but
-    that cascade_model_spec does not already cover ([tools_support],
-    [thinking_support], [max_context], [streaming] live in the parent
-    record). *)
 type cascade_model_capabilities =
   { max_output_tokens : int option
     (** Hard cap on output tokens. None when unknown / model-default. *)
-  ; supports_parallel_tool_calls : bool
-    (** Multiple [tool_use] blocks in one assistant response.
-          OpenAI / Anthropic recent models do; CLI wrappers usually
-          don't. *)
-  ; supports_image_input : bool (** Vision input via base64 / URL image blocks. *)
-  ; supports_native_streaming : bool
+  ; (* Tool use *)
+    supports_parallel_tool_calls : bool
+    (** Multiple [tool_use] blocks in one assistant response. *)
+  ; supports_tool_choice : bool
+    (** Server-side [tool_choice] forcing. Most CLI-wrappers do not
+          honour it. *)
+  ; (* Thinking / reasoning *)
+    supports_extended_thinking : bool
+    (** [budget_tokens] / [reasoning_effort] knob. Distinct from
+          {!cascade_model_spec.thinking_support} which is the on/off
+          gate; this is the budgeted-depth control. *)
+  ; supports_reasoning_budget : bool (** Per-request reasoning depth control accepted. *)
+  ; thinking_control_format : cascade_thinking_control_format
+    (** Wire shape for thinking control on OpenAI-compat backends.
+          [No_thinking_control] is the safe default (no reasoning
+          surface). *)
+  ; (* Multimodal *)
+    supports_image_input : bool (** Vision input via base64 / URL image blocks. *)
+  ; supports_audio_input : bool
+  ; supports_video_input : bool
+  ; supports_multimodal_inputs : bool
+    (** Any non-text input. Distinct from the per-modality flags above:
+          true when at least one of image/audio/video is true. Declarative
+          surface keeps both so validators can detect the discrepancy. *)
+  ; (* Output format *)
+    supports_response_format_json : bool
+    (** [response_format = json_object] / JSON mode. *)
+  ; supports_structured_output : bool
+    (** JSON-schema strict mode (100% conforming output). *)
+  ; (* Protocol *)
+    supports_native_streaming : bool
     (** Server-Sent Events streaming on the wire protocol. Distinct
           from {!cascade_model_spec.streaming} which advertises the
           model's declared streaming support — this field tracks the
@@ -157,18 +189,51 @@ type cascade_model_capabilities =
   ; supports_caching : bool
     (** Provider supports any form of response caching (Anthropic
           prompt caching, OpenAI prompt caching, GLM cache). *)
-  ; supports_response_format_json : bool
-    (** [response_format = json_object] / JSON mode. *)
+  ; supports_prompt_caching : bool
+    (** Anthropic-style explicit prompt cache_control blocks. *)
+  ; prompt_cache_alignment : int option
+    (** Token-boundary alignment for prompt cache breakpoints (Anthropic
+          requires multiples of 1024 in some tiers). *)
+  ; (* Sampling parameters *)
+    supports_top_k : bool
+  ; supports_min_p : bool
+  ; supports_seed : bool (** Deterministic seed for reproducible sampling. *)
+  ; (* Usage reporting *)
+    emits_usage_tokens : bool
+    (** True when the provider's standard response carries
+          [input_tokens]/[output_tokens] (direct APIs like Anthropic,
+          OpenAI, Gemini, Kimi-API, GLM, Ollama). False for CLI-class
+          wrappers that strip usage before returning (codex_cli,
+          gemini_cli, kimi_cli). Default-true matches OAS. *)
+  ; (* Advanced modalities *)
+    supports_computer_use : bool
   }
 [@@deriving show, eq]
 
 let cascade_model_capabilities_default =
   { max_output_tokens = None
   ; supports_parallel_tool_calls = false
+  ; supports_tool_choice = false
+  ; supports_extended_thinking = false
+  ; supports_reasoning_budget = false
+  ; thinking_control_format = No_thinking_control
   ; supports_image_input = false
+  ; supports_audio_input = false
+  ; supports_video_input = false
+  ; supports_multimodal_inputs = false
+  ; supports_response_format_json = false
+  ; supports_structured_output = false
   ; supports_native_streaming = false
   ; supports_caching = false
-  ; supports_response_format_json = false
+  ; supports_prompt_caching = false
+  ; prompt_cache_alignment = None
+  ; supports_top_k = false
+  ; supports_min_p = false
+  ; supports_seed = false
+  ; emits_usage_tokens =
+      true
+      (* stricter default: most providers report usage; CLI wrappers explicitly opt out *)
+  ; supports_computer_use = false
   }
 ;;
 

--- a/lib/cascade_decl/cascade_declarative_types.mli
+++ b/lib/cascade_decl/cascade_declarative_types.mli
@@ -95,32 +95,80 @@ type cascade_provider =
 
 (** {1 Layer 2: Models} *)
 
-(** Per-model capabilities — RFC-0058 Model axis M1 (Phase 5.3 prep).
+(** Wire-format for controlling thinking/reasoning on OpenAI-compat
+    backends. Mirrors OAS [Llm_provider.Capabilities.thinking_control_format].
 
-    Mirrors the dispatch-critical subset of OAS
-    {!Llm_provider.Capabilities.capabilities}. cascade.toml
-    [\[models.<id>.capabilities\]] sub-table becomes the SSOT for the
-    fields below.
+    The three variants describe how an OpenAI-compat backend's request
+    body should encode "enable thinking":
+    - [No_thinking_control]: no reasoning surface at all (legacy GPT-4o,
+      Anthropic CLI wrappers).
+    - [Thinking_object]: DeepSeek/GLM-style \{"thinking":\{"type":"enabled"\}\}.
+    - [Chat_template_kwargs]: llama-server-style
+      \{"chat_template_kwargs":\{"enable_thinking":bool\}\}.
 
-    M1 (this PR): schema-only addition; no callers consume.
-    M2 (follow-up): OAS [for_model_id_static], which currently
+    Recorded on the model because the same physical model can be served
+    by backends with different thinking-control wire shapes (e.g., qwen3
+    via llama-server vs via DeepSeek's API), so the model entry must
+    pin which shape the backend expects. *)
+type cascade_thinking_control_format =
+  | No_thinking_control
+  | Thinking_object
+  | Chat_template_kwargs
+[@@deriving show, eq]
+
+(** Per-model capabilities — RFC-0058 Model axis M1 + M1b (Phase 5.3 prep).
+
+    Mirrors OAS {!Llm_provider.Capabilities.capabilities} for the fields
+    that real OAS callers actually branch on (measured via grep on
+    [.supports_*] / [.max_*] / [.emits_*] field access — 13 fields with
+    ≥4 access sites, 6 more shipped pre-emptively for cascade routing
+    completeness).
+
+    Schema-additive: no callers consume the fields in this PR. M2
+    follow-up wires OAS [for_model_id_static], which currently
     substring-matches on the upstream API model identifier (e.g.
     [\"claude-sonnet-4-6\"] — Llm_provider.Capabilities.for_model_id
     receives the api-name, not the cascade [\[models.<id>\]] key
-    [\"sonnet\"]), is replaced by cascade.toml lookup via
-    {!model_capabilities_for_id} — keyed on the cascade [<id>] (the
-    cascade key, not the api-name).
+    [\"sonnet\"]), to read these fields via {!model_capabilities_for_id} —
+    keyed on the cascade [<id>] (the cascade key, not the api-name).
 
     Field selection excludes fields already present on
-    {!cascade_model_spec} ([tools_support], [thinking_support],
-    [max_context], [streaming]) to avoid duplicate SSOT. *)
+    {!cascade_model_spec} ([tools_support] mirrors
+    [Capabilities.supports_tools], [thinking_support] mirrors
+    [supports_reasoning], [max_context] mirrors [max_context_tokens],
+    [streaming] is the abstract gate distinct from
+    {!supports_native_streaming}'s wire-protocol claim) — these are not
+    duplicated to avoid two-SSOT drift. *)
 type cascade_model_capabilities =
   { max_output_tokens : int option
-  ; supports_parallel_tool_calls : bool
-  ; supports_image_input : bool
-  ; supports_native_streaming : bool
+  ; (* Tool use *)
+    supports_parallel_tool_calls : bool
+  ; supports_tool_choice : bool
+  ; (* Thinking / reasoning *)
+    supports_extended_thinking : bool
+  ; supports_reasoning_budget : bool
+  ; thinking_control_format : cascade_thinking_control_format
+  ; (* Multimodal *)
+    supports_image_input : bool
+  ; supports_audio_input : bool
+  ; supports_video_input : bool
+  ; supports_multimodal_inputs : bool
+  ; (* Output format *)
+    supports_response_format_json : bool
+  ; supports_structured_output : bool
+  ; (* Protocol *)
+    supports_native_streaming : bool
   ; supports_caching : bool
-  ; supports_response_format_json : bool
+  ; supports_prompt_caching : bool
+  ; prompt_cache_alignment : int option
+  ; (* Sampling parameters *)
+    supports_top_k : bool
+  ; supports_min_p : bool
+  ; supports_seed : bool
+  ; (* Usage reporting *)
+    emits_usage_tokens : bool
+  ; (* Advanced modalities *)
+    supports_computer_use : bool
   }
 [@@deriving show, eq]
 

--- a/test/test_cascade_declarative_parser.ml
+++ b/test/test_cascade_declarative_parser.ml
@@ -1138,6 +1138,153 @@ max-context = 4096
        (model_capabilities_for_id cfg "does-not-exist"))
 ;;
 
+(* --- M1b: expanded schema fields (15 additions) --- *)
+
+let test_model_capabilities_m1b_full () =
+  (* Exercise all 15 fields added in M1b. Asserts each field is reachable
+     via TOML and that defaults stay separate from declared-true values. *)
+  let toml =
+    {|
+[models.m]
+max-context = 4096
+
+[models.m.capabilities]
+supports-tool-choice = true
+supports-extended-thinking = true
+supports-reasoning-budget = true
+thinking-control-format = "thinking-object"
+supports-audio-input = true
+supports-video-input = true
+supports-multimodal-inputs = true
+supports-structured-output = true
+supports-prompt-caching = true
+prompt-cache-alignment = 1024
+supports-top-k = true
+supports-min-p = true
+supports-seed = true
+emits-usage-tokens = false
+supports-computer-use = true
+|}
+  in
+  let cfg = ok_config (parse_string toml) in
+  match cfg.models with
+  | [ m ] ->
+    (match m.capabilities with
+     | Some c ->
+       check bool "tool_choice" true c.supports_tool_choice;
+       check bool "extended_thinking" true c.supports_extended_thinking;
+       check bool "reasoning_budget" true c.supports_reasoning_budget;
+       check
+         string
+         "thinking_control_format"
+         "Cascade_declarative_types.Thinking_object"
+         (show_cascade_thinking_control_format c.thinking_control_format);
+       check bool "audio_input" true c.supports_audio_input;
+       check bool "video_input" true c.supports_video_input;
+       check bool "multimodal_inputs" true c.supports_multimodal_inputs;
+       check bool "structured_output" true c.supports_structured_output;
+       check bool "prompt_caching" true c.supports_prompt_caching;
+       check (option int) "prompt_cache_alignment" (Some 1024) c.prompt_cache_alignment;
+       check bool "top_k" true c.supports_top_k;
+       check bool "min_p" true c.supports_min_p;
+       check bool "seed" true c.supports_seed;
+       (* Default-true field set explicitly to false here — the value
+          difference confirms parse path honors caller-declared values. *)
+       check bool "emits_usage_tokens declared false" false c.emits_usage_tokens;
+       check bool "computer_use" true c.supports_computer_use
+     | None -> failwith "expected capabilities record")
+  | _ -> failwith "expected exactly one model"
+;;
+
+let test_model_capabilities_emits_usage_default_true () =
+  (* emits_usage_tokens is the only default-true bool in the schema —
+     mirrors OAS default_capabilities (most direct APIs emit usage; CLI
+     wrappers explicitly opt out). Without an explicit declaration the
+     parsed value must be true. *)
+  let toml =
+    {|
+[models.m]
+max-context = 4096
+
+[models.m.capabilities]
+supports-tool-choice = true
+|}
+  in
+  let cfg = ok_config (parse_string toml) in
+  match cfg.models with
+  | [ m ] ->
+    (match m.capabilities with
+     | Some c ->
+       check bool "emits_usage_tokens default true" true c.emits_usage_tokens;
+       (* Defaults-false sanity check against drift *)
+       check bool "audio_input default false" false c.supports_audio_input;
+       check bool "computer_use default false" false c.supports_computer_use
+     | None -> failwith "expected capabilities record")
+  | _ -> failwith "expected exactly one model"
+;;
+
+let test_thinking_control_format_variants () =
+  let qualified v = "Cascade_declarative_types." ^ v in
+  let cases =
+    [ "no-thinking-control", qualified "No_thinking_control"
+    ; "thinking-object", qualified "Thinking_object"
+    ; "chat-template-kwargs", qualified "Chat_template_kwargs"
+    ; (* Unknown values warn + fall back to No_thinking_control. *)
+      "garbage-value", qualified "No_thinking_control"
+    ]
+  in
+  List.iter
+    (fun (raw, expected) ->
+       let toml =
+         Printf.sprintf
+           {|
+[models.m]
+max-context = 4096
+
+[models.m.capabilities]
+thinking-control-format = "%s"
+|}
+           raw
+       in
+       let cfg = ok_config (parse_string toml) in
+       match cfg.models with
+       | [ m ] ->
+         (match m.capabilities with
+          | Some c ->
+            check
+              string
+              (Printf.sprintf "thinking-control-format=%S → %s" raw expected)
+              expected
+              (show_cascade_thinking_control_format c.thinking_control_format)
+          | None -> failwith "expected capabilities record")
+       | _ -> failwith "expected exactly one model")
+    cases
+;;
+
+let test_prompt_cache_alignment_zero_rejected () =
+  let toml =
+    {|
+[models.m]
+max-context = 4096
+
+[models.m.capabilities]
+prompt-cache-alignment = 0
+|}
+  in
+  let cfg = ok_config (parse_string toml) in
+  match cfg.models with
+  | [ m ] ->
+    (match m.capabilities with
+     | Some c ->
+       check
+         (option int)
+         "prompt-cache-alignment=0 rejected → None"
+         None
+         c.prompt_cache_alignment
+     | None -> failwith "expected capabilities record")
+  | _ -> failwith "expected exactly one model"
+;;
+
 (* --- capabilities_for_provider_id lookup helper (Phase 5.1 A.3 prep) --- *)
 
 let test_capabilities_for_provider_id_present () =
@@ -1295,7 +1442,7 @@ let () =
             `Quick
             test_capabilities_for_provider_id_unknown_provider
         ] )
-    ; ( "model_capabilities (M1 — Model axis prep)"
+    ; ( "model_capabilities (M1b — Model axis prep, expanded)"
       , [ test_case
             "[models.<id>.capabilities] sub-table parses 6 fields"
             `Quick
@@ -1313,6 +1460,22 @@ let () =
             "model_capabilities_for_id returns None for unknown"
             `Quick
             test_model_capabilities_for_id_unknown
+        ; test_case
+            "M1b expanded — all 15 added fields reachable + value differentiation"
+            `Quick
+            test_model_capabilities_m1b_full
+        ; test_case
+            "M1b expanded — emits_usage_tokens default-true (sole exception)"
+            `Quick
+            test_model_capabilities_emits_usage_default_true
+        ; test_case
+            "M1b expanded — thinking_control_format 4 variants (incl. fallback)"
+            `Quick
+            test_thinking_control_format_variants
+        ; test_case
+            "M1b expanded — prompt-cache-alignment=0 rejected → None"
+            `Quick
+            test_prompt_cache_alignment_zero_rejected
         ] )
     ]
 ;;


### PR DESCRIPTION
## Summary

Expands the M1 minimal 6-field schema (#14666) to cover the OAS callsite inventory measured by grep on `.supports_*` / `.max_*` / `.emits_*` field access in `oas/lib/llm_provider/`.

**Depends on**: #14666 (M1 base schema). Branched off M1's branch. Will need rebase onto main after #14666 lands.

## Why now

User signal "모델을 싸그리 다 청소" — comprehensive cleanup of model-name knowledge from code. M2 OAS cutover (rewrite `for_model_id_static` 1000+ LOC if/elsif tree to cascade.toml lookup) requires cascade_model_capabilities to cover every field OAS callers actually branch on. M1's 6 fields were a starter set; M1b grows to the full coverage so M2 can ship without "missing field" friction.

## Top OAS callsite frequencies

| Field | OAS hits | Cascade state |
|-------|----------|---------------|
| max_context_tokens | 13 | already on `cascade_model_spec.max_context` |
| supports_tools | 10 | already on `cascade_model_spec.tools_support` |
| emits_usage_tokens | 8 | **M1b** (default-true) |
| is_ollama | 6 | NOT model-level — provider attribute |
| supports_seed | 5 | **M1b** |
| supports_reasoning | 5 | already on `cascade_model_spec.thinking_support` |
| supports_min_p | 5 | **M1b** |
| supports_video_input | 4 | **M1b** |
| supports_top_k | 4 | **M1b** |
| supports_tool_choice | 4 | **M1b** |
| supports_image_input | 4 | already (M1) |
| supports_audio_input | 4 | **M1b** |
| max_output_tokens | 4 | already (M1) |

Plus 6 routing-completeness fields (`supports_extended_thinking`, `supports_reasoning_budget`, `supports_multimodal_inputs`, `supports_structured_output`, `supports_prompt_caching`, `prompt_cache_alignment`, `supports_computer_use`) and the `thinking_control_format` closed sum type mirroring OAS exactly.

**Total**: 6 → 21 fields + 1 enum.

## Default semantics

- All booleans default `false` EXCEPT `emits_usage_tokens` defaults `true` (mirrors OAS `default_capabilities` — most direct APIs report usage; CLI wrappers explicitly opt out via codex_cli/gemini_cli/kimi_cli branches)
- `thinking_control_format` defaults `No_thinking_control` (safe zero-knowledge default)
- `prompt_cache_alignment` defaults `None` (positive-int validated, 0 rejected with WARN)

## What's NOT in this PR

| 항목 | 어디 |
|------|------|
| cascade.toml 8 model entry backfill with new fields | M2-prereq follow-up |
| match_patterns / match_priority for prefix-based lookup | Separate PR (M2-prereq) |
| OAS `for_model_id_static` body rewrite | M2 (depends on match_patterns + backfill) |

## Test plan

- [x] `dune build` green
- [x] `test_cascade_declarative_parser` 53/53 (4 new M1b tests)
  - All 15 added fields reachable + value differentiation
  - `emits_usage_tokens` default-true (sole exception)
  - `thinking_control_format` 4 variants (incl. unknown-value fallback)
  - `prompt-cache-alignment=0` rejected → None
- [x] `test_cascade_declarative_adapter` 17/17 unchanged
- [x] `ocamlformat --check` clean on 4 touched files

## Refs

- #14666 — M1 base PR (6-field schema)
- OAS `oas/lib/llm_provider/capabilities.ml` — 1000+ LOC if/elsif tree with 27 substring branches (the M2 cutover target)
- User signal: "모델을 싸그리 다 청소" (2026-05-11)

🤖 Generated with [Claude Code](https://claude.com/claude-code)