### PR TITLE
chore(deps): bump agent_sdk 0.184.0 → 0.193.4

### DIFF
--- a/masc_mcp.opam.locked
+++ b/masc_mcp.opam.locked
@@ -11,7 +11,7 @@ homepage: "https://github.com/jeong-sik/masc-mcp"
 doc: "https://github.com/jeong-sik/masc-mcp"
 bug-reports: "https://github.com/jeong-sik/masc-mcp/issues"
 depends: [
-  "agent_sdk" {= "0.184.0"}
+  "agent_sdk" {= "0.193.4"}
   "alcotest" {with-test & = "1.9.1"}
   "ambient-context-eio" {= "0.2"}
   "bigstringaf" {= "0.10.0"}
@@ -86,8 +86,8 @@ build: [
 dev-repo: "git+https://github.com/jeong-sik/masc-mcp.git"
 pin-depends: [
   [
-    "agent_sdk.0.184.0"
-    "git+https://github.com/jeong-sik/oas.git#19e3f1e58a9392ff87a8c587e4ed8c5e385765ce"
+    "agent_sdk.0.193.4"
+    "git+https://github.com/jeong-sik/oas.git#7ed9c05260dce7b813bfaf524a2799573eb6479d"
   ]
   [
     "bisect_ppx.2.8.3"


### PR DESCRIPTION
## 목표

masc-mcp의 OAS pin lock catch-up. **9 minor + N patch 만큼 밀려 있던 의존성을 main으로 정렬**한다.

본 PR로 들어오는 새 OAS 기능:
- `Tool.disclosure_level` 인프라 (OAS PR #1508, merged f48ccec3)
- `Disclosure_resolver` per-turn adaptive mechanism (OAS PR #1511, merged 7ed9c052)
- 이전 9 minor 사이의 CDAL relocation 포함 (RFC-OAS-011 OAS-E PR-6)

RFC-OAS-013 (OAS PR #1510 Draft) 카나리 활성화의 *전제 조건* — keeper에서 새 API를 호출하려면 lock이 먼저 0.193.4를 가리켜야 한다.

## 변경 파일

| 파일 | 변경 |
|---|---|
| `masc_mcp.opam.locked` | `agent_sdk = 0.184.0` → `0.193.4`, pin commit `19e3f1e` → `7ed9c05` |

`masc_mcp.opam`과 `dune-project`의 `(agent_sdk (>= 0.193.0))` 제약은 *건드리지 않음*. 둘 다 이미 0.193.4를 허용. 활성화 PR(keeper에서 신규 API 직접 사용)에서 `>= 0.193.4`로 좁힐 예정.

## 사전 호환성 검증 (코드 변경 무용 확인)

OAS 0.193.0 BREAKING은 **CDAL 모듈 23개를 agent_sdk에서 제거하고 masc_mcp.cdal_runtime으로 이전** (RFC-OAS-011). masc-mcp가 이 이전을 이미 완료했는지 확인:

```bash
# masc-mcp main 시점 (current HEAD): cdal_runtime 디렉토리 존재
$ ls lib/cdal_runtime/ | head
audit.ml
autonomy_diff_guard.ml
autonomy_exec.ml
autonomy_trace_analyzer.ml
cdal_proof.ml
...

# Agent_sdk-removed CDAL 모듈을 lib/에서 import하는 곳: 0건
$ grep -rE "Agent_sdk\.(Cdal_proof|Mode_enforcer|Mode_resolver|Risk_contract|Proof_capture|Proof_store|Contract_runner|Conformance|Audit|Autonomy_exec|Sessions_proof|Runtime_evidence)" lib/
(no matches)
```

→ 이번 bump가 본 작업에 *코드 변경 없이* 빌드 통과할 가능성 높음. CI가 최종 결정.

## 로컬 검증

본 PR은 lock 파일만 변경 — 로컬 dune build는 새 OAS opam install이 선행돼야 함. CI 결과로 위임:
- 빌드/테스트 fail 시 별도 fix PR로 대응 (이번 PR scope 외).

## 미검증

- OAS 0.185 ~ 0.193 사이 *CDAL 외* breaking change (예: SSE event 타입 변경, Tool_id Variant 등)의 masc-mcp 영향. 0건일 가능성 높지만 CI에서 확실.

## 다음 단계

본 PR 머지 후:
1. **keeper 활성화 PR**: `lib/keeper/keeper_run_tools.ml`에 `Builder.with_disclosure_level (Hybrid { full_names = ... })` + `with_disclosure_resolver` 추가. RFC-OAS-013 §7 step 3.
2. P0 카나리 (1명, 7일) telemetry 측정.

## Cross-references

- OAS PR #1508 (merged) — disclosure_level infrastructure
- OAS PR #1511 (merged) — disclosure_resolver fallback mechanism
- OAS PR #1510 (Draft) — RFC-OAS-013 activation plan