### PR TITLE
fix(dashboard-cascade): restore path-explicit declared_provider_schemes contract

### DIFF
--- a/lib/dashboard_cascade.ml
+++ b/lib/dashboard_cascade.ml
@@ -708,38 +708,37 @@ let provider_scheme_of_model_string (s : string) : string =
 ;;
 
 (** Collect the set of provider scheme prefixes declared by any cascade
-    profile.  RFC-0066 Phase 2: reads the live validated snapshot via
-    [Cascade_catalog_runtime.inspect_active] so declarative
-    [provider]/[model]/[profile] configs are visible.  Errors and
-    non-validated states yield the empty set — the health endpoint must
-    keep responding even if the catalog is rejected.
+    profile in [config_path].  Reads the typed catalog (so invalid
+    profiles are skipped) and then each profile's raw model list.  Errors
+    are swallowed into an empty set — a missing/malformed [cascade.toml]
+    is already surfaced by [config_json]; we do not want the health
+    endpoint to disappear just because the catalog loader fails.
 
-    The [?config_path] argument is preserved for backward compatibility
-    with callers; under declarative config the runtime resolves its own
-    path through [Config_dir_resolver].  Callers that previously passed
-    an explicit path now get the snapshot's source-of-truth view. *)
-let declared_provider_schemes_set ?config_path:_ () : StringSet.t =
-  match Cascade_catalog_runtime.inspect_active () with
-  | Error _ -> StringSet.empty
-  | Ok state ->
-    let snapshot =
-      match state with
-      | Cascade_catalog_runtime.Validated snapshot -> Some snapshot
-      | Validated_with_rejections { snapshot; _ } -> Some snapshot
-      | Serving_last_known_good { snapshot; _ } -> Some snapshot
-    in
-    (match snapshot with
-     | None -> StringSet.empty
-     | Some snapshot ->
+    Path-explicit reads (legacy contract preserved): callers that pass
+    an explicit [config_path] must see schemes from THAT path.
+    Snapshot-based reads cross-talk with fixture tests (snapshot's
+    source_path is unrelated to caller's path).  An earlier
+    snapshot-first variant was reverted because it broke the
+    [?config_path:None -> []] contract relied on by
+    [test_declared_provider_schemes_handles_missing_path]. *)
+let declared_provider_schemes_set ?(config_path : string option) () : StringSet.t =
+  match config_path with
+  | None -> StringSet.empty
+  | Some path ->
+    (match Cascade_config_loader.load_catalog ~config_path:path with
+     | Error _ -> StringSet.empty
+     | Ok entries ->
        List.fold_left
-         (fun acc (profile : Cascade_catalog_runtime.profile_build) ->
+         (fun acc (entry : Cascade_config_loader.catalog_entry) ->
+            let models =
+              Cascade_config_loader.load_profile ~config_path:path ~name:entry.name
+            in
             List.fold_left
-              (fun acc (entry : Cascade_config_loader.weighted_entry) ->
-                StringSet.add (provider_scheme_of_model_string entry.model) acc)
+              (fun acc m -> StringSet.add (provider_scheme_of_model_string m) acc)
               acc
-              profile.weighted_entries)
+              models)
          StringSet.empty
-         snapshot.profiles)
+         entries)
 ;;
 
 (** Public list version of {!declared_provider_schemes_set}.  Sorted and


### PR DESCRIPTION
## Summary

Fix a main-blocker introduced by my own PR #14652 (RFC-0066 Phase 2 admin-merge): `Dashboard_cascade.declared_provider_schemes_set` was migrated to a snapshot-only variant that ignored its `?config_path` argument. This broke the legacy contract that path-explicit health endpoint reads rely on, and surfaced as 2 failing tests on `origin/main`:

- `test_declared_provider_schemes_handles_missing_path` — expected `?config_path:None -> []`, got snapshot data.
- `test_declared_provider_schemes_handles_malformed_config` — expected malformed path -> `[]`, got snapshot data.

## Fix

Revert `declared_provider_schemes_set` to the legacy `Cascade_config_loader.load_catalog` + `load_profile` path. Path-explicit callers see catalog data from THAT path; `?config_path:None` returns empty.

Snapshot migration of this site is deferred — it requires either:
- Teaching callers to cross-check `snapshot.source_path` against `?config_path` (already populated since #14671), OR
- Removing the explicit `?config_path` contract from the dashboard surface entirely.

Both are larger than this main-fix.

## Test plan

- [x] `dune build --root .` green.
- [x] `test_dashboard_cascade.exe`: 5 failures → 2 failures (health_json #7, #8 fixed).
- 3 `keeper_profile_json` failures REMAIN on main but are unrelated:
  - Test expects `canonical = "default"` fallback assuming empty live catalog.
  - Process-wide test environment now auto-loads `cascade.toml` (post RFC-0058 §9.3), so canonical resolves to actual `routes.keeper_turn = "beta_editor"`.
  - Separate follow-up — needs test reset or expectation update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)