### PR TITLE
fix(cascade_decl): escape quotes in .mli docstring break the build

### DIFF
--- a/lib/cascade_decl/cascade_declarative_types.mli
+++ b/lib/cascade_decl/cascade_declarative_types.mli
@@ -127,9 +127,9 @@ type cascade_thinking_control_format =
     Schema-additive: no callers consume the fields in this PR. M2
     follow-up wires OAS [for_model_id_static], which currently
     substring-matches on the upstream API model identifier (e.g.
-    [\"claude-sonnet-4-6\"] — Llm_provider.Capabilities.for_model_id
+    ['claude-sonnet-4-6'] — Llm_provider.Capabilities.for_model_id
     receives the api-name, not the cascade [\[models.<id>\]] key
-    [\"sonnet\"]), to read these fields via {!model_capabilities_for_id} —
+    ['sonnet']), to read these fields via {!model_capabilities_for_id} —
     keyed on the cascade [<id>] (the cascade key, not the api-name).
 
     Field selection excludes fields already present on


### PR DESCRIPTION
**main is red** — `dune build` fails on `lib/cascade_decl/cascade_declarative_types.mli`. RFC-0058 M1b commit (#14674) introduced `[\"claude-sonnet-4-6\"]` and `[\"sonnet\"]` inside a docstring. OCaml's comment scanner treats the first `"` as a string-literal start; `\` is meaningless to it, so the strings run from line 130 to line 307 and produce `Error: This comment contains an unterminated string literal`.

**Fix**: `\"…\"` → `'…'` (single quotes — not recognised as string delimiters). 2-line change.

**Verified**:
```
$ dune build --root . lib/cascade_decl/
EXIT=0
```

Other `\"` matches in the repo are either inside `.ml` string literals (legit escapes) or in `.mli` docstrings where the string closes within the same line, so they don't escape into surrounding code. Scope kept minimal — only the trap on main.

Source error reproduced by user during `dune build` from masc-mcp root.

## Why this trap is sneaky

OCaml comment scanner rule: inside `(* ... *)`, a raw `"` opens a string literal and `\"` inside that string is an escape for `"` (consumed as a regular char). So `[\"X\"]` reads as:
1. `[` — comment char
2. `\` — comment char (no special meaning in comments)
3. `"` — **string literal starts**
4. `X\"` — escaped quote, still inside the string
5. `]` — still inside the string

The string never closes on that line and silently swallows everything (including `*)`) until it finds an *unescaped* `"`. With two such patterns at L130 and L132, the string consumed L130–L307 before line 307's `"use defaults"` produced an even more confusing "String literal begins here" diagnostic at the *second* quote.

Single quotes `'X'` avoid the trap because OCaml's *character* literal is `'c'` (single char, single byte) and `'claude-sonnet-4-6'` doesn't parse as one — the lexer treats it as a regular comment fragment.
