### PR TITLE
fix(cascade-decl): restore M1c match_prefixes — stacked PR squash collapse recovery

### DIFF
--- a/lib/cascade_decl/cascade_declarative_parser.ml
+++ b/lib/cascade_decl/cascade_declarative_parser.ml
@@ -356,6 +356,32 @@ let parse_model (id : string) (tbl : Otoml.t)
       Otoml.find_opt tbl Fun.id [ "capabilities" ]
       |> Option.map (parse_model_capabilities ~path:(path ^ ".capabilities"))
     in
+    let match_prefixes =
+      match Otoml.find_opt tbl Fun.id [ "match-prefixes" ] with
+      | None -> []
+      | Some v ->
+        (try
+           Otoml.get_array Otoml.get_string v
+           |> List.filter_map (fun s ->
+             let trimmed = String.trim s in
+             if String.length trimmed = 0
+             then (
+               Logs.warn (fun m ->
+                 m
+                   "cascade_declarative_parser: %s.match-prefixes contains empty entry, \
+                    ignoring"
+                   path);
+               None)
+             else Some trimmed)
+         with
+         | _ ->
+           Logs.warn (fun m ->
+             m
+               "cascade_declarative_parser: %s.match-prefixes — expected string array, \
+                ignoring"
+               path);
+           [])
+    in
     Ok
       { id
       ; api_name
@@ -365,6 +391,7 @@ let parse_model (id : string) (tbl : Otoml.t)
       ; max_thinking_budget
       ; streaming
       ; capabilities
+      ; match_prefixes
       })
 ;;
 

--- a/lib/cascade_decl/cascade_declarative_types.ml
+++ b/lib/cascade_decl/cascade_declarative_types.ml
@@ -250,6 +250,30 @@ type cascade_model_spec =
           the [\[models.<id>.capabilities\]] sub-table is absent —
           callers treat as defaults (see
           {!cascade_model_capabilities_default}). *)
+  ; match_prefixes : string list
+    (** Prefixes for matching against requested model_id strings.
+          Empty list = the spec matches a single specific model_id given
+          by [api_name].
+
+          M2 OAS cutover replaces the substring if/elsif tree in
+          {!Llm_provider.Capabilities.for_model_id_static} with a
+          longest-prefix-first scan over cascade.toml [\[models.*\]]
+          entries — given a request for [model_id], find the spec whose
+          [match_prefixes] contain the longest string [p] such that
+          [model_id] starts with [p].
+
+          Single-spec example: [\[models.sonnet\]] with [api-name =
+          "claude-sonnet-4-6"] and [match-prefixes = []] matches only
+          [claude-sonnet-4-6]. Family example: [\[models.sonnet-family\]]
+          with [match-prefixes = ["claude-sonnet-4"]] matches every
+          [claude-sonnet-4-*] release.
+
+          Longest-prefix-first resolves precedence without an explicit
+          priority field: [match-prefixes = ["glm-5-turbo"]] beats
+          [match-prefixes = ["glm-5"]] because the former is longer.
+          Mirrors the implicit ordering of OAS's if/elsif tree
+          ([starts_with "glm-5-turbo"] checked before [starts_with
+          "glm-5"]). *)
   }
 [@@deriving show, eq]
 
@@ -364,6 +388,59 @@ let model_capabilities_for_id (cfg : cascade_config) (id : string)
   : cascade_model_capabilities option
   =
   Option.bind (model_of_id cfg id) (fun (m : cascade_model_spec) -> m.capabilities)
+;;
+
+let model_spec_for_api_name (cfg : cascade_config) (model_id : string)
+  : cascade_model_spec option
+  =
+  (* Longest-prefix-first scan over [models.*] entries.
+     - Exact api_name match wins outright (longest possible match).
+     - Otherwise the spec whose match_prefixes contains the longest
+       string p with String.starts_with model_id p wins.
+     - Ties on length resolve to the first-declared entry (List.fold_left
+       keeps the earlier-seen winner unless a strictly-longer match arrives).
+     - Returns None if no entry matches. *)
+  let starts_with ~prefix s =
+    let plen = String.length prefix in
+    String.length s >= plen && String.sub s 0 plen = prefix
+  in
+  let best_match =
+    List.fold_left
+      (fun acc (m : cascade_model_spec) ->
+         (* Exact api_name match: synthetic prefix of full length. *)
+         let exact_candidate =
+           if m.api_name = model_id then Some (String.length model_id, m) else None
+         in
+         let prefix_candidates =
+           List.filter_map
+             (fun p ->
+                if starts_with ~prefix:p model_id then Some (String.length p, m) else None)
+             m.match_prefixes
+         in
+         let candidates =
+           match exact_candidate with
+           | Some c -> c :: prefix_candidates
+           | None -> prefix_candidates
+         in
+         List.fold_left
+           (fun acc' (len, spec) ->
+              match acc' with
+              | None -> Some (len, spec)
+              | Some (best_len, _) when len > best_len -> Some (len, spec)
+              | Some _ -> acc')
+           acc
+           candidates)
+      None
+      cfg.models
+  in
+  Option.map snd best_match
+;;
+
+let model_capabilities_for_api_name (cfg : cascade_config) (model_id : string)
+  : cascade_model_capabilities option
+  =
+  Option.bind (model_spec_for_api_name cfg model_id) (fun (m : cascade_model_spec) ->
+    m.capabilities)
 ;;
 
 let binding_of_key (cfg : cascade_config) (provider_id : string) (model_id : string)

--- a/lib/cascade_decl/cascade_declarative_types.mli
+++ b/lib/cascade_decl/cascade_declarative_types.mli
@@ -189,6 +189,17 @@ type cascade_model_spec =
           {!cascade_model_capabilities_default}. Distinct from the
           A.3 provider-capabilities cutover, which consumes
           [cascade_provider.capabilities]. *)
+  ; match_prefixes : string list
+    (** M1c. Prefixes for matching against requested model_id strings.
+          Empty list = the spec matches only exact equality to
+          [api_name]. Multi-element list = the spec matches any
+          model_id starting with one of the listed prefixes.
+
+          Used by {!model_spec_for_api_name} and
+          {!model_capabilities_for_api_name} to replicate the
+          longest-prefix-first semantics of OAS
+          [Llm_provider.Capabilities.for_model_id_static]'s if/elsif
+          tree without OAS knowing model names. *)
   }
 [@@deriving show, eq]
 
@@ -330,6 +341,41 @@ val model_capabilities_for_id
   -> cascade_model_capabilities option
 
 val model_of_id : cascade_config -> string -> cascade_model_spec option
+
+val model_spec_for_api_name
+  :  cascade_config
+  -> string
+  -> cascade_model_spec option
+(** [model_spec_for_api_name cfg model_id] returns the cascade.toml
+    model spec that best matches a requested [model_id] string.
+
+    Resolution rule (longest-prefix-first):
+    + If any spec's [api_name] equals [model_id], return that spec
+      (a synthetic prefix of full length always beats any other).
+    + Otherwise, scan every spec's {!cascade_model_spec.match_prefixes}
+      and return the spec whose matched prefix is longest. Ties on
+      length resolve to the first-declared entry.
+    + Returns [None] if no spec matches.
+
+    Replaces the substring if/elsif tree in OAS
+    [Llm_provider.Capabilities.for_model_id_static] with cascade.toml
+    as the SSOT — the OAS function becomes a thin wrapper invoking
+    this lookup.
+
+    M2 caller cutover wires OAS [for_model_id_static] to this. *)
+
+val model_capabilities_for_api_name
+  :  cascade_config
+  -> string
+  -> cascade_model_capabilities option
+(** [model_capabilities_for_api_name cfg model_id] returns the
+    per-model capabilities of the spec resolved via
+    {!model_spec_for_api_name}. [None] if either no spec matches the
+    requested [model_id] or the resolved spec declared no
+    [\[models.<id>.capabilities\]] sub-table.
+
+    M2 cutover replaces OAS substring-on-model-id capability
+    derivation with this lookup. *)
 val binding_of_key : cascade_config -> string -> string -> cascade_binding option
 val alias_of_key : cascade_config -> string -> string -> string -> cascade_alias option
 val binding_key : cascade_binding -> string

--- a/test/test_cascade_declarative_adapter.ml
+++ b/test/test_cascade_declarative_adapter.ml
@@ -276,6 +276,7 @@ let test_alias_parent_missing () =
           ; max_thinking_budget = None
           ; streaming = true
           ; capabilities = None
+          ; match_prefixes = []
           }
         ]
     ; bindings = []
@@ -540,6 +541,7 @@ let test_duplicate_routes () =
           ; max_thinking_budget = None
           ; streaming = true
           ; capabilities = None
+          ; match_prefixes = []
           }
         ]
     ; bindings =

--- a/test/test_cascade_declarative_parser.ml
+++ b/test/test_cascade_declarative_parser.ml
@@ -1138,6 +1138,139 @@ max-context = 4096
        (model_capabilities_for_id cfg "does-not-exist"))
 ;;
 
+(* --- M1c: match_prefixes + longest-prefix-first lookup --- *)
+
+let test_match_prefixes_parses () =
+  let toml =
+    {|
+[models.sonnet-family]
+api-name = "claude-sonnet-4-6"
+max-context = 200000
+match-prefixes = ["claude-sonnet-4", "claude-sonnet-3.5"]
+|}
+  in
+  let cfg = ok_config (parse_string toml) in
+  match cfg.models with
+  | [ m ] ->
+    check
+      (list string)
+      "match-prefixes parsed in order"
+      [ "claude-sonnet-4"; "claude-sonnet-3.5" ]
+      m.match_prefixes
+  | _ -> failwith "expected exactly one model"
+;;
+
+let test_match_prefixes_absent_defaults_empty () =
+  let toml =
+    {|
+[models.m]
+max-context = 4096
+|}
+  in
+  let cfg = ok_config (parse_string toml) in
+  match cfg.models with
+  | [ m ] -> check (list string) "match_prefixes default []" [] m.match_prefixes
+  | _ -> failwith "expected exactly one model"
+;;
+
+let test_match_prefixes_empty_strings_dropped () =
+  let toml =
+    {|
+[models.m]
+api-name = "x"
+max-context = 4096
+match-prefixes = ["", "good-prefix", "  "]
+|}
+  in
+  let cfg = ok_config (parse_string toml) in
+  match cfg.models with
+  | [ m ] ->
+    check (list string) "blank entries filtered" [ "good-prefix" ] m.match_prefixes
+  | _ -> failwith "expected exactly one model"
+;;
+
+let test_model_spec_for_api_name_exact () =
+  (* Exact api_name match beats any prefix match. *)
+  let toml =
+    {|
+[models.sonnet]
+api-name = "claude-sonnet-4-6"
+max-context = 200000
+
+[models.sonnet-family]
+api-name = "claude-sonnet-4-other"
+max-context = 200000
+match-prefixes = ["claude-sonnet-4"]
+|}
+  in
+  let cfg = ok_config (parse_string toml) in
+  match model_spec_for_api_name cfg "claude-sonnet-4-6" with
+  | Some m -> check string "exact api_name wins" "sonnet" m.id
+  | None -> failwith "expected exact-match resolution"
+;;
+
+let test_model_spec_for_api_name_longest_prefix () =
+  (* When multiple prefixes match, longest wins (mirrors OAS if/elsif
+     ordering: glm-5-turbo checked before glm-5 catchall). *)
+  let toml =
+    {|
+[models.glm-5-turbo]
+api-name = "glm-5-turbo"
+max-context = 128000
+match-prefixes = ["glm-5-turbo"]
+
+[models.glm-5-family]
+api-name = "glm-5-family-default"
+max-context = 200000
+match-prefixes = ["glm-5"]
+|}
+  in
+  let cfg = ok_config (parse_string toml) in
+  match model_spec_for_api_name cfg "glm-5-turbo-2026" with
+  | Some m -> check string "longer prefix wins" "glm-5-turbo" m.id
+  | None -> failwith "expected longest-prefix resolution"
+;;
+
+let test_model_spec_for_api_name_no_match () =
+  let toml =
+    {|
+[models.m]
+api-name = "x"
+max-context = 4096
+match-prefixes = ["claude-"]
+|}
+  in
+  let cfg = ok_config (parse_string toml) in
+  check
+    (option string)
+    "no prefix or exact match → None"
+    None
+    (Option.map
+       (fun (m : cascade_model_spec) -> m.id)
+       (model_spec_for_api_name cfg "gpt-5"))
+;;
+
+let test_model_capabilities_for_api_name_via_prefix () =
+  let toml =
+    {|
+[models.gpt-5-family]
+api-name = "gpt-5-family-default"
+max-context = 1050000
+match-prefixes = ["gpt-5"]
+
+[models.gpt-5-family.capabilities]
+supports-parallel-tool-calls = true
+supports-image-input = true
+|}
+  in
+  let cfg = ok_config (parse_string toml) in
+  match model_capabilities_for_api_name cfg "gpt-5.3-codex-spark" with
+  | Some c ->
+    check bool "parallel via prefix lookup" true c.supports_parallel_tool_calls;
+    check bool "image via prefix lookup" true c.supports_image_input
+  | None -> failwith "expected capabilities via prefix lookup"
+;;
+
 (* --- M1b: expanded schema fields (15 additions) --- *)
 
 let test_model_capabilities_m1b_full () =
@@ -1476,6 +1609,34 @@ let () =
             "M1b expanded — prompt-cache-alignment=0 rejected → None"
             `Quick
             test_prompt_cache_alignment_zero_rejected
+        ; test_case
+            "M1c — match-prefixes parses sorted list"
+            `Quick
+            test_match_prefixes_parses
+        ; test_case
+            "M1c — match-prefixes absent defaults to []"
+            `Quick
+            test_match_prefixes_absent_defaults_empty
+        ; test_case
+            "M1c — match-prefixes empty/blank strings dropped"
+            `Quick
+            test_match_prefixes_empty_strings_dropped
+        ; test_case
+            "M1c — model_spec_for_api_name: exact api_name wins"
+            `Quick
+            test_model_spec_for_api_name_exact
+        ; test_case
+            "M1c — model_spec_for_api_name: longest prefix wins"
+            `Quick
+            test_model_spec_for_api_name_longest_prefix
+        ; test_case
+            "M1c — model_spec_for_api_name: no match → None"
+            `Quick
+            test_model_spec_for_api_name_no_match
+        ; test_case
+            "M1c — model_capabilities_for_api_name via prefix"
+            `Quick
+            test_model_capabilities_for_api_name_via_prefix
         ] )
     ]
 ;;


### PR DESCRIPTION
## 발견

PR #14675 (M1c — `match_prefixes` + longest-prefix-first lookup) 의 변경사항이 `origin/main`에 도달하지 않음. GitHub squash merge가 stacked PR child diff를 자동 포함하지 않은 패턴.

### 증거
```bash
$ gh pr view 14675 --json state,mergedAt,mergeCommit
{"state":"MERGED","mergedAt":"2026-05-11T15:02:26Z","mergeCommit":{"oid":"156d1f085f98e2ba93a4af0b5da123e0de9e2c40"}}

$ git branch --contains 156d1f085 -r
origin/feature/rfc-0058-model-axis-m1b-expanded-schema    ← main 아님

$ rg -n "match_prefixes" lib/cascade_decl/
(0 hits on current main)
```

PR 상태는 MERGED이지만 squash가 #14674 의 diff만 main에 반영, #14675의 추가 diff는 #14674 feature branch에 남아있다가 lost.

## 변경

`156d1f085` 단일 commit을 그대로 cherry-pick. 313 insertions, 충돌 없음.

| 파일 | 변경 |
|------|------|
| `lib/cascade_decl/cascade_declarative_types.ml` | `match_prefixes : string list` 필드 + `model_spec_for_api_name` / `model_capabilities_for_api_name` longest-prefix-first lookup |
| `lib/cascade_decl/cascade_declarative_types.mli` | 시그니처 노출 |
| `lib/cascade_decl/cascade_declarative_parser.ml` | `match-prefixes` TOML key 파싱 |
| `test/test_cascade_declarative_parser.ml` | 7 새 테스트 |
| `test/test_cascade_declarative_adapter.ml` | record literal에 `match_prefixes = []` 추가 |

## 후속

이 PR이 머지되면 RFC-0058 Model axis Phase 1 (cascade.toml 27 family backfill) 진행 가능. plan: \`/Users/dancer/me/planning/claude-plans/me-workspace-yousleepwhen-masc-mcp-polymorphic-leaf.md\`.

## Squash collapse 재발 방지 제안

- Stacked PR 머지 시 child PR을 child branch에 merge하지 않고 main에 직접 PR (각 PR이 main 기반)
- 또는 stack 머지 시 base PR을 rebase merge (squash 아님)로 → child diff 보존
- 본 PR 머지 후 memory에 패턴 기록 권장