### PR TITLE
ci(tla): job-level concurrency for tla-specs — Option A of 4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -938,6 +938,14 @@ jobs:
     # Draft via admin-merge fast-track) is detected on the next main run rather
     # than persisting silently. See #14668 root cause analysis.
     if: ${{ always() && !cancelled() && needs.pr-live-gate.outputs.run_heavy == 'true' && needs.changes.result == 'success' && (needs.changes.outputs.tla == 'true' || needs.pr-live-gate.outputs.live_state == 'NON_PR') }}
+    # Per-job concurrency: each main commit gets its own queue slot keyed by
+    # sha, so workflow-level cancel-in-progress doesn't abort an in-flight TLA
+    # check when a subsequent push lands. PR runs use run_id so they still
+    # supersede on synchronize (workflow-level behaviour preserved at the
+    # workflow concurrency block — this job-level block is additive).
+    concurrency:
+      group: tla-specs-${{ github.event_name == 'push' && github.sha || github.run_id }}
+      cancel-in-progress: false
 
     steps:
       - name: Checkout


### PR DESCRIPTION
## Option A of 4 parallel PRs evaluating fixes for #14670 cancel cascade

Sibling PRs: B (separate workflow), C (workflow cancel exclusion for main), D (cron sweep).

## Problem

#14670 forced TLA+ to run on every main push (bypassing path-scope). However, ci.yml's workflow-level `concurrency.cancel-in-progress=true` on push events aborts the entire workflow when subsequent pushes land. The 2026-05-11 14:22-15:02 fast-track merge window had **30+ consecutive main runs cancelled** — TLA never completed on any.

## This option

Add a job-level `concurrency` block on `tla-specs` with `cancel-in-progress: false` and a per-sha group key.

## ⚠️ Critical caveat

**This does NOT solve the root problem on its own.** GitHub Actions' workflow-level `cancel-in-progress` cancels the entire workflow run, including all jobs in it — job-level concurrency cannot override workflow-level cancellation. The job-level block here is defensive only (prevents same-job re-entry within a single run).

Included in the PR series for completeness. Recommend B or C as the actual fix.

## Comparison

| | A (this) | B | C | D |
|---|---|---|---|---|
| Solves cancel cascade | ❌ | ✅ | ✅ | ✅ (with latency) |
| Cost per main commit | 0 | +5min | +35min | 1 run/hour |
| Surface area | 1 line ci.yml | new workflow file | ci.yml concurrency | new workflow file |
| Latency to detect | N/A | 0 | 0 | ≤1h |