### PR TITLE
ci(tla): separate workflow per main commit — Option B of 4

### DIFF
--- a/.github/workflows/tla-main.yml
+++ b/.github/workflows/tla-main.yml
@@ -1,0 +1,55 @@
+name: TLA+ Main Verification
+
+# Independent of ci.yml — ensures every main commit gets TLA verification
+# even when ci.yml's workflow-level cancel-in-progress aborts the main ci
+# run due to rapid back-to-back merges.
+#
+# Background: #14668 fixed a clean-spec violation (KeeperCascadeRouting
+# TypeOK) that persisted on main for 4 days. #14670 forced TLA to run on
+# every main push by bypassing path-scope. However, ci.yml's
+# concurrency.cancel-in-progress=true on push events cancels the entire
+# workflow when the next merge lands, so 30+ consecutive main pushes
+# (2026-05-11 14:22-15:02 window) all cancelled before TLA could complete.
+#
+# This workflow has its own concurrency group keyed by sha, so each commit
+# gets its own slot and runs to completion regardless of subsequent pushes.
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+  schedule:
+    - cron: '0 */6 * * *'  # belt-and-suspenders: 6h sweep catches gaps
+
+concurrency:
+  group: tla-main-${{ github.sha || github.run_id }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  tla-specs:
+    name: TLA+ Model Checking (main)
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup Java
+        uses: actions/setup-java@v5
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+
+      - name: Download tla2tools.jar (pinned v1.8.0)
+        run: |
+          curl -fsSL -o specs/keeper-state-machine/tla2tools.jar \
+            https://github.com/tlaplus/tlaplus/releases/download/v1.8.0/tla2tools.jar
+
+      - name: Run TLA+ model checking
+        run: |
+          make -C specs check-clean
+          make -C specs check-buggy


### PR DESCRIPTION
## Option B of 4 parallel PRs evaluating fixes for #14670 cancel cascade

Sibling PRs: A (job-level concurrency, ineffective), C (workflow cancel exclusion for main), D (cron sweep).

## Problem

#14670 forced TLA+ to run on every main push. However, ci.yml's workflow-level `concurrency.cancel-in-progress=true` aborted 30+ consecutive main runs during the 2026-05-11 14:22-15:02 fast-track merge window — TLA never completed.

## This option — recommended

New `.github/workflows/tla-main.yml`:
- `on: push` to main + `workflow_dispatch` + 6h cron belt-and-suspenders
- Own `concurrency` block keyed by `github.sha` with `cancel-in-progress: false`
- Each main commit gets its own slot, runs to completion regardless of subsequent pushes
- Independent of ci.yml's workflow-level cancel

## Effect

Every main commit triggers a fresh TLA verification run that completes (~5min typical, 40min timeout). No interaction with ci.yml's cancel semantics.

## Trade-off

- Pros: actually solves the cancel cascade; surgical (TLA only); ci.yml unchanged; cron fallback covers schedule gaps.
- Cons: +5min runner per main commit (~100/day peak → 8h runner/day, manageable); split-brain risk if ci.yml's tla-specs and tla-main.yml drift.

## Comparison

| | A | B (this) | C | D |
|---|---|---|---|---|
| Solves cancel cascade | ❌ | ✅ | ✅ | ✅ (with latency) |
| Cost per main commit | 0 | +5min | +35min | 1 run/hour |
| Surface area | 1 line ci.yml | new workflow file | ci.yml concurrency | new workflow file |
| Latency to detect | N/A | 0 | 0 | ≤1h |

## Follow-up if accepted

Remove `tla-specs` job from ci.yml main-push path (keep PR-time path-scoped only) to avoid duplicate runs.