### PR TITLE
ci(tla): exclude main pushes from cancel-in-progress — Option C of 4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,13 +14,22 @@ permissions:
   pull-requests: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.head.repo.full_name || github.repository }}-${{ github.head_ref || github.ref_name || github.run_id }}
+  # On main pushes each commit gets its own group (keyed by sha) so successive
+  # merges do not abort each other's CI — every commit gets a verification
+  # window. On PRs and non-main pushes, supersede outdated runs as before
+  # (group keyed by ref so synchronize cancels the older run).
+  group: >-
+    ${{ github.workflow }}-${{ github.event.pull_request.head.repo.full_name || github.repository }}-${{
+      github.event_name == 'push' && github.ref_name == 'main' && github.sha
+      || github.head_ref || github.ref_name || github.run_id
+    }}
   # Code-changing PR events supersede older CI for the same PR. Pushes to the
-  # same branch also supersede older post-merge CI; only the latest branch head
-  # needs the full verification matrix. State-only readiness events must not
-  # cancel an already-running code CI; they may queue behind it to run the
-  # ready/full-matrix path.
-  cancel-in-progress: ${{ github.event_name == 'push' || (github.event_name == 'pull_request' && contains(fromJSON('["opened","synchronize","reopened"]'), github.event.action)) }}
+  # same branch also supersede older post-merge CI EXCEPT for main pushes —
+  # main commits are independent state that must each be verified (background:
+  # #14668 / #14670, 30+ main runs cancelled before TLA could complete on
+  # 2026-05-11). State-only readiness events must not cancel already-running
+  # code CI; they may queue behind it to run the ready/full-matrix path.
+  cancel-in-progress: ${{ (github.event_name == 'push' && github.ref_name != 'main') || (github.event_name == 'pull_request' && contains(fromJSON('["opened","synchronize","reopened"]'), github.event.action)) }}
 
 jobs:
   pr-sync-check:


### PR DESCRIPTION
## Option C of 4 parallel PRs evaluating fixes for #14670 cancel cascade

Sibling PRs: A (job-level concurrency, ineffective), B (separate workflow), D (cron sweep).

## Problem

#14670 forced TLA+ to run on every main push. However, ci.yml's workflow-level `concurrency.cancel-in-progress=true` aborted 30+ consecutive main runs during the 2026-05-11 14:22-15:02 fast-track merge window — TLA (and all other jobs) never completed.

## This option

Two changes to ci.yml workflow-level concurrency:

1. **Group key on main pushes uses commit sha** (not just ref_name), so each main commit gets its own queue slot.
2. **`cancel-in-progress=false` on main pushes** (kept `true` for PRs and non-main pushes).

```yaml
group: >-
  ${{ github.workflow }}-${{ ... }}-${{
    github.event_name == 'push' && github.ref_name == 'main' && github.sha
    || github.head_ref || github.ref_name || github.run_id
  }}
cancel-in-progress: ${{ (github.event_name == 'push' && github.ref_name != 'main') || (github.event_name == 'pull_request' && contains(...)) }}
```

## Effect

Every main commit runs the **full** ci.yml workflow (build/test/lint/health/structure-ratchet/tla-specs/...) to completion. PR behaviour preserved — synchronize still cancels outdated runs.

## Trade-off

- Pros: covers *all* jobs (not just TLA) — fixes the same gap for build/lint/health verification on main. Single-file change.
- Cons: ~35min runner per main commit. With ~100 main merges/day peak, ~58h runner/day added. Largest cost option of the four.

## Comparison

| | A | B | C (this) | D |
|---|---|---|---|---|
| Solves cancel cascade | ❌ | ✅ | ✅ | ✅ (with latency) |
| Cost per main commit | 0 | +5min | +35min | 1 run/hour |
| Coverage | TLA | TLA | **all jobs** | TLA |
| Latency to detect | N/A | 0 | 0 | ≤1h |

If cost is acceptable, this is the most general fix. If TLA-only coverage is enough, B is cheaper.