### PR TITLE
ci(tla): hourly cron sweep of main HEAD — Option D of 4

### DIFF
--- a/.github/workflows/tla-scheduled.yml
+++ b/.github/workflows/tla-scheduled.yml
@@ -1,0 +1,62 @@
+name: TLA+ Scheduled Sweep
+
+# Periodic main-branch TLA verification. Catches spec violations that slip
+# past ci.yml's tla-specs job when rapid back-to-back merges trigger
+# workflow-level cancel-in-progress (see #14668 / #14670 background).
+#
+# Trade-off: latency-bounded detection (≤1h) vs zero-cost per-commit
+# verification. Cheapest option of the four (A/B/C/D evaluation) but accepts
+# a window where a spec violation can sit on main undetected.
+#
+# Pairs well with ci.yml's path-scoped PR-time check — most spec-affecting
+# changes are still caught at PR time; this is the safety net for spec
+# violations introduced by non-tla-path PRs via admin-merge fast-track.
+
+on:
+  schedule:
+    - cron: '0 * * * *'  # hourly
+  workflow_dispatch:
+
+concurrency:
+  group: tla-scheduled
+  cancel-in-progress: true  # if a sweep is running, the new hour's sweep
+                             # can supersede — they verify the same HEAD
+
+permissions:
+  contents: read
+
+jobs:
+  tla-specs:
+    name: TLA+ Model Checking (scheduled main HEAD)
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v5
+        with:
+          ref: main
+
+      - name: Setup Java
+        uses: actions/setup-java@v5
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+
+      - name: Download tla2tools.jar (pinned v1.8.0)
+        run: |
+          curl -fsSL -o specs/keeper-state-machine/tla2tools.jar \
+            https://github.com/tlaplus/tlaplus/releases/download/v1.8.0/tla2tools.jar
+
+      - name: Run TLA+ model checking
+        run: |
+          make -C specs check-clean
+          make -C specs check-buggy
+
+      - name: Record sweep result
+        if: always()
+        run: |
+          printf 'TLA sweep at %s on main HEAD %s — conclusion: %s\n' \
+            "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+            "$(git rev-parse HEAD)" \
+            "${{ job.status }}"


### PR DESCRIPTION
## Option D of 4 parallel PRs evaluating fixes for #14670 cancel cascade

Sibling PRs: A (job-level concurrency, ineffective), B (separate workflow), C (workflow cancel exclusion for main).

## Problem

#14670 forced TLA+ to run on every main push. However, ci.yml's workflow-level `concurrency.cancel-in-progress=true` aborted 30+ consecutive main runs during the 2026-05-11 14:22-15:02 fast-track merge window — TLA never completed.

## This option

New `.github/workflows/tla-scheduled.yml`:
- `on: schedule: cron '0 * * * *'` (hourly)
- Checks out main HEAD and runs `make check-clean` + `make check-buggy`
- `workflow_dispatch` for manual triggers

Pairs with ci.yml's existing path-scoped tla-specs (kept as-is). This is a *safety net*, not a per-commit guarantee.

## Effect

24 TLA runs/day on whatever is at main HEAD at sweep time. Bounds detection latency to ≤1h for spec violations on main.

## Trade-off

- Pros: cheapest of the four (24 runs/day vs ~100/day peak for B/C). Zero impact on ci.yml. Simple to revert.
- Cons: ≤1h detection latency — a spec violation introduced by an admin-merge fast-track PR can sit on main up to 1h before alerting. Cron schedule lag may extend this. Doesn't capture the specific commit that introduced the violation (sweep tests HEAD, not the commit just merged).

## Comparison

| | A | B | C | D (this) |
|---|---|---|---|---|
| Solves cancel cascade | ❌ | ✅ | ✅ | ✅ (with latency) |
| Cost per main commit | 0 | +5min | +35min | 0 (24 runs/day total) |
| Per-commit attribution | N/A | ✅ | ✅ | ❌ (HEAD only) |
| Latency to detect | N/A | 0 | 0 | ≤1h |

## Could also combine

D + (B or C) is reasonable — per-commit verification + periodic sweep for paranoia. D alone if cost is the primary concern.