### PR TITLE
fix(tool_coord): suggested_next applies take_items 2 to all branches

### DIFF
--- a/lib/tool_coord.ml
+++ b/lib/tool_coord.ml
@@ -469,27 +469,35 @@ let status_summary_string (ctx : context) =
       ~session_active:false
   in
   let suggested_next =
+    (* All branches must end with [take_items 2] so masc_status response
+       size stays bounded.  Prior pipeline had a trailing [|> take_items 2]
+       that applied uniformly; restoring that invariant explicitly per
+       branch (Copilot review #14662 thread tool_coord.ml:492). *)
     if Option.is_some planning_state.planning_missing_task
     then []
     else if Option.is_some planning_state.deliverable_conflict_task
     then [ "masc_deliver"; "masc_status" ]
-    else
-      guidance.next_steps
-      |> List.map (fun (step : Workflow_guide.step) -> step.tool)
-      |> fun tools ->
-      if credential_blocked
-      then List.filter (fun tool -> not (is_lifecycle_tool tool)) tools
-      else (
-        match binding.drift_reason with
-        | Some "no_owned" ->
-          let tools =
-            List.filter (fun tool -> not (String.equal tool "masc_transition")) tools
-          in
-          let tools =
-            if fresh_todo_count > 0 then "masc_claim_next" :: tools else tools
-          in
-          unique_strings tools
-        | Some _ | None -> tools |> take_items 2)
+    else (
+      let tools =
+        guidance.next_steps
+        |> List.map (fun (step : Workflow_guide.step) -> step.tool)
+      in
+      let tools =
+        if credential_blocked
+        then List.filter (fun tool -> not (is_lifecycle_tool tool)) tools
+        else (
+          match binding.drift_reason with
+          | Some "no_owned" ->
+            let tools =
+              List.filter (fun tool -> not (String.equal tool "masc_transition")) tools
+            in
+            let tools =
+              if fresh_todo_count > 0 then "masc_claim_next" :: tools else tools
+            in
+            unique_strings tools
+          | Some _ | None -> tools)
+      in
+      take_items 2 tools)
   in
   let attention_items =
     let items = [] in


### PR DESCRIPTION
## Summary

Post-merge follow-up to #14662.  Copilot review left one unresolved
thread at `lib/tool_coord.ml:492` after the PR squash-merged:

> \`suggested_next\` no longer applies \`take_items 2\` consistently.
> The list is only truncated in the \`Some _ | None\` drift_reason
> branch; the \`credential_blocked\` path and the \`Some \"no_owned\"\`
> path can now return an unbounded number of tools.

The prior pipeline ended with \`|> take_items 2\`, capping uniformly at
≤ 2 entries.  After the recent branch restructure, two branches escape
the cap, changing \`masc_status\` output shape/size.

## Fix

Restructure so all three branches build into a single \`tools\` binding,
with \`take_items 2\` applied once at the end.  Each branch's
filtering/insertion behaviour is preserved; only the trailing cap is
now guaranteed across paths.

## Diff shape

- All three branches (credential_blocked, no_owned, default) now flow
  into a shared \`let tools = ... in take_items 2 tools\` tail.
- 25 insertions / 17 deletions in a single file.

## Test plan

- [ ] CI green
- [ ] \`masc_status\` smoke: invoke with credential-blocked + no_owned
      paths — verify \`suggested_next\` ≤ 2 entries

RFC-WAIVED: not in credential/identity/operator/sandbox/hooks/workflow scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)