### PR TITLE
fix(test): migrate test_dashboard_goals.parse_json_result to Tool_result.t (main blocker)

### DIFF
--- a/test/test_dashboard_goals.ml
+++ b/test/test_dashboard_goals.ml
@@ -36,10 +36,12 @@ let with_room f =
 let coord_ctx config : Tool_coord.context =
   { Tool_coord.config; agent_name = "planner" }
 
-let parse_json_result (result : Tool_coord.tool_result) =
-  match result with
-  | { success = true; message = body } -> Yojson.Safe.from_string body
-  | { success = false; message = body } -> fail body
+let parse_json_result (result : Tool_result.t) =
+  (* RFC-0062 Phase 4d-2: Tool_coord.tool_result alias deleted.
+     Callers now consume Tool_result.t directly. [legacy_message] preserves
+     the prior string body for backward-compatible parsing. *)
+  if result.success then Yojson.Safe.from_string result.legacy_message
+  else fail result.legacy_message
 
 let principal_json ~kind ~id =
   `Assoc [ ("kind", `String kind); ("id", `String id) ]


### PR DESCRIPTION
## Main blocker

dune build on main currently fails:

\`\`\`
File \"test/test_dashboard_goals.ml\", line 39, characters 32-54:
39 | let parse_json_result (result : Tool_coord.tool_result) =
                                     ^^^^^^^^^^^^^^^^^^^^^^
Error: Unbound type constructor Tool_coord.tool_result
\`\`\`

## Root cause

RFC-0062 Phase 4d-2 (#14622) deleted the \`Tool_coord.tool_result\` alias:

\`\`\`
$ rg -n 'Coord_types.tool_result|type tool_result' lib/tool_coord.ml
26:(* [type tool_result = Coord_types.tool_result] DELETED in RFC-0062 Phase 4d-2.
\`\`\`

test_dashboard_goals.ml:39 still annotated \`parse_json_result\` with the deleted alias.

## Fix

Single-call-site migration to \`Tool_result.t\`:

| 항목 | Before | After |
|------|--------|-------|
| 타입 annotation | \`Tool_coord.tool_result\` | \`Tool_result.t\` |
| 패턴 | record \`{ success; message }\` | \`if/else on .success\` |
| 본문 필드 | \`message\` | \`legacy_message\` (RFC-0062 backward-compat carrier) |

\`Tool_coord.dispatch\` 시그니처는 변경 없음 (\`Tool_result.t option\` 반환). caller (L234, L252)도 변경 불필요.

## Verification

- Type-correctness: \`Tool_result.t\` mli에 \`success : bool\` + \`legacy_message : string\` 필드 확인 (\`lib/tool_result.mli:38-44\`).
- 동작 동등성: \`legacy_message\`가 RFC-0062에서 기존 \`message\` 문자열 그대로 보존하도록 설계됨 (mli docstring).
- CI에 빌드 검증 위임 (local dune lock 대기 길어서).

🤖 Generated with [Claude Code](https://claude.com/claude-code)