### PR TITLE
feat(cascade): TOML SSOT hardening — loop iterations 1+2

### DIFF
--- a/lib/cascade/cascade_catalog_runtime.ml
+++ b/lib/cascade/cascade_catalog_runtime.ml
@@ -670,7 +670,7 @@ let validate_path_result ?sw ?net ~config_path () =
          ~errors:[ Printf.sprintf "active cascade source is missing: %s" source_path ]
          ~profiles:[])
   else
-    match Cascade_config_loader.load_json config_path with
+    match Cascade_config_loader.load_catalog_source config_path with
     | Error msg ->
         Error
           (rejection_of_path ~config_path:source_path ~attempted_mtime ~checked_at

--- a/lib/cascade/cascade_config.ml
+++ b/lib/cascade/cascade_config.ml
@@ -16,7 +16,7 @@ let resolve_auto_model_id = Cascade_model_resolve.resolve_auto_model_id
 let parse_custom_model = Cascade_model_resolve.parse_custom_model
 
 (* Config loader *)
-let load_json = Cascade_config_loader.load_json
+let load_catalog_source = Cascade_config_loader.load_catalog_source
 let load_profile = Cascade_config_loader.load_profile
 
 type inference_params = Cascade_config_loader.inference_params = {
@@ -818,12 +818,12 @@ let resolve_model_strings_traced_with
     ~rand_int ?config_path ~name ~defaults () =
   match config_path with
   | Some path ->
-    (* Probe load_json before delegating to load_profile_weighted so we
+    (* Probe load_catalog_source before delegating to load_profile_weighted so we
        can distinguish a load failure (Load_failed source) from a
        successful-but-empty profile (Hardcoded_defaults source).  The
        load is cached, so the subsequent call inside
        load_profile_weighted is a cache hit. *)
-    (match Cascade_config_loader.load_json path with
+    (match Cascade_config_loader.load_catalog_source path with
      | Error msg -> (defaults, Load_failed msg)
      | Ok _ ->
     let from_file_weighted =
@@ -972,7 +972,7 @@ let resolve_model_strings_with_trace ?config_path ~name ~defaults () =
   | Some path ->
     (* Phase 2b: same probe pattern as resolve_model_strings_traced_with —
        distinguish a load fault from operator-intended absence. *)
-    (match Cascade_config_loader.load_json path with
+    (match Cascade_config_loader.load_catalog_source path with
      | Error msg ->
        let candidates =
          List.map (fun m ->
@@ -1240,13 +1240,13 @@ let model_ids_of_specs (specs : string list) : string list =
   |> List.sort_uniq String.compare
 
 let normalize_priority_tiers ~config_path ~name raw_tiers =
-  (* Phase 2c: probe load_json before delegating so that an unreadable
+  (* Phase 2c: probe load_catalog_source before delegating so that an unreadable
      cascade.toml/json surfaces as a load-failure error instead of the
      generic "no configured models" message — the latter mis-leads
      operators into thinking the profile is empty when the file is
      actually broken.  Mirrors the probe pattern in
      resolve_model_strings_traced_with / _with_trace (PR #11361). *)
-  match Cascade_config_loader.load_json config_path with
+  match Cascade_config_loader.load_catalog_source config_path with
   | Error msg ->
       Error
         (Printf.sprintf

--- a/lib/cascade/cascade_config.mli
+++ b/lib/cascade/cascade_config.mli
@@ -327,15 +327,19 @@ val resolve_model_strings_with_trace :
   unit ->
   string list * selection_trace
 
-(** {1 Raw JSON Access} *)
+(** {1 Catalog Source Access} *)
 
-(** Load and cache the raw JSON config file.
-    Cached with mtime-based hot-reload.
+(** Load and cache the cascade catalog source.
+
+    Returns a [Yojson.Safe.t] view for legacy JSON-shaped consumers,
+    but reads no on-disk JSON: [cascade.toml] is the SSOT and is parsed
+    into the returned value in memory. Cached by source-path mtime.
     Exposed for consumers needing custom fields beyond model lists
     (e.g., per-cascade temperature/max_tokens overrides).
 
-    @since 0.89.1 *)
-val load_json : string -> (Yojson.Safe.t, string) result
+    @since 0.89.1
+    @since RFC-0058 §9 Phase 9.3 renamed from [load_json]. *)
+val load_catalog_source : string -> (Yojson.Safe.t, string) result
 
 (** {1 Inference Parameters} *)
 

--- a/lib/cascade/cascade_config_loader.ml
+++ b/lib/cascade/cascade_config_loader.ml
@@ -94,8 +94,13 @@ let load_toml_in_memory config_path =
    JSON-only branch (mtime-cached disk read of cascade.json) has been
    removed along with [source_kind = Json]. All paths flow through
    [load_toml_in_memory], which renders TOML to JSON in memory and
-   caches by source-path mtime. *)
-let load_json path =
+   caches by source-path mtime.
+
+   Named [load_catalog_source] rather than [load_json] because no
+   on-disk JSON is read: a sibling [cascade.toml] is parsed and
+   rendered to an in-memory [Yojson.Safe.t] view that legacy
+   JSON-shaped consumers walk via [Yojson.Safe.Util]. *)
+let load_catalog_source path =
   try load_toml_in_memory path with
   | Sys_error msg -> Error msg
   | Unix.Unix_error (err, fn, arg) ->
@@ -455,7 +460,7 @@ let detect_capability_mismatches (entries : catalog_entry list)
 ;;
 
 let load_catalog ~config_path =
-  match load_json config_path with
+  match load_catalog_source config_path with
   | Error _ as err -> err
   | Ok (`Assoc fields) ->
     (* RFC-0058: register TOML-declared profiles before catalog parsing
@@ -574,7 +579,7 @@ let load_catalog ~config_path =
 
 let load_profile_weighted ~config_path ~name =
   let key = name ^ "_models" in
-  match load_json config_path with
+  match load_catalog_source config_path with
   | Error msg ->
     (* Surface the load failure on the standard logging channel so
          operators see it without tailing stderr. Returning the empty
@@ -654,7 +659,7 @@ let read_bool_field json key =
 ;;
 
 let resolve_inference_params ~config_path ~name =
-  match load_json config_path with
+  match load_catalog_source config_path with
   | Error msg ->
     Log.Misc.warn
       "[CascadeConfig] resolve_inference_params: %s (name=%s, path=%s)"
@@ -747,7 +752,7 @@ let read_api_key_env_field json key =
 ;;
 
 let resolve_api_key_env ~config_path ~name =
-  match load_json config_path with
+  match load_catalog_source config_path with
   | Error msg ->
     Log.Misc.warn
       "[CascadeConfig] resolve_api_key_env: %s (name=%s, path=%s)"
@@ -843,7 +848,7 @@ let empty_strategy_config =
 ;;
 
 let resolve_strategy_config ~config_path ~name =
-  match load_json config_path with
+  match load_catalog_source config_path with
   | Error msg ->
     Log.Misc.warn
       "[CascadeConfig] resolve_strategy_config: %s (name=%s, path=%s)"
@@ -910,7 +915,7 @@ let cascade_item_of_weighted_entry (entry : weighted_entry)
 let load_cascade_profile_hierarchical ~(config_path : string) ~(name : string)
   : Cascade_ref.cascade_profile option
   =
-  match load_json config_path with
+  match load_catalog_source config_path with
   | Error _ -> None
   | Ok json ->
     let open Yojson.Safe.Util in

--- a/lib/cascade/cascade_config_loader.mli
+++ b/lib/cascade/cascade_config_loader.mli
@@ -1,4 +1,4 @@
-(** JSON config loading with mtime-based hot-reload.
+(** Cascade catalog source loading with mtime-based hot-reload.
 
     @since 0.59.0
     @since 0.92.0 extracted from Cascade_config
@@ -6,13 +6,21 @@
     @stability Internal
     @since 0.93.1 *)
 
-(** Load and cache a raw JSON config file.
-    Cached with mtime-based hot-reload. When a sibling [cascade.toml] exists,
-    it is validated/materialized first and this loader then reads the
-    generated [cascade.json]. *)
-val load_json : string -> (Yojson.Safe.t, string) result
+(** Load and cache the cascade catalog source.
 
-(** Drop the cached JSON entry for one [cascade.json] path.
+    Despite returning [Yojson.Safe.t] for backward compatibility with the
+    JSON-shaped consumers (which still walk the value via
+    [Yojson.Safe.Util]), this function does not read any JSON from disk.
+    The on-disk source is [cascade.toml]; it is parsed by [Otoml] and
+    rendered to an in-memory [Yojson.Safe.t] view by
+    [Cascade_toml_materializer]. The cache is keyed by the resolved
+    source-path mtime.
+
+    @since RFC-0058 §9 Phase 9.3 renamed from [load_json] — no on-disk
+    JSON is read or written. *)
+val load_catalog_source : string -> (Yojson.Safe.t, string) result
+
+(** Drop the cached entry for one cascade source path.
 
     Intended for in-process editors/tests that overwrite the file and need
     the next read to bypass the previous mtime cache entry immediately.

--- a/lib/cascade/cascade_routes.ml
+++ b/lib/cascade/cascade_routes.ml
@@ -170,7 +170,7 @@ let configured_route_bindings ?config_path () =
   match path_opt with
   | None -> []
   | Some path -> (
-      match Cascade_config_loader.load_json path with
+      match Cascade_config_loader.load_catalog_source path with
       | Ok json -> route_bindings_from_json json
       | Error _ -> [])
 

--- a/lib/cascade_catalog_validator.ml
+++ b/lib/cascade_catalog_validator.ml
@@ -53,7 +53,7 @@ let discover_profiles_in_json = function
   | _ -> []
 
 let discover_profiles ~config_path =
-  match Cascade_config_loader.load_json config_path with
+  match Cascade_config_loader.load_catalog_source config_path with
   | Ok json -> discover_profiles_in_json json
   | Error _ -> []
 
@@ -356,7 +356,7 @@ let diagnose_profile ~config_path ~profile =
   issues @ capability_issues
 
 let diagnose_catalog ~config_path =
-  match Cascade_config_loader.load_json config_path with
+  match Cascade_config_loader.load_catalog_source config_path with
   | Error msg ->
       [
         {

--- a/lib/cascade_inference.ml
+++ b/lib/cascade_inference.ml
@@ -1,8 +1,10 @@
 (** Per-cascade inference parameters — thin delegation to MASC Cascade_config.
 
     Previously (v2.128.0-v2.148.0) this module maintained its own JSON cache
-    and field extraction. Since OAS v0.89.1 exposes [Cascade_config.load_json]
-    and [Cascade_config.resolve_inference_params], we now delegate entirely.
+    and field extraction. Since OAS v0.89.1 exposes
+    [Cascade_config.load_catalog_source] (renamed from [load_json] in
+    RFC-0058 §9 Phase 9.3) and [Cascade_config.resolve_inference_params],
+    we now delegate entirely.
 
     Public API preserved for backward compatibility:
     - [resolve_temperature], [resolve_max_tokens] (16 call sites in MASC)

--- a/lib/keeper/keeper_admission_policy.mli
+++ b/lib/keeper/keeper_admission_policy.mli
@@ -115,9 +115,9 @@ val parse_admission_json :
     — every persona must declare candidates explicitly to make I5
     (drift observability) defensible.
 
-    Pure: no file I/O.  The caller is expected to read the JSON from
-    [cascade_config_loader.load_json] and select the appropriate
-    sub-object before calling this function. *)
+    Pure: no file I/O.  The caller is expected to read the catalog
+    source via [Cascade_config_loader.load_catalog_source] and select
+    the appropriate sub-object before calling this function. *)
 
 (** {1 Query} *)
 

--- a/lib/keeper/keeper_admission_runtime.ml
+++ b/lib/keeper/keeper_admission_runtime.ml
@@ -134,14 +134,14 @@ let init_once_from_base_path ~base_path =
   if not (try_claim_init ())
   then ()
   else (
-    (* I/O outside the critical section.  [Cascade_config_loader.load_json]
-       can call [Eio.traceln] and may block on disk — holding [init_mutex]
-       across that risks domain-wide stalls of any other fiber that hits
-       this code. *)
+    (* I/O outside the critical section.
+       [Cascade_config_loader.load_catalog_source] can call [Eio.traceln]
+       and may block on disk — holding [init_mutex] across that risks
+       domain-wide stalls of any other fiber that hits this code. *)
     let cascade_json_path =
       Filename.concat (Filename.concat base_path ".masc/config") "cascade.json"
     in
-    match Cascade_config_loader.load_json cascade_json_path with
+    match Cascade_config_loader.load_catalog_source cascade_json_path with
     | Error msg ->
       (* Transient or permanent read failure — leave registry empty,
            revert to Idle so the next heartbeat tick can retry. *)

--- a/lib/keeper/keeper_admission_runtime.mli
+++ b/lib/keeper/keeper_admission_runtime.mli
@@ -27,8 +27,12 @@
 
 val init_once_from_base_path : base_path:string -> unit
 (** Idempotent init.  First successful call:
-      1. Reads [<base_path>/.masc/config/cascade.json] via
-         [Cascade_config_loader.load_json] (mtime-cached).
+      1. Reads the cascade catalog source via
+         [Cascade_config_loader.load_catalog_source] (mtime-cached).
+         The [<base_path>/.masc/config/cascade.json] path is passed
+         for backward compatibility; the loader redirects to the
+         sibling [cascade.toml] which is the actual SSOT
+         (RFC-0058 §9 Phase 9.3).
       2. Builds [Keeper_admission_registry] from the [admission]
          sub-object.
       3. Sets [policy_lookup] to [Keeper_admission_registry.lookup].
@@ -40,8 +44,8 @@ val init_once_from_base_path : base_path:string -> unit
     Concurrency model: a three-state flag (Idle/In_progress/Done) is
     guarded by a [Mutex.protect] that is held ONLY across state
     transitions, never across the file I/O step.  This prevents
-    domain-wide stalls when [Cascade_config_loader.load_json] traces
-    via [Eio.traceln] or blocks on disk.
+    domain-wide stalls when [Cascade_config_loader.load_catalog_source]
+    traces via [Eio.traceln] or blocks on disk.
 
     Failure model: a transient load failure logs via [Log.Keeper.warn],
     reverts the flag to Idle, and returns.  The next heartbeat tick

--- a/test/test_cascade_toml_materialization.ml
+++ b/test/test_cascade_toml_materialization.ml
@@ -428,7 +428,7 @@ unknown_field = 1
       check bool "rejection mentions unknown field" true
         (contains_substring rendered "unknown field")
 
-(* Phase 2 regression: when load_json fails (malformed JSON, missing
+(* Phase 2 regression: when load_catalog_source fails (malformed TOML, missing
    IO, or strict-field rejection on TOML side), the resolved
    selection_trace.source must be [Load_failed _], not the bug-prior
    [Hardcoded_defaults].  Without this, an operator viewing the


### PR DESCRIPTION
## /loop cascade-toml-hardening — multi-iteration PR

### Iteration 1 (commit 4249f78c)
**Rename `load_json` → `load_catalog_source` across 12 files / 26 occurrences.**

- Function name dated back to when `cascade.json` was the on-disk source. Since RFC-0058 §9 Phase 9.3 (#14592), TOML is the sole SSOT and no JSON is read from disk; the loader returns `Yojson.Safe.t` only for legacy consumers.
- Two `.mli` docstrings directly contradicted the actual flow: `cascade_config_loader.mli` claimed "this loader then reads the generated cascade.json" and `keeper_admission_runtime.mli` claimed "Reads `<base_path>/.masc/config/cascade.json`". Both rewritten.
- Pure rename + docstring rewrite; no behavior change.

### Iteration 2 (commit 6e708bd9d)
**Split silent fallthrough in `discover_profile_names` + add telemetry.**

`cascade_catalog_runtime.ml:discover_profile_names` previously collapsed `Some (Error _)` and `None` from the declarative parser into a single legacy fallback arm. Adapter errors were silently discarded and operators had no signal that the live `cascade.toml` was producing parse faults.

Three arms now distinct:

| Parser result | New behavior | New metric label |
|---|---|---|
| `Some (Ok _)` | Steady state — declarative success | `path="declarative"` |
| `Some (Error errs)` | Each error surfaced via `Log.Misc.warn` (was silent); fallback engages with WARN; counter ticks | `path="legacy_after_decl_error"` + `masc_cascade_declarative_parse_errors_total` |
| `None` | DEBUG note (expected for pre-RFC-0058 fixtures) | `path="legacy_no_decl"` |

New Prometheus metrics:

- `masc_cascade_profile_discovery_total{path}` — which arm wins per discovery call. Non-zero `path="legacy_after_decl_error"` on production is the explicit signal that cascade.toml is broken.
- `masc_cascade_declarative_parse_errors_total` — declarative parser fault rate.

Behavior preserved: steady-state callers receive the same profile names. Only the fallback arms gained observability + structured WARN.

### Remaining /loop backlog (future iterations)
- (#3) Parallel declarative validation mismatch (`cascade_catalog_runtime.ml:791-815`) is WARN-only, no Prometheus counter.
- (#4) `load_toml_in_memory` mtime cache TOCTOU race window.
- (#5) `Serving_last_known_good` state entry has no telemetry/alarm.
- (housekeeping) `keeper_admission_runtime.ml:141` still constructs path with literal `cascade.json` — materializer redirects so it works, but the variable name + literal are misleading.

### Verification
- `dune build lib/ bin/` → clean
- `test_cascade_toml_materialization` → 20/20 OK
- `test_cascade_catalog_runtime` → 23/23 OK
- `rg '\bload_json\b'` → only intentional RFC-0058 §9.3 history annotations remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)