### PR TITLE
refactor(keeper): remove is_ollama_cfg variant match (RFC-0058 Phase 5.6 leak 1/4)

### DIFF
--- a/lib/keeper/keeper_turn_liveness.ml
+++ b/lib/keeper/keeper_turn_liveness.ml
@@ -11,79 +11,83 @@ open Keeper_types
 
 type local_only_liveness_decision =
   | Keep_effective_cascade of string
-  | Probe_local_only_urls of {
-      effective_cascade : string;
-      fallback_cascade : string;
-      probeable_base_urls : string list;
-    }
+  | Probe_local_only_urls of
+      { effective_cascade : string
+      ; fallback_cascade : string
+      ; probeable_base_urls : string list
+      }
 
 let decide_local_only_liveness
-    ?resolve_label
-    ~(base_cascade : string)
-    ~(effective_cascade : string)
-    (labels : string list) : local_only_liveness_decision =
+      ?resolve_label
+      ~(base_cascade : string)
+      ~(effective_cascade : string)
+      (labels : string list)
+  : local_only_liveness_decision
+  =
   let resolve_label =
     match resolve_label with
     | Some resolve_label -> resolve_label
     | None -> fun label -> Cascade_config.parse_model_string label
   in
-  let normalized_base =
-    Keeper_cascade_profile.normalize_declared_name base_cascade
-  in
+  let normalized_base = Keeper_cascade_profile.normalize_declared_name base_cascade in
   let normalized_effective =
     Keeper_cascade_profile.normalize_declared_name effective_cascade
   in
-  if not (String.equal normalized_effective Keeper_config.local_only_cascade_name)
-     || String.equal normalized_base Keeper_config.local_only_cascade_name
+  if
+    (not (String.equal normalized_effective Keeper_config.local_only_cascade_name))
+    || String.equal normalized_base Keeper_config.local_only_cascade_name
   then Keep_effective_cascade normalized_effective
-  else
+  else (
     let probeable_urls =
       labels
       |> List.filter_map resolve_label
       |> List.filter_map (fun (cfg : Llm_provider.Provider_config.t) ->
-             if Cascade_capacity_probe.can_probe ~url:cfg.base_url then
-               Some cfg.base_url
-             else None)
+        if Cascade_capacity_probe.can_probe ~url:cfg.base_url
+        then Some cfg.base_url
+        else None)
       |> dedupe_keep_order
     in
     match probeable_urls with
     | [] -> Keep_effective_cascade normalized_effective
     | probeable_base_urls ->
-        Probe_local_only_urls
-          {
-            effective_cascade = normalized_effective;
-            fallback_cascade = normalized_base;
-            probeable_base_urls;
-          }
+      Probe_local_only_urls
+        { effective_cascade = normalized_effective
+        ; fallback_cascade = normalized_base
+        ; probeable_base_urls
+        })
+;;
 
 let fail_open_local_only_when_unavailable
-    ?resolve_label
-    ?probe_base_url
-    ~(base_cascade : string)
-    ~(effective_cascade : string)
-    (labels : string list) : string =
+      ?resolve_label
+      ?probe_base_url
+      ~(base_cascade : string)
+      ~(effective_cascade : string)
+      (labels : string list)
+  : string
+  =
   match
-    decide_local_only_liveness ?resolve_label ~base_cascade ~effective_cascade
-      labels
+    decide_local_only_liveness ?resolve_label ~base_cascade ~effective_cascade labels
   with
   | Keep_effective_cascade cascade -> cascade
-  | Probe_local_only_urls
-      { effective_cascade; fallback_cascade; probeable_base_urls } ->
-      let probe_base_url =
-        match probe_base_url with
-        | Some probe -> Some probe
-        | None ->
-          (match Eio_context.get_switch_opt (), Eio_context.get_net_opt () with
-           | Some sw, Some net ->
-             Some (fun base_url ->
+  | Probe_local_only_urls { effective_cascade; fallback_cascade; probeable_base_urls } ->
+    let probe_base_url =
+      match probe_base_url with
+      | Some probe -> Some probe
+      | None ->
+        (match Eio_context.get_switch_opt (), Eio_context.get_net_opt () with
+         | Some sw, Some net ->
+           Some
+             (fun base_url ->
                Option.is_some (Cascade_capacity_probe.probe ~sw ~net ~url:base_url ()))
-           | _ -> None)
-      in
-      (match probe_base_url with
-       | None -> effective_cascade
-       | Some probe ->
-         if List.exists probe probeable_base_urls then effective_cascade
-         else fallback_cascade)
+         | _ -> None)
+    in
+    (match probe_base_url with
+     | None -> effective_cascade
+     | Some probe ->
+       if List.exists probe probeable_base_urls
+       then effective_cascade
+       else fallback_cascade)
+;;
 
 (** PR-B: saturation pre-skip support (provider-agnostic).
 
@@ -110,10 +114,9 @@ let fail_open_local_only_when_unavailable
 
     Pure: [resolve_label] resolves labels and [can_probe] queries the
     probe registry — both are injected dependencies for tests. *)
-let resolve_shared_probeable_base_url
-    ?resolve_label
-    ?can_probe
-    (labels : string list) : string option =
+let resolve_shared_probeable_base_url ?resolve_label ?can_probe (labels : string list)
+  : string option
+  =
   let resolve_label =
     match resolve_label with
     | Some f -> f
@@ -126,19 +129,18 @@ let resolve_shared_probeable_base_url
   in
   match labels with
   | [] -> None
-  | first :: rest -> (
-      match resolve_label first with
-      | None -> None
-      | Some cfg ->
-          let base_url = cfg.base_url in
-          let same_host label =
-            match resolve_label label with
-            | Some other -> String.equal other.base_url base_url
-            | None -> false
-          in
-          if List.for_all same_host rest && can_probe base_url then
-            Some base_url
-          else None)
+  | first :: rest ->
+    (match resolve_label first with
+     | None -> None
+     | Some cfg ->
+       let base_url = cfg.base_url in
+       let same_host label =
+         match resolve_label label with
+         | Some other -> String.equal other.base_url base_url
+         | None -> false
+       in
+       if List.for_all same_host rest && can_probe base_url then Some base_url else None)
+;;
 
 (** [is_base_url_saturated ?capacity_lookup base_url] returns [true]
     only when the cache has a fresh entry whose
@@ -147,9 +149,7 @@ let resolve_shared_probeable_base_url
     failed probes are deliberately treated as "not saturated" so a
     flaky probe never starves the keeper.  Mirrors the conservative
     fail-open policy in [Cascade_http_probe.try_probe]. *)
-let is_base_url_saturated
-    ?capacity_lookup
-    (base_url : string) : bool =
+let is_base_url_saturated ?capacity_lookup (base_url : string) : bool =
   let capacity_lookup =
     match capacity_lookup with
     | Some f -> f
@@ -158,8 +158,9 @@ let is_base_url_saturated
   match capacity_lookup base_url with
   | None -> false
   | Some (info : Cascade_throttle.capacity_info) ->
-      info.process_available <= 0
-      && (info.process_active > 0 || info.process_queue_length > 0)
+    info.process_available <= 0
+    && (info.process_active > 0 || info.process_queue_length > 0)
+;;
 
 (** Backoff sleep applied after a saturation skip so the keeper does
     not hot-spin against a busy local backend. Short by design:
@@ -172,21 +173,22 @@ let saturation_skip_jitter_factor = 0.4
 
 let saturation_skip_sleep_duration () =
   let jitter =
-    saturation_skip_backoff_sec
-    *. saturation_skip_jitter_factor
-    *. Random.float 1.0
+    saturation_skip_backoff_sec *. saturation_skip_jitter_factor *. Random.float 1.0
   in
   saturation_skip_backoff_sec +. jitter
+;;
 
 let turn_livelock_max_attempts () =
-  Int.max 1
-    (Env_config_core.get_int ~default:3
-       "MASC_KEEPER_TURN_LIVELOCK_MAX_ATTEMPTS")
+  Int.max 1 (Env_config_core.get_int ~default:3 "MASC_KEEPER_TURN_LIVELOCK_MAX_ATTEMPTS")
+;;
 
 let turn_livelock_stuck_after_sec () =
-  Float.max 1.0
-    (Env_config_core.get_float ~default:1800.0
+  Float.max
+    1.0
+    (Env_config_core.get_float
+       ~default:1800.0
        "MASC_KEEPER_TURN_LIVELOCK_STUCK_AFTER_SEC")
+;;
 
 (* PR-B follow-up: bound consecutive saturation skips per keeper.
 
@@ -208,39 +210,39 @@ let turn_livelock_stuck_after_sec () =
    the documented fail-open invariant. *)
 
 let saturation_skip_counts : (string, int) Hashtbl.t = Hashtbl.create 32
-
 let saturation_skip_counts_mutex = Eio.Mutex.create ()
-
 let max_consecutive_saturation_skips_default = 5
-
-let max_consecutive_saturation_skips_env =
-  "MASC_MAX_CONSECUTIVE_SATURATION_SKIPS"
+let max_consecutive_saturation_skips_env = "MASC_MAX_CONSECUTIVE_SATURATION_SKIPS"
 
 let max_consecutive_saturation_skips () =
-  Int.max 1
+  Int.max
+    1
     (Env_config_core.get_int
        ~default:max_consecutive_saturation_skips_default
        max_consecutive_saturation_skips_env)
+;;
 
 let saturation_skip_count_get ~keeper_name =
   Eio.Mutex.use_ro saturation_skip_counts_mutex (fun () ->
-    Option.value ~default:0
-      (Hashtbl.find_opt saturation_skip_counts keeper_name))
+    Option.value ~default:0 (Hashtbl.find_opt saturation_skip_counts keeper_name))
+;;
 
 let saturation_skip_count_inc ~keeper_name =
   Eio.Mutex.use_rw ~protect:false saturation_skip_counts_mutex (fun () ->
     let cur =
-      Option.value ~default:0
-        (Hashtbl.find_opt saturation_skip_counts keeper_name)
+      Option.value ~default:0 (Hashtbl.find_opt saturation_skip_counts keeper_name)
     in
     let next = cur + 1 in
     Hashtbl.replace saturation_skip_counts keeper_name next;
     next)
+;;
 
 let saturation_skip_count_reset ~keeper_name =
   Eio.Mutex.use_rw ~protect:false saturation_skip_counts_mutex (fun () ->
     Hashtbl.remove saturation_skip_counts keeper_name)
+;;
 
 let saturation_skip_count_clear_all () =
   Eio.Mutex.use_rw ~protect:false saturation_skip_counts_mutex (fun () ->
     Hashtbl.clear saturation_skip_counts)
+;;

--- a/lib/keeper/keeper_turn_liveness.ml
+++ b/lib/keeper/keeper_turn_liveness.ml
@@ -1,5 +1,9 @@
-(* Keeper_turn_liveness — phase-buffer cascade liveness decisions, ollama
-   saturation pre-skip, and turn liveload configuration.
+(* Keeper_turn_liveness — phase-buffer cascade liveness decisions,
+   capacity-probe saturation pre-skip, and turn liveload configuration.
+
+   Provider-specific knowledge lives in [Cascade_capacity_probe]; this
+   module routes probeable URLs through that registry without naming
+   any single provider.
 
    Extracted from keeper_unified_turn.ml (L328-499) during the god-file split. *)
 
@@ -81,61 +85,69 @@ let fail_open_local_only_when_unavailable
          if List.exists probe probeable_base_urls then effective_cascade
          else fallback_cascade)
 
-(** PR-B: ollama saturation pre-skip support.
+(** PR-B: saturation pre-skip support (provider-agnostic).
 
     When every label in the resolved cascade points at the same
-    ollama [base_url] (single-provider profile), we can pre-check the
-    [Cascade_capacity_probe] cache before paying an [Agent.run] dispatch.
-    If the probe reports [process_available <= 0] the request would
-    queue on a busy slot and very likely blow the keeper turn budget,
-    causing a cascading FAILED cycle.  Skipping the turn here keeps
-    the keeper alive without burning the budget. *)
+    [base_url] AND a registered [Cascade_capacity_probe] recognises
+    that URL, we can pre-check the probe cache before paying an
+    [Agent.run] dispatch.  If the probe reports
+    [process_available <= 0] the request would queue on a busy slot
+    and very likely blow the keeper turn budget, causing a cascading
+    FAILED cycle.  Skipping the turn here keeps the keeper alive
+    without burning the budget.
 
-(** [resolve_ollama_only_base_url ?resolve_label labels] returns
-    [Some url] when [labels] is non-empty AND every label parses to
-    an ollama provider config sharing the same [base_url].  Returns
-    [None] when the cascade has zero candidates, when any candidate
-    is non-ollama, when ollama candidates point at different hosts,
-    or when any label fails to parse.
+    No provider variant is named — the probe registry is the
+    boundary that decides which URLs are probeable.  Adding a new
+    local backend (vllm, lmstudio, …) only needs a new probe
+    registration. *)
 
-    Pure: [resolve_label] is the only injected dependency for tests. *)
-let resolve_ollama_only_base_url
+(** [resolve_shared_probeable_base_url ?resolve_label ?can_probe labels]
+    returns [Some url] when [labels] is non-empty AND every label
+    parses to a provider config sharing the same [base_url] AND that
+    URL is recognised by the capacity-probe registry.  Returns
+    [None] otherwise (empty cascade, any unresolved label, mixed
+    hosts, or no registered probe for the URL).
+
+    Pure: [resolve_label] resolves labels and [can_probe] queries the
+    probe registry — both are injected dependencies for tests. *)
+let resolve_shared_probeable_base_url
     ?resolve_label
+    ?can_probe
     (labels : string list) : string option =
   let resolve_label =
     match resolve_label with
     | Some f -> f
     | None -> fun label -> Cascade_config.parse_model_string label
   in
+  let can_probe =
+    match can_probe with
+    | Some f -> f
+    | None -> fun url -> Cascade_capacity_probe.can_probe ~url
+  in
   match labels with
   | [] -> None
-  | first :: rest ->
-      let is_ollama_cfg (cfg : Llm_provider.Provider_config.t) =
-        match cfg.kind with
-        | Llm_provider.Provider_config.Ollama -> true
-        | _ -> false
-      in
-      (match resolve_label first with
-       | Some cfg when is_ollama_cfg cfg ->
-           let base_url = cfg.base_url in
-           let same_ollama_host label =
-             match resolve_label label with
-             | Some other when is_ollama_cfg other ->
-                 String.equal other.base_url base_url
-             | _ -> false
-           in
-           if List.for_all same_ollama_host rest then Some base_url
-           else None
-       | _ -> None)
+  | first :: rest -> (
+      match resolve_label first with
+      | None -> None
+      | Some cfg ->
+          let base_url = cfg.base_url in
+          let same_host label =
+            match resolve_label label with
+            | Some other -> String.equal other.base_url base_url
+            | None -> false
+          in
+          if List.for_all same_host rest && can_probe base_url then
+            Some base_url
+          else None)
 
-(** [is_ollama_saturated ?capacity_lookup base_url] returns [true]
+(** [is_base_url_saturated ?capacity_lookup base_url] returns [true]
     only when the cache has a fresh entry whose
     [process_available <= 0] AND there is at least one queued or
     active request.  [None] (no cache entry / probe never ran) and
     failed probes are deliberately treated as "not saturated" so a
     flaky probe never starves the keeper.  Mirrors the conservative
     fail-open policy in [Cascade_http_probe.try_probe]. *)
-let is_ollama_saturated
+let is_base_url_saturated
     ?capacity_lookup
     (base_url : string) : bool =
   let capacity_lookup =
@@ -150,7 +162,7 @@ let is_ollama_saturated
       && (info.process_active > 0 || info.process_queue_length > 0)
 
 (** Backoff sleep applied after a saturation skip so the keeper does
-    not hot-spin against a busy ollama instance. Short by design:
+    not hot-spin against a busy local backend. Short by design:
     the heartbeat loop already has its own pacing (see
     [keeper_keepalive.ml]); this only covers the case where multiple
     keepers race the probe cache. *)

--- a/lib/keeper/keeper_turn_liveness.mli
+++ b/lib/keeper/keeper_turn_liveness.mli
@@ -15,87 +15,87 @@ open Keeper_types
     preserving [local_only]. *)
 type local_only_liveness_decision =
   | Keep_effective_cascade of string
-  | Probe_local_only_urls of {
-      effective_cascade : string;
-      fallback_cascade : string;
-      probeable_base_urls : string list;
-    }
+  | Probe_local_only_urls of
+      { effective_cascade : string
+      ; fallback_cascade : string
+      ; probeable_base_urls : string list
+      }
 
-val decide_local_only_liveness :
-  ?resolve_label:(string -> Llm_provider.Provider_config.t option) ->
-  base_cascade:string ->
-  effective_cascade:string ->
-  string list ->
-  local_only_liveness_decision
+val decide_local_only_liveness
+  :  ?resolve_label:(string -> Llm_provider.Provider_config.t option)
+  -> base_cascade:string
+  -> effective_cascade:string
+  -> string list
+  -> local_only_liveness_decision
 
-val fail_open_local_only_when_unavailable :
-  ?resolve_label:(string -> Llm_provider.Provider_config.t option) ->
-  ?probe_base_url:(string -> bool) ->
-  base_cascade:string ->
-  effective_cascade:string ->
-  string list ->
-  string
 (** When phase routing temporarily forces the phase-buffer route, fail open to the
     keeper's configured base cascade if no registered local-capable probe
     reports the endpoint as serving. Legacy [local_only] aliases
     normalize through [routes.phase_buffer]. *)
+val fail_open_local_only_when_unavailable
+  :  ?resolve_label:(string -> Llm_provider.Provider_config.t option)
+  -> ?probe_base_url:(string -> bool)
+  -> base_cascade:string
+  -> effective_cascade:string
+  -> string list
+  -> string
 
-val resolve_shared_probeable_base_url :
-  ?resolve_label:(string -> Llm_provider.Provider_config.t option) ->
-  ?can_probe:(string -> bool) ->
-  string list ->
-  string option
 (** PR-B: when every label in the resolved cascade points at the same
     [base_url] AND a registered [Cascade_capacity_probe] recognises
     that URL, return [Some url]; otherwise [None]. Purely structural:
     does not probe the network. Provider variant is never inspected —
     the probe registry is the boundary that decides which URLs are
     probeable. *)
+val resolve_shared_probeable_base_url
+  :  ?resolve_label:(string -> Llm_provider.Provider_config.t option)
+  -> ?can_probe:(string -> bool)
+  -> string list
+  -> string option
 
-val is_base_url_saturated :
-  ?capacity_lookup:(string -> Cascade_throttle.capacity_info option) ->
-  string ->
-  bool
 (** Read the [Cascade_capacity_probe] cache and report whether the endpoint
     is saturated (no available slots while at least one request is active
     or queued). No cache / failed probe returns [false] (fail-open) so a
     flaky probe never starves the keeper. *)
+val is_base_url_saturated
+  :  ?capacity_lookup:(string -> Cascade_throttle.capacity_info option)
+  -> string
+  -> bool
 
-val saturation_skip_backoff_sec : float
 (** Backoff sleep applied after a saturation skip (seconds). *)
+val saturation_skip_backoff_sec : float
 
-val saturation_skip_jitter_factor : float
 (** Jitter factor for saturation skip sleep. *)
+val saturation_skip_jitter_factor : float
 
-val saturation_skip_sleep_duration : unit -> float
 (** Compute a jittered sleep duration for saturation skip. *)
+val saturation_skip_sleep_duration : unit -> float
 
-val turn_livelock_max_attempts : unit -> int
 (** Configurable livelock detection max attempts. *)
+val turn_livelock_max_attempts : unit -> int
 
-val turn_livelock_stuck_after_sec : unit -> float
 (** Configurable livelock detection stuck threshold (seconds). *)
+val turn_livelock_stuck_after_sec : unit -> float
 
-val max_consecutive_saturation_skips : unit -> int
 (** Upper bound on consecutive saturation skips per keeper (env
     [MASC_MAX_CONSECUTIVE_SATURATION_SKIPS], default 5, floored at
     1).  When a keeper exceeds this count its next dispatch escapes
     the saturation pre-skip path so a stuck or stale probe cannot
     starve the keeper indefinitely. *)
+val max_consecutive_saturation_skips : unit -> int
 
-val saturation_skip_count_get : keeper_name:string -> int
 (** Current consecutive-skip count for [keeper_name].  Returns 0 when
     the keeper has no recorded skips. *)
+val saturation_skip_count_get : keeper_name:string -> int
 
-val saturation_skip_count_inc : keeper_name:string -> int
 (** Increment and return the new consecutive-skip count for
     [keeper_name].  Caller decides whether to act on the new count
     (compare against {!max_consecutive_saturation_skips}). *)
+val saturation_skip_count_inc : keeper_name:string -> int
 
-val saturation_skip_count_reset : keeper_name:string -> unit
 (** Reset [keeper_name]'s consecutive-skip count to zero.  Called on
     every non-skip path (probe reports unsaturated, non-probeable
     cascade, force-dispatch escape). *)
+val saturation_skip_count_reset : keeper_name:string -> unit
 
-val saturation_skip_count_clear_all : unit -> unit
 (** Test helper: clear all per-keeper consecutive-skip counters. *)
+val saturation_skip_count_clear_all : unit -> unit

--- a/lib/keeper/keeper_turn_liveness.mli
+++ b/lib/keeper/keeper_turn_liveness.mli
@@ -40,15 +40,19 @@ val fail_open_local_only_when_unavailable :
     reports the endpoint as serving. Legacy [local_only] aliases
     normalize through [routes.phase_buffer]. *)
 
-val resolve_ollama_only_base_url :
+val resolve_shared_probeable_base_url :
   ?resolve_label:(string -> Llm_provider.Provider_config.t option) ->
+  ?can_probe:(string -> bool) ->
   string list ->
   string option
-(** PR-B: when every label in the resolved cascade points at the
-    same ollama [base_url] return [Some url], else [None]. Purely
-    structural: does not probe the network. *)
+(** PR-B: when every label in the resolved cascade points at the same
+    [base_url] AND a registered [Cascade_capacity_probe] recognises
+    that URL, return [Some url]; otherwise [None]. Purely structural:
+    does not probe the network. Provider variant is never inspected —
+    the probe registry is the boundary that decides which URLs are
+    probeable. *)
 
-val is_ollama_saturated :
+val is_base_url_saturated :
   ?capacity_lookup:(string -> Cascade_throttle.capacity_info option) ->
   string ->
   bool
@@ -90,7 +94,7 @@ val saturation_skip_count_inc : keeper_name:string -> int
 
 val saturation_skip_count_reset : keeper_name:string -> unit
 (** Reset [keeper_name]'s consecutive-skip count to zero.  Called on
-    every non-skip path (probe reports unsaturated, non-ollama
+    every non-skip path (probe reports unsaturated, non-probeable
     cascade, force-dispatch escape). *)
 
 val saturation_skip_count_clear_all : unit -> unit

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -459,12 +459,12 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
         let labels =
           Keeper_coordination.effective_model_labels_for_turn meta_for_check
         in
-        match resolve_ollama_only_base_url labels with
+        match resolve_shared_probeable_base_url labels with
         | None ->
             saturation_skip_count_reset ~keeper_name:meta.name;
             None
         | Some base_url ->
-            if not (is_ollama_saturated base_url) then begin
+            if not (is_base_url_saturated base_url) then begin
               saturation_skip_count_reset ~keeper_name:meta.name;
               None
             end

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -10,7 +10,6 @@ open Keeper_types
 open Keeper_exec_context
 module Social = Keeper_social_model
 module KCP = Keeper_cascade_profile
-
 include Keeper_turn_helpers
 include Keeper_turn_liveness
 include Keeper_turn_cascade_budget
@@ -24,56 +23,65 @@ include Keeper_turn_cascade_budget
    for the SDK-error fallback, this routing reduces to a clean variant
    match — no substring classifier left in this function. *)
 let registry_failure_reason_of_terminal_reason
-    (terminal_reason : Keeper_turn_terminal.t)
-    ~(raw_error : string) : Keeper_registry.failure_reason option =
+      (terminal_reason : Keeper_turn_terminal.t)
+      ~(raw_error : string)
+  : Keeper_registry.failure_reason option
+  =
   let detail = short_preview raw_error in
   match terminal_reason.disposition with
   | Keeper_turn_disposition.Required_tool_use_no_tool_call ->
-      Some
-        (Keeper_registry.Tool_required_unsatisfied
-           { code = "required_tool_use_no_tool_call"; detail })
+    Some
+      (Keeper_registry.Tool_required_unsatisfied
+         { code = "required_tool_use_no_tool_call"; detail })
   | Keeper_turn_disposition.Required_tool_use_unsatisfied ->
-      Some
-        (Keeper_registry.Tool_required_unsatisfied
-           { code = "required_tool_use_unsatisfied"; detail })
+    Some
+      (Keeper_registry.Tool_required_unsatisfied
+         { code = "required_tool_use_unsatisfied"; detail })
   | Keeper_turn_disposition.Provider_error c ->
-      Some
-        (Keeper_registry.Provider_runtime_error
-           { code = Keeper_turn_terminal_code.to_wire c; detail })
+    Some
+      (Keeper_registry.Provider_runtime_error
+         { code = Keeper_turn_terminal_code.to_wire c; detail })
   | Keeper_turn_disposition.Success
   | Keeper_turn_disposition.External_cancel
   | Keeper_turn_disposition.Turn_wall_clock_timeout
   | Keeper_turn_disposition.Oas_timeout_budget
   | Keeper_turn_disposition.Gh_repo_context_missing_worktree
   | Keeper_turn_disposition.Post_commit_ambiguous
-  | Keeper_turn_disposition.Unknown _ ->
-      None
+  | Keeper_turn_disposition.Unknown _ -> None
+;;
 
 let should_auto_pause_required_tool_contract_violation
-    ~(paused : bool)
-    ~(consecutive_failures : int)
-    (err : Agent_sdk.Error.sdk_error) : bool =
+      ~(paused : bool)
+      ~(consecutive_failures : int)
+      (err : Agent_sdk.Error.sdk_error)
+  : bool
+  =
   EC.is_required_tool_contract_violation err
   && consecutive_failures >= Keeper_behavioral_regime.turn_fail_streak_threshold
   && not paused
+;;
 
 let record_streaming_cancelled_observation
-    ~(config : Coord.config)
-    ~(run_meta : keeper_meta)
-    ~(run_generation : int)
-    ~(cascade_name : Keeper_execution_receipt.cascade_name)
-    ~(keeper_turn_id : int)
-    () : unit =
+      ~(config : Coord.config)
+      ~(run_meta : keeper_meta)
+      ~(run_generation : int)
+      ~(cascade_name : Keeper_execution_receipt.cascade_name)
+      ~(keeper_turn_id : int)
+      ()
+  : unit
+  =
   let fiber_stop_set =
     match Keeper_registry.get ~base_path:config.base_path run_meta.name with
     | Some entry -> Atomic.get entry.fiber_stop
     | None -> false
   in
-  if fiber_stop_set then
+  if fiber_stop_set
+  then
     (* FSM: SupervisorRequestsStop — stop signal confirmed while streaming;
        turn about to cancel cooperatively. *)
     Keeper_turn_fsm.emit_transition
-      ~keeper_name:run_meta.name ~turn_id:keeper_turn_id
+      ~keeper_name:run_meta.name
+      ~turn_id:keeper_turn_id
       ~prev:Keeper_turn_fsm.Streaming
       Keeper_turn_fsm.Streaming;
   let terminal_reason_code =
@@ -92,72 +100,79 @@ let record_streaming_cancelled_observation
     ();
   (* FSM: HonorStopSignal — cooperative cancel. *)
   Keeper_turn_fsm.emit_transition
-    ~keeper_name:run_meta.name ~turn_id:keeper_turn_id
+    ~keeper_name:run_meta.name
+    ~turn_id:keeper_turn_id
     ~prev:Keeper_turn_fsm.Streaming
     (Keeper_turn_fsm.Cancelled Keeper_turn_fsm.Cancelled_supervisor_stop)
+;;
 
 let sdk_error_of_retry_slot_reacquire_timeout
-    ~(keeper_name : string)
-    (timeout : Keeper_turn_slot.semaphore_wait_timeout) =
-  let phase =
-    Keeper_turn_slot.semaphore_wait_phase_to_string timeout.timeout_phase
-  in
-  let holder_summary =
-    Keeper_turn_slot.format_slot_holders timeout.timeout_holders
-  in
+      ~(keeper_name : string)
+      (timeout : Keeper_turn_slot.semaphore_wait_timeout)
+  =
+  let phase = Keeper_turn_slot.semaphore_wait_phase_to_string timeout.timeout_phase in
+  let holder_summary = Keeper_turn_slot.format_slot_holders timeout.timeout_holders in
   Agent_sdk.Error.Api
     (Agent_sdk.Retry.Timeout
-       {
-         message =
+       { message =
            Printf.sprintf
-             "keeper turn slot reacquire timed out after degraded retry \
-              (keeper=%s phase=%s wait=%.0fs holders=%s)"
+             "keeper turn slot reacquire timed out after degraded retry (keeper=%s \
+              phase=%s wait=%.0fs holders=%s)"
              keeper_name
              phase
              timeout.timeout_wait_sec
-             holder_summary;
+             holder_summary
        })
+;;
 
-type turn_tool_event_tracker = {
-  pending_tool_inputs : (string, Yojson.Safe.t Queue.t) Hashtbl.t;
-  mutable mutating_tools_committed : string list;
-  mutable integrity_error : Agent_sdk.Error.sdk_error option;
-}
+type turn_tool_event_tracker =
+  { pending_tool_inputs : (string, Yojson.Safe.t Queue.t) Hashtbl.t
+  ; mutable mutating_tools_committed : string list
+  ; mutable integrity_error : Agent_sdk.Error.sdk_error option
+  }
 
 let create_turn_tool_event_tracker () =
-  {
-    pending_tool_inputs = Hashtbl.create 8;
-    mutating_tools_committed = [];
-    integrity_error = None;
+  { pending_tool_inputs = Hashtbl.create 8
+  ; mutating_tools_committed = []
+  ; integrity_error = None
   }
+;;
 
 let turn_tool_event_integrity_error tracker = tracker.integrity_error
 
 let committed_mutating_tools_from_events tracker =
   EC.committed_mutating_tools tracker.mutating_tools_committed
+;;
 
 let push_turn_tool_input tracker tool_name input =
   let q =
     match Hashtbl.find_opt tracker.pending_tool_inputs tool_name with
     | Some q -> q
     | None ->
-        let q = Queue.create () in
-        Hashtbl.add tracker.pending_tool_inputs tool_name q;
-        q
+      let q = Queue.create () in
+      Hashtbl.add tracker.pending_tool_inputs tool_name q;
+      q
   in
   Queue.add input q
+;;
 
 let pop_turn_tool_input tracker tool_name =
   match Hashtbl.find_opt tracker.pending_tool_inputs tool_name with
   | Some q when not (Queue.is_empty q) -> Some (Queue.pop q)
   | _ -> None
+;;
 
-let record_unmatched_tool_completed tracker ~keeper_name ~tool_name ~outcome
-    ~tool_committed =
+let record_unmatched_tool_completed
+      tracker
+      ~keeper_name
+      ~tool_name
+      ~outcome
+      ~tool_committed
+  =
   let message =
     Printf.sprintf
-      "%s: keeper turn event-bus integrity error: ToolCompleted(%s) for \
-       tool=%s arrived without matching ToolCalled"
+      "%s: keeper turn event-bus integrity error: ToolCompleted(%s) for tool=%s arrived \
+       without matching ToolCalled"
       keeper_name
       outcome
       tool_name
@@ -166,69 +181,74 @@ let record_unmatched_tool_completed tracker ~keeper_name ~tool_name ~outcome
   let mutating_tool_committed =
     tool_committed && Keeper_exec_tools.has_mutating_side_effect tool_name
   in
-  if mutating_tool_committed then
-    tracker.mutating_tools_committed <-
-      tool_name :: tracker.mutating_tools_committed;
+  if mutating_tool_committed
+  then tracker.mutating_tools_committed <- tool_name :: tracker.mutating_tools_committed;
   match tracker.integrity_error with
   | Some _ -> ()
   | None ->
-      let base_error = Agent_sdk.Error.Internal message in
-      let error =
-        if mutating_tool_committed then
-          EC.reclassify_error_after_side_effect
-            ~tool_names:[ tool_name ]
-            base_error
-        else
-          base_error
-      in
-      tracker.integrity_error <- Some error
+    let base_error = Agent_sdk.Error.Internal message in
+    let error =
+      if mutating_tool_committed
+      then EC.reclassify_error_after_side_effect ~tool_names:[ tool_name ] base_error
+      else base_error
+    in
+    tracker.integrity_error <- Some error
+;;
 
 let record_turn_tool_events
-    ?(has_mutating_side_effect_with_input =
-      Keeper_exec_tools.has_mutating_side_effect_with_input)
-    ~(keeper_name : string)
-    (tracker : turn_tool_event_tracker)
-    (events : Agent_sdk.Event_bus.event list) : unit =
+      ?(has_mutating_side_effect_with_input =
+        Keeper_exec_tools.has_mutating_side_effect_with_input)
+      ~(keeper_name : string)
+      (tracker : turn_tool_event_tracker)
+      (events : Agent_sdk.Event_bus.event list)
+  : unit
+  =
   List.iter
     (fun (evt : Agent_sdk.Event_bus.event) ->
-      match evt.payload with
-      | Agent_sdk.Event_bus.ToolCalled { tool_name; input; _ } ->
-          push_turn_tool_input tracker tool_name input
-      | Agent_sdk.Event_bus.ToolCompleted { tool_name; output = Ok _; _ } -> (
-          match pop_turn_tool_input tracker tool_name with
+       match evt.payload with
+       | Agent_sdk.Event_bus.ToolCalled { tool_name; input; _ } ->
+         push_turn_tool_input tracker tool_name input
+       | Agent_sdk.Event_bus.ToolCompleted { tool_name; output = Ok _; _ } ->
+         (match pop_turn_tool_input tracker tool_name with
           | Some input ->
-              if has_mutating_side_effect_with_input ~tool_name ~input then
-                tracker.mutating_tools_committed <-
-                  tool_name :: tracker.mutating_tools_committed
+            if has_mutating_side_effect_with_input ~tool_name ~input
+            then
+              tracker.mutating_tools_committed
+              <- tool_name :: tracker.mutating_tools_committed
           | None ->
-              record_unmatched_tool_completed
-                tracker
-                ~keeper_name
-                ~tool_name
-                ~outcome:"ok"
-                ~tool_committed:true )
-      | Agent_sdk.Event_bus.ToolCompleted { tool_name; output = Error _; _ } -> (
-          match pop_turn_tool_input tracker tool_name with
+            record_unmatched_tool_completed
+              tracker
+              ~keeper_name
+              ~tool_name
+              ~outcome:"ok"
+              ~tool_committed:true)
+       | Agent_sdk.Event_bus.ToolCompleted { tool_name; output = Error _; _ } ->
+         (match pop_turn_tool_input tracker tool_name with
           | Some _ -> ()
           | None ->
-              record_unmatched_tool_completed
-                tracker
-                ~keeper_name
-                ~tool_name
-                ~outcome:"error"
-                ~tool_committed:false )
-      | _ -> ())
+            record_unmatched_tool_completed
+              tracker
+              ~keeper_name
+              ~tool_name
+              ~outcome:"error"
+              ~tool_committed:false)
+       | _ -> ())
     events
+;;
 
-let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
-    ~(observation : Keeper_world_observation.world_observation)
-    ~(generation : int)
-    ?(channel : Keeper_world_observation.keeper_cycle_channel = Scheduled_autonomous)
-    ?(semaphore_wait_ms = 0)
-    ?turn_slot_control
-    ?shared_context
-    ?selected_item
-    () : (keeper_meta, Agent_sdk.Error.sdk_error) result =
+let run_keeper_cycle
+      ~(config : Coord.config)
+      ~(meta : keeper_meta)
+      ~(observation : Keeper_world_observation.world_observation)
+      ~(generation : int)
+      ?(channel : Keeper_world_observation.keeper_cycle_channel = Scheduled_autonomous)
+      ?(semaphore_wait_ms = 0)
+      ?turn_slot_control
+      ?shared_context
+      ?selected_item
+      ()
+  : (keeper_meta, Agent_sdk.Error.sdk_error) result
+  =
   (* Spec navigation (OCaml -> TLA+) — plan §19 Cycle 28 anchor for
      B2 (Task Acquisition).  Authoritative spec mirror is
      specs/keeper-state-machine/KeeperTaskAcquisition.tla (Cycle 8 /
@@ -281,7 +301,8 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
      skip paths without a turn correlator. *)
   let keeper_turn_id = meta.runtime.usage.total_turns in
   Keeper_turn_fsm.emit_transition
-    ~keeper_name:meta.name ~turn_id:keeper_turn_id
+    ~keeper_name:meta.name
+    ~turn_id:keeper_turn_id
     ~prev:Keeper_turn_fsm.Idle
     Keeper_turn_fsm.Phase_gating;
   (* SupervisorRequestsStop / HonorStopSignal — check stop signal at turn entry.
@@ -295,13 +316,17 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
     | Some entry -> Atomic.get entry.fiber_stop
     | None -> false
   in
-  if supervisor_stop_at_entry then begin
-    Log.Keeper.info ~keeper_name:meta.name ~turn_id:keeper_turn_id
+  if supervisor_stop_at_entry
+  then (
+    Log.Keeper.info
+      ~keeper_name:meta.name
+      ~turn_id:keeper_turn_id
       "%s: supervisor stop signal observed at turn entry — honoring (phase_gating)"
       meta.name;
     (* FSM: SupervisorRequestsStop — stop signal raised while in active state *)
     Keeper_turn_fsm.emit_transition
-      ~keeper_name:meta.name ~turn_id:keeper_turn_id
+      ~keeper_name:meta.name
+      ~turn_id:keeper_turn_id
       ~prev:Keeper_turn_fsm.Phase_gating
       Keeper_turn_fsm.Phase_gating;
     record_pre_dispatch_terminal_observation
@@ -318,21 +343,22 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
       ();
     (* FSM: HonorStopSignal — cooperative cancel at phase_gating *)
     Keeper_turn_fsm.emit_transition
-      ~keeper_name:meta.name ~turn_id:keeper_turn_id
+      ~keeper_name:meta.name
+      ~turn_id:keeper_turn_id
       ~prev:Keeper_turn_fsm.Phase_gating
       (Keeper_turn_fsm.Cancelled Keeper_turn_fsm.Cancelled_supervisor_stop);
-    Ok meta
-  end else
-  match Keeper_registry.get_phase ~base_path:registry_base_path meta.name with
-  | Some phase when not (Keeper_state_machine.can_execute_turn phase) ->
+    Ok meta)
+  else (
+    match Keeper_registry.get_phase ~base_path:registry_base_path meta.name with
+    | Some phase when not (Keeper_state_machine.can_execute_turn phase) ->
       let phase_string = Keeper_state_machine.phase_to_string phase in
       Log.Keeper.info
-        ~keeper_name:meta.name ~turn_id:keeper_turn_id
+        ~keeper_name:meta.name
+        ~turn_id:keeper_turn_id
         "%s: keeper cycle skipped in non-executable phase=%s"
-        meta.name phase_string;
-      let terminal_reason_code =
-        Printf.sprintf "non_executable_phase:%s" phase_string
-      in
+        meta.name
+        phase_string;
+      let terminal_reason_code = Printf.sprintf "non_executable_phase:%s" phase_string in
       record_pre_dispatch_terminal_observation
         ~config
         ~meta
@@ -346,15 +372,17 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
         ~keeper_turn_id
         ();
       Keeper_turn_fsm.emit_transition
-        ~keeper_name:meta.name ~turn_id:keeper_turn_id
+        ~keeper_name:meta.name
+        ~turn_id:keeper_turn_id
         ~prev:Keeper_turn_fsm.Phase_gating
         Keeper_turn_fsm.Done;
       Ok meta
-  | phase_opt ->
+    | phase_opt ->
       (* State-aware cascade routing (TLA+ KeeperCoreTriad.SelectCascade).
          At this point [phase] is executable; blocked phases returned above. *)
       Keeper_turn_fsm.emit_transition
-        ~keeper_name:meta.name ~turn_id:keeper_turn_id
+        ~keeper_name:meta.name
+        ~turn_id:keeper_turn_id
         ~prev:Keeper_turn_fsm.Phase_gating
         Keeper_turn_fsm.Cascade_routing;
       (* RFC-0041 Phase B4: when a specific item was selected by the
@@ -363,27 +391,31 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
       let meta =
         match selected_item with
         | Some (group, item) ->
-            let cascade_ref =
-              Some Cascade_ref.{ group; item = Some item.id }
-            in
-            { meta with cascade_ref }
+          let cascade_ref = Some Cascade_ref.{ group; item = Some item.id } in
+          { meta with cascade_ref }
         | None -> meta
       in
       let effective_cascade_name =
-        let phase = match phase_opt with
+        let phase =
+          match phase_opt with
           | Some p -> p
           | None ->
-              Log.Keeper.warn
-                ~keeper_name:meta.name ~turn_id:keeper_turn_id
-                "%s: registry phase lookup returned None, defaulting to Failing"
-                meta.name;
-              Keeper_state_machine.Failing
+            Log.Keeper.warn
+              ~keeper_name:meta.name
+              ~turn_id:keeper_turn_id
+              "%s: registry phase lookup returned None, defaulting to Failing"
+              meta.name;
+            Keeper_state_machine.Failing
         in
-        let routing = Keeper_cascade_routing.select_cascade
-          ~base_cascade:(cascade_name_of_meta meta) ~phase
+        let routing =
+          Keeper_cascade_routing.select_cascade
+            ~base_cascade:(cascade_name_of_meta meta)
+            ~phase
         in
-        Prometheus.inc_counter Keeper_metrics.metric_keeper_fsm_edge_transitions
-          ~labels:[("edge", "ksm_to_kcl_routing")] ();
+        Prometheus.inc_counter
+          Keeper_metrics.metric_keeper_fsm_edge_transitions
+          ~labels:[ "edge", "ksm_to_kcl_routing" ]
+          ();
         let routed_meta = set_cascade_name routing.effective_cascade meta in
         let routed_labels =
           Keeper_model_labels.configured_model_labels_of_meta routed_meta
@@ -394,12 +426,19 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
             ~effective_cascade:routing.effective_cascade
             routed_labels
         in
-        Log.Keeper.debug "%s: cascade routing: %s -> %s (reason: %s)"
-          meta.name (cascade_name_of_meta meta) routing.effective_cascade routing.reason;
-        if not (String.equal resolved_cascade routing.effective_cascade) then
+        Log.Keeper.debug
+          "%s: cascade routing: %s -> %s (reason: %s)"
+          meta.name
+          (cascade_name_of_meta meta)
+          routing.effective_cascade
+          routing.reason;
+        if not (String.equal resolved_cascade routing.effective_cascade)
+        then
           Log.Keeper.warn
             "%s: local_only unavailable for labels [%s]; falling back to base cascade %s"
-            meta.name (String.concat ", " routed_labels) resolved_cascade;
+            meta.name
+            (String.concat ", " routed_labels)
+            resolved_cascade;
         resolved_cascade
       in
       let effective_cascade_name =
@@ -408,42 +447,39 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
             ~cascade_name:(KCP.runtime_name_of_string effective_cascade_name)
         with
         | Some remaining_sec ->
-            Prometheus.set_gauge
-              Keeper_metrics.metric_keeper_provider_cooldown_remaining_sec
-              ~labels:[
-                ("keeper", meta.name);
-                ("cascade", effective_cascade_name);
-              ]
-              (float_of_int remaining_sec);
-            (match
-               EC.fallback_cascade_for_unavailable_profile
-                 ~base_cascade:(cascade_name_of_meta meta)
-                 ~effective_cascade:effective_cascade_name
-             with
-             | Some fallback_cascade
-               when not (String.equal fallback_cascade effective_cascade_name) ->
-                 Log.Keeper.warn
-                   "%s: cascade %s provider cooldown pending (%ds); fail-opening to %s"
-                   meta.name effective_cascade_name remaining_sec fallback_cascade;
-                 Prometheus.inc_counter
-                   Keeper_metrics.metric_keeper_provider_cooldown_skip
-                   ~labels:[
-                     ("keeper", meta.name);
-                     ("from_cascade", effective_cascade_name);
-                     ("to_cascade", fallback_cascade);
-                   ]
-                   ();
-                 fallback_cascade
-             | _ -> effective_cascade_name)
+          Prometheus.set_gauge
+            Keeper_metrics.metric_keeper_provider_cooldown_remaining_sec
+            ~labels:[ "keeper", meta.name; "cascade", effective_cascade_name ]
+            (float_of_int remaining_sec);
+          (match
+             EC.fallback_cascade_for_unavailable_profile
+               ~base_cascade:(cascade_name_of_meta meta)
+               ~effective_cascade:effective_cascade_name
+           with
+           | Some fallback_cascade
+             when not (String.equal fallback_cascade effective_cascade_name) ->
+             Log.Keeper.warn
+               "%s: cascade %s provider cooldown pending (%ds); fail-opening to %s"
+               meta.name
+               effective_cascade_name
+               remaining_sec
+               fallback_cascade;
+             Prometheus.inc_counter
+               Keeper_metrics.metric_keeper_provider_cooldown_skip
+               ~labels:
+                 [ "keeper", meta.name
+                 ; "from_cascade", effective_cascade_name
+                 ; "to_cascade", fallback_cascade
+                 ]
+               ();
+             fallback_cascade
+           | _ -> effective_cascade_name)
         | None ->
-            Prometheus.set_gauge
-              Keeper_metrics.metric_keeper_provider_cooldown_remaining_sec
-              ~labels:[
-                ("keeper", meta.name);
-                ("cascade", effective_cascade_name);
-              ]
-              0.0;
-            effective_cascade_name
+          Prometheus.set_gauge
+            Keeper_metrics.metric_keeper_provider_cooldown_remaining_sec
+            ~labels:[ "keeper", meta.name; "cascade", effective_cascade_name ]
+            0.0;
+          effective_cascade_name
       in
       (* PR-B: ollama saturation pre-skip.  If the resolved cascade
          is ollama-only and the [/api/ps] cache reports zero
@@ -453,35 +489,33 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
          normal dispatch path (fail-open) so a flaky probe never
          starves the keeper. *)
       let saturation_skip_meta =
-        let meta_for_check =
-          set_cascade_name effective_cascade_name meta
-        in
-        let labels =
-          Keeper_coordination.effective_model_labels_for_turn meta_for_check
-        in
+        let meta_for_check = set_cascade_name effective_cascade_name meta in
+        let labels = Keeper_coordination.effective_model_labels_for_turn meta_for_check in
         match resolve_shared_probeable_base_url labels with
         | None ->
-            saturation_skip_count_reset ~keeper_name:meta.name;
-            None
+          saturation_skip_count_reset ~keeper_name:meta.name;
+          None
         | Some base_url ->
-            if not (is_base_url_saturated base_url) then begin
+          if not (is_base_url_saturated base_url)
+          then (
+            saturation_skip_count_reset ~keeper_name:meta.name;
+            None)
+          else (
+            let next_count = saturation_skip_count_inc ~keeper_name:meta.name in
+            let cap = max_consecutive_saturation_skips () in
+            if next_count > cap
+            then (
+              Log.Keeper.warn
+                ~keeper_name:meta.name
+                ~turn_id:keeper_turn_id
+                "%s: saturation skip cap reached (count=%d cap=%d) \xe2\x80\x94 \
+                 force-dispatching despite saturated probe"
+                meta.name
+                next_count
+                cap;
               saturation_skip_count_reset ~keeper_name:meta.name;
-              None
-            end
-            else
-              let next_count =
-                saturation_skip_count_inc ~keeper_name:meta.name
-              in
-              let cap = max_consecutive_saturation_skips () in
-              if next_count > cap then begin
-                Log.Keeper.warn
-                  ~keeper_name:meta.name ~turn_id:keeper_turn_id
-                  "%s: saturation skip cap reached (count=%d cap=%d) \
-                   \xe2\x80\x94 force-dispatching despite saturated probe"
-                  meta.name next_count cap;
-                saturation_skip_count_reset ~keeper_name:meta.name;
-                None
-              end else
+              None)
+            else (
               let info = Cascade_capacity_probe.cached ~url:base_url () in
               let queue_len =
                 match info with
@@ -494,18 +528,23 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
                 | None -> 0
               in
               Log.Keeper.info
-                ~keeper_name:meta.name ~turn_id:keeper_turn_id
-                "%s: ollama saturated for keeper=%s cascade=%s queue=%d \
-                 available=%d skip_count=%d/%d \xe2\x80\x94 skipping turn"
-                meta.name meta.name effective_cascade_name queue_len
-                available next_count cap;
+                ~keeper_name:meta.name
+                ~turn_id:keeper_turn_id
+                "%s: ollama saturated for keeper=%s cascade=%s queue=%d available=%d \
+                 skip_count=%d/%d \xe2\x80\x94 skipping turn"
+                meta.name
+                meta.name
+                effective_cascade_name
+                queue_len
+                available
+                next_count
+                cap;
               record_pre_dispatch_terminal_observation
                 ~config
                 ~meta
                 ~generation
                 ~cascade_name:
-                  (Keeper_execution_receipt.cascade_name_of_string
-                     effective_cascade_name)
+                  (Keeper_execution_receipt.cascade_name_of_string effective_cascade_name)
                 ~outcome:`Skipped
                 ~terminal_reason_code:"ollama_saturated"
                 ~activity_kind:"keeper.turn_skipped"
@@ -513,52 +552,53 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
                 ~keeper_turn_id
                 ();
               Keeper_turn_fsm.emit_transition
-                ~keeper_name:meta.name ~turn_id:keeper_turn_id
+                ~keeper_name:meta.name
+                ~turn_id:keeper_turn_id
                 ~prev:Keeper_turn_fsm.Cascade_routing
                 (Keeper_turn_fsm.Failed
                    (Keeper_turn_fsm.Failure_cascade_unavailable
-                      { base = effective_cascade_name;
-                        resolved = Some "ollama_saturated" }));
+                      { base = effective_cascade_name
+                      ; resolved = Some "ollama_saturated"
+                      }));
               Prometheus.inc_counter
                 Keeper_metrics.metric_keeper_ollama_saturation_skip
-                ~labels:[ ("keeper", meta.name);
-                          ("cascade", effective_cascade_name) ]
+                ~labels:[ "keeper", meta.name; "cascade", effective_cascade_name ]
                 ();
               (match Eio_context.get_clock_opt () with
                | Some clock ->
-                   (try Eio.Time.sleep clock (saturation_skip_sleep_duration ());
-                    with
-                    | Eio.Cancel.Cancelled _ as e -> raise e
-                    | exn ->
-                        Log.Keeper.debug
-                          "%s: saturation skip sleep failed: %s"
-                          meta.name (Printexc.to_string exn))
+                 (try Eio.Time.sleep clock (saturation_skip_sleep_duration ()) with
+                  | Eio.Cancel.Cancelled _ as e -> raise e
+                  | exn ->
+                    Log.Keeper.debug
+                      "%s: saturation skip sleep failed: %s"
+                      meta.name
+                      (Printexc.to_string exn))
                | None -> ());
-              Some meta
+              Some meta))
       in
       (match saturation_skip_meta with
        | Some meta_after_skip -> Ok meta_after_skip
        | None ->
-      let build_cascade_execution ~(cascade_name : KCP.runtime_name) :
-          (cascade_execution, Agent_sdk.Error.sdk_error) result =
-        let cascade_name_string = KCP.runtime_name_to_string cascade_name in
-        let meta_for_cascade = set_cascade_name cascade_name_string meta in
-        let model_labels =
-          Keeper_coordination.effective_model_labels_for_turn meta_for_cascade
-        in
-        match ensure_api_keys_for_labels model_labels with
-        | Error e -> Error (Agent_sdk.Error.Internal e)
-        | Ok () -> (
-            match ensure_local_discovery_ready model_labels with
-            | Error e -> Error (Agent_sdk.Error.Internal e)
-            | Ok () ->
+         let build_cascade_execution ~(cascade_name : KCP.runtime_name)
+           : (cascade_execution, Agent_sdk.Error.sdk_error) result
+           =
+           let cascade_name_string = KCP.runtime_name_to_string cascade_name in
+           let meta_for_cascade = set_cascade_name cascade_name_string meta in
+           let model_labels =
+             Keeper_coordination.effective_model_labels_for_turn meta_for_cascade
+           in
+           match ensure_api_keys_for_labels model_labels with
+           | Error e -> Error (Agent_sdk.Error.Internal e)
+           | Ok () ->
+             (match ensure_local_discovery_ready model_labels with
+              | Error e -> Error (Agent_sdk.Error.Internal e)
+              | Ok () ->
                 let max_context_resolution =
                   Keeper_exec_context.resolve_max_context_resolution
-                    ~requested_override:meta.max_context_override model_labels
+                    ~requested_override:meta.max_context_override
+                    model_labels
                 in
-                let max_context =
-                  resolved_max_context_for_turn ~meta model_labels
-                in
+                let max_context = resolved_max_context_for_turn ~meta model_labels in
                 let temperature =
                   Cascade_inference.resolve_temperature
                     ~cascade_name
@@ -572,158 +612,169 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
                   in
                   (* Capability gate: clamp to provider ceiling (TLA+ S3) *)
                   Cascade_inference.clamp_max_tokens_to_ceiling
-                    ~provider_ceiling:(Some max_context) raw
+                    ~provider_ceiling:(Some max_context)
+                    raw
                 in
                 Ok
-                  {
-                    cascade_name;
-                    max_context_resolution;
-                    max_context;
-                    temperature;
-                    max_tokens;
+                  { cascade_name
+                  ; max_context_resolution
+                  ; max_context
+                  ; temperature
+                  ; max_tokens
                   })
-      in
-      let effective_cascade_runtime_name =
-        KCP.Runtime_name effective_cascade_name
-      in
-      match
-        build_cascade_execution ~cascade_name:effective_cascade_runtime_name
-      with
-      | Error err ->
-          let terminal_reason_code =
-            Printf.sprintf "pre_dispatch_%s"
-              (Keeper_agent_error.terminal_reason_code_of_sdk_error err)
-          in
-          let error_message = Agent_sdk.Error.to_string err in
-          record_pre_dispatch_terminal_observation
-            ~config
-            ~meta
-            ~generation
-            ~cascade_name:effective_cascade_runtime_name
-            ~outcome:`Error
-            ~terminal_reason_code
-            ~activity_kind:"keeper.turn_blocked"
-            ~trajectory_outcome:(Trajectory.Failed terminal_reason_code)
-            ~error_kind:
-              (Keeper_execution_receipt.error_kind_of_string
-                 (sdk_error_kind err))
-            ~error_message
-            ~keeper_turn_id
-            ();
-          Keeper_turn_fsm.emit_transition
-            ~keeper_name:meta.name ~turn_id:keeper_turn_id
-            ~prev:Keeper_turn_fsm.Cascade_routing
-            (Keeper_turn_fsm.Failed
-               (Keeper_turn_fsm.Failure_provider_error
-                  { kind = sdk_error_kind err;
-                    detail = error_message }));
-          Error err
-      | Ok initial_execution ->
-      let turn_id = meta.runtime.usage.total_turns in
-      let model = match meta.models with m :: _ -> Some m | [] -> None in
-      (match
-         Keeper_turn_livelock.guard_and_record_turn_start
-           ~keeper:meta.name
-           ~turn_id
-           ~max_attempts:(turn_livelock_max_attempts ())
-           ~stuck_after_sec:(turn_livelock_stuck_after_sec ())
-           ?model
-           ()
-       with
-       | Keeper_turn_livelock.Blocked reason ->
-           let reason_string =
-             Keeper_turn_livelock.gate_reason_to_string reason
-           in
-           let terminal_reason_code =
-             Printf.sprintf "turn_livelock:%s" reason_string
-           in
-           let error_message =
-             Printf.sprintf "keeper turn livelock blocked: %s"
-               reason_string
-           in
-           Log.Keeper.error
-             ~keeper_name:meta.name ~turn_id:keeper_turn_id
-             "%s: keeper turn livelock guard blocked dispatch turn=%d: %s"
-             meta.name turn_id
-             reason_string;
-           Prometheus.inc_counter
-             Keeper_metrics.metric_keeper_turn_livelock_blocks
-             ~labels:[("keeper", meta.name)]
-             ();
-           record_pre_dispatch_terminal_observation
-             ~config
-             ~meta
-             ~generation
-             ~cascade_name:initial_execution.cascade_name
-             (* β6: "blocked" was not in outcome_kind quad-state
+         in
+         let effective_cascade_runtime_name = KCP.Runtime_name effective_cascade_name in
+         (match build_cascade_execution ~cascade_name:effective_cascade_runtime_name with
+          | Error err ->
+            let terminal_reason_code =
+              Printf.sprintf
+                "pre_dispatch_%s"
+                (Keeper_agent_error.terminal_reason_code_of_sdk_error err)
+            in
+            let error_message = Agent_sdk.Error.to_string err in
+            record_pre_dispatch_terminal_observation
+              ~config
+              ~meta
+              ~generation
+              ~cascade_name:effective_cascade_runtime_name
+              ~outcome:`Error
+              ~terminal_reason_code
+              ~activity_kind:"keeper.turn_blocked"
+              ~trajectory_outcome:(Trajectory.Failed terminal_reason_code)
+              ~error_kind:
+                (Keeper_execution_receipt.error_kind_of_string (sdk_error_kind err))
+              ~error_message
+              ~keeper_turn_id
+              ();
+            Keeper_turn_fsm.emit_transition
+              ~keeper_name:meta.name
+              ~turn_id:keeper_turn_id
+              ~prev:Keeper_turn_fsm.Cascade_routing
+              (Keeper_turn_fsm.Failed
+                 (Keeper_turn_fsm.Failure_provider_error
+                    { kind = sdk_error_kind err; detail = error_message }));
+            Error err
+          | Ok initial_execution ->
+            let turn_id = meta.runtime.usage.total_turns in
+            let model =
+              match meta.models with
+              | m :: _ -> Some m
+              | [] -> None
+            in
+            (match
+               Keeper_turn_livelock.guard_and_record_turn_start
+                 ~keeper:meta.name
+                 ~turn_id
+                 ~max_attempts:(turn_livelock_max_attempts ())
+                 ~stuck_after_sec:(turn_livelock_stuck_after_sec ())
+                 ?model
+                 ()
+             with
+             | Keeper_turn_livelock.Blocked reason ->
+               let reason_string = Keeper_turn_livelock.gate_reason_to_string reason in
+               let terminal_reason_code =
+                 Printf.sprintf "turn_livelock:%s" reason_string
+               in
+               let error_message =
+                 Printf.sprintf "keeper turn livelock blocked: %s" reason_string
+               in
+               Log.Keeper.error
+                 ~keeper_name:meta.name
+                 ~turn_id:keeper_turn_id
+                 "%s: keeper turn livelock guard blocked dispatch turn=%d: %s"
+                 meta.name
+                 turn_id
+                 reason_string;
+               Prometheus.inc_counter
+                 Keeper_metrics.metric_keeper_turn_livelock_blocks
+                 ~labels:[ "keeper", meta.name ]
+                 ();
+               record_pre_dispatch_terminal_observation
+                 ~config
+                 ~meta
+                 ~generation
+                 ~cascade_name:initial_execution.cascade_name
+                   (* β6: "blocked" was not in outcome_kind quad-state
                 (ok/skipped/error/cancelled), causing operator_disposition
                 to classify livelock-blocked turns as "unknown".  Map to
                 "error" — livelock IS a turn failure; the specific reason
                 is captured in terminal_reason_code. *)
-             ~outcome:`Error
-             ~terminal_reason_code
-             ~activity_kind:"keeper.turn_blocked"
-             ~trajectory_outcome:(Trajectory.Gated terminal_reason_code)
-             ~error_kind:
-               (Keeper_execution_receipt.error_kind_of_string
-                  "turn_livelock_blocked")
-             ~error_message
-             ~keeper_turn_id
-             ();
-           Keeper_turn_fsm.emit_transition
-             ~keeper_name:meta.name ~turn_id:keeper_turn_id
-             ~prev:Keeper_turn_fsm.Cascade_routing
-             (Keeper_turn_fsm.Failed
-                (Keeper_turn_fsm.Failure_turn_livelock_blocked
-                   { reason = reason_string }));
-           Error (Agent_sdk.Error.Internal error_message)
-       | Keeper_turn_livelock.Started _ ->
-      Keeper_turn_fsm.emit_transition
-        ~keeper_name:meta.name ~turn_id:keeper_turn_id
-        ~prev:Keeper_turn_fsm.Cascade_routing
-        Keeper_turn_fsm.Awaiting_provider;
-      (* Yield before CPU-bound prompt construction so the Eio scheduler
+                 ~outcome:`Error
+                 ~terminal_reason_code
+                 ~activity_kind:"keeper.turn_blocked"
+                 ~trajectory_outcome:(Trajectory.Gated terminal_reason_code)
+                 ~error_kind:
+                   (Keeper_execution_receipt.error_kind_of_string "turn_livelock_blocked")
+                 ~error_message
+                 ~keeper_turn_id
+                 ();
+               Keeper_turn_fsm.emit_transition
+                 ~keeper_name:meta.name
+                 ~turn_id:keeper_turn_id
+                 ~prev:Keeper_turn_fsm.Cascade_routing
+                 (Keeper_turn_fsm.Failed
+                    (Keeper_turn_fsm.Failure_turn_livelock_blocked
+                       { reason = reason_string }));
+               Error (Agent_sdk.Error.Internal error_message)
+             | Keeper_turn_livelock.Started _ ->
+               Keeper_turn_fsm.emit_transition
+                 ~keeper_name:meta.name
+                 ~turn_id:keeper_turn_id
+                 ~prev:Keeper_turn_fsm.Cascade_routing
+                 Keeper_turn_fsm.Awaiting_provider;
+               (* Yield before CPU-bound prompt construction so the Eio scheduler
          can service HTTP handlers between keeper turn setups. *)
-      Eio.Fiber.yield ();
-      (* 2. Build unified prompt — diversity entropy recorded in decision_audit
+               Eio.Fiber.yield ();
+               (* 2. Build unified prompt — diversity entropy recorded in decision_audit
          (keeper_keepalive.ml), not injected into prompt (#6814). *)
-      let system_prompt, user_message =
-        Keeper_unified_prompt.build_prompt ~meta ~base_path:config.base_path
-          ~observation ()
-      in
-      Eio.Fiber.yield ();
-      let base_dir = session_base_dir config in
-      (* Ensure session dir tree for filesystem fallback (issue #3019) *)
-      Keeper_types.mkdir_p (Filename.concat base_dir (Keeper_id.Trace_id.to_string meta.runtime.trace_id));
-      let masc_root = Coord.masc_root_dir config in
-      let trajectory_acc =
-        Trajectory.create_accumulator
-          ~masc_root
-          ~keeper_name:meta.name
-          ~trace_id:(Keeper_id.Trace_id.to_string meta.runtime.trace_id)
-          ~generation:meta.runtime.generation
-      in
-      let max_cost_usd = Keeper_config.keeper_tool_cost_max_usd () in
-      (* 4. Build turn prompt callback: use our unified system prompt *)
-      let build_turn_prompt ~base_system_prompt:_ ~messages:_
-          : Keeper_agent_run.turn_prompt =
-        (* Unified path already places soft context (continuity, worktree)
+               let system_prompt, user_message =
+                 Keeper_unified_prompt.build_prompt
+                   ~meta
+                   ~base_path:config.base_path
+                   ~observation
+                   ()
+               in
+               Eio.Fiber.yield ();
+               let base_dir = session_base_dir config in
+               (* Ensure session dir tree for filesystem fallback (issue #3019) *)
+               Keeper_types.mkdir_p
+                 (Filename.concat
+                    base_dir
+                    (Keeper_id.Trace_id.to_string meta.runtime.trace_id));
+               let masc_root = Coord.masc_root_dir config in
+               let trajectory_acc =
+                 Trajectory.create_accumulator
+                   ~masc_root
+                   ~keeper_name:meta.name
+                   ~trace_id:(Keeper_id.Trace_id.to_string meta.runtime.trace_id)
+                   ~generation:meta.runtime.generation
+               in
+               let max_cost_usd = Keeper_config.keeper_tool_cost_max_usd () in
+               (* 4. Build turn prompt callback: use our unified system prompt *)
+               let build_turn_prompt ~base_system_prompt:_ ~messages:_
+                 : Keeper_agent_run.turn_prompt
+                 =
+                 (* Unified path already places soft context (continuity, worktree)
            in the user_message via Keeper_unified_prompt.build_prompt.
            No dynamic_context needed here. *)
-        { system_prompt; dynamic_context = "" }
-      in
-      let prompt_timeout_metrics =
-        Keeper_agent_run.build_prompt_metrics ~system_prompt
-          ~dynamic_context:"" ~user_message
-      in
-      let prompt_timeout_estimate_tokens =
-        max 1 prompt_timeout_metrics.estimated_total_tokens
-      in
-      let turn_affordances =
-        Keeper_unified_metrics.observed_affordances_of_observation ~meta observation
-      in
-      (* 5. Run via OAS Agent.run() with transient-error retry *)
-      (* Track whether side-effecting tool calls have been executed.
+                 { system_prompt; dynamic_context = "" }
+               in
+               let prompt_timeout_metrics =
+                 Keeper_agent_run.build_prompt_metrics
+                   ~system_prompt
+                   ~dynamic_context:""
+                   ~user_message
+               in
+               let prompt_timeout_estimate_tokens =
+                 max 1 prompt_timeout_metrics.estimated_total_tokens
+               in
+               let turn_affordances =
+                 Keeper_unified_metrics.observed_affordances_of_observation
+                   ~meta
+                   observation
+               in
+               (* 5. Run via OAS Agent.run() with transient-error retry *)
+               (* Track whether side-effecting tool calls have been executed.
          If a board_post/comment/shell/file edit succeeded and then a
          transient error occurs, retrying would replay those tool calls and
          produce duplicates. In that case, we propagate the error instead of
@@ -732,94 +783,92 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
          Uses the OAS Event_bus (ToolCalled + ToolCompleted) rather than
          MASC-side observers. The per-turn subscription is scoped by
          [filter_agent meta.name], so no cross-keeper contamination. *)
-      let tool_event_tracker = create_turn_tool_event_tracker () in
-      let post_commit_failure_reason = ref None in
-      let paused_meta_override = ref None in
-      let current_turn_blocker_info = ref None in
-      let event_bus_drain_cancel = ref None in
-      let turn_event_bus_mu = Eio.Mutex.create () in
-      let mark_paused_after_overflow ~run_meta ~reason =
-        let paused_meta =
-          pause_keeper_for_overflow
-            ~config
-            ~meta:run_meta
-            ~reason
-        in
-        paused_meta_override := Some paused_meta
-      in
-      (* Side-effect tracking is driven by the OAS Event_bus (ToolCalled +
+               let tool_event_tracker = create_turn_tool_event_tracker () in
+               let post_commit_failure_reason = ref None in
+               let paused_meta_override = ref None in
+               let current_turn_blocker_info = ref None in
+               let event_bus_drain_cancel = ref None in
+               let turn_event_bus_mu = Eio.Mutex.create () in
+               let mark_paused_after_overflow ~run_meta ~reason =
+                 let paused_meta =
+                   pause_keeper_for_overflow ~config ~meta:run_meta ~reason
+                 in
+                 paused_meta_override := Some paused_meta
+               in
+               (* Side-effect tracking is driven by the OAS Event_bus (ToolCalled +
          ToolCompleted) rather than MASC-side observers. Pairing is by
          tool_name order within the per-turn subscription, which is safe
          because the turn is single-fibered and filter_agent restricts to
          this keeper. *)
-      let event_bus_sub =
-        match Keeper_event_bus.get () with
-        | Some bus ->
-          Some (Agent_sdk_metrics_bridge.subscribe
-                  ~purpose:"keeper_turn"
-                  ~filter:(Agent_sdk.Event_bus.filter_agent meta.name) bus)
-        | None -> None
-      in
-      let turn_event_bus = ref empty_turn_event_bus_summary in
-      let with_turn_event_bus_lock f =
-        Eio.Mutex.use_rw ~protect:true turn_event_bus_mu f
-      in
-      let process_tool_events_for_side_effects
-          (events : Agent_sdk.Event_bus.event list) : unit =
-        record_turn_tool_events
-          ~keeper_name:meta.name
-          tool_event_tracker
-          events
-      in
-      (* PR-J: [?site] labels the call-site so PromQL can attribute
+               let event_bus_sub =
+                 match Keeper_event_bus.get () with
+                 | Some bus ->
+                   Some
+                     (Agent_sdk_metrics_bridge.subscribe
+                        ~purpose:"keeper_turn"
+                        ~filter:(Agent_sdk.Event_bus.filter_agent meta.name)
+                        bus)
+                 | None -> None
+               in
+               let turn_event_bus = ref empty_turn_event_bus_summary in
+               let with_turn_event_bus_lock f =
+                 Eio.Mutex.use_rw ~protect:true turn_event_bus_mu f
+               in
+               let process_tool_events_for_side_effects
+                     (events : Agent_sdk.Event_bus.event list)
+                 : unit
+                 =
+                 record_turn_tool_events ~keeper_name:meta.name tool_event_tracker events
+               in
+               (* PR-J: [?site] labels the call-site so PromQL can attribute
          drain pressure to background polling vs unsubscribe vs the
          retry path. [outcome=drained] when at least one event was
          pulled, [outcome=empty] otherwise (the latter is the no-op
          tick that establishes the lock-acquire baseline). *)
-      let drain_turn_event_bus ?(site = "unspecified") () =
-        with_turn_event_bus_lock (fun () ->
-          let events =
-            match event_bus_sub, Keeper_event_bus.get () with
-            | Some sub, Some _bus -> Agent_sdk_metrics_bridge.drain sub
-            | _ -> []
-          in
-          let outcome = if events = [] then "empty" else "drained" in
-          Prometheus.inc_counter Keeper_metrics.metric_keeper_event_bus_drain
-            ~labels:[("site", site); ("outcome", outcome)] ();
-          process_tool_events_for_side_effects events;
-          let summary = summarize_turn_event_bus events in
-          turn_event_bus :=
-            merge_turn_event_bus_summary !turn_event_bus summary;
-          !turn_event_bus)
-      in
-      let committed_mutating_tools_snapshot () =
-        with_turn_event_bus_lock (fun () ->
-          committed_mutating_tools_from_events tool_event_tracker)
-      in
-      let event_bus_integrity_error_snapshot () =
-        with_turn_event_bus_lock (fun () ->
-          turn_tool_event_integrity_error tool_event_tracker)
-      in
-      let start_background_turn_event_bus_drain ~clock =
-        match event_bus_sub, Eio_context.get_switch_opt () with
-        | Some _, Some sw ->
-            Eio.Fiber.fork ~sw (fun () ->
-              Eio.Cancel.sub (fun cc ->
-                event_bus_drain_cancel := Some cc;
-                let rec loop () =
-                  try
-                    ignore (drain_turn_event_bus ~site:"background_poll" ());
-                  with
-                  | Eio.Cancel.Cancelled _ as e -> raise e
-                  | exn ->
-                    Log.Keeper.warn
-                      "%s: keeper_turn event-bus drain failed: %s"
-                      meta.name (Printexc.to_string exn);
-                    Prometheus.inc_counter
-                      Keeper_metrics.metric_keeper_event_bus_drain
-                      ~labels:[("site", "background_poll"); ("outcome", "exception")]
-                      ();
-                  (* 2026-04-20: 0.25s → 0.05s.  OAS publishes a burst
+               let drain_turn_event_bus ?(site = "unspecified") () =
+                 with_turn_event_bus_lock (fun () ->
+                   let events =
+                     match event_bus_sub, Keeper_event_bus.get () with
+                     | Some sub, Some _bus -> Agent_sdk_metrics_bridge.drain sub
+                     | _ -> []
+                   in
+                   let outcome = if events = [] then "empty" else "drained" in
+                   Prometheus.inc_counter
+                     Keeper_metrics.metric_keeper_event_bus_drain
+                     ~labels:[ "site", site; "outcome", outcome ]
+                     ();
+                   process_tool_events_for_side_effects events;
+                   let summary = summarize_turn_event_bus events in
+                   turn_event_bus := merge_turn_event_bus_summary !turn_event_bus summary;
+                   !turn_event_bus)
+               in
+               let committed_mutating_tools_snapshot () =
+                 with_turn_event_bus_lock (fun () ->
+                   committed_mutating_tools_from_events tool_event_tracker)
+               in
+               let event_bus_integrity_error_snapshot () =
+                 with_turn_event_bus_lock (fun () ->
+                   turn_tool_event_integrity_error tool_event_tracker)
+               in
+               let start_background_turn_event_bus_drain ~clock =
+                 match event_bus_sub, Eio_context.get_switch_opt () with
+                 | Some _, Some sw ->
+                   Eio.Fiber.fork ~sw (fun () ->
+                     Eio.Cancel.sub (fun cc ->
+                       event_bus_drain_cancel := Some cc;
+                       let rec loop () =
+                         try ignore (drain_turn_event_bus ~site:"background_poll" ()) with
+                         | Eio.Cancel.Cancelled _ as e -> raise e
+                         | exn ->
+                           Log.Keeper.warn
+                             "%s: keeper_turn event-bus drain failed: %s"
+                             meta.name
+                             (Printexc.to_string exn);
+                           Prometheus.inc_counter
+                             Keeper_metrics.metric_keeper_event_bus_drain
+                             ~labels:[ "site", "background_poll"; "outcome", "exception" ]
+                             ();
+                           (* 2026-04-20: 0.25s → 0.05s.  OAS publishes a burst
                      of events per tool cycle (ToolCalled / ToolResult /
                      ToolCompleted + assistant / usage).  With 0.25s
                      polling, a tool-heavy turn could accumulate >256
@@ -833,234 +882,264 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
                      typical inter-event spacing so depth stays below
                      the warn threshold outside tool bursts.  Override
                      via [MASC_KEEPER_TURN_DRAIN_INTERVAL_SEC]. *)
-                  Eio.Time.sleep clock (turn_event_bus_drain_interval_sec ());
-                  loop ()
-                in
-                loop ()))
-        | _ -> ()
-      in
-      let unsubscribe_event_bus () =
-        (match !event_bus_drain_cancel with
-         | Some cc ->
-           event_bus_drain_cancel := None;
-           (try Eio.Cancel.cancel cc (Failure "event_bus_unsubscribed") with
-            | Eio.Cancel.Cancelled _ -> ()
-            | Invalid_argument msg ->
-                Log.Keeper.debug
-                  "%s: event bus drain cancel ignored after context finish: %s"
-                  meta.name msg)
-         | None -> ());
-        ignore (drain_turn_event_bus ~site:"unsubscribe_final" ());
-        match event_bus_sub, Keeper_event_bus.get () with
-        | Some sub, Some bus -> Agent_sdk_metrics_bridge.unsubscribe bus sub
-        | _ -> ()
-      in
-      (* Mark turn boundary for the composite observer (issue #7122).
+                           Eio.Time.sleep clock (turn_event_bus_drain_interval_sec ());
+                           loop ()
+                       in
+                       loop ()))
+                 | _ -> ()
+               in
+               let unsubscribe_event_bus () =
+                 (match !event_bus_drain_cancel with
+                  | Some cc ->
+                    event_bus_drain_cancel := None;
+                    (try Eio.Cancel.cancel cc (Failure "event_bus_unsubscribed") with
+                     | Eio.Cancel.Cancelled _ -> ()
+                     | Invalid_argument msg ->
+                       Log.Keeper.debug
+                         "%s: event bus drain cancel ignored after context finish: %s"
+                         meta.name
+                         msg)
+                  | None -> ());
+                 ignore (drain_turn_event_bus ~site:"unsubscribe_final" ());
+                 match event_bus_sub, Keeper_event_bus.get () with
+                 | Some sub, Some bus -> Agent_sdk_metrics_bridge.unsubscribe bus sub
+                 | _ -> ()
+               in
+               (* Mark turn boundary for the composite observer (issue #7122).
          [mark_turn_started] installs [current_turn_observation = Some _]
          so the composite observer can surface live in-turn states like
          [`Executing`]. The matching [mark_turn_finished] in the finally
          block clears the field, preventing stale state on idle keepers. *)
-      Keeper_registry.mark_turn_started
-        ~base_path:config.base_path meta.name;
-      let meta =
-        match Keeper_registry.get ~base_path:config.base_path meta.name with
-        | Some entry ->
-          let () =
-            match write_meta_with_merge
-              ~merge:Keeper_meta_merge.heartbeat_fields_from_disk
-              config entry.meta
-            with
-            | Ok () -> ()
-            | Error err ->
-                Prometheus.inc_counter
-                  Keeper_metrics.metric_keeper_write_meta_failures
-                  ~labels:
-                    [("keeper", entry.meta.name); ("phase", "turn_start")]
-                  ();
-                Log.Keeper.warn
-                  "%s: turn-start write_meta_with_merge failed: %s"
-                  entry.meta.name err
-          in
-          entry.meta
-        | None -> meta
-      in
-      Keeper_registry.mark_turn_measurement
-        ~base_path:config.base_path meta.name;
-      (match Keeper_registry.get ~base_path:config.base_path meta.name with
-       | Some { current_turn_observation = Some { measurement = Some _; _ }; _ } ->
-           Keeper_registry.set_turn_decision_stage
-             ~base_path:config.base_path meta.name
-             Keeper_registry.Decision_guard_ok
-       | _ -> ());
-      let last_execution = ref initial_execution in
-      let last_timeout_budget : oas_timeout_budget_resolution option ref = ref None in
-      let degraded_retry_info = ref None in
-      let cascade_rotation_attempts = ref [] in
-      let record_cascade_rotation_attempt
-          ?slot_release_at_phase
-          ?productive_phase_elapsed_ms
-          ?retry_phase_elapsed_ms
-          ~(from_cascade : Keeper_execution_receipt.cascade_name)
-          ~(retry : EC.degraded_retry)
-          ~(outcome : Keeper_execution_receipt.cascade_rotation_outcome)
-          (err : Agent_sdk.Error.sdk_error) =
-        let attempt : Keeper_execution_receipt.cascade_rotation_attempt =
-          {
-            from_cascade;
-            to_cascade =
-              Keeper_execution_receipt.cascade_name_of_string retry.next_cascade;
-            reason = retry.fallback_reason;
-            outcome;
-            slot_release_at_phase;
-            productive_phase_elapsed_ms;
-            retry_phase_elapsed_ms;
-            error_kind =
-              Some
-                (Keeper_execution_receipt.error_kind_of_string
-                   (sdk_error_kind err));
-            error_message = Some (Agent_sdk.Error.to_string err);
-            recorded_at = now_iso ();
-          }
-        in
-        cascade_rotation_attempts := attempt :: !cascade_rotation_attempts
-      in
-      let run_result, latency_ms =
-        (* Cancel-safe cleanup (#9747): stdlib [Fun.protect] wraps cleanup
+               Keeper_registry.mark_turn_started ~base_path:config.base_path meta.name;
+               let meta =
+                 match Keeper_registry.get ~base_path:config.base_path meta.name with
+                 | Some entry ->
+                   let () =
+                     match
+                       write_meta_with_merge
+                         ~merge:Keeper_meta_merge.heartbeat_fields_from_disk
+                         config
+                         entry.meta
+                     with
+                     | Ok () -> ()
+                     | Error err ->
+                       Prometheus.inc_counter
+                         Keeper_metrics.metric_keeper_write_meta_failures
+                         ~labels:[ "keeper", entry.meta.name; "phase", "turn_start" ]
+                         ();
+                       Log.Keeper.warn
+                         "%s: turn-start write_meta_with_merge failed: %s"
+                         entry.meta.name
+                         err
+                   in
+                   entry.meta
+                 | None -> meta
+               in
+               Keeper_registry.mark_turn_measurement ~base_path:config.base_path meta.name;
+               (match Keeper_registry.get ~base_path:config.base_path meta.name with
+                | Some { current_turn_observation = Some { measurement = Some _; _ }; _ }
+                  ->
+                  Keeper_registry.set_turn_decision_stage
+                    ~base_path:config.base_path
+                    meta.name
+                    Keeper_registry.Decision_guard_ok
+                | _ -> ());
+               let last_execution = ref initial_execution in
+               let last_timeout_budget : oas_timeout_budget_resolution option ref =
+                 ref None
+               in
+               let degraded_retry_info = ref None in
+               let cascade_rotation_attempts = ref [] in
+               let record_cascade_rotation_attempt
+                     ?slot_release_at_phase
+                     ?productive_phase_elapsed_ms
+                     ?retry_phase_elapsed_ms
+                     ~(from_cascade : Keeper_execution_receipt.cascade_name)
+                     ~(retry : EC.degraded_retry)
+                     ~(outcome : Keeper_execution_receipt.cascade_rotation_outcome)
+                     (err : Agent_sdk.Error.sdk_error)
+                 =
+                 let attempt : Keeper_execution_receipt.cascade_rotation_attempt =
+                   { from_cascade
+                   ; to_cascade =
+                       Keeper_execution_receipt.cascade_name_of_string retry.next_cascade
+                   ; reason = retry.fallback_reason
+                   ; outcome
+                   ; slot_release_at_phase
+                   ; productive_phase_elapsed_ms
+                   ; retry_phase_elapsed_ms
+                   ; error_kind =
+                       Some
+                         (Keeper_execution_receipt.error_kind_of_string
+                            (sdk_error_kind err))
+                   ; error_message = Some (Agent_sdk.Error.to_string err)
+                   ; recorded_at = now_iso ()
+                   }
+                 in
+                 cascade_rotation_attempts := attempt :: !cascade_rotation_attempts
+               in
+               let run_result, latency_ms =
+                 (* Cancel-safe cleanup (#9747): stdlib [Fun.protect] wraps cleanup
            exceptions in [Fun.Finally_raised], losing the outer
            [Eio.Cancel.Cancelled]. Cleanup here swallows Cancelled (the
            outer one is already in flight) and logs non-cancel exceptions
            instead of propagating them. *)
-        let cleanup () =
-          (try unsubscribe_event_bus () with
-           | Eio.Cancel.Cancelled _ -> ()
-           | e ->
-             Log.Keeper.warn
-               "%s: unsubscribe_event_bus in turn cleanup raised: %s"
-               meta.name (Printexc.to_string e);
-             Prometheus.inc_counter
-               Keeper_metrics.metric_keeper_turn_cleanup_failures
-               ~labels:[("keeper", meta.name); ("site", "unsubscribe_event_bus")]
-               ());
-          (try
-             Keeper_registry.mark_turn_finished
-               ~base_path:config.base_path meta.name
-           with
-           | Eio.Cancel.Cancelled _ -> ()
-           | e ->
-             Log.Keeper.warn
-               "%s: mark_turn_finished in turn cleanup raised: %s"
-               meta.name (Printexc.to_string e);
-             Prometheus.inc_counter
-               Keeper_metrics.metric_keeper_turn_cleanup_failures
-               ~labels:[("keeper", meta.name); ("site", "mark_turn_finished")]
-               ());
-        in
-        match
-        Keeper_exec_context.timed (fun () ->
-          match Eio_context.get_clock () with
-          | Error msg -> Error (Agent_sdk.Error.Internal msg)
-          | Ok clock ->
-          let timeout_sec =
-            Keeper_runtime_resolved.turn_timeout_sec ()
-          in
-          start_background_turn_event_bus_drain ~clock;
-          let turn_started_at = Eio.Time.now clock in
-          let turn_deadline = turn_started_at +. timeout_sec in
-          let remaining_turn_budget_s () =
-            Float.max 0.0 (turn_deadline -. Eio.Time.now clock)
-          in
-          let retry_phase_started_at = ref None in
-          let elapsed_ms seconds =
-            int_of_float (Float.max 0.0 seconds *. 1000.0)
-          in
-          let current_turn_phase_elapsed_ms () =
-            let now = Eio.Time.now clock in
-            match !retry_phase_started_at with
-            | None -> (elapsed_ms (now -. turn_started_at), Some 0)
-            | Some retry_started_at ->
-                ( elapsed_ms (retry_started_at -. turn_started_at),
-                  Some (elapsed_ms (now -. retry_started_at)) )
-          in
-          let keeper_profile =
-            Keeper_types_profile.load_keeper_profile_defaults meta.name
-          in
-          let max_idle_turns, max_turns =
-            match channel with
-            | Keeper_world_observation.Reactive ->
-                ( Keeper_runtime_resolved.reactive_max_idle_turns (),
-                  Keeper_types_profile.effective_max_turns_per_call
-                    keeper_profile )
-            | Keeper_world_observation.Scheduled_autonomous ->
-                ( Keeper_runtime_resolved.autonomous_max_idle_turns (),
-                  Keeper_types_profile
-                  .effective_max_turns_per_call_scheduled_autonomous
-                    keeper_profile )
-          in
-          let initial_tool_requirement =
-            if
-              Keeper_agent_run.should_require_tools_for_initial_turn
-                ~max_turns ~turn_affordances
-            then Keeper_agent_tool_surface.Required
-            else Keeper_agent_tool_surface.Optional
-          in
-          let do_run ~(execution : cascade_execution) ~run_meta ~run_generation ~is_retry
-              ~oas_timeout_s ~attempt_watchdog_s =
-            last_execution := execution;
-            Otel_genai.with_keeper_turn_span
-              ~keeper_name:run_meta.name
-              ~agent_name:run_meta.agent_name
-              ~cascade_name:execution.cascade_name
-              ~trace_id:(Keeper_id.Trace_id.to_string run_meta.runtime.trace_id)
-              ~generation:run_generation
-              ~max_context:execution.max_context
-              ~max_turns
-              ~max_idle_turns
-              ~channel:(Keeper_world_observation.channel_to_string channel)
-              ~is_retry
-              ~current_task_id:
-                (Option.map Keeper_id.Task_id.to_string
-                   run_meta.current_task_id)
-              (fun () ->
-                Keeper_turn_fsm.emit_transition
-                  ~keeper_name:meta.name ~turn_id:keeper_turn_id
-                  ~prev:Keeper_turn_fsm.Awaiting_provider
-                  Keeper_turn_fsm.Streaming;
-                try
-                  Eio.Time.with_timeout_exn clock attempt_watchdog_s (fun () ->
-                      Keeper_agent_run.run_turn ~config ~meta:run_meta ~base_dir
-                        ~max_context:execution.max_context ~build_turn_prompt
-                        ~user_message ~cascade_name:execution.cascade_name
-                        ~world_observation:observation
-                        ~turn_affordances
-                        ?provider_filter:
-                          (Env_config_keeper.KeeperCascade.provider_allowlist ())
-                        ~generation:run_generation
-                        ~max_turns
-                        ~max_idle_turns
-                        ~history_user_source:"world_state_prompt"
-                        ~history_assistant_source:"internal_assistant"
-                        ~degraded_retry_applied:(Option.is_some !degraded_retry_info)
-                        ?degraded_retry_cascade:
-                          (Option.map
-                             (fun (retry : EC.degraded_retry) -> retry.next_cascade)
-                             !degraded_retry_info)
-                        ?fallback_reason:
-                          (Option.map
-                             (fun (retry : EC.degraded_retry) -> retry.fallback_reason)
-                             !degraded_retry_info)
-                        ~cascade_rotation_attempts:
-                          (List.rev !cascade_rotation_attempts)
-                        ~temperature:execution.temperature
-                        ~max_tokens:execution.max_tokens
-                        ~oas_timeout_s
-                        ?max_cost_usd
-                        ~trajectory_acc
-                        ~is_retry
-                        ?shared_context
-                        ?event_bus:(Keeper_event_bus.get ())
-                        ())
-                with Eio.Cancel.Cancelled _ as e ->
-                  (* Cycle 1b-iv: external cancellation that escapes the
+                 let cleanup () =
+                   (try unsubscribe_event_bus () with
+                    | Eio.Cancel.Cancelled _ -> ()
+                    | e ->
+                      Log.Keeper.warn
+                        "%s: unsubscribe_event_bus in turn cleanup raised: %s"
+                        meta.name
+                        (Printexc.to_string e);
+                      Prometheus.inc_counter
+                        Keeper_metrics.metric_keeper_turn_cleanup_failures
+                        ~labels:[ "keeper", meta.name; "site", "unsubscribe_event_bus" ]
+                        ());
+                   try
+                     Keeper_registry.mark_turn_finished
+                       ~base_path:config.base_path
+                       meta.name
+                   with
+                   | Eio.Cancel.Cancelled _ -> ()
+                   | e ->
+                     Log.Keeper.warn
+                       "%s: mark_turn_finished in turn cleanup raised: %s"
+                       meta.name
+                       (Printexc.to_string e);
+                     Prometheus.inc_counter
+                       Keeper_metrics.metric_keeper_turn_cleanup_failures
+                       ~labels:[ "keeper", meta.name; "site", "mark_turn_finished" ]
+                       ()
+                 in
+                 match
+                   Keeper_exec_context.timed (fun () ->
+                     match Eio_context.get_clock () with
+                     | Error msg -> Error (Agent_sdk.Error.Internal msg)
+                     | Ok clock ->
+                       let timeout_sec = Keeper_runtime_resolved.turn_timeout_sec () in
+                       start_background_turn_event_bus_drain ~clock;
+                       let turn_started_at = Eio.Time.now clock in
+                       let turn_deadline = turn_started_at +. timeout_sec in
+                       let remaining_turn_budget_s () =
+                         Float.max 0.0 (turn_deadline -. Eio.Time.now clock)
+                       in
+                       let retry_phase_started_at = ref None in
+                       let elapsed_ms seconds =
+                         int_of_float (Float.max 0.0 seconds *. 1000.0)
+                       in
+                       let current_turn_phase_elapsed_ms () =
+                         let now = Eio.Time.now clock in
+                         match !retry_phase_started_at with
+                         | None -> elapsed_ms (now -. turn_started_at), Some 0
+                         | Some retry_started_at ->
+                           ( elapsed_ms (retry_started_at -. turn_started_at)
+                           , Some (elapsed_ms (now -. retry_started_at)) )
+                       in
+                       let keeper_profile =
+                         Keeper_types_profile.load_keeper_profile_defaults meta.name
+                       in
+                       let max_idle_turns, max_turns =
+                         match channel with
+                         | Keeper_world_observation.Reactive ->
+                           ( Keeper_runtime_resolved.reactive_max_idle_turns ()
+                           , Keeper_types_profile.effective_max_turns_per_call
+                               keeper_profile )
+                         | Keeper_world_observation.Scheduled_autonomous ->
+                           ( Keeper_runtime_resolved.autonomous_max_idle_turns ()
+                           , Keeper_types_profile
+                             .effective_max_turns_per_call_scheduled_autonomous
+                               keeper_profile )
+                       in
+                       let initial_tool_requirement =
+                         if
+                           Keeper_agent_run.should_require_tools_for_initial_turn
+                             ~max_turns
+                             ~turn_affordances
+                         then Keeper_agent_tool_surface.Required
+                         else Keeper_agent_tool_surface.Optional
+                       in
+                       let do_run
+                             ~(execution : cascade_execution)
+                             ~run_meta
+                             ~run_generation
+                             ~is_retry
+                             ~oas_timeout_s
+                             ~attempt_watchdog_s
+                         =
+                         last_execution := execution;
+                         Otel_genai.with_keeper_turn_span
+                           ~keeper_name:run_meta.name
+                           ~agent_name:run_meta.agent_name
+                           ~cascade_name:execution.cascade_name
+                           ~trace_id:
+                             (Keeper_id.Trace_id.to_string run_meta.runtime.trace_id)
+                           ~generation:run_generation
+                           ~max_context:execution.max_context
+                           ~max_turns
+                           ~max_idle_turns
+                           ~channel:(Keeper_world_observation.channel_to_string channel)
+                           ~is_retry
+                           ~current_task_id:
+                             (Option.map
+                                Keeper_id.Task_id.to_string
+                                run_meta.current_task_id)
+                           (fun () ->
+                              Keeper_turn_fsm.emit_transition
+                                ~keeper_name:meta.name
+                                ~turn_id:keeper_turn_id
+                                ~prev:Keeper_turn_fsm.Awaiting_provider
+                                Keeper_turn_fsm.Streaming;
+                              try
+                                Eio.Time.with_timeout_exn
+                                  clock
+                                  attempt_watchdog_s
+                                  (fun () ->
+                                     Keeper_agent_run.run_turn
+                                       ~config
+                                       ~meta:run_meta
+                                       ~base_dir
+                                       ~max_context:execution.max_context
+                                       ~build_turn_prompt
+                                       ~user_message
+                                       ~cascade_name:execution.cascade_name
+                                       ~world_observation:observation
+                                       ~turn_affordances
+                                       ?provider_filter:
+                                         (Env_config_keeper.KeeperCascade
+                                          .provider_allowlist
+                                            ())
+                                       ~generation:run_generation
+                                       ~max_turns
+                                       ~max_idle_turns
+                                       ~history_user_source:"world_state_prompt"
+                                       ~history_assistant_source:"internal_assistant"
+                                       ~degraded_retry_applied:
+                                         (Option.is_some !degraded_retry_info)
+                                       ?degraded_retry_cascade:
+                                         (Option.map
+                                            (fun (retry : EC.degraded_retry) ->
+                                               retry.next_cascade)
+                                            !degraded_retry_info)
+                                       ?fallback_reason:
+                                         (Option.map
+                                            (fun (retry : EC.degraded_retry) ->
+                                               retry.fallback_reason)
+                                            !degraded_retry_info)
+                                       ~cascade_rotation_attempts:
+                                         (List.rev !cascade_rotation_attempts)
+                                       ~temperature:execution.temperature
+                                       ~max_tokens:execution.max_tokens
+                                       ~oas_timeout_s
+                                       ?max_cost_usd
+                                       ~trajectory_acc
+                                       ~is_retry
+                                       ?shared_context
+                                       ?event_bus:(Keeper_event_bus.get ())
+                                       ())
+                              with
+                              | Eio.Cancel.Cancelled _ as e ->
+                                (* Cycle 1b-iv: external cancellation that escapes the
                      in-band receipt builder in [Keeper_agent_run.run_turn].
                      The 14 inner Cancel handlers all re-raise; without an
                      outer catch the receipt for this turn is silently
@@ -1078,47 +1157,56 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
                      [fiber_stop] is false and we skip straight to
                      HonorStopSignal with the same conservative cancel
                      reason. *)
-                  record_streaming_cancelled_observation
-                    ~config
-                    ~run_meta
-                    ~run_generation
-                    ~cascade_name:execution.cascade_name
-                    ~keeper_turn_id
-                    ();
-                  raise e
-                | Eio.Time.Timeout ->
-                  Error
-                    (Agent_sdk.Error.Api
-                       (Timeout
-                          {
-                            message =
-                              Printf.sprintf
-                                "Turn wall-clock budget exhausted during cascade attempt \
-                                 (budget=%.1fs, watchdog=%.1fs)"
-                                oas_timeout_s attempt_watchdog_s;
-                          })))
-          in
-          let fail_open_rotation_cascades =
-            active_fail_open_rotation_cascades ()
-          in
-          let rec retry_loop ~run_meta ~(execution : cascade_execution)
-              ~run_generation
-              ~attempt ~is_retry
-              ~allow_degraded_wall_clock_retry_budget
-              ~overflow_retry_used
-              ~attempted_cascades =
-            let execution_cascade_name =
-              KCP.runtime_name_to_string execution.cascade_name
-            in
-            let mark_terminal_error err =
-              if EC.is_cascade_exhausted_error err then begin
-                Keeper_registry.set_turn_cascade_state
-                  ~base_path:config.base_path meta.name
-                  (Keeper_registry.Packed Cascade_exhausted : Keeper_registry.packed_cascade_state);
-                Prometheus.inc_counter
-                  Keeper_metrics.metric_keeper_fsm_edge_transitions
-                  ~labels:[("edge", "kcl_to_ktc_exhaustion")] ();
-                (* Cycle 52 narrative: cascade exhaustion is a silent
+                                record_streaming_cancelled_observation
+                                  ~config
+                                  ~run_meta
+                                  ~run_generation
+                                  ~cascade_name:execution.cascade_name
+                                  ~keeper_turn_id
+                                  ();
+                                raise e
+                              | Eio.Time.Timeout ->
+                                Error
+                                  (Agent_sdk.Error.Api
+                                     (Timeout
+                                        { message =
+                                            Printf.sprintf
+                                              "Turn wall-clock budget exhausted during \
+                                               cascade attempt (budget=%.1fs, \
+                                               watchdog=%.1fs)"
+                                              oas_timeout_s
+                                              attempt_watchdog_s
+                                        })))
+                       in
+                       let fail_open_rotation_cascades =
+                         active_fail_open_rotation_cascades ()
+                       in
+                       let rec retry_loop
+                                 ~run_meta
+                                 ~(execution : cascade_execution)
+                                 ~run_generation
+                                 ~attempt
+                                 ~is_retry
+                                 ~allow_degraded_wall_clock_retry_budget
+                                 ~overflow_retry_used
+                                 ~attempted_cascades
+                         =
+                         let execution_cascade_name =
+                           KCP.runtime_name_to_string execution.cascade_name
+                         in
+                         let mark_terminal_error err =
+                           if EC.is_cascade_exhausted_error err
+                           then (
+                             Keeper_registry.set_turn_cascade_state
+                               ~base_path:config.base_path
+                               meta.name
+                               (Keeper_registry.Packed Cascade_exhausted
+                                : Keeper_registry.packed_cascade_state);
+                             Prometheus.inc_counter
+                               Keeper_metrics.metric_keeper_fsm_edge_transitions
+                               ~labels:[ "edge", "kcl_to_ktc_exhaustion" ]
+                               ();
+                             (* Cycle 52 narrative: cascade exhaustion is a silent
                    failure on dashboards reading only Turn_failed.  The
                    fsm_edge counter records the transition, but operators
                    forensically investigating "why is this keeper stuck?"
@@ -1126,94 +1214,103 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
                    'all cascades exhausted' from 'single transient error'.
                    Companion to PR #11708 (gate rejection narrative) and
                    PR #11717 (unmapped regression alert). *)
-                Log.Keeper.warn
-                  "%s: all cascades exhausted (terminal) — last_err=%s \
-                   attempt=%d attempted_cascades=[%s]"
-                  meta.name (Agent_sdk.Error.to_string err) attempt
-                  (String.concat ", " attempted_cascades);
-                Prometheus.inc_counter
-                  Keeper_metrics.metric_keeper_oas_execution_errors
-                  ~labels:[("keeper", meta.name); ("phase", "cascade_exhausted")]
-                  ()
-              end
-              else begin
-                Keeper_registry.set_turn_phase
-                  ~base_path:config.base_path meta.name
-                  Keeper_registry.(Packed Turn_finalizing);
-                (* Cycle 52 narrative companion: non-exhaustion terminal
+                             Log.Keeper.warn
+                               "%s: all cascades exhausted (terminal) — last_err=%s \
+                                attempt=%d attempted_cascades=[%s]"
+                               meta.name
+                               (Agent_sdk.Error.to_string err)
+                               attempt
+                               (String.concat ", " attempted_cascades);
+                             Prometheus.inc_counter
+                               Keeper_metrics.metric_keeper_oas_execution_errors
+                               ~labels:
+                                 [ "keeper", meta.name; "phase", "cascade_exhausted" ]
+                               ())
+                           else (
+                             Keeper_registry.set_turn_phase
+                               ~base_path:config.base_path
+                               meta.name
+                               Keeper_registry.(Packed Turn_finalizing);
+                             (* Cycle 52 narrative companion: non-exhaustion terminal
                    errors (transient).  Logged so dashboard readers can
                    distinguish exhaustion from transient failure without
                    re-parsing Turn_finalizing reason fields. *)
-                Prometheus.inc_counter
-                  Keeper_metrics.metric_keeper_oas_execution_errors
-                  ~labels:[("keeper", meta.name); ("phase", "terminal_non_exhaustion")]
-                  ();
-                Log.Keeper.warn
-                  "%s: turn terminal (non-exhaustion error) — err=%s \
-                   attempt=%d"
-                  meta.name (Agent_sdk.Error.to_string err) attempt
-              end
-            in
-            let attempt_timeout_budget = ref None in
-            let max_turns =
-              match channel with
-              | Keeper_world_observation.Reactive ->
-                  Keeper_types_profile.effective_max_turns_per_call
-                    keeper_profile
-              | Keeper_world_observation.Scheduled_autonomous ->
-                  Keeper_types_profile
-                  .effective_max_turns_per_call_scheduled_autonomous
-                    keeper_profile
-            in
-            let attempt_result =
-              let reserve_degraded_retry_budget =
-                match
-                  Keeper_cascade_profile.fallback_cascade_for
-                    execution_cascade_name
-                with
-                | Some fallback_cascade ->
-                    not (String.equal fallback_cascade execution_cascade_name)
-                | None -> false
-              in
-              let allow_wall_clock_retry_budget =
-                allow_wall_clock_retry_budget_for_attempt
-                  ~is_retry
-                  ~degraded_rotation_first_attempt:allow_degraded_wall_clock_retry_budget
-                  ~attempt
-                  ~attempted_cascades
-              in
-              match
-                resolve_bounded_oas_timeout_budget_with_turn_budget
-                  ~allow_wall_clock_retry_budget
-                  ~is_retry
-                  ~reserve_degraded_retry_budget
-                  ~max_turns
-                  ~estimated_input_tokens:prompt_timeout_estimate_tokens
-                  ~remaining_turn_budget_s:(remaining_turn_budget_s ())
-              with
-              | None ->
-                  Error
-                    (Keeper_turn_driver.sdk_error_of_masc_internal_error
-                       (Keeper_turn_driver.Oas_timeout_budget
-                          {
-                            budget_sec = 0.0;
-                            keeper_turn_timeout_sec = timeout_sec;
-                            estimated_input_tokens =
-                              prompt_timeout_estimate_tokens;
-                            source =
-                              (if is_retry then "pre_retry_budget_unavailable"
-                               else "pre_attempt_budget_unavailable");
-                            remaining_turn_budget_sec =
-                              Some (remaining_turn_budget_s ());
-                            min_required_sec = min_oas_timeout_budget_sec;
-                            phase =
-                              (if is_retry then "pre_retry_budget_gate"
-                               else "pre_attempt_budget_gate");
-                          }))
-              | Some timeout_budget ->
-                  attempt_timeout_budget := Some timeout_budget;
-                  last_timeout_budget := Some timeout_budget;
-                  (* Cascade_trying marking moved into the disclosure
+                             Prometheus.inc_counter
+                               Keeper_metrics.metric_keeper_oas_execution_errors
+                               ~labels:
+                                 [ "keeper", meta.name
+                                 ; "phase", "terminal_non_exhaustion"
+                                 ]
+                               ();
+                             Log.Keeper.warn
+                               "%s: turn terminal (non-exhaustion error) — err=%s \
+                                attempt=%d"
+                               meta.name
+                               (Agent_sdk.Error.to_string err)
+                               attempt)
+                         in
+                         let attempt_timeout_budget = ref None in
+                         let max_turns =
+                           match channel with
+                           | Keeper_world_observation.Reactive ->
+                             Keeper_types_profile.effective_max_turns_per_call
+                               keeper_profile
+                           | Keeper_world_observation.Scheduled_autonomous ->
+                             Keeper_types_profile
+                             .effective_max_turns_per_call_scheduled_autonomous
+                               keeper_profile
+                         in
+                         let attempt_result =
+                           let reserve_degraded_retry_budget =
+                             match
+                               Keeper_cascade_profile.fallback_cascade_for
+                                 execution_cascade_name
+                             with
+                             | Some fallback_cascade ->
+                               not (String.equal fallback_cascade execution_cascade_name)
+                             | None -> false
+                           in
+                           let allow_wall_clock_retry_budget =
+                             allow_wall_clock_retry_budget_for_attempt
+                               ~is_retry
+                               ~degraded_rotation_first_attempt:
+                                 allow_degraded_wall_clock_retry_budget
+                               ~attempt
+                               ~attempted_cascades
+                           in
+                           match
+                             resolve_bounded_oas_timeout_budget_with_turn_budget
+                               ~allow_wall_clock_retry_budget
+                               ~is_retry
+                               ~reserve_degraded_retry_budget
+                               ~max_turns
+                               ~estimated_input_tokens:prompt_timeout_estimate_tokens
+                               ~remaining_turn_budget_s:(remaining_turn_budget_s ())
+                           with
+                           | None ->
+                             Error
+                               (Keeper_turn_driver.sdk_error_of_masc_internal_error
+                                  (Keeper_turn_driver.Oas_timeout_budget
+                                     { budget_sec = 0.0
+                                     ; keeper_turn_timeout_sec = timeout_sec
+                                     ; estimated_input_tokens =
+                                         prompt_timeout_estimate_tokens
+                                     ; source =
+                                         (if is_retry
+                                          then "pre_retry_budget_unavailable"
+                                          else "pre_attempt_budget_unavailable")
+                                     ; remaining_turn_budget_sec =
+                                         Some (remaining_turn_budget_s ())
+                                     ; min_required_sec = min_oas_timeout_budget_sec
+                                     ; phase =
+                                         (if is_retry
+                                          then "pre_retry_budget_gate"
+                                          else "pre_attempt_budget_gate")
+                                     }))
+                           | Some timeout_budget ->
+                             attempt_timeout_budget := Some timeout_budget;
+                             last_timeout_budget := Some timeout_budget;
+                             (* Cascade_trying marking moved into the disclosure
                      hook in [Keeper_run_tools] (BeforeTurnParams) so
                      that the spec-mandated atomic group
                      [SelectToolPolicy(idle->selecting) ->
@@ -1229,117 +1326,143 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
                      (assertion at keeper_registry.ml:721). Spec
                      reference: [KeeperCascadeLifecycle.tla]
                      [KeeperTurnCycle.tla]. *)
-                  let attempt_watchdog_s =
-                    attempt_watchdog_timeout_sec
-                      ~remaining_turn_budget_s:(remaining_turn_budget_s ())
-                      timeout_budget
-                  in
-                  do_run ~execution ~run_meta ~run_generation ~is_retry
-                    ~oas_timeout_s:timeout_budget.effective_timeout_sec
-                    ~attempt_watchdog_s
-            in
-            match attempt_result with
-            | Ok result ->
-                let selected_model =
-                  match result.cascade_observation with
-                  | Some observation -> observation.selected_model
-                  | None -> None
-                in
-                Keeper_registry.set_turn_selected_model
-                  ~base_path:config.base_path meta.name
-                  selected_model;
-                Keeper_registry.set_turn_cascade_state
-                  ~base_path:config.base_path meta.name
-                  (Keeper_registry.Packed Cascade_done : Keeper_registry.packed_cascade_state);
-                Ok result
-            | Error err ->
-                let err =
-                  reclassify_oas_timeout_for_attempt
-                    ~timeout_budget:!attempt_timeout_budget err
-                in
-                let _ = drain_turn_event_bus ~site:"reconcile_pre_check" () in
-                let err =
-                  match event_bus_integrity_error_snapshot () with
-                  | Some integrity_err -> integrity_err
-                  | None -> err
-                in
-                let committed_tools = committed_mutating_tools_snapshot () in
-                if committed_tools <> []
-                   && Keeper_tool_registry.all_tools_reconcile_safe
-                        committed_tools
-                   && (EC.is_auto_recoverable_turn_error err
-                       || EC.is_required_tool_contract_violation err)
-                then begin
-                  (* All committed tools are board-like (duplicate-tolerant)
+                             let attempt_watchdog_s =
+                               attempt_watchdog_timeout_sec
+                                 ~remaining_turn_budget_s:(remaining_turn_budget_s ())
+                                 timeout_budget
+                             in
+                             do_run
+                               ~execution
+                               ~run_meta
+                               ~run_generation
+                               ~is_retry
+                               ~oas_timeout_s:timeout_budget.effective_timeout_sec
+                               ~attempt_watchdog_s
+                         in
+                         match attempt_result with
+                         | Ok result ->
+                           let selected_model =
+                             match result.cascade_observation with
+                             | Some observation -> observation.selected_model
+                             | None -> None
+                           in
+                           Keeper_registry.set_turn_selected_model
+                             ~base_path:config.base_path
+                             meta.name
+                             selected_model;
+                           Keeper_registry.set_turn_cascade_state
+                             ~base_path:config.base_path
+                             meta.name
+                             (Keeper_registry.Packed Cascade_done
+                              : Keeper_registry.packed_cascade_state);
+                           Ok result
+                         | Error err ->
+                           let err =
+                             reclassify_oas_timeout_for_attempt
+                               ~timeout_budget:!attempt_timeout_budget
+                               err
+                           in
+                           let _ = drain_turn_event_bus ~site:"reconcile_pre_check" () in
+                           let err =
+                             match event_bus_integrity_error_snapshot () with
+                             | Some integrity_err -> integrity_err
+                             | None -> err
+                           in
+                           let committed_tools = committed_mutating_tools_snapshot () in
+                           if
+                             committed_tools <> []
+                             && Keeper_tool_registry.all_tools_reconcile_safe
+                                  committed_tools
+                             && (EC.is_auto_recoverable_turn_error err
+                                 || EC.is_required_tool_contract_violation err)
+                           then (
+                             (* All committed tools are board-like (duplicate-tolerant)
                      AND the failure is transient or the server rejected the
                      request body before processing (parse error).  Parse
                      errors mean the LLM never saw the request, so no risk
                      of duplicate processing.  The keeper's next cycle will
                      build a fresh prompt that may avoid the parse issue. *)
-                  let err_preview = short_preview (Agent_sdk.Error.to_string err) in
-                  let reason =
-                    if EC.is_server_rejected_parse_error err then "server parse rejection"
-                    else if EC.is_required_tool_contract_violation err then
-                      "required tool contract violation"
-                    else "transient error"
-                  in
-                  Log.Keeper.warn
-                    "%s: %s after committed reconcile-safe tool(s) [%s] — auto-recovering (error: %s)"
-                    meta.name reason
-                    (String.concat ", " committed_tools)
-                    err_preview;
-                  Prometheus.inc_counter
-                    Keeper_metrics.metric_keeper_turn_error_after_tools
-                    ~labels:[("keeper", meta.name); ("reason", reason)]
-                    ();
-                  mark_terminal_error err;
-                  Error err
-                end else if committed_tools <> [] then begin
-                  let reclassified, failure_reason =
-                    match
-                      EC.classify_post_commit_failure
-                        ~tool_names:committed_tools
-                        err
-                    with
-                    | Some classified -> classified
-                    | None ->
-                        ( EC.reclassify_error_after_side_effect
-                            ~tool_names:committed_tools err,
-                          Keeper_registry.Ambiguous_partial_commit {
-                            kind = Keeper_registry.Post_commit_failure;
-                            detail =
-                              EC.summarize_post_commit_failure
-                                ~tool_names:committed_tools
-                                ~kind:Keeper_registry.Post_commit_failure
-                                err;
-                          } )
-                  in
-                  post_commit_failure_reason := Some failure_reason;
-                  let err_preview = short_preview (Agent_sdk.Error.to_string err) in
-                  if EC.is_transient_network_error err then begin
-                    Prometheus.inc_counter
-                      Keeper_metrics.metric_keeper_post_turn_wirein_failures
-                      ~labels:[("keeper", meta.name); ("site", "post_commit_transient")]
-                      ();
-                    Log.Keeper.error
-                      "%s: transient provider error after committed mutating tool call(s) [%s] — treating as integrity failure, skipping retry to prevent duplicate (error: %s)"
-                      meta.name
-                      (String.concat ", " committed_tools)
-                      err_preview
-                  end else
-                    Log.Keeper.error
-                      "%s: error after committed mutating tool call(s) [%s] — turn outcome is ambiguous and requires reconcile (error: %s)"
-                      meta.name
-                      (String.concat ", " committed_tools)
-                      err_preview;
-                  Prometheus.inc_counter
-                    Keeper_metrics.metric_keeper_turn_error_after_tools
-                    ~labels:[("keeper", meta.name)]
-                    ();
-                  mark_terminal_error reclassified;
-                  Error reclassified
-                end else if
-                  (* Fast-fail after one cascade rotation for a contract
+                             let err_preview =
+                               short_preview (Agent_sdk.Error.to_string err)
+                             in
+                             let reason =
+                               if EC.is_server_rejected_parse_error err
+                               then "server parse rejection"
+                               else if EC.is_required_tool_contract_violation err
+                               then "required tool contract violation"
+                               else "transient error"
+                             in
+                             Log.Keeper.warn
+                               "%s: %s after committed reconcile-safe tool(s) [%s] — \
+                                auto-recovering (error: %s)"
+                               meta.name
+                               reason
+                               (String.concat ", " committed_tools)
+                               err_preview;
+                             Prometheus.inc_counter
+                               Keeper_metrics.metric_keeper_turn_error_after_tools
+                               ~labels:[ "keeper", meta.name; "reason", reason ]
+                               ();
+                             mark_terminal_error err;
+                             Error err)
+                           else if committed_tools <> []
+                           then (
+                             let reclassified, failure_reason =
+                               match
+                                 EC.classify_post_commit_failure
+                                   ~tool_names:committed_tools
+                                   err
+                               with
+                               | Some classified -> classified
+                               | None ->
+                                 ( EC.reclassify_error_after_side_effect
+                                     ~tool_names:committed_tools
+                                     err
+                                 , Keeper_registry.Ambiguous_partial_commit
+                                     { kind = Keeper_registry.Post_commit_failure
+                                     ; detail =
+                                         EC.summarize_post_commit_failure
+                                           ~tool_names:committed_tools
+                                           ~kind:Keeper_registry.Post_commit_failure
+                                           err
+                                     } )
+                             in
+                             post_commit_failure_reason := Some failure_reason;
+                             let err_preview =
+                               short_preview (Agent_sdk.Error.to_string err)
+                             in
+                             if EC.is_transient_network_error err
+                             then (
+                               Prometheus.inc_counter
+                                 Keeper_metrics.metric_keeper_post_turn_wirein_failures
+                                 ~labels:
+                                   [ "keeper", meta.name
+                                   ; "site", "post_commit_transient"
+                                   ]
+                                 ();
+                               Log.Keeper.error
+                                 "%s: transient provider error after committed mutating \
+                                  tool call(s) [%s] — treating as integrity failure, \
+                                  skipping retry to prevent duplicate (error: %s)"
+                                 meta.name
+                                 (String.concat ", " committed_tools)
+                                 err_preview)
+                             else
+                               Log.Keeper.error
+                                 "%s: error after committed mutating tool call(s) [%s] — \
+                                  turn outcome is ambiguous and requires reconcile \
+                                  (error: %s)"
+                                 meta.name
+                                 (String.concat ", " committed_tools)
+                                 err_preview;
+                             Prometheus.inc_counter
+                               Keeper_metrics.metric_keeper_turn_error_after_tools
+                               ~labels:[ "keeper", meta.name ]
+                               ();
+                             mark_terminal_error reclassified;
+                             Error reclassified)
+                           else if
+                             (* Fast-fail after one cascade rotation for a contract
                      violation: if the LLM called no tools or only used
                      passive/read-only tools on the first cascade and the
                      same pattern repeats on a rotated cascade, further
@@ -1364,166 +1487,179 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
                      allow one more rotation to try it — the fallback
                      has a different model composition and may not
                      exhibit the same passive-tool behavior. *)
-                  let fallback_not_yet_tried =
-                    match
-                      KCP.fallback_cascade_for execution_cascade_name
-                    with
-                    | Some fb ->
-                        not (List.exists (String.equal fb) attempted_cascades)
-                        && not (String.equal fb execution_cascade_name)
-                    | None -> false
-                  in
-                  EC.should_cap_rotation_for_contract_violation
-                    ~attempted_cascades
-                    ~fallback_not_yet_tried
-                    err
-                then begin
-                  Log.Keeper.warn
-                    "%s: required_tool_contract_violation after rotation \
-                     (%s, %d cascade(s) attempted) — skipping further \
-                     rotation; rotating again is unlikely to change the \
-                     model's tool-use choice. Error: %s"
-                    meta.name execution_cascade_name
-                    (List.length attempted_cascades)
-                    (short_preview (Agent_sdk.Error.to_string err));
-                  Prometheus.inc_counter
-                    "masc_keeper_contract_violation_rotation_capped_total"
-                    ~labels:[ ("keeper", meta.name) ]
-                    ();
-                  mark_terminal_error err;
-                  Error err
-                end else
-                  (* Budget gate: check whether there is enough wall-clock
+                             let fallback_not_yet_tried =
+                               match KCP.fallback_cascade_for execution_cascade_name with
+                               | Some fb ->
+                                 (not (List.exists (String.equal fb) attempted_cascades))
+                                 && not (String.equal fb execution_cascade_name)
+                               | None -> false
+                             in
+                             EC.should_cap_rotation_for_contract_violation
+                               ~attempted_cascades
+                               ~fallback_not_yet_tried
+                               err
+                           then (
+                             Log.Keeper.warn
+                               "%s: required_tool_contract_violation after rotation (%s, \
+                                %d cascade(s) attempted) — skipping further rotation; \
+                                rotating again is unlikely to change the model's \
+                                tool-use choice. Error: %s"
+                               meta.name
+                               execution_cascade_name
+                               (List.length attempted_cascades)
+                               (short_preview (Agent_sdk.Error.to_string err));
+                             Prometheus.inc_counter
+                               "masc_keeper_contract_violation_rotation_capped_total"
+                               ~labels:[ "keeper", meta.name ]
+                               ();
+                             mark_terminal_error err;
+                             Error err)
+                           else (
+                             (* Budget gate: check whether there is enough wall-clock
                      remaining to schedule a degraded cascade retry.  The
                      gate always uses per-attempt semantics (fresh floor) for
                      the candidate because, by definition, every degraded
                      retry is itself a retry — even when the failing attempt
                      was the first attempt (is_retry=false here). *)
-                  match
-                    next_fail_open_cascade_for_turn_with_budget
-                      ?rotation_cascades:fail_open_rotation_cascades
-                      ~base_cascade:(cascade_name_of_meta meta)
-                      ~effective_cascade:execution_cascade_name
-                      ~tool_requirement:initial_tool_requirement
-                      ~attempted_cascades
-                      ~estimated_input_tokens:
-                        prompt_timeout_estimate_tokens
-                      ~max_turns
-                      ~time_spent_in_turn_s:
-                        (timeout_sec -. remaining_turn_budget_s ())
-                      ~remaining_turn_budget_s:(remaining_turn_budget_s ())
-                      err
-                  with
-                  | Degraded_retry_allowed degraded_retry -> (
-                      match
-                        build_cascade_execution
-                          ~cascade_name:
-                            (KCP.Runtime_name degraded_retry.next_cascade)
-                      with
-                      | Error fail_open_err ->
-                          let productive_phase_elapsed_ms, retry_phase_elapsed_ms =
-                            current_turn_phase_elapsed_ms ()
-                          in
-                          record_cascade_rotation_attempt
-                            ~slot_release_at_phase:
-                              Keeper_execution_receipt.Retry_setup_failed
-                            ~productive_phase_elapsed_ms
-                            ?retry_phase_elapsed_ms
-                            ~from_cascade:execution.cascade_name
-                            ~retry:degraded_retry
-                            ~outcome:
-                              Keeper_execution_receipt.Rotation_setup_failed
-                            fail_open_err;
-                          Log.Keeper.warn
-                            "%s: recoverable cascade failure in %s suggested degraded retry to %s (reason=%s), but retry setup failed: %s"
-                            meta.name execution_cascade_name
-                            degraded_retry.next_cascade
-                            (EC.degraded_retry_reason_to_string
-                               degraded_retry.fallback_reason)
-                            (short_preview (Agent_sdk.Error.to_string fail_open_err));
-                          mark_terminal_error fail_open_err;
-                          Error fail_open_err
-                      | Ok next_execution ->
-                          let next_execution_cascade_name =
-                            KCP.runtime_name_to_string
-                              next_execution.cascade_name
-                          in
-                          if Option.is_none !retry_phase_started_at then
-                            retry_phase_started_at := Some (Eio.Time.now clock);
-                          let productive_phase_elapsed_ms, retry_phase_elapsed_ms =
-                            current_turn_phase_elapsed_ms ()
-                          in
-                          let slot_release_at_phase =
-                            match turn_slot_control with
-                            | Some slot_control ->
-                                slot_control.Keeper_turn_slot.release_for_retry ();
-                                Some Keeper_execution_receipt.Retry_scheduled
-                            | None -> None
-                          in
-                          record_cascade_rotation_attempt
-                            ?slot_release_at_phase
-                            ~productive_phase_elapsed_ms
-                            ?retry_phase_elapsed_ms
-                            ~from_cascade:execution.cascade_name
-                            ~retry:degraded_retry
-                            ~outcome:
-                              Keeper_execution_receipt.Rotation_retry_scheduled
-                            err;
-                          degraded_retry_info := Some degraded_retry;
-                          Log.Keeper.warn
-                            "%s: recoverable cascade failure in %s; rotation retry on cascade=%s reason=%s max_context=%d context_budget=%d primary_budget=%d requested_override=%s: %s"
-                            meta.name execution_cascade_name
-                            next_execution_cascade_name
-                            (EC.degraded_retry_reason_to_string
-                               degraded_retry.fallback_reason)
-                            next_execution.max_context
-                            next_execution.max_context_resolution.effective_budget
-                            next_execution.max_context_resolution.primary_budget
-                            (match
-                               next_execution.max_context_resolution.requested_override
+                             match
+                               next_fail_open_cascade_for_turn_with_budget
+                                 ?rotation_cascades:fail_open_rotation_cascades
+                                 ~base_cascade:(cascade_name_of_meta meta)
+                                 ~effective_cascade:execution_cascade_name
+                                 ~tool_requirement:initial_tool_requirement
+                                 ~attempted_cascades
+                                 ~estimated_input_tokens:prompt_timeout_estimate_tokens
+                                 ~max_turns
+                                 ~time_spent_in_turn_s:
+                                   (timeout_sec -. remaining_turn_budget_s ())
+                                 ~remaining_turn_budget_s:(remaining_turn_budget_s ())
+                                 err
                              with
-                            | Some requested -> string_of_int requested
-                            | None -> "none")
-                            (short_preview (Agent_sdk.Error.to_string err));
-                          Eio.Fiber.yield ();
-                          let run_retry_after_reacquire () =
-                            retry_loop ~run_meta ~execution:next_execution
-                              ~run_generation
-                              ~attempt:1
-                              ~is_retry:true
-                              ~allow_degraded_wall_clock_retry_budget:true
-                              ~overflow_retry_used
-                              ~attempted_cascades:
-                                (next_execution_cascade_name :: attempted_cascades)
-                          in
-                          match turn_slot_control with
-                          | None -> run_retry_after_reacquire ()
-                          | Some slot_control -> (
-                              match
-                                slot_control.Keeper_turn_slot.reacquire_after_retry ()
-                              with
-                              | Ok retry_semaphore_wait_ms ->
-                                  Log.Keeper.info
-                                    "%s: reacquired keeper turn slot for degraded retry on cascade=%s wait_ms=%d"
-                                    meta.name
-                                    next_execution_cascade_name
-                                    retry_semaphore_wait_ms;
-                                  run_retry_after_reacquire ()
-                              | Error (`Semaphore_wait_timeout timeout) ->
-                                  let slot_err =
-                                    sdk_error_of_retry_slot_reacquire_timeout
-                                      ~keeper_name:meta.name timeout
+                             | Degraded_retry_allowed degraded_retry ->
+                               (match
+                                  build_cascade_execution
+                                    ~cascade_name:
+                                      (KCP.Runtime_name degraded_retry.next_cascade)
+                                with
+                                | Error fail_open_err ->
+                                  let productive_phase_elapsed_ms, retry_phase_elapsed_ms =
+                                    current_turn_phase_elapsed_ms ()
                                   in
+                                  record_cascade_rotation_attempt
+                                    ~slot_release_at_phase:
+                                      Keeper_execution_receipt.Retry_setup_failed
+                                    ~productive_phase_elapsed_ms
+                                    ?retry_phase_elapsed_ms
+                                    ~from_cascade:execution.cascade_name
+                                    ~retry:degraded_retry
+                                    ~outcome:
+                                      Keeper_execution_receipt.Rotation_setup_failed
+                                    fail_open_err;
                                   Log.Keeper.warn
-                                    "%s: degraded retry to %s skipped because turn slot reacquire timed out: %s"
+                                    "%s: recoverable cascade failure in %s suggested \
+                                     degraded retry to %s (reason=%s), but retry setup \
+                                     failed: %s"
                                     meta.name
-                                    next_execution_cascade_name
+                                    execution_cascade_name
+                                    degraded_retry.next_cascade
+                                    (EC.degraded_retry_reason_to_string
+                                       degraded_retry.fallback_reason)
                                     (short_preview
-                                       (Agent_sdk.Error.to_string slot_err));
-                                  mark_terminal_error slot_err;
-                                  Error slot_err))
-                  | Degraded_retry_budget_exhausted degraded_retry ->
-                      (* #13120 review (P1, threads 2 & 4): record the
+                                       (Agent_sdk.Error.to_string fail_open_err));
+                                  mark_terminal_error fail_open_err;
+                                  Error fail_open_err
+                                | Ok next_execution ->
+                                  let next_execution_cascade_name =
+                                    KCP.runtime_name_to_string next_execution.cascade_name
+                                  in
+                                  if Option.is_none !retry_phase_started_at
+                                  then retry_phase_started_at := Some (Eio.Time.now clock);
+                                  let productive_phase_elapsed_ms, retry_phase_elapsed_ms =
+                                    current_turn_phase_elapsed_ms ()
+                                  in
+                                  let slot_release_at_phase =
+                                    match turn_slot_control with
+                                    | Some slot_control ->
+                                      slot_control.Keeper_turn_slot.release_for_retry ();
+                                      Some Keeper_execution_receipt.Retry_scheduled
+                                    | None -> None
+                                  in
+                                  record_cascade_rotation_attempt
+                                    ?slot_release_at_phase
+                                    ~productive_phase_elapsed_ms
+                                    ?retry_phase_elapsed_ms
+                                    ~from_cascade:execution.cascade_name
+                                    ~retry:degraded_retry
+                                    ~outcome:
+                                      Keeper_execution_receipt.Rotation_retry_scheduled
+                                    err;
+                                  degraded_retry_info := Some degraded_retry;
+                                  Log.Keeper.warn
+                                    "%s: recoverable cascade failure in %s; rotation \
+                                     retry on cascade=%s reason=%s max_context=%d \
+                                     context_budget=%d primary_budget=%d \
+                                     requested_override=%s: %s"
+                                    meta.name
+                                    execution_cascade_name
+                                    next_execution_cascade_name
+                                    (EC.degraded_retry_reason_to_string
+                                       degraded_retry.fallback_reason)
+                                    next_execution.max_context
+                                    next_execution.max_context_resolution.effective_budget
+                                    next_execution.max_context_resolution.primary_budget
+                                    (match
+                                       next_execution.max_context_resolution
+                                         .requested_override
+                                     with
+                                     | Some requested -> string_of_int requested
+                                     | None -> "none")
+                                    (short_preview (Agent_sdk.Error.to_string err));
+                                  Eio.Fiber.yield ();
+                                  let run_retry_after_reacquire () =
+                                    retry_loop
+                                      ~run_meta
+                                      ~execution:next_execution
+                                      ~run_generation
+                                      ~attempt:1
+                                      ~is_retry:true
+                                      ~allow_degraded_wall_clock_retry_budget:true
+                                      ~overflow_retry_used
+                                      ~attempted_cascades:
+                                        (next_execution_cascade_name :: attempted_cascades)
+                                  in
+                                  (match turn_slot_control with
+                                   | None -> run_retry_after_reacquire ()
+                                   | Some slot_control ->
+                                     (match
+                                        slot_control
+                                          .Keeper_turn_slot.reacquire_after_retry
+                                          ()
+                                      with
+                                      | Ok retry_semaphore_wait_ms ->
+                                        Log.Keeper.info
+                                          "%s: reacquired keeper turn slot for degraded \
+                                           retry on cascade=%s wait_ms=%d"
+                                          meta.name
+                                          next_execution_cascade_name
+                                          retry_semaphore_wait_ms;
+                                        run_retry_after_reacquire ()
+                                      | Error (`Semaphore_wait_timeout timeout) ->
+                                        let slot_err =
+                                          sdk_error_of_retry_slot_reacquire_timeout
+                                            ~keeper_name:meta.name
+                                            timeout
+                                        in
+                                        Log.Keeper.warn
+                                          "%s: degraded retry to %s skipped because turn \
+                                           slot reacquire timed out: %s"
+                                          meta.name
+                                          next_execution_cascade_name
+                                          (short_preview
+                                             (Agent_sdk.Error.to_string slot_err));
+                                        mark_terminal_error slot_err;
+                                        Error slot_err)))
+                             | Degraded_retry_budget_exhausted degraded_retry ->
+                               (* #13120 review (P1, threads 2 & 4): record the
                          rejection in [cascade_rotation_attempts] so
                          downstream receipts show "rotation considered,
                          budget exhausted".  Do NOT flip
@@ -1538,576 +1674,655 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
                          evidence trail is captured by
                          [cascade_rotation_attempts] (with outcome
                          label) regardless. *)
-                      let productive_phase_elapsed_ms, retry_phase_elapsed_ms =
-                        current_turn_phase_elapsed_ms ()
-                      in
-                      record_cascade_rotation_attempt
-                        ~slot_release_at_phase:
-                          Keeper_execution_receipt.Retry_budget_exhausted
-                        ~productive_phase_elapsed_ms
-                        ?retry_phase_elapsed_ms
-                        ~from_cascade:execution.cascade_name
-                        ~retry:degraded_retry
-                        ~outcome:
-                          Keeper_execution_receipt.Rotation_budget_exhausted
-                        err;
-                      Log.Keeper.warn
-                        "%s: recoverable cascade failure in %s suggested degraded retry to %s (reason=%s), but remaining turn budget %.1fs is below the OAS retry guard/minimum; ending this cycle: %s"
-                        meta.name execution_cascade_name
-                        degraded_retry.next_cascade
-                        (EC.degraded_retry_reason_to_string
-                           degraded_retry.fallback_reason)
-                        (remaining_turn_budget_s ())
-                        (short_preview (Agent_sdk.Error.to_string err));
-                      mark_terminal_error err;
-                      Error err
-                  | Degraded_retry_slot_phase_exhausted degraded_retry ->
-                      (* #13120 review (P1, thread 3): same observability
+                               let productive_phase_elapsed_ms, retry_phase_elapsed_ms =
+                                 current_turn_phase_elapsed_ms ()
+                               in
+                               record_cascade_rotation_attempt
+                                 ~slot_release_at_phase:
+                                   Keeper_execution_receipt.Retry_budget_exhausted
+                                 ~productive_phase_elapsed_ms
+                                 ?retry_phase_elapsed_ms
+                                 ~from_cascade:execution.cascade_name
+                                 ~retry:degraded_retry
+                                 ~outcome:
+                                   Keeper_execution_receipt.Rotation_budget_exhausted
+                                 err;
+                               Log.Keeper.warn
+                                 "%s: recoverable cascade failure in %s suggested \
+                                  degraded retry to %s (reason=%s), but remaining turn \
+                                  budget %.1fs is below the OAS retry guard/minimum; \
+                                  ending this cycle: %s"
+                                 meta.name
+                                 execution_cascade_name
+                                 degraded_retry.next_cascade
+                                 (EC.degraded_retry_reason_to_string
+                                    degraded_retry.fallback_reason)
+                                 (remaining_turn_budget_s ())
+                                 (short_preview (Agent_sdk.Error.to_string err));
+                               mark_terminal_error err;
+                               Error err
+                             | Degraded_retry_slot_phase_exhausted degraded_retry ->
+                               (* #13120 review (P1, thread 3): same observability
                          contract as the budget-exhausted branch above —
                          the rejection is recorded in
                          [cascade_rotation_attempts] (with a distinct
                          "slot_phase_exhausted" outcome label), but
                          [degraded_retry_info] is NOT flipped because
                          no rotation was actually applied. *)
-                      let productive_phase_elapsed_ms, retry_phase_elapsed_ms =
-                        current_turn_phase_elapsed_ms ()
-                      in
-                      record_cascade_rotation_attempt
-                        ~slot_release_at_phase:
-                          Keeper_execution_receipt.Productive_phase_exhausted
-                        ~productive_phase_elapsed_ms
-                        ?retry_phase_elapsed_ms
-                        ~from_cascade:execution.cascade_name
-                        ~retry:degraded_retry
-                        ~outcome:
-                          Keeper_execution_receipt.Rotation_slot_phase_exhausted
-                        err;
-                      Log.Keeper.warn
-                        "%s: recoverable cascade failure in %s suggested degraded retry to %s (reason=%s), but productive slot phase budget %.1fs is exhausted after %.1fs; ending this cycle to release the outer turn slot: %s"
-                        meta.name execution_cascade_name
-                        degraded_retry.next_cascade
-                        (EC.degraded_retry_reason_to_string
-                           degraded_retry.fallback_reason)
-                        degraded_retry_slot_phase_budget_sec
-                        (timeout_sec -. remaining_turn_budget_s ())
-                        (short_preview (Agent_sdk.Error.to_string err));
-                      mark_terminal_error err;
-                      Error err
-                  | No_degraded_retry when EC.is_transient_network_error err
-                              && attempt <= EC.max_transient_retries () ->
-                      let delay = EC.transient_backoff_sec attempt in
-                      Log.Keeper.warn
-                        "%s: transient network error cascade=%s max_context=%d context_budget=%d primary_budget=%d requested_override=%s retry=%d/%d backoff=%.0fs: %s"
-                        meta.name execution_cascade_name
-                        execution.max_context
-                        execution.max_context_resolution.effective_budget
-                        execution.max_context_resolution.primary_budget
-                        (match execution.max_context_resolution.requested_override with
-                         | Some requested -> string_of_int requested
-                         | None -> "none")
-                        attempt (EC.max_transient_retries ()) delay
-                        (short_preview (Agent_sdk.Error.to_string err));
-                      Prometheus.inc_counter
-                        Keeper_metrics.metric_keeper_oas_execution_errors
-                        ~labels:[("keeper", meta.name); ("phase", "recoverable_cascade_transient")]
-                        ();
-                      Eio.Time.sleep clock delay;
-                      retry_loop ~run_meta ~execution ~run_generation
-                        ~attempt:(attempt + 1)
-                        ~is_retry:true
-                        ~allow_degraded_wall_clock_retry_budget:false
-                        ~overflow_retry_used
-                        ~attempted_cascades
-                  | No_degraded_retry when EC.is_context_overflow err ->
-                  let current_turn_event_bus =
-                    drain_turn_event_bus ~site:"context_overflow_capture" () in
-                  dispatch_keeper_phase_event
-                    ~config
-                    ~keeper_name:meta.name
-                    (context_overflow_event_of_error
-                       ~fallback_tokens:execution.max_context
-                       ~turn_event_bus:current_turn_event_bus
-                       err);
-                  if not overflow_retry_used then
-                    match
-                      recover_context_overflow_retry
-                        ~meta:run_meta
-                        ~base_dir
-                        ~max_cascade_context:execution.max_context
-                        ~error:err
-                    with
-                    | Some retry_plan ->
-                        Keeper_registry.set_turn_phase
-                          ~base_path:config.base_path meta.name
-                          Keeper_registry.(Packed Turn_compacting);
-                        (* SDK boundary classification: [EC.is_context_overflow err]
+                               let productive_phase_elapsed_ms, retry_phase_elapsed_ms =
+                                 current_turn_phase_elapsed_ms ()
+                               in
+                               record_cascade_rotation_attempt
+                                 ~slot_release_at_phase:
+                                   Keeper_execution_receipt.Productive_phase_exhausted
+                                 ~productive_phase_elapsed_ms
+                                 ?retry_phase_elapsed_ms
+                                 ~from_cascade:execution.cascade_name
+                                 ~retry:degraded_retry
+                                 ~outcome:
+                                   Keeper_execution_receipt.Rotation_slot_phase_exhausted
+                                 err;
+                               Log.Keeper.warn
+                                 "%s: recoverable cascade failure in %s suggested \
+                                  degraded retry to %s (reason=%s), but productive slot \
+                                  phase budget %.1fs is exhausted after %.1fs; ending \
+                                  this cycle to release the outer turn slot: %s"
+                                 meta.name
+                                 execution_cascade_name
+                                 degraded_retry.next_cascade
+                                 (EC.degraded_retry_reason_to_string
+                                    degraded_retry.fallback_reason)
+                                 degraded_retry_slot_phase_budget_sec
+                                 (timeout_sec -. remaining_turn_budget_s ())
+                                 (short_preview (Agent_sdk.Error.to_string err));
+                               mark_terminal_error err;
+                               Error err
+                             | No_degraded_retry
+                               when EC.is_transient_network_error err
+                                    && attempt <= EC.max_transient_retries () ->
+                               let delay = EC.transient_backoff_sec attempt in
+                               Log.Keeper.warn
+                                 "%s: transient network error cascade=%s max_context=%d \
+                                  context_budget=%d primary_budget=%d \
+                                  requested_override=%s retry=%d/%d backoff=%.0fs: %s"
+                                 meta.name
+                                 execution_cascade_name
+                                 execution.max_context
+                                 execution.max_context_resolution.effective_budget
+                                 execution.max_context_resolution.primary_budget
+                                 (match
+                                    execution.max_context_resolution.requested_override
+                                  with
+                                  | Some requested -> string_of_int requested
+                                  | None -> "none")
+                                 attempt
+                                 (EC.max_transient_retries ())
+                                 delay
+                                 (short_preview (Agent_sdk.Error.to_string err));
+                               Prometheus.inc_counter
+                                 Keeper_metrics.metric_keeper_oas_execution_errors
+                                 ~labels:
+                                   [ "keeper", meta.name
+                                   ; "phase", "recoverable_cascade_transient"
+                                   ]
+                                 ();
+                               Eio.Time.sleep clock delay;
+                               retry_loop
+                                 ~run_meta
+                                 ~execution
+                                 ~run_generation
+                                 ~attempt:(attempt + 1)
+                                 ~is_retry:true
+                                 ~allow_degraded_wall_clock_retry_budget:false
+                                 ~overflow_retry_used
+                                 ~attempted_cascades
+                             | No_degraded_retry when EC.is_context_overflow err ->
+                               let current_turn_event_bus =
+                                 drain_turn_event_bus ~site:"context_overflow_capture" ()
+                               in
+                               dispatch_keeper_phase_event
+                                 ~config
+                                 ~keeper_name:meta.name
+                                 (context_overflow_event_of_error
+                                    ~fallback_tokens:execution.max_context
+                                    ~turn_event_bus:current_turn_event_bus
+                                    err);
+                               if not overflow_retry_used
+                               then (
+                                 match
+                                   recover_context_overflow_retry
+                                     ~meta:run_meta
+                                     ~base_dir
+                                     ~max_cascade_context:execution.max_context
+                                     ~error:err
+                                 with
+                                 | Some retry_plan ->
+                                   Keeper_registry.set_turn_phase
+                                     ~base_path:config.base_path
+                                     meta.name
+                                     Keeper_registry.(Packed Turn_compacting);
+                                   (* SDK boundary classification: [EC.is_context_overflow err]
                            was already true above, so the typed klass is fixed.
                            Stamp the typed [blocker_info] so downstream consumers
                            (rollover gate) reason over [klass] instead of
                            substring-matching the [detail] field — keeper layer
                            treats provider/model as opaque aliases. *)
-                        current_turn_blocker_info :=
-                          Some
-                            {
-                              klass = Sdk_token_budget_exceeded;
-                              detail = Agent_sdk.Error.to_string err;
-                            };
-                        dispatch_keeper_phase_event
-                          ~config
-                          ~keeper_name:meta.name
-                          Keeper_state_machine.Compaction_started;
-                        Prometheus.inc_counter
-                          Keeper_metrics.metric_keeper_fsm_edge_transitions
-                          ~labels:[("edge", "kmc_to_ksm_compact_completed")] ();
-                        dispatch_keeper_phase_event
-                          ~config
-                          ~keeper_name:meta.name
-                          (Keeper_state_machine.Compaction_completed
-                             {
-                               before_tokens =
-                                 retry_plan.compaction.before_tokens;
-                               after_tokens =
-                                 retry_plan.compaction.after_tokens;
-                             });
-                        Keeper_registry.prepare_turn_retry_after_compaction
-                          ~base_path:config.base_path meta.name;
-                        let retry_meta =
-                          if retry_plan.retry_generation = run_meta.runtime.generation
-                          then run_meta
-                          else
-                            map_runtime
-                              (fun rt ->
-                                {
-                                  rt with
-                                  generation = retry_plan.retry_generation;
-                                })
-                              run_meta
-                        in
-                        let retry_execution =
-                          { execution with max_context = retry_plan.retry_max_context }
-                        in
-                        Eio.Fiber.yield ();
-                        retry_loop
-                          ~run_meta:retry_meta
-                          ~execution:retry_execution
-                          ~run_generation:retry_plan.retry_generation
-                          ~attempt:1
-                          ~is_retry:true
-                          ~allow_degraded_wall_clock_retry_budget:false
-                          ~overflow_retry_used:true
-                          ~attempted_cascades
-                    | None ->
-                        mark_paused_after_overflow
-                          ~run_meta
-                          ~reason:"auto_compact_recovery_unavailable";
-                        Keeper_registry.set_turn_phase
-                          ~base_path:config.base_path meta.name
-                          Keeper_registry.(Packed Turn_finalizing);
-                        Error err
-                  else begin
-                    mark_paused_after_overflow
-                      ~run_meta
-                      ~reason:"overflow_persisted_after_auto_compact_retry";
-                      Keeper_registry.set_turn_phase
-                        ~base_path:config.base_path meta.name
-                        Keeper_registry.(Packed Turn_finalizing);
-                    Error err
-                  end
-                | No_degraded_retry ->
-                    mark_terminal_error err;
-                    Error err
-          in
-          (* Wall-clock timeout guards against indefinite TCP-level hangs
+                                   current_turn_blocker_info
+                                   := Some
+                                        { klass = Sdk_token_budget_exceeded
+                                        ; detail = Agent_sdk.Error.to_string err
+                                        };
+                                   dispatch_keeper_phase_event
+                                     ~config
+                                     ~keeper_name:meta.name
+                                     Keeper_state_machine.Compaction_started;
+                                   Prometheus.inc_counter
+                                     Keeper_metrics.metric_keeper_fsm_edge_transitions
+                                     ~labels:[ "edge", "kmc_to_ksm_compact_completed" ]
+                                     ();
+                                   dispatch_keeper_phase_event
+                                     ~config
+                                     ~keeper_name:meta.name
+                                     (Keeper_state_machine.Compaction_completed
+                                        { before_tokens =
+                                            retry_plan.compaction.before_tokens
+                                        ; after_tokens =
+                                            retry_plan.compaction.after_tokens
+                                        });
+                                   Keeper_registry.prepare_turn_retry_after_compaction
+                                     ~base_path:config.base_path
+                                     meta.name;
+                                   let retry_meta =
+                                     if
+                                       retry_plan.retry_generation
+                                       = run_meta.runtime.generation
+                                     then run_meta
+                                     else
+                                       map_runtime
+                                         (fun rt ->
+                                            { rt with
+                                              generation = retry_plan.retry_generation
+                                            })
+                                         run_meta
+                                   in
+                                   let retry_execution =
+                                     { execution with
+                                       max_context = retry_plan.retry_max_context
+                                     }
+                                   in
+                                   Eio.Fiber.yield ();
+                                   retry_loop
+                                     ~run_meta:retry_meta
+                                     ~execution:retry_execution
+                                     ~run_generation:retry_plan.retry_generation
+                                     ~attempt:1
+                                     ~is_retry:true
+                                     ~allow_degraded_wall_clock_retry_budget:false
+                                     ~overflow_retry_used:true
+                                     ~attempted_cascades
+                                 | None ->
+                                   mark_paused_after_overflow
+                                     ~run_meta
+                                     ~reason:"auto_compact_recovery_unavailable";
+                                   Keeper_registry.set_turn_phase
+                                     ~base_path:config.base_path
+                                     meta.name
+                                     Keeper_registry.(Packed Turn_finalizing);
+                                   Error err)
+                               else (
+                                 mark_paused_after_overflow
+                                   ~run_meta
+                                   ~reason:"overflow_persisted_after_auto_compact_retry";
+                                 Keeper_registry.set_turn_phase
+                                   ~base_path:config.base_path
+                                   meta.name
+                                   Keeper_registry.(Packed Turn_finalizing);
+                                 Error err)
+                             | No_degraded_retry ->
+                               mark_terminal_error err;
+                               Error err)
+                       in
+                       (* Wall-clock timeout guards against indefinite TCP-level hangs
              from upstream LLM providers. Without this, a single stalled
              connection blocks the keeper fiber forever. *)
-          (try
-            Eio.Time.with_timeout_exn clock timeout_sec
-              (fun () ->
-                retry_loop ~run_meta:meta ~execution:initial_execution
-                  ~run_generation:generation ~attempt:1
-                  ~is_retry:false
-                  ~allow_degraded_wall_clock_retry_budget:false
-                  ~overflow_retry_used:false
-                  ~attempted_cascades:
-                    [ KCP.runtime_name_to_string initial_execution.cascade_name ])
-          with Eio.Time.Timeout ->
-            let msg =
-              Printf.sprintf
-                "Turn wall-clock timeout after %.0fs (MASC_KEEPER_TURN_TIMEOUT_SEC)"
-                timeout_sec
-            in
-            Log.Keeper.error "%s: %s" meta.name msg;
-            Prometheus.inc_counter
-              Keeper_metrics.metric_keeper_turn_timeout_committed
-              ~labels:[("keeper", meta.name)]
-              ();
-            let _ = drain_turn_event_bus ~site:"error_path_drain" () in
-            (match event_bus_integrity_error_snapshot () with
-             | Some integrity_err ->
-               Log.Keeper.error
-                 "%s: event-bus order violation during timeout path; treating turn as failed before retry/reconcile decisions"
-                 meta.name;
-                Keeper_registry.set_turn_phase
-                  ~base_path:config.base_path meta.name
-                  Keeper_registry.(Packed Turn_finalizing);
-               Error integrity_err
-             | None ->
-            let committed_tools = committed_mutating_tools_snapshot () in
-            if committed_tools <> []
-               && Keeper_tool_registry.all_tools_reconcile_safe
-                    committed_tools
-            then begin
-              (* Timeouts are inherently transient — the provider was
+                       (try
+                          Eio.Time.with_timeout_exn clock timeout_sec (fun () ->
+                            retry_loop
+                              ~run_meta:meta
+                              ~execution:initial_execution
+                              ~run_generation:generation
+                              ~attempt:1
+                              ~is_retry:false
+                              ~allow_degraded_wall_clock_retry_budget:false
+                              ~overflow_retry_used:false
+                              ~attempted_cascades:
+                                [ KCP.runtime_name_to_string
+                                    initial_execution.cascade_name
+                                ])
+                        with
+                        | Eio.Time.Timeout ->
+                          let msg =
+                            Printf.sprintf
+                              "Turn wall-clock timeout after %.0fs \
+                               (MASC_KEEPER_TURN_TIMEOUT_SEC)"
+                              timeout_sec
+                          in
+                          Log.Keeper.error "%s: %s" meta.name msg;
+                          Prometheus.inc_counter
+                            Keeper_metrics.metric_keeper_turn_timeout_committed
+                            ~labels:[ "keeper", meta.name ]
+                            ();
+                          let _ = drain_turn_event_bus ~site:"error_path_drain" () in
+                          (match event_bus_integrity_error_snapshot () with
+                           | Some integrity_err ->
+                             Log.Keeper.error
+                               "%s: event-bus order violation during timeout path; \
+                                treating turn as failed before retry/reconcile decisions"
+                               meta.name;
+                             Keeper_registry.set_turn_phase
+                               ~base_path:config.base_path
+                               meta.name
+                               Keeper_registry.(Packed Turn_finalizing);
+                             Error integrity_err
+                           | None ->
+                             let committed_tools = committed_mutating_tools_snapshot () in
+                             if
+                               committed_tools <> []
+                               && Keeper_tool_registry.all_tools_reconcile_safe
+                                    committed_tools
+                             then (
+                               (* Timeouts are inherently transient — the provider was
                  reachable (tools executed) but took too long.  Board-only
                  committed tools are duplicate-tolerant, so we auto-recover
                  instead of recording an integrity failure.  Unlike the
                  retry_loop path, no is_transient check is needed: a
                  wall-clock timeout after successful tool execution is
                  always transient by nature. *)
-              Log.Keeper.warn
-                "%s: turn wall-clock timeout after committed reconcile-safe tool(s) [%s] — auto-recovering (timeout: %s)"
-                meta.name
-                (String.concat ", " committed_tools)
-                msg;
-              Prometheus.inc_counter
-                Keeper_metrics.metric_keeper_turn_timeout_committed
-                ~labels:[("keeper", meta.name)]
-                ();
-              Keeper_registry.set_turn_phase
-                ~base_path:config.base_path meta.name
-                Keeper_registry.(Packed Turn_finalizing);
-              Error (Agent_sdk.Error.Api (Timeout { message = msg }))
-            end else if committed_tools <> [] then begin
-              let timeout_err =
-                Agent_sdk.Error.Api (Timeout { message = msg })
-              in
-              let reclassified, failure_reason =
-                match
-                  EC.classify_post_commit_failure
-                    ~tool_names:committed_tools
-                    ~kind:Keeper_registry.Post_commit_timeout
-                    timeout_err
-                with
-                | Some classified -> classified
-                | None ->
-                    ( EC.reclassify_error_after_side_effect
-                        ~tool_names:committed_tools
-                        timeout_err,
-                      Keeper_registry.Ambiguous_partial_commit {
-                        kind = Keeper_registry.Post_commit_timeout;
-                        detail =
-                          EC.summarize_post_commit_failure
-                            ~tool_names:committed_tools
-                            ~kind:Keeper_registry.Post_commit_timeout
-                            timeout_err;
-                      } )
-              in
-              post_commit_failure_reason := Some failure_reason;
-              Log.Keeper.error
-                "%s: turn wall-clock timeout after committed mutating tool call(s) [%s] — treating as integrity failure; evidence recorded for next-turn observation"
-                meta.name
-                (String.concat ", " committed_tools);
-              Prometheus.inc_counter
-                Keeper_metrics.metric_keeper_turn_timeout_committed
-                ~labels:[("keeper", meta.name)]
-                ();
-              Keeper_registry.set_turn_phase
-                ~base_path:config.base_path meta.name
-                Keeper_registry.(Packed Turn_finalizing);
-              Error reclassified
-            end else begin
-              Keeper_registry.set_turn_phase
-                ~base_path:config.base_path meta.name
-                Keeper_registry.(Packed Turn_finalizing);
-              Error
-                (Keeper_turn_driver.sdk_error_of_masc_internal_error
-                   (Keeper_turn_driver.Turn_timeout
-                      { elapsed_sec = timeout_sec }))
-            end)))
-        with
-        | result -> cleanup (); result
-        | exception e ->
-            let backtrace = Printexc.get_raw_backtrace () in
-            cleanup ();
-            Printexc.raise_with_backtrace e backtrace
-      in
-      let turn_event_bus = drain_turn_event_bus ~site:"turn_finalize_capture" () in
-      (match turn_event_bus.correlation_id with
-       | Some correlation_id ->
-           Keeper_registry.set_last_correlation_id
-             ~base_path:config.base_path meta.name
-             correlation_id
-       | None -> ());
-      let run_result =
-        match event_bus_integrity_error_snapshot () with
-        | Some integrity_err -> Error integrity_err
-        | None -> run_result
-      in
-      let degraded_retry_info = !degraded_retry_info in
-      let degraded_retry_applied = Option.is_some degraded_retry_info in
-      let degraded_retry_cascade =
-        Option.map
-          (fun (retry : EC.degraded_retry) -> retry.next_cascade)
-          degraded_retry_info
-      in
-      let fallback_reason =
-        Option.map
-          (fun (retry : EC.degraded_retry) -> retry.fallback_reason)
-          degraded_retry_info
-      in
-      (* RFC-0041 Phase B3: record per-item health after turn completion. *)
-      (match selected_item with
-       | Some (_group, item) ->
-           let success =
-             match run_result with
-             | Ok _ -> true
-             | Error _ -> false
-           in
-           Keeper_health_probe.record_item_result
-             ~keeper_name:meta.name
-             ~item_id:item.Cascade_ref.id
-             ~success
-       | None -> ());
-      match run_result with
-      | Error err ->
-          let final_execution = !last_execution in
-          finalize_trajectory_acc ~config ~keeper_name:meta.name trajectory_acc
-            (Trajectory.Failed (Agent_sdk.Error.to_string err));
-          let e_str = Agent_sdk.Error.to_string err in
-          let is_transient = EC.is_transient_network_error err in
-          (match Keeper_turn_driver.classify_masc_internal_error err with
-           | Some (Keeper_turn_driver.Oas_timeout_budget _) ->
-               Prometheus.inc_counter
-                 Keeper_metrics.metric_keeper_oas_timeout_classifications
-                 ~labels:[("classification", "structural_budget")] ()
-           | Some (Keeper_turn_driver.Turn_timeout _) ->
-               Prometheus.inc_counter
-                 Keeper_metrics.metric_keeper_oas_timeout_classifications
-                 ~labels:[("classification", "turn_wall_clock")] ()
-           | _ -> (
-               match err with
-               | Agent_sdk.Error.Api (Timeout { message }) ->
-               let classification =
-                 if is_transient then "transient_network"
-                 else if EC.is_structural_oas_timeout_message message then
-                   "structural_budget"
-                 else "other_timeout"
+                               Log.Keeper.warn
+                                 "%s: turn wall-clock timeout after committed \
+                                  reconcile-safe tool(s) [%s] — auto-recovering \
+                                  (timeout: %s)"
+                                 meta.name
+                                 (String.concat ", " committed_tools)
+                                 msg;
+                               Prometheus.inc_counter
+                                 Keeper_metrics.metric_keeper_turn_timeout_committed
+                                 ~labels:[ "keeper", meta.name ]
+                                 ();
+                               Keeper_registry.set_turn_phase
+                                 ~base_path:config.base_path
+                                 meta.name
+                                 Keeper_registry.(Packed Turn_finalizing);
+                               Error (Agent_sdk.Error.Api (Timeout { message = msg })))
+                             else if committed_tools <> []
+                             then (
+                               let timeout_err =
+                                 Agent_sdk.Error.Api (Timeout { message = msg })
+                               in
+                               let reclassified, failure_reason =
+                                 match
+                                   EC.classify_post_commit_failure
+                                     ~tool_names:committed_tools
+                                     ~kind:Keeper_registry.Post_commit_timeout
+                                     timeout_err
+                                 with
+                                 | Some classified -> classified
+                                 | None ->
+                                   ( EC.reclassify_error_after_side_effect
+                                       ~tool_names:committed_tools
+                                       timeout_err
+                                   , Keeper_registry.Ambiguous_partial_commit
+                                       { kind = Keeper_registry.Post_commit_timeout
+                                       ; detail =
+                                           EC.summarize_post_commit_failure
+                                             ~tool_names:committed_tools
+                                             ~kind:Keeper_registry.Post_commit_timeout
+                                             timeout_err
+                                       } )
+                               in
+                               post_commit_failure_reason := Some failure_reason;
+                               Log.Keeper.error
+                                 "%s: turn wall-clock timeout after committed mutating \
+                                  tool call(s) [%s] — treating as integrity failure; \
+                                  evidence recorded for next-turn observation"
+                                 meta.name
+                                 (String.concat ", " committed_tools);
+                               Prometheus.inc_counter
+                                 Keeper_metrics.metric_keeper_turn_timeout_committed
+                                 ~labels:[ "keeper", meta.name ]
+                                 ();
+                               Keeper_registry.set_turn_phase
+                                 ~base_path:config.base_path
+                                 meta.name
+                                 Keeper_registry.(Packed Turn_finalizing);
+                               Error reclassified)
+                             else (
+                               Keeper_registry.set_turn_phase
+                                 ~base_path:config.base_path
+                                 meta.name
+                                 Keeper_registry.(Packed Turn_finalizing);
+                               Error
+                                 (Keeper_turn_driver.sdk_error_of_masc_internal_error
+                                    (Keeper_turn_driver.Turn_timeout
+                                       { elapsed_sec = timeout_sec }))))))
+                 with
+                 | result ->
+                   cleanup ();
+                   result
+                 | exception e ->
+                   let backtrace = Printexc.get_raw_backtrace () in
+                   cleanup ();
+                   Printexc.raise_with_backtrace e backtrace
                in
-               Prometheus.inc_counter
-                 Keeper_metrics.metric_keeper_oas_timeout_classifications
-                 ~labels:[("classification", classification)] ()
-               | _ -> ()));
-          let is_server_parse_rejection = EC.is_server_rejected_parse_error err in
-          let is_auto_recoverable = EC.is_auto_recoverable_turn_error err in
-          let is_ambiguous_partial = EC.is_ambiguous_side_effect_error err in
-          Prometheus.inc_counter Keeper_metrics.metric_keeper_turns
-            ~labels:[("keeper_name", meta.name); ("outcome", "failure")] ();
-          Keeper_turn_fsm.emit_transition
-            ~keeper_name:meta.name ~turn_id:keeper_turn_id
-            ~prev:Keeper_turn_fsm.Streaming
-            (Keeper_turn_fsm.Failed
-               (Keeper_turn_fsm.Failure_provider_error
-                  { kind = sdk_error_kind err;
-                    detail = short_preview e_str }));
-          Log.Keeper.error
-            "%s: keeper cycle FAILED cascade=%s max_context=%d context_budget=%d primary_budget=%d requested_override=%s latency=%dms%s error=%s"
-            meta.name
-            (KCP.runtime_name_to_string final_execution.cascade_name)
-            final_execution.max_context
-            final_execution.max_context_resolution.effective_budget
-            final_execution.max_context_resolution.primary_budget
-            (match final_execution.max_context_resolution.requested_override with
-             | Some requested -> string_of_int requested
-             | None -> "none")
-            latency_ms
-            (if is_ambiguous_partial then
-               " (ambiguous partial commit)"
-             else if is_server_parse_rejection then
-               " (server parse rejection, auto-recoverable)"
-             else if is_transient then
-               " (transient, cooldown preserved)"
-             else "")
-            (short_preview e_str);
-          Prometheus.inc_counter
-            Keeper_metrics.metric_keeper_oas_execution_errors
-            ~labels:[("keeper", meta.name); ("phase", "cycle_failed")]
-            ();
-          let social_state, social_transition_reason =
-            Social.derive_failure_state ~meta ~observation
-              ~previous_state:previous_social_state
-              ~is_auto_recoverable ~sdk_error:(Some err) ~reason:e_str
-          in
-          let failure_meta_base =
-            match !paused_meta_override with
-            | Some paused_meta -> paused_meta
-            | None -> meta
-          in
-          let updated_meta =
-            Keeper_unified_metrics.update_metrics_from_failure
-              failure_meta_base
-              ~latency_ms
-              ~observation
-              ~reason:e_str
-              ~is_transient
-              ~social_state
-              ~social_transition_reason:
-                (Social.transition_reason_to_string social_transition_reason)
-              ~sdk_error:err
-              ()
-          in
-          let err, updated_meta =
-            if is_ambiguous_partial then begin
-              (* Ambiguous partial commit must not auto-resume silently.
+               let turn_event_bus =
+                 drain_turn_event_bus ~site:"turn_finalize_capture" ()
+               in
+               (match turn_event_bus.correlation_id with
+                | Some correlation_id ->
+                  Keeper_registry.set_last_correlation_id
+                    ~base_path:config.base_path
+                    meta.name
+                    correlation_id
+                | None -> ());
+               let run_result =
+                 match event_bus_integrity_error_snapshot () with
+                 | Some integrity_err -> Error integrity_err
+                 | None -> run_result
+               in
+               let degraded_retry_info = !degraded_retry_info in
+               let degraded_retry_applied = Option.is_some degraded_retry_info in
+               let degraded_retry_cascade =
+                 Option.map
+                   (fun (retry : EC.degraded_retry) -> retry.next_cascade)
+                   degraded_retry_info
+               in
+               let fallback_reason =
+                 Option.map
+                   (fun (retry : EC.degraded_retry) -> retry.fallback_reason)
+                   degraded_retry_info
+               in
+               (* RFC-0041 Phase B3: record per-item health after turn completion. *)
+               (match selected_item with
+                | Some (_group, item) ->
+                  let success =
+                    match run_result with
+                    | Ok _ -> true
+                    | Error _ -> false
+                  in
+                  Keeper_health_probe.record_item_result
+                    ~keeper_name:meta.name
+                    ~item_id:item.Cascade_ref.id
+                    ~success
+                | None -> ());
+               (match run_result with
+                | Error err ->
+                  let final_execution = !last_execution in
+                  finalize_trajectory_acc
+                    ~config
+                    ~keeper_name:meta.name
+                    trajectory_acc
+                    (Trajectory.Failed (Agent_sdk.Error.to_string err));
+                  let e_str = Agent_sdk.Error.to_string err in
+                  let is_transient = EC.is_transient_network_error err in
+                  (match Keeper_turn_driver.classify_masc_internal_error err with
+                   | Some (Keeper_turn_driver.Oas_timeout_budget _) ->
+                     Prometheus.inc_counter
+                       Keeper_metrics.metric_keeper_oas_timeout_classifications
+                       ~labels:[ "classification", "structural_budget" ]
+                       ()
+                   | Some (Keeper_turn_driver.Turn_timeout _) ->
+                     Prometheus.inc_counter
+                       Keeper_metrics.metric_keeper_oas_timeout_classifications
+                       ~labels:[ "classification", "turn_wall_clock" ]
+                       ()
+                   | _ ->
+                     (match err with
+                      | Agent_sdk.Error.Api (Timeout { message }) ->
+                        let classification =
+                          if is_transient
+                          then "transient_network"
+                          else if EC.is_structural_oas_timeout_message message
+                          then "structural_budget"
+                          else "other_timeout"
+                        in
+                        Prometheus.inc_counter
+                          Keeper_metrics.metric_keeper_oas_timeout_classifications
+                          ~labels:[ "classification", classification ]
+                          ()
+                      | _ -> ()));
+                  let is_server_parse_rejection = EC.is_server_rejected_parse_error err in
+                  let is_auto_recoverable = EC.is_auto_recoverable_turn_error err in
+                  let is_ambiguous_partial = EC.is_ambiguous_side_effect_error err in
+                  Prometheus.inc_counter
+                    Keeper_metrics.metric_keeper_turns
+                    ~labels:[ "keeper_name", meta.name; "outcome", "failure" ]
+                    ();
+                  Keeper_turn_fsm.emit_transition
+                    ~keeper_name:meta.name
+                    ~turn_id:keeper_turn_id
+                    ~prev:Keeper_turn_fsm.Streaming
+                    (Keeper_turn_fsm.Failed
+                       (Keeper_turn_fsm.Failure_provider_error
+                          { kind = sdk_error_kind err; detail = short_preview e_str }));
+                  Log.Keeper.error
+                    "%s: keeper cycle FAILED cascade=%s max_context=%d context_budget=%d \
+                     primary_budget=%d requested_override=%s latency=%dms%s error=%s"
+                    meta.name
+                    (KCP.runtime_name_to_string final_execution.cascade_name)
+                    final_execution.max_context
+                    final_execution.max_context_resolution.effective_budget
+                    final_execution.max_context_resolution.primary_budget
+                    (match final_execution.max_context_resolution.requested_override with
+                     | Some requested -> string_of_int requested
+                     | None -> "none")
+                    latency_ms
+                    (if is_ambiguous_partial
+                     then " (ambiguous partial commit)"
+                     else if is_server_parse_rejection
+                     then " (server parse rejection, auto-recoverable)"
+                     else if is_transient
+                     then " (transient, cooldown preserved)"
+                     else "")
+                    (short_preview e_str);
+                  Prometheus.inc_counter
+                    Keeper_metrics.metric_keeper_oas_execution_errors
+                    ~labels:[ "keeper", meta.name; "phase", "cycle_failed" ]
+                    ();
+                  let social_state, social_transition_reason =
+                    Social.derive_failure_state
+                      ~meta
+                      ~observation
+                      ~previous_state:previous_social_state
+                      ~is_auto_recoverable
+                      ~sdk_error:(Some err)
+                      ~reason:e_str
+                  in
+                  let failure_meta_base =
+                    match !paused_meta_override with
+                    | Some paused_meta -> paused_meta
+                    | None -> meta
+                  in
+                  let updated_meta =
+                    Keeper_unified_metrics.update_metrics_from_failure
+                      failure_meta_base
+                      ~latency_ms
+                      ~observation
+                      ~reason:e_str
+                      ~is_transient
+                      ~social_state
+                      ~social_transition_reason:
+                        (Social.transition_reason_to_string social_transition_reason)
+                      ~sdk_error:err
+                      ()
+                  in
+                  let err, updated_meta =
+                    if is_ambiguous_partial
+                    then (
+                      (* Ambiguous partial commit must not auto-resume silently.
                  The keeper is paused and an explicit continue gate is
                  raised for the operator. Approving the gate auto-resumes
                  the keeper; rejecting it leaves the keeper paused. *)
-              let committed_tools = committed_mutating_tools_snapshot () in
-              let failure_reason =
-                Option.value
-                  ~default:
-                    (Keeper_registry.Ambiguous_partial_commit {
-                      kind = Keeper_registry.Post_commit_failure;
-                      detail = e_str;
-                    })
-                  !post_commit_failure_reason
-              in
-              Keeper_registry.set_failure_reason ~base_path:config.base_path
-                meta.name
-                (Some failure_reason);
-              match
-                sync_keeper_paused_state
-                  ~config
-                  ~meta:updated_meta
-                  ~paused:true
-              with
-              | Ok paused_meta ->
-                  let approval_id =
-                    enqueue_partial_commit_continue_gate
-                      ~config
-                      ~meta:paused_meta
-                      ~failure_reason
-                      ~committed_tools
-                      ~error_detail:e_str
+                      let committed_tools = committed_mutating_tools_snapshot () in
+                      let failure_reason =
+                        Option.value
+                          ~default:
+                            (Keeper_registry.Ambiguous_partial_commit
+                               { kind = Keeper_registry.Post_commit_failure
+                               ; detail = e_str
+                               })
+                          !post_commit_failure_reason
+                      in
+                      Keeper_registry.set_failure_reason
+                        ~base_path:config.base_path
+                        meta.name
+                        (Some failure_reason);
+                      match
+                        sync_keeper_paused_state ~config ~meta:updated_meta ~paused:true
+                      with
+                      | Ok paused_meta ->
+                        let approval_id =
+                          enqueue_partial_commit_continue_gate
+                            ~config
+                            ~meta:paused_meta
+                            ~failure_reason
+                            ~committed_tools
+                            ~error_detail:e_str
+                        in
+                        Prometheus.inc_counter
+                          Keeper_metrics.metric_keeper_turn_error_after_tools
+                          ~labels:[ "keeper", meta.name; "reason", "ambiguous_partial" ]
+                          ();
+                        Log.Keeper.warn
+                          "%s: ambiguous partial commit (tools=[%s], reason=%s); paused \
+                           keeper and opened continue gate id=%s"
+                          meta.name
+                          (String.concat ", " committed_tools)
+                          (Keeper_registry.failure_reason_to_string failure_reason)
+                          approval_id;
+                        err, paused_meta
+                      | Error sync_err ->
+                        let combined_err =
+                          Agent_sdk.Error.Internal
+                            (Printf.sprintf
+                               "%s: ambiguous partial commit pause sync failed: %s \
+                                (original_error=%s)"
+                               meta.name
+                               sync_err
+                               (short_preview e_str))
+                        in
+                        Log.Keeper.error "%s" (Agent_sdk.Error.to_string combined_err);
+                        Prometheus.inc_counter
+                          Keeper_metrics.metric_keeper_cascade_sync_failures
+                          ~labels:
+                            [ "keeper", meta.name; "site", "ambiguous_partial_pause" ]
+                          ();
+                        combined_err, updated_meta)
+                    else err, updated_meta
                   in
-                  Prometheus.inc_counter
-                    Keeper_metrics.metric_keeper_turn_error_after_tools
-                    ~labels:[("keeper", meta.name); ("reason", "ambiguous_partial")]
-                    ();
-                  Log.Keeper.warn
-                    "%s: ambiguous partial commit (tools=[%s], reason=%s); \
-                     paused keeper and opened continue gate id=%s"
-                    meta.name
-                    (String.concat ", " committed_tools)
-                    (Keeper_registry.failure_reason_to_string failure_reason)
-                    approval_id;
-                  (err, paused_meta)
-              | Error sync_err ->
-                  let combined_err =
-                    Agent_sdk.Error.Internal
-                      (Printf.sprintf
-                         "%s: ambiguous partial commit pause sync failed: %s \
-                          (original_error=%s)"
-                         meta.name sync_err (short_preview e_str))
+                  let e_str = Agent_sdk.Error.to_string err in
+                  let terminal_reason =
+                    Keeper_turn_terminal.of_failure
+                      ~post_commit_ambiguous:is_ambiguous_partial
+                      ~raw_error:e_str
+                      err
                   in
-                  Log.Keeper.error "%s" (Agent_sdk.Error.to_string combined_err);
-                  Prometheus.inc_counter
-                    Keeper_metrics.metric_keeper_cascade_sync_failures
-                    ~labels:[("keeper", meta.name); ("site", "ambiguous_partial_pause")]
+                  if not is_ambiguous_partial
+                  then (
+                    match
+                      registry_failure_reason_of_terminal_reason
+                        terminal_reason
+                        ~raw_error:e_str
+                    with
+                    | Some failure_reason ->
+                      Keeper_registry.set_failure_reason
+                        ~base_path:config.base_path
+                        meta.name
+                        (Some failure_reason)
+                    | None -> ());
+                  (match
+                     Keeper_passive_loop_detector.progress_class_of_disposition
+                       terminal_reason.disposition
+                   with
+                   | Some progress_class ->
+                     Keeper_passive_loop_detector.record_turn
+                       ~keeper_name:updated_meta.name
+                       ~progress_class
+                   | None -> ());
+                  Keeper_unified_metrics.append_decision_record
+                    ~config
+                    ~meta:updated_meta
+                    ~observation
+                    ~latency_ms
+                    ~semaphore_wait_ms
+                    ~outcome:(if is_ambiguous_partial then "partial" else "error")
+                    ~degraded_retry_applied
+                    ?degraded_retry_cascade
+                    ?fallback_reason:
+                      (Option.map EC.degraded_retry_reason_to_string fallback_reason)
+                    ~social_state
+                    ~error:e_str
+                    ~terminal_reason
                     ();
-                  (combined_err, updated_meta)
-            end else
-              (err, updated_meta)
-          in
-          let e_str = Agent_sdk.Error.to_string err in
-          let terminal_reason =
-            Keeper_turn_terminal.of_failure
-              ~post_commit_ambiguous:is_ambiguous_partial
-              ~raw_error:e_str err
-          in
-          if not is_ambiguous_partial then begin
-            match
-              registry_failure_reason_of_terminal_reason terminal_reason
-                ~raw_error:e_str
-            with
-            | Some failure_reason ->
-                Keeper_registry.set_failure_reason
-                  ~base_path:config.base_path meta.name
-                  (Some failure_reason)
-            | None -> ()
-          end;
-          (match
-             Keeper_passive_loop_detector.progress_class_of_disposition
-               terminal_reason.disposition
-           with
-           | Some progress_class ->
-               Keeper_passive_loop_detector.record_turn
-                 ~keeper_name:updated_meta.name ~progress_class
-           | None -> ());
-          Keeper_unified_metrics.append_decision_record ~config ~meta:updated_meta ~observation
-            ~latency_ms ~semaphore_wait_ms
-            ~outcome:(if is_ambiguous_partial then "partial" else "error")
-            ~degraded_retry_applied
-            ?degraded_retry_cascade
-            ?fallback_reason:
-              (Option.map EC.degraded_retry_reason_to_string fallback_reason)
-            ~social_state
-            ~error:e_str
-            ~terminal_reason
-            ();
-          (* #9769 root fix: heartbeat-field-merge prevents the
+                  (* #9769 root fix: heartbeat-field-merge prevents the
              turn-failure retry from clobbering heartbeat-owned fields
              (joined_room_ids, last_seen_seq_by_room), which was the
              dominant source of the observed CAS race exhaustion after
              keeper OAS timeout. *)
-          (match
-             write_meta_with_merge
-               ~merge:Keeper_meta_merge.heartbeat_fields_from_disk
-               config updated_meta
-           with
-           | Ok () -> ()
-           | Error msg ->
-               Prometheus.inc_counter
-                 Keeper_metrics.metric_keeper_write_meta_failures
-                 ~labels:
-                   [ ("keeper", updated_meta.name);
-                     ("phase",
-                      if is_version_conflict_error msg
-                      then "turn_failure_cas_race"
-                      else "turn_failure")
-                   ]
-                 ();
-               if is_version_conflict_error msg then
-                 Log.Keeper.warn
-                   "write_meta lost CAS race after retries (turn failure path): %s" msg
-               else
-                 Log.Keeper.error
-                   "write_meta failed after unified turn failure: %s" msg);
-                 Prometheus.inc_counter
-                   Keeper_metrics.metric_keeper_write_meta_cycle_failures
-                   ~labels:[("keeper", meta.name); ("site", "turn_failure")]
-                   ();
-          if is_ambiguous_partial then begin
-            let failure_reason =
-              Option.value
-                ~default:
-                  (Keeper_registry.Ambiguous_partial_commit {
-                    kind = Keeper_registry.Post_commit_failure;
-                    detail = e_str;
-                  })
-                !post_commit_failure_reason
-            in
-            Keeper_registry.set_failure_reason ~base_path:config.base_path
-              meta.name
-              (Some failure_reason);
-            let committed_tools = committed_mutating_tools_snapshot () in
-            Log.Keeper.info
-              "%s: reconcile-required failure latched as %s after committed tools [%s]"
-              meta.name
-              (Keeper_registry.failure_reason_to_string failure_reason)
-              (String.concat ", " committed_tools)
-          end;
-          let base_path = config.base_path in
-          (* Transient errors (429 rate limit, 503 overloaded, network
+                  (match
+                     write_meta_with_merge
+                       ~merge:Keeper_meta_merge.heartbeat_fields_from_disk
+                       config
+                       updated_meta
+                   with
+                   | Ok () -> ()
+                   | Error msg ->
+                     Prometheus.inc_counter
+                       Keeper_metrics.metric_keeper_write_meta_failures
+                       ~labels:
+                         [ "keeper", updated_meta.name
+                         ; ( "phase"
+                           , if is_version_conflict_error msg
+                             then "turn_failure_cas_race"
+                             else "turn_failure" )
+                         ]
+                       ();
+                     if is_version_conflict_error msg
+                     then
+                       Log.Keeper.warn
+                         "write_meta lost CAS race after retries (turn failure path): %s"
+                         msg
+                     else
+                       Log.Keeper.error
+                         "write_meta failed after unified turn failure: %s"
+                         msg);
+                  Prometheus.inc_counter
+                    Keeper_metrics.metric_keeper_write_meta_cycle_failures
+                    ~labels:[ "keeper", meta.name; "site", "turn_failure" ]
+                    ();
+                  if is_ambiguous_partial
+                  then (
+                    let failure_reason =
+                      Option.value
+                        ~default:
+                          (Keeper_registry.Ambiguous_partial_commit
+                             { kind = Keeper_registry.Post_commit_failure
+                             ; detail = e_str
+                             })
+                        !post_commit_failure_reason
+                    in
+                    Keeper_registry.set_failure_reason
+                      ~base_path:config.base_path
+                      meta.name
+                      (Some failure_reason);
+                    let committed_tools = committed_mutating_tools_snapshot () in
+                    Log.Keeper.info
+                      "%s: reconcile-required failure latched as %s after committed \
+                       tools [%s]"
+                      meta.name
+                      (Keeper_registry.failure_reason_to_string failure_reason)
+                      (String.concat ", " committed_tools));
+                  let base_path = config.base_path in
+                  (* Transient errors (429 rate limit, 503 overloaded, network
              timeout) do not count toward the consecutive failure threshold.
              They are already retried at the turn level with backoff; killing
              the keeper fiber for a transient API blip is an overreaction
@@ -2122,26 +2337,28 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
              auto-pause from ever triggering. The keeper would loop
              indefinitely on a broken cascade without operator notification.
              Retry eligibility != failure tracking. *)
-          let counts_toward_crash =
-            not is_auto_recoverable || EC.is_cascade_exhausted_error err
-          in
-          if counts_toward_crash then
-            Keeper_registry.increment_turn_failures ~base_path meta.name
-          else
-            Log.Keeper.info
-              "%s: auto-recoverable turn failure (not counted toward crash threshold): %s"
-              meta.name (short_preview e_str);
-          let count = Keeper_registry.get_turn_failures ~base_path meta.name in
-          let threshold =
-            Runtime_params.get Governance_registry.keeper_max_turn_failures
-          in
-          record_turn_failure_stress
-            ~meta
-            ~is_auto_recoverable
-            ~consecutive:count
-            ~threshold
-            ~err;
-          (* Stamp [last_failure_reason] on FIRST cascade_exhausted-class
+                  let counts_toward_crash =
+                    (not is_auto_recoverable) || EC.is_cascade_exhausted_error err
+                  in
+                  if counts_toward_crash
+                  then Keeper_registry.increment_turn_failures ~base_path meta.name
+                  else
+                    Log.Keeper.info
+                      "%s: auto-recoverable turn failure (not counted toward crash \
+                       threshold): %s"
+                      meta.name
+                      (short_preview e_str);
+                  let count = Keeper_registry.get_turn_failures ~base_path meta.name in
+                  let threshold =
+                    Runtime_params.get Governance_registry.keeper_max_turn_failures
+                  in
+                  record_turn_failure_stress
+                    ~meta
+                    ~is_auto_recoverable
+                    ~consecutive:count
+                    ~threshold
+                    ~err;
+                  (* Stamp [last_failure_reason] on FIRST cascade_exhausted-class
              failure (not just at threshold).  Without this, the stale
              watchdog kills with [idle 328s] and operators see no signal
              until the 3rd failure trips auto-pause below — by which time
@@ -2159,11 +2376,13 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
              field via [reset_turn_failures] + [set_failure_reason None]
              at line 966-967.  Auto-pause site below (line 2275) still
              stamps the same value at threshold — idempotent overwrite. *)
-          if EC.is_cascade_exhausted_error err && count > 0 then
-            Keeper_registry.set_failure_reason ~base_path:config.base_path
-              meta.name
-              (Some (Keeper_registry.Turn_consecutive_failures count));
-          (* task-074 (#fleet-stall 2026-04-26): break the supervisor restart
+                  if EC.is_cascade_exhausted_error err && count > 0
+                  then
+                    Keeper_registry.set_failure_reason
+                      ~base_path:config.base_path
+                      meta.name
+                      (Some (Keeper_registry.Turn_consecutive_failures count));
+                  (* task-074 (#fleet-stall 2026-04-26): break the supervisor restart
              loop on cascade_exhausted. Without this guard, [count >= threshold]
              below raises [Keeper_fiber_crash], the supervisor restarts the
              fiber, the same cascade still has no working provider, and the
@@ -2172,479 +2391,555 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
              burns more turns. The pause uses the same [sync_keeper_paused_state]
              entry point as operator-driven pause, so [operator_paused] stays
              the SSOT — no new state surface, dashboard already renders this. *)
-          let cascade_auto_paused =
-            EC.is_cascade_exhausted_error err
-            && count >= Keeper_behavioral_regime.turn_fail_streak_threshold
-            && not updated_meta.paused
-          in
-          let tool_contract_auto_paused =
-            should_auto_pause_required_tool_contract_violation
-              ~paused:updated_meta.paused
-              ~consecutive_failures:count err
-          in
-          let auto_pause_succeeded =
-            if cascade_auto_paused || tool_contract_auto_paused then begin
-              let released_task_id =
-                if tool_contract_auto_paused then
-                  Option.map Keeper_id.Task_id.to_string
-                    updated_meta.current_task_id
-                else None
-              in
-              let pause_meta =
-                if tool_contract_auto_paused then
-                  { updated_meta with current_task_id = None }
-                else
-                  updated_meta
-              in
-              match
-                sync_keeper_paused_state ~config ~meta:pause_meta ~paused:true
-              with
-              | Ok _ ->
-                  if cascade_auto_paused then begin
-                    Keeper_registry.set_failure_reason ~base_path:config.base_path
+                  let cascade_auto_paused =
+                    EC.is_cascade_exhausted_error err
+                    && count >= Keeper_behavioral_regime.turn_fail_streak_threshold
+                    && not updated_meta.paused
+                  in
+                  let tool_contract_auto_paused =
+                    should_auto_pause_required_tool_contract_violation
+                      ~paused:updated_meta.paused
+                      ~consecutive_failures:count
+                      err
+                  in
+                  let auto_pause_succeeded =
+                    if cascade_auto_paused || tool_contract_auto_paused
+                    then (
+                      let released_task_id =
+                        if tool_contract_auto_paused
+                        then
+                          Option.map
+                            Keeper_id.Task_id.to_string
+                            updated_meta.current_task_id
+                        else None
+                      in
+                      let pause_meta =
+                        if tool_contract_auto_paused
+                        then { updated_meta with current_task_id = None }
+                        else updated_meta
+                      in
+                      match
+                        sync_keeper_paused_state ~config ~meta:pause_meta ~paused:true
+                      with
+                      | Ok _ ->
+                        if cascade_auto_paused
+                        then (
+                          Keeper_registry.set_failure_reason
+                            ~base_path:config.base_path
+                            meta.name
+                            (Some (Keeper_registry.Turn_consecutive_failures count));
+                          Log.Keeper.warn
+                            "%s: auto-paused after %d cascade_exhausted failures \
+                             (pause_threshold=%d, crash_threshold=%d); operator must \
+                             resume after cascade fix"
+                            meta.name
+                            count
+                            Keeper_behavioral_regime.turn_fail_streak_threshold
+                            threshold)
+                        else
+                          Log.Keeper.warn
+                            "%s: auto-paused after %d required-tool contract failures \
+                             (pause_threshold=%d, crash_threshold=%d, released_task=%s); \
+                             operator must inspect provider tool contract before \
+                             resuming"
+                            meta.name
+                            count
+                            Keeper_behavioral_regime.turn_fail_streak_threshold
+                            threshold
+                            (Option.value ~default:"none" released_task_id);
+                        true
+                      | Error sync_err ->
+                        let auto_pause_kind =
+                          if cascade_auto_paused then "cascade" else "tool_contract"
+                        in
+                        Log.Keeper.error
+                          "%s: %s auto-pause sync failed: %s (persistent failure remains \
+                           on the crash path)"
+                          meta.name
+                          auto_pause_kind
+                          sync_err;
+                        Prometheus.inc_counter
+                          Keeper_metrics.metric_keeper_cascade_sync_failures
+                          ~labels:
+                            [ "keeper", meta.name
+                            ; ( "site"
+                              , if cascade_auto_paused
+                                then "auto_pause"
+                                else "tool_contract_auto_pause" )
+                            ]
+                          ();
+                        false)
+                    else false
+                  in
+                  if count >= threshold && not auto_pause_succeeded
+                  then (
+                    Prometheus.inc_counter
+                      Keeper_metrics.metric_keeper_oas_execution_errors
+                      ~labels:[ "keeper", meta.name; "phase", "persistent_escalation" ]
+                      ();
+                    Log.Keeper.error
+                      "%s: %d consecutive persistent turn failures (threshold=%d), \
+                       escalating to supervisor crash path"
+                      meta.name
+                      count
+                      threshold;
+                    Keeper_registry.set_failure_reason
+                      ~base_path:config.base_path
                       meta.name
                       (Some (Keeper_registry.Turn_consecutive_failures count));
-                    Log.Keeper.warn
-                      "%s: auto-paused after %d cascade_exhausted failures \
-                       (pause_threshold=%d, crash_threshold=%d); operator must \
-                       resume after cascade fix"
-                      meta.name count
-                      Keeper_behavioral_regime.turn_fail_streak_threshold
-                      threshold
-                  end else
-                    Log.Keeper.warn
-                      "%s: auto-paused after %d required-tool contract \
-                       failures (pause_threshold=%d, crash_threshold=%d, \
-                       released_task=%s); operator must inspect provider tool \
-                       contract before resuming"
-                      meta.name count
-                      Keeper_behavioral_regime.turn_fail_streak_threshold
-                      threshold
-                      (Option.value ~default:"none" released_task_id);
-                  true
-              | Error sync_err ->
-                  let auto_pause_kind =
-                    if cascade_auto_paused then "cascade" else "tool_contract"
+                    raise Keeper_registry.Keeper_fiber_crash);
+                  Error err
+                | Ok result ->
+                  let final_execution = !last_execution in
+                  finalize_trajectory_acc
+                    ~config
+                    ~keeper_name:meta.name
+                    trajectory_acc
+                    Trajectory.Completed;
+                  let explicit_accountability_claim =
+                    Social.extract_accountability_claim result
                   in
-                  Log.Keeper.error
-                    "%s: %s auto-pause sync failed: %s \
-                     (persistent failure remains on the crash path)"
-                    meta.name auto_pause_kind sync_err;
-                  Prometheus.inc_counter
-                    Keeper_metrics.metric_keeper_cascade_sync_failures
-                    ~labels:
-                      [ ("keeper", meta.name);
-                        ( "site",
-                          if cascade_auto_paused then "auto_pause"
-                          else "tool_contract_auto_pause" ) ]
-                    ();
-                  false
-            end else
-              false
-          in
-          if count >= threshold && not auto_pause_succeeded then begin
-            Prometheus.inc_counter
-              Keeper_metrics.metric_keeper_oas_execution_errors
-              ~labels:[("keeper", meta.name); ("phase", "persistent_escalation")]
-              ();
-            Log.Keeper.error
-              "%s: %d consecutive persistent turn failures (threshold=%d), escalating to supervisor crash path"
-              meta.name count threshold;
-            Keeper_registry.set_failure_reason ~base_path:config.base_path
-              meta.name
-              (Some (Keeper_registry.Turn_consecutive_failures count));
-            raise Keeper_registry.Keeper_fiber_crash
-          end;
-          Error err
-      | Ok result ->
-          let final_execution = !last_execution in
-          finalize_trajectory_acc ~config ~keeper_name:meta.name trajectory_acc
-            Trajectory.Completed;
-          let explicit_accountability_claim =
-            Social.extract_accountability_claim result
-          in
-          let result, social_state, social_transition_reason =
-            Social.apply_to_result ~meta ~observation
-              ~previous_state:previous_social_state result
-          in
-          let used_model_id =
-            Keeper_agent_run.surface_model_used result
-          in
-          let resolved_model_id =
-            Keeper_agent_run.surface_resolved_model_id result
-          in
-          let usage_trust_for_cost =
-            Keeper_unified_metrics.classify_usage_trust
-              ~usage_reported:result.usage_reported
-              ~usage:result.usage
-              ~model_used:used_model_id
-              ~resolved_model_id
-              ~context_max:0
-          in
-          let turn_cost =
-            Keeper_unified_metrics.estimate_trusted_usage_cost_usd
-              ~usage_trusted:
-                (Keeper_unified_metrics.usage_trust_is_trusted
-                   usage_trust_for_cost)
-              ~model:used_model_id
-              result.usage
-          in
-          let resilience_handles =
-            post_turn_resilience_handles ~config ~meta
-          in
-          let lifecycle =
-            apply_post_turn_lifecycle_with_resilience_handles ~base_dir
-              ~resilience_audit_store:
-                resilience_handles.resilience_audit_store
-              ~resilience_strategy_executor:
-                resilience_handles.resilience_strategy_executor
-              ~on_compaction_started:(fun () ->
-                dispatch_keeper_phase_event
-                  ~config
-                  ~keeper_name:meta.name
-                  Keeper_state_machine.Compaction_started)
-              ~on_handoff_started:(fun () ->
-                dispatch_keeper_phase_event
-                  ~config
-                  ~keeper_name:meta.name
-                  Keeper_state_machine.Handoff_started)
-              ~meta
-              ~model:result.model_used
-              ~primary_model_max_tokens:final_execution.max_context
-              ~current_turn_blocker_info:!current_turn_blocker_info
-              ~checkpoint:result.checkpoint
-            |> resilience_handles.sync_lifecycle_meta
-          in
-          dispatch_post_turn_lifecycle_events
-            ~config
-            ~keeper_name:meta.name
-            lifecycle;
-          (* 6. Observe result and update metrics.
+                  let result, social_state, social_transition_reason =
+                    Social.apply_to_result
+                      ~meta
+                      ~observation
+                      ~previous_state:previous_social_state
+                      result
+                  in
+                  let used_model_id = Keeper_agent_run.surface_model_used result in
+                  let resolved_model_id =
+                    Keeper_agent_run.surface_resolved_model_id result
+                  in
+                  let usage_trust_for_cost =
+                    Keeper_unified_metrics.classify_usage_trust
+                      ~usage_reported:result.usage_reported
+                      ~usage:result.usage
+                      ~model_used:used_model_id
+                      ~resolved_model_id
+                      ~context_max:0
+                  in
+                  let turn_cost =
+                    Keeper_unified_metrics.estimate_trusted_usage_cost_usd
+                      ~usage_trusted:
+                        (Keeper_unified_metrics.usage_trust_is_trusted
+                           usage_trust_for_cost)
+                      ~model:used_model_id
+                      result.usage
+                  in
+                  let resilience_handles = post_turn_resilience_handles ~config ~meta in
+                  let lifecycle =
+                    apply_post_turn_lifecycle_with_resilience_handles
+                      ~base_dir
+                      ~resilience_audit_store:resilience_handles.resilience_audit_store
+                      ~resilience_strategy_executor:
+                        resilience_handles.resilience_strategy_executor
+                      ~on_compaction_started:(fun () ->
+                        dispatch_keeper_phase_event
+                          ~config
+                          ~keeper_name:meta.name
+                          Keeper_state_machine.Compaction_started)
+                      ~on_handoff_started:(fun () ->
+                        dispatch_keeper_phase_event
+                          ~config
+                          ~keeper_name:meta.name
+                          Keeper_state_machine.Handoff_started)
+                      ~meta
+                      ~model:result.model_used
+                      ~primary_model_max_tokens:final_execution.max_context
+                      ~current_turn_blocker_info:!current_turn_blocker_info
+                      ~checkpoint:result.checkpoint
+                    |> resilience_handles.sync_lifecycle_meta
+                  in
+                  dispatch_post_turn_lifecycle_events
+                    ~config
+                    ~keeper_name:meta.name
+                    lifecycle;
+                  (* 6. Observe result and update metrics.
              Always update proactive_rt regardless of turn type.
              Previously, scope-only reactive turns (pending_scope but no
              mentions/board) skipped the timestamp update, freezing the
              proactive cooldown timer so the second autonomous turn never
              fired.  See Bug #3 in the root-cause analysis. *)
-          let updated_meta =
-            Keeper_unified_metrics.update_metrics_from_result lifecycle.updated_meta ~latency_ms
-              ~observation
-              ~social_state
-              ~social_transition_reason:
-                (Social.transition_reason_to_string social_transition_reason)
-              ~context_max:lifecycle.context_max
-              ~update_proactive_rt:true
-              result
-          in
-          (* #9926: observe consecutive stay_silent turns to detect the
+                  let updated_meta =
+                    Keeper_unified_metrics.update_metrics_from_result
+                      lifecycle.updated_meta
+                      ~latency_ms
+                      ~observation
+                      ~social_state
+                      ~social_transition_reason:
+                        (Social.transition_reason_to_string social_transition_reason)
+                      ~context_max:lifecycle.context_max
+                      ~update_proactive_rt:true
+                      result
+                  in
+                  (* #9926: observe consecutive stay_silent turns to detect the
              masc-improver-style loop that burned 13.3h of LLM time on
              unclaimable backlog. Pure in-memory counter; fires a latched
              warn + counter metric when the streak crosses
              MASC_STAY_SILENT_LOOP_THRESHOLD (default 10). *)
-          Keeper_stay_silent_loop_detector.record_turn
-            ~keeper_name:updated_meta.Keeper_types.name
-            ~speech_act:updated_meta.Keeper_types.runtime.last_speech_act;
-          (* #12799: observe consecutive passive-read turns to detect keepers
+                  Keeper_stay_silent_loop_detector.record_turn
+                    ~keeper_name:updated_meta.Keeper_types.name
+                    ~speech_act:updated_meta.Keeper_types.runtime.last_speech_act;
+                  (* #12799: observe consecutive passive-read turns to detect keepers
              stuck issuing only status/read tools without execution progress.
              Derive the dominant progress class from the tool names used this
              turn: if all tools are passive_status / claim_context the streak
              increments; any execution or completion tool resets it. *)
-          (let progress_class =
-             let names = result.tools_used in
-             if names = [] then
-               (* No tools called: treat as passive.  A turn with no tool
+                  (let progress_class =
+                     let names = result.tools_used in
+                     if names = []
+                     then
+                       (* No tools called: treat as passive.  A turn with no tool
                   calls is a pure reasoning/text turn — no execution or
                   task completion occurred, so it counts against the
                   passive streak rather than resetting it. *)
-               "passive_status"
-             else if List.for_all
-                       (fun name ->
-                          match
-                            Keeper_tool_disclosure.classify_tool_progress name
-                          with
-                          | Keeper_tool_disclosure.Execution
-                          | Keeper_tool_disclosure.Completion -> false
-                          | Keeper_tool_disclosure.Passive_status
-                          | Keeper_tool_disclosure.Claim_context -> true)
-                       names
-             then "passive_status"
-             else "execution"
-           in
-           Keeper_passive_loop_detector.record_turn
-             ~keeper_name:updated_meta.Keeper_types.name
-             ~progress_class);
-          (try
-             (* Spec: KeeperTaskAcquisition.tla AssignTask vs
+                       "passive_status"
+                     else if
+                       List.for_all
+                         (fun name ->
+                            match Keeper_tool_disclosure.classify_tool_progress name with
+                            | Keeper_tool_disclosure.Execution
+                            | Keeper_tool_disclosure.Completion -> false
+                            | Keeper_tool_disclosure.Passive_status
+                            | Keeper_tool_disclosure.Claim_context -> true)
+                         names
+                     then "passive_status"
+                     else "execution"
+                   in
+                   Keeper_passive_loop_detector.record_turn
+                     ~keeper_name:updated_meta.Keeper_types.name
+                     ~progress_class);
+                  (try
+                     (* Spec: KeeperTaskAcquisition.tla AssignTask vs
                 EmptyQueueSleep — non-empty queue picks "turn"
                 (claim-and-finish path), empty picks
                 "scheduled_autonomous" (no claim this cycle). *)
-             let any_pending =
-               observation.pending_mentions <> []
-               || observation.pending_board_events <> []
-               || observation.pending_scope_messages <> []
-             in
-             let channel =
-               if any_pending then "turn" else "scheduled_autonomous"
-             in
-             (* Cycle 44: KeeperTaskAcquisition.tla post-action guards
+                     let any_pending =
+                       observation.pending_mentions <> []
+                       || observation.pending_board_events <> []
+                       || observation.pending_scope_messages <> []
+                     in
+                     let channel =
+                       if any_pending then "turn" else "scheduled_autonomous"
+                     in
+                     (* Cycle 44: KeeperTaskAcquisition.tla post-action guards
                 pin the structural invariant the decision relied on.
                 The [@@fsm_guard] PPX now routes assertions through
                 [Keeper_fsm_guard_runtime.wrap_unit ~stage:"guard"]
                 automatically, so the manual outer wrap is removed to
                 avoid double-counting Prometheus violations. *)
-             if any_pending
-             then post_assign_task ~any_pending ~channel
-             else post_empty_queue_sleep ~any_pending ~channel;
-             Keeper_unified_metrics.append_metrics_snapshot ~config ~meta:updated_meta ~observation
-               ~result ~latency_ms ~turn_cost
-               ~turn_generation:lifecycle.turn_generation
-               ~channel
-               ~snapshot_source:"keeper_unified_turn"
-               ~context_ratio:lifecycle.context_ratio
-               ~context_tokens:lifecycle.context_tokens
-               ~context_max:lifecycle.context_max
-               ~message_count:lifecycle.message_count
-               ~compaction:lifecycle.compaction
-               ~handoff_json:lifecycle.handoff_json
-               ?timeout_budget_json:
-                 (Option.map oas_timeout_budget_resolution_to_yojson
-                    !last_timeout_budget)
-               ()
-          with
-           | Eio.Cancel.Cancelled _ as e -> raise e
-           | exn ->
-               (* #10047: surface drop as a Prometheus counter so
+                     if any_pending
+                     then post_assign_task ~any_pending ~channel
+                     else post_empty_queue_sleep ~any_pending ~channel;
+                     Keeper_unified_metrics.append_metrics_snapshot
+                       ~config
+                       ~meta:updated_meta
+                       ~observation
+                       ~result
+                       ~latency_ms
+                       ~turn_cost
+                       ~turn_generation:lifecycle.turn_generation
+                       ~channel
+                       ~snapshot_source:"keeper_unified_turn"
+                       ~context_ratio:lifecycle.context_ratio
+                       ~context_tokens:lifecycle.context_tokens
+                       ~context_max:lifecycle.context_max
+                       ~message_count:lifecycle.message_count
+                       ~compaction:lifecycle.compaction
+                       ~handoff_json:lifecycle.handoff_json
+                       ?timeout_budget_json:
+                         (Option.map
+                            oas_timeout_budget_resolution_to_yojson
+                            !last_timeout_budget)
+                       ()
+                   with
+                   | Eio.Cancel.Cancelled _ as e -> raise e
+                   | exn ->
+                     (* #10047: surface drop as a Prometheus counter so
                   dashboards can alert when state advances without a
                   matching metric record (keeper was running but jsonl
                   shows no turn). *)
-               let channel =
-                 if observation.pending_mentions <> []
-                    || observation.pending_board_events <> []
-                    || observation.pending_scope_messages <> []
-                 then "turn"
-                 else "scheduled_autonomous"
-               in
-               Prometheus.inc_counter
-                 Keeper_metrics.metric_keeper_metric_emit_dropped
-                 ~labels:[
-                   ("keeper", updated_meta.Keeper_types.name);
-                   ("channel", channel);
-                   ("site", "keeper_unified_turn");
-                 ] ();
-               Log.Keeper.error
-                 "write metrics snapshot failed after keeper cycle: %s"
-                 (Printexc.to_string exn);
-               Prometheus.inc_counter
-                 Keeper_metrics.metric_keeper_turn_metrics_snapshot_failures
-                 ~labels:[("keeper", meta.name); ("site", "post_cycle")]
-                 ());
-          let turn_mode = Keeper_unified_metrics.turn_mode_of_result result in
-          let turn_mode_label =
-            Keeper_unified_metrics.turn_mode_to_string turn_mode
-          in
-          let model_used = Keeper_agent_run.surface_model_used result in
-          let resolved_model_id =
-            Keeper_agent_run.surface_resolved_model_id result
-          in
-          let usage_trust =
-            Keeper_unified_metrics.classify_usage_trust
-              ~usage_reported:result.usage_reported
-              ~usage:result.usage
-              ~model_used
-              ~resolved_model_id
-              ~context_max:lifecycle.context_max
-          in
-          let usage_trusted =
-            Keeper_unified_metrics.usage_trust_is_trusted usage_trust
-          in
-          let wall_tokens_per_second =
-            if usage_trusted && latency_ms > 0 then
-              Some
-                (float_of_int result.usage.output_tokens
-                 /. (float_of_int latency_ms /. 1000.0))
-            else None
-          in
-          (* Emit turn-completed event to Activity Graph for timeline token visibility *)
-          (try
-            let event =
-              Activity_graph.emit config
-                ~actor:{ kind = "agent"; id = updated_meta.agent_name }
-                ~kind:"keeper.turn_completed"
-                ~payload:(`Assoc
-                  ([
-                    ("keeper_name", `String updated_meta.name);
-                    ("input_tokens", (if usage_trusted then `Int result.usage.input_tokens else `Null));
-                    ("output_tokens", (if usage_trusted then `Int result.usage.output_tokens else `Null));
-                    ("cache_creation_tokens", (if usage_trusted then `Int result.usage.cache_creation_input_tokens else `Null));
-                    ("cache_read_tokens", (if usage_trusted then `Int result.usage.cache_read_input_tokens else `Null));
-                    ("cost_usd", (if usage_trusted then `Float turn_cost else `Null));
-                    ("latency_ms", `Int latency_ms);
-                    ("model_used", `String model_used);
-                    ("resolved_model_id", `String resolved_model_id);
-                    ( "usage_trust",
-                      `String
-                        (Keeper_unified_metrics.usage_trust_to_string
-                           usage_trust) );
-                    ( "usage_anomaly_reasons",
-                      `List
-                        (List.map
-                           (fun reason -> `String reason)
-                           (Keeper_unified_metrics.usage_trust_reasons
-                              usage_trust)) );
-                    ("turn_mode", `String turn_mode_label);
-                    ("context_ratio", `Float lifecycle.context_ratio);
-                    ("tools_used", `List (List.map (fun s -> `String s) result.tools_used));
-                  ]
-                  @ (match wall_tokens_per_second with
-                     | Some v -> [("tokens_per_second", `Float v)]
-                     | None -> [])
-                  @ (match result.inference_telemetry with
-                     | Some t ->
-                       (match t.reasoning_tokens with Some n -> [("reasoning_tokens", `Int n)] | None -> [])
-                       @ (match t.timings with
-                          | Some ti ->
-                            (match ti.prompt_per_second with
-                             | Some v -> [("prompt_per_second", `Float v)]
-                             | None -> [])
-                            @ (match ti.predicted_per_second with
-                               | Some v -> [("hw_decode_tokens_per_second", `Float v)]
-                               | None -> [])
-                          | None -> [])
-                     | None -> [])))
-                ~tags:["keeper"; "turn"; "metrics"]
-                ()
-            in
-            Log.Keeper.debug
-              "%s: activity graph turn_completed emitted seq=%d"
-              updated_meta.name event.seq
-          with
-          | Eio.Cancel.Cancelled _ as e -> raise e
-          | exn ->
-              report_keeper_cycle_side_effect_issue
-                ~config
-                ~keeper_name:updated_meta.name
-                ~side_effect:"activity graph turn_completed emit"
-                (Printexc.to_string exn));
-          Keeper_unified_metrics.broadcast_lifecycle_events ~name:updated_meta.name
-            ~turn_generation:lifecycle.turn_generation
-            ~compaction:lifecycle.compaction
-            ~handoff_json:lifecycle.handoff_json;
-          Keeper_unified_metrics.append_decision_record ~config ~meta:updated_meta ~observation
-            ~latency_ms ~semaphore_wait_ms ~outcome:"success"
-            ~degraded_retry_applied
-            ?degraded_retry_cascade
-            ?fallback_reason:
-              (Option.map EC.degraded_retry_reason_to_string fallback_reason)
-            ~turn_mode
-            ~social_state
-            ~result:(Some result) ();
-          (match explicit_accountability_claim with
-          | Some claim ->
-              let trace_id =
-                Keeper_id.Trace_id.to_string updated_meta.runtime.trace_id
-              in
-              let validated_evidence = Keeper_unified_metrics.visible_run_validation result in
-              let strong_evidence =
-                Keeper_unified_metrics.has_substantive_tool_calls result.tools_used
-                || Option.is_some validated_evidence
-              in
-              Keeper_accountability.record_completion_claim config
-                ~keeper_name:updated_meta.name
-                ~agent_name:updated_meta.agent_name
-                ~trace_id
-                ~turn_number:updated_meta.runtime.usage.total_turns
-                ~subject:claim.subject
-                ?task_id:claim.task_id
-                ~evidence_refs:claim.evidence_refs
-                ~surface:(Social.delivery_surface_to_string social_state.delivery_surface)
-                ~strong_evidence
-                ~strong_evidence_refs:
-                  (Keeper_unified_metrics.accountability_evidence_refs
-                     ~trace_id
-                     ~turn_number:updated_meta.runtime.usage.total_turns
-                     ~result
-                     ~validated_evidence)
-                ()
-          | None -> ());
-          let outcome_str =
-            match result.stop_reason with
-            | Cascade_runner.Completed -> "completed"
-            | Cascade_runner.TurnBudgetExhausted { turns_used; limit; _ } ->
-                Printf.sprintf "budget_exhausted(%d/%d)" turns_used limit
-            | Cascade_runner.MutationBoundaryReached { turns_used; tool_name } ->
-                (match tool_name with
-                 | Some tool ->
-                     Printf.sprintf "mutation_boundary(%d:%s)" turns_used tool
-                 | None ->
-                     Printf.sprintf "mutation_boundary(%d)" turns_used)
-          in
-          let outcome_label =
-            match result.stop_reason with
-            | Cascade_runner.Completed -> "success"
-            | Cascade_runner.TurnBudgetExhausted _ -> "budget_exhausted"
-            | Cascade_runner.MutationBoundaryReached _ -> "mutation_boundary"
-          in
-          Prometheus.inc_counter Keeper_metrics.metric_keeper_turns
-            ~labels:[("keeper_name", updated_meta.name); ("outcome", outcome_label)] ();
-          if usage_trusted then begin
-            Prometheus.inc_counter Keeper_metrics.metric_keeper_input_tokens
-              ~labels:[("keeper_name", updated_meta.name); ("model", model_used)]
-              ~delta:(float_of_int result.usage.input_tokens) ();
-            Prometheus.inc_counter Keeper_metrics.metric_keeper_output_tokens
-              ~labels:[("keeper_name", updated_meta.name); ("model", model_used)]
-              ~delta:(float_of_int result.usage.output_tokens) ();
-            (* #7469 Step 1: emit prompt-cache usage so Anthropic/Bedrock
+                     let channel =
+                       if
+                         observation.pending_mentions <> []
+                         || observation.pending_board_events <> []
+                         || observation.pending_scope_messages <> []
+                       then "turn"
+                       else "scheduled_autonomous"
+                     in
+                     Prometheus.inc_counter
+                       Keeper_metrics.metric_keeper_metric_emit_dropped
+                       ~labels:
+                         [ "keeper", updated_meta.Keeper_types.name
+                         ; "channel", channel
+                         ; "site", "keeper_unified_turn"
+                         ]
+                       ();
+                     Log.Keeper.error
+                       "write metrics snapshot failed after keeper cycle: %s"
+                       (Printexc.to_string exn);
+                     Prometheus.inc_counter
+                       Keeper_metrics.metric_keeper_turn_metrics_snapshot_failures
+                       ~labels:[ "keeper", meta.name; "site", "post_cycle" ]
+                       ());
+                  let turn_mode = Keeper_unified_metrics.turn_mode_of_result result in
+                  let turn_mode_label =
+                    Keeper_unified_metrics.turn_mode_to_string turn_mode
+                  in
+                  let model_used = Keeper_agent_run.surface_model_used result in
+                  let resolved_model_id =
+                    Keeper_agent_run.surface_resolved_model_id result
+                  in
+                  let usage_trust =
+                    Keeper_unified_metrics.classify_usage_trust
+                      ~usage_reported:result.usage_reported
+                      ~usage:result.usage
+                      ~model_used
+                      ~resolved_model_id
+                      ~context_max:lifecycle.context_max
+                  in
+                  let usage_trusted =
+                    Keeper_unified_metrics.usage_trust_is_trusted usage_trust
+                  in
+                  let wall_tokens_per_second =
+                    if usage_trusted && latency_ms > 0
+                    then
+                      Some
+                        (float_of_int result.usage.output_tokens
+                         /. (float_of_int latency_ms /. 1000.0))
+                    else None
+                  in
+                  (* Emit turn-completed event to Activity Graph for timeline token visibility *)
+                  (try
+                     let event =
+                       Activity_graph.emit
+                         config
+                         ~actor:{ kind = "agent"; id = updated_meta.agent_name }
+                         ~kind:"keeper.turn_completed"
+                         ~payload:
+                           (`Assoc
+                               ([ "keeper_name", `String updated_meta.name
+                                ; ( "input_tokens"
+                                  , if usage_trusted
+                                    then `Int result.usage.input_tokens
+                                    else `Null )
+                                ; ( "output_tokens"
+                                  , if usage_trusted
+                                    then `Int result.usage.output_tokens
+                                    else `Null )
+                                ; ( "cache_creation_tokens"
+                                  , if usage_trusted
+                                    then `Int result.usage.cache_creation_input_tokens
+                                    else `Null )
+                                ; ( "cache_read_tokens"
+                                  , if usage_trusted
+                                    then `Int result.usage.cache_read_input_tokens
+                                    else `Null )
+                                ; ( "cost_usd"
+                                  , if usage_trusted then `Float turn_cost else `Null )
+                                ; "latency_ms", `Int latency_ms
+                                ; "model_used", `String model_used
+                                ; "resolved_model_id", `String resolved_model_id
+                                ; ( "usage_trust"
+                                  , `String
+                                      (Keeper_unified_metrics.usage_trust_to_string
+                                         usage_trust) )
+                                ; ( "usage_anomaly_reasons"
+                                  , `List
+                                      (List.map
+                                         (fun reason -> `String reason)
+                                         (Keeper_unified_metrics.usage_trust_reasons
+                                            usage_trust)) )
+                                ; "turn_mode", `String turn_mode_label
+                                ; "context_ratio", `Float lifecycle.context_ratio
+                                ; ( "tools_used"
+                                  , `List
+                                      (List.map (fun s -> `String s) result.tools_used) )
+                                ]
+                                @ (match wall_tokens_per_second with
+                                   | Some v -> [ "tokens_per_second", `Float v ]
+                                   | None -> [])
+                                @
+                                match result.inference_telemetry with
+                                | Some t ->
+                                  (match t.reasoning_tokens with
+                                   | Some n -> [ "reasoning_tokens", `Int n ]
+                                   | None -> [])
+                                  @
+                                    (match t.timings with
+                                    | Some ti ->
+                                      (match ti.prompt_per_second with
+                                       | Some v -> [ "prompt_per_second", `Float v ]
+                                       | None -> [])
+                                      @
+                                        (match ti.predicted_per_second with
+                                        | Some v ->
+                                          [ "hw_decode_tokens_per_second", `Float v ]
+                                        | None -> [])
+                                    | None -> [])
+                                | None -> []))
+                         ~tags:[ "keeper"; "turn"; "metrics" ]
+                         ()
+                     in
+                     Log.Keeper.debug
+                       "%s: activity graph turn_completed emitted seq=%d"
+                       updated_meta.name
+                       event.seq
+                   with
+                   | Eio.Cancel.Cancelled _ as e -> raise e
+                   | exn ->
+                     report_keeper_cycle_side_effect_issue
+                       ~config
+                       ~keeper_name:updated_meta.name
+                       ~side_effect:"activity graph turn_completed emit"
+                       (Printexc.to_string exn));
+                  Keeper_unified_metrics.broadcast_lifecycle_events
+                    ~name:updated_meta.name
+                    ~turn_generation:lifecycle.turn_generation
+                    ~compaction:lifecycle.compaction
+                    ~handoff_json:lifecycle.handoff_json;
+                  Keeper_unified_metrics.append_decision_record
+                    ~config
+                    ~meta:updated_meta
+                    ~observation
+                    ~latency_ms
+                    ~semaphore_wait_ms
+                    ~outcome:"success"
+                    ~degraded_retry_applied
+                    ?degraded_retry_cascade
+                    ?fallback_reason:
+                      (Option.map EC.degraded_retry_reason_to_string fallback_reason)
+                    ~turn_mode
+                    ~social_state
+                    ~result:(Some result)
+                    ();
+                  (match explicit_accountability_claim with
+                   | Some claim ->
+                     let trace_id =
+                       Keeper_id.Trace_id.to_string updated_meta.runtime.trace_id
+                     in
+                     let validated_evidence =
+                       Keeper_unified_metrics.visible_run_validation result
+                     in
+                     let strong_evidence =
+                       Keeper_unified_metrics.has_substantive_tool_calls result.tools_used
+                       || Option.is_some validated_evidence
+                     in
+                     Keeper_accountability.record_completion_claim
+                       config
+                       ~keeper_name:updated_meta.name
+                       ~agent_name:updated_meta.agent_name
+                       ~trace_id
+                       ~turn_number:updated_meta.runtime.usage.total_turns
+                       ~subject:claim.subject
+                       ?task_id:claim.task_id
+                       ~evidence_refs:claim.evidence_refs
+                       ~surface:
+                         (Social.delivery_surface_to_string social_state.delivery_surface)
+                       ~strong_evidence
+                       ~strong_evidence_refs:
+                         (Keeper_unified_metrics.accountability_evidence_refs
+                            ~trace_id
+                            ~turn_number:updated_meta.runtime.usage.total_turns
+                            ~result
+                            ~validated_evidence)
+                       ()
+                   | None -> ());
+                  let outcome_str =
+                    match result.stop_reason with
+                    | Cascade_runner.Completed -> "completed"
+                    | Cascade_runner.TurnBudgetExhausted { turns_used; limit; _ } ->
+                      Printf.sprintf "budget_exhausted(%d/%d)" turns_used limit
+                    | Cascade_runner.MutationBoundaryReached { turns_used; tool_name } ->
+                      (match tool_name with
+                       | Some tool ->
+                         Printf.sprintf "mutation_boundary(%d:%s)" turns_used tool
+                       | None -> Printf.sprintf "mutation_boundary(%d)" turns_used)
+                  in
+                  let outcome_label =
+                    match result.stop_reason with
+                    | Cascade_runner.Completed -> "success"
+                    | Cascade_runner.TurnBudgetExhausted _ -> "budget_exhausted"
+                    | Cascade_runner.MutationBoundaryReached _ -> "mutation_boundary"
+                  in
+                  Prometheus.inc_counter
+                    Keeper_metrics.metric_keeper_turns
+                    ~labels:[ "keeper_name", updated_meta.name; "outcome", outcome_label ]
+                    ();
+                  if usage_trusted
+                  then (
+                    Prometheus.inc_counter
+                      Keeper_metrics.metric_keeper_input_tokens
+                      ~labels:[ "keeper_name", updated_meta.name; "model", model_used ]
+                      ~delta:(float_of_int result.usage.input_tokens)
+                      ();
+                    Prometheus.inc_counter
+                      Keeper_metrics.metric_keeper_output_tokens
+                      ~labels:[ "keeper_name", updated_meta.name; "model", model_used ]
+                      ~delta:(float_of_int result.usage.output_tokens)
+                      ();
+                    (* #7469 Step 1: emit prompt-cache usage so Anthropic/Bedrock
                hit rate is observable. Skip when both are zero — non-caching
                providers (GLM/local-llama) would otherwise register a series
                per keeper+model combination that never moves off zero.
                Metric names pulled from [Prometheus] constants so a typo
                here would fail to compile instead of silently creating a
                dead series. *)
-            (if result.usage.cache_creation_input_tokens > 0 then
-               Prometheus.inc_counter Keeper_metrics.metric_keeper_cache_creation_tokens
-                 ~labels:[("keeper_name", updated_meta.name); ("model", model_used)]
-                 ~delta:(float_of_int result.usage.cache_creation_input_tokens) ());
-            (if result.usage.cache_read_input_tokens > 0 then
-               Prometheus.inc_counter Keeper_metrics.metric_keeper_cache_read_tokens
-                 ~labels:[("keeper_name", updated_meta.name); ("model", model_used)]
-                 ~delta:(float_of_int result.usage.cache_read_input_tokens) ())
-          end else begin
-            let reasons =
-              match Keeper_unified_metrics.usage_trust_reasons usage_trust with
-              | [] -> [Keeper_unified_metrics.usage_trust_to_string usage_trust]
-              | reasons -> reasons
-            in
-            List.iter
-              (fun reason ->
-                 Prometheus.inc_counter
-                   Keeper_metrics.metric_keeper_usage_anomalies
-                   ~labels:
-                     [
-                       ("keeper_name", updated_meta.name);
-                       ("model", model_used);
-                       ("reason", reason);
-                     ]
-                   ())
-              reasons;
-            Log.Keeper.warn
-              "%s: keeper usage telemetry untrusted model=%s resolved_model=%s reasons=%s input=%d output=%d context_max=%d"
-              updated_meta.name model_used resolved_model_id
-              (String.concat "," reasons)
-              result.usage.input_tokens
-              result.usage.output_tokens
-              lifecycle.context_max
-          end;
-          let logged_total_tokens =
-            if usage_trusted then
-              result.usage.input_tokens + result.usage.output_tokens
-            else 0
-          in
-          Log.Keeper.info
-            "%s: keeper cycle OK model=%s tokens=%d latency=%dms mode=%s stop=%s"
-            updated_meta.name model_used logged_total_tokens
-            latency_ms
-            turn_mode_label
-            outcome_str;
-          (* 7. Persist updated meta — RMW retry to avoid losing the cycle's
+                    if result.usage.cache_creation_input_tokens > 0
+                    then
+                      Prometheus.inc_counter
+                        Keeper_metrics.metric_keeper_cache_creation_tokens
+                        ~labels:[ "keeper_name", updated_meta.name; "model", model_used ]
+                        ~delta:(float_of_int result.usage.cache_creation_input_tokens)
+                        ();
+                    if result.usage.cache_read_input_tokens > 0
+                    then
+                      Prometheus.inc_counter
+                        Keeper_metrics.metric_keeper_cache_read_tokens
+                        ~labels:[ "keeper_name", updated_meta.name; "model", model_used ]
+                        ~delta:(float_of_int result.usage.cache_read_input_tokens)
+                        ())
+                  else (
+                    let reasons =
+                      match Keeper_unified_metrics.usage_trust_reasons usage_trust with
+                      | [] -> [ Keeper_unified_metrics.usage_trust_to_string usage_trust ]
+                      | reasons -> reasons
+                    in
+                    List.iter
+                      (fun reason ->
+                         Prometheus.inc_counter
+                           Keeper_metrics.metric_keeper_usage_anomalies
+                           ~labels:
+                             [ "keeper_name", updated_meta.name
+                             ; "model", model_used
+                             ; "reason", reason
+                             ]
+                           ())
+                      reasons;
+                    Log.Keeper.warn
+                      "%s: keeper usage telemetry untrusted model=%s resolved_model=%s \
+                       reasons=%s input=%d output=%d context_max=%d"
+                      updated_meta.name
+                      model_used
+                      resolved_model_id
+                      (String.concat "," reasons)
+                      result.usage.input_tokens
+                      result.usage.output_tokens
+                      lifecycle.context_max);
+                  let logged_total_tokens =
+                    if usage_trusted
+                    then result.usage.input_tokens + result.usage.output_tokens
+                    else 0
+                  in
+                  Log.Keeper.info
+                    "%s: keeper cycle OK model=%s tokens=%d latency=%dms mode=%s stop=%s"
+                    updated_meta.name
+                    model_used
+                    logged_total_tokens
+                    latency_ms
+                    turn_mode_label
+                    outcome_str;
+                  (* 7. Persist updated meta — RMW retry to avoid losing the cycle's
              usage/trace data when a heartbeat fiber bumps meta_version
              between the cycle's read and its write. #9764 / #9769:
              field-level merge preserves heartbeat-owned fields from
@@ -2653,77 +2948,90 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
              Self-healing circuit breaker: clear [auto_resume_after_sec]
              so a successful turn resets the exponential back-off to the
              initial delay for the next auto-pause cycle. *)
-          let updated_meta =
-            if updated_meta.auto_resume_after_sec <> None
-            then { updated_meta with auto_resume_after_sec = None }
-            else updated_meta
-          in
-          (match
-             write_meta_with_merge
-               ~merge:Keeper_meta_merge.heartbeat_fields_from_disk
-               config updated_meta
-           with
-           | Ok () -> ()
-           | Error msg ->
-               Prometheus.inc_counter
-                 Keeper_metrics.metric_keeper_write_meta_failures
-                 ~labels:
-                   [ ("keeper", updated_meta.name);
-                     ("phase",
-                      if is_version_conflict_error msg
-                      then "keeper_cycle_cas_race"
-                      else "keeper_cycle")
-                   ]
-                 ();
-               if is_version_conflict_error msg then
-                 Log.Keeper.warn
-                   "write_meta lost CAS race after retries (keeper cycle): %s" msg
-               else
-                 Log.Keeper.error
-                   "write_meta failed after keeper cycle: %s" msg);
-                   Prometheus.inc_counter
-                     Keeper_metrics.metric_keeper_write_meta_cycle_failures
-                     ~labels:[("keeper", meta.name); ("site", "keeper_cycle")]
-                     ();
-          (* 8. Handle stop reason *)
-          Keeper_turn_fsm.emit_transition
-            ~keeper_name:meta.name ~turn_id:keeper_turn_id
-            ~prev:Keeper_turn_fsm.Streaming
-            Keeper_turn_fsm.Completing;
-          (match result.stop_reason with
-           | Cascade_runner.TurnBudgetExhausted { turns_used; limit } ->
-             (* INFO, not WARN: mirrors MutationBoundaryReached below.
+                  let updated_meta =
+                    if updated_meta.auto_resume_after_sec <> None
+                    then { updated_meta with auto_resume_after_sec = None }
+                    else updated_meta
+                  in
+                  (match
+                     write_meta_with_merge
+                       ~merge:Keeper_meta_merge.heartbeat_fields_from_disk
+                       config
+                       updated_meta
+                   with
+                   | Ok () -> ()
+                   | Error msg ->
+                     Prometheus.inc_counter
+                       Keeper_metrics.metric_keeper_write_meta_failures
+                       ~labels:
+                         [ "keeper", updated_meta.name
+                         ; ( "phase"
+                           , if is_version_conflict_error msg
+                             then "keeper_cycle_cas_race"
+                             else "keeper_cycle" )
+                         ]
+                       ();
+                     if is_version_conflict_error msg
+                     then
+                       Log.Keeper.warn
+                         "write_meta lost CAS race after retries (keeper cycle): %s"
+                         msg
+                     else Log.Keeper.error "write_meta failed after keeper cycle: %s" msg);
+                  Prometheus.inc_counter
+                    Keeper_metrics.metric_keeper_write_meta_cycle_failures
+                    ~labels:[ "keeper", meta.name; "site", "keeper_cycle" ]
+                    ();
+                  (* 8. Handle stop reason *)
+                  Keeper_turn_fsm.emit_transition
+                    ~keeper_name:meta.name
+                    ~turn_id:keeper_turn_id
+                    ~prev:Keeper_turn_fsm.Streaming
+                    Keeper_turn_fsm.Completing;
+                  (match result.stop_reason with
+                   | Cascade_runner.TurnBudgetExhausted { turns_used; limit } ->
+                     (* INFO, not WARN: mirrors MutationBoundaryReached below.
                 The keeper made progress and saved a checkpoint; this is
                 a normal pause-and-resume signal, not a failure. *)
-             Log.Keeper.info
-               "keeper:%s turn budget exhausted (%d/%d), checkpoint saved — will resume next cycle"
-               updated_meta.name turns_used limit;
-             (* Do NOT increment turn_failures — this is not a crash.
+                     Log.Keeper.info
+                       "keeper:%s turn budget exhausted (%d/%d), checkpoint saved — will \
+                        resume next cycle"
+                       updated_meta.name
+                       turns_used
+                       limit;
+                     (* Do NOT increment turn_failures — this is not a crash.
                 The keeper made progress and saved a checkpoint.
                 Reset failures since the turn itself ran successfully. *)
-             Keeper_registry.reset_turn_failures ~base_path:config.base_path
-               updated_meta.name
-           | Cascade_runner.MutationBoundaryReached { tool_name; _ } ->
-             Log.Keeper.info
-               "keeper:%s mutation boundary reached after %s, checkpoint saved — will resume next cycle"
-               updated_meta.name
-               (match tool_name with Some tool -> tool | None -> "committed tool");
-             Keeper_registry.reset_turn_failures ~base_path:config.base_path
-               updated_meta.name
-           | Cascade_runner.Completed ->
-             Keeper_registry.reset_turn_failures ~base_path:config.base_path
-               updated_meta.name);
-          Keeper_turn_fsm.emit_transition
-            ~keeper_name:meta.name ~turn_id:keeper_turn_id
-            ~prev:Keeper_turn_fsm.Completing
-            Keeper_turn_fsm.Done;
-          (* Cycle 45: KeeperTaskAcquisition.tla TurnComplete post-action
+                     Keeper_registry.reset_turn_failures
+                       ~base_path:config.base_path
+                       updated_meta.name
+                   | Cascade_runner.MutationBoundaryReached { tool_name; _ } ->
+                     Log.Keeper.info
+                       "keeper:%s mutation boundary reached after %s, checkpoint saved — \
+                        will resume next cycle"
+                       updated_meta.name
+                       (match tool_name with
+                        | Some tool -> tool
+                        | None -> "committed tool");
+                     Keeper_registry.reset_turn_failures
+                       ~base_path:config.base_path
+                       updated_meta.name
+                   | Cascade_runner.Completed ->
+                     Keeper_registry.reset_turn_failures
+                       ~base_path:config.base_path
+                       updated_meta.name);
+                  Keeper_turn_fsm.emit_transition
+                    ~keeper_name:meta.name
+                    ~turn_id:keeper_turn_id
+                    ~prev:Keeper_turn_fsm.Completing
+                    Keeper_turn_fsm.Done;
+                  (* Cycle 45: KeeperTaskAcquisition.tla TurnComplete post-action
              — the cycle ran to completion and is about to return an
              [Ok] result.  Manual [wrap_unit] removed: the PPX-injected
              [wrap_unit ~stage:"guard"] already routes [Assert_failure]
              to the Prometheus counter. *)
-          cycle_completed := true;
-          post_turn_complete_task ~cycle_completed;
-          Ok updated_meta))
+                  cycle_completed := true;
+                  post_turn_complete_task ~cycle_completed;
+                  Ok updated_meta)))))
+;;
 
 let run_unified_turn = run_keeper_cycle

--- a/lib/keeper/keeper_unified_turn.mli
+++ b/lib/keeper/keeper_unified_turn.mli
@@ -228,10 +228,13 @@ val fail_open_local_only_when_unavailable :
   string
 
 (** PR-B: when every label in the resolved cascade points at the
-    same ollama [base_url] return [Some url], else [None].  Purely
-    structural: does not probe the network. *)
-val resolve_ollama_only_base_url :
+    same [base_url] AND a registered [Cascade_capacity_probe]
+    recognises that URL, return [Some url]; otherwise [None].
+    Purely structural: does not probe the network. Provider variant
+    is never inspected. *)
+val resolve_shared_probeable_base_url :
   ?resolve_label:(string -> Llm_provider.Provider_config.t option) ->
+  ?can_probe:(string -> bool) ->
   string list ->
   string option
 
@@ -239,7 +242,7 @@ val resolve_ollama_only_base_url :
     the endpoint is saturated (no available slots while at least one
     request is active or queued).  No cache / failed probe returns
     [false] (fail-open) so a flaky probe never starves the keeper. *)
-val is_ollama_saturated :
+val is_base_url_saturated :
   ?capacity_lookup:(string -> Cascade_throttle.capacity_info option) ->
   string ->
   bool

--- a/lib/keeper/keeper_unified_turn.mli
+++ b/lib/keeper/keeper_unified_turn.mli
@@ -8,90 +8,74 @@
 
     @since Unified Keeper Loop *)
 
-(** Run a unified keeper turn.
+val bounded_oas_timeout_for_turn_budget
+  :  estimated_input_tokens:int
+  -> remaining_turn_budget_s:float
+  -> float option
 
-    1. Builds unified prompt from meta + observation
-    2. Calls [Keeper_agent_run.run_turn] with keeper tools and hooks
-    3. Observes tool history from result to update metrics
-    4. Returns updated keeper_meta
-
-    @param config Coord configuration
-    @param meta Current keeper metadata
-    @param observation World state snapshot
-    @param generation Current generation counter *)
-(** Update keeper metrics by observing what the agent did (tool calls, text output).
-    No action classification — metrics are derived from the run result.
-
-    Exposed for testing. *)
-(** Cap a single OAS Agent.run timeout to the remaining unified-turn
-    wall-clock budget. Returns [None] when too little budget remains to
-    schedule another call safely. *)
-val bounded_oas_timeout_for_turn_budget :
-  estimated_input_tokens:int -> remaining_turn_budget_s:float -> float option
-
-val bounded_oas_timeout_for_turn_budget_with_turn_budget :
-  estimated_input_tokens:int ->
-  max_turns:int ->
-  remaining_turn_budget_s:float ->
-  float option
+val bounded_oas_timeout_for_turn_budget_with_turn_budget
+  :  estimated_input_tokens:int
+  -> max_turns:int
+  -> remaining_turn_budget_s:float
+  -> float option
 
 (** Full timeout-budget resolution used by the unified turn loop.
     Exposed for regression tests that need to distinguish "an OAS
     call had a bounded budget" from "the turn had no retry budget
     left before dispatch". *)
-type oas_timeout_budget_resolution = {
-  effective_timeout_sec : float;
-  adaptive_timeout_sec : float;
-  keeper_turn_timeout_sec : float;
-  remaining_turn_budget_sec : float;
-  estimated_input_tokens : int;
-  max_turns : int;
-  source : string;
-}
+type oas_timeout_budget_resolution =
+  { effective_timeout_sec : float
+  ; adaptive_timeout_sec : float
+  ; keeper_turn_timeout_sec : float
+  ; remaining_turn_budget_sec : float
+  ; estimated_input_tokens : int
+  ; max_turns : int
+  ; source : string
+  }
 
-val resolve_bounded_oas_timeout_budget_with_turn_budget :
-  allow_wall_clock_retry_budget:bool ->
-  is_retry:bool ->
-  reserve_degraded_retry_budget:bool ->
-  estimated_input_tokens:int ->
-  max_turns:int ->
-  remaining_turn_budget_s:float ->
-  oas_timeout_budget_resolution option
+val resolve_bounded_oas_timeout_budget_with_turn_budget
+  :  allow_wall_clock_retry_budget:bool
+  -> is_retry:bool
+  -> reserve_degraded_retry_budget:bool
+  -> estimated_input_tokens:int
+  -> max_turns:int
+  -> remaining_turn_budget_s:float
+  -> oas_timeout_budget_resolution option
 
 (** Per-attempt watchdog used around the OAS call. It fires before the
     enclosing keeper-turn wall-clock timeout so recoverable provider stalls can
     still rotate through the degraded cascade path. *)
-val attempt_watchdog_timeout_sec :
-  remaining_turn_budget_s:float -> oas_timeout_budget_resolution -> float
+val attempt_watchdog_timeout_sec
+  :  remaining_turn_budget_s:float
+  -> oas_timeout_budget_resolution
+  -> float
 
-val allow_wall_clock_retry_budget_for_attempt :
-  is_retry:bool ->
-  degraded_rotation_first_attempt:bool ->
-  attempt:int ->
-  attempted_cascades:string list ->
-  bool
+val allow_wall_clock_retry_budget_for_attempt
+  :  is_retry:bool
+  -> degraded_rotation_first_attempt:bool
+  -> attempt:int
+  -> attempted_cascades:string list
+  -> bool
 
-val oas_retry_budget_available_for_turn :
-  allow_wall_clock_retry_budget:bool ->
-  is_retry:bool ->
-  estimated_input_tokens:int ->
-  max_turns:int ->
-  remaining_turn_budget_s:float ->
-  bool
+val oas_retry_budget_available_for_turn
+  :  allow_wall_clock_retry_budget:bool
+  -> is_retry:bool
+  -> estimated_input_tokens:int
+  -> max_turns:int
+  -> remaining_turn_budget_s:float
+  -> bool
 
 val degraded_retry_slot_phase_budget_sec : float
-
-val degraded_retry_slot_phase_available :
-  time_spent_in_turn_s:float -> bool
+val degraded_retry_slot_phase_available : time_spent_in_turn_s:float -> bool
 
 (** Reclassify a structural OAS timeout only when the current attempt
     actually dispatched with an OAS timeout budget. This prevents a
     pre-retry turn-budget exhaustion from borrowing a stale previous
     attempt budget and incorrectly rotating cascades. *)
-val reclassify_oas_timeout_for_attempt :
-  timeout_budget:oas_timeout_budget_resolution option ->
-  Agent_sdk.Error.sdk_error ->
-  Agent_sdk.Error.sdk_error
+val reclassify_oas_timeout_for_attempt
+  :  timeout_budget:oas_timeout_budget_resolution option
+  -> Agent_sdk.Error.sdk_error
+  -> Agent_sdk.Error.sdk_error
 
 type degraded_retry_budget_decision =
   | No_degraded_retry
@@ -99,37 +83,36 @@ type degraded_retry_budget_decision =
   | Degraded_retry_budget_exhausted of Keeper_error_classify.degraded_retry
   | Degraded_retry_allowed of Keeper_error_classify.degraded_retry
 
-val next_fail_open_cascade_for_turn_with_budget :
-  ?rotation_cascades:string list ->
-  base_cascade:string ->
-  effective_cascade:string ->
-  tool_requirement:Keeper_agent_tool_surface.tool_requirement ->
-  attempted_cascades:string list ->
-  estimated_input_tokens:int ->
-  max_turns:int ->
-  ?time_spent_in_turn_s:float ->
-  remaining_turn_budget_s:float ->
-  Agent_sdk.Error.sdk_error ->
-  degraded_retry_budget_decision
+val next_fail_open_cascade_for_turn_with_budget
+  :  ?rotation_cascades:string list
+  -> base_cascade:string
+  -> effective_cascade:string
+  -> tool_requirement:Keeper_agent_tool_surface.tool_requirement
+  -> attempted_cascades:string list
+  -> estimated_input_tokens:int
+  -> max_turns:int
+  -> ?time_spent_in_turn_s:float
+  -> remaining_turn_budget_s:float
+  -> Agent_sdk.Error.sdk_error
+  -> degraded_retry_budget_decision
 
 (** Turn-local overflow hint published by the OAS event bus before a
     proactive compaction attempt. Exposed for regression tests. *)
-type turn_event_bus_overflow = {
-  estimated_tokens : int;
-  limit_tokens : int;
-}
+type turn_event_bus_overflow =
+  { estimated_tokens : int
+  ; limit_tokens : int
+  }
 
 (** Summary of event-bus signals observed during a single keeper turn.
     Exposed for regression tests. *)
-type turn_event_bus_summary = {
-  correlation_id : string option;
-  overflow_imminent : turn_event_bus_overflow option;
-}
+type turn_event_bus_summary =
+  { correlation_id : string option
+  ; overflow_imminent : turn_event_bus_overflow option
+  }
 
 (** Fold the drained OAS event-bus events for a single keeper turn into
     the signals MASC currently consumes. *)
-val summarize_turn_event_bus :
-  Agent_sdk.Event_bus.event list -> turn_event_bus_summary
+val summarize_turn_event_bus : Agent_sdk.Event_bus.event list -> turn_event_bus_summary
 
 (** Turn-local tool-event pairing state used to detect event-bus integrity
     failures before side-effect retry logic falls back to unknown input.
@@ -138,62 +121,58 @@ type turn_tool_event_tracker
 
 val create_turn_tool_event_tracker : unit -> turn_tool_event_tracker
 
-val record_turn_tool_events :
-  ?has_mutating_side_effect_with_input:
-    (tool_name:string -> input:Yojson.Safe.t -> bool) ->
-  keeper_name:string ->
-  turn_tool_event_tracker ->
-  Agent_sdk.Event_bus.event list ->
-  unit
+val record_turn_tool_events
+  :  ?has_mutating_side_effect_with_input:(tool_name:string -> input:Yojson.Safe.t -> bool)
+  -> keeper_name:string
+  -> turn_tool_event_tracker
+  -> Agent_sdk.Event_bus.event list
+  -> unit
 
-val turn_tool_event_integrity_error :
-  turn_tool_event_tracker -> Agent_sdk.Error.sdk_error option
+val turn_tool_event_integrity_error
+  :  turn_tool_event_tracker
+  -> Agent_sdk.Error.sdk_error option
 
-val committed_mutating_tools_from_events :
-  turn_tool_event_tracker -> string list
+val committed_mutating_tools_from_events : turn_tool_event_tracker -> string list
 
 (** Build the keeper overflow event from either a drained event-bus
     signal or the structured OAS error fallback. Exposed for tests. *)
-val context_overflow_event_of_error :
-  fallback_tokens:int ->
-  ?turn_event_bus:turn_event_bus_summary ->
-  Agent_sdk.Error.sdk_error ->
-  Keeper_state_machine.event
+val context_overflow_event_of_error
+  :  fallback_tokens:int
+  -> ?turn_event_bus:turn_event_bus_summary
+  -> Agent_sdk.Error.sdk_error
+  -> Keeper_state_machine.event
 
 (** Resolve the initial keeper turn context budget.
     Uses the first available model in the cascade rather than the largest
     fallback model, so lifecycle context math matches the provider that will
     receive the first request. Exposed for regression tests. *)
-val resolved_max_context_for_turn :
-  meta:Keeper_types.keeper_meta ->
-  string list ->
-  int
+val resolved_max_context_for_turn : meta:Keeper_types.keeper_meta -> string list -> int
 
 (** Persist paused/resumed state before mutating the live registry/phase.
     Returns [Error] when disk sync fails so callers can surface the failure
     instead of silently diverging runtime vs persisted state. *)
-val sync_keeper_paused_state :
-  config:Coord.config ->
-  meta:Keeper_types.keeper_meta ->
-  paused:bool ->
-  (Keeper_types.keeper_meta, string) result
+val sync_keeper_paused_state
+  :  config:Coord.config
+  -> meta:Keeper_types.keeper_meta
+  -> paused:bool
+  -> (Keeper_types.keeper_meta, string) result
 
 (** Required-tool contract failures are persistent keeper/provider contract
     failures, not transient provider blips. Repeated occurrences should pause
     the keeper before the generic supervisor crash/restart loop re-enters the
     same prompt and model family. Exposed for regression tests. *)
-val should_auto_pause_required_tool_contract_violation :
-  paused:bool ->
-  consecutive_failures:int ->
-  Agent_sdk.Error.sdk_error ->
-  bool
+val should_auto_pause_required_tool_contract_violation
+  :  paused:bool
+  -> consecutive_failures:int
+  -> Agent_sdk.Error.sdk_error
+  -> bool
 
 (** Ensure local-provider discovery is refreshed before a turn when the
     selected labels depend on runtime discovery. Exposed for targeted tests. *)
-val ensure_local_discovery_ready :
-  ?refresh:(string list -> bool) ->
-  string list ->
-  (unit, string) result
+val ensure_local_discovery_ready
+  :  ?refresh:(string list -> bool)
+  -> string list
+  -> (unit, string) result
 
 (** Deterministic decision for the phase-buffer fallback boundary. This
     does not probe runtime liveness; it only decides whether the selected
@@ -202,50 +181,50 @@ val ensure_local_discovery_ready :
     through routes before this decision. *)
 type local_only_liveness_decision =
   | Keep_effective_cascade of string
-  | Probe_local_only_urls of {
-      effective_cascade : string;
-      fallback_cascade : string;
-      probeable_base_urls : string list;
-    }
+  | Probe_local_only_urls of
+      { effective_cascade : string
+      ; fallback_cascade : string
+      ; probeable_base_urls : string list
+      }
 
-val decide_local_only_liveness :
-  ?resolve_label:(string -> Llm_provider.Provider_config.t option) ->
-  base_cascade:string ->
-  effective_cascade:string ->
-  string list ->
-  local_only_liveness_decision
+val decide_local_only_liveness
+  :  ?resolve_label:(string -> Llm_provider.Provider_config.t option)
+  -> base_cascade:string
+  -> effective_cascade:string
+  -> string list
+  -> local_only_liveness_decision
 
 (** When phase routing temporarily forces the phase-buffer route, fail open to the
     keeper's configured base cascade if the local Ollama endpoint is
     unavailable. Explicit legacy [local_only] aliases follow the configured
     [routes.phase_buffer] target. Exposed for targeted tests. *)
-val fail_open_local_only_when_unavailable :
-  ?resolve_label:(string -> Llm_provider.Provider_config.t option) ->
-  ?probe_base_url:(string -> bool) ->
-  base_cascade:string ->
-  effective_cascade:string ->
-  string list ->
-  string
+val fail_open_local_only_when_unavailable
+  :  ?resolve_label:(string -> Llm_provider.Provider_config.t option)
+  -> ?probe_base_url:(string -> bool)
+  -> base_cascade:string
+  -> effective_cascade:string
+  -> string list
+  -> string
 
 (** PR-B: when every label in the resolved cascade points at the
     same [base_url] AND a registered [Cascade_capacity_probe]
     recognises that URL, return [Some url]; otherwise [None].
     Purely structural: does not probe the network. Provider variant
     is never inspected. *)
-val resolve_shared_probeable_base_url :
-  ?resolve_label:(string -> Llm_provider.Provider_config.t option) ->
-  ?can_probe:(string -> bool) ->
-  string list ->
-  string option
+val resolve_shared_probeable_base_url
+  :  ?resolve_label:(string -> Llm_provider.Provider_config.t option)
+  -> ?can_probe:(string -> bool)
+  -> string list
+  -> string option
 
 (** PR-B: read the [Cascade_capacity_probe] cache and report whether
     the endpoint is saturated (no available slots while at least one
     request is active or queued).  No cache / failed probe returns
     [false] (fail-open) so a flaky probe never starves the keeper. *)
-val is_base_url_saturated :
-  ?capacity_lookup:(string -> Cascade_throttle.capacity_info option) ->
-  string ->
-  bool
+val is_base_url_saturated
+  :  ?capacity_lookup:(string -> Cascade_throttle.capacity_info option)
+  -> string
+  -> bool
 
 (** Upper bound on consecutive saturation skips per keeper (env
     [MASC_MAX_CONSECUTIVE_SATURATION_SKIPS], default 5, floored at
@@ -272,59 +251,71 @@ val saturation_skip_count_clear_all : unit -> unit
     active path feeds this from the live cascade catalog: catalog order is
     preserved while retaining only reserved recovery profiles and
     keeper-assignable profiles. *)
-val fail_open_rotation_cascades_from_catalog :
-  catalog_names:string list ->
-  keeper_assignable:string list ->
-  string list option
+val fail_open_rotation_cascades_from_catalog
+  :  catalog_names:string list
+  -> keeper_assignable:string list
+  -> string list option
 
 (** Resolve the next cascade to try after an auto-recoverable failure.
     Uses the current effective cascade, the turn tool requirement, and
     optionally a runtime/catalog-owned rotation order, then suppresses
     suggestions that would loop back to a cascade already attempted during
     the current turn. Exposed for targeted tests. *)
-val next_fail_open_cascade_for_turn :
-  ?rotation_cascades:string list ->
-  base_cascade:string ->
-  effective_cascade:string ->
-  tool_requirement:Keeper_agent_tool_surface.tool_requirement ->
-  attempted_cascades:string list ->
-  Agent_sdk.Error.sdk_error ->
-  Keeper_error_classify.degraded_retry option
+val next_fail_open_cascade_for_turn
+  :  ?rotation_cascades:string list
+  -> base_cascade:string
+  -> effective_cascade:string
+  -> tool_requirement:Keeper_agent_tool_surface.tool_requirement
+  -> attempted_cascades:string list
+  -> Agent_sdk.Error.sdk_error
+  -> Keeper_error_classify.degraded_retry option
 
 (** Record the streaming-cancel observation shared by the Eio.Cancel handler.
     Exposed so tests can pin the supervisor [fiber_stop] branch without forcing
     a live provider cancellation. *)
-val record_streaming_cancelled_observation :
-  config:Coord.config ->
-  run_meta:Keeper_types.keeper_meta ->
-  run_generation:int ->
-  cascade_name:Keeper_execution_receipt.cascade_name ->
-  keeper_turn_id:int ->
-  unit ->
-  unit
+val record_streaming_cancelled_observation
+  :  config:Coord.config
+  -> run_meta:Keeper_types.keeper_meta
+  -> run_generation:int
+  -> cascade_name:Keeper_execution_receipt.cascade_name
+  -> keeper_turn_id:int
+  -> unit
+  -> unit
 
-val run_keeper_cycle :
-  config:Coord.config ->
-  meta:Keeper_types.keeper_meta ->
-  observation:Keeper_world_observation.world_observation ->
-  generation:int ->
-  ?channel:Keeper_world_observation.keeper_cycle_channel ->
-  ?semaphore_wait_ms:int ->
-  ?turn_slot_control:Keeper_turn_slot.keeper_turn_slot_control ->
-  ?shared_context:Agent_sdk.Context.t ->
-  ?selected_item:(string * Cascade_ref.cascade_item) ->
-  unit ->
-  (Keeper_types.keeper_meta, Agent_sdk.Error.sdk_error) result
+val run_keeper_cycle
+  :  config:Coord.config
+  -> meta:Keeper_types.keeper_meta
+  -> observation:Keeper_world_observation.world_observation
+  -> generation:int
+  -> ?channel:Keeper_world_observation.keeper_cycle_channel
+  -> ?semaphore_wait_ms:int
+  -> ?turn_slot_control:Keeper_turn_slot.keeper_turn_slot_control
+  -> ?shared_context:Agent_sdk.Context.t
+  -> ?selected_item:string * Cascade_ref.cascade_item
+  -> unit
+  -> (Keeper_types.keeper_meta, Agent_sdk.Error.sdk_error) result
 
-val run_unified_turn :
-  config:Coord.config ->
-  meta:Keeper_types.keeper_meta ->
-  observation:Keeper_world_observation.world_observation ->
-  generation:int ->
-  ?channel:Keeper_world_observation.keeper_cycle_channel ->
-  ?semaphore_wait_ms:int ->
-  ?turn_slot_control:Keeper_turn_slot.keeper_turn_slot_control ->
-  ?shared_context:Agent_sdk.Context.t ->
-  ?selected_item:(string * Cascade_ref.cascade_item) ->
-  unit ->
-  (Keeper_types.keeper_meta, Agent_sdk.Error.sdk_error) result
+(** Run a unified keeper turn.
+
+    1. Builds unified prompt from meta + observation
+    2. Calls [Keeper_agent_run.run_turn] with keeper tools and hooks
+    3. Observes tool history from result to update metrics
+    4. Returns updated keeper_meta
+
+    @param config Coord configuration
+    @param meta Current keeper metadata
+    @param observation World state snapshot
+    @param generation Current generation counter *)
+
+val run_unified_turn
+  :  config:Coord.config
+  -> meta:Keeper_types.keeper_meta
+  -> observation:Keeper_world_observation.world_observation
+  -> generation:int
+  -> ?channel:Keeper_world_observation.keeper_cycle_channel
+  -> ?semaphore_wait_ms:int
+  -> ?turn_slot_control:Keeper_turn_slot.keeper_turn_slot_control
+  -> ?shared_context:Agent_sdk.Context.t
+  -> ?selected_item:string * Cascade_ref.cascade_item
+  -> unit
+  -> (Keeper_types.keeper_meta, Agent_sdk.Error.sdk_error) result

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -1,7 +1,5 @@
 module Types = Masc_domain
-
 open Alcotest
-
 module WO = Masc_mcp.Keeper_world_observation
 module UP = Masc_mcp.Keeper_unified_prompt
 module UT = Masc_mcp.Keeper_unified_turn
@@ -29,37 +27,43 @@ let oas_error_cascade_name = Masc_mcp.Keeper_turn_driver.cascade_name_of_string
 
 let has_prompt_root path =
   Sys.file_exists (Filename.concat path "config/prompts/keeper.unified.system.md")
+;;
 
 let repo_root () =
   match Sys.getenv_opt "DUNE_SOURCEROOT" with
   | Some root when has_prompt_root root -> root
   | _ ->
-      let rec ascend path =
-        if has_prompt_root path then path
-        else
-          let parent = Filename.dirname path in
-          if String.equal parent path then Sys.getcwd () else ascend parent
-      in
-      ascend (Sys.getcwd ())
+    let rec ascend path =
+      if has_prompt_root path
+      then path
+      else (
+        let parent = Filename.dirname path in
+        if String.equal parent path then Sys.getcwd () else ascend parent)
+    in
+    ascend (Sys.getcwd ())
+;;
 
 let copy_file src dst =
   let ic = open_in_bin src in
   Fun.protect
     ~finally:(fun () -> close_in_noerr ic)
     (fun () ->
-      let oc = open_out_bin dst in
-      Fun.protect
-        ~finally:(fun () -> close_out_noerr oc)
-        (fun () -> output_string oc (In_channel.input_all ic)))
+       let oc = open_out_bin dst in
+       Fun.protect
+         ~finally:(fun () -> close_out_noerr oc)
+         (fun () -> output_string oc (In_channel.input_all ic)))
+;;
 
 let unix_mkdir_p path =
   let rec loop dir =
-    if dir = "" || dir = "." || Sys.file_exists dir then ()
+    if dir = "" || dir = "." || Sys.file_exists dir
+    then ()
     else (
       loop (Filename.dirname dir);
       Unix.mkdir dir 0o755)
   in
   loop path
+;;
 
 let () =
   let base_path = repo_root () in
@@ -83,49 +87,63 @@ let () =
   Prompt_registry.set_markdown_dir prompts_dir;
   ignore (Result.get_ok (Masc_mcp.Keeper_exec_tools.init_policy_config ~base_path));
   Masc_mcp.Prompt_defaults.init ()
+;;
 
 let temp_dir () =
   let dir = Filename.temp_file "test_keeper_unified_" "" in
   Unix.unlink dir;
   Unix.mkdir dir 0o755;
   dir
+;;
 
 let cleanup_dir dir =
   let rec rm path =
-    if Sys.file_exists path then
-      if Sys.is_directory path then (
+    if Sys.file_exists path
+    then
+      if Sys.is_directory path
+      then (
         Array.iter (fun name -> rm (Filename.concat path name)) (Sys.readdir path);
         Unix.rmdir path)
-      else
-        Unix.unlink path
+      else Unix.unlink path
   in
-  try rm dir with _ -> ()
+  try rm dir with
+  | _ -> ()
+;;
 
 let read_jsonl_line path =
   let ic = open_in path in
-  Fun.protect ~finally:(fun () -> close_in_noerr ic) (fun () ->
-    input_line ic |> Yojson.Safe.from_string)
+  Fun.protect
+    ~finally:(fun () -> close_in_noerr ic)
+    (fun () -> input_line ic |> Yojson.Safe.from_string)
+;;
 
 let contains_substring haystack needle =
   let hay_len = String.length haystack in
   let needle_len = String.length needle in
   let rec loop i =
-    if i + needle_len > hay_len then false
-    else if String.sub haystack i needle_len = needle then true
+    if i + needle_len > hay_len
+    then false
+    else if String.sub haystack i needle_len = needle
+    then true
     else loop (i + 1)
   in
   needle_len = 0 || loop 0
+;;
 
 let substring_index haystack needle =
   let hay_len = String.length haystack in
   let needle_len = String.length needle in
   let rec loop i =
-    if needle_len = 0 then Some 0
-    else if i + needle_len > hay_len then None
-    else if String.sub haystack i needle_len = needle then Some i
+    if needle_len = 0
+    then Some 0
+    else if i + needle_len > hay_len
+    then None
+    else if String.sub haystack i needle_len = needle
+    then Some i
     else loop (i + 1)
   in
   loop 0
+;;
 
 let source_file_contains file_rel needle =
   let path = Filename.concat (repo_root ()) file_rel in
@@ -133,90 +151,98 @@ let source_file_contains file_rel needle =
   Fun.protect
     ~finally:(fun () -> close_in_noerr ic)
     (fun () -> contains_substring (In_channel.input_all ic) needle)
+;;
 
 let contains_disallowed_control_char s =
   let rec loop i =
-    if i >= String.length s then false
-    else
+    if i >= String.length s
+    then false
+    else (
       let code = Char.code s.[i] in
       if (code < 32 && s.[i] <> '\n' && s.[i] <> '\r' && s.[i] <> '\t') || code = 127
       then true
-      else loop (i + 1)
+      else loop (i + 1))
   in
   loop 0
+;;
 
 let tool_log_entry ?ts tool_name =
   let ts = Option.value ~default:(Time_compat.now ()) ts in
-  `Assoc [ ("tool", `String tool_name); ("ts", `Float ts) ]
+  `Assoc [ "tool", `String tool_name; "ts", `Float ts ]
+;;
 
 let with_env name value f =
   let old = Sys.getenv_opt name in
   Unix.putenv name value;
-  Fun.protect ~finally:(fun () ->
-    match old with
-    | Some v -> Unix.putenv name v
-    | None -> (try Unix.putenv name "" with _ -> ()))
+  Fun.protect
+    ~finally:(fun () ->
+      match old with
+      | Some v -> Unix.putenv name v
+      | None ->
+        (try Unix.putenv name "" with
+         | _ -> ()))
     f
+;;
 
 let prepare_test_config_root base_dir =
-  let config_dir =
-    Filename.concat (Filename.concat base_dir ".masc") "config"
-  in
+  let config_dir = Filename.concat (Filename.concat base_dir ".masc") "config" in
   Keeper_types.mkdir_p config_dir;
   copy_file
     (Filename.concat (repo_root ()) "config/cascade.json")
     (Filename.concat config_dir "cascade.json");
   config_dir
+;;
 
 let with_test_runtime_roots base_dir f =
   let config_dir = prepare_test_config_root base_dir in
-  with_env "MASC_BASE_PATH" base_dir @@ fun () ->
-  with_env "MASC_CONFIG_DIR" config_dir @@ fun () ->
+  with_env "MASC_BASE_PATH" base_dir
+  @@ fun () ->
+  with_env "MASC_CONFIG_DIR" config_dir
+  @@ fun () ->
   Masc_mcp.Config_dir_resolver.reset ();
-  Fun.protect
-    ~finally:(fun () -> Masc_mcp.Config_dir_resolver.reset ())
-    f
+  Fun.protect ~finally:(fun () -> Masc_mcp.Config_dir_resolver.reset ()) f
+;;
 
 (* ---------- World Observation type tests ---------- *)
 
 let base_observation : WO.world_observation =
-  {
-    pending_mentions = [];
-    pending_board_events = [];
-    pending_scope_messages = [];
-    message_cursor_updates = [];
-    idle_seconds = 0;
-    active_goals = [];
-    continuity_summary = "";
-    worktree_change_summary = None;
-    context_ratio = 0.0;
-    economic_pressure = AE.Normal;
-    unclaimed_task_count = 0;
-    claimable_task_count = 0;
-    failed_task_count = 0;
-    pending_verification_count = 0;
-    backlog_updated_since_last_scheduled_autonomous = false;
-    active_agent_count = 0;
-    last_turn_budget = None;
-    work_discovery_due = false;
+  { pending_mentions = []
+  ; pending_board_events = []
+  ; pending_scope_messages = []
+  ; message_cursor_updates = []
+  ; idle_seconds = 0
+  ; active_goals = []
+  ; continuity_summary = ""
+  ; worktree_change_summary = None
+  ; context_ratio = 0.0
+  ; economic_pressure = AE.Normal
+  ; unclaimed_task_count = 0
+  ; claimable_task_count = 0
+  ; failed_task_count = 0
+  ; pending_verification_count = 0
+  ; backlog_updated_since_last_scheduled_autonomous = false
+  ; active_agent_count = 0
+  ; last_turn_budget = None
+  ; work_discovery_due = false
   }
+;;
 
 let sample_board_event : WO.pending_board_event =
-  {
-    post_id = "board-post-1";
-    author = "alice";
-    title = "Need help";
-    preview = "Please take a look.";
-    hearth = Some "research";
-    post_kind = Masc_mcp.Board.Human_post;
-    updated_at = 0.0;
-    explicit_mention = false;
-    matched_targets = [];
-    self_commented = false;
-    new_external_since = 0;
-    latest_external_author = None;
-    latest_external_preview = None;
+  { post_id = "board-post-1"
+  ; author = "alice"
+  ; title = "Need help"
+  ; preview = "Please take a look."
+  ; hearth = Some "research"
+  ; post_kind = Masc_mcp.Board.Human_post
+  ; updated_at = 0.0
+  ; explicit_mention = false
+  ; matched_targets = []
+  ; self_commented = false
+  ; new_external_since = 0
+  ; latest_external_author = None
+  ; latest_external_preview = None
   }
+;;
 
 let test_observation_defaults () =
   let obs = base_observation in
@@ -228,653 +254,762 @@ let test_observation_defaults () =
   check int "active_agents default" 0 obs.active_agent_count;
   check bool "no mentions" true (obs.pending_mentions = []);
   check bool "no goals" true (obs.active_goals = [])
+;;
 
 let test_observation_with_mentions () =
   let obs =
     { base_observation with
-      pending_mentions = [("alice", "hey keeper"); ("bob", "need help")]
+      pending_mentions = [ "alice", "hey keeper"; "bob", "need help" ]
     }
   in
   check int "mention count" 2 (List.length obs.pending_mentions)
+;;
 
 let test_observation_with_goals () =
-  let obs =
-    { base_observation with
-      active_goals = ["goal-1"; "goal-2"; "goal-3"]
-    }
-  in
+  let obs = { base_observation with active_goals = [ "goal-1"; "goal-2"; "goal-3" ] } in
   check int "goal count" 3 (List.length obs.active_goals)
+;;
 
 let test_observation_economic_modes () =
-  let modes = [AE.Normal; AE.Frugal; AE.Hustle] in
+  let modes = [ AE.Normal; AE.Frugal; AE.Hustle ] in
   List.iter
     (fun mode ->
-      let obs = { base_observation with economic_pressure = mode } in
-      check bool "observation created" true (obs.idle_seconds >= 0))
+       let obs = { base_observation with economic_pressure = mode } in
+       check bool "observation created" true (obs.idle_seconds >= 0))
     modes
+;;
 
 (* ---------- Unified Prompt tests ---------- *)
 
 let make_meta name : Masc_mcp.Keeper_types.keeper_meta =
-  let json = `Assoc [
-    ("name", `String name);
-    ("trace_id", `String ("test-trace-" ^ name));
-    ("goal", `String "test goal");
-  ] in
+  let json =
+    `Assoc
+      [ "name", `String name
+      ; "trace_id", `String ("test-trace-" ^ name)
+      ; "goal", `String "test goal"
+      ]
+  in
   match Masc_test_deps.meta_of_json_fixture json with
   | Ok m -> m
   | Error e -> failwith ("meta_of_json failed: " ^ e)
+;;
 
-let minimal_meta : Masc_mcp.Keeper_types.keeper_meta =
-  make_meta "test-keeper"
+let minimal_meta : Masc_mcp.Keeper_types.keeper_meta = make_meta "test-keeper"
 
 let minimal_policy_meta =
-  {
-    minimal_meta with
-    tool_access =
-      Preset { preset = Minimal; also_allow = [] };
-  }
+  { minimal_meta with tool_access = Preset { preset = Minimal; also_allow = [] } }
+;;
 
-let room_signal_meta =
-  { minimal_meta with room_signal_prompt_enabled = true }
+let room_signal_meta = { minimal_meta with room_signal_prompt_enabled = true }
 
 let contract_requiring_tools required_tools : Masc_domain.task_contract =
-  {
-    strict = false;
-    completion_contract = [];
-    required_tools;
-    required_evidence = [];
-    inspect_gate_evidence = [];
-    verify_gate_evidence = [];
-    links =
-      {
-        operation_id = None;
-        session_id = None;
-        autoresearch_loop_id = None;
-      };
+  { strict = false
+  ; completion_contract = []
+  ; required_tools
+  ; required_evidence = []
+  ; inspect_gate_evidence = []
+  ; verify_gate_evidence = []
+  ; links = { operation_id = None; session_id = None; autoresearch_loop_id = None }
   }
+;;
 
 let test_observe_uses_precollected_board_events () =
   let base_dir = temp_dir () in
   Fun.protect
     ~finally:(fun () -> cleanup_dir base_dir)
     (fun () ->
-      Eio_main.run @@ fun env ->
-  Fs_compat.set_fs (Eio.Stdenv.fs env);
-      Unix.putenv "MASC_BASE_PATH" base_dir;
-      Masc_mcp.Board.reset_global_for_test ();
-      Masc_mcp.Board_dispatch.reset_for_test ();
-      Masc_mcp.Board_dispatch.init_jsonl ();
-      let config = Masc_mcp.Coord.default_config base_dir in
-      ignore (Masc_mcp.Coord.init config ~agent_name:(Some "observer"));
-      (match
-         Masc_mcp.Board_dispatch.create_post ~author:"alice"
-           ~title:"Need sangsu" ~content:"@test-keeper please check this"
-           ~post_kind:Masc_mcp.Board.Human_post ()
-       with
-      | Ok _ -> ()
-      | Error e -> fail ("create_post failed: " ^ Masc_mcp.Board.show_board_error e));
-      let events, _, _ =
-        WO.collect_board_events ~base_path:base_dir
-          ~continuity_summary:"goal test-keeper"
-          ~meta:minimal_meta
-      in
-      let obs =
-        WO.observe ~allowed_tool_names:None
-          ~pending_board_events:(Some events)
-          ~config ~meta:minimal_meta
-      in
-      check int "precollected board events preserved" (List.length events)
-        (List.length obs.pending_board_events);
-      check bool "board event schedules turn" true
-        (WO.should_run_keeper_cycle ~meta:minimal_meta obs))
+       Eio_main.run
+       @@ fun env ->
+       Fs_compat.set_fs (Eio.Stdenv.fs env);
+       Unix.putenv "MASC_BASE_PATH" base_dir;
+       Masc_mcp.Board.reset_global_for_test ();
+       Masc_mcp.Board_dispatch.reset_for_test ();
+       Masc_mcp.Board_dispatch.init_jsonl ();
+       let config = Masc_mcp.Coord.default_config base_dir in
+       ignore (Masc_mcp.Coord.init config ~agent_name:(Some "observer"));
+       (match
+          Masc_mcp.Board_dispatch.create_post
+            ~author:"alice"
+            ~title:"Need sangsu"
+            ~content:"@test-keeper please check this"
+            ~post_kind:Masc_mcp.Board.Human_post
+            ()
+        with
+        | Ok _ -> ()
+        | Error e -> fail ("create_post failed: " ^ Masc_mcp.Board.show_board_error e));
+       let events, _, _ =
+         WO.collect_board_events
+           ~base_path:base_dir
+           ~continuity_summary:"goal test-keeper"
+           ~meta:minimal_meta
+       in
+       let obs =
+         WO.observe
+           ~allowed_tool_names:None
+           ~pending_board_events:(Some events)
+           ~config
+           ~meta:minimal_meta
+       in
+       check
+         int
+         "precollected board events preserved"
+         (List.length events)
+         (List.length obs.pending_board_events);
+       check
+         bool
+         "board event schedules turn"
+         true
+         (WO.should_run_keeper_cycle ~meta:minimal_meta obs))
+;;
 
 let test_board_signal_stimulus_becomes_pending_board_event () =
   let base_dir = temp_dir () in
   Fun.protect
     ~finally:(fun () -> cleanup_dir base_dir)
     (fun () ->
-      Eio_main.run @@ fun env ->
-      Fs_compat.set_fs (Eio.Stdenv.fs env);
-      Unix.putenv "MASC_BASE_PATH" base_dir;
-      Masc_mcp.Board.reset_global_for_test ();
-      Masc_mcp.Board_dispatch.reset_for_test ();
-      Masc_mcp.Board_dispatch.init_jsonl ();
-      let post =
-        match
-          Masc_mcp.Board_dispatch.create_post ~author:"alice"
-            ~title:"Need test-keeper"
-            ~content:"@test-keeper please react from the queued stimulus"
-            ~post_kind:Masc_mcp.Board.Human_post ()
-        with
-        | Ok post -> post
-        | Error e -> fail ("create_post failed: " ^ Masc_mcp.Board.show_board_error e)
-      in
-      let post_id = Masc_mcp.Board.Post_id.to_string post.id in
-      let payload =
-        `Assoc
-          [
-            ("source", `String "board_signal");
-            ("kind", `String "post_created");
-            ("post_id", `String post_id);
-            ("author", `String "alice");
-            ("title", `String "Need test-keeper");
-            ( "content",
-              `String "@test-keeper please react from the queued stimulus" );
-            ("hearth", `Null);
-            ("wake_reason", `String "explicit_mention");
-          ]
-        |> Yojson.Safe.to_string
-      in
-      let stimulus : Masc_mcp.Keeper_event_queue.stimulus =
-        {
-          post_id;
-          urgency = Masc_mcp.Keeper_event_queue.Immediate;
-          arrived_at = Time_compat.now ();
-          payload;
-        }
-      in
-      match
-        WO.pending_board_event_of_stimulus
-          ~continuity_summary:"goal test-keeper"
-          ~meta:minimal_meta stimulus
-      with
-      | None -> fail "queued board stimulus was not converted"
-      | Some event ->
-          check string "post id" post_id event.post_id;
-          check string "author" "alice" event.author;
-          check string "title from board snapshot" "Need test-keeper" event.title;
-          check bool "explicit mention" true event.explicit_mention;
-          check (list string) "matched target" [ "test-keeper" ]
-            event.matched_targets;
-          check bool "schedules turn" true
-            (WO.should_run_keeper_cycle ~meta:minimal_meta
-               { base_observation with pending_board_events = [ event ] }))
+       Eio_main.run
+       @@ fun env ->
+       Fs_compat.set_fs (Eio.Stdenv.fs env);
+       Unix.putenv "MASC_BASE_PATH" base_dir;
+       Masc_mcp.Board.reset_global_for_test ();
+       Masc_mcp.Board_dispatch.reset_for_test ();
+       Masc_mcp.Board_dispatch.init_jsonl ();
+       let post =
+         match
+           Masc_mcp.Board_dispatch.create_post
+             ~author:"alice"
+             ~title:"Need test-keeper"
+             ~content:"@test-keeper please react from the queued stimulus"
+             ~post_kind:Masc_mcp.Board.Human_post
+             ()
+         with
+         | Ok post -> post
+         | Error e -> fail ("create_post failed: " ^ Masc_mcp.Board.show_board_error e)
+       in
+       let post_id = Masc_mcp.Board.Post_id.to_string post.id in
+       let payload =
+         `Assoc
+           [ "source", `String "board_signal"
+           ; "kind", `String "post_created"
+           ; "post_id", `String post_id
+           ; "author", `String "alice"
+           ; "title", `String "Need test-keeper"
+           ; "content", `String "@test-keeper please react from the queued stimulus"
+           ; "hearth", `Null
+           ; "wake_reason", `String "explicit_mention"
+           ]
+         |> Yojson.Safe.to_string
+       in
+       let stimulus : Masc_mcp.Keeper_event_queue.stimulus =
+         { post_id
+         ; urgency = Masc_mcp.Keeper_event_queue.Immediate
+         ; arrived_at = Time_compat.now ()
+         ; payload
+         }
+       in
+       match
+         WO.pending_board_event_of_stimulus
+           ~continuity_summary:"goal test-keeper"
+           ~meta:minimal_meta
+           stimulus
+       with
+       | None -> fail "queued board stimulus was not converted"
+       | Some event ->
+         check string "post id" post_id event.post_id;
+         check string "author" "alice" event.author;
+         check string "title from board snapshot" "Need test-keeper" event.title;
+         check bool "explicit mention" true event.explicit_mention;
+         check (list string) "matched target" [ "test-keeper" ] event.matched_targets;
+         check
+           bool
+           "schedules turn"
+           true
+           (WO.should_run_keeper_cycle
+              ~meta:minimal_meta
+              { base_observation with pending_board_events = [ event ] }))
+;;
 
 let test_legacy_board_comment_stimulus_becomes_pending_board_event () =
   let base_dir = temp_dir () in
   Fun.protect
     ~finally:(fun () -> cleanup_dir base_dir)
     (fun () ->
-      Eio_main.run @@ fun env ->
-      Fs_compat.set_fs (Eio.Stdenv.fs env);
-      Unix.putenv "MASC_BASE_PATH" base_dir;
-      Masc_mcp.Board.reset_global_for_test ();
-      Masc_mcp.Board_dispatch.reset_for_test ();
-      Masc_mcp.Board_dispatch.init_jsonl ();
-      let post =
-        match
-          Masc_mcp.Board_dispatch.create_post ~author:"alice"
-            ~title:"Need test-keeper"
-            ~content:"@test-keeper please react from the queued stimulus"
-            ~post_kind:Masc_mcp.Board.Human_post ()
-        with
-        | Ok post -> post
-        | Error e -> fail ("create_post failed: " ^ Masc_mcp.Board.show_board_error e)
-      in
-      let post_id = Masc_mcp.Board.Post_id.to_string post.id in
-      let payload =
-        `Assoc
-          [
-            ("source", `String "board_signal");
-            ("kind", `String "comment");
-            ("post_id", `String post_id);
-            ("author", `String "bob");
-            ("title", `String "Need test-keeper");
-            ("content", `String "comment payload from live board signal");
-            ("hearth", `Null);
-            ("wake_reason", `String "scope_message");
-          ]
-        |> Yojson.Safe.to_string
-      in
-      let stimulus : Masc_mcp.Keeper_event_queue.stimulus =
-        {
-          post_id;
-          urgency = Masc_mcp.Keeper_event_queue.Normal;
-          arrived_at = Time_compat.now ();
-          payload;
-        }
-      in
-      match
-        WO.pending_board_event_of_stimulus
-          ~continuity_summary:"goal test-keeper"
-          ~meta:minimal_meta stimulus
-      with
-      | None -> fail "legacy board comment stimulus was not converted"
-      | Some event ->
-          check string "post id" post_id event.post_id;
-          check string "latest external author" "bob"
-            (Option.value ~default:"" event.latest_external_author);
-          check int "new external comment" 1 event.new_external_since;
-          check bool "schedules turn" true
-            (WO.should_run_keeper_cycle ~meta:minimal_meta
-               { base_observation with pending_board_events = [ event ] }))
+       Eio_main.run
+       @@ fun env ->
+       Fs_compat.set_fs (Eio.Stdenv.fs env);
+       Unix.putenv "MASC_BASE_PATH" base_dir;
+       Masc_mcp.Board.reset_global_for_test ();
+       Masc_mcp.Board_dispatch.reset_for_test ();
+       Masc_mcp.Board_dispatch.init_jsonl ();
+       let post =
+         match
+           Masc_mcp.Board_dispatch.create_post
+             ~author:"alice"
+             ~title:"Need test-keeper"
+             ~content:"@test-keeper please react from the queued stimulus"
+             ~post_kind:Masc_mcp.Board.Human_post
+             ()
+         with
+         | Ok post -> post
+         | Error e -> fail ("create_post failed: " ^ Masc_mcp.Board.show_board_error e)
+       in
+       let post_id = Masc_mcp.Board.Post_id.to_string post.id in
+       let payload =
+         `Assoc
+           [ "source", `String "board_signal"
+           ; "kind", `String "comment"
+           ; "post_id", `String post_id
+           ; "author", `String "bob"
+           ; "title", `String "Need test-keeper"
+           ; "content", `String "comment payload from live board signal"
+           ; "hearth", `Null
+           ; "wake_reason", `String "scope_message"
+           ]
+         |> Yojson.Safe.to_string
+       in
+       let stimulus : Masc_mcp.Keeper_event_queue.stimulus =
+         { post_id
+         ; urgency = Masc_mcp.Keeper_event_queue.Normal
+         ; arrived_at = Time_compat.now ()
+         ; payload
+         }
+       in
+       match
+         WO.pending_board_event_of_stimulus
+           ~continuity_summary:"goal test-keeper"
+           ~meta:minimal_meta
+           stimulus
+       with
+       | None -> fail "legacy board comment stimulus was not converted"
+       | Some event ->
+         check string "post id" post_id event.post_id;
+         check
+           string
+           "latest external author"
+           "bob"
+           (Option.value ~default:"" event.latest_external_author);
+         check int "new external comment" 1 event.new_external_since;
+         check
+           bool
+           "schedules turn"
+           true
+           (WO.should_run_keeper_cycle
+              ~meta:minimal_meta
+              { base_observation with pending_board_events = [ event ] }))
+;;
 
 let test_observe_splits_absolute_and_claimable_backlog () =
   let base_dir = temp_dir () in
   Fun.protect
     ~finally:(fun () -> cleanup_dir base_dir)
     (fun () ->
-      let config = Masc_mcp.Coord.default_config base_dir in
-      ignore (Masc_mcp.Coord.init config ~agent_name:(Some "observer"));
-      ignore
-        (Masc_mcp.Coord.add_task config ~title:"Open task" ~priority:1
-           ~description:"");
-      ignore
-        (Masc_mcp.Coord.add_task config ~title:"Bash task" ~priority:1
-           ~description:""
-           ~contract:(contract_requiring_tools [ "keeper_bash" ]));
-      let obs =
-        WO.observe ~allowed_tool_names:(Some [ "keeper_task_claim" ])
-          ~pending_board_events:(Some []) ~config ~meta:minimal_meta
-      in
-      check int "absolute todo backlog" 2 obs.unclaimed_task_count;
-      check int "matched claimable backlog" 1 obs.claimable_task_count)
+       let config = Masc_mcp.Coord.default_config base_dir in
+       ignore (Masc_mcp.Coord.init config ~agent_name:(Some "observer"));
+       ignore
+         (Masc_mcp.Coord.add_task config ~title:"Open task" ~priority:1 ~description:"");
+       ignore
+         (Masc_mcp.Coord.add_task
+            config
+            ~title:"Bash task"
+            ~priority:1
+            ~description:""
+            ~contract:(contract_requiring_tools [ "keeper_bash" ]));
+       let obs =
+         WO.observe
+           ~allowed_tool_names:(Some [ "keeper_task_claim" ])
+           ~pending_board_events:(Some [])
+           ~config
+           ~meta:minimal_meta
+       in
+       check int "absolute todo backlog" 2 obs.unclaimed_task_count;
+       check int "matched claimable backlog" 1 obs.claimable_task_count)
+;;
 
 let test_observe_claimable_backlog_respects_active_goal_ids () =
   let base_dir = temp_dir () in
   Fun.protect
     ~finally:(fun () -> cleanup_dir base_dir)
     (fun () ->
-      let config = Masc_mcp.Coord.default_config base_dir in
-      ignore (Masc_mcp.Coord.init config ~agent_name:(Some "observer"));
-      let goal, _ =
-        match Masc_mcp.Goal_store.upsert_goal config ~title:"Scoped goal" () with
-        | Ok payload -> payload
-        | Error msg -> fail msg
-      in
-      let other_goal, _ =
-        match Masc_mcp.Goal_store.upsert_goal config ~title:"Other goal" () with
-        | Ok payload -> payload
-        | Error msg -> fail msg
-      in
-      ignore
-        (Masc_mcp.Coord.add_task ~goal_id:other_goal.id config
-           ~title:"Out-of-scope task" ~priority:1 ~description:"desc");
-      let meta = { minimal_meta with active_goal_ids = [ goal.id ] } in
-      let obs =
-        WO.observe ~allowed_tool_names:(Some [ "keeper_task_claim" ])
-          ~pending_board_events:(Some []) ~config ~meta
-      in
-      check int "absolute todo backlog" 1 obs.unclaimed_task_count;
-      check int "scoped claimable backlog" 0 obs.claimable_task_count;
-      let signal =
-        obs
-        |> KCC.of_keeper_world_observation
-        |> KCC.classify_actionable_signal_for_tools
-             ~allowed_tool_names:[ "keeper_task_claim" ]
-      in
-      check bool "out-of-scope backlog is not actionable" false
-        (KCC.is_actionable signal))
+       let config = Masc_mcp.Coord.default_config base_dir in
+       ignore (Masc_mcp.Coord.init config ~agent_name:(Some "observer"));
+       let goal, _ =
+         match Masc_mcp.Goal_store.upsert_goal config ~title:"Scoped goal" () with
+         | Ok payload -> payload
+         | Error msg -> fail msg
+       in
+       let other_goal, _ =
+         match Masc_mcp.Goal_store.upsert_goal config ~title:"Other goal" () with
+         | Ok payload -> payload
+         | Error msg -> fail msg
+       in
+       ignore
+         (Masc_mcp.Coord.add_task
+            ~goal_id:other_goal.id
+            config
+            ~title:"Out-of-scope task"
+            ~priority:1
+            ~description:"desc");
+       let meta = { minimal_meta with active_goal_ids = [ goal.id ] } in
+       let obs =
+         WO.observe
+           ~allowed_tool_names:(Some [ "keeper_task_claim" ])
+           ~pending_board_events:(Some [])
+           ~config
+           ~meta
+       in
+       check int "absolute todo backlog" 1 obs.unclaimed_task_count;
+       check int "scoped claimable backlog" 0 obs.claimable_task_count;
+       let signal =
+         obs
+         |> KCC.of_keeper_world_observation
+         |> KCC.classify_actionable_signal_for_tools
+              ~allowed_tool_names:[ "keeper_task_claim" ]
+       in
+       check
+         bool
+         "out-of-scope backlog is not actionable"
+         false
+         (KCC.is_actionable signal))
+;;
 
 let test_observe_claimable_backlog_uses_auto_goal_fallback_scope () =
   let base_dir = temp_dir () in
   Fun.protect
     ~finally:(fun () -> cleanup_dir base_dir)
     (fun () ->
-      let config = Masc_mcp.Coord.default_config base_dir in
-      ignore (Masc_mcp.Coord.init config ~agent_name:(Some "observer"));
-      let auto_goal, _ =
-        match
-          Masc_mcp.Goal_store.upsert_goal config
-            ~title:
-              (Masc_mcp.Keeper_goal_repair.goal_title_of_purpose
-                 minimal_meta.goal)
-            ()
-        with
-        | Ok payload -> payload
-        | Error msg -> fail msg
-      in
-      let product_goal, _ =
-        match Masc_mcp.Goal_store.upsert_goal config ~title:"Product goal" () with
-        | Ok payload -> payload
-        | Error msg -> fail msg
-      in
-      ignore
-        (Masc_mcp.Coord.add_task ~goal_id:product_goal.id config
-           ~title:"Fallback task" ~priority:1 ~description:"desc");
-      let meta = { minimal_meta with active_goal_ids = [ auto_goal.id ] } in
-      let obs =
-        WO.observe ~allowed_tool_names:(Some [ "keeper_task_claim" ])
-          ~pending_board_events:(Some []) ~config ~meta
-      in
-      check int "absolute todo backlog" 1 obs.unclaimed_task_count;
-      check int "auto-goal fallback claimable backlog" 1
-        obs.claimable_task_count)
+       let config = Masc_mcp.Coord.default_config base_dir in
+       ignore (Masc_mcp.Coord.init config ~agent_name:(Some "observer"));
+       let auto_goal, _ =
+         match
+           Masc_mcp.Goal_store.upsert_goal
+             config
+             ~title:(Masc_mcp.Keeper_goal_repair.goal_title_of_purpose minimal_meta.goal)
+             ()
+         with
+         | Ok payload -> payload
+         | Error msg -> fail msg
+       in
+       let product_goal, _ =
+         match Masc_mcp.Goal_store.upsert_goal config ~title:"Product goal" () with
+         | Ok payload -> payload
+         | Error msg -> fail msg
+       in
+       ignore
+         (Masc_mcp.Coord.add_task
+            ~goal_id:product_goal.id
+            config
+            ~title:"Fallback task"
+            ~priority:1
+            ~description:"desc");
+       let meta = { minimal_meta with active_goal_ids = [ auto_goal.id ] } in
+       let obs =
+         WO.observe
+           ~allowed_tool_names:(Some [ "keeper_task_claim" ])
+           ~pending_board_events:(Some [])
+           ~config
+           ~meta
+       in
+       check int "absolute todo backlog" 1 obs.unclaimed_task_count;
+       check int "auto-goal fallback claimable backlog" 1 obs.claimable_task_count)
+;;
 
 let test_durable_signal_present_sees_claimable_backlog_for_smart_hb_gate () =
   let base_dir = temp_dir () in
   Fun.protect
     ~finally:(fun () -> cleanup_dir base_dir)
     (fun () ->
-      let config = Masc_mcp.Coord.default_config base_dir in
-      ignore (Masc_mcp.Coord.init config ~agent_name:(Some "observer"));
-      ignore
-        (Masc_mcp.Coord.add_task config ~title:"Open task" ~priority:1
-           ~description:"");
-      let meta = { minimal_meta with work_discovery_enabled = Some false } in
-      let present =
-        WO.durable_signal_present
-          ~allowed_tool_names:(Some [ "keeper_task_claim" ])
-          ~pending_board_events:(Some [])
-          ~config ~meta
-      in
-      check bool "claimable backlog forces smart heartbeat emit" true present)
+       let config = Masc_mcp.Coord.default_config base_dir in
+       ignore (Masc_mcp.Coord.init config ~agent_name:(Some "observer"));
+       ignore
+         (Masc_mcp.Coord.add_task config ~title:"Open task" ~priority:1 ~description:"");
+       let meta = { minimal_meta with work_discovery_enabled = Some false } in
+       let present =
+         WO.durable_signal_present
+           ~allowed_tool_names:(Some [ "keeper_task_claim" ])
+           ~pending_board_events:(Some [])
+           ~config
+           ~meta
+       in
+       check bool "claimable backlog forces smart heartbeat emit" true present)
+;;
 
 let test_durable_signal_present_filters_unclaimable_backlog_for_smart_hb_gate () =
   let base_dir = temp_dir () in
   Fun.protect
     ~finally:(fun () -> cleanup_dir base_dir)
     (fun () ->
-      let config = Masc_mcp.Coord.default_config base_dir in
-      ignore (Masc_mcp.Coord.init config ~agent_name:(Some "observer"));
-      ignore
-        (Masc_mcp.Coord.add_task config ~title:"Bash task" ~priority:1
-           ~description:""
-           ~contract:(contract_requiring_tools [ "keeper_bash" ]));
-      let meta = { minimal_meta with work_discovery_enabled = Some false } in
-      let present =
-        WO.durable_signal_present
-          ~allowed_tool_names:(Some [ "keeper_task_claim" ])
-          ~pending_board_events:(Some [])
-          ~config ~meta
-      in
-      check bool "unclaimable backlog stays idle" false present)
+       let config = Masc_mcp.Coord.default_config base_dir in
+       ignore (Masc_mcp.Coord.init config ~agent_name:(Some "observer"));
+       ignore
+         (Masc_mcp.Coord.add_task
+            config
+            ~title:"Bash task"
+            ~priority:1
+            ~description:""
+            ~contract:(contract_requiring_tools [ "keeper_bash" ]));
+       let meta = { minimal_meta with work_discovery_enabled = Some false } in
+       let present =
+         WO.durable_signal_present
+           ~allowed_tool_names:(Some [ "keeper_task_claim" ])
+           ~pending_board_events:(Some [])
+           ~config
+           ~meta
+       in
+       check bool "unclaimable backlog stays idle" false present)
+;;
 
 let test_collect_board_events_keeps_non_mentions_as_followup_signal () =
   let base_dir = temp_dir () in
   Fun.protect
     ~finally:(fun () -> cleanup_dir base_dir)
     (fun () ->
-      Eio_main.run @@ fun env ->
-      Fs_compat.set_fs (Eio.Stdenv.fs env);
-      Unix.putenv "MASC_BASE_PATH" base_dir;
-      Masc_mcp.Board.reset_global_for_test ();
-      Masc_mcp.Board_dispatch.reset_for_test ();
-      Masc_mcp.Board_dispatch.init_jsonl ();
-      let config = Masc_mcp.Coord.default_config base_dir in
-      ignore (Masc_mcp.Coord.init config ~agent_name:(Some "observer"));
-      (match
-         Masc_mcp.Board_dispatch.create_post ~author:"alice"
-           ~title:"General update" ~content:"No direct mention here"
-           ~post_kind:Masc_mcp.Board.Human_post ()
-       with
-      | Ok _ -> ()
-      | Error e -> fail ("create_post failed: " ^ Masc_mcp.Board.show_board_error e));
-      let events, new_count, mention_count =
-        WO.collect_board_events ~base_path:base_dir
-          ~continuity_summary:"goal test-keeper"
-          ~meta:minimal_meta
-      in
-      check int "default keepers ignore unmatched non-mention events" 0
-        (List.length events);
-      check int "new count includes non-mention" 1 new_count;
-      check int "mention count stays zero" 0 mention_count)
+       Eio_main.run
+       @@ fun env ->
+       Fs_compat.set_fs (Eio.Stdenv.fs env);
+       Unix.putenv "MASC_BASE_PATH" base_dir;
+       Masc_mcp.Board.reset_global_for_test ();
+       Masc_mcp.Board_dispatch.reset_for_test ();
+       Masc_mcp.Board_dispatch.init_jsonl ();
+       let config = Masc_mcp.Coord.default_config base_dir in
+       ignore (Masc_mcp.Coord.init config ~agent_name:(Some "observer"));
+       (match
+          Masc_mcp.Board_dispatch.create_post
+            ~author:"alice"
+            ~title:"General update"
+            ~content:"No direct mention here"
+            ~post_kind:Masc_mcp.Board.Human_post
+            ()
+        with
+        | Ok _ -> ()
+        | Error e -> fail ("create_post failed: " ^ Masc_mcp.Board.show_board_error e));
+       let events, new_count, mention_count =
+         WO.collect_board_events
+           ~base_path:base_dir
+           ~continuity_summary:"goal test-keeper"
+           ~meta:minimal_meta
+       in
+       check
+         int
+         "default keepers ignore unmatched non-mention events"
+         0
+         (List.length events);
+       check int "new count includes non-mention" 1 new_count;
+       check int "mention count stays zero" 0 mention_count)
+;;
 
 let test_collect_board_events_keeps_non_mentions_for_room_signal_keepers () =
   let base_dir = temp_dir () in
   Fun.protect
     ~finally:(fun () -> cleanup_dir base_dir)
     (fun () ->
-      Eio_main.run @@ fun env ->
-      Fs_compat.set_fs (Eio.Stdenv.fs env);
-      Unix.putenv "MASC_BASE_PATH" base_dir;
-      Masc_mcp.Board.reset_global_for_test ();
-      Masc_mcp.Board_dispatch.reset_for_test ();
-      Masc_mcp.Board_dispatch.init_jsonl ();
-      let config = Masc_mcp.Coord.default_config base_dir in
-      ignore (Masc_mcp.Coord.init config ~agent_name:(Some "observer"));
-      (match
-         Masc_mcp.Board_dispatch.create_post ~author:"alice"
-           ~title:"General update" ~content:"No direct mention here"
-           ~post_kind:Masc_mcp.Board.Human_post ()
-       with
-      | Ok _ -> ()
-      | Error e -> fail ("create_post failed: " ^ Masc_mcp.Board.show_board_error e));
-      let events, new_count, mention_count =
-        WO.collect_board_events ~base_path:base_dir
-          ~continuity_summary:"goal test-keeper"
-          ~meta:room_signal_meta
-      in
-      check int "room-signal keepers keep non-mention events" 1
-        (List.length events);
-      check int "new count includes non-mention" 1 new_count;
-      check int "mention count stays zero" 0 mention_count;
-      check bool "event is not explicit mention" false
-        (List.hd events).explicit_mention)
+       Eio_main.run
+       @@ fun env ->
+       Fs_compat.set_fs (Eio.Stdenv.fs env);
+       Unix.putenv "MASC_BASE_PATH" base_dir;
+       Masc_mcp.Board.reset_global_for_test ();
+       Masc_mcp.Board_dispatch.reset_for_test ();
+       Masc_mcp.Board_dispatch.init_jsonl ();
+       let config = Masc_mcp.Coord.default_config base_dir in
+       ignore (Masc_mcp.Coord.init config ~agent_name:(Some "observer"));
+       (match
+          Masc_mcp.Board_dispatch.create_post
+            ~author:"alice"
+            ~title:"General update"
+            ~content:"No direct mention here"
+            ~post_kind:Masc_mcp.Board.Human_post
+            ()
+        with
+        | Ok _ -> ()
+        | Error e -> fail ("create_post failed: " ^ Masc_mcp.Board.show_board_error e));
+       let events, new_count, mention_count =
+         WO.collect_board_events
+           ~base_path:base_dir
+           ~continuity_summary:"goal test-keeper"
+           ~meta:room_signal_meta
+       in
+       check int "room-signal keepers keep non-mention events" 1 (List.length events);
+       check int "new count includes non-mention" 1 new_count;
+       check int "mention count stays zero" 0 mention_count;
+       check bool "event is not explicit mention" false (List.hd events).explicit_mention)
+;;
 
 let test_collect_board_events_keeps_external_replies_after_self_comment () =
   let base_dir = temp_dir () in
   Fun.protect
     ~finally:(fun () -> cleanup_dir base_dir)
     (fun () ->
-      Eio_main.run @@ fun env ->
-      Fs_compat.set_fs (Eio.Stdenv.fs env);
-      Unix.putenv "MASC_BASE_PATH" base_dir;
-      Masc_mcp.Board.reset_global_for_test ();
-      Masc_mcp.Board_dispatch.reset_for_test ();
-      Masc_mcp.Board_dispatch.init_jsonl ();
-      let config = Masc_mcp.Coord.default_config base_dir in
-      ignore (Masc_mcp.Coord.init config ~agent_name:(Some "observer"));
-      let post_id =
-        match
-          Masc_mcp.Board_dispatch.create_post ~author:"alice"
-            ~title:"General update" ~content:"No direct mention here"
-            ~post_kind:Masc_mcp.Board.Human_post ()
+       Eio_main.run
+       @@ fun env ->
+       Fs_compat.set_fs (Eio.Stdenv.fs env);
+       Unix.putenv "MASC_BASE_PATH" base_dir;
+       Masc_mcp.Board.reset_global_for_test ();
+       Masc_mcp.Board_dispatch.reset_for_test ();
+       Masc_mcp.Board_dispatch.init_jsonl ();
+       let config = Masc_mcp.Coord.default_config base_dir in
+       ignore (Masc_mcp.Coord.init config ~agent_name:(Some "observer"));
+       let post_id =
+         match
+           Masc_mcp.Board_dispatch.create_post
+             ~author:"alice"
+             ~title:"General update"
+             ~content:"No direct mention here"
+             ~post_kind:Masc_mcp.Board.Human_post
+             ()
+         with
+         | Ok post -> Masc_mcp.Board.Post_id.to_string post.id
+         | Error e -> fail ("create_post failed: " ^ Masc_mcp.Board.show_board_error e)
+       in
+       (match
+          Masc_mcp.Board_dispatch.add_comment
+            ~post_id
+            ~author:"test-keeper"
+            ~content:"I am following this thread."
+            ()
         with
-        | Ok post -> Masc_mcp.Board.Post_id.to_string post.id
-        | Error e -> fail ("create_post failed: " ^ Masc_mcp.Board.show_board_error e)
-      in
-      (match
-         Masc_mcp.Board_dispatch.add_comment ~post_id ~author:"test-keeper"
-           ~content:"I am following this thread."
-           ()
-       with
-      | Ok _ -> ()
-      | Error e -> fail ("add_comment failed: " ^ Masc_mcp.Board.show_board_error e));
-      Unix.sleepf 0.02;
-      (match
-         Masc_mcp.Board_dispatch.add_comment ~post_id ~author:"bob"
-           ~content:"Thanks, there is a new question for you."
-           ()
-       with
-      | Ok _ -> ()
-      | Error e -> fail ("add_comment failed: " ^ Masc_mcp.Board.show_board_error e));
-      let events, new_count, mention_count =
-        WO.collect_board_events ~base_path:base_dir
-          ~continuity_summary:"goal test-keeper"
-          ~meta:minimal_meta
-      in
-      check int "new count still tracks recent post" 1 new_count;
-      check int "mention count stays zero" 0 mention_count;
-      match events with
-      | [ event ] ->
-          check bool "follow-up marks self commented" true event.self_commented;
-          check int "external reply count" 1 event.new_external_since;
-          check bool "no explicit mention required" false event.explicit_mention;
-          check string "latest external author" "bob"
-            (Option.value ~default:"" event.latest_external_author)
-      | _ -> fail "expected one follow-up board event")
+        | Ok _ -> ()
+        | Error e -> fail ("add_comment failed: " ^ Masc_mcp.Board.show_board_error e));
+       Unix.sleepf 0.02;
+       (match
+          Masc_mcp.Board_dispatch.add_comment
+            ~post_id
+            ~author:"bob"
+            ~content:"Thanks, there is a new question for you."
+            ()
+        with
+        | Ok _ -> ()
+        | Error e -> fail ("add_comment failed: " ^ Masc_mcp.Board.show_board_error e));
+       let events, new_count, mention_count =
+         WO.collect_board_events
+           ~base_path:base_dir
+           ~continuity_summary:"goal test-keeper"
+           ~meta:minimal_meta
+       in
+       check int "new count still tracks recent post" 1 new_count;
+       check int "mention count stays zero" 0 mention_count;
+       match events with
+       | [ event ] ->
+         check bool "follow-up marks self commented" true event.self_commented;
+         check int "external reply count" 1 event.new_external_since;
+         check bool "no explicit mention required" false event.explicit_mention;
+         check
+           string
+           "latest external author"
+           "bob"
+           (Option.value ~default:"" event.latest_external_author)
+       | _ -> fail "expected one follow-up board event")
+;;
 
 let test_collect_board_events_treats_generated_alias_as_self_comment () =
   let base_dir = temp_dir () in
-  let meta =
-    {
-      (make_meta "ramarama") with
-      agent_name = "keeper-ramarama-agent";
-    }
-  in
+  let meta = { (make_meta "ramarama") with agent_name = "keeper-ramarama-agent" } in
   Fun.protect
     ~finally:(fun () -> cleanup_dir base_dir)
     (fun () ->
-      Eio_main.run @@ fun env ->
-      Fs_compat.set_fs (Eio.Stdenv.fs env);
-      Unix.putenv "MASC_BASE_PATH" base_dir;
-      Masc_mcp.Board.reset_global_for_test ();
-      Masc_mcp.Board_dispatch.reset_for_test ();
-      Masc_mcp.Board_dispatch.init_jsonl ();
-      let config = Masc_mcp.Coord.default_config base_dir in
-      ignore (Masc_mcp.Coord.init config ~agent_name:(Some "observer"));
-      let post_id =
-        match
-          Masc_mcp.Board_dispatch.create_post ~author:"alice"
-            ~title:"General update" ~content:"No direct mention here"
-            ~post_kind:Masc_mcp.Board.Human_post ()
+       Eio_main.run
+       @@ fun env ->
+       Fs_compat.set_fs (Eio.Stdenv.fs env);
+       Unix.putenv "MASC_BASE_PATH" base_dir;
+       Masc_mcp.Board.reset_global_for_test ();
+       Masc_mcp.Board_dispatch.reset_for_test ();
+       Masc_mcp.Board_dispatch.init_jsonl ();
+       let config = Masc_mcp.Coord.default_config base_dir in
+       ignore (Masc_mcp.Coord.init config ~agent_name:(Some "observer"));
+       let post_id =
+         match
+           Masc_mcp.Board_dispatch.create_post
+             ~author:"alice"
+             ~title:"General update"
+             ~content:"No direct mention here"
+             ~post_kind:Masc_mcp.Board.Human_post
+             ()
+         with
+         | Ok post -> Masc_mcp.Board.Post_id.to_string post.id
+         | Error e -> fail ("create_post failed: " ^ Masc_mcp.Board.show_board_error e)
+       in
+       (match
+          Masc_mcp.Board_dispatch.add_comment
+            ~post_id
+            ~author:"ramarama-fierce-panda"
+            ~content:"I am following this thread."
+            ()
         with
-        | Ok post -> Masc_mcp.Board.Post_id.to_string post.id
-        | Error e -> fail ("create_post failed: " ^ Masc_mcp.Board.show_board_error e)
-      in
-      (match
-         Masc_mcp.Board_dispatch.add_comment ~post_id
-           ~author:"ramarama-fierce-panda"
-           ~content:"I am following this thread."
-           ()
-       with
-      | Ok _ -> ()
-      | Error e -> fail ("add_comment failed: " ^ Masc_mcp.Board.show_board_error e));
-      Unix.sleepf 0.02;
-      (match
-         Masc_mcp.Board_dispatch.add_comment ~post_id ~author:"bob"
-           ~content:"Thanks, there is a new question for you."
-           ()
-       with
-      | Ok _ -> ()
-      | Error e -> fail ("add_comment failed: " ^ Masc_mcp.Board.show_board_error e));
-      let events, new_count, mention_count =
-        WO.collect_board_events ~base_path:base_dir
-          ~continuity_summary:"goal ramarama"
-          ~meta
-      in
-      check int "new count still tracks recent post" 1 new_count;
-      check int "mention count stays zero" 0 mention_count;
-      match events with
-      | [ event ] ->
-          check bool "generated alias counts as self comment" true event.self_commented;
-          check int "external reply count" 1 event.new_external_since;
-          check string "latest external author" "bob"
-            (Option.value ~default:"" event.latest_external_author)
-      | _ -> fail "expected one follow-up board event")
+        | Ok _ -> ()
+        | Error e -> fail ("add_comment failed: " ^ Masc_mcp.Board.show_board_error e));
+       Unix.sleepf 0.02;
+       (match
+          Masc_mcp.Board_dispatch.add_comment
+            ~post_id
+            ~author:"bob"
+            ~content:"Thanks, there is a new question for you."
+            ()
+        with
+        | Ok _ -> ()
+        | Error e -> fail ("add_comment failed: " ^ Masc_mcp.Board.show_board_error e));
+       let events, new_count, mention_count =
+         WO.collect_board_events
+           ~base_path:base_dir
+           ~continuity_summary:"goal ramarama"
+           ~meta
+       in
+       check int "new count still tracks recent post" 1 new_count;
+       check int "mention count stays zero" 0 mention_count;
+       match events with
+       | [ event ] ->
+         check bool "generated alias counts as self comment" true event.self_commented;
+         check int "external reply count" 1 event.new_external_since;
+         check
+           string
+           "latest external author"
+           "bob"
+           (Option.value ~default:"" event.latest_external_author)
+       | _ -> fail "expected one follow-up board event")
+;;
 
 let test_observe_ignores_scope_messages_without_room_signal_opt_in () =
   let base_dir = temp_dir () in
   Fun.protect
     ~finally:(fun () -> cleanup_dir base_dir)
     (fun () ->
-      Eio_main.run @@ fun env ->
-      Fs_compat.set_fs (Eio.Stdenv.fs env);
-      Unix.putenv "MASC_BASE_PATH" base_dir;
-      let config = Masc_mcp.Coord.default_config base_dir in
-      ignore (Masc_mcp.Coord.init config ~agent_name:(Some "observer"));
-      ignore (Masc_mcp.Coord.broadcast config ~from_agent:"alice" ~content:"general room update");
-      let meta = { minimal_meta with joined_room_ids = [ "default" ] } in
-      let obs =
-        WO.observe ~allowed_tool_names:None
-          ~pending_board_events:(Some [])
-          ~config ~meta
-      in
-      check int "mentions stay empty" 0 (List.length obs.pending_mentions);
-      check int "scope messages stay empty" 0
-        (List.length obs.pending_scope_messages))
+       Eio_main.run
+       @@ fun env ->
+       Fs_compat.set_fs (Eio.Stdenv.fs env);
+       Unix.putenv "MASC_BASE_PATH" base_dir;
+       let config = Masc_mcp.Coord.default_config base_dir in
+       ignore (Masc_mcp.Coord.init config ~agent_name:(Some "observer"));
+       ignore
+         (Masc_mcp.Coord.broadcast
+            config
+            ~from_agent:"alice"
+            ~content:"general room update");
+       let meta = { minimal_meta with joined_room_ids = [ "default" ] } in
+       let obs =
+         WO.observe ~allowed_tool_names:None ~pending_board_events:(Some []) ~config ~meta
+       in
+       check int "mentions stay empty" 0 (List.length obs.pending_mentions);
+       check int "scope messages stay empty" 0 (List.length obs.pending_scope_messages))
+;;
 
 let test_observe_collects_scope_messages_for_room_signal_keepers () =
   let base_dir = temp_dir () in
   Fun.protect
     ~finally:(fun () -> cleanup_dir base_dir)
     (fun () ->
-      Eio_main.run @@ fun env ->
-      Fs_compat.set_fs (Eio.Stdenv.fs env);
-      Unix.putenv "MASC_BASE_PATH" base_dir;
-      let config = Masc_mcp.Coord.default_config base_dir in
-      ignore (Masc_mcp.Coord.init config ~agent_name:(Some "observer"));
-      ignore (Masc_mcp.Coord.broadcast config ~from_agent:"alice" ~content:"general room update");
-      let meta = { room_signal_meta with joined_room_ids = [ "default" ] } in
-      let obs =
-        WO.observe ~allowed_tool_names:None
-          ~pending_board_events:(Some [])
-          ~config ~meta
-      in
-      check int "mentions stay empty" 0 (List.length obs.pending_mentions);
-      check bool "scope messages collected" true
-        (List.length obs.pending_scope_messages >= 1))
+       Eio_main.run
+       @@ fun env ->
+       Fs_compat.set_fs (Eio.Stdenv.fs env);
+       Unix.putenv "MASC_BASE_PATH" base_dir;
+       let config = Masc_mcp.Coord.default_config base_dir in
+       ignore (Masc_mcp.Coord.init config ~agent_name:(Some "observer"));
+       ignore
+         (Masc_mcp.Coord.broadcast
+            config
+            ~from_agent:"alice"
+            ~content:"general room update");
+       let meta = { room_signal_meta with joined_room_ids = [ "default" ] } in
+       let obs =
+         WO.observe ~allowed_tool_names:None ~pending_board_events:(Some []) ~config ~meta
+       in
+       check int "mentions stay empty" 0 (List.length obs.pending_mentions);
+       check
+         bool
+         "scope messages collected"
+         true
+         (List.length obs.pending_scope_messages >= 1))
+;;
 
 let test_observe_damps_keeper_scope_chatter_but_keeps_direct_mentions () =
   let base_dir = temp_dir () in
   Fun.protect
     ~finally:(fun () -> cleanup_dir base_dir)
     (fun () ->
-      Eio_main.run @@ fun env ->
-      Fs_compat.set_fs (Eio.Stdenv.fs env);
-      Unix.putenv "MASC_BASE_PATH" base_dir;
-      let config = Masc_mcp.Coord.default_config base_dir in
-      ignore (Masc_mcp.Coord.init config ~agent_name:(Some "observer"));
-      ignore
-        (Masc_mcp.Coord.broadcast config
-           ~from_agent:"keeper-ramarama-agent"
-           ~content:"general keeper room update");
-      ignore
-        (Masc_mcp.Coord.broadcast config
-           ~from_agent:"keeper-ramarama-agent"
-           ~content:"@test-keeper please inspect this");
-      ignore
-        (Masc_mcp.Coord.broadcast config ~from_agent:"operator"
-           ~content:"general operator room update");
-      let meta = { room_signal_meta with joined_room_ids = [ "default" ] } in
-      let obs =
-        WO.observe ~allowed_tool_names:None
-          ~pending_board_events:(Some [])
-          ~config ~meta
-      in
-      check int "keeper direct mention collected" 1
-        (List.length obs.pending_mentions);
-      check int "only operator scope collected" 1
-        (List.length obs.pending_scope_messages);
-      match obs.pending_scope_messages with
-      | [ (author, content) ] ->
-          check string "scope author" "operator" author;
-          check string "scope content" "general operator room update" content
-      | _ -> fail "expected one operator scope message")
+       Eio_main.run
+       @@ fun env ->
+       Fs_compat.set_fs (Eio.Stdenv.fs env);
+       Unix.putenv "MASC_BASE_PATH" base_dir;
+       let config = Masc_mcp.Coord.default_config base_dir in
+       ignore (Masc_mcp.Coord.init config ~agent_name:(Some "observer"));
+       ignore
+         (Masc_mcp.Coord.broadcast
+            config
+            ~from_agent:"keeper-ramarama-agent"
+            ~content:"general keeper room update");
+       ignore
+         (Masc_mcp.Coord.broadcast
+            config
+            ~from_agent:"keeper-ramarama-agent"
+            ~content:"@test-keeper please inspect this");
+       ignore
+         (Masc_mcp.Coord.broadcast
+            config
+            ~from_agent:"operator"
+            ~content:"general operator room update");
+       let meta = { room_signal_meta with joined_room_ids = [ "default" ] } in
+       let obs =
+         WO.observe ~allowed_tool_names:None ~pending_board_events:(Some []) ~config ~meta
+       in
+       check int "keeper direct mention collected" 1 (List.length obs.pending_mentions);
+       check
+         int
+         "only operator scope collected"
+         1
+         (List.length obs.pending_scope_messages);
+       match obs.pending_scope_messages with
+       | [ (author, content) ] ->
+         check string "scope author" "operator" author;
+         check string "scope content" "general operator room update" content
+       | _ -> fail "expected one operator scope message")
+;;
 
 let test_observe_skips_stale_terminal_task_mentions () =
   let base_dir = temp_dir () in
   Fun.protect
     ~finally:(fun () -> cleanup_dir base_dir)
     (fun () ->
-      Eio_main.run @@ fun env ->
-      Fs_compat.set_fs (Eio.Stdenv.fs env);
-      Unix.putenv "MASC_BASE_PATH" base_dir;
-      let config = Masc_mcp.Coord.default_config base_dir in
-      ignore (Masc_mcp.Coord.init config ~agent_name:(Some "observer"));
-      ignore
-        (Masc_mcp.Coord.add_task config ~title:"Terminal task" ~priority:1
-           ~description:"");
-      ignore
-        (Masc_mcp.Coord.claim_task config ~agent_name:"nick0cave"
-           ~task_id:"task-001");
-      ignore
-        (Masc_mcp.Coord.broadcast config ~from_agent:"taskmaster"
-           ~content:
-             "@test-keeper task-001 stale claim detected: current_task_id=null \
-              but MASC still lists task-001 as claimed by you. Please release \
-              it.");
-      (match
-         Masc_mcp.Coord.force_done_task_r config ~agent_name:"operator"
-           ~task_id:"task-001" ~notes:"terminal in backlog" ()
-       with
-       | Ok _ -> ()
-       | Error err -> fail (Masc_domain.masc_error_to_string err));
-      let meta = { minimal_meta with joined_room_ids = [ "default" ] } in
-      let obs =
-        WO.observe ~allowed_tool_names:None
-          ~pending_board_events:(Some [])
-          ~config ~meta
-      in
-      check int "stale mention skipped" 0 (List.length obs.pending_mentions);
-      check int "scope messages stay empty" 0
-        (List.length obs.pending_scope_messages);
-      check bool "cursor advanced" true
-        (List.exists
-           (fun (room_id, seq) -> String.equal room_id "default" && seq > 0)
-           obs.message_cursor_updates))
+       Eio_main.run
+       @@ fun env ->
+       Fs_compat.set_fs (Eio.Stdenv.fs env);
+       Unix.putenv "MASC_BASE_PATH" base_dir;
+       let config = Masc_mcp.Coord.default_config base_dir in
+       ignore (Masc_mcp.Coord.init config ~agent_name:(Some "observer"));
+       ignore
+         (Masc_mcp.Coord.add_task
+            config
+            ~title:"Terminal task"
+            ~priority:1
+            ~description:"");
+       ignore
+         (Masc_mcp.Coord.claim_task config ~agent_name:"nick0cave" ~task_id:"task-001");
+       ignore
+         (Masc_mcp.Coord.broadcast
+            config
+            ~from_agent:"taskmaster"
+            ~content:
+              "@test-keeper task-001 stale claim detected: current_task_id=null but MASC \
+               still lists task-001 as claimed by you. Please release it.");
+       (match
+          Masc_mcp.Coord.force_done_task_r
+            config
+            ~agent_name:"operator"
+            ~task_id:"task-001"
+            ~notes:"terminal in backlog"
+            ()
+        with
+        | Ok _ -> ()
+        | Error err -> fail (Masc_domain.masc_error_to_string err));
+       let meta = { minimal_meta with joined_room_ids = [ "default" ] } in
+       let obs =
+         WO.observe ~allowed_tool_names:None ~pending_board_events:(Some []) ~config ~meta
+       in
+       check int "stale mention skipped" 0 (List.length obs.pending_mentions);
+       check int "scope messages stay empty" 0 (List.length obs.pending_scope_messages);
+       check
+         bool
+         "cursor advanced"
+         true
+         (List.exists
+            (fun (room_id, seq) -> String.equal room_id "default" && seq > 0)
+            obs.message_cursor_updates))
+;;
 
 let test_scheduled_turn_uses_cooldown_only () =
   let meta =
@@ -882,92 +1017,116 @@ let test_scheduled_turn_uses_cooldown_only () =
       current_task_id =
         (match Masc_mcp.Keeper_id.Task_id.of_string "task-123" with
          | Ok value -> Some value
-         | Error err -> fail ("task id parse failed: " ^ err));
-      proactive =
-        { enabled = true; idle_sec = 0; cooldown_sec = 60 };
-      runtime =
+         | Error err -> fail ("task id parse failed: " ^ err))
+    ; proactive = { enabled = true; idle_sec = 0; cooldown_sec = 60 }
+    ; runtime =
         { minimal_meta.runtime with
           proactive_rt =
             { minimal_meta.runtime.proactive_rt with
-              last_ts = Time_compat.now () -. 120.0;
-            };
-        };
+              last_ts = Time_compat.now () -. 120.0
+            }
+        }
     }
   in
   let obs = { base_observation with idle_seconds = 0 } in
-  check bool "cooldown opens scheduled turn for current task" true
+  check
+    bool
+    "cooldown opens scheduled turn for current task"
+    true
     (WO.keeper_cycle_decision
        ~provider_cooldown_remaining_sec:(fun ~cascade_name:_ -> None)
-       ~meta obs).should_run
+       ~meta
+       obs)
+      .should_run
+;;
 
 let test_scheduled_turn_skips_without_structured_work_signal () =
   let meta =
     { minimal_meta with
-      proactive =
-        { enabled = true; idle_sec = 0; cooldown_sec = 60 };
-      runtime =
+      proactive = { enabled = true; idle_sec = 0; cooldown_sec = 60 }
+    ; runtime =
         { minimal_meta.runtime with
           proactive_rt =
             { minimal_meta.runtime.proactive_rt with
-              last_ts = Time_compat.now () -. 120.0;
-            };
-        };
+              last_ts = Time_compat.now () -. 120.0
+            }
+        }
     }
   in
   let obs = { base_observation with idle_seconds = 0 } in
-  check bool "no signal blocks scheduled turn" false
+  check
+    bool
+    "no signal blocks scheduled turn"
+    false
     (WO.should_run_keeper_cycle ~meta obs);
   let decision = WO.keeper_cycle_decision ~meta obs in
-  check bool "decision records no-signal reason" true
+  check
+    bool
+    "decision records no-signal reason"
+    true
     (match decision.verdict with
-     | WO.Skip { reasons = (first, rest) } ->
-         List.exists (function WO.No_signal -> true | _ -> false)
-           (first :: rest)
+     | WO.Skip { reasons = first, rest } ->
+       List.exists
+         (function
+           | WO.No_signal -> true
+           | _ -> false)
+         (first :: rest)
      | WO.Run _ -> false)
+;;
 
 let test_scheduled_turn_respects_cooldown () =
   let meta =
     { minimal_meta with
-      proactive =
-        { enabled = true; idle_sec = 0; cooldown_sec = 300 };
-      runtime =
+      proactive = { enabled = true; idle_sec = 0; cooldown_sec = 300 }
+    ; runtime =
         { minimal_meta.runtime with
           proactive_rt =
             { minimal_meta.runtime.proactive_rt with
-              last_ts = Time_compat.now () -. 30.0;
-            };
-        };
+              last_ts = Time_compat.now () -. 30.0
+            }
+        }
     }
   in
-  check bool "cooldown blocks scheduled turn" false
+  check
+    bool
+    "cooldown blocks scheduled turn"
+    false
     (WO.should_run_keeper_cycle ~meta base_observation)
+;;
 
 let test_scheduled_turn_requires_idle_gate () =
   let meta =
-    {
-      minimal_meta with
-      proactive =
-        { enabled = true; idle_sec = 300; cooldown_sec = 60 };
-      runtime =
-        {
-          minimal_meta.runtime with
+    { minimal_meta with
+      proactive = { enabled = true; idle_sec = 300; cooldown_sec = 60 }
+    ; runtime =
+        { minimal_meta.runtime with
           proactive_rt =
             { minimal_meta.runtime.proactive_rt with
-              last_ts = Time_compat.now () -. 600.0;
-            };
-        };
+              last_ts = Time_compat.now () -. 600.0
+            }
+        }
     }
   in
   let obs = { base_observation with idle_seconds = 120 } in
-  check bool "idle gate blocks scheduled turn" false
+  check
+    bool
+    "idle gate blocks scheduled turn"
+    false
     (WO.should_run_keeper_cycle ~meta obs);
   let decision = WO.keeper_cycle_decision ~meta obs in
-  check bool "decision records idle wait reason" true
+  check
+    bool
+    "decision records idle wait reason"
+    true
     (match decision.verdict with
-     | WO.Skip { reasons = (first, rest)} ->
-         List.exists (function WO.Idle_gate_pending _ -> true | _ -> false)
-           (first :: rest)
+     | WO.Skip { reasons = first, rest } ->
+       List.exists
+         (function
+           | WO.Idle_gate_pending _ -> true
+           | _ -> false)
+         (first :: rest)
      | WO.Run _ -> false)
+;;
 
 let test_provider_cooldown_blocks_scheduled_turn_when_work_is_ready () =
   let meta =
@@ -975,16 +1134,15 @@ let test_provider_cooldown_blocks_scheduled_turn_when_work_is_ready () =
       current_task_id =
         (match Masc_mcp.Keeper_id.Task_id.of_string "task-456" with
          | Ok value -> Some value
-         | Error err -> fail ("task id parse failed: " ^ err));
-      proactive =
-        { enabled = true; idle_sec = 0; cooldown_sec = 60 };
-      runtime =
+         | Error err -> fail ("task id parse failed: " ^ err))
+    ; proactive = { enabled = true; idle_sec = 0; cooldown_sec = 60 }
+    ; runtime =
         { minimal_meta.runtime with
           proactive_rt =
             { minimal_meta.runtime.proactive_rt with
-              last_ts = Time_compat.now () -. 120.0;
-            };
-        };
+              last_ts = Time_compat.now () -. 120.0
+            }
+        }
     }
   in
   let decision =
@@ -994,15 +1152,24 @@ let test_provider_cooldown_blocks_scheduled_turn_when_work_is_ready () =
       base_observation
   in
   check bool "provider cooldown blocks scheduled turn" false decision.should_run;
-  check string "channel stays scheduled_autonomous" "scheduled_autonomous"
+  check
+    string
+    "channel stays scheduled_autonomous"
+    "scheduled_autonomous"
     (WO.channel_to_string decision.channel);
-  check bool "decision records provider cooldown wait reason" true
+  check
+    bool
+    "decision records provider cooldown wait reason"
+    true
     (match decision.verdict with
-     | WO.Skip { reasons = (first, rest) } ->
-         List.exists
-           (function WO.Provider_cooldown_pending { remaining_sec = 3599 } -> true | _ -> false)
-           (first :: rest)
+     | WO.Skip { reasons = first, rest } ->
+       List.exists
+         (function
+           | WO.Provider_cooldown_pending { remaining_sec = 3599 } -> true
+           | _ -> false)
+         (first :: rest)
      | WO.Run _ -> false)
+;;
 
 let test_provider_cooldown_keeps_scheduled_turn_open_when_fail_open_exists () =
   let meta =
@@ -1010,16 +1177,15 @@ let test_provider_cooldown_keeps_scheduled_turn_open_when_fail_open_exists () =
       current_task_id =
         (match Masc_mcp.Keeper_id.Task_id.of_string "task-789" with
          | Ok value -> Some value
-         | Error err -> fail ("task id parse failed: " ^ err));
-      proactive =
-        { enabled = true; idle_sec = 0; cooldown_sec = 60 };
-      runtime =
+         | Error err -> fail ("task id parse failed: " ^ err))
+    ; proactive = { enabled = true; idle_sec = 0; cooldown_sec = 60 }
+    ; runtime =
         { minimal_meta.runtime with
           proactive_rt =
             { minimal_meta.runtime.proactive_rt with
-              last_ts = Time_compat.now () -. 120.0;
-            };
-        };
+              last_ts = Time_compat.now () -. 120.0
+            }
+        }
     }
   in
   let decision =
@@ -1028,99 +1194,119 @@ let test_provider_cooldown_keeps_scheduled_turn_open_when_fail_open_exists () =
       ~meta
       base_observation
   in
-  check bool "provider cooldown keeps scheduled turn open when fallback exists"
-    true decision.should_run;
-  check bool "decision does not surface cooldown skip when fail-open exists"
+  check
+    bool
+    "provider cooldown keeps scheduled turn open when fallback exists"
+    true
+    decision.should_run;
+  check
+    bool
+    "decision does not surface cooldown skip when fail-open exists"
     false
     (match decision.verdict with
-     | WO.Skip { reasons = (first, rest) } ->
-         List.exists
-           (function WO.Provider_cooldown_pending _ -> true | _ -> false)
-           (first :: rest)
+     | WO.Skip { reasons = first, rest } ->
+       List.exists
+         (function
+           | WO.Provider_cooldown_pending _ -> true
+           | _ -> false)
+         (first :: rest)
      | WO.Run _ -> false)
+;;
 
 let test_effective_cooldown_no_decay_within_base () =
   (* Within the base cooldown period, no decay should apply. *)
   let result =
-    WO.effective_scheduled_autonomous_cooldown
-      ~base_cooldown:1800 ~since_last:900 ()
+    WO.effective_scheduled_autonomous_cooldown ~base_cooldown:1800 ~since_last:900 ()
   in
   check int "no decay within base" 1800 result
+;;
 
 let test_effective_cooldown_at_boundary () =
   (* Exactly at the base cooldown, no decay yet. *)
   let result =
-    WO.effective_scheduled_autonomous_cooldown
-      ~base_cooldown:1800 ~since_last:1800 ()
+    WO.effective_scheduled_autonomous_cooldown ~base_cooldown:1800 ~since_last:1800 ()
   in
   check int "no decay at boundary" 1800 result
+;;
 
 let test_effective_cooldown_first_decay () =
   (* One full extra period: cooldown halved. *)
   let result =
-    WO.effective_scheduled_autonomous_cooldown
-      ~base_cooldown:1800 ~since_last:3600 ()
+    WO.effective_scheduled_autonomous_cooldown ~base_cooldown:1800 ~since_last:3600 ()
   in
   check int "first decay halves cooldown" 900 result
+;;
 
 let test_effective_cooldown_second_decay () =
   (* Two extra periods: cooldown quartered. *)
   let result =
-    WO.effective_scheduled_autonomous_cooldown
-      ~base_cooldown:1800 ~since_last:5400 ()
+    WO.effective_scheduled_autonomous_cooldown ~base_cooldown:1800 ~since_last:5400 ()
   in
   check int "second decay quarters cooldown" 450 result
+;;
 
 let test_effective_cooldown_floor () =
   (* Four+ extra periods: cooldown at floor (300s default). *)
   let result =
-    WO.effective_scheduled_autonomous_cooldown
-      ~base_cooldown:1800 ~since_last:10800 ()
+    WO.effective_scheduled_autonomous_cooldown ~base_cooldown:1800 ~since_last:10800 ()
   in
   check int "decay floors at min_cooldown" 300 result
+;;
 
 let test_effective_cooldown_max_int () =
   (* max_int (first scheduled autonomous cycle ever): should hit floor immediately. *)
   let result =
-    WO.effective_scheduled_autonomous_cooldown
-      ~base_cooldown:1800 ~since_last:max_int ()
+    WO.effective_scheduled_autonomous_cooldown ~base_cooldown:1800 ~since_last:max_int ()
   in
   check int "max_int hits floor" 300 result
+;;
 
 let test_noop_backoff_doubles_cooldown () =
   let result =
     WO.effective_scheduled_autonomous_cooldown
-      ~base_cooldown:1800 ~since_last:900
-      ~consecutive_noop_count:1 ()
+      ~base_cooldown:1800
+      ~since_last:900
+      ~consecutive_noop_count:1
+      ()
   in
   (* 1 noop → 2x multiplier → effective base = 3600, since_last < 3600 *)
   check int "1 noop doubles effective base" 3600 result
+;;
 
 let test_noop_backoff_quadruples_cooldown () =
   let result =
     WO.effective_scheduled_autonomous_cooldown
-      ~base_cooldown:1800 ~since_last:900
-      ~consecutive_noop_count:2 ()
+      ~base_cooldown:1800
+      ~since_last:900
+      ~consecutive_noop_count:2
+      ()
   in
   (* 2 noops → 4x multiplier → effective base = 7200 *)
   check int "2 noops quadruples effective base" 7200 result
+;;
 
 let test_noop_backoff_caps_at_8x () =
   let result =
     WO.effective_scheduled_autonomous_cooldown
-      ~base_cooldown:1800 ~since_last:900
-      ~consecutive_noop_count:5 ()
+      ~base_cooldown:1800
+      ~since_last:900
+      ~consecutive_noop_count:5
+      ()
   in
   (* 5 noops → capped at 3 → 8x multiplier → effective base = 14400 *)
   check int "noop backoff caps at 8x" 14400 result
+;;
 
 let test_noop_backoff_zero_noops_unchanged () =
   let result =
     WO.effective_scheduled_autonomous_cooldown
-      ~base_cooldown:1800 ~since_last:900
-      ~consecutive_noop_count:0 ()
+      ~base_cooldown:1800
+      ~since_last:900
+      ~consecutive_noop_count:0
+      ()
   in
   check int "0 noops = no backoff" 1800 result
+;;
 
 let test_idle_decay_triggers_turn () =
   (* After extended idle, decay should make cooldown_elapsed true
@@ -1131,307 +1317,317 @@ let test_idle_decay_triggers_turn () =
       current_task_id =
         (match Masc_mcp.Keeper_id.Task_id.of_string "task-123" with
          | Ok value -> Some value
-         | Error err -> fail ("task id parse failed: " ^ err));
-      proactive =
-        { enabled = true; idle_sec = 0; cooldown_sec = 1800 };
-      runtime =
+         | Error err -> fail ("task id parse failed: " ^ err))
+    ; proactive = { enabled = true; idle_sec = 0; cooldown_sec = 1800 }
+    ; runtime =
         { minimal_meta.runtime with
-          consecutive_noop_count = 0;
-          proactive_rt =
+          consecutive_noop_count = 0
+        ; proactive_rt =
             { minimal_meta.runtime.proactive_rt with
-              consecutive_noop_count = 0;
-              last_ts = Time_compat.now () -. 4000.0;
-            };
-        };
+              consecutive_noop_count = 0
+            ; last_ts = Time_compat.now () -. 4000.0
+            }
+        }
     }
   in
-  check bool "idle decay triggers turn before base cooldown" true
+  check
+    bool
+    "idle decay triggers turn before base cooldown"
+    true
     (WO.keeper_cycle_decision
        ~provider_cooldown_remaining_sec:(fun ~cascade_name:_ -> None)
-       ~meta base_observation).should_run
+       ~meta
+       base_observation)
+      .should_run
+;;
 
 let test_scheduled_turn_decision_uses_backlog_acceleration () =
   let meta =
-    {
-      minimal_meta with
-      proactive =
-        { enabled = true; idle_sec = 60; cooldown_sec = 900 };
-      runtime =
-        {
-          minimal_meta.runtime with
+    { minimal_meta with
+      proactive = { enabled = true; idle_sec = 60; cooldown_sec = 900 }
+    ; runtime =
+        { minimal_meta.runtime with
           proactive_rt =
             { minimal_meta.runtime.proactive_rt with
-              last_ts = Time_compat.now () -. 320.0;
-            };
-        };
+              last_ts = Time_compat.now () -. 320.0
+            }
+        }
     }
   in
-  let obs =
-    {
-      base_observation with
-      idle_seconds = 120;
-      failed_task_count = 2;
-    }
-  in
+  let obs = { base_observation with idle_seconds = 120; failed_task_count = 2 } in
   let decision =
     WO.keeper_cycle_decision
       ~provider_cooldown_remaining_sec:(fun ~cascade_name:_ -> None)
-      ~meta obs
+      ~meta
+      obs
   in
   check bool "backlog acceleration opens scheduled turn" true decision.should_run;
-  check bool "marks actionable backlog" true
+  check
+    bool
+    "marks actionable backlog"
+    true
     (match decision.verdict with
-     | WO.Run { reasons = (first, rest)} ->
-         List.exists (function WO.Task_backlog _ -> true | _ -> false)
-           (first :: rest)
+     | WO.Run { reasons = first, rest } ->
+       List.exists
+         (function
+           | WO.Task_backlog _ -> true
+           | _ -> false)
+         (first :: rest)
      | WO.Skip _ -> false);
-  check bool "marks backlog cooldown elapsed" true
+  check
+    bool
+    "marks backlog cooldown elapsed"
+    true
     (match decision.verdict with
-     | WO.Run { reasons = (first, rest)} ->
-         List.mem WO.Task_reactive_cooldown_elapsed (first :: rest)
+     | WO.Run { reasons = first, rest } ->
+       List.mem WO.Task_reactive_cooldown_elapsed (first :: rest)
      | WO.Skip _ -> false)
+;;
 
 let test_scheduled_turn_ignores_unclaimable_backlog () =
   let meta =
-    {
-      minimal_meta with
-      proactive =
-        { enabled = true; idle_sec = 600; cooldown_sec = 900 };
-      runtime =
-        {
-          minimal_meta.runtime with
+    { minimal_meta with
+      proactive = { enabled = true; idle_sec = 600; cooldown_sec = 900 }
+    ; runtime =
+        { minimal_meta.runtime with
           proactive_rt =
             { minimal_meta.runtime.proactive_rt with
-              last_ts = Time_compat.now () -. 320.0;
-            };
-        };
+              last_ts = Time_compat.now () -. 320.0
+            }
+        }
     }
   in
   let obs =
-    {
-      base_observation with
-      idle_seconds = 120;
-      unclaimed_task_count = 3;
-      claimable_task_count = 0;
-      backlog_updated_since_last_scheduled_autonomous = true;
+    { base_observation with
+      idle_seconds = 120
+    ; unclaimed_task_count = 3
+    ; claimable_task_count = 0
+    ; backlog_updated_since_last_scheduled_autonomous = true
     }
   in
   let decision =
     WO.keeper_cycle_decision
       ~provider_cooldown_remaining_sec:(fun ~cascade_name:_ -> None)
-      ~meta obs
+      ~meta
+      obs
   in
-  check bool "absolute-only backlog does not wake keeper" false
-    decision.should_run;
-  check bool "no task backlog reason for unclaimable backlog" true
+  check bool "absolute-only backlog does not wake keeper" false decision.should_run;
+  check
+    bool
+    "no task backlog reason for unclaimable backlog"
+    true
     (match decision.verdict with
-     | WO.Skip { reasons = (first, rest)} ->
-         List.exists (function WO.No_signal -> true | _ -> false)
-           (first :: rest)
+     | WO.Skip { reasons = first, rest } ->
+       List.exists
+         (function
+           | WO.No_signal -> true
+           | _ -> false)
+         (first :: rest)
      | WO.Run _ -> false)
+;;
 
 let test_verdict_reasons_to_strings_uses_structured_run_tags () =
   let verdict =
     WO.Run
-      {
-        reasons =
-          ( WO.Scheduled_autonomous_turn,
-            [
-              WO.Idle_cooldown_elapsed { idle_sec = 120; cooldown = 900 };
-              WO.Cooldown_elapsed;
-              WO.Task_backlog { unclaimed = 1; failed = 2 };
-              WO.Task_reactive_cooldown_elapsed;
-            ] );
+      { reasons =
+          ( WO.Scheduled_autonomous_turn
+          , [ WO.Idle_cooldown_elapsed { idle_sec = 120; cooldown = 900 }
+            ; WO.Cooldown_elapsed
+            ; WO.Task_backlog { unclaimed = 1; failed = 2 }
+            ; WO.Task_reactive_cooldown_elapsed
+            ] )
       }
   in
-  check (list string) "structured run tags"
-    [ "scheduled_autonomous_turn";
-      "idle_cooldown_elapsed";
-      "cooldown_elapsed";
-      "task_backlog";
-      "task_reactive_cooldown_elapsed" ]
+  check
+    (list string)
+    "structured run tags"
+    [ "scheduled_autonomous_turn"
+    ; "idle_cooldown_elapsed"
+    ; "cooldown_elapsed"
+    ; "task_backlog"
+    ; "task_reactive_cooldown_elapsed"
+    ]
     (WO.verdict_reasons_to_strings verdict)
+;;
 
 let test_verdict_reasons_to_strings_uses_structured_skip_tags () =
   let idle_gate_verdict =
-    WO.Skip
-      {
-        reasons =
-          ( WO.Idle_gate_pending { remaining_sec = 180 }, [] );
-      }
+    WO.Skip { reasons = WO.Idle_gate_pending { remaining_sec = 180 }, [] }
   in
   let cooldown_verdict =
-    WO.Skip
-      {
-        reasons =
-          ( WO.Cooldown_pending { remaining_sec = 60 }, [] );
-      }
+    WO.Skip { reasons = WO.Cooldown_pending { remaining_sec = 60 }, [] }
   in
   let provider_cooldown_verdict =
-    WO.Skip
-      {
-        reasons =
-          ( WO.Provider_cooldown_pending { remaining_sec = 3599 }, [] );
-      }
+    WO.Skip { reasons = WO.Provider_cooldown_pending { remaining_sec = 3599 }, [] }
   in
-  check (list string) "structured idle-gate skip tags"
+  check
+    (list string)
+    "structured idle-gate skip tags"
     [ "idle_gate_pending" ]
     (WO.verdict_reasons_to_strings idle_gate_verdict);
-  check (list string) "structured cooldown skip tags"
+  check
+    (list string)
+    "structured cooldown skip tags"
     [ "cooldown_pending" ]
     (WO.verdict_reasons_to_strings cooldown_verdict);
-  check (list string) "structured provider cooldown skip tags"
+  check
+    (list string)
+    "structured provider cooldown skip tags"
     [ "provider_cooldown_pending" ]
     (WO.verdict_reasons_to_strings provider_cooldown_verdict)
+;;
 
 let test_paused_keeper_blocks_turns_even_with_reactive_signal () =
   let meta = { minimal_meta with paused = true } in
-  let obs =
-    { base_observation with pending_mentions = [ ("alice", "@keeper wake up") ] }
-  in
+  let obs = { base_observation with pending_mentions = [ "alice", "@keeper wake up" ] } in
   let decision = WO.unified_turn_decision ~meta obs in
   check bool "paused keeper does not run" false decision.should_run;
-  check string "channel stays reactive" "reactive"
-    (WO.channel_to_string decision.channel);
-  check (list string) "paused reason is surfaced"
+  check string "channel stays reactive" "reactive" (WO.channel_to_string decision.channel);
+  check
+    (list string)
+    "paused reason is surfaced"
     [ "keeper_paused" ]
     (WO.verdict_reasons_to_strings decision.verdict)
+;;
 
 let test_pending_approval_blocks_turns_until_resolved () =
-  Eio_main.run @@ fun _env ->
+  Eio_main.run
+  @@ fun _env ->
   let reactive_obs =
-    {
-      base_observation with
-      pending_mentions = [ ("alice", "@keeper continue") ];
-    }
+    { base_observation with pending_mentions = [ "alice", "@keeper continue" ] }
   in
   let id =
     AQ.submit_pending
       ~keeper_name:minimal_meta.name
       ~tool_name:"keeper_continue_after_partial_commit"
-      ~input:(`Assoc [ ("kind", `String "continue_gate_required") ])
+      ~input:(`Assoc [ "kind", `String "continue_gate_required" ])
       ~risk_level:AQ.Critical
       ~on_resolution:(fun _ -> ())
       ()
   in
   let decision = WO.unified_turn_decision ~meta:minimal_meta reactive_obs in
   check bool "approval pending blocks turn" false decision.should_run;
-  check (list string) "approval pending reason is surfaced"
+  check
+    (list string)
+    "approval pending reason is surfaced"
     [ "approval_pending" ]
     (WO.verdict_reasons_to_strings decision.verdict);
   match AQ.resolve ~id ~decision:Agent_sdk.Hooks.Approve with
   | Ok () ->
     let resumed = WO.unified_turn_decision ~meta:minimal_meta reactive_obs in
     check bool "approval resolve re-opens reactive scheduling" true resumed.should_run;
-    check string "resolved approval restores reactive channel" "reactive"
+    check
+      string
+      "resolved approval restores reactive channel"
+      "reactive"
       (WO.channel_to_string resumed.channel)
   | Error err -> Alcotest.fail ("resolve failed: " ^ AQ.resolve_error_to_string err)
+;;
 
 let test_task_reactive_cooldown_floor_never_hits_zero () =
   with_env "MASC_KEEPER_PROACTIVE_TASK_MIN_COOLDOWN_SEC" "0" (fun () ->
     let meta =
-      {
-        minimal_meta with
-        proactive =
-          { enabled = true; idle_sec = 60; cooldown_sec = 900 };
-        runtime =
-          {
-            minimal_meta.runtime with
+      { minimal_meta with
+        proactive = { enabled = true; idle_sec = 60; cooldown_sec = 900 }
+      ; runtime =
+          { minimal_meta.runtime with
             proactive_rt =
               { minimal_meta.runtime.proactive_rt with
-                last_ts = Time_compat.now () -. 320.0;
-              };
-          };
+                last_ts = Time_compat.now () -. 320.0
+              }
+          }
       }
     in
-    let obs =
-      {
-        base_observation with
-        idle_seconds = 120;
-        failed_task_count = 1;
-      }
-    in
+    let obs = { base_observation with idle_seconds = 120; failed_task_count = 1 } in
     let decision =
       WO.keeper_cycle_decision
         ~provider_cooldown_remaining_sec:(fun ~cascade_name:_ -> None)
-        ~meta obs
+        ~meta
+        obs
     in
-    check (option int) "task reactive cooldown clamps to positive floor" (Some 300)
+    check
+      (option int)
+      "task reactive cooldown clamps to positive floor"
+      (Some 300)
       decision.task_reactive_cooldown)
+;;
 
 let test_task_backlog_cooldown_applies_noop_backoff_once () =
   with_env "MASC_KEEPER_PROACTIVE_TASK_MIN_COOLDOWN_SEC" "0" (fun () ->
     let meta =
-      {
-        minimal_meta with
-        proactive =
-          { enabled = true; idle_sec = 120; cooldown_sec = 300 };
-        runtime =
-          {
-            minimal_meta.runtime with
-            consecutive_noop_count = 16;
-            proactive_rt =
+      { minimal_meta with
+        proactive = { enabled = true; idle_sec = 120; cooldown_sec = 300 }
+      ; runtime =
+          { minimal_meta.runtime with
+            consecutive_noop_count = 16
+          ; proactive_rt =
               { minimal_meta.runtime.proactive_rt with
-                consecutive_noop_count = 3;
-                last_ts = Time_compat.now () -. 1000.0;
-              };
-          };
+                consecutive_noop_count = 3
+              ; last_ts = Time_compat.now () -. 1000.0
+              }
+          }
       }
     in
     let obs =
-      {
-        base_observation with
-        idle_seconds = 1000;
-        unclaimed_task_count = 1;
-        claimable_task_count = 1;
+      { base_observation with
+        idle_seconds = 1000
+      ; unclaimed_task_count = 1
+      ; claimable_task_count = 1
       }
     in
     let decision =
       WO.keeper_cycle_decision
         ~provider_cooldown_remaining_sec:(fun ~cascade_name:_ -> None)
-        ~meta obs
+        ~meta
+        obs
     in
-    check (option int) "cooldown uses proactive noop backoff once" (Some 2400)
+    check
+      (option int)
+      "cooldown uses proactive noop backoff once"
+      (Some 2400)
       decision.effective_cooldown;
-    check (option int) "task cooldown stays responsive" (Some 800)
+    check
+      (option int)
+      "task cooldown stays responsive"
+      (Some 800)
       decision.task_reactive_cooldown;
     check bool "task backlog can schedule after task cooldown" true decision.should_run)
+;;
 
 let test_scheduled_turn_decision_runs_immediately_on_fresh_backlog_update () =
   let meta =
-    {
-      minimal_meta with
-      proactive =
-        { enabled = true; idle_sec = 60; cooldown_sec = 60 };
-      runtime =
-        {
-          minimal_meta.runtime with
+    { minimal_meta with
+      proactive = { enabled = true; idle_sec = 60; cooldown_sec = 60 }
+    ; runtime =
+        { minimal_meta.runtime with
           proactive_rt =
-            { minimal_meta.runtime.proactive_rt with
-              last_ts = Time_compat.now ();
-            };
-        };
+            { minimal_meta.runtime.proactive_rt with last_ts = Time_compat.now () }
+        }
     }
   in
   let obs =
-    {
-      base_observation with
-      unclaimed_task_count = 1;
-      claimable_task_count = 1;
-      backlog_updated_since_last_scheduled_autonomous = true;
+    { base_observation with
+      unclaimed_task_count = 1
+    ; claimable_task_count = 1
+    ; backlog_updated_since_last_scheduled_autonomous = true
     }
   in
   let decision =
     WO.keeper_cycle_decision
       ~provider_cooldown_remaining_sec:(fun ~cascade_name:_ -> None)
-      ~meta obs
+      ~meta
+      obs
   in
   check bool "fresh backlog bypasses cooldown" true decision.should_run;
-  check bool "backlog emits reactive cooldown tag" true
+  check
+    bool
+    "backlog emits reactive cooldown tag"
+    true
     (match decision.verdict with
-     | WO.Run { reasons = (first, rest) } ->
-         List.mem WO.Task_reactive_cooldown_elapsed (first :: rest)
+     | WO.Run { reasons = first, rest } ->
+       List.mem WO.Task_reactive_cooldown_elapsed (first :: rest)
      | WO.Skip _ -> false)
+;;
 
 (* Phase 1 — Bootstrap bypass *)
 
@@ -1441,87 +1637,93 @@ let test_bootstrap_turn_fires_when_never_started () =
      not elapsed.  This breaks the bootstrap deadlock. *)
   let meta =
     { minimal_meta with
-      proactive =
-        { enabled = true; idle_sec = 300; cooldown_sec = 1800 };
-      runtime =
+      proactive = { enabled = true; idle_sec = 300; cooldown_sec = 1800 }
+    ; runtime =
         { minimal_meta.runtime with
-          proactive_rt =
-            { minimal_meta.runtime.proactive_rt with
-              last_ts = 0.0;
-            };
-        };
+          proactive_rt = { minimal_meta.runtime.proactive_rt with last_ts = 0.0 }
+        }
     }
   in
   let obs = { base_observation with idle_seconds = 0 } in
   let decision =
     WO.keeper_cycle_decision
       ~provider_cooldown_remaining_sec:(fun ~cascade_name:_ -> None)
-      ~meta obs
+      ~meta
+      obs
   in
   check bool "bootstrap: should_run=true when never started" true decision.should_run;
-  check bool "bootstrap: Never_started reason emitted" true
+  check
+    bool
+    "bootstrap: Never_started reason emitted"
+    true
     (match decision.verdict with
-     | WO.Run { reasons = (first, rest) } ->
-         List.mem WO.Never_started (first :: rest)
+     | WO.Run { reasons = first, rest } -> List.mem WO.Never_started (first :: rest)
      | WO.Skip _ -> false);
-  check int "bootstrap: since_last_scheduled_autonomous = max_int" max_int
+  check
+    int
+    "bootstrap: since_last_scheduled_autonomous = max_int"
+    max_int
     (Option.value ~default:(-1) decision.since_last_scheduled_autonomous)
+;;
 
 let test_bootstrap_turn_emits_scheduled_autonomous_channel () =
   let meta =
     { minimal_meta with
-      proactive =
-        { enabled = true; idle_sec = 600; cooldown_sec = 900 };
-      runtime =
+      proactive = { enabled = true; idle_sec = 600; cooldown_sec = 900 }
+    ; runtime =
         { minimal_meta.runtime with
-          proactive_rt =
-            { minimal_meta.runtime.proactive_rt with
-              last_ts = 0.0;
-            };
-        };
+          proactive_rt = { minimal_meta.runtime.proactive_rt with last_ts = 0.0 }
+        }
     }
   in
   let obs = { base_observation with idle_seconds = 0 } in
   let decision =
     WO.keeper_cycle_decision
       ~provider_cooldown_remaining_sec:(fun ~cascade_name:_ -> None)
-      ~meta obs
+      ~meta
+      obs
   in
-  check string "bootstrap channel is scheduled_autonomous" "scheduled_autonomous"
+  check
+    string
+    "bootstrap channel is scheduled_autonomous"
+    "scheduled_autonomous"
     (WO.channel_to_string decision.channel)
+;;
 
 let test_provider_cooldown_blocks_bootstrap_turn () =
   let meta =
     { (Masc_mcp.Keeper_types.set_cascade_name
          Masc_mcp.(Keeper_config.default_cascade_name ())
-         minimal_meta) with
-      proactive =
-        { enabled = true; idle_sec = 300; cooldown_sec = 1800 };
-      runtime =
+         minimal_meta)
+      with
+      proactive = { enabled = true; idle_sec = 300; cooldown_sec = 1800 }
+    ; runtime =
         { minimal_meta.runtime with
-          proactive_rt =
-            { minimal_meta.runtime.proactive_rt with
-              last_ts = 0.0;
-            };
-        };
+          proactive_rt = { minimal_meta.runtime.proactive_rt with last_ts = 0.0 }
+        }
     }
   in
   let obs = { base_observation with idle_seconds = 0 } in
   let decision =
     WO.keeper_cycle_decision
       ~provider_cooldown_remaining_sec:(fun ~cascade_name:_ -> Some 3599)
-      ~meta obs
+      ~meta
+      obs
   in
   check bool "provider cooldown blocks bootstrap turn" false decision.should_run;
-  check bool "bootstrap cooldown skip reason emitted" true
+  check
+    bool
+    "bootstrap cooldown skip reason emitted"
+    true
     (match decision.verdict with
-     | WO.Skip { reasons = (first, rest) } ->
-         List.exists
-           (function
-             | WO.Provider_cooldown_pending { remaining_sec = 3599 } -> true
-             | _ -> false)
-           (first :: rest)
+     | WO.Skip { reasons = first, rest } ->
+       List.exists
+         (function
+           | WO.Provider_cooldown_pending { remaining_sec = 3599 } -> true
+           | _ -> false)
+         (first :: rest)
      | WO.Run _ -> false)
+;;
 
 (* Phase 2 — Minimum proactive cadence *)
 
@@ -1532,65 +1734,77 @@ let test_min_interval_fires_without_work_signal () =
   with_env "MASC_KEEPER_PROACTIVE_MIN_INTERVAL_SEC" "900" (fun () ->
     let meta =
       { minimal_meta with
-        proactive =
-          { enabled = true; idle_sec = 0; cooldown_sec = 600 };
-        runtime =
+        proactive = { enabled = true; idle_sec = 0; cooldown_sec = 600 }
+      ; runtime =
           { minimal_meta.runtime with
             proactive_rt =
               { minimal_meta.runtime.proactive_rt with
                 (* 1000s > 900s min_interval, so the elapsed condition triggers *)
-                last_ts = Time_compat.now () -. 1000.0;
-              };
-          };
+                last_ts = Time_compat.now () -. 1000.0
+              }
+          }
       }
     in
     let obs = { base_observation with idle_seconds = 0 } in
     let decision =
       WO.keeper_cycle_decision
         ~provider_cooldown_remaining_sec:(fun ~cascade_name:_ -> None)
-        ~meta obs
+        ~meta
+        obs
     in
     check bool "min interval elapsed fires turn" true decision.should_run;
-    check bool "Min_interval_elapsed reason emitted" true
+    check
+      bool
+      "Min_interval_elapsed reason emitted"
+      true
       (match decision.verdict with
-       | WO.Run { reasons = (first, rest) } ->
-           List.mem WO.Min_interval_elapsed (first :: rest)
+       | WO.Run { reasons = first, rest } ->
+         List.mem WO.Min_interval_elapsed (first :: rest)
        | WO.Skip _ -> false))
+;;
 
 let test_min_interval_turn_is_not_tagged_entropic () =
   with_env "MASC_KEEPER_PROACTIVE_MIN_INTERVAL_SEC" "900" (fun () ->
-    Fun.protect ~finally:Random.self_init @@ fun () ->
+    Fun.protect ~finally:Random.self_init
+    @@ fun () ->
     Random.init 15;
     let meta =
       { minimal_meta with
-        proactive =
-          { enabled = true; idle_sec = 0; cooldown_sec = 600 };
-        runtime =
+        proactive = { enabled = true; idle_sec = 0; cooldown_sec = 600 }
+      ; runtime =
           { minimal_meta.runtime with
             proactive_rt =
               { minimal_meta.runtime.proactive_rt with
-                last_ts = Time_compat.now () -. 1000.0;
-              };
-          };
+                last_ts = Time_compat.now () -. 1000.0
+              }
+          }
       }
     in
     let obs = { base_observation with idle_seconds = 0 } in
     let decision =
       WO.keeper_cycle_decision
         ~provider_cooldown_remaining_sec:(fun ~cascade_name:_ -> None)
-        ~meta obs
+        ~meta
+        obs
     in
     check bool "min interval elapsed fires turn" true decision.should_run;
-    check bool "Min_interval_elapsed reason emitted" true
+    check
+      bool
+      "Min_interval_elapsed reason emitted"
+      true
       (match decision.verdict with
-       | WO.Run { reasons = (first, rest) } ->
-           List.mem WO.Min_interval_elapsed (first :: rest)
+       | WO.Run { reasons = first, rest } ->
+         List.mem WO.Min_interval_elapsed (first :: rest)
        | WO.Skip _ -> false);
-    check bool "Min_interval_elapsed is not tagged as entropic" false
+    check
+      bool
+      "Min_interval_elapsed is not tagged as entropic"
+      false
       (match decision.verdict with
-       | WO.Run { reasons = (first, rest) } ->
-           List.mem WO.Entropic_oscillation (first :: rest)
+       | WO.Run { reasons = first, rest } ->
+         List.mem WO.Entropic_oscillation (first :: rest)
        | WO.Skip _ -> false))
+;;
 
 let test_min_interval_does_not_fire_before_elapsed () =
   (* With since_last = 500s and min_interval = 900s, the keeper should
@@ -1598,31 +1812,38 @@ let test_min_interval_does_not_fire_before_elapsed () =
   with_env "MASC_KEEPER_PROACTIVE_MIN_INTERVAL_SEC" "900" (fun () ->
     let meta =
       { minimal_meta with
-        proactive =
-          { enabled = true; idle_sec = 0; cooldown_sec = 600 };
-        runtime =
+        proactive = { enabled = true; idle_sec = 0; cooldown_sec = 600 }
+      ; runtime =
           { minimal_meta.runtime with
             proactive_rt =
               { minimal_meta.runtime.proactive_rt with
                 (* 500s < 900s min_interval, so not-yet-elapsed condition holds *)
-                last_ts = Time_compat.now () -. 500.0;
-              };
-          };
+                last_ts = Time_compat.now () -. 500.0
+              }
+          }
       }
     in
     let obs = { base_observation with idle_seconds = 0 } in
     let decision =
       WO.keeper_cycle_decision
         ~provider_cooldown_remaining_sec:(fun ~cascade_name:_ -> None)
-        ~meta obs
+        ~meta
+        obs
     in
     check bool "min interval not yet elapsed: should_run=false" false decision.should_run;
-    check bool "No_signal reason present when interval pending" true
+    check
+      bool
+      "No_signal reason present when interval pending"
+      true
       (match decision.verdict with
-       | WO.Skip { reasons = (first, rest) } ->
-           List.exists (function WO.No_signal -> true | _ -> false)
-             (first :: rest)
+       | WO.Skip { reasons = first, rest } ->
+         List.exists
+           (function
+             | WO.No_signal -> true
+             | _ -> false)
+           (first :: rest)
        | WO.Run _ -> false))
+;;
 
 let test_min_interval_never_fires_for_bootstrap () =
   (* The Min_interval_elapsed path must not fire when is_bootstrap = true
@@ -1631,284 +1852,409 @@ let test_min_interval_never_fires_for_bootstrap () =
   with_env "MASC_KEEPER_PROACTIVE_MIN_INTERVAL_SEC" "900" (fun () ->
     let meta =
       { minimal_meta with
-        proactive =
-          { enabled = true; idle_sec = 0; cooldown_sec = 600 };
-        runtime =
+        proactive = { enabled = true; idle_sec = 0; cooldown_sec = 600 }
+      ; runtime =
           { minimal_meta.runtime with
-            proactive_rt =
-              { minimal_meta.runtime.proactive_rt with
-                last_ts = 0.0;
-              };
-          };
+            proactive_rt = { minimal_meta.runtime.proactive_rt with last_ts = 0.0 }
+          }
       }
     in
     let obs = { base_observation with idle_seconds = 0 } in
     let decision =
       WO.keeper_cycle_decision
         ~provider_cooldown_remaining_sec:(fun ~cascade_name:_ -> None)
-        ~meta obs
+        ~meta
+        obs
     in
-    check bool "bootstrap does not emit Min_interval_elapsed" false
+    check
+      bool
+      "bootstrap does not emit Min_interval_elapsed"
+      false
       (match decision.verdict with
-       | WO.Run { reasons = (first, rest) } ->
-           List.mem WO.Min_interval_elapsed (first :: rest)
+       | WO.Run { reasons = first, rest } ->
+         List.mem WO.Min_interval_elapsed (first :: rest)
        | WO.Skip _ -> false);
-    check bool "bootstrap emits Never_started" true
+    check
+      bool
+      "bootstrap emits Never_started"
+      true
       (match decision.verdict with
-       | WO.Run { reasons = (first, rest) } ->
-           List.mem WO.Never_started (first :: rest)
+       | WO.Run { reasons = first, rest } -> List.mem WO.Never_started (first :: rest)
        | WO.Skip _ -> false))
+;;
 
 let test_provider_cooldown_blocks_min_interval_turn () =
   with_env "MASC_KEEPER_PROACTIVE_MIN_INTERVAL_SEC" "900" (fun () ->
     let meta =
       { (Masc_mcp.Keeper_types.set_cascade_name
            Masc_mcp.(Keeper_config.default_cascade_name ())
-           minimal_meta) with
-        proactive =
-          { enabled = true; idle_sec = 0; cooldown_sec = 600 };
-        runtime =
+           minimal_meta)
+        with
+        proactive = { enabled = true; idle_sec = 0; cooldown_sec = 600 }
+      ; runtime =
           { minimal_meta.runtime with
             proactive_rt =
               { minimal_meta.runtime.proactive_rt with
-                last_ts = Time_compat.now () -. 1000.0;
-              };
-          };
+                last_ts = Time_compat.now () -. 1000.0
+              }
+          }
       }
     in
     let obs = { base_observation with idle_seconds = 0 } in
     let decision =
       WO.keeper_cycle_decision
         ~provider_cooldown_remaining_sec:(fun ~cascade_name:_ -> Some 3599)
-        ~meta obs
+        ~meta
+        obs
     in
     check bool "provider cooldown blocks min-interval turn" false decision.should_run;
-    check bool "min-interval cooldown skip reason emitted" true
+    check
+      bool
+      "min-interval cooldown skip reason emitted"
+      true
       (match decision.verdict with
-       | WO.Skip { reasons = (first, rest) } ->
-           List.exists
-             (function
-               | WO.Provider_cooldown_pending { remaining_sec = 3599 } -> true
-               | _ -> false)
-             (first :: rest)
+       | WO.Skip { reasons = first, rest } ->
+         List.exists
+           (function
+             | WO.Provider_cooldown_pending { remaining_sec = 3599 } -> true
+             | _ -> false)
+           (first :: rest)
        | WO.Run _ -> false))
+;;
 
 let test_runtime_trust_snapshot_tolerates_null_telemetry () =
-  Eio_main.run @@ fun env ->
+  Eio_main.run
+  @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
   let base_dir = temp_dir () in
   Fun.protect
     ~finally:(fun () -> cleanup_dir base_dir)
     (fun () ->
-      with_test_runtime_roots base_dir @@ fun () ->
-      let config = Masc_mcp.Coord.default_config base_dir in
-      let keeper_name = "runtime-trust-null-telemetry" in
-      let meta = { minimal_meta with name = keeper_name } in
-      let decision_path = Keeper_types.keeper_decision_log_path config keeper_name in
-      Keeper_types.mkdir_p (Filename.dirname decision_path);
-      Masc_mcp.Keeper_types_support.append_jsonl_line
-        decision_path
-        (`Assoc [ ("telemetry", `Null) ]);
-      let snapshot =
-        Masc_mcp.Keeper_runtime_trust_snapshot.snapshot_json ~config ~meta
-      in
-	      check bool "selected model stays null" true
-	        Yojson.Safe.Util.(snapshot |> member "selected_model" = `Null))
+       with_test_runtime_roots base_dir
+       @@ fun () ->
+       let config = Masc_mcp.Coord.default_config base_dir in
+       let keeper_name = "runtime-trust-null-telemetry" in
+       let meta = { minimal_meta with name = keeper_name } in
+       let decision_path = Keeper_types.keeper_decision_log_path config keeper_name in
+       Keeper_types.mkdir_p (Filename.dirname decision_path);
+       Masc_mcp.Keeper_types_support.append_jsonl_line
+         decision_path
+         (`Assoc [ "telemetry", `Null ]);
+       let snapshot =
+         Masc_mcp.Keeper_runtime_trust_snapshot.snapshot_json ~config ~meta
+       in
+       check
+         bool
+         "selected model stays null"
+         true
+         Yojson.Safe.Util.(snapshot |> member "selected_model" = `Null))
+;;
 
 let test_runtime_trust_snapshot_surfaces_terminal_reason () =
-  Eio_main.run @@ fun env ->
+  Eio_main.run
+  @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
   let base_dir = temp_dir () in
   Fun.protect
     ~finally:(fun () -> cleanup_dir base_dir)
     (fun () ->
-      with_test_runtime_roots base_dir @@ fun () ->
-      let config = Masc_mcp.Coord.default_config base_dir in
-      let keeper_name = "runtime-trust-terminal-reason" in
-      let meta =
-        {
-          minimal_meta with
-          name = keeper_name;
-          active_goal_ids = [ "goal-terminal-reason" ];
-        }
-      in
-      let decision_path = Keeper_types.keeper_decision_log_path config keeper_name in
-      Keeper_types.mkdir_p (Filename.dirname decision_path);
-      Masc_mcp.Keeper_types_support.append_jsonl_line
-        decision_path
-        (`Assoc
-          [
-            ("ts_unix", `Float 1_712_000_000.0);
-            ("trace_id", `String "trace-terminal-reason");
-            ("turn_id", `Int 7);
-            ("task_id", `String "task-terminal-reason");
-            ("goal_ids", `List [ `String "goal-terminal-reason" ]);
-            ( "terminal_reason",
-              `Assoc
-                [
-                  ("code", `String "gh_repo_context_missing_worktree");
-                  ("source", `String "legacy_error_text");
-                  ("severity", `String "warn");
-                  ( "summary",
-                    `String "GitHub command blocked because the active task has no linked worktree" );
-                  ("next_action", `String "create_or_link_worktree");
-                ] );
-          ]);
-      let snapshot =
-        Masc_mcp.Keeper_runtime_trust_snapshot.snapshot_json ~config ~meta
-      in
-      let open Yojson.Safe.Util in
-      check string "latest terminal code" "gh_repo_context_missing_worktree"
-        (snapshot |> member "latest_terminal_reason" |> member "code" |> to_string);
-      check string "latest next action" "create_or_link_worktree"
-        (snapshot |> member "latest_next_action" |> to_string);
-      let timeline = snapshot |> member "causal_timeline" |> to_list in
-      check bool "terminal reason event present" true
-        (List.exists
-           (fun event ->
-             event |> member "kind" |> to_string = "terminal_reason"
-             && event |> member "next_human_action" |> to_string = "create_or_link_worktree")
-           timeline))
+       with_test_runtime_roots base_dir
+       @@ fun () ->
+       let config = Masc_mcp.Coord.default_config base_dir in
+       let keeper_name = "runtime-trust-terminal-reason" in
+       let meta =
+         { minimal_meta with
+           name = keeper_name
+         ; active_goal_ids = [ "goal-terminal-reason" ]
+         }
+       in
+       let decision_path = Keeper_types.keeper_decision_log_path config keeper_name in
+       Keeper_types.mkdir_p (Filename.dirname decision_path);
+       Masc_mcp.Keeper_types_support.append_jsonl_line
+         decision_path
+         (`Assoc
+             [ "ts_unix", `Float 1_712_000_000.0
+             ; "trace_id", `String "trace-terminal-reason"
+             ; "turn_id", `Int 7
+             ; "task_id", `String "task-terminal-reason"
+             ; "goal_ids", `List [ `String "goal-terminal-reason" ]
+             ; ( "terminal_reason"
+               , `Assoc
+                   [ "code", `String "gh_repo_context_missing_worktree"
+                   ; "source", `String "legacy_error_text"
+                   ; "severity", `String "warn"
+                   ; ( "summary"
+                     , `String
+                         "GitHub command blocked because the active task has no linked \
+                          worktree" )
+                   ; "next_action", `String "create_or_link_worktree"
+                   ] )
+             ]);
+       let snapshot =
+         Masc_mcp.Keeper_runtime_trust_snapshot.snapshot_json ~config ~meta
+       in
+       let open Yojson.Safe.Util in
+       check
+         string
+         "latest terminal code"
+         "gh_repo_context_missing_worktree"
+         (snapshot |> member "latest_terminal_reason" |> member "code" |> to_string);
+       check
+         string
+         "latest next action"
+         "create_or_link_worktree"
+         (snapshot |> member "latest_next_action" |> to_string);
+       let timeline = snapshot |> member "causal_timeline" |> to_list in
+       check
+         bool
+         "terminal reason event present"
+         true
+         (List.exists
+            (fun event ->
+               event |> member "kind" |> to_string = "terminal_reason"
+               && event
+                  |> member "next_human_action"
+                  |> to_string
+                  = "create_or_link_worktree")
+            timeline))
+;;
 
 let test_runtime_trust_snapshot_reads_terminal_reason_code_alias () =
-  Eio_main.run @@ fun env ->
+  Eio_main.run
+  @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
   let base_dir = temp_dir () in
   Fun.protect
     ~finally:(fun () -> cleanup_dir base_dir)
     (fun () ->
-      with_test_runtime_roots base_dir @@ fun () ->
-      let config = Masc_mcp.Coord.default_config base_dir in
-      let keeper_name = "runtime-trust-terminal-code-alias" in
-      let meta = { minimal_meta with name = keeper_name } in
-      let decision_path = Keeper_types.keeper_decision_log_path config keeper_name in
-      Keeper_types.mkdir_p (Filename.dirname decision_path);
-      Masc_mcp.Keeper_types_support.append_jsonl_line
-        decision_path
-        (`Assoc
-          [
-            ("ts_unix", `Float 1_712_000_010.0);
-            ("trace_id", `String "trace-terminal-code-alias");
-            ("turn_id", `Int 9);
-            ("terminal_reason_code", `String "provider_error");
-          ]);
-      let snapshot =
-        Masc_mcp.Keeper_runtime_trust_snapshot.snapshot_json ~config ~meta
-      in
-      let open Yojson.Safe.Util in
-      check string "latest terminal code alias" "provider_error"
-        (snapshot |> member "latest_terminal_reason" |> member "code" |> to_string);
-      let timeline = snapshot |> member "causal_timeline" |> to_list in
-      check bool "terminal reason alias event present" true
-        (List.exists
-           (fun event ->
-             event |> member "kind" |> to_string = "terminal_reason"
-             (* RFC-0047 PR-3 (#14271) removed the legacy
+       with_test_runtime_roots base_dir
+       @@ fun () ->
+       let config = Masc_mcp.Coord.default_config base_dir in
+       let keeper_name = "runtime-trust-terminal-code-alias" in
+       let meta = { minimal_meta with name = keeper_name } in
+       let decision_path = Keeper_types.keeper_decision_log_path config keeper_name in
+       Keeper_types.mkdir_p (Filename.dirname decision_path);
+       Masc_mcp.Keeper_types_support.append_jsonl_line
+         decision_path
+         (`Assoc
+             [ "ts_unix", `Float 1_712_000_010.0
+             ; "trace_id", `String "trace-terminal-code-alias"
+             ; "turn_id", `Int 9
+             ; "terminal_reason_code", `String "provider_error"
+             ]);
+       let snapshot =
+         Masc_mcp.Keeper_runtime_trust_snapshot.snapshot_json ~config ~meta
+       in
+       let open Yojson.Safe.Util in
+       check
+         string
+         "latest terminal code alias"
+         "provider_error"
+         (snapshot |> member "latest_terminal_reason" |> member "code" |> to_string);
+       let timeline = snapshot |> member "causal_timeline" |> to_list in
+       check
+         bool
+         "terminal reason alias event present"
+         true
+         (List.exists
+            (fun event ->
+               event |> member "kind" |> to_string = "terminal_reason"
+               (* RFC-0047 PR-3 (#14271) removed the legacy
                 "provider_error" alias special-case in
                 [Keeper_turn_disposition.summary]; the wire string
                 "provider_error" now decodes to
                 [Unknown { raw_error = "provider_error" }] whose
                 summary is "keeper turn ended with provider_error". *)
-             && event |> member "summary" |> to_string
-                = "keeper turn ended with provider_error")
-           timeline))
+               && event
+                  |> member "summary"
+                  |> to_string
+                  = "keeper turn ended with provider_error")
+            timeline))
+;;
 
 let test_prompt_contains_identity () =
-  let sys, _user = UP.build_prompt ~base_path:"/test" ~meta:minimal_meta ~observation:base_observation () in
+  let sys, _user =
+    UP.build_prompt ~base_path:"/test" ~meta:minimal_meta ~observation:base_observation ()
+  in
   check bool "contains name" true (String.length sys > 0);
-  check bool "contains keeper name" true
+  check
+    bool
+    "contains keeper name"
+    true
     (let has_name =
-       try ignore (Str.search_forward (Str.regexp_string "test-keeper") sys 0); true
-       with Not_found -> false
-     in has_name)
+       try
+         ignore (Str.search_forward (Str.regexp_string "test-keeper") sys 0);
+         true
+       with
+       | Not_found -> false
+     in
+     has_name)
+;;
 
 let test_prompt_contains_goal () =
-  let sys, _user = UP.build_prompt ~base_path:"/test" ~meta:minimal_meta ~observation:base_observation () in
-  check bool "contains goal" true
+  let sys, _user =
+    UP.build_prompt ~base_path:"/test" ~meta:minimal_meta ~observation:base_observation ()
+  in
+  check
+    bool
+    "contains goal"
+    true
     (let has_goal =
-       try ignore (Str.search_forward (Str.regexp_string "test goal") sys 0); true
-       with Not_found -> false
-     in has_goal)
+       try
+         ignore (Str.search_forward (Str.regexp_string "test goal") sys 0);
+         true
+       with
+       | Not_found -> false
+     in
+     has_goal)
+;;
 
 let test_prompt_mentions_extend_turns_guidance () =
-  let sys, _user = UP.build_prompt ~base_path:"/test" ~meta:minimal_meta ~observation:base_observation () in
-  check bool "mentions extend_turns" true
+  let sys, _user =
+    UP.build_prompt ~base_path:"/test" ~meta:minimal_meta ~observation:base_observation ()
+  in
+  check
+    bool
+    "mentions extend_turns"
+    true
+    (let found =
+       try
+         ignore (Str.search_forward (Str.regexp_string "extend_turns") sys 0);
+         true
+       with
+       | Not_found -> false
+     in
+     found);
+  check
+    bool
+    "mentions generation continuity"
+    true
     (let found =
        try
          ignore
-           (Str.search_forward (Str.regexp_string "extend_turns") sys 0);
+           (Str.search_forward
+              (Str.regexp_string "checkpoint survives across cycles")
+              sys
+              0);
          true
-       with Not_found -> false
-     in found);
-  check bool "mentions generation continuity" true
-    (let found =
-       try
-         ignore
-           (Str.search_forward (Str.regexp_string "checkpoint survives across cycles") sys 0);
-         true
-       with Not_found -> false
-     in found)
+       with
+       | Not_found -> false
+     in
+     found)
+;;
 
 let test_prompt_includes_operational_tool_guidance () =
-  let sys, _user = UP.build_prompt ~base_path:"/test" ~meta:minimal_meta ~observation:base_observation () in
-  check bool "mentions task audit guidance" true
+  let sys, _user =
+    UP.build_prompt ~base_path:"/test" ~meta:minimal_meta ~observation:base_observation ()
+  in
+  check
+    bool
+    "mentions task audit guidance"
+    true
     (contains_substring sys "keeper_tasks_audit");
-  check bool "mentions tool-first principle" true
+  check
+    bool
+    "mentions tool-first principle"
+    true
     (contains_substring sys "Tool-first principle");
-  check bool "mentions worktree inspection guidance" true
+  check
+    bool
+    "mentions worktree inspection guidance"
+    true
     (contains_substring sys "masc_code_read");
-  check bool "mentions server-managed heartbeat" true
+  check
+    bool
+    "mentions server-managed heartbeat"
+    true
     (contains_substring sys "Heartbeat is server-managed");
-  check bool "mentions draft PR broker" true
+  check
+    bool
+    "mentions draft PR broker"
+    true
     (contains_substring sys "keeper_pr_create draft=true");
-  check bool "raw gh PR creation not documented" false
+  check
+    bool
+    "raw gh PR creation not documented"
+    false
     (contains_substring sys "open draft PRs after pushing")
+;;
 
 let test_prompt_includes_research_evidence_contract () =
   let sys, _user =
-    UP.build_prompt ~base_path:"/test" ~meta:minimal_meta
-      ~observation:base_observation ()
+    UP.build_prompt ~base_path:"/test" ~meta:minimal_meta ~observation:base_observation ()
   in
-  check bool "mentions research evidence" true
+  check
+    bool
+    "mentions research evidence"
+    true
     (contains_substring sys "Research evidence");
-  check bool "mentions web search" true
-    (contains_substring sys "masc_web_search");
-  check bool "mentions uncited marker" true
-    (contains_substring sys "[uncited]");
-  check bool "mentions board sources metadata" true
+  check bool "mentions web search" true (contains_substring sys "masc_web_search");
+  check bool "mentions uncited marker" true (contains_substring sys "[uncited]");
+  check
+    bool
+    "mentions board sources metadata"
+    true
     (contains_substring sys "sources` array")
+;;
 
 let test_capabilities_prompt_distinguishes_sandbox_and_worktree () =
   let prompt = Prompt_registry.get_prompt "keeper.capabilities" in
-  check bool "sandbox paths documented" true
-    (contains_substring prompt "sandbox_repos");
-  check bool "local backend host path not model-facing" false
-    (contains_substring prompt "ALL tool calls that accept `cwd` or `path` MUST resolve under `.masc/playground");
-  check bool "github shorthand removed" false
-    (contains_substring prompt "keeper_github");
-  check bool "sandbox is default coding workspace" true
+  check bool "sandbox paths documented" true (contains_substring prompt "sandbox_repos");
+  check
+    bool
+    "local backend host path not model-facing"
+    false
+    (contains_substring
+       prompt
+       "ALL tool calls that accept `cwd` or `path` MUST resolve under `.masc/playground");
+  check bool "github shorthand removed" false (contains_substring prompt "keeper_github");
+  check
+    bool
+    "sandbox is default coding workspace"
+    true
     (contains_substring prompt "default coding workspace");
-  check bool "git path documented via keeper_bash" true
+  check
+    bool
+    "git path documented via keeper_bash"
+    true
     (contains_substring prompt "keeper_bash cmd='git status'");
-  check bool "draft pr tool documented" true
+  check
+    bool
+    "draft pr tool documented"
+    true
     (contains_substring prompt "keeper_pr_create");
-  check bool "gh pr create path not documented" false
+  check
+    bool
+    "gh pr create path not documented"
+    false
     (contains_substring prompt "keeper_shell op=gh cmd='pr create --draft");
-  check bool "legacy pr workflow removed from prompt" false
+  check
+    bool
+    "legacy pr workflow removed from prompt"
+    false
     (contains_substring prompt "keeper_pr_workflow")
+;;
 
 let test_world_prompt_distinguishes_sandbox_and_worktree () =
   let prompt = Prompt_registry.get_prompt "keeper.world" in
-  check bool "world prompt names single sandbox" true
+  check
+    bool
+    "world prompt names single sandbox"
+    true
     (contains_substring prompt "Your sandbox is the only filesystem ground");
   (* Keep the containment clause asserted so bare server-root `.worktrees/...`
      paths cannot drift back in. *)
-  check bool "world prompt names worktree workflow inside sandbox" true
-    (contains_substring prompt
-       "Repo worktrees live *inside* your sandbox clone");
-  check bool "world prompt names canonical sandbox-relative worktree path" true
-    (contains_substring prompt
-       "repos/<REPO_NAME>/.worktrees/<branch-or-task>/")
+  check
+    bool
+    "world prompt names worktree workflow inside sandbox"
+    true
+    (contains_substring prompt "Repo worktrees live *inside* your sandbox clone");
+  check
+    bool
+    "world prompt names canonical sandbox-relative worktree path"
+    true
+    (contains_substring prompt "repos/<REPO_NAME>/.worktrees/<branch-or-task>/")
+;;
 
 let test_system_prompt_prefers_bash_and_gh_pr_lane () =
   let sys =
@@ -1923,241 +2269,377 @@ let test_system_prompt_prefers_bash_and_gh_pr_lane () =
       ~instructions:""
       ()
   in
-  check bool "mentions active schema guard" true
-    (contains_substring sys
+  check
+    bool
+    "mentions active schema guard"
+    true
+    (contains_substring
+       sys
        "Use only the tool schemas currently shown to you by the runtime");
-  check bool "mentions gh identity as conditional route" true
-    (contains_substring sys
-       "when keeper_shell op=gh is present");
-  check bool "does not advertise removed keeper_github" false
+  check
+    bool
+    "mentions gh identity as conditional route"
+    true
+    (contains_substring sys "when keeper_shell op=gh is present");
+  check
+    bool
+    "does not advertise removed keeper_github"
+    false
     (contains_substring sys "keeper_github");
-  check bool "legacy pr workflow removed" false
+  check
+    bool
+    "legacy pr workflow removed"
+    false
     (contains_substring sys "keeper_pr_workflow")
+;;
 
 let test_prompt_includes_autonomous_trigger_section () =
   let meta =
-    {
-      minimal_meta with
+    { minimal_meta with
       current_task_id =
         (match Masc_mcp.Keeper_id.Task_id.of_string "task-123" with
          | Ok value -> Some value
-         | Error err -> fail ("task id parse failed: " ^ err));
-      proactive =
-        { enabled = true; idle_sec = 0; cooldown_sec = 60 };
-      runtime =
-        {
-          minimal_meta.runtime with
-          consecutive_noop_count = 0;
-          proactive_rt =
+         | Error err -> fail ("task id parse failed: " ^ err))
+    ; proactive = { enabled = true; idle_sec = 0; cooldown_sec = 60 }
+    ; runtime =
+        { minimal_meta.runtime with
+          consecutive_noop_count = 0
+        ; proactive_rt =
             { minimal_meta.runtime.proactive_rt with
-              consecutive_noop_count = 0;
-              last_ts = Time_compat.now () -. 300.0;
-            };
-        };
+              consecutive_noop_count = 0
+            ; last_ts = Time_compat.now () -. 300.0
+            }
+        }
     }
   in
-  let _sys, user = UP.build_prompt ~base_path:"/test" ~meta ~observation:base_observation () in
-  check bool "has autonomous trigger section" true
+  let _sys, user =
+    UP.build_prompt ~base_path:"/test" ~meta ~observation:base_observation ()
+  in
+  check
+    bool
+    "has autonomous trigger section"
+    true
     (contains_substring user "Autonomous Trigger");
-  check bool "includes scheduled reason" true
+  check
+    bool
+    "includes scheduled reason"
+    true
     (contains_substring user "scheduled autonomous keepalive turn");
-  check bool "includes cooldown detail" true
+  check
+    bool
+    "includes cooldown detail"
+    true
     (contains_substring user "effective cooldown")
+;;
 
 let test_prompt_omits_autonomous_trigger_for_reactive_turn () =
   let obs =
-    {
-      base_observation with
-      pending_mentions = [ ("alice", "please check this") ];
-      idle_seconds = 999;
+    { base_observation with
+      pending_mentions = [ "alice", "please check this" ]
+    ; idle_seconds = 999
     }
   in
-  let _sys, user = UP.build_prompt ~base_path:"/test" ~meta:minimal_meta ~observation:obs () in
-  check bool "reactive turn omits autonomous trigger section" false
+  let _sys, user =
+    UP.build_prompt ~base_path:"/test" ~meta:minimal_meta ~observation:obs ()
+  in
+  check
+    bool
+    "reactive turn omits autonomous trigger section"
+    false
     (contains_substring user "Autonomous Trigger")
+;;
 
 let test_prompt_omits_empty_sections () =
-  let _sys, user = UP.build_prompt ~base_path:"/test" ~meta:minimal_meta ~observation:base_observation () in
-  check bool "no mention section" true
-    (not (let found =
-       try ignore (Str.search_forward (Str.regexp_string "Pending Mentions") user 0); true
-       with Not_found -> false
-     in found));
-  check bool "no goals section" true
-    (not (let found =
-       try ignore (Str.search_forward (Str.regexp_string "Active Goals") user 0); true
-       with Not_found -> false
-     in found))
+  let _sys, user =
+    UP.build_prompt ~base_path:"/test" ~meta:minimal_meta ~observation:base_observation ()
+  in
+  check
+    bool
+    "no mention section"
+    true
+    (not
+       (let found =
+          try
+            ignore (Str.search_forward (Str.regexp_string "Pending Mentions") user 0);
+            true
+          with
+          | Not_found -> false
+        in
+        found));
+  check
+    bool
+    "no goals section"
+    true
+    (not
+       (let found =
+          try
+            ignore (Str.search_forward (Str.regexp_string "Active Goals") user 0);
+            true
+          with
+          | Not_found -> false
+        in
+        found))
+;;
 
 let test_prompt_continuity_drops_inert_idle_directives () =
   let obs =
-    {
-      base_observation with
+    { base_observation with
       continuity_summary =
         "Goal: structural quality improvement\n\
          Next plan: stay silent until new actionable work appears\n\
          Next: 대기 유지; all non-destructive actions exhausted\n\
-         Constraints: repos/ empty";
-      unclaimed_task_count = 125;
+         Constraints: repos/ empty"
+    ; unclaimed_task_count = 125
     }
   in
   let _sys, user =
     UP.build_prompt ~base_path:"/test" ~meta:minimal_meta ~observation:obs ()
   in
-  check bool "continuity section present" true
-    (contains_substring user "### Continuity");
-  check bool "advisory note present" true
+  check bool "continuity section present" true (contains_substring user "### Continuity");
+  check
+    bool
+    "advisory note present"
+    true
     (contains_substring user "ignore prior silence/wait directives");
-  check bool "idle next plan removed" false
+  check
+    bool
+    "idle next plan removed"
+    false
     (contains_substring user "stay silent until new actionable work appears");
-  check bool "idle next removed" false
-    (contains_substring user "대기 유지");
-  check bool "goal preserved" true
+  check bool "idle next removed" false (contains_substring user "대기 유지");
+  check
+    bool
+    "goal preserved"
+    true
     (contains_substring user "Goal: structural quality improvement");
-  check bool "constraints preserved" true
+  check
+    bool
+    "constraints preserved"
+    true
     (contains_substring user "Constraints: repos/ empty")
+;;
 
 let test_prompt_continuity_drops_stale_tool_surface_claims () =
-  Eio_main.run @@ fun env ->
+  Eio_main.run
+  @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
   let obs =
-    {
-      base_observation with
+    { base_observation with
       continuity_summary =
         "Goal: restore autonomous tool use\n\
          Next plan: call keeper_task_claim after checking live policy\n\
-         Constraints: tool surface: masc_* only; no keeper_* tools visible";
-      unclaimed_task_count = 3;
-      claimable_task_count = 3;
+         Constraints: tool surface: masc_* only; no keeper_* tools visible"
+    ; unclaimed_task_count = 3
+    ; claimable_task_count = 3
     }
   in
   let _sys, user =
     UP.build_prompt ~base_path:"/test" ~meta:minimal_meta ~observation:obs ()
   in
-  check bool "continuity section present" true
-    (contains_substring user "### Continuity");
-  check bool "stale masc-only surface removed" false
+  check bool "continuity section present" true (contains_substring user "### Continuity");
+  check
+    bool
+    "stale masc-only surface removed"
+    false
     (contains_substring user "masc_* only");
-  check bool "stale missing keeper tools removed" false
+  check
+    bool
+    "stale missing keeper tools removed"
+    false
     (contains_substring user "no keeper_* tools");
-  check bool "goal preserved" true
+  check
+    bool
+    "goal preserved"
+    true
     (contains_substring user "Goal: restore autonomous tool use");
-  check bool "live policy action preserved" true
+  check
+    bool
+    "live policy action preserved"
+    true
     (contains_substring user "keeper_task_claim")
+;;
 
 let test_prompt_includes_mentions_section () =
-  let obs =
-    { base_observation with
-      pending_mentions = [("alice", "hello keeper")]
-    }
+  let obs = { base_observation with pending_mentions = [ "alice", "hello keeper" ] } in
+  let _sys, user =
+    UP.build_prompt ~base_path:"/test" ~meta:minimal_meta ~observation:obs ()
   in
-  let _sys, user = UP.build_prompt ~base_path:"/test" ~meta:minimal_meta ~observation:obs () in
-  check bool "has mention section" true
+  check
+    bool
+    "has mention section"
+    true
     (let found =
-       try ignore (Str.search_forward (Str.regexp_string "Pending Mentions") user 0); true
-       with Not_found -> false
-     in found);
-  check bool "has mention content" true
+       try
+         ignore (Str.search_forward (Str.regexp_string "Pending Mentions") user 0);
+         true
+       with
+       | Not_found -> false
+     in
+     found);
+  check
+    bool
+    "has mention content"
+    true
     (let found =
-       try ignore (Str.search_forward (Str.regexp_string "@alice") user 0); true
-       with Not_found -> false
-     in found)
+       try
+         ignore (Str.search_forward (Str.regexp_string "@alice") user 0);
+         true
+       with
+       | Not_found -> false
+     in
+     found)
+;;
 
 let test_prompt_includes_goals_section () =
-  let obs =
-    { base_observation with
-      active_goals = ["goal-abc"]
-    }
+  let obs = { base_observation with active_goals = [ "goal-abc" ] } in
+  let _sys, user =
+    UP.build_prompt ~base_path:"/test" ~meta:minimal_meta ~observation:obs ()
   in
-  let _sys, user = UP.build_prompt ~base_path:"/test" ~meta:minimal_meta ~observation:obs () in
-  check bool "has goals section" true
+  check
+    bool
+    "has goals section"
+    true
     (let found =
-       try ignore (Str.search_forward (Str.regexp_string "Active Goals") user 0); true
-       with Not_found -> false
-     in found)
+       try
+         ignore (Str.search_forward (Str.regexp_string "Active Goals") user 0);
+         true
+       with
+       | Not_found -> false
+     in
+     found)
+;;
 
 let test_prompt_includes_context_ratio () =
   let obs = { base_observation with context_ratio = 0.75 } in
-  let _sys, user = UP.build_prompt ~base_path:"/test" ~meta:minimal_meta ~observation:obs () in
-  check bool "has context percentage" true
+  let _sys, user =
+    UP.build_prompt ~base_path:"/test" ~meta:minimal_meta ~observation:obs ()
+  in
+  check
+    bool
+    "has context percentage"
+    true
     (let found =
-       try ignore (Str.search_forward (Str.regexp_string "75%") user 0); true
-       with Not_found -> false
-     in found)
+       try
+         ignore (Str.search_forward (Str.regexp_string "75%") user 0);
+         true
+       with
+       | Not_found -> false
+     in
+     found)
+;;
 
 let test_prompt_includes_idle () =
   let obs = { base_observation with idle_seconds = 300 } in
-  let _sys, user = UP.build_prompt ~base_path:"/test" ~meta:minimal_meta ~observation:obs () in
-  check bool "has idle seconds" true
+  let _sys, user =
+    UP.build_prompt ~base_path:"/test" ~meta:minimal_meta ~observation:obs ()
+  in
+  check
+    bool
+    "has idle seconds"
+    true
     (let found =
-       try ignore (Str.search_forward (Str.regexp_string "300s") user 0); true
-       with Not_found -> false
-     in found)
+       try
+         ignore (Str.search_forward (Str.regexp_string "300s") user 0);
+         true
+       with
+       | Not_found -> false
+     in
+     found)
+;;
 
 let test_prompt_frugal_economy () =
   let obs = { base_observation with economic_pressure = AE.Frugal } in
-  let _sys, user = UP.build_prompt ~base_path:"/test" ~meta:minimal_meta ~observation:obs () in
-  check bool "has frugal warning" true
+  let _sys, user =
+    UP.build_prompt ~base_path:"/test" ~meta:minimal_meta ~observation:obs ()
+  in
+  check
+    bool
+    "has frugal warning"
+    true
     (let found =
-       try ignore (Str.search_forward (Str.regexp_string "Frugal") user 0); true
-       with Not_found -> false
-     in found)
+       try
+         ignore (Str.search_forward (Str.regexp_string "Frugal") user 0);
+         true
+       with
+       | Not_found -> false
+     in
+     found)
+;;
 
 let test_prompt_hustle_economy () =
   let obs = { base_observation with economic_pressure = AE.Hustle } in
-  let _sys, user = UP.build_prompt ~base_path:"/test" ~meta:minimal_meta ~observation:obs () in
-  check bool "has hustle warning" true
+  let _sys, user =
+    UP.build_prompt ~base_path:"/test" ~meta:minimal_meta ~observation:obs ()
+  in
+  check
+    bool
+    "has hustle warning"
+    true
     (let found =
-       try ignore (Str.search_forward (Str.regexp_string "Hustle") user 0); true
-       with Not_found -> false
-     in found)
+       try
+         ignore (Str.search_forward (Str.regexp_string "Hustle") user 0);
+         true
+       with
+       | Not_found -> false
+     in
+     found)
+;;
 
 let test_prompt_includes_worktree_delta () =
   let obs =
     { base_observation with
       worktree_change_summary =
         Some
-          "<git_status_change>\nWorking tree changed since last keeper turn (1 files):\n M lib/example.ml\n</git_status_change>"
+          "<git_status_change>\n\
+           Working tree changed since last keeper turn (1 files):\n\
+          \ M lib/example.ml\n\
+           </git_status_change>"
     }
   in
-  let _sys, user = UP.build_prompt ~base_path:"/test" ~meta:minimal_meta ~observation:obs () in
-  check bool "has worktree section" true
+  let _sys, user =
+    UP.build_prompt ~base_path:"/test" ~meta:minimal_meta ~observation:obs ()
+  in
+  check
+    bool
+    "has worktree section"
+    true
     (let found =
        try
-         ignore
-           (Str.search_forward
-              (Str.regexp_string "Live Worktree Delta")
-              user 0);
+         ignore (Str.search_forward (Str.regexp_string "Live Worktree Delta") user 0);
          true
-       with Not_found -> false
-     in found);
-  check bool "has git status block" true
+       with
+       | Not_found -> false
+     in
+     found);
+  check
+    bool
+    "has git status block"
+    true
     (let found =
        try
-         ignore
-           (Str.search_forward
-              (Str.regexp_string "<git_status_change>")
-              user 0);
+         ignore (Str.search_forward (Str.regexp_string "<git_status_change>") user 0);
          true
-       with Not_found -> false
-     in found)
+       with
+       | Not_found -> false
+     in
+     found)
+;;
 
 let test_prompt_orders_stable_sections_before_reactive_sections () =
   let obs =
-    {
-      base_observation with
-      active_goals = [ "goal-abc" ];
-      continuity_summary =
-        "Goal: structural quality improvement\nNext: verify latest runtime state";
-      pending_mentions = [ ("alice", "hello keeper") ];
-      pending_board_events = [ sample_board_event ];
-      worktree_change_summary =
-        Some "<git_status_change>\n M lib/example.ml\n</git_status_change>";
-      context_ratio = 0.42;
-      idle_seconds = 45;
-      unclaimed_task_count = 2;
-      claimable_task_count = 2;
-      active_agent_count = 3;
+    { base_observation with
+      active_goals = [ "goal-abc" ]
+    ; continuity_summary =
+        "Goal: structural quality improvement\nNext: verify latest runtime state"
+    ; pending_mentions = [ "alice", "hello keeper" ]
+    ; pending_board_events = [ sample_board_event ]
+    ; worktree_change_summary =
+        Some "<git_status_change>\n M lib/example.ml\n</git_status_change>"
+    ; context_ratio = 0.42
+    ; idle_seconds = 45
+    ; unclaimed_task_count = 2
+    ; claimable_task_count = 2
+    ; active_agent_count = 3
     }
   in
   let _sys, user =
@@ -2168,71 +2650,116 @@ let test_prompt_orders_stable_sections_before_reactive_sections () =
     | Some i -> i
     | None -> fail ("missing section: " ^ needle)
   in
-  check bool "active goals precede pending mentions" true
+  check
+    bool
+    "active goals precede pending mentions"
+    true
     (idx "### Active Goals" < idx "### Pending Mentions");
-  check bool "continuity precedes board activity" true
+  check
+    bool
+    "continuity precedes board activity"
+    true
     (idx "### Continuity" < idx "### Board Activity");
-  check bool "context precedes live worktree delta" true
+  check
+    bool
+    "context precedes live worktree delta"
+    true
     (idx "### Context" < idx "### Live Worktree Delta")
+;;
 
 let test_prompt_room_state_section () =
   let obs =
     { base_observation with
-      unclaimed_task_count = 3;
-      claimable_task_count = 3;
-      failed_task_count = 1;
-      active_agent_count = 5;
+      unclaimed_task_count = 3
+    ; claimable_task_count = 3
+    ; failed_task_count = 1
+    ; active_agent_count = 5
     }
   in
-  let _sys, user = UP.build_prompt ~base_path:"/test" ~meta:minimal_meta ~observation:obs () in
-  check bool "has namespace state" true
+  let _sys, user =
+    UP.build_prompt ~base_path:"/test" ~meta:minimal_meta ~observation:obs ()
+  in
+  check
+    bool
+    "has namespace state"
+    true
     (let found =
        try
-         ignore
-           (Str.search_forward (Str.regexp_string "Namespace State") user 0);
+         ignore (Str.search_forward (Str.regexp_string "Namespace State") user 0);
          true
-       with Not_found -> false
-     in found)
+       with
+       | Not_found -> false
+     in
+     found)
+;;
 
 let test_prompt_includes_claim_first_guidance () =
   let obs =
     { base_observation with
-      unclaimed_task_count = 3;
-      claimable_task_count = 3;
-      active_agent_count = 5;
+      unclaimed_task_count = 3
+    ; claimable_task_count = 3
+    ; active_agent_count = 5
     }
   in
   let sys, user =
     UP.build_prompt ~base_path:"/test" ~meta:minimal_meta ~observation:obs ()
   in
-  check bool "system prompt explains auto-claim" true
+  check
+    bool
+    "system prompt explains auto-claim"
+    true
     (contains_substring sys "Call keeper_task_claim with {}");
-  check bool "user prompt adds immediate task move section" true
+  check
+    bool
+    "user prompt adds immediate task move section"
+    true
     (contains_substring user "### Immediate Task Move");
-  check bool "user prompt explains no task_id needed" true
+  check
+    bool
+    "user prompt explains no task_id needed"
+    true
     (contains_substring user "Do not wait for keeper_tasks_list");
-  check bool "user prompt prefers claim before browsing" true
-    (contains_substring user "Prefer keeper_task_claim before keeper_board_list or keeper_shell");
-  check bool "user prompt explains gh requires claim first" true
+  check
+    bool
+    "user prompt prefers claim before browsing"
+    true
+    (contains_substring
+       user
+       "Prefer keeper_task_claim before keeper_board_list or keeper_shell");
+  check
+    bool
+    "user prompt explains gh requires claim first"
+    true
     (contains_substring user "If you need keeper_shell op=gh, claim first")
+;;
 
 let test_prompt_omits_claim_first_guidance_when_no_claimable_tasks () =
   let obs =
     { base_observation with
-      unclaimed_task_count = 3;
-      claimable_task_count = 0;
-      active_agent_count = 5;
+      unclaimed_task_count = 3
+    ; claimable_task_count = 0
+    ; active_agent_count = 5
     }
   in
   let sys, user =
     UP.build_prompt ~base_path:"/test" ~meta:minimal_meta ~observation:obs ()
   in
-  check bool "system prompt omits auto-claim for unclaimable backlog" false
+  check
+    bool
+    "system prompt omits auto-claim for unclaimable backlog"
+    false
     (contains_substring sys "Call keeper_task_claim with {}");
-  check bool "user prompt omits immediate task move for unclaimable backlog" false
+  check
+    bool
+    "user prompt omits immediate task move for unclaimable backlog"
+    false
     (contains_substring user "### Immediate Task Move");
-  check bool "namespace exposes zero matched availability" true
+  check
+    bool
+    "namespace exposes zero matched availability"
+    true
     (contains_substring user "Claimable tasks for this keeper: 0")
+;;
 
 let test_prompt_omits_claim_first_guidance_when_task_claimed () =
   let current_task_id =
@@ -2243,174 +2770,253 @@ let test_prompt_omits_claim_first_guidance_when_task_claimed () =
   let meta = { minimal_meta with current_task_id = Some current_task_id } in
   let obs =
     { base_observation with
-      unclaimed_task_count = 3;
-      claimable_task_count = 3;
-      active_agent_count = 5;
+      unclaimed_task_count = 3
+    ; claimable_task_count = 3
+    ; active_agent_count = 5
     }
   in
-  let _sys, user =
-    UP.build_prompt ~base_path:"/test" ~meta ~observation:obs ()
-  in
-  check bool "no immediate task move section once task claimed" false
+  let _sys, user = UP.build_prompt ~base_path:"/test" ~meta ~observation:obs () in
+  check
+    bool
+    "no immediate task move section once task claimed"
+    false
     (contains_substring user "### Immediate Task Move")
+;;
 
 let test_prompt_omits_claim_first_guidance_when_claim_tool_unavailable () =
   let obs =
     { base_observation with
-      unclaimed_task_count = 3;
-      claimable_task_count = 3;
-      active_agent_count = 5;
+      unclaimed_task_count = 3
+    ; claimable_task_count = 3
+    ; active_agent_count = 5
     }
   in
   let sys, user =
     UP.build_prompt ~base_path:"/test" ~meta:minimal_policy_meta ~observation:obs ()
   in
-  check bool "system prompt omits auto-claim when tool unavailable" false
+  check
+    bool
+    "system prompt omits auto-claim when tool unavailable"
+    false
     (contains_substring sys "Call keeper_task_claim with {}");
-  check bool "user prompt omits immediate task move when tool unavailable" false
+  check
+    bool
+    "user prompt omits immediate task move when tool unavailable"
+    false
     (contains_substring user "### Immediate Task Move")
+;;
 
 let test_prompt_omits_claim_first_guidance_when_paused () =
   let meta = { minimal_meta with paused = true } in
   let obs =
     { base_observation with
-      unclaimed_task_count = 3;
-      claimable_task_count = 3;
-      active_agent_count = 5;
+      unclaimed_task_count = 3
+    ; claimable_task_count = 3
+    ; active_agent_count = 5
     }
   in
-  let sys, user =
-    UP.build_prompt ~base_path:"/test" ~meta ~observation:obs ()
-  in
-  check bool "system prompt omits auto-claim while paused" false
+  let sys, user = UP.build_prompt ~base_path:"/test" ~meta ~observation:obs () in
+  check
+    bool
+    "system prompt omits auto-claim while paused"
+    false
     (contains_substring sys "Call keeper_task_claim with {}");
-  check bool "user prompt omits immediate task move while paused" false
+  check
+    bool
+    "user prompt omits immediate task move while paused"
+    false
     (contains_substring user "### Immediate Task Move")
+;;
 
 let test_work_discovery_nudge_uses_registered_keeper_tool_schemas () =
   let module Guidance = Masc_mcp.Keeper_tool_guidance in
   let social_meta =
-    {
-      minimal_meta with
-      tool_access = Preset { preset = Social; also_allow = [] };
-    }
+    { minimal_meta with tool_access = Preset { preset = Social; also_allow = [] } }
   in
   let coding_meta =
-    {
-      minimal_meta with
-      tool_access = Preset { preset = Coding; also_allow = [] };
-    }
+    { minimal_meta with tool_access = Preset { preset = Coding; also_allow = [] } }
   in
-  let social_allowed =
-    Masc_mcp.Keeper_exec_tools.keeper_allowed_tool_names social_meta
-  in
-  let coding_allowed =
-    Masc_mcp.Keeper_exec_tools.keeper_allowed_tool_names coding_meta
-  in
+  let social_allowed = Masc_mcp.Keeper_exec_tools.keeper_allowed_tool_names social_meta in
+  let coding_allowed = Masc_mcp.Keeper_exec_tools.keeper_allowed_tool_names coding_meta in
   let social_guidance =
     Guidance.render_preferred_tools ~allowed_tool_names:social_allowed
   in
   let coding_guidance =
     Guidance.render_preferred_tools ~allowed_tool_names:coding_allowed
   in
-  check bool "obsolete claim alias removed" false
+  check
+    bool
+    "obsolete claim alias removed"
+    false
     (source_file_contains "lib/keeper/keeper_agent_run.ml" "keeper_claim_task");
-  check bool "social guidance includes claim schema when allowed" true
+  check
+    bool
+    "social guidance includes claim schema when allowed"
+    true
     (contains_substring social_guidance "`keeper_task_claim` {}");
-  check bool "social guidance includes board post when allowed" true
+  check
+    bool
+    "social guidance includes board post when allowed"
+    true
     (contains_substring social_guidance "`keeper_board_post` { content:");
-  check bool "social guidance includes web search when allowed" true
+  check
+    bool
+    "social guidance includes web search when allowed"
+    true
     (contains_substring social_guidance "`masc_web_search` { query:");
-  check bool "social guidance omits bash outside preset" false
+  check
+    bool
+    "social guidance omits bash outside preset"
+    false
     (contains_substring social_guidance "`keeper_bash` { cmd:");
-  check bool "social guidance omits worktree outside preset" false
+  check
+    bool
+    "social guidance omits worktree outside preset"
+    false
     (contains_substring social_guidance "`masc_worktree_create` { task_id:");
-  check bool "coding guidance includes bash schema" true
+  check
+    bool
+    "coding guidance includes bash schema"
+    true
     (contains_substring coding_guidance "`keeper_bash` { cmd:");
-  check bool "coding guidance includes web search schema" true
+  check
+    bool
+    "coding guidance includes web search schema"
+    true
     (contains_substring coding_guidance "`masc_web_search` { query:");
-  check bool "coding guidance includes worktree schema" true
+  check
+    bool
+    "coding guidance includes worktree schema"
+    true
     (contains_substring coding_guidance "`masc_worktree_create` { task_id:");
-  check bool "legacy worktree branch_name schema removed" false
+  check
+    bool
+    "legacy worktree branch_name schema removed"
+    false
     (source_file_contains "lib/keeper/keeper_agent_run.ml" "branch_name:");
-  check bool "tool-less runtime escape hatch removed from nudge" false
+  check
+    bool
+    "tool-less runtime escape hatch removed from nudge"
+    false
     (source_file_contains "lib/keeper/keeper_agent_run.ml" "NO_TOOL_CHANNEL");
-  check bool "work discovery nudge warns gh needs claimed task" true
+  check
+    bool
+    "work discovery nudge warns gh needs claimed task"
+    true
     (contains_substring
-       (Option.value ~default:""
+       (Option.value
+          ~default:""
           (Guidance.render_gh_workflow ~allowed_tool_names:coding_allowed))
-       "keeper_shell op=gh` derives repo context from the active task worktree/current_task_id");
-  check bool "unknown tool guard names server-managed public lifecycle tools" true
+       "keeper_shell op=gh` derives repo context from the active task \
+        worktree/current_task_id");
+  check
+    bool
+    "unknown tool guard names server-managed public lifecycle tools"
+    true
     (contains_substring (Guidance.render_unknown_tool_guard ()) "masc_heartbeat");
-  check bool "unknown tool guard warns against public board alias" true
+  check
+    bool
+    "unknown tool guard warns against public board alias"
+    true
     (contains_substring (Guidance.render_unknown_tool_guard ()) "masc_board_list");
-  check bool "keeper_shell schema documents gh claim prerequisite" true
-    (source_file_contains "lib/tool_shard.ml"
+  check
+    bool
+    "keeper_shell schema documents gh claim prerequisite"
+    true
+    (source_file_contains
+       "lib/tool_shard.ml"
        "Requires an active claimed task/current_task_id");
-  check bool "keeper_shell gh runtime allows sandbox fallback" true
-    (source_file_contains "lib/keeper/keeper_shell_gh_context.ml"
+  check
+    bool
+    "keeper_shell gh runtime allows sandbox fallback"
+    true
+    (source_file_contains
+       "lib/keeper/keeper_shell_gh_context.ml"
        "task_id = \"(sandbox)\"");
-  check bool
+  check
+    bool
     "work discovery nudge avoids pre-filter policy tool names"
     false
-    (source_file_contains "lib/keeper/keeper_agent_run.ml"
+    (source_file_contains
+       "lib/keeper/keeper_agent_run.ml"
        "render_preferred_tools ~allowed_tool_names");
-  check bool
+  check
+    bool
     "claimed-task nudge avoids hard-coded execution tool names"
     false
-    (source_file_contains "lib/keeper/keeper_agent_run.ml"
+    (source_file_contains
+       "lib/keeper/keeper_agent_run.ml"
        "Use keeper_bash, keeper_shell, keeper_fs_read")
+;;
 
 (* ---------- Config tests ---------- *)
 
 let test_unified_turn_runtime_defaults () =
   with_env "MASC_KEEPER_UNIFIED_TEMP" "" (fun () ->
-  with_env "MASC_KEEPER_UNIFIED_MAX_TOKENS" "" (fun () ->
-    check (float 0.01) "unified temp default" 0.4
-      (KC.keeper_unified_temperature ());
-    (* Runtime param default is 65536 (safe fallback).
+    with_env "MASC_KEEPER_UNIFIED_MAX_TOKENS" "" (fun () ->
+      check (float 0.01) "unified temp default" 0.4 (KC.keeper_unified_temperature ());
+      (* Runtime param default is 65536 (safe fallback).
        In production, cascade.json overrides to 16384.
        This test verifies the runtime default, not cascade-resolved value. *)
-    check int "unified max_tokens default" 65536
-      (KC.keeper_unified_max_tokens ())
-    (* max_turns is set in keeper_agent_run.ml from keeper runtime config. *)))
+      check int "unified max_tokens default" 65536 (KC.keeper_unified_max_tokens ())
+      (* max_turns is set in keeper_agent_run.ml from keeper runtime config. *)))
+;;
 
 let test_meta_defaults_social_model () =
-  check string "default social model" "bdi_speech_v1"
-    minimal_meta.social_model
+  check string "default social model" "bdi_speech_v1" minimal_meta.social_model
+;;
 
 let test_social_model_registry_round_trip () =
-  check (option string) "known model id resolves"
+  check
+    (option string)
+    "known model id resolves"
     (Some "bdi_speech_v1")
-    (KSM.model_id_of_string "bdi_speech_v1"
-    |> Option.map KSM.model_id_to_string);
-  check (option string) "second model id resolves"
+    (KSM.model_id_of_string "bdi_speech_v1" |> Option.map KSM.model_id_to_string);
+  check
+    (option string)
+    "second model id resolves"
     (Some "magentic_ledger_v1")
-    (KSM.model_id_of_string "magentic_ledger_v1"
-    |> Option.map KSM.model_id_to_string);
-  check bool "unknown model id rejected" true
+    (KSM.model_id_of_string "magentic_ledger_v1" |> Option.map KSM.model_id_to_string);
+  check
+    bool
+    "unknown model id rejected"
+    true
     (Option.is_none (KSM.model_id_of_string "experimental_v99"));
-  check bool "unknown model flagged as unrecognized" false
+  check
+    bool
+    "unknown model flagged as unrecognized"
+    false
     (KSM.is_known_social_model "experimental_v99");
-  check (option string) "unknown model exposes explicit fallback"
+  check
+    (option string)
+    "unknown model exposes explicit fallback"
     (Some "bdi_speech_v1")
     (KSM.fallback_social_model "experimental_v99");
-  check string "unknown model normalized to baseline" "bdi_speech_v1"
+  check
+    string
+    "unknown model normalized to baseline"
+    "bdi_speech_v1"
     (KSM.normalize_social_model "experimental_v99")
+;;
 
 (* ---------- Metrics observation tests ---------- *)
 
-let sample_prompt_metrics ?(system_prompt = "You are a keeper.")
-    ?(dynamic_context = "")
-    ?(user_message = "Check the board.")
-    () =
+let sample_prompt_metrics
+      ?(system_prompt = "You are a keeper.")
+      ?(dynamic_context = "")
+      ?(user_message = "Check the board.")
+      ()
+  =
   KAR.build_prompt_metrics ~system_prompt ~dynamic_context ~user_message
+;;
 
-let sample_ctx_composition ?(system_prompt = "You are a keeper.")
-    ?(dynamic_context = "")
-    ?(user_message = "Check the board.")
-    ?(actual_input_tokens : int option = None)
-    () =
+let sample_ctx_composition
+      ?(system_prompt = "You are a keeper.")
+      ?(dynamic_context = "")
+      ?(user_message = "Check the board.")
+      ?(actual_input_tokens : int option = None)
+      ()
+  =
   KAR.build_ctx_composition_metrics
     ~system_prompt
     ~dynamic_context
@@ -2419,235 +3025,309 @@ let sample_ctx_composition ?(system_prompt = "You are a keeper.")
     ~user_message
     ~history_messages:[]
     ~actual_input_tokens
+;;
 
 let sample_tool_surface_metrics () : Masc_mcp.Keeper_agent_run.tool_surface_metrics =
-  {
-    turn_lane = Masc_mcp.Keeper_agent_tool_surface.Lane_tool_optional;
-    tool_surface_class = Masc_mcp.Keeper_agent_tool_surface.Surface_mixed;
-    tool_requirement = Masc_mcp.Keeper_agent_tool_surface.Optional;
-    visible_tool_count = 0;
-    tool_gate_enabled = false;
-    tool_surface_fallback_used = false;
-    required_tool_names = [];
-    missing_required_tool_names = [];
-    config_root = "";
-    cascade_config_path = None;
-    gemini_mcp_disabled = false;
-    approval_mode_effective = None;
-    approval_mode_derived = false;
+  { turn_lane = Masc_mcp.Keeper_agent_tool_surface.Lane_tool_optional
+  ; tool_surface_class = Masc_mcp.Keeper_agent_tool_surface.Surface_mixed
+  ; tool_requirement = Masc_mcp.Keeper_agent_tool_surface.Optional
+  ; visible_tool_count = 0
+  ; tool_gate_enabled = false
+  ; tool_surface_fallback_used = false
+  ; required_tool_names = []
+  ; missing_required_tool_names = []
+  ; config_root = ""
+  ; cascade_config_path = None
+  ; gemini_mcp_disabled = false
+  ; approval_mode_effective = None
+  ; approval_mode_derived = false
   }
-let make_run_result ~text ~tools ~model ~input_tok ~output_tok
-    ?(usage_reported = true)
-    ?(cache_creation_tokens = 0)
-    ?(cache_read_tokens = 0)
-    ?(tool_calls = [])
-    ?proof
-    ?trace_ref
-    ?run_validation
-    ?cascade_observation
-    () : Masc_mcp.Keeper_agent_run.run_result =
-  {
-    response_text = text;
-    model_used = model;
-    prompt_metrics = sample_prompt_metrics ();
-    ctx_composition =
+;;
+
+let make_run_result
+      ~text
+      ~tools
+      ~model
+      ~input_tok
+      ~output_tok
+      ?(usage_reported = true)
+      ?(cache_creation_tokens = 0)
+      ?(cache_read_tokens = 0)
+      ?(tool_calls = [])
+      ?proof
+      ?trace_ref
+      ?run_validation
+      ?cascade_observation
+      ()
+  : Masc_mcp.Keeper_agent_run.run_result
+  =
+  { response_text = text
+  ; model_used = model
+  ; prompt_metrics = sample_prompt_metrics ()
+  ; ctx_composition =
       sample_ctx_composition
         ~actual_input_tokens:(if input_tok > 0 then Some input_tok else None)
-        ();
-    cascade_observation;
-    turn_count = 1;
-    tool_calls_made = List.length tools;
-    usage =
-      {
-        input_tokens = input_tok;
-        output_tokens = output_tok;
-        cache_creation_input_tokens = cache_creation_tokens;
-        cache_read_input_tokens = cache_read_tokens;
-        cost_usd = None;
-      };
-    usage_reported;
-    tools_used = tools;
-    tool_calls;
-    checkpoint = None;
-    proof;
-    trace_ref;
-    run_validation;
-    stop_reason = Masc_mcp.Cascade_runner.Completed;
-    inference_telemetry = None;
-    tool_surface = sample_tool_surface_metrics ();
+        ()
+  ; cascade_observation
+  ; turn_count = 1
+  ; tool_calls_made = List.length tools
+  ; usage =
+      { input_tokens = input_tok
+      ; output_tokens = output_tok
+      ; cache_creation_input_tokens = cache_creation_tokens
+      ; cache_read_input_tokens = cache_read_tokens
+      ; cost_usd = None
+      }
+  ; usage_reported
+  ; tools_used = tools
+  ; tool_calls
+  ; checkpoint = None
+  ; proof
+  ; trace_ref
+  ; run_validation
+  ; stop_reason = Masc_mcp.Cascade_runner.Completed
+  ; inference_telemetry = None
+  ; tool_surface = sample_tool_surface_metrics ()
   }
+;;
 
 let sample_cdal_proof ?(raw_evidence_refs = []) () : Masc_mcp_cdal_runtime.Cdal_proof.t =
-  {
-    schema_version = Masc_mcp_cdal_runtime.Cdal_proof.schema_version_current;
-    run_id = "keeper-metrics-proof-test";
-    contract_id = "md5:test";
-    requested_execution_mode = Execute;
-    effective_execution_mode = Execute;
-    mode_decision_source = "passthrough";
-    risk_class = Masc_mcp_cdal_runtime.Risk_class.Low;
-    provider_snapshot =
-      {
-        provider_name = "test";
-        model_id = "test-model";
-        api_version = None;
-      };
-    capability_snapshot =
-      {
-        tools = [ "read"; "write" ];
-        mcp_servers = [];
-        max_turns = 10;
-        max_tokens = Some 4096;
-        thinking_enabled = None;
-      };
-    tool_trace_refs = [];
-    raw_evidence_refs;
-    checkpoint_ref = None;
-    result_status = Completed;
-    started_at = 1000.0;
-    ended_at = 1001.0;
-    scope = None;
+  { schema_version = Masc_mcp_cdal_runtime.Cdal_proof.schema_version_current
+  ; run_id = "keeper-metrics-proof-test"
+  ; contract_id = "md5:test"
+  ; requested_execution_mode = Execute
+  ; effective_execution_mode = Execute
+  ; mode_decision_source = "passthrough"
+  ; risk_class = Masc_mcp_cdal_runtime.Risk_class.Low
+  ; provider_snapshot =
+      { provider_name = "test"; model_id = "test-model"; api_version = None }
+  ; capability_snapshot =
+      { tools = [ "read"; "write" ]
+      ; mcp_servers = []
+      ; max_turns = 10
+      ; max_tokens = Some 4096
+      ; thinking_enabled = None
+      }
+  ; tool_trace_refs = []
+  ; raw_evidence_refs
+  ; checkpoint_ref = None
+  ; result_status = Completed
+  ; started_at = 1000.0
+  ; ended_at = 1001.0
+  ; scope = None
   }
+;;
 
 let test_prompt_metrics_fingerprint_is_deterministic () =
   let metrics_a =
-    sample_prompt_metrics ~system_prompt:"sys" ~dynamic_context:"ctx"
-      ~user_message:"user" ()
+    sample_prompt_metrics
+      ~system_prompt:"sys"
+      ~dynamic_context:"ctx"
+      ~user_message:"user"
+      ()
   in
   let metrics_b =
-    sample_prompt_metrics ~system_prompt:"sys" ~dynamic_context:"ctx"
-      ~user_message:"user" ()
+    sample_prompt_metrics
+      ~system_prompt:"sys"
+      ~dynamic_context:"ctx"
+      ~user_message:"user"
+      ()
   in
   let metrics_c =
-    sample_prompt_metrics ~system_prompt:"sys" ~dynamic_context:"ctx"
-      ~user_message:"changed user" ()
+    sample_prompt_metrics
+      ~system_prompt:"sys"
+      ~dynamic_context:"ctx"
+      ~user_message:"changed user"
+      ()
   in
-  check string "same inputs -> same fingerprint"
-    metrics_a.fingerprint metrics_b.fingerprint;
-  check bool "different prompt inputs -> different fingerprint" true
+  check
+    string
+    "same inputs -> same fingerprint"
+    metrics_a.fingerprint
+    metrics_b.fingerprint;
+  check
+    bool
+    "different prompt inputs -> different fingerprint"
+    true
     (metrics_a.fingerprint <> metrics_c.fingerprint);
-  check int "cacheable tokens follow system prompt"
+  check
+    int
+    "cacheable tokens follow system prompt"
     metrics_a.system_prompt_segment.estimated_tokens
     metrics_a.estimated_cacheable_tokens;
-  check int "total estimated tokens are additive"
+  check
+    int
+    "total estimated tokens are additive"
     (metrics_a.system_prompt_segment.estimated_tokens
      + metrics_a.dynamic_context_segment.estimated_tokens
      + metrics_a.user_message_segment.estimated_tokens)
     metrics_a.estimated_total_tokens
+;;
 
 let test_metrics_text_response () =
   let result =
-    make_run_result ~text:"I checked the board." ~tools:[]
-      ~model:"test-model" ~input_tok:100 ~output_tok:50 ()
+    make_run_result
+      ~text:"I checked the board."
+      ~tools:[]
+      ~model:"test-model"
+      ~input_tok:100
+      ~output_tok:50
+      ()
   in
   let updated =
-    UM.update_metrics_from_result minimal_meta ~latency_ms:200
-      ~observation:base_observation result
+    UM.update_metrics_from_result
+      minimal_meta
+      ~latency_ms:200
+      ~observation:base_observation
+      result
   in
-  check int "total_turns +1" (minimal_meta.runtime.usage.total_turns + 1) updated.runtime.usage.total_turns;
-  check int "proactive_count +1"
-    (minimal_meta.runtime.proactive_rt.count_total + 1) updated.runtime.proactive_rt.count_total;
-  check int "proactive visible_count +1"
+  check
+    int
+    "total_turns +1"
+    (minimal_meta.runtime.usage.total_turns + 1)
+    updated.runtime.usage.total_turns;
+  check
+    int
+    "proactive_count +1"
+    (minimal_meta.runtime.proactive_rt.count_total + 1)
+    updated.runtime.proactive_rt.count_total;
+  check
+    int
+    "proactive visible_count +1"
     (minimal_meta.runtime.proactive_rt.visible_count_total + 1)
     updated.runtime.proactive_rt.visible_count_total;
-  check bool "proactive outcome text" true
+  check
+    bool
+    "proactive outcome text"
+    true
     (updated.runtime.proactive_rt.last_outcome
      = Masc_mcp.Keeper_types.Proactive_text_response);
-  check int "no autonomous action" minimal_meta.runtime.autonomous_action_count
+  check
+    int
+    "no autonomous action"
+    minimal_meta.runtime.autonomous_action_count
     updated.runtime.autonomous_action_count;
-  check int "input tokens" (minimal_meta.runtime.usage.total_input_tokens + 100) updated.runtime.usage.total_input_tokens;
-  check int "output tokens" (minimal_meta.runtime.usage.total_output_tokens + 50) updated.runtime.usage.total_output_tokens
+  check
+    int
+    "input tokens"
+    (minimal_meta.runtime.usage.total_input_tokens + 100)
+    updated.runtime.usage.total_input_tokens;
+  check
+    int
+    "output tokens"
+    (minimal_meta.runtime.usage.total_output_tokens + 50)
+    updated.runtime.usage.total_output_tokens
+;;
 
 let test_metrics_idle_seconds_gauge_records_observation () =
   let idle_seconds = 19_006 in
   let result =
-    make_run_result ~text:"I checked the board." ~tools:[]
-      ~model:"test-model" ~input_tok:100 ~output_tok:50 ()
+    make_run_result
+      ~text:"I checked the board."
+      ~tools:[]
+      ~model:"test-model"
+      ~input_tok:100
+      ~output_tok:50
+      ()
   in
-  let observation = { base_observation with idle_seconds = idle_seconds } in
-  ignore
-    (UM.update_metrics_from_result minimal_meta ~latency_ms:200
-       ~observation result);
-  check (option (float 0.001)) "success idle seconds gauge"
+  let observation = { base_observation with idle_seconds } in
+  ignore (UM.update_metrics_from_result minimal_meta ~latency_ms:200 ~observation result);
+  check
+    (option (float 0.001))
+    "success idle seconds gauge"
     (Some (float_of_int idle_seconds))
     (Masc_mcp.Prometheus.get_metric_value
        Masc_mcp.Keeper_metrics.metric_keeper_idle_seconds
-       ~labels:[ ("keeper_name", minimal_meta.name) ]
+       ~labels:[ "keeper_name", minimal_meta.name ]
        ());
   let failure_idle_seconds = idle_seconds + 1 in
   let failure_observation =
     { base_observation with idle_seconds = failure_idle_seconds }
   in
   ignore
-    (UM.update_metrics_from_failure minimal_meta ~latency_ms:100
-       ~observation:failure_observation ~reason:"synthetic failure" ());
-  check (option (float 0.001)) "failure idle seconds gauge"
+    (UM.update_metrics_from_failure
+       minimal_meta
+       ~latency_ms:100
+       ~observation:failure_observation
+       ~reason:"synthetic failure"
+       ());
+  check
+    (option (float 0.001))
+    "failure idle seconds gauge"
     (Some (float_of_int failure_idle_seconds))
     (Masc_mcp.Prometheus.get_metric_value
        Masc_mcp.Keeper_metrics.metric_keeper_idle_seconds
-       ~labels:[ ("keeper_name", minimal_meta.name) ]
+       ~labels:[ "keeper_name", minimal_meta.name ]
        ())
+;;
 
 let test_metrics_surface_model_prefers_successful_cascade_label () =
   let selected_label = "llama:qwen3.5-3b-a3b-ud-q8-xl" in
   let result =
-    make_run_result ~text:"I checked the board." ~tools:[]
-      ~model:"qwen3.5:27b-nvfp4" ~input_tok:100 ~output_tok:50
+    make_run_result
+      ~text:"I checked the board."
+      ~tools:[]
+      ~model:"qwen3.5:27b-nvfp4"
+      ~input_tok:100
+      ~output_tok:50
       ~cascade_observation:
-        {
-          Masc_mcp.Cascade_legacy_runner.cascade_name =
+        { Masc_mcp.Cascade_legacy_runner.cascade_name =
             Masc_mcp.Keeper_cascade_profile.Runtime_name
-              Masc_mcp.(Keeper_config.default_cascade_name ());
-          strategy = Some "round_robin";
-          configured_labels = [ "llama:auto" ];
-          candidate_models =
-            [ "llama:qwen3.5-35b-a3b-ud-q8-xl"; selected_label ];
-          primary_model = Some "llama:qwen3.5-35b-a3b-ud-q8-xl";
-          selected_model = Some "qwen3.5:27b-nvfp4";
-          selected_model_raw = Some "qwen3.5:27b-nvfp4";
-          selected_index = None;
-          fallback_hops = Some 1;
-          fallback_applied = true;
-          attempts =
-            [
-              {
-                Masc_mcp.Cascade_legacy_runner.attempt_index = 0;
-                model_id = "qwen3.5-35b-a3b-ud-q8-xl";
-                model_label = Some "llama:qwen3.5-35b-a3b-ud-q8-xl";
-                latency_ms = None;
-                error = Some "HTTP 503";
-              };
-              {
-                attempt_index = 1;
-                model_id = "qwen3.5-3b-a3b-ud-q8-xl";
-                model_label = Some selected_label;
-                latency_ms = Some 187;
-                error = None;
-              };
-            ];
-          fallback_events =
-            [
-              {
-                from_model_id = "qwen3.5-35b-a3b-ud-q8-xl";
-                from_model_label = Some "llama:qwen3.5-35b-a3b-ud-q8-xl";
-                to_model_id = "qwen3.5-3b-a3b-ud-q8-xl";
-                to_model_label = Some selected_label;
-                reason = "HTTP 503";
-              };
-            ];
-          attempt_details_available = true;
-          attempt_details_source = "oas_metrics_callbacks";
+              Masc_mcp.(Keeper_config.default_cascade_name ())
+        ; strategy = Some "round_robin"
+        ; configured_labels = [ "llama:auto" ]
+        ; candidate_models = [ "llama:qwen3.5-35b-a3b-ud-q8-xl"; selected_label ]
+        ; primary_model = Some "llama:qwen3.5-35b-a3b-ud-q8-xl"
+        ; selected_model = Some "qwen3.5:27b-nvfp4"
+        ; selected_model_raw = Some "qwen3.5:27b-nvfp4"
+        ; selected_index = None
+        ; fallback_hops = Some 1
+        ; fallback_applied = true
+        ; attempts =
+            [ { Masc_mcp.Cascade_legacy_runner.attempt_index = 0
+              ; model_id = "qwen3.5-35b-a3b-ud-q8-xl"
+              ; model_label = Some "llama:qwen3.5-35b-a3b-ud-q8-xl"
+              ; latency_ms = None
+              ; error = Some "HTTP 503"
+              }
+            ; { attempt_index = 1
+              ; model_id = "qwen3.5-3b-a3b-ud-q8-xl"
+              ; model_label = Some selected_label
+              ; latency_ms = Some 187
+              ; error = None
+              }
+            ]
+        ; fallback_events =
+            [ { from_model_id = "qwen3.5-35b-a3b-ud-q8-xl"
+              ; from_model_label = Some "llama:qwen3.5-35b-a3b-ud-q8-xl"
+              ; to_model_id = "qwen3.5-3b-a3b-ud-q8-xl"
+              ; to_model_label = Some selected_label
+              ; reason = "HTTP 503"
+              }
+            ]
+        ; attempt_details_available = true
+        ; attempt_details_source = "oas_metrics_callbacks"
         }
       ()
   in
   let updated =
-    UM.update_metrics_from_result minimal_meta ~latency_ms:200
-      ~observation:base_observation result
+    UM.update_metrics_from_result
+      minimal_meta
+      ~latency_ms:200
+      ~observation:base_observation
+      result
   in
-  check string "helper canonicalizes surface model" selected_label
+  check
+    string
+    "helper canonicalizes surface model"
+    selected_label
     (KAR.surface_model_used result);
-  check string "last_model_used stores canonical surface label" selected_label
+  check
+    string
+    "last_model_used stores canonical surface label"
+    selected_label
     updated.runtime.usage.last_model_used
+;;
 
 (* #9953: [surface_resolved_model_id] returns the concrete model_id from
    the last cascade attempt, even when [model_label] is populated. This
@@ -2655,325 +3335,533 @@ let test_metrics_surface_model_prefers_successful_cascade_label () =
    variant instead of the auto label. *)
 let test_metrics_resolved_model_id_prefers_last_attempt_id () =
   let result =
-    make_run_result ~text:"I checked the board." ~tools:[]
-      ~model:"claude-opus-4-6" ~input_tok:100 ~output_tok:50
+    make_run_result
+      ~text:"I checked the board."
+      ~tools:[]
+      ~model:"claude-opus-4-6"
+      ~input_tok:100
+      ~output_tok:50
       ~cascade_observation:
-        {
-          Masc_mcp.Cascade_legacy_runner.cascade_name =
+        { Masc_mcp.Cascade_legacy_runner.cascade_name =
             Masc_mcp.Keeper_cascade_profile.Runtime_name
-              Masc_mcp.(Keeper_config.default_cascade_name ());
-          strategy = Some "round_robin";
-          configured_labels = [ "claude_code:auto" ];
-          candidate_models =
-            [ "claude-sonnet-4-6"; "claude-opus-4-6" ];
-          primary_model = Some "claude-sonnet-4-6";
-          selected_model = Some "claude-opus-4-6";
-          selected_model_raw = Some "claude-opus-4-6";
-          selected_index = None;
-          fallback_hops = Some 1;
-          fallback_applied = true;
-          attempts =
-            [
-              {
-                Masc_mcp.Cascade_legacy_runner.attempt_index = 0;
-                model_id = "claude-sonnet-4-6";
-                model_label = Some "claude_code:auto";
-                latency_ms = None;
-                error = Some "HTTP 503";
-              };
-              {
-                attempt_index = 1;
-                model_id = "claude-opus-4-6";
-                model_label = Some "claude_code:auto";
-                latency_ms = Some 187;
-                error = None;
-              };
-            ];
-          fallback_events = [];
-          attempt_details_available = true;
-          attempt_details_source = "oas_metrics_callbacks";
+              Masc_mcp.(Keeper_config.default_cascade_name ())
+        ; strategy = Some "round_robin"
+        ; configured_labels = [ "claude_code:auto" ]
+        ; candidate_models = [ "claude-sonnet-4-6"; "claude-opus-4-6" ]
+        ; primary_model = Some "claude-sonnet-4-6"
+        ; selected_model = Some "claude-opus-4-6"
+        ; selected_model_raw = Some "claude-opus-4-6"
+        ; selected_index = None
+        ; fallback_hops = Some 1
+        ; fallback_applied = true
+        ; attempts =
+            [ { Masc_mcp.Cascade_legacy_runner.attempt_index = 0
+              ; model_id = "claude-sonnet-4-6"
+              ; model_label = Some "claude_code:auto"
+              ; latency_ms = None
+              ; error = Some "HTTP 503"
+              }
+            ; { attempt_index = 1
+              ; model_id = "claude-opus-4-6"
+              ; model_label = Some "claude_code:auto"
+              ; latency_ms = Some 187
+              ; error = None
+              }
+            ]
+        ; fallback_events = []
+        ; attempt_details_available = true
+        ; attempt_details_source = "oas_metrics_callbacks"
         }
       ()
   in
-  check string "surface_model_used returns cascade label"
-    "claude_code:auto" (KAR.surface_model_used result);
-  check string "surface_resolved_model_id returns concrete variant id"
-    "claude-opus-4-6" (KAR.surface_resolved_model_id result)
+  check
+    string
+    "surface_model_used returns cascade label"
+    "claude_code:auto"
+    (KAR.surface_model_used result);
+  check
+    string
+    "surface_resolved_model_id returns concrete variant id"
+    "claude-opus-4-6"
+    (KAR.surface_resolved_model_id result)
+;;
 
 (* #9953: when no cascade observation is available, resolved id falls
    back to the raw [model_used] reported by the provider, not to the
    empty string. This preserves signal for non-cascade keeper turns. *)
 let test_metrics_resolved_model_id_fallback_to_model_used () =
   let result =
-    make_run_result ~text:"ok" ~tools:[] ~model:"claude-opus-4-6"
-      ~input_tok:10 ~output_tok:5 ()
+    make_run_result
+      ~text:"ok"
+      ~tools:[]
+      ~model:"claude-opus-4-6"
+      ~input_tok:10
+      ~output_tok:5
+      ()
   in
-  check string "surface_resolved_model_id falls back to model_used"
-    "claude-opus-4-6" (KAR.surface_resolved_model_id result)
+  check
+    string
+    "surface_resolved_model_id falls back to model_used"
+    "claude-opus-4-6"
+    (KAR.surface_resolved_model_id result)
+;;
 
 let test_metrics_tool_response () =
   let result =
-    make_run_result ~text:"" ~tools:["keeper_board_post"; "keeper_board_comment"]
-      ~model:"test-model" ~input_tok:200 ~output_tok:80 ()
+    make_run_result
+      ~text:""
+      ~tools:[ "keeper_board_post"; "keeper_board_comment" ]
+      ~model:"test-model"
+      ~input_tok:200
+      ~output_tok:80
+      ()
   in
   let updated =
-    UM.update_metrics_from_result minimal_meta ~latency_ms:500
-      ~observation:base_observation result
+    UM.update_metrics_from_result
+      minimal_meta
+      ~latency_ms:500
+      ~observation:base_observation
+      result
   in
-  check int "proactive_count +1" (minimal_meta.runtime.proactive_rt.count_total + 1)
+  check
+    int
+    "proactive_count +1"
+    (minimal_meta.runtime.proactive_rt.count_total + 1)
     updated.runtime.proactive_rt.count_total;
-  check int "proactive visible_count +1"
+  check
+    int
+    "proactive visible_count +1"
     (minimal_meta.runtime.proactive_rt.visible_count_total + 1)
     updated.runtime.proactive_rt.visible_count_total;
-  check bool "proactive outcome tool" true
-    (updated.runtime.proactive_rt.last_outcome
-     = Masc_mcp.Keeper_types.Proactive_tool_use);
-  check int "autonomous_action +2" (minimal_meta.runtime.autonomous_action_count + 2)
+  check
+    bool
+    "proactive outcome tool"
+    true
+    (updated.runtime.proactive_rt.last_outcome = Masc_mcp.Keeper_types.Proactive_tool_use);
+  check
+    int
+    "autonomous_action +2"
+    (minimal_meta.runtime.autonomous_action_count + 2)
     updated.runtime.autonomous_action_count;
-  check bool "last autonomous action ts updated" true
+  check
+    bool
+    "last autonomous action ts updated"
+    true
     (String.trim updated.runtime.last_autonomous_action_at <> "");
   check int "latency_ms" 500 updated.runtime.usage.last_latency_ms
+;;
 
 let test_metrics_noop_response () =
   let result =
-    make_run_result ~text:"" ~tools:[]
-      ~model:"test-model" ~input_tok:50 ~output_tok:10 ()
+    make_run_result ~text:"" ~tools:[] ~model:"test-model" ~input_tok:50 ~output_tok:10 ()
   in
   let updated =
-    UM.update_metrics_from_result minimal_meta ~latency_ms:100
-      ~observation:base_observation result
+    UM.update_metrics_from_result
+      minimal_meta
+      ~latency_ms:100
+      ~observation:base_observation
+      result
   in
-  check int "proactive_count +1"
+  check
+    int
+    "proactive_count +1"
     (minimal_meta.runtime.proactive_rt.count_total + 1)
     updated.runtime.proactive_rt.count_total;
-  check int "proactive visible_count unchanged"
+  check
+    int
+    "proactive visible_count unchanged"
     minimal_meta.runtime.proactive_rt.visible_count_total
     updated.runtime.proactive_rt.visible_count_total;
-  check bool "proactive outcome silent" true
-    (updated.runtime.proactive_rt.last_outcome
-     = Masc_mcp.Keeper_types.Proactive_silent);
-  check int "autonomous unchanged" minimal_meta.runtime.autonomous_action_count
+  check
+    bool
+    "proactive outcome silent"
+    true
+    (updated.runtime.proactive_rt.last_outcome = Masc_mcp.Keeper_types.Proactive_silent);
+  check
+    int
+    "autonomous unchanged"
+    minimal_meta.runtime.autonomous_action_count
     updated.runtime.autonomous_action_count;
-  check int "total_turns +1" (minimal_meta.runtime.usage.total_turns + 1) updated.runtime.usage.total_turns
+  check
+    int
+    "total_turns +1"
+    (minimal_meta.runtime.usage.total_turns + 1)
+    updated.runtime.usage.total_turns
+;;
 
 let test_metrics_observation_only_tools_are_noop () =
   let observation_only =
-    [
-      Masc_mcp.Tool_name.Keeper.to_string Masc_mcp.Tool_name.Keeper.Board_list;
-      Masc_mcp.Tool_name.Keeper.to_string
-        Masc_mcp.Tool_name.Keeper.Context_status;
-      Masc_mcp.Tool_name.Keeper.to_string
-        Masc_mcp.Tool_name.Keeper.Tool_search;
-      Masc_mcp.Tool_name.Keeper.to_string Masc_mcp.Tool_name.Keeper.Tasks_list;
-      Masc_mcp.Tool_name.Keeper.to_string Masc_mcp.Tool_name.Keeper.Task_claim;
+    [ Masc_mcp.Tool_name.Keeper.to_string Masc_mcp.Tool_name.Keeper.Board_list
+    ; Masc_mcp.Tool_name.Keeper.to_string Masc_mcp.Tool_name.Keeper.Context_status
+    ; Masc_mcp.Tool_name.Keeper.to_string Masc_mcp.Tool_name.Keeper.Tool_search
+    ; Masc_mcp.Tool_name.Keeper.to_string Masc_mcp.Tool_name.Keeper.Tasks_list
+    ; Masc_mcp.Tool_name.Keeper.to_string Masc_mcp.Tool_name.Keeper.Task_claim
     ]
   in
   let result =
-    make_run_result ~text:"" ~tools:observation_only
-      ~model:"test-model" ~input_tok:50 ~output_tok:10 ()
+    make_run_result
+      ~text:""
+      ~tools:observation_only
+      ~model:"test-model"
+      ~input_tok:50
+      ~output_tok:10
+      ()
   in
   let updated =
-    UM.update_metrics_from_result minimal_meta ~latency_ms:100
-      ~observation:base_observation result
+    UM.update_metrics_from_result
+      minimal_meta
+      ~latency_ms:100
+      ~observation:base_observation
+      result
   in
-  check bool "tools are not substantive" false
+  check
+    bool
+    "tools are not substantive"
+    false
     (UM.has_substantive_tool_calls observation_only);
-  check int "proactive visible_count unchanged"
+  check
+    int
+    "proactive visible_count unchanged"
     minimal_meta.runtime.proactive_rt.visible_count_total
     updated.runtime.proactive_rt.visible_count_total;
-  check int "autonomous action unchanged"
+  check
+    int
+    "autonomous action unchanged"
     minimal_meta.runtime.autonomous_action_count
     updated.runtime.autonomous_action_count;
-  check int "autonomous tool turn unchanged"
+  check
+    int
+    "autonomous tool turn unchanged"
     minimal_meta.runtime.autonomous_tool_turn_count
     updated.runtime.autonomous_tool_turn_count;
-  check int "noop turn increments"
+  check
+    int
+    "noop turn increments"
     (minimal_meta.runtime.noop_turn_count + 1)
     updated.runtime.noop_turn_count
+;;
 
 let test_metrics_execution_tools_are_substantive () =
-  check bool "claim alone is not execution progress" false
+  check
+    bool
+    "claim alone is not execution progress"
+    false
     (UM.has_substantive_tool_calls [ "keeper_task_claim" ]);
-  check bool "task listing is not execution progress" false
+  check
+    bool
+    "task listing is not execution progress"
+    false
     (UM.has_substantive_tool_calls [ "keeper_tasks_list" ]);
-  check bool "task creation is execution progress" true
+  check
+    bool
+    "task creation is execution progress"
+    true
     (UM.has_substantive_tool_calls [ "keeper_task_create" ]);
-  check bool "masc task creation is execution progress" true
+  check
+    bool
+    "masc task creation is execution progress"
+    true
     (UM.has_substantive_tool_calls [ "masc_add_task" ]);
-  check bool "masc batch task creation is execution progress" true
+  check
+    bool
+    "masc batch task creation is execution progress"
+    true
     (UM.has_substantive_tool_calls [ "masc_batch_add_tasks" ]);
-  check bool "force release is execution progress" true
+  check
+    bool
+    "force release is execution progress"
+    true
     (UM.has_substantive_tool_calls [ "keeper_task_force_release" ]);
-  check bool "bash is execution progress" true
+  check
+    bool
+    "bash is execution progress"
+    true
     (UM.has_substantive_tool_calls [ "keeper_bash" ]);
-  check bool "completion is execution progress" true
+  check
+    bool
+    "completion is execution progress"
+    true
     (UM.has_substantive_tool_calls [ "keeper_task_submit_for_verification" ])
+;;
 
-let sample_run_ref : Agent_sdk.Raw_trace.run_ref = {
-  worker_run_id = "test-run"; path = "/tmp/test.jsonl";
-  start_seq = 0; end_seq = 5; agent_name = "test"; session_id = None;
-}
+let sample_run_ref : Agent_sdk.Raw_trace.run_ref =
+  { worker_run_id = "test-run"
+  ; path = "/tmp/test.jsonl"
+  ; start_seq = 0
+  ; end_seq = 5
+  ; agent_name = "test"
+  ; session_id = None
+  }
+;;
 
 let test_metrics_validated_evidence_counts_as_visible () =
-  let validation : Agent_sdk.Raw_trace.run_validation = {
-    run_ref = sample_run_ref; ok = true;
-    checks = []; evidence = ["tool_paired:keeper_fs_read"];
-    paired_tool_result_count = 1; has_file_write = false;
-    verification_pass_after_file_write = false;
-    final_text = None; tool_names = ["keeper_fs_read"];
-    stop_reason = None; failure_reason = None;
-  } in
-  let result =
-    make_run_result ~text:"" ~tools:[]
-      ~model:"test-model" ~input_tok:50 ~output_tok:10
-      ~run_validation:validation ()
-  in
-  let updated =
-    UM.update_metrics_from_result minimal_meta ~latency_ms:100
-      ~observation:base_observation result
-  in
-  check int "proactive visible_count +1"
-    (minimal_meta.runtime.proactive_rt.visible_count_total + 1)
-    updated.runtime.proactive_rt.visible_count_total;
-  check bool "validated evidence outcome is tool_use" true
-    (updated.runtime.proactive_rt.last_outcome
-     = Masc_mcp.Keeper_types.Proactive_tool_use);
-  check string "validated evidence preview"
-    "(validated evidence: keeper_fs_read)"
-    updated.runtime.proactive_rt.last_preview;
-  check int "noop unchanged"
-    minimal_meta.runtime.noop_turn_count
-    updated.runtime.noop_turn_count;
-  check int "autonomous action unchanged"
-    minimal_meta.runtime.autonomous_action_count
-    updated.runtime.autonomous_action_count;
-  check string "last autonomous action ts unchanged"
-    minimal_meta.runtime.last_autonomous_action_at
-    updated.runtime.last_autonomous_action_at;
-  check bool "last_reason contains validated_evidence" true
-    (String.length updated.runtime.proactive_rt.last_reason > 0
-     && (let r = updated.runtime.proactive_rt.last_reason in
-         try ignore (Str.search_forward (Str.regexp_string "validated_evidence") r 0); true
-         with Not_found -> false))
-
-let test_metrics_failed_validation_does_not_count_as_visible () =
-  let validation : Agent_sdk.Raw_trace.run_validation = {
-    run_ref = sample_run_ref; ok = false;
-    checks = []; evidence = [];
-    paired_tool_result_count = 0; has_file_write = false;
-    verification_pass_after_file_write = false;
-    final_text = None; tool_names = [];
-    stop_reason = None; failure_reason = Some "validation failed";
-  } in
-  let result =
-    make_run_result ~text:"" ~tools:[]
-      ~model:"test-model" ~input_tok:50 ~output_tok:10
-      ~run_validation:validation ()
-  in
-  let updated =
-    UM.update_metrics_from_result minimal_meta ~latency_ms:100
-      ~observation:base_observation result
-  in
-  check int "proactive visible_count unchanged"
-    minimal_meta.runtime.proactive_rt.visible_count_total
-    updated.runtime.proactive_rt.visible_count_total;
-  check bool "outcome is silent" true
-    (updated.runtime.proactive_rt.last_outcome
-     = Masc_mcp.Keeper_types.Proactive_silent)
-
-let test_metrics_file_write_evidence_counts_as_visible () =
-  let validation : Agent_sdk.Raw_trace.run_validation = {
-    run_ref = sample_run_ref; ok = true;
-    checks = []; evidence = [];
-    paired_tool_result_count = 0; has_file_write = true;
-    verification_pass_after_file_write = true;
-    final_text = None; tool_names = ["keeper_fs_write"];
-    stop_reason = None; failure_reason = None;
-  } in
-  let result =
-    make_run_result ~text:"" ~tools:[]
-      ~model:"test-model" ~input_tok:50 ~output_tok:10
-      ~run_validation:validation ()
-  in
-  let updated =
-    UM.update_metrics_from_result minimal_meta ~latency_ms:100
-      ~observation:base_observation result
-  in
-  check int "proactive visible_count +1"
-    (minimal_meta.runtime.proactive_rt.visible_count_total + 1)
-    updated.runtime.proactive_rt.visible_count_total;
-  check bool "file write evidence outcome is tool_use" true
-    (updated.runtime.proactive_rt.last_outcome
-     = Masc_mcp.Keeper_types.Proactive_tool_use);
-  check string "file write evidence preview"
-    "(validated evidence: file_write)"
-    updated.runtime.proactive_rt.last_preview;
-  check int "noop unchanged"
-    minimal_meta.runtime.noop_turn_count
-    updated.runtime.noop_turn_count;
-  check int "autonomous action unchanged"
-    minimal_meta.runtime.autonomous_action_count
-    updated.runtime.autonomous_action_count;
-  check string "last autonomous action ts unchanged"
-    minimal_meta.runtime.last_autonomous_action_at
-    updated.runtime.last_autonomous_action_at
-
-let test_metrics_heartbeat_only_tool_response_is_maintenance_only () =
-  let result =
-    make_run_result ~text:"" ~tools:[]
-      ~model:"test-model" ~input_tok:40 ~output_tok:0 ()
-  in
-  let updated =
-    UM.update_metrics_from_result minimal_meta ~latency_ms:80
-      ~observation:base_observation result
-  in
-  check int "proactive_count +1"
-    (minimal_meta.runtime.proactive_rt.count_total + 1)
-    updated.runtime.proactive_rt.count_total;
-  check int "proactive visible_count unchanged"
-    minimal_meta.runtime.proactive_rt.visible_count_total
-    updated.runtime.proactive_rt.visible_count_total;
-  check bool "heartbeat-only outcome stays silent" true
-    (updated.runtime.proactive_rt.last_outcome
-     = Masc_mcp.Keeper_types.Proactive_silent);
-  check int "autonomous action unchanged"
-    minimal_meta.runtime.autonomous_action_count
-    updated.runtime.autonomous_action_count;
-  check int "autonomous tool turn unchanged"
-    minimal_meta.runtime.autonomous_tool_turn_count
-    updated.runtime.autonomous_tool_turn_count;
-  check int "noop turn increments"
-    (minimal_meta.runtime.noop_turn_count + 1)
-    updated.runtime.noop_turn_count
-
-let test_metrics_reactive_turn_does_not_mutate_proactive_runtime () =
-  let reactive_observation =
-    { base_observation with
-      pending_mentions = [ ("alice", "@test-keeper check this") ]
+  let validation : Agent_sdk.Raw_trace.run_validation =
+    { run_ref = sample_run_ref
+    ; ok = true
+    ; checks = []
+    ; evidence = [ "tool_paired:keeper_fs_read" ]
+    ; paired_tool_result_count = 1
+    ; has_file_write = false
+    ; verification_pass_after_file_write = false
+    ; final_text = None
+    ; tool_names = [ "keeper_fs_read" ]
+    ; stop_reason = None
+    ; failure_reason = None
     }
   in
   let result =
-    make_run_result ~text:"On it." ~tools:[]
-      ~model:"test-model" ~input_tok:90 ~output_tok:30 ()
+    make_run_result
+      ~text:""
+      ~tools:[]
+      ~model:"test-model"
+      ~input_tok:50
+      ~output_tok:10
+      ~run_validation:validation
+      ()
   in
   let updated =
-    UM.update_metrics_from_result minimal_meta ~latency_ms:120
-      ~observation:reactive_observation result
+    UM.update_metrics_from_result
+      minimal_meta
+      ~latency_ms:100
+      ~observation:base_observation
+      result
   in
-  check int "proactive_count unchanged on reactive turn"
-    minimal_meta.runtime.proactive_rt.count_total
-    updated.runtime.proactive_rt.count_total;
-  check int "proactive visible_count unchanged on reactive turn"
+  check
+    int
+    "proactive visible_count +1"
+    (minimal_meta.runtime.proactive_rt.visible_count_total + 1)
+    updated.runtime.proactive_rt.visible_count_total;
+  check
+    bool
+    "validated evidence outcome is tool_use"
+    true
+    (updated.runtime.proactive_rt.last_outcome = Masc_mcp.Keeper_types.Proactive_tool_use);
+  check
+    string
+    "validated evidence preview"
+    "(validated evidence: keeper_fs_read)"
+    updated.runtime.proactive_rt.last_preview;
+  check
+    int
+    "noop unchanged"
+    minimal_meta.runtime.noop_turn_count
+    updated.runtime.noop_turn_count;
+  check
+    int
+    "autonomous action unchanged"
+    minimal_meta.runtime.autonomous_action_count
+    updated.runtime.autonomous_action_count;
+  check
+    string
+    "last autonomous action ts unchanged"
+    minimal_meta.runtime.last_autonomous_action_at
+    updated.runtime.last_autonomous_action_at;
+  check
+    bool
+    "last_reason contains validated_evidence"
+    true
+    (String.length updated.runtime.proactive_rt.last_reason > 0
+     &&
+     let r = updated.runtime.proactive_rt.last_reason in
+     try
+       ignore (Str.search_forward (Str.regexp_string "validated_evidence") r 0);
+       true
+     with
+     | Not_found -> false)
+;;
+
+let test_metrics_failed_validation_does_not_count_as_visible () =
+  let validation : Agent_sdk.Raw_trace.run_validation =
+    { run_ref = sample_run_ref
+    ; ok = false
+    ; checks = []
+    ; evidence = []
+    ; paired_tool_result_count = 0
+    ; has_file_write = false
+    ; verification_pass_after_file_write = false
+    ; final_text = None
+    ; tool_names = []
+    ; stop_reason = None
+    ; failure_reason = Some "validation failed"
+    }
+  in
+  let result =
+    make_run_result
+      ~text:""
+      ~tools:[]
+      ~model:"test-model"
+      ~input_tok:50
+      ~output_tok:10
+      ~run_validation:validation
+      ()
+  in
+  let updated =
+    UM.update_metrics_from_result
+      minimal_meta
+      ~latency_ms:100
+      ~observation:base_observation
+      result
+  in
+  check
+    int
+    "proactive visible_count unchanged"
     minimal_meta.runtime.proactive_rt.visible_count_total
     updated.runtime.proactive_rt.visible_count_total;
-  check bool "proactive outcome unchanged on reactive turn" true
+  check
+    bool
+    "outcome is silent"
+    true
+    (updated.runtime.proactive_rt.last_outcome = Masc_mcp.Keeper_types.Proactive_silent)
+;;
+
+let test_metrics_file_write_evidence_counts_as_visible () =
+  let validation : Agent_sdk.Raw_trace.run_validation =
+    { run_ref = sample_run_ref
+    ; ok = true
+    ; checks = []
+    ; evidence = []
+    ; paired_tool_result_count = 0
+    ; has_file_write = true
+    ; verification_pass_after_file_write = true
+    ; final_text = None
+    ; tool_names = [ "keeper_fs_write" ]
+    ; stop_reason = None
+    ; failure_reason = None
+    }
+  in
+  let result =
+    make_run_result
+      ~text:""
+      ~tools:[]
+      ~model:"test-model"
+      ~input_tok:50
+      ~output_tok:10
+      ~run_validation:validation
+      ()
+  in
+  let updated =
+    UM.update_metrics_from_result
+      minimal_meta
+      ~latency_ms:100
+      ~observation:base_observation
+      result
+  in
+  check
+    int
+    "proactive visible_count +1"
+    (minimal_meta.runtime.proactive_rt.visible_count_total + 1)
+    updated.runtime.proactive_rt.visible_count_total;
+  check
+    bool
+    "file write evidence outcome is tool_use"
+    true
+    (updated.runtime.proactive_rt.last_outcome = Masc_mcp.Keeper_types.Proactive_tool_use);
+  check
+    string
+    "file write evidence preview"
+    "(validated evidence: file_write)"
+    updated.runtime.proactive_rt.last_preview;
+  check
+    int
+    "noop unchanged"
+    minimal_meta.runtime.noop_turn_count
+    updated.runtime.noop_turn_count;
+  check
+    int
+    "autonomous action unchanged"
+    minimal_meta.runtime.autonomous_action_count
+    updated.runtime.autonomous_action_count;
+  check
+    string
+    "last autonomous action ts unchanged"
+    minimal_meta.runtime.last_autonomous_action_at
+    updated.runtime.last_autonomous_action_at
+;;
+
+let test_metrics_heartbeat_only_tool_response_is_maintenance_only () =
+  let result =
+    make_run_result ~text:"" ~tools:[] ~model:"test-model" ~input_tok:40 ~output_tok:0 ()
+  in
+  let updated =
+    UM.update_metrics_from_result
+      minimal_meta
+      ~latency_ms:80
+      ~observation:base_observation
+      result
+  in
+  check
+    int
+    "proactive_count +1"
+    (minimal_meta.runtime.proactive_rt.count_total + 1)
+    updated.runtime.proactive_rt.count_total;
+  check
+    int
+    "proactive visible_count unchanged"
+    minimal_meta.runtime.proactive_rt.visible_count_total
+    updated.runtime.proactive_rt.visible_count_total;
+  check
+    bool
+    "heartbeat-only outcome stays silent"
+    true
+    (updated.runtime.proactive_rt.last_outcome = Masc_mcp.Keeper_types.Proactive_silent);
+  check
+    int
+    "autonomous action unchanged"
+    minimal_meta.runtime.autonomous_action_count
+    updated.runtime.autonomous_action_count;
+  check
+    int
+    "autonomous tool turn unchanged"
+    minimal_meta.runtime.autonomous_tool_turn_count
+    updated.runtime.autonomous_tool_turn_count;
+  check
+    int
+    "noop turn increments"
+    (minimal_meta.runtime.noop_turn_count + 1)
+    updated.runtime.noop_turn_count
+;;
+
+let test_metrics_reactive_turn_does_not_mutate_proactive_runtime () =
+  let reactive_observation =
+    { base_observation with pending_mentions = [ "alice", "@test-keeper check this" ] }
+  in
+  let result =
+    make_run_result
+      ~text:"On it."
+      ~tools:[]
+      ~model:"test-model"
+      ~input_tok:90
+      ~output_tok:30
+      ()
+  in
+  let updated =
+    UM.update_metrics_from_result
+      minimal_meta
+      ~latency_ms:120
+      ~observation:reactive_observation
+      result
+  in
+  check
+    int
+    "proactive_count unchanged on reactive turn"
+    minimal_meta.runtime.proactive_rt.count_total
+    updated.runtime.proactive_rt.count_total;
+  check
+    int
+    "proactive visible_count unchanged on reactive turn"
+    minimal_meta.runtime.proactive_rt.visible_count_total
+    updated.runtime.proactive_rt.visible_count_total;
+  check
+    bool
+    "proactive outcome unchanged on reactive turn"
+    true
     (minimal_meta.runtime.proactive_rt.last_outcome
      = updated.runtime.proactive_rt.last_outcome)
+;;
 
 let test_silent_proactive_cycle_advances_cooldown_anchor () =
   let result =
-    make_run_result ~text:"" ~tools:[]
-      ~model:"test-model" ~input_tok:40 ~output_tok:10 ()
+    make_run_result ~text:"" ~tools:[] ~model:"test-model" ~input_tok:40 ~output_tok:10 ()
   in
   let updated =
     UM.update_metrics_from_result
@@ -2984,536 +3872,671 @@ let test_silent_proactive_cycle_advances_cooldown_anchor () =
       ~observation:base_observation
       result
   in
-  check bool "silent proactive updates last_ts" true
+  check
+    bool
+    "silent proactive updates last_ts"
+    true
     (updated.runtime.proactive_rt.last_ts > 0.0);
-  check bool "silent proactive leaves last_visible_ts untouched" true
+  check
+    bool
+    "silent proactive leaves last_visible_ts untouched"
+    true
     (updated.runtime.proactive_rt.last_visible_ts = 0.0);
-  check bool "cooldown blocks immediate rerun after silent cycle" false
+  check
+    bool
+    "cooldown blocks immediate rerun after silent cycle"
+    false
     (WO.should_run_keeper_cycle ~meta:updated base_observation)
+;;
 
 let test_metrics_reactive_failure_does_not_mutate_proactive_runtime () =
   let reactive_observation =
-    { base_observation with
-      pending_board_events = [ sample_board_event ]
-    }
+    { base_observation with pending_board_events = [ sample_board_event ] }
   in
   let updated =
-    UM.update_metrics_from_failure minimal_meta ~latency_ms:90
-      ~observation:reactive_observation ~reason:"reactive failure" ()
+    UM.update_metrics_from_failure
+      minimal_meta
+      ~latency_ms:90
+      ~observation:reactive_observation
+      ~reason:"reactive failure"
+      ()
   in
-  check int "reactive failure leaves proactive_count unchanged"
+  check
+    int
+    "reactive failure leaves proactive_count unchanged"
     minimal_meta.runtime.proactive_rt.count_total
     updated.runtime.proactive_rt.count_total;
-  check int "reactive failure leaves visible_count unchanged"
+  check
+    int
+    "reactive failure leaves visible_count unchanged"
     minimal_meta.runtime.proactive_rt.visible_count_total
     updated.runtime.proactive_rt.visible_count_total;
-  check bool "reactive failure leaves last_ts unchanged" true
-    (updated.runtime.proactive_rt.last_ts
-     = minimal_meta.runtime.proactive_rt.last_ts);
-  check bool "reactive failure leaves last_outcome unchanged" true
+  check
+    bool
+    "reactive failure leaves last_ts unchanged"
+    true
+    (updated.runtime.proactive_rt.last_ts = minimal_meta.runtime.proactive_rt.last_ts);
+  check
+    bool
+    "reactive failure leaves last_outcome unchanged"
+    true
     (updated.runtime.proactive_rt.last_outcome
      = minimal_meta.runtime.proactive_rt.last_outcome)
+;;
 
 let test_meta_migration_does_not_infer_visible_proactive_fields () =
   let legacy_json =
     `Assoc
-      [
-        ("name", `String "legacy-keeper");
-        ("goal", `String "legacy goal");
-        ("trace_id", `String "legacy-trace");
-        ("proactive_count_total", `Int 7);
-        ("last_proactive_ts", `Float 1234.0);
+      [ "name", `String "legacy-keeper"
+      ; "goal", `String "legacy goal"
+      ; "trace_id", `String "legacy-trace"
+      ; "proactive_count_total", `Int 7
+      ; "last_proactive_ts", `Float 1234.0
       ]
   in
   match Masc_test_deps.meta_of_json_fixture legacy_json with
   | Error e -> fail ("legacy meta_of_json failed: " ^ e)
   | Ok meta ->
-      check int "legacy visible count stays unknown->0" 0
-        meta.runtime.proactive_rt.visible_count_total;
-      check (float 0.001) "legacy visible ts stays unknown->0" 0.0
-        meta.runtime.proactive_rt.last_visible_ts;
-      check bool "legacy outcome unknown" true
-        (meta.runtime.proactive_rt.last_outcome
-         = Masc_mcp.Keeper_types.Proactive_unknown)
+    check
+      int
+      "legacy visible count stays unknown->0"
+      0
+      meta.runtime.proactive_rt.visible_count_total;
+    check
+      (float 0.001)
+      "legacy visible ts stays unknown->0"
+      0.0
+      meta.runtime.proactive_rt.last_visible_ts;
+    check
+      bool
+      "legacy outcome unknown"
+      true
+      (meta.runtime.proactive_rt.last_outcome = Masc_mcp.Keeper_types.Proactive_unknown)
+;;
 
 let test_append_metrics_snapshot_includes_cascade_observation () =
-  Eio_main.run @@ fun env ->
+  Eio_main.run
+  @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
   let base_dir = temp_dir () in
   Fun.protect
     ~finally:(fun () -> cleanup_dir base_dir)
     (fun () ->
-      let config = Masc_mcp.Coord.default_config base_dir in
-      let validation : Agent_sdk.Raw_trace.run_validation = {
-        run_ref = sample_run_ref; ok = true;
-        checks = []; evidence = ["tool_paired:keeper_board_list"];
-        paired_tool_result_count = 1; has_file_write = false;
-        verification_pass_after_file_write = false;
-        final_text = Some "Observed";
-        tool_names = ["keeper_board_list"];
-        stop_reason = Some "completed"; failure_reason = None;
-      } in
-      let result =
-        {
-          (make_run_result ~text:"Observed" ~tools:[]
-             ~model:"qwen3.5:27b-nvfp4" ~input_tok:40 ~output_tok:20 ())
-          with
-          prompt_metrics =
-            sample_prompt_metrics
-              ~system_prompt:"You are a keeper focused on triage."
-              ~dynamic_context:"Pending mentions: 2"
-              ~user_message:"Review the board and decide what to do next."
-              ();
-          trace_ref = Some sample_run_ref;
-          run_validation = Some validation;
-          cascade_observation =
-            Some
-              {
-                Masc_mcp.Cascade_legacy_runner.cascade_name =
-                  Masc_mcp.Keeper_cascade_profile.Runtime_name
-                    Masc_mcp.(Keeper_config.default_cascade_name ());
-                strategy = Some "round_robin";
-                configured_labels = [ "llama:auto" ];
-                candidate_models =
-                  [
-                    "llama:qwen3.5-35b-a3b-ud-q8-xl";
-                    "llama:qwen3.5-3b-a3b-ud-q8-xl";
-                  ];
-                primary_model = Some "llama:qwen3.5-35b-a3b-ud-q8-xl";
-                selected_model = Some "qwen3.5:27b-nvfp4";
-                selected_model_raw = Some "qwen3.5:27b-nvfp4";
-                selected_index = Some 1;
-                fallback_hops = Some 1;
-                fallback_applied = true;
-                attempts =
-                  [
-                    {
-                      Masc_mcp.Cascade_legacy_runner.attempt_index = 0;
-                      model_id = "qwen3.5-35b-a3b-ud-q8-xl";
-                      model_label = Some "llama:qwen3.5-35b-a3b-ud-q8-xl";
-                      latency_ms = None;
-                      error = Some "HTTP 503";
-                    };
-                    {
-                      attempt_index = 1;
-                      model_id = "qwen3.5-3b-a3b-ud-q8-xl";
-                      model_label = Some "llama:qwen3.5-3b-a3b-ud-q8-xl";
-                      latency_ms = Some 187;
-                      error = None;
-                    };
-                  ];
-                fallback_events =
-                  [
-                    {
-                      from_model_id = "qwen3.5-35b-a3b-ud-q8-xl";
-                      from_model_label = Some "llama:qwen3.5-35b-a3b-ud-q8-xl";
-                      to_model_id = "qwen3.5-3b-a3b-ud-q8-xl";
-                      to_model_label = Some "llama:qwen3.5-3b-a3b-ud-q8-xl";
-                      reason = "HTTP 503";
-                    };
-                  ];
-                attempt_details_available = true;
-                attempt_details_source = "oas_metrics_callbacks";
-              };
-        }
-      in
-      let deliberation_execution =
-        KD.baseline_execution_result
-          (KD.empty_world_observation ~keeper_name:minimal_meta.name)
-      in
-      let completed_before =
-        Masc_mcp.Prometheus.metric_value_or_zero
-          Masc_mcp.Keeper_metrics.metric_keeper_turn_completed
-          ~labels:[("keeper_name", minimal_meta.name)]
-          ()
-      in
-      UM.append_metrics_snapshot
-        ~config
-        ~meta:minimal_meta
-        ~observation:base_observation
-        ~result
-        ~latency_ms:123
-        ~turn_cost:0.01
-        ~turn_generation:1
-        ~channel:"turn"
-        ~snapshot_source:"test"
-        ~context_ratio:0.1
-        ~context_tokens:10
-        ~context_max:100
-        ~message_count:2
-        ~compaction:
-          {
-            Masc_mcp.Keeper_exec_context.applied = false;
-            attempted = false;
-            failure_reason = None;
-            trigger = None;
-            decision = Masc_mcp.Keeper_exec_context.Blocked_below_thresholds;
-            before_tokens = 0;
-            after_tokens = 0;
-            saved_tokens = 0;
-          }
-        ~handoff_json:None
-        ~deliberation_execution
-        ();
-      let completed_after =
-        Masc_mcp.Prometheus.metric_value_or_zero
-          Masc_mcp.Keeper_metrics.metric_keeper_turn_completed
-          ~labels:[("keeper_name", minimal_meta.name)]
-          ()
-      in
-      check (float 0.0001) "turn completed counter increments"
-        (completed_before +. 1.0)
-        completed_after;
-      let metrics_store =
-        Masc_mcp.Keeper_types.keeper_metrics_store config minimal_meta.name
-      in
-      let line =
-        match Dated_jsonl.read_recent_lines metrics_store 1 with
-        | [ line ] -> line
-        | _ -> fail "expected one metrics line"
-      in
-      let json = Yojson.Safe.from_string line in
-      check string "metrics snapshot uses canonical surface model"
-        "llama:qwen3.5-3b-a3b-ud-q8-xl"
-        Yojson.Safe.Util.(json |> member "model_used" |> to_string);
-      check bool "cascade field present" true
-        Yojson.Safe.Util.(json |> member "cascade" <> `Null);
-      check string "cascade name persisted" Masc_mcp.(Keeper_config.default_cascade_name ())
-        Yojson.Safe.Util.(
-          json |> member "cascade" |> member "cascade_name" |> to_string);
-      check bool "fallback applied persisted" true
-        Yojson.Safe.Util.(
-          json |> member "cascade" |> member "fallback_applied" |> to_bool);
-      check int "attempts persisted" 2
-        Yojson.Safe.Util.(
-          json |> member "cascade" |> member "attempts" |> to_list
-          |> List.length);
-      check bool "attempt details available persisted" true
-        Yojson.Safe.Util.(
-          json |> member "cascade" |> member "attempt_details_available" |> to_bool);
-      check string "attempt detail boundary persisted" "oas_metrics_callbacks"
-        Yojson.Safe.Util.(
-          json |> member "cascade" |> member "attempt_details_source" |> to_string);
-      check string "action source persisted" "baseline"
-        Yojson.Safe.Util.(json |> member "action_source" |> to_string);
-      check string "nested deliberation execution source persisted" "baseline"
-        Yojson.Safe.Util.(
-          json |> member "deliberation_execution" |> member "action_source"
-          |> to_string);
-      check string "top-level prompt fingerprint persisted"
-        result.prompt_metrics.fingerprint
-        Yojson.Safe.Util.(json |> member "prompt_fingerprint" |> to_string);
-      check int "prompt total tokens persisted"
-        result.prompt_metrics.estimated_total_tokens
-        Yojson.Safe.Util.(
-          json |> member "prompt" |> member "estimated_total_tokens"
-          |> to_int);
-      check int "system prompt bytes persisted"
-        result.prompt_metrics.system_prompt_segment.bytes
-        Yojson.Safe.Util.(
-          json |> member "prompt" |> member "system_prompt" |> member "bytes"
-          |> to_int);
-      check string "user message fingerprint persisted"
-        (Option.value ~default:""
-           result.prompt_metrics.user_message_segment.fingerprint)
-        Yojson.Safe.Util.(
-          json |> member "prompt" |> member "user_message"
-          |> member "fingerprint" |> to_string);
-      check int "ctx composition known tokens persisted"
-        result.ctx_composition.estimated_known_tokens
-        Yojson.Safe.Util.(
-          json |> member "ctx_composition" |> member "estimated_known_tokens"
-          |> to_int);
-      check int "ctx composition display total persisted"
-        result.ctx_composition.display_total_tokens
-        Yojson.Safe.Util.(
-          json |> member "ctx_composition" |> member "display_total_tokens"
-          |> to_int);
-      check bool "ctx composition unattributed bucket persisted" true
-        Yojson.Safe.Util.(
-          json |> member "ctx_composition" |> member "segments"
-          |> member "unattributed" <> `Null);
-      check string "trace ref worker run id persisted"
-        sample_run_ref.worker_run_id
-        Yojson.Safe.Util.(
-          json |> member "trace_ref" |> member "worker_run_id" |> to_string);
-      check bool "run validation persisted" true
-        Yojson.Safe.Util.(json |> member "run_validation" <> `Null);
-      check bool "run validation ok persisted" true
-        Yojson.Safe.Util.(
-          json |> member "run_validation" |> member "ok" |> to_bool))
+       let config = Masc_mcp.Coord.default_config base_dir in
+       let validation : Agent_sdk.Raw_trace.run_validation =
+         { run_ref = sample_run_ref
+         ; ok = true
+         ; checks = []
+         ; evidence = [ "tool_paired:keeper_board_list" ]
+         ; paired_tool_result_count = 1
+         ; has_file_write = false
+         ; verification_pass_after_file_write = false
+         ; final_text = Some "Observed"
+         ; tool_names = [ "keeper_board_list" ]
+         ; stop_reason = Some "completed"
+         ; failure_reason = None
+         }
+       in
+       let result =
+         { (make_run_result
+              ~text:"Observed"
+              ~tools:[]
+              ~model:"qwen3.5:27b-nvfp4"
+              ~input_tok:40
+              ~output_tok:20
+              ())
+           with
+           prompt_metrics =
+             sample_prompt_metrics
+               ~system_prompt:"You are a keeper focused on triage."
+               ~dynamic_context:"Pending mentions: 2"
+               ~user_message:"Review the board and decide what to do next."
+               ()
+         ; trace_ref = Some sample_run_ref
+         ; run_validation = Some validation
+         ; cascade_observation =
+             Some
+               { Masc_mcp.Cascade_legacy_runner.cascade_name =
+                   Masc_mcp.Keeper_cascade_profile.Runtime_name
+                     Masc_mcp.(Keeper_config.default_cascade_name ())
+               ; strategy = Some "round_robin"
+               ; configured_labels = [ "llama:auto" ]
+               ; candidate_models =
+                   [ "llama:qwen3.5-35b-a3b-ud-q8-xl"; "llama:qwen3.5-3b-a3b-ud-q8-xl" ]
+               ; primary_model = Some "llama:qwen3.5-35b-a3b-ud-q8-xl"
+               ; selected_model = Some "qwen3.5:27b-nvfp4"
+               ; selected_model_raw = Some "qwen3.5:27b-nvfp4"
+               ; selected_index = Some 1
+               ; fallback_hops = Some 1
+               ; fallback_applied = true
+               ; attempts =
+                   [ { Masc_mcp.Cascade_legacy_runner.attempt_index = 0
+                     ; model_id = "qwen3.5-35b-a3b-ud-q8-xl"
+                     ; model_label = Some "llama:qwen3.5-35b-a3b-ud-q8-xl"
+                     ; latency_ms = None
+                     ; error = Some "HTTP 503"
+                     }
+                   ; { attempt_index = 1
+                     ; model_id = "qwen3.5-3b-a3b-ud-q8-xl"
+                     ; model_label = Some "llama:qwen3.5-3b-a3b-ud-q8-xl"
+                     ; latency_ms = Some 187
+                     ; error = None
+                     }
+                   ]
+               ; fallback_events =
+                   [ { from_model_id = "qwen3.5-35b-a3b-ud-q8-xl"
+                     ; from_model_label = Some "llama:qwen3.5-35b-a3b-ud-q8-xl"
+                     ; to_model_id = "qwen3.5-3b-a3b-ud-q8-xl"
+                     ; to_model_label = Some "llama:qwen3.5-3b-a3b-ud-q8-xl"
+                     ; reason = "HTTP 503"
+                     }
+                   ]
+               ; attempt_details_available = true
+               ; attempt_details_source = "oas_metrics_callbacks"
+               }
+         }
+       in
+       let deliberation_execution =
+         KD.baseline_execution_result
+           (KD.empty_world_observation ~keeper_name:minimal_meta.name)
+       in
+       let completed_before =
+         Masc_mcp.Prometheus.metric_value_or_zero
+           Masc_mcp.Keeper_metrics.metric_keeper_turn_completed
+           ~labels:[ "keeper_name", minimal_meta.name ]
+           ()
+       in
+       UM.append_metrics_snapshot
+         ~config
+         ~meta:minimal_meta
+         ~observation:base_observation
+         ~result
+         ~latency_ms:123
+         ~turn_cost:0.01
+         ~turn_generation:1
+         ~channel:"turn"
+         ~snapshot_source:"test"
+         ~context_ratio:0.1
+         ~context_tokens:10
+         ~context_max:100
+         ~message_count:2
+         ~compaction:
+           { Masc_mcp.Keeper_exec_context.applied = false
+           ; attempted = false
+           ; failure_reason = None
+           ; trigger = None
+           ; decision = Masc_mcp.Keeper_exec_context.Blocked_below_thresholds
+           ; before_tokens = 0
+           ; after_tokens = 0
+           ; saved_tokens = 0
+           }
+         ~handoff_json:None
+         ~deliberation_execution
+         ();
+       let completed_after =
+         Masc_mcp.Prometheus.metric_value_or_zero
+           Masc_mcp.Keeper_metrics.metric_keeper_turn_completed
+           ~labels:[ "keeper_name", minimal_meta.name ]
+           ()
+       in
+       check
+         (float 0.0001)
+         "turn completed counter increments"
+         (completed_before +. 1.0)
+         completed_after;
+       let metrics_store =
+         Masc_mcp.Keeper_types.keeper_metrics_store config minimal_meta.name
+       in
+       let line =
+         match Dated_jsonl.read_recent_lines metrics_store 1 with
+         | [ line ] -> line
+         | _ -> fail "expected one metrics line"
+       in
+       let json = Yojson.Safe.from_string line in
+       check
+         string
+         "metrics snapshot uses canonical surface model"
+         "llama:qwen3.5-3b-a3b-ud-q8-xl"
+         Yojson.Safe.Util.(json |> member "model_used" |> to_string);
+       check
+         bool
+         "cascade field present"
+         true
+         Yojson.Safe.Util.(json |> member "cascade" <> `Null);
+       check
+         string
+         "cascade name persisted"
+         Masc_mcp.(Keeper_config.default_cascade_name ())
+         Yojson.Safe.Util.(json |> member "cascade" |> member "cascade_name" |> to_string);
+       check
+         bool
+         "fallback applied persisted"
+         true
+         Yojson.Safe.Util.(
+           json |> member "cascade" |> member "fallback_applied" |> to_bool);
+       check
+         int
+         "attempts persisted"
+         2
+         Yojson.Safe.Util.(
+           json |> member "cascade" |> member "attempts" |> to_list |> List.length);
+       check
+         bool
+         "attempt details available persisted"
+         true
+         Yojson.Safe.Util.(
+           json |> member "cascade" |> member "attempt_details_available" |> to_bool);
+       check
+         string
+         "attempt detail boundary persisted"
+         "oas_metrics_callbacks"
+         Yojson.Safe.Util.(
+           json |> member "cascade" |> member "attempt_details_source" |> to_string);
+       check
+         string
+         "action source persisted"
+         "baseline"
+         Yojson.Safe.Util.(json |> member "action_source" |> to_string);
+       check
+         string
+         "nested deliberation execution source persisted"
+         "baseline"
+         Yojson.Safe.Util.(
+           json |> member "deliberation_execution" |> member "action_source" |> to_string);
+       check
+         string
+         "top-level prompt fingerprint persisted"
+         result.prompt_metrics.fingerprint
+         Yojson.Safe.Util.(json |> member "prompt_fingerprint" |> to_string);
+       check
+         int
+         "prompt total tokens persisted"
+         result.prompt_metrics.estimated_total_tokens
+         Yojson.Safe.Util.(
+           json |> member "prompt" |> member "estimated_total_tokens" |> to_int);
+       check
+         int
+         "system prompt bytes persisted"
+         result.prompt_metrics.system_prompt_segment.bytes
+         Yojson.Safe.Util.(
+           json |> member "prompt" |> member "system_prompt" |> member "bytes" |> to_int);
+       check
+         string
+         "user message fingerprint persisted"
+         (Option.value ~default:"" result.prompt_metrics.user_message_segment.fingerprint)
+         Yojson.Safe.Util.(
+           json
+           |> member "prompt"
+           |> member "user_message"
+           |> member "fingerprint"
+           |> to_string);
+       check
+         int
+         "ctx composition known tokens persisted"
+         result.ctx_composition.estimated_known_tokens
+         Yojson.Safe.Util.(
+           json |> member "ctx_composition" |> member "estimated_known_tokens" |> to_int);
+       check
+         int
+         "ctx composition display total persisted"
+         result.ctx_composition.display_total_tokens
+         Yojson.Safe.Util.(
+           json |> member "ctx_composition" |> member "display_total_tokens" |> to_int);
+       check
+         bool
+         "ctx composition unattributed bucket persisted"
+         true
+         Yojson.Safe.Util.(
+           json
+           |> member "ctx_composition"
+           |> member "segments"
+           |> member "unattributed"
+           <> `Null);
+       check
+         string
+         "trace ref worker run id persisted"
+         sample_run_ref.worker_run_id
+         Yojson.Safe.Util.(
+           json |> member "trace_ref" |> member "worker_run_id" |> to_string);
+       check
+         bool
+         "run validation persisted"
+         true
+         Yojson.Safe.Util.(json |> member "run_validation" <> `Null);
+       check
+         bool
+         "run validation ok persisted"
+         true
+         Yojson.Safe.Util.(json |> member "run_validation" |> member "ok" |> to_bool))
+;;
 
 let test_append_metrics_snapshot_treats_validated_evidence_as_tool_use () =
-  Eio_main.run @@ fun env ->
+  Eio_main.run
+  @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
   let base_dir = temp_dir () in
   Fun.protect
     ~finally:(fun () -> cleanup_dir base_dir)
     (fun () ->
-      let config = Masc_mcp.Coord.default_config base_dir in
-      let validation : Agent_sdk.Raw_trace.run_validation = {
-        run_ref = sample_run_ref; ok = true;
-        checks = []; evidence = ["tool_paired:keeper_fs_read"];
-        paired_tool_result_count = 1; has_file_write = false;
-        verification_pass_after_file_write = false;
-        final_text = None; tool_names = ["keeper_fs_read"];
-        stop_reason = None; failure_reason = None;
-      } in
-      let result =
-        make_run_result ~text:"" ~tools:[]
-          ~model:"openai:qwen3.5-35b" ~input_tok:40 ~output_tok:20
-          ~run_validation:validation ()
-      in
-      UM.append_metrics_snapshot
-        ~config
-        ~meta:minimal_meta
-        ~observation:base_observation
-        ~result
-        ~latency_ms:123
-        ~turn_cost:0.01
-        ~turn_generation:1
-        ~channel:"scheduled_autonomous"
-        ~snapshot_source:"test"
-        ~context_ratio:0.1
-        ~context_tokens:10
-        ~context_max:100
-        ~message_count:2
-        ~compaction:
-          {
-            Masc_mcp.Keeper_exec_context.applied = false;
-            attempted = false;
-            failure_reason = None;
-            trigger = None;
-            decision = Masc_mcp.Keeper_exec_context.Blocked_below_thresholds;
-            before_tokens = 0;
-            after_tokens = 0;
-            saved_tokens = 0;
-          }
-        ~handoff_json:None
-        ();
-      let metrics_store =
-        Masc_mcp.Keeper_types.keeper_metrics_store config minimal_meta.name
-      in
-      let line =
-        match Dated_jsonl.read_recent_lines metrics_store 1 with
-        | [ line ] -> line
-        | _ -> fail "expected one metrics line"
-      in
-      let json = Yojson.Safe.from_string line in
-      check string "turn mode persisted as tool_use" "tool_use"
-        Yojson.Safe.Util.(json |> member "turn_mode" |> to_string);
-      check bool "work_kind removed from snapshot" true
-        (match Yojson.Safe.Util.(json |> member "work_kind") with
-         | `Null -> true
-         | _ -> false);
-      check string "scheduled autonomous outcome persisted as tool_use"
-        "tool_use"
-        Yojson.Safe.Util.(
-          json |> member "scheduled_autonomous_outcome" |> to_string))
+       let config = Masc_mcp.Coord.default_config base_dir in
+       let validation : Agent_sdk.Raw_trace.run_validation =
+         { run_ref = sample_run_ref
+         ; ok = true
+         ; checks = []
+         ; evidence = [ "tool_paired:keeper_fs_read" ]
+         ; paired_tool_result_count = 1
+         ; has_file_write = false
+         ; verification_pass_after_file_write = false
+         ; final_text = None
+         ; tool_names = [ "keeper_fs_read" ]
+         ; stop_reason = None
+         ; failure_reason = None
+         }
+       in
+       let result =
+         make_run_result
+           ~text:""
+           ~tools:[]
+           ~model:"openai:qwen3.5-35b"
+           ~input_tok:40
+           ~output_tok:20
+           ~run_validation:validation
+           ()
+       in
+       UM.append_metrics_snapshot
+         ~config
+         ~meta:minimal_meta
+         ~observation:base_observation
+         ~result
+         ~latency_ms:123
+         ~turn_cost:0.01
+         ~turn_generation:1
+         ~channel:"scheduled_autonomous"
+         ~snapshot_source:"test"
+         ~context_ratio:0.1
+         ~context_tokens:10
+         ~context_max:100
+         ~message_count:2
+         ~compaction:
+           { Masc_mcp.Keeper_exec_context.applied = false
+           ; attempted = false
+           ; failure_reason = None
+           ; trigger = None
+           ; decision = Masc_mcp.Keeper_exec_context.Blocked_below_thresholds
+           ; before_tokens = 0
+           ; after_tokens = 0
+           ; saved_tokens = 0
+           }
+         ~handoff_json:None
+         ();
+       let metrics_store =
+         Masc_mcp.Keeper_types.keeper_metrics_store config minimal_meta.name
+       in
+       let line =
+         match Dated_jsonl.read_recent_lines metrics_store 1 with
+         | [ line ] -> line
+         | _ -> fail "expected one metrics line"
+       in
+       let json = Yojson.Safe.from_string line in
+       check
+         string
+         "turn mode persisted as tool_use"
+         "tool_use"
+         Yojson.Safe.Util.(json |> member "turn_mode" |> to_string);
+       check
+         bool
+         "work_kind removed from snapshot"
+         true
+         (match Yojson.Safe.Util.(json |> member "work_kind") with
+          | `Null -> true
+          | _ -> false);
+       check
+         string
+         "scheduled autonomous outcome persisted as tool_use"
+         "tool_use"
+         Yojson.Safe.Util.(json |> member "scheduled_autonomous_outcome" |> to_string))
+;;
 
 let test_append_metrics_snapshot_counts_only_mode_violation_refs () =
-  Eio_main.run @@ fun env ->
+  Eio_main.run
+  @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
   let base_dir = temp_dir () in
   Fun.protect
     ~finally:(fun () -> cleanup_dir base_dir)
     (fun () ->
-      let config = Masc_mcp.Coord.default_config base_dir in
-      let proof =
-        sample_cdal_proof
-          ~raw_evidence_refs:
-            [
-              "proof-store://keeper-metrics-proof-test/evidence/effects.json";
-              "proof-store://keeper-metrics-proof-test/evidence/mode_violations.json";
-              "proof-store://keeper-metrics-proof-test/evidence/review_warning.json";
-            ]
-          ()
-      in
-      let result =
-        make_run_result
-          ~text:""
-          ~tools:[]
-          ~model:"openai:qwen3.5-35b"
-          ~input_tok:40
-          ~output_tok:20
-          ~proof
-          ()
-      in
-      UM.append_metrics_snapshot
-        ~config
-        ~meta:minimal_meta
-        ~observation:base_observation
-        ~result
-        ~latency_ms:123
-        ~turn_cost:0.01
-        ~turn_generation:1
-        ~channel:"turn"
-        ~snapshot_source:"test"
-        ~context_ratio:0.1
-        ~context_tokens:10
-        ~context_max:100
-        ~message_count:2
-        ~compaction:
-          {
-            Masc_mcp.Keeper_exec_context.applied = false;
-            attempted = false;
-            failure_reason = None;
-            trigger = None;
-            decision = Masc_mcp.Keeper_exec_context.Blocked_below_thresholds;
-            before_tokens = 0;
-            after_tokens = 0;
-            saved_tokens = 0;
-          }
-        ~handoff_json:None
-        ();
-      let metrics_store =
-        Masc_mcp.Keeper_types.keeper_metrics_store config minimal_meta.name
-      in
-      let line =
-        match Dated_jsonl.read_recent_lines metrics_store 1 with
-        | [ line ] -> line
-        | _ -> fail "expected one metrics line"
-      in
-      let cdal_proof =
-        Yojson.Safe.Util.(Yojson.Safe.from_string line |> member "cdal_proof")
-      in
-      check int "only mode_violations refs count as violations" 1
-        Yojson.Safe.Util.(cdal_proof |> member "violation_count" |> to_int);
-      check int "raw evidence refs are counted separately" 3
-        Yojson.Safe.Util.(
-          cdal_proof |> member "raw_evidence_ref_count" |> to_int))
+       let config = Masc_mcp.Coord.default_config base_dir in
+       let proof =
+         sample_cdal_proof
+           ~raw_evidence_refs:
+             [ "proof-store://keeper-metrics-proof-test/evidence/effects.json"
+             ; "proof-store://keeper-metrics-proof-test/evidence/mode_violations.json"
+             ; "proof-store://keeper-metrics-proof-test/evidence/review_warning.json"
+             ]
+           ()
+       in
+       let result =
+         make_run_result
+           ~text:""
+           ~tools:[]
+           ~model:"openai:qwen3.5-35b"
+           ~input_tok:40
+           ~output_tok:20
+           ~proof
+           ()
+       in
+       UM.append_metrics_snapshot
+         ~config
+         ~meta:minimal_meta
+         ~observation:base_observation
+         ~result
+         ~latency_ms:123
+         ~turn_cost:0.01
+         ~turn_generation:1
+         ~channel:"turn"
+         ~snapshot_source:"test"
+         ~context_ratio:0.1
+         ~context_tokens:10
+         ~context_max:100
+         ~message_count:2
+         ~compaction:
+           { Masc_mcp.Keeper_exec_context.applied = false
+           ; attempted = false
+           ; failure_reason = None
+           ; trigger = None
+           ; decision = Masc_mcp.Keeper_exec_context.Blocked_below_thresholds
+           ; before_tokens = 0
+           ; after_tokens = 0
+           ; saved_tokens = 0
+           }
+         ~handoff_json:None
+         ();
+       let metrics_store =
+         Masc_mcp.Keeper_types.keeper_metrics_store config minimal_meta.name
+       in
+       let line =
+         match Dated_jsonl.read_recent_lines metrics_store 1 with
+         | [ line ] -> line
+         | _ -> fail "expected one metrics line"
+       in
+       let cdal_proof =
+         Yojson.Safe.Util.(Yojson.Safe.from_string line |> member "cdal_proof")
+       in
+       check
+         int
+         "only mode_violations refs count as violations"
+         1
+         Yojson.Safe.Util.(cdal_proof |> member "violation_count" |> to_int);
+       check
+         int
+         "raw evidence refs are counted separately"
+         3
+         Yojson.Safe.Util.(cdal_proof |> member "raw_evidence_ref_count" |> to_int))
+;;
 
 let test_append_metrics_snapshot_nulls_unreported_usage () =
-  Eio_main.run @@ fun env ->
+  Eio_main.run
+  @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
   let base_dir = temp_dir () in
   Fun.protect
     ~finally:(fun () -> cleanup_dir base_dir)
     (fun () ->
-      let config = Masc_mcp.Coord.default_config base_dir in
-      let result =
-        make_run_result
-          ~text:"Kimi replied without usage."
-          ~tools:[]
-          ~model:"kimi_cli:kimi-for-coding"
-          ~input_tok:0
-          ~output_tok:0
-          ~usage_reported:false
-          ()
-      in
-      UM.append_metrics_snapshot
-        ~config
-        ~meta:minimal_meta
-        ~observation:base_observation
-        ~result
-        ~latency_ms:321
-        ~turn_cost:0.42
-        ~turn_generation:1
-        ~channel:"turn"
-        ~snapshot_source:"test"
-        ~context_ratio:0.1
-        ~context_tokens:10
-        ~context_max:100
-        ~message_count:2
-        ~compaction:
-          {
-            Masc_mcp.Keeper_exec_context.applied = false;
-            attempted = false;
-            failure_reason = None;
-            trigger = None;
-            decision = Masc_mcp.Keeper_exec_context.Blocked_below_thresholds;
-            before_tokens = 0;
-            after_tokens = 0;
-            saved_tokens = 0;
-          }
-        ~handoff_json:None
-        ();
-      let metrics_store =
-        Masc_mcp.Keeper_types.keeper_metrics_store config minimal_meta.name
-      in
-      let line =
-        match Dated_jsonl.read_recent_lines metrics_store 1 with
-        | [ line ] -> line
-        | _ -> fail "expected one metrics line"
-      in
-      let json = Yojson.Safe.from_string line in
-      let open Yojson.Safe.Util in
-      let usage = json |> member "usage" in
-      check bool "snapshot input_tokens null when usage unreported" true
-        (match usage |> member "input_tokens" with `Null -> true | _ -> false);
-      check bool "snapshot output_tokens null when usage unreported" true
-        (match usage |> member "output_tokens" with `Null -> true | _ -> false);
-      check bool "snapshot total_tokens null when usage unreported" true
-        (match usage |> member "total_tokens" with `Null -> true | _ -> false);
-      check bool "snapshot cache_creation_tokens null when usage unreported" true
-        (match usage |> member "cache_creation_tokens" with `Null -> true | _ -> false);
-      check bool "snapshot cache_read_tokens null when usage unreported" true
-        (match usage |> member "cache_read_tokens" with `Null -> true | _ -> false);
-      check bool "snapshot cost_usd null when usage unreported" true
-        (match json |> member "cost_usd" with `Null -> true | _ -> false))
+       let config = Masc_mcp.Coord.default_config base_dir in
+       let result =
+         make_run_result
+           ~text:"Kimi replied without usage."
+           ~tools:[]
+           ~model:"kimi_cli:kimi-for-coding"
+           ~input_tok:0
+           ~output_tok:0
+           ~usage_reported:false
+           ()
+       in
+       UM.append_metrics_snapshot
+         ~config
+         ~meta:minimal_meta
+         ~observation:base_observation
+         ~result
+         ~latency_ms:321
+         ~turn_cost:0.42
+         ~turn_generation:1
+         ~channel:"turn"
+         ~snapshot_source:"test"
+         ~context_ratio:0.1
+         ~context_tokens:10
+         ~context_max:100
+         ~message_count:2
+         ~compaction:
+           { Masc_mcp.Keeper_exec_context.applied = false
+           ; attempted = false
+           ; failure_reason = None
+           ; trigger = None
+           ; decision = Masc_mcp.Keeper_exec_context.Blocked_below_thresholds
+           ; before_tokens = 0
+           ; after_tokens = 0
+           ; saved_tokens = 0
+           }
+         ~handoff_json:None
+         ();
+       let metrics_store =
+         Masc_mcp.Keeper_types.keeper_metrics_store config minimal_meta.name
+       in
+       let line =
+         match Dated_jsonl.read_recent_lines metrics_store 1 with
+         | [ line ] -> line
+         | _ -> fail "expected one metrics line"
+       in
+       let json = Yojson.Safe.from_string line in
+       let open Yojson.Safe.Util in
+       let usage = json |> member "usage" in
+       check
+         bool
+         "snapshot input_tokens null when usage unreported"
+         true
+         (match usage |> member "input_tokens" with
+          | `Null -> true
+          | _ -> false);
+       check
+         bool
+         "snapshot output_tokens null when usage unreported"
+         true
+         (match usage |> member "output_tokens" with
+          | `Null -> true
+          | _ -> false);
+       check
+         bool
+         "snapshot total_tokens null when usage unreported"
+         true
+         (match usage |> member "total_tokens" with
+          | `Null -> true
+          | _ -> false);
+       check
+         bool
+         "snapshot cache_creation_tokens null when usage unreported"
+         true
+         (match usage |> member "cache_creation_tokens" with
+          | `Null -> true
+          | _ -> false);
+       check
+         bool
+         "snapshot cache_read_tokens null when usage unreported"
+         true
+         (match usage |> member "cache_read_tokens" with
+          | `Null -> true
+          | _ -> false);
+       check
+         bool
+         "snapshot cost_usd null when usage unreported"
+         true
+         (match json |> member "cost_usd" with
+          | `Null -> true
+          | _ -> false))
+;;
 
 let test_append_metrics_snapshot_persists_cache_usage () =
-  Eio_main.run @@ fun env ->
+  Eio_main.run
+  @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
   let base_dir = temp_dir () in
   Fun.protect
     ~finally:(fun () -> cleanup_dir base_dir)
     (fun () ->
-      let config = Masc_mcp.Coord.default_config base_dir in
-      let result =
-        make_run_result
-          ~text:"Claude reported cache usage."
-          ~tools:[]
-          ~model:"claude:claude-sonnet-4-6"
-          ~input_tok:2000
-          ~output_tok:200
-          ~cache_creation_tokens:1500
-          ~cache_read_tokens:300
-          ()
-      in
-      UM.append_metrics_snapshot
-        ~config
-        ~meta:minimal_meta
-        ~observation:base_observation
-        ~result
-        ~latency_ms:321
-        ~turn_cost:0.42
-        ~turn_generation:1
-        ~channel:"turn"
-        ~snapshot_source:"test"
-        ~context_ratio:0.1
-        ~context_tokens:10
-        ~context_max:100_000
-        ~message_count:2
-        ~compaction:
-          {
-            Masc_mcp.Keeper_exec_context.applied = false;
-            attempted = false;
-            failure_reason = None;
-            trigger = None;
-            decision = Masc_mcp.Keeper_exec_context.Blocked_below_thresholds;
-            before_tokens = 0;
-            after_tokens = 0;
-            saved_tokens = 0;
-          }
-        ~handoff_json:None
-        ();
-      let metrics_store =
-        Masc_mcp.Keeper_types.keeper_metrics_store config minimal_meta.name
-      in
-      let line =
-        match Dated_jsonl.read_recent_lines metrics_store 1 with
-        | [ line ] -> line
-        | _ -> fail "expected one metrics line"
-      in
-      let usage =
-        Yojson.Safe.Util.(Yojson.Safe.from_string line |> member "usage")
-      in
-      let open Yojson.Safe.Util in
-      check int "cache creation persisted"
-        1500 (usage |> member "cache_creation_tokens" |> to_int);
-      check int "cache read persisted"
-        300 (usage |> member "cache_read_tokens" |> to_int))
+       let config = Masc_mcp.Coord.default_config base_dir in
+       let result =
+         make_run_result
+           ~text:"Claude reported cache usage."
+           ~tools:[]
+           ~model:"claude:claude-sonnet-4-6"
+           ~input_tok:2000
+           ~output_tok:200
+           ~cache_creation_tokens:1500
+           ~cache_read_tokens:300
+           ()
+       in
+       UM.append_metrics_snapshot
+         ~config
+         ~meta:minimal_meta
+         ~observation:base_observation
+         ~result
+         ~latency_ms:321
+         ~turn_cost:0.42
+         ~turn_generation:1
+         ~channel:"turn"
+         ~snapshot_source:"test"
+         ~context_ratio:0.1
+         ~context_tokens:10
+         ~context_max:100_000
+         ~message_count:2
+         ~compaction:
+           { Masc_mcp.Keeper_exec_context.applied = false
+           ; attempted = false
+           ; failure_reason = None
+           ; trigger = None
+           ; decision = Masc_mcp.Keeper_exec_context.Blocked_below_thresholds
+           ; before_tokens = 0
+           ; after_tokens = 0
+           ; saved_tokens = 0
+           }
+         ~handoff_json:None
+         ();
+       let metrics_store =
+         Masc_mcp.Keeper_types.keeper_metrics_store config minimal_meta.name
+       in
+       let line =
+         match Dated_jsonl.read_recent_lines metrics_store 1 with
+         | [ line ] -> line
+         | _ -> fail "expected one metrics line"
+       in
+       let usage = Yojson.Safe.Util.(Yojson.Safe.from_string line |> member "usage") in
+       let open Yojson.Safe.Util in
+       check
+         int
+         "cache creation persisted"
+         1500
+         (usage |> member "cache_creation_tokens" |> to_int);
+       check int "cache read persisted" 300 (usage |> member "cache_read_tokens" |> to_int))
+;;
 
 let test_estimate_trusted_usage_cost_uses_cache_usage () =
   let result =
@@ -3537,376 +4560,562 @@ let test_estimate_trusted_usage_cost_uses_cache_usage () =
      + cache read 200k * $3/M * 0.1 = $2.535.  This pins the unified
      keeper path to the same cache-aware pricing semantics as OAS. *)
   check (float 0.001) "cache-aware trusted cost" 2.535 cost;
-  check (float 0.001) "untrusted usage is zero cost" 0.0
+  check
+    (float 0.001)
+    "untrusted usage is zero cost"
+    0.0
     (UM.estimate_trusted_usage_cost_usd
        ~usage_trusted:false
        ~model:"claude-sonnet-4-6"
        result.usage)
+;;
 
 let test_record_keeper_total_cost_metric () =
   let keeper_name = "cost-metric-keeper" in
   UM.record_keeper_total_cost_usd ~keeper_name ~total_cost_usd:0.042;
-  check (option (float 0.0001)) "keeper total cost gauge" (Some 0.042)
+  check
+    (option (float 0.0001))
+    "keeper total cost gauge"
+    (Some 0.042)
     (Masc_mcp.Prometheus.get_metric_value
        Masc_mcp.Keeper_metrics.metric_keeper_total_cost_usd
-       ~labels:[ ("keeper_name", keeper_name) ]
+       ~labels:[ "keeper_name", keeper_name ]
        ())
+;;
 
 let test_append_metrics_snapshot_marks_untrusted_usage () =
-  Eio_main.run @@ fun env ->
+  Eio_main.run
+  @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
   let base_dir = temp_dir () in
   Fun.protect
     ~finally:(fun () -> cleanup_dir base_dir)
     (fun () ->
-      let config = Masc_mcp.Coord.default_config base_dir in
-      let result =
-        make_run_result
-          ~text:"Usage is absurd."
-          ~tools:[]
-          ~model:"llama:qwen3.5-27b"
-          ~input_tok:1_200_001
-          ~output_tok:20
-          ()
-      in
-      UM.append_metrics_snapshot
-        ~config
-        ~meta:minimal_meta
-        ~observation:base_observation
-        ~result
-        ~latency_ms:321
-        ~turn_cost:0.42
-        ~turn_generation:1
-        ~channel:"turn"
-        ~snapshot_source:"test"
-        ~context_ratio:0.1
-        ~context_tokens:10
-        ~context_max:100_000
-        ~message_count:2
-        ~compaction:
-          {
-            Masc_mcp.Keeper_exec_context.applied = false;
-            attempted = false;
-            failure_reason = None;
-            trigger = None;
-            decision = Masc_mcp.Keeper_exec_context.Blocked_below_thresholds;
-            before_tokens = 0;
-            after_tokens = 0;
-            saved_tokens = 0;
-          }
-        ~handoff_json:None
-        ();
-      let metrics_store =
-        Masc_mcp.Keeper_types.keeper_metrics_store config minimal_meta.name
-      in
-      let line =
-        match Dated_jsonl.read_recent_lines metrics_store 1 with
-        | [ line ] -> line
-        | _ -> fail "expected one metrics line"
-      in
-      let json = Yojson.Safe.from_string line in
-      let open Yojson.Safe.Util in
-      check string "usage trust persisted" "untrusted"
-        (json |> member "usage_trust" |> to_string);
-      check string "nested usage trust persisted" "untrusted"
-        (json |> member "usage" |> member "usage_trust" |> to_string);
-      check bool "cost hidden when usage untrusted" true
-        (match json |> member "cost_usd" with `Null -> true | _ -> false);
-      let reasons =
-        json |> member "usage_anomaly_reasons" |> to_list |> List.map to_string
-      in
-      check bool "absolute token anomaly persisted" true
-        (List.mem "input_tokens_gt_1m" reasons);
-      check bool "context token anomaly persisted" true
-        (List.mem "input_tokens_gt_2x_context_max" reasons))
+       let config = Masc_mcp.Coord.default_config base_dir in
+       let result =
+         make_run_result
+           ~text:"Usage is absurd."
+           ~tools:[]
+           ~model:"llama:qwen3.5-27b"
+           ~input_tok:1_200_001
+           ~output_tok:20
+           ()
+       in
+       UM.append_metrics_snapshot
+         ~config
+         ~meta:minimal_meta
+         ~observation:base_observation
+         ~result
+         ~latency_ms:321
+         ~turn_cost:0.42
+         ~turn_generation:1
+         ~channel:"turn"
+         ~snapshot_source:"test"
+         ~context_ratio:0.1
+         ~context_tokens:10
+         ~context_max:100_000
+         ~message_count:2
+         ~compaction:
+           { Masc_mcp.Keeper_exec_context.applied = false
+           ; attempted = false
+           ; failure_reason = None
+           ; trigger = None
+           ; decision = Masc_mcp.Keeper_exec_context.Blocked_below_thresholds
+           ; before_tokens = 0
+           ; after_tokens = 0
+           ; saved_tokens = 0
+           }
+         ~handoff_json:None
+         ();
+       let metrics_store =
+         Masc_mcp.Keeper_types.keeper_metrics_store config minimal_meta.name
+       in
+       let line =
+         match Dated_jsonl.read_recent_lines metrics_store 1 with
+         | [ line ] -> line
+         | _ -> fail "expected one metrics line"
+       in
+       let json = Yojson.Safe.from_string line in
+       let open Yojson.Safe.Util in
+       check
+         string
+         "usage trust persisted"
+         "untrusted"
+         (json |> member "usage_trust" |> to_string);
+       check
+         string
+         "nested usage trust persisted"
+         "untrusted"
+         (json |> member "usage" |> member "usage_trust" |> to_string);
+       check
+         bool
+         "cost hidden when usage untrusted"
+         true
+         (match json |> member "cost_usd" with
+          | `Null -> true
+          | _ -> false);
+       let reasons =
+         json |> member "usage_anomaly_reasons" |> to_list |> List.map to_string
+       in
+       check
+         bool
+         "absolute token anomaly persisted"
+         true
+         (List.mem "input_tokens_gt_1m" reasons);
+       check
+         bool
+         "context token anomaly persisted"
+         true
+         (List.mem "input_tokens_gt_2x_context_max" reasons))
+;;
 
 let test_append_decision_record_persists_tool_calls () =
-  Eio_main.run @@ fun env ->
+  Eio_main.run
+  @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
   let base_dir = temp_dir () in
   Fun.protect
     ~finally:(fun () -> cleanup_dir base_dir)
     (fun () ->
-      let current_task_id =
-        match Masc_mcp.Keeper_id.Task_id.of_string "task-runtime-trust" with
-        | Ok task_id -> task_id
-        | Error err -> fail ("task id parse failed: " ^ err)
-      in
-      let config = Masc_mcp.Coord.default_config base_dir in
-      ignore (Masc_mcp.Coord.init config ~agent_name:(Some "observer"));
-      let meta =
-        {
-          minimal_meta with
-          active_goal_ids = [ "goal-runtime-trust" ];
-          current_task_id = Some current_task_id;
-        }
-      in
-      let tool_calls : KAR.tool_call_detail list =
-        [ { tool_name = "keeper_shell"
-          ; provider = "codex_cli"
-          ; outcome = "ok"
-          ; latency_ms = 12.5
-          ; route_evidence =
-              Some
-                (`Assoc
-                   [
-                     ("tool_name", `String "keeper_shell");
-                     ("command", `String "git_status");
-                     ("cwd", `String "repos/masc-mcp");
-                     ("via", `String "docker");
-                     ("sandbox_profile", `String "docker");
-                     ("git_creds_enabled", `Bool true);
-                     ("network_mode", `String "bridge");
-                   ])
-          }
-        ; { tool_name = "keeper_board_post"
-          ; provider = "codex_cli"
-          ; outcome = "error"
-          ; latency_ms = 3.0
-          ; route_evidence = None
-          }
-        ]
-      in
-      let result =
-        make_run_result
-          ~text:"Checked GitHub and reported blocker."
-          ~tools:["keeper_shell"; "keeper_board_post"]
-          ~tool_calls
-          ~model:"codex_cli:gpt-5.4"
-          ~input_tok:40
-          ~output_tok:20
-          ()
-      in
-      Fun.protect
-        ~finally:KTCL.reset_for_testing
-        (fun () ->
-          KTCL.set_turn_context
-            ~keeper_name:meta.name
-            ~thinking_enabled:false
-            ~keeper_turn_id:8
-            ~approval_mode:"manual"
-            ();
-          UM.append_decision_record
-            ~config
-            ~meta
-            ~observation:base_observation
-            ~latency_ms:42
-            ~outcome:"success"
-            ~degraded_retry_applied:true
-            ~degraded_retry_cascade:KC.local_recovery_cascade_name
-            ~fallback_reason:"turn_timeout"
-            ~turn_mode:UM.Tool_use
-            ~result:(Some result)
-            ());
-      let json =
-        read_jsonl_line (Keeper_types.keeper_decision_log_path config meta.name)
-      in
-      check int "tool call count persisted" 2
-        Yojson.Safe.Util.(json |> member "tool_call_count" |> to_int);
-      check int "turn id persisted" 8
-        Yojson.Safe.Util.(json |> member "turn_id" |> to_int);
-      check int "duration alias persisted" 42
-        Yojson.Safe.Util.(json |> member "duration_ms" |> to_int);
-      check (option string) "task id persisted"
-        (Some "task-runtime-trust")
-        Yojson.Safe.Util.(json |> member "task_id" |> to_string_option);
-      check (option string) "goal id persisted"
-        (Some "goal-runtime-trust")
-        Yojson.Safe.Util.(json |> member "goal_id" |> to_string_option);
-      check (list string) "goal ids persisted"
-        [ "goal-runtime-trust" ]
-        Yojson.Safe.Util.(json |> member "goal_ids" |> to_list |> List.map to_string);
-      check (option string) "approval mode persisted"
-        (Some "manual")
-        Yojson.Safe.Util.(json |> member "approval_mode" |> to_string_option);
-      check (option string) "runtime contract backend persisted"
-        (Some "local")
-        Yojson.Safe.Util.(
-          json |> member "runtime_contract" |> member "backend" |> to_string_option);
-      check int "pending approval count persisted" 0
-        Yojson.Safe.Util.(json |> member "pending_approval_count" |> to_int);
-      check (list string) "tools used persisted"
-        ["keeper_shell"; "keeper_board_post"]
-        Yojson.Safe.Util.(json |> member "tools_used" |> to_list |> List.map to_string);
-      check (option string) "turn mode persisted" (Some "tool_use")
-        Yojson.Safe.Util.(json |> member "turn_mode" |> to_string_option);
-      check bool "degraded retry flag persisted" true
-        Yojson.Safe.Util.(json |> member "degraded_retry_applied" |> to_bool);
-      check (option string) "degraded retry cascade persisted"
-        (Some KC.local_recovery_cascade_name)
-        Yojson.Safe.Util.(
-          json |> member "degraded_retry_cascade" |> to_string_option);
-      check (option string) "fallback reason persisted"
-        (Some "turn_timeout")
-        Yojson.Safe.Util.(json |> member "fallback_reason" |> to_string_option);
-      check bool "selected_mode removed from decision log" true
-        (match Yojson.Safe.Util.(json |> member "selected_mode") with
-         | `Null -> true
-         | _ -> false);
-      let recorded_tool_calls =
-        Yojson.Safe.Util.(json |> member "tool_calls" |> to_list)
-      in
-      check int "tool call details persisted" 2 (List.length recorded_tool_calls);
-      check string "first tool name" "keeper_shell"
-        Yojson.Safe.Util.(List.nth recorded_tool_calls 0 |> member "tool_name" |> to_string);
-      check string "first provider" "codex_cli"
-        Yojson.Safe.Util.(List.nth recorded_tool_calls 0 |> member "provider" |> to_string);
-      check string "first route via" "docker"
-        Yojson.Safe.Util.(
-          List.nth recorded_tool_calls 0 |> member "route_evidence"
-          |> member "via" |> to_string);
-      check bool "first route git creds" true
-        Yojson.Safe.Util.(
-          List.nth recorded_tool_calls 0 |> member "route_evidence"
-          |> member "git_creds_enabled" |> to_bool);
-	      check string "second outcome" "error"
-	        Yojson.Safe.Util.(List.nth recorded_tool_calls 1 |> member "outcome" |> to_string);
-      check bool "second route evidence absent" true
-        (match
-           Yojson.Safe.Util.(
-             List.nth recorded_tool_calls 1 |> member "route_evidence")
-         with
-         | `Null -> true
-         | _ -> false);
-	      check (float 0.001) "second latency" 3.0
-	        Yojson.Safe.Util.(List.nth recorded_tool_calls 1 |> member "latency_ms" |> to_float);
-	      check string "terminal reason success" "success"
-	        Yojson.Safe.Util.(json |> member "terminal_reason" |> member "code" |> to_string);
-	      check string "terminal reason code alias" "success"
-	        Yojson.Safe.Util.(json |> member "terminal_reason_code" |> to_string);
-	      check string "provider context selected model" "codex_cli:gpt-5.4"
-	        Yojson.Safe.Util.(json |> member "provider_context" |> member "selected_model" |> to_string);
-	      check string "tool contract requirement" "optional"
-	        Yojson.Safe.Util.(json |> member "tool_contract" |> member "requirement" |> to_string);
-	      check int "tool contract count mirrors tool calls" 2
-	        Yojson.Safe.Util.(json |> member "tool_contract" |> member "tool_call_count" |> to_int))
+       let current_task_id =
+         match Masc_mcp.Keeper_id.Task_id.of_string "task-runtime-trust" with
+         | Ok task_id -> task_id
+         | Error err -> fail ("task id parse failed: " ^ err)
+       in
+       let config = Masc_mcp.Coord.default_config base_dir in
+       ignore (Masc_mcp.Coord.init config ~agent_name:(Some "observer"));
+       let meta =
+         { minimal_meta with
+           active_goal_ids = [ "goal-runtime-trust" ]
+         ; current_task_id = Some current_task_id
+         }
+       in
+       let tool_calls : KAR.tool_call_detail list =
+         [ { tool_name = "keeper_shell"
+           ; provider = "codex_cli"
+           ; outcome = "ok"
+           ; latency_ms = 12.5
+           ; route_evidence =
+               Some
+                 (`Assoc
+                     [ "tool_name", `String "keeper_shell"
+                     ; "command", `String "git_status"
+                     ; "cwd", `String "repos/masc-mcp"
+                     ; "via", `String "docker"
+                     ; "sandbox_profile", `String "docker"
+                     ; "git_creds_enabled", `Bool true
+                     ; "network_mode", `String "bridge"
+                     ])
+           }
+         ; { tool_name = "keeper_board_post"
+           ; provider = "codex_cli"
+           ; outcome = "error"
+           ; latency_ms = 3.0
+           ; route_evidence = None
+           }
+         ]
+       in
+       let result =
+         make_run_result
+           ~text:"Checked GitHub and reported blocker."
+           ~tools:[ "keeper_shell"; "keeper_board_post" ]
+           ~tool_calls
+           ~model:"codex_cli:gpt-5.4"
+           ~input_tok:40
+           ~output_tok:20
+           ()
+       in
+       Fun.protect ~finally:KTCL.reset_for_testing (fun () ->
+         KTCL.set_turn_context
+           ~keeper_name:meta.name
+           ~thinking_enabled:false
+           ~keeper_turn_id:8
+           ~approval_mode:"manual"
+           ();
+         UM.append_decision_record
+           ~config
+           ~meta
+           ~observation:base_observation
+           ~latency_ms:42
+           ~outcome:"success"
+           ~degraded_retry_applied:true
+           ~degraded_retry_cascade:KC.local_recovery_cascade_name
+           ~fallback_reason:"turn_timeout"
+           ~turn_mode:UM.Tool_use
+           ~result:(Some result)
+           ());
+       let json =
+         read_jsonl_line (Keeper_types.keeper_decision_log_path config meta.name)
+       in
+       check
+         int
+         "tool call count persisted"
+         2
+         Yojson.Safe.Util.(json |> member "tool_call_count" |> to_int);
+       check
+         int
+         "turn id persisted"
+         8
+         Yojson.Safe.Util.(json |> member "turn_id" |> to_int);
+       check
+         int
+         "duration alias persisted"
+         42
+         Yojson.Safe.Util.(json |> member "duration_ms" |> to_int);
+       check
+         (option string)
+         "task id persisted"
+         (Some "task-runtime-trust")
+         Yojson.Safe.Util.(json |> member "task_id" |> to_string_option);
+       check
+         (option string)
+         "goal id persisted"
+         (Some "goal-runtime-trust")
+         Yojson.Safe.Util.(json |> member "goal_id" |> to_string_option);
+       check
+         (list string)
+         "goal ids persisted"
+         [ "goal-runtime-trust" ]
+         Yojson.Safe.Util.(json |> member "goal_ids" |> to_list |> List.map to_string);
+       check
+         (option string)
+         "approval mode persisted"
+         (Some "manual")
+         Yojson.Safe.Util.(json |> member "approval_mode" |> to_string_option);
+       check
+         (option string)
+         "runtime contract backend persisted"
+         (Some "local")
+         Yojson.Safe.Util.(
+           json |> member "runtime_contract" |> member "backend" |> to_string_option);
+       check
+         int
+         "pending approval count persisted"
+         0
+         Yojson.Safe.Util.(json |> member "pending_approval_count" |> to_int);
+       check
+         (list string)
+         "tools used persisted"
+         [ "keeper_shell"; "keeper_board_post" ]
+         Yojson.Safe.Util.(json |> member "tools_used" |> to_list |> List.map to_string);
+       check
+         (option string)
+         "turn mode persisted"
+         (Some "tool_use")
+         Yojson.Safe.Util.(json |> member "turn_mode" |> to_string_option);
+       check
+         bool
+         "degraded retry flag persisted"
+         true
+         Yojson.Safe.Util.(json |> member "degraded_retry_applied" |> to_bool);
+       check
+         (option string)
+         "degraded retry cascade persisted"
+         (Some KC.local_recovery_cascade_name)
+         Yojson.Safe.Util.(json |> member "degraded_retry_cascade" |> to_string_option);
+       check
+         (option string)
+         "fallback reason persisted"
+         (Some "turn_timeout")
+         Yojson.Safe.Util.(json |> member "fallback_reason" |> to_string_option);
+       check
+         bool
+         "selected_mode removed from decision log"
+         true
+         (match Yojson.Safe.Util.(json |> member "selected_mode") with
+          | `Null -> true
+          | _ -> false);
+       let recorded_tool_calls =
+         Yojson.Safe.Util.(json |> member "tool_calls" |> to_list)
+       in
+       check int "tool call details persisted" 2 (List.length recorded_tool_calls);
+       check
+         string
+         "first tool name"
+         "keeper_shell"
+         Yojson.Safe.Util.(
+           List.nth recorded_tool_calls 0 |> member "tool_name" |> to_string);
+       check
+         string
+         "first provider"
+         "codex_cli"
+         Yojson.Safe.Util.(
+           List.nth recorded_tool_calls 0 |> member "provider" |> to_string);
+       check
+         string
+         "first route via"
+         "docker"
+         Yojson.Safe.Util.(
+           List.nth recorded_tool_calls 0
+           |> member "route_evidence"
+           |> member "via"
+           |> to_string);
+       check
+         bool
+         "first route git creds"
+         true
+         Yojson.Safe.Util.(
+           List.nth recorded_tool_calls 0
+           |> member "route_evidence"
+           |> member "git_creds_enabled"
+           |> to_bool);
+       check
+         string
+         "second outcome"
+         "error"
+         Yojson.Safe.Util.(
+           List.nth recorded_tool_calls 1 |> member "outcome" |> to_string);
+       check
+         bool
+         "second route evidence absent"
+         true
+         (match
+            Yojson.Safe.Util.(List.nth recorded_tool_calls 1 |> member "route_evidence")
+          with
+          | `Null -> true
+          | _ -> false);
+       check
+         (float 0.001)
+         "second latency"
+         3.0
+         Yojson.Safe.Util.(
+           List.nth recorded_tool_calls 1 |> member "latency_ms" |> to_float);
+       check
+         string
+         "terminal reason success"
+         "success"
+         Yojson.Safe.Util.(json |> member "terminal_reason" |> member "code" |> to_string);
+       check
+         string
+         "terminal reason code alias"
+         "success"
+         Yojson.Safe.Util.(json |> member "terminal_reason_code" |> to_string);
+       check
+         string
+         "provider context selected model"
+         "codex_cli:gpt-5.4"
+         Yojson.Safe.Util.(
+           json |> member "provider_context" |> member "selected_model" |> to_string);
+       check
+         string
+         "tool contract requirement"
+         "optional"
+         Yojson.Safe.Util.(
+           json |> member "tool_contract" |> member "requirement" |> to_string);
+       check
+         int
+         "tool contract count mirrors tool calls"
+         2
+         Yojson.Safe.Util.(
+           json |> member "tool_contract" |> member "tool_call_count" |> to_int))
+;;
 
 let test_append_decision_record_nulls_unreported_usage () =
-  Eio_main.run @@ fun env ->
+  Eio_main.run
+  @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
   let base_dir = temp_dir () in
   Fun.protect
     ~finally:(fun () -> cleanup_dir base_dir)
     (fun () ->
-      let config = Masc_mcp.Coord.default_config base_dir in
-      ignore (Masc_mcp.Coord.init config ~agent_name:(Some "observer"));
-      let result =
-        make_run_result
-          ~text:"Kimi replied without usage."
-          ~tools:[]
-          ~model:"kimi_cli:kimi-for-coding"
-          ~input_tok:0
-          ~output_tok:0
-          ~usage_reported:false
-          ()
-      in
-      UM.append_decision_record
-        ~config
-        ~meta:minimal_meta
-        ~observation:base_observation
-        ~latency_ms:420
-        ~outcome:"success"
-        ~turn_mode:UM.Text_response
-        ~result:(Some result)
-        ();
-      let json =
-        read_jsonl_line (Keeper_types.keeper_decision_log_path config minimal_meta.name)
-      in
-      let open Yojson.Safe.Util in
-      let telemetry = json |> member "telemetry" in
-      check bool "input_tokens null when usage unreported" true
-        (match telemetry |> member "input_tokens" with `Null -> true | _ -> false);
-      check bool "output_tokens null when usage unreported" true
-        (match telemetry |> member "output_tokens" with `Null -> true | _ -> false);
-      check bool "cache_read_tokens null when usage unreported" true
-        (match telemetry |> member "cache_read_tokens" with `Null -> true | _ -> false);
-      check bool "cost_usd null when usage unreported" true
-        (match telemetry |> member "cost_usd" with `Null -> true | _ -> false);
-      check bool "tokens_per_second null when usage unreported" true
-        (match telemetry |> member "tokens_per_second" with `Null -> true | _ -> false);
-      check string "outcome persisted" "success"
-        (telemetry |> member "outcome" |> to_string);
-      check bool "usage_reported false persisted" false
-        (telemetry |> member "usage_reported" |> to_bool);
-      check bool "telemetry_reported false persisted" false
-        (telemetry |> member "telemetry_reported" |> to_bool);
-      check string "coverage stage persisted" "oas"
-        (telemetry |> member "coverage_stage" |> to_string);
-	      check string "coverage reason persisted" "missing_usage_and_inference"
-	        (telemetry |> member "coverage_reason" |> to_string))
+       let config = Masc_mcp.Coord.default_config base_dir in
+       ignore (Masc_mcp.Coord.init config ~agent_name:(Some "observer"));
+       let result =
+         make_run_result
+           ~text:"Kimi replied without usage."
+           ~tools:[]
+           ~model:"kimi_cli:kimi-for-coding"
+           ~input_tok:0
+           ~output_tok:0
+           ~usage_reported:false
+           ()
+       in
+       UM.append_decision_record
+         ~config
+         ~meta:minimal_meta
+         ~observation:base_observation
+         ~latency_ms:420
+         ~outcome:"success"
+         ~turn_mode:UM.Text_response
+         ~result:(Some result)
+         ();
+       let json =
+         read_jsonl_line (Keeper_types.keeper_decision_log_path config minimal_meta.name)
+       in
+       let open Yojson.Safe.Util in
+       let telemetry = json |> member "telemetry" in
+       check
+         bool
+         "input_tokens null when usage unreported"
+         true
+         (match telemetry |> member "input_tokens" with
+          | `Null -> true
+          | _ -> false);
+       check
+         bool
+         "output_tokens null when usage unreported"
+         true
+         (match telemetry |> member "output_tokens" with
+          | `Null -> true
+          | _ -> false);
+       check
+         bool
+         "cache_read_tokens null when usage unreported"
+         true
+         (match telemetry |> member "cache_read_tokens" with
+          | `Null -> true
+          | _ -> false);
+       check
+         bool
+         "cost_usd null when usage unreported"
+         true
+         (match telemetry |> member "cost_usd" with
+          | `Null -> true
+          | _ -> false);
+       check
+         bool
+         "tokens_per_second null when usage unreported"
+         true
+         (match telemetry |> member "tokens_per_second" with
+          | `Null -> true
+          | _ -> false);
+       check
+         string
+         "outcome persisted"
+         "success"
+         (telemetry |> member "outcome" |> to_string);
+       check
+         bool
+         "usage_reported false persisted"
+         false
+         (telemetry |> member "usage_reported" |> to_bool);
+       check
+         bool
+         "telemetry_reported false persisted"
+         false
+         (telemetry |> member "telemetry_reported" |> to_bool);
+       check
+         string
+         "coverage stage persisted"
+         "oas"
+         (telemetry |> member "coverage_stage" |> to_string);
+       check
+         string
+         "coverage reason persisted"
+         "missing_usage_and_inference"
+         (telemetry |> member "coverage_reason" |> to_string))
+;;
 
 let test_append_decision_record_classifies_legacy_worktree_error () =
-  Eio_main.run @@ fun env ->
+  Eio_main.run
+  @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
   let base_dir = temp_dir () in
   Fun.protect
     ~finally:(fun () -> cleanup_dir base_dir)
     (fun () ->
-      let config = Masc_mcp.Coord.default_config base_dir in
-      ignore (Masc_mcp.Coord.init config ~agent_name:(Some "observer"));
-      UM.append_decision_record
-        ~config
-        ~meta:minimal_meta
-        ~observation:base_observation
-        ~latency_ms:19
-        ~outcome:"error"
-        ~error:
-          "keeper_shell failed: gh_repo_context_missing_worktree: active task has no linked worktree"
-        ();
-      let json =
-        read_jsonl_line (Keeper_types.keeper_decision_log_path config minimal_meta.name)
-      in
-      let open Yojson.Safe.Util in
-      check int "error duration alias persisted" 19
-        (json |> member "duration_ms" |> to_int);
-      check string "terminal code" "gh_repo_context_missing_worktree"
-        (json |> member "terminal_reason" |> member "code" |> to_string);
-      check string "terminal code alias" "gh_repo_context_missing_worktree"
-        (json |> member "terminal_reason_code" |> to_string);
-      check string "next action" "create_or_link_worktree"
-        (json |> member "terminal_reason" |> member "next_action" |> to_string);
-      check string "tool contract unknown for error path" "unknown"
-        (json |> member "tool_contract" |> member "requirement" |> to_string))
+       let config = Masc_mcp.Coord.default_config base_dir in
+       ignore (Masc_mcp.Coord.init config ~agent_name:(Some "observer"));
+       UM.append_decision_record
+         ~config
+         ~meta:minimal_meta
+         ~observation:base_observation
+         ~latency_ms:19
+         ~outcome:"error"
+         ~error:
+           "keeper_shell failed: gh_repo_context_missing_worktree: active task has no \
+            linked worktree"
+         ();
+       let json =
+         read_jsonl_line (Keeper_types.keeper_decision_log_path config minimal_meta.name)
+       in
+       let open Yojson.Safe.Util in
+       check
+         int
+         "error duration alias persisted"
+         19
+         (json |> member "duration_ms" |> to_int);
+       check
+         string
+         "terminal code"
+         "gh_repo_context_missing_worktree"
+         (json |> member "terminal_reason" |> member "code" |> to_string);
+       check
+         string
+         "terminal code alias"
+         "gh_repo_context_missing_worktree"
+         (json |> member "terminal_reason_code" |> to_string);
+       check
+         string
+         "next action"
+         "create_or_link_worktree"
+         (json |> member "terminal_reason" |> member "next_action" |> to_string);
+       check
+         string
+         "tool contract unknown for error path"
+         "unknown"
+         (json |> member "tool_contract" |> member "requirement" |> to_string))
+;;
 
 let test_append_decision_record_preserves_no_result_skipped_outcome () =
-  Eio_main.run @@ fun env ->
+  Eio_main.run
+  @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
   let base_dir = temp_dir () in
   Fun.protect
     ~finally:(fun () -> cleanup_dir base_dir)
     (fun () ->
-      let config = Masc_mcp.Coord.default_config base_dir in
-      ignore (Masc_mcp.Coord.init config ~agent_name:(Some "observer"));
-      UM.append_decision_record
-        ~config
-        ~meta:minimal_meta
-        ~observation:base_observation
-        ~latency_ms:11
-        ~outcome:"skipped"
-        ~terminal_reason:(Masc_mcp.Keeper_turn_terminal.of_code "ollama_saturated")
-        ();
-      let json =
-        read_jsonl_line (Keeper_types.keeper_decision_log_path config minimal_meta.name)
-      in
-      let open Yojson.Safe.Util in
-      let telemetry = json |> member "telemetry" in
-      check string "top-level skipped outcome persisted" "skipped"
-        (json |> member "outcome" |> to_string);
-      check string "telemetry skipped outcome persisted" "skipped"
-        (telemetry |> member "outcome" |> to_string);
-      check bool "skipped telemetry category is null" true
-        Yojson.Safe.Util.(telemetry |> member "error_category" = `Null);
-      check string "skipped telemetry coverage stage" "pre_dispatch"
-        (telemetry |> member "coverage_stage" |> to_string);
-      check string "skipped telemetry coverage reason" "skipped_turn"
-        (telemetry |> member "coverage_reason" |> to_string);
-      check string "terminal code alias" "ollama_saturated"
-        (json |> member "terminal_reason_code" |> to_string);
-      check int "duration alias persisted" 11
-        (json |> member "duration_ms" |> to_int))
+       let config = Masc_mcp.Coord.default_config base_dir in
+       ignore (Masc_mcp.Coord.init config ~agent_name:(Some "observer"));
+       UM.append_decision_record
+         ~config
+         ~meta:minimal_meta
+         ~observation:base_observation
+         ~latency_ms:11
+         ~outcome:"skipped"
+         ~terminal_reason:(Masc_mcp.Keeper_turn_terminal.of_code "ollama_saturated")
+         ();
+       let json =
+         read_jsonl_line (Keeper_types.keeper_decision_log_path config minimal_meta.name)
+       in
+       let open Yojson.Safe.Util in
+       let telemetry = json |> member "telemetry" in
+       check
+         string
+         "top-level skipped outcome persisted"
+         "skipped"
+         (json |> member "outcome" |> to_string);
+       check
+         string
+         "telemetry skipped outcome persisted"
+         "skipped"
+         (telemetry |> member "outcome" |> to_string);
+       check
+         bool
+         "skipped telemetry category is null"
+         true
+         Yojson.Safe.Util.(telemetry |> member "error_category" = `Null);
+       check
+         string
+         "skipped telemetry coverage stage"
+         "pre_dispatch"
+         (telemetry |> member "coverage_stage" |> to_string);
+       check
+         string
+         "skipped telemetry coverage reason"
+         "skipped_turn"
+         (telemetry |> member "coverage_reason" |> to_string);
+       check
+         string
+         "terminal code alias"
+         "ollama_saturated"
+         (json |> member "terminal_reason_code" |> to_string);
+       check int "duration alias persisted" 11 (json |> member "duration_ms" |> to_int))
+;;
 
 let test_run_keeper_cycle_skips_non_executable_phase () =
-  Eio_main.run @@ fun env ->
+  Eio_main.run
+  @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
   let base_dir = temp_dir () in
   let old_base_path = Sys.getenv_opt "MASC_BASE_PATH" in
@@ -3918,125 +5127,139 @@ let test_run_keeper_cycle_skips_non_executable_phase () =
       KR.clear ();
       cleanup_dir base_dir)
     (fun () ->
-      KR.clear ();
-      Unix.putenv "MASC_BASE_PATH" base_dir;
-      let meta = make_meta "phase-gated-keeper" in
-      let config = Masc_mcp.Coord.default_config base_dir in
-      ignore (KR.register ~base_path:base_dir meta.name meta);
-      (match KR.dispatch_event ~base_path:base_dir meta.name KP.Operator_pause with
-       | Ok _ -> ()
-       | Error err -> fail (KP.transition_error_to_string err));
-      check (option string) "phase paused before run"
-        (Some "paused")
-        (Option.map KP.phase_to_string
-           (KR.get_phase ~base_path:base_dir meta.name));
-      let phase_skip_labels =
-        [
-          ("from", "phase_gating");
-          ("to", "done");
-          ("action", "PhaseGateSkip");
-          ("keeper", meta.name);
-        ]
-      in
-      let legacy_phase_cancel_labels =
-        [
-          ("from", "phase_gating");
-          ("to", "cancelled:phase_gate_close");
-          ("action", "HonorStopSignal");
-          ("keeper", meta.name);
-        ]
-      in
-      let phase_skip_before =
-        Masc_mcp.Prometheus.metric_value_or_zero
-          Masc_mcp.Keeper_metrics.metric_keeper_turn_fsm_transitions
-          ~labels:phase_skip_labels
-          ()
-      in
-      let legacy_phase_cancel_before =
-        Masc_mcp.Prometheus.metric_value_or_zero
-          Masc_mcp.Keeper_metrics.metric_keeper_turn_fsm_transitions
-          ~labels:legacy_phase_cancel_labels
-          ()
-      in
-      match
-        UT.run_keeper_cycle
-          ~config
-          ~meta
-          ~observation:base_observation
-          ~generation:meta.runtime.generation
-          ()
-      with
-      | Error err ->
-          Alcotest.fail
-            ("expected paused-phase skip, got error: "
-            ^ Agent_sdk.Error.to_string err)
-      | Ok updated ->
-          let phase_skip_after =
-            Masc_mcp.Prometheus.metric_value_or_zero
-              Masc_mcp.Keeper_metrics.metric_keeper_turn_fsm_transitions
-              ~labels:phase_skip_labels
-              ()
-          in
-          let legacy_phase_cancel_after =
-            Masc_mcp.Prometheus.metric_value_or_zero
-              Masc_mcp.Keeper_metrics.metric_keeper_turn_fsm_transitions
-              ~labels:legacy_phase_cancel_labels
-              ()
-          in
-          check string "keeper name preserved" meta.name updated.name;
-          check (float 0.0) "phase skip emits Done transition"
-            (phase_skip_before +. 1.0)
-            phase_skip_after;
-          check (float 0.0) "phase skip does not emit legacy cancel"
-            legacy_phase_cancel_before
-            legacy_phase_cancel_after;
-          check (option string) "phase remains paused after skipped turn"
-            (Some "paused")
-            (Option.map KP.phase_to_string
-               (KR.get_phase ~base_path:base_dir meta.name));
-          (match
-             Masc_mcp.Keeper_execution_receipt.latest_json config meta.name
-           with
-           | None -> fail "expected skipped turn execution receipt"
-           | Some receipt ->
-              check string "skipped receipt outcome" "receipt_skipped"
-                 Yojson.Safe.Util.(receipt |> member "outcome" |> to_string);
-               check string "skipped receipt terminal reason"
-                 "non_executable_phase:paused"
-                 Yojson.Safe.Util.(
-                   receipt |> member "terminal_reason_code" |> to_string);
-               check string "skipped receipt action radius tool"
-                 "keeper_turn"
-                 Yojson.Safe.Util.(
-                   receipt |> member "action_radius" |> member "tool_name"
-                   |> to_string);
-               check string "skipped receipt runtime contract keeper"
-                 meta.name
-                 Yojson.Safe.Util.(
-                   receipt |> member "runtime_contract" |> member "keeper_name"
-                   |> to_string));
-          let trajectory_path =
-            Masc_mcp.Trajectory.trajectory_path
-              (Masc_mcp.Coord.masc_root_dir config)
+       KR.clear ();
+       Unix.putenv "MASC_BASE_PATH" base_dir;
+       let meta = make_meta "phase-gated-keeper" in
+       let config = Masc_mcp.Coord.default_config base_dir in
+       ignore (KR.register ~base_path:base_dir meta.name meta);
+       (match KR.dispatch_event ~base_path:base_dir meta.name KP.Operator_pause with
+        | Ok _ -> ()
+        | Error err -> fail (KP.transition_error_to_string err));
+       check
+         (option string)
+         "phase paused before run"
+         (Some "paused")
+         (Option.map KP.phase_to_string (KR.get_phase ~base_path:base_dir meta.name));
+       let phase_skip_labels =
+         [ "from", "phase_gating"
+         ; "to", "done"
+         ; "action", "PhaseGateSkip"
+         ; "keeper", meta.name
+         ]
+       in
+       let legacy_phase_cancel_labels =
+         [ "from", "phase_gating"
+         ; "to", "cancelled:phase_gate_close"
+         ; "action", "HonorStopSignal"
+         ; "keeper", meta.name
+         ]
+       in
+       let phase_skip_before =
+         Masc_mcp.Prometheus.metric_value_or_zero
+           Masc_mcp.Keeper_metrics.metric_keeper_turn_fsm_transitions
+           ~labels:phase_skip_labels
+           ()
+       in
+       let legacy_phase_cancel_before =
+         Masc_mcp.Prometheus.metric_value_or_zero
+           Masc_mcp.Keeper_metrics.metric_keeper_turn_fsm_transitions
+           ~labels:legacy_phase_cancel_labels
+           ()
+       in
+       match
+         UT.run_keeper_cycle
+           ~config
+           ~meta
+           ~observation:base_observation
+           ~generation:meta.runtime.generation
+           ()
+       with
+       | Error err ->
+         Alcotest.fail
+           ("expected paused-phase skip, got error: " ^ Agent_sdk.Error.to_string err)
+       | Ok updated ->
+         let phase_skip_after =
+           Masc_mcp.Prometheus.metric_value_or_zero
+             Masc_mcp.Keeper_metrics.metric_keeper_turn_fsm_transitions
+             ~labels:phase_skip_labels
+             ()
+         in
+         let legacy_phase_cancel_after =
+           Masc_mcp.Prometheus.metric_value_or_zero
+             Masc_mcp.Keeper_metrics.metric_keeper_turn_fsm_transitions
+             ~labels:legacy_phase_cancel_labels
+             ()
+         in
+         check string "keeper name preserved" meta.name updated.name;
+         check
+           (float 0.0)
+           "phase skip emits Done transition"
+           (phase_skip_before +. 1.0)
+           phase_skip_after;
+         check
+           (float 0.0)
+           "phase skip does not emit legacy cancel"
+           legacy_phase_cancel_before
+           legacy_phase_cancel_after;
+         check
+           (option string)
+           "phase remains paused after skipped turn"
+           (Some "paused")
+           (Option.map KP.phase_to_string (KR.get_phase ~base_path:base_dir meta.name));
+         (match Masc_mcp.Keeper_execution_receipt.latest_json config meta.name with
+          | None -> fail "expected skipped turn execution receipt"
+          | Some receipt ->
+            check
+              string
+              "skipped receipt outcome"
+              "receipt_skipped"
+              Yojson.Safe.Util.(receipt |> member "outcome" |> to_string);
+            check
+              string
+              "skipped receipt terminal reason"
+              "non_executable_phase:paused"
+              Yojson.Safe.Util.(receipt |> member "terminal_reason_code" |> to_string);
+            check
+              string
+              "skipped receipt action radius tool"
+              "keeper_turn"
+              Yojson.Safe.Util.(
+                receipt |> member "action_radius" |> member "tool_name" |> to_string);
+            check
+              string
+              "skipped receipt runtime contract keeper"
               meta.name
-              (Masc_mcp.Keeper_id.Trace_id.to_string meta.runtime.trace_id)
-          in
-          let trajectory_summary = read_jsonl_line trajectory_path in
-          check string "skipped trajectory summary type" "trajectory_summary"
-            Yojson.Safe.Util.(
-              trajectory_summary |> member "type" |> to_string);
-          check string "skipped trajectory outcome status" "gated"
-            Yojson.Safe.Util.(
-              trajectory_summary |> member "outcome" |> member "status"
-              |> to_string);
-          check string "skipped trajectory outcome reason"
-            "non_executable_phase:paused"
-            Yojson.Safe.Util.(
-              trajectory_summary |> member "outcome" |> member "reason"
-              |> to_string))
+              Yojson.Safe.Util.(
+                receipt |> member "runtime_contract" |> member "keeper_name" |> to_string));
+         let trajectory_path =
+           Masc_mcp.Trajectory.trajectory_path
+             (Masc_mcp.Coord.masc_root_dir config)
+             meta.name
+             (Masc_mcp.Keeper_id.Trace_id.to_string meta.runtime.trace_id)
+         in
+         let trajectory_summary = read_jsonl_line trajectory_path in
+         check
+           string
+           "skipped trajectory summary type"
+           "trajectory_summary"
+           Yojson.Safe.Util.(trajectory_summary |> member "type" |> to_string);
+         check
+           string
+           "skipped trajectory outcome status"
+           "gated"
+           Yojson.Safe.Util.(
+             trajectory_summary |> member "outcome" |> member "status" |> to_string);
+         check
+           string
+           "skipped trajectory outcome reason"
+           "non_executable_phase:paused"
+           Yojson.Safe.Util.(
+             trajectory_summary |> member "outcome" |> member "reason" |> to_string))
+;;
 
 let test_run_keeper_cycle_livelock_block_returns_error () =
-  Eio_main.run @@ fun env ->
+  Eio_main.run
+  @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
   let base_dir = temp_dir () in
   Fun.protect
@@ -4045,67 +5268,85 @@ let test_run_keeper_cycle_livelock_block_returns_error () =
       Masc_mcp.Keeper_turn_livelock.reset_for_tests ();
       cleanup_dir base_dir)
     (fun () ->
-      with_test_runtime_roots base_dir @@ fun () ->
-      KR.clear ();
-      Masc_mcp.Keeper_turn_livelock.reset_for_tests ();
-      with_env "MASC_KEEPER_TURN_LIVELOCK_MAX_ATTEMPTS" "1" @@ fun () ->
-      with_env "MASC_KEEPER_TURN_LIVELOCK_STUCK_AFTER_SEC" "1800.0" @@ fun () ->
-      let meta = make_meta "livelock-blocked-keeper" in
-      let config = Masc_mcp.Coord.default_config base_dir in
-      ignore (Masc_mcp.Coord.init config ~agent_name:(Some "observer"));
-      ignore (KR.register ~base_path:base_dir meta.name meta);
-      ignore
-        (Masc_mcp.Keeper_turn_livelock.guard_and_record_turn_start
-           ~keeper:meta.name
-           ~turn_id:meta.runtime.usage.total_turns
-           ~max_attempts:1
-           ~stuck_after_sec:1800.0
-           ());
-      match
-        UT.run_keeper_cycle
-          ~config
-          ~meta
-          ~observation:base_observation
-          ~generation:meta.runtime.generation
-          ()
-      with
-      | Ok _ -> fail "expected livelock-blocked turn to return Error"
-      | Error err ->
-          let error_message = Agent_sdk.Error.to_string err in
-          check bool "error mentions livelock" true
-            (contains_substring error_message "livelock blocked");
-          (match
-             Masc_mcp.Keeper_execution_receipt.latest_json config meta.name
-           with
-           | None -> fail "expected livelock-blocked execution receipt"
-           | Some receipt ->
-               check string "blocked receipt outcome" "receipt_failed"
-                 Yojson.Safe.Util.(receipt |> member "outcome" |> to_string);
-               check string "blocked operator disposition" "pause_human"
+       with_test_runtime_roots base_dir
+       @@ fun () ->
+       KR.clear ();
+       Masc_mcp.Keeper_turn_livelock.reset_for_tests ();
+       with_env "MASC_KEEPER_TURN_LIVELOCK_MAX_ATTEMPTS" "1"
+       @@ fun () ->
+       with_env "MASC_KEEPER_TURN_LIVELOCK_STUCK_AFTER_SEC" "1800.0"
+       @@ fun () ->
+       let meta = make_meta "livelock-blocked-keeper" in
+       let config = Masc_mcp.Coord.default_config base_dir in
+       ignore (Masc_mcp.Coord.init config ~agent_name:(Some "observer"));
+       ignore (KR.register ~base_path:base_dir meta.name meta);
+       ignore
+         (Masc_mcp.Keeper_turn_livelock.guard_and_record_turn_start
+            ~keeper:meta.name
+            ~turn_id:meta.runtime.usage.total_turns
+            ~max_attempts:1
+            ~stuck_after_sec:1800.0
+            ());
+       match
+         UT.run_keeper_cycle
+           ~config
+           ~meta
+           ~observation:base_observation
+           ~generation:meta.runtime.generation
+           ()
+       with
+       | Ok _ -> fail "expected livelock-blocked turn to return Error"
+       | Error err ->
+         let error_message = Agent_sdk.Error.to_string err in
+         check
+           bool
+           "error mentions livelock"
+           true
+           (contains_substring error_message "livelock blocked");
+         (match Masc_mcp.Keeper_execution_receipt.latest_json config meta.name with
+          | None -> fail "expected livelock-blocked execution receipt"
+          | Some receipt ->
+            check
+              string
+              "blocked receipt outcome"
+              "receipt_failed"
+              Yojson.Safe.Util.(receipt |> member "outcome" |> to_string);
+            check
+              string
+              "blocked operator disposition"
+              "pause_human"
+              Yojson.Safe.Util.(receipt |> member "operator_disposition" |> to_string);
+            check
+              string
+              "blocked disposition reason"
+              "turn_livelock_blocked"
+              Yojson.Safe.Util.(
+                receipt |> member "operator_disposition_reason" |> to_string);
+            check
+              string
+              "blocked receipt error kind"
+              "turn_livelock_blocked"
+              Yojson.Safe.Util.(receipt |> member "error" |> member "kind" |> to_string);
+            check
+              bool
+              "blocked receipt error message"
+              true
+              (contains_substring
                  Yojson.Safe.Util.(
-                   receipt |> member "operator_disposition" |> to_string);
-               check string "blocked disposition reason"
-                 "turn_livelock_blocked"
-                 Yojson.Safe.Util.(
-                   receipt |> member "operator_disposition_reason"
-                   |> to_string);
-               check string "blocked receipt error kind"
-                 "turn_livelock_blocked"
-                 Yojson.Safe.Util.(
-                   receipt |> member "error" |> member "kind" |> to_string);
-               check bool "blocked receipt error message" true
-                 (contains_substring
-                    Yojson.Safe.Util.(
-                      receipt |> member "error" |> member "message" |> to_string)
-                    "livelock blocked");
-               check bool "blocked receipt terminal reason" true
-                 (contains_substring
-                    Yojson.Safe.Util.(
-                      receipt |> member "terminal_reason_code" |> to_string)
-                    "turn_livelock:attempts_exhausted")))
+                   receipt |> member "error" |> member "message" |> to_string)
+                 "livelock blocked");
+            check
+              bool
+              "blocked receipt terminal reason"
+              true
+              (contains_substring
+                 Yojson.Safe.Util.(receipt |> member "terminal_reason_code" |> to_string)
+                 "turn_livelock:attempts_exhausted")))
+;;
 
 let test_streaming_cancel_records_supervisor_stop_when_fiber_stop_set () =
-  Eio_main.run @@ fun env ->
+  Eio_main.run
+  @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
   let base_dir = temp_dir () in
   Fun.protect
@@ -4113,111 +5354,154 @@ let test_streaming_cancel_records_supervisor_stop_when_fiber_stop_set () =
       KR.clear ();
       cleanup_dir base_dir)
     (fun () ->
-      with_test_runtime_roots base_dir @@ fun () ->
-      KR.clear ();
-      let meta = make_meta "streaming-supervisor-stop-keeper" in
-      let config = Masc_mcp.Coord.default_config base_dir in
-      ignore (Masc_mcp.Coord.init config ~agent_name:(Some "observer"));
-      let entry = KR.register ~base_path:base_dir meta.name meta in
-      Atomic.set entry.fiber_stop true;
-      let supervisor_request_labels =
-        [
-          ("from", "streaming");
-          ("to", "streaming");
-          ("action", "SupervisorRequestsStop");
-          ("keeper", meta.name);
-        ]
-      in
-      let honor_stop_labels =
-        [
-          ("from", "streaming");
-          ("to", "cancelled:supervisor_stop");
-          ("action", "HonorStopSignal");
-          ("keeper", meta.name);
-        ]
-      in
-      let supervisor_request_before =
-        Masc_mcp.Prometheus.metric_value_or_zero
-          Masc_mcp.Keeper_metrics.metric_keeper_turn_fsm_transitions
-          ~labels:supervisor_request_labels
-          ()
-      in
-      let honor_stop_before =
-        Masc_mcp.Prometheus.metric_value_or_zero
-          Masc_mcp.Keeper_metrics.metric_keeper_turn_fsm_transitions
-          ~labels:honor_stop_labels
-          ()
-      in
-      UT.record_streaming_cancelled_observation
-        ~config
-        ~run_meta:meta
-        ~run_generation:meta.runtime.generation
-        ~cascade_name:
-          (Masc_mcp.Keeper_execution_receipt.cascade_name_of_string
-             (Masc_mcp.Keeper_types.cascade_name_of_meta meta))
-        ~keeper_turn_id:meta.runtime.usage.total_turns
-        ();
-      let supervisor_request_after =
-        Masc_mcp.Prometheus.metric_value_or_zero
-          Masc_mcp.Keeper_metrics.metric_keeper_turn_fsm_transitions
-          ~labels:supervisor_request_labels
-          ()
-      in
-      let honor_stop_after =
-        Masc_mcp.Prometheus.metric_value_or_zero
-          Masc_mcp.Keeper_metrics.metric_keeper_turn_fsm_transitions
-          ~labels:honor_stop_labels
-          ()
-      in
-      check (float 0.0)
-        "streaming supervisor stop emits SupervisorRequestsStop"
-        (supervisor_request_before +. 1.0)
-        supervisor_request_after;
-      check (float 0.0)
-        "streaming supervisor stop emits HonorStopSignal"
-        (honor_stop_before +. 1.0)
-        honor_stop_after;
-      match Masc_mcp.Keeper_execution_receipt.latest_json config meta.name with
-      | None -> fail "expected streaming cancel execution receipt"
-      | Some receipt ->
-          check string "streaming cancel receipt outcome" "receipt_cancelled"
-            Yojson.Safe.Util.(receipt |> member "outcome" |> to_string);
-          check string "streaming cancel terminal reason" "supervisor_stop"
-            Yojson.Safe.Util.(
-              receipt |> member "terminal_reason_code" |> to_string))
+       with_test_runtime_roots base_dir
+       @@ fun () ->
+       KR.clear ();
+       let meta = make_meta "streaming-supervisor-stop-keeper" in
+       let config = Masc_mcp.Coord.default_config base_dir in
+       ignore (Masc_mcp.Coord.init config ~agent_name:(Some "observer"));
+       let entry = KR.register ~base_path:base_dir meta.name meta in
+       Atomic.set entry.fiber_stop true;
+       let supervisor_request_labels =
+         [ "from", "streaming"
+         ; "to", "streaming"
+         ; "action", "SupervisorRequestsStop"
+         ; "keeper", meta.name
+         ]
+       in
+       let honor_stop_labels =
+         [ "from", "streaming"
+         ; "to", "cancelled:supervisor_stop"
+         ; "action", "HonorStopSignal"
+         ; "keeper", meta.name
+         ]
+       in
+       let supervisor_request_before =
+         Masc_mcp.Prometheus.metric_value_or_zero
+           Masc_mcp.Keeper_metrics.metric_keeper_turn_fsm_transitions
+           ~labels:supervisor_request_labels
+           ()
+       in
+       let honor_stop_before =
+         Masc_mcp.Prometheus.metric_value_or_zero
+           Masc_mcp.Keeper_metrics.metric_keeper_turn_fsm_transitions
+           ~labels:honor_stop_labels
+           ()
+       in
+       UT.record_streaming_cancelled_observation
+         ~config
+         ~run_meta:meta
+         ~run_generation:meta.runtime.generation
+         ~cascade_name:
+           (Masc_mcp.Keeper_execution_receipt.cascade_name_of_string
+              (Masc_mcp.Keeper_types.cascade_name_of_meta meta))
+         ~keeper_turn_id:meta.runtime.usage.total_turns
+         ();
+       let supervisor_request_after =
+         Masc_mcp.Prometheus.metric_value_or_zero
+           Masc_mcp.Keeper_metrics.metric_keeper_turn_fsm_transitions
+           ~labels:supervisor_request_labels
+           ()
+       in
+       let honor_stop_after =
+         Masc_mcp.Prometheus.metric_value_or_zero
+           Masc_mcp.Keeper_metrics.metric_keeper_turn_fsm_transitions
+           ~labels:honor_stop_labels
+           ()
+       in
+       check
+         (float 0.0)
+         "streaming supervisor stop emits SupervisorRequestsStop"
+         (supervisor_request_before +. 1.0)
+         supervisor_request_after;
+       check
+         (float 0.0)
+         "streaming supervisor stop emits HonorStopSignal"
+         (honor_stop_before +. 1.0)
+         honor_stop_after;
+       match Masc_mcp.Keeper_execution_receipt.latest_json config meta.name with
+       | None -> fail "expected streaming cancel execution receipt"
+       | Some receipt ->
+         check
+           string
+           "streaming cancel receipt outcome"
+           "receipt_cancelled"
+           Yojson.Safe.Util.(receipt |> member "outcome" |> to_string);
+         check
+           string
+           "streaming cancel terminal reason"
+           "supervisor_stop"
+           Yojson.Safe.Util.(receipt |> member "terminal_reason_code" |> to_string))
+;;
 
 let test_run_keeper_cycle_records_trajectory_source_contract () =
-  check bool "keeper cycle creates trajectory accumulator" true
-    (source_file_contains "lib/keeper/keeper_unified_turn.ml"
+  check
+    bool
+    "keeper cycle creates trajectory accumulator"
+    true
+    (source_file_contains
+       "lib/keeper/keeper_unified_turn.ml"
        "Trajectory.create_accumulator");
-  check bool "keeper cycle passes trajectory_acc to agent run" true
-    (source_file_contains "lib/keeper/keeper_unified_turn.ml"
-       "~trajectory_acc");
-  check bool "keeper cycle resolves masc root via Coord.masc_root_dir" true
-    (source_file_contains "lib/keeper/keeper_unified_turn.ml"
+  check
+    bool
+    "keeper cycle passes trajectory_acc to agent run"
+    true
+    (source_file_contains "lib/keeper/keeper_unified_turn.ml" "~trajectory_acc");
+  check
+    bool
+    "keeper cycle resolves masc root via Coord.masc_root_dir"
+    true
+    (source_file_contains
+       "lib/keeper/keeper_unified_turn.ml"
        "Coord.masc_root_dir config");
-  check bool "keeper cycle finalizes trajectory on completion/failure" true
-    (source_file_contains "lib/keeper/keeper_turn_helpers.ml"
+  check
+    bool
+    "keeper cycle finalizes trajectory on completion/failure"
+    true
+    (source_file_contains
+       "lib/keeper/keeper_turn_helpers.ml"
        "let finalize_trajectory_acc");
-  check bool "pre-dispatch exits record terminal receipt" true
-    (source_file_contains "lib/keeper/keeper_unified_turn.ml"
+  check
+    bool
+    "pre-dispatch exits record terminal receipt"
+    true
+    (source_file_contains
+       "lib/keeper/keeper_unified_turn.ml"
        "record_pre_dispatch_terminal_observation");
-  check bool "saturation skip has durable terminal reason" true
-    (source_file_contains "lib/keeper/keeper_unified_turn.ml"
+  check
+    bool
+    "saturation skip has durable terminal reason"
+    true
+    (source_file_contains
+       "lib/keeper/keeper_unified_turn.ml"
        "~terminal_reason_code:\"ollama_saturated\"");
-  check bool "saturation skip is not recorded as error" true
-    (source_file_contains "lib/keeper/keeper_unified_turn.ml"
+  check
+    bool
+    "saturation skip is not recorded as error"
+    true
+    (source_file_contains
+       "lib/keeper/keeper_unified_turn.ml"
        "~terminal_reason_code:\"ollama_saturated\"\n\
        \                ~activity_kind:\"keeper.turn_skipped\"");
-  check bool "saturation skip uses fsm-allowed cascade unavailable transition" true
-    (source_file_contains "lib/keeper/keeper_unified_turn.ml"
+  check
+    bool
+    "saturation skip uses fsm-allowed cascade unavailable transition"
+    true
+    (source_file_contains
+       "lib/keeper/keeper_unified_turn.ml"
        "Keeper_turn_fsm.Failure_cascade_unavailable");
-  check bool "livelock block has durable terminal reason" true
-    (source_file_contains "lib/keeper/keeper_unified_turn.ml"
+  check
+    bool
+    "livelock block has durable terminal reason"
+    true
+    (source_file_contains
+       "lib/keeper/keeper_unified_turn.ml"
        "Printf.sprintf \"turn_livelock:%s\"")
+;;
 
 let test_pre_tool_gate_records_durable_attempt_telemetry () =
-  Eio_main.run @@ fun env ->
+  Eio_main.run
+  @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
   let base_dir = temp_dir () in
   Fun.protect
@@ -4225,144 +5509,204 @@ let test_pre_tool_gate_records_durable_attempt_telemetry () =
       KTCL.reset_for_testing ();
       cleanup_dir base_dir)
     (fun () ->
-      let keeper_name = "pre-tool-gate-keeper" in
-      let meta_ref = ref (make_meta keeper_name) in
-      let config = Masc_mcp.Coord.default_config base_dir in
-      let masc_root = Masc_mcp.Coord.masc_root_dir config in
-      let trace_id = "trace-pre-tool-gate" in
-      let acc =
-        Masc_mcp.Trajectory.create_accumulator
-          ~masc_root ~keeper_name ~trace_id ~generation:9
-      in
-      KTCL.reset_for_testing ();
-      KTCL.init ~base_path:base_dir ();
-      KTCL.set_turn_context
-        ~keeper_name
-        ~agent_name:"pre-tool-gate-agent"
-        ~trace_id
-        ~session_id:"session-pre-tool-gate"
-        ~generation:9
-        ~turn:3
-        ~keeper_turn_id:3
-        ~task_id:"task-pre-tool"
-        ~goal_ids:["goal-pre-tool"]
-        ~approval_mode:"manual"
-        ~tool_surface_class:"execution"
-        ~visible_tool_count:1
-        ~required_tools:["keeper_bash"]
-        ();
-      let hooks =
-        HK.make_hooks
-          ~config
-          ~meta_ref
-          ~generation:9
-          ~pre_tool_use_guard:(fun ~tool_name:_ ~input:_ ->
-            Some "operator approval required before dispatch")
-          ~trajectory_acc:acc
-          ()
-      in
-      let schedule : Agent_sdk.Hooks.tool_schedule =
-        {
-          planned_index = 0;
-          batch_index = 0;
-          batch_size = 1;
-          concurrency_class = "default";
-          batch_kind = "sequential";
-        }
-      in
-      let decision =
-        Agent_sdk.Hooks.invoke hooks.pre_tool_use
-          (Agent_sdk.Hooks.PreToolUse
-             {
-               tool_use_id = "toolu_pre_gate";
-               tool_name = "keeper_bash";
-               input = `Assoc [ ("cmd", `String "git status --short") ];
-               accumulated_cost_usd = 0.0;
-               turn = 3;
-               schedule;
-             })
-      in
-      check string "custom gate blocked"
-        "Override"
-        (Agent_sdk.Hooks.decision_kind_to_string
-           (Agent_sdk.Hooks.classify_decision decision));
-      let entries =
-        Masc_mcp.Trajectory.read_entries ~masc_root ~keeper_name ~trace_id
-      in
-      check int "trajectory entry count" 1 (List.length entries);
-      (match entries with
-       | [ entry ] ->
-         check string "trajectory tool" "keeper_bash" entry.tool_name;
-         check int "trajectory turn" 3 entry.turn;
-         (match entry.gate_decision with
-          | Masc_mcp.Trajectory.Reject reason ->
-            check bool "reject reason names pre-tool guard" true
-              (contains_substring reason "pre_tool_use_guard")
-          | Masc_mcp.Trajectory.Pass ->
-            fail "expected rejected gate decision");
-         check bool "trajectory error present" true
-           (Option.is_some entry.error)
-       | _ -> fail "expected one trajectory entry");
-      let raw_trajectory =
-        read_jsonl_line
-          (Masc_mcp.Trajectory.trajectory_path masc_root keeper_name trace_id)
-      in
-      let runtime_contract =
-        Yojson.Safe.Util.member "runtime_contract" raw_trajectory
-      in
-      check string "runtime contract keeper" keeper_name
-        Yojson.Safe.Util.(runtime_contract |> member "keeper_name" |> to_string);
-      check string "runtime contract trace" trace_id
-        Yojson.Safe.Util.(runtime_contract |> member "trace_id" |> to_string);
-      let action_radius =
-        Yojson.Safe.Util.member "action_radius" raw_trajectory
-      in
-      check string "action radius tool" "keeper_bash"
-        Yojson.Safe.Util.(action_radius |> member "tool_name" |> to_string);
-      check bool "action radius failed" false
-        Yojson.Safe.Util.(action_radius |> member "success" |> to_bool);
-      let tool_call_entries = KTCL.read_recent ~keeper_name ~n:1 () in
-      check int "tool-call log entry count" 1 (List.length tool_call_entries);
-      let tool_call = List.hd tool_call_entries in
-      check string "tool-call log tool" "keeper_bash"
-        (Safe_ops.json_string ~default:"" "tool" tool_call);
-      check bool "tool-call log failed" false
-        (Safe_ops.json_bool ~default:true "success" tool_call);
-      check string "tool-call trace" trace_id
-        (Safe_ops.json_string ~default:"" "trace_id" tool_call))
+       let keeper_name = "pre-tool-gate-keeper" in
+       let meta_ref = ref (make_meta keeper_name) in
+       let config = Masc_mcp.Coord.default_config base_dir in
+       let masc_root = Masc_mcp.Coord.masc_root_dir config in
+       let trace_id = "trace-pre-tool-gate" in
+       let acc =
+         Masc_mcp.Trajectory.create_accumulator
+           ~masc_root
+           ~keeper_name
+           ~trace_id
+           ~generation:9
+       in
+       KTCL.reset_for_testing ();
+       KTCL.init ~base_path:base_dir ();
+       KTCL.set_turn_context
+         ~keeper_name
+         ~agent_name:"pre-tool-gate-agent"
+         ~trace_id
+         ~session_id:"session-pre-tool-gate"
+         ~generation:9
+         ~turn:3
+         ~keeper_turn_id:3
+         ~task_id:"task-pre-tool"
+         ~goal_ids:[ "goal-pre-tool" ]
+         ~approval_mode:"manual"
+         ~tool_surface_class:"execution"
+         ~visible_tool_count:1
+         ~required_tools:[ "keeper_bash" ]
+         ();
+       let hooks =
+         HK.make_hooks
+           ~config
+           ~meta_ref
+           ~generation:9
+           ~pre_tool_use_guard:(fun ~tool_name:_ ~input:_ ->
+             Some "operator approval required before dispatch")
+           ~trajectory_acc:acc
+           ()
+       in
+       let schedule : Agent_sdk.Hooks.tool_schedule =
+         { planned_index = 0
+         ; batch_index = 0
+         ; batch_size = 1
+         ; concurrency_class = "default"
+         ; batch_kind = "sequential"
+         }
+       in
+       let decision =
+         Agent_sdk.Hooks.invoke
+           hooks.pre_tool_use
+           (Agent_sdk.Hooks.PreToolUse
+              { tool_use_id = "toolu_pre_gate"
+              ; tool_name = "keeper_bash"
+              ; input = `Assoc [ "cmd", `String "git status --short" ]
+              ; accumulated_cost_usd = 0.0
+              ; turn = 3
+              ; schedule
+              })
+       in
+       check
+         string
+         "custom gate blocked"
+         "Override"
+         (Agent_sdk.Hooks.decision_kind_to_string
+            (Agent_sdk.Hooks.classify_decision decision));
+       let entries = Masc_mcp.Trajectory.read_entries ~masc_root ~keeper_name ~trace_id in
+       check int "trajectory entry count" 1 (List.length entries);
+       (match entries with
+        | [ entry ] ->
+          check string "trajectory tool" "keeper_bash" entry.tool_name;
+          check int "trajectory turn" 3 entry.turn;
+          (match entry.gate_decision with
+           | Masc_mcp.Trajectory.Reject reason ->
+             check
+               bool
+               "reject reason names pre-tool guard"
+               true
+               (contains_substring reason "pre_tool_use_guard")
+           | Masc_mcp.Trajectory.Pass -> fail "expected rejected gate decision");
+          check bool "trajectory error present" true (Option.is_some entry.error)
+        | _ -> fail "expected one trajectory entry");
+       let raw_trajectory =
+         read_jsonl_line
+           (Masc_mcp.Trajectory.trajectory_path masc_root keeper_name trace_id)
+       in
+       let runtime_contract = Yojson.Safe.Util.member "runtime_contract" raw_trajectory in
+       check
+         string
+         "runtime contract keeper"
+         keeper_name
+         Yojson.Safe.Util.(runtime_contract |> member "keeper_name" |> to_string);
+       check
+         string
+         "runtime contract trace"
+         trace_id
+         Yojson.Safe.Util.(runtime_contract |> member "trace_id" |> to_string);
+       let action_radius = Yojson.Safe.Util.member "action_radius" raw_trajectory in
+       check
+         string
+         "action radius tool"
+         "keeper_bash"
+         Yojson.Safe.Util.(action_radius |> member "tool_name" |> to_string);
+       check
+         bool
+         "action radius failed"
+         false
+         Yojson.Safe.Util.(action_radius |> member "success" |> to_bool);
+       let tool_call_entries = KTCL.read_recent ~keeper_name ~n:1 () in
+       check int "tool-call log entry count" 1 (List.length tool_call_entries);
+       let tool_call = List.hd tool_call_entries in
+       check
+         string
+         "tool-call log tool"
+         "keeper_bash"
+         (Safe_ops.json_string ~default:"" "tool" tool_call);
+       check
+         bool
+         "tool-call log failed"
+         false
+         (Safe_ops.json_bool ~default:true "success" tool_call);
+       check
+         string
+         "tool-call trace"
+         trace_id
+         (Safe_ops.json_string ~default:"" "trace_id" tool_call))
+;;
 
 let test_run_keeper_cycle_surfaces_side_effect_failures_source_contract () =
-  check bool "keeper cycle records side-effect issues in registry" true
-    (source_file_contains "lib/keeper/keeper_turn_helpers.ml"
+  check
+    bool
+    "keeper cycle records side-effect issues in registry"
+    true
+    (source_file_contains
+       "lib/keeper/keeper_turn_helpers.ml"
        "Keeper_registry.record_error ~base_path:config.base_path");
-  check bool "trajectory finalize is not silently ignored" false
-    (source_file_contains "lib/keeper/keeper_unified_turn.ml"
+  check
+    bool
+    "trajectory finalize is not silently ignored"
+    false
+    (source_file_contains
+       "lib/keeper/keeper_unified_turn.ml"
        "ignore (Trajectory.finalize trajectory_acc outcome)");
-  check bool "paused-state sync result is not discarded" false
-    (source_file_contains "lib/keeper/keeper_unified_turn.ml"
+  check
+    bool
+    "paused-state sync result is not discarded"
+    false
+    (source_file_contains
+       "lib/keeper/keeper_unified_turn.ml"
        "let _ = sync_keeper_paused_state");
-  check bool "local discovery refresh is not silently ignored" false
-    (source_file_contains "lib/keeper/keeper_unified_turn.ml"
+  check
+    bool
+    "local discovery refresh is not silently ignored"
+    false
+    (source_file_contains
+       "lib/keeper/keeper_unified_turn.ml"
        "ignore (Cascade_runtime.refresh_local_discovery_if_possible model_labels)");
-  check bool "manual keeper_msg local discovery refresh is not silently ignored" false
-    (source_file_contains "lib/keeper/keeper_turn.ml"
+  check
+    bool
+    "manual keeper_msg local discovery refresh is not silently ignored"
+    false
+    (source_file_contains
+       "lib/keeper/keeper_turn.ml"
        "ignore (Cascade_runtime.refresh_local_discovery_if_possible effective_models)");
-  check bool "activity graph emit is not silently ignored" false
-    (source_file_contains "lib/keeper/keeper_unified_turn.ml"
+  check
+    bool
+    "activity graph emit is not silently ignored"
+    false
+    (source_file_contains
+       "lib/keeper/keeper_unified_turn.ml"
        "ignore (Activity_graph.emit config");
   let null_fallback_text = "using " ^ "Null input" in
-  check bool "unmatched ToolCompleted does not fall back to Null input" false
-    (source_file_contains "lib/keeper/keeper_unified_turn.ml"
-       null_fallback_text);
-  check bool "discovery helper guards keeper setup" true
-    (source_file_contains "lib/keeper/keeper_unified_turn.ml"
+  check
+    bool
+    "unmatched ToolCompleted does not fall back to Null input"
+    false
+    (source_file_contains "lib/keeper/keeper_unified_turn.ml" null_fallback_text);
+  check
+    bool
+    "discovery helper guards keeper setup"
+    true
+    (source_file_contains
+       "lib/keeper/keeper_unified_turn.ml"
        "ensure_local_discovery_ready model_labels");
-  check bool "manual keeper_msg discovery helper guards keeper setup" true
-    (source_file_contains "lib/keeper/keeper_turn.ml"
+  check
+    bool
+    "manual keeper_msg discovery helper guards keeper setup"
+    true
+    (source_file_contains
+       "lib/keeper/keeper_turn.ml"
        "ensure_local_discovery_ready effective_models");
-  check bool "manual keeper_msg async facade preflights before submit" true
-    (source_file_contains "lib/tool_keeper.ml"
+  check
+    bool
+    "manual keeper_msg async facade preflights before submit"
+    true
+    (source_file_contains
+       "lib/tool_keeper.ml"
        "Turn.preflight_keeper_msg ctx resolved_args")
+;;
 
 let test_sync_keeper_paused_state_surfaces_write_failure_without_mutating_registry () =
   let base_dir = temp_dir () in
@@ -4371,28 +5715,34 @@ let test_sync_keeper_paused_state_surfaces_write_failure_without_mutating_regist
       KR.clear ();
       cleanup_dir base_dir)
     (fun () ->
-      let config = Masc_mcp.Coord.default_config base_dir in
-      let meta = make_meta "paused-sync-failure" in
-      ignore (KR.register ~base_path:base_dir meta.name meta);
-      let masc_root = Masc_mcp.Coord.masc_root_dir config in
-      Masc_mcp.Keeper_types.mkdir_p masc_root;
-      let keepers_path = Filename.concat masc_root "keepers" in
-      let oc = open_out_bin keepers_path in
-      close_out oc;
-      match UT.sync_keeper_paused_state ~config ~meta ~paused:true with
-      | Ok _ -> fail "expected paused-state sync failure"
-      | Error msg ->
-          check bool "write failure surfaced" true
-            (contains_substring msg "failed to write meta");
-          let latest =
-            match KR.get ~base_path:base_dir meta.name with
-            | Some entry -> entry.meta
-            | None -> fail "expected registered keeper entry"
-          in
-          check bool "registry meta unchanged" false latest.paused;
-          check (option string) "phase unchanged" (Some "running")
-            (Option.map KP.phase_to_string
-               (KR.get_phase ~base_path:base_dir meta.name)))
+       let config = Masc_mcp.Coord.default_config base_dir in
+       let meta = make_meta "paused-sync-failure" in
+       ignore (KR.register ~base_path:base_dir meta.name meta);
+       let masc_root = Masc_mcp.Coord.masc_root_dir config in
+       Masc_mcp.Keeper_types.mkdir_p masc_root;
+       let keepers_path = Filename.concat masc_root "keepers" in
+       let oc = open_out_bin keepers_path in
+       close_out oc;
+       match UT.sync_keeper_paused_state ~config ~meta ~paused:true with
+       | Ok _ -> fail "expected paused-state sync failure"
+       | Error msg ->
+         check
+           bool
+           "write failure surfaced"
+           true
+           (contains_substring msg "failed to write meta");
+         let latest =
+           match KR.get ~base_path:base_dir meta.name with
+           | Some entry -> entry.meta
+           | None -> fail "expected registered keeper entry"
+         in
+         check bool "registry meta unchanged" false latest.paused;
+         check
+           (option string)
+           "phase unchanged"
+           (Some "running")
+           (Option.map KP.phase_to_string (KR.get_phase ~base_path:base_dir meta.name)))
+;;
 
 let test_ensure_local_discovery_ready_surfaces_refresh_failure () =
   let refresh_calls = ref 0 in
@@ -4405,63 +5755,69 @@ let test_ensure_local_discovery_ready_surfaces_refresh_failure () =
   with
   | Ok () -> fail "expected local discovery refresh failure"
   | Error msg ->
-      check int "refresh called once" 1 !refresh_calls;
-      check bool "error includes label" true
-        (contains_substring msg "llama:auto")
+    check int "refresh called once" 1 !refresh_calls;
+    check bool "error includes label" true (contains_substring msg "llama:auto")
+;;
 
 let test_keeper_msg_async_failure_surface () =
-  Eio_main.run @@ fun env ->
+  Eio_main.run
+  @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
-  Eio.Switch.run @@ fun sw ->
+  Eio.Switch.run
+  @@ fun sw ->
   let base_dir = temp_dir () in
   Fun.protect
     ~finally:(fun () ->
       KR.clear ();
       cleanup_dir base_dir)
     (fun () ->
-      with_test_runtime_roots base_dir @@ fun () ->
-      let keeper_name = "msg-preflight" in
-      let config = Masc_mcp.Coord.default_config base_dir in
-      ignore (Masc_mcp.Coord.init config ~agent_name:(Some "operator"));
-      let meta = make_meta keeper_name in
-      (match Masc_mcp.Keeper_types.write_meta ~force:true config meta with
-      | Ok () -> ()
-      | Error err -> fail ("write_meta failed: " ^ err));
-      let ctx : _ Masc_mcp.Tool_keeper.context =
-        {
-          config;
-          agent_name = "operator";
-          sw;
-          clock = Eio.Stdenv.clock env;
-          proc_mgr = Some (Eio.Stdenv.process_mgr env);
-          net = None;
-        }
-      in
-      KTH.For_testing.with_local_discovery_refresh
-        (fun _labels -> false)
-        (fun () ->
-          match
-            Masc_mcp.Tool_keeper.dispatch ctx ~name:"masc_keeper_msg"
-              ~args:
-                (`Assoc
-                   [
-                     ("name", `String keeper_name);
-                     ("message", `String "check discovery failure");
-                   ])
-          with
-          | Some (false, err) ->
-              if not
-                   (contains_substring err "local discovery refresh required"
-                    && contains_substring err "refresh failed")
+       with_test_runtime_roots base_dir
+       @@ fun () ->
+       let keeper_name = "msg-preflight" in
+       let config = Masc_mcp.Coord.default_config base_dir in
+       ignore (Masc_mcp.Coord.init config ~agent_name:(Some "operator"));
+       let meta = make_meta keeper_name in
+       (match Masc_mcp.Keeper_types.write_meta ~force:true config meta with
+        | Ok () -> ()
+        | Error err -> fail ("write_meta failed: " ^ err));
+       let ctx : _ Masc_mcp.Tool_keeper.context =
+         { config
+         ; agent_name = "operator"
+         ; sw
+         ; clock = Eio.Stdenv.clock env
+         ; proc_mgr = Some (Eio.Stdenv.process_mgr env)
+         ; net = None
+         }
+       in
+       KTH.For_testing.with_local_discovery_refresh
+         (fun _labels -> false)
+         (fun () ->
+            match
+              Masc_mcp.Tool_keeper.dispatch
+                ctx
+                ~name:"masc_keeper_msg"
+                ~args:
+                  (`Assoc
+                      [ "name", `String keeper_name
+                      ; "message", `String "check discovery failure"
+                      ])
+            with
+            | Some (false, err) ->
+              if
+                not
+                  (contains_substring err "local discovery refresh required"
+                   && contains_substring err "refresh failed")
               then fail ("unexpected synchronous error: " ^ err)
-          | Some (true, body) ->
+            | Some (true, body) ->
               fail ("expected synchronous failure, got queued body: " ^ body)
-          | None -> fail "masc_keeper_msg dispatch missing"))
+            | None -> fail "masc_keeper_msg dispatch missing"))
+;;
 
 let provider_config_of_label label =
   match Masc_mcp.Cascade_config.parse_model_string label with
   | Some cfg -> cfg
   | None -> fail ("expected model label to parse: " ^ label)
+;;
 
 let test_decide_local_only_liveness_keeps_non_local_effective () =
   match
@@ -4472,8 +5828,9 @@ let test_decide_local_only_liveness_keeps_non_local_effective () =
       [ "not-a-real-label" ]
   with
   | UT.Keep_effective_cascade cascade ->
-      check string "keeps selected cascade" (KC.default_cascade_name ()) cascade
+    check string "keeps selected cascade" (KC.default_cascade_name ()) cascade
   | UT.Probe_local_only_urls _ -> fail "unexpected local-only probe decision"
+;;
 
 let test_decide_local_only_liveness_keeps_explicit_local_only () =
   match
@@ -4484,9 +5841,13 @@ let test_decide_local_only_liveness_keeps_explicit_local_only () =
       [ "not-a-real-label" ]
   with
   | UT.Keep_effective_cascade cascade ->
-      check string "legacy local_only alias follows phase-buffer route"
-        KC.local_only_cascade_name cascade
+    check
+      string
+      "legacy local_only alias follows phase-buffer route"
+      KC.local_only_cascade_name
+      cascade
   | UT.Probe_local_only_urls _ -> fail "unexpected local-only probe decision"
+;;
 
 let test_decide_local_only_liveness_requests_deduped_ollama_probe () =
   let label = "ollama:qwen3.6:35b-a3b-mlx-bf16" in
@@ -4498,12 +5859,12 @@ let test_decide_local_only_liveness_requests_deduped_ollama_probe () =
       [ label; label ]
   with
   | UT.Keep_effective_cascade _ -> fail "expected Ollama liveness probe"
-  | UT.Probe_local_only_urls
-      { effective_cascade; fallback_cascade; probeable_base_urls } ->
-      check string "effective cascade" KC.local_only_cascade_name effective_cascade;
-      check string "fallback cascade" "tool_rerank" fallback_cascade;
-      check (list string) "deduped probe URLs" [ cfg.base_url ]
-        probeable_base_urls
+  | UT.Probe_local_only_urls { effective_cascade; fallback_cascade; probeable_base_urls }
+    ->
+    check string "effective cascade" KC.local_only_cascade_name effective_cascade;
+    check string "fallback cascade" "tool_rerank" fallback_cascade;
+    check (list string) "deduped probe URLs" [ cfg.base_url ] probeable_base_urls
+;;
 
 let test_fail_open_local_only_when_probe_fails () =
   let cascade =
@@ -4514,6 +5875,7 @@ let test_fail_open_local_only_when_probe_fails () =
       [ "ollama:qwen3.6:35b-a3b-mlx-bf16" ]
   in
   check string "falls back to base cascade" "tool_rerank" cascade
+;;
 
 let test_fail_open_local_only_preserves_explicit_local_only_base () =
   let probe_calls = ref 0 in
@@ -4527,8 +5889,12 @@ let test_fail_open_local_only_preserves_explicit_local_only_base () =
       [ "ollama:qwen3.6:35b-a3b-mlx-bf16" ]
   in
   check int "probe not called" 0 !probe_calls;
-  check string "legacy local_only alias follows phase-buffer route"
-    KC.local_only_cascade_name cascade
+  check
+    string
+    "legacy local_only alias follows phase-buffer route"
+    KC.local_only_cascade_name
+    cascade
+;;
 
 let test_fail_open_local_only_preserves_healthy_local_only () =
   let cascade =
@@ -4538,48 +5904,48 @@ let test_fail_open_local_only_preserves_healthy_local_only () =
       ~effective_cascade:KC.local_only_cascade_name
       [ "ollama:qwen3.6:35b-a3b-mlx-bf16" ]
   in
-  check string "healthy ollama keeps phase-buffer route"
-    KC.local_only_cascade_name cascade
+  check
+    string
+    "healthy ollama keeps phase-buffer route"
+    KC.local_only_cascade_name
+    cascade
+;;
 
 (* PR-B: ollama saturation pre-skip helpers. *)
 
-let make_capacity_info ?(total = 1) ?(active = 0) ?(available = 1)
-    ?(queue = 0) () : Masc_mcp.Cascade_throttle.capacity_info =
-  {
-    total;
-    process_active = active;
-    process_available = available;
-    process_queue_length = queue;
-    source = Llm_provider.Provider_throttle.Discovered;
+let make_capacity_info ?(total = 1) ?(active = 0) ?(available = 1) ?(queue = 0) ()
+  : Masc_mcp.Cascade_throttle.capacity_info
+  =
+  { total
+  ; process_active = active
+  ; process_available = available
+  ; process_queue_length = queue
+  ; source = Llm_provider.Provider_throttle.Discovered
   }
+;;
 
 let test_resolve_shared_probeable_base_url_empty_returns_none () =
   match UT.resolve_shared_probeable_base_url [] with
   | None -> ()
   | Some _ -> fail "empty labels should not resolve to a shared host"
+;;
 
 let test_resolve_shared_probeable_base_url_single_label () =
   let label = "ollama:qwen3.6:35b-a3b-mlx-bf16" in
   let cfg = provider_config_of_label label in
-  match
-    UT.resolve_shared_probeable_base_url
-      ~can_probe:(fun _ -> true)
-      [ label ]
-  with
+  match UT.resolve_shared_probeable_base_url ~can_probe:(fun _ -> true) [ label ] with
   | Some url -> check string "single label base url" cfg.base_url url
   | None -> fail "single probeable label should resolve"
+;;
 
 let test_resolve_shared_probeable_base_url_requires_probe_registration () =
   (* Provider variant is irrelevant; what matters is whether the URL
      is recognised by the probe registry. *)
   let label = "ollama:qwen3.6:35b-a3b-mlx-bf16" in
-  match
-    UT.resolve_shared_probeable_base_url
-      ~can_probe:(fun _ -> false)
-      [ label ]
-  with
+  match UT.resolve_shared_probeable_base_url ~can_probe:(fun _ -> false) [ label ] with
   | None -> ()
   | Some _ -> fail "no probe registration must yield None"
+;;
 
 let test_resolve_shared_probeable_base_url_mixed_host () =
   match
@@ -4589,23 +5955,24 @@ let test_resolve_shared_probeable_base_url_mixed_host () =
   with
   | None -> ()
   | Some _ -> fail "mixed hosts must not collapse to a single base url"
+;;
 
 let test_resolve_shared_probeable_base_url_different_hosts () =
   let resolve_label = function
     | "ollama:a" ->
-        Some
-          (Llm_provider.Provider_config.make
-             ~kind:Llm_provider.Provider_config.Ollama
-             ~model_id:"a"
-             ~base_url:"http://127.0.0.1:11434"
-             ())
+      Some
+        (Llm_provider.Provider_config.make
+           ~kind:Llm_provider.Provider_config.Ollama
+           ~model_id:"a"
+           ~base_url:"http://127.0.0.1:11434"
+           ())
     | "ollama:b" ->
-        Some
-          (Llm_provider.Provider_config.make
-             ~kind:Llm_provider.Provider_config.Ollama
-             ~model_id:"b"
-             ~base_url:"http://10.0.0.5:11434"
-             ())
+      Some
+        (Llm_provider.Provider_config.make
+           ~kind:Llm_provider.Provider_config.Ollama
+           ~model_id:"b"
+           ~base_url:"http://10.0.0.5:11434"
+           ())
     | _ -> None
   in
   match
@@ -4616,39 +5983,57 @@ let test_resolve_shared_probeable_base_url_different_hosts () =
   with
   | None -> ()
   | Some _ -> fail "different hosts must not collapse"
+;;
 
 let test_is_base_url_saturated_returns_false_when_cache_missing () =
   let url = "http://127.0.0.1:11434" in
-  check bool "missing cache treated as healthy" false
+  check
+    bool
+    "missing cache treated as healthy"
+    false
     (UT.is_base_url_saturated ~capacity_lookup:(fun _ -> None) url)
+;;
 
 let test_is_base_url_saturated_returns_false_when_idle () =
   let url = "http://127.0.0.1:11434" in
   let info = make_capacity_info ~active:0 ~available:1 ~queue:0 () in
-  check bool "idle endpoint not saturated" false
-    (UT.is_base_url_saturated
-       ~capacity_lookup:(fun _ -> Some info) url)
+  check
+    bool
+    "idle endpoint not saturated"
+    false
+    (UT.is_base_url_saturated ~capacity_lookup:(fun _ -> Some info) url)
+;;
 
 let test_is_base_url_saturated_returns_true_when_full_with_queue () =
   let url = "http://127.0.0.1:11434" in
   let info = make_capacity_info ~active:1 ~available:0 ~queue:3 () in
-  check bool "full endpoint with queue is saturated" true
-    (UT.is_base_url_saturated
-       ~capacity_lookup:(fun _ -> Some info) url)
+  check
+    bool
+    "full endpoint with queue is saturated"
+    true
+    (UT.is_base_url_saturated ~capacity_lookup:(fun _ -> Some info) url)
+;;
 
 let test_is_base_url_saturated_ignores_zero_available_when_idle () =
   (* Defensive: discovery may report 0 available before any traffic.
      Without active or queued requests the keeper should still dispatch. *)
   let url = "http://127.0.0.1:11434" in
   let info = make_capacity_info ~active:0 ~available:0 ~queue:0 () in
-  check bool "idle endpoint with no slots is fail-open" false
-    (UT.is_base_url_saturated
-       ~capacity_lookup:(fun _ -> Some info) url)
+  check
+    bool
+    "idle endpoint with no slots is fail-open"
+    false
+    (UT.is_base_url_saturated ~capacity_lookup:(fun _ -> Some info) url)
+;;
 
 let test_saturation_skip_count_starts_at_zero () =
   UT.saturation_skip_count_clear_all ();
-  check int "fresh keeper has zero skip count" 0
+  check
+    int
+    "fresh keeper has zero skip count"
+    0
     (UT.saturation_skip_count_get ~keeper_name:"fresh_keeper")
+;;
 
 let test_saturation_skip_count_inc_returns_new_value () =
   UT.saturation_skip_count_clear_all ();
@@ -4658,8 +6043,8 @@ let test_saturation_skip_count_inc_returns_new_value () =
   check int "first inc returns 1" 1 n1;
   check int "second inc returns 2" 2 n2;
   check int "third inc returns 3" 3 n3;
-  check int "get matches last inc" 3
-    (UT.saturation_skip_count_get ~keeper_name:"k_inc")
+  check int "get matches last inc" 3 (UT.saturation_skip_count_get ~keeper_name:"k_inc")
+;;
 
 let test_saturation_skip_count_reset_zeros_one_keeper () =
   UT.saturation_skip_count_clear_all ();
@@ -4667,67 +6052,83 @@ let test_saturation_skip_count_reset_zeros_one_keeper () =
   let _ = UT.saturation_skip_count_inc ~keeper_name:"k_b" in
   let _ = UT.saturation_skip_count_inc ~keeper_name:"k_b" in
   UT.saturation_skip_count_reset ~keeper_name:"k_a";
-  check int "reset target zeroed" 0
-    (UT.saturation_skip_count_get ~keeper_name:"k_a");
-  check int "untouched keeper preserved" 2
+  check int "reset target zeroed" 0 (UT.saturation_skip_count_get ~keeper_name:"k_a");
+  check
+    int
+    "untouched keeper preserved"
+    2
     (UT.saturation_skip_count_get ~keeper_name:"k_b")
+;;
 
 let test_saturation_skip_cap_default_is_at_least_one () =
   (* The cap is floored at 1 even if the env var is set to 0 or
      negative — a cap of 0 would force-dispatch every cycle. *)
-  let prev = try Some (Sys.getenv "MASC_MAX_CONSECUTIVE_SATURATION_SKIPS")
-             with Not_found -> None in
+  let prev =
+    try Some (Sys.getenv "MASC_MAX_CONSECUTIVE_SATURATION_SKIPS") with
+    | Not_found -> None
+  in
   Unix.putenv "MASC_MAX_CONSECUTIVE_SATURATION_SKIPS" "0";
   let cap = UT.max_consecutive_saturation_skips () in
   (match prev with
    | Some v -> Unix.putenv "MASC_MAX_CONSECUTIVE_SATURATION_SKIPS" v
    | None -> Unix.putenv "MASC_MAX_CONSECUTIVE_SATURATION_SKIPS" "");
   check bool "cap floored at 1 even with env=0" true (cap >= 1)
+;;
 
 let wrapped_claude_limit_error () =
   Agent_sdk.Error.Api
     (NetworkError
-       {
-         message =
-           "claude exited with code 1: {\"type\":\"result\",\"subtype\":\"success\",\"is_error\":true,\"api_error_status\":429,\"result\":\"You've hit your limit · resets Apr 24 at 4am (Asia/Seoul)\"}";
-         kind = Llm_provider.Http_client.Unknown;
+       { message =
+           "claude exited with code 1: \
+            {\"type\":\"result\",\"subtype\":\"success\",\"is_error\":true,\"api_error_status\":429,\"result\":\"You've \
+            hit your limit · resets Apr 24 at 4am (Asia/Seoul)\"}"
+       ; kind = Llm_provider.Http_client.Unknown
        })
+;;
 
 let wrapped_claude_max_turns_message =
-  "claude exited with code 1: {\"type\":\"result\",\"subtype\":\"error_max_turns\",\"is_error\":true,\"stop_reason\":\"tool_use\",\"terminal_reason\":\"max_turns\",\"errors\":[\"Reached maximum number of turns (10)\"]}"
+  "claude exited with code 1: \
+   {\"type\":\"result\",\"subtype\":\"error_max_turns\",\"is_error\":true,\"stop_reason\":\"tool_use\",\"terminal_reason\":\"max_turns\",\"errors\":[\"Reached \
+   maximum number of turns (10)\"]}"
+;;
 
 let wrapped_claude_max_turns_error () =
   Agent_sdk.Error.Api
     (NetworkError
-       {
-         message = wrapped_claude_max_turns_message;
-         kind = Llm_provider.Http_client.Unknown;
+       { message = wrapped_claude_max_turns_message
+       ; kind = Llm_provider.Http_client.Unknown
        })
+;;
 
 let wrapped_cascade_max_turns_error () =
   Masc_mcp.Keeper_turn_driver.sdk_error_of_masc_internal_error
     (Masc_mcp.Keeper_turn_driver.Cascade_exhausted
-       {
-         cascade_name =
-           oas_error_cascade_name Masc_mcp.(Keeper_config.default_cascade_name ());
-         reason = Keeper_types.Other_detail wrapped_claude_max_turns_message;
+       { cascade_name =
+           oas_error_cascade_name Masc_mcp.(Keeper_config.default_cascade_name ())
+       ; reason = Keeper_types.Other_detail wrapped_claude_max_turns_message
        })
+;;
 
 let required_tool_contract_violation_error () =
   Agent_sdk.Error.Agent
     (CompletionContractViolation
-       {
-         contract = Agent_sdk.Completion_contract_id.Require_tool_use;
-         reason =
-           "required tool contract unsatisfied: tool_choice requested tool use, but the model returned no ToolUse block";
+       { contract = Agent_sdk.Completion_contract_id.Require_tool_use
+       ; reason =
+           "required tool contract unsatisfied: tool_choice requested tool use, but the \
+            model returned no ToolUse block"
        })
+;;
 
 let expect_degraded_retry label expected_cascade expected_reason = function
   | Some (retry : EC.degraded_retry) ->
-      check string (label ^ " cascade") expected_cascade retry.next_cascade;
-      check string (label ^ " reason") expected_reason
-        (EC.degraded_retry_reason_to_string retry.fallback_reason)
+    check string (label ^ " cascade") expected_cascade retry.next_cascade;
+    check
+      string
+      (label ^ " reason")
+      expected_reason
+      (EC.degraded_retry_reason_to_string retry.fallback_reason)
   | None -> fail (label ^ ": expected degraded retry")
+;;
 
 let test_degraded_retry_after_recoverable_error_uses_local_recovery_for_hard_quota () =
   let degraded_retry =
@@ -4736,25 +6137,35 @@ let test_degraded_retry_after_recoverable_error_uses_local_recovery_for_hard_quo
       ~tool_requirement:Masc_mcp.Keeper_agent_tool_surface.Optional
       (wrapped_claude_limit_error ())
   in
-  expect_degraded_retry "hard quota degraded retry"
-    KC.local_recovery_cascade_name "hard_quota" degraded_retry
+  expect_degraded_retry
+    "hard quota degraded retry"
+    KC.local_recovery_cascade_name
+    "hard_quota"
+    degraded_retry
+;;
 
-let test_degraded_retry_after_recoverable_error_uses_local_recovery_for_resumable_session () =
+let test_degraded_retry_after_recoverable_error_uses_local_recovery_for_resumable_session
+      ()
+  =
   let degraded_retry =
     EC.degraded_retry_after_recoverable_error
       ~effective_cascade:"underdog"
       ~tool_requirement:Masc_mcp.Keeper_agent_tool_surface.Optional
       (Masc_mcp.Keeper_turn_driver.sdk_error_of_masc_internal_error
          (Masc_mcp.Keeper_turn_driver.Resumable_cli_session
-            {
-              cascade_name = oas_error_cascade_name "kimi_cli_keeper";
-              detail =
-                "kimi exited with code 75: \nTo resume this session: kimi -r ff37febe-2adb-4ac6-9dc6-cae23e672fbc";
-              exit_code = Some 75;
+            { cascade_name = oas_error_cascade_name "kimi_cli_keeper"
+            ; detail =
+                "kimi exited with code 75: \n\
+                 To resume this session: kimi -r ff37febe-2adb-4ac6-9dc6-cae23e672fbc"
+            ; exit_code = Some 75
             }))
   in
-  expect_degraded_retry "resumable session degraded retry"
-    KC.local_recovery_cascade_name "resumable_cli_session" degraded_retry
+  expect_degraded_retry
+    "resumable session degraded retry"
+    KC.local_recovery_cascade_name
+    "resumable_cli_session"
+    degraded_retry
+;;
 
 let test_degraded_retry_after_recoverable_error_includes_admission_queue_timeout () =
   let degraded_retry =
@@ -4763,14 +6174,17 @@ let test_degraded_retry_after_recoverable_error_includes_admission_queue_timeout
       ~tool_requirement:Masc_mcp.Keeper_agent_tool_surface.Optional
       (Masc_mcp.Keeper_turn_driver.sdk_error_of_masc_internal_error
          (Masc_mcp.Keeper_turn_driver.Admission_queue_timeout
-            {
-              keeper_name = "nick0cave";
-              cascade_name = oas_error_cascade_name "big_three";
-              wait_sec = 90.0;
+            { keeper_name = "nick0cave"
+            ; cascade_name = oas_error_cascade_name "big_three"
+            ; wait_sec = 90.0
             }))
   in
-  expect_degraded_retry "admission queue timeout degraded retry"
-    KC.local_recovery_cascade_name "admission_queue_timeout" degraded_retry
+  expect_degraded_retry
+    "admission queue timeout degraded retry"
+    KC.local_recovery_cascade_name
+    "admission_queue_timeout"
+    degraded_retry
+;;
 
 let test_degraded_retry_after_recoverable_error_includes_turn_timeout () =
   let degraded_retry =
@@ -4780,8 +6194,12 @@ let test_degraded_retry_after_recoverable_error_includes_turn_timeout () =
       (Masc_mcp.Keeper_turn_driver.sdk_error_of_masc_internal_error
          (Masc_mcp.Keeper_turn_driver.Turn_timeout { elapsed_sec = 180.0 }))
   in
-  expect_degraded_retry "turn timeout degraded retry"
-    KC.local_recovery_cascade_name "turn_timeout" degraded_retry
+  expect_degraded_retry
+    "turn timeout degraded retry"
+    KC.local_recovery_cascade_name
+    "turn_timeout"
+    degraded_retry
+;;
 
 let test_degraded_retry_after_recoverable_error_includes_oas_timeout_budget () =
   let degraded_retry =
@@ -4790,18 +6208,21 @@ let test_degraded_retry_after_recoverable_error_includes_oas_timeout_budget () =
       ~tool_requirement:Masc_mcp.Keeper_agent_tool_surface.Optional
       (Masc_mcp.Keeper_turn_driver.sdk_error_of_masc_internal_error
          (Masc_mcp.Keeper_turn_driver.Oas_timeout_budget
-            {
-              budget_sec = 273.0;
-              keeper_turn_timeout_sec = 1200.0;
-              estimated_input_tokens = 2_000;
-              source = "adaptive_estimated_input_tokens";
-              remaining_turn_budget_sec = Some 600.0;
-              min_required_sec = 15.0;
-              phase = "test_phase";
+            { budget_sec = 273.0
+            ; keeper_turn_timeout_sec = 1200.0
+            ; estimated_input_tokens = 2_000
+            ; source = "adaptive_estimated_input_tokens"
+            ; remaining_turn_budget_sec = Some 600.0
+            ; min_required_sec = 15.0
+            ; phase = "test_phase"
             }))
   in
-  expect_degraded_retry "oas timeout budget degraded retry"
-    KC.local_recovery_cascade_name "oas_timeout_budget" degraded_retry
+  expect_degraded_retry
+    "oas timeout budget degraded retry"
+    KC.local_recovery_cascade_name
+    "oas_timeout_budget"
+    degraded_retry
+;;
 
 let test_degraded_retry_after_recoverable_error_includes_max_turns () =
   let degraded_retry =
@@ -4810,8 +6231,12 @@ let test_degraded_retry_after_recoverable_error_includes_max_turns () =
       ~tool_requirement:Masc_mcp.Keeper_agent_tool_surface.Optional
       (wrapped_cascade_max_turns_error ())
   in
-  expect_degraded_retry "max turns degraded retry"
-    KC.local_recovery_cascade_name "max_turns" degraded_retry
+  expect_degraded_retry
+    "max turns degraded retry"
+    KC.local_recovery_cascade_name
+    "max_turns"
+    degraded_retry
+;;
 
 let test_degraded_retry_after_recoverable_error_blocks_required_tools () =
   let degraded_retry =
@@ -4820,8 +6245,8 @@ let test_degraded_retry_after_recoverable_error_blocks_required_tools () =
       ~tool_requirement:Masc_mcp.Keeper_agent_tool_surface.Required
       (wrapped_claude_limit_error ())
   in
-  check bool "required tool turn stays terminal" true
-    (Option.is_none degraded_retry)
+  check bool "required tool turn stays terminal" true (Option.is_none degraded_retry)
+;;
 
 let test_degraded_retry_after_recoverable_error_does_not_broaden_local_only () =
   let degraded_retry =
@@ -4830,8 +6255,8 @@ let test_degraded_retry_after_recoverable_error_does_not_broaden_local_only () =
       ~tool_requirement:Masc_mcp.Keeper_agent_tool_surface.Optional
       (wrapped_claude_limit_error ())
   in
-  check bool "local_only does not broaden further" true
-    (Option.is_none degraded_retry)
+  check bool "local_only does not broaden further" true (Option.is_none degraded_retry)
+;;
 
 let test_degraded_retry_after_recoverable_error_does_not_broaden_local_recovery () =
   let degraded_retry =
@@ -4840,8 +6265,12 @@ let test_degraded_retry_after_recoverable_error_does_not_broaden_local_recovery 
       ~tool_requirement:Masc_mcp.Keeper_agent_tool_surface.Optional
       (wrapped_claude_limit_error ())
   in
-  check bool "local_recovery does not broaden further" true
+  check
+    bool
+    "local_recovery does not broaden further"
+    true
     (Option.is_none degraded_retry)
+;;
 
 let test_fallback_cascade_for_unavailable_profile_prefers_default () =
   let fallback =
@@ -4849,8 +6278,12 @@ let test_fallback_cascade_for_unavailable_profile_prefers_default () =
       ~base_cascade:"tool_rerank"
       ~effective_cascade:"tool_rerank"
   in
-  check (option string) "non-default cascade fallback target is default"
-    (Some (KC.default_cascade_name ())) fallback
+  check
+    (option string)
+    "non-default cascade fallback target is default"
+    (Some (KC.default_cascade_name ()))
+    fallback
+;;
 
 let test_fallback_cascade_for_unavailable_profile_prefers_base_after_phase_override () =
   let fallback =
@@ -4858,8 +6291,12 @@ let test_fallback_cascade_for_unavailable_profile_prefers_base_after_phase_overr
       ~base_cascade:"tool_rerank"
       ~effective_cascade:KC.local_recovery_cascade_name
   in
-  check (option string) "phase override fallback target is base cascade"
-    (Some "tool_rerank") fallback
+  check
+    (option string)
+    "phase override fallback target is base cascade"
+    (Some "tool_rerank")
+    fallback
+;;
 
 let test_next_fail_open_cascade_for_turn_returns_untried_default_cascade () =
   let degraded_retry =
@@ -4870,8 +6307,12 @@ let test_next_fail_open_cascade_for_turn_returns_untried_default_cascade () =
       ~attempted_cascades:[ "tool_rerank" ]
       (wrapped_claude_limit_error ())
   in
-  expect_degraded_retry "next degraded retry"
-    (KC.default_cascade_name ()) "hard_quota" degraded_retry
+  expect_degraded_retry
+    "next degraded retry"
+    (KC.default_cascade_name ())
+    "hard_quota"
+    degraded_retry
+;;
 
 let test_next_fail_open_cascade_for_turn_continues_to_local_recovery () =
   let degraded_retry =
@@ -4879,12 +6320,15 @@ let test_next_fail_open_cascade_for_turn_continues_to_local_recovery () =
       ~base_cascade:"tool_rerank"
       ~effective_cascade:"tool_rerank"
       ~tool_requirement:Masc_mcp.Keeper_agent_tool_surface.Optional
-      ~attempted_cascades:
-        [ "tool_rerank"; (KC.default_cascade_name ()) ]
+      ~attempted_cascades:[ "tool_rerank"; KC.default_cascade_name () ]
       (wrapped_claude_limit_error ())
   in
-  check bool "collapsed local_recovery is exhausted after default" true
+  check
+    bool
+    "collapsed local_recovery is exhausted after default"
+    true
     (Option.is_none degraded_retry)
+;;
 
 let test_next_fail_open_cascade_for_turn_suppresses_exhausted_rotation_group () =
   let degraded_retry =
@@ -4893,15 +6337,11 @@ let test_next_fail_open_cascade_for_turn_suppresses_exhausted_rotation_group () 
       ~effective_cascade:"tool_rerank"
       ~tool_requirement:Masc_mcp.Keeper_agent_tool_surface.Optional
       ~attempted_cascades:
-        [
-          "tool_rerank";
-          (KC.default_cascade_name ());
-          KC.local_recovery_cascade_name;
-        ]
+        [ "tool_rerank"; KC.default_cascade_name (); KC.local_recovery_cascade_name ]
       (wrapped_claude_limit_error ())
   in
-  check bool "exhausted rotation group suppressed" true
-    (Option.is_none degraded_retry)
+  check bool "exhausted rotation group suppressed" true (Option.is_none degraded_retry)
+;;
 
 let test_next_fail_open_cascade_for_required_tool_uses_default_not_strict () =
   let degraded_retry =
@@ -4912,8 +6352,12 @@ let test_next_fail_open_cascade_for_required_tool_uses_default_not_strict () =
       ~attempted_cascades:[ "tool_rerank" ]
       (wrapped_claude_limit_error ())
   in
-  expect_degraded_retry "required tool degraded retry skips strict injection"
-    (KC.default_cascade_name ()) "hard_quota" degraded_retry
+  expect_degraded_retry
+    "required tool degraded retry skips strict injection"
+    (KC.default_cascade_name ())
+    "hard_quota"
+    degraded_retry
+;;
 
 let test_next_fail_open_cascade_for_turn_allows_required_tool_rotation () =
   let degraded_retry =
@@ -4924,8 +6368,12 @@ let test_next_fail_open_cascade_for_turn_allows_required_tool_rotation () =
       ~attempted_cascades:[ "strict_exec" ]
       (wrapped_claude_limit_error ())
   in
-  expect_degraded_retry "required tool degraded retry"
-    "tool_rerank" "hard_quota" degraded_retry
+  expect_degraded_retry
+    "required tool degraded retry"
+    "tool_rerank"
+    "hard_quota"
+    degraded_retry
+;;
 
 let test_next_fail_open_cascade_for_turn_retries_required_tool_contract_violation () =
   let degraded_retry =
@@ -4936,31 +6384,27 @@ let test_next_fail_open_cascade_for_turn_retries_required_tool_contract_violatio
       ~attempted_cascades:[ "strict_exec" ]
       (required_tool_contract_violation_error ())
   in
-  expect_degraded_retry "required contract degraded retry"
-    (KC.default_cascade_name ()) "required_tool_contract_violation" degraded_retry
+  expect_degraded_retry
+    "required contract degraded retry"
+    (KC.default_cascade_name ())
+    "required_tool_contract_violation"
+    degraded_retry
+;;
 
 let test_next_fail_open_cascade_for_turn_uses_catalog_rotation_profile () =
   let degraded_retry =
     UT.next_fail_open_cascade_for_turn
       ~rotation_cascades:
-        [
-          (KC.default_cascade_name ());
-          KC.local_recovery_cascade_name;
-          "ollama_only";
-        ]
+        [ KC.default_cascade_name (); KC.local_recovery_cascade_name; "ollama_only" ]
       ~base_cascade:"tool_rerank"
       ~effective_cascade:"tool_rerank"
       ~tool_requirement:Masc_mcp.Keeper_agent_tool_surface.Optional
       ~attempted_cascades:
-        [
-          "tool_rerank";
-          (KC.default_cascade_name ());
-          KC.local_recovery_cascade_name;
-        ]
+        [ "tool_rerank"; KC.default_cascade_name (); KC.local_recovery_cascade_name ]
       (wrapped_claude_limit_error ())
   in
-  expect_degraded_retry "catalog degraded retry"
-    "ollama_only" "hard_quota" degraded_retry
+  expect_degraded_retry "catalog degraded retry" "ollama_only" "hard_quota" degraded_retry
+;;
 
 let test_next_fail_open_cascade_for_turn_does_not_inject_default_when_catalog_omits_it () =
   let degraded_retry =
@@ -4972,8 +6416,12 @@ let test_next_fail_open_cascade_for_turn_does_not_inject_default_when_catalog_om
       ~attempted_cascades:[ "tool_rerank" ]
       (wrapped_claude_limit_error ())
   in
-  expect_degraded_retry "catalog-only degraded retry"
-    "resilient_profile" "hard_quota" degraded_retry
+  expect_degraded_retry
+    "catalog-only degraded retry"
+    "resilient_profile"
+    "hard_quota"
+    degraded_retry
+;;
 
 let test_next_fail_open_cascade_for_required_tool_filters_local_recovery_catalog () =
   let degraded_retry =
@@ -4985,8 +6433,12 @@ let test_next_fail_open_cascade_for_required_tool_filters_local_recovery_catalog
       ~attempted_cascades:[ "strict_exec" ]
       (required_tool_contract_violation_error ())
   in
-  expect_degraded_retry "required catalog degraded retry"
-    (KC.default_cascade_name ()) "required_tool_contract_violation" degraded_retry
+  expect_degraded_retry
+    "required catalog degraded retry"
+    (KC.default_cascade_name ())
+    "required_tool_contract_violation"
+    degraded_retry
+;;
 
 let test_next_fail_open_cascade_for_required_tool_rejects_local_recovery_only_catalog () =
   let degraded_retry =
@@ -4998,8 +6450,12 @@ let test_next_fail_open_cascade_for_required_tool_rejects_local_recovery_only_ca
       ~attempted_cascades:[ "strict_exec" ]
       (required_tool_contract_violation_error ())
   in
-  expect_degraded_retry "required catalog default-backed recovery"
-    (KC.default_cascade_name ()) "required_tool_contract_violation" degraded_retry
+  expect_degraded_retry
+    "required catalog default-backed recovery"
+    (KC.default_cascade_name ())
+    "required_tool_contract_violation"
+    degraded_retry
+;;
 
 let test_degraded_rotation_after_recoverable_error_filters_required_catalog_directly () =
   let degraded_retry =
@@ -5011,11 +6467,14 @@ let test_degraded_rotation_after_recoverable_error_filters_required_catalog_dire
       ~attempted_cascades:[ "strict_exec" ]
       (required_tool_contract_violation_error ())
   in
-  expect_degraded_retry "required catalog classifier rotation"
-    "big_three" "required_tool_contract_violation" degraded_retry
+  expect_degraded_retry
+    "required catalog classifier rotation"
+    "big_three"
+    "required_tool_contract_violation"
+    degraded_retry
+;;
 
-let test_degraded_rotation_preserves_local_recovery_profile_hint_for_required_tool
-    () =
+let test_degraded_rotation_preserves_local_recovery_profile_hint_for_required_tool () =
   let degraded_retry =
     EC.degraded_rotation_after_recoverable_error
       ~rotation_cascades:[ "big_three"; "local_recovery" ]
@@ -5026,8 +6485,12 @@ let test_degraded_rotation_preserves_local_recovery_profile_hint_for_required_to
       ~attempted_cascades:[ "tier_fast"; "keeper_bound_safe"; "big_three" ]
       (required_tool_contract_violation_error ())
   in
-  expect_degraded_retry "required local_recovery fallback profile"
-    "local_recovery" "required_tool_contract_violation" degraded_retry
+  expect_degraded_retry
+    "required local_recovery fallback profile"
+    "local_recovery"
+    "required_tool_contract_violation"
+    degraded_retry
+;;
 
 let test_degraded_rotation_after_recoverable_error_normalizes_catalog_directly () =
   let degraded_retry =
@@ -5039,8 +6502,12 @@ let test_degraded_rotation_after_recoverable_error_normalizes_catalog_directly (
       ~attempted_cascades:[ "tool_rerank" ]
       (wrapped_claude_limit_error ())
   in
-  expect_degraded_retry "normalized catalog classifier rotation"
-    "catalog_next" "hard_quota" degraded_retry
+  expect_degraded_retry
+    "normalized catalog classifier rotation"
+    "catalog_next"
+    "hard_quota"
+    degraded_retry
+;;
 
 let test_degraded_rotation_prefers_fallback_hint_over_catalog () =
   let degraded_retry =
@@ -5053,8 +6520,12 @@ let test_degraded_rotation_prefers_fallback_hint_over_catalog () =
       ~attempted_cascades:[ "ollama_only" ]
       (wrapped_claude_limit_error ())
   in
-  expect_degraded_retry "fallback_hint takes priority"
-    "local_with_kimi_coding_with_glm" "hard_quota" degraded_retry
+  expect_degraded_retry
+    "fallback_hint takes priority"
+    "local_with_kimi_coding_with_glm"
+    "hard_quota"
+    degraded_retry
+;;
 
 let test_degraded_rotation_skips_already_attempted_fallback_hint () =
   let degraded_retry =
@@ -5064,12 +6535,15 @@ let test_degraded_rotation_skips_already_attempted_fallback_hint () =
       ~base_cascade:"ollama_only"
       ~effective_cascade:"ollama_only"
       ~tool_requirement:Masc_mcp.Keeper_agent_tool_surface.Optional
-      ~attempted_cascades:
-        [ "ollama_only"; "local_with_kimi_coding_with_glm" ]
+      ~attempted_cascades:[ "ollama_only"; "local_with_kimi_coding_with_glm" ]
       (wrapped_claude_limit_error ())
   in
-  expect_degraded_retry "exhausted hint falls through to catalog"
-    KC.local_recovery_cascade_name "hard_quota" degraded_retry
+  expect_degraded_retry
+    "exhausted hint falls through to catalog"
+    KC.local_recovery_cascade_name
+    "hard_quota"
+    degraded_retry
+;;
 
 let test_degraded_rotation_ignores_blank_fallback_hint () =
   let degraded_retry =
@@ -5082,55 +6556,53 @@ let test_degraded_rotation_ignores_blank_fallback_hint () =
       ~attempted_cascades:[ "ollama_only" ]
       (wrapped_claude_limit_error ())
   in
-  expect_degraded_retry "blank hint behaves like no hint"
-    KC.local_recovery_cascade_name "hard_quota" degraded_retry
+  expect_degraded_retry
+    "blank hint behaves like no hint"
+    KC.local_recovery_cascade_name
+    "hard_quota"
+    degraded_retry
+;;
 
 let test_fail_open_rotation_cascades_from_catalog_merges_reserved_and_assignable () =
   let rotation =
     UT.fail_open_rotation_cascades_from_catalog
       ~catalog_names:
-        [
-          (KC.default_cascade_name ());
-          KC.local_recovery_cascade_name;
-          "ollama_only";
-        ]
-      ~keeper_assignable:[ (KC.default_cascade_name ()); "ollama_only" ]
+        [ KC.default_cascade_name (); KC.local_recovery_cascade_name; "ollama_only" ]
+      ~keeper_assignable:[ KC.default_cascade_name (); "ollama_only" ]
   in
-  check (option (list string)) "catalog-derived rotation order"
-    (Some
-       [
-         (KC.default_cascade_name ());
-         "ollama_only";
-       ])
+  check
+    (option (list string))
+    "catalog-derived rotation order"
+    (Some [ KC.default_cascade_name (); "ollama_only" ])
     rotation
+;;
 
 let test_fail_open_rotation_cascades_from_catalog_preserves_catalog_order () =
   let rotation =
     UT.fail_open_rotation_cascades_from_catalog
       ~catalog_names:
-        [
-          "ollama_only";
-          KC.local_recovery_cascade_name;
-          (KC.default_cascade_name ());
-        ]
-      ~keeper_assignable:[ (KC.default_cascade_name ()); "ollama_only" ]
+        [ "ollama_only"; KC.local_recovery_cascade_name; KC.default_cascade_name () ]
+      ~keeper_assignable:[ KC.default_cascade_name (); "ollama_only" ]
   in
-  check (option (list string)) "catalog-derived rotation preserves catalog order"
-    (Some
-       [
-         "ollama_only";
-         (KC.default_cascade_name ());
-       ])
+  check
+    (option (list string))
+    "catalog-derived rotation preserves catalog order"
+    (Some [ "ollama_only"; KC.default_cascade_name () ])
     rotation
+;;
 
 let test_fail_open_rotation_cascades_from_catalog_empty_when_unresolved () =
   let rotation =
     UT.fail_open_rotation_cascades_from_catalog
       ~catalog_names:[]
-      ~keeper_assignable:[ (KC.default_cascade_name ()) ]
+      ~keeper_assignable:[ KC.default_cascade_name () ]
   in
-  check (option (list string)) "unresolved catalog falls back to legacy path"
-    None rotation
+  check
+    (option (list string))
+    "unresolved catalog falls back to legacy path"
+    None
+    rotation
+;;
 
 let test_fail_open_rotation_cascades_from_catalog_empty_without_assignable_candidates () =
   let rotation =
@@ -5138,86 +6610,115 @@ let test_fail_open_rotation_cascades_from_catalog_empty_without_assignable_candi
       ~catalog_names:[ "experimental_only" ]
       ~keeper_assignable:[]
   in
-  check (option (list string)) "resolved catalog without assignable candidates"
-    None rotation
+  check
+    (option (list string))
+    "resolved catalog without assignable candidates"
+    None
+    rotation
+;;
 
 (* context_overflow_limit is now in OAS as Retry.extract_context_limit.
    These tests verify the OAS SSOT API is accessible from MASC. *)
 let test_context_overflow_limit_parses_common_oas_errors () =
-  check (option int) "available context size extracted" (Some 159671)
+  check
+    (option int)
+    "available context size extracted"
+    (Some 159671)
     (Agent_sdk.Retry.extract_context_limit
-       "OpenAI returned 400: This model's maximum context length is 128000 tokens. However, your messages resulted in 193217 tokens. available context size (159671)");
-  check (option int) "input budget exceeded extracted" (Some 8192)
+       "OpenAI returned 400: This model's maximum context length is 128000 tokens. \
+        However, your messages resulted in 193217 tokens. available context size \
+        (159671)");
+  check
+    (option int)
+    "input budget exceeded extracted"
+    (Some 8192)
     (Agent_sdk.Retry.extract_context_limit
        "Agent run failed: Input token budget exceeded:\n  10847/8192");
-  check (option int) "non-overflow message" None
-    (Agent_sdk.Retry.extract_context_limit
-       "HTTP error: 503 Service Unavailable")
+  check
+    (option int)
+    "non-overflow message"
+    None
+    (Agent_sdk.Retry.extract_context_limit "HTTP error: 503 Service Unavailable")
+;;
 
 let test_is_context_overflow_only_for_overflow_errors () =
-  check bool "ContextOverflow matches" true
+  check
+    bool
+    "ContextOverflow matches"
+    true
     (EC.is_context_overflow
        (Agent_sdk.Error.Api (ContextOverflow { message = "exceeded"; limit = Some 32768 })));
-  check bool "ContextOverflow without limit" true
+  check
+    bool
+    "ContextOverflow without limit"
+    true
     (EC.is_context_overflow
        (Agent_sdk.Error.Api (ContextOverflow { message = "exceeded"; limit = None })));
-  check bool "NetworkError does not match" false
+  check
+    bool
+    "NetworkError does not match"
+    false
     (EC.is_context_overflow
        (Agent_sdk.Error.Api
           (NetworkError
-             {
-               message = "Connection_reset";
-               kind = Llm_provider.Http_client.Connection_refused;
+             { message = "Connection_reset"
+             ; kind = Llm_provider.Http_client.Connection_refused
              })));
-  check bool "Internal does not match" false
+  check
+    bool
+    "Internal does not match"
+    false
+    (EC.is_context_overflow (Agent_sdk.Error.Internal "some error"));
+  check
+    bool
+    "TokenBudgetExceeded Input matches"
+    true
     (EC.is_context_overflow
-       (Agent_sdk.Error.Internal "some error"));
-  check bool "TokenBudgetExceeded Input matches" true
+       (Agent_sdk.Error.Agent
+          (TokenBudgetExceeded { kind = "Input"; used = 204917; limit = 200000 })));
+  check
+    bool
+    "TokenBudgetExceeded Total does not match"
+    false
     (EC.is_context_overflow
-       (Agent_sdk.Error.Agent (TokenBudgetExceeded { kind = "Input"; used = 204917; limit = 200000 })));
-  check bool "TokenBudgetExceeded Total does not match" false
-    (EC.is_context_overflow
-       (Agent_sdk.Error.Agent (TokenBudgetExceeded { kind = "Total"; used = 300000; limit = 250000 })))
+       (Agent_sdk.Error.Agent
+          (TokenBudgetExceeded { kind = "Total"; used = 300000; limit = 250000 })))
+;;
 
 let test_summarize_turn_event_bus_extracts_overflow_signal () =
   let events =
-    [
-      Agent_sdk.Event_bus.mk_event
+    [ Agent_sdk.Event_bus.mk_event
         ~correlation_id:"cid-123"
         ~run_id:"run-1"
-        (Agent_sdk.Event_bus.TurnStarted
-           { agent_name = minimal_meta.name; turn = 1 });
-      Agent_sdk.Event_bus.mk_event
+        (Agent_sdk.Event_bus.TurnStarted { agent_name = minimal_meta.name; turn = 1 })
+    ; Agent_sdk.Event_bus.mk_event
         ~correlation_id:"cid-123"
         ~run_id:"run-1"
         (Agent_sdk.Event_bus.ContextOverflowImminent
-           {
-             agent_name = minimal_meta.name;
-             estimated_tokens = 205_000;
-             limit_tokens = 200_000;
-             ratio = 1.025;
-           });
+           { agent_name = minimal_meta.name
+           ; estimated_tokens = 205_000
+           ; limit_tokens = 200_000
+           ; ratio = 1.025
+           })
     ]
   in
   let summary = UT.summarize_turn_event_bus events in
-  check (option string) "correlation id from first event" (Some "cid-123")
+  check
+    (option string)
+    "correlation id from first event"
+    (Some "cid-123")
     summary.correlation_id;
   match summary.overflow_imminent with
   | Some overflow ->
-      check int "estimated tokens" 205_000 overflow.estimated_tokens;
-      check int "limit tokens" 200_000 overflow.limit_tokens
+    check int "estimated tokens" 205_000 overflow.estimated_tokens;
+    check int "limit tokens" 200_000 overflow.limit_tokens
   | None -> fail "expected overflow_imminent summary"
+;;
 
 let test_context_overflow_event_prefers_event_bus_signal () =
   let turn_event_bus : UT.turn_event_bus_summary =
-    {
-      correlation_id = Some "cid-123";
-      overflow_imminent =
-        Some
-          {
-            estimated_tokens = 205_000;
-            limit_tokens = 200_000;
-          };
+    { correlation_id = Some "cid-123"
+    ; overflow_imminent = Some { estimated_tokens = 205_000; limit_tokens = 200_000 }
     }
   in
   match
@@ -5228,17 +6729,11 @@ let test_context_overflow_event_prefers_event_bus_signal () =
          (ContextOverflow { message = "prompt exceeds context"; limit = Some 32_768 }))
   with
   | KP.Context_overflow_detected
-      {
-        source = `Oas_signal;
-        token_count;
-        limit_tokens = Some limit_tokens;
-      } ->
-      check int "estimated tokens win" 205_000 token_count;
-      check int "event bus limit wins" 200_000 limit_tokens
-  | event ->
-      fail
-        ("expected oas_signal overflow event, got "
-        ^ KP.event_to_string event)
+      { source = `Oas_signal; token_count; limit_tokens = Some limit_tokens } ->
+    check int "estimated tokens win" 205_000 token_count;
+    check int "event bus limit wins" 200_000 limit_tokens
+  | event -> fail ("expected oas_signal overflow event, got " ^ KP.event_to_string event)
+;;
 
 let test_context_overflow_event_falls_back_without_event_bus_signal () =
   match
@@ -5248,119 +6743,172 @@ let test_context_overflow_event_falls_back_without_event_bus_signal () =
          (ContextOverflow { message = "prompt exceeds context"; limit = Some 32_768 }))
   with
   | KP.Context_overflow_detected
-      {
-        source = `Prompt_rejected;
-        token_count;
-        limit_tokens = Some limit_tokens;
-      } ->
-      check int "fallback uses error limit" 32_768 token_count;
-      check int "fallback preserves limit" 32_768 limit_tokens
+      { source = `Prompt_rejected; token_count; limit_tokens = Some limit_tokens } ->
+    check int "fallback uses error limit" 32_768 token_count;
+    check int "fallback preserves limit" 32_768 limit_tokens
   | event ->
-      fail
-        ("expected prompt_rejected overflow event, got "
-        ^ KP.event_to_string event)
+    fail ("expected prompt_rejected overflow event, got " ^ KP.event_to_string event)
+;;
 
 let test_metrics_persist_social_state_fields () =
   let result =
     make_run_result
       ~text:
-        "SOCIAL_MODEL: bdi_speech_v1\nBELIEF_SUMMARY: quiet_room\nACTIVE_DESIRE: maintain_quiet_readiness\nCURRENT_INTENTION: stay_available_without_noise\nBLOCKER: none\nNEED: none\nSPEECH_ACT: stay_silent\nDELIVERY_SURFACE: silent"
+        "SOCIAL_MODEL: bdi_speech_v1\n\
+         BELIEF_SUMMARY: quiet_room\n\
+         ACTIVE_DESIRE: maintain_quiet_readiness\n\
+         CURRENT_INTENTION: stay_available_without_noise\n\
+         BLOCKER: none\n\
+         NEED: none\n\
+         SPEECH_ACT: stay_silent\n\
+         DELIVERY_SURFACE: silent"
       ~tools:[]
-      ~model:"test-model" ~input_tok:50 ~output_tok:10 ()
+      ~model:"test-model"
+      ~input_tok:50
+      ~output_tok:10
+      ()
   in
   let base_dir = temp_dir () in
   Fun.protect
     ~finally:(fun () -> cleanup_dir base_dir)
     (fun () ->
-      let routed, social_state, transition_reason =
-        KSM.apply_to_result ~meta:minimal_meta
-          ~observation:base_observation ~previous_state:None result
-      in
-      let updated =
-        UM.update_metrics_from_result minimal_meta ~latency_ms:100
-          ~observation:base_observation ~social_state
-          ~social_transition_reason:
-            (KSM.transition_reason_to_string transition_reason)
-          routed
-      in
-      check string "active desire tracked" "maintain_quiet_readiness"
-        updated.runtime.last_active_desire;
-      check string "current intention tracked" "stay_available_without_noise"
-        updated.runtime.last_current_intention;
-      check string "speech act tracked" "stay_silent"
-        updated.runtime.last_speech_act;
-      check string "transition reason tracked" "headers:explicit_social_headers"
-        updated.runtime.last_social_transition_reason;
-      check bool "no blocker tracked" true (Option.is_none updated.runtime.last_blocker);
-      check string "no need tracked" "" updated.runtime.last_need)
+       let routed, social_state, transition_reason =
+         KSM.apply_to_result
+           ~meta:minimal_meta
+           ~observation:base_observation
+           ~previous_state:None
+           result
+       in
+       let updated =
+         UM.update_metrics_from_result
+           minimal_meta
+           ~latency_ms:100
+           ~observation:base_observation
+           ~social_state
+           ~social_transition_reason:(KSM.transition_reason_to_string transition_reason)
+           routed
+       in
+       check
+         string
+         "active desire tracked"
+         "maintain_quiet_readiness"
+         updated.runtime.last_active_desire;
+       check
+         string
+         "current intention tracked"
+         "stay_available_without_noise"
+         updated.runtime.last_current_intention;
+       check string "speech act tracked" "stay_silent" updated.runtime.last_speech_act;
+       check
+         string
+         "transition reason tracked"
+         "headers:explicit_social_headers"
+         updated.runtime.last_social_transition_reason;
+       check bool "no blocker tracked" true (Option.is_none updated.runtime.last_blocker);
+       check string "no need tracked" "" updated.runtime.last_need)
+;;
 
 let test_metrics_failure_response () =
   let reason = "Agent run failed: Max turns exceeded (turn 10, limit 10)" in
   let updated =
-    UM.update_metrics_from_failure minimal_meta ~latency_ms:250
-      ~observation:base_observation ~reason
-      ~social_transition_reason:"failure:run_error" ()
+    UM.update_metrics_from_failure
+      minimal_meta
+      ~latency_ms:250
+      ~observation:base_observation
+      ~reason
+      ~social_transition_reason:"failure:run_error"
+      ()
   in
-  check int "total_turns +1" (minimal_meta.runtime.usage.total_turns + 1) updated.runtime.usage.total_turns;
+  check
+    int
+    "total_turns +1"
+    (minimal_meta.runtime.usage.total_turns + 1)
+    updated.runtime.usage.total_turns;
   check int "latency recorded" 250 updated.runtime.usage.last_latency_ms;
   check bool "last_turn_ts updated" true (updated.runtime.usage.last_turn_ts > 0.0);
-  check int "proactive count +1" (minimal_meta.runtime.proactive_rt.count_total + 1)
+  check
+    int
+    "proactive count +1"
+    (minimal_meta.runtime.proactive_rt.count_total + 1)
     updated.runtime.proactive_rt.count_total;
-  check bool "proactive outcome error" true
-    (updated.runtime.proactive_rt.last_outcome
-     = Masc_mcp.Keeper_types.Proactive_error);
-  check bool "failure reason tagged" true
+  check
+    bool
+    "proactive outcome error"
+    true
+    (updated.runtime.proactive_rt.last_outcome = Masc_mcp.Keeper_types.Proactive_error);
+  check
+    bool
+    "failure reason tagged"
+    true
     (let found =
        try
          ignore
            (Str.search_forward
               (Str.regexp_string "unified:error:")
-              updated.runtime.proactive_rt.last_reason 0);
+              updated.runtime.proactive_rt.last_reason
+              0);
          true
-       with Not_found -> false
+       with
+       | Not_found -> false
      in
      found);
-  check bool "failure preview preserved" true
+  check
+    bool
+    "failure preview preserved"
+    true
     (let found =
        try
          ignore
            (Str.search_forward
               (Str.regexp_string "Max turns exceeded")
-              updated.runtime.proactive_rt.last_preview 0);
+              updated.runtime.proactive_rt.last_preview
+              0);
          true
-       with Not_found -> false
+       with
+       | Not_found -> false
      in
      found);
-  check string "failure transition reason tracked" "failure:run_error"
+  check
+    string
+    "failure transition reason tracked"
+    "failure:run_error"
     updated.runtime.last_social_transition_reason
+;;
 
 let test_metrics_failure_timeout_increments_proactive_backoff () =
   let sdk_error =
     Masc_mcp.Keeper_turn_driver.sdk_error_of_masc_internal_error
       (Masc_mcp.Keeper_turn_driver.Oas_timeout_budget
-         {
-           budget_sec = 90.0;
-           keeper_turn_timeout_sec = 90.0;
-           estimated_input_tokens = 42_000;
-           source = "test";
-           remaining_turn_budget_sec = Some 0.0;
-           min_required_sec = 15.0;
-           phase = "test_phase";
+         { budget_sec = 90.0
+         ; keeper_turn_timeout_sec = 90.0
+         ; estimated_input_tokens = 42_000
+         ; source = "test"
+         ; remaining_turn_budget_sec = Some 0.0
+         ; min_required_sec = 15.0
+         ; phase = "test_phase"
          })
   in
   let updated =
-    UM.update_metrics_from_failure minimal_meta ~latency_ms:90
+    UM.update_metrics_from_failure
+      minimal_meta
+      ~latency_ms:90
       ~observation:base_observation
-      ~reason:"OAS budget timeout after 90s" ~sdk_error
-      ~social_transition_reason:"failure:run_error" ()
+      ~reason:"OAS budget timeout after 90s"
+      ~sdk_error
+      ~social_transition_reason:"failure:run_error"
+      ()
   in
-  check int "proactive timeout backoff count +1"
+  check
+    int
+    "proactive timeout backoff count +1"
     (minimal_meta.runtime.proactive_rt.consecutive_noop_count + 1)
     updated.runtime.proactive_rt.consecutive_noop_count
+;;
 
 let test_metrics_failure_response_redacts_resumable_cli_session_detail () =
   let raw_reason =
-    "kimi exited with code 75: \nTo resume this session: kimi -r ff37febe-2adb-4ac6-9dc6-cae23e672fbc"
+    "kimi exited with code 75: \n\
+     To resume this session: kimi -r ff37febe-2adb-4ac6-9dc6-cae23e672fbc"
   in
   let canonical_detail =
     Masc_mcp.Cascade_runner.Kimi_cli_transport_local.resumable_session_detail
@@ -5368,21 +6916,29 @@ let test_metrics_failure_response_redacts_resumable_cli_session_detail () =
   let sdk_error =
     Masc_mcp.Keeper_turn_driver.sdk_error_of_masc_internal_error
       (Masc_mcp.Keeper_turn_driver.Resumable_cli_session
-         {
-           cascade_name = oas_error_cascade_name "kimi_cli_keeper";
-           detail = canonical_detail;
-           exit_code = Some 75;
+         { cascade_name = oas_error_cascade_name "kimi_cli_keeper"
+         ; detail = canonical_detail
+         ; exit_code = Some 75
          })
   in
   let updated =
-    UM.update_metrics_from_failure minimal_meta ~latency_ms:250
-      ~observation:base_observation ~reason:raw_reason ~sdk_error
-      ~social_transition_reason:"failure:run_error" ()
+    UM.update_metrics_from_failure
+      minimal_meta
+      ~latency_ms:250
+      ~observation:base_observation
+      ~reason:raw_reason
+      ~sdk_error
+      ~social_transition_reason:"failure:run_error"
+      ()
   in
-  check string "last reason is redacted"
+  check
+    string
+    "last reason is redacted"
     ("unified:error:" ^ canonical_detail)
     updated.runtime.proactive_rt.last_reason;
-  check string "last preview is redacted"
+  check
+    string
+    "last preview is redacted"
     canonical_detail
     updated.runtime.proactive_rt.last_preview;
   let blocker_detail =
@@ -5391,42 +6947,64 @@ let test_metrics_failure_response_redacts_resumable_cli_session_detail () =
     | None -> ""
   in
   check string "last blocker is redacted" canonical_detail blocker_detail;
-  check bool "raw resume hint removed from last blocker" false
+  check
+    bool
+    "raw resume hint removed from last blocker"
+    false
     (contains_substring blocker_detail "To resume this session:");
-  check bool "raw session token removed from last reason" false
+  check
+    bool
+    "raw session token removed from last reason"
+    false
     (contains_substring updated.runtime.proactive_rt.last_reason "kimi -r");
   match updated.runtime.last_blocker with
   | Some { klass = Keeper_types.Cascade_exhausted (Keeper_types.Other_detail detail); _ }
     ->
-      check string "blocker class detail preserved as canonical detail"
-        canonical_detail detail
+    check
+      string
+      "blocker class detail preserved as canonical detail"
+      canonical_detail
+      detail
   | _ -> fail "expected resumable CLI session blocker class"
+;;
 
 let test_prompt_includes_board_activity_section () =
-  let obs =
-    { base_observation with
-      pending_board_events = [ sample_board_event ]
-    }
+  let obs = { base_observation with pending_board_events = [ sample_board_event ] } in
+  let _sys, user =
+    UP.build_prompt ~base_path:"/test" ~meta:minimal_meta ~observation:obs ()
   in
-  let _sys, user = UP.build_prompt ~base_path:"/test" ~meta:minimal_meta ~observation:obs () in
-  check bool "has board activity section" true
+  check
+    bool
+    "has board activity section"
+    true
     (let found =
-       try ignore (Str.search_forward (Str.regexp_string "Board Activity") user 0); true
-       with Not_found -> false
-     in found);
-  check bool "includes board event preview" true
+       try
+         ignore (Str.search_forward (Str.regexp_string "Board Activity") user 0);
+         true
+       with
+       | Not_found -> false
+     in
+     found);
+  check
+    bool
+    "includes board event preview"
+    true
     (let found =
-       try ignore (Str.search_forward (Str.regexp_string "Please take a look.") user 0); true
-       with Not_found -> false
-     in found)
+       try
+         ignore (Str.search_forward (Str.regexp_string "Please take a look.") user 0);
+         true
+       with
+       | Not_found -> false
+     in
+     found)
+;;
 
 let test_prompt_marks_board_curation_due_for_multi_event_window () =
   let second_board_event =
-    {
-      sample_board_event with
-      post_id = "board-post-2";
-      title = "Answer candidate";
-      preview = "This may answer the earlier thread.";
+    { sample_board_event with
+      post_id = "board-post-2"
+    ; title = "Answer candidate"
+    ; preview = "This may answer the earlier thread."
     }
   in
   let obs =
@@ -5437,51 +7015,52 @@ let test_prompt_marks_board_curation_due_for_multi_event_window () =
   let _sys, user =
     UP.build_prompt ~base_path:"/test" ~meta:minimal_meta ~observation:obs ()
   in
-  check bool "marks curation due" true
-    (contains_substring user "Curation due");
-  check bool "names curation submit tool" true
+  check bool "marks curation due" true (contains_substring user "Curation due");
+  check
+    bool
+    "names curation submit tool"
+    true
     (contains_substring user "keeper_board_curation_submit")
+;;
 
 let test_prompt_prefers_silence_guidance () =
-  let sys, _user = UP.build_prompt ~base_path:"/test" ~meta:minimal_meta ~observation:base_observation () in
-  check bool "mentions speech act header" true
+  let sys, _user =
+    UP.build_prompt ~base_path:"/test" ~meta:minimal_meta ~observation:base_observation ()
+  in
+  check
+    bool
+    "mentions speech act header"
+    true
     (let found =
        try
          ignore (Str.search_forward (Str.regexp_string "SPEECH_ACT:") sys 0);
          true
-       with Not_found -> false
+       with
+       | Not_found -> false
      in
      found)
+;;
 
 let test_sanitize_text_utf8_replaces_control_chars () =
   let raw = "alpha\000beta\001gamma\127delta\n\tomega" in
   let sanitized = Masc_mcp.Inference_utils.sanitize_text_utf8 raw in
-  check bool "no disallowed control chars" false
+  check
+    bool
+    "no disallowed control chars"
+    false
     (contains_disallowed_control_char sanitized);
-  check string "content preserved with spaces"
-    "alpha beta gamma delta\n\tomega"
-    sanitized
+  check string "content preserved with spaces" "alpha beta gamma delta\n\tomega" sanitized
+;;
 
 let test_prompt_sanitizes_control_chars () =
-  let meta =
-    { minimal_meta with
-      instructions = "watch\000this";
-    }
-  in
+  let meta = { minimal_meta with instructions = "watch\000this" } in
   let obs =
     { base_observation with
-      pending_mentions = [ ("alice", "ping\001pong") ];
-      pending_board_events =
-        [
-          { sample_board_event with
-            preview = "bad\127preview";
-          };
-        ];
+      pending_mentions = [ "alice", "ping\001pong" ]
+    ; pending_board_events = [ { sample_board_event with preview = "bad\127preview" } ]
     }
   in
-  let sys_raw, user_raw =
-    UP.build_prompt ~base_path:"/test" ~meta ~observation:obs ()
-  in
+  let sys_raw, user_raw = UP.build_prompt ~base_path:"/test" ~meta ~observation:obs () in
   (* #6645 intentionally moved UTF-8 sanitization from MASC's
      [build_prompt] to the OAS pipeline boundary (agent.ml,
      pipeline.ml, agent_turn.ml in OAS v0.121.0). MASC callers now
@@ -5495,219 +7074,247 @@ let test_prompt_sanitizes_control_chars () =
      [build_prompt] output itself was deliberately removed by #6645. *)
   let sys = Masc_mcp.Inference_utils.sanitize_text_utf8 sys_raw in
   let user = Masc_mcp.Inference_utils.sanitize_text_utf8 user_raw in
-  check bool "system prompt sanitized" false
-    (contains_disallowed_control_char sys);
-  check bool "user prompt sanitized" false
-    (contains_disallowed_control_char user);
-  check bool "mention text preserved after sanitize" true
+  check bool "system prompt sanitized" false (contains_disallowed_control_char sys);
+  check bool "user prompt sanitized" false (contains_disallowed_control_char user);
+  check
+    bool
+    "mention text preserved after sanitize"
+    true
     (contains_substring user "ping pong");
-  check bool "board preview preserved after sanitize" true
+  check
+    bool
+    "board preview preserved after sanitize"
+    true
     (contains_substring user "bad preview")
+;;
 
 let test_sanitize_messages_utf8_cleans_history_path () =
   let user_msg =
     Agent_sdk.Types.
-      {
-        role = User;
-        content = [ Text "hist\000ory\127entry" ];
-        name = None;
-        tool_call_id = None;
-      metadata = [];
+      { role = User
+      ; content = [ Text "hist\000ory\127entry" ]
+      ; name = None
+      ; tool_call_id = None
+      ; metadata = []
       }
   in
   let tool_msg =
     Agent_sdk.Types.
-      {
-        role = Tool;
-        content =
-          [
-            ToolResult
-              {
-                tool_use_id = "tool\001id";
-                content = "result\127payload";
-                is_error = false;
-                json = Some (`Assoc [("key\000", `String "value\127")]);
-              };
-          ];
-        name = None;
-        tool_call_id = None;
-      metadata = [];
+      { role = Tool
+      ; content =
+          [ ToolResult
+              { tool_use_id = "tool\001id"
+              ; content = "result\127payload"
+              ; is_error = false
+              ; json = Some (`Assoc [ "key\000", `String "value\127" ])
+              }
+          ]
+      ; name = None
+      ; tool_call_id = None
+      ; metadata = []
       }
   in
   let assistant_msg =
     Agent_sdk.Types.
-      {
-        role = Assistant;
-        content =
-          [
-            ToolUse
-              {
-                id = "call\001id";
-                name = "keeper\127shell";
-                input =
+      { role = Assistant
+      ; content =
+          [ ToolUse
+              { id = "call\001id"
+              ; name = "keeper\127shell"
+              ; input =
                   `Assoc
-                    [
-                      ("pattern\000", `String "bad\127bytes");
-                      ("nested", `List [`String "x\001y"]);
-                    ];
-              };
-          ];
-        name = None;
-        tool_call_id = None;
-        metadata = [];
+                    [ "pattern\000", `String "bad\127bytes"
+                    ; "nested", `List [ `String "x\001y" ]
+                    ]
+              }
+          ]
+      ; name = None
+      ; tool_call_id = None
+      ; metadata = []
       }
   in
   let sanitized =
-    Masc_mcp.Inference_utils.sanitize_messages_utf8
-      [ user_msg; assistant_msg; tool_msg ]
+    Masc_mcp.Inference_utils.sanitize_messages_utf8 [ user_msg; assistant_msg; tool_msg ]
   in
   match sanitized with
   | [ user_msg; assistant_msg; tool_msg ] ->
-      check string "user history content sanitized" "hist ory entry"
-        (Agent_sdk.Types.text_of_message user_msg);
-      (match assistant_msg.Agent_sdk.Types.content with
-       | [ Agent_sdk.Types.ToolUse { id; name; input } ] ->
-           check string "tool use id sanitized" "call id" id;
-           check string "tool use name sanitized" "keeper shell" name;
-           (match input with
-            | `Assoc
-                [
-                  (key, `String value);
-                  ("nested", `List [`String nested_value]);
-                ] ->
-                check string "tool use json key sanitized" "pattern " key;
-                check string "tool use json value sanitized" "bad bytes" value;
-                check string "tool use nested json sanitized" "x y" nested_value
-            | _ -> fail "expected sanitized tool use json")
-       | _ -> fail "expected sanitized tool use");
-      (match tool_msg.Agent_sdk.Types.content with
-       | [ Agent_sdk.Types.ToolResult { tool_use_id; content; _ } ] ->
-           check string "tool id sanitized" "tool id" tool_use_id;
-           check string "tool payload sanitized" "result payload" content;
-           (match tool_msg.Agent_sdk.Types.content with
-            | [ Agent_sdk.Types.ToolResult { json = Some (`Assoc [ (key, `String value) ]); _ } ] ->
-                check string "tool json key sanitized" "key " key;
-                check string "tool json value sanitized" "value " value
-            | _ -> fail "expected sanitized tool result json")
-       | _ -> fail "expected sanitized tool result")
+    check
+      string
+      "user history content sanitized"
+      "hist ory entry"
+      (Agent_sdk.Types.text_of_message user_msg);
+    (match assistant_msg.Agent_sdk.Types.content with
+     | [ Agent_sdk.Types.ToolUse { id; name; input } ] ->
+       check string "tool use id sanitized" "call id" id;
+       check string "tool use name sanitized" "keeper shell" name;
+       (match input with
+        | `Assoc [ (key, `String value); ("nested", `List [ `String nested_value ]) ] ->
+          check string "tool use json key sanitized" "pattern " key;
+          check string "tool use json value sanitized" "bad bytes" value;
+          check string "tool use nested json sanitized" "x y" nested_value
+        | _ -> fail "expected sanitized tool use json")
+     | _ -> fail "expected sanitized tool use");
+    (match tool_msg.Agent_sdk.Types.content with
+     | [ Agent_sdk.Types.ToolResult { tool_use_id; content; _ } ] ->
+       check string "tool id sanitized" "tool id" tool_use_id;
+       check string "tool payload sanitized" "result payload" content;
+       (match tool_msg.Agent_sdk.Types.content with
+        | [ Agent_sdk.Types.ToolResult
+              { json = Some (`Assoc [ (key, `String value) ]); _ }
+          ] ->
+          check string "tool json key sanitized" "key " key;
+          check string "tool json value sanitized" "value " value
+        | _ -> fail "expected sanitized tool result json")
+     | _ -> fail "expected sanitized tool result")
   | _ -> fail "expected three sanitized messages"
+;;
 
 let test_sanitize_messages_utf8_reuses_clean_history_list () =
   let msgs =
-    [
-      Agent_sdk.Types.user_msg "already clean";
-      Agent_sdk.Types.assistant_msg "still clean";
+    [ Agent_sdk.Types.user_msg "already clean"
+    ; Agent_sdk.Types.assistant_msg "still clean"
     ]
   in
   let sanitized = Masc_mcp.Inference_utils.sanitize_messages_utf8 msgs in
   check bool "same list reused" true (sanitized == msgs)
+;;
 
 let test_overflow_detection_and_limit_parsing () =
-  check bool "ContextOverflow with limit" true
+  check
+    bool
+    "ContextOverflow with limit"
+    true
     (EC.is_context_overflow
        (Agent_sdk.Error.Api (ContextOverflow { message = "exceeded"; limit = Some 8192 })));
-  check (option int) "parses limit via OAS SSOT" (Some 8192)
+  check
+    (option int)
+    "parses limit via OAS SSOT"
+    (Some 8192)
     (Agent_sdk.Retry.extract_context_limit
        "HTTP 400: prompt exceeds available context size (8192 tokens)");
-  check (option int) "no limit in unrelated error" None
+  check
+    (option int)
+    "no limit in unrelated error"
+    None
     (Agent_sdk.Retry.extract_context_limit "Network error: connection reset");
-  check bool "NetworkError not overflow" false
+  check
+    bool
+    "NetworkError not overflow"
+    false
     (EC.is_context_overflow
        (Agent_sdk.Error.Api
-          (NetworkError
-             { message = "timeout"; kind = Llm_provider.Http_client.Timeout })))
+          (NetworkError { message = "timeout"; kind = Llm_provider.Http_client.Timeout })))
+;;
 
 let test_side_effect_timeout_reclassified_as_persistent () =
   let original =
-    Agent_sdk.Error.Api
-      (Timeout { message = "Execution cancelled after 300.0s" })
+    Agent_sdk.Error.Api (Timeout { message = "Execution cancelled after 300.0s" })
   in
   let reclassified =
-    EC.reclassify_error_after_side_effect
-      ~tool_names:["keeper_fs_edit"] original
+    EC.reclassify_error_after_side_effect ~tool_names:[ "keeper_fs_edit" ] original
   in
-  check bool "marked ambiguous partial" true
+  check
+    bool
+    "marked ambiguous partial"
+    true
     (EC.is_ambiguous_side_effect_error reclassified);
-  check bool "no longer transient" false
-    (EC.is_transient_network_error reclassified);
-  check bool "mentions tool name" true
-    (contains_substring
-       (Agent_sdk.Error.to_string reclassified)
-       "keeper_fs_edit")
+  check bool "no longer transient" false (EC.is_transient_network_error reclassified);
+  check
+    bool
+    "mentions tool name"
+    true
+    (contains_substring (Agent_sdk.Error.to_string reclassified) "keeper_fs_edit")
+;;
 
 let test_side_effect_reclassification_requires_committed_tools () =
   let original =
-    Agent_sdk.Error.Api
-      (Timeout { message = "Execution cancelled after 300.0s" })
+    Agent_sdk.Error.Api (Timeout { message = "Execution cancelled after 300.0s" })
   in
-  let reclassified =
-    EC.reclassify_error_after_side_effect
-      ~tool_names:[] original
-  in
-  check bool "no committed tool keeps transient" true
+  let reclassified = EC.reclassify_error_after_side_effect ~tool_names:[] original in
+  check
+    bool
+    "no committed tool keeps transient"
+    true
     (EC.is_transient_network_error reclassified);
-  check bool "not marked ambiguous partial" false
+  check
+    bool
+    "not marked ambiguous partial"
+    false
     (EC.is_ambiguous_side_effect_error reclassified)
+;;
 
 let test_side_effect_reclassification_ignores_read_only_tools () =
   let original =
-    Agent_sdk.Error.Api
-      (Timeout { message = "Execution cancelled after 300.0s" })
+    Agent_sdk.Error.Api (Timeout { message = "Execution cancelled after 300.0s" })
   in
   let reclassified =
     EC.reclassify_error_after_side_effect
-      ~tool_names:["keeper_board_list"; "keeper_fs_read"] original
+      ~tool_names:[ "keeper_board_list"; "keeper_fs_read" ]
+      original
   in
-  check bool "read-only timeout stays transient" true
+  check
+    bool
+    "read-only timeout stays transient"
+    true
     (EC.is_transient_network_error reclassified);
-  check bool "read-only timeout not ambiguous partial" false
+  check
+    bool
+    "read-only timeout not ambiguous partial"
+    false
     (EC.is_ambiguous_side_effect_error reclassified)
+;;
 
 let test_side_effect_reclassification_marks_any_post_commit_error () =
-  let original =
-    Agent_sdk.Error.Api
-      (AuthError { message = "Unauthorized" })
-  in
+  let original = Agent_sdk.Error.Api (AuthError { message = "Unauthorized" }) in
   let reclassified =
-    EC.reclassify_error_after_side_effect
-      ~tool_names:["keeper_fs_edit"] original
+    EC.reclassify_error_after_side_effect ~tool_names:[ "keeper_fs_edit" ] original
   in
-  check bool "auth error stays non-transient" false
+  check
+    bool
+    "auth error stays non-transient"
+    false
     (EC.is_transient_network_error reclassified);
-  check bool "auth error becomes ambiguous partial" true
+  check
+    bool
+    "auth error becomes ambiguous partial"
+    true
     (EC.is_ambiguous_side_effect_error reclassified)
+;;
 
 let test_post_commit_failure_kind_marks_timeouts () =
   let timeout_error =
-    Agent_sdk.Error.Api
-      (Timeout { message = "Execution cancelled after 300.0s" })
+    Agent_sdk.Error.Api (Timeout { message = "Execution cancelled after 300.0s" })
   in
-  check string "timeout kind" "post_commit_timeout"
+  check
+    string
+    "timeout kind"
+    "post_commit_timeout"
     (KR.ambiguous_partial_commit_kind_to_string
        (EC.post_commit_failure_kind_of_error timeout_error))
+;;
 
 let test_post_commit_failure_kind_marks_non_timeouts_as_failures () =
-  let auth_error =
-    Agent_sdk.Error.Api
-      (AuthError { message = "Unauthorized" })
-  in
-  check string "failure kind" "post_commit_failure"
+  let auth_error = Agent_sdk.Error.Api (AuthError { message = "Unauthorized" }) in
+  check
+    string
+    "failure kind"
+    "post_commit_failure"
     (KR.ambiguous_partial_commit_kind_to_string
        (EC.post_commit_failure_kind_of_error auth_error))
+;;
 
 let tool_event_ok_result : Agent_sdk.Types.tool_result =
   Ok { Agent_sdk.Types.content = "ok" }
+;;
 
 let tool_event_error_result : Agent_sdk.Types.tool_result =
   Error
-    {
-      Agent_sdk.Types.message = "tool failed";
-      recoverable = false;
-      error_class = None;
-    }
+    { Agent_sdk.Types.message = "tool failed"; recoverable = false; error_class = None }
+;;
 
 let mk_tool_event payload =
   Agent_sdk.Event_bus.mk_event ~run_id:"run-tool-event-pairing" payload
+;;
 
 let test_turn_tool_event_tracker_pairs_called_across_drains () =
   let tracker = UT.create_turn_tool_event_tracker () in
@@ -5715,41 +7322,41 @@ let test_turn_tool_event_tracker_pairs_called_across_drains () =
   UT.record_turn_tool_events
     ~keeper_name
     tracker
-    [
-      mk_tool_event
+    [ mk_tool_event
         (Agent_sdk.Event_bus.ToolCalled
-           {
-             agent_name = keeper_name;
-             tool_name = "keeper_fs_edit";
-             input =
+           { agent_name = keeper_name
+           ; tool_name = "keeper_fs_edit"
+           ; input =
                `Assoc
-                 [
-                   ("path", `String "/tmp/keeper-note.md");
-                   ("content", `String "updated");
-                 ];
-           });
+                 [ "path", `String "/tmp/keeper-note.md"; "content", `String "updated" ]
+           })
     ];
-  check (option string) "no error after pending call" None
-    (Option.map Agent_sdk.Error.to_string
-       (UT.turn_tool_event_integrity_error tracker));
+  check
+    (option string)
+    "no error after pending call"
+    None
+    (Option.map Agent_sdk.Error.to_string (UT.turn_tool_event_integrity_error tracker));
   UT.record_turn_tool_events
     ~keeper_name
     tracker
-    [
-      mk_tool_event
+    [ mk_tool_event
         (Agent_sdk.Event_bus.ToolCompleted
-           {
-             agent_name = keeper_name;
-             tool_name = "keeper_fs_edit";
-             output = tool_event_ok_result;
-           });
+           { agent_name = keeper_name
+           ; tool_name = "keeper_fs_edit"
+           ; output = tool_event_ok_result
+           })
     ];
-  check (option string) "paired completion has no integrity error" None
-    (Option.map Agent_sdk.Error.to_string
-       (UT.turn_tool_event_integrity_error tracker));
-  check (list string) "paired mutating tool committed"
+  check
+    (option string)
+    "paired completion has no integrity error"
+    None
+    (Option.map Agent_sdk.Error.to_string (UT.turn_tool_event_integrity_error tracker));
+  check
+    (list string)
+    "paired mutating tool committed"
     [ "keeper_fs_edit" ]
     (UT.committed_mutating_tools_from_events tracker)
+;;
 
 let test_turn_tool_event_tracker_rejects_completed_without_called () =
   let tracker = UT.create_turn_tool_event_tracker () in
@@ -5757,26 +7364,33 @@ let test_turn_tool_event_tracker_rejects_completed_without_called () =
   UT.record_turn_tool_events
     ~keeper_name
     tracker
-    [
-      mk_tool_event
+    [ mk_tool_event
         (Agent_sdk.Event_bus.ToolCompleted
-           {
-             agent_name = keeper_name;
-             tool_name = "keeper_fs_edit";
-             output = tool_event_ok_result;
-           });
+           { agent_name = keeper_name
+           ; tool_name = "keeper_fs_edit"
+           ; output = tool_event_ok_result
+           })
     ];
   match UT.turn_tool_event_integrity_error tracker with
   | None -> fail "expected unmatched ToolCompleted integrity error"
   | Some err ->
-      let rendered = Agent_sdk.Error.to_string err in
-      check bool "error names missing ToolCalled" true
-        (contains_substring rendered "without matching ToolCalled");
-      check bool "mutating mismatch becomes ambiguous partial" true
-        (EC.is_ambiguous_side_effect_error err);
-      check (list string) "unmatched mutating tool committed"
-        [ "keeper_fs_edit" ]
-        (UT.committed_mutating_tools_from_events tracker)
+    let rendered = Agent_sdk.Error.to_string err in
+    check
+      bool
+      "error names missing ToolCalled"
+      true
+      (contains_substring rendered "without matching ToolCalled");
+    check
+      bool
+      "mutating mismatch becomes ambiguous partial"
+      true
+      (EC.is_ambiguous_side_effect_error err);
+    check
+      (list string)
+      "unmatched mutating tool committed"
+      [ "keeper_fs_edit" ]
+      (UT.committed_mutating_tools_from_events tracker)
+;;
 
 let test_turn_tool_event_tracker_rejects_failed_completed_without_commit () =
   let tracker = UT.create_turn_tool_event_tracker () in
@@ -5784,158 +7398,206 @@ let test_turn_tool_event_tracker_rejects_failed_completed_without_commit () =
   UT.record_turn_tool_events
     ~keeper_name
     tracker
-    [
-      mk_tool_event
+    [ mk_tool_event
         (Agent_sdk.Event_bus.ToolCompleted
-           {
-             agent_name = keeper_name;
-             tool_name = "keeper_fs_edit";
-             output = tool_event_error_result;
-           });
+           { agent_name = keeper_name
+           ; tool_name = "keeper_fs_edit"
+           ; output = tool_event_error_result
+           })
     ];
   match UT.turn_tool_event_integrity_error tracker with
   | None -> fail "expected unmatched failed ToolCompleted integrity error"
   | Some err ->
-      let rendered = Agent_sdk.Error.to_string err in
-      check bool "error names missing ToolCalled" true
-        (contains_substring rendered "without matching ToolCalled");
-      check bool "failed mismatch is not ambiguous partial" false
-        (EC.is_ambiguous_side_effect_error err);
-      check (list string) "failed unmatched tool not committed"
-        []
-        (UT.committed_mutating_tools_from_events tracker)
+    let rendered = Agent_sdk.Error.to_string err in
+    check
+      bool
+      "error names missing ToolCalled"
+      true
+      (contains_substring rendered "without matching ToolCalled");
+    check
+      bool
+      "failed mismatch is not ambiguous partial"
+      false
+      (EC.is_ambiguous_side_effect_error err);
+    check
+      (list string)
+      "failed unmatched tool not committed"
+      []
+      (UT.committed_mutating_tools_from_events tracker)
+;;
 
 let test_server_rejected_parse_error_ollama_closing_brace () =
   let err =
     Agent_sdk.Error.Api
-      (InvalidRequest { message = {|Value looks like object, but can't find closing '}' symbol|} })
+      (InvalidRequest
+         { message = {|Value looks like object, but can't find closing '}' symbol|} })
   in
-  check bool "ollama closing brace is parse error" true
+  check
+    bool
+    "ollama closing brace is parse error"
+    true
     (EC.is_server_rejected_parse_error err);
-  check bool "ollama closing brace is NOT transient network" false
+  check
+    bool
+    "ollama closing brace is NOT transient network"
+    false
     (EC.is_transient_network_error err)
+;;
 
 let test_server_rejected_parse_error_unterminated () =
   let err =
-    Agent_sdk.Error.Api
-      (InvalidRequest { message = "Unterminated string in JSON" })
+    Agent_sdk.Error.Api (InvalidRequest { message = "Unterminated string in JSON" })
   in
-  check bool "unterminated is parse error" true
-    (EC.is_server_rejected_parse_error err)
+  check bool "unterminated is parse error" true (EC.is_server_rejected_parse_error err)
+;;
 
 let test_server_rejected_parse_error_unexpected_char () =
   let err =
     Agent_sdk.Error.Api
       (InvalidRequest { message = "Unexpected character in JSON at position 42" })
   in
-  check bool "unexpected character in json is parse error" true
+  check
+    bool
+    "unexpected character in json is parse error"
+    true
     (EC.is_server_rejected_parse_error err)
+;;
 
 let test_server_rejected_parse_error_parse_error () =
   let err =
-    Agent_sdk.Error.Api
-      (InvalidRequest { message = "Parse error at position 1024" })
+    Agent_sdk.Error.Api (InvalidRequest { message = "Parse error at position 1024" })
   in
-  check bool "parse error is parse error" true
-    (EC.is_server_rejected_parse_error err)
+  check bool "parse error is parse error" true (EC.is_server_rejected_parse_error err)
+;;
 
 let test_server_rejected_parse_error_case_insensitive () =
   let err =
-    Agent_sdk.Error.Api
-      (InvalidRequest { message = "PARSE ERROR in request body" })
+    Agent_sdk.Error.Api (InvalidRequest { message = "PARSE ERROR in request body" })
   in
-  check bool "uppercase PARSE ERROR detected" true
-    (EC.is_server_rejected_parse_error err)
+  check bool "uppercase PARSE ERROR detected" true (EC.is_server_rejected_parse_error err)
+;;
 
 let test_server_rejected_parse_error_generic_invalid_request () =
-  let err =
-    Agent_sdk.Error.Api
-      (InvalidRequest { message = "bad tool schema" })
-  in
-  check bool "generic InvalidRequest is NOT parse error" false
+  let err = Agent_sdk.Error.Api (InvalidRequest { message = "bad tool schema" }) in
+  check
+    bool
+    "generic InvalidRequest is NOT parse error"
+    false
     (EC.is_server_rejected_parse_error err)
+;;
 
 let test_server_rejected_parse_error_generic_closing () =
   let err =
-    Agent_sdk.Error.Api
-      (InvalidRequest { message = "Service closing for maintenance" })
+    Agent_sdk.Error.Api (InvalidRequest { message = "Service closing for maintenance" })
   in
-  check bool "generic 'closing' is NOT parse error" false
+  check
+    bool
+    "generic 'closing' is NOT parse error"
+    false
     (EC.is_server_rejected_parse_error err)
+;;
 
 let test_server_rejected_parse_error_generic_cant_find () =
   let err =
     Agent_sdk.Error.Api
       (InvalidRequest { message = "Can't find the specified tool 'my_tool'" })
   in
-  check bool "generic 'can't find' is NOT parse error" false
+  check
+    bool
+    "generic 'can't find' is NOT parse error"
+    false
     (EC.is_server_rejected_parse_error err)
+;;
 
 let test_server_rejected_parse_error_network_error () =
   let err =
     Agent_sdk.Error.Api
       (NetworkError
-         {
-           message = "connection refused";
-           kind = Llm_provider.Http_client.Connection_refused;
+         { message = "connection refused"
+         ; kind = Llm_provider.Http_client.Connection_refused
          })
   in
-  check bool "network error is NOT parse error" false
+  check
+    bool
+    "network error is NOT parse error"
+    false
     (EC.is_server_rejected_parse_error err)
+;;
 
 let test_auto_recoverable_turn_error_includes_transient_network () =
   let err =
-    Agent_sdk.Error.Api
-      (Timeout { message = "Execution cancelled after 300.0s" })
+    Agent_sdk.Error.Api (Timeout { message = "Execution cancelled after 300.0s" })
   in
-  check bool "timeout is auto-recoverable" true
-    (EC.is_auto_recoverable_turn_error err)
+  check bool "timeout is auto-recoverable" true (EC.is_auto_recoverable_turn_error err)
+;;
 
 let test_auto_recoverable_turn_error_includes_server_parse_rejection () =
   let err =
-    Agent_sdk.Error.Api
-      (InvalidRequest { message = "Parse error at position 42" })
+    Agent_sdk.Error.Api (InvalidRequest { message = "Parse error at position 42" })
   in
-  check bool "server parse rejection is auto-recoverable" true
+  check
+    bool
+    "server parse rejection is auto-recoverable"
+    true
     (EC.is_auto_recoverable_turn_error err)
+;;
 
 let test_auto_recoverable_turn_error_includes_wrapped_hard_quota () =
   let err =
     Agent_sdk.Error.Api
       (NetworkError
-         {
-           message =
-             "claude exited with code 1: {\"type\":\"result\",\"subtype\":\"success\",\"is_error\":true,\"api_error_status\":429,\"result\":\"You've hit your limit · resets Apr 24 at 4am (Asia/Seoul)\"}";
-           kind = Llm_provider.Http_client.Unknown;
+         { message =
+             "claude exited with code 1: \
+              {\"type\":\"result\",\"subtype\":\"success\",\"is_error\":true,\"api_error_status\":429,\"result\":\"You've \
+              hit your limit · resets Apr 24 at 4am (Asia/Seoul)\"}"
+         ; kind = Llm_provider.Http_client.Unknown
          })
   in
-  check bool "wrapped hard quota is auto-recoverable" true
+  check
+    bool
+    "wrapped hard quota is auto-recoverable"
+    true
     (EC.is_auto_recoverable_turn_error err)
+;;
 
 let test_auto_recoverable_turn_error_includes_wrapped_max_turns () =
-  check bool "wrapped CLI max-turns is auto-recoverable" true
+  check
+    bool
+    "wrapped CLI max-turns is auto-recoverable"
+    true
     (EC.is_auto_recoverable_turn_error (wrapped_claude_max_turns_error ()))
+;;
 
 let test_required_tool_contract_violation_detected () =
   let err =
     Agent_sdk.Error.Agent
       (CompletionContractViolation
-         {
-           contract = Agent_sdk.Completion_contract_id.Require_tool_use;
-           reason =
-             "required tool contract unsatisfied: tool_choice requested tool use, but the model returned no ToolUse block";
+         { contract = Agent_sdk.Completion_contract_id.Require_tool_use
+         ; reason =
+             "required tool contract unsatisfied: tool_choice requested tool use, but \
+              the model returned no ToolUse block"
          })
   in
-  check bool "tool-choice contract violation detected" true
+  check
+    bool
+    "tool-choice contract violation detected"
+    true
     (EC.is_required_tool_contract_violation err)
+;;
 
 let test_required_tool_contract_violation_ignores_legacy_internal_error () =
   let err =
     Agent_sdk.Error.Internal
-      "Completion contract [require_tool_use] violated: required tool contract unsatisfied: tool_choice requested tool use, but the model returned no ToolUse block"
+      "Completion contract [require_tool_use] violated: required tool contract \
+       unsatisfied: tool_choice requested tool use, but the model returned no ToolUse \
+       block"
   in
-  check bool "legacy internal contract violation ignored" false
+  check
+    bool
+    "legacy internal contract violation ignored"
+    false
     (EC.is_required_tool_contract_violation err)
+;;
 
 (* Rotation-cap threshold: the cap must NOT fire on the very first attempt
    (attempted_cascades length = 1, meaning no rotation has occurred yet).
@@ -5944,137 +7606,179 @@ let test_required_tool_contract_violation_ignores_legacy_internal_error () =
    offering at least one cascade rotation. *)
 let test_should_cap_rotation_does_not_fire_on_first_attempt () =
   let err = required_tool_contract_violation_error () in
-  check bool "cap must not fire when no rotation has been attempted" false
+  check
+    bool
+    "cap must not fire when no rotation has been attempted"
+    false
     (EC.should_cap_rotation_for_contract_violation
        ~attempted_cascades:[ "strict_exec" ]
        ~fallback_not_yet_tried:false
        err)
+;;
 
 let test_should_cap_rotation_fires_after_one_rotation () =
   let err = required_tool_contract_violation_error () in
-  check bool "cap fires when one rotation has already been attempted" true
+  check
+    bool
+    "cap fires when one rotation has already been attempted"
+    true
     (EC.should_cap_rotation_for_contract_violation
-       ~attempted_cascades:[ "strict_exec"; (KC.default_cascade_name ()) ]
+       ~attempted_cascades:[ "strict_exec"; KC.default_cascade_name () ]
        ~fallback_not_yet_tried:false
        err)
+;;
 
 let test_should_cap_rotation_suppressed_while_fallback_available () =
   let err = required_tool_contract_violation_error () in
-  check bool "cap is suppressed when an untried fallback cascade exists" false
+  check
+    bool
+    "cap is suppressed when an untried fallback cascade exists"
+    false
     (EC.should_cap_rotation_for_contract_violation
-       ~attempted_cascades:[ "strict_exec"; (KC.default_cascade_name ()) ]
+       ~attempted_cascades:[ "strict_exec"; KC.default_cascade_name () ]
        ~fallback_not_yet_tried:true
        err)
+;;
 
 let test_should_cap_rotation_ignores_non_contract_violation_error () =
   let err = wrapped_claude_limit_error () in
-  check bool "cap does not fire for non-contract-violation errors" false
+  check
+    bool
+    "cap does not fire for non-contract-violation errors"
+    false
     (EC.should_cap_rotation_for_contract_violation
-       ~attempted_cascades:[ "strict_exec"; (KC.default_cascade_name ()) ]
+       ~attempted_cascades:[ "strict_exec"; KC.default_cascade_name () ]
        ~fallback_not_yet_tried:false
        err)
+;;
 
 let test_cascade_exhausted_error_detected_from_structured_internal_error () =
   let err =
     Masc_mcp.Keeper_turn_driver.sdk_error_of_masc_internal_error
       (Masc_mcp.Keeper_turn_driver.Cascade_exhausted
-         {
-           cascade_name =
-             oas_error_cascade_name Masc_mcp.(Keeper_config.default_cascade_name ());
-           reason = Masc_mcp.Keeper_types.All_providers_failed;
+         { cascade_name =
+             oas_error_cascade_name Masc_mcp.(Keeper_config.default_cascade_name ())
+         ; reason = Masc_mcp.Keeper_types.All_providers_failed
          })
   in
-  check bool "structured cascade exhausted error detected" true
+  check
+    bool
+    "structured cascade exhausted error detected"
+    true
     (EC.is_cascade_exhausted_error err)
+;;
 
 let test_cascade_exhausted_error_ignores_legacy_internal_error () =
   let err =
     Agent_sdk.Error.Internal
       "cascade keeper_unified: all models failed: no providers available"
   in
-  check bool "legacy internal cascade exhaustion ignored" false
+  check
+    bool
+    "legacy internal cascade exhaustion ignored"
+    false
     (EC.is_cascade_exhausted_error err)
+;;
 
 let test_auto_recoverable_turn_error_excludes_required_tool_contract_violation () =
   let err =
     Agent_sdk.Error.Agent
       (CompletionContractViolation
-         {
-           contract = Agent_sdk.Completion_contract_id.Require_tool_use;
-           reason =
-             "required tool contract unsatisfied: tool_choice requested tool use, but the model returned no ToolUse block";
+         { contract = Agent_sdk.Completion_contract_id.Require_tool_use
+         ; reason =
+             "required tool contract unsatisfied: tool_choice requested tool use, but \
+              the model returned no ToolUse block"
          })
   in
-  check bool "tool-choice contract violation is not globally auto-recoverable" false
+  check
+    bool
+    "tool-choice contract violation is not globally auto-recoverable"
+    false
     (EC.is_auto_recoverable_turn_error err)
+;;
 
 let test_auto_recoverable_turn_error_excludes_persistent_errors () =
-  let err =
-    Agent_sdk.Error.Api
-      (AuthError { message = "Unauthorized" })
-  in
-  check bool "auth error is persistent" false
-    (EC.is_auto_recoverable_turn_error err)
+  let err = Agent_sdk.Error.Api (AuthError { message = "Unauthorized" }) in
+  check bool "auth error is persistent" false (EC.is_auto_recoverable_turn_error err)
+;;
 
 let test_auto_recoverable_turn_error_includes_wrapped_cascade_exhausted_hard_quota () =
   let err =
     Masc_mcp.Keeper_turn_driver.sdk_error_of_masc_internal_error
       (Masc_mcp.Keeper_turn_driver.Cascade_exhausted
-         {
-           cascade_name =
-             oas_error_cascade_name Masc_mcp.(Keeper_config.default_cascade_name ());
-           reason =
+         { cascade_name =
+             oas_error_cascade_name Masc_mcp.(Keeper_config.default_cascade_name ())
+         ; reason =
              Keeper_types.Other_detail
-               "claude exited with code 1: {\"type\":\"result\",\"subtype\":\"success\",\"is_error\":true,\"api_error_status\":429,\"result\":\"You've hit your limit · resets Apr 24 at 4am (Asia/Seoul)\"}";
+               "claude exited with code 1: \
+                {\"type\":\"result\",\"subtype\":\"success\",\"is_error\":true,\"api_error_status\":429,\"result\":\"You've \
+                hit your limit · resets Apr 24 at 4am (Asia/Seoul)\"}"
          })
   in
-  check bool "wrapped cascade hard quota is auto-recoverable" true
+  check
+    bool
+    "wrapped cascade hard quota is auto-recoverable"
+    true
     (EC.is_auto_recoverable_turn_error err)
+;;
 
 let test_auto_recoverable_turn_error_includes_wrapped_cascade_max_turns () =
-  check bool "wrapped cascade max-turns is auto-recoverable" true
+  check
+    bool
+    "wrapped cascade max-turns is auto-recoverable"
+    true
     (EC.is_auto_recoverable_turn_error (wrapped_cascade_max_turns_error ()))
+;;
 
 let test_auto_recoverable_turn_error_includes_filtered_candidates_cascade_exhaustion () =
   let err =
     Masc_mcp.Keeper_turn_driver.sdk_error_of_masc_internal_error
       (Masc_mcp.Keeper_turn_driver.Cascade_exhausted
-         {
-           cascade_name =
-             oas_error_cascade_name Masc_mcp.(Keeper_config.default_cascade_name ());
-           reason = Keeper_types.Candidates_filtered_after_cycles;
+         { cascade_name =
+             oas_error_cascade_name Masc_mcp.(Keeper_config.default_cascade_name ())
+         ; reason = Keeper_types.Candidates_filtered_after_cycles
          })
   in
-  check bool "filtered candidates cascade exhaustion is auto-recoverable" true
+  check
+    bool
+    "filtered candidates cascade exhaustion is auto-recoverable"
+    true
     (EC.is_auto_recoverable_turn_error err)
+;;
 
 let test_auto_recoverable_turn_error_includes_resumable_cli_session_error () =
   let err =
     Masc_mcp.Keeper_turn_driver.sdk_error_of_masc_internal_error
       (Masc_mcp.Keeper_turn_driver.Resumable_cli_session
-         {
-           cascade_name = oas_error_cascade_name "kimi_cli_keeper";
-           detail =
-             Masc_mcp.Cascade_runner.Kimi_cli_transport_local.resumable_session_detail;
-           exit_code = Some 75;
+         { cascade_name = oas_error_cascade_name "kimi_cli_keeper"
+         ; detail =
+             Masc_mcp.Cascade_runner.Kimi_cli_transport_local.resumable_session_detail
+         ; exit_code = Some 75
          })
   in
-  check bool "resumable CLI session error is auto-recoverable" true
+  check
+    bool
+    "resumable CLI session error is auto-recoverable"
+    true
     (EC.is_auto_recoverable_turn_error err)
+;;
 
 let test_cascade_exhausted_error_includes_resumable_cli_session_error () =
   let err =
     Masc_mcp.Keeper_turn_driver.sdk_error_of_masc_internal_error
       (Masc_mcp.Keeper_turn_driver.Resumable_cli_session
-         {
-           cascade_name = oas_error_cascade_name "kimi_cli_keeper";
-           detail =
-             Masc_mcp.Cascade_runner.Kimi_cli_transport_local.resumable_session_detail;
-           exit_code = Some 75;
+         { cascade_name = oas_error_cascade_name "kimi_cli_keeper"
+         ; detail =
+             Masc_mcp.Cascade_runner.Kimi_cli_transport_local.resumable_session_detail
+         ; exit_code = Some 75
          })
   in
-  check bool "resumable CLI session error is treated as cascade exhaustion surface" true
+  check
+    bool
+    "resumable CLI session error is treated as cascade exhaustion surface"
+    true
     (EC.is_cascade_exhausted_error err)
+;;
 
 let test_bounded_oas_timeout_uses_adaptive_when_budget_is_large () =
   let estimated_input_tokens = 2_000 in
@@ -6084,18 +7788,18 @@ let test_bounded_oas_timeout_uses_adaptive_when_budget_is_large () =
   in
   match
     UT.bounded_oas_timeout_for_turn_budget
-      ~estimated_input_tokens ~remaining_turn_budget_s:1200.0
+      ~estimated_input_tokens
+      ~remaining_turn_budget_s:1200.0
   with
   | Some timeout_s ->
-      (* The bounded variant subtracts a 15s finalization guard from
+    (* The bounded variant subtracts a 15s finalization guard from
          [remaining_turn_budget_s] and caps at the adaptive raw.  After
          the bulkhead hard ceiling, [turn_timeout_sec] is 600, so the
          adaptive cap dominates this large remaining-budget case. *)
-      check bool "bounded timeout at or below adaptive raw"
-        true (timeout_s <= expected);
-      check (float 0.01) "bounded uses hard-capped adaptive timeout"
-        expected timeout_s
+    check bool "bounded timeout at or below adaptive raw" true (timeout_s <= expected);
+    check (float 0.01) "bounded uses hard-capped adaptive timeout" expected timeout_s
   | None -> fail "expected bounded timeout"
+;;
 
 (* #10008 fm2: the budget formula no longer scales with token count,
    so [bounded_oas_timeout_for_turn_budget] returns the same value
@@ -6106,24 +7810,31 @@ let test_bounded_oas_timeout_uses_adaptive_when_budget_is_large () =
 let test_bounded_oas_timeout_is_token_independent () =
   match
     ( UT.bounded_oas_timeout_for_turn_budget
-        ~estimated_input_tokens:2_000 ~remaining_turn_budget_s:1200.0,
-      UT.bounded_oas_timeout_for_turn_budget
-        ~estimated_input_tokens:262_144 ~remaining_turn_budget_s:1200.0 )
+        ~estimated_input_tokens:2_000
+        ~remaining_turn_budget_s:1200.0
+    , UT.bounded_oas_timeout_for_turn_budget
+        ~estimated_input_tokens:262_144
+        ~remaining_turn_budget_s:1200.0 )
   with
   | Some low_prompt_timeout, Some high_prompt_timeout ->
-      check (float 0.01) "token count no longer affects budget"
-        low_prompt_timeout high_prompt_timeout
+    check
+      (float 0.01)
+      "token count no longer affects budget"
+      low_prompt_timeout
+      high_prompt_timeout
   | _ -> fail "expected bounded timeouts for both prompt sizes"
+;;
 
 let test_bounded_oas_timeout_caps_to_remaining_turn_budget () =
   match
     UT.bounded_oas_timeout_for_turn_budget
-      ~estimated_input_tokens:2_000 ~remaining_turn_budget_s:235.7
+      ~estimated_input_tokens:2_000
+      ~remaining_turn_budget_s:235.7
   with
   | Some timeout_s ->
-      check (float 0.01) "remaining budget cap leaves finalization guard"
-        220.7 timeout_s
+    check (float 0.01) "remaining budget cap leaves finalization guard" 220.7 timeout_s
   | None -> fail "expected bounded timeout"
+;;
 
 let test_bounded_oas_timeout_uses_channel_turn_budget_override () =
   let max_turns =
@@ -6131,145 +7842,159 @@ let test_bounded_oas_timeout_uses_channel_turn_budget_override () =
   in
   let estimated_input_tokens = 2_000 in
   let raw =
-    Env_config.KeeperKeepalive
-    .oas_timeout_for_estimated_input_tokens_with_turn_budget
-      ~estimated_input_tokens ~max_turns
+    Env_config.KeeperKeepalive.oas_timeout_for_estimated_input_tokens_with_turn_budget
+      ~estimated_input_tokens
+      ~max_turns
   in
   match
     UT.bounded_oas_timeout_for_turn_budget_with_turn_budget
-      ~max_turns ~estimated_input_tokens ~remaining_turn_budget_s:1200.0
+      ~max_turns
+      ~estimated_input_tokens
+      ~remaining_turn_budget_s:1200.0
   with
   | Some timeout_s ->
-      (* #10008 fm2: raw formula no longer depends on max_turns;
+    (* #10008 fm2: raw formula no longer depends on max_turns;
          bounded variant still subtracts the 15s finalization guard
          from [remaining_turn_budget_s] and caps at the raw.  After
          the bulkhead hard ceiling, the raw 600s cap dominates. *)
-      check bool "bounded timeout at or below raw formula output"
-        true (timeout_s <= raw);
-      check (float 0.01) "bounded uses channel hard-capped raw timeout"
-        raw timeout_s
+    check bool "bounded timeout at or below raw formula output" true (timeout_s <= raw);
+    check (float 0.01) "bounded uses channel hard-capped raw timeout" raw timeout_s
   | None -> fail "expected bounded timeout"
+;;
 
 let test_bounded_oas_timeout_reserves_degraded_retry_budget () =
   match
     UT.resolve_bounded_oas_timeout_budget_with_turn_budget
       ~allow_wall_clock_retry_budget:false
-      ~is_retry:false ~reserve_degraded_retry_budget:true
-      ~estimated_input_tokens:2_000 ~max_turns:4
+      ~is_retry:false
+      ~reserve_degraded_retry_budget:true
+      ~estimated_input_tokens:2_000
+      ~max_turns:4
       ~remaining_turn_budget_s:500.0
   with
   | Some budget ->
-      check (float 0.01)
-        "first attempt keeps half the usable turn budget for fallback"
-        242.5 budget.effective_timeout_sec;
-      check (float 0.01) "remaining budget records raw wall-clock remaining"
-        500.0 budget.remaining_turn_budget_sec;
-      check string "source records retry reserve"
-        "adaptive_estimated_input_tokens_capped_by_degraded_retry_budget"
-        budget.source
+    check
+      (float 0.01)
+      "first attempt keeps half the usable turn budget for fallback"
+      242.5
+      budget.effective_timeout_sec;
+    check
+      (float 0.01)
+      "remaining budget records raw wall-clock remaining"
+      500.0
+      budget.remaining_turn_budget_sec;
+    check
+      string
+      "source records retry reserve"
+      "adaptive_estimated_input_tokens_capped_by_degraded_retry_budget"
+      budget.source
   | None -> fail "expected bounded timeout"
+;;
 
 let test_attempt_watchdog_preserves_degraded_retry_reserve () =
   match
     UT.resolve_bounded_oas_timeout_budget_with_turn_budget
       ~allow_wall_clock_retry_budget:false
-      ~is_retry:false ~reserve_degraded_retry_budget:true
-      ~estimated_input_tokens:2_000 ~max_turns:4
+      ~is_retry:false
+      ~reserve_degraded_retry_budget:true
+      ~estimated_input_tokens:2_000
+      ~max_turns:4
       ~remaining_turn_budget_s:500.0
   with
   | Some budget ->
-      check (float 0.01)
-        "attempt watchdog includes OAS timeout plus finalization guard"
-        257.5
-        (UT.attempt_watchdog_timeout_sec
-           ~remaining_turn_budget_s:500.0
-           budget)
+    check
+      (float 0.01)
+      "attempt watchdog includes OAS timeout plus finalization guard"
+      257.5
+      (UT.attempt_watchdog_timeout_sec ~remaining_turn_budget_s:500.0 budget)
   | None -> fail "expected bounded timeout"
+;;
 
 let test_attempt_watchdog_fires_before_outer_turn_timeout () =
   let budget =
-    {
-      UT.effective_timeout_sec = 293.0;
-      adaptive_timeout_sec = 600.0;
-      keeper_turn_timeout_sec = 600.0;
-      remaining_turn_budget_sec = 293.0;
-      estimated_input_tokens = 2_000;
-      max_turns = 4;
-      source = "adaptive_per_attempt_retry";
+    { UT.effective_timeout_sec = 293.0
+    ; adaptive_timeout_sec = 600.0
+    ; keeper_turn_timeout_sec = 600.0
+    ; remaining_turn_budget_sec = 293.0
+    ; estimated_input_tokens = 2_000
+    ; max_turns = 4
+    ; source = "adaptive_per_attempt_retry"
     }
   in
-  check (float 0.01)
+  check
+    (float 0.01)
     "retry watchdog is capped just before the enclosing turn timeout"
     292.0
-    (UT.attempt_watchdog_timeout_sec
-       ~remaining_turn_budget_s:293.0
-       budget)
+    (UT.attempt_watchdog_timeout_sec ~remaining_turn_budget_s:293.0 budget)
+;;
 
 let test_bounded_oas_timeout_refuses_too_little_budget () =
-  check (option (float 0.01)) "insufficient budget returns none" None
+  check
+    (option (float 0.01))
+    "insufficient budget returns none"
+    None
     (UT.bounded_oas_timeout_for_turn_budget
-       ~estimated_input_tokens:2_000 ~remaining_turn_budget_s:20.0)
+       ~estimated_input_tokens:2_000
+       ~remaining_turn_budget_s:20.0)
+;;
 
 let test_oas_timeout_reclassifies_only_current_attempt_budget () =
   let err =
-    Agent_sdk.Error.Api
-      (Timeout { message = "Timeout after 273.0s (budget=273s)" })
+    Agent_sdk.Error.Api (Timeout { message = "Timeout after 273.0s (budget=273s)" })
   in
   match
     UT.resolve_bounded_oas_timeout_budget_with_turn_budget
       ~allow_wall_clock_retry_budget:false
-      ~is_retry:false ~reserve_degraded_retry_budget:false
-      ~estimated_input_tokens:2_000 ~max_turns:4
+      ~is_retry:false
+      ~reserve_degraded_retry_budget:false
+      ~estimated_input_tokens:2_000
+      ~max_turns:4
       ~remaining_turn_budget_s:1200.0
   with
   | None -> fail "expected timeout budget"
   | Some timeout_budget ->
-      let classified =
-        UT.reclassify_oas_timeout_for_attempt
-          ~timeout_budget:(Some timeout_budget)
-          err
-      in
-      (match
-         Masc_mcp.Keeper_turn_driver.classify_masc_internal_error classified
-       with
-       | Some (Masc_mcp.Keeper_turn_driver.Oas_timeout_budget budget) ->
-           check int "estimated tokens preserved" 2_000
-             budget.estimated_input_tokens;
-           check string "source preserved" timeout_budget.source budget.source;
-           check (option (float 0.001)) "remaining budget preserved"
-             (Some timeout_budget.remaining_turn_budget_sec)
-             budget.remaining_turn_budget_sec;
-           check string "phase" "cascade_attempt_watchdog" budget.phase
-       | _ -> fail "expected OAS timeout budget classification")
+    let classified =
+      UT.reclassify_oas_timeout_for_attempt ~timeout_budget:(Some timeout_budget) err
+    in
+    (match Masc_mcp.Keeper_turn_driver.classify_masc_internal_error classified with
+     | Some (Masc_mcp.Keeper_turn_driver.Oas_timeout_budget budget) ->
+       check int "estimated tokens preserved" 2_000 budget.estimated_input_tokens;
+       check string "source preserved" timeout_budget.source budget.source;
+       check
+         (option (float 0.001))
+         "remaining budget preserved"
+         (Some timeout_budget.remaining_turn_budget_sec)
+         budget.remaining_turn_budget_sec;
+       check string "phase" "cascade_attempt_watchdog" budget.phase
+     | _ -> fail "expected OAS timeout budget classification")
+;;
 
 let test_pre_retry_timeout_helper_does_not_reuse_stale_budget () =
   let err =
     Agent_sdk.Error.Api
       (Timeout
-         {
-           message =
-             "Turn wall-clock budget exhausted before retry (remaining=2.0s)";
-         })
+         { message = "Turn wall-clock budget exhausted before retry (remaining=2.0s)" })
   in
-  let classified =
-    UT.reclassify_oas_timeout_for_attempt ~timeout_budget:None err
-  in
-  check bool "plain helper call without budget stays raw timeout" true
-    (Option.is_none
-       (Masc_mcp.Keeper_turn_driver.classify_masc_internal_error classified))
+  let classified = UT.reclassify_oas_timeout_for_attempt ~timeout_budget:None err in
+  check
+    bool
+    "plain helper call without budget stays raw timeout"
+    true
+    (Option.is_none (Masc_mcp.Keeper_turn_driver.classify_masc_internal_error classified))
+;;
 
 let oas_timeout_budget_error () =
   Masc_mcp.Keeper_turn_driver.sdk_error_of_masc_internal_error
     (Masc_mcp.Keeper_turn_driver.Oas_timeout_budget
-       {
-         budget_sec = 273.0;
-         keeper_turn_timeout_sec = 1200.0;
-         estimated_input_tokens = 2_000;
-         source = "adaptive_estimated_input_tokens";
-         remaining_turn_budget_sec = Some 600.0;
-         min_required_sec = 15.0;
-         phase = "test_phase";
+       { budget_sec = 273.0
+       ; keeper_turn_timeout_sec = 1200.0
+       ; estimated_input_tokens = 2_000
+       ; source = "adaptive_estimated_input_tokens"
+       ; remaining_turn_budget_sec = Some 600.0
+       ; min_required_sec = 15.0
+       ; phase = "test_phase"
        })
+;;
 
 let test_degraded_retry_budget_gate_allows_remaining_budget () =
   match
@@ -6284,15 +8009,17 @@ let test_degraded_retry_budget_gate_allows_remaining_budget () =
       (oas_timeout_budget_error ())
   with
   | UT.Degraded_retry_allowed retry ->
-      check string "retry cascade" KC.local_recovery_cascade_name
-        retry.next_cascade;
-      check string "fallback reason" "oas_timeout_budget"
-        (EC.degraded_retry_reason_to_string retry.fallback_reason)
+    check string "retry cascade" KC.local_recovery_cascade_name retry.next_cascade;
+    check
+      string
+      "fallback reason"
+      "oas_timeout_budget"
+      (EC.degraded_retry_reason_to_string retry.fallback_reason)
   | UT.Degraded_retry_slot_phase_exhausted _ ->
-      fail "expected productive slot phase budget to remain"
-  | UT.Degraded_retry_budget_exhausted _ ->
-      fail "expected retry budget to remain"
+    fail "expected productive slot phase budget to remain"
+  | UT.Degraded_retry_budget_exhausted _ -> fail "expected retry budget to remain"
   | UT.No_degraded_retry -> fail "expected degraded retry"
+;;
 
 let test_degraded_retry_budget_gate_blocks_exhausted_budget () =
   match
@@ -6307,14 +8034,21 @@ let test_degraded_retry_budget_gate_blocks_exhausted_budget () =
       (oas_timeout_budget_error ())
   with
   | UT.Degraded_retry_budget_exhausted retry ->
-      check string "retry cascade candidate" KC.local_recovery_cascade_name
-        retry.next_cascade;
-      check string "fallback reason" "oas_timeout_budget"
-        (EC.degraded_retry_reason_to_string retry.fallback_reason)
+    check
+      string
+      "retry cascade candidate"
+      KC.local_recovery_cascade_name
+      retry.next_cascade;
+    check
+      string
+      "fallback reason"
+      "oas_timeout_budget"
+      (EC.degraded_retry_reason_to_string retry.fallback_reason)
   | UT.Degraded_retry_slot_phase_exhausted _ ->
-      fail "expected exhausted retry budget, not slot phase budget"
+    fail "expected exhausted retry budget, not slot phase budget"
   | UT.Degraded_retry_allowed _ -> fail "expected exhausted retry budget"
   | UT.No_degraded_retry -> fail "expected recoverable retry candidate"
+;;
 
 let test_degraded_retry_slot_phase_allows_oas_timeout_local_recovery () =
   match
@@ -6330,15 +8064,21 @@ let test_degraded_retry_slot_phase_allows_oas_timeout_local_recovery () =
       (oas_timeout_budget_error ())
   with
   | UT.Degraded_retry_allowed retry ->
-      check string "retry cascade candidate" KC.local_recovery_cascade_name
-        retry.next_cascade;
-      check string "fallback reason" "oas_timeout_budget"
-        (EC.degraded_retry_reason_to_string retry.fallback_reason)
+    check
+      string
+      "retry cascade candidate"
+      KC.local_recovery_cascade_name
+      retry.next_cascade;
+    check
+      string
+      "fallback reason"
+      "oas_timeout_budget"
+      (EC.degraded_retry_reason_to_string retry.fallback_reason)
   | UT.Degraded_retry_slot_phase_exhausted _ ->
-      fail "expected OAS timeout budget to bypass slot phase for local recovery"
-  | UT.Degraded_retry_budget_exhausted _ ->
-      fail "expected retry budget to remain"
+    fail "expected OAS timeout budget to bypass slot phase for local recovery"
+  | UT.Degraded_retry_budget_exhausted _ -> fail "expected retry budget to remain"
   | UT.No_degraded_retry -> fail "expected recoverable retry candidate"
+;;
 
 let test_degraded_retry_slot_phase_allows_first_contract_rotation () =
   match
@@ -6354,15 +8094,17 @@ let test_degraded_retry_slot_phase_allows_first_contract_rotation () =
       (required_tool_contract_violation_error ())
   with
   | UT.Degraded_retry_allowed retry ->
-      check string "retry cascade candidate" (KC.default_cascade_name ())
-        retry.next_cascade;
-      check string "fallback reason" "required_tool_contract_violation"
-        (EC.degraded_retry_reason_to_string retry.fallback_reason)
+    check string "retry cascade candidate" (KC.default_cascade_name ()) retry.next_cascade;
+    check
+      string
+      "fallback reason"
+      "required_tool_contract_violation"
+      (EC.degraded_retry_reason_to_string retry.fallback_reason)
   | UT.Degraded_retry_slot_phase_exhausted _ ->
-      fail "expected first contract rotation to bypass productive slot phase"
-  | UT.Degraded_retry_budget_exhausted _ ->
-      fail "expected retry budget to remain"
+    fail "expected first contract rotation to bypass productive slot phase"
+  | UT.Degraded_retry_budget_exhausted _ -> fail "expected retry budget to remain"
   | UT.No_degraded_retry -> fail "expected recoverable retry candidate"
+;;
 
 (* Regression: GitHub #12675 / RFC #12887 — per-attempt retry budget cap.
    When is_retry=true, the budget resolution must refuse the retry if the
@@ -6381,9 +8123,10 @@ let test_per_attempt_retry_budget_with_near_zero_remaining () =
   with
   | None -> () (* expected: retry is aborted to release the slot cleanly *)
   | Some _ ->
-      fail
-        "is_retry=true must refuse budget when outer turn time spent exceeds \
-         per-attempt cap"
+    fail
+      "is_retry=true must refuse budget when outer turn time spent exceeds per-attempt \
+       cap"
+;;
 
 let test_per_attempt_retry_budget_capped_by_remaining_when_healthy () =
   match
@@ -6397,8 +8140,12 @@ let test_per_attempt_retry_budget_capped_by_remaining_when_healthy () =
   with
   | None -> fail "is_retry=true should resolve with healthy remaining"
   | Some budget ->
-      check bool "effective capped by min(adaptive, remaining)" true
-        (budget.effective_timeout_sec <= 1200.0)
+    check
+      bool
+      "effective capped by min(adaptive, remaining)"
+      true
+      (budget.effective_timeout_sec <= 1200.0)
+;;
 
 let test_per_attempt_retry_blocks_after_adaptive_budget_spent () =
   match
@@ -6411,8 +8158,8 @@ let test_per_attempt_retry_blocks_after_adaptive_budget_spent () =
       ~remaining_turn_budget_s:300.0
   with
   | None -> ()
-  | Some _ ->
-      fail "plain retry should refuse once the adaptive budget was already spent"
+  | Some _ -> fail "plain retry should refuse once the adaptive budget was already spent"
+;;
 
 let test_degraded_retry_wall_clock_budget_allows_remaining_turn_time () =
   match
@@ -6426,10 +8173,13 @@ let test_degraded_retry_wall_clock_budget_allows_remaining_turn_time () =
   with
   | None -> fail "degraded retry should use remaining wall-clock budget"
   | Some budget ->
-      check string "source marks wall-clock retry"
-        "adaptive_wall_clock_retry" budget.source;
-      check (float 0.01) "wall-clock retry leaves finalization guard"
-        285.0 budget.effective_timeout_sec
+    check string "source marks wall-clock retry" "adaptive_wall_clock_retry" budget.source;
+    check
+      (float 0.01)
+      "wall-clock retry leaves finalization guard"
+      285.0
+      budget.effective_timeout_sec
+;;
 
 let test_degraded_retry_wall_clock_budget_gate_is_one_shot () =
   let allowed ~degraded_rotation_first_attempt ~attempt ~attempted_cascades =
@@ -6440,18 +8190,39 @@ let test_degraded_retry_wall_clock_budget_gate_is_one_shot () =
       ~attempted_cascades
   in
   let rotated_cascades = [ "local_recovery"; "underdog" ] in
-  check bool "first degraded rotation attempt may use wall clock" true
-    (allowed ~degraded_rotation_first_attempt:true ~attempt:1
+  check
+    bool
+    "first degraded rotation attempt may use wall clock"
+    true
+    (allowed
+       ~degraded_rotation_first_attempt:true
+       ~attempt:1
        ~attempted_cascades:rotated_cascades);
-  check bool "same-cascade retry after rotation uses per-attempt budget" false
-    (allowed ~degraded_rotation_first_attempt:false ~attempt:2
+  check
+    bool
+    "same-cascade retry after rotation uses per-attempt budget"
+    false
+    (allowed
+       ~degraded_rotation_first_attempt:false
+       ~attempt:2
        ~attempted_cascades:rotated_cascades);
-  check bool "attempt counter still blocks later retries" false
-    (allowed ~degraded_rotation_first_attempt:true ~attempt:2
+  check
+    bool
+    "attempt counter still blocks later retries"
+    false
+    (allowed
+       ~degraded_rotation_first_attempt:true
+       ~attempt:2
        ~attempted_cascades:rotated_cascades);
-  check bool "non-rotated retry cannot use wall clock" false
-    (allowed ~degraded_rotation_first_attempt:true ~attempt:1
+  check
+    bool
+    "non-rotated retry cannot use wall clock"
+    false
+    (allowed
+       ~degraded_rotation_first_attempt:true
+       ~attempt:1
        ~attempted_cascades:[ "underdog" ])
+;;
 
 let test_non_retry_still_refuses_tiny_budget () =
   match
@@ -6464,8 +8235,8 @@ let test_non_retry_still_refuses_tiny_budget () =
       ~remaining_turn_budget_s:20.0
   with
   | None -> ()
-  | Some _ ->
-      fail "is_retry=false should refuse budget when remaining < guard + min"
+  | Some _ -> fail "is_retry=false should refuse budget when remaining < guard + min"
+;;
 
 let test_per_attempt_retry_refuses_zero_remaining () =
   (* Wall-clock gate: a retry with 0.0s remaining would be immediately
@@ -6480,8 +8251,8 @@ let test_per_attempt_retry_refuses_zero_remaining () =
       ~remaining_turn_budget_s:0.0
   with
   | None -> ()
-  | Some _ ->
-      fail "is_retry=true with 0.0s remaining should return None"
+  | Some _ -> fail "is_retry=true with 0.0s remaining should return None"
+;;
 
 let test_degraded_retry_budget_gate_allows_retry_with_tiny_remaining () =
   (* Regression: GitHub #12675 — this simulates the real call-site scenario:
@@ -6506,228 +8277,327 @@ let test_degraded_retry_budget_gate_allows_retry_with_tiny_remaining () =
   with
   | UT.Degraded_retry_budget_exhausted _ -> ()
   | UT.Degraded_retry_allowed _ ->
-      fail "expected retry aborted due to per-attempt cap exceeded"
+    fail "expected retry aborted due to per-attempt cap exceeded"
   | UT.Degraded_retry_slot_phase_exhausted _ ->
-      fail "expected retry budget exhaustion without slot phase input"
+    fail "expected retry budget exhaustion without slot phase input"
   | UT.No_degraded_retry -> fail "expected degraded retry"
+;;
 
 let test_pure_local_labels_detection () =
-  check bool "ollama-only cascade is pure local" true
+  check
+    bool
+    "ollama-only cascade is pure local"
+    true
     (OMR.labels_are_pure_local [ "ollama:qwen3.5:35b-a3b-nvfp4" ]);
-  check bool "mixed cascade is not pure local" false
+  check
+    bool
+    "mixed cascade is not pure local"
+    false
     (OMR.labels_are_pure_local [ "glm:glm-5.1"; "ollama:qwen3.5:35b-a3b-nvfp4" ])
+;;
 
 let test_clamp_context_for_pure_local_labels () =
   let local_floor = Env_config.ContextCompact.small_local_floor in
-  check int "pure local max_context gets capped" local_floor
+  check
+    int
+    "pure local max_context gets capped"
+    local_floor
     (OMR.clamp_context_for_pure_local_labels
        ~labels:[ "ollama:qwen3.5:35b-a3b-nvfp4" ]
        ~max_context:262_144);
-  check int "mixed cascade keeps raw context" 262_144
+  check
+    int
+    "mixed cascade keeps raw context"
+    262_144
     (OMR.clamp_context_for_pure_local_labels
        ~labels:[ "glm:glm-5.1"; "ollama:qwen3.5:35b-a3b-nvfp4" ]
        ~max_context:262_144)
+;;
 
 let test_resolved_max_context_for_turn_uses_primary_budget () =
   let labels = [ "glm:glm-5.1"; "ollama:qwen3.5:35b-a3b-nvfp4" ] in
   let expected = OMR.resolve_primary_max_context labels in
-  check int "turn budget follows primary available model" expected
+  check
+    int
+    "turn budget follows primary available model"
+    expected
     (UT.resolved_max_context_for_turn ~meta:minimal_meta labels)
+;;
 
 let test_max_context_resolution_separates_override_and_effective_budget () =
   let labels = [ "unknown:model" ] in
   let resolution =
-    KEC.resolve_max_context_resolution
-      ~requested_override:(Some 1_000_000) labels
+    KEC.resolve_max_context_resolution ~requested_override:(Some 1_000_000) labels
   in
-  check int "primary budget uses fallback context window"
+  check
+    int
+    "primary budget uses fallback context window"
     Masc_mcp.Cascade_runtime.fallback_context_window
     resolution.primary_budget;
-  check int "turn budget preserves requested override" 1_000_000
-    resolution.turn_budget;
-  check int "effective budget caps to primary budget"
-    resolution.primary_budget resolution.effective_budget
+  check int "turn budget preserves requested override" 1_000_000 resolution.turn_budget;
+  check
+    int
+    "effective budget caps to primary budget"
+    resolution.primary_budget
+    resolution.effective_budget
+;;
 
 let test_resolved_max_context_for_turn_uses_effective_budget () =
   let labels = [ "unknown:model" ] in
   let meta = { minimal_meta with max_context_override = Some 1_000_000 } in
   let resolution =
     KEC.resolve_max_context_resolution
-      ~requested_override:meta.max_context_override labels
+      ~requested_override:meta.max_context_override
+      labels
   in
-  check int "turn dispatch budget is capped to effective budget"
+  check
+    int
+    "turn dispatch budget is capped to effective budget"
     resolution.effective_budget
     (UT.resolved_max_context_for_turn ~meta labels)
+;;
 
 let test_side_effect_reclassification_ignores_keeper_read_only_tools () =
   let original =
-    Agent_sdk.Error.Api
-      (Timeout { message = "Execution cancelled after 300.0s" })
+    Agent_sdk.Error.Api (Timeout { message = "Execution cancelled after 300.0s" })
   in
   let reclassified =
     EC.reclassify_error_after_side_effect
-      ~tool_names:["keeper_tasks_list"; "keeper_memory_search"] original
+      ~tool_names:[ "keeper_tasks_list"; "keeper_memory_search" ]
+      original
   in
-  check bool "read-only keeper tools stay transient" true
+  check
+    bool
+    "read-only keeper tools stay transient"
+    true
     (EC.is_transient_network_error reclassified);
-  check bool "read-only keeper tools are not ambiguous" false
+  check
+    bool
+    "read-only keeper tools are not ambiguous"
+    false
     (EC.is_ambiguous_side_effect_error reclassified)
+;;
 
 let test_side_effect_reclassification_drops_keeper_read_only_tools_from_mixed_set () =
   let original =
-    Agent_sdk.Error.Api
-      (Timeout { message = "Execution cancelled after 300.0s" })
+    Agent_sdk.Error.Api (Timeout { message = "Execution cancelled after 300.0s" })
   in
   let reclassified =
     EC.reclassify_error_after_side_effect
-      ~tool_names:["keeper_tasks_list"; "keeper_fs_edit"; "keeper_memory_search"]
+      ~tool_names:[ "keeper_tasks_list"; "keeper_fs_edit"; "keeper_memory_search" ]
       original
   in
   let rendered = Agent_sdk.Error.to_string reclassified in
-  check bool "mixed set is ambiguous" true
+  check
+    bool
+    "mixed set is ambiguous"
+    true
     (EC.is_ambiguous_side_effect_error reclassified);
-  check bool "keeps mutating tool" true
-    (contains_substring rendered "keeper_fs_edit");
-  check bool "drops tasks_list from ambiguous set" false
+  check bool "keeps mutating tool" true (contains_substring rendered "keeper_fs_edit");
+  check
+    bool
+    "drops tasks_list from ambiguous set"
+    false
     (contains_substring rendered "keeper_tasks_list");
-  check bool "drops memory_search from ambiguous set" false
+  check
+    bool
+    "drops memory_search from ambiguous set"
+    false
     (contains_substring rendered "keeper_memory_search")
+;;
 
 let test_metrics_mixed_response () =
   let result =
-    make_run_result ~text:"Done." ~tools:["keeper_fs_edit"]
-      ~model:"test-model" ~input_tok:150 ~output_tok:60 ()
+    make_run_result
+      ~text:"Done."
+      ~tools:[ "keeper_fs_edit" ]
+      ~model:"test-model"
+      ~input_tok:150
+      ~output_tok:60
+      ()
   in
   let updated =
-    UM.update_metrics_from_result minimal_meta ~latency_ms:300
-      ~observation:base_observation result
+    UM.update_metrics_from_result
+      minimal_meta
+      ~latency_ms:300
+      ~observation:base_observation
+      result
   in
-  check int "proactive +1" (minimal_meta.runtime.proactive_rt.count_total + 1)
+  check
+    int
+    "proactive +1"
+    (minimal_meta.runtime.proactive_rt.count_total + 1)
     updated.runtime.proactive_rt.count_total;
-  check int "proactive visible_count +1"
+  check
+    int
+    "proactive visible_count +1"
     (minimal_meta.runtime.proactive_rt.visible_count_total + 1)
     updated.runtime.proactive_rt.visible_count_total;
-  check bool "proactive outcome mixed" true
+  check
+    bool
+    "proactive outcome mixed"
+    true
     (updated.runtime.proactive_rt.last_outcome
      = Masc_mcp.Keeper_types.Proactive_mixed_response);
-  check int "autonomous +1" (minimal_meta.runtime.autonomous_action_count + 1)
+  check
+    int
+    "autonomous +1"
+    (minimal_meta.runtime.autonomous_action_count + 1)
     updated.runtime.autonomous_action_count;
-  check bool "proactive reason has unified" true
+  check
+    bool
+    "proactive reason has unified"
+    true
     (let found =
-       try ignore (Str.search_forward (Str.regexp_string "unified:tools=") updated.runtime.proactive_rt.last_reason 0); true
-       with Not_found -> false
-     in found)
+       try
+         ignore
+           (Str.search_forward
+              (Str.regexp_string "unified:tools=")
+              updated.runtime.proactive_rt.last_reason
+              0);
+         true
+       with
+       | Not_found -> false
+     in
+     found)
+;;
 
 let test_normalize_response_text_passthrough () =
   match KTD.normalize_response_text ~text:"All good." ~tool_names:[] () with
   | Ok text -> check string "keeps text" "All good." text
   | Error e -> fail ("unexpected error: " ^ e)
+;;
 
 let test_normalize_response_text_tool_only_synthesizes () =
-  match KTD.normalize_response_text
-          ~text:""
-          ~tool_names:["keeper_board_post"; "keeper_board_comment"]
-          ()
+  match
+    KTD.normalize_response_text
+      ~text:""
+      ~tool_names:[ "keeper_board_post"; "keeper_board_comment" ]
+      ()
   with
   | Ok text ->
-      check bool "mentions no textual reply" true
-        (String.length text > 0
-         && String.contains text 'T');
-      check bool "mentions first tool" true
-        (let found =
-           try
-             ignore
-               (Str.search_forward
-                  (Str.regexp_string "keeper_board_post")
-                  text 0);
-             true
-           with Not_found -> false
-         in
-         found)
+    check
+      bool
+      "mentions no textual reply"
+      true
+      (String.length text > 0 && String.contains text 'T');
+    check
+      bool
+      "mentions first tool"
+      true
+      (let found =
+         try
+           ignore (Str.search_forward (Str.regexp_string "keeper_board_post") text 0);
+           true
+         with
+         | Not_found -> false
+       in
+       found)
   | Error e -> fail ("unexpected error: " ^ e)
+;;
 
 let test_normalize_response_text_empty_without_tools_errors () =
   match KTD.normalize_response_text ~text:"" ~tool_names:[] () with
   | Ok text -> fail ("expected error, got: " ^ text)
   | Error e ->
-      check bool "error mentions textual reply" true
-        (let found =
-           try
-             ignore
-               (Str.search_forward
-                  (Str.regexp_string "no textual reply")
-                  e 0);
-             true
-           with Not_found -> false
-         in
-         found)
+    check
+      bool
+      "error mentions textual reply"
+      true
+      (let found =
+         try
+           ignore (Str.search_forward (Str.regexp_string "no textual reply") e 0);
+           true
+         with
+         | Not_found -> false
+       in
+       found)
+;;
 
 let test_validate_completion_contract_allows_text_without_tools () =
   match
-    KTD.validate_completion_contract
-      ~contract:KTD.Allow_text_or_tool
-      ~tool_names:[]
-      ()
+    KTD.validate_completion_contract ~contract:KTD.Allow_text_or_tool ~tool_names:[] ()
   with
   | Ok () -> ()
   | Error e -> fail ("unexpected error: " ^ e)
+;;
 
 let test_validate_completion_contract_requires_tool_use () =
   match
-    KTD.validate_completion_contract
-      ~contract:KTD.Require_tool_use
-      ~tool_names:[]
-      ()
+    KTD.validate_completion_contract ~contract:KTD.Require_tool_use ~tool_names:[] ()
   with
   | Ok () -> fail "expected tool contract failure"
   | Error e ->
-      check bool "error mentions required tool contract" true
-        (contains_substring e "required tool contract")
+    check
+      bool
+      "error mentions required tool contract"
+      true
+      (contains_substring e "required tool contract")
+;;
 
 let test_validate_completion_contract_accepts_stay_silent () =
   match
     KTD.validate_completion_contract
       ~contract:KTD.Require_tool_use
-      ~tool_names:["keeper_stay_silent"]
+      ~tool_names:[ "keeper_stay_silent" ]
       ()
   with
   | Ok () -> ()
   | Error e -> fail ("unexpected error: " ^ e)
+;;
 
 let test_unexpected_tool_names_accepts_keeper_surface () =
-  check (list string) "no unexpected tools" []
+  check
+    (list string)
+    "no unexpected tools"
+    []
     (KTD.unexpected_tool_names
-       ~allowed_tool_names:
-         [ "keeper_task_claim"; "keeper_board_comment"; "extend_turns" ]
+       ~allowed_tool_names:[ "keeper_task_claim"; "keeper_board_comment"; "extend_turns" ]
        ~tool_names:[ "keeper_task_claim"; "extend_turns" ])
+;;
 
 let test_unexpected_tool_names_reports_foreign_surface () =
-  check (list string) "foreign tools flagged"
+  check
+    (list string)
+    "foreign tools flagged"
     [ "Skill"; "Bash"; "Agent" ]
     (KTD.unexpected_tool_names
-       ~allowed_tool_names:
-         [ "keeper_task_claim"; "keeper_board_comment"; "extend_turns" ]
-       ~tool_names:
-         [ "keeper_task_claim"; "Skill"; "Bash"; "Skill"; "Agent" ])
+       ~allowed_tool_names:[ "keeper_task_claim"; "keeper_board_comment"; "extend_turns" ]
+       ~tool_names:[ "keeper_task_claim"; "Skill"; "Bash"; "Skill"; "Agent" ])
+;;
 
 let test_completion_contract_of_tool_choice_allows_auto () =
-  check bool "auto allows text" true
+  check
+    bool
+    "auto allows text"
+    true
     (match KTD.completion_contract_of_tool_choice None with
      | KTD.Allow_text_or_tool -> true
      | KTD.Require_tool_use -> false);
-  check bool "none allows text" true
+  check
+    bool
+    "none allows text"
+    true
     (match KTD.completion_contract_of_tool_choice (Some Agent_sdk.Types.None_) with
      | KTD.Allow_text_or_tool -> true
      | KTD.Require_tool_use -> false)
+;;
 
 let test_completion_contract_of_tool_choice_requires_any () =
-  check bool "any requires tool use" true
+  check
+    bool
+    "any requires tool use"
+    true
     (match KTD.completion_contract_of_tool_choice (Some Agent_sdk.Types.Any) with
      | KTD.Require_tool_use -> true
      | KTD.Allow_text_or_tool -> false)
+;;
 
 let test_run_completion_contract_latches_required_tool_use () =
-  check bool "required tool use stays latched across run" true
+  check
+    bool
+    "required tool use stays latched across run"
+    true
     (match
        KTD.run_completion_contract
          ~turn_contract:KTD.Allow_text_or_tool
@@ -6735,7 +8605,10 @@ let test_run_completion_contract_latches_required_tool_use () =
      with
      | KTD.Require_tool_use -> true
      | KTD.Allow_text_or_tool -> false);
-  check bool "optional stays optional when no required turn seen" true
+  check
+    bool
+    "optional stays optional when no required turn seen"
+    true
     (match
        KTD.run_completion_contract
          ~turn_contract:KTD.Allow_text_or_tool
@@ -6743,6 +8616,7 @@ let test_run_completion_contract_latches_required_tool_use () =
      with
      | KTD.Allow_text_or_tool -> true
      | KTD.Require_tool_use -> false)
+;;
 
 let test_validate_completion_contract_presence_requires_keeper_surface_tool () =
   (match
@@ -6759,8 +8633,12 @@ let test_validate_completion_contract_presence_requires_keeper_surface_tool () =
   with
   | Ok () -> fail "expected keeper-surface contract failure"
   | Error e ->
-    check bool "error mentions keeper-surface tools" true
+    check
+      bool
+      "error mentions keeper-surface tools"
+      true
       (contains_substring e "keeper-surface tools")
+;;
 
 let test_actionable_tool_contract_flags_no_tools () =
   match
@@ -6770,9 +8648,13 @@ let test_actionable_tool_contract_flags_no_tools () =
       ~tool_names:[]
   with
   | Some reason ->
-      check bool "reason mentions no keeper tools" true
-        (contains_substring reason "no keeper tools")
+    check
+      bool
+      "reason mentions no keeper tools"
+      true
+      (contains_substring reason "no keeper tools")
   | None -> fail "expected actionable no-tool violation"
+;;
 
 let test_actionable_tool_contract_flags_passive_only_tools () =
   match
@@ -6782,9 +8664,13 @@ let test_actionable_tool_contract_flags_passive_only_tools () =
       ~tool_names:[ "keeper_board_get"; "masc_status" ]
   with
   | Some reason ->
-      check bool "reason mentions passive tools" true
-        (contains_substring reason "passive status/read tools")
+    check
+      bool
+      "reason mentions passive tools"
+      true
+      (contains_substring reason "passive status/read tools")
   | None -> fail "expected actionable passive-only violation"
+;;
 
 let test_actionable_tool_contract_rejects_claim_context_when_already_claimed () =
   let () =
@@ -6795,15 +8681,22 @@ let test_actionable_tool_contract_rejects_claim_context_when_already_claimed () 
         ~tool_names:[ "keeper_task_claim" ]
     with
     | Some reason ->
-        check bool "reason mentions execution progress" true
-          (contains_substring reason "without execution progress")
+      check
+        bool
+        "reason mentions execution progress"
+        true
+        (contains_substring reason "without execution progress")
     | None -> fail "expected actionable claim-context-only violation"
   in
-  check (option string) "claim context is allowed before ownership" None
+  check
+    (option string)
+    "claim context is allowed before ownership"
+    None
     (KTD.actionable_tool_contract_violation_reason
        ~claim_context_allowed:true
        ~actionable_signal_context:true
        ~tool_names:[ "keeper_task_claim" ])
+;;
 
 let test_actionable_tool_contract_rejects_stay_silent_when_already_claimed () =
   let check_violation label tool_names =
@@ -6814,46 +8707,79 @@ let test_actionable_tool_contract_rejects_stay_silent_when_already_claimed () =
         ~tool_names
     with
     | Some reason ->
-        check bool (label ^ " mentions owned active task") true
-          (contains_substring reason "owned active task");
-        check bool (label ^ " mentions execution progress") true
-          (contains_substring reason "without execution progress")
+      check
+        bool
+        (label ^ " mentions owned active task")
+        true
+        (contains_substring reason "owned active task");
+      check
+        bool
+        (label ^ " mentions execution progress")
+        true
+        (contains_substring reason "without execution progress")
     | None -> fail (label ^ ": expected owned-task silence violation")
   in
   check_violation "stay_silent alone" [ "keeper_stay_silent" ];
-  check_violation "stay_silent plus passive"
+  check_violation
+    "stay_silent plus passive"
     [ "keeper_stay_silent"; "keeper_tasks_list"; "masc_status" ];
-  check_violation "claim plus passive"
-    [ "keeper_task_claim"; "keeper_tasks_list" ];
-  check (option string) "task completion still satisfies owned task" None
+  check_violation "claim plus passive" [ "keeper_task_claim"; "keeper_tasks_list" ];
+  check
+    (option string)
+    "task completion still satisfies owned task"
+    None
     (KTD.actionable_tool_contract_violation_reason
        ~claim_context_allowed:false
        ~actionable_signal_context:true
        ~tool_names:[ "keeper_task_done" ])
+;;
 
 let test_claim_tool_classification_covers_masc_claim_task () =
-  check bool "keeper claim is claim tool" true
+  check
+    bool
+    "keeper claim is claim tool"
+    true
     (KTD.is_claim_tool_name "keeper_task_claim");
-  check bool "masc claim next is claim tool" true
+  check
+    bool
+    "masc claim next is claim tool"
+    true
     (KTD.is_claim_tool_name "masc_claim_next");
-  check bool "masc claim task is claim tool" true
+  check
+    bool
+    "masc claim task is claim tool"
+    true
     (KTD.is_claim_tool_name "masc_claim_task");
-  check bool "task creation is not claim tool" false
+  check
+    bool
+    "task creation is not claim tool"
+    false
     (KTD.is_claim_tool_name "keeper_task_create");
-  check bool "task list is not claim tool" false
+  check
+    bool
+    "task list is not claim tool"
+    false
     (KTD.is_claim_tool_name "keeper_tasks_list")
+;;
 
 let test_actionable_tool_contract_allows_execution_tools () =
-  check (option string) "execution tool satisfies actionable signal" None
+  check
+    (option string)
+    "execution tool satisfies actionable signal"
+    None
     (KTD.actionable_tool_contract_violation_reason
        ~claim_context_allowed:true
        ~actionable_signal_context:true
        ~tool_names:[ "keeper_bash"; "masc_status" ]);
-  check (option string) "non-actionable no-op remains allowed" None
+  check
+    (option string)
+    "non-actionable no-op remains allowed"
+    None
     (KTD.actionable_tool_contract_violation_reason
        ~claim_context_allowed:true
        ~actionable_signal_context:false
        ~tool_names:[])
+;;
 
 let test_stay_silent_requires_typed_no_work_proof_on_actionable_signal () =
   (* keeper_stay_silent has effect_domain=Read_only in tool_catalog but is
@@ -6861,9 +8787,15 @@ let test_stay_silent_requires_typed_no_work_proof_on_actionable_signal () =
      satisfy a plain required-tool contract.  On an actionable world signal,
      however, stay_silent must not close the turn unless the typed observation
      path already proved there is no actionable work. *)
-  check bool "stay_silent satisfies required contract" true
+  check
+    bool
+    "stay_silent satisfies required contract"
+    true
     (KTD.tool_name_can_satisfy_required_contract "keeper_stay_silent");
-  check bool "completion tool set includes stay_silent" true
+  check
+    bool
+    "completion tool set includes stay_silent"
+    true
     (KTD.is_completion_tool_name "keeper_stay_silent");
   (match
      KTD.actionable_tool_contract_violation_reason
@@ -6872,130 +8804,159 @@ let test_stay_silent_requires_typed_no_work_proof_on_actionable_signal () =
        ~tool_names:[ "keeper_stay_silent"; "keeper_tasks_list" ]
    with
    | Some reason ->
-       check bool "reason mentions typed no-work proof" true
-         (contains_substring reason "typed no-work proof")
+     check
+       bool
+       "reason mentions typed no-work proof"
+       true
+       (contains_substring reason "typed no-work proof")
    | None -> fail "expected stay_silent actionable violation");
-  check (option string) "execution plus stay_silent remains accepted" None
+  check
+    (option string)
+    "execution plus stay_silent remains accepted"
+    None
     (KTD.actionable_tool_contract_violation_reason
        ~claim_context_allowed:true
        ~actionable_signal_context:true
        ~tool_names:[ "keeper_board_comment"; "keeper_stay_silent" ]);
-  check (option string) "owned-task progress plus stay_silent remains accepted" None
+  check
+    (option string)
+    "owned-task progress plus stay_silent remains accepted"
+    None
     (KTD.actionable_tool_contract_violation_reason
        ~claim_context_allowed:false
        ~actionable_signal_context:true
        ~tool_names:[ "keeper_bash"; "keeper_stay_silent" ]);
-  check (option string) "non-actionable stay_silent remains allowed" None
+  check
+    (option string)
+    "non-actionable stay_silent remains allowed"
+    None
     (KTD.actionable_tool_contract_violation_reason
        ~claim_context_allowed:true
        ~actionable_signal_context:false
        ~tool_names:[ "keeper_stay_silent" ]);
   (* Without stay_silent, passive-only still violates *)
-  check bool "passive-only still violates" true
+  check
+    bool
+    "passive-only still violates"
+    true
     (Option.is_some
        (KTD.actionable_tool_contract_violation_reason
           ~claim_context_allowed:true
           ~actionable_signal_context:true
           ~tool_names:[ "keeper_tasks_list"; "masc_status" ]))
+;;
 
-let required_tool_call name input
-  : Agent_sdk.Completion_contract.tool_call
-  =
+let required_tool_call name input : Agent_sdk.Completion_contract.tool_call =
   { name; input; tool = None }
+;;
 
 let satisfies_required_tool name input =
-  Result.is_ok
-    (KTD.required_tool_satisfaction (required_tool_call name input))
+  Result.is_ok (KTD.required_tool_satisfaction (required_tool_call name input))
+;;
 
 let satisfies_explicit_required_tool ~required_tool_names name input =
   Result.is_ok
     (KTD.required_tool_satisfaction_for_required_names
        ~required_tool_names
        (required_tool_call name input))
+;;
 
 let test_required_tool_satisfaction_rejects_passive_tools () =
-  check bool "masc_status is passive" false
+  check
+    bool
+    "masc_status is passive"
+    false
     (satisfies_required_tool "masc_status" (`Assoc []));
-  check bool "keeper_tasks_list is passive" false
+  check
+    bool
+    "keeper_tasks_list is passive"
+    false
     (satisfies_required_tool "keeper_tasks_list" (`Assoc []));
   (* keeper_stay_silent is a Completion tool and intentionally satisfies
      the required-tool contract despite its Read_only effect_domain.
      See keeper_tool_disclosure.ml is_completion_tool_name exemption. *)
-  check bool "keeper_stay_silent satisfies as completion" true
+  check
+    bool
+    "keeper_stay_silent satisfies as completion"
+    true
     (satisfies_required_tool "keeper_stay_silent" (`Assoc []));
-  check bool "Read alias is passive" false
-    (satisfies_required_tool "Read" (`Assoc []));
-  check bool "read-only gh shell is passive" false
-    (satisfies_required_tool "keeper_shell"
-       (`Assoc
-          [
-            ("op", `String "gh");
-            ("cmd", `String "pr view 123");
-          ]))
+  check bool "Read alias is passive" false (satisfies_required_tool "Read" (`Assoc []));
+  check
+    bool
+    "read-only gh shell is passive"
+    false
+    (satisfies_required_tool
+       "keeper_shell"
+       (`Assoc [ "op", `String "gh"; "cmd", `String "pr view 123" ]))
+;;
 
 let test_required_tool_satisfaction_accepts_mutating_tools () =
-  check bool "keeper_task_claim mutates" true
+  check
+    bool
+    "keeper_task_claim mutates"
+    true
     (satisfies_required_tool "keeper_task_claim" (`Assoc []));
-  check bool "Write alias mutates" true
-    (satisfies_required_tool "Write" (`Assoc []));
-  check bool "mutating gh shell satisfies" true
-    (satisfies_required_tool "keeper_shell"
-       (`Assoc
-          [
-            ("op", `String "gh");
-            ("cmd", `String "pr comment 123 --body ok");
-          ]))
+  check bool "Write alias mutates" true (satisfies_required_tool "Write" (`Assoc []));
+  check
+    bool
+    "mutating gh shell satisfies"
+    true
+    (satisfies_required_tool
+       "keeper_shell"
+       (`Assoc [ "op", `String "gh"; "cmd", `String "pr comment 123 --body ok" ]))
+;;
 
 let test_explicit_required_tool_satisfaction_accepts_named_passive_tool () =
-  check bool "generic masc_web_search remains passive" false
+  check
+    bool
+    "generic masc_web_search remains passive"
+    false
     (satisfies_required_tool "masc_web_search" (`Assoc []));
-  check bool "explicit masc_web_search satisfies required contract" true
+  check
+    bool
+    "explicit masc_web_search satisfies required contract"
+    true
     (satisfies_explicit_required_tool
        ~required_tool_names:[ "masc_web_search" ]
-       "masc_web_search" (`Assoc []));
-  check bool "explicit required list canonicalizes WebSearch alias" true
+       "masc_web_search"
+       (`Assoc []));
+  check
+    bool
+    "explicit required list canonicalizes WebSearch alias"
+    true
     (satisfies_explicit_required_tool
        ~required_tool_names:[ "masc_web_search" ]
-       "WebSearch" (`Assoc []));
-  check bool "unlisted passive tool still rejected" false
+       "WebSearch"
+       (`Assoc []));
+  check
+    bool
+    "unlisted passive tool still rejected"
+    false
     (satisfies_explicit_required_tool
        ~required_tool_names:[ "keeper_bash" ]
-       "masc_web_search" (`Assoc []))
+       "masc_web_search"
+       (`Assoc []))
+;;
 
 let test_tool_usage_delta_uses_registry_counts () =
-  let before =
-    [
-      ("keeper_board_post", 1);
-      ("keeper_fs_read", 0);
-      ("keeper_voice_agent", 2);
-    ]
-  in
-  let after =
-    [
-      ("keeper_board_post", 1);
-      ("keeper_fs_read", 1);
-      ("keeper_voice_agent", 4);
-    ]
-  in
-  check (list string) "delta tracks repeated calls"
+  let before = [ "keeper_board_post", 1; "keeper_fs_read", 0; "keeper_voice_agent", 2 ] in
+  let after = [ "keeper_board_post", 1; "keeper_fs_read", 1; "keeper_voice_agent", 4 ] in
+  check
+    (list string)
+    "delta tracks repeated calls"
     [ "keeper_fs_read"; "keeper_voice_agent"; "keeper_voice_agent" ]
     (KTD.tool_usage_delta ~before ~after)
+;;
 
 let test_tool_usage_delta_ignores_removed_tools () =
-  let before =
-    [
-      ("keeper_board_post", 2);
-      ("keeper_voice_agent", 1);
-    ]
-  in
-  let after =
-    [
-      ("keeper_board_post", 2);
-    ]
-  in
-  check (list string) "no phantom tools when counts drop"
+  let before = [ "keeper_board_post", 2; "keeper_voice_agent", 1 ] in
+  let after = [ "keeper_board_post", 2 ] in
+  check
+    (list string)
+    "no phantom tools when counts drop"
     []
     (KTD.tool_usage_delta ~before ~after)
+;;
 
 let test_merge_observed_tool_names_prefers_hook_without_double_counting () =
   let merged =
@@ -7004,9 +8965,12 @@ let test_merge_observed_tool_names_prefers_hook_without_double_counting () =
       ~registry_observed_tool_names:
         [ "keeper_bash"; "keeper_pr_create"; "keeper_board_post" ]
   in
-  check (list string) "hook evidence plus registry-only tail"
+  check
+    (list string)
+    "hook evidence plus registry-only tail"
     [ "keeper_bash"; "keeper_pr_create"; "keeper_board_post" ]
     merged
+;;
 
 let test_merge_observed_tool_names_preserves_extra_registry_repeats () =
   let merged =
@@ -7014,9 +8978,12 @@ let test_merge_observed_tool_names_preserves_extra_registry_repeats () =
       ~hook_observed_tool_names:[ "keeper_bash" ]
       ~registry_observed_tool_names:[ "keeper_bash"; "keeper_bash" ]
   in
-  check (list string) "max count per observed source"
+  check
+    (list string)
+    "max count per observed source"
     [ "keeper_bash"; "keeper_bash" ]
     merged
+;;
 
 let test_merge_reported_and_observed_tool_names_preserves_synthetic_tools () =
   let merged =
@@ -7024,9 +8991,12 @@ let test_merge_reported_and_observed_tool_names_preserves_synthetic_tools () =
       ~reported_tool_names:[ "keeper_board_post" ]
       ~observed_tool_names:[ "keeper_voice_agent"; "keeper_voice_agent" ]
   in
-  check (list string) "observed dispatch plus synthetic tool"
+  check
+    (list string)
+    "observed dispatch plus synthetic tool"
     [ "keeper_voice_agent"; "keeper_voice_agent"; "keeper_board_post" ]
     merged
+;;
 
 let test_final_keeper_tool_names_falls_back_to_reported_tool_use () =
   let final_tools =
@@ -7035,185 +9005,302 @@ let test_final_keeper_tool_names_falls_back_to_reported_tool_use () =
       ~observed_tool_names:[]
       ~allowed_tool_names:[ "keeper_task_claim"; "keeper_bash" ]
   in
-  check (list string) "reported keeper tool plus alias preserved"
+  check
+    (list string)
+    "reported keeper tool plus alias preserved"
     [ "keeper_task_claim"; "keeper_bash" ]
     final_tools
+;;
 
 let test_final_keeper_tool_names_accepts_reported_mcp_keeper_tool () =
   let final_tools =
     KTD.final_keeper_tool_names
-      ~reported_tool_names:
-        [ "mcp__masc__masc_board_post"; "list_mcp_resources" ]
+      ~reported_tool_names:[ "mcp__masc__masc_board_post"; "list_mcp_resources" ]
       ~observed_tool_names:[]
       ~allowed_tool_names:[ "keeper_board_post"; "keeper_bash" ]
   in
-  check (list string) "reported MCP keeper tool preserved"
+  check
+    (list string)
+    "reported MCP keeper tool preserved"
     [ "keeper_board_post" ]
     final_tools;
-  check (option string) "reported execution tool satisfies actionable signal" None
+  check
+    (option string)
+    "reported execution tool satisfies actionable signal"
+    None
     (KTD.actionable_tool_contract_violation_reason
        ~claim_context_allowed:true
        ~actionable_signal_context:true
        ~tool_names:final_tools)
+;;
 
 (* prioritized_disclosed_tool_names tests removed: function replaced
    by OAS Tool_selector.select in #5429 boundary cleanup. *)
 
 let test_tool_query_text_of_user_message_strips_continuity_noise () =
   let user_message =
-    "## Current World State\n\n### Namespace State\n- Failed tasks: 5\n\n### Autonomous Trigger\n- Scheduler: scheduled autonomous keepalive turn.\n\n### Continuity\nDONE: 하트비트 갱신\nNEXT: 대기 유지\n\n### Live Worktree Delta\n<git_status_change>\n?? lib/example.ml\n</git_status_change>\n"
+    "## Current World State\n\n\
+     ### Namespace State\n\
+     - Failed tasks: 5\n\n\
+     ### Autonomous Trigger\n\
+     - Scheduler: scheduled autonomous keepalive turn.\n\n\
+     ### Continuity\n\
+     DONE: 하트비트 갱신\n\
+     NEXT: 대기 유지\n\n\
+     ### Live Worktree Delta\n\
+     <git_status_change>\n\
+     ?? lib/example.ml\n\
+     </git_status_change>\n"
   in
   let query = KTD.tool_query_text_of_user_message user_message in
-  check bool "continuity heading stripped" false
+  check
+    bool
+    "continuity heading stripped"
+    false
     (contains_substring query "### Continuity");
-  check bool "heartbeat residue stripped" false
-    (contains_substring query "하트비트 갱신");
-  check bool "autonomous trigger stripped" false
+  check bool "heartbeat residue stripped" false (contains_substring query "하트비트 갱신");
+  check
+    bool
+    "autonomous trigger stripped"
+    false
     (contains_substring query "Autonomous Trigger");
-  check bool "worktree section preserved" true
+  check
+    bool
+    "worktree section preserved"
+    true
     (contains_substring query "Live Worktree Delta")
+;;
 
 let test_tool_query_text_of_user_message_keeps_counted_headers () =
   let obs =
-    {
-      base_observation with
-      pending_mentions = [ ("alice", "please inspect the failures") ];
-      pending_scope_messages = [ ("bob", "recent room update") ];
-      active_goals = [ "goal-1" ];
-      pending_board_events = [ sample_board_event ];
-      failed_task_count = 2;
+    { base_observation with
+      pending_mentions = [ "alice", "please inspect the failures" ]
+    ; pending_scope_messages = [ "bob", "recent room update" ]
+    ; active_goals = [ "goal-1" ]
+    ; pending_board_events = [ sample_board_event ]
+    ; failed_task_count = 2
     }
   in
-  let _sys, user = UP.build_prompt ~base_path:"/test" ~meta:minimal_meta ~observation:obs () in
+  let _sys, user =
+    UP.build_prompt ~base_path:"/test" ~meta:minimal_meta ~observation:obs ()
+  in
   let query = KTD.tool_query_text_of_user_message user in
-  check bool "keeps counted pending mentions header" true
+  check
+    bool
+    "keeps counted pending mentions header"
+    true
     (contains_substring query "### Pending Mentions (1)");
-  check bool "keeps mention content" true
+  check
+    bool
+    "keeps mention content"
+    true
     (contains_substring query "@alice: please inspect the failures");
-  check bool "keeps counted scope messages header" true
+  check
+    bool
+    "keeps counted scope messages header"
+    true
     (contains_substring query "### Scope Messages (1 recent)");
-  check bool "keeps counted active goals header" true
+  check
+    bool
+    "keeps counted active goals header"
+    true
     (contains_substring query "### Active Goals (1)");
-  check bool "keeps counted board activity header" true
+  check
+    bool
+    "keeps counted board activity header"
+    true
     (contains_substring query "### Board Activity (1 new)")
+;;
 
 let test_scope_messages_prompt_caps_payload_not_count () =
   let pending_scope_messages =
     List.init 15 (fun i ->
-      ( Printf.sprintf "agent-%02d" i,
-        Printf.sprintf "message-%02d %s" i (String.make 220 'x') ))
+      ( Printf.sprintf "agent-%02d" i
+      , Printf.sprintf "message-%02d %s" i (String.make 220 'x') ))
   in
   let obs = { base_observation with pending_scope_messages } in
   let _sys, user =
     UP.build_prompt ~base_path:"/test" ~meta:minimal_meta ~observation:obs ()
   in
-  check bool "header keeps real scope message count" true
+  check
+    bool
+    "header keeps real scope message count"
+    true
     (contains_substring user "### Scope Messages (15 recent)");
-  check bool "older scope messages are summarized" true
+  check
+    bool
+    "older scope messages are summarized"
+    true
     (contains_substring user "omitted 3 older scope messages");
-  check bool "oldest omitted message absent" false
-    (contains_substring user "message-00");
-  check bool "newest retained message present" true
-    (contains_substring user "message-14");
-  check bool "long scope message preview capped" false
+  check bool "oldest omitted message absent" false (contains_substring user "message-00");
+  check bool "newest retained message present" true (contains_substring user "message-14");
+  check
+    bool
+    "long scope message preview capped"
+    false
     (contains_substring user (String.make 180 'x'))
+;;
 
 let test_social_model_silences_skip_only_turn () =
   let result =
     make_run_result
       ~text:
-        "SOCIAL_MODEL: bdi_speech_v1\nBELIEF_SUMMARY: quiet_room\nACTIVE_DESIRE: maintain_quiet_readiness\nCURRENT_INTENTION: stay_available_without_noise\nBLOCKER: none\nNEED: none\nSPEECH_ACT: stay_silent\nDELIVERY_SURFACE: silent"
+        "SOCIAL_MODEL: bdi_speech_v1\n\
+         BELIEF_SUMMARY: quiet_room\n\
+         ACTIVE_DESIRE: maintain_quiet_readiness\n\
+         CURRENT_INTENTION: stay_available_without_noise\n\
+         BLOCKER: none\n\
+         NEED: none\n\
+         SPEECH_ACT: stay_silent\n\
+         DELIVERY_SURFACE: silent"
       ~tools:[]
-      ~model:"test-model" ~input_tok:20 ~output_tok:5 ()
+      ~model:"test-model"
+      ~input_tok:20
+      ~output_tok:5
+      ()
   in
   let base_dir = temp_dir () in
   Fun.protect
     ~finally:(fun () -> cleanup_dir base_dir)
     (fun () ->
-      let routed, state, _ =
-        KSM.apply_to_result ~meta:minimal_meta
-          ~observation:base_observation ~previous_state:None result
-      in
-      check string "speech act" "stay_silent"
-        (KSM.speech_act_to_string state.speech_act);
-      check string "delivery surface" "silent"
-        (KSM.delivery_surface_to_string state.delivery_surface);
-      check string "visible response suppressed" "" routed.response_text;
-      check (list string) "no synthetic tools" [] routed.tools_used)
+       let routed, state, _ =
+         KSM.apply_to_result
+           ~meta:minimal_meta
+           ~observation:base_observation
+           ~previous_state:None
+           result
+       in
+       check string "speech act" "stay_silent" (KSM.speech_act_to_string state.speech_act);
+       check
+         string
+         "delivery surface"
+         "silent"
+         (KSM.delivery_surface_to_string state.delivery_surface);
+       check string "visible response suppressed" "" routed.response_text;
+       check (list string) "no synthetic tools" [] routed.tools_used)
+;;
 
 let test_social_model_unknown_meta_falls_back_to_baseline () =
   let meta = { minimal_meta with social_model = "experimental_v99" } in
   let result =
-    make_run_result ~text:"I can respond normally." ~tools:[]
-      ~model:"test-model" ~input_tok:20 ~output_tok:5 ()
+    make_run_result
+      ~text:"I can respond normally."
+      ~tools:[]
+      ~model:"test-model"
+      ~input_tok:20
+      ~output_tok:5
+      ()
   in
   let routed, state, _ =
-    KSM.apply_to_result ~meta ~observation:base_observation
-      ~previous_state:None result
+    KSM.apply_to_result ~meta ~observation:base_observation ~previous_state:None result
   in
-  check string "unknown meta model falls back to baseline"
-    "bdi_speech_v1" state.social_model;
-  check string "visible response preserved"
-    "I can respond normally." routed.response_text
+  check
+    string
+    "unknown meta model falls back to baseline"
+    "bdi_speech_v1"
+    state.social_model;
+  check string "visible response preserved" "I can respond normally." routed.response_text
+;;
 
 let test_social_model_unknown_header_falls_back_to_baseline () =
   let result =
     make_run_result
       ~text:
-        "SOCIAL_MODEL: experimental_v99\nBELIEF_SUMMARY: quiet_room\nACTIVE_DESIRE: maintain_quiet_readiness\nCURRENT_INTENTION: stay_available_without_noise\nBLOCKER: none\nNEED: none\nSPEECH_ACT: stay_silent\nDELIVERY_SURFACE: silent"
+        "SOCIAL_MODEL: experimental_v99\n\
+         BELIEF_SUMMARY: quiet_room\n\
+         ACTIVE_DESIRE: maintain_quiet_readiness\n\
+         CURRENT_INTENTION: stay_available_without_noise\n\
+         BLOCKER: none\n\
+         NEED: none\n\
+         SPEECH_ACT: stay_silent\n\
+         DELIVERY_SURFACE: silent"
       ~tools:[]
-      ~model:"test-model" ~input_tok:20 ~output_tok:5 ()
+      ~model:"test-model"
+      ~input_tok:20
+      ~output_tok:5
+      ()
   in
   let routed, state, _ =
-    KSM.apply_to_result ~meta:minimal_meta
-      ~observation:base_observation ~previous_state:None result
+    KSM.apply_to_result
+      ~meta:minimal_meta
+      ~observation:base_observation
+      ~previous_state:None
+      result
   in
-  check string "unknown header model falls back to baseline"
-    "bdi_speech_v1" state.social_model;
+  check
+    string
+    "unknown header model falls back to baseline"
+    "bdi_speech_v1"
+    state.social_model;
   check string "visible response suppressed" "" routed.response_text
+;;
 
 let test_social_model_infers_visible_reply_without_headers () =
   let result =
-    make_run_result ~text:"I think I should ask for help." ~tools:[]
-      ~model:"test-model" ~input_tok:20 ~output_tok:5 ()
+    make_run_result
+      ~text:"I think I should ask for help."
+      ~tools:[]
+      ~model:"test-model"
+      ~input_tok:20
+      ~output_tok:5
+      ()
   in
   let base_dir = temp_dir () in
   Fun.protect
     ~finally:(fun () -> cleanup_dir base_dir)
     (fun () ->
-      let routed, state, _ =
-        KSM.apply_to_result ~meta:minimal_meta
-          ~observation:base_observation ~previous_state:None result
-      in
-      check string "speech act" "inform"
-        (KSM.speech_act_to_string state.speech_act);
-      check string "delivery surface" "visible_reply"
-        (KSM.delivery_surface_to_string state.delivery_surface);
-      check (option string) "no blocker persisted" None state.blocker;
-      check string "visible response preserved"
-        "I think I should ask for help." routed.response_text;
-      check (list string) "no synthetic tools" [] routed.tools_used)
+       let routed, state, _ =
+         KSM.apply_to_result
+           ~meta:minimal_meta
+           ~observation:base_observation
+           ~previous_state:None
+           result
+       in
+       check string "speech act" "inform" (KSM.speech_act_to_string state.speech_act);
+       check
+         string
+         "delivery surface"
+         "visible_reply"
+         (KSM.delivery_surface_to_string state.delivery_surface);
+       check (option string) "no blocker persisted" None state.blocker;
+       check
+         string
+         "visible response preserved"
+         "I think I should ask for help."
+         routed.response_text;
+       check (list string) "no synthetic tools" [] routed.tools_used)
+;;
 
 let test_social_model_empty_text_without_headers_stays_silent () =
   let result =
-    make_run_result ~text:"" ~tools:[]
-      ~model:"test-model" ~input_tok:20 ~output_tok:5 ()
+    make_run_result ~text:"" ~tools:[] ~model:"test-model" ~input_tok:20 ~output_tok:5 ()
   in
   let routed, state, transition_reason =
-    KSM.apply_to_result ~meta:minimal_meta
-      ~observation:base_observation ~previous_state:None result
+    KSM.apply_to_result
+      ~meta:minimal_meta
+      ~observation:base_observation
+      ~previous_state:None
+      result
   in
-  check string "speech act" "defer"
-    (KSM.speech_act_to_string state.speech_act);
-  check string "delivery surface" "silent"
+  check string "speech act" "defer" (KSM.speech_act_to_string state.speech_act);
+  check
+    string
+    "delivery surface"
+    "silent"
     (KSM.delivery_surface_to_string state.delivery_surface);
-  check (option string) "blocker notes empty protocol violation"
-    (Some "no tool calls and no social headers") state.blocker;
-  check string "transition reason"
+  check
+    (option string)
+    "blocker notes empty protocol violation"
+    (Some "no tool calls and no social headers")
+    state.blocker;
+  check
+    string
+    "transition reason"
     "protocol_violation:no_tool_calls_and_no_social_headers"
     (KSM.transition_reason_to_string transition_reason);
   check string "visible response suppressed" "" routed.response_text;
   check (list string) "no synthetic tools" [] routed.tools_used
+;;
 
 let test_social_model_state_only_reply_stays_silent () =
   let result =
@@ -7221,535 +9308,828 @@ let test_social_model_state_only_reply_stays_silent () =
       ~text:
         "[STATE]\nGoal: keep things tidy\nProgress: no visible response needed\n[/STATE]"
       ~tools:[]
-      ~model:"test-model" ~input_tok:20 ~output_tok:5 ()
+      ~model:"test-model"
+      ~input_tok:20
+      ~output_tok:5
+      ()
   in
   let routed, state, _ =
-    KSM.apply_to_result ~meta:minimal_meta
-      ~observation:base_observation ~previous_state:None result
+    KSM.apply_to_result
+      ~meta:minimal_meta
+      ~observation:base_observation
+      ~previous_state:None
+      result
   in
-  check string "speech act" "defer"
-    (KSM.speech_act_to_string state.speech_act);
-  check string "delivery surface" "silent"
+  check string "speech act" "defer" (KSM.speech_act_to_string state.speech_act);
+  check
+    string
+    "delivery surface"
+    "silent"
     (KSM.delivery_surface_to_string state.delivery_surface);
   check string "visible response suppressed" "" routed.response_text
+;;
 
 let test_social_model_strips_state_block_from_visible_reply () =
   let result =
     make_run_result
       ~text:
-        "Board checked.\n[STATE]\nGoal: keep things tidy\nProgress: board scanned\n[/STATE]"
+        "Board checked.\n\
+         [STATE]\n\
+         Goal: keep things tidy\n\
+         Progress: board scanned\n\
+         [/STATE]"
       ~tools:[]
-      ~model:"test-model" ~input_tok:20 ~output_tok:5 ()
+      ~model:"test-model"
+      ~input_tok:20
+      ~output_tok:5
+      ()
   in
   let routed, state, _ =
-    KSM.apply_to_result ~meta:minimal_meta
-      ~observation:base_observation ~previous_state:None result
+    KSM.apply_to_result
+      ~meta:minimal_meta
+      ~observation:base_observation
+      ~previous_state:None
+      result
   in
-  check string "speech act" "inform"
-    (KSM.speech_act_to_string state.speech_act);
-  check string "delivery surface" "visible_reply"
+  check string "speech act" "inform" (KSM.speech_act_to_string state.speech_act);
+  check
+    string
+    "delivery surface"
+    "visible_reply"
     (KSM.delivery_surface_to_string state.delivery_surface);
-  check string "visible response strips state block"
-    "Board checked."
-    routed.response_text
+  check string "visible response strips state block" "Board checked." routed.response_text
+;;
 
 let test_social_model_routes_blocker_to_board_post () =
   let result =
     make_run_result
       ~text:
-        "SOCIAL_MODEL: bdi_speech_v1\nBELIEF_SUMMARY: quiet_room\nACTIVE_DESIRE: seek_help\nCURRENT_INTENTION: recover_tool_route\nBLOCKER: tool route unavailable\nNEED: tool route or operator guidance\nSPEECH_ACT: request_help\nDELIVERY_SURFACE: board_post"
+        "SOCIAL_MODEL: bdi_speech_v1\n\
+         BELIEF_SUMMARY: quiet_room\n\
+         ACTIVE_DESIRE: seek_help\n\
+         CURRENT_INTENTION: recover_tool_route\n\
+         BLOCKER: tool route unavailable\n\
+         NEED: tool route or operator guidance\n\
+         SPEECH_ACT: request_help\n\
+         DELIVERY_SURFACE: board_post"
       ~tools:[]
-      ~model:"test-model" ~input_tok:30 ~output_tok:10 ()
+      ~model:"test-model"
+      ~input_tok:30
+      ~output_tok:10
+      ()
   in
   let base_dir = temp_dir () in
   Fun.protect
     ~finally:(fun () -> cleanup_dir base_dir)
     (fun () ->
-      Eio_main.run @@ fun env ->
-      Fs_compat.set_fs (Eio.Stdenv.fs env);
-      Unix.putenv "MASC_BASE_PATH" base_dir;
-      Masc_mcp.Board.reset_global_for_test ();
-      Masc_mcp.Board_dispatch.reset_for_test ();
-      Masc_mcp.Board_dispatch.init_jsonl ();
-      let config = Masc_mcp.Coord.default_config base_dir in
-      ignore (Masc_mcp.Coord.init config ~agent_name:(Some "observer"));
-      let routed, state, _ =
-        KSM.apply_to_result ~meta:minimal_meta
-          ~observation:base_observation ~previous_state:None result
-      in
-      let posts =
-        Masc_mcp.Board_dispatch.list_posts
-          ~sort_by:Masc_mcp.Board_dispatch.Recent ~limit:10 ()
-      in
-      check string "speech act" "request_help"
-        (KSM.speech_act_to_string state.speech_act);
-      check string "delivery surface" "board_post"
-        (KSM.delivery_surface_to_string state.delivery_surface);
-      check string "response suppressed after routing" "" routed.response_text;
-      check bool "synthetic board tool recorded" true
-        (List.mem "keeper_board_post" routed.tools_used);
-      check int "one board post created" 1 (List.length posts);
-      match posts with
-      | [ post ] ->
-          check string "post author" minimal_meta.name
-            (Masc_mcp.Board.Agent_id.to_string post.author);
-          check bool "post body mentions blocker" true
-            (contains_substring post.body "blocked")
-      | _ -> fail "expected one request-help board post")
+       Eio_main.run
+       @@ fun env ->
+       Fs_compat.set_fs (Eio.Stdenv.fs env);
+       Unix.putenv "MASC_BASE_PATH" base_dir;
+       Masc_mcp.Board.reset_global_for_test ();
+       Masc_mcp.Board_dispatch.reset_for_test ();
+       Masc_mcp.Board_dispatch.init_jsonl ();
+       let config = Masc_mcp.Coord.default_config base_dir in
+       ignore (Masc_mcp.Coord.init config ~agent_name:(Some "observer"));
+       let routed, state, _ =
+         KSM.apply_to_result
+           ~meta:minimal_meta
+           ~observation:base_observation
+           ~previous_state:None
+           result
+       in
+       let posts =
+         Masc_mcp.Board_dispatch.list_posts
+           ~sort_by:Masc_mcp.Board_dispatch.Recent
+           ~limit:10
+           ()
+       in
+       check
+         string
+         "speech act"
+         "request_help"
+         (KSM.speech_act_to_string state.speech_act);
+       check
+         string
+         "delivery surface"
+         "board_post"
+         (KSM.delivery_surface_to_string state.delivery_surface);
+       check string "response suppressed after routing" "" routed.response_text;
+       check
+         bool
+         "synthetic board tool recorded"
+         true
+         (List.mem "keeper_board_post" routed.tools_used);
+       check int "one board post created" 1 (List.length posts);
+       match posts with
+       | [ post ] ->
+         check
+           string
+           "post author"
+           minimal_meta.name
+           (Masc_mcp.Board.Agent_id.to_string post.author);
+         check
+           bool
+           "post body mentions blocker"
+           true
+           (contains_substring post.body "blocked")
+       | _ -> fail "expected one request-help board post")
+;;
 
 let test_social_model_tool_only_turn_skips_protocol_violation () =
   let result =
-    make_run_result ~text:"" ~tools:["masc_status"]
-      ~model:"test-model" ~input_tok:10 ~output_tok:1 ()
+    make_run_result
+      ~text:""
+      ~tools:[ "masc_status" ]
+      ~model:"test-model"
+      ~input_tok:10
+      ~output_tok:1
+      ()
   in
   let routed, state, transition_reason =
-    KSM.apply_to_result ~meta:minimal_meta
-      ~observation:base_observation ~previous_state:None result
+    KSM.apply_to_result
+      ~meta:minimal_meta
+      ~observation:base_observation
+      ~previous_state:None
+      result
   in
-  check string "speech act" "inform"
-    (KSM.speech_act_to_string state.speech_act);
-  check string "delivery surface" "visible_reply"
+  check string "speech act" "inform" (KSM.speech_act_to_string state.speech_act);
+  check
+    string
+    "delivery surface"
+    "visible_reply"
     (KSM.delivery_surface_to_string state.delivery_surface);
   check (option string) "no protocol violation blocker" None state.blocker;
-  check string "transition reason" "tool_only:visible_reply"
+  check
+    string
+    "transition reason"
+    "tool_only:visible_reply"
     (KSM.transition_reason_to_string transition_reason);
-  check bool "tool-only turn synthesizes visible response" true
+  check
+    bool
+    "tool-only turn synthesizes visible response"
+    true
     (contains_substring routed.response_text "Tools used: masc_status.");
-  check (list string) "tool list preserved" ["masc_status"] routed.tools_used
+  check (list string) "tool list preserved" [ "masc_status" ] routed.tools_used
+;;
 
 let test_social_model_previous_state_of_meta_restores_runtime_fields () =
   let meta =
-    {
-      minimal_meta with
+    { minimal_meta with
       runtime =
-        {
-          minimal_meta.runtime with
-          last_speech_act = "request_help";
-          last_social_transition_reason = "headers:explicit_social_headers";
-          last_active_desire = "seek_help";
-          last_current_intention = "recover_tool_route";
-          last_blocker =
+        { minimal_meta.runtime with
+          last_speech_act = "request_help"
+        ; last_social_transition_reason = "headers:explicit_social_headers"
+        ; last_active_desire = "seek_help"
+        ; last_current_intention = "recover_tool_route"
+        ; last_blocker =
             Some
               (Keeper_types.blocker_info_of_class
                  ~detail:"tool route unavailable"
-                 Keeper_types.No_tool_capable_provider);
-          last_need = "operator guidance";
-        };
+                 Keeper_types.No_tool_capable_provider)
+        ; last_need = "operator guidance"
+        }
     }
   in
   match KSM.previous_state_of_meta meta with
   | None -> fail "expected previous social state"
   | Some state ->
-      check string "social model restored" "bdi_speech_v1" state.social_model;
-      check (option string) "active desire restored"
-        (Some "seek_help") state.active_desire;
-      check (option string) "current intention restored"
-        (Some "recover_tool_route") state.current_intention;
-      check (option string) "blocker restored"
-        (Some "tool route unavailable") state.blocker;
-      check (option string) "need restored"
-        (Some "operator guidance") state.need;
-      check string "speech act restored" "request_help"
-        (KSM.speech_act_to_string state.speech_act);
-      check string "delivery surface inferred from speech act" "board_post"
-        (KSM.delivery_surface_to_string state.delivery_surface)
+    check string "social model restored" "bdi_speech_v1" state.social_model;
+    check (option string) "active desire restored" (Some "seek_help") state.active_desire;
+    check
+      (option string)
+      "current intention restored"
+      (Some "recover_tool_route")
+      state.current_intention;
+    check (option string) "blocker restored" (Some "tool route unavailable") state.blocker;
+    check (option string) "need restored" (Some "operator guidance") state.need;
+    check
+      string
+      "speech act restored"
+      "request_help"
+      (KSM.speech_act_to_string state.speech_act);
+    check
+      string
+      "delivery surface inferred from speech act"
+      "board_post"
+      (KSM.delivery_surface_to_string state.delivery_surface)
+;;
 
 let test_social_model_tool_only_turn_carries_previous_state () =
   let result =
-    make_run_result ~text:"" ~tools:["masc_status"]
-      ~model:"test-model" ~input_tok:10 ~output_tok:1 ()
+    make_run_result
+      ~text:""
+      ~tools:[ "masc_status" ]
+      ~model:"test-model"
+      ~input_tok:10
+      ~output_tok:1
+      ()
   in
   let previous_state =
     Some
       KSM.
-        {
-          social_model = "bdi_speech_v1";
-          belief_summary = "mentions=1";
-          active_desire = Some "seek_help";
-          current_intention = Some "recover_tool_route";
-          blocker = Some "tool route unavailable";
-          need = Some "operator guidance";
-          speech_act = Request_help;
-          delivery_surface = Board_post;
+        { social_model = "bdi_speech_v1"
+        ; belief_summary = "mentions=1"
+        ; active_desire = Some "seek_help"
+        ; current_intention = Some "recover_tool_route"
+        ; blocker = Some "tool route unavailable"
+        ; need = Some "operator guidance"
+        ; speech_act = Request_help
+        ; delivery_surface = Board_post
         }
   in
   let routed, state, _ =
-    KSM.apply_to_result ~meta:minimal_meta
-      ~observation:base_observation ~previous_state result
+    KSM.apply_to_result
+      ~meta:minimal_meta
+      ~observation:base_observation
+      ~previous_state
+      result
   in
-  check string "speech act becomes inform for tool-only turn" "inform"
+  check
+    string
+    "speech act becomes inform for tool-only turn"
+    "inform"
     (KSM.speech_act_to_string state.speech_act);
-  check (option string) "active desire carried"
-    (Some "seek_help") state.active_desire;
-  check (option string) "current intention carried"
-    (Some "recover_tool_route") state.current_intention;
-  check (option string) "need carried"
-    (Some "operator guidance") state.need;
-  check (option string) "blocker not carried into tool-only turn" None
-    state.blocker;
-  check bool "tool-only response still synthesized" true
+  check (option string) "active desire carried" (Some "seek_help") state.active_desire;
+  check
+    (option string)
+    "current intention carried"
+    (Some "recover_tool_route")
+    state.current_intention;
+  check (option string) "need carried" (Some "operator guidance") state.need;
+  check (option string) "blocker not carried into tool-only turn" None state.blocker;
+  check
+    bool
+    "tool-only response still synthesized"
+    true
     (contains_substring routed.response_text "Tools used: masc_status.");
-  check (list string) "tool list preserved" ["masc_status"] routed.tools_used
+  check (list string) "tool list preserved" [ "masc_status" ] routed.tools_used
+;;
 
 let test_social_model_infers_board_comment_from_tool_use () =
   let result =
-    make_run_result ~text:"" ~tools:["keeper_board_comment"; "masc_status"]
-      ~model:"test-model" ~input_tok:10 ~output_tok:1 ()
+    make_run_result
+      ~text:""
+      ~tools:[ "keeper_board_comment"; "masc_status" ]
+      ~model:"test-model"
+      ~input_tok:10
+      ~output_tok:1
+      ()
   in
   let routed, state, transition_reason =
-    KSM.apply_to_result ~meta:minimal_meta
-      ~observation:base_observation ~previous_state:None result
+    KSM.apply_to_result
+      ~meta:minimal_meta
+      ~observation:base_observation
+      ~previous_state:None
+      result
   in
-  check string "speech act" "comment_board"
-    (KSM.speech_act_to_string state.speech_act);
-  check string "delivery surface" "board_comment"
+  check string "speech act" "comment_board" (KSM.speech_act_to_string state.speech_act);
+  check
+    string
+    "delivery surface"
+    "board_comment"
     (KSM.delivery_surface_to_string state.delivery_surface);
   check (option string) "no protocol violation blocker" None state.blocker;
-  check string "transition reason" "tool_only:comment_board"
+  check
+    string
+    "transition reason"
+    "tool_only:comment_board"
     (KSM.transition_reason_to_string transition_reason);
-  check bool "tool turn keeps synthesized visible response" true
-    (contains_substring routed.response_text
+  check
+    bool
+    "tool turn keeps synthesized visible response"
+    true
+    (contains_substring
+       routed.response_text
        "Tools used: keeper_board_comment, masc_status.");
-  check (list string) "tool list preserved"
-    ["keeper_board_comment"; "masc_status"] routed.tools_used
+  check
+    (list string)
+    "tool list preserved"
+    [ "keeper_board_comment"; "masc_status" ]
+    routed.tools_used
+;;
 
 let test_social_model_does_not_infer_comment_vote_as_board_comment () =
   let result =
-    make_run_result ~text:""
-      ~tools:["keeper_board_comment_vote"; "masc_status"]
-      ~model:"test-model" ~input_tok:10 ~output_tok:1 ()
+    make_run_result
+      ~text:""
+      ~tools:[ "keeper_board_comment_vote"; "masc_status" ]
+      ~model:"test-model"
+      ~input_tok:10
+      ~output_tok:1
+      ()
   in
   let routed, state, transition_reason =
-    KSM.apply_to_result ~meta:minimal_meta
-      ~observation:base_observation ~previous_state:None result
+    KSM.apply_to_result
+      ~meta:minimal_meta
+      ~observation:base_observation
+      ~previous_state:None
+      result
   in
-  check string "speech act" "inform"
-    (KSM.speech_act_to_string state.speech_act);
-  check string "delivery surface" "visible_reply"
+  check string "speech act" "inform" (KSM.speech_act_to_string state.speech_act);
+  check
+    string
+    "delivery surface"
+    "visible_reply"
     (KSM.delivery_surface_to_string state.delivery_surface);
-  check string "transition reason" "tool_only:visible_reply"
+  check
+    string
+    "transition reason"
+    "tool_only:visible_reply"
     (KSM.transition_reason_to_string transition_reason);
-  check bool "tool-only turn synthesizes visible response" true
-    (contains_substring routed.response_text
+  check
+    bool
+    "tool-only turn synthesizes visible response"
+    true
+    (contains_substring
+       routed.response_text
        "Tools used: keeper_board_comment_vote, masc_status.");
-  check (list string) "tool list preserved"
-    ["keeper_board_comment_vote"; "masc_status"] routed.tools_used
+  check
+    (list string)
+    "tool list preserved"
+    [ "keeper_board_comment_vote"; "masc_status" ]
+    routed.tools_used
+;;
 
 let test_social_model_infers_masc_claim_task_from_tool_use () =
   let result =
-    make_run_result ~text:"" ~tools:["masc_claim_task"]
-      ~model:"test-model" ~input_tok:10 ~output_tok:1 ()
+    make_run_result
+      ~text:""
+      ~tools:[ "masc_claim_task" ]
+      ~model:"test-model"
+      ~input_tok:10
+      ~output_tok:1
+      ()
   in
   let routed, state, transition_reason =
-    KSM.apply_to_result ~meta:minimal_meta
-      ~observation:base_observation ~previous_state:None result
+    KSM.apply_to_result
+      ~meta:minimal_meta
+      ~observation:base_observation
+      ~previous_state:None
+      result
   in
-  check string "speech act" "claim_task"
-    (KSM.speech_act_to_string state.speech_act);
-  check string "delivery surface" "task_claim"
+  check string "speech act" "claim_task" (KSM.speech_act_to_string state.speech_act);
+  check
+    string
+    "delivery surface"
+    "task_claim"
     (KSM.delivery_surface_to_string state.delivery_surface);
-  check string "transition reason" "tool_only:claim_task"
+  check
+    string
+    "transition reason"
+    "tool_only:claim_task"
     (KSM.transition_reason_to_string transition_reason);
-  check (list string) "tool list preserved" ["masc_claim_task"]
-    routed.tools_used
+  check (list string) "tool list preserved" [ "masc_claim_task" ] routed.tools_used
+;;
 
 let test_social_model_magentic_ledger_silences_tool_only_turn () =
   let meta = { minimal_meta with social_model = "magentic_ledger_v1" } in
   let result =
-    make_run_result ~text:"" ~tools:["masc_status"]
-      ~model:"test-model" ~input_tok:10 ~output_tok:1 ()
+    make_run_result
+      ~text:""
+      ~tools:[ "masc_status" ]
+      ~model:"test-model"
+      ~input_tok:10
+      ~output_tok:1
+      ()
   in
   let routed, state, transition_reason =
-    KSM.apply_to_result ~meta ~observation:base_observation
-      ~previous_state:None result
+    KSM.apply_to_result ~meta ~observation:base_observation ~previous_state:None result
   in
   check string "social model" "magentic_ledger_v1" state.social_model;
-  check string "speech act" "stay_silent"
-    (KSM.speech_act_to_string state.speech_act);
-  check string "delivery surface" "silent"
+  check string "speech act" "stay_silent" (KSM.speech_act_to_string state.speech_act);
+  check
+    string
+    "delivery surface"
+    "silent"
     (KSM.delivery_surface_to_string state.delivery_surface);
-  check (option string) "active desire reflects progress ledger"
-    (Some "advance_task_progress") state.active_desire;
-  check (option string) "current intention tracks evidence"
-    (Some "record_progress_evidence") state.current_intention;
-  check string "transition reason" "tool_only:progress_ledger"
+  check
+    (option string)
+    "active desire reflects progress ledger"
+    (Some "advance_task_progress")
+    state.active_desire;
+  check
+    (option string)
+    "current intention tracks evidence"
+    (Some "record_progress_evidence")
+    state.current_intention;
+  check
+    string
+    "transition reason"
+    "tool_only:progress_ledger"
     (KSM.transition_reason_to_string transition_reason);
-  check bool "belief summary is ledger shaped" true
+  check
+    bool
+    "belief summary is ledger shaped"
+    true
     (contains_substring state.belief_summary "ledger:phase=advancing");
   check string "visible response suppressed" "" routed.response_text;
-  check (list string) "tool list preserved" ["masc_status"] routed.tools_used
+  check (list string) "tool list preserved" [ "masc_status" ] routed.tools_used
+;;
 
 let test_social_model_magentic_ledger_tracks_masc_claim_task () =
   let meta = { minimal_meta with social_model = "magentic_ledger_v1" } in
   let result =
-    make_run_result ~text:"" ~tools:["masc_claim_task"]
-      ~model:"test-model" ~input_tok:10 ~output_tok:1 ()
+    make_run_result
+      ~text:""
+      ~tools:[ "masc_claim_task" ]
+      ~model:"test-model"
+      ~input_tok:10
+      ~output_tok:1
+      ()
   in
   let routed, state, transition_reason =
-    KSM.apply_to_result ~meta ~observation:base_observation
-      ~previous_state:None result
+    KSM.apply_to_result ~meta ~observation:base_observation ~previous_state:None result
   in
   check string "social model" "magentic_ledger_v1" state.social_model;
-  check (option string) "current intention tracks claim"
-    (Some "capture_next_task") state.current_intention;
-  check string "transition reason" "tool_only:claim_task"
+  check
+    (option string)
+    "current intention tracks claim"
+    (Some "capture_next_task")
+    state.current_intention;
+  check
+    string
+    "transition reason"
+    "tool_only:claim_task"
     (KSM.transition_reason_to_string transition_reason);
   check string "visible response suppressed" "" routed.response_text;
-  check (list string) "tool list preserved" ["masc_claim_task"]
-    routed.tools_used
+  check (list string) "tool list preserved" [ "masc_claim_task" ] routed.tools_used
+;;
 
 let test_social_model_magentic_ledger_hides_nonvisible_tool_text () =
   let meta = { minimal_meta with social_model = "magentic_ledger_v1" } in
   let result =
-    make_run_result ~text:"" ~tools:["keeper_board_comment"; "masc_status"]
-      ~model:"test-model" ~input_tok:10 ~output_tok:1 ()
+    make_run_result
+      ~text:""
+      ~tools:[ "keeper_board_comment"; "masc_status" ]
+      ~model:"test-model"
+      ~input_tok:10
+      ~output_tok:1
+      ()
   in
   let routed, state, transition_reason =
-    KSM.apply_to_result ~meta ~observation:base_observation
-      ~previous_state:None result
+    KSM.apply_to_result ~meta ~observation:base_observation ~previous_state:None result
   in
   check string "social model" "magentic_ledger_v1" state.social_model;
-  check string "speech act" "comment_board"
-    (KSM.speech_act_to_string state.speech_act);
-  check string "delivery surface" "board_comment"
+  check string "speech act" "comment_board" (KSM.speech_act_to_string state.speech_act);
+  check
+    string
+    "delivery surface"
+    "board_comment"
     (KSM.delivery_surface_to_string state.delivery_surface);
-  check string "transition reason preserved" "tool_only:comment_board"
+  check
+    string
+    "transition reason preserved"
+    "tool_only:comment_board"
     (KSM.transition_reason_to_string transition_reason);
-  check string "non-visible tool turn does not synthesize text" ""
-    routed.response_text;
-  check (list string) "tool list preserved"
-    ["keeper_board_comment"; "masc_status"] routed.tools_used
+  check string "non-visible tool turn does not synthesize text" "" routed.response_text;
+  check
+    (list string)
+    "tool list preserved"
+    [ "keeper_board_comment"; "masc_status" ]
+    routed.tools_used
+;;
 
-let test_social_model_magentic_ledger_previous_state_of_meta_restores_model ()
-    =
+let test_social_model_magentic_ledger_previous_state_of_meta_restores_model () =
   let meta =
-    {
-      minimal_meta with
-      social_model = "magentic_ledger_v1";
-      runtime =
-        {
-          minimal_meta.runtime with
-          last_speech_act = "inform";
-          last_active_desire = "advance_task_progress";
-          last_current_intention = "record_progress_evidence";
-        };
+    { minimal_meta with
+      social_model = "magentic_ledger_v1"
+    ; runtime =
+        { minimal_meta.runtime with
+          last_speech_act = "inform"
+        ; last_active_desire = "advance_task_progress"
+        ; last_current_intention = "record_progress_evidence"
+        }
     }
   in
   match KSM.previous_state_of_meta meta with
   | None -> fail "expected previous social state"
   | Some state ->
-      check string "social model restored" "magentic_ledger_v1"
-        state.social_model;
-      check string "speech act restored" "inform"
-        (KSM.speech_act_to_string state.speech_act)
+    check string "social model restored" "magentic_ledger_v1" state.social_model;
+    check
+      string
+      "speech act restored"
+      "inform"
+      (KSM.speech_act_to_string state.speech_act)
+;;
 
 let test_social_model_previous_state_of_meta_falls_back_for_unknown_model () =
   let meta =
-    {
-      minimal_meta with
-      social_model = "experimental_v99";
-      runtime =
-        {
-          minimal_meta.runtime with
-          last_speech_act = "request_help";
-          last_active_desire = "seek_help";
-          last_current_intention = "recover_tool_route";
-          last_blocker =
+    { minimal_meta with
+      social_model = "experimental_v99"
+    ; runtime =
+        { minimal_meta.runtime with
+          last_speech_act = "request_help"
+        ; last_active_desire = "seek_help"
+        ; last_current_intention = "recover_tool_route"
+        ; last_blocker =
             Some
               (Keeper_types.blocker_info_of_class
                  ~detail:"tool route unavailable"
-                 Keeper_types.No_tool_capable_provider);
-          last_need = "operator guidance";
-        };
+                 Keeper_types.No_tool_capable_provider)
+        ; last_need = "operator guidance"
+        }
     }
   in
   match KSM.previous_state_of_meta meta with
   | None -> fail "expected fallback previous social state"
   | Some state ->
-      check string "unknown model falls back to default" "bdi_speech_v1"
-        state.social_model;
-      check string "speech act restored under fallback" "request_help"
-        (KSM.speech_act_to_string state.speech_act);
-      check string "delivery surface inferred under fallback" "board_post"
-        (KSM.delivery_surface_to_string state.delivery_surface)
+    check string "unknown model falls back to default" "bdi_speech_v1" state.social_model;
+    check
+      string
+      "speech act restored under fallback"
+      "request_help"
+      (KSM.speech_act_to_string state.speech_act);
+    check
+      string
+      "delivery surface inferred under fallback"
+      "board_post"
+      (KSM.delivery_surface_to_string state.delivery_surface)
+;;
 
 let test_social_model_bdi_failure_state_rewrites_claim_retry_loop () =
   let observation =
-    {
-      base_observation with
-      unclaimed_task_count = 12;
-      claimable_task_count = 12;
-    }
+    { base_observation with unclaimed_task_count = 12; claimable_task_count = 12 }
   in
   let previous_state =
     Some
       KSM.
-        {
-          social_model = "bdi_speech_v1";
-          belief_summary = "unclaimed_tasks=12; idle=406s";
-          active_desire = Some "claim_next_task";
-          current_intention = Some "keeper_task_claim {}";
-          blocker = None;
-          need = Some "available task";
-          speech_act = Inform;
-          delivery_surface = Visible_reply;
+        { social_model = "bdi_speech_v1"
+        ; belief_summary = "unclaimed_tasks=12; idle=406s"
+        ; active_desire = Some "claim_next_task"
+        ; current_intention = Some "keeper_task_claim {}"
+        ; blocker = None
+        ; need = Some "available task"
+        ; speech_act = Inform
+        ; delivery_surface = Visible_reply
         }
   in
   let state, transition_reason =
-    KSM.derive_failure_state ~meta:minimal_meta ~observation ~previous_state
+    KSM.derive_failure_state
+      ~meta:minimal_meta
+      ~observation
+      ~previous_state
       ~is_auto_recoverable:true
       ~sdk_error:None
       ~reason:
-        "Internal error: [masc_oas_error] {\"kind\":\"cascade_exhausted\",\"cascade_name\":\"tool_use_strict\"}"
+        "Internal error: [masc_oas_error] \
+         {\"kind\":\"cascade_exhausted\",\"cascade_name\":\"tool_use_strict\"}"
   in
-  check string "transition reason" "failure:run_error"
+  check
+    string
+    "transition reason"
+    "failure:run_error"
     (KSM.transition_reason_to_string transition_reason);
-  check string "speech act stays defer" "defer"
+  check
+    string
+    "speech act stays defer"
+    "defer"
     (KSM.speech_act_to_string state.speech_act);
-  check string "delivery surface stays silent" "silent"
+  check
+    string
+    "delivery surface stays silent"
+    "silent"
     (KSM.delivery_surface_to_string state.delivery_surface);
-  check (option string) "active desire rewrites to route recovery"
-    (Some "recover_tool_route") state.active_desire;
-  check (option string) "stale claim intention is replaced"
-    (Some "retry_claim_after_recovery") state.current_intention;
-  check (option string) "need requests recovery guidance"
-    (Some "provider_recovery_or_operator_guidance") state.need;
-  check bool "blocker keeps failure detail" true
+  check
+    (option string)
+    "active desire rewrites to route recovery"
+    (Some "recover_tool_route")
+    state.active_desire;
+  check
+    (option string)
+    "stale claim intention is replaced"
+    (Some "retry_claim_after_recovery")
+    state.current_intention;
+  check
+    (option string)
+    "need requests recovery guidance"
+    (Some "provider_recovery_or_operator_guidance")
+    state.need;
+  check
+    bool
+    "blocker keeps failure detail"
+    true
     (match state.blocker with
-    | Some blocker -> contains_substring blocker "cascade_exhausted"
-    | None -> false)
+     | Some blocker -> contains_substring blocker "cascade_exhausted"
+     | None -> false)
+;;
 
 let test_social_model_required_tool_failure_requests_help () =
   let state, transition_reason =
-    KSM.derive_failure_state ~meta:minimal_meta ~observation:base_observation
-      ~previous_state:None ~is_auto_recoverable:false
+    KSM.derive_failure_state
+      ~meta:minimal_meta
+      ~observation:base_observation
+      ~previous_state:None
+      ~is_auto_recoverable:false
       ~sdk_error:(Some (required_tool_contract_violation_error ()))
       ~reason:
-        "Completion contract [require_tool_use] violated: actionable keeper \
-         signal was present, but the model called no keeper tools"
+        "Completion contract [require_tool_use] violated: actionable keeper signal was \
+         present, but the model called no keeper tools"
   in
-  check string "transition reason" "failure:run_error"
+  check
+    string
+    "transition reason"
+    "failure:run_error"
     (KSM.transition_reason_to_string transition_reason);
-  check string "speech act requests help" "request_help"
+  check
+    string
+    "speech act requests help"
+    "request_help"
     (KSM.speech_act_to_string state.speech_act);
-  check string "delivery surface is operator-visible board post" "board_post"
+  check
+    string
+    "delivery surface is operator-visible board post"
+    "board_post"
     (KSM.delivery_surface_to_string state.delivery_surface);
-  check (option string) "active desire recovers route"
-    (Some "recover_tool_route") state.active_desire;
-  check (option string) "intention surfaces blocker"
-    (Some "surface_required_tool_blocker") state.current_intention;
-  check (option string) "need names route recovery"
-    (Some "operator_guidance_or_tool_capable_route") state.need;
-  check bool "blocker keeps contract detail" true
+  check
+    (option string)
+    "active desire recovers route"
+    (Some "recover_tool_route")
+    state.active_desire;
+  check
+    (option string)
+    "intention surfaces blocker"
+    (Some "surface_required_tool_blocker")
+    state.current_intention;
+  check
+    (option string)
+    "need names route recovery"
+    (Some "operator_guidance_or_tool_capable_route")
+    state.need;
+  check
+    bool
+    "blocker keeps contract detail"
+    true
     (match state.blocker with
-    | Some blocker -> contains_substring blocker "require_tool_use"
-    | None -> false)
+     | Some blocker -> contains_substring blocker "require_tool_use"
+     | None -> false)
+;;
 
-let test_social_model_bdi_failure_state_keeps_existing_carry_without_claim_context
-    () =
+let test_social_model_bdi_failure_state_keeps_existing_carry_without_claim_context () =
   let previous_state =
     Some
       KSM.
-        {
-          social_model = "bdi_speech_v1";
-          belief_summary = "mentions=1";
-          active_desire = Some "seek_help";
-          current_intention = Some "recover_tool_route";
-          blocker = Some "tool route unavailable";
-          need = Some "operator guidance";
-          speech_act = Request_help;
-          delivery_surface = Board_post;
+        { social_model = "bdi_speech_v1"
+        ; belief_summary = "mentions=1"
+        ; active_desire = Some "seek_help"
+        ; current_intention = Some "recover_tool_route"
+        ; blocker = Some "tool route unavailable"
+        ; need = Some "operator guidance"
+        ; speech_act = Request_help
+        ; delivery_surface = Board_post
         }
   in
   let state, _ =
-    KSM.derive_failure_state ~meta:minimal_meta ~observation:base_observation
-      ~previous_state ~is_auto_recoverable:false
+    KSM.derive_failure_state
+      ~meta:minimal_meta
+      ~observation:base_observation
+      ~previous_state
+      ~is_auto_recoverable:false
       ~sdk_error:None
       ~reason:"local config error"
   in
-  check (option string) "active desire still carries on ordinary failure"
-    (Some "seek_help") state.active_desire;
-  check (option string) "current intention still carries on ordinary failure"
-    (Some "recover_tool_route") state.current_intention;
-  check (option string) "need still carries on ordinary failure"
-    (Some "operator guidance") state.need
+  check
+    (option string)
+    "active desire still carries on ordinary failure"
+    (Some "seek_help")
+    state.active_desire;
+  check
+    (option string)
+    "current intention still carries on ordinary failure"
+    (Some "recover_tool_route")
+    state.current_intention;
+  check
+    (option string)
+    "need still carries on ordinary failure"
+    (Some "operator guidance")
+    state.need
+;;
 
 let test_social_model_magentic_ledger_stalled_state_carries_until_delta () =
   let meta = { minimal_meta with social_model = "magentic_ledger_v1" } in
   let previous_state =
     Some
-      {
-        KSM.social_model = "magentic_ledger_v1";
-        belief_summary = "ledger:phase=stalled; event=goal_idle_timeout";
-        active_desire = Some "recover_forward_motion";
-        current_intention = Some "request_replan";
-        blocker = Some "stalled_without_progress_evidence";
-        need = Some "fresh_plan_or_external_delta";
-        speech_act = KSM.Stay_silent;
-        delivery_surface = KSM.Silent;
+      { KSM.social_model = "magentic_ledger_v1"
+      ; belief_summary = "ledger:phase=stalled; event=goal_idle_timeout"
+      ; active_desire = Some "recover_forward_motion"
+      ; current_intention = Some "request_replan"
+      ; blocker = Some "stalled_without_progress_evidence"
+      ; need = Some "fresh_plan_or_external_delta"
+      ; speech_act = KSM.Stay_silent
+      ; delivery_surface = KSM.Silent
       }
   in
   let observation =
     { base_observation with active_goals = [ "goal-1" ]; idle_seconds = 0 }
   in
   let result =
-    make_run_result ~text:"" ~tools:[]
-      ~model:"test-model" ~input_tok:10 ~output_tok:1 ()
+    make_run_result ~text:"" ~tools:[] ~model:"test-model" ~input_tok:10 ~output_tok:1 ()
   in
-  let _, state, _ =
-    KSM.apply_to_result ~meta ~observation ~previous_state result
-  in
-  check (option string) "stalled desire carried" (Some "recover_forward_motion")
+  let _, state, _ = KSM.apply_to_result ~meta ~observation ~previous_state result in
+  check
+    (option string)
+    "stalled desire carried"
+    (Some "recover_forward_motion")
     state.active_desire;
-  check (option string) "stalled intention carried" (Some "request_replan")
+  check
+    (option string)
+    "stalled intention carried"
+    (Some "request_replan")
     state.current_intention;
-  check bool "belief summary remains stalled" true
+  check
+    bool
+    "belief summary remains stalled"
+    true
     (contains_substring state.belief_summary "ledger:phase=stalled")
+;;
 
 let test_keeper_allowed_tools_exclude_heartbeat () =
   let allowed =
     Masc_mcp.Keeper_exec_tools.keeper_allowed_tool_names minimal_policy_meta
   in
-  check bool "masc_heartbeat hidden from keeper tool surface" false
+  check
+    bool
+    "masc_heartbeat hidden from keeper tool surface"
+    false
     (List.mem "masc_heartbeat" allowed)
+;;
 
 let test_should_require_tools_for_initial_turn_matches_first_turn_gate () =
   let affordances = [ "task_claim"; "board_post_or_comment" ] in
-  check bool "single-turn call reserves final turn without forcing strict lane" false
+  check
+    bool
+    "single-turn call reserves final turn without forcing strict lane"
+    false
     (KAR.should_require_tools_for_initial_turn ~max_turns:1 ~turn_affordances:affordances);
-  check bool "two-turn call can require initial tools" true
+  check
+    bool
+    "two-turn call can require initial tools"
+    true
     (KAR.should_require_tools_for_initial_turn ~max_turns:2 ~turn_affordances:affordances);
-  check bool "two-turn board action can require initial tools" true
-    (KAR.should_require_tools_for_initial_turn ~max_turns:2
+  check
+    bool
+    "two-turn board action can require initial tools"
+    true
+    (KAR.should_require_tools_for_initial_turn
+       ~max_turns:2
        ~turn_affordances:[ "board_post_or_comment" ]);
-  check bool "two-turn board curation can require initial tools" true
-    (KAR.should_require_tools_for_initial_turn ~max_turns:2
+  check
+    bool
+    "two-turn board curation can require initial tools"
+    true
+    (KAR.should_require_tools_for_initial_turn
+       ~max_turns:2
        ~turn_affordances:[ "board_curation" ]);
-  check bool "three-turn call can require initial tools" true
+  check
+    bool
+    "three-turn call can require initial tools"
+    true
     (KAR.should_require_tools_for_initial_turn ~max_turns:3 ~turn_affordances:affordances);
-  check bool "pending verification requires an action tool" true
-    (KAR.should_require_tools_for_initial_turn ~max_turns:3
+  check
+    bool
+    "pending verification requires an action tool"
+    true
+    (KAR.should_require_tools_for_initial_turn
+       ~max_turns:3
        ~turn_affordances:[ "task_verify" ]);
-  check bool "timer-only work discovery stays optional" false
-    (KAR.should_require_tools_for_initial_turn ~max_turns:3
+  check
+    bool
+    "timer-only work discovery stays optional"
+    false
+    (KAR.should_require_tools_for_initial_turn
+       ~max_turns:3
        ~turn_affordances:[ "work_discovery" ]);
-  check bool "worktree delta inspection requires an action tool" true
-    (KAR.should_require_tools_for_initial_turn ~max_turns:3
+  check
+    bool
+    "worktree delta inspection requires an action tool"
+    true
+    (KAR.should_require_tools_for_initial_turn
+       ~max_turns:3
        ~turn_affordances:[ "inspect_worktree_delta" ]);
-  check bool "no tool-required affordance stays optional" false
-    (KAR.should_require_tools_for_initial_turn ~max_turns:3 ~turn_affordances:[ "observe" ])
+  check
+    bool
+    "no tool-required affordance stays optional"
+    false
+    (KAR.should_require_tools_for_initial_turn
+       ~max_turns:3
+       ~turn_affordances:[ "observe" ])
+;;
 
 let test_should_require_tools_for_initial_turn_covers_actionable_affordances () =
   let require affordance =
-    KAR.should_require_tools_for_initial_turn ~max_turns:2
+    KAR.should_require_tools_for_initial_turn
+      ~max_turns:2
       ~turn_affordances:[ affordance ]
   in
   check bool "reply requires tool gate" true (require "reply_in_room");
   check bool "verification requires tool gate" true (require "task_verify");
-  check bool "board curation requires tool gate" true
-    (require "board_curation");
-  check bool "worktree inspection requires tool gate" true
+  check bool "board curation requires tool gate" true (require "board_curation");
+  check
+    bool
+    "worktree inspection requires tool gate"
+    true
     (require "inspect_worktree_delta")
+;;
 
 let test_turn_affordances_require_tool_gate_with_allowed_filters_by_tool () =
   (* P1: an affordance must have a matching tool in the keeper's
@@ -7758,122 +10138,173 @@ let test_turn_affordances_require_tool_gate_with_allowed_filters_by_tool () =
      satisfy the demanded action class. *)
   let gate ~tools affordances =
     KAR.turn_affordances_require_tool_gate_with_allowed
-      ~allowed_tool_names:tools affordances
+      ~allowed_tool_names:tools
+      affordances
   in
-  check bool
-    "task_claim affordance with claim tool present -> gate fires" true
+  check
+    bool
+    "task_claim affordance with claim tool present -> gate fires"
+    true
     (gate ~tools:[ "keeper_task_claim" ] [ "task_claim" ]);
-  check bool
-    "task_claim affordance without any claim tool -> gate suppressed" false
-    (gate ~tools:[ "keeper_board_post"; "keeper_context_status" ]
-       [ "task_claim" ]);
-  check bool
-    "board_post_or_comment with comment tool -> gate fires" true
+  check
+    bool
+    "task_claim affordance without any claim tool -> gate suppressed"
+    false
+    (gate ~tools:[ "keeper_board_post"; "keeper_context_status" ] [ "task_claim" ]);
+  check
+    bool
+    "board_post_or_comment with comment tool -> gate fires"
+    true
     (gate ~tools:[ "keeper_board_comment" ] [ "board_post_or_comment" ]);
-  check bool
-    "board_post_or_comment without any post tool -> gate suppressed" false
-    (gate ~tools:[ "keeper_task_claim"; "keeper_tasks_list" ]
-       [ "board_post_or_comment" ]);
-  check bool
-    "board_curation with submit tool -> gate fires" true
+  check
+    bool
+    "board_post_or_comment without any post tool -> gate suppressed"
+    false
+    (gate ~tools:[ "keeper_task_claim"; "keeper_tasks_list" ] [ "board_post_or_comment" ]);
+  check
+    bool
+    "board_curation with submit tool -> gate fires"
+    true
     (gate ~tools:[ "keeper_board_curation_submit" ] [ "board_curation" ]);
-  check bool
-    "board_curation without submit tool -> gate suppressed" false
-    (gate ~tools:[ "keeper_board_post"; "keeper_board_comment" ]
-       [ "board_curation" ]);
-  check bool
-    "any matching affordance is enough" true
+  check
+    bool
+    "board_curation without submit tool -> gate suppressed"
+    false
+    (gate ~tools:[ "keeper_board_post"; "keeper_board_comment" ] [ "board_curation" ]);
+  check
+    bool
+    "any matching affordance is enough"
+    true
     (gate
        ~tools:[ "masc_claim_next" ]
        [ "task_claim"; "task_audit"; "board_post_or_comment" ]);
-  check bool
-    "task_audit with only passive audit/list tools -> gate suppressed" false
-    (gate ~tools:[ "keeper_tasks_audit"; "keeper_tasks_list" ]
-       [ "task_audit" ]);
-  check bool
-    "task_verify with only passive task list -> gate suppressed" false
+  check
+    bool
+    "task_audit with only passive audit/list tools -> gate suppressed"
+    false
+    (gate ~tools:[ "keeper_tasks_audit"; "keeper_tasks_list" ] [ "task_audit" ]);
+  check
+    bool
+    "task_verify with only passive task list -> gate suppressed"
+    false
     (gate ~tools:[ "keeper_tasks_list" ] [ "task_verify" ]);
-  check bool
-    "task_verify with submit tool -> gate fires" true
+  check
+    bool
+    "task_verify with submit tool -> gate fires"
+    true
     (gate ~tools:[ "keeper_task_submit_for_verification" ] [ "task_verify" ]);
-  check bool
+  check
+    bool
     "timer-only work_discovery does not hard-gate even with progress tools"
     false
-    (gate ~tools:[ "keeper_board_post"; "keeper_task_create" ]
-       [ "work_discovery" ]);
-  check bool
-    "work_discovery can accompany another concrete gated affordance" true
+    (gate ~tools:[ "keeper_board_post"; "keeper_task_create" ] [ "work_discovery" ]);
+  check
+    bool
+    "work_discovery can accompany another concrete gated affordance"
+    true
     (gate ~tools:[ "keeper_task_claim" ] [ "work_discovery"; "task_claim" ]);
-  check bool
-    "all gated affordances missing tools -> gate suppressed" false
+  check
+    bool
+    "all gated affordances missing tools -> gate suppressed"
+    false
     (gate
        ~tools:[ "keeper_context_status"; "keeper_time_now" ]
        [ "task_claim"; "task_verify"; "board_post_or_comment" ]);
-  check bool "empty affordances -> gate stays off" false
+  check
+    bool
+    "empty affordances -> gate stays off"
+    false
     (gate ~tools:[ "keeper_task_claim" ] []);
-  check bool
-    "unknown affordance string is ignored" false
+  check
+    bool
+    "unknown affordance string is ignored"
+    false
     (gate ~tools:[ "keeper_task_claim" ] [ "totally_unknown_affordance" ])
+;;
 
 let test_turn_affordance_gate_suppression_metric () =
   let metric affordance =
     Masc_mcp.Prometheus.metric_value_or_zero
       Masc_mcp.Keeper_metrics.metric_keeper_required_tool_gate_suppressed_total
-      ~labels:[ ("affordance", affordance) ]
+      ~labels:[ "affordance", affordance ]
       ()
   in
   let gate ~tools affordances =
     KAR.turn_affordances_require_tool_gate_with_allowed
-      ~record_suppression_metric:true ~allowed_tool_names:tools affordances
+      ~record_suppression_metric:true
+      ~allowed_tool_names:tools
+      affordances
   in
   let verify_before = metric "task_verify" in
   let unknown_before = metric "totally_unknown_affordance" in
-  check bool "passive task_verify list tool suppresses gate" false
+  check
+    bool
+    "passive task_verify list tool suppresses gate"
+    false
     (gate ~tools:[ "keeper_tasks_list" ] [ "task_verify" ]);
-  check (float 0.0) "task_verify suppression increments metric"
+  check
+    (float 0.0)
+    "task_verify suppression increments metric"
     (verify_before +. 1.0)
     (metric "task_verify");
-  check (float 0.0) "unknown affordance does not create metric label"
+  check
+    (float 0.0)
+    "unknown affordance does not create metric label"
     unknown_before
     (metric "totally_unknown_affordance");
   let claim_before = metric "task_claim" in
-  check bool "claim tool present keeps gate active" true
+  check
+    bool
+    "claim tool present keeps gate active"
+    true
     (gate ~tools:[ "keeper_task_claim" ] [ "task_claim" ]);
-  check (float 0.0) "successful gate does not increment suppression metric"
+  check
+    (float 0.0)
+    "successful gate does not increment suppression metric"
     claim_before
     (metric "task_claim")
+;;
 
 let test_required_gate_surface_removes_passive_distractions () =
   let module Surface = Masc_mcp.Keeper_agent_tool_surface in
-  check (list string)
+  check
+    (list string)
     "required gate keeps actionable tools only"
     [ "keeper_task_claim"; "keeper_board_post" ]
     (Surface.tool_names_for_required_gate_surface
        ~tool_gate_requested:true
        ~required_tool_names:[]
-       [ "keeper_tasks_list"; "keeper_task_claim"; "keeper_stay_silent";
-         "keeper_board_post"; "masc_status" ]);
-  check (list string)
+       [ "keeper_tasks_list"
+       ; "keeper_task_claim"
+       ; "keeper_stay_silent"
+       ; "keeper_board_post"
+       ; "masc_status"
+       ]);
+  check
+    (list string)
     "optional turn keeps passive tools visible"
     [ "keeper_tasks_list"; "keeper_board_post" ]
     (Surface.tool_names_for_required_gate_surface
        ~tool_gate_requested:false
        ~required_tool_names:[]
        [ "keeper_tasks_list"; "keeper_board_post" ]);
-  check (list string)
+  check
+    (list string)
     "passive-only surface remains unchanged when no action exists"
     [ "keeper_tasks_list"; "masc_status" ]
     (Surface.tool_names_for_required_gate_surface
        ~tool_gate_requested:true
        ~required_tool_names:[]
        [ "keeper_tasks_list"; "masc_status" ]);
-  check (list string)
+  check
+    (list string)
     "explicit read-only required tool survives required gate"
     [ "masc_web_search"; "keeper_board_post" ]
     (Surface.tool_names_for_required_gate_surface
        ~tool_gate_requested:true
        ~required_tool_names:[ "masc_web_search" ]
        [ "keeper_tasks_list"; "masc_web_search"; "keeper_board_post" ])
+;;
 
 let test_tools_for_gated_affordance_covers_each_variant () =
   (* Compile-time exhaustiveness already ensures every variant is
@@ -7889,12 +10320,16 @@ let test_tools_for_gated_affordance_covers_each_variant () =
   in
   let nonempty label affordance =
     let tools = Surface.tools_for_gated_affordance affordance in
-    check bool
+    check
+      bool
       (Printf.sprintf "tools_for_gated_affordance non-empty for %s" label)
-      true (tools <> []);
-    check (list string)
+      true
+      (tools <> []);
+    check
+      (list string)
       (Printf.sprintf "tools_for_gated_affordance known tools for %s" label)
-      [] (List.filter (fun name -> not (known_tool_name name)) tools)
+      []
+      (List.filter (fun name -> not (known_tool_name name)) tools)
   in
   nonempty "Board_curation" Surface.Board_curation;
   nonempty "Board_post_or_comment" Surface.Board_post_or_comment;
@@ -7905,62 +10340,70 @@ let test_tools_for_gated_affordance_covers_each_variant () =
   nonempty "Task_verify" Surface.Task_verify;
   nonempty "Work_discovery" Surface.Work_discovery;
   nonempty "Inspect_worktree_delta" Surface.Inspect_worktree_delta;
-  check (list string)
+  check
+    (list string)
     "board_curation force-includes submit tool"
     [ "keeper_board_curation_submit" ]
     (Surface.preferred_tool_names_for_turn_affordances
        [ "board_curation"; "task_claim"; "board_curation" ]);
-  check (list string)
+  check
+    (list string)
     "generic board affordance has no forced specific tool"
     []
-    (Surface.preferred_tool_names_for_turn_affordances
-       [ "board_post_or_comment" ]);
-  check bool "work discovery includes keeper-native task creation" true
-    (List.mem "keeper_task_create"
+    (Surface.preferred_tool_names_for_turn_affordances [ "board_post_or_comment" ]);
+  check
+    bool
+    "work discovery includes keeper-native task creation"
+    true
+    (List.mem
+       "keeper_task_create"
        (Surface.tools_for_gated_affordance Surface.Work_discovery))
+;;
 
 let test_preferred_tool_choice_for_required_turn_claims_first () =
   let module Surface = Masc_mcp.Keeper_agent_tool_surface in
-  let choose ?(has_current_task = false) ?(turn_affordances = [ "task_claim" ])
-      ?(allowed_tool_names =
-        [ "keeper_task_claim"; "keeper_tasks_list"; "keeper_board_post" ])
-      () =
-    KAR.preferred_tool_choice_for_required_turn ~has_current_task
-      ~turn_affordances ~allowed_tool_names
+  let choose
+        ?(has_current_task = false)
+        ?(turn_affordances = [ "task_claim" ])
+        ?(allowed_tool_names =
+          [ "keeper_task_claim"; "keeper_tasks_list"; "keeper_board_post" ])
+        ()
+    =
+    KAR.preferred_tool_choice_for_required_turn
+      ~has_current_task
+      ~turn_affordances
+      ~allowed_tool_names
   in
   (match choose () with
    | Agent_sdk.Types.Tool name ->
-       check string "forces claim tool first" "keeper_task_claim" name
+     check string "forces claim tool first" "keeper_task_claim" name
    | other ->
-       fail
-         (Printf.sprintf "expected Tool keeper_task_claim, got %s"
-            (Agent_sdk.Types.show_tool_choice other)));
+     fail
+       (Printf.sprintf
+          "expected Tool keeper_task_claim, got %s"
+          (Agent_sdk.Types.show_tool_choice other)));
   (match choose ~has_current_task:true () with
    | Agent_sdk.Types.Any -> ()
    | other ->
-       fail
-         (Printf.sprintf
-            "expected Any when already owning work, got %s"
-            (Agent_sdk.Types.show_tool_choice other)));
+     fail
+       (Printf.sprintf
+          "expected Any when already owning work, got %s"
+          (Agent_sdk.Types.show_tool_choice other)));
   (* Board curation is the most specific action for a due curation
      window, so prefer the submit tool over generic board/task tools. *)
   (match
      choose
        ~turn_affordances:[ "board_curation"; "task_claim" ]
        ~allowed_tool_names:
-         [
-           "keeper_board_curation_submit";
-           "keeper_task_claim";
-           "keeper_board_post";
-         ]
+         [ "keeper_board_curation_submit"; "keeper_task_claim"; "keeper_board_post" ]
        ()
    with
    | Agent_sdk.Types.Any -> ()
    | other ->
-       fail
-         (Printf.sprintf
-            "expected Any for board curation required turn, got %s"
-            (Agent_sdk.Types.show_tool_choice other)));
+     fail
+       (Printf.sprintf
+          "expected Any for board curation required turn, got %s"
+          (Agent_sdk.Types.show_tool_choice other)));
   (match
      choose
        ~turn_affordances:[ "board_curation" ]
@@ -7969,11 +10412,10 @@ let test_preferred_tool_choice_for_required_turn_claims_first () =
    with
    | Agent_sdk.Types.Auto -> ()
    | other ->
-       fail
-         (Printf.sprintf
-            "expected Auto when curation submit is unavailable and keeper is idle, \
-             got %s"
-            (Agent_sdk.Types.show_tool_choice other)));
+     fail
+       (Printf.sprintf
+          "expected Auto when curation submit is unavailable and keeper is idle, got %s"
+          (Agent_sdk.Types.show_tool_choice other)));
   (* #10008: when no specific tool is applicable for the current
      affordance, fall back to [Auto] so the model can respond with
      honest refusal text ("no eligible task to claim") instead of
@@ -7986,10 +10428,10 @@ let test_preferred_tool_choice_for_required_turn_claims_first () =
    with
    | Agent_sdk.Types.Auto -> ()
    | other ->
-       fail
-         (Printf.sprintf
-            "expected Auto for task audit with passive audit tool, got %s"
-            (Agent_sdk.Types.show_tool_choice other)));
+     fail
+       (Printf.sprintf
+          "expected Auto for task audit with passive audit tool, got %s"
+          (Agent_sdk.Types.show_tool_choice other)));
   (match
      choose
        ~turn_affordances:[ "task_audit" ]
@@ -7998,11 +10440,10 @@ let test_preferred_tool_choice_for_required_turn_claims_first () =
    with
    | Agent_sdk.Types.Auto -> ()
    | other ->
-       fail
-         (Printf.sprintf
-            "expected Auto for task audit without applicable tool \
-             (#10008), got %s"
-            (Agent_sdk.Types.show_tool_choice other)));
+     fail
+       (Printf.sprintf
+          "expected Auto for task audit without applicable tool (#10008), got %s"
+          (Agent_sdk.Types.show_tool_choice other)));
   (match
      choose
        ~turn_affordances:[ "task_verify" ]
@@ -8011,46 +10452,44 @@ let test_preferred_tool_choice_for_required_turn_claims_first () =
    with
    | Agent_sdk.Types.Auto -> ()
    | other ->
-       fail
-         (Printf.sprintf
-            "expected Auto for task verify with passive task list, got %s"
-            (Agent_sdk.Types.show_tool_choice other)));
+     fail
+       (Printf.sprintf
+          "expected Auto for task verify with passive task list, got %s"
+          (Agent_sdk.Types.show_tool_choice other)));
   (match
      choose
        ~turn_affordances:[ "task_verify" ]
-       ~allowed_tool_names:
-         [ "keeper_tasks_list"; "keeper_task_submit_for_verification" ]
+       ~allowed_tool_names:[ "keeper_tasks_list"; "keeper_task_submit_for_verification" ]
        ()
    with
    | Agent_sdk.Types.Auto -> ()
    | other ->
-       fail
-         (Printf.sprintf
-            "expected Auto for idle task verify turn, got %s"
-            (Agent_sdk.Types.show_tool_choice other)));
+     fail
+       (Printf.sprintf
+          "expected Auto for idle task verify turn, got %s"
+          (Agent_sdk.Types.show_tool_choice other)));
   (match
      choose
        ~has_current_task:true
        ~turn_affordances:[ "task_verify" ]
-       ~allowed_tool_names:
-         [ "keeper_tasks_list"; "keeper_task_submit_for_verification" ]
+       ~allowed_tool_names:[ "keeper_tasks_list"; "keeper_task_submit_for_verification" ]
        ()
    with
    | Agent_sdk.Types.Any -> ()
    | other ->
-       fail
-         (Printf.sprintf
-            "expected Any for active task verify turn, got %s"
-            (Agent_sdk.Types.show_tool_choice other)));
+     fail
+       (Printf.sprintf
+          "expected Any for active task verify turn, got %s"
+          (Agent_sdk.Types.show_tool_choice other)));
   (match choose ~allowed_tool_names:[ "keeper_board_post" ] () with
-  | Agent_sdk.Types.Auto -> ()
-  | other ->
-      fail
-        (Printf.sprintf
-           "expected Auto when claim is unavailable and keeper is \
-            idle (#10008), got %s"
-           (Agent_sdk.Types.show_tool_choice other)));
-  check (list string)
+   | Agent_sdk.Types.Auto -> ()
+   | other ->
+     fail
+       (Printf.sprintf
+          "expected Auto when claim is unavailable and keeper is idle (#10008), got %s"
+          (Agent_sdk.Types.show_tool_choice other)));
+  check
+    (list string)
     "per-call required tools override active task required tools"
     [ "keeper_board_post" ]
     (Surface.required_tool_names_for_turn
@@ -8064,35 +10503,37 @@ let test_preferred_tool_choice_for_required_turn_claims_first () =
   (match
      Surface.preferred_tool_choice_for_required_tool_names
        ~required_tool_names:product_design_required_tools
-       ~allowed_tool_names:
-         [ "keeper_board_curation_submit"; "keeper_board_post" ]
+       ~allowed_tool_names:[ "keeper_board_curation_submit"; "keeper_board_post" ]
    with
    | Agent_sdk.Types.Any -> ()
    | other ->
-       fail
-         (Printf.sprintf
-            "expected Any for product/design reprobe required tool, got %s"
-            (Agent_sdk.Types.show_tool_choice other)));
-  check (list string)
+     fail
+       (Printf.sprintf
+          "expected Any for product/design reprobe required tool, got %s"
+          (Agent_sdk.Types.show_tool_choice other)));
+  check
+    (list string)
     "active task required tools remain when no per-call requirement exists"
     [ "keeper_board_curation_submit" ]
     (Surface.required_tool_names_for_turn
        ~current_task_required_tool_names:[ "keeper_board_curation_submit" ]
        ~per_call_required_tool_names:[]);
-  check (list string)
+  check
+    (list string)
     "satisfied per-call required tool is not forced again"
     []
     (Surface.outstanding_required_tool_names
        ~required_tool_names:[ "keeper_pr_review_comment" ]
        ~satisfied_tool_names:[ "keeper_pr_review_comment" ]);
-  check (list string)
+  check
+    (list string)
     "unsatisfied required tool remains outstanding"
     [ "keeper_board_post" ]
     (Surface.outstanding_required_tool_names
-       ~required_tool_names:
-         [ "keeper_pr_review_comment"; "keeper_board_post" ]
+       ~required_tool_names:[ "keeper_pr_review_comment"; "keeper_board_post" ]
        ~satisfied_tool_names:[ "keeper_pr_review_comment" ]);
-  check (list string)
+  check
+    (list string)
     "failed required tool call remains outstanding"
     [ "keeper_pr_review_comment" ]
     (Surface.outstanding_required_tool_names
@@ -8100,7 +10541,8 @@ let test_preferred_tool_choice_for_required_turn_claims_first () =
        ~satisfied_tool_names:
          (Surface.satisfied_required_tool_names_of_outcomes
             [ "keeper_pr_review_comment", "error" ]));
-  check (list string)
+  check
+    (list string)
     "successful required tool call is satisfied"
     []
     (Surface.outstanding_required_tool_names
@@ -8111,13 +10553,14 @@ let test_preferred_tool_choice_for_required_turn_claims_first () =
   (match
      Surface.preferred_tool_choice_for_required_tool_names
        ~required_tool_names:[ "keeper_board_post" ]
-       ~allowed_tool_names:
-         [ "keeper_board_curation_submit"; "keeper_board_post" ]
+       ~allowed_tool_names:[ "keeper_board_curation_submit"; "keeper_board_post" ]
    with
    | Agent_sdk.Types.Any -> ()
    | other ->
-       fail (Printf.sprintf "expected Any for single required tool, got %s"
-               (Agent_sdk.Types.show_tool_choice other)));
+     fail
+       (Printf.sprintf
+          "expected Any for single required tool, got %s"
+          (Agent_sdk.Types.show_tool_choice other)));
   (match
      Surface.preferred_tool_choice_for_required_tool_names
        ~required_tool_names:[ "keeper_pr_create" ]
@@ -8125,36 +10568,35 @@ let test_preferred_tool_choice_for_required_turn_claims_first () =
    with
    | Agent_sdk.Types.Any -> ()
    | other ->
-       fail
-         (Printf.sprintf
-            "expected Any for keeper_pr_create to avoid raw require_specific_tool \
-             MCP-prefix mismatches, got %s"
-            (Agent_sdk.Types.show_tool_choice other)));
+     fail
+       (Printf.sprintf
+          "expected Any for keeper_pr_create to avoid raw require_specific_tool \
+           MCP-prefix mismatches, got %s"
+          (Agent_sdk.Types.show_tool_choice other)));
   (match
      Surface.preferred_tool_choice_for_required_tool_names
-       ~required_tool_names:
-         [ "keeper_shell"; "keeper_bash"; "keeper_board_post" ]
-       ~allowed_tool_names:
-         [ "keeper_shell"; "keeper_bash"; "keeper_board_post" ]
+       ~required_tool_names:[ "keeper_shell"; "keeper_bash"; "keeper_board_post" ]
+       ~allowed_tool_names:[ "keeper_shell"; "keeper_bash"; "keeper_board_post" ]
    with
    | Agent_sdk.Types.Any -> ()
    | other ->
-       fail
-         (Printf.sprintf "expected Any for multiple required tools, got %s"
-            (Agent_sdk.Types.show_tool_choice other)));
+     fail
+       (Printf.sprintf
+          "expected Any for multiple required tools, got %s"
+          (Agent_sdk.Types.show_tool_choice other)));
   (match
      Surface.preferred_tool_choice_for_required_tool_names
        ~required_tool_names:[ "keeper_tasks_audit" ]
        ~allowed_tool_names:[ "keeper_tasks_audit"; "keeper_board_post" ]
    with
    | Agent_sdk.Types.Tool name ->
-       check string "explicit passive required tool is forced"
-         "keeper_tasks_audit" name
+     check string "explicit passive required tool is forced" "keeper_tasks_audit" name
    | other ->
-       fail
-         (Printf.sprintf
-            "expected Tool keeper_tasks_audit for passive-only explicit required tool, got %s"
-            (Agent_sdk.Types.show_tool_choice other)));
+     fail
+       (Printf.sprintf
+          "expected Tool keeper_tasks_audit for passive-only explicit required tool, got \
+           %s"
+          (Agent_sdk.Types.show_tool_choice other)));
   (match
      Surface.preferred_tool_choice_for_required_tool_names
        ~required_tool_names:[ "keeper_tasks_audit"; "keeper_board_post" ]
@@ -8162,1135 +10604,1731 @@ let test_preferred_tool_choice_for_required_turn_claims_first () =
    with
    | Agent_sdk.Types.Any -> ()
    | other ->
-       fail
-         (Printf.sprintf
-            "expected Any for mixed passive/active required \
-             tools, got %s"
-            (Agent_sdk.Types.show_tool_choice other)));
+     fail
+       (Printf.sprintf
+          "expected Any for mixed passive/active required tools, got %s"
+          (Agent_sdk.Types.show_tool_choice other)));
   (* Active task keeper retains the strict gate even without a
      specific applicable tool — the caller is expected to make
      progress via board_post, task_update, etc. *)
   match
-    choose ~has_current_task:true
+    choose
+      ~has_current_task:true
       ~turn_affordances:[ "task_audit" ]
       ~allowed_tool_names:[ "keeper_tasks_list"; "keeper_board_post" ]
       ()
   with
   | Agent_sdk.Types.Any -> ()
   | other ->
-      fail
-        (Printf.sprintf
-           "expected Any for active-task keeper (must make \
-            progress), got %s"
-           (Agent_sdk.Types.show_tool_choice other))
+    fail
+      (Printf.sprintf
+         "expected Any for active-task keeper (must make progress), got %s"
+         (Agent_sdk.Types.show_tool_choice other))
+;;
 
 let test_direct_keeper_msg_timeout_overrides_meta_per_provider_timeout () =
   let meta =
-    { (make_meta "product-design-timeout") with
-      per_provider_timeout_s = Some 300.0;
-    }
+    { (make_meta "product-design-timeout") with per_provider_timeout_s = Some 300.0 }
   in
-  check (option (float 0.001))
+  check
+    (option (float 0.001))
     "explicit direct-message timeout wins over stale per-provider timeout"
     (Some 900.0)
-    (KAR.per_provider_timeout_for_turn ~meta ~oas_timeout_s:900.0
-       ~timeout_s:900.0 ());
-  check (option (float 0.001))
+    (KAR.per_provider_timeout_for_turn ~meta ~oas_timeout_s:900.0 ~timeout_s:900.0 ());
+  check
+    (option (float 0.001))
     "profile per-provider timeout still applies without explicit override"
     (Some 300.0)
     (KAR.per_provider_timeout_for_turn ~meta ~timeout_s:900.0 ())
+;;
 
 (* ---------- render_inline_skip_reason tests ---------- *)
 
 let str_contains s sub =
-  try ignore (Str.search_forward (Str.regexp_string sub) s 0); true
-  with Not_found -> false
+  try
+    ignore (Str.search_forward (Str.regexp_string sub) s 0);
+    true
+  with
+  | Not_found -> false
+;;
 
 let test_render_inline_skip_reason_deny () =
-  let result = KG.render_inline_skip_reason
-    ~tool_name:"keeper_bash"
-    ~reason_code:"keeper_deny"
-    ~reason_text:"tool is on the keeper deny list"
+  let result =
+    KG.render_inline_skip_reason
+      ~tool_name:"keeper_bash"
+      ~reason_code:"keeper_deny"
+      ~reason_text:"tool is on the keeper deny list"
   in
   check bool "prefix" true (String.starts_with ~prefix:"[tool_skipped]" result);
   check bool "tool" true (str_contains result "tool=keeper_bash");
   check bool "code" true (str_contains result "code=keeper_deny");
   check bool "reason encoded" true (str_contains result "reason=tool%20is%20on")
+;;
 
 let test_render_inline_skip_reason_cost () =
-  let result = KG.render_inline_skip_reason
-    ~tool_name:"keeper_bash"
-    ~reason_code:"cost_gate"
-    ~reason_text:"accumulated_cost_usd=0.5100 exceeded limit=0.5000"
+  let result =
+    KG.render_inline_skip_reason
+      ~tool_name:"keeper_bash"
+      ~reason_code:"cost_gate"
+      ~reason_text:"accumulated_cost_usd=0.5100 exceeded limit=0.5000"
   in
   check bool "prefix" true (String.starts_with ~prefix:"[tool_skipped]" result);
   check bool "code" true (str_contains result "code=cost_gate");
   check bool "reason encoded equals" true (str_contains result "0.5100%20exceeded")
+;;
 
 let test_render_inline_skip_reason_destructive () =
-  let result = KG.render_inline_skip_reason
-    ~tool_name:"keeper_bash"
-    ~reason_code:"destructive_guard"
-    ~reason_text:"pattern='rm -rf' (recursive forced deletion)"
+  let result =
+    KG.render_inline_skip_reason
+      ~tool_name:"keeper_bash"
+      ~reason_code:"destructive_guard"
+      ~reason_text:"pattern='rm -rf' (recursive forced deletion)"
   in
   check bool "prefix" true (String.starts_with ~prefix:"[tool_skipped]" result);
   check bool "code" true (str_contains result "code=destructive_guard");
   check bool "pattern encoded" true (str_contains result "pattern%3D")
+;;
 
 let test_render_inline_escape_edge_cases () =
   (* Empty reason text *)
-  let empty = KG.render_inline_skip_reason
-    ~tool_name:"t" ~reason_code:"c" ~reason_text:"" in
+  let empty =
+    KG.render_inline_skip_reason ~tool_name:"t" ~reason_code:"c" ~reason_text:""
+  in
   check bool "empty reason" true (str_contains empty "reason=");
   (* Percent sign in reason *)
-  let pct = KG.render_inline_skip_reason
-    ~tool_name:"t" ~reason_code:"c" ~reason_text:"CPU at 90%" in
+  let pct =
+    KG.render_inline_skip_reason ~tool_name:"t" ~reason_code:"c" ~reason_text:"CPU at 90%"
+  in
   check bool "percent encoded" true (str_contains pct "90%25")
+;;
 
 let test_render_inline_with_replacement () =
   (* keeper_board_post has replacement=masc_board_post in Tool_catalog *)
-  let result = KG.render_inline_skip_reason
-    ~tool_name:"keeper_board_post"
-    ~reason_code:"keeper_deny"
-    ~reason_text:"denied"
+  let result =
+    KG.render_inline_skip_reason
+      ~tool_name:"keeper_board_post"
+      ~reason_code:"keeper_deny"
+      ~reason_text:"denied"
   in
   check bool "has replacement" true (str_contains result "replacement=")
+;;
 
 let test_normalize_override_passthrough () =
   let override_text =
     "[tool_skipped] tool=keeper_bash source=keeper_hook code=keeper_deny \
      reason=tool%20is%20on%20the%20keeper%20deny%20list"
   in
-  match KTD.normalize_response_text
-          ~text:override_text
-          ~tool_names:["keeper_bash"]
-          ()
+  match
+    KTD.normalize_response_text ~text:override_text ~tool_names:[ "keeper_bash" ] ()
   with
   | Ok text -> check string "passes through" override_text text
   | Error e -> fail ("unexpected error: " ^ e)
+;;
 
 (* ---------- Metacognition tests ---------- *)
 
 let test_on_idle_nudge_at_first_idle () =
   (* Use an explicit skip_at=3 to exercise the pure helper at a chosen
      threshold, independent of any global/default configuration. *)
-  let decision = HK.on_idle_decision_with_threshold
-    ~skip_at:3
-    ~consecutive_idle_turns:1
-    ~allowed_tools:[]
-    ~tool_names:["keeper_board_list"; "keeper_tasks_list"] in
+  let decision =
+    HK.on_idle_decision_with_threshold
+      ~skip_at:3
+      ~consecutive_idle_turns:1
+      ~allowed_tools:[]
+      ~tool_names:[ "keeper_board_list"; "keeper_tasks_list" ]
+  in
   match decision with
   | Agent_sdk.Hooks.Nudge msg ->
-    check bool "nudge mentions repeated tools"
-      true (contains_substring msg "keeper_board_list")
+    check
+      bool
+      "nudge mentions repeated tools"
+      true
+      (contains_substring msg "keeper_board_list")
   | other ->
-    fail (Printf.sprintf "expected Nudge, got %s"
-      (Agent_sdk.Hooks.decision_kind_to_string
-        (Agent_sdk.Hooks.classify_decision other)))
+    fail
+      (Printf.sprintf
+         "expected Nudge, got %s"
+         (Agent_sdk.Hooks.decision_kind_to_string
+            (Agent_sdk.Hooks.classify_decision other)))
+;;
 
 let test_on_idle_final_warning_before_skip () =
   (* At skip_at - 1, the hook should send a final-warning nudge *)
-  let decision = HK.on_idle_decision_with_threshold
-    ~skip_at:3
-    ~consecutive_idle_turns:2
-    ~allowed_tools:[]
-    ~tool_names:["keeper_board_list"] in
+  let decision =
+    HK.on_idle_decision_with_threshold
+      ~skip_at:3
+      ~consecutive_idle_turns:2
+      ~allowed_tools:[]
+      ~tool_names:[ "keeper_board_list" ]
+  in
   match decision with
   | Agent_sdk.Hooks.Nudge msg ->
-    check bool "final warning mentions stay_silent"
-      true (contains_substring msg "stay_silent")
+    check
+      bool
+      "final warning mentions stay_silent"
+      true
+      (contains_substring msg "stay_silent")
   | other ->
-    fail (Printf.sprintf "expected Nudge (final warning), got %s"
-      (Agent_sdk.Hooks.decision_kind_to_string
-        (Agent_sdk.Hooks.classify_decision other)))
+    fail
+      (Printf.sprintf
+         "expected Nudge (final warning), got %s"
+         (Agent_sdk.Hooks.decision_kind_to_string
+            (Agent_sdk.Hooks.classify_decision other)))
+;;
 
 let test_on_idle_skip_at_repeated_idle () =
   (* At skip_at the hook should issue Skip; use explicit threshold so the
      test does not depend on the global constant *)
-  let decision = HK.on_idle_decision_with_threshold
-    ~skip_at:3
-    ~consecutive_idle_turns:3
-    ~allowed_tools:[]
-    ~tool_names:["keeper_board_list"] in
+  let decision =
+    HK.on_idle_decision_with_threshold
+      ~skip_at:3
+      ~consecutive_idle_turns:3
+      ~allowed_tools:[]
+      ~tool_names:[ "keeper_board_list" ]
+  in
   match decision with
   | Agent_sdk.Hooks.Skip -> ()
   | other ->
-    fail (Printf.sprintf "expected Skip, got %s"
-      (Agent_sdk.Hooks.decision_kind_to_string
-        (Agent_sdk.Hooks.classify_decision other)))
+    fail
+      (Printf.sprintf
+         "expected Skip, got %s"
+         (Agent_sdk.Hooks.decision_kind_to_string
+            (Agent_sdk.Hooks.classify_decision other)))
+;;
 
 let test_on_idle_skip_with_custom_threshold () =
   (* The pure helper must respect a custom skip_at value *)
-  let decision = HK.on_idle_decision_with_threshold
-    ~skip_at:2
-    ~consecutive_idle_turns:2
-    ~allowed_tools:[]
-    ~tool_names:["keeper_board_list"] in
+  let decision =
+    HK.on_idle_decision_with_threshold
+      ~skip_at:2
+      ~consecutive_idle_turns:2
+      ~allowed_tools:[]
+      ~tool_names:[ "keeper_board_list" ]
+  in
   match decision with
   | Agent_sdk.Hooks.Skip -> ()
   | other ->
-    fail (Printf.sprintf "expected Skip at custom threshold 2, got %s"
-      (Agent_sdk.Hooks.decision_kind_to_string
-        (Agent_sdk.Hooks.classify_decision other)))
+    fail
+      (Printf.sprintf
+         "expected Skip at custom threshold 2, got %s"
+         (Agent_sdk.Hooks.decision_kind_to_string
+            (Agent_sdk.Hooks.classify_decision other)))
+;;
 
 let test_recent_tool_streak_count_counts_tail_matches () =
   let now = Time_compat.now () in
   let entries =
-    [
-      tool_log_entry ~ts:(now -. 30.0) "keeper_fs_read";
-      tool_log_entry ~ts:(now -. 20.0) "masc_status";
-      tool_log_entry ~ts:(now -. 10.0) "masc_status";
+    [ tool_log_entry ~ts:(now -. 30.0) "keeper_fs_read"
+    ; tool_log_entry ~ts:(now -. 20.0) "masc_status"
+    ; tool_log_entry ~ts:(now -. 10.0) "masc_status"
     ]
   in
-  check int "tail streak count" 2
+  check
+    int
+    "tail streak count"
+    2
     (HK.recent_tool_streak_count ~tool_name:"masc_status" entries)
+;;
 
 let test_recent_tool_streak_count_ignores_stale_entries () =
   let now = Time_compat.now () in
   let entries =
-    [
-      tool_log_entry ~ts:(now -. 1800.0) "masc_status";
-      tool_log_entry ~ts:(now -. 10.0) "masc_status";
+    [ tool_log_entry ~ts:(now -. 1800.0) "masc_status"
+    ; tool_log_entry ~ts:(now -. 10.0) "masc_status"
     ]
   in
-  check int "stale entry does not extend streak" 1
-    (HK.recent_tool_streak_count ~within_sec:60.0 ~tool_name:"masc_status"
-       entries)
+  check
+    int
+    "stale entry does not extend streak"
+    1
+    (HK.recent_tool_streak_count ~within_sec:60.0 ~tool_name:"masc_status" entries)
+;;
+
 (* ---------- Test runner ---------- *)
 
 let () =
-  run "Keeper Cycle"
-    [
-      ( "world_observation",
-        [
-          test_case "defaults" `Quick test_observation_defaults;
-          test_case "with mentions" `Quick test_observation_with_mentions;
-          test_case "uses precollected board events" `Quick
-            test_observe_uses_precollected_board_events;
-          test_case "queued board stimulus becomes board event" `Quick
-            test_board_signal_stimulus_becomes_pending_board_event;
-          test_case "legacy queued board comment becomes board event" `Quick
-            test_legacy_board_comment_stimulus_becomes_pending_board_event;
-          test_case "splits absolute and claimable backlog" `Quick
-            test_observe_splits_absolute_and_claimable_backlog;
-          test_case "claimable backlog respects active goals" `Quick
-            test_observe_claimable_backlog_respects_active_goal_ids;
-          test_case "claimable backlog mirrors auto-goal fallback" `Quick
-            test_observe_claimable_backlog_uses_auto_goal_fallback_scope;
-          test_case "durable signal sees claimable backlog" `Quick
-            test_durable_signal_present_sees_claimable_backlog_for_smart_hb_gate;
-          test_case "durable signal filters unclaimable backlog" `Quick
-            test_durable_signal_present_filters_unclaimable_backlog_for_smart_hb_gate;
-          test_case "default keepers ignore unmatched non-mention board events" `Quick
-            test_collect_board_events_keeps_non_mentions_as_followup_signal;
-          test_case "room-signal keepers keep unmatched non-mention board events" `Quick
-            test_collect_board_events_keeps_non_mentions_for_room_signal_keepers;
-          test_case "keeps external replies after self comment" `Quick
-            test_collect_board_events_keeps_external_replies_after_self_comment;
-          test_case "treats generated alias as self comment" `Quick
-            test_collect_board_events_treats_generated_alias_as_self_comment;
-          test_case "default keepers ignore scope messages" `Quick
-            test_observe_ignores_scope_messages_without_room_signal_opt_in;
-          test_case "room-signal keepers collect scope messages" `Quick
-            test_observe_collects_scope_messages_for_room_signal_keepers;
-          test_case "room-signal keepers damp keeper scope chatter" `Quick
-            test_observe_damps_keeper_scope_chatter_but_keeps_direct_mentions;
-          test_case "stale terminal task mentions advance cursor" `Quick
-            test_observe_skips_stale_terminal_task_mentions;
-          test_case "scheduled turn uses cooldown only when work exists" `Quick
-            test_scheduled_turn_uses_cooldown_only;
-          test_case "scheduled turn skips without structured work signal" `Quick
-            test_scheduled_turn_skips_without_structured_work_signal;
-          test_case "scheduled turn respects cooldown" `Quick
-            test_scheduled_turn_respects_cooldown;
-          test_case "scheduled turn requires idle gate" `Quick
-            test_scheduled_turn_requires_idle_gate;
-          test_case "provider cooldown blocks scheduled turn" `Quick
-            test_provider_cooldown_blocks_scheduled_turn_when_work_is_ready;
-          test_case "provider cooldown keeps scheduled turn open when fail-open exists" `Quick
-            test_provider_cooldown_keeps_scheduled_turn_open_when_fail_open_exists;
-          test_case "idle decay: no decay within base" `Quick
-            test_effective_cooldown_no_decay_within_base;
-          test_case "idle decay: at boundary" `Quick
-            test_effective_cooldown_at_boundary;
-          test_case "idle decay: first decay" `Quick
-            test_effective_cooldown_first_decay;
-          test_case "idle decay: second decay" `Quick
-            test_effective_cooldown_second_decay;
-          test_case "idle decay: floor" `Quick
-            test_effective_cooldown_floor;
-          test_case "idle decay: max_int" `Quick
-            test_effective_cooldown_max_int;
-          test_case "noop backoff: doubles cooldown" `Quick
-            test_noop_backoff_doubles_cooldown;
-          test_case "noop backoff: quadruples cooldown" `Quick
-            test_noop_backoff_quadruples_cooldown;
-          test_case "noop backoff: caps at 8x" `Quick
-            test_noop_backoff_caps_at_8x;
-          test_case "noop backoff: zero noops unchanged" `Quick
-            test_noop_backoff_zero_noops_unchanged;
-          test_case "idle decay: triggers turn" `Quick
-            test_idle_decay_triggers_turn;
-          test_case "scheduled decision uses backlog acceleration" `Quick
-            test_scheduled_turn_decision_uses_backlog_acceleration;
-          test_case "scheduled decision ignores unclaimable backlog" `Quick
-            test_scheduled_turn_ignores_unclaimable_backlog;
-          test_case "verdict reasons use structured run tags" `Quick
-            test_verdict_reasons_to_strings_uses_structured_run_tags;
-          test_case "verdict reasons use structured skip tags" `Quick
-            test_verdict_reasons_to_strings_uses_structured_skip_tags;
-          test_case "paused keeper blocks turns" `Quick
-            test_paused_keeper_blocks_turns_even_with_reactive_signal;
-          test_case "pending approval blocks turns" `Quick
-            test_pending_approval_blocks_turns_until_resolved;
-          test_case "task reactive cooldown floor never hits zero" `Quick
-            test_task_reactive_cooldown_floor_never_hits_zero;
-          test_case "task backlog cooldown applies noop backoff once" `Quick
-            test_task_backlog_cooldown_applies_noop_backoff_once;
-          test_case "fresh backlog update bypasses cooldown" `Quick
-            test_scheduled_turn_decision_runs_immediately_on_fresh_backlog_update;
-          test_case "bootstrap: fires when keeper never started" `Quick
-            test_bootstrap_turn_fires_when_never_started;
-          test_case "bootstrap: channel is scheduled_autonomous" `Quick
-            test_bootstrap_turn_emits_scheduled_autonomous_channel;
-          test_case "bootstrap: provider cooldown blocks first turn" `Quick
-            test_provider_cooldown_blocks_bootstrap_turn;
-          test_case "min interval: fires without work signal after interval" `Quick
-            test_min_interval_fires_without_work_signal;
-          test_case "min interval: not tagged entropic" `Quick
-            test_min_interval_turn_is_not_tagged_entropic;
-          test_case "min interval: does not fire before elapsed" `Quick
-            test_min_interval_does_not_fire_before_elapsed;
-          test_case "min interval: never fires for bootstrap turn" `Quick
-            test_min_interval_never_fires_for_bootstrap;
-          test_case "min interval: provider cooldown blocks turn" `Quick
-            test_provider_cooldown_blocks_min_interval_turn;
-	          test_case "runtime trust snapshot tolerates null telemetry" `Quick
-	            test_runtime_trust_snapshot_tolerates_null_telemetry;
-	          test_case "runtime trust snapshot surfaces terminal reason" `Quick
-	            test_runtime_trust_snapshot_surfaces_terminal_reason;
-	          test_case "runtime trust snapshot reads terminal reason code alias" `Quick
-	            test_runtime_trust_snapshot_reads_terminal_reason_code_alias;
-	          test_case "with goals" `Quick test_observation_with_goals;
-          test_case "economic modes" `Quick test_observation_economic_modes;
-        ] );
-      ( "unified_prompt",
-        [
-          test_case "contains identity" `Quick test_prompt_contains_identity;
-          test_case "contains goal" `Quick test_prompt_contains_goal;
-          test_case "mentions extend_turns guidance" `Quick
-            test_prompt_mentions_extend_turns_guidance;
-          test_case "includes operational tool guidance" `Quick
-            test_prompt_includes_operational_tool_guidance;
-          test_case "includes research evidence contract" `Quick
-            test_prompt_includes_research_evidence_contract;
-          test_case "distinguishes sandbox and worktree" `Quick
-            test_capabilities_prompt_distinguishes_sandbox_and_worktree;
-          test_case "world prompt distinguishes sandbox and worktree" `Quick
-            test_world_prompt_distinguishes_sandbox_and_worktree;
-          test_case "prefers submit over legacy workflow" `Quick
-            test_system_prompt_prefers_bash_and_gh_pr_lane;
-          test_case "includes autonomous trigger section" `Quick
-            test_prompt_includes_autonomous_trigger_section;
-          test_case "omits autonomous trigger for reactive turn" `Quick
-            test_prompt_omits_autonomous_trigger_for_reactive_turn;
-          test_case "omits empty sections" `Quick test_prompt_omits_empty_sections;
-          test_case "continuity drops inert idle directives" `Quick
-            test_prompt_continuity_drops_inert_idle_directives;
-          test_case "continuity drops stale tool surface claims" `Quick
-            test_prompt_continuity_drops_stale_tool_surface_claims;
-          test_case "includes mentions" `Quick test_prompt_includes_mentions_section;
-          test_case "includes board activity" `Quick
-            test_prompt_includes_board_activity_section;
-          test_case "marks board curation due" `Quick
-            test_prompt_marks_board_curation_due_for_multi_event_window;
-          test_case "includes goals" `Quick test_prompt_includes_goals_section;
-          test_case "includes context ratio" `Quick test_prompt_includes_context_ratio;
-          test_case "includes idle" `Quick test_prompt_includes_idle;
-          test_case "frugal economy" `Quick test_prompt_frugal_economy;
-          test_case "hustle economy" `Quick test_prompt_hustle_economy;
-          test_case "includes worktree delta" `Quick test_prompt_includes_worktree_delta;
-          test_case "orders stable sections before reactive sections" `Quick
-            test_prompt_orders_stable_sections_before_reactive_sections;
-          test_case "room state section" `Quick test_prompt_room_state_section;
-          test_case "claim first guidance" `Quick
-            test_prompt_includes_claim_first_guidance;
-          test_case "claim first guidance omitted when no task is claimable" `Quick
-            test_prompt_omits_claim_first_guidance_when_no_claimable_tasks;
-          test_case "claim first guidance omitted when task claimed" `Quick
-            test_prompt_omits_claim_first_guidance_when_task_claimed;
-          test_case "claim first guidance omitted when tool unavailable" `Quick
-            test_prompt_omits_claim_first_guidance_when_claim_tool_unavailable;
-          test_case "claim first guidance omitted when paused" `Quick
-            test_prompt_omits_claim_first_guidance_when_paused;
-          test_case "work discovery nudge uses registered tool schemas" `Quick
-            test_work_discovery_nudge_uses_registered_keeper_tool_schemas;
-          test_case "prefers silence guidance" `Quick
-            test_prompt_prefers_silence_guidance;
-          test_case "sanitize_text_utf8 replaces control chars" `Quick
-            test_sanitize_text_utf8_replaces_control_chars;
-          test_case "prompt sanitizes control chars" `Quick
-            test_prompt_sanitizes_control_chars;
-          test_case "sanitize_messages_utf8 cleans history path" `Quick
-            test_sanitize_messages_utf8_cleans_history_path;
-          test_case "sanitize_messages_utf8 reuses clean history list" `Quick
-            test_sanitize_messages_utf8_reuses_clean_history_list;
-        ] );
-      ( "metacognition",
-        [
-          test_case "on_idle nudge at first idle" `Quick
-            test_on_idle_nudge_at_first_idle;
-          test_case "on_idle final warning before skip" `Quick
-            test_on_idle_final_warning_before_skip;
-          test_case "on_idle skip at repeated idle" `Quick
-            test_on_idle_skip_at_repeated_idle;
-          test_case "on_idle skip with custom threshold" `Quick
-            test_on_idle_skip_with_custom_threshold;
-          test_case "recent tool streak counts tail matches" `Quick
-            test_recent_tool_streak_count_counts_tail_matches;
-          test_case "recent tool streak ignores stale entries" `Quick
-            test_recent_tool_streak_count_ignores_stale_entries;
-        ] );
-      ( "config",
-        [
-          test_case "default social model" `Quick
-            test_meta_defaults_social_model;
-          test_case "unified runtime defaults" `Quick
-            test_unified_turn_runtime_defaults;
-        ] );
-      ( "metrics_observation",
-        [
-          test_case "prompt metrics fingerprint" `Quick
-            test_prompt_metrics_fingerprint_is_deterministic;
-          test_case "text response" `Quick test_metrics_text_response;
-          test_case "idle seconds gauge records observation" `Quick
-            test_metrics_idle_seconds_gauge_records_observation;
-          test_case "surface model prefers successful cascade label" `Quick
-            test_metrics_surface_model_prefers_successful_cascade_label;
-          test_case "resolved_model_id prefers last attempt id (#9953)"
+  run
+    "Keeper Cycle"
+    [ ( "world_observation"
+      , [ test_case "defaults" `Quick test_observation_defaults
+        ; test_case "with mentions" `Quick test_observation_with_mentions
+        ; test_case
+            "uses precollected board events"
             `Quick
-            test_metrics_resolved_model_id_prefers_last_attempt_id;
-          test_case "resolved_model_id falls back to model_used (#9953)"
-            `Quick test_metrics_resolved_model_id_fallback_to_model_used;
-          test_case "tool response" `Quick test_metrics_tool_response;
-          test_case "noop response" `Quick test_metrics_noop_response;
-          test_case "observation-only tools are noop" `Quick
-            test_metrics_observation_only_tools_are_noop;
-          test_case "execution tools are substantive" `Quick
-            test_metrics_execution_tools_are_substantive;
-          test_case "validated evidence counts as visible" `Quick
-            test_metrics_validated_evidence_counts_as_visible;
-          test_case "failed validation does not count as visible" `Quick
-            test_metrics_failed_validation_does_not_count_as_visible;
-          test_case "file write evidence counts as visible" `Quick
-            test_metrics_file_write_evidence_counts_as_visible;
-          test_case "heartbeat-only tool response is maintenance only" `Quick
-            test_metrics_heartbeat_only_tool_response_is_maintenance_only;
-          test_case "reactive turn leaves proactive runtime untouched" `Quick
-            test_metrics_reactive_turn_does_not_mutate_proactive_runtime;
-          test_case "silent proactive cycle advances cooldown anchor" `Quick
-            test_silent_proactive_cycle_advances_cooldown_anchor;
-          test_case "reactive failure leaves proactive runtime untouched" `Quick
-            test_metrics_reactive_failure_does_not_mutate_proactive_runtime;
-          test_case "legacy migration does not infer visible proactive fields" `Quick
-            test_meta_migration_does_not_infer_visible_proactive_fields;
-          test_case "snapshot includes cascade observation" `Quick
-            test_append_metrics_snapshot_includes_cascade_observation;
-          test_case "snapshot treats validated evidence as tool use" `Quick
-            test_append_metrics_snapshot_treats_validated_evidence_as_tool_use;
-          test_case "snapshot counts only mode violation refs" `Quick
-            test_append_metrics_snapshot_counts_only_mode_violation_refs;
-          test_case "snapshot nulls unreported usage" `Quick
-            test_append_metrics_snapshot_nulls_unreported_usage;
-          test_case "snapshot persists cache usage" `Quick
-            test_append_metrics_snapshot_persists_cache_usage;
-          test_case "trusted usage cost uses cache token pricing" `Quick
-            test_estimate_trusted_usage_cost_uses_cache_usage;
-          test_case "total cost gauge records accumulated keeper cost" `Quick
-            test_record_keeper_total_cost_metric;
-          test_case "snapshot marks untrusted usage" `Quick
-            test_append_metrics_snapshot_marks_untrusted_usage;
-          test_case "decision record persists tool call details" `Quick
-            test_append_decision_record_persists_tool_calls;
-	          test_case "decision record nulls unreported usage" `Quick
-	            test_append_decision_record_nulls_unreported_usage;
-	          test_case "decision record classifies worktree blocker" `Quick
-	            test_append_decision_record_classifies_legacy_worktree_error;
-	          test_case "decision record preserves no-result skipped outcome" `Quick
-	            test_append_decision_record_preserves_no_result_skipped_outcome;
-	          test_case "social fields" `Quick
-	            test_metrics_persist_social_state_fields;
-          test_case "failure response" `Quick test_metrics_failure_response;
-          test_case "timeout failure increments proactive backoff" `Quick
-            test_metrics_failure_timeout_increments_proactive_backoff;
-          test_case "failure response redacts resumable session detail" `Quick
-            test_metrics_failure_response_redacts_resumable_cli_session_detail;
-          test_case "mixed response" `Quick test_metrics_mixed_response;
-          test_case "normalize passthrough" `Quick
-            test_normalize_response_text_passthrough;
-          test_case "normalize tool only synthesizes" `Quick
-            test_normalize_response_text_tool_only_synthesizes;
-          test_case "normalize empty without tools errors" `Quick
-            test_normalize_response_text_empty_without_tools_errors;
-          test_case "completion contract allows text without tools" `Quick
-            test_validate_completion_contract_allows_text_without_tools;
-          test_case "completion contract requires tool use" `Quick
-            test_validate_completion_contract_requires_tool_use;
-          test_case "completion contract accepts stay silent" `Quick
-            test_validate_completion_contract_accepts_stay_silent;
-          test_case "unexpected tool names accepts keeper surface" `Quick
-            test_unexpected_tool_names_accepts_keeper_surface;
-          test_case "unexpected tool names reports foreign surface" `Quick
-            test_unexpected_tool_names_reports_foreign_surface;
-          test_case "completion contract mapping allows auto" `Quick
-            test_completion_contract_of_tool_choice_allows_auto;
-          test_case "completion contract mapping requires any" `Quick
-            test_completion_contract_of_tool_choice_requires_any;
-          test_case "run completion contract latches required tool use"
-            `Quick test_run_completion_contract_latches_required_tool_use;
-          test_case
+            test_observe_uses_precollected_board_events
+        ; test_case
+            "queued board stimulus becomes board event"
+            `Quick
+            test_board_signal_stimulus_becomes_pending_board_event
+        ; test_case
+            "legacy queued board comment becomes board event"
+            `Quick
+            test_legacy_board_comment_stimulus_becomes_pending_board_event
+        ; test_case
+            "splits absolute and claimable backlog"
+            `Quick
+            test_observe_splits_absolute_and_claimable_backlog
+        ; test_case
+            "claimable backlog respects active goals"
+            `Quick
+            test_observe_claimable_backlog_respects_active_goal_ids
+        ; test_case
+            "claimable backlog mirrors auto-goal fallback"
+            `Quick
+            test_observe_claimable_backlog_uses_auto_goal_fallback_scope
+        ; test_case
+            "durable signal sees claimable backlog"
+            `Quick
+            test_durable_signal_present_sees_claimable_backlog_for_smart_hb_gate
+        ; test_case
+            "durable signal filters unclaimable backlog"
+            `Quick
+            test_durable_signal_present_filters_unclaimable_backlog_for_smart_hb_gate
+        ; test_case
+            "default keepers ignore unmatched non-mention board events"
+            `Quick
+            test_collect_board_events_keeps_non_mentions_as_followup_signal
+        ; test_case
+            "room-signal keepers keep unmatched non-mention board events"
+            `Quick
+            test_collect_board_events_keeps_non_mentions_for_room_signal_keepers
+        ; test_case
+            "keeps external replies after self comment"
+            `Quick
+            test_collect_board_events_keeps_external_replies_after_self_comment
+        ; test_case
+            "treats generated alias as self comment"
+            `Quick
+            test_collect_board_events_treats_generated_alias_as_self_comment
+        ; test_case
+            "default keepers ignore scope messages"
+            `Quick
+            test_observe_ignores_scope_messages_without_room_signal_opt_in
+        ; test_case
+            "room-signal keepers collect scope messages"
+            `Quick
+            test_observe_collects_scope_messages_for_room_signal_keepers
+        ; test_case
+            "room-signal keepers damp keeper scope chatter"
+            `Quick
+            test_observe_damps_keeper_scope_chatter_but_keeps_direct_mentions
+        ; test_case
+            "stale terminal task mentions advance cursor"
+            `Quick
+            test_observe_skips_stale_terminal_task_mentions
+        ; test_case
+            "scheduled turn uses cooldown only when work exists"
+            `Quick
+            test_scheduled_turn_uses_cooldown_only
+        ; test_case
+            "scheduled turn skips without structured work signal"
+            `Quick
+            test_scheduled_turn_skips_without_structured_work_signal
+        ; test_case
+            "scheduled turn respects cooldown"
+            `Quick
+            test_scheduled_turn_respects_cooldown
+        ; test_case
+            "scheduled turn requires idle gate"
+            `Quick
+            test_scheduled_turn_requires_idle_gate
+        ; test_case
+            "provider cooldown blocks scheduled turn"
+            `Quick
+            test_provider_cooldown_blocks_scheduled_turn_when_work_is_ready
+        ; test_case
+            "provider cooldown keeps scheduled turn open when fail-open exists"
+            `Quick
+            test_provider_cooldown_keeps_scheduled_turn_open_when_fail_open_exists
+        ; test_case
+            "idle decay: no decay within base"
+            `Quick
+            test_effective_cooldown_no_decay_within_base
+        ; test_case "idle decay: at boundary" `Quick test_effective_cooldown_at_boundary
+        ; test_case "idle decay: first decay" `Quick test_effective_cooldown_first_decay
+        ; test_case "idle decay: second decay" `Quick test_effective_cooldown_second_decay
+        ; test_case "idle decay: floor" `Quick test_effective_cooldown_floor
+        ; test_case "idle decay: max_int" `Quick test_effective_cooldown_max_int
+        ; test_case
+            "noop backoff: doubles cooldown"
+            `Quick
+            test_noop_backoff_doubles_cooldown
+        ; test_case
+            "noop backoff: quadruples cooldown"
+            `Quick
+            test_noop_backoff_quadruples_cooldown
+        ; test_case "noop backoff: caps at 8x" `Quick test_noop_backoff_caps_at_8x
+        ; test_case
+            "noop backoff: zero noops unchanged"
+            `Quick
+            test_noop_backoff_zero_noops_unchanged
+        ; test_case "idle decay: triggers turn" `Quick test_idle_decay_triggers_turn
+        ; test_case
+            "scheduled decision uses backlog acceleration"
+            `Quick
+            test_scheduled_turn_decision_uses_backlog_acceleration
+        ; test_case
+            "scheduled decision ignores unclaimable backlog"
+            `Quick
+            test_scheduled_turn_ignores_unclaimable_backlog
+        ; test_case
+            "verdict reasons use structured run tags"
+            `Quick
+            test_verdict_reasons_to_strings_uses_structured_run_tags
+        ; test_case
+            "verdict reasons use structured skip tags"
+            `Quick
+            test_verdict_reasons_to_strings_uses_structured_skip_tags
+        ; test_case
+            "paused keeper blocks turns"
+            `Quick
+            test_paused_keeper_blocks_turns_even_with_reactive_signal
+        ; test_case
+            "pending approval blocks turns"
+            `Quick
+            test_pending_approval_blocks_turns_until_resolved
+        ; test_case
+            "task reactive cooldown floor never hits zero"
+            `Quick
+            test_task_reactive_cooldown_floor_never_hits_zero
+        ; test_case
+            "task backlog cooldown applies noop backoff once"
+            `Quick
+            test_task_backlog_cooldown_applies_noop_backoff_once
+        ; test_case
+            "fresh backlog update bypasses cooldown"
+            `Quick
+            test_scheduled_turn_decision_runs_immediately_on_fresh_backlog_update
+        ; test_case
+            "bootstrap: fires when keeper never started"
+            `Quick
+            test_bootstrap_turn_fires_when_never_started
+        ; test_case
+            "bootstrap: channel is scheduled_autonomous"
+            `Quick
+            test_bootstrap_turn_emits_scheduled_autonomous_channel
+        ; test_case
+            "bootstrap: provider cooldown blocks first turn"
+            `Quick
+            test_provider_cooldown_blocks_bootstrap_turn
+        ; test_case
+            "min interval: fires without work signal after interval"
+            `Quick
+            test_min_interval_fires_without_work_signal
+        ; test_case
+            "min interval: not tagged entropic"
+            `Quick
+            test_min_interval_turn_is_not_tagged_entropic
+        ; test_case
+            "min interval: does not fire before elapsed"
+            `Quick
+            test_min_interval_does_not_fire_before_elapsed
+        ; test_case
+            "min interval: never fires for bootstrap turn"
+            `Quick
+            test_min_interval_never_fires_for_bootstrap
+        ; test_case
+            "min interval: provider cooldown blocks turn"
+            `Quick
+            test_provider_cooldown_blocks_min_interval_turn
+        ; test_case
+            "runtime trust snapshot tolerates null telemetry"
+            `Quick
+            test_runtime_trust_snapshot_tolerates_null_telemetry
+        ; test_case
+            "runtime trust snapshot surfaces terminal reason"
+            `Quick
+            test_runtime_trust_snapshot_surfaces_terminal_reason
+        ; test_case
+            "runtime trust snapshot reads terminal reason code alias"
+            `Quick
+            test_runtime_trust_snapshot_reads_terminal_reason_code_alias
+        ; test_case "with goals" `Quick test_observation_with_goals
+        ; test_case "economic modes" `Quick test_observation_economic_modes
+        ] )
+    ; ( "unified_prompt"
+      , [ test_case "contains identity" `Quick test_prompt_contains_identity
+        ; test_case "contains goal" `Quick test_prompt_contains_goal
+        ; test_case
+            "mentions extend_turns guidance"
+            `Quick
+            test_prompt_mentions_extend_turns_guidance
+        ; test_case
+            "includes operational tool guidance"
+            `Quick
+            test_prompt_includes_operational_tool_guidance
+        ; test_case
+            "includes research evidence contract"
+            `Quick
+            test_prompt_includes_research_evidence_contract
+        ; test_case
+            "distinguishes sandbox and worktree"
+            `Quick
+            test_capabilities_prompt_distinguishes_sandbox_and_worktree
+        ; test_case
+            "world prompt distinguishes sandbox and worktree"
+            `Quick
+            test_world_prompt_distinguishes_sandbox_and_worktree
+        ; test_case
+            "prefers submit over legacy workflow"
+            `Quick
+            test_system_prompt_prefers_bash_and_gh_pr_lane
+        ; test_case
+            "includes autonomous trigger section"
+            `Quick
+            test_prompt_includes_autonomous_trigger_section
+        ; test_case
+            "omits autonomous trigger for reactive turn"
+            `Quick
+            test_prompt_omits_autonomous_trigger_for_reactive_turn
+        ; test_case "omits empty sections" `Quick test_prompt_omits_empty_sections
+        ; test_case
+            "continuity drops inert idle directives"
+            `Quick
+            test_prompt_continuity_drops_inert_idle_directives
+        ; test_case
+            "continuity drops stale tool surface claims"
+            `Quick
+            test_prompt_continuity_drops_stale_tool_surface_claims
+        ; test_case "includes mentions" `Quick test_prompt_includes_mentions_section
+        ; test_case
+            "includes board activity"
+            `Quick
+            test_prompt_includes_board_activity_section
+        ; test_case
+            "marks board curation due"
+            `Quick
+            test_prompt_marks_board_curation_due_for_multi_event_window
+        ; test_case "includes goals" `Quick test_prompt_includes_goals_section
+        ; test_case "includes context ratio" `Quick test_prompt_includes_context_ratio
+        ; test_case "includes idle" `Quick test_prompt_includes_idle
+        ; test_case "frugal economy" `Quick test_prompt_frugal_economy
+        ; test_case "hustle economy" `Quick test_prompt_hustle_economy
+        ; test_case "includes worktree delta" `Quick test_prompt_includes_worktree_delta
+        ; test_case
+            "orders stable sections before reactive sections"
+            `Quick
+            test_prompt_orders_stable_sections_before_reactive_sections
+        ; test_case "room state section" `Quick test_prompt_room_state_section
+        ; test_case
+            "claim first guidance"
+            `Quick
+            test_prompt_includes_claim_first_guidance
+        ; test_case
+            "claim first guidance omitted when no task is claimable"
+            `Quick
+            test_prompt_omits_claim_first_guidance_when_no_claimable_tasks
+        ; test_case
+            "claim first guidance omitted when task claimed"
+            `Quick
+            test_prompt_omits_claim_first_guidance_when_task_claimed
+        ; test_case
+            "claim first guidance omitted when tool unavailable"
+            `Quick
+            test_prompt_omits_claim_first_guidance_when_claim_tool_unavailable
+        ; test_case
+            "claim first guidance omitted when paused"
+            `Quick
+            test_prompt_omits_claim_first_guidance_when_paused
+        ; test_case
+            "work discovery nudge uses registered tool schemas"
+            `Quick
+            test_work_discovery_nudge_uses_registered_keeper_tool_schemas
+        ; test_case "prefers silence guidance" `Quick test_prompt_prefers_silence_guidance
+        ; test_case
+            "sanitize_text_utf8 replaces control chars"
+            `Quick
+            test_sanitize_text_utf8_replaces_control_chars
+        ; test_case
+            "prompt sanitizes control chars"
+            `Quick
+            test_prompt_sanitizes_control_chars
+        ; test_case
+            "sanitize_messages_utf8 cleans history path"
+            `Quick
+            test_sanitize_messages_utf8_cleans_history_path
+        ; test_case
+            "sanitize_messages_utf8 reuses clean history list"
+            `Quick
+            test_sanitize_messages_utf8_reuses_clean_history_list
+        ] )
+    ; ( "metacognition"
+      , [ test_case "on_idle nudge at first idle" `Quick test_on_idle_nudge_at_first_idle
+        ; test_case
+            "on_idle final warning before skip"
+            `Quick
+            test_on_idle_final_warning_before_skip
+        ; test_case
+            "on_idle skip at repeated idle"
+            `Quick
+            test_on_idle_skip_at_repeated_idle
+        ; test_case
+            "on_idle skip with custom threshold"
+            `Quick
+            test_on_idle_skip_with_custom_threshold
+        ; test_case
+            "recent tool streak counts tail matches"
+            `Quick
+            test_recent_tool_streak_count_counts_tail_matches
+        ; test_case
+            "recent tool streak ignores stale entries"
+            `Quick
+            test_recent_tool_streak_count_ignores_stale_entries
+        ] )
+    ; ( "config"
+      , [ test_case "default social model" `Quick test_meta_defaults_social_model
+        ; test_case "unified runtime defaults" `Quick test_unified_turn_runtime_defaults
+        ] )
+    ; ( "metrics_observation"
+      , [ test_case
+            "prompt metrics fingerprint"
+            `Quick
+            test_prompt_metrics_fingerprint_is_deterministic
+        ; test_case "text response" `Quick test_metrics_text_response
+        ; test_case
+            "idle seconds gauge records observation"
+            `Quick
+            test_metrics_idle_seconds_gauge_records_observation
+        ; test_case
+            "surface model prefers successful cascade label"
+            `Quick
+            test_metrics_surface_model_prefers_successful_cascade_label
+        ; test_case
+            "resolved_model_id prefers last attempt id (#9953)"
+            `Quick
+            test_metrics_resolved_model_id_prefers_last_attempt_id
+        ; test_case
+            "resolved_model_id falls back to model_used (#9953)"
+            `Quick
+            test_metrics_resolved_model_id_fallback_to_model_used
+        ; test_case "tool response" `Quick test_metrics_tool_response
+        ; test_case "noop response" `Quick test_metrics_noop_response
+        ; test_case
+            "observation-only tools are noop"
+            `Quick
+            test_metrics_observation_only_tools_are_noop
+        ; test_case
+            "execution tools are substantive"
+            `Quick
+            test_metrics_execution_tools_are_substantive
+        ; test_case
+            "validated evidence counts as visible"
+            `Quick
+            test_metrics_validated_evidence_counts_as_visible
+        ; test_case
+            "failed validation does not count as visible"
+            `Quick
+            test_metrics_failed_validation_does_not_count_as_visible
+        ; test_case
+            "file write evidence counts as visible"
+            `Quick
+            test_metrics_file_write_evidence_counts_as_visible
+        ; test_case
+            "heartbeat-only tool response is maintenance only"
+            `Quick
+            test_metrics_heartbeat_only_tool_response_is_maintenance_only
+        ; test_case
+            "reactive turn leaves proactive runtime untouched"
+            `Quick
+            test_metrics_reactive_turn_does_not_mutate_proactive_runtime
+        ; test_case
+            "silent proactive cycle advances cooldown anchor"
+            `Quick
+            test_silent_proactive_cycle_advances_cooldown_anchor
+        ; test_case
+            "reactive failure leaves proactive runtime untouched"
+            `Quick
+            test_metrics_reactive_failure_does_not_mutate_proactive_runtime
+        ; test_case
+            "legacy migration does not infer visible proactive fields"
+            `Quick
+            test_meta_migration_does_not_infer_visible_proactive_fields
+        ; test_case
+            "snapshot includes cascade observation"
+            `Quick
+            test_append_metrics_snapshot_includes_cascade_observation
+        ; test_case
+            "snapshot treats validated evidence as tool use"
+            `Quick
+            test_append_metrics_snapshot_treats_validated_evidence_as_tool_use
+        ; test_case
+            "snapshot counts only mode violation refs"
+            `Quick
+            test_append_metrics_snapshot_counts_only_mode_violation_refs
+        ; test_case
+            "snapshot nulls unreported usage"
+            `Quick
+            test_append_metrics_snapshot_nulls_unreported_usage
+        ; test_case
+            "snapshot persists cache usage"
+            `Quick
+            test_append_metrics_snapshot_persists_cache_usage
+        ; test_case
+            "trusted usage cost uses cache token pricing"
+            `Quick
+            test_estimate_trusted_usage_cost_uses_cache_usage
+        ; test_case
+            "total cost gauge records accumulated keeper cost"
+            `Quick
+            test_record_keeper_total_cost_metric
+        ; test_case
+            "snapshot marks untrusted usage"
+            `Quick
+            test_append_metrics_snapshot_marks_untrusted_usage
+        ; test_case
+            "decision record persists tool call details"
+            `Quick
+            test_append_decision_record_persists_tool_calls
+        ; test_case
+            "decision record nulls unreported usage"
+            `Quick
+            test_append_decision_record_nulls_unreported_usage
+        ; test_case
+            "decision record classifies worktree blocker"
+            `Quick
+            test_append_decision_record_classifies_legacy_worktree_error
+        ; test_case
+            "decision record preserves no-result skipped outcome"
+            `Quick
+            test_append_decision_record_preserves_no_result_skipped_outcome
+        ; test_case "social fields" `Quick test_metrics_persist_social_state_fields
+        ; test_case "failure response" `Quick test_metrics_failure_response
+        ; test_case
+            "timeout failure increments proactive backoff"
+            `Quick
+            test_metrics_failure_timeout_increments_proactive_backoff
+        ; test_case
+            "failure response redacts resumable session detail"
+            `Quick
+            test_metrics_failure_response_redacts_resumable_cli_session_detail
+        ; test_case "mixed response" `Quick test_metrics_mixed_response
+        ; test_case
+            "normalize passthrough"
+            `Quick
+            test_normalize_response_text_passthrough
+        ; test_case
+            "normalize tool only synthesizes"
+            `Quick
+            test_normalize_response_text_tool_only_synthesizes
+        ; test_case
+            "normalize empty without tools errors"
+            `Quick
+            test_normalize_response_text_empty_without_tools_errors
+        ; test_case
+            "completion contract allows text without tools"
+            `Quick
+            test_validate_completion_contract_allows_text_without_tools
+        ; test_case
+            "completion contract requires tool use"
+            `Quick
+            test_validate_completion_contract_requires_tool_use
+        ; test_case
+            "completion contract accepts stay silent"
+            `Quick
+            test_validate_completion_contract_accepts_stay_silent
+        ; test_case
+            "unexpected tool names accepts keeper surface"
+            `Quick
+            test_unexpected_tool_names_accepts_keeper_surface
+        ; test_case
+            "unexpected tool names reports foreign surface"
+            `Quick
+            test_unexpected_tool_names_reports_foreign_surface
+        ; test_case
+            "completion contract mapping allows auto"
+            `Quick
+            test_completion_contract_of_tool_choice_allows_auto
+        ; test_case
+            "completion contract mapping requires any"
+            `Quick
+            test_completion_contract_of_tool_choice_requires_any
+        ; test_case
+            "run completion contract latches required tool use"
+            `Quick
+            test_run_completion_contract_latches_required_tool_use
+        ; test_case
             "completion contract presence requires keeper-surface tool"
             `Quick
-            test_validate_completion_contract_presence_requires_keeper_surface_tool;
-          test_case "actionable signal rejects no tools" `Quick
-            test_actionable_tool_contract_flags_no_tools;
-          test_case "actionable signal rejects passive-only tools" `Quick
-            test_actionable_tool_contract_flags_passive_only_tools;
-          test_case
+            test_validate_completion_contract_presence_requires_keeper_surface_tool
+        ; test_case
+            "actionable signal rejects no tools"
+            `Quick
+            test_actionable_tool_contract_flags_no_tools
+        ; test_case
+            "actionable signal rejects passive-only tools"
+            `Quick
+            test_actionable_tool_contract_flags_passive_only_tools
+        ; test_case
             "actionable signal rejects claim context after ownership"
             `Quick
-            test_actionable_tool_contract_rejects_claim_context_when_already_claimed;
-          test_case
+            test_actionable_tool_contract_rejects_claim_context_when_already_claimed
+        ; test_case
             "actionable signal rejects stay_silent after ownership"
             `Quick
-            test_actionable_tool_contract_rejects_stay_silent_when_already_claimed;
-          test_case "claim tool classification covers masc claim task" `Quick
-            test_claim_tool_classification_covers_masc_claim_task;
-          test_case "actionable signal allows execution tools" `Quick
-            test_actionable_tool_contract_allows_execution_tools;
-          test_case "stay_silent needs typed no-work proof on actionable signal" `Quick
-            test_stay_silent_requires_typed_no_work_proof_on_actionable_signal;
-          test_case "required tool predicate rejects passive tools" `Quick
-            test_required_tool_satisfaction_rejects_passive_tools;
-          test_case "required tool predicate accepts mutating tools" `Quick
-            test_required_tool_satisfaction_accepts_mutating_tools;
-          test_case
+            test_actionable_tool_contract_rejects_stay_silent_when_already_claimed
+        ; test_case
+            "claim tool classification covers masc claim task"
+            `Quick
+            test_claim_tool_classification_covers_masc_claim_task
+        ; test_case
+            "actionable signal allows execution tools"
+            `Quick
+            test_actionable_tool_contract_allows_execution_tools
+        ; test_case
+            "stay_silent needs typed no-work proof on actionable signal"
+            `Quick
+            test_stay_silent_requires_typed_no_work_proof_on_actionable_signal
+        ; test_case
+            "required tool predicate rejects passive tools"
+            `Quick
+            test_required_tool_satisfaction_rejects_passive_tools
+        ; test_case
+            "required tool predicate accepts mutating tools"
+            `Quick
+            test_required_tool_satisfaction_accepts_mutating_tools
+        ; test_case
             "explicit required tool predicate accepts named passive tool"
             `Quick
-            test_explicit_required_tool_satisfaction_accepts_named_passive_tool;
-          test_case "tool usage delta uses registry counts" `Quick
-            test_tool_usage_delta_uses_registry_counts;
-          test_case "tool usage delta ignores removed tools" `Quick
-            test_tool_usage_delta_ignores_removed_tools;
-          test_case "merge observed tool names uses hook evidence" `Quick
-            test_merge_observed_tool_names_prefers_hook_without_double_counting;
-          test_case "merge observed tool names keeps extra registry repeats" `Quick
-            test_merge_observed_tool_names_preserves_extra_registry_repeats;
-          test_case "merge observed and synthetic tool names" `Quick
-            test_merge_reported_and_observed_tool_names_preserves_synthetic_tools;
-          test_case "final keeper tool names fall back to reported tools"
+            test_explicit_required_tool_satisfaction_accepts_named_passive_tool
+        ; test_case
+            "tool usage delta uses registry counts"
             `Quick
-            test_final_keeper_tool_names_falls_back_to_reported_tool_use;
-          test_case "final keeper tool names accept reported MCP keeper tool"
+            test_tool_usage_delta_uses_registry_counts
+        ; test_case
+            "tool usage delta ignores removed tools"
             `Quick
-            test_final_keeper_tool_names_accepts_reported_mcp_keeper_tool;
-          test_case "tool query strips continuity noise" `Quick
-            test_tool_query_text_of_user_message_strips_continuity_noise;
-          test_case "tool query keeps counted headers" `Quick
-            test_tool_query_text_of_user_message_keeps_counted_headers;
-          test_case "scope messages cap prompt payload not count" `Quick
-            test_scope_messages_prompt_caps_payload_not_count;
-          test_case "social model registry round trip" `Quick
-            test_social_model_registry_round_trip;
-          test_case "social model silences skip-only turn" `Quick
-            test_social_model_silences_skip_only_turn;
-          test_case "social model unknown meta falls back to baseline" `Quick
-            test_social_model_unknown_meta_falls_back_to_baseline;
-          test_case "social model unknown header falls back to baseline" `Quick
-            test_social_model_unknown_header_falls_back_to_baseline;
-          test_case "social model infers visible reply without headers" `Quick
-            test_social_model_infers_visible_reply_without_headers;
-          test_case "social model empty text without headers stays silent" `Quick
-            test_social_model_empty_text_without_headers_stays_silent;
-          test_case "social model state-only reply stays silent" `Quick
-            test_social_model_state_only_reply_stays_silent;
-          test_case "social model strips state block from visible reply" `Quick
-            test_social_model_strips_state_block_from_visible_reply;
-          test_case "social model routes blocker to board post" `Quick
-            test_social_model_routes_blocker_to_board_post;
-          test_case "social model tool-only turn skips protocol violation" `Quick
-            test_social_model_tool_only_turn_skips_protocol_violation;
-          test_case "social model restores previous state from runtime" `Quick
-            test_social_model_previous_state_of_meta_restores_runtime_fields;
-          test_case "social model tool-only turn carries previous state" `Quick
-            test_social_model_tool_only_turn_carries_previous_state;
-          test_case "social model infers board comment from tool use" `Quick
-            test_social_model_infers_board_comment_from_tool_use;
-          test_case
-            "social model does not infer comment vote as board comment" `Quick
-            test_social_model_does_not_infer_comment_vote_as_board_comment;
-          test_case "social model infers masc claim task from tool use" `Quick
-            test_social_model_infers_masc_claim_task_from_tool_use;
-          test_case "magentic ledger silences tool-only turn" `Quick
-            test_social_model_magentic_ledger_silences_tool_only_turn;
-          test_case "magentic ledger tracks masc claim task" `Quick
-            test_social_model_magentic_ledger_tracks_masc_claim_task;
-          test_case "magentic ledger hides non-visible tool text" `Quick
-            test_social_model_magentic_ledger_hides_nonvisible_tool_text;
-          test_case "magentic ledger restores previous state model" `Quick
-            test_social_model_magentic_ledger_previous_state_of_meta_restores_model;
-          test_case "social model previous state falls back for unknown model" `Quick
-            test_social_model_previous_state_of_meta_falls_back_for_unknown_model;
-          test_case "bdi failure rewrites stale claim retry loop" `Quick
-            test_social_model_bdi_failure_state_rewrites_claim_retry_loop;
-          test_case "bdi required-tool failure requests help" `Quick
-            test_social_model_required_tool_failure_requests_help;
-          test_case "bdi failure keeps ordinary carry state" `Quick
-            test_social_model_bdi_failure_state_keeps_existing_carry_without_claim_context;
-          test_case "magentic ledger stalled state carries until delta" `Quick
-            test_social_model_magentic_ledger_stalled_state_carries_until_delta;
-          test_case "render_inline deny" `Quick
-            test_render_inline_skip_reason_deny;
-          test_case "render_inline cost" `Quick
-            test_render_inline_skip_reason_cost;
-          test_case "render_inline destructive" `Quick
-            test_render_inline_skip_reason_destructive;
-          test_case "normalize override passthrough" `Quick
-            test_normalize_override_passthrough;
-          test_case "escape edge cases" `Quick
-            test_render_inline_escape_edge_cases;
-          test_case "render_inline with replacement" `Quick
-            test_render_inline_with_replacement;
-        ] );
-      ( "transient_network_error",
-        [
-          test_case "NetworkError detected" `Quick (fun () ->
-            check bool "network error" true
+            test_tool_usage_delta_ignores_removed_tools
+        ; test_case
+            "merge observed tool names uses hook evidence"
+            `Quick
+            test_merge_observed_tool_names_prefers_hook_without_double_counting
+        ; test_case
+            "merge observed tool names keeps extra registry repeats"
+            `Quick
+            test_merge_observed_tool_names_preserves_extra_registry_repeats
+        ; test_case
+            "merge observed and synthetic tool names"
+            `Quick
+            test_merge_reported_and_observed_tool_names_preserves_synthetic_tools
+        ; test_case
+            "final keeper tool names fall back to reported tools"
+            `Quick
+            test_final_keeper_tool_names_falls_back_to_reported_tool_use
+        ; test_case
+            "final keeper tool names accept reported MCP keeper tool"
+            `Quick
+            test_final_keeper_tool_names_accepts_reported_mcp_keeper_tool
+        ; test_case
+            "tool query strips continuity noise"
+            `Quick
+            test_tool_query_text_of_user_message_strips_continuity_noise
+        ; test_case
+            "tool query keeps counted headers"
+            `Quick
+            test_tool_query_text_of_user_message_keeps_counted_headers
+        ; test_case
+            "scope messages cap prompt payload not count"
+            `Quick
+            test_scope_messages_prompt_caps_payload_not_count
+        ; test_case
+            "social model registry round trip"
+            `Quick
+            test_social_model_registry_round_trip
+        ; test_case
+            "social model silences skip-only turn"
+            `Quick
+            test_social_model_silences_skip_only_turn
+        ; test_case
+            "social model unknown meta falls back to baseline"
+            `Quick
+            test_social_model_unknown_meta_falls_back_to_baseline
+        ; test_case
+            "social model unknown header falls back to baseline"
+            `Quick
+            test_social_model_unknown_header_falls_back_to_baseline
+        ; test_case
+            "social model infers visible reply without headers"
+            `Quick
+            test_social_model_infers_visible_reply_without_headers
+        ; test_case
+            "social model empty text without headers stays silent"
+            `Quick
+            test_social_model_empty_text_without_headers_stays_silent
+        ; test_case
+            "social model state-only reply stays silent"
+            `Quick
+            test_social_model_state_only_reply_stays_silent
+        ; test_case
+            "social model strips state block from visible reply"
+            `Quick
+            test_social_model_strips_state_block_from_visible_reply
+        ; test_case
+            "social model routes blocker to board post"
+            `Quick
+            test_social_model_routes_blocker_to_board_post
+        ; test_case
+            "social model tool-only turn skips protocol violation"
+            `Quick
+            test_social_model_tool_only_turn_skips_protocol_violation
+        ; test_case
+            "social model restores previous state from runtime"
+            `Quick
+            test_social_model_previous_state_of_meta_restores_runtime_fields
+        ; test_case
+            "social model tool-only turn carries previous state"
+            `Quick
+            test_social_model_tool_only_turn_carries_previous_state
+        ; test_case
+            "social model infers board comment from tool use"
+            `Quick
+            test_social_model_infers_board_comment_from_tool_use
+        ; test_case
+            "social model does not infer comment vote as board comment"
+            `Quick
+            test_social_model_does_not_infer_comment_vote_as_board_comment
+        ; test_case
+            "social model infers masc claim task from tool use"
+            `Quick
+            test_social_model_infers_masc_claim_task_from_tool_use
+        ; test_case
+            "magentic ledger silences tool-only turn"
+            `Quick
+            test_social_model_magentic_ledger_silences_tool_only_turn
+        ; test_case
+            "magentic ledger tracks masc claim task"
+            `Quick
+            test_social_model_magentic_ledger_tracks_masc_claim_task
+        ; test_case
+            "magentic ledger hides non-visible tool text"
+            `Quick
+            test_social_model_magentic_ledger_hides_nonvisible_tool_text
+        ; test_case
+            "magentic ledger restores previous state model"
+            `Quick
+            test_social_model_magentic_ledger_previous_state_of_meta_restores_model
+        ; test_case
+            "social model previous state falls back for unknown model"
+            `Quick
+            test_social_model_previous_state_of_meta_falls_back_for_unknown_model
+        ; test_case
+            "bdi failure rewrites stale claim retry loop"
+            `Quick
+            test_social_model_bdi_failure_state_rewrites_claim_retry_loop
+        ; test_case
+            "bdi required-tool failure requests help"
+            `Quick
+            test_social_model_required_tool_failure_requests_help
+        ; test_case
+            "bdi failure keeps ordinary carry state"
+            `Quick
+            test_social_model_bdi_failure_state_keeps_existing_carry_without_claim_context
+        ; test_case
+            "magentic ledger stalled state carries until delta"
+            `Quick
+            test_social_model_magentic_ledger_stalled_state_carries_until_delta
+        ; test_case "render_inline deny" `Quick test_render_inline_skip_reason_deny
+        ; test_case "render_inline cost" `Quick test_render_inline_skip_reason_cost
+        ; test_case
+            "render_inline destructive"
+            `Quick
+            test_render_inline_skip_reason_destructive
+        ; test_case
+            "normalize override passthrough"
+            `Quick
+            test_normalize_override_passthrough
+        ; test_case "escape edge cases" `Quick test_render_inline_escape_edge_cases
+        ; test_case
+            "render_inline with replacement"
+            `Quick
+            test_render_inline_with_replacement
+        ] )
+    ; ( "transient_network_error"
+      , [ test_case "NetworkError detected" `Quick (fun () ->
+            check
+              bool
+              "network error"
+              true
               (EC.is_transient_network_error
                  (Agent_sdk.Error.Api
                     (NetworkError
-                       {
-                         message = "Connection_reset";
-                         kind = Llm_provider.Http_client.Connection_refused;
-                       }))));
-          test_case "Timeout detected" `Quick (fun () ->
-            check bool "timeout" true
+                       { message = "Connection_reset"
+                       ; kind = Llm_provider.Http_client.Connection_refused
+                       }))))
+        ; test_case "Timeout detected" `Quick (fun () ->
+            check
+              bool
+              "timeout"
+              true
               (EC.is_transient_network_error
-                 (Agent_sdk.Error.Api (Timeout { message = "connection timed out" }))));
-          test_case "structural OAS timeout is not network transient" `Quick (fun () ->
-            check bool "oas budget timeout" false
+                 (Agent_sdk.Error.Api (Timeout { message = "connection timed out" }))))
+        ; test_case "structural OAS timeout is not network transient" `Quick (fun () ->
+            check
+              bool
+              "oas budget timeout"
+              false
               (EC.is_transient_network_error
                  (Agent_sdk.Error.Api
-                    (Timeout { message = "Timeout after 573.2s (budget=573s)" }))));
-          test_case "Overloaded detected" `Quick (fun () ->
-            check bool "overloaded" true
+                    (Timeout { message = "Timeout after 573.2s (budget=573s)" }))))
+        ; test_case "Overloaded detected" `Quick (fun () ->
+            check
+              bool
+              "overloaded"
+              true
               (EC.is_transient_network_error
-                 (Agent_sdk.Error.Api (Overloaded { message = "server busy" }))));
-          test_case "ServerError 503 detected" `Quick (fun () ->
-            check bool "503" true
+                 (Agent_sdk.Error.Api (Overloaded { message = "server busy" }))))
+        ; test_case "ServerError 503 detected" `Quick (fun () ->
+            check
+              bool
+              "503"
+              true
               (EC.is_transient_network_error
-                 (Agent_sdk.Error.Api (ServerError { status = 503; message = "Service Unavailable" }))));
-          test_case "ServerError 500 not transient" `Quick (fun () ->
-            check bool "500" false
+                 (Agent_sdk.Error.Api
+                    (ServerError { status = 503; message = "Service Unavailable" }))))
+        ; test_case "ServerError 500 not transient" `Quick (fun () ->
+            check
+              bool
+              "500"
+              false
               (EC.is_transient_network_error
-                 (Agent_sdk.Error.Api (ServerError { status = 500; message = "Internal" }))));
-          test_case "AuthError not transient" `Quick (fun () ->
-            check bool "auth" false
+                 (Agent_sdk.Error.Api (ServerError { status = 500; message = "Internal" }))))
+        ; test_case "AuthError not transient" `Quick (fun () ->
+            check
+              bool
+              "auth"
+              false
               (EC.is_transient_network_error
-                 (Agent_sdk.Error.Api (AuthError { message = "Unauthorized" }))));
-          test_case "RateLimited not transient" `Quick (fun () ->
-            check bool "rate limit" false
+                 (Agent_sdk.Error.Api (AuthError { message = "Unauthorized" }))))
+        ; test_case "RateLimited not transient" `Quick (fun () ->
+            check
+              bool
+              "rate limit"
+              false
               (EC.is_transient_network_error
-                 (Agent_sdk.Error.Api (RateLimited { retry_after = None; message = "429" }))));
-          test_case "ContextOverflow not transient" `Quick (fun () ->
-            check bool "overflow" false
+                 (Agent_sdk.Error.Api
+                    (RateLimited { retry_after = None; message = "429" }))))
+        ; test_case "ContextOverflow not transient" `Quick (fun () ->
+            check
+              bool
+              "overflow"
+              false
               (EC.is_transient_network_error
-                 (Agent_sdk.Error.Api (ContextOverflow { message = "exceeded"; limit = None }))));
-          test_case "Internal error not transient" `Quick (fun () ->
-            check bool "internal" false
-              (EC.is_transient_network_error
-                 (Agent_sdk.Error.Internal "some error")));
-          test_case "timeout after mutating tool becomes persistent" `Quick
-            test_side_effect_timeout_reclassified_as_persistent;
-          test_case "reclassification requires committed tools" `Quick
-            test_side_effect_reclassification_requires_committed_tools;
-          test_case "read-only tool timeouts stay transient" `Quick
-            test_side_effect_reclassification_ignores_read_only_tools;
-          test_case "any post-commit error becomes ambiguous partial" `Quick
-            test_side_effect_reclassification_marks_any_post_commit_error;
-          test_case "timeout classified as post-commit timeout" `Quick
-            test_post_commit_failure_kind_marks_timeouts;
-          test_case "non-timeout classified as post-commit failure" `Quick
-            test_post_commit_failure_kind_marks_non_timeouts_as_failures;
-          test_case "tool events pair across drains" `Quick
-            test_turn_tool_event_tracker_pairs_called_across_drains;
-          test_case "ToolCompleted requires prior ToolCalled" `Quick
-            test_turn_tool_event_tracker_rejects_completed_without_called;
-          test_case "failed ToolCompleted does not claim commit" `Quick
-            test_turn_tool_event_tracker_rejects_failed_completed_without_commit;
-          test_case "ollama closing brace detected as server parse error" `Quick
-            test_server_rejected_parse_error_ollama_closing_brace;
-          test_case "unterminated JSON detected as server parse error" `Quick
-            test_server_rejected_parse_error_unterminated;
-          test_case "unexpected character in JSON detected" `Quick
-            test_server_rejected_parse_error_unexpected_char;
-          test_case "parse error detected" `Quick
-            test_server_rejected_parse_error_parse_error;
-          test_case "case insensitive detection" `Quick
-            test_server_rejected_parse_error_case_insensitive;
-          test_case "generic InvalidRequest is NOT server parse error" `Quick
-            test_server_rejected_parse_error_generic_invalid_request;
-          test_case "generic 'closing' is NOT server parse error" `Quick
-            test_server_rejected_parse_error_generic_closing;
-          test_case "generic 'can't find' is NOT server parse error" `Quick
-            test_server_rejected_parse_error_generic_cant_find;
-          test_case "network error is NOT server parse error" `Quick
-            test_server_rejected_parse_error_network_error;
-          test_case "auto-recoverable includes transient network" `Quick
-            test_auto_recoverable_turn_error_includes_transient_network;
-          test_case "auto-recoverable includes server parse rejection" `Quick
-            test_auto_recoverable_turn_error_includes_server_parse_rejection;
-          test_case "auto-recoverable includes wrapped hard quota" `Quick
-            test_auto_recoverable_turn_error_includes_wrapped_hard_quota;
-          test_case "auto-recoverable includes wrapped CLI max turns" `Quick
-            test_auto_recoverable_turn_error_includes_wrapped_max_turns;
-          test_case "required tool contract violation detected from structured error" `Quick
-            test_required_tool_contract_violation_detected;
-          test_case "legacy internal contract violation is ignored" `Quick
-            test_required_tool_contract_violation_ignores_legacy_internal_error;
-          test_case "rotation cap does not fire before first rotation" `Quick
-            test_should_cap_rotation_does_not_fire_on_first_attempt;
-          test_case "rotation cap fires after one rotation" `Quick
-            test_should_cap_rotation_fires_after_one_rotation;
-          test_case "rotation cap suppressed while fallback available" `Quick
-            test_should_cap_rotation_suppressed_while_fallback_available;
-          test_case "rotation cap ignores non-contract-violation errors" `Quick
-            test_should_cap_rotation_ignores_non_contract_violation_error;
-          test_case "structured cascade exhausted error detected" `Quick
-            test_cascade_exhausted_error_detected_from_structured_internal_error;
-          test_case "legacy internal cascade exhaustion is ignored" `Quick
-            test_cascade_exhausted_error_ignores_legacy_internal_error;
-          test_case "auto-recoverable excludes tool-choice contract violation" `Quick
-            test_auto_recoverable_turn_error_excludes_required_tool_contract_violation;
-          test_case "auto-recoverable excludes persistent errors" `Quick
-            test_auto_recoverable_turn_error_excludes_persistent_errors;
-          test_case "auto-recoverable includes wrapped cascade hard quota" `Quick
-            test_auto_recoverable_turn_error_includes_wrapped_cascade_exhausted_hard_quota;
-          test_case "auto-recoverable includes wrapped cascade max turns" `Quick
-            test_auto_recoverable_turn_error_includes_wrapped_cascade_max_turns;
-          test_case "auto-recoverable includes filtered candidates cascade exhaustion" `Quick
-            test_auto_recoverable_turn_error_includes_filtered_candidates_cascade_exhaustion;
-          test_case "auto-recoverable includes resumable CLI session error" `Quick
-            test_auto_recoverable_turn_error_includes_resumable_cli_session_error;
-          test_case "cascade exhausted surface includes resumable CLI session error" `Quick
-            test_cascade_exhausted_error_includes_resumable_cli_session_error;
-          test_case "bounded OAS timeout keeps adaptive timeout under full budget" `Quick
-            test_bounded_oas_timeout_uses_adaptive_when_budget_is_large;
-          test_case "bounded OAS timeout is token-independent (#10008 fm2)" `Quick
-            test_bounded_oas_timeout_is_token_independent;
-          test_case "bounded OAS timeout caps to remaining turn budget" `Quick
-            test_bounded_oas_timeout_caps_to_remaining_turn_budget;
-          test_case "bounded OAS timeout respects channel turn budget override" `Quick
-            test_bounded_oas_timeout_uses_channel_turn_budget_override;
-          test_case "bounded OAS timeout reserves degraded retry budget" `Quick
-            test_bounded_oas_timeout_reserves_degraded_retry_budget;
-          test_case "attempt watchdog preserves degraded retry reserve" `Quick
-            test_attempt_watchdog_preserves_degraded_retry_reserve;
-          test_case "attempt watchdog fires before outer turn timeout" `Quick
-            test_attempt_watchdog_fires_before_outer_turn_timeout;
-          test_case "bounded OAS timeout refuses too little remaining budget" `Quick
-            test_bounded_oas_timeout_refuses_too_little_budget;
-          test_case "OAS timeout classification uses current attempt budget" `Quick
-            test_oas_timeout_reclassifies_only_current_attempt_budget;
-          test_case "plain pre-retry timeout helper does not reuse stale budget" `Quick
-            test_pre_retry_timeout_helper_does_not_reuse_stale_budget;
-          test_case "degraded retry is allowed when turn budget remains" `Quick
-            test_degraded_retry_budget_gate_allows_remaining_budget;
-          test_case "degraded retry is blocked when turn budget is exhausted" `Quick
-            test_degraded_retry_budget_gate_blocks_exhausted_budget;
-          test_case "OAS timeout budget can still rotate to local recovery after slot phase" `Quick
-            test_degraded_retry_slot_phase_allows_oas_timeout_local_recovery;
-          test_case "contract retry gets first rotation after slot phase (#12888)"
+                 (Agent_sdk.Error.Api
+                    (ContextOverflow { message = "exceeded"; limit = None }))))
+        ; test_case "Internal error not transient" `Quick (fun () ->
+            check
+              bool
+              "internal"
+              false
+              (EC.is_transient_network_error (Agent_sdk.Error.Internal "some error")))
+        ; test_case
+            "timeout after mutating tool becomes persistent"
             `Quick
-            test_degraded_retry_slot_phase_allows_first_contract_rotation;
-          test_case "per-attempt retry budget with near-zero remaining (#12675)" `Quick
-            test_per_attempt_retry_budget_with_near_zero_remaining;
-          test_case "per-attempt retry budget capped by healthy remaining" `Quick
-            test_per_attempt_retry_budget_capped_by_remaining_when_healthy;
-          test_case "plain retry blocks after adaptive budget is spent" `Quick
-            test_per_attempt_retry_blocks_after_adaptive_budget_spent;
-          test_case "degraded retry can use remaining wall-clock budget" `Quick
-            test_degraded_retry_wall_clock_budget_allows_remaining_turn_time;
-          test_case "degraded retry wall-clock budget is one-shot" `Quick
-            test_degraded_retry_wall_clock_budget_gate_is_one_shot;
-          test_case "non-retry still refuses tiny budget" `Quick
-            test_non_retry_still_refuses_tiny_budget;
-          test_case "per-attempt retry refuses zero remaining (#12675)" `Quick
-            test_per_attempt_retry_refuses_zero_remaining;
-          test_case "degraded retry gate allows retry with tiny remaining (#12675)" `Quick
-            test_degraded_retry_budget_gate_allows_retry_with_tiny_remaining;
-          test_case "pure local label detection" `Quick
-            test_pure_local_labels_detection;
-          test_case "pure local context clamp" `Quick
-            test_clamp_context_for_pure_local_labels;
-          test_case "turn context budget uses primary model" `Quick
-            test_resolved_max_context_for_turn_uses_primary_budget;
-          test_case "max_context resolution separates override and effective budget" `Quick
-            test_max_context_resolution_separates_override_and_effective_budget;
-          test_case "resolved max_context dispatch uses effective budget" `Quick
-            test_resolved_max_context_for_turn_uses_effective_budget;
-          test_case "read-only keeper tools do not become ambiguous partial" `Quick
-            test_side_effect_reclassification_ignores_keeper_read_only_tools;
-          test_case "mixed tool sets only keep mutating keeper tools" `Quick
-            test_side_effect_reclassification_drops_keeper_read_only_tools_from_mixed_set;
-          test_case "overflow detection and limit parsing" `Quick
-            test_overflow_detection_and_limit_parsing;
-        ] );
-      ( "context_overflow",
-        [
-          test_case "parses common OAS overflow errors (SSOT)" `Quick
-            test_context_overflow_limit_parses_common_oas_errors;
-          test_case "is_context_overflow only matches ContextOverflow" `Quick
-            test_is_context_overflow_only_for_overflow_errors;
-          test_case "summarize_turn_event_bus extracts overflow signal" `Quick
-            test_summarize_turn_event_bus_extracts_overflow_signal;
-          test_case "context_overflow_event prefers event bus signal" `Quick
-            test_context_overflow_event_prefers_event_bus_signal;
-          test_case "context_overflow_event falls back without event bus signal" `Quick
-            test_context_overflow_event_falls_back_without_event_bus_signal;
-        ] );
-      ( "phase_gate",
-        [
-          test_case "run_keeper_cycle skips paused keeper" `Quick
-            test_run_keeper_cycle_skips_non_executable_phase;
-          test_case "run_keeper_cycle errors on livelock block" `Quick
-            test_run_keeper_cycle_livelock_block_returns_error;
-          test_case "streaming cancel records supervisor stop" `Quick
-            test_streaming_cancel_records_supervisor_stop_when_fiber_stop_set;
-          test_case "run_keeper_cycle records trajectory contract" `Quick
-            test_run_keeper_cycle_records_trajectory_source_contract;
-          test_case "pre-tool gates record durable attempt telemetry" `Quick
-            test_pre_tool_gate_records_durable_attempt_telemetry;
-          test_case "run_keeper_cycle surfaces side-effect failures contract"
+            test_side_effect_timeout_reclassified_as_persistent
+        ; test_case
+            "reclassification requires committed tools"
             `Quick
-            test_run_keeper_cycle_surfaces_side_effect_failures_source_contract;
-          test_case "paused-state sync surfaces write failure" `Quick
-            test_sync_keeper_paused_state_surfaces_write_failure_without_mutating_registry;
-          test_case "local discovery guard surfaces refresh failure" `Quick
-            test_ensure_local_discovery_ready_surfaces_refresh_failure;
-          test_case "async keeper_msg preflight surfaces discovery failure" `Quick
-            test_keeper_msg_async_failure_surface;
-          test_case "local_only liveness decision keeps non-local route" `Quick
-            test_decide_local_only_liveness_keeps_non_local_effective;
-          test_case "local_only liveness decision keeps explicit local base"
+            test_side_effect_reclassification_requires_committed_tools
+        ; test_case
+            "read-only tool timeouts stay transient"
             `Quick
-            test_decide_local_only_liveness_keeps_explicit_local_only;
-          test_case "local_only liveness decision requests deduped probe"
+            test_side_effect_reclassification_ignores_read_only_tools
+        ; test_case
+            "any post-commit error becomes ambiguous partial"
             `Quick
-            test_decide_local_only_liveness_requests_deduped_ollama_probe;
-          test_case "local_only fail-open falls back when ollama is down" `Quick
-            test_fail_open_local_only_when_probe_fails;
-          test_case "explicit local_only does not fail-open" `Quick
-            test_fail_open_local_only_preserves_explicit_local_only_base;
-          test_case "healthy local_only stays selected" `Quick
-            test_fail_open_local_only_preserves_healthy_local_only;
-          test_case "PR-B: empty labels yield no shared host" `Quick
-            test_resolve_shared_probeable_base_url_empty_returns_none;
-          test_case "PR-B: single probeable label resolves" `Quick
-            test_resolve_shared_probeable_base_url_single_label;
-          test_case "PR-B: probe registry gates resolution" `Quick
-            test_resolve_shared_probeable_base_url_requires_probe_registration;
-          test_case "PR-B: mixed hosts collapse to None" `Quick
-            test_resolve_shared_probeable_base_url_mixed_host;
-          test_case "PR-B: different hosts collapse to None" `Quick
-            test_resolve_shared_probeable_base_url_different_hosts;
-          test_case "PR-B: missing cache is fail-open" `Quick
-            test_is_base_url_saturated_returns_false_when_cache_missing;
-          test_case "PR-B: idle endpoint not saturated" `Quick
-            test_is_base_url_saturated_returns_false_when_idle;
-          test_case "PR-B: full endpoint with queue is saturated" `Quick
-            test_is_base_url_saturated_returns_true_when_full_with_queue;
-          test_case "PR-B: zero available without traffic is fail-open" `Quick
-            test_is_base_url_saturated_ignores_zero_available_when_idle;
-          test_case "PR-B follow-up: fresh keeper has zero skip count" `Quick
-            test_saturation_skip_count_starts_at_zero;
-          test_case "PR-B follow-up: inc returns monotonic counts" `Quick
-            test_saturation_skip_count_inc_returns_new_value;
-          test_case "PR-B follow-up: reset zeros one keeper only" `Quick
-            test_saturation_skip_count_reset_zeros_one_keeper;
-          test_case "PR-B follow-up: cap floored at 1" `Quick
-            test_saturation_skip_cap_default_is_at_least_one;
-          test_case "hard quota degraded retry uses local_recovery" `Quick
-            test_degraded_retry_after_recoverable_error_uses_local_recovery_for_hard_quota;
-          test_case "resumable session degraded retry uses local_recovery"
+            test_side_effect_reclassification_marks_any_post_commit_error
+        ; test_case
+            "timeout classified as post-commit timeout"
             `Quick
-            test_degraded_retry_after_recoverable_error_uses_local_recovery_for_resumable_session;
-          test_case "admission queue timeout is degraded-retry eligible"
+            test_post_commit_failure_kind_marks_timeouts
+        ; test_case
+            "non-timeout classified as post-commit failure"
             `Quick
-            test_degraded_retry_after_recoverable_error_includes_admission_queue_timeout;
-          test_case "turn timeout is degraded-retry eligible" `Quick
-            test_degraded_retry_after_recoverable_error_includes_turn_timeout;
-          test_case "OAS timeout budget is degraded-retry eligible" `Quick
-            test_degraded_retry_after_recoverable_error_includes_oas_timeout_budget;
-          test_case "max turns is degraded-retry eligible" `Quick
-            test_degraded_retry_after_recoverable_error_includes_max_turns;
-          test_case "required tool turns block degraded retry" `Quick
-            test_degraded_retry_after_recoverable_error_blocks_required_tools;
-          test_case "local_only stays terminal for degraded retry" `Quick
-            test_degraded_retry_after_recoverable_error_does_not_broaden_local_only;
-          test_case "local_recovery stays terminal for degraded retry" `Quick
-            test_degraded_retry_after_recoverable_error_does_not_broaden_local_recovery;
-          test_case "unavailable profile fallback prefers default" `Quick
-            test_fallback_cascade_for_unavailable_profile_prefers_default;
-          test_case "unavailable phase override fallback prefers base" `Quick
-            test_fallback_cascade_for_unavailable_profile_prefers_base_after_phase_override;
-          test_case "next degraded retry returns untried default cascade"
+            test_post_commit_failure_kind_marks_non_timeouts_as_failures
+        ; test_case
+            "tool events pair across drains"
             `Quick
-            test_next_fail_open_cascade_for_turn_returns_untried_default_cascade;
-          test_case "next degraded retry continues to local_recovery"
+            test_turn_tool_event_tracker_pairs_called_across_drains
+        ; test_case
+            "ToolCompleted requires prior ToolCalled"
             `Quick
-            test_next_fail_open_cascade_for_turn_continues_to_local_recovery;
-          test_case "next degraded retry suppresses exhausted rotation group"
+            test_turn_tool_event_tracker_rejects_completed_without_called
+        ; test_case
+            "failed ToolCompleted does not claim commit"
             `Quick
-            test_next_fail_open_cascade_for_turn_suppresses_exhausted_rotation_group;
-          test_case "required-tool rotation uses default without strict injection"
+            test_turn_tool_event_tracker_rejects_failed_completed_without_commit
+        ; test_case
+            "ollama closing brace detected as server parse error"
             `Quick
-            test_next_fail_open_cascade_for_required_tool_uses_default_not_strict;
-          test_case "required tool turns rotate without dropping requirement"
+            test_server_rejected_parse_error_ollama_closing_brace
+        ; test_case
+            "unterminated JSON detected as server parse error"
             `Quick
-            test_next_fail_open_cascade_for_turn_allows_required_tool_rotation;
-          test_case "required tool contract violations rotate retry lane"
+            test_server_rejected_parse_error_unterminated
+        ; test_case
+            "unexpected character in JSON detected"
             `Quick
-            test_next_fail_open_cascade_for_turn_retries_required_tool_contract_violation;
-          test_case "catalog rotation can continue beyond reserved recovery"
+            test_server_rejected_parse_error_unexpected_char
+        ; test_case
+            "parse error detected"
             `Quick
-            test_next_fail_open_cascade_for_turn_uses_catalog_rotation_profile;
-          test_case "catalog rotation does not inject missing default"
+            test_server_rejected_parse_error_parse_error
+        ; test_case
+            "case insensitive detection"
             `Quick
-            test_next_fail_open_cascade_for_turn_does_not_inject_default_when_catalog_omits_it;
-          test_case "required-tool catalog rotation filters local recovery"
+            test_server_rejected_parse_error_case_insensitive
+        ; test_case
+            "generic InvalidRequest is NOT server parse error"
             `Quick
-            test_next_fail_open_cascade_for_required_tool_filters_local_recovery_catalog;
-          test_case "required-tool local-recovery-only catalog exhausts"
+            test_server_rejected_parse_error_generic_invalid_request
+        ; test_case
+            "generic 'closing' is NOT server parse error"
             `Quick
-            test_next_fail_open_cascade_for_required_tool_rejects_local_recovery_only_catalog;
-          test_case "classifier filters required-tool catalog rotation"
+            test_server_rejected_parse_error_generic_closing
+        ; test_case
+            "generic 'can't find' is NOT server parse error"
             `Quick
-            test_degraded_rotation_after_recoverable_error_filters_required_catalog_directly;
-          test_case
+            test_server_rejected_parse_error_generic_cant_find
+        ; test_case
+            "network error is NOT server parse error"
+            `Quick
+            test_server_rejected_parse_error_network_error
+        ; test_case
+            "auto-recoverable includes transient network"
+            `Quick
+            test_auto_recoverable_turn_error_includes_transient_network
+        ; test_case
+            "auto-recoverable includes server parse rejection"
+            `Quick
+            test_auto_recoverable_turn_error_includes_server_parse_rejection
+        ; test_case
+            "auto-recoverable includes wrapped hard quota"
+            `Quick
+            test_auto_recoverable_turn_error_includes_wrapped_hard_quota
+        ; test_case
+            "auto-recoverable includes wrapped CLI max turns"
+            `Quick
+            test_auto_recoverable_turn_error_includes_wrapped_max_turns
+        ; test_case
+            "required tool contract violation detected from structured error"
+            `Quick
+            test_required_tool_contract_violation_detected
+        ; test_case
+            "legacy internal contract violation is ignored"
+            `Quick
+            test_required_tool_contract_violation_ignores_legacy_internal_error
+        ; test_case
+            "rotation cap does not fire before first rotation"
+            `Quick
+            test_should_cap_rotation_does_not_fire_on_first_attempt
+        ; test_case
+            "rotation cap fires after one rotation"
+            `Quick
+            test_should_cap_rotation_fires_after_one_rotation
+        ; test_case
+            "rotation cap suppressed while fallback available"
+            `Quick
+            test_should_cap_rotation_suppressed_while_fallback_available
+        ; test_case
+            "rotation cap ignores non-contract-violation errors"
+            `Quick
+            test_should_cap_rotation_ignores_non_contract_violation_error
+        ; test_case
+            "structured cascade exhausted error detected"
+            `Quick
+            test_cascade_exhausted_error_detected_from_structured_internal_error
+        ; test_case
+            "legacy internal cascade exhaustion is ignored"
+            `Quick
+            test_cascade_exhausted_error_ignores_legacy_internal_error
+        ; test_case
+            "auto-recoverable excludes tool-choice contract violation"
+            `Quick
+            test_auto_recoverable_turn_error_excludes_required_tool_contract_violation
+        ; test_case
+            "auto-recoverable excludes persistent errors"
+            `Quick
+            test_auto_recoverable_turn_error_excludes_persistent_errors
+        ; test_case
+            "auto-recoverable includes wrapped cascade hard quota"
+            `Quick
+            test_auto_recoverable_turn_error_includes_wrapped_cascade_exhausted_hard_quota
+        ; test_case
+            "auto-recoverable includes wrapped cascade max turns"
+            `Quick
+            test_auto_recoverable_turn_error_includes_wrapped_cascade_max_turns
+        ; test_case
+            "auto-recoverable includes filtered candidates cascade exhaustion"
+            `Quick
+            test_auto_recoverable_turn_error_includes_filtered_candidates_cascade_exhaustion
+        ; test_case
+            "auto-recoverable includes resumable CLI session error"
+            `Quick
+            test_auto_recoverable_turn_error_includes_resumable_cli_session_error
+        ; test_case
+            "cascade exhausted surface includes resumable CLI session error"
+            `Quick
+            test_cascade_exhausted_error_includes_resumable_cli_session_error
+        ; test_case
+            "bounded OAS timeout keeps adaptive timeout under full budget"
+            `Quick
+            test_bounded_oas_timeout_uses_adaptive_when_budget_is_large
+        ; test_case
+            "bounded OAS timeout is token-independent (#10008 fm2)"
+            `Quick
+            test_bounded_oas_timeout_is_token_independent
+        ; test_case
+            "bounded OAS timeout caps to remaining turn budget"
+            `Quick
+            test_bounded_oas_timeout_caps_to_remaining_turn_budget
+        ; test_case
+            "bounded OAS timeout respects channel turn budget override"
+            `Quick
+            test_bounded_oas_timeout_uses_channel_turn_budget_override
+        ; test_case
+            "bounded OAS timeout reserves degraded retry budget"
+            `Quick
+            test_bounded_oas_timeout_reserves_degraded_retry_budget
+        ; test_case
+            "attempt watchdog preserves degraded retry reserve"
+            `Quick
+            test_attempt_watchdog_preserves_degraded_retry_reserve
+        ; test_case
+            "attempt watchdog fires before outer turn timeout"
+            `Quick
+            test_attempt_watchdog_fires_before_outer_turn_timeout
+        ; test_case
+            "bounded OAS timeout refuses too little remaining budget"
+            `Quick
+            test_bounded_oas_timeout_refuses_too_little_budget
+        ; test_case
+            "OAS timeout classification uses current attempt budget"
+            `Quick
+            test_oas_timeout_reclassifies_only_current_attempt_budget
+        ; test_case
+            "plain pre-retry timeout helper does not reuse stale budget"
+            `Quick
+            test_pre_retry_timeout_helper_does_not_reuse_stale_budget
+        ; test_case
+            "degraded retry is allowed when turn budget remains"
+            `Quick
+            test_degraded_retry_budget_gate_allows_remaining_budget
+        ; test_case
+            "degraded retry is blocked when turn budget is exhausted"
+            `Quick
+            test_degraded_retry_budget_gate_blocks_exhausted_budget
+        ; test_case
+            "OAS timeout budget can still rotate to local recovery after slot phase"
+            `Quick
+            test_degraded_retry_slot_phase_allows_oas_timeout_local_recovery
+        ; test_case
+            "contract retry gets first rotation after slot phase (#12888)"
+            `Quick
+            test_degraded_retry_slot_phase_allows_first_contract_rotation
+        ; test_case
+            "per-attempt retry budget with near-zero remaining (#12675)"
+            `Quick
+            test_per_attempt_retry_budget_with_near_zero_remaining
+        ; test_case
+            "per-attempt retry budget capped by healthy remaining"
+            `Quick
+            test_per_attempt_retry_budget_capped_by_remaining_when_healthy
+        ; test_case
+            "plain retry blocks after adaptive budget is spent"
+            `Quick
+            test_per_attempt_retry_blocks_after_adaptive_budget_spent
+        ; test_case
+            "degraded retry can use remaining wall-clock budget"
+            `Quick
+            test_degraded_retry_wall_clock_budget_allows_remaining_turn_time
+        ; test_case
+            "degraded retry wall-clock budget is one-shot"
+            `Quick
+            test_degraded_retry_wall_clock_budget_gate_is_one_shot
+        ; test_case
+            "non-retry still refuses tiny budget"
+            `Quick
+            test_non_retry_still_refuses_tiny_budget
+        ; test_case
+            "per-attempt retry refuses zero remaining (#12675)"
+            `Quick
+            test_per_attempt_retry_refuses_zero_remaining
+        ; test_case
+            "degraded retry gate allows retry with tiny remaining (#12675)"
+            `Quick
+            test_degraded_retry_budget_gate_allows_retry_with_tiny_remaining
+        ; test_case "pure local label detection" `Quick test_pure_local_labels_detection
+        ; test_case
+            "pure local context clamp"
+            `Quick
+            test_clamp_context_for_pure_local_labels
+        ; test_case
+            "turn context budget uses primary model"
+            `Quick
+            test_resolved_max_context_for_turn_uses_primary_budget
+        ; test_case
+            "max_context resolution separates override and effective budget"
+            `Quick
+            test_max_context_resolution_separates_override_and_effective_budget
+        ; test_case
+            "resolved max_context dispatch uses effective budget"
+            `Quick
+            test_resolved_max_context_for_turn_uses_effective_budget
+        ; test_case
+            "read-only keeper tools do not become ambiguous partial"
+            `Quick
+            test_side_effect_reclassification_ignores_keeper_read_only_tools
+        ; test_case
+            "mixed tool sets only keep mutating keeper tools"
+            `Quick
+            test_side_effect_reclassification_drops_keeper_read_only_tools_from_mixed_set
+        ; test_case
+            "overflow detection and limit parsing"
+            `Quick
+            test_overflow_detection_and_limit_parsing
+        ] )
+    ; ( "context_overflow"
+      , [ test_case
+            "parses common OAS overflow errors (SSOT)"
+            `Quick
+            test_context_overflow_limit_parses_common_oas_errors
+        ; test_case
+            "is_context_overflow only matches ContextOverflow"
+            `Quick
+            test_is_context_overflow_only_for_overflow_errors
+        ; test_case
+            "summarize_turn_event_bus extracts overflow signal"
+            `Quick
+            test_summarize_turn_event_bus_extracts_overflow_signal
+        ; test_case
+            "context_overflow_event prefers event bus signal"
+            `Quick
+            test_context_overflow_event_prefers_event_bus_signal
+        ; test_case
+            "context_overflow_event falls back without event bus signal"
+            `Quick
+            test_context_overflow_event_falls_back_without_event_bus_signal
+        ] )
+    ; ( "phase_gate"
+      , [ test_case
+            "run_keeper_cycle skips paused keeper"
+            `Quick
+            test_run_keeper_cycle_skips_non_executable_phase
+        ; test_case
+            "run_keeper_cycle errors on livelock block"
+            `Quick
+            test_run_keeper_cycle_livelock_block_returns_error
+        ; test_case
+            "streaming cancel records supervisor stop"
+            `Quick
+            test_streaming_cancel_records_supervisor_stop_when_fiber_stop_set
+        ; test_case
+            "run_keeper_cycle records trajectory contract"
+            `Quick
+            test_run_keeper_cycle_records_trajectory_source_contract
+        ; test_case
+            "pre-tool gates record durable attempt telemetry"
+            `Quick
+            test_pre_tool_gate_records_durable_attempt_telemetry
+        ; test_case
+            "run_keeper_cycle surfaces side-effect failures contract"
+            `Quick
+            test_run_keeper_cycle_surfaces_side_effect_failures_source_contract
+        ; test_case
+            "paused-state sync surfaces write failure"
+            `Quick
+            test_sync_keeper_paused_state_surfaces_write_failure_without_mutating_registry
+        ; test_case
+            "local discovery guard surfaces refresh failure"
+            `Quick
+            test_ensure_local_discovery_ready_surfaces_refresh_failure
+        ; test_case
+            "async keeper_msg preflight surfaces discovery failure"
+            `Quick
+            test_keeper_msg_async_failure_surface
+        ; test_case
+            "local_only liveness decision keeps non-local route"
+            `Quick
+            test_decide_local_only_liveness_keeps_non_local_effective
+        ; test_case
+            "local_only liveness decision keeps explicit local base"
+            `Quick
+            test_decide_local_only_liveness_keeps_explicit_local_only
+        ; test_case
+            "local_only liveness decision requests deduped probe"
+            `Quick
+            test_decide_local_only_liveness_requests_deduped_ollama_probe
+        ; test_case
+            "local_only fail-open falls back when ollama is down"
+            `Quick
+            test_fail_open_local_only_when_probe_fails
+        ; test_case
+            "explicit local_only does not fail-open"
+            `Quick
+            test_fail_open_local_only_preserves_explicit_local_only_base
+        ; test_case
+            "healthy local_only stays selected"
+            `Quick
+            test_fail_open_local_only_preserves_healthy_local_only
+        ; test_case
+            "PR-B: empty labels yield no shared host"
+            `Quick
+            test_resolve_shared_probeable_base_url_empty_returns_none
+        ; test_case
+            "PR-B: single probeable label resolves"
+            `Quick
+            test_resolve_shared_probeable_base_url_single_label
+        ; test_case
+            "PR-B: probe registry gates resolution"
+            `Quick
+            test_resolve_shared_probeable_base_url_requires_probe_registration
+        ; test_case
+            "PR-B: mixed hosts collapse to None"
+            `Quick
+            test_resolve_shared_probeable_base_url_mixed_host
+        ; test_case
+            "PR-B: different hosts collapse to None"
+            `Quick
+            test_resolve_shared_probeable_base_url_different_hosts
+        ; test_case
+            "PR-B: missing cache is fail-open"
+            `Quick
+            test_is_base_url_saturated_returns_false_when_cache_missing
+        ; test_case
+            "PR-B: idle endpoint not saturated"
+            `Quick
+            test_is_base_url_saturated_returns_false_when_idle
+        ; test_case
+            "PR-B: full endpoint with queue is saturated"
+            `Quick
+            test_is_base_url_saturated_returns_true_when_full_with_queue
+        ; test_case
+            "PR-B: zero available without traffic is fail-open"
+            `Quick
+            test_is_base_url_saturated_ignores_zero_available_when_idle
+        ; test_case
+            "PR-B follow-up: fresh keeper has zero skip count"
+            `Quick
+            test_saturation_skip_count_starts_at_zero
+        ; test_case
+            "PR-B follow-up: inc returns monotonic counts"
+            `Quick
+            test_saturation_skip_count_inc_returns_new_value
+        ; test_case
+            "PR-B follow-up: reset zeros one keeper only"
+            `Quick
+            test_saturation_skip_count_reset_zeros_one_keeper
+        ; test_case
+            "PR-B follow-up: cap floored at 1"
+            `Quick
+            test_saturation_skip_cap_default_is_at_least_one
+        ; test_case
+            "hard quota degraded retry uses local_recovery"
+            `Quick
+            test_degraded_retry_after_recoverable_error_uses_local_recovery_for_hard_quota
+        ; test_case
+            "resumable session degraded retry uses local_recovery"
+            `Quick
+            test_degraded_retry_after_recoverable_error_uses_local_recovery_for_resumable_session
+        ; test_case
+            "admission queue timeout is degraded-retry eligible"
+            `Quick
+            test_degraded_retry_after_recoverable_error_includes_admission_queue_timeout
+        ; test_case
+            "turn timeout is degraded-retry eligible"
+            `Quick
+            test_degraded_retry_after_recoverable_error_includes_turn_timeout
+        ; test_case
+            "OAS timeout budget is degraded-retry eligible"
+            `Quick
+            test_degraded_retry_after_recoverable_error_includes_oas_timeout_budget
+        ; test_case
+            "max turns is degraded-retry eligible"
+            `Quick
+            test_degraded_retry_after_recoverable_error_includes_max_turns
+        ; test_case
+            "required tool turns block degraded retry"
+            `Quick
+            test_degraded_retry_after_recoverable_error_blocks_required_tools
+        ; test_case
+            "local_only stays terminal for degraded retry"
+            `Quick
+            test_degraded_retry_after_recoverable_error_does_not_broaden_local_only
+        ; test_case
+            "local_recovery stays terminal for degraded retry"
+            `Quick
+            test_degraded_retry_after_recoverable_error_does_not_broaden_local_recovery
+        ; test_case
+            "unavailable profile fallback prefers default"
+            `Quick
+            test_fallback_cascade_for_unavailable_profile_prefers_default
+        ; test_case
+            "unavailable phase override fallback prefers base"
+            `Quick
+            test_fallback_cascade_for_unavailable_profile_prefers_base_after_phase_override
+        ; test_case
+            "next degraded retry returns untried default cascade"
+            `Quick
+            test_next_fail_open_cascade_for_turn_returns_untried_default_cascade
+        ; test_case
+            "next degraded retry continues to local_recovery"
+            `Quick
+            test_next_fail_open_cascade_for_turn_continues_to_local_recovery
+        ; test_case
+            "next degraded retry suppresses exhausted rotation group"
+            `Quick
+            test_next_fail_open_cascade_for_turn_suppresses_exhausted_rotation_group
+        ; test_case
+            "required-tool rotation uses default without strict injection"
+            `Quick
+            test_next_fail_open_cascade_for_required_tool_uses_default_not_strict
+        ; test_case
+            "required tool turns rotate without dropping requirement"
+            `Quick
+            test_next_fail_open_cascade_for_turn_allows_required_tool_rotation
+        ; test_case
+            "required tool contract violations rotate retry lane"
+            `Quick
+            test_next_fail_open_cascade_for_turn_retries_required_tool_contract_violation
+        ; test_case
+            "catalog rotation can continue beyond reserved recovery"
+            `Quick
+            test_next_fail_open_cascade_for_turn_uses_catalog_rotation_profile
+        ; test_case
+            "catalog rotation does not inject missing default"
+            `Quick
+            test_next_fail_open_cascade_for_turn_does_not_inject_default_when_catalog_omits_it
+        ; test_case
+            "required-tool catalog rotation filters local recovery"
+            `Quick
+            test_next_fail_open_cascade_for_required_tool_filters_local_recovery_catalog
+        ; test_case
+            "required-tool local-recovery-only catalog exhausts"
+            `Quick
+            test_next_fail_open_cascade_for_required_tool_rejects_local_recovery_only_catalog
+        ; test_case
+            "classifier filters required-tool catalog rotation"
+            `Quick
+            test_degraded_rotation_after_recoverable_error_filters_required_catalog_directly
+        ; test_case
             "classifier preserves explicit local_recovery fallback profile"
             `Quick
-            test_degraded_rotation_preserves_local_recovery_profile_hint_for_required_tool;
-          test_case "classifier normalizes catalog rotation"
+            test_degraded_rotation_preserves_local_recovery_profile_hint_for_required_tool
+        ; test_case
+            "classifier normalizes catalog rotation"
             `Quick
-            test_degraded_rotation_after_recoverable_error_normalizes_catalog_directly;
-          test_case "fallback_hint preempts catalog rotation"
+            test_degraded_rotation_after_recoverable_error_normalizes_catalog_directly
+        ; test_case
+            "fallback_hint preempts catalog rotation"
             `Quick
-            test_degraded_rotation_prefers_fallback_hint_over_catalog;
-          test_case "fallback_hint skipped when already attempted"
+            test_degraded_rotation_prefers_fallback_hint_over_catalog
+        ; test_case
+            "fallback_hint skipped when already attempted"
             `Quick
-            test_degraded_rotation_skips_already_attempted_fallback_hint;
-          test_case "blank fallback_hint behaves like no hint"
+            test_degraded_rotation_skips_already_attempted_fallback_hint
+        ; test_case
+            "blank fallback_hint behaves like no hint"
             `Quick
-            test_degraded_rotation_ignores_blank_fallback_hint;
-          test_case "catalog rotation order merges reserved and assignable"
+            test_degraded_rotation_ignores_blank_fallback_hint
+        ; test_case
+            "catalog rotation order merges reserved and assignable"
             `Quick
-            test_fail_open_rotation_cascades_from_catalog_merges_reserved_and_assignable;
-          test_case "catalog rotation preserves catalog order"
+            test_fail_open_rotation_cascades_from_catalog_merges_reserved_and_assignable
+        ; test_case
+            "catalog rotation preserves catalog order"
             `Quick
-            test_fail_open_rotation_cascades_from_catalog_preserves_catalog_order;
-          test_case "unresolved catalog keeps legacy rotation fallback"
+            test_fail_open_rotation_cascades_from_catalog_preserves_catalog_order
+        ; test_case
+            "unresolved catalog keeps legacy rotation fallback"
             `Quick
-            test_fail_open_rotation_cascades_from_catalog_empty_when_unresolved;
-          test_case "resolved catalog without assignable candidates falls back"
+            test_fail_open_rotation_cascades_from_catalog_empty_when_unresolved
+        ; test_case
+            "resolved catalog without assignable candidates falls back"
             `Quick
-            test_fail_open_rotation_cascades_from_catalog_empty_without_assignable_candidates;
-        ] );
-      ( "tool_classification",
-        [
-          test_case "keeper allowed tools exclude heartbeat" `Quick
-            test_keeper_allowed_tools_exclude_heartbeat;
-          test_case "initial tool requirement mirrors first-turn gate" `Quick
-            test_should_require_tools_for_initial_turn_matches_first_turn_gate;
-          test_case "initial tool requirement covers actionable affordances"
+            test_fail_open_rotation_cascades_from_catalog_empty_without_assignable_candidates
+        ] )
+    ; ( "tool_classification"
+      , [ test_case
+            "keeper allowed tools exclude heartbeat"
             `Quick
-            test_should_require_tools_for_initial_turn_covers_actionable_affordances;
-          test_case "task backlog required turn prefers claim tool choice"
-            `Quick test_preferred_tool_choice_for_required_turn_claims_first;
-          test_case "direct keeper msg timeout overrides stale per-provider timeout"
+            test_keeper_allowed_tools_exclude_heartbeat
+        ; test_case
+            "initial tool requirement mirrors first-turn gate"
             `Quick
-            test_direct_keeper_msg_timeout_overrides_meta_per_provider_timeout;
-          test_case "affordance gate filters by allowed_tool_names"
+            test_should_require_tools_for_initial_turn_matches_first_turn_gate
+        ; test_case
+            "initial tool requirement covers actionable affordances"
             `Quick
-            test_turn_affordances_require_tool_gate_with_allowed_filters_by_tool;
-          test_case "affordance gate suppression emits metric" `Quick
-            test_turn_affordance_gate_suppression_metric;
-          test_case "required gate surface removes passive distractions" `Quick
-            test_required_gate_surface_removes_passive_distractions;
-          test_case "tools_for_gated_affordance non-empty for every variant"
-            `Quick test_tools_for_gated_affordance_covers_each_variant;
-        ] );
-      ( "verification_surface",
-        [
-          test_case "affordance: keeper sees task_verify when pending>0"
-            `Quick (fun () ->
-              let meta =
-                { minimal_meta with mention_targets = [ "analyst" ] }
-              in
-              let obs =
-                { base_observation with pending_verification_count = 3 }
-              in
-              let affordances =
-                UM.observed_affordances_of_observation ~meta obs
-              in
-              check bool "task_verify present for keeper" true
-                (List.mem "task_verify" affordances));
-          test_case "affordance: verifier-tagged keeper also sees task_verify"
+            test_should_require_tools_for_initial_turn_covers_actionable_affordances
+        ; test_case
+            "task backlog required turn prefers claim tool choice"
             `Quick
-            (fun () ->
-              let meta =
-                { minimal_meta with mention_targets = [ "verifier" ] }
-              in
-              let obs =
-                { base_observation with pending_verification_count = 3 }
-              in
-              let affordances =
-                UM.observed_affordances_of_observation ~meta obs
-              in
-              check bool "task_verify present for verifier-tagged keeper" true
-                (List.mem "task_verify" affordances));
-          test_case "affordance: no meta keeps legacy surface-to-all" `Quick
-            (fun () ->
-              let obs =
-                { base_observation with pending_verification_count = 2 }
-              in
-              let affordances =
-                UM.observed_affordances_of_observation obs
-              in
-              check bool "task_verify present without meta" true
-                (List.mem "task_verify" affordances));
-          test_case "affordance: work discovery nudge is not a hard contract"
+            test_preferred_tool_choice_for_required_turn_claims_first
+        ; test_case
+            "direct keeper msg timeout overrides stale per-provider timeout"
+            `Quick
+            test_direct_keeper_msg_timeout_overrides_meta_per_provider_timeout
+        ; test_case
+            "affordance gate filters by allowed_tool_names"
+            `Quick
+            test_turn_affordances_require_tool_gate_with_allowed_filters_by_tool
+        ; test_case
+            "affordance gate suppression emits metric"
+            `Quick
+            test_turn_affordance_gate_suppression_metric
+        ; test_case
+            "required gate surface removes passive distractions"
+            `Quick
+            test_required_gate_surface_removes_passive_distractions
+        ; test_case
+            "tools_for_gated_affordance non-empty for every variant"
+            `Quick
+            test_tools_for_gated_affordance_covers_each_variant
+        ] )
+    ; ( "verification_surface"
+      , [ test_case "affordance: keeper sees task_verify when pending>0" `Quick (fun () ->
+            let meta = { minimal_meta with mention_targets = [ "analyst" ] } in
+            let obs = { base_observation with pending_verification_count = 3 } in
+            let affordances = UM.observed_affordances_of_observation ~meta obs in
+            check
+              bool
+              "task_verify present for keeper"
+              true
+              (List.mem "task_verify" affordances))
+        ; test_case
+            "affordance: verifier-tagged keeper also sees task_verify"
             `Quick
             (fun () ->
-              let obs = { base_observation with work_discovery_due = true } in
-              let affordances =
-                UM.observed_affordances_of_observation obs
-              in
-              check bool "work_discovery present" true
-                (List.mem "work_discovery" affordances);
-              let contract_obs =
-                Masc_mcp.Keeper_contract_classifier.of_keeper_world_observation
-                  obs
-              in
-              check bool "timer-only discovery is not actionable" false
-                (Masc_mcp.Keeper_contract_classifier.is_actionable
-                   (Masc_mcp.Keeper_contract_classifier.classify_actionable_signal
-                      contract_obs)));
-          test_case "affordance: board curation requires multi-event window"
+               let meta = { minimal_meta with mention_targets = [ "verifier" ] } in
+               let obs = { base_observation with pending_verification_count = 3 } in
+               let affordances = UM.observed_affordances_of_observation ~meta obs in
+               check
+                 bool
+                 "task_verify present for verifier-tagged keeper"
+                 true
+                 (List.mem "task_verify" affordances))
+        ; test_case "affordance: no meta keeps legacy surface-to-all" `Quick (fun () ->
+            let obs = { base_observation with pending_verification_count = 2 } in
+            let affordances = UM.observed_affordances_of_observation obs in
+            check
+              bool
+              "task_verify present without meta"
+              true
+              (List.mem "task_verify" affordances))
+        ; test_case
+            "affordance: work discovery nudge is not a hard contract"
             `Quick
             (fun () ->
-              let second_board_event =
-                {
-                  sample_board_event with
-                  post_id = "board-post-2";
-                  title = "Follow-up";
-                  preview = "Another board item needs routing.";
-                }
-              in
-              let obs =
-                {
-                  base_observation with
-                  pending_board_events =
-                    [ sample_board_event; second_board_event ];
-                }
-              in
-              let affordances =
-                UM.observed_affordances_of_observation obs
-              in
-              check bool "board_curation present" true
-                (List.mem "board_curation" affordances));
-          test_case "affordance: single board event skips curation gate" `Quick
-            (fun () ->
-              let obs =
-                {
-                  base_observation with
-                  pending_board_events = [ sample_board_event ];
-                }
-              in
-              let affordances =
-                UM.observed_affordances_of_observation obs
-              in
-              check bool "board_curation absent" false
-                (List.mem "board_curation" affordances));
-          test_case "affordance: task claim requires matched backlog" `Quick
-            (fun () ->
-              let obs =
-                {
-                  base_observation with
-                  unclaimed_task_count = 3;
-                  claimable_task_count = 0;
-                }
-              in
-              let affordances =
-                UM.observed_affordances_of_observation obs
-              in
-              check bool "task_claim absent for unclaimable backlog" false
-                (List.mem "task_claim" affordances));
-          test_case "affordance: task claim present for claimable backlog" `Quick
-            (fun () ->
-              let obs =
-                {
-                  base_observation with
-                  unclaimed_task_count = 3;
-                  claimable_task_count = 1;
-                }
-              in
-              let affordances =
-                UM.observed_affordances_of_observation obs
-              in
-              check bool "task_claim present for matched backlog" true
-                (List.mem "task_claim" affordances));
-          test_case "trigger: absolute and matched backlog split" `Quick
-            (fun () ->
-              let obs =
-                {
-                  base_observation with
-                  unclaimed_task_count = 3;
-                  claimable_task_count = 1;
-                }
-              in
-              let triggers = UM.observed_triggers_of_observation obs in
-              check bool "absolute backlog trigger remains visible" true
-                (List.mem "new_unclaimed_task" triggers);
-              check bool "matched backlog trigger is explicit" true
-                (List.mem "claimable_task" triggers));
-          test_case "trigger: keeper sees pending_verification"
-            `Quick (fun () ->
-              let meta =
-                { minimal_meta with mention_targets = [ "scholar" ] }
-              in
-              let obs =
-                { base_observation with pending_verification_count = 5 }
-              in
-              let triggers =
-                UM.observed_triggers_of_observation ~meta obs
-              in
-              check bool "pending_verification present for keeper" true
-                (List.mem "pending_verification" triggers));
-          test_case "trigger: verifier-tagged keeper also sees pending_verification"
+               let obs = { base_observation with work_discovery_due = true } in
+               let affordances = UM.observed_affordances_of_observation obs in
+               check
+                 bool
+                 "work_discovery present"
+                 true
+                 (List.mem "work_discovery" affordances);
+               let contract_obs =
+                 Masc_mcp.Keeper_contract_classifier.of_keeper_world_observation obs
+               in
+               check
+                 bool
+                 "timer-only discovery is not actionable"
+                 false
+                 (Masc_mcp.Keeper_contract_classifier.is_actionable
+                    (Masc_mcp.Keeper_contract_classifier.classify_actionable_signal
+                       contract_obs)))
+        ; test_case
+            "affordance: board curation requires multi-event window"
             `Quick
             (fun () ->
-              let meta =
-                { minimal_meta with mention_targets = [ "검증자" ] }
-              in
-              let obs =
-                { base_observation with pending_verification_count = 1 }
-              in
-              let triggers =
-                UM.observed_triggers_of_observation ~meta obs
-              in
-              check bool "pending_verification present for verifier-tagged keeper"
-                true
-                (List.mem "pending_verification" triggers));
-        ] );
+               let second_board_event =
+                 { sample_board_event with
+                   post_id = "board-post-2"
+                 ; title = "Follow-up"
+                 ; preview = "Another board item needs routing."
+                 }
+               in
+               let obs =
+                 { base_observation with
+                   pending_board_events = [ sample_board_event; second_board_event ]
+                 }
+               in
+               let affordances = UM.observed_affordances_of_observation obs in
+               check
+                 bool
+                 "board_curation present"
+                 true
+                 (List.mem "board_curation" affordances))
+        ; test_case "affordance: single board event skips curation gate" `Quick (fun () ->
+            let obs =
+              { base_observation with pending_board_events = [ sample_board_event ] }
+            in
+            let affordances = UM.observed_affordances_of_observation obs in
+            check
+              bool
+              "board_curation absent"
+              false
+              (List.mem "board_curation" affordances))
+        ; test_case "affordance: task claim requires matched backlog" `Quick (fun () ->
+            let obs =
+              { base_observation with unclaimed_task_count = 3; claimable_task_count = 0 }
+            in
+            let affordances = UM.observed_affordances_of_observation obs in
+            check
+              bool
+              "task_claim absent for unclaimable backlog"
+              false
+              (List.mem "task_claim" affordances))
+        ; test_case
+            "affordance: task claim present for claimable backlog"
+            `Quick
+            (fun () ->
+               let obs =
+                 { base_observation with
+                   unclaimed_task_count = 3
+                 ; claimable_task_count = 1
+                 }
+               in
+               let affordances = UM.observed_affordances_of_observation obs in
+               check
+                 bool
+                 "task_claim present for matched backlog"
+                 true
+                 (List.mem "task_claim" affordances))
+        ; test_case "trigger: absolute and matched backlog split" `Quick (fun () ->
+            let obs =
+              { base_observation with unclaimed_task_count = 3; claimable_task_count = 1 }
+            in
+            let triggers = UM.observed_triggers_of_observation obs in
+            check
+              bool
+              "absolute backlog trigger remains visible"
+              true
+              (List.mem "new_unclaimed_task" triggers);
+            check
+              bool
+              "matched backlog trigger is explicit"
+              true
+              (List.mem "claimable_task" triggers))
+        ; test_case "trigger: keeper sees pending_verification" `Quick (fun () ->
+            let meta = { minimal_meta with mention_targets = [ "scholar" ] } in
+            let obs = { base_observation with pending_verification_count = 5 } in
+            let triggers = UM.observed_triggers_of_observation ~meta obs in
+            check
+              bool
+              "pending_verification present for keeper"
+              true
+              (List.mem "pending_verification" triggers))
+        ; test_case
+            "trigger: verifier-tagged keeper also sees pending_verification"
+            `Quick
+            (fun () ->
+               let meta = { minimal_meta with mention_targets = [ "검증자" ] } in
+               let obs = { base_observation with pending_verification_count = 1 } in
+               let triggers = UM.observed_triggers_of_observation ~meta obs in
+               check
+                 bool
+                 "pending_verification present for verifier-tagged keeper"
+                 true
+                 (List.mem "pending_verification" triggers))
+        ] )
     ]
+;;

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -4553,27 +4553,44 @@ let make_capacity_info ?(total = 1) ?(active = 0) ?(available = 1)
     source = Llm_provider.Provider_throttle.Discovered;
   }
 
-let test_resolve_ollama_only_base_url_empty_returns_none () =
-  match UT.resolve_ollama_only_base_url [] with
+let test_resolve_shared_probeable_base_url_empty_returns_none () =
+  match UT.resolve_shared_probeable_base_url [] with
   | None -> ()
-  | Some _ -> fail "empty labels should not resolve to ollama-only"
+  | Some _ -> fail "empty labels should not resolve to a shared host"
 
-let test_resolve_ollama_only_base_url_single_ollama () =
+let test_resolve_shared_probeable_base_url_single_label () =
   let label = "ollama:qwen3.6:35b-a3b-mlx-bf16" in
   let cfg = provider_config_of_label label in
-  match UT.resolve_ollama_only_base_url [ label ] with
-  | Some url -> check string "single ollama base url" cfg.base_url url
-  | None -> fail "single ollama label should resolve"
-
-let test_resolve_ollama_only_base_url_mixed_provider () =
   match
-    UT.resolve_ollama_only_base_url
+    UT.resolve_shared_probeable_base_url
+      ~can_probe:(fun _ -> true)
+      [ label ]
+  with
+  | Some url -> check string "single label base url" cfg.base_url url
+  | None -> fail "single probeable label should resolve"
+
+let test_resolve_shared_probeable_base_url_requires_probe_registration () =
+  (* Provider variant is irrelevant; what matters is whether the URL
+     is recognised by the probe registry. *)
+  let label = "ollama:qwen3.6:35b-a3b-mlx-bf16" in
+  match
+    UT.resolve_shared_probeable_base_url
+      ~can_probe:(fun _ -> false)
+      [ label ]
+  with
+  | None -> ()
+  | Some _ -> fail "no probe registration must yield None"
+
+let test_resolve_shared_probeable_base_url_mixed_host () =
+  match
+    UT.resolve_shared_probeable_base_url
+      ~can_probe:(fun _ -> true)
       [ "ollama:qwen3.6:35b-a3b-mlx-bf16"; "claude:sonnet-4-5" ]
   with
   | None -> ()
-  | Some _ -> fail "mixed provider must not be classified as ollama-only"
+  | Some _ -> fail "mixed hosts must not collapse to a single base url"
 
-let test_resolve_ollama_only_base_url_different_hosts () =
+let test_resolve_shared_probeable_base_url_different_hosts () =
   let resolve_label = function
     | "ollama:a" ->
         Some
@@ -4592,38 +4609,40 @@ let test_resolve_ollama_only_base_url_different_hosts () =
     | _ -> None
   in
   match
-    UT.resolve_ollama_only_base_url ~resolve_label
+    UT.resolve_shared_probeable_base_url
+      ~resolve_label
+      ~can_probe:(fun _ -> true)
       [ "ollama:a"; "ollama:b" ]
   with
   | None -> ()
-  | Some _ -> fail "different ollama hosts must not collapse"
+  | Some _ -> fail "different hosts must not collapse"
 
-let test_is_ollama_saturated_returns_false_when_cache_missing () =
+let test_is_base_url_saturated_returns_false_when_cache_missing () =
   let url = "http://127.0.0.1:11434" in
   check bool "missing cache treated as healthy" false
-    (UT.is_ollama_saturated ~capacity_lookup:(fun _ -> None) url)
+    (UT.is_base_url_saturated ~capacity_lookup:(fun _ -> None) url)
 
-let test_is_ollama_saturated_returns_false_when_idle () =
+let test_is_base_url_saturated_returns_false_when_idle () =
   let url = "http://127.0.0.1:11434" in
   let info = make_capacity_info ~active:0 ~available:1 ~queue:0 () in
   check bool "idle endpoint not saturated" false
-    (UT.is_ollama_saturated
+    (UT.is_base_url_saturated
        ~capacity_lookup:(fun _ -> Some info) url)
 
-let test_is_ollama_saturated_returns_true_when_full_with_queue () =
+let test_is_base_url_saturated_returns_true_when_full_with_queue () =
   let url = "http://127.0.0.1:11434" in
   let info = make_capacity_info ~active:1 ~available:0 ~queue:3 () in
   check bool "full endpoint with queue is saturated" true
-    (UT.is_ollama_saturated
+    (UT.is_base_url_saturated
        ~capacity_lookup:(fun _ -> Some info) url)
 
-let test_is_ollama_saturated_ignores_zero_available_when_idle () =
+let test_is_base_url_saturated_ignores_zero_available_when_idle () =
   (* Defensive: discovery may report 0 available before any traffic.
      Without active or queued requests the keeper should still dispatch. *)
   let url = "http://127.0.0.1:11434" in
   let info = make_capacity_info ~active:0 ~available:0 ~queue:0 () in
   check bool "idle endpoint with no slots is fail-open" false
-    (UT.is_ollama_saturated
+    (UT.is_base_url_saturated
        ~capacity_lookup:(fun _ -> Some info) url)
 
 let test_saturation_skip_count_starts_at_zero () =
@@ -8975,22 +8994,24 @@ let () =
             test_fail_open_local_only_preserves_explicit_local_only_base;
           test_case "healthy local_only stays selected" `Quick
             test_fail_open_local_only_preserves_healthy_local_only;
-          test_case "PR-B: empty labels are not ollama-only" `Quick
-            test_resolve_ollama_only_base_url_empty_returns_none;
-          test_case "PR-B: single ollama label is ollama-only" `Quick
-            test_resolve_ollama_only_base_url_single_ollama;
-          test_case "PR-B: mixed providers are not ollama-only" `Quick
-            test_resolve_ollama_only_base_url_mixed_provider;
-          test_case "PR-B: different ollama hosts are not ollama-only" `Quick
-            test_resolve_ollama_only_base_url_different_hosts;
+          test_case "PR-B: empty labels yield no shared host" `Quick
+            test_resolve_shared_probeable_base_url_empty_returns_none;
+          test_case "PR-B: single probeable label resolves" `Quick
+            test_resolve_shared_probeable_base_url_single_label;
+          test_case "PR-B: probe registry gates resolution" `Quick
+            test_resolve_shared_probeable_base_url_requires_probe_registration;
+          test_case "PR-B: mixed hosts collapse to None" `Quick
+            test_resolve_shared_probeable_base_url_mixed_host;
+          test_case "PR-B: different hosts collapse to None" `Quick
+            test_resolve_shared_probeable_base_url_different_hosts;
           test_case "PR-B: missing cache is fail-open" `Quick
-            test_is_ollama_saturated_returns_false_when_cache_missing;
+            test_is_base_url_saturated_returns_false_when_cache_missing;
           test_case "PR-B: idle endpoint not saturated" `Quick
-            test_is_ollama_saturated_returns_false_when_idle;
+            test_is_base_url_saturated_returns_false_when_idle;
           test_case "PR-B: full endpoint with queue is saturated" `Quick
-            test_is_ollama_saturated_returns_true_when_full_with_queue;
+            test_is_base_url_saturated_returns_true_when_full_with_queue;
           test_case "PR-B: zero available without traffic is fail-open" `Quick
-            test_is_ollama_saturated_ignores_zero_available_when_idle;
+            test_is_base_url_saturated_ignores_zero_available_when_idle;
           test_case "PR-B follow-up: fresh keeper has zero skip count" `Quick
             test_saturation_skip_count_starts_at_zero;
           test_case "PR-B follow-up: inc returns monotonic counts" `Quick


### PR DESCRIPTION
## Summary

Replace `resolve_ollama_only_base_url` / `is_ollama_saturated` with provider-agnostic `resolve_shared_probeable_base_url` / `is_base_url_saturated`. The probe-registration check moves to `Cascade_capacity_probe.can_probe` (already provider-agnostic), so the liveness module no longer pattern-matches on `Llm_provider.Provider_config.Ollama`.

Closes 1 of the remaining 4 leak sites in RFC-0058 Phase 5.6 (provider-zero-exposure).

## Why

Liveness is *lifecycle* code, not *provider* code. `keeper_turn_liveness.ml` previously knew that Ollama was a special variant — adding any new local backend (vllm, lmstudio) would have required a touch here. After this PR, the lifecycle module is unaware of provider variants; only the probe registry decides which URLs are probeable.

## Invariant sealed by tests

`test_resolve_shared_probeable_base_url_requires_probe_registration` — same input label (`ollama:qwen3.6...`) returns `None` when `~can_probe:(fun _ -> false)` is injected. This is the compilable proof that *variant is no longer read*.

## Ratchet metric

`rg "Ollama|is_ollama|ollama_only" lib/keeper/keeper_turn_liveness.ml`

| | count |
|---|---|
| Before (origin/main) | 8 |
| After  (this branch) | 0 |

## Workaround self-check (CLAUDE.md §워크어라운드 거부 기준)

| # | check | result |
|---|---|---|
| 1 | telemetry-as-fix? | no — variant match removed, behaviour preserved |
| 2 | string classifier? | no — typed registry boundary |
| 3 | N-of-M? | no — target file 8 → 0 |
| 4 | catch-all `_ ->` added? | no |
| 5 | cap/cooldown/dedup/repair? | no |
| 6 | test backdoor? | no — `?can_probe` is a meaningful production injection |
| 7 | same typo N sites? | no |

## Test plan
- [x] Renamed 4 existing tests; behavior preserved with `~can_probe:(fun _ -> true)` injection
- [x] New `requires_probe_registration` test seals the invariant
- [x] Alcotest list updated (9 tests registered, 0 old-name leftovers)
- [ ] CI build + test (local build blocked by dune-local.sh global lock, relying on CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)