### PR TITLE
docs(rfc): renumber keeper-turn-disposition to RFC-0068 (resolve 0047 collision)

### DIFF
--- a/docs/rfc/RFC-0068-keeper-turn-disposition-typed.md
+++ b/docs/rfc/RFC-0068-keeper-turn-disposition-typed.md
@@ -1,4 +1,9 @@
-# RFC-0047 — Typed `Keeper_turn_disposition` (operator-facing closed sum)
+# RFC-0068 — Typed `Keeper_turn_disposition` (operator-facing closed sum)
+
+> **Renumber note (2026-05-12)**: Originally filed as RFC-0047 on 2026-05-08,
+> conflicting with `RFC-0047-oas-adapter-decomposition.md` (Implemented
+> #14314). Renumbered to RFC-0068 to resolve the collision, mirroring the
+> RFC-0057 → RFC-0067 renumber pattern (#14672).
 
 - **Status**: Draft
 - **Author**: vincent (with Claude)
@@ -84,7 +89,7 @@ layer-1 (runtime) wire strings. RFC-0042 PR-3 alone cannot remove them.
 | G2 | Adding a new operator disposition is a compile error in every consumer. |
 | G3 | Layer separation: runtime termination (`Keeper_turn_terminal_code.t`) and operator disposition (`Keeper_turn_disposition.t`) are two distinct types. Promotion is explicit (`Provider_error of Keeper_turn_terminal_code.t`). |
 | G4 | Wire format on the receipt JSON `code` field is byte-for-byte preserved during PR-1 and PR-2; PR-3 is the only step that can change it (and only by *adding* fields, not removing). |
-| G5 | RFC-0042 PR-3 (the field-swap step) is replaced by RFC-0047 PR-2/PR-3 (the disposition migration). The runtime type stays narrow. |
+| G5 | RFC-0042 PR-3 (the field-swap step) is replaced by RFC-0068 PR-2/PR-3 (the disposition migration). The runtime type stays narrow. |
 
 ### Non-goals
 
@@ -282,13 +287,13 @@ typed.
 ### 5.3 Interaction with RFC-0042 PR-3 (deferred)
 
 RFC-0042 PR-3 ("`Keeper_turn_terminal.t.code: string → t`") is **not
-landing as written**. RFC-0047 supersedes that step. RFC-0042 stays
+landing as written**. RFC-0068 supersedes that step. RFC-0042 stays
 correct for the runtime layer (PR-1 + PR-2 + PR-2.5 already merged);
 PR-3 / PR-4 of RFC-0042 are repurposed:
 
-- RFC-0042 PR-3 → RFC-0047 PR-2 (add disposition field to
+- RFC-0042 PR-3 → RFC-0068 PR-2 (add disposition field to
   `Keeper_turn_terminal.t`)
-- RFC-0042 PR-4 (reader migration) → RFC-0047 PR-3
+- RFC-0042 PR-4 (reader migration) → RFC-0068 PR-3
 
 Both RFC-0042 docs (#14181 still open) and this RFC need the same
 maintainer review for that handoff to be authoritative.
@@ -310,7 +315,7 @@ require:
 
 1. Confirmation that the layer separation in §3 is the canonical
    shape (vs. a single-type expansion of `Keeper_turn_terminal_code.t`).
-2. Confirmation that RFC-0042 PR-3/PR-4 are superseded by RFC-0047
+2. Confirmation that RFC-0042 PR-3/PR-4 are superseded by RFC-0068
    PR-2/PR-3 (so RFC-0042 closes after PR-2.5 + RFC-0042 docs merge).
 3. Maintainer approval of the disposition variant set in §3.1
    (the inventory was lifted from current


### PR DESCRIPTION
## Summary

- `RFC-0047-keeper-turn-disposition-typed.md` (Draft, 5/8) → `RFC-0068-keeper-turn-disposition-typed.md`
- 다른 RFC-0047 (`oas-adapter-decomposition.md`, Implemented #14314) 와 번호 충돌 해소
- 패턴: `#14672 docs(rfc): renumber goal-scope atomicity RFC to RFC-0067` (RFC-0057 collision 해결)

## Cross-reference audit

| Reference | Verdict |
|---|---|
| `docs/rfc/RFC-0051-*.md` (6 refs) | 모두 oas-adapter 컨텍스트 → 유지 |
| `docs/rfc/RFC-0047-caller-inventory.txt`, `RFC-0047-module-graph.dot` | oas-adapter 부속 → 유지 |
| `docs/rfc/RFC-0053-*.md:123` ("OAS tool calling protocol ... typed dispatch는 RFC-0047이 처리") | oas-adapter 컨텍스트 → 유지 |
| `memory/`, `knowledge/` | RFC-0047 hit 없음 |

RFC body 내 self-reference 6건만 RFC-0068 로 교체. RFC-0042 같은 외부 RFC 인용은 손대지 않음.

## Test plan

- [x] `ls docs/rfc/ | grep -oE '^RFC-[0-9]+' | sort | uniq -c` — RFC-0047 entries는 oas-adapter `.md` + `.txt` + `.dot` 3개 (정상 multi-file).
- [x] `rg 'RFC-0047' docs/rfc/RFC-0068-keeper-turn-disposition-typed.md` — renumber note 의 historical reference 만 남음.
- [x] dune build 영향 없음 (docs/rfc/ 는 OCaml 빌드 의존성 없음).

RFC-WAIVED: meta-cleanup (RFC inventory hygiene, see plan hashed-yawning-sedgewick — docs/rfc/ governance 자체 정리)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
