### PR TITLE
refactor(provider-adapter): RFC-0058 §2.4 — collapse 3 closed-variant dispatch sites

### DIFF
--- a/lib/provider_adapter.ml
+++ b/lib/provider_adapter.ml
@@ -1505,9 +1505,12 @@ let adapter_of_provider_config (cfg : Llm_provider.Provider_config.t) =
   (* RFC-0058 §2.4: dispatch flows through the kind→canonical_name table
      ([adapter_canonical_name_of_provider_kind]) rather than enumerating
      every provider variant inline. [Glm] and [OpenAI_compat] still need
-     the endpoint-derived [cascade_prefix] because multiple endpoints
-     share the same kind, so the canonical name is not knowable from
-     the kind alone. *)
+     a registry lookup because multiple distinct providers share the
+     same [kind]: [OpenAI_compat] is disambiguated by [base_url] via
+     [openai_compat_adapter_by_endpoint], while [Glm] is disambiguated
+     by registry label ([glm] vs [glm-coding]) via
+     [provider_name_of_config]. [provider_label_from_registry] folds
+     both into the same [cascade_prefix] key. *)
   match cfg.kind with
   | Llm_provider.Provider_config.Glm
   | Llm_provider.Provider_config.OpenAI_compat ->

--- a/lib/provider_adapter.ml
+++ b/lib/provider_adapter.ml
@@ -1502,28 +1502,18 @@ let provider_label_from_registry (cfg : Llm_provider.Provider_config.t) =
   | None -> Llm_provider.Provider_registry.provider_name_of_config cfg
 
 let adapter_of_provider_config (cfg : Llm_provider.Provider_config.t) =
+  (* RFC-0058 §2.4: dispatch flows through the kind→canonical_name table
+     ([adapter_canonical_name_of_provider_kind]) rather than enumerating
+     every provider variant inline. [Glm] and [OpenAI_compat] still need
+     the endpoint-derived [cascade_prefix] because multiple endpoints
+     share the same kind, so the canonical name is not knowable from
+     the kind alone. *)
   match cfg.kind with
-  | Llm_provider.Provider_config.Claude_code ->
-      resolve_direct_adapter cn_claude
-  | Codex_cli ->
-      resolve_direct_adapter cn_codex
-  | Gemini_cli ->
-      resolve_direct_adapter cn_gemini
-  | Kimi_cli ->
-      resolve_direct_adapter cn_kimi
-  | Anthropic ->
-      resolve_direct_adapter cn_claude_api
-  | Gemini ->
-      resolve_direct_adapter cn_gemini_api
-  | Kimi ->
-      resolve_direct_adapter cn_kimi_api
-  | Ollama ->
-      resolve_direct_adapter cn_ollama
-  | DashScope ->
-      resolve_direct_adapter cn_codex_api
-  | Glm
-  | OpenAI_compat ->
+  | Llm_provider.Provider_config.Glm
+  | Llm_provider.Provider_config.OpenAI_compat ->
       resolve_adapter_by_cascade_prefix (provider_label_from_registry cfg)
+  | kind ->
+      resolve_direct_adapter (adapter_canonical_name_of_provider_kind kind)
 
 (* RFC-0058 §2.4 boundary: callers with only the typed [provider_kind]
    (no full provider config) resolve to an adapter through the same
@@ -1750,44 +1740,41 @@ let auth_detail_of_provider provider =
         note = None }
 
 let auth_env_keys_of_provider_kind (kind : Llm_provider.Provider_config.provider_kind) : string list =
+  (* RFC-0058 §2.4: Kimi and Gemini have non-adapter overrides
+     (multi-key fallback list and Vertex env pair respectively);
+     every other kind defers to the adapter's [auth_mode]. The
+     wildcard branch covers all current and future provider_kind
+     variants without enumerating them. *)
   match kind with
   | Llm_provider.Provider_config.Kimi -> kimi_api_key_envs
-  | Llm_provider.Provider_config.Gemini -> [ google_cloud_project_env; google_cloud_location_env ]
-  | Llm_provider.Provider_config.Anthropic
-  | Llm_provider.Provider_config.Ollama
-  | Llm_provider.Provider_config.Gemini_cli
-  | Llm_provider.Provider_config.Kimi_cli
-  | Llm_provider.Provider_config.Glm
-  | Llm_provider.Provider_config.DashScope
-  | Llm_provider.Provider_config.Claude_code
-  | Llm_provider.Provider_config.Codex_cli
-  | Llm_provider.Provider_config.OpenAI_compat ->
+  | Llm_provider.Provider_config.Gemini ->
+      [ google_cloud_project_env; google_cloud_location_env ]
+  | _ ->
       let adapter_name = adapter_canonical_name_of_provider_kind kind in
       (match resolve_direct_adapter adapter_name with
-      | Some adapter -> (
-          match adapter.auth_mode with
-          | Api_key env_name -> [ env_name ]
-          | No_auth | Cli_cached_login | Vertex_adc _ ->
-              Option.to_list (Llm_provider.Provider_config.default_api_key_env kind))
-      | None -> Option.to_list (Llm_provider.Provider_config.default_api_key_env kind))
+       | Some adapter -> (
+           match adapter.auth_mode with
+           | Api_key env_name -> [ env_name ]
+           | No_auth | Cli_cached_login | Vertex_adc _ ->
+               Option.to_list
+                 (Llm_provider.Provider_config.default_api_key_env kind))
+       | None ->
+           Option.to_list
+             (Llm_provider.Provider_config.default_api_key_env kind))
 
 let docker_auth_env_keys_of_provider_config (cfg : Llm_provider.Provider_config.t) : string list =
+  (* Docker sandboxes invoke OpenAI_compat over loopback against the
+     local-runtime pool, which carries no remote credentials; every
+     other kind delegates to the keyset its adapter declares. Gemini
+     uses the API-key env (not Vertex ADC) inside the sandbox because
+     ADC files are not mounted. *)
   match cfg.kind with
   | Llm_provider.Provider_config.OpenAI_compat ->
-    let uri = Uri.of_string cfg.base_url in
-    if Masc_network_defaults.is_loopback_host_opt (Uri.host uri) then []
-    else auth_env_keys_of_provider_kind cfg.kind
+      let uri = Uri.of_string cfg.base_url in
+      if Masc_network_defaults.is_loopback_host_opt (Uri.host uri) then []
+      else auth_env_keys_of_provider_kind cfg.kind
   | Llm_provider.Provider_config.Gemini -> [ gemini_api_key_env ]
-  | Llm_provider.Provider_config.Anthropic
-  | Llm_provider.Provider_config.Kimi
-  | Llm_provider.Provider_config.Ollama
-  | Llm_provider.Provider_config.Gemini_cli
-  | Llm_provider.Provider_config.Kimi_cli
-  | Llm_provider.Provider_config.Glm
-  | Llm_provider.Provider_config.DashScope
-  | Llm_provider.Provider_config.Claude_code
-  | Llm_provider.Provider_config.Codex_cli ->
-      auth_env_keys_of_provider_kind cfg.kind
+  | _ -> auth_env_keys_of_provider_kind cfg.kind
 
 let all_auth_env_keys () : string list =
   direct_adapters


### PR DESCRIPTION
## Summary

Replace 11-arm closed-variant enumerations with wildcard branches in `lib/provider_adapter.ml` so that adding a new provider stays a pure cascade.toml edit (RFC-0058 §2.4 invariant: *code dispatches by api_format, never by provider name*).

## Sites collapsed

| Site | Before | After |
|---|---|---|
| `adapter_of_provider_config` | 11-arm match enumerating every variant → constants `cn_claude`/`cn_codex`/… | 2-arm: `Glm \| OpenAI_compat` keep endpoint-derived `cascade_prefix` lookup; wildcard defers to `adapter_canonical_name_of_provider_kind`. |
| `auth_env_keys_of_provider_kind` | 9-arm OR pattern listing every non-Kimi/non-Gemini variant | `_` wildcard delegating to adapter resolver. |
| `docker_auth_env_keys_of_provider_config` | 9-arm OR pattern listing every non-OpenAI_compat/non-Gemini variant | `_` wildcard delegating to `auth_env_keys_of_provider_kind cfg.kind`. |

`Glm | OpenAI_compat` is preserved because multiple endpoints share the same kind, so canonical name is not knowable from kind alone — they go through `resolve_adapter_by_cascade_prefix` keyed on the runtime registry label. `Kimi` keeps the multi-key API-key fallback list. `Gemini` keeps the Vertex env pair. Docker `OpenAI_compat` keeps the loopback short-circuit and Docker-specific `Gemini` keeps the API-key env (ADC files not mounted).

## Why this is safe

- **Single-file change**, `lib/provider_adapter.ml` only.
- **Semantic-preserving**: every kind still resolves to the same canonical adapter name via the same `adapter_canonical_name_of_provider_kind` table.
- **No new types**, no `.mli` changes, no caller signature changes.

## Closed-variant refs eliminated

~14 explicit `Llm_provider.Provider_config.{Claude_code|Codex_cli|Gemini_cli|Kimi_cli|Anthropic|Ollama|DashScope|...}` references removed from dispatch code (variants themselves untouched — that comes in Phase 5.4/TYPE-DEF later batches per the 8-batch plan).

## Verification

- `dune build --root . @check` on origin/main `edc1bdb97` — green.
- Diff: `1 file changed, 36 insertions(+), 49 deletions(-)`.

## Stack position

- Phase 5.1 follow-up to B2 (#14647 / #14650 / #14651) which already converted `provider_tool_support`, `cascade_error_classify`, `keeper_usage_trust`, `cascade_oas_runner`, `dashboard_provider_runs` to the resolver pattern.
- Independent of B3 (`cascade_transport.ml`) which carries the bulk of remaining policy-dependent dispatch.

## RFC

RFC-0058 §2.4 invariant + Phase 5.1 closed-variant erasure tracker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)