### PR TITLE
refactor(keeper): exhaustive new_phase match in entry_actions_for (/loop iter 2)

### DIFF
--- a/lib/keeper/keeper_state_machine.ml
+++ b/lib/keeper/keeper_state_machine.ml
@@ -32,6 +32,7 @@ let phase_to_string = function
   | Restarting -> "restarting"
   | Dead -> "dead"
   | Zombie -> "zombie"
+;;
 
 let phase_of_string = function
   | "offline" -> Some Offline
@@ -48,85 +49,112 @@ let phase_of_string = function
   | "dead" -> Some Dead
   | "zombie" -> Some Zombie
   | _ -> None
+;;
 
 let all_phases =
-  [ Offline; Running; Failing; Overflowed; Compacting; HandingOff;
-    Draining; Paused; Stopped; Crashed; Restarting; Dead; Zombie ]
+  [ Offline
+  ; Running
+  ; Failing
+  ; Overflowed
+  ; Compacting
+  ; HandingOff
+  ; Draining
+  ; Paused
+  ; Stopped
+  ; Crashed
+  ; Restarting
+  ; Dead
+  ; Zombie
+  ]
+;;
 
 (* ── Conditions ────────────────────────────────────────── *)
 
-type conditions = {
-  launch_pending : bool;
-  fiber_alive : bool;
-  heartbeat_healthy : bool;
-  turn_healthy : bool;
-  context_within_budget : bool;
-  context_handoff_needed : bool;
-  compaction_active : bool;
-  handoff_active : bool;
-  operator_paused : bool;
-  stop_requested : bool;
-  restart_budget_remaining : bool;
-  backoff_elapsed : bool;
-  guardrail_triggered : bool;
-  drain_complete : bool;
-  context_overflow : bool;
-  compact_retry_exhausted : bool;
-  terminal_failure_latched : bool;
-  credential_archived : bool;
-  zombie_timeout_reached : bool;
-}
+type conditions =
+  { launch_pending : bool
+  ; fiber_alive : bool
+  ; heartbeat_healthy : bool
+  ; turn_healthy : bool
+  ; context_within_budget : bool
+  ; context_handoff_needed : bool
+  ; compaction_active : bool
+  ; handoff_active : bool
+  ; operator_paused : bool
+  ; stop_requested : bool
+  ; restart_budget_remaining : bool
+  ; backoff_elapsed : bool
+  ; guardrail_triggered : bool
+  ; drain_complete : bool
+  ; context_overflow : bool
+  ; compact_retry_exhausted : bool
+  ; terminal_failure_latched : bool
+  ; credential_archived : bool
+  ; zombie_timeout_reached : bool
+  }
 
-let default_conditions = {
-  launch_pending = false;
-  fiber_alive = false;
-  heartbeat_healthy = true;
-  turn_healthy = true;
-  context_within_budget = true;
-  context_handoff_needed = false;
-  compaction_active = false;
-  handoff_active = false;
-  operator_paused = false;
-  stop_requested = false;
-  restart_budget_remaining = false;
-  backoff_elapsed = false;
-  guardrail_triggered = false;
-  drain_complete = false;
-  context_overflow = false;
-  compact_retry_exhausted = false;
-  terminal_failure_latched = false;
-  credential_archived = false;
-  zombie_timeout_reached = false;
-}
+let default_conditions =
+  { launch_pending = false
+  ; fiber_alive = false
+  ; heartbeat_healthy = true
+  ; turn_healthy = true
+  ; context_within_budget = true
+  ; context_handoff_needed = false
+  ; compaction_active = false
+  ; handoff_active = false
+  ; operator_paused = false
+  ; stop_requested = false
+  ; restart_budget_remaining = false
+  ; backoff_elapsed = false
+  ; guardrail_triggered = false
+  ; drain_complete = false
+  ; context_overflow = false
+  ; compact_retry_exhausted = false
+  ; terminal_failure_latched = false
+  ; credential_archived = false
+  ; zombie_timeout_reached = false
+  }
+;;
 
 (* ── Events ────────────────────────────────────────────── *)
 
-type auto_rule_summary = {
-  reflect : bool;
-  plan : bool;
-  compact : bool;
-  handoff : bool;
-  guardrail_stop : bool;
-  guardrail_reason : string option;
-  goal_drift : float;
-}
+type auto_rule_summary =
+  { reflect : bool
+  ; plan : bool
+  ; compact : bool
+  ; handoff : bool
+  ; guardrail_stop : bool
+  ; guardrail_reason : string option
+  ; goal_drift : float
+  }
 
 type event =
   | Heartbeat_ok
-  | Heartbeat_failed of { consecutive : int; max_allowed : int }
+  | Heartbeat_failed of
+      { consecutive : int
+      ; max_allowed : int
+      }
   | Turn_succeeded
-  | Turn_failed of { consecutive : int; max_allowed : int }
-  | Context_measured of {
-      context_ratio : float;
-      message_count : int;
-      token_count : int;
-      auto_rules : auto_rule_summary;
-    }
+  | Turn_failed of
+      { consecutive : int
+      ; max_allowed : int
+      }
+  | Context_measured of
+      { context_ratio : float
+      ; message_count : int
+      ; token_count : int
+      ; auto_rules : auto_rule_summary
+      }
   | Compaction_started
-  | Compaction_completed of { before_tokens : int; after_tokens : int }
+  | Compaction_completed of
+      { before_tokens : int
+      ; after_tokens : int
+      }
   | Compaction_failed of { reason : string }
   | Handoff_started
-  | Handoff_completed of { new_trace_id : string; generation : int }
+  | Handoff_completed of
+      { new_trace_id : string
+      ; generation : int
+      }
   | Handoff_failed of { reason : string }
   | Operator_pause
   | Operator_resume
@@ -141,14 +169,14 @@ type event =
   | Zombie_timeout
   | Guardrail_stop of { reason : string }
   | Terminal_failure_detected of { reason : string }
-  | Context_overflow_detected of {
-      source : [`Prompt_rejected | `Oas_signal];
-      token_count : int;
-      limit_tokens : int option;
-    }
+  | Context_overflow_detected of
+      { source : [ `Prompt_rejected | `Oas_signal ]
+      ; token_count : int
+      ; limit_tokens : int option
+      }
   | Auto_compact_triggered
   | Compact_retry_exhausted
-    (** Issue #8581: latch the [compact_retry_exhausted] condition.
+  (** Issue #8581: latch the [compact_retry_exhausted] condition.
 
         Before this event existed, the field was read in [derive_phase]
         but never set in OCaml — the right disjunct of the Paused
@@ -162,62 +190,64 @@ type event =
         observability, while the existing first disjunct
         ([operator_paused]) still drives derive_phase deterministically. *)
   | Operator_compact_requested
-  | Operator_clear_requested of { preserve_system : bool; reason : string }
+  | Operator_clear_requested of
+      { preserve_system : bool
+      ; reason : string
+      }
 
 let event_to_string = function
   | Heartbeat_ok -> "heartbeat_ok"
   | Heartbeat_failed r ->
     Printf.sprintf "heartbeat_failed(%d/%d)" r.consecutive r.max_allowed
   | Turn_succeeded -> "turn_succeeded"
-  | Turn_failed r ->
-    Printf.sprintf "turn_failed(%d/%d)" r.consecutive r.max_allowed
-  | Context_measured r ->
-    Printf.sprintf "context_measured(ratio=%.3f)" r.context_ratio
+  | Turn_failed r -> Printf.sprintf "turn_failed(%d/%d)" r.consecutive r.max_allowed
+  | Context_measured r -> Printf.sprintf "context_measured(ratio=%.3f)" r.context_ratio
   | Compaction_started -> "compaction_started"
   | Compaction_completed r ->
     Printf.sprintf "compaction_completed(%d->%d)" r.before_tokens r.after_tokens
-  | Compaction_failed r ->
-    Printf.sprintf "compaction_failed(%s)" r.reason
+  | Compaction_failed r -> Printf.sprintf "compaction_failed(%s)" r.reason
   | Handoff_started -> "handoff_started"
-  | Handoff_completed r ->
-    Printf.sprintf "handoff_completed(gen=%d)" r.generation
-  | Handoff_failed r ->
-    Printf.sprintf "handoff_failed(%s)" r.reason
+  | Handoff_completed r -> Printf.sprintf "handoff_completed(gen=%d)" r.generation
+  | Handoff_failed r -> Printf.sprintf "handoff_failed(%s)" r.reason
   | Operator_pause -> "operator_pause"
   | Operator_resume -> "operator_resume"
-  | Operator_stop r ->
-    Printf.sprintf "operator_stop(remove_meta=%b)" r.remove_meta
+  | Operator_stop r -> Printf.sprintf "operator_stop(remove_meta=%b)" r.remove_meta
   | Stop_requested -> "stop_requested"
   | Drain_complete -> "drain_complete"
   | Fiber_started -> "fiber_started"
-  | Fiber_terminated r ->
-    Printf.sprintf "fiber_terminated(%s)" r.outcome
+  | Fiber_terminated r -> Printf.sprintf "fiber_terminated(%s)" r.outcome
   | Supervisor_restart_attempt r ->
     Printf.sprintf "supervisor_restart_attempt(%d)" r.attempt
   | Restart_budget_exhausted -> "restart_budget_exhausted"
   | Credential_archived -> "credential_archived"
   | Zombie_timeout -> "zombie_timeout"
-  | Guardrail_stop r ->
-    Printf.sprintf "guardrail_stop(%s)" r.reason
-  | Terminal_failure_detected r ->
-    Printf.sprintf "terminal_failure_detected(%s)" r.reason
+  | Guardrail_stop r -> Printf.sprintf "guardrail_stop(%s)" r.reason
+  | Terminal_failure_detected r -> Printf.sprintf "terminal_failure_detected(%s)" r.reason
   | Context_overflow_detected r ->
-    let src = match r.source with
+    let src =
+      match r.source with
       | `Prompt_rejected -> "prompt_rejected"
       | `Oas_signal -> "oas_signal"
     in
-    let lim = match r.limit_tokens with
+    let lim =
+      match r.limit_tokens with
       | Some n -> string_of_int n
       | None -> "?"
     in
-    Printf.sprintf "context_overflow_detected(%s,tokens=%d,limit=%s)"
-      src r.token_count lim
+    Printf.sprintf
+      "context_overflow_detected(%s,tokens=%d,limit=%s)"
+      src
+      r.token_count
+      lim
   | Auto_compact_triggered -> "auto_compact_triggered"
   | Compact_retry_exhausted -> "compact_retry_exhausted"
   | Operator_compact_requested -> "operator_compact_requested"
   | Operator_clear_requested r ->
-    Printf.sprintf "operator_clear_requested(preserve_system=%b,reason=%s)"
-      r.preserve_system r.reason
+    Printf.sprintf
+      "operator_clear_requested(preserve_system=%b,reason=%s)"
+      r.preserve_system
+      r.reason
+;;
 
 (* ── Entry Actions ─────────────────────────────────────── *)
 
@@ -234,7 +264,10 @@ type entry_action =
   | Start_handoff
   | Start_drain
   | Schedule_restart of { delay_sec : float }
-  | Publish_lifecycle of { event_name : string; detail : string }
+  | Publish_lifecycle of
+      { event_name : string
+      ; detail : string
+      }
   | Mark_dead_tombstone
   | Mark_zombie_tombstone
   | Cleanup_and_unregister
@@ -243,26 +276,39 @@ type entry_action =
 
 (* ── Transition Types ──────────────────────────────────── *)
 
-type transition_result = {
-  prev_phase : phase;
-  new_phase : phase;
-  updated_conditions : conditions;
-  entry_actions : entry_action list;
-  event_applied : event;
-  timestamp : float;
-}
+type transition_result =
+  { prev_phase : phase
+  ; new_phase : phase
+  ; updated_conditions : conditions
+  ; entry_actions : entry_action list
+  ; event_applied : event
+  ; timestamp : float
+  }
 
 type transition_error =
-  | Terminal_state of { current : phase; attempted_event : string }
-  | Invalid_transition of { from_phase : phase; to_phase : phase; reason : string }
+  | Terminal_state of
+      { current : phase
+      ; attempted_event : string
+      }
+  | Invalid_transition of
+      { from_phase : phase
+      ; to_phase : phase
+      ; reason : string
+      }
 
 let transition_error_to_string = function
   | Terminal_state r ->
-    Printf.sprintf "terminal_state: %s cannot accept %s"
-      (phase_to_string r.current) r.attempted_event
+    Printf.sprintf
+      "terminal_state: %s cannot accept %s"
+      (phase_to_string r.current)
+      r.attempted_event
   | Invalid_transition r ->
-    Printf.sprintf "invalid_transition: %s -> %s (%s)"
-      (phase_to_string r.from_phase) (phase_to_string r.to_phase) r.reason
+    Printf.sprintf
+      "invalid_transition: %s -> %s (%s)"
+      (phase_to_string r.from_phase)
+      (phase_to_string r.to_phase)
+      r.reason
+;;
 
 (* ── Transition Matrix ─────────────────────────────────── *)
 
@@ -282,8 +328,15 @@ let can_transition ~from_phase ~to_phase =
   | Offline, _ -> false
   (* Running -> buffer states, Paused, Stopped, Crashed (fiber death),
      Overflowed (prompt exceeded provider budget) *)
-  | Running, (Failing | Overflowed | Compacting | HandingOff | Draining
-             | Paused | Stopped | Crashed) -> true
+  | ( Running
+    , ( Failing
+      | Overflowed
+      | Compacting
+      | HandingOff
+      | Draining
+      | Paused
+      | Stopped
+      | Crashed ) ) -> true
   | Running, _ -> false
   (* Failing -> Running (recovery) | Crashed (threshold) | Draining (stop)
      | Paused (operator can pause for investigation)
@@ -328,11 +381,22 @@ let can_transition ~from_phase ~to_phase =
      | Draining (stop_requested persists) | Paused (operator_paused persists) *)
   | Restarting, (Running | Crashed | Draining | Paused) -> true
   | Restarting, _ -> false
+;;
 
 let can_execute_turn = function
   | Running | Failing -> true
-  | Offline | Overflowed | Compacting | HandingOff | Draining | Paused
-  | Stopped | Crashed | Restarting | Dead | Zombie -> false
+  | Offline
+  | Overflowed
+  | Compacting
+  | HandingOff
+  | Draining
+  | Paused
+  | Stopped
+  | Crashed
+  | Restarting
+  | Dead
+  | Zombie -> false
+;;
 
 (* ── derive_phase ──────────────────────────────────────── *)
 
@@ -420,72 +484,78 @@ let derive_phase (c : conditions) : phase =
      ops so the keeper stays in Draining until compaction/handoff exits. *)
 
   (* 0. Forced terminal state — external cleanup/credential signals. *)
-  if c.credential_archived || c.zombie_timeout_reached then Dead
-  (* 1. Completed stop — drain succeeded AND no buffer ops in flight *)
-  else if c.stop_requested && c.drain_complete
-     && not c.compaction_active && not c.handoff_active then Stopped
-  (* 2. Pre-start registration. This is the only path into Offline. *)
-  else if c.launch_pending && not c.fiber_alive then Offline
-  (* 3. Terminal structural failure — Zombie (non-recoverable) *)
-  else if c.terminal_failure_latched then Zombie
-  (* 4. Fiber lifecycle — Dead / Restarting / Crashed *)
-  else if not c.fiber_alive && not c.restart_budget_remaining then Dead
-  else if not c.fiber_alive && c.restart_budget_remaining && c.backoff_elapsed then Restarting
-  else if not c.fiber_alive && c.restart_budget_remaining then Crashed
-  (* 5. In-progress stop — still draining *)
-  else if c.stop_requested then Draining
-  (* 6. Guardrail -> Failing *)
-  else if c.guardrail_triggered then Failing
-  (* 7. Operator pause OR auto-compact retry budget exhausted.
+  if c.credential_archived || c.zombie_timeout_reached
+  then Dead (* 1. Completed stop — drain succeeded AND no buffer ops in flight *)
+  else if
+    c.stop_requested
+    && c.drain_complete
+    && (not c.compaction_active)
+    && not c.handoff_active
+  then Stopped (* 2. Pre-start registration. This is the only path into Offline. *)
+  else if c.launch_pending && not c.fiber_alive
+  then Offline (* 3. Terminal structural failure — Zombie (non-recoverable) *)
+  else if c.terminal_failure_latched
+  then Zombie (* 4. Fiber lifecycle — Dead / Restarting / Crashed *)
+  else if (not c.fiber_alive) && not c.restart_budget_remaining
+  then Dead
+  else if (not c.fiber_alive) && c.restart_budget_remaining && c.backoff_elapsed
+  then Restarting
+  else if (not c.fiber_alive) && c.restart_budget_remaining
+  then Crashed (* 5. In-progress stop — still draining *)
+  else if c.stop_requested
+  then Draining (* 6. Guardrail -> Failing *)
+  else if c.guardrail_triggered
+  then
+    Failing
+    (* 7. Operator pause OR auto-compact retry budget exhausted.
      When [compact_retry_exhausted] is latched together with an ongoing
      [context_overflow], the keeper MUST land on [Paused] so that an
      operator has to intervene; otherwise [Overflowed → Compacting]
      would loop indefinitely. *)
-  else if c.operator_paused
-       || (c.context_overflow && c.compact_retry_exhausted) then Paused
-  (* 8. Buffer states: in-progress operations *)
-  else if c.handoff_active then HandingOff
-  else if c.compaction_active then Compacting
-  (* 8b. Context overflow awaiting auto-compact.
+  else if c.operator_paused || (c.context_overflow && c.compact_retry_exhausted)
+  then Paused (* 8. Buffer states: in-progress operations *)
+  else if c.handoff_active
+  then HandingOff
+  else if c.compaction_active
+  then
+    Compacting
+    (* 8b. Context overflow awaiting auto-compact.
      Transient: [entry_actions_for] emits [Start_compaction] on entry,
      which flips [compaction_active] via [Auto_compact_triggered] and the
      next [derive_phase] returns [Compacting]. If [compaction_active] is
      already set (compaction already started), priority 8 wins and the
      keeper reads as [Compacting], not [Overflowed]. *)
-  else if c.context_overflow then Overflowed
-  (* 9. Health degradation *)
-  else if not c.heartbeat_healthy
-          || not c.turn_healthy
-  then Failing
-  (* 10. Healthy running *)
-  else if c.fiber_alive then Running
+  else if c.context_overflow
+  then Overflowed (* 9. Health degradation *)
+  else if (not c.heartbeat_healthy) || not c.turn_healthy
+  then Failing (* 10. Healthy running *)
+  else if c.fiber_alive
+  then Running
   (* 11. Initial / unreachable fallback *)
   else Offline
+;;
 
 (* ── Condition Updaters ────────────────────────────────── *)
 
 (** Update conditions based on an event. Returns new conditions. *)
 let update_conditions (c : conditions) (ev : event) : conditions =
   match ev with
-  | Heartbeat_ok ->
-    { c with heartbeat_healthy = true }
+  | Heartbeat_ok -> { c with heartbeat_healthy = true }
   | Heartbeat_failed { consecutive; max_allowed } ->
     (* Any failure makes heartbeat unhealthy. Recovery requires Heartbeat_ok.
        The consecutive count is for audit/logging, not for health determination. *)
     let _ = max_allowed in
     { c with heartbeat_healthy = consecutive = 0 }
-  | Turn_succeeded ->
-    { c with turn_healthy = true }
+  | Turn_succeeded -> { c with turn_healthy = true }
   | Turn_failed { consecutive; max_allowed } ->
     let _ = max_allowed in
     { c with turn_healthy = consecutive = 0 }
   | Context_measured { auto_rules; _ } ->
     { c with
-      guardrail_triggered = auto_rules.guardrail_stop;
-      context_handoff_needed = auto_rules.handoff;
+      guardrail_triggered = auto_rules.guardrail_stop
+    ; context_handoff_needed = auto_rules.handoff
     }
-  | Compaction_started ->
-    { c with compaction_active = true }
+  | Compaction_started -> { c with compaction_active = true }
   | Compaction_completed { before_tokens; after_tokens } ->
     (* #9988: "completed" alone does not mean the overflow was resolved.
        In production 98.4% of [Compaction_completed] events arrive with
@@ -502,19 +572,20 @@ let update_conditions (c : conditions) (ev : event) : conditions =
        handoff) can take over. Only a real reduction clears the flag
        and releases the retry-exhausted latch. *)
     let saved_tokens = before_tokens - after_tokens in
-    if saved_tokens > 0 then
+    if saved_tokens > 0
+    then
       { c with
-        compaction_active = false;
-        context_overflow = false;
-        compact_retry_exhausted = false;
+        compaction_active = false
+      ; context_overflow = false
+      ; compact_retry_exhausted = false
       }
-    else begin
+    else (
       Log.Keeper.warn
-        "[fsm] compaction_completed with no savings (before=%d after=%d); \
-         keeping context_overflow=true to avoid noop re-trigger loop"
-        before_tokens after_tokens;
-      { c with compaction_active = false }
-    end
+        "[fsm] compaction_completed with no savings (before=%d after=%d); keeping \
+         context_overflow=true to avoid noop re-trigger loop"
+        before_tokens
+        after_tokens;
+      { c with compaction_active = false })
   | Compaction_failed _ ->
     (* Leave [context_overflow] set — the overflow has not been resolved.
        The retry-exhausted latch is owned by the caller (keeper_unified_turn
@@ -522,22 +593,14 @@ let update_conditions (c : conditions) (ev : event) : conditions =
        [Operator_clear_requested] or [Context_overflow_detected] after
        the retry budget is depleted. *)
     { c with compaction_active = false }
-  | Handoff_started ->
-    { c with handoff_active = true }
-  | Handoff_completed _ ->
-    { c with handoff_active = false }
-  | Handoff_failed _ ->
-    { c with handoff_active = false }
-  | Operator_pause ->
-    { c with operator_paused = true }
-  | Operator_resume ->
-    { c with operator_paused = false }
-  | Operator_stop _ ->
-    { c with stop_requested = true }
-  | Stop_requested ->
-    { c with stop_requested = true }
-  | Drain_complete ->
-    { c with drain_complete = true }
+  | Handoff_started -> { c with handoff_active = true }
+  | Handoff_completed _ -> { c with handoff_active = false }
+  | Handoff_failed _ -> { c with handoff_active = false }
+  | Operator_pause -> { c with operator_paused = true }
+  | Operator_resume -> { c with operator_paused = false }
+  | Operator_stop _ -> { c with stop_requested = true }
+  | Stop_requested -> { c with stop_requested = true }
+  | Drain_complete -> { c with drain_complete = true }
   | Fiber_started ->
     (* A new fiber = a new life. Reset health, buffer, backoff, and stop conditions.
        Previous heartbeat/turn failures, in-progress compaction/handoff, and
@@ -553,34 +616,33 @@ let update_conditions (c : conditions) (ev : event) : conditions =
        that should survive restarts. Budget is preserved — it's a supervisor
        policy, not a fiber concern. *)
     { c with
-      launch_pending = false;
-      fiber_alive = true;
-      heartbeat_healthy = true;
-      turn_healthy = true;
-      compaction_active = false;
-      handoff_active = false;
-      backoff_elapsed = false;
-      guardrail_triggered = false;
-      drain_complete = false;
-      stop_requested = false;
-      context_overflow = false;
-      compact_retry_exhausted = false;
-      terminal_failure_latched = false;
+      launch_pending = false
+    ; fiber_alive = true
+    ; heartbeat_healthy = true
+    ; turn_healthy = true
+    ; compaction_active = false
+    ; handoff_active = false
+    ; backoff_elapsed = false
+    ; guardrail_triggered = false
+    ; drain_complete = false
+    ; stop_requested = false
+    ; context_overflow = false
+    ; compact_retry_exhausted = false
+    ; terminal_failure_latched = false
     }
-  | Fiber_terminated _ ->
-    { c with fiber_alive = false }
-  | Supervisor_restart_attempt _ ->
-    { c with backoff_elapsed = true }
-  | Restart_budget_exhausted ->
-    { c with restart_budget_remaining = false }
+  | Fiber_terminated _ -> { c with fiber_alive = false }
+  | Supervisor_restart_attempt _ -> { c with backoff_elapsed = true }
+  | Restart_budget_exhausted -> { c with restart_budget_remaining = false }
   | Credential_archived ->
-    { c with restart_budget_remaining = false; fiber_alive = false; credential_archived = true }
+    { c with
+      restart_budget_remaining = false
+    ; fiber_alive = false
+    ; credential_archived = true
+    }
   | Zombie_timeout ->
     { c with restart_budget_remaining = false; zombie_timeout_reached = true }
-  | Guardrail_stop _ ->
-    { c with guardrail_triggered = true }
-  | Terminal_failure_detected _ ->
-    { c with terminal_failure_latched = true }
+  | Guardrail_stop _ -> { c with guardrail_triggered = true }
+  | Terminal_failure_detected _ -> { c with terminal_failure_latched = true }
   | Context_overflow_detected _ ->
     (* Hard overflow reported by the provider. The phase derivation
        maps this to either [Overflowed] (auto-compact path) or [Paused]
@@ -608,10 +670,8 @@ let update_conditions (c : conditions) (ev : event) : conditions =
   | Operator_clear_requested _ ->
     (* Last resort: context fully dropped by [masc_keeper_clear].
        Conditions reset in-place without passing through [Compacting]. *)
-    { c with
-      context_overflow = false;
-      compact_retry_exhausted = false;
-    }
+    { c with context_overflow = false; compact_retry_exhausted = false }
+;;
 
 (** Compute entry actions for a phase transition.
     [Publish_lifecycle] is always consumed by the registry runtime.
@@ -631,68 +691,99 @@ let update_conditions (c : conditions) (ev : event) : conditions =
     into Restarting from non-Crashed) now return [] from explicit arms
     with comments documenting *why* the no-op is intentional. *)
 let entry_actions_for ~prev_phase ~new_phase ~(event : event) : entry_action list =
-  let lifecycle name detail =
-    Publish_lifecycle { event_name = name; detail }
-  in
+  let lifecycle name detail = Publish_lifecycle { event_name = name; detail } in
   match new_phase with
-  | Compacting ->
-    [ Start_compaction; lifecycle "compaction_started" "" ]
-  | HandingOff ->
-    [ Start_handoff; lifecycle "handoff_started" "" ]
-  | Draining ->
-    [ Start_drain; lifecycle "draining" "" ]
+  | Compacting -> [ Start_compaction; lifecycle "compaction_started" "" ]
+  | HandingOff -> [ Start_handoff; lifecycle "handoff_started" "" ]
+  | Draining -> [ Start_drain; lifecycle "draining" "" ]
   | Dead ->
-    [ Mark_dead_tombstone;
-      lifecycle "dead" (event_to_string event);
-      Trigger_immediate_cleanup;
-      Cancel_pending_oas ]
-  | Zombie ->
-    [ Mark_zombie_tombstone; lifecycle "zombie" "terminal structural failure" ]
+    [ Mark_dead_tombstone
+    ; lifecycle "dead" (event_to_string event)
+    ; Trigger_immediate_cleanup
+    ; Cancel_pending_oas
+    ]
+  | Zombie -> [ Mark_zombie_tombstone; lifecycle "zombie" "terminal structural failure" ]
   | Stopped ->
-    [ Cleanup_and_unregister;
-      lifecycle "stopped"
+    [ Cleanup_and_unregister
+    ; lifecycle
+        "stopped"
         (match event with
-         | Operator_stop { remove_meta } ->
-           Printf.sprintf "remove_meta=%b" remove_meta
+         | Operator_stop { remove_meta } -> Printf.sprintf "remove_meta=%b" remove_meta
          | Drain_complete -> "drain_complete"
-         | Heartbeat_ok | Heartbeat_failed _ | Turn_succeeded | Turn_failed _
-         | Context_measured _ | Compaction_started | Compaction_completed _
-         | Compaction_failed _ | Context_overflow_detected _
-         | Compact_retry_exhausted | Handoff_started | Handoff_completed _
-         | Handoff_failed _ | Operator_pause | Operator_resume
-         | Stop_requested | Fiber_started | Fiber_terminated _
-         | Supervisor_restart_attempt _ | Restart_budget_exhausted
-         | Credential_archived | Zombie_timeout | Guardrail_stop _
-         | Terminal_failure_detected _ | Auto_compact_triggered
-         | Operator_compact_requested | Operator_clear_requested _ ->
-           event_to_string event) ]
+         | Heartbeat_ok
+         | Heartbeat_failed _
+         | Turn_succeeded
+         | Turn_failed _
+         | Context_measured _
+         | Compaction_started
+         | Compaction_completed _
+         | Compaction_failed _
+         | Context_overflow_detected _
+         | Compact_retry_exhausted
+         | Handoff_started
+         | Handoff_completed _
+         | Handoff_failed _
+         | Operator_pause
+         | Operator_resume
+         | Stop_requested
+         | Fiber_started
+         | Fiber_terminated _
+         | Supervisor_restart_attempt _
+         | Restart_budget_exhausted
+         | Credential_archived
+         | Zombie_timeout
+         | Guardrail_stop _
+         | Terminal_failure_detected _
+         | Auto_compact_triggered
+         | Operator_compact_requested
+         | Operator_clear_requested _ -> event_to_string event)
+    ]
   (* [Overflowed] entry actions: request a compaction so the registry can
      promote the committed [Overflowed] transition into the follow-up
      [Auto_compact_triggered] event, and publish the transition so
      operators can see "context overflow" distinctly from generic failure. *)
   | Overflowed ->
-    [ Start_compaction;
-      lifecycle "overflowed"
+    [ Start_compaction
+    ; lifecycle
+        "overflowed"
         (match event with
          | Context_overflow_detected r ->
-           let lim = match r.limit_tokens with
+           let lim =
+             match r.limit_tokens with
              | Some n -> Printf.sprintf ",limit=%d" n
              | None -> ""
            in
            Printf.sprintf "tokens=%d%s" r.token_count lim
-         | Compact_retry_exhausted | Heartbeat_ok | Heartbeat_failed _
-         | Turn_succeeded | Turn_failed _ | Context_measured _
-         | Compaction_started | Compaction_completed _ | Compaction_failed _
-         | Handoff_started | Handoff_completed _ | Handoff_failed _
-         | Operator_pause | Operator_resume | Operator_stop _
-         | Stop_requested | Drain_complete | Fiber_started | Fiber_terminated _
-         | Supervisor_restart_attempt _ | Restart_budget_exhausted
-         | Credential_archived | Zombie_timeout | Guardrail_stop _
-         | Terminal_failure_detected _ | Auto_compact_triggered
-         | Operator_compact_requested | Operator_clear_requested _ ->
-           event_to_string event) ]
-  | Failing ->
-    [ lifecycle "failing" (event_to_string event) ]
+         | Compact_retry_exhausted
+         | Heartbeat_ok
+         | Heartbeat_failed _
+         | Turn_succeeded
+         | Turn_failed _
+         | Context_measured _
+         | Compaction_started
+         | Compaction_completed _
+         | Compaction_failed _
+         | Handoff_started
+         | Handoff_completed _
+         | Handoff_failed _
+         | Operator_pause
+         | Operator_resume
+         | Operator_stop _
+         | Stop_requested
+         | Drain_complete
+         | Fiber_started
+         | Fiber_terminated _
+         | Supervisor_restart_attempt _
+         | Restart_budget_exhausted
+         | Credential_archived
+         | Zombie_timeout
+         | Guardrail_stop _
+         | Terminal_failure_detected _
+         | Auto_compact_triggered
+         | Operator_compact_requested
+         | Operator_clear_requested _ -> event_to_string event)
+    ]
+  | Failing -> [ lifecycle "failing" (event_to_string event) ]
   | Paused ->
     (* Distinguish operator-pause from overflow-induced pause so the
        dashboard can surface the right message.
@@ -704,18 +795,35 @@ let entry_actions_for ~prev_phase ~new_phase ~(event : event) : entry_action lis
        reaches the dashboard. *)
     let detail =
       match event with
-      | Context_overflow_detected _
-      | Compact_retry_exhausted -> "auto-compact retry exhausted"
+      | Context_overflow_detected _ | Compact_retry_exhausted ->
+        "auto-compact retry exhausted"
       | Operator_pause -> "operator request"
-      | Heartbeat_ok | Heartbeat_failed _ | Turn_succeeded | Turn_failed _
-      | Context_measured _ | Compaction_started | Compaction_completed _
-      | Compaction_failed _ | Handoff_started | Handoff_completed _
-      | Handoff_failed _ | Operator_resume | Operator_stop _
-      | Stop_requested | Drain_complete | Fiber_started | Fiber_terminated _
-      | Supervisor_restart_attempt _ | Restart_budget_exhausted
-      | Credential_archived | Zombie_timeout | Guardrail_stop _
-      | Terminal_failure_detected _ | Auto_compact_triggered
-      | Operator_compact_requested | Operator_clear_requested _ ->
+      | Heartbeat_ok
+      | Heartbeat_failed _
+      | Turn_succeeded
+      | Turn_failed _
+      | Context_measured _
+      | Compaction_started
+      | Compaction_completed _
+      | Compaction_failed _
+      | Handoff_started
+      | Handoff_completed _
+      | Handoff_failed _
+      | Operator_resume
+      | Operator_stop _
+      | Stop_requested
+      | Drain_complete
+      | Fiber_started
+      | Fiber_terminated _
+      | Supervisor_restart_attempt _
+      | Restart_budget_exhausted
+      | Credential_archived
+      | Zombie_timeout
+      | Guardrail_stop _
+      | Terminal_failure_detected _
+      | Auto_compact_triggered
+      | Operator_compact_requested
+      | Operator_clear_requested _ ->
         (* These events should not normally trigger a Paused transition,
            but if they do, label generically rather than mis-attributing
            to "operator request". *)
@@ -724,10 +832,19 @@ let entry_actions_for ~prev_phase ~new_phase ~(event : event) : entry_action lis
     [ lifecycle "paused" detail ]
   | Restarting ->
     (match prev_phase with
-     | Crashed ->
-       [ lifecycle "restarting" "backoff elapsed" ]
-     | Offline | Running | Failing | Overflowed | Compacting | HandingOff
-     | Draining | Paused | Stopped | Restarting | Dead | Zombie ->
+     | Crashed -> [ lifecycle "restarting" "backoff elapsed" ]
+     | Offline
+     | Running
+     | Failing
+     | Overflowed
+     | Compacting
+     | HandingOff
+     | Draining
+     | Paused
+     | Stopped
+     | Restarting
+     | Dead
+     | Zombie ->
        (* Direct transitions to Restarting from non-Crashed phases are not
           a normal lifecycle path; the supervisor / registry owns publishing
           for those rare corner cases. Intentional no-op (matches the
@@ -735,10 +852,8 @@ let entry_actions_for ~prev_phase ~new_phase ~(event : event) : entry_action lis
        [])
   | Running ->
     (match prev_phase with
-     | Restarting ->
-       [ lifecycle "restarted" "fiber launched" ]
-     | Failing ->
-       [ lifecycle "recovered" "failure counters reset" ]
+     | Restarting -> [ lifecycle "restarted" "fiber launched" ]
+     | Failing -> [ lifecycle "recovered" "failure counters reset" ]
      | Paused ->
        (* Issue #8732 (sibling of #8728): resume is event-driven, not always
           operator-initiated. [Compaction_completed] / [Fiber_terminated]
@@ -752,23 +867,47 @@ let entry_actions_for ~prev_phase ~new_phase ~(event : event) : entry_action lis
          | Operator_resume -> "operator request"
          | Compaction_completed _ -> "auto-compact recovered"
          | Fiber_terminated _ -> "fiber recovered"
-         | Heartbeat_ok | Heartbeat_failed _ | Turn_succeeded | Turn_failed _
-         | Context_measured _ | Compaction_started | Compaction_failed _
-         | Handoff_started | Handoff_completed _ | Handoff_failed _
-         | Operator_stop _ | Operator_pause | Stop_requested | Drain_complete
-         | Fiber_started | Supervisor_restart_attempt _
-         | Restart_budget_exhausted | Credential_archived | Zombie_timeout
-         | Guardrail_stop _ | Terminal_failure_detected _
-         | Auto_compact_triggered | Operator_compact_requested
-         | Context_overflow_detected _ | Compact_retry_exhausted
+         | Heartbeat_ok
+         | Heartbeat_failed _
+         | Turn_succeeded
+         | Turn_failed _
+         | Context_measured _
+         | Compaction_started
+         | Compaction_failed _
+         | Handoff_started
+         | Handoff_completed _
+         | Handoff_failed _
+         | Operator_stop _
+         | Operator_pause
+         | Stop_requested
+         | Drain_complete
+         | Fiber_started
+         | Supervisor_restart_attempt _
+         | Restart_budget_exhausted
+         | Credential_archived
+         | Zombie_timeout
+         | Guardrail_stop _
+         | Terminal_failure_detected _
+         | Auto_compact_triggered
+         | Operator_compact_requested
+         | Context_overflow_detected _
+         | Compact_retry_exhausted
          | Operator_clear_requested _ ->
            (* These events should not normally trigger a Paused→Running
               transition; label generically via [event_to_string]. *)
            event_to_string event
        in
        [ lifecycle "resumed" detail ]
-     | Offline | Running | Overflowed | Compacting | HandingOff | Draining
-     | Stopped | Crashed | Dead | Zombie ->
+     | Offline
+     | Running
+     | Overflowed
+     | Compacting
+     | HandingOff
+     | Draining
+     | Stopped
+     | Crashed
+     | Dead
+     | Zombie ->
        (* [register] takes Init → Running without traversing this function
           (it uses [register_with_state] directly). For other prevs (e.g.
           Compacting → Running on auto-compact success, Overflowed →
@@ -792,6 +931,7 @@ let entry_actions_for ~prev_phase ~new_phase ~(event : event) : entry_action lis
        so dashboards can distinguish crash cause without relying on the
        supervisor's follow-up. *)
     []
+;;
 
 (* ── apply_event ───────────────────────────────────────── *)
 
@@ -799,162 +939,169 @@ let apply_event ~current_phase ~conditions ~event ~now =
   (* Terminal states reject all events *)
   match current_phase with
   | Stopped | Dead | Zombie ->
-    Error (Terminal_state {
-      current = current_phase;
-      attempted_event = event_to_string event;
-    })
+    Error
+      (Terminal_state { current = current_phase; attempted_event = event_to_string event })
   | _ ->
     let updated_conditions = update_conditions conditions event in
     let new_phase = derive_phase updated_conditions in
     (* Validate transition is allowed *)
-    if new_phase = current_phase then
+    if new_phase = current_phase
+    then
       (* No transition — still valid *)
-      Ok {
-        prev_phase = current_phase;
-        new_phase;
-        updated_conditions;
-        entry_actions = [];
-        event_applied = event;
-        timestamp = now;
-      }
-    else if can_transition ~from_phase:current_phase ~to_phase:new_phase then
-      Ok {
-        prev_phase = current_phase;
-        new_phase;
-        updated_conditions;
-        entry_actions = entry_actions_for ~prev_phase:current_phase ~new_phase ~event;
-        event_applied = event;
-        timestamp = now;
-      }
+      Ok
+        { prev_phase = current_phase
+        ; new_phase
+        ; updated_conditions
+        ; entry_actions = []
+        ; event_applied = event
+        ; timestamp = now
+        }
+    else if can_transition ~from_phase:current_phase ~to_phase:new_phase
+    then
+      Ok
+        { prev_phase = current_phase
+        ; new_phase
+        ; updated_conditions
+        ; entry_actions = entry_actions_for ~prev_phase:current_phase ~new_phase ~event
+        ; event_applied = event
+        ; timestamp = now
+        }
     else
       (* derive_phase produced a phase that can_transition rejects.
          This indicates a logic error between derive_phase and the matrix. *)
-      Error (Invalid_transition {
-        from_phase = current_phase;
-        to_phase = new_phase;
-        reason = Printf.sprintf "event %s caused derive_phase to produce %s from %s, \
-                                 but this transition is not in the matrix"
-          (event_to_string event)
-          (phase_to_string new_phase)
-          (phase_to_string current_phase);
-      })
+      Error
+        (Invalid_transition
+           { from_phase = current_phase
+           ; to_phase = new_phase
+           ; reason =
+               Printf.sprintf
+                 "event %s caused derive_phase to produce %s from %s, but this \
+                  transition is not in the matrix"
+                 (event_to_string event)
+                 (phase_to_string new_phase)
+                 (phase_to_string current_phase)
+           })
+;;
 
 (* ── JSON Serialization ────────────────────────────────── *)
 
 let phase_to_json p = `String (phase_to_string p)
 
 let conditions_to_json (c : conditions) =
-  `Assoc [
-    "launch_pending", `Bool c.launch_pending;
-    "fiber_alive", `Bool c.fiber_alive;
-    "heartbeat_healthy", `Bool c.heartbeat_healthy;
-    "turn_healthy", `Bool c.turn_healthy;
-    "context_within_budget", `Bool c.context_within_budget;
-    "context_handoff_needed", `Bool c.context_handoff_needed;
-    "compaction_active", `Bool c.compaction_active;
-    "handoff_active", `Bool c.handoff_active;
-    "operator_paused", `Bool c.operator_paused;
-    "stop_requested", `Bool c.stop_requested;
-    "restart_budget_remaining", `Bool c.restart_budget_remaining;
-    "backoff_elapsed", `Bool c.backoff_elapsed;
-    "guardrail_triggered", `Bool c.guardrail_triggered;
-    "drain_complete", `Bool c.drain_complete;
-    "context_overflow", `Bool c.context_overflow;
-    "compact_retry_exhausted", `Bool c.compact_retry_exhausted;
-    "terminal_failure_latched", `Bool c.terminal_failure_latched;
-    "credential_archived", `Bool c.credential_archived;
-    "zombie_timeout_reached", `Bool c.zombie_timeout_reached;
-  ]
+  `Assoc
+    [ "launch_pending", `Bool c.launch_pending
+    ; "fiber_alive", `Bool c.fiber_alive
+    ; "heartbeat_healthy", `Bool c.heartbeat_healthy
+    ; "turn_healthy", `Bool c.turn_healthy
+    ; "context_within_budget", `Bool c.context_within_budget
+    ; "context_handoff_needed", `Bool c.context_handoff_needed
+    ; "compaction_active", `Bool c.compaction_active
+    ; "handoff_active", `Bool c.handoff_active
+    ; "operator_paused", `Bool c.operator_paused
+    ; "stop_requested", `Bool c.stop_requested
+    ; "restart_budget_remaining", `Bool c.restart_budget_remaining
+    ; "backoff_elapsed", `Bool c.backoff_elapsed
+    ; "guardrail_triggered", `Bool c.guardrail_triggered
+    ; "drain_complete", `Bool c.drain_complete
+    ; "context_overflow", `Bool c.context_overflow
+    ; "compact_retry_exhausted", `Bool c.compact_retry_exhausted
+    ; "terminal_failure_latched", `Bool c.terminal_failure_latched
+    ; "credential_archived", `Bool c.credential_archived
+    ; "zombie_timeout_reached", `Bool c.zombie_timeout_reached
+    ]
+;;
 
 let event_to_json (ev : event) : Yojson.Safe.t =
   let obj typ fields = `Assoc (("type", `String typ) :: fields) in
   match ev with
   | Heartbeat_ok -> obj "heartbeat_ok" []
   | Heartbeat_failed r ->
-    obj "heartbeat_failed" [
-      "consecutive", `Int r.consecutive;
-      "max_allowed", `Int r.max_allowed;
-    ]
+    obj
+      "heartbeat_failed"
+      [ "consecutive", `Int r.consecutive; "max_allowed", `Int r.max_allowed ]
   | Turn_succeeded -> obj "turn_succeeded" []
   | Turn_failed r ->
-    obj "turn_failed" [
-      "consecutive", `Int r.consecutive;
-      "max_allowed", `Int r.max_allowed;
-    ]
+    obj
+      "turn_failed"
+      [ "consecutive", `Int r.consecutive; "max_allowed", `Int r.max_allowed ]
   | Context_measured r ->
-    obj "context_measured" [
-      "context_ratio", `Float r.context_ratio;
-      "message_count", `Int r.message_count;
-      "token_count", `Int r.token_count;
-      "auto_rules", `Assoc [
-        "reflect", `Bool r.auto_rules.reflect;
-        "plan", `Bool r.auto_rules.plan;
-        "compact", `Bool r.auto_rules.compact;
-        "handoff", `Bool r.auto_rules.handoff;
-        "guardrail_stop", `Bool r.auto_rules.guardrail_stop;
-        "goal_drift", `Float r.auto_rules.goal_drift;
-      ];
-    ]
+    obj
+      "context_measured"
+      [ "context_ratio", `Float r.context_ratio
+      ; "message_count", `Int r.message_count
+      ; "token_count", `Int r.token_count
+      ; ( "auto_rules"
+        , `Assoc
+            [ "reflect", `Bool r.auto_rules.reflect
+            ; "plan", `Bool r.auto_rules.plan
+            ; "compact", `Bool r.auto_rules.compact
+            ; "handoff", `Bool r.auto_rules.handoff
+            ; "guardrail_stop", `Bool r.auto_rules.guardrail_stop
+            ; "goal_drift", `Float r.auto_rules.goal_drift
+            ] )
+      ]
   | Compaction_started -> obj "compaction_started" []
   | Compaction_completed r ->
-    obj "compaction_completed" [
-      "before_tokens", `Int r.before_tokens;
-      "after_tokens", `Int r.after_tokens;
-    ]
-  | Compaction_failed r -> obj "compaction_failed" ["reason", `String r.reason]
+    obj
+      "compaction_completed"
+      [ "before_tokens", `Int r.before_tokens; "after_tokens", `Int r.after_tokens ]
+  | Compaction_failed r -> obj "compaction_failed" [ "reason", `String r.reason ]
   | Handoff_started -> obj "handoff_started" []
   | Handoff_completed r ->
-    obj "handoff_completed" [
-      "new_trace_id", `String r.new_trace_id;
-      "generation", `Int r.generation;
-    ]
-  | Handoff_failed r -> obj "handoff_failed" ["reason", `String r.reason]
+    obj
+      "handoff_completed"
+      [ "new_trace_id", `String r.new_trace_id; "generation", `Int r.generation ]
+  | Handoff_failed r -> obj "handoff_failed" [ "reason", `String r.reason ]
   | Operator_pause -> obj "operator_pause" []
   | Operator_resume -> obj "operator_resume" []
-  | Operator_stop r -> obj "operator_stop" ["remove_meta", `Bool r.remove_meta]
+  | Operator_stop r -> obj "operator_stop" [ "remove_meta", `Bool r.remove_meta ]
   | Stop_requested -> obj "stop_requested" []
   | Drain_complete -> obj "drain_complete" []
   | Fiber_started -> obj "fiber_started" []
-  | Fiber_terminated r -> obj "fiber_terminated" ["outcome", `String r.outcome]
+  | Fiber_terminated r -> obj "fiber_terminated" [ "outcome", `String r.outcome ]
   | Supervisor_restart_attempt r ->
-    obj "supervisor_restart_attempt" ["attempt", `Int r.attempt]
+    obj "supervisor_restart_attempt" [ "attempt", `Int r.attempt ]
   | Restart_budget_exhausted -> obj "restart_budget_exhausted" []
   | Credential_archived -> obj "credential_archived" []
   | Zombie_timeout -> obj "zombie_timeout" []
-  | Guardrail_stop r -> obj "guardrail_stop" ["reason", `String r.reason]
+  | Guardrail_stop r -> obj "guardrail_stop" [ "reason", `String r.reason ]
   | Terminal_failure_detected r ->
-    obj "terminal_failure_detected" ["reason", `String r.reason]
+    obj "terminal_failure_detected" [ "reason", `String r.reason ]
   | Context_overflow_detected r ->
-    let source = match r.source with
+    let source =
+      match r.source with
       | `Prompt_rejected -> "prompt_rejected"
       | `Oas_signal -> "oas_signal"
     in
-    let limit_tokens = match r.limit_tokens with
+    let limit_tokens =
+      match r.limit_tokens with
       | Some n -> `Int n
       | None -> `Null
     in
-    obj "context_overflow_detected" [
-      "source", `String source;
-      "token_count", `Int r.token_count;
-      "limit_tokens", limit_tokens;
-    ]
+    obj
+      "context_overflow_detected"
+      [ "source", `String source
+      ; "token_count", `Int r.token_count
+      ; "limit_tokens", limit_tokens
+      ]
   | Auto_compact_triggered -> obj "auto_compact_triggered" []
   | Compact_retry_exhausted -> obj "compact_retry_exhausted" []
   | Operator_compact_requested -> obj "operator_compact_requested" []
   | Operator_clear_requested r ->
-    obj "operator_clear_requested" [
-      "preserve_system", `Bool r.preserve_system;
-      "reason", `String r.reason;
-    ]
+    obj
+      "operator_clear_requested"
+      [ "preserve_system", `Bool r.preserve_system; "reason", `String r.reason ]
+;;
 
 let transition_result_to_json (tr : transition_result) =
-  `Assoc [
-    "prev_phase", phase_to_json tr.prev_phase;
-    "new_phase", phase_to_json tr.new_phase;
-    "conditions", conditions_to_json tr.updated_conditions;
-    "event", event_to_json tr.event_applied;
-    "timestamp", `Float tr.timestamp;
-  ]
+  `Assoc
+    [ "prev_phase", phase_to_json tr.prev_phase
+    ; "new_phase", phase_to_json tr.new_phase
+    ; "conditions", conditions_to_json tr.updated_conditions
+    ; "event", event_to_json tr.event_applied
+    ; "timestamp", `Float tr.timestamp
+    ]
+;;
 
 (* ── Mermaid State Diagram ────────────────────────────── *)
 
@@ -973,6 +1120,7 @@ let phase_to_mermaid_id = function
   | Restarting -> "Restarting"
   | Dead -> "Dead"
   | Zombie -> "Zombie"
+;;
 
 let phase_to_mermaid ~(current : phase) : string =
   let b = Buffer.create 512 in
@@ -1036,53 +1184,57 @@ let phase_to_mermaid ~(current : phase) : string =
   p "    classDef terminal fill:#6b7280,stroke:#4b5563,color:#fff\n";
   p "    classDef buffer fill:#f59e0b,stroke:#d97706,color:#fff\n";
   (match current with
-   | Stopped | Dead | Zombie ->
-     p "    class %s terminal\n" (phase_to_mermaid_id current)
-   | Failing | Overflowed | Compacting | HandingOff | Draining | Restarting
-   | Crashed ->
+   | Stopped | Dead | Zombie -> p "    class %s terminal\n" (phase_to_mermaid_id current)
+   | Failing | Overflowed | Compacting | HandingOff | Draining | Restarting | Crashed ->
      p "    class %s buffer\n" (phase_to_mermaid_id current)
-   | Running | Offline | Paused ->
-     p "    class %s active\n" (phase_to_mermaid_id current));
+   | Running | Offline | Paused -> p "    class %s active\n" (phase_to_mermaid_id current));
   Buffer.contents b
+;;
 
 (* --- Attribution envelope conversion (Layer 1) ---
    Keeper FSM is Det by design: non-deterministic measurements are
    already translated into typed events at the boundary before this
    module sees them. See the [event] type docstring. *)
 
-let attribution_of_transition ~event
-    (result : (transition_result, transition_error) result) : Attribution.t =
+let attribution_of_transition
+      ~event
+      (result : (transition_result, transition_error) result)
+  : Attribution.t
+  =
   let event_name = event_to_string event in
   match result with
   | Ok tr ->
     let evidence : Yojson.Safe.t =
-      `Assoc [
-        ("event", `String event_name);
-        ("from_phase", `String (phase_to_string tr.prev_phase));
-        ("to_phase", `String (phase_to_string tr.new_phase));
-        ("timestamp", `Float tr.timestamp);
-      ]
+      `Assoc
+        [ "event", `String event_name
+        ; "from_phase", `String (phase_to_string tr.prev_phase)
+        ; "to_phase", `String (phase_to_string tr.new_phase)
+        ; "timestamp", `Float tr.timestamp
+        ]
     in
     Attribution.passed ~origin:Det ~gate:"keeper_fsm" ~evidence
   | Error (Invalid_transition { from_phase; to_phase; reason }) ->
-    let evidence : Yojson.Safe.t =
-      `Assoc [ ("event", `String event_name) ]
-    in
-    Attribution.transition_blocked ~origin:Det ~gate:"keeper_fsm" ~evidence
+    let evidence : Yojson.Safe.t = `Assoc [ "event", `String event_name ] in
+    Attribution.transition_blocked
+      ~origin:Det
+      ~gate:"keeper_fsm"
+      ~evidence
       ~from_state:(phase_to_string from_phase)
       ~to_state:(phase_to_string to_phase)
       ~reason
   | Error (Terminal_state { current; attempted_event }) ->
     let evidence : Yojson.Safe.t =
-      `Assoc [
-        ("event", `String event_name);
-        ("current_phase", `String (phase_to_string current));
-        ("attempted_event", `String attempted_event);
-      ]
+      `Assoc
+        [ "event", `String event_name
+        ; "current_phase", `String (phase_to_string current)
+        ; "attempted_event", `String attempted_event
+        ]
     in
     let reason =
       Printf.sprintf
         "keeper in terminal phase %s, event %s ignored"
-        (phase_to_string current) attempted_event
+        (phase_to_string current)
+        attempted_event
     in
     Attribution.policy_failed ~origin:Det ~gate:"keeper_fsm" ~evidence ~reason
+;;

--- a/lib/keeper/keeper_state_machine.ml
+++ b/lib/keeper/keeper_state_machine.ml
@@ -618,26 +618,37 @@ let update_conditions (c : conditions) (ev : event) : conditions =
     [Start_compaction] is additionally consumed for the auto-compact
     [Overflowed] path; the remaining variants stay descriptive here
     because their side effects are still owned elsewhere
-    (post-turn lifecycle or supervisor). *)
+    (post-turn lifecycle or supervisor).
+
+    Structure (Iteration 2, /loop FSM drift hunt — Phase A-2):
+    Outer match is on [new_phase] so every phase variant is exhaustively
+    enumerated and the compiler warns on future phase addition. Inner
+    matches on [prev_phase] enumerate every variant explicitly (no
+    wildcard) so the same future-proofing applies to prev-dependent arms.
+    Pre-refactor behaviour is preserved verbatim — the four classes that
+    previously fell through the [| _ -> []] catch-all (transitions into
+    Offline, Crashed, into Running from non-{Restarting,Failing,Paused},
+    into Restarting from non-Crashed) now return [] from explicit arms
+    with comments documenting *why* the no-op is intentional. *)
 let entry_actions_for ~prev_phase ~new_phase ~(event : event) : entry_action list =
   let lifecycle name detail =
     Publish_lifecycle { event_name = name; detail }
   in
-  match prev_phase, new_phase with
-  | _, Compacting ->
+  match new_phase with
+  | Compacting ->
     [ Start_compaction; lifecycle "compaction_started" "" ]
-  | _, HandingOff ->
+  | HandingOff ->
     [ Start_handoff; lifecycle "handoff_started" "" ]
-  | _, Draining ->
+  | Draining ->
     [ Start_drain; lifecycle "draining" "" ]
-  | _, Dead ->
+  | Dead ->
     [ Mark_dead_tombstone;
       lifecycle "dead" (event_to_string event);
       Trigger_immediate_cleanup;
       Cancel_pending_oas ]
-  | _, Zombie ->
+  | Zombie ->
     [ Mark_zombie_tombstone; lifecycle "zombie" "terminal structural failure" ]
-  | _, Stopped ->
+  | Stopped ->
     [ Cleanup_and_unregister;
       lifecycle "stopped"
         (match event with
@@ -655,15 +666,11 @@ let entry_actions_for ~prev_phase ~new_phase ~(event : event) : entry_action lis
          | Terminal_failure_detected _ | Auto_compact_triggered
          | Operator_compact_requested | Operator_clear_requested _ ->
            event_to_string event) ]
-  | Crashed, Restarting ->
-    [ lifecycle "restarting" "backoff elapsed" ]
-  | Restarting, Running ->
-    [ lifecycle "restarted" "fiber launched" ]
   (* [Overflowed] entry actions: request a compaction so the registry can
      promote the committed [Overflowed] transition into the follow-up
      [Auto_compact_triggered] event, and publish the transition so
      operators can see "context overflow" distinctly from generic failure. *)
-  | _, Overflowed ->
+  | Overflowed ->
     [ Start_compaction;
       lifecycle "overflowed"
         (match event with
@@ -684,11 +691,9 @@ let entry_actions_for ~prev_phase ~new_phase ~(event : event) : entry_action lis
          | Terminal_failure_detected _ | Auto_compact_triggered
          | Operator_compact_requested | Operator_clear_requested _ ->
            event_to_string event) ]
-  | _, Failing ->
+  | Failing ->
     [ lifecycle "failing" (event_to_string event) ]
-  | Failing, Running ->
-    [ lifecycle "recovered" "failure counters reset" ]
-  | _, Paused ->
+  | Paused ->
     (* Distinguish operator-pause from overflow-induced pause so the
        dashboard can surface the right message.
        Issue #8728: Compact_retry_exhausted (added in #8581 specifically
@@ -717,35 +722,76 @@ let entry_actions_for ~prev_phase ~new_phase ~(event : event) : entry_action lis
         event_to_string event
     in
     [ lifecycle "paused" detail ]
-  | Paused, Running ->
-    (* Issue #8732 (sibling of #8728): resume is event-driven, not always
-       operator-initiated. [Compaction_completed] / [Fiber_terminated]
-       clear the latched [compact_retry_exhausted] flag and let
-       [derive_phase] leave Paused; if we hardcode "operator request"
-       the dashboard claims a human resumed the keeper when in fact
-       auto-compact recovered. Mirror the per-event arms used in the
-       Paused-detail label. *)
-    let detail =
-      match event with
-      | Operator_resume -> "operator request"
-      | Compaction_completed _ -> "auto-compact recovered"
-      | Fiber_terminated _ -> "fiber recovered"
-      | Heartbeat_ok | Heartbeat_failed _ | Turn_succeeded | Turn_failed _
-      | Context_measured _ | Compaction_started | Compaction_failed _
-      | Handoff_started | Handoff_completed _ | Handoff_failed _
-      | Operator_stop _ | Operator_pause | Stop_requested | Drain_complete
-      | Fiber_started | Supervisor_restart_attempt _
-      | Restart_budget_exhausted | Credential_archived | Zombie_timeout
-      | Guardrail_stop _ | Terminal_failure_detected _
-      | Auto_compact_triggered | Operator_compact_requested
-      | Context_overflow_detected _ | Compact_retry_exhausted
-      | Operator_clear_requested _ ->
-        (* These events should not normally trigger a Paused→Running
-           transition; label generically via [event_to_string]. *)
-        event_to_string event
-    in
-    [ lifecycle "resumed" detail ]
-  | _ -> []
+  | Restarting ->
+    (match prev_phase with
+     | Crashed ->
+       [ lifecycle "restarting" "backoff elapsed" ]
+     | Offline | Running | Failing | Overflowed | Compacting | HandingOff
+     | Draining | Paused | Stopped | Restarting | Dead | Zombie ->
+       (* Direct transitions to Restarting from non-Crashed phases are not
+          a normal lifecycle path; the supervisor / registry owns publishing
+          for those rare corner cases. Intentional no-op (matches the
+          pre-refactor catch-all [| _ -> []]). *)
+       [])
+  | Running ->
+    (match prev_phase with
+     | Restarting ->
+       [ lifecycle "restarted" "fiber launched" ]
+     | Failing ->
+       [ lifecycle "recovered" "failure counters reset" ]
+     | Paused ->
+       (* Issue #8732 (sibling of #8728): resume is event-driven, not always
+          operator-initiated. [Compaction_completed] / [Fiber_terminated]
+          clear the latched [compact_retry_exhausted] flag and let
+          [derive_phase] leave Paused; if we hardcode "operator request"
+          the dashboard claims a human resumed the keeper when in fact
+          auto-compact recovered. Mirror the per-event arms used in the
+          Paused-detail label. *)
+       let detail =
+         match event with
+         | Operator_resume -> "operator request"
+         | Compaction_completed _ -> "auto-compact recovered"
+         | Fiber_terminated _ -> "fiber recovered"
+         | Heartbeat_ok | Heartbeat_failed _ | Turn_succeeded | Turn_failed _
+         | Context_measured _ | Compaction_started | Compaction_failed _
+         | Handoff_started | Handoff_completed _ | Handoff_failed _
+         | Operator_stop _ | Operator_pause | Stop_requested | Drain_complete
+         | Fiber_started | Supervisor_restart_attempt _
+         | Restart_budget_exhausted | Credential_archived | Zombie_timeout
+         | Guardrail_stop _ | Terminal_failure_detected _
+         | Auto_compact_triggered | Operator_compact_requested
+         | Context_overflow_detected _ | Compact_retry_exhausted
+         | Operator_clear_requested _ ->
+           (* These events should not normally trigger a Paused→Running
+              transition; label generically via [event_to_string]. *)
+           event_to_string event
+       in
+       [ lifecycle "resumed" detail ]
+     | Offline | Running | Overflowed | Compacting | HandingOff | Draining
+     | Stopped | Crashed | Dead | Zombie ->
+       (* [register] takes Init → Running without traversing this function
+          (it uses [register_with_state] directly). For other prevs (e.g.
+          Compacting → Running on auto-compact success, Overflowed →
+          Running similarly), the registry runtime publishes its own
+          lifecycle event covering the recovery semantics. Intentional
+          no-op (matches the pre-refactor catch-all [| _ -> []]). *)
+       [])
+  | Offline ->
+    (* Returning to Offline is rare and typically driven by registry-level
+       lifecycle (register_offline or unregister-then-readmit). Intentional
+       no-op (matches the pre-refactor catch-all [| _ -> []]). Future RFC
+       candidate: emit a distinct "offline" lifecycle when transitioning
+       *from* a non-Offline phase, for dashboard auditability. *)
+    []
+  | Crashed ->
+    (* The fiber terminated unexpectedly. The supervisor publishes its own
+       lifecycle event via [Supervisor_restart_attempt] follow-up, so we
+       avoid double-publishing here. Intentional no-op (matches the
+       pre-refactor catch-all [| _ -> []]). Future RFC candidate: emit a
+       distinct "crashed" lifecycle with the terminating event's detail
+       so dashboards can distinguish crash cause without relying on the
+       supervisor's follow-up. *)
+    []
 
 (* ── apply_event ───────────────────────────────────────── *)
 


### PR DESCRIPTION
## Iteration 2 (Phase A-2) — `entry_actions_for` catch-all 제거

`/loop` FSM drift hunt iteration 2. plan: `~/.claude/plans/breezy-napping-sketch.md`. iteration 1: #14694 (audit memo).

## 발견 (HIGH risk, 사전 식별)

`lib/keeper/keeper_state_machine.ml:626-748` `entry_actions_for`가 `match prev_phase, new_phase with ... | _ -> []` 패턴. 13×13 = 169 phase pair 중 명시된 11 케이스 외 나머지는 *silent no-op*.

Silent 처리되던 4 transition class:
- `_, Offline`
- `_, Running` (prev ∉ {Restarting, Failing, Paused})
- `_, Crashed`
- `_, Restarting` (prev ≠ Crashed)

**과거 같은 패턴이 일으킨 사고**: 함수 안 주석에 `#8728`, `#8732` 인용 — 둘 다 catch-all이 dashboard mis-attribution 일으킨 사례.

## 순서도

```mermaid
flowchart LR
  E[event] --> AE[apply_event]
  AE -->|new_phase ≠ current| EA[entry_actions_for]
  subgraph "Before: tuple match (prev × new)"
    EA --> B1["_, Compacting"]
    EA --> B2["_, HandingOff"]
    EA --> B3["..."]
    EA --> B4["Paused, Running"]
    EA --> CATCH["_ -> [] (silent)"]
    CATCH -.->|"4 classes\nfall through"| SILENT[dashboard miss]
  end
  subgraph "After: new_phase outer match"
    EA2[entry_actions_for] --> N1[new_phase = Compacting]
    EA2 --> N2[new_phase = ...]
    EA2 --> N3[new_phase = Running] --> P1[prev = Restarting/Failing/Paused/other-explicit]
    EA2 --> N4[new_phase = Offline/Crashed]
    N4 -->|explicit| EMPTY["[] with rationale"]
  end
```

## Before / After

**Before (line 626):**
```ocaml
match prev_phase, new_phase with
| _, Compacting -> [ Start_compaction; ... ]
| _, HandingOff -> [ ... ]
...
| Paused, Running -> [ ... ]
| _ -> []  (* silent for 4 transition classes *)
```

**After:**
```ocaml
match new_phase with
| Compacting -> [ Start_compaction; ... ]
| HandingOff -> [ ... ]
...
| Restarting ->
  (match prev_phase with
   | Crashed -> [ ... ]
   | Offline | Running | Failing | ... | Zombie ->
     (* 의도된 no-op + 사유 주석 *)
     [])
| Running ->
  (match prev_phase with
   | Restarting -> [ ... ]
   | Failing -> [ ... ]
   | Paused -> [ ... ]
   | Offline | Running | Overflowed | ... | Zombie ->
     (* 의도된 no-op + 사유 주석 *)
     [])
| Offline -> []   (* 사유 주석 *)
| Crashed -> []   (* 사유 주석 *)
```

## 왜 톱니처럼 정교하지 않은가

1. **Compiler가 phase 추가를 못 잡음** — 13 phase variant인데 `| _ -> []`가 항상 매치. 새 phase 추가 시 silent no-op으로 흡수.
2. **의도된 silent vs 누락 silent 구분 불가** — `_ -> []`가 둘을 같은 형태로 처리. 코드 리뷰에서 "이게 의도인가 누락인가" 판단 불가.
3. **#8728, #8732 사고 재발 위험** — 같은 함수 안에서 이미 두 차례 dashboard mis-attribution 사례.

## 본 PR 수정

- Outer match를 `new_phase` 단일로 변경. OCaml compiler가 13 phase 모두 enumerate 강제.
- Inner match (Restarting/Running prev-dependent arms)도 wildcard 없이 모든 phase 명시.
- 4 silent class는 *explicit `[]` + 사유 주석*으로 보존.
- 의미 (behavior) 변경 0건 — 모든 기존 lifecycle 발행 시점 동일.

**+92 / -46 (lib/keeper/keeper_state_machine.ml 1파일).**

## Verification

- [x] `dune build @check` (full project typecheck, silent success)
- [x] +92 / -46 diff — net +46 LOC는 4 explicit arms + 주석
- [x] PR Live Gate path scope: `lib/keeper/` 변경 → build 트리거 (skip 안 됨)
- [ ] CI Build and Test 결과 대기

## Trade-off

- **단점**: inner match에서 phase enumerate가 반복 (Restarting prev에 12개, Running prev에 10개). 신규 phase 추가 시 두 inner match 모두 수정 필요 — 단 컴파일러가 강제하므로 안전.
- **미수정**: 4 silent class를 *실제로* lifecycle 발행해야 하는지(예: `_, Crashed`의 distinct "crashed" 이벤트)는 별도 RFC 후보. 본 PR은 *구조 정교화 only*, 의미 변경 없음.
- **단순 대안 검토**: `[@warning "-fragile-match"]`로 컴파일러 warn 추가만 — 검토했지만 silent no-op vs explicit no-op 구분 정보가 코드에 없게 됨. 거부.

## RFC

`RFC-WAIVED: behavior-preserving refactor on lib/keeper/, no agent delegation subsystem (credential / identity / repo / operator / sandbox / dashboard-cred / hooks / workflow doc) affected.`

## 진행 추적

다음 iteration: **Phase A-3** — `derive_phase` priority chain (TLA+ `DerivePhase` line 52-73 ↔ OCaml line ~?) drift 검증. 우선순위 순서가 두 spec에 정확히 일치하는지 line-by-line cross-check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)