### PR TITLE
refactor(tool-assignment-telemetry): typed error_kind — private-string wrapper → closed sum (2 variants)

### DIFF
--- a/lib/keeper/keeper_execution_receipt.ml
+++ b/lib/keeper/keeper_execution_receipt.ml
@@ -346,7 +346,7 @@ let string_contains_ci haystack needle =
 
 (* Cycle 51 observability: alert when [operator_disposition] cannot
    classify a receipt and falls through to the catch-all
-   [("unknown", "unmapped_cascade_state")].
+   [(Disp_unknown, Reason_unmapped_cascade_state)].
 
    PR #11651 fixed the historical "blocked" -> "unknown" silent path
    (livelock turns emitted [outcome="blocked"] which was not in
@@ -375,7 +375,54 @@ let () =
        structured detail goes to the WARN log line at the firing site."
     ()
 
-let operator_disposition (receipt : t) =
+type operator_disposition_kind =
+  | Disp_pass
+  | Disp_pause_human
+  | Disp_alert_exhausted
+  | Disp_fail_open_next_cascade
+  | Disp_pass_next_model
+  | Disp_user_cancelled
+  | Disp_skipped
+  | Disp_unknown
+
+let operator_disposition_kind_to_string = function
+  | Disp_pass -> "pass"
+  | Disp_pause_human -> "pause_human"
+  | Disp_alert_exhausted -> "alert_exhausted"
+  | Disp_fail_open_next_cascade -> "fail_open_next_cascade"
+  | Disp_pass_next_model -> "pass_next_model"
+  | Disp_user_cancelled -> "user_cancelled"
+  | Disp_skipped -> "skipped"
+  | Disp_unknown -> "unknown"
+
+type operator_disposition_reason =
+  | Reason_healthy
+  | Reason_cascade_exhausted
+  | Reason_preflight_config_error
+  | Reason_degraded_retry
+  | Reason_cascade_fallback
+  | Reason_provider_runtime_error
+  | Reason_tool_required_unsatisfied
+  | Reason_turn_livelock_blocked
+  | Reason_cancelled
+  | Reason_phase_skipped
+  | Reason_unmapped_cascade_state
+
+let operator_disposition_reason_to_string = function
+  | Reason_healthy -> "healthy"
+  | Reason_cascade_exhausted -> "cascade_exhausted"
+  | Reason_preflight_config_error -> "preflight_config_error"
+  | Reason_degraded_retry -> "degraded_retry"
+  | Reason_cascade_fallback -> "cascade_fallback"
+  | Reason_provider_runtime_error -> "provider_runtime_error"
+  | Reason_tool_required_unsatisfied -> "tool_required_unsatisfied"
+  | Reason_turn_livelock_blocked -> "turn_livelock_blocked"
+  | Reason_cancelled -> "cancelled"
+  | Reason_phase_skipped -> "phase_skipped"
+  | Reason_unmapped_cascade_state -> "unmapped_cascade_state"
+
+let operator_disposition (receipt : t) :
+    operator_disposition_kind * operator_disposition_reason =
   let terminal_reason = String.lowercase_ascii receipt.terminal_reason_code in
   let error_kind =
     Option.map
@@ -414,21 +461,21 @@ let operator_disposition (receipt : t) =
      typed migration drops them.  Cascade exhaustion still reaches this
      branch via [terminal_reason="cascade_exhausted"]. *)
   if String.equal terminal_reason "cascade_exhausted"
-  then ("alert_exhausted", "cascade_exhausted")
+  then (Disp_alert_exhausted, Reason_cascade_exhausted)
   else if preflight_config_failure then
-    ("pause_human", "preflight_config_error")
+    (Disp_pause_human, Reason_preflight_config_error)
   else if
     provider_runtime_failure
     && (receipt.degraded_retry_applied
         || Option.is_some receipt.degraded_retry_cascade)
-  then ("fail_open_next_cascade", "degraded_retry")
+  then (Disp_fail_open_next_cascade, Reason_degraded_retry)
   else if
     provider_runtime_failure
     && (receipt.cascade_fallback_applied
         || receipt.cascade_outcome = Cascade_passed_to_next_model)
-  then ("pass_next_model", "cascade_fallback")
+  then (Disp_pass_next_model, Reason_cascade_fallback)
   else if provider_runtime_failure then
-    ("pause_human", "provider_runtime_error")
+    (Disp_pause_human, Reason_provider_runtime_error)
   else if
     String.starts_with ~prefix:"completion_contract_violation:" terminal_reason
   then
@@ -441,14 +488,14 @@ let operator_disposition (receipt : t) =
        regression counter is meant to flag. Treat terminal_reason as
        authoritative — the disposition is the same as the explicit
        [tool_required_unsatisfied] branch below. *)
-    ("pause_human", "tool_required_unsatisfied")
+    (Disp_pause_human, Reason_tool_required_unsatisfied)
   else if
     String.starts_with ~prefix:"turn_livelock:" terminal_reason
     ||
     (match error_kind with
      | Some "turn_livelock_blocked" -> true
      | Some _ | None -> false)
-  then ("pause_human", "turn_livelock_blocked")
+  then (Disp_pause_human, Reason_turn_livelock_blocked)
   else if
     receipt.tool_surface.tool_requirement = Required
     && (List.mem receipt.tool_contract_result
@@ -462,13 +509,13 @@ let operator_disposition (receipt : t) =
           ; Contract_no_tool_capable_provider
           ]
         || receipt.tools_used = [])
-  then ("pause_human", "tool_required_unsatisfied")
+  then (Disp_pause_human, Reason_tool_required_unsatisfied)
   else if receipt.degraded_retry_applied || Option.is_some receipt.degraded_retry_cascade
-  then ("fail_open_next_cascade", "degraded_retry")
+  then (Disp_fail_open_next_cascade, Reason_degraded_retry)
   else if
     receipt.cascade_fallback_applied
     || receipt.cascade_outcome = Cascade_passed_to_next_model
-  then ("pass_next_model", "cascade_fallback")
+  then (Disp_pass_next_model, Reason_cascade_fallback)
   (* "healthy" requires an explicit success signal: turn completed without
      error AND cascade reached the configured terminal. Any other fallthrough
      is an unmapped state — surface it as "unknown" so a new cascade_outcome
@@ -484,10 +531,10 @@ let operator_disposition (receipt : t) =
      [specs/keeper-turn-fsm/KeeperTurnFSM.tla]. *)
   else
     match receipt.outcome with
-    | `Cancelled -> ("user_cancelled", "cancelled")
-    | `Skipped -> ("skipped", "phase_skipped")
+    | `Cancelled -> (Disp_user_cancelled, Reason_cancelled)
+    | `Skipped -> (Disp_skipped, Reason_phase_skipped)
     | `Ok when receipt.cascade_outcome = Cascade_completed ->
-      ("pass", "healthy")
+      (Disp_pass, Reason_healthy)
     | _ ->
       Prometheus.inc_counter
         Keeper_metrics.metric_keeper_receipt_unmapped_disposition ();
@@ -505,11 +552,13 @@ let operator_disposition (receipt : t) =
         (Option.value
            (Option.map error_kind_to_string receipt.error_kind)
            ~default:"<none>");
-      ("unknown", "unmapped_cascade_state")
+      (Disp_unknown, Reason_unmapped_cascade_state)
 
 let to_json (receipt : t) =
-  let operator_disposition, operator_disposition_reason =
-    operator_disposition receipt
+  let disposition, disposition_reason = operator_disposition receipt in
+  let operator_disposition = operator_disposition_kind_to_string disposition in
+  let operator_disposition_reason =
+    operator_disposition_reason_to_string disposition_reason
   in
   let error_json =
     match receipt.error_kind, receipt.error_message with
@@ -726,10 +775,14 @@ let to_json (receipt : t) =
    anchor in [keeper_supervisor.ml] (StaleRunning watchdog +
    emit_stale_keeper_broadcast) is deferred to a separate cycle. *)
 let needs_operator_broadcast = function
-  | "pause_human" | "alert_exhausted" | "unknown" -> true
-  | _ -> false
+  | Disp_pause_human | Disp_alert_exhausted | Disp_unknown -> true
+  | Disp_pass | Disp_fail_open_next_cascade | Disp_pass_next_model
+  | Disp_user_cancelled | Disp_skipped ->
+    false
 
 let operator_broadcast_payload (receipt : t) ~disposition ~reason =
+  let disposition_s = operator_disposition_kind_to_string disposition in
+  let reason_s = operator_disposition_reason_to_string reason in
   `Assoc
     [ "schema", `String "keeper.operator_broadcast_required.v1"
     ; "keeper_name", `String receipt.keeper_name
@@ -740,8 +793,8 @@ let operator_broadcast_payload (receipt : t) ~disposition ~reason =
         match receipt.turn_count with
         | Some value -> `Int value
         | None -> `Null )
-    ; "disposition", `String disposition
-    ; "disposition_reason", `String reason
+    ; "disposition", `String disposition_s
+    ; "disposition_reason", `String reason_s
     ; "outcome", `String (outcome_kind_to_tla_receipt receipt.outcome)
     ; "terminal_reason_code", `String receipt.terminal_reason_code
     ; ( "current_task_id",
@@ -813,7 +866,10 @@ let emit_operator_broadcast config (receipt : t) ~disposition ~reason =
   in
   Log.Keeper.error
     "%s: operator_broadcast_required emitted disposition=%s reason=%s seq=%d"
-    receipt.keeper_name disposition reason event.seq
+    receipt.keeper_name
+    (operator_disposition_kind_to_string disposition)
+    (operator_disposition_reason_to_string reason)
+    event.seq
 
 let append (config : Coord.config) (receipt : t) =
   let store =
@@ -836,7 +892,10 @@ let append (config : Coord.config) (receipt : t) =
       Log.Keeper.error
         "%s: operator_broadcast_required EMIT FAILED disposition=%s \
          reason=%s exn=%s"
-        receipt.keeper_name disposition reason (Printexc.to_string exn)
+        receipt.keeper_name
+        (operator_disposition_kind_to_string disposition)
+        (operator_disposition_reason_to_string reason)
+        (Printexc.to_string exn)
 
 (* Watchdog-driven broadcast (#fleet-stall 2026-04-26 Step 3): emitted by a
    supervisor-side fiber when a Running keeper has not produced a turn for

--- a/lib/keeper/keeper_execution_receipt.mli
+++ b/lib/keeper/keeper_execution_receipt.mli
@@ -211,16 +211,56 @@ val sandbox_kind_of_meta :
   Keeper_types.keeper_meta -> Keeper_types.sandbox_profile
 val to_json : t -> Yojson.Safe.t
 
+(** Operator-facing classification of a finished turn. Closed set.
+
+    Producer is [operator_disposition]; consumers
+    ([needs_operator_broadcast], dashboard JSON, broadcast payload)
+    pattern-match exhaustively. The wire form is byte-compatible with the
+    pre-typing string ([operator_disposition_kind_to_string]). *)
+type operator_disposition_kind =
+  | Disp_pass
+  | Disp_pause_human
+  | Disp_alert_exhausted
+  | Disp_fail_open_next_cascade
+  | Disp_pass_next_model
+  | Disp_user_cancelled
+  | Disp_skipped
+  | Disp_unknown
+
+val operator_disposition_kind_to_string : operator_disposition_kind -> string
+
+(** Reason paired with [operator_disposition_kind]. Closed set; the wire
+    form is byte-compatible with the pre-typing string. *)
+type operator_disposition_reason =
+  | Reason_healthy
+  | Reason_cascade_exhausted
+  | Reason_preflight_config_error
+  | Reason_degraded_retry
+  | Reason_cascade_fallback
+  | Reason_provider_runtime_error
+  | Reason_tool_required_unsatisfied
+  | Reason_turn_livelock_blocked
+  | Reason_cancelled
+  | Reason_phase_skipped
+  | Reason_unmapped_cascade_state
+
+val operator_disposition_reason_to_string :
+  operator_disposition_reason -> string
+
 (** Derived display pair (disposition, reason) computed from receipt fields.
     Exposed for test access; the runtime path consumes it via [append]. *)
-val operator_disposition : t -> string * string
+val operator_disposition :
+  t -> operator_disposition_kind * operator_disposition_reason
 
 (** [needs_operator_broadcast disposition] returns true when the disposition
     indicates a silent dead-end that operators must be notified about. *)
-val needs_operator_broadcast : string -> bool
+val needs_operator_broadcast : operator_disposition_kind -> bool
 
 val operator_broadcast_payload :
-  t -> disposition:string -> reason:string -> Yojson.Safe.t
+  t ->
+  disposition:operator_disposition_kind ->
+  reason:operator_disposition_reason ->
+  Yojson.Safe.t
 (** Structured payload emitted for [keeper.operator_broadcast_required].
     Exposed so tests can pin the diagnostic fields operators need when a
     keeper turn pauses or stalls silently. *)

--- a/lib/mcp_server_eio_call_tool.ml
+++ b/lib/mcp_server_eio_call_tool.ml
@@ -853,8 +853,9 @@ let handle_call_tool_eio ~execute_tool_eio ~maybe_emit_resource_notifications
    | Some aid ->
        let error_kind =
          if not success then
-           let kind = if !timeout_hit then "timeout" else "tool_failure" in
-           Some (Tool_assignment_telemetry.error_kind_of_string kind)
+           Some
+             (if !timeout_hit then Tool_assignment_telemetry.Et_timeout
+              else Tool_assignment_telemetry.Et_tool_failure)
          else None
        in
        Tool_assignment_telemetry.emit_completed

--- a/lib/tool_assignment_telemetry.ml
+++ b/lib/tool_assignment_telemetry.ml
@@ -22,11 +22,22 @@ module Float = Stdlib.Float
 
 type assignment_id = string
 
-type error_kind = Error_kind of string
+(* Producer emits exactly two error categories ([mcp_server_eio_call_tool]:
+   "timeout" on cancellation, "tool_failure" otherwise).  Closing the
+   sum turns drift into a compile error; the JSON reader fails closed
+   via [error_kind_of_string : _ -> _ option]. *)
+type error_kind =
+  | Et_timeout
+  | Et_tool_failure
 
-let error_kind_of_string value = Error_kind value
+let error_kind_to_string = function
+  | Et_timeout -> "timeout"
+  | Et_tool_failure -> "tool_failure"
 
-let error_kind_to_string (Error_kind value) = value
+let error_kind_of_string = function
+  | "timeout" -> Some Et_timeout
+  | "tool_failure" -> Some Et_tool_failure
+  | _ -> None
 
 type tool_event =
   | Assigned of {
@@ -143,7 +154,7 @@ let event_of_json json : (tool_event, string) Result.t =
         let error_kind =
           match json |> member "error_kind" with
           | `Null -> None
-          | `String s -> Some (error_kind_of_string s)
+          | `String s -> error_kind_of_string s
           | _ -> None
         in
         Ok

--- a/lib/tool_assignment_telemetry.mli
+++ b/lib/tool_assignment_telemetry.mli
@@ -16,11 +16,19 @@
 
 type assignment_id = string
 
-type error_kind = private Error_kind of string
-(** Coarse tool completion error family. *)
+(** Coarse tool completion error family. Closed set; the producer
+    [mcp_server_eio_call_tool] only ever emits two categories
+    ([Et_timeout] on cancellation/timeout, [Et_tool_failure] otherwise).
+    Wire form is byte-compatible with the previous private-string
+    wrapper via [error_kind_to_string]. *)
+type error_kind =
+  | Et_timeout
+  | Et_tool_failure
 
-val error_kind_of_string : string -> error_kind
-(** Convert a wire/log label into an internal error-kind value. *)
+val error_kind_of_string : string -> error_kind option
+(** Parse a wire/log label. Returns [None] for unknown values so JSON
+    decoders fail-closed (matches CLAUDE.md anti-pattern #2: unknown
+    inputs must not collapse into a permissive default). *)
 
 val error_kind_to_string : error_kind -> string
 (** Convert an internal error-kind value back to the public wire label. *)

--- a/lib/worker_dev_tools.ml
+++ b/lib/worker_dev_tools.ml
@@ -717,10 +717,24 @@ include Gh_command_validation
 let mkdir_p path _perm =
   Fs_compat.mkdir_p path
 
-type tool_exec_error_kind = Tool_exec_error_kind of string
+(* Closed sum: five producer-emitted error categories. The closed type
+   replaces the previous [Tool_exec_error_kind of string] wrapper —
+   string values are only re-introduced at the telemetry wire via
+   [tool_exec_error_kind_to_string].  Adding a new variant is a compile
+   obligation at every observer call site below. *)
+type tool_exec_error_kind =
+  | Path_blocked
+  | File_read_error
+  | File_write_error
+  | Command_blocked
+  | Shell_error
 
-let tool_exec_error_kind_of_string value = Tool_exec_error_kind value
-let tool_exec_error_kind_to_string (Tool_exec_error_kind value) = value
+let tool_exec_error_kind_to_string = function
+  | Path_blocked -> "path_blocked"
+  | File_read_error -> "file_read_error"
+  | File_write_error -> "file_write_error"
+  | Command_blocked -> "command_blocked"
+  | Shell_error -> "shell_error"
 
 type tool_exec_observer =
   tool_name:string ->
@@ -772,7 +786,7 @@ let make_file_read ?workdir ?on_exec () =
            Option.iter
              (fun (f : tool_exec_observer) ->
                 f ~tool_name:"file_read" ~success:false ~duration_ms
-                  ~error_kind:(tool_exec_error_kind_of_string "path_blocked")
+                  ~error_kind:(Path_blocked)
                   ~error_message:err ())
              on_exec;
            tool_error err
@@ -798,7 +812,7 @@ let make_file_read ?workdir ?on_exec () =
              Option.iter
                (fun (f : tool_exec_observer) ->
                   f ~tool_name:"file_read" ~success:false ~duration_ms
-                    ~error_kind:(tool_exec_error_kind_of_string "file_read_error")
+                    ~error_kind:(File_read_error)
                     ~error_message:msg ())
                on_exec;
              tool_error (Printf.sprintf "Cannot read: %s" msg))
@@ -835,7 +849,7 @@ let make_file_write ?workdir ?on_exec () =
            Option.iter
              (fun (f : tool_exec_observer) ->
                 f ~tool_name:"file_write" ~success:false ~duration_ms
-                  ~error_kind:(tool_exec_error_kind_of_string "path_blocked")
+                  ~error_kind:(Path_blocked)
                   ~error_message:err ())
              on_exec;
            tool_error err
@@ -861,7 +875,7 @@ let make_file_write ?workdir ?on_exec () =
              Option.iter
                (fun (f : tool_exec_observer) ->
                   f ~tool_name:"file_write" ~success:false ~duration_ms
-                    ~error_kind:(tool_exec_error_kind_of_string "file_write_error")
+                    ~error_kind:(File_write_error)
                     ~error_message:msg ())
                on_exec;
              tool_error (Printf.sprintf "Cannot write: %s" msg))
@@ -946,7 +960,7 @@ let make_shell_exec_with_allowlist ~workdir ~on_exec ~proc_mgr ~clock ~allowed_c
             Option.iter
               (fun (f : tool_exec_observer) ->
                 f ~tool_name:"shell_exec" ~success:false ~duration_ms:0
-                  ~error_kind:(tool_exec_error_kind_of_string "command_blocked")
+                  ~error_kind:(Command_blocked)
                   ~error_message:(block_reason_to_string reason) ())
               on_exec;
             tool_error (block_reason_to_string reason)
@@ -1012,7 +1026,7 @@ let make_shell_exec_with_allowlist ~workdir ~on_exec ~proc_mgr ~clock ~allowed_c
                    f ~tool_name:"shell_exec" ~success:true ~duration_ms ()
                  else
                    f ~tool_name:"shell_exec" ~success:false ~duration_ms
-                     ~error_kind:(tool_exec_error_kind_of_string "shell_error") ())
+                     ~error_kind:(Shell_error) ())
                on_exec;
              result
            with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
@@ -1021,7 +1035,7 @@ let make_shell_exec_with_allowlist ~workdir ~on_exec ~proc_mgr ~clock ~allowed_c
              Option.iter
                (fun (f : tool_exec_observer) ->
                  f ~tool_name:"shell_exec" ~success:false ~duration_ms
-                   ~error_kind:(tool_exec_error_kind_of_string "shell_error")
+                   ~error_kind:(Shell_error)
                    ~error_message:exn_msg ())
                on_exec;
              tool_error

--- a/lib/worker_dev_tools.mli
+++ b/lib/worker_dev_tools.mli
@@ -137,13 +137,21 @@ val attribution_of_validation :
 
     Issue #10358: closes the 17.3% blank-error gap for tool_called
     rows fed via [worker_container.build_local_shell_tools]. *)
-type tool_exec_error_kind = private Tool_exec_error_kind of string
-(** Typed boundary wrapper for the observer's categorized error label.
+(** Closed sum classifying the producer error categories emitted by the
+    in-tree shell/file tools. Five variants mirror the docstring above:
+    [Path_blocked], [File_read_error], [File_write_error],
+    [Command_blocked], [Shell_error].
 
-    Keep raw strings at the telemetry/wire boundary; do not expose
-    raw-string error-kind callback signatures from this module. *)
+    Raw strings stay only at the telemetry/wire boundary
+    ([tool_exec_error_kind_to_string]); adding a new variant becomes a
+    compile obligation at every observer call site. *)
+type tool_exec_error_kind =
+  | Path_blocked
+  | File_read_error
+  | File_write_error
+  | Command_blocked
+  | Shell_error
 
-val tool_exec_error_kind_of_string : string -> tool_exec_error_kind
 val tool_exec_error_kind_to_string : tool_exec_error_kind -> string
 
 type tool_exec_observer =

--- a/test/test_keeper_pause_broadcast.ml
+++ b/test/test_keeper_pause_broadcast.ml
@@ -99,8 +99,10 @@ let mk_receipt
 
 let check_disp label receipt expected_disp expected_reason =
   let disp, reason = R.operator_disposition receipt in
-  check string (label ^ " (disposition)") expected_disp disp;
-  check string (label ^ " (reason)") expected_reason reason
+  check string (label ^ " (disposition)") expected_disp
+    (R.operator_disposition_kind_to_string disp);
+  check string (label ^ " (reason)") expected_reason
+    (R.operator_disposition_reason_to_string reason)
 
 (* === Bug class: tool_contract_result violations must pause_human ====== *)
 
@@ -237,15 +239,17 @@ let test_fail_open_for_degraded_retry () =
 (* === Trigger predicate ============================================== *)
 
 let test_needs_broadcast_predicate () =
-  check bool "pause_human triggers" true (R.needs_operator_broadcast "pause_human");
+  check bool "pause_human triggers" true
+    (R.needs_operator_broadcast R.Disp_pause_human);
   check bool "alert_exhausted triggers" true
-    (R.needs_operator_broadcast "alert_exhausted");
-  check bool "unknown triggers" true (R.needs_operator_broadcast "unknown");
-  check bool "pass does not" false (R.needs_operator_broadcast "pass");
+    (R.needs_operator_broadcast R.Disp_alert_exhausted);
+  check bool "unknown triggers" true
+    (R.needs_operator_broadcast R.Disp_unknown);
+  check bool "pass does not" false (R.needs_operator_broadcast R.Disp_pass);
   check bool "pass_next_model does not" false
-    (R.needs_operator_broadcast "pass_next_model");
+    (R.needs_operator_broadcast R.Disp_pass_next_model);
   check bool "fail_open_next_cascade does not" false
-    (R.needs_operator_broadcast "fail_open_next_cascade")
+    (R.needs_operator_broadcast R.Disp_fail_open_next_cascade)
 
 (* === Symmetric coverage: each broadcast disposition is reachable ===== *)
 
@@ -293,8 +297,8 @@ let test_broadcast_payload_carries_turn_diagnostics () =
       ()
   in
   let payload =
-    R.operator_broadcast_payload receipt ~disposition:"pause_human"
-      ~reason:"tool_required_unsatisfied"
+    R.operator_broadcast_payload receipt ~disposition:R.Disp_pause_human
+      ~reason:R.Reason_tool_required_unsatisfied
   in
   check string "task id" "task-102"
     (payload |> U.member "current_task_id" |> U.to_string);

--- a/test/test_tool_assignment_telemetry.ml
+++ b/test/test_tool_assignment_telemetry.ml
@@ -144,7 +144,7 @@ let test_completed_error_kind_round_trip () =
       ~tool_name:"read"
       ~success:false
       ~duration_ms:7.0
-      ~error_kind:(Tool_assignment_telemetry.error_kind_of_string "timeout")
+      ~error_kind:Tool_assignment_telemetry.Et_timeout
       ();
     match Tool_assignment_telemetry.read_recent ~n:1 with
     | Error msg -> fail ("read_recent failed: " ^ msg)


### PR DESCRIPTION
## Summary

Track A typed-enum sweep — third application of the `private X of string` → closed sum pattern. Eight identical wrappers exist in `lib/`; this PR closes one.

`Tool_assignment_telemetry.error_kind`:

| Variant | Wire |
|---|---|
| `Et_timeout` | `timeout` |
| `Et_tool_failure` | `tool_failure` |

## Rationale

The sole producer in `mcp_server_eio_call_tool.ml:854-859` emits exactly two literals. The previous `private Error_kind of string` wrapper provided API surface containment (callers outside the module can't construct it) but the producer module itself could pass any string. Closing the type makes adding a third category a compile obligation.

## Fail-closed JSON read

`error_kind_of_string` now returns `option` (was `string -> error_kind`). The JSON reader at `event_of_json` deserializes unknown strings to `None` rather than collapsing them into `Some (Error_kind s)`. This satisfies CLAUDE.md §AI 코드 생성 안티패턴 #2 — Unknown → Permissive Default must not silently fall through.

Backward compat: any legacy JSONL containing an unknown `error_kind` string previously round-tripped opaquely; now the field reads as `None`. The producer never emitted anything outside the two variants, so this only affects synthetic / hand-edited data.

## Stack

Based on #14699 (`feat/tool-exec-error-kind-typed`), which is on top of #14696.

## Test plan

- [x] `dune build --root . @check` clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)