### PR TITLE
refactor(turn_intent): replace manual equal with [@@deriving eq]

### DIFF
--- a/lib/keeper/keeper_turn_intent.ml
+++ b/lib/keeper/keeper_turn_intent.ml
@@ -1,9 +1,4 @@
-type t = Mechanical | Cognitive
-
-let equal a b =
-  match a, b with
-  | Mechanical, Mechanical | Cognitive, Cognitive -> true
-  | _ -> false
+type t = Mechanical | Cognitive [@@deriving eq]
 
 let to_string = function
   | Mechanical -> "mechanical"

--- a/lib/keeper/keeper_turn_intent.mli
+++ b/lib/keeper/keeper_turn_intent.mli
@@ -12,9 +12,7 @@
     Gating lives in [Keeper_config.keeper_adaptive_thinking_mode ()]; when
     that flag is false, classification is not consulted. *)
 
-type t = Mechanical | Cognitive
-
-val equal : t -> t -> bool
+type t = Mechanical | Cognitive [@@deriving eq]
 
 val to_string : t -> string
 


### PR DESCRIPTION
## Why

`Keeper_turn_intent.equal` was hand-written:

\`\`\`ocaml
let equal a b =
  match a, b with
  | Mechanical, Mechanical | Cognitive, Cognitive -> true
  | _ -> false
\`\`\`

`Keeper_turn_intent.t` has two constructors today, so this is correct *today*. But the `_ -> false` catch-all silently absorbs any future variant. If we ever add a `Routing` (or `Reasoning`, or `Adversarial`) constructor:

- `(Routing, Routing)` would evaluate to `false` — a reflexive equality violation
- The bug is invisible: the compiler never warns, runtime never errors, tests that don't exercise the new pair pass

This is the FSM Sparse Match anti-pattern in `~/me/instructions/software-development.md`. The fix is to delegate equality generation to a deriver that always produces exhaustive code.

## What

\`\`\`ocaml
type t = Mechanical | Cognitive [@@deriving eq]
\`\`\`

`[@@deriving eq]` is already used in `lib/cascade_decl/cascade_declarative_types.ml` and `lib/ide/ide_annotation_types.ml`, so this is consistent with house style. The generated `equal` is structurally exhaustive — adding a new constructor adds a new reflexive case automatically, and any partial rewrite produces a compile error.

## Caller compat

`Keeper_turn_intent.equal : t -> t -> bool` — same signature. The lone call site is `lib/keeper/keeper_run_tools.ml:1276`:

\`\`\`ocaml
Some (Keeper_turn_intent.equal i Keeper_turn_intent.Cognitive)
\`\`\`

Unchanged.

## Verification

\`\`\`
dune build @lib/keeper/check --root .   # exit 0
\`\`\`

## Why this counts as "Variant 처리가 더 유리한 곳"

The user's brief asked specifically for cases where variant handling is more advantageous than the current shape. Hand-written equality on a closed sum is the textbook case: the deriver subsumes the hand-written body, drops a known-buggy catch-all pattern, and removes -5 LOC of maintenance surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)