### PR TITLE
feat(fs_compat): Eio-native streaming JSONL + HTTP route non-blocking IO

### DIFF
--- a/lib/dashboard_tla_specs.ml
+++ b/lib/dashboard_tla_specs.ml
@@ -143,14 +143,7 @@ let specs_json () : Yojson.Safe.t =
   ]
 
 let read_file_safe path =
-  try
-    let ic = Stdlib.open_in_bin path in
-    Stdlib.Fun.protect
-      ~finally:(fun () -> Stdlib.close_in_noerr ic)
-      (fun () ->
-         let len = Stdlib.in_channel_length ic in
-         Stdlib.really_input_string ic len)
-    |> fun contents -> Some contents
+  try Some (Fs_compat.load_file path)
   with Sys_error _ | End_of_file -> None
 
 let normalize_int s =

--- a/lib/dashboard_tla_specs.ml
+++ b/lib/dashboard_tla_specs.ml
@@ -15,14 +15,14 @@ module Char = Stdlib.Char
 module Int = Stdlib.Int
 module Float = Stdlib.Float
 
-type spec_entry = {
-  name : string;
-  path : string;
-  category : string;
-  has_clean_cfg : bool;
-  has_buggy_cfg : bool;
-  mtime : float;
-}
+type spec_entry =
+  { name : string
+  ; path : string
+  ; category : string
+  ; has_clean_cfg : bool
+  ; has_buggy_cfg : bool
+  ; mtime : float
+  }
 
 type tlc_status =
   | Tlc_passed
@@ -32,55 +32,63 @@ type tlc_status =
   | Tlc_error
   | Tlc_not_run
 
-type tlc_result_entry = {
-  spec_name : string;
-  cfg_name : string;
-  category : string;
-  status : tlc_status;
-  states_explored : int option;
-  distinct_states : int option;
-  diameter : int option;
-  last_run_at : float option;
-  violation : string option;
-  log_path : string option;
-}
+type tlc_result_entry =
+  { spec_name : string
+  ; cfg_name : string
+  ; category : string
+  ; status : tlc_status
+  ; states_explored : int option
+  ; distinct_states : int option
+  ; diameter : int option
+  ; last_run_at : float option
+  ; violation : string option
+  ; log_path : string option
+  }
 
 let specs_dir () =
   match Sys.getenv_opt "MASC_SPECS_DIR" with
   | Some p when not (String.equal p "") -> p
   | _ -> "specs"
+;;
 
 let tlc_results_dir () =
   match Sys.getenv_opt "MASC_TLC_RESULTS_DIR" with
   | Some p when not (String.equal p "") -> p
   | _ -> Filename.get_temp_dir_name ()
+;;
 
 let category_of_subdir = function
   | "boundary" -> "boundary"
   | "bug-models" -> "bug-models"
   | _ -> "other"
+;;
 
 let is_tla_file name = Filename.check_suffix name ".tla"
 
 let safe_stat_mtime path =
-  try (Unix.stat path).st_mtime
-  with Unix.Unix_error _ -> 0.0
+  try (Unix.stat path).st_mtime with
+  | Unix.Unix_error _ -> 0.0
+;;
 
 let readdir_safe dir =
-  try Sys.readdir dir |> Array.to_list
-  with Sys_error _ -> []
+  try Sys.readdir dir |> Array.to_list with
+  | Sys_error _ -> []
+;;
 
 let is_directory_safe p =
-  try Sys.is_directory p
-  with Sys_error _ -> false
+  try Sys.is_directory p with
+  | Sys_error _ -> false
+;;
 
 let file_exists_safe p =
-  try Sys.file_exists p
-  with Sys_error _ -> false
+  try Sys.file_exists p with
+  | Sys_error _ -> false
+;;
 
 let scan_subdir ~root sub =
   let subpath = Filename.concat root sub in
-  if not (is_directory_safe subpath) then []
+  if not (is_directory_safe subpath)
+  then []
   else
     readdir_safe subpath
     |> List.filter is_tla_file
@@ -89,18 +97,19 @@ let scan_subdir ~root sub =
       let file_path = Filename.concat subpath f in
       let clean_cfg = Filename.concat subpath (name ^ ".cfg") in
       let buggy_cfg = Filename.concat subpath (name ^ "-buggy.cfg") in
-      {
-        name;
-        path = Filename.concat sub f;
-        category = category_of_subdir sub;
-        has_clean_cfg = file_exists_safe clean_cfg;
-        has_buggy_cfg = file_exists_safe buggy_cfg;
-        mtime = safe_stat_mtime file_path;
+      { name
+      ; path = Filename.concat sub f
+      ; category = category_of_subdir sub
+      ; has_clean_cfg = file_exists_safe clean_cfg
+      ; has_buggy_cfg = file_exists_safe buggy_cfg
+      ; mtime = safe_stat_mtime file_path
       })
+;;
 
 let list_specs () =
   let root = specs_dir () in
-  if not (is_directory_safe root) then []
+  if not (is_directory_safe root)
+  then []
   else
     readdir_safe root
     |> List.concat_map (fun sub -> scan_subdir ~root sub)
@@ -108,100 +117,117 @@ let list_specs () =
       match String.compare a.category b.category with
       | 0 -> String.compare a.name b.name
       | c -> c)
+;;
 
 let iso_of_unix_time t =
   let open Unix in
   let tm = gmtime t in
-  Printf.sprintf "%04d-%02d-%02dT%02d:%02d:%02dZ"
-    (tm.tm_year + 1900) (tm.tm_mon + 1) tm.tm_mday
-    tm.tm_hour tm.tm_min tm.tm_sec
+  Printf.sprintf
+    "%04d-%02d-%02dT%02d:%02d:%02dZ"
+    (tm.tm_year + 1900)
+    (tm.tm_mon + 1)
+    tm.tm_mday
+    tm.tm_hour
+    tm.tm_min
+    tm.tm_sec
+;;
 
 let entry_to_json e : Yojson.Safe.t =
-  `Assoc [
-    "name", `String e.name;
-    "path", `String e.path;
-    "category", `String e.category;
-    "has_clean_cfg", `Bool e.has_clean_cfg;
-    "has_buggy_cfg", `Bool e.has_buggy_cfg;
-    "mtime_iso", `String (iso_of_unix_time e.mtime);
-  ]
+  `Assoc
+    [ "name", `String e.name
+    ; "path", `String e.path
+    ; "category", `String e.category
+    ; "has_clean_cfg", `Bool e.has_clean_cfg
+    ; "has_buggy_cfg", `Bool e.has_buggy_cfg
+    ; "mtime_iso", `String (iso_of_unix_time e.mtime)
+    ]
+;;
 
 let specs_dir_json root =
-  if not (file_exists_safe root) then `Null
-  else
-    try `String (Unix.realpath root)
-    with Unix.Unix_error _ -> `String root
+  if not (file_exists_safe root)
+  then `Null
+  else (
+    try `String (Unix.realpath root) with
+    | Unix.Unix_error _ -> `String root)
+;;
 
 let specs_json () : Yojson.Safe.t =
   let root = specs_dir () in
   let entries = list_specs () in
-  `Assoc [
-    "updated_at", `String (iso_of_unix_time (Unix.gettimeofday ()));
-    "specs_dir", specs_dir_json root;
-    "count", `Int (List.length entries);
-    "entries", `List (List.map entry_to_json entries);
-  ]
+  `Assoc
+    [ "updated_at", `String (iso_of_unix_time (Unix.gettimeofday ()))
+    ; "specs_dir", specs_dir_json root
+    ; "count", `Int (List.length entries)
+    ; "entries", `List (List.map entry_to_json entries)
+    ]
+;;
 
 let read_file_safe path =
-  try Some (Fs_compat.load_file path)
-  with Sys_error _ | End_of_file -> None
+  try Some (Fs_compat.load_file path) with
+  | Sys_error _ | End_of_file -> None
+;;
 
 let normalize_int s =
   Stdlib.String.to_seq s
   |> Stdlib.Seq.filter (fun c -> not (Char.equal c ','))
   |> String.of_seq
   |> Stdlib.int_of_string_opt
+;;
 
 let contains_substring needle haystack =
   let needle_len = String.length needle in
   let haystack_len = String.length haystack in
-  if needle_len = 0 then true
-  else if needle_len > haystack_len then false
-  else
+  if needle_len = 0
+  then true
+  else if needle_len > haystack_len
+  then false
+  else (
     let rec loop i =
       i + needle_len <= haystack_len
       && (String.equal (Stdlib.String.sub haystack i needle_len) needle || loop (i + 1))
     in
-    loop 0
+    loop 0)
+;;
 
-let split_lines text =
-  String.split_on_char '\n' text |> List.map String.trim
+let split_lines text = String.split_on_char '\n' text |> List.map String.trim
 
 let digit_token_to_int token =
   let cleaned =
     token
     |> Stdlib.String.to_seq
     |> Stdlib.Seq.filter (function
-         | '0' .. '9' | ',' -> true
-         | _ -> false)
+      | '0' .. '9' | ',' -> true
+      | _ -> false)
     |> String.of_seq
   in
   if String.equal cleaned "" then None else normalize_int cleaned
+;;
 
 let ints_in_line line =
-  line
-  |> String.split_on_char ' '
-  |> List.filter_map digit_token_to_int
+  line |> String.split_on_char ' ' |> List.filter_map digit_token_to_int
+;;
 
 let violation_line text =
   split_lines text
   |> List.find_opt (fun line ->
-       contains_substring " is violated" line
-       || contains_substring "Temporal properties were violated" line
-       || contains_substring "Invariant " line
-          && contains_substring "violated" line)
+    contains_substring " is violated" line
+    || contains_substring "Temporal properties were violated" line
+    || (contains_substring "Invariant " line && contains_substring "violated" line))
   |> Option.map String.trim
+;;
 
 let status_of_log text =
   if contains_substring "Model checking completed. No error has been found." text
   then Tlc_passed
   else if Option.is_some (violation_line text)
   then Tlc_violated
-  else if contains_substring "Error:" text
-          || contains_substring "Exception" text
-          || contains_substring "Parsing failed" text
+  else if
+    contains_substring "Error:" text
+    || contains_substring "Exception" text
+    || contains_substring "Parsing failed" text
   then Tlc_error
   else Tlc_running
+;;
 
 let tlc_status_to_string = function
   | Tlc_passed -> "passed"
@@ -210,18 +236,20 @@ let tlc_status_to_string = function
   | Tlc_queued -> "queued"
   | Tlc_error -> "error"
   | Tlc_not_run -> "not_run"
+;;
 
 let metrics_of_log text =
   let state_pair =
     split_lines text
     |> List.find_map (fun line ->
-         if contains_substring "states generated" line
-            && contains_substring "distinct states" line
-         then
-           match ints_in_line line with
-           | a :: b :: _ -> Some (a, b)
-           | _ -> None
-         else None)
+      if
+        contains_substring "states generated" line
+        && contains_substring "distinct states" line
+      then (
+        match ints_in_line line with
+        | a :: b :: _ -> Some (a, b)
+        | _ -> None)
+      else None)
   in
   let states_explored, distinct_states =
     match state_pair with
@@ -231,102 +259,105 @@ let metrics_of_log text =
   let diameter =
     split_lines text
     |> List.find_map (fun line ->
-         if contains_substring "depth of the complete state graph search" line
-         then
-           match ints_in_line line with
-           | value :: _ -> Some value
-           | [] -> None
-         else None)
+      if contains_substring "depth of the complete state graph search" line
+      then (
+        match ints_in_line line with
+        | value :: _ -> Some value
+        | [] -> None)
+      else None)
   in
   states_explored, distinct_states, diameter
+;;
 
 let cfg_entries_for_spec (entry : spec_entry) =
-  let clean =
-    if entry.has_clean_cfg then
-      [ (entry.name ^ ".cfg", entry.name) ]
-    else []
-  in
+  let clean = if entry.has_clean_cfg then [ entry.name ^ ".cfg", entry.name ] else [] in
   let buggy =
-    if entry.has_buggy_cfg then
-      [ (entry.name ^ "-buggy.cfg", entry.name ^ "-buggy") ]
+    if entry.has_buggy_cfg
+    then [ entry.name ^ "-buggy.cfg", entry.name ^ "-buggy" ]
     else []
   in
   clean @ buggy
+;;
 
 let result_for_cfg ~results_dir (spec : spec_entry) (cfg_name, cfg_stem) =
   let log_path = Filename.concat results_dir ("tlc-" ^ cfg_stem ^ ".log") in
   match read_file_safe log_path with
   | None ->
-      {
-        spec_name = spec.name;
-        cfg_name;
-        category = spec.category;
-        status = Tlc_not_run;
-        states_explored = None;
-        distinct_states = None;
-        diameter = None;
-        last_run_at = None;
-        violation = None;
-        log_path = None;
-      }
+    { spec_name = spec.name
+    ; cfg_name
+    ; category = spec.category
+    ; status = Tlc_not_run
+    ; states_explored = None
+    ; distinct_states = None
+    ; diameter = None
+    ; last_run_at = None
+    ; violation = None
+    ; log_path = None
+    }
   | Some text ->
-      let states_explored, distinct_states, diameter = metrics_of_log text in
-      {
-        spec_name = spec.name;
-        cfg_name;
-        category = spec.category;
-        status = status_of_log text;
-        states_explored;
-        distinct_states;
-        diameter;
-        last_run_at = Some (safe_stat_mtime log_path);
-        violation = violation_line text;
-        log_path = Some log_path;
-      }
+    let states_explored, distinct_states, diameter = metrics_of_log text in
+    { spec_name = spec.name
+    ; cfg_name
+    ; category = spec.category
+    ; status = status_of_log text
+    ; states_explored
+    ; distinct_states
+    ; diameter
+    ; last_run_at = Some (safe_stat_mtime log_path)
+    ; violation = violation_line text
+    ; log_path = Some log_path
+    }
+;;
 
 let list_tlc_results () =
   let results_dir = tlc_results_dir () in
   list_specs ()
   |> List.concat_map (fun spec ->
-       cfg_entries_for_spec spec
-       |> List.map (result_for_cfg ~results_dir spec))
+    cfg_entries_for_spec spec |> List.map (result_for_cfg ~results_dir spec))
+;;
 
 let option_int_json = function
   | Some v -> `Int v
   | None -> `Null
+;;
 
 let option_string_json = function
   | Some v -> `String v
   | None -> `Null
+;;
 
 let option_time_json = function
   | Some v -> `String (iso_of_unix_time v)
   | None -> `Null
+;;
 
 let tlc_entry_to_json e : Yojson.Safe.t =
-  `Assoc [
-    "spec_name", `String e.spec_name;
-    "cfg_name", `String e.cfg_name;
-    "category", `String e.category;
-    "status", `String (tlc_status_to_string e.status);
-    "states_explored", option_int_json e.states_explored;
-    "distinct_states", option_int_json e.distinct_states;
-    "diameter", option_int_json e.diameter;
-    "last_run_at", option_time_json e.last_run_at;
-    "violation", option_string_json e.violation;
-    "log_path", option_string_json e.log_path;
-  ]
+  `Assoc
+    [ "spec_name", `String e.spec_name
+    ; "cfg_name", `String e.cfg_name
+    ; "category", `String e.category
+    ; "status", `String (tlc_status_to_string e.status)
+    ; "states_explored", option_int_json e.states_explored
+    ; "distinct_states", option_int_json e.distinct_states
+    ; "diameter", option_int_json e.diameter
+    ; "last_run_at", option_time_json e.last_run_at
+    ; "violation", option_string_json e.violation
+    ; "log_path", option_string_json e.log_path
+    ]
+;;
 
 let tlc_results_json () : Yojson.Safe.t =
   let results_dir = tlc_results_dir () in
   let entries = list_tlc_results () in
-  `Assoc [
-    "updated_at", `String (iso_of_unix_time (Unix.gettimeofday ()));
-    "results_dir",
-      (if is_directory_safe results_dir then
-         try `String (Unix.realpath results_dir)
-         with Unix.Unix_error _ -> `String results_dir
-       else `Null);
-    "count", `Int (List.length entries);
-    "entries", `List (List.map tlc_entry_to_json entries);
-  ]
+  `Assoc
+    [ "updated_at", `String (iso_of_unix_time (Unix.gettimeofday ()))
+    ; ( "results_dir"
+      , if is_directory_safe results_dir
+        then (
+          try `String (Unix.realpath results_dir) with
+          | Unix.Unix_error _ -> `String results_dir)
+        else `Null )
+    ; "count", `Int (List.length entries)
+    ; "entries", `List (List.map tlc_entry_to_json entries)
+    ]
+;;

--- a/lib/fs_compat/fs_compat.ml
+++ b/lib/fs_compat/fs_compat.ml
@@ -486,6 +486,52 @@ let load_jsonl_diagnostics (path : string) : Yojson.Safe.t list * int =
 let load_jsonl (path : string) : Yojson.Safe.t list =
   fst (load_jsonl_diagnostics path)
 
+(** Stream JSONL line-by-line, folding [f] over parsed values.
+
+    Uses [Eio.Buf_read.lines] over [Eio.Path.with_open_in] when the
+    global fs is registered ([set_fs] called at boot), giving O(1)
+    resident memory regardless of file size and non-blocking IO inside
+    the Eio scheduler.  Falls back to {!load_jsonl} + [List.fold_left]
+    when no fs is available (tests, pre-boot helpers).
+
+    [line_no] is 1-based and skips blank lines so it tracks the
+    {b printed} JSONL row number rather than the raw byte stream
+    position — matches {!load_jsonl_diagnostics} semantics.
+
+    Malformed JSON lines are skipped after a stderr warning, like
+    {!load_jsonl_diagnostics}.  Raises [Sys_error] on missing /
+    unreadable files (consistent with the rest of the module). *)
+let fold_jsonl_lines ~init ~f path =
+  if not (file_exists path) then init
+  else
+  with_fs_or_fallback ~path
+    ~fallback:(fun () ->
+      let parsed = fst (load_jsonl_diagnostics path) in
+      let _, result =
+        List.fold_left
+          (fun (n, acc) json -> (n + 1, f acc ~line_no:n json))
+          (1, init) parsed
+      in
+      result)
+    (fun fs ->
+      let eio_path = Eio.Path.(fs / path) in
+      Eio.Path.with_open_in eio_path (fun flow ->
+        let buf = Eio.Buf_read.of_flow ~max_size:Int.max_int flow in
+        let line_idx = ref 0 in
+        let acc = ref init in
+        Eio.Buf_read.lines buf
+        |> Seq.iter (fun raw ->
+               incr line_idx;
+               let trimmed = String.trim raw in
+               if not (String.equal trimmed "") then
+                 match Yojson.Safe.from_string trimmed with
+                 | json -> acc := f !acc ~line_no:!line_idx json
+                 | exception Yojson.Json_error msg ->
+                     Stdlib.Printf.eprintf
+                       "[fs_compat] malformed JSONL (%s) line %d: %s\n%!"
+                       path !line_idx msg);
+        !acc))
+
 (** Append JSON value as line to JSONL file. *)
 let append_jsonl (path : string) (json : Yojson.Safe.t) : unit =
   let dir = Stdlib.Filename.dirname path in

--- a/lib/fs_compat/fs_compat.ml
+++ b/lib/fs_compat/fs_compat.ml
@@ -569,35 +569,63 @@ let load_jsonl (path : string) : Yojson.Safe.t list = fst (load_jsonl_diagnostic
     position — matches {!load_jsonl_diagnostics} semantics.
 
     Malformed JSON lines are skipped after a stderr warning, like
-    {!load_jsonl_diagnostics}.  Raises [Sys_error] on missing /
-    unreadable files (consistent with the rest of the module). *)
+    {!load_jsonl_diagnostics}.  Returns [init] when [path] does not
+    exist (no read attempt).  Raises [Sys_error] on read failures of
+    an existing file (e.g. permission denied, mid-stream IO error). *)
 let fold_jsonl_lines ~init ~f path =
   if not (file_exists path)
   then init
   else
+    (* 16 MiB per-line cap — protects [Eio.Buf_read.of_flow] from a
+       corrupted/attacker-controlled JSONL with no newlines (which
+       would otherwise force the buf_read to grow unbounded).  Real
+       audit/metric rows are <1 KiB; 16 MiB is two orders of
+       magnitude over expected and still bounds the OOM blast. *)
+    let max_line_bytes = 16 * 1024 * 1024 in
     with_fs_or_fallback
       ~path
       ~fallback:(fun () ->
-        let parsed = fst (load_jsonl_diagnostics path) in
-        let _, result =
-          List.fold_left
-            (fun (n, acc) json -> n + 1, f acc ~line_no:n json)
-            (1, init)
-            parsed
-        in
-        result)
+        (* Iterate raw lines so [line_no] reflects the same "non-blank
+           index, malformed counted but skipped" semantics as the Eio
+           branch; folding over [fst (load_jsonl_diagnostics ...)] alone
+           would skip malformed rows and desync the index. *)
+        let line_idx = ref 0 in
+        let acc = ref init in
+        let chan = Stdlib.open_in path in
+        Fun.protect
+          ~finally:(fun () -> Stdlib.close_in_noerr chan)
+          (fun () ->
+            try
+              while true do
+                let raw = Stdlib.input_line chan in
+                let trimmed = String.trim raw in
+                if not (String.equal trimmed "")
+                then begin
+                  incr line_idx;
+                  match Yojson.Safe.from_string trimmed with
+                  | json -> acc := f !acc ~line_no:!line_idx json
+                  | exception Yojson.Json_error msg ->
+                    Stdlib.Printf.eprintf
+                      "[fs_compat] malformed JSONL (%s) line %d: %s\n%!"
+                      path
+                      !line_idx
+                      msg
+                end
+              done
+            with End_of_file -> ());
+        !acc)
       (fun fs ->
          let eio_path = Eio.Path.(fs / path) in
          Eio.Path.with_open_in eio_path (fun flow ->
-           let buf = Eio.Buf_read.of_flow ~max_size:Int.max_int flow in
+           let buf = Eio.Buf_read.of_flow ~max_size:max_line_bytes flow in
            let line_idx = ref 0 in
            let acc = ref init in
            Eio.Buf_read.lines buf
            |> Seq.iter (fun raw ->
-             incr line_idx;
              let trimmed = String.trim raw in
              if not (String.equal trimmed "")
-             then (
+             then begin
+               incr line_idx;
                match Yojson.Safe.from_string trimmed with
                | json -> acc := f !acc ~line_no:!line_idx json
                | exception Yojson.Json_error msg ->
@@ -605,7 +633,8 @@ let fold_jsonl_lines ~init ~f path =
                    "[fs_compat] malformed JSONL (%s) line %d: %s\n%!"
                    path
                    !line_idx
-                   msg));
+                   msg
+             end);
            !acc))
 ;;
 

--- a/lib/fs_compat/fs_compat.ml
+++ b/lib/fs_compat/fs_compat.ml
@@ -20,29 +20,26 @@ let global_fs : Eio.Fs.dir_ty Eio.Path.t option Atomic.t = Atomic.make None
 
 (** Set the global Eio filesystem. Call once at server startup.
     @param fs The Eio fs from [Eio.Stdenv.fs env] *)
-let set_fs fs =
-  Atomic.set global_fs (Some fs)
+let set_fs fs = Atomic.set global_fs (Some fs)
 
 (** Clear the global fs (testing/shutdown only — not called in production).
     Safe because test runners and shutdown are single-fiber sequential. *)
-let clear_fs () =
-  Atomic.set global_fs None
+let clear_fs () = Atomic.set global_fs None
 
-let get_fs_opt () =
-  Atomic.get global_fs
+let get_fs_opt () = Atomic.get global_fs
 
 (** Check if Eio fs is available *)
-let has_fs () =
-  Option.is_some (Atomic.get global_fs)
+let has_fs () = Option.is_some (Atomic.get global_fs)
 
 (** Normalize [Eio.Io] to [Sys_error] so callers only need one catch.
     Eio operations raise [Eio.Io _] on permission errors, missing files, etc.
     Stdlib I/O already raises [Sys_error], so wrapping only the Eio branch
     keeps the exception contract uniform. *)
 let with_io ~path f =
-  try f ()
-  with Eio.Io _ as e ->
+  try f () with
+  | Eio.Io _ as e ->
     raise (Sys_error (Printf.sprintf "%s: %s" path (Printexc.to_string e)))
+;;
 
 (* #9921: defense-in-depth write-boundary guard.
 
@@ -71,61 +68,70 @@ let test_exec_home_guard ~op path =
   let is_test_exec =
     String.length basename >= 5 && String.starts_with basename ~prefix:"test_"
   in
-  if not is_test_exec then ()
-  else
+  if not is_test_exec
+  then ()
+  else (
     let allow =
       match Sys.getenv_opt "MASC_TEST_ALLOW_HOME_BASE_PATH" with
       | Some v ->
-          let v = String.lowercase_ascii (String.trim v) in
-          String.equal v "1" || String.equal v "true" || String.equal v "yes"
+        let v = String.lowercase_ascii (String.trim v) in
+        String.equal v "1" || String.equal v "true" || String.equal v "yes"
       | None -> false
     in
-    if allow then ()
-    else
+    if allow
+    then ()
+    else (
       match Sys.getenv_opt "HOME" with
       | None | Some "" -> ()
       | Some home ->
-          let home_norm =
-            let trimmed = String.trim home in
-            let len = String.length trimmed in
-            if len > 1 && Char.equal trimmed.[len - 1] '/' then
-              String.sub trimmed 0 (len - 1)
-            else
-              trimmed
-          in
-          let home_len = String.length home_norm in
-          if home_len > 0
-             && String.length path >= home_len
-             && String.starts_with path ~prefix:home_norm
-          then
-            raise
-              (Test_isolation_breach
-                 (Printf.sprintf
-                    "#9921 %s blocked under HOME=%S (path=%S) in test executable %S. \
-                     MASC_BASE_PATH override did not apply — fix the test setup or \
-                     set MASC_TEST_ALLOW_HOME_BASE_PATH=1."
-                    op home_norm path
-                    (Stdlib.Filename.basename Stdlib.Sys.executable_name)))
+        let home_norm =
+          let trimmed = String.trim home in
+          let len = String.length trimmed in
+          if len > 1 && Char.equal trimmed.[len - 1] '/'
+          then String.sub trimmed 0 (len - 1)
+          else trimmed
+        in
+        let home_len = String.length home_norm in
+        if
+          home_len > 0
+          && String.length path >= home_len
+          && String.starts_with path ~prefix:home_norm
+        then
+          raise
+            (Test_isolation_breach
+               (Printf.sprintf
+                  "#9921 %s blocked under HOME=%S (path=%S) in test executable %S. \
+                   MASC_BASE_PATH override did not apply — fix the test setup or set \
+                   MASC_TEST_ALLOW_HOME_BASE_PATH=1."
+                  op
+                  home_norm
+                  path
+                  (Stdlib.Filename.basename Stdlib.Sys.executable_name)))))
+;;
 
 let with_fs_or_fallback ~path ~fallback f =
   match Atomic.get global_fs with
-  | Some fs -> (
-      try with_io ~path (fun () -> f fs)
-      with Stdlib.Effect.Unhandled _ -> fallback ())
+  | Some fs ->
+    (try with_io ~path (fun () -> f fs) with
+     | Stdlib.Effect.Unhandled _ -> fallback ())
   | None -> fallback ()
+;;
 
 let load_file_unix (path : string) : string =
   let ic = Stdlib.open_in path in
-  Stdlib.Fun.protect ~finally:(fun () -> Stdlib.close_in_noerr ic) (fun () ->
-    let len = Stdlib.in_channel_length ic in
-    Stdlib.really_input_string ic len
-  )
+  Stdlib.Fun.protect
+    ~finally:(fun () -> Stdlib.close_in_noerr ic)
+    (fun () ->
+       let len = Stdlib.in_channel_length ic in
+       Stdlib.really_input_string ic len)
+;;
 
 let save_file_unix (path : string) (content : string) : unit =
   let oc = Stdlib.open_out path in
-  Stdlib.Fun.protect ~finally:(fun () -> Stdlib.close_out_noerr oc) (fun () ->
-    Stdlib.output_string oc content
-  )
+  Stdlib.Fun.protect
+    ~finally:(fun () -> Stdlib.close_out_noerr oc)
+    (fun () -> Stdlib.output_string oc content)
+;;
 
 (** LRU fd cache for [append_file_unix].
 
@@ -157,10 +163,10 @@ let save_file_unix (path : string) (content : string) : unit =
 let fd_cache_max_size = 16
 
 module Append_fd_cache = struct
-  type entry = {
-    mutable channel : Stdlib.out_channel;
-    mutable last_used : int;
-  }
+  type entry =
+    { mutable channel : Stdlib.out_channel
+    ; mutable last_used : int
+    }
 
   let cache : (string, entry) Hashtbl.t = Hashtbl.create 17
   let counter = ref 0
@@ -169,61 +175,59 @@ module Append_fd_cache = struct
   let with_lock f =
     Mutex.lock mutex;
     Fun.protect ~finally:(fun () -> Mutex.unlock mutex) f
+  ;;
 
   let evict_lru_if_needed_locked () =
-    if Hashtbl.length cache >= fd_cache_max_size then begin
+    if Hashtbl.length cache >= fd_cache_max_size
+    then (
       let victim_path = ref None in
       let victim_use = ref max_int in
       Hashtbl.iter
         (fun path entry ->
            if entry.last_used < !victim_use
-           then begin
+           then (
              victim_path := Some path;
-             victim_use := entry.last_used
-           end)
+             victim_use := entry.last_used))
         cache;
       match !victim_path with
       | None -> ()
       | Some path ->
-          (match Hashtbl.find_opt cache path with
-           | Some entry ->
-               Stdlib.close_out_noerr entry.channel;
-               Hashtbl.remove cache path
-           | None -> ())
-    end
+        (match Hashtbl.find_opt cache path with
+         | Some entry ->
+           Stdlib.close_out_noerr entry.channel;
+           Hashtbl.remove cache path
+         | None -> ()))
+  ;;
 
   let get_or_open_locked path =
     match Hashtbl.find_opt cache path with
     | Some entry ->
-        incr counter;
-        entry.last_used <- !counter;
-        entry.channel
+      incr counter;
+      entry.last_used <- !counter;
+      entry.channel
     | None ->
-        evict_lru_if_needed_locked ();
-        let oc =
-          Stdlib.open_out_gen
-            [ Stdlib.Open_append; Stdlib.Open_creat ]
-            0o644 path
-        in
-        incr counter;
-        let entry = { channel = oc; last_used = !counter } in
-        Hashtbl.add cache path entry;
-        oc
+      evict_lru_if_needed_locked ();
+      let oc = Stdlib.open_out_gen [ Stdlib.Open_append; Stdlib.Open_creat ] 0o644 path in
+      incr counter;
+      let entry = { channel = oc; last_used = !counter } in
+      Hashtbl.add cache path entry;
+      oc
+  ;;
 
   let invalidate path =
     with_lock (fun () ->
       match Hashtbl.find_opt cache path with
       | None -> ()
       | Some entry ->
-          Stdlib.close_out_noerr entry.channel;
-          Hashtbl.remove cache path)
+        Stdlib.close_out_noerr entry.channel;
+        Hashtbl.remove cache path)
+  ;;
 
   let close_all () =
     with_lock (fun () ->
-      Hashtbl.iter
-        (fun _ entry -> Stdlib.close_out_noerr entry.channel)
-        cache;
+      Hashtbl.iter (fun _ entry -> Stdlib.close_out_noerr entry.channel) cache;
       Hashtbl.clear cache)
+  ;;
 end
 
 let () = Stdlib.at_exit Append_fd_cache.close_all
@@ -235,41 +239,53 @@ let append_file_unix (path : string) (content : string) : unit =
       Stdlib.output_string oc content;
       Stdlib.flush oc)
   in
-  try write_with_cached ()
-  with exn ->
+  try write_with_cached () with
+  | exn ->
     (* On I/O error invalidate the cached fd so the next call re-opens
        fresh.  Re-raise so callers see the same error class as before
        (Sys_error wrapping Unix_error). *)
     Append_fd_cache.invalidate path;
     raise exn
+;;
 
 let mkdir_p_unix (path : string) : unit =
   let rec ensure_dir (p : string) : unit =
-    if String.equal p "" || String.equal p "." || String.equal p "/" then ()
-    else if Stdlib.Sys.file_exists p then ()
-    else begin
+    if String.equal p "" || String.equal p "." || String.equal p "/"
+    then ()
+    else if Stdlib.Sys.file_exists p
+    then ()
+    else (
       ensure_dir (Stdlib.Filename.dirname p);
-      try Unix.mkdir p 0o755 with Unix.Unix_error (Unix.EEXIST, _, _) -> ()
-    end
+      try Unix.mkdir p 0o755 with
+      | Unix.Unix_error (Unix.EEXIST, _, _) -> ())
   in
   ensure_dir path
+;;
 
 (** Load entire file contents as string.
     Eio-native when available, fallback to Unix.
     @raises Sys_error on all I/O failures. Eio.Io is normalized internally. *)
 let load_file (path : string) : string =
-  with_fs_or_fallback ~path ~fallback:(fun () -> load_file_unix path) (fun fs ->
-      let eio_path = Eio.Path.(fs / path) in
-      Eio.Path.load eio_path)
+  with_fs_or_fallback
+    ~path
+    ~fallback:(fun () -> load_file_unix path)
+    (fun fs ->
+       let eio_path = Eio.Path.(fs / path) in
+       Eio.Path.load eio_path)
+;;
 
 (** Save string to file (overwrite).
     Eio-native when available, fallback to Unix.
     @raises Sys_error on all I/O failures. Eio.Io is normalized internally. *)
 let save_file (path : string) (content : string) : unit =
   test_exec_home_guard ~op:"save_file" path;
-  with_fs_or_fallback ~path ~fallback:(fun () -> save_file_unix path content) (fun fs ->
-      let eio_path = Eio.Path.(fs / path) in
-      Eio.Path.save ~create:(`Or_truncate 0o644) eio_path content)
+  with_fs_or_fallback
+    ~path
+    ~fallback:(fun () -> save_file_unix path content)
+    (fun fs ->
+       let eio_path = Eio.Path.(fs / path) in
+       Eio.Path.save ~create:(`Or_truncate 0o644) eio_path content)
+;;
 
 (* Durable atomic write: tmp → fsync(tmp) → rename → fsync(parent dir).
    Without the fsync pair, a crash between the rename and the kernel's
@@ -278,13 +294,20 @@ let save_file (path : string) (content : string) : unit =
 let fsync_path path =
   let fd = Unix.openfile path [ Unix.O_RDONLY ] 0 in
   Stdlib.Fun.protect
-    ~finally:(fun () -> try Unix.close fd with Eio.Cancel.Cancelled _ as e -> raise e | exn -> Stdlib.Printf.eprintf "[fs_compat] fsync_path close failed: %s\n%!" (Printexc.to_string exn))
+    ~finally:(fun () ->
+      try Unix.close fd with
+      | Eio.Cancel.Cancelled _ as e -> raise e
+      | exn ->
+        Stdlib.Printf.eprintf
+          "[fs_compat] fsync_path close failed: %s\n%!"
+          (Printexc.to_string exn))
     (fun () ->
-      try Unix.fsync fd
-      with Unix.Unix_error ((Unix.EINVAL | Unix.EOPNOTSUPP), _, _) ->
-        (* Some filesystems (tmpfs on some kernels) reject fsync. The data
+       try Unix.fsync fd with
+       | Unix.Unix_error ((Unix.EINVAL | Unix.EOPNOTSUPP), _, _) ->
+         (* Some filesystems (tmpfs on some kernels) reject fsync. The data
            is still durable to the extent the underlying FS offers. *)
-        ())
+         ())
+;;
 
 (* #10205 finding 2: keep the atomic-tmp filename shape in one place
    so the writer ([save_file_atomic]) and the orphan-sweep matcher
@@ -297,22 +320,24 @@ let atomic_tmp_suffix = ".tmp"
 
 let save_file_atomic (path : string) (content : string) : (unit, string) Result.t =
   let dir = Stdlib.Filename.dirname path in
-  let tmp =
-    Stdlib.Filename.temp_file ~temp_dir:dir atomic_tmp_prefix atomic_tmp_suffix
-  in
+  let tmp = Stdlib.Filename.temp_file ~temp_dir:dir atomic_tmp_prefix atomic_tmp_suffix in
   try
     save_file tmp content;
     fsync_path tmp;
     Stdlib.Sys.rename tmp path;
-    (try fsync_path dir with Unix.Unix_error _ -> ());
+    (try fsync_path dir with
+     | Unix.Unix_error _ -> ());
     Ok ()
   with
   | Eio.Cancel.Cancelled _ as e ->
-    (try Stdlib.Sys.remove tmp with Sys_error _ -> ());
+    (try Stdlib.Sys.remove tmp with
+     | Sys_error _ -> ());
     raise e
   | exn ->
-    (try Stdlib.Sys.remove tmp with Sys_error _ -> ());
+    (try Stdlib.Sys.remove tmp with
+     | Sys_error _ -> ());
     Error (Printf.sprintf "save_file_atomic %s: %s" path (Printexc.to_string exn))
+;;
 
 (* #10130: orphaned [.atomic_*.tmp] files from [save_file_atomic]
    that accumulated because the owning process was SIGKILL'd or
@@ -340,11 +365,11 @@ let is_atomic_orphan_name name =
   n >= p + s
   && String.starts_with name ~prefix:atomic_tmp_prefix
   && String.ends_with ~suffix:atomic_tmp_suffix name
+;;
 
-let cleanup_atomic_orphans
-    ~(base_path : string)
-    ?(recovered_subdir = ".recovered")
-    () : int * int =
+let cleanup_atomic_orphans ~(base_path : string) ?(recovered_subdir = ".recovered") ()
+  : int * int
+  =
   let recovered_dir = Stdlib.Filename.concat base_path recovered_subdir in
   let deleted = ref 0 in
   let preserved = ref 0 in
@@ -355,26 +380,36 @@ let cleanup_atomic_orphans
      [Unix_error]), and correct when [base_path] itself does not exist
      yet (boot-time race). *)
   let ensure_recovered_dir () =
-    try mkdir_p_unix recovered_dir with Unix.Unix_error _ -> ()
+    try mkdir_p_unix recovered_dir with
+    | Unix.Unix_error _ -> ()
   in
   let handle_file dir name =
     let path = Stdlib.Filename.concat dir name in
     match Unix.stat path with
     | exception Unix.Unix_error _ -> ()
     | stat when stat.Unix.st_size = 0 ->
-        (try Stdlib.Sys.remove path; incr deleted
-         with Sys_error _ -> ())
+      (try
+         Stdlib.Sys.remove path;
+         incr deleted
+       with
+       | Sys_error _ -> ())
     | _stat ->
-        ensure_recovered_dir ();
-        let target =
-          Stdlib.Filename.concat recovered_dir
-            (Printf.sprintf "%s.%.0f" name (Unix.gettimeofday () *. 1000.0))
-        in
-        (try Stdlib.Sys.rename path target; incr preserved
-         with Sys_error _ | Unix.Unix_error _ -> ())
+      ensure_recovered_dir ();
+      let target =
+        Stdlib.Filename.concat
+          recovered_dir
+          (Printf.sprintf "%s.%.0f" name (Unix.gettimeofday () *. 1000.0))
+      in
+      (try
+         Stdlib.Sys.rename path target;
+         incr preserved
+       with
+       | Sys_error _ | Unix.Unix_error _ -> ())
   in
   let scan_dir dir entries =
-    Array.iter (fun name -> if is_atomic_orphan_name name then handle_file dir name) entries
+    Array.iter
+      (fun name -> if is_atomic_orphan_name name then handle_file dir name)
+      entries
   in
   let read_dir_entries dir =
     match Stdlib.Sys.readdir dir with
@@ -387,104 +422,139 @@ let cleanup_atomic_orphans
      the cached entry array. *)
   let entries = read_dir_entries base_path in
   scan_dir base_path entries;
-  Array.iter (fun name -> if String.equal name recovered_subdir then ()
-      else
-        let sub = Stdlib.Filename.concat base_path name in
-        match Unix.stat sub with
-        | exception Unix.Unix_error _ -> ()
-        | stat when (=) stat.Unix.st_kind Unix.S_DIR ->
-            scan_dir sub (read_dir_entries sub)
-        | _ -> ()) entries;
-  (!deleted, !preserved)
+  Array.iter
+    (fun name ->
+       if String.equal name recovered_subdir
+       then ()
+       else (
+         let sub = Stdlib.Filename.concat base_path name in
+         match Unix.stat sub with
+         | exception Unix.Unix_error _ -> ()
+         | stat when stat.Unix.st_kind = Unix.S_DIR -> scan_dir sub (read_dir_entries sub)
+         | _ -> ()))
+    entries;
+  !deleted, !preserved
+;;
 
 (** Append string to file.
     Eio-native when available, fallback to Unix.
     @raises Sys_error on all I/O failures. Eio.Io is normalized internally. *)
 let append_file (path : string) (content : string) : unit =
   test_exec_home_guard ~op:"append_file" path;
-  with_fs_or_fallback ~path ~fallback:(fun () -> append_file_unix path content) (fun fs ->
-      let eio_path = Eio.Path.(fs / path) in
-      Eio.Path.save ~append:true ~create:(`If_missing 0o644) eio_path content)
+  with_fs_or_fallback
+    ~path
+    ~fallback:(fun () -> append_file_unix path content)
+    (fun fs ->
+       let eio_path = Eio.Path.(fs / path) in
+       Eio.Path.save ~append:true ~create:(`If_missing 0o644) eio_path content)
+;;
 
 (** Check if file exists.
     Uses Stdlib.Sys.file_exists (works in both Eio and non-Eio contexts). *)
 let file_exists (path : string) : bool =
-  with_fs_or_fallback ~path ~fallback:(fun () -> Stdlib.Sys.file_exists path) (fun fs ->
-    try
-      let _ = Eio.Path.stat ~follow:true Eio.Path.(fs / path) in true
-    with Eio.Io _ -> false)
+  with_fs_or_fallback
+    ~path
+    ~fallback:(fun () -> Stdlib.Sys.file_exists path)
+    (fun fs ->
+       try
+         let _ = Eio.Path.stat ~follow:true Eio.Path.(fs / path) in
+         true
+       with
+       | Eio.Io _ -> false)
+;;
 
 let file_size (path : string) : int option =
-  with_fs_or_fallback ~path
-    ~fallback:(fun () -> try Some (Unix.stat path).st_size with Unix.Unix_error _ -> None)
+  with_fs_or_fallback
+    ~path
+    ~fallback:(fun () ->
+      try Some (Unix.stat path).st_size with
+      | Unix.Unix_error _ -> None)
     (fun _fs ->
-      try Some (Eio_unix.run_in_systhread (fun () -> (Unix.stat path).st_size))
-      with Unix.Unix_error _ -> None)
+       try Some (Eio_unix.run_in_systhread (fun () -> (Unix.stat path).st_size)) with
+       | Unix.Unix_error _ -> None)
+;;
 
 let file_mtime (path : string) : float option =
-  with_fs_or_fallback ~path
-    ~fallback:(fun () -> try Some (Unix.stat path).st_mtime with Unix.Unix_error _ -> None)
+  with_fs_or_fallback
+    ~path
+    ~fallback:(fun () ->
+      try Some (Unix.stat path).st_mtime with
+      | Unix.Unix_error _ -> None)
     (fun _fs ->
-      try Some (Eio_unix.run_in_systhread (fun () -> (Unix.stat path).st_mtime))
-      with Unix.Unix_error _ -> None)
-
+       try Some (Eio_unix.run_in_systhread (fun () -> (Unix.stat path).st_mtime)) with
+       | Unix.Unix_error _ -> None)
+;;
 
 let rename (src : string) (dst : string) : unit =
-  with_fs_or_fallback ~path:src ~fallback:(fun () -> Stdlib.Sys.rename src dst) (fun fs ->
-    Eio.Path.rename Eio.Path.(fs / src) Eio.Path.(fs / dst))
+  with_fs_or_fallback
+    ~path:src
+    ~fallback:(fun () -> Stdlib.Sys.rename src dst)
+    (fun fs -> Eio.Path.rename Eio.Path.(fs / src) Eio.Path.(fs / dst))
+;;
 
 let rmdir (path : string) : unit =
-  with_fs_or_fallback ~path ~fallback:(fun () -> Unix.rmdir path) (fun fs ->
-    Eio.Path.rmdir Eio.Path.(fs / path))
+  with_fs_or_fallback
+    ~path
+    ~fallback:(fun () -> Unix.rmdir path)
+    (fun fs -> Eio.Path.rmdir Eio.Path.(fs / path))
+;;
 
 let realpath (path : string) : string =
-  with_fs_or_fallback ~path
+  with_fs_or_fallback
+    ~path
     ~fallback:(fun () -> Unix.realpath path)
-    (fun _fs ->
-      Eio_unix.run_in_systhread (fun () -> Unix.realpath path))
+    (fun _fs -> Eio_unix.run_in_systhread (fun () -> Unix.realpath path))
+;;
 
 (** Create directory recursively if not exists.
     @raises Sys_error on all I/O failures. Eio.Io is normalized internally. *)
 let mkdir_p (path : string) : unit =
   test_exec_home_guard ~op:"mkdir_p" path;
-  with_fs_or_fallback ~path ~fallback:(fun () -> mkdir_p_unix path) (fun fs ->
-      let eio_path = Eio.Path.(fs / path) in
-      Eio.Path.mkdirs ~exists_ok:true ~perm:0o755 eio_path)
+  with_fs_or_fallback
+    ~path
+    ~fallback:(fun () -> mkdir_p_unix path)
+    (fun fs ->
+       let eio_path = Eio.Path.(fs / path) in
+       Eio.Path.mkdirs ~exists_ok:true ~perm:0o755 eio_path)
+;;
 
 (** Parse pre-read string lines as JSONL.
     Use when lines come from [Keeper_memory.read_file_tail_lines] or
     other non-file sources.  Logs malformed lines with [source] tag. *)
-let parse_jsonl_lines ~(source : string) (lines : string list)
-    : Yojson.Safe.t list * int =
+let parse_jsonl_lines ~(source : string) (lines : string list) : Yojson.Safe.t list * int =
   let malformed = ref 0 in
   let parsed =
-    List.filter_map (fun line ->
-      let trimmed = String.trim line in
-      if String.equal trimmed "" then None
-      else
-        match Yojson.Safe.from_string trimmed with
-        | json -> Some json
-        | exception Yojson.Json_error msg ->
-            incr malformed;
-            Stdlib.Printf.eprintf "[fs_compat] malformed JSONL (%s): %s\n%!" source msg;
-            None
-    ) lines
+    List.filter_map
+      (fun line ->
+         let trimmed = String.trim line in
+         if String.equal trimmed ""
+         then None
+         else (
+           match Yojson.Safe.from_string trimmed with
+           | json -> Some json
+           | exception Yojson.Json_error msg ->
+             incr malformed;
+             Stdlib.Printf.eprintf "[fs_compat] malformed JSONL (%s): %s\n%!" source msg;
+             None))
+      lines
   in
-  (parsed, !malformed)
+  parsed, !malformed
+;;
 
 (** Load JSONL file, returning parsed values and count of malformed lines.
     Delegates to [parse_jsonl_lines] for the actual parsing. *)
 let load_jsonl_diagnostics (path : string) : Yojson.Safe.t list * int =
-  if not (file_exists path) then ([], 0)
-  else
+  if not (file_exists path)
+  then [], 0
+  else (
     let content = load_file path in
     let lines = String.split_on_char '\n' content in
-    parse_jsonl_lines ~source:path lines
+    parse_jsonl_lines ~source:path lines)
+;;
 
 (** Load JSONL file as list of JSON values.
     Malformed lines are logged and dropped. *)
-let load_jsonl (path : string) : Yojson.Safe.t list =
-  fst (load_jsonl_diagnostics path)
+let load_jsonl (path : string) : Yojson.Safe.t list = fst (load_jsonl_diagnostics path)
 
 (** Stream JSONL line-by-line, folding [f] over parsed values.
 
@@ -502,35 +572,42 @@ let load_jsonl (path : string) : Yojson.Safe.t list =
     {!load_jsonl_diagnostics}.  Raises [Sys_error] on missing /
     unreadable files (consistent with the rest of the module). *)
 let fold_jsonl_lines ~init ~f path =
-  if not (file_exists path) then init
+  if not (file_exists path)
+  then init
   else
-  with_fs_or_fallback ~path
-    ~fallback:(fun () ->
-      let parsed = fst (load_jsonl_diagnostics path) in
-      let _, result =
-        List.fold_left
-          (fun (n, acc) json -> (n + 1, f acc ~line_no:n json))
-          (1, init) parsed
-      in
-      result)
-    (fun fs ->
-      let eio_path = Eio.Path.(fs / path) in
-      Eio.Path.with_open_in eio_path (fun flow ->
-        let buf = Eio.Buf_read.of_flow ~max_size:Int.max_int flow in
-        let line_idx = ref 0 in
-        let acc = ref init in
-        Eio.Buf_read.lines buf
-        |> Seq.iter (fun raw ->
-               incr line_idx;
-               let trimmed = String.trim raw in
-               if not (String.equal trimmed "") then
-                 match Yojson.Safe.from_string trimmed with
-                 | json -> acc := f !acc ~line_no:!line_idx json
-                 | exception Yojson.Json_error msg ->
-                     Stdlib.Printf.eprintf
-                       "[fs_compat] malformed JSONL (%s) line %d: %s\n%!"
-                       path !line_idx msg);
-        !acc))
+    with_fs_or_fallback
+      ~path
+      ~fallback:(fun () ->
+        let parsed = fst (load_jsonl_diagnostics path) in
+        let _, result =
+          List.fold_left
+            (fun (n, acc) json -> n + 1, f acc ~line_no:n json)
+            (1, init)
+            parsed
+        in
+        result)
+      (fun fs ->
+         let eio_path = Eio.Path.(fs / path) in
+         Eio.Path.with_open_in eio_path (fun flow ->
+           let buf = Eio.Buf_read.of_flow ~max_size:Int.max_int flow in
+           let line_idx = ref 0 in
+           let acc = ref init in
+           Eio.Buf_read.lines buf
+           |> Seq.iter (fun raw ->
+             incr line_idx;
+             let trimmed = String.trim raw in
+             if not (String.equal trimmed "")
+             then (
+               match Yojson.Safe.from_string trimmed with
+               | json -> acc := f !acc ~line_no:!line_idx json
+               | exception Yojson.Json_error msg ->
+                 Stdlib.Printf.eprintf
+                   "[fs_compat] malformed JSONL (%s) line %d: %s\n%!"
+                   path
+                   !line_idx
+                   msg));
+           !acc))
+;;
 
 (** Append JSON value as line to JSONL file. *)
 let append_jsonl (path : string) (json : Yojson.Safe.t) : unit =
@@ -538,6 +615,7 @@ let append_jsonl (path : string) (json : Yojson.Safe.t) : unit =
   mkdir_p dir;
   let line = Yojson.Safe.to_string json ^ "\n" in
   append_file path line
+;;
 
 (* ================================================================ *)
 (* Storage Backend Abstraction                                      *)
@@ -547,20 +625,17 @@ type backend_kind =
   | Local
   | Remote of string
 
-type backend = {
-  kind : backend_kind;
-  base_path : string;
-}
+type backend =
+  { kind : backend_kind
+  ; base_path : string
+  }
 
-let create_backend ?(kind = Local) ~base_path () =
-  { kind; base_path }
-
-let backend_base_path (b : backend) =
-  b.base_path
+let create_backend ?(kind = Local) ~base_path () = { kind; base_path }
+let backend_base_path (b : backend) = b.base_path
 
 let backend_kind_to_string = function
   | Local -> "local"
   | Remote url -> Printf.sprintf "remote(%s)" url
+;;
 
-let default_backend ~base_path =
-  { kind = Local; base_path }
+let default_backend ~base_path = { kind = Local; base_path }

--- a/lib/fs_compat/fs_compat.mli
+++ b/lib/fs_compat/fs_compat.mli
@@ -99,12 +99,18 @@ val load_jsonl_diagnostics : string -> Yojson.Safe.t list * int
 val parse_jsonl_lines : source:string -> string list -> Yojson.Safe.t list * int
 
 (** Stream JSONL line-by-line via [Eio.Buf_read.lines] when the global
-    fs is registered, falling back to {!load_jsonl} + [List.fold_left]
-    otherwise.  [line_no] is the 1-based index of {b non-blank} JSONL
-    rows (matches {!load_jsonl_diagnostics}).  Use when the file may be
-    too large to materialize as a list, e.g. audit/metrics JSONL on
-    HTTP hot paths.  Returns [init] when [path] is missing (consistent
-    with {!load_jsonl}); raises [Sys_error] on read failures of an
+    fs is registered, falling back to a raw-line iterator over the
+    Stdlib channel otherwise (both branches share the same [line_no]
+    counting).  [line_no] is the 1-based index of {b non-blank}
+    JSONL rows — blank lines are skipped, malformed lines emit a
+    stderr warning and are skipped but {i still consume} the index
+    so the counter tracks the printed JSONL row number rather than
+    the count of successfully parsed values.  Use when the file may
+    be too large to materialize as a list, e.g. audit/metrics JSONL
+    on HTTP hot paths.
+
+    Returns [init] when [path] is missing (consistent with
+    {!load_jsonl}); raises [Sys_error] on read failures of an
     existing file. *)
 val fold_jsonl_lines
   :  init:'acc

--- a/lib/fs_compat/fs_compat.mli
+++ b/lib/fs_compat/fs_compat.mli
@@ -3,46 +3,41 @@
     @since 2026-02 - Keeper Emergent Identity v2.0
 *)
 
-exception Test_isolation_breach of string
 (** #9921: raised by mutating [Fs_compat] entry points
     ([append_file], [save_file], [mkdir_p]) when the target path falls
     under [HOME] and the process is a test executable. Defense in depth
     behind [Env_config_core.base_path_prod_guard]. Bypass with
     [MASC_TEST_ALLOW_HOME_BASE_PATH=1]. *)
+exception Test_isolation_breach of string
 
-val set_fs : Eio.Fs.dir_ty Eio.Path.t -> unit
 (** Set global Eio filesystem. Call at server startup. *)
+val set_fs : Eio.Fs.dir_ty Eio.Path.t -> unit
 
-val clear_fs : unit -> unit
 (** Clear global fs (testing/shutdown). *)
+val clear_fs : unit -> unit
 
-val get_fs_opt : unit -> Eio.Fs.dir_ty Eio.Path.t option
 (** Get the global Eio filesystem if available. *)
+val get_fs_opt : unit -> Eio.Fs.dir_ty Eio.Path.t option
 
-val has_fs : unit -> bool
 (** Check if Eio fs is available. *)
+val has_fs : unit -> bool
 
-val load_file : string -> string
 (** Load entire file as string. *)
+val load_file : string -> string
 
-val save_file : string -> string -> unit
 (** Save string to file (overwrite). *)
+val save_file : string -> string -> unit
 
-val save_file_atomic : string -> string -> (unit, string) Result.t
 (** Write content to path via temp file + rename.
     Returns [Error msg] on I/O failure instead of raising. *)
+val save_file_atomic : string -> string -> (unit, string) Result.t
 
-val is_atomic_orphan_name : string -> bool
 (** [true] iff [name] matches the [.atomic_*.tmp] pattern produced
     by [Filename.temp_file ~temp_dir:dir ".atomic_" ".tmp"] inside
     {!save_file_atomic}.  Exposed for tests and for a potential
     periodic sweep. *)
+val is_atomic_orphan_name : string -> bool
 
-val cleanup_atomic_orphans :
-  base_path:string ->
-  ?recovered_subdir:string ->
-  unit ->
-  int * int
 (** #10130: boot-time sweep for [.atomic_*.tmp] orphans left
     behind when [save_file_atomic]'s with-handler never ran (the
     owning process was SIGKILL'd, or [Filename.temp_file] itself
@@ -59,50 +54,50 @@ val cleanup_atomic_orphans :
     Returns [(deleted, preserved)]:
     - [deleted]: zero-byte orphans removed.
     - [preserved]: non-zero orphans moved to [recovered_subdir]. *)
+val cleanup_atomic_orphans
+  :  base_path:string
+  -> ?recovered_subdir:string
+  -> unit
+  -> int * int
 
-val append_file : string -> string -> unit
 (** Append string to file. *)
+val append_file : string -> string -> unit
 
-val file_exists : string -> bool
 (** Check if file exists. *)
+val file_exists : string -> bool
 
-val file_size : string -> int option
 (** Return file size or None *)
+val file_size : string -> int option
 
-val file_mtime : string -> float option
 (** Return file mtime or None *)
+val file_mtime : string -> float option
 
-val rename : string -> string -> unit
 (** Rename file. *)
+val rename : string -> string -> unit
 
-val rmdir : string -> unit
 (** Remove directory. *)
+val rmdir : string -> unit
 
-val realpath : string -> string
 (** Get realpath. *)
+val realpath : string -> string
 
-val mkdir_p : string -> unit
 (** Create directory recursively. *)
+val mkdir_p : string -> unit
 
-val load_jsonl : string -> Yojson.Safe.t list
 (** Load JSONL file as list of JSON values.
     Malformed lines are logged and dropped. *)
+val load_jsonl : string -> Yojson.Safe.t list
 
-val load_jsonl_diagnostics : string -> Yojson.Safe.t list * int
 (** Load JSONL file, returning parsed values and count of malformed lines.
     Logs each malformed line with the provided source label. Use when the caller needs
     to surface degraded state (e.g. dashboard malformed_lines field). *)
+val load_jsonl_diagnostics : string -> Yojson.Safe.t list * int
 
-val parse_jsonl_lines : source:string -> string list -> Yojson.Safe.t list * int
 (** Parse pre-read string lines as JSONL, returning parsed values and
     malformed count.  [source] is used in log messages.
     Use when lines come from tail-readers or non-file sources. *)
+val parse_jsonl_lines : source:string -> string list -> Yojson.Safe.t list * int
 
-val fold_jsonl_lines :
-  init:'acc ->
-  f:('acc -> line_no:int -> Yojson.Safe.t -> 'acc) ->
-  string ->
-  'acc
 (** Stream JSONL line-by-line via [Eio.Buf_read.lines] when the global
     fs is registered, falling back to {!load_jsonl} + [List.fold_left]
     otherwise.  [line_no] is the 1-based index of {b non-blank} JSONL
@@ -111,9 +106,14 @@ val fold_jsonl_lines :
     HTTP hot paths.  Returns [init] when [path] is missing (consistent
     with {!load_jsonl}); raises [Sys_error] on read failures of an
     existing file. *)
+val fold_jsonl_lines
+  :  init:'acc
+  -> f:('acc -> line_no:int -> Yojson.Safe.t -> 'acc)
+  -> string
+  -> 'acc
 
-val append_jsonl : string -> Yojson.Safe.t -> unit
 (** Append JSON value as line to JSONL file. *)
+val append_jsonl : string -> Yojson.Safe.t -> unit
 
 (** {1 Storage Backend Abstraction}
 
@@ -124,23 +124,23 @@ val append_jsonl : string -> Yojson.Safe.t -> unit
     @since 2.95.0 — Issue #1442 *)
 
 type backend_kind =
-  | Local            (** Local filesystem (Eio or Unix fallback) *)
+  | Local (** Local filesystem (Eio or Unix fallback) *)
   | Remote of string (** Remote endpoint URL *)
 
-type backend = {
-  kind : backend_kind;
-  base_path : string;  (** Root directory for this backend *)
-}
+type backend =
+  { kind : backend_kind
+  ; base_path : string (** Root directory for this backend *)
+  }
 
-val create_backend : ?kind:backend_kind -> base_path:string -> unit -> backend
 (** Create a backend descriptor.
     Defaults to [Local] when [kind] is omitted. *)
+val create_backend : ?kind:backend_kind -> base_path:string -> unit -> backend
 
-val backend_base_path : backend -> string
 (** Return the base_path of a backend. *)
+val backend_base_path : backend -> string
 
-val backend_kind_to_string : backend_kind -> string
 (** Serialize backend_kind for logging/diagnostics. *)
+val backend_kind_to_string : backend_kind -> string
 
-val default_backend : base_path:string -> backend
 (** Convenience: create a [Local] backend with the given base_path. *)
+val default_backend : base_path:string -> backend

--- a/lib/fs_compat/fs_compat.mli
+++ b/lib/fs_compat/fs_compat.mli
@@ -98,6 +98,20 @@ val parse_jsonl_lines : source:string -> string list -> Yojson.Safe.t list * int
     malformed count.  [source] is used in log messages.
     Use when lines come from tail-readers or non-file sources. *)
 
+val fold_jsonl_lines :
+  init:'acc ->
+  f:('acc -> line_no:int -> Yojson.Safe.t -> 'acc) ->
+  string ->
+  'acc
+(** Stream JSONL line-by-line via [Eio.Buf_read.lines] when the global
+    fs is registered, falling back to {!load_jsonl} + [List.fold_left]
+    otherwise.  [line_no] is the 1-based index of {b non-blank} JSONL
+    rows (matches {!load_jsonl_diagnostics}).  Use when the file may be
+    too large to materialize as a list, e.g. audit/metrics JSONL on
+    HTTP hot paths.  Returns [init] when [path] is missing (consistent
+    with {!load_jsonl}); raises [Sys_error] on read failures of an
+    existing file. *)
+
 val append_jsonl : string -> Yojson.Safe.t -> unit
 (** Append JSON value as line to JSONL file. *)
 

--- a/lib/model_inference_metrics.ml
+++ b/lib/model_inference_metrics.ml
@@ -697,29 +697,13 @@ let read_all_decisions ~base_path ~since_unix : raw_entry list =
       (fun fname ->
          let path = Filename.concat keeper_dir fname in
          try
-           let ic = open_in path in
-           let entries = ref [] in
-           Eio_guard.protect
-             ~finally:(fun () -> close_in_noerr ic)
-             (fun () ->
-                (try
-                   while true do
-                     let line = input_line ic in
-                     if String.length line > 2
-                     then (
-                       match Yojson.Safe.from_string line with
-                       | json ->
-                         (match parse_telemetry_entry json ~since_unix with
-                          | Some e -> entries := e :: !entries
-                          | None -> ())
-                       | exception (Eio.Cancel.Cancelled _ as exn) ->
-                         let bt = Printexc.get_raw_backtrace () in
-                         Printexc.raise_with_backtrace exn bt
-                       | exception Yojson.Json_error _ -> ())
-                   done
-                 with
-                 | End_of_file -> ());
-                !entries)
+           Fs_compat.fold_jsonl_lines
+             ~init:[]
+             ~f:(fun acc ~line_no:_ json ->
+               match parse_telemetry_entry json ~since_unix with
+               | Some e -> e :: acc
+               | None -> acc)
+             path
          with
          | Eio.Cancel.Cancelled _ as exn ->
            let bt = Printexc.get_raw_backtrace () in
@@ -734,29 +718,13 @@ let read_cost_entries_legacy ~base_path ~since_unix : raw_entry list =
   then []
   else (
     try
-      let ic = open_in path in
-      let entries = ref [] in
-      Eio_guard.protect
-        ~finally:(fun () -> close_in_noerr ic)
-        (fun () ->
-           (try
-              while true do
-                let line = input_line ic in
-                if String.length line > 2
-                then (
-                  match Yojson.Safe.from_string line with
-                  | json ->
-                    (match parse_cost_entry json ~since_unix with
-                     | Some e -> entries := e :: !entries
-                     | None -> ())
-                  | exception (Eio.Cancel.Cancelled _ as exn) ->
-                    let bt = Printexc.get_raw_backtrace () in
-                    Printexc.raise_with_backtrace exn bt
-                  | exception Yojson.Json_error _ -> ())
-              done
-            with
-            | End_of_file -> ());
-           !entries)
+      Fs_compat.fold_jsonl_lines
+        ~init:[]
+        ~f:(fun acc ~line_no:_ json ->
+          match parse_cost_entry json ~since_unix with
+          | Some e -> e :: acc
+          | None -> acc)
+        path
     with
     | Eio.Cancel.Cancelled _ as exn ->
       let bt = Printexc.get_raw_backtrace () in

--- a/lib/server/server_dashboard_http_runtime_info.ml
+++ b/lib/server/server_dashboard_http_runtime_info.ml
@@ -621,7 +621,7 @@ let int_of_string_opt raw =
 
 let load_benchmark_rows path =
   let lines =
-    try In_channel.with_open_text path In_channel.input_all |> String.split_on_char '\n'
+    try Fs_compat.load_file path |> String.split_on_char '\n'
     with Sys_error _ -> []
   in
   lines

--- a/lib/server/server_dashboard_http_runtime_info.ml
+++ b/lib/server/server_dashboard_http_runtime_info.ml
@@ -3,60 +3,77 @@
 
 open Dashboard_http_helpers
 
-let contains_substring ~needle haystack =
-  String_util.contains_substring haystack needle
+let contains_substring ~needle haystack = String_util.contains_substring haystack needle
 
 let take n xs =
   let rec loop acc remaining xs =
-    if remaining <= 0 then List.rev acc
-    else
+    if remaining <= 0
+    then List.rev acc
+    else (
       match xs with
       | [] -> List.rev acc
-      | x :: tl -> loop (x :: acc) (remaining - 1) tl
+      | x :: tl -> loop (x :: acc) (remaining - 1) tl)
   in
   loop [] n xs
+;;
 
 let trim_to_option raw =
   let trimmed = String.trim raw in
   if trimmed = "" then None else Some trimmed
+;;
 
 let list_hd_opt = function
   | [] -> None
   | x :: _ -> Some x
+;;
 
-type dashboard_runtime_probe_cache_entry = {
-  probe : Yojson.Safe.t;
-  refreshed_at : float;
-}
+type dashboard_runtime_probe_cache_entry =
+  { probe : Yojson.Safe.t
+  ; refreshed_at : float
+  }
 
 let dashboard_runtime_probe_cache : dashboard_runtime_probe_cache_entry option Atomic.t =
   Atomic.make None
+;;
 
 let dashboard_runtime_probe_cache_ttl_sec = 30.0
 let dashboard_runtime_probe_force_min_refresh_sec = 10.0
 let dashboard_runtime_probe_timeout_sec = 15
 let dashboard_runtime_probe_refresh_in_flight = Atomic.make false
+
 let dashboard_runtime_probe_runner_hook : (unit -> Yojson.Safe.t) option Atomic.t =
   Atomic.make None
+;;
 
 let set_dashboard_runtime_probe_runner_for_tests hook =
   Atomic.set dashboard_runtime_probe_runner_hook (Some hook)
+;;
 
 let clear_dashboard_runtime_probe_runner_for_tests () =
   Atomic.set dashboard_runtime_probe_runner_hook None
+;;
 
 let clear_dashboard_runtime_probe_cache_for_tests () =
   Atomic.set dashboard_runtime_probe_cache None;
   Atomic.set dashboard_runtime_probe_refresh_in_flight false
+;;
 
 let path_descends_from ~root path =
   String.equal path root || String.starts_with ~prefix:(root ^ "/") path
+;;
 
 let path_relative_to ~root path =
-  if String.equal path root then Some "."
-  else if String.starts_with ~prefix:(root ^ "/") path then
-    Some (String.sub path (String.length root + 1) (String.length path - String.length root - 1))
+  if String.equal path root
+  then Some "."
+  else if String.starts_with ~prefix:(root ^ "/") path
+  then
+    Some
+      (String.sub
+         path
+         (String.length root + 1)
+         (String.length path - String.length root - 1))
   else None
+;;
 
 (* Per-path TTL cache for `git rev-parse --short HEAD`.  Each miss forks
    git and can take seconds on large worktrees (~/me etc.), yet HEAD
@@ -65,70 +82,73 @@ let path_relative_to ~root path =
    off the 5 s git-probe budget on the hot path. *)
 let git_rev_parse_short_ttl_sec = 60.0
 
-let git_rev_parse_short_cache :
-    (string, string option * float) Hashtbl.t =
+let git_rev_parse_short_cache : (string, string option * float) Hashtbl.t =
   Hashtbl.create 4
+;;
 
-let git_rev_parse_short_in_flight : (string, unit) Hashtbl.t =
-  Hashtbl.create 4
-
+let git_rev_parse_short_in_flight : (string, unit) Hashtbl.t = Hashtbl.create 4
 let git_rev_parse_short_mu = Stdlib.Mutex.create ()
 
-let git_rev_parse_short_probe_hook_for_tests :
-    (string -> string option) option Atomic.t =
+let git_rev_parse_short_probe_hook_for_tests : (string -> string option) option Atomic.t =
   Atomic.make None
+;;
 
 let set_git_rev_parse_short_probe_hook_for_tests hook =
   Atomic.set git_rev_parse_short_probe_hook_for_tests (Some hook)
+;;
 
 let clear_git_rev_parse_short_probe_hook_for_tests () =
   Atomic.set git_rev_parse_short_probe_hook_for_tests None
+;;
 
 let git_rev_parse_short_cached_lookup dir ~now =
   Stdlib.Mutex.lock git_rev_parse_short_mu;
   Fun.protect
     ~finally:(fun () -> Stdlib.Mutex.unlock git_rev_parse_short_mu)
     (fun () ->
-      match Hashtbl.find_opt git_rev_parse_short_cache dir with
-      | Some (value, ts) when now -. ts <= git_rev_parse_short_ttl_sec ->
-          Some value
-      | _ -> None)
+       match Hashtbl.find_opt git_rev_parse_short_cache dir with
+       | Some (value, ts) when now -. ts <= git_rev_parse_short_ttl_sec -> Some value
+       | _ -> None)
+;;
 
 let git_rev_parse_short_cached_any dir =
   Stdlib.Mutex.lock git_rev_parse_short_mu;
   Fun.protect
     ~finally:(fun () -> Stdlib.Mutex.unlock git_rev_parse_short_mu)
-    (fun () ->
-      Hashtbl.find_opt git_rev_parse_short_cache dir
-      |> Option.map fst)
+    (fun () -> Hashtbl.find_opt git_rev_parse_short_cache dir |> Option.map fst)
+;;
 
 let git_rev_parse_short_try_begin_refresh dir =
   Stdlib.Mutex.lock git_rev_parse_short_mu;
   Fun.protect
     ~finally:(fun () -> Stdlib.Mutex.unlock git_rev_parse_short_mu)
     (fun () ->
-      if Hashtbl.mem git_rev_parse_short_in_flight dir then false
-      else begin
-        Hashtbl.replace git_rev_parse_short_in_flight dir ();
-        true
-      end)
+       if Hashtbl.mem git_rev_parse_short_in_flight dir
+       then false
+       else (
+         Hashtbl.replace git_rev_parse_short_in_flight dir ();
+         true))
+;;
 
 let git_rev_parse_short_finish_refresh dir value ~now =
   Stdlib.Mutex.lock git_rev_parse_short_mu;
   Fun.protect
     ~finally:(fun () -> Stdlib.Mutex.unlock git_rev_parse_short_mu)
     (fun () ->
-      Hashtbl.replace git_rev_parse_short_cache dir (value, now);
-      Hashtbl.remove git_rev_parse_short_in_flight dir)
+       Hashtbl.replace git_rev_parse_short_cache dir (value, now);
+       Hashtbl.remove git_rev_parse_short_in_flight dir)
+;;
 
 let git_rev_parse_short_cancel_refresh dir =
   Stdlib.Mutex.lock git_rev_parse_short_mu;
   Fun.protect
     ~finally:(fun () -> Stdlib.Mutex.unlock git_rev_parse_short_mu)
     (fun () -> Hashtbl.remove git_rev_parse_short_in_flight dir)
+;;
 
 let git_rev_parse_short_probe_argv dir =
   [ "git"; "-C"; dir; "--no-optional-locks"; "rev-parse"; "--short"; "HEAD" ]
+;;
 
 (* Bumped 5s → 15s for large repos (#9765, #9775).
    `~/me` repeatedly trips the 5s budget on first probe after TTL
@@ -144,18 +164,19 @@ let git_rev_parse_short_probe dir =
   match Atomic.get git_rev_parse_short_probe_hook_for_tests with
   | Some hook -> hook dir
   | None ->
-      let argv = git_rev_parse_short_probe_argv dir in
-      let raw_source = String.concat " " (List.map Filename.quote argv) in
-      match
-        Masc_exec.Exec_gate.run_argv_with_status
-          ~actor:(Masc_exec.Agent_id.of_string "system/runtime_info")
-          ~raw_source
-          ~summary:"dashboard runtime git probe"
-          ~timeout_sec:git_rev_parse_short_probe_timeout_sec
-          argv
-      with
-      | Unix.WEXITED 0, output -> trim_to_option output
-      | _ -> None
+    let argv = git_rev_parse_short_probe_argv dir in
+    let raw_source = String.concat " " (List.map Filename.quote argv) in
+    (match
+       Masc_exec.Exec_gate.run_argv_with_status
+         ~actor:(Masc_exec.Agent_id.of_string "system/runtime_info")
+         ~raw_source
+         ~summary:"dashboard runtime git probe"
+         ~timeout_sec:git_rev_parse_short_probe_timeout_sec
+         argv
+     with
+     | Unix.WEXITED 0, output -> trim_to_option output
+     | _ -> None)
+;;
 
 let git_rev_parse_short_refresh dir =
   try
@@ -165,207 +186,225 @@ let git_rev_parse_short_refresh dir =
   with
   | Eio.Cancel.Cancelled _ as e -> raise e
   | exn ->
-      git_rev_parse_short_cancel_refresh dir;
-      raise exn
+    git_rev_parse_short_cancel_refresh dir;
+    raise exn
+;;
 
 let maybe_refresh_git_rev_parse_short_in_background dir =
   match Eio_context.get_switch_opt () with
   | None -> ()
   | Some sw ->
-      if git_rev_parse_short_try_begin_refresh dir then
-        Eio.Fiber.fork ~sw (fun () ->
-          try let _ = git_rev_parse_short_refresh dir in () with
-          | Eio.Cancel.Cancelled _ as e -> raise e
-          | exn ->
-              Log.Dashboard.warn
-                "dashboard runtime git probe refresh failed for %s: %s"
-                dir (Printexc.to_string exn))
+    if git_rev_parse_short_try_begin_refresh dir
+    then
+      Eio.Fiber.fork ~sw (fun () ->
+        try
+          let _ = git_rev_parse_short_refresh dir in
+          ()
+        with
+        | Eio.Cancel.Cancelled _ as e -> raise e
+        | exn ->
+          Log.Dashboard.warn
+            "dashboard runtime git probe refresh failed for %s: %s"
+            dir
+            (Printexc.to_string exn))
+;;
 
 let git_rev_parse_short path =
   match trim_to_option path with
   | None -> None
   | Some dir when not (Sys.file_exists dir) -> None
   | Some dir ->
-      let now = Time_compat.now () in
-      (match git_rev_parse_short_cached_lookup dir ~now with
-       | Some value -> value
-       | None -> (
-           match git_rev_parse_short_cached_any dir with
-           | Some stale ->
-               maybe_refresh_git_rev_parse_short_in_background dir;
-               stale
-           | None ->
-               if git_rev_parse_short_try_begin_refresh dir then
-                 git_rev_parse_short_refresh dir
-               else
-                 git_rev_parse_short_cached_any dir |> Option.value ~default:None))
+    let now = Time_compat.now () in
+    (match git_rev_parse_short_cached_lookup dir ~now with
+     | Some value -> value
+     | None ->
+       (match git_rev_parse_short_cached_any dir with
+        | Some stale ->
+          maybe_refresh_git_rev_parse_short_in_background dir;
+          stale
+        | None ->
+          if git_rev_parse_short_try_begin_refresh dir
+          then git_rev_parse_short_refresh dir
+          else git_rev_parse_short_cached_any dir |> Option.value ~default:None))
+;;
 
 let clear_git_rev_parse_short_cache_for_tests () =
   Stdlib.Mutex.lock git_rev_parse_short_mu;
   Fun.protect
     ~finally:(fun () -> Stdlib.Mutex.unlock git_rev_parse_short_mu)
     (fun () ->
-      Hashtbl.clear git_rev_parse_short_cache;
-      Hashtbl.clear git_rev_parse_short_in_flight)
+       Hashtbl.clear git_rev_parse_short_cache;
+       Hashtbl.clear git_rev_parse_short_in_flight)
+;;
 
 let seed_git_rev_parse_short_cache_for_tests dir value ~refreshed_at =
   Stdlib.Mutex.lock git_rev_parse_short_mu;
   Fun.protect
     ~finally:(fun () -> Stdlib.Mutex.unlock git_rev_parse_short_mu)
     (fun () ->
-      Hashtbl.replace git_rev_parse_short_cache dir (value, refreshed_at);
-      Hashtbl.remove git_rev_parse_short_in_flight dir)
+       Hashtbl.replace git_rev_parse_short_cache dir (value, refreshed_at);
+       Hashtbl.remove git_rev_parse_short_in_flight dir)
+;;
 
 let path_item_json ~source path =
   `Assoc
-    [
-      ("path", `String path);
-      ("exists", `Bool (String.trim path <> "" && Sys.file_exists path));
-      ("source", `String source);
+    [ "path", `String path
+    ; "exists", `Bool (String.trim path <> "" && Sys.file_exists path)
+    ; "source", `String source
     ]
+;;
 
 let shutdown_signal_of_message message =
-  if contains_substring ~needle:"Received SIGTERM" message then Some "SIGTERM"
-  else if contains_substring ~needle:"Received SIGINT" message then Some "SIGINT"
+  if contains_substring ~needle:"Received SIGTERM" message
+  then Some "SIGTERM"
+  else if contains_substring ~needle:"Received SIGINT" message
+  then Some "SIGINT"
   else None
+;;
 
 let runtime_diagnostics_json () =
   let entries = Log.Ring.recent ~limit:200 ~order:`Newest_first () in
   let diagnostics =
     entries
     |> List.filter_map (fun (entry : Log.Ring.entry) ->
-           let message = entry.message in
-           match shutdown_signal_of_message message with
-           | Some signal ->
-               Some
-                 (`Assoc
-                   [
-                     ("ts", `String entry.ts);
-                     ("kind", `String "external_signal");
-                     ("signal", `String signal);
-                     ("message", `String message);
-                   ])
-           | None when contains_substring
-                           ~needle:"repairing state and rewriting canonical JSON"
-                           message ->
-               Some
-                 (`Assoc
-                   [
-                     ("ts", `String entry.ts);
-                     ("kind", `String "state_repair");
-                     ("message", `String message);
-                   ])
-           | None when contains_substring ~needle:"invalid agent JSON" message
-                       || contains_substring ~needle:"repaired agent JSON" message
-                       || contains_substring
-                            ~needle:"parse error: Types_core.agent.last_seen"
-                            message ->
-               Some
-                 (`Assoc
-                   [
-                     ("ts", `String entry.ts);
-                     ("kind", `String "agent_state");
-                     ("message", `String message);
-                   ])
-           | None -> None)
+      let message = entry.message in
+      match shutdown_signal_of_message message with
+      | Some signal ->
+        Some
+          (`Assoc
+              [ "ts", `String entry.ts
+              ; "kind", `String "external_signal"
+              ; "signal", `String signal
+              ; "message", `String message
+              ])
+      | None
+        when contains_substring
+               ~needle:"repairing state and rewriting canonical JSON"
+               message ->
+        Some
+          (`Assoc
+              [ "ts", `String entry.ts
+              ; "kind", `String "state_repair"
+              ; "message", `String message
+              ])
+      | None
+        when contains_substring ~needle:"invalid agent JSON" message
+             || contains_substring ~needle:"repaired agent JSON" message
+             || contains_substring
+                  ~needle:"parse error: Types_core.agent.last_seen"
+                  message ->
+        Some
+          (`Assoc
+              [ "ts", `String entry.ts
+              ; "kind", `String "agent_state"
+              ; "message", `String message
+              ])
+      | None -> None)
     |> take 8
   in
   let count kind =
     List.fold_left
       (fun acc json ->
-        match Yojson.Safe.Util.member "kind" json with
-        | `String value when String.equal value kind -> acc + 1
-        | _ -> acc)
-      0 diagnostics
+         match Yojson.Safe.Util.member "kind" json with
+         | `String value when String.equal value kind -> acc + 1
+         | _ -> acc)
+      0
+      diagnostics
   in
-  ( `List diagnostics,
-    count "external_signal",
-    count "state_repair",
-    count "agent_state" )
+  `List diagnostics, count "external_signal", count "state_repair", count "agent_state"
+;;
 
 let run_dashboard_runtime_probe () =
   match Atomic.get dashboard_runtime_probe_runner_hook with
   | Some hook -> hook ()
   | None ->
-      Tool_local_runtime.runtime_ollama_probe_json ~probe_runs:2 ~max_tokens:8
-        ~timeout_sec:dashboard_runtime_probe_timeout_sec ~ps_timeout_sec:2
-        ~generate_when_unloaded:false ~run_generate:false ()
+    Tool_local_runtime.runtime_ollama_probe_json
+      ~probe_runs:2
+      ~max_tokens:8
+      ~timeout_sec:dashboard_runtime_probe_timeout_sec
+      ~ps_timeout_sec:2
+      ~generate_when_unloaded:false
+      ~run_generate:false
+      ()
+;;
 
 let dashboard_runtime_probe_cached_value () =
   match Atomic.get dashboard_runtime_probe_cache with
   | Some entry -> Some (entry.probe, entry.refreshed_at)
   | None -> None
+;;
 
 let dashboard_runtime_probe_fresh_value ~now =
   match dashboard_runtime_probe_cached_value () with
   | Some (probe, refreshed_at)
     when now -. refreshed_at <= dashboard_runtime_probe_cache_ttl_sec ->
-      Some (probe, refreshed_at)
+    Some (probe, refreshed_at)
   | _ -> None
+;;
 
 let dashboard_runtime_probe_recent_value ~now =
   match dashboard_runtime_probe_cached_value () with
   | Some (probe, refreshed_at)
     when now -. refreshed_at <= dashboard_runtime_probe_force_min_refresh_sec ->
-      Some (probe, refreshed_at)
+    Some (probe, refreshed_at)
   | _ -> None
+;;
 
 let dashboard_runtime_probe_http_json ?(force = false) () =
   let now = Time_compat.now () in
   let probe, cache_hit, refreshed_at =
     match
-      if force then dashboard_runtime_probe_recent_value ~now
+      if force
+      then dashboard_runtime_probe_recent_value ~now
       else dashboard_runtime_probe_fresh_value ~now
     with
-    | Some (cached, cached_at) -> (cached, true, cached_at)
+    | Some (cached, cached_at) -> cached, true, cached_at
     | None ->
-        if
-          Atomic.compare_and_set dashboard_runtime_probe_refresh_in_flight false
-            true
-        then
-          (* Run the Eio-yielding probe outside any Stdlib mutex/Fun.protect
+      if Atomic.compare_and_set dashboard_runtime_probe_refresh_in_flight false true
+      then (
+        (* Run the Eio-yielding probe outside any Stdlib mutex/Fun.protect
              scope.  The CAS guard above serialises refreshes; the [match]
              below ensures the in-flight flag is always cleared even when
              the probe raises or is cancelled (Atomic.set never yields). *)
-          match run_dashboard_runtime_probe () with
-          | fresh ->
-              let refreshed_at = Time_compat.now () in
-              Atomic.set dashboard_runtime_probe_cache
-                (Some { probe = fresh; refreshed_at });
-              Atomic.set dashboard_runtime_probe_refresh_in_flight false;
-              (fresh, false, refreshed_at)
-          | exception exn ->
-              let bt = Printexc.get_raw_backtrace () in
-              Atomic.set dashboard_runtime_probe_refresh_in_flight false;
-              Printexc.raise_with_backtrace exn bt
-        else
-          let fallback_now = Time_compat.now () in
-          match
-            if not force then dashboard_runtime_probe_fresh_value ~now:fallback_now
-            else None
-          with
-          | Some (cached, cached_at) -> (cached, true, cached_at)
-          | None -> (
-              match dashboard_runtime_probe_cached_value () with
-              | Some (cached, cached_at) -> (cached, false, cached_at)
-              | None -> (`Null, false, 0.0))
+        match run_dashboard_runtime_probe () with
+        | fresh ->
+          let refreshed_at = Time_compat.now () in
+          Atomic.set dashboard_runtime_probe_cache (Some { probe = fresh; refreshed_at });
+          Atomic.set dashboard_runtime_probe_refresh_in_flight false;
+          fresh, false, refreshed_at
+        | exception exn ->
+          let bt = Printexc.get_raw_backtrace () in
+          Atomic.set dashboard_runtime_probe_refresh_in_flight false;
+          Printexc.raise_with_backtrace exn bt)
+      else (
+        let fallback_now = Time_compat.now () in
+        match
+          if not force
+          then dashboard_runtime_probe_fresh_value ~now:fallback_now
+          else None
+        with
+        | Some (cached, cached_at) -> cached, true, cached_at
+        | None ->
+          (match dashboard_runtime_probe_cached_value () with
+           | Some (cached, cached_at) -> cached, false, cached_at
+           | None -> `Null, false, 0.0))
   in
   let response_now = Time_compat.now () in
   let refreshed_at_json, cache_age_json =
-    if refreshed_at > 0.0 then
-      (`Float refreshed_at, `Float (max 0.0 (response_now -. refreshed_at)))
-    else
-      (`Null, `Null)
+    if refreshed_at > 0.0
+    then `Float refreshed_at, `Float (max 0.0 (response_now -. refreshed_at))
+    else `Null, `Null
   in
   `Assoc
-    [
-      ("generated_at", `String (Masc_domain.now_iso ()));
-      ("refreshed_at_unix", refreshed_at_json);
-      ("cache_ttl_sec", `Float dashboard_runtime_probe_cache_ttl_sec);
-      ("cache_age_sec", cache_age_json);
-      ("cache_hit", `Bool cache_hit);
-      ("probe", probe);
+    [ "generated_at", `String (Masc_domain.now_iso ())
+    ; "refreshed_at_unix", refreshed_at_json
+    ; "cache_ttl_sec", `Float dashboard_runtime_probe_cache_ttl_sec
+    ; "cache_age_sec", cache_age_json
+    ; "cache_hit", `Bool cache_hit
+    ; "probe", probe
     ]
+;;
+
 let runtime_resolution_json (config : Coord.config) =
   let build = Build_identity.current () in
   let runtime_commit = build.commit in
@@ -374,8 +413,7 @@ let runtime_resolution_json (config : Coord.config) =
   let workspace_commit = git_rev_parse_short config.workspace_path in
   let resolved_base_commit = git_rev_parse_short config.base_path in
   let base_path_input =
-    Env_config_core.base_path_raw_opt ()
-    |> Option.value ~default:config.workspace_path
+    Env_config_core.base_path_raw_opt () |> Option.value ~default:config.workspace_path
   in
   let prompt_markdown_dir =
     Prompt_registry.get_markdown_dir () |> Option.value ~default:""
@@ -387,8 +425,7 @@ let runtime_resolution_json (config : Coord.config) =
   in
   let source_mismatch =
     match runtime_commit, server_repo_commit, workspace_commit with
-    | Some runtime, Some server_repo, _ ->
-        not (String.equal runtime server_repo)
+    | Some runtime, Some server_repo, _ -> not (String.equal runtime server_repo)
     | Some runtime, None, Some workspace -> not (String.equal runtime workspace)
     | _ -> false
   in
@@ -398,167 +435,174 @@ let runtime_resolution_json (config : Coord.config) =
   let warnings =
     []
     |> fun acc ->
-    if source_mismatch then
+    if source_mismatch
+    then (
       let runtime = Option.value ~default:"unknown" runtime_commit in
       let source_label, source_commit =
         match server_repo_commit with
-        | Some commit -> ("server repo HEAD", commit)
-        | None ->
-            ("workspace HEAD", Option.value ~default:"unknown" workspace_commit)
+        | Some commit -> "server repo HEAD", commit
+        | None -> "workspace HEAD", Option.value ~default:"unknown" workspace_commit
       in
       Printf.sprintf
-        "Runtime build commit (%s) differs from %s (%s). Rebuild/restart from the intended server worktree."
-        runtime source_label source_commit
-      :: acc
-    else acc
-    |> fun acc ->
-    if prompt_dir_mismatch then
-      (Printf.sprintf
-         "Prompt markdown dir (%s) differs from resolved config root (%s)."
-         prompt_markdown_dir expected_prompt_dir)
-      :: acc
-    else acc
-    |> fun acc ->
-    if signal_count > 0 then
-      (Printf.sprintf
-         "Recent external shutdown signals detected in server logs (%d). Ephemeral agents will not auto-rejoin after these restarts."
-         signal_count)
-      :: acc
-    else acc
-    |> fun acc ->
-    if repair_count > 0 then
-      (Printf.sprintf "Recent room-state repair events detected (%d)." repair_count)
-      :: acc
-    else acc
-    |> fun acc ->
-    if agent_issue_count > 0 then
-      (Printf.sprintf
-         "Recent agent-state compatibility warnings detected (%d)."
-         agent_issue_count)
-      :: acc
-    else acc
-    |> fun acc ->
-    acc
-    |> List.rev
+        "Runtime build commit (%s) differs from %s (%s). Rebuild/restart from the \
+         intended server worktree."
+        runtime
+        source_label
+        source_commit
+      :: acc)
+    else
+      acc
+      |> fun acc ->
+      if prompt_dir_mismatch
+      then
+        Printf.sprintf
+          "Prompt markdown dir (%s) differs from resolved config root (%s)."
+          prompt_markdown_dir
+          expected_prompt_dir
+        :: acc
+      else
+        acc
+        |> fun acc ->
+        if signal_count > 0
+        then
+          Printf.sprintf
+            "Recent external shutdown signals detected in server logs (%d). Ephemeral \
+             agents will not auto-rejoin after these restarts."
+            signal_count
+          :: acc
+        else
+          acc
+          |> fun acc ->
+          if repair_count > 0
+          then
+            Printf.sprintf "Recent room-state repair events detected (%d)." repair_count
+            :: acc
+          else
+            acc
+            |> fun acc ->
+            if agent_issue_count > 0
+            then
+              Printf.sprintf
+                "Recent agent-state compatibility warnings detected (%d)."
+                agent_issue_count
+              :: acc
+            else acc |> fun acc -> acc |> List.rev
   in
   let status = if warnings = [] then "ready" else "warn" in
   `Assoc
-    [
-      ("status", `String status);
-      ("warnings", `List (List.map (fun warning -> `String warning) warnings));
-      ("base_path", path_item_json ~source:"input" base_path_input);
-      ("workspace_path", path_item_json ~source:"workspace" config.workspace_path);
-      ("resolved_base_path", path_item_json ~source:"resolved_base" config.base_path);
-      ("data_root", path_item_json ~source:"runtime_data" (Coord.masc_root_dir config));
-      ("prompt_markdown_dir", path_item_json ~source:"prompt_registry" prompt_markdown_dir);
-      ( "server_repo_path",
-        match server_repo_path with
+    [ "status", `String status
+    ; "warnings", `List (List.map (fun warning -> `String warning) warnings)
+    ; "base_path", path_item_json ~source:"input" base_path_input
+    ; "workspace_path", path_item_json ~source:"workspace" config.workspace_path
+    ; "resolved_base_path", path_item_json ~source:"resolved_base" config.base_path
+    ; "data_root", path_item_json ~source:"runtime_data" (Coord.masc_root_dir config)
+    ; "prompt_markdown_dir", path_item_json ~source:"prompt_registry" prompt_markdown_dir
+    ; ( "server_repo_path"
+      , match server_repo_path with
         | Some path -> path_item_json ~source:"server_binary" path
         | None ->
-            `Assoc
-              [
-                ("path", `Null);
-                ("exists", `Bool false);
-                ("source", `String "server_binary");
-              ] );
-      ( "server_repo_git_commit",
-        Option.fold
-          ~none:`Null
-          ~some:(fun value -> `String value)
-          server_repo_commit );
-      ( "workspace_git_commit",
-        Option.fold ~none:`Null ~some:(fun value -> `String value) workspace_commit
-      );
-      ( "resolved_base_git_commit",
-        Option.fold
-          ~none:`Null
-          ~some:(fun value -> `String value)
-          resolved_base_commit );
-      ("source_mismatch", `Bool source_mismatch);
-      ("diagnostics", diagnostics);
-      ("keeper_runtime", Keeper_runtime_resolved.(current () |> to_yojson));
-      ("build", Build_identity.to_yojson build);
+          `Assoc
+            [ "path", `Null; "exists", `Bool false; "source", `String "server_binary" ] )
+    ; ( "server_repo_git_commit"
+      , Option.fold ~none:`Null ~some:(fun value -> `String value) server_repo_commit )
+    ; ( "workspace_git_commit"
+      , Option.fold ~none:`Null ~some:(fun value -> `String value) workspace_commit )
+    ; ( "resolved_base_git_commit"
+      , Option.fold ~none:`Null ~some:(fun value -> `String value) resolved_base_commit )
+    ; "source_mismatch", `Bool source_mismatch
+    ; "diagnostics", diagnostics
+    ; ("keeper_runtime", Keeper_runtime_resolved.(current () |> to_yojson))
+    ; "build", Build_identity.to_yojson build
     ]
+;;
 
 let dashboard_tools_http_json ?actor (config : Coord.config) : Yojson.Safe.t =
   let ctx : Tool_misc.context =
-    {
-      config;
-      agent_name = Option.value ~default:"dashboard" actor;
-    }
+    { config; agent_name = Option.value ~default:"dashboard" actor }
   in
   `Assoc
-    [
-      ("generated_at", `String (Masc_domain.now_iso ()));
-      ("config_resolution", Config_dir_resolver.(resolve () |> to_json));
-      ("runtime_resolution", runtime_resolution_json config);
-      ( "tool_inventory",
-        Tool_misc.tool_inventory_json ctx ~include_hidden:true
-          ~include_deprecated:true );
-      ( "tool_usage",
-        Tool_unified.summary_report ()
-        |> Tool_usage_log.attach_source_metadata
-             ~masc_root:(Coord.masc_root_dir config) );
+    [ "generated_at", `String (Masc_domain.now_iso ())
+    ; ("config_resolution", Config_dir_resolver.(resolve () |> to_json))
+    ; "runtime_resolution", runtime_resolution_json config
+    ; ( "tool_inventory"
+      , Tool_misc.tool_inventory_json ctx ~include_hidden:true ~include_deprecated:true )
+    ; ( "tool_usage"
+      , Tool_unified.summary_report ()
+        |> Tool_usage_log.attach_source_metadata ~masc_root:(Coord.masc_root_dir config) )
     ]
+;;
 
-type dashboard_perf_row = {
-  benchmark : string;
-  avg_ms : int;
-  p50_ms : int;
-  p95_ms : int;
-  max_ms : int;
-  notes : string;
-}
+type dashboard_perf_row =
+  { benchmark : string
+  ; avg_ms : int
+  ; p50_ms : int
+  ; p95_ms : int
+  ; max_ms : int
+  ; notes : string
+  }
 
-type dashboard_perf_compare_row = {
-  benchmark : string;
-  avg_delta_ms : int;
-  avg_delta_pct : float option;
-  p95_delta_ms : int;
-  p95_delta_pct : float option;
-  max_delta_ms : int;
-  verdict : string;
-}
+type dashboard_perf_compare_row =
+  { benchmark : string
+  ; avg_delta_ms : int
+  ; avg_delta_pct : float option
+  ; p95_delta_ms : int
+  ; p95_delta_pct : float option
+  ; max_delta_ms : int
+  ; verdict : string
+  }
 
 let dedupe_strings values =
   List.fold_left
-    (fun acc value ->
-      if value = "" || List.mem value acc then acc else acc @ [ value ])
-    [] values
+    (fun acc value -> if value = "" || List.mem value acc then acc else acc @ [ value ])
+    []
+    values
+;;
 
 let parse_benchmark_timestamp path =
   let base = Filename.basename path in
   let prefix = "results_" in
   let suffix = ".csv" in
-  if String.length base <= String.length prefix + String.length suffix then None
-  else if not (String.starts_with ~prefix base) || not (Filename.check_suffix base suffix)
+  if String.length base <= String.length prefix + String.length suffix
+  then None
+  else if
+    (not (String.starts_with ~prefix base)) || not (Filename.check_suffix base suffix)
   then None
   else
     Some
-      (String.sub base (String.length prefix)
+      (String.sub
+         base
+         (String.length prefix)
          (String.length base - String.length prefix - String.length suffix))
+;;
 
 let current_worktree_results_dir (config : Coord.config) =
   let cwd = Sys.getcwd () in
   let worktrees_root = Filename.concat config.base_path ".worktrees" in
-  if String.equal cwd worktrees_root then
-    None
-  else if path_descends_from ~root:worktrees_root cwd then
-    let rel = String.sub cwd (String.length worktrees_root + 1)
-        (String.length cwd - String.length worktrees_root - 1) in
+  if String.equal cwd worktrees_root
+  then None
+  else if path_descends_from ~root:worktrees_root cwd
+  then (
+    let rel =
+      String.sub
+        cwd
+        (String.length worktrees_root + 1)
+        (String.length cwd - String.length worktrees_root - 1)
+    in
     let worktree_name =
       match String.index_opt rel '/' with
       | Some i -> String.sub rel 0 i
       | None -> rel
     in
     let worktree_root = Filename.concat worktrees_root worktree_name in
-    Some (Filename.concat worktree_root "benchmarks/results")
+    Some (Filename.concat worktree_root "benchmarks/results"))
   else None
+;;
 
 let display_benchmark_path (config : Coord.config) path =
   match path_relative_to ~root:config.base_path path with
   | Some relative -> relative
   | None -> Filename.basename path
+;;
 
 let benchmark_results_dir_candidates (config : Coord.config) =
   let env_dir =
@@ -567,9 +611,8 @@ let benchmark_results_dir_candidates (config : Coord.config) =
     | some -> some
   in
   let scoped_dirs =
-    [
-      Option.value ~default:"" (current_worktree_results_dir config);
-      Filename.concat config.base_path "benchmarks/results";
+    [ Option.value ~default:"" (current_worktree_results_dir config)
+    ; Filename.concat config.base_path "benchmarks/results"
     ]
   in
   dedupe_strings
@@ -577,187 +620,207 @@ let benchmark_results_dir_candidates (config : Coord.config) =
      | Some dir -> [ dir ]
      | None -> scoped_dirs)
   |> List.filter (fun path -> Sys.file_exists path && Sys.is_directory path)
+;;
 
 let benchmark_result_files results_dir =
   let entries =
-    try Sys.readdir results_dir |> Array.to_list
-    with Sys_error _ -> []
+    try Sys.readdir results_dir |> Array.to_list with
+    | Sys_error _ -> []
   in
   entries
   |> List.filter (fun name ->
-         String.starts_with ~prefix:"results_" name
-         && Filename.check_suffix name ".csv")
+    String.starts_with ~prefix:"results_" name && Filename.check_suffix name ".csv")
   |> List.map (Filename.concat results_dir)
   |> List.filter (fun path -> Sys.file_exists path)
+;;
 
 let latest_file_by_mtime files =
   files
   |> List.filter_map (fun path ->
-         try Some (path, (Unix.stat path).Unix.st_mtime)
-         with Unix.Unix_error _ | Sys_error _ -> None)
+    try Some (path, (Unix.stat path).Unix.st_mtime) with
+    | Unix.Unix_error _ | Sys_error _ -> None)
   |> List.sort (fun (_, left) (_, right) -> Float.compare right left)
   |> List.map fst
   |> list_hd_opt
+;;
 
 let latest_benchmark_result_file (config : Coord.config) =
   benchmark_results_dir_candidates config
   |> List.concat_map benchmark_result_files
   |> latest_file_by_mtime
+;;
 
 let split_csv_row line =
   match String.split_on_char ',' line with
   | benchmark :: avg_ms :: p50_ms :: p95_ms :: max_ms :: notes ->
-      Some
-        ( benchmark,
-          avg_ms,
-          p50_ms,
-          p95_ms,
-          max_ms,
-          String.concat "," notes |> String.trim )
+    Some
+      (benchmark, avg_ms, p50_ms, p95_ms, max_ms, String.concat "," notes |> String.trim)
   | _ -> None
+;;
 
-let int_of_string_opt raw =
-  int_of_string_opt ((String.trim raw))
+let int_of_string_opt raw = int_of_string_opt (String.trim raw)
 
 let load_benchmark_rows path =
   let lines =
-    try Fs_compat.load_file path |> String.split_on_char '\n'
-    with Sys_error _ -> []
+    try Fs_compat.load_file path |> String.split_on_char '\n' with
+    | Sys_error _ -> []
   in
   lines
   |> List.filter_map (fun line ->
-         let trimmed = String.trim line in
-         if trimmed = "" || String.starts_with ~prefix:"benchmark," trimmed then None
-         else
-           match split_csv_row trimmed with
-           | Some (benchmark, avg_ms, p50_ms, p95_ms, max_ms, notes) -> (
-               match
-                 ( int_of_string_opt avg_ms,
-                   int_of_string_opt p50_ms,
-                   int_of_string_opt p95_ms,
-                   int_of_string_opt max_ms )
-               with
-               | Some avg_ms, Some p50_ms, Some p95_ms, Some max_ms ->
-                   Some { benchmark; avg_ms; p50_ms; p95_ms; max_ms; notes }
-               | _ -> None)
-           | None -> None)
+    let trimmed = String.trim line in
+    if trimmed = "" || String.starts_with ~prefix:"benchmark," trimmed
+    then None
+    else (
+      match split_csv_row trimmed with
+      | Some (benchmark, avg_ms, p50_ms, p95_ms, max_ms, notes) ->
+        (match
+           ( int_of_string_opt avg_ms
+           , int_of_string_opt p50_ms
+           , int_of_string_opt p95_ms
+           , int_of_string_opt max_ms )
+         with
+         | Some avg_ms, Some p50_ms, Some p95_ms, Some max_ms ->
+           Some { benchmark; avg_ms; p50_ms; p95_ms; max_ms; notes }
+         | _ -> None)
+      | None -> None))
+;;
 
 let load_benchmark_meta path =
-  if Sys.file_exists path then
-    try Some (Yojson.Safe.from_file path)
-    with Yojson.Json_error _ | Sys_error _ -> None
+  if Sys.file_exists path
+  then (
+    try Some (Yojson.Safe.from_file path) with
+    | Yojson.Json_error _ | Sys_error _ -> None)
   else None
+;;
 
 let note_tags_json notes =
   let tags =
     notes
     |> String.split_on_char ';'
     |> List.filter_map (fun token ->
-           match String.split_on_char '=' token with
-           | [ key; value ] ->
-               let key = String.trim key in
-               let value = String.trim value in
-               if key = "" || value = "" then None else Some (key, `String value)
-           | _ -> None)
+      match String.split_on_char '=' token with
+      | [ key; value ] ->
+        let key = String.trim key in
+        let value = String.trim value in
+        if key = "" || value = "" then None else Some (key, `String value)
+      | _ -> None)
   in
   `Assoc tags
+;;
 
 let dashboard_perf_row_json (row : dashboard_perf_row) =
   `Assoc
-    [
-      ("benchmark", `String row.benchmark);
-      ("avg_ms", `Int row.avg_ms);
-      ("p50_ms", `Int row.p50_ms);
-      ("p95_ms", `Int row.p95_ms);
-      ("max_ms", `Int row.max_ms);
-      ("notes", `String row.notes);
-      ("note_tags", note_tags_json row.notes);
+    [ "benchmark", `String row.benchmark
+    ; "avg_ms", `Int row.avg_ms
+    ; "p50_ms", `Int row.p50_ms
+    ; "p95_ms", `Int row.p95_ms
+    ; "max_ms", `Int row.max_ms
+    ; "notes", `String row.notes
+    ; "note_tags", note_tags_json row.notes
     ]
+;;
 
 let pct_delta ~baseline delta =
-  if baseline = 0 then None
-  else Some ((float_of_int delta /. float_of_int baseline) *. 100.0)
+  if baseline = 0
+  then None
+  else Some (float_of_int delta /. float_of_int baseline *. 100.0)
+;;
 
 let compare_verdict ~avg_delta ~p95_delta =
-  if ((avg_delta > 0 && p95_delta < 0) || (avg_delta < 0 && p95_delta > 0))
-     && (abs avg_delta >= 50 || abs p95_delta >= 50)
+  if
+    ((avg_delta > 0 && p95_delta < 0) || (avg_delta < 0 && p95_delta > 0))
+    && (abs avg_delta >= 50 || abs p95_delta >= 50)
   then "mixed"
-  else if avg_delta >= 50 && p95_delta >= 0 then "regressed"
-  else if p95_delta >= 50 && avg_delta >= 0 then "regressed"
-  else if avg_delta <= -50 && p95_delta <= 0 then "improved"
-  else if p95_delta <= -50 && avg_delta <= 0 then "improved"
+  else if avg_delta >= 50 && p95_delta >= 0
+  then "regressed"
+  else if p95_delta >= 50 && avg_delta >= 0
+  then "regressed"
+  else if avg_delta <= -50 && p95_delta <= 0
+  then "improved"
+  else if p95_delta <= -50 && avg_delta <= 0
+  then "improved"
   else "stable"
+;;
 
 let compare_rows ~baseline ~current =
   current
   |> List.filter_map (fun (row : dashboard_perf_row) ->
-         match List.find_opt (fun (candidate : dashboard_perf_row) ->
-                 String.equal candidate.benchmark row.benchmark) baseline with
-         | None -> None
-         | Some base ->
-             let avg_delta = row.avg_ms - base.avg_ms in
-             let p95_delta = row.p95_ms - base.p95_ms in
-             Some
-               {
-                 benchmark = row.benchmark;
-                 avg_delta_ms = avg_delta;
-                 avg_delta_pct = pct_delta ~baseline:base.avg_ms avg_delta;
-                 p95_delta_ms = p95_delta;
-                 p95_delta_pct = pct_delta ~baseline:base.p95_ms p95_delta;
-                 max_delta_ms = row.max_ms - base.max_ms;
-                 verdict = compare_verdict ~avg_delta ~p95_delta;
-               })
+    match
+      List.find_opt
+        (fun (candidate : dashboard_perf_row) ->
+           String.equal candidate.benchmark row.benchmark)
+        baseline
+    with
+    | None -> None
+    | Some base ->
+      let avg_delta = row.avg_ms - base.avg_ms in
+      let p95_delta = row.p95_ms - base.p95_ms in
+      Some
+        { benchmark = row.benchmark
+        ; avg_delta_ms = avg_delta
+        ; avg_delta_pct = pct_delta ~baseline:base.avg_ms avg_delta
+        ; p95_delta_ms = p95_delta
+        ; p95_delta_pct = pct_delta ~baseline:base.p95_ms p95_delta
+        ; max_delta_ms = row.max_ms - base.max_ms
+        ; verdict = compare_verdict ~avg_delta ~p95_delta
+        })
   |> List.sort (fun left right ->
-         compare
-           (abs right.p95_delta_ms, abs right.avg_delta_ms)
-           (abs left.p95_delta_ms, abs left.avg_delta_ms))
+    compare
+      (abs right.p95_delta_ms, abs right.avg_delta_ms)
+      (abs left.p95_delta_ms, abs left.avg_delta_ms))
+;;
 
 let dashboard_perf_compare_row_json (row : dashboard_perf_compare_row) =
   `Assoc
-    [
-      ("benchmark", `String row.benchmark);
-      ("avg_delta_ms", `Int row.avg_delta_ms);
-      ( "avg_delta_pct",
-        Option.fold ~none:`Null ~some:(fun value -> `Float value) row.avg_delta_pct );
-      ("p95_delta_ms", `Int row.p95_delta_ms);
-      ( "p95_delta_pct",
-        Option.fold ~none:`Null ~some:(fun value -> `Float value) row.p95_delta_pct );
-      ("max_delta_ms", `Int row.max_delta_ms);
-      ("verdict", `String row.verdict);
+    [ "benchmark", `String row.benchmark
+    ; "avg_delta_ms", `Int row.avg_delta_ms
+    ; ( "avg_delta_pct"
+      , Option.fold ~none:`Null ~some:(fun value -> `Float value) row.avg_delta_pct )
+    ; "p95_delta_ms", `Int row.p95_delta_ms
+    ; ( "p95_delta_pct"
+      , Option.fold ~none:`Null ~some:(fun value -> `Float value) row.p95_delta_pct )
+    ; "max_delta_ms", `Int row.max_delta_ms
+    ; "verdict", `String row.verdict
     ]
+;;
 
 let baseline_file_for ~current_file ~meta =
   match meta with
-  | Some json -> (
-      match json_string_field_opt "compare_baseline_file" json with
-      | Some path when Sys.file_exists path -> Some path
-      | _ -> None)
+  | Some json ->
+    (match json_string_field_opt "compare_baseline_file" json with
+     | Some path when Sys.file_exists path -> Some path
+     | _ -> None)
   | None ->
-      let results_dir = Filename.dirname current_file in
-      benchmark_result_files results_dir
-      |> List.filter (fun path -> not (String.equal path current_file))
-      |> latest_file_by_mtime
+    let results_dir = Filename.dirname current_file in
+    benchmark_result_files results_dir
+    |> List.filter (fun path -> not (String.equal path current_file))
+    |> latest_file_by_mtime
+;;
 
 let benchmark_source_json config ~results_dir ~result_file ~meta_file ~baseline_file =
   `Assoc
-    [
-      ("results_dir", `String (display_benchmark_path config results_dir));
-      ("result_file", `String (display_benchmark_path config result_file));
-      ( "meta_file",
-        Option.fold ~none:`Null
+    [ "results_dir", `String (display_benchmark_path config results_dir)
+    ; "result_file", `String (display_benchmark_path config result_file)
+    ; ( "meta_file"
+      , Option.fold
+          ~none:`Null
           ~some:(fun path -> `String (display_benchmark_path config path))
-          meta_file );
-      ( "baseline_file",
-        Option.fold ~none:`Null
+          meta_file )
+    ; ( "baseline_file"
+      , Option.fold
+          ~none:`Null
           ~some:(fun path -> `String (display_benchmark_path config path))
-          baseline_file );
+          baseline_file )
     ]
+;;
 
 let latest_run_json ~result_file ~meta rows =
   let timestamp = parse_benchmark_timestamp result_file in
   let started_at = Option.bind meta (json_string_field_opt "started_at") in
   let pattern = Option.bind meta (json_string_field_opt "pattern") in
-  let iterations = Option.bind meta (fun json -> Safe_ops.json_int_opt "iterations" json) in
+  let iterations =
+    Option.bind meta (fun json -> Safe_ops.json_int_opt "iterations" json)
+  in
   let warmup_iterations =
     Option.bind meta (fun json -> Safe_ops.json_int_opt "warmup_iterations" json)
   in
@@ -765,117 +828,125 @@ let latest_run_json ~result_file ~meta rows =
     Option.bind meta (fun json -> Safe_ops.json_int_opt "session_warmup_iterations" json)
   in
   `Assoc
-    [
-      ("timestamp", Option.fold ~none:`Null ~some:(fun value -> `String value) timestamp);
-      ("started_at", Option.fold ~none:`Null ~some:(fun value -> `String value) started_at);
-      ("pattern", Option.fold ~none:`Null ~some:(fun value -> `String value) pattern);
-      ("iterations", Option.fold ~none:`Null ~some:(fun value -> `Int value) iterations);
-      ("warmup_iterations", Option.fold ~none:`Null ~some:(fun value -> `Int value) warmup_iterations);
-      ( "session_warmup_iterations",
-        Option.fold ~none:`Null ~some:(fun value -> `Int value) session_warmup_iterations );
-      ("benchmark_count", `Int (List.length rows));
+    [ "timestamp", Option.fold ~none:`Null ~some:(fun value -> `String value) timestamp
+    ; "started_at", Option.fold ~none:`Null ~some:(fun value -> `String value) started_at
+    ; "pattern", Option.fold ~none:`Null ~some:(fun value -> `String value) pattern
+    ; "iterations", Option.fold ~none:`Null ~some:(fun value -> `Int value) iterations
+    ; ( "warmup_iterations"
+      , Option.fold ~none:`Null ~some:(fun value -> `Int value) warmup_iterations )
+    ; ( "session_warmup_iterations"
+      , Option.fold ~none:`Null ~some:(fun value -> `Int value) session_warmup_iterations
+      )
+    ; "benchmark_count", `Int (List.length rows)
     ]
+;;
 
 let worst_live_mcp rows =
   rows
   |> List.filter (fun (row : dashboard_perf_row) ->
-         String.starts_with ~prefix:"mcp_" row.benchmark
-         && not (String.equal row.benchmark "mcp_session_init"))
+    String.starts_with ~prefix:"mcp_" row.benchmark
+    && not (String.equal row.benchmark "mcp_session_init"))
   |> List.sort (fun left right -> compare right.p95_ms left.p95_ms)
   |> list_hd_opt
+;;
 
 let row_by_name rows name =
   List.find_opt (fun (row : dashboard_perf_row) -> String.equal row.benchmark name) rows
+;;
 
 let verdict_counts_json rows =
   let counts =
     rows
     |> List.fold_left
          (fun (improved, stable, mixed, regressed) (row : dashboard_perf_compare_row) ->
-           match row.verdict with
-           | "improved" -> (improved + 1, stable, mixed, regressed)
-           | "mixed" -> (improved, stable, mixed + 1, regressed)
-           | "regressed" -> (improved, stable, mixed, regressed + 1)
-           | _ -> (improved, stable + 1, mixed, regressed))
+            match row.verdict with
+            | "improved" -> improved + 1, stable, mixed, regressed
+            | "mixed" -> improved, stable, mixed + 1, regressed
+            | "regressed" -> improved, stable, mixed, regressed + 1
+            | _ -> improved, stable + 1, mixed, regressed)
          (0, 0, 0, 0)
   in
   let improved, stable, mixed, regressed = counts in
   `Assoc
-    [
-      ("improved", `Int improved);
-      ("stable", `Int stable);
-      ("mixed", `Int mixed);
-      ("regressed", `Int regressed);
+    [ "improved", `Int improved
+    ; "stable", `Int stable
+    ; "mixed", `Int mixed
+    ; "regressed", `Int regressed
     ]
+;;
 
 let dashboard_perf_http_json (config : Coord.config) : Yojson.Safe.t =
   match latest_benchmark_result_file config with
   | None ->
-      `Assoc
-        [
-          ("generated_at", `String (Masc_domain.now_iso ()));
-          ("status", `String "empty");
-          ("benchmarks", `List []);
-          ("comparison", `Null);
-          ( "candidate_dirs",
-            `List
-              (benchmark_results_dir_candidates config
-              |> List.map (fun path -> `String (display_benchmark_path config path))) );
-          ("message", `String "No benchmark artifacts found");
-        ]
+    `Assoc
+      [ "generated_at", `String (Masc_domain.now_iso ())
+      ; "status", `String "empty"
+      ; "benchmarks", `List []
+      ; "comparison", `Null
+      ; ( "candidate_dirs"
+        , `List
+            (benchmark_results_dir_candidates config
+             |> List.map (fun path -> `String (display_benchmark_path config path))) )
+      ; "message", `String "No benchmark artifacts found"
+      ]
   | Some result_file ->
-      let results_dir = Filename.dirname result_file in
-      let rows = load_benchmark_rows result_file in
-      let meta_file =
-        let path = Filename.chop_suffix result_file ".csv" ^ ".meta.json" in
-        if Sys.file_exists path then Some path else None
-      in
-      let meta = Option.bind meta_file load_benchmark_meta in
-      let baseline_file = baseline_file_for ~current_file:result_file ~meta in
-      let comparison_rows =
-        match baseline_file with
-        | Some path ->
-            let baseline_rows = load_benchmark_rows path in
-            compare_rows ~baseline:baseline_rows ~current:rows
-        | None -> []
-      in
-      `Assoc
-        [
-          ("generated_at", `String (Masc_domain.now_iso ()));
-          ("status", `String "ok");
-          ( "source",
-            benchmark_source_json config ~results_dir ~result_file ~meta_file
-              ~baseline_file );
-          ("latest_run", latest_run_json ~result_file ~meta rows);
-          ( "highlights",
+    let results_dir = Filename.dirname result_file in
+    let rows = load_benchmark_rows result_file in
+    let meta_file =
+      let path = Filename.chop_suffix result_file ".csv" ^ ".meta.json" in
+      if Sys.file_exists path then Some path else None
+    in
+    let meta = Option.bind meta_file load_benchmark_meta in
+    let baseline_file = baseline_file_for ~current_file:result_file ~meta in
+    let comparison_rows =
+      match baseline_file with
+      | Some path ->
+        let baseline_rows = load_benchmark_rows path in
+        compare_rows ~baseline:baseline_rows ~current:rows
+      | None -> []
+    in
+    `Assoc
+      [ "generated_at", `String (Masc_domain.now_iso ())
+      ; "status", `String "ok"
+      ; ( "source"
+        , benchmark_source_json config ~results_dir ~result_file ~meta_file ~baseline_file
+        )
+      ; "latest_run", latest_run_json ~result_file ~meta rows
+      ; ( "highlights"
+        , `Assoc
+            [ ( "session_init"
+              , Option.fold
+                  ~none:`Null
+                  ~some:dashboard_perf_row_json
+                  (row_by_name rows "mcp_session_init") )
+            ; ( "worst_live_mcp"
+              , Option.fold
+                  ~none:`Null
+                  ~some:dashboard_perf_row_json
+                  (worst_live_mcp rows) )
+            ; ( "runtime_status"
+              , Option.fold
+                  ~none:`Null
+                  ~some:dashboard_perf_row_json
+                  (row_by_name rows "oas_runtime_status") )
+            ; ( "runtime_single"
+              , Option.fold
+                  ~none:`Null
+                  ~some:dashboard_perf_row_json
+                  (row_by_name rows "oas_runtime_single") )
+            ] )
+      ; "benchmarks", `List (List.map dashboard_perf_row_json rows)
+      ; ( "comparison"
+        , match baseline_file with
+          | None -> `Null
+          | Some path ->
             `Assoc
-              [
-                ( "session_init",
-                  Option.fold ~none:`Null ~some:dashboard_perf_row_json
-                    (row_by_name rows "mcp_session_init") );
-                ( "worst_live_mcp",
-                  Option.fold ~none:`Null ~some:dashboard_perf_row_json
-                    (worst_live_mcp rows) );
-                ( "runtime_status",
-                  Option.fold ~none:`Null ~some:dashboard_perf_row_json
-                    (row_by_name rows "oas_runtime_status") );
-                ( "runtime_single",
-                  Option.fold ~none:`Null ~some:dashboard_perf_row_json
-                    (row_by_name rows "oas_runtime_single") );
-              ] );
-          ("benchmarks", `List (List.map dashboard_perf_row_json rows));
-          ( "comparison",
-            match baseline_file with
-            | None -> `Null
-            | Some path ->
-                `Assoc
-                  [
-                    ("baseline_file", `String (display_benchmark_path config path));
-                    ("verdict_counts", verdict_counts_json comparison_rows);
-                    ( "top_changes",
-                      `List
-                        (comparison_rows
-                        |> take 8
-                        |> List.map dashboard_perf_compare_row_json) );
-                  ] );
-        ]
+              [ "baseline_file", `String (display_benchmark_path config path)
+              ; "verdict_counts", verdict_counts_json comparison_rows
+              ; ( "top_changes"
+                , `List
+                    (comparison_rows |> take 8 |> List.map dashboard_perf_compare_row_json)
+                )
+              ] )
+      ]
+;;

--- a/lib/server/server_routes_http_routes_sidecar.ml
+++ b/lib/server/server_routes_http_routes_sidecar.ml
@@ -162,7 +162,7 @@ let sidecar_status_config = function
   | id -> invalid_arg (Printf.sprintf "unknown sidecar id: %s" id)
 ;;
 
-let read_file path = In_channel.with_open_text path In_channel.input_all
+let read_file path = Fs_compat.load_file path
 
 let strip_matching_quotes value =
   let len = String.length value in
@@ -1148,7 +1148,7 @@ let handle_get_config _state request reqd =
             ])
     else (
       let content =
-        try In_channel.with_open_text path In_channel.input_all with
+        try Fs_compat.load_file path with
         | Sys_error _ -> ""
       in
       match Keeper_toml_loader.parse_toml content with

--- a/lib/server/server_startup_takeover.ml
+++ b/lib/server/server_startup_takeover.ml
@@ -137,11 +137,7 @@ let probe_liveness ?(timeout_sec = 3.0) ?(path = Server_health_paths.liveness) p
 ;;
 
 let read_pid_file path =
-  Safe_ops.protect ~default:None (fun () ->
-    let ic = open_in path in
-    Eio_guard.protect
-      ~finally:(fun () -> close_in_noerr ic)
-      (fun () -> Some (In_channel.input_all ic)))
+  Safe_ops.protect ~default:None (fun () -> Some (Fs_compat.load_file path))
 ;;
 
 let parsed_pid path =

--- a/test/test_fs_compat.ml
+++ b/test/test_fs_compat.ml
@@ -316,7 +316,7 @@ let () =
             `Quick
             test_fold_jsonl_lines_streaming_memory
         ; test_case
-            "missing file raises Sys_error"
+            "missing file returns init"
             `Quick
             test_fold_jsonl_lines_missing_file
         ] )

--- a/test/test_fs_compat.ml
+++ b/test/test_fs_compat.ml
@@ -7,42 +7,51 @@
 open Alcotest
 
 let rec rm_rf (path : string) : unit =
-  if Sys.file_exists path then
-    if Sys.is_directory path then begin
-      Sys.readdir path
-      |> Array.iter (fun name -> rm_rf (Filename.concat path name));
-      Unix.rmdir path
-    end else
-      Sys.remove path
+  if Sys.file_exists path
+  then
+    if Sys.is_directory path
+    then (
+      Sys.readdir path |> Array.iter (fun name -> rm_rf (Filename.concat path name));
+      Unix.rmdir path)
+    else Sys.remove path
+;;
 
 let with_tmp_dir (f : string -> unit) : unit =
   let tmp = Filename.temp_file "masc_fs_compat_" ".tmp" in
   Sys.remove tmp;
   Unix.mkdir tmp 0o755;
-  Fun.protect
-    ~finally:(fun () -> rm_rf tmp)
-    (fun () -> f tmp)
+  Fun.protect ~finally:(fun () -> rm_rf tmp) (fun () -> f tmp)
+;;
 
 let test_mkdir_p_creates_nested_dirs () =
   Fs_compat.clear_fs ();
-  with_tmp_dir @@ fun base ->
+  with_tmp_dir
+  @@ fun base ->
   let path = Filename.concat base "a/b/c" in
   Fs_compat.mkdir_p path;
   check bool "created leaf dir" true (Sys.file_exists path && Sys.is_directory path)
+;;
 
 let test_mkdir_p_does_not_shell_inject () =
   Fs_compat.clear_fs ();
-  with_tmp_dir @@ fun base ->
+  with_tmp_dir
+  @@ fun base ->
   let pwned = Filename.concat base "pwned" in
   let dangerous = Filename.concat base ("dir;touch " ^ pwned ^ "/x") in
   Fs_compat.mkdir_p dangerous;
   (* If mkdir_p used a shell (`mkdir -p <path>`), this would create pwned. *)
   check bool "no shell side-effect file created" false (Sys.file_exists pwned);
-  check bool "dangerous path exists" true (Sys.file_exists dangerous && Sys.is_directory dangerous)
+  check
+    bool
+    "dangerous path exists"
+    true
+    (Sys.file_exists dangerous && Sys.is_directory dangerous)
+;;
 
 let test_save_file_atomic_leaves_no_tmp_on_success () =
   Fs_compat.clear_fs ();
-  with_tmp_dir @@ fun base ->
+  with_tmp_dir
+  @@ fun base ->
   let target = Filename.concat base "out.json" in
   (match Fs_compat.save_file_atomic target {|{"ok":true}|} with
    | Ok () -> ()
@@ -52,25 +61,27 @@ let test_save_file_atomic_leaves_no_tmp_on_success () =
   let leftover_tmps =
     Sys.readdir base
     |> Array.to_list
-    |> List.filter (fun n ->
-        String.length n >= 8 && String.sub n 0 8 = ".atomic_")
+    |> List.filter (fun n -> String.length n >= 8 && String.sub n 0 8 = ".atomic_")
   in
   check (list string) "no leftover .atomic_ tmp files" [] leftover_tmps
+;;
 
 let test_save_file_atomic_overwrites_existing () =
   Fs_compat.clear_fs ();
-  with_tmp_dir @@ fun base ->
+  with_tmp_dir
+  @@ fun base ->
   let target = Filename.concat base "out.json" in
   Fs_compat.save_file target "old";
   (match Fs_compat.save_file_atomic target "new" with
    | Ok () -> ()
    | Error msg -> fail msg);
   check string "overwrite succeeded" "new" (Fs_compat.load_file target)
+;;
 
 let with_redirected_stderr (f : unit -> 'a) : 'a * string =
   let tmp = Filename.temp_file "masc_stderr_" ".log" in
   let saved = Unix.dup Unix.stderr in
-  let fd = Unix.openfile tmp [Unix.O_WRONLY; Unix.O_TRUNC] 0o600 in
+  let fd = Unix.openfile tmp [ Unix.O_WRONLY; Unix.O_TRUNC ] 0o600 in
   Unix.dup2 fd Unix.stderr;
   Unix.close fd;
   let result =
@@ -89,11 +100,13 @@ let with_redirected_stderr (f : unit -> 'a) : 'a * string =
     Sys.remove tmp;
     s
   in
-  (result, captured)
+  result, captured
+;;
 
 let test_load_jsonl_diagnostics_counts_malformed_lines () =
   Fs_compat.clear_fs ();
-  with_tmp_dir @@ fun base ->
+  with_tmp_dir
+  @@ fun base ->
   let path = Filename.concat base "broken.jsonl" in
   Fs_compat.save_file path "{\"ok\":1}\nnot-json\n{\"ok\":2}\n";
   let (parsed, malformed), _ =
@@ -101,10 +114,12 @@ let test_load_jsonl_diagnostics_counts_malformed_lines () =
   in
   check int "parsed count" 2 (List.length parsed);
   check int "malformed count" 1 malformed
+;;
 
 let test_load_jsonl_diagnostics_warn_includes_full_path () =
   Fs_compat.clear_fs ();
-  with_tmp_dir @@ fun base ->
+  with_tmp_dir
+  @@ fun base ->
   let path = Filename.concat base "broken.jsonl" in
   Fs_compat.save_file path "garbage\n";
   let _, captured =
@@ -114,163 +129,196 @@ let test_load_jsonl_diagnostics_warn_includes_full_path () =
     let nlen = String.length needle in
     let hlen = String.length hay in
     let rec loop i =
-      if i + nlen > hlen then false
-      else if String.sub hay i nlen = needle then true
+      if i + nlen > hlen
+      then false
+      else if String.sub hay i nlen = needle
+      then true
       else loop (i + 1)
     in
     loop 0
   in
-  check bool "warn message contains full path (not just basename)" true
+  check
+    bool
+    "warn message contains full path (not just basename)"
+    true
     (contains captured path)
+;;
 
 let write_lines path lines =
   let oc = open_out path in
   Fun.protect
     ~finally:(fun () -> close_out_noerr oc)
     (fun () ->
-       List.iter (fun l -> output_string oc l; output_char oc '\n') lines)
+       List.iter
+         (fun l ->
+            output_string oc l;
+            output_char oc '\n')
+         lines)
+;;
 
 let test_fold_jsonl_lines_small () =
-  with_tmp_dir @@ fun base ->
+  with_tmp_dir
+  @@ fun base ->
   let path = Filename.concat base "small.jsonl" in
-  write_lines path [{|{"n":1}|}; {|{"n":2}|}; {|{"n":3}|}];
+  write_lines path [ {|{"n":1}|}; {|{"n":2}|}; {|{"n":3}|} ];
   let total =
     Fs_compat.fold_jsonl_lines
       ~init:0
       ~f:(fun acc ~line_no:_ json ->
-        match json with `Assoc [(_, `Int n)] -> acc + n | _ -> acc)
+        match json with
+        | `Assoc [ (_, `Int n) ] -> acc + n
+        | _ -> acc)
       path
   in
   check int "fold sum" 6 total
+;;
 
 let test_fold_jsonl_lines_skips_blank_and_malformed () =
-  with_tmp_dir @@ fun base ->
+  with_tmp_dir
+  @@ fun base ->
   let path = Filename.concat base "mixed.jsonl" in
-  write_lines path [{|{"n":1}|}; ""; {|not-json|}; {|{"n":2}|}];
+  write_lines path [ {|{"n":1}|}; ""; {|not-json|}; {|{"n":2}|} ];
   let collected = ref [] in
   let (), _stderr =
     with_redirected_stderr (fun () ->
       Fs_compat.fold_jsonl_lines
         ~init:()
-        ~f:(fun () ~line_no:_ json ->
-          collected := json :: !collected)
+        ~f:(fun () ~line_no:_ json -> collected := json :: !collected)
         path)
   in
   let values = List.rev !collected in
   let ns =
     List.map
       (fun json ->
-        match json with
-        | `Assoc [(_, `Int n)] -> n
-        | _ -> -1)
+         match json with
+         | `Assoc [ (_, `Int n) ] -> n
+         | _ -> -1)
       values
   in
   check int "valid line count (blank + malformed skipped)" 2 (List.length ns);
-  check (list int) "extracted values in order" [1; 2] ns
+  check (list int) "extracted values in order" [ 1; 2 ] ns
+;;
 
 let test_fold_jsonl_lines_missing_trailing_newline () =
-  with_tmp_dir @@ fun base ->
+  with_tmp_dir
+  @@ fun base ->
   let path = Filename.concat base "no_trailing.jsonl" in
   let oc = open_out path in
   Fun.protect
     ~finally:(fun () -> close_out_noerr oc)
     (fun () ->
-      output_string oc {|{"n":1}|};
-      output_char oc '\n';
-      output_string oc {|{"n":2}|});
+       output_string oc {|{"n":1}|};
+       output_char oc '\n';
+       output_string oc {|{"n":2}|});
   let total =
     Fs_compat.fold_jsonl_lines
       ~init:0
       ~f:(fun acc ~line_no:_ json ->
-        match json with `Assoc [(_, `Int n)] -> acc + n | _ -> acc)
+        match json with
+        | `Assoc [ (_, `Int n) ] -> acc + n
+        | _ -> acc)
       path
   in
   check int "no-trailing-newline reads last line" 3 total
+;;
 
 let test_fold_jsonl_lines_streaming_memory () =
-  with_tmp_dir @@ fun base ->
+  with_tmp_dir
+  @@ fun base ->
   let path = Filename.concat base "big.jsonl" in
   let oc = open_out path in
   Fun.protect
     ~finally:(fun () -> close_out_noerr oc)
     (fun () ->
-      for i = 1 to 10_000 do
-        output_string oc (Printf.sprintf "{\"n\":%d}\n" i)
-      done);
+       for i = 1 to 10_000 do
+         output_string oc (Printf.sprintf "{\"n\":%d}\n" i)
+       done);
   Gc.compact ();
   let total =
     Fs_compat.fold_jsonl_lines
       ~init:0
       ~f:(fun acc ~line_no:_ json ->
-        match json with `Assoc [(_, `Int n)] -> acc + n | _ -> acc)
+        match json with
+        | `Assoc [ (_, `Int n) ] -> acc + n
+        | _ -> acc)
       path
   in
   Gc.compact ();
-  let live_after_bytes =
-    (Gc.stat ()).Gc.live_words * (Sys.word_size / 8)
-  in
+  let live_after_bytes = (Gc.stat ()).Gc.live_words * (Sys.word_size / 8) in
   check int "fold all 10k entries" 50_005_000 total;
   (* Streaming guarantee: post-fold heap stays bounded.  The 10k-line
      file is ~100 KB on disk; allow 4x slack for test harness overhead
      so this catches a regression (e.g. accidentally retaining a list
      of all 10k JSON nodes) without being flaky. *)
   let bound = 4 * 1024 * 1024 in
-  check bool
+  check
+    bool
     (Printf.sprintf "post-fold heap < 4 MB (was %d bytes)" live_after_bytes)
-    true (live_after_bytes < bound)
+    true
+    (live_after_bytes < bound)
+;;
 
 let test_fold_jsonl_lines_missing_file () =
-  with_tmp_dir @@ fun base ->
+  with_tmp_dir
+  @@ fun base ->
   let path = Filename.concat base "does_not_exist.jsonl" in
   let result =
-    Fs_compat.fold_jsonl_lines
-      ~init:0
-      ~f:(fun acc ~line_no:_ _json -> acc + 1)
-      path
+    Fs_compat.fold_jsonl_lines ~init:0 ~f:(fun acc ~line_no:_ _json -> acc + 1) path
   in
   (* Consistent with [load_jsonl]: missing file returns [init] silently
      rather than raising. *)
   check int "missing file returns init" 0 result
+;;
 
 let () =
-  Eio_main.run @@ fun env ->
+  Eio_main.run
+  @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
   Eio_guard.enable ();
-  run "fs_compat" [
-    ( "mkdir_p"
-    , [
-        test_case "creates nested dirs" `Quick test_mkdir_p_creates_nested_dirs;
-        test_case "no shell injection" `Quick test_mkdir_p_does_not_shell_inject;
-      ]
-    );
-    ( "save_file_atomic"
-    , [
-        test_case "leaves no .atomic_ tmp on success" `Quick
-          test_save_file_atomic_leaves_no_tmp_on_success;
-        test_case "overwrites existing target" `Quick
-          test_save_file_atomic_overwrites_existing;
-      ]
-    );
-    ( "load_jsonl_diagnostics"
-    , [
-        test_case "counts malformed lines" `Quick
-          test_load_jsonl_diagnostics_counts_malformed_lines;
-        test_case "warn includes full path" `Quick
-          test_load_jsonl_diagnostics_warn_includes_full_path;
-      ]
-    );
-    ( "fold_jsonl_lines"
-    , [
-        test_case "small fold sum" `Quick test_fold_jsonl_lines_small;
-        test_case "skips blank, surfaces line_no" `Quick
-          test_fold_jsonl_lines_skips_blank_and_malformed;
-        test_case "missing trailing newline" `Quick
-          test_fold_jsonl_lines_missing_trailing_newline;
-        test_case "10k lines stays streaming" `Quick
-          test_fold_jsonl_lines_streaming_memory;
-        test_case "missing file raises Sys_error" `Quick
-          test_fold_jsonl_lines_missing_file;
-      ]
-    );
-  ]
-
+  run
+    "fs_compat"
+    [ ( "mkdir_p"
+      , [ test_case "creates nested dirs" `Quick test_mkdir_p_creates_nested_dirs
+        ; test_case "no shell injection" `Quick test_mkdir_p_does_not_shell_inject
+        ] )
+    ; ( "save_file_atomic"
+      , [ test_case
+            "leaves no .atomic_ tmp on success"
+            `Quick
+            test_save_file_atomic_leaves_no_tmp_on_success
+        ; test_case
+            "overwrites existing target"
+            `Quick
+            test_save_file_atomic_overwrites_existing
+        ] )
+    ; ( "load_jsonl_diagnostics"
+      , [ test_case
+            "counts malformed lines"
+            `Quick
+            test_load_jsonl_diagnostics_counts_malformed_lines
+        ; test_case
+            "warn includes full path"
+            `Quick
+            test_load_jsonl_diagnostics_warn_includes_full_path
+        ] )
+    ; ( "fold_jsonl_lines"
+      , [ test_case "small fold sum" `Quick test_fold_jsonl_lines_small
+        ; test_case
+            "skips blank, surfaces line_no"
+            `Quick
+            test_fold_jsonl_lines_skips_blank_and_malformed
+        ; test_case
+            "missing trailing newline"
+            `Quick
+            test_fold_jsonl_lines_missing_trailing_newline
+        ; test_case
+            "10k lines stays streaming"
+            `Quick
+            test_fold_jsonl_lines_streaming_memory
+        ; test_case
+            "missing file raises Sys_error"
+            `Quick
+            test_fold_jsonl_lines_missing_file
+        ] )
+    ]
+;;

--- a/test/test_fs_compat.ml
+++ b/test/test_fs_compat.ml
@@ -123,6 +123,115 @@ let test_load_jsonl_diagnostics_warn_includes_full_path () =
   check bool "warn message contains full path (not just basename)" true
     (contains captured path)
 
+let write_lines path lines =
+  let oc = open_out path in
+  Fun.protect
+    ~finally:(fun () -> close_out_noerr oc)
+    (fun () ->
+       List.iter (fun l -> output_string oc l; output_char oc '\n') lines)
+
+let test_fold_jsonl_lines_small () =
+  with_tmp_dir @@ fun base ->
+  let path = Filename.concat base "small.jsonl" in
+  write_lines path [{|{"n":1}|}; {|{"n":2}|}; {|{"n":3}|}];
+  let total =
+    Fs_compat.fold_jsonl_lines
+      ~init:0
+      ~f:(fun acc ~line_no:_ json ->
+        match json with `Assoc [(_, `Int n)] -> acc + n | _ -> acc)
+      path
+  in
+  check int "fold sum" 6 total
+
+let test_fold_jsonl_lines_skips_blank_and_malformed () =
+  with_tmp_dir @@ fun base ->
+  let path = Filename.concat base "mixed.jsonl" in
+  write_lines path [{|{"n":1}|}; ""; {|not-json|}; {|{"n":2}|}];
+  let collected = ref [] in
+  let (), _stderr =
+    with_redirected_stderr (fun () ->
+      Fs_compat.fold_jsonl_lines
+        ~init:()
+        ~f:(fun () ~line_no:_ json ->
+          collected := json :: !collected)
+        path)
+  in
+  let values = List.rev !collected in
+  let ns =
+    List.map
+      (fun json ->
+        match json with
+        | `Assoc [(_, `Int n)] -> n
+        | _ -> -1)
+      values
+  in
+  check int "valid line count (blank + malformed skipped)" 2 (List.length ns);
+  check (list int) "extracted values in order" [1; 2] ns
+
+let test_fold_jsonl_lines_missing_trailing_newline () =
+  with_tmp_dir @@ fun base ->
+  let path = Filename.concat base "no_trailing.jsonl" in
+  let oc = open_out path in
+  Fun.protect
+    ~finally:(fun () -> close_out_noerr oc)
+    (fun () ->
+      output_string oc {|{"n":1}|};
+      output_char oc '\n';
+      output_string oc {|{"n":2}|});
+  let total =
+    Fs_compat.fold_jsonl_lines
+      ~init:0
+      ~f:(fun acc ~line_no:_ json ->
+        match json with `Assoc [(_, `Int n)] -> acc + n | _ -> acc)
+      path
+  in
+  check int "no-trailing-newline reads last line" 3 total
+
+let test_fold_jsonl_lines_streaming_memory () =
+  with_tmp_dir @@ fun base ->
+  let path = Filename.concat base "big.jsonl" in
+  let oc = open_out path in
+  Fun.protect
+    ~finally:(fun () -> close_out_noerr oc)
+    (fun () ->
+      for i = 1 to 10_000 do
+        output_string oc (Printf.sprintf "{\"n\":%d}\n" i)
+      done);
+  Gc.compact ();
+  let total =
+    Fs_compat.fold_jsonl_lines
+      ~init:0
+      ~f:(fun acc ~line_no:_ json ->
+        match json with `Assoc [(_, `Int n)] -> acc + n | _ -> acc)
+      path
+  in
+  Gc.compact ();
+  let live_after_bytes =
+    (Gc.stat ()).Gc.live_words * (Sys.word_size / 8)
+  in
+  check int "fold all 10k entries" 50_005_000 total;
+  (* Streaming guarantee: post-fold heap stays bounded.  The 10k-line
+     file is ~100 KB on disk; allow 4x slack for test harness overhead
+     so this catches a regression (e.g. accidentally retaining a list
+     of all 10k JSON nodes) without being flaky. *)
+  let bound = 4 * 1024 * 1024 in
+  check bool
+    (Printf.sprintf "post-fold heap < 4 MB (was %d bytes)" live_after_bytes)
+    true (live_after_bytes < bound)
+
+let test_fold_jsonl_lines_missing_file () =
+  with_tmp_dir @@ fun base ->
+  let path = Filename.concat base "does_not_exist.jsonl" in
+  let result =
+    Fs_compat.fold_jsonl_lines
+      ~init:0
+      ~f:(fun acc ~line_no:_ _json -> acc + 1)
+      path
+  in
+  (* Consistent with [load_jsonl]: missing file returns [init] silently
+     rather than raising. *)
+  check int "missing file returns init" 0 result
+
 let () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
@@ -148,6 +257,19 @@ let () =
           test_load_jsonl_diagnostics_counts_malformed_lines;
         test_case "warn includes full path" `Quick
           test_load_jsonl_diagnostics_warn_includes_full_path;
+      ]
+    );
+    ( "fold_jsonl_lines"
+    , [
+        test_case "small fold sum" `Quick test_fold_jsonl_lines_small;
+        test_case "skips blank, surfaces line_no" `Quick
+          test_fold_jsonl_lines_skips_blank_and_malformed;
+        test_case "missing trailing newline" `Quick
+          test_fold_jsonl_lines_missing_trailing_newline;
+        test_case "10k lines stays streaming" `Quick
+          test_fold_jsonl_lines_streaming_memory;
+        test_case "missing file raises Sys_error" `Quick
+          test_fold_jsonl_lines_missing_file;
       ]
     );
   ]


### PR DESCRIPTION
## Summary

OCaml 5.x 활용 leverage gap 두 가지를 한 PR 로 닫음:

### 1. Streaming JSONL reader (`Fs_compat.fold_jsonl_lines`)

`Eio.Path.with_open_in` + `Eio.Buf_read.lines` 위에 line-streaming fold API 도입. global Eio fs (`server_runtime_bootstrap.ml:305` 가 boot 시 등록) 활성 시 O(1) resident memory + non-blocking. fallback 은 기존 `load_jsonl` + `List.fold_left` (test/pre-boot).

기존 패턴 (`open_in` + `input_line` 루프 + ref accumulator) 은 매 syscall 마다 Eio scheduler stall + 전체 entry list 적재 후 return. 2 callsite 마이그레이션:
- `model_inference_metrics.read_telemetry_entries` (telemetry JSONL 디렉토리 fold)
- `model_inference_metrics.read_cost_entries_legacy` (costs.jsonl)

### 2. HTTP route 의 bare `In_channel.*` → `Fs_compat.load_file`

HTTP request handler 안에서 `In_channel.with_open_text path In_channel.input_all` 직접 호출이 같은 Domain 의 모든 fiber stall. `Fs_compat.load_file` 는 이미 Eio-aware — 단순 치환으로 즉시 non-blocking. 5 callsite:

| 파일 | LOC delta |
|---|---|
| `lib/server/server_routes_http_routes_sidecar.ml:165` (read_file helper) | -1/+1 |
| `lib/server/server_routes_http_routes_sidecar.ml:1151` (inline) | -1/+1 |
| `lib/server/server_dashboard_http_runtime_info.ml:624` (benchmark CSV) | -1/+1 |
| `lib/dashboard_tla_specs.ml:145` (read_file_safe simplify) | -10/+3 |
| `lib/server/server_startup_takeover.ml:144` (PID file) | -5/+1 |

## 사전 베스트 프랙티스 리서치 (출처: eio 1.2 docs, ocaml-multicore/eio multicore.md)

- `Eio.Path.load` vs `with_open_in`: 전체 string 적재 vs lazy flow. JSONL line streaming = `with_open_in`.
- `Eio.Buf_read.lines` 은 `string Seq.t`, lazy, non-buffering.
- global fs Atomic.t 보호 — cross-domain safe (`Fs_compat.global_fs : ... Atomic.t`).
- `with_fs_or_fallback` 패턴 = `Stdlib.Effect.Unhandled` 잡아 non-Eio context graceful fallback. masc-mcp 표준.

## Test plan

- [x] `dune build --root . @check`: PASS (full type-check)
- [x] `dune exec test/test_fs_compat.exe`: **11/11 PASS** (5 신규 streaming 케이스 + 6 기존)
  - small fold sum
  - blank + malformed line skip 검증
  - trailing-newline-less file 처리
  - 10k-line streaming heap bound (post-fold < 4 MB)
  - missing file → init 반환 (load_jsonl 일관성)
- [x] `dune exec test/test_model_inference_metrics.exe`: **32/32 PASS** (마이그레이션 회귀 검증)

## 후속 (별도 PR)

- PR-B: RFC-0059 PR-7-pilot — keeper supervisor Domain_pool migration (parallelism axis)
- PR-C: `repo_manager/credential_materializer.ml` 3 site + `coord_lifecycle.ml:19` 동일 패턴 확장
- PR-D: HTTP response side (cohttp-eio body streaming) audit

RFC-WAIVED: 본 PR 은 `fs_compat` + HTTP route hot path 정리. 영향 subsystem 이 `keeper_sandbox`, `credential_*`, `operator_control`, dashboard credential, Claude hooks, workflow 문서 모두 해당 없음 → RFC 발견 체크 트리거 X (메타-RFC 불필요).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
