### PR TITLE
refactor(agent-stress): typed error_kind — private-string wrapper → closed sum (9 SDK variants)

### DIFF
--- a/lib/agent_stress.ml
+++ b/lib/agent_stress.ml
@@ -23,11 +23,43 @@ module Random = Stdlib.Random
 (* Types                                                            *)
 (* ================================================================ *)
 
-type error_kind = Error_kind of string
+(* Closed sum mirroring [Agent_sdk.Error.sdk_error]'s 9 constructors.
+   The sole producer ([Keeper_turn_cascade_budget.sdk_error_kind])
+   pattern-matches the SDK tag, so the producer surface is bounded by
+   the SDK type itself. *)
+type error_kind =
+  | Ek_api
+  | Ek_agent
+  | Ek_mcp
+  | Ek_config
+  | Ek_serialization
+  | Ek_io
+  | Ek_orchestration
+  | Ek_a2a
+  | Ek_internal
 
-let error_kind_of_string value = Error_kind value
+let error_kind_to_string = function
+  | Ek_api -> "api"
+  | Ek_agent -> "agent"
+  | Ek_mcp -> "mcp"
+  | Ek_config -> "config"
+  | Ek_serialization -> "serialization"
+  | Ek_io -> "io"
+  | Ek_orchestration -> "orchestration"
+  | Ek_a2a -> "a2a"
+  | Ek_internal -> "internal"
 
-let error_kind_to_string (Error_kind value) = value
+let error_kind_of_string = function
+  | "api" -> Some Ek_api
+  | "agent" -> Some Ek_agent
+  | "mcp" -> Some Ek_mcp
+  | "config" -> Some Ek_config
+  | "serialization" -> Some Ek_serialization
+  | "io" -> Some Ek_io
+  | "orchestration" -> Some Ek_orchestration
+  | "a2a" -> Some Ek_a2a
+  | "internal" -> Some Ek_internal
+  | _ -> None
 
 type stress_kind =
   | Failure_streak of int

--- a/lib/agent_stress.mli
+++ b/lib/agent_stress.mli
@@ -27,14 +27,31 @@ module Random = Stdlib.Random
 
     @since RFC-0001 Gate A *)
 
-(** Coarse error family attached to turn-failure stress events. *)
-type error_kind = private Error_kind of string
+(** Coarse SDK error family attached to a [Turn_failure]. Closed set
+    mirroring [Agent_sdk.Error.sdk_error]'s 9 constructors — the single
+    producer in [keeper_turn_cascade_budget.sdk_error_kind] exhaustively
+    matches the SDK error tag, so the value space is bounded.
 
-val error_kind_of_string : string -> error_kind
-(** Convert a wire/log label into an internal error-kind value. *)
+    Wire form is the lowercase string via [error_kind_to_string]
+    (byte-compatible with the previous private-string wrapper). *)
+type error_kind =
+  | Ek_api
+  | Ek_agent
+  | Ek_mcp
+  | Ek_config
+  | Ek_serialization
+  | Ek_io
+  | Ek_orchestration
+  | Ek_a2a
+  | Ek_internal
+
+val error_kind_of_string : string -> error_kind option
+(** Parse a wire label. [None] on unknown so write-only JSON paths fail
+    closed instead of round-tripping arbitrary strings
+    (CLAUDE.md anti-pattern #2: Unknown → Permissive Default). *)
 
 val error_kind_to_string : error_kind -> string
-(** Convert an internal error-kind value back to the public wire label. *)
+(** Convert to the public wire label. *)
 
 (** Stress event kinds -- each maps to a measurable condition. *)
 type stress_kind =

--- a/lib/keeper/keeper_turn_cascade_budget.ml
+++ b/lib/keeper/keeper_turn_cascade_budget.ml
@@ -63,16 +63,17 @@ let next_fail_open_cascade_for_turn
     ~base_cascade ~effective_cascade ~tool_requirement
     ~attempted_cascades err
 
-let sdk_error_kind = function
-  | Agent_sdk.Error.Api _ -> "api"
-  | Agent_sdk.Error.Agent _ -> "agent"
-  | Agent_sdk.Error.Mcp _ -> "mcp"
-  | Agent_sdk.Error.Config _ -> "config"
-  | Agent_sdk.Error.Serialization _ -> "serialization"
-  | Agent_sdk.Error.Io _ -> "io"
-  | Agent_sdk.Error.Orchestration _ -> "orchestration"
-  | Agent_sdk.Error.A2a _ -> "a2a"
-  | Agent_sdk.Error.Internal _ -> "internal"
+let sdk_error_kind : Agent_sdk.Error.sdk_error -> Agent_stress.error_kind =
+  function
+  | Agent_sdk.Error.Api _ -> Ek_api
+  | Agent_sdk.Error.Agent _ -> Ek_agent
+  | Agent_sdk.Error.Mcp _ -> Ek_mcp
+  | Agent_sdk.Error.Config _ -> Ek_config
+  | Agent_sdk.Error.Serialization _ -> Ek_serialization
+  | Agent_sdk.Error.Io _ -> Ek_io
+  | Agent_sdk.Error.Orchestration _ -> Ek_orchestration
+  | Agent_sdk.Error.A2a _ -> Ek_a2a
+  | Agent_sdk.Error.Internal _ -> Ek_internal
 
 let record_turn_failure_stress
     ~(meta : keeper_meta)
@@ -95,7 +96,7 @@ let record_turn_failure_stress
         threshold;
         counted_toward_crash = not is_auto_recoverable;
         recoverable = is_auto_recoverable;
-        error_kind = Some (Agent_stress.error_kind_of_string (sdk_error_kind err));
+        error_kind = Some (sdk_error_kind err);
       };
     timestamp = Unix.gettimeofday ();
   }

--- a/lib/keeper/keeper_turn_cascade_budget.mli
+++ b/lib/keeper/keeper_turn_cascade_budget.mli
@@ -32,7 +32,7 @@ val next_fail_open_cascade_for_turn :
   Agent_sdk.Error.sdk_error ->
   EC.degraded_retry option
 
-val sdk_error_kind : Agent_sdk.Error.sdk_error -> string
+val sdk_error_kind : Agent_sdk.Error.sdk_error -> Agent_stress.error_kind
 
 val record_turn_failure_stress :
   meta:keeper_meta ->
@@ -48,7 +48,7 @@ val oas_timeout_guard_sec : float
 val min_oas_timeout_budget_sec : float
 (** Minimum OAS timeout budget (seconds). *)
 
-val sdk_error_kind : Agent_sdk.Error.sdk_error -> string
+val sdk_error_kind : Agent_sdk.Error.sdk_error -> Agent_stress.error_kind
 
 type oas_timeout_budget_resolution = {
   effective_timeout_sec : float;

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -606,7 +606,7 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
             ~trajectory_outcome:(Trajectory.Failed terminal_reason_code)
             ~error_kind:
               (Keeper_execution_receipt.error_kind_of_string
-                 (sdk_error_kind err))
+                 (Agent_stress.error_kind_to_string (sdk_error_kind err)))
             ~error_message
             ~keeper_turn_id
             ();
@@ -615,7 +615,7 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
             ~prev:Keeper_turn_fsm.Cascade_routing
             (Keeper_turn_fsm.Failed
                (Keeper_turn_fsm.Failure_provider_error
-                  { kind = sdk_error_kind err;
+                  { kind = Agent_stress.error_kind_to_string (sdk_error_kind err);
                     detail = error_message }));
           Error err
       | Ok initial_execution ->
@@ -917,7 +917,7 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
             error_kind =
               Some
                 (Keeper_execution_receipt.error_kind_of_string
-                   (sdk_error_kind err));
+                   (Agent_stress.error_kind_to_string (sdk_error_kind err)));
             error_message = Some (Agent_sdk.Error.to_string err);
             recorded_at = now_iso ();
           }
@@ -1907,7 +1907,7 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
             ~prev:Keeper_turn_fsm.Streaming
             (Keeper_turn_fsm.Failed
                (Keeper_turn_fsm.Failure_provider_error
-                  { kind = sdk_error_kind err;
+                  { kind = Agent_stress.error_kind_to_string (sdk_error_kind err);
                     detail = short_preview e_str }));
           Log.Keeper.error
             "%s: keeper cycle FAILED cascade=%s max_context=%d context_budget=%d primary_budget=%d requested_override=%s latency=%dms%s error=%s"

--- a/test/test_agent_stress.ml
+++ b/test/test_agent_stress.ml
@@ -20,7 +20,7 @@ let test_turn_failure_json_contract () =
           threshold = 3;
           counted_toward_crash = true;
           recoverable = false;
-          error_kind = Some (Stress.error_kind_of_string "api");
+          error_kind = Some Stress.Ek_api;
         };
       timestamp = 1_777_120_045.0;
     }

--- a/test/test_dashboard_o5_feeds.ml
+++ b/test/test_dashboard_o5_feeds.ml
@@ -41,7 +41,7 @@ let test_agent_stress_feed_exposes_board_rows () =
             ; threshold = 4
             ; counted_toward_crash = true
             ; recoverable = false
-            ; error_kind = Some (Agent_stress.error_kind_of_string "api")
+            ; error_kind = Some Agent_stress.Ek_api
             }
       ; timestamp = 99.0
       }


### PR DESCRIPTION
## Summary

Track A typed-enum sweep — fourth application of `private X of string` → closed sum. This module's `error_kind` is bounded by `Agent_sdk.Error.sdk_error`'s 9 constructors:

| Variant | Wire |
|---|---|
| `Ek_api` | `api` |
| `Ek_agent` | `agent` |
| `Ek_mcp` | `mcp` |
| `Ek_config` | `config` |
| `Ek_serialization` | `serialization` |
| `Ek_io` | `io` |
| `Ek_orchestration` | `orchestration` |
| `Ek_a2a` | `a2a` |
| `Ek_internal` | `internal` |

## Producer becomes typed

`Keeper_turn_cascade_budget.sdk_error_kind` previously returned `string` and was wrapped with `Agent_stress.error_kind_of_string` at the call site. Now it returns `Agent_stress.error_kind` directly — the SDK pattern-match is exhaustive, so adding a new SDK constructor surfaces as a compile error at the projection.

## Boundary stringification (deliberate)

Three sites in `keeper_unified_turn.ml` bridge through `Agent_stress.error_kind_to_string` because their consumers (`Keeper_execution_receipt.error_kind`, `Keeper_turn_fsm.Failure_provider_error.kind`) are themselves still `private Error_kind of string` wrappers. Closing each of those is a follow-up PR in the 8-wrapper sweep — see CLAUDE.md §N-of-M Patch for why incremental closure beats a single mega-PR.

## Fail-closed JSON read

`error_kind_of_string` now returns `option` (was `string -> error_kind`). Unknown labels deserialize to `None` rather than collapsing into `Some (Error_kind s)`.

## Stack

Based on #14701 (`feat/tool-assignment-error-kind-typed`) → #14699 → #14696.

## Test plan

- [x] `dune build --root . @check` clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)