### PR TITLE
refactor(cascade): Http_probe uses explicit URL registry (kill :11434 substring scan)

### DIFF
--- a/lib/cascade/cascade_http_probe.ml
+++ b/lib/cascade/cascade_http_probe.ml
@@ -4,8 +4,42 @@
 
 (* Re-export the shared heuristic from [Masc_network_defaults].  Keeping
    the symbol here preserves this module's public [.mli] surface while
-   eliminating the substring literal duplicated across cascade modules. *)
+   eliminating the substring literal duplicated across cascade modules.
+
+   Substring-scan classification is unreliable: a vLLM server on :11434
+   matches; an ollama on a non-default port does not. The probe's
+   [Http_probe] adapter therefore consults an explicit registry instead
+   (see [registered_urls] below); [is_ollama_url] survives only as a
+   transitional helper for legacy callers in other modules. *)
 let is_ollama_url = Masc_network_defaults.is_ollama_url
+
+(* ── Explicit URL registry (replaces substring scan inside this module) ───
+   Probes only fire against URLs that callers have explicitly registered,
+   eliminating the [:11434] substring heuristic's false positives. The
+   default ollama URL is registered at module load to preserve
+   out-of-the-box behaviour for the canonical local deployment. *)
+let registered_urls : (string, unit) Hashtbl.t = Hashtbl.create 4
+let registry_mutex = Eio.Mutex.create ()
+
+let register_url ~url =
+  Eio.Mutex.use_rw ~protect:false registry_mutex (fun () ->
+    Hashtbl.replace registered_urls url ())
+;;
+
+let is_registered ~url =
+  Eio.Mutex.use_ro registry_mutex (fun () -> Hashtbl.mem registered_urls url)
+;;
+
+let registered_count () =
+  Eio.Mutex.use_ro registry_mutex (fun () -> Hashtbl.length registered_urls)
+;;
+
+let registry_clear () =
+  Eio.Mutex.use_rw ~protect:false registry_mutex (fun () ->
+    Hashtbl.clear registered_urls)
+;;
+
+let () = register_url ~url:Masc_network_defaults.ollama_default_url
 
 (* ── Cache ──────────────────────────────────────────────────── *)
 
@@ -146,7 +180,7 @@ let refresh_many ~sw ~net ?timeout_s urls =
   in
   List.iter
     (fun url ->
-       if is_ollama_url url
+       if is_registered ~url
        then (
          match cached_capacity url with
          | Some _ -> () (* still fresh, skip *)
@@ -163,7 +197,7 @@ let refresh_many ~sw ~net ?timeout_s urls =
    [Cascade_capacity_probe.Probe] without an explicit annotation,
    avoiding a circular dependency between the two compilation units. *)
 module Http_probe = struct
-  let can_probe ~url = is_ollama_url url
+  let can_probe ~url = is_registered ~url
 
   let probe ~sw ~net ~url ?timeout_s () =
     match timeout_s with

--- a/lib/cascade/cascade_http_probe.mli
+++ b/lib/cascade/cascade_http_probe.mli
@@ -32,8 +32,35 @@
 (** [is_ollama_url url] mirrors the heuristic in
     {!Cascade_client_capacity.looks_like_ollama}: any URL whose
     host:port substring contains [:11434].  Re-exported here so
-    callers do not have to depend on both modules. *)
+    callers do not have to depend on both modules.
+
+    Prefer {!register_url} + {!is_registered} for new code: substring
+    matching misclassifies non-ollama servers running on :11434 and
+    misses ollama servers on non-default ports.  The {!Http_probe}
+    adapter no longer consults this function — it uses the registry
+    below. *)
 val is_ollama_url : string -> bool
+
+(** {1 Explicit URL registry}
+
+    The {!Http_probe} adapter only fires against URLs that callers
+    have explicitly registered.
+    {!Masc_network_defaults.ollama_default_url} is registered at
+    module load so the default deployment works without ceremony;
+    other URLs (custom ports, remote tunnels) must be registered by
+    a caller that already knows the URL is ollama-native. *)
+
+(** [register_url ~url] adds [url] to the probe registry.  Idempotent. *)
+val register_url : url:string -> unit
+
+(** [is_registered ~url] reports whether [url] has been registered. *)
+val is_registered : url:string -> bool
+
+(** Number of registered URLs.  Test helper. *)
+val registered_count : unit -> int
+
+(** Empty the URL registry.  Test helper. *)
+val registry_clear : unit -> unit
 
 (** {1 Cache lookup (synchronous, IO-free)} *)
 

--- a/test/test_cascade_http_probe.ml
+++ b/test/test_cascade_http_probe.ml
@@ -117,11 +117,53 @@ let test_cache_size_after_clear () =
    cache_size after a manual store:  not exposed publicly, so just
    verify the empty/clear lifecycle here. *)
 
+(* ── Explicit URL registry — Http_probe.can_probe no longer uses
+   substring scan. Proves three invariants kept across the migration:
+   - default URL works without explicit register (module-load side-effect)
+   - non-:11434 ollama URL still probeable once registered
+   - substring-only matches (vLLM on :11434) are rejected unless
+     the caller has explicitly registered them. *)
+
+let test_default_url_registered_at_load () =
+  check bool "ollama_default_url registered on module load" true
+    (P.is_registered ~url:Masc_network_defaults.ollama_default_url);
+  check bool "Http_probe.can_probe accepts default url" true
+    (P.Http_probe.can_probe ~url:Masc_network_defaults.ollama_default_url)
+
+let test_register_url_non_default_port () =
+  let url = "http://127.0.0.1:51234" in
+  check bool "non-default url not auto-registered" false
+    (P.is_registered ~url);
+  P.register_url ~url;
+  check bool "registered after explicit call" true (P.is_registered ~url);
+  check bool "Http_probe.can_probe accepts registered url" true
+    (P.Http_probe.can_probe ~url);
+  P.registry_clear ();
+  P.register_url ~url:Masc_network_defaults.ollama_default_url
+
+let test_can_probe_rejects_substring_only_match () =
+  let foreign_url = "http://vllm.example.com:11434/v1" in
+  P.registry_clear ();
+  check bool "substring :11434 alone does not register" false
+    (P.is_registered ~url:foreign_url);
+  check bool "Http_probe.can_probe rejects substring-only :11434" false
+    (P.Http_probe.can_probe ~url:foreign_url);
+  (* Restore default for the rest of the suite. *)
+  P.register_url ~url:Masc_network_defaults.ollama_default_url
+
 let () =
   run "cascade_http_probe" [
     "is_ollama_url", [
       test_case "positive matches" `Quick test_is_ollama_url_positive;
       test_case "negative cases" `Quick test_is_ollama_url_negative;
+    ];
+    "Http_probe URL registry", [
+      test_case "ollama_default_url registered at load" `Quick
+        test_default_url_registered_at_load;
+      test_case "explicit register accepts non-default port" `Quick
+        test_register_url_non_default_port;
+      test_case "can_probe rejects substring-only :11434" `Quick
+        test_can_probe_rejects_substring_only_match;
     ];
     "parse_response", [
       test_case "one loaded model" `Quick test_parse_response_one_loaded;


### PR DESCRIPTION
## Summary

Replace the `:11434` substring scan inside `Cascade_http_probe.Http_probe` with an explicit URL registry. The default ollama URL is auto-registered at module load; non-default URLs become explicit `Cascade_http_probe.register_url` calls.

Closes a class of probe misclassification not covered by RFC-0064's adapter extraction.

## Why this matters

`is_ollama_url` is a substring scan for `:11434` (`lib/config/masc_network_defaults.ml:56`):

```ocaml
let is_ollama_url url =
  (* url contains ":11434" → true, else false *)
```

Failure modes observed in practice:
- **False positive**: vLLM / lmstudio / any reverse-proxied service on port 11434 is misclassified as ollama; probe then hits `/api/ps` and silently fails (fail-open denies the optimisation but does not surface the misconfiguration)
- **False negative**: ollama on a non-default port (multi-instance tests, port-mapped containers, tunneled deployments) is invisible to the probe even when the operator explicitly knows it is ollama

After this PR, `Http_probe.can_probe` answers an authoritative question — "was this URL registered as ollama-native?" — instead of guessing from the port.

## Sealed by tests

| Test | Invariant |
|---|---|
| `default_url_registered_at_load` | Module-load side-effect keeps zero-config behaviour |
| `register_url_non_default_port` | Caller-registered URL on `:51234` becomes probeable (false-negative cured) |
| `can_probe_rejects_substring_only_match` | `http://vllm.example.com:11434/v1` is **not** accepted (false-positive cured) |

## Scope

- ✅ `Cascade_http_probe.Http_probe` boundary sealed
- ⏭ `cascade_client_capacity.ml` / `dashboard_cascade.ml` still use `is_ollama_url` for *different* decisions (capacity registration, label rendering). Their migration is a separate PR (or RFC) — out of scope.

## Workaround self-check

| # | check | result |
|---|---|---|
| 1 | telemetry-as-fix? | no — substring scan removed, no counter added |
| 2 | string classifier? | no — *removes* a string classifier from the probe boundary |
| 3 | N-of-M? | partial — see "Scope" above; the boundary of *this* probe module is fully sealed |
| 4 | catch-all `_ ->` added? | no |
| 5 | cap/cooldown/dedup/repair? | no |
| 6 | test backdoor? | no — `register_url`/`registry_clear` are production primitives |
| 7 | same typo N sites? | no |

## Ratchet metric (inside `lib/cascade/cascade_http_probe.ml`)

| | call sites |
|---|---|
| Before (origin/main) | 3 (`refresh_many`, `Http_probe.can_probe`, top-level `is_ollama_url` definition) |
| After (this branch) | 0 internal uses (top-level binding kept for legacy external callers) |

## Test plan

- [x] 3 new tests in `test_cascade_http_probe.ml`
- [x] Existing `is_ollama_url` tests preserved (legacy compatibility)
- [ ] CI build + test (local build blocked by `dune-local.sh` global lock)

## Follow-ups (not this PR)

- migrate `cascade_client_capacity.auto_register_for_candidates` to also call `Http_probe.register_url`
- migrate `dashboard_cascade` URL classifier to a typed capability flag on `Provider_config.t`
- eventually delete `Masc_network_defaults.is_ollama_url` once all callers are migrated

🤖 Generated with [Claude Code](https://claude.com/claude-code)