### PR TITLE
feat(repo_manager): credential_materializer non-blocking IO migration

### DIFF
--- a/lib/repo_manager/credential_materializer.ml
+++ b/lib/repo_manager/credential_materializer.ml
@@ -94,27 +94,17 @@ let hosts_yml_has_oauth_token ~gh_config_dir =
   if not (Sys.file_exists path) then false
   else
     try
-      let ic = open_in path in
-      Fun.protect
-        ~finally:(fun () -> close_in_noerr ic)
-        (fun () ->
-          let found = ref false in
-          (try
-             while not !found do
-               let line = input_line ic in
-               let trimmed = String.trim line in
-               let prefix = "oauth_token:" in
-               let plen = String.length prefix in
-               if String.length trimmed > plen
-                  && String.equal (String.sub trimmed 0 plen) prefix
-                  && String.trim
-                       (String.sub trimmed plen
-                          (String.length trimmed - plen))
-                     <> ""
-               then found := true
-             done
-           with End_of_file -> ());
-          !found)
+      let prefix = "oauth_token:" in
+      let plen = String.length prefix in
+      Fs_compat.load_file path
+      |> String.split_on_char '\n'
+      |> List.exists (fun line ->
+           let trimmed = String.trim line in
+           String.length trimmed > plen
+           && String.equal (String.sub trimmed 0 plen) prefix
+           && String.trim
+                (String.sub trimmed plen (String.length trimmed - plen))
+              <> "")
     with Sys_error _ -> false
 
 let gh_auth_status_ok ~gh_config_dir =
@@ -191,27 +181,21 @@ let read_token_from_hosts_yml ~gh_config_dir =
   if not (Sys.file_exists path) then None
   else
     try
-      let ic = open_in path in
-      Fun.protect
-        ~finally:(fun () -> close_in_noerr ic)
-        (fun () ->
-          let token = ref None in
-          (try
-             while !token = None do
-               let line = input_line ic in
-               let trimmed = String.trim line in
-               let prefix = "oauth_token:" in
-               let plen = String.length prefix in
-               if String.length trimmed > plen
-                  && String.equal (String.sub trimmed 0 plen) prefix
-               then
-                 let raw =
-                   String.sub trimmed plen (String.length trimmed - plen)
-                 in
-                 token := Some (strip_value_decorations raw)
-             done
-           with End_of_file -> ());
-          !token)
+      let prefix = "oauth_token:" in
+      let plen = String.length prefix in
+      Fs_compat.load_file path
+      |> String.split_on_char '\n'
+      |> List.find_map (fun line ->
+           let trimmed = String.trim line in
+           if
+             String.length trimmed > plen
+             && String.equal (String.sub trimmed 0 plen) prefix
+           then
+             let raw =
+               String.sub trimmed plen (String.length trimmed - plen)
+             in
+             Some (strip_value_decorations raw)
+           else None)
     with Sys_error _ -> None
 
 (** Compute the SHA-256 prefix of the [oauth_token] stored in
@@ -343,19 +327,11 @@ let relabel_hosts_yml ~gh_config_dir ~identity_label =
   if not (Sys.file_exists path) then ()
   else
     try
-      let ic = open_in path in
       let lines =
-        Fun.protect
-          ~finally:(fun () -> close_in_noerr ic)
-          (fun () ->
-            let lines = ref [] in
-            (try
-               while true do lines := input_line ic :: !lines done
-             with End_of_file -> ());
-            !lines)
+        Fs_compat.load_file path |> String.split_on_char '\n'
       in
       let rewritten =
-        List.rev_map
+        List.map
           (fun line ->
             let trimmed = String.trim line in
             let prefix = "user:" in
@@ -376,13 +352,7 @@ let relabel_hosts_yml ~gh_config_dir ~identity_label =
             else line)
           lines
       in
-      let oc = open_out path in
-      Fun.protect
-        ~finally:(fun () -> close_out_noerr oc)
-        (fun () ->
-          List.iter
-            (fun line -> output_string oc line; output_char oc '\n')
-            rewritten)
+      Fs_compat.save_file path (String.concat "\n" rewritten)
     with Sys_error _ -> ()
 
 (* RFC-0019 PR-B Slice 2 + §8 R3: refuse paths that escape via [..]

--- a/lib/repo_manager/dune
+++ b/lib/repo_manager/dune
@@ -14,6 +14,7 @@
  (wrapped false)
  (libraries
    masc_mcp.config
+   masc_mcp.fs_compat
    masc_mcp.masc_exec
    masc_mcp.masc_log
    digestif


### PR DESCRIPTION
## Summary

PR-A 의 패턴 (HTTP route blocking IO → Fs_compat.load_file) 을 credential_materializer 의 3 callsite 에 확장. 같은 5.x leverage gap, 같은 fix.

| 함수 | 변경 |
|---|---|
| `hosts_yml_has_oauth_token` | `while + input_line` → `List.exists` |
| `extract_oauth_token_value` | `while + input_line` → `List.find_map` |
| `relabel_hosts_yml` | `while + input_line` + `open_out` → `String.split_on_char` / `Fs_compat.save_file` |

각 iteration 의 `input_line` syscall 이 같은 Domain 의 모든 fiber stall → `Fs_compat.load_file` (이미 Eio-aware) 단일 호출로 대체. hosts.yml 은 보통 < 50 line 이라 early-exit 손실은 미미.

## Skip 결정 (의도된 보존)

`lib/coord/coord_lifecycle.ml:19` `agent_parse_error_snapshot` 의 200-byte bounded `In_channel.input` 은 OOM 안전장치 (comment 명시: "Reads at most 200 bytes to avoid OOM on large/corrupt files"). `Fs_compat.load_file` 로 마이그레이션하면 전체 파일 로딩되어 안전장치 손실. 200-byte 단일 syscall 의 차단 영향은 미미하므로 유지.

## Test plan

- [x] `dune build --root . @check`: PASS
- [x] `dune exec test/test_credential_materializer.exe`: **23/23 PASS** — `verify_state`, `hosts.yml relabel`, `F-1 gate fingerprint` 등 회귀 모두 통과
- [x] `dune build --root . lib/repo_manager`: PASS (신규 `masc_mcp.fs_compat` 의존성 추가)

## 후속

PR-B 는 RFC-0059 PR-7-pilot keeper Domain_pool 별도 진행. PR-D 는 HTTP response side cohttp-eio body streaming audit.

RFC-WAIVED: 본 PR 은 hosts.yml 읽기 I/O 패턴 변경. `credential_*` 영역이지만 *credential lifecycle / OAuth 로직 변경 없음* — 순수 IO 비블러킹 마이그레이션. 동작 의미 보존. 패턴 PR-A (#14706) 와 동일하게 RFC-WAIVED 적용.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
