### PR TITLE
fix(worker-dev-tools): close orphan docstring around tool_exec_error_kind (main build broken)

### DIFF
--- a/lib/worker_dev_tools.mli
+++ b/lib/worker_dev_tools.mli
@@ -117,10 +117,8 @@ val attribution_of_validation : cmd:string -> (unit, block_reason) result -> Att
 
 (** {1 OAS tool factories} *)
 
-(** Per-call observer hook invoked at the end of every tool execution.
-
 (** Closed sum classifying the producer error categories emitted by the
-    in-tree shell/file tools. Five variants mirror the docstring above:
+    in-tree shell/file tools. Five variants mirror the categorised tags:
     [Path_blocked], [File_read_error], [File_write_error],
     [Command_blocked], [Shell_error].
 
@@ -135,6 +133,8 @@ type tool_exec_error_kind =
   | Shell_error
 
 val tool_exec_error_kind_to_string : tool_exec_error_kind -> string
+
+(** Per-call observer hook invoked at the end of every tool execution.
 
     Receives the tool name, success flag, elapsed wall-clock duration,
     and (on failure) a categorized [error_kind] tag plus the
@@ -152,7 +152,6 @@ val tool_exec_error_kind_to_string : tool_exec_error_kind -> string
 
     Issue #10358: closes the 17.3% blank-error gap for tool_called
     rows fed via [worker_container.build_local_shell_tools]. *)
-
 type tool_exec_observer =
   tool_name:string
   -> success:bool


### PR DESCRIPTION
## main 빌드 복구 — orphan docstring around `tool_exec_error_kind`

`/loop` iter 5 작업 중 발견. main의 `lib/worker_dev_tools.mli`가 빌드 안 됨:
```
File "lib/worker_dev_tools.mli", line 160, characters 17-37:
160 |   -> ?error_kind:tool_exec_error_kind
                       ^^^^^^^^^^^^^^^^^^^^
Error: Unbound type constructor tool_exec_error_kind
```

## Root cause

PR #14709 (`refactor(worker-dev-tools): typed tool_exec_error_kind`)가 `.mli` line 120에 **닫히지 않은 `(**` 도큐스트링**을 남김:

```
118  (** {1 OAS tool factories} *)
119
120  (** Per-call observer hook invoked at the end of every tool execution.   ← opens depth 1
121
122  (** Closed sum classifying the producer error categories ...             ← opens depth 2
...
129      compile obligation at every observer call site. *)                  ← closes depth 2 → 1
130  type tool_exec_error_kind =                                              ← STILL inside outer comment
...
137  val tool_exec_error_kind_to_string : tool_exec_error_kind -> string      ← STILL inside outer comment
138
139      Receives the tool name, success flag, ...                            ← floating text inside comment
...
154      rows fed via [...]. *)                                               ← closes depth 1
155
156  type tool_exec_observer = ...                                            ← outside comment, refs line 130 type
```

OCaml comments nest, so line 120's `(**` was never closed until line 154's `*)`. Result: `type tool_exec_error_kind` (line 130) and its `_to_string` val (line 137) were *inside the comment*, invisible to the parser. Line 160's `tool_exec_observer` referenced them → "Unbound type constructor".

## 본 PR

순수한 docstring layout 재구성. 두 docstring을 각자의 *대상 타입* 바로 앞으로 재배치:

1. `(** Closed sum classifying ... *)` 그대로 → `type tool_exec_error_kind` 위.
2. `(** Per-call observer hook ... Receives the tool name ... Issue #10358 ... *)` 두 조각 (line 120 + lines 139-154)을 *하나의 정상 docstring*으로 합쳐 → `type tool_exec_observer` 위.

타입 정의·val 시그니처·module surface는 *전혀 건드리지 않음*. **+3 / -4 LOC.**

## Verification

- [x] `dune build @check` 통과 (worktree local)
- [ ] CI Build & Test (main fix 머지 후 다른 PR들도 자동 복구)

## Trade-off

- **단점**: 동일 코멘트 패턴 (orphan + nested) 재발 방지 lint은 본 PR에 포함 안 함 — `ocamlformat` 또는 `odoc` validator가 catch 했어야 함. CI에 docstring validator 추가는 별도 RFC.
- **장점**: 최소한 main이 빌드되어 다른 PR들 (#14694, #14698, #14702 머지됨, #14707, #14713 등 `/loop` 작업물)의 CI가 정상 작동.

## 영향 받는 PR (main 복구 후 자동 unblock)

- #14690 (OAS pin bump — main fix 의존)
- #14707 (TLA+ spec — KNOWN_FAILURES skip이지만 CI Build는 통과해야)
- **#14713** (iter 5 test addition — direct CI dependency)
- 그 외 active draft 다수

## RFC

`RFC-WAIVED: docstring layout fix on lib/worker_dev_tools.mli, no agent delegation subsystem surface modified.`

🤖 Generated with [Claude Code](https://claude.com/claude-code)