### PR TITLE
fix(keeper): harden boolean guard predicates (3 sites) — explicit variant enumeration

### DIFF
--- a/lib/keeper/keeper_run_tools.ml
+++ b/lib/keeper/keeper_run_tools.ml
@@ -613,9 +613,16 @@ let prepare_agent_setup
   in
   let tool_gate_requested_for_turn ~current_tool_choice ~is_last_turn ~allowed_tool_names =
     let caller_requires_tools =
+      (* Enumerate every [tool_choice] variant + [None] so a new constructor
+         added to [Agent_sdk.Types.tool_choice] surfaces a Warning 8 here.
+         [Auto] and [None_] correctly evaluate to [false] (no tool *required*);
+         the old [_ -> false] catch-all would have absorbed any future variant
+         in the same direction without review. *)
       match current_tool_choice with
       | Some (Agent_sdk.Types.Any | Agent_sdk.Types.Tool _) -> true
-      | _ -> false
+      | Some (Agent_sdk.Types.Auto | Agent_sdk.Types.None_)
+      | None ->
+        false
     in
     max_turns > 1
     && (not is_last_turn)

--- a/lib/keeper/keeper_runtime_contract.ml
+++ b/lib/keeper/keeper_runtime_contract.ml
@@ -125,9 +125,18 @@ let resolve_observation_claim_goal_scope ?agent_tool_names ~(config : Coord.conf
     ~config ~meta ()
 
 let task_is_blocked (task : Masc_domain.task) =
+  (* Enumerate every [task_status] variant so the compiler flags any new
+     constructor here. The old [_ -> false] silently extended "not blocked"
+     to any future status (e.g. a hypothetical [BlockedOnReview]) which
+     would be exactly the wrong default for a blocked-task detector. *)
   match task.task_status with
   | Masc_domain.AwaitingVerification _ -> true
-  | _ -> false
+  | Masc_domain.Todo
+  | Masc_domain.Claimed _
+  | Masc_domain.InProgress _
+  | Masc_domain.Done _
+  | Masc_domain.Cancelled _ ->
+    false
 
 let goal_progress_json ?config (meta : keeper_meta) =
   match config with

--- a/lib/keeper/keeper_turn_cascade_budget.ml
+++ b/lib/keeper/keeper_turn_cascade_budget.ml
@@ -306,9 +306,24 @@ let degraded_retry_slot_phase_available ~(time_spent_in_turn_s : float) : bool =
 
 let degraded_retry_bypasses_slot_phase_guard
     (err : Agent_sdk.Error.sdk_error) : bool =
+  (* Enumerate every [masc_internal_error] variant plus [None] so the
+     compiler flags any new constructor here. The old [_ -> false] silently
+     extended the "not a budget exhaustion" set whenever a new error class
+     was added to Cascade_error_classify, which is exactly the wrong default
+     for a guard that decides whether to bypass slot-phase admission. *)
   match Keeper_turn_driver.classify_masc_internal_error err with
   | Some (Keeper_turn_driver.Oas_timeout_budget _) -> true
-  | _ -> false
+  | Some
+      ( Keeper_turn_driver.Cascade_exhausted _
+      | Keeper_turn_driver.Resumable_cli_session _
+      | Keeper_turn_driver.No_tool_capable_provider _
+      | Keeper_turn_driver.Accept_rejected _
+      | Keeper_turn_driver.Admission_queue_timeout _
+      | Keeper_turn_driver.Admission_queue_rejected _
+      | Keeper_turn_driver.Turn_timeout _
+      | Keeper_turn_driver.Ambiguous_post_commit _ )
+  | None ->
+    false
 
 let reclassify_oas_timeout_for_attempt
     ~(timeout_budget : oas_timeout_budget_resolution option)


### PR DESCRIPTION
## Why

Three boolean guards in `lib/keeper/` reduce a closed sum to `bool` with the shape:

\`\`\`ocaml
| <target-variant(s)> -> true
| _ -> false
\`\`\`

For a *guard predicate* (whose purpose is to detect a specific condition), `_ -> false` as the default is the **wrong** safety direction: any future variant silently inherits "guard not triggered". The compiler never warns and there is no runtime signal. This is the FSM Sparse Match anti-pattern in `~/me/instructions/software-development.md`.

## Sites

### 1. `keeper_turn_cascade_budget.ml:307-311` — `degraded_retry_bypasses_slot_phase_guard`

Scrutinee: `masc_internal_error option` (9 constructors). Old code caught only `Oas_timeout_budget` and dumped the other 8 + `None` into the catch-all. Adding a 10th error class would silently inherit "do not bypass slot-phase admission".

### 2. `keeper_runtime_contract.ml:127-130` — `task_is_blocked`

Scrutinee: `Masc_domain.task_status` (6 constructors). Old code caught only `AwaitingVerification` and treated everything else (including a hypothetical future `BlockedOnReview`) as "not blocked". Scheduling code would silently skip task gating for new blocking states.

### 3. `keeper_run_tools.ml:614-619` — `caller_requires_tools` (inside `tool_gate_requested_for_turn`)

Scrutinee: `Agent_sdk.Types.tool_choice option` (4 constructors + `None`). Old code caught only `Some (Any | Tool _)` and dumped `Some Auto`, `Some None_`, and `None` into the catch-all. A future tool-choice variant that *should* require tools (e.g. a hypothetical `Required`) would silently inherit "does not require".

## What

All three sites: enumerate every non-target variant explicitly. Behavior is unchanged for the current variant set. Going forward the compiler issues Warning 8 at these guard predicates when a new constructor is added, forcing a deliberate decision.

A short comment at each site explains *why* the catch-all was the wrong default direction (guard-specific) so a future reader doesn't reintroduce it.

## Verification

\`\`\`
dune build @lib/keeper/check --root .   # exit 0
\`\`\`

## Scope

Surgical. Three predicates, three files, no behavior change. No `.mli` change.

## Why this matters disproportionately

A `_ -> false` over a closed sum looks identical to a `_ -> false` over a string — but the failure mode is opposite. On strings the catch-all is structurally required and the choice of default is the design decision. On a closed sum the catch-all is *avoidable* and choosing it is choosing to opt out of the type system's exhaustiveness guarantee. The first is engineering; the second is regression-debt.

## Commits

1. `fix(keeper): harden guard predicates with explicit variant enumeration` (sites 1 + 2)
2. `fix(keeper): make tool_gate caller_requires_tools tool_choice match exhaustive` (site 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)