### PR TITLE
refactor(provider): apply_wire_overlay boundary helper (RFC-0058 Phase 5.6 leak 3/4)

### DIFF
--- a/lib/keeper/keeper_agent_context.ml
+++ b/lib/keeper/keeper_agent_context.ml
@@ -7,24 +7,29 @@
 
 type stop_reason =
   | Completed
-  | TurnBudgetExhausted of { turns_used : int; limit : int }
-  | MutationBoundaryReached of { turns_used : int; tool_name : string option }
+  | TurnBudgetExhausted of
+      { turns_used : int
+      ; limit : int
+      }
+  | MutationBoundaryReached of
+      { turns_used : int
+      ; tool_name : string option
+      }
 
-type config = {
-  name : string;
-  provider_cfg : Llm_provider.Provider_config.t;
-  provider : Agent_sdk.Provider.config;
-  model_id : string;
-  priority : Llm_provider.Request_priority.t option;
-  system_prompt : string;
-  tools : Agent_sdk.Tool.t list;
-  runtime_mcp_policy :
-    Llm_provider.Llm_transport.runtime_mcp_policy option;
-  max_turns : int;
-  max_idle_turns : int;
-  stream_idle_timeout_s : float option;
-  max_execution_time_s : float option;
-      (** Wall-clock ceiling for one [Agent_sdk.Agent.run] / [run_stream]
+type config =
+  { name : string
+  ; provider_cfg : Llm_provider.Provider_config.t
+  ; provider : Agent_sdk.Provider.config
+  ; model_id : string
+  ; priority : Llm_provider.Request_priority.t option
+  ; system_prompt : string
+  ; tools : Agent_sdk.Tool.t list
+  ; runtime_mcp_policy : Llm_provider.Llm_transport.runtime_mcp_policy option
+  ; max_turns : int
+  ; max_idle_turns : int
+  ; stream_idle_timeout_s : float option
+  ; max_execution_time_s : float option
+    (** Wall-clock ceiling for one [Agent_sdk.Agent.run] / [run_stream]
           call. When [Some s] AND a clock is available at the call site,
           agent_sdk's [with_optional_timeout] returns
           [Error (Api (Retry.Timeout {...}))] after [s] seconds — the
@@ -33,123 +38,122 @@ type config = {
           when a provider closes the connection without [end_turn].
           Default [None] preserves the historical behaviour
           (block indefinitely on stream-parser hang). *)
-  max_tokens : int;
-  max_input_tokens : int option;
-  max_cost_usd : float option;
-  temperature : float;
-  hooks : Agent_sdk.Hooks.hooks option;
-  context_reducer : Agent_sdk.Context_reducer.t option;
-  guardrails : Agent_sdk.Guardrails.t option;
-  event_bus : Agent_sdk.Event_bus.t option;
-  checkpoint_dir : string option;
-  session_id : string option;
-  description : string option;
-  memory : Agent_sdk.Memory.t option;
-  initial_messages : Agent_sdk.Types.message list;
-  raw_trace : Agent_sdk.Raw_trace.t option;
-  tool_retry_policy : Agent_sdk.Tool_retry_policy.t option;
-  required_tool_satisfaction :
-    Agent_sdk.Completion_contract.required_tool_satisfaction;
-  contract : Masc_mcp_cdal_runtime.Risk_contract.t option;
-  enable_thinking : bool option;
-  transport : Masc_grpc_transport.t;
-  allowed_paths : string list;
-  checkpoint_sidecar : Yojson.Safe.t option;
-  cache_system_prompt : bool;
-  yield_on_tool : bool;
-  compact_ratio : float option;
-  context_injector : Agent_sdk.Hooks.context_injector option;
-  context : Agent_sdk.Context.t option;
-  slot_id : int option;
-  approval : Agent_sdk.Hooks.approval_callback option;
-  exit_condition : (int -> bool) option;
-  exit_condition_result : (int -> stop_reason * string option) option;
-  summarizer : (Agent_sdk.Types.message list -> string) option;
-  cli_transport_overrides :
-    Cascade_transport.cli_transport_overrides option;
-      (** Custom summarizer for OAS [Budget_strategy.reduce_for_budget]
+  ; max_tokens : int
+  ; max_input_tokens : int option
+  ; max_cost_usd : float option
+  ; temperature : float
+  ; hooks : Agent_sdk.Hooks.hooks option
+  ; context_reducer : Agent_sdk.Context_reducer.t option
+  ; guardrails : Agent_sdk.Guardrails.t option
+  ; event_bus : Agent_sdk.Event_bus.t option
+  ; checkpoint_dir : string option
+  ; session_id : string option
+  ; description : string option
+  ; memory : Agent_sdk.Memory.t option
+  ; initial_messages : Agent_sdk.Types.message list
+  ; raw_trace : Agent_sdk.Raw_trace.t option
+  ; tool_retry_policy : Agent_sdk.Tool_retry_policy.t option
+  ; required_tool_satisfaction : Agent_sdk.Completion_contract.required_tool_satisfaction
+  ; contract : Masc_mcp_cdal_runtime.Risk_contract.t option
+  ; enable_thinking : bool option
+  ; transport : Masc_grpc_transport.t
+  ; allowed_paths : string list
+  ; checkpoint_sidecar : Yojson.Safe.t option
+  ; cache_system_prompt : bool
+  ; yield_on_tool : bool
+  ; compact_ratio : float option
+  ; context_injector : Agent_sdk.Hooks.context_injector option
+  ; context : Agent_sdk.Context.t option
+  ; slot_id : int option
+  ; approval : Agent_sdk.Hooks.approval_callback option
+  ; exit_condition : (int -> bool) option
+  ; exit_condition_result : (int -> stop_reason * string option) option
+  ; summarizer : (Agent_sdk.Types.message list -> string) option
+  ; cli_transport_overrides : Cascade_transport.cli_transport_overrides option
+    (** Custom summarizer for OAS [Budget_strategy.reduce_for_budget]
           Emergency-phase compaction. Defaults to OAS's extractive
           default. Keeper workers inject [Keeper_summarizer.keeper_summarizer]
           to scrub [STATE] blocks before the 100-char truncation. *)
-}
+  }
 
 let default_config
-    ~name
-    ~(provider_cfg : Llm_provider.Provider_config.t)
-    ~system_prompt
-    ~tools : config =
+      ~name
+      ~(provider_cfg : Llm_provider.Provider_config.t)
+      ~system_prompt
+      ~tools
+  : config
+  =
   let provider =
     Agent_sdk.Provider.config_of_provider_config provider_cfg
     |> Provider_adapter.apply_wire_overlay ~provider_cfg
   in
-  {
-    name;
-    provider_cfg;
-    provider;
-    model_id = provider_cfg.model_id;
-    priority = None;
-    system_prompt;
-    tools;
-    runtime_mcp_policy = None;
-    max_turns = 20;
-    max_idle_turns = 3;
-    stream_idle_timeout_s = None;
-    max_execution_time_s = None;
-    max_tokens = Cascade_legacy_runner.default_max_tokens;
-    max_input_tokens = None;
-    max_cost_usd = None;
-    temperature = Cascade_legacy_runner.default_temperature;
-    hooks = None;
-    context_reducer = None;
-    guardrails = None;
-    event_bus = None;
-    checkpoint_dir = None;
-    session_id = None;
-    description = None;
-    memory = None;
-    initial_messages = [];
-    raw_trace = None;
-    tool_retry_policy = None;
-    required_tool_satisfaction =
-      Agent_sdk.Completion_contract.any_tool_call_satisfies;
-    contract = None;
-    enable_thinking = None;
-    transport = Masc_grpc_transport.from_env ();
-    allowed_paths = [];
-    checkpoint_sidecar = None;
-    cache_system_prompt = false;
-    yield_on_tool = false;
-    compact_ratio = None;
-    context_injector = None;
-    context = None;
-    slot_id = None;
-    approval = None;
-    exit_condition = None;
-    exit_condition_result = None;
-    summarizer = None;
-    cli_transport_overrides = None;
+  { name
+  ; provider_cfg
+  ; provider
+  ; model_id = provider_cfg.model_id
+  ; priority = None
+  ; system_prompt
+  ; tools
+  ; runtime_mcp_policy = None
+  ; max_turns = 20
+  ; max_idle_turns = 3
+  ; stream_idle_timeout_s = None
+  ; max_execution_time_s = None
+  ; max_tokens = Cascade_legacy_runner.default_max_tokens
+  ; max_input_tokens = None
+  ; max_cost_usd = None
+  ; temperature = Cascade_legacy_runner.default_temperature
+  ; hooks = None
+  ; context_reducer = None
+  ; guardrails = None
+  ; event_bus = None
+  ; checkpoint_dir = None
+  ; session_id = None
+  ; description = None
+  ; memory = None
+  ; initial_messages = []
+  ; raw_trace = None
+  ; tool_retry_policy = None
+  ; required_tool_satisfaction = Agent_sdk.Completion_contract.any_tool_call_satisfies
+  ; contract = None
+  ; enable_thinking = None
+  ; transport = Masc_grpc_transport.from_env ()
+  ; allowed_paths = []
+  ; checkpoint_sidecar = None
+  ; cache_system_prompt = false
+  ; yield_on_tool = false
+  ; compact_ratio = None
+  ; context_injector = None
+  ; context = None
+  ; slot_id = None
+  ; approval = None
+  ; exit_condition = None
+  ; exit_condition_result = None
+  ; summarizer = None
+  ; cli_transport_overrides = None
   }
+;;
 
 let guardrails_of_config (config : config) =
-  let tool_names =
-    List.map (fun (t : Agent_sdk.Tool.t) -> t.schema.name) config.tools
-  in
+  let tool_names = List.map (fun (t : Agent_sdk.Tool.t) -> t.schema.name) config.tools in
   match config.guardrails with
   | Some g -> g
   | None ->
-      {
-        Agent_sdk.Guardrails.default with
-        tool_filter =
-          if tool_names <> [] then Agent_sdk.Guardrails.AllowList tool_names
-          else Agent_sdk.Guardrails.AllowAll;
-      }
+    { Agent_sdk.Guardrails.default with
+      tool_filter =
+        (if tool_names <> []
+         then Agent_sdk.Guardrails.AllowList tool_names
+         else Agent_sdk.Guardrails.AllowAll)
+    }
+;;
 
 let builder_without_approval
-    ~(net : [ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t)
-    ~(config : config)
-    ?transport
-    ()
-  : Agent_sdk.Builder.t =
+      ~(net : [ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t)
+      ~(config : config)
+      ?transport
+      ()
+  : Agent_sdk.Builder.t
+  =
   let guardrails = guardrails_of_config config in
   let builder =
     Agent_sdk.Builder.create ~net ~model:config.model_id
@@ -174,10 +178,9 @@ let builder_without_approval
     | None -> builder
   in
   let builder =
-    if config.tools <> [] then
-      Agent_sdk.Builder.with_tool_choice Agent_sdk.Types.Auto builder
-    else
-      builder
+    if config.tools <> []
+    then Agent_sdk.Builder.with_tool_choice Agent_sdk.Types.Auto builder
+    else builder
   in
   let builder =
     match config.hooks with
@@ -211,7 +214,8 @@ let builder_without_approval
   in
   let builder =
     Agent_sdk.Builder.with_required_tool_satisfaction
-      config.required_tool_satisfaction builder
+      config.required_tool_satisfaction
+      builder
   in
   let builder =
     match config.enable_thinking with
@@ -239,33 +243,28 @@ let builder_without_approval
     | None -> builder
   in
   let builder =
-    if config.cache_system_prompt then
-      Agent_sdk.Builder.with_cache_system_prompt true builder
-    else
-      builder
+    if config.cache_system_prompt
+    then Agent_sdk.Builder.with_cache_system_prompt true builder
+    else builder
   in
   let builder =
-    if config.yield_on_tool then
-      Agent_sdk.Builder.with_yield_on_tool true builder
-    else
-      builder
+    if config.yield_on_tool
+    then Agent_sdk.Builder.with_yield_on_tool true builder
+    else builder
   in
   let builder =
-    if config.allowed_paths <> [] then
-      Agent_sdk.Builder.with_allowed_paths config.allowed_paths builder
-    else
-      builder
+    if config.allowed_paths <> []
+    then Agent_sdk.Builder.with_allowed_paths config.allowed_paths builder
+    else builder
   in
   let builder =
-    if config.initial_messages <> [] then
-      Agent_sdk.Builder.with_initial_messages config.initial_messages builder
-    else
-      builder
+    if config.initial_messages <> []
+    then Agent_sdk.Builder.with_initial_messages config.initial_messages builder
+    else builder
   in
   let builder =
     match config.compact_ratio with
-    | Some ratio ->
-        Agent_sdk.Builder.with_context_thresholds ~compact_ratio:ratio builder
+    | Some ratio -> Agent_sdk.Builder.with_context_thresholds ~compact_ratio:ratio builder
     | None -> builder
   in
   let builder =
@@ -296,76 +295,75 @@ let builder_without_approval
   match transport with
   | Some transport -> Agent_sdk.Builder.with_transport transport builder
   | None -> builder
+;;
 
-type prepared_resume = {
-  patched_checkpoint : Agent_sdk.Checkpoint.t;
-  agent_config : Agent_sdk.Types.agent_config;
-  options : Agent_sdk.Agent.options;
-}
+type prepared_resume =
+  { patched_checkpoint : Agent_sdk.Checkpoint.t
+  ; agent_config : Agent_sdk.Types.agent_config
+  ; options : Agent_sdk.Agent.options
+  }
 
-let prepare_resume ~(config : config) ~(checkpoint : Agent_sdk.Checkpoint.t) :
-    prepared_resume =
+let prepare_resume ~(config : config) ~(checkpoint : Agent_sdk.Checkpoint.t)
+  : prepared_resume
+  =
   let effective_max_turns = checkpoint.turn_count + config.max_turns in
   let effective_max_cost_usd =
     match config.max_cost_usd with
-    | Some budget ->
-        Some (checkpoint.usage.estimated_cost_usd +. budget)
+    | Some budget -> Some (checkpoint.usage.estimated_cost_usd +. budget)
     | None -> None
   in
   let patched_checkpoint =
-    {
-      checkpoint with
-      Agent_sdk.Checkpoint.model = config.model_id;
-      system_prompt = Some config.system_prompt;
-      temperature = Some config.temperature;
-      enable_thinking = config.enable_thinking;
-      cache_system_prompt = config.cache_system_prompt;
-      max_input_tokens = config.max_input_tokens;
-      max_total_tokens = None;
+    { checkpoint with
+      Agent_sdk.Checkpoint.model = config.model_id
+    ; system_prompt = Some config.system_prompt
+    ; temperature = Some config.temperature
+    ; enable_thinking = config.enable_thinking
+    ; cache_system_prompt = config.cache_system_prompt
+    ; max_input_tokens = config.max_input_tokens
+    ; max_total_tokens = None
     }
   in
   let agent_config : Agent_sdk.Types.agent_config =
-    {
-      Agent_sdk.Types.default_config with
-      name = config.name;
-      model = config.model_id;
-      system_prompt = Some config.system_prompt;
-      max_tokens = Some config.max_tokens;
-      max_turns = effective_max_turns;
-      temperature = Some config.temperature;
-      enable_thinking = config.enable_thinking;
-      cache_system_prompt = config.cache_system_prompt;
-      max_input_tokens = config.max_input_tokens;
-      max_cost_usd = effective_max_cost_usd;
-      yield_on_tool = config.yield_on_tool;
-      context_compact_ratio = config.compact_ratio;
-      priority = config.priority;
-      exit_condition = config.exit_condition;
+    { Agent_sdk.Types.default_config with
+      name = config.name
+    ; model = config.model_id
+    ; system_prompt = Some config.system_prompt
+    ; max_tokens = Some config.max_tokens
+    ; max_turns = effective_max_turns
+    ; temperature = Some config.temperature
+    ; enable_thinking = config.enable_thinking
+    ; cache_system_prompt = config.cache_system_prompt
+    ; max_input_tokens = config.max_input_tokens
+    ; max_cost_usd = effective_max_cost_usd
+    ; yield_on_tool = config.yield_on_tool
+    ; context_compact_ratio = config.compact_ratio
+    ; priority = config.priority
+    ; exit_condition = config.exit_condition
     }
   in
   let options : Agent_sdk.Agent.options =
-    {
-      Agent_sdk.Agent.default_options with
-      provider = Some config.provider;
-      hooks = Option.value ~default:Agent_sdk.Hooks.empty config.hooks;
-      max_idle_turns = config.max_idle_turns;
-      stream_idle_timeout_s = config.stream_idle_timeout_s;
-      max_execution_time_s = config.max_execution_time_s;
-      guardrails = guardrails_of_config config;
-      context_reducer = config.context_reducer;
-      context_injector = config.context_injector;
-      event_bus = config.event_bus;
-      memory = config.memory;
-      raw_trace = config.raw_trace;
-      tool_retry_policy = config.tool_retry_policy;
-      required_tool_satisfaction = config.required_tool_satisfaction;
-      allowed_paths = config.allowed_paths;
-      description = config.description;
-      approval = config.approval;
-      slot_id = config.slot_id;
-      runtime_mcp_policy = config.runtime_mcp_policy;
-      summarizer = config.summarizer;
-      priority = config.priority;
+    { Agent_sdk.Agent.default_options with
+      provider = Some config.provider
+    ; hooks = Option.value ~default:Agent_sdk.Hooks.empty config.hooks
+    ; max_idle_turns = config.max_idle_turns
+    ; stream_idle_timeout_s = config.stream_idle_timeout_s
+    ; max_execution_time_s = config.max_execution_time_s
+    ; guardrails = guardrails_of_config config
+    ; context_reducer = config.context_reducer
+    ; context_injector = config.context_injector
+    ; event_bus = config.event_bus
+    ; memory = config.memory
+    ; raw_trace = config.raw_trace
+    ; tool_retry_policy = config.tool_retry_policy
+    ; required_tool_satisfaction = config.required_tool_satisfaction
+    ; allowed_paths = config.allowed_paths
+    ; description = config.description
+    ; approval = config.approval
+    ; slot_id = config.slot_id
+    ; runtime_mcp_policy = config.runtime_mcp_policy
+    ; summarizer = config.summarizer
+    ; priority = config.priority
     }
   in
   { patched_checkpoint; agent_config; options }
+;;

--- a/lib/keeper/keeper_agent_context.ml
+++ b/lib/keeper/keeper_agent_context.ml
@@ -79,33 +79,8 @@ let default_config
     ~system_prompt
     ~tools : config =
   let provider =
-    let provider = Agent_sdk.Provider.config_of_provider_config provider_cfg in
-    match provider_cfg.kind, provider.provider with
-    | Llm_provider.Provider_config.OpenAI_compat, Agent_sdk.Provider.Local { base_url }
-      when not
-             (String.equal provider_cfg.request_path
-                Masc_network_defaults.openai_chat_completions_path) ->
-        let auth_header =
-          if String.trim provider_cfg.api_key = "" then None
-          else Some "Authorization"
-        in
-        let static_token =
-          match String.trim provider_cfg.api_key with
-          | "" -> None
-          | token -> Some token
-        in
-        {
-          provider with
-          provider =
-            Agent_sdk.Provider.OpenAICompat
-              {
-                base_url;
-                auth_header;
-                path = provider_cfg.request_path;
-                static_token;
-              };
-        }
-    | _ -> provider
+    Agent_sdk.Provider.config_of_provider_config provider_cfg
+    |> Provider_adapter.apply_wire_overlay ~provider_cfg
   in
   {
     name;

--- a/lib/provider_adapter.ml
+++ b/lib/provider_adapter.ml
@@ -1501,6 +1501,55 @@ let provider_label_from_registry (cfg : Llm_provider.Provider_config.t) =
   | Some adapter -> adapter.cascade_prefix
   | None -> Llm_provider.Provider_registry.provider_name_of_config cfg
 
+(** [apply_wire_overlay ~provider_cfg provider] returns [provider] with
+    its wire-layer transport rewritten when the SDK's
+    {!Agent_sdk.Provider.config_of_provider_config} mapping under-routes
+    an [OpenAI_compat] cfg as [Local] (no support for a custom
+    [request_path] / auth header).
+
+    Behaviour:
+    - When [provider_cfg.kind = OpenAI_compat] AND the SDK produced
+      [Local { base_url }] AND [provider_cfg.request_path] is not the
+      default OpenAI chat-completions path, the [provider] field is
+      rewrapped as [OpenAICompat { base_url; auth_header; path;
+      static_token }] so the configured non-default path and optional
+      auth token actually reach the wire.
+    - All other shapes are returned unchanged.
+
+    Keeper-layer callers ({!Keeper_agent_context.default_config}) used
+    to inline this match on [provider_cfg.kind] and
+    [provider.provider]. RFC-0058 Phase 5.6 moves that inspection into
+    this single boundary helper so adding another OpenAI-compatible
+    transport (vLLM, lmstudio, OpenRouter) only requires touching this
+    adapter module — keeper code never names a provider variant. *)
+let apply_wire_overlay
+    ~(provider_cfg : Llm_provider.Provider_config.t)
+    (provider : Agent_sdk.Provider.config) : Agent_sdk.Provider.config =
+  match provider_cfg.kind, provider.provider with
+  | Llm_provider.Provider_config.OpenAI_compat,
+    Agent_sdk.Provider.Local { base_url }
+    when not
+           (String.equal
+              provider_cfg.request_path
+              Masc_network_defaults.openai_chat_completions_path) ->
+    let api_key_trimmed = String.trim provider_cfg.api_key in
+    let auth_header =
+      if String.equal api_key_trimmed "" then None else Some "Authorization"
+    in
+    let static_token =
+      if String.equal api_key_trimmed "" then None else Some api_key_trimmed
+    in
+    { provider with
+      provider =
+        Agent_sdk.Provider.OpenAICompat
+          { base_url
+          ; auth_header
+          ; path = provider_cfg.request_path
+          ; static_token
+          }
+    }
+  | _ -> provider
+
 let adapter_of_provider_config (cfg : Llm_provider.Provider_config.t) =
   (* RFC-0058 §2.4: dispatch flows through the kind→canonical_name table
      ([adapter_canonical_name_of_provider_kind]) rather than enumerating

--- a/lib/provider_adapter.ml
+++ b/lib/provider_adapter.ml
@@ -8,10 +8,10 @@ type auth_mode =
   | No_auth
   | Cli_cached_login
   | Api_key of string
-  | Vertex_adc of {
-      project_env : string;
-      location_env : string;
-    }
+  | Vertex_adc of
+      { project_env : string
+      ; location_env : string
+      }
 
 type model_family =
   | Generic
@@ -21,11 +21,11 @@ type model_family =
 
 type auto_models_source =
   | No_auto_models
-  | Env_csv_or_default of {
-      env_var : string;
-      defaults : string list;
-      prefer_default_model_env : bool;
-    }
+  | Env_csv_or_default of
+      { env_var : string
+      ; defaults : string list
+      ; prefer_default_model_env : bool
+      }
   | Zai_general_auto_models
   | Zai_coding_auto_models
 
@@ -34,78 +34,81 @@ type reporting_policy =
   | Missing_by_design
   | Unknown
 
-type model_policy = {
-  default_model_env : string option;
-  default_model_fallback : string option;
-  auto_models : auto_models_source;
-  expand_auto : bool;
-  family : model_family;
-}
+type model_policy =
+  { default_model_env : string option
+  ; default_model_fallback : string option
+  ; auto_models : auto_models_source
+  ; expand_auto : bool
+  ; family : model_family
+  }
 
-type tool_policy = {
-  supports_runtime_mcp_http_headers : bool;
-  requires_per_keeper_bridging_for_bound_actor_tools : bool;
-  identity_runtime_mcp_header_keys : string list;
-  argv_prompt_preflight : bool;
-  uses_anthropic_caching : bool;
-  max_turns_per_attempt : int option;
-  tolerates_bound_actor_fallback : bool;
-}
+type tool_policy =
+  { supports_runtime_mcp_http_headers : bool
+  ; requires_per_keeper_bridging_for_bound_actor_tools : bool
+  ; identity_runtime_mcp_header_keys : string list
+  ; argv_prompt_preflight : bool
+  ; uses_anthropic_caching : bool
+  ; max_turns_per_attempt : int option
+  ; tolerates_bound_actor_fallback : bool
+  }
 
-type telemetry_policy = {
-  usage_reporting : reporting_policy;
-  runtime_reporting : reporting_policy;
-}
+type telemetry_policy =
+  { usage_reporting : reporting_policy
+  ; runtime_reporting : reporting_policy
+  }
 
 type voice_transport =
   | Voice_openai_compat
   | Voice_elevenlabs_direct
   | Voice_mcp
 
-type adapter = {
-  canonical_name : string;
-  runtime_kind : runtime_kind;
-  auth_mode : auth_mode;
-  aliases : string list;
-  spawn_key : string option;       (** Key for CLI spawn lookup in Spawn.spawn_config_of_key. None = not spawnable via CLI. *)
-  cascade_prefix : string;         (** MASC cascade model prefix (e.g. "claude", "openai").
+type adapter =
+  { canonical_name : string
+  ; runtime_kind : runtime_kind
+  ; auth_mode : auth_mode
+  ; aliases : string list
+  ; spawn_key : string option
+    (** Key for CLI spawn lookup in Spawn.spawn_config_of_key. None = not spawnable via CLI. *)
+  ; cascade_prefix : string
+    (** MASC cascade model prefix (e.g. "claude", "openai").
                                        CONTRACT: Must match the prefix used by the local
                                        [Cascade_config] parser and Provider_registry-compatible
                                        model labels. This is the primary naming boundary between
                                        MASC routing and OAS provider configs. *)
-  default_voice : string option;   (** Default TTS voice name. None = no voice assignment. *)
-  endpoint_url : string option;    (** Base URL for the provider API. *)
-  default_model_id : string option; (** Default model ID for the provider. *)
-  model_policy : model_policy;
-  tool_policy : tool_policy;
-  telemetry_policy : telemetry_policy;
-}
+  ; default_voice : string option
+    (** Default TTS voice name. None = no voice assignment. *)
+  ; endpoint_url : string option (** Base URL for the provider API. *)
+  ; default_model_id : string option (** Default model ID for the provider. *)
+  ; model_policy : model_policy
+  ; tool_policy : tool_policy
+  ; telemetry_policy : telemetry_policy
+  }
 
-type voice_adapter = {
-  canonical_name : string;
-  transport : voice_transport;
-  auth_mode : auth_mode;
-  aliases : string list;
-}
+type voice_adapter =
+  { canonical_name : string
+  ; transport : voice_transport
+  ; auth_mode : auth_mode
+  ; aliases : string list
+  }
 
-type voice_http_request = {
-  url : string;
-  headers : (string * string) list;
-  body_json : Yojson.Safe.t;
-}
+type voice_http_request =
+  { url : string
+  ; headers : (string * string) list
+  ; body_json : Yojson.Safe.t
+  }
 
-type voice_stt_request = {
-  url : string;
-  headers : (string * string) list;
-  form_fields : (string * string) list;
-  file_field : string * string;  (** (field_name, file_path) *)
-}
+type voice_stt_request =
+  { url : string
+  ; headers : (string * string) list
+  ; form_fields : (string * string) list
+  ; file_field : string * string (** (field_name, file_path) *)
+  }
 
 type gemini_direct_auth =
-  | Gemini_vertex_adc of {
-      project : string;
-      location : string;
-    }
+  | Gemini_vertex_adc of
+      { project : string
+      ; location : string
+      }
   | Gemini_api_key
   | Gemini_auth_missing of string
 
@@ -117,55 +120,60 @@ let string_of_runtime_kind = function
   | Local -> "local"
   | Cli_agent -> "cli_agent"
   | Direct_api -> "direct_api"
+;;
 
 let string_of_auth_mode = function
   | No_auth -> "none"
   | Cli_cached_login -> "cli_cached_login"
   | Api_key env_name -> "api_key:" ^ env_name
   | Vertex_adc { project_env; location_env } ->
-      "vertex_adc:" ^ project_env ^ ":" ^ location_env
+    "vertex_adc:" ^ project_env ^ ":" ^ location_env
+;;
 
 let string_of_voice_transport = function
   | Voice_openai_compat -> "openai_compat"
   | Voice_elevenlabs_direct -> "elevenlabs_direct"
   | Voice_mcp -> "voice_mcp"
+;;
 
 let normalize_label label = String.trim label |> String.lowercase_ascii
 
 let env_value_opt ?(getenv = Sys.getenv_opt) name =
   match getenv name with
   | Some raw ->
-      let trimmed = String.trim raw in
-      if trimmed = "" then None else Some trimmed
+    let trimmed = String.trim raw in
+    if trimmed = "" then None else Some trimmed
   | None -> None
+;;
 
 let csv_items raw =
   raw
   |> String.split_on_char ','
   |> List.map String.trim
   |> List.filter (fun s -> s <> "")
+;;
 
 let no_tool_http_headers =
-  {
-    supports_runtime_mcp_http_headers = false;
-    requires_per_keeper_bridging_for_bound_actor_tools = false;
-    identity_runtime_mcp_header_keys = [];
-    argv_prompt_preflight = false;
-    uses_anthropic_caching = false;
-    max_turns_per_attempt = None;
-    tolerates_bound_actor_fallback = false;
+  { supports_runtime_mcp_http_headers = false
+  ; requires_per_keeper_bridging_for_bound_actor_tools = false
+  ; identity_runtime_mcp_header_keys = []
+  ; argv_prompt_preflight = false
+  ; uses_anthropic_caching = false
+  ; max_turns_per_attempt = None
+  ; tolerates_bound_actor_fallback = false
   }
+;;
 
 let runtime_mcp_http_headers =
-  {
-    supports_runtime_mcp_http_headers = true;
-    requires_per_keeper_bridging_for_bound_actor_tools = false;
-    identity_runtime_mcp_header_keys = [];
-    argv_prompt_preflight = false;
-    uses_anthropic_caching = false;
-    max_turns_per_attempt = None;
-    tolerates_bound_actor_fallback = false;
+  { supports_runtime_mcp_http_headers = true
+  ; requires_per_keeper_bridging_for_bound_actor_tools = false
+  ; identity_runtime_mcp_header_keys = []
+  ; argv_prompt_preflight = false
+  ; uses_anthropic_caching = false
+  ; max_turns_per_attempt = None
+  ; tolerates_bound_actor_fallback = false
   }
+;;
 
 (* Codex CLI quirk: its cached login cannot natively inject per-keeper auth
    headers, so any runtime MCP policy that uses bound-actor tools requires
@@ -180,22 +188,27 @@ let runtime_mcp_http_headers =
    [identity_runtime_mcp_header_keys] enumerates the keys accepted via this
    carve-out even with [supports_runtime_mcp_http_headers = false]. *)
 let codex_cli_tool_policy =
-  {
-    supports_runtime_mcp_http_headers = false;
-    requires_per_keeper_bridging_for_bound_actor_tools = true;
-    identity_runtime_mcp_header_keys =
-      [ "authorization"; "x-masc-agent-name"; "x-masc-keeper-name" ];
-    argv_prompt_preflight = true;
-    uses_anthropic_caching = false;
-    max_turns_per_attempt = None;
-    tolerates_bound_actor_fallback = false;
+  { supports_runtime_mcp_http_headers = false
+  ; requires_per_keeper_bridging_for_bound_actor_tools = true
+  ; identity_runtime_mcp_header_keys =
+      [ "authorization"; "x-masc-agent-name"; "x-masc-keeper-name" ]
+  ; argv_prompt_preflight = true
+  ; uses_anthropic_caching = false
+  ; max_turns_per_attempt = None
+  ; tolerates_bound_actor_fallback = false
   }
+;;
+
 let telemetry_reported = { usage_reporting = Reported; runtime_reporting = Reported }
 let telemetry_unknown = { usage_reporting = Unknown; runtime_reporting = Unknown }
+
 let telemetry_usage_missing =
   { usage_reporting = Missing_by_design; runtime_reporting = Unknown }
+;;
+
 let telemetry_usage_missing_runtime_reported =
   { usage_reporting = Missing_by_design; runtime_reporting = Reported }
+;;
 
 (* ── Canonical adapter names (single definition point) ──────── *)
 
@@ -214,9 +227,7 @@ let cn_kimi_coding = "kimi-coding"
 let cn_glm = "glm-api"
 let cn_glm_coding_plan = "glm-coding-plan"
 let cn_openrouter = "openrouter"
-
 let kimi_api_key_envs = [ "KIMI_API_KEY_SB"; "KIMI_API_KEY" ]
-
 let kimi_coding_key_envs = [ "KIMI_CODING_API_KEY"; "KIMI_API_KEY_SB" ]
 
 let display_provider_name label =
@@ -226,6 +237,7 @@ let display_provider_name label =
   | "kimi-api" -> cn_kimi
   | "kimi-coding" | "kimi_coding" -> cn_kimi_coding
   | _ -> String.trim label
+;;
 
 (** Default API base URLs — overridable via env var for proxying/testing.
     Where OAS Provider_registry already defines a default, query it rather
@@ -234,9 +246,10 @@ let display_provider_name label =
 let env_url_or ~env ~default =
   match Sys.getenv_opt env with
   | Some url ->
-      let trimmed = String.trim url in
-      if trimmed <> "" then trimmed else default
+    let trimmed = String.trim url in
+    if trimmed <> "" then trimmed else default
   | None -> default
+;;
 
 (** Query OAS Provider_registry for a provider's default base_url.
     Returns empty string if the provider is not known to OAS.
@@ -246,52 +259,52 @@ let registry_default_base_url name =
   match Llm_provider.Provider_registry.find registry name with
   | Some entry -> entry.defaults.base_url
   | None -> ""
+;;
 
 let anthropic_api_url () =
-  env_url_or ~env:"ANTHROPIC_API_URL"
-    ~default:(registry_default_base_url "claude")
+  env_url_or ~env:"ANTHROPIC_API_URL" ~default:(registry_default_base_url "claude")
+;;
 
-let openai_api_url () =
-  env_url_or ~env:"OPENAI_API_URL" ~default:"https://api.openai.com"
+let openai_api_url () = env_url_or ~env:"OPENAI_API_URL" ~default:"https://api.openai.com"
 
 let openrouter_api_url () =
-  env_url_or ~env:"OPENROUTER_API_URL"
-    ~default:(registry_default_base_url "openrouter")
+  env_url_or ~env:"OPENROUTER_API_URL" ~default:(registry_default_base_url "openrouter")
+;;
 
 let gemini_generative_api_url () =
-  env_url_or ~env:"GEMINI_API_URL"
-    ~default:(registry_default_base_url "gemini")
+  env_url_or ~env:"GEMINI_API_URL" ~default:(registry_default_base_url "gemini")
+;;
 
 let glm_api_url () =
   env_url_or ~env:"ZAI_BASE_URL" ~default:Llm_provider.Zai_catalog.general_base_url
+;;
 
 let glm_coding_api_url () =
   env_url_or ~env:"ZAI_CODING_BASE_URL" ~default:Llm_provider.Zai_catalog.coding_base_url
+;;
 
 let moonshot_compat_base_url = "https://api.moonshot.ai/v1"
-
-let kimi_api_url () =
-  env_url_or ~env:"KIMI_BASE_URL" ~default:moonshot_compat_base_url
-
+let kimi_api_url () = env_url_or ~env:"KIMI_BASE_URL" ~default:moonshot_compat_base_url
 let kimi_coding_base_url = "https://api.kimi.com/coding/v1"
 
 let kimi_coding_api_url () =
   env_url_or ~env:"KIMI_CODING_BASE_URL" ~default:kimi_coding_base_url
-(** SSOT cascade prefix for local llama-server instances.
+;;
+
+(* SSOT cascade prefix for local llama-server instances.
     All cascade label construction for local models must use this constant.
     Format: [local_cascade_prefix ^ ":" ^ model_id] → e.g. "llama:qwen3.5" *)
 let local_cascade_prefix = cn_llama
 
 (** Build a cascade model label for a local model.
     Single entry point — other modules must not concatenate prefix manually. *)
-let make_local_label (model_id : string) : string =
-  local_cascade_prefix ^ ":" ^ model_id
+let make_local_label (model_id : string) : string = local_cascade_prefix ^ ":" ^ model_id
 
 (** SSOT string form of OAS [provider_kind].
     This must stay aligned with [Provider_config.string_of_provider_kind]. *)
-let string_of_provider_kind
-    : Llm_provider.Provider_config.provider_kind -> string
-  = Llm_provider.Provider_config.string_of_provider_kind
+let string_of_provider_kind : Llm_provider.Provider_config.provider_kind -> string =
+  Llm_provider.Provider_config.string_of_provider_kind
+;;
 
 (** Map OAS [provider_kind] to the MASC adapter canonical name when adapter
     semantics are required.
@@ -300,7 +313,7 @@ let string_of_provider_kind
     llama remains an [OpenAI_compat] kind but is identified by endpoint rather
     than by this helper. *)
 let adapter_canonical_name_of_provider_kind
-    : Llm_provider.Provider_config.provider_kind -> string
+  : Llm_provider.Provider_config.provider_kind -> string
   = function
   | Anthropic -> cn_claude_api
   | Kimi -> cn_kimi_api
@@ -313,157 +326,140 @@ let adapter_canonical_name_of_provider_kind
   | Glm -> cn_glm
   | Claude_code -> cn_claude
   | Codex_cli -> cn_codex
+;;
 
 (** Single source of truth for all provider/runtime adapters.
     Simple names ([claude], [codex], [gemini]) are CLI runtimes.
     Direct API adapters use explicit [*-api] canonical names. *)
 let direct_adapters =
-  [
-    {
-      canonical_name = cn_llama;
-      runtime_kind = Local;
-      auth_mode = No_auth;
-      aliases = [ cn_llama; "llama.cpp"; "llamacpp" ];
-      spawn_key = Some "llama";
-      cascade_prefix = "llama";
-      default_voice = Some "Laura";
-      endpoint_url = Some Env_config_runtime.Llama.server_url;
-      default_model_id =
+  [ { canonical_name = cn_llama
+    ; runtime_kind = Local
+    ; auth_mode = No_auth
+    ; aliases = [ cn_llama; "llama.cpp"; "llamacpp" ]
+    ; spawn_key = Some "llama"
+    ; cascade_prefix = "llama"
+    ; default_voice = Some "Laura"
+    ; endpoint_url = Some Env_config_runtime.Llama.server_url
+    ; default_model_id =
         (let m = Env_config_runtime.Llama.default_model in
-         if m = "" || m = "explicit-model-required" then None else Some m);
-      model_policy =
-        {
-          default_model_env = Some "LLAMA_DEFAULT_MODEL";
-          default_model_fallback = None;
-          auto_models = No_auto_models;
-          expand_auto = false;
-          family = Generic;
-        };
-      tool_policy = no_tool_http_headers;
-      telemetry_policy = telemetry_reported;
-    };
-    {
-      canonical_name = cn_ollama;
-      runtime_kind = Local;
-      auth_mode = No_auth;
-      aliases = [ cn_ollama; "ollama-local" ];
-      spawn_key = None;
-      cascade_prefix = "ollama";
-      default_voice = None;
-      endpoint_url = Some Env_config_runtime.Ollama.server_url;
-      default_model_id =
+         if m = "" || m = "explicit-model-required" then None else Some m)
+    ; model_policy =
+        { default_model_env = Some "LLAMA_DEFAULT_MODEL"
+        ; default_model_fallback = None
+        ; auto_models = No_auto_models
+        ; expand_auto = false
+        ; family = Generic
+        }
+    ; tool_policy = no_tool_http_headers
+    ; telemetry_policy = telemetry_reported
+    }
+  ; { canonical_name = cn_ollama
+    ; runtime_kind = Local
+    ; auth_mode = No_auth
+    ; aliases = [ cn_ollama; "ollama-local" ]
+    ; spawn_key = None
+    ; cascade_prefix = "ollama"
+    ; default_voice = None
+    ; endpoint_url = Some Env_config_runtime.Ollama.server_url
+    ; default_model_id =
         (let m = Env_config_runtime.Ollama.default_model in
-         if m = "" then None else Some m);
-      model_policy =
-        {
-          default_model_env = Some "OLLAMA_DEFAULT_MODEL";
-          default_model_fallback = None;
-          auto_models = No_auto_models;
-          expand_auto = false;
-          family = Generic;
-        };
-      tool_policy =
-        { no_tool_http_headers with tolerates_bound_actor_fallback = true };
-      telemetry_policy = telemetry_usage_missing_runtime_reported;
-    };
-    {
-      canonical_name = cn_claude;
-      runtime_kind = Cli_agent;
-      auth_mode = Cli_cached_login;
-      aliases = [ cn_claude; "claude-code"; "claude_code" ];
-      spawn_key = Some "claude";
-      cascade_prefix = "claude_code";
-      default_voice = Some "Sarah";
-      endpoint_url = None;
-      default_model_id = Some "auto";
-      model_policy =
-        {
-          default_model_env = None;
-          default_model_fallback = Some "auto";
-          auto_models =
+         if m = "" then None else Some m)
+    ; model_policy =
+        { default_model_env = Some "OLLAMA_DEFAULT_MODEL"
+        ; default_model_fallback = None
+        ; auto_models = No_auto_models
+        ; expand_auto = false
+        ; family = Generic
+        }
+    ; tool_policy = { no_tool_http_headers with tolerates_bound_actor_fallback = true }
+    ; telemetry_policy = telemetry_usage_missing_runtime_reported
+    }
+  ; { canonical_name = cn_claude
+    ; runtime_kind = Cli_agent
+    ; auth_mode = Cli_cached_login
+    ; aliases = [ cn_claude; "claude-code"; "claude_code" ]
+    ; spawn_key = Some "claude"
+    ; cascade_prefix = "claude_code"
+    ; default_voice = Some "Sarah"
+    ; endpoint_url = None
+    ; default_model_id = Some "auto"
+    ; model_policy =
+        { default_model_env = None
+        ; default_model_fallback = Some "auto"
+        ; auto_models =
             Env_csv_or_default
-              {
-                env_var = "MASC_CLAUDE_CODE_AUTO_MODELS";
-                defaults = [ "auto" ];
-                prefer_default_model_env = false;
-              };
-          expand_auto = true;
-          family = Generic;
-        };
-      tool_policy =
-        {
-          runtime_mcp_http_headers with
-          uses_anthropic_caching = true;
-          max_turns_per_attempt = Some 30;
-          tolerates_bound_actor_fallback = true;
-        };
-      telemetry_policy = telemetry_usage_missing_runtime_reported;
-    };
-    {
-      canonical_name = cn_codex;
-      runtime_kind = Cli_agent;
-      auth_mode = Cli_cached_login;
-      aliases = [ cn_codex; "codex-cli"; "codex_cli" ];
-      spawn_key = Some "codex";
-      cascade_prefix = "codex_cli";
-      default_voice = Some "George";
-      endpoint_url = None;
-      default_model_id = Some "auto";
-      model_policy =
-        {
-          default_model_env = None;
-          default_model_fallback = Some "auto";
-          auto_models =
+              { env_var = "MASC_CLAUDE_CODE_AUTO_MODELS"
+              ; defaults = [ "auto" ]
+              ; prefer_default_model_env = false
+              }
+        ; expand_auto = true
+        ; family = Generic
+        }
+    ; tool_policy =
+        { runtime_mcp_http_headers with
+          uses_anthropic_caching = true
+        ; max_turns_per_attempt = Some 30
+        ; tolerates_bound_actor_fallback = true
+        }
+    ; telemetry_policy = telemetry_usage_missing_runtime_reported
+    }
+  ; { canonical_name = cn_codex
+    ; runtime_kind = Cli_agent
+    ; auth_mode = Cli_cached_login
+    ; aliases = [ cn_codex; "codex-cli"; "codex_cli" ]
+    ; spawn_key = Some "codex"
+    ; cascade_prefix = "codex_cli"
+    ; default_voice = Some "George"
+    ; endpoint_url = None
+    ; default_model_id = Some "auto"
+    ; model_policy =
+        { default_model_env = None
+        ; default_model_fallback = Some "auto"
+        ; auto_models =
             Env_csv_or_default
-              {
-                env_var = "MASC_CODEX_CLI_AUTO_MODELS";
-                defaults =
-                  [
-                    "gpt-5.2";
-                    "gpt-5.3-codex-spark";
-                    "gpt-5.3-codex";
-                    "gpt-5.4-mini";
-                    "gpt-5.4";
-                    "gpt-5.5";
-                  ];
-                prefer_default_model_env = false;
-              };
-          expand_auto = true;
-          family = Generic;
-        };
-      tool_policy = codex_cli_tool_policy;
-      telemetry_policy = telemetry_usage_missing_runtime_reported;
-    };
-    {
-      canonical_name = cn_gemini;
-      runtime_kind = Cli_agent;
-      auth_mode = Cli_cached_login;
-      aliases = [ cn_gemini; "gemini-cli"; "gemini_cli" ];
-      spawn_key = Some "gemini";
-      cascade_prefix = "gemini_cli";
-      default_voice = Some "Roger";
-      endpoint_url = None;
-      default_model_id = Some "auto";
-      model_policy =
-        {
-          default_model_env = Some "GEMINI_DEFAULT_MODEL";
-          default_model_fallback = Some "gemini-3-flash-preview";
-          auto_models =
+              { env_var = "MASC_CODEX_CLI_AUTO_MODELS"
+              ; defaults =
+                  [ "gpt-5.2"
+                  ; "gpt-5.3-codex-spark"
+                  ; "gpt-5.3-codex"
+                  ; "gpt-5.4-mini"
+                  ; "gpt-5.4"
+                  ; "gpt-5.5"
+                  ]
+              ; prefer_default_model_env = false
+              }
+        ; expand_auto = true
+        ; family = Generic
+        }
+    ; tool_policy = codex_cli_tool_policy
+    ; telemetry_policy = telemetry_usage_missing_runtime_reported
+    }
+  ; { canonical_name = cn_gemini
+    ; runtime_kind = Cli_agent
+    ; auth_mode = Cli_cached_login
+    ; aliases = [ cn_gemini; "gemini-cli"; "gemini_cli" ]
+    ; spawn_key = Some "gemini"
+    ; cascade_prefix = "gemini_cli"
+    ; default_voice = Some "Roger"
+    ; endpoint_url = None
+    ; default_model_id = Some "auto"
+    ; model_policy =
+        { default_model_env = Some "GEMINI_DEFAULT_MODEL"
+        ; default_model_fallback = Some "gemini-3-flash-preview"
+        ; auto_models =
             Env_csv_or_default
-              {
-                env_var = "MASC_GEMINI_CLI_AUTO_MODELS";
-                defaults =
-                  [
-                    "gemini-3-flash-preview";
-                    "gemini-3.1-flash-lite-preview";
-                    "gemini-3.1-pro-preview";
-                  ];
-                prefer_default_model_env = true;
-              };
-          expand_auto = true;
-          family = Generic;
-        };
-      (* gemini-cli reads MCP servers only from ~/.gemini/settings.json or
+              { env_var = "MASC_GEMINI_CLI_AUTO_MODELS"
+              ; defaults =
+                  [ "gemini-3-flash-preview"
+                  ; "gemini-3.1-flash-lite-preview"
+                  ; "gemini-3.1-pro-preview"
+                  ]
+              ; prefer_default_model_env = true
+              }
+        ; expand_auto = true
+        ; family = Generic
+        }
+    ; (* gemini-cli reads MCP servers only from ~/.gemini/settings.json or
          project .gemini/settings.json (no --mcp-config flag — see
          google-gemini/gemini-cli#3470 closed via PR #5481 which added
          the [gemini mcp add] subcommand for the global file, and #4674
@@ -475,306 +471,289 @@ let direct_adapters =
          lib/llm_provider/transport_gemini_cli.ml (runtime_mcp_policy = Some
          _ branch). Keep this false until upstream adds per-invocation
          MCP config injection. See masc-mcp#11356 for full analysis. *)
-      tool_policy =
-        { no_tool_http_headers with tolerates_bound_actor_fallback = true };
-      telemetry_policy = telemetry_usage_missing_runtime_reported;
-    };
-    {
-      canonical_name = cn_kimi;
-      runtime_kind = Cli_agent;
-      auth_mode = Cli_cached_login;
-      aliases = [ cn_kimi; "kimi-cli"; "kimi_cli" ];
-      spawn_key = None;
-      cascade_prefix = "kimi_cli";
-      default_voice = None;
-      endpoint_url = None;
-      default_model_id = Some "auto";
-      model_policy =
-        {
-          default_model_env = None;
-          default_model_fallback = Some "kimi-for-coding";
-          auto_models =
+      tool_policy = { no_tool_http_headers with tolerates_bound_actor_fallback = true }
+    ; telemetry_policy = telemetry_usage_missing_runtime_reported
+    }
+  ; { canonical_name = cn_kimi
+    ; runtime_kind = Cli_agent
+    ; auth_mode = Cli_cached_login
+    ; aliases = [ cn_kimi; "kimi-cli"; "kimi_cli" ]
+    ; spawn_key = None
+    ; cascade_prefix = "kimi_cli"
+    ; default_voice = None
+    ; endpoint_url = None
+    ; default_model_id = Some "auto"
+    ; model_policy =
+        { default_model_env = None
+        ; default_model_fallback = Some "kimi-for-coding"
+        ; auto_models =
             Env_csv_or_default
-              {
-                env_var = "MASC_KIMI_CLI_AUTO_MODELS";
-                defaults = [ "kimi-for-coding" ];
-                prefer_default_model_env = false;
-              };
-          expand_auto = true;
-          family = Generic;
-        };
-      tool_policy =
-        { runtime_mcp_http_headers with tolerates_bound_actor_fallback = true };
-      telemetry_policy = telemetry_usage_missing;
-    };
-    {
-      canonical_name = cn_claude_api;
-      runtime_kind = Direct_api;
-      auth_mode = Api_key "ANTHROPIC_API_KEY";
-      aliases = [ cn_claude_api; "anthropic" ];
-      spawn_key = None;
-      cascade_prefix = "claude";
-      default_voice = Some "Sarah";
-      endpoint_url = Some (anthropic_api_url ());
-      default_model_id = Some "auto";
-      model_policy =
-        {
-          default_model_env = Some "ANTHROPIC_DEFAULT_MODEL";
-          default_model_fallback = Some "claude-sonnet-4-6-20250514";
-          auto_models = No_auto_models;
-          expand_auto = false;
-          family = Generic;
-        };
-      tool_policy =
-        { no_tool_http_headers with uses_anthropic_caching = true };
-      telemetry_policy = telemetry_reported;
-    };
-    {
-      canonical_name = cn_codex_api;
-      runtime_kind = Direct_api;
-      auth_mode = Api_key "OPENAI_API_KEY";
-      aliases = [ cn_codex_api; "openai" ];
-      spawn_key = None;
-      cascade_prefix = "openai";
-      default_voice = Some "George";
-      endpoint_url = Some (openai_api_url ());
-      default_model_id = Some "auto";
-      model_policy =
-        {
-          default_model_env = Some "OPENAI_DEFAULT_MODEL";
-          default_model_fallback = Some "gpt-4.1";
-          auto_models = No_auto_models;
-          expand_auto = false;
-          family = Generic;
-        };
-      tool_policy = no_tool_http_headers;
-      telemetry_policy = telemetry_reported;
-    };
-    {
-      canonical_name = cn_gemini_api;
-      runtime_kind = Direct_api;
-      auth_mode =
+              { env_var = "MASC_KIMI_CLI_AUTO_MODELS"
+              ; defaults = [ "kimi-for-coding" ]
+              ; prefer_default_model_env = false
+              }
+        ; expand_auto = true
+        ; family = Generic
+        }
+    ; tool_policy =
+        { runtime_mcp_http_headers with tolerates_bound_actor_fallback = true }
+    ; telemetry_policy = telemetry_usage_missing
+    }
+  ; { canonical_name = cn_claude_api
+    ; runtime_kind = Direct_api
+    ; auth_mode = Api_key "ANTHROPIC_API_KEY"
+    ; aliases = [ cn_claude_api; "anthropic" ]
+    ; spawn_key = None
+    ; cascade_prefix = "claude"
+    ; default_voice = Some "Sarah"
+    ; endpoint_url = Some (anthropic_api_url ())
+    ; default_model_id = Some "auto"
+    ; model_policy =
+        { default_model_env = Some "ANTHROPIC_DEFAULT_MODEL"
+        ; default_model_fallback = Some "claude-sonnet-4-6-20250514"
+        ; auto_models = No_auto_models
+        ; expand_auto = false
+        ; family = Generic
+        }
+    ; tool_policy = { no_tool_http_headers with uses_anthropic_caching = true }
+    ; telemetry_policy = telemetry_reported
+    }
+  ; { canonical_name = cn_codex_api
+    ; runtime_kind = Direct_api
+    ; auth_mode = Api_key "OPENAI_API_KEY"
+    ; aliases = [ cn_codex_api; "openai" ]
+    ; spawn_key = None
+    ; cascade_prefix = "openai"
+    ; default_voice = Some "George"
+    ; endpoint_url = Some (openai_api_url ())
+    ; default_model_id = Some "auto"
+    ; model_policy =
+        { default_model_env = Some "OPENAI_DEFAULT_MODEL"
+        ; default_model_fallback = Some "gpt-4.1"
+        ; auto_models = No_auto_models
+        ; expand_auto = false
+        ; family = Generic
+        }
+    ; tool_policy = no_tool_http_headers
+    ; telemetry_policy = telemetry_reported
+    }
+  ; { canonical_name = cn_gemini_api
+    ; runtime_kind = Direct_api
+    ; auth_mode =
         Vertex_adc
-          {
-            project_env = google_cloud_project_env;
-            location_env = google_cloud_location_env;
-          };
-      aliases = [ cn_gemini_api; "google" ];
-      spawn_key = None;
-      cascade_prefix = "gemini";
-      default_voice = Some "Roger";
-      endpoint_url = None; (** Resolved dynamically for Gemini *)
-      default_model_id = Some "auto";
-      model_policy =
-        {
-          default_model_env = Some "GEMINI_DEFAULT_MODEL";
-          default_model_fallback = Some "gemini-3-flash-preview";
-          auto_models = No_auto_models;
-          expand_auto = false;
-          family = Generic;
-        };
-      tool_policy = no_tool_http_headers;
-      telemetry_policy = telemetry_reported;
-    };
-    {
-      canonical_name = cn_kimi_api;
-      runtime_kind = Direct_api;
-      auth_mode = Api_key "KIMI_API_KEY_SB";
-      aliases = [ cn_kimi_api; "moonshot" ];
-      spawn_key = None;
-      cascade_prefix = "kimi";
-      default_voice = None;
-      endpoint_url = Some (kimi_api_url ());
-      default_model_id = Some "auto";
-      model_policy =
-        {
-          default_model_env = Some "KIMI_DEFAULT_MODEL";
-          default_model_fallback = Some "kimi-k2.5";
-          auto_models = No_auto_models;
-          expand_auto = false;
-          family = Kimi_api_family;
-        };
-      tool_policy = no_tool_http_headers;
-      telemetry_policy = telemetry_reported;
-    };
-    {
-      canonical_name = cn_kimi_coding;
-      runtime_kind = Direct_api;
-      auth_mode = Api_key "KIMI_CODING_API_KEY";
-      aliases = [ cn_kimi_coding; "kimi_coding" ];
-      spawn_key = None;
-      cascade_prefix = "kimi_coding";
-      default_voice = None;
-      endpoint_url = Some (kimi_coding_api_url ());
-      default_model_id = Some "auto";
-      model_policy =
-        {
-          default_model_env = Some "KIMI_CODING_DEFAULT_MODEL";
-          default_model_fallback = Some "kimi-coding-auto";
-          auto_models = No_auto_models;
-          expand_auto = false;
-          family = Kimi_api_family;
-        };
-      tool_policy = no_tool_http_headers;
-      telemetry_policy = telemetry_reported;
-    };
-    {
-      canonical_name = cn_glm;
-      runtime_kind = Direct_api;
-      auth_mode = Api_key "ZAI_API_KEY";
-      aliases = [ cn_glm; "glm"; "glm_cloud"; "zai" ];
-      spawn_key = None;
-      cascade_prefix = "glm";
-      default_voice = None;
-      endpoint_url = Some (glm_api_url ());
-      default_model_id = Some "auto";
-      model_policy =
-        {
-          default_model_env = Some "ZAI_DEFAULT_MODEL";
-          default_model_fallback = Some "glm-5.1";
-          auto_models = Zai_general_auto_models;
-          expand_auto = true;
-          family = Glm_general;
-        };
-      tool_policy = no_tool_http_headers;
-      telemetry_policy = telemetry_reported;
-    };
-    {
-      canonical_name = cn_glm_coding_plan;
-      runtime_kind = Direct_api;
-      auth_mode = Api_key "ZAI_API_KEY";
-      aliases = [ cn_glm_coding_plan; "glm-coding" ];
-      spawn_key = None;
-      cascade_prefix = "glm-coding";
-      default_voice = None;
-      endpoint_url = Some (glm_coding_api_url ());
-      default_model_id = Some "auto";
-      model_policy =
-        {
-          default_model_env = Some "ZAI_CODING_DEFAULT_MODEL";
-          default_model_fallback = Some "glm-5.1";
-          auto_models = Zai_coding_auto_models;
-          expand_auto = true;
-          family = Glm_coding;
-        };
-      tool_policy = no_tool_http_headers;
-      telemetry_policy = telemetry_reported;
-    };
-    {
-      canonical_name = cn_openrouter;
-      runtime_kind = Direct_api;
-      auth_mode = Api_key "OPENROUTER_API_KEY";
-      aliases = [ cn_openrouter ];
-      spawn_key = None;
-      cascade_prefix = "openrouter";
-      default_voice = None;
-      endpoint_url = Some (openrouter_api_url ());
-      default_model_id = None;
-      model_policy =
-        {
-          default_model_env = Some "OPENROUTER_DEFAULT_MODEL";
-          default_model_fallback = None;
-          auto_models = No_auto_models;
-          expand_auto = false;
-          family = Generic;
-        };
-      tool_policy = no_tool_http_headers;
-      telemetry_policy = telemetry_reported;
-    };
+          { project_env = google_cloud_project_env
+          ; location_env = google_cloud_location_env
+          }
+    ; aliases = [ cn_gemini_api; "google" ]
+    ; spawn_key = None
+    ; cascade_prefix = "gemini"
+    ; default_voice = Some "Roger"
+    ; endpoint_url = None
+    ; (* Resolved dynamically for Gemini *)
+      default_model_id = Some "auto"
+    ; model_policy =
+        { default_model_env = Some "GEMINI_DEFAULT_MODEL"
+        ; default_model_fallback = Some "gemini-3-flash-preview"
+        ; auto_models = No_auto_models
+        ; expand_auto = false
+        ; family = Generic
+        }
+    ; tool_policy = no_tool_http_headers
+    ; telemetry_policy = telemetry_reported
+    }
+  ; { canonical_name = cn_kimi_api
+    ; runtime_kind = Direct_api
+    ; auth_mode = Api_key "KIMI_API_KEY_SB"
+    ; aliases = [ cn_kimi_api; "moonshot" ]
+    ; spawn_key = None
+    ; cascade_prefix = "kimi"
+    ; default_voice = None
+    ; endpoint_url = Some (kimi_api_url ())
+    ; default_model_id = Some "auto"
+    ; model_policy =
+        { default_model_env = Some "KIMI_DEFAULT_MODEL"
+        ; default_model_fallback = Some "kimi-k2.5"
+        ; auto_models = No_auto_models
+        ; expand_auto = false
+        ; family = Kimi_api_family
+        }
+    ; tool_policy = no_tool_http_headers
+    ; telemetry_policy = telemetry_reported
+    }
+  ; { canonical_name = cn_kimi_coding
+    ; runtime_kind = Direct_api
+    ; auth_mode = Api_key "KIMI_CODING_API_KEY"
+    ; aliases = [ cn_kimi_coding; "kimi_coding" ]
+    ; spawn_key = None
+    ; cascade_prefix = "kimi_coding"
+    ; default_voice = None
+    ; endpoint_url = Some (kimi_coding_api_url ())
+    ; default_model_id = Some "auto"
+    ; model_policy =
+        { default_model_env = Some "KIMI_CODING_DEFAULT_MODEL"
+        ; default_model_fallback = Some "kimi-coding-auto"
+        ; auto_models = No_auto_models
+        ; expand_auto = false
+        ; family = Kimi_api_family
+        }
+    ; tool_policy = no_tool_http_headers
+    ; telemetry_policy = telemetry_reported
+    }
+  ; { canonical_name = cn_glm
+    ; runtime_kind = Direct_api
+    ; auth_mode = Api_key "ZAI_API_KEY"
+    ; aliases = [ cn_glm; "glm"; "glm_cloud"; "zai" ]
+    ; spawn_key = None
+    ; cascade_prefix = "glm"
+    ; default_voice = None
+    ; endpoint_url = Some (glm_api_url ())
+    ; default_model_id = Some "auto"
+    ; model_policy =
+        { default_model_env = Some "ZAI_DEFAULT_MODEL"
+        ; default_model_fallback = Some "glm-5.1"
+        ; auto_models = Zai_general_auto_models
+        ; expand_auto = true
+        ; family = Glm_general
+        }
+    ; tool_policy = no_tool_http_headers
+    ; telemetry_policy = telemetry_reported
+    }
+  ; { canonical_name = cn_glm_coding_plan
+    ; runtime_kind = Direct_api
+    ; auth_mode = Api_key "ZAI_API_KEY"
+    ; aliases = [ cn_glm_coding_plan; "glm-coding" ]
+    ; spawn_key = None
+    ; cascade_prefix = "glm-coding"
+    ; default_voice = None
+    ; endpoint_url = Some (glm_coding_api_url ())
+    ; default_model_id = Some "auto"
+    ; model_policy =
+        { default_model_env = Some "ZAI_CODING_DEFAULT_MODEL"
+        ; default_model_fallback = Some "glm-5.1"
+        ; auto_models = Zai_coding_auto_models
+        ; expand_auto = true
+        ; family = Glm_coding
+        }
+    ; tool_policy = no_tool_http_headers
+    ; telemetry_policy = telemetry_reported
+    }
+  ; { canonical_name = cn_openrouter
+    ; runtime_kind = Direct_api
+    ; auth_mode = Api_key "OPENROUTER_API_KEY"
+    ; aliases = [ cn_openrouter ]
+    ; spawn_key = None
+    ; cascade_prefix = "openrouter"
+    ; default_voice = None
+    ; endpoint_url = Some (openrouter_api_url ())
+    ; default_model_id = None
+    ; model_policy =
+        { default_model_env = Some "OPENROUTER_DEFAULT_MODEL"
+        ; default_model_fallback = None
+        ; auto_models = No_auto_models
+        ; expand_auto = false
+        ; family = Generic
+        }
+    ; tool_policy = no_tool_http_headers
+    ; telemetry_policy = telemetry_reported
+    }
   ]
+;;
 
 let find_direct_adapter_by_alias label =
   let normalized = normalize_label label in
   List.find_opt
     (fun (adapter : adapter) ->
-      List.exists (fun alias -> normalize_label alias = normalized) adapter.aliases)
+       List.exists (fun alias -> normalize_label alias = normalized) adapter.aliases)
     direct_adapters
+;;
 
 let resolve_adapter_by_cascade_prefix label =
   let normalized = normalize_label label in
   List.find_opt
-    (fun (adapter : adapter) ->
-      normalize_label adapter.cascade_prefix = normalized)
+    (fun (adapter : adapter) -> normalize_label adapter.cascade_prefix = normalized)
     direct_adapters
+;;
 
 let resolve_model_policy_default ?getenv (policy : model_policy) =
   match policy.default_model_env with
-  | Some env_name -> (
-      match env_value_opt ?getenv env_name with
-      | Some _ as value -> value
-      | None -> policy.default_model_fallback)
+  | Some env_name ->
+    (match env_value_opt ?getenv env_name with
+     | Some _ as value -> value
+     | None -> policy.default_model_fallback)
   | None -> policy.default_model_fallback
+;;
 
 let resolve_auto_models ?getenv (policy : model_policy) =
   match policy.auto_models with
   | No_auto_models -> None
   | Zai_general_auto_models -> Some (Llm_provider.Zai_catalog.glm_auto_models ())
   | Zai_coding_auto_models -> Some (Llm_provider.Zai_catalog.glm_coding_auto_models ())
-  | Env_csv_or_default { env_var; defaults; prefer_default_model_env } -> (
-      match env_value_opt ?getenv env_var with
-      | Some raw -> (
-          match csv_items raw with
-          | [] -> Some defaults
-          | items -> Some items)
-      | None when prefer_default_model_env -> (
-          match policy.default_model_env with
-          | Some default_env -> (
-              match env_value_opt ?getenv default_env with
-              | Some model_id -> Some [ model_id ]
-              | None -> Some defaults)
-          | None -> Some defaults)
-      | None -> Some defaults)
+  | Env_csv_or_default { env_var; defaults; prefer_default_model_env } ->
+    (match env_value_opt ?getenv env_var with
+     | Some raw ->
+       (match csv_items raw with
+        | [] -> Some defaults
+        | items -> Some items)
+     | None when prefer_default_model_env ->
+       (match policy.default_model_env with
+        | Some default_env ->
+          (match env_value_opt ?getenv default_env with
+           | Some model_id -> Some [ model_id ]
+           | None -> Some defaults)
+        | None -> Some defaults)
+     | None -> Some defaults)
+;;
 
 let default_model_id_for_cascade_prefix ?getenv provider_name =
   match resolve_adapter_by_cascade_prefix provider_name with
   | Some adapter -> resolve_model_policy_default ?getenv adapter.model_policy
   | None -> None
+;;
 
 let auto_models_for_provider ?getenv provider_name =
   match find_direct_adapter_by_alias provider_name with
   | Some adapter when adapter.model_policy.expand_auto ->
-      resolve_auto_models ?getenv adapter.model_policy
+    resolve_auto_models ?getenv adapter.model_policy
   | Some _ -> None
   | None -> None
+;;
 
 let auto_models_for_cascade_prefix ?getenv provider_name =
   match resolve_adapter_by_cascade_prefix provider_name with
   | Some adapter when adapter.model_policy.expand_auto ->
-      resolve_auto_models ?getenv adapter.model_policy
+    resolve_auto_models ?getenv adapter.model_policy
   | Some _ -> None
   | None -> None
+;;
 
 let voice_openai_compat_adapter =
-  {
-    canonical_name = "voice-openai-compat";
-    transport = Voice_openai_compat;
-    auth_mode = No_auth;
-    aliases =
-      [ "voice-openai-compat"; "openai_compat"; "openai"; "railway-elevenlabs-proxy" ];
+  { canonical_name = "voice-openai-compat"
+  ; transport = Voice_openai_compat
+  ; auth_mode = No_auth
+  ; aliases =
+      [ "voice-openai-compat"; "openai_compat"; "openai"; "railway-elevenlabs-proxy" ]
   }
+;;
 
 let voice_elevenlabs_direct_adapter =
-  {
-    canonical_name = "elevenlabs-direct";
-    transport = Voice_elevenlabs_direct;
-    auth_mode = Api_key "ELEVENLABS_API_KEY";
-    aliases = [ "elevenlabs-direct"; "elevenlabs"; "tts-elevenlabs" ];
+  { canonical_name = "elevenlabs-direct"
+  ; transport = Voice_elevenlabs_direct
+  ; auth_mode = Api_key "ELEVENLABS_API_KEY"
+  ; aliases = [ "elevenlabs-direct"; "elevenlabs"; "tts-elevenlabs" ]
   }
+;;
 
 let voice_mcp_adapter =
-  {
-    canonical_name = "voice-mcp";
-    transport = Voice_mcp;
-    auth_mode = No_auth;
-    aliases = [ "voice-mcp"; "voice_mcp"; "mcp"; "local-voice-mcp" ];
+  { canonical_name = "voice-mcp"
+  ; transport = Voice_mcp
+  ; auth_mode = No_auth
+  ; aliases = [ "voice-mcp"; "voice_mcp"; "mcp"; "local-voice-mcp" ]
   }
+;;
 
 let voice_adapters =
-  [
-    voice_openai_compat_adapter;
-    voice_elevenlabs_direct_adapter;
-    voice_mcp_adapter;
-  ]
+  [ voice_openai_compat_adapter; voice_elevenlabs_direct_adapter; voice_mcp_adapter ]
+;;
 
 (** The "custom" provider prefix represents user-provided self-hosted
     endpoints (e.g. "custom:model@url").  It is not in [direct_adapters]
@@ -791,9 +770,10 @@ let requires_discovery pname =
   let normalized = normalize_label pname in
   List.exists
     (fun (adapter : adapter) ->
-      adapter.runtime_kind = Local
-      && List.exists (fun alias -> normalize_label alias = normalized) adapter.aliases)
+       adapter.runtime_kind = Local
+       && List.exists (fun alias -> normalize_label alias = normalized) adapter.aliases)
     direct_adapters
+;;
 
 (** Returns true if the provider is self-hosted and always considered
     available (no API key validation needed).  Covers both
@@ -801,6 +781,7 @@ let requires_discovery pname =
 let is_local_provider pname =
   let normalized = normalize_label pname in
   normalized = cn_custom || requires_discovery pname
+;;
 
 (** Default fallback label for local runtime when no other preferred
     model labels are configured.  Uses "provider:auto" for the first
@@ -813,12 +794,15 @@ let default_local_fallback_label () =
   with
   | Some adapter -> adapter.canonical_name ^ ":auto"
   | None -> "auto"
+;;
 
-let resolve_direct_adapter label =
-  find_direct_adapter_by_alias label
+let resolve_direct_adapter label = find_direct_adapter_by_alias label
 
 let resolve_direct_canonical_name label =
-  Option.map (fun (adapter : adapter) -> adapter.canonical_name) (resolve_direct_adapter label)
+  Option.map
+    (fun (adapter : adapter) -> adapter.canonical_name)
+    (resolve_direct_adapter label)
+;;
 
 (** Resolve spawn_key for an agent label.
     Returns the key to look up in Spawn.spawn_config_of_key. *)
@@ -826,20 +810,21 @@ let resolve_spawn_key label =
   match resolve_direct_adapter label with
   | Some adapter -> adapter.spawn_key
   | None -> None
+;;
 
 (** Check if a name is a known direct adapter label or alias.
     This includes adapters that do not have a CLI spawn_key (e.g. glm, openrouter). *)
-let is_known_provider name =
-  resolve_direct_adapter name <> None
+let is_known_provider name = resolve_direct_adapter name <> None
 
 (** Check if a name is a CLI-spawnable agent (has a spawn_key).
     For a broader "known provider" predicate, use {!is_known_provider}. *)
-let is_spawnable_agent name =
-  resolve_spawn_key name <> None
+let is_spawnable_agent name = resolve_spawn_key name <> None
 
 let spawnable_canonical_names () =
   direct_adapters
-  |> List.filter_map (fun a -> if a.spawn_key <> None then Some a.canonical_name else None)
+  |> List.filter_map (fun a ->
+    if a.spawn_key <> None then Some a.canonical_name else None)
+;;
 
 (** All agent voices as (canonical_name, voice_name) pairs.
     For backward compatibility with voice_bridge_core. *)
@@ -849,28 +834,31 @@ let all_agent_voices () =
     match a.default_voice with
     | Some v -> Some (a.canonical_name, v)
     | None -> None)
+;;
 
 let resolve_voice_adapter label =
   let normalized = normalize_label label in
   List.find_opt
     (fun (adapter : voice_adapter) ->
-      List.exists (fun alias -> normalize_label alias = normalized) adapter.aliases)
+       List.exists (fun alias -> normalize_label alias = normalized) adapter.aliases)
     voice_adapters
+;;
 
 let voice_adapter_labels (adapter : voice_adapter) =
-  adapter.canonical_name
-  :: string_of_voice_transport adapter.transport
-  :: adapter.aliases
+  adapter.canonical_name :: string_of_voice_transport adapter.transport :: adapter.aliases
+;;
 
 let voice_adapter_for_endpoint_kind = function
   | Voice_config.Openai_compat -> voice_openai_compat_adapter
   | Voice_config.Elevenlabs_direct -> voice_elevenlabs_direct_adapter
   | Voice_config.Voice_mcp -> voice_mcp_adapter
+;;
 
 let voice_adapter_for_endpoint (endpoint : Voice_config.endpoint) =
   match resolve_voice_adapter endpoint.id with
   | Some adapter -> adapter
   | None -> voice_adapter_for_endpoint_kind endpoint.kind
+;;
 
 let voice_endpoint_matches_provider_label label (endpoint : Voice_config.endpoint) =
   let normalized = normalize_label label in
@@ -880,7 +868,10 @@ let voice_endpoint_matches_provider_label label (endpoint : Voice_config.endpoin
     :: Voice_config.string_of_endpoint_kind endpoint.kind
     :: voice_adapter_labels adapter
   in
-  List.exists (fun candidate -> String.equal (normalize_label candidate) normalized) candidates
+  List.exists
+    (fun candidate -> String.equal (normalize_label candidate) normalized)
+    candidates
+;;
 
 let select_voice_endpoints ?provider (endpoints : Voice_config.endpoint list) =
   let endpoints =
@@ -888,48 +879,55 @@ let select_voice_endpoints ?provider (endpoints : Voice_config.endpoint list) =
   in
   match provider with
   | Some label when String.trim label <> "" ->
-      List.filter (voice_endpoint_matches_provider_label label) endpoints
+    List.filter (voice_endpoint_matches_provider_label label) endpoints
   | _ -> endpoints
+;;
 
 let voice_auth_env_name ?endpoint_api_key_env (adapter : voice_adapter) =
   match endpoint_api_key_env with
   | Some raw ->
-      let trimmed = String.trim raw in
-      if trimmed <> "" then Some trimmed
-      else (
-        match adapter.auth_mode with
-        | Api_key env_name -> Some env_name
-        | _ -> None)
-  | None -> (
+    let trimmed = String.trim raw in
+    if trimmed <> ""
+    then Some trimmed
+    else (
       match adapter.auth_mode with
       | Api_key env_name -> Some env_name
       | _ -> None)
+  | None ->
+    (match adapter.auth_mode with
+     | Api_key env_name -> Some env_name
+     | _ -> None)
+;;
 
 let voice_endpoint_auth_env_name (endpoint : Voice_config.endpoint) =
   let adapter = voice_adapter_for_endpoint endpoint in
   voice_auth_env_name ?endpoint_api_key_env:endpoint.api_key_env adapter
+;;
 
 let trim_opt = function
   | Some raw ->
-      let trimmed = String.trim raw in
-      if trimmed = "" then None else Some trimmed
+    let trimmed = String.trim raw in
+    if trimmed = "" then None else Some trimmed
   | None -> None
+;;
 
 let normalize_base_url value =
   let trimmed = String.trim value in
-  if String.length trimmed > 1 && String.ends_with ~suffix:"/" trimmed then
-    String.sub trimmed 0 (String.length trimmed - 1)
-  else
-    trimmed
+  if String.length trimmed > 1 && String.ends_with ~suffix:"/" trimmed
+  then String.sub trimmed 0 (String.length trimmed - 1)
+  else trimmed
+;;
 
 let legacy_voice_env_warning_emitted = Atomic.make false
 
 let warn_legacy_voice_env_once () =
-  if not (Atomic.get legacy_voice_env_warning_emitted) then (
+  if not (Atomic.get legacy_voice_env_warning_emitted)
+  then (
     Atomic.set legacy_voice_env_warning_emitted true;
     Log.Misc.warn
       "VOICE_MCP_HOST/PORT fallback is deprecated; prefer .masc/voice_config.json \
        session.endpoints or MASC_HTTP_* listener settings.")
+;;
 
 let legacy_voice_base_url_opt () =
   let host_opt = Sys.getenv_opt "VOICE_MCP_HOST" |> trim_opt in
@@ -937,111 +935,137 @@ let legacy_voice_base_url_opt () =
   match host_opt, port_opt with
   | None, None -> None
   | _ ->
-      warn_legacy_voice_env_once ();
-      let host = Option.value host_opt ~default:(Env_config.Voice.default_host) in
-      let port = Option.value port_opt ~default:(string_of_int Env_config.Voice.default_port) in
-      Some (Printf.sprintf "http://%s:%s" host port)
+    warn_legacy_voice_env_once ();
+    let host = Option.value host_opt ~default:Env_config.Voice.default_host in
+    let port =
+      Option.value port_opt ~default:(string_of_int Env_config.Voice.default_port)
+    in
+    Some (Printf.sprintf "http://%s:%s" host port)
+;;
 
 let http_listener_env_explicit () =
   Option.is_some (Sys.getenv_opt Env_config_core.http_base_url_env_key |> trim_opt)
   || Option.is_some (Sys.getenv_opt Env_config_core.host_env_key |> trim_opt)
   || Option.is_some (Sys.getenv_opt Env_config_core.http_port_env_key |> trim_opt)
+;;
 
 let default_voice_session_base_url () =
   match Sys.getenv_opt Env_config_core.http_base_url_env_key |> trim_opt with
   | Some base_url -> normalize_base_url base_url
   | None ->
-      if http_listener_env_explicit () then
-        Printf.sprintf "http://%s:%s"
-          (Env_config_core.masc_host ()) (Env_config_core.masc_http_port ())
-      else (
-        match legacy_voice_base_url_opt () with
-        | Some legacy_base_url -> normalize_base_url legacy_base_url
-        | None ->
-            Printf.sprintf "http://%s:%s"
-              (Env_config_core.masc_host ()) (Env_config_core.masc_http_port ()))
+    if http_listener_env_explicit ()
+    then
+      Printf.sprintf
+        "http://%s:%s"
+        (Env_config_core.masc_host ())
+        (Env_config_core.masc_http_port ())
+    else (
+      match legacy_voice_base_url_opt () with
+      | Some legacy_base_url -> normalize_base_url legacy_base_url
+      | None ->
+        Printf.sprintf
+          "http://%s:%s"
+          (Env_config_core.masc_host ())
+          (Env_config_core.masc_http_port ()))
+;;
 
 let compose_voice_endpoint_url ~base_url ~path =
   let base_uri = Uri.of_string base_url in
   let base_path = Uri.path base_uri in
   let base_path =
-    if base_path = "" then "/"
-    else if String.ends_with ~suffix:"/" base_path && String.length base_path > 1 then
-      String.sub base_path 0 (String.length base_path - 1)
+    if base_path = ""
+    then "/"
+    else if String.ends_with ~suffix:"/" base_path && String.length base_path > 1
+    then String.sub base_path 0 (String.length base_path - 1)
     else base_path
   in
   let final_path =
-    if path = "/mcp" then
-      if String.ends_with ~suffix:"/mcp" base_path then base_path
-      else if base_path = "/" then "/mcp"
+    if path = "/mcp"
+    then
+      if String.ends_with ~suffix:"/mcp" base_path
+      then base_path
+      else if base_path = "/"
+      then "/mcp"
       else base_path ^ "/mcp"
-    else if path = "/health" then
-      if String.ends_with ~suffix:"/health" base_path then base_path
-      else if String.ends_with ~suffix:"/mcp" base_path then
-        String.sub base_path 0 (String.length base_path - 4) ^ "/health"
-      else if base_path = "/" then "/health"
+    else if path = "/health"
+    then
+      if String.ends_with ~suffix:"/health" base_path
+      then base_path
+      else if String.ends_with ~suffix:"/mcp" base_path
+      then String.sub base_path 0 (String.length base_path - 4) ^ "/health"
+      else if base_path = "/"
+      then "/health"
       else base_path ^ "/health"
-    else if base_path = "/" then path
+    else if base_path = "/"
+    then path
     else base_path ^ path
   in
   Uri.with_path base_uri final_path |> Uri.to_string
+;;
 
 let default_voice_session_url ~path =
   compose_voice_endpoint_url ~base_url:(default_voice_session_base_url ()) ~path
+;;
 
 let voice_session_endpoint_result (config : Voice_config.t) =
   match Voice_config.select_endpoint config.session.endpoints with
   | Some endpoint ->
-      let adapter = voice_adapter_for_endpoint endpoint in
-      if adapter.transport = Voice_mcp then Ok endpoint
-      else
-        Error
-          (Printf.sprintf "session endpoint %s must use kind=voice_mcp" endpoint.id)
+    let adapter = voice_adapter_for_endpoint endpoint in
+    if adapter.transport = Voice_mcp
+    then Ok endpoint
+    else Error (Printf.sprintf "session endpoint %s must use kind=voice_mcp" endpoint.id)
   | None -> Error "no configured session endpoint"
+;;
 
 let voice_session_mcp_url_of_endpoint (endpoint : Voice_config.endpoint) =
   let adapter = voice_adapter_for_endpoint endpoint in
-  if adapter.transport <> Voice_mcp then
+  if adapter.transport <> Voice_mcp
+  then
     Error (Printf.sprintf "session endpoint %s must use voice_mcp transport" endpoint.id)
-  else
+  else (
     match endpoint.mcp_url with
     | Some url -> Ok url
-    | None -> (
-        match endpoint.base_url with
-        | Some base_url -> Ok (compose_voice_endpoint_url ~base_url ~path:"/mcp")
-        | None -> Ok (default_voice_session_url ~path:"/mcp"))
+    | None ->
+      (match endpoint.base_url with
+       | Some base_url -> Ok (compose_voice_endpoint_url ~base_url ~path:"/mcp")
+       | None -> Ok (default_voice_session_url ~path:"/mcp")))
+;;
 
 let voice_session_health_url_of_endpoint (endpoint : Voice_config.endpoint) =
   let adapter = voice_adapter_for_endpoint endpoint in
-  if adapter.transport <> Voice_mcp then
+  if adapter.transport <> Voice_mcp
+  then
     Error (Printf.sprintf "session endpoint %s must use voice_mcp transport" endpoint.id)
-  else
+  else (
     match endpoint.health_url with
     | Some url -> Ok url
-    | None -> (
-        match endpoint.base_url with
-        | Some base_url -> Ok (compose_voice_endpoint_url ~base_url ~path:"/health")
-        | None -> Ok (default_voice_session_url ~path:"/health"))
+    | None ->
+      (match endpoint.base_url with
+       | Some base_url -> Ok (compose_voice_endpoint_url ~base_url ~path:"/health")
+       | None -> Ok (default_voice_session_url ~path:"/health")))
+;;
 
 let voice_transport_supports_http_tts (adapter : voice_adapter) =
   match adapter.transport with
   | Voice_openai_compat | Voice_elevenlabs_direct -> true
   | Voice_mcp -> false
+;;
 
 let voice_endpoint_supports_http_tts (endpoint : Voice_config.endpoint) =
-  voice_adapter_for_endpoint endpoint
-  |> voice_transport_supports_http_tts
+  voice_adapter_for_endpoint endpoint |> voice_transport_supports_http_tts
+;;
 
 (** ElevenLabs base URL — SSOT is [Voice_config.default_elevenlabs_base_url]. *)
 let default_elevenlabs_base_url = Voice_config.default_elevenlabs_base_url
 
 let voice_endpoint_base_url (endpoint : Voice_config.endpoint) =
   match voice_adapter_for_endpoint endpoint with
-  | { transport = Voice_elevenlabs_direct; _ } -> (
-      match endpoint.base_url with
-      | Some value -> Some (normalize_base_url value)
-      | None -> Some default_elevenlabs_base_url)
+  | { transport = Voice_elevenlabs_direct; _ } ->
+    (match endpoint.base_url with
+     | Some value -> Some (normalize_base_url value)
+     | None -> Some default_elevenlabs_base_url)
   | _ -> Option.map normalize_base_url endpoint.base_url
+;;
 
 let elevenlabs_voice_id voice =
   match String.trim voice with
@@ -1051,106 +1075,103 @@ let elevenlabs_voice_id voice =
   | "Laura" -> "FGY2WhTYpPnrIDTdsKH5"
   | "" -> "21m00Tcm4TlvDq8ikWAM"
   | value -> value
+;;
 
-let voice_http_request_for_tts (endpoint : Voice_config.endpoint) ~api_key
-    ~message ~voice ~model ~(tuning : Voice_config.voice_tuning) =
+let voice_http_request_for_tts
+      (endpoint : Voice_config.endpoint)
+      ~api_key
+      ~message
+      ~voice
+      ~model
+      ~(tuning : Voice_config.voice_tuning)
+  =
   let adapter = voice_adapter_for_endpoint endpoint in
   match voice_endpoint_base_url endpoint, adapter.transport with
   | None, _ ->
-      Error
-        (Printf.sprintf "voice config endpoint %s missing base_url" endpoint.id)
+    Error (Printf.sprintf "voice config endpoint %s missing base_url" endpoint.id)
   | Some _, Voice_mcp ->
-      Error
-        (Printf.sprintf
-           "voice config endpoint %s uses voice_mcp and cannot build HTTP TTS request"
-           endpoint.id)
+    Error
+      (Printf.sprintf
+         "voice config endpoint %s uses voice_mcp and cannot build HTTP TTS request"
+         endpoint.id)
   | Some base_url, Voice_openai_compat ->
-      let headers =
-        [ ("Content-Type", "application/json"); ("Accept", "audio/mpeg") ]
-        @
-        if api_key = "" then [] else [ ("Authorization", "Bearer " ^ api_key) ]
-      in
-      let body_json =
-        `Assoc
-          [
-            ("input", `String message);
-            ("voice", `String voice);
-            ("model", `String model);
-            ("response_format", `String "mp3");
-            ( "voice_settings",
-              `Assoc
-                [
-                  ("stability", `Float tuning.stability);
-                  ("similarity_boost", `Float tuning.similarity_boost);
-                  ("style", `Float tuning.style);
-                ] );
-          ]
-      in
-      Ok { url = base_url ^ "/audio/speech"; headers; body_json }
-  | Some base_url, Voice_elevenlabs_direct ->
-      let headers =
-        [
-          ("xi-api-key", api_key);
-          ("Content-Type", "application/json");
-          ("Accept", "audio/mpeg");
+    let headers =
+      [ "Content-Type", "application/json"; "Accept", "audio/mpeg" ]
+      @ if api_key = "" then [] else [ "Authorization", "Bearer " ^ api_key ]
+    in
+    let body_json =
+      `Assoc
+        [ "input", `String message
+        ; "voice", `String voice
+        ; "model", `String model
+        ; "response_format", `String "mp3"
+        ; ( "voice_settings"
+          , `Assoc
+              [ "stability", `Float tuning.stability
+              ; "similarity_boost", `Float tuning.similarity_boost
+              ; "style", `Float tuning.style
+              ] )
         ]
-      in
-      let body_json =
-        `Assoc
-          [
-            ("text", `String message);
-            ("model_id", `String model);
-            ( "voice_settings",
-              `Assoc
-                [
-                  ("stability", `Float tuning.stability);
-                  ("similarity_boost", `Float tuning.similarity_boost);
-                  ("style", `Float tuning.style);
-                ] );
-          ]
-      in
-      Ok
-        {
-          url =
-            Printf.sprintf "%s/text-to-speech/%s" base_url
-              (elevenlabs_voice_id voice);
-          headers;
-          body_json;
-        }
+    in
+    Ok { url = base_url ^ "/audio/speech"; headers; body_json }
+  | Some base_url, Voice_elevenlabs_direct ->
+    let headers =
+      [ "xi-api-key", api_key
+      ; "Content-Type", "application/json"
+      ; "Accept", "audio/mpeg"
+      ]
+    in
+    let body_json =
+      `Assoc
+        [ "text", `String message
+        ; "model_id", `String model
+        ; ( "voice_settings"
+          , `Assoc
+              [ "stability", `Float tuning.stability
+              ; "similarity_boost", `Float tuning.similarity_boost
+              ; "style", `Float tuning.style
+              ] )
+        ]
+    in
+    Ok
+      { url = Printf.sprintf "%s/text-to-speech/%s" base_url (elevenlabs_voice_id voice)
+      ; headers
+      ; body_json
+      }
+;;
 
-let voice_stt_request_for_endpoint (endpoint : Voice_config.endpoint) ~api_key
-    ~audio_file ~model =
+let voice_stt_request_for_endpoint
+      (endpoint : Voice_config.endpoint)
+      ~api_key
+      ~audio_file
+      ~model
+  =
   let adapter = voice_adapter_for_endpoint endpoint in
   match voice_endpoint_base_url endpoint, adapter.transport with
   | None, _ ->
-      Error
-        (Printf.sprintf "voice config endpoint %s missing base_url" endpoint.id)
+    Error (Printf.sprintf "voice config endpoint %s missing base_url" endpoint.id)
   | Some _, Voice_mcp ->
-      Error
-        (Printf.sprintf
-           "voice config endpoint %s uses voice_mcp and cannot build HTTP STT request"
-           endpoint.id)
+    Error
+      (Printf.sprintf
+         "voice config endpoint %s uses voice_mcp and cannot build HTTP STT request"
+         endpoint.id)
   | Some base_url, Voice_openai_compat ->
-      let headers =
-        if api_key = "" then []
-        else [ ("Authorization", "Bearer " ^ api_key) ]
-      in
-      Ok
-        {
-          url = base_url ^ "/audio/transcriptions";
-          headers;
-          form_fields = [ ("model", model) ];
-          file_field = ("file", audio_file);
-        }
+    let headers = if api_key = "" then [] else [ "Authorization", "Bearer " ^ api_key ] in
+    Ok
+      { url = base_url ^ "/audio/transcriptions"
+      ; headers
+      ; form_fields = [ "model", model ]
+      ; file_field = "file", audio_file
+      }
   | Some base_url, Voice_elevenlabs_direct ->
-      let headers = [ ("xi-api-key", api_key) ] in
-      Ok
-        {
-          url = base_url ^ "/speech-to-text";
-          headers;
-          form_fields = [ ("model_id", model) ];
-          file_field = ("file", audio_file);
-        }
+    let headers = [ "xi-api-key", api_key ] in
+    Ok
+      { url = base_url ^ "/speech-to-text"
+      ; headers
+      ; form_fields = [ "model_id", model ]
+      ; file_field = "file", audio_file
+      }
+;;
 
 let default_cli_agent_name () = Env_config_runtime.Cli.default_agent
 
@@ -1159,13 +1180,15 @@ let split_csv_nonempty raw =
   |> String.split_on_char ','
   |> List.map String.trim
   |> List.filter (fun s -> s <> "")
+;;
 
 let nonempty_env name =
   match Sys.getenv_opt name with
   | Some raw ->
-      let trimmed = String.trim raw in
-      if trimmed = "" then None else Some trimmed
+    let trimmed = String.trim raw in
+    if trimmed = "" then None else Some trimmed
   | None -> None
+;;
 
 let env_present name = Option.is_some (nonempty_env name)
 
@@ -1174,6 +1197,7 @@ let auth_env_var_of_adapter (adapter : adapter) =
   match adapter.auth_mode with
   | Api_key env_name -> Some env_name
   | _ -> None
+;;
 
 (** Check whether a provider (by canonical name or alias) has its
     auth credential configured.  Returns [true] for [No_auth] providers
@@ -1181,92 +1205,92 @@ let auth_env_var_of_adapter (adapter : adapter) =
 let provider_auth_available label =
   match resolve_direct_adapter label with
   | Some adapter ->
-      (match adapter.auth_mode with
-       | No_auth -> true
-       | Cli_cached_login ->
-            (match adapter.spawn_key with
-            | Some cmd -> Llm_provider.Provider_registry.command_in_path cmd
-            | None -> false)
-       | Api_key env_name ->
-           env_present env_name
-           || (adapter.canonical_name = cn_kimi_api
-               && List.exists env_present kimi_api_key_envs)
-           || (adapter.canonical_name = cn_kimi_coding
-               && List.exists env_present kimi_coding_key_envs)
-       | Vertex_adc { project_env; _ } -> env_present project_env)
+    (match adapter.auth_mode with
+     | No_auth -> true
+     | Cli_cached_login ->
+       (match adapter.spawn_key with
+        | Some cmd -> Llm_provider.Provider_registry.command_in_path cmd
+        | None -> false)
+     | Api_key env_name ->
+       env_present env_name
+       || (adapter.canonical_name = cn_kimi_api
+           && List.exists env_present kimi_api_key_envs)
+       || (adapter.canonical_name = cn_kimi_coding
+           && List.exists env_present kimi_coding_key_envs)
+     | Vertex_adc { project_env; _ } -> env_present project_env)
   | None -> false
+;;
 
 (** Derive the auth_kind string for a provider by looking up its
     adapter config, instead of hardcoding vendor env var names. *)
 let auth_kind_for_canonical_name name =
   match resolve_direct_adapter name with
   | Some adapter ->
-      if adapter.canonical_name = cn_kimi_api then
-        "api_key:KIMI_API_KEY_SB|KIMI_API_KEY"
-      else if adapter.canonical_name = cn_kimi_coding then
-        "api_key:KIMI_CODING_API_KEY|KIMI_API_KEY_SB"
-      else
-        string_of_auth_mode adapter.auth_mode
+    if adapter.canonical_name = cn_kimi_api
+    then "api_key:KIMI_API_KEY_SB|KIMI_API_KEY"
+    else if adapter.canonical_name = cn_kimi_coding
+    then "api_key:KIMI_CODING_API_KEY|KIMI_API_KEY_SB"
+    else string_of_auth_mode adapter.auth_mode
   | None -> "unknown"
+;;
 
 let bare_ollama_migration_message () =
-  "Bare `ollama` without a model requires OLLAMA_DEFAULT_MODEL env var. Use `ollama:<model>` for explicit selection."
+  "Bare `ollama` without a model requires OLLAMA_DEFAULT_MODEL env var. Use \
+   `ollama:<model>` for explicit selection."
+;;
 
 let is_bare_ollama_label label =
   let normalized = normalize_label label in
-  String.equal normalized cn_ollama
-  && Env_config_runtime.Ollama.default_model = ""
+  String.equal normalized cn_ollama && Env_config_runtime.Ollama.default_model = ""
+;;
 
 let explicit_llama_model_id_result () =
   match nonempty_env "LLAMA_DEFAULT_MODEL" with
   | Some model_id -> Ok model_id
-  | None -> (
-      match
-        ( nonempty_env "MASC_DEFAULT_PROVIDER",
-          nonempty_env "MASC_DEFAULT_MODEL" )
-      with
-      | Some provider, Some model_id
-        when String.equal (String.lowercase_ascii provider) "llama" ->
-          Ok model_id
-      | _ ->
-          Error
-            "LLAMA_DEFAULT_MODEL is not set; configure LLAMA_DEFAULT_MODEL or MASC_DEFAULT_PROVIDER=llama with MASC_DEFAULT_MODEL")
+  | None ->
+    (match nonempty_env "MASC_DEFAULT_PROVIDER", nonempty_env "MASC_DEFAULT_MODEL" with
+     | Some provider, Some model_id
+       when String.equal (String.lowercase_ascii provider) "llama" -> Ok model_id
+     | _ ->
+       Error
+         "LLAMA_DEFAULT_MODEL is not set; configure LLAMA_DEFAULT_MODEL or \
+          MASC_DEFAULT_PROVIDER=llama with MASC_DEFAULT_MODEL")
+;;
 
 let explicit_llama_model_label_result () =
   Result.map make_local_label (explicit_llama_model_id_result ())
+;;
 
 let gemini_direct_available () =
   env_present google_cloud_project_env || env_present gemini_api_key_env
+;;
 
 let configured_default_model_label_result () =
   match Env_config.Model_defaults.default_cascade_opt () with
   | Some raw ->
-      let labels = split_csv_nonempty raw in
-      (match labels with
-       | first :: _ -> Ok first
-       | [] -> Error "MASC_DEFAULT_CASCADE is set but empty")
-  | None -> (
-      match
-        ( nonempty_env "MASC_DEFAULT_PROVIDER",
-          nonempty_env "MASC_DEFAULT_MODEL" )
-      with
-      | Some provider, Some model_id -> Ok (provider ^ ":" ^ model_id)
-      | Some _, None ->
-          Error
-            "MASC_DEFAULT_MODEL is required when MASC_DEFAULT_PROVIDER is set"
-      | None, Some _ ->
-          Error
-            "MASC_DEFAULT_PROVIDER is required when MASC_DEFAULT_MODEL is set"
-      | None, None -> Error "No explicit default model configured")
+    let labels = split_csv_nonempty raw in
+    (match labels with
+     | first :: _ -> Ok first
+     | [] -> Error "MASC_DEFAULT_CASCADE is set but empty")
+  | None ->
+    (match nonempty_env "MASC_DEFAULT_PROVIDER", nonempty_env "MASC_DEFAULT_MODEL" with
+     | Some provider, Some model_id -> Ok (provider ^ ":" ^ model_id)
+     | Some _, None ->
+       Error "MASC_DEFAULT_MODEL is required when MASC_DEFAULT_PROVIDER is set"
+     | None, Some _ ->
+       Error "MASC_DEFAULT_PROVIDER is required when MASC_DEFAULT_MODEL is set"
+     | None, None -> Error "No explicit default model configured")
+;;
 
 let configured_verifier_model_label_result () =
   match nonempty_env "MASC_DEFAULT_VERIFIER_MODEL" with
   | Some label -> Ok label
   | None -> configured_default_model_label_result ()
+;;
 
 let provider_model_label provider model =
-  if model = "" then None
-  else Some (Printf.sprintf "%s:%s" provider model)
+  if model = "" then None else Some (Printf.sprintf "%s:%s" provider model)
+;;
 
 (** Derives the default model label for an adapter from its [runtime_kind]
     and [cascade_prefix].  Local adapters require an explicit model ID
@@ -1279,11 +1303,15 @@ let default_model_label_for_adapter (adapter : adapter) =
     Result.map
       (fun model_id -> adapter.cascade_prefix ^ ":" ^ model_id)
       (explicit_llama_model_id_result ())
-  | Cli_agent
-  | Direct_api ->
-    match adapter.default_model_id with
-    | Some _ -> Ok (adapter.cascade_prefix ^ ":auto")
-    | None -> Error (Printf.sprintf "Provider '%s' requires explicit runtime_model" adapter.canonical_name)
+  | Cli_agent | Direct_api ->
+    (match adapter.default_model_id with
+     | Some _ -> Ok (adapter.cascade_prefix ^ ":auto")
+     | None ->
+       Error
+         (Printf.sprintf
+            "Provider '%s' requires explicit runtime_model"
+            adapter.canonical_name))
+;;
 
 (** Build the "provider:auto" label for each adapter that has auth
     credentials present.  Used by preferred_*_model_labels to avoid
@@ -1293,19 +1321,21 @@ let auto_label_for_adapter (adapter : adapter) =
     match adapter.auth_mode with
     | No_auth -> true
     | Cli_cached_login ->
-        (match adapter.spawn_key with
-         | Some cmd -> Llm_provider.Provider_registry.command_in_path cmd
-         | None -> false)
+      (match adapter.spawn_key with
+       | Some cmd -> Llm_provider.Provider_registry.command_in_path cmd
+       | None -> false)
     | Api_key env_name -> env_present env_name
     | Vertex_adc { project_env; _ } -> env_present project_env
   in
-  if not is_available then None
-  else
+  if not is_available
+  then None
+  else (
     match default_model_label_for_adapter adapter with
     | Ok label -> Some label
     | Error msg ->
-        Log.Misc.warn "[ProviderAdapter] default_model_label_for_adapter failed: %s" msg;
-        None
+      Log.Misc.warn "[ProviderAdapter] default_model_label_for_adapter failed: %s" msg;
+      None)
+;;
 
 (** Cloud adapters that participate in auto-detection (excludes llama
     which requires explicit model config, and openrouter which requires
@@ -1313,78 +1343,87 @@ let auto_label_for_adapter (adapter : adapter) =
 let auto_detect_adapters =
   List.filter
     (fun (adapter : adapter) ->
-      adapter.runtime_kind = Direct_api
-      && adapter.canonical_name <> cn_openrouter)
+       adapter.runtime_kind = Direct_api && adapter.canonical_name <> cn_openrouter)
     direct_adapters
+;;
 
 let preferred_execution_model_labels () =
-  let explicit = [
-    (match configured_default_model_label_result () with
-    | Ok label -> Some label
-    | Error _ -> None);
-    (match explicit_llama_model_label_result () with
-    | Ok label -> Some label
-    | Error _ -> None);
-    (* No hardcoded provider preference here.  Model order is determined
+  let explicit =
+    [ (match configured_default_model_label_result () with
+       | Ok label -> Some label
+       | Error _ -> None)
+    ; (match explicit_llama_model_label_result () with
+       | Ok label -> Some label
+       | Error _ -> None)
+      (* No hardcoded provider preference here.  Model order is determined
        by MASC cascade.json via [Cascade_config], not by this adapter module. The auto_detect
        list below only serves as a last-resort fallback when cascade.json
        is missing entirely. *)
-  ] in
+    ]
+  in
   Json_util.dedupe_keep_order
     (List.filter_map Fun.id explicit
      @ List.filter_map auto_label_for_adapter auto_detect_adapters)
+;;
 
 let preferred_verifier_model_labels () =
-  let explicit = [
-    (match configured_verifier_model_label_result () with
-    | Ok label -> Some label
-    | Error _ -> None);
-    (match explicit_llama_model_label_result () with
-    | Ok label -> Some label
-    | Error _ -> None);
-  ] in
+  let explicit =
+    [ (match configured_verifier_model_label_result () with
+       | Ok label -> Some label
+       | Error _ -> None)
+    ; (match explicit_llama_model_label_result () with
+       | Ok label -> Some label
+       | Error _ -> None)
+    ]
+  in
   Json_util.dedupe_keep_order
     (List.filter_map Fun.id explicit
      @ List.filter_map auto_label_for_adapter auto_detect_adapters)
+;;
 
 let default_model_labels_result () =
   let labels = preferred_execution_model_labels () in
-  if labels = [] then
+  if labels = []
+  then
     Error
-      "No default model configured; set LLAMA_DEFAULT_MODEL, MASC_DEFAULT_CASCADE, MASC_DEFAULT_PROVIDER/MASC_DEFAULT_MODEL, or a supported cloud provider credential"
+      "No default model configured; set LLAMA_DEFAULT_MODEL, MASC_DEFAULT_CASCADE, \
+       MASC_DEFAULT_PROVIDER/MASC_DEFAULT_MODEL, or a supported cloud provider \
+       credential"
   else Ok labels
+;;
 
 let default_model_label_result () =
   match default_model_labels_result () with
   | Ok (first :: _) -> Ok first
   | Ok [] -> Error "No default model configured"
   | Error _ as e -> e
+;;
 
 let provider_prefix_of_label_result label =
   let normalized = String.trim label in
   match String.index_opt normalized ':' with
   | Some idx when idx > 0 ->
-      Ok
-        (String.sub normalized 0 idx |> String.trim |> String.lowercase_ascii)
+    Ok (String.sub normalized 0 idx |> String.trim |> String.lowercase_ascii)
   | _ ->
-      Error
-        (Printf.sprintf
-           "Default model label must be provider:model, got: %s"
-           normalized)
+    Error
+      (Printf.sprintf "Default model label must be provider:model, got: %s" normalized)
+;;
 
-let provider_label_of_provider_kind
-    (kind : Llm_provider.Provider_config.provider_kind) : string =
+let provider_label_of_provider_kind (kind : Llm_provider.Provider_config.provider_kind)
+  : string
+  =
   let cn = adapter_canonical_name_of_provider_kind kind in
   match resolve_direct_adapter cn with
   | Some adapter -> adapter.cascade_prefix
   | None -> cn
+;;
 
 let provider_label_of_explicit_prefix (prefix : string) : string option =
   let normalized = normalize_label prefix in
   match resolve_adapter_by_cascade_prefix normalized with
   | Some adapter -> Some adapter.cascade_prefix
-  | None ->
-      if String.equal normalized cn_custom then Some cn_custom else None
+  | None -> if String.equal normalized cn_custom then Some cn_custom else None
+;;
 
 (** Classify a model label to a provider name for telemetry grouping.
 
@@ -1402,24 +1441,27 @@ let provider_of_model_label ?provider_kind (model : string) : string =
   | Some provider, _ -> provider
   | None, Some kind -> provider_label_of_provider_kind kind
   | None, None -> "unknown"
+;;
 
 let adapter_of_registry_label label =
   match resolve_adapter_by_cascade_prefix label with
   | Some adapter -> Some adapter
   | None -> resolve_direct_adapter label
+;;
 
 let supports_runtime_mcp_http_headers_for_model_label ?provider_kind model =
   let provider_label =
     match provider_prefix_of_label_result model with
     | Ok prefix -> prefix
-    | Error _ -> (
-        match provider_kind with
-        | Some kind -> provider_label_of_provider_kind kind
-        | None -> model)
+    | Error _ ->
+      (match provider_kind with
+       | Some kind -> provider_label_of_provider_kind kind
+       | None -> model)
   in
   match adapter_of_registry_label provider_label with
   | Some adapter -> adapter.tool_policy.supports_runtime_mcp_http_headers
   | None -> false
+;;
 
 (** Whether a provider emits no usage tokens in its standard response.
 
@@ -1435,71 +1477,77 @@ let is_structurally_unmetered_provider (provider : string) : bool =
     | None -> resolve_direct_adapter provider
   in
   match adapter with
-  | Some { telemetry_policy = { usage_reporting = Missing_by_design; _ }; _ } ->
-      true
+  | Some { telemetry_policy = { usage_reporting = Missing_by_design; _ }; _ } -> true
   | Some _ | None -> false
+;;
 
 let default_model_provider_prefix_result () =
   match default_model_label_result () with
   | Ok label -> provider_prefix_of_label_result label
   | Error _ as e -> e
+;;
 
 let default_model_override_label_result model_id =
   let model_id = String.trim model_id in
-  if model_id = "" then
-    Error "default:<model> requires a non-empty model id"
-  else
+  if model_id = ""
+  then Error "default:<model> requires a non-empty model id"
+  else (
     match default_model_provider_prefix_result () with
     | Ok provider -> Ok (provider ^ ":" ^ model_id)
-    | Error _ as e -> e
+    | Error _ as e -> e)
+;;
 
 let vertex_location () =
   match Sys.getenv_opt google_cloud_location_env with
   | Some raw ->
-      let trimmed = String.trim raw in
-      if trimmed = "" then "global" else trimmed
+    let trimmed = String.trim raw in
+    if trimmed = "" then "global" else trimmed
   | None -> "global"
+;;
 
 let resolve_gemini_direct_auth () =
   match Sys.getenv_opt google_cloud_project_env with
   | Some raw when String.trim raw <> "" ->
-      Gemini_vertex_adc
-        {
-          project = String.trim raw;
-          location = vertex_location ();
-        }
-  | _ -> (
-      match Sys.getenv_opt gemini_api_key_env with
-      | Some raw when String.trim raw <> "" -> Gemini_api_key
-      | _ ->
-          Gemini_auth_missing
-            "Gemini auth unavailable; set GOOGLE_CLOUD_PROJECT for Vertex ADC or GEMINI_API_KEY")
+    Gemini_vertex_adc { project = String.trim raw; location = vertex_location () }
+  | _ ->
+    (match Sys.getenv_opt gemini_api_key_env with
+     | Some raw when String.trim raw <> "" -> Gemini_api_key
+     | _ ->
+       Gemini_auth_missing
+         "Gemini auth unavailable; set GOOGLE_CLOUD_PROJECT for Vertex ADC or \
+          GEMINI_API_KEY")
+;;
 
 let gemini_vertex_openai_base_url ~project ~location =
   Printf.sprintf
     "https://aiplatform.googleapis.com/v1/projects/%s/locations/%s/endpoints/openapi"
-    project location
+    project
+    location
+;;
 
 let same_base_url left right =
   String.equal (normalize_base_url left) (normalize_base_url right)
+;;
 
 let openai_compat_adapter_by_endpoint (cfg : Llm_provider.Provider_config.t) =
-  if cfg.kind <> Llm_provider.Provider_config.OpenAI_compat then None
+  if cfg.kind <> Llm_provider.Provider_config.OpenAI_compat
+  then None
   else
     List.find_opt
       (fun (adapter : adapter) ->
-        adapter.runtime_kind = Direct_api
-        &&
-        match adapter.endpoint_url with
-        | Some endpoint when endpoint <> "" ->
-            same_base_url endpoint cfg.base_url
-        | Some _ | None -> false)
+         adapter.runtime_kind = Direct_api
+         &&
+         match adapter.endpoint_url with
+         | Some endpoint when endpoint <> "" -> same_base_url endpoint cfg.base_url
+         | Some _ | None -> false)
       direct_adapters
+;;
 
 let provider_label_from_registry (cfg : Llm_provider.Provider_config.t) =
   match openai_compat_adapter_by_endpoint cfg with
   | Some adapter -> adapter.cascade_prefix
   | None -> Llm_provider.Provider_registry.provider_name_of_config cfg
+;;
 
 (** [apply_wire_overlay ~provider_cfg provider] returns [provider] with
     its wire-layer transport rewritten when the SDK's
@@ -1523,11 +1571,12 @@ let provider_label_from_registry (cfg : Llm_provider.Provider_config.t) =
     transport (vLLM, lmstudio, OpenRouter) only requires touching this
     adapter module — keeper code never names a provider variant. *)
 let apply_wire_overlay
-    ~(provider_cfg : Llm_provider.Provider_config.t)
-    (provider : Agent_sdk.Provider.config) : Agent_sdk.Provider.config =
+      ~(provider_cfg : Llm_provider.Provider_config.t)
+      (provider : Agent_sdk.Provider.config)
+  : Agent_sdk.Provider.config
+  =
   match provider_cfg.kind, provider.provider with
-  | Llm_provider.Provider_config.OpenAI_compat,
-    Agent_sdk.Provider.Local { base_url }
+  | Llm_provider.Provider_config.OpenAI_compat, Agent_sdk.Provider.Local { base_url }
     when not
            (String.equal
               provider_cfg.request_path
@@ -1542,13 +1591,10 @@ let apply_wire_overlay
     { provider with
       provider =
         Agent_sdk.Provider.OpenAICompat
-          { base_url
-          ; auth_header
-          ; path = provider_cfg.request_path
-          ; static_token
-          }
+          { base_url; auth_header; path = provider_cfg.request_path; static_token }
     }
   | _ -> provider
+;;
 
 let adapter_of_provider_config (cfg : Llm_provider.Provider_config.t) =
   (* RFC-0058 §2.4: dispatch flows through the kind→canonical_name table
@@ -1561,11 +1607,10 @@ let adapter_of_provider_config (cfg : Llm_provider.Provider_config.t) =
      [provider_name_of_config]. [provider_label_from_registry] folds
      both into the same [cascade_prefix] key. *)
   match cfg.kind with
-  | Llm_provider.Provider_config.Glm
-  | Llm_provider.Provider_config.OpenAI_compat ->
-      resolve_adapter_by_cascade_prefix (provider_label_from_registry cfg)
-  | kind ->
-      resolve_direct_adapter (adapter_canonical_name_of_provider_kind kind)
+  | Llm_provider.Provider_config.Glm | Llm_provider.Provider_config.OpenAI_compat ->
+    resolve_adapter_by_cascade_prefix (provider_label_from_registry cfg)
+  | kind -> resolve_direct_adapter (adapter_canonical_name_of_provider_kind kind)
+;;
 
 (* RFC-0058 §2.4 boundary: callers with only the typed [provider_kind]
    (no full provider config) resolve to an adapter through the same
@@ -1573,49 +1618,54 @@ let adapter_of_provider_config (cfg : Llm_provider.Provider_config.t) =
    kinds that need a [cascade_prefix] string to disambiguate (Glm /
    OpenAI_compat) — those callers must use [adapter_of_provider_config]
    or a label-based resolver instead. *)
-let adapter_of_provider_kind
-    (kind : Llm_provider.Provider_config.provider_kind) =
+let adapter_of_provider_kind (kind : Llm_provider.Provider_config.provider_kind) =
   match kind with
   | Glm | OpenAI_compat -> None
   | _ -> resolve_direct_adapter (adapter_canonical_name_of_provider_kind kind)
+;;
 
 let provider_label_of_config (cfg : Llm_provider.Provider_config.t) =
   match adapter_of_provider_config cfg with
   | Some adapter -> adapter.cascade_prefix
   | None -> provider_label_from_registry cfg
+;;
 
 let provider_health_key_of_config (cfg : Llm_provider.Provider_config.t) =
   match cfg.kind with
   | Llm_provider.Provider_config.OpenAI_compat
     when Llm_provider.Provider_config.is_local cfg ->
-      let base_url = String.trim cfg.base_url in
-      if base_url = "" then provider_label_of_config cfg
-      else
-        Printf.sprintf "%s:%s@%s" (provider_label_of_config cfg)
-          cfg.model_id base_url
+    let base_url = String.trim cfg.base_url in
+    if base_url = ""
+    then provider_label_of_config cfg
+    else Printf.sprintf "%s:%s@%s" (provider_label_of_config cfg) cfg.model_id base_url
   | _ -> provider_label_of_config cfg
+;;
 
 let provider_model_health_key_of_config cfg =
   Printf.sprintf "%s:%s" (provider_health_key_of_config cfg) cfg.model_id
+;;
 
 let display_provider_name_of_config (cfg : Llm_provider.Provider_config.t) =
   display_provider_name (provider_label_of_config cfg)
+;;
 
 let model_label_of_config (cfg : Llm_provider.Provider_config.t) =
   Printf.sprintf "%s:%s" (display_provider_name_of_config cfg) cfg.model_id
+;;
 
-let supports_runtime_mcp_http_headers_for_config
-    (cfg : Llm_provider.Provider_config.t) =
+let supports_runtime_mcp_http_headers_for_config (cfg : Llm_provider.Provider_config.t) =
   match adapter_of_provider_config cfg with
   | Some adapter -> adapter.tool_policy.supports_runtime_mcp_http_headers
   | None -> false
+;;
 
 let requires_per_keeper_bridging_for_bound_actor_tools_for_config
-    (cfg : Llm_provider.Provider_config.t) =
+      (cfg : Llm_provider.Provider_config.t)
+  =
   match adapter_of_provider_config cfg with
-  | Some adapter ->
-      adapter.tool_policy.requires_per_keeper_bridging_for_bound_actor_tools
+  | Some adapter -> adapter.tool_policy.requires_per_keeper_bridging_for_bound_actor_tools
   | None -> false
+;;
 
 (** RFC-0058 §2.4 SSOT bridge: build a [tool_policy] record from a
     cascade-decl [cascade_capabilities] (the TOML-parsed shape).
@@ -1643,49 +1693,57 @@ let requires_per_keeper_bridging_for_bound_actor_tools_for_config
     cascade-toml-driven path. This PR adds the primitive only;
     no caller swaps. *)
 let tool_policy_of_cascade_capabilities
-    (caps : Cascade_declarative_types.cascade_capabilities option) =
+      (caps : Cascade_declarative_types.cascade_capabilities option)
+  =
   match caps with
   | None -> no_tool_http_headers
   | Some c ->
-      {
-        supports_runtime_mcp_http_headers = c.supports_runtime_mcp_http_headers;
-        requires_per_keeper_bridging_for_bound_actor_tools =
-          c.requires_per_keeper_bridging_for_bound_actor_tools;
-        identity_runtime_mcp_header_keys = c.identity_runtime_mcp_header_keys;
-        argv_prompt_preflight = c.argv_prompt_preflight;
-        uses_anthropic_caching = c.uses_anthropic_caching;
-        max_turns_per_attempt = c.max_turns_per_attempt;
-        tolerates_bound_actor_fallback = c.tolerates_bound_actor_fallback;
-      }
+    { supports_runtime_mcp_http_headers = c.supports_runtime_mcp_http_headers
+    ; requires_per_keeper_bridging_for_bound_actor_tools =
+        c.requires_per_keeper_bridging_for_bound_actor_tools
+    ; identity_runtime_mcp_header_keys = c.identity_runtime_mcp_header_keys
+    ; argv_prompt_preflight = c.argv_prompt_preflight
+    ; uses_anthropic_caching = c.uses_anthropic_caching
+    ; max_turns_per_attempt = c.max_turns_per_attempt
+    ; tolerates_bound_actor_fallback = c.tolerates_bound_actor_fallback
+    }
+;;
 
 let requires_per_keeper_bridging_for_bound_actor_tools_for_kind
-    (kind : Llm_provider.Provider_config.provider_kind) =
+      (kind : Llm_provider.Provider_config.provider_kind)
+  =
   match adapter_of_provider_kind kind with
-  | Some adapter ->
-      adapter.tool_policy.requires_per_keeper_bridging_for_bound_actor_tools
+  | Some adapter -> adapter.tool_policy.requires_per_keeper_bridging_for_bound_actor_tools
   | None -> false
+;;
 
 let tolerates_bound_actor_fallback_for_kind
-    (kind : Llm_provider.Provider_config.provider_kind) =
+      (kind : Llm_provider.Provider_config.provider_kind)
+  =
   match adapter_of_provider_kind kind with
   | Some adapter -> adapter.tool_policy.tolerates_bound_actor_fallback
   | None -> false
+;;
 
 (** Normalize a header key for case-insensitive comparison against
     [tool_policy.identity_runtime_mcp_header_keys]. *)
 let normalize_header_key key = String.lowercase_ascii (String.trim key)
 
 let accepts_runtime_mcp_http_header_for_config
-    (cfg : Llm_provider.Provider_config.t) (key : string) =
+      (cfg : Llm_provider.Provider_config.t)
+      (key : string)
+  =
   match adapter_of_provider_config cfg with
   | None -> false
   | Some adapter ->
-      if adapter.tool_policy.supports_runtime_mcp_http_headers then true
-      else
-        let normalized = normalize_header_key key in
-        List.exists
-          (fun k -> normalize_header_key k = normalized)
-          adapter.tool_policy.identity_runtime_mcp_header_keys
+    if adapter.tool_policy.supports_runtime_mcp_http_headers
+    then true
+    else (
+      let normalized = normalize_header_key key in
+      List.exists
+        (fun k -> normalize_header_key k = normalized)
+        adapter.tool_policy.identity_runtime_mcp_header_keys)
+;;
 
 (** SSOT for the OAS provider_kind → capabilities mapping.  This is the
     one place that pattern-matches on [Llm_provider.Provider_config.provider_kind]
@@ -1693,8 +1751,7 @@ let accepts_runtime_mcp_http_header_for_config
     modules; centralising it here keeps consumers off the closed variant. *)
 let oas_capabilities_of_config (cfg : Llm_provider.Provider_config.t) =
   match cfg.kind with
-  | Llm_provider.Provider_config.Ollama ->
-      Llm_provider.Capabilities.ollama_capabilities
+  | Llm_provider.Provider_config.Ollama -> Llm_provider.Capabilities.ollama_capabilities
   | Anthropic -> Llm_provider.Capabilities.anthropic_capabilities
   | Kimi -> Llm_provider.Capabilities.kimi_capabilities
   | Glm -> Llm_provider.Capabilities.glm_capabilities
@@ -1705,21 +1762,21 @@ let oas_capabilities_of_config (cfg : Llm_provider.Provider_config.t) =
   | Gemini_cli -> Llm_provider.Capabilities.gemini_cli_capabilities
   | Kimi_cli -> Llm_provider.Capabilities.kimi_cli_capabilities
   | Codex_cli -> Llm_provider.Capabilities.codex_cli_capabilities
-
+;;
 
 (* ── Generic provider auth detail ─────────────────────────────── *)
 
 (** Provider-agnostic auth detail for dashboard display.
     Encapsulates vendor-specific auth logic (e.g. Gemini Vertex/API key)
     so consumers do not branch on vendor names. *)
-type auth_detail = {
-  auth_kind : string;
-  status : string;
-  available : bool;
-  supports_run : bool;
-  endpoint_url : string option;
-  note : string option;
-}
+type auth_detail =
+  { auth_kind : string
+  ; status : string
+  ; available : bool
+  ; supports_run : bool
+  ; endpoint_url : string option
+  ; note : string option
+  }
 
 (** Cascade config prefix from adapter record. No match needed. *)
 let cascade_prefix_of_adapter (adapter : adapter) = adapter.cascade_prefix
@@ -1738,60 +1795,88 @@ let endpoint_url_of_adapter (adapter : adapter) = adapter.endpoint_url
     When the exact provider identity matters, the only unambiguous approach is
     to parse the prefix directly from the original provider:model label. This
     helper should be used only when a best-effort cascade prefix is sufficient. *)
-let cascade_prefix_of_provider_kind (kind : Llm_provider.Provider_config.provider_kind) : string =
+let cascade_prefix_of_provider_kind (kind : Llm_provider.Provider_config.provider_kind)
+  : string
+  =
   let cn = adapter_canonical_name_of_provider_kind kind in
   match resolve_direct_adapter cn with
   | Some a -> a.cascade_prefix
   | None -> cn
+;;
 
 (** Resolve auth detail for any provider by canonical name or alias.
     Gemini-specific Vertex ADC vs API Key logic is internal. *)
 let auth_detail_of_provider provider =
   match resolve_direct_adapter provider with
   | None ->
-    { auth_kind = "unknown"; status = "unsupported"; available = false;
-      supports_run = false; endpoint_url = None;
-      note = Some "Unsupported provider" }
+    { auth_kind = "unknown"
+    ; status = "unsupported"
+    ; available = false
+    ; supports_run = false
+    ; endpoint_url = None
+    ; note = Some "Unsupported provider"
+    }
   | Some adapter ->
     let auth_kind_base =
-      if adapter.canonical_name = cn_kimi_api then
-        "api_key:KIMI_API_KEY"
-      else
-        string_of_auth_mode adapter.auth_mode
+      if adapter.canonical_name = cn_kimi_api
+      then "api_key:KIMI_API_KEY"
+      else string_of_auth_mode adapter.auth_mode
     in
-    if adapter.canonical_name = cn_gemini_api then
+    if adapter.canonical_name = cn_gemini_api
+    then (
       match resolve_gemini_direct_auth () with
       | Gemini_api_key ->
-        { auth_kind = "api_key:GEMINI_API_KEY"; status = "configured";
-          available = true; supports_run = true;
-          endpoint_url = Some (gemini_generative_api_url ());
-          note = None }
+        { auth_kind = "api_key:GEMINI_API_KEY"
+        ; status = "configured"
+        ; available = true
+        ; supports_run = true
+        ; endpoint_url = Some (gemini_generative_api_url ())
+        ; note = None
+        }
       | Gemini_vertex_adc { project; location } ->
-        { auth_kind = Printf.sprintf "vertex_adc:%s:%s" project location;
-          status = "vertex_adc"; available = true; supports_run = false;
-          endpoint_url = Some (gemini_vertex_openai_base_url ~project ~location);
-          note = Some "Dashboard run MVP only supports Gemini via GEMINI_API_KEY. \
-                       Vertex ADC inventory is visible but run is disabled." }
+        { auth_kind = Printf.sprintf "vertex_adc:%s:%s" project location
+        ; status = "vertex_adc"
+        ; available = true
+        ; supports_run = false
+        ; endpoint_url = Some (gemini_vertex_openai_base_url ~project ~location)
+        ; note =
+            Some
+              "Dashboard run MVP only supports Gemini via GEMINI_API_KEY. Vertex ADC \
+               inventory is visible but run is disabled."
+        }
       | Gemini_auth_missing message ->
-        { auth_kind = auth_kind_base; status = "missing_auth";
-          available = false; supports_run = false;
-          endpoint_url = None; note = Some message }
-    else if adapter.runtime_kind = Cli_agent then
+        { auth_kind = auth_kind_base
+        ; status = "missing_auth"
+        ; available = false
+        ; supports_run = false
+        ; endpoint_url = None
+        ; note = Some message
+        })
+    else if adapter.runtime_kind = Cli_agent
+    then (
       let available = provider_auth_available provider in
-      { auth_kind = auth_kind_base;
-        status = (if available then "configured" else "missing_auth");
-        available; supports_run = available;
-        endpoint_url = None;
-        note = Some "Cached CLI login is assumed; final validation happens at execution time." }
-    else
+      { auth_kind = auth_kind_base
+      ; status = (if available then "configured" else "missing_auth")
+      ; available
+      ; supports_run = available
+      ; endpoint_url = None
+      ; note =
+          Some "Cached CLI login is assumed; final validation happens at execution time."
+      })
+    else (
       let available = provider_auth_available provider in
-      { auth_kind = auth_kind_base;
-        status = (if available then "configured" else "missing_auth");
-        available; supports_run = available;
-        endpoint_url = endpoint_url_of_adapter adapter;
-        note = None }
+      { auth_kind = auth_kind_base
+      ; status = (if available then "configured" else "missing_auth")
+      ; available
+      ; supports_run = available
+      ; endpoint_url = endpoint_url_of_adapter adapter
+      ; note = None
+      })
+;;
 
-let auth_env_keys_of_provider_kind (kind : Llm_provider.Provider_config.provider_kind) : string list =
+let auth_env_keys_of_provider_kind (kind : Llm_provider.Provider_config.provider_kind)
+  : string list
+  =
   (* RFC-0058 §2.4: Kimi and Gemini have non-adapter overrides
      (multi-key fallback list and Vertex env pair respectively);
      every other kind defers to the adapter's [auth_mode]. The
@@ -1800,21 +1885,21 @@ let auth_env_keys_of_provider_kind (kind : Llm_provider.Provider_config.provider
   match kind with
   | Llm_provider.Provider_config.Kimi -> kimi_api_key_envs
   | Llm_provider.Provider_config.Gemini ->
-      [ google_cloud_project_env; google_cloud_location_env ]
+    [ google_cloud_project_env; google_cloud_location_env ]
   | _ ->
-      let adapter_name = adapter_canonical_name_of_provider_kind kind in
-      (match resolve_direct_adapter adapter_name with
-       | Some adapter -> (
-           match adapter.auth_mode with
-           | Api_key env_name -> [ env_name ]
-           | No_auth | Cli_cached_login | Vertex_adc _ ->
-               Option.to_list
-                 (Llm_provider.Provider_config.default_api_key_env kind))
-       | None ->
-           Option.to_list
-             (Llm_provider.Provider_config.default_api_key_env kind))
+    let adapter_name = adapter_canonical_name_of_provider_kind kind in
+    (match resolve_direct_adapter adapter_name with
+     | Some adapter ->
+       (match adapter.auth_mode with
+        | Api_key env_name -> [ env_name ]
+        | No_auth | Cli_cached_login | Vertex_adc _ ->
+          Option.to_list (Llm_provider.Provider_config.default_api_key_env kind))
+     | None -> Option.to_list (Llm_provider.Provider_config.default_api_key_env kind))
+;;
 
-let docker_auth_env_keys_of_provider_config (cfg : Llm_provider.Provider_config.t) : string list =
+let docker_auth_env_keys_of_provider_config (cfg : Llm_provider.Provider_config.t)
+  : string list
+  =
   (* Docker sandboxes invoke OpenAI_compat over loopback against the
      local-runtime pool, which carries no remote credentials; every
      other kind delegates to the keyset its adapter declares. Gemini
@@ -1822,11 +1907,13 @@ let docker_auth_env_keys_of_provider_config (cfg : Llm_provider.Provider_config.
      ADC files are not mounted. *)
   match cfg.kind with
   | Llm_provider.Provider_config.OpenAI_compat ->
-      let uri = Uri.of_string cfg.base_url in
-      if Masc_network_defaults.is_loopback_host_opt (Uri.host uri) then []
-      else auth_env_keys_of_provider_kind cfg.kind
+    let uri = Uri.of_string cfg.base_url in
+    if Masc_network_defaults.is_loopback_host_opt (Uri.host uri)
+    then []
+    else auth_env_keys_of_provider_kind cfg.kind
   | Llm_provider.Provider_config.Gemini -> [ gemini_api_key_env ]
   | _ -> auth_env_keys_of_provider_kind cfg.kind
+;;
 
 let all_auth_env_keys () : string list =
   direct_adapters
@@ -1838,5 +1925,6 @@ let all_auth_env_keys () : string list =
     | Api_key env_name -> [ env_name ]
     | Vertex_adc _ -> [])
   |> List.sort_uniq String.compare
+;;
 
 (* is_spawnable removed: use is_spawnable_agent directly. *)

--- a/lib/provider_adapter.mli
+++ b/lib/provider_adapter.mli
@@ -18,10 +18,10 @@ type auth_mode =
   | No_auth
   | Cli_cached_login
   | Api_key of string
-  | Vertex_adc of {
-      project_env : string;
-      location_env : string;
-    }
+  | Vertex_adc of
+      { project_env : string
+      ; location_env : string
+      }
 
 type model_family =
   | Generic
@@ -31,11 +31,11 @@ type model_family =
 
 type auto_models_source =
   | No_auto_models
-  | Env_csv_or_default of {
-      env_var : string;
-      defaults : string list;
-      prefer_default_model_env : bool;
-    }
+  | Env_csv_or_default of
+      { env_var : string
+      ; defaults : string list
+      ; prefer_default_model_env : bool
+      }
   | Zai_general_auto_models
   | Zai_coding_auto_models
 
@@ -44,18 +44,18 @@ type reporting_policy =
   | Missing_by_design
   | Unknown
 
-type model_policy = {
-  default_model_env : string option;
-  default_model_fallback : string option;
-  auto_models : auto_models_source;
-  expand_auto : bool;
-  family : model_family;
-}
+type model_policy =
+  { default_model_env : string option
+  ; default_model_fallback : string option
+  ; auto_models : auto_models_source
+  ; expand_auto : bool
+  ; family : model_family
+  }
 
-type tool_policy = {
-  supports_runtime_mcp_http_headers : bool;
-  requires_per_keeper_bridging_for_bound_actor_tools : bool;
-      (** When true, this provider's runtime cannot inject per-keeper auth
+type tool_policy =
+  { supports_runtime_mcp_http_headers : bool
+  ; requires_per_keeper_bridging_for_bound_actor_tools : bool
+    (** When true, this provider's runtime cannot inject per-keeper auth
           headers natively. Bound-actor runtime MCP tools therefore require
           explicit per-keeper bridging at the cascade layer; otherwise the
           filter must reject the policy for this provider.
@@ -63,35 +63,35 @@ type tool_policy = {
           Codex CLI is currently the only adapter that sets this to [true]:
           its cached login does not allow per-keeper authorization headers
           to be injected on each request without bridging. *)
-  identity_runtime_mcp_header_keys : string list;
-      (** Header keys the provider can carry even when
+  ; identity_runtime_mcp_header_keys : string list
+    (** Header keys the provider can carry even when
           [supports_runtime_mcp_http_headers = false].  Empty for most
           providers.  Codex CLI carries [authorization] (via
           [bearer_token_env_var]) plus the non-secret MASC identity
           headers ([x-masc-agent-name], [x-masc-keeper-name]).
           Keys are matched case-insensitively after trimming. *)
-  argv_prompt_preflight : bool;
-      (** When true, callers must run a prompt argv/context-window preflight
+  ; argv_prompt_preflight : bool
+    (** When true, callers must run a prompt argv/context-window preflight
           before spawning a turn (the runtime serialises the full prompt on
           a single argv vector and rejects oversize input). Codex CLI's
           [codex exec] subprocess transport is the canonical case.
           RFC-0058 §2.4: capability flag, not a vendor match. *)
-  uses_anthropic_caching : bool;
-      (** When true, the provider's wire format supports Anthropic-style
+  ; uses_anthropic_caching : bool
+    (** When true, the provider's wire format supports Anthropic-style
           prompt caching via [cache_control] blocks, so usage telemetry
           should report [cache_creation_input_tokens] /
           [cache_read_input_tokens] above the cacheable input threshold.
           Used by [Keeper_usage_trust] to flag caching-likely-disabled
           anomalies. RFC-0058 §2.4: capability flag, not a vendor match. *)
-  max_turns_per_attempt : int option;
-      (** Hard cap on the provider-internal agent loop turn count for a
+  ; max_turns_per_attempt : int option
+    (** Hard cap on the provider-internal agent loop turn count for a
           single subprocess attempt.  [None] means the provider does not
           impose a sub-keeper cap; [Some n] clamps the keeper-level
           [max_turns] to [n] before handing it to the underlying CLI.
           Only Claude Code currently sets this (loop hard cap = 30).
           RFC-0058 §2.4: capability flag, not a vendor match. *)
-  tolerates_bound_actor_fallback : bool;
-      (** When true, this adapter is considered a viable fallback target
+  ; tolerates_bound_actor_fallback : bool
+    (** When true, this adapter is considered a viable fallback target
           when the operator's catalog also contains an adapter that
           [requires_per_keeper_bridging_for_bound_actor_tools = true]
           (e.g. Codex CLI). Catalog static validation
@@ -108,69 +108,69 @@ type tool_policy = {
           single canonical adapter), so the swap drops it pending an
           explicit reinstatement when GLM gains a per-keeper auth path.
           RFC-0058 §2.4: capability flag, not a vendor match. *)
-}
+  }
 
-type telemetry_policy = {
-  usage_reporting : reporting_policy;
-  runtime_reporting : reporting_policy;
-}
+type telemetry_policy =
+  { usage_reporting : reporting_policy
+  ; runtime_reporting : reporting_policy
+  }
 
 type voice_transport =
   | Voice_openai_compat
   | Voice_elevenlabs_direct
   | Voice_mcp
 
-type adapter = {
-  canonical_name : string;
-  runtime_kind : runtime_kind;
-  auth_mode : auth_mode;
-  aliases : string list;
-  spawn_key : string option;
-  cascade_prefix : string;
-  default_voice : string option;
-  endpoint_url : string option;
-  default_model_id : string option;
-  model_policy : model_policy;
-  tool_policy : tool_policy;
-  telemetry_policy : telemetry_policy;
-}
+type adapter =
+  { canonical_name : string
+  ; runtime_kind : runtime_kind
+  ; auth_mode : auth_mode
+  ; aliases : string list
+  ; spawn_key : string option
+  ; cascade_prefix : string
+  ; default_voice : string option
+  ; endpoint_url : string option
+  ; default_model_id : string option
+  ; model_policy : model_policy
+  ; tool_policy : tool_policy
+  ; telemetry_policy : telemetry_policy
+  }
 
-type voice_adapter = {
-  canonical_name : string;
-  transport : voice_transport;
-  auth_mode : auth_mode;
-  aliases : string list;
-}
+type voice_adapter =
+  { canonical_name : string
+  ; transport : voice_transport
+  ; auth_mode : auth_mode
+  ; aliases : string list
+  }
 
-type voice_http_request = {
-  url : string;
-  headers : (string * string) list;
-  body_json : Yojson.Safe.t;
-}
+type voice_http_request =
+  { url : string
+  ; headers : (string * string) list
+  ; body_json : Yojson.Safe.t
+  }
 
-type voice_stt_request = {
-  url : string;
-  headers : (string * string) list;
-  form_fields : (string * string) list;
-  file_field : string * string;
-}
+type voice_stt_request =
+  { url : string
+  ; headers : (string * string) list
+  ; form_fields : (string * string) list
+  ; file_field : string * string
+  }
 
 type gemini_direct_auth =
-  | Gemini_vertex_adc of {
-      project : string;
-      location : string;
-    }
+  | Gemini_vertex_adc of
+      { project : string
+      ; location : string
+      }
   | Gemini_api_key
   | Gemini_auth_missing of string
 
-type auth_detail = {
-  auth_kind : string;
-  status : string;
-  available : bool;
-  supports_run : bool;
-  endpoint_url : string option;
-  note : string option;
-}
+type auth_detail =
+  { auth_kind : string
+  ; status : string
+  ; available : bool
+  ; supports_run : bool
+  ; endpoint_url : string option
+  ; note : string option
+  }
 
 (** {1 Canonical Provider Names} *)
 
@@ -222,16 +222,17 @@ val local_cascade_prefix : string
 val make_local_label : string -> string
 
 (** SSOT string form of OAS [Provider_config.provider_kind]. *)
-val string_of_provider_kind :
-  Llm_provider.Provider_config.provider_kind -> string
+val string_of_provider_kind : Llm_provider.Provider_config.provider_kind -> string
 
 (** Resolve required auth env keys for a provider kind. *)
-val auth_env_keys_of_provider_kind :
-  Llm_provider.Provider_config.provider_kind -> string list
+val auth_env_keys_of_provider_kind
+  :  Llm_provider.Provider_config.provider_kind
+  -> string list
 
 (** Resolve Docker worker auth env keys for a provider config. *)
-val docker_auth_env_keys_of_provider_config :
-  Llm_provider.Provider_config.t -> string list
+val docker_auth_env_keys_of_provider_config
+  :  Llm_provider.Provider_config.t
+  -> string list
 
 (** Collect all auth env keys across direct adapters. *)
 val all_auth_env_keys : unit -> string list
@@ -258,16 +259,22 @@ val is_spawnable_agent : string -> bool
 val spawnable_canonical_names : unit -> string list
 
 (** Resolve the declared default model id for a cascade prefix. *)
-val default_model_id_for_cascade_prefix :
-  ?getenv:(string -> string option) -> string -> string option
+val default_model_id_for_cascade_prefix
+  :  ?getenv:(string -> string option)
+  -> string
+  -> string option
 
 (** Resolve declared auto-model expansion for a provider canonical name/alias. *)
-val auto_models_for_provider :
-  ?getenv:(string -> string option) -> string -> string list option
+val auto_models_for_provider
+  :  ?getenv:(string -> string option)
+  -> string
+  -> string list option
 
 (** Resolve declared auto-model expansion for a cascade prefix. *)
-val auto_models_for_cascade_prefix :
-  ?getenv:(string -> string option) -> string -> string list option
+val auto_models_for_cascade_prefix
+  :  ?getenv:(string -> string option)
+  -> string
+  -> string list option
 
 (** Returns true if the provider uses runtime discovery (e.g. live /props probe). *)
 val requires_discovery : string -> bool
@@ -282,11 +289,14 @@ val voice_adapter_for_endpoint : Voice_config.endpoint -> voice_adapter
 val voice_adapter_for_endpoint_kind : Voice_config.endpoint_kind -> voice_adapter
 val voice_adapter_labels : voice_adapter -> string list
 val voice_endpoint_matches_provider_label : string -> Voice_config.endpoint -> bool
-val select_voice_endpoints :
-  ?provider:string -> Voice_config.endpoint list -> Voice_config.endpoint list
+
+val select_voice_endpoints
+  :  ?provider:string
+  -> Voice_config.endpoint list
+  -> Voice_config.endpoint list
+
 (** Resolve auth env var name for a voice adapter, with optional endpoint override. *)
-val voice_auth_env_name :
-  ?endpoint_api_key_env:string -> voice_adapter -> string option
+val voice_auth_env_name : ?endpoint_api_key_env:string -> voice_adapter -> string option
 
 val voice_endpoint_auth_env_name : Voice_config.endpoint -> string option
 val voice_transport_supports_http_tts : voice_adapter -> bool
@@ -298,30 +308,34 @@ val all_agent_voices : unit -> (string * string) list
 (** {1 Voice Session URLs} *)
 
 val default_voice_session_url : path:string -> string
-val voice_session_endpoint_result :
-  Voice_config.t -> (Voice_config.endpoint, string) result
-val voice_session_mcp_url_of_endpoint :
-  Voice_config.endpoint -> (string, string) result
-val voice_session_health_url_of_endpoint :
-  Voice_config.endpoint -> (string, string) result
+
+val voice_session_endpoint_result
+  :  Voice_config.t
+  -> (Voice_config.endpoint, string) result
+
+val voice_session_mcp_url_of_endpoint : Voice_config.endpoint -> (string, string) result
+
+val voice_session_health_url_of_endpoint
+  :  Voice_config.endpoint
+  -> (string, string) result
 
 (** {1 Voice HTTP Requests} *)
 
-val voice_http_request_for_tts :
-  Voice_config.endpoint ->
-  api_key:string ->
-  message:string ->
-  voice:string ->
-  model:string ->
-  tuning:Voice_config.voice_tuning ->
-  (voice_http_request, string) result
+val voice_http_request_for_tts
+  :  Voice_config.endpoint
+  -> api_key:string
+  -> message:string
+  -> voice:string
+  -> model:string
+  -> tuning:Voice_config.voice_tuning
+  -> (voice_http_request, string) result
 
-val voice_stt_request_for_endpoint :
-  Voice_config.endpoint ->
-  api_key:string ->
-  audio_file:string ->
-  model:string ->
-  (voice_stt_request, string) result
+val voice_stt_request_for_endpoint
+  :  Voice_config.endpoint
+  -> api_key:string
+  -> audio_file:string
+  -> model:string
+  -> (voice_stt_request, string) result
 
 (** {1 Model Label Resolution} *)
 
@@ -356,15 +370,19 @@ val provider_prefix_of_label_result : string -> (string, string) result
     model ids are classified only when the caller supplies typed
     [provider_kind] telemetry; otherwise this returns ["unknown"] rather than
     guessing from vendor-looking substrings. *)
-val provider_of_model_label :
-  ?provider_kind:Llm_provider.Provider_config.provider_kind -> string -> string
+val provider_of_model_label
+  :  ?provider_kind:Llm_provider.Provider_config.provider_kind
+  -> string
+  -> string
 
 (** Whether the model label resolves to a provider that supports runtime MCP
     HTTP headers. Bare labels are accepted only when they exactly match an
     adapter/cascade registry entry or when [provider_kind] supplies the typed
     provider boundary. *)
-val supports_runtime_mcp_http_headers_for_model_label :
-  ?provider_kind:Llm_provider.Provider_config.provider_kind -> string -> bool
+val supports_runtime_mcp_http_headers_for_model_label
+  :  ?provider_kind:Llm_provider.Provider_config.provider_kind
+  -> string
+  -> bool
 
 (** True when the provider emits no usage tokens in its standard response.
     Used by metrics coverage gating so text-only turns against CLI-class
@@ -406,8 +424,7 @@ val endpoint_url_of_adapter : adapter -> string option
 
 (** Best-effort mapping from Provider_registry/OAS [provider_kind] to a
     MASC cascade prefix. *)
-val cascade_prefix_of_provider_kind :
-  Llm_provider.Provider_config.provider_kind -> string
+val cascade_prefix_of_provider_kind : Llm_provider.Provider_config.provider_kind -> string
 
 (** {1 Gemini Auth} *)
 
@@ -418,18 +435,17 @@ val resolve_gemini_direct_auth : unit -> gemini_direct_auth
 val gemini_vertex_openai_base_url : project:string -> location:string -> string
 
 (** Resolve the concrete provider adapter for a provider config. *)
-val adapter_of_provider_config :
-  Llm_provider.Provider_config.t -> adapter option
+val adapter_of_provider_config : Llm_provider.Provider_config.t -> adapter option
 
 (** Resolve the concrete provider adapter for an OAS [provider_kind].
     Used by call sites that only have the typed kind (no full config)
     and need adapter-level capability flags. RFC-0058 §2.4 boundary. *)
-val adapter_of_provider_kind :
-  Llm_provider.Provider_config.provider_kind -> adapter option
+val adapter_of_provider_kind
+  :  Llm_provider.Provider_config.provider_kind
+  -> adapter option
 
 (** Stable provider label/cascade prefix for a provider config. *)
-val provider_label_of_config :
-  Llm_provider.Provider_config.t -> string
+val provider_label_of_config : Llm_provider.Provider_config.t -> string
 
 (** Apply a wire-layer overlay to an SDK [provider] config.
 
@@ -446,41 +462,37 @@ val provider_label_of_config :
     SDK's [provider] variant; keeper-layer callers
     ({!Keeper_agent_context.default_config}) no longer pattern-match on
     either. *)
-val apply_wire_overlay :
-  provider_cfg:Llm_provider.Provider_config.t ->
-  Agent_sdk.Provider.config ->
-  Agent_sdk.Provider.config
+val apply_wire_overlay
+  :  provider_cfg:Llm_provider.Provider_config.t
+  -> Agent_sdk.Provider.config
+  -> Agent_sdk.Provider.config
 
 (** Stable key for cascade health and circuit-breaker state.
     Most providers are keyed at provider level. Local OpenAI-compatible
     endpoints include model and base URL so independent loopback runtimes can
     fail over without sharing cooldown state. *)
-val provider_health_key_of_config :
-  Llm_provider.Provider_config.t -> string
+val provider_health_key_of_config : Llm_provider.Provider_config.t -> string
 
 (** Stable model-level key for model-specific cascade health state. *)
-val provider_model_health_key_of_config :
-  Llm_provider.Provider_config.t -> string
+val provider_model_health_key_of_config : Llm_provider.Provider_config.t -> string
 
 (** User-facing provider label for a provider config. *)
-val display_provider_name_of_config :
-  Llm_provider.Provider_config.t -> string
+val display_provider_name_of_config : Llm_provider.Provider_config.t -> string
 
 (** Build the stable "provider:model" label for a provider config. *)
-val model_label_of_config :
-  Llm_provider.Provider_config.t -> string
+val model_label_of_config : Llm_provider.Provider_config.t -> string
 
 (** Whether the resolved adapter declares runtime MCP HTTP header support. *)
-val supports_runtime_mcp_http_headers_for_config :
-  Llm_provider.Provider_config.t -> bool
+val supports_runtime_mcp_http_headers_for_config : Llm_provider.Provider_config.t -> bool
 
 (** Whether the resolved adapter requires explicit per-keeper bridging in
     order to carry a runtime MCP policy that uses bound-actor tools.
 
     Currently only [codex_cli] returns [true]; the cascade filter uses this
     flag to gate entries without dispatching on provider name. *)
-val requires_per_keeper_bridging_for_bound_actor_tools_for_config :
-  Llm_provider.Provider_config.t -> bool
+val requires_per_keeper_bridging_for_bound_actor_tools_for_config
+  :  Llm_provider.Provider_config.t
+  -> bool
 
 (** RFC-0058 §2.4 SSOT bridge: build a [tool_policy] from a cascade-decl
     [cascade_capabilities] (the TOML-parsed shape).
@@ -511,8 +523,9 @@ val requires_per_keeper_bridging_for_bound_actor_tools_for_config :
     [config/cascade.toml] becomes the lookup root and the 13 hardcoded
     [tool_policy = ...] records collapse into a single cascade-toml-
     driven path. *)
-val tool_policy_of_cascade_capabilities :
-  Cascade_declarative_types.cascade_capabilities option -> tool_policy
+val tool_policy_of_cascade_capabilities
+  :  Cascade_declarative_types.cascade_capabilities option
+  -> tool_policy
 
 (** Same as {!requires_per_keeper_bridging_for_bound_actor_tools_for_config}
     but takes a typed [provider_kind] directly.  Used by call sites that do
@@ -520,8 +533,9 @@ val tool_policy_of_cascade_capabilities :
     actor authorisation resolution, cascade catalog static validation).
     Returns [false] when no adapter resolves for [kind].
     RFC-0058 §2.4: capability flag, not a vendor match. *)
-val requires_per_keeper_bridging_for_bound_actor_tools_for_kind :
-  Llm_provider.Provider_config.provider_kind -> bool
+val requires_per_keeper_bridging_for_bound_actor_tools_for_kind
+  :  Llm_provider.Provider_config.provider_kind
+  -> bool
 
 (** Whether the resolved adapter for [kind] is a viable fallback when
     the catalog also contains a bridging-required adapter (Codex CLI).
@@ -529,15 +543,17 @@ val requires_per_keeper_bridging_for_bound_actor_tools_for_kind :
     PK.Glm and PK.OpenAI_compat, which have no single canonical adapter).
     Used by {!Cascade_catalog_validator.codex_with_bound_actor_only_issue}.
     RFC-0058 §2.4: capability flag, not a vendor match. *)
-val tolerates_bound_actor_fallback_for_kind :
-  Llm_provider.Provider_config.provider_kind -> bool
+val tolerates_bound_actor_fallback_for_kind
+  :  Llm_provider.Provider_config.provider_kind
+  -> bool
 
 (** OAS-level capabilities for a provider config.  SSOT for the kind →
     capability mapping; centralises what was previously a closed-variant
     [match Llm_provider.Provider_config.provider_kind] in
     [Provider_tool_support]. *)
-val oas_capabilities_of_config :
-  Llm_provider.Provider_config.t -> Llm_provider.Capabilities.capabilities
+val oas_capabilities_of_config
+  :  Llm_provider.Provider_config.t
+  -> Llm_provider.Capabilities.capabilities
 
 (** Whether a runtime-MCP HTTP header key is acceptable for the resolved
     adapter, even when general HTTP-header support is off.  Covers the
@@ -545,9 +561,10 @@ val oas_capabilities_of_config :
     ([authorization], [x-masc-agent-name], [x-masc-keeper-name]).
     Returns [true] unconditionally for adapters with
     [supports_runtime_mcp_http_headers = true]. *)
-val accepts_runtime_mcp_http_header_for_config :
-  Llm_provider.Provider_config.t -> string -> bool
-
+val accepts_runtime_mcp_http_header_for_config
+  :  Llm_provider.Provider_config.t
+  -> string
+  -> bool
 
 (** {1 Misc} *)
 

--- a/lib/provider_adapter.mli
+++ b/lib/provider_adapter.mli
@@ -431,6 +431,26 @@ val adapter_of_provider_kind :
 val provider_label_of_config :
   Llm_provider.Provider_config.t -> string
 
+(** Apply a wire-layer overlay to an SDK [provider] config.
+
+    {!Agent_sdk.Provider.config_of_provider_config} maps an
+    [OpenAI_compat] cfg to [Local] when no transport hints exist on the
+    SDK side, which drops the configured non-default [request_path] and
+    auth token. [apply_wire_overlay] detects that under-routing and
+    rewraps the [provider] field as [OpenAICompat] with the cfg's
+    [base_url], [api_key]-derived auth header, custom [path], and
+    [static_token].
+
+    All other shapes pass through unchanged. This is the single
+    boundary site that inspects [provider_cfg.kind] alongside the
+    SDK's [provider] variant; keeper-layer callers
+    ({!Keeper_agent_context.default_config}) no longer pattern-match on
+    either. *)
+val apply_wire_overlay :
+  provider_cfg:Llm_provider.Provider_config.t ->
+  Agent_sdk.Provider.config ->
+  Agent_sdk.Provider.config
+
 (** Stable key for cascade health and circuit-breaker state.
     Most providers are keyed at provider level. Local OpenAI-compatible
     endpoints include model and base URL so independent loopback runtimes can

--- a/test/test_provider_adapter.ml
+++ b/test/test_provider_adapter.ml
@@ -428,6 +428,113 @@ let test_unmetered_provider_uses_declared_telemetry_policy () =
   check bool "unknown provider is not silently exempt" false
     (Adapter.is_structurally_unmetered_provider "unknown")
 
+(* RFC-0058 Phase 5.6 boundary helper: apply_wire_overlay.
+
+   These tests seal the invariant that the keeper layer no longer
+   needs to pattern-match on [provider_cfg.kind] and the SDK's
+   [provider] variant: every shape gets routed by this single helper
+   inside [Provider_adapter]. *)
+
+let agent_sdk_local_cfg ~base_url ~model_id ~api_key_env =
+  { Agent_sdk.Provider.provider = Agent_sdk.Provider.Local { base_url }
+  ; model_id
+  ; api_key_env
+  }
+
+let agent_sdk_anthropic_cfg ~model_id ~api_key_env =
+  { Agent_sdk.Provider.provider = Agent_sdk.Provider.Anthropic
+  ; model_id
+  ; api_key_env
+  }
+
+let test_apply_wire_overlay_rewraps_openai_compat_local_custom_path () =
+  let cfg =
+    Llm_provider.Provider_config.make
+      ~kind:Llm_provider.Provider_config.OpenAI_compat
+      ~model_id:"qwen3.6:35b-a3b-mlx-bf16"
+      ~base_url:"http://127.0.0.1:11434"
+      ~request_path:"/api/chat" (* non-default ollama-native path *)
+      ~api_key:"secret-token"
+      ()
+  in
+  let sdk_cfg =
+    agent_sdk_local_cfg
+      ~base_url:"http://127.0.0.1:11434"
+      ~model_id:"qwen3.6:35b-a3b-mlx-bf16"
+      ~api_key_env:""
+  in
+  let result = Adapter.apply_wire_overlay ~provider_cfg:cfg sdk_cfg in
+  match result.provider with
+  | Agent_sdk.Provider.OpenAICompat
+      { base_url; auth_header; path; static_token } ->
+    check string "base_url preserved" "http://127.0.0.1:11434" base_url;
+    check (option string) "auth_header set when api_key non-empty"
+      (Some "Authorization") auth_header;
+    check string "non-default path forwarded" "/api/chat" path;
+    check (option string) "static_token preserved" (Some "secret-token")
+      static_token
+  | _ -> fail "expected OpenAICompat overlay"
+
+let test_apply_wire_overlay_keeps_local_when_path_is_default () =
+  let cfg =
+    Llm_provider.Provider_config.make
+      ~kind:Llm_provider.Provider_config.OpenAI_compat
+      ~model_id:"qwen3.6:35b-a3b-mlx-bf16"
+      ~base_url:"http://127.0.0.1:11434"
+      ~request_path:"/v1/chat/completions" (* canonical OpenAI path *)
+      ()
+  in
+  let sdk_cfg =
+    agent_sdk_local_cfg
+      ~base_url:"http://127.0.0.1:11434"
+      ~model_id:"qwen3.6:35b-a3b-mlx-bf16"
+      ~api_key_env:""
+  in
+  let result = Adapter.apply_wire_overlay ~provider_cfg:cfg sdk_cfg in
+  match result.provider with
+  | Agent_sdk.Provider.Local { base_url } ->
+    check string "default path leaves Local untouched"
+      "http://127.0.0.1:11434" base_url
+  | _ -> fail "default path must not trigger overlay"
+
+let test_apply_wire_overlay_passthrough_for_anthropic () =
+  let cfg =
+    Llm_provider.Provider_config.make
+      ~kind:Llm_provider.Provider_config.Claude_api
+      ~model_id:"claude-sonnet-4-5"
+      ~base_url:"https://api.anthropic.com"
+      ()
+  in
+  let sdk_cfg =
+    agent_sdk_anthropic_cfg ~model_id:"claude-sonnet-4-5"
+      ~api_key_env:"ANTHROPIC_API_KEY"
+  in
+  let result = Adapter.apply_wire_overlay ~provider_cfg:cfg sdk_cfg in
+  match result.provider with
+  | Agent_sdk.Provider.Anthropic -> ()
+  | _ -> fail "non-OpenAI_compat kind must pass through"
+
+let test_apply_wire_overlay_omits_auth_header_when_key_blank () =
+  let cfg =
+    Llm_provider.Provider_config.make
+      ~kind:Llm_provider.Provider_config.OpenAI_compat
+      ~model_id:"local-model"
+      ~base_url:"http://127.0.0.1:8000"
+      ~request_path:"/api/chat"
+      ~api_key:"   " (* whitespace-only treated as blank *)
+      ()
+  in
+  let sdk_cfg =
+    agent_sdk_local_cfg ~base_url:"http://127.0.0.1:8000"
+      ~model_id:"local-model" ~api_key_env:""
+  in
+  let result = Adapter.apply_wire_overlay ~provider_cfg:cfg sdk_cfg in
+  match result.provider with
+  | Agent_sdk.Provider.OpenAICompat { auth_header; static_token; _ } ->
+    check (option string) "auth_header None when key blank" None auth_header;
+    check (option string) "static_token None when key blank" None static_token
+  | _ -> fail "expected OpenAICompat overlay even with blank key"
+
 let test_openai_compat_provider_identity_uses_endpoint_metadata () =
   let kimi_endpoint_cfg =
     Llm_provider.Provider_config.make
@@ -600,5 +707,16 @@ let () =
             test_stt_request_openai_compat;
           test_case "stt request mcp rejected" `Quick
             test_stt_request_mcp_rejected;
+        ] );
+      ( "apply_wire_overlay",
+        [
+          test_case "rewraps Local->OpenAICompat for custom path" `Quick
+            test_apply_wire_overlay_rewraps_openai_compat_local_custom_path;
+          test_case "keeps Local on default OpenAI path" `Quick
+            test_apply_wire_overlay_keeps_local_when_path_is_default;
+          test_case "passthrough for Anthropic kind" `Quick
+            test_apply_wire_overlay_passthrough_for_anthropic;
+          test_case "blank api_key yields no auth header" `Quick
+            test_apply_wire_overlay_omits_auth_header_when_key_blank;
         ] );
     ]

--- a/test/test_provider_adapter.ml
+++ b/test/test_provider_adapter.ml
@@ -1,5 +1,4 @@
 open Alcotest
-
 module Adapter = Masc_mcp.Provider_adapter
 
 let with_env name value f =
@@ -13,6 +12,7 @@ let with_env name value f =
       | Some v -> Unix.putenv name v
       | None -> Unix.putenv name "")
     f
+;;
 
 let test_resolve_direct_aliases () =
   let claude = Option.get (Adapter.resolve_direct_adapter "anthropic") in
@@ -23,11 +23,15 @@ let test_resolve_direct_aliases () =
   check string "codex-api alias" "codex-api" codex.canonical_name;
   let kimi = Option.get (Adapter.resolve_direct_adapter "kimi-api") in
   check string "kimi direct canonical" "kimi-api" kimi.canonical_name
+;;
 
 let test_resolve_cli_canonical_names () =
   let claude = Option.get (Adapter.resolve_direct_adapter "claude") in
   check string "claude canonical" "claude" claude.canonical_name;
-  check string "claude runtime" "cli_agent"
+  check
+    string
+    "claude runtime"
+    "cli_agent"
     (Adapter.string_of_runtime_kind claude.runtime_kind);
   let gemini = Option.get (Adapter.resolve_direct_adapter "gemini") in
   check string "gemini canonical" "gemini" gemini.canonical_name;
@@ -35,57 +39,93 @@ let test_resolve_cli_canonical_names () =
   check string "kimi canonical" "kimi" kimi.canonical_name;
   let codex = Option.get (Adapter.resolve_direct_adapter "codex") in
   check string "codex canonical" "codex" codex.canonical_name
+;;
 
 let test_kimi_direct_auth_accepts_primary_and_fallback_envs () =
   with_env "KIMI_API_KEY_SB" None (fun () ->
-      with_env "KIMI_API_KEY" (Some "kimi-key") (fun () ->
-          check bool "kimi direct auth available via fallback env" true
-            (Adapter.provider_auth_available "kimi-api");
-          check (list string) "kimi direct env keys"
-            [ "KIMI_API_KEY_SB"; "KIMI_API_KEY" ]
-            (Adapter.auth_env_keys_of_provider_kind
-               Llm_provider.Provider_config.Kimi)))
+    with_env "KIMI_API_KEY" (Some "kimi-key") (fun () ->
+      check
+        bool
+        "kimi direct auth available via fallback env"
+        true
+        (Adapter.provider_auth_available "kimi-api");
+      check
+        (list string)
+        "kimi direct env keys"
+        [ "KIMI_API_KEY_SB"; "KIMI_API_KEY" ]
+        (Adapter.auth_env_keys_of_provider_kind Llm_provider.Provider_config.Kimi)))
+;;
 
 let test_provider_kind_string_uses_oas_ssot () =
-  check string "anthropic ssot" "anthropic"
+  check
+    string
+    "anthropic ssot"
+    "anthropic"
     (Adapter.string_of_provider_kind Llm_provider.Provider_config.Anthropic);
-  check string "openai_compat ssot" "openai_compat"
+  check
+    string
+    "openai_compat ssot"
+    "openai_compat"
     (Adapter.string_of_provider_kind Llm_provider.Provider_config.OpenAI_compat);
-  check string "claude_code ssot" "claude_code"
+  check
+    string
+    "claude_code ssot"
+    "claude_code"
     (Adapter.string_of_provider_kind Llm_provider.Provider_config.Claude_code)
+;;
 
 let test_cascade_prefix_of_provider_kind_keeps_adapter_mapping () =
-  check string "anthropic prefix" "claude"
-    (Adapter.cascade_prefix_of_provider_kind
-       Llm_provider.Provider_config.Anthropic);
-  check string "openai compat prefix" "openai"
-    (Adapter.cascade_prefix_of_provider_kind
-       Llm_provider.Provider_config.OpenAI_compat);
-  check string "codex cli prefix" "codex_cli"
-    (Adapter.cascade_prefix_of_provider_kind
-       Llm_provider.Provider_config.Codex_cli)
+  check
+    string
+    "anthropic prefix"
+    "claude"
+    (Adapter.cascade_prefix_of_provider_kind Llm_provider.Provider_config.Anthropic);
+  check
+    string
+    "openai compat prefix"
+    "openai"
+    (Adapter.cascade_prefix_of_provider_kind Llm_provider.Provider_config.OpenAI_compat);
+  check
+    string
+    "codex cli prefix"
+    "codex_cli"
+    (Adapter.cascade_prefix_of_provider_kind Llm_provider.Provider_config.Codex_cli)
+;;
 
 let test_auth_env_keys_of_provider_kind_defaults () =
-  check (list string) "anthropic env keys" [ "ANTHROPIC_API_KEY" ]
-    (Adapter.auth_env_keys_of_provider_kind
-       Llm_provider.Provider_config.Anthropic);
-  check (list string) "openai compat env keys" [ "OPENAI_API_KEY" ]
-    (Adapter.auth_env_keys_of_provider_kind
-       Llm_provider.Provider_config.OpenAI_compat);
-  check (list string) "glm env keys" [ "ZAI_API_KEY" ]
+  check
+    (list string)
+    "anthropic env keys"
+    [ "ANTHROPIC_API_KEY" ]
+    (Adapter.auth_env_keys_of_provider_kind Llm_provider.Provider_config.Anthropic);
+  check
+    (list string)
+    "openai compat env keys"
+    [ "OPENAI_API_KEY" ]
+    (Adapter.auth_env_keys_of_provider_kind Llm_provider.Provider_config.OpenAI_compat);
+  check
+    (list string)
+    "glm env keys"
+    [ "ZAI_API_KEY" ]
     (Adapter.auth_env_keys_of_provider_kind Llm_provider.Provider_config.Glm);
-  check (list string) "ollama env keys" []
-    (Adapter.auth_env_keys_of_provider_kind
-       Llm_provider.Provider_config.Ollama);
-  check (list string) "claude code env keys" []
-    (Adapter.auth_env_keys_of_provider_kind
-       Llm_provider.Provider_config.Claude_code)
+  check
+    (list string)
+    "ollama env keys"
+    []
+    (Adapter.auth_env_keys_of_provider_kind Llm_provider.Provider_config.Ollama);
+  check
+    (list string)
+    "claude code env keys"
+    []
+    (Adapter.auth_env_keys_of_provider_kind Llm_provider.Provider_config.Claude_code)
+;;
 
 let test_gemini_auth_env_key_paths () =
-  check (list string) "gemini inventory env keys"
+  check
+    (list string)
+    "gemini inventory env keys"
     [ "GOOGLE_CLOUD_PROJECT"; "GOOGLE_CLOUD_LOCATION" ]
-    (Adapter.auth_env_keys_of_provider_kind
-       Llm_provider.Provider_config.Gemini);
+    (Adapter.auth_env_keys_of_provider_kind Llm_provider.Provider_config.Gemini);
   let config =
     Llm_provider.Provider_config.make
       ~kind:Llm_provider.Provider_config.Gemini
@@ -93,205 +133,281 @@ let test_gemini_auth_env_key_paths () =
       ~base_url:"https://generativelanguage.googleapis.com"
       ()
   in
-  check (list string) "gemini docker env keys" [ "GEMINI_API_KEY" ]
+  check
+    (list string)
+    "gemini docker env keys"
+    [ "GEMINI_API_KEY" ]
     (Adapter.docker_auth_env_keys_of_provider_config config)
+;;
 
 let test_gemini_direct_auth_vertex_adc () =
   with_env "GOOGLE_CLOUD_PROJECT" (Some "demo-project") (fun () ->
-      with_env "GOOGLE_CLOUD_LOCATION" (Some "asia-northeast3") (fun () ->
-          with_env "GEMINI_API_KEY" None (fun () ->
-              match Adapter.resolve_gemini_direct_auth () with
-              | Adapter.Gemini_vertex_adc { project; location } ->
-                  check string "project" "demo-project" project;
-                  check string "location" "asia-northeast3" location
-              | _ -> fail "expected vertex adc")))
+    with_env "GOOGLE_CLOUD_LOCATION" (Some "asia-northeast3") (fun () ->
+      with_env "GEMINI_API_KEY" None (fun () ->
+        match Adapter.resolve_gemini_direct_auth () with
+        | Adapter.Gemini_vertex_adc { project; location } ->
+          check string "project" "demo-project" project;
+          check string "location" "asia-northeast3" location
+        | _ -> fail "expected vertex adc")))
+;;
 
 let test_gemini_direct_auth_api_key_fallback () =
   with_env "GOOGLE_CLOUD_PROJECT" None (fun () ->
-      with_env "GEMINI_API_KEY" (Some "dummy-key") (fun () ->
-          match Adapter.resolve_gemini_direct_auth () with
-          | Adapter.Gemini_api_key -> ()
-          | _ -> fail "expected api key fallback"))
+    with_env "GEMINI_API_KEY" (Some "dummy-key") (fun () ->
+      match Adapter.resolve_gemini_direct_auth () with
+      | Adapter.Gemini_api_key -> ()
+      | _ -> fail "expected api key fallback"))
+;;
 
 let test_gemini_direct_auth_missing () =
   with_env "GOOGLE_CLOUD_PROJECT" None (fun () ->
-      with_env "GEMINI_API_KEY" None (fun () ->
-          match Adapter.resolve_gemini_direct_auth () with
-          | Adapter.Gemini_auth_missing message ->
-              check bool "actionable message" true (String.length message > 0)
-          | _ -> fail "expected missing auth"))
+    with_env "GEMINI_API_KEY" None (fun () ->
+      match Adapter.resolve_gemini_direct_auth () with
+      | Adapter.Gemini_auth_missing message ->
+        check bool "actionable message" true (String.length message > 0)
+      | _ -> fail "expected missing auth"))
+;;
 
 let test_vertex_base_url () =
-  check string "vertex base url"
+  check
+    string
+    "vertex base url"
     "https://aiplatform.googleapis.com/v1/projects/demo/locations/global/endpoints/openapi"
     (Adapter.gemini_vertex_openai_base_url ~project:"demo" ~location:"global")
+;;
 
 let test_default_cli_agent_name () =
-  check string "default cli agent" "auto"
-    (Adapter.default_cli_agent_name ())
+  check string "default cli agent" "auto" (Adapter.default_cli_agent_name ())
+;;
 
 let test_default_local_model_label () =
   with_env "MASC_DEFAULT_PROVIDER" (Some "test-provider") (fun () ->
-      with_env "MASC_DEFAULT_MODEL" (Some "test-model") (fun () ->
-          match Adapter.default_model_label_result () with
-          | Ok label ->
-              check string "default local label" "test-provider:test-model" label
-          | Error msg -> fail msg))
+    with_env "MASC_DEFAULT_MODEL" (Some "test-model") (fun () ->
+      match Adapter.default_model_label_result () with
+      | Ok label -> check string "default local label" "test-provider:test-model" label
+      | Error msg -> fail msg))
+;;
 
 let test_default_model_provider_prefix_result () =
   with_env "MASC_DEFAULT_PROVIDER" (Some "test-provider") (fun () ->
-      with_env "MASC_DEFAULT_MODEL" (Some "test-model") (fun () ->
-          match Adapter.default_model_provider_prefix_result () with
-          | Ok prefix -> check string "default provider prefix" "test-provider" prefix
-          | Error msg -> fail msg))
+    with_env "MASC_DEFAULT_MODEL" (Some "test-model") (fun () ->
+      match Adapter.default_model_provider_prefix_result () with
+      | Ok prefix -> check string "default provider prefix" "test-provider" prefix
+      | Error msg -> fail msg))
+;;
 
 let test_default_model_override_label_result () =
   with_env "MASC_DEFAULT_PROVIDER" (Some "gemini") (fun () ->
-      with_env "MASC_DEFAULT_MODEL" (Some "gemini-3.1-pro-preview") (fun () ->
-          match Adapter.default_model_override_label_result "gemini-3-flash-preview" with
-          | Ok label ->
-              check string "override keeps provider" "gemini:gemini-3-flash-preview"
-                label
-          | Error msg -> fail msg))
+    with_env "MASC_DEFAULT_MODEL" (Some "gemini-3.1-pro-preview") (fun () ->
+      match Adapter.default_model_override_label_result "gemini-3-flash-preview" with
+      | Ok label ->
+        check string "override keeps provider" "gemini:gemini-3-flash-preview" label
+      | Error msg -> fail msg))
+;;
 
 let test_resolve_voice_aliases () =
   let elevenlabs = Option.get (Adapter.resolve_voice_adapter "elevenlabs") in
   check string "elevenlabs alias" "elevenlabs-direct" elevenlabs.canonical_name;
   let openai_compat = Option.get (Adapter.resolve_voice_adapter "openai_compat") in
-  check string "openai compat alias" "voice-openai-compat"
-    openai_compat.canonical_name
+  check string "openai compat alias" "voice-openai-compat" openai_compat.canonical_name
+;;
 
 let test_voice_auth_env_resolution () =
   let elevenlabs = Option.get (Adapter.resolve_voice_adapter "elevenlabs-direct") in
-  check (option string) "elevenlabs auth env"
+  check
+    (option string)
+    "elevenlabs auth env"
     (Some "ELEVENLABS_API_KEY")
     (Adapter.voice_auth_env_name elevenlabs);
   let openai_compat = Option.get (Adapter.resolve_voice_adapter "voice-openai-compat") in
-  check (option string) "endpoint override auth env"
+  check
+    (option string)
+    "endpoint override auth env"
     (Some "VOICE_PROXY_KEY")
     (Adapter.voice_auth_env_name ~endpoint_api_key_env:"VOICE_PROXY_KEY" openai_compat)
+;;
 
 let test_stt_request_elevenlabs_direct () =
   let endpoint : Masc_mcp.Voice_config.endpoint =
-    { id = "test-stt"; kind = Elevenlabs_direct;
-      base_url = Some "https://api.elevenlabs.io/v1";
-      mcp_url = None; health_url = None;
-      api_key_env = Some "ELEVENLABS_API_KEY";
-      enabled = true; timeout_seconds = Some 30.0; max_retries = Some 2 }
+    { id = "test-stt"
+    ; kind = Elevenlabs_direct
+    ; base_url = Some "https://api.elevenlabs.io/v1"
+    ; mcp_url = None
+    ; health_url = None
+    ; api_key_env = Some "ELEVENLABS_API_KEY"
+    ; enabled = true
+    ; timeout_seconds = Some 30.0
+    ; max_retries = Some 2
+    }
   in
   with_env "ELEVENLABS_API_KEY" (Some "test-key-123") (fun () ->
-    match Adapter.voice_stt_request_for_endpoint endpoint
-            ~api_key:"test-key-123" ~audio_file:"/tmp/test.wav"
-            ~model:"scribe_v2" with
+    match
+      Adapter.voice_stt_request_for_endpoint
+        endpoint
+        ~api_key:"test-key-123"
+        ~audio_file:"/tmp/test.wav"
+        ~model:"scribe_v2"
+    with
     | Ok req ->
-        check string "url" "https://api.elevenlabs.io/v1/speech-to-text" req.url;
-        check bool "has xi-api-key header" true
-          (List.exists (fun (k, _) -> k = "xi-api-key") req.headers);
-        check bool "model_id in form_fields" true
-          (List.exists (fun (k, v) -> k = "model_id" && v = "scribe_v2")
-             req.form_fields);
-        let field_name, file_path = req.file_field in
-        check string "file field name" "file" field_name;
-        check string "file path" "/tmp/test.wav" file_path
+      check string "url" "https://api.elevenlabs.io/v1/speech-to-text" req.url;
+      check
+        bool
+        "has xi-api-key header"
+        true
+        (List.exists (fun (k, _) -> k = "xi-api-key") req.headers);
+      check
+        bool
+        "model_id in form_fields"
+        true
+        (List.exists (fun (k, v) -> k = "model_id" && v = "scribe_v2") req.form_fields);
+      let field_name, file_path = req.file_field in
+      check string "file field name" "file" field_name;
+      check string "file path" "/tmp/test.wav" file_path
     | Error err -> fail (Printf.sprintf "expected Ok, got Error: %s" err))
+;;
 
 let test_stt_request_openai_compat () =
   let endpoint : Masc_mcp.Voice_config.endpoint =
-    { id = "test-openai-stt"; kind = Openai_compat;
-      base_url = Some "https://api.openai.com/v1";
-      mcp_url = None; health_url = None;
-      api_key_env = Some "OPENAI_API_KEY";
-      enabled = true; timeout_seconds = Some 30.0; max_retries = Some 2 }
+    { id = "test-openai-stt"
+    ; kind = Openai_compat
+    ; base_url = Some "https://api.openai.com/v1"
+    ; mcp_url = None
+    ; health_url = None
+    ; api_key_env = Some "OPENAI_API_KEY"
+    ; enabled = true
+    ; timeout_seconds = Some 30.0
+    ; max_retries = Some 2
+    }
   in
-  match Adapter.voice_stt_request_for_endpoint endpoint
-          ~api_key:"sk-test" ~audio_file:"/tmp/test.wav"
-          ~model:"whisper-1" with
+  match
+    Adapter.voice_stt_request_for_endpoint
+      endpoint
+      ~api_key:"sk-test"
+      ~audio_file:"/tmp/test.wav"
+      ~model:"whisper-1"
+  with
   | Ok req ->
-      check string "url" "https://api.openai.com/v1/audio/transcriptions" req.url;
-      check bool "has Authorization header" true
-        (List.exists (fun (k, _) -> k = "Authorization") req.headers);
-      check bool "model in form_fields" true
-        (List.exists (fun (k, v) -> k = "model" && v = "whisper-1")
-           req.form_fields)
+    check string "url" "https://api.openai.com/v1/audio/transcriptions" req.url;
+    check
+      bool
+      "has Authorization header"
+      true
+      (List.exists (fun (k, _) -> k = "Authorization") req.headers);
+    check
+      bool
+      "model in form_fields"
+      true
+      (List.exists (fun (k, v) -> k = "model" && v = "whisper-1") req.form_fields)
   | Error err -> fail (Printf.sprintf "expected Ok, got Error: %s" err)
+;;
 
 let test_requires_discovery_llama () =
-  check bool "llama requires discovery" true
-    (Adapter.requires_discovery "llama");
-  check bool "llamacpp requires discovery" true
-    (Adapter.requires_discovery "llamacpp");
-  check bool "LLAMA case insensitive" true
-    (Adapter.requires_discovery "LLAMA")
+  check bool "llama requires discovery" true (Adapter.requires_discovery "llama");
+  check bool "llamacpp requires discovery" true (Adapter.requires_discovery "llamacpp");
+  check bool "LLAMA case insensitive" true (Adapter.requires_discovery "LLAMA")
+;;
 
 let test_requires_discovery_cloud () =
-  check bool "claude does not require discovery" false
+  check
+    bool
+    "claude does not require discovery"
+    false
     (Adapter.requires_discovery "claude");
-  check bool "gemini does not require discovery" false
+  check
+    bool
+    "gemini does not require discovery"
+    false
     (Adapter.requires_discovery "gemini");
-  check bool "custom does not require discovery" false
+  check
+    bool
+    "custom does not require discovery"
+    false
     (Adapter.requires_discovery "custom")
+;;
 
 let test_is_local_provider_llama () =
-  check bool "llama is local" true
-    (Adapter.is_local_provider "llama");
-  check bool "llamacpp is local" true
-    (Adapter.is_local_provider "llamacpp")
+  check bool "llama is local" true (Adapter.is_local_provider "llama");
+  check bool "llamacpp is local" true (Adapter.is_local_provider "llamacpp")
+;;
 
 let test_is_local_provider_custom () =
-  check bool "custom is local" true
-    (Adapter.is_local_provider "custom");
-  check bool "CUSTOM case insensitive" true
-    (Adapter.is_local_provider "CUSTOM")
+  check bool "custom is local" true (Adapter.is_local_provider "custom");
+  check bool "CUSTOM case insensitive" true (Adapter.is_local_provider "CUSTOM")
+;;
 
 let test_is_local_provider_cloud () =
-  check bool "claude is not local" false
-    (Adapter.is_local_provider "claude");
-  check bool "gemini is not local" false
-    (Adapter.is_local_provider "gemini");
-  check bool "unknown is not local" false
-    (Adapter.is_local_provider "unknown-provider")
+  check bool "claude is not local" false (Adapter.is_local_provider "claude");
+  check bool "gemini is not local" false (Adapter.is_local_provider "gemini");
+  check bool "unknown is not local" false (Adapter.is_local_provider "unknown-provider")
+;;
 
 let test_make_local_label () =
-  check string "make_local_label basic" "llama:qwen3.5"
+  check
+    string
+    "make_local_label basic"
+    "llama:qwen3.5"
     (Adapter.make_local_label "qwen3.5");
-  check string "make_local_label preserves model id" "llama:some-model"
+  check
+    string
+    "make_local_label preserves model id"
+    "llama:some-model"
     (Adapter.make_local_label "some-model");
   (* Verify make_local_label uses the same prefix as the llama adapter *)
-  check string "prefix matches cn_llama" Adapter.local_cascade_prefix
-    Adapter.cn_llama
+  check string "prefix matches cn_llama" Adapter.local_cascade_prefix Adapter.cn_llama
+;;
 
 let test_default_local_fallback_label () =
   let label = Adapter.default_local_fallback_label () in
-  check bool "fallback label contains colon" true
-    (String.contains label ':');
-  check bool "fallback label ends with :auto" true
+  check bool "fallback label contains colon" true (String.contains label ':');
+  check
+    bool
+    "fallback label ends with :auto"
+    true
     (let suffix = ":auto" in
      let slen = String.length label in
      let plen = String.length suffix in
      slen >= plen && String.sub label (slen - plen) plen = suffix)
+;;
 
 let test_stt_request_mcp_rejected () =
   let endpoint : Masc_mcp.Voice_config.endpoint =
-    { id = "test-mcp-stt"; kind = Voice_mcp;
-      base_url = None; mcp_url = Some "http://localhost:8936";
-      health_url = None; api_key_env = None;
-      enabled = true; timeout_seconds = Some 5.0; max_retries = Some 1 }
+    { id = "test-mcp-stt"
+    ; kind = Voice_mcp
+    ; base_url = None
+    ; mcp_url = Some "http://localhost:8936"
+    ; health_url = None
+    ; api_key_env = None
+    ; enabled = true
+    ; timeout_seconds = Some 5.0
+    ; max_retries = Some 1
+    }
   in
-  match Adapter.voice_stt_request_for_endpoint endpoint
-          ~api_key:"" ~audio_file:"/tmp/test.wav" ~model:"scribe_v2" with
+  match
+    Adapter.voice_stt_request_for_endpoint
+      endpoint
+      ~api_key:""
+      ~audio_file:"/tmp/test.wav"
+      ~model:"scribe_v2"
+  with
   | Ok _ -> fail "expected Error for voice_mcp endpoint"
   | Error _ -> ()
+;;
 
 let test_auto_models_use_declared_policy () =
   with_env "MASC_KIMI_CLI_AUTO_MODELS" None (fun () ->
-      check (option (list string)) "kimi cli declared default"
-        (Some [ "kimi-for-coding" ])
-        (Adapter.auto_models_for_cascade_prefix "kimi_cli");
-      with_env "MASC_GEMINI_CLI_AUTO_MODELS" None (fun () ->
-          with_env "GEMINI_DEFAULT_MODEL" (Some "gemini-3-flash-preview") (fun () ->
-              check (option (list string)) "gemini cli prefers explicit default model env"
-                (Some [ "gemini-3-flash-preview" ])
-                (Adapter.auto_models_for_cascade_prefix "gemini_cli"))))
+    check
+      (option (list string))
+      "kimi cli declared default"
+      (Some [ "kimi-for-coding" ])
+      (Adapter.auto_models_for_cascade_prefix "kimi_cli");
+    with_env "MASC_GEMINI_CLI_AUTO_MODELS" None (fun () ->
+      with_env "GEMINI_DEFAULT_MODEL" (Some "gemini-3-flash-preview") (fun () ->
+        check
+          (option (list string))
+          "gemini cli prefers explicit default model env"
+          (Some [ "gemini-3-flash-preview" ])
+          (Adapter.auto_models_for_cascade_prefix "gemini_cli"))))
+;;
 
 let test_runtime_mcp_header_support_uses_declared_policy () =
   let kimi_cli_cfg =
@@ -308,23 +424,42 @@ let test_runtime_mcp_header_support_uses_declared_policy () =
       ~base_url:""
       ()
   in
-  check bool "kimi cli supports runtime MCP headers" true
+  check
+    bool
+    "kimi cli supports runtime MCP headers"
+    true
     (Adapter.supports_runtime_mcp_http_headers_for_config kimi_cli_cfg);
-  check bool "codex cli does not support runtime MCP headers" false
+  check
+    bool
+    "codex cli does not support runtime MCP headers"
+    false
     (Adapter.supports_runtime_mcp_http_headers_for_config codex_cli_cfg);
-  check bool "claude code model label supports runtime MCP headers" true
-    (Adapter.supports_runtime_mcp_http_headers_for_model_label
-       "claude_code:auto");
-  check bool "kimi cli model label supports runtime MCP headers" true
-    (Adapter.supports_runtime_mcp_http_headers_for_model_label
-       "kimi_cli:kimi-for-coding");
-  check bool "bare exact cascade prefix uses registry" true
+  check
+    bool
+    "claude code model label supports runtime MCP headers"
+    true
+    (Adapter.supports_runtime_mcp_http_headers_for_model_label "claude_code:auto");
+  check
+    bool
+    "kimi cli model label supports runtime MCP headers"
+    true
+    (Adapter.supports_runtime_mcp_http_headers_for_model_label "kimi_cli:kimi-for-coding");
+  check
+    bool
+    "bare exact cascade prefix uses registry"
+    true
     (Adapter.supports_runtime_mcp_http_headers_for_model_label "kimi_cli");
-  check bool "codex cli model label keeps declared false" false
-    (Adapter.supports_runtime_mcp_http_headers_for_model_label
-       "codex_cli:gpt-5.4");
-  check bool "bare model id does not guess by substring" false
+  check
+    bool
+    "codex cli model label keeps declared false"
+    false
+    (Adapter.supports_runtime_mcp_http_headers_for_model_label "codex_cli:gpt-5.4");
+  check
+    bool
+    "bare model id does not guess by substring"
+    false
     (Adapter.supports_runtime_mcp_http_headers_for_model_label "gpt-5.4")
+;;
 
 let test_provider_label_of_config_preserves_cli_vs_api_identity () =
   let kimi_api_cfg =
@@ -342,12 +477,14 @@ let test_provider_label_of_config_preserves_cli_vs_api_identity () =
       ~base_url:""
       ()
   in
-  check string "kimi api label" "kimi"
-    (Adapter.provider_label_of_config kimi_api_cfg);
-  check string "kimi cli label" "kimi_cli"
-    (Adapter.provider_label_of_config kimi_cli_cfg);
-  check string "kimi cli model label" "kimi_cli:kimi-for-coding"
+  check string "kimi api label" "kimi" (Adapter.provider_label_of_config kimi_api_cfg);
+  check string "kimi cli label" "kimi_cli" (Adapter.provider_label_of_config kimi_cli_cfg);
+  check
+    string
+    "kimi cli model label"
+    "kimi_cli:kimi-for-coding"
     (Adapter.model_label_of_config kimi_cli_cfg)
+;;
 
 let test_provider_health_key_is_provider_scoped () =
   let cfg label =
@@ -358,14 +495,23 @@ let test_provider_health_key_is_provider_scoped () =
   let claude_auto = cfg "claude_code:auto" in
   let claude_sonnet = cfg "claude_code:claude-sonnet-4-6" in
   let gemini_auto = cfg "gemini_cli:auto" in
-  check string "same provider shares health key" "claude_code"
+  check
+    string
+    "same provider shares health key"
+    "claude_code"
     (Adapter.provider_health_key_of_config claude_auto);
-  check string "same provider different model shares health key"
+  check
+    string
+    "same provider different model shares health key"
     (Adapter.provider_health_key_of_config claude_auto)
     (Adapter.provider_health_key_of_config claude_sonnet);
-  check bool "same model id across providers remains isolated" true
+  check
+    bool
+    "same model id across providers remains isolated"
+    true
     (Adapter.provider_health_key_of_config claude_auto
      <> Adapter.provider_health_key_of_config gemini_auto)
+;;
 
 let test_local_openai_compat_health_key_is_endpoint_scoped () =
   let cfg label =
@@ -375,9 +521,13 @@ let test_local_openai_compat_health_key_is_endpoint_scoped () =
   in
   let primary = cfg "custom:primary@http://127.0.0.1:11111" in
   let fallback = cfg "custom:primary@http://127.0.0.1:22222" in
-  check bool "same local model on different endpoints is isolated" true
+  check
+    bool
+    "same local model on different endpoints is isolated"
+    true
     (Adapter.provider_health_key_of_config primary
      <> Adapter.provider_health_key_of_config fallback)
+;;
 
 let test_provider_model_health_key_is_model_scoped () =
   let cfg label =
@@ -387,46 +537,93 @@ let test_provider_model_health_key_is_model_scoped () =
   in
   let glm_code = cfg "glm-coding:glm-5-code" in
   let glm_51 = cfg "glm-coding:glm-5.1" in
-  check string "provider health key stays provider scoped" "glm-coding"
+  check
+    string
+    "provider health key stays provider scoped"
+    "glm-coding"
     (Adapter.provider_health_key_of_config glm_code);
-  check string "model health key includes concrete model" "glm-coding:glm-5-code"
+  check
+    string
+    "model health key includes concrete model"
+    "glm-coding:glm-5-code"
     (Adapter.provider_model_health_key_of_config glm_code);
-  check bool "sibling models do not share model health key" true
+  check
+    bool
+    "sibling models do not share model health key"
+    true
     (Adapter.provider_model_health_key_of_config glm_code
      <> Adapter.provider_model_health_key_of_config glm_51);
-  check string "sibling models still share provider health key"
+  check
+    string
+    "sibling models still share provider health key"
     (Adapter.provider_health_key_of_config glm_code)
     (Adapter.provider_health_key_of_config glm_51)
+;;
 
 let test_provider_of_model_label_uses_typed_boundaries () =
-  check string "explicit prefix wins over coarse kind" "glm-coding"
+  check
+    string
+    "explicit prefix wins over coarse kind"
+    "glm-coding"
     (Adapter.provider_of_model_label
        ~provider_kind:Llm_provider.Provider_config.OpenAI_compat
        "glm-coding:glm-5.1");
-  check string "bare labels do not guess" "unknown"
+  check
+    string
+    "bare labels do not guess"
+    "unknown"
     (Adapter.provider_of_model_label "gpt-5.4");
-  check string "typed bare label uses provider kind" "openai"
+  check
+    string
+    "typed bare label uses provider kind"
+    "openai"
     (Adapter.provider_of_model_label
        ~provider_kind:Llm_provider.Provider_config.OpenAI_compat
        "gpt-5.4");
-  check string "unknown explicit prefix stays unknown" "unknown"
+  check
+    string
+    "unknown explicit prefix stays unknown"
+    "unknown"
     (Adapter.provider_of_model_label "private-provider:model-x")
+;;
 
 let test_unmetered_provider_uses_declared_telemetry_policy () =
-  check bool "kimi cli usage missing by design" true
+  check
+    bool
+    "kimi cli usage missing by design"
+    true
     (Adapter.is_structurally_unmetered_provider "kimi_cli");
-  check bool "codex cli usage missing by design" true
+  check
+    bool
+    "codex cli usage missing by design"
+    true
     (Adapter.is_structurally_unmetered_provider "codex_cli");
-  check bool "gemini cli usage missing by design" true
+  check
+    bool
+    "gemini cli usage missing by design"
+    true
     (Adapter.is_structurally_unmetered_provider "gemini_cli");
-  check bool "claude code usage missing by design" true
+  check
+    bool
+    "claude code usage missing by design"
+    true
     (Adapter.is_structurally_unmetered_provider "claude_code");
-  check bool "ollama usage missing by design" true
+  check
+    bool
+    "ollama usage missing by design"
+    true
     (Adapter.is_structurally_unmetered_provider "ollama");
-  check bool "direct openai reports usage" false
+  check
+    bool
+    "direct openai reports usage"
+    false
     (Adapter.is_structurally_unmetered_provider "openai");
-  check bool "unknown provider is not silently exempt" false
+  check
+    bool
+    "unknown provider is not silently exempt"
+    false
     (Adapter.is_structurally_unmetered_provider "unknown")
+;;
 
 (* RFC-0058 Phase 5.6 boundary helper: apply_wire_overlay.
 
@@ -440,12 +637,11 @@ let agent_sdk_local_cfg ~base_url ~model_id ~api_key_env =
   ; model_id
   ; api_key_env
   }
+;;
 
 let agent_sdk_anthropic_cfg ~model_id ~api_key_env =
-  { Agent_sdk.Provider.provider = Agent_sdk.Provider.Anthropic
-  ; model_id
-  ; api_key_env
-  }
+  { Agent_sdk.Provider.provider = Agent_sdk.Provider.Anthropic; model_id; api_key_env }
+;;
 
 let test_apply_wire_overlay_rewraps_openai_compat_local_custom_path () =
   let cfg =
@@ -465,15 +661,17 @@ let test_apply_wire_overlay_rewraps_openai_compat_local_custom_path () =
   in
   let result = Adapter.apply_wire_overlay ~provider_cfg:cfg sdk_cfg in
   match result.provider with
-  | Agent_sdk.Provider.OpenAICompat
-      { base_url; auth_header; path; static_token } ->
+  | Agent_sdk.Provider.OpenAICompat { base_url; auth_header; path; static_token } ->
     check string "base_url preserved" "http://127.0.0.1:11434" base_url;
-    check (option string) "auth_header set when api_key non-empty"
-      (Some "Authorization") auth_header;
+    check
+      (option string)
+      "auth_header set when api_key non-empty"
+      (Some "Authorization")
+      auth_header;
     check string "non-default path forwarded" "/api/chat" path;
-    check (option string) "static_token preserved" (Some "secret-token")
-      static_token
+    check (option string) "static_token preserved" (Some "secret-token") static_token
   | _ -> fail "expected OpenAICompat overlay"
+;;
 
 let test_apply_wire_overlay_keeps_local_when_path_is_default () =
   let cfg =
@@ -493,9 +691,9 @@ let test_apply_wire_overlay_keeps_local_when_path_is_default () =
   let result = Adapter.apply_wire_overlay ~provider_cfg:cfg sdk_cfg in
   match result.provider with
   | Agent_sdk.Provider.Local { base_url } ->
-    check string "default path leaves Local untouched"
-      "http://127.0.0.1:11434" base_url
+    check string "default path leaves Local untouched" "http://127.0.0.1:11434" base_url
   | _ -> fail "default path must not trigger overlay"
+;;
 
 let test_apply_wire_overlay_passthrough_for_anthropic () =
   let cfg =
@@ -506,13 +704,13 @@ let test_apply_wire_overlay_passthrough_for_anthropic () =
       ()
   in
   let sdk_cfg =
-    agent_sdk_anthropic_cfg ~model_id:"claude-sonnet-4-5"
-      ~api_key_env:"ANTHROPIC_API_KEY"
+    agent_sdk_anthropic_cfg ~model_id:"claude-sonnet-4-5" ~api_key_env:"ANTHROPIC_API_KEY"
   in
   let result = Adapter.apply_wire_overlay ~provider_cfg:cfg sdk_cfg in
   match result.provider with
   | Agent_sdk.Provider.Anthropic -> ()
   | _ -> fail "non-OpenAI_compat kind must pass through"
+;;
 
 let test_apply_wire_overlay_omits_auth_header_when_key_blank () =
   let cfg =
@@ -525,8 +723,10 @@ let test_apply_wire_overlay_omits_auth_header_when_key_blank () =
       ()
   in
   let sdk_cfg =
-    agent_sdk_local_cfg ~base_url:"http://127.0.0.1:8000"
-      ~model_id:"local-model" ~api_key_env:""
+    agent_sdk_local_cfg
+      ~base_url:"http://127.0.0.1:8000"
+      ~model_id:"local-model"
+      ~api_key_env:""
   in
   let result = Adapter.apply_wire_overlay ~provider_cfg:cfg sdk_cfg in
   match result.provider with
@@ -534,6 +734,7 @@ let test_apply_wire_overlay_omits_auth_header_when_key_blank () =
     check (option string) "auth_header None when key blank" None auth_header;
     check (option string) "static_token None when key blank" None static_token
   | _ -> fail "expected OpenAICompat overlay even with blank key"
+;;
 
 let test_openai_compat_provider_identity_uses_endpoint_metadata () =
   let kimi_endpoint_cfg =
@@ -552,59 +753,88 @@ let test_openai_compat_provider_identity_uses_endpoint_metadata () =
       ~request_path:"/v1/chat/completions"
       ()
   in
-  check string "moonshot endpoint maps to kimi adapter" "kimi"
+  check
+    string
+    "moonshot endpoint maps to kimi adapter"
+    "kimi"
     (Adapter.provider_label_of_config kimi_endpoint_cfg);
-  check string "model id alone does not imply kimi" "openai"
+  check
+    string
+    "model id alone does not imply kimi"
+    "openai"
     (Adapter.provider_label_of_config openai_endpoint_cfg)
+;;
 
 (* RFC-0058 §2.4 SSOT bridge — cascade-decl capabilities → tool_policy. *)
 
 let test_tool_policy_of_cascade_capabilities_none_is_conservative () =
   let policy = Adapter.tool_policy_of_cascade_capabilities None in
-  check bool "None: supports_runtime_mcp_http_headers = false" false
+  check
+    bool
+    "None: supports_runtime_mcp_http_headers = false"
+    false
     policy.supports_runtime_mcp_http_headers;
-  check bool "None: requires_per_keeper_bridging = false" false
+  check
+    bool
+    "None: requires_per_keeper_bridging = false"
+    false
     policy.requires_per_keeper_bridging_for_bound_actor_tools;
-  check (list string) "None: identity_runtime_mcp_header_keys = []" []
+  check
+    (list string)
+    "None: identity_runtime_mcp_header_keys = []"
+    []
     policy.identity_runtime_mcp_header_keys;
-  check bool "None: argv_prompt_preflight = false" false
-    policy.argv_prompt_preflight;
-  check bool "None: uses_anthropic_caching = false" false
-    policy.uses_anthropic_caching;
-  check (option int) "None: max_turns_per_attempt = None" None
+  check bool "None: argv_prompt_preflight = false" false policy.argv_prompt_preflight;
+  check bool "None: uses_anthropic_caching = false" false policy.uses_anthropic_caching;
+  check
+    (option int)
+    "None: max_turns_per_attempt = None"
+    None
     policy.max_turns_per_attempt;
-  check bool "None: tolerates_bound_actor_fallback = false" false
+  check
+    bool
+    "None: tolerates_bound_actor_fallback = false"
+    false
     policy.tolerates_bound_actor_fallback
+;;
 
 let test_tool_policy_of_cascade_capabilities_some_maps_subset () =
   let caps : Cascade_declarative_types.cascade_capabilities =
-    {
-      Cascade_declarative_types.cascade_capabilities_default with
-      supports_runtime_mcp_http_headers = true;
-      requires_per_keeper_bridging_for_bound_actor_tools = true;
-      identity_runtime_mcp_header_keys = [ "authorization"; "x-openai-beta" ];
-      argv_prompt_preflight = true;
-      uses_anthropic_caching = true;
-      max_turns_per_attempt = Some 8;
-      tolerates_bound_actor_fallback = true;
+    { Cascade_declarative_types.cascade_capabilities_default with
+      supports_runtime_mcp_http_headers = true
+    ; requires_per_keeper_bridging_for_bound_actor_tools = true
+    ; identity_runtime_mcp_header_keys = [ "authorization"; "x-openai-beta" ]
+    ; argv_prompt_preflight = true
+    ; uses_anthropic_caching = true
+    ; max_turns_per_attempt = Some 8
+    ; tolerates_bound_actor_fallback = true
     }
   in
   let policy = Adapter.tool_policy_of_cascade_capabilities (Some caps) in
-  check bool "Some: supports_runtime_mcp_http_headers" true
+  check
+    bool
+    "Some: supports_runtime_mcp_http_headers"
+    true
     policy.supports_runtime_mcp_http_headers;
-  check bool "Some: requires_per_keeper_bridging" true
+  check
+    bool
+    "Some: requires_per_keeper_bridging"
+    true
     policy.requires_per_keeper_bridging_for_bound_actor_tools;
-  check (list string) "Some: identity_runtime_mcp_header_keys"
+  check
+    (list string)
+    "Some: identity_runtime_mcp_header_keys"
     [ "authorization"; "x-openai-beta" ]
     policy.identity_runtime_mcp_header_keys;
-  check bool "Some: argv_prompt_preflight" true
-    policy.argv_prompt_preflight;
-  check bool "Some: uses_anthropic_caching" true
-    policy.uses_anthropic_caching;
-  check (option int) "Some: max_turns_per_attempt" (Some 8)
-    policy.max_turns_per_attempt;
-  check bool "Some: tolerates_bound_actor_fallback" true
+  check bool "Some: argv_prompt_preflight" true policy.argv_prompt_preflight;
+  check bool "Some: uses_anthropic_caching" true policy.uses_anthropic_caching;
+  check (option int) "Some: max_turns_per_attempt" (Some 8) policy.max_turns_per_attempt;
+  check
+    bool
+    "Some: tolerates_bound_actor_fallback"
+    true
     policy.tolerates_bound_actor_fallback
+;;
 
 let test_tool_policy_of_cascade_capabilities_default_matches_none () =
   let from_default =
@@ -612,111 +842,156 @@ let test_tool_policy_of_cascade_capabilities_default_matches_none () =
       (Some Cascade_declarative_types.cascade_capabilities_default)
   in
   let from_none = Adapter.tool_policy_of_cascade_capabilities None in
-  check bool "default Some matches None: supports_runtime_mcp_http_headers"
+  check
+    bool
+    "default Some matches None: supports_runtime_mcp_http_headers"
     from_none.supports_runtime_mcp_http_headers
     from_default.supports_runtime_mcp_http_headers;
-  check bool "default Some matches None: requires_per_keeper_bridging"
+  check
+    bool
+    "default Some matches None: requires_per_keeper_bridging"
     from_none.requires_per_keeper_bridging_for_bound_actor_tools
     from_default.requires_per_keeper_bridging_for_bound_actor_tools;
-  check (list string) "default Some matches None: identity headers"
+  check
+    (list string)
+    "default Some matches None: identity headers"
     from_none.identity_runtime_mcp_header_keys
     from_default.identity_runtime_mcp_header_keys;
-  check bool "default Some matches None: tolerates_bound_actor_fallback"
+  check
+    bool
+    "default Some matches None: tolerates_bound_actor_fallback"
     from_none.tolerates_bound_actor_fallback
     from_default.tolerates_bound_actor_fallback
+;;
 
 let () =
-  run "Provider Adapter"
-    [
-      ( "registry",
-        [
-          test_case "resolve direct aliases" `Quick test_resolve_direct_aliases;
-          test_case "resolve cli canonicals" `Quick test_resolve_cli_canonical_names;
-          test_case "kimi direct auth accepts fallback envs" `Quick
-            test_kimi_direct_auth_accepts_primary_and_fallback_envs;
-          test_case "provider kind string uses oas ssot" `Quick
-            test_provider_kind_string_uses_oas_ssot;
-          test_case "cascade prefix keeps adapter mapping" `Quick
-            test_cascade_prefix_of_provider_kind_keeps_adapter_mapping;
-          test_case "provider kind auth env defaults" `Quick
-            test_auth_env_keys_of_provider_kind_defaults;
-          test_case "gemini auth env key paths" `Quick
-            test_gemini_auth_env_key_paths;
-          test_case "gemini vertex adc" `Quick test_gemini_direct_auth_vertex_adc;
-          test_case "gemini api key fallback" `Quick
-            test_gemini_direct_auth_api_key_fallback;
-          test_case "gemini missing auth" `Quick test_gemini_direct_auth_missing;
-          test_case "vertex base url" `Quick test_vertex_base_url;
-          test_case "default cli agent" `Quick test_default_cli_agent_name;
-          test_case "default local model label" `Quick test_default_local_model_label;
-          test_case "default provider prefix" `Quick
-            test_default_model_provider_prefix_result;
-          test_case "default override label" `Quick
-            test_default_model_override_label_result;
-          test_case "declared auto model policy" `Quick
-            test_auto_models_use_declared_policy;
-          test_case "declared runtime MCP header policy" `Quick
-            test_runtime_mcp_header_support_uses_declared_policy;
-          test_case "provider label keeps cli vs api identity" `Quick
-            test_provider_label_of_config_preserves_cli_vs_api_identity;
-          test_case "provider health key is provider scoped" `Quick
-            test_provider_health_key_is_provider_scoped;
-          test_case "local openai compat health key is endpoint scoped" `Quick
-            test_local_openai_compat_health_key_is_endpoint_scoped;
-          test_case "provider model health key is model scoped" `Quick
-            test_provider_model_health_key_is_model_scoped;
-          test_case "provider model label uses typed boundaries" `Quick
-            test_provider_of_model_label_uses_typed_boundaries;
-          test_case "unmetered provider uses telemetry policy" `Quick
-            test_unmetered_provider_uses_declared_telemetry_policy;
-          test_case "openai compat identity uses endpoint metadata" `Quick
-            test_openai_compat_provider_identity_uses_endpoint_metadata;
-          test_case "resolve voice aliases" `Quick test_resolve_voice_aliases;
-          test_case "voice auth env resolution" `Quick
-            test_voice_auth_env_resolution;
-          test_case "tool_policy_of_cascade_capabilities None is conservative"
+  run
+    "Provider Adapter"
+    [ ( "registry"
+      , [ test_case "resolve direct aliases" `Quick test_resolve_direct_aliases
+        ; test_case "resolve cli canonicals" `Quick test_resolve_cli_canonical_names
+        ; test_case
+            "kimi direct auth accepts fallback envs"
             `Quick
-            test_tool_policy_of_cascade_capabilities_none_is_conservative;
-          test_case "tool_policy_of_cascade_capabilities Some maps subset"
-            `Quick test_tool_policy_of_cascade_capabilities_some_maps_subset;
-          test_case "tool_policy_of_cascade_capabilities default matches None"
+            test_kimi_direct_auth_accepts_primary_and_fallback_envs
+        ; test_case
+            "provider kind string uses oas ssot"
             `Quick
-            test_tool_policy_of_cascade_capabilities_default_matches_none;
-        ] );
-      ( "local_provider",
-        [
-          test_case "requires_discovery llama" `Quick
-            test_requires_discovery_llama;
-          test_case "requires_discovery cloud" `Quick
-            test_requires_discovery_cloud;
-          test_case "is_local_provider llama" `Quick
-            test_is_local_provider_llama;
-          test_case "is_local_provider custom" `Quick
-            test_is_local_provider_custom;
-          test_case "is_local_provider cloud" `Quick
-            test_is_local_provider_cloud;
-          test_case "make_local_label" `Quick test_make_local_label;
-          test_case "default_local_fallback_label" `Quick
-            test_default_local_fallback_label;
-        ] );
-      ( "stt",
-        [
-          test_case "stt request elevenlabs direct" `Quick
-            test_stt_request_elevenlabs_direct;
-          test_case "stt request openai compat" `Quick
-            test_stt_request_openai_compat;
-          test_case "stt request mcp rejected" `Quick
-            test_stt_request_mcp_rejected;
-        ] );
-      ( "apply_wire_overlay",
-        [
-          test_case "rewraps Local->OpenAICompat for custom path" `Quick
-            test_apply_wire_overlay_rewraps_openai_compat_local_custom_path;
-          test_case "keeps Local on default OpenAI path" `Quick
-            test_apply_wire_overlay_keeps_local_when_path_is_default;
-          test_case "passthrough for Anthropic kind" `Quick
-            test_apply_wire_overlay_passthrough_for_anthropic;
-          test_case "blank api_key yields no auth header" `Quick
-            test_apply_wire_overlay_omits_auth_header_when_key_blank;
-        ] );
+            test_provider_kind_string_uses_oas_ssot
+        ; test_case
+            "cascade prefix keeps adapter mapping"
+            `Quick
+            test_cascade_prefix_of_provider_kind_keeps_adapter_mapping
+        ; test_case
+            "provider kind auth env defaults"
+            `Quick
+            test_auth_env_keys_of_provider_kind_defaults
+        ; test_case "gemini auth env key paths" `Quick test_gemini_auth_env_key_paths
+        ; test_case "gemini vertex adc" `Quick test_gemini_direct_auth_vertex_adc
+        ; test_case
+            "gemini api key fallback"
+            `Quick
+            test_gemini_direct_auth_api_key_fallback
+        ; test_case "gemini missing auth" `Quick test_gemini_direct_auth_missing
+        ; test_case "vertex base url" `Quick test_vertex_base_url
+        ; test_case "default cli agent" `Quick test_default_cli_agent_name
+        ; test_case "default local model label" `Quick test_default_local_model_label
+        ; test_case
+            "default provider prefix"
+            `Quick
+            test_default_model_provider_prefix_result
+        ; test_case
+            "default override label"
+            `Quick
+            test_default_model_override_label_result
+        ; test_case
+            "declared auto model policy"
+            `Quick
+            test_auto_models_use_declared_policy
+        ; test_case
+            "declared runtime MCP header policy"
+            `Quick
+            test_runtime_mcp_header_support_uses_declared_policy
+        ; test_case
+            "provider label keeps cli vs api identity"
+            `Quick
+            test_provider_label_of_config_preserves_cli_vs_api_identity
+        ; test_case
+            "provider health key is provider scoped"
+            `Quick
+            test_provider_health_key_is_provider_scoped
+        ; test_case
+            "local openai compat health key is endpoint scoped"
+            `Quick
+            test_local_openai_compat_health_key_is_endpoint_scoped
+        ; test_case
+            "provider model health key is model scoped"
+            `Quick
+            test_provider_model_health_key_is_model_scoped
+        ; test_case
+            "provider model label uses typed boundaries"
+            `Quick
+            test_provider_of_model_label_uses_typed_boundaries
+        ; test_case
+            "unmetered provider uses telemetry policy"
+            `Quick
+            test_unmetered_provider_uses_declared_telemetry_policy
+        ; test_case
+            "openai compat identity uses endpoint metadata"
+            `Quick
+            test_openai_compat_provider_identity_uses_endpoint_metadata
+        ; test_case "resolve voice aliases" `Quick test_resolve_voice_aliases
+        ; test_case "voice auth env resolution" `Quick test_voice_auth_env_resolution
+        ; test_case
+            "tool_policy_of_cascade_capabilities None is conservative"
+            `Quick
+            test_tool_policy_of_cascade_capabilities_none_is_conservative
+        ; test_case
+            "tool_policy_of_cascade_capabilities Some maps subset"
+            `Quick
+            test_tool_policy_of_cascade_capabilities_some_maps_subset
+        ; test_case
+            "tool_policy_of_cascade_capabilities default matches None"
+            `Quick
+            test_tool_policy_of_cascade_capabilities_default_matches_none
+        ] )
+    ; ( "local_provider"
+      , [ test_case "requires_discovery llama" `Quick test_requires_discovery_llama
+        ; test_case "requires_discovery cloud" `Quick test_requires_discovery_cloud
+        ; test_case "is_local_provider llama" `Quick test_is_local_provider_llama
+        ; test_case "is_local_provider custom" `Quick test_is_local_provider_custom
+        ; test_case "is_local_provider cloud" `Quick test_is_local_provider_cloud
+        ; test_case "make_local_label" `Quick test_make_local_label
+        ; test_case
+            "default_local_fallback_label"
+            `Quick
+            test_default_local_fallback_label
+        ] )
+    ; ( "stt"
+      , [ test_case
+            "stt request elevenlabs direct"
+            `Quick
+            test_stt_request_elevenlabs_direct
+        ; test_case "stt request openai compat" `Quick test_stt_request_openai_compat
+        ; test_case "stt request mcp rejected" `Quick test_stt_request_mcp_rejected
+        ] )
+    ; ( "apply_wire_overlay"
+      , [ test_case
+            "rewraps Local->OpenAICompat for custom path"
+            `Quick
+            test_apply_wire_overlay_rewraps_openai_compat_local_custom_path
+        ; test_case
+            "keeps Local on default OpenAI path"
+            `Quick
+            test_apply_wire_overlay_keeps_local_when_path_is_default
+        ; test_case
+            "passthrough for Anthropic kind"
+            `Quick
+            test_apply_wire_overlay_passthrough_for_anthropic
+        ; test_case
+            "blank api_key yields no auth header"
+            `Quick
+            test_apply_wire_overlay_omits_auth_header_when_key_blank
+        ] )
     ]
+;;


### PR DESCRIPTION
## Summary

Move the OpenAI_compat+Local rewrap pattern out of the keeper layer into a single Provider_adapter helper. Closes 1 of the 4 remaining RFC-0058 Phase 5.6 leak sites; follows up #14691 (leak 1 — turn liveness).

## Before / After

**Before** — `lib/keeper/keeper_agent_context.ml:83-108`

```ocaml
match provider_cfg.kind, provider.provider with
| Llm_provider.Provider_config.OpenAI_compat,
  Agent_sdk.Provider.Local { base_url }
  when not (String.equal provider_cfg.request_path
              Masc_network_defaults.openai_chat_completions_path) ->
  (* 22 lines: rebuild auth_header, static_token, rewrap as OpenAICompat *)
| _ -> provider
```

Cross-layer coupling: keeper inspected an `Llm_provider` variant **and** an `Agent_sdk.Provider` variant simultaneously.

**After** — keeper layer is now provider-agnostic:

```ocaml
let provider =
  Agent_sdk.Provider.config_of_provider_config provider_cfg
  |> Provider_adapter.apply_wire_overlay ~provider_cfg
```

The variant match lives in `Provider_adapter.apply_wire_overlay` — the boundary site explicitly named in RFC-0058 §2.4.

## Why

`config_of_provider_config` under-routes `OpenAI_compat` configs to `Local { base_url }` because the SDK has no concept of a custom `request_path` or static auth token. When the operator configures e.g. `request_path = "/api/chat"` (ollama native) or a non-trivial `api_key`, the SDK's default mapping silently drops both. The overlay rewraps as `OpenAICompat { base_url; auth_header; path; static_token }` so the cfg's intent reaches the wire.

Adding a new OpenAI-compatible provider (vLLM, lmstudio, OpenRouter) now needs only an edit inside `Provider_adapter`; keeper code never names a provider variant.

## Sealing tests

| Test | Invariant |
|---|---|
| `rewraps Local->OpenAICompat for custom path` | Custom `request_path` + non-blank `api_key` produces a fully-populated `OpenAICompat` overlay |
| `keeps Local on default OpenAI path` | Default `/v1/chat/completions` passes through — no spurious rewrap |
| `passthrough for Anthropic kind` | Non-`OpenAI_compat` kinds untouched |
| `blank api_key yields no auth header` | Whitespace-only `api_key` produces `auth_header = None`, `static_token = None` |

## Workaround self-check

| # | check | result |
|---|---|---|
| 1 | telemetry-as-fix? | no — variant match removed, no counter |
| 2 | string classifier? | no — typed match on `Provider_config.t` |
| 3 | N-of-M? | no — this file's `provider_cfg.kind` matches go 1 → 0 |
| 4 | catch-all `_ ->` added? | no |
| 5 | cap/cooldown/dedup/repair? | no |
| 6 | test backdoor? | no |
| 7 | same typo N sites? | no |

## Ratchet metric

`rg "provider_cfg\.kind" lib/keeper/keeper_agent_context.ml`

| | matches |
|---|---|
| Before (origin/main) | 1 |
| After (this branch)  | 0 |

## Test plan

- [x] 4 new tests in `test_provider_adapter.ml`
- [x] Existing tests preserved
- [ ] CI build + test (local build blocked by `dune-local.sh` global lock)

🤖 Generated with [Claude Code](https://claude.com/claude-code)