### PR TITLE
refactor(cascade): caller-driven explicit capacity register, kill looks_like_ollama

### DIFF
--- a/lib/cascade/cascade_client_capacity.ml
+++ b/lib/cascade/cascade_client_capacity.ml
@@ -202,44 +202,16 @@ let () =
       (fun (url, max_concurrent) -> register ~url ~max_concurrent)
       (parse_capacity_env s)
 
-(* ── Heuristic auto-registration for ollama-like URLs ─────────────
-
-   Auto-registration runs whenever a candidate set arrives without an
-   explicit MASC_CLIENT_CAPACITY entry. The pattern check delegates to
-   [Masc_network_defaults] so the URL→provider mapping stays in one
-   place; we used to make these decisions here and elsewhere with
-   ad-hoc substring checks, so the audit (audit_derived_state #9, Kimi
-   3-7) flagged it as a hidden heuristic. Operators who want to pin
-   capacity should use MASC_CLIENT_CAPACITY (parsed above); when this
-   path fires we log it at info level so the auto-decision is visible
-   in the operations log. *)
-
-let looks_like_ollama = Masc_network_defaults.is_ollama_url
+(* The old [looks_like_ollama] / [auto_register_for_candidates] /
+   [auto_register_ollama_with_override] helpers used a [:11434]
+   substring scan to decide which URLs to register. That heuristic
+   misclassified non-ollama services on the same port and missed
+   ollama on non-default ports. The keeper-side caller
+   ([Keeper_turn_driver]) now consults
+   [Provider_adapter.is_http_probe_capable_kind] and calls
+   {!register} directly, so the heuristic is gone. *)
 
 let looks_like_cli_sentinel = Masc_network_defaults.is_cli_sentinel_url
-
-let auto_register_for_candidates ~base_urls =
-  let max_concurrent = 1 in
-  List.iter
-    (fun url ->
-       if looks_like_ollama url && not (is_registered url) then begin
-         Log.Misc.info
-           "auto-registering ollama-like url=%S with max_concurrent=%d \
-            (override via MASC_CLIENT_CAPACITY)" url max_concurrent;
-         register ~url ~max_concurrent
-       end)
-    base_urls
-
-let auto_register_ollama_with_override ~base_urls ~max_concurrent =
-  List.iter
-    (fun url ->
-       if looks_like_ollama url && not (is_registered url) then begin
-         Log.Misc.info
-           "auto-registering ollama-like url=%S with override max_concurrent=%d"
-           url max_concurrent;
-         register ~url ~max_concurrent
-       end)
-    base_urls
 
 let auto_register_cli_for_candidates ~capacity_keys =
   let max_concurrent = cli_default_max () in

--- a/lib/cascade/cascade_client_capacity.mli
+++ b/lib/cascade/cascade_client_capacity.mli
@@ -33,7 +33,8 @@ val register : url:string -> max_concurrent:int -> unit
 
     Typical callers:
     - module init parses [MASC_CLIENT_CAPACITY]
-    - [auto_register_for_candidates] auto-registers ollama URLs *)
+    - [Keeper_turn_driver] registers HTTP-probe-capable candidates
+      gated on [Provider_adapter.is_http_probe_capable_kind] *)
 
 val registered_urls : unit -> string list
 (** Snapshot of currently-registered URLs.  Test helper. *)
@@ -56,28 +57,7 @@ val snapshot : unit -> (string * Cascade_throttle.capacity_info) list
 val unregister_all : unit -> unit
 (** Remove every registration.  Test helper. *)
 
-(** {1 Auto-registration} *)
-
-val auto_register_for_candidates :
-  base_urls:string list ->
-  unit
-(** For each base URL that looks like an ollama HTTP endpoint
-    (heuristic: host/port contains [:11434]) and is not yet
-    registered, register it with concurrency [1].
-
-    Idempotent.  Safe to call on every cascade attempt; already-
-    registered URLs are left alone. *)
-
-val auto_register_ollama_with_override :
-  base_urls:string list ->
-  max_concurrent:int ->
-  unit
-(** Like {!auto_register_for_candidates} but with an explicit
-    [max_concurrent] that overrides the env default.  Used by the
-    per-cascade [<name>_ollama_max_concurrent] field.
-
-    Idempotent and only touches URLs that look like ollama and are
-    not already registered. *)
+(** {1 CLI sentinel auto-registration} *)
 
 val auto_register_cli_for_candidates :
   capacity_keys:string list ->

--- a/lib/cascade/cascade_config.mli
+++ b/lib/cascade/cascade_config.mli
@@ -571,8 +571,11 @@ val resolve_ollama_max_concurrent :
   name:string ->
   unit ->
   int option
-(** Per-cascade override for the ollama client-capacity registration
-    default ({!Cascade_client_capacity.auto_register_for_candidates}).
+(** Per-cascade override for the HTTP-probe-capable provider's
+    client-capacity registration default.  The caller in
+    {!Keeper_turn_driver} consults
+    {!Provider_adapter.is_http_probe_capable_kind} and registers
+    matching cfgs through {!Cascade_client_capacity.register}.
     [None] means "use the literal default of 1". *)
 
 val resolve_cli_max_concurrent :

--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -812,13 +812,24 @@ let run_named
       | None -> ""
   in
   let candidate_capacity_keys = List.map capacity_key_of candidate_cfgs in
-  (match ollama_max with
-   | None ->
-     Cascade_client_capacity.auto_register_for_candidates
-       ~base_urls:candidate_base_urls
-   | Some n ->
-     Cascade_client_capacity.auto_register_ollama_with_override
-       ~base_urls:candidate_base_urls ~max_concurrent:n);
+  (* Register HTTP-probe-capable provider URLs explicitly.  Capability
+     check goes through [Provider_adapter.is_http_probe_capable_kind] —
+     keeper code does not name a provider variant.  Both registries
+     receive the same URL: [Cascade_client_capacity] for the per-process
+     semaphore, [Cascade_http_probe] for the [/api/ps] probe adapter. *)
+  let http_probe_max_concurrent = Option.value ollama_max ~default:1 in
+  List.iter
+    (fun (cfg : Llm_provider.Provider_config.t) ->
+       if Provider_adapter.is_http_probe_capable_kind cfg.kind
+          && cfg.base_url <> ""
+       then begin
+         if not (Cascade_client_capacity.is_registered cfg.base_url) then
+           Cascade_client_capacity.register
+             ~url:cfg.base_url
+             ~max_concurrent:http_probe_max_concurrent;
+         Cascade_http_probe.register_url ~url:cfg.base_url
+       end)
+    candidate_cfgs;
   (* Refresh provider [/api/ps] cache for any candidate whose cache
      entry has expired.  Failures are swallowed inside the probe so
      a flaky probe never breaks the cascade — it just denies the

--- a/lib/provider_adapter.ml
+++ b/lib/provider_adapter.ml
@@ -783,6 +783,22 @@ let is_local_provider pname =
   normalized = cn_custom || requires_discovery pname
 ;;
 
+(** [is_http_probe_capable_kind kind] is [true] when the provider
+    serves an HTTP capacity probe endpoint that
+    {!Cascade_http_probe} can poll (currently the ollama [/api/ps]
+    schema).  Used by caller-side registration paths
+    ({!Keeper_turn_driver}) to decide whether to register a cfg's
+    [base_url] with the probe registry.
+
+    RFC-0058 Phase 5.6: capability predicate, not a vendor match —
+    keeper callers stay provider-agnostic.  Adding vLLM/lmstudio
+    requires editing this one boundary site. *)
+let is_http_probe_capable_kind (kind : Llm_provider.Provider_config.provider_kind) : bool =
+  match kind with
+  | Llm_provider.Provider_config.Ollama -> true
+  | _ -> false
+;;
+
 (** Default fallback label for local runtime when no other preferred
     model labels are configured.  Uses "provider:auto" for the first
     [Local] adapter found. *)

--- a/lib/provider_adapter.mli
+++ b/lib/provider_adapter.mli
@@ -282,6 +282,19 @@ val requires_discovery : string -> bool
 (** Returns true if the provider is self-hosted and always available. *)
 val is_local_provider : string -> bool
 
+(** [is_http_probe_capable_kind kind] is [true] when the provider
+    serves an HTTP capacity probe endpoint that
+    {!Cascade_http_probe} can poll (currently the ollama [/api/ps]
+    schema). Caller-side capacity-register paths consult this flag
+    to decide whether to register the cfg's [base_url] with the
+    probe registry.
+
+    RFC-0058 Phase 5.6: capability predicate, not a vendor match.
+    Adding vLLM / lmstudio support means editing this one boundary
+    site, never the keeper layer. *)
+val is_http_probe_capable_kind :
+  Llm_provider.Provider_config.provider_kind -> bool
+
 (** {1 Voice Adapter Resolution} *)
 
 val resolve_voice_adapter : string -> voice_adapter option

--- a/test/test_cascade_strategy.ml
+++ b/test/test_cascade_strategy.ml
@@ -512,30 +512,14 @@ let test_client_capacity_clamp_max () =
   | Some info ->
     check int "max_concurrent <=0 clamped to 1" 1 info.total
 
-let test_ollama_auto_register () =
-  C.unregister_all ();
-  C.auto_register_for_candidates ~base_urls:[
-    "http://127.0.0.1:11434";
-    "http://glm.example.com/api";    (* not ollama: 11434 not in URL *)
-    "http://other:11434/api";        (* ollama-like *)
-  ];
-  let urls = C.registered_urls () in
-  check bool "127.0.0.1:11434 registered"
-    true (List.mem "http://127.0.0.1:11434" urls);
-  check bool "other:11434 registered"
-    true (List.mem "http://other:11434/api" urls);
-  check bool "glm.example.com NOT registered"
-    false (List.mem "http://glm.example.com/api" urls)
-
-let test_ollama_register_with_override () =
-  C.unregister_all ();
-  C.auto_register_ollama_with_override
-    ~base_urls:["http://127.0.0.1:11434"]
-    ~max_concurrent:4;
-  match C.capacity "http://127.0.0.1:11434" with
-  | None -> fail "expected registration"
-  | Some info ->
-    check int "override max=4" 4 info.total
+(* The previous [test_ollama_auto_register] /
+   [test_ollama_register_with_override] tests exercised the substring-scan
+   auto-registration path inside [Cascade_client_capacity]. That path is
+   gone now — the caller ([Keeper_turn_driver]) consults
+   [Provider_adapter.is_http_probe_capable_kind] and calls
+   [Cascade_client_capacity.register] explicitly, so the test surface
+   for the removed [auto_register_for_candidates] /
+   [auto_register_ollama_with_override] functions is gone with them. *)
 
 (* ── Phase C3: CLI sentinel auto-registration ──────────────── *)
 
@@ -1248,10 +1232,6 @@ let () =
         test_client_capacity_unregistered_url;
       test_case "max_concurrent <= 0 clamped to 1" `Quick
         test_client_capacity_clamp_max;
-      test_case "auto-register matches :11434 hosts" `Quick
-        test_ollama_auto_register;
-      test_case "auto_register override sets max" `Quick
-        test_ollama_register_with_override;
       test_case "cli sentinel auto-register filters non-CLI" `Quick
         test_cli_auto_register_filters_sentinels;
       test_case "cli auto_register override sets max" `Quick


### PR DESCRIPTION
## Summary

Follow-up to PR #14710 (Http_probe explicit URL registry). Removes the remaining substring-scan classifier inside `Cascade_client_capacity`. The keeper-side caller now consults `Provider_adapter.is_http_probe_capable_kind` (new capability predicate, boundary-only) and calls `register` directly.

## Why

`looks_like_ollama` aliased `Masc_network_defaults.is_ollama_url`, the same `:11434` substring scan we already retired from `Cascade_http_probe`. Two failure modes:

- vLLM/lmstudio on `:11434` mis-classified as ollama
- ollama on a non-default port invisible to auto-registration

`Keeper_turn_driver` already holds `candidate_cfgs : Provider_config.t list`. The typed kind is right there — no need to guess from URL string.

## Before / After

**Before** — keeper hands raw `base_urls` to a `cascade_client_capacity` heuristic:

```ocaml
match ollama_max with
| None ->
  Cascade_client_capacity.auto_register_for_candidates
    ~base_urls:candidate_base_urls
| Some n ->
  Cascade_client_capacity.auto_register_ollama_with_override
    ~base_urls:candidate_base_urls ~max_concurrent:n
```

**After** — keeper consults a typed capability predicate and registers explicitly:

```ocaml
let http_probe_max_concurrent = Option.value ollama_max ~default:1 in
List.iter (fun (cfg : Llm_provider.Provider_config.t) ->
  if Provider_adapter.is_http_probe_capable_kind cfg.kind
     && cfg.base_url <> ""
  then begin
    if not (Cascade_client_capacity.is_registered cfg.base_url) then
      Cascade_client_capacity.register
        ~url:cfg.base_url ~max_concurrent:http_probe_max_concurrent;
    Cascade_http_probe.register_url ~url:cfg.base_url
  end
) candidate_cfgs
```

## Dead code removed

| Symbol | Status |
|---|---|
| `Cascade_client_capacity.looks_like_ollama` | removed (alias for `is_ollama_url`) |
| `Cascade_client_capacity.auto_register_for_candidates` | removed |
| `Cascade_client_capacity.auto_register_ollama_with_override` | removed |
| `test_ollama_auto_register`, `test_ollama_register_with_override` | removed (substring-path tests) |

Net diff: **+71 / -96 LOC**.

## New boundary helper

`Provider_adapter.is_http_probe_capable_kind : provider_kind -> bool` — currently `Ollama -> true`, everything else `false`. Adding vLLM/lmstudio support means editing this one site, never the keeper layer.

## Workaround self-check

| # | check | result |
|---|---|---|
| 1 | telemetry-as-fix? | no |
| 2 | string classifier? | **removed** — typed predicate replaces substring scan |
| 3 | N-of-M? | partial — `Masc_network_defaults.is_ollama_url` still used by `dashboard_cascade` / `cascade_client_capacity_history` for human-readable labels. That decision is rendering, not capacity registration — out of probe scope. |
| 4 | catch-all `_ ->` added? | the predicate uses `\| _ -> false` deliberately: "Ollama is the only HTTP-probe-capable kind today; adding vLLM means editing this one site" — correct closed-sum default, not a swallowing catch-all |
| 5 | cap/cooldown/dedup/repair? | no |
| 6 | test backdoor? | no |
| 7 | same typo N sites? | no |

## Test plan

- [x] 2 substring-scan tests removed
- [x] Remaining capacity / CLI sentinel tests preserved
- [ ] CI build + test (local build blocked by `dune-local.sh` global lock)

🤖 Generated with [Claude Code](https://claude.com/claude-code)