### PR TITLE
refactor(channel-gate-metrics): typed error_kind — private-string wrapper → closed sum (5 variants)

### DIFF
--- a/lib/gate/channel_gate_metrics.ml
+++ b/lib/gate/channel_gate_metrics.ml
@@ -9,10 +9,31 @@ type outcome =
   | Dispatch_unavailable
   | Internal_error of string
 
-type error_kind = Error_kind of string
+(* Closed sum mirroring the in-module producer surface (5 sites in this
+   file).  [Ek_none] replaces the [Error_kind ""] sentinel previously
+   used to encode the no-error state for [Success] and [Duplicate]
+   outcomes. *)
+type error_kind =
+  | Ek_none
+  | Ek_validation
+  | Ek_keeper
+  | Ek_dispatch_unavailable
+  | Ek_internal
 
-let error_kind_of_string value = Error_kind value
-let error_kind_to_string (Error_kind value) = value
+let error_kind_to_string = function
+  | Ek_none -> ""
+  | Ek_validation -> "validation"
+  | Ek_keeper -> "keeper"
+  | Ek_dispatch_unavailable -> "dispatch_unavailable"
+  | Ek_internal -> "internal"
+
+let error_kind_of_string = function
+  | "" -> Some Ek_none
+  | "validation" -> Some Ek_validation
+  | "keeper" -> Some Ek_keeper
+  | "dispatch_unavailable" -> Some Ek_dispatch_unavailable
+  | "internal" -> Some Ek_internal
+  | _ -> None
 
 type channel_stats = {
   channel : string;
@@ -130,7 +151,7 @@ let make_binding_acc () =
     last_error_ts = 0.0;
     keeper = "";
     last_error = "";
-    last_error_kind = error_kind_of_string "";
+    last_error_kind = Ek_none;
     last_outcome = "idle";
     total_dur_ms = 0;
     timed_count = 0;
@@ -153,7 +174,7 @@ let make_acc () =
     last_keeper = "";
     last_room_id = "";
     last_error = "";
-    last_error_kind = error_kind_of_string "";
+    last_error_kind = Ek_none;
     last_outcome = "idle";
     total_dur_ms = 0;
     timed_count = 0;
@@ -233,12 +254,12 @@ let get_or_create_binding acc room_id =
       binding
 
 let outcome_error_details = function
-  | Validation_error message -> (error_kind_of_string "validation", message)
-  | Keeper_error message -> (error_kind_of_string "keeper", message)
+  | Validation_error message -> (Ek_validation, message)
+  | Keeper_error message -> (Ek_keeper, message)
   | Dispatch_unavailable ->
-      (error_kind_of_string "dispatch_unavailable", "keeper dispatch unavailable")
-  | Internal_error message -> (error_kind_of_string "internal", message)
-  | Success | Duplicate -> (error_kind_of_string "", "")
+      (Ek_dispatch_unavailable, "keeper dispatch unavailable")
+  | Internal_error message -> (Ek_internal, message)
+  | Success | Duplicate -> (Ek_none, "")
 
 let append_event ~channel ~room_id ~keeper ~duration_ms outcome ~timestamp =
   let error_kind, error = outcome_error_details outcome in
@@ -315,40 +336,40 @@ let record_attempt ~channel ~room_id ~keeper ~duration_ms outcome =
       | Validation_error message ->
           acc.validation_error_count <- acc.validation_error_count + 1;
           update_error_fields acc ~now
-            ~kind:(error_kind_of_string "validation") ~message;
+            ~kind:(Ek_validation) ~message;
           (match binding with
            | Some binding ->
                update_binding_error_fields binding ~now
-                 ~kind:(error_kind_of_string "validation") ~message
+                 ~kind:(Ek_validation) ~message
            | None -> ())
       | Keeper_error message ->
           acc.keeper_error_count <- acc.keeper_error_count + 1;
-          update_error_fields acc ~now ~kind:(error_kind_of_string "keeper")
+          update_error_fields acc ~now ~kind:(Ek_keeper)
             ~message;
           (match binding with
            | Some binding ->
                update_binding_error_fields binding ~now
-                 ~kind:(error_kind_of_string "keeper") ~message
+                 ~kind:(Ek_keeper) ~message
            | None -> ())
       | Dispatch_unavailable ->
           acc.dispatch_unavailable_count <- acc.dispatch_unavailable_count + 1;
           update_error_fields acc ~now
-            ~kind:(error_kind_of_string "dispatch_unavailable")
+            ~kind:(Ek_dispatch_unavailable)
             ~message:"keeper dispatch unavailable";
           (match binding with
            | Some binding ->
                update_binding_error_fields binding ~now
-                 ~kind:(error_kind_of_string "dispatch_unavailable")
+                 ~kind:(Ek_dispatch_unavailable)
                  ~message:"keeper dispatch unavailable"
            | None -> ())
       | Internal_error message ->
           acc.internal_error_count <- acc.internal_error_count + 1;
-          update_error_fields acc ~now ~kind:(error_kind_of_string "internal")
+          update_error_fields acc ~now ~kind:(Ek_internal)
             ~message;
           (match binding with
            | Some binding ->
                update_binding_error_fields binding ~now
-                 ~kind:(error_kind_of_string "internal") ~message
+                 ~kind:(Ek_internal) ~message
            | None -> ()));
       append_event ~channel:channel_key ~room_id:trimmed_room ~keeper:trimmed_keeper
         ~duration_ms outcome ~timestamp:now)

--- a/lib/gate/channel_gate_metrics.mli
+++ b/lib/gate/channel_gate_metrics.mli
@@ -15,12 +15,29 @@ type outcome =
   | Dispatch_unavailable
   | Internal_error of string
 
-(** Closed wrapper for connector error-kind labels. JSON/status surfaces
-    continue to render the stable snake_case string labels. *)
-type error_kind = private Error_kind of string
+(** Connector error-kind labels. Closed set mirroring the in-module
+    producer surface: validation / keeper / dispatch_unavailable /
+    internal, plus [Ek_none] as the sentinel used by [Success] and
+    [Duplicate] outcomes (previously the empty-string [Error_kind ""]).
 
-val error_kind_of_string : string -> error_kind
+    JSON/status surfaces render via [error_kind_to_string]; wire output
+    is byte-compatible with the prior [private Error_kind of string]
+    wrapper. *)
+type error_kind =
+  | Ek_none
+  | Ek_validation
+  | Ek_keeper
+  | Ek_dispatch_unavailable
+  | Ek_internal
+
+val error_kind_of_string : string -> error_kind option
+(** Parse a wire label. [None] on unknown so JSON read paths fail
+    closed (CLAUDE.md anti-pattern #2 — Unknown → Permissive Default
+    forbidden). *)
+
 val error_kind_to_string : error_kind -> string
+(** Render to the JSON/status wire label (byte-compatible with the
+    pre-typing private-string wrapper). *)
 
 (** Per-channel statistics snapshot (immutable). *)
 type channel_stats = {

--- a/test/test_channel_gate_metrics.ml
+++ b/test/test_channel_gate_metrics.ml
@@ -24,8 +24,9 @@ let check_error_kind name expected actual =
   check string name expected (Metrics.error_kind_to_string actual)
 
 let test_error_kind_round_trip () =
-  let kind = Metrics.error_kind_of_string "validation" in
-  check_error_kind "round trip" "validation" kind
+  match Metrics.error_kind_of_string "validation" with
+  | Some kind -> check_error_kind "round trip" "validation" kind
+  | None -> fail "expected Ek_validation for \"validation\""
 
 let test_record_attempt_tracks_connector_diagnostics () =
   with_eio (fun () ->


### PR DESCRIPTION
Track A typed-enum sweep — 5th application of private-string wrapper closure. Close Channel_gate_metrics.error_kind to 5-variant closed sum: Ek_none (Success/Duplicate sentinel) + Ek_validation + Ek_keeper + Ek_dispatch_unavailable + Ek_internal. All 15+ producer sites collapse to direct variant constructors. error_kind_of_string returns option (fail-closed JSON read per CLAUDE.md anti-pattern #2). Wire format byte-compatible. 6 private-string wrappers remain in the masc-mcp-wide sweep. 🤖 Generated with Claude Code