### PR TITLE
feat(cascade_runner): delegate proof_result_status_to_string to canonical

### DIFF
--- a/lib/cascade/cascade_runner.ml
+++ b/lib/cascade/cascade_runner.ml
@@ -95,17 +95,15 @@ type run_result = {
   stop_reason : stop_reason;
 }
 
-let lowercase_enum_case_name raw =
-  let raw =
-    match String.rindex_opt raw '.' with
-    | Some idx when idx + 1 < String.length raw ->
-        String.sub raw (idx + 1) (String.length raw - idx - 1)
-    | _ -> raw
-  in
-  String.lowercase_ascii raw
-
-let proof_result_status_to_string status =
-  Masc_mcp_cdal_runtime.Cdal_proof.show_result_status status |> lowercase_enum_case_name
+(* Delegate to the canonical [Cdal_proof.result_status_to_string]
+   (exposed in #14712 / T5).  Previously this re-implemented the same
+   wire conversion via [show_result_status] + [String.rindex '.']
+   substring split — a fragile [@@deriving show] strip that breaks
+   silently when the type is moved or the module renamed.  Both this
+   call site and [keeper_turn_telemetry.log_keeper_proof] had grown
+   independent copies of the same workaround. *)
+let proof_result_status_to_string =
+  Masc_mcp_cdal_runtime.Cdal_proof.result_status_to_string
 
 (* ================================================================ *)
 (* Internal: resolve provider                                        *)

--- a/lib/cascade/cascade_runner.mli
+++ b/lib/cascade/cascade_runner.mli
@@ -16,8 +16,7 @@
     {!Cascade_legacy_runner} and {!Keeper_turn_driver}.
 
     Internal helpers stay private at this boundary
-    ([lowercase_enum_case_name],
-    [invalid_runtime_config],
+    ([invalid_runtime_config],
     [cli_model_override],
     [provider_supports_inline_tools],
     [provider_supports_runtime_mcp_lane],

--- a/lib/cdal_runtime/cdal_proof.mli
+++ b/lib/cdal_runtime/cdal_proof.mli
@@ -62,3 +62,11 @@ type t =
 val to_json : t -> Yojson.Safe.t
 val of_json : Yojson.Safe.t -> (t, string) result
 val schema_version_current : int
+
+(** Closed-set wire label for {!result_status}.  Prefer this over
+    {!show_result_status} (the [@@deriving show] artifact prefixes
+    each constructor with the module path, e.g.
+    ["Cdal_proof.Completed"], which downstream callers then strip by
+    substring split — a fragile pattern that breaks silently when the
+    type is moved or the module renamed). *)
+val result_status_to_string : result_status -> string

--- a/lib/keeper/keeper_turn_telemetry.ml
+++ b/lib/keeper/keeper_turn_telemetry.ml
@@ -11,16 +11,16 @@ let string_list_json (items : string list) : Yojson.Safe.t =
 let blocking_gap_artifacts (verdict : Cdal_types.contract_verdict) : string list =
   verdict.completeness_gaps
   |> List.filter_map (fun (gap : Cdal_types.completeness_gap) ->
-       if gap.impact = Cdal_types.Blocks_verdict then Some gap.artifact else None)
+    if gap.impact = Cdal_types.Blocks_verdict then Some gap.artifact else None)
   |> List.sort_uniq String.compare
 ;;
 
-let friction_gap_artifacts
-      (fp : Cdal_friction_projection.friction_projection) : string list
+let friction_gap_artifacts (fp : Cdal_friction_projection.friction_projection)
+  : string list
   =
   fp.evidence_gap_groups
   |> List.map (fun (group : Cdal_friction_projection.evidence_gap_group) ->
-       group.artifact)
+    group.artifact)
   |> List.sort_uniq String.compare
 ;;
 
@@ -30,15 +30,14 @@ let contract_verdict_activity_payload
   : Yojson.Safe.t
   =
   `Assoc
-    [
-      ("keeper_name", `String keeper_name);
-      ("run_id", `String verdict.run_id);
-      ("contract_id", `String verdict.contract_id);
-      ("status", `String (Cdal_types.contract_status_to_string verdict.status));
-      ("claim_scope", `String verdict.claim_scope);
-      ("judgment_hash", `String verdict.judgment_hash);
-      ("finding_count", `Int (List.length verdict.findings));
-      ("blocking_gap_artifacts", string_list_json (blocking_gap_artifacts verdict));
+    [ "keeper_name", `String keeper_name
+    ; "run_id", `String verdict.run_id
+    ; "contract_id", `String verdict.contract_id
+    ; "status", `String (Cdal_types.contract_status_to_string verdict.status)
+    ; "claim_scope", `String verdict.claim_scope
+    ; "judgment_hash", `String verdict.judgment_hash
+    ; "finding_count", `Int (List.length verdict.findings)
+    ; "blocking_gap_artifacts", string_list_json (blocking_gap_artifacts verdict)
     ]
 ;;
 
@@ -48,14 +47,13 @@ let friction_activity_payload
   : Yojson.Safe.t
   =
   `Assoc
-    [
-      ("keeper_name", `String keeper_name);
-      ("window", `String fp.window);
-      ("based_on_run_ids", string_list_json fp.based_on_run_ids);
-      ("blocked_attempt_count", `Int fp.blocked_attempt_count);
-      ("blocked_group_count", `Int (List.length fp.blocked_attempt_groups));
-      ("review_tripwires", string_list_json fp.review_tripwires);
-      ("evidence_gap_artifacts", string_list_json (friction_gap_artifacts fp));
+    [ "keeper_name", `String keeper_name
+    ; "window", `String fp.window
+    ; "based_on_run_ids", string_list_json fp.based_on_run_ids
+    ; "blocked_attempt_count", `Int fp.blocked_attempt_count
+    ; "blocked_group_count", `Int (List.length fp.blocked_attempt_groups)
+    ; "review_tripwires", string_list_json fp.review_tripwires
+    ; "evidence_gap_artifacts", string_list_json (friction_gap_artifacts fp)
     ]
 ;;
 
@@ -100,7 +98,8 @@ let log_keeper_contract_verdict
     if Keeper_types_profile.keeper_debug
     then
       Log.Keeper.debug
-        "keeper:%s contract_verdict: status=%s scope=%s hash=%s findings=%d blocking_gaps=[%s]"
+        "keeper:%s contract_verdict: status=%s scope=%s hash=%s findings=%d \
+         blocking_gaps=[%s]"
         keeper_name
         (Cdal_types.contract_status_to_string verdict.status)
         verdict.claim_scope
@@ -109,7 +108,8 @@ let log_keeper_contract_verdict
         (String.concat "," blocking_gaps)
   | Cdal_types.Violated | Cdal_types.Inconclusive ->
     Log.Keeper.warn
-      "keeper:%s contract_verdict: status=%s scope=%s hash=%s findings=%d blocking_gaps=[%s]"
+      "keeper:%s contract_verdict: status=%s scope=%s hash=%s findings=%d \
+       blocking_gaps=[%s]"
       keeper_name
       (Cdal_types.contract_status_to_string verdict.status)
       verdict.claim_scope

--- a/lib/keeper/keeper_turn_telemetry.ml
+++ b/lib/keeper/keeper_turn_telemetry.ml
@@ -60,13 +60,14 @@ let friction_activity_payload
 ;;
 
 let log_keeper_proof ~(keeper_name : string) (proof : Masc_mcp_cdal_runtime.Cdal_proof.t) =
+  (* Closed-set wire label.  Previously this called [show_result_status]
+     (a [@@deriving show] artifact that returns ["Cdal_proof.Completed"])
+     and stripped the module prefix by [String.rindex_opt raw '.']
+     substring split — a fragile pattern that breaks silently when the
+     type is moved or the module renamed.  [result_status_to_string] is
+     now exposed in the [.mli] for callers that need the wire label. *)
   let status_string =
-    Masc_mcp_cdal_runtime.Cdal_proof.show_result_status proof.result_status
-    |> fun raw ->
-    match String.rindex_opt raw '.' with
-    | Some idx when idx + 1 < String.length raw ->
-      String.sub raw (idx + 1) (String.length raw - idx - 1)
-    | _ -> raw |> String.lowercase_ascii
+    Masc_mcp_cdal_runtime.Cdal_proof.result_status_to_string proof.result_status
   in
   match proof.result_status with
   | Masc_mcp_cdal_runtime.Cdal_proof.Completed ->


### PR DESCRIPTION
## Summary

Follow-up to #14712 (T5).  Removes the second independent copy of the
same `[@@deriving show]` substring-split workaround for
`Cdal_proof.result_status` wire conversion.

## Why

After #14712 exposed `Cdal_proof.result_status_to_string` in the
canonical `.mli`, two sites in the codebase had grown independent
copies of the same fragile pattern:

1. `keeper_turn_telemetry.log_keeper_proof` — fixed by #14712
2. `cascade_runner.proof_result_status_to_string` — fixed here

Both did:

```ocaml
Cdal_proof.show_result_status status (* "Cdal_proof.Completed" *)
|> String.rindex '.' + sub             (* strip module prefix *)
|> String.lowercase_ascii
```

Failure mode: silent breakage when `Cdal_proof` is moved or renamed.

## Changes

| File | Change |
|------|--------|
| `lib/cascade/cascade_runner.ml` | `proof_result_status_to_string` becomes a direct delegate to `Cdal_proof.result_status_to_string`; remove the now-unused `lowercase_enum_case_name` helper |
| `lib/cascade/cascade_runner.mli` | Drop `lowercase_enum_case_name` from the "internal helpers" docstring (the function no longer exists) |

Wire format preserved: both produce `"completed" | "errored" | "timed_out" | "cancelled" | "context_overflow"`.

## Test plan

- [ ] CI green
- [ ] `rg 'show_result_status' lib/cascade/cascade_runner.ml` = 0

## Stacking

Depends on #14712 (T5).  Merge order: #14712 first, then this.  Base
branch is `feat/turn-telemetry-typed-status` for now; once #14712
merges I'll retarget to `main`.

RFC-WAIVED: not in credential/identity/operator/sandbox/hooks/workflow scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)