### PR TITLE
refactor(cdal_runtime): replace manual to_int/equal/compare with [@@deriving eq, ord]

### DIFF
--- a/lib/cdal_runtime/dune
+++ b/lib/cdal_runtime/dune
@@ -70,4 +70,4 @@
  (flags
   (:standard -open Agent_sdk_base -open Agent_sdk -open Agent_sdk__))
  (preprocess
-  (pps ppx_deriving_yojson ppx_deriving.show ppx_inline_test ppx_let)))
+  (pps ppx_deriving_yojson ppx_deriving.show ppx_deriving.eq ppx_deriving.ord ppx_inline_test ppx_let)))

--- a/lib/cdal_runtime/execution_mode.ml
+++ b/lib/cdal_runtime/execution_mode.ml
@@ -2,7 +2,7 @@ type t =
   | Diagnose
   | Draft
   | Execute
-[@@deriving show]
+[@@deriving show, eq, ord]
 
 let to_string = function
   | Diagnose -> "diagnose"
@@ -24,12 +24,4 @@ let of_yojson = function
   | j -> Error (Printf.sprintf "expected string, got %s" (Yojson.Safe.to_string j))
 ;;
 
-let to_int = function
-  | Diagnose -> 0
-  | Draft -> 1
-  | Execute -> 2
-;;
-
-let equal a b = to_int a = to_int b
-let compare a b = Int.compare (to_int a) (to_int b)
-let can_serve ~requested ~effective = to_int effective <= to_int requested
+let can_serve ~requested ~effective = compare effective requested <= 0

--- a/lib/cdal_runtime/execution_mode.mli
+++ b/lib/cdal_runtime/execution_mode.mli
@@ -10,12 +10,10 @@ type t =
   | Diagnose (** Read-only analysis, no mutations *)
   | Draft (** Workspace-local mutations, no external side effects *)
   | Execute (** Full execution with external side effects *)
-[@@deriving yojson, show]
+[@@deriving yojson, show, eq, ord]
 
 val to_string : t -> string
 val of_string : string -> (t, string) result
-val equal : t -> t -> bool
-val compare : t -> t -> int
 
 (** [can_serve ~requested ~effective] returns [true] iff
     [effective <= requested] in the ordering [Diagnose < Draft < Execute].

--- a/lib/cdal_runtime/risk_class.ml
+++ b/lib/cdal_runtime/risk_class.ml
@@ -3,7 +3,7 @@ type t =
   | Medium
   | High
   | Critical
-[@@deriving show]
+[@@deriving show, eq, ord]
 
 let to_string = function
   | Low -> "low"
@@ -26,16 +26,6 @@ let of_yojson = function
   | `String s -> of_string s
   | j -> Error (Printf.sprintf "expected string, got %s" (Yojson.Safe.to_string j))
 ;;
-
-let to_int = function
-  | Low -> 0
-  | Medium -> 1
-  | High -> 2
-  | Critical -> 3
-;;
-
-let equal a b = to_int a = to_int b
-let compare a b = Int.compare (to_int a) (to_int b)
 
 let max_mode = function
   | Low -> Some Execution_mode.Execute

--- a/lib/cdal_runtime/risk_class.mli
+++ b/lib/cdal_runtime/risk_class.mli
@@ -11,12 +11,10 @@ type t =
   | Medium (** One or more ambiguous/mid-level axes *)
   | High (** Any one axis large; Execute forbidden without human review *)
   | Critical (** Hard to reverse or external system damage; default = reject *)
-[@@deriving yojson, show]
+[@@deriving yojson, show, eq, ord]
 
 val to_string : t -> string
 val of_string : string -> (t, string) result
-val equal : t -> t -> bool
-val compare : t -> t -> int
 
 (** Maximum allowed execution mode for this risk class.
     [None] means the run should be rejected outright. *)


### PR DESCRIPTION
## Why

`Risk_class` and `Execution_mode` in `lib/cdal_runtime/` both use the same shape:

\`\`\`ocaml
let to_int = function Low -> 0 | Medium -> 1 | High -> 2 | Critical -> 3
let equal a b = to_int a = to_int b
let compare a b = Int.compare (to_int a) (to_int b)
\`\`\`

The `to_int` function is private (not in `.mli`) — it exists solely to back `equal` and `compare`. This is the textbook case where `[@@deriving eq, ord]` subsumes hand-written code entirely. The deriver-generated `compare` orders by *constructor declaration order*, which matches the existing `to_int` ranking exactly in both modules:

| Type | Constructor order | `to_int` value |
|------|-------------------|----------------|
| `Risk_class.t` | Low, Medium, High, Critical | 0, 1, 2, 3 |
| `Execution_mode.t` | Diagnose, Draft, Execute | 0, 1, 2 |

The hand-written shape is also forward-fragile: if a new constructor is inserted between two existing ones (e.g. `Verify` between `Draft` and `Execute`), a developer must remember to renumber `to_int` to preserve the ranking. The deriver does this automatically — the new constructor's rank is its position in the declaration.

## What

- Add `eq, ord` to the existing `[@@deriving]` lists (both `.ml` and `.mli`)
- Delete the manual `to_int`, `equal`, `compare` definitions in both `.ml` files
- Drop redundant `val equal` / `val compare` lines in both `.mli` files (the deriver attribute on the type generates them)
- Rewrite `Execution_mode.can_serve` to use the derived `compare` instead of the removed `to_int`
- Add `ppx_deriving.eq` and `ppx_deriving.ord` to `lib/cdal_runtime/dune` preprocess (already enabled in the main `lib/dune`)

## Caller compat

All external callers consume `equal` and `compare` with unchanged signatures:

- `test/test_masc_contract_catalog.ml:32,50` — `Risk_class.equal`
- `lib/cdal/cdal_judge.ml:17,69` — `Risk_class.equal`, `Execution_mode.equal`
- `lib/cdal_runtime/mode_resolver.ml:6,27,29` — `Execution_mode.compare`, `Execution_mode.equal`

No caller updates needed.

## Verification

\`\`\`
dune build @lib/cdal_runtime/check @lib/cdal/check --root .   # exit 0
\`\`\`

## Net LOC

- `risk_class.ml`: -10 LOC (deleted `to_int`, `equal`, `compare`)
- `risk_class.mli`: -2 LOC (deleted `val equal`, `val compare`)
- `execution_mode.ml`: -10 LOC (same)
- `execution_mode.mli`: -2 LOC (same)
- `dune`: +0 LOC (extended preprocess line)

## Why this counts as "Variant 처리가 더 유리한 곳"

Hand-written `equal`/`compare` on a closed sum is a deriver-displaceable maintenance surface. The deriver gives stronger guarantees:
1. **Forward-compat**: new constructors are auto-ranked by position
2. **Reflexivity guaranteed**: no `_ -> false` catch-all hiding `(X, X) -> false` bugs
3. **No hidden helper**: deletes `to_int` whose only purpose was to back comparison

The same `Stdlib.(=)` style polymorphic compare would also work for these specific types, but `[@@deriving eq]` is preferred because (a) it preserves the explicit "this is a closed sum, comparison is structural" contract in the type definition, and (b) it does not silently drift if the type later gains a non-comparable field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)