### PR TITLE
perf(tool_access_policy): set-based membership for Inter/Diff/resolve

### DIFF
--- a/lib/tool_access_policy.ml
+++ b/lib/tool_access_policy.ml
@@ -85,12 +85,23 @@ let with_deny_selector policy selector =
 let with_deny_names policy names =
   with_deny_selector policy (Names names)
 
+(* Membership-only normalization: skip empties + trim, but skip the
+   StringSet dedup that [normalize_names] performs (duplicates do not
+   change membership).  Short-circuits on first match via [List.exists]. *)
+let name_in_normalized_list name candidates =
+  List.exists
+    (fun candidate ->
+      let trimmed = String.trim candidate in
+      (not (String.equal trimmed ""))
+      && String.equal trimmed name)
+    candidates
+
 let rec selector_matches_name selector name =
   match selector with
   | Empty -> false
   | All -> true
   | Names names ->
-      List.mem name (normalize_names names)
+      name_in_normalized_list name names
   | Surface surface ->
       Tool_catalog.is_on_surface surface name
   | Union selectors ->
@@ -135,20 +146,26 @@ let rec resolve_selector ?candidates selector =
           let first_set = resolve_selector ?candidates first in
           List.fold_left
             (fun acc sel ->
-              let resolved = resolve_selector ?candidates sel in
-              List.filter (fun name -> List.mem name resolved) acc)
+              let resolved_set =
+                StringSet.of_list (resolve_selector ?candidates sel)
+              in
+              List.filter (fun name -> StringSet.mem name resolved_set) acc)
             first_set rest
           |> normalize_names)
   | Diff { base; exclude } ->
       let base_resolved = resolve_selector ?candidates base in
-      let exclude_resolved = resolve_selector ?candidates exclude in
+      let exclude_set =
+        StringSet.of_list (resolve_selector ?candidates exclude)
+      in
       base_resolved
-      |> List.filter (fun name -> not (List.mem name exclude_resolved))
+      |> List.filter (fun name -> not (StringSet.mem name exclude_set))
       |> normalize_names
 
 let resolve ?candidates policy =
   let allowed = resolve_selector ?candidates policy.allow in
-  let denied = resolve_selector ?candidates policy.deny in
+  let denied_set =
+    StringSet.of_list (resolve_selector ?candidates policy.deny)
+  in
   allowed
-  |> List.filter (fun name -> not (List.mem name denied))
+  |> List.filter (fun name -> not (StringSet.mem name denied_set))
   |> normalize_names


### PR DESCRIPTION
## Summary

Replaces O(N×M) `List.mem` set operations with `StringSet` (O(N log M)) inside `tool_access_policy.ml`. Also drops the redundant `StringSet` dedup that `selector_matches_name` was doing on the `Names` branch for membership queries — duplicates don't change membership, so the dedup was pure overhead per call.

## Changes (internal only — public ADT unchanged)

1. **`selector_matches_name` Names branch** — was `List.mem name (normalize_names names)`, building a fresh `StringSet` + list conversion per call. New helper `name_in_normalized_list` does `List.exists` with inline trim/empty-skip, short-circuiting on first match.
2. **`resolve_selector` Inter fold** — `List.filter (fun n -> List.mem n resolved)` → `StringSet.of_list resolved` built once per fold step, then `StringSet.mem`.
3. **`resolve_selector` Diff** — same pattern for `exclude_set`.
4. **`resolve` final deny filter** — `denied` list converted to set once.

## Hot callers benefiting

| Caller | Path | Frequency |
|--------|------|-----------|
| `Auth.authorize` | `lib/auth.ml:1340` `allows_name` | per-request |
| `Eval_gate.pre_check` | `lib/eval_gate.ml:221,224` (2 calls) | per tool call in eval |
| `Worker_oas` PreToolUse hook | `lib/worker_oas.ml:331` | per tool invocation |
| `Keeper_tool_policy.compute_resolved_allowlist` | `lib/keeper/keeper_tool_policy.ml:431` | per keeper turn |

## Semantic preservation

All semantics preserved (trim, empty-skip, dedup at final `normalize_names`). Existing tests in `test/test_tool_access_policy.ml` and `test/test_tool_access_role.ml` should pass unchanged.

## Test plan

- [ ] CI lib/ build green
- [ ] `dune runtest test/test_tool_access_policy.exe` passes
- [ ] `dune runtest test/test_tool_access_role.exe` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)