### PR TITLE
fix(keeper): make FSM-violation warn log reachable in guard_transition

### DIFF
--- a/lib/keeper/keeper_turn_fsm.ml
+++ b/lib/keeper/keeper_turn_fsm.ml
@@ -272,14 +272,18 @@ let guard_transition ?ctx ~keeper_name ~turn_id ~from_state ~to_state () =
   match assert_transition_allowed ?ctx ~from_state ~to_state () with
   | Ok _ -> ()
   | Error violation ->
+      (* Log first: [wrap_unit] catches [Assert_failure] only to bump the
+         Prometheus counter, then re-raises. Anything sequenced after
+         [wrap_unit] would never run, so the diagnostic warn has to
+         precede it for operators to see *which* transition violated. *)
+      Log.Keeper.warn ~keeper_name ~turn_id
+        "[fsm:transition:violation] %s -> %s (%s)"
+        violation.from_state violation.to_state violation.reason;
       let stage = violation.from_state ^ "->" ^ violation.to_state in
       Keeper_fsm_guard_runtime.wrap_unit
         ~action:"KeeperTurnFSM.Next"
         ~stage
-        (fun () -> assert false);
-      Log.Keeper.warn ~keeper_name ~turn_id
-        "[fsm:transition:violation] %s -> %s (%s)"
-        violation.from_state violation.to_state violation.reason
+        (fun () -> assert false)
 
 (* Per-keeper last-transition wallclock, used to record the dwell time
    spent in [prev] state when a transition fires. Single-domain Eio


### PR DESCRIPTION
## Summary

One-line semantic: re-order [`Log.Keeper.warn`] above the [`wrap_unit`] call inside `Keeper_turn_fsm.guard_transition` so the diagnostic message actually reaches the keeper log when an FSM-transition violation fires.

## Why this matters

`Keeper_fsm_guard_runtime.wrap_unit` catches `Assert_failure`, increments a Prometheus counter, and **re-raises** the exception. Anything sequenced after `wrap_unit` is therefore unreachable — including the `Log.Keeper.warn "[fsm:transition:violation] %s -> %s (%s)"` line that lived just below it.

Effect on operators:
- Counter `keeper_fsm_guard_violation{action="KeeperTurnFSM.Next", stage="<from>-><to>"}` was incrementing on every violation ✓
- The matching warn line that says *which* transition + *why* was never emitted ✗
- Result: operator could see "FSM violations happened" but had to dump the metric labels to learn anything actionable

## Before

```ocaml
| Error violation ->
    let stage = violation.from_state ^ "->" ^ violation.to_state in
    Keeper_fsm_guard_runtime.wrap_unit
      ~action:"KeeperTurnFSM.Next"
      ~stage
      (fun () -> assert false);
    (* unreachable — wrap_unit re-raised Assert_failure above *)
    Log.Keeper.warn ~keeper_name ~turn_id
      "[fsm:transition:violation] %s -> %s (%s)"
      violation.from_state violation.to_state violation.reason
```

## After

```ocaml
| Error violation ->
    Log.Keeper.warn ~keeper_name ~turn_id
      "[fsm:transition:violation] %s -> %s (%s)"
      violation.from_state violation.to_state violation.reason;
    let stage = violation.from_state ^ "->" ^ violation.to_state in
    Keeper_fsm_guard_runtime.wrap_unit
      ~action:"KeeperTurnFSM.Next"
      ~stage
      (fun () -> assert false)
```

No behaviour change beyond restoring intended observability: counter still bumps, exception still escapes (loud failure preserved).

## Workaround self-check

| # | check | result |
|---|---|---|
| 1 | telemetry-as-fix? | no — counter unchanged; this restores a previously-dead log line |
| 2 | string classifier? | no |
| 3 | N-of-M? | no — single call site of this pattern |
| 4 | catch-all `_ ->` added? | no |
| 5 | cap/cooldown/dedup/repair? | no |
| 6 | test backdoor? | no |
| 7 | same typo N sites? | no |

## Test plan

- [ ] CI build + test (local build blocked by `dune-local.sh` global lock)
- (No new unit test — log capture is not part of the existing test harness for keeper modules; the dead-code argument is structurally evident from `wrap_unit`'s [body](https://github.com/jeong-sik/masc-mcp/blob/main/lib/keeper/keeper_fsm_guard_runtime.ml).)

🤖 Generated with [Claude Code](https://claude.com/claude-code)