### PR TITLE
feat(cascade_runner): delegate proof_result_status_to_string to canonical

### DIFF
--- a/lib/cascade/cascade_runner.ml
+++ b/lib/cascade/cascade_runner.ml
@@ -95,17 +95,15 @@ type run_result = {
   stop_reason : stop_reason;
 }
 
-let lowercase_enum_case_name raw =
-  let raw =
-    match String.rindex_opt raw '.' with
-    | Some idx when idx + 1 < String.length raw ->
-        String.sub raw (idx + 1) (String.length raw - idx - 1)
-    | _ -> raw
-  in
-  String.lowercase_ascii raw
-
-let proof_result_status_to_string status =
-  Masc_mcp_cdal_runtime.Cdal_proof.show_result_status status |> lowercase_enum_case_name
+(* Delegate to the canonical [Cdal_proof.result_status_to_string]
+   (exposed in #14712 / T5).  Previously this re-implemented the same
+   wire conversion via [show_result_status] + [String.rindex '.']
+   substring split — a fragile [@@deriving show] strip that breaks
+   silently when the type is moved or the module renamed.  Both this
+   call site and [keeper_turn_telemetry.log_keeper_proof] (fixed in
+   #14712) had grown independent copies of the same workaround. *)
+let proof_result_status_to_string =
+  Masc_mcp_cdal_runtime.Cdal_proof.result_status_to_string
 
 (* ================================================================ *)
 (* Internal: resolve provider                                        *)

--- a/lib/cascade/cascade_runner.mli
+++ b/lib/cascade/cascade_runner.mli
@@ -16,8 +16,7 @@
     {!Cascade_legacy_runner} and {!Keeper_turn_driver}.
 
     Internal helpers stay private at this boundary
-    ([lowercase_enum_case_name],
-    [invalid_runtime_config],
+    ([invalid_runtime_config],
     [cli_model_override],
     [provider_supports_inline_tools],
     [provider_supports_runtime_mcp_lane],


### PR DESCRIPTION
## Summary

Re-open of #14724 (which was closed when its T5 base branch was deleted
after merge).  Removes the second independent copy of the
`[@@deriving show]` substring-split workaround for
`Cdal_proof.result_status` wire conversion.

## Why

After #14712 exposed `Cdal_proof.result_status_to_string` in the
canonical `.mli`, two sites in the codebase had grown independent
copies of the same fragile pattern:

1. `keeper_turn_telemetry.log_keeper_proof` — fixed by #14712
2. `cascade_runner.proof_result_status_to_string` — **still on main**, fixed here

Both did:

```ocaml
Cdal_proof.show_result_status status (* "Cdal_proof.Completed" *)
|> String.rindex '.' + sub             (* strip module prefix *)
|> String.lowercase_ascii
```

Failure mode: silent breakage when `Cdal_proof` is moved or renamed,
or if a future variant carries a payload (`"Cdal_proof.Errored \"oom\""`
would leak payload into the metric label, causing cardinality regression).

## Changes

| File | Change |
|------|--------|
| `lib/cascade/cascade_runner.ml` | `proof_result_status_to_string` becomes a direct delegate to `Cdal_proof.result_status_to_string`; remove the now-unused `lowercase_enum_case_name` helper |
| `lib/cascade/cascade_runner.mli` | Drop `lowercase_enum_case_name` from the "internal helpers" docstring (the function no longer exists) |

Wire format preserved: `"completed" | "errored" | "timed_out" | "cancelled" | "context_overflow"`.

## Test plan

- [ ] CI green
- [ ] `rg 'show_result_status' lib/cascade/cascade_runner.ml` = 0
- [ ] `rg 'lowercase_enum_case_name' lib/` = 0

RFC-WAIVED: not in credential/identity/operator/sandbox/hooks/workflow scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)