### PR TITLE
style: fix pre-existing ocamlformat doc comment violations on main

### DIFF
--- a/lib/keeper/keeper_exec_context.mli
+++ b/lib/keeper/keeper_exec_context.mli
@@ -11,9 +11,7 @@ open Keeper_types
 (** {1 Working Context Types (re-exported from Keeper_types)} *)
 
 type working_context = Keeper_types.working_context
-
 type checkpoint = Keeper_types.checkpoint
-
 type session_context = Keeper_types.session_context
 
 (** {1 Working Context Operations} *)
@@ -35,16 +33,18 @@ val set_system_prompt : working_context -> system_prompt:string -> working_conte
 val append : working_context -> Agent_sdk.Types.message -> working_context
 val append_many : working_context -> Agent_sdk.Types.message list -> working_context
 val sync_oas_context : working_context -> working_context
-val role_to_string : Agent_sdk.Types.role -> string
-val role_of_string : string -> Agent_sdk.Types.role
+
 (** Backwards-compatible: unknown -> [Tool] (safest fallback) + warn log.
     See {!role_of_string_opt} for the strict version. Issue #8623. *)
+val role_to_string : Agent_sdk.Types.role -> string
 
-val role_of_string_opt : string -> Agent_sdk.Types.role option
 (** Strict variant — returns [None] for unrecognised role strings.
     Use this in checkpoint loaders / new code where silently
     misattributing a chat-history message would corrupt the
     LLM-visible conversation. *)
+val role_of_string : string -> Agent_sdk.Types.role
+
+val role_of_string_opt : string -> Agent_sdk.Types.role option
 val message_to_json : Agent_sdk.Types.message -> Yojson.Safe.t
 val message_of_json : Yojson.Safe.t -> Agent_sdk.Types.message
 val serialize_context : working_context -> string
@@ -68,87 +68,87 @@ val save_session_checkpoint : session_context -> checkpoint -> unit
 (** {1 Keeper Context Lifecycle} *)
 
 val log_keeper_exn : label:string -> exn -> unit
+val checkpoint_max_tokens : Agent_sdk.Checkpoint.t -> fallback:int -> int
 
-val checkpoint_max_tokens :
-  Agent_sdk.Checkpoint.t -> fallback:int -> int
-
-val context_of_oas_checkpoint :
-  ?repair_orphans:bool ->
-  max_checkpoint_messages:int ->
-  Agent_sdk.Checkpoint.t -> primary_model_max_tokens:int -> working_context
+val context_of_oas_checkpoint
+  :  ?repair_orphans:bool
+  -> max_checkpoint_messages:int
+  -> Agent_sdk.Checkpoint.t
+  -> primary_model_max_tokens:int
+  -> working_context
 
 val checkpoint_model_of_meta : keeper_meta -> string
 
-val save_oas_checkpoint :
-  max_checkpoint_messages:int ->
-  session:session_context ->
-  agent_name:string ->
-  model:string ->
-  ctx:working_context ->
-  generation:int ->
-  (Agent_sdk.Checkpoint.t, string) result
+val save_oas_checkpoint
+  :  max_checkpoint_messages:int
+  -> session:session_context
+  -> agent_name:string
+  -> model:string
+  -> ctx:working_context
+  -> generation:int
+  -> (Agent_sdk.Checkpoint.t, string) result
 
 (** {1 Handoff Rollover} *)
 
-type handoff_rollover = {
-  updated_meta : keeper_meta;
-  handoff_json : Yojson.Safe.t option;
-  attempted : bool;
-  failure_reason : string option;
-  context_ratio : float;
-  context_tokens : int;
-  context_max : int;
-  message_count : int;
-}
+type handoff_rollover =
+  { updated_meta : keeper_meta
+  ; handoff_json : Yojson.Safe.t option
+  ; attempted : bool
+  ; failure_reason : string option
+  ; context_ratio : float
+  ; context_tokens : int
+  ; context_max : int
+  ; message_count : int
+  }
 
-type compaction_event = {
-  attempted : bool;
-  applied : bool;
-  failure_reason : string option;
-  trigger : Compaction_trigger.t option;
-  decision : Keeper_compact_policy.compaction_decision;
-  before_tokens : int;
-  after_tokens : int;
-  saved_tokens : int;
-}
+type compaction_event =
+  { attempted : bool
+  ; applied : bool
+  ; failure_reason : string option
+  ; trigger : Compaction_trigger.t option
+  ; decision : Keeper_compact_policy.compaction_decision
+  ; before_tokens : int
+  ; after_tokens : int
+  ; saved_tokens : int
+  }
 
-type post_turn_lifecycle = {
-  updated_meta : keeper_meta;
-  checkpoint : Agent_sdk.Checkpoint.t option;
-  handoff_json : Yojson.Safe.t option;
-  handoff_attempted : bool;
-  handoff_failure_reason : string option;
-  compaction : compaction_event;
-  turn_generation : int;
-  context_ratio : float;
-  context_tokens : int;
-  context_max : int;
-  message_count : int;
-}
+type post_turn_lifecycle =
+  { updated_meta : keeper_meta
+  ; checkpoint : Agent_sdk.Checkpoint.t option
+  ; handoff_json : Yojson.Safe.t option
+  ; handoff_attempted : bool
+  ; handoff_failure_reason : string option
+  ; compaction : compaction_event
+  ; turn_generation : int
+  ; context_ratio : float
+  ; context_tokens : int
+  ; context_max : int
+  ; message_count : int
+  }
 
-type max_context_resolution = {
-  requested_override : int option;
-  primary_budget : int;
-  cascade_budget : int;
-  turn_budget : int;
-  effective_budget : int;
-}
+type max_context_resolution =
+  { requested_override : int option
+  ; primary_budget : int
+  ; cascade_budget : int
+  ; turn_budget : int
+  ; effective_budget : int
+  }
 
-type overflow_retry_recovery = {
-  checkpoint : Agent_sdk.Checkpoint.t;
-  compaction : compaction_event;
-  turn_generation : int;
-}
+type overflow_retry_recovery =
+  { checkpoint : Agent_sdk.Checkpoint.t
+  ; compaction : compaction_event
+  ; turn_generation : int
+  }
 
-val maybe_rollover_oas_handoff :
-  on_started:(unit -> unit) ->
-  base_dir:string ->
-  meta:keeper_meta ->
-  model:string ->
-  primary_model_max_tokens:int ->
-  current_turn_blocker_info:blocker_info option ->
-  checkpoint:Agent_sdk.Checkpoint.t option ->
-  handoff_rollover
+val maybe_rollover_oas_handoff
+  :  on_started:(unit -> unit)
+  -> base_dir:string
+  -> meta:keeper_meta
+  -> model:string
+  -> primary_model_max_tokens:int
+  -> current_turn_blocker_info:blocker_info option
+  -> checkpoint:Agent_sdk.Checkpoint.t option
+  -> handoff_rollover
 
 (** {2 Pure gate helpers (for testing)} *)
 
@@ -167,28 +167,27 @@ val blocker_class_indicates_overflow : blocker_class -> bool
 
     Returns [Go reason] when a handoff should be attempted; [Skip reason]
     otherwise. The [reason] string is surfaced in logs and [handoff_json]. *)
-val classify_rollover_gate :
-  auto_handoff:bool ->
-  cooldown_elapsed:bool ->
-  ratio:float ->
-  handoff_threshold:float ->
-  last_outcome:proactive_cycle_outcome ->
-  last_blocker_info:blocker_info option ->
-  ?current_turn_blocker_info:blocker_info option ->
-  unit ->
-  rollover_gate_decision
+val classify_rollover_gate
+  :  auto_handoff:bool
+  -> cooldown_elapsed:bool
+  -> ratio:float
+  -> handoff_threshold:float
+  -> last_outcome:proactive_cycle_outcome
+  -> last_blocker_info:blocker_info option
+  -> ?current_turn_blocker_info:blocker_info option
+  -> unit
+  -> rollover_gate_decision
 
 (** {1 Checkpoint Loading and Saving} *)
 
-val load_context_from_checkpoint :
-  max_checkpoint_messages:int ->
-  trace_id:string ->
-  primary_model_max_tokens:int ->
-  base_dir:string ->
-  session_context * working_context option
+val load_context_from_checkpoint
+  :  max_checkpoint_messages:int
+  -> trace_id:string
+  -> primary_model_max_tokens:int
+  -> base_dir:string
+  -> session_context * working_context option
 
-val save_checkpoint :
-  session_context -> working_context -> generation:int -> checkpoint
+val save_checkpoint : session_context -> working_context -> generation:int -> checkpoint
 
 (** {1 Compaction} *)
 
@@ -198,43 +197,43 @@ type compaction_decision = Keeper_compact_policy.compaction_decision =
   | Applied of Compaction_trigger.t
   | Blocked_below_thresholds
   | Skipped_no_checkpoint
-  | Skipped_continuity_reflection of {
-      hold_s : float;
-      cooldown_sec : int;
-    }
+  | Skipped_continuity_reflection of
+      { hold_s : float
+      ; cooldown_sec : int
+      }
 
 val compaction_decision_to_string : compaction_decision -> string
 val compaction_decision_applied : compaction_decision -> bool
 
-val apply_post_turn_lifecycle :
-  on_compaction_started:(unit -> unit) ->
-  on_handoff_started:(unit -> unit) ->
-  base_dir:string ->
-  meta:keeper_meta ->
-  model:string ->
-  primary_model_max_tokens:int ->
-  current_turn_blocker_info:blocker_info option ->
-  checkpoint:Agent_sdk.Checkpoint.t option ->
-  post_turn_lifecycle
+val apply_post_turn_lifecycle
+  :  on_compaction_started:(unit -> unit)
+  -> on_handoff_started:(unit -> unit)
+  -> base_dir:string
+  -> meta:keeper_meta
+  -> model:string
+  -> primary_model_max_tokens:int
+  -> current_turn_blocker_info:blocker_info option
+  -> checkpoint:Agent_sdk.Checkpoint.t option
+  -> post_turn_lifecycle
 
-val apply_post_turn_lifecycle_with_resilience_handles :
-  resilience_audit_store:Shared_audit.Store.t option ->
-  resilience_strategy_executor:Resilience.Recovery.strategy_executor option ->
-  on_compaction_started:(unit -> unit) ->
-  on_handoff_started:(unit -> unit) ->
-  base_dir:string ->
-  meta:keeper_meta ->
-  model:string ->
-  primary_model_max_tokens:int ->
-  current_turn_blocker_info:blocker_info option ->
-  checkpoint:Agent_sdk.Checkpoint.t option ->
-  post_turn_lifecycle
+val apply_post_turn_lifecycle_with_resilience_handles
+  :  resilience_audit_store:Shared_audit.Store.t option
+  -> resilience_strategy_executor:Resilience.Recovery.strategy_executor option
+  -> on_compaction_started:(unit -> unit)
+  -> on_handoff_started:(unit -> unit)
+  -> base_dir:string
+  -> meta:keeper_meta
+  -> model:string
+  -> primary_model_max_tokens:int
+  -> current_turn_blocker_info:blocker_info option
+  -> checkpoint:Agent_sdk.Checkpoint.t option
+  -> post_turn_lifecycle
 
-val dispatch_keeper_phase_event :
-  config:Coord.config ->
-  keeper_name:string ->
-  Keeper_state_machine.event ->
-  unit
+val dispatch_keeper_phase_event
+  :  config:Coord.config
+  -> keeper_name:string
+  -> Keeper_state_machine.event
+  -> unit
 
 (** Canonical metric name for the compaction outcome counter.
 
@@ -247,11 +246,11 @@ val compaction_outcome_metric : string
     emits the outcome counter and (for [saved_tokens <= 0]) a warn log,
     without dispatching an FSM event.  Exposed for unit tests and for
     callers that need the observability signal before/after a dispatch.  *)
-val record_compaction_outcome :
-  keeper_name:string ->
-  before_tokens:int ->
-  after_tokens:int ->
-  unit
+val record_compaction_outcome
+  :  keeper_name:string
+  -> before_tokens:int
+  -> after_tokens:int
+  -> unit
 
 (** [dispatch_compaction_completed ~config ~keeper_name ~before_tokens
     ~after_tokens] dispatches a [Compaction_completed] phase event and
@@ -266,83 +265,73 @@ val record_compaction_outcome :
     Two emit paths exist ([tool_keeper] manual compact recovery and
     [dispatch_post_turn_lifecycle_events] automatic compact); both
     funnel through this helper to keep observability coherent. *)
-val dispatch_compaction_completed :
-  config:Coord.config ->
-  keeper_name:string ->
-  before_tokens:int ->
-  after_tokens:int ->
-  unit
+val dispatch_compaction_completed
+  :  config:Coord.config
+  -> keeper_name:string
+  -> before_tokens:int
+  -> after_tokens:int
+  -> unit
 
-val dispatch_post_turn_lifecycle_events :
-  config:Coord.config ->
-  keeper_name:string ->
-  post_turn_lifecycle ->
-  unit
+val dispatch_post_turn_lifecycle_events
+  :  config:Coord.config
+  -> keeper_name:string
+  -> post_turn_lifecycle
+  -> unit
 
-val recover_latest_checkpoint_for_overflow_retry :
-  base_dir:string ->
-  meta:keeper_meta ->
-  model:string ->
-  primary_model_max_tokens:int ->
-  overflow_retry_recovery option
+val recover_latest_checkpoint_for_overflow_retry
+  :  base_dir:string
+  -> meta:keeper_meta
+  -> model:string
+  -> primary_model_max_tokens:int
+  -> overflow_retry_recovery option
 
 (** {1 Trace and Board Utilities} *)
 
 val generate_trace_id : ?now:float -> unit -> string
-
 val keeper_board_write_tool_names : string list
-
 val keeper_write_done : string list -> bool
-
 val keeper_action_kind_of_tool_names : string list -> string
 
 (** {1 Model and Coord Utilities} *)
 
-val effective_model_labels_for_turn :
-  keeper_meta -> string list
+val effective_model_labels_for_turn : keeper_meta -> string list
 
-val resolve_max_context_resolution :
-  requested_override:int option ->
-  string list ->
-  max_context_resolution
+val resolve_max_context_resolution
+  :  requested_override:int option
+  -> string list
+  -> max_context_resolution
 
-val resolve_max_context_resolution_of_meta :
-  keeper_meta -> max_context_resolution
-
+val resolve_max_context_resolution_of_meta : keeper_meta -> max_context_resolution
 val room_cursor_for : keeper_meta -> string -> int
-
 val set_room_cursor : keeper_meta -> string -> int -> keeper_meta
-
 val room_ids_for_meta : Coord.config -> keeper_meta -> string list
-
 val ensure_keeper_room_presence : Coord.config -> keeper_meta -> keeper_meta
 
 (** {1 Mention Detection} *)
 
-val exact_direct_mention_present :
-  targets:string list -> string -> bool
+val exact_direct_mention_present : targets:string list -> string -> bool
 
 (** {1 Prompt Delegation} *)
 
 val keeper_constitution : unit -> string
 
-val build_keeper_system_prompt :
-  goal:string ->
-  short_goal:string ->
-  mid_goal:string ->
-  long_goal:string ->
-  will:string ->
-  needs:string ->
-  desires:string ->
-  instructions:string ->
-  ?persona_extended:string ->
-  ?keeper_name:string ->
-  ?allowed_orgs:string list ->
-  ?denied_repos:string list ->
-  ?git_clone_policy_loaded:bool ->
-  ?active_goals:(string * string * string) list ->
-  unit ->
-  string
+val build_keeper_system_prompt
+  :  goal:string
+  -> short_goal:string
+  -> mid_goal:string
+  -> long_goal:string
+  -> will:string
+  -> needs:string
+  -> desires:string
+  -> instructions:string
+  -> ?persona_extended:string
+  -> ?keeper_name:string
+  -> ?allowed_orgs:string list
+  -> ?denied_repos:string list
+  -> ?git_clone_policy_loaded:bool
+  -> ?active_goals:(string * string * string) list
+  -> unit
+  -> string
 
 val append_trait_clause : base:string -> clause:string -> string
 

--- a/lib/keeper/keeper_unified_turn.mli
+++ b/lib/keeper/keeper_unified_turn.mli
@@ -8,21 +8,6 @@
 
     @since Unified Keeper Loop *)
 
-val bounded_oas_timeout_for_turn_budget
-  :  estimated_input_tokens:int
-  -> remaining_turn_budget_s:float
-  -> float option
-
-val bounded_oas_timeout_for_turn_budget_with_turn_budget
-  :  estimated_input_tokens:int
-  -> max_turns:int
-  -> remaining_turn_budget_s:float
-  -> float option
-
-(** Full timeout-budget resolution used by the unified turn loop.
-    Exposed for regression tests that need to distinguish "an OAS
-    call had a bounded budget" from "the turn had no retry budget
-    left before dispatch". *)
 type oas_timeout_budget_resolution =
   { effective_timeout_sec : float
   ; adaptive_timeout_sec : float
@@ -306,6 +291,17 @@ val run_keeper_cycle
     @param meta Current keeper metadata
     @param observation World state snapshot
     @param generation Current generation counter *)
+
+val bounded_oas_timeout_for_turn_budget
+  :  estimated_input_tokens:int
+  -> remaining_turn_budget_s:float
+  -> float option
+
+val bounded_oas_timeout_for_turn_budget_with_turn_budget
+  :  estimated_input_tokens:int
+  -> max_turns:int
+  -> remaining_turn_budget_s:float
+  -> float option
 
 val run_unified_turn
   :  config:Coord.config


### PR DESCRIPTION
Three files on main had misplaced documentation comments that cause ocamlformat (0.29.0) to fail with Warning 50 whenever these files are included in a PR's changed-files check.

- **lib/keeper/keeper_exec_context.mli**: Ambiguous doc comments between val declarations → moved before their respective vals
- **lib/keeper/keeper_unified_turn.mli**: Orphaned doc comments at top of file → moved before val run_unified_turn
- **lib/provider_adapter.ml**: Already fixed on main (regular comments instead of doc comments)

Fixing these on main prevents future PRs that touch these files from failing CI with the same ocamlformat errors.

Refs: recurring ocamlformat CI failures across multiple PRs