### PR TITLE
feat(types_auth): permission_to_string lock wire format vs deriving show drift

### DIFF
--- a/lib/auth.ml
+++ b/lib/auth.ml
@@ -1211,7 +1211,7 @@ let check_permission config ~agent_name ~token ~permission : (unit, masc_error) 
       Error
         (Auth
            (Auth_error.Forbidden
-              { agent = agent_name; action = show_permission permission }))
+              { agent = agent_name; action = permission_to_string permission }))
   else (
     match verify_optional_token config ~agent_name ~token with
     | Error e -> Error e
@@ -1222,7 +1222,7 @@ let check_permission config ~agent_name ~token ~permission : (unit, masc_error) 
         Error
           (Auth
              (Auth_error.Forbidden
-                { agent = agent_name; action = show_permission permission }))
+                { agent = agent_name; action = permission_to_string permission }))
     | Ok None ->
       if not auth_cfg.require_token
       then
@@ -1234,7 +1234,7 @@ let check_permission config ~agent_name ~token ~permission : (unit, masc_error) 
           Error
             (Auth
                (Auth_error.Forbidden
-                  { agent = agent_name; action = show_permission permission }))
+                  { agent = agent_name; action = permission_to_string permission }))
       else Error (Auth (Auth_error.Unauthorized "Token required")))
 ;;
 

--- a/lib/tool_catalog.ml
+++ b/lib/tool_catalog.ml
@@ -946,7 +946,7 @@ let metadata_to_fields name =
   in
   match meta.required_permission with
   | Some permission ->
-      ("requiredPermission", `String (Masc_domain.show_permission permission))
+      ("requiredPermission", `String (Masc_domain.permission_to_string permission))
       :: with_actor_binding
   | None -> with_actor_binding
 

--- a/lib/tool_misc_admin.ml
+++ b/lib/tool_misc_admin.ml
@@ -71,7 +71,7 @@ let int_arg_opt args key =
 
 let permission_to_json tool_name =
   match Auth.permission_for_tool tool_name with
-  | Some permission -> `String (Masc_domain.show_permission permission)
+  | Some permission -> `String (Masc_domain.permission_to_string permission)
   | None -> `Null
 
 let auth_snapshot_json ctx =

--- a/lib/types/types_auth.ml
+++ b/lib/types/types_auth.ml
@@ -143,6 +143,30 @@ type permission =
   | CanAdmin
 [@@deriving show { with_path = false }]
 
+(** Stable wire format for [permission].  Returns the same string as
+    [show_permission] does today (PascalCase constructor name), but
+    locks the contract: future renames of the variant constructor will
+    NOT change the wire string, because callers must update this
+    explicit match at the same time.  Public API/SSE/error output
+    (tool_catalog requiredPermission, Auth_error.Forbidden action)
+    depends on these exact strings. *)
+let permission_to_string = function
+  | CanInit -> "CanInit"
+  | CanReset -> "CanReset"
+  | CanJoin -> "CanJoin"
+  | CanLeave -> "CanLeave"
+  | CanReadState -> "CanReadState"
+  | CanAddTask -> "CanAddTask"
+  | CanClaimTask -> "CanClaimTask"
+  | CanCompleteTask -> "CanCompleteTask"
+  | CanBroadcast -> "CanBroadcast"
+  | CanOpenPortal -> "CanOpenPortal"
+  | CanSendPortal -> "CanSendPortal"
+  | CanCreateWorktree -> "CanCreateWorktree"
+  | CanRemoveWorktree -> "CanRemoveWorktree"
+  | CanVote -> "CanVote"
+  | CanAdmin -> "CanAdmin"
+
 (** Get permissions for a role *)
 let permissions_for_role = function
   | Worker -> [

--- a/lib/types/types_auth.mli
+++ b/lib/types/types_auth.mli
@@ -126,6 +126,14 @@ type permission =
   | CanAdmin
 [@@deriving show { with_path = false }]
 
+val permission_to_string : permission -> string
+(** Stable wire format for {!permission}.  Returns the same string
+    {!show_permission} does today (PascalCase constructor name) but
+    locks the contract against [@@deriving show] template drift and
+    accidental renames.  Public API/SSE/error output depends on these
+    exact strings — prefer this over [show_permission] at any
+    externally-observable boundary. *)
+
 val permissions_for_role : agent_role -> permission list
 (** [Worker] permissions exclude [CanInit] / [CanReset] / [CanAdmin].
     [Admin] adds those three to the [Worker] set. *)


### PR DESCRIPTION
## Summary

`Types_auth.permission` is a 15-variant closed sum emitted on
externally-observable boundaries (JSON catalog, error responses).
All five emit sites use `show_permission` — a `[@@deriving show
{ with_path = false }]` artifact.  Lock the wire format with an
explicit typed `permission_to_string`.

## Why

Current wire output happens to match the constructor name
(e.g. `"CanInit"`), but the contract is at the mercy of:

1. **`[@@deriving show]` template changes upstream** — a ppx update
   could alter the rendering (e.g. add quoting, change formatting).
2. **Constructor renames** — `CanInit` → `CanInitialize` would
   silently flip the wire string with no compile error at the
   emission site.
3. **Future payload-bearing variants** — `[@@deriving show]` inlines
   payload values (`"Errored \"oom\""`), which would leak data into
   metric labels and break JSON consumers.

Same anti-pattern as #14712 (`show_result_status` substring split):
relying on `[@@deriving show]` for cross-API contracts.

## Approach

```ocaml
(* lib/types/types_auth.ml *)
let permission_to_string = function
  | CanInit -> "CanInit"
  | CanReset -> "CanReset"
  | ...
  | CanAdmin -> "CanAdmin"
```

Byte-equal output today; the explicit match forces deliberate
review on any future renames or payloads.

## Sites migrated (5)

| File | Context |
|------|---------|
| `lib/tool_catalog.ml:949` | JSON `requiredPermission` field (public contract) |
| `lib/tool_misc_admin.ml:74` | JSON catalog row |
| `lib/auth.ml:1214` | `Auth_error.Forbidden { action }` (gate rejection) |
| `lib/auth.ml:1225` | `Auth_error.Forbidden { action }` (gate rejection) |
| `lib/auth.ml:1237` | `Auth_error.Forbidden { action }` (anon worker path) |

## Test plan

- [ ] CI green
- [ ] `rg 'show_permission' lib/` returns only the `.mli` ppx declaration

RFC-WAIVED: not in credential/identity/operator/sandbox/hooks/workflow scope.
(The auth.ml touches are emission-only — no actual auth logic change.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)