### PR TITLE
perf(tool_catalog_surfaces): direct variant match for is_on_surface

### DIFF
--- a/lib/tool_catalog_surfaces.ml
+++ b/lib/tool_catalog_surfaces.ml
@@ -486,20 +486,42 @@ let all_surfaces =
   ]
 ;;
 
+let build_surface_set tools =
+  let tbl = Hashtbl.create (List.length tools) in
+  List.iter (fun name -> Hashtbl.replace tbl name ()) tools;
+  tbl
+;;
+
+(* Per-surface membership tables, bound once at module load.  Direct
+   variant match (below) replaces a List.assoc_opt scan over an
+   (surface * Hashtbl) association list — the latter required linear
+   structural-equality comparison of variants on every call. *)
+let public_mcp_set = build_surface_set public_mcp_surface_tools
+let spawned_agent_set = build_surface_set spawned_agent_surface_tools
+let local_worker_set = build_surface_set local_worker_surface_tools
+let session_min_set = build_surface_set session_min_surface_tools
+let admin_set = build_surface_set admin_surface_tools
+let keeper_internal_set = build_surface_set keeper_internal_surface_tools
+let keeper_denied_set = build_surface_set keeper_denied_surface_tools
+let system_internal_set = build_surface_set system_internal_surface_tools
+
+let set_for_surface = function
+  | Public_mcp -> public_mcp_set
+  | Spawned_agent -> spawned_agent_set
+  | Local_worker -> local_worker_set
+  | Session_min -> session_min_set
+  | Admin -> admin_set
+  | Keeper_internal -> keeper_internal_set
+  | Keeper_denied -> keeper_denied_set
+  | System_internal -> system_internal_set
+;;
+
 let surface_sets : (surface * (string, unit) Hashtbl.t) list =
-  List.map
-    (fun surface ->
-       let tools = tools_for_surface surface in
-       let tbl = Hashtbl.create (List.length tools) in
-       List.iter (fun name -> Hashtbl.replace tbl name ()) tools;
-       surface, tbl)
-    all_surfaces
+  List.map (fun surface -> surface, set_for_surface surface) all_surfaces
 ;;
 
 let is_on_surface surface name =
-  match List.assoc_opt surface surface_sets with
-  | Some tbl -> Hashtbl.mem tbl name
-  | None -> false
+  Hashtbl.mem (set_for_surface surface) name
 ;;
 
 let surfaces_for_tool name =


### PR DESCRIPTION
## Summary

\`is_on_surface\` previously did \`List.assoc_opt surface surface_sets\` (linear scan over an 8-entry assoc list, structural variant comparison) **before** the Hashtbl lookup — making the .mli's "O(1) amortised" claim inaccurate.

This PR binds one Hashtbl per surface as a top-level value, then dispatches via direct pattern match on the \`surface\` variant. Variant match O(1) + Hashtbl.mem O(1) = the .mli claim now holds.

## Where this compounds

\`is_on_surface\` is invoked from \`Tool_access_policy.selector_matches_name | Surface s ->\` which fires:

- once per allow-check **and** once per deny-check
- in \`Auth.authorize\`, \`Eval_gate.pre_check\`, \`Worker_oas\` PreToolUse hook
- → every tool call ran 2 × (8-variant scan + Hashtbl.mem)

Now it's 2 × (pattern match + Hashtbl.mem).

## Changes

1. **\`build_surface_set\`** — extracted helper that converts a name list into a hashtable.
2. **Eight \`*_set\` top-level bindings** — one per surface variant, built at module load.
3. **\`set_for_surface\`** — pure variant match returning the right hashtable.
4. **\`is_on_surface\`** — single \`Hashtbl.mem (set_for_surface surface) name\` expression.
5. **\`surface_sets\`** preserved (still needed by \`surfaces_for_tool\` iteration), now derived from the per-surface bindings.

## Semantic preservation

Behaviour preserved. The dead \`None -> false\` branch of the old \`List.assoc_opt\` was unreachable anyway (\`surface_sets\` covers every variant by construction); removing it makes the type system, not a runtime fallback, prove that.

## Test plan

- [ ] CI lib/ build green
- [ ] \`dune runtest test/test_tool_catalog_surfaces.exe\` passes
- [ ] \`dune runtest test/test_tool_surface_ssot.exe\` passes (consumes \`is_on_surface\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)