### PR TITLE
feat(keeper): apply_event precondition layer for Compact_retry_exhausted (R-A-9 PR-1) (/loop iter 10)

### DIFF
--- a/lib/keeper/keeper_registry.ml
+++ b/lib/keeper/keeper_registry.ml
@@ -1885,7 +1885,12 @@ let rec dispatch_event_with_audit
                   "registry(%s): followup skipped, already terminal: %s (event: %s)"
                   name
                   (Keeper_state_machine.phase_to_string current)
-                  attempted_event)
+                  attempted_event
+            | Error (Keeper_state_machine.Precondition_violation { event = ev; reason }) ->
+                record_followup_dispatch_rejection followup_event;
+                Log.Keeper.warn
+                  "registry(%s): followup skipped, precondition violated: %s (%s)"
+                  name ev reason)
        (List.filter_map
             (followup_event_of_entry_action ~phase:tr.new_phase)
             tr.entry_actions);
@@ -1936,6 +1941,7 @@ let dispatch_event_and_log ~base_path name event =
       match e with
       | Keeper_state_machine.Terminal_state _ -> "terminal_state"
       | Keeper_state_machine.Invalid_transition _ -> "invalid_transition"
+      | Keeper_state_machine.Precondition_violation _ -> "precondition_violation"
     in
     Prometheus.inc_counter
       Keeper_metrics.metric_keeper_dispatch_event_failures
@@ -1957,6 +1963,7 @@ let dispatch_event_with_audit_and_log ~base_path ?snapshot ?events_fired ?select
       match e with
       | Keeper_state_machine.Terminal_state _ -> "terminal_state"
       | Keeper_state_machine.Invalid_transition _ -> "invalid_transition"
+      | Keeper_state_machine.Precondition_violation _ -> "precondition_violation"
     in
     Prometheus.inc_counter
       Keeper_metrics.metric_keeper_dispatch_event_failures

--- a/lib/keeper/keeper_state_machine.ml
+++ b/lib/keeper/keeper_state_machine.ml
@@ -969,38 +969,38 @@ let entry_actions_for ~prev_phase ~new_phase ~(event : event) : entry_action lis
 let check_event_precondition (c : conditions) (ev : event)
   : (unit, transition_error) result
   =
+  (* [reason] strings are short stable tags ("context_overflow=false" etc).
+     They flow into [transition_error_to_string] log lines and the
+     [Attribution.policy_failed.reason] telemetry field — keeping them
+     low-cardinality lets operators aggregate / alert on the exact
+     precondition that failed, while the long explanatory text stays
+     in source comments above each branch.
+
+     TLA+ §CompactRetryExhausted predicates: context_overflow=true /\
+     ~compaction_active /\ ~compact_retry_exhausted. *)
   match ev with
   | Compact_retry_exhausted ->
     if not c.context_overflow
     then
+      (* Latching the retry flag on a non-overflowed keeper would force
+         Paused on the next overflow event (TLA+ violation). *)
       Error
         (Precondition_violation
-           { event = event_to_string ev
-           ; reason =
-               "TLA+ §CompactRetryExhausted requires context_overflow=true; \
-                latching the retry flag on a non-overflowed keeper would \
-                force Paused on the next overflow event"
-           })
+           { event = event_to_string ev; reason = "context_overflow=false" })
     else if c.compaction_active
     then
+      (* Latching the retry flag while a compaction is in flight
+         conflates the in-progress attempt with budget exhaustion. *)
       Error
         (Precondition_violation
-           { event = event_to_string ev
-           ; reason =
-               "TLA+ §CompactRetryExhausted requires ~compaction_active; \
-                latching the retry flag while a compaction is in flight \
-                conflates the in-progress attempt with budget exhaustion"
-           })
+           { event = event_to_string ev; reason = "compaction_active=true" })
     else if c.compact_retry_exhausted
     then
+      (* Retry latch is idempotent — re-latching surfaces a duplicate
+         dispatch in the caller. *)
       Error
         (Precondition_violation
-           { event = event_to_string ev
-           ; reason =
-               "TLA+ §CompactRetryExhausted requires ~compact_retry_exhausted; \
-                the retry latch is idempotent — re-latching surfaces a \
-                duplicate dispatch in the caller"
-           })
+           { event = event_to_string ev; reason = "already_latched" })
     else Ok ()
   (* Remaining 4 events covered in follow-up PRs (R-A-9 PR-2/PR-3). *)
   | _ -> Ok ()

--- a/lib/keeper/keeper_state_machine.ml
+++ b/lib/keeper/keeper_state_machine.ml
@@ -295,6 +295,10 @@ type transition_error =
       ; to_phase : phase
       ; reason : string
       }
+  | Precondition_violation of
+      { event : string
+      ; reason : string
+      }
 
 let transition_error_to_string = function
   | Terminal_state r ->
@@ -308,6 +312,8 @@ let transition_error_to_string = function
       (phase_to_string r.from_phase)
       (phase_to_string r.to_phase)
       r.reason
+  | Precondition_violation r ->
+    Printf.sprintf "precondition_violation: %s — %s" r.event r.reason
 ;;
 
 (* ── Transition Matrix ─────────────────────────────────── *)
@@ -936,6 +942,70 @@ let entry_actions_for ~prev_phase ~new_phase ~(event : event) : entry_action lis
     []
 ;;
 
+(* ── Event preconditions (R-A-9 minimal layer) ──────────
+
+   TLA+ KeeperStateMachine.tla enumerates state preconditions per
+   action (e.g. CompactRetryExhausted requires
+   [context_overflow /\ ~compaction_active /\ ~compact_retry_exhausted]).
+   [update_conditions] is a pure record-update and ignores them — a
+   mis-ordered caller can set [compact_retry_exhausted = TRUE] on a
+   non-overflowed keeper, which then latches the keeper into [Paused]
+   the next time an overflow event arrives (silent forced operator
+   intervention).
+
+   This helper enforces a subset of those preconditions at the
+   [apply_event] boundary so silent corruption becomes a typed
+   [Precondition_violation] result.  Only the most operationally
+   dangerous event is covered in this first PR; the remaining four
+   (Auto_compact_triggered, Operator_compact_requested,
+   Context_overflow_detected, Operator_clear_requested) follow in
+   subsequent PRs as the spec/code refinement chain (R-A-9 PR-2/PR-3)
+   matures.
+
+   Background:
+     - iter 9 audit memo: docs/tla-audit/ksm-precondition-enforcement-gap-2026-05-12.md
+     - iter 9 PR #14730 (systematic gap class)
+     - TLA+ §CompactRetryExhausted in KeeperStateMachine.tla *)
+let check_event_precondition (c : conditions) (ev : event)
+  : (unit, transition_error) result
+  =
+  match ev with
+  | Compact_retry_exhausted ->
+    if not c.context_overflow
+    then
+      Error
+        (Precondition_violation
+           { event = event_to_string ev
+           ; reason =
+               "TLA+ §CompactRetryExhausted requires context_overflow=true; \
+                latching the retry flag on a non-overflowed keeper would \
+                force Paused on the next overflow event"
+           })
+    else if c.compaction_active
+    then
+      Error
+        (Precondition_violation
+           { event = event_to_string ev
+           ; reason =
+               "TLA+ §CompactRetryExhausted requires ~compaction_active; \
+                latching the retry flag while a compaction is in flight \
+                conflates the in-progress attempt with budget exhaustion"
+           })
+    else if c.compact_retry_exhausted
+    then
+      Error
+        (Precondition_violation
+           { event = event_to_string ev
+           ; reason =
+               "TLA+ §CompactRetryExhausted requires ~compact_retry_exhausted; \
+                the retry latch is idempotent — re-latching surfaces a \
+                duplicate dispatch in the caller"
+           })
+    else Ok ()
+  (* Remaining 4 events covered in follow-up PRs (R-A-9 PR-2/PR-3). *)
+  | _ -> Ok ()
+;;
+
 (* ── apply_event ───────────────────────────────────────── *)
 
 let apply_event ~current_phase ~conditions ~event ~now =
@@ -945,6 +1015,9 @@ let apply_event ~current_phase ~conditions ~event ~now =
     Error
       (Terminal_state { current = current_phase; attempted_event = event_to_string event })
   | _ ->
+    (match check_event_precondition conditions event with
+     | Error _ as e -> e
+     | Ok () ->
     let updated_conditions = update_conditions conditions event in
     let new_phase = derive_phase updated_conditions in
     (* Validate transition is allowed *)
@@ -983,7 +1056,7 @@ let apply_event ~current_phase ~conditions ~event ~now =
                  (event_to_string event)
                  (phase_to_string new_phase)
                  (phase_to_string current_phase)
-           })
+           }))
 ;;
 
 (* ── JSON Serialization ────────────────────────────────── *)
@@ -1238,6 +1311,15 @@ let attribution_of_transition
         "keeper in terminal phase %s, event %s ignored"
         (phase_to_string current)
         attempted_event
+    in
+    Attribution.policy_failed ~origin:Det ~gate:"keeper_fsm" ~evidence ~reason
+  | Error (Precondition_violation { event = ev; reason }) ->
+    let evidence : Yojson.Safe.t =
+      `Assoc
+        [ "event", `String event_name
+        ; "violated_event", `String ev
+        ; "precondition_reason", `String reason
+        ]
     in
     Attribution.policy_failed ~origin:Det ~gate:"keeper_fsm" ~evidence ~reason
 ;;

--- a/lib/keeper/keeper_state_machine.mli
+++ b/lib/keeper/keeper_state_machine.mli
@@ -266,6 +266,12 @@ type transition_result = {
 type transition_error =
   | Terminal_state of { current : phase; attempted_event : string }
   | Invalid_transition of { from_phase : phase; to_phase : phase; reason : string }
+  | Precondition_violation of { event : string; reason : string }
+        (** Event was dispatched at a phase/conditions state that the TLA+
+            spec's corresponding action would not enable.  Used to surface
+            silent state-machine corruption caused by mis-ordered callers.
+            See [docs/tla-audit/ksm-precondition-enforcement-gap-2026-05-12.md]
+            (iter 9 #14730) for the systematic gap analysis and R-A-9. *)
 
 val transition_error_to_string : transition_error -> string
 

--- a/test/test_keeper_lifecycle_chaos.ml
+++ b/test/test_keeper_lifecycle_chaos.ml
@@ -52,9 +52,11 @@ let dispatch_expect_rejected name event =
   match R.dispatch_event ~base_path:bp name event with
   | Ok _ -> Alcotest.fail "expected rejected transition"
   (* R.dispatch_event returns a closed transition_error type:
-     rejected terminal keepers yield either Terminal_state or Invalid_transition. *)
+     rejected terminal keepers yield Terminal_state, Invalid_transition,
+     or Precondition_violation. *)
   | Error (KSM.Terminal_state _) -> ()
   | Error (KSM.Invalid_transition _) -> ()
+  | Error (KSM.Precondition_violation _) -> ()
 
 let setup name =
   R.clear ();

--- a/test/test_keeper_lifecycle_chaos.ml
+++ b/test/test_keeper_lifecycle_chaos.ml
@@ -51,9 +51,12 @@ let dispatch name event =
 let dispatch_expect_rejected name event =
   match R.dispatch_event ~base_path:bp name event with
   | Ok _ -> Alcotest.fail "expected rejected transition"
-  (* R.dispatch_event returns a closed transition_error type:
-     rejected terminal keepers yield Terminal_state, Invalid_transition,
-     or Precondition_violation. *)
+  (* R.dispatch_event returns a closed transition_error type.  Terminal
+     keepers always yield Terminal_state (apply_event guards on
+     terminal phase before invoking check_event_precondition).  This
+     helper is also reused for non-terminal rejection-path tests
+     elsewhere — accept Invalid_transition / Precondition_violation
+     so a single helper covers both regimes. *)
   | Error (KSM.Terminal_state _) -> ()
   | Error (KSM.Invalid_transition _) -> ()
   | Error (KSM.Precondition_violation _) -> ()

--- a/test/test_keeper_state_machine.ml
+++ b/test/test_keeper_state_machine.ml
@@ -2609,6 +2609,78 @@ let outcome_kind_of = function
   | A.Partial_pass _ -> "partial_pass"
 ;;
 
+(* ── Compact_retry_exhausted precondition (R-A-9 PR-1) ─────── *)
+
+(** Helper: pin both the variant tag and the short stable reason. *)
+let expect_precondition_reason ~current_phase ~conditions ~event ~expected_reason =
+  match SM.apply_event ~current_phase ~conditions ~event ~now:1000.0 with
+  | Error (SM.Precondition_violation r) ->
+    check string "precondition reason" expected_reason r.reason
+  | Error e ->
+    fail
+      ("expected Precondition_violation, got " ^ SM.transition_error_to_string e)
+  | Ok _ -> fail "expected Precondition_violation, got Ok"
+;;
+
+let test_precondition_compact_retry_no_overflow () =
+  (* TLA+ §CompactRetryExhausted requires context_overflow=true.
+     Without it the dispatch must reject with the
+     [context_overflow=false] tag. *)
+  let c = { running_conditions with context_overflow = false } in
+  expect_precondition_reason
+    ~current_phase:SM.Running
+    ~conditions:c
+    ~event:SM.Compact_retry_exhausted
+    ~expected_reason:"context_overflow=false"
+;;
+
+let test_precondition_compact_retry_compaction_active () =
+  (* In-flight compaction (compaction_active=true) must reject. *)
+  let c =
+    { running_conditions with context_overflow = true; compaction_active = true }
+  in
+  expect_precondition_reason
+    ~current_phase:SM.Compacting
+    ~conditions:c
+    ~event:SM.Compact_retry_exhausted
+    ~expected_reason:"compaction_active=true"
+;;
+
+let test_precondition_compact_retry_already_latched () =
+  (* Retry latch is idempotent — re-latching must reject as duplicate
+     dispatch from the caller. *)
+  let c =
+    { running_conditions with
+      context_overflow = true
+    ; compaction_active = false
+    ; compact_retry_exhausted = true
+    }
+  in
+  expect_precondition_reason
+    ~current_phase:SM.Paused
+    ~conditions:c
+    ~event:SM.Compact_retry_exhausted
+    ~expected_reason:"already_latched"
+;;
+
+let test_precondition_compact_retry_accepts_when_preconditions_satisfied () =
+  (* Sanity: when all three preconditions hold, dispatch succeeds. *)
+  let c =
+    { running_conditions with
+      context_overflow = true
+    ; compaction_active = false
+    ; compact_retry_exhausted = false
+    }
+  in
+  let tr =
+    apply_ok
+      ~current_phase:SM.Overflowed
+      ~conditions:c
+      ~event:SM.Compact_retry_exhausted
+  in
+  check bool "compact_retry_exhausted latched" true tr.updated_conditions.compact_retry_exhausted
+;;
+
 let test_attribution_ok_passed () =
   let tr =
     apply_ok
@@ -3003,6 +3075,24 @@ let () =
             "every condition field has setter and clearer"
             `Quick
             test_setclear_coverage
+        ] )
+    ; ( "compact_retry_precondition"
+      , [ test_case
+            "rejects when context_overflow=false"
+            `Quick
+            test_precondition_compact_retry_no_overflow
+        ; test_case
+            "rejects when compaction_active=true"
+            `Quick
+            test_precondition_compact_retry_compaction_active
+        ; test_case
+            "rejects when already_latched"
+            `Quick
+            test_precondition_compact_retry_already_latched
+        ; test_case
+            "accepts when all preconditions satisfied"
+            `Quick
+            test_precondition_compact_retry_accepts_when_preconditions_satisfied
         ] )
     ; ( "attribution"
       , [ test_case "successful transition → Passed" `Quick test_attribution_ok_passed


### PR DESCRIPTION
## Iteration 10 (R-A-9 PR-1) — `apply_event` precondition layer (1 of 5 events)

`/loop` FSM drift hunt iter 10. plan: `~/.claude/plans/breezy-napping-sketch.md`. iter 9 PR #14730 (audit) 직후 본격 fix.

## Why

iter 9가 식별한 *systematic gap class*: 5 condition-setter events 중 4개가 OCaml에서 TLA+ precondition을 silent하게 우회. 3 documented silent-corruption scenarios. 단일 RFC (R-A-9)로 5 fix를 *통합 layer*에 흡수 제안.

본 PR은 그 layer의 *minimal foothold* — 가장 위험한 1 event부터.

## What

**New error variant** (`.mli` + `.ml`):
```ocaml
type transition_error =
  | Terminal_state of {...}
  | Invalid_transition of {...}
  | Precondition_violation of { event : string; reason : string }   (* new *)
```

**New helper** in `keeper_state_machine.ml`:
```ocaml
let check_event_precondition (c : conditions) (ev : event)
  : (unit, transition_error) result
  =
  match ev with
  | Compact_retry_exhausted ->
    if not c.context_overflow then Error (...)
    else if c.compaction_active then Error (...)
    else if c.compact_retry_exhausted then Error (...)
    else Ok ()
  | _ -> Ok ()  (* 다음 4 events R-A-9 PR-2/PR-3 *)
```

**apply_event 통합**:
```ocaml
let apply_event ~current_phase ~conditions ~event ~now =
  match current_phase with
  | Stopped | Dead | Zombie -> Error (Terminal_state {...})
  | _ ->
    (match check_event_precondition conditions event with
     | Error _ as e -> e
     | Ok () -> ... existing flow ...)
```

**Propagation**:
- `attribution_of_transition` 새 arm (policy_failed origin=Det)
- `keeper_registry.dispatch_event_*` 두 곳에 reason_label arm (`"precondition_violation"`)
- `keeper_registry`의 followup-dispatch loop에 새 match arm
- `test/test_keeper_lifecycle_chaos.ml` exhaustive match arm 추가

**+100 / -3 LOC, 4 files**.

## 적용 event 선택 근거

`Compact_retry_exhausted`이 iter 9 scenario B의 *highest impact*:
- 잘못 dispatched 되면 *operator 강제 개입* 필요 (Paused phase)
- production caller bugs가 keeper를 *영구 잠금*
- TLA+ spec이 3개 precondition을 명시 — 모두 enforce

3 misuse vectors 모두 차단:
1. non-overflowed keeper에서 latch → forced Paused 차단
2. compaction in-flight 중 latch → conflation 차단
3. duplicate latch → idempotent silent accept 차단

## 다음 4 events 계획 (R-A-9 PR-2/PR-3)

본 PR이 *layer 자체* 정착 (variant + helper + propagation). 후속 PR이 *각 event*에 precondition arm 추가:

- PR-2: `Auto_compact_triggered`, `Context_overflow_detected` (overflow lifecycle 핵심)
- PR-3: `Operator_compact_requested`, `Operator_clear_requested` (operator path)

각 follow-up PR은 *helper에 한 줄 추가* 수준 — layer가 자리 잡혔으므로.

## Verification

- [x] `dune build @check` 통과 (full project typecheck silent)
- [x] `attribution_of_transition` exhaustive match update
- [x] `keeper_registry`의 2 reason_label match + 1 followup loop arm update
- [x] `test_keeper_lifecycle_chaos.ml` exhaustive match arm 추가
- [ ] (후속 PR) negative test for misuse scenarios A/B/C

## Trade-off

- **단점**: 1 event만 cover — 나머지 4 events는 silent corruption vector 남아있음.
- **장점**: Structural change (new variant + helper + propagation)가 *behavior-preserving manner*로 정착. 후속 PR이 *기계적 add-only*가 됨.
- **단점**: error variant 추가로 모든 caller pattern match 갱신 강제 (이미 처리됨). 미래 다른 PR이 cascade 영향 받을 수 있음.

## RFC

`RFC-WAIVED: behavior-augmenting layer addition on lib/keeper/, no agent delegation subsystem surface modified. R-A-9 multi-PR plan: PR-1 (this) lays the layer, PR-2/PR-3 fill remaining events.`

## 진행 추적

다음 iteration: **R-A-9 PR-2** (Auto_compact_triggered + Context_overflow_detected) OR **R-A-8 PR-2** (TLC verify + KNOWN_FAILURES 제거 — iter 8 #14727 머지됨).

🤖 Generated with [Claude Code](https://claude.com/claude-code)