### PR TITLE
refactor(provider): timeout_bounds_of_kind boundary helper (RFC-0058 Phase 5.6 leak 4/4)

### DIFF
--- a/lib/keeper/keeper_turn_driver_helpers.ml
+++ b/lib/keeper/keeper_turn_driver_helpers.ml
@@ -31,24 +31,18 @@ let first_health_cooldown provider_cfg =
          | Ok () -> None
          | Error msg -> Some (provider_key, msg))
 
-type provider_attempt_timeout_constraints = {
+(* Manifest alias of [Provider_adapter.timeout_bounds]: keeps the
+   keeper-public type name stable while the [match provider_cfg.kind]
+   that produces values lives inside the adapter boundary
+   (RFC-0058 Phase 5.6). *)
+type provider_attempt_timeout_constraints = Provider_adapter.timeout_bounds = {
   min_timeout_s : float option;
   max_timeout_s : float option;
 }
 
 let provider_attempt_timeout_constraints
     (provider_cfg : Llm_provider.Provider_config.t) =
-  match provider_cfg.kind with
-  | Llm_provider.Provider_config.Ollama ->
-      { min_timeout_s = Some 300.0; max_timeout_s = None }
-  | Claude_code ->
-      { min_timeout_s = None; max_timeout_s = Some 120.0 }
-  | Gemini | Gemini_cli ->
-      { min_timeout_s = None; max_timeout_s = Some 180.0 }
-  | Kimi_cli ->
-      { min_timeout_s = None; max_timeout_s = Some 60.0 }
-  | Anthropic | Kimi | OpenAI_compat | Glm | DashScope | Codex_cli ->
-      { min_timeout_s = None; max_timeout_s = None }
+  Provider_adapter.timeout_bounds_of_kind provider_cfg.kind
 
 let apply_provider_attempt_timeout_constraints constraints timeout_s =
   let timeout_s =

--- a/lib/keeper/keeper_turn_driver_helpers.mli
+++ b/lib/keeper/keeper_turn_driver_helpers.mli
@@ -9,7 +9,11 @@ val provider_health_keys_of_config :
 val first_health_cooldown :
   Llm_provider.Provider_config.t -> (string * string) option
 
-type provider_attempt_timeout_constraints = {
+(** Manifest alias of {!Provider_adapter.timeout_bounds}.  RFC-0058
+    Phase 5.6 moved the [match provider_cfg.kind] that produces
+    values inside the adapter boundary; the keeper-public type name
+    stays so existing callers keep compiling. *)
+type provider_attempt_timeout_constraints = Provider_adapter.timeout_bounds = {
   min_timeout_s : float option;
   max_timeout_s : float option;
 }

--- a/lib/provider_adapter.ml
+++ b/lib/provider_adapter.ml
@@ -799,6 +799,41 @@ let is_http_probe_capable_kind (kind : Llm_provider.Provider_config.provider_kin
   | _ -> false
 ;;
 
+(** Per-provider per-attempt timeout bounds.
+
+    [min_timeout_s] is the floor below which an attempt timeout is
+    never set (e.g. ollama needs 300s to load a cold model — anything
+    lower means the keeper turn fails before the model finishes
+    initialising).
+
+    [max_timeout_s] is the ceiling above which an attempt cannot
+    block (e.g. claude_code's 120s subprocess budget — exceeding it
+    means the CLI has hung and the supervisor must intervene). *)
+type timeout_bounds =
+  { min_timeout_s : float option
+  ; max_timeout_s : float option
+  }
+
+(** [timeout_bounds_of_kind kind] is the per-provider attempt timeout
+    policy.  Encapsulates the only [match provider_cfg.kind] site that
+    used to live in keeper-layer driver helpers; new providers add an
+    arm here, not at the call site.
+
+    RFC-0058 Phase 5.6: vendor-specific operational tunables live
+    inside the adapter boundary, not the keeper turn-driver. *)
+let timeout_bounds_of_kind (kind : Llm_provider.Provider_config.provider_kind)
+  : timeout_bounds
+  =
+  match kind with
+  | Llm_provider.Provider_config.Ollama ->
+    { min_timeout_s = Some 300.0; max_timeout_s = None }
+  | Claude_code -> { min_timeout_s = None; max_timeout_s = Some 120.0 }
+  | Gemini | Gemini_cli -> { min_timeout_s = None; max_timeout_s = Some 180.0 }
+  | Kimi_cli -> { min_timeout_s = None; max_timeout_s = Some 60.0 }
+  | Anthropic | Kimi | OpenAI_compat | Glm | DashScope | Codex_cli ->
+    { min_timeout_s = None; max_timeout_s = None }
+;;
+
 (** Default fallback label for local runtime when no other preferred
     model labels are configured.  Uses "provider:auto" for the first
     [Local] adapter found. *)

--- a/lib/provider_adapter.mli
+++ b/lib/provider_adapter.mli
@@ -295,6 +295,26 @@ val is_local_provider : string -> bool
 val is_http_probe_capable_kind :
   Llm_provider.Provider_config.provider_kind -> bool
 
+(** Per-provider per-attempt timeout bounds.
+
+    [min_timeout_s] is the floor below which an attempt timeout is
+    never set; [max_timeout_s] is the ceiling above which an attempt
+    cannot block. *)
+type timeout_bounds =
+  { min_timeout_s : float option
+  ; max_timeout_s : float option
+  }
+
+(** [timeout_bounds_of_kind kind] is the per-provider attempt timeout
+    policy.  Encapsulates the only [match provider_cfg.kind] site
+    that used to live in keeper-layer driver helpers; new providers
+    add an arm here, not at the call site.
+
+    RFC-0058 Phase 5.6: vendor-specific operational tunables live
+    inside the adapter boundary, not the keeper turn-driver. *)
+val timeout_bounds_of_kind :
+  Llm_provider.Provider_config.provider_kind -> timeout_bounds
+
 (** {1 Voice Adapter Resolution} *)
 
 val resolve_voice_adapter : string -> voice_adapter option

--- a/test/test_provider_adapter.ml
+++ b/test/test_provider_adapter.ml
@@ -625,6 +625,62 @@ let test_unmetered_provider_uses_declared_telemetry_policy () =
     (Adapter.is_structurally_unmetered_provider "unknown")
 ;;
 
+(* RFC-0058 Phase 5.6 boundary helper: timeout_bounds_of_kind.
+
+   These tests seal the per-provider attempt timeout policy inside
+   the adapter boundary. The previous [match provider_cfg.kind] site
+   lived in [Keeper_turn_driver_helpers]; the helper now lives here
+   so adding vLLM/lmstudio means editing this site, not the keeper
+   layer. *)
+
+let test_timeout_bounds_ollama_has_300s_floor () =
+  let b = Adapter.timeout_bounds_of_kind Llm_provider.Provider_config.Ollama in
+  check (option (float 0.001)) "ollama min 300s" (Some 300.0) b.min_timeout_s;
+  check (option (float 0.001)) "ollama no max"    None         b.max_timeout_s
+
+let test_timeout_bounds_claude_code_has_120s_ceiling () =
+  let b =
+    Adapter.timeout_bounds_of_kind Llm_provider.Provider_config.Claude_code
+  in
+  check (option (float 0.001)) "claude_code no min" None         b.min_timeout_s;
+  check (option (float 0.001)) "claude_code max 120s" (Some 120.0) b.max_timeout_s
+
+let test_timeout_bounds_gemini_variants_share_ceiling () =
+  let b_api =
+    Adapter.timeout_bounds_of_kind Llm_provider.Provider_config.Gemini
+  in
+  let b_cli =
+    Adapter.timeout_bounds_of_kind Llm_provider.Provider_config.Gemini_cli
+  in
+  check (option (float 0.001)) "Gemini max 180s" (Some 180.0) b_api.max_timeout_s;
+  check (option (float 0.001)) "Gemini_cli max 180s" (Some 180.0)
+    b_cli.max_timeout_s
+
+let test_timeout_bounds_kimi_cli_has_60s_ceiling () =
+  let b =
+    Adapter.timeout_bounds_of_kind Llm_provider.Provider_config.Kimi_cli
+  in
+  check (option (float 0.001)) "kimi_cli max 60s" (Some 60.0) b.max_timeout_s
+
+let test_timeout_bounds_unconstrained_kinds_have_no_bounds () =
+  let unconstrained =
+    [ Llm_provider.Provider_config.Anthropic
+    ; Llm_provider.Provider_config.Kimi
+    ; Llm_provider.Provider_config.OpenAI_compat
+    ; Llm_provider.Provider_config.Glm
+    ; Llm_provider.Provider_config.DashScope
+    ; Llm_provider.Provider_config.Codex_cli
+    ]
+  in
+  List.iter
+    (fun kind ->
+       let b = Adapter.timeout_bounds_of_kind kind in
+       check (option (float 0.001))
+         "unconstrained min = None" None b.min_timeout_s;
+       check (option (float 0.001))
+         "unconstrained max = None" None b.max_timeout_s)
+    unconstrained
+
 (* RFC-0058 Phase 5.6 boundary helper: apply_wire_overlay.
 
    These tests seal the invariant that the keeper layer no longer
@@ -974,6 +1030,28 @@ let () =
             test_stt_request_elevenlabs_direct
         ; test_case "stt request openai compat" `Quick test_stt_request_openai_compat
         ; test_case "stt request mcp rejected" `Quick test_stt_request_mcp_rejected
+        ] )
+    ; ( "timeout_bounds_of_kind"
+      , [ test_case
+            "ollama floors at 300s"
+            `Quick
+            test_timeout_bounds_ollama_has_300s_floor
+        ; test_case
+            "claude_code ceiling 120s"
+            `Quick
+            test_timeout_bounds_claude_code_has_120s_ceiling
+        ; test_case
+            "gemini variants share 180s ceiling"
+            `Quick
+            test_timeout_bounds_gemini_variants_share_ceiling
+        ; test_case
+            "kimi_cli ceiling 60s"
+            `Quick
+            test_timeout_bounds_kimi_cli_has_60s_ceiling
+        ; test_case
+            "unconstrained kinds report no bounds"
+            `Quick
+            test_timeout_bounds_unconstrained_kinds_have_no_bounds
         ] )
     ; ( "apply_wire_overlay"
       , [ test_case


### PR DESCRIPTION
## Summary

The last `match provider_cfg.kind` inside the keeper layer moves into `Provider_adapter.timeout_bounds_of_kind`. Closes the final RFC-0058 Phase 5.6 leak in keeper scope (after #14691 / #14710 / #14717 / #14721).

## Why

`Keeper_turn_driver_helpers.provider_attempt_timeout_constraints` inlined per-provider operational tunables (ollama needs 300s for model loading, claude_code CLI hangs past 120s, gemini past 180s, kimi_cli past 60s). Operational tunables belong inside the adapter boundary — adding vLLM/lmstudio should mean editing one site, not the keeper turn driver.

## Before / After

**Before** — `lib/keeper/keeper_turn_driver_helpers.ml:39-51`

```ocaml
let provider_attempt_timeout_constraints (cfg : Llm_provider.Provider_config.t) =
  match cfg.kind with
  | Llm_provider.Provider_config.Ollama -> { min = Some 300.0; max = None }
  | Claude_code                         -> { min = None; max = Some 120.0 }
  | Gemini | Gemini_cli                 -> { min = None; max = Some 180.0 }
  | Kimi_cli                            -> { min = None; max = Some 60.0 }
  | Anthropic | Kimi | OpenAI_compat | Glm | DashScope | Codex_cli ->
    { min = None; max = None }
```

**After** — boundary helper holds the match; keeper-side is a one-liner with a manifest alias:

```ocaml
(* lib/provider_adapter.ml *)
type timeout_bounds =
  { min_timeout_s : float option; max_timeout_s : float option }

let timeout_bounds_of_kind kind = (* same 5-arm match, lives here now *) ...
```

```ocaml
(* lib/keeper/keeper_turn_driver_helpers.ml *)
type provider_attempt_timeout_constraints =
  Provider_adapter.timeout_bounds = {
    min_timeout_s : float option; max_timeout_s : float option;
  }

let provider_attempt_timeout_constraints (cfg : Llm_provider.Provider_config.t) =
  Provider_adapter.timeout_bounds_of_kind cfg.kind
```

Caller code (`Keeper_turn_driver.effective_provider_attempt_timeout_s` + `test_oas_worker.ml`) compiles unchanged — the record name and field shape are preserved by the manifest alias.

## Sealing tests

5 new test cases over every `provider_kind` arm:

| Test | Invariant |
|---|---|
| `ollama floors at 300s` | `Some 300.0` floor preserved |
| `claude_code ceiling 120s` | `Some 120.0` ceiling preserved |
| `gemini variants share 180s ceiling` | `Gemini` and `Gemini_cli` both `Some 180.0` |
| `kimi_cli ceiling 60s` | `Some 60.0` ceiling preserved |
| `unconstrained kinds report no bounds` | 6 remaining kinds all `None / None` |

## Workaround self-check

| # | check | result |
|---|---|---|
| 1 | telemetry-as-fix? | no |
| 2 | string classifier? | no — typed match on provider_kind |
| 3 | N-of-M? | no — last keeper-layer `provider_cfg.kind` site (4/4 in our sweep) |
| 4 | catch-all `_ ->` added? | no — exhaustive over all 11 kinds |
| 5 | cap/cooldown/dedup/repair? | no |
| 6 | test backdoor? | no |
| 7 | same typo N sites? | no |

## Ratchet

`rg "match.*provider_cfg\.kind" lib/keeper/keeper_turn_driver_helpers.ml`

| | matches |
|---|---|
| Before (origin/main) | 1 |
| After (this branch)  | 0 |

Across keeper-layer (excluding `Provider_adapter` boundary):

| | matches |
|---|---|
| Before this PR | 1 |
| After this PR | **0** — keeper layer fully variant-agnostic |

## Test plan

- [x] 5 new sealing tests
- [x] Existing callers preserved by manifest alias
- [ ] CI build + test (local build blocked by `dune-local.sh` global lock)

🤖 Generated with [Claude Code](https://claude.com/claude-code)