### PR TITLE
feat(telemetry): typed phase variant for oas_execution_errors metric

### DIFF
--- a/lib/keeper/keeper_post_turn.ml
+++ b/lib/keeper/keeper_post_turn.ml
@@ -734,7 +734,7 @@ let recover_latest_checkpoint_for_overflow_retry
          (Keeper_id.Trace_id.to_string meta.runtime.trace_id) d;
        Prometheus.inc_counter
          Keeper_metrics.metric_keeper_oas_execution_errors
-         ~labels:[("keeper", meta.name); ("phase", "overflow_retry_oas_load")]
+         ~labels:[("keeper", meta.name); ("phase", Oas_execution_error_phase.(to_label Overflow_retry_oas_load))]
          ()
    | Error Not_found ->
        Log.Keeper.debug

--- a/lib/keeper/keeper_turn_cascade_budget.ml
+++ b/lib/keeper/keeper_turn_cascade_budget.ml
@@ -836,7 +836,7 @@ let post_turn_resilience_handles
     with
     | Error detail ->
         Prometheus.inc_counter Keeper_metrics.metric_keeper_oas_execution_errors
-          ~labels:[("keeper", meta.name); ("phase", "resilience_audit_store")]
+          ~labels:[("keeper", meta.name); ("phase", Oas_execution_error_phase.(to_label Resilience_audit_store))]
           ();
         Log.Keeper.error
           "keeper:%s resilience audit store unavailable; execution disabled: %s"

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -925,7 +925,7 @@ let run_keeper_cycle
                      | Error err ->
                        Prometheus.inc_counter
                          Keeper_metrics.metric_keeper_write_meta_failures
-                         ~labels:[ "keeper", entry.meta.name; "phase", "turn_start" ]
+                         ~labels:[ "keeper", entry.meta.name; "phase", Oas_execution_error_phase.(to_label Turn_start) ]
                          ();
                        Log.Keeper.warn
                          "%s: turn-start write_meta_with_merge failed: %s"
@@ -1224,7 +1224,7 @@ let run_keeper_cycle
                              Prometheus.inc_counter
                                Keeper_metrics.metric_keeper_oas_execution_errors
                                ~labels:
-                                 [ "keeper", meta.name; "phase", "cascade_exhausted" ]
+                                 [ "keeper", meta.name; "phase", Oas_execution_error_phase.(to_label Cascade_exhausted) ]
                                ())
                            else (
                              Keeper_registry.set_turn_phase
@@ -1239,7 +1239,7 @@ let run_keeper_cycle
                                Keeper_metrics.metric_keeper_oas_execution_errors
                                ~labels:
                                  [ "keeper", meta.name
-                                 ; "phase", "terminal_non_exhaustion"
+                                 ; "phase", Oas_execution_error_phase.(to_label Terminal_non_exhaustion)
                                  ]
                                ();
                              Log.Keeper.warn
@@ -1763,7 +1763,7 @@ let run_keeper_cycle
                                  Keeper_metrics.metric_keeper_oas_execution_errors
                                  ~labels:
                                    [ "keeper", meta.name
-                                   ; "phase", "recoverable_cascade_transient"
+                                   ; "phase", Oas_execution_error_phase.(to_label Recoverable_cascade_transient)
                                    ]
                                  ();
                                Eio.Time.sleep clock delay;
@@ -2126,7 +2126,7 @@ let run_keeper_cycle
                     (short_preview e_str);
                   Prometheus.inc_counter
                     Keeper_metrics.metric_keeper_oas_execution_errors
-                    ~labels:[ "keeper", meta.name; "phase", "cycle_failed" ]
+                    ~labels:[ "keeper", meta.name; "phase", Oas_execution_error_phase.(to_label Cycle_failed) ]
                     ();
                   let social_state, social_transition_reason =
                     Social.derive_failure_state
@@ -2475,7 +2475,7 @@ let run_keeper_cycle
                   then (
                     Prometheus.inc_counter
                       Keeper_metrics.metric_keeper_oas_execution_errors
-                      ~labels:[ "keeper", meta.name; "phase", "persistent_escalation" ]
+                      ~labels:[ "keeper", meta.name; "phase", Oas_execution_error_phase.(to_label Persistent_escalation) ]
                       ();
                     Log.Keeper.error
                       "%s: %d consecutive persistent turn failures (threshold=%d), \

--- a/lib/keeper/oas_execution_error_phase.ml
+++ b/lib/keeper/oas_execution_error_phase.ml
@@ -1,0 +1,20 @@
+type t =
+  | Turn_start
+  | Cascade_exhausted
+  | Terminal_non_exhaustion
+  | Recoverable_cascade_transient
+  | Cycle_failed
+  | Persistent_escalation
+  | Resilience_audit_store
+  | Overflow_retry_oas_load
+
+let to_label = function
+  | Turn_start -> "turn_start"
+  | Cascade_exhausted -> "cascade_exhausted"
+  | Terminal_non_exhaustion -> "terminal_non_exhaustion"
+  | Recoverable_cascade_transient -> "recoverable_cascade_transient"
+  | Cycle_failed -> "cycle_failed"
+  | Persistent_escalation -> "persistent_escalation"
+  | Resilience_audit_store -> "resilience_audit_store"
+  | Overflow_retry_oas_load -> "overflow_retry_oas_load"
+;;

--- a/lib/keeper/oas_execution_error_phase.mli
+++ b/lib/keeper/oas_execution_error_phase.mli
@@ -1,0 +1,25 @@
+(** Oas_execution_error_phase — closed sum for the [phase] label on
+    two keeper-side metrics:
+
+    - [metric_keeper_oas_execution_errors] (7 phases from
+      [keeper_unified_turn], [keeper_turn_cascade_budget],
+      [keeper_post_turn])
+    - [metric_keeper_write_meta_failures] ([turn_start])
+
+    Replaces 8 hardcoded string literals scattered across 3 files.
+    The compiler enforces exhaustive coverage in [to_label] (a missing
+    constructor is a compile error there) so adding a new phase
+    requires a single edit here and the new wire string surfaces
+    immediately. *)
+
+type t =
+  | Turn_start
+  | Cascade_exhausted
+  | Terminal_non_exhaustion
+  | Recoverable_cascade_transient
+  | Cycle_failed
+  | Persistent_escalation
+  | Resilience_audit_store
+  | Overflow_retry_oas_load
+
+val to_label : t -> string


### PR DESCRIPTION
## Summary

Re-open of #14704 from a fresh `main` checkpoint.  Collapse 8
hardcoded `"phase"` label strings on keeper-side error metrics —
scattered across 3 files — into a closed `Oas_execution_error_phase.t`.

## Why

The original PR #14704 was opened before T1/T2/T5/T7 landed and
developed conflicts with their ocamlformat-heavy merges.  Per memory
`feedback_masc_mcp_admin_merge_fast_track` the rebase would have
required re-applying the changes onto godfile reformats — too noisy
to review.  Open a fresh PR with the same shape.

## Sites (8)

| File | Phase literal |
|------|--------------|
| `keeper_unified_turn.ml:928` | `turn_start` |
| `keeper_unified_turn.ml:1227` | `cascade_exhausted` |
| `keeper_unified_turn.ml:1242` | `terminal_non_exhaustion` |
| `keeper_unified_turn.ml:1766` | `recoverable_cascade_transient` |
| `keeper_unified_turn.ml:2129` | `cycle_failed` |
| `keeper_unified_turn.ml:2478` | `persistent_escalation` |
| `keeper_turn_cascade_budget.ml:839` | `resilience_audit_store` |
| `keeper_post_turn.ml:737` | `overflow_retry_oas_load` |

## Approach

New `lib/keeper/oas_execution_error_phase.ml(.mli)`:

```ocaml
type t =
  | Turn_start
  | Cascade_exhausted
  | Terminal_non_exhaustion
  | Recoverable_cascade_transient
  | Cycle_failed
  | Persistent_escalation
  | Resilience_audit_store
  | Overflow_retry_oas_load

val to_label : t -> string
```

8 literal sites replaced with `("phase", Oas_execution_error_phase.(to_label <V>))`.
Wire format byte-equal.

## Test plan

- [ ] CI green
- [ ] `rg '"phase", "(turn_start|cascade_exhausted|terminal_non_exhaustion|recoverable_cascade_transient|cycle_failed|persistent_escalation|resilience_audit_store|overflow_retry_oas_load)"' lib/` = 0

RFC-WAIVED: not in credential/identity/operator/sandbox/hooks/workflow scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)