### PR TITLE
feat(keeper): extend precondition layer to overflow lifecycle (R-A-9 PR-2)

### DIFF
--- a/lib/keeper/keeper_state_machine.ml
+++ b/lib/keeper/keeper_state_machine.ml
@@ -967,8 +967,12 @@ let entry_actions_for ~prev_phase ~new_phase ~(event : event) : entry_action lis
      - R-A-6.b: Restart_budget_exhausted (non-idempotency — pairs with
        §S3 BudgetNeverRevives liveness invariant; iter 14 audit).
 
-   Coverage at 6/6 enumerated R-A-9 events.  Other events have no spec
-   preconditions beyond NotTerminal and fall through the catch-all.
+   Coverage: 5/5 R-A-9 events (Compact_retry_exhausted,
+   Context_overflow_detected, Auto_compact_triggered,
+   Operator_compact_requested, Operator_clear_requested) plus the
+   adjacent R-A-6.b Restart_budget_exhausted arm (iter 14 follow-up).
+   Other events have no spec preconditions beyond NotTerminal and
+   fall through the catch-all.
 
    Background:
      - iter 9 audit memo: docs/tla-audit/ksm-precondition-enforcement-gap-2026-05-12.md

--- a/lib/keeper/keeper_state_machine.ml
+++ b/lib/keeper/keeper_state_machine.ml
@@ -955,17 +955,19 @@ let entry_actions_for ~prev_phase ~new_phase ~(event : event) : entry_action lis
 
    This helper enforces a subset of those preconditions at the
    [apply_event] boundary so silent corruption becomes a typed
-   [Precondition_violation] result.  Only the most operationally
-   dangerous event is covered in this first PR; the remaining four
-   (Auto_compact_triggered, Operator_compact_requested,
-   Context_overflow_detected, Operator_clear_requested) follow in
-   subsequent PRs as the spec/code refinement chain (R-A-9 PR-2/PR-3)
-   matures.
+   [Precondition_violation] result.  Coverage extends incrementally
+   across the spec/code refinement chain (R-A-9):
+     - PR-1: Compact_retry_exhausted (latch correctness)
+     - PR-2: Context_overflow_detected, Auto_compact_triggered (overflow
+       lifecycle — the two events that drive Overflowed↔Compacting)
+     - PR-3: Operator_compact_requested, Operator_clear_requested
+       (operator-driven buffer ops)
 
    Background:
      - iter 9 audit memo: docs/tla-audit/ksm-precondition-enforcement-gap-2026-05-12.md
      - iter 9 PR #14730 (systematic gap class)
-     - TLA+ §CompactRetryExhausted in KeeperStateMachine.tla *)
+     - TLA+ §ContextOverflowDetected, §AutoCompactTriggered,
+       §CompactRetryExhausted in KeeperStateMachine.tla *)
 let check_event_precondition (c : conditions) (ev : event)
   : (unit, transition_error) result
   =
@@ -1002,7 +1004,66 @@ let check_event_precondition (c : conditions) (ev : event)
         (Precondition_violation
            { event = event_to_string ev; reason = "already_latched" })
     else Ok ()
-  (* Remaining 4 events covered in follow-up PRs (R-A-9 PR-2/PR-3). *)
+  | Context_overflow_detected _ ->
+    if c.compaction_active
+    then
+      Error
+        (Precondition_violation
+           { event = event_to_string ev
+           ; reason =
+               "TLA+ §ContextOverflowDetected requires ~compaction_active; \
+                an overflow signal while compaction is already running means \
+                the in-flight compaction is the runaway — the retry latch \
+                must catch it, not a fresh overflow event that conflates the \
+                two attempts"
+           })
+    else Ok ()
+  | Auto_compact_triggered ->
+    if not c.context_overflow
+    then
+      Error
+        (Precondition_violation
+           { event = event_to_string ev
+           ; reason =
+               "TLA+ §AutoCompactTriggered requires context_overflow=true; \
+                triggering auto-compaction on a non-overflowed keeper flips \
+                compaction_active outside the Overflowed→Compacting transition \
+                and corrupts the overflow lifecycle invariant"
+           })
+    else if c.compaction_active
+    then
+      Error
+        (Precondition_violation
+           { event = event_to_string ev
+           ; reason =
+               "TLA+ §AutoCompactTriggered requires ~compaction_active; \
+                re-triggering while a compaction is already in flight \
+                duplicates the buffer op and tangles the ordering"
+           })
+    else if c.handoff_active
+    then
+      Error
+        (Precondition_violation
+           { event = event_to_string ev
+           ; reason =
+               "TLA+ §AutoCompactTriggered requires ~handoff_active; \
+                starting a compaction during handoff entangles two buffer \
+                ops on the same keeper"
+           })
+    else if c.compact_retry_exhausted
+    then
+      Error
+        (Precondition_violation
+           { event = event_to_string ev
+           ; reason =
+               "TLA+ §AutoCompactTriggered requires ~compact_retry_exhausted; \
+                the retry budget is spent — DerivePhase routes the next \
+                overflow to Paused, and a fresh auto-compact would defeat \
+                that latch (Issue #8581 root cause)"
+           })
+    else Ok ()
+  (* Remaining 2 events covered in follow-up PR (R-A-9 PR-3:
+     Operator_compact_requested, Operator_clear_requested). *)
   | _ -> Ok ()
 ;;
 

--- a/lib/keeper/keeper_state_machine.ml
+++ b/lib/keeper/keeper_state_machine.ml
@@ -955,13 +955,19 @@ let entry_actions_for ~prev_phase ~new_phase ~(event : event) : entry_action lis
 
    This helper enforces a subset of those preconditions at the
    [apply_event] boundary so silent corruption becomes a typed
-   [Precondition_violation] result.  Coverage extends incrementally
+   [Precondition_violation] result.  Coverage extended incrementally
    across the spec/code refinement chain (R-A-9):
      - PR-1: Compact_retry_exhausted (latch correctness)
      - PR-2: Context_overflow_detected, Auto_compact_triggered (overflow
        lifecycle — the two events that drive Overflowed↔Compacting)
-     - PR-3: Operator_compact_requested, Operator_clear_requested
-       (operator-driven buffer ops)
+     - PR-3: Operator_compact_requested (operator-driven buffer op
+       exclusivity).  Operator_clear_requested is deliberately *not*
+       arm-enforced beyond the terminal guard — see its arm below for
+       the operator escape-hatch rationale.
+
+   Coverage closed at 5/5 R-A-9 events as of PR-3.  Other events have
+   no spec preconditions beyond NotTerminal and fall through the
+   catch-all.
 
    Background:
      - iter 9 audit memo: docs/tla-audit/ksm-precondition-enforcement-gap-2026-05-12.md
@@ -1062,8 +1068,48 @@ let check_event_precondition (c : conditions) (ev : event)
                 that latch (Issue #8581 root cause)"
            })
     else Ok ()
-  (* Remaining 2 events covered in follow-up PR (R-A-9 PR-3:
-     Operator_compact_requested, Operator_clear_requested). *)
+  | Operator_compact_requested ->
+    (* TLA+ §OperatorCompactRequested.  Operator path differs from
+       AutoCompactTriggered: it does NOT require [context_overflow], so
+       an operator can pre-emptively compact a not-yet-overflowed
+       keeper.  But the two buffer-op exclusivity preconditions are
+       identical — concurrent compaction or handoff entangles ops. *)
+    if c.compaction_active
+    then
+      Error
+        (Precondition_violation
+           { event = event_to_string ev
+           ; reason =
+               "TLA+ §OperatorCompactRequested requires ~compaction_active; \
+                stacking operator-driven compaction on top of an in-flight \
+                buffer op duplicates the work and confuses the retry latch \
+                that OperatorCompactRequested clears as a side-effect"
+           })
+    else if c.handoff_active
+    then
+      Error
+        (Precondition_violation
+           { event = event_to_string ev
+           ; reason =
+               "TLA+ §OperatorCompactRequested requires ~handoff_active; \
+                handoff already owns the buffer, so a concurrent operator \
+                compaction would race on the same keeper context"
+           })
+    else Ok ()
+  | Operator_clear_requested _ ->
+    (* TLA+ §OperatorClearRequested deliberately requires only NotTerminal
+       (lib §masc_keeper_clear: "Last-resort: operator drops the keeper's
+       context entirely").  The terminal guard at the top of [apply_event]
+       already enforces this, so no extra arm is needed here.  Documented
+       to make the deliberate minimal precondition explicit — adding any
+       check beyond NotTerminal would weaken the operator escape-hatch. *)
+    Ok ()
+  (* Other events have no TLA+ state preconditions beyond what
+     [apply_event]'s terminal guard already enforces; their semantics
+     are encoded in [update_conditions] + [derive_phase] (e.g.
+     [Heartbeat_failed] always flips [heartbeat_healthy] to false
+     regardless of prior state).  Adding speculative arms here would
+     drift from the spec. *)
   | _ -> Ok ()
 ;;
 

--- a/lib/keeper/keeper_state_machine.ml
+++ b/lib/keeper/keeper_state_machine.ml
@@ -956,7 +956,7 @@ let entry_actions_for ~prev_phase ~new_phase ~(event : event) : entry_action lis
    This helper enforces a subset of those preconditions at the
    [apply_event] boundary so silent corruption becomes a typed
    [Precondition_violation] result.  Coverage extended incrementally
-   across the spec/code refinement chain (R-A-9):
+   across the spec/code refinement chain (R-A-9, then R-A-6.b):
      - PR-1: Compact_retry_exhausted (latch correctness)
      - PR-2: Context_overflow_detected, Auto_compact_triggered (overflow
        lifecycle — the two events that drive Overflowed↔Compacting)
@@ -964,10 +964,11 @@ let entry_actions_for ~prev_phase ~new_phase ~(event : event) : entry_action lis
        exclusivity).  Operator_clear_requested is deliberately *not*
        arm-enforced beyond the terminal guard — see its arm below for
        the operator escape-hatch rationale.
+     - R-A-6.b: Restart_budget_exhausted (non-idempotency — pairs with
+       §S3 BudgetNeverRevives liveness invariant; iter 14 audit).
 
-   Coverage closed at 5/5 R-A-9 events as of PR-3.  Other events have
-   no spec preconditions beyond NotTerminal and fall through the
-   catch-all.
+   Coverage at 6/6 enumerated R-A-9 events.  Other events have no spec
+   preconditions beyond NotTerminal and fall through the catch-all.
 
    Background:
      - iter 9 audit memo: docs/tla-audit/ksm-precondition-enforcement-gap-2026-05-12.md
@@ -1104,6 +1105,30 @@ let check_event_precondition (c : conditions) (ev : event)
        to make the deliberate minimal precondition explicit — adding any
        check beyond NotTerminal would weaken the operator escape-hatch. *)
     Ok ()
+  | Restart_budget_exhausted ->
+    (* TLA+ §RestartBudgetExhausted requires [restart_budget_remaining];
+       re-exhausting an already-exhausted budget is a logical no-op in
+       isolation, but masks a duplicate dispatch in the caller and —
+       paired with the §S3 [BudgetNeverRevives] invariant — indicates
+       the supervisor's restart-vs-mark-dead gate was bypassed.
+
+       This is the 6th R-A-9 candidate, identified in iter 14 audit
+       memo `docs/tla-audit/ksm-a6-budget-never-revives-2026-05-12.md`
+       — same systematic gap class as the 5 events in iter 9's
+       original enumeration. *)
+    if not c.restart_budget_remaining
+    then
+      Error
+        (Precondition_violation
+           { event = event_to_string ev
+           ; reason =
+               "TLA+ §RestartBudgetExhausted requires \
+                restart_budget_remaining=true; re-exhausting an already-\
+                exhausted budget masks a duplicate dispatch and \
+                signals the supervisor's restart-vs-mark-dead gate \
+                may have been bypassed (see §S3 BudgetNeverRevives)"
+           })
+    else Ok ()
   (* Other events have no TLA+ state preconditions beyond what
      [apply_event]'s terminal guard already enforces; their semantics
      are encoded in [update_conditions] + [derive_phase] (e.g.

--- a/test/test_keeper_state_machine.ml
+++ b/test/test_keeper_state_machine.ml
@@ -2947,7 +2947,7 @@ let test_pre_operator_clear_no_extra_precondition () =
     ()
 ;;
 
-(* — Restart_budget_exhausted (R-A-6.b — 6th R-A-9 event) ─── *)
+(* — Restart_budget_exhausted (R-A-6.b — adjacent arm, not R-A-9) ─── *)
 
 let test_pre_restart_budget_already_exhausted () =
   (* Pairs with §S3 BudgetNeverRevives: re-exhausting an already-cleared

--- a/test/test_keeper_state_machine.ml
+++ b/test/test_keeper_state_machine.ml
@@ -2947,6 +2947,23 @@ let test_pre_operator_clear_no_extra_precondition () =
     ()
 ;;
 
+(* — Restart_budget_exhausted (R-A-6.b — 6th R-A-9 event) ─── *)
+
+let test_pre_restart_budget_already_exhausted () =
+  (* Pairs with §S3 BudgetNeverRevives: re-exhausting an already-cleared
+     budget is masked as a no-op by [update_conditions] (the unconditional
+     [false] write), but signals a duplicate dispatch from the supervisor
+     or operator path. *)
+  let c = { running_conditions with restart_budget_remaining = false } in
+  let err =
+    apply_err
+      ~current_phase:SM.Crashed
+      ~conditions:c
+      ~event:SM.Restart_budget_exhausted
+  in
+  assert_precondition_violation ~event_name:"restart_budget_exhausted" err
+;;
+
 (* ── Test suite ────────────────────────────────────────── *)
 
 let () =
@@ -3318,6 +3335,10 @@ let () =
             "Operator_clear_requested is escape-hatch (no extra precondition)"
             `Quick
             test_pre_operator_clear_no_extra_precondition
+        ; test_case
+            "Restart_budget_exhausted is non-idempotent (R-A-6.b)"
+            `Quick
+            test_pre_restart_budget_already_exhausted
         ] )
     ]
 ;;

--- a/test/test_keeper_state_machine.ml
+++ b/test/test_keeper_state_machine.ml
@@ -2783,6 +2783,170 @@ let test_attribution_gate_and_origin_invariant () =
     cases
 ;;
 
+(* ── Precondition layer negative tests (R-A-9 wrap-up) ──
+
+   Each event covered by [check_event_precondition] gets one test per
+   spec-declared misuse vector.  The arms encode TLA+ §CompactRetryExhausted,
+   §ContextOverflowDetected, §AutoCompactTriggered, §OperatorCompactRequested.
+   Operator_clear_requested has no extra precondition (escape-hatch) — we
+   verify it accepts even an unusual condition state. *)
+
+let overflowed_conditions : SM.conditions =
+  { running_conditions with context_overflow = true }
+;;
+
+(* [event_to_string] for payload-carrying events appends the payload
+   (e.g. "context_overflow_detected(prompt_rejected,...)"), so we use
+   prefix match rather than equality. *)
+let assert_precondition_violation ~event_name err =
+  match err with
+  | SM.Precondition_violation { event; reason = _ } ->
+    check
+      bool
+      ("event name prefix " ^ event_name ^ " in " ^ event)
+      true
+      (Astring.String.is_prefix ~affix:event_name event)
+  | other ->
+    Alcotest.fail
+      ("expected Precondition_violation, got " ^ SM.transition_error_to_string other)
+;;
+
+(* — Compact_retry_exhausted (PR-1) ─────────────────────── *)
+
+let test_pre_compact_retry_no_overflow () =
+  let err =
+    apply_err
+      ~current_phase:SM.Running
+      ~conditions:running_conditions
+      ~event:SM.Compact_retry_exhausted
+  in
+  assert_precondition_violation ~event_name:"compact_retry_exhausted" err
+;;
+
+let test_pre_compact_retry_compaction_active () =
+  let c = { overflowed_conditions with compaction_active = true } in
+  let err =
+    apply_err ~current_phase:SM.Compacting ~conditions:c ~event:SM.Compact_retry_exhausted
+  in
+  assert_precondition_violation ~event_name:"compact_retry_exhausted" err
+;;
+
+let test_pre_compact_retry_already_exhausted () =
+  let c = { overflowed_conditions with compact_retry_exhausted = true } in
+  let err =
+    apply_err ~current_phase:SM.Paused ~conditions:c ~event:SM.Compact_retry_exhausted
+  in
+  assert_precondition_violation ~event_name:"compact_retry_exhausted" err
+;;
+
+(* — Context_overflow_detected (PR-2) ─────────────────────── *)
+
+let overflow_event =
+  SM.Context_overflow_detected
+    { source = `Prompt_rejected; token_count = 100_000; limit_tokens = Some 200_000 }
+;;
+
+let test_pre_overflow_during_compaction () =
+  let c = { running_conditions with compaction_active = true } in
+  let err = apply_err ~current_phase:SM.Compacting ~conditions:c ~event:overflow_event in
+  assert_precondition_violation ~event_name:"context_overflow_detected" err
+;;
+
+(* — Auto_compact_triggered (PR-2) ─────────────────────── *)
+
+let test_pre_auto_compact_no_overflow () =
+  let err =
+    apply_err
+      ~current_phase:SM.Running
+      ~conditions:running_conditions
+      ~event:SM.Auto_compact_triggered
+  in
+  assert_precondition_violation ~event_name:"auto_compact_triggered" err
+;;
+
+let test_pre_auto_compact_active () =
+  let c = { overflowed_conditions with compaction_active = true } in
+  let err =
+    apply_err ~current_phase:SM.Compacting ~conditions:c ~event:SM.Auto_compact_triggered
+  in
+  assert_precondition_violation ~event_name:"auto_compact_triggered" err
+;;
+
+let test_pre_auto_compact_handoff_active () =
+  let c = { overflowed_conditions with handoff_active = true } in
+  let err =
+    apply_err ~current_phase:SM.HandingOff ~conditions:c ~event:SM.Auto_compact_triggered
+  in
+  assert_precondition_violation ~event_name:"auto_compact_triggered" err
+;;
+
+let test_pre_auto_compact_retry_exhausted () =
+  let c = { overflowed_conditions with compact_retry_exhausted = true } in
+  let err =
+    apply_err ~current_phase:SM.Paused ~conditions:c ~event:SM.Auto_compact_triggered
+  in
+  assert_precondition_violation ~event_name:"auto_compact_triggered" err
+;;
+
+(* — Operator_compact_requested (PR-3) ─────────────────────── *)
+
+let test_pre_operator_compact_during_compaction () =
+  let c = { running_conditions with compaction_active = true } in
+  let err =
+    apply_err
+      ~current_phase:SM.Compacting
+      ~conditions:c
+      ~event:SM.Operator_compact_requested
+  in
+  assert_precondition_violation ~event_name:"operator_compact_requested" err
+;;
+
+let test_pre_operator_compact_during_handoff () =
+  let c = { running_conditions with handoff_active = true } in
+  let err =
+    apply_err
+      ~current_phase:SM.HandingOff
+      ~conditions:c
+      ~event:SM.Operator_compact_requested
+  in
+  assert_precondition_violation ~event_name:"operator_compact_requested" err
+;;
+
+(* — Operator_clear_requested (PR-3 escape-hatch) ────────────
+
+   Deliberate no-arm: the precondition layer never rejects this event.
+   Whether the resulting state transition is matrix-valid is a separate
+   FSM concern; the contract under test here is *only* that the
+   precondition arm doesn't surface Precondition_violation.
+
+   We exercise a misuse-shaped condition state (overflow + retry-latched)
+   that would block Compact_retry_exhausted or Auto_compact_triggered,
+   and check that Operator_clear_requested still slips through the
+   precondition layer. *)
+let test_pre_operator_clear_no_extra_precondition () =
+  let c =
+    { running_conditions with
+      context_overflow = true
+    ; compact_retry_exhausted = true
+    }
+  in
+  let clear_event =
+    SM.Operator_clear_requested
+      { preserve_system = false; reason = "operator escape-hatch" }
+  in
+  match
+    SM.apply_event ~current_phase:SM.Running ~conditions:c ~event:clear_event ~now:0.0
+  with
+  | Ok _ -> ()
+  | Error (SM.Precondition_violation { event; _ }) ->
+    Alcotest.fail
+      ("Operator_clear_requested escape-hatch contract violated — \
+        precondition layer rejected with event=" ^ event)
+  | Error _ ->
+    (* Matrix or terminal errors are out of scope for this test. *)
+    ()
+;;
+
 (* ── Test suite ────────────────────────────────────────── *)
 
 let () =
@@ -3108,6 +3272,52 @@ let () =
             "gate=keeper_fsm origin=Det invariant"
             `Quick
             test_attribution_gate_and_origin_invariant
+        ] )
+    ; ( "precondition_layer"
+      , [ test_case
+            "Compact_retry_exhausted requires context_overflow"
+            `Quick
+            test_pre_compact_retry_no_overflow
+        ; test_case
+            "Compact_retry_exhausted requires ~compaction_active"
+            `Quick
+            test_pre_compact_retry_compaction_active
+        ; test_case
+            "Compact_retry_exhausted is non-idempotent (~already_exhausted)"
+            `Quick
+            test_pre_compact_retry_already_exhausted
+        ; test_case
+            "Context_overflow_detected requires ~compaction_active"
+            `Quick
+            test_pre_overflow_during_compaction
+        ; test_case
+            "Auto_compact_triggered requires context_overflow"
+            `Quick
+            test_pre_auto_compact_no_overflow
+        ; test_case
+            "Auto_compact_triggered requires ~compaction_active"
+            `Quick
+            test_pre_auto_compact_active
+        ; test_case
+            "Auto_compact_triggered requires ~handoff_active"
+            `Quick
+            test_pre_auto_compact_handoff_active
+        ; test_case
+            "Auto_compact_triggered requires ~compact_retry_exhausted (#8581)"
+            `Quick
+            test_pre_auto_compact_retry_exhausted
+        ; test_case
+            "Operator_compact_requested requires ~compaction_active"
+            `Quick
+            test_pre_operator_compact_during_compaction
+        ; test_case
+            "Operator_compact_requested requires ~handoff_active"
+            `Quick
+            test_pre_operator_compact_during_handoff
+        ; test_case
+            "Operator_clear_requested is escape-hatch (no extra precondition)"
+            `Quick
+            test_pre_operator_clear_no_extra_precondition
         ] )
     ]
 ;;


### PR DESCRIPTION
## Finding (Iteration 11, Phase R-A-9 PR-2)

**Spec**: `specs/keeper-state-machine/KeeperStateMachine.tla` §411-436 (`ContextOverflowDetected`, `AutoCompactTriggered`)
**OCaml**: `lib/keeper/keeper_state_machine.ml` (`check_event_precondition`, +69/-8 LOC)
**Aspect**: 2개 신규 precondition arm — overflow 라이프사이클 핵심 이벤트 쌍의 silent corruption 차단.
**Risk**: MID (layer가 PR-1에서 자리 잡힘; 본 PR은 helper-internal add-only)
**Workaround signature**: N/A (R-A-9 RFC follow-through; PR body에 일관 인용)
**Stack**: base = `feat/ksm-apply-event-precondition-layer` (PR #14735). PR-1 머지 후 main으로 자동 rebase.

## 순서도

### Overflow lifecycle event 체인 (TLA+ Next disjunct §497-498)

```mermaid
stateDiagram-v2
    [*] --> Running
    Running --> Overflowed: Context_overflow_detected\nprecond: ~compaction_active
    Overflowed --> Compacting: Auto_compact_triggered\nprecond: context_overflow ∧ ~compaction_active\n         ∧ ~handoff_active ∧ ~compact_retry_exhausted
    Compacting --> Running: Compaction_completed (savings>0)
    Compacting --> Overflowed: Compaction_completed (savings≤0)\nor Compaction_failed
    Overflowed --> Paused: Compact_retry_exhausted (PR-1 covered)
    note right of Overflowed
      misuse vectors (now rejected):
      • Context_overflow_detected when compaction_active=true
        → conflates two attempts
      • Auto_compact_triggered without context_overflow
        → flips compaction_active outside Overflowed
      • Auto_compact_triggered when retry budget spent
        → defeats Issue #8581 latch
    end note
```

## Before / After

### Before — helper covered only `Compact_retry_exhausted` (1 of 5 events)

```ocaml
let check_event_precondition (c : conditions) (ev : event) =
  match ev with
  | Compact_retry_exhausted -> ...  (* 3 conditions *)
  | _ -> Ok ()  (* 4 events silently corrupt-able *)
```

### After — coverage extended to 3 of 5 events

```ocaml
let check_event_precondition (c : conditions) (ev : event) =
  match ev with
  | Compact_retry_exhausted -> ...
  | Context_overflow_detected _ ->
    if c.compaction_active then Error (Precondition_violation {...})
    else Ok ()
  | Auto_compact_triggered ->
    if not c.context_overflow then Error ...
    else if c.compaction_active then Error ...
    else if c.handoff_active then Error ...
    else if c.compact_retry_exhausted then Error ...
    else Ok ()
  | _ -> Ok ()  (* 2 events remaining — PR-3 *)
```

## 왜 톱니처럼 정교하지 않은가 (이번 PR에서 닫힌 silent vectors)

iter 9 audit memo가 enumerate한 5 silent corruption 시나리오 중 본 PR이 닫은 3건:

1. **Overflow during in-flight compaction → state confusion**
   - `Context_overflow_detected` while `compaction_active=true` → 두 개의 overflow attempt가 logical하게 한 phase에 공존. TLA+은 `~compaction_active`로 이를 금지.
   - 본 PR: typed reject.

2. **Auto-compact on non-overflowed keeper → unscoped compaction**
   - `Auto_compact_triggered` without `context_overflow=true` → DerivePhase가 의도하지 않은 Compacting 진입. Overflowed→Compacting 전이 invariant 위반.
   - 본 PR: typed reject.

3. **Auto-compact after retry budget exhausted → Issue #8581 latch 무력화**
   - `Auto_compact_triggered` while `compact_retry_exhausted=true` → DerivePhase가 다음 overflow를 Paused로 라우팅하려는데 latch가 다시 풀림. PR-1에서 latch correctness 보호했고, 본 PR은 latch 해제 경로 자체를 차단.
   - 본 PR: typed reject.

## 본 PR 수정 (mechanical add-only)

| 변경 | 위치 |
|---|---|
| `Context_overflow_detected _` arm 추가 | `lib/keeper/keeper_state_machine.ml:1005-1018` |
| `Auto_compact_triggered` arm 추가 (4 conditions) | `lib/keeper/keeper_state_machine.ml:1019-1062` |
| helper docstring 업데이트 (3-of-5 → coverage chain 명시) | `lib/keeper/keeper_state_machine.ml:956-970` |

**무엇이 *바뀌지 않았는가***:
- `transition_error` variant — PR-1에서 추가됨, exhaustive match arm 모두 그대로.
- `apply_event` dispatch — `check_event_precondition` 호출 자리 그대로.
- `keeper_registry.ml` — `reason_label` 매치 arm 그대로 (`Precondition_violation -> "precondition_violation"`).
- chaos 테스트 — `dispatch_expect_rejected`의 closed match arm 그대로.

이게 PR-1의 layer foothold 설계가 검증됐다는 뜻 — variant + helper signature + dispatch가 한 번 자리 잡히니 새 event는 helper에 한 case 추가만으로 끝남.

## Verification

- [x] `dune build --root . @check` — clean (silent success).
- [x] `dune exec --root . test/test_keeper_state_machine.exe` — **114 tests pass** (includes PR-1's 3 attribution test arms).
- [x] `dune exec --root . test/test_keeper_lifecycle_chaos.exe` — **10 tests pass** (closed match에 `Precondition_violation _` arm 이미 있음, fleet/compaction/handoff/pause/shutdown 시나리오 모두 회귀 없음).
- [ ] CI 후 별도 spec TLC verify는 R-A-8 PR-2에서 (KNOWN_FAILURES #8710 해제 시점 매치).

## Trade-off / 후속 PR

- **PR-3 후보 (R-A-9 마지막)**: `Operator_compact_requested`, `Operator_clear_requested`. spec §455-466은 OperatorClearRequested가 `OperatorCompactRequested`보다 더 permissive (NotTerminal만 요구) — operator escape-hatch 의도 보존하려고 OCaml에서도 같은 minimal precondition.
- **Negative test 추가**: PR-3 또는 R-A-9 wrap-up PR에서 5종 misuse scenario 모두 unit test로. 본 PR은 layer extension에 집중.
- **R-A-8 PR-2 (TLC verify + KNOWN_FAILURES 제거)**: 본 stack과 독립. R-A-9 layer가 안정화되면 R-A-8 PR-2 진행 시 PauseAfterRetryExhaustion property가 active로.

## RFC 참조

- R-A-9 (apply_event precondition layer) — local RFC backlog 항목, iter 9에서 식별. 본 PR이 PR-2/3 사이클 절반 진행.
- `RFC-WAIVED`: credential / identity / operator-control / sandbox / hooks 범위 밖. `bash scripts/pr-rfc-check.sh` matches 없음 (keeper FSM 내부 precondition tightening).

## 진행 추적

다음 iteration 시작점: **R-A-9 PR-3** (Operator_compact_requested + Operator_clear_requested) 또는 **R-A-8 PR-2** (KeeperStateMachine TLC re-verify + KNOWN_FAILURES purge).

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
