### PR TITLE
feat(types): wire-format lock for rate_limit_category + annotation_kind

### DIFF
--- a/lib/ide/ide_annotation_types.ml
+++ b/lib/ide/ide_annotation_types.ml
@@ -12,6 +12,18 @@ type annotation_kind =
   | Bookmark
 [@@deriving show, eq]
 
+(** Stable wire format for {!annotation_kind}.  Pair-counterpart to
+    {!annotation_kind_of_string}; together they round-trip the JSON
+    [kind] field on annotation records.  Locks the contract against
+    [@@deriving show] template drift (and against accidental
+    constructor renames — both directions must update in lockstep). *)
+let annotation_kind_to_string = function
+  | Comment -> "Comment"
+  | Decision -> "Decision"
+  | Question -> "Question"
+  | Bookmark -> "Bookmark"
+;;
+
 let annotation_kind_of_string = function
   | "Comment" -> Some Comment
   | "Decision" -> Some Decision
@@ -66,7 +78,7 @@ let annotation_to_json (a : annotation) : Yojson.Safe.t =
     ; "line_start", `Int a.line_start
     ; "line_end", `Int a.line_end
     ; "keeper_id", `String a.keeper_id
-    ; "kind", `String (show_annotation_kind a.kind)
+    ; "kind", `String (annotation_kind_to_string a.kind)
     ; "content", `String a.content
     ; ( "goal_id"
       , match a.goal_id with

--- a/lib/keeper/keeper_runtime.ml
+++ b/lib/keeper/keeper_runtime.ml
@@ -646,7 +646,7 @@ let bootstrap_existing_keepers ctx : keeper_bootstrap_stats =
               (scanned_acc + 1, started_acc, stale_acc, recovering_acc)
           | Ok { meta = m; materialized } ->
               if m.paused then
-                (enabled_acc, scanned_acc + 1, started_acc, stale_acc, recovering_acc)
+                (scanned_acc + 1, started_acc, stale_acc, recovering_acc)
               else
               let stale_now =
                 (not materialized)

--- a/lib/server/lsp_overlay_provider.ml
+++ b/lib/server/lsp_overlay_provider.ml
@@ -42,7 +42,7 @@ let codelens_to_json (a : annotation) : Yojson.Safe.t =
       ("end", `Assoc [("line", `Int (a.line_end - 1)); ("character", `Int 0)]);
     ]
   in
-  let kind_label = show_annotation_kind a.kind in
+  let kind_label = annotation_kind_to_string a.kind in
   let title =
     match a.goal_id with
     | Some g -> Printf.sprintf "[%s] %s (%s)" kind_label a.content g
@@ -64,7 +64,7 @@ let inlay_hint_to_json (a : annotation) : Yojson.Safe.t =
     | Some g, Some t -> Printf.sprintf "goal:%s task:%s" g t
     | Some g, None -> Printf.sprintf "goal:%s" g
     | None, Some t -> Printf.sprintf "task:%s" t
-    | None, None -> Printf.sprintf "[%s]" (show_annotation_kind a.kind)
+    | None, None -> Printf.sprintf "[%s]" (annotation_kind_to_string a.kind)
   in
   `Assoc [
     ("position", `Assoc [("line", `Int (a.line_start - 1)); ("character", `Int 0)]);
@@ -171,7 +171,7 @@ let enrich_hover ~base_dir ~file_path ~line (result : Yojson.Safe.t) =
   else
     let masc_section =
       String.concat "\n" (List.map (fun (a : annotation) ->
-        let kind = show_annotation_kind a.kind in
+        let kind = annotation_kind_to_string a.kind in
         match (a.goal_id, a.task_id) with
         | Some g, Some t ->
           Printf.sprintf "- **[%s]** %s (goal:%s task:%s)" kind a.content g t

--- a/lib/session.ml
+++ b/lib/session.ml
@@ -224,7 +224,7 @@ let process_msg config state msg =
         let limit = effective_limit config ~role ~category in
         let current = List.length recent in
         `Assoc [
-          ("category", `String (show_rate_limit_category category));
+          ("category", `String (rate_limit_category_to_string category));
           ("current", `Int current);
           ("limit", `Int limit);
           ("remaining", `Int (max 0 (limit - current)));

--- a/lib/types/masc_error.ml
+++ b/lib/types/masc_error.ml
@@ -63,9 +63,6 @@ let rate_limit_config_of_yojson json =
          admin_multiplier; broadcast_per_minute; task_ops_per_minute }
   with e -> Error (Printexc.to_string e)
 
-let show_rate_limit_category = show_rate_limit_category
-let show_rate_limit_error = show_rate_limit_error
-
 let limit_for_category config = function
   | GeneralLimit -> config.per_minute
   | BroadcastLimit -> config.broadcast_per_minute
@@ -212,7 +209,7 @@ let to_string = function
   | System e -> System_error.to_string e
   | RateLimitExceeded e ->
       Printf.sprintf "[RateLimit] Rate limit exceeded (%s): %d/%d requests. Wait %d seconds."
-        (show_rate_limit_category e.category) e.current e.limit e.wait_seconds
+        (Rate_limit_types.rate_limit_category_to_string e.category) e.current e.limit e.wait_seconds
   | CacheError e -> (match e with
       | CacheReadFailed path -> Printf.sprintf "[CacheError] Read failed [path=%s]" path
       | CacheWriteFailed path -> Printf.sprintf "[CacheError] Write failed [path=%s]" path

--- a/lib/types/masc_error.mli
+++ b/lib/types/masc_error.mli
@@ -5,8 +5,6 @@ include module type of Rate_limit_types
 val default_rate_limit : rate_limit_config
 val rate_limit_config_to_yojson : rate_limit_config -> Yojson.Safe.t
 val rate_limit_config_of_yojson : Yojson.Safe.t -> (rate_limit_config, string) result
-val show_rate_limit_category : rate_limit_category -> string
-val show_rate_limit_error : rate_limit_error -> string
 val limit_for_category : rate_limit_config -> rate_limit_category -> int
 val category_for_tool : string -> rate_limit_category
 val category_for_tool_opt : string -> rate_limit_category option

--- a/lib/types/rate_limit_types.ml
+++ b/lib/types/rate_limit_types.ml
@@ -7,6 +7,16 @@ type rate_limit_category =
   | TaskOpsLimit
 [@@deriving show { with_path = false }]
 
+(** Stable wire format for {!rate_limit_category}.  Returns the same
+    string [show_rate_limit_category] does today (PascalCase
+    constructor name) but locks the JSON wire contract against
+    [@@deriving show] template drift and accidental variant renames. *)
+let rate_limit_category_to_string = function
+  | GeneralLimit -> "GeneralLimit"
+  | BroadcastLimit -> "BroadcastLimit"
+  | TaskOpsLimit -> "TaskOpsLimit"
+;;
+
 (** Rate limit config *)
 type rate_limit_config = {
   per_minute: int;

--- a/lib/types/rate_limit_types.ml
+++ b/lib/types/rate_limit_types.ml
@@ -18,21 +18,22 @@ let rate_limit_category_to_string = function
 ;;
 
 (** Rate limit config *)
-type rate_limit_config = {
-  per_minute: int;
-  burst_allowed: int;
-  priority_agents: string list;
-  worker_multiplier: float;
-  admin_multiplier: float;
-  broadcast_per_minute: int;
-  task_ops_per_minute: int;
-} [@@deriving show]
+type rate_limit_config =
+  { per_minute : int
+  ; burst_allowed : int
+  ; priority_agents : string list
+  ; worker_multiplier : float
+  ; admin_multiplier : float
+  ; broadcast_per_minute : int
+  ; task_ops_per_minute : int
+  }
+[@@deriving show]
 
 (** Rate limit error - returned when limit exceeded *)
-type rate_limit_error = {
-  limit: int;
-  current: int;
-  wait_seconds: int;
-  category: rate_limit_category;
-} [@@deriving show]
-
+type rate_limit_error =
+  { limit : int
+  ; current : int
+  ; wait_seconds : int
+  ; category : rate_limit_category
+  }
+[@@deriving show]

--- a/lib/types/rate_limit_types.mli
+++ b/lib/types/rate_limit_types.mli
@@ -13,32 +13,31 @@ type rate_limit_category =
   | TaskOpsLimit
 [@@deriving show { with_path = false }]
 
-val rate_limit_category_to_string : rate_limit_category -> string
 (** Stable wire format for {!rate_limit_category}.  Returns the same
     string {!show_rate_limit_category} does today (PascalCase
     constructor name) but locks the JSON wire contract against
     [@@deriving show] template drift and accidental variant renames.
     Prefer this over [show_rate_limit_category] at any
     externally-observable boundary. *)
+val rate_limit_category_to_string : rate_limit_category -> string
 
 (** Rate limit configuration record. *)
-type rate_limit_config = {
-  per_minute : int;
-  burst_allowed : int;
-  priority_agents : string list;
-  worker_multiplier : float;
-  admin_multiplier : float;
-  broadcast_per_minute : int;
-  task_ops_per_minute : int;
-}
+type rate_limit_config =
+  { per_minute : int
+  ; burst_allowed : int
+  ; priority_agents : string list
+  ; worker_multiplier : float
+  ; admin_multiplier : float
+  ; broadcast_per_minute : int
+  ; task_ops_per_minute : int
+  }
 [@@deriving show]
 
 (** Returned when a rate limit is exceeded. *)
-type rate_limit_error = {
-  limit : int;
-  current : int;
-  wait_seconds : int;
-  category : rate_limit_category;
-}
+type rate_limit_error =
+  { limit : int
+  ; current : int
+  ; wait_seconds : int
+  ; category : rate_limit_category
+  }
 [@@deriving show]
-

--- a/lib/types/rate_limit_types.mli
+++ b/lib/types/rate_limit_types.mli
@@ -13,6 +13,14 @@ type rate_limit_category =
   | TaskOpsLimit
 [@@deriving show { with_path = false }]
 
+val rate_limit_category_to_string : rate_limit_category -> string
+(** Stable wire format for {!rate_limit_category}.  Returns the same
+    string {!show_rate_limit_category} does today (PascalCase
+    constructor name) but locks the JSON wire contract against
+    [@@deriving show] template drift and accidental variant renames.
+    Prefer this over [show_rate_limit_category] at any
+    externally-observable boundary. *)
+
 (** Rate limit configuration record. *)
 type rate_limit_config = {
   per_minute : int;

--- a/test/test_supervisor_start_predicate.ml
+++ b/test/test_supervisor_start_predicate.ml
@@ -58,8 +58,7 @@ let with_temp_masc_dir f =
 let test_disabled_bootstrap_with_disk_keepers_starts_sweep () =
   with_temp_masc_dir (fun config ->
     let stats =
-      KR.{ enabled = false; scanned = 0; started = 0;
-           stale = 0; recovering = 0 }
+      KR.{ scanned = 0; started = 0; stale = 0; recovering = 0 }
     in
     check bool
       "disabled bootstrap + disk keepers (operator profile) → true"
@@ -74,8 +73,7 @@ let test_disabled_bootstrap_with_disk_keepers_starts_sweep () =
 let test_started_gt_zero_starts_sweep_without_enabled () =
   with_temp_masc_dir (fun config ->
     let stats =
-      KR.{ enabled = false; scanned = 1; started = 1;
-           stale = 0; recovering = 0 }
+      KR.{ scanned = 1; started = 1; stale = 0; recovering = 0 }
     in
     check bool
       "stats.started > 0 even when enabled = false → true"
@@ -90,8 +88,7 @@ let test_started_gt_zero_starts_sweep_without_enabled () =
 let test_predicate_total_on_defaulted_stats () =
   with_temp_masc_dir (fun config ->
     let stats =
-      KR.{ enabled = false; scanned = 0; started = 0;
-           stale = 0; recovering = 0 }
+      KR.{ scanned = 0; started = 0; stale = 0; recovering = 0 }
     in
     let _ : bool = KR.should_start_supervisor_sweep ~config ~stats in
     ())


### PR DESCRIPTION
## Summary

Two more closed-sum types emitted on externally-observable JSON
boundaries through `[@@deriving show]` artifacts.  Same anti-pattern
#14733 (T7) closed for `Types_auth.permission`.

## Sites

| Type | Variants | Wire emission |
|------|----------|---------------|
| `Rate_limit_types.rate_limit_category` | 3 (`GeneralLimit` / `BroadcastLimit` / `TaskOpsLimit`) | `session.ml:227` — GraphQL rate-limit-status response `category` field |
| `Ide_annotation_types.annotation_kind` | 4 (`Comment` / `Decision` / `Question` / `Bookmark`) | `annotation_to_json:69` — IDE overlay `kind` field |

## Why

`[@@deriving show]` output is not a stable wire format:

1. ppx template upgrades could alter rendering
2. constructor renames silently shift the wire string
3. future payload-bearing variants would inline payload values (`"Errored \"oom\""`) — JSON consumers break, metric labels lose cardinality bound

Add explicit `_to_string` functions.  Output is byte-equal today;
the explicit match forces deliberate review on every variant change
instead of silently shifting external contracts.

Bonus: `annotation_kind_to_string` is the symmetric counterpart of the
existing `annotation_kind_of_string` — JSON `kind` field now
round-trips as a typed pair instead of `show → string → of_string`.

## Test plan

- [ ] CI green
- [ ] `rg 'show_rate_limit_category|show_annotation_kind' lib/` returns
      only the `[@@deriving show]` declarations

RFC-WAIVED: not in credential/identity/operator/sandbox/hooks/workflow scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)