### PR TITLE
perf(tool_access_role): memoize per-role policy + admin/worker tool lists

### DIFF
--- a/lib/tool_access_role.ml
+++ b/lib/tool_access_role.ml
@@ -60,11 +60,29 @@ let tools_for_required_role required_role =
          | Some permission ->
              (=) (required_role_of_permission permission) required_role)
 
+(* ── Memoization rationale ─────────────────────────────────────────
+   [tools_for_required_role] sorts ~100 tool names via
+   [List.sort_uniq] then filters each through a [permission_for_tool]
+   Hashtbl lookup.  Inputs ([Tool_permission_map.known_tool_names],
+   permission metadata, catalog surfaces) are module-init-frozen, so
+   the result is constant for the program lifetime.
+
+   [policy_for_role Worker] is called per-request from
+   [Auth.authorize_tool_for_role]; rebuilding the same selector each
+   call was pure waste.
+
+   [lazy] (instead of eager [let]) defers evaluation until first call,
+   so we read [Tool_permission_map.known_tool_names] *after* all module
+   init side effects have populated the catalog. *)
+
+let admin_only_tools_lazy = lazy (tools_for_required_role Admin_role)
+let worker_only_tools_lazy = lazy (tools_for_required_role Worker_role)
+
 (* ================================================================ *)
 (* Admin-only tools (CanInit + CanReset + CanAdmin)                 *)
 (* ================================================================ *)
 
-let admin_only_tools () = tools_for_required_role Admin_role
+let admin_only_tools () = Lazy.force admin_only_tools_lazy
 
 (* ================================================================ *)
 (* Worker-only tools (CanAddTask + CanClaimTask + CanCompleteTask + *)
@@ -72,18 +90,26 @@ let admin_only_tools () = tools_for_required_role Admin_role
 (*                    CanCreateWorktree + CanRemoveWorktree + CanVote) *)
 (* ================================================================ *)
 
-let worker_only_tools () = tools_for_required_role Worker_role
+let worker_only_tools () = Lazy.force worker_only_tools_lazy
 
 (* ================================================================ *)
 (* Role → Policy                                                     *)
 (* ================================================================ *)
 
+let admin_policy : Tool_access_policy.t =
+  { Tool_access_policy.allow = All; deny = Empty }
+
+let worker_policy_lazy : Tool_access_policy.t Lazy.t =
+  lazy
+    {
+      Tool_access_policy.allow =
+        Diff
+          { base = All
+          ; exclude = Names (Lazy.force admin_only_tools_lazy)
+          };
+      deny = Empty;
+    }
+
 let policy_for_role : Masc_domain.agent_role -> Tool_access_policy.t = function
-  | Admin ->
-      { Tool_access_policy.allow = All; deny = Empty }
-  | Worker ->
-      {
-        allow =
-          Diff { base = All; exclude = Names (admin_only_tools ()) };
-        deny = Empty;
-      }
+  | Admin -> admin_policy
+  | Worker -> Lazy.force worker_policy_lazy


### PR DESCRIPTION
## Summary

\`policy_for_role\` is hit per-request from \`Auth.authorize_tool_for_role\`. The Worker arm rebuilt a fresh \`Diff { base = All; exclude = Names (admin_only_tools ()) }\` selector every call by running \`tools_for_required_role\` over ~100 catalog tool names — \`List.sort_uniq String.compare\` (O(n log n)) + per-tool \`permission_for_tool\` Hashtbl lookup + filter. All inputs are **module-init-frozen** (catalog surfaces, permission metadata), so the result is constant for the program lifetime.

This PR replaces that re-derivation with \`lazy\` memoization:

| Name | Before | After |
|------|--------|-------|
| \`admin_only_tools ()\` | recompute each call | \`Lazy.force\` once |
| \`worker_only_tools ()\` | recompute each call | \`Lazy.force\` once |
| \`policy_for_role Admin\` | rebuild record each call | constant value |
| \`policy_for_role Worker\` | rebuild Diff/Names each call | \`Lazy.force\` once |

## Why \`lazy\` instead of eager \`let\`

\`Tool_permission_map.known_tool_names\` depends on \`Tool_catalog.registered_metadata\`, which is populated by per-module side effects during startup. Eager top-level binding could read the catalog before all registrations land. \`lazy\` defers evaluation to first call site, well after all module init.

## API preservation

\`tool_access_role.mli\` unchanged — \`admin_only_tools : unit -> string list\`, \`worker_only_tools : unit -> string list\`, \`policy_for_role : agent_role -> Tool_access_policy.t\` all keep their public signatures. The thunked \`unit -> ...\` arrow is still in place so future cache invalidation (if ever needed) doesn't require an API break.

## Thread safety

OCaml 5's \`Lazy.force\` provides memory ordering for the result write. Concurrent forces may evaluate the thunk more than once but the result is deterministic (pure read of frozen catalog state), so no correctness issue. Eio runs on OCaml 5 — fine.

## Test plan

- [ ] CI lib/ build green
- [ ] \`dune runtest test/test_tool_access_role.exe\` passes (existing tests cover Admin/Worker policy behavior on tool_name membership)

🤖 Generated with [Claude Code](https://claude.com/claude-code)