### PR TITLE
feat(cascade-decl): RFC-0058 Phase A — protocol field + R12 validation

### DIFF
--- a/lib/cascade_decl/cascade_declarative_parser.ml
+++ b/lib/cascade_decl/cascade_declarative_parser.ml
@@ -167,14 +167,17 @@ let parse_provider (id : string) (tbl : Otoml.t)
   in
   let protocol_result =
     match Otoml.find_opt tbl Otoml.get_string [ "protocol" ] with
-    | Some p -> api_format_of_protocol p
+    | Some p ->
+      (match api_format_of_protocol p with
+       | Ok fmt -> Ok (p, fmt)
+       | Error e -> Error e)
     | None -> Error "missing required field 'protocol'"
   in
   let transport_result = transport_of_provider tbl id in
   match protocol_result, transport_result with
   | Error e, _ -> Error (error (path ^ ".protocol") e)
   | _, Error e -> Error (error path e)
-  | Ok api_format, Ok transport ->
+  | Ok (protocol, api_format), Ok transport ->
     let is_non_interactive =
       Otoml.find_or ~default:false tbl Otoml.get_boolean [ "is-non-interactive" ]
     in
@@ -226,6 +229,7 @@ let parse_provider (id : string) (tbl : Otoml.t)
     Ok
       { id
       ; display_name
+      ; protocol
       ; api_format
       ; transport
       ; is_non_interactive

--- a/lib/cascade_decl/cascade_declarative_types.ml
+++ b/lib/cascade_decl/cascade_declarative_types.ml
@@ -110,6 +110,7 @@ let cascade_capabilities_default =
 type cascade_provider =
   { id : string
   ; display_name : string
+  ; protocol : string
   ; api_format : cascade_api_format
   ; transport : cascade_transport
   ; is_non_interactive : bool

--- a/lib/cascade_decl/cascade_declarative_types.mli
+++ b/lib/cascade_decl/cascade_declarative_types.mli
@@ -73,6 +73,7 @@ val cascade_capabilities_default : cascade_capabilities
 type cascade_provider =
   { id : string
   ; display_name : string
+  ; protocol : string
   ; api_format : cascade_api_format
   ; transport : cascade_transport
   ; is_non_interactive : bool

--- a/lib/cascade_decl/cascade_declarative_validator.ml
+++ b/lib/cascade_decl/cascade_declarative_validator.ml
@@ -11,7 +11,8 @@
     R8: System targets reference existing bindings or aliases
     R9: At most one is-default=true per provider
     R10: Strategy-specific fields match the declared strategy
-    R11: Binding max-concurrent required and positive (RFC-0058 §3.4) *)
+    R11: Binding max-concurrent required and positive (RFC-0058 §3.4)
+    R12: Protocol ↔ transport consistency (RFC-0058 §2.1) *)
 
 open Cascade_declarative_types
 
@@ -313,6 +314,53 @@ let validate_strategy_fields (cfg : cascade_config) : validation_error list =
    tests) now get R11 enforcement; the parser's tolerant load path
    is unchanged. *)
 
+(* --- R12: Protocol ↔ transport consistency ---
+
+   A protocol string ending in "-cli" must pair with a Cli transport,
+   and one ending in "-http" must pair with an Http transport.
+   This catches misconfigurations where, e.g., a CLI provider is
+   accidentally given an HTTP endpoint. *)
+
+let validate_protocol_transport (cfg : cascade_config) : validation_error list =
+  List.filter_map
+    (fun (p : cascade_provider) ->
+       let path = Printf.sprintf "providers.%s.protocol" p.id in
+       let expected_transport =
+         if String.length p.protocol >= 4
+            && String.sub p.protocol (String.length p.protocol - 4) 4 = "-cli"
+         then Some "Cli"
+         else if String.length p.protocol >= 5
+                 && String.sub p.protocol (String.length p.protocol - 5) 5 = "-http"
+         then Some "Http"
+         else None
+       in
+       match expected_transport with
+       | None -> None
+       | Some expected ->
+         (match p.transport with
+          | Cli _ when expected = "Cli" -> None
+          | Http _ when expected = "Http" -> None
+          | Cli _ ->
+            Some
+              { rule = "R12"
+              ; path
+              ; message =
+                  Printf.sprintf
+                    "protocol %S implies Http transport, but transport is Cli"
+                    p.protocol
+              }
+          | Http _ ->
+            Some
+              { rule = "R12"
+              ; path
+              ; message =
+                  Printf.sprintf
+                    "protocol %S implies Cli transport, but transport is Http"
+                    p.protocol
+              }))
+    cfg.providers
+;;
+
 let validate_binding_capacity (cfg : cascade_config) : validation_error list =
   List.filter_map
     (fun (b : cascade_binding) ->
@@ -343,4 +391,5 @@ let validate (cfg : cascade_config) : validation_error list =
   @ validate_single_default cfg
   @ validate_strategy_fields cfg
   @ validate_binding_capacity cfg
+  @ validate_protocol_transport cfg
 ;;

--- a/lib/cascade_decl/cascade_declarative_validator.mli
+++ b/lib/cascade_decl/cascade_declarative_validator.mli
@@ -1,10 +1,11 @@
 (** Declarative cascade config cross-reference validator (RFC-0058 v2).
 
-    [validate] checks all 11 load-time invariants (R1–R11) on a parsed
+    [validate] checks all 12 load-time invariants (R1–R12) on a parsed
     [cascade_config] and returns every error found rather than stopping
     at the first. R11 (binding max-concurrent required & positive,
-    RFC-0058 §3.4) is enforced unconditionally — RFC-0058 Phase 5.5
-    collapsed the previous laxer variant into this single entry point. *)
+    RFC-0058 §3.4) is enforced unconditionally. R12 (protocol ↔ transport
+    consistency, RFC-0058 §2.1) checks that protocol suffixes like "-cli"
+    and "-http" match the declared transport type. *)
 
 type validation_error =
   { rule : string

--- a/test/test_cascade_declarative_validator.ml
+++ b/test/test_cascade_declarative_validator.ml
@@ -629,6 +629,71 @@ sticky-ttl-ms = 600000
 
 (* --- Test suite --- *)
 
+(* --- R12: Protocol ↔ transport consistency --- *)
+
+let test_r12_cli_protocol_with_cli_transport () =
+  let toml = {|
+[providers.claude-code]
+protocol = "anthropic-cli"
+command = "claude"
+
+[models.haiku]
+max-context = 200000
+
+[claude-code.haiku]
+is-default = true
+max-concurrent = 1
+|} in
+  let errs = validate_toml toml in
+  check bool "no R12 errors" false
+    (List.exists (fun (e : validation_error) -> e.rule = "R12") errs)
+
+let test_r12_http_protocol_with_http_transport () =
+  let toml = {|
+[providers.ollama]
+protocol = "ollama-http"
+endpoint = "http://localhost:11434"
+
+[models.qwen3]
+max-context = 32768
+
+[ollama.qwen3]
+max-concurrent = 1
+|} in
+  let errs = validate_toml toml in
+  check bool "no R12 errors" false
+    (List.exists (fun (e : validation_error) -> e.rule = "R12") errs)
+
+let test_r12_cli_protocol_with_http_transport () =
+  let toml = {|
+[providers.bad]
+protocol = "anthropic-cli"
+endpoint = "http://localhost:8080"
+
+[models.m]
+max-context = 4096
+
+[bad.m]
+max-concurrent = 1
+|} in
+  let errs = validate_toml toml in
+  has_rule_at "R12" "providers.bad.protocol" errs
+
+let test_r12_http_protocol_with_cli_transport () =
+  let toml = {|
+[providers.bad]
+protocol = "openai-http"
+command = "my-cli"
+
+[models.m]
+max-context = 4096
+
+[bad.m]
+max-concurrent = 1
+|} in
+  let errs = validate_toml toml in
+  has_rule_at "R12" "providers.bad.protocol" errs
+
 let () =
   run "RFC-0058 Declarative Validator"
     [ "valid", [
@@ -679,5 +744,11 @@ let () =
         test_case "scoring on correct strategy" `Quick test_r10_scoring_on_correct_strategy;
         test_case "no strategy fields is ok" `Quick test_r10_no_strategy_fields_is_ok;
         test_case "multiple mismatches" `Quick test_r10_multiple_mismatches;
+      ];
+      "R12_protocol_transport", [
+        test_case "cli protocol with cli transport ok" `Quick test_r12_cli_protocol_with_cli_transport;
+        test_case "http protocol with http transport ok" `Quick test_r12_http_protocol_with_http_transport;
+        test_case "cli protocol with http transport mismatch" `Quick test_r12_cli_protocol_with_http_transport;
+        test_case "http protocol with cli transport mismatch" `Quick test_r12_http_protocol_with_cli_transport;
       ];
     ]


### PR DESCRIPTION
## Summary

RFC-0058 Phase A completion: add `protocol` field to `cascade_provider` and R12 validation rule for protocol ↔ transport consistency.

### Changes
- **`cascade_declarative_types.ml/mli`**: Add `protocol : string` field to `cascade_provider`
- **`cascade_declarative_parser.ml`**: Retain protocol string alongside derived `api_format` (was previously discarded)
- **`cascade_declarative_validator.ml/mli`**: Add R12 rule — protocol suffix `-cli` must pair with `Cli` transport, `-http` with `Http`
- **`test_cascade_declarative_validator.ml`**: Add 4 R12 test cases (match + mismatch for CLI and HTTP)

### Context
Part of the Provider-Free Cascade migration plan (`~/.claude/plans/rippling-mixing-rainbow.md`). Phase A makes `protocol` available for Phase C (direct TOML → transport construction, bypassing `Provider_config.t`).

### Verification
- `cascade_decl` sub-library builds clean (`dune build`)
- Full test binary blocked by pre-existing `worker_dev_tools.mli` type error (unrelated)