### PR TITLE
feat(keeper): close R-A-9 precondition layer with operator events (PR-3)

### DIFF
--- a/lib/keeper/keeper_state_machine.ml
+++ b/lib/keeper/keeper_state_machine.ml
@@ -955,13 +955,19 @@ let entry_actions_for ~prev_phase ~new_phase ~(event : event) : entry_action lis
 
    This helper enforces a subset of those preconditions at the
    [apply_event] boundary so silent corruption becomes a typed
-   [Precondition_violation] result.  Coverage extends incrementally
+   [Precondition_violation] result.  Coverage extended incrementally
    across the spec/code refinement chain (R-A-9):
      - PR-1: Compact_retry_exhausted (latch correctness)
      - PR-2: Context_overflow_detected, Auto_compact_triggered (overflow
        lifecycle — the two events that drive Overflowed↔Compacting)
-     - PR-3: Operator_compact_requested, Operator_clear_requested
-       (operator-driven buffer ops)
+     - PR-3: Operator_compact_requested (operator-driven buffer op
+       exclusivity).  Operator_clear_requested is deliberately *not*
+       arm-enforced beyond the terminal guard — see its arm below for
+       the operator escape-hatch rationale.
+
+   Coverage closed at 5/5 R-A-9 events as of PR-3.  Other events have
+   no spec preconditions beyond NotTerminal and fall through the
+   catch-all.
 
    Background:
      - iter 9 audit memo: docs/tla-audit/ksm-precondition-enforcement-gap-2026-05-12.md
@@ -1062,8 +1068,48 @@ let check_event_precondition (c : conditions) (ev : event)
                 that latch (Issue #8581 root cause)"
            })
     else Ok ()
-  (* Remaining 2 events covered in follow-up PR (R-A-9 PR-3:
-     Operator_compact_requested, Operator_clear_requested). *)
+  | Operator_compact_requested ->
+    (* TLA+ §OperatorCompactRequested.  Operator path differs from
+       AutoCompactTriggered: it does NOT require [context_overflow], so
+       an operator can pre-emptively compact a not-yet-overflowed
+       keeper.  But the two buffer-op exclusivity preconditions are
+       identical — concurrent compaction or handoff entangles ops. *)
+    if c.compaction_active
+    then
+      Error
+        (Precondition_violation
+           { event = event_to_string ev
+           ; reason =
+               "TLA+ §OperatorCompactRequested requires ~compaction_active; \
+                stacking operator-driven compaction on top of an in-flight \
+                buffer op duplicates the work and confuses the retry latch \
+                that OperatorCompactRequested clears as a side-effect"
+           })
+    else if c.handoff_active
+    then
+      Error
+        (Precondition_violation
+           { event = event_to_string ev
+           ; reason =
+               "TLA+ §OperatorCompactRequested requires ~handoff_active; \
+                handoff already owns the buffer, so a concurrent operator \
+                compaction would race on the same keeper context"
+           })
+    else Ok ()
+  | Operator_clear_requested _ ->
+    (* TLA+ §OperatorClearRequested deliberately requires only NotTerminal
+       (lib §masc_keeper_clear: "Last-resort: operator drops the keeper's
+       context entirely").  The terminal guard at the top of [apply_event]
+       already enforces this, so no extra arm is needed here.  Documented
+       to make the deliberate minimal precondition explicit — adding any
+       check beyond NotTerminal would weaken the operator escape-hatch. *)
+    Ok ()
+  (* Other events have no TLA+ state preconditions beyond what
+     [apply_event]'s terminal guard already enforces; their semantics
+     are encoded in [update_conditions] + [derive_phase] (e.g.
+     [Heartbeat_failed] always flips [heartbeat_healthy] to false
+     regardless of prior state).  Adding speculative arms here would
+     drift from the spec. *)
   | _ -> Ok ()
 ;;
 


### PR DESCRIPTION
## Finding (Iteration 12, Phase R-A-9 PR-3 — layer close)

**Spec**: `specs/keeper-state-machine/KeeperStateMachine.tla` §453-478 (`OperatorCompactRequested`, `OperatorClearRequested`)
**OCaml**: `lib/keeper/keeper_state_machine.ml` (`check_event_precondition`, +51/-5 LOC)
**Aspect**: R-A-9 layer 마무리 — operator path 2개 이벤트 arm. `Operator_compact_requested`는 2 condition typed reject, `Operator_clear_requested`는 의도된 escape-hatch로 명시 (no-arm + 문서화).
**Risk**: LOW (operator path; PR-1/PR-2와 동일한 helper-internal add-only)
**Workaround signature**: N/A (R-A-9 RFC follow-through)
**Stack**: base = `feature/r-a-9-pr-2-precondition-arms` (PR #14738). PR-1/PR-2 머지 후 main으로 자동 rebase.

## 순서도

### R-A-9 layer coverage 5/5 closed

```mermaid
stateDiagram-v2
    [*] --> Running
    Running --> Overflowed: Context_overflow_detected (PR-2)\nprecond: ~compaction_active
    Overflowed --> Compacting: Auto_compact_triggered (PR-2)\n4 conditions
    Compacting --> Running: Compaction_completed (savings>0)
    Compacting --> Overflowed: Compaction_completed (savings≤0)
    Overflowed --> Paused: Compact_retry_exhausted (PR-1)\n3 conditions
    Compacting --> Compacting: Operator_compact_requested (PR-3)\nprecond: ~compaction_active ∧ ~handoff_active\n        (no context_overflow needed)
    Overflowed --> Running: Operator_clear_requested (PR-3)\nprecond: NotTerminal only\n        (deliberate escape-hatch — no arm beyond top-level guard)
    note right of Compacting
      operator-driven path differs from auto:
      • operator MAY pre-emptively compact
        (no context_overflow required)
      • operator clears retry latch as side-effect
      • but buffer-op exclusivity preserved:
        ~compaction_active ∧ ~handoff_active
    end note
```

## Before / After

### Before — `_ -> Ok ()` swallowed 2 remaining events

```ocaml
let check_event_precondition (c : conditions) (ev : event) =
  match ev with
  | Compact_retry_exhausted -> ...        (* PR-1, 3 conditions *)
  | Context_overflow_detected _ -> ...    (* PR-2, 1 condition *)
  | Auto_compact_triggered -> ...         (* PR-2, 4 conditions *)
  | _ -> Ok ()                            (* swallows Operator_*: silent *)
```

### After — R-A-9 5/5 covered, catch-all narrowed

```ocaml
let check_event_precondition (c : conditions) (ev : event) =
  match ev with
  | Compact_retry_exhausted -> ...
  | Context_overflow_detected _ -> ...
  | Auto_compact_triggered -> ...
  | Operator_compact_requested ->
    if c.compaction_active then Error ...
    else if c.handoff_active then Error ...
    else Ok ()
  | Operator_clear_requested _ ->
    (* deliberate no-arm — operator escape-hatch. NotTerminal already
       enforced by apply_event's terminal guard. Documented arm so a
       future contributor doesn't tighten under wrong impression. *)
    Ok ()
  | _ -> Ok ()  (* events with no TLA+ state precondition *)
```

## 왜 톱니처럼 정교하지 않은가 (이번 PR이 닫은 silent vectors)

iter 9 audit memo가 enumerate한 5 silent corruption 시나리오 중 본 PR이 닫은 1건 + 1건 의도적 보존:

**닫음**:
- **Operator_compact_requested while compaction or handoff in-flight** → buffer-op race. Operator가 in-flight compaction 위에 새 compaction 요청 시, `OperatorCompactRequested`가 retry latch를 side-effect로 clear하면서 in-flight attempt의 retry budget 정보가 잘못 reset됨. Handoff와 concurrent 시 같은 keeper context 위 두 buffer op 경쟁.

**보존 (의도)**:
- **Operator_clear_requested**: spec §467-478이 명시적으로 "Last-resort: operator drops the keeper's context entirely" — escape-hatch. NotTerminal 외 추가 precondition은 의도적으로 *없음*. Arm을 추가하면 escape-hatch 의도 약화. 본 PR은 빈 `Ok ()` arm + rationale 주석으로 *명시적 의도 보존*.

## 왜 escape-hatch arm을 만드는가? (anti-pattern 예방)

Catch-all `_ -> Ok ()`만 두면 future contributor가 본 helper를 보고 "5번째 R-A-9 event는 누락된 것"으로 오해해 임의 precondition 추가 가능. Explicit no-arm + 주석은:

1. **의도 명시**: spec §467-478 "Last-resort" 의도가 코드에 보존됨.
2. **회귀 차단**: 미래 PR이 `Operator_clear_requested _ -> ...` 패턴 추가 시 grep으로 즉시 발견.
3. **layer completeness 시각화**: R-A-9 5/5 모두 명시적으로 나열됨.

(이건 catch-all 제거 시 5번째 event "잊혀짐" 위험을 ad-hoc 주석으로 해결하는 워크어라운드 #4 catch-all 패턴과 정반대 — explicit no-arm은 *코드 레벨 의도 선언*이지 silent acceptance가 아님.)

## 본 PR 수정 (mechanical add-only)

| 변경 | 위치 |
|---|---|
| `Operator_compact_requested` arm (2 conditions) | `lib/keeper/keeper_state_machine.ml:1065-1086` |
| `Operator_clear_requested _` arm (rationale 주석 + `Ok ()`) | `lib/keeper/keeper_state_machine.ml:1087-1095` |
| Helper docstring update — 5/5 coverage closed | `lib/keeper/keeper_state_machine.ml:956-972` |

**무엇이 *바뀌지 않았는가***: variant, dispatch, registry, chaos test — 모두 PR-1 그대로. PR-3는 *PR-1 layer 설계 검증의 최종 증거*.

## Verification

- [x] `dune build --root . @check` — clean (silent success).
- [x] `dune exec --root . test/test_keeper_state_machine.exe` — **114 tests pass**.
- [x] `dune exec --root . test/test_keeper_lifecycle_chaos.exe` — **10 tests pass**.
- [ ] Negative test 추가 (5 misuse scenario × Result.Error 검증) — wrap-up PR 후보.

## Trade-off / 후속 PR

- **R-A-9 wrap-up PR (optional)**: 5 misuse scenarios 모두 unit test로 — Compact_retry_exhausted×3, Context_overflow_detected×1, Auto_compact_triggered×4, Operator_compact_requested×2 = 10 negative tests. layer가 닫혔으므로 test-only add-only.
- **R-A-8 PR-2**: KeeperStateMachine TLC re-verify + KNOWN_FAILURES 제거. R-A-9 stack과 독립.
- **R-A-1.b**: KSM superset condition refinement (credential_archived/zombie_timeout_reached TLA+ VARIABLES 확장). 별도 spec PR.

## RFC 참조

- R-A-9 (apply_event precondition layer) — local RFC backlog. 본 PR이 layer **closure**.
- `RFC-WAIVED`: credential / identity / operator-control / sandbox / hooks 범위 밖. `bash scripts/pr-rfc-check.sh` matches 없음 (keeper FSM 내부 precondition).

## 진행 추적

다음 iteration 시작점: **R-A-9 wrap-up** (5 negative tests, optional) 또는 **R-A-8 PR-2** (KNOWN_FAILURES purge + TLC re-verify) 또는 **A-6 liveness** (BudgetNeverRevives + DeadIsForever).

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
