### PR TITLE
test(keeper): R-A-9 precondition layer negative tests (wrap-up)

### DIFF
--- a/test/test_keeper_state_machine.ml
+++ b/test/test_keeper_state_machine.ml
@@ -2711,6 +2711,170 @@ let test_attribution_gate_and_origin_invariant () =
     cases
 ;;
 
+(* ── Precondition layer negative tests (R-A-9 wrap-up) ──
+
+   Each event covered by [check_event_precondition] gets one test per
+   spec-declared misuse vector.  The arms encode TLA+ §CompactRetryExhausted,
+   §ContextOverflowDetected, §AutoCompactTriggered, §OperatorCompactRequested.
+   Operator_clear_requested has no extra precondition (escape-hatch) — we
+   verify it accepts even an unusual condition state. *)
+
+let overflowed_conditions : SM.conditions =
+  { running_conditions with context_overflow = true }
+;;
+
+(* [event_to_string] for payload-carrying events appends the payload
+   (e.g. "context_overflow_detected(prompt_rejected,...)"), so we use
+   prefix match rather than equality. *)
+let assert_precondition_violation ~event_name err =
+  match err with
+  | SM.Precondition_violation { event; reason = _ } ->
+    check
+      bool
+      ("event name prefix " ^ event_name ^ " in " ^ event)
+      true
+      (Astring.String.is_prefix ~affix:event_name event)
+  | other ->
+    Alcotest.fail
+      ("expected Precondition_violation, got " ^ SM.transition_error_to_string other)
+;;
+
+(* — Compact_retry_exhausted (PR-1) ─────────────────────── *)
+
+let test_pre_compact_retry_no_overflow () =
+  let err =
+    apply_err
+      ~current_phase:SM.Running
+      ~conditions:running_conditions
+      ~event:SM.Compact_retry_exhausted
+  in
+  assert_precondition_violation ~event_name:"compact_retry_exhausted" err
+;;
+
+let test_pre_compact_retry_compaction_active () =
+  let c = { overflowed_conditions with compaction_active = true } in
+  let err =
+    apply_err ~current_phase:SM.Compacting ~conditions:c ~event:SM.Compact_retry_exhausted
+  in
+  assert_precondition_violation ~event_name:"compact_retry_exhausted" err
+;;
+
+let test_pre_compact_retry_already_exhausted () =
+  let c = { overflowed_conditions with compact_retry_exhausted = true } in
+  let err =
+    apply_err ~current_phase:SM.Paused ~conditions:c ~event:SM.Compact_retry_exhausted
+  in
+  assert_precondition_violation ~event_name:"compact_retry_exhausted" err
+;;
+
+(* — Context_overflow_detected (PR-2) ─────────────────────── *)
+
+let overflow_event =
+  SM.Context_overflow_detected
+    { source = `Prompt_rejected; token_count = 100_000; limit_tokens = Some 200_000 }
+;;
+
+let test_pre_overflow_during_compaction () =
+  let c = { running_conditions with compaction_active = true } in
+  let err = apply_err ~current_phase:SM.Compacting ~conditions:c ~event:overflow_event in
+  assert_precondition_violation ~event_name:"context_overflow_detected" err
+;;
+
+(* — Auto_compact_triggered (PR-2) ─────────────────────── *)
+
+let test_pre_auto_compact_no_overflow () =
+  let err =
+    apply_err
+      ~current_phase:SM.Running
+      ~conditions:running_conditions
+      ~event:SM.Auto_compact_triggered
+  in
+  assert_precondition_violation ~event_name:"auto_compact_triggered" err
+;;
+
+let test_pre_auto_compact_active () =
+  let c = { overflowed_conditions with compaction_active = true } in
+  let err =
+    apply_err ~current_phase:SM.Compacting ~conditions:c ~event:SM.Auto_compact_triggered
+  in
+  assert_precondition_violation ~event_name:"auto_compact_triggered" err
+;;
+
+let test_pre_auto_compact_handoff_active () =
+  let c = { overflowed_conditions with handoff_active = true } in
+  let err =
+    apply_err ~current_phase:SM.HandingOff ~conditions:c ~event:SM.Auto_compact_triggered
+  in
+  assert_precondition_violation ~event_name:"auto_compact_triggered" err
+;;
+
+let test_pre_auto_compact_retry_exhausted () =
+  let c = { overflowed_conditions with compact_retry_exhausted = true } in
+  let err =
+    apply_err ~current_phase:SM.Paused ~conditions:c ~event:SM.Auto_compact_triggered
+  in
+  assert_precondition_violation ~event_name:"auto_compact_triggered" err
+;;
+
+(* — Operator_compact_requested (PR-3) ─────────────────────── *)
+
+let test_pre_operator_compact_during_compaction () =
+  let c = { running_conditions with compaction_active = true } in
+  let err =
+    apply_err
+      ~current_phase:SM.Compacting
+      ~conditions:c
+      ~event:SM.Operator_compact_requested
+  in
+  assert_precondition_violation ~event_name:"operator_compact_requested" err
+;;
+
+let test_pre_operator_compact_during_handoff () =
+  let c = { running_conditions with handoff_active = true } in
+  let err =
+    apply_err
+      ~current_phase:SM.HandingOff
+      ~conditions:c
+      ~event:SM.Operator_compact_requested
+  in
+  assert_precondition_violation ~event_name:"operator_compact_requested" err
+;;
+
+(* — Operator_clear_requested (PR-3 escape-hatch) ────────────
+
+   Deliberate no-arm: the precondition layer never rejects this event.
+   Whether the resulting state transition is matrix-valid is a separate
+   FSM concern; the contract under test here is *only* that the
+   precondition arm doesn't surface Precondition_violation.
+
+   We exercise a misuse-shaped condition state (overflow + retry-latched)
+   that would block Compact_retry_exhausted or Auto_compact_triggered,
+   and check that Operator_clear_requested still slips through the
+   precondition layer. *)
+let test_pre_operator_clear_no_extra_precondition () =
+  let c =
+    { running_conditions with
+      context_overflow = true
+    ; compact_retry_exhausted = true
+    }
+  in
+  let clear_event =
+    SM.Operator_clear_requested
+      { preserve_system = false; reason = "operator escape-hatch" }
+  in
+  match
+    SM.apply_event ~current_phase:SM.Running ~conditions:c ~event:clear_event ~now:0.0
+  with
+  | Ok _ -> ()
+  | Error (SM.Precondition_violation { event; _ }) ->
+    Alcotest.fail
+      ("Operator_clear_requested escape-hatch contract violated — \
+        precondition layer rejected with event=" ^ event)
+  | Error _ ->
+    (* Matrix or terminal errors are out of scope for this test. *)
+    ()
+;;
+
 (* ── Test suite ────────────────────────────────────────── *)
 
 let () =
@@ -3018,6 +3182,52 @@ let () =
             "gate=keeper_fsm origin=Det invariant"
             `Quick
             test_attribution_gate_and_origin_invariant
+        ] )
+    ; ( "precondition_layer"
+      , [ test_case
+            "Compact_retry_exhausted requires context_overflow"
+            `Quick
+            test_pre_compact_retry_no_overflow
+        ; test_case
+            "Compact_retry_exhausted requires ~compaction_active"
+            `Quick
+            test_pre_compact_retry_compaction_active
+        ; test_case
+            "Compact_retry_exhausted is non-idempotent (~already_exhausted)"
+            `Quick
+            test_pre_compact_retry_already_exhausted
+        ; test_case
+            "Context_overflow_detected requires ~compaction_active"
+            `Quick
+            test_pre_overflow_during_compaction
+        ; test_case
+            "Auto_compact_triggered requires context_overflow"
+            `Quick
+            test_pre_auto_compact_no_overflow
+        ; test_case
+            "Auto_compact_triggered requires ~compaction_active"
+            `Quick
+            test_pre_auto_compact_active
+        ; test_case
+            "Auto_compact_triggered requires ~handoff_active"
+            `Quick
+            test_pre_auto_compact_handoff_active
+        ; test_case
+            "Auto_compact_triggered requires ~compact_retry_exhausted (#8581)"
+            `Quick
+            test_pre_auto_compact_retry_exhausted
+        ; test_case
+            "Operator_compact_requested requires ~compaction_active"
+            `Quick
+            test_pre_operator_compact_during_compaction
+        ; test_case
+            "Operator_compact_requested requires ~handoff_active"
+            `Quick
+            test_pre_operator_compact_during_handoff
+        ; test_case
+            "Operator_clear_requested is escape-hatch (no extra precondition)"
+            `Quick
+            test_pre_operator_clear_no_extra_precondition
         ] )
     ]
 ;;


### PR DESCRIPTION
## Finding (Iteration 13, R-A-9 wrap-up — negative tests)

**Spec**: `specs/keeper-state-machine/KeeperStateMachine.tla` (5 event preconditions)
**OCaml**: `test/test_keeper_state_machine.ml` (+210 LOC, single file, test add-only)
**Aspect**: R-A-9 layer를 *실행 가능한 spec*으로 봉인 — 5 event × 11 misuse vector 모두 unit test화. R-A-9 PR-1/PR-2/PR-3가 helper에 enforce했고, 본 PR이 그 enforce가 실제로 모든 미세 corruption 시나리오에서 작동하는지 증명.
**Risk**: LOW (test-only)
**Stack**: base = `feature/r-a-9-pr-2-precondition-arms` (PR #14738). PR #14738이 PR-3 (#14743)를 stack auto-merge로 흡수했으므로 본 PR base에 5/5 layer 코드 모두 포함.

## 순서도

### R-A-9 layer test coverage matrix

```mermaid
graph TB
    subgraph PR1[PR-1 #14735 — Compact_retry_exhausted]
        T1[no context_overflow]
        T2[compaction_active]
        T3[already exhausted]
    end
    subgraph PR2[PR-2 #14738 — overflow lifecycle]
        T4[overflow during compaction]
        T5[auto-compact no overflow]
        T6[auto-compact compaction_active]
        T7[auto-compact handoff_active]
        T8[auto-compact retry_exhausted #8581]
    end
    subgraph PR3[PR-3 #14743 — operator events]
        T9[op-compact during compaction]
        T10[op-compact during handoff]
        T11[op-clear escape-hatch contract]
    end
    PR1 --> Pass[Precondition_violation typed reject]
    PR2 --> Pass
    PR3 --> Pass
    style Pass fill:#94e2a3
```

## Before / After (test surface)

| | Before this PR | After |
|---|---|---|
| Precondition arm tests | 0 (only existing 3 attribution tests reference variant) | **11 negative + 1 contract** |
| Misuse vectors covered | 0/11 | 11/11 |
| `event_to_string` payload formatting | Not exercised | Prefix-match helper added |
| Operator_clear escape-hatch contract | Implicit (helper comment only) | Explicit assertion: misuse state → no `Precondition_violation` |

## 왜 톱니처럼 정교하지 않은가 (이번 PR이 닫은 결함)

R-A-9 PR-1/PR-2/PR-3가 코드에 enforce했지만 negative test 부재로 다음 회귀가 silent 가능:

- 누군가 helper에서 한 condition 체크를 실수로 제거 → 코드 컴파일 통과, attribution test 통과 (positive path만 검사). 본 PR negative test가 실패하면서 즉시 발견.
- `event_to_string`가 payload 포맷 변경 → error reason 정확성 회귀. 본 PR prefix-match가 양쪽 모두 견딤.
- Operator_clear escape-hatch에 누군가 "안전상" precondition 추가 → spec §467 의도("Last-resort: drops context entirely") 위반. 본 PR contract test 즉시 실패.

이게 *executable spec*의 가치 — 코드는 의도를 표현하고 테스트는 그 의도가 회귀하지 않음을 증명.

## 본 PR 수정

| 변경 | 위치 |
|---|---|
| `assert_precondition_violation ~event_name` (prefix-match helper) | `test/test_keeper_state_machine.ml:2715-2730` |
| `overflowed_conditions`, `overflow_event` 헬퍼 | `test/test_keeper_state_machine.ml:2710-2740` |
| 11 negative/contract tests (R-A-9 5/5 events) | `test/test_keeper_state_machine.ml:2733-2870` |
| `precondition_layer` test group 등록 (11 cases) | `test/test_keeper_state_machine.ml:3026-3070` |

## 발견된 sharp edge (해결)

- **`event_to_string`가 payload 포함**: `Context_overflow_detected` → `"context_overflow_detected(prompt_rejected,tokens=100000,limit=200000)"`. equality match는 fragile (token count 변화 시 회귀). Prefix-match로 해결. 이건 string classifier #2 워크어라운드 아님 — TLA+ event 이름은 spec-anchored이고 payload는 정보 보강. SSOT `event_to_string`을 정규화하는 방향은 PR scope 밖.
- **Operator_clear contract under matrix-invalid conditions**: `compaction_active=true` 위에서 clear → `derive_phase`가 handoff_active로 HandingOff 산출 시 matrix-invalid. 이건 precondition 책임 밖이라 contract를 "Precondition_violation 아님"으로 좁힘.

## Verification

- [x] `dune build --root . @check` — clean.
- [x] `dune exec --root . test/test_keeper_state_machine.exe` — **125 tests pass** (was 114, +11 new).
- [x] `dune exec --root . test/test_keeper_lifecycle_chaos.exe` — **10 tests pass** (no regression).

## Trade-off / 후속 PR

- **TLA+ TLC verify 미수행**: 본 PR은 OCaml unit test scope. TLA+ Bug Model로 같은 5 misuse vector를 spec 레벨에서 검증하는 작업은 R-A-9 spec-side wrap-up (별도 PR 후보).
- **R-A-8 PR-2 (KNOWN_FAILURES purge)**: 본 stack과 독립. 다음 iteration 후보.

## RFC 참조

- R-A-9 (apply_event precondition layer) — **CLOSED iter 12**, 본 PR은 negative coverage 봉인.
- `RFC-WAIVED`: test-only. credential / identity / operator-control / sandbox / hooks 범위 밖.

## 진행 추적

다음 iteration 시작점: **R-A-8 PR-2** (TLC re-verify + KNOWN_FAILURES purge → 30+ stuck PR 해제 임팩트) OR **A-6 liveness** (BudgetNeverRevives, DeadIsForever ↔ OCaml restart_count) OR **R-A-1.b** (KSM superset condition refinement).

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
