### PR TITLE
feat(sse): typed Sse_reject_reason — close ad-hoc Error tuple string

### DIFF
--- a/lib/server/server_mcp_transport_http.mli
+++ b/lib/server/server_mcp_transport_http.mli
@@ -89,7 +89,8 @@ val get_last_event_id : Httpun.Request.t -> int option
 val mcp_headers : string -> string -> (string * string) list
 val json_headers :
   deps:deps -> string -> string -> string -> (string * string) list
-val check_sse_connect_guard : string -> (unit, string * float) result
+val check_sse_connect_guard
+  : string -> (unit, Sse_reject_reason.t * float) result
 val stop_sse_session : string -> unit
 val is_active_sse_session : string -> bool
 val reap_stale_guards : unit -> int

--- a/lib/server/server_mcp_transport_http_conn.ml
+++ b/lib/server/server_mcp_transport_http_conn.ml
@@ -194,7 +194,7 @@ let check_sse_connect_guard session_id =
         sse_reconnect_min_interval_s -. (now -. state.last_connect_at)
     in
     if session_wait_s > 0.0 then begin
-      result := Error ("session_cooldown", session_wait_s);
+      result := Error (Sse_reject_reason.Session_cooldown, session_wait_s);
       map
     end else begin
       let window_wait_s =
@@ -208,7 +208,7 @@ let check_sse_connect_guard session_id =
           0.0
       in
       if window_wait_s > 0.0 then begin
-        result := Error ("window_limit", window_wait_s);
+        result := Error (Sse_reject_reason.Window_limit, window_wait_s);
         map
       end else begin
         result := Ok ();

--- a/lib/server/server_mcp_transport_http_conn.mli
+++ b/lib/server/server_mcp_transport_http_conn.mli
@@ -122,18 +122,18 @@ val make_inline_sse_conn :
 (** {1 Connect-rate guard} *)
 
 val check_sse_connect_guard :
-  string -> (unit, string * float) result
+  string -> (unit, Sse_reject_reason.t * float) result
 (** [check_sse_connect_guard session_id] verifies that the
     session's SSE connect rate is within the configured limits
     AND records the new connect time on success.
 
     Returns:
     - [Ok ()] when the connect is allowed.
-    - [Error ("session_cooldown", wait_s)] when
+    - [Error (Sse_reject_reason.Session_cooldown, wait_s)] when
       {!sse_reconnect_min_interval_s} has not elapsed since the
       last connect on this session.
-    - [Error ("window_limit", wait_s)] when the session has
-      hit {!sse_connect_max_in_window} connects within
+    - [Error (Sse_reject_reason.Window_limit, wait_s)] when the
+      session has hit {!sse_connect_max_in_window} connects within
       {!sse_connect_window_s}.  [wait_s] is the time until the
       oldest connect-time entry leaves the window.
 

--- a/lib/server/server_mcp_transport_http_respond.ml
+++ b/lib/server/server_mcp_transport_http_respond.ml
@@ -112,7 +112,8 @@ let respond_not_ready ~(deps : Server_mcp_transport_http_types.deps) request req
 
 let respond_sse_rate_limited ~(deps : Server_mcp_transport_http_types.deps) ~origin ~session_id ~protocol_version
     ~reason ~retry_after_s reqd =
-  Transport_metrics.inc_sse_reject ~reason;
+  let reason_label = Sse_reject_reason.to_label reason in
+  Transport_metrics.inc_sse_reject ~reason:reason_label;
   let retry_after_s = Float.max retry_after_s 0.001 in
   let retry_after_header =
     retry_after_s |> Float.ceil |> int_of_float |> max 1 |> string_of_int
@@ -121,7 +122,7 @@ let respond_sse_rate_limited ~(deps : Server_mcp_transport_http_types.deps) ~ori
     `Assoc
       [
         ("error", `String "sse_connection_rate_limited");
-        ("reason", `String reason);
+        ("reason", `String reason_label);
         ("retry_after_seconds", `Float retry_after_s);
       ]
     |> Yojson.Safe.to_string

--- a/lib/server/server_mcp_transport_http_respond.mli
+++ b/lib/server/server_mcp_transport_http_respond.mli
@@ -97,7 +97,7 @@ val respond_sse_rate_limited :
   origin:string ->
   session_id:string ->
   protocol_version:string ->
-  reason:string ->
+  reason:Sse_reject_reason.t ->
   retry_after_s:float ->
   Httpun.Reqd.t ->
   unit

--- a/lib/server/server_mcp_transport_http_sse.mli
+++ b/lib/server/server_mcp_transport_http_sse.mli
@@ -37,7 +37,7 @@ val respond_sse_rate_limited :
   origin:string ->
   session_id:string ->
   protocol_version:string ->
-  reason:string ->
+  reason:Sse_reject_reason.t ->
   retry_after_s:float ->
   Httpun.Reqd.t ->
   unit

--- a/lib/server/server_routes_http_common.mli
+++ b/lib/server/server_routes_http_common.mli
@@ -142,7 +142,7 @@ val json_headers : string -> string -> string -> (string * string) list
 (** {1 SSE session control} *)
 
 val check_sse_connect_guard :
-  string -> (unit, string * float) result
+  string -> (unit, Sse_reject_reason.t * float) result
 val stop_sse_session : string -> unit
 val close_all_sse_connections : unit -> unit
 

--- a/lib/server/sse_reject_reason.ml
+++ b/lib/server/sse_reject_reason.ml
@@ -1,0 +1,8 @@
+type t =
+  | Session_cooldown
+  | Window_limit
+
+let to_label = function
+  | Session_cooldown -> "session_cooldown"
+  | Window_limit -> "window_limit"
+;;

--- a/lib/server/sse_reject_reason.mli
+++ b/lib/server/sse_reject_reason.mli
@@ -1,0 +1,19 @@
+(** Sse_reject_reason — closed sum for SSE-connect rate-limit rejects.
+
+    Replaces the prior [Error (string * float)] tuple where the string
+    was constrained-in-practice to two values ({"session_cooldown",
+    "window_limit"}) but had no type-level guarantee.  The metric label
+    on [metric_sse_rejects] now derives from a closed variant so adding
+    a third gate becomes a single edit instead of a string-literal
+    sprinkle. *)
+
+type t =
+  | Session_cooldown (** Per-session reconnect cooldown window unmet. *)
+  | Window_limit
+  (** Per-session connect-count threshold over the
+                          sliding window. *)
+
+(** Stable wire format for the [reason] label on
+    [metric_sse_rejects].  Returns the exact strings the legacy
+    code emitted: ["session_cooldown"] / ["window_limit"]. *)
+val to_label : t -> string

--- a/test/test_http_negotiation.ml
+++ b/test/test_http_negotiation.ml
@@ -174,16 +174,19 @@ let test_sse_guard_registry_is_shared_with_cleanup_loop () =
   let session_id = "shared-sse-guard-registry" in
   match Transport.check_sse_connect_guard session_id with
   | Error (reason, retry_after_s) ->
-      failf "expected first guard insert to succeed, got %s %.3f" reason
+      failf "expected first guard insert to succeed, got %s %.3f"
+        (Masc_mcp.Sse_reject_reason.to_label reason)
         retry_after_s
   | Ok () ->
       check int "cleanup keeps fresh guard entries" 0
         (Cleanup_view.reap_stale_guards ());
       (match Transport.check_sse_connect_guard session_id with
-      | Error ("session_cooldown", retry_after_s) ->
+      | Error (Masc_mcp.Sse_reject_reason.Session_cooldown, retry_after_s) ->
           check bool "cooldown stays positive" true (retry_after_s > 0.0)
       | Error (reason, retry_after_s) ->
-          failf "expected shared cooldown guard, got %s %.3f" reason retry_after_s
+          failf "expected shared cooldown guard, got %s %.3f"
+            (Masc_mcp.Sse_reject_reason.to_label reason)
+            retry_after_s
       | Ok () ->
           fail "expected second guard check to observe shared cooldown state")
 
@@ -193,14 +196,17 @@ let test_preserve_guard_keeps_ag_ui_cooldown () =
   let session_id = "ag-ui-preserve-guard" in
   match Transport.check_sse_connect_guard session_id with
   | Error (reason, retry_after_s) ->
-      failf "expected first guard insert to succeed, got %s %.3f" reason
+      failf "expected first guard insert to succeed, got %s %.3f"
+        (Masc_mcp.Sse_reject_reason.to_label reason)
         retry_after_s
   | Ok () ->
       Cleanup_view.stop_sse_session_preserve_guard session_id;
       (match Transport.check_sse_connect_guard session_id with
       | Ok () -> fail "expected preserved guard to enforce reconnect cooldown"
       | Error (reason, retry_after_s) ->
-          check string "preserves session cooldown reason" "session_cooldown" reason;
+          check string "preserves session cooldown reason"
+            "session_cooldown"
+            (Masc_mcp.Sse_reject_reason.to_label reason);
           check bool "preserved retry-after is positive" true (retry_after_s > 0.0));
       ignore (Cleanup_view.reap_stale_guards ())
 


### PR DESCRIPTION
## Summary

`check_sse_connect_guard` returned `(unit, string * float) result` where
the string was de facto constrained to two values
(`"session_cooldown"` / `"window_limit"`) but had no type-level
guarantee.  Replace with `Sse_reject_reason.t` closed sum.

## Why

The .mli docstring on `origin/main` already documented the closed set:

> - `Error (\"session_cooldown\", wait_s)` when ...
> - `Error (\"window_limit\", wait_s)` when ...

The string flows directly into the `metric_sse_rejects` Prometheus
label.  Adding a third gate today means editing three sites
(producer, consumer-binding, .mli prose) with no compiler help — a
silent partial-rollout risk and a soft form of the workaround #2
"string classifier" anti-pattern.

After the fix:

- Producer (`http_conn.check_sse_connect_guard`) returns
  `(unit, Sse_reject_reason.t * float) result`.
- Consumer (`http_respond.respond_sse_rate_limited`) converts to
  label at the emission boundary via `Sse_reject_reason.to_label`.
- Adding a third gate becomes a single edit to
  `sse_reject_reason.ml(.mli)`; the compiler enforces coverage at
  `to_label` and at every match site.

## Changes

| File | Change |
|------|--------|
| `lib/server/sse_reject_reason.ml(.mli)` | New module with the closed sum and `to_label` |
| `lib/server/server_mcp_transport_http_conn.{ml,mli}` | Guard returns `Sse_reject_reason.t * float` |
| `lib/server/server_mcp_transport_http.mli` | Re-exported signature |
| `lib/server/server_mcp_transport_http_respond.{ml,mli}` | Responder accepts `Sse_reject_reason.t`; converts at emit |
| `lib/server/server_mcp_transport_http_sse.mli` | Pinned-alias signature |

Wire format byte-equal (`"session_cooldown"` / `"window_limit"`).

## Test plan

- [ ] CI green
- [ ] `rg '"(session_cooldown|window_limit)"' lib/server/` returns only
      the new `to_label` strings + the .mli prose docstrings

RFC-WAIVED: not in credential/identity/operator/sandbox/hooks/workflow scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)