### PR TITLE
perf(tool_catalog): O(1) keeper_internal membership + dedupe surface query in metadata

### DIFF
--- a/lib/tool_catalog.ml
+++ b/lib/tool_catalog.ml
@@ -338,8 +338,6 @@ let registered_metadata name =
 (* ================================================================ *)
 
 (* Delegate to surfaces sub-module *)
-let keeper_internal_set = Tool_catalog_surfaces.keeper_internal_tools
-
 let keeper_internal_replacement = Tool_catalog_surfaces.keeper_internal_replacement
 
 let public_mcp_tools = Tool_catalog_surfaces.public_mcp_surface_tools
@@ -801,14 +799,20 @@ let attach_inferred_effect_domain name (meta : metadata) =
   | None -> { meta with effect_domain = inferred_effect_domain name }
 
 let metadata name =
+  (* Hot path: called from MCP execute, tool list, OAS bridge, capability
+     registry, keeper guards, help registry, governance risk, etc.  Cache
+     surface-membership checks per call rather than re-querying. *)
+  let is_system_internal =
+    Tool_catalog_surfaces.is_on_surface System_internal name
+  in
   let base =
     match Hashtbl.find_opt metadata_table name with
     | Some meta -> meta
     | None ->
       if is_public_mcp name then default_metadata
-      else if List.mem name keeper_internal_set then
+      else if Tool_catalog_surfaces.is_on_surface Keeper_internal name then
         keeper_internal_metadata name
-      else if Tool_catalog_surfaces.is_on_surface System_internal name then
+      else if is_system_internal then
         { default_metadata with
           visibility = Hidden;
           allow_direct_call_when_hidden = true;
@@ -822,7 +826,7 @@ let metadata name =
           reason = Some "Internal tool; not on public MCP surface." }
   in
   let with_surface_visibility =
-    if Tool_catalog_surfaces.is_on_surface System_internal name then
+    if is_system_internal then
     (* Surface membership is the canonical "hidden but callable" contract for
        system-internal tools, even when a tool also carries explicit metadata
        for semantic hints like readonly/destructive. *)


### PR DESCRIPTION
## Summary

\`Tool_catalog.metadata\` is hot-path — called from MCP execute, OAS tool bridge, capability registry, keeper guards, help registry, governance risk, profile filter, etc. Two inefficiencies found:

### 1. \`List.mem name keeper_internal_set\` → \`is_on_surface Keeper_internal name\`

The fall-through branch in the cache-miss path used \`List.mem name keeper_internal_set\` — O(n) linear scan over a ~12-30 entry tool name list. After #14734 wired up the per-surface Hashtbl, the equivalent membership check is O(1) via \`Tool_catalog_surfaces.is_on_surface Keeper_internal name\`.

**Semantics identical**: \`keeper_internal_surface_tools = keeper_internal_tools\` in \`tool_catalog_surfaces.ml:355\` — both name the same backing list.

### 2. Hoist \`Tool_catalog_surfaces.is_on_surface System_internal name\`

The same membership check fired twice per \`metadata\` call:
- once in the cache-miss branch to decide the synthesized default metadata
- once in the surface-visibility override block

Even at O(1) each, doubling the call for a hot-path function is waste. Lifted to a single \`let is_system_internal = ...\` at function entry.

### 3. Drop unused local alias

\`let keeper_internal_set = Tool_catalog_surfaces.keeper_internal_tools\` existed only to feed the substituted \`List.mem\`. Not exposed in \`tool_catalog.mli\`, no external callers (\`rg Tool_catalog.keeper_internal_set lib/ test/ bin/\` → 0). Removed.

## Compounded wins from prior PRs

This PR builds on:
- **#14728** \`Tool_access_policy\` set ops — earlier in this loop
- **#14734** \`Tool_catalog_surfaces.is_on_surface\` direct variant match — provides the O(1) plumbing this PR consumes
- **#14740** \`Tool_access_role\` per-role memoization

Combined effect: a per-MCP-request authorization + metadata lookup now hits **only Hashtbl.mem + variant dispatch**, with no list scans anywhere on the hot path.

## Test plan

- [ ] CI lib/ build green
- [ ] Tool_catalog metadata tests (\`test_tool_catalog*\`) pass
- [ ] No callers of removed \`Tool_catalog.keeper_internal_set\` (verified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)