### PR TITLE
refactor(task_stage): replace manual index/can_transition with [@@deriving eq, ord]

### DIFF
--- a/lib/types/dune
+++ b/lib/types/dune
@@ -5,4 +5,4 @@
  (wrapped false)
  (modules rate_limit_types masc_error ids types_core types_auth masc_domain task_stage severity)
  (libraries yojson unix time_compat masc_core base64 uuidm)
- (preprocess (pps ppx_deriving.show ppx_deriving.eq ppx_deriving_yojson)))
+ (preprocess (pps ppx_deriving.show ppx_deriving.eq ppx_deriving.ord ppx_deriving_yojson)))

--- a/lib/types/task_stage.ml
+++ b/lib/types/task_stage.ml
@@ -10,7 +10,7 @@ type t =
   | Implement
   | Verify
   | Review
-[@@deriving show]
+[@@deriving show, eq, ord]
 
 let to_string = function
   | Decompose -> "decompose"
@@ -35,15 +35,8 @@ let of_yojson = function
 
 let all = [Decompose; Inspect; Implement; Verify; Review]
 
-let index = function
-  | Decompose -> 0
-  | Inspect -> 1
-  | Implement -> 2
-  | Verify -> 3
-  | Review -> 4
-
 let can_transition ~current ~target =
-  index target >= index current
+  compare target current >= 0
 
 let validate_transition ~current ~target =
   if can_transition ~current ~target then Ok ()

--- a/lib/types/task_stage.mli
+++ b/lib/types/task_stage.mli
@@ -24,9 +24,9 @@ val of_yojson : Yojson.Safe.t -> (t, string) result
 val all : t list
 
 (** Can transition from [current] to [target]?
-    Forward transitions (target > current under {!compare}) are allowed.
-    Same-stage re-entry is allowed (idempotent).
-    Backward transitions are forbidden. *)
+    Implemented as [compare target current >= 0]: forward transitions
+    (target after current in canonical order) and same-stage re-entry
+    (idempotent) are allowed; backward transitions are forbidden. *)
 val can_transition : current:t -> target:t -> bool
 
 (** Validate a transition, returning Error with reason if forbidden. *)

--- a/lib/types/task_stage.mli
+++ b/lib/types/task_stage.mli
@@ -12,7 +12,7 @@ type t =
   | Implement
   | Verify
   | Review
-[@@deriving show]
+[@@deriving show, eq, ord]
 
 val to_string : t -> string
 val of_string : string -> (t, string) result
@@ -23,11 +23,8 @@ val of_yojson : Yojson.Safe.t -> (t, string) result
 (** All stages in canonical order. *)
 val all : t list
 
-(** Index of a stage (0-based). *)
-val index : t -> int
-
 (** Can transition from [current] to [target]?
-    Forward transitions (index target > index current) are allowed.
+    Forward transitions (target > current under {!compare}) are allowed.
     Same-stage re-entry is allowed (idempotent).
     Backward transitions are forbidden. *)
 val can_transition : current:t -> target:t -> bool

--- a/test/test_task_stage.ml
+++ b/test/test_task_stage.ml
@@ -19,9 +19,13 @@ let test_of_string_invalid () =
   | Ok _ -> fail "expected error for invalid stage"
 
 let test_index_order () =
-  let indices = List.map Task_stage.index Task_stage.all in
-  let sorted = List.sort Int.compare indices in
-  check (list int) "indices are ordered" sorted indices;
+  (* [all] must be in ascending canonical order under [compare].
+     Sorting it should be a no-op. *)
+  let sorted = List.sort Task_stage.compare Task_stage.all in
+  check (list string)
+    "canonical [all] is sorted"
+    (List.map Task_stage.to_string sorted)
+    (List.map Task_stage.to_string Task_stage.all);
   check int "5 stages" 5 (List.length Task_stage.all)
 
 let test_forward_transition () =

--- a/test/test_task_stage.ml
+++ b/test/test_task_stage.ml
@@ -18,7 +18,7 @@ let test_of_string_invalid () =
   | Error _ -> ()
   | Ok _ -> fail "expected error for invalid stage"
 
-let test_index_order () =
+let test_canonical_order () =
   (* [all] must be in ascending canonical order under [compare].
      Sorting it should be a no-op. *)
   let sorted = List.sort Task_stage.compare Task_stage.all in
@@ -109,7 +109,7 @@ let () =
       "yojson roundtrip", `Quick, test_yojson_roundtrip;
     ];
     "ordering", [
-      "index order", `Quick, test_index_order;
+      "canonical order", `Quick, test_canonical_order;
       "forward allowed", `Quick, test_forward_transition;
       "same stage idempotent", `Quick, test_same_stage;
       "backward forbidden", `Quick, test_backward_forbidden;


### PR DESCRIPTION
## Why

`Task_stage.t` is an ordered 5-variant closed sum:

\`\`\`ocaml
type t = Decompose | Inspect | Implement | Verify | Review
\`\`\`

The module shipped a private `index : t -> int` mapping each constructor to its declaration position, and used it inside `can_transition` to compare ranks:

\`\`\`ocaml
let index = function
  | Decompose -> 0 | Inspect -> 1 | Implement -> 2 | Verify -> 3 | Review -> 4

let can_transition ~current ~target = index target >= index current
\`\`\`

This is the same pattern closed in PR #14726 for `cdal_runtime/risk_class` and `cdal_runtime/execution_mode`: a hand-written `to_int`-style helper whose only purpose is to back comparison. The deriver-generated `compare` from `[@@deriving ord]` orders constructors by declaration position — exactly the ranking `index` encoded by hand.

The hand-written shape is forward-fragile: if a new constructor is inserted between two existing ones (e.g. a `Refactor` step between `Implement` and `Verify`), `index` must be renumbered explicitly. The deriver does this automatically.

## What

- Add `eq, ord` to `[@@deriving]` (both `.ml` and `.mli`)
- Delete private `index : t -> int` (only consumer was one inline test)
- Rewrite `can_transition` as `compare target current >= 0`
- Update `test_task_stage.test_index_order` to verify canonical ordering through `Task_stage.compare` applied to `all`
- Add `ppx_deriving.ord` to `lib/types/dune` preprocess (alongside the existing `ppx_deriving.eq`)

## Caller compat

`grep -r 'Task_stage\.' lib/ bin/ test/` shows only:
- `Task_stage.to_string`, `to_yojson`, `of_yojson`, `of_string`, `all`, `can_transition`, `validate_transition`, `t` — all preserved
- `Task_stage.index` — used **only** in `test/test_task_stage.ml:22` (updated in this PR)

No production caller is affected. `Task_stage.equal` and `Task_stage.compare` are new vals exposed via the `.mli`'s `[@@deriving]` attribute.

## Verification

\`\`\`
dune build @lib/types/check --root .   # exit 0
\`\`\`

A wider build of `test/test_task_stage.exe` currently fails on `lib/keeper/keeper_runtime.ml:649` (5-tuple vs 4-tuple type mismatch). That regression is **pre-existing on main HEAD** (introduced by PR #14745) and unrelated to this PR. CI on a green main will validate the test.

## Why this counts as "Variant 처리가 더 유리한 곳"

Same reasoning as #14726: hand-written ordinal helpers on a closed sum are deriver-displaceable maintenance surface. Deleting `index` removes 7 LOC of code that the type system can generate exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)