### PR TITLE
docs(tla-audit): A-6 BudgetNeverRevives structural enforcement gap (iter 14)

### DIFF
--- a/docs/tla-audit/ksm-a6-budget-never-revives-2026-05-12.md
+++ b/docs/tla-audit/ksm-a6-budget-never-revives-2026-05-12.md
@@ -1,0 +1,140 @@
+# A-6 Liveness Audit — `BudgetNeverRevives` Structural Gap
+
+**Iteration**: 14 (/loop FSM/TLA+/OCaml drift hunt)
+**Date**: 2026-05-12
+**Spec**: `specs/keeper-state-machine/KeeperStateMachine.tla` §S3 `BudgetNeverRevives`
+**Risk**: MID — invariant currently *holds in practice* but not *structurally enforced*.
+**Type**: Audit-only (no code change in this PR).
+
+## TLA+ contract
+
+```tla
+\* S3: Budget never revives once exhausted
+BudgetNeverRevives ==
+    [](~restart_budget_remaining => [](~restart_budget_remaining))
+```
+
+The flag is monotonic: once cleared, it stays cleared.  Paired with
+`RestartBudgetExhausted` action (line 371-380), which has the
+precondition `restart_budget_remaining = TRUE` (you can only exhaust
+budget if it isn't already exhausted) and sets it to FALSE.
+
+## OCaml topology
+
+Two parallel "budget" axes:
+
+| Axis | Type | Set by | Read by |
+|---|---|---|---|
+| `restart_count` (registry entry) | `int` | `record_restart` (incrementing) | `supervisor.ml:1468` gate `>= max_restarts` |
+| `restart_budget_remaining` (conditions) | `bool` | `Restart_budget_exhausted` event + `mark_dead` | `derive_phase` Dead routing (line 505) |
+
+The **supervisor uses the counter, not the flag**, to decide
+restart-vs-mark-dead.  The flag is set as a *side-effect* inside the
+same `to_mark_dead` loop, after the routing decision is already made.
+
+## How `BudgetNeverRevives` is currently honored
+
+Single-path coupling — `keeper_supervisor.ml`:
+
+```
+sweep_and_recover()
+  └─ if restart_count >= max_restarts:
+        to_mark_dead ← entry
+            └─ dispatch Restart_budget_exhausted  (sets flag=false)
+            └─ mark_dead                          (also sets flag=false)
+     else if restart_count < max_restarts AND now - last_restart >= delay:
+        to_restart ← entry
+            └─ dispatch Supervisor_restart_attempt
+            └─ register_restarting(...)            (overwrites flag=true)
+```
+
+Two flag-changing paths.  They **happen to** be mutually exclusive
+because the supervisor only ever sends a keeper down one branch per
+sweep.  The exclusivity is a consequence of `if/else`, not a typed
+invariant.
+
+## Structural gap (what would break it)
+
+`register_restarting` is a registry-level primitive that
+unconditionally writes `restart_budget_remaining = true`
+(`keeper_registry.ml:771`).  Any future caller that invokes it on a
+keeper whose flag was previously cleared — via *any* path — would
+silently revive the budget and violate `BudgetNeverRevives`.
+
+Three concrete vectors that could materialize:
+
+1. **Operator-driven re-registration**: a `/masc_keeper_revive` command
+   that calls `register_restarting` after operator inspection.  No
+   guard against entry-with-budget=false → silent invariant violation.
+2. **Non-supervisor recovery path**: if heartbeat-keeper or
+   work-pipeline adds a "best-effort restart" path that bypasses the
+   `restart_count >= max_restarts` gate, but the keeper had budget
+   cleared via some other event sequence.
+3. **Direct `Restart_budget_exhausted` event injection**: a manual
+   admin command, debug tool, or migration script that dispatches the
+   event *without* subsequently calling `mark_dead`.  The keeper is
+   then in `restart_budget_remaining=false ∧ phase∈{Crashed, Failing,
+   ...}`, eligible for the supervisor's restart branch on the next
+   sweep — `register_restarting` revives it.
+
+In all three cases, the compiler stays silent.  The first failure
+surfaces only when an invariant check runs (`keeper_invariant_check.ml`
+has `DeadRequiresNoBudget` but no symmetric "no-revive" assertion) or
+when a downstream consumer relies on the BudgetNeverRevives semantics
+(e.g., dashboards rendering "permanently dead" badges).
+
+## Spec-side adjacent gap — `Restart_budget_exhausted` non-idempotency
+
+`update_conditions` at `lib/keeper/keeper_state_machine.ml:644`:
+
+```ocaml
+| Restart_budget_exhausted -> { c with restart_budget_remaining = false }
+```
+
+Unconditional set.  Spec §RestartBudgetExhausted requires the
+precondition `restart_budget_remaining = TRUE` (non-idempotency:
+re-exhausting an already-exhausted budget is a logical no-op but masks
+a duplicate dispatch in the caller).
+
+This is the same systematic gap class as iter 9 F-9.1 (5
+condition-setter events).  `Restart_budget_exhausted` was not on the
+original list — making this the **6th candidate** for the R-A-9
+precondition layer.
+
+## Suggested fix paths (RFC candidates)
+
+| ID | Scope | Action | Risk |
+|---|---|---|---|
+| R-A-6.a | Registry boundary | `register_restarting` returns `Result.t`, refuses to revive when an existing entry has `restart_budget_remaining=false`.  Distinguishes "new keeper registration" (no prior entry) from "restart of existing" (prior entry must have budget). | MID — touches 1 supervisor caller, 2 test callers. |
+| R-A-6.b | FSM precondition layer | Add `Restart_budget_exhausted` arm to `check_event_precondition` (R-A-9 6th event): require `restart_budget_remaining=true`.  Idempotency violation → typed `Precondition_violation`. | LOW — single helper arm, follows the same pattern as PR-1/PR-2/PR-3. |
+| R-A-6.c | Invariant checker | Add `BudgetNeverRevives` invariant to `keeper_invariant_check.ml` so an out-of-band revival surfaces at the next sweep instead of silently propagating. | LOW — pure read-only check, no flow change. |
+
+R-A-6.b is the highest-leverage minimal fix and aligns with the closed
+R-A-9 stack.  R-A-6.a is structurally cleaner but requires supervisor
+touch.  R-A-6.c is defensive — useful regardless of which structural
+fix lands.
+
+## Verification target (for future PR)
+
+- TLA+ Bug Model: add `BudgetRevivesAction == ... restart_budget_remaining'
+  = TRUE` and `INVARIANT BudgetNeverRevives` — confirm spec catches the
+  revival in N steps.
+- OCaml test: simulate the three vectors above and assert
+  `register_restarting` (or the FSM event) refuses or surfaces typed
+  error.
+
+## Out-of-scope for this iteration
+
+- TLC re-verify of `BudgetNeverRevives` against the current spec —
+  blocked by KNOWN_FAILURES #8710 until R-A-8 PR-2 closes.
+- Supervisor restart-decision refactor (gate on flag vs counter) —
+  RFC-scope.
+
+## References
+
+- iter 9 audit memo (R-A-9 systematic gap class): `ksm-precondition-enforcement-gap-2026-05-12.md`
+- TLA+ S3 property line 543-544
+- `register_restarting`: `lib/keeper/keeper_registry.ml:768-775`
+- Supervisor restart decision: `lib/keeper/keeper_supervisor.ml:1468-1473`
+- Mark-dead path: `lib/keeper/keeper_supervisor.ml:1639-1646`
+- `Restart_budget_exhausted` event handler: `lib/keeper/keeper_state_machine.ml:644`


### PR DESCRIPTION
## Finding (Iteration 14, Phase A-6 — liveness audit)

**Spec**: `specs/keeper-state-machine/KeeperStateMachine.tla` §S3 `BudgetNeverRevives` (line 543-544)
**OCaml**: `lib/keeper/keeper_registry.ml:768-775` + `lib/keeper/keeper_supervisor.ml:1468-1646` + `lib/keeper/keeper_state_machine.ml:644`
**Aspect**: TLA+ liveness 속성 vs OCaml 구조적 enforcement — `BudgetNeverRevives`는 *현재 실수로* honored됨 (supervisor if/else 단일 게이트). 어떤 분기 추가도 silent 위반 가능.
**Risk**: MID (invariant currently holds; gap is *structural*, not behavioral)
**Type**: Audit-only — 새 audit memo 1개, 코드 변경 0.

## 순서도 — 두 parallel budget axes + single coupling point

```mermaid
graph TB
    subgraph supervisor[keeper_supervisor.ml sweep]
        Gate{restart_count >= max?}
        Gate -->|YES| MarkDead[to_mark_dead<br/>→ dispatch Restart_budget_exhausted<br/>→ mark_dead]
        Gate -->|NO| Restart[to_restart<br/>→ register_restarting<br/>= TRUE overwrite]
    end
    subgraph fsm[FSM conditions]
        Flag[restart_budget_remaining: bool]
        Counter[restart_count: int<br/>registry_entry]
    end
    MarkDead -->|sets false| Flag
    Restart -->|sets true unconditional| Flag
    Restart -.->|increments| Counter
    Gate -.->|reads only counter| Counter
    style Gate fill:#ffe58a
    style Restart fill:#ffb3b3
```

붉은색이 본 audit의 위험 지점 — `register_restarting`은 spec의 `BudgetNeverRevives`를 *모르고* unconditional true overwrite. 현재는 `Gate`의 if/else 게이트가 분기를 분리하지만 **타입 시스템도 invariant 체크도 이 결합을 보장하지 않음**.

## 왜 톱니처럼 정교하지 않은가

세 가지 미래 시나리오가 silent하게 invariant 위반 가능:

1. **Operator-driven `/masc_keeper_revive` command**: `register_restarting` 호출 시 사전 entry budget 체크 부재.
2. **Non-supervisor recovery path**: heartbeat-keeper / work-pipeline이 best-effort restart 추가 시 `restart_count >= max` 게이트 우회.
3. **Manual `Restart_budget_exhausted` event injection** (admin tool, migration): 후속 `mark_dead` 없으면 sweep에서 to_restart로 라우팅 → revive.

세 vector 모두 컴파일러 silent, `keeper_invariant_check.ml`의 `DeadRequiresNoBudget`은 대칭 "no-revive" assertion 없음.

## 인접 발견: `Restart_budget_exhausted` non-idempotency 결여

`lib/keeper/keeper_state_machine.ml:644`:
```ocaml
| Restart_budget_exhausted -> { c with restart_budget_remaining = false }  (* unconditional *)
```

TLA+ §RestartBudgetExhausted: `/\ NotTerminal /\ restart_budget_remaining /\ restart_budget_remaining' = FALSE` — 정확히 R-A-9 systematic gap class. **iter 9 audit가 식별한 5 events 외 6번째 후보**.

## 본 PR 내용

- `docs/tla-audit/ksm-a6-budget-never-revives-2026-05-12.md` (+140 LOC): 위 분석 + 3 RFC 후보:
  - **R-A-6.a**: `register_restarting` returns `Result.t`, refuses to revive (MID risk, supervisor 1 caller + test 2 caller 수정).
  - **R-A-6.b**: `Restart_budget_exhausted` arm을 R-A-9 helper에 추가 (LOW risk, helper-internal — minimum-leverage next-PR).
  - **R-A-6.c**: `BudgetNeverRevives` invariant를 `keeper_invariant_check.ml`에 추가 (LOW, defensive).

## Verification

- [x] Memo internal consistency — spec 인용 line numbers + OCaml file locations 모두 직접 검증.
- [ ] TLC Bug Model verification — TLC re-verify는 KNOWN_FAILURES #8710 영향, R-A-8 PR-2 closeout 후.

## Trade-off

- **Audit-only 결정 사유**: 10-min budget. 구조적 fix (R-A-6.a)는 supervisor flow touch — 별도 PR 필요. R-A-6.b는 다음 iteration에서 즉시 진행 가능 (R-A-9 패턴 그대로).
- **Re-verification 우선순위**: 본 memo는 *현재 invariant가 honored됨*을 명시. 즉각적 production 영향 없음. 우선순위는 R-A-8 PR-2 (KNOWN_FAILURES) > R-A-6.b > R-A-6.a/c.

## RFC 참조

- A-6 sub-aspect (liveness audit) — plan의 Phase A 항목 진행.
- R-A-9 systematic gap (iter 9 audit) — 본 memo가 6번째 후보 추가.
- `RFC-WAIVED`: docs-only audit, 코드 영향 없음. credential / identity / operator-control / sandbox / hooks 범위 밖.

## 진행 추적

다음 iteration 시작점: **R-A-6.b** (R-A-9 6번째 event arm, helper-internal add-only) OR **R-A-8 PR-2** (KNOWN_FAILURES purge) OR **A-6.후속 — BudgetRevivesAction Bug Model**.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
