### PR TITLE
feat(rfc-0070): Phase 3b-i — Keeper_hash_algo + RFC §3.1 amend (BLAKE3 deferred)

### DIFF
--- a/docs/rfc/RFC-0070-keeper-sandbox-pure-edge-separation.md
+++ b/docs/rfc/RFC-0070-keeper-sandbox-pure-edge-separation.md
@@ -80,7 +80,9 @@ val of_request
 (* Same input ⇒ identical plan. No Random, no Unix.time. *)
 ```
 
-`Container_name.t` is a private string derived as `"masc-keeper-" ^ base36(Hash_algo.digest hash_algo (turn_id ‖ attempt ‖ suffix)[0..15])`, where `Hash_algo.t = BLAKE3 | SHA_256 | SHA_512` (closed variant, default `BLAKE3` per §8 Q1). The slice takes the first **16 bytes (128 bits)** of the digest, encoded in base36. Direct collision probability is 1/2^128; birthday-bound collision threshold (concurrent keepers in the same fleet) is ~2^64 ≈ 1.8×10^19 — effectively zero under any realistic load. Test backdoor `Container_name.of_string_for_test` is exposed only under `let%test_module` and not in the public `.mli`. **The algorithm choice is parametric** — wall-clock is the only construction-time dependency that must remain absent.
+`Container_name.t` is a private string derived as `"masc-keeper-" ^ hex(Hash_algo.digest_bytes hash_algo (turn_id ‖ attempt ‖ suffix))[0..31]`, where `Hash_algo.t = SHA_256 | SHA_512` (closed variant, default `SHA_256` per §8 Q1). The hex slice takes the first **32 hex chars = 16 bytes (128 bits)** of the digest. Direct collision probability is 1/2^128; birthday-bound collision threshold (concurrent keepers in the same fleet) is ~2^64 ≈ 1.8×10^19 — effectively zero under any realistic load. Test backdoor `Container_name.of_string_for_test` is exposed only under `let%test_module` and not in the public `.mli`. **The algorithm choice is parametric** — wall-clock is the only construction-time dependency that must remain absent.
+
+(BLAKE3 was originally in the variant; deferred to a follow-up — opam `digestif` 1.3.0 ships BLAKE2B/2S but not BLAKE3, and adding a separate `blake3` opam dependency is out of Phase 3b-i scope. RFC §8 Q1 updated. Hex encoding chosen over base36 to match the existing `Digestif.to_hex` convention used 8+ times elsewhere in `lib/` — see `lib/cache_eio.ml:58`, `lib/rate_limit.ml:230`, `lib/eval_calibration.ml:126`.)
 
 ### 3.2 Edge layer (Docker_client + Sandbox_executor)
 
@@ -193,7 +195,7 @@ Phases 1-5 are independently mergeable and revertible. Phase 5 closes the loop b
 | Alert flood from quarantine path | Alert dedup TTL: same `Container_name.t` quarantine event suppresses re-alert within 1h. Recorded in `Quarantine.t` state. |
 | Mock vs real daemon divergence | Phase 4 integration test runs both paths; mock impl reviewed against `docker --version` output diff suite. |
 | RFC-0036 cleanup hook *non-throwing* contract vs this RFC's Result.t *escalating* contract | `Sandbox_cleanup.adapter` wraps internal Result.t into the public hook (`log + swallow`). Public hook contract preserved. Internal logic retains typed errors. |
-| BLAKE3 dependency in OCaml — current opam constraints | Phase 1 chooses between `blake3` (current pin), `digestif` (already present), or `Mirage_crypto.Hash`. Decision tracked in Phase 1 PR; fallback is `Mirage_crypto.Hash.SHA256.digest` if BLAKE3 unavailable on target opam switch. |
+| BLAKE3 dependency in OCaml — current opam constraints | RESOLVED Phase 3b-i (#14741 follow-up): `digestif` 1.3.0 (already present, used 8+ times in `lib/`) ships BLAKE2B/2S/SHA-256/SHA-512 but **not BLAKE3**. Adopted `Hash_algo.t = SHA_256 \| SHA_512` for Phase 3b. Future BLAKE3 = separate PR adding `blake3` opam dep + variant arm. |
 
 ## 7. Out of Scope (v2 candidates)
 
@@ -204,7 +206,7 @@ Phases 1-5 are independently mergeable and revertible. Phase 5 closes the loop b
 
 ## 8. Open Questions
 
-1. **Default Hash_algo.t** — §3.1 now types the choice as `Hash_algo.t = BLAKE3 | SHA_256 | SHA_512`. Phase 1 decides the *default* (BLAKE3 if opam pin friction is acceptable, else SHA_256). The variant remains for future migration without re-deriving persisted names.
+1. **Default Hash_algo.t** — RESOLVED Phase 3b-i: variant is `SHA_256 | SHA_512`, default `SHA_256`. BLAKE3 deferred (digestif 1.3.0 lacks it). Future expansion = variant arm + opam dep in a separate PR.
 2. **`Container_name.t` representation** — `private string` vs phantom-typed wrapper? Default: `private string` for opam-friendly cross-compilation.
 3. **Mock client thread safety** — single-fiber injection vs concurrent? Default: single-fiber; concurrent injection adds complexity not yet justified by test patterns.
 4. **Quarantine persistence across server restart** — in-memory only, or JSONL trail? Default: in-memory; restart loses state, restart-cleanup catches it via labels.

--- a/lib/keeper/keeper_hash_algo.ml
+++ b/lib/keeper/keeper_hash_algo.ml
@@ -1,0 +1,28 @@
+(* RFC-0070 Phase 3b-i — Hash algorithm variant impl. See .mli. *)
+
+type t =
+  | SHA_256
+  | SHA_512
+[@@deriving show, eq]
+
+let all = [ SHA_256; SHA_512 ]
+
+let to_string = function
+  | SHA_256 -> "sha256"
+  | SHA_512 -> "sha512"
+
+let of_string s =
+  match String.lowercase_ascii s with
+  | "sha256" | "sha-256" | "sha_256" -> Some SHA_256
+  | "sha512" | "sha-512" | "sha_512" -> Some SHA_512
+  | _ -> None
+
+let digest_hex algo s =
+  match algo with
+  | SHA_256 -> Digestif.SHA256.(digest_string s |> to_hex)
+  | SHA_512 -> Digestif.SHA512.(digest_string s |> to_hex)
+
+let digest_bytes algo s =
+  match algo with
+  | SHA_256 -> Digestif.SHA256.(digest_string s |> to_raw_string)
+  | SHA_512 -> Digestif.SHA512.(digest_string s |> to_raw_string)

--- a/lib/keeper/keeper_hash_algo.mli
+++ b/lib/keeper/keeper_hash_algo.mli
@@ -1,0 +1,47 @@
+(** RFC-0070 Phase 3b-i — Hash algorithm variant for sandbox plan
+    derivation.
+
+    Closed sum of supported hash algorithms. New algorithms are added
+    by extending the variant — the compiler enforces exhaustive caller
+    updates. No string-keyed indirection, no runtime catch-all.
+
+    Reference: docs/rfc/RFC-0070-keeper-sandbox-pure-edge-separation.md §3.1, §8 Q1
+
+    Backend: [digestif] (opam) 1.3.0. BLAKE3 deferred — digestif 1.3.0
+    does not ship BLAKE3 (only BLAKE2B/2S of the BLAKE family). Adding
+    BLAKE3 requires opam dependency [blake3] or a digestif version
+    bump. Tracked in RFC §8 Q1. *)
+
+(** {1 Algorithm variant} *)
+
+type t =
+  | SHA_256
+  | SHA_512
+[@@deriving show, eq]
+
+(** [all] is the canonical enumeration of the variant. Use for
+    property tests and config emission; the compiler does not enforce
+    completeness of this list — callers that depend on completeness
+    should pattern-match the variant instead. *)
+val all : t list
+
+(** [to_string] returns a stable lowercase identifier suitable for
+    config emission and telemetry labels. *)
+val to_string : t -> string
+
+(** [of_string s] parses [s] case-insensitively. Returns [None] on
+    unknown input — no permissive default. *)
+val of_string : string -> t option
+
+(** {1 Digest API} *)
+
+(** [digest_hex algo s] returns the hexadecimal-encoded digest of [s]
+    under [algo]. Determinism contract: same [(algo, s)] ⇒ identical
+    output. No process state, no clock, no random. *)
+val digest_hex : t -> string -> string
+
+(** [digest_bytes algo s] returns the binary digest of [s] under
+    [algo]. Use {!digest_hex} for human-facing identifiers; this
+    function is for callers that truncate or re-encode the bytes
+    themselves. *)
+val digest_bytes : t -> string -> string


### PR DESCRIPTION
## 목표 — RFC-0070 §3.1 Phase 3b-i

Typed `Hash_algo` variant + digest API. 1 모듈 (60 lines) + RFC §3.1 amend (variant 3→2 arm, BLAKE3 deferral 명시).

## RFC 인용

| RFC | 관계 |
|-----|------|
| **RFC-0070** | 본 PR이 이행하는 spec — §3.1, §8 Q1 amend 포함 |
| **RFC-0006** | RFC-0070이 cite — sandbox 직교 (본 PR 무영향) |
| RFC-0036 | RFC-0070이 cite — cleanup hook (본 PR 무영향) |

## 변경

```
lib/keeper/keeper_hash_algo.mli    50 lines (interface)
lib/keeper/keeper_hash_algo.ml     27 lines (impl using digestif)
docs/rfc/RFC-0070-*.md             3-line amend (§3.1 + §6 + §8 Q1)
```

## RFC §3.1 amend 핵심

`Hash_algo.t = BLAKE3 | SHA_256 | SHA_512` → `SHA_256 | SHA_512`. 

**근거**: opam `digestif` 1.3.0 (lib/에 8+ caller 보유)이 BLAKE2B/2S/SHA-256/SHA-512는 제공하지만 BLAKE3는 없음. 의사 변종(BLAKE3 → failwith)을 두는 것은 closed sum 정신 위반 — "signature lying". 변종을 *실제로 구현 가능한 것만*으로 정정. 추후 BLAKE3는 `blake3` opam 의존 추가 + variant arm 한 PR로.

## 결정성 contract

`digest_hex algo s`: same `(algo, s)` ⇒ identical output. wall-clock/Random/global state 없음. exhaustive match (catch-all 없음).

## 검증

- **Isolated ocamlc**: .mli/.ml 컴파일 PASS (Phase 3a 검증 패턴 재사용).
- **`scripts/dune-local.sh build @check`**: BLOCKED — *upstream main 회귀 2건*:
  - #14744 `tool_catalog_surfaces` RESOLVED by #14746 ✅
  - **NEW**: `keeper_runtime.ml:649` + `test_supervisor_start_predicate.ml:61` — PR #14745 `drop dead [enabled] field`의 부분 cleanup. `enabled` field 제거됐으나 caller 5-tuple + test record 미정리. 본 PR 무관.

## Workaround Rejection Bar self-check

| 시그니처 | 본 PR 해당? |
|---------|------------|
| Counter-as-fix | N/A |
| String 분류기 | N/A — closed variant |
| N-of-M | N/A — 1 변종, 1 PR |
| Cap/cooldown/dedup/repair | N/A |
| Test backdoor | N/A |
| Catch-all `_ ->` | N/A — exhaustive |

## 미검증

- Property test: `∀ (algo, s), digest_hex algo s |> String.length = expected_len algo`. Phase 3b-ii에서.
- Real callers: Phase 3b-ii `Keeper_container_name.of_hash_hex`가 첫 caller.

## 다음 PR

- **Phase 3b-ii**: `Keeper_container_name` (Hash_algo를 첫 caller) — private string, of_hash_hex derivation, 16-byte truncate.
- **Phase 3b-iii**: Plan record fields (Image, Mount, Ulimit, Network) + of_request.
- **Phase 3b-iv**: Real Docker_client.

RFC-0070 §4 Migration.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
