### PR TITLE
fix(keeper): surface pending_confirms_removed count from handle_keeper_down

### DIFF
--- a/lib/keeper/keeper_turn_lifecycle.ml
+++ b/lib/keeper/keeper_turn_lifecycle.ml
@@ -21,12 +21,17 @@ let handle_keeper_down ctx args : tool_result =
          stop_keepalive ~base_path:ctx.config.base_path resolved_name
      | _ -> ());
     match read_meta_resolved ctx.config requested_name with
-    | Error e -> (false, "" ^ e)
+    | Error e -> (false, e)
     | Ok None -> (true, Printf.sprintf "keeper already absent: %s" requested_name)
     | Ok (Some (name, m)) ->
-      ignore
-        (Operator_pending_confirm.remove_pending_confirms_by_target ctx.config
-           ~target_type:"keeper" ~target_id:(Some name));
+      let pending_confirms_removed =
+        Operator_pending_confirm.remove_pending_confirms_by_target ctx.config
+          ~target_type:"keeper" ~target_id:(Some name)
+      in
+      Log.Misc.info
+        "[keeper_down] cleanup keeper=%s pending_confirms_removed=%d \
+         remove_meta=%b remove_session=%b"
+        name pending_confirms_removed remove_meta remove_session;
       (if remove_meta then
          ( Safe_ops.remove_file_logged ~context:"keeper_down"
              (keeper_meta_path ctx.config name);
@@ -89,5 +94,6 @@ let handle_keeper_down ctx args : tool_result =
         ("stopped", `Bool true);
         ("remove_meta", `Bool remove_meta);
         ("remove_session", `Bool remove_session);
+        ("pending_confirms_removed", `Int pending_confirms_removed);
       ] in
       (true, Yojson.Safe.to_string json)


### PR DESCRIPTION
## Summary

`Operator_pending_confirm.remove_pending_confirms_by_target` returns the number of pending confirms it cleared, but `handle_keeper_down` threw it away with `ignore`. Align the keeper-down surface with the sibling `agent_purge` path in `server_dashboard_http_delete_actions.ml`, which already captures and logs that count.

## Why

Operators trigger keeper teardown via two surfaces:

- `agent_purge` (dashboard HTTP) — logs `pending_confirms_removed=N` per agent
- `masc_keeper_down` (MCP tool) — silently dropped the count

Same operation, different visibility. After this PR, both surfaces emit a comparable log line + dashboard-readable count in their structured response.

## Changes

1. Capture `pending_confirms_removed = Operator_pending_confirm.remove_pending_confirms_by_target ...`
2. Emit `Log.Misc.info "[keeper_down] cleanup keeper=%s pending_confirms_removed=%d remove_meta=%b remove_session=%b" ...` (mirrors the agent_purge format)
3. Add `("pending_confirms_removed", \`Int pending_confirms_removed)` to the JSON response — dashboard consumers can render it without re-querying

Plus one micro-cleanup: dropped the no-op `("" ^ e)` string concat from the `Error e` branch.

Diff: **+10 / -4 LOC**.

## Workaround self-check

| # | check | result |
|---|---|---|
| 1 | telemetry-as-fix? | no — log + JSON restore a previously-swallowed count; no new counter |
| 2 | string classifier? | no |
| 3 | N-of-M? | no — single ignore site in this handler |
| 4 | catch-all `_ ->` added? | no |
| 5 | cap/cooldown/dedup/repair? | no |
| 6 | test backdoor? | no |
| 7 | same typo N sites? | no |

## Test plan

- [x] Same return value, now captured + reported
- [ ] CI build + test (local build blocked by `dune-local.sh` global lock)

🤖 Generated with [Claude Code](https://claude.com/claude-code)