### PR TITLE
feat(telemetry): typed Error_event_type for metric_error_events label

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -3,6 +3,7 @@
  (name masc_mcp)
  (public_name masc_mcp)
 (private_modules
+ error_event_type
  dashboard_http_keeper_metrics
  dashboard_http_keeper_detail
  dashboard_http_tool_quality

--- a/lib/error_event_type.ml
+++ b/lib/error_event_type.ml
@@ -1,0 +1,8 @@
+type t =
+  | Parsing
+  | Missing_config
+
+let to_label = function
+  | Parsing -> "parsing"
+  | Missing_config -> "missing_config"
+;;

--- a/lib/error_event_type.mli
+++ b/lib/error_event_type.mli
@@ -1,0 +1,22 @@
+(** Error_event_type — closed sum for the [type] label on
+    [metric_error_events] (`masc_error_events_total`).
+
+    Replaces 6 hardcoded string literals scattered across 3 files
+    (`tool_metrics_persist.ml`, `run_eio.ml`, `server_runtime_bootstrap.ml`).
+    The comment on the metric definition in `prometheus.ml` even
+    spelled out the open-ended risk:
+
+        "Error events by type (parsing, missing_config, etc.)"
+
+    "etc." is the workaround #2 admission — future callers can sprinkle
+    any string they like.  Close the set here so a new event type
+    requires a single edit and the new wire string surfaces at compile
+    time at every emission site. *)
+
+type t =
+  | Parsing (** JSON / config parse failure. *)
+  | Missing_config (** Required runtime configuration absent at boot. *)
+
+(** Stable wire format for the [type] label.  Returns the exact
+    strings the legacy code emitted: ["parsing"] / ["missing_config"]. *)
+val to_label : t -> string

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -1144,7 +1144,10 @@ let init () =
     Histogram;
   add metric_tasks "Total tasks processed" Counter;
   add metric_errors "Total errors" Counter;
-  add metric_error_events "Error events by type (parsing, missing_config, etc.)" Counter;
+  (* [type] label is bound by [Error_event_type.t] — adding a new value
+     requires extending the closed sum and re-running every emit site
+     through the compiler. *)
+  add metric_error_events "Error events by type (parsing, missing_config)" Counter;
   add
     metric_workspace_route_failures
     "Total workspace route filesystem/git/read exceptions, labeled by site"

--- a/lib/run_eio.ml
+++ b/lib/run_eio.ml
@@ -46,7 +46,7 @@ let run_record_of_json (json : Yojson.Safe.t) : run_record option =
     let deliverable = Safe_ops.json_string ~default:"" "deliverable" json in
     Some { task_id; agent_name; plan; deliverable; created_at; updated_at }
   | _ ->
-    Prometheus.inc_counter Prometheus.metric_error_events ~labels:[("type", "parsing")] ();
+    Prometheus.inc_counter Prometheus.metric_error_events ~labels:[("type", Error_event_type.(to_label Parsing))] ();
     Log.Misc.error "run_of_json: missing required fields";
     None
 
@@ -62,7 +62,7 @@ let log_entry_of_json (json : Yojson.Safe.t) : log_entry option =
   | Some timestamp, Some note ->
     Some { timestamp; note }
   | _ ->
-    Prometheus.inc_counter Prometheus.metric_error_events ~labels:[("type", "parsing")] ();
+    Prometheus.inc_counter Prometheus.metric_error_events ~labels:[("type", Error_event_type.(to_label Parsing))] ();
     Log.Misc.error "log_entry_of_json: missing required fields";
     None
 

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -290,7 +290,7 @@ let record_tool_policy_init_failure ~base_path msg =
     ~labels:[("base_path", base_path)]
     ();
   Prometheus.inc_counter Prometheus.metric_error_events
-    ~labels:[("type", "missing_config")]
+    ~labels:[("type", Error_event_type.(to_label Missing_config))]
     ();
   Log.Server.error "Fatal tool policy config load failure: %s" msg
 
@@ -1236,7 +1236,7 @@ let bootstrap_prompt_state (state : Mcp_server.server_state) =
   let missing_prompt_files = Prompt_registry.validate_required_prompt_files () in
   if missing_prompt_files <> [] then
     begin
-    Prometheus.inc_counter Prometheus.metric_error_events ~labels:[("type", "missing_config")] ();
+    Prometheus.inc_counter Prometheus.metric_error_events ~labels:[("type", Error_event_type.(to_label Missing_config))] ();
     Log.Misc.error "required prompt files missing: %s"
       (missing_prompt_files
       |> List.map (fun (key, path) -> Printf.sprintf "%s -> %s" key path)
@@ -1245,7 +1245,7 @@ let bootstrap_prompt_state (state : Mcp_server.server_state) =
   let invalid_prompt_templates = Prompt_registry.validate_prompt_templates () in
   if invalid_prompt_templates <> [] then
     begin
-    Prometheus.inc_counter Prometheus.metric_error_events ~labels:[("type", "missing_config")] ();
+    Prometheus.inc_counter Prometheus.metric_error_events ~labels:[("type", Error_event_type.(to_label Missing_config))] ();
     Log.Misc.error "prompt templates use unknown variables: %s"
       (invalid_prompt_templates
       |> List.map (fun (key, variable) -> Printf.sprintf "%s -> %s" key variable)

--- a/lib/tool_metrics_persist.ml
+++ b/lib/tool_metrics_persist.ml
@@ -62,7 +62,7 @@ let parse_record (json : Yojson.Safe.t)
       |> List.filter_map (fun (field, is_missing) ->
         if is_missing then Some field else None)
     in
-    Prometheus.inc_counter Prometheus.metric_error_events ~labels:[("type", "parsing")] ();
+    Prometheus.inc_counter Prometheus.metric_error_events ~labels:[("type", Error_event_type.(to_label Parsing))] ();
     Error
       (Printf.sprintf "missing required field(s): %s"
          (String.concat ", " missing))


### PR DESCRIPTION
## Summary

6 hardcoded `"type"` label strings on `metric_error_events`
(`masc_error_events_total`) — scattered across 3 files — collapsed into
a closed sum `Error_event_type.t`.

## Why

The comment on the metric definition in `prometheus.ml` said the quiet
part out loud:

> "Error events by type (parsing, missing_config, etc.)"

"etc." is the workaround #2 admission — future callers could sprinkle
any string they liked and the cardinality would drift silently.  The
closed sum now requires extending the variant and re-running every
emit site through the compiler.

## Sites (6)

| File | Variant |
|------|---------|
| `lib/tool_metrics_persist.ml:65` | `Parsing` |
| `lib/run_eio.ml:49` | `Parsing` |
| `lib/run_eio.ml:65` | `Parsing` |
| `lib/server/server_runtime_bootstrap.ml:293` | `Missing_config` |
| `lib/server/server_runtime_bootstrap.ml:1239` | `Missing_config` |
| `lib/server/server_runtime_bootstrap.ml:1248` | `Missing_config` |

## Approach

New `lib/error_event_type.ml(.mli)`:

```ocaml
type t = Parsing | Missing_config

val to_label : t -> string
```

Wire format byte-equal.

## Test plan

- [ ] CI green
- [ ] `rg '"type", "(parsing|missing_config)"' lib/` = 0

RFC-WAIVED: not in credential/identity/operator/sandbox/hooks/workflow scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)