### PR TITLE
feat(telemetry): typed kind labels for keeper alert/sse failure metrics

### DIFF
--- a/lib/keeper/alert_persist_kind.ml
+++ b/lib/keeper/alert_persist_kind.ml
@@ -1,0 +1,10 @@
+type t =
+  | Alert
+  | Failed_channels
+  | Deadletter
+
+let to_label = function
+  | Alert -> "alert"
+  | Failed_channels -> "failed_channels"
+  | Deadletter -> "deadletter"
+;;

--- a/lib/keeper/alert_persist_kind.mli
+++ b/lib/keeper/alert_persist_kind.mli
@@ -1,0 +1,15 @@
+(** Alert_persist_kind — closed sum for the [kind] label on
+    [metric_keeper_alert_persist_failures].
+
+    Replaces 3 hardcoded string literals in [keeper_alerting.ml]
+    (`"alert"` / `"failed_channels"` / `"deadletter"`).  The closed
+    sum forces every emit site through the compiler so adding a
+    new persistence failure category requires a single edit and
+    the new wire string surfaces immediately. *)
+
+type t =
+  | Alert (** Primary alert payload persist failure. *)
+  | Failed_channels (** Per-channel delivery failure record persist failure. *)
+  | Deadletter (** Deadletter store persist failure. *)
+
+val to_label : t -> string

--- a/lib/keeper/keeper_alerting.ml
+++ b/lib/keeper/keeper_alerting.ml
@@ -552,7 +552,7 @@ let maybe_emit_interesting_alert
       in
       (try append_jsonl_line (keeper_alerts_path ctx.config) alert_json with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
       Log.Keeper.error "alert JSONL write failed: %s" (Printexc.to_string exn);
-        Prometheus.inc_counter Keeper_metrics.metric_keeper_alert_persist_failures ~labels:[("kind", "alert")] ());
+        Prometheus.inc_counter Keeper_metrics.metric_keeper_alert_persist_failures ~labels:[("kind", Alert_persist_kind.(to_label Alert))] ());
       let board_result =
         run_alert_channel_with_retry ctx
           ~channel:"board"
@@ -625,7 +625,7 @@ let maybe_emit_interesting_alert
               ])
          with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
            Log.Keeper.error "failed-channels JSONL write failed: %s" (Printexc.to_string exn);
-           Prometheus.inc_counter Keeper_metrics.metric_keeper_alert_persist_failures ~labels:[("kind", "failed_channels")] ());
+           Prometheus.inc_counter Keeper_metrics.metric_keeper_alert_persist_failures ~labels:[("kind", Alert_persist_kind.(to_label Failed_channels))] ());
       if deadlettered then
         (try
            append_jsonl_line
@@ -640,7 +640,7 @@ let maybe_emit_interesting_alert
               ])
          with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
            Log.Keeper.error "deadletter JSONL write failed: %s" (Printexc.to_string exn);
-           Prometheus.inc_counter Keeper_metrics.metric_keeper_alert_persist_failures ~labels:[("kind", "deadletter")] ());
+           Prometheus.inc_counter Keeper_metrics.metric_keeper_alert_persist_failures ~labels:[("kind", Alert_persist_kind.(to_label Deadletter))] ());
       {
         enabled = true;
         triggered = true;

--- a/lib/keeper/keeper_unified_metrics.ml
+++ b/lib/keeper/keeper_unified_metrics.ml
@@ -1583,7 +1583,7 @@ let broadcast_lifecycle_events ~(name : string)
      | exn ->
          Log.Keeper.error "compaction SSE broadcast failed: %s"
            (Printexc.to_string exn);
-         Prometheus.inc_counter Keeper_metrics.metric_keeper_metrics_sse_failures ~labels:[("kind", "compaction")] ());
+         Prometheus.inc_counter Keeper_metrics.metric_keeper_metrics_sse_failures ~labels:[("kind", Metrics_sse_failure_kind.(to_label Compaction))] ());
   match handoff_json with
   | Some ((`Assoc _ as handoff)) ->
       let from_generation =
@@ -1611,7 +1611,7 @@ let broadcast_lifecycle_events ~(name : string)
       | exn ->
           Log.Keeper.error "handoff SSE broadcast failed: %s"
             (Printexc.to_string exn);
-          Prometheus.inc_counter Keeper_metrics.metric_keeper_metrics_sse_failures ~labels:[("kind", "handoff")] ())
+          Prometheus.inc_counter Keeper_metrics.metric_keeper_metrics_sse_failures ~labels:[("kind", Metrics_sse_failure_kind.(to_label Handoff))] ())
   | _ -> ()
 
 let update_metrics_from_failure (meta : keeper_meta) ~(latency_ms : int)

--- a/lib/keeper/metrics_sse_failure_kind.ml
+++ b/lib/keeper/metrics_sse_failure_kind.ml
@@ -1,0 +1,8 @@
+type t =
+  | Compaction
+  | Handoff
+
+let to_label = function
+  | Compaction -> "compaction"
+  | Handoff -> "handoff"
+;;

--- a/lib/keeper/metrics_sse_failure_kind.mli
+++ b/lib/keeper/metrics_sse_failure_kind.mli
@@ -1,0 +1,12 @@
+(** Metrics_sse_failure_kind — closed sum for the [kind] label on
+    [metric_keeper_metrics_sse_failures].
+
+    Replaces 2 hardcoded string literals in [keeper_unified_metrics.ml]
+    (`"compaction"` / `"handoff"`) — the two SSE broadcast paths
+    whose failures are counted on this metric. *)
+
+type t =
+  | Compaction (** keeper_compaction lifecycle SSE broadcast failure. *)
+  | Handoff (** keeper handoff/rollover SSE broadcast failure. *)
+
+val to_label : t -> string


### PR DESCRIPTION
## Summary

Two more keeper-side metrics with `kind` label hardcoded strings
collapsed into closed sums.

## Sites (5)

| Metric | File | Variant |
|--------|------|---------|
| `metric_keeper_alert_persist_failures` | `keeper_alerting.ml:555` | `Alert_persist_kind.Alert` |
| `metric_keeper_alert_persist_failures` | `keeper_alerting.ml:628` | `Alert_persist_kind.Failed_channels` |
| `metric_keeper_alert_persist_failures` | `keeper_alerting.ml:643` | `Alert_persist_kind.Deadletter` |
| `metric_keeper_metrics_sse_failures` | `keeper_unified_metrics.ml:1586` | `Metrics_sse_failure_kind.Compaction` |
| `metric_keeper_metrics_sse_failures` | `keeper_unified_metrics.ml:1614` | `Metrics_sse_failure_kind.Handoff` |

## Why

Same workaround #2 (string classifier) pattern that earlier sweep
iterations closed for `compaction_trigger`, `oas_execution_error_phase`,
`error_event_type`, `sse_reject_reason`.

Each metric had a closed-in-practice set of values (3 and 2
respectively) but with no type-level guarantee — adding a new value
historically meant one-line edits scattered across emit sites, and
dashboards had to enumerate possible values by reading code.

## Approach

Two new modules, both following the established `Foo_kind.t` +
`to_label` pattern:

```ocaml
(* lib/keeper/alert_persist_kind.ml *)
type t = Alert | Failed_channels | Deadletter
val to_label : t -> string

(* lib/keeper/metrics_sse_failure_kind.ml *)
type t = Compaction | Handoff
val to_label : t -> string
```

Wire format byte-equal.

## Test plan

- [ ] CI green
- [ ] `rg '~labels:\[\("kind", "(alert|failed_channels|deadletter|compaction|handoff)"\)\]' lib/keeper/` = 0

RFC-WAIVED: not in credential/identity/operator/sandbox/hooks/workflow scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)