### PR TITLE
feat(keeper): A-7 — wire snapshot invariant scan into supervisor sweep

### DIFF
--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -1421,6 +1421,35 @@ let sweep_and_recover (ctx : _ context) =
      This prevents reconcile from re-launching keepers that sweep is about
      to process (defense-in-depth alongside is_registered check). *)
   let entries = Keeper_registry.all ~base_path () in
+  (* R-A-6.c / A-7 wire-in: per-sweep snapshot invariant scan.
+
+     Iter 14 audit (`docs/tla-audit/ksm-a6-budget-never-revives-2026-05-12.md`)
+     identified that `keeper_invariant_check` was test-only — production
+     never invoked it.  Iter 16 (#14758) added [check_snapshot_invariants]
+     suitable for sweep-time scans.
+
+     Policy: WARN log per violation.  Intentionally NOT halting the sweep
+     or marking-dead — a violation here is a development/migration
+     signal, not a runtime emergency.  Metric/alarm escalation is a
+     follow-up. *)
+  List.iter
+    (fun (entry : Keeper_registry.registry_entry) ->
+       let vs =
+         Keeper_invariant_check.check_snapshot_invariants
+           ~phase:entry.phase
+           ~conditions:entry.conditions
+       in
+       List.iter
+         (fun (v : Keeper_invariant_check.violation) ->
+            Log.Keeper.warn
+              "keeper_invariant_violation: keeper=%s phase=%s property=%s \
+               detail=%s"
+              entry.name
+              (Keeper_state_machine.phase_to_string entry.phase)
+              v.property
+              v.detail)
+         vs)
+    entries;
   let to_restart = ref [] in
   let to_unregister = ref [] in
   let to_mark_dead = ref [] in


### PR DESCRIPTION
## Finding (Iteration 17, Phase A-7)

**Spec**: `specs/keeper-state-machine/KeeperStateMachine.tla` (invariants 1, 6, 7, 8, 9 enforced at sweep time)
**OCaml**: `lib/keeper/keeper_supervisor.ml` (`sweep_and_recover` +29 LOC)
**Aspect**: 3 iteration audit chain의 production wire-in. iter 14 audit가 "step invariant은 있으나 production 미호출" 발견 → iter 16 #14758이 snapshot form 추가 → 본 PR이 supervisor sweep에 호출자 추가. **Wire-in chain 완성**.
**Risk**: LOW — additive WARN log, no flow change
**Stack**: base = `feature/r-a-6-c-snapshot-invariants` (PR #14758). 머지 후 main으로 auto-rebase.

## 순서도 — invariant scan in sweep order

```mermaid
graph TB
    Start[sweep_and_recover entry] --> Health[Keeper_health_probe.run_once]
    Health --> All[Keeper_registry.all → entries]
    All --> Scan[**NEW** snapshot invariant scan<br/>per entry × 5 invariants]
    Scan -->|violation| Warn[Log.Keeper.warn keeper_invariant_violation]
    Scan -->|clean| Continue1
    Warn --> Continue1[continue sweep — no halt]
    Continue1 --> Categorize[to_restart / to_mark_dead /<br/>to_unregister / to_cleanup_dead]
    Categorize --> Restart[restart loop]
    Categorize --> MarkDead[mark_dead loop]
    style Scan fill:#94e2a3
    style Warn fill:#ffe58a
```

## 3-iteration audit chain 완성

| Iter | PR | 기여 |
|---|---|---|
| 14 | #14751 | Audit memo — `check_step_invariants` 코드 존재하나 production 미호출. 3 future revival vectors 식별. |
| 16 | #14758 | `check_snapshot_invariants` 함수 추가 — prev-state 없이 5 invariants 검사. |
| **17 (this)** | this | Supervisor sweep에 호출 추가 — invariant이 *실제로* production에서 평가됨. |

세 iteration 모두 동일 결함의 다른 차원을 다룸 — *식별*, *도구 제공*, *사용*. 한 iteration에 모두 담으면 10-min budget 초과 + 결정 합쳐짐. 분리해 각 단계 의도가 명확.

## Wire-in 위치 선택 근거

`sweep_and_recover`의 entry point 직후:

```
Line 1419: Keeper_health_probe.run_once       ← 이미 sweep-time 점검
Line 1423: entries = Keeper_registry.all      ← entries 확보
Line 1424: ← **NEW: invariant scan 여기**
Line 1454: to_restart / to_mark_dead 분류 시작 ← entries 처리
```

**이 위치인 이유**:
- entries 확보 직후 — entry state는 sweep-snapshot으로 안정.
- 분류 처리 *이전* — scan 결과가 분류 logic에 영향 미치지 않음 (read-only).
- `run_once` 패턴과 일관 — sweep-time 점검 layer 추가.

다른 옵션들 거부:
- ❌ 각 entry 처리 inline: 가독성 저하, 처리 분기마다 중복.
- ❌ 별도 fiber로 비동기: race condition, sweep과 다른 snapshot.
- ❌ `dispatch_event` 옆 step form 사용: step invariant은 이미 호출되도록 wire-in 가능하지만 더 큰 변경 (registry write path 전반 touch).

## Policy 선택: WARN log only

**선택**: WARN log emit, sweep 계속 진행.

**거부된 옵션**:
- ❌ **Halt sweep on violation**: invariant logic 자체 버그 시 healthy keepers mass-stop 위험. liveness > correctness here.
- ❌ **Mark_dead on critical violation**: severity tiering 정의 안 됨 (DeadRequiresNoBudget critical vs DerivePhaseAgreement warning?).
- ❌ **Prometheus counter only**: 운영자 즉시 알림 어려움. WARN log는 standard log pipeline이 잡음.
- ⏭️ **Metric + alarm escalation**: follow-up RFC (severity tier 정의 + 알람 thresholds).

WARN-then-continue가 **defensive observability**의 표준 — Schmidt's law "make it visible, then make it actionable, then make it preventable" 첫 단계.

## 왜 톱니처럼 정교하지 않은가 (이번 PR이 닫은 결함)

iter 14 audit가 발견한 모순: spec §S3 BudgetNeverRevives invariant이 OCaml에 **존재**했으나 production이 한 번도 평가하지 않았음. 다른 5 invariants도 마찬가지. 본 PR 이전에는 invariant이 *unit test/PBT 환경에서만 작동하는 paper-spec* — production state mutation이 어떻게 invariant을 위반해도 silent.

이제 supervisor sweep 매 iteration마다 모든 entry를 5 invariants로 검사하고 WARN log 남김. 새 mutation path가 추가되어 invariant을 위반하면:
1. 다음 sweep tick에서 즉시 가시화.
2. 운영자가 WARN log 패턴 모니터링 가능.
3. 회귀가 silent하게 main에 들어오지 못함.

## 본 PR 수정

| 변경 | 위치 |
|---|---|
| Snapshot scan loop + WARN log (29 LOC) | `lib/keeper/keeper_supervisor.ml:1424-1452` |

**무엇이 *바뀌지 않았는가***: scan 자체는 read-only, sweep flow (`to_restart` / `to_mark_dead` 분류 + 처리)는 그대로. 71+ supervisor tests 회귀 0.

## Verification

- [x] `dune build --root . @check` — clean.
- [x] `dune exec --root . test/test_keeper_state_machine.exe` — **123 tests pass** (R-A-6.c snapshot tests 포함).
- [x] `dune exec --root . test/test_keeper_supervisor.exe` — **70 tests pass** (30s, no regression).
- [x] `dune exec --root . test/test_keeper_lifecycle_chaos.exe` — **10 tests pass**.

## Trade-off / 후속 PR

- **Severity tiering 미정의**: critical (Dead/Stopped invariants) vs warning (DerivePhaseAgreement) 구분 없음. RFC-scope.
- **Metric 미추가**: Prometheus counter 추가 시 operator dashboard 가능. follow-up.
- **Alarm escalation 미정의**: N consecutive violations → page operator? 정책 결정 필요.
- **History-dependent invariants 미커버**: BudgetNeverRevives, DeadIsForever 등은 step-form만 가능. registry entry에 prev-snapshot 캐싱하거나 trace replay 도입 시 가능 — RFC-scope.

## RFC 참조

- A-7 (plan Phase A-7 — invariant wire-in).
- `RFC-WAIVED`: keeper FSM observability, credential / identity / operator-control / sandbox / hooks 범위 밖.

## 진행 추적

다음 iteration 시작점: **R-A-6.a** (register_restarting Result.t guard — 진짜 §S3 BudgetNeverRevives 위반 root cause, MID risk) OR **R-A-8 PR-2** (KNOWN_FAILURES purge, TLC run) OR **A-7 severity tiering** (metric + alarm escalation).

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
