### PR TITLE
fix(keeper): two more guard predicates with explicit variant enumeration

### DIFF
--- a/lib/anti_rationalization.ml
+++ b/lib/anti_rationalization.ml
@@ -727,9 +727,24 @@ let review
           by liveness — the operator must fix the cascade definition
           before the safety net can do useful work. *)
             let cascade_permanently_dead =
+              (* Enumerate every [masc_internal_error] variant plus [None]
+                 so the compiler flags any new constructor here. Same
+                 reasoning as [degraded_retry_bypasses_slot_phase_guard]
+                 (closed in PR #14716): a guard whose default direction
+                 is [false] must not absorb new error classes silently. *)
               match Keeper_turn_driver.classify_masc_internal_error err with
               | Some (Keeper_turn_driver.No_tool_capable_provider _) -> true
-              | _ -> false
+              | Some
+                  ( Keeper_turn_driver.Cascade_exhausted _
+                  | Keeper_turn_driver.Resumable_cli_session _
+                  | Keeper_turn_driver.Accept_rejected _
+                  | Keeper_turn_driver.Admission_queue_timeout _
+                  | Keeper_turn_driver.Admission_queue_rejected _
+                  | Keeper_turn_driver.Turn_timeout _
+                  | Keeper_turn_driver.Oas_timeout_budget _
+                  | Keeper_turn_driver.Ambiguous_post_commit _ )
+              | None ->
+                false
             in
             let mode = Env_config.AntiRationalization.fail_mode in
             let mode_str = Env_config.AntiRationalization.fail_mode_to_string mode in

--- a/lib/governance_pipeline_risk.ml
+++ b/lib/governance_pipeline_risk.ml
@@ -246,9 +246,14 @@ let payload_severity input : payload_severity =
   loop Payload_clean strings
 
 let has_destructive_payload input =
+  (* Enumerate every [payload_severity] variant. A future severity
+     (e.g. [Payload_admin_only], [Payload_data_exfil]) added between
+     Evasion_only and Destructive should be classified deliberately —
+     the [_ -> false] catch-all would have silently inherited
+     "not destructive" for a new high-risk class. *)
   match payload_severity input with
   | Payload_destructive -> true
-  | _ -> false
+  | Payload_clean | Payload_evasion_only -> false
 
 let has_empty_overwrite_payload input =
   collect_string_values ~keys:empty_overwrite_payload_keys input


### PR DESCRIPTION
## Why

Two more boolean guards used `_ -> false` catch-all over closed sums. Same anti-pattern as PR #14716; these were missed in that sweep because they live *outside* `lib/keeper/`.

For a guard predicate (whose purpose is to detect a specific condition), `_ -> false` as the default is the **wrong** safety direction: any future variant silently inherits "guard not triggered". Compiler stays silent.

## Sites

### 1. `lib/anti_rationalization.ml:729` — `cascade_permanently_dead`

Scrutinee: `Keeper_turn_driver.classify_masc_internal_error err`, type `masc_internal_error option` (9 constructors + `None`). Old code caught only `Some (No_tool_capable_provider _)` and dumped the other 8 variants + `None` into the catch-all. A future error class would silently inherit "cascade is healthy" — the opposite of what this guard exists to detect (the function decides whether to *fail open* with a safety-net approval).

### 2. `lib/governance_pipeline_risk.ml:248` — `has_destructive_payload`

Scrutinee: `payload_severity`, a 3-variant closed sum (`Payload_clean | Payload_evasion_only | Payload_destructive`). Old `_ -> false` would absorb any future severity (e.g. `Payload_admin_only`, `Payload_data_exfil`) into "not destructive" — exactly the wrong default for a destructive-payload detector.

## What

Both sites: enumerate every non-target variant explicitly. Behavior is unchanged for the current variants. The compiler will now flag a new constructor at each guard so the maintainer must deliberately decide whether it triggers the guard.

A short comment at each site explains *why* the catch-all was the wrong default direction (guard-specific) so a future reader doesn't reintroduce it.

## Verification

\`\`\`
dune build lib/anti_rationalization.ml lib/governance_pipeline_risk.ml --root .   # exit 0
\`\`\`

## Scope

Surgical. Two predicates, two files, no behavior change. No `.mli` change.

## Companion PRs

- #14716 (MERGED) closed three guard predicates in `lib/keeper/`
- This PR closes two more guard predicates in `lib/` top-level

After this PR, a follow-up grep `rg -B 3 '\| _ -> false$' lib/ | rg -B 2 'classify_masc_internal_error\|payload_severity\|task_status'` should be empty for the same anti-pattern shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)