### PR TITLE
perf(mcp): O(1) tool_allowed_in_profile Full — drop per-call visible_tool_schemas rebuild

### DIFF
--- a/lib/config.ml
+++ b/lib/config.ml
@@ -101,6 +101,21 @@ let all_tool_names () : string list =
 let is_tool_visible tool_name =
   Tool_catalog.is_visible tool_name
 
+(* O(1) membership lookup for "is this name in raw_all_tool_schemas?".
+   Hot path: [Mcp_server_eio_tool_profile.tool_allowed_in_profile Full]
+   previously rebuilt visible_tool_schemas (dedupe + canonicalize + filter)
+   then List.map .name then List.mem per dispatch — ~150 entries scanned
+   per MCP tool call.  Hashtbl built once at module init. *)
+let raw_tool_name_set : (string, unit) Hashtbl.t =
+  let tbl = Hashtbl.create (List.length raw_all_tool_schemas * 2) in
+  List.iter
+    (fun (schema : Masc_domain.tool_schema) ->
+      Hashtbl.replace tbl schema.name ())
+    raw_all_tool_schemas;
+  tbl
+
+let is_raw_tool_name name = Hashtbl.mem raw_tool_name_set name
+
 let visible_tool_schemas ?(include_hidden = false) ?(include_deprecated = false) () :
     Masc_domain.tool_schema list =
   Capability_registry.visible_public_tool_schemas_from ~include_hidden

--- a/lib/config.mli
+++ b/lib/config.mli
@@ -19,6 +19,14 @@ val all_tool_names : unit -> string list
 val is_tool_visible : string -> bool
 (** Check if a tool is visible. *)
 
+val is_raw_tool_name : string -> bool
+(** [is_raw_tool_name name] is [true] when [name] appears in
+    {!raw_all_tool_schemas} — i.e. the tool universe before any
+    capability / visibility filtering.  O(1) via a name-keyed Hashtbl
+    built once at module init.  Used on the MCP dispatch hot path
+    where the alternative was rebuilding the entire visible schema
+    list per call just to membership-test one name. *)
+
 val visible_tool_schemas :
   ?include_hidden:bool ->
   ?include_deprecated:bool ->

--- a/lib/mcp_server_eio_tool_profile.ml
+++ b/lib/mcp_server_eio_tool_profile.ml
@@ -116,11 +116,17 @@ let tool_allowed_in_profile ?(internal_keeper_runtime = false) state profile
       if Tool_catalog.is_on_surface Tool_catalog.Keeper_internal tool_name then
         internal_keeper_runtime
       else
-        let allowed_schema_names =
-          Config.visible_tool_schemas ~include_hidden:true ~include_deprecated:true ()
-          |> List.map (fun (schema : Masc_domain.tool_schema) -> schema.name)
-        in
-        List.mem tool_name allowed_schema_names
+        (* Equivalent to [List.mem tool_name (names from
+           visible_tool_schemas ~include_hidden:true
+           ~include_deprecated:true)]: that helper composes raw schemas
+           → dedupe → canonicalize → filter is_visible.  Dedupe and
+           canonicalize do not change the name set, so the name set is
+           exactly { n | n ∈ raw_all_tool_schemas.names ∧ is_visible n }.
+           Two O(1) checks replace ~150 schema canonicalizations + a
+           List.mem per dispatch. *)
+        Config.is_raw_tool_name tool_name
+        && Tool_catalog.is_visible ~include_hidden:true ~include_deprecated:true
+             tool_name
   | Managed_agent ->
       Option.is_some (Sdk_tool_contract.sdk_binding_by_name tool_name)
       || (tool_schemas_for_profile state Managed_agent


### PR DESCRIPTION
## Summary

\`Mcp_server_eio_tool_profile.tool_allowed_in_profile state Full tool_name\` rebuilt the entire visible schema list per dispatch:

\`\`\`ocaml
let allowed_schema_names =
  Config.visible_tool_schemas ~include_hidden:true ~include_deprecated:true ()
  |> List.map (fun s -> s.name)
in
List.mem tool_name allowed_schema_names
\`\`\`

That helper runs \`dedupe + canonicalize + filter is_visible\` over ~150 raw schemas. Per MCP dispatch we paid hundreds of allocations plus a full \`Tool_help_registry.canonicalize_schemas\` pass, then \`List.map\` + \`List.mem\`.

## The simpler equivalent

The composed pipeline reduces to two O(1) lookups:

\`\`\`
names_of (visible_tool_schemas ~hidden ~deprecated)
= { n | n ∈ raw_all_tool_schemas.names ∧ is_visible ~hidden ~deprecated n }
\`\`\`

- **Dedupe** removes duplicate schemas but does not change the name *set*.
- **Canonicalize** rewrites descriptions, not names.
- **Filter \`is_visible\`** is per-name; replicable directly on \`tool_name\`.

So membership is: \`is_raw_tool_name(name) && is_visible(name)\`.

## Changes

- \`lib/config.ml\`: precompute \`raw_tool_name_set : (string, unit) Hashtbl.t\` once at module init; expose \`Config.is_raw_tool_name : string -> bool\`.
- \`lib/config.mli\`: add \`val is_raw_tool_name\` with docstring noting the hot-path rationale.
- \`lib/mcp_server_eio_tool_profile.ml\`: replace the schema-rebuild + \`List.mem\` chain with \`is_raw_tool_name && Tool_catalog.is_visible\`.

## Compounding

This continues the per-dispatch cost-shedding chain established by:
- #14728 \`Tool_access_policy\` O(1) set ops
- #14734 \`Tool_catalog_surfaces.is_on_surface\` direct variant match
- #14740 \`Tool_access_role\` per-role policy memoization
- #14749 \`Tool_catalog.metadata\` keeper_internal Hashtbl + dedupe surface query

After this PR, a Full-profile dispatch authorization decision touches **only Hashtbl.mem + variant match** — no list rebuilds, no canonicalize passes.

## Test plan

- [ ] CI lib/ build green
- [ ] \`dune runtest test/test_mcp_server_eio*.exe\` passes
- [ ] Smoke test: \`tool_allowed_in_profile Full\` returns true for a known visible tool, false for a known hidden non-keeper-internal tool

🤖 Generated with [Claude Code](https://claude.com/claude-code)