### PR TITLE
feat(rfc-0070): Phase 3b-ii — Keeper_container_name (deterministic name derivation)

### DIFF
--- a/lib/keeper/keeper_container_name.ml
+++ b/lib/keeper/keeper_container_name.ml
@@ -12,9 +12,11 @@ let of_hash_hex ~algo ~turn_id ~attempt ~suffix =
   let input =
     (* Use unit separators (US, \x1F) so concatenation is unambiguous —
        different (turn_id, attempt, suffix) tuples map to different
-       inputs even when one field's serialisation could otherwise
-       collide with another's (e.g., suffix="42|7" vs turn_id=42 ++
-       attempt=7). *)
+       inputs even when adjacent digit fields could otherwise blur.
+       Without separators, [Printf.sprintf "%d%d%s" 1 23 "x" = "123x"]
+       and [Printf.sprintf "%d%d%s" 12 3 "x" = "123x"] — same string.
+       With \x1f between fields these become "1\x1f23\x1fx" vs
+       "12\x1f3\x1fx" and remain distinct. *)
     Printf.sprintf "%d\x1f%d\x1f%s" turn_id attempt suffix
   in
   let hex = Keeper_hash_algo.digest_hex algo input in

--- a/lib/keeper/keeper_container_name.ml
+++ b/lib/keeper/keeper_container_name.ml
@@ -1,0 +1,27 @@
+(* RFC-0070 Phase 3b-ii — Container_name derivation. See .mli. *)
+
+type t = string
+
+(* Slice the first N hex chars of the hex-encoded digest. 32 hex chars
+   = 16 bytes = 128 bits of entropy from the digest. RFC §3.1. *)
+let hex_chars_taken = 32
+
+let prefix = "masc-keeper-"
+
+let of_hash_hex ~algo ~turn_id ~attempt ~suffix =
+  let input =
+    (* Use unit separators (US, \x1F) so concatenation is unambiguous —
+       different (turn_id, attempt, suffix) tuples map to different
+       inputs even when one field's serialisation could otherwise
+       collide with another's (e.g., suffix="42|7" vs turn_id=42 ++
+       attempt=7). *)
+    Printf.sprintf "%d\x1f%d\x1f%s" turn_id attempt suffix
+  in
+  let hex = Keeper_hash_algo.digest_hex algo input in
+  prefix ^ String.sub hex 0 hex_chars_taken
+
+let to_string t = t
+
+let equal = String.equal
+
+let pp ppf t = Format.pp_print_string ppf t

--- a/lib/keeper/keeper_container_name.mli
+++ b/lib/keeper/keeper_container_name.mli
@@ -1,0 +1,45 @@
+(** RFC-0070 Phase 3b-ii — Deterministic docker container name.
+
+    Pure derivation: same [(algo, turn_id, attempt, suffix)] ⇒ identical
+    {!t}. No wall-clock, no Random, no process state.
+
+    Reference: docs/rfc/RFC-0070-keeper-sandbox-pure-edge-separation.md §3.1
+
+    Wire format:
+    {v "masc-keeper-" ^ hex(Keeper_hash_algo.digest_bytes algo input)[0..31] v}
+
+    The 32-hex-char (16-byte / 128-bit) slice gives a direct collision
+    probability of 1/2^128 and birthday bound ~2^64 — effectively zero
+    under any realistic fleet load.
+
+    Docker container-name constraints satisfied:
+    - regex [a-zA-Z0-9][a-zA-Z0-9_.-]* (hex chars + "-" prefix segment OK)
+    - length <= 64 (this format is 44 chars: 12 prefix + 32 hex) *)
+
+(** Abstract container-name type. The underlying string is the
+    serialised wire form. *)
+type t
+
+(** [of_hash_hex ~algo ~turn_id ~attempt ~suffix] derives the
+    container name. Pure function of declared inputs.
+
+    [suffix] is the keeper-derived disambiguator (typically the keeper
+    name or a config-derived identifier) folded into the hash so two
+    keepers running the same [turn_id]/[attempt] still get distinct
+    names. Must be UTF-8 safe; the implementation hashes the raw bytes
+    so any non-empty string is accepted. *)
+val of_hash_hex
+  :  algo:Keeper_hash_algo.t
+  -> turn_id:int
+  -> attempt:int
+  -> suffix:string
+  -> t
+
+(** [to_string t] returns the wire form, suitable for direct passing
+    to [docker run --name <to_string t> ...]. *)
+val to_string : t -> string
+
+(** [equal] / [pp] for property tests and dashboards. *)
+val equal : t -> t -> bool
+
+val pp : Format.formatter -> t -> unit

--- a/lib/keeper/keeper_container_name.mli
+++ b/lib/keeper/keeper_container_name.mli
@@ -26,8 +26,9 @@ type t
     [suffix] is the keeper-derived disambiguator (typically the keeper
     name or a config-derived identifier) folded into the hash so two
     keepers running the same [turn_id]/[attempt] still get distinct
-    names. Must be UTF-8 safe; the implementation hashes the raw bytes
-    so any non-empty string is accepted. *)
+    names. The implementation hashes the raw bytes so any string is
+    accepted, including the empty string (uncommon but not rejected
+    — the caller is expected to pass a meaningful identifier). *)
 val of_hash_hex
   :  algo:Keeper_hash_algo.t
   -> turn_id:int

--- a/test/dune
+++ b/test/dune
@@ -591,6 +591,7 @@
         test_keeper_personality_io_render
         test_keeper_identity_outcome_label
         test_keeper_hash_algo
+        test_keeper_container_name
         test_worker_runtime
         test_capability_registry
         test_tool_local_runtime_verify
@@ -801,6 +802,7 @@
         test_keeper_personality_io_render
         test_keeper_identity_outcome_label
         test_keeper_hash_algo
+        test_keeper_container_name
         test_worker_runtime
         test_capability_registry
         test_tool_local_runtime_verify

--- a/test/test_keeper_container_name.ml
+++ b/test/test_keeper_container_name.ml
@@ -1,0 +1,152 @@
+(** RFC-0070 Phase 3b-ii — tests for [Keeper_container_name].
+
+    Pins the derivation contract: determinism, uniqueness across
+    distinct input tuples, length invariant, prefix invariant, and
+    that the unit-separator collision guard works. *)
+
+open Alcotest
+open Masc_mcp
+
+let make ?(algo = Keeper_hash_algo.SHA_256) ~turn_id ~attempt ~suffix () =
+  Keeper_container_name.of_hash_hex ~algo ~turn_id ~attempt ~suffix
+
+(* ── Determinism: same input ⇒ same output ────────────────────── *)
+
+let test_determinism_basic () =
+  let a = make ~turn_id:1 ~attempt:0 ~suffix:"k" () in
+  let b = make ~turn_id:1 ~attempt:0 ~suffix:"k" () in
+  check string "same input → same output"
+    (Keeper_container_name.to_string a)
+    (Keeper_container_name.to_string b)
+
+let test_determinism_sha512 () =
+  let a = make ~algo:Keeper_hash_algo.SHA_512 ~turn_id:9 ~attempt:3 ~suffix:"persona" () in
+  let b = make ~algo:Keeper_hash_algo.SHA_512 ~turn_id:9 ~attempt:3 ~suffix:"persona" () in
+  check string "SHA-512 same input → same output"
+    (Keeper_container_name.to_string a)
+    (Keeper_container_name.to_string b)
+
+(* ── Uniqueness: distinct input tuples ⇒ distinct outputs ──── *)
+
+let test_uniqueness_turn_id () =
+  let a = Keeper_container_name.to_string (make ~turn_id:1 ~attempt:0 ~suffix:"k" ()) in
+  let b = Keeper_container_name.to_string (make ~turn_id:2 ~attempt:0 ~suffix:"k" ()) in
+  if String.equal a b then fail "turn_id should distinguish containers"
+
+let test_uniqueness_attempt () =
+  let a = Keeper_container_name.to_string (make ~turn_id:1 ~attempt:0 ~suffix:"k" ()) in
+  let b = Keeper_container_name.to_string (make ~turn_id:1 ~attempt:1 ~suffix:"k" ()) in
+  if String.equal a b then fail "attempt should distinguish containers"
+
+let test_uniqueness_suffix () =
+  let a = Keeper_container_name.to_string (make ~turn_id:1 ~attempt:0 ~suffix:"alice" ()) in
+  let b = Keeper_container_name.to_string (make ~turn_id:1 ~attempt:0 ~suffix:"bob" ()) in
+  if String.equal a b then fail "suffix should distinguish containers"
+
+let test_uniqueness_algo () =
+  let a = Keeper_container_name.to_string
+            (make ~algo:Keeper_hash_algo.SHA_256 ~turn_id:7 ~attempt:1 ~suffix:"x" ()) in
+  let b = Keeper_container_name.to_string
+            (make ~algo:Keeper_hash_algo.SHA_512 ~turn_id:7 ~attempt:1 ~suffix:"x" ()) in
+  if String.equal a b then fail "algo choice should change the digest prefix"
+
+(* ── Unit-separator collision guard ───────────────────────────── *)
+
+(* The implementation uses \x1f (unit separator) between fields so
+   that (turn_id=42, attempt=7) and (turn_id=4, attempt=27) cannot
+   produce identical inputs by mere digit concatenation. *)
+
+let test_no_field_boundary_collision () =
+  let a = Keeper_container_name.to_string (make ~turn_id:42 ~attempt:7 ~suffix:"s" ()) in
+  let b = Keeper_container_name.to_string (make ~turn_id:4 ~attempt:27 ~suffix:"s" ()) in
+  if String.equal a b then fail "field-boundary collision — separator missing"
+
+let test_no_suffix_boundary_collision () =
+  (* (turn_id=1, suffix="2|x") vs (turn_id=12, suffix="x") would
+     collide under naïve concat. The separator prevents this. *)
+  let a = Keeper_container_name.to_string (make ~turn_id:1 ~attempt:0 ~suffix:"2-x" ()) in
+  let b = Keeper_container_name.to_string (make ~turn_id:12 ~attempt:0 ~suffix:"x" ()) in
+  if String.equal a b then fail "suffix-boundary collision — separator missing"
+
+(* ── Length + prefix invariants ───────────────────────────────── *)
+
+let test_length () =
+  let n = Keeper_container_name.to_string (make ~turn_id:1 ~attempt:0 ~suffix:"k" ()) in
+  check int "length = 12 + 32 = 44" 44 (String.length n)
+
+let test_prefix () =
+  let n = Keeper_container_name.to_string (make ~turn_id:1 ~attempt:0 ~suffix:"k" ()) in
+  let has_prefix = String.length n >= 12 && String.sub n 0 12 = "masc-keeper-" in
+  check bool "prefix = masc-keeper-" true has_prefix
+
+let test_charset () =
+  let n = Keeper_container_name.to_string (make ~turn_id:1 ~attempt:0 ~suffix:"k" ()) in
+  (* After the "masc-keeper-" prefix, every char is a lowercase hex digit. *)
+  let suffix = String.sub n 12 (String.length n - 12) in
+  let valid =
+    String.for_all (fun c -> (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f')) suffix
+  in
+  check bool "hex chars after prefix" true valid
+
+(* ── Empty / large input edge cases ───────────────────────────── *)
+
+let test_empty_suffix () =
+  let n = Keeper_container_name.to_string (make ~turn_id:0 ~attempt:0 ~suffix:"" ()) in
+  check int "empty suffix still yields full-length name" 44 (String.length n)
+
+let test_large_inputs () =
+  let big_suffix = String.make 10_000 'x' in
+  let n = Keeper_container_name.to_string (make ~turn_id:max_int ~attempt:max_int ~suffix:big_suffix ()) in
+  check int "large inputs still yield full-length name" 44 (String.length n)
+
+(* ── equal / pp sanity ────────────────────────────────────────── *)
+
+let test_equal_reflexive () =
+  let n = make ~turn_id:1 ~attempt:0 ~suffix:"k" () in
+  check bool "equal is reflexive" true (Keeper_container_name.equal n n)
+
+let test_pp_matches_to_string () =
+  let n = make ~turn_id:1 ~attempt:0 ~suffix:"k" () in
+  let buf = Buffer.create 64 in
+  let ppf = Format.formatter_of_buffer buf in
+  Keeper_container_name.pp ppf n;
+  Format.pp_print_flush ppf ();
+  check string "pp emits to_string" (Keeper_container_name.to_string n) (Buffer.contents buf)
+
+let () =
+  run "Keeper_container_name"
+    [
+      ( "determinism",
+        [
+          test_case "SHA-256 same input → same output" `Quick test_determinism_basic;
+          test_case "SHA-512 same input → same output" `Quick test_determinism_sha512;
+        ] );
+      ( "uniqueness",
+        [
+          test_case "turn_id distinguishes" `Quick test_uniqueness_turn_id;
+          test_case "attempt distinguishes" `Quick test_uniqueness_attempt;
+          test_case "suffix distinguishes" `Quick test_uniqueness_suffix;
+          test_case "algo distinguishes" `Quick test_uniqueness_algo;
+        ] );
+      ( "collision guard",
+        [
+          test_case "no field-boundary collision (42/7 vs 4/27)" `Quick test_no_field_boundary_collision;
+          test_case "no suffix-boundary collision" `Quick test_no_suffix_boundary_collision;
+        ] );
+      ( "format invariants",
+        [
+          test_case "length = 44" `Quick test_length;
+          test_case "prefix = masc-keeper-" `Quick test_prefix;
+          test_case "hex charset after prefix" `Quick test_charset;
+        ] );
+      ( "edge cases",
+        [
+          test_case "empty suffix" `Quick test_empty_suffix;
+          test_case "max_int / large suffix" `Quick test_large_inputs;
+        ] );
+      ( "equal / pp",
+        [
+          test_case "equal reflexive" `Quick test_equal_reflexive;
+          test_case "pp = to_string" `Quick test_pp_matches_to_string;
+        ] );
+    ]

--- a/test/test_keeper_container_name.ml
+++ b/test/test_keeper_container_name.ml
@@ -61,12 +61,14 @@ let test_no_field_boundary_collision () =
   let b = Keeper_container_name.to_string (make ~turn_id:4 ~attempt:27 ~suffix:"s" ()) in
   if String.equal a b then fail "field-boundary collision — separator missing"
 
-let test_no_suffix_boundary_collision () =
-  (* (turn_id=1, suffix="2|x") vs (turn_id=12, suffix="x") would
-     collide under naïve concat. The separator prevents this. *)
-  let a = Keeper_container_name.to_string (make ~turn_id:1 ~attempt:0 ~suffix:"2-x" ()) in
-  let b = Keeper_container_name.to_string (make ~turn_id:12 ~attempt:0 ~suffix:"x" ()) in
-  if String.equal a b then fail "suffix-boundary collision — separator missing"
+let test_no_attempt_suffix_boundary_collision () =
+  (* Without separators, [Printf.sprintf "%d%d%s" 0 2 "3x"] and
+     [Printf.sprintf "%d%d%s" 0 23 "x"] both produce "023x" — same
+     string. With the \x1f unit separator they become distinct
+     ("0\x1f2\x1f3x" vs "0\x1f23\x1fx"), and so do their digests. *)
+  let a = Keeper_container_name.to_string (make ~turn_id:0 ~attempt:2 ~suffix:"3x" ()) in
+  let b = Keeper_container_name.to_string (make ~turn_id:0 ~attempt:23 ~suffix:"x" ()) in
+  if String.equal a b then fail "attempt/suffix-boundary collision — separator missing"
 
 (* ── Length + prefix invariants ───────────────────────────────── *)
 
@@ -131,7 +133,7 @@ let () =
       ( "collision guard",
         [
           test_case "no field-boundary collision (42/7 vs 4/27)" `Quick test_no_field_boundary_collision;
-          test_case "no suffix-boundary collision" `Quick test_no_suffix_boundary_collision;
+          test_case "no attempt/suffix-boundary collision (2/3x vs 23/x)" `Quick test_no_attempt_suffix_boundary_collision;
         ] );
       ( "format invariants",
         [


### PR DESCRIPTION
## 목표 — RFC-0070 §3.1 Phase 3b-ii

Deterministic container-name derivation. Phase 3b-i (Hash_algo)의 첫 caller — RFC §3.1 wire format 구현.

## RFC 인용

| RFC | 관계 |
|-----|------|
| **RFC-0070** | 본 PR이 이행하는 spec — §3.1 wire format |
| RFC-0006 | 본 PR 무영향 (cite-only, sandbox 직교) |
| RFC-0036 | 본 PR 무영향 (cite-only) |

## Wire format

```
masc-keeper-<32 hex chars>
~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^
12 chars    16 bytes (128 bits) of hash, hex-encoded
total: 44 chars
```

- direct collision: 1/2^128
- birthday bound: 2^64 ≈ 1.8×10^19 (effectively zero under any realistic fleet load)
- docker container-name constraints: ✅ regex `[a-zA-Z0-9][a-zA-Z0-9_.-]*`, ✅ length ≤ 64

## 결정성 contract

`of_hash_hex ~algo ~turn_id ~attempt ~suffix` — same inputs ⇒ identical output. wall-clock/Random/global state 0.

### Field-boundary collision guard

Input 직렬화는 ASCII unit separator (`\x1f`) 로 구분:
```
"%d\x1f%d\x1f%s" turn_id attempt suffix
```

→ `(turn_id=42, attempt=7, suffix="s")` 와 `(turn_id=4, attempt=27, suffix="s")` 가 *digit-concat collision* 못함. 테스트에서 pin.

## 변경

```
lib/keeper/keeper_container_name.mli   46 lines (interface)
lib/keeper/keeper_container_name.ml    25 lines (impl)
test/test_keeper_container_name.ml    140 lines (15 assertion)
test/dune                              +2 (test_keeper_container_name 등록)
```

## Test 커버리지 (15 assertions, 6 group)

| 그룹 | 검증 |
|------|------|
| determinism | SHA-256/SHA-512 same input → same output |
| uniqueness | turn_id / attempt / suffix / algo 4축 모두 distinguish |
| collision guard | field-boundary (42/7 vs 4/27) + suffix-boundary 2 시나리오 pin |
| format invariants | length=44, prefix=`masc-keeper-`, hex charset |
| edge cases | empty suffix, max_int + 10K-char suffix |
| equal/pp | reflexive, pp = to_string |

## 검증

- **Isolated ocamlc**: Phase 3a/3b-i 패턴 (확신 high — digestif + 닫힌 sum만 사용)
- **`scripts/dune-local.sh build @check`**: main 회귀 미해소 (#14745 cleanup pending) — 본 PR 무관

## Workaround Rejection Bar self-check

| 시그니처 | 본 PR 해당? |
|---------|------------|
| Counter-as-fix | N/A |
| String 분류기 | N/A — typed `of_hash_hex` |
| N-of-M | N/A — 1 모듈, 1 PR |
| Cap/cooldown/dedup/repair | N/A |
| Test backdoor | N/A — `of_string_for_test` 미도입 (Phase 3b-iii에서 caller emerge 시 검토) |
| Catch-all `_ ->` | N/A — match expression 0 |

## 미검증

- main 회귀 해소 후 실제 `dune build @runtest` 통과 여부. test vector는 SHA-2 표준 + alcotest 표준 패턴이라 high confidence.
- `equal` 기반 hash-set 멤버십 (Phase 3c quarantine `Set.Make` 사용 시 필요) — Phase 3c에서 평가.

## 다음 PR

- **Phase 3b-iii**: Plan record fields (Image / Mount / Ulimit / Network) + `Keeper_sandbox_plan.of_request` real derivation (Phase 3a stub 대체)
- **Phase 3b-iv**: `Real : Docker_client.S` (Eio.Process spawn)
- 의존: 본 PR 머지 + RFC-0036 Phase A (cleanup hook, Phase 3c 의존)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
