### PR TITLE
docs(tla-audit): KTC Phase B-1 — turn_phase 2-phase spec coverage gap

### DIFF
--- a/docs/tla-audit/ktc-b1-turn-phase-spec-gap-2026-05-12.md
+++ b/docs/tla-audit/ktc-b1-turn-phase-spec-gap-2026-05-12.md
@@ -1,0 +1,96 @@
+# KTC Phase B-1 Audit — 3-Axis State Cross-Check
+
+**Iteration**: 19 (/loop FSM/TLA+/OCaml drift hunt — first KTC entry)
+**Date**: 2026-05-12
+**Spec**: `specs/keeper-state-machine/KeeperTurnCycle.tla` (373 LOC)
+**OCaml**: `lib/keeper/keeper_registry.ml` (`turn_phase` / `decision_stage` / `cascade_state` types)
+**Risk**: MID — 2 active OCaml phases not modeled in spec; 7 invariants currently exclude these phases by silent omission.
+**Type**: Audit-only (no code change in this PR).
+
+## 3-axis cross-check matrix
+
+| Axis | Spec set | OCaml variants | Aligned? |
+|---|---|---|---|
+| `turn_phase` (`TurnPhaseSet` §110) | 5: idle, prompting, executing, compacting, finalizing | 7: Turn_idle, Turn_prompting, **Turn_routing**, Turn_executing, Turn_compacting, Turn_finalizing, **Turn_exhausted** | ❌ **2 phases missing in spec** |
+| `decision_stage` (`DecisionSet` §111) | 4: undecided, guard_ok, gate_rejected, tool_policy_selected | 4: Decision_undecided, Decision_guard_ok, Decision_gate_rejected, Decision_tool_policy_selected | ✅ Aligned |
+| `cascade_state` (`CascadeSet` §112) | 5: idle, selecting, trying, done, exhausted | 5: Cascade_idle, Cascade_selecting, Cascade_trying, Cascade_done, Cascade_exhausted | ✅ Aligned |
+
+## Drift detail — `turn_phase`
+
+OCaml has two phases TLA+ doesn't model:
+
+### `Turn_routing` (`[@tla.active]`)
+- Added by PR #14395 ("allow Turn_exhausted from Turn_prompting/Turn_routing"), per progress memory.
+- Active phase — keeper is mid-turn, fully observable state.
+- Spec-wise unmodeled — `BindMeasurement`/`GuardOk`/`SelectToolPolicy` actions assume direct progression from prompting → executing.
+
+### `Turn_exhausted` (`[@tla.terminal]`)
+- Same PR #14395.  Terminal turn state (no progression).
+- The OCaml comment at `keeper_registry.ml:169-172` directly admits the drift:
+  > "Turn_routing and Turn_exhausted were added to the normal variant on main while this PR was in flight; the GADT tracks them too so the transition matrix below stays compile-time exhaustive."
+
+### `[@tla.idle|active|terminal]` annotations as ground truth
+
+OCaml uses `[@tla.idle]`, `[@tla.active]`, `[@tla.terminal]` PPX attributes on each variant.  These embed the spec-classification intent *in the OCaml type itself* — `Turn_routing [@tla.active]` is a documentation-level claim "this is an active phase per TLA+".  But the *spec* doesn't actually list these phases.  The annotation is forward-looking metadata that spec hasn't caught up on.
+
+## How 7 invariants currently behave on the unmodeled phases
+
+`KeeperTurnCycle.tla` invariants §316-352 quantify over `turn_phase \in TurnPhaseSet` (= 5-element set).  Since `Turn_routing` / `Turn_exhausted` are not in the set, an OCaml state machine that's currently in those phases is **outside the spec's universe**.  The 7 invariants — `NoLiveTurnClearsState`, `IdleRequiresNotLive`, `GateRejectedRequiresFinalizing`, `SelectingRequiresToolPolicy`, `ExecutingRequiresTrying`, `CompactingRequiresTrying`, `TerminalCascadeRequiresFinalizing` — say nothing about those phases.
+
+This is a coverage gap, not a contradiction.  An OCaml run that enters `Turn_routing` and violates what *would be* a sensible "Routing should imply X" invariant is silently allowed at the spec level.  The Bug Model can't detect routing-related corruption because routing isn't in the universe.
+
+## Three concrete invariant candidates for the missing phases
+
+Drawn directly from OCaml's `[@tla.active|terminal]` annotations + production semantics inferred from #14395:
+
+1. **`RoutingRequiresToolPolicy`** (spec extension):
+   ```tla
+   RoutingRequiresToolPolicy ==
+       turn_phase = "routing" =>
+           /\ turn_live
+           /\ decision_stage = "tool_policy_selected"
+           /\ cascade_state \in {"selecting", "trying"}
+   ```
+   Mirrors `SelectingRequiresToolPolicy` / `ExecutingRequiresTrying` for the routing phase.
+
+2. **`ExhaustedRequiresTerminalCascade`** (spec extension):
+   ```tla
+   ExhaustedRequiresTerminalCascade ==
+       turn_phase = "exhausted" =>
+           /\ cascade_state = "exhausted"
+   ```
+   Mirrors the OCaml `[@tla.terminal]` annotation.  Exhausted should pair with cascade exhausted.
+
+3. **`ExhaustedIsForever`** (spec extension):
+   ```tla
+   ExhaustedIsForever == [](turn_phase = "exhausted" => [](turn_phase = "exhausted"))
+   ```
+   Liveness — terminal phase shouldn't transition out (parallels `DeadIsForever` in KSM §S1).
+
+## Suggested RFC fix paths
+
+| ID | Scope | Action | Risk |
+|---|---|---|---|
+| R-B-1.a | Spec extension | Add `routing` and `exhausted` to `TurnPhaseSet`.  Add 3 new actions in `Next` (`EnterRouting`, `TurnExhausted`, transitions).  TLC re-verify. | MID — spec re-verification needed (5-15 min TLC). |
+| R-B-1.b | Spec invariants | Add 3 invariants above to `Safety` after R-B-1.a.  Independent PR for review focus. | LOW — invariant addition only. |
+| R-B-1.c | OCaml `[@tla.*]` annotation parsing | If a PPX/script validates that every `[@tla.*]` variant corresponds to a spec set member, the drift would be compile-time caught.  Currently the annotation is documentation-only. | MID — PPX work. |
+
+R-B-1.a is the prerequisite for R-B-1.b.  R-B-1.c is the structural fix that prevents future occurrences.
+
+## Out-of-scope for this iteration
+
+- TLC re-verify with extended `TurnPhaseSet` — requires R-B-1.a's spec change first.
+- B-2 `Turn_exhausted` transition matrix audit (post-#14395) — separate sub-aspect, will likely overlap.
+- B-3 `SelectingRequiresToolPolicy` ↔ OCaml policy binding — separate sub-aspect.
+- B-4 deadlock-free liveness — separate sub-aspect.
+
+## References
+
+- KTC spec line 98-112 (VARIABLES + 3-axis sets)
+- KTC spec line 316-352 (7 safety invariants)
+- OCaml `turn_phase` definition: `lib/keeper/keeper_registry.ml:158-166`
+- OCaml `decision_stage`: `lib/keeper/keeper_registry.ml:295-300`
+- OCaml `cascade_state`: `lib/keeper/keeper_registry.ml:385-391`
+- Self-admission comment: `lib/keeper/keeper_registry.ml:168-172`
+- PR #14395 (Turn_exhausted transitions, history reference)
+- KSM A-1 audit pattern parallel: `docs/tla-audit/ksm-init-mapping-2026-05-12.md`


### PR DESCRIPTION
## Finding (Iteration 19, Phase B-1 — KTC entry)

**Spec**: `specs/keeper-state-machine/KeeperTurnCycle.tla` (373 LOC, first KTC entry)
**OCaml**: `lib/keeper/keeper_registry.ml:158-391` (3-axis state definitions)
**Aspect**: 새 spec entry. 3-axis (turn_phase × decision_stage × cascade_state) cross-check 결과 **2 phase drift** 발견 (Turn_routing, Turn_exhausted). decision_stage / cascade_state는 정렬.
**Risk**: MID — 2 active OCaml phases가 spec universe 밖. TLC Bug Model이 해당 phase 관련 corruption 못 잡음.
**Type**: Audit-only, 코드 변경 0. 3 RFC 후보 도출.

## 순서도 — 3-axis cross-check matrix

```mermaid
graph TB
    subgraph spec[TLA+ KeeperTurnCycle.tla]
        TP_spec[TurnPhaseSet: 5<br/>idle / prompting / executing<br/>compacting / finalizing]
        DS_spec[DecisionSet: 4]
        CS_spec[CascadeSet: 5]
    end
    subgraph ocaml[OCaml keeper_registry.ml]
        TP_ocaml[turn_phase: 7<br/>Turn_idle, Turn_prompting<br/>**Turn_routing** (active)<br/>Turn_executing, Turn_compacting<br/>Turn_finalizing, **Turn_exhausted** (terminal)]
        DS_ocaml[decision_stage: 4]
        CS_ocaml[cascade_state: 5]
    end
    TP_spec -.✗ DRIFT.-> TP_ocaml
    DS_spec -.✓ aligned.-> DS_ocaml
    CS_spec -.✓ aligned.-> CS_ocaml
    style TP_spec fill:#ffb3b3
    style TP_ocaml fill:#ffb3b3
```

## TLA+ universe gap

KTC §316-352의 7 safety invariants 모두 `turn_phase \in TurnPhaseSet` (5-set) 위에서 quantification. OCaml이 `Turn_routing` 또는 `Turn_exhausted`에 있으면 **spec universe 밖** → 어떤 corruption도 silent.

OCaml comment line 168-172 자체가 자인:
> "Turn_routing and Turn_exhausted were added to the normal variant on main while this PR was in flight"

이건 `#14395` PR의 trail로 spec 업데이트가 빠진 KSM A-1 패턴 반복.

## `[@tla.*]` annotation은 documentation-only

OCaml은 `[@tla.idle]`, `[@tla.active]`, `[@tla.terminal]` PPX 어트리뷰트를 모든 variant에 부착:
```ocaml
| Turn_routing [@tla.active]      (* claim: active per TLA+ *)
| Turn_exhausted [@tla.terminal]  (* claim: terminal per TLA+ *)
```

문제: **spec 자체는 이 phases를 모름**. annotation은 forward-looking 메타데이터이고 spec이 따라잡지 못함. 컴파일러도 이 lie를 잡지 못함 — R-B-1.c가 정확히 이 결함의 구조적 fix.

## 3 RFC 후보

### R-B-1.a: Spec extension (prerequisite)
```tla
TurnPhaseSet == {"idle", "prompting", "routing", "executing",
                 "compacting", "finalizing", "exhausted"}
```
+ 3 new actions (`EnterRouting`, `TurnExhausted`, transitions). TLC re-verify (5-15min). MID risk.

### R-B-1.b: Invariants (follow R-B-1.a)
```tla
RoutingRequiresToolPolicy ==
    turn_phase = "routing" => /\ turn_live
                              /\ decision_stage = "tool_policy_selected"
                              /\ cascade_state \in {"selecting", "trying"}
ExhaustedRequiresTerminalCascade ==
    turn_phase = "exhausted" => cascade_state = "exhausted"
ExhaustedIsForever ==
    [](turn_phase = "exhausted" => [](turn_phase = "exhausted"))
```
LOW risk. R-B-1.a 완료 후.

### R-B-1.c: PPX/script — `[@tla.*]` 검증 (structural)
컴파일 시 모든 `[@tla.idle|active|terminal]` variant이 spec set 멤버인지 검증. drift 발생 시 컴파일 실패. MID risk (PPX 작업).

**최고 leverage**: R-B-1.c — 미래 재발 방지. R-B-1.a는 즉각, R-B-1.b는 invariant 추가, R-B-1.c는 *재발 차단 메커니즘*.

## 본 PR 내용

- `docs/tla-audit/ktc-b1-turn-phase-spec-gap-2026-05-12.md` (+96 LOC): 위 분석 + 3 RFC 후보.

## Verification

- [x] OCaml line 인용은 직접 `wc -l` + line 번호 cross-check.
- [x] KTC spec invariants enumeration 직접 `grep`.
- [ ] TLC re-verify: R-B-1.a PR scope.

## Trade-off

- **Audit-only 결정 사유**: R-B-1.a는 TLC re-verify 5-15min, 10-min iteration budget 초과 위험. 별도 PR로.
- **R-B-1.c가 *실제로* 가치 있음**: KSM에서도 같은 패턴 (`[@tla.*]` annotation 존재), 다른 spec(KCR, KCAF 등)도 동일. 한 PPX/script이 모든 spec drift 차단 가능 — 다음 사이클의 최고 후보.

## RFC 참조

- B-1 (plan Phase B 첫 항목).
- KSM A-1 audit 패턴 참고: `docs/tla-audit/ksm-init-mapping-2026-05-12.md` (#14694).
- `RFC-WAIVED`: docs-only, 코드 영향 없음. credential / identity / operator-control / sandbox / hooks 범위 밖.

## 진행 추적

다음 iteration 시작점: **R-B-1.c** (`[@tla.*]` annotation 검증 PPX/script — 모든 spec drift 한번에 차단, 최고 leverage) OR **R-B-1.a** (KTC spec extension + TLC re-verify) OR **R-A-8 PR-2** (KSM KNOWN_FAILURES purge).

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
