### PR TITLE
feat(telemetry): typed Paused_state_persist_phase variant

### DIFF
--- a/lib/keeper/paused_state_persist_phase.ml
+++ b/lib/keeper/paused_state_persist_phase.ml
@@ -1,0 +1,10 @@
+type t =
+  | Boot_resume_persist
+  | Boot_resume_check
+  | Directive
+
+let to_label = function
+  | Boot_resume_persist -> "boot_resume_persist"
+  | Boot_resume_check -> "boot_resume_check"
+  | Directive -> "directive"
+;;

--- a/lib/keeper/paused_state_persist_phase.mli
+++ b/lib/keeper/paused_state_persist_phase.mli
@@ -1,0 +1,21 @@
+(** Paused_state_persist_phase — closed sum for the [phase] label on
+    [metric_keeper_paused_state_persist_errors].
+
+    Replaces 3 hardcoded string literals scattered across 6 emit sites
+    in [server_dashboard_http_keeper_api.ml]
+    (`"boot_resume_persist"` / `"boot_resume_check"` / `"directive"`).
+    Each phase corresponds to a distinct write path; closing the set
+    forces every emit site through the compiler. *)
+
+type t =
+  | Boot_resume_persist
+  (** Persist-time failure during boot-time resume of a previously
+          paused keeper (writing the resumed state record). *)
+  | Boot_resume_check
+  (** Read-back failure during boot-time resume (verifying the
+          persisted state). *)
+  | Directive
+  (** Failure persisting an operator-issued pause/resume directive
+          (e.g. POST /dashboard/api/keepers/:name/pause). *)
+
+val to_label : t -> string

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -1688,7 +1688,8 @@ let init () =
   add
     Keeper_metrics.metric_keeper_paused_state_persist_errors
     "Total keeper paused-state persistence failures, labeled by phase \
-     (boot_resume_check|boot_resume_persist) and reason (read_meta_error|meta_missing)"
+     (boot_resume_check|boot_resume_persist|directive) and reason \
+     (read_meta_error|meta_missing)"
     Counter;
   add
     Keeper_metrics.metric_keeper_unexpected_tool_partial_tolerance

--- a/lib/server/server_dashboard_http_keeper_api.ml
+++ b/lib/server/server_dashboard_http_keeper_api.ml
@@ -666,7 +666,7 @@ let handle_keeper_lifecycle_post ?body_str ~sw ~clock ~tool_name ~action
             (if paused then "pause" else "resume");
           Prometheus.inc_counter
             Keeper_metrics.metric_keeper_paused_state_persist_errors
-            ~labels:[("phase", "boot_resume_persist");
+            ~labels:[("phase", Paused_state_persist_phase.(to_label Boot_resume_persist));
                      ("reason", "meta_missing")]
             ()
       | Error err ->
@@ -677,7 +677,7 @@ let handle_keeper_lifecycle_post ?body_str ~sw ~clock ~tool_name ~action
             err;
           Prometheus.inc_counter
             Keeper_metrics.metric_keeper_paused_state_persist_errors
-            ~labels:[("phase", "boot_resume_persist");
+            ~labels:[("phase", Paused_state_persist_phase.(to_label Boot_resume_persist));
                      ("reason", "read_meta_error")]
             ()
     in
@@ -704,7 +704,7 @@ let handle_keeper_lifecycle_post ?body_str ~sw ~clock ~tool_name ~action
             name;
           Prometheus.inc_counter
             Keeper_metrics.metric_keeper_paused_state_persist_errors
-            ~labels:[("phase", "boot_resume_check");
+            ~labels:[("phase", Paused_state_persist_phase.(to_label Boot_resume_check));
                      ("reason", "meta_missing")]
             ()
       | Error err ->
@@ -714,7 +714,7 @@ let handle_keeper_lifecycle_post ?body_str ~sw ~clock ~tool_name ~action
             err;
           Prometheus.inc_counter
             Keeper_metrics.metric_keeper_paused_state_persist_errors
-            ~labels:[("phase", "boot_resume_check");
+            ~labels:[("phase", Paused_state_persist_phase.(to_label Boot_resume_check));
                      ("reason", "read_meta_error")]
             ()
     in
@@ -902,7 +902,7 @@ let handle_keeper_directive_post state _agent_name req reqd body_str =
                err;
              Prometheus.inc_counter
                Keeper_metrics.metric_keeper_paused_state_persist_errors
-               ~labels:[("phase", "directive");
+               ~labels:[("phase", Paused_state_persist_phase.(to_label Directive));
                         ("reason", "read_meta_error")]
                ();
              Http.Response.json ~status:`Internal_server_error ~request:req
@@ -919,7 +919,7 @@ let handle_keeper_directive_post state _agent_name req reqd body_str =
                name;
              Prometheus.inc_counter
                Keeper_metrics.metric_keeper_paused_state_persist_errors
-               ~labels:[("phase", "directive");
+               ~labels:[("phase", Paused_state_persist_phase.(to_label Directive));
                         ("reason", "meta_missing")]
                ();
              Http.Response.json ~status:`Not_found ~request:req


### PR DESCRIPTION
## Summary

6 hardcoded `"phase"` label strings on
`metric_keeper_paused_state_persist_errors` — all in
`server_dashboard_http_keeper_api.ml` — collapsed into a closed sum
`Paused_state_persist_phase.t`.

## Sites (6)

| Site | Variant |
|------|---------|
| `:669` | `Boot_resume_persist` |
| `:680` | `Boot_resume_persist` |
| `:707` | `Boot_resume_check` |
| `:717` | `Boot_resume_check` |
| `:905` | `Directive` |
| `:922` | `Directive` |

## Why

Same workaround #2 (string classifier) pattern earlier sweep
iterations closed for `oas_execution_error_phase` (#14737),
`error_event_type` (#14755), `alert_persist_kind` +
`metrics_sse_failure_kind` (#14760).

Each phase corresponds to a distinct write path (boot-time persist /
boot-time read-back / operator directive); closing the set forces
every emit site through the compiler so adding a new phase requires a
single edit and the new wire string surfaces at compile time at every
emission site.

## Approach

```ocaml
(* lib/keeper/paused_state_persist_phase.ml *)
type t =
  | Boot_resume_persist
  | Boot_resume_check
  | Directive

val to_label : t -> string
```

Wire format byte-equal.

## Test plan

- [ ] CI green
- [ ] `rg '"phase", "(boot_resume_persist|boot_resume_check|directive)"' lib/` = 0

RFC-WAIVED: not in credential/identity/operator/sandbox/hooks/workflow scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)