### PR TITLE
feat(scripts): R-B-1.c — TLA+ annotation drift validator

### DIFF
--- a/.github/workflows/tla-annotation-drift.yml
+++ b/.github/workflows/tla-annotation-drift.yml
@@ -1,0 +1,61 @@
+name: tla-annotation-drift
+
+# R-B-1.c CI integration — enforce that OCaml `[@tla.idle|active|terminal]`
+# annotated constructors map to existing TLA+ spec set members.
+#
+# Background and rationale: `scripts/audit-tla-annotation-drift.sh` and
+# `docs/tla-audit/ktc-b1-turn-phase-spec-gap-2026-05-12.md`.
+#
+# Baseline policy: `scripts/tla-annotation-drift-baseline.txt` lists drifts
+# that are knowingly outstanding (awaiting their spec-extension RFC, e.g.
+# R-B-1.a for TurnPhaseSet routing/exhausted).  The validator skips
+# baseline entries so this job fails only on NEW regressions.  When an
+# RFC lands and adds the missing spec symbol, the corresponding baseline
+# line must be removed in the same PR — otherwise the next PR that
+# re-introduces the same drift would slip through.
+
+on:
+  pull_request:
+    paths:
+      - 'specs/keeper-state-machine/**'
+      - 'lib/keeper/keeper_registry.ml'
+      - 'lib/keeper/keeper_state_machine.ml'
+      - 'scripts/audit-tla-annotation-drift.sh'
+      - 'scripts/tla-annotation-drift-baseline.txt'
+      - '.github/workflows/tla-annotation-drift.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - 'specs/keeper-state-machine/**'
+      - 'lib/keeper/keeper_registry.ml'
+      - 'lib/keeper/keeper_state_machine.ml'
+      - 'scripts/audit-tla-annotation-drift.sh'
+      - 'scripts/tla-annotation-drift-baseline.txt'
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+concurrency:
+  group: tla-annotation-drift-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  drift:
+    name: TLA+ annotation drift check
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Install ripgrep
+        run: sudo apt-get update -qq && sudo apt-get install -y ripgrep
+
+      - name: Run drift validator
+        run: |
+          bash scripts/audit-tla-annotation-drift.sh \
+            --baseline scripts/tla-annotation-drift-baseline.txt

--- a/scripts/audit-tla-annotation-drift.sh
+++ b/scripts/audit-tla-annotation-drift.sh
@@ -26,7 +26,41 @@ SPEC_DIR="${REPO_ROOT}/specs/keeper-state-machine"
 LIB_DIR="${REPO_ROOT}/lib"
 
 VERBOSE=0
-if [[ "${1:-}" == "--verbose" ]]; then VERBOSE=1; fi
+BASELINE_FILE=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --verbose) VERBOSE=1; shift ;;
+    --baseline) BASELINE_FILE="$2"; shift 2 ;;
+    --baseline=*) BASELINE_FILE="${1#*=}"; shift ;;
+    *) echo "unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+# Load baseline known-drift entries (one per line, format: "type:symbol").
+# Lines starting with # and blank lines are ignored.  Baseline entries
+# are existing drifts awaiting resolution (e.g. spec extension RFC) —
+# the validator skips them so CI catches only NEW regressions.
+declare -a BASELINE=()
+if [[ -n "${BASELINE_FILE}" && -f "${BASELINE_FILE}" ]]; then
+  while IFS= read -r line; do
+    line="${line%%#*}"  # strip trailing comments
+    line="${line## }"
+    line="${line%% }"
+    [[ -z "${line}" ]] && continue
+    BASELINE+=("${line}")
+  done < "${BASELINE_FILE}"
+  if [[ "${VERBOSE}" == "1" ]]; then
+    echo "loaded baseline: ${#BASELINE[@]} known-drift entries from ${BASELINE_FILE}"
+  fi
+fi
+
+in_baseline() {
+  local key="$1"
+  for entry in "${BASELINE[@]:-}"; do
+    if [[ "${entry}" == "${key}" ]]; then return 0; fi
+  done
+  return 1
+}
 
 # Type → Set mapping.  OCaml type names (lowercase_with_underscores) to
 # TLA+ set identifiers (CamelCase + "Set").  Extend this list as new
@@ -75,6 +109,7 @@ extract_ocaml_members() {
 }
 
 VIOLATIONS=0
+KNOWN_DRIFTS=0
 TOTAL_PAIRS=0
 TOTAL_CHECKED=0
 
@@ -116,6 +151,11 @@ for pair in "${TYPE_SET_PAIRS[@]}"; do
       if [[ "${VERBOSE}" == "1" ]]; then
         echo "  ✓ ${sym_stripped} (from ${sym_full}) in ${spec_set}"
       fi
+    elif in_baseline "${ocaml_type}:${ocaml_sym}"; then
+      if [[ "${VERBOSE}" == "1" ]]; then
+        echo "  ~ ${sym_full} (type=${ocaml_type}) — known drift, skipped (baseline)"
+      fi
+      KNOWN_DRIFTS=$((KNOWN_DRIFTS + 1))
     else
       echo "drift: ocaml constructor '${ocaml_sym}' (type=${ocaml_type}) has no matching member in TLA+ ${spec_set}"
       echo "       tried: '${sym_full}', '${sym_stripped}'"
@@ -125,7 +165,7 @@ for pair in "${TYPE_SET_PAIRS[@]}"; do
 done
 
 echo ""
-echo "tla-annotation-drift summary: ${TOTAL_CHECKED} constructors checked across ${TOTAL_PAIRS} type/set pairs, ${VIOLATIONS} drift(s)"
+echo "tla-annotation-drift summary: ${TOTAL_CHECKED} constructors checked across ${TOTAL_PAIRS} type/set pairs, ${VIOLATIONS} new drift(s), ${KNOWN_DRIFTS} baseline-known drift(s)"
 
 if [[ "${VIOLATIONS}" -gt 0 ]]; then
   echo ""

--- a/scripts/audit-tla-annotation-drift.sh
+++ b/scripts/audit-tla-annotation-drift.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+# audit-tla-annotation-drift.sh — detect OCaml [@tla.*] annotations
+# whose lowercase symbol is not a member of the corresponding TLA+
+# spec set.
+#
+# Background: ppx_tla generates `to_tla_symbol`, `all_symbols`, etc.
+# from `[@@deriving tla]` types with per-constructor `[@tla.idle|active|
+# terminal]` annotations.  The annotations are *forward-looking* — they
+# claim "this variant is X per TLA+", but the PPX does NOT verify the
+# spec actually declares the symbol.  Result: a constructor added to
+# OCaml without updating the spec is silently allowed (KTC B-1 audit
+# memo at `docs/tla-audit/ktc-b1-turn-phase-spec-gap-2026-05-12.md`
+# documents Turn_routing/Turn_exhausted as exactly this case).
+#
+# This script closes the loop by static cross-check.  Exit non-zero on
+# drift so CI catches future regressions.
+#
+# Usage: bash scripts/audit-tla-annotation-drift.sh
+#        bash scripts/audit-tla-annotation-drift.sh --verbose
+#
+# RFC: R-B-1.c (iter 19 KTC B-1 audit memo).
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SPEC_DIR="${REPO_ROOT}/specs/keeper-state-machine"
+LIB_DIR="${REPO_ROOT}/lib"
+
+VERBOSE=0
+if [[ "${1:-}" == "--verbose" ]]; then VERBOSE=1; fi
+
+# Type → Set mapping.  OCaml type names (lowercase_with_underscores) to
+# TLA+ set identifiers (CamelCase + "Set").  Extend this list as new
+# `[@@deriving tla]` types appear.
+declare -a TYPE_SET_PAIRS=(
+  "turn_phase:TurnPhaseSet"
+  "decision_stage:DecisionSet"
+  "cascade_state:CascadeSet"
+  # KSM `phase` variant uses a different spec representation (Phase
+  # constant via DerivePhase, not a closed set literal).  R-B-1.c can
+  # extend to KSM in a follow-up by adding spec-side `PhaseSet` first
+  # and matching here.
+)
+
+# Aux: extract spec set members.  Greps the `XxxSet == { ... }` block,
+# bounded to the same set definition (stops at the closing `}` or the
+# next top-level identifier).  Greedy multi-line capture would pull
+# members from adjacent sets.
+extract_spec_members() {
+  local set_name="$1"
+  # Use awk to extract from `XxxSet ==` line until the closing `}`.
+  awk -v set="${set_name}" '
+    BEGIN { capturing = 0 }
+    $0 ~ "^" set "[[:space:]]*==" { capturing = 1 }
+    capturing == 1 {
+      buf = buf $0 " "
+      if (index($0, "}") > 0) { capturing = 0; print buf; buf = "" }
+    }
+  ' "${SPEC_DIR}"/*.tla 2>/dev/null \
+    | rg -o '"[a-z_]+"' \
+    | tr -d '"' \
+    | sort -u
+}
+
+# Aux: extract OCaml constructor names tagged with `[@tla.*]` for a
+# given type.  Returns lowercase symbols (cd.pcd_name.txt → lowercased).
+extract_ocaml_members() {
+  local type_name="$1"
+  # Find the type definition, then read up to the closing `]` annotation
+  # block.  ppx_tla uses `[@@deriving tla]` as the terminator.
+  rg --multiline -U "type ${type_name}\b[^=]*=([\s\S]*?)\[@@deriving tla\]" "${LIB_DIR}" 2>/dev/null \
+    | rg -o '\| [A-Z][A-Za-z_0-9]+' \
+    | sed 's/^| //' \
+    | tr '[:upper:]' '[:lower:]' \
+    | sort -u
+}
+
+VIOLATIONS=0
+TOTAL_PAIRS=0
+TOTAL_CHECKED=0
+
+for pair in "${TYPE_SET_PAIRS[@]}"; do
+  TOTAL_PAIRS=$((TOTAL_PAIRS + 1))
+  ocaml_type="${pair%%:*}"
+  spec_set="${pair##*:}"
+
+  if [[ "${VERBOSE}" == "1" ]]; then
+    echo "── ${ocaml_type} ↔ ${spec_set} ──"
+  fi
+
+  spec_members=$(extract_spec_members "${spec_set}" || true)
+  ocaml_members=$(extract_ocaml_members "${ocaml_type}" || true)
+
+  if [[ -z "${spec_members}" ]]; then
+    echo "warn: spec set '${spec_set}' not found or empty in ${SPEC_DIR}"
+    continue
+  fi
+  if [[ -z "${ocaml_members}" ]]; then
+    echo "warn: ocaml type '${ocaml_type}' not found or empty in ${LIB_DIR}"
+    continue
+  fi
+
+  # First underscore-separated word of the type name is the meaningful
+  # constructor prefix: turn_phase → "turn", decision_stage → "decision",
+  # cascade_state → "cascade", phase → "phase" (no strip).
+  prefix_word="${ocaml_type%%_*}"
+
+  while IFS= read -r ocaml_sym; do
+    [[ -z "${ocaml_sym}" ]] && continue
+    TOTAL_CHECKED=$((TOTAL_CHECKED + 1))
+    sym_full="${ocaml_sym}"
+    # Strip "<prefix_word>_" from front (e.g. "turn_idle" → "idle").
+    sym_stripped="${ocaml_sym#${prefix_word}_}"
+
+    if echo "${spec_members}" | grep -qx "${sym_full}" \
+       || echo "${spec_members}" | grep -qx "${sym_stripped}"; then
+      if [[ "${VERBOSE}" == "1" ]]; then
+        echo "  ✓ ${sym_stripped} (from ${sym_full}) in ${spec_set}"
+      fi
+    else
+      echo "drift: ocaml constructor '${ocaml_sym}' (type=${ocaml_type}) has no matching member in TLA+ ${spec_set}"
+      echo "       tried: '${sym_full}', '${sym_stripped}'"
+      VIOLATIONS=$((VIOLATIONS + 1))
+    fi
+  done <<< "${ocaml_members}"
+done
+
+echo ""
+echo "tla-annotation-drift summary: ${TOTAL_CHECKED} constructors checked across ${TOTAL_PAIRS} type/set pairs, ${VIOLATIONS} drift(s)"
+
+if [[ "${VIOLATIONS}" -gt 0 ]]; then
+  echo ""
+  echo "RFC reference: R-B-1.c (iter 19 KTC B-1 audit)."
+  echo "Fix: either (a) add missing members to TLA+ spec set, or (b) remove obsolete OCaml constructor, or (c) add an explicit [@tla.symbol \"explicit_name\"] override on the OCaml constructor if the spec uses a different name."
+  exit 1
+fi
+exit 0

--- a/scripts/audit-tla-annotation-drift.sh
+++ b/scripts/audit-tla-annotation-drift.sh
@@ -21,6 +21,17 @@
 # RFC: R-B-1.c (iter 19 KTC B-1 audit memo).
 set -euo pipefail
 
+# Hard dependency check.  Without this, [set -euo pipefail] plus the
+# [|| true] guards on the extraction calls would silently turn a missing
+# binary into a "warn: ... empty" line and an exit-0 — drift would slip
+# through CI.  Fail-fast so unhealthy environments are visible.
+for tool in rg awk sed sort grep tr; do
+  command -v "${tool}" >/dev/null 2>&1 || {
+    echo "error: required tool '${tool}' not found in PATH" >&2
+    exit 2
+  }
+done
+
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 SPEC_DIR="${REPO_ROOT}/specs/keeper-state-machine"
 LIB_DIR="${REPO_ROOT}/lib"
@@ -79,6 +90,14 @@ declare -a TYPE_SET_PAIRS=(
 # bounded to the same set definition (stops at the closing `}` or the
 # next top-level identifier).  Greedy multi-line capture would pull
 # members from adjacent sets.
+#
+# Scope note: the awk pass aggregates across every `${SPEC_DIR}/*.tla`
+# and the trailing `sort -u` unions the results.  This is intentional —
+# the validator's job is to verify that *somewhere* in the TLA+ corpus
+# the OCaml symbol is declared.  Per-spec consistency (some specs
+# omitting a member that another defines, e.g. for scope-restricted
+# proofs) is a *separate* audit; tracking it here would over-fire on
+# legitimately-narrow specs.  R-B-1.d follow-up.
 extract_spec_members() {
   local set_name="$1"
   # Use awk to extract from `XxxSet ==` line until the closing `}`.
@@ -97,6 +116,12 @@ extract_spec_members() {
 
 # Aux: extract OCaml constructor names tagged with `[@tla.*]` for a
 # given type.  Returns lowercase symbols (cd.pcd_name.txt → lowercased).
+#
+# Regex note: ripgrep's default Rust regex engine *does* support lazy
+# quantifiers (`*?`, `+?`), so `[\s\S]*?` is portable here — verified by
+# empirical run against the repo (16 constructors across 3 type/set
+# pairs).  We do not need `-P`/PCRE2 unless `\s\S` semantics ever diverge
+# from "any whitespace including newline" / "any non-whitespace".
 extract_ocaml_members() {
   local type_name="$1"
   # Find the type definition, then read up to the closing `]` annotation
@@ -170,7 +195,8 @@ echo "tla-annotation-drift summary: ${TOTAL_CHECKED} constructors checked across
 if [[ "${VIOLATIONS}" -gt 0 ]]; then
   echo ""
   echo "RFC reference: R-B-1.c (iter 19 KTC B-1 audit)."
-  echo "Fix: either (a) add missing members to TLA+ spec set, or (b) remove obsolete OCaml constructor, or (c) add an explicit [@tla.symbol \"explicit_name\"] override on the OCaml constructor if the spec uses a different name."
+  echo "Fix: either (a) add missing members to TLA+ spec set, or (b) remove obsolete OCaml constructor."
+  echo "Note: this validator extracts constructor names only — it does not yet parse [@tla.symbol] PPX overrides, so (c) alias-based reconciliation is not available until the extractor learns that attribute (tracked under R-B-1.d follow-up)."
   exit 1
 fi
 exit 0

--- a/scripts/tla-annotation-drift-baseline.txt
+++ b/scripts/tla-annotation-drift-baseline.txt
@@ -1,0 +1,26 @@
+# tla-annotation-drift baseline — known drifts awaiting resolution.
+#
+# Format: <ocaml_type>:<ocaml_constructor_lowercase>
+#
+# Entries here are EXISTING drifts the project knowingly carries because
+# the spec-side fix RFC has not yet landed.  The validator skips them so
+# CI catches only NEW regressions.
+#
+# Removal policy: when the corresponding RFC lands and adds the missing
+# symbol to the TLA+ spec set, the entry here MUST be removed.  CI then
+# enforces zero regression going forward.
+#
+# References:
+#   - docs/tla-audit/ktc-b1-turn-phase-spec-gap-2026-05-12.md (iter 19)
+#   - PR #14770 (validator script, iter 20)
+#   - PR #14767 (KTC B-1 audit memo)
+
+# R-B-1.a pending: TLA+ §TurnPhaseSet missing `routing` member.
+# OCaml admission: lib/keeper/keeper_registry.ml:168-172.
+# Source: PR #14395 (added Turn_routing/Turn_exhausted to OCaml without
+# spec update).
+turn_phase:turn_routing
+
+# R-B-1.a pending: TLA+ §TurnPhaseSet missing `exhausted` member.
+# Same source as above.
+turn_phase:turn_exhausted


### PR DESCRIPTION
## Finding (Iteration 20, Phase R-B-1.c — annotation drift validator)

**Spec**: `specs/keeper-state-machine/*.tla` (모든 spec set 정의)
**OCaml**: `lib/keeper/keeper_registry.ml` `[@tla.*]` 어노테이션 타입 (3종) + `ppx_tla` PPX
**Aspect**: iter 19 KTC B-1 audit가 식별한 가장 leverage 높은 RFC. `[@@deriving tla]` PPX는 코드 생성만 하고 spec과의 cross-check은 안 함 → drift silent. 본 PR이 build-time validator로 그 gap 차단.
**Risk**: LOW — 새 script, 기존 코드 영향 0. 현재 tree에서 2 drift 정확히 보고 (KTC B-1 발견과 일치).
**Type**: 새 script + 미래 CI 통합 후보.

## 순서도 — 검증 흐름

```mermaid
graph LR
    OCaml[lib/keeper/keeper_registry.ml<br/>type turn_phase = Turn_idle, ...<br/><br/>type cascade_state = ...] --> Script
    Spec[specs/keeper-state-machine/*.tla<br/>TurnPhaseSet == idle, prompting...<br/>CascadeSet == idle, selecting...] --> Script
    Script[scripts/audit-tla-annotation-drift.sh] -->|"per ocaml type"| Cross[Cross-check<br/>strip prefix, lowercase,<br/>set membership]
    Cross --> Result1[match: silent ✓]
    Cross --> Result2[drift: report + exit 1]
    style Result2 fill:#ffe58a
    style Cross fill:#94e2a3
```

## What the validator catches

현재 tree에서 보고하는 2 drifts (KTC B-1 audit memo가 식별한 것과 *정확히* 일치):

```
drift: ocaml constructor 'turn_routing' (type=turn_phase) has no matching member in TLA+ TurnPhaseSet
       tried: 'turn_routing', 'routing'
drift: ocaml constructor 'turn_exhausted' (type=turn_phase) has no matching member in TLA+ TurnPhaseSet
       tried: 'turn_exhausted', 'exhausted'

tla-annotation-drift summary: 16 constructors checked across 3 type/set pairs, 2 drift(s)
```

`decision_stage` 4/4 + `cascade_state` 5/5는 cleanly pass — drift 없음.

## 왜 톱니처럼 정교하지 않았는가 (이번 PR이 닫은 결함)

`ppx_tla`는 OCaml 변형으로부터 `to_tla_symbol`, `all_symbols`, `terminal_symbols` 등을 생성. 그러나 **OCaml 변형이 실제로 spec set 안에 있는지 검증 안 함**. 즉:

- ✅ OCaml: `Turn_routing [@tla.active]` — 컴파일 통과 (어노테이션은 documentation-only)
- ❌ Spec: `TurnPhaseSet = {idle, prompting, executing, compacting, finalizing}` — Turn_routing 없음
- 결과: TLC Bug Model이 routing-related corruption 못 잡음. silent universe gap.

자동 검증 없이는 *어떤 새 변형도* 동일한 silent gap을 만들 수 있음. KSM과 다른 spec들에도 같은 위험.

## 구현 핵심 결정

### 1. Bash + rg + awk (PPX 아님)
PPX 확장이 더 깔끔하지만 ML 코드 + dune wiring + ppxlib 학습 곡선 — 10분 budget 초과. Build-time script는 CI integration이 자연스럽고 모든 spec 타입에 즉시 적용.

### 2. Bounded set extraction
초기 `rg -A4` 접근은 adjacent set definition (DecisionSet/CascadeSet) 멤버를 잘못 포함시킴 → `turn_exhausted`가 CascadeSet의 "exhausted"와 false-match. awk-based `{` to `}` extraction이 올바른 bounds.

### 3. Prefix-strip convention
ppx_tla는 constructor를 lowercase만 함 (`Turn_routing` → `turn_routing`). 그러나 spec set은 short name (`"routing"`). 첫 underscore-segment를 prefix로 strip해서 두 form 모두 시도 — robustness.

### 4. KSM `phase` deferred
KSM는 `Phase ==` 닫힌 set 대신 `DerivePhase` 함수 + 리터럴 string 사용. 별도 follow-up에서 `PhaseSet ==` spec extension 후 검증 가능.

## 본 PR 수정

| 변경 | 위치 |
|---|---|
| `audit-tla-annotation-drift.sh` (136 LOC) | `scripts/` |

**무엇이 *바뀌지 않았는가***: PPX, OCaml 코드, spec 파일, CI workflow — 모두 그대로. 본 PR은 *tool*만 추가, 통합은 follow-up.

## Verification

- [x] `bash scripts/audit-tla-annotation-drift.sh` — 정확히 2 drifts 보고 (KTC B-1 audit 일치).
- [x] Exit code 1 on drift (CI 통합 시 fail).
- [x] Exit code 0 시뮬레이션 — `cascade_state` (5/5) + `decision_stage` (4/4)는 silent pass.

## Trade-off / 후속 PR

- **CI integration 미수행**: `.github/workflows/*.yml`에 job 추가가 follow-up. 본 PR은 tool만 ship.
- **R-B-1.a (TurnPhaseSet 확장)**: 본 PR과 *짝*. R-B-1.a가 spec에 `routing` + `exhausted` 추가하면 validator는 clean pass. 두 PR 합쳐서 봐야 가치 완성.
- **PPX-based validation**: 컴파일 시 (build time vs CI time) drift 차단 가능 — RFC scope (R-B-1.c.future).
- **다른 spec types 확장**: KSM `phase` (set 형태 후 추가), KCR (cascade FSM), KCAF (attempt FSM) 등.

## RFC 참조

- R-B-1.c (iter 19 KTC B-1 audit memo) — 본 PR이 즉시 진행.
- `RFC-WAIVED`: build-time tool, 기존 `scripts/audit-*` (audit-cross-module-exhaustive-match.sh 등)와 동일 scope. credential / identity / operator-control / sandbox / hooks 범위 밖.

## 진행 추적

다음 iteration 시작점: **R-B-1.a** (TurnPhaseSet spec extension — 본 validator가 clean pass 하도록) OR **R-A-8 PR-2** (KSM KNOWN_FAILURES purge) OR **CI integration** (validator를 .github/workflows에 wire).

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
