### PR TITLE
fix(provider): is_http_probe_capable_kind enumerate every variant

### DIFF
--- a/lib/provider_adapter.ml
+++ b/lib/provider_adapter.ml
@@ -796,7 +796,8 @@ let is_local_provider pname =
 let is_http_probe_capable_kind (kind : Llm_provider.Provider_config.provider_kind) : bool =
   match kind with
   | Llm_provider.Provider_config.Ollama -> true
-  | _ -> false
+  | Anthropic | Claude_code | OpenAI_compat | Glm | DashScope | Codex_cli
+  | Gemini | Gemini_cli | Kimi | Kimi_cli -> false
 ;;
 
 (** Per-provider per-attempt timeout bounds.


### PR DESCRIPTION
## Summary

Self-correction: the [`is_http_probe_capable_kind`] helper that PR #14721 introduced still carried a `_ -> false` catch-all. The PR's self-check said "no catch-all added — exhaustive over all 11 kinds" but the source said otherwise. Replace the wildcard with explicit enumeration so the compiler forces a deliberate classification when a new `provider_kind` constructor lands.

## Why it matters

The function decides whether `Keeper_turn_driver` should `Cascade_http_probe.register_url cfg.base_url` for that cfg. When a future local HTTP-probe-capable provider (vLLM, lmstudio, llama-server) ships as a new constructor:

- **Before this PR**: wildcard silently returns `false`. Capacity registry never sees the URL → saturation pre-skip never fires → operator loses a quiet performance optimisation **with no compiler signal**.
- **After this PR**: compiler errors at this boundary site, the maintainer makes the call deliberately.

Same anti-pattern that PR #14716 / #14762 / #14766 closed in keeper-side guard predicates — this one was on the adapter side, missed in our own self-check.

## Before / After

```ocaml
(* Before — wildcard absorbs 10 constructors *)
let is_http_probe_capable_kind kind =
  match kind with
  | Llm_provider.Provider_config.Ollama -> true
  | _ -> false

(* After — every variant is named *)
let is_http_probe_capable_kind kind =
  match kind with
  | Llm_provider.Provider_config.Ollama -> true
  | Anthropic | Claude_code | OpenAI_compat | Glm | DashScope | Codex_cli
  | Gemini | Gemini_cli | Kimi | Kimi_cli -> false
```

Sibling helper `timeout_bounds_of_kind` in the same module (PR #14736) already uses explicit enumeration; this PR brings `is_http_probe_capable_kind` into the same shape.

Behavior is unchanged for the current 11 kinds.

## Workaround self-check

| # | check | result |
|---|---|---|
| 1 | telemetry-as-fix? | no |
| 2 | string classifier? | no — typed match on closed sum |
| 3 | N-of-M? | no — single site, finishes a sweep started by #14716 / #14762 / #14766 |
| 4 | catch-all `_ ->` added? | REMOVED, not added |
| 5 | cap/cooldown/dedup/repair? | no |
| 6 | test backdoor? | no |
| 7 | same typo N sites? | no |

## Test plan

- [x] Boundary helper preserved for current 11 kinds
- [ ] CI build + test (local build blocked by `dune-local.sh` global lock)

🤖 Generated with [Claude Code](https://claude.com/claude-code)