### PR TITLE
ci(tla-annotation-drift): wire R-B-1.c validator into PR/push gate with baseline

### DIFF
--- a/.github/workflows/tla-annotation-drift.yml
+++ b/.github/workflows/tla-annotation-drift.yml
@@ -1,0 +1,61 @@
+name: tla-annotation-drift
+
+# R-B-1.c CI integration — enforce that OCaml `[@tla.idle|active|terminal]`
+# annotated constructors map to existing TLA+ spec set members.
+#
+# Background and rationale: `scripts/audit-tla-annotation-drift.sh` and
+# `docs/tla-audit/ktc-b1-turn-phase-spec-gap-2026-05-12.md`.
+#
+# Baseline policy: `scripts/tla-annotation-drift-baseline.txt` lists drifts
+# that are knowingly outstanding (awaiting their spec-extension RFC, e.g.
+# R-B-1.a for TurnPhaseSet routing/exhausted).  The validator skips
+# baseline entries so this job fails only on NEW regressions.  When an
+# RFC lands and adds the missing spec symbol, the corresponding baseline
+# line must be removed in the same PR — otherwise the next PR that
+# re-introduces the same drift would slip through.
+
+on:
+  pull_request:
+    paths:
+      - 'specs/keeper-state-machine/**'
+      - 'lib/keeper/keeper_registry.ml'
+      - 'lib/keeper/keeper_state_machine.ml'
+      - 'scripts/audit-tla-annotation-drift.sh'
+      - 'scripts/tla-annotation-drift-baseline.txt'
+      - '.github/workflows/tla-annotation-drift.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - 'specs/keeper-state-machine/**'
+      - 'lib/keeper/keeper_registry.ml'
+      - 'lib/keeper/keeper_state_machine.ml'
+      - 'scripts/audit-tla-annotation-drift.sh'
+      - 'scripts/tla-annotation-drift-baseline.txt'
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+concurrency:
+  group: tla-annotation-drift-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  drift:
+    name: TLA+ annotation drift check
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Install ripgrep
+        run: sudo apt-get update -qq && sudo apt-get install -y ripgrep
+
+      - name: Run drift validator
+        run: |
+          bash scripts/audit-tla-annotation-drift.sh \
+            --baseline scripts/tla-annotation-drift-baseline.txt

--- a/scripts/audit-tla-annotation-drift.sh
+++ b/scripts/audit-tla-annotation-drift.sh
@@ -26,7 +26,41 @@ SPEC_DIR="${REPO_ROOT}/specs/keeper-state-machine"
 LIB_DIR="${REPO_ROOT}/lib"
 
 VERBOSE=0
-if [[ "${1:-}" == "--verbose" ]]; then VERBOSE=1; fi
+BASELINE_FILE=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --verbose) VERBOSE=1; shift ;;
+    --baseline) BASELINE_FILE="$2"; shift 2 ;;
+    --baseline=*) BASELINE_FILE="${1#*=}"; shift ;;
+    *) echo "unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+# Load baseline known-drift entries (one per line, format: "type:symbol").
+# Lines starting with # and blank lines are ignored.  Baseline entries
+# are existing drifts awaiting resolution (e.g. spec extension RFC) —
+# the validator skips them so CI catches only NEW regressions.
+declare -a BASELINE=()
+if [[ -n "${BASELINE_FILE}" && -f "${BASELINE_FILE}" ]]; then
+  while IFS= read -r line; do
+    line="${line%%#*}"  # strip trailing comments
+    line="${line## }"
+    line="${line%% }"
+    [[ -z "${line}" ]] && continue
+    BASELINE+=("${line}")
+  done < "${BASELINE_FILE}"
+  if [[ "${VERBOSE}" == "1" ]]; then
+    echo "loaded baseline: ${#BASELINE[@]} known-drift entries from ${BASELINE_FILE}"
+  fi
+fi
+
+in_baseline() {
+  local key="$1"
+  for entry in "${BASELINE[@]:-}"; do
+    if [[ "${entry}" == "${key}" ]]; then return 0; fi
+  done
+  return 1
+}
 
 # Type → Set mapping.  OCaml type names (lowercase_with_underscores) to
 # TLA+ set identifiers (CamelCase + "Set").  Extend this list as new
@@ -75,6 +109,7 @@ extract_ocaml_members() {
 }
 
 VIOLATIONS=0
+KNOWN_DRIFTS=0
 TOTAL_PAIRS=0
 TOTAL_CHECKED=0
 
@@ -116,6 +151,11 @@ for pair in "${TYPE_SET_PAIRS[@]}"; do
       if [[ "${VERBOSE}" == "1" ]]; then
         echo "  ✓ ${sym_stripped} (from ${sym_full}) in ${spec_set}"
       fi
+    elif in_baseline "${ocaml_type}:${ocaml_sym}"; then
+      if [[ "${VERBOSE}" == "1" ]]; then
+        echo "  ~ ${sym_full} (type=${ocaml_type}) — known drift, skipped (baseline)"
+      fi
+      KNOWN_DRIFTS=$((KNOWN_DRIFTS + 1))
     else
       echo "drift: ocaml constructor '${ocaml_sym}' (type=${ocaml_type}) has no matching member in TLA+ ${spec_set}"
       echo "       tried: '${sym_full}', '${sym_stripped}'"
@@ -125,7 +165,7 @@ for pair in "${TYPE_SET_PAIRS[@]}"; do
 done
 
 echo ""
-echo "tla-annotation-drift summary: ${TOTAL_CHECKED} constructors checked across ${TOTAL_PAIRS} type/set pairs, ${VIOLATIONS} drift(s)"
+echo "tla-annotation-drift summary: ${TOTAL_CHECKED} constructors checked across ${TOTAL_PAIRS} type/set pairs, ${VIOLATIONS} new drift(s), ${KNOWN_DRIFTS} baseline-known drift(s)"
 
 if [[ "${VIOLATIONS}" -gt 0 ]]; then
   echo ""

--- a/scripts/tla-annotation-drift-baseline.txt
+++ b/scripts/tla-annotation-drift-baseline.txt
@@ -1,0 +1,26 @@
+# tla-annotation-drift baseline — known drifts awaiting resolution.
+#
+# Format: <ocaml_type>:<ocaml_constructor_lowercase>
+#
+# Entries here are EXISTING drifts the project knowingly carries because
+# the spec-side fix RFC has not yet landed.  The validator skips them so
+# CI catches only NEW regressions.
+#
+# Removal policy: when the corresponding RFC lands and adds the missing
+# symbol to the TLA+ spec set, the entry here MUST be removed.  CI then
+# enforces zero regression going forward.
+#
+# References:
+#   - docs/tla-audit/ktc-b1-turn-phase-spec-gap-2026-05-12.md (iter 19)
+#   - PR #14770 (validator script, iter 20)
+#   - PR #14767 (KTC B-1 audit memo)
+
+# R-B-1.a pending: TLA+ §TurnPhaseSet missing `routing` member.
+# OCaml admission: lib/keeper/keeper_registry.ml:168-172.
+# Source: PR #14395 (added Turn_routing/Turn_exhausted to OCaml without
+# spec update).
+turn_phase:turn_routing
+
+# R-B-1.a pending: TLA+ §TurnPhaseSet missing `exhausted` member.
+# Same source as above.
+turn_phase:turn_exhausted


### PR DESCRIPTION
## Finding (Iteration 21, Phase R-B-1.c CI integration)

**Spec**: 미래 모든 TLA+ spec drift 차단 인프라
**OCaml**: `scripts/audit-tla-annotation-drift.sh` (PR #14770) + 본 PR이 baseline + CI wire-in
**Aspect**: iter 19 audit → iter 20 validator → iter 21 enforcement chain의 마지막 link. Validator를 GitHub Actions에 wire — 신규 PR이 spec-drift 도입하면 CI fail. R-B-1.a 대기 중인 2 known drifts는 baseline으로 허용.
**Risk**: LOW — CI 추가, 기존 코드 영향 0. `tokens-drift.yml` 패턴 그대로.
**Stack**: base = `feat/r-b-1-c-tla-annotation-drift-validator` (PR #14770).

## 순서도 — 3-PR enforcement chain 완성

```mermaid
graph LR
    iter19[iter 19 PR #14767<br/>KTC B-1 audit memo<br/>finding] --> iter20[iter 20 PR #14770<br/>validator script<br/>tool]
    iter20 --> iter21[iter 21 THIS PR<br/>baseline + CI wire<br/>enforcement]
    iter21 -->|GitHub Actions| CI[PR fails on new drift]
    iter21 -->|baseline.txt| Known[2 known drifts<br/>R-B-1.a pending]
    style iter21 fill:#94e2a3
```

## What the CI does

신규 PR이 다음 path 중 하나 건드리면 발사:
- `specs/keeper-state-machine/**`
- `lib/keeper/keeper_registry.ml`
- `lib/keeper/keeper_state_machine.ml`
- validator script / baseline / workflow 자체

5분 timeout 내 `bash audit-tla-annotation-drift.sh --baseline ...` 실행. 새 drift 발견 시 fail.

## Baseline 메커니즘

```
$ bash scripts/audit-tla-annotation-drift.sh --baseline scripts/tla-annotation-drift-baseline.txt
tla-annotation-drift summary: 16 constructors checked across 3 type/set pairs, 0 new drift(s), 2 baseline-known drift(s)
exit=0
```

Baseline 파일:
```
turn_phase:turn_routing    # R-B-1.a pending
turn_phase:turn_exhausted  # R-B-1.a pending
```

**Paired-update policy**: R-B-1.a가 TurnPhaseSet 확장 시 baseline의 두 라인도 같은 PR에서 제거해야 함. 그러지 않으면 *동일 형태 drift*가 다른 OCaml 추가로 재발해도 baseline이 흡수해버림.

## 왜 톱니처럼 정교하지 않은가 (이번 PR이 닫은 결함)

iter 19 ~ 20까지 다음 결함은 있었음:
- ❌ `[@tla.*]` annotation은 documentation-only (iter 19 finding)
- ✅ Validator 존재 (iter 20)
- ❌ **Validator는 manual 실행만, PR에서 자동 실행 없음** (이번 iter까지)

본 PR이 마지막 ❌를 닫음. 이제 *어떤 contributor*도 새 `[@tla.*]` 변형을 spec 미동기화로 PR 올리면 즉시 CI fail. silent drift 영구 차단.

## 본 PR 수정

| 변경 | 위치 |
|---|---|
| `--baseline <file>` flag + comment-friendly parsing | `scripts/audit-tla-annotation-drift.sh` (+44 LOC) |
| Baseline file with 2 R-B-1.a pending entries | `scripts/tla-annotation-drift-baseline.txt` (+26 LOC) |
| GitHub Actions workflow (path-scoped trigger, 5-min timeout) | `.github/workflows/tla-annotation-drift.yml` (+61 LOC) |

**무엇이 *바뀌지 않았는가***: spec 파일, OCaml lib, 기존 workflow — 모두 그대로. 본 PR은 enforcement infrastructure 추가만.

## Failure mode catalog (CI behavior)

| Scenario | CI 동작 |
|---|---|
| 신규 OCaml `[@tla.active]` 추가, spec 미동기화 | ❌ FAIL — drift report + exit 1 |
| 신규 OCaml + 같은 PR에서 spec set 확장 | ✓ PASS — validator clean |
| 신규 OCaml + `[@tla.symbol "explicit_name"]` override (spec name 사용) | ✓ PASS |
| baseline-known drift은 그대로 (R-B-1.a 미land) | ✓ PASS — baseline skip |
| R-B-1.a land + baseline 미제거 | ⚠️ silent — paired-update policy 문서화로 mitigation |

## Verification

- [x] `bash scripts/audit-tla-annotation-drift.sh --baseline scripts/tla-annotation-drift-baseline.txt` → exit 0, "0 new drift(s), 2 baseline-known drift(s)".
- [x] Workflow YAML valid (path-scoped trigger).
- [ ] CI 첫 실행은 PR 머지 후 — push 트리거 또는 다음 PR에서 검증.

## Trade-off / 후속 PR

- **Baseline maintenance burden**: R-B-1.a land 시 baseline 2 라인 제거 필수. PR description에 강조.
- **Required status check 미설정**: 본 PR은 workflow만 추가. 사용자가 branch protection rules에서 `tla-annotation-drift` job을 required로 등록할지 결정.
- **R-B-1.a (TurnPhaseSet 확장)**: 본 PR과 *짝*. TLC re-verify 위험으로 별도 PR.

## RFC 참조

- R-B-1.c CI 통합 (iter 19 audit, iter 20 script, **iter 21 CI**) — 3-PR chain 완성.
- `tokens-drift.yml` 패턴 참조 — 동일 path-scoped trigger + bash script.
- `RFC-WAIVED`: build-time drift gate, 기존 CI audit workflow와 동일 scope. credential / identity / operator-control / sandbox / hooks 범위 밖.

## 진행 추적

다음 iteration 시작점: **R-B-1.a** (TurnPhaseSet 확장 + baseline 2 라인 제거 — paired update) OR **R-A-8 PR-2** (KSM KNOWN_FAILURES purge — TLC run risk) OR **Phase C** (KCR cascade routing 진입).

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
