### PR TITLE
feat(telemetry): typed Operator_compact_result variant

### DIFF
--- a/lib/keeper/operator_compact_result.ml
+++ b/lib/keeper/operator_compact_result.ml
@@ -1,0 +1,12 @@
+type t =
+  | Ok
+  | No_checkpoint
+  | Precondition
+  | Not_found
+
+let to_label = function
+  | Ok -> "ok"
+  | No_checkpoint -> "no_checkpoint"
+  | Precondition -> "precondition"
+  | Not_found -> "not_found"
+;;

--- a/lib/keeper/operator_compact_result.mli
+++ b/lib/keeper/operator_compact_result.mli
@@ -1,0 +1,20 @@
+(** Operator_compact_result — closed sum for the [result] label on
+    [metric_keeper_operator_compact].
+
+    The metric registration in [prometheus.ml] already documented the
+    closed set verbatim:
+
+        "Total operator-invoked masc_keeper_compact calls
+         (labels: result=ok|no_checkpoint|precondition|not_found)"
+
+    Locks the contract: a typo or new value at one emit site is now a
+    compile error at [to_label] (the type's witness) instead of a
+    silent cardinality drift on the Prometheus surface. *)
+
+type t =
+  | Ok (** Compaction applied successfully. *)
+  | No_checkpoint (** No checkpoint to compact from. *)
+  | Precondition (** Preconditions for compaction unmet (e.g. keeper paused). *)
+  | Not_found (** Operator referenced a keeper name that does not exist. *)
+
+val to_label : t -> string

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -1388,7 +1388,10 @@ let init () =
     "Whether an allowed keeper tool is unused or below the diversity threshold (1=yes, \
      0=no; labels: keeper, tool)"
     Gauge;
-  (* Operator-initiated overflow recovery — emitted by tool_keeper.ml *)
+  (* Operator-initiated overflow recovery — emitted by tool_keeper.ml.
+     [result] label is bound by [Operator_compact_result.t]; adding a
+     new value requires extending the closed sum and re-running every
+     emit site through the compiler. *)
   add
     Keeper_metrics.metric_keeper_operator_compact
     "Total operator-invoked masc_keeper_compact calls (labels: \

--- a/lib/tool_keeper.ml
+++ b/lib/tool_keeper.ml
@@ -1357,7 +1357,7 @@ let handle_keeper_compact ctx args : tool_result =
     match Keeper_registry.get ~base_path:ctx.config.base_path name with
     | None ->
       Prometheus.inc_counter Keeper_metrics.metric_keeper_operator_compact
-        ~labels:[("keeper", name); ("result", "not_found")] ();
+        ~labels:[("keeper", name); ("result", Operator_compact_result.(to_label Not_found))] ();
       (false, error_response_typed ~code:Validation_error
         (Printf.sprintf "keeper %s is not in the registry" name))
     | Some entry ->
@@ -1373,7 +1373,7 @@ let handle_keeper_compact ctx args : tool_result =
     in
     if not allowed then begin
       Prometheus.inc_counter Keeper_metrics.metric_keeper_operator_compact
-        ~labels:[("keeper", name); ("result", "precondition")] ();
+        ~labels:[("keeper", name); ("result", Operator_compact_result.(to_label Precondition))] ();
       (false, error_response_typed ~code:Validation_error
         (Printf.sprintf
            "keeper %s is in phase %s; compaction requires Overflowed, Paused, or force=true"
@@ -1406,7 +1406,7 @@ let handle_keeper_compact ctx args : tool_result =
             ~after_tokens:recovery.compaction.after_tokens;
           invalidate_status_cache name;
           Prometheus.inc_counter Keeper_metrics.metric_keeper_operator_compact
-            ~labels:[("keeper", name); ("result", "ok")] ();
+            ~labels:[("keeper", name); ("result", Operator_compact_result.(to_label Ok))] ();
           (true,
            Yojson.Safe.to_string
              (`Assoc [
@@ -1432,7 +1432,7 @@ let handle_keeper_compact ctx args : tool_result =
                reason = "no_valid_checkpoint";
             });
           Prometheus.inc_counter Keeper_metrics.metric_keeper_operator_compact
-            ~labels:[("keeper", name); ("result", "no_checkpoint")] ();
+            ~labels:[("keeper", name); ("result", Operator_compact_result.(to_label No_checkpoint))] ();
           (false,
            Printf.sprintf
              "keeper %s: checkpoint compaction unavailable (no valid checkpoint found)"


### PR DESCRIPTION
## Summary

4 hardcoded `result` label strings on `metric_keeper_operator_compact`
(in `tool_keeper.ml`) collapsed into a closed sum
`Operator_compact_result.t`.

## Why

The metric registration in `prometheus.ml` already documented the
closed set verbatim:

> "Total operator-invoked `masc_keeper_compact` calls (labels:
> `result=ok|no_checkpoint|precondition|not_found`)"

i.e. the author had full closed-set awareness but the type system was
bypassed.  Same workaround #2 pattern (string classifier) earlier
sweep iterations closed for `oas_execution_error_phase` (#14737),
`error_event_type` (#14755), `alert_persist_kind` (#14760),
`paused_state_persist_phase` (#14768).

Locks the contract: a typo or new value at one emit site is now a
compile error at `to_label` (the type's witness) instead of a silent
cardinality drift.

## Sites (4)

| File:Line | Variant |
|-----------|---------|
| `tool_keeper.ml:1360` | `Not_found` |
| `tool_keeper.ml:1376` | `Precondition` |
| `tool_keeper.ml:1409` | `Ok` |
| `tool_keeper.ml:1435` | `No_checkpoint` |

## Approach

```ocaml
(* lib/keeper/operator_compact_result.ml *)
type t = Ok | No_checkpoint | Precondition | Not_found

val to_label : t -> string
```

Wire format byte-equal.

## Test plan

- [ ] CI green
- [ ] `rg '"result", "(ok|no_checkpoint|precondition|not_found)"' lib/` = 0

RFC-WAIVED: not in credential/identity/operator/sandbox/hooks/workflow scope.
(The "operator" in the metric name refers to operator-initiated keeper
compact calls — not the [operator_control] subsystem that the RFC gate
guards.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)