### PR TITLE
refactor(rfc-0070-3b-ii): rename of_hash_hex → derive

### DIFF
--- a/lib/keeper/keeper_container_name.ml
+++ b/lib/keeper/keeper_container_name.ml
@@ -8,7 +8,7 @@ let hex_chars_taken = 32
 
 let prefix = "masc-keeper-"
 
-let of_hash_hex ~algo ~turn_id ~attempt ~suffix =
+let derive ~algo ~turn_id ~attempt ~suffix =
   let input =
     (* Use unit separators (US, \x1F) so concatenation is unambiguous —
        different (turn_id, attempt, suffix) tuples map to different

--- a/lib/keeper/keeper_container_name.mli
+++ b/lib/keeper/keeper_container_name.mli
@@ -20,7 +20,7 @@
     serialised wire form. *)
 type t
 
-(** [of_hash_hex ~algo ~turn_id ~attempt ~suffix] derives the
+(** [derive ~algo ~turn_id ~attempt ~suffix] derives the
     container name. Pure function of declared inputs.
 
     [suffix] is the keeper-derived disambiguator (typically the keeper
@@ -29,7 +29,7 @@ type t
     names. The implementation hashes the raw bytes so any string is
     accepted, including the empty string (uncommon but not rejected
     — the caller is expected to pass a meaningful identifier). *)
-val of_hash_hex
+val derive
   :  algo:Keeper_hash_algo.t
   -> turn_id:int
   -> attempt:int

--- a/test/test_keeper_container_name.ml
+++ b/test/test_keeper_container_name.ml
@@ -8,7 +8,7 @@ open Alcotest
 open Masc_mcp
 
 let make ?(algo = Keeper_hash_algo.SHA_256) ~turn_id ~attempt ~suffix () =
-  Keeper_container_name.of_hash_hex ~algo ~turn_id ~attempt ~suffix
+  Keeper_container_name.derive ~algo ~turn_id ~attempt ~suffix
 
 (* ── Determinism: same input ⇒ same output ────────────────────── *)
 


### PR DESCRIPTION
## 목표 — PR #14764 후속 rename + thread closeloop

PR #14764 (Phase 3b-ii) admin-merge 후 도착한 2 Copilot threads 처리.

## RFC 인용

| RFC | 관계 |
|-----|------|
| **RFC-0070** | §3.1 — Container_name derivation API 표면 |
| RFC-0006 | cite-only |
| RFC-0036 | cite-only |

## Copilot 2 threads 처리

| Thread | 판정 | 처리 |
|--------|------|------|
| T6 `of_hash_hex` 이름 | **ACCEPT** | `derive`로 rename — 의미 정확화 (digest를 받는 게 아니라 *생성*함) |
| T7 `private_modules` | **REJECT (조건부 negative answer, 일관성)** | 동일 패턴 #14757 cite. public surface 의도 — test/caller 접근 필요 |

## 변경

```
lib/keeper/keeper_container_name.mli   ±2 (val of_hash_hex → val derive)
lib/keeper/keeper_container_name.ml    ±1 (let of_hash_hex → let derive)
test/test_keeper_container_name.ml     ±1 (caller helper)
```

총 4 line diff, behavior change 0.

## 검증

- **Isolated ocamlc**: Phase 3a/3b-i 패턴 (확신 high — pure rename)
- **`dune build @check`**: main 회귀 (#14745 keeper_runtime cleanup pending) 미해소 — 본 PR 무관

## Workaround Rejection Bar self-check

| 시그니처 | 본 PR 해당? |
|---------|------------|
| Counter-as-fix | N/A |
| String 분류기 | N/A |
| N-of-M | N/A — 단일 rename, 1 PR |
| Cap/cooldown/dedup/repair | N/A |
| Test backdoor | N/A |
| Catch-all `_ ->` | N/A |

## 미검증

- Phase 3b-iii가 `derive`를 caller로 사용 시 실제 readability 가치 확인 가능 (논리적 정합성은 확정)

## 다음 PR

- **Phase 3b-iii**: Plan record fields + `Keeper_sandbox_plan.of_request` real impl (Phase 3a stub 대체). `Keeper_container_name.derive`가 첫 caller.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
