### PR TITLE
docs(tla-audit): KCR Phase C-1 — fallback cap mechanism mismatch

### DIFF
--- a/docs/tla-audit/kcr-c1-fallback-cap-mechanism-gap-2026-05-12.md
+++ b/docs/tla-audit/kcr-c1-fallback-cap-mechanism-gap-2026-05-12.md
@@ -1,0 +1,158 @@
+# KCR Phase C-1 Audit — Fallback Cap Mechanism Mismatch
+
+**Iteration**: 22 (/loop FSM/TLA+/OCaml drift hunt — first KCR entry)
+**Date**: 2026-05-12
+**Spec**: `specs/keeper-state-machine/KeeperCascadeRouting.tla` (366 LOC)
+**OCaml**: `lib/keeper/keeper_cascade_selector.ml` (`select_item_for_turn`)
+**Risk**: MID — both mechanisms terminate fallback in *practice*, but they cap by different metrics, so TLA+ `FallbackCountBounded` is enforced by a side-effect, not by a faithful OCaml counterpart.
+**Type**: Audit-only (no code change in this PR).
+
+## Spec context
+
+`KeeperCascadeRouting.tla` models cascade fallback with an explicit
+counter:
+
+```tla
+VARIABLES
+    ...
+    fallback_count,        \* keeper → Nat
+    group_path,            \* keeper → Seq(Groups) — visited groups this turn
+    turn_blocked           \* keeper → BOOLEAN — BUG tracking
+
+(* I5: Fallback count stays bounded. *)
+FallbackCountBounded ==
+    \A keeper \in Keepers : fallback_count[keeper] <= MaxFallbacks
+
+ItemDegrade(keeper) ==
+    /\ keeper_state[keeper] = "Turning"
+    /\ ...
+    /\ fallback_count[keeper] < MaxFallbacks   \* explicit precondition
+    /\ ...
+    /\ fallback_count' = [fallback_count EXCEPT ![keeper] = @ + 1]
+
+GroupFallback(keeper) ==
+    /\ ...
+    /\ fallback_count[keeper] < MaxFallbacks   \* explicit precondition
+    /\ ...
+    /\ fallback_count' = [fallback_count EXCEPT ![keeper] = @ + 1]
+```
+
+`MaxFallbacks` is a CONSTANT — configurable per TLC run (cfg file).
+
+PR #14668 (merged 2026-05-11) explicitly added the `<` precondition to
+prevent TypeOK violation on overflow — confirms this is a recent
+spec-side tightening.
+
+## OCaml mechanism
+
+`lib/keeper/keeper_cascade_selector.ml:5-72`:
+
+```ocaml
+let rec try_group group_name visited =
+  if List.mem group_name visited then
+    Error `No_available_item    (* cycle detection only *)
+  else
+    match find_group cascade_profile group_name with
+    | None -> Error `No_available_item
+    | Some group ->
+        match find_healthy items with
+        | Some item -> Ok (group_name, item)
+        | None ->
+            (match group.fallback_group with
+             | Some next -> try_group next (group_name :: visited)
+             | None -> Error `No_available_item)
+```
+
+The OCaml caps fallback *implicitly* via:
+1. The `visited` list prevents revisiting a group.
+2. Therefore the recursion depth is bounded by `O(profile.groups)` — the
+   number of distinct groups in the cascade profile.
+
+There is **no explicit `fallback_count` counter** and **no
+`MaxFallbacks`-equivalent configuration**.
+
+## Why the two mechanisms are not equivalent
+
+Both terminate fallback, but they cap by different metrics:
+
+| Mechanism | Cap source | Tunable? |
+|---|---|---|
+| TLA+ `fallback_count <= MaxFallbacks` | explicit counter | yes, via cfg CONSTANT |
+| OCaml visited-list cycle detection | distinct-group count | no, derived from profile shape |
+
+Consider a profile with 5 groups and `MaxFallbacks = 3`:
+
+- **TLA+**: 3 fallbacks allowed before TypeOK violation.  4th attempt
+  blocked by `fallback_count < MaxFallbacks` precondition.
+- **OCaml**: 4 fallbacks allowed (visited would be `[g1, g2, g3, g4]`,
+  pursuing `g5` is fine), 5th attempt blocked only when visited covers
+  all groups.
+
+This is a real semantic gap.  The spec `FallbackCountBounded` invariant
+is enforced *in production* only because real cascade profiles
+typically have fewer groups than the spec's `MaxFallbacks` setting.
+Change either side independently — increase `MaxFallbacks` in cfg, or
+add a 6th group to a profile — and the gap surfaces.
+
+## Three concrete drift scenarios
+
+1. **Spec re-verification with larger `MaxFallbacks`**:
+   `MaxFallbacks = 10` in cfg, profile with 6 groups.  Spec admits 10
+   fallbacks ⇒ TLC explores transitions OCaml can never execute.
+   Spec coverage > production coverage; the spec catches no extra bugs.
+
+2. **Profile expansion in production**:
+   Operator extends a cascade profile to 8 groups while `MaxFallbacks`
+   in cfg stays 5.  OCaml allows 8 fallbacks per turn, spec catches
+   only 5.  Real OCaml behavior is *outside* the spec's reachable
+   state space.
+
+3. **Spec tightening for adaptive routing**:
+   A future RFC introduces "early-exit" cap based on observed latency
+   (e.g. abort fallback after 2 attempts if elapsed > budget).  This
+   would correspond to a tighter `MaxFallbacks` in spec — but OCaml's
+   visited-list cap can't model the budget-aware tightening.
+
+## Suggested RFC fix paths
+
+| ID | Scope | Action | Risk |
+|---|---|---|---|
+| R-C-1.a | OCaml-side parity | Add explicit `fallback_count` parameter to `try_group`, threading `~max_fallbacks` from a config source.  Pin the count alongside `visited` so cycle + counter both bound recursion. | MID — touches `select_item_for_turn` signature + caller (`keeper_cascade_routing.ml`?) + 1+ test files. |
+| R-C-1.b | Spec-side relaxation | Drop `MaxFallbacks` from spec and rely on `NoGroupCycle` invariant alone.  TLC re-verify confirms cycle detection is sufficient.  Simpler spec; documents that the production mechanism is the SSOT. | LOW — spec change, TLC re-verify (5-15 min). |
+| R-C-1.c | Both, with shared CONSTANT | Pin `MaxFallbacks` value identically in OCaml config and TLA+ cfg.  Add audit script to verify equivalence (R-B-1.c pattern). | MID — requires both implementations and a cross-check tool. |
+
+R-C-1.b is the cheapest fix if the visited-list cycle detection is the
+intended production semantics.  R-C-1.a preserves the spec's tighter
+contract.  R-C-1.c bridges them at the cost of an extra invariant
+check.
+
+## Adjacent question — is `fallback_count` even tracked in production?
+
+`grep -irn "fallback_count" lib/` returns matches only in:
+- `lib/model_inference_metrics.ml` (LLM inference fallback metric — different domain)
+- `lib/eval_calibration.ml`, `lib/dashboard/*` — telemetry/UI
+
+None of these track the cascade-router-level fallback count the spec
+models.  The mechanism mismatch isn't just about cap value — *the
+counter itself is absent* on the OCaml side, only the *effect* of
+bounded fallback is present (via cycle detection).
+
+This deepens the spec coverage gap: the TLA+ `fallback_count` variable
+is observable in spec traces (a Bug Model could assert "if
+fallback_count[k] > N then some property holds"), but no equivalent
+OCaml dashboard/log surface exposes the same count.
+
+## Out-of-scope for this iteration
+
+- TLC re-verification with R-C-1.b spec relaxation — separate PR.
+- C-2 health asymmetric transitions audit — separate sub-aspect.
+- C-3 fallback chain traversal vs OCaml `try_group` — overlaps with this
+  audit, defer to a focused diff PR.
+
+## References
+
+- KCR spec line 33-42 (CONSTANTS), 55-65 (VARIABLES), 144-184 (ItemDegrade + GroupFallback), 259-260 (FallbackCountBounded invariant).
+- OCaml `keeper_cascade_selector.ml:5-72` (`select_item_for_turn`).
+- PR #14668: `fix(specs): cap fallback_count in ItemDegrade — KeeperCascadeRouting TypeOK clean fix` (merged 2026-05-11) — the spec-side tightening that exposed this OCaml gap.
+- Adjacent pattern: KSM A-1 audit (`ksm-init-mapping-2026-05-12.md`) — same shape "OCaml ahead of spec on representation, spec stricter on contract".
+- KTC B-1 audit (`ktc-b1-turn-phase-spec-gap-2026-05-12.md`) — sibling drift class.


### PR DESCRIPTION
## Finding (Iteration 22, Phase C-1 — KCR entry)

**Spec**: `specs/keeper-state-machine/KeeperCascadeRouting.tla` (366 LOC, first KCR entry)
**OCaml**: `lib/keeper/keeper_cascade_selector.ml` (`select_item_for_turn`)
**Aspect**: 새 spec entry. TLA+ `FallbackCountBounded` invariant은 explicit counter로 cap 강제, OCaml은 visited-list cycle detection만 — *동일 목적, 다른 metric*. 두 메커니즘 *서로 정확히 매핑 안 됨*.
**Risk**: MID — 현재 production은 *우연히* 안전 (profile groups < MaxFallbacks). 설정 또는 profile 변경 시 spec coverage gap 발생.
**Type**: Audit-only — 코드 변경 0, 3 RFC 후보 도출.

## 순서도 — Cap 메커니즘 비교

```mermaid
graph TB
    subgraph spec[TLA+ KeeperCascadeRouting.tla]
        SpecVar[fallback_count : keeper → Nat]
        SpecCfg[MaxFallbacks cfg CONSTANT]
        SpecPre[ItemDegrade precondition:<br/>fallback_count < MaxFallbacks]
        SpecInv[FallbackCountBounded invariant]
        SpecVar --> SpecPre
        SpecCfg --> SpecPre
        SpecPre --> SpecInv
    end
    subgraph ocaml[OCaml keeper_cascade_selector.ml]
        TryGroup[try_group group visited]
        VisitedCheck[List.mem group visited → Error]
        Implicit[implicit cap = O profile.groups]
        TryGroup --> VisitedCheck
        VisitedCheck --> Implicit
    end
    SpecPre -.✗ no counterpart.-> Implicit
    style Implicit fill:#ffe58a
    style SpecPre fill:#94e2a3
```

## TLA+ side (PR #14668이 추가한 cap)

```tla
ItemDegrade(keeper) ==
    /\ ...
    /\ fallback_count[keeper] < MaxFallbacks   (* PR #14668 *)
    /\ fallback_count' = [... EXCEPT ![keeper] = @ + 1]

(* I5: Fallback count stays bounded. *)
FallbackCountBounded ==
    \A keeper \in Keepers : fallback_count[keeper] <= MaxFallbacks
```

## OCaml side — *counter 자체가 부재*

`lib/keeper/keeper_cascade_selector.ml:12-47`:

```ocaml
let rec try_group group_name visited =
  if List.mem group_name visited then
    Error `No_available_item    (* cycle detection only *)
  else
    ... try fallback group, recurse with (group_name :: visited) ...
```

`grep -irn "fallback_count" lib/`은 *cascade-router-level* counter를 찾지 못함 — `lib/model_inference_metrics.ml`, `lib/eval_calibration.ml`, dashboard 모듈에서 매칭되지만 모두 다른 도메인 (LLM inference fallback 또는 telemetry).

## 왜 톱니처럼 정교하지 않은가 (이번 PR이 식별한 결함)

두 메커니즘은 *결과적으로 동일하게* fallback을 종료시키지만:

| | TLA+ | OCaml |
|---|---|---|
| Cap source | explicit `MaxFallbacks` CONSTANT | implicit `O(profile.groups)` |
| Tunable | yes (cfg) | no (profile shape) |
| Counter observable | yes (variable) | no (only termination effect) |

이 mismatch가 *우연히* 안전한 이유: 실제 cascade profile은 보통 group 수가 MaxFallbacks보다 적음. 다음 시나리오에서 silent gap 발생:

1. **MaxFallbacks=10, profile 6 groups**: spec 10번 fallback admit, OCaml 6번. Spec coverage > production. TLC가 OCaml이 못 실행하는 transition 탐색.
2. **Profile 8 groups, MaxFallbacks=5**: OCaml 8번 fallback admit, spec 5번. Production 동작이 spec reachable state 밖.
3. **미래 budget-aware cap RFC**: spec은 tightening 가능, OCaml visited-list로는 못 모델링.

## 3 RFC 후보

| ID | 방향 | Risk |
|---|---|---|
| **R-C-1.a** | OCaml parity — explicit counter + config-threaded `~max_fallbacks` | MID (signature change) |
| **R-C-1.b** | Spec relaxation — drop `MaxFallbacks`, `NoGroupCycle` 단독으로 충분 | LOW (spec change + TLC re-verify) |
| **R-C-1.c** | 양쪽 + 공유 CONSTANT + audit script (R-B-1.c 패턴) | MID (양쪽 구현 + tool) |

가장 leverage 높음: **R-C-1.b** — spec을 production semantics에 맞춤. 가장 strict: **R-C-1.c** — 양방향 enforcement.

## 본 PR 내용

- `docs/tla-audit/kcr-c1-fallback-cap-mechanism-gap-2026-05-12.md` (+158 LOC): 위 분석 + 3 RFC 후보 + 3 drift 시나리오 enumerate.

## Verification

- [x] OCaml `select_item_for_turn` line-by-line 직접 검토 (line 5-72).
- [x] TLA+ ItemDegrade + GroupFallback action 직접 검토 (line 144-184).
- [x] `grep -irn fallback_count lib/` 결과 모두 cross-check.
- [x] PR #14668 mergedAt + title 확인 (gh CLI).
- [ ] TLC re-verify with R-C-1.b spec relaxation: 별도 PR scope.

## Trade-off

- **Audit-only 결정 사유**: 3 RFC 모두 design discussion 필요. R-C-1.a는 caller cascade, R-C-1.b는 spec change + TLC, R-C-1.c는 양쪽 + tool. 10-min budget 초과.
- **C-2/C-3 별도 sub-aspect**: health asymmetric transitions, fallback chain traversal — 본 audit과 인접하나 분리해서 진행.

## RFC 참조

- C-1 (plan Phase C 첫 항목).
- KSM A-1 (#14694), KTC B-1 (#14767) 패턴 참고 — 동일 "spec-vs-OCaml mismatch" 클래스.
- `RFC-WAIVED`: docs-only, 코드 영향 없음. credential / identity / operator-control / sandbox / hooks 범위 밖.

## 진행 추적

다음 iteration 시작점: **R-C-1.b** (spec relaxation, LOW risk + TLC re-verify) OR **C-2** (health asymmetric transitions) OR **R-B-1.a** (KTC TurnPhaseSet 확장).

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
