### PR TITLE
feat(telemetry): typed Bookkeeping_failure_kind variant

### DIFF
--- a/lib/keeper/bookkeeping_failure_kind.ml
+++ b/lib/keeper/bookkeeping_failure_kind.ml
@@ -1,0 +1,8 @@
+type t =
+  | Cancelled
+  | Exception
+
+let to_label = function
+  | Cancelled -> "cancelled"
+  | Exception -> "exception"
+;;

--- a/lib/keeper/bookkeeping_failure_kind.mli
+++ b/lib/keeper/bookkeeping_failure_kind.mli
@@ -1,0 +1,20 @@
+(** Bookkeeping_failure_kind — closed sum for the [kind] label on
+    [metric_keeper_turn_slot_bookkeeping_failures].
+
+    The metric registration in [prometheus.ml] already documented the
+    closed set verbatim:
+
+        "Total keeper turn-slot release bookkeeping callbacks that
+         could not complete while preserving semaphore release
+         (labels: op, kind=cancelled|exception)"
+
+    Closes the [kind] label.  The [op] label intentionally stays
+    free-form because it carries dynamic context (e.g.
+    [drop_holder <label>]) needed to disambiguate which bookkeeping
+    callback failed. *)
+
+type t =
+  | Cancelled (** Bookkeeping fiber was cancelled mid-flight. *)
+  | Exception (** Bookkeeping callback raised an OCaml exception. *)
+
+val to_label : t -> string

--- a/lib/keeper/keeper_turn_slot.ml
+++ b/lib/keeper/keeper_turn_slot.ml
@@ -646,10 +646,10 @@ let run_after_acquire_flag_hook_for_test ~label ~keeper_name =
   | Some hook -> hook ~label ~keeper_name
 ;;
 
-let observe_bookkeeping_failure ~op ~kind =
+let observe_bookkeeping_failure ~op ~(kind : Bookkeeping_failure_kind.t) =
   Prometheus.inc_counter
     Keeper_metrics.metric_keeper_turn_slot_bookkeeping_failures
-    ~labels:[ "op", op; "kind", kind ]
+    ~labels:[ "op", op; "kind", Bookkeeping_failure_kind.to_label kind ]
     ()
 ;;
 
@@ -667,10 +667,10 @@ let safe_bookkeeping ~op f =
     (* Bookkeeping (holder table / waiter queue / completion stamp) is
        advisory and self-healing; skipping under fiber cancellation is
        acceptable.  The semaphore release that follows must still run. *)
-    observe_bookkeeping_failure ~op ~kind:"cancelled";
+    observe_bookkeeping_failure ~op ~kind:Bookkeeping_failure_kind.Cancelled;
     Log.Keeper.warn "release_keeper_turn_slot: %s skipped (Cancelled)" op
   | exn ->
-    observe_bookkeeping_failure ~op ~kind:"exception";
+    observe_bookkeeping_failure ~op ~kind:Bookkeeping_failure_kind.Exception;
     Log.Keeper.warn "release_keeper_turn_slot: %s failed: %s" op (Printexc.to_string exn)
 ;;
 
@@ -695,13 +695,13 @@ let release_recorded_holder
     let force_released =
       try consume_force_release ~label ~keeper_name ~acquisition_id with
       | Eio.Cancel.Cancelled _ ->
-        observe_bookkeeping_failure ~op:("drop_holder " ^ label_str) ~kind:"cancelled";
+        observe_bookkeeping_failure ~op:("drop_holder " ^ label_str) ~kind:Bookkeeping_failure_kind.Cancelled;
         Log.Keeper.warn
           "release_keeper_turn_slot: drop_holder %s skipped (Cancelled)"
           label_str;
         false
       | exn ->
-        observe_bookkeeping_failure ~op:("drop_holder " ^ label_str) ~kind:"exception";
+        observe_bookkeeping_failure ~op:("drop_holder " ^ label_str) ~kind:Bookkeeping_failure_kind.Exception;
         Log.Keeper.warn
           "release_keeper_turn_slot: drop_holder %s failed: %s"
           label_str

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -1276,6 +1276,9 @@ let init () =
     Keeper_metrics.metric_keeper_turn_queue_depth
     "Current keeper turn wait queue depth (labels: channel=autonomous_queue)"
     Gauge;
+  (* [kind] is bound by [Bookkeeping_failure_kind.t]; [op] is free-form
+     dynamic context (e.g. ["drop_holder <label>"]) needed to
+     disambiguate which bookkeeping callback failed. *)
   add
     Keeper_metrics.metric_keeper_turn_slot_bookkeeping_failures
     "Total keeper turn-slot release bookkeeping callbacks that could not complete while \


### PR DESCRIPTION
## Summary

`metric_keeper_turn_slot_bookkeeping_failures` `kind` label
collapsed into closed sum `Bookkeeping_failure_kind.t`.  Found by
auditing `prometheus.ml` `add()` description strings for
`labels=a|b|c` enumeration admissions (pattern surfaced after #14773).

## Why

The metric registration in `prometheus.ml` already enumerated the
closed set:

> "labels: op, **kind=cancelled|exception**"

i.e. the author had closed-set awareness but the type system was
bypassed.  Same workaround #2 pattern earlier sweep iterations closed
for many other metrics (#14704, #14755, #14760, #14768, #14773).

## Sites (4)

| File:Line | Variant |
|-----------|---------|
| `keeper_turn_slot.ml:670` | `Cancelled` (safe_bookkeeping cancellation path) |
| `keeper_turn_slot.ml:673` | `Exception` (safe_bookkeeping exception path) |
| `keeper_turn_slot.ml:698` | `Cancelled` (drop_holder cancellation path) |
| `keeper_turn_slot.ml:704` | `Exception` (drop_holder exception path) |

## Approach

`observe_bookkeeping_failure ~op:string ~kind:string` →
`~kind:Bookkeeping_failure_kind.t`.  4 callers updated.  Wire format
byte-equal.

`op` label intentionally stays free-form because it carries dynamic
context (e.g. `"drop_holder <label>"`) needed to disambiguate which
bookkeeping callback failed.

## Test plan

- [ ] CI green
- [ ] `rg '~kind:"(cancelled|exception)"' lib/keeper/` = 0

RFC-WAIVED: not in credential/identity/operator/sandbox/hooks/workflow scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)