### PR TITLE
fix(mode_enforcer): make effective_class tool_effect_class match exhaustive

### DIFF
--- a/lib/cdal_runtime/mode_enforcer.ml
+++ b/lib/cdal_runtime/mode_enforcer.ml
@@ -246,9 +246,16 @@ let classify_bash_tool input =
 ;;
 
 let effective_class tool_name input =
+  (* Enumerate every [tool_effect_class] variant so the compiler flags
+     any new constructor here. The previous [c -> c] catch-all was
+     identity passthrough, which is the right call for the three
+     statically-classifiable variants today — but a future variant
+     that should be refined from [input] (e.g. a [Network_dynamic]
+     mirroring [Shell_dynamic]) would silently inherit the static
+     classification with no review point. *)
   match classify_tool tool_name with
   | Shell_dynamic -> classify_bash_tool input
-  | c -> c
+  | (Read_only | Local_mutation | External_effect) as c -> c
 ;;
 
 let tool_effect_class_of_string = function


### PR DESCRIPTION
## Why

`Mode_enforcer.effective_class` refines `Shell_dynamic` via `classify_bash_tool input` and passes the other three `tool_effect_class` variants through unchanged:

\`\`\`ocaml
let effective_class tool_name input =
  match classify_tool tool_name with
  | Shell_dynamic -> classify_bash_tool input
  | c -> c
\`\`\`

`tool_effect_class` has 4 constructors today: `Read_only | Local_mutation | External_effect | Shell_dynamic`. The `| c -> c` catch-all is identity-passthrough for the three non-Shell variants — which is the right call today, but the compiler stays silent if a future variant should *also* be input-refined.

A hypothetical `Network_dynamic` constructor (parallel to `Shell_dynamic` but for outbound HTTP/socket tools) would inherit the static classification silently. No review point, no test failure, just a quiet capability gap. Same FSM Sparse Match anti-pattern as:

- OAS PR #1522 (`reserve_strategy_budget` on `Context_reducer.strategy`)
- masc-mcp PR #14716 / #14762 (boolean guard predicates over closed sums)

## What

\`\`\`ocaml
| Shell_dynamic -> classify_bash_tool input
| (Read_only | Local_mutation | External_effect) as c -> c
\`\`\`

Behavior unchanged for the current 4 variants. Adding a 5th constructor to `tool_effect_class` will now trigger `Warning 8: this pattern-matching is not exhaustive` at this call site, forcing the maintainer to deliberately decide whether the new class needs per-input refinement.

A short comment explains *why* the identity passthrough was the wrong default direction (input-refinement might be needed for new variants) so a future reader doesn't reintroduce the catch-all.

## Verification

\`\`\`
dune build @lib/cdal_runtime/check --root .   # exit 0
\`\`\`

## Scope

Surgical. One function, one file, no behavior change. No `.mli` change.

## Sweep observation

This is the only short-form `| c -> c` identity passthrough on a closed sum in `masc-mcp/lib/`. A grep for `\| [a-z] -> [a-z]$` returned only this site. Longer-named identity passthroughs (`| other -> other`) elsewhere are on `Yojson.Safe.t` (open polymorphic) or `Option.t` (already 2-case exhaustive) — structurally justified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)