### PR TITLE
perf(benchmark_scoring): O(C+R) replaces O(C×R) in required/forbidden tool checks

### DIFF
--- a/lib/tool_call_quality_benchmark_scoring.ml
+++ b/lib/tool_call_quality_benchmark_scoring.ml
@@ -97,6 +97,19 @@ let evaluate_json_check ~(target : Yojson.Safe.t option) (check : json_check) =
 let tool_used tool_name (run : evidence_run) =
   List.exists (fun call -> String.equal call.tool_name tool_name) run.tool_calls
 
+(* Build a name-keyed set over [run.tool_calls] in one pass.  Used by
+   [required_tool_score] and [forbidden_tool_used] to replace
+   O(R × C) repeated linear scans with O(C + R) build + lookup. *)
+let tool_call_name_set (run : evidence_run) =
+  let tbl = Hashtbl.create (List.length run.tool_calls) in
+  List.iter (fun call -> Hashtbl.replace tbl call.tool_name ()) run.tool_calls;
+  tbl
+
+let name_set_of_list names =
+  let tbl = Hashtbl.create (List.length names) in
+  List.iter (fun name -> Hashtbl.replace tbl name ()) names;
+  tbl
+
 let arg_check_passes (run : evidence_run) (check : arg_check) =
   let predicate call =
     String.equal call.tool_name check.tool_name
@@ -121,16 +134,23 @@ let required_tool_score (benchmark_case : benchmark_case) (run : evidence_run) =
       (match benchmark_case.required_tools with
        | [] -> 1.0
        | required_tools ->
+           (* Build the run's tool-name set once; replaces R × O(C) scans
+              with O(C) build + R × O(1) lookups. *)
+           let used = tool_call_name_set run in
            required_tools
            |> List.map (fun tool_name ->
-                  if tool_used tool_name run then 1.0 else 0.0)
+                  if Hashtbl.mem used tool_name then 1.0 else 0.0)
            |> avg_float)
 
 let forbidden_tool_used (benchmark_case : benchmark_case) (run : evidence_run) =
   match benchmark_case.category with
   | Tool_forbidden -> Stdlib.List.length run.tool_calls > 0
   | _ ->
-      List.exists (fun tool_name -> tool_used tool_name run) benchmark_case.forbidden_tools
+      (* Same shape as [required_tool_score]: one O(C) build, F lookups. *)
+      let used = tool_call_name_set run in
+      List.exists
+        (fun tool_name -> Hashtbl.mem used tool_name)
+        benchmark_case.forbidden_tools
 
 let task_pass_score (benchmark_case : benchmark_case) (run : evidence_run) =
   let reported = Option.value ~default:false run.task_success in
@@ -182,9 +202,14 @@ let unnecessary_tool_rate (benchmark_case : benchmark_case) (run : evidence_run)
     match benchmark_case.category with
     | Tool_forbidden -> 1.0
     | _ ->
+        (* Iteration is reversed here vs [forbidden_tool_used]: we scan
+           run.tool_calls and check each name against forbidden_tools,
+           so build the set from forbidden_tools (F entries) and let
+           the scan be C × O(1). *)
+        let forbidden_set = name_set_of_list benchmark_case.forbidden_tools in
         let forbidden_count =
           run.tool_calls
-          |> List.filter (fun call -> List.mem call.tool_name benchmark_case.forbidden_tools)
+          |> List.filter (fun call -> Hashtbl.mem forbidden_set call.tool_name)
           |> List.length
         in
         let over_limit = max 0 (call_count - benchmark_case.max_tool_calls) in


### PR DESCRIPTION
## Summary

Three scoring helpers in \`lib/tool_call_quality_benchmark_scoring.ml\` had compounding O(N×M) shapes per scored benchmark case:

| Helper | Pattern | Cost |
|--------|---------|------|
| \`required_tool_score\` | for each required_tool, \`tool_used\` scans \`run.tool_calls\` | O(R × C) |
| \`forbidden_tool_used\` | for each forbidden_tool, \`tool_used\` scans \`run.tool_calls\` | O(F × C) |
| \`unnecessary_tool_rate\` | for each tool_call, \`List.mem call.tool_name forbidden_tools\` | O(C × F) |

With C~100 tool calls and R/F~5-10, that's **~3000 string compares per scored case**, across thousands of cases per benchmark run.

## Fix

Two thin Hashtbl builders, applied differently based on iteration direction:

\`\`\`ocaml
let tool_call_name_set (run : evidence_run) =
  let tbl = Hashtbl.create (List.length run.tool_calls) in
  List.iter (fun call -> Hashtbl.replace tbl call.tool_name ()) run.tool_calls;
  tbl

let name_set_of_list names =
  let tbl = Hashtbl.create (List.length names) in
  List.iter (fun name -> Hashtbl.replace tbl name ()) names;
  tbl
\`\`\`

- \`required_tool_score\` / \`forbidden_tool_used\`: iteration is *"for each required/forbidden name, is it in the run?"* → build the set from **run.tool_calls**.
- \`unnecessary_tool_rate\`: iteration is reversed *"for each tool_call, is its name in forbidden?"* → build the set from **forbidden_tools**.

**General rule applied**: build the set from whichever side hosts the membership lookup, not whichever side is being iterated. Recognizing this asymmetry is what determines which Hashtbl to materialize.

## Compounding with prior loop PRs

Continues the per-call cost-shedding established in:
- #14728/#14734/#14740/#14749 (auth + catalog hot path)
- #14756/#14763 (help registry + dispatch profile)
- #14769/#14774 (typed permission match + schema required-set)

Benchmark scoring isn't on the auth dispatch hot path, but score_run runs across thousands of benchmark cases per evaluation pass — same N×M shape, different domain.

## Semantic preservation

All three helpers preserve their existing semantics:
- \`Hashtbl.mem set name\` ↔ \`List.mem name list\` on the same name set
- Build order doesn't matter for membership (no ordering invariant)
- Empty lists still yield empty sets → still produce 0 matches

\`tool_used\` is kept as a public helper since other code in this module may still use it (single-name shortcut).

## Test plan

- [ ] CI lib/ build green
- [ ] \`dune runtest test/test_tool_call_quality_benchmark*.exe\` passes
- [ ] Smoke: score_run output equals pre-PR output on a sample evidence_run

🤖 Generated with [Claude Code](https://claude.com/claude-code)