### PR TITLE
spec(kcr): remove PerKeeperIsolation == TRUE placeholder — RFC-C-2.c

### DIFF
--- a/specs/INDEX.md
+++ b/specs/INDEX.md
@@ -5,7 +5,7 @@ Edit the generator, not this file. Re-run: scripts/gen-tla-index.sh > specs/INDE
 
 # TLA+ Spec Index
 
-Generated: 2026-05-11T17:07:36Z (HEAD: ea85e0219)
+Generated: 2026-05-11T19:36:25Z (HEAD: 1e673193a)
 
 Source of truth: `specs/`. Run `scripts/gen-tla-index.sh > specs/INDEX.md` to refresh.
 
@@ -121,7 +121,7 @@ Source of truth: `specs/`. Run `scripts/gen-tla-index.sh > specs/INDEX.md` to re
 | KeeperApprovalQueue.tla | KeeperApprovalQueue | manual | 2 | 1 | clean={inv:TypeOK, inv:SafetyInvariant} buggy={inv:TypeOK, inv:SafetyInvariant} | a18102f83db7 |
 | KeeperCascadeAttemptFSM.tla | KeeperCascadeAttemptFSM | manual | 2 | 1 | clean={inv:SafetyInvariant} buggy={inv:SafetyInvariant} | b81b3dc6da48 |
 | KeeperCascadeLifecycle.tla | KeeperCascadeLifecycle | manual | 2 | 1 | clean={inv:Safety, prop:TryingEventuallyTerminates, prop:FinalizingEventuallyClears} buggy={inv:CascadeSelectionRequiresMeasurement} | e305638eb658 |
-| KeeperCascadeRouting.tla | KeeperCascadeRouting | manual | 2 | 1 | clean={inv:TypeOK, inv:KeeperNeverBlockedByCascade, inv:TurnProceedsIfHealthyItemExists, inv:NoGroupCycle, inv:HealthStateConsistent, inv:FallbackCountBounded, inv:SelectedItemInPath} buggy={inv:TypeOK, inv:KeeperNeverBlockedByCascade, inv:TurnProceedsIfHealthyItemExists, inv:NoGroupCycle, inv:HealthStateConsistent, inv:FallbackCountBounded, inv:SelectedItemInPath} | 68a975c42500 |
+| KeeperCascadeRouting.tla | KeeperCascadeRouting | manual | 2 | 1 | clean={inv:TypeOK, inv:KeeperNeverBlockedByCascade, inv:TurnProceedsIfHealthyItemExists, inv:NoGroupCycle, inv:HealthStateConsistent, inv:FallbackCountBounded, inv:SelectedItemInPath} buggy={inv:TypeOK, inv:KeeperNeverBlockedByCascade, inv:TurnProceedsIfHealthyItemExists, inv:NoGroupCycle, inv:HealthStateConsistent, inv:FallbackCountBounded, inv:SelectedItemInPath} | b2bdc9d76d73 |
 | KeeperCircuitBreaker.tla | KeeperCircuitBreaker | manual | 2 | 1 | clean={inv:SafetyInvariant} buggy={inv:TripOnlyWithStreak} | 1d4d87f2bb68 |
 | KeeperCompactionLifecycle.tla | KeeperCompactionLifecycle | manual | 2 | 1 | clean={inv:Safety, prop:OverflowEventuallyLeavesOverflow, prop:CompactingEventuallyStops} buggy={inv:CompactingAlignsAll} | ae32b2f6ae60 |
 | KeeperCompositeLifecycle.tla | KeeperCompositeLifecycle | manual | 5 | 4 | clean={inv:SafetyInvariant, prop:EventualMeasurementResolves, prop:RecoveryEventuallyCompletes, prop:OverflowedEventuallyResolves} buggy-attempt={inv:ToolSurfaceFeedsAttempt} buggy-cascade={inv:NoCascadeBeforeMeasurement} buggy-compaction={inv:CompactionAtomicity, inv:PhaseTurnAlignment} buggy-post-turn={inv:PostTurnConsumesAttempt} | 36530914cd50 |

--- a/specs/keeper-state-machine/KeeperCascadeRouting.tla
+++ b/specs/keeper-state-machine/KeeperCascadeRouting.tla
@@ -265,10 +265,31 @@ SelectedItemInPath ==
         selected_item[keeper] /= "none"
         => ItemGroup[selected_item[keeper]] \in Range(group_path[keeper])
 
-(* I7: Per-keeper isolation — one keeper's item health does not
-   directly affect another keeper's state.  This is structural:
-   all health updates are keyed by (keeper, item) pair. *)
-PerKeeperIsolation == TRUE  (* Structural invariant: enforced by variable typing *)
+(* I7: Per-keeper isolation — partial truth.
+   --------------------------------------------------------------
+   In this spec, [item_health] and [consecutive_failures] are keyed by
+   <<keeper, item>>, so one keeper's failure history on item i does not
+   poison another keeper's view of the same item.  At this layer the
+   isolation property *is* structural: TLC cannot construct a transition
+   that violates it because the variable typing forbids it.
+
+   Production reality (lib/cascade/cascade_health_tracker.ml) is more
+   nuanced: that module tracks a separate axis of "cooldown" state keyed
+   by [provider_key] rather than <<keeper, item>>, so two keepers using
+   the same provider share the cooldown state.  This is a deliberate
+   design choice in production (one provider's transient 429 should
+   affect everyone), not a bug.  But it means a strict literal reading
+   of "per-keeper isolation" as a project-wide invariant would be false.
+
+   Removed the `PerKeeperIsolation == TRUE` placeholder that previously
+   sat here.  A trivially-true definition is misleading because it
+   suggests an invariant strong enough to enforce keeper-vs-keeper
+   isolation across all axes — including production's cooldown axis —
+   when in fact this spec deliberately abstracts cooldown away.
+
+   See: docs/tla-audit/kcr-c2-health-state-representation-gap-2026-05-12.md
+   for the full audit and RFC-C-2 candidates.
+   -------------------------------------------------------------- *)
 
 Safety ==
     /\ TypeOK


### PR DESCRIPTION
## Finding (Iteration 24, Phase R-C-2.c — spec lie removal)

**Spec**: `specs/keeper-state-machine/KeeperCascadeRouting.tla:268-271`
**OCaml**: 영향 0 — spec doc 변경만
**Aspect**: iter 23 audit가 식별한 *spec lie*를 정직한 documentation으로 교체. `PerKeeperIsolation == TRUE` placeholder는 cfg에도 Safety conjunction에도 없는 dead definition — TLC가 검증하지 않으면서 *해당 invariant이 enforced된다는 인상*만 남기는 misleading 정의.
**Risk**: LOW — TLC behavior 변경 0 (placeholder가 unused). Documentation enhancement only.
**Type**: Spec-only, +25/-4 LOC.

## Audit chain (iter 23 → 24)

```mermaid
graph LR
    iter23[iter 23 PR #14777<br/>KCR C-2 audit<br/>finds 4 gap surfaces] --> 분기[3 RFC 후보]
    분기 --> A[R-C-2.a OCaml Degraded variant MID]
    분기 --> B[R-C-2.b SoftRateLimit spec action MID + TLC]
    분기 --> C[**R-C-2.c THIS PR**<br/>spec lie 제거 LOW doc-only]
    style C fill:#94e2a3
```

## What was wrong

`KeeperCascadeRouting.tla:271`:
```tla
PerKeeperIsolation == TRUE  (* Structural invariant: enforced by variable typing *)
```

문제:
- `KeeperCascadeRouting.cfg`에 `INVARIANT PerKeeperIsolation` 없음 — TLC는 이 property를 검증하지 않음.
- `Safety == ...` conjunction에 포함되지 않음 — Safety conjunction 검사 시에도 무시됨.
- `rg PerKeeperIsolation specs/` 결과 단일 line — *어디서도 참조 안 됨*.
- 하지만 *정의가 존재*해서 spec reader에게 "이 invariant이 존재하고 enforced되어 있다"는 잘못된 인상.

게다가 *실제로* keeper 간 isolation은 *부분적으로만* 사실:
- ✅ Spec layer: `item_health[<<keeper, item>>]`, `consecutive_failures[<<keeper, item>>]`은 keeper 별로 분리.
- ❌ Production layer: `lib/cascade/cascade_health_tracker.ml`은 `provider_key`로 cooldown 키 공유 — 두 keeper가 같은 provider 사용 시 cooldown state 공유 (의도적 설계).

`PerKeeperIsolation == TRUE` placeholder가 이 nuance를 가림.

## Before / After

### Before
```tla
(* I7: Per-keeper isolation — one keeper's item health does not
   directly affect another keeper's state.  This is structural:
   all health updates are keyed by (keeper, item) pair. *)
PerKeeperIsolation == TRUE  (* Structural invariant: enforced by variable typing *)
```

### After (excerpt)
```tla
(* I7: Per-keeper isolation — partial truth.
   --------------------------------------------------------------
   In this spec, [item_health] and [consecutive_failures] are keyed by
   <<keeper, item>>, so one keeper's failure history on item i does not
   poison another keeper's view of the same item.  At this layer the
   isolation property *is* structural...

   Production reality (lib/cascade/cascade_health_tracker.ml) is more
   nuanced: that module tracks a separate axis of "cooldown" state keyed
   by [provider_key] rather than <<keeper, item>>, so two keepers using
   the same provider share the cooldown state...

   Removed the `PerKeeperIsolation == TRUE` placeholder that previously
   sat here.  A trivially-true definition is misleading...
   -------------------------------------------------------------- *)
```

## 왜 톱니처럼 정교하지 않은가 (이번 PR이 닫은 결함)

Spec hygiene 결함: *vacuous tautology가 invariant인 척*. Spec reader가 `PerKeeperIsolation` 정의를 보고 "OK, structural invariant enforced"로 해석. 실제로는:
1. Vacuous (== TRUE)
2. Unused (어디서도 reference 안 됨)
3. Misleading (production에서 part-true)

이런 dead-but-misleading 정의는 *spec maturity의 noise*. 본 PR이 honest documentation으로 교체해 reader misleading 차단. spec maintenance 비용도 감소 (mental load 줄어듦).

## TLC impact

**Zero**. 검증된 변경:
- `rg INVARIANT specs/keeper-state-machine/KeeperCascadeRouting.cfg`에 `PerKeeperIsolation` 없음.
- `Safety == /\ TypeOK /\ KeeperNeverBlockedByCascade /\ ... /\ SelectedItemInPath` (line 273-280) — PerKeeperIsolation 미포함.
- Tla 파일 cfg가 변경 안 됨, INVARIANT directives 동일.

`tla-scheduled.yml` (시간당 main HEAD 검증) 다음 발화에서 cleanly pass 예상.

## 본 PR 수정

| 변경 | 위치 |
|---|---|
| Dead `PerKeeperIsolation == TRUE` 제거 + honest documentation block | `specs/keeper-state-machine/KeeperCascadeRouting.tla:268-291` |

## Verification

- [x] `rg PerKeeperIsolation specs/` — only the new comment mention.
- [x] Spec parses identically (cfg / Safety / INVARIANT 모두 unchanged).
- [x] OCaml 영향 0 (lib/ 변경 없음).
- [ ] TLC scheduled re-verify: `tla-scheduled.yml` 다음 hourly 실행.

## Trade-off

- **R-C-2.a / R-C-2.b 미수행**: OCaml Degraded variant + spec SoftRateLimit action은 별도 PR. 본 PR은 lying 제거만.
- **추가 sub-aspects 미수행**: KCR `MaxConsecutive` ↔ cascade_health_tracker `threshold` 동기화도 같은 패턴 후보 — 별도 audit.

## RFC 참조

- R-C-2.c (iter 23 KCR C-2 audit memo, PR #14777) — 본 PR이 즉시 진행.
- `RFC-WAIVED`: spec doc-only change, 코드 영향 없음. credential / identity / operator-control / sandbox / hooks 범위 밖.

## 진행 추적

다음 iteration 시작점: **C-3** (fallback chain traversal — `try_group` 재귀 vs spec GroupFallback semantics) OR **R-B-1.a** (TurnPhaseSet 확장) OR **R-C-1.b** (KCR MaxFallbacks spec relaxation).

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
