### PR TITLE
docs(tla-audit): KeeperCoreTriad C-3 — Terminal cascade contract gap

### DIFF
--- a/docs/tla-audit/kct-c3-terminal-cascade-contract-gap-2026-05-12.md
+++ b/docs/tla-audit/kct-c3-terminal-cascade-contract-gap-2026-05-12.md
@@ -1,0 +1,125 @@
+# KeeperCoreTriad C-3 Audit — Terminal Cascade Contract Gap
+
+**Iteration**: 25 (/loop FSM/TLA+/OCaml drift hunt)
+**Date**: 2026-05-12
+**Spec**: `specs/keeper-state-machine/KeeperCoreTriad.tla` §S1 NoTerminalCascade (line 361-363)
+**OCaml**: `lib/keeper/keeper_cascade_routing.ml:32-34` (`select_cascade` for terminal phases)
+**Risk**: LOW — silent contract gap, currently *not exercised* because terminal keepers don't drive turn dispatch.  Would surface if a code path invoked `select_cascade` on a phase that the spec considers terminal but doesn't gate the call site.
+**Type**: Audit-only (no code change in this PR).
+
+## File-naming clarification (plan correction)
+
+The plan's Phase C-3 sub-aspect is described as "Fallback chain traversal
+↔ `keeper_cascade_routing.ml`".  Reading the file reveals:
+**`keeper_cascade_routing.ml` does NOT implement fallback chain
+traversal** — that lives in `keeper_cascade_selector.ml:try_group`
+(already audited in C-1 #14776).  `keeper_cascade_routing.ml`
+implements *phase-aware cascade selection* and mirrors
+`KeeperCoreTriad.tla`'s `SelectCascade` action, not
+`KeeperCascadeRouting.tla`'s `ItemDegrade` / `GroupFallback`.
+
+So the true content of "C-3" is a different audit: how
+`select_cascade` honors `KeeperCoreTriad.SafetyInvariant` (S1-S5).
+This memo covers S1 (NoTerminalCascade) — the others are independent
+follow-ups.
+
+## TLA+ S1 contract
+
+```tla
+(* Spec phase set, line 106: *)
+Phases == {"Running", "Failing", "Overflowed", "Compacting",
+           "HandingOff", "Draining", "Terminal"}
+
+(* Spec mapping comment, line 102: *)
+\*   "Terminal"    ↔ Offline | Paused | Stopped | Crashed | Restarting | Dead
+
+(* S1 invariant, line 361-363: *)
+NoTerminalCascade ==
+    phase = "Terminal" => effective_cascade = "none"
+```
+
+The spec collapses 6 KSM phases into a single abstract `"Terminal"`
+and requires that the effective cascade for those phases is `"none"`.
+
+## OCaml behavior
+
+```ocaml
+(* lib/keeper/keeper_cascade_routing.ml:32-34 *)
+| Offline | Stopped | Dead | Zombie | Crashed | Restarting ->
+    { effective_cascade = base_cascade;
+      reason = "non-turn phase (blocked upstream)" }
+```
+
+For *all six* KSM phases the spec calls "Terminal", OCaml returns
+`base_cascade` — a real cascade name, not `"none"`.  The reason
+string admits this is a non-turn phase ("blocked upstream") but the
+*return value* still carries the base cascade.
+
+Note: `Paused` is also in the spec's "Terminal" abstraction but in
+OCaml's switch it falls under `Draining | Paused -> base_cascade`
+(line 29-31) with a *different* reason ("winding down: complete
+in-progress work").  Same end value, different intent.  `Zombie` is
+extra — present in OCaml but not mentioned in spec line 102's
+mapping comment.
+
+## Why this is technically a contract violation
+
+`KeeperCoreTriad.SafetyInvariant` lists `NoTerminalCascade` as a
+required property.  If OCaml passed the result of
+`select_cascade phase=Stopped` to any production code that asserts
+S1 (e.g. "if phase = Terminal then effective_cascade must = none"),
+the assertion would fail.
+
+## Why production stays correct (today)
+
+The two production callers don't exercise this contract violation:
+
+1. `lib/keeper/keeper_unified_turn.ml:411` — invoked from the turn
+   execution path.  Turn execution is upstream-gated by the keeper
+   FSM: a Dead/Stopped/Zombie keeper doesn't enter turn cycle at all.
+   So `select_cascade` is effectively only called for Running/Failing/
+   buffer-op phases.
+2. `lib/server/server_dashboard_http_keeper_api.ml:1423` — dashboard
+   render path.  Read-only; no S1 assertion downstream.
+
+The `base_cascade` return for terminal phases is *unreachable in
+production*, making this a paper contract gap rather than a runtime
+bug.
+
+## Three RFC candidates
+
+| ID | Direction | Risk |
+|---|---|---|
+| R-C-3.a | OCaml — return `Result.t` (or option) from `select_cascade`, with `Error/None` for terminal phases.  Forces callers to handle the case explicitly.  Honors S1 at the type level. | MID (signature change) |
+| R-C-3.b | OCaml — return an "effective_cascade = `none`" sentinel string for terminal phases.  Caller responsibility unchanged but value matches spec.  Less type-safe than R-C-3.a but minimal disruption. | LOW (single-file change) |
+| R-C-3.c | Spec — relax `NoTerminalCascade` to acknowledge that callers are gated upstream; document that the spec's `"none"` is an abstraction over "OCaml caller never asks for terminal-phase cascade".  Add the gating predicate as a separate invariant on the *call graph*, not the function return. | LOW (spec docs only) |
+
+R-C-3.b is the cheapest production-side honoring of S1 (a single arm
+edit + update comment).  R-C-3.a is structurally cleaner but
+cascades through 2 callers + tests.  R-C-3.c documents reality.
+
+## Adjacent observation — `Zombie` not in spec mapping
+
+Spec line 102's terminal-mapping comment lists *6 KSM phases* but
+omits `Zombie`.  OCaml `Zombie` falls through to `base_cascade`
+with the "non-turn phase" reason.  The omission may be a doc lag
+(spec written before Zombie was added) or a deliberate signal that
+Zombie has different semantics than Stopped/Dead.  Worth verifying
+on next KCT audit pass.
+
+## Out-of-scope for this iteration
+
+- S2-S5 cross-checks (FailingUsesRecovery, BufferOpsUseLocalOnly,
+  CapabilityGateHolds, SideEffectContainment, PhaseDecisionConsistency).
+  Each is a separate audit slice and deserves its own focused PR.
+- Plan-level fix: the project plan's C-3 description references the
+  wrong file.  Update at plan-revision time.
+
+## References
+
+- KCT spec §361-363 (NoTerminalCascade), §102 (phase mapping), §106 (Phases set).
+- `lib/keeper/keeper_cascade_routing.ml:32-34`.
+- Callers: `lib/keeper/keeper_unified_turn.ml:411`,
+  `lib/server/server_dashboard_http_keeper_api.ml:1423`.
+- C-1 audit (`kcr-c1-fallback-cap-mechanism-gap-2026-05-12.md`) — different domain (KCR.tla, not KCT.tla).
+- KSM A-1 (`ksm-init-mapping-2026-05-12.md`) — same shape "spec contract vs OCaml return value".


### PR DESCRIPTION
## Finding (Iteration 25, Phase C-3 — KCT entry + plan correction)

**Spec**: `specs/keeper-state-machine/KeeperCoreTriad.tla` §S1 NoTerminalCascade
**OCaml**: `lib/keeper/keeper_cascade_routing.ml:32-34`
**Aspect**: 두 가지 발견 (1) Plan-level: C-3가 잘못된 파일 인용 — `routing.ml`은 fallback chain 아니고 phase-aware cascade selection. (2) Spec contract gap: §S1은 terminal → "none" 요구, OCaml은 terminal → base_cascade 반환.
**Risk**: LOW — paper contract violation, production callers는 upstream-gated (terminal keeper는 turn cycle 진입 안 함).
**Type**: Audit-only, 코드 변경 0, 3 RFC 후보 도출.

## Plan correction (file misattribution)

Project plan의 Phase C-3:
> "C-3: Fallback chain traversal ↔ `keeper_cascade_routing.ml`"

직접 검토 결과 **mismatch**:
- `keeper_cascade_routing.ml` = phase-aware cascade SELECTION (KCT.SelectCascade 대응)
- Fallback chain traversal = `keeper_cascade_selector.ml:try_group` (C-1 #14776에서 이미 다룸)

따라서 본 audit은 plan의 C-3 *true content*에 해당: KCT SafetyInvariant S1 verification. 다음 plan revision 시 file 인용 수정 필요.

## TLA+ S1 contract

```tla
Phases == {"Running", "Failing", "Overflowed", "Compacting",
           "HandingOff", "Draining", "Terminal"}

\*   "Terminal"    ↔ Offline | Paused | Stopped | Crashed | Restarting | Dead

NoTerminalCascade ==
    phase = "Terminal" => effective_cascade = "none"
```

## OCaml behavior

```ocaml
(* line 32-34 *)
| Offline | Stopped | Dead | Zombie | Crashed | Restarting ->
    { effective_cascade = base_cascade;
      reason = "non-turn phase (blocked upstream)" }
```

**6/6 spec-terminal phases**가 OCaml에서 `base_cascade` 반환 — `"none"`이 아님. 추가: `Zombie`는 spec mapping comment에 누락됨 (doc lag 추정).

## 왜 톱니처럼 정교하지 않은가 (paper contract gap)

- TLA+ `select_cascade(Stopped) = base_cascade` 결과를 받아 S1 assertion하면 spec invariant violation.
- 그러나 production callers (2곳)이 *call-graph-level*로 gating:
  1. `keeper_unified_turn.ml:411` — turn execution, terminal keeper는 진입 안 함.
  2. `server_dashboard_http_keeper_api.ml:1423` — read-only dashboard.
- 따라서 unreachable in production. *Paper* contract violation, not *runtime* bug.

이건 contract가 *function boundary*에 있지 않고 *call graph*에 있음을 의미. 미래 contributor가 새 caller 추가하면 silent S1 violation 가능. 타입 시스템으로 차단 안 됨.

## 3 RFC 후보

| ID | 방향 | Risk |
|---|---|---|
| **R-C-3.a** | OCaml `select_cascade` returns `(routing_decision, _) result` or option, terminal → Error/None | MID (signature + 2 callers + tests) |
| **R-C-3.b** | OCaml returns sentinel `"none"` for terminal phases, matches spec value | LOW (single-file arm edit) |
| **R-C-3.c** | Spec relax `NoTerminalCascade` to document call-graph gating reality | LOW (spec docs only) |

R-C-3.b 가장 cheap; R-C-3.a 가장 strict; R-C-3.c R-C-2.c와 동일 *spec honest* 패턴.

## 본 PR 내용

- `docs/tla-audit/kct-c3-terminal-cascade-contract-gap-2026-05-12.md` (+125 LOC): 위 분석 + plan correction + 3 RFC 후보.

## Adjacent insight — `Zombie` doc lag

Spec line 102 phase mapping comment에 `Zombie` 누락. OCaml `Zombie`은 `base_cascade` 반환 (다른 terminal과 동일). doc lag로 추정 — 다음 KCT audit pass에서 verify.

## Verification

- [x] OCaml line 32-34 직접 검토.
- [x] Spec §S1 + §102 phase mapping + §106 Phases 직접 검토.
- [x] Production callers 2곳 (`grep -rn "select_cascade"`) 확인.

## Trade-off / 후속 PR

- **S2-S5 cross-checks 미수행**: FailingUsesRecovery (S2), BufferOpsUseLocalOnly (S3?), CapabilityGateHolds (S4), SideEffectContainment, PhaseDecisionConsistency (S5) 각각 별도 audit slice.
- **Plan-level file 인용 수정**: 다음 plan revision 시.

## RFC 참조

- C-3 (plan Phase C 세번째 항목 — true content는 KCT 검증).
- C-1 (#14776) — *KCR*.tla audit, 다른 spec.
- KSM A-1 (`#14694`) — 같은 "spec contract vs OCaml return value" 패턴.
- R-C-2.c (#14782) — *spec docs honest replacement* 패턴 reference, R-C-3.c와 동일 형태.
- `RFC-WAIVED`: docs-only audit. credential / identity / operator-control / sandbox / hooks 범위 밖.

## 진행 추적

다음 iteration 시작점: **R-C-3.b** (`"none"` sentinel return for terminal, LOW single-file) OR **S2 FailingUsesRecovery audit** (자매 sub-aspect) OR **R-B-1.a** (TurnPhaseSet 확장).

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
