### PR TITLE
feat(telemetry): two mini wire-format locks (atomic_orphan_size_class + silent_dashboard_actor_outcome)

### DIFF
--- a/lib/server/atomic_orphan_size_class.ml
+++ b/lib/server/atomic_orphan_size_class.ml
@@ -1,0 +1,8 @@
+type t =
+  | Empty
+  | With_data
+
+let to_label = function
+  | Empty -> "empty"
+  | With_data -> "with_data"
+;;

--- a/lib/server/atomic_orphan_size_class.mli
+++ b/lib/server/atomic_orphan_size_class.mli
@@ -1,0 +1,13 @@
+(** Atomic_orphan_size_class — closed sum for the [size_class] label on
+    [metric_fs_atomic_orphans_cleaned].
+
+    Replaces 2 hardcoded literals (`"empty"` / `"with_data"`) in
+    [server_runtime_bootstrap.ml].  The two values disambiguate
+    save_file_atomic orphan cleanups by whether the orphan contained
+    recoverable data (#10130 recovery). *)
+
+type t =
+  | Empty (** Orphaned atomic save file with no content (safe to delete). *)
+  | With_data (** Orphaned file held content; preserved under .recovered/. *)
+
+val to_label : t -> string

--- a/lib/server/server_auth.ml
+++ b/lib/server/server_auth.ml
@@ -302,7 +302,7 @@ let dashboard_actor_for_request ~base_path request =
             token_hash_prefix;
           Prometheus.inc_counter
             Prometheus.metric_silent_dashboard_actor_fallback
-            ~labels:[ ("outcome", "none") ]
+            ~labels:[ ("outcome", Silent_dashboard_actor_outcome.(to_label None_resolved)) ]
             ();
           request_actor_hint request
       | Error err ->
@@ -344,7 +344,7 @@ let dashboard_actor_for_request ~base_path request =
             token_hash_prefix err_kind hint err_str extra_hint;
           Prometheus.inc_counter
             Prometheus.metric_silent_dashboard_actor_fallback
-            ~labels:[ ("outcome", "error"); ("err_kind", err_kind) ]
+            ~labels:[ ("outcome", Silent_dashboard_actor_outcome.(to_label Error_classified)); ("err_kind", err_kind) ]
             ();
           request_actor_hint request)
   | None -> request_actor_hint request

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -1585,13 +1585,13 @@ let run ~sw ~env ~host ~port ~base_path ~make_routes ~make_request_handler
           if deleted > 0 then
             Prometheus.inc_counter
               Prometheus.metric_fs_atomic_orphans_cleaned
-              ~labels:[ ("size_class", "empty") ]
+              ~labels:[ ("size_class", Atomic_orphan_size_class.(to_label Empty)) ]
               ~delta:(float_of_int deleted)
               ();
           if preserved > 0 then
             Prometheus.inc_counter
               Prometheus.metric_fs_atomic_orphans_cleaned
-              ~labels:[ ("size_class", "with_data") ]
+              ~labels:[ ("size_class", Atomic_orphan_size_class.(to_label With_data)) ]
               ~delta:(float_of_int preserved)
               ();
           if deleted + preserved > 0 then

--- a/lib/server/silent_dashboard_actor_outcome.ml
+++ b/lib/server/silent_dashboard_actor_outcome.ml
@@ -1,0 +1,8 @@
+type t =
+  | None_resolved
+  | Error_classified
+
+let to_label = function
+  | None_resolved -> "none"
+  | Error_classified -> "error"
+;;

--- a/lib/server/silent_dashboard_actor_outcome.mli
+++ b/lib/server/silent_dashboard_actor_outcome.mli
@@ -1,0 +1,16 @@
+(** Silent_dashboard_actor_outcome — closed sum for the [outcome] label
+    on [metric_silent_dashboard_actor_fallback].
+
+    Replaces 2 hardcoded literals (`"none"` / `"error"`) in
+    [server_auth.ml].  The [error] arm is paired with the typed
+    [Auth_error_kind] enum in an adjacent label ([err_kind]); this
+    closes the remaining hardcoded string. *)
+
+type t =
+  | None_resolved (** Bearer token resolved to no agent (token unknown). *)
+  | Error_classified
+  (** Token resolution raised a classified [Auth_error_kind]; the
+          companion [err_kind] label carries the closed-sum
+          classification. *)
+
+val to_label : t -> string


### PR DESCRIPTION
## Summary

Two more closed-set Prometheus labels collapsed into typed sums.
Mini-PR bundle (same pattern, both are 2-variant, 2-site).

## Sites

| Metric | Label | Variant | Sites |
|--------|-------|---------|-------|
| `metric_fs_atomic_orphans_cleaned` | `size_class` | `Atomic_orphan_size_class.t` | `server_runtime_bootstrap.ml:1588,1594` |
| `metric_silent_dashboard_actor_fallback` | `outcome` | `Silent_dashboard_actor_outcome.t` | `server_auth.ml:305,347` |

## Why

Same workaround #2 (string classifier) pattern earlier sweep iterations
closed for many metrics (#14704, #14755, #14760, #14768, #14773,
#14778).  Both labels were de-facto 2-element closed sets stored as
string literals; the typed sums force every emit site through the
compiler so adding a new value requires extending the variant.

The `outcome` site sits alongside the already-typed `err_kind`
(`Auth_error_kind`) — companion typing brings the metric to fully
typed labels.

## Approach

```ocaml
(* lib/server/atomic_orphan_size_class.ml *)
type t = Empty | With_data

(* lib/server/silent_dashboard_actor_outcome.ml *)
type t = None_resolved | Error_classified
```

Both expose `to_label : t -> string`.  Wire format byte-equal.

## Test plan

- [ ] CI green
- [ ] `rg '"size_class", "(empty|with_data)"' lib/` = 0
- [ ] `rg '"outcome", "(none|error)"' lib/server/server_auth.ml` = 0

RFC-WAIVED: not in credential/identity/operator/sandbox/hooks/workflow scope.
(`server_auth.ml` touches the silent-dashboard-actor metric only; no
auth logic changes.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)