### PR TITLE
perf(keeper_repo_mapping): consolidate + O(R+M) filter_repos_by_mapping helper

### DIFF
--- a/lib/repo_manager/keeper_repo_mapping.ml
+++ b/lib/repo_manager/keeper_repo_mapping.ml
@@ -115,16 +115,21 @@ let allowed_repositories ~keeper_id ~base_path =
   let* mapping = find_mapping ~base_path keeper_id in
   Ok mapping.repository_ids
 
+let is_wildcard s = s = "*"
+
 (* Filter [repos] down to those whose id appears in
    [mapping.repository_ids], with ["*"] as a wildcard that bypasses
    filtering entirely.  Replaces two copy-pasted O(R x M) loops in
    [credentials_for_keeper] and [apply_mapping]: each was
    [List.filter (fun r -> List.exists (String.equal r.id) mapping.repository_ids) repos].
-   The set is materialised only when no wildcard short-circuits the
-   check, so the wildcard case stays allocation-free. *)
+   The Hashtbl materialisation is skipped when a wildcard short-circuits
+   the check, so the wildcard case avoids building the membership set
+   (the [is_wildcard] predicate itself is a fully-saturated function so
+   no closure is allocated per call, unlike [(String.equal "*")] which
+   would partially apply). *)
 let filter_repos_by_mapping (mapping : keeper_repo_mapping)
     (repos : repository list) : repository list =
-  if List.exists (String.equal "*") mapping.repository_ids then
+  if List.exists is_wildcard mapping.repository_ids then
     repos
   else
     let mapping_id_set =

--- a/lib/repo_manager/keeper_repo_mapping.ml
+++ b/lib/repo_manager/keeper_repo_mapping.ml
@@ -115,6 +115,27 @@ let allowed_repositories ~keeper_id ~base_path =
   let* mapping = find_mapping ~base_path keeper_id in
   Ok mapping.repository_ids
 
+(* Filter [repos] down to those whose id appears in
+   [mapping.repository_ids], with ["*"] as a wildcard that bypasses
+   filtering entirely.  Replaces two copy-pasted O(R x M) loops in
+   [credentials_for_keeper] and [apply_mapping]: each was
+   [List.filter (fun r -> List.exists (String.equal r.id) mapping.repository_ids) repos].
+   The set is materialised only when no wildcard short-circuits the
+   check, so the wildcard case stays allocation-free. *)
+let filter_repos_by_mapping (mapping : keeper_repo_mapping)
+    (repos : repository list) : repository list =
+  if List.exists (String.equal "*") mapping.repository_ids then
+    repos
+  else
+    let mapping_id_set =
+      let tbl = Hashtbl.create (List.length mapping.repository_ids) in
+      List.iter (fun id -> Hashtbl.replace tbl id ()) mapping.repository_ids;
+      tbl
+    in
+    List.filter
+      (fun (r : repository) -> Hashtbl.mem mapping_id_set r.id)
+      repos
+
 (** Resolve the credentials currently mapped to [keeper_id], by looking
     through every repository the keeper is allowed to access and
     extracting each repository's [credential_id] into a unique list of
@@ -160,15 +181,7 @@ let credentials_for_keeper ~base_path ~keeper_id =
             Ok [credential]
       | Some _ | None ->
       let* repos = Repo_store.load_all ~base_path in
-      let mapped_repos =
-        if List.exists (String.equal "*") mapping.repository_ids then
-          repos
-        else
-          List.filter
-            (fun (r : repository) ->
-              List.exists (String.equal r.id) mapping.repository_ids)
-            repos
-      in
+      let mapped_repos = filter_repos_by_mapping mapping repos in
       (* Unique credential ids preserving first-seen order, so a keeper
          with several repos pointing at the same credential collapses to
          a single entry; the bridge can then dispatch deterministically. *)
@@ -253,13 +266,7 @@ let apply_mapping ~keeper_id ~base_path ~repositories =
         keeper_id msg;
       repositories
   | Mapping_found mapping ->
-      if List.exists (String.equal "*") mapping.repository_ids then
-        repositories
-      else
-        List.filter
-          (fun (r : repository) ->
-            List.exists (String.equal r.id) mapping.repository_ids)
-          repositories
+      filter_repos_by_mapping mapping repositories
 
 (* Path normalization for prefix comparison. *)
 let normalize_path_for_prefix_check path =


### PR DESCRIPTION
## Summary

\`lib/repo_manager/keeper_repo_mapping.ml\` had **two copy-pasted O(R×M) loops** doing the same repo-filter logic:

\`\`\`ocaml
(* credentials_for_keeper, lines 163-170 *)
if List.exists (String.equal "*") mapping.repository_ids then repos
else
  List.filter
    (fun r -> List.exists (String.equal r.id) mapping.repository_ids)
    repos

(* apply_mapping, lines 256-262 — identical *)
if List.exists (String.equal "*") mapping.repository_ids then repositories
else
  List.filter
    (fun r -> List.exists (String.equal r.id) mapping.repository_ids)
    repositories
\`\`\`

For R repos × M mapping ids without the \`"*"\` wildcard, each call did R × M string compares.

## Fix

Extract a single private helper:

\`\`\`ocaml
let filter_repos_by_mapping (mapping : keeper_repo_mapping)
    (repos : repository list) : repository list =
  if List.exists (String.equal "*") mapping.repository_ids then
    repos
  else
    let mapping_id_set =
      let tbl = Hashtbl.create (List.length mapping.repository_ids) in
      List.iter (fun id -> Hashtbl.replace tbl id ()) mapping.repository_ids;
      tbl
    in
    List.filter
      (fun (r : repository) -> Hashtbl.mem mapping_id_set r.id)
      repos
\`\`\`

| Path | Before | After |
|------|--------|-------|
| Wildcard \`"*"\` present | O(M) check, return all | unchanged — wildcard skipped Hashtbl build |
| Wildcard absent | R × M string compares | O(M) build + R × O(1) lookup = O(R + M) |

## Why two-for-one consolidation

When the identical inefficiency appears in 2+ call sites, the shared helper is the right abstraction. Each call site now routes through one implementation — any future change to the wildcard/membership semantics happens in exactly one place.

## API preservation

\`keeper_repo_mapping.mli\` is unchanged — the helper is private to the \`.ml\`. \`credentials_for_keeper\` and \`apply_mapping\` keep their existing signatures.

## Test plan

- [ ] CI lib/ build green
- [ ] \`dune runtest test/test_keeper_repo_mapping.exe\` (if present) passes
- [ ] Smoke: a keeper with \`"*"\` mapping sees all repos; a keeper with explicit id list sees only mapped repos

🤖 Generated with [Claude Code](https://claude.com/claude-code)