### PR TITLE
docs(rfc-0070-3b-iii): timeout_budget naming + error payload semantics (Copilot review)

### DIFF
--- a/lib/keeper/keeper_sandbox_plan.ml
+++ b/lib/keeper/keeper_sandbox_plan.ml
@@ -18,8 +18,10 @@ type t =
   }
 
 let of_request ~turn_id ~attempt ~meta_name ~cmd =
-  if String.equal meta_name "" then Error (Invalid_meta "meta_name must not be empty")
-  else if String.equal cmd "" then Error (Invalid_command "cmd must not be empty")
+  (* Error payload = offending value (per .mli contract). Empty-string
+     callers see [Invalid_meta ""] / [Invalid_command ""]. *)
+  if String.equal meta_name "" then Error (Invalid_meta meta_name)
+  else if String.equal cmd "" then Error (Invalid_command cmd)
   else
     let container_name =
       Keeper_container_name.derive

--- a/lib/keeper/keeper_sandbox_plan.mli
+++ b/lib/keeper/keeper_sandbox_plan.mli
@@ -1,8 +1,9 @@
 (** RFC-0070 Phase 3b-iii — Pure construction of a docker run plan.
 
     Real (no longer stub) implementation of {!of_request}. Phase 3a
-    established the type contract with [Error Unsupported_profile] for
-    every call; Phase 3b-iii returns a populated {!t}.
+    established the type contract with [Error] [Unsupported_profile]
+    (a Phase-3a-only catch-all, now removed) for every call; Phase
+    3b-iii returns a populated {!t}.
 
     Reference: docs/rfc/RFC-0070-keeper-sandbox-pure-edge-separation.md §3.1
 
@@ -10,19 +11,25 @@
     identical {!t}. No wall-clock, no Random, no global state.
 
     Scope of Phase 3b-iii: the record exposes the four most-needed
-    fields (container_name, image, command, timeout_budget). Mount,
-    ulimit, and network_mode are deferred to Phase 3b-iv where they
-    arrive as typed records together with the {!Real} {!Docker_client}
-    implementation. *)
+    fields ([container_name], [image], [command], [timeout_budget_sec]).
+    Mount, ulimit, and network_mode are deferred to Phase 3b-iv where
+    they arrive as typed records together with the [Real]
+    [Docker_client] implementation. *)
 
 (** {1 Errors} *)
 
 (** Closed sum — no catch-all. Phase 3b-iii narrows from Phase 3a's
-    {!Unsupported_profile} catch-all to two concrete validation arms.
-    Phase 3b-iv may add more as Mount / Network validation lands. *)
+    [Unsupported_profile] catch-all (now removed) to two concrete
+    validation arms. Phase 3b-iv may add more as Mount / Network
+    validation lands.
+
+    The [string] payload on each arm is the *offending input value*,
+    not a human-readable message. Display strings are caller-formatted
+    from the variant + payload at the error site, so payload semantics
+    stay stable and grep-able. *)
 type plan_error =
-  | Invalid_meta of string
-  | Invalid_command of string
+  | Invalid_meta of string  (** payload = the offending [meta_name] (often [""]) *)
+  | Invalid_command of string  (** payload = the offending [cmd] (often [""]) *)
 
 (** {1 Plan} *)
 
@@ -37,15 +44,16 @@ type t
     its declared inputs alone. Pure: no I/O, no clock, no random.
 
     Validation:
-    - [meta_name] must be non-empty (returns [Invalid_meta] otherwise).
-    - [cmd] must be non-empty (returns [Invalid_command] otherwise).
+    - [meta_name] must be non-empty (returns [Invalid_meta meta_name]
+      otherwise — the offending value is the payload).
+    - [cmd] must be non-empty (returns [Invalid_command cmd] otherwise).
 
     Fields populated:
     - [container_name = Keeper_container_name.derive ~algo:SHA_256
       ~turn_id ~attempt ~suffix:meta_name]
     - [image = default_image] (Phase 3b-iv: caller-provided)
     - [command = cmd]
-    - [timeout_budget = default_timeout_budget_sec] (Phase 3b-iv:
+    - [timeout_budget_sec = default_timeout_budget_sec] (Phase 3b-iv:
       caller-provided)
 
     The signature accepts [meta_name] as a [string] in Phase 3a/3b-iii

--- a/test/test_keeper_sandbox_plan.ml
+++ b/test/test_keeper_sandbox_plan.ml
@@ -13,8 +13,10 @@ let plan_error_pp ppf = function
 
 let plan_error_eq a b =
   match a, b with
-  | Keeper_sandbox_plan.Invalid_meta _, Keeper_sandbox_plan.Invalid_meta _ -> true
-  | Keeper_sandbox_plan.Invalid_command _, Keeper_sandbox_plan.Invalid_command _ -> true
+  | Keeper_sandbox_plan.Invalid_meta x, Keeper_sandbox_plan.Invalid_meta y ->
+      String.equal x y
+  | Keeper_sandbox_plan.Invalid_command x, Keeper_sandbox_plan.Invalid_command y ->
+      String.equal x y
   | _ -> false
 
 let plan_t = testable Keeper_sandbox_plan.pp Keeper_sandbox_plan.equal
@@ -41,6 +43,26 @@ let test_empty_cmd_rejected () =
     "empty cmd → Invalid_command"
     (Error (Keeper_sandbox_plan.Invalid_command ""))
     result
+
+(* ── Payload semantics: error carries offending value (Phase 3b-iii contract) ── *)
+
+let test_invalid_meta_payload_is_offending () =
+  let result =
+    Keeper_sandbox_plan.of_request ~turn_id:1 ~attempt:0 ~meta_name:"" ~cmd:"x"
+  in
+  match result with
+  | Error (Keeper_sandbox_plan.Invalid_meta payload) ->
+      check string "Invalid_meta payload = offending meta_name (\"\")" "" payload
+  | _ -> fail "expected Invalid_meta"
+
+let test_invalid_command_payload_is_offending () =
+  let result =
+    Keeper_sandbox_plan.of_request ~turn_id:1 ~attempt:0 ~meta_name:"k" ~cmd:""
+  in
+  match result with
+  | Error (Keeper_sandbox_plan.Invalid_command payload) ->
+      check string "Invalid_command payload = offending cmd (\"\")" "" payload
+  | _ -> fail "expected Invalid_command"
 
 (* ── Happy path: returns Ok with populated fields ─────────────── *)
 
@@ -127,6 +149,12 @@ let () =
         [
           test_case "empty meta rejected" `Quick test_empty_meta_rejected;
           test_case "empty cmd rejected" `Quick test_empty_cmd_rejected;
+          test_case "Invalid_meta payload = offending meta_name"
+            `Quick
+            test_invalid_meta_payload_is_offending;
+          test_case "Invalid_command payload = offending cmd"
+            `Quick
+            test_invalid_command_payload_is_offending;
         ] );
       ( "happy path",
         [


### PR DESCRIPTION
## 목표 — PR #14781 후속 cleanup (5 Copilot threads)

PR #14781 admin-merge 후 도착한 5 Copilot threads 모두 ACCEPT + 처리.

## RFC 인용

| RFC | 관계 |
|-----|------|
| **RFC-0070** | §3.1 — Plan record API + error semantics |
| RFC-0006 | cite-only (sandbox surface) |
| RFC-0036 | cite-only (cleanup hook) |

## Copilot 5 threads 처리

| Thread | 판정 | 처리 |
|--------|------|------|
| T8 odoc `{!Unsupported_profile}` broken | **ACCEPT** | plain text로 변경 + Phase-3a-only 명시 |
| T9 module description `timeout_budget` 누락 _sec | **ACCEPT** | `timeout_budget_sec` 통일 + code-tag bracket |
| T10 'Fields populated' bullet `timeout_budget` | **ACCEPT** | 동일 통일 |
| T11 test plan_error_eq payload 무시 | **ACCEPT** | `String.equal`로 강화 + 2 새 test ("payload = offending value") |
| T12 `Invalid_meta of string` semantic 불명 | **ACCEPT** | .mli docstring으로 명시 — payload는 *offending value*, not human-readable message |

## Behavior change (T11/T12 일관성)

**Before**: `Error (Invalid_meta "meta_name must not be empty")` (human-readable message in payload)
**After**: `Error (Invalid_meta meta_name)` (offending value in payload — typically `""`)

근거: payload semantics가 *stable + grep-able*. Display strings는 caller-formatted at error site. Phase 3b-iv가 첫 consumer가 될 때 일관 처리. 기존 caller 0건 (Phase 3a stub 이후 Plan은 처음 production).

## 변경

```
lib/keeper/keeper_sandbox_plan.mli   ±15 (4 amends + 변종 arm docstring)
lib/keeper/keeper_sandbox_plan.ml    ±3 (error payload semantics 변경)
test/test_keeper_sandbox_plan.ml     ±36 (eq 강화 + 2 새 test)
```

## 새 Test (payload semantics 강제)

```ocaml
test_invalid_meta_payload_is_offending:
  empty meta → Error (Invalid_meta payload)
  assert payload = ""

test_invalid_command_payload_is_offending:
  empty cmd → Error (Invalid_command payload)
  assert payload = ""
```

`plan_error_eq` 강화 — `String.equal` payload 비교. 잘못된 payload 도 test fail 유발 (T11 close).

## 검증

- **Isolated ocamlc**: 의존성 origin/main에 있음 (Keeper_container_name, Keeper_hash_algo, Keeper_sandbox_plan)
- **`dune build @check`** repo-wide: main 회귀 (#14745 keeper_runtime cleanup pending) 미해소

## Workaround Rejection Bar self-check

| 시그니처 | 본 PR 해당? |
|---------|------------|
| Counter-as-fix | N/A |
| String 분류기 | N/A — typed error variants, payload = offending value (semantic clarification) |
| N-of-M | N/A — 5 thread 모두 1 PR |
| Cap/cooldown/dedup/repair | N/A |
| Test backdoor | N/A |
| Catch-all `_ ->` | N/A — variant match exhaustive |

## 미검증

- `dune runtest`로 새 2 test 실제 통과 — main 회귀로 인해 repo-wide build BLOCKED. 단 logic은 명백 (string assertion on closed variant).

5 thread `resolveReviewThread` 처리 예정.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
