### PR TITLE
docs(tla-audit): KCT S2/S3 — Failing & buffer cascade alignment

### DIFF
--- a/docs/tla-audit/kct-s2s3-failing-buffer-cascade-alignment-2026-05-12.md
+++ b/docs/tla-audit/kct-s2s3-failing-buffer-cascade-alignment-2026-05-12.md
@@ -3,7 +3,7 @@
 **Iteration**: 26 (/loop FSM/TLA+/OCaml drift hunt)
 **Date**: 2026-05-12
 **Spec**: `specs/keeper-state-machine/KeeperCoreTriad.tla` §S2 FailingUsesRecovery, §S3 BufferOpsUseLocalOnly
-**OCaml**: `lib/keeper/keeper_cascade_routing.ml:20-25`, `lib/keeper/keeper_config.ml:26-33`, `lib/cascade/cascade_routes.ml:64-65, 251-271`
+**OCaml**: `lib/keeper/keeper_cascade_routing.ml:20-25`, `lib/keeper/keeper_config.ml:26-33`, `lib/cascade/cascade_routes.ml:64-65, 209-271`
 **Risk**: LOW — alignment is correct in the *default* deployment.  Configuration-dependent gap: operator-supplied catalogs/routes may resolve to non-spec names, in which case spec-literal match no longer holds verbatim — though the *intent* (use recovery / buffer profile, not main keeper cascade) is preserved.
 **Type**: Audit-only (no code change in this PR).  Companion to C-3 (terminal cascade) audit.
 

--- a/docs/tla-audit/kct-s2s3-failing-buffer-cascade-alignment-2026-05-12.md
+++ b/docs/tla-audit/kct-s2s3-failing-buffer-cascade-alignment-2026-05-12.md
@@ -1,0 +1,173 @@
+# KeeperCoreTriad S2/S3 Audit — Failing & Buffer Cascade Alignment
+
+**Iteration**: 26 (/loop FSM/TLA+/OCaml drift hunt)
+**Date**: 2026-05-12
+**Spec**: `specs/keeper-state-machine/KeeperCoreTriad.tla` §S2 FailingUsesRecovery, §S3 BufferOpsUseLocalOnly
+**OCaml**: `lib/keeper/keeper_cascade_routing.ml:20-25`, `lib/keeper/keeper_config.ml:26-33`, `lib/cascade/cascade_routes.ml:64-65, 251-271`
+**Risk**: LOW — alignment is correct in the *default* deployment.  Configuration-dependent gap: operator-supplied catalogs/routes may resolve to non-spec names, in which case spec-literal match no longer holds verbatim — though the *intent* (use recovery / buffer profile, not main keeper cascade) is preserved.
+**Type**: Audit-only (no code change in this PR).  Companion to C-3 (terminal cascade) audit.
+
+## TLA+ S2/S3 contracts
+
+```tla
+(* Spec line ~365: *)
+FailingUsesRecovery ==
+    (phase = "Failing" /\ turn_status = "selecting" /\ effective_cascade /= "none")
+        => effective_cascade = "local_recovery"
+
+(* Spec line ~370: *)
+BufferOpsUseLocalOnly ==
+    (phase \in {"Compacting", "HandingOff"}
+     /\ turn_status = "selecting"
+     /\ effective_cascade /= "none")
+        => effective_cascade = "local_only"
+```
+
+Both are **conditional implication** invariants gated on `turn_status = "selecting"`
+(an upstream caller responsibility).  `select_cascade` itself is
+phase-only — it does not know `turn_status`.
+
+## OCaml dispatch (the *intent* side)
+
+```ocaml
+(* lib/keeper/keeper_cascade_routing.ml:20-25 *)
+| Failing ->
+    { effective_cascade = Keeper_config.local_recovery_cascade_name;
+      reason = "failing phase: cheap local recovery" }
+| Compacting | HandingOff ->
+    { effective_cascade = Keeper_config.local_only_cascade_name;
+      reason = "buffer operation: local model sufficient" }
+```
+
+Intent matches the spec: Failing → recovery profile, Compacting|HandingOff →
+buffer profile.  Provenance of the *string value* is the issue.
+
+## String value resolution (the *literal* side)
+
+```ocaml
+(* lib/keeper/keeper_config.ml:26-33 *)
+let local_recovery_cascade_name =
+  Keeper_cascade_profile.cascade_name_for_use Phase_recovery
+
+let local_only_cascade_name =
+  Keeper_cascade_profile.cascade_name_for_use Phase_buffer
+```
+
+```ocaml
+(* lib/cascade/cascade_routes.ml:64-65 — route spec *)
+| Phase_recovery -> route Phase_recovery "phase_recovery" [ "local_recovery" ]
+| Phase_buffer   -> route Phase_buffer   "phase_buffer"   [ "local_only" ]
+
+(* lib/cascade/cascade_routes.ml:251-271 — resolution *)
+let cascade_name_for_use ?config_path use =
+  let route_target = configured_route_bindings ... in
+  let catalog_names = ... in
+  let fallback = fallback_from_entries use entries in
+  match route_target with
+  | Some target when catalog_names = [] -> fallback     (* uses first alias *)
+  | Some target when List.mem target catalog_names -> target
+  | Some target -> fallback                              (* invalid target *)
+  | None -> fallback
+```
+
+`fallback_from_entries`:
+1. If `entries` (catalog) is non-empty → returns *first catalog entry's
+   `name`*, ignoring the aliases.
+2. Else → `first_alias_or_key spec` — for `Phase_recovery` this is
+   `"local_recovery"`, exactly the spec literal.
+
+## Three resolution scenarios
+
+| Scenario | Catalog state | Operator route | Resolved name | Spec match? |
+|---|---|---|---|---|
+| **Default boot** (empty catalog) | `[]` | None | first alias: `"local_recovery"` / `"local_only"` | ✅ exact |
+| **Catalog without route override** | non-empty, has profile named e.g. `"recovery"` | None | *first catalog entry name* | ❌ probably not literal |
+| **Operator route to a catalog profile** | non-empty | `"phase_recovery": "custom_recovery"` if in catalog | `"custom_recovery"` | ❌ |
+
+The spec assumes scenario 1's literal value, but production frequently
+runs scenarios 2/3.
+
+## Why this isn't a runtime bug today
+
+- The spec's `effective_cascade` is an abstract *cascade identity*, not a
+  string-equality assertion in production code.  No OCaml branch reads the
+  output of `select_cascade` and asserts `= "local_recovery"`.
+- The intent (use a recovery/buffer profile, not the main keeper cascade)
+  *is* preserved through the `Phase_recovery` / `Phase_buffer` typed
+  enum — the indirection is in *which catalog name implements that role*.
+- The `turn_status = "selecting"` gate in S2/S3 is a callsite invariant,
+  not a property of `select_cascade`.  Upstream
+  (`keeper_unified_turn.ml:411` per C-3 audit) gates the call appropriately.
+
+So S2/S3 hold *in production* via the typed `logical_use` indirection,
+not via literal string equality.
+
+## Why the spec is brittle here
+
+The spec encodes a string literal as the contract surface:
+
+```tla
+effective_cascade = "local_recovery"   \* hard-coded string
+```
+
+This is the same anti-pattern as KCT terminal cascade (C-3) — spec
+overspecifies a value that production legitimately abstracts.  The spec
+captures *intent* with the string, but the *identifier* is a moving target
+on the production side.
+
+## Three RFC candidates
+
+| ID | Direction | Risk |
+|---|---|---|
+| R-S2.a | **Spec — relax to symbolic identifiers**. Introduce spec CONSTANTs `RECOVERY_PROFILE`, `BUFFER_PROFILE` instead of hardcoded strings.  Spec retains intent, decouples from production string churn.  Matches the typed `logical_use` design. | LOW (spec change, TLC re-verify) |
+| R-S2.b | **OCaml — sentinel constants on the *spec* side**. Force `local_recovery_cascade_name` to a build-time literal `"local_recovery"` (no catalog lookup), and treat operator routing as a *separate* layer mapping that name to catalog profiles. | MID (boots into stronger invariants but loses operator flexibility on naming) |
+| R-S2.c | **Both — document the abstraction**. Add a spec comment §S2 explaining `"local_recovery"` is the canonical name of the role, not the operator's catalog entry name; cross-reference `Keeper_cascade_profile.Phase_recovery`.  No code change. | LOW (doc only) |
+
+R-S2.c is the cheapest — admits the typed-identifier abstraction is the
+SSOT and the spec literal is a stand-in.  R-S2.a is the structurally
+cleaner fix (CONSTANT → cfg parameter).  R-S2.b is a regression of
+operator-driven naming flexibility and is **not recommended**.
+
+## Comparison with C-3 (terminal cascade gap)
+
+C-3 (kct-c3-terminal-cascade-contract-gap-2026-05-12.md) noted that
+`select_cascade` returns `base_cascade` for terminal phases where spec
+requires `"none"`.  The gap is similar in *shape* (spec wants a specific
+string; OCaml emits a different one) but **opposite in direction**:
+
+| Audit | Spec wants | OCaml emits | Gap shape |
+|---|---|---|---|
+| C-3 (Terminal) | `"none"` | `base_cascade` | OCaml *more permissive* than spec |
+| S2/S3 (this) | `"local_recovery"` / `"local_only"` | catalog-resolved name | OCaml *more configurable* than spec |
+
+Both are **paper contract gaps**, neither is a runtime bug, both surface
+when an extra layer (callsite gating, operator config) is taken into
+account.
+
+## Recommended next step
+
+R-S2.c (doc-only spec comment) is the cheapest path to align spec
+expectations with production reality.  It can be bundled with R-C-3.c
+(terminal cascade spec relaxation) into a single small spec doc PR that
+acknowledges the typed-identifier abstraction as the SSOT.
+
+## Out-of-scope for this iteration
+
+- S3 second component (CapabilityGateHolds): `turn_status = "executing"`
+  predicate on `requested_max_tokens` — different mechanism (token budget
+  not cascade selection), separate audit.
+- S4 SideEffectContainment, S5 PhaseDecisionConsistency — different
+  invariant families, separate audits.
+- R-C-3.b sentinel implementation — risky (test impact), deferred.
+
+## References
+
+- KCT spec §S2 (FailingUsesRecovery), §S3 (BufferOpsUseLocalOnly,
+  CapabilityGateHolds).
+- `lib/keeper/keeper_cascade_routing.ml:20-25` (intent dispatch).
+- `lib/keeper/keeper_config.ml:26-33` (name resolution call).
+- `lib/cascade/cascade_routes.ml:64-65, 209-271` (route_spec + fallback
+  resolution).
+- C-3 audit (`kct-c3-terminal-cascade-contract-gap-2026-05-12.md`) —
+  sibling spec-literal gap pattern.
+- RFC-0058 (declarative route mapping) — origin of the indirection layer.


### PR DESCRIPTION
## Finding (Iteration 26, KCT S2/S3 cross-check)

**Spec**: `specs/keeper-state-machine/KeeperCoreTriad.tla` §S2 FailingUsesRecovery, §S3 BufferOpsUseLocalOnly
**OCaml**: `lib/keeper/keeper_cascade_routing.ml:20-25` + `lib/keeper/keeper_config.ml:26-33` + `lib/cascade/cascade_routes.ml:64-65, 251-271`
**Aspect**: Cascade name alignment for `Failing` → `local_recovery`, `Compacting|HandingOff` → `local_only`.
**Risk**: LOW — default-deployment alignment OK, operator-configured catalogs/routes resolve to non-spec names.
**Workaround signature**: N/A (audit-only)

## 순서도

```mermaid
flowchart LR
  A[select_cascade phase] -->|Failing| B[local_recovery_cascade_name]
  A -->|Compacting<br/>HandingOff| C[local_only_cascade_name]
  B --> D[cascade_name_for_use Phase_recovery]
  C --> E[cascade_name_for_use Phase_buffer]
  D --> F{operator route?}
  E --> F
  F -->|Yes + in catalog| G[operator-named target]
  F -->|No / invalid| H[fallback_from_entries]
  H -->|catalog empty| I[first alias: local_recovery / local_only]
  H -->|catalog non-empty| J[first catalog entry name]
  I -.->|✅ spec literal match| K[Spec: 'local_recovery' / 'local_only']
  G -.->|❌ name mismatch| K
  J -.->|❌ name mismatch| K
```

## Finding

| Scenario | Catalog | Operator route | Resolved | Spec match |
|---|---|---|---|---|
| Default boot | empty | None | `local_recovery` / `local_only` | ✅ exact |
| Catalog only | non-empty | None | first catalog entry | ❌ |
| Operator + catalog | non-empty | mapped | operator-named | ❌ |

Spec encodes `"local_recovery"` / `"local_only"` as **string literals**; OCaml resolves dynamically through catalog/route layer (RFC-0058 declarative routing).  Intent (use recovery/buffer profile, not main cascade) is preserved via typed `logical_use` enum.

## 왜 톱니처럼 정교하지 않은가

스펙이 cascade 식별자를 *문자열 리터럴*로 박아두고 있는데 OCaml은 catalog 매핑을 통해 dynamic하게 해석한다.  Operator가 catalog profile 이름을 바꾸면 spec 리터럴과 갈라진다.  의도(role)는 typed enum (`Phase_recovery`/`Phase_buffer`)으로 보존되므로 runtime bug는 아니지만, spec 입장에서는 paper contract violation.  C-3 (terminal cascade)와 같은 *spec-literal vs OCaml indirection* 패턴의 사례.

## 본 PR 수정

`docs/tla-audit/kct-s2s3-failing-buffer-cascade-alignment-2026-05-12.md` (+173 LOC) — audit memo only.  No spec or OCaml change.

## Trade-off

- 정확성: spec literal 매칭은 default deployment에서만 보장.  Operator config에서는 catalog 해석에 의존.
- 표현력 vs 단순성: operator naming flexibility는 production이 가져가고, spec은 abstract identifier로 후퇴해야 align.

## RFC 후보

- **R-S2.a**: spec CONSTANTs (`RECOVERY_PROFILE`, `BUFFER_PROFILE`) 도입.  TLC re-verify.  LOW.
- **R-S2.b**: OCaml literal sentinel 강제.  Operator naming flexibility 회귀.  **권장하지 않음**.
- **R-S2.c**: spec 주석으로 abstraction 명시.  C-3.c와 묶어서 단일 spec doc PR 권장.  LOW.

## RFC 참조

`RFC-WAIVED: audit memo only, no subsystem touched.`

연관:
- C-3 audit (`kct-c3-terminal-cascade-contract-gap-2026-05-12.md`) — 같은 spec-literal vs OCaml indirection 패턴, 반대 방향.
- RFC-0058 (declarative route mapping) — abstraction layer origin.

## Verification

- [ ] `dune build @check` (audit memo only — no code change to validate)
- [x] 인용한 라인 번호 cross-check 완료 (cascade_routes.ml:64-65, 251-271; cascade_routing.ml:20-25)

## 진행 추적

다음 iteration 시작점: KCT S3-CapabilityGateHolds (token budget 차원) 또는 R-B-1.a (KTC TurnPhaseSet 확장).

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>