### PR TITLE
feat(telemetry): typed Profile_load_failure_site variant

### DIFF
--- a/lib/keeper/keeper_types_profile.ml
+++ b/lib/keeper/keeper_types_profile.ml
@@ -549,7 +549,7 @@ let personas_root_opt () =
   | exn ->
       Prometheus.inc_counter
         Keeper_metrics.metric_keeper_profile_load_failures
-        ~labels:[("site", "personas_root")]
+        ~labels:[("site", Profile_load_failure_site.(to_label Personas_root))]
         ();
       Log.Keeper.warn "personas_root_opt unexpected: %s" (Printexc.to_string exn);
       None
@@ -564,7 +564,7 @@ let persona_profile_path_opt name =
     | exn ->
         Prometheus.inc_counter
           Keeper_metrics.metric_keeper_profile_load_failures
-          ~labels:[("site", "personas_dirs_resolve")]
+          ~labels:[("site", Profile_load_failure_site.(to_label Personas_dirs_resolve))]
           ();
         Log.Keeper.warn "personas_dirs unexpected: %s" (Printexc.to_string exn);
         []
@@ -1264,7 +1264,7 @@ let log_toml_skip_once ~file ~error =
     Hashtbl.add logged_toml_skip key ();
     Prometheus.inc_counter
       Keeper_metrics.metric_keeper_profile_load_failures
-      ~labels:[("site", "toml_skip")]
+      ~labels:[("site", Profile_load_failure_site.(to_label Toml_skip))]
       ();
     Log.Keeper.warn "toml_loader: skipping %s: %s" file error;
     true
@@ -1754,7 +1754,7 @@ let keeper_default_source_snapshot name : keeper_default_source_snapshot =
       | Error e ->
           Prometheus.inc_counter
             Keeper_metrics.metric_keeper_profile_load_failures
-            ~labels:[("site", "toml_fallback")]
+            ~labels:[("site", Profile_load_failure_site.(to_label Toml_fallback))]
             ();
           Log.Keeper.warn
             "toml config for %s failed (%s), falling back to persona"
@@ -1783,7 +1783,7 @@ let load_persona_extended ?(max_chars = persona_description_max_chars) name : st
     | exn ->
         Prometheus.inc_counter
           Keeper_metrics.metric_keeper_profile_load_failures
-          ~labels:[("site", "load_persona_extended")]
+          ~labels:[("site", Profile_load_failure_site.(to_label Load_persona_extended))]
           ();
         Log.Keeper.warn "load_persona_extended personas_dirs unexpected: %s"
           (Printexc.to_string exn);
@@ -1799,7 +1799,7 @@ let load_persona_extended ?(max_chars = persona_description_max_chars) name : st
         | Error msg ->
           Prometheus.inc_counter
             Keeper_metrics.metric_keeper_profile_load_failures
-            ~labels:[("site", "agent_md_read")]
+            ~labels:[("site", Profile_load_failure_site.(to_label Agent_md_read))]
             ();
           Log.Keeper.warn "[load_agent_md] failed to read %s: %s" path msg;
           None
@@ -1879,7 +1879,7 @@ let list_persona_summaries () : persona_summary list =
     | exn ->
         Prometheus.inc_counter
           Keeper_metrics.metric_keeper_profile_load_failures
-          ~labels:[("site", "list_persona_summaries")]
+          ~labels:[("site", Profile_load_failure_site.(to_label List_persona_summaries))]
           ();
         Log.Keeper.warn "list_persona_summaries personas_dirs unexpected: %s"
           (Printexc.to_string exn);

--- a/lib/keeper/profile_load_failure_site.ml
+++ b/lib/keeper/profile_load_failure_site.ml
@@ -1,0 +1,18 @@
+type t =
+  | Personas_root
+  | Personas_dirs_resolve
+  | Toml_skip
+  | Toml_fallback
+  | Load_persona_extended
+  | Agent_md_read
+  | List_persona_summaries
+
+let to_label = function
+  | Personas_root -> "personas_root"
+  | Personas_dirs_resolve -> "personas_dirs_resolve"
+  | Toml_skip -> "toml_skip"
+  | Toml_fallback -> "toml_fallback"
+  | Load_persona_extended -> "load_persona_extended"
+  | Agent_md_read -> "agent_md_read"
+  | List_persona_summaries -> "list_persona_summaries"
+;;

--- a/lib/keeper/profile_load_failure_site.mli
+++ b/lib/keeper/profile_load_failure_site.mli
@@ -1,0 +1,17 @@
+(** Profile_load_failure_site — closed sum for the [site] label on
+    [metric_keeper_profile_load_failures].
+
+    Replaces 7 hardcoded literals scattered across 7 emit sites in
+    [keeper_types_profile.ml].  Each `site` corresponds to a distinct
+    failure path in the persona/profile loading pipeline. *)
+
+type t =
+  | Personas_root (** Could not enumerate the personas root directory. *)
+  | Personas_dirs_resolve (** Failed to resolve one or more configured personas dirs. *)
+  | Toml_skip (** TOML parse skipped because the file was unreadable / invalid. *)
+  | Toml_fallback (** TOML load fell back to defaults after a soft error. *)
+  | Load_persona_extended (** Extended persona body failed to load. *)
+  | Agent_md_read (** AGENT.md sidecar read failed. *)
+  | List_persona_summaries (** Building the persona-summary listing raised an error. *)
+
+val to_label : t -> string


### PR DESCRIPTION
## Summary

7 hardcoded `site` label literals in `keeper_types_profile.ml` (all
emitting on `metric_keeper_profile_load_failures`) collapsed into a
closed sum `Profile_load_failure_site.t`.

## Sites (7)

| File:Line | Variant | Failure path |
|-----------|---------|--------------|
| `keeper_types_profile.ml:552` | `Personas_root` | personas root dir enumeration |
| `keeper_types_profile.ml:567` | `Personas_dirs_resolve` | resolve configured personas dirs |
| `keeper_types_profile.ml:1267` | `Toml_skip` | TOML parse skipped (unreadable/invalid) |
| `keeper_types_profile.ml:1757` | `Toml_fallback` | TOML load fell back to defaults |
| `keeper_types_profile.ml:1786` | `Load_persona_extended` | extended persona body load |
| `keeper_types_profile.ml:1802` | `Agent_md_read` | AGENT.md sidecar read |
| `keeper_types_profile.ml:1882` | `List_persona_summaries` | persona-summary listing build |

## Why

Same workaround #2 (string classifier) pattern earlier sweep iterations
closed for cross-file metrics (T4, T10, T11) and single-file metrics
(T12, T13, T14, T15).  Profile-load failure has the largest single-PR
site count remaining: 7 closed values on one metric.

Adding a new site historically meant one-line edit at one location
with no compiler help.  After this PR, adding a new site requires
extending `Profile_load_failure_site.t` and re-running every emit
through the compiler.

## Approach

```ocaml
(* lib/keeper/profile_load_failure_site.ml *)
type t =
  | Personas_root
  | Personas_dirs_resolve
  | Toml_skip
  | Toml_fallback
  | Load_persona_extended
  | Agent_md_read
  | List_persona_summaries

val to_label : t -> string
```

Wire format byte-equal.

## Test plan

- [ ] CI green
- [ ] `rg '"site", "(personas_root|personas_dirs_resolve|toml_skip|toml_fallback|load_persona_extended|agent_md_read|list_persona_summaries)"' lib/keeper/keeper_types_profile.ml` = 0

RFC-WAIVED: not in credential/identity/operator/sandbox/hooks/workflow scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)