### PR TITLE
spec(kct): document cascade-name role abstraction — R-C-3.c + R-S2.c

### DIFF
--- a/specs/INDEX.md
+++ b/specs/INDEX.md
@@ -5,7 +5,7 @@ Edit the generator, not this file. Re-run: scripts/gen-tla-index.sh > specs/INDE
 
 # TLA+ Spec Index
 
-Generated: 2026-05-11T20:26:07Z (HEAD: 63dceb726)
+Generated: 2026-05-11T20:35:57Z (HEAD: 0eeb7660c)
 
 Source of truth: `specs/`. Run `scripts/gen-tla-index.sh > specs/INDEX.md` to refresh.
 
@@ -127,7 +127,7 @@ Source of truth: `specs/`. Run `scripts/gen-tla-index.sh > specs/INDEX.md` to re
 | KeeperCompositeLifecycle.tla | KeeperCompositeLifecycle | manual | 5 | 4 | clean={inv:SafetyInvariant, prop:EventualMeasurementResolves, prop:RecoveryEventuallyCompletes, prop:OverflowedEventuallyResolves} buggy-attempt={inv:ToolSurfaceFeedsAttempt} buggy-cascade={inv:NoCascadeBeforeMeasurement} buggy-compaction={inv:CompactionAtomicity, inv:PhaseTurnAlignment} buggy-post-turn={inv:PostTurnConsumesAttempt} | 36530914cd50 |
 | KeeperConditionsGovernPhase.tla | KeeperConditionsGovernPhase | manual | 2 | 1 | clean={inv:Safety, prop:HandoffEventuallyAcknowledged} buggy={inv:TypeOK, prop:HandoffEventuallyAcknowledged} | 191c247c0f8c |
 | KeeperContextLifecycle.tla | KeeperContextLifecycle | manual | 4 | 2 | clean={inv:TypeOK, inv:ContextIsolation, inv:ResumeIdentity, inv:TurnMonotonicity, inv:CompactionPairIntegrity, inv:CheckpointConsistency, inv:BudgetAfterCompaction, prop:CompactionProgress, prop:EventualTurnCompletion, prop:AllKeepersTerminate} buggy={inv:TypeOK, inv:ContextIsolation, inv:ResumeIdentity, inv:TurnMonotonicity, inv:CompactionPairIntegrity, inv:CheckpointConsistency, inv:BudgetAfterCompaction} ci-buggy={inv:ContextIsolation, inv:ResumeIdentity} ci={inv:TypeOK, inv:ContextIsolation, inv:ResumeIdentity, inv:TurnMonotonicity, inv:CompactionPairIntegrity, inv:CheckpointConsistency, inv:BudgetAfterCompaction} | e7d6cf456c70 |
-| KeeperCoreTriad.tla | KeeperCoreTriad | manual | 2 | 1 | clean={inv:SafetyInvariant, prop:RunningEventuallyCompletes CapabilityNeverDeadlocks} buggy={inv:SafetyInvariant} | 99cff8619b65 |
+| KeeperCoreTriad.tla | KeeperCoreTriad | manual | 2 | 1 | clean={inv:SafetyInvariant, prop:RunningEventuallyCompletes CapabilityNeverDeadlocks} buggy={inv:SafetyInvariant} | 040df2f64d84 |
 | KeeperCounterCausality.tla | KeeperCounterCausality | manual | 2 | 1 | clean={inv:Safety} buggy={inv:CausePresentWhenCounted} | 531942a050de |
 | KeeperDecisionPipeline.tla | KeeperDecisionPipeline | manual | 4 | 2 | clean={inv:TypeOK, inv:Safety, prop:Liveness} buggy={inv:DecisionBoundaryRequiresMeasurement} cap2-buggy={inv:DecisionBoundaryRequiresMeasurement} cap2={inv:TypeOK, inv:ToolSetNeverEmpty, inv:RecoveryFloorMaintained, prop:FailingEventuallyRecovers} | 1fa85b795cb7 |
 | KeeperDwellMonotone.tla | KeeperDwellMonotone | manual | 2 | 1 | clean={inv:Safety} buggy={inv:DwellNonNegative} | c9d0a52acb27 |

--- a/specs/INDEX.md
+++ b/specs/INDEX.md
@@ -5,7 +5,7 @@ Edit the generator, not this file. Re-run: scripts/gen-tla-index.sh > specs/INDE
 
 # TLA+ Spec Index
 
-Generated: 2026-05-11T20:35:57Z (HEAD: 0eeb7660c)
+Generated: 2026-05-11T20:36:25Z (HEAD: ba20343d1)
 
 Source of truth: `specs/`. Run `scripts/gen-tla-index.sh > specs/INDEX.md` to refresh.
 

--- a/specs/keeper-state-machine/KeeperCoreTriad.tla
+++ b/specs/keeper-state-machine/KeeperCoreTriad.tla
@@ -365,19 +365,29 @@ Spec == Init /\ [][Next]_vars /\ WF_vars(Next)
 \*
 \* On the OCaml side (`lib/keeper/keeper_cascade_routing.ml` +
 \* `lib/cascade/cascade_routes.ml`), cascade names are resolved through a
-\* typed `logical_use` enum (`Phase_recovery`, `Phase_buffer`) →
-\* `cascade_name_for_use` → catalog/route lookup → first-alias fallback.
+\* typed `logical_use` enum (`Phase_recovery`, `Phase_buffer`) and a
+\* prioritised resolution chain in `cascade_name_for_use`:
+\*   (a) operator-supplied `routes.<key>` binding, if its target exists
+\*       in the live catalog;
+\*   (b) first catalog entry name (the boot-time default profile);
+\*   (c) `route_spec.aliases` first element, or the route key — *only*
+\*       when the catalog is empty (a state boot validation rejects).
 \* The literal string produced at runtime depends on operator catalog and
 \* routes (RFC-0058 declarative route mapping); only the *default empty
-\* catalog* boot path produces the literal strings written here.
+\* catalog* boot path produces the literal strings written below.
 \*
-\* These invariants therefore assert ROLE identity, not string equality:
+\* The invariants below are written as TLA+ string equalities, but those
+\* literals should be read as canonical *role identifiers* — they stand
+\* in for the typed `logical_use` role that production resolves through
+\* the chain above:
 \*   - "none"           ↔ "no cascade is active for this turn"
 \*   - "local_recovery" ↔ `Phase_recovery` role
 \*   - "local_only"     ↔ `Phase_buffer` role
+\* TLC still compares strings; the *semantic* claim is role identity.
 \* See `docs/tla-audit/kct-c3-terminal-cascade-contract-gap-2026-05-12.md`
 \* and `docs/tla-audit/kct-s2s3-failing-buffer-cascade-alignment-2026-05-12.md`
-\* for the production indirection analysis.
+\* (the latter lands via PR #14787) for the production indirection
+\* analysis.
 
 \* S1: Terminal phase never has an active cascade.
 \* OCaml note: `select_cascade` returns `base_cascade` for terminal phases

--- a/specs/keeper-state-machine/KeeperCoreTriad.tla
+++ b/specs/keeper-state-machine/KeeperCoreTriad.tla
@@ -357,20 +357,51 @@ Next ==
 Spec == Init /\ [][Next]_vars /\ WF_vars(Next)
 
 \* ── Safety Invariants ────────────────────────────────────
+\*
+\* CASCADE NAME ABSTRACTION (S1/S2/S3-buffer)
+\* ----------------------------------------
+\* The string literals "none", "local_recovery", and "local_only" used below
+\* are SPEC-LEVEL CANONICAL ROLE NAMES, not literal OCaml return values.
+\*
+\* On the OCaml side (`lib/keeper/keeper_cascade_routing.ml` +
+\* `lib/cascade/cascade_routes.ml`), cascade names are resolved through a
+\* typed `logical_use` enum (`Phase_recovery`, `Phase_buffer`) →
+\* `cascade_name_for_use` → catalog/route lookup → first-alias fallback.
+\* The literal string produced at runtime depends on operator catalog and
+\* routes (RFC-0058 declarative route mapping); only the *default empty
+\* catalog* boot path produces the literal strings written here.
+\*
+\* These invariants therefore assert ROLE identity, not string equality:
+\*   - "none"           ↔ "no cascade is active for this turn"
+\*   - "local_recovery" ↔ `Phase_recovery` role
+\*   - "local_only"     ↔ `Phase_buffer` role
+\* See `docs/tla-audit/kct-c3-terminal-cascade-contract-gap-2026-05-12.md`
+\* and `docs/tla-audit/kct-s2s3-failing-buffer-cascade-alignment-2026-05-12.md`
+\* for the production indirection analysis.
 
-\* S1: Terminal phase never has an active cascade
+\* S1: Terminal phase never has an active cascade.
+\* OCaml note: `select_cascade` returns `base_cascade` for terminal phases
+\* (paper contract gap — caller graph upstream-gates the call so the value
+\* is unreachable in production).  See C-3 audit memo above.
 NoTerminalCascade ==
     phase = "Terminal" => effective_cascade = "none"
 
-\* S2: Cascade selection in Failing phase must yield local_recovery.
+\* S2: Cascade selection in Failing phase must yield the Phase_recovery role.
 \* Note: if a keeper transitions to Failing MID-TURN, the already-selected
 \* cascade remains — cascade is chosen at turn start, not re-evaluated.
 \* This invariant checks the selection action, not the runtime state.
+\* OCaml: `Failing -> Keeper_config.local_recovery_cascade_name`, which
+\* resolves through `Phase_recovery` route — string match only in the
+\* default catalog.  See S2/S3 audit memo above.
 FailingUsesRecovery ==
     (phase = "Failing" /\ turn_status = "selecting"
      /\ effective_cascade /= "none") =>
         effective_cascade = "local_recovery"
 
+\* S3 (buffer): Cascade selection in buffer-operation phases must yield
+\* the Phase_buffer role.  OCaml:
+\* `Compacting | HandingOff -> Keeper_config.local_only_cascade_name`,
+\* which resolves through `Phase_buffer` route.  See S2/S3 audit memo.
 BufferOpsUseLocalOnly ==
     (phase \in {"Compacting", "HandingOff"} /\ turn_status = "selecting"
      /\ effective_cascade /= "none") =>


### PR DESCRIPTION
## Finding (Iteration 27, KCT spec hygiene bundle)

**Spec**: `specs/keeper-state-machine/KeeperCoreTriad.tla:359-403`
**OCaml**: `lib/keeper/keeper_cascade_routing.ml:20-25, 32-34`, `lib/keeper/keeper_config.ml:26-33`, `lib/cascade/cascade_routes.ml:64-65, 251-271`
**Aspect**: Apply R-C-3.c + R-S2.c — bundle two LOW-risk doc fixes for the cascade-name string-literal vs OCaml-indirection pattern.
**Risk**: LOW — comments-only spec change, no TLC semantics affected.
**Workaround signature**: N/A — this *closes* the spec-literal hardcode anti-pattern in a doc-honest way (the alternative, forcing OCaml to literal strings, would regress operator-naming flexibility — R-S2.b explicitly rejected as workaround).

## 순서도

```mermaid
flowchart TB
  subgraph Spec [Spec contract — KCT §S1/S2/S3-buffer]
    S1[NoTerminalCascade<br/>'none']
    S2[FailingUsesRecovery<br/>'local_recovery']
    S3[BufferOpsUseLocalOnly<br/>'local_only']
  end
  subgraph Ocaml [OCaml dispatch]
    R1[Terminal → base_cascade]
    R2[Failing → local_recovery_cascade_name]
    R3[Compacting/HandingOff → local_only_cascade_name]
  end
  subgraph Resolution [Name resolution]
    L[Phase_recovery / Phase_buffer typed enum]
    C[catalog/route lookup]
    F[first-alias fallback]
  end
  S1 -.->|paper gap, prod safe| R1
  S2 -.->|role match| R2
  S3 -.->|role match| R3
  R2 --> L --> C --> F
  R3 --> L --> C --> F
  F -->|empty catalog| Lit[literal: 'local_recovery'/'local_only']
  C -->|operator config| Op[operator-named profile]
  Lit -.->|✅ spec literal exact| Spec
  Op -.->|❌ literal mismatch<br/>✅ role identity preserved| Spec
```

## Before / After

```diff
-\* ── Safety Invariants ────────────────────────────────────
+\* ── Safety Invariants ────────────────────────────────────
+\*
+\* CASCADE NAME ABSTRACTION (S1/S2/S3-buffer)
+\* ----------------------------------------
+\* The string literals "none", "local_recovery", and "local_only" used below
+\* are SPEC-LEVEL CANONICAL ROLE NAMES, not literal OCaml return values.
+\* ...
+\* See `docs/tla-audit/kct-c3-...` and `kct-s2s3-...` for analysis.

-\* S1: Terminal phase never has an active cascade
+\* S1: Terminal phase never has an active cascade.
+\* OCaml note: `select_cascade` returns `base_cascade` for terminal phases
+\* (paper contract gap — caller graph upstream-gates the call so the value
+\* is unreachable in production).  See C-3 audit memo above.
 NoTerminalCascade ==
     phase = "Terminal" => effective_cascade = "none"
```

(See full file diff — +34/-3 LOC, comments only.)

## 왜 톱니처럼 정교하지 않은가

C-3 audit (#14783)와 S2/S3 audit (#14787)이 같은 anti-pattern을 잡았다 — spec이 cascade 식별자를 *문자열 리터럴*로 박아두고 OCaml이 typed enum (`logical_use`) → catalog → first-alias로 dynamic 해석하는 indirection layer.  운영자가 catalog profile 이름을 바꾸면 spec 리터럴과 미스매치되지만 role identity (`Phase_recovery` / `Phase_buffer`)는 보존된다.

이 PR은 spec에 명시적 abstraction 주석을 추가하여 *spec literal = canonical role name* 임을 표현.  OCaml dispatch도 함께 인용해서 reader가 indirection을 추적 가능하게 만듦.

대안 (R-S2.b: OCaml literal sentinel) 는 operator-naming flexibility 회귀이므로 거부.  R-C-3.a/R-S2.a (CONSTANT 도입)는 더 큰 spec 리팩터로 후속 PR.

## 본 PR 수정

`specs/keeper-state-machine/KeeperCoreTriad.tla` +34/-3 (comments only):
- Top-of-section commentary block on cascade-name abstraction.
- Per-invariant OCaml dispatch notes for S1/S2/S3-buffer.
- Audit memo cross-references.

## Verification

- [x] TLC clean cfg: 77 distinct states, no errors (unchanged from main).
- [x] TLC buggy cfg: `SafetyInvariant violated` (unchanged — BugAction still triggers).
- [x] Comments-only — no Init/Next/Spec definition change.
- [ ] CI `tla-specs` job re-runs path-scoped — expected pass.

## Trade-off

- 장점: spec reader가 OCaml indirection을 명시적으로 인지.  audit memo cross-reference로 reasoning chain 보존.  TLC 행동 변경 0.
- 단점: invariant *자체*는 여전히 string literal equality 형식.  CONSTANT로 추출하는 R-C-3.a/R-S2.a 가 더 깨끗하지만 cfg 추가 + TLC re-verify scope 확장이라 별도 PR.
- 후속: S5 PhaseDecisionConsistency (line 392-394)도 `"none"` 리터럴 사용.  같은 abstraction 적용 가능하지만 본 PR 범위 외 (S1/S2/S3-buffer 만 처리).

## RFC 참조

`RFC-WAIVED: spec docs-only, no subsystem touched per RFC index.`

연관 audit memos (둘 다 main에 머지됨):
- `docs/tla-audit/kct-c3-terminal-cascade-contract-gap-2026-05-12.md` (#14783)
- `docs/tla-audit/kct-s2s3-failing-buffer-cascade-alignment-2026-05-12.md` (#14787)

연관 RFC: RFC-0058 (declarative route mapping, indirection origin).

## 진행 추적

다음 iteration 시작점: **R-B-1.a** (KTC TurnPhaseSet 확장 — routing/exhausted 추가 + TLC re-verify + baseline 라인 제거) 또는 **R-A-8 PR-2** (KNOWN_FAILURES purge + TLC verify) 또는 **KCT S5 PhaseDecisionConsistency** (같은 cascade abstraction 적용 follow-up).

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>