### PR TITLE
fix(goal_store): make normalize_goal Goal_phase tuple match exhaustive

### DIFF
--- a/lib/goal/goal_store.ml
+++ b/lib/goal/goal_store.ml
@@ -279,9 +279,18 @@ and normalize_goal (goal : goal) =
     goal with
     status = goal_status_of_phase goal.phase;
     active_verification_request_id =
+      (* Enumerate every [Goal_phase.t] variant so the compiler flags any
+         new phase added here. Only [Awaiting_verification] keeps an
+         active verification request_id; all other phases clear it as part
+         of [normalize_goal]. A future phase added to [Goal_phase.t] (e.g.
+         a hypothetical [Awaiting_review]) that should also retain the
+         request_id would silently inherit "clear" under the previous
+         [_, _ -> None] catch-all. *)
       (match goal.phase, goal.active_verification_request_id with
       | Goal_phase.Awaiting_verification, request_id -> request_id
-      | _, _ -> None);
+      | ( Goal_phase.Executing | Goal_phase.Awaiting_approval
+        | Goal_phase.Blocked | Goal_phase.Paused
+        | Goal_phase.Completed | Goal_phase.Dropped ), _ -> None);
   }
 
 and goal_status_of_phase = function


### PR DESCRIPTION
## Why

`normalize_goal` decides whether to keep or clear `active_verification_request_id` based on the goal's phase:

\`\`\`ocaml
match goal.phase, goal.active_verification_request_id with
| Goal_phase.Awaiting_verification, request_id -> request_id
| _, _ -> None
\`\`\`

`Goal_phase.t` has 7 variants today: `Executing | Awaiting_verification | Awaiting_approval | Blocked | Paused | Completed | Dropped`. The `_, _` catch-all silently absorbs the remaining 6 phases — clearing the request_id, which is the correct behavior today.

But a future phase added to `Goal_phase.t` (e.g. a hypothetical `Awaiting_review` that mirrors `Awaiting_verification` for a different verifier tier) would silently inherit "clear request_id" with no review point. Same FSM Sparse Match anti-pattern (`~/me/instructions/software-development.md`) as the closed-sum tuple matches addressed in masc-mcp PR #14716.

## What

\`\`\`ocaml
| Goal_phase.Awaiting_verification, request_id -> request_id
| ( Goal_phase.Executing | Goal_phase.Awaiting_approval
  | Goal_phase.Blocked | Goal_phase.Paused
  | Goal_phase.Completed | Goal_phase.Dropped ), _ -> None
\`\`\`

Behavior unchanged for current 7 phases. Adding an 8th constructor to `Goal_phase.t` will now trigger `Warning 8: this pattern-matching is not exhaustive` at this site, forcing the maintainer to deliberately decide whether the new phase needs to preserve the verification request_id.

A short comment explains *why* the catch-all was the wrong default direction (silent "clear" semantics overrides per-phase intent) so a future reader doesn't reintroduce it.

## Verification

\`\`\`
dune build lib/goal/goal_store.ml --root .   # exit 0
\`\`\`

## Scope

Surgical. One match expression, one file, no behavior change. No `.mli` change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)