### PR TITLE
perf(agent_tool_surfaces): three set-based membership swaps for spawn-time helpers

### DIFF
--- a/lib/agent_tool_surfaces.ml
+++ b/lib/agent_tool_surfaces.ml
@@ -43,6 +43,14 @@ let dedupe_schemas (schemas : Masc_domain.tool_schema list) =
 let prefixed_tool_names names =
   names |> List.map (fun name -> "mcp__masc__" ^ name)
 
+(* Hashtbl materialisation helper for membership-only checks.  Used
+   below where we'd otherwise scan a name list per element of a
+   filter loop — replaces O(N x M) with O(N + M). *)
+let name_set names =
+  let tbl = Hashtbl.create (List.length names) in
+  List.iter (fun name -> Hashtbl.replace tbl name ()) names;
+  tbl
+
 let lookup_schemas_by_name_exn ~label all_schemas values =
   let requested =
     values
@@ -121,7 +129,7 @@ let local_worker_spawn_schemas : Masc_domain.tool_schema list =
     Tool_schemas_inline_infra.schemas
 
 let select_public_local_worker_schemas () =
-  let wanted = local_worker_public_tool_names in
+  let wanted_set = name_set local_worker_public_tool_names in
   dedupe_schemas
     (Tool_board.tools
     @ Tool_schemas_coord_core.schemas
@@ -132,7 +140,7 @@ let select_public_local_worker_schemas () =
     @ local_worker_run_schemas
     @ local_worker_spawn_schemas)
   |> List.filter (fun (schema : Masc_domain.tool_schema) ->
-         List.mem schema.name wanted)
+         Hashtbl.mem wanted_set schema.name)
 
 let resolve_named_schemas all_schemas values :
     (Masc_domain.tool_schema list, string) Result.t =
@@ -142,19 +150,28 @@ let resolve_named_schemas all_schemas values :
     |> List.filter (fun value -> not (String.equal value ""))
     |> unique_preserve_order
   in
+  (* Materialise both directions of the membership relation once:
+     - [requested_set] for the first filter (per-schema lookup),
+     - [found_set] for the missing-name check (per-requested lookup).
+     Previous shape ran [List.mem] / [List.exists] per element in each
+     filter — O(S x R) and O(R x found) respectively. *)
+  let requested_set = name_set requested in
   let schemas =
     all_schemas
     |> List.filter (fun (schema : Masc_domain.tool_schema) ->
-           List.mem schema.name requested)
+           Hashtbl.mem requested_set schema.name)
+  in
+  let found_set =
+    let tbl = Hashtbl.create (List.length schemas) in
+    List.iter
+      (fun (schema : Masc_domain.tool_schema) ->
+        Hashtbl.replace tbl schema.name ())
+      schemas;
+    tbl
   in
   let missing =
     requested
-    |> List.filter (fun tool_name ->
-           not
-             (List.exists
-                (fun (schema : Masc_domain.tool_schema) ->
-                  String.equal schema.name tool_name)
-                schemas))
+    |> List.filter (fun tool_name -> not (Hashtbl.mem found_set tool_name))
   in
   match missing with [] ->
     Ok schemas
@@ -217,10 +234,10 @@ let build_tool_catalog ~(role : string) () : string list =
     | "coordinator" | "fleet_leader" ->
         filter_catalog_to_available ~available:all_names coordination_tool_names
     | _ ->
-        (* autonomous: all except admin *)
-        List.filter
-          (fun name -> not (List.mem name admin_tool_names))
-          all_names
+        (* autonomous: all except admin.  Replace per-name [List.mem]
+           scan over [admin_tool_names] with O(1) Hashtbl lookup. *)
+        let admin_set = name_set admin_tool_names in
+        List.filter (fun name -> not (Hashtbl.mem admin_set name)) all_names
   in
   unique_preserve_order filtered
 


### PR DESCRIPTION
## Summary

\`lib/agent_tool_surfaces.ml\` had three remaining \`List.mem\`/\`List.exists\` patterns on the spawn-time path. Two other functions in the file (\`lookup_schemas_by_name_exn\` line 53, \`filter_catalog_to_available\` line 196) already used Hashtbl / StringSet — but three sibling helpers had been left as O(N×M):

| Helper | Pattern | Cost |
|--------|---------|------|
| \`select_public_local_worker_schemas\` (line 134) | per-schema \`List.mem schema.name wanted\` | O(S × W) |
| \`resolve_named_schemas\` (lines 147 + 154) | filter + missing-check both linear-scan | O(S × R) + O(R × found) |
| \`build_tool_catalog\` autonomous branch (line 222) | per-name \`List.mem name admin_tool_names\` | O(all × admin) |

All three fire on agent spawn — multiple times for fleet boot.

## Fix

Introduce a private \`name_set : string list -> (string, unit) Hashtbl.t\` at the top of the module:

\`\`\`ocaml
let name_set names =
  let tbl = Hashtbl.create (List.length names) in
  List.iter (fun name -> Hashtbl.replace tbl name ()) names;
  tbl
\`\`\`

Then:

1. **\`select_public_local_worker_schemas\`** — build \`wanted_set\` once, replace \`List.mem\` with \`Hashtbl.mem\`.
2. **\`resolve_named_schemas\`** — materialise *both* directions (\`requested_set\` for the first filter, \`found_set\` for the missing-name check). This kills the worst O(N×M) in the file: the nested \`List.exists\` scan over already-filtered schemas.
3. **\`build_tool_catalog\` autonomous branch** — build \`admin_set\` once, swap \`List.mem\` for \`Hashtbl.mem\`.

## Pattern continuity

This is the **same helper shape** the loop has established in prior PRs:
- #14774 \`required_set\` for OAS schema conversion
- #14780 \`tool_call_name_set\` / \`name_set_of_list\` for benchmark scoring
- #14785 \`mapping_id_set\` for keeper-repo mapping

When the same primitive keeps surfacing, the codebase is asking for a shared utility. \`name_set\` could promote to a common library after a few more occurrences justify the move.

## API preservation

No \`.mli\` changes — \`name_set\` is private to the \`.ml\`. All public entry points (\`select_public_local_worker_schemas\`, \`resolve_named_schemas\`, \`build_tool_catalog\`) keep their existing signatures and behaviour.

## Test plan

- [ ] CI lib/ build green
- [ ] \`dune runtest test/test_agent_tool_surfaces.exe\` (if present) passes
- [ ] Smoke: agent spawn for worker / coordinator / autonomous roles returns the same tool sets

🤖 Generated with [Claude Code](https://claude.com/claude-code)