### PR TITLE
spec(ktc): extend TurnPhaseSet — routing + exhausted (R-B-1.a)

### DIFF
--- a/scripts/tla-annotation-drift-baseline.txt
+++ b/scripts/tla-annotation-drift-baseline.txt
@@ -15,12 +15,12 @@
 #   - PR #14770 (validator script, iter 20)
 #   - PR #14767 (KTC B-1 audit memo)
 
-# R-B-1.a pending: TLA+ §TurnPhaseSet missing `routing` member.
-# OCaml admission: lib/keeper/keeper_registry.ml:168-172.
-# Source: PR #14395 (added Turn_routing/Turn_exhausted to OCaml without
-# spec update).
-turn_phase:turn_routing
-
-# R-B-1.a pending: TLA+ §TurnPhaseSet missing `exhausted` member.
-# Same source as above.
-turn_phase:turn_exhausted
+# (Baseline currently empty.)
+#
+# R-B-1.a landed in iter 28 (this PR): KTC TurnPhaseSet extended to
+# include `routing` and `exhausted`.  Both prior baseline entries
+# removed.  CI now enforces zero turn_phase drift going forward.
+#
+# Per-action transition modeling for routing/exhausted is intentionally
+# deferred — see B-2 follow-up audit
+# (`docs/tla-audit/ktc-b1-turn-phase-spec-gap-2026-05-12.md`).

--- a/specs/INDEX.md
+++ b/specs/INDEX.md
@@ -5,7 +5,7 @@ Edit the generator, not this file. Re-run: scripts/gen-tla-index.sh > specs/INDE
 
 # TLA+ Spec Index
 
-Generated: 2026-05-11T19:36:25Z (HEAD: 1e673193a)
+Generated: 2026-05-11T20:16:36Z (HEAD: 8b3d41e4f)
 
 Source of truth: `specs/`. Run `scripts/gen-tla-index.sh > specs/INDEX.md` to refresh.
 
@@ -147,7 +147,7 @@ Source of truth: `specs/`. Run `scripts/gen-tla-index.sh > specs/INDEX.md` to re
 | KeeperTaskAcquisition.tla | KeeperTaskAcquisition | manual | 2 | 1 | clean={inv:TypeOK, inv:SafetyInvariant} buggy={inv:TypeOK, inv:SafetyInvariant} | dacc5ab9bbfc |
 | KeeperToolSurface.tla | KeeperToolSurface | manual | 2 | 1 | clean={inv:SafetyInvariant} buggy={inv:SafetyInvariant} | 0a1193720c81 |
 | KeeperTraceSpec.tla | KeeperTraceSpec | manual | 2 | 1 | clean={inv:TypeOK, inv:RunningRequiresFiber, inv:OfflineRequiresLaunchPending, inv:StoppedRequiresDrain, inv:DeadRequiresNoBudget, inv:DerivePhaseAgreement, prop:RestartCountMonotonic, prop:BudgetNeverRevives, prop:TransitionMatrixAgreement} buggy={inv:TypeOK, inv:DerivePhaseAgreementMustHold} | 733248761720 |
-| KeeperTurnCycle.tla | KeeperTurnCycle | manual | 2 | 1 | clean={inv:TypeOK, inv:Safety, prop:Liveness} buggy={inv:SelectingRequiresToolPolicyMustHold} | 10f382232724 |
+| KeeperTurnCycle.tla | KeeperTurnCycle | manual | 2 | 1 | clean={inv:TypeOK, inv:Safety, prop:Liveness} buggy={inv:SelectingRequiresToolPolicyMustHold} | c5ab5611bf0b |
 | KeeperTurnSlot.tla | KeeperTurnSlot | manual | 2 | 1 | clean={inv:Safety} buggy={inv:RetryPhaseRequiresReleased} | f75c324a95fe |
 | KeeperWorkPipeline.tla | KeeperWorkPipeline | manual | 1 | 0 | clean={inv:TypeOK, inv:WorkspaceAlwaysBounded, inv:IdentityConsistent, inv:NoForcePush, inv:ReviewBeforeSubmit, prop:EventualCompletion, prop:NoOrphanWorkspace} | ab03a79d78e6 |
 | OperatorPauseBroadcast.tla | OperatorPauseBroadcast | manual | 2 | 1 | clean={inv:TypeOK, inv:EmittedBeforeResolved, prop:PauseLeadsToBroadcast, prop:OperatorPauseEverHandled} buggy={inv:TypeOK, prop:PauseLeadsToBroadcast} | 2ef619cbcd73 |

--- a/specs/keeper-state-machine/KeeperTurnCycle.tla
+++ b/specs/keeper-state-machine/KeeperTurnCycle.tla
@@ -6,7 +6,8 @@
 (* stores in [Keeper_registry.current_turn_observation]. It is not the old *)
 (* "tool_call/side_effect/done" linear storyboard; the current runtime is  *)
 (* a 3-axis machine:                                                        *)
-(*   - turn_phase      : prompting | executing | compacting | finalizing   *)
+(*   - turn_phase      : prompting | routing | executing | compacting |    *)
+(*                       finalizing | exhausted                            *)
 (*   - decision_stage  : undecided | guard_ok | gate_rejected |            *)
 (*                       tool_policy_selected                              *)
 (*   - cascade_state   : idle | selecting | trying | done | exhausted      *)
@@ -107,7 +108,24 @@ vars ==
     << turn_live, turn_phase, decision_stage, cascade_state,
        measurement_bound, selected_model_bound >>
 
-TurnPhaseSet == {"idle", "prompting", "executing", "compacting", "finalizing"}
+\* TurnPhaseSet: phase membership type.
+\*
+\* R-B-1.a (iter 28, 2026-05-12): `routing` and `exhausted` added to close
+\* the spec drift identified by `audit-tla-annotation-drift.sh`.  OCaml has
+\* carried these since PR #14395 (Turn_routing active + Turn_exhausted
+\* terminal).  This commit extends the type widening only; per-action
+\* transition modeling (e.g. RoutingStart, RoutingExhausted, retry pumps
+\* through routing) is intentionally deferred — see B-2 follow-up audit
+\* (`docs/tla-audit/ktc-b1-turn-phase-spec-gap-2026-05-12.md`).
+\*
+\* The wider set keeps TypeOK total (every OCaml turn_phase is now
+\* spec-typable) without altering the reachable state graph: Init pins
+\* `turn_phase = "idle"` and no existing action transitions into routing
+\* or exhausted, so TLC clean+buggy state counts are unchanged.  The
+\* cross-axis invariants (SelectingRequiresToolPolicy etc.) are
+\* conditional on specific phase membership and are not affected.
+TurnPhaseSet == {"idle", "prompting", "routing", "executing",
+                 "compacting", "finalizing", "exhausted"}
 DecisionSet  == {"undecided", "guard_ok", "gate_rejected", "tool_policy_selected"}
 CascadeSet   == {"idle", "selecting", "trying", "done", "exhausted"}
 ActionSet    == {


### PR DESCRIPTION
## Finding (Iteration 28, R-B-1.a closure)

**Spec**: `specs/keeper-state-machine/KeeperTurnCycle.tla:110` (TurnPhaseSet)
**OCaml**: `lib/keeper/keeper_registry.ml:161-225` (Turn_routing/Turn_exhausted)
**Aspect**: KTC `TurnPhaseSet` extended from 5 to 7 members to close iter 19 B-1 audit drift.
**Risk**: LOW — type widening only, no action transitions added, TLC reachable state graph unchanged.
**Workaround signature**: N/A — this *closes* a real spec drift (audit→tool→CI chain culmination).

## 순서도

```mermaid
flowchart LR
  subgraph Before [TurnPhaseSet — 5 members]
    A[idle]
    B[prompting]
    C[executing]
    D[compacting]
    E[finalizing]
  end
  subgraph After [TurnPhaseSet — 7 members]
    A2[idle]
    B2[prompting]
    R2[routing<br/>+ NEW]
    C2[executing]
    D2[compacting]
    E2[finalizing]
    X2[exhausted<br/>+ NEW]
  end
  subgraph Ocaml [OCaml turn_phase 7 constructors]
    O1[Turn_idle]
    O2[Turn_prompting]
    OR[Turn_routing @tla.active]
    O3[Turn_executing]
    O4[Turn_compacting]
    O5[Turn_finalizing]
    OX[Turn_exhausted @tla.terminal]
  end
  Before -.->|R-B-1.a iter 28 widens| After
  After ===|exact 7/7 match| Ocaml
```

## Why type widening is safe

- `Init` pins `turn_phase = "idle"` → entry point unchanged.
- No existing action (StartTurn, BindMeasurement, …) transitions *into* routing or exhausted.  So reachable states from `Init` remain the same 10 distinct states.
- TypeOK requires `turn_phase \in TurnPhaseSet`.  Widening keeps every reachable value typable.  No regression.
- Cross-axis invariants (SelectingRequiresToolPolicy, ExecutingRequiresTrying, CompactingRequiresTrying, TerminalCascadeRequiresFinalizing) are *conditional* on specific phase membership — `phase = "executing"` etc. — and are not weakened by extra members the spec can never reach.

## 왜 톱니처럼 정교하지 않은가 (closure narrative)

**iter 19** (#14767, B-1 audit) → identified that OCaml `Turn_routing`/`Turn_exhausted` were added in PR #14395 without spec sync. 5 of 7 OCaml phases modeled.

**iter 20** (#14770, R-B-1.c) → wrote `scripts/audit-tla-annotation-drift.sh`: bash+rg+awk static cross-check that catches this class of drift compiler-wise.  Validator correctly reported exactly 2 drifts on current tree.

**iter 21** (#14772, R-B-1.c CI) → added `--baseline` flag + GitHub Actions workflow.  Baseline file listed the 2 known drifts pending this exact landing.

**iter 28** (this PR) → spec widening + paired baseline removal.  CI now enforces zero turn_phase drift going forward.

Per-action transitions (RoutingStart, RoutingExhausted, retry pumps through routing) are intentionally deferred to **B-2** — that's modeling work, not type-system work.

## Before / After

```diff
-TurnPhaseSet == {"idle", "prompting", "executing", "compacting", "finalizing"}
+TurnPhaseSet == {"idle", "prompting", "routing", "executing",
+                 "compacting", "finalizing", "exhausted"}
```

```diff
-# R-B-1.a pending: TLA+ §TurnPhaseSet missing `routing` member.
-turn_phase:turn_routing
-
-# R-B-1.a pending: TLA+ §TurnPhaseSet missing `exhausted` member.
-turn_phase:turn_exhausted
+# (Baseline currently empty.)
+# R-B-1.a landed in iter 28 (this PR): ...
```

## Verification

- [x] TLC clean cfg: 10 distinct states, no errors (unchanged from main).
- [x] TLC buggy cfg: `SelectingRequiresToolPolicyMustHold` violated (unchanged — BugAction unaffected).
- [x] `bash scripts/audit-tla-annotation-drift.sh --baseline ...`: `16 constructors checked across 3 type/set pairs, 0 new drift(s), 0 baseline-known drift(s)`.
- [ ] CI `tla-specs` job (path-scoped trigger).
- [ ] CI `tla-annotation-drift` workflow (from iter 21).

## Trade-off

- 장점: 1-line type extension closes 2 baseline drifts.  CI now enforces zero turn_phase drift compiler-wise.  3-PR audit→tool→CI chain converges with measurable outcome.
- 단점: routing/exhausted으로의 *action transitions* 가 spec에 아직 없음 — `Init`+기존 actions만으로는 새 phase 도달 불가.  Cross-axis invariants가 새 phase 위에서 corruption 못 잡음 (audit memo 발견 그대로).  B-2에서 action modeling 필요.

## RFC 참조

`RFC-WAIVED: spec extension only, no subsystem touched per RFC index.`

연관:
- `docs/tla-audit/ktc-b1-turn-phase-spec-gap-2026-05-12.md` (iter 19 audit)
- PR #14770 (validator script)
- PR #14772 (CI workflow + baseline)
- PR #14395 (OCaml original add — predates spec sync)

## 진행 추적

다음 iteration 시작점: **B-2** (RoutingStart / RoutingExhausted 등 action modeling) 또는 **R-A-8 PR-2** (KNOWN_FAILURES purge + TLC verify) 또는 **KCT S5 PhaseDecisionConsistency** (iter 27 spec-doc abstraction follow-up).

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>