### PR TITLE
spec(kct): document S5 cascade-name abstraction — RFC-S5.c

### DIFF
--- a/specs/INDEX.md
+++ b/specs/INDEX.md
@@ -5,7 +5,7 @@ Edit the generator, not this file. Re-run: scripts/gen-tla-index.sh > specs/INDE
 
 # TLA+ Spec Index
 
-Generated: 2026-05-11T20:16:36Z (HEAD: 8b3d41e4f)
+Generated: 2026-05-11T20:26:07Z (HEAD: 63dceb726)
 
 Source of truth: `specs/`. Run `scripts/gen-tla-index.sh > specs/INDEX.md` to refresh.
 
@@ -127,7 +127,7 @@ Source of truth: `specs/`. Run `scripts/gen-tla-index.sh > specs/INDEX.md` to re
 | KeeperCompositeLifecycle.tla | KeeperCompositeLifecycle | manual | 5 | 4 | clean={inv:SafetyInvariant, prop:EventualMeasurementResolves, prop:RecoveryEventuallyCompletes, prop:OverflowedEventuallyResolves} buggy-attempt={inv:ToolSurfaceFeedsAttempt} buggy-cascade={inv:NoCascadeBeforeMeasurement} buggy-compaction={inv:CompactionAtomicity, inv:PhaseTurnAlignment} buggy-post-turn={inv:PostTurnConsumesAttempt} | 36530914cd50 |
 | KeeperConditionsGovernPhase.tla | KeeperConditionsGovernPhase | manual | 2 | 1 | clean={inv:Safety, prop:HandoffEventuallyAcknowledged} buggy={inv:TypeOK, prop:HandoffEventuallyAcknowledged} | 191c247c0f8c |
 | KeeperContextLifecycle.tla | KeeperContextLifecycle | manual | 4 | 2 | clean={inv:TypeOK, inv:ContextIsolation, inv:ResumeIdentity, inv:TurnMonotonicity, inv:CompactionPairIntegrity, inv:CheckpointConsistency, inv:BudgetAfterCompaction, prop:CompactionProgress, prop:EventualTurnCompletion, prop:AllKeepersTerminate} buggy={inv:TypeOK, inv:ContextIsolation, inv:ResumeIdentity, inv:TurnMonotonicity, inv:CompactionPairIntegrity, inv:CheckpointConsistency, inv:BudgetAfterCompaction} ci-buggy={inv:ContextIsolation, inv:ResumeIdentity} ci={inv:TypeOK, inv:ContextIsolation, inv:ResumeIdentity, inv:TurnMonotonicity, inv:CompactionPairIntegrity, inv:CheckpointConsistency, inv:BudgetAfterCompaction} | e7d6cf456c70 |
-| KeeperCoreTriad.tla | KeeperCoreTriad | manual | 2 | 1 | clean={inv:SafetyInvariant, prop:RunningEventuallyCompletes CapabilityNeverDeadlocks} buggy={inv:SafetyInvariant} | f2385a52bc7f |
+| KeeperCoreTriad.tla | KeeperCoreTriad | manual | 2 | 1 | clean={inv:SafetyInvariant, prop:RunningEventuallyCompletes CapabilityNeverDeadlocks} buggy={inv:SafetyInvariant} | 99cff8619b65 |
 | KeeperCounterCausality.tla | KeeperCounterCausality | manual | 2 | 1 | clean={inv:Safety} buggy={inv:CausePresentWhenCounted} | 531942a050de |
 | KeeperDecisionPipeline.tla | KeeperDecisionPipeline | manual | 4 | 2 | clean={inv:TypeOK, inv:Safety, prop:Liveness} buggy={inv:DecisionBoundaryRequiresMeasurement} cap2-buggy={inv:DecisionBoundaryRequiresMeasurement} cap2={inv:TypeOK, inv:ToolSetNeverEmpty, inv:RecoveryFloorMaintained, prop:FailingEventuallyRecovers} | 1fa85b795cb7 |
 | KeeperDwellMonotone.tla | KeeperDwellMonotone | manual | 2 | 1 | clean={inv:Safety} buggy={inv:DwellNonNegative} | c9d0a52acb27 |

--- a/specs/keeper-state-machine/KeeperCoreTriad.tla
+++ b/specs/keeper-state-machine/KeeperCoreTriad.tla
@@ -388,7 +388,22 @@ SideEffectContainment ==
     \* i.e., if side_effect is TRUE, outcome is never plain "error"
     \* it must be "partial_commit" instead
 
-\* S5: Active turn has a cascade selected
+\* S5: Active turn has a cascade selected.
+\*
+\* Cascade-name abstraction: `"none"` here is the SPEC-LEVEL EMPTY-ROLE
+\* SENTINEL — it asserts "no cascade is selected", not a literal string
+\* match against an OCaml return value.  The OCaml side has no literal
+\* "none" — `select_cascade` always returns a real cascade name (even for
+\* terminal phases — see `docs/tla-audit/kct-c3-terminal-cascade-contract
+\* -gap-2026-05-12.md`); the empty-role assertion is preserved
+\* STRUCTURALLY by the caller graph upstream gating the call for non-
+\* active turn_status values.
+\*
+\* The invariant therefore captures a structural property: the dispatch
+\* table in `lib/keeper/keeper_cascade_routing.ml` returns a non-empty
+\* cascade name for all phases that can co-occur with
+\* turn_status in {selecting, executing, retrying}, namely
+\* {Running, Failing, Compacting, HandingOff}.
 PhaseDecisionConsistency ==
     turn_status \in {"selecting", "executing", "retrying"} =>
         effective_cascade /= "none"


### PR DESCRIPTION
## Finding (Iteration 29, KCT S5 abstraction follow-up)

**Spec**: `specs/keeper-state-machine/KeeperCoreTriad.tla:391-394` (PhaseDecisionConsistency)
**OCaml**: `lib/keeper/keeper_cascade_routing.ml` (dispatch table, all branches return non-empty cascade name)
**Aspect**: S5 uses `"none"` empty-role sentinel; OCaml has no literal `"none"`.  Document structural caller-graph preservation.
**Risk**: LOW — comments-only spec change, TLC clean/buggy both unchanged.
**Workaround signature**: N/A — completes the abstraction-comment family started in iter 27 (#14789 still Draft).

## Why now (pattern closure)

The `"none"` cascade literal appears in **4 KCT invariants**:

| Invariant | Use of `"none"` | Status |
|---|---|---|
| S1 NoTerminalCascade | terminal => `= "none"` (equality assertion) | iter 27 #14789 (Draft) |
| S2 FailingUsesRecovery | `effective_cascade /= "none"` (precondition) | iter 27 #14789 (Draft) |
| S3 BufferOpsUseLocalOnly | `effective_cascade /= "none"` (precondition) | iter 27 #14789 (Draft) |
| **S5 PhaseDecisionConsistency** | active turn => `/= "none"` (non-emptiness) | **this PR (iter 29)** |

iter 27 covered S1/S2/S3-buffer in one bundle (literal-equality + precondition guards).  S5 was deliberately deferred ("같은 abstraction 적용 가능하지만 본 PR 범위 외").  This PR completes the family.

## 순서도

```mermaid
flowchart LR
  subgraph S5spec [KCT §S5]
    A[turn_status ∈ selecting,executing,retrying]
    B[effective_cascade /= 'none']
    A --> B
  end
  subgraph Caller [Caller graph — keeper_unified_turn.ml]
    C[turn_status enters active set]
    D[phase ∈ Running, Failing, Compacting, HandingOff]
    C --> D
  end
  subgraph Dispatch [keeper_cascade_routing.ml]
    E[Running → base_cascade]
    F[Failing → local_recovery_cascade_name]
    G[Compacting/HandingOff → local_only_cascade_name]
  end
  D --> Dispatch
  Dispatch -.->|all non-empty| B
```

Structural caller-graph argument: turn_status only enters the active set for phases that the OCaml dispatch maps to non-empty cascade names → S5 holds without any OCaml-side string equality check.

## Before / After

```diff
-\* S5: Active turn has a cascade selected
+\* S5: Active turn has a cascade selected.
+\*
+\* Cascade-name abstraction: `"none"` here is the SPEC-LEVEL EMPTY-ROLE
+\* SENTINEL — it asserts "no cascade is selected", not a literal string
+\* match against an OCaml return value.  The OCaml side has no literal
+\* "none" — `select_cascade` always returns a real cascade name (even
+\* for terminal phases — see kct-c3-... audit memo); the empty-role
+\* assertion is preserved STRUCTURALLY by the caller graph upstream
+\* gating the call for non-active turn_status values.
+\* ...
 PhaseDecisionConsistency ==
     turn_status \in {"selecting", "executing", "retrying"} =>
         effective_cascade /= "none"
```

## 왜 톱니처럼 정교하지 않은가

S5의 `"none"` 리터럴은 S1의 `= "none"` (equality) 와 S2/S3-buffer의 `/= "none"` (precondition guard) 와 함께 같은 abstraction 패턴 family.  iter 27이 3개를 묶었고, S5만 미적용 상태로 남으면 reader가 "왜 S5만 다른 처리?" 의문을 갖게 됨.  단일 spec 안에서 동일 anti-pattern의 instance를 모두 같은 방식으로 처리하는게 일관성 측면에서 옳음.

## 본 PR 수정

`specs/keeper-state-machine/KeeperCoreTriad.tla` +16/-1 (comments only) — S5 invariant 위에 cascade-name abstraction 주석 + structural caller-graph argument 추가.  C-3 audit memo cross-reference로 reasoning chain 보존.

## Verification

- [x] TLC clean cfg: 77 distinct states, no errors (unchanged from main).
- [x] TLC buggy cfg: `SafetyInvariant violated` (unchanged — BugAction still triggers).
- [x] Comments-only — no semantic change.

## Trade-off

- 장점: 4개 invariants 모두 abstraction 주석 family 완성.  S1/S5의 다른 형태 (`equality` vs `non-emptiness`)도 같은 caller-graph argument 위에서 정합.
- 단점: iter 27 (#14789) 가 아직 Draft 상태 — 그게 먼저 머지되면 이 PR rebase 필요할 수 있으나 disjoint line range (391-394 vs 359-377)이라 trivial.

## RFC 참조

`RFC-WAIVED: spec docs-only, no subsystem touched per RFC index.`

연관:
- PR #14789 (iter 27 R-C-3.c + R-S2.c bundle, S1/S2/S3-buffer) — Draft
- `docs/tla-audit/kct-c3-terminal-cascade-contract-gap-2026-05-12.md` (#14783) merged
- `docs/tla-audit/kct-s2s3-failing-buffer-cascade-alignment-2026-05-12.md` (#14787) merged

## 진행 추적

다음 iteration 시작점: **B-2** (RoutingStart/RoutingExhausted action modeling — needs careful state-machine design, may run >10min — fallback to audit memo) OR **R-A-8 PR-2** (KNOWN_FAILURES purge — multi-iteration TLC verification) OR **KCAF D-1** (6-phase attempt FSM, new spec entry).

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>