### PR TITLE
feat(telemetry): typed Checkpoint_failure_operation variant

### DIFF
--- a/lib/keeper/checkpoint_failure_operation.ml
+++ b/lib/keeper/checkpoint_failure_operation.ml
@@ -1,0 +1,18 @@
+type t =
+  | Migrate_main_history
+  | Migrate_internal_history
+  | Oas_parse
+  | Oas_store
+  | Oas_io
+  | Oas_sdk
+  | Load_legacy
+
+let to_label = function
+  | Migrate_main_history -> "migrate_main_history"
+  | Migrate_internal_history -> "migrate_internal_history"
+  | Oas_parse -> "oas_parse"
+  | Oas_store -> "oas_store"
+  | Oas_io -> "oas_io"
+  | Oas_sdk -> "oas_sdk"
+  | Load_legacy -> "load_legacy"
+;;

--- a/lib/keeper/checkpoint_failure_operation.mli
+++ b/lib/keeper/checkpoint_failure_operation.mli
@@ -1,0 +1,17 @@
+(** Checkpoint_failure_operation — closed sum for the [operation] label
+    on [metric_keeper_checkpoint_failures].
+
+    Replaces 7 hardcoded literals scattered across 7 emit sites in
+    [keeper_context_core.ml].  Each value names a distinct
+    checkpoint-related failure mode in keeper context loading/saving. *)
+
+type t =
+  | Migrate_main_history (** Legacy → current main-history schema migration. *)
+  | Migrate_internal_history (** Legacy → current internal-history schema migration. *)
+  | Oas_parse (** Parse failure on OAS checkpoint payload. *)
+  | Oas_store (** OAS checkpoint store write failure. *)
+  | Oas_io (** Generic OAS checkpoint I/O failure. *)
+  | Oas_sdk (** OAS SDK-level checkpoint error. *)
+  | Load_legacy (** Legacy checkpoint format load failure. *)
+
+val to_label : t -> string

--- a/lib/keeper/keeper_context_core.ml
+++ b/lib/keeper/keeper_context_core.ml
@@ -781,7 +781,7 @@ let migrate_session_history_logs
        | Error detail ->
            Prometheus.inc_counter
              Keeper_metrics.metric_keeper_checkpoint_failures
-             ~labels:[("operation", "migrate_main_history")]
+             ~labels:[("operation", Checkpoint_failure_operation.(to_label Migrate_main_history))]
              ();
            Log.Keeper.error "migrate_session_history_logs: save main history failed for %s: %s"
              main_path detail);
@@ -793,7 +793,7 @@ let migrate_session_history_logs
        | Error detail ->
            Prometheus.inc_counter
              Keeper_metrics.metric_keeper_checkpoint_failures
-             ~labels:[("operation", "migrate_internal_history")]
+             ~labels:[("operation", Checkpoint_failure_operation.(to_label Migrate_internal_history))]
              ();
            Log.Keeper.error "migrate_session_history_logs: save internal history failed for %s: %s"
              internal_path detail);
@@ -1346,25 +1346,25 @@ let load_context_from_checkpoint ~max_checkpoint_messages ~trace_id ~primary_mod
    | Error (Parse_error detail) ->
        Prometheus.inc_counter
          Keeper_metrics.metric_keeper_checkpoint_failures
-         ~labels:[("operation", "oas_parse")]
+         ~labels:[("operation", Checkpoint_failure_operation.(to_label Oas_parse))]
          ();
        Log.Keeper.error "keeper:%s OAS checkpoint parse error: %s" trace_id detail
    | Error (Store_error detail) ->
        Prometheus.inc_counter
          Keeper_metrics.metric_keeper_checkpoint_failures
-         ~labels:[("operation", "oas_store")]
+         ~labels:[("operation", Checkpoint_failure_operation.(to_label Oas_store))]
          ();
        Log.Keeper.error "keeper:%s OAS checkpoint store error: %s" trace_id detail
    | Error (Io_error detail) ->
        Prometheus.inc_counter
          Keeper_metrics.metric_keeper_checkpoint_failures
-         ~labels:[("operation", "oas_io")]
+         ~labels:[("operation", Checkpoint_failure_operation.(to_label Oas_io))]
          ();
        Log.Keeper.error "keeper:%s OAS checkpoint I/O error: %s" trace_id detail
    | Error (Sdk_other_error detail) ->
        Prometheus.inc_counter
          Keeper_metrics.metric_keeper_checkpoint_failures
-         ~labels:[("operation", "oas_sdk")]
+         ~labels:[("operation", Checkpoint_failure_operation.(to_label Oas_sdk))]
          ();
        Log.Keeper.error "keeper:%s OAS checkpoint SDK error: %s" trace_id detail
    | Error Not_found ->
@@ -1382,7 +1382,7 @@ let load_context_from_checkpoint ~max_checkpoint_messages ~trace_id ~primary_mod
     with ex ->
       Prometheus.inc_counter
         Keeper_metrics.metric_keeper_checkpoint_failures
-        ~labels:[("operation", "load_legacy")]
+        ~labels:[("operation", Checkpoint_failure_operation.(to_label Load_legacy))]
         ();
       Log.Keeper.error "keeper:%s checkpoint load failed: %s" trace_id
         (Printexc.to_string ex);


### PR DESCRIPTION
## Summary

7 hardcoded `operation` label literals in `keeper_context_core.ml`
(all on `metric_keeper_checkpoint_failures`) collapsed into closed sum
`Checkpoint_failure_operation.t`.

## Sites (7)

| File:Line | Variant |
|-----------|---------|
| `keeper_context_core.ml:784` | `Migrate_main_history` |
| `keeper_context_core.ml:796` | `Migrate_internal_history` |
| `keeper_context_core.ml:1349` | `Oas_parse` |
| `keeper_context_core.ml:1355` | `Oas_store` |
| `keeper_context_core.ml:1361` | `Oas_io` |
| `keeper_context_core.ml:1367` | `Oas_sdk` |
| `keeper_context_core.ml:1385` | `Load_legacy` |

## Why

Same single-file 7-site cluster as the just-merged #14788
(Profile_load_failure_site).  Both are workaround #2 (string
classifier) patterns: each label is a closed set in spirit but
written as raw literal at each emit site, with no compiler help when
a new operation is added or renamed.

After this PR, adding a new operation requires extending
`Checkpoint_failure_operation.t` and re-running every emit through the
compiler.

## Approach

```ocaml
type t =
  | Migrate_main_history
  | Migrate_internal_history
  | Oas_parse
  | Oas_store
  | Oas_io
  | Oas_sdk
  | Load_legacy

val to_label : t -> string
```

Wire format byte-equal.

## Test plan

- [ ] CI green
- [ ] `rg '"operation", "(migrate_main_history|migrate_internal_history|oas_parse|oas_store|oas_io|oas_sdk|load_legacy)"' lib/keeper/keeper_context_core.ml` = 0

RFC-WAIVED: not in credential/identity/operator/sandbox/hooks/workflow scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)