### PR TITLE
fix(rfc-0070-3b-iv.0): drop Exited exit-code payload (Copilot review, design fix)

### DIFF
--- a/lib/keeper/docker_response.ml
+++ b/lib/keeper/docker_response.ml
@@ -6,7 +6,7 @@ type ps_status =
   | Running
   | Paused
   | Restarting
-  | Exited of { code : int }
+  | Exited
   | Dead
 [@@deriving show, eq]
 
@@ -19,11 +19,7 @@ let parse_state s =
   | "running" -> Ok Running
   | "paused" -> Ok Paused
   | "restarting" -> Ok Restarting
-  | "exited" ->
-    (* Phase 3b-iv.0: bare "exited" — exit code 0 placeholder.
-       Phase 3b-iv.2 will consume the docker-inspect record and
-       supply the real ExitCode. *)
-    Ok (Exited { code = 0 })
+  | "exited" -> Ok Exited
   | "dead" -> Ok Dead
   | _ -> Error (Unknown_state s)
 
@@ -32,7 +28,7 @@ let state_to_string = function
   | Running -> "running"
   | Paused -> "paused"
   | Restarting -> "restarting"
-  | Exited _ -> "exited"
+  | Exited -> "exited"
   | Dead -> "dead"
 
 type exec_result =

--- a/lib/keeper/docker_response.mli
+++ b/lib/keeper/docker_response.mli
@@ -18,6 +18,13 @@
     below; we lift them into a closed sum so callers cannot drift on
     new docker versions without compiler help. *)
 
+(** Six closed states from docker's [State] field.
+
+    Exit code is NOT carried here. The [State] token alone does not
+    convey [ExitCode]; that field arrives via [docker inspect].
+    Phase 3b-iv.2 will introduce a separate [inspect_record] type
+    that pairs [ps_status] with the inspect-only fields
+    ([ExitCode], [StartedAt], [FinishedAt], ...). *)
 type ps_status =
   | Created
   | Running
@@ -26,11 +33,6 @@ type ps_status =
   | Exited
   | Dead
 [@@deriving show, eq]
-(** Exit code is NOT carried here. The [State] token alone does not
-    convey [ExitCode]; that field arrives via [docker inspect].
-    Phase 3b-iv.2 will introduce a separate [inspect_record] type
-    that pairs [ps_status] with the inspect-only fields
-    ([ExitCode], [StartedAt], [FinishedAt], ...). *)
 
 (** Parsing failures for [parse_state]. Closed sum — no catch-all. *)
 type state_parse_error =

--- a/lib/keeper/docker_response.mli
+++ b/lib/keeper/docker_response.mli
@@ -23,9 +23,14 @@ type ps_status =
   | Running
   | Paused
   | Restarting
-  | Exited of { code : int }
+  | Exited
   | Dead
 [@@deriving show, eq]
+(** Exit code is NOT carried here. The [State] token alone does not
+    convey [ExitCode]; that field arrives via [docker inspect].
+    Phase 3b-iv.2 will introduce a separate [inspect_record] type
+    that pairs [ps_status] with the inspect-only fields
+    ([ExitCode], [StartedAt], [FinishedAt], ...). *)
 
 (** Parsing failures for [parse_state]. Closed sum — no catch-all. *)
 type state_parse_error =
@@ -35,23 +40,23 @@ type state_parse_error =
 
 (** [parse_state s] decodes a docker [State] string into the typed
     variant. Pure. The lowercase canonical forms are accepted
-    case-insensitively. [Exited of { code }] requires the caller to
-    supply [code] separately (docker exposes exit code via
-    [ExitCode] / [docker inspect]). For Phase 3b-iv.0 the parser
-    yields [Exited { code = 0 }] on the bare "exited" token; later
-    phases extend the parser to consume the inspect record. *)
+    case-insensitively. The function inspects only the [State] token,
+    so it returns [Exited] without an exit code — callers that need
+    [ExitCode] must consume the inspect record separately (Phase
+    3b-iv.2). *)
 val parse_state : string -> (ps_status, state_parse_error) result
 
-(** [state_to_string s] is the canonical lowercase token. Inverse of
-    [parse_state] for non-Exited variants; Exited's exit code is not
-    encoded in the state token (docker emits separately). *)
+(** [state_to_string s] is the canonical lowercase token. Round-trips
+    through [parse_state] for every variant (no per-variant payload). *)
 val state_to_string : ps_status -> string
 
 (** {1 Exec result}
 
-    What an executed [docker run] or [docker exec] returned to us.
-    Distinct from {!ps_status}: this is per-call result, that is
-    container-lifecycle state. *)
+    [exec_result] is the *per-call result* of an executed [docker run]
+    or [docker exec] — exit code plus captured streams. This is
+    distinct from {!ps_status}, which describes the
+    *container lifecycle state* over time. The two answer different
+    questions: "did this call succeed?" vs "is this container alive?". *)
 
 type exec_result =
   { exit_code : int

--- a/test/test_docker_response.ml
+++ b/test/test_docker_response.ml
@@ -40,8 +40,8 @@ let test_parse_restarting () =
     (Docker_response.parse_state "restarting")
 
 let test_parse_exited () =
-  check (result status_t err_t) "exited → code 0 placeholder"
-    (Ok (Docker_response.Exited { code = 0 }))
+  check (result status_t err_t) "exited (state token only — exit code via inspect, Phase 3b-iv.2)"
+    (Ok Docker_response.Exited)
     (Docker_response.parse_state "exited")
 
 let test_parse_dead () =
@@ -85,14 +85,14 @@ let test_to_string_canonical () =
     (Docker_response.state_to_string Docker_response.Paused);
   check string "Restarting → restarting" "restarting"
     (Docker_response.state_to_string Docker_response.Restarting);
-  check string "Exited → exited (code not encoded in token)" "exited"
-    (Docker_response.state_to_string (Docker_response.Exited { code = 42 }));
+  check string "Exited → exited" "exited"
+    (Docker_response.state_to_string Docker_response.Exited);
   check string "Dead → dead" "dead"
     (Docker_response.state_to_string Docker_response.Dead)
 
-(* ── Round-trip: parse ∘ to_string = id (except Exited code) ─── *)
+(* ── Round-trip: parse ∘ to_string = id (all variants, no per-variant payload) ── *)
 
-let roundtrip_non_exited cases =
+let roundtrip_all cases =
   List.iter
     (fun s ->
       check (result status_t err_t) (Printf.sprintf "round-trip %s" s)
@@ -105,15 +105,15 @@ let roundtrip_non_exited cases =
     cases
 
 let test_roundtrip () =
-  roundtrip_non_exited [ "created"; "running"; "paused"; "restarting"; "dead" ]
+  roundtrip_all [ "created"; "running"; "paused"; "restarting"; "exited"; "dead" ]
 
 (* ── exec_result equality + show ──────────────────────────────── *)
 
-let test_exec_result_equal () =
+let test_exec_result_structural_equality () =
   let a = Docker_response.{ exit_code = 0; stdout = "hi"; stderr = "" } in
   let b = Docker_response.{ exit_code = 0; stdout = "hi"; stderr = "" } in
   let c = Docker_response.{ exit_code = 1; stdout = "hi"; stderr = "" } in
-  check bool "equal reflexive" true (Docker_response.equal_exec_result a b);
+  check bool "structural equality (a ≡ b by field)" true (Docker_response.equal_exec_result a b);
   check bool "exit_code distinguishes" false (Docker_response.equal_exec_result a c)
 
 let () =
@@ -142,7 +142,11 @@ let () =
       ( "canonical form",
         [ test_case "state_to_string canonical" `Quick test_to_string_canonical ] );
       ( "round-trip",
-        [ test_case "parse ∘ to_string = id for non-Exited" `Quick test_roundtrip ] );
+        [ test_case "parse ∘ to_string = id (all variants)" `Quick test_roundtrip ] );
       ( "exec_result",
-        [ test_case "equal + exit_code distinguishes" `Quick test_exec_result_equal ] );
+        [
+          test_case "structural equality + exit_code distinguishes"
+            `Quick
+            test_exec_result_structural_equality;
+        ] );
     ]

--- a/test/test_docker_response.ml
+++ b/test/test_docker_response.ml
@@ -125,7 +125,7 @@ let () =
           test_case "running" `Quick test_parse_running;
           test_case "paused" `Quick test_parse_paused;
           test_case "restarting" `Quick test_parse_restarting;
-          test_case "exited (placeholder code)" `Quick test_parse_exited;
+          test_case "exited (state token only)" `Quick test_parse_exited;
           test_case "dead" `Quick test_parse_dead;
         ] );
       ( "case + whitespace tolerance",


### PR DESCRIPTION
## 목표 — PR #14792 후속 cleanup (4 Copilot threads, design fix)

PR #14792 admin-merge 후 도착한 4 threads 처리. **핵심**: T13/T14의 *silent misrepresentation* design 결함 정정 — `Exited of { code }` payload 제거.

## RFC 인용

| RFC | 관계 |
|-----|------|
| **RFC-0070** | §3.3 — ps_status closed sum 정정 |
| RFC-0006 | cite-only |
| RFC-0036 | cite-only |

## Copilot 4 threads 처리

| Thread | 판정 | 처리 |
|--------|------|------|
| T13 (ml:28) `Exited { code = 0 }` 하드코딩 | **ACCEPT (design fix)** | payload 제거 → bare `Exited`. ExitCode는 Phase 3b-iv.2 inspect_record로 |
| T14 (mli:43) 같은 우려 mli 문서 | **ACCEPT** | mli docstring + variant 정정 |
| T15 (mli:54) exec_result vs ps_status 혼동 | **ACCEPT** | docstring 명확화 ("per-call result" vs "lifecycle state") |
| T16 (test:116) "equal reflexive" 부정확 라벨 | **ACCEPT** | 함수명 `test_exec_result_structural_equality` + 라벨 정정 |

## Design fix 핵심 (T13/T14)

**Before (silent misrepresentation, §AI 안티패턴 §2)**:
```ocaml
| Exited of { code : int }  
parse_state "exited" → Ok (Exited { code = 0 })  (* ← caller가 진짜 exit code로 오인 가능 *)
```

**After (honest absence)**:
```ocaml
| Exited                  
parse_state "exited" → Ok Exited

(* Phase 3b-iv.2 inspect_record type 도입:
   type inspect_record = { state: ps_status; exit_code: int option; ... } *)
```

state 토큰만으로 *진짜 exit code 알 수 없음* → variant payload 제거로 *type에 absent 표현*. Phase 3b-iv.2 시점에 별도 type으로 진짜 ExitCode 운반.

## 변경

```
lib/keeper/docker_response.mli   ±15 (variant + 3 docstring)
lib/keeper/docker_response.ml    ±10 (variant + parse_state + state_to_string)
test/test_docker_response.ml     ±10 (Exited test + roundtrip + label fix)
```

## Round-trip 확장

Round-trip test가 *모든 6 variant* 포함하도록 확장 (이전엔 Exited 제외, payload 때문). 변종 payload 없으므로 *uniform parse ∘ to_string = id*.

## 검증

- **Isolated ocamlc**: pure types, 외부 deps 0
- **`dune build @check`** repo-wide: main 회귀 (#14745) 미해소

## Workaround Rejection Bar self-check

| 시그니처 | 본 PR 해당? |
|---------|------------|
| Counter-as-fix | N/A |
| String 분류기 | N/A — typed transform 유지 |
| N-of-M | N/A — 4 thread 1 PR |
| Cap/cooldown/dedup/repair | N/A |
| Test backdoor | N/A |
| Catch-all `_ ->` | N/A |

## 미검증

- Phase 3b-iv.2 시점에 inspect_record가 ExitCode 옮길 때 본 PR의 decision이 자연스러운지 — 별 issue 없음 (option 타입 또는 별도 record field)

## 다음 PR

- **3b-iv.1**: `Docker_client.Mock` — `Docker_response.exec_result` + `ps_status` (Exited bare) 사용
- **3b-iv.2**: `Docker_client.Real` + `inspect_record` type (state + exit_code option + ...)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
