### PR TITLE
feat(telemetry): two more _failures.operation typed variants

### DIFF
--- a/lib/keeper/chat_store_operation.ml
+++ b/lib/keeper/chat_store_operation.ml
@@ -1,0 +1,8 @@
+type t =
+  | Append
+  | Load
+
+let to_label = function
+  | Append -> "append"
+  | Load -> "load"
+;;

--- a/lib/keeper/chat_store_operation.mli
+++ b/lib/keeper/chat_store_operation.mli
@@ -1,0 +1,11 @@
+(** Chat_store_operation — closed sum for the [operation] label on
+    [metric_keeper_chat_store_failures].
+
+    Replaces 2 hardcoded literals in [keeper_chat_store.ml]
+    (`"append"` / `"load"`). *)
+
+type t =
+  | Append (** Append-to-chat-store I/O failure. *)
+  | Load (** Read-from-chat-store I/O failure. *)
+
+val to_label : t -> string

--- a/lib/keeper/keeper_chat_store.ml
+++ b/lib/keeper/keeper_chat_store.ml
@@ -59,7 +59,7 @@ let append_pair ~base_dir ~keeper_name
   | exn ->
     Prometheus.inc_counter
       Keeper_metrics.metric_keeper_chat_store_failures
-      ~labels:[("operation", "append")]
+      ~labels:[("operation", Chat_store_operation.(to_label Append))]
       ();
     Log.Keeper.warn "keeper_chat_store: append failed for %s: %s"
       (sanitize_name keeper_name) (Printexc.to_string exn)
@@ -125,7 +125,7 @@ let load ~base_dir ~keeper_name : chat_message list =
   | exn ->
       Prometheus.inc_counter
         Keeper_metrics.metric_keeper_chat_store_failures
-        ~labels:[("operation", "load")]
+        ~labels:[("operation", Chat_store_operation.(to_label Load))]
         ();
       Log.Keeper.warn "keeper_chat_store: load failed for %s: %s"
         (sanitize_name keeper_name) (Printexc.to_string exn);

--- a/lib/keeper/keeper_world_observation.ml
+++ b/lib/keeper/keeper_world_observation.ml
@@ -336,7 +336,7 @@ let read_backlog_counts ~allowed_tool_names ~(config : Coord.config)
   | ex ->
       Prometheus.inc_counter
         Keeper_metrics.metric_keeper_observation_query_failures
-        ~labels:[("operation", "read_backlog_counts")]
+        ~labels:[("operation", Observation_query_operation.(to_label Read_backlog_counts))]
         ();
       Log.Keeper.warn "read_backlog_counts failed: %s" (Printexc.to_string ex);
       (0, 0, 0, 0, false)
@@ -349,7 +349,7 @@ let count_active_agents ~(config : Coord.config) : int =
   | ex ->
       Prometheus.inc_counter
         Keeper_metrics.metric_keeper_observation_query_failures
-        ~labels:[("operation", "count_active_agents")]
+        ~labels:[("operation", Observation_query_operation.(to_label Count_active_agents))]
         ();
       Log.Keeper.warn "count_active_agents failed: %s" (Printexc.to_string ex);
       0
@@ -891,7 +891,7 @@ let collect_board_events_with_cursor_policy ~advance_cursor ~(base_path : string
         if final_events <> [] then begin
           Prometheus.inc_counter
             Keeper_metrics.metric_keeper_observation_query_failures
-            ~labels:[("operation", "cursor_stale")]
+            ~labels:[("operation", Observation_query_operation.(to_label Cursor_stale))]
             ();
           Log.Keeper.warn
             "board cursor not updated for %s despite %d events processed"
@@ -903,7 +903,7 @@ let collect_board_events_with_cursor_policy ~advance_cursor ~(base_path : string
   | exn ->
     Prometheus.inc_counter
       Keeper_metrics.metric_keeper_observation_query_failures
-      ~labels:[("operation", "board_events")]
+      ~labels:[("operation", Observation_query_operation.(to_label Board_events))]
       ();
     Log.Keeper.warn "board event collection failed: %s"
       (Printexc.to_string exn);
@@ -1355,7 +1355,7 @@ let keeper_cycle_decision
                    should_run (derived below) stays consistent with verdict. *)
                 Prometheus.inc_counter
                   Keeper_metrics.metric_keeper_observation_query_failures
-                  ~labels:[("operation", "empty_run_reasons")]
+                  ~labels:[("operation", Observation_query_operation.(to_label Empty_run_reasons))]
                   ();
                 Log.Keeper.warn
                   "unreachable: should_run=true but run_reasons is empty";

--- a/lib/keeper/observation_query_operation.ml
+++ b/lib/keeper/observation_query_operation.ml
@@ -1,0 +1,14 @@
+type t =
+  | Read_backlog_counts
+  | Count_active_agents
+  | Cursor_stale
+  | Board_events
+  | Empty_run_reasons
+
+let to_label = function
+  | Read_backlog_counts -> "read_backlog_counts"
+  | Count_active_agents -> "count_active_agents"
+  | Cursor_stale -> "cursor_stale"
+  | Board_events -> "board_events"
+  | Empty_run_reasons -> "empty_run_reasons"
+;;

--- a/lib/keeper/observation_query_operation.mli
+++ b/lib/keeper/observation_query_operation.mli
@@ -1,0 +1,15 @@
+(** Observation_query_operation — closed sum for the [operation] label on
+    [metric_keeper_observation_query_failures].
+
+    Replaces 5 hardcoded literals in [keeper_world_observation.ml].
+    Each value names a distinct read-path failure mode of the
+    world-observation query layer. *)
+
+type t =
+  | Read_backlog_counts
+  | Count_active_agents
+  | Cursor_stale
+  | Board_events
+  | Empty_run_reasons
+
+val to_label : t -> string


### PR DESCRIPTION
## Summary

Two more keeper-side `_failures.operation` label clusters collapsed
into typed sums.  Same single-file cluster pattern as #14788 (T16) and
#14795 (T17).

## Sites (7)

| Metric | Variant | Sites |
|--------|---------|-------|
| `metric_keeper_observation_query_failures` | `Observation_query_operation.t` (5 vars) | `keeper_world_observation.ml:339,352,894,906,1358` |
| `metric_keeper_chat_store_failures` | `Chat_store_operation.t` (2 vars) | `keeper_chat_store.ml:62,128` |

## Approach

```ocaml
(* Observation_query_operation *)
type t =
  | Read_backlog_counts
  | Count_active_agents
  | Cursor_stale
  | Board_events
  | Empty_run_reasons

(* Chat_store_operation *)
type t = Append | Load
```

Both expose `to_label : t -> string`.  Wire format byte-equal.

## Test plan

- [ ] CI green
- [ ] `rg '"operation", "(read_backlog_counts|count_active_agents|cursor_stale|board_events|empty_run_reasons)"' lib/` = 0
- [ ] `rg '"operation", "(append|load)"' lib/keeper/keeper_chat_store.ml` = 0

RFC-WAIVED: not in credential/identity/operator/sandbox/hooks/workflow scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)