### PR TITLE
docs(tla-audit): KCAF R-D-1.c BLOCKED — ppx_tla shadowing constraint

### DIFF
--- a/docs/tla-audit/kcaf-d1-rd1c-blocked-ppx-shadowing-2026-05-12.md
+++ b/docs/tla-audit/kcaf-d1-rd1c-blocked-ppx-shadowing-2026-05-12.md
@@ -1,0 +1,108 @@
+# KCAF R-D-1.c Correction — ppx_tla shadowing blocks single-annotation fix
+
+**Iteration**: 31 (/loop FSM/TLA+/OCaml drift hunt)
+**Date**: 2026-05-12
+**Spec**: `specs/keeper-state-machine/KeeperCascadeAttemptFSM.tla`
+**OCaml**: `lib/cascade/cascade_fsm.ml:15-20` (`decision` type), `ppx_tla/ppx_tla.ml:151, 383`
+**Risk**: HIGH — corrects iter 30 audit's MISCLASSIFICATION of R-D-1.c risk from LOW to BLOCKED.
+**Type**: Audit correction memo.  **Empirical finding** — attempted the fix and the build error surfaced the constraint.
+
+## What iter 30 claimed
+
+> **R-D-1.c**: OCaml — add `[@@deriving tla]` to `decision` type.  No semantic change; type becomes scannable by R-B-1.c validator.  Pairs with R-D-1.b adding `decision:DecisionSet` to the pair list.
+>
+> **Risk**: LOW — single annotation line + paired validator update.
+
+## What iter 31 found empirically
+
+Attempted the single-line fix in `lib/cascade/cascade_fsm.ml:20` and `.mli:37` (add `[@@deriving tla]` after the `decision` constructors).
+
+Build error:
+
+```
+File "test/test_keeper_cascade_tla_mirror.ml", line 10, characters 19-28:
+10 |     (to_tla_symbol Slot_full);
+                        ^^^^^^^^^
+Error: This variant expression is expected to have type decision
+       There is no constructor Slot_full within type decision
+```
+
+## Root cause — ppx_tla emits unprefixed function names
+
+```ocaml
+(* ppx_tla/ppx_tla.ml:151 *)
+Ast_builder.Default.ppat_var ~loc (Loc.make ~loc "to_tla_symbol")
+```
+
+The deriver always emits a function literally named `to_tla_symbol` (and `all_symbols`, `is_terminal`, etc.).  It does **not** prefix by the type name.
+
+When `[@@deriving tla]` is applied to BOTH `provider_outcome` (line 13) and `decision` (proposed) in the same module:
+
+1. First derive emits `let to_tla_symbol : provider_outcome -> string = function …`
+2. Second derive emits `let to_tla_symbol : decision -> string = function …`
+3. The second SHADOWS the first by standard OCaml binding semantics.
+4. `test_keeper_cascade_tla_mirror.ml`'s `(to_tla_symbol Slot_full)` now type-resolves against the `decision`-typed function, and `Slot_full` doesn't exist in `decision`.
+
+The same shadowing applies to `all_symbols`, `is_terminal`, `terminal_symbols`, etc.
+
+## Why iter 30 missed this
+
+The iter 30 audit memo reasoned by analogy:
+- `provider_outcome` has `[@@deriving tla]` and builds.
+- `decision` has the per-constructor `[@tla.symbol ...]` annotations.
+- ∴ Adding the derive should "just work".
+
+The reasoning ignored the *intra-module shadowing constraint*.  No prior `[@@deriving tla]` site in the codebase has TWO derived types in the same `.ml` file with overlapping function names exposed via `open`.
+
+**Lesson**: audit risk classifications based on syntactic analogy can miss build-system semantics.  R-D-1.c should have been flagged MID minimum until empirically validated.
+
+## R-D-1.c is BLOCKED until R-D-1.d lands
+
+A new prerequisite candidate emerges:
+
+| ID | Direction | Risk |
+|---|---|---|
+| **R-D-1.d** | ppx_tla — add `[@@deriving tla { prefix }]` option (or `[@@deriving tla] [@@tla.prefix "decision"]` attribute) emitting `decision_to_tla_symbol`, `decision_all_symbols`, `decision_is_terminal`, … instead of unprefixed names.  Backwards compatible (default behavior unchanged when no prefix). | MID — `ppx_tla.ml` deriver change (~30-50 LOC across `make_*_impl` functions), `ppx_tla` tests, downstream caller-site updates if any. |
+
+Then R-D-1.c becomes:
+
+> Add `[@@deriving tla { prefix = "decision" }]` to `decision` type.  Validator scans `decision_to_tla_symbol` via R-D-1.b's `provider_outcome:ProviderOutcomes, decision:DecisionSet` pair list extension.
+
+## Adjacent unrelated lint observations during build
+
+`dune build @check` surfaced two unrelated pre-existing errors that should *not* be attributed to this iteration's change:
+
+1. `test/test_keeper_sandbox_plan.ml:32` — `result` applied as a function but actually a constructor; orthogonal to KCAF.
+2. `Keeper_registry.registry_entry` vs tuple mismatch in some unrelated caller; orthogonal.
+
+These appear to be live failures on main that other PRs may already be addressing.  Reported here only so future readers know the iter 31 attempt was rolled back **cleanly** and these errors persist independently of this PR.
+
+## RFC backlog update
+
+Updated KCAF queue:
+
+| RFC | Status | Note |
+|---|---|---|
+| R-D-1.a | Open | Split `Call_err` into 3 typed variants (MID, multi-file). |
+| R-D-1.b | Open | Extend validator to CONSTANT-style sets (LOW-MID). |
+| R-D-1.c | **BLOCKED** | Pending R-D-1.d. |
+| **R-D-1.d** | **New** | Add `prefix` option to ppx_tla deriver (MID, ppx_tla.ml). |
+
+The cheapest *implementable* KCAF fix is now R-D-1.b (validator-side, doesn't depend on ppx).
+
+## Why this audit memo has value despite no fix
+
+- Documents a real constraint discovered empirically.
+- Updates risk classifications based on evidence rather than analogy.
+- Identifies a previously-invisible prerequisite (R-D-1.d).
+- Establishes the *Loop Discipline*: when an audit claims LOW risk, an attempted fix is the cheapest way to confirm.  When the fix surfaces a hidden constraint, the audit memo is *more valuable than the fix would have been* — it prevents the same misclassification in adjacent slices.
+
+This is the audit-correction shape that the workaround anti-pattern §CLAUDE.md flags as healthy: **prefer surfacing constraints over silencing them with workarounds**.  A naïve approach to this constraint (renaming all test references, or putting `decision` in a sub-module to break shadowing) would be a string-classifier-style workaround.  The structural fix is ppx_tla extension.
+
+## References
+
+- iter 30 audit: `docs/tla-audit/kcaf-d1-attempt-fsm-coverage-2026-05-12.md` — original R-D-1.c claim.
+- `ppx_tla/ppx_tla.ml:151, 383` — unprefixed `to_tla_symbol` emission.
+- `test/test_keeper_cascade_tla_mirror.ml:10` — the shadowing-sensitive call site.
+- `lib/cascade/cascade_fsm.ml:13` — existing `[@@deriving tla]` on `provider_outcome`.
+- iter 28 (#14793) — R-B-1.a closure as comparable "spec/OCaml symmetry" effort that *did* succeed (single-spec type widening, no ppx interaction).

--- a/docs/tla-audit/kcaf-d1-rd1c-blocked-ppx-shadowing-2026-05-12.md
+++ b/docs/tla-audit/kcaf-d1-rd1c-blocked-ppx-shadowing-2026-05-12.md
@@ -72,8 +72,8 @@ Then R-D-1.c becomes:
 
 `dune build @check` surfaced two unrelated pre-existing errors that should *not* be attributed to this iteration's change:
 
-1. `test/test_keeper_sandbox_plan.ml:32` — `result` applied as a function but actually a constructor; orthogonal to KCAF.
-2. `Keeper_registry.registry_entry` vs tuple mismatch in some unrelated caller; orthogonal.
+1. `test/test_keeper_sandbox_plan.ml:32` — identifier shadowing: the local `let result = Keeper_sandbox_plan.of_request ...` at line 28 shadows `Alcotest.result`, so the subsequent `check (result plan_t plan_error_t) ...` tries to apply the shadowed value (a record) as a 2-arg function.  Orthogonal to KCAF; rename the local to e.g. `outcome` to lift the shadow.
+2. `Keeper_registry.registry_entry` vs tuple mismatch in an unrelated caller — exact file:line not captured in this memo's working tree at iter 31 rollback time; run `dune build --root . @check` on a clean main checkout to recover the trace, or check open PRs touching `Keeper_registry.registry_entry` shape.
 
 These appear to be live failures on main that other PRs may already be addressing.  Reported here only so future readers know the iter 31 attempt was rolled back **cleanly** and these errors persist independently of this PR.
 
@@ -97,7 +97,7 @@ The cheapest *implementable* KCAF fix is now R-D-1.b (validator-side, doesn't de
 - Identifies a previously-invisible prerequisite (R-D-1.d).
 - Establishes the *Loop Discipline*: when an audit claims LOW risk, an attempted fix is the cheapest way to confirm.  When the fix surfaces a hidden constraint, the audit memo is *more valuable than the fix would have been* — it prevents the same misclassification in adjacent slices.
 
-This is the audit-correction shape that the workaround anti-pattern §CLAUDE.md flags as healthy: **prefer surfacing constraints over silencing them with workarounds**.  A naïve approach to this constraint (renaming all test references, or putting `decision` in a sub-module to break shadowing) would be a string-classifier-style workaround.  The structural fix is ppx_tla extension.
+This is the audit-correction shape that the operator's local "Workaround Rejection Bar" guidance flags as healthy: **prefer surfacing constraints over silencing them with workarounds**.  (The guidance lives in the operator-local `~/me/CLAUDE.md` / `~/me/instructions/software-development.md` and is not tracked in this repo — see also RFC-0064 §Workaround Anti-pattern and RFC-0068 for in-repo applications of the same rule.)  A naïve approach to this constraint (renaming all test references, or putting `decision` in a sub-module to break shadowing) would be a string-classifier-style workaround.  The structural fix is ppx_tla extension.
 
 ## References
 


### PR DESCRIPTION
## Finding (Iteration 31, audit correction)

**Spec**: `specs/keeper-state-machine/KeeperCascadeAttemptFSM.tla`
**OCaml**: `ppx_tla/ppx_tla.ml:151, 383` (unprefixed deriver emit)
**Aspect**: Corrects iter 30 (#14798) misclassification of R-D-1.c risk from LOW to BLOCKED.
**Risk**: HIGH — overturns a published audit's risk classification based on empirical build evidence.
**Workaround signature**: N/A (audit-only)

## 순서도

```mermaid
flowchart TB
  A[iter 30 audit memo claim:<br/>R-D-1.c is LOW risk single annotation] --> B{iter 31 attempts the fix}
  B --> C[Add @@deriving tla to decision]
  C --> D[dune build @check]
  D --> E[BUILD FAILS:<br/>test_keeper_cascade_tla_mirror.ml<br/>'No constructor Slot_full within type decision']
  E --> F[Root cause:<br/>ppx_tla emits unprefixed to_tla_symbol]
  F --> G[Two derives in same module → shadowing]
  G --> H[Rollback edit + write correction memo]
  H --> I[New RFC: R-D-1.d<br/>ppx_tla prefix option]
  I --> J[R-D-1.c → BLOCKED until R-D-1.d lands]
```

## What iter 31 attempted and learned

Single-line `[@@deriving tla]` added to `decision` in both `cascade_fsm.ml` and `.mli`.  Build error:

```
File "test/test_keeper_cascade_tla_mirror.ml", line 10, characters 19-28:
10 |     (to_tla_symbol Slot_full);
                        ^^^^^^^^^
Error: This variant expression is expected to have type decision
       There is no constructor Slot_full within type decision
```

`ppx_tla` always emits a function literally named `to_tla_symbol` (and `all_symbols`, `is_terminal`, etc., per ppx_tla.ml:151, 383).  Two derives in one module → shadowing → consumer `open` sees only the last-defined function.

## Why iter 30 missed this

Reasoned by syntactic analogy:
- `provider_outcome` carries `[@@deriving tla]` and builds (cascade_fsm.ml:13).
- `decision` has per-constructor `[@tla.symbol ...]` annotations.
- ∴ Adding the derive should "just work".

The reasoning ignored **intra-module shadowing**.  No prior `[@@deriving tla]` site in the codebase has two derived types with overlapping function names in the same module — empirically a corner case the analogy didn't cover.

## RFC backlog update

| RFC | Status | Note |
|---|---|---|
| R-D-1.a | Open | Split `Call_err` into 3 typed variants (MID). |
| R-D-1.b | Open | Extend validator CONSTANT-style sets (LOW-MID).  **Cheapest implementable KCAF fix.** |
| R-D-1.c | **BLOCKED** | Pending R-D-1.d. |
| **R-D-1.d** | **NEW** | Add `prefix` option to `ppx_tla` deriver.  Backwards compatible.  MID — ~30-50 LOC in ppx_tla.ml + tests. |

## 왜 톱니처럼 정교하지 않은가

`ppx_tla`는 다중 [@@deriving tla] 사용을 지원하지 않음.  Function name이 type별로 prefixed 되지 않아 같은 모듈 내 두 type derive 시 shadowing 발생.  이것은 deriver design의 부재 — `prefix` 옵션이 표준 ppx 패턴이지만 ppx_tla에서는 미구현.

같은 모듈에서 두 variant type 모두 spec과 cross-check 받게 하려면 deriver 자체의 capability 확장이 선행되어야 함.  이 PR은 그 prerequisite를 명시적으로 표기.

## 본 PR 수정

`docs/tla-audit/kcaf-d1-rd1c-blocked-ppx-shadowing-2026-05-12.md` (+108 LOC) — correction memo.  No code change (the attempted edit was rolled back cleanly).

## Trade-off

- 장점: empirical finding이 audit memo의 syntactic-analogy reasoning bug 차단.  R-D-1.d prerequisite 명시.  Future audits에 패턴 학습 자료 (CLAUDE.md §workaround anti-pattern 인용).
- 단점: 본 iter에서 실제 코드 변경 0.  "Empty PR"은 아니지만 (108 LOC docs) "negative result" 형태.  R-D-1.b가 다음 candidates.

## Adjacent observations

`dune build @check` 실행 중 unrelated pre-existing 실패 2건:
1. `test/test_keeper_sandbox_plan.ml:32` — `result plan_t plan_error_t` applied as function (constructor mismatch).
2. `Keeper_registry.registry_entry` vs tuple mismatch in some unrelated caller.

본 PR과 무관 — main에서 이미 깨져있을 가능성, 별도 PR로 추적해야.  Reported here for traceability only.

## RFC 참조

`RFC-WAIVED: audit memo only, no subsystem touched.`

연관:
- iter 30 audit: `docs/tla-audit/kcaf-d1-attempt-fsm-coverage-2026-05-12.md` (#14798) — R-D-1.c original claim being corrected.
- `ppx_tla/ppx_tla.ml:151, 383` — deriver emit site.
- `test/test_keeper_cascade_tla_mirror.ml:10` — shadowing-sensitive consumer.

## 진행 추적

다음 iteration 시작점: **R-D-1.b** (validator CONSTANT-style set extension, cheapest implementable) OR **R-D-1.d** (ppx_tla prefix, MID) OR **R-A-8 PR-2** (KNOWN_FAILURES purge).

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>