### PR TITLE
perf(mcp_server_eio_tool_profile): O(1) managed_agent passthrough membership

### DIFF
--- a/lib/mcp_server_eio_tool_profile.ml
+++ b/lib/mcp_server_eio_tool_profile.ml
@@ -36,6 +36,19 @@ let managed_agent_passthrough_tool_names =
                 "masc_a2a_delegate";
               ]))
 
+(* O(1) membership view of [managed_agent_passthrough_tool_names].
+   Used by [tool_schemas_for_profile Managed_agent] to filter
+   ~150 visible schemas per request — replaces a per-schema
+   [List.mem] scan over ~20 passthrough names. *)
+let managed_agent_passthrough_tool_set : (string, unit) Hashtbl.t =
+  let tbl =
+    Hashtbl.create (List.length managed_agent_passthrough_tool_names)
+  in
+  List.iter
+    (fun name -> Hashtbl.replace tbl name ())
+    managed_agent_passthrough_tool_names;
+  tbl
+
 module StringSet = Set.Make (String)
 module StringMap = Map.Make (String)
 
@@ -100,7 +113,7 @@ let tool_schemas_for_profile ?(include_hidden = false)
         let passthrough =
           Config.visible_tool_schemas ~include_hidden:true ~include_deprecated:false ()
           |> List.filter (fun (schema : Masc_domain.tool_schema) ->
-                 List.mem schema.name managed_agent_passthrough_tool_names
+                 Hashtbl.mem managed_agent_passthrough_tool_set schema.name
                  && Tool_catalog.is_visible ~include_hidden:true schema.name)
         in
         dedupe_tool_schemas_by_name


### PR DESCRIPTION
## Summary

\`tool_schemas_for_profile Managed_agent\` (lib/mcp_server_eio_tool_profile.ml:100-105) runs per managed-agent \`tools/list\` request. Its passthrough filter iterated \`Config.visible_tool_schemas\` (~150 schemas) and for every schema did:

\`\`\`ocaml
List.mem schema.name managed_agent_passthrough_tool_names  (* ~20 names *)
\`\`\`

That's ~3000 string compares per request, just for the passthrough membership predicate.

## Fix

\`managed_agent_passthrough_tool_names\` is module-load-constant (derived from \`spawned_agent_public_tool_names\` minus 4 hardcoded names). Build a sibling Hashtbl once at module init:

\`\`\`ocaml
let managed_agent_passthrough_tool_set : (string, unit) Hashtbl.t =
  let tbl =
    Hashtbl.create (List.length managed_agent_passthrough_tool_names)
  in
  List.iter
    (fun name -> Hashtbl.replace tbl name ())
    managed_agent_passthrough_tool_names;
  tbl
\`\`\`

Per-schema check drops to O(1).

## What I intentionally did NOT change

Three other \`List.mem\` sites in this file (lines 31, 430, 475):

| Site | List size | Calls/sec |
|------|-----------|-----------|
| Line 31 (\`managed_agent_passthrough_tool_names\` exclude list) | 4 elements (static) | once at module init |
| Line 430 (\`tools/list\` param allowlist) | 6 elements (static) | per-request, small |
| Line 475 (\`cursor\`-only param allowlist) | 2 elements (static) | per-request, small |

For lists of 2-6 elements, \`String.equal × N\` beats \`Hashtbl.mem\`'s lookup constant factor. The decision rule applied: optimize when (list size ≥ ~8) AND (per-request); leave alone otherwise. This is the discipline missing from "optimize everywhere" sweeps that introduce noise without measurable wins.

## Pattern continuity

This is the *correct* version of the same shape as #14774, #14780, #14785, #14791, #14796: module-load-constant list + per-request hot loop scans it → sibling Hashtbl.

## Test plan

- [ ] CI lib/ build green
- [ ] \`dune runtest test/test_mcp_server_eio*.exe\` passes
- [ ] Smoke: \`tools/list\` against Managed_agent profile returns identical schema set

🤖 Generated with [Claude Code](https://claude.com/claude-code)