### PR TITLE
feat(rfc-0070): Phase 3b-iv.1a — Docker_client.S concrete + ps_record type

### DIFF
--- a/lib/keeper/docker_client.ml
+++ b/lib/keeper/docker_client.ml
@@ -1,6 +1,4 @@
-(* RFC-0070 Phase 3a — Docker daemon client stub. See docker_client.mli
-   for the contract. Phase 3b adds [module Real], Phase 3c adds
-   [module Mock]; both satisfy [S]. *)
+(* RFC-0070 Phase 3b-iv.1a — concrete module type S. See .mli. *)
 
 type sandbox_error =
   | Daemon_unreachable
@@ -11,21 +9,18 @@ type sandbox_error =
   | Cleanup_failed
 
 module type S = sig
-  type plan
-  type exec_result
-  type ps_record
-  type container_name
-
-  val run : plan -> (exec_result, sandbox_error) result
+  val run
+    :  Keeper_sandbox_plan.t
+    -> (Docker_response.exec_result, sandbox_error) result
 
   val exec
-    :  container:container_name
+    :  container:Keeper_container_name.t
     -> cmd:string
-    -> (exec_result, sandbox_error) result
+    -> (Docker_response.exec_result, sandbox_error) result
 
   val ps_query
     :  labels:(string * string) list
-    -> (ps_record list, sandbox_error) result
+    -> (Docker_response.ps_record list, sandbox_error) result
 
-  val rm : container_name -> (unit, sandbox_error) result
+  val rm : Keeper_container_name.t -> (unit, sandbox_error) result
 end

--- a/lib/keeper/docker_client.mli
+++ b/lib/keeper/docker_client.mli
@@ -1,12 +1,13 @@
-(** RFC-0070 Phase 3a — Docker daemon client (signature only).
+(** RFC-0070 Phase 3b-iv.1a — Docker daemon client (signature, concrete).
 
-    Stub signatures. Implementation arrives in Phase 3b (Real) and
-    Phase 3c (Mock + property tests). Phase 3a establishes the
-    sandbox_error closed sum and the module type so that future caller
-    cutover (Phase 3d) has a compilation-checked contract to migrate
-    against.
+    Phase 3a stub kept the four payload types abstract; Phase 3b-iv.1a
+    closes them to the concrete shared types now that
+    {!Keeper_sandbox_plan}, {!Keeper_container_name}, and
+    {!Docker_response} are on main. With the signature concrete, the
+    upcoming [Mock] and [Real] implementations are *interchangeable*
+    at any call site that takes [(module Docker_client.S)].
 
-    Reference: docs/rfc/RFC-0070-keeper-sandbox-pure-edge-separation.md §3.2
+    Reference: docs/rfc/RFC-0070-keeper-sandbox-pure-edge-separation.md §3.2, §3.3
 
     Non-determinism contract: every function in {!S} is at the
     process boundary (docker daemon, network, host clock). All such
@@ -19,8 +20,9 @@
     failure. The reader is forced to handle each by exhaustive match.
 
     Phase 3b may refine arms with concrete payload fields (image
-    digest, container name, exit code). Phase 3a keeps the variant
-    skeleton minimal. *)
+    digest, container name, exit code). Phase 3a kept the variant
+    skeleton minimal; Phase 3b-iv.1a preserves that minimum until a
+    caller surfaces an actual payload need. *)
 type sandbox_error =
   | Daemon_unreachable
   | Image_pull_failed
@@ -31,39 +33,24 @@ type sandbox_error =
 
 (** {1 Client interface} *)
 
-(** Sandbox executor client. [Real] (Phase 3b) spawns docker via
-    [Eio.Process]; [Mock] (Phase 3c) feeds injected responses for
-    property-seeded replay tests. *)
+(** Sandbox executor client. [Real] (Phase 3b-iv.2) spawns docker via
+    [Eio.Process]; [Mock] (Phase 3b-iv.1b) feeds injected responses
+    for property-seeded replay tests. Both satisfy {!S} so callers
+    parameterising on [(module S)] swap them without conditional
+    branches. *)
 module type S = sig
-  (** Sandbox plan accepted by [run]. Concrete type bound at
-      implementation time to {!Keeper_sandbox_plan.t} or a mock
-      stand-in. *)
-  type plan
-
-  (** Captured execution result (exit code + stdout + stderr).
-      Concrete shape lands in Phase 3b. *)
-  type exec_result
-
-  (** Parsed [docker ps] line. Phase 3b parses
-      [docker ps --format '\{\{json .\}\}'] via ppx_deriving_yojson. *)
-  type ps_record
-
-  (** Opaque container handle (derived from
-      {!Keeper_sandbox_plan.t}'s container_name in Phase 3b). *)
-  type container_name
-
   val run
-    :  plan
-    -> (exec_result, sandbox_error) result
+    :  Keeper_sandbox_plan.t
+    -> (Docker_response.exec_result, sandbox_error) result
 
   val exec
-    :  container:container_name
+    :  container:Keeper_container_name.t
     -> cmd:string
-    -> (exec_result, sandbox_error) result
+    -> (Docker_response.exec_result, sandbox_error) result
 
   val ps_query
     :  labels:(string * string) list
-    -> (ps_record list, sandbox_error) result
+    -> (Docker_response.ps_record list, sandbox_error) result
 
-  val rm : container_name -> (unit, sandbox_error) result
+  val rm : Keeper_container_name.t -> (unit, sandbox_error) result
 end

--- a/lib/keeper/docker_response.ml
+++ b/lib/keeper/docker_response.ml
@@ -37,3 +37,11 @@ type exec_result =
   ; stderr : string
   }
 [@@deriving show, eq]
+
+type ps_record =
+  { id : string
+  ; name : Keeper_container_name.t
+  ; status : ps_status
+  ; labels : (string * string) list
+  }
+[@@deriving show, eq]

--- a/lib/keeper/docker_response.mli
+++ b/lib/keeper/docker_response.mli
@@ -66,3 +66,23 @@ type exec_result =
   ; stderr : string
   }
 [@@deriving show, eq]
+
+(** {1 Container snapshot ([docker ps] row)} *)
+
+(** A row from [docker ps --format '\{\{json .\}\}']. The fields are
+    *exactly* what cleanup / quarantine logic in Phase 3b-iv.3 needs to
+    branch on; richer per-container metadata stays in
+    [docker inspect]'s separate response surface (introduced in Phase
+    3b-iv.2 alongside [Docker_client.Real]).
+
+    [labels] is the parsed label dictionary. Docker's wire format emits
+    a single comma-separated string ("k1=v1,k2=v2"); the parser splits
+    it before constructing the record so callers see structured data,
+    not the raw string. *)
+type ps_record =
+  { id : string
+  ; name : Keeper_container_name.t
+  ; status : ps_status
+  ; labels : (string * string) list
+  }
+[@@deriving show, eq]

--- a/lib/keeper/docker_response.mli
+++ b/lib/keeper/docker_response.mli
@@ -69,16 +69,17 @@ type exec_result =
 
 (** {1 Container snapshot ([docker ps] row)} *)
 
-(** A row from [docker ps --format '\{\{json .\}\}']. The fields are
+(** A row from [docker ps --format '{{json .}}']. The fields are
     *exactly* what cleanup / quarantine logic in Phase 3b-iv.3 needs to
     branch on; richer per-container metadata stays in
     [docker inspect]'s separate response surface (introduced in Phase
     3b-iv.2 alongside [Docker_client.Real]).
 
-    [labels] is the parsed label dictionary. Docker's wire format emits
-    a single comma-separated string ("k1=v1,k2=v2"); the parser splits
-    it before constructing the record so callers see structured data,
-    not the raw string. *)
+    [labels] is an ordered association list, *not* a hash-map: docker's
+    wire format emits a single comma-separated string ("k1=v1,k2=v2"),
+    and the parser splits in input order before constructing the
+    record.  Callers (and tests) treat list order as meaningful for
+    structural equality — see [test_ps_record_labels_order]. *)
 type ps_record =
   { id : string
   ; name : Keeper_container_name.t

--- a/test/test_docker_response.ml
+++ b/test/test_docker_response.ml
@@ -116,6 +116,44 @@ let test_exec_result_structural_equality () =
   check bool "structural equality (a ≡ b by field)" true (Docker_response.equal_exec_result a b);
   check bool "exit_code distinguishes" false (Docker_response.equal_exec_result a c)
 
+(* ── ps_record structural equality (Phase 3b-iv.1a) ────────────── *)
+
+let sample_name =
+  Keeper_container_name.derive
+    ~algo:Keeper_hash_algo.SHA_256
+    ~turn_id:1
+    ~attempt:0
+    ~suffix:"test"
+
+let sample_ps_record =
+  Docker_response.
+    { id = "abc123"
+    ; name = sample_name
+    ; status = Running
+    ; labels = [ "masc.keeper", "test"; "masc.run_id", "42" ]
+    }
+
+let test_ps_record_structural_equality () =
+  let a = sample_ps_record in
+  let b = sample_ps_record in
+  let c = { sample_ps_record with status = Docker_response.Dead } in
+  check bool "ps_record structural equality" true (Docker_response.equal_ps_record a b);
+  check bool "status field distinguishes" false (Docker_response.equal_ps_record a c)
+
+let test_ps_record_labels_order () =
+  (* Labels are an association list — order matters for structural
+     equality. The parsing layer (Phase 3b-iv.2) is responsible for
+     emitting them in a canonical order if order-independence is
+     required. *)
+  let a = sample_ps_record in
+  let b =
+    { sample_ps_record with
+      labels = [ "masc.run_id", "42"; "masc.keeper", "test" ]
+    }
+  in
+  check bool "label list order matters (no auto-sort)"
+    false (Docker_response.equal_ps_record a b)
+
 let () =
   run "Docker_response"
     [
@@ -148,5 +186,14 @@ let () =
           test_case "structural equality + exit_code distinguishes"
             `Quick
             test_exec_result_structural_equality;
+        ] );
+      ( "ps_record",
+        [
+          test_case "structural equality + status distinguishes"
+            `Quick
+            test_ps_record_structural_equality;
+          test_case "label list order matters"
+            `Quick
+            test_ps_record_labels_order;
         ] );
     ]


### PR DESCRIPTION
## 목표 — RFC-0070 §3.2/§3.3 Phase 3b-iv.1a

Mock/Real client implementation의 *type 인프라*. Phase 3b-iv.1b (Mock 본구현)의 직접 prerequisite.

## RFC 인용

| RFC | 관계 |
|-----|------|
| **RFC-0070** | §3.2 (Docker_client.S concrete) + §3.3 (ps_record typed) |
| RFC-0006 | cite-only |
| RFC-0036 | cite-only |

## 두 개의 coordinated 변경

### 1. `Docker_response.ps_record` 신설

```ocaml
type ps_record = {
  id : string;
  name : Keeper_container_name.t;
  status : ps_status;            (* 닫힌 sum, Phase 3b-iv.0 *)
  labels : (string * string) list;
} [@@deriving show, eq]
```

Mock + Real이 *동일 record*를 produce/consume. Phase 3b-iv.2 JSON parser가 docker stdout → `ps_record`.

### 2. `Docker_client.S` abstract → concrete refactor

Phase 3a stub `module type S` 의 `type plan`, `type exec_result`, `type ps_record`, `type container_name` 4-abstract types 제거. 공유 concrete types로 닫음:

```ocaml
module type S = sig
  val run     : Keeper_sandbox_plan.t -> (Docker_response.exec_result, sandbox_error) result
  val exec    : container:Keeper_container_name.t -> cmd:string -> ...
  val ps_query: labels:(string * string) list -> (Docker_response.ps_record list, sandbox_error) result
  val rm      : Keeper_container_name.t -> (unit, sandbox_error) result
end
```

→ Mock + Real이 *interchangeable*. `(module Docker_client.S)` 어떤 caller도 swap 가능, conditional branch 0.

## Backward compat

Phase 3a stub의 S surface는 *zero callers* (의도적, contract-only). signature shrink (4 abstract types + 4 functions → 4 functions on shared concrete types)는 *strict simplification* — migration cost 0.

## 변경

```
lib/keeper/docker_response.mli   +20 (ps_record type + docstring)
lib/keeper/docker_response.ml    +9 (ps_record record)
lib/keeper/docker_client.mli     ±50 (S 시그니처 refactor)
lib/keeper/docker_client.ml      ±10 (same)
test/test_docker_response.ml     +30 (2 새 assertion + sample fixture)
```

## Test 추가 (총 +2 assertion)

- `ps_record structural equality + status distinguishes`
- `label list order matters (no auto-sort)` — parser layer responsibility (Phase 3b-iv.2)

## 검증

- **Isolated ocamlc**: 의존성 origin/main에 있음 (Keeper_sandbox_plan, Keeper_container_name, Docker_response.ps_status)
- **`dune build @check`** repo-wide: main 회귀 (#14745) 미해소

## Workaround Rejection Bar self-check

| 시그니처 | 본 PR 해당? |
|---------|------------|
| Counter-as-fix | N/A |
| String 분류기 | N/A — typed `ps_status` + `ps_record` |
| N-of-M | N/A — 2 coordinated changes, 1 PR |
| Cap/cooldown/dedup/repair | N/A |
| Test backdoor | N/A |
| Catch-all `_ ->` | N/A — exhaustive |

## 미검증

- 실제 Mock implementation (Phase 3b-iv.1b) — 본 PR은 type 인프라만
- 실제 docker JSON parsing → `ps_record` (Phase 3b-iv.2)

## 다음 PR

- **3b-iv.1b**: `Docker_client.Mock` module — inject_response API, Mock implementing S
- **3b-iv.2**: `Docker_client.Real` + JSON parser

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
