### PR TITLE
feat(scripts): R-D-1.b — TLC cfg CONSTANT-style spec set extraction

### DIFF
--- a/scripts/audit-tla-annotation-drift.sh
+++ b/scripts/audit-tla-annotation-drift.sh
@@ -74,8 +74,18 @@ in_baseline() {
 }
 
 # Type → Set mapping.  OCaml type names (lowercase_with_underscores) to
-# TLA+ set identifiers (CamelCase + "Set").  Extend this list as new
-# `[@@deriving tla]` types appear.
+# TLA+ set identifiers.  Extend this list as new `[@@deriving tla]`
+# types appear.
+#
+# Two source forms supported:
+#   "<ocaml_type>:<set_name>"          — TLA+ in-spec set definition
+#                                        (`SetName == { "a", "b" }`)
+#   "<ocaml_type>:cfg:<const_name>"    — TLC cfg CONSTANT block
+#                                        (`CONSTANTS  ConstName = { "a", "b" }`)
+# The `cfg:` form is needed when a spec models its alphabet as a
+# CONSTANT supplied by the TLC config (e.g. KCAF's `ProviderOutcomes`).
+# Added in R-D-1.b (iter 32) following the KCAF D-1 audit
+# (`docs/tla-audit/kcaf-d1-attempt-fsm-coverage-2026-05-12.md`).
 declare -a TYPE_SET_PAIRS=(
   "turn_phase:TurnPhaseSet"
   "decision_stage:DecisionSet"
@@ -84,6 +94,11 @@ declare -a TYPE_SET_PAIRS=(
   # constant via DerivePhase, not a closed set literal).  R-B-1.c can
   # extend to KSM in a follow-up by adding spec-side `PhaseSet` first
   # and matching here.
+  #
+  # KCAF pair (activation deferred — surfaces the known 3-way Call_err
+  # vs 1-way OCaml drift documented in iter 30 audit Gap 1.  Enable in
+  # a follow-up that lands paired baseline entries.):
+  #   "provider_outcome:cfg:ProviderOutcomes"
 )
 
 # Aux: extract spec set members.  Greps the `XxxSet == { ... }` block,
@@ -109,6 +124,26 @@ extract_spec_members() {
       if (index($0, "}") > 0) { capturing = 0; print buf; buf = "" }
     }
   ' "${SPEC_DIR}"/*.tla 2>/dev/null \
+    | rg -o '"[a-z_]+"' \
+    | tr -d '"' \
+    | sort -u
+}
+
+# Aux: extract TLC cfg CONSTANT members.  Greps the
+# `ConstName = { ... }` block from `*.cfg` files, bounded the same way
+# as the spec-set extractor.  Used for CONSTANT-style spec alphabets
+# (e.g. KCAF's `ProviderOutcomes`) where the set is cfg-supplied rather
+# than declared in the `.tla` file.
+extract_cfg_constant_members() {
+  local const_name="$1"
+  awk -v const="${const_name}" '
+    BEGIN { capturing = 0 }
+    $0 ~ "^[[:space:]]*" const "[[:space:]]*=" && index($0, "{") > 0 { capturing = 1 }
+    capturing == 1 {
+      buf = buf $0 " "
+      if (index($0, "}") > 0) { capturing = 0; print buf; buf = "" }
+    }
+  ' "${SPEC_DIR}"/*.cfg 2>/dev/null \
     | rg -o '"[a-z_]+"' \
     | tr -d '"' \
     | sort -u
@@ -141,13 +176,27 @@ TOTAL_CHECKED=0
 for pair in "${TYPE_SET_PAIRS[@]}"; do
   TOTAL_PAIRS=$((TOTAL_PAIRS + 1))
   ocaml_type="${pair%%:*}"
-  spec_set="${pair##*:}"
-
-  if [[ "${VERBOSE}" == "1" ]]; then
-    echo "── ${ocaml_type} ↔ ${spec_set} ──"
+  rest="${pair#*:}"
+  # Dispatch on source form.  "cfg:<name>" → TLC cfg CONSTANT; anything
+  # else is a TLA+ spec set name.  See TYPE_SET_PAIRS comment for the
+  # supported forms.
+  if [[ "${rest}" == cfg:* ]]; then
+    spec_set="${rest#cfg:}"
+    spec_origin="cfg"
+  else
+    spec_set="${rest}"
+    spec_origin="tla"
   fi
 
-  spec_members=$(extract_spec_members "${spec_set}" || true)
+  if [[ "${VERBOSE}" == "1" ]]; then
+    echo "── ${ocaml_type} ↔ ${spec_set} (${spec_origin}) ──"
+  fi
+
+  if [[ "${spec_origin}" == "cfg" ]]; then
+    spec_members=$(extract_cfg_constant_members "${spec_set}" || true)
+  else
+    spec_members=$(extract_spec_members "${spec_set}" || true)
+  fi
   ocaml_members=$(extract_ocaml_members "${ocaml_type}" || true)
 
   if [[ -z "${spec_members}" ]]; then


### PR DESCRIPTION
## Finding (Iteration 32, R-D-1.b validator extension)

**Spec**: `specs/keeper-state-machine/KeeperCascadeAttemptFSM.cfg` (CONSTANT ProviderOutcomes)
**OCaml**: `lib/cascade/cascade_fsm.ml:7-13` (`provider_outcome` typed surface)
**Validator**: `scripts/audit-tla-annotation-drift.sh:101-115` (new `extract_cfg_constant_members`) + main-loop dispatcher
**Aspect**: Extend R-B-1.c validator to recognize TLC cfg CONSTANT-style spec alphabets — needed for KCAF's `ProviderOutcomes` per iter 30 Gap 3.
**Risk**: LOW — pure capability addition, KCAF pair intentionally commented out (no CI surprise).
**Workaround signature**: N/A — this is the structural-fix path identified in iter 31 ppx-blocker memo as the *cheapest implementable* KCAF audit closure.

## 순서도

```mermaid
flowchart TB
  subgraph Before [Validator V1 — iter 20/21/28]
    A1[grep XxxSet == in *.tla]
    A1 --> A2[3 type/set pairs: KTC turn_phase/decision_stage/cascade_state]
  end
  subgraph After [Validator V2 — iter 32 R-D-1.b]
    B1{pair format?}
    B1 -->|"type:Set"| B2[extract_spec_members<br/>parse *.tla]
    B1 -->|"type:cfg:Const"| B3[extract_cfg_constant_members<br/>parse *.cfg<br/>NEW]
    B2 --> B4[membership check]
    B3 --> B4
  end
  Before --> After
  After -.->|when KCAF pair activated| C[surfaces iter 30 Gap 1:<br/>call_err drift]
```

## Empirical verification

**Existing pairs unchanged**:
```
$ bash scripts/audit-tla-annotation-drift.sh --baseline scripts/tla-annotation-drift-baseline.txt
tla-annotation-drift summary: 16 constructors checked across 3 type/set pairs, 0 new drift(s), 0 baseline-known drift(s)
```

**KCAF pair smoke-tested by temporarily activating** (NOT committed):
```
drift: ocaml constructor 'call_err' (type=provider_outcome) has no matching member in TLA+ ProviderOutcomes
       tried: 'call_err', 'call_err'
tla-annotation-drift summary: 20 constructors checked across 4 type/set pairs, 1 new drift(s), 0 baseline-known drift(s)
```

The cfg parser correctly extracted the 6-member `ProviderOutcomes` alphabet from `KeeperCascadeAttemptFSM.cfg` and surfaced exactly the drift iter 30 Gap 1 documented: OCaml's 1-way `Call_err` vs spec's 3-way `call_err_cascadeable` / `_terminal` / `_hard_quota`.  The other 3 OCaml constructors (`Call_ok`, `Accept_rejected`, `Slot_full`) matched cleanly.

## Why the KCAF pair is committed COMMENTED OUT

Activating it now would:
- Fire 1+ drift on every spec-touching PR (`call_err` until R-D-1.a lands).
- Block legitimate merges by failing CI on pre-existing main state.

Two valid activation paths for a follow-up PR:
1. **R-D-1.a path**: Land Call_err 3-way split first → no drift → validator stays green when pair activates.
2. **Baseline path**: Add `provider_outcome:call_err` to baseline + activate pair.  Validator records the known drift, CI passes, R-D-1.a removes baseline later (paired-update policy — see iter 21 #14772 precedent).

Activation **alone**, without one of the above, would be a workaround-magnet (CI failure pressuring future PRs to bypass `tla-annotation-drift` check).

## 왜 톱니처럼 정교하지 않은가

R-B-1.c validator (iter 20) hardcoded its parse path to `XxxSet == { ... }` in `.tla` files.  KCAF (KeeperCascadeAttemptFSM.tla) deliberately models its alphabet as a CONSTANT in its `.cfg` file — both valid TLA+ idioms, but the validator could only see one.  The asymmetry let KCAF carry a spec/OCaml drift (iter 30 Gap 1) invisible to the chain.  This PR widens the validator's mouth to match the spec corpus's actual diet.

## 본 PR 수정

`scripts/audit-tla-annotation-drift.sh` +54/-5:
- New `extract_cfg_constant_members` helper (awk-bounded, mirrors `extract_spec_members` structure).
- Main-loop dispatcher reads "cfg:" prefix on rest-of-pair.
- `TYPE_SET_PAIRS` syntax documented for both forms.
- Commented-out `provider_outcome:cfg:ProviderOutcomes` entry with activation rationale.

## Verification

- [x] Existing pairs: `16 constructors / 3 pairs / 0 drifts` unchanged.
- [x] KCAF pair smoke-tested: 1 drift correctly surfaced (`call_err`), 3 others matched.
- [x] `set -euo pipefail` guard intact.
- [x] Hard tool dependency check (`rg`/`awk`/`sed`/`sort`/`grep`/`tr`) unchanged.
- [ ] CI `tla-annotation-drift.yml` (added iter 21) — expected pass on path-scoped trigger.

## Trade-off

- 장점: 모든 KCAF-style CONSTANT-alphabet spec이 validator coverage 안에 들어옴.  Iter 30 Gap 3 (validator coverage 부재) 구조적 해결.  미래 RFC-D-1.a/D-1.c land 시 즉시 enforce.
- 단점: KCAF pair 자체가 commented out — 실제 enforcement는 follow-up까지 대기.  smoke test로 capability 검증했으나 main에서는 dormant.  이건 의도 (activation alone은 workaround-magnet).

## RFC 참조

`RFC-WAIVED: scripts-only validator extension, no subsystem touched per RFC index.`

연관:
- iter 19 KTC B-1 audit (#14767) — R-B-1.c origin.
- iter 20 validator script (#14770 merged) — Validator V1.
- iter 21 CI workflow (#14772) — baseline mechanism.
- iter 28 (#14793 merged) — first paired-update (R-B-1.a apply + baseline removal).
- iter 30 KCAF D-1 audit (#14798) — Gap 1/2/3 identification.
- iter 31 R-D-1.c blocker memo (#14800) — ppx_tla shadowing constraint.
- RFC-WAIVED references compatible with iter 21 precedent.

## 진행 추적

다음 iteration 시작점: **R-D-1.b activation** (paired baseline + KCAF pair uncomment) OR **R-D-1.a** (Call_err 3-way split — closes the surfaced drift instead of baseline-listing it) OR **R-D-1.d** (ppx_tla prefix option — unblocks R-D-1.c).

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>