### PR TITLE
ci(tla-annotation-drift): R-D-1.b activate — KCAF provider_outcome

### DIFF
--- a/.github/workflows/tla-annotation-drift.yml
+++ b/.github/workflows/tla-annotation-drift.yml
@@ -20,6 +20,8 @@ on:
       - 'specs/keeper-state-machine/**'
       - 'lib/keeper/keeper_registry.ml'
       - 'lib/keeper/keeper_state_machine.ml'
+      - 'lib/cascade/cascade_fsm.ml'
+      - 'lib/cascade/cascade_fsm.mli'
       - 'scripts/audit-tla-annotation-drift.sh'
       - 'scripts/tla-annotation-drift-baseline.txt'
       - '.github/workflows/tla-annotation-drift.yml'
@@ -30,6 +32,8 @@ on:
       - 'specs/keeper-state-machine/**'
       - 'lib/keeper/keeper_registry.ml'
       - 'lib/keeper/keeper_state_machine.ml'
+      - 'lib/cascade/cascade_fsm.ml'
+      - 'lib/cascade/cascade_fsm.mli'
       - 'scripts/audit-tla-annotation-drift.sh'
       - 'scripts/tla-annotation-drift-baseline.txt'
   workflow_dispatch: {}

--- a/scripts/audit-tla-annotation-drift.sh
+++ b/scripts/audit-tla-annotation-drift.sh
@@ -95,10 +95,11 @@ declare -a TYPE_SET_PAIRS=(
   # extend to KSM in a follow-up by adding spec-side `PhaseSet` first
   # and matching here.
   #
-  # KCAF pair (activation deferred — surfaces the known 3-way Call_err
-  # vs 1-way OCaml drift documented in iter 30 audit Gap 1.  Enable in
-  # a follow-up that lands paired baseline entries.):
-  #   "provider_outcome:cfg:ProviderOutcomes"
+  # KCAF pair — activated iter 33 (R-D-1.b activation, this PR).  The
+  # known `call_err` drift (iter 30 audit Gap 1) is recorded in the
+  # paired baseline file with R-D-1.a as the removal trigger.  CI now
+  # enforces zero NEW drift on provider_outcome going forward.
+  "provider_outcome:cfg:ProviderOutcomes"
 )
 
 # Aux: extract spec set members.  Greps the `XxxSet == { ... }` block,

--- a/scripts/tla-annotation-drift-baseline.txt
+++ b/scripts/tla-annotation-drift-baseline.txt
@@ -12,15 +12,28 @@
 #
 # References:
 #   - docs/tla-audit/ktc-b1-turn-phase-spec-gap-2026-05-12.md (iter 19)
+#   - docs/tla-audit/kcaf-d1-attempt-fsm-coverage-2026-05-12.md (iter 30)
 #   - PR #14770 (validator script, iter 20)
 #   - PR #14767 (KTC B-1 audit memo)
+#   - PR #14803 (R-D-1.b cfg CONSTANT-style support, iter 32)
+#   - PR #14798 (KCAF D-1 audit, iter 30)
 
-# (Baseline currently empty.)
+# R-D-1.a pending: KCAF spec §ProviderOutcomes has a 3-way call_err
+# alphabet (call_err_cascadeable / _terminal / _hard_quota) while OCaml
+# `Cascade_fsm.provider_outcome` carries a single `Call_err`
+# constructor with runtime classification via
+# `Cascade_health_filter.should_cascade_to_next` plus
+# `sdk_error_is_hard_quota` (keeper_turn_driver.ml:657-669).
 #
-# R-B-1.a landed in iter 28 (this PR): KTC TurnPhaseSet extended to
-# include `routing` and `exhausted`.  Both prior baseline entries
-# removed.  CI now enforces zero turn_phase drift going forward.
+# Production correctness preserved through:
+#   - Cascade_health_filter corpus tests
+#   - 3-BugAction model in KeeperCascadeAttemptFSM-buggy.cfg
+#   - Fun.protect finalizer in with_keeper_turn_slot
 #
-# Per-action transition modeling for routing/exhausted is intentionally
-# deferred — see B-2 follow-up audit
+# Removal trigger: R-D-1.a (Call_err 3-way split) lands.  See iter 30
+# audit memo §"Three RFC candidates".
+provider_outcome:call_err
+
+# Per-action transition modeling for KTC routing/exhausted is
+# intentionally deferred — see B-2 follow-up audit
 # (`docs/tla-audit/ktc-b1-turn-phase-spec-gap-2026-05-12.md`).


### PR DESCRIPTION
## Finding (Iteration 33, R-D-1.b activation — 4-iter KCAF chain closure)

**Spec**: `specs/keeper-state-machine/KeeperCascadeAttemptFSM.cfg` (`ProviderOutcomes` CONSTANT)
**OCaml**: `lib/cascade/cascade_fsm.ml:7-13` (`provider_outcome` typed surface)
**Validator**: `scripts/audit-tla-annotation-drift.sh` (TYPE_SET_PAIRS uncommented), `scripts/tla-annotation-drift-baseline.txt` (paired baseline)
**CI**: `.github/workflows/tla-annotation-drift.yml` (path scope extended)
**Aspect**: Activate KCAF type/set pair that iter 32 added as commented placeholder.
**Risk**: LOW — drift is baseline-known, CI passes on current main, future regressions caught.
**Workaround signature**: N/A — paired-baseline policy mirrors iter 28 #14793 precedent.

## 순서도

```mermaid
flowchart LR
  subgraph Chain [4-iter KCAF chain]
    A[iter 30 #14798<br/>D-1 audit memo<br/>3 gaps identified]
    B[iter 31 #14800<br/>R-D-1.c blocker<br/>ppx_tla shadowing]
    C[iter 32 #14803 ✓<br/>R-D-1.b capability<br/>cfg parser]
    D[iter 33 THIS PR<br/>R-D-1.b activation<br/>baseline + uncomment]
    A --> B
    A --> C
    C --> D
    A -.->|Gap 1| D
  end
  subgraph Result [Validator state]
    R1[20 constructors / 4 pairs / 0 new / 1 baseline-known]
  end
  D --> Result
```

## Verbose validator output (after activation)

```
── turn_phase ↔ TurnPhaseSet (tla) ──
  ✓ idle, prompting, routing, executing, compacting, finalizing, exhausted
── decision_stage ↔ DecisionSet (tla) ──
  ✓ undecided, guard_ok, gate_rejected, tool_policy_selected
── cascade_state ↔ CascadeSet (tla) ──
  ✓ idle, selecting, trying, done, exhausted
── provider_outcome ↔ ProviderOutcomes (cfg) ──   ← NEW
  ✓ accept_rejected, call_ok, slot_full
  ~ call_err — known drift, skipped (baseline)

tla-annotation-drift summary: 20 constructors checked across 4 type/set pairs,
                              0 new drift(s), 1 baseline-known drift(s)
```

## Three files modified

### 1. `scripts/audit-tla-annotation-drift.sh` (+5/-4)

Uncomment `"provider_outcome:cfg:ProviderOutcomes"` in `TYPE_SET_PAIRS`.  Replace deferral rationale with activation history reference.

### 2. `scripts/tla-annotation-drift-baseline.txt` (+19/-7)

Add `provider_outcome:call_err` baseline entry.  Cross-reference iter 30 audit + iter 32 capability PR.  Document removal trigger (R-D-1.a Call_err 3-way split).

### 3. `.github/workflows/tla-annotation-drift.yml` (+4)

Extend path scope on both `pull_request` and `push` triggers to include `lib/cascade/cascade_fsm.ml` and `.mli` — so the validator fires when the `provider_outcome` type is modified.

## 왜 톱니처럼 정교하지 않은가

Iter 32 added validator *capability* for CONSTANT-style spec alphabets but left activation deferred to avoid surfacing the known iter 30 Gap 1 drift on every spec-touching PR (CI failure pressure → workaround-magnet).  This PR pairs activation with a baseline entry so CI passes verbatim on current main while NEW regressions are now caught.

이 PR이 닫는 것은 *iter 30 audit의 3 gap class 중 Gap 3* (validator coverage 부재).  Gap 1 (Call_err runtime-classified) 은 baseline에 기록되어 R-D-1.a apply 시까지 보존.  Gap 2 (`decision` 타입 `[@@deriving tla]` 부재) 는 R-D-1.c/d 블락커 별도 트랙.

## 본 PR 수정

3 files, +28/-10 LOC total — CI activation + baseline pair + path scope.

## Verification

- [x] Validator: `20 constructors checked across 4 type/set pairs, 0 new drift(s), 1 baseline-known drift(s)` — exit 0.
- [x] Verbose run: KCAF symbols (accept_rejected, call_ok, slot_full) match cleanly.  `call_err` correctly routed to baseline-known.
- [x] Baseline file references iter 30 audit + iter 32 capability PR.
- [x] CI workflow path scope extended.
- [ ] CI `tla-annotation-drift` job (path-scoped trigger on this PR's diff).

## Trade-off

- 장점: iter 30 Gap 3 구조적 해결.  R-B-1.c validator coverage 50% 확장 (3→4 pairs, KTC + KCAF).  CI enforces zero NEW provider_outcome drift going forward.  Paired-baseline policy mirrors iter 28 precedent.
- 단점: Gap 1 (call_err 3-way drift)은 baseline에 *기록*만 됨 — R-D-1.a 실제 구현은 다음 iter 후보.  Gap 2는 별도 R-D-1.c/d 블락커 트랙.

## RFC 참조

`RFC-WAIVED: scripts + CI activation only, no subsystem touched per RFC index.`

연관:
- iter 30 KCAF D-1 audit (#14798) — Gap 1/2/3 identification.
- iter 31 R-D-1.c blocker (#14800) — ppx_tla shadowing.
- iter 32 R-D-1.b capability (#14803 ✓ merged) — cfg parser.
- iter 28 R-B-1.a closure (#14793 ✓ merged) — paired-baseline policy precedent.

## 진행 추적

다음 iteration 시작점: **R-D-1.a** (Call_err 3-way split — baseline removal trigger, MID multi-file) OR **R-D-1.d** (ppx_tla prefix option — unblocks R-D-1.c) OR **B-2** (KTC RoutingStart action modeling).

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>