### PR TITLE
feat(telemetry): extend Checkpoint_failure_operation + new Fs_failure_site

### DIFF
--- a/lib/keeper/checkpoint_failure_operation.ml
+++ b/lib/keeper/checkpoint_failure_operation.ml
@@ -6,6 +6,8 @@ type t =
   | Oas_io
   | Oas_sdk
   | Load_legacy
+  | Migration_save
+  | Restore_legacy
 
 let to_label = function
   | Migrate_main_history -> "migrate_main_history"
@@ -15,4 +17,6 @@ let to_label = function
   | Oas_io -> "oas_io"
   | Oas_sdk -> "oas_sdk"
   | Load_legacy -> "load_legacy"
+  | Migration_save -> "migration_save"
+  | Restore_legacy -> "restore_legacy"
 ;;

--- a/lib/keeper/checkpoint_failure_operation.mli
+++ b/lib/keeper/checkpoint_failure_operation.mli
@@ -13,5 +13,7 @@ type t =
   | Oas_io (** Generic OAS checkpoint I/O failure. *)
   | Oas_sdk (** OAS SDK-level checkpoint error. *)
   | Load_legacy (** Legacy checkpoint format load failure. *)
+  | Migration_save (** Persisting a migrated checkpoint to the OAS store failed. *)
+  | Restore_legacy (** Restoring the working context from a legacy checkpoint raised. *)
 
 val to_label : t -> string

--- a/lib/keeper/fs_failure_site.ml
+++ b/lib/keeper/fs_failure_site.ml
@@ -1,0 +1,12 @@
+type t =
+  | Ensure_dir_cancelled
+  | Ensure_dir_failed
+  | Save_atomic_failed
+  | Save_atomic_raised
+
+let to_label = function
+  | Ensure_dir_cancelled -> "ensure_dir_cancelled"
+  | Ensure_dir_failed -> "ensure_dir_failed"
+  | Save_atomic_failed -> "save_atomic_failed"
+  | Save_atomic_raised -> "save_atomic_raised"
+;;

--- a/lib/keeper/fs_failure_site.mli
+++ b/lib/keeper/fs_failure_site.mli
@@ -1,0 +1,13 @@
+(** Fs_failure_site — closed sum for the [site] label on
+    [metric_keeper_fs_failures].
+
+    Replaces 4 hardcoded literals in [keeper_fs.ml].  Each value names
+    a distinct failure path in keeper-side filesystem helpers. *)
+
+type t =
+  | Ensure_dir_cancelled (** mkdir-p path was cancelled mid-flight. *)
+  | Ensure_dir_failed (** mkdir-p raised a non-cancellation exception. *)
+  | Save_atomic_failed (** Atomic save returned Error (write/rename/fsync failed). *)
+  | Save_atomic_raised (** Atomic save raised an unexpected exception. *)
+
+val to_label : t -> string

--- a/lib/keeper/keeper_context_core.ml
+++ b/lib/keeper/keeper_context_core.ml
@@ -1428,7 +1428,7 @@ let load_context_from_checkpoint ~max_checkpoint_messages ~trace_id ~primary_mod
          | Error detail ->
              Prometheus.inc_counter
                Keeper_metrics.metric_keeper_checkpoint_failures
-               ~labels:[("operation", "migration_save")]
+               ~labels:[("operation", Checkpoint_failure_operation.(to_label Migration_save))]
                ();
              Log.Keeper.error
                "keeper:%s checkpoint migration save failed: %s"
@@ -1455,7 +1455,7 @@ let load_context_from_checkpoint ~max_checkpoint_messages ~trace_id ~primary_mod
        with ex ->
          Prometheus.inc_counter
            Keeper_metrics.metric_keeper_checkpoint_failures
-           ~labels:[("operation", "restore_legacy")]
+           ~labels:[("operation", Checkpoint_failure_operation.(to_label Restore_legacy))]
            ();
          Log.Keeper.error "keeper:%s checkpoint restore failed: %s"
            trace_id (Printexc.to_string ex);

--- a/lib/keeper/keeper_fs.ml
+++ b/lib/keeper/keeper_fs.ml
@@ -33,14 +33,14 @@ let ensure_dir (path : string) : string =
         | Eio.Cancel.Cancelled _ as exn ->
             Prometheus.inc_counter
               Keeper_metrics.metric_keeper_fs_failures
-              ~labels:[("path", path); ("site", "ensure_dir_cancelled")]
+              ~labels:[("path", path); ("site", Fs_failure_site.(to_label Ensure_dir_cancelled))]
               ();
             Log.Keeper.warn "keeper_fs: ensure_dir cancelled path=%s" path;
             Error (exn, Printexc.get_raw_backtrace ())
         | exn ->
             Prometheus.inc_counter
               Keeper_metrics.metric_keeper_fs_failures
-              ~labels:[("path", path); ("site", "ensure_dir_failed")]
+              ~labels:[("path", path); ("site", Fs_failure_site.(to_label Ensure_dir_failed))]
               ();
             Log.Keeper.warn "keeper_fs: ensure_dir failed path=%s: %s"
               path (Printexc.to_string exn);
@@ -79,7 +79,7 @@ let save_atomic (path : string) (content : string) : (unit, string) result =
     | Error msg ->
         Prometheus.inc_counter
           Keeper_metrics.metric_keeper_fs_failures
-          ~labels:[("path", path); ("site", "save_atomic_failed")]
+          ~labels:[("path", path); ("site", Fs_failure_site.(to_label Save_atomic_failed))]
           ();
         Log.Keeper.warn "keeper_fs: save_atomic failed path=%s error=%s" path msg;
         Error msg
@@ -89,7 +89,7 @@ let save_atomic (path : string) (content : string) : (unit, string) result =
       let msg = Printexc.to_string exn in
       Prometheus.inc_counter
         Keeper_metrics.metric_keeper_fs_failures
-        ~labels:[("path", path); ("site", "save_atomic_raised")]
+        ~labels:[("path", path); ("site", Fs_failure_site.(to_label Save_atomic_raised))]
         ();
       Log.Keeper.warn "keeper_fs: save_atomic raised path=%s error=%s" path msg;
       Error msg


### PR DESCRIPTION
## Summary

Two follow-ups:

1. **Extend `Checkpoint_failure_operation.t`** with `Migration_save` +
   `Restore_legacy`.  These 2 sites in `keeper_context_core.ml` (lines
   1431, 1458) were missed by #14795 (T17) — they sit 50+ lines below
   the primary cluster the audit grep caught (lines 784–1385) and
   only surfaced after a fresh `git show origin/main` audit on this
   iteration.

2. **New `Fs_failure_site.t`** for `metric_keeper_fs_failures.site`
   label (4 sites in `keeper_fs.ml`):

   | Variant | Site |
   |---------|------|
   | `Ensure_dir_cancelled` | mkdir-p cancellation |
   | `Ensure_dir_failed` | mkdir-p non-cancel exception |
   | `Save_atomic_failed` | atomic save returned Error |
   | `Save_atomic_raised` | atomic save raised unexpected exception |

## Why

Same single-file cluster pattern as #14788/#14795/#14799.  After T17
audit caught 7 of 9 checkpoint failure sites, the remaining 2 surfaced
on re-audit.  Fs failure site is a separate metric in the same
`_failures.<label>` family.

## Test plan

- [ ] CI green
- [ ] `rg '"operation", "(migration_save|restore_legacy)"' lib/keeper/keeper_context_core.ml` = 0
- [ ] `rg '"site", "(ensure_dir_cancelled|ensure_dir_failed|save_atomic_failed|save_atomic_raised)"' lib/keeper/keeper_fs.ml` = 0

RFC-WAIVED: not in credential/identity/operator/sandbox/hooks/workflow scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)