### PR TITLE
fix(cascade_config): make sticky_ttl_ms cascade_strategy.kind tuple match exhaustive

### DIFF
--- a/lib/cascade/cascade_config.ml
+++ b/lib/cascade/cascade_config.ml
@@ -1308,10 +1308,19 @@ let resolve_strategy ?config_path ~name () =
       | _ -> (parsed_kind, [])
     in
     let sticky_ttl_ms =
+      (* Enumerate every [Cascade_strategy.kind] variant so the compiler
+         flags any new strategy added here. [sticky_ttl_ms] is only
+         meaningful for [Sticky]; the six other strategies today produce
+         0 (no TTL applicable). A future strategy that *also* needs a
+         per-attempt TTL (e.g. [Hash_sticky], [Affinity]) would inherit
+         "no TTL" silently under the previous [_, _ -> 0] catch-all. *)
       match kind, cfg.sticky_ttl_ms with
       | Cascade_strategy.Sticky, Some n -> n
       | Cascade_strategy.Sticky, None -> Cascade_strategy.default_sticky_ttl_ms
-      | _, _ -> 0
+      | ( Cascade_strategy.Failover | Cascade_strategy.Capacity_aware
+        | Cascade_strategy.Weighted_random
+        | Cascade_strategy.Circuit_breaker_cycling
+        | Cascade_strategy.Priority_tier | Cascade_strategy.Round_robin ), _ -> 0
     in
     let defaults = Cascade_strategy.default_scoring_params in
     let scoring = {


### PR DESCRIPTION
## Why

`sticky_ttl_ms` resolution dispatches on `(kind, cfg.sticky_ttl_ms)`:

\`\`\`ocaml
match kind, cfg.sticky_ttl_ms with
| Cascade_strategy.Sticky, Some n -> n
| Cascade_strategy.Sticky, None -> Cascade_strategy.default_sticky_ttl_ms
| _, _ -> 0
\`\`\`

`Cascade_strategy.kind` has 7 constructors today: `Failover | Capacity_aware | Weighted_random | Circuit_breaker_cycling | Priority_tier | Sticky | Round_robin`. The `_, _` catch-all silently absorbs the 6 non-Sticky strategies — correctly returning 0 (no TTL applicable) today.

A future strategy that *also* needs a per-attempt TTL (e.g. a hypothetical `Hash_sticky` or `Affinity_persistent` mirroring `Sticky` for a different hashing scheme) would silently inherit 0 with no review point. Same FSM Sparse Match anti-pattern as the closed-sum tuple matches addressed in PRs #14716, #14762, #14790.

## What

\`\`\`ocaml
| Cascade_strategy.Sticky, Some n -> n
| Cascade_strategy.Sticky, None -> Cascade_strategy.default_sticky_ttl_ms
| ( Cascade_strategy.Failover | Cascade_strategy.Capacity_aware
  | Cascade_strategy.Weighted_random
  | Cascade_strategy.Circuit_breaker_cycling
  | Cascade_strategy.Priority_tier | Cascade_strategy.Round_robin ), _ -> 0
\`\`\`

Behavior unchanged for the current 7 kinds. Adding an 8th constructor to `Cascade_strategy.kind` will now trigger `Warning 8: this pattern-matching is not exhaustive` at this site, forcing the maintainer to deliberately decide whether the new strategy needs a TTL.

## Verification

\`\`\`
dune build lib/cascade/cascade_config.ml --root .   # exit 0
\`\`\`

## Scope

Surgical. One match expression, one file, no behavior change. No `.mli` change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)