### PR TITLE
perf(cascade_oas_runner): fix misnamed assignable_set — actual Hashtbl, not reversed list

### DIFF
--- a/lib/cascade/cascade_oas_runner.ml
+++ b/lib/cascade/cascade_oas_runner.ml
@@ -522,8 +522,19 @@ let resolve_tool_capable_provider_across_cascades
   | Error _ -> None
   | Ok all_names ->
     let assignable_names = Keeper_cascade_profile.keeper_catalog_names () in
-    let assignable_set = List.fold_left (fun acc n -> n :: acc) [] assignable_names in
-    let is_keeper_assignable name = List.mem name assignable_set in
+    (* Name had said "set" but the prior implementation was
+       [List.fold_left (fun acc n -> n :: acc) [] assignable_names] —
+       i.e. a reversed list with O(N) [List.mem] semantics.
+       [is_keeper_assignable] fires once per cascade in the
+       [List.concat_map] below; with N cascades x M assignable_names
+       that was O(N x M).  Materialise an actual Hashtbl so the
+       lookup is O(1) and the name matches the behaviour. *)
+    let assignable_set : (string, unit) Hashtbl.t =
+      let tbl = Hashtbl.create (List.length assignable_names) in
+      List.iter (fun n -> Hashtbl.replace tbl n ()) assignable_names;
+      tbl
+    in
+    let is_keeper_assignable name = Hashtbl.mem assignable_set name in
     let scored_candidates =
       all_names
       |> List.filter (fun name -> name <> exclude_cascade)


### PR DESCRIPTION
## Summary

\`resolve_tool_capable_provider_across_cascades\` (lib/cascade/cascade_oas_runner.ml:524-526) had a variable named \`assignable_set\` whose implementation was a **reversed list**, not a set:

\`\`\`ocaml
let assignable_names = Keeper_cascade_profile.keeper_catalog_names () in
let assignable_set = List.fold_left (fun acc n -> n :: acc) [] assignable_names in
let is_keeper_assignable name = List.mem name assignable_set in
\`\`\`

The fold is \`List.rev\` written longhand; the \`List.mem\` against it is O(N) per check. \`is_keeper_assignable\` fires once per cascade in the \`List.concat_map\` ~40 lines below, so with N cascades × M assignable_names the cost is O(N × M) per invocation — and this function runs per cascade-routing decision.

## Fix

Replace with an actual \`(string, unit) Hashtbl\`:

\`\`\`ocaml
let assignable_set : (string, unit) Hashtbl.t =
  let tbl = Hashtbl.create (List.length assignable_names) in
  List.iter (fun n -> Hashtbl.replace tbl n ()) assignable_names;
  tbl
in
let is_keeper_assignable name = Hashtbl.mem assignable_set name in
\`\`\`

Per-cascade check drops to O(1). The variable name now matches the semantics.

## Why this surfaces a broader pattern

The misleading name suggests an incomplete refactor: someone started writing set semantics, got distracted, and ended up with a list copy that masquerades as a set. The bug is **both** a correctness/clarity issue (name lies about behavior) and a perf issue (lookup is linear). A grep heuristic for "vars named \`*_set\` with non-set implementations" would have caught this earlier.

## Test plan

- [ ] CI lib/ build green
- [ ] Cascade-routing smoke: \`is_keeper_assignable\` returns the same booleans as before for known catalog names

🤖 Generated with [Claude Code](https://claude.com/claude-code)