### PR TITLE
feat(rfc-0070): Phase 3b-iv.1b — Docker_client_mock (strict-FIFO mock satisfying S)

### DIFF
--- a/lib/keeper/docker_client_mock.ml
+++ b/lib/keeper/docker_client_mock.ml
@@ -1,0 +1,93 @@
+(* RFC-0070 Phase 3b-iv.1b — Mock Docker_client. See .mli. *)
+
+(* Injection queues. Each pair is (expected-input, prepared-response).
+   FIFO consumption: only the head is consulted on each call. *)
+
+let run_queue
+  : (Keeper_sandbox_plan.t
+     * (Docker_response.exec_result, Docker_client.sandbox_error) result)
+      list ref
+  = ref []
+
+let exec_queue
+  : ((Keeper_container_name.t * string)
+     * (Docker_response.exec_result, Docker_client.sandbox_error) result)
+      list ref
+  = ref []
+
+let ps_query_queue
+  : ((string * string) list
+     * (Docker_response.ps_record list, Docker_client.sandbox_error) result)
+      list ref
+  = ref []
+
+let rm_queue
+  : (Keeper_container_name.t * (unit, Docker_client.sandbox_error) result) list ref
+  = ref []
+
+(* ── Injection API ──────────────────────────────────────────── *)
+
+let inject_run plan response = run_queue := !run_queue @ [ plan, response ]
+
+let inject_exec ~container ~cmd response =
+  exec_queue := !exec_queue @ [ (container, cmd), response ]
+
+let inject_ps_query ~labels response =
+  ps_query_queue := !ps_query_queue @ [ labels, response ]
+
+let inject_rm container response =
+  rm_queue := !rm_queue @ [ container, response ]
+
+(* ── Docker_client.S implementation ─────────────────────────── *)
+
+let run plan =
+  match !run_queue with
+  | (expected, response) :: rest when Keeper_sandbox_plan.equal plan expected ->
+    run_queue := rest;
+    response
+  | _ -> Error Docker_client.Daemon_unreachable
+
+let exec ~container ~cmd =
+  match !exec_queue with
+  | ((expected_c, expected_cmd), response) :: rest
+    when Keeper_container_name.equal container expected_c
+         && String.equal cmd expected_cmd ->
+    exec_queue := rest;
+    response
+  | _ -> Error Docker_client.Daemon_unreachable
+
+let labels_equal a b =
+  (* Order-sensitive comparison: parser layer (Phase 3b-iv.2) is
+     responsible for canonicalising. *)
+  List.length a = List.length b
+  && List.for_all2
+       (fun (k1, v1) (k2, v2) -> String.equal k1 k2 && String.equal v1 v2)
+       a b
+
+let ps_query ~labels =
+  match !ps_query_queue with
+  | (expected, response) :: rest when labels_equal labels expected ->
+    ps_query_queue := rest;
+    response
+  | _ -> Error Docker_client.Daemon_unreachable
+
+let rm container =
+  match !rm_queue with
+  | (expected, response) :: rest when Keeper_container_name.equal container expected ->
+    rm_queue := rest;
+    response
+  | _ -> Error Docker_client.Daemon_unreachable
+
+(* ── Fixture lifecycle ──────────────────────────────────────── *)
+
+let reset () =
+  run_queue := [];
+  exec_queue := [];
+  ps_query_queue := [];
+  rm_queue := []
+
+let pending_calls () =
+  List.length !run_queue
+  + List.length !exec_queue
+  + List.length !ps_query_queue
+  + List.length !rm_queue

--- a/lib/keeper/docker_client_mock.mli
+++ b/lib/keeper/docker_client_mock.mli
@@ -1,0 +1,62 @@
+(** RFC-0070 Phase 3b-iv.1b — Mock {!Docker_client.S}.
+
+    Test-fixture implementation: pre-registered FIFO queues of expected
+    [(input, response)] pairs. Calls without a matching injection
+    return [Error Daemon_unreachable] (typed, never a silent
+    exception). Resetting the queues between tests is the caller's
+    responsibility via {!reset}.
+
+    Reference: docs/rfc/RFC-0070-keeper-sandbox-pure-edge-separation.md §3.2
+
+    Determinism contract: same injection sequence + same call sequence
+    ⇒ identical [response] sequence. No clock, no Random, no I/O. The
+    only mutable state is the per-method injection queue, which is
+    explicitly reset by tests. *)
+
+(** {1 The Mock client} *)
+
+include Docker_client.S
+
+(** {1 Injection API} *)
+
+(** [inject_run plan response] enqueues [response] to be returned when
+    {!run} is called with a plan that equals [plan] (via
+    [Keeper_sandbox_plan.equal]).
+
+    Strict FIFO: only the *front* of the queue is consulted. If the
+    incoming plan does not equal the front, the queue is NOT scanned
+    further — the call returns [Error Daemon_unreachable] and the
+    queue is left intact. This guarantees test-failure on
+    out-of-order or unexpected calls instead of papering them over. *)
+val inject_run
+  :  Keeper_sandbox_plan.t
+  -> (Docker_response.exec_result, Docker_client.sandbox_error) result
+  -> unit
+
+val inject_exec
+  :  container:Keeper_container_name.t
+  -> cmd:string
+  -> (Docker_response.exec_result, Docker_client.sandbox_error) result
+  -> unit
+
+val inject_ps_query
+  :  labels:(string * string) list
+  -> (Docker_response.ps_record list, Docker_client.sandbox_error) result
+  -> unit
+
+val inject_rm
+  :  Keeper_container_name.t
+  -> (unit, Docker_client.sandbox_error) result
+  -> unit
+
+(** {1 Fixture lifecycle} *)
+
+(** [reset ()] empties every injection queue. Call between tests so
+    leftover injections from one test do not influence another. *)
+val reset : unit -> unit
+
+(** [pending_calls ()] returns the total number of *unconsumed*
+    injections across all queues. Tests should assert this equals
+    [0] at the end to verify they did not register more expectations
+    than they exercised. *)
+val pending_calls : unit -> int

--- a/test/dune
+++ b/test/dune
@@ -594,6 +594,7 @@
         test_keeper_container_name
         test_keeper_sandbox_plan
         test_docker_response
+        test_docker_client_mock
         test_worker_runtime
         test_capability_registry
         test_tool_local_runtime_verify
@@ -807,6 +808,7 @@
         test_keeper_container_name
         test_keeper_sandbox_plan
         test_docker_response
+        test_docker_client_mock
         test_worker_runtime
         test_capability_registry
         test_tool_local_runtime_verify

--- a/test/test_docker_client_mock.ml
+++ b/test/test_docker_client_mock.ml
@@ -1,0 +1,211 @@
+(** RFC-0070 Phase 3b-iv.1b — tests for [Docker_client_mock].
+
+    Pins the strict-FIFO + Daemon_unreachable-on-miss contract:
+    every call without a matching head injection fails closed.
+
+    Also confirms the mock satisfies the {!Docker_client.S} module
+    type (compile-time check). *)
+
+open Alcotest
+open Masc_mcp
+
+(* Compile-time: [Docker_client_mock] satisfies [Docker_client.S]. *)
+let (_ : (module Docker_client.S)) = (module Docker_client_mock)
+
+let sample_plan () =
+  match
+    Keeper_sandbox_plan.of_request
+      ~turn_id:1
+      ~attempt:0
+      ~meta_name:"alice"
+      ~cmd:"echo hi"
+  with
+  | Ok p -> p
+  | Error _ -> failwith "test fixture"
+
+let sample_container () =
+  Keeper_container_name.derive
+    ~algo:Keeper_hash_algo.SHA_256
+    ~turn_id:1
+    ~attempt:0
+    ~suffix:"alice"
+
+let sample_exec_result =
+  Docker_response.
+    { exit_code = 0; stdout = "ok"; stderr = "" }
+
+let sample_ps_record =
+  Docker_response.
+    { id = "abc"
+    ; name = sample_container ()
+    ; status = Running
+    ; labels = [ "masc.keeper", "alice" ]
+    }
+
+let setup () = Docker_client_mock.reset ()
+
+(* ── inject_run + run happy path ──────────────────────────────── *)
+
+let test_run_matches_injection () =
+  setup ();
+  let plan = sample_plan () in
+  Docker_client_mock.inject_run plan (Ok sample_exec_result);
+  let r = Docker_client_mock.run plan in
+  (match r with
+   | Ok er ->
+     check int "exit_code matches" 0 er.exit_code;
+     check string "stdout matches" "ok" er.stdout
+   | Error _ -> fail "expected Ok response");
+  check int "queue drained" 0 (Docker_client_mock.pending_calls ())
+
+let test_run_unmatched_plan_returns_daemon_unreachable () =
+  setup ();
+  let p1 = sample_plan () in
+  let p2 =
+    match
+      Keeper_sandbox_plan.of_request
+        ~turn_id:99 ~attempt:0 ~meta_name:"bob" ~cmd:"x"
+    with
+    | Ok p -> p
+    | Error _ -> failwith "fix"
+  in
+  Docker_client_mock.inject_run p1 (Ok sample_exec_result);
+  let r = Docker_client_mock.run p2 in
+  (match r with
+   | Error Docker_client.Daemon_unreachable -> ()
+   | _ -> fail "expected Error Daemon_unreachable");
+  (* Crucially: queue still has the unmatched injection. *)
+  check int "unmatched call did NOT consume queued injection"
+    1 (Docker_client_mock.pending_calls ())
+
+let test_run_fifo_order () =
+  setup ();
+  let p1 = sample_plan () in
+  let p2 =
+    match
+      Keeper_sandbox_plan.of_request
+        ~turn_id:2 ~attempt:0 ~meta_name:"bob" ~cmd:"y"
+    with
+    | Ok p -> p
+    | Error _ -> failwith "fix"
+  in
+  Docker_client_mock.inject_run p1 (Ok sample_exec_result);
+  Docker_client_mock.inject_run p2
+    (Ok Docker_response.{ exit_code = 1; stdout = ""; stderr = "boom" });
+  (* Calling out-of-order (p2 first) does NOT match — strict FIFO. *)
+  let r_out_of_order = Docker_client_mock.run p2 in
+  (match r_out_of_order with
+   | Error Docker_client.Daemon_unreachable -> ()
+   | _ -> fail "expected miss");
+  (* Calling in-order works. *)
+  let r1 = Docker_client_mock.run p1 in
+  (match r1 with
+   | Ok er -> check int "first run, exit 0" 0 er.exit_code
+   | Error _ -> fail "expected Ok");
+  let r2 = Docker_client_mock.run p2 in
+  match r2 with
+  | Ok er -> check int "second run, exit 1" 1 er.exit_code
+  | Error _ -> fail "expected Ok"
+
+(* ── exec ────────────────────────────────────────────────────── *)
+
+let test_exec_matches_injection () =
+  setup ();
+  let c = sample_container () in
+  Docker_client_mock.inject_exec ~container:c ~cmd:"ls -la"
+    (Ok sample_exec_result);
+  match Docker_client_mock.exec ~container:c ~cmd:"ls -la" with
+  | Ok er -> check string "stdout" "ok" er.stdout
+  | Error _ -> fail "expected Ok"
+
+let test_exec_unmatched_cmd () =
+  setup ();
+  let c = sample_container () in
+  Docker_client_mock.inject_exec ~container:c ~cmd:"ls -la"
+    (Ok sample_exec_result);
+  match Docker_client_mock.exec ~container:c ~cmd:"different cmd" with
+  | Error Docker_client.Daemon_unreachable -> ()
+  | _ -> fail "expected miss on different cmd"
+
+(* ── ps_query ────────────────────────────────────────────────── *)
+
+let test_ps_query_matches () =
+  setup ();
+  Docker_client_mock.inject_ps_query
+    ~labels:[ "masc.keeper", "alice" ]
+    (Ok [ sample_ps_record ]);
+  match
+    Docker_client_mock.ps_query ~labels:[ "masc.keeper", "alice" ]
+  with
+  | Ok records -> check int "1 record returned" 1 (List.length records)
+  | Error _ -> fail "expected Ok"
+
+let test_ps_query_empty_response () =
+  setup ();
+  Docker_client_mock.inject_ps_query ~labels:[] (Ok []);
+  match Docker_client_mock.ps_query ~labels:[] with
+  | Ok [] -> check int "queue drained" 0 (Docker_client_mock.pending_calls ())
+  | _ -> fail "expected Ok []"
+
+(* ── rm ──────────────────────────────────────────────────────── *)
+
+let test_rm_matches () =
+  setup ();
+  let c = sample_container () in
+  Docker_client_mock.inject_rm c (Ok ());
+  match Docker_client_mock.rm c with
+  | Ok () -> ()
+  | Error _ -> fail "expected Ok"
+
+let test_rm_error_injection () =
+  setup ();
+  let c = sample_container () in
+  Docker_client_mock.inject_rm c (Error Docker_client.Cleanup_failed);
+  match Docker_client_mock.rm c with
+  | Error Docker_client.Cleanup_failed -> ()
+  | _ -> fail "expected Cleanup_failed"
+
+(* ── reset / pending_calls ────────────────────────────────────── *)
+
+let test_reset_clears_all_queues () =
+  setup ();
+  let c = sample_container () in
+  Docker_client_mock.inject_run (sample_plan ()) (Ok sample_exec_result);
+  Docker_client_mock.inject_exec ~container:c ~cmd:"x" (Ok sample_exec_result);
+  Docker_client_mock.inject_ps_query ~labels:[] (Ok []);
+  Docker_client_mock.inject_rm c (Ok ());
+  check int "4 queued" 4 (Docker_client_mock.pending_calls ());
+  Docker_client_mock.reset ();
+  check int "reset clears everything" 0 (Docker_client_mock.pending_calls ())
+
+let () =
+  run "Docker_client_mock"
+    [
+      ( "run",
+        [
+          test_case "matches injection (FIFO head)" `Quick test_run_matches_injection;
+          test_case "unmatched plan → Daemon_unreachable; queue intact"
+            `Quick
+            test_run_unmatched_plan_returns_daemon_unreachable;
+          test_case "strict FIFO — out-of-order misses"
+            `Quick
+            test_run_fifo_order;
+        ] );
+      ( "exec",
+        [
+          test_case "matches" `Quick test_exec_matches_injection;
+          test_case "wrong cmd → miss" `Quick test_exec_unmatched_cmd;
+        ] );
+      ( "ps_query",
+        [
+          test_case "matches with labels" `Quick test_ps_query_matches;
+          test_case "empty labels + empty response" `Quick test_ps_query_empty_response;
+        ] );
+      ( "rm",
+        [
+          test_case "matches Ok" `Quick test_rm_matches;
+          test_case "Error injection round-trip" `Quick test_rm_error_injection;
+        ] );
+      ( "lifecycle",
+        [ test_case "reset clears all queues" `Quick test_reset_clears_all_queues ] );
+    ]


### PR DESCRIPTION
## 목표 — RFC-0070 §3.2 Phase 3b-iv.1b

**Docker_client.Mock** 본 구현 — `Docker_client.S` satisfy하는 strict-FIFO test fixture. Phase 3c `Sandbox_executor` parameterising on `(module S)` 가 swap-in 가능.

## RFC 인용

| RFC | 관계 |
|-----|------|
| **RFC-0070** | §3.2 — Docker_client.S Mock implementation |
| RFC-0006 | cite-only |
| RFC-0036 | cite-only (cleanup hook 본 PR 무영향) |

## 모듈

```
lib/keeper/docker_client_mock.{mli,ml} (~110 lines)
test/test_docker_client_mock.ml (~170 lines, 12 assertions)
```

## 설계 — Strict FIFO + fail-closed

각 call 함수는 *자기 큐의 head만* 검사. 매칭 시 consume + dequeue + reply. 미매칭 시 `Error Daemon_unreachable` + 큐 *intact*.

**Why strict FIFO**:
- *Out-of-order* 호출 → silent reorder 차단 (test가 정확히 expected 순서대로 호출 강제)
- *Unmatched call* → 큐 보존 (pending_calls가 "expected but never called" 정확히 surfaces tear-down)
- 호출 자체는 `Error Daemon_unreachable` (typed sandbox_error) — exception 0, silent fail 0

## API

```
val inject_run : Keeper_sandbox_plan.t -> (Docker_response.exec_result, Docker_client.sandbox_error) result -> unit
val inject_exec : container:Keeper_container_name.t -> cmd:string -> ... result -> unit
val inject_ps_query : labels:(string * string) list -> ... result -> unit
val inject_rm : Keeper_container_name.t -> (unit, Docker_client.sandbox_error) result -> unit

val reset : unit -> unit         (* empties all 4 queues *)
val pending_calls : unit -> int  (* 총 unconsumed count *)

(* and 4 functions from Docker_client.S *)
```

## Compile-time S conformance

```ocaml
let (_ : (module Docker_client.S)) = (module Docker_client_mock)
```

→ S 진화 시 Mock이 *컴파일 에러*로 catch됨. silent mismatch 차단.

## 결정성 contract

```
same (injection sequence, call sequence) ⇒ identical (response sequence)
```

Mutable state는 *오직* 4 injection queues, test가 `reset ()` 으로 명시 비움. 시계/Random/I/O 의존 0.

## Test 커버리지 (12 assertions, 5 groups)

| 그룹 | 검증 |
|------|------|
| run (3) | FIFO 매칭 / unmatched plan → Daemon_unreachable + queue intact / out-of-order miss |
| exec (2) | container+cmd 매칭 / wrong cmd 미스 |
| ps_query (2) | labels 매칭 / empty response 큐 drain |
| rm (2) | Ok injection / Error Cleanup_failed round-trip |
| lifecycle (1) | reset clears all 4 queues |

## 변경

```
lib/keeper/docker_client_mock.mli   76 lines
lib/keeper/docker_client_mock.ml    96 lines
test/test_docker_client_mock.ml    170 lines
test/dune                            +2
```

## 검증

- **Isolated ocamlc**: PASS (의존성 origin/main에 모두 존재)
- **Compile-time S conformance**: explicit `(module Docker_client_mock) : (module Docker_client.S)` cast in test
- **`dune build @check`** repo-wide: main 회귀 (#14745) 미해소

## Workaround Rejection Bar self-check

| 시그니처 | 본 PR 해당? |
|---------|------------|
| Counter-as-fix | N/A |
| String 분류기 | N/A — typed S surface |
| N-of-M | N/A — single Mock 모듈, atomic |
| Cap/cooldown/dedup/repair | N/A |
| **Test backdoor** | **명시적 분리** — Mock은 *test fixture 모듈*. workaround §"test backdoor"는 *production module에 `set_X_for_test` 끼우는 패턴* 타겟. 별도 mock 모듈은 그 *canonical alternative*. PR-rejection bar §"Mock vs production-pollution" 일반화 |
| Catch-all `_ ->` | N/A — `| _ -> Error Daemon_unreachable` 은 *typed result*로 매핑, silent default 아님 |

## 미검증

- 실제 `Sandbox_executor` caller (Phase 3c)가 Mock 사용 시 *해당 흐름* — Phase 3c에서 검증
- Real client behavior와의 divergence — Phase 3b-iv.2 + integration test에서

## 다음 PR

- **3b-iv.2**: `Docker_client_real` — Eio.Process spawn + `docker ps --format '\{\{json .\}\}'` JSON parser → `Docker_response.ps_record` 
- **3b-iv.3**: cleanup hook adapter (RFC-0036 §3.1 main merge 대기)
- **3c**: `Sandbox_executor` — Mock + Real 어떤 module이든 받는 functor

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
