### PR TITLE
fix(cascade_health_tracker): make outcome_matches tuple match exhaustive

### DIFF
--- a/lib/cascade/cascade_health_tracker.ml
+++ b/lib/cascade/cascade_health_tracker.ml
@@ -922,6 +922,13 @@ type outcome_kind =
   | Outcome_soft_rate_limited
 
 let outcome_matches kind ev =
+  (* Enumerate every [outcome_kind] x [outcome] pair so the compiler
+     flags any new variant added to either type. Adding e.g. an
+     [Outcome_circuit_break] kind without a matching [Circuit_break]
+     outcome (or vice versa) would silently inherit [false] under the
+     previous [_, _ -> false] catch-all, masking a probable mismatch.
+     Same FSM Sparse Match anti-pattern as PRs #14716, #14762, #14790,
+     #14806. *)
   match kind, ev.outcome with
   | Outcome_success, Success
   | Outcome_failure, Failure
@@ -929,7 +936,18 @@ let outcome_matches kind ev =
   | Outcome_hard_quota, Hard_quota
   | Outcome_terminal_failure, Terminal_failure
   | Outcome_soft_rate_limited, Soft_rate_limited -> true
-  | _, _ -> false
+  | Outcome_success,
+      (Failure | Rejected | Hard_quota | Terminal_failure | Soft_rate_limited)
+  | Outcome_failure,
+      (Success | Rejected | Hard_quota | Terminal_failure | Soft_rate_limited)
+  | Outcome_rejected,
+      (Success | Failure | Hard_quota | Terminal_failure | Soft_rate_limited)
+  | Outcome_hard_quota,
+      (Success | Failure | Rejected | Terminal_failure | Soft_rate_limited)
+  | Outcome_terminal_failure,
+      (Success | Failure | Rejected | Hard_quota | Soft_rate_limited)
+  | Outcome_soft_rate_limited,
+      (Success | Failure | Rejected | Hard_quota | Terminal_failure) -> false
 
 (* Count [outcome] events recorded for [provider_key] within the last
    [window_s] seconds.  We piggyback on the same event ring used by


### PR DESCRIPTION
## Why

`outcome_matches` in `lib/cascade/cascade_health_tracker.ml:924` dispatches on `(outcome_kind, outcome)`:

```ocaml
match kind, ev.outcome with
| Outcome_success, Success
| Outcome_failure, Failure
| Outcome_rejected, Rejected
| Outcome_hard_quota, Hard_quota
| Outcome_terminal_failure, Terminal_failure
| Outcome_soft_rate_limited, Soft_rate_limited -> true
| _, _ -> false
```

Both `outcome_kind` (line 916) and `outcome` (line 282) are closed sums with 6 variants each. The `_, _` catch-all silently absorbs 30 of 36 pairs — correctly returning `false` for all mismatch combinations today.

A future variant added to either type (e.g. `Outcome_circuit_break` / `Circuit_break`) without a paired-true case would silently inherit `false`. Same FSM Sparse Match anti-pattern (`~/me/instructions/software-development.md`) as recent PRs #14716, #14762, #14790, #14806.

## What

Enumerate the 30 off-diagonal pairs explicitly as 6 grouped patterns (one per `outcome_kind` constructor). Adding a 7th constructor to either type now triggers `Warning 8: pattern-matching is not exhaustive`, forcing the maintainer to deliberately decide whether the new variant pairs with an existing or new one on the other axis.

A short comment explains *why* the catch-all was the wrong default direction (silent "false" overrides per-pair intent) so a future reader doesn't reintroduce it.

## Verification

- `git show` confirms 6 `true`-rows + 6 `false`-rows = 36 pairs, fully exhaustive
- Behavior unchanged: all current pairs that returned `true` still do; all current pairs that returned `false` still do
- Sibling sweep: `grep '_, _ -> false' lib/cascade/cascade_health_tracker.ml` returns zero — single-site fix, no N-of-M

## Self-check (CLAUDE.md Workaround Rejection Bar)

| # | Check | Result |
|---|---|---|
| 1 | telemetry-as-fix? | no — removes catch-all, no counter added |
| 2 | string classifier? | no |
| 3 | N-of-M? | no — only site in file |
| 4 | catch-all added? | no — `_, _ ->` removed |
| 5 | cap/cooldown/dedup? | no |
| 6 | test backdoor? | no |
| 7 | typo N sites? | no |

🤖 Generated with [Claude Code](https://claude.com/claude-code)