### PR TITLE
fix(goal_store): make update-review Goal_phase match exhaustive (followup to #14790)

### DIFF
--- a/lib/goal/goal_store.ml
+++ b/lib/goal/goal_store.ml
@@ -755,9 +755,15 @@ let review_goal config ~goal_id ~(outcome : review_outcome) ?new_horizon ?note (
         last_review_note = note;
         last_review_at = Some now;
         active_verification_request_id =
+          (* Enumerate every [Goal_phase.t] variant. Mirrors the fix
+             applied to [normalize_goal] in PR #14790; this call site
+             was missed in that sweep. Only [Awaiting_verification]
+             retains the active request_id; all other phases clear it. *)
           (match phase with
           | Goal_phase.Awaiting_verification -> goal.active_verification_request_id
-          | _ -> None);
+          | Goal_phase.Executing | Goal_phase.Awaiting_approval
+          | Goal_phase.Blocked | Goal_phase.Paused
+          | Goal_phase.Completed | Goal_phase.Dropped -> None);
         updated_at = now;
       })
 


### PR DESCRIPTION
## Why

`goal_store.ml` has two sites where `active_verification_request_id` is zeroed unless `phase = Awaiting_verification`:

1. `normalize_goal` — closed in PR #14790
2. `update-review` site (around line 757) — **missed in #14790**, fixed here

Both sites had the same shape:

\`\`\`ocaml
match phase with
| Goal_phase.Awaiting_verification -> goal.active_verification_request_id
| _ -> None
\`\`\`

The `_ -> None` catch-all silently absorbs the 6 non-`Awaiting_verification` phases — correct today, but a future phase added to `Goal_phase.t` that should also retain the request_id would silently inherit "clear" with no review point.

## What

Mirror the explicit enumeration from #14790:

\`\`\`ocaml
| Goal_phase.Awaiting_verification -> goal.active_verification_request_id
| Goal_phase.Executing | Goal_phase.Awaiting_approval
| Goal_phase.Blocked | Goal_phase.Paused
| Goal_phase.Completed | Goal_phase.Dropped -> None
\`\`\`

Behavior unchanged for current 7 phases. Adding an 8th phase will now trigger `Warning 8: this pattern-matching is not exhaustive` at *both* `goal_store` sites simultaneously, so a phase introduction can't accidentally diverge between them.

## Verification

\`\`\`
dune build lib/goal/goal_store.ml --root .   # exit 0
\`\`\`

## Scope

Surgical. One match expression, one file, no behavior change. No `.mli` change.

## Process lesson

PR #14790 should have grepped every `Goal_phase.Awaiting_verification -> ... | _ -> None` occurrence, not just the one in `normalize_goal`. Same anti-pattern appearing twice in the same file is exactly the *N-of-M* failure mode flagged in `~/me/instructions/software-development.md` §"AI 페어 프로그래밍 검증 규칙" (a fix that only catches K of N sites). This follow-up closes the gap; future sweeps should grep the **type-and-arm pattern**, not just the function name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)