### PR TITLE
perf(cascade_config): O(N) dedupe_stable — Hashtbl seen, list output

### DIFF
--- a/lib/cascade/cascade_config.ml
+++ b/lib/cascade/cascade_config.ml
@@ -1026,13 +1026,19 @@ let resolve_model_strings_with_trace ?config_path ~name ~defaults () =
     (defaults, { candidates; source = Hardcoded_defaults })
 
 let dedupe_stable (items : string list) =
-  let rec loop seen acc = function
+  (* Stable dedupe (first occurrence wins, ordering preserved).
+     Previous impl scanned a growing [seen] list via [List.mem] per
+     item — O(N^2).  Use a Hashtbl for membership while keeping a
+     list for the ordered output: O(N) total. *)
+  let seen = Hashtbl.create (List.length items) in
+  let rec loop acc = function
     | [] -> List.rev acc
+    | item :: rest when Hashtbl.mem seen item -> loop acc rest
     | item :: rest ->
-      if List.mem item seen then loop seen acc rest
-      else loop (item :: seen) (item :: acc) rest
+        Hashtbl.replace seen item ();
+        loop (item :: acc) rest
   in
-  loop [] [] items
+  loop [] items
 
 let expand_model_strings_for_execution ?rotation_scope (items : string list) =
   items

--- a/test/test_cascade_model_resolve.ml
+++ b/test/test_cascade_model_resolve.ml
@@ -166,6 +166,44 @@ let test_expand_model_strings_for_execution_matches_auto_expansion () =
       (C.expand_auto_models items)
       (C.expand_model_strings_for_execution items))
 
+let test_expand_model_strings_for_execution_dedupe_stable_repeated_inputs () =
+  with_clean_env (fun () ->
+    (* Pure repeated literals: dedupe must keep first occurrence and
+       preserve insertion order. *)
+    let items =
+      [ "codex_cli:gpt-5.2"
+      ; "kimi_cli:kimi-for-coding"
+      ; "codex_cli:gpt-5.2"
+      ; "kimi_cli:kimi-for-coding"
+      ; "codex_cli:gpt-5.2"
+      ]
+    in
+    check (list string) "first occurrence wins, order preserved"
+      [ "codex_cli:gpt-5.2"; "kimi_cli:kimi-for-coding" ]
+      (C.expand_model_strings_for_execution items))
+
+let test_expand_model_strings_for_execution_dedupe_explicit_and_auto () =
+  with_clean_env (fun () ->
+    (* Explicit model that an auto-expansion would also produce: the
+       explicit one (declared first) wins; the auto-expansion's
+       contribution of the same name is dropped, but its other entries
+       remain in expansion order. *)
+    let items = [ "codex_cli:gpt-5.2"; "codex_cli:auto" ] in
+    let expanded = C.expand_model_strings_for_execution items in
+    (* (a) head is the explicit declaration *)
+    check string "explicit first occurrence retained at head"
+      "codex_cli:gpt-5.2"
+      (List.hd expanded);
+    (* (b) duplicate of the explicit name does not reappear *)
+    let occurrences =
+      List.filter (String.equal "codex_cli:gpt-5.2") expanded
+      |> List.length
+    in
+    check int "no duplicate of explicit name" 1 occurrences;
+    (* (c) auto-expansion of other entries still present (sanity) *)
+    check bool "auto-expanded siblings present" true
+      (List.length expanded > 1))
+
 let test_expand_model_strings_for_execution_rotation_scope_rotates () =
   with_clean_env (fun () ->
     State.clear_all ();
@@ -342,6 +380,10 @@ let () =
         `Quick test_expand_auto_models_includes_cli_auto_specs;
       test_case "execution expansion matches auto expansion"
         `Quick test_expand_model_strings_for_execution_matches_auto_expansion;
+      test_case "dedupe_stable: first wins on repeats"
+        `Quick test_expand_model_strings_for_execution_dedupe_stable_repeated_inputs;
+      test_case "dedupe_stable: explicit beats auto-expansion"
+        `Quick test_expand_model_strings_for_execution_dedupe_explicit_and_auto;
       test_case "execution expansion can rotate by scope"
         `Quick test_expand_model_strings_for_execution_rotation_scope_rotates;
       test_case "weighted ordering rotates auto by scope"


### PR DESCRIPTION
## Summary

\`dedupe_stable\` (lib/cascade/cascade_config.ml:1028) is a classic O(N²) dedupe:

\`\`\`ocaml
let rec loop seen acc = function
  | [] -> List.rev acc
  | item :: rest ->
    if List.mem item seen then loop seen acc rest        (* O(|seen|) *)
    else loop (item :: seen) (item :: acc) rest
in
loop [] [] items
\`\`\`

For N items, total work is N × N/2 = O(N²). The caller \`expand_model_strings_for_execution\` invokes this *after* \`List.concat_map (expand_auto_model_string)\`, which can fan a small input list out to 20-50 entries when "auto" pseudo-models expand. That's exactly where the quadratic cost kicks in.

## Fix

Split the dedup concerns:

\`\`\`ocaml
let dedupe_stable (items : string list) =
  let seen = Hashtbl.create (List.length items) in
  let rec loop acc = function
    | [] -> List.rev acc
    | item :: rest when Hashtbl.mem seen item -> loop acc rest
    | item :: rest ->
        Hashtbl.replace seen item ();
        loop (item :: acc) rest
  in
  loop [] items
\`\`\`

| Channel | Role |
|---------|------|
| \`seen : (string, unit) Hashtbl.t\` | O(1) membership |
| \`acc : string list\` | ordered output (first occurrence wins) |

Total: O(N) build + O(N) walk = O(N).

## Behaviour preservation

- **First occurrence wins** — same as before (\`when Hashtbl.mem\` skip; \`else\` adds and marks).
- **Order preserved** — \`acc\` accumulates in reverse, final \`List.rev\` restores input order.
- **Output equivalence** — for any input \`xs\`, new \`dedupe_stable xs\` returns the same list as the old implementation.

## Same shape as prior loop PRs

The "list channel for ordering + Hashtbl channel for membership" split is exactly the pattern used in #14796 (thompson_sampling selected_names) and the misnamed \`assignable_set\` fix in #14807. When the same dedup-while-preserving-order shape keeps surfacing, this is the canonical OCaml answer.

## Test plan

- [ ] CI lib/ build green
- [ ] \`dune runtest test/test_cascade_config*.exe\` passes
- [ ] Smoke: \`expand_model_strings_for_execution\` returns same list as before for a sample input

🤖 Generated with [Claude Code](https://claude.com/claude-code)