### PR TITLE
perf(rfc-0070-3b-iv.1b): Queue.t replaces list-append FIFO (Copilot review)

### DIFF
--- a/lib/keeper/docker_client_mock.ml
+++ b/lib/keeper/docker_client_mock.ml
@@ -1,9 +1,10 @@
 (* RFC-0070 Phase 3b-iv.1b — Mock Docker_client. See .mli. *)
 
 (* Injection queues — proper FIFO via [Queue.t] (amortized O(1) push +
-   O(1) peek/pop), replacing the iter-20 [list @ [x]] form (O(n²)
-   across many injections). Behaviour is identical from the caller's
-   perspective. *)
+   O(1) peek/pop), replacing the previous [q := !q @ [x]] list-append
+   form which was O(n) per push and O(n²) across many injections (the
+   ref-cell + list-append idiom from the original mock).  Behaviour
+   is identical from the caller's perspective. *)
 
 let run_queue
   : (Keeper_sandbox_plan.t
@@ -30,8 +31,15 @@ let rm_queue
 (* ── Injection API ──────────────────────────────────────────── *)
 
 let inject_run plan response = Queue.add (plan, response) run_queue
-let inject_exec ~container ~cmd response = Queue.add ((container, cmd), response) exec_queue
-let inject_ps_query ~labels response = Queue.add (labels, response) ps_query_queue
+
+let inject_exec ~container ~cmd response =
+  Queue.add ((container, cmd), response) exec_queue
+;;
+
+let inject_ps_query ~labels response =
+  Queue.add (labels, response) ps_query_queue
+;;
+
 let inject_rm container response = Queue.add (container, response) rm_queue
 
 (* ── Docker_client.S implementation ─────────────────────────── *)

--- a/lib/keeper/docker_client_mock.ml
+++ b/lib/keeper/docker_client_mock.ml
@@ -1,58 +1,58 @@
 (* RFC-0070 Phase 3b-iv.1b — Mock Docker_client. See .mli. *)
 
-(* Injection queues. Each pair is (expected-input, prepared-response).
-   FIFO consumption: only the head is consulted on each call. *)
+(* Injection queues — proper FIFO via [Queue.t] (amortized O(1) push +
+   O(1) peek/pop), replacing the iter-20 [list @ [x]] form (O(n²)
+   across many injections). Behaviour is identical from the caller's
+   perspective. *)
 
 let run_queue
   : (Keeper_sandbox_plan.t
      * (Docker_response.exec_result, Docker_client.sandbox_error) result)
-      list ref
-  = ref []
+      Queue.t
+  = Queue.create ()
 
 let exec_queue
   : ((Keeper_container_name.t * string)
      * (Docker_response.exec_result, Docker_client.sandbox_error) result)
-      list ref
-  = ref []
+      Queue.t
+  = Queue.create ()
 
 let ps_query_queue
   : ((string * string) list
      * (Docker_response.ps_record list, Docker_client.sandbox_error) result)
-      list ref
-  = ref []
+      Queue.t
+  = Queue.create ()
 
 let rm_queue
-  : (Keeper_container_name.t * (unit, Docker_client.sandbox_error) result) list ref
-  = ref []
+  : (Keeper_container_name.t * (unit, Docker_client.sandbox_error) result) Queue.t
+  = Queue.create ()
 
 (* ── Injection API ──────────────────────────────────────────── *)
 
-let inject_run plan response = run_queue := !run_queue @ [ plan, response ]
-
-let inject_exec ~container ~cmd response =
-  exec_queue := !exec_queue @ [ (container, cmd), response ]
-
-let inject_ps_query ~labels response =
-  ps_query_queue := !ps_query_queue @ [ labels, response ]
-
-let inject_rm container response =
-  rm_queue := !rm_queue @ [ container, response ]
+let inject_run plan response = Queue.add (plan, response) run_queue
+let inject_exec ~container ~cmd response = Queue.add ((container, cmd), response) exec_queue
+let inject_ps_query ~labels response = Queue.add (labels, response) ps_query_queue
+let inject_rm container response = Queue.add (container, response) rm_queue
 
 (* ── Docker_client.S implementation ─────────────────────────── *)
 
+(* Consume-on-match: peek the head; if it matches, pop and reply.
+   Otherwise leave the queue intact and return Daemon_unreachable.
+   Strict FIFO — out-of-order calls fail closed without consuming. *)
+
 let run plan =
-  match !run_queue with
-  | (expected, response) :: rest when Keeper_sandbox_plan.equal plan expected ->
-    run_queue := rest;
+  match Queue.peek_opt run_queue with
+  | Some (expected, response) when Keeper_sandbox_plan.equal plan expected ->
+    ignore (Queue.pop run_queue);
     response
   | _ -> Error Docker_client.Daemon_unreachable
 
 let exec ~container ~cmd =
-  match !exec_queue with
-  | ((expected_c, expected_cmd), response) :: rest
+  match Queue.peek_opt exec_queue with
+  | Some ((expected_c, expected_cmd), response)
     when Keeper_container_name.equal container expected_c
          && String.equal cmd expected_cmd ->
-    exec_queue := rest;
+    ignore (Queue.pop exec_queue);
     response
   | _ -> Error Docker_client.Daemon_unreachable
 
@@ -65,29 +65,29 @@ let labels_equal a b =
        a b
 
 let ps_query ~labels =
-  match !ps_query_queue with
-  | (expected, response) :: rest when labels_equal labels expected ->
-    ps_query_queue := rest;
+  match Queue.peek_opt ps_query_queue with
+  | Some (expected, response) when labels_equal labels expected ->
+    ignore (Queue.pop ps_query_queue);
     response
   | _ -> Error Docker_client.Daemon_unreachable
 
 let rm container =
-  match !rm_queue with
-  | (expected, response) :: rest when Keeper_container_name.equal container expected ->
-    rm_queue := rest;
+  match Queue.peek_opt rm_queue with
+  | Some (expected, response) when Keeper_container_name.equal container expected ->
+    ignore (Queue.pop rm_queue);
     response
   | _ -> Error Docker_client.Daemon_unreachable
 
 (* ── Fixture lifecycle ──────────────────────────────────────── *)
 
 let reset () =
-  run_queue := [];
-  exec_queue := [];
-  ps_query_queue := [];
-  rm_queue := []
+  Queue.clear run_queue;
+  Queue.clear exec_queue;
+  Queue.clear ps_query_queue;
+  Queue.clear rm_queue
 
 let pending_calls () =
-  List.length !run_queue
-  + List.length !exec_queue
-  + List.length !ps_query_queue
-  + List.length !rm_queue
+  Queue.length run_queue
+  + Queue.length exec_queue
+  + Queue.length ps_query_queue
+  + Queue.length rm_queue


### PR DESCRIPTION
## 목표 — PR #14808 후속 (3 Copilot threads)

PR #14808 admin-merge 후 도착한 3 threads 처리.

## RFC 인용

| RFC | 관계 |
|-----|------|
| **RFC-0070** | §3.2 Docker_client.S Mock perf |
| RFC-0006 | cite-only |
| RFC-0036 | cite-only |

## Copilot 3 threads 처리

| Thread | 판정 | 처리 |
|--------|------|------|
| T17 (mock:39) `list @ [x]` O(n²) FIFO | **ACCEPT (perf)** | `Queue.t` 교체 — amortized O(1) push/peek/pop |
| T18 (mock:18) `private_modules` | **REJECT (일관 trail)** | PR #14752 T1, #14764 T7과 동일 사유 — public 의도 (test + Phase 3c caller 접근) |
| T19 (test:11) `open Masc_mcp` wrapper claim | **REJECT (Copilot misinterpretation)** | `rg -l "^open Masc_mcp" test/ \| wc -l` = **224** — masc-mcp test 표준 convention |

## T17 fix details

Behaviour 동일 (strict FIFO + consume-on-match + Daemon_unreachable on miss + queue-intact on miss). 차이는 *operation 복잡도*:

| op | Before | After |
|----|--------|-------|
| inject (push) | O(n) `q := !q @ [x]` | amortized O(1) `Queue.add` |
| match peek | O(1) head pattern | O(1) `Queue.peek_opt` |
| consume | O(n) `q := rest` (rebind) | O(1) `Queue.pop` |
| reset | O(1) `q := []` | O(1) `Queue.clear` |
| pending | O(n) `List.length` | O(1) `Queue.length` |

Test fixtures에서 일반적 영향 미미 (<100 injections per test) — 그러나 정직성 측면에서 정확한 자료구조 사용.

## 검증

- Isolated ocamlc PASS
- Behaviour 변경 0 (test fixture API 표면 동일)

## Workaround Rejection Bar self-check

| 시그니처 | 본 PR 해당? |
|---------|------------|
| Counter-as-fix | N/A |
| String 분류기 | N/A |
| N-of-M | N/A — 3 threads 1 PR |
| Cap/cooldown/dedup/repair | N/A — perf fix, behaviour 보존 |
| Test backdoor | Mock 모듈 자체 (이미 PR #14808에서 명시한 *canonical alternative*) |
| Catch-all `_ ->` | N/A |

## 미검증

- 본 PR이 main 회귀 해소 후 실제 `dune runtest` 통과 — pure refactor, high confidence

3 thread `resolveReviewThread` 처리 예정. T18/T19 reject는 cite previous PR + in-the-wild 컨벤션.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
