### PR TITLE
docs(tla-audit): KCAF D-2 — exhausted_normal vs exhausted_hard_quota

### DIFF
--- a/docs/tla-audit/kcaf-d2-exhausted-asymmetry-2026-05-12.md
+++ b/docs/tla-audit/kcaf-d2-exhausted-asymmetry-2026-05-12.md
@@ -1,0 +1,189 @@
+# KCAF D-2 Audit — `exhausted_normal` vs `exhausted_hard_quota` asymmetry
+
+**Iteration**: 36 (/loop FSM/TLA+/OCaml drift hunt)
+**Date**: 2026-05-12
+**Spec**: `specs/keeper-state-machine/KeeperCascadeAttemptFSM.tla:79-84, 153-174, 240-241` (terminal phase set + ResolveExhaustedNormal/ResolveHardQuota + HardQuotaTerminalImmediate invariant)
+**OCaml**: `lib/cascade/cascade_fsm.ml:20, 44-52` (single `Exhausted` constructor + decide branches), `lib/keeper/keeper_turn_driver.ml:644-672` (hard-quota fast-path)
+**Risk**: MID — spec distinguishes two terminal phases with a load-bearing invariant; OCaml collapses both into one constructor, recovering the distinction only through caller-side flow and side-effects (cooldown record).
+**Type**: Audit-only.  Terminal-phase analog of iter 30 D-1 Gap 1 (input-level `Call_err` runtime classifier).
+
+## Spec model (3 paths to terminal)
+
+```tla
+PhaseSet ==
+    {"idle", "attempting", "awaiting_response",
+     "success", "exhausted_normal", "exhausted_hard_quota"}
+
+TerminalSet == {"success", "exhausted_normal", "exhausted_hard_quota"}
+
+\* Normal exhaustion: last tier + cascadeable error
+ResolveExhaustedNormal ==
+    /\ attempt_phase = "awaiting_response"
+    /\ tier_index = MaxTiers - 1
+    /\ \E outcome \in (ProviderOutcomes \ {"call_ok", "call_err_hard_quota"}):
+         /\ attempt_phase' = "exhausted_normal"
+         /\ slot_held' = FALSE
+         /\ UNCHANGED <<tier_index, hard_quota_taken>>
+
+\* Hard-quota: ANY tier, force terminal, slot released, flag set
+ResolveHardQuota ==
+    /\ attempt_phase = "awaiting_response"
+    /\ last_outcome' = "call_err_hard_quota"
+    /\ attempt_phase' = "exhausted_hard_quota"
+    /\ slot_held' = FALSE
+    /\ hard_quota_taken' = TRUE
+    /\ UNCHANGED <<tier_index>>
+
+\* Load-bearing invariant
+HardQuotaTerminalImmediate ==
+    attempt_phase = "exhausted_hard_quota" => hard_quota_taken
+```
+
+Two distinct terminal phases.  `hard_quota_taken` flag tracks whether
+the hard-quota fast-path fired.  Spec asserts: if FSM landed in
+`exhausted_hard_quota`, the flag MUST be true.  This is what
+`BugHardQuotaBypass` (spec line 191) violates.
+
+## OCaml model (single constructor, branch in caller)
+
+```ocaml
+(* lib/cascade/cascade_fsm.ml:20 — single typed surface *)
+| Exhausted of { last_err : Llm_provider.Http_client.http_error option }
+    [@tla.symbol "exhausted"]
+
+(* lib/cascade/cascade_fsm.ml:44, 52 — decide returns Exhausted from
+   two distinct semantic paths *)
+| Accept_rejected { response; reason } when is_last && not accept_on_exhaustion ->
+    Exhausted { last_err = Some (AcceptRejected { reason }) }
+| Call_err err when not should_cascade ->
+    Exhausted { last_err = Some err }
+```
+
+`decide` is *agnostic to hard-quota*.  The classification happens upstream:
+
+```ocaml
+(* lib/keeper/keeper_turn_driver.ml:654-672 *)
+match sdk_error_to_cascade_outcome sdk_err with
+| Some outcome ->
+  let decision =
+    if sdk_error_is_hard_quota sdk_err then
+      let last_err = ... in
+      Cascade_fsm.Exhausted { last_err }    (* fast-path: skip decide *)
+    else
+      Cascade_fsm.decide ~accept_on_exhaustion:false ~is_last outcome
+  in
+  ...
+```
+
+Both branches return the **same** `Exhausted` constructor.  The
+distinction is:
+- *Whether the hard-quota predicate fired* (runtime branch taken).
+- *Cooldown side effect* recorded ~line 1760 (before this match).
+- *Tier index* (hard-quota fires on any tier, normal only on last).
+
+None of these are visible to the caller's `| Cascade_fsm.Exhausted _ ->`
+pattern at line 512, 722.  Once `decide`-or-fast-path returns, the
+two semantic paths are indistinguishable.
+
+## Why this is the terminal-phase analog of D-1 Gap 1
+
+| Gap level | D-1 (iter 30) | D-2 (this) |
+|---|---|---|
+| Spec abstract alphabet | `call_err_cascadeable` / `_terminal` / `_hard_quota` | `exhausted_normal` / `exhausted_hard_quota` |
+| OCaml type | single `Call_err` | single `Exhausted` |
+| Classifier location | `Cascade_health_filter.should_cascade_to_next` (input side) + `sdk_error_is_hard_quota` | `sdk_error_is_hard_quota` (already noted in D-1) + tier_index check |
+| Cross-file coupling | `keeper_turn_driver.ml:657-669` | same site + line 1760 cooldown record |
+| Load-bearing invariant | `BugHardQuotaBypass` violates `HardQuotaTerminalImmediate` | identical |
+| Production preservation | Cascade_health_filter corpus tests + Fun.protect finalizer | + cooldown side effect persists to next turn |
+
+D-1 caught the spec asymmetry at the *error input* level; D-2 catches it at the *terminal output* level.  Both share the same classifier (`sdk_error_is_hard_quota`) and the same cross-file location.
+
+## Where production stays correct (today)
+
+- Hard-quota cooldown side effect (`record_failure` ~line 1760) persists across the `Exhausted` collapse — next turn's selector skips the keeper anyway.
+- `Cascade_metrics.on_exhausted` (cascade_fsm.ml:133) fires for both flavors but with the same `cascade_name` — the metric loses the distinction without the side effect.
+- The bug model in `KeeperCascadeAttemptFSM-buggy.cfg` already covers
+  `BugHardQuotaBypass` at TLC level: it asserts that if the override
+  isn't used, `HardQuotaTerminalImmediate` is violated.  TLC catches
+  the regression spec-side; production catches it via cooldown
+  divergence (a hard-quota retry burning OAS turn budget) — different
+  observability paths.
+
+## Three RFC candidates
+
+| ID | Direction | Risk |
+|---|---|---|
+| **R-D-2.a** | OCaml — split `Cascade_fsm.Exhausted` into typed sub-variants `Exhausted_normal of {...}` and `Exhausted_hard_quota of {...}`.  Removes the runtime-classifier-recovery requirement at every caller.  Pairs cleanly with R-D-1.a (Call_err split) since both share `sdk_error_is_hard_quota`. | MID — type sig change in cascade_fsm.ml/.mli + keeper_turn_driver.ml caller arm + dashboard metric updates + tests.  ~10-15 call sites. |
+| R-D-2.b | Spec — drop the spec asymmetry, merge `exhausted_normal` and `exhausted_hard_quota` into a single `exhausted` terminal.  `hard_quota_taken` flag remains but no longer gates a phase.  Bug model adapts: `BugHardQuotaBypass` instead asserts that `hard_quota_taken` is correctly set rather than that the phase is `_hard_quota`.  LESS recommended — gives up safety surface. | LOW-MID — spec change + TLC re-verify, but reduces drift-catching power. |
+| R-D-2.c | Spec — add inline commentary noting the OCaml classifier lives outside `decide` (in `keeper_turn_driver.ml:657-669`), so the spec's two terminal phases are *role identities* captured by `hard_quota_taken`, not OCaml constructor distinctions.  Honest-doc pattern (iter 27 KCT, iter 35 KTC precedents). | LOW (doc only) |
+
+R-D-2.c is the cheapest LOW alignment fix and matches the established honest-doc pattern.  R-D-2.a is the structurally cleanest correctness fix and could land as a bundle with R-D-1.a (Call_err split) since both share the `sdk_error_is_hard_quota` predicate, which would close both iter 30 Gap 1 and this D-2 gap in one PR.  R-D-2.b is NOT recommended — gives up the spec's load-bearing distinction without commensurate benefit.
+
+## Pattern family: outcome-level classifier drift
+
+iter 30 (D-1) and iter 36 (this D-2) together define a **family of drift**:
+
+```
+Spec:    [typed alphabet at input] → [decision FSM] → [typed alphabet at output]
+              ↑                             ↑                          ↑
+              D-1 gap                       —                          D-2 gap
+              ↓                             ↓                          ↓
+OCaml:   [single Call_err] → [runtime classifier outside decide] → [single Exhausted]
+              ↑                             ↑                          ↑
+              flattens here                 — same classifier —        flattens here
+```
+
+Both gaps share:
+- The same upstream-of-decide classifier (`sdk_error_is_hard_quota`).
+- The same cross-file location (`keeper_turn_driver.ml:654-672`).
+- The same recovery path (the OCaml caller's behavior matches spec's
+  intent through *separately-stored side effects* — cooldown record,
+  tier index — rather than constructor distinctions).
+
+This pattern is a **flat-vs-typed alphabet collapse** at the FSM boundary.
+Closing it structurally requires R-D-2.a + R-D-1.a *together*, treating
+the `sdk_error_is_hard_quota` boundary as the single classifier site to
+move from runtime to constructor.
+
+## R-D-2.a bundled with R-D-1.a (proposed PR shape)
+
+If R-D-1.a (Call_err split) and R-D-2.a (Exhausted split) land in the
+same PR, the diff shape becomes:
+
+1. Update `cascade_fsm.ml/.mli` `provider_outcome` to 6 typed
+   constructors (call_ok, call_err_cascadeable, call_err_terminal,
+   call_err_hard_quota, accept_rejected, slot_full) — matches spec's
+   ProviderOutcomes alphabet.
+2. Update `cascade_fsm.ml/.mli` `decision` to 5 typed constructors
+   (accept, accept_on_exhaustion, try_next, exhausted_normal,
+   exhausted_hard_quota) — matches spec's PhaseSet's terminal members.
+3. Move `sdk_error_is_hard_quota` *into* `cascade_fsm.decide` as a
+   classifier parameter, so the runtime decision is centralized.
+4. Update `keeper_turn_driver.ml:654-672` to remove the fast-path
+   branch — `decide` handles it via constructor selection.
+5. Remove `provider_outcome:call_err` baseline entry from iter 33's
+   addition (paired-removal policy).
+
+This is a sizeable refactor — ~150-300 LOC across cascade + keeper +
+tests — but it closes 3 gaps simultaneously (D-1, D-2, and iter 33
+baseline).  Recommended as a future multi-iteration RFC.
+
+## Out-of-scope for this iteration
+
+- R-D-2.a/b/c implementation — separate PR.
+- Cross-spec invariant linking KCAF terminal phases to KTC `exhausted`
+  in routing projection — Phase E observer concern.
+- `Cascade_metrics.on_exhausted` distinguishing the two flavors —
+  observability follow-up; landing R-D-2.a unlocks it trivially.
+
+## References
+
+- KCAF spec §79-84 (PhaseSet), §153-174 (ResolveExhaustedNormal/Hard),
+  §191-200 (BugHardQuotaBypass), §240-241 (HardQuotaTerminalImmediate).
+- `lib/cascade/cascade_fsm.ml:20, 44-52, 116-133` (decide + caller pattern).
+- `lib/keeper/keeper_turn_driver.ml:644-672, 512, 722` (fast-path +
+  caller-arm pattern matches).
+- iter 30 D-1 audit (`kcaf-d1-attempt-fsm-coverage-2026-05-12.md`) —
+  input-level analog.
+- iter 33 R-D-1.b activation (#14804) — baseline-listed `provider_outcome:call_err`.
+- iter 27 (#14789), iter 35 (#14811) — honest-doc precedents for R-D-2.c.


### PR DESCRIPTION
## Finding (Iteration 36, KCAF D-2 audit)

**Spec**: `specs/keeper-state-machine/KeeperCascadeAttemptFSM.tla:79-84, 153-174, 240-241` (terminal phases + Resolve actions + HardQuotaTerminalImmediate invariant)
**OCaml**: `lib/cascade/cascade_fsm.ml:20, 44-52` (single `Exhausted` constructor) + `lib/keeper/keeper_turn_driver.ml:654-672` (hard-quota fast-path branch)
**Aspect**: Terminal-phase analog of iter 30 D-1 Gap 1 (input-level `Call_err` classifier).  Same pattern family.
**Risk**: MID — spec asserts a load-bearing distinction; OCaml collapses both terminals into one constructor, recovering the difference only through cooldown side effects + tier-index check.
**Workaround signature**: N/A (audit-only)

## 순서도

```mermaid
flowchart LR
  subgraph Spec [KCAF spec]
    A[awaiting_response]
    A -->|tier=last AND cascadeable err<br/>ResolveExhaustedNormal| EN[exhausted_normal]
    A -->|hard_quota override<br/>ResolveHardQuota<br/>hard_quota_taken=TRUE| EH[exhausted_hard_quota]
    EH -.->|HardQuotaTerminalImmediate<br/>load-bearing invariant| Inv[exhausted_hard_quota ⇒ hard_quota_taken]
  end
  subgraph Ocaml [OCaml decide + keeper_turn_driver]
    C[keeper_turn_driver.ml:654-672]
    C -->|if sdk_error_is_hard_quota<br/>FAST PATH| X1[Exhausted last_err]
    C -->|else: Cascade_fsm.decide| D[decide ~is_last]
    D -->|Accept_rejected on last| X2[Exhausted last_err]
    D -->|Call_err NOT cascadeable| X3[Exhausted last_err]
  end
  Spec -.->|spec 2-way| Pattern[Pattern]
  Ocaml -.->|OCaml 1-way + runtime branch + cooldown side effect| Pattern
  Pattern --> Family[Pattern family: flat-vs-typed alphabet collapse at FSM boundary]
```

## Comparison with D-1 (iter 30)

| Gap level | D-1 (iter 30) | **D-2 (this)** |
|---|---|---|
| Spec abstract alphabet | `call_err_cascadeable` / `_terminal` / `_hard_quota` (input) | **`exhausted_normal` / `_hard_quota` (output)** |
| OCaml type | single `Call_err` | **single `Exhausted`** |
| Classifier predicate | `should_cascade_to_next` + `sdk_error_is_hard_quota` | **`sdk_error_is_hard_quota` (shared with D-1)** |
| Cross-file location | `keeper_turn_driver.ml:657-669` | **same site + line 1760 cooldown** |
| Load-bearing invariant | (none; alphabet only) | **HardQuotaTerminalImmediate** |
| Bug model | (none) | **BugHardQuotaBypass exercises it** |

D-1 caught the spec asymmetry at the **input** level; D-2 catches it at the **output** level.  Both share the same classifier and the same cross-file location — they are *two faces of one structural drift*.

## Three RFC candidates

| ID | Direction | Risk |
|---|---|---|
| **R-D-2.a** | OCaml — split `Exhausted` into `Exhausted_normal` / `Exhausted_hard_quota`.  **Bundles cleanly with R-D-1.a** (Call_err split) since both share `sdk_error_is_hard_quota`.  Bundled closes 3 gaps simultaneously (D-1 input, D-2 output, iter 33 baseline). | MID — ~150-300 LOC bundled |
| R-D-2.b | Spec — merge two terminals into one `exhausted` + retain `hard_quota_taken` flag.  Bug model adapts.  **NOT recommended** — gives up safety surface. | LOW-MID |
| **R-D-2.c** | Spec — honest-doc note explaining `sdk_error_is_hard_quota` runs *outside* `decide`, so spec's two terminals are role identities, not OCaml constructor distinctions.  Matches iter 27/35 honest-doc pattern. | LOW (doc only) |

## R-D-2.a + R-D-1.a bundle (proposed PR shape)

1. `cascade_fsm.ml/.mli` — `provider_outcome` to 6 typed constructors matching `ProviderOutcomes`.
2. `cascade_fsm.ml/.mli` — `decision` to 5 typed constructors matching `PhaseSet` terminals.
3. Move `sdk_error_is_hard_quota` *into* `decide` as a classifier — centralizes runtime decision.
4. `keeper_turn_driver.ml:654-672` — remove fast-path branch; `decide` returns correct constructor.
5. Remove `provider_outcome:call_err` baseline entry (paired-removal policy, iter 28 + 33 precedent).

Sizeable refactor but closes 3 gaps + activates structurally cleaner FSM boundary.

## 왜 톱니처럼 정교하지 않은가

같은 `sdk_error_is_hard_quota` predicate가 두 곳에서 spec/OCaml drift을 만든다 — D-1 (input) + D-2 (output).  Single classifier site, two boundary collapses.  Production은 *분리된 side effects* (cooldown record, tier index)으로 분류 정보를 보존하지만, **타입 시스템 차원에서는 정보 손실**이다.

D-1 + D-2 함께 close하면 cascade FSM boundary가 *runtime predicate → constructor selection* 으로 전환된다 (Alexis King "parse, don't validate" 적용).  CLAUDE.md §software-development.md §Coding Principle와 정합.

## 본 PR 수정

`docs/tla-audit/kcaf-d2-exhausted-asymmetry-2026-05-12.md` (+189 LOC, audit only).

## Why production stays correct (today)

- Hard-quota cooldown side effect (~line 1760, `record_failure`) persists across `Exhausted` collapse — next turn's selector skips the keeper.
- `Cascade_metrics.on_exhausted` (cascade_fsm.ml:133) fires both flavors but loses metric distinction without side-effect cross-reference.
- TLC bug model: `BugHardQuotaBypass` + `HardQuotaTerminalImmediate` catches regression spec-side.

## Verification

- [x] Spec terminal phases enumerated (3 of 3 from KCAF.tla:79-84).
- [x] OCaml `Exhausted` collapse confirmed (cascade_fsm.ml:20, 44-52 single constructor; keeper_turn_driver.ml:654-672 two-branch caller).
- [x] Shared classifier confirmed: `sdk_error_is_hard_quota` used at both D-1 input branch (line 569 — caller arms `Try_next`/`Exhausted`) and D-2 output branch (line 657).
- [ ] R-D-2.a/b/c implementation deferred to future iter.

## Trade-off

- 장점: 패턴 family 정의 (D-1 + D-2 = single classifier, two collapses).  R-D-2.a + R-D-1.a 묶음 PR roadmap 명시.  Production safety mechanisms (cooldown, BugAction) enumerated.
- 단점: 코드/스펙 변경 0.  Audit-only.

## RFC 참조

`RFC-WAIVED: audit memo only, no subsystem touched per RFC index.`

연관:
- iter 30 KCAF D-1 audit (`kcaf-d1-attempt-fsm-coverage-2026-05-12.md`) — input-level analog.
- iter 33 R-D-1.b activation (#14804 ✓ merged) — baseline currently lists `provider_outcome:call_err`.
- iter 27 (#14789), iter 35 (#14811) — honest-doc precedents for R-D-2.c.

## 진행 추적

다음 iteration 시작점: **R-D-2.c** (cheapest LOW honest-doc — single inline comment, iter 35 pattern) OR **R-B-2.b** (RoutingExhausted single action, LOW-MID TLC dry-run needed) OR **R-D-2.a + R-D-1.a bundle** (MID multi-file refactor — recommended as eventual closure but defer until ready for ~150-300 LOC change).

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>