### PR TITLE
fix(autonomous_phase): make can_transition tag-pair match exhaustive

### DIFF
--- a/lib/autonomous/autonomous_phase.ml
+++ b/lib/autonomous/autonomous_phase.ml
@@ -130,10 +130,18 @@ module Transition = struct
   let to_string : type a b. (a, b) t -> string =
    fun t -> to_tla_symbol (to_tag t)
 
-  (* The pair match enumerates the same 19 valid edges as the GADT.
-     Constructor-name disambiguation: [Tag_*] are outer (phase) tags
-     visible by parent-scope lookup; [T_*] are this sub-module's
-     transition tags. Pattern names are unambiguous. *)
+  (* The pair match enumerates all 8x8 = 64 (tag, tag) pairs so the
+     compiler flags any new [tag] variant. The 19 valid edges mirror
+     the GADT constructors above; the 45 forbidden edges are now
+     explicit per "from" axis instead of being absorbed by a single
+     [_, _ -> false] catch-all. Adding a 9th phase tag would silently
+     inherit "no transitions" under the catch-all, masking missing
+     edges; with this enumeration the compiler forces every new tag
+     to be considered against every existing tag.
+     Same FSM Sparse Match anti-pattern as PRs #14716, #14790, #14806,
+     #14810, #14812. Constructor-name disambiguation: [Tag_*] are outer
+     (phase) tags visible by parent-scope lookup; [T_*] are this
+     sub-module's transition tags. *)
   let can_transition ~from_ ~to_ =
     match (any_to_tag from_, any_to_tag to_) with
     | Tag_idle, Tag_perceiving -> true
@@ -155,5 +163,28 @@ module Transition = struct
     | Tag_adapting, Tag_planning -> true
     | Tag_adapting, Tag_idle -> true
     | Tag_adapting, Tag_perceiving -> true
-    | _, _ -> false
+    | Tag_idle,
+        (Tag_idle | Tag_intending | Tag_planning | Tag_executing
+        | Tag_verifying | Tag_reflecting)
+    | Tag_perceiving,
+        (Tag_perceiving | Tag_planning | Tag_executing | Tag_verifying
+        | Tag_reflecting | Tag_adapting)
+    | Tag_intending,
+        (Tag_perceiving | Tag_intending | Tag_executing | Tag_verifying
+        | Tag_reflecting | Tag_adapting)
+    | Tag_planning,
+        (Tag_idle | Tag_perceiving | Tag_planning | Tag_verifying
+        | Tag_reflecting | Tag_adapting)
+    | Tag_executing,
+        (Tag_perceiving | Tag_intending | Tag_planning | Tag_executing
+        | Tag_reflecting)
+    | Tag_verifying,
+        (Tag_idle | Tag_perceiving | Tag_intending | Tag_planning
+        | Tag_executing | Tag_verifying)
+    | Tag_reflecting,
+        (Tag_perceiving | Tag_intending | Tag_executing | Tag_verifying
+        | Tag_reflecting)
+    | Tag_adapting,
+        (Tag_intending | Tag_executing | Tag_verifying | Tag_reflecting
+        | Tag_adapting) -> false
 end


### PR DESCRIPTION
## Why

`Autonomous_phase.GADT_transition.can_transition` in `lib/autonomous/autonomous_phase.ml:137` dispatches on `(any_to_tag from_, any_to_tag to_)` where both axes are the closed `tag` sum:

```ocaml
type tag =
  | Tag_idle | Tag_perceiving | Tag_intending | Tag_planning
  | Tag_executing | Tag_verifying | Tag_reflecting | Tag_adapting
```

The original match enumerated 19 allowed transitions + `_, _ -> false` catch-all absorbing the remaining 45 of 64 pairs:

```ocaml
match (any_to_tag from_, any_to_tag to_) with
| Tag_idle, Tag_perceiving -> true
| ...18 more allowed edges...
| _, _ -> false
```

Correct behavior today, but a 9th phase tag added to `tag` would silently inherit "no transitions" under the catch-all — the new tag would appear as a sink with zero outgoing or incoming edges, masking missing FSM edges that the GADT constructors (lines 7-127) already enforce structurally.

Same FSM Sparse Match anti-pattern as PRs #14716, #14790, #14806, #14810, #14812. CLAUDE.md `software-development.md` §"AI 코드 생성 안티패턴 §4 (FSM sparse match)" calls this out directly.

## What

Enumerate the 45 forbidden pairs explicitly as 8 grouped patterns (one per "from" tag). Adding a 9th tag now triggers `Warning 8: pattern-matching is not exhaustive`, forcing the maintainer to deliberately decide which transitions the new phase participates in (on both axes).

Counts: 19 true-rows + 8 grouped-false patterns covering `6+6+6+6+5+6+5+5 = 45` pairs = **64 total** ✓

## Verification

| From | Allowed (true) | Forbidden (false, grouped) |
|---|---|---|
| Tag_idle | perceiving, adapting (2) | idle, intending, planning, executing, verifying, reflecting (6) |
| Tag_perceiving | idle, intending (2) | perceiving, planning, executing, verifying, reflecting, adapting (6) |
| Tag_intending | planning, idle (2) | perceiving, intending, executing, verifying, reflecting, adapting (6) |
| Tag_planning | executing, intending (2) | idle, perceiving, planning, verifying, reflecting, adapting (6) |
| Tag_executing | verifying, adapting, idle (3) | perceiving, intending, planning, executing, reflecting (5) |
| Tag_verifying | reflecting, adapting (2) | idle, perceiving, intending, planning, executing, verifying (6) |
| Tag_reflecting | idle, adapting, planning (3) | perceiving, intending, executing, verifying, reflecting (5) |
| Tag_adapting | planning, idle, perceiving (3) | intending, executing, verifying, reflecting, adapting (5) |

Total: **19 true + 45 false = 64 pairs**. Behavior unchanged.

## Self-check (CLAUDE.md Workaround Rejection Bar)

| # | Check | Result |
|---|---|---|
| 1 | telemetry-as-fix? | no — removes catch-all, no counter |
| 2 | string classifier? | no |
| 3 | N-of-M? | no — only site with this FSM |
| 4 | catch-all added? | no — `_, _ ->` removed |
| 5 | cap/cooldown/dedup? | no |
| 6 | test backdoor? | no |
| 7 | typo N sites? | no |

🤖 Generated with [Claude Code](https://claude.com/claude-code)