### PR TITLE
spec(kcaf): document runtime classifier indirection — R-D-2.c

### DIFF
--- a/specs/INDEX.md
+++ b/specs/INDEX.md
@@ -5,7 +5,7 @@ Edit the generator, not this file. Re-run: scripts/gen-tla-index.sh > specs/INDE
 
 # TLA+ Spec Index
 
-Generated: 2026-05-11T21:25:55Z (HEAD: ae53af478)
+Generated: 2026-05-11T21:46:18Z (HEAD: 1c481d9af)
 
 Source of truth: `specs/`. Run `scripts/gen-tla-index.sh > specs/INDEX.md` to refresh.
 
@@ -119,7 +119,7 @@ Source of truth: `specs/`. Run `scripts/gen-tla-index.sh > specs/INDEX.md` to re
 |------|--------|------|-----|-------|-------------------------|---------------|
 | KeeperAdmissionLiveness.tla | KeeperAdmissionLiveness | manual | 3 | 2 | clean={inv:TypeOK, inv:RateRespect, inv:TokensInRange, inv:QueueWellFormed, inv:TokenInflightConservation} buggy-2={inv:TypeOK, inv:RateRespect, inv:TokensInRange, inv:QueueWellFormed, inv:TokenInflightConservation} buggy={inv:TypeOK, inv:RateRespect, inv:TokensInRange, inv:QueueWellFormed, inv:TokenInflightConservation} | d0de975d7f83 |
 | KeeperApprovalQueue.tla | KeeperApprovalQueue | manual | 2 | 1 | clean={inv:TypeOK, inv:SafetyInvariant} buggy={inv:TypeOK, inv:SafetyInvariant} | a18102f83db7 |
-| KeeperCascadeAttemptFSM.tla | KeeperCascadeAttemptFSM | manual | 2 | 1 | clean={inv:SafetyInvariant} buggy={inv:SafetyInvariant} | b81b3dc6da48 |
+| KeeperCascadeAttemptFSM.tla | KeeperCascadeAttemptFSM | manual | 2 | 1 | clean={inv:SafetyInvariant} buggy={inv:SafetyInvariant} | a6708aff38f9 |
 | KeeperCascadeLifecycle.tla | KeeperCascadeLifecycle | manual | 2 | 1 | clean={inv:Safety, prop:TryingEventuallyTerminates, prop:FinalizingEventuallyClears} buggy={inv:CascadeSelectionRequiresMeasurement} | e305638eb658 |
 | KeeperCascadeRouting.tla | KeeperCascadeRouting | manual | 2 | 1 | clean={inv:TypeOK, inv:KeeperNeverBlockedByCascade, inv:TurnProceedsIfHealthyItemExists, inv:NoGroupCycle, inv:HealthStateConsistent, inv:FallbackCountBounded, inv:SelectedItemInPath} buggy={inv:TypeOK, inv:KeeperNeverBlockedByCascade, inv:TurnProceedsIfHealthyItemExists, inv:NoGroupCycle, inv:HealthStateConsistent, inv:FallbackCountBounded, inv:SelectedItemInPath} | b2bdc9d76d73 |
 | KeeperCircuitBreaker.tla | KeeperCircuitBreaker | manual | 2 | 1 | clean={inv:SafetyInvariant} buggy={inv:TripOnlyWithStreak} | 1d4d87f2bb68 |

--- a/specs/keeper-state-machine/KeeperCascadeAttemptFSM.tla
+++ b/specs/keeper-state-machine/KeeperCascadeAttemptFSM.tla
@@ -42,6 +42,41 @@
 \*     - BugSemaphoreRelease : slot released mid-cascade between tiers
 \*     - BugTryNextLoops    : Try_next fires without advancing tier_index
 \*   At least one invariant MUST be violated.
+\*
+\* Runtime classifier indirection (R-D-2.c, iter 37, 2026-05-12):
+\*   The spec's two terminal phases `exhausted_normal` and
+\*   `exhausted_hard_quota` are ROLE IDENTITIES at the FSM level — both
+\*   collapse to a single `Cascade_fsm.Exhausted { last_err }`
+\*   constructor on the OCaml side (`lib/cascade/cascade_fsm.ml:20`).
+\*
+\*   Classification happens UPSTREAM of `decide` in
+\*   `lib/keeper/keeper_turn_driver.ml:654-672`:
+\*
+\*     if sdk_error_is_hard_quota sdk_err then
+\*       Cascade_fsm.Exhausted { last_err }   (* fast-path, skips decide *)
+\*     else
+\*       Cascade_fsm.decide ~accept_on_exhaustion:false ~is_last outcome
+\*
+\*   Both branches return the SAME constructor.  Production preserves the
+\*   distinction through (a) the cooldown side effect recorded ~line 1760
+\*   and (b) the implicit "fast-path was taken" execution trace.  Callers'
+\*   `| Cascade_fsm.Exhausted _ ->` pattern at lines 512, 722 cannot
+\*   recover the classification.
+\*
+\*   This is the TERMINAL-PHASE ANALOG of the input-level Call_err gap
+\*   documented in D-1 (`kcaf-d1-attempt-fsm-coverage-2026-05-12.md`):
+\*   both gaps share the `sdk_error_is_hard_quota` predicate as the
+\*   runtime classifier site.  See
+\*   `docs/tla-audit/kcaf-d2-exhausted-asymmetry-2026-05-12.md` for the
+\*   pattern-family analysis (flat-vs-typed alphabet collapse at FSM
+\*   boundary) and the R-D-2.a+R-D-1.a bundle proposal that would close
+\*   both gaps structurally.
+\*
+\*   Why the spec keeps the distinction anyway: TLC's
+\*   `HardQuotaTerminalImmediate` invariant + `BugHardQuotaBypass`
+\*   BugAction catch the regression spec-side BEFORE the OCaml collapse;
+\*   the spec is the canonical safety surface for this anti-pattern even
+\*   though OCaml represents it implicitly.
 
 EXTENDS Naturals, Sequences, FiniteSets
 


### PR DESCRIPTION
## Finding (Iteration 37, R-D-2.c apply)

**Spec**: `specs/keeper-state-machine/KeeperCascadeAttemptFSM.tla:37-44` (header §"Bug Model" + new §"Runtime classifier indirection")
**OCaml**: `lib/cascade/cascade_fsm.ml:20` (single `Exhausted` constructor) + `lib/keeper/keeper_turn_driver.ml:654-672` (hard-quota fast-path)
**Aspect**: Apply R-D-2.c — extend KCAF header to acknowledge the runtime-classifier indirection that collapses spec's two terminal phases into OCaml's single constructor.
**Risk**: LOW — comments-only spec change.  TLC clean (29 distinct states) and buggy (SafetyInvariant violated) both unchanged.
**Workaround signature**: N/A — third application of the honest-doc pattern (iter 27/35 precedents).

## 순서도

```mermaid
flowchart TB
  subgraph Spec [KCAF spec — 2 typed terminals]
    A[awaiting_response]
    A -->|ResolveExhaustedNormal<br/>tier=last+cascadeable err| EN[exhausted_normal]
    A -->|ResolveHardQuota<br/>hard_quota_taken=TRUE| EH[exhausted_hard_quota]
    EH -.->|HardQuotaTerminalImmediate<br/>load-bearing invariant| Inv[exhausted_hard_quota ⇒ hard_quota_taken]
  end
  subgraph Ocaml [OCaml — 1 collapsed constructor]
    C[keeper_turn_driver.ml:654-672]
    C -->|if sdk_error_is_hard_quota<br/>FAST PATH| X[Cascade_fsm.Exhausted last_err]
    C -->|else: decide ~is_last| D[decide]
    D -->|Accept_rejected on last| X
    D -->|Call_err NOT cascadeable| X
  end
  Spec -.->|spec safety surface| TLC[TLC bug model<br/>BugHardQuotaBypass +<br/>HardQuotaTerminalImmediate<br/>catches regression]
  Ocaml -.->|production preservation| Side[Cooldown side effect<br/>~line 1760 +<br/>fast-path trace]
```

## Why R-D-2.c (doc-only) over R-D-2.a (bundle)

The D-2 audit (#14815 ✓ merged) identified 3 paths:

| ID | Direction | Risk | Today's pick |
|---|---|---|---|
| **R-D-2.a** + R-D-1.a bundle | OCaml split + classifier into decide | MID ~150-300 LOC | — defer to multi-iter slot |
| R-D-2.b | Spec merge two terminals | LOW-MID, gives up safety | — NOT recommended |
| **R-D-2.c** | Honest-doc note (iter 27/35 pattern) | **LOW (doc only)** | **this PR** |

R-D-2.a+R-D-1.a is the structurally cleanest fix and the eventually-correct path, but its size (~150-300 LOC across cascade + keeper + tests) exceeds the 10-min budget.  R-D-2.c lands the LOW honest-doc closure today while the bundle waits for a deliberate multi-iter slot.

## Before / After (header section addition)

```diff
 \* Bug Model (per project's TLA+ Bug Model convention):
 \*   ...
 \*   At least one invariant MUST be violated.
+\*
+\* Runtime classifier indirection (R-D-2.c, iter 37, 2026-05-12):
+\*   The spec's two terminal phases `exhausted_normal` and
+\*   `exhausted_hard_quota` are ROLE IDENTITIES at the FSM level — both
+\*   collapse to a single `Cascade_fsm.Exhausted { last_err }`
+\*   constructor on the OCaml side ...
+\*   ...
+\*   This is the TERMINAL-PHASE ANALOG of the input-level Call_err gap
+\*   documented in D-1 ... both gaps share the
+\*   `sdk_error_is_hard_quota` predicate ...
```

(+35 LOC, single hunk in header.)

## 왜 톱니처럼 정교하지 않은가

같은 `sdk_error_is_hard_quota` predicate가 D-1 (input) + D-2 (output) 두 곳에서 spec/OCaml drift를 만든다.  Production safety는 cooldown side effect + BugAction TLC + Cascade_metrics으로 보존되지만, *타입 시스템 차원에서는 정보 손실*.

이번 PR은 spec 안에서 *그 indirection을 명시*하여 future maintainer가 "어, 왜 OCaml에서 둘이 같지?" 질문할 때 답을 spec 본문에서 찾을 수 있게 함.  iter 27/35 precedents의 패턴 — 워크어라운드 (gap silence) 의 반대 (honest surface with owner + cross-references).

## 본 PR 수정

`specs/keeper-state-machine/KeeperCascadeAttemptFSM.tla` +35/-0 (comments only) — header §"Runtime classifier indirection" 신규 섹션.  Variables/Init/Next/Actions/Invariants/BugActions 모두 변경 없음.

## Verification

- [x] TLC clean cfg: 29 distinct states, no errors (unchanged from main).
- [x] TLC buggy cfg: SafetyInvariant violated (unchanged — 3 BugActions still trigger).
- [x] Comments-only — no semantic change.
- [ ] CI `tla-specs` job (path-scoped trigger).

## Honest-doc pattern catalog (now 3 datapoints)

| Iter | Spec | Indirection | Owner |
|---|---|---|---|
| 27 (#14789 ✓) | KCT | string-literal cascade names | typed `logical_use` enum + catalog/route lookup |
| 35 (#14811 ✓) | KTC | routing/exhausted action gap | OCaml GADT exhaustiveness + KCAF attempt FSM |
| **37 (this)** | KCAF | terminal-phase classifier | `sdk_error_is_hard_quota` + cooldown side effect |

Pattern: when spec models distinctions OCaml represents implicitly through runtime predicates / external side-effects, the spec gains a header §"<indirection name>" section naming the OCaml site + responsibility owner.  Workaround anti-pattern §CLAUDE.md flags *silencing* gaps; this pattern *surfaces* them.

## Trade-off

- 장점: D-2 audit (#14815)의 LOW RFC closure.  Spec header가 architectural map 역할 (FSM safety surface ↔ runtime classifier indirection).  Future maintainers는 OCaml collapse를 인지하고 R-D-2.a 미적용 상태에서도 spec semantics를 신뢰 가능.
- 단점: 실제 OCaml split (R-D-2.a + R-D-1.a bundle)은 deferred.  Cooldown side effect + fast-path trace가 여전히 OCaml-side preservation mechanism (runtime, not type).

## RFC 참조

`RFC-WAIVED: spec docs-only, no subsystem touched per RFC index.`

연관:
- iter 30 KCAF D-1 audit (#14798 ✓ merged) — input-level analog.
- iter 36 KCAF D-2 audit (#14815 ✓ merged) — 3 RFC candidates + pattern family.
- iter 27 KCT R-C-3.c + R-S2.c bundle (#14789 ✓ merged) — honest-doc precedent.
- iter 35 KTC R-B-2.c (#14811 ✓ merged) — honest-doc precedent.

## 진행 추적

다음 iteration 시작점: **R-D-2.a + R-D-1.a bundle** (MID multi-file ~150-300 LOC — closes iter 33 baseline + D-1 + D-2 gaps in one structural fix) OR **R-B-2.b** (RoutingExhausted action TLC dry-run needed) OR **KCAF D-3** (slot management invariant audit, new sub-aspect).

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>