### PR TITLE
feat(telemetry): 5 typed *_failure_site variants for keeper subsystems (18 sites)

### DIFF
--- a/lib/keeper/approval_queue_failure_site.ml
+++ b/lib/keeper/approval_queue_failure_site.ml
@@ -1,0 +1,18 @@
+type t =
+  | Upsert_rule_save
+  | Matching_rule_save
+  | Audit_store_create
+  | Resolution_callback
+  | Remember_rule
+  | Approval_expired
+  | Expire_callback
+
+let to_label = function
+  | Upsert_rule_save -> "upsert_rule_save"
+  | Matching_rule_save -> "matching_rule_save"
+  | Audit_store_create -> "audit_store_create"
+  | Resolution_callback -> "resolution_callback"
+  | Remember_rule -> "remember_rule"
+  | Approval_expired -> "approval_expired"
+  | Expire_callback -> "expire_callback"
+;;

--- a/lib/keeper/approval_queue_failure_site.mli
+++ b/lib/keeper/approval_queue_failure_site.mli
@@ -1,0 +1,13 @@
+(** Approval_queue_failure_site — closed sum for [site] label on
+    [metric_keeper_approval_queue_failures] (7 sites). *)
+
+type t =
+  | Upsert_rule_save
+  | Matching_rule_save
+  | Audit_store_create
+  | Resolution_callback
+  | Remember_rule
+  | Approval_expired
+  | Expire_callback
+
+val to_label : t -> string

--- a/lib/keeper/compact_audit_failure_site.ml
+++ b/lib/keeper/compact_audit_failure_site.ml
@@ -1,0 +1,12 @@
+type t =
+  | Retention_prune
+  | Persist_start
+  | Persist_complete
+  | Handle_event
+
+let to_label = function
+  | Retention_prune -> "retention_prune"
+  | Persist_start -> "persist_start"
+  | Persist_complete -> "persist_complete"
+  | Handle_event -> "handle_event"
+;;

--- a/lib/keeper/compact_audit_failure_site.mli
+++ b/lib/keeper/compact_audit_failure_site.mli
@@ -1,0 +1,10 @@
+(** Compact_audit_failure_site — closed sum for [site] label on
+    [metric_keeper_compact_audit_failures] (4 sites). *)
+
+type t =
+  | Retention_prune
+  | Persist_start
+  | Persist_complete
+  | Handle_event
+
+val to_label : t -> string

--- a/lib/keeper/crash_persistence_failure_site.ml
+++ b/lib/keeper/crash_persistence_failure_site.ml
@@ -1,0 +1,8 @@
+type t =
+  | Crash_write
+  | Sp_write
+
+let to_label = function
+  | Crash_write -> "crash_write"
+  | Sp_write -> "sp_write"
+;;

--- a/lib/keeper/crash_persistence_failure_site.mli
+++ b/lib/keeper/crash_persistence_failure_site.mli
@@ -1,0 +1,8 @@
+(** Crash_persistence_failure_site — closed sum for [site] label on
+    [metric_keeper_crash_persistence_failures] (2 sites). *)
+
+type t =
+  | Crash_write
+  | Sp_write
+
+val to_label : t -> string

--- a/lib/keeper/execution_receipt_failure_site.ml
+++ b/lib/keeper/execution_receipt_failure_site.ml
@@ -1,0 +1,10 @@
+type t =
+  | Unmapped_disposition
+  | Emit_failed
+  | Stale_broadcast
+
+let to_label = function
+  | Unmapped_disposition -> "unmapped_disposition"
+  | Emit_failed -> "emit_failed"
+  | Stale_broadcast -> "stale_broadcast"
+;;

--- a/lib/keeper/execution_receipt_failure_site.mli
+++ b/lib/keeper/execution_receipt_failure_site.mli
@@ -1,0 +1,9 @@
+(** Execution_receipt_failure_site — closed sum for [site] label on
+    [metric_keeper_execution_receipt_failures] (3 sites). *)
+
+type t =
+  | Unmapped_disposition
+  | Emit_failed
+  | Stale_broadcast
+
+val to_label : t -> string

--- a/lib/keeper/generation_lineage_failure_site.ml
+++ b/lib/keeper/generation_lineage_failure_site.ml
@@ -1,0 +1,8 @@
+type t =
+  | Index_append
+  | Manifest_save
+
+let to_label = function
+  | Index_append -> "index_append"
+  | Manifest_save -> "manifest_save"
+;;

--- a/lib/keeper/generation_lineage_failure_site.mli
+++ b/lib/keeper/generation_lineage_failure_site.mli
@@ -1,0 +1,8 @@
+(** Generation_lineage_failure_site — closed sum for [site] label on
+    [metric_keeper_generation_lineage_failures] (2 sites). *)
+
+type t =
+  | Index_append
+  | Manifest_save
+
+val to_label : t -> string

--- a/lib/keeper/keeper_approval_queue.ml
+++ b/lib/keeper/keeper_approval_queue.ml
@@ -424,7 +424,7 @@ let upsert_rule
        | Error msg ->
          Prometheus.inc_counter
            Keeper_metrics.metric_keeper_approval_queue_failures
-           ~labels:[ "keeper", keeper_name; "site", "upsert_rule_save" ]
+           ~labels:[ "keeper", keeper_name; "site", Approval_queue_failure_site.(to_label Upsert_rule_save) ]
            ();
          Log.Keeper.warn "upsert_rule: save failed: %s" msg);
       candidate, true)
@@ -487,7 +487,7 @@ let find_matching_rule
        | Error msg ->
          Prometheus.inc_counter
            Keeper_metrics.metric_keeper_approval_queue_failures
-           ~labels:[ "keeper", keeper_name; "site", "matching_rule_save" ]
+           ~labels:[ "keeper", keeper_name; "site", Approval_queue_failure_site.(to_label Matching_rule_save) ]
            ();
          Log.Keeper.warn "find_matching_rule: save failed: %s" msg);
       Some { rule_id = rule.id; matched_by = "always_rule" })
@@ -537,7 +537,7 @@ let get_audit_store ?base_path () =
   | exn ->
     Prometheus.inc_counter
       Keeper_metrics.metric_keeper_approval_queue_failures
-      ~labels:[ "keeper", "aggregate"; "site", "audit_store_create" ]
+      ~labels:[ "keeper", "aggregate"; "site", Approval_queue_failure_site.(to_label Audit_store_create) ]
       ();
     Log.Keeper.warn
       "approval_queue: audit store creation failed: %s"
@@ -887,7 +887,7 @@ let resolve_entry ?base_path (entry : pending_approval) (decision : decision) =
       | exn ->
         Prometheus.inc_counter
           Keeper_metrics.metric_keeper_approval_queue_failures
-          ~labels:[ "keeper", entry.keeper_name; "site", "resolution_callback" ]
+          ~labels:[ "keeper", entry.keeper_name; "site", Approval_queue_failure_site.(to_label Resolution_callback) ]
           ();
         Log.Keeper.warn
           "approval_queue: resolution callback failed id=%s err=%s"
@@ -1193,7 +1193,7 @@ let remember_rule_for_entry ?base_path ?created_by (entry : pending_approval) =
     | exn ->
       Prometheus.inc_counter
         Keeper_metrics.metric_keeper_approval_queue_failures
-        ~labels:[ "keeper", entry.keeper_name; "site", "remember_rule" ]
+        ~labels:[ "keeper", entry.keeper_name; "site", Approval_queue_failure_site.(to_label Remember_rule) ]
         ();
       Log.Keeper.warn
         "approval_queue: remember rule failed id=%s err=%s"
@@ -1356,7 +1356,7 @@ let expire_stale ~max_wait_s =
        in
        Prometheus.inc_counter
          Keeper_metrics.metric_keeper_approval_queue_failures
-         ~labels:[ "keeper", entry.keeper_name; "site", "approval_expired" ]
+         ~labels:[ "keeper", entry.keeper_name; "site", Approval_queue_failure_site.(to_label Approval_expired) ]
          ();
        Log.Keeper.warn
          "HITL_APPROVAL_EXPIRED: id=%s keeper=%s tool=%s"
@@ -1390,7 +1390,7 @@ let expire_stale ~max_wait_s =
           | exn ->
             Prometheus.inc_counter
               Keeper_metrics.metric_keeper_approval_queue_failures
-              ~labels:[ "keeper", entry.keeper_name; "site", "expire_callback" ]
+              ~labels:[ "keeper", entry.keeper_name; "site", Approval_queue_failure_site.(to_label Expire_callback) ]
               ();
             Log.Keeper.warn
               "approval_queue: expire callback failed id=%s err=%s"

--- a/lib/keeper/keeper_compact_audit.ml
+++ b/lib/keeper/keeper_compact_audit.ml
@@ -183,7 +183,7 @@ let prune_best_effort base_path ~retention_days =
   | exception e ->
     Prometheus.inc_counter
       Keeper_metrics.metric_keeper_compact_audit_failures
-      ~labels:[("keeper", "global"); ("site", "retention_prune")]
+      ~labels:[("keeper", "global"); ("site", Compact_audit_failure_site.(to_label Retention_prune))]
       ();
     Log.Keeper.warn
       "keeper_compact_audit: retention prune failed: %s"
@@ -356,7 +356,7 @@ let handle_event ~base_path ~retention_days (evt : Agent_sdk.Event_bus.event)
      | Error (Io_failure m | Serialize_failure m) ->
        Prometheus.inc_counter
          Keeper_metrics.metric_keeper_compact_audit_failures
-         ~labels:[("keeper", agent_name); ("site", "persist_start")]
+         ~labels:[("keeper", agent_name); ("site", Compact_audit_failure_site.(to_label Persist_start))]
          ();
        Log.Keeper.warn "keeper_compact_audit: persist_start failed: %s" m)
   | Agent_sdk.Event_bus.ContextCompacted
@@ -386,7 +386,7 @@ let handle_event ~base_path ~retention_days (evt : Agent_sdk.Event_bus.event)
      | Error (Io_failure m | Serialize_failure m) ->
        Prometheus.inc_counter
          Keeper_metrics.metric_keeper_compact_audit_failures
-         ~labels:[("keeper", agent_name); ("site", "persist_complete")]
+         ~labels:[("keeper", agent_name); ("site", Compact_audit_failure_site.(to_label Persist_complete))]
          ();
        Log.Keeper.warn "keeper_compact_audit: persist_complete failed: %s" m)
   | _payload -> Log.Misc.debug "keeper_compact_audit: ignoring non-compaction event"
@@ -425,7 +425,7 @@ let spawn_subscriber
             | exn ->
                Prometheus.inc_counter
                  Keeper_metrics.metric_keeper_compact_audit_failures
-                 ~labels:[("keeper", "batch"); ("site", "handle_event")]
+                 ~labels:[("keeper", "batch"); ("site", Compact_audit_failure_site.(to_label Handle_event))]
                  ();
                Log.Keeper.warn "keeper_compact_audit: handle_event failed: %s"
                  (Printexc.to_string exn))

--- a/lib/keeper/keeper_crash_persistence.ml
+++ b/lib/keeper/keeper_crash_persistence.ml
@@ -130,7 +130,7 @@ let start_drain_fiber ~sw ~clock =
          with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
            Prometheus.inc_counter
              Keeper_metrics.metric_keeper_crash_persistence_failures
-             ~labels:[("site", "crash_write")]
+             ~labels:[("site", Crash_persistence_failure_site.(to_label Crash_write))]
              ();
            Log.Keeper.warn "crash persistence write failed for %s: %s"
              ev.name (Printexc.to_string exn))
@@ -141,7 +141,7 @@ let start_drain_fiber ~sw ~clock =
          with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
            Prometheus.inc_counter
              Keeper_metrics.metric_keeper_crash_persistence_failures
-             ~labels:[("site", "sp_write")]
+             ~labels:[("site", Crash_persistence_failure_site.(to_label Sp_write))]
              ();
            Log.Keeper.warn "sp persistence write failed: %s"
              (Printexc.to_string exn))

--- a/lib/keeper/keeper_execution_receipt.ml
+++ b/lib/keeper/keeper_execution_receipt.ml
@@ -546,7 +546,7 @@ let operator_disposition (receipt : t)
       Prometheus.inc_counter Keeper_metrics.metric_keeper_receipt_unmapped_disposition ();
       Prometheus.inc_counter
         Keeper_metrics.metric_keeper_execution_receipt_failures
-        ~labels:[ "keeper", receipt.keeper_name; "site", "unmapped_disposition" ]
+        ~labels:[ "keeper", receipt.keeper_name; "site", Execution_receipt_failure_site.(to_label Unmapped_disposition) ]
         ();
       Log.Keeper.warn
         "operator_disposition: unmapped (outcome=%s cascade_outcome=%s \
@@ -892,7 +892,7 @@ let append (config : Coord.config) (receipt : t) =
          own diagnostic that watchdogs/log alerts will pick up. *)
       Prometheus.inc_counter
         Keeper_metrics.metric_keeper_execution_receipt_failures
-        ~labels:[ "keeper", receipt.keeper_name; "site", "emit_failed" ]
+        ~labels:[ "keeper", receipt.keeper_name; "site", Execution_receipt_failure_site.(to_label Emit_failed) ]
         ();
       Log.Keeper.error
         "%s: operator_broadcast_required EMIT FAILED disposition=%s reason=%s exn=%s"
@@ -1018,7 +1018,7 @@ let emit_stale_keeper_broadcast
   in
   Prometheus.inc_counter
     Keeper_metrics.metric_keeper_execution_receipt_failures
-    ~labels:[ "keeper", keeper_name; "site", "stale_broadcast" ]
+    ~labels:[ "keeper", keeper_name; "site", Execution_receipt_failure_site.(to_label Stale_broadcast) ]
     ();
   Log.Keeper.error
     "%s: stale_keeper_broadcast emitted last_turn=%.0fs ago cascade=%s seq=%d"

--- a/lib/keeper/keeper_generation_lineage.ml
+++ b/lib/keeper/keeper_generation_lineage.ml
@@ -242,7 +242,7 @@ let record_handoff_artifacts
        | exn ->
            Prometheus.inc_counter
              Keeper_metrics.metric_keeper_generation_lineage_failures
-             ~labels:[("keeper", child.name); ("site", "index_append")]
+             ~labels:[("keeper", child.name); ("site", Generation_lineage_failure_site.(to_label Index_append))]
              ();
            Log.Keeper.warn
              "keeper:%s failed to append generation index %s: %s"
@@ -250,7 +250,7 @@ let record_handoff_artifacts
   | Error err ->
       Prometheus.inc_counter
         Keeper_metrics.metric_keeper_generation_lineage_failures
-        ~labels:[("keeper", child.name); ("site", "manifest_save")]
+        ~labels:[("keeper", child.name); ("site", Generation_lineage_failure_site.(to_label Manifest_save))]
         ();
       Log.Keeper.warn
         "keeper:%s failed to save generation manifest %s: %s"


### PR DESCRIPTION
## Summary

Bulk sweep iteration — five distinct keeper-side `_failures.site`
labels collapsed into typed sums.  Same single-file cluster pattern as
#14788 / #14795 / #14799 / #14805.

## Sites (18 across 5 metrics)

| Metric | Variant | Sites | File |
|--------|---------|-------|------|
| `metric_keeper_approval_queue_failures` | `Approval_queue_failure_site.t` | 7 | `keeper_approval_queue.ml` |
| `metric_keeper_compact_audit_failures` | `Compact_audit_failure_site.t` | 4 | `keeper_compact_audit.ml` |
| `metric_keeper_crash_persistence_failures` | `Crash_persistence_failure_site.t` | 2 | `keeper_crash_persistence.ml` |
| `metric_keeper_execution_receipt_failures` | `Execution_receipt_failure_site.t` | 3 | `keeper_execution_receipt.ml` |
| `metric_keeper_generation_lineage_failures` | `Generation_lineage_failure_site.t` | 2 | `keeper_generation_lineage.ml` |

## Variants

- `Approval_queue_failure_site`: `Upsert_rule_save | Matching_rule_save | Audit_store_create | Resolution_callback | Remember_rule | Approval_expired | Expire_callback`
- `Compact_audit_failure_site`: `Retention_prune | Persist_start | Persist_complete | Handle_event`
- `Crash_persistence_failure_site`: `Crash_write | Sp_write`
- `Execution_receipt_failure_site`: `Unmapped_disposition | Emit_failed | Stale_broadcast`
- `Generation_lineage_failure_site`: `Index_append | Manifest_save`

All expose `to_label : t -> string`.  Wire format byte-equal.

## Why

Continuation of the sweep that's been closing keeper-side
`_failures.<label>` workaround #2 string classifiers metric by metric.
After this PR, the same audit grep
(`rg '~labels:\[.*"site", "[a-z_]+"' lib/keeper/`)
yields a much smaller surface.

## Test plan

- [ ] CI green
- [ ] grep verifies 0 raw-string sites left in the 5 touched files

RFC-WAIVED: not in credential/identity/operator/sandbox/hooks/workflow scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)