### PR TITLE
feat(rfc-0070): Phase 3c.0 — Sandbox_executor functor scaffold

### DIFF
--- a/lib/keeper/sandbox_executor.ml
+++ b/lib/keeper/sandbox_executor.ml
@@ -1,0 +1,5 @@
+(* RFC-0070 Phase 3c.0 — Sandbox_executor scaffold. See .mli. *)
+
+module Make (D : Docker_client.S) = struct
+  let execute_plan plan = D.run plan
+end

--- a/lib/keeper/sandbox_executor.mli
+++ b/lib/keeper/sandbox_executor.mli
@@ -1,0 +1,32 @@
+(** RFC-0070 Phase 3c.0 — Sandbox_executor (scaffold).
+
+    Functor on {!Docker_client.S}. Composes a pure
+    {!Keeper_sandbox_plan.t} with a daemon client to execute one
+    sandbox call end-to-end. Both Mock (Phase 3b-iv.1b) and the
+    upcoming Real (Phase 3b-iv.2) satisfy [S], so this functor is
+    interchangeable across them.
+
+    Reference: docs/rfc/RFC-0070-keeper-sandbox-pure-edge-separation.md §3.2
+
+    Phase 3c.0 scope: minimal scaffold — [execute_plan] is a thin pass
+    through [D.run]. The added value at this phase is *type composition*:
+    Plan → daemon client → typed response, end-to-end. Retry policy
+    (Phase 3c.1) and quarantine state machine (Phase 3c.2, depends on
+    RFC-0036 §3.1 cleanup_hook) follow in separate PRs.
+
+    Determinism contract: deterministic plan + deterministic client ⇒
+    deterministic response. Phase 3c.0 has no clock, no retry, no
+    backoff — execute_plan is a single forward call. *)
+
+module Make : functor (D : Docker_client.S) -> sig
+  (** [execute_plan plan] runs [plan] through [D.run] and returns the
+      typed daemon response.
+
+      Phase 3c.0: 1:1 forwarding. Phase 3c.1 adds retry policy on
+      [Daemon_unreachable] / [Image_pull_failed]; other
+      [sandbox_error] arms remain immediate (caller-classified
+      retryable-ness lands with the retry policy). *)
+  val execute_plan
+    :  Keeper_sandbox_plan.t
+    -> (Docker_response.exec_result, Docker_client.sandbox_error) result
+end

--- a/test/dune
+++ b/test/dune
@@ -595,6 +595,7 @@
         test_keeper_sandbox_plan
         test_docker_response
         test_docker_client_mock
+        test_sandbox_executor
         test_worker_runtime
         test_capability_registry
         test_tool_local_runtime_verify
@@ -809,6 +810,7 @@
         test_keeper_sandbox_plan
         test_docker_response
         test_docker_client_mock
+        test_sandbox_executor
         test_worker_runtime
         test_capability_registry
         test_tool_local_runtime_verify

--- a/test/test_sandbox_executor.ml
+++ b/test/test_sandbox_executor.ml
@@ -1,0 +1,128 @@
+(** RFC-0070 Phase 3c.0 — tests for [Sandbox_executor.Make].
+
+    Demonstrates the Mock + functor composition end-to-end:
+    [Sandbox_executor.Make(Docker_client_mock)] satisfies the same
+    interface that [Sandbox_executor.Make(Docker_client_real)] will
+    in Phase 3b-iv.2. *)
+
+open Alcotest
+open Masc_mcp
+
+module Executor = Sandbox_executor.Make (Docker_client_mock)
+
+let setup () = Docker_client_mock.reset ()
+
+let sample_plan ?(turn_id = 1) ?(meta_name = "alice") () =
+  match
+    Keeper_sandbox_plan.of_request
+      ~turn_id
+      ~attempt:0
+      ~meta_name
+      ~cmd:"echo hi"
+  with
+  | Ok p -> p
+  | Error _ -> failwith "test fixture"
+
+let sample_exec_ok =
+  Docker_response.{ exit_code = 0; stdout = "ok"; stderr = "" }
+
+(* ── Happy path: Mock injection consumed end-to-end ─────────── *)
+
+let test_execute_plan_happy () =
+  setup ();
+  let plan = sample_plan () in
+  Docker_client_mock.inject_run plan (Ok sample_exec_ok);
+  let r = Executor.execute_plan plan in
+  (match r with
+   | Ok er -> check string "stdout" "ok" er.stdout
+   | Error _ -> fail "expected Ok");
+  check int "Mock injection consumed (queue empty)"
+    0 (Docker_client_mock.pending_calls ())
+
+(* ── Error injection round-trip ───────────────────────────────── *)
+
+let test_execute_plan_daemon_unreachable () =
+  setup ();
+  let plan = sample_plan () in
+  Docker_client_mock.inject_run plan (Error Docker_client.Daemon_unreachable);
+  match Executor.execute_plan plan with
+  | Error Docker_client.Daemon_unreachable -> ()
+  | _ -> fail "expected Error Daemon_unreachable"
+
+let test_execute_plan_image_pull_failed () =
+  setup ();
+  let plan = sample_plan () in
+  Docker_client_mock.inject_run plan (Error Docker_client.Image_pull_failed);
+  match Executor.execute_plan plan with
+  | Error Docker_client.Image_pull_failed -> ()
+  | _ -> fail "expected Error Image_pull_failed"
+
+(* ── No injection: Mock's default Daemon_unreachable surfaces ── *)
+
+let test_execute_plan_no_injection () =
+  setup ();
+  let plan = sample_plan () in
+  match Executor.execute_plan plan with
+  | Error Docker_client.Daemon_unreachable -> ()
+  | _ -> fail "expected Mock's default Daemon_unreachable miss"
+
+(* ── Determinism: same plan + same injection ⇒ same response ── *)
+
+let test_determinism () =
+  setup ();
+  let plan = sample_plan () in
+  Docker_client_mock.inject_run plan (Ok sample_exec_ok);
+  Docker_client_mock.inject_run plan (Ok sample_exec_ok);
+  let r1 = Executor.execute_plan plan in
+  let r2 = Executor.execute_plan plan in
+  match r1, r2 with
+  | Ok er1, Ok er2 ->
+    check bool "same inputs ⇒ same response"
+      true (Docker_response.equal_exec_result er1 er2)
+  | _ -> fail "expected both Ok"
+
+(* ── Strict-FIFO interaction with executor: out-of-order plan ── *)
+
+let test_wrong_plan_does_not_consume_injection () =
+  setup ();
+  let p1 = sample_plan ~turn_id:1 () in
+  let p2 = sample_plan ~turn_id:2 () in
+  Docker_client_mock.inject_run p1 (Ok sample_exec_ok);
+  (* Execute the wrong plan first — should miss, queue stays intact. *)
+  let r_miss = Executor.execute_plan p2 in
+  (match r_miss with
+   | Error Docker_client.Daemon_unreachable -> ()
+   | _ -> fail "expected miss");
+  check int "queue intact after miss" 1 (Docker_client_mock.pending_calls ());
+  (* Now execute the right plan — should match + drain. *)
+  let r_ok = Executor.execute_plan p1 in
+  match r_ok with
+  | Ok _ ->
+    check int "queue drained after correct plan"
+      0 (Docker_client_mock.pending_calls ())
+  | _ -> fail "expected Ok after correct plan"
+
+let () =
+  run "Sandbox_executor"
+    [
+      ( "execute_plan",
+        [
+          test_case "happy path forwards Mock's Ok" `Quick test_execute_plan_happy;
+          test_case "Daemon_unreachable round-trip"
+            `Quick
+            test_execute_plan_daemon_unreachable;
+          test_case "Image_pull_failed round-trip"
+            `Quick
+            test_execute_plan_image_pull_failed;
+          test_case "no injection ⇒ default Daemon_unreachable"
+            `Quick
+            test_execute_plan_no_injection;
+        ] );
+      ("determinism", [ test_case "same plan + injection ⇒ same response" `Quick test_determinism ]);
+      ( "FIFO interaction",
+        [
+          test_case "wrong plan misses, queue intact"
+            `Quick
+            test_wrong_plan_does_not_consume_injection;
+        ] );
+    ]


### PR DESCRIPTION
## 목표 — RFC-0070 §3.2 Phase 3c.0

**Sandbox_executor.Make functor scaffold** — Phase 3b-i / 3b-ii / 3b-iii / 3b-iv (all 9 머지) 의 *첫 caller* 증명. RFC §3.2의 "module type S parameterisation"의 첫 실현.

## RFC 인용

| RFC | 관계 |
|-----|------|
| **RFC-0070** | §3.2 — Sandbox_executor functor |
| RFC-0006 | cite-only |
| RFC-0036 | cite-only (Phase 3c.2 cleanup hook 대기) |

## 모듈

```ocaml
module Make : functor (D : Docker_client.S) -> sig
  val execute_plan
    :  Keeper_sandbox_plan.t
    -> (Docker_response.exec_result, Docker_client.sandbox_error) result
end
```

Phase 3c.0: 1:1 forwarding through `D.run`. Phase 3c.1이 retry policy, Phase 3c.2가 quarantine state machine (RFC-0036 의존).

## 결정성 contract

```
deterministic plan + deterministic client ⇒ deterministic response
```

Phase 3c.0: no clock, no retry, no backoff. 단일 forward.

## Caller chain 첫 완성

```
Keeper_sandbox_plan (3b-iii)
  ▶ Keeper_container_name.derive (3b-ii)
    ▶ Keeper_hash_algo.digest_hex (3b-i)
  ▶ Docker_client.S.run (3a + 3b-iv.1a)
    ▶ Docker_client_mock (3b-iv.1b) — 본 PR에서 첫 caller
  ▶ Docker_response.exec_result (3b-iv.0)
```

→ **각 typed module이 finally caller position에서 exercised**. RFC §4 Migration의 Phase 3 "caller cutover" 일부 시작.

## Test 커버리지 (7 assertions, 3 groups)

| 그룹 | 검증 |
|------|------|
| execute_plan (4) | Mock Ok / Daemon_unreachable / Image_pull_failed / no-injection 기본값 |
| determinism (1) | same plan + injection ⇒ same response |
| FIFO interaction (1) | wrong plan misses, queue intact (Phase 3b-iv.1b strict-FIFO 검증) |

**Top-level compile-time witness**:
```ocaml
module Executor = Sandbox_executor.Make (Docker_client_mock)
```
→ Mock이 S 만족 + functor satisfied — *컴파일 시점에 검증*.

## 변경

```
lib/keeper/sandbox_executor.mli   33 lines
lib/keeper/sandbox_executor.ml     6 lines
test/test_sandbox_executor.ml    132 lines (7 assertion)
test/dune                          +2
```

## 검증

- **Isolated ocamlc** PASS — 의존성 origin/main에 모두 존재
- **Compile-time S satisfaction**: `Sandbox_executor.Make (Docker_client_mock)` instantiation succeeds
- **`dune build @check`** repo-wide: main 회귀 (#14745) 미해소

## Workaround Rejection Bar self-check

| 시그니처 | 본 PR 해당? |
|---------|------------|
| Counter-as-fix | N/A |
| String 분류기 | N/A |
| N-of-M | N/A — 1 functor, 1 PR |
| Cap/cooldown/dedup/repair | N/A |
| Test backdoor | N/A |
| Catch-all `_ ->` | N/A — single forwarding |

## 미검증

- Phase 3b-iv.2 Real client 등장 시 *동일 functor*에 swap-in 검증 — Real merge 후 별도 test
- Retry/quarantine 로직 — Phase 3c.1/3c.2

## 다음 PR

- **Phase 3b-iv.2**: `Docker_client_real` (Eio.Process spawn + docker JSON parser) — 본 functor의 두 번째 instance
- **Phase 3c.1**: retry policy on `Sandbox_executor.Make` (count-based, no sleep yet)
- **Phase 3c.2**: cleanup quarantine state machine (RFC-0036 §3.1 의존)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
