### PR TITLE
fix(dashboard_attention): make classify_agent matches exhaustive

### DIFF
--- a/lib/dashboard/dashboard_attention.ml
+++ b/lib/dashboard/dashboard_attention.ml
@@ -42,6 +42,13 @@ let detect_stuck_agents ~(now : float)
   in
   all_agents
   |> List.filter_map (fun (agent : Masc_domain.agent) ->
+         (* Enumerate every [Dashboard_labels.agent_group] variant so
+            the compiler flags any new group added. Only [Stuck] yields
+            an attention item; [Working], [Idle], [Offline] do not. A
+            future group (e.g. [Recovering]) would silently inherit
+            "no attention" under the previous [_ -> None] catch-all.
+            Same FSM Sparse Match anti-pattern as PRs #14716, #14790,
+            #14806, #14810, #14816. *)
          match Dashboard_labels.classify_agent ~now agent with
          | Dashboard_labels.Stuck ->
              let task_info =
@@ -63,7 +70,9 @@ let detect_stuck_agents ~(now : float)
                      task_info;
                  suggested_tool = "masc_observe_capacity";
                }
-         | _ -> None)
+         | Dashboard_labels.Working
+         | Dashboard_labels.Idle
+         | Dashboard_labels.Offline -> None)
 
 (** Detect idle agents when pending tasks exist *)
 let detect_idle_with_pending ~(now : float)
@@ -78,9 +87,13 @@ let detect_idle_with_pending ~(now : float)
     List.length
       (List.filter
          (fun a ->
+           (* Same exhaustive-enumeration reasoning as
+              [detect_stuck_agents] above. *)
            match Dashboard_labels.classify_agent ~now a with
            | Dashboard_labels.Idle -> true
-           | _ -> false)
+           | Dashboard_labels.Working
+           | Dashboard_labels.Stuck
+           | Dashboard_labels.Offline -> false)
          all_agents)
   in
   let pending_count =


### PR DESCRIPTION
## Why

Two sites in `lib/dashboard/dashboard_attention.ml` dispatch on `Dashboard_labels.classify_agent : Masc_domain.agent -> agent_group` where `agent_group` is a closed sum with 4 variants:

```ocaml
type agent_group = Working | Stuck | Idle | Offline [@@deriving eq]
```

Both sites originally used `_` catch-all:

- **`detect_stuck_agents`** (line 45-66): `Stuck -> Some attention_item | _ -> None`
- **`detect_idle_with_pending`** (line 81-83): `Idle -> true | _ -> false`

A future `agent_group` variant (e.g. `Recovering`, `Compacting`) would silently inherit "no attention" / "not idle" under the catch-all, masking missing review of how the new group should be triaged.

Same FSM Sparse Match anti-pattern as PRs #14716, #14790, #14806, #14810, #14816. The attention dashboard is a natural downstream consumer of these closed-sum classifiers — exhaustive enumeration here gives the same compiler-forced review point as the upstream `autonomous_phase.can_transition` fix in #14816.

## What

Enumerate the 3 non-target variants explicitly at each site. Adding a 5th `agent_group` constructor now triggers `Warning 8: pattern-matching is not exhaustive` at both sites.

```ocaml
(* Site 1 — detect_stuck_agents *)
| Dashboard_labels.Stuck -> Some { ... }
| Dashboard_labels.Working
| Dashboard_labels.Idle
| Dashboard_labels.Offline -> None

(* Site 2 — detect_idle_with_pending *)
| Dashboard_labels.Idle -> true
| Dashboard_labels.Working
| Dashboard_labels.Stuck
| Dashboard_labels.Offline -> false
```

Behavior unchanged for current 4 variants.

## Self-check (CLAUDE.md Workaround Rejection Bar)

| # | Check | Result |
|---|---|---|
| 1 | telemetry-as-fix? | no — removes catch-all |
| 2 | string classifier? | no |
| 3 | N-of-M? | **yes** — both sites in same file folded into one PR (avoids separate followup) |
| 4 | catch-all added? | no — both `_ ->` removed |
| 5 | cap/cooldown/dedup? | no |
| 6 | test backdoor? | no |
| 7 | typo N sites? | no — same root pattern, two same-file callsites |

🤖 Generated with [Claude Code](https://claude.com/claude-code)