### PR TITLE
spec(kcl): sync TurnPhaseSet + doc KcafPhaseSet collapse — R-E-1.a+c

### DIFF
--- a/specs/INDEX.md
+++ b/specs/INDEX.md
@@ -5,7 +5,7 @@ Edit the generator, not this file. Re-run: scripts/gen-tla-index.sh > specs/INDE
 
 # TLA+ Spec Index
 
-Generated: 2026-05-11T21:46:18Z (HEAD: 1c481d9af)
+Generated: 2026-05-11T22:06:04Z (HEAD: f0f6fad65)
 
 Source of truth: `specs/`. Run `scripts/gen-tla-index.sh > specs/INDEX.md` to refresh.
 
@@ -124,7 +124,7 @@ Source of truth: `specs/`. Run `scripts/gen-tla-index.sh > specs/INDEX.md` to re
 | KeeperCascadeRouting.tla | KeeperCascadeRouting | manual | 2 | 1 | clean={inv:TypeOK, inv:KeeperNeverBlockedByCascade, inv:TurnProceedsIfHealthyItemExists, inv:NoGroupCycle, inv:HealthStateConsistent, inv:FallbackCountBounded, inv:SelectedItemInPath} buggy={inv:TypeOK, inv:KeeperNeverBlockedByCascade, inv:TurnProceedsIfHealthyItemExists, inv:NoGroupCycle, inv:HealthStateConsistent, inv:FallbackCountBounded, inv:SelectedItemInPath} | b2bdc9d76d73 |
 | KeeperCircuitBreaker.tla | KeeperCircuitBreaker | manual | 2 | 1 | clean={inv:SafetyInvariant} buggy={inv:TripOnlyWithStreak} | 1d4d87f2bb68 |
 | KeeperCompactionLifecycle.tla | KeeperCompactionLifecycle | manual | 2 | 1 | clean={inv:Safety, prop:OverflowEventuallyLeavesOverflow, prop:CompactingEventuallyStops} buggy={inv:CompactingAlignsAll} | ae32b2f6ae60 |
-| KeeperCompositeLifecycle.tla | KeeperCompositeLifecycle | manual | 5 | 4 | clean={inv:SafetyInvariant, prop:EventualMeasurementResolves, prop:RecoveryEventuallyCompletes, prop:OverflowedEventuallyResolves} buggy-attempt={inv:ToolSurfaceFeedsAttempt} buggy-cascade={inv:NoCascadeBeforeMeasurement} buggy-compaction={inv:CompactionAtomicity, inv:PhaseTurnAlignment} buggy-post-turn={inv:PostTurnConsumesAttempt} | 36530914cd50 |
+| KeeperCompositeLifecycle.tla | KeeperCompositeLifecycle | manual | 5 | 4 | clean={inv:SafetyInvariant, prop:EventualMeasurementResolves, prop:RecoveryEventuallyCompletes, prop:OverflowedEventuallyResolves} buggy-attempt={inv:ToolSurfaceFeedsAttempt} buggy-cascade={inv:NoCascadeBeforeMeasurement} buggy-compaction={inv:CompactionAtomicity, inv:PhaseTurnAlignment} buggy-post-turn={inv:PostTurnConsumesAttempt} | cc0b3d033262 |
 | KeeperConditionsGovernPhase.tla | KeeperConditionsGovernPhase | manual | 2 | 1 | clean={inv:Safety, prop:HandoffEventuallyAcknowledged} buggy={inv:TypeOK, prop:HandoffEventuallyAcknowledged} | 191c247c0f8c |
 | KeeperContextLifecycle.tla | KeeperContextLifecycle | manual | 4 | 2 | clean={inv:TypeOK, inv:ContextIsolation, inv:ResumeIdentity, inv:TurnMonotonicity, inv:CompactionPairIntegrity, inv:CheckpointConsistency, inv:BudgetAfterCompaction, prop:CompactionProgress, prop:EventualTurnCompletion, prop:AllKeepersTerminate} buggy={inv:TypeOK, inv:ContextIsolation, inv:ResumeIdentity, inv:TurnMonotonicity, inv:CompactionPairIntegrity, inv:CheckpointConsistency, inv:BudgetAfterCompaction} ci-buggy={inv:ContextIsolation, inv:ResumeIdentity} ci={inv:TypeOK, inv:ContextIsolation, inv:ResumeIdentity, inv:TurnMonotonicity, inv:CompactionPairIntegrity, inv:CheckpointConsistency, inv:BudgetAfterCompaction} | e7d6cf456c70 |
 | KeeperCoreTriad.tla | KeeperCoreTriad | manual | 2 | 1 | clean={inv:SafetyInvariant, prop:RunningEventuallyCompletes CapabilityNeverDeadlocks} buggy={inv:SafetyInvariant} | 040df2f64d84 |

--- a/specs/keeper-state-machine/KeeperCompositeLifecycle.tla
+++ b/specs/keeper-state-machine/KeeperCompositeLifecycle.tla
@@ -134,13 +134,43 @@ vars == <<ksm_phase, ktc_turn_phase, kdp_decision, kcl_cascade_state,
 
 PhaseSet       == {"Running", "Failing", "Overflowed", "Compacting",
                    "HandingOff", "Draining", "Stable"}
-TurnPhaseSet   == {"idle", "prompting", "executing", "compacting",
-                   "finalizing"}
+
+\* TurnPhaseSet: KTC projection.  iter 39 R-E-1.a (2026-05-12) sync —
+\* KTC.tla:127 widened to 7 members in iter 28 (#14793 R-B-1.a) to match
+\* OCaml's 7-constructor `Keeper_registry.turn_phase`; KCL had carried
+\* the pre-iter-28 5-member set, creating a cross-spec drift documented
+\* in `docs/tla-audit/kcl-e1-cross-spec-projection-drift-2026-05-12.md`
+\* (PR #14822 Finding 1, HIGH risk).  Type widening only — KCL's existing
+\* observer actions don't transition into routing/exhausted; per-attempt
+\* FSM is owned by KCAF and the keeper-projection action set by KTC
+\* (B-2 audit #14809).  Action modeling deferred — see KTC R-B-2.{a,b,c}.
+TurnPhaseSet   == {"idle", "prompting", "routing", "executing",
+                   "compacting", "finalizing", "exhausted"}
+
 DecisionSet    == {"undecided", "guard_ok", "gate_rejected",
                    "tool_policy_selected"}
 CascadeSet     == {"idle", "selecting", "trying", "done", "exhausted"}
 CompactionSet  == {"accumulating", "compacting", "done"}
+
+\* KcafPhaseSet: DELIBERATE 3:6 projection collapse from KCAF.tla:79-81.
+\* iter 39 R-E-1.c (2026-05-12, this commit) documents the mapping per
+\* iter 38 KCL E-1 Finding 2 (PR #14822):
+\*
+\*   KCL abstract      ↔  KCAF concrete
+\*   "idle"            ↔  "idle"
+\*   "attempting"      ↔  "attempting", "awaiting_response"
+\*   "terminal"        ↔  "success", "exhausted_normal", "exhausted_hard_quota"
+\*
+\* The terminal collapse silently merges KCAF's distinguished terminals
+\* (exhausted_normal vs exhausted_hard_quota documented in D-2 audit
+\* #14815).  Joint invariants conditioning on `kcaf_attempt_phase` cannot
+\* distinguish hard-quota from normal exhaustion at the cross-spec level
+\* — the D-2 safety surface (HardQuotaTerminalImmediate +
+\* BugHardQuotaBypass) lives only in KCAF, not in any KCL joint property.
+\* This is INTENTIONAL: KCL operates at a coarser observation
+\* granularity; per-terminal-flavor invariants belong in KCAF.
 KcafPhaseSet   == {"idle", "attempting", "terminal"}
+
 KptoPhaseSet   == {"idle", "active", "persisted"}
 ActionSet      == {
                    "StartTurn", "MeasurementBroadcast", "DecideGuard",


### PR DESCRIPTION
## Finding (Iteration 39, R-E-1.a + R-E-1.c bundle)

**Spec**: `specs/keeper-state-machine/KeeperCompositeLifecycle.tla:135-144` (projection sets)
**Source specs**: KTC.tla:127 (iter 28 widened), KCAF.tla:79-81 (iter 30/36/37 audited)
**Aspect**: Close iter 38 KCL E-1 Finding 1 (HIGH) — KCL TurnPhaseSet drift since iter 28 — and document Finding 2 (deliberate KcafPhaseSet 3:6 collapse) in one PR.
**Risk**: LOW-MID — type widening + comments-only.  TLC clean (173 distinct states, depth 41) and all 4 buggy cfgs (4 invariant violations) unchanged.
**Workaround signature**: N/A — closes a HIGH-priority spec-spec drift discovered in iter 38.

## 순서도

```mermaid
flowchart LR
  subgraph Before [KCL projection sets — pre-iter-39]
    T1[TurnPhaseSet = 5<br/>STALE since iter 28]
    K1[KcafPhaseSet = 3<br/>collapse undocumented]
  end
  subgraph After [KCL projection sets — post-iter-39]
    T2[TurnPhaseSet = 7<br/>matches KTC.tla:127]
    K2[KcafPhaseSet = 3<br/>3:6 mapping documented]
  end
  Before -- iter 39 --> After
  T2 ==>|sync target| KTC[KTC TurnPhaseSet = 7<br/>iter 28 R-B-1.a]
  K2 -.->|deliberate collapse,<br/>now explicit| KCAF[KCAF PhaseSet = 6<br/>iter 30/36/37 audited]
```

## Bundle rationale

iter 38 audit (#14822) recommended R-E-1.a + R-E-1.c bundled:
- R-E-1.a (HIGH): sync stale TurnPhaseSet to KTC's 7 members.
- R-E-1.c (LOW): document KcafPhaseSet 3:6 deliberate projection.

Bundling distinguishes "stale projection needs sync" from "deliberate projection needs explanation" in one PR — clearer than two separate PRs that confuse reviewers about whether KcafPhaseSet is also stale.

## Before / After

```diff
-TurnPhaseSet   == {"idle", "prompting", "executing", "compacting",
-                   "finalizing"}
+\* TurnPhaseSet: KTC projection.  iter 39 R-E-1.a (2026-05-12) sync ...
+TurnPhaseSet   == {"idle", "prompting", "routing", "executing",
+                   "compacting", "finalizing", "exhausted"}

+\* KcafPhaseSet: DELIBERATE 3:6 projection collapse from KCAF.tla:79-81.
+\* iter 39 R-E-1.c (2026-05-12, this commit) documents the mapping ...
+\*   KCL abstract      ↔  KCAF concrete
+\*   "idle"            ↔  "idle"
+\*   "attempting"      ↔  "attempting", "awaiting_response"
+\*   "terminal"        ↔  "success", "exhausted_normal", "exhausted_hard_quota"
 KcafPhaseSet   == {"idle", "attempting", "terminal"}
```

## 왜 톱니처럼 정교하지 않은가

iter 28 widened KTC TurnPhaseSet 5→7, OCaml↔KTC drift closure 완료.  그러나 *KCL observer가 같이 update 받지 못함* — R-B-1.c validator는 OCaml↔spec axis만 보고 spec↔spec axis는 미관찰 (script line 89-100 explicit deferral).  KCL의 joint invariants이 routing/exhausted 위에서 vacuously true 로 평가됨 = cross-spec safety surface 부분적 marketability.

KcafPhaseSet의 3:6 collapse는 *의도적* (observer pattern legitimately operates at coarser granularity).  그러나 mapping 문서화 부재 → reader가 D-2의 distinguished terminals (exhausted_normal/_hard_quota)가 어떻게 merge되는지 spec 안에서 확인 불가.  honest-doc이 이 갭을 surface.

## Verification

- [x] TLC clean cfg: 173 distinct states, depth 41, no errors (unchanged from main).
- [x] TLC buggy-attempt cfg: `ToolSurfaceFeedsAttempt` violated (unchanged).
- [x] TLC buggy-cascade cfg: `NoCascadeBeforeMeasurement` violated (unchanged).
- [x] TLC buggy-compaction cfg: `CompactionAtomicity` violated (unchanged).
- [x] TLC buggy-post-turn cfg: `PostTurnConsumesAttempt` violated (unchanged).
- [x] `ktc_turn_phase` usage scan (lines 67, 116, 165, 180, 198-402, 457, 524-525, 544-599) — all positive equality checks except fairness disjunction line 524-525 (`/= "prompting"` *benefits* from widening).  No negative full-set membership tests that would regress with widening.
- [ ] CI `tla-specs` job (path-scoped trigger).

## Trade-off

- 장점: iter 38 Finding 1 (HIGH) closed.  Finding 2 documented.  KCL → KTC TurnPhaseSet sync 1-line + per-set rationale.  TLC behavior unchanged across all 5 cfgs (1 clean + 4 buggy).  Honest-doc pattern 4 datapoints (iter 27/35/37/39).
- 단점: 실제 routing/exhausted을 reach 하는 KCL 액션은 추가 안 함 — KCL behavioral coverage는 그대로.  KTC R-B-2.{a,b,c} 액션 모델링은 별도 PR.  R-E-1.b validator 확장 (cross-spec 비교)도 별도 iter.

## R-E-1.b deferred

iter 38 audit's R-E-1.b proposed extending `audit-tla-annotation-drift.sh` to compare set definitions across `*.tla` files.  This is the *structural* prevention path — same shape as iter 19→20→21→28→32→33 KTC chain.  Deferred to a future iter because:
- This PR closes the known instance (TurnPhaseSet drift).
- R-E-1.b needs ~30-50 LOC bash + baseline format extension (medium iter).
- The validator change should be paired with an empirical smoke test that activates against a known drift (like iter 32's R-D-1.b smoke test).

The R-B-1.c chain extension to cross-spec is the natural future-iter direction now that the gap class is named.

## RFC 참조

`RFC-WAIVED: spec change only (type widening + comments), no subsystem touched per RFC index.`

연관:
- iter 38 KCL E-1 audit (#14822 ✓ merged) — 3 findings + 3 RFC candidates posted.
- iter 28 KTC R-B-1.a (#14793 ✓ merged) — source of the staleness; precedent for type widening.
- iter 30 KCAF D-1 (#14798) + iter 36 D-2 (#14815) + iter 37 R-D-2.c (#14817 ✓ merged) — KCAF 6-phase context referenced in KcafPhaseSet doc.
- iter 27 (#14789), iter 35 (#14811), iter 37 (#14817) — honest-doc pattern precedents (this PR is the 4th datapoint).
- `scripts/audit-tla-annotation-drift.sh:89-100` — explicit "per-spec consistency out of scope" comment that R-E-1.b would relax.

## 진행 추적

다음 iteration 시작점: **R-E-1.b** (validator extension to cross-spec set comparison — MID, ~30-50 LOC bash + baseline) OR **R-D-2.a + R-D-1.a bundle** (still-pending MID multi-file refactor, ~150-300 LOC) OR **KSM A-5 잔여 update_conditions** (matrix 22 event × 19 field).

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>