### PR TITLE
feat(telemetry): extend Checkpoint_failure_operation + 2 new *_failure_site variants (6 sites)

### DIFF
--- a/lib/keeper/cascade_sync_failure_site.ml
+++ b/lib/keeper/cascade_sync_failure_site.ml
@@ -1,0 +1,8 @@
+type t =
+  | Resume_sync
+  | Pause_sync
+
+let to_label = function
+  | Resume_sync -> "resume_sync"
+  | Pause_sync -> "pause_sync"
+;;

--- a/lib/keeper/cascade_sync_failure_site.mli
+++ b/lib/keeper/cascade_sync_failure_site.mli
@@ -1,0 +1,9 @@
+(** Cascade_sync_failure_site — closed sum for [site] label on
+    [metric_keeper_cascade_sync_failures] (2 sites in
+    keeper_turn_cascade_budget.ml). *)
+
+type t =
+  | Resume_sync
+  | Pause_sync
+
+val to_label : t -> string

--- a/lib/keeper/checkpoint_failure_operation.ml
+++ b/lib/keeper/checkpoint_failure_operation.ml
@@ -8,6 +8,7 @@ type t =
   | Load_legacy
   | Migration_save
   | Restore_legacy
+  | Create_initial_save
 
 let to_label = function
   | Migrate_main_history -> "migrate_main_history"
@@ -19,4 +20,5 @@ let to_label = function
   | Load_legacy -> "load_legacy"
   | Migration_save -> "migration_save"
   | Restore_legacy -> "restore_legacy"
+  | Create_initial_save -> "create_initial_save"
 ;;

--- a/lib/keeper/checkpoint_failure_operation.mli
+++ b/lib/keeper/checkpoint_failure_operation.mli
@@ -15,5 +15,6 @@ type t =
   | Load_legacy (** Legacy checkpoint format load failure. *)
   | Migration_save (** Persisting a migrated checkpoint to the OAS store failed. *)
   | Restore_legacy (** Restoring the working context from a legacy checkpoint raised. *)
+  | Create_initial_save (** Initial checkpoint save during keeper boot create flow. *)
 
 val to_label : t -> string

--- a/lib/keeper/keeper_turn_cascade_budget.ml
+++ b/lib/keeper/keeper_turn_cascade_budget.ml
@@ -897,7 +897,7 @@ let enqueue_partial_commit_continue_gate
                meta.name err);
              Prometheus.inc_counter
                Keeper_metrics.metric_keeper_cascade_sync_failures
-               ~labels:[("keeper", meta.name); ("site", "resume_sync")]
+               ~labels:[("keeper", meta.name); ("site", Cascade_sync_failure_site.(to_label Resume_sync))]
                ()
       | Agent_sdk.Hooks.Reject reason ->
         (match sync_keeper_paused_state ~config ~meta:latest_meta ~paused:true with
@@ -914,7 +914,7 @@ let enqueue_partial_commit_continue_gate
                meta.name err reason);
              Prometheus.inc_counter
                Keeper_metrics.metric_keeper_cascade_sync_failures
-               ~labels:[("keeper", meta.name); ("site", "pause_sync")]
+               ~labels:[("keeper", meta.name); ("site", Cascade_sync_failure_site.(to_label Pause_sync))]
                ())
     ()
 

--- a/lib/keeper/keeper_turn_up_create.ml
+++ b/lib/keeper/keeper_turn_up_create.ml
@@ -600,7 +600,7 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
       | Error e ->
         Prometheus.inc_counter
           Keeper_metrics.metric_keeper_checkpoint_failures
-          ~labels:[("keeper", p.name); ("site", "create_initial_save")]
+          ~labels:[("keeper", p.name); ("site", Checkpoint_failure_operation.(to_label Create_initial_save))]
           ();
         Log.Keeper.error
           "create_keeper failed: initial checkpoint save error for name=%s: %s"

--- a/lib/keeper/keeper_turn_up_update.ml
+++ b/lib/keeper/keeper_turn_up_update.ml
@@ -194,7 +194,7 @@ let update_keeper (ctx : _ context) (p : parsed_args) (old : keeper_meta) : tool
       if len > Keeper_config.prompt_render_max_bytes then
         Prometheus.inc_counter
           Keeper_metrics.metric_keeper_turn_up_update_failures
-          ~labels:[("keeper", old.name); ("site", "prompt_cap")]
+          ~labels:[("keeper", old.name); ("site", Turn_up_update_failure_site.(to_label Prompt_cap))]
           ();
         Log.Keeper.warn
           "update_keeper personality.%s for %s exceeds prompt cap \
@@ -340,7 +340,7 @@ let update_keeper (ctx : _ context) (p : parsed_args) (old : keeper_meta) : tool
   | Error err ->
       Prometheus.inc_counter
         Keeper_metrics.metric_keeper_turn_up_update_failures
-        ~labels:[("keeper", p.name); ("site", "sandbox_validation")]
+        ~labels:[("keeper", p.name); ("site", Turn_up_update_failure_site.(to_label Sandbox_validation))]
         ();
       Log.Keeper.warn "update_keeper failed sandbox validation for %s: %s"
         p.name err;
@@ -353,7 +353,7 @@ let update_keeper (ctx : _ context) (p : parsed_args) (old : keeper_meta) : tool
        | Error err ->
            Prometheus.inc_counter
              Keeper_metrics.metric_keeper_turn_up_update_failures
-             ~labels:[("keeper", p.name); ("site", "sandbox_preflight")]
+             ~labels:[("keeper", p.name); ("site", Turn_up_update_failure_site.(to_label Sandbox_preflight))]
              ();
            Log.Keeper.warn "update_keeper failed sandbox preflight for %s: %s"
              p.name err;

--- a/lib/keeper/turn_up_update_failure_site.ml
+++ b/lib/keeper/turn_up_update_failure_site.ml
@@ -1,0 +1,10 @@
+type t =
+  | Prompt_cap
+  | Sandbox_validation
+  | Sandbox_preflight
+
+let to_label = function
+  | Prompt_cap -> "prompt_cap"
+  | Sandbox_validation -> "sandbox_validation"
+  | Sandbox_preflight -> "sandbox_preflight"
+;;

--- a/lib/keeper/turn_up_update_failure_site.mli
+++ b/lib/keeper/turn_up_update_failure_site.mli
@@ -1,0 +1,10 @@
+(** Turn_up_update_failure_site — closed sum for [site] label on
+    [metric_keeper_turn_up_update_failures] (3 sites in
+    keeper_turn_up_update.ml). *)
+
+type t =
+  | Prompt_cap
+  | Sandbox_validation
+  | Sandbox_preflight
+
+val to_label : t -> string


### PR DESCRIPTION
## Summary

Continuing the `*_failures.site` sweep:

1. **Extend `Checkpoint_failure_operation.t`** with `Create_initial_save`
   (1 site in `keeper_turn_up_create.ml:603` — same metric as T17/T19).
2. **New `Cascade_sync_failure_site.t`** (2 sites in `keeper_turn_cascade_budget.ml`):
   `Resume_sync | Pause_sync`.
3. **New `Turn_up_update_failure_site.t`** (3 sites in `keeper_turn_up_update.ml`):
   `Prompt_cap | Sandbox_validation | Sandbox_preflight`.

## Sites (6)

| Metric | Site | Variant |
|--------|------|---------|
| `metric_keeper_checkpoint_failures` | `keeper_turn_up_create.ml:603` | `Checkpoint_failure_operation.Create_initial_save` |
| `metric_keeper_cascade_sync_failures` | `keeper_turn_cascade_budget.ml:900` | `Cascade_sync_failure_site.Resume_sync` |
| `metric_keeper_cascade_sync_failures` | `keeper_turn_cascade_budget.ml:917` | `Cascade_sync_failure_site.Pause_sync` |
| `metric_keeper_turn_up_update_failures` | `keeper_turn_up_update.ml:197` | `Turn_up_update_failure_site.Prompt_cap` |
| `metric_keeper_turn_up_update_failures` | `keeper_turn_up_update.ml:343` | `Turn_up_update_failure_site.Sandbox_validation` |
| `metric_keeper_turn_up_update_failures` | `keeper_turn_up_update.ml:356` | `Turn_up_update_failure_site.Sandbox_preflight` |

Wire format byte-equal.

## Test plan

- [ ] CI green
- [ ] `rg '"site", "(resume_sync|pause_sync|prompt_cap|sandbox_validation|sandbox_preflight|create_initial_save)"' lib/keeper/` = 0

RFC-WAIVED: not in credential/identity/operator/sandbox/hooks/workflow scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)