### PR TITLE
perf(coord): O(R+A) replaces O(R×A) in task-claim and task-schedule guards

### DIFF
--- a/lib/coord/coord_task_classify.ml
+++ b/lib/coord/coord_task_classify.ml
@@ -201,8 +201,14 @@ let task_required_tools (task : Masc_domain.task) =
 ;;
 
 let missing_required_tools ~allowed required =
+  (* Build a name-keyed Hashtbl over [allowed] once; per-required-name
+     check drops from O(|allowed|) to O(1).  Called on the task-claim
+     guard path where [allowed] is typically the agent's tool surface
+     (~30-50 names) and [required] is 1-5 contract tools. *)
+  let allowed_set = Hashtbl.create (List.length allowed) in
+  List.iter (fun name -> Hashtbl.replace allowed_set name ()) allowed;
   List.filter
-    (fun required_name -> not (List.exists (String.equal required_name) allowed))
+    (fun required_name -> not (Hashtbl.mem allowed_set required_name))
     required
 ;;
 

--- a/lib/coord/coord_task_classify.ml
+++ b/lib/coord/coord_task_classify.ml
@@ -204,8 +204,10 @@ let missing_required_tools ~allowed required =
   (* Build a name-keyed Hashtbl over [allowed] once; per-required-name
      check drops from O(|allowed|) to O(1).  Called on the task-claim
      guard path where [allowed] is typically the agent's tool surface
-     (~30-50 names) and [required] is 1-5 contract tools. *)
-  let allowed_set = Hashtbl.create (List.length allowed) in
+     (~30-50 names) and [required] is 1-5 contract tools.
+     Constant initial bucket size avoids the [List.length allowed]
+     pre-traversal (Hashtbl grows automatically). *)
+  let allowed_set = Hashtbl.create 32 in
   List.iter (fun name -> Hashtbl.replace allowed_set name ()) allowed;
   List.filter
     (fun required_name -> not (Hashtbl.mem allowed_set required_name))

--- a/lib/coord/coord_task_schedule.ml
+++ b/lib/coord/coord_task_schedule.ml
@@ -88,18 +88,37 @@ let task_required_tools (task : Masc_domain.task) =
 let string_list_contains all value =
   List.exists (String.equal value) all
 
+(* Build [allowed] as a [(name, unit) Hashtbl.t] once.  Constant
+   initial bucket size avoids the [List.length allowed] pre-traversal
+   (Hashtbl grows automatically); [allowed] is typically the agent's
+   tool surface, ~30-50 names. *)
+let build_allowed_set allowed =
+  let set = Hashtbl.create 32 in
+  List.iter (fun name -> Hashtbl.replace set name ()) allowed;
+  set
+
+let make_required_tools_predicate ?agent_tool_names () =
+  match agent_tool_names with
+  | None ->
+      (* Without an explicit surface, the surface is open: all required
+         tools are considered allowed.  Empty [required] also short-
+         circuits to [true] below. *)
+      fun _required_tools -> true
+  | Some allowed ->
+      let allowed_set = build_allowed_set allowed in
+      fun required_tools ->
+        match required_tools with
+        | [] -> true
+        | _ ->
+            List.for_all (fun name -> Hashtbl.mem allowed_set name)
+              required_tools
+
 let required_tools_allowed ?agent_tool_names required_tools =
-  match required_tools, agent_tool_names with
-  | [], _ -> true
-  | _ :: _, None -> true
-  | required, Some allowed ->
-      (* Materialise [allowed] as a Hashtbl once so [List.for_all] does
-         O(1) lookups instead of [List.exists String.equal] per
-         required tool.  Called per task-schedule eligibility check
-         with ~30-50 allowed names and 1-5 required names. *)
-      let allowed_set = Hashtbl.create (List.length allowed) in
-      List.iter (fun name -> Hashtbl.replace allowed_set name ()) allowed;
-      List.for_all (fun name -> Hashtbl.mem allowed_set name) required
+  (* Single-shot caller convenience.  Per-candidate loops should hoist
+     [make_required_tools_predicate] above the loop so the allowed-set
+     is built once per claim cycle instead of once per candidate. *)
+  let pred = make_required_tools_predicate ?agent_tool_names () in
+  pred required_tools
 
 let underscore_name name =
   String.map (function '-' -> '_' | c -> c) name
@@ -562,9 +581,15 @@ let claim_next_r
                 (List.filter (fun task -> task_required_tools task <> []) unclaimed)));
              ("ts", `String (now_iso ()));
            ]);
+      (* Hoist allowed-set materialisation above the per-candidate
+         filter so we pay O(A) once instead of O(R*A).  Restores the
+         O(R+A) win that this PR's title advertises. *)
+      let required_tools_allowed_for_agent =
+        make_required_tools_predicate ?agent_tool_names ()
+      in
       let required_tool_claim_allowed (task : task) =
         let required_tools = task_required_tools task in
-        required_tools_allowed ?agent_tool_names required_tools
+        required_tools_allowed_for_agent required_tools
         && not (receipt_blocks_task task)
       in
       let required_tool_excluded =

--- a/lib/coord/coord_task_schedule.ml
+++ b/lib/coord/coord_task_schedule.ml
@@ -93,7 +93,13 @@ let required_tools_allowed ?agent_tool_names required_tools =
   | [], _ -> true
   | _ :: _, None -> true
   | required, Some allowed ->
-      List.for_all (string_list_contains allowed) required
+      (* Materialise [allowed] as a Hashtbl once so [List.for_all] does
+         O(1) lookups instead of [List.exists String.equal] per
+         required tool.  Called per task-schedule eligibility check
+         with ~30-50 allowed names and 1-5 required names. *)
+      let allowed_set = Hashtbl.create (List.length allowed) in
+      List.iter (fun name -> Hashtbl.replace allowed_set name ()) allowed;
+      List.for_all (fun name -> Hashtbl.mem allowed_set name) required
 
 let underscore_name name =
   String.map (function '-' -> '_' | c -> c) name

--- a/lib/coord/coord_task_schedule.mli
+++ b/lib/coord/coord_task_schedule.mli
@@ -31,6 +31,15 @@ val string_list_contains : string list -> string -> bool
 val required_tools_allowed :
   ?agent_tool_names:string list -> string list -> bool
 
+(** [make_required_tools_predicate ?agent_tool_names ()] returns a
+    closure that checks whether a given [required_tools] list is
+    satisfied by [agent_tool_names].  The allowed-set is materialised
+    once at call time and reused across every invocation of the
+    returned closure — call this {b outside} per-candidate loops to
+    avoid rebuilding the set per task. *)
+val make_required_tools_predicate :
+  ?agent_tool_names:string list -> unit -> (string list -> bool)
+
 val underscore_name : string -> string
 val hyphen_name : string -> string
 val keeper_name_from_agent_name : string -> string option

--- a/lib/keeper/keeper_world_observation.ml
+++ b/lib/keeper/keeper_world_observation.ml
@@ -285,13 +285,13 @@ let read_backlog_counts ~allowed_tool_names ~(config : Coord.config)
         ~meta
         ()
     in
-    let required_tools_allowed required_tools =
-      match allowed_tool_names with
-      | Some names ->
-          Coord_task_schedule.required_tools_allowed ~agent_tool_names:names
-            required_tools
-      | None ->
-          Coord_task_schedule.required_tools_allowed required_tools
+    (* Build the allowed-set once and reuse across all candidates in
+       the [unclaimed_tasks] filter below — see PR #14826 for the
+       O(R+A) rationale. *)
+    let required_tools_allowed =
+      Coord_task_schedule.make_required_tools_predicate
+        ?agent_tool_names:allowed_tool_names
+        ()
     in
     let claimable =
       List.length


### PR DESCRIPTION
## Summary

Two near-identical O(R × A) loops sat in adjacent files on the task-claim / task-schedule paths:

| File | Function | Pattern |
|------|----------|---------|
| \`lib/coord/coord_task_classify.ml:203\` | \`missing_required_tools\` | \`List.filter (fun req -> not (List.exists (String.equal req) allowed)) required\` |
| \`lib/coord/coord_task_schedule.ml:96\` | \`required_tools_allowed\` | \`List.for_all (string_list_contains allowed) required\` (\`string_list_contains = List.exists String.equal\`) |

Both fire when MASC evaluates whether an agent can claim or be scheduled a task:
- \`allowed\` = the agent's tool surface (~30-50 names)
- \`required\` = the task contract's \`required_tools\` (1-5 names)

Per-call cost: **30-250 string compares**.

## Fix

Materialise \`allowed\` as a \`(string, unit) Hashtbl.t\` once at the start of each function. Per-required check drops from O(|allowed|) to O(1).

\`\`\`ocaml
let allowed_set = Hashtbl.create (List.length allowed) in
List.iter (fun name -> Hashtbl.replace allowed_set name ()) allowed;
\`\`\`

Build cost is one linear pass over \`allowed\` — dominated by the work already being paid in the per-required scan. Net: O(R × A) → O(R + A).

## Why not extract a shared helper

The same shape now appears in 9 PRs this loop. The threshold for promoting \`name_set\` to a project-wide utility is approaching — but adding a new shared module dependency for two functions in \`lib/coord/\` (separate from the \`lib/cascade/\` and \`lib/tool_*.ml\` callers) introduces more friction than the inlined version. Holding off until a clear ownership home emerges.

## Test plan

- [ ] CI lib/ build green
- [ ] \`dune runtest test/test_coord_task*.exe\` passes (if present)
- [ ] Smoke: task-claim with required_tools subset of agent surface → claim allowed (same as before)
- [ ] Smoke: task-claim with required_tools containing a name not in surface → claim rejected (same as before)

🤖 Generated with [Claude Code](https://claude.com/claude-code)