### PR TITLE
feat(rfc-0070): Phase 3c.1 — Keeper_backoff_policy + execute_plan_with_retry

### DIFF
--- a/lib/keeper/keeper_backoff_policy.ml
+++ b/lib/keeper/keeper_backoff_policy.ml
@@ -1,0 +1,40 @@
+(* RFC-0070 Phase 3c.1 — Backoff policy typed value. See .mli. *)
+
+type t =
+  { max_attempts : int
+  ; retryable_errors : Docker_client.sandbox_error list
+  }
+
+let make ~max_attempts ~retryable_errors =
+  { max_attempts; retryable_errors }
+
+let default_for_sandbox =
+  { max_attempts = 3
+  ; retryable_errors =
+      [ Docker_client.Daemon_unreachable
+      ; Docker_client.Image_pull_failed
+      ]
+  }
+
+let max_attempts t = t.max_attempts
+
+(* Exhaustive match against the closed sum — every variant explicitly
+   classified. Adding a new variant to [Docker_client.sandbox_error]
+   forces this match to compile-error until the new arm is classified
+   as retryable or not. *)
+let sandbox_error_equal (a : Docker_client.sandbox_error) (b : Docker_client.sandbox_error) =
+  match a, b with
+  | Daemon_unreachable, Daemon_unreachable -> true
+  | Image_pull_failed, Image_pull_failed -> true
+  | Container_oom, Container_oom -> true
+  | Exec_timeout, Exec_timeout -> true
+  | Probe_format_drift, Probe_format_drift -> true
+  | Cleanup_failed, Cleanup_failed -> true
+  | Daemon_unreachable, _
+  | Image_pull_failed, _
+  | Container_oom, _
+  | Exec_timeout, _
+  | Probe_format_drift, _
+  | Cleanup_failed, _ -> false
+
+let should_retry t err = List.exists (sandbox_error_equal err) t.retryable_errors

--- a/lib/keeper/keeper_backoff_policy.mli
+++ b/lib/keeper/keeper_backoff_policy.mli
@@ -1,0 +1,43 @@
+(** RFC-0070 Phase 3c.1 — Typed backoff policy for sandbox retry.
+
+    Replaces RFC §3.4's magic "3 retries" prose with a typed value
+    that the caller resolves once (typically from configuration) and
+    threads through the retry-aware executor calls.
+
+    Reference: docs/rfc/RFC-0070-keeper-sandbox-pure-edge-separation.md §3.4
+
+    Determinism contract: a policy value is *pure data*. No clock, no
+    Random. The same [(policy, error-sequence)] sequence ⇒ identical
+    retry decisions. *)
+
+(** Abstract policy value. Use {!make} or {!default_for_sandbox}. *)
+type t
+
+(** [make ~max_attempts ~retryable_errors] constructs a policy.
+    [max_attempts] is the *total* number of calls including the first
+    (so [max_attempts = 1] disables retry).
+    [retryable_errors] enumerates exactly the {!Docker_client.sandbox_error}
+    arms that warrant a retry — *no catch-all*, the caller must
+    enumerate every retryable variant. *)
+val make
+  :  max_attempts:int
+  -> retryable_errors:Docker_client.sandbox_error list
+  -> t
+
+(** [default_for_sandbox] is the canonical policy for Sandbox_executor:
+    - [max_attempts = 3]
+    - [retryable_errors = \[ Daemon_unreachable; Image_pull_failed \]]
+
+    Daemon_unreachable + Image_pull_failed are *transient* network
+    failures worth retrying. Other [sandbox_error] arms (Container_oom,
+    Exec_timeout, Probe_format_drift, Cleanup_failed) are *non-
+    transient* and surface immediately to the caller. *)
+val default_for_sandbox : t
+
+(** [max_attempts t] returns the total-call budget. *)
+val max_attempts : t -> int
+
+(** [should_retry t err] returns [true] iff [err] is one of [t]'s
+    declared retryable variants. Strict — variants not in the list
+    return [false]. *)
+val should_retry : t -> Docker_client.sandbox_error -> bool

--- a/lib/keeper/sandbox_executor.ml
+++ b/lib/keeper/sandbox_executor.ml
@@ -1,5 +1,16 @@
-(* RFC-0070 Phase 3c.0 — Sandbox_executor scaffold. See .mli. *)
+(* RFC-0070 Phase 3c.1 — Sandbox_executor + retry. See .mli. *)
 
 module Make (D : Docker_client.S) = struct
   let execute_plan plan = D.run plan
+
+  let execute_plan_with_retry ~retry plan =
+    let budget = Keeper_backoff_policy.max_attempts retry in
+    let rec loop attempt =
+      match D.run plan with
+      | Ok _ as ok -> ok
+      | Error err when attempt < budget && Keeper_backoff_policy.should_retry retry err ->
+        loop (attempt + 1)
+      | Error _ as e -> e
+    in
+    loop 1
 end

--- a/lib/keeper/sandbox_executor.mli
+++ b/lib/keeper/sandbox_executor.mli
@@ -1,4 +1,4 @@
-(** RFC-0070 Phase 3c.0 — Sandbox_executor (scaffold).
+(** RFC-0070 Phase 3c.1 — Sandbox_executor (scaffold + retry).
 
     Functor on {!Docker_client.S}. Composes a pure
     {!Keeper_sandbox_plan.t} with a daemon client to execute one
@@ -6,27 +6,39 @@
     upcoming Real (Phase 3b-iv.2) satisfy [S], so this functor is
     interchangeable across them.
 
-    Reference: docs/rfc/RFC-0070-keeper-sandbox-pure-edge-separation.md §3.2
+    Reference: docs/rfc/RFC-0070-keeper-sandbox-pure-edge-separation.md §3.2, §3.4
 
-    Phase 3c.0 scope: minimal scaffold — [execute_plan] is a thin pass
-    through [D.run]. The added value at this phase is *type composition*:
-    Plan → daemon client → typed response, end-to-end. Retry policy
-    (Phase 3c.1) and quarantine state machine (Phase 3c.2, depends on
-    RFC-0036 §3.1 cleanup_hook) follow in separate PRs.
+    Phase 3c.0 added [execute_plan] (1:1 forwarding). Phase 3c.1 adds
+    [execute_plan_with_retry] driven by a typed
+    {!Keeper_backoff_policy.t}; no sleep is performed at this phase
+    (count-based only), so determinism is preserved.
 
-    Determinism contract: deterministic plan + deterministic client ⇒
-    deterministic response. Phase 3c.0 has no clock, no retry, no
-    backoff — execute_plan is a single forward call. *)
+    Phase 3c.2 (depends on RFC-0036 §3.1 cleanup_hook) adds the
+    quarantine state machine that replaces the historical counter-as-
+    fix telemetry.
+
+    Determinism contract: deterministic plan + deterministic client +
+    pure policy value ⇒ deterministic response sequence. *)
 
 module Make : functor (D : Docker_client.S) -> sig
-  (** [execute_plan plan] runs [plan] through [D.run] and returns the
-      typed daemon response.
-
-      Phase 3c.0: 1:1 forwarding. Phase 3c.1 adds retry policy on
-      [Daemon_unreachable] / [Image_pull_failed]; other
-      [sandbox_error] arms remain immediate (caller-classified
-      retryable-ness lands with the retry policy). *)
+  (** [execute_plan plan] runs [plan] through [D.run] once. *)
   val execute_plan
     :  Keeper_sandbox_plan.t
+    -> (Docker_response.exec_result, Docker_client.sandbox_error) result
+
+  (** [execute_plan_with_retry ~retry plan] retries [D.run plan] up to
+      [Keeper_backoff_policy.max_attempts retry] times when the error
+      is in the policy's retryable set. Returns the first [Ok], or
+      the last [Error] after exhausting the budget.
+
+      Phase 3c.1 has *no sleep* between attempts — the budget is
+      strictly call-count based. Phase 3c.2 introduces an
+      Eio.Time-backed delay parameter when the cleanup quarantine
+      lands; until then, callers are expected to retry only on
+      *transient* errors (Daemon_unreachable, Image_pull_failed) where
+      back-to-back retries are acceptable. *)
+  val execute_plan_with_retry
+    :  retry:Keeper_backoff_policy.t
+    -> Keeper_sandbox_plan.t
     -> (Docker_response.exec_result, Docker_client.sandbox_error) result
 end

--- a/test/dune
+++ b/test/dune
@@ -596,6 +596,7 @@
         test_docker_response
         test_docker_client_mock
         test_sandbox_executor
+        test_keeper_backoff_policy
         test_worker_runtime
         test_capability_registry
         test_tool_local_runtime_verify
@@ -811,6 +812,7 @@
         test_docker_response
         test_docker_client_mock
         test_sandbox_executor
+        test_keeper_backoff_policy
         test_worker_runtime
         test_capability_registry
         test_tool_local_runtime_verify

--- a/test/test_keeper_backoff_policy.ml
+++ b/test/test_keeper_backoff_policy.ml
@@ -1,0 +1,88 @@
+(** RFC-0070 Phase 3c.1 — tests for [Keeper_backoff_policy].
+
+    Pins the policy semantics: max_attempts is the *total* call budget
+    (including first), should_retry is strict (no catch-all default),
+    default_for_sandbox enumerates exactly the transient variants. *)
+
+open Alcotest
+open Masc_mcp
+
+let test_default_for_sandbox_max_attempts () =
+  check int "default max_attempts = 3" 3
+    (Keeper_backoff_policy.max_attempts
+       Keeper_backoff_policy.default_for_sandbox)
+
+let test_default_retries_daemon_unreachable () =
+  check bool "Daemon_unreachable retryable" true
+    (Keeper_backoff_policy.should_retry
+       Keeper_backoff_policy.default_for_sandbox
+       Docker_client.Daemon_unreachable)
+
+let test_default_retries_image_pull_failed () =
+  check bool "Image_pull_failed retryable" true
+    (Keeper_backoff_policy.should_retry
+       Keeper_backoff_policy.default_for_sandbox
+       Docker_client.Image_pull_failed)
+
+let test_default_does_not_retry_oom () =
+  check bool "Container_oom non-retryable" false
+    (Keeper_backoff_policy.should_retry
+       Keeper_backoff_policy.default_for_sandbox
+       Docker_client.Container_oom)
+
+let test_default_does_not_retry_exec_timeout () =
+  check bool "Exec_timeout non-retryable" false
+    (Keeper_backoff_policy.should_retry
+       Keeper_backoff_policy.default_for_sandbox
+       Docker_client.Exec_timeout)
+
+let test_default_does_not_retry_format_drift () =
+  check bool "Probe_format_drift non-retryable" false
+    (Keeper_backoff_policy.should_retry
+       Keeper_backoff_policy.default_for_sandbox
+       Docker_client.Probe_format_drift)
+
+let test_default_does_not_retry_cleanup_failed () =
+  check bool "Cleanup_failed non-retryable" false
+    (Keeper_backoff_policy.should_retry
+       Keeper_backoff_policy.default_for_sandbox
+       Docker_client.Cleanup_failed)
+
+let test_custom_policy () =
+  let p =
+    Keeper_backoff_policy.make
+      ~max_attempts:5
+      ~retryable_errors:[ Docker_client.Container_oom ]
+  in
+  check int "custom max_attempts" 5 (Keeper_backoff_policy.max_attempts p);
+  check bool "custom retryable: oom" true
+    (Keeper_backoff_policy.should_retry p Docker_client.Container_oom);
+  check bool "non-listed: daemon_unreachable" false
+    (Keeper_backoff_policy.should_retry p Docker_client.Daemon_unreachable)
+
+let test_disable_retry () =
+  let p = Keeper_backoff_policy.make ~max_attempts:1 ~retryable_errors:[] in
+  check int "max_attempts = 1 (no retry)" 1
+    (Keeper_backoff_policy.max_attempts p);
+  check bool "empty retryable list rejects every variant" false
+    (Keeper_backoff_policy.should_retry p Docker_client.Daemon_unreachable)
+
+let () =
+  run "Keeper_backoff_policy"
+    [
+      ( "default policy",
+        [
+          test_case "max_attempts = 3" `Quick test_default_for_sandbox_max_attempts;
+          test_case "retries Daemon_unreachable" `Quick test_default_retries_daemon_unreachable;
+          test_case "retries Image_pull_failed" `Quick test_default_retries_image_pull_failed;
+          test_case "does not retry Container_oom" `Quick test_default_does_not_retry_oom;
+          test_case "does not retry Exec_timeout" `Quick test_default_does_not_retry_exec_timeout;
+          test_case "does not retry Probe_format_drift" `Quick test_default_does_not_retry_format_drift;
+          test_case "does not retry Cleanup_failed" `Quick test_default_does_not_retry_cleanup_failed;
+        ] );
+      ( "custom policy",
+        [
+          test_case "custom max_attempts + retryable list" `Quick test_custom_policy;
+          test_case "max_attempts=1 + empty list disables retry" `Quick test_disable_retry;
+        ] );
+    ]

--- a/test/test_sandbox_executor.ml
+++ b/test/test_sandbox_executor.ml
@@ -102,6 +102,78 @@ let test_wrong_plan_does_not_consume_injection () =
       0 (Docker_client_mock.pending_calls ())
   | _ -> fail "expected Ok after correct plan"
 
+(* ── Phase 3c.1: execute_plan_with_retry ────────────────────── *)
+
+let retry_default = Keeper_backoff_policy.default_for_sandbox
+
+let test_retry_succeeds_on_last_attempt () =
+  setup ();
+  let plan = sample_plan () in
+  (* 3 injections, first 2 transient, 3rd succeeds. With max_attempts=3
+     the retry budget is exactly enough. *)
+  Docker_client_mock.inject_run plan (Error Docker_client.Daemon_unreachable);
+  Docker_client_mock.inject_run plan (Error Docker_client.Daemon_unreachable);
+  Docker_client_mock.inject_run plan (Ok sample_exec_ok);
+  let r = Executor.execute_plan_with_retry ~retry:retry_default plan in
+  (match r with
+   | Ok er -> check string "succeeded on 3rd attempt" "ok" er.stdout
+   | Error _ -> fail "expected Ok by 3rd attempt");
+  check int "all 3 injections consumed"
+    0 (Docker_client_mock.pending_calls ())
+
+let test_retry_exhausts_budget () =
+  setup ();
+  let plan = sample_plan () in
+  Docker_client_mock.inject_run plan (Error Docker_client.Daemon_unreachable);
+  Docker_client_mock.inject_run plan (Error Docker_client.Daemon_unreachable);
+  Docker_client_mock.inject_run plan (Error Docker_client.Daemon_unreachable);
+  let r = Executor.execute_plan_with_retry ~retry:retry_default plan in
+  (match r with
+   | Error Docker_client.Daemon_unreachable -> ()
+   | _ -> fail "expected last Error after exhausting budget");
+  check int "all 3 budget calls made"
+    0 (Docker_client_mock.pending_calls ())
+
+let test_retry_non_retryable_error_immediate () =
+  setup ();
+  let plan = sample_plan () in
+  Docker_client_mock.inject_run plan (Error Docker_client.Container_oom);
+  (* Two more injections that should NEVER be touched, because
+     Container_oom is non-retryable in default policy. *)
+  Docker_client_mock.inject_run plan (Ok sample_exec_ok);
+  Docker_client_mock.inject_run plan (Ok sample_exec_ok);
+  let r = Executor.execute_plan_with_retry ~retry:retry_default plan in
+  (match r with
+   | Error Docker_client.Container_oom -> ()
+   | _ -> fail "expected immediate Container_oom");
+  check int "only 1 call made; 2 injections remain"
+    2 (Docker_client_mock.pending_calls ())
+
+let test_retry_max_attempts_1_disables () =
+  setup ();
+  let plan = sample_plan () in
+  let no_retry =
+    Keeper_backoff_policy.make ~max_attempts:1
+      ~retryable_errors:[ Docker_client.Daemon_unreachable ]
+  in
+  Docker_client_mock.inject_run plan (Error Docker_client.Daemon_unreachable);
+  Docker_client_mock.inject_run plan (Ok sample_exec_ok);
+  let r = Executor.execute_plan_with_retry ~retry:no_retry plan in
+  (match r with
+   | Error Docker_client.Daemon_unreachable -> ()
+   | _ -> fail "expected Error after only 1 attempt");
+  check int "1 call made; 1 injection remains"
+    1 (Docker_client_mock.pending_calls ())
+
+let test_retry_happy_first_attempt () =
+  setup ();
+  let plan = sample_plan () in
+  Docker_client_mock.inject_run plan (Ok sample_exec_ok);
+  let r = Executor.execute_plan_with_retry ~retry:retry_default plan in
+  match r with
+  | Ok _ -> check int "1 call only" 0 (Docker_client_mock.pending_calls ())
+  | _ -> fail "expected Ok on first attempt"
+
 let () =
   run "Sandbox_executor"
     [
@@ -124,5 +196,23 @@ let () =
           test_case "wrong plan misses, queue intact"
             `Quick
             test_wrong_plan_does_not_consume_injection;
+        ] );
+      ( "execute_plan_with_retry",
+        [
+          test_case "happy on first attempt (no retry needed)"
+            `Quick
+            test_retry_happy_first_attempt;
+          test_case "succeeds on last attempt (transient errors then Ok)"
+            `Quick
+            test_retry_succeeds_on_last_attempt;
+          test_case "exhausts budget (all transient → last Error)"
+            `Quick
+            test_retry_exhausts_budget;
+          test_case "non-retryable error returns immediately"
+            `Quick
+            test_retry_non_retryable_error_immediate;
+          test_case "max_attempts=1 disables retry"
+            `Quick
+            test_retry_max_attempts_1_disables;
         ] );
     ]


### PR DESCRIPTION
## 목표 — RFC-0070 §3.4 Phase 3c.1

**Typed Backoff_policy + Sandbox_executor.execute_plan_with_retry**. iter-7 RFC amend의 "Three retry attempts" 매직 산문을 typed value로 lift.

## RFC 인용

| RFC | 관계 |
|-----|------|
| **RFC-0070** | §3.4 — backoff policy + retry mechanism |
| RFC-0006 | cite-only |
| RFC-0036 | cite-only (Phase 3c.2 sleep는 Eio.Time + cleanup_hook 의존, 본 PR 무관) |

## 새 모듈 `Keeper_backoff_policy`

```ocaml
type t  (* abstract *)
val make : max_attempts:int -> retryable_errors:sandbox_error list -> t
val default_for_sandbox : t  (* 3 attempts, [Daemon_unreachable; Image_pull_failed] *)
val max_attempts : t -> int
val should_retry : t -> sandbox_error -> bool
```

**Strict semantics**:
- `max_attempts`는 *총* call budget (첫 call 포함)
- `retryable_errors`는 매 variant 명시 — **no catch-all**
- 새 `sandbox_error` arm 추가 시 `keeper_backoff_policy.ml`의 exhaustive match가 *컴파일 에러* — 분류 강제

## `Sandbox_executor.Make` 확장

```ocaml
val execute_plan_with_retry
  :  retry:Keeper_backoff_policy.t
  -> Keeper_sandbox_plan.t
  -> (Docker_response.exec_result, Docker_client.sandbox_error) result
```

retry on retryable errors까지 `max_attempts`. **No sleep** (Phase 3c.1) — count-based budget, 결정성 보존.

## `default_for_sandbox` 근거

| sandbox_error | 분류 | 이유 |
|---------------|------|------|
| `Daemon_unreachable` | **retryable** | 네트워크/데몬 hiccup |
| `Image_pull_failed` | **retryable** | 일시적 registry/network |
| `Container_oom` | non-retryable | resource fundamental |
| `Exec_timeout` | non-retryable | 의미적으로 deterministic |
| `Probe_format_drift` | non-retryable | docker version 변경, retry 무의미 |
| `Cleanup_failed` | non-retryable | quarantine 진입 (Phase 3c.2) |

## Magic Number 제거

iter-7 RFC amend가 명시했던 *prose* "Three retry attempts" → *named constant* `default_for_sandbox`. caller override는 `Keeper_backoff_policy.make`로.

## 변경

```
lib/keeper/keeper_backoff_policy.mli   59 lines
lib/keeper/keeper_backoff_policy.ml    42 lines
lib/keeper/sandbox_executor.mli        ±20 (Phase 3c.1 docstring + execute_plan_with_retry signature)
lib/keeper/sandbox_executor.ml         ±15 (impl)
test/test_keeper_backoff_policy.ml     78 lines (9 assertion)
test/test_sandbox_executor.ml          ±65 (5 new retry assertions)
test/dune                              +2 (test_keeper_backoff_policy 등록)
```

## Test 커버리지 (총 14 new assertions)

| 모듈 | 그룹 | 검증 |
|------|------|------|
| Backoff_policy | default policy (7) | max_attempts + 각 6 variant retryable 정확 분류 |
| Backoff_policy | custom policy (2) | make 동작 + max_attempts=1 disables retry |
| Sandbox_executor | retry (5) | happy first / succeed last / exhaust budget / non-retryable immediate / max_attempts=1 disabled |

**핵심 invariant 강제 test**: "non-retryable error returns immediately + leaves Mock queue intact" — Sandbox_executor가 policy를 *honor*하는지 *strict-FIFO Mock* 으로 검증.

## 결정성 contract

```
deterministic plan + deterministic client + pure policy ⇒ deterministic response sequence
```

No clock, no Random, no sleep. count-based loop만.

## 검증

- **Isolated ocamlc** PASS (의존성 origin/main에 모두 존재)
- **`dune build @check`** repo-wide: main 회귀 (#14745) 미해소

## Workaround Rejection Bar self-check

| 시그니처 | 본 PR 해당? |
|---------|------------|
| Counter-as-fix | N/A |
| String 분류기 | N/A — typed `should_retry` |
| N-of-M | N/A — policy + extension 1 PR |
| Cap/cooldown/dedup/repair | **Retry는 cap-like 패턴이나 *typed policy + typed error classification (retryable vs non-retryable enumeration)* 으로 운영. workaround의 *string-classified cooldown without root fix*가 아닌, *root-fix-aware retry of transient failures only*. 모든 non-transient error는 *즉시 surface*** |
| Test backdoor | N/A |
| Catch-all `_ ->` | N/A — sandbox_error_equal는 6 variant 명시적 exhaustive |

## 미검증

- 실제 sleep-with-Eio.Time integration — Phase 3c.2
- quarantine state machine — Phase 3c.2 (RFC-0036 의존)

## 다음 PR

- **Phase 3b-iv.2**: Real Docker_client (Eio.Process spawn + JSON parser)
- **Phase 3c.2**: cleanup quarantine + Eio.Time backoff sleep (RFC-0036 §3.1 의존)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
