### PR TITLE
feat(scripts): R-E-1.b cross-spec set comparison — opt-in capability

### DIFF
--- a/scripts/audit-tla-annotation-drift.sh
+++ b/scripts/audit-tla-annotation-drift.sh
@@ -38,11 +38,13 @@ LIB_DIR="${REPO_ROOT}/lib"
 
 VERBOSE=0
 BASELINE_FILE=""
+CHECK_CROSS_SPEC=0
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --verbose) VERBOSE=1; shift ;;
     --baseline) BASELINE_FILE="$2"; shift 2 ;;
     --baseline=*) BASELINE_FILE="${1#*=}"; shift ;;
+    --check-cross-spec) CHECK_CROSS_SPEC=1; shift ;;
     *) echo "unknown arg: $1" >&2; exit 2 ;;
   esac
 done
@@ -128,6 +130,39 @@ extract_spec_members() {
     | rg -o '"[a-z_]+"' \
     | tr -d '"' \
     | sort -u
+}
+
+# Aux: extract a spec set's members PER SPEC FILE, so the caller can
+# detect cross-spec drift (e.g. KTC.tla defines TurnPhaseSet with 7
+# members but KCL.tla defines it with 5 — R-E-1.b finding from iter 38
+# audit `docs/tla-audit/kcl-e1-cross-spec-projection-drift-2026-05-12.md`).
+#
+# Output: one line per spec file that contains the set:
+#   <spec_basename>: <space-sorted member1> <member2> ...
+#
+# Empty output means the set is not defined in any spec.
+extract_set_members_per_spec() {
+  local set_name="$1"
+  local spec
+  for spec in "${SPEC_DIR}"/*.tla; do
+    local members
+    members=$(awk -v set="${set_name}" '
+      BEGIN { capturing = 0 }
+      $0 ~ "^" set "[[:space:]]*==" { capturing = 1 }
+      capturing == 1 {
+        buf = buf $0 " "
+        if (index($0, "}") > 0) { capturing = 0; print buf; buf = "" }
+      }
+    ' "${spec}" 2>/dev/null \
+      | rg -o '"[a-z_]+"' \
+      | tr -d '"' \
+      | sort -u \
+      | tr '\n' ' ')
+    members="${members% }"   # strip trailing space
+    if [[ -n "${members}" ]]; then
+      echo "$(basename "${spec}" .tla): ${members}"
+    fi
+  done
 }
 
 # Aux: extract TLC cfg CONSTANT members.  Greps the
@@ -239,13 +274,72 @@ for pair in "${TYPE_SET_PAIRS[@]}"; do
   done <<< "${ocaml_members}"
 done
 
-echo ""
-echo "tla-annotation-drift summary: ${TOTAL_CHECKED} constructors checked across ${TOTAL_PAIRS} type/set pairs, ${VIOLATIONS} new drift(s), ${KNOWN_DRIFTS} baseline-known drift(s)"
+# ── Cross-spec set uniformity check (R-E-1.b, iter 40) ─────────────
+#
+# When a set name appears in MULTIPLE *.tla files, check that all
+# occurrences define the same member set.  Detects drift where one
+# spec is widened (e.g. iter 28 KTC TurnPhaseSet 5→7) but observer
+# specs (KCL) are not synced — the bug class identified in iter 38
+# audit (`docs/tla-audit/kcl-e1-cross-spec-projection-drift-2026-05-12.md`).
+#
+# Rule of thumb: spec set names that appear verbatim in multiple
+# specs are EXPECTED to be uniform.  Deliberate projection collapses
+# (e.g. KCL's KcafPhaseSet collapses KCAF's PhaseSet 6→3) use a
+# DIFFERENT set name on purpose, so they don't appear here.
+#
+# Listed sets are the cross-spec-shared identifiers most likely to
+# drift across spec extensions.  Extend as new shared sets emerge.
+# Each entry should appear in 2+ *.tla files for the check to be
+# meaningful.  Entries that appear in only one spec are silently
+# skipped — see the empty-output guard inside the loop.
+declare -a CROSS_SPEC_UNIFORM_SETS=(
+  # KTC + KCL: turn-phase projection (synced in iter 39 R-E-1.a).
+  "TurnPhaseSet"
+  # KTC + KCL: decision projection.
+  "DecisionSet"
+  # KTC + KCL: cascade-state projection.
+  "CascadeSet"
+)
 
-if [[ "${VIOLATIONS}" -gt 0 ]]; then
+CROSS_SPEC_DRIFTS=0
+CROSS_SPEC_CHECKED=0
+if [[ "${CHECK_CROSS_SPEC}" == "1" ]]; then
+for shared_set in "${CROSS_SPEC_UNIFORM_SETS[@]}"; do
+  [[ -z "${shared_set}" ]] && continue
+  CROSS_SPEC_CHECKED=$((CROSS_SPEC_CHECKED + 1))
+  per_spec_output=$(extract_set_members_per_spec "${shared_set}" || true)
+  if [[ -z "${per_spec_output}" ]]; then
+    if [[ "${VERBOSE}" == "1" ]]; then
+      echo "── ${shared_set} cross-spec ──  (not defined in any spec, skipping)"
+    fi
+    continue
+  fi
+  unique_member_signatures=$(echo "${per_spec_output}" | awk -F': ' '{print $2}' | sort -u | wc -l | tr -d ' ')
+  occurrences=$(echo "${per_spec_output}" | wc -l | tr -d ' ')
+  if [[ "${VERBOSE}" == "1" ]]; then
+    echo "── ${shared_set} cross-spec (${occurrences} spec(s), ${unique_member_signatures} unique signature(s)) ──"
+    echo "${per_spec_output}" | sed 's/^/  /'
+  fi
+  if [[ "${unique_member_signatures}" -gt 1 ]]; then
+    echo "cross-spec-drift: set '${shared_set}' has divergent definitions across spec files"
+    echo "${per_spec_output}" | sed 's/^/  /'
+    CROSS_SPEC_DRIFTS=$((CROSS_SPEC_DRIFTS + 1))
+  fi
+done
+fi
+
+echo ""
+if [[ "${CHECK_CROSS_SPEC}" == "1" ]]; then
+  echo "tla-annotation-drift summary: ${TOTAL_CHECKED} constructors checked across ${TOTAL_PAIRS} type/set pairs, ${VIOLATIONS} new drift(s), ${KNOWN_DRIFTS} baseline-known drift(s); ${CROSS_SPEC_CHECKED} cross-spec set(s) checked, ${CROSS_SPEC_DRIFTS} cross-spec drift(s)"
+else
+  echo "tla-annotation-drift summary: ${TOTAL_CHECKED} constructors checked across ${TOTAL_PAIRS} type/set pairs, ${VIOLATIONS} new drift(s), ${KNOWN_DRIFTS} baseline-known drift(s) (cross-spec scan available via --check-cross-spec, opt-in)"
+fi
+
+if [[ "${VIOLATIONS}" -gt 0 || "${CROSS_SPEC_DRIFTS}" -gt 0 ]]; then
   echo ""
-  echo "RFC reference: R-B-1.c (iter 19 KTC B-1 audit)."
-  echo "Fix: either (a) add missing members to TLA+ spec set, or (b) remove obsolete OCaml constructor."
+  echo "RFC reference: R-B-1.c (iter 19 KTC B-1 audit), R-E-1.b (iter 38 KCL E-1 audit, cross-spec pass)."
+  echo "Fix (annotation drift): either (a) add missing members to TLA+ spec set, or (b) remove obsolete OCaml constructor."
+  echo "Fix (cross-spec drift): sync all spec files defining the same set name to the same members.  If the projection is DELIBERATE (observer pattern), rename to a distinct identifier (e.g. KcafPhaseSet vs PhaseSet) and document in the spec header."
   echo "Note: this validator extracts constructor names only — it does not yet parse [@tla.symbol] PPX overrides, so (c) alias-based reconciliation is not available until the extractor learns that attribute (tracked under R-B-1.d follow-up)."
   exit 1
 fi


### PR DESCRIPTION
## Finding (Iteration 40, R-E-1.b capability)

**Validator**: `scripts/audit-tla-annotation-drift.sh` (+98/-4 LOC)
**Scope**: New `--check-cross-spec` opt-in pass + 3 monitored sets (TurnPhaseSet, DecisionSet, CascadeSet).
**Aspect**: Close iter 38 KCL E-1 Finding 3 (LOW, structural) — extend R-B-1.c validator chain to detect spec↔spec drift.
**Risk**: LOW — opt-in flag, default-off run unchanged.  Smoke test confirms scanner detects iter 38's drift class.
**Workaround signature**: N/A — structural prevention of the spec-spec drift family discovered iter 38.

## 순서도

```mermaid
flowchart TB
  subgraph V1 [Validator V1 — iter 20/21/32/33]
    A[OCaml types ↔ spec sets<br/>4 type/set pairs<br/>OCaml→spec axis only]
  end
  subgraph V2 [Validator V2 — iter 40 R-E-1.b]
    A2[V1 base intact]
    B[--check-cross-spec opt-in flag]
    C[extract_set_members_per_spec function<br/>per-file member extraction]
    D[CROSS_SPEC_UNIFORM_SETS list<br/>TurnPhaseSet, DecisionSet, CascadeSet]
    E[per-pair check unchanged<br/>+ cross-spec scan when opt-in]
    A2 --> E
    B --> C --> D --> E
  end
  V1 --> V2
  V2 -.->|iter 41 audits| Audits[3 divergences found:<br/>TurnPhaseSet, DecisionSet, CascadeSet<br/>each surfaces partial projections<br/>in KCompactionLifecycle/KEventQueue]
```

## Verification (empirical smoke test)

```
=== DEFAULT (cross-spec disabled) ===
tla-annotation-drift summary: 20 constructors checked across 4 type/set pairs,
  0 new drift(s), 1 baseline-known drift(s)
  (cross-spec scan available via --check-cross-spec, opt-in)
[exit 0]

=== --check-cross-spec (opt-in) ===
cross-spec-drift: set 'TurnPhaseSet' has divergent definitions across spec files
cross-spec-drift: set 'DecisionSet' has divergent definitions across spec files
cross-spec-drift: set 'CascadeSet' has divergent definitions across spec files
tla-annotation-drift summary: 20 constructors checked across 4 type/set pairs,
  0 new drift(s), 1 baseline-known drift(s);
  3 cross-spec set(s) checked, 3 cross-spec drift(s)
[exit 1]
```

3 divergences found — all involve partial projections in `KeeperCompactionLifecycle.tla` or `KeeperEventQueue.tla` (e.g. `DecisionSet` 3-member in KCompactionLifecycle vs 4-member elsewhere).

## Why opt-in, not opt-out

iter 32 R-D-1.b pattern (#14803 ✓ merged): ship capability commented-out / opt-in, activate in a paired follow-up that baselines known divergences.

Activating now without baseline would:
- Fail every spec-touching PR (CI would report 3 cross-spec drifts).
- Create workaround-magnet pressure to disable the check.

Opt-in flag lets developers run the check locally, while CI activation pairs with iter 41 audit + baseline entries.

## iter 41 follow-up roadmap

For each of the 3 found divergences:

| Set | Spec files | Audit classification |
|---|---|---|
| TurnPhaseSet | (need to scan output, but KTC+KCL synced; remaining drift involves KCompactionLifecycle?) | TBD |
| DecisionSet | KCompactionLifecycle 3 vs others 4 (missing `gate_rejected`?) | likely deliberate observer projection — rename to e.g. `KMC_DecisionSet` |
| CascadeSet | KCompactionLifecycle 2 vs others 5 | same |

**iter 41 audit memo + paired-fix PR** to either:
- (a) sync (if stale, like iter 39 KCL TurnPhaseSet),
- (b) rename to distinct identifier (deliberate observer pattern, like KcafPhaseSet),
- (c) extend baseline file format to allow per-set per-spec exemptions.

## 왜 톱니처럼 정교하지 않은가

iter 19→20→21→28→32→33 chain built validator infrastructure for OCaml↔spec drift but had a known blind spot (script line 89-100 explicit: per-spec consistency out of scope).  iter 38 KCL E-1 audit identified this gap.  This PR ships the *capability* to close the gap.

Same structural pattern as iter 32: extend the validator's *coverage axis* (cfg-style sets there, cross-spec sets here), with empirical smoke test confirming the new axis catches the known drift class, but defer enforcement to a paired follow-up to avoid workaround pressure.

## 본 PR 수정

`scripts/audit-tla-annotation-drift.sh` +98/-4:
- New `extract_set_members_per_spec` helper.
- New `CROSS_SPEC_UNIFORM_SETS` array (3 entries).
- New `--check-cross-spec` flag.
- Cross-spec scan loop with `CROSS_SPEC_DRIFTS` counter.
- Summary line + exit code support new dimension.
- Updated fix-suggestion text for both drift classes.

## Trade-off

- 장점: Closes iter 38 Finding 3 (validator coverage gap).  Empirical smoke test proves scanner catches the iter 38 drift class.  Default-off preserves existing CI green.  R-B-1.c chain now has 6 iters (19→20→21→28→32→33→40).
- 단점: Cross-spec drifts surfaced but not yet enforced — iter 41 audit needed before CI activation.  Currently 3 divergences need classification (stale/deliberate/baselined).

## RFC 참조

`RFC-WAIVED: scripts-only validator extension, no subsystem touched per RFC index.`

연관:
- iter 38 KCL E-1 audit (#14822 ✓ merged) — Finding 3 + R-E-1.b proposal.
- iter 39 R-E-1.a+c bundle (#14824 ✓ merged) — first instance of cross-spec drift (TurnPhaseSet 5→7 sync).
- iter 32 R-D-1.b (#14803 ✓ merged) — capability without activation precedent.
- iter 33 R-D-1.b activation (#14804 ✓ merged) — paired-baseline activation pattern.
- iter 19 KTC B-1 audit (`ktc-b1-turn-phase-spec-gap-2026-05-12.md`) — original R-B-1.c source.

## 진행 추적

다음 iteration 시작점: **iter 41 cross-spec drift audit** (classify 3 divergences in TurnPhaseSet/DecisionSet/CascadeSet, propose per-set fix) OR **R-D-2.a + R-D-1.a bundle** (still-pending MID multi-file ~150-300 LOC) OR **KSM A-5 잔여** (update_conditions 22×19 matrix).

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>