### PR TITLE
fix(keeper_turn_terminal): make is_unknown_empty exhaustive

### DIFF
--- a/lib/keeper/keeper_turn_terminal.ml
+++ b/lib/keeper/keeper_turn_terminal.ml
@@ -93,9 +93,32 @@ let of_legacy_error_text raw_error =
    other [of_legacy_error_text] result has classified the error and
    should be returned as-is. *)
 let is_unknown_empty (reason : t) =
+  (* Enumerate every [Keeper_turn_disposition.t] variant so the
+     compiler flags any new disposition added. Only the empty-raw
+     [Unknown { raw_error = "" }] case opts into the SDK-error-derived
+     code; all other dispositions (Success, External_cancel,
+     Turn_wall_clock_timeout, Oas_timeout_budget,
+     Gh_repo_context_missing_worktree, Required_tool_use_no_tool_call,
+     Required_tool_use_unsatisfied, Post_commit_ambiguous,
+     Provider_error, and Unknown with non-empty raw_error) must yield
+     [false]. A future disposition variant added to
+     [Keeper_turn_disposition.t] would silently inherit [false] under
+     the previous [_ -> false] catch-all without a review point on
+     whether the new variant should opt into the unknown-empty
+     pathway. Same FSM Sparse Match anti-pattern as PRs #14716,
+     #14790, #14806, #14810, #14816, #14823. *)
   match reason.disposition with
   | Keeper_turn_disposition.Unknown { raw_error = "" } -> true
-  | _ -> false
+  | Keeper_turn_disposition.Unknown { raw_error = _ }
+  | Keeper_turn_disposition.Success
+  | Keeper_turn_disposition.External_cancel
+  | Keeper_turn_disposition.Turn_wall_clock_timeout
+  | Keeper_turn_disposition.Oas_timeout_budget
+  | Keeper_turn_disposition.Gh_repo_context_missing_worktree
+  | Keeper_turn_disposition.Required_tool_use_no_tool_call
+  | Keeper_turn_disposition.Required_tool_use_unsatisfied
+  | Keeper_turn_disposition.Post_commit_ambiguous
+  | Keeper_turn_disposition.Provider_error _ -> false
 ;;
 
 let of_failure ?(post_commit_ambiguous = false) ?(tool_call_count = 0) ~raw_error err =


### PR DESCRIPTION
## Why

`is_unknown_empty` in `lib/keeper/keeper_turn_terminal.ml:95` dispatches on `reason.disposition : Keeper_turn_disposition.t` (10-variant closed sum: `Success | External_cancel | Turn_wall_clock_timeout | Oas_timeout_budget | Gh_repo_context_missing_worktree | Required_tool_use_no_tool_call | Required_tool_use_unsatisfied | Post_commit_ambiguous | Provider_error of _ | Unknown of {raw_error: string}`):

```ocaml
match reason.disposition with
| Keeper_turn_disposition.Unknown { raw_error = "" } -> true
| _ -> false
```

The `_` catch-all hides 9 disposition variants + `Unknown` with non-empty `raw_error`. A future disposition variant added to `Keeper_turn_disposition.t` (e.g. `Sandbox_violation`, `Quota_breached`) would silently inherit `false` under the catch-all without a review point on whether the new variant should opt into the unknown-empty SDK-error-derived pathway.

Same FSM Sparse Match anti-pattern as PRs #14716, #14790, #14806, #14810, #14816, #14823. CLAUDE.md `software-development.md` §"AI 코드 생성 안티패턴 §4 (FSM Sparse Match)" applies directly.

## What

Enumerate all 10 dispositions explicitly. Adding an 11th constructor to `Keeper_turn_disposition.t` now triggers `Warning 8: pattern-matching is not exhaustive`, forcing the maintainer to decide whether the new variant maps to `true` or `false`.

The added comment explains the intent (only empty-raw Unknown opts into SDK-error-derived code) so a future reader doesn't reintroduce the catch-all.

Behavior unchanged for current 10 dispositions.

## Self-check (CLAUDE.md Workaround Rejection Bar)

| # | Check | Result |
|---|---|---|
| 1 | telemetry-as-fix? | no — removes catch-all |
| 2 | string classifier? | no |
| 3 | N-of-M? | no — sole `is_*` predicate in this file |
| 4 | catch-all added? | no — `_ ->` removed |
| 5 | cap/cooldown/dedup? | no |
| 6 | test backdoor? | no |
| 7 | typo N sites? | no |

🤖 Generated with [Claude Code](https://claude.com/claude-code)