### PR TITLE
feat(telemetry): Supervisor_cleanup_failure_site + extend Observation_query_operation (8 sites)

### DIFF
--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -243,7 +243,7 @@ let launch_supervised_fiber
        (Keeper_state_machine.transition_error_to_string err);
      Prometheus.inc_counter
        Keeper_metrics.metric_keeper_supervisor_cleanup_failures
-       ~labels:[ "keeper", meta.name; "site", "fiber_start_rejected" ]
+       ~labels:[ "keeper", meta.name; "site", Supervisor_cleanup_failure_site.(to_label Fiber_start_rejected) ]
        ());
   if restart_launch_noop_enabled_for_test ()
   then ()
@@ -795,7 +795,7 @@ let restore_reconcile_continue_gate (ctx : _ context) (meta : keeper_meta) =
             reason;
           Prometheus.inc_counter
             Keeper_metrics.metric_keeper_supervisor_cleanup_failures
-            ~labels:[ "keeper", meta.name; "site", "reconcile_gate_rejected" ]
+            ~labels:[ "keeper", meta.name; "site", Supervisor_cleanup_failure_site.(to_label Reconcile_gate_rejected) ]
             ())
       ()
   in
@@ -863,7 +863,7 @@ let reconcile_keepalive_keepers (ctx : _ context) =
         | Error err ->
           Prometheus.inc_counter
             Keeper_metrics.metric_keeper_observation_query_failures
-            ~labels:[ "operation", "reconcile_read_meta" ]
+            ~labels:[ "operation", Observation_query_operation.(to_label Reconcile_read_meta) ]
             ();
           Log.Keeper.warn "reconcile: read_meta failed for %s: %s" name err);
        Eio_guard.yield_step reconcile_ym)
@@ -940,7 +940,7 @@ let cleanup_dead_tombstone (ctx : _ context) (entry : Keeper_registry.registry_e
         entry.name;
       Prometheus.inc_counter
         Keeper_metrics.metric_keeper_supervisor_cleanup_failures
-        ~labels:[ "keeper", entry.name; "site", "dead_tombstone_meta_write" ]
+        ~labels:[ "keeper", entry.name; "site", Supervisor_cleanup_failure_site.(to_label Dead_tombstone_meta_write) ]
         ())
   | Ok None ->
     Keeper_registry.unregister ~base_path:ctx.config.base_path entry.name;
@@ -955,7 +955,7 @@ let cleanup_dead_tombstone (ctx : _ context) (entry : Keeper_registry.registry_e
     Log.Keeper.warn "%s: dead tombstone unregistered (meta missing)" entry.name;
     Prometheus.inc_counter
       Keeper_metrics.metric_keeper_supervisor_cleanup_failures
-      ~labels:[ "keeper", entry.name; "site", "dead_tombstone_meta_missing" ]
+      ~labels:[ "keeper", entry.name; "site", Supervisor_cleanup_failure_site.(to_label Dead_tombstone_meta_missing) ]
       ()
   | Error err ->
     Keeper_registry.unregister ~base_path:ctx.config.base_path entry.name;
@@ -970,7 +970,7 @@ let cleanup_dead_tombstone (ctx : _ context) (entry : Keeper_registry.registry_e
     Log.Keeper.warn "%s: dead tombstone unregistered (meta error: %s)" entry.name err;
     Prometheus.inc_counter
       Keeper_metrics.metric_keeper_supervisor_cleanup_failures
-      ~labels:[ "keeper", entry.name; "site", "dead_tombstone_meta_error" ]
+      ~labels:[ "keeper", entry.name; "site", Supervisor_cleanup_failure_site.(to_label Dead_tombstone_meta_error) ]
       ()
 ;;
 
@@ -1554,7 +1554,7 @@ let sweep_and_recover (ctx : _ context) =
       msg;
     Prometheus.inc_counter
       Keeper_metrics.metric_keeper_supervisor_cleanup_failures
-      ~labels:[ "keeper", entry.name; "site", "force_watchdog_crash" ]
+      ~labels:[ "keeper", entry.name; "site", Supervisor_cleanup_failure_site.(to_label Force_watchdog_crash) ]
       ();
     (* 2026-05-05 fleet-stuck cycle: when a keeper fiber is stuck inside
        an LLM subprocess that does not honour [Eio.Cancel.Cancelled],
@@ -1849,7 +1849,7 @@ let sweep_and_recover (ctx : _ context) =
              (Printexc.to_string exn);
            Prometheus.inc_counter
              Keeper_metrics.metric_keeper_supervisor_cleanup_failures
-             ~labels:[ "keeper", name; "site", "paused_meta_prune" ]
+             ~labels:[ "keeper", name; "site", Supervisor_cleanup_failure_site.(to_label Paused_meta_prune) ]
              ())
       | _ -> ());
     Eio_guard.yield_step sweep_names_ym);

--- a/lib/keeper/observation_query_operation.ml
+++ b/lib/keeper/observation_query_operation.ml
@@ -4,6 +4,7 @@ type t =
   | Cursor_stale
   | Board_events
   | Empty_run_reasons
+  | Reconcile_read_meta
 
 let to_label = function
   | Read_backlog_counts -> "read_backlog_counts"
@@ -11,4 +12,5 @@ let to_label = function
   | Cursor_stale -> "cursor_stale"
   | Board_events -> "board_events"
   | Empty_run_reasons -> "empty_run_reasons"
+  | Reconcile_read_meta -> "reconcile_read_meta"
 ;;

--- a/lib/keeper/observation_query_operation.mli
+++ b/lib/keeper/observation_query_operation.mli
@@ -11,5 +11,6 @@ type t =
   | Cursor_stale
   | Board_events
   | Empty_run_reasons
+  | Reconcile_read_meta (** Supervisor reconcile-loop meta read failure (#14828 sweep). *)
 
 val to_label : t -> string

--- a/lib/keeper/supervisor_cleanup_failure_site.ml
+++ b/lib/keeper/supervisor_cleanup_failure_site.ml
@@ -1,0 +1,18 @@
+type t =
+  | Fiber_start_rejected
+  | Reconcile_gate_rejected
+  | Dead_tombstone_meta_write
+  | Dead_tombstone_meta_missing
+  | Dead_tombstone_meta_error
+  | Force_watchdog_crash
+  | Paused_meta_prune
+
+let to_label = function
+  | Fiber_start_rejected -> "fiber_start_rejected"
+  | Reconcile_gate_rejected -> "reconcile_gate_rejected"
+  | Dead_tombstone_meta_write -> "dead_tombstone_meta_write"
+  | Dead_tombstone_meta_missing -> "dead_tombstone_meta_missing"
+  | Dead_tombstone_meta_error -> "dead_tombstone_meta_error"
+  | Force_watchdog_crash -> "force_watchdog_crash"
+  | Paused_meta_prune -> "paused_meta_prune"
+;;

--- a/lib/keeper/supervisor_cleanup_failure_site.mli
+++ b/lib/keeper/supervisor_cleanup_failure_site.mli
@@ -1,0 +1,14 @@
+(** Supervisor_cleanup_failure_site — closed sum for [site] label on
+    [metric_keeper_supervisor_cleanup_failures] (7 sites in
+    keeper_supervisor.ml). *)
+
+type t =
+  | Fiber_start_rejected
+  | Reconcile_gate_rejected
+  | Dead_tombstone_meta_write
+  | Dead_tombstone_meta_missing
+  | Dead_tombstone_meta_error
+  | Force_watchdog_crash
+  | Paused_meta_prune
+
+val to_label : t -> string


### PR DESCRIPTION
## Summary

Continuing the sweep:

1. **New `Supervisor_cleanup_failure_site.t`** for
   `metric_keeper_supervisor_cleanup_failures` (7 sites in
   `keeper_supervisor.ml`):

   `Fiber_start_rejected | Reconcile_gate_rejected | Dead_tombstone_meta_write | Dead_tombstone_meta_missing | Dead_tombstone_meta_error | Force_watchdog_crash | Paused_meta_prune`

2. **Extend `Observation_query_operation.t`** with `Reconcile_read_meta`
   (1 site at `keeper_supervisor.ml:866` — a metric_keeper_observation_query_failures emit that didn't get caught by T18 because it was inside a different module).

## Sites (8)

| Metric | File:Line | Variant |
|--------|-----------|---------|
| `metric_keeper_supervisor_cleanup_failures` | `keeper_supervisor.ml:246` | `Fiber_start_rejected` |
| `metric_keeper_supervisor_cleanup_failures` | `keeper_supervisor.ml:798` | `Reconcile_gate_rejected` |
| `metric_keeper_supervisor_cleanup_failures` | `keeper_supervisor.ml:943` | `Dead_tombstone_meta_write` |
| `metric_keeper_supervisor_cleanup_failures` | `keeper_supervisor.ml:958` | `Dead_tombstone_meta_missing` |
| `metric_keeper_supervisor_cleanup_failures` | `keeper_supervisor.ml:973` | `Dead_tombstone_meta_error` |
| `metric_keeper_supervisor_cleanup_failures` | `keeper_supervisor.ml:1557` | `Force_watchdog_crash` |
| `metric_keeper_supervisor_cleanup_failures` | `keeper_supervisor.ml:1852` | `Paused_meta_prune` |
| `metric_keeper_observation_query_failures` | `keeper_supervisor.ml:866` | `Observation_query_operation.Reconcile_read_meta` (extend) |

Wire format byte-equal.

## Test plan

- [ ] CI green
- [ ] `rg '"site", "(fiber_start_rejected|reconcile_gate_rejected|dead_tombstone_meta_(write\|missing\|error)|force_watchdog_crash|paused_meta_prune)"' lib/keeper/keeper_supervisor.ml` = 0

RFC-WAIVED: not in credential/identity/operator/sandbox/hooks/workflow scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)