### PR TITLE
fix(rfc-0070-3c.1): Keeper_backoff_policy precondition + docstring (Copilot review)

### DIFF
--- a/lib/keeper/keeper_backoff_policy.ml
+++ b/lib/keeper/keeper_backoff_policy.ml
@@ -6,6 +6,11 @@ type t =
   }
 
 let make ~max_attempts ~retryable_errors =
+  if max_attempts < 1 then
+    invalid_arg
+      (Printf.sprintf
+         "Keeper_backoff_policy.make: max_attempts must be >= 1 (got %d)"
+         max_attempts);
   { max_attempts; retryable_errors }
 
 let default_for_sandbox =

--- a/lib/keeper/keeper_backoff_policy.mli
+++ b/lib/keeper/keeper_backoff_policy.mli
@@ -15,7 +15,11 @@ type t
 
 (** [make ~max_attempts ~retryable_errors] constructs a policy.
     [max_attempts] is the *total* number of calls including the first
-    (so [max_attempts = 1] disables retry).
+    (so [max_attempts = 1] disables retry). **Must be [>= 1]**;
+    [Invalid_argument] is raised for [<= 0] — a zero-attempt policy
+    would let a caller queue an action and never execute it, which
+    is silent-failure-by-construction.
+
     [retryable_errors] enumerates exactly the {!Docker_client.sandbox_error}
     arms that warrant a retry — *no catch-all*, the caller must
     enumerate every retryable variant. *)

--- a/lib/keeper/sandbox_executor.mli
+++ b/lib/keeper/sandbox_executor.mli
@@ -26,10 +26,15 @@ module Make : functor (D : Docker_client.S) -> sig
     :  Keeper_sandbox_plan.t
     -> (Docker_response.exec_result, Docker_client.sandbox_error) result
 
-  (** [execute_plan_with_retry ~retry plan] retries [D.run plan] up to
-      [Keeper_backoff_policy.max_attempts retry] times when the error
-      is in the policy's retryable set. Returns the first [Ok], or
-      the last [Error] after exhausting the budget.
+  (** [execute_plan_with_retry ~retry plan] calls [D.run plan] up to
+      [Keeper_backoff_policy.max_attempts retry] times *in total*
+      (one initial call plus up to [max_attempts - 1] retries on
+      retryable errors). Concretely: with [max_attempts = 3] the
+      callee may run at most three times — initial + 2 retries.
+
+      Returns the first [Ok], or the last [Error] after exhausting
+      the call budget. Non-retryable errors return immediately
+      regardless of remaining budget.
 
       Phase 3c.1 has *no sleep* between attempts — the budget is
       strictly call-count based. Phase 3c.2 introduces an

--- a/lib/keeper/sandbox_executor.mli
+++ b/lib/keeper/sandbox_executor.mli
@@ -28,9 +28,10 @@ module Make : functor (D : Docker_client.S) -> sig
 
   (** [execute_plan_with_retry ~retry plan] calls [D.run plan] up to
       [Keeper_backoff_policy.max_attempts retry] times *in total*
-      (one initial call plus up to [max_attempts - 1] retries on
-      retryable errors). Concretely: with [max_attempts = 3] the
-      callee may run at most three times — initial + 2 retries.
+      (one initial call plus up to [Keeper_backoff_policy.max_attempts
+      retry - 1] retries on retryable errors). Concretely: with
+      [Keeper_backoff_policy.max_attempts retry = 3] the callee may
+      run at most three times — initial + 2 retries.
 
       Returns the first [Ok], or the last [Error] after exhausting
       the call budget. Non-retryable errors return immediately

--- a/test/test_keeper_backoff_policy.ml
+++ b/test/test_keeper_backoff_policy.ml
@@ -67,6 +67,32 @@ let test_disable_retry () =
   check bool "empty retryable list rejects every variant" false
     (Keeper_backoff_policy.should_retry p Docker_client.Daemon_unreachable)
 
+(* ── Precondition enforcement (Copilot review T20/T21) ──────── *)
+
+let test_make_rejects_zero_attempts () =
+  check_raises "max_attempts=0 raises Invalid_argument"
+    (Invalid_argument
+       "Keeper_backoff_policy.make: max_attempts must be >= 1 (got 0)")
+    (fun () ->
+      let _ : Keeper_backoff_policy.t =
+        Keeper_backoff_policy.make ~max_attempts:0 ~retryable_errors:[]
+      in
+      ())
+
+let test_make_rejects_negative_attempts () =
+  check_raises "max_attempts=-3 raises Invalid_argument"
+    (Invalid_argument
+       "Keeper_backoff_policy.make: max_attempts must be >= 1 (got -3)")
+    (fun () ->
+      let _ : Keeper_backoff_policy.t =
+        Keeper_backoff_policy.make ~max_attempts:(-3) ~retryable_errors:[]
+      in
+      ())
+
+let test_make_accepts_minimum_one () =
+  let p = Keeper_backoff_policy.make ~max_attempts:1 ~retryable_errors:[] in
+  check int "min boundary 1 accepted" 1 (Keeper_backoff_policy.max_attempts p)
+
 let () =
   run "Keeper_backoff_policy"
     [
@@ -84,5 +110,11 @@ let () =
         [
           test_case "custom max_attempts + retryable list" `Quick test_custom_policy;
           test_case "max_attempts=1 + empty list disables retry" `Quick test_disable_retry;
+        ] );
+      ( "precondition enforcement",
+        [
+          test_case "make rejects max_attempts=0" `Quick test_make_rejects_zero_attempts;
+          test_case "make rejects negative max_attempts" `Quick test_make_rejects_negative_attempts;
+          test_case "make accepts minimum 1" `Quick test_make_accepts_minimum_one;
         ] );
     ]


### PR DESCRIPTION
## 목표 — PR #14827 후속 (Copilot 3 threads)

PR #14827 admin-merge 후 도착한 3 threads 모두 ACCEPT. 모두 *invariant/precondition* 명확화.

## RFC 인용

| RFC | 관계 |
|-----|------|
| **RFC-0070** | §3.4 — Backoff_policy precondition + executor wording |
| RFC-0006 | cite-only |
| RFC-0036 | cite-only |

## Copilot 3 threads 처리

| Thread | 판정 | 처리 |
|--------|------|------|
| T20 (policy.ml:17) `make`에 validation 부재 | **ACCEPT** | `max_attempts < 1` → `Invalid_argument` raise |
| T21 (policy.mli:25) docstring domain 미명시 | **ACCEPT** | "Must be [>= 1]; Invalid_argument otherwise" 명시 |
| T22 (executor.mli:32) "up to max_attempts" wording 모호 | **ACCEPT** | "in total (one initial call + up to max_attempts-1 retries)" + 예시 |

## Precondition 강제 — silent-failure-by-construction 차단

**Before**:
```ocaml
make ~max_attempts:0 ~retryable_errors:[]  (* OK silently *)
```
caller가 0-attempt policy 만들면 action queue되지만 never execute. *Silent failure*.

**After**:
```ocaml
make ~max_attempts:0 ~retryable_errors:[]
(* raises: Invalid_argument "Keeper_backoff_policy.make: max_attempts must be >= 1 (got 0)" *)
```

mli docstring에 *Invalid_argument contract* 명시 — caller가 surface에서 precondition 확인.

## 변경

```
lib/keeper/keeper_backoff_policy.ml     ±5 (validation raise)
lib/keeper/keeper_backoff_policy.mli    ±3 (docstring + Invalid_argument 명시)
lib/keeper/sandbox_executor.mli         ±5 (wording 정확화 + 예시)
test/test_keeper_backoff_policy.ml      ±35 (3 new precondition tests)
```

## Test 추가 (총 3 new assertions)

- `make rejects max_attempts=0` → Invalid_argument with exact message
- `make rejects negative max_attempts` (got -3)
- `make accepts minimum 1`

`check_raises`는 canonical `Invalid_argument` + matched message text 둘 다 pin — exception type + diagnostic content 양쪽 *공개 contract*로 굳힘.

## 검증

- Isolated ocamlc PASS
- behaviour 변경: invalid input rejection만 추가 (정상 input 동일)

## Workaround Rejection Bar self-check

| 시그니처 | 본 PR 해당? |
|---------|------------|
| Counter-as-fix | N/A |
| String 분류기 | N/A |
| N-of-M | N/A — 3 thread 1 PR |
| Cap/cooldown/dedup/repair | N/A — precondition 강제 |
| Test backdoor | N/A |
| Catch-all `_ ->` | N/A |

## 미검증

- runtime 영향 — `Invalid_argument`은 caller 응용 의무. 본 PR의 *static contract* 와 *test* 가 사양 명시. caller 검증은 추후 통합 시점.

3 thread `resolveReviewThread` 처리 예정.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
