### PR TITLE
perf(cascade_strategy): O(1) in_tier membership via Hashtbl in priority_tier_order

### DIFF
--- a/lib/cascade/cascade_strategy.ml
+++ b/lib/cascade/cascade_strategy.ml
@@ -532,7 +532,12 @@ let priority_tier_order adapter ctx ~tiers ~cycle cands =
   match allowed with
   | [] -> []
   | _ ->
-    let in_tier c = List.mem (adapter.health_key c) allowed in
+    (* Materialise [allowed] as a Hashtbl once so the per-candidate
+       membership check is O(1); prior shape did [List.mem health_key
+       allowed] per candidate, i.e. O(C x A) per ordering call. *)
+    let allowed_set = Hashtbl.create (List.length allowed) in
+    List.iter (fun name -> Hashtbl.replace allowed_set name ()) allowed;
+    let in_tier c = Hashtbl.mem allowed_set (adapter.health_key c) in
     let tier_cands = List.filter in_tier cands in
     (* Starvation guard: if every tier candidate reports capacity=0, fall
        through with the unfiltered tier list so at least one call is


### PR DESCRIPTION
## Summary

\`priority_tier_order\` (used by the \`Priority_tier\` cascade strategy) filtered candidates with:

\`\`\`ocaml
let in_tier c = List.mem (adapter.health_key c) allowed in
let tier_cands = List.filter in_tier cands in
\`\`\`

For C candidates × A allowed names, the filter is O(C × A) per ordering call. \`order_candidates t Priority_tier ...\` runs per cascade-decision per cycle.

## Fix

Materialise \`allowed\` as a \`(string, unit) Hashtbl\` once before the filter:

\`\`\`ocaml
let allowed_set = Hashtbl.create (List.length allowed) in
List.iter (fun name -> Hashtbl.replace allowed_set name ()) allowed;
let in_tier c = Hashtbl.mem allowed_set (adapter.health_key c) in
\`\`\`

Per-candidate check drops to O(1). With typical A=5-10 and C=10-30, the change shaves 50-300 string compares per ordering call.

## What I intentionally did NOT touch

The \`weighted_shuffle.pick\` function ~40 lines above has its own O(N²) shape — recomputes total weight + filters chosen item per round in a sampling-without-replacement loop. That's a deeper algorithmic restructure (move to a partial-sum tree or reservoir sampling), not a Hashtbl swap. Saving for an explicit perf-focused PR with user sign-off, since changing the randomized sampling logic touches fairness semantics.

## Test plan

- [ ] CI lib/ build green
- [ ] \`dune runtest test/test_cascade_strategy*.exe\` passes (if present)
- [ ] Smoke: priority_tier_order returns same ordering for known tier configurations

🤖 Generated with [Claude Code](https://claude.com/claude-code)