### PR TITLE
spec(kcasc,kdp): sync TurnPhaseSet to 7 members — cross-spec Class A (iter 42)

### DIFF
--- a/specs/INDEX.md
+++ b/specs/INDEX.md
@@ -5,7 +5,7 @@ Edit the generator, not this file. Re-run: scripts/gen-tla-index.sh > specs/INDE
 
 # TLA+ Spec Index
 
-Generated: 2026-05-11T22:06:04Z (HEAD: f0f6fad65)
+Generated: 2026-05-11T22:35:58Z (HEAD: 1cb75c15e)
 
 Source of truth: `specs/`. Run `scripts/gen-tla-index.sh > specs/INDEX.md` to refresh.
 
@@ -120,7 +120,7 @@ Source of truth: `specs/`. Run `scripts/gen-tla-index.sh > specs/INDEX.md` to re
 | KeeperAdmissionLiveness.tla | KeeperAdmissionLiveness | manual | 3 | 2 | clean={inv:TypeOK, inv:RateRespect, inv:TokensInRange, inv:QueueWellFormed, inv:TokenInflightConservation} buggy-2={inv:TypeOK, inv:RateRespect, inv:TokensInRange, inv:QueueWellFormed, inv:TokenInflightConservation} buggy={inv:TypeOK, inv:RateRespect, inv:TokensInRange, inv:QueueWellFormed, inv:TokenInflightConservation} | d0de975d7f83 |
 | KeeperApprovalQueue.tla | KeeperApprovalQueue | manual | 2 | 1 | clean={inv:TypeOK, inv:SafetyInvariant} buggy={inv:TypeOK, inv:SafetyInvariant} | a18102f83db7 |
 | KeeperCascadeAttemptFSM.tla | KeeperCascadeAttemptFSM | manual | 2 | 1 | clean={inv:SafetyInvariant} buggy={inv:SafetyInvariant} | a6708aff38f9 |
-| KeeperCascadeLifecycle.tla | KeeperCascadeLifecycle | manual | 2 | 1 | clean={inv:Safety, prop:TryingEventuallyTerminates, prop:FinalizingEventuallyClears} buggy={inv:CascadeSelectionRequiresMeasurement} | e305638eb658 |
+| KeeperCascadeLifecycle.tla | KeeperCascadeLifecycle | manual | 2 | 1 | clean={inv:Safety, prop:TryingEventuallyTerminates, prop:FinalizingEventuallyClears} buggy={inv:CascadeSelectionRequiresMeasurement} | 9134dad5df91 |
 | KeeperCascadeRouting.tla | KeeperCascadeRouting | manual | 2 | 1 | clean={inv:TypeOK, inv:KeeperNeverBlockedByCascade, inv:TurnProceedsIfHealthyItemExists, inv:NoGroupCycle, inv:HealthStateConsistent, inv:FallbackCountBounded, inv:SelectedItemInPath} buggy={inv:TypeOK, inv:KeeperNeverBlockedByCascade, inv:TurnProceedsIfHealthyItemExists, inv:NoGroupCycle, inv:HealthStateConsistent, inv:FallbackCountBounded, inv:SelectedItemInPath} | b2bdc9d76d73 |
 | KeeperCircuitBreaker.tla | KeeperCircuitBreaker | manual | 2 | 1 | clean={inv:SafetyInvariant} buggy={inv:TripOnlyWithStreak} | 1d4d87f2bb68 |
 | KeeperCompactionLifecycle.tla | KeeperCompactionLifecycle | manual | 2 | 1 | clean={inv:Safety, prop:OverflowEventuallyLeavesOverflow, prop:CompactingEventuallyStops} buggy={inv:CompactingAlignsAll} | ae32b2f6ae60 |
@@ -129,7 +129,7 @@ Source of truth: `specs/`. Run `scripts/gen-tla-index.sh > specs/INDEX.md` to re
 | KeeperContextLifecycle.tla | KeeperContextLifecycle | manual | 4 | 2 | clean={inv:TypeOK, inv:ContextIsolation, inv:ResumeIdentity, inv:TurnMonotonicity, inv:CompactionPairIntegrity, inv:CheckpointConsistency, inv:BudgetAfterCompaction, prop:CompactionProgress, prop:EventualTurnCompletion, prop:AllKeepersTerminate} buggy={inv:TypeOK, inv:ContextIsolation, inv:ResumeIdentity, inv:TurnMonotonicity, inv:CompactionPairIntegrity, inv:CheckpointConsistency, inv:BudgetAfterCompaction} ci-buggy={inv:ContextIsolation, inv:ResumeIdentity} ci={inv:TypeOK, inv:ContextIsolation, inv:ResumeIdentity, inv:TurnMonotonicity, inv:CompactionPairIntegrity, inv:CheckpointConsistency, inv:BudgetAfterCompaction} | e7d6cf456c70 |
 | KeeperCoreTriad.tla | KeeperCoreTriad | manual | 2 | 1 | clean={inv:SafetyInvariant, prop:RunningEventuallyCompletes CapabilityNeverDeadlocks} buggy={inv:SafetyInvariant} | 040df2f64d84 |
 | KeeperCounterCausality.tla | KeeperCounterCausality | manual | 2 | 1 | clean={inv:Safety} buggy={inv:CausePresentWhenCounted} | 531942a050de |
-| KeeperDecisionPipeline.tla | KeeperDecisionPipeline | manual | 4 | 2 | clean={inv:TypeOK, inv:Safety, prop:Liveness} buggy={inv:DecisionBoundaryRequiresMeasurement} cap2-buggy={inv:DecisionBoundaryRequiresMeasurement} cap2={inv:TypeOK, inv:ToolSetNeverEmpty, inv:RecoveryFloorMaintained, prop:FailingEventuallyRecovers} | 1fa85b795cb7 |
+| KeeperDecisionPipeline.tla | KeeperDecisionPipeline | manual | 4 | 2 | clean={inv:TypeOK, inv:Safety, prop:Liveness} buggy={inv:DecisionBoundaryRequiresMeasurement} cap2-buggy={inv:DecisionBoundaryRequiresMeasurement} cap2={inv:TypeOK, inv:ToolSetNeverEmpty, inv:RecoveryFloorMaintained, prop:FailingEventuallyRecovers} | 3476c0518970 |
 | KeeperDwellMonotone.tla | KeeperDwellMonotone | manual | 2 | 1 | clean={inv:Safety} buggy={inv:DwellNonNegative} | c9d0a52acb27 |
 | KeeperEventQueue.tla | KeeperEventQueue | manual | 2 | 1 | clean={inv:TypeOK, inv:SafetyInvariant} buggy={inv:TypeOK, inv:SafetyInvariant} | baf45bee2716 |
 | KeeperGenerationLineage.tla | KeeperGenerationLineage | manual | 2 | 1 | clean={inv:TypeOK, inv:CurrentTraceIsolation, inv:GenerationMatchesHistory, inv:CurrentTraceNotInHistory, inv:TraceHistoryUnique, inv:TraceIdsAllocated, inv:IdleCheckpointMatchesCommittedLineage, prop:HandoffEventuallyResolves} buggy={inv:TypeOK, inv:GenerationMatchesHistory, inv:CurrentTraceNotInHistory, inv:TraceHistoryUnique, inv:TraceIdsAllocated, inv:IdleCheckpointMatchesCommittedLineage} | b43e50f9ae3e |

--- a/specs/keeper-state-machine/KeeperCascadeLifecycle.tla
+++ b/specs/keeper-state-machine/KeeperCascadeLifecycle.tla
@@ -57,7 +57,7 @@ vars ==
     << turn_live, turn_phase, decision_stage, cascade_state,
        measurement_bound, selected_model_bound >>
 
-TurnPhaseSet == {"idle", "prompting", "executing", "compacting", "finalizing"}
+TurnPhaseSet == {"idle", "prompting", "routing", "executing", "compacting", "finalizing", "exhausted"}
 DecisionSet  == {"undecided", "guard_ok", "gate_rejected", "tool_policy_selected"}
 CascadeSet   == {"idle", "selecting", "trying", "done", "exhausted"}
 ActionSet    == {

--- a/specs/keeper-state-machine/KeeperDecisionPipeline.tla
+++ b/specs/keeper-state-machine/KeeperDecisionPipeline.tla
@@ -72,7 +72,7 @@ VARIABLES
 
 vars == <<turn_live, turn_phase, decision_stage, cascade_state, measurement_bound>>
 
-TurnPhaseSet == {"idle", "prompting", "executing", "compacting", "finalizing"}
+TurnPhaseSet == {"idle", "prompting", "routing", "executing", "compacting", "finalizing", "exhausted"}
 DecisionSet  == {"undecided", "guard_ok", "gate_rejected", "tool_policy_selected"}
 CascadeSet   == {"idle", "selecting", "trying", "done", "exhausted"}
 ActionSet    == {


### PR DESCRIPTION
## Iter 42 — Cross-spec Class A STALE sync (R-E-1.a extension)

**Iteration**: 42 (/loop FSM/TLA+/OCaml drift hunt)
**Closes**: 2 of 3 Class A STALE divergences identified in iter 41 audit (#14830).
**Pattern**: iter 39 R-E-1.a (#14824 — KCL TurnPhaseSet 5→7 sync).
**Risk**: LOW — type-widening only, no controller logic.

## Finding

Iter 41 audit classified the 7 cross-spec divergences surfaced by iter 40 scanner (#14828) into:
- **Class A — STALE** (this PR): 2 specs carry pre-iter-28 5-member `TurnPhaseSet`.
- **Class B — DELIBERATE PROJECTION** (deferred to iter 43): KMC observer-pattern renames.
- **Class C — NAME COLLISION** (deferred to iter 43): KEQ DecisionSet vocabulary collision.

This PR closes Class A. The 2 specs (`KeeperCascadeLifecycle`, `KeeperDecisionPipeline`) have the same root cause as iter 39's KCL drift: iter 28 #14793 widened KTC `TurnPhaseSet` from 5 → 7 members (added `routing`, `exhausted`), but observer specs were not synced.

## Before / After

```tla
\* KeeperCascadeLifecycle.tla:60 (BEFORE)
TurnPhaseSet == {"idle", "prompting", "executing", "compacting", "finalizing"}

\* AFTER (sync to KTC canonical)
TurnPhaseSet == {"idle", "prompting", "routing", "executing",
                 "compacting", "finalizing", "exhausted"}
```

Identical widening applied to `KeeperDecisionPipeline.tla:75`.

## 왜 톱니처럼 정교하지 않은가

R-B-1.c drift validator chain (iter 19→33) catches *OCaml→spec* drift but not *spec↔spec*. Iter 40's `--check-cross-spec` flag surfaced this gap, iter 41 classified it. Observer specs (KCascadeLifecycle, KDecisionPipeline) silently lag KTC because no automated tool compares set members across `*.tla` files.

Consequence pre-fix: KCascadeLifecycle's `ktc_turn_phase` variable could never reach `"routing"` or `"exhausted"` — joint invariants over those phases evaluated vacuously, weakening cross-spec coverage. No production bug (KTC's own spec catches turn_phase regressions), but cross-spec safety surface was 28% thinner than declared.

## TLC Verification

| Spec / cfg | Before | After |
|---|---|---|
| `KCascadeLifecycle.cfg` (clean) | 10 distinct states, no errors | 10 distinct states, no errors ✓ |
| `KCascadeLifecycle-buggy.cfg` | `CascadeSelectionRequiresMeasurement` violated | violated ✓ |
| `KDecisionPipeline.cfg` (clean) | 7 distinct states, no errors | 7 distinct states, no errors ✓ |
| `KDecisionPipeline-buggy.cfg` | `DecisionBoundaryRequiresMeasurement` violated | violated ✓ |
| `KDecisionPipeline-cap2-buggy.cfg` | invariant violated | violated ✓ |
| `KDecisionPipeline-cap2.cfg` | pre-existing `ToolSetNeverEmpty` error (orthogonal) | unchanged (pre-existing) |

Cross-spec scanner post-fix:
```
── TurnPhaseSet cross-spec (5 spec(s), 2 unique signature(s)) ──
  KeeperCascadeLifecycle:    7  ← canonical
  KeeperCompactionLifecycle: 4  ← Class B (deferred iter 43)
  KeeperCompositeLifecycle:  7  ← canonical
  KeeperDecisionPipeline:    7  ← canonical
  KeeperTurnCycle:           7  ← canonical
```

4 of 7 divergences remain (3 KMC Class B + 1 KEQ Class C). Iter 43 closes those + activates `--check-cross-spec` in CI.

## RFC

`RFC-WAIVED`: spec change only (type widening). Not in any RFC subsystem (credential/identity/repo/operator/sandbox/hooks/workflow). Verified with `bash ~/me/scripts/pr-rfc-check.sh --pr-body /tmp/pr-body-iter42.md`.

## References

- Iter 41 audit (#14830 ✓ merged): `docs/tla-audit/cross-spec-3-divergences-classify-2026-05-12.md`
- Iter 40 scanner capability (#14828 ✓ merged): `--check-cross-spec` opt-in
- Iter 39 KCL R-E-1.a (#14824 ✓ merged): single-spec STALE sync precedent
- Iter 38 KCL E-1 (`kcl-e1-cross-spec-projection-drift-2026-05-12.md`): discovery of spec↔spec drift class
- Iter 28 KTC R-B-1.a (#14793 ✓ merged): source of the staleness

## Next (iter 43)

1. **Class B rename** (3 set renames in `KeeperCompactionLifecycle.tla`):
   - `TurnPhaseSet` → `KMC_TurnPhaseSet`
   - `DecisionSet`  → `KMC_DecisionSet`
   - `CascadeSet`   → `KMC_CascadeSet`
2. **Class C rename** (1 set rename in `KeeperEventQueue.tla`):
   - `DecisionSet` → `SmartHeartbeatDecisionSet`
3. **CI activation**: enable `--check-cross-spec` flag in workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>