### PR TITLE
feat(telemetry): Turn_cleanup + Write_meta_cycle + Cascade_sync extend (5 sites)

### DIFF
--- a/lib/keeper/cascade_sync_failure_site.ml
+++ b/lib/keeper/cascade_sync_failure_site.ml
@@ -1,8 +1,10 @@
 type t =
   | Resume_sync
   | Pause_sync
+  | Ambiguous_partial_pause
 
 let to_label = function
   | Resume_sync -> "resume_sync"
   | Pause_sync -> "pause_sync"
+  | Ambiguous_partial_pause -> "ambiguous_partial_pause"
 ;;

--- a/lib/keeper/cascade_sync_failure_site.mli
+++ b/lib/keeper/cascade_sync_failure_site.mli
@@ -1,9 +1,12 @@
 (** Cascade_sync_failure_site — closed sum for [site] label on
-    [metric_keeper_cascade_sync_failures] (2 sites in
-    keeper_turn_cascade_budget.ml). *)
+    [metric_keeper_cascade_sync_failures] (now 3 sites across
+    keeper_turn_cascade_budget.ml + keeper_unified_turn.ml). *)
 
 type t =
   | Resume_sync
   | Pause_sync
+  | Ambiguous_partial_pause
+  (** Post-mutating-tool ambiguous-pause path in keeper_unified_turn.ml.
+          Operator-disposition equivalent of post-commit ambiguity. *)
 
 val to_label : t -> string

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -994,7 +994,7 @@ let run_keeper_cycle
                         (Printexc.to_string e);
                       Prometheus.inc_counter
                         Keeper_metrics.metric_keeper_turn_cleanup_failures
-                        ~labels:[ "keeper", meta.name; "site", "unsubscribe_event_bus" ]
+                        ~labels:[ "keeper", meta.name; "site", Turn_cleanup_failure_site.(to_label Unsubscribe_event_bus) ]
                         ());
                    try
                      Keeper_registry.mark_turn_finished
@@ -1009,7 +1009,7 @@ let run_keeper_cycle
                        (Printexc.to_string e);
                      Prometheus.inc_counter
                        Keeper_metrics.metric_keeper_turn_cleanup_failures
-                       ~labels:[ "keeper", meta.name; "site", "mark_turn_finished" ]
+                       ~labels:[ "keeper", meta.name; "site", Turn_cleanup_failure_site.(to_label Mark_turn_finished) ]
                        ()
                  in
                  match
@@ -2214,7 +2214,7 @@ let run_keeper_cycle
                         Prometheus.inc_counter
                           Keeper_metrics.metric_keeper_cascade_sync_failures
                           ~labels:
-                            [ "keeper", meta.name; "site", "ambiguous_partial_pause" ]
+                            [ "keeper", meta.name; "site", Cascade_sync_failure_site.(to_label Ambiguous_partial_pause) ]
                           ();
                         combined_err, updated_meta)
                     else err, updated_meta
@@ -2297,7 +2297,7 @@ let run_keeper_cycle
                          msg);
                   Prometheus.inc_counter
                     Keeper_metrics.metric_keeper_write_meta_cycle_failures
-                    ~labels:[ "keeper", meta.name; "site", "turn_failure" ]
+                    ~labels:[ "keeper", meta.name; "site", Write_meta_cycle_failure_site.(to_label Turn_failure) ]
                     ();
                   if is_ambiguous_partial
                   then (
@@ -2979,7 +2979,7 @@ let run_keeper_cycle
                      else Log.Keeper.error "write_meta failed after keeper cycle: %s" msg);
                   Prometheus.inc_counter
                     Keeper_metrics.metric_keeper_write_meta_cycle_failures
-                    ~labels:[ "keeper", meta.name; "site", "keeper_cycle" ]
+                    ~labels:[ "keeper", meta.name; "site", Write_meta_cycle_failure_site.(to_label Keeper_cycle) ]
                     ();
                   (* 8. Handle stop reason *)
                   Keeper_turn_fsm.emit_transition

--- a/lib/keeper/turn_cleanup_failure_site.ml
+++ b/lib/keeper/turn_cleanup_failure_site.ml
@@ -1,0 +1,8 @@
+type t =
+  | Unsubscribe_event_bus
+  | Mark_turn_finished
+
+let to_label = function
+  | Unsubscribe_event_bus -> "unsubscribe_event_bus"
+  | Mark_turn_finished -> "mark_turn_finished"
+;;

--- a/lib/keeper/turn_cleanup_failure_site.mli
+++ b/lib/keeper/turn_cleanup_failure_site.mli
@@ -1,0 +1,9 @@
+(** Turn_cleanup_failure_site — closed sum for [site] label on
+    [metric_keeper_turn_cleanup_failures] (2 sites in
+    keeper_unified_turn.ml). *)
+
+type t =
+  | Unsubscribe_event_bus
+  | Mark_turn_finished
+
+val to_label : t -> string

--- a/lib/keeper/write_meta_cycle_failure_site.ml
+++ b/lib/keeper/write_meta_cycle_failure_site.ml
@@ -1,0 +1,8 @@
+type t =
+  | Turn_failure
+  | Keeper_cycle
+
+let to_label = function
+  | Turn_failure -> "turn_failure"
+  | Keeper_cycle -> "keeper_cycle"
+;;

--- a/lib/keeper/write_meta_cycle_failure_site.mli
+++ b/lib/keeper/write_meta_cycle_failure_site.mli
@@ -1,0 +1,9 @@
+(** Write_meta_cycle_failure_site — closed sum for [site] label on
+    [metric_keeper_write_meta_cycle_failures] (2 sites in
+    keeper_unified_turn.ml). *)
+
+type t =
+  | Turn_failure
+  | Keeper_cycle
+
+val to_label : t -> string


### PR DESCRIPTION
## Summary

Three more keeper_unified_turn.ml clusters typed:

1. **New `Turn_cleanup_failure_site.t`** (2 sites on
   `metric_keeper_turn_cleanup_failures`):
   `Unsubscribe_event_bus | Mark_turn_finished`

2. **New `Write_meta_cycle_failure_site.t`** (2 sites on
   `metric_keeper_write_meta_cycle_failures`):
   `Turn_failure | Keeper_cycle`

3. **Extend `Cascade_sync_failure_site.t`** with `Ambiguous_partial_pause`
   (1 site on `metric_keeper_cascade_sync_failures`, post-mutating-tool
   ambiguous-pause path).

## Sites (5)

| Metric | File:Line | Variant |
|--------|-----------|---------|
| `metric_keeper_turn_cleanup_failures` | `keeper_unified_turn.ml:997` | `Unsubscribe_event_bus` |
| `metric_keeper_turn_cleanup_failures` | `keeper_unified_turn.ml:1012` | `Mark_turn_finished` |
| `metric_keeper_cascade_sync_failures` | `keeper_unified_turn.ml:2217` | `Ambiguous_partial_pause` |
| `metric_keeper_write_meta_cycle_failures` | `keeper_unified_turn.ml:2300` | `Turn_failure` |
| `metric_keeper_write_meta_cycle_failures` | `keeper_unified_turn.ml:2982` | `Keeper_cycle` |

Wire format byte-equal.

## Test plan

- [ ] CI green
- [ ] `rg '"site", "(unsubscribe_event_bus|mark_turn_finished|turn_failure|keeper_cycle|ambiguous_partial_pause)"' lib/keeper/keeper_unified_turn.ml` = 0

RFC-WAIVED: not in credential/identity/operator/sandbox/hooks/workflow scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)