### PR TITLE
feat(rfc-0070): Phase 3b-iv.2.0 — Docker_client_real skeleton (typed placeholder)

### DIFF
--- a/lib/keeper/docker_client_real.ml
+++ b/lib/keeper/docker_client_real.ml
@@ -1,0 +1,14 @@
+(* RFC-0070 Phase 3b-iv.2.0 — Real Docker_client skeleton. See .mli.
+
+   Every function returns a typed placeholder [Error Cleanup_failed].
+   Sub-phases 3b-iv.2.{1,2,3,4} replace each function body with the
+   real Process_eio-backed spawn; the public signature does not
+   change between sub-phases so callers can wire this module today
+   and pick up new behaviour as it lands. *)
+
+let placeholder = Error Docker_client.Cleanup_failed
+
+let run (_ : Keeper_sandbox_plan.t) = placeholder
+let exec ~container:_ ~cmd:_ = placeholder
+let ps_query ~labels:_ = placeholder
+let rm (_ : Keeper_container_name.t) = Error Docker_client.Cleanup_failed

--- a/lib/keeper/docker_client_real.mli
+++ b/lib/keeper/docker_client_real.mli
@@ -1,0 +1,27 @@
+(** RFC-0070 Phase 3b-iv.2.0 — Real {!Docker_client.S} (skeleton).
+
+    Phase 3a's stub kept [Docker_client.S] as a *signature only*.
+    Phase 3b-iv.1b added [Docker_client_mock] for tests. Phase
+    3b-iv.2.0 adds the *production* implementation skeleton, satisfying
+    [S] so callers parameterising on [(module Docker_client.S)] can
+    swap it in alongside the mock at compile time.
+
+    Reference: docs/rfc/RFC-0070-keeper-sandbox-pure-edge-separation.md §3.2
+
+    Phase 3b-iv.2 skeleton scope: every function in [S] is implemented
+    but returns [Error Cleanup_failed] — a typed placeholder that
+    *cannot* silently succeed. Phase 3b-iv.2.1 wires [rm] to
+    [Process_eio.run_argv_with_status]; subsequent sub-phases wire
+    [exec], [run], [ps_query] in their own PRs. Each sub-phase replaces
+    the placeholder with a real spawn while preserving the typed
+    [sandbox_error] surface — no caller code changes between
+    sub-phases.
+
+    **Why a placeholder skeleton and not [failwith]**: returning
+    [Error Cleanup_failed] keeps the signature in {!result}; a caller
+    that wires Real before Phase 3b-iv.2.{1,2,3,4} land will receive a
+    typed failure they can pattern-match on, not an exception that
+    surfaces as a crash. RFC-0070's "no silent failure, no exception
+    leak" contract is preserved. *)
+
+include Docker_client.S

--- a/test/dune
+++ b/test/dune
@@ -595,6 +595,7 @@
         test_keeper_sandbox_plan
         test_docker_response
         test_docker_client_mock
+        test_docker_client_real
         test_sandbox_executor
         test_keeper_backoff_policy
         test_worker_runtime
@@ -811,6 +812,7 @@
         test_keeper_sandbox_plan
         test_docker_response
         test_docker_client_mock
+        test_docker_client_real
         test_sandbox_executor
         test_keeper_backoff_policy
         test_worker_runtime

--- a/test/test_docker_client_real.ml
+++ b/test/test_docker_client_real.ml
@@ -1,0 +1,89 @@
+(** RFC-0070 Phase 3b-iv.2.0 — tests for [Docker_client_real] skeleton.
+
+    Pins the typed-placeholder contract: every function returns
+    [Error Cleanup_failed]. Critically, this includes a compile-time
+    witness that [Docker_client_real] satisfies [Docker_client.S],
+    so the [Sandbox_executor.Make] functor accepts both Mock and
+    Real interchangeably.
+
+    Sub-phases 3b-iv.2.{1,2,3,4} replace each placeholder one at a
+    time; the corresponding test cases below will be retargeted to
+    cover the new behaviour as each sub-phase lands. *)
+
+open Alcotest
+open Masc_mcp
+
+(* Compile-time witness: Real satisfies S. *)
+let (_ : (module Docker_client.S)) = (module Docker_client_real)
+
+(* And it composes with the executor functor (along with Mock from
+   Phase 3b-iv.1b). *)
+module Real_executor = Sandbox_executor.Make (Docker_client_real)
+
+let sample_plan () =
+  match
+    Keeper_sandbox_plan.of_request
+      ~turn_id:1
+      ~attempt:0
+      ~meta_name:"alice"
+      ~cmd:"echo hi"
+  with
+  | Ok p -> p
+  | Error _ -> failwith "test fixture"
+
+let sample_container () =
+  Keeper_container_name.derive
+    ~algo:Keeper_hash_algo.SHA_256
+    ~turn_id:1
+    ~attempt:0
+    ~suffix:"alice"
+
+(* ── Each S function returns the typed placeholder ──────────── *)
+
+let test_run_placeholder () =
+  match Docker_client_real.run (sample_plan ()) with
+  | Error Docker_client.Cleanup_failed -> ()
+  | _ -> fail "expected Cleanup_failed placeholder"
+
+let test_exec_placeholder () =
+  match
+    Docker_client_real.exec ~container:(sample_container ()) ~cmd:"ls"
+  with
+  | Error Docker_client.Cleanup_failed -> ()
+  | _ -> fail "expected Cleanup_failed placeholder"
+
+let test_ps_query_placeholder () =
+  match Docker_client_real.ps_query ~labels:[] with
+  | Error Docker_client.Cleanup_failed -> ()
+  | _ -> fail "expected Cleanup_failed placeholder"
+
+let test_rm_placeholder () =
+  match Docker_client_real.rm (sample_container ()) with
+  | Error Docker_client.Cleanup_failed -> ()
+  | _ -> fail "expected Cleanup_failed placeholder"
+
+(* ── Functor instantiation works with Real ───────────────────── *)
+
+let test_executor_with_real_returns_placeholder () =
+  let r = Real_executor.execute_plan (sample_plan ()) in
+  match r with
+  | Error Docker_client.Cleanup_failed -> ()
+  | _ -> fail "executor with Real placeholder should surface Cleanup_failed"
+
+let () =
+  run "Docker_client_real (skeleton)"
+    [
+      ( "S placeholder",
+        [
+          test_case "run → Cleanup_failed" `Quick test_run_placeholder;
+          test_case "exec → Cleanup_failed" `Quick test_exec_placeholder;
+          test_case "ps_query → Cleanup_failed" `Quick test_ps_query_placeholder;
+          test_case "rm → Cleanup_failed" `Quick test_rm_placeholder;
+        ] );
+      ( "Functor composition",
+        [
+          test_case "Sandbox_executor.Make (Real) instantiates + forwards placeholder"
+            `Quick
+            test_executor_with_real_returns_placeholder;
+        ] );
+    ]


### PR DESCRIPTION
## 목표 — RFC-0070 §3.2 Phase 3b-iv.2.0

**Docker_client_real skeleton** — production-side `Docker_client.S` impl 진입 (placeholder phase). Mock + Real이 *동일 functor*에 들어가 *callers 어디든 swap-in 가능*.

## RFC 인용

| RFC | 관계 |
|-----|------|
| **RFC-0070** | §3.2 — production Docker_client.S |
| RFC-0006 | cite-only |
| RFC-0036 | cite-only |

## Phase 3b-iv.2 분할

| Sub-phase | scope | LOC | 본 PR? |
|-----------|-------|-----|--------|
| **3b-iv.2.0** | skeleton, S satisfies, 4 placeholders | ~30 | ✅ |
| 3b-iv.2.1 | `rm` real impl | ~25 | 다음 |
| 3b-iv.2.2 | `exec` real impl | ~35 | 다음 |
| 3b-iv.2.3 | `run` real (Plan → argv 조립) | ~50 | 다음 |
| 3b-iv.2.4 | `ps_query` + JSON parser | ~70 | 다음 |

각 sub-phase 25-70 LOC, *지름길 없는 안전한 점진*. Phase 3a/3b-i 분할 전략과 동일.

## Skeleton design — typed placeholder

```ocaml
let placeholder = Error Docker_client.Cleanup_failed

let run (_ : Keeper_sandbox_plan.t) = placeholder
let exec ~container:_ ~cmd:_ = placeholder
let ps_query ~labels:_ = placeholder
let rm (_ : Keeper_container_name.t) = placeholder
```

**Why typed placeholder, not failwith**:
- 본 PR 이후 Real을 wire한 caller가 *exception 받지 않고* typed `Error Cleanup_failed`로 받음
- `Sandbox_executor.Make (Real)`가 *fully composable* — `executor.execute_plan` 호출 시 *consistent type*
- RFC-0070 §"no silent failure, no exception leak" 일관 유지

## Eio.Process wrapper *재발견*

Plan 작성 중 발견: `lib/process/process_eio.mli` 이 *이미* `run_argv_with_status_split` (argv + stdin + status + stdout + stderr) 제공. Global init 패턴, typed errors. **신규 `Docker_process` wrapper 작성 불필요** — Phase 3b-iv.2.1+ 가 *기존 Process_eio*를 *직접 호출*. CLAUDE.md §AI 안티패턴 §1 "scattered hardcoded defaults" 회피.

## Test 커버리지 (5 assertions)

| 그룹 | 검증 |
|------|------|
| S placeholder (4) | run / exec / ps_query / rm 각각 Cleanup_failed |
| Functor composition (1) | `Sandbox_executor.Make (Real)` instantiation + executor가 Cleanup_failed forward |

**Compile-time witness 2개**:
```ocaml
let (_ : (module Docker_client.S)) = (module Docker_client_real)
module Real_executor = Sandbox_executor.Make (Docker_client_real)
```
→ S 만족 + functor composition 컴파일 시점에 *둘 다* 검증.

## Mock + Real interchangeability 달성

이제 caller가 `(module Docker_client.S)`로 parameterize하면 *Mock + Real* 둘 다 받음. functor pattern (Phase 3c.0)이 *production용*도 사용 가능.

## 변경

```
lib/keeper/docker_client_real.mli   23 lines
lib/keeper/docker_client_real.ml    16 lines (placeholder)
test/test_docker_client_real.ml     90 lines (5 assertion)
test/dune                            +2
```

## 검증

- Isolated ocamlc PASS (의존성 origin/main에 모두 존재)
- 2 compile-time witnesses (S 만족 + functor compose) 강제

## Workaround Rejection Bar self-check

| 시그니처 | 본 PR 해당? |
|---------|------------|
| Counter-as-fix | N/A |
| String 분류기 | N/A |
| **N-of-M** | **명시적 acknowledge**: 본 PR이 *4 placeholders* ship. 4 follow-up PRs (.2.1/.2.2/.2.3/.2.4)이 *typed signature 위에서 한 함수씩 교체*, *caller-surface 변경 0*. **Skeleton phase의 measurable value**: compile-time witness + functor instantiation — implementation PRs와 *독립적*. 따라서 N-of-M의 *concern* (다른 PR이 *Q-of-M*) 회피 |
| Cap/cooldown/dedup/repair | N/A |
| Test backdoor | N/A |
| Catch-all `_ ->` | N/A |

## 미검증

- Real implementation behaviour — sub-phase 3b-iv.2.{1,2,3,4}
- Integration test with real docker daemon — separate track

## 다음 PR

- **3b-iv.2.1**: `rm` 실제 `Process_eio.run_argv_with_status` wire
- 그 이후 exec / run / ps_query 순차

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
