### PR TITLE
feat(telemetry): keeper_checkpoint_store typed labels (8 sites)

### DIFF
--- a/lib/keeper/checkpoint_failure_operation.ml
+++ b/lib/keeper/checkpoint_failure_operation.ml
@@ -9,6 +9,8 @@ type t =
   | Migration_save
   | Restore_legacy
   | Create_initial_save
+  | Cleanup
+  | Malformed_load
 
 let to_label = function
   | Migrate_main_history -> "migrate_main_history"
@@ -21,4 +23,6 @@ let to_label = function
   | Migration_save -> "migration_save"
   | Restore_legacy -> "restore_legacy"
   | Create_initial_save -> "create_initial_save"
+  | Cleanup -> "cleanup"
+  | Malformed_load -> "malformed_load"
 ;;

--- a/lib/keeper/checkpoint_failure_operation.mli
+++ b/lib/keeper/checkpoint_failure_operation.mli
@@ -16,5 +16,7 @@ type t =
   | Migration_save (** Persisting a migrated checkpoint to the OAS store failed. *)
   | Restore_legacy (** Restoring the working context from a legacy checkpoint raised. *)
   | Create_initial_save (** Initial checkpoint save during keeper boot create flow. *)
+  | Cleanup (** Checkpoint-store cleanup pass failure. *)
+  | Malformed_load (** Load attempt aborted because checkpoint payload was malformed. *)
 
 val to_label : t -> string

--- a/lib/keeper/checkpoint_store_failure_site.ml
+++ b/lib/keeper/checkpoint_store_failure_site.ml
@@ -1,0 +1,16 @@
+type t =
+  | Save
+  | Oas_cleanup
+  | Oas_save
+  | Oas_delete
+  | Oas_archive_fallback
+  | Oas_archive_primary
+
+let to_label = function
+  | Save -> "save"
+  | Oas_cleanup -> "oas_cleanup"
+  | Oas_save -> "oas_save"
+  | Oas_delete -> "oas_delete"
+  | Oas_archive_fallback -> "oas_archive_fallback"
+  | Oas_archive_primary -> "oas_archive_primary"
+;;

--- a/lib/keeper/checkpoint_store_failure_site.mli
+++ b/lib/keeper/checkpoint_store_failure_site.mli
@@ -1,0 +1,20 @@
+(** Checkpoint_store_failure_site — closed sum for [site] label on
+    [metric_keeper_checkpoint_failures] when emitted from the
+    checkpoint-store layer (6 sites in keeper_checkpoint_store.ml).
+
+    NOTE: the underlying metric is shared with
+    {!Checkpoint_failure_operation} but emits use the legacy [site]
+    label key (kept verbatim to preserve Grafana dashboard queries
+    that select on `site=...`).  A follow-up RFC could harmonise the
+    label key to a single [operation] across both call sites once
+    dashboards are migrated. *)
+
+type t =
+  | Save (** Legacy-format checkpoint save failure. *)
+  | Oas_cleanup (** OAS checkpoint cleanup pass failed. *)
+  | Oas_save (** OAS checkpoint primary save failed. *)
+  | Oas_delete (** OAS checkpoint delete failed. *)
+  | Oas_archive_fallback (** Archive-tier fallback save failed. *)
+  | Oas_archive_primary (** Archive-tier primary save failed. *)
+
+val to_label : t -> string

--- a/lib/keeper/keeper_checkpoint_store.ml
+++ b/lib/keeper/keeper_checkpoint_store.ml
@@ -56,7 +56,7 @@ let prune ~(session_dir : string) ~(keep : int) : int =
            path (Printexc.to_string exn);
          Prometheus.inc_counter
            Keeper_metrics.metric_keeper_checkpoint_failures
-           ~labels:[("keeper", "aggregate"); ("operation", "cleanup")]
+           ~labels:[("keeper", "aggregate"); ("operation", Checkpoint_failure_operation.(to_label Cleanup))]
            ()))
       to_remove;
     List.length to_remove
@@ -91,7 +91,7 @@ let save
     Log.Keeper.warn "save_checkpoint failed for %s: %s" path msg;
     Prometheus.inc_counter
       Keeper_metrics.metric_keeper_checkpoint_failures
-      ~labels:[("site", "save")]
+      ~labels:[("site", Checkpoint_store_failure_site.(to_label Save))]
       ()
 
 (* ================================================================ *)
@@ -134,7 +134,7 @@ let load_latest ~(session_dir : string) : Keeper_types.checkpoint option =
          path (Printexc.to_string exn);
        Prometheus.inc_counter
          Keeper_metrics.metric_keeper_checkpoint_failures
-         ~labels:[("keeper", "aggregate"); ("operation", "malformed_load")]
+         ~labels:[("keeper", "aggregate"); ("operation", Checkpoint_failure_operation.(to_label Malformed_load))]
          ();
        None)
 
@@ -196,7 +196,7 @@ let prune_oas_history ~(session_dir : string) : unit =
                path (Printexc.to_string exn);
              Prometheus.inc_counter
                Keeper_metrics.metric_keeper_checkpoint_failures
-               ~labels:[("site", "oas_cleanup")]
+               ~labels:[("site", Checkpoint_store_failure_site.(to_label Oas_cleanup))]
                ())
 
 let hardlink_oas_history_from_canonical
@@ -238,7 +238,7 @@ let save_oas_history ~(session_dir : string) (ckpt : Agent_sdk.Checkpoint.t) : u
     Log.Keeper.warn "save_oas_history failed for %s: %s" snapshot_id msg;
     Prometheus.inc_counter
       Keeper_metrics.metric_keeper_checkpoint_failures
-      ~labels:[("site", "oas_save")]
+      ~labels:[("site", Checkpoint_store_failure_site.(to_label Oas_save))]
       ()
 
 let delete_oas_history_files ~(session_dir : string) ~(snapshot_ids : string list)
@@ -257,7 +257,7 @@ let delete_oas_history_files ~(session_dir : string) ~(snapshot_ids : string lis
               path (Printexc.to_string exn);
             Prometheus.inc_counter
               Keeper_metrics.metric_keeper_checkpoint_failures
-              ~labels:[("site", "oas_delete")]
+              ~labels:[("site", Checkpoint_store_failure_site.(to_label Oas_delete))]
               ();
             (deleted, snapshot_id :: missing))
       else
@@ -280,7 +280,7 @@ let save_oas ~(session_dir : string) (ckpt : Agent_sdk.Checkpoint.t)
              ckpt.session_id (Printexc.to_string exn);
            Prometheus.inc_counter
              Keeper_metrics.metric_keeper_checkpoint_failures
-             ~labels:[("site", "oas_archive_fallback")]
+             ~labels:[("site", Checkpoint_store_failure_site.(to_label Oas_archive_fallback))]
              ());
       Ok ()
     | Error msg -> Error msg
@@ -301,7 +301,7 @@ let save_oas ~(session_dir : string) (ckpt : Agent_sdk.Checkpoint.t)
                         ckpt.session_id (Printexc.to_string exn);
                       Prometheus.inc_counter
                         Keeper_metrics.metric_keeper_checkpoint_failures
-                        ~labels:[("site", "oas_archive_primary")]
+                        ~labels:[("site", Checkpoint_store_failure_site.(to_label Oas_archive_primary))]
                         ());
                  Ok ()
              | Error err -> Error (Agent_sdk.Error.to_string err))


### PR DESCRIPTION
## Summary

All 8 sites in `keeper_checkpoint_store.ml` on `metric_keeper_checkpoint_failures` typed:

1. **Extend `Checkpoint_failure_operation.t`** with `Cleanup | Malformed_load` (2 sites on `operation` label)
2. **New `Checkpoint_store_failure_site.t`** for 6 sites on `site` label:
   `Save | Oas_cleanup | Oas_save | Oas_delete | Oas_archive_fallback | Oas_archive_primary`

## Sites (8)

| File:Line | Label | Variant |
|-----------|-------|---------|
| `keeper_checkpoint_store.ml:59` | `operation` | `Checkpoint_failure_operation.Cleanup` |
| `keeper_checkpoint_store.ml:94` | `site` | `Checkpoint_store_failure_site.Save` |
| `keeper_checkpoint_store.ml:137` | `operation` | `Checkpoint_failure_operation.Malformed_load` |
| `keeper_checkpoint_store.ml:199` | `site` | `Checkpoint_store_failure_site.Oas_cleanup` |
| `keeper_checkpoint_store.ml:241` | `site` | `Checkpoint_store_failure_site.Oas_save` |
| `keeper_checkpoint_store.ml:260` | `site` | `Checkpoint_store_failure_site.Oas_delete` |
| `keeper_checkpoint_store.ml:283` | `site` | `Checkpoint_store_failure_site.Oas_archive_fallback` |
| `keeper_checkpoint_store.ml:304` | `site` | `Checkpoint_store_failure_site.Oas_archive_primary` |

## Note

The same metric (`metric_keeper_checkpoint_failures`) uses two
different label key names (`operation` vs `site`) across emit
sites — an inconsistency that pre-dates this PR.  Preserved verbatim
to keep Grafana queries that select on each key intact.  A follow-up
RFC could harmonise to a single label key once dashboards migrate.

Wire format byte-equal.

## Test plan

- [ ] CI green
- [ ] `rg '"(operation\|site)", "(cleanup\|malformed_load\|save\|oas_cleanup\|oas_save\|oas_delete\|oas_archive_fallback\|oas_archive_primary)"' lib/keeper/keeper_checkpoint_store.ml` = 0

RFC-WAIVED: not in credential/identity/operator/sandbox/hooks/workflow scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)