### PR TITLE
fix(resilience_outcome): make is_full / is_partial / is_graceful predicates exhaustive

### DIFF
--- a/lib/shared_types/resilience_outcome.ml
+++ b/lib/shared_types/resilience_outcome.ml
@@ -44,15 +44,15 @@ let graceful ?fallback ~reason ~recovery_strategy ~confidence () =
 
 let is_full : type a e. (a, e) t -> bool = function
   | FullSuccess _ -> true
-  | _ -> false
+  | PartialSuccess _ | GracefulFailure _ -> false
 
 let is_partial : type a e. (a, e) t -> bool = function
   | PartialSuccess _ -> true
-  | _ -> false
+  | FullSuccess _ | GracefulFailure _ -> false
 
 let is_graceful : type a e. (a, e) t -> bool = function
   | GracefulFailure _ -> true
-  | _ -> false
+  | FullSuccess _ | PartialSuccess _ -> false
 
 let value_opt : type a e. (a, e) t -> a option = function
   | FullSuccess { value; _ } -> Some value


### PR DESCRIPTION
## Why

`Resilience_outcome.t` is a 3-variant GADT (`FullSuccess | PartialSuccess | GracefulFailure`). Three predicate accessors use `| _ -> false` catch-alls, which silently absorb any future variant additions to the type.

## Sites

| Function | Line | Catch-all shape |
|----------|------|-----------------|
| `is_full` | 45-47 | `\| FullSuccess _ -> true \| _ -> false` |
| `is_partial` | 49-51 | `\| PartialSuccess _ -> true \| _ -> false` |
| `is_graceful` | 53-55 | `\| GracefulFailure _ -> true \| _ -> false` |

Same module's `value_opt` (L57-60), `confidence` (L62-65), `map` (L67-85), `cata` (L87-101), `class_to_string` (L115-118) all already enumerate all three constructors — the predicates were the odd ones out.

## Fix

Replace catch-all with explicit sibling enumeration:

```ocaml
let is_full : type a e. (a, e) t -> bool = function
  | FullSuccess _ -> true
  | PartialSuccess _ | GracefulFailure _ -> false
```

## Why now

If a future PR adds e.g. `Cancelled` or `Degraded` to the GADT (the type is named *Resilience_outcome* — variant churn is a realistic risk):
- `is_full` / `is_partial` / `is_graceful` would all silently return `false` for the new variant
- Downstream classification logic (cf. `class_to_string` users) would misroute the new outcome with no compiler warning

After this PR, OCaml warning 8 will surface the missing arm at compile time, forcing a per-predicate decision.

## Behavior preservation

Under the current 3-variant type the new explicit arms produce identical truth tables to the prior `_ -> false`. No semantic change.

## Verification

- `dune build @lib/shared_types/check --root .` exit 0
- `git diff --stat`: 1 file, +3 −3
- No public API change (signatures, `.mli` not touched)

## Methodology

Applied iter #22-#23 sweep cross-check protocol:
1. main grep for `\| _ -> false$` over closed-sum predicates → candidate
2. `gh pr view <PR> --json files` cross-check across 5 open PRs (#14841/#14837/#14835/#14758/#14718) → no overlap
3. surgical fix with explicit constructor enumeration