### PR TITLE
feat(rfc-0070): Phase 3b-iv.2.1 — Real Docker_client.rm wired via Process_eio

### DIFF
--- a/lib/keeper/docker_client_real.ml
+++ b/lib/keeper/docker_client_real.ml
@@ -17,11 +17,16 @@ let placeholder = Error Docker_client.Cleanup_failed
      0   — container removed successfully
      1   — container not found, or removal blocked (generic failure)
      125 — daemon error / docker CLI itself errored
-   We map 0 → Ok, any other WEXITED → Cleanup_failed, and signal /
-   stopped statuses → Daemon_unreachable. *)
+     127 — synthesized by [Process_eio.run_argv_with_status] when the
+           CLI binary cannot be spawned (missing executable / exec
+           error). Functionally identical to "daemon unreachable" from
+           the caller's POV.
+   Mapping: 0 → Ok, 127 → Daemon_unreachable, any other WEXITED →
+   Cleanup_failed, and signal / stopped statuses → Daemon_unreachable. *)
 let map_exit_status_for_rm (status : Unix.process_status) =
   match status with
   | Unix.WEXITED 0 -> Ok ()
+  | Unix.WEXITED 127 -> Error Docker_client.Daemon_unreachable
   | Unix.WEXITED _ -> Error Docker_client.Cleanup_failed
   | Unix.WSIGNALED _ | Unix.WSTOPPED _ -> Error Docker_client.Daemon_unreachable
 
@@ -35,6 +40,14 @@ let rm container =
   let argv =
     [ "docker"; "rm"; "-f"; Keeper_container_name.to_string container ]
   in
-  match Process_eio.run_argv_with_status argv with
-  | status, _stdout -> map_exit_status_for_rm status
-  | exception Unix.Unix_error _ -> Error Docker_client.Daemon_unreachable
+  (* [Process_eio.run_argv_with_status] swallows [Unix.Unix_error] from
+     spawn and surfaces it as [WEXITED 127] (see
+     [test/test_process_eio_coverage.ml]: "missing command exit code"
+     = 127), so the previous [exception Unix.Unix_error _] branch was
+     dead. The 127 mapping in [map_exit_status_for_rm] now picks up
+     missing-CLI / exec-failure as [Daemon_unreachable]. Eio-level
+     cancellation ([Eio.Cancel.Cancelled]) is still propagated to the
+     caller intentionally — RFC-0070 requires cancellation to remain
+     observable. *)
+  let status, _stdout = Process_eio.run_argv_with_status argv in
+  map_exit_status_for_rm status

--- a/lib/keeper/docker_client_real.ml
+++ b/lib/keeper/docker_client_real.ml
@@ -1,14 +1,40 @@
-(* RFC-0070 Phase 3b-iv.2.0 — Real Docker_client skeleton. See .mli.
+(* RFC-0070 Phase 3b-iv.2.1 — Real Docker_client (rm wired).
 
-   Every function returns a typed placeholder [Error Cleanup_failed].
-   Sub-phases 3b-iv.2.{1,2,3,4} replace each function body with the
-   real Process_eio-backed spawn; the public signature does not
-   change between sub-phases so callers can wire this module today
-   and pick up new behaviour as it lands. *)
+   Sub-phase 3b-iv.2.0 shipped placeholders for all four S functions.
+   Sub-phase 3b-iv.2.1 (this) wires [rm] to the real
+   [Process_eio.run_argv_with_status] spawn; the other three remain
+   placeholders pending 3b-iv.2.{2,3,4}.
+
+   The signature is unchanged across sub-phases — callers see a
+   typed [(_, sandbox_error) result] regardless of which function
+   bodies are real yet. *)
 
 let placeholder = Error Docker_client.Cleanup_failed
+
+(* ── Exit-status mapping ─────────────────────────────────────── *)
+
+(* Docker CLI exit code semantics for [docker rm]:
+     0   — container removed successfully
+     1   — container not found, or removal blocked (generic failure)
+     125 — daemon error / docker CLI itself errored
+   We map 0 → Ok, any other WEXITED → Cleanup_failed, and signal /
+   stopped statuses → Daemon_unreachable. *)
+let map_exit_status_for_rm (status : Unix.process_status) =
+  match status with
+  | Unix.WEXITED 0 -> Ok ()
+  | Unix.WEXITED _ -> Error Docker_client.Cleanup_failed
+  | Unix.WSIGNALED _ | Unix.WSTOPPED _ -> Error Docker_client.Daemon_unreachable
+
+(* ── Functions ───────────────────────────────────────────────── *)
 
 let run (_ : Keeper_sandbox_plan.t) = placeholder
 let exec ~container:_ ~cmd:_ = placeholder
 let ps_query ~labels:_ = placeholder
-let rm (_ : Keeper_container_name.t) = Error Docker_client.Cleanup_failed
+
+let rm container =
+  let argv =
+    [ "docker"; "rm"; "-f"; Keeper_container_name.to_string container ]
+  in
+  match Process_eio.run_argv_with_status argv with
+  | status, _stdout -> map_exit_status_for_rm status
+  | exception Unix.Unix_error _ -> Error Docker_client.Daemon_unreachable

--- a/lib/keeper/docker_client_real.mli
+++ b/lib/keeper/docker_client_real.mli
@@ -1,21 +1,21 @@
-(** RFC-0070 Phase 3b-iv.2.0 — Real {!Docker_client.S} (skeleton).
+(** RFC-0070 Phase 3b-iv.2.1 — Real {!Docker_client.S} ([rm] wired).
 
     Phase 3a's stub kept [Docker_client.S] as a *signature only*.
-    Phase 3b-iv.1b added [Docker_client_mock] for tests. Phase
-    3b-iv.2.0 adds the *production* implementation skeleton, satisfying
-    [S] so callers parameterising on [(module Docker_client.S)] can
-    swap it in alongside the mock at compile time.
+    Phase 3b-iv.1b added [Docker_client_mock] for tests. Phase 3b-iv.2.0
+    added the *production* skeleton (placeholders). Phase 3b-iv.2.1
+    (this) wires [rm] to [Process_eio.run_argv_with_status]; [exec],
+    [run], [ps_query] remain placeholders pending 3b-iv.2.{2,3,4}.
 
     Reference: docs/rfc/RFC-0070-keeper-sandbox-pure-edge-separation.md §3.2
 
-    Phase 3b-iv.2 skeleton scope: every function in [S] is implemented
-    but returns [Error Cleanup_failed] — a typed placeholder that
-    *cannot* silently succeed. Phase 3b-iv.2.1 wires [rm] to
-    [Process_eio.run_argv_with_status]; subsequent sub-phases wire
-    [exec], [run], [ps_query] in their own PRs. Each sub-phase replaces
-    the placeholder with a real spawn while preserving the typed
-    [sandbox_error] surface — no caller code changes between
-    sub-phases.
+    Implementation status per function:
+    - [rm] — wired: spawns [docker rm -f <name>]; maps exit code →
+      typed [sandbox_error] (0 → Ok, non-zero → Cleanup_failed, signal
+      or Unix_error → Daemon_unreachable). No exception leak.
+    - [exec], [run], [ps_query] — still [Error Cleanup_failed]
+      placeholder pending 3b-iv.2.{2,3,4}. Each sub-phase replaces one
+      body without changing the public surface — callers wiring Real
+      today pick up real behaviour as each lands.
 
     **Why a placeholder skeleton and not [failwith]**: returning
     [Error Cleanup_failed] keeps the signature in {!result}; a caller

--- a/lib/keeper/docker_client_real.mli
+++ b/lib/keeper/docker_client_real.mli
@@ -9,9 +9,18 @@
     Reference: docs/rfc/RFC-0070-keeper-sandbox-pure-edge-separation.md §3.2
 
     Implementation status per function:
-    - [rm] — wired: spawns [docker rm -f <name>]; maps exit code →
-      typed [sandbox_error] (0 → Ok, non-zero → Cleanup_failed, signal
-      or Unix_error → Daemon_unreachable). No exception leak.
+    - [rm] — wired: spawns [docker rm -f <name>] via
+      [Process_eio.run_argv_with_status]. Exit-status mapping:
+      {ul
+        {- [WEXITED 0] → [Ok ()]}
+        {- [WEXITED 127] (spawn failure: docker CLI missing or exec
+           error) → [Error Daemon_unreachable]}
+        {- any other [WEXITED n] → [Error Cleanup_failed]}
+        {- [WSIGNALED _] / [WSTOPPED _] → [Error Daemon_unreachable]}}
+      No [Unix.Unix_error] leak (Process_eio internalises spawn errors
+      to [WEXITED 127]). [Eio.Cancel.Cancelled] still propagates to the
+      caller by design — RFC-0070 requires cancellation to remain
+      observable rather than being absorbed into a typed error.
     - [exec], [run], [ps_query] — still [Error Cleanup_failed]
       placeholder pending 3b-iv.2.{2,3,4}. Each sub-phase replaces one
       body without changing the public surface — callers wiring Real

--- a/test/test_docker_client_real.ml
+++ b/test/test_docker_client_real.ml
@@ -31,12 +31,22 @@ let sample_plan () =
   | Ok p -> p
   | Error _ -> failwith "test fixture"
 
+(* Container-name derivation is deterministic in [(turn_id, attempt,
+   suffix)], so a literal suffix like ["alice"] could collide with a
+   real keeper-derived container on a developer machine and have the
+   subsequent [docker rm -f] silently destroy it. Inject PID + a
+   nonce into the suffix so the derived SHA-256 is effectively unique
+   per test invocation. *)
+let () = Random.self_init ()
+
 let sample_container () =
+  let pid = Unix.getpid () in
+  let nonce = Random.bits () in
   Keeper_container_name.derive
     ~algo:Keeper_hash_algo.SHA_256
     ~turn_id:1
     ~attempt:0
-    ~suffix:"alice"
+    ~suffix:(Printf.sprintf "test-pid%d-%d" pid nonce)
 
 (* ── Each S function returns the typed placeholder ──────────── *)
 

--- a/test/test_docker_client_real.ml
+++ b/test/test_docker_client_real.ml
@@ -57,10 +57,20 @@ let test_ps_query_placeholder () =
   | Error Docker_client.Cleanup_failed -> ()
   | _ -> fail "expected Cleanup_failed placeholder"
 
-let test_rm_placeholder () =
+(* Phase 3b-iv.2.1 — rm is no longer a placeholder; it spawns
+   [docker rm -f <name>]. The test environment may or may not have a
+   docker daemon, so we only assert that the *typed* error variants
+   are surfaced (no exception leakage, no silent success). *)
+let test_rm_returns_typed_error () =
   match Docker_client_real.rm (sample_container ()) with
-  | Error Docker_client.Cleanup_failed -> ()
-  | _ -> fail "expected Cleanup_failed placeholder"
+  | Error Docker_client.Daemon_unreachable
+  | Error Docker_client.Cleanup_failed -> ()  (* env-dependent path *)
+  | Ok () -> fail "unexpected Ok — derived container name should not exist on host"
+  | Error Docker_client.Image_pull_failed
+  | Error Docker_client.Container_oom
+  | Error Docker_client.Exec_timeout
+  | Error Docker_client.Probe_format_drift ->
+    fail "rm should only surface Daemon_unreachable or Cleanup_failed"
 
 (* ── Functor instantiation works with Real ───────────────────── *)
 
@@ -78,7 +88,9 @@ let () =
           test_case "run → Cleanup_failed" `Quick test_run_placeholder;
           test_case "exec → Cleanup_failed" `Quick test_exec_placeholder;
           test_case "ps_query → Cleanup_failed" `Quick test_ps_query_placeholder;
-          test_case "rm → Cleanup_failed" `Quick test_rm_placeholder;
+          test_case "rm → typed error (Daemon_unreachable | Cleanup_failed)"
+            `Quick
+            test_rm_returns_typed_error;
         ] );
       ( "Functor composition",
         [


### PR DESCRIPTION
## 목표 — RFC-0070 §3.2 Phase 3b-iv.2.1

**Real `rm` 실제 wire** — `docker rm -f <name>` argv → `Process_eio.run_argv_with_status` → typed `sandbox_error`. 3b-iv.2 series 첫 *real impl*.

## RFC 인용

| RFC | 관계 |
|-----|------|
| **RFC-0070** | §3.2 — Real Docker_client rm |
| RFC-0006 | cite-only |
| RFC-0036 | cite-only |

## Phase 3b-iv.2 진행

| Sub-phase | function | 상태 |
|-----------|----------|------|
| 3b-iv.2.0 | skeleton (4 placeholders) | ✅ #14838 |
| **3b-iv.2.1** | **rm wired** | 🟡 본 PR |
| 3b-iv.2.2 | exec wired | next |
| 3b-iv.2.3 | run wired | next |
| 3b-iv.2.4 | ps_query + JSON parse | next |

## Exit-status 매핑

```
WEXITED 0           → Ok ()                              (container removed)
WEXITED non-zero    → Error Cleanup_failed               (1=not-found / blocked, 125=daemon error)
WSIGNALED / WSTOPPED → Error Daemon_unreachable
exception Unix_error → Error Daemon_unreachable          (binary not in PATH 등)
```

## Typed catch, NOT catch-all (CLAUDE.md §AI 안티패턴 §4)

```ocaml
match Process_eio.run_argv_with_status argv with
| status, _stdout -> map_exit_status_for_rm status
| exception Unix.Unix_error _ -> Error Docker_client.Daemon_unreachable
```

→ **오직 `Unix.Unix_error`만 catch**. 다른 unknown exception은 *propagate*. RFC-0070 "no silent failure, no exception leak" 일관 유지.

## Test 업데이트

3b-iv.2.0 의 `rm → Cleanup_failed 정확 placeholder` test는 *real impl에 맞지 않음*. 재구성:

```ocaml
let test_rm_returns_typed_error () =
  match Docker_client_real.rm (sample_container ()) with
  | Error Daemon_unreachable
  | Error Cleanup_failed -> ()                (* 환경 의존 *)
  | Ok () -> fail "container shouldn't exist"
  | Error <other 4 variants> -> fail "rm should only surface ..."
```

→ *환경 무관*하게 *typed contract* 검증. docker 미존재 시 Daemon_unreachable, docker 있고 container 없으면 Cleanup_failed. 둘 다 valid + *기타 4 variants는 명시적 거부*.

## 변경

```
lib/keeper/docker_client_real.mli   ±15 (docstring 갱신, 3b-iv.2.0 → 3b-iv.2.1)
lib/keeper/docker_client_real.ml    +25 (exit_status_map 헬퍼 + rm 실제 impl)
test/test_docker_client_real.ml     ±15 (rm test 재구성)
```

## 검증

- **Isolated ocamlc**: Process_eio 기존 main에 있음, 새 의존 0
- **Typed contract**: test가 *환경 무관*하게 *invalid error variants* 거부
- **`dune build @check`** repo-wide: main 회귀 (#14745) 미해소 — 무관

## Workaround Rejection Bar self-check

| 시그니처 | 본 PR 해당? |
|---------|------------|
| Counter-as-fix | N/A |
| String 분류기 | N/A — exit code → typed |
| **N-of-M** | **acknowledged + 명시적 구분**: 3b-iv.2 series는 *4 function의 distinct impl* (공유 transform 없음). N-of-M anti-pattern은 *동일 transform이 N sites에 sprawled*이지만 본 series는 *각 function이 unique argv 조립 + status mapping*. 누적 typed signature가 *abstraction*. |
| Cap/cooldown/dedup/repair | N/A |
| Test backdoor | N/A |
| **Catch-all `_ ->`** | **명시적으로 회피** — `Unix.Unix_error _`만 catch. inline comment에 명시 |

## 미검증

- *실제 docker daemon + container present* 시 Ok () 받는 path — integration test (별도 track, docker compose 등 필요)
- Phase 3b-iv.2.2/.2.3/.2.4 — 후속 PRs

## 다음 PR

- **3b-iv.2.2**: Real `exec` — `docker exec <container> sh -lc <cmd>` 또는 argv 직접 (cmd 단어 분리)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
