### PR TITLE
perf(keeper_exec_board): precompile static regexps in quantitative_claim guard

### DIFF
--- a/lib/keeper/keeper_exec_board.ml
+++ b/lib/keeper/keeper_exec_board.ml
@@ -61,6 +61,23 @@ let re_matches pattern text =
     true
   with Not_found -> false
 
+(* Precompile the static patterns used by [content_has_risky_quantitative_claim]
+   so each board-post check reuses the same DFA instead of rebuilding it
+   from the literal pattern on every call.  [Str] keeps match-group state
+   global, but only [match_beginning]/[match_end] read it — here we only
+   take the boolean from [search_forward], so sharing the regex across
+   fibers is safe for our use. *)
+let re_line_ref_short = Str.regexp_case_fold "[Ll][0-9][0-9]*"
+let re_line_ref_file =
+  Str.regexp_case_fold "[A-Za-z0-9_./-]+\\.[A-Za-z0-9_]+:[0-9][0-9]*"
+let re_percent = Str.regexp_case_fold "[0-9][0-9]*%"
+
+let re_matches_compiled re text =
+  try
+    ignore (Str.search_forward re text 0);
+    true
+  with Not_found -> false
+
 let contains_substring haystack needle =
   let len_haystack = String.length haystack in
   let len_needle = String.length needle in
@@ -129,8 +146,8 @@ let contains_word lower word =
 
 let content_has_risky_quantitative_claim content =
   let has_line_ref =
-    re_matches "[Ll][0-9][0-9]*" content
-    || re_matches "[A-Za-z0-9_./-]+\\.[A-Za-z0-9_]+:[0-9][0-9]*" content
+    re_matches_compiled re_line_ref_short content
+    || re_matches_compiled re_line_ref_file content
   in
   let lower = String.lowercase_ascii content in
   let has_quantifier =
@@ -139,7 +156,7 @@ let content_has_risky_quantitative_claim content =
       [ "site"; "sites"; "hit"; "hits"; "line"; "lines"; "occurrence";
         "occurrences"; "pattern"; "patterns"; "instance"; "instances";
         "accuracy" ]
-    || re_matches "[0-9][0-9]*%" content
+    || re_matches_compiled re_percent content
     || content_has_standalone_count content
   in
   has_line_ref && has_quantifier

--- a/lib/keeper/keeper_exec_board.ml
+++ b/lib/keeper/keeper_exec_board.ml
@@ -63,10 +63,16 @@ let re_matches pattern text =
 
 (* Precompile the static patterns used by [content_has_risky_quantitative_claim]
    so each board-post check reuses the same DFA instead of rebuilding it
-   from the literal pattern on every call.  [Str] keeps match-group state
-   global, but only [match_beginning]/[match_end] read it — here we only
-   take the boolean from [search_forward], so sharing the regex across
-   fibers is safe for our use. *)
+   from the literal pattern on every call.
+   Concurrency note: [Str] mutates a process-global last-match state on
+   every [search_forward]/[string_match], and the entire [Str.matched_*]
+   family ([matched_group], [matched_string], [match_beginning],
+   [match_end], [group_beginning], [group_end]) reads it. Sharing a
+   compiled regexp across fibers/domains is safe, but no caller may rely
+   on [Str.matched_*] without external serialization — here we only
+   consume the boolean from [search_forward] and never inspect match
+   groups, so the global state is not observed. Migrate to [Re] if
+   match-group access is ever needed on this hot path. *)
 let re_line_ref_short = Str.regexp_case_fold "[Ll][0-9][0-9]*"
 let re_line_ref_file =
   Str.regexp_case_fold "[A-Za-z0-9_./-]+\\.[A-Za-z0-9_]+:[0-9][0-9]*"


### PR DESCRIPTION
## Summary
- `content_has_risky_quantitative_claim` runs on every `keeper_board_post` call.
- It calls `re_matches` with **three compile-time constant patterns**: `[Ll][0-9][0-9]*`, `[A-Za-z0-9_./-]+\.[A-Za-z0-9_]+:[0-9][0-9]*`, `[0-9][0-9]*%`.
- Each call rebuilds the regex AST + DFA via `Str.regexp_case_fold` from scratch.

This PR hoists the three patterns to module-level bindings (compiled once at module init) and routes the call sites through a new `re_matches_compiled` helper that reuses the shared DFA.

## Why this is safe
`Str` keeps match-group state (`match_beginning`/`match_end`) in module globals — sharing a compiled regex across fibers would be racy *if* that state were read. Here we only consume the boolean from `search_forward`, so the global state is never observed. The inline comment documents this so future contributors don't extend the pattern in a way that would break the invariant.

## Behaviour
No change. The original `re_matches` helper is preserved for any non-static (e.g. dynamic substring) callers, even though there are currently none.

## Test plan
- [x] `dune build lib/keeper/`
- [ ] CI green

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>