### PR TITLE
fix(supervisor): pair crash_msg with old_entry in to_mark_dead push — main broken

### DIFF
--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -1751,7 +1751,7 @@ let sweep_and_recover (ctx : _ context) =
               Keeper_metrics.metric_keeper_restart_outcomes
               ~labels:[ "keeper", old_entry.name; "outcome", "refused_budget_exhausted" ]
               ();
-            to_mark_dead := old_entry :: !to_mark_dead
+            to_mark_dead := (old_entry, crash_msg) :: !to_mark_dead
           | Ok reg ->
             Keeper_registry.restore_supervisor_state
               ~base_path


### PR DESCRIPTION
## Why (urgent — main does not build)

origin/main HEAD `9fc2516fe` fails `dune build @lib/check --root .`:

\`\`\`
File \"lib/keeper/keeper_supervisor.ml\", line 1754, characters 28-37:
1754 |             to_mark_dead := old_entry :: !to_mark_dead
                                   ^^^^^^^^^
Error: The value old_entry has type Keeper_registry.registry_entry
       but an expression was expected of type
         Keeper_registry.registry_entry * string
\`\`\`

`to_mark_dead` is `(registry_entry * string) ref`:
- Decl at L1426: `let to_mark_dead = ref [] in`
- Other writer at L1469: `to_mark_dead := (entry, msg) :: !to_mark_dead`
- Consumer at L1640: `fun ((entry : Keeper_registry.registry_entry), msg) -> ...`

PR #14765 (`R-A-6.a — register_restarting refuses revival of budget-exhausted keeper`, commit `6930636fe`) added a second writer at L1754 but used the pre-tuple shape (just `old_entry`). The type-system caught it, but somehow it landed on main.

## Fix

One character: pass `crash_msg` (in scope from the outer lambda `fun ((old_entry : ...), crash_msg) -> ...` at L1715) as the second tuple slot:

\`\`\`diff
- to_mark_dead := old_entry :: !to_mark_dead
+ to_mark_dead := (old_entry, crash_msg) :: !to_mark_dead
\`\`\`

`crash_msg` is the most descriptive string at this site — the consumer at L1640 uses `msg` for the `Cascade_events.publish_keeper_dead ~reason:msg` and the structured Log.Keeper.error line, which is exactly the original crash that triggered the restart attempt the supervisor just refused.

## How this slipped past CI

PR #14765's CI must have masked the error. Possible causes:
1. Different build target (no `@lib/check`)
2. Stale cache
3. dune-local.sh lock contention timeout (see `feedback_masc_mcp_dune_local_lock_contention`)

Out of scope for this PR — the immediate priority is unblock main. Bisect / CI hardening is a follow-up.

## Verification

- `dune build @lib/check --root .` exit 0 (was erroring on origin/main)
- `git diff --stat`: 1 file, +1 −1
- No semantic surprise: the consumer's `msg` channel for the new entry will be the keeper's crash message — semantically aligned with the L1469 sibling site

## Cross-check

Per iter #23 in-flight PR sweep protocol:
- `gh pr view 14758 --json files` — touches keeper_supervisor.ml but **does not modify line 1754** (test-only diff in the to_mark_dead area)
- `gh pr view 14718 --json files` — touches keeper_supervisor.ml, but `gh pr diff 14718 | rg to_mark_dead` returns nothing
- Other 4 open PRs do not touch the file

Safe to merge without conflict.

## Priority

This is a main-blocker. Anyone running `dune build @lib/check --root .` on a fresh checkout fails. Recommend admin-merge ASAP.