### PR TITLE
fix(eval_calibration): make false-positive tuple-match exhaustive over (verdict × label_verdict)

### DIFF
--- a/lib/eval_calibration.ml
+++ b/lib/eval_calibration.ml
@@ -303,7 +303,9 @@ let select_examples ~(max_examples : int) : calibration_example list =
   let false_positives, others = List.partition (fun d ->
     match d.evaluator_verdict, d.human_verdict with
     | Anti_rationalization.Approve, Reject_label -> true
-    | _ -> false
+    | Anti_rationalization.Approve, Approve_label -> false
+    | Anti_rationalization.Reject _, Reject_label -> false
+    | Anti_rationalization.Reject _, Approve_label -> false
   ) divs in
   let sorted = false_positives @ others in
   let limited =


### PR DESCRIPTION
## Why

`select_examples` (lib/eval_calibration.ml:300-307) classifies divergences via a 2-axis tuple match with `_ -> false` catch-all:

\`\`\`ocaml
match d.evaluator_verdict, d.human_verdict with
| Anti_rationalization.Approve, Reject_label -> true
| _ -> false
\`\`\`

- `evaluator_verdict` = `Anti_rationalization.verdict` = `Approve | Reject of string` (anti_rationalization.ml:27-29)
- `human_verdict` = `label_verdict` = `Approve_label | Reject_label` (eval_calibration.ml:20-22)

Cross-product is 4 quadrants. Three are absorbed silently by `_ -> false`. A future variant addition (e.g., `Defer | Abstain` on either side) gets the same silent default, but the semantics might differ — a deferring evaluator paired with a rejecting human is arguably *more* false-positive-like than an approving evaluator + approving human.

## Fix

Enumerate all 4 quadrants explicitly:

\`\`\`ocaml
| Anti_rationalization.Approve, Reject_label -> true
| Anti_rationalization.Approve, Approve_label -> false
| Anti_rationalization.Reject _, Reject_label -> false
| Anti_rationalization.Reject _, Approve_label -> false
\`\`\`

Truth table identical to the prior catch-all under the current 2×2 type. After this PR, any new variant on either axis forces an explicit per-quadrant decision at compile time.

## ⚠️ Blocked by #14846

origin/main currently fails `dune build @lib/check --root .` due to a type error in `keeper_supervisor.ml:1754` (unrelated to this PR). #14846 unblocks main with a 1-character tuple-pairing fix. **Wait for #14846 to merge before reviewing CI on this PR.**

## Cross-check

Per iter #23 sweep protocol:
- 5 open PRs (#14841/#14837/#14835/#14758/#14718/#14826) — none touch `lib/eval_calibration.ml` or `lib/anti_rationalization.ml` (verified via `gh pr view <PR> --json files`)
- Safe to merge in any order vs other open PRs once #14846 is in

## Verification

- `git diff --stat`: 1 file, +3 −1
- Behavior preserved (truth-table identical)
- No `.mli` change (function not exported as far as the match was concerned — keeps internal)