### PR TITLE
fix(tool_name): make is_keeper / is_masc / is_masc_keeper exhaustive

### DIFF
--- a/lib/tool_name.ml
+++ b/lib/tool_name.ml
@@ -652,19 +652,29 @@ let of_string s =
 
 let pp fmt t = Format.pp_print_string fmt (to_string t)
 
+(* Enumerate every [t] constructor in each sibling predicate so the
+   compiler flags any new variant added to [t]. If a future variant
+   (say [External of ...]) joins the sum, the previous [_ -> false]
+   catch-alls would silently classify it as not-keeper / not-masc /
+   not-masc_keeper without any review point; with explicit
+   enumeration the new variant must be deliberately mapped on each
+   predicate. Mirrors the [is_board] convention below and the fix
+   shape in PR #14842 (Resilience_outcome predicates). Same FSM
+   Sparse Match anti-pattern as PRs #14716, #14790, #14806, #14810,
+   #14816, #14823, #14829. *)
 let is_keeper = function
   | Keeper _ -> true
-  | _ -> false
+  | Masc _ | Masc_keeper _ -> false
 ;;
 
 let is_masc = function
   | Masc _ -> true
-  | _ -> false
+  | Keeper _ | Masc_keeper _ -> false
 ;;
 
 let is_masc_keeper = function
   | Masc_keeper _ -> true
-  | _ -> false
+  | Keeper _ | Masc _ -> false
 ;;
 
 let is_board = function


### PR DESCRIPTION
## Why

`Tool_name.t` is a 3-variant closed sum:

```ocaml
type t =
  | Keeper of Keeper.t
  | Masc of Masc.t
  | Masc_keeper of Masc_keeper.t
```

Three sibling `is_*` predicates each used a `_ -> false` catch-all (lines 655-668):

```ocaml
let is_keeper = function | Keeper _ -> true | _ -> false
let is_masc = function | Masc _ -> true | _ -> false
let is_masc_keeper = function | Masc_keeper _ -> true | _ -> false
```

If a future variant joins the sum, all three predicates would silently classify it as `not-keeper / not-masc / not-masc_keeper` without any review point on whether the new variant should belong to one of these categories.

Sibling `is_board` (line 670-674) and `to_string` (line 635-638) in the same file already enumerate all 3 variants explicitly — the predicates were the odd ones out. Same fix shape as PR #14842 (`Resilience_outcome` is_full / is_partial / is_graceful). Same FSM Sparse Match anti-pattern as PRs #14716, #14790, #14806, #14810, #14816, #14823, #14829, #14842.

## What

Replace `_ -> false` with explicit sibling enumeration:

```ocaml
let is_keeper = function
  | Keeper _ -> true
  | Masc _ | Masc_keeper _ -> false

let is_masc = function
  | Masc _ -> true
  | Keeper _ | Masc_keeper _ -> false

let is_masc_keeper = function
  | Masc_keeper _ -> true
  | Keeper _ | Masc _ -> false
```

Adding a new constructor to `Tool_name.t` now triggers `Warning 8: pattern-matching is not exhaustive` at each of the 3 predicates, forcing the maintainer to deliberately decide its classification.

A short comment explains the convention and points to the precedent `is_board` form so a future reader doesn't reintroduce the catch-all.

Behavior unchanged for current 3 variants.

## Self-check (CLAUDE.md Workaround Rejection Bar)

| # | Check | Result |
|---|---|---|
| 1 | telemetry-as-fix? | no — removes catch-all |
| 2 | string classifier? | no |
| 3 | N-of-M? | **yes** — 3 sibling predicates in same file folded into one PR |
| 4 | catch-all added? | no — all 3 `_ ->` removed |
| 5 | cap/cooldown/dedup? | no |
| 6 | test backdoor? | no |
| 7 | typo N sites? | no — codemod-equivalent across 3 siblings |

🤖 Generated with [Claude Code](https://claude.com/claude-code)