### PR TITLE
feat(telemetry): 4 single-variant *_site sums for keeper_unified_turn (4 sites)

### DIFF
--- a/lib/keeper/event_bus_drain_site.ml
+++ b/lib/keeper/event_bus_drain_site.ml
@@ -1,0 +1,5 @@
+type t = Background_poll
+
+let to_label = function
+  | Background_poll -> "background_poll"
+;;

--- a/lib/keeper/event_bus_drain_site.mli
+++ b/lib/keeper/event_bus_drain_site.mli
@@ -1,0 +1,9 @@
+(** Event_bus_drain_site — closed sum for [site] label on
+    [metric_keeper_event_bus_drain].  Currently a single-variant sum
+    capturing the only emit site in keeper_unified_turn.ml; closing
+    the type here so a future emit-site addition surfaces at compile
+    time. *)
+
+type t = Background_poll
+
+val to_label : t -> string

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -866,7 +866,7 @@ let run_keeper_cycle
                              (Printexc.to_string exn);
                            Prometheus.inc_counter
                              Keeper_metrics.metric_keeper_event_bus_drain
-                             ~labels:[ "site", "background_poll"; "outcome", "exception" ]
+                             ~labels:[ "site", Event_bus_drain_site.(to_label Background_poll); "outcome", "exception" ]
                              ();
                            (* 2026-04-20: 0.25s → 0.05s.  OAS publishes a burst
                      of events per tool cycle (ToolCalled / ToolResult /
@@ -1437,7 +1437,7 @@ let run_keeper_cycle
                                  Keeper_metrics.metric_keeper_post_turn_wirein_failures
                                  ~labels:
                                    [ "keeper", meta.name
-                                   ; "site", "post_commit_transient"
+                                   ; "site", Post_turn_wirein_failure_site.(to_label Post_commit_transient)
                                    ]
                                  ();
                                Log.Keeper.error
@@ -2672,7 +2672,7 @@ let run_keeper_cycle
                        ~labels:
                          [ "keeper", updated_meta.Keeper_types.name
                          ; "channel", channel
-                         ; "site", "keeper_unified_turn"
+                         ; "site", Metric_emit_dropped_site.(to_label Keeper_unified_turn)
                          ]
                        ();
                      Log.Keeper.error
@@ -2680,7 +2680,7 @@ let run_keeper_cycle
                        (Printexc.to_string exn);
                      Prometheus.inc_counter
                        Keeper_metrics.metric_keeper_turn_metrics_snapshot_failures
-                       ~labels:[ "keeper", meta.name; "site", "post_cycle" ]
+                       ~labels:[ "keeper", meta.name; "site", Turn_metrics_snapshot_failure_site.(to_label Post_cycle) ]
                        ());
                   let turn_mode = Keeper_unified_metrics.turn_mode_of_result result in
                   let turn_mode_label =

--- a/lib/keeper/metric_emit_dropped_site.ml
+++ b/lib/keeper/metric_emit_dropped_site.ml
@@ -1,0 +1,5 @@
+type t = Keeper_unified_turn
+
+let to_label = function
+  | Keeper_unified_turn -> "keeper_unified_turn"
+;;

--- a/lib/keeper/metric_emit_dropped_site.mli
+++ b/lib/keeper/metric_emit_dropped_site.mli
@@ -1,0 +1,6 @@
+(** Metric_emit_dropped_site — closed sum for [site] label on
+    [metric_keeper_metric_emit_dropped]. *)
+
+type t = Keeper_unified_turn
+
+val to_label : t -> string

--- a/lib/keeper/post_turn_wirein_failure_site.ml
+++ b/lib/keeper/post_turn_wirein_failure_site.ml
@@ -1,0 +1,5 @@
+type t = Post_commit_transient
+
+let to_label = function
+  | Post_commit_transient -> "post_commit_transient"
+;;

--- a/lib/keeper/post_turn_wirein_failure_site.mli
+++ b/lib/keeper/post_turn_wirein_failure_site.mli
@@ -1,0 +1,6 @@
+(** Post_turn_wirein_failure_site — closed sum for [site] label on
+    [metric_keeper_post_turn_wirein_failures]. *)
+
+type t = Post_commit_transient
+
+val to_label : t -> string

--- a/lib/keeper/turn_metrics_snapshot_failure_site.ml
+++ b/lib/keeper/turn_metrics_snapshot_failure_site.ml
@@ -1,0 +1,5 @@
+type t = Post_cycle
+
+let to_label = function
+  | Post_cycle -> "post_cycle"
+;;

--- a/lib/keeper/turn_metrics_snapshot_failure_site.mli
+++ b/lib/keeper/turn_metrics_snapshot_failure_site.mli
@@ -1,0 +1,6 @@
+(** Turn_metrics_snapshot_failure_site — closed sum for [site] label on
+    [metric_keeper_turn_metrics_snapshot_failures]. *)
+
+type t = Post_cycle
+
+val to_label : t -> string


### PR DESCRIPTION
## Summary

Closes the four remaining hardcoded `site` label strings in
`keeper_unified_turn.ml` — each a single-emit-site metric whose label
is technically a closed set of one.  Typing them at this stage so a
future second emit-site addition surfaces at compile time at the
`to_label` witness.

## Sites (4)

| Metric | Site | Variant |
|--------|------|---------|
| `metric_keeper_event_bus_drain` | `keeper_unified_turn.ml:869` | `Event_bus_drain_site.Background_poll` |
| `metric_keeper_post_turn_wirein_failures` | `keeper_unified_turn.ml:1440` | `Post_turn_wirein_failure_site.Post_commit_transient` |
| `metric_keeper_metric_emit_dropped` | `keeper_unified_turn.ml:2675` | `Metric_emit_dropped_site.Keeper_unified_turn` |
| `metric_keeper_turn_metrics_snapshot_failures` | `keeper_unified_turn.ml:2683` | `Turn_metrics_snapshot_failure_site.Post_cycle` |

## Why

Sweep tail.  Each metric currently has a single emit site, so the
typed-variant ROI is small *today* — but the file-level grep audit
keeps catching these as "raw label strings" and each requires the
same think-through to decide whether they're closed or open.  Typing
them removes the false-positive surface and makes a future second
emit site surface at the `to_label` witness rather than as a silent
new label value.

Wire format byte-equal.

## Test plan

- [ ] CI green
- [ ] `rg '"site", "(background_poll|post_commit_transient|keeper_unified_turn|post_cycle)"' lib/keeper/keeper_unified_turn.ml` = 0

RFC-WAIVED: not in credential/identity/operator/sandbox/hooks/workflow scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)