### PR TITLE
fix(chronicle_types): make is_active / is_completed exhaustive over epoch_status

### DIFF
--- a/lib/chronicle_types.ml
+++ b/lib/chronicle_types.ml
@@ -57,10 +57,10 @@ let epoch_id ~year ~label =
   Printf.sprintf "%s-%s" year label
 
 let is_active (epoch : chronicle_epoch) =
-  match epoch.status with Active -> true | _ -> false
+  match epoch.status with Active -> true | Completed | Abandoned -> false
 
 let is_completed (epoch : chronicle_epoch) =
-  match epoch.status with Completed -> true | _ -> false
+  match epoch.status with Completed -> true | Active | Abandoned -> false
 
 let lesson_counts (epoch : chronicle_epoch) =
   let pos = ref 0 and neg = ref 0 and mix = ref 0 in


### PR DESCRIPTION
## Why

`epoch_status` is a 3-variant closed sum (`Active | Completed | Abandoned`, lib/chronicle_types.ml:24-28). Two predicate accessors use `| _ -> false` catch-alls:

\`\`\`ocaml
let is_active e    = match e.status with Active -> true    | _ -> false
let is_completed e = match e.status with Completed -> true | _ -> false
\`\`\`

The same module's `lesson_counts` (L65-73) already does exhaustive enumeration over `outcome_kind = Positive | Negative | Mixed`. The catch-all predicates were inconsistent with the module's own pattern.

## Fix

Replace catch-all with explicit sibling enumeration:

\`\`\`ocaml
let is_active e    = match e.status with Active -> true    | Completed | Abandoned -> false
let is_completed e = match e.status with Completed -> true | Active | Abandoned -> false
\`\`\`

Truth tables identical to prior catch-all under the current 3-variant type. After this PR, OCaml warning 8 forces a per-predicate decision on any future variant addition (e.g., a hypothetical `Paused` or `Aborted`).

## Symmetry note (out of scope)

`is_abandoned` is missing for symmetry. Adding it now would expand API surface without a current caller — left as a follow-up if a consumer materializes.

## Cross-check

Per iter #23 sweep protocol:
- 5 open PRs (#14844/#14845/#14849/#14850/#14851) — none touch `lib/chronicle_types.ml`
- Verified via `gh pr view <PR> --json files`

## Verification

- `dune build @lib/check --root .` exit 0 (main is buildable again after #14846 merged)
- `git diff --stat`: 1 file, +2 −2