### PR TITLE
fix(telemetry_eio): close 9 catch-all sites over closed-sum event type

### DIFF
--- a/lib/telemetry_eio.ml
+++ b/lib/telemetry_eio.ml
@@ -307,12 +307,14 @@ let count_active_agents events =
   let joined = List.filter_map (fun r ->
     match r.event with
     | Agent_joined { agent_id; _ } -> Some agent_id
-    | _ -> None
+    | Agent_left _ | Task_started _ | Task_completed _ | Handoff_triggered _
+    | Error_occurred _ | Tool_called _ | Tool_assigned _ -> None
   ) events in
   let left = List.filter_map (fun r ->
     match r.event with
     | Agent_left { agent_id; _ } -> Some agent_id
-    | _ -> None
+    | Agent_joined _ | Task_started _ | Task_completed _ | Handoff_triggered _
+    | Error_occurred _ | Tool_called _ | Tool_assigned _ -> None
   ) events in
   let active = List.filter (fun id -> not (List.mem id left)) joined in
   List.length (List.sort_uniq String.compare active)
@@ -321,12 +323,14 @@ let count_tasks_in_progress events =
   let started = List.filter_map (fun r ->
     match r.event with
     | Task_started { task_id; _ } -> Some task_id
-    | _ -> None
+    | Agent_joined _ | Agent_left _ | Task_completed _ | Handoff_triggered _
+    | Error_occurred _ | Tool_called _ | Tool_assigned _ -> None
   ) events in
   let completed = List.filter_map (fun r ->
     match r.event with
     | Task_completed { task_id; _ } -> Some task_id
-    | _ -> None
+    | Agent_joined _ | Agent_left _ | Task_started _ | Handoff_triggered _
+    | Error_occurred _ | Tool_called _ | Tool_assigned _ -> None
   ) events in
   let in_progress = List.filter (fun id -> not (List.mem id completed)) started in
   List.length (List.sort_uniq String.compare in_progress)
@@ -335,14 +339,16 @@ let count_completed_tasks events =
   List_util.count_if (fun r ->
     match r.event with
     | Task_completed _ -> true
-    | _ -> false
+    | Agent_joined _ | Agent_left _ | Task_started _ | Handoff_triggered _
+    | Error_occurred _ | Tool_called _ | Tool_assigned _ -> false
   ) events
 
 let avg_duration events =
   let durations = List.filter_map (fun r ->
     match r.event with
     | Task_completed { duration_ms; _ } -> Some (float_of_int duration_ms)
-    | _ -> None
+    | Agent_joined _ | Agent_left _ | Task_started _ | Handoff_triggered _
+    | Error_occurred _ | Tool_called _ | Tool_assigned _ -> None
   ) events in
   match durations with
   | [] -> 0.0
@@ -354,12 +360,14 @@ let calculate_handoff_rate events =
   let handoffs = List_util.count_if (fun r ->
     match r.event with
     | Handoff_triggered _ -> true
-    | _ -> false
+    | Agent_joined _ | Agent_left _ | Task_started _ | Task_completed _
+    | Error_occurred _ | Tool_called _ | Tool_assigned _ -> false
   ) events in
   let task_events = List_util.count_if (fun r ->
     match r.event with
     | Task_started _ | Task_completed _ -> true
-    | _ -> false
+    | Agent_joined _ | Agent_left _ | Handoff_triggered _ | Error_occurred _
+    | Tool_called _ | Tool_assigned _ -> false
   ) events in
   if task_events = 0 then 0.0
   else float_of_int handoffs /. float_of_int task_events
@@ -368,7 +376,8 @@ let calculate_error_rate events =
   let errors = List_util.count_if (fun r ->
     match r.event with
     | Error_occurred _ -> true
-    | _ -> false
+    | Agent_joined _ | Agent_left _ | Task_started _ | Task_completed _
+    | Handoff_triggered _ | Tool_called _ | Tool_assigned _ -> false
   ) events in
   let total = List.length events in
   if total = 0 then 0.0


### PR DESCRIPTION
## Why

`event` is an 8-variant closed sum (lib/telemetry_eio.ml:27-67):

\`\`\`ocaml
type event =
  | Agent_joined of { ... }
  | Agent_left of { ... }
  | Task_started of { ... }
  | Task_completed of { ... }
  | Handoff_triggered of { ... }
  | Error_occurred of { ... }
  | Tool_called of { ... }
  | Tool_assigned of { ... }
\`\`\`

The module's own dispatch logic (L225-230, L271-278) is already exhaustive. But 9 predicate-style filters in the metrics-calculation section used `_ -> None` / `_ -> false` catch-alls — the module was internally inconsistent.

## Sites

| Line | Function | Predicate |
|------|----------|-----------|
| 307-311 | `count_active_agents` | `Agent_joined → Some id` |
| 312-316 | `count_active_agents` | `Agent_left → Some id` |
| 321-325 | `count_tasks_in_progress` | `Task_started → Some id` |
| 326-330 | `count_tasks_in_progress` | `Task_completed → Some id` |
| 334-339 | `count_completed_tasks` | `Task_completed → true` |
| 341-346 | `avg_duration` | `Task_completed → Some duration` |
| 353-358 | `calculate_handoff_rate` | `Handoff_triggered → true` |
| 359-363 | `calculate_handoff_rate` | `Task_started \| Task_completed → true` |
| 367-372 | `calculate_error_rate` | `Error_occurred → true` |

## Fix

Each catch-all replaced with explicit enumeration of the 7 sibling constructors (or 6 for the two-arm `Task_started|Task_completed` case). Example:

\`\`\`ocaml
- | Task_completed _ -> true
- | _ -> false
+ | Task_completed _ -> true
+ | Agent_joined _ | Agent_left _ | Task_started _ | Handoff_triggered _
+ | Error_occurred _ | Tool_called _ | Tool_assigned _ -> false
\`\`\`

Truth tables identical to prior catch-all under the current 8-variant type. After this PR, OCaml warning 8 forces per-predicate decision on any future variant addition.

## Cross-check

Per iter #23 sweep protocol:
- 6 open PRs (#14844/#14845/#14849/#14850/#14851/#14852) — none touch `lib/telemetry_eio.ml`
- Verified via `gh pr view <PR> --json files`

## Verification

- `dune build @lib/check --root .` exit 0
- `git diff --stat`: 1 file, +18 −9