### PR TITLE
feat(rfc-0070): Phase 3b-iv.2.2 — Real Docker_client.exec wired via Process_eio

### DIFF
--- a/lib/keeper/docker_client_real.ml
+++ b/lib/keeper/docker_client_real.ml
@@ -1,17 +1,17 @@
-(* RFC-0070 Phase 3b-iv.2.1 — Real Docker_client (rm wired).
+(* RFC-0070 Phase 3b-iv.2.2 — Real Docker_client (rm + exec wired).
 
    Sub-phase 3b-iv.2.0 shipped placeholders for all four S functions.
-   Sub-phase 3b-iv.2.1 (this) wires [rm] to the real
-   [Process_eio.run_argv_with_status] spawn; the other three remain
-   placeholders pending 3b-iv.2.{2,3,4}.
+   Sub-phase 3b-iv.2.1 wired [rm] (#14844). Sub-phase 3b-iv.2.2 (this)
+   wires [exec]; [run] and [ps_query] remain placeholders pending
+   3b-iv.2.{3,4}.
 
-   The signature is unchanged across sub-phases — callers see a
-   typed [(_, sandbox_error) result] regardless of which function
-   bodies are real yet. *)
+   The signature is unchanged across sub-phases — callers see a typed
+   [(_, sandbox_error) result] regardless of which function bodies are
+   real yet. *)
 
 let placeholder = Error Docker_client.Cleanup_failed
 
-(* ── Exit-status mapping ─────────────────────────────────────── *)
+(* ── Exit-status mapping helpers ─────────────────────────────── *)
 
 (* Docker CLI exit code semantics for [docker rm]:
      0   — container removed successfully
@@ -20,9 +20,7 @@ let placeholder = Error Docker_client.Cleanup_failed
      127 — synthesized by [Process_eio.run_argv_with_status] when the
            CLI binary cannot be spawned (missing executable / exec
            error). Functionally identical to "daemon unreachable" from
-           the caller's POV.
-   Mapping: 0 → Ok, 127 → Daemon_unreachable, any other WEXITED →
-   Cleanup_failed, and signal / stopped statuses → Daemon_unreachable. *)
+           the caller's POV. *)
 let map_exit_status_for_rm (status : Unix.process_status) =
   match status with
   | Unix.WEXITED 0 -> Ok ()
@@ -30,24 +28,54 @@ let map_exit_status_for_rm (status : Unix.process_status) =
   | Unix.WEXITED _ -> Error Docker_client.Cleanup_failed
   | Unix.WSIGNALED _ | Unix.WSTOPPED _ -> Error Docker_client.Daemon_unreachable
 
+(* Docker CLI exit code semantics for [docker exec]:
+     0       — command ran in container, exited zero
+     non-zero (general) — command ran in container, exited non-zero;
+                         this is a *response*, not a daemon error
+     125     — daemon error (couldn't run docker exec itself)
+     126     — command found in container but not executable
+     127     — synthesized by [Process_eio.run_argv_with_status_split]
+               for missing docker CLI; functionally Daemon_unreachable.
+
+   exec's semantic distinction vs rm: a non-zero exit inside the
+   container is the *command's* result, returned as
+   [Ok exec_result { exit_code = non-zero; ... }]. Only daemon-level
+   failures (125, 127, signal) surface as [Error Daemon_unreachable]. *)
+let map_status_for_exec
+    ((status, stdout, stderr) :
+      Unix.process_status * string * string)
+  =
+  match status with
+  | Unix.WEXITED 125 | Unix.WEXITED 127 ->
+    Error Docker_client.Daemon_unreachable
+  | Unix.WEXITED code ->
+    Ok Docker_response.{ exit_code = code; stdout; stderr }
+  | Unix.WSIGNALED _ | Unix.WSTOPPED _ ->
+    Error Docker_client.Daemon_unreachable
+
 (* ── Functions ───────────────────────────────────────────────── *)
 
 let run (_ : Keeper_sandbox_plan.t) = placeholder
-let exec ~container:_ ~cmd:_ = placeholder
 let ps_query ~labels:_ = placeholder
+
+let exec ~container ~cmd =
+  let argv =
+    [ "docker"
+    ; "exec"
+    ; Keeper_container_name.to_string container
+    ; "sh"
+    ; "-lc"
+    ; cmd
+    ]
+  in
+  (* [Process_eio.run_argv_with_status_split] returns
+     [(status, stdout, stderr)]; on spawn failure the status is
+     synthesized as [WEXITED 127] (see 3b-iv.2.1 commit on rm). *)
+  map_status_for_exec (Process_eio.run_argv_with_status_split argv)
 
 let rm container =
   let argv =
     [ "docker"; "rm"; "-f"; Keeper_container_name.to_string container ]
   in
-  (* [Process_eio.run_argv_with_status] swallows [Unix.Unix_error] from
-     spawn and surfaces it as [WEXITED 127] (see
-     [test/test_process_eio_coverage.ml]: "missing command exit code"
-     = 127), so the previous [exception Unix.Unix_error _] branch was
-     dead. The 127 mapping in [map_exit_status_for_rm] now picks up
-     missing-CLI / exec-failure as [Daemon_unreachable]. Eio-level
-     cancellation ([Eio.Cancel.Cancelled]) is still propagated to the
-     caller intentionally — RFC-0070 requires cancellation to remain
-     observable. *)
   let status, _stdout = Process_eio.run_argv_with_status argv in
   map_exit_status_for_rm status

--- a/lib/keeper/docker_client_real.mli
+++ b/lib/keeper/docker_client_real.mli
@@ -1,10 +1,10 @@
-(** RFC-0070 Phase 3b-iv.2.1 — Real {!Docker_client.S} ([rm] wired).
+(** RFC-0070 Phase 3b-iv.2.2 — Real {!Docker_client.S} ([rm] + [exec] wired).
 
-    Phase 3a's stub kept [Docker_client.S] as a *signature only*.
-    Phase 3b-iv.1b added [Docker_client_mock] for tests. Phase 3b-iv.2.0
-    added the *production* skeleton (placeholders). Phase 3b-iv.2.1
-    (this) wires [rm] to [Process_eio.run_argv_with_status]; [exec],
-    [run], [ps_query] remain placeholders pending 3b-iv.2.{2,3,4}.
+    Phase 3a's stub kept [Docker_client.S] as a *signature only*. Phase
+    3b-iv.1b added [Docker_client_mock] for tests. Phase 3b-iv.2.0
+    added the *production* skeleton. Phase 3b-iv.2.1 (#14844) wired
+    [rm]; Phase 3b-iv.2.2 (this) wires [exec]. [run] and [ps_query]
+    remain placeholders pending 3b-iv.2.{3,4}.
 
     Reference: docs/rfc/RFC-0070-keeper-sandbox-pure-edge-separation.md §3.2
 
@@ -21,10 +21,23 @@
       to [WEXITED 127]). [Eio.Cancel.Cancelled] still propagates to the
       caller by design — RFC-0070 requires cancellation to remain
       observable rather than being absorbed into a typed error.
-    - [exec], [run], [ps_query] — still [Error Cleanup_failed]
-      placeholder pending 3b-iv.2.{2,3,4}. Each sub-phase replaces one
-      body without changing the public surface — callers wiring Real
-      today pick up real behaviour as each lands.
+    - [exec] — wired: spawns
+      [docker exec <name> sh -lc <cmd>] via
+      [Process_eio.run_argv_with_status_split]. The semantic
+      distinction vs [rm] matters: a non-zero exit *inside the
+      container* is the *command's* result, returned as
+      [Ok exec_result { exit_code = n; stdout; stderr }] — not a
+      daemon error. Only daemon-level statuses become
+      [Error Daemon_unreachable]:
+      {ul
+        {- [WEXITED 125] (daemon error)}
+        {- [WEXITED 127] (docker CLI missing / spawn failure)}
+        {- [WSIGNALED _] / [WSTOPPED _]}}
+      All other [WEXITED n] values surface as
+      [Ok { exit_code = n; stdout; stderr }].
+    - [run], [ps_query] — still [Error Cleanup_failed] placeholder
+      pending 3b-iv.2.{3,4}. Each sub-phase replaces one body without
+      changing the public surface.
 
     **Why a placeholder skeleton and not [failwith]**: returning
     [Error Cleanup_failed] keeps the signature in {!result}; a caller

--- a/test/test_docker_client_real.ml
+++ b/test/test_docker_client_real.ml
@@ -55,12 +55,25 @@ let test_run_placeholder () =
   | Error Docker_client.Cleanup_failed -> ()
   | _ -> fail "expected Cleanup_failed placeholder"
 
-let test_exec_placeholder () =
+(* Phase 3b-iv.2.2 — exec is no longer a placeholder. It spawns
+   [docker exec <container> sh -lc <cmd>]. The test environment may
+   or may not have a docker daemon, so we only assert the *typed*
+   contract: either [Ok exec_result] (daemon present, command ran
+   inside container even if it failed) or [Error Daemon_unreachable]
+   (no daemon / CLI missing). Other [sandbox_error] variants are
+   semantically out of scope for [exec] and must NOT surface. *)
+let test_exec_returns_typed_result () =
   match
-    Docker_client_real.exec ~container:(sample_container ()) ~cmd:"ls"
+    Docker_client_real.exec ~container:(sample_container ()) ~cmd:"echo hi"
   with
-  | Error Docker_client.Cleanup_failed -> ()
-  | _ -> fail "expected Cleanup_failed placeholder"
+  | Ok _ -> ()                                    (* daemon present *)
+  | Error Docker_client.Daemon_unreachable -> ()  (* daemon / CLI missing *)
+  | Error Docker_client.Cleanup_failed
+  | Error Docker_client.Image_pull_failed
+  | Error Docker_client.Container_oom
+  | Error Docker_client.Exec_timeout
+  | Error Docker_client.Probe_format_drift ->
+    fail "exec should only surface Ok exec_result or Error Daemon_unreachable"
 
 let test_ps_query_placeholder () =
   match Docker_client_real.ps_query ~labels:[] with
@@ -96,7 +109,9 @@ let () =
       ( "S placeholder",
         [
           test_case "run → Cleanup_failed" `Quick test_run_placeholder;
-          test_case "exec → Cleanup_failed" `Quick test_exec_placeholder;
+          test_case "exec → Ok exec_result | Error Daemon_unreachable"
+            `Quick
+            test_exec_returns_typed_result;
           test_case "ps_query → Cleanup_failed" `Quick test_ps_query_placeholder;
           test_case "rm → typed error (Daemon_unreachable | Cleanup_failed)"
             `Quick


### PR DESCRIPTION
## 목표 — RFC-0070 §3.2 Phase 3b-iv.2.2

**Real `exec` 실제 wire** — `docker exec <container> sh -lc <cmd>` via Process_eio. 3b-iv.2 series 2번째 sub-phase impl.

## RFC 인용

| RFC | 관계 |
|-----|------|
| **RFC-0070** | §3.2 — Real Docker_client.exec |
| RFC-0006 | cite-only |
| RFC-0036 | cite-only |

## Phase 3b-iv.2 진행

| Sub-phase | function | 상태 |
|-----------|----------|------|
| 3b-iv.2.0 | skeleton (4 placeholders) | ✅ #14838 |
| 3b-iv.2.1 | rm wired | ✅ #14844 |
| **3b-iv.2.2** | **exec wired** | 🟡 본 PR |
| 3b-iv.2.3 | run wired | next |
| 3b-iv.2.4 | ps_query + JSON parse | next |

## Semantic 분리 (vs rm)

- **rm** non-zero exit = *removal failed* = **Error Cleanup_failed** (caller-perspective error)
- **exec** non-zero exit = *command exited n inside container* = **Ok exec_result { exit_code: n; ...}** (caller-perspective response)

Daemon-level statuses만 `Error Daemon_unreachable`:
- WEXITED 125 (daemon error)
- WEXITED 127 (CLI missing / spawn failure)
- WSIGNALED / WSTOPPED

→ container 안 명령이 *fail해도 Ok*. caller가 `exec_result.exit_code` 보고 처리. RFC §3.3 `exec_result vs ps_status` 의미적 분리 정확 일치.

## `sh -lc` wrapping

```
docker exec <name> sh -lc <cmd>
```

caller가 `cmd:string` 전달. shell 안 *parse + execute*. shell injection safety는 keeper 책임 (Plan record의 command field가 authoritative source).

## 변경

```
lib/keeper/docker_client_real.mli   ±25 (Phase 3b-iv.2.1 → 2.2, exec semantics)
lib/keeper/docker_client_real.ml    +30 (map_status_for_exec + exec impl)
test/test_docker_client_real.ml     ±15 (exec test 재구성)
```

## Test 갱신

```ocaml
let test_exec_returns_typed_result () =
  match Docker_client_real.exec ~container ~cmd:"echo hi" with
  | Ok _ -> ()                                    (* daemon present *)
  | Error Daemon_unreachable -> ()                (* daemon missing *)
  | Error <other 5 variants> -> fail "exec should only surface Ok or Daemon_unreachable"
```

→ 환경 무관, *typed contract* 검증.

## 검증

- Isolated ocamlc PASS (Process_eio.run_argv_with_status_split 기존 main에 있음)
- Typed contract test (5 invalid error variants 명시적 거부)
- `dune build @check` repo-wide: main 회귀 (#14745) 미해소

## Workaround Rejection Bar self-check

| 시그니처 | 본 PR 해당? |
|---------|------------|
| Counter-as-fix | N/A |
| String 분류기 | N/A — exit code → typed |
| **N-of-M** | **acknowledged**: 3b-iv.2 series 진행 중. 각 함수는 *distinct argv 조립 + distinct status semantics* (exec 는 non-zero → Ok, rm 은 → Error). *공유 transform 없음*. 누적 typed signature가 abstraction |
| Cap/cooldown/dedup/repair | N/A |
| Test backdoor | N/A |
| **Catch-all `_ ->`** | N/A — Process_eio 가 Unix_error → WEXITED 127 internalise. signal/stopped만 explicit pattern. |

## 미검증

- *real docker daemon + container present* 시 Ok with actual exit_code — integration test 별도
- shell injection 안전성 — caller (keeper) 책임

## 다음 PR

- **3b-iv.2.3**: Real `run` — `docker run` argv 조립 (Plan → image/cmd/timeout)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
