### PR TITLE
perf(shell_char_check): jump-table pattern match in command validators

### DIFF
--- a/lib/gh_command_validation.ml
+++ b/lib/gh_command_validation.ml
@@ -6,11 +6,20 @@
 
     @since godfile decomposition pass 2 *)
 
+(* Forbidden ASCII shell metacharacters.  Kept as a [char list] for
+   docs/tests that reference the source definition; the actual scan in
+   [contains_forbidden_shell_chars] uses a closed pattern match so the
+   compiler emits a jump table (O(1) per char) instead of an O(M) list
+   walk for every byte of [cmd]. *)
 let forbidden_shell_chars =
   [ ';'; '|'; '&'; '>'; '<'; '`'; '$'; '\n'; '\r' ]
 
 let contains_forbidden_shell_chars cmd =
-  String.exists (fun ch -> List.mem ch forbidden_shell_chars) cmd
+  String.exists
+    (function
+      | ';' | '|' | '&' | '>' | '<' | '`' | '$' | '\n' | '\r' -> true
+      | _ -> false)
+    cmd
 
 (** Top-level gh CLI commands allowed. Commands not in this list are
     rejected at the allowlist gate. *)

--- a/lib/worker_dev_tools.ml
+++ b/lib/worker_dev_tools.ml
@@ -166,10 +166,18 @@ let readonly_allowed_commands =
   ]
 ;;
 
+(* Mirror of [Gh_command_validation.forbidden_shell_chars].  Kept as a
+   list for docs/tests; the scan uses a closed pattern match below so the
+   per-byte check compiles to a jump table instead of an O(M) list walk
+   over [cmd]. *)
 let forbidden_shell_chars = [ ';'; '|'; '&'; '>'; '<'; '`'; '$'; '\n'; '\r' ]
 
 let contains_forbidden_shell_chars cmd =
-  String.exists (fun ch -> List.mem ch forbidden_shell_chars) cmd
+  String.exists
+    (function
+      | ';' | '|' | '&' | '>' | '<' | '`' | '$' | '\n' | '\r' -> true
+      | _ -> false)
+    cmd
 ;;
 
 (** Relaxed metacharacter set for Coding/Full preset keepers.
@@ -199,7 +207,11 @@ let has_dangerous_ampersand cmd =
 ;;
 
 let contains_forbidden_shell_chars_coding cmd =
-  String.exists (fun ch -> List.mem ch forbidden_shell_chars_coding_base) cmd
+  String.exists
+    (function
+      | ';' | '`' | '$' | '\n' | '\r' -> true
+      | _ -> false)
+    cmd
   || has_dangerous_ampersand cmd
 ;;
 


### PR DESCRIPTION
## Summary
- Three shell-metacharacter scans run on every gh/bash command a keeper issues. All three were doing `String.exists (fun ch -> List.mem ch <static_char_list>) cmd` — O(\|cmd\| * M) per call.
- Replaced the inner closure with a closed `function` match over the literal chars. OCaml lowers a closed `int` pattern match to a jump table, so the per-byte check is **O(1)** regardless of M. Net per-call cost drops from O(\|cmd\| * M) to O(\|cmd\|).

## Sites
| File | Function | M (chars) |
|---|---|---|
| `lib/gh_command_validation.ml` | `contains_forbidden_shell_chars` | 9 |
| `lib/worker_dev_tools.ml` | `contains_forbidden_shell_chars` | 9 |
| `lib/worker_dev_tools.ml` | `contains_forbidden_shell_chars_coding` | 5 |

## Why the list bindings stay
`forbidden_shell_chars` / `forbidden_shell_chars_coding_base` remain as source-of-truth documentation. Inline comments explain why the scan uses the pattern-match form instead of the list. Adding a new forbidden char now touches **both** the list and the pattern — intentional, so the documented constant stays honest.

## Test plan
- [x] `dune build lib/`
- [ ] CI green

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>