### PR TITLE
spec(kctxl): R-H-1.a apply — Zombie phase doc (iter 48, 5th honest-doc)

### DIFF
--- a/specs/INDEX.md
+++ b/specs/INDEX.md
@@ -5,7 +5,7 @@ Edit the generator, not this file. Re-run: scripts/gen-tla-index.sh > specs/INDE
 
 # TLA+ Spec Index
 
-Generated: 2026-05-11T23:08:00Z (HEAD: 9fc2516fe)
+Generated: 2026-05-11T23:56:10Z (HEAD: 45f48b887)
 
 Source of truth: `specs/`. Run `scripts/gen-tla-index.sh > specs/INDEX.md` to refresh.
 
@@ -126,7 +126,7 @@ Source of truth: `specs/`. Run `scripts/gen-tla-index.sh > specs/INDEX.md` to re
 | KeeperCompactionLifecycle.tla | KeeperCompactionLifecycle | manual | 2 | 1 | clean={inv:Safety, prop:OverflowEventuallyLeavesOverflow, prop:CompactingEventuallyStops} buggy={inv:CompactingAlignsAll} | 0a7dff742c90 |
 | KeeperCompositeLifecycle.tla | KeeperCompositeLifecycle | manual | 5 | 4 | clean={inv:SafetyInvariant, prop:EventualMeasurementResolves, prop:RecoveryEventuallyCompletes, prop:OverflowedEventuallyResolves} buggy-attempt={inv:ToolSurfaceFeedsAttempt} buggy-cascade={inv:NoCascadeBeforeMeasurement} buggy-compaction={inv:CompactionAtomicity, inv:PhaseTurnAlignment} buggy-post-turn={inv:PostTurnConsumesAttempt} | cc0b3d033262 |
 | KeeperConditionsGovernPhase.tla | KeeperConditionsGovernPhase | manual | 2 | 1 | clean={inv:Safety, prop:HandoffEventuallyAcknowledged} buggy={inv:TypeOK, prop:HandoffEventuallyAcknowledged} | 191c247c0f8c |
-| KeeperContextLifecycle.tla | KeeperContextLifecycle | manual | 4 | 2 | clean={inv:TypeOK, inv:ContextIsolation, inv:ResumeIdentity, inv:TurnMonotonicity, inv:CompactionPairIntegrity, inv:CheckpointConsistency, inv:BudgetAfterCompaction, prop:CompactionProgress, prop:EventualTurnCompletion, prop:AllKeepersTerminate} buggy={inv:TypeOK, inv:ContextIsolation, inv:ResumeIdentity, inv:TurnMonotonicity, inv:CompactionPairIntegrity, inv:CheckpointConsistency, inv:BudgetAfterCompaction} ci-buggy={inv:ContextIsolation, inv:ResumeIdentity} ci={inv:TypeOK, inv:ContextIsolation, inv:ResumeIdentity, inv:TurnMonotonicity, inv:CompactionPairIntegrity, inv:CheckpointConsistency, inv:BudgetAfterCompaction} | e7d6cf456c70 |
+| KeeperContextLifecycle.tla | KeeperContextLifecycle | manual | 4 | 2 | clean={inv:TypeOK, inv:ContextIsolation, inv:ResumeIdentity, inv:TurnMonotonicity, inv:CompactionPairIntegrity, inv:CheckpointConsistency, inv:BudgetAfterCompaction, prop:CompactionProgress, prop:EventualTurnCompletion, prop:AllKeepersTerminate} buggy={inv:TypeOK, inv:ContextIsolation, inv:ResumeIdentity, inv:TurnMonotonicity, inv:CompactionPairIntegrity, inv:CheckpointConsistency, inv:BudgetAfterCompaction} ci-buggy={inv:ContextIsolation, inv:ResumeIdentity} ci={inv:TypeOK, inv:ContextIsolation, inv:ResumeIdentity, inv:TurnMonotonicity, inv:CompactionPairIntegrity, inv:CheckpointConsistency, inv:BudgetAfterCompaction} | ff941b270423 |
 | KeeperCoreTriad.tla | KeeperCoreTriad | manual | 2 | 1 | clean={inv:SafetyInvariant, prop:RunningEventuallyCompletes CapabilityNeverDeadlocks} buggy={inv:SafetyInvariant} | 040df2f64d84 |
 | KeeperCounterCausality.tla | KeeperCounterCausality | manual | 2 | 1 | clean={inv:Safety} buggy={inv:CausePresentWhenCounted} | 531942a050de |
 | KeeperDecisionPipeline.tla | KeeperDecisionPipeline | manual | 2 | 1 | clean={inv:TypeOK, inv:Safety, prop:Liveness} buggy={inv:DecisionBoundaryRequiresMeasurement} | 3476c0518970 |

--- a/specs/keeper-state-machine/KeeperContextLifecycle.tla
+++ b/specs/keeper-state-machine/KeeperContextLifecycle.tla
@@ -80,9 +80,20 @@ vars == <<keeper_phase, turn_number, context_id, context_tokens, message_count,
 \* table above as the authoritative abstraction function.
 \*
 \* Unmodeled here (covered in companion specs):
-\*   HandingOff, Draining, Paused, Restarting
+\*   HandingOff, Draining, Paused, Restarting, Zombie
 \* See KeeperGenerationLineage.tla for HandingOff and
 \*     KeeperReconcileLiveness.tla for Paused/Restarting/Draining.
+\* Zombie ("zombie" wire format) is terminal-terminal: it is reachable
+\* only post-Dead when supervisor cleanup latches a never-cleared
+\* failure (see ZombieIsForever / ZombieRequiresTerminalFailureLatched
+\* in KeeperStateMachine.tla, added iter 4 #14707).  No context-
+\* lifecycle events are reachable from Zombie, so it is intentionally
+\* omitted from the abstract Phases set rather than collapsed into
+\* "dead".  See iter 47 audit memo
+\* docs/tla-audit/kctxl-h1-phase-mapping-zombie-gap-2026-05-12.md
+\* for the analysis (KSM phase type carries 13 constructors; this
+\* spec projects to 7 abstract values covering 8 of the 12 non-Zombie
+\* phases — Failing|Crashed collapse into "error", others as listed).
 Phases == {"idle", "running", "compacting", "overflow_retry", "done", "error", "dead"}
 
 \* ── Initial State ────────────────────────────────────────


### PR DESCRIPTION
## Iter 48 — R-H-1.a apply: KCtxL Zombie doc inline addition

**Iteration**: 48 (/loop FSM/TLA+/OCaml drift hunt)
**Closes**: iter 47 audit (#14850) R-H-1.a recommendation.
**Pattern**: **5th honest-doc datapoint** (iter 27 KCT, 35 KTC, 37 KCAF, 39 KCL, 48 this).
**Risk**: LOW — comments-only spec change.

## Finding (iter 47 recap)

`KeeperContextLifecycle.tla` mapped 12 of 13 OCaml `phase` constructors.  **Zombie was missing** from both the mapping table (line 67-77) AND the unmodeled list (line 83).  iter 3-4 (#14702/#14707) added Zombie post-KCtxL authoring; the mapping docs lagged.

Production safe pre-fix: Zombie is terminal-terminal (post-Dead, no context-lifecycle events reachable from it), so KCtxL's `Phases` set was structurally coherent — only documentation lagged.

## Change

```diff
 \* Unmodeled here (covered in companion specs):
-\*   HandingOff, Draining, Paused, Restarting
+\*   HandingOff, Draining, Paused, Restarting, Zombie
 \* See KeeperGenerationLineage.tla for HandingOff and
 \*     KeeperReconcileLiveness.tla for Paused/Restarting/Draining.
+\* Zombie ("zombie" wire format) is terminal-terminal: it is reachable
+\* only post-Dead when supervisor cleanup latches a never-cleared
+\* failure (see ZombieIsForever / ZombieRequiresTerminalFailureLatched
+\* in KeeperStateMachine.tla, added iter 4 #14707).  No context-
+\* lifecycle events are reachable from Zombie, so it is intentionally
+\* omitted from the abstract Phases set rather than collapsed into
+\* "dead".  See iter 47 audit memo
+\* docs/tla-audit/kctxl-h1-phase-mapping-zombie-gap-2026-05-12.md
+\* for the analysis (KSM phase type carries 13 constructors; this
+\* spec projects to 7 abstract values covering 8 of the 12 non-Zombie
+\* phases — Failing|Crashed collapse into "error", others as listed).
 Phases == {"idle", "running", "compacting", "overflow_retry", "done", "error", "dead"}
```

+12/-1 LOC, single file (`KeeperContextLifecycle.tla` lines 82-95).

## Pattern alignment

| iter | Spec | Honest-doc target |
|---|---|---|
| 27 (#14789 merged) | KCT | `"none"`/`"local_recovery"`/`"local_only"` cascade names — canonical role names per OCaml dispatch |
| 35 (#14811) | KTC | Routing/Exhausted action-level gap — GADT exhaustiveness in `keeper_registry.ml:234-244` |
| 37 (#14817 merged) | KCAF | Terminal classifier indirection — `sdk_error_is_hard_quota` cross-file fast-path |
| 39 (#14824 merged) | KCL | KcafPhaseSet 3:6 collapse — distinguished terminals merged in projection |
| **48 (this)** | **KCtxL** | **Zombie terminal-terminal omission — KSM safety surface owner reference** |

Same shape: 5-15 LOC inline doc addition + owner cross-reference + safety-preservation rationale + audit memo backlink.

## TLC Verification

| Cfg | Result |
|---|---|
| KCtxL-buggy.cfg | violation exit 12 (expected, unchanged) ✓ |
| KCtxL-ci-buggy.cfg | 23 distinct states, counterexample on CompactionCompletesBuggy ✓ |
| KCtxL-ci.cfg | 44M+ distinct states within 50s checkpoint, no errors ✓ |
| KCtxL.cfg | not re-run (5.6M+ states; comments-only change is structurally semantically transparent per iter 27/35/37/39 precedent) |

Comments-only changes cannot affect TLC reachability or invariant evaluation by construction.  All 4 prior honest-doc datapoints (#14789/#14811/#14817/#14824) verified this empirically — re-verification on the largest cfg would be over-engineering.

## RFC backlog status

| ID | Status |
|---|---|
| **R-H-1.a** KCtxL Zombie doc | **CLOSED** this PR |
| R-H-1.b sweep observer specs (KGenerationLineage, KReconcileLiveness, KCL, …) for Zombie-missing mapping tables | **DEFERRED** to iter 49+ |
| R-H-1.c doc-validation script (extends R-B-1.c chain) | **DEFERRED** pending recurrence evidence (R-F-1.c precedent: don't build infra for single-instance phenomena) |

## RFC

`RFC-WAIVED`: spec doc-only change, no subsystem touched.

## References

- iter 47 audit (#14850 ✓ merged): `docs/tla-audit/kctxl-h1-phase-mapping-zombie-gap-2026-05-12.md`
- iter 4 A-4 (#14707): Zombie introduction context (`ZombieIsForever` / `ZombieRequiresTerminalFailureLatched`)
- iter 3 A-3 (#14702 ✓ merged): derive_phase priority chain
- iter 27 KCT (#14789 ✓ merged), iter 35 KTC (#14811), iter 37 KCAF (#14817 ✓ merged), iter 39 KCL (#14824 ✓ merged) — prior 4 honest-doc datapoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>