### PR TITLE
fix(keeper_registry): make is_running exhaustive over phase

### DIFF
--- a/lib/keeper/keeper_registry.ml
+++ b/lib/keeper/keeper_registry.ml
@@ -1404,9 +1404,28 @@ let get_turn_failures ~base_path name =
   | None -> 0
 
 let is_running ~base_path name =
+  (* Enumerate every [Keeper_state_machine.phase] variant so the
+     compiler flags any new phase added to the FSM. Only [Running] is
+     the live execution state; all other 12 phases (Offline, Failing,
+     Overflowed, Compacting, HandingOff, Draining, Paused, Stopped,
+     Crashed, Restarting, Dead, Zombie) must yield [false]. A future
+     phase variant (e.g. a hypothetical [Migrating] or [Healing])
+     would silently inherit [false] under the previous [Some _ ->
+     false] catch-all without a review point on whether the new
+     phase should count as "running" for any downstream consumer.
+     Mirrors [Keeper_state_machine.can_execute_turn]'s enumeration
+     (line 392) — same scrutinee type, same convention. Same FSM
+     Sparse Match anti-pattern as PRs #14716, #14790, #14806, #14810,
+     #14816, #14823, #14829, #14842, #14849. *)
   match get ~base_path name with
   | Some { phase = Running; _ } -> true
-  | Some _ -> false
+  | Some
+      { phase =
+          ( Offline | Failing | Overflowed | Compacting | HandingOff
+          | Draining | Paused | Stopped | Crashed | Restarting | Dead
+          | Zombie )
+      ; _
+      } -> false
   | None -> false
 
 (** True if the keeper has ANY registry entry (regardless of state).

--- a/lib/keeper/keeper_registry.ml
+++ b/lib/keeper/keeper_registry.ml
@@ -1405,18 +1405,25 @@ let get_turn_failures ~base_path name =
 
 let is_running ~base_path name =
   (* Enumerate every [Keeper_state_machine.phase] variant so the
-     compiler flags any new phase added to the FSM. Only [Running] is
-     the live execution state; all other 12 phases (Offline, Failing,
-     Overflowed, Compacting, HandingOff, Draining, Paused, Stopped,
-     Crashed, Restarting, Dead, Zombie) must yield [false]. A future
-     phase variant (e.g. a hypothetical [Migrating] or [Healing])
-     would silently inherit [false] under the previous [Some _ ->
-     false] catch-all without a review point on whether the new
-     phase should count as "running" for any downstream consumer.
-     Mirrors [Keeper_state_machine.can_execute_turn]'s enumeration
-     (line 392) — same scrutinee type, same convention. Same FSM
-     Sparse Match anti-pattern as PRs #14716, #14790, #14806, #14810,
-     #14816, #14823, #14829, #14842, #14849. *)
+     compiler flags any new phase added to the FSM.
+
+     This predicate is intentionally narrower than
+     [Keeper_state_machine.can_execute_turn] (defined alongside the
+     phase type): [can_execute_turn] returns [true] for both [Running]
+     and [Failing] because a keeper in [Failing] may still complete
+     its in-flight turn before the recovery transition; [is_running]
+     answers the operator-facing question "is this keeper currently
+     running?" and treats only [Running] as such. The 12 other phases
+     (Offline, Failing, Overflowed, Compacting, HandingOff, Draining,
+     Paused, Stopped, Crashed, Restarting, Dead, Zombie) yield [false]
+     here. A future phase variant (e.g. a hypothetical [Migrating] or
+     [Healing]) would silently inherit [false] under the previous
+     [Some _ -> false] catch-all without a review point on whether
+     the new phase should count as "running" for any downstream
+     consumer.
+
+     Same FSM Sparse Match anti-pattern fix as PRs #14716, #14790,
+     #14806, #14810, #14816, #14823, #14829, #14842, #14849. *)
   match get ~base_path name with
   | Some { phase = Running; _ } -> true
   | Some


### PR DESCRIPTION
## Why

`is_running` in `lib/keeper/keeper_registry.ml:1406` dispatched on `Keeper_state_machine.phase` (13-variant closed sum: Offline, Running, Failing, Overflowed, Compacting, HandingOff, Draining, Paused, Stopped, Crashed, Restarting, Dead, Zombie):

```ocaml
match get ~base_path name with
| Some { phase = Running; _ } -> true
| Some _ -> false
| None -> false
```

The `Some _` catch-all hides 12 non-Running phases. A future phase variant (e.g. hypothetical `Migrating` or `Healing`) would silently inherit `false` under the catch-all without a review point on whether the new phase counts as "running" for any downstream consumer (`bootstrap_existing_keepers`, `keeper_repo_mapping`, dashboard polls, etc).

Sibling `Keeper_state_machine.can_execute_turn` (line 392) enumerates all 13 variants explicitly — same scrutinee type, established convention. This `is_running` was the odd one out.

Same FSM Sparse Match anti-pattern as PRs #14716, #14790, #14806, #14810, #14816, #14823, #14829, #14842, #14849. CLAUDE.md `software-development.md` §"AI 코드 생성 안티패턴 §4" applies directly.

## What

Replace `Some _ -> false` with explicit enumeration of the 12 non-Running phases:

```ocaml
match get ~base_path name with
| Some { phase = Running; _ } -> true
| Some
    { phase =
        ( Offline | Failing | Overflowed | Compacting | HandingOff
        | Draining | Paused | Stopped | Crashed | Restarting | Dead
        | Zombie )
    ; _
    } -> false
| None -> false
```

Adding a 14th constructor to `phase` now triggers `Warning 8: pattern-matching is not exhaustive` here, forcing the maintainer to decide whether the new phase counts as "running" for this predicate (and by extension, for all 5+ callers of `is_running`).

A comment explains the convention and points to `can_execute_turn` as the precedent so a future reader doesn't reintroduce the catch-all.

Behavior unchanged for current 13 phases.

## Self-check (CLAUDE.md Workaround Rejection Bar)

| # | Check | Result |
|---|---|---|
| 1 | telemetry-as-fix? | no — removes catch-all |
| 2 | string classifier? | no |
| 3 | N-of-M? | no — only `is_running` uses phase catch-all in this file |
| 4 | catch-all added? | no — `Some _ ->` removed |
| 5 | cap/cooldown/dedup? | no |
| 6 | test backdoor? | no |
| 7 | typo N sites? | no |

🤖 Generated with [Claude Code](https://claude.com/claude-code)