### PR TITLE
feat(telemetry): Tool_policy_failure_site + Metric_emit_dropped_site extend (3 sites)

### DIFF
--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -977,7 +977,7 @@ let emit_cost_event
       | exn ->
         Prometheus.inc_counter
           Keeper_metrics.metric_keeper_metric_emit_dropped
-          ~labels:[("keeper", agent_name); ("site", "cost_event_write")]
+          ~labels:[("keeper", agent_name); ("site", Metric_emit_dropped_site.(to_label Cost_event_write))]
           ();
         Log.Keeper.error "emit_cost_event: failed to write %s: %s"
           (Dated_jsonl.base_dir store) (Printexc.to_string exn))

--- a/lib/keeper/keeper_tool_policy.ml
+++ b/lib/keeper/keeper_tool_policy.ml
@@ -374,7 +374,7 @@ let preset_allowlist preset =
     ~on_none:(fun () ->
       Prometheus.inc_counter
         Keeper_metrics.metric_keeper_tool_policy_failures
-        ~labels:[("site", "policy_config_not_loaded"); ("preset", name)]
+        ~labels:[("site", Tool_policy_failure_site.(to_label Policy_config_not_loaded)); ("preset", name)]
         ();
       Log.Keeper.error
         "tool policy config not loaded; preset '%s' returns empty. \

--- a/lib/keeper/metric_emit_dropped_site.ml
+++ b/lib/keeper/metric_emit_dropped_site.ml
@@ -1,5 +1,8 @@
-type t = Keeper_unified_turn
+type t =
+  | Keeper_unified_turn
+  | Cost_event_write
 
 let to_label = function
   | Keeper_unified_turn -> "keeper_unified_turn"
+  | Cost_event_write -> "cost_event_write"
 ;;

--- a/lib/keeper/metric_emit_dropped_site.mli
+++ b/lib/keeper/metric_emit_dropped_site.mli
@@ -1,6 +1,8 @@
 (** Metric_emit_dropped_site — closed sum for [site] label on
     [metric_keeper_metric_emit_dropped]. *)
 
-type t = Keeper_unified_turn
+type t =
+  | Keeper_unified_turn
+  | Cost_event_write (** Cost event write failure inside keeper_hooks_oas.ml. *)
 
 val to_label : t -> string

--- a/lib/keeper/tool_policy_failure_site.ml
+++ b/lib/keeper/tool_policy_failure_site.ml
@@ -1,0 +1,8 @@
+type t =
+  | Tool_code_write_load_failed
+  | Policy_config_not_loaded
+
+let to_label = function
+  | Tool_code_write_load_failed -> "tool_code_write_load_failed"
+  | Policy_config_not_loaded -> "policy_config_not_loaded"
+;;

--- a/lib/keeper/tool_policy_failure_site.mli
+++ b/lib/keeper/tool_policy_failure_site.mli
@@ -1,0 +1,12 @@
+(** Tool_policy_failure_site — closed sum for the [site] label on
+    [metric_keeper_tool_policy_failures] (2 sites across
+    keeper_tool_policy.ml and tool_code_write.ml).
+
+    Both sites surface failures of the tool-policy TOML load path. *)
+
+type t =
+  | Tool_code_write_load_failed
+  (** tool_policy.toml load failed inside the tool_code_write path. *)
+  | Policy_config_not_loaded (** Policy config absent or empty at preset lookup time. *)
+
+val to_label : t -> string

--- a/lib/tool_code_write.ml
+++ b/lib/tool_code_write.ml
@@ -227,7 +227,7 @@ let observe_policy_config_load_error ~base_path ~env_config_dir msg =
     Option.value ~default:"<resolved-from-base-path>" env_config_dir
   in
   Prometheus.inc_counter Keeper_metrics.metric_keeper_tool_policy_failures
-    ~labels:[("site", "tool_code_write_load_failed"); ("preset", "n/a")]
+    ~labels:[("site", Tool_policy_failure_site.(to_label Tool_code_write_load_failed)); ("preset", "n/a")]
     ();
   Log.Keeper.warn
     "tool_code_write: tool_policy.toml load failed; git clone policy is \


### PR DESCRIPTION
## Summary

Sweep tail wrap-up of the last hardcoded `site` label strings outside
the keeper-side `_failures` family:

1. **New `Tool_policy_failure_site.t`** (2 sites on
   `metric_keeper_tool_policy_failures`):
   `Tool_code_write_load_failed | Policy_config_not_loaded`
2. **Extend `Metric_emit_dropped_site.t`** with `Cost_event_write`
   (1 site in `keeper_hooks_oas.ml`, same metric as #14851 / T25).

## Sites (3)

| File:Line | Metric | Variant |
|-----------|--------|---------|
| `tool_code_write.ml:230` | `metric_keeper_tool_policy_failures` | `Tool_policy_failure_site.Tool_code_write_load_failed` |
| `keeper_tool_policy.ml:377` | `metric_keeper_tool_policy_failures` | `Tool_policy_failure_site.Policy_config_not_loaded` |
| `keeper_hooks_oas.ml:980` | `metric_keeper_metric_emit_dropped` | `Metric_emit_dropped_site.Cost_event_write` (extend) |

## Sweep status

After this PR, the audit grep

```
rg '~labels:\[.*"(site|operation)", "[a-z_]+"' lib/
```

yields no remaining workaround #2 string-classifier sites on the
keeper-side telemetry surface.  The remaining `Printf.sprintf`/`show_*`
free-form label values are intentional context (e.g. `op`, `origin`,
`agent_name`) — not closed sets.

Wire format byte-equal.

## Test plan

- [ ] CI green
- [ ] `rg '"site", "(tool_code_write_load_failed|policy_config_not_loaded|cost_event_write)"' lib/` = 0

RFC-WAIVED: not in credential/identity/operator/sandbox/hooks/workflow scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)