### PR TITLE
fix(dashboard_verification): make is_rejected exhaustive over request_status × verdict

### DIFF
--- a/lib/dashboard/dashboard_verification.ml
+++ b/lib/dashboard/dashboard_verification.ml
@@ -251,7 +251,8 @@ let rejection_row_json (req : V.verification_request) : Yojson.Safe.t =
 let is_rejected (req : V.verification_request) : bool =
   match req.status with
   | V.Completed (V.Fail _) | V.Completed (V.Partial _) -> true
-  | _ -> false
+  | V.Completed V.Pass -> false
+  | V.Pending | V.Assigned _ -> false
 
 let bucket_of_status (req : V.verification_request) : string =
   req |> status_bucket_of_request |> status_bucket_to_string


### PR DESCRIPTION
## Why

`is_rejected` classifies verification requests using a nested-variant match with `_ -> false` catch-all:

\`\`\`ocaml
let is_rejected (req : V.verification_request) : bool =
  match req.status with
  | V.Completed (V.Fail _) | V.Completed (V.Partial _) -> true
  | _ -> false
\`\`\`

Types involved (lib/verification.mli):
- `request_status = Pending | Assigned of string | Completed of verdict` (3 variants)
- `verdict = Pass | Fail of string | Partial of float * string` (3 variants)

The catch-all silently absorbs 3 cases:
- `V.Pending` — in-flight, no verdict yet
- `V.Assigned _` — in-flight, assigned to verifier
- `V.Completed V.Pass` — verification passed

A future variant on either type (e.g., `Cancelled`, `Expired`, `Retry`, `Inconclusive`) silently defaults to *not rejected*, but the dashboard's rejected-recent list might want some of those counted.

## Fix

\`\`\`ocaml
let is_rejected (req : V.verification_request) : bool =
  match req.status with
  | V.Completed (V.Fail _) | V.Completed (V.Partial _) -> true
  | V.Completed V.Pass -> false
  | V.Pending | V.Assigned _ -> false
\`\`\`

Truth table identical under current types. OCaml warning 8 now forces explicit per-arm decision on any future variant addition.

## Cross-check (iter #23 protocol + iter #26 refinement)

- Open PRs (#14856/#14857/#14858/#14859/#14758/#14718) — none touch `lib/dashboard/dashboard_verification.ml`
- Recently merged PRs (`git log origin/main --since='2 days ago' -- lib/dashboard/dashboard_verification.ml`) — none
- Safe to merge

## Verification

- `dune build @lib/check --root .` exit 0
- `git diff --stat`: 1 file, +2 −1