### PR TITLE
feat(rfc-0070): Phase 3b-iv.2.3 — Real Docker_client.run wired (Plan → argv)

### DIFF
--- a/lib/keeper/docker_client_real.ml
+++ b/lib/keeper/docker_client_real.ml
@@ -1,9 +1,9 @@
-(* RFC-0070 Phase 3b-iv.2.2 — Real Docker_client (rm + exec wired).
+(* RFC-0070 Phase 3b-iv.2.3 — Real Docker_client (rm + exec + run wired).
 
    Sub-phase 3b-iv.2.0 shipped placeholders for all four S functions.
-   Sub-phase 3b-iv.2.1 wired [rm] (#14844). Sub-phase 3b-iv.2.2 (this)
-   wires [exec]; [run] and [ps_query] remain placeholders pending
-   3b-iv.2.{3,4}.
+   Sub-phase 3b-iv.2.1 wired [rm] (#14844); 3b-iv.2.2 wired [exec]
+   (#14854); 3b-iv.2.3 (this) wires [run]. Only [ps_query] remains a
+   placeholder pending 3b-iv.2.4.
 
    The signature is unchanged across sub-phases — callers see a typed
    [(_, sandbox_error) result] regardless of which function bodies are
@@ -28,20 +28,17 @@ let map_exit_status_for_rm (status : Unix.process_status) =
   | Unix.WEXITED _ -> Error Docker_client.Cleanup_failed
   | Unix.WSIGNALED _ | Unix.WSTOPPED _ -> Error Docker_client.Daemon_unreachable
 
-(* Docker CLI exit code semantics for [docker exec]:
-     0       — command ran in container, exited zero
-     non-zero (general) — command ran in container, exited non-zero;
-                         this is a *response*, not a daemon error
-     125     — daemon error (couldn't run docker exec itself)
-     126     — command found in container but not executable
-     127     — synthesized by [Process_eio.run_argv_with_status_split]
-               for missing docker CLI; functionally Daemon_unreachable.
+(* Docker CLI exit code semantics for [docker exec] AND [docker run]:
+   both return the executed *command's* exit code on success; only
+   daemon-level statuses (125, 127, signal) surface as
+   [Error Daemon_unreachable]. A non-zero command exit is a *response*
+   ([Ok exec_result]), not a daemon error.
 
-   exec's semantic distinction vs rm: a non-zero exit inside the
-   container is the *command's* result, returned as
-   [Ok exec_result { exit_code = non-zero; ... }]. Only daemon-level
-   failures (125, 127, signal) surface as [Error Daemon_unreachable]. *)
-let map_status_for_exec
+   Shared between [exec] and [run] because both produce
+   {!Docker_response.exec_result} on success; the host process IS the
+   docker CLI, and its [WEXITED n] reflects what docker reported about
+   the containerized command. *)
+let map_status_to_exec_result
     ((status, stdout, stderr) :
       Unix.process_status * string * string)
   =
@@ -55,7 +52,6 @@ let map_status_for_exec
 
 (* ── Functions ───────────────────────────────────────────────── *)
 
-let run (_ : Keeper_sandbox_plan.t) = placeholder
 let ps_query ~labels:_ = placeholder
 
 let exec ~container ~cmd =
@@ -71,7 +67,35 @@ let exec ~container ~cmd =
   (* [Process_eio.run_argv_with_status_split] returns
      [(status, stdout, stderr)]; on spawn failure the status is
      synthesized as [WEXITED 127] (see 3b-iv.2.1 commit on rm). *)
-  map_status_for_exec (Process_eio.run_argv_with_status_split argv)
+  map_status_to_exec_result (Process_eio.run_argv_with_status_split argv)
+
+let run plan =
+  let container_name =
+    Keeper_container_name.to_string (Keeper_sandbox_plan.container_name plan)
+  in
+  let image = Keeper_sandbox_plan.image plan in
+  let command = Keeper_sandbox_plan.command plan in
+  let timeout_sec = Keeper_sandbox_plan.timeout_budget_sec plan in
+  (* [docker run --rm --name <name> <image> sh -lc <cmd>].
+     [--rm] removes the container after exit (Phase 3b-iii default
+     cleanup strategy — RFC §3.1's spec deferred a typed cleanup
+     policy to a follow-up RFC). [sh -lc] mirrors [exec]'s wrapping
+     so caller-passed [cmd] strings work identically across both
+     functions. *)
+  let argv =
+    [ "docker"
+    ; "run"
+    ; "--rm"
+    ; "--name"
+    ; container_name
+    ; image
+    ; "sh"
+    ; "-lc"
+    ; command
+    ]
+  in
+  map_status_to_exec_result
+    (Process_eio.run_argv_with_status_split ~timeout_sec argv)
 
 let rm container =
   let argv =

--- a/lib/keeper/docker_client_real.mli
+++ b/lib/keeper/docker_client_real.mli
@@ -1,10 +1,11 @@
-(** RFC-0070 Phase 3b-iv.2.2 — Real {!Docker_client.S} ([rm] + [exec] wired).
+(** RFC-0070 Phase 3b-iv.2.3 — Real {!Docker_client.S}
+    ([rm] + [exec] + [run] wired).
 
     Phase 3a's stub kept [Docker_client.S] as a *signature only*. Phase
     3b-iv.1b added [Docker_client_mock] for tests. Phase 3b-iv.2.0
     added the *production* skeleton. Phase 3b-iv.2.1 (#14844) wired
-    [rm]; Phase 3b-iv.2.2 (this) wires [exec]. [run] and [ps_query]
-    remain placeholders pending 3b-iv.2.{3,4}.
+    [rm]; 3b-iv.2.2 (#14854) wired [exec]; 3b-iv.2.3 (this) wires
+    [run]. Only [ps_query] remains a placeholder pending 3b-iv.2.4.
 
     Reference: docs/rfc/RFC-0070-keeper-sandbox-pure-edge-separation.md §3.2
 
@@ -35,9 +36,19 @@
         {- [WSIGNALED _] / [WSTOPPED _]}}
       All other [WEXITED n] values surface as
       [Ok { exit_code = n; stdout; stderr }].
-    - [run], [ps_query] — still [Error Cleanup_failed] placeholder
-      pending 3b-iv.2.{3,4}. Each sub-phase replaces one body without
-      changing the public surface.
+    - [run] — wired: spawns
+      [docker run --rm --name <name> <image> sh -lc <cmd>] via
+      [Process_eio.run_argv_with_status_split], passing
+      [Keeper_sandbox_plan.timeout_budget_sec] as the
+      [?timeout_sec] parameter. Status mapping is the same as [exec]
+      ({!Docker_response.exec_result} on container-command exit;
+      [Error Daemon_unreachable] on daemon-level status). [--rm]
+      flag removes the container after exit (RFC §3.1's interim
+      default cleanup; a typed cleanup-policy field on
+      {!Keeper_sandbox_plan.t} is deferred to a follow-up RFC).
+    - [ps_query] — still [Error Cleanup_failed] placeholder pending
+      3b-iv.2.4 (JSON parser for
+      [docker ps --format '\{\{json .\}\}']).
 
     **Why a placeholder skeleton and not [failwith]**: returning
     [Error Cleanup_failed] keeps the signature in {!result}; a caller

--- a/test/test_docker_client_real.ml
+++ b/test/test_docker_client_real.ml
@@ -50,10 +50,21 @@ let sample_container () =
 
 (* ── Each S function returns the typed placeholder ──────────── *)
 
-let test_run_placeholder () =
+(* Phase 3b-iv.2.3 — run is no longer a placeholder. It spawns
+   [docker run --rm --name <name> <image> sh -lc <cmd>]. Same typed
+   contract as [exec]: either [Ok exec_result] (daemon present) or
+   [Error Daemon_unreachable] (daemon / CLI missing). No other
+   [sandbox_error] variant is semantically valid for [run]. *)
+let test_run_returns_typed_result () =
   match Docker_client_real.run (sample_plan ()) with
-  | Error Docker_client.Cleanup_failed -> ()
-  | _ -> fail "expected Cleanup_failed placeholder"
+  | Ok _ -> ()                                     (* daemon present *)
+  | Error Docker_client.Daemon_unreachable -> ()   (* daemon / CLI missing *)
+  | Error Docker_client.Cleanup_failed
+  | Error Docker_client.Image_pull_failed
+  | Error Docker_client.Container_oom
+  | Error Docker_client.Exec_timeout
+  | Error Docker_client.Probe_format_drift ->
+    fail "run should only surface Ok exec_result or Error Daemon_unreachable"
 
 (* Phase 3b-iv.2.2 — exec is no longer a placeholder. It spawns
    [docker exec <container> sh -lc <cmd>]. The test environment may
@@ -97,18 +108,27 @@ let test_rm_returns_typed_error () =
 
 (* ── Functor instantiation works with Real ───────────────────── *)
 
-let test_executor_with_real_returns_placeholder () =
-  let r = Real_executor.execute_plan (sample_plan ()) in
-  match r with
-  | Error Docker_client.Cleanup_failed -> ()
-  | _ -> fail "executor with Real placeholder should surface Cleanup_failed"
+(* Phase 3b-iv.2.3 — executor.execute_plan calls Real.run, which is
+   now wired. Same typed contract as test_run_returns_typed_result. *)
+let test_executor_with_real_returns_typed_result () =
+  match Real_executor.execute_plan (sample_plan ()) with
+  | Ok _ -> ()
+  | Error Docker_client.Daemon_unreachable -> ()
+  | Error Docker_client.Cleanup_failed
+  | Error Docker_client.Image_pull_failed
+  | Error Docker_client.Container_oom
+  | Error Docker_client.Exec_timeout
+  | Error Docker_client.Probe_format_drift ->
+    fail "executor with Real should only surface Ok or Daemon_unreachable"
 
 let () =
-  run "Docker_client_real (skeleton)"
+  run "Docker_client_real (Phase 3b-iv.2.3)"
     [
       ( "S placeholder",
         [
-          test_case "run → Cleanup_failed" `Quick test_run_placeholder;
+          test_case "run → Ok exec_result | Error Daemon_unreachable"
+            `Quick
+            test_run_returns_typed_result;
           test_case "exec → Ok exec_result | Error Daemon_unreachable"
             `Quick
             test_exec_returns_typed_result;
@@ -121,6 +141,6 @@ let () =
         [
           test_case "Sandbox_executor.Make (Real) instantiates + forwards placeholder"
             `Quick
-            test_executor_with_real_returns_placeholder;
+            test_executor_with_real_returns_typed_result;
         ] );
     ]


### PR DESCRIPTION
## 목표 — RFC-0070 §3.2 Phase 3b-iv.2.3

**Real `run` 실제 wire** — `docker run --rm --name <name> <image> sh -lc <cmd>`. Plan record의 4 fields 모두 argv 조립에 사용. **Phase 3b-iv.2 series 4/5 완료** (남은 1: ps_query).

## RFC 인용

| RFC | 관계 |
|-----|------|
| **RFC-0070** | §3.1 (Plan record fields) + §3.2 (Real Docker_client.run) |
| RFC-0006 | cite-only |
| RFC-0036 | cite-only |

## Phase 3b-iv.2 진행

| Sub-phase | function | 상태 |
|-----------|----------|------|
| 3b-iv.2.0 | skeleton (4 placeholders) | ✅ #14838 |
| 3b-iv.2.1 | rm wired | ✅ #14844 |
| 3b-iv.2.2 | exec wired | ✅ #14854 |
| **3b-iv.2.3** | **run wired** | 🟡 본 PR |
| 3b-iv.2.4 | ps_query + JSON parse | 다음 (final) |

## Plan record → argv 조립

```
docker run --rm --name <container_name> <image> sh -lc <cmd>
```

| Plan field | argv 위치 |
|------------|----------|
| container_name | `--name <name>` |
| image | positional image arg |
| command | `sh -lc <cmd>` (exec와 동일 wrapping) |
| timeout_budget_sec | `?timeout_sec` parameter on Process_eio |

**Plan record 4 fields 모두 wired** — Phase 3b-iii (#14781)에서 정의한 typed record가 *처음으로* production caller에 의해 사용.

## `--rm` flag 명시 (RFC trade-off)

- Phase 3b-iii spec는 explicit cleanup strategy 없음
- RFC §3.1 typed cleanup-policy field는 *follow-up RFC*로 미룸
- `--rm`는 *interim default* — docker native cleanup, 단일 컨테이너 자동 제거
- *Future*: cleanup-policy typed field가 `--rm | --keep-container | --pause` 등 variant로 

## Status mapping refactor

`map_status_for_exec` → **`map_status_to_exec_result`** rename + 일반화. exec와 run 둘 다 `Docker_response.exec_result` 반환 (같은 의미: container 안 명령의 exit code) → 동일 매핑 공유.

## 변경

```
lib/keeper/docker_client_real.mli   ±15 (Phase 3b-iv.2.2 → 2.3, run semantics docstring)
lib/keeper/docker_client_real.ml    +40 (map_to_exec_result rename + run impl + argv 조립)
test/test_docker_client_real.ml     ±25 (run + executor test 재구성, suite title)
```

## Test 갱신

```ocaml
let test_run_returns_typed_result () =
  match Docker_client_real.run (sample_plan ()) with
  | Ok _ -> ()                                     (* daemon present *)
  | Error Daemon_unreachable -> ()                 (* daemon / CLI missing *)
  | Error <other 5 variants> -> fail "run should only surface ..."

let test_executor_with_real_returns_typed_result () =
  (* Sandbox_executor.Make (Real).execute_plan → Real.run *)
  (* 이제 placeholder 아님, 동일 typed contract *)
```

`Sandbox_executor.Make (Real)`가 *이제 실제 docker run 호출* — functor pattern과 Plan record가 *end-to-end로 wire됨*.

## 검증

- Isolated ocamlc PASS (Process_eio.run_argv_with_status_split + Keeper_sandbox_plan accessors 기존 main에 있음)
- Typed contract test (5 invalid error variants 명시적 거부)
- `dune build @check` repo-wide: main 회귀 (#14745) 미해소 — 무관

## Workaround Rejection Bar self-check

| 시그니처 | 본 PR 해당? |
|---------|------------|
| Counter-as-fix | N/A |
| String 분류기 | N/A — exit code → typed |
| **N-of-M** | **acknowledged**: 4/5 sub-phase 완료. 1 placeholder 남음 (ps_query). 각 함수는 *distinct argv 조립 + distinct status semantics*. status-mapping refactor가 *중복 제거* — exec + run 공유 helper |
| Cap/cooldown/dedup/repair | N/A — `--rm`은 docker native cleanup, *workaround 아닌 documented mechanism* |
| Test backdoor | N/A |
| **Catch-all `_ ->`** | N/A — Process_eio가 Unix_error → WEXITED 127 internalise; signal/stopped explicit |

## 미검증

- *real docker daemon + image available* 시 Ok with stdout/stderr capture — integration test 별도
- timeout 실제 적용 — Process_eio.run_argv_with_status_split의 ?timeout_sec semantics에 의존

## 다음 PR

- **3b-iv.2.4 (final)**: Real `ps_query` — `docker ps --format '\{\{json .\}\}'` + JSON parser → `Docker_response.ps_record list`. JSON parser가 새 piece (line-by-line decode, label string split).

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
