### PR TITLE
fix(keeper): make 2 phase-match catch-alls exhaustive (#14857 followup)

### DIFF
--- a/lib/keeper/keeper_registry.ml
+++ b/lib/keeper/keeper_registry.ml
@@ -897,9 +897,16 @@ let mark_dead ~base_path name ~at =
   Log.Keeper.error "registry: marking keeper dead name=%s at=%.0f" name at;
   update_entry ~base_path name (fun entry ->
     if entry.phase <> Dead then begin
+      (* Enumerate every phase so the compiler flags any new variant.
+         Only the Running phase contributes to [running_count_atomic];
+         all other phases were never counted, so transitioning to
+         Dead from them must not decrement. Same FSM Sparse Match
+         anti-pattern as PR #14857 (this file's [is_running]). *)
       (match entry.phase with
        | Running -> decr_running_count_clamped ()
-       | _ -> ());
+       | Offline | Failing | Overflowed | Compacting | HandingOff
+       | Draining | Paused | Stopped | Crashed | Restarting | Dead
+       | Zombie -> ());
       let conditions =
         { Keeper_state_machine.default_conditions with
           launch_pending = false;

--- a/lib/keeper/keeper_runtime.ml
+++ b/lib/keeper/keeper_runtime.ml
@@ -773,6 +773,18 @@ let start_supervisor_sweep ctx =
           (try
             Keeper_registry.all ~base_path ()
             |> List.iter (fun (entry : Keeper_registry.registry_entry) ->
+              (* Enumerate every phase so the compiler flags any new
+                 variant added to [Keeper_state_machine.phase]. TOML
+                 hot-reload only reconciles Running keepers; the other
+                 12 phases must skip (a Stopped/Crashed/Dead/Zombie
+                 keeper has no in-memory meta to update; a Compacting
+                 or HandingOff keeper is mid-transition and reconcile
+                 would race; Offline / Paused / Failing / Overflowed /
+                 Draining / Restarting are all transient or paused
+                 states). A future phase (e.g. Migrating, Healing)
+                 would silently skip reconcile under [_ -> ()] without
+                 a review point. Same FSM Sparse Match anti-pattern as
+                 PR #14857. *)
               match entry.phase with
               | Keeper_state_machine.Running ->
                   (match ensure_keeper_meta ctx.config entry.name with
@@ -786,7 +798,18 @@ let start_supervisor_sweep ctx =
                    | Error e ->
                        Log.Keeper.warn "TOML reconcile failed for %s: %s"
                          entry.name e)
-              | _ -> ())
+              | Keeper_state_machine.Offline
+              | Keeper_state_machine.Failing
+              | Keeper_state_machine.Overflowed
+              | Keeper_state_machine.Compacting
+              | Keeper_state_machine.HandingOff
+              | Keeper_state_machine.Draining
+              | Keeper_state_machine.Paused
+              | Keeper_state_machine.Stopped
+              | Keeper_state_machine.Crashed
+              | Keeper_state_machine.Restarting
+              | Keeper_state_machine.Dead
+              | Keeper_state_machine.Zombie -> ())
            with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
              Prometheus.inc_counter
                Keeper_metrics.metric_keeper_toml_reconcile_sweep_failures


### PR DESCRIPTION
## Why

Two sites in keeper lifecycle modules dispatched on `Keeper_state_machine.phase` (13-variant closed sum) with `| _ -> ()` catch-alls:

| File | Line | Function context |
|------|------|------------------|
| `lib/keeper/keeper_runtime.ml` | 776 | TOML hot-reload reconcile (only runs for Running) |
| `lib/keeper/keeper_registry.ml` | 901 | `mark_dead` running_count decrement (only for Running→Dead) |

Both follow the same shape as `is_running` (closed in PR #14857): single match arm for Running + catch-all hiding 12 other phases. A future phase added to `Keeper_state_machine.phase` (e.g. hypothetical `Migrating`, `Healing`) would silently skip reconcile / count-decrement under the catch-all without a review point on whether the new phase should participate.

Same FSM Sparse Match anti-pattern as PRs #14716, #14790, #14806, #14810, #14816, #14823, #14829, #14842, #14849, #14857. The convention in this subsystem is exhaustive enumeration: `keeper_state_machine.ml::can_execute_turn` (line 392) and `keeper_supervisor.ml::should_cleanup_dead` (line 84) already enumerate all 13 phases — these two sites in the boot/termination path were holdouts.

## What

Replace `_ -> ()` with explicit enumeration of the 12 non-Running phases at both sites. Adding a 14th constructor to `Keeper_state_machine.phase` now triggers `Warning 8: pattern-matching is not exhaustive` at both sites, forcing the maintainer to decide whether the new phase participates in TOML reconcile and running-count tracking.

Each site gets a comment explaining the per-phase semantics (e.g. "Stopped/Crashed/Dead/Zombie have no in-memory meta to update; Compacting/HandingOff are mid-transition and would race") so a future reader doesn't reintroduce the catch-all.

Behavior unchanged for current 13 phases.

## Self-check (CLAUDE.md Workaround Rejection Bar)

| # | Check | Result |
|---|---|---|
| 1 | telemetry-as-fix? | no — removes catch-all |
| 2 | string classifier? | no |
| 3 | N-of-M? | **yes** — 2 sites in 2 files folded (same fix shape, same scrutinee type) to avoid separate followups |
| 4 | catch-all added? | no — both `_ ->` removed |
| 5 | cap/cooldown/dedup? | no |
| 6 | test backdoor? | no |
| 7 | typo N sites? | no — same root pattern, codemod-equivalent |

🤖 Generated with [Claude Code](https://claude.com/claude-code)