### PR TITLE
fix(chronicle_index): close 3 catch-all sites over epoch_status (N-of-M followup #14852)

### DIFF
--- a/lib/chronicle_index.ml
+++ b/lib/chronicle_index.ml
@@ -59,7 +59,9 @@ let find_epoch (idx : index) epoch_id =
 
 let active_epochs (idx : index) =
   List.filter (fun (s : epoch_summary) ->
-    match s.status with Chronicle_types.Active -> true | _ -> false)
+    match s.status with
+    | Chronicle_types.Active -> true
+    | Chronicle_types.Completed | Chronicle_types.Abandoned -> false)
     idx.epochs
 
 let add_or_replace_epoch (idx : index) (summary : epoch_summary) =
@@ -78,7 +80,7 @@ let active_trail_stagnation_score epochs =
     |> List.filter_map (fun (s : epoch_summary) ->
            match s.status with
            | Chronicle_types.Active -> Some (max 0.0 s.conductivity)
-           | _ -> None)
+           | Chronicle_types.Completed | Chronicle_types.Abandoned -> None)
   in
   match active_conductivities with
   | [] -> 0.0
@@ -130,7 +132,7 @@ let evaporate_active_epochs ?policy idx =
                  evaporate_conductivity ?policy ~stagnation_score
                    summary.conductivity
              }
-         | _ -> summary)
+         | Chronicle_types.Completed | Chronicle_types.Abandoned -> summary)
       idx.epochs
   in
   { idx with epochs }


### PR DESCRIPTION
## Why

PR #14852 made `Chronicle_types.is_active` / `is_completed` exhaustive over `epoch_status = Active | Completed | Abandoned`. **3 sibling sites in `lib/chronicle_index.ml` use the same predicate logic** but still carry `_ -> false / None / summary` catch-alls.

Discovered via type+constructor matrix sweep (memory feedback iter #22):

\`\`\`bash
rg 'Chronicle_types\.Active\b' lib/ -t ocaml
\`\`\`

Surfaces all 3 in one grep. iter #25's PR #14852 was function-name-scoped (`is_active`, `is_completed` only), missing module-level siblings — classic N-of-M anti-pattern.

## Sites

| Line | Function | Catch-all shape |
|------|----------|-----------------|
| 60-63 | `active_epochs` | `Active -> true \| _ -> false` |
| 75-81 | `active_trail_stagnation_score` | `Active -> Some _ \| _ -> None` |
| 121-134 | `evaporate_active_epochs` | `Active -> {...} \| _ -> summary` |

## Fix

Each catch-all replaced with explicit `Completed | Abandoned` enumeration:

\`\`\`ocaml
match s.status with
| Chronicle_types.Active -> true
| Chronicle_types.Completed | Chronicle_types.Abandoned -> false
\`\`\`

Truth table identical under current 3-variant type. OCaml warning 8 now forces per-site decision on any future variant addition.

## 3-axis cross-check (iter #26 protocol)

1. main repo working tree synced with `git pull --rebase origin main` (HEAD `768a61cca`)
2. Open PRs (#14864/#14865/#14758/#14718) — none touch `lib/chronicle_index.ml`
3. Recently merged in 48h — only #14852 touched chronicle_types (the parent PR)

## Verification

- `dune build @lib/check --root .` exit 0
- `git diff --stat`: 1 file, +5 −3