### PR TITLE
fix(governance_anomaly): make failure_rate_of_batch outcome match exhaustive

### DIFF
--- a/lib/governance_anomaly.ml
+++ b/lib/governance_anomaly.ml
@@ -111,7 +111,7 @@ let failure_rate_of_batch entries =
         (fun e ->
           match e.Audit_log.outcome with
           | Audit_log.Failure _ -> true
-          | _ -> false)
+          | Audit_log.Success -> false)
         entries
     in
     float_of_int (List.length failures) /. float_of_int n


### PR DESCRIPTION
## Why

`Audit_log.outcome = Success | Failure of string` (lib/audit_log.mli:29-31, 2 variants).

`failure_rate_of_batch` at lib/governance_anomaly.ml:112-114 used `| _ -> false` catch-all:

\`\`\`ocaml
match e.Audit_log.outcome with
| Audit_log.Failure _ -> true
| _ -> false
\`\`\`

A sibling site at `lib/dashboard/dashboard_http_monitoring.ml:32` already used the *explicit* form for the same predicate:

\`\`\`ocaml
match e.outcome with
| Audit_log.Failure _ -> true
| Audit_log.Success -> false
\`\`\`

N-of-M anti-pattern — the explicit form was the established target shape in the codebase.

## Fix

\`\`\`diff
match e.Audit_log.outcome with
| Audit_log.Failure _ -> true
- | _ -> false
+ | Audit_log.Success -> false
\`\`\`

Behavior preserving. OCaml warning 8 now surfaces a future `Audit_log.outcome` variant addition at compile time.

## 3-axis cross-check (iter #26 protocol)

1. main repo working tree synced — HEAD `768a61cca`
2. Open PRs (#14864/#14865/#14758/#14718/#14866) — none touch `lib/governance_anomaly.ml`
3. Recently merged in 48h — none touch `lib/governance_anomaly.ml` or `lib/audit_log.ml`

## Verification

- `dune build @lib/check --root .` exit 0
- `git diff --stat`: 1 file, +1 −1