### PR TITLE
fix(dashboard_oas_bridge): make cancels fold status match exhaustive (intra-module N-of-M)

### DIFF
--- a/lib/dashboard/dashboard_oas_bridge.ml
+++ b/lib/dashboard/dashboard_oas_bridge.ml
@@ -416,7 +416,9 @@ let summary ?provider ?limit () =
       let cancels =
         List.fold_left
           (fun acc (s, _) ->
-            match s.status with Cancelled _ -> acc + 1 | _ -> acc)
+            match s.status with
+            | Cancelled _ -> acc + 1
+            | Success | Error _ | Timeout -> acc)
           0 xs
       in
       {


### PR DESCRIPTION
## Why

Same file, same module, same fold-over-status pattern — but inconsistent style. L411-413 of `lib/dashboard/dashboard_oas_bridge.ml` already enumerates all 4 status variants explicitly:

\`\`\`ocaml
match s.status with
| Error _ | Timeout -> acc + 1
| Success | Cancelled _ -> acc
\`\`\`

But L416-420 used `_ -> acc` catch-all:

\`\`\`ocaml
match s.status with Cancelled _ -> acc + 1 | _ -> acc
\`\`\`

Intra-module N-of-M — the established target shape was right next to it.

## Fix

\`\`\`ocaml
match s.status with
| Cancelled _ -> acc + 1
| Success | Error _ | Timeout -> acc
\`\`\`

Behavior preserving under current 4-variant type. OCaml warning 8 surfaces any future variant addition at compile time.

## 3-axis cross-check (iter #26 protocol)

1. main repo working tree synced — HEAD `768a61cca`
2. Open PRs (#14864/#14865/#14758/#14718/#14866/#14868) — none touch `lib/dashboard/dashboard_oas_bridge.ml`
3. Recently merged in 48h — none

## Verification

- `dune build @lib/check --root .` exit 0
- `git diff --stat`: 1 file, +3 −1