### PR TITLE
perf(telemetry_eio): O(N) set-difference for count_active_agents + count_tasks_in_progress

### DIFF
--- a/lib/telemetry_eio.ml
+++ b/lib/telemetry_eio.ml
@@ -303,37 +303,58 @@ let read_events_since ?fs config ~since : event_record list =
   List.filter (fun r -> r.timestamp >= since) all
 
 (** Metrics calculation functions (pure) *)
+
+(* Count distinct elements in [present_set] that are not in [absent_set] —
+   shared kernel for [count_active_agents] (joined \ left) and
+   [count_tasks_in_progress] (started \ completed).  Each event list is
+   walked once into a Hashtbl, then the second pass filters and counts.
+   Replaces the previous O(N x M) [List.filter ... List.mem] + O(N log N)
+   [List.sort_uniq] pipeline with two linear passes. *)
+let count_distinct_set_difference
+    (events : event_record list)
+    ~(present : event_record -> string option)
+    ~(absent : event_record -> string option)
+    : int =
+  let absent_set : (string, unit) Hashtbl.t = Hashtbl.create 16 in
+  let present_set : (string, unit) Hashtbl.t = Hashtbl.create 16 in
+  List.iter (fun r ->
+    (match absent r with
+     | Some id -> Hashtbl.replace absent_set id ()
+     | None -> ());
+    match present r with
+    | Some id -> Hashtbl.replace present_set id ()
+    | None -> ()
+  ) events;
+  Hashtbl.fold
+    (fun id () acc -> if Hashtbl.mem absent_set id then acc else acc + 1)
+    present_set
+    0
+
 let count_active_agents events =
-  let joined = List.filter_map (fun r ->
-    match r.event with
-    | Agent_joined { agent_id; _ } -> Some agent_id
-    | Agent_left _ | Task_started _ | Task_completed _ | Handoff_triggered _
-    | Error_occurred _ | Tool_called _ | Tool_assigned _ -> None
-  ) events in
-  let left = List.filter_map (fun r ->
-    match r.event with
-    | Agent_left { agent_id; _ } -> Some agent_id
-    | Agent_joined _ | Task_started _ | Task_completed _ | Handoff_triggered _
-    | Error_occurred _ | Tool_called _ | Tool_assigned _ -> None
-  ) events in
-  let active = List.filter (fun id -> not (List.mem id left)) joined in
-  List.length (List.sort_uniq String.compare active)
+  count_distinct_set_difference events
+    ~present:(fun r ->
+      match r.event with
+      | Agent_joined { agent_id; _ } -> Some agent_id
+      | Agent_left _ | Task_started _ | Task_completed _ | Handoff_triggered _
+      | Error_occurred _ | Tool_called _ | Tool_assigned _ -> None)
+    ~absent:(fun r ->
+      match r.event with
+      | Agent_left { agent_id; _ } -> Some agent_id
+      | Agent_joined _ | Task_started _ | Task_completed _ | Handoff_triggered _
+      | Error_occurred _ | Tool_called _ | Tool_assigned _ -> None)
 
 let count_tasks_in_progress events =
-  let started = List.filter_map (fun r ->
-    match r.event with
-    | Task_started { task_id; _ } -> Some task_id
-    | Agent_joined _ | Agent_left _ | Task_completed _ | Handoff_triggered _
-    | Error_occurred _ | Tool_called _ | Tool_assigned _ -> None
-  ) events in
-  let completed = List.filter_map (fun r ->
-    match r.event with
-    | Task_completed { task_id; _ } -> Some task_id
-    | Agent_joined _ | Agent_left _ | Task_started _ | Handoff_triggered _
-    | Error_occurred _ | Tool_called _ | Tool_assigned _ -> None
-  ) events in
-  let in_progress = List.filter (fun id -> not (List.mem id completed)) started in
-  List.length (List.sort_uniq String.compare in_progress)
+  count_distinct_set_difference events
+    ~present:(fun r ->
+      match r.event with
+      | Task_started { task_id; _ } -> Some task_id
+      | Agent_joined _ | Agent_left _ | Task_completed _ | Handoff_triggered _
+      | Error_occurred _ | Tool_called _ | Tool_assigned _ -> None)
+    ~absent:(fun r ->
+      match r.event with
+      | Task_completed { task_id; _ } -> Some task_id
+      | Agent_joined _ | Agent_left _ | Task_started _ | Handoff_triggered _
+      | Error_occurred _ | Tool_called _ | Tool_assigned _ -> None)
 
 let count_completed_tasks events =
   List_util.count_if (fun r ->


### PR DESCRIPTION
## Summary
`count_active_agents` and `count_tasks_in_progress` shared a worst-case **O(N²)** pipeline for what is fundamentally a set-difference cardinality:

```ocaml
let present  = List.filter_map ... events in           (* O(N) *)
let absent   = List.filter_map ... events in           (* O(N) *)
let kept     = List.filter (fun id ->                  (* O(P × A) ← *)
                 not (List.mem id absent)) present in
List.length (List.sort_uniq String.compare kept)       (* O(P log P) *)
```

For sessions with thousands of events the inner `List.mem` and the trailing `sort_uniq` dominate, and the result is just an `int`.

## Change
Factor out `count_distinct_set_difference` that walks `events` **once**, populating two `(string, unit) Hashtbl.t`s via the supplied projectors, then folds the `present` Hashtbl counting members not in `absent`. Net: **O(N)** total, no list intermediates, no sort.

`count_active_agents` and `count_tasks_in_progress` collapse to two `~present` / `~absent` callbacks; the event-variant matches are preserved verbatim so the unit-test contract holds (`test_telemetry_eio_coverage.ml` — empty, one_joined, joined_then_left, multiple, plus parallel cases for tasks).

## Surface
- `lib/telemetry_eio.ml` only.
- `lib/telemetry_eio.mli` unchanged — `count_distinct_set_difference` stays internal.
- No test edits. The existing 7 telemetry coverage tests pin the semantics.

## Test plan
- [x] `lib/telemetry_eio.ml` compiles standalone
- [ ] CI green — existing `test_telemetry_eio_coverage.ml` re-runs on the new implementation

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>