### PR TITLE
feat(rfc-0070): Phase 3b-iv.2.4 — Real Docker_client.ps_query + JSON parser (series closure)

### DIFF
--- a/lib/keeper/docker_client_real.ml
+++ b/lib/keeper/docker_client_real.ml
@@ -19,6 +19,7 @@
 let map_exit_status_for_rm (status : Unix.process_status) =
   match status with
   | Unix.WEXITED 0 -> Ok ()
+  | Unix.WEXITED 124 -> Error Docker_client.Exec_timeout
   | Unix.WEXITED 127 -> Error Docker_client.Daemon_unreachable
   | Unix.WEXITED _ -> Error Docker_client.Cleanup_failed
   | Unix.WSIGNALED _ | Unix.WSTOPPED _ -> Error Docker_client.Daemon_unreachable
@@ -33,6 +34,7 @@ let map_status_to_exec_result
       Unix.process_status * string * string)
   =
   match status with
+  | Unix.WEXITED 124 -> Error Docker_client.Exec_timeout
   | Unix.WEXITED 125 | Unix.WEXITED 127 ->
     Error Docker_client.Daemon_unreachable
   | Unix.WEXITED code ->
@@ -131,6 +133,7 @@ let ps_query ~labels =
   in
   match status with
   | Unix.WEXITED 0 -> Ok (parse_ps_output stdout)
+  | Unix.WEXITED 124 -> Error Docker_client.Exec_timeout
   | Unix.WEXITED 125 | Unix.WEXITED 127 ->
     Error Docker_client.Daemon_unreachable
   | Unix.WEXITED _ -> Error Docker_client.Probe_format_drift

--- a/lib/keeper/docker_client_real.ml
+++ b/lib/keeper/docker_client_real.ml
@@ -1,15 +1,10 @@
-(* RFC-0070 Phase 3b-iv.2.3 — Real Docker_client (rm + exec + run wired).
+(* RFC-0070 Phase 3b-iv.2.4 — Real Docker_client (all 4 functions wired).
 
    Sub-phase 3b-iv.2.0 shipped placeholders for all four S functions.
-   Sub-phase 3b-iv.2.1 wired [rm] (#14844); 3b-iv.2.2 wired [exec]
-   (#14854); 3b-iv.2.3 (this) wires [run]. Only [ps_query] remains a
-   placeholder pending 3b-iv.2.4.
-
-   The signature is unchanged across sub-phases — callers see a typed
-   [(_, sandbox_error) result] regardless of which function bodies are
-   real yet. *)
-
-let placeholder = Error Docker_client.Cleanup_failed
+   Sub-phases 3b-iv.2.{1,2,3} wired [rm] (#14844), [exec] (#14854),
+   and [run] (#14862). Sub-phase 3b-iv.2.4 (this) wires [ps_query] +
+   the JSON parser for [docker ps --format '\{\{json .\}\}'] output.
+   Phase 3b-iv.2 series closes here. *)
 
 (* ── Exit-status mapping helpers ─────────────────────────────── *)
 
@@ -32,12 +27,7 @@ let map_exit_status_for_rm (status : Unix.process_status) =
    both return the executed *command's* exit code on success; only
    daemon-level statuses (125, 127, signal) surface as
    [Error Daemon_unreachable]. A non-zero command exit is a *response*
-   ([Ok exec_result]), not a daemon error.
-
-   Shared between [exec] and [run] because both produce
-   {!Docker_response.exec_result} on success; the host process IS the
-   docker CLI, and its [WEXITED n] reflects what docker reported about
-   the containerized command. *)
+   ([Ok exec_result]), not a daemon error. *)
 let map_status_to_exec_result
     ((status, stdout, stderr) :
       Unix.process_status * string * string)
@@ -50,9 +40,102 @@ let map_status_to_exec_result
   | Unix.WSIGNALED _ | Unix.WSTOPPED _ ->
     Error Docker_client.Daemon_unreachable
 
+(* ── JSON parsing helpers for ps_query ───────────────────────── *)
+
+(* [parse_labels "k1=v1,k2=v2"] returns [[("k1","v1"); ("k2","v2")]].
+   Empty input maps to []. Tokens without '=' are dropped. Docker emits
+   labels as a single comma-joined string in [docker ps --format].
+
+   Order-preserving — the parsed list mirrors docker's emission order.
+   {!Docker_response.equal_ps_record} treats label order as
+   significant; canonical ordering is a higher-level concern (e.g.
+   sort by key) the parser does NOT impose here. *)
+let parse_labels (s : string) : (string * string) list =
+  if String.equal s "" then []
+  else
+    let parts = String.split_on_char ',' s in
+    List.filter_map
+      (fun part ->
+        match String.index_opt part '=' with
+        | None -> None
+        | Some i ->
+          let k = String.sub part 0 i in
+          let v = String.sub part (i + 1) (String.length part - i - 1) in
+          Some (k, v))
+      parts
+
+(* Required-only subset of docker's ps JSON line. [@@deriving
+   yojson { strict = false }] tolerates unknown fields like
+   [CreatedAt], [Status], [Ports] without failure. *)
+type raw_ps_record =
+  { id : string [@key "ID"]
+  ; names : string [@key "Names"]
+  ; state : string [@key "State"]
+  ; labels : string [@key "Labels"]
+  }
+[@@deriving yojson { strict = false }]
+
+(* [parse_ps_line line] decodes one JSON-formatted [docker ps] line
+   into a {!Docker_response.ps_record}. Returns [None] when the line
+   is empty, fails to decode as JSON, fails to match the required
+   schema, or carries an unknown [State] token — every drop is
+   *opportunistic*; the caller (ps_query) silently skips. This is
+   the documented compromise between RFC §3.3 "no permissive default"
+   and the operational reality that [docker ps] can emit stray output
+   under unusual conditions (e.g. warning lines on stderr leaking into
+   stdout under specific BuildKit configurations); a single
+   unparseable line should NOT collapse the entire fleet listing. *)
+let parse_ps_line (line : string) : Docker_response.ps_record option =
+  let trimmed = String.trim line in
+  if String.equal trimmed "" then None
+  else
+    match Yojson.Safe.from_string trimmed with
+    | exception Yojson.Json_error _ -> None
+    | json ->
+      (match raw_ps_record_of_yojson json with
+       | Error _ -> None
+       | Ok raw ->
+         (match Docker_response.parse_state raw.state with
+          | Error _ -> None
+          | Ok status ->
+            Some
+              Docker_response.
+                { id = raw.id
+                ; name = Keeper_container_name.of_external_string raw.names
+                ; status
+                ; labels = parse_labels raw.labels
+                }))
+
+(* [parse_ps_output stdout] splits stdout by newline and parses each
+   line. Unparseable lines are silently dropped (see [parse_ps_line]'s
+   rationale). *)
+let parse_ps_output (stdout : string) : Docker_response.ps_record list =
+  String.split_on_char '\n' stdout |> List.filter_map parse_ps_line
+
+(* [labels_to_filter_args] folds each [(k, v)] into a [--filter
+   label=k=v] pair on the argv, suitable for [docker ps]. *)
+let labels_to_filter_args (labels : (string * string) list) : string list =
+  List.concat_map
+    (fun (k, v) -> [ "--filter"; Printf.sprintf "label=%s=%s" k v ])
+    labels
+
 (* ── Functions ───────────────────────────────────────────────── *)
 
-let ps_query ~labels:_ = placeholder
+let ps_query ~labels =
+  let argv =
+    [ "docker"; "ps"; "-a"; "--format"; "{{json .}}" ]
+    @ labels_to_filter_args labels
+  in
+  let status, stdout, _stderr =
+    Process_eio.run_argv_with_status_split argv
+  in
+  match status with
+  | Unix.WEXITED 0 -> Ok (parse_ps_output stdout)
+  | Unix.WEXITED 125 | Unix.WEXITED 127 ->
+    Error Docker_client.Daemon_unreachable
+  | Unix.WEXITED _ -> Error Docker_client.Probe_format_drift
+  | Unix.WSIGNALED _ | Unix.WSTOPPED _ ->
+    Error Docker_client.Daemon_unreachable
 
 let exec ~container ~cmd =
   let argv =
@@ -64,9 +147,6 @@ let exec ~container ~cmd =
     ; cmd
     ]
   in
-  (* [Process_eio.run_argv_with_status_split] returns
-     [(status, stdout, stderr)]; on spawn failure the status is
-     synthesized as [WEXITED 127] (see 3b-iv.2.1 commit on rm). *)
   map_status_to_exec_result (Process_eio.run_argv_with_status_split argv)
 
 let run plan =
@@ -76,12 +156,6 @@ let run plan =
   let image = Keeper_sandbox_plan.image plan in
   let command = Keeper_sandbox_plan.command plan in
   let timeout_sec = Keeper_sandbox_plan.timeout_budget_sec plan in
-  (* [docker run --rm --name <name> <image> sh -lc <cmd>].
-     [--rm] removes the container after exit (Phase 3b-iii default
-     cleanup strategy — RFC §3.1's spec deferred a typed cleanup
-     policy to a follow-up RFC). [sh -lc] mirrors [exec]'s wrapping
-     so caller-passed [cmd] strings work identically across both
-     functions. *)
   let argv =
     [ "docker"
     ; "run"

--- a/lib/keeper/docker_client_real.ml
+++ b/lib/keeper/docker_client_real.ml
@@ -1,10 +1,11 @@
-(* RFC-0070 Phase 3b-iv.2.4 — Real Docker_client (all 4 functions wired).
+(* RFC-0070 Phase 3b-iv.2.5 — Real Docker_client (parser extracted).
 
    Sub-phase 3b-iv.2.0 shipped placeholders for all four S functions.
-   Sub-phases 3b-iv.2.{1,2,3} wired [rm] (#14844), [exec] (#14854),
-   and [run] (#14862). Sub-phase 3b-iv.2.4 (this) wires [ps_query] +
-   the JSON parser for [docker ps --format '\{\{json .\}\}'] output.
-   Phase 3b-iv.2 series closes here. *)
+   Sub-phases 3b-iv.2.{1,2,3,4} wired [rm] (#14844), [exec] (#14854),
+   [run] (#14862), and [ps_query]+JSON parser (#14871). Sub-phase
+   3b-iv.2.5 (this) extracts the JSON parser to {!Docker_ps_parser}
+   so each silent-drop path is exercised by unit tests with
+   synthetic JSON fixtures. *)
 
 (* ── Exit-status mapping helpers ─────────────────────────────── *)
 
@@ -40,82 +41,9 @@ let map_status_to_exec_result
   | Unix.WSIGNALED _ | Unix.WSTOPPED _ -> Error Docker_client.Daemon_unreachable
 ;;
 
-(* ── JSON parsing helpers for ps_query ───────────────────────── *)
-
-(* [parse_labels "k1=v1,k2=v2"] returns [[("k1","v1"); ("k2","v2")]].
-   Empty input maps to []. Tokens without '=' are dropped. Docker emits
-   labels as a single comma-joined string in [docker ps --format].
-
-   Order-preserving — the parsed list mirrors docker's emission order.
-   {!Docker_response.equal_ps_record} treats label order as
-   significant; canonical ordering is a higher-level concern (e.g.
-   sort by key) the parser does NOT impose here. *)
-let parse_labels (s : string) : (string * string) list =
-  if String.equal s ""
-  then []
-  else (
-    let parts = String.split_on_char ',' s in
-    List.filter_map
-      (fun part ->
-         match String.index_opt part '=' with
-         | None -> None
-         | Some i ->
-           let k = String.sub part 0 i in
-           let v = String.sub part (i + 1) (String.length part - i - 1) in
-           Some (k, v))
-      parts)
-;;
-
-(* Required-only subset of docker's ps JSON line. [@@deriving
-   yojson { strict = false }] tolerates unknown fields like
-   [CreatedAt], [Status], [Ports] without failure. *)
-type raw_ps_record =
-  { id : string [@key "ID"]
-  ; names : string [@key "Names"]
-  ; state : string [@key "State"]
-  ; labels : string [@key "Labels"]
-  }
-[@@deriving yojson { strict = false }]
-
-(* [parse_ps_line line] decodes one JSON-formatted [docker ps] line
-   into a {!Docker_response.ps_record}. Returns [None] when the line
-   is empty, fails to decode as JSON, fails to match the required
-   schema, or carries an unknown [State] token — every drop is
-   *opportunistic*; the caller (ps_query) silently skips. This is
-   the documented compromise between RFC §3.3 "no permissive default"
-   and the operational reality that [docker ps] can emit stray output
-   under unusual conditions (e.g. warning lines on stderr leaking into
-   stdout under specific BuildKit configurations); a single
-   unparseable line should NOT collapse the entire fleet listing. *)
-let parse_ps_line (line : string) : Docker_response.ps_record option =
-  let trimmed = String.trim line in
-  if String.equal trimmed ""
-  then None
-  else (
-    match Yojson.Safe.from_string trimmed with
-    | exception Yojson.Json_error _ -> None
-    | json ->
-      (match raw_ps_record_of_yojson json with
-       | Error _ -> None
-       | Ok raw ->
-         (match Docker_response.parse_state raw.state with
-          | Error _ -> None
-          | Ok status ->
-            Some
-              Docker_response.
-                { id = raw.id
-                ; name = Keeper_container_name.of_external_string raw.names
-                ; status
-                ; labels = parse_labels raw.labels
-                })))
-;;
-
-(* [parse_ps_output stdout] splits stdout by newline and parses each
-   line. Unparseable lines are silently dropped (see [parse_ps_line]'s
-   rationale). *)
-let parse_ps_output (stdout : string) : Docker_response.ps_record list =
-  String.split_on_char '\n' stdout |> List.filter_map parse_ps_line
-;;
+(* JSON parsing helpers extracted to {!Docker_ps_parser} so each
+   silent-drop path is testable via synthetic JSON fixtures. See
+   that module's .mli for the surface and trade-off rationale. *)
 
 (* [labels_to_filter_args] folds each [(k, v)] into a [--filter
    label=k=v] pair on the argv, suitable for [docker ps]. *)
@@ -131,7 +59,7 @@ let ps_query ~labels =
   in
   let status, stdout, _stderr = Process_eio.run_argv_with_status_split argv in
   match status with
-  | Unix.WEXITED 0 -> Ok (parse_ps_output stdout)
+  | Unix.WEXITED 0 -> Ok (Docker_ps_parser.parse_output stdout)
   | Unix.WEXITED 124 -> Error Docker_client.Exec_timeout
   | Unix.WEXITED 125 | Unix.WEXITED 127 -> Error Docker_client.Daemon_unreachable
   | Unix.WEXITED _ -> Error Docker_client.Probe_format_drift

--- a/lib/keeper/docker_client_real.mli
+++ b/lib/keeper/docker_client_real.mli
@@ -1,11 +1,15 @@
-(** RFC-0070 Phase 3b-iv.2.3 — Real {!Docker_client.S}
-    ([rm] + [exec] + [run] wired).
+(** RFC-0070 Phase 3b-iv.2.4 — Real {!Docker_client.S} (all 4 functions wired).
 
     Phase 3a's stub kept [Docker_client.S] as a *signature only*. Phase
-    3b-iv.1b added [Docker_client_mock] for tests. Phase 3b-iv.2.0
-    added the *production* skeleton. Phase 3b-iv.2.1 (#14844) wired
-    [rm]; 3b-iv.2.2 (#14854) wired [exec]; 3b-iv.2.3 (this) wires
-    [run]. Only [ps_query] remains a placeholder pending 3b-iv.2.4.
+    3b-iv.1b added [Docker_client_mock] for tests. Phase 3b-iv.2.0 added
+    the *production* skeleton. Phase 3b-iv.2.1 (#14844) wired [rm];
+    3b-iv.2.2 (#14854) wired [exec]; 3b-iv.2.3 (#14862) wired [run];
+    Phase 3b-iv.2.4 (this) wires [ps_query] + the JSON parser.
+
+    **Phase 3b-iv.2 series closes here**: all four [S] functions are
+    real spawns. Production callers parameterising on
+    [(module Docker_client.S)] can now swap in this module without
+    placeholder branches.
 
     Reference: docs/rfc/RFC-0070-keeper-sandbox-pure-edge-separation.md §3.2
 
@@ -46,15 +50,31 @@
       flag removes the container after exit (RFC §3.1's interim
       default cleanup; a typed cleanup-policy field on
       {!Keeper_sandbox_plan.t} is deferred to a follow-up RFC).
-    - [ps_query] — still [Error Cleanup_failed] placeholder pending
-      3b-iv.2.4 (JSON parser for
-      [docker ps --format '\{\{json .\}\}']).
+    - [ps_query] — wired: spawns
+      [docker ps -a --format '\{\{json .\}\}' --filter label=k=v ...]
+      via [Process_eio.run_argv_with_status_split], then parses each
+      stdout line as one {!Docker_response.ps_record}. Status mapping:
+      {ul
+        {- [WEXITED 0] → [Ok records] (records is a possibly-empty
+           list — unparseable lines are dropped silently; see the
+           [parse_ps_line] inline comment for the operational
+           rationale)}
+        {- [WEXITED 125] / [WEXITED 127] / signal / stopped →
+           [Error Daemon_unreachable]}
+        {- any other [WEXITED n] → [Error Probe_format_drift]
+           (docker ps reported a non-zero exit without daemon signals
+           — usually an argv-shape mismatch with the installed docker
+           version)}}
+      The unparseable-line silent drop is the documented compromise
+      between RFC §3.3 "no permissive default" and operational
+      reality: a single stray output line should NOT collapse fleet
+      listing for the cleanup loop.
 
-    **Why a placeholder skeleton and not [failwith]**: returning
-    [Error Cleanup_failed] keeps the signature in {!result}; a caller
-    that wires Real before Phase 3b-iv.2.{1,2,3,4} land will receive a
-    typed failure they can pattern-match on, not an exception that
+    **Why the original placeholder skeleton mattered**: returning
+    [Error Cleanup_failed] kept the signature in {!result}; callers
+    wiring Real *before* the impl sub-phases landed received a typed
+    failure they could pattern-match on, not an exception that
     surfaces as a crash. RFC-0070's "no silent failure, no exception
-    leak" contract is preserved. *)
+    leak" contract preserved across the whole series. *)
 
 include Docker_client.S

--- a/lib/keeper/docker_client_real.mli
+++ b/lib/keeper/docker_client_real.mli
@@ -18,6 +18,9 @@
       [Process_eio.run_argv_with_status]. Exit-status mapping:
       {ul
         {- [WEXITED 0] → [Ok ()]}
+        {- [WEXITED 124] (synthesised by [Process_eio] when
+           [?timeout_sec] elapses before the child exits) →
+           [Error Exec_timeout]}
         {- [WEXITED 127] (spawn failure: docker CLI missing or exec
            error) → [Error Daemon_unreachable]}
         {- any other [WEXITED n] → [Error Cleanup_failed]}
@@ -32,12 +35,16 @@
       distinction vs [rm] matters: a non-zero exit *inside the
       container* is the *command's* result, returned as
       [Ok exec_result { exit_code = n; stdout; stderr }] — not a
-      daemon error. Only daemon-level statuses become
+      daemon error. Daemon-level statuses become
       [Error Daemon_unreachable]:
       {ul
         {- [WEXITED 125] (daemon error)}
         {- [WEXITED 127] (docker CLI missing / spawn failure)}
         {- [WSIGNALED _] / [WSTOPPED _]}}
+      [WEXITED 124] (synthesised by [Process_eio] on timeout) surfaces
+      as [Error Exec_timeout] — it would be misleading to return
+      [Ok exec_result { exit_code = 124 }] for a request that never
+      actually ran to completion inside the container.
       All other [WEXITED n] values surface as
       [Ok { exit_code = n; stdout; stderr }].
     - [run] — wired: spawns
@@ -59,6 +66,7 @@
            list — unparseable lines are dropped silently; see the
            [parse_ps_line] inline comment for the operational
            rationale)}
+        {- [WEXITED 124] (Process_eio timeout) → [Error Exec_timeout]}
         {- [WEXITED 125] / [WEXITED 127] / signal / stopped →
            [Error Daemon_unreachable]}
         {- any other [WEXITED n] → [Error Probe_format_drift]

--- a/lib/keeper/docker_ps_parser.ml
+++ b/lib/keeper/docker_ps_parser.ml
@@ -1,0 +1,58 @@
+(* RFC-0070 Phase 3b-iv.2.5 — pure parser for docker ps JSON output.
+   See .mli for the public surface and the silent-drop trade-off
+   rationale. Extracted unchanged from docker_client_real.ml (Phase
+   3b-iv.2.4 / #14871). *)
+
+let parse_labels (s : string) : (string * string) list =
+  if String.equal s ""
+  then []
+  else (
+    let parts = String.split_on_char ',' s in
+    List.filter_map
+      (fun part ->
+         match String.index_opt part '=' with
+         | None -> None
+         | Some i ->
+           let k = String.sub part 0 i in
+           let v = String.sub part (i + 1) (String.length part - i - 1) in
+           Some (k, v))
+      parts)
+;;
+
+(* Required-only subset of docker's ps JSON line. [@@deriving
+   yojson { strict = false }] tolerates unknown fields like
+   [CreatedAt], [Status], [Ports] without failure. *)
+type raw_ps_record =
+  { id : string [@key "ID"]
+  ; names : string [@key "Names"]
+  ; state : string [@key "State"]
+  ; labels : string [@key "Labels"]
+  }
+[@@deriving yojson { strict = false }]
+
+let parse_line (line : string) : Docker_response.ps_record option =
+  let trimmed = String.trim line in
+  if String.equal trimmed ""
+  then None
+  else (
+    match Yojson.Safe.from_string trimmed with
+    | exception Yojson.Json_error _ -> None
+    | json ->
+      (match raw_ps_record_of_yojson json with
+       | Error _ -> None
+       | Ok raw ->
+         (match Docker_response.parse_state raw.state with
+          | Error _ -> None
+          | Ok status ->
+            Some
+              Docker_response.
+                { id = raw.id
+                ; name = Keeper_container_name.of_external_string raw.names
+                ; status
+                ; labels = parse_labels raw.labels
+                })))
+;;
+
+let parse_output (stdout : string) : Docker_response.ps_record list =
+  String.split_on_char '\n' stdout |> List.filter_map parse_line
+;;

--- a/lib/keeper/docker_ps_parser.mli
+++ b/lib/keeper/docker_ps_parser.mli
@@ -1,0 +1,61 @@
+(** RFC-0070 Phase 3b-iv.2.5 — pure parser for [docker ps --format '\{\{json .\}\}'] output.
+
+    Extracted from {!Docker_client_real} so the parser surface can be
+    exercised directly by hermetic unit tests with synthetic JSON
+    fixtures (no docker daemon dependency). Phase 3b-iv.2.4 (#14871)
+    left these helpers [private] in [docker_client_real.ml]; this PR
+    promotes them to a typed boundary so each silent-drop path
+    (empty / Yojson.Json_error / schema-mismatch / unknown State) is
+    individually testable.
+
+    {!Docker_client_real.ps_query} now delegates to {!parse_output};
+    no other production caller is intended.
+
+    Reference: docs/rfc/RFC-0070-keeper-sandbox-pure-edge-separation.md §3.3 *)
+
+(** [parse_labels s] decodes docker's comma-joined label string
+    [["k1=v1,k2=v2"]] into an association list.
+
+    - Empty input → [[]].
+    - Tokens without ['='] → dropped (no [Some (k, "")] permissive
+      default; the absence of a key/value separator is parser-defined
+      noise, not a typed value).
+    - Order-preserving: the result mirrors docker's emission order.
+      Canonical re-ordering (e.g. sort by key) is the caller's
+      responsibility — {!Docker_response.equal_ps_record} treats
+      label order as significant. *)
+val parse_labels : string -> (string * string) list
+
+(** [parse_line line] decodes one JSON-formatted [docker ps] line
+    into a {!Docker_response.ps_record}.
+
+    Returns [None] when *any* of the four enumerated failure paths
+    fires:
+    + [line] is empty (after [String.trim])
+    + [line] is not valid JSON (Yojson raises [Json_error])
+    + [line] is valid JSON but does not satisfy the required schema
+      (missing [ID] / [Names] / [State] / [Labels])
+    + [line] is schema-valid but carries an unknown [State] token
+      (one that {!Docker_response.parse_state} rejects)
+
+    All four are *deliberate silent drops* — RFC §3.3 documented
+    trade-off. They are *enumerated*, not a catch-all [_ -> None]:
+    every code path is reachable and individually exercisable by
+    {!test_docker_ps_parser}.
+
+    The [Names] string is wrapped via
+    {!Keeper_container_name.of_external_string} — *unsafe*. docker
+    may emit container names that did not originate from
+    {!Keeper_container_name.derive}, and the parser does not enforce
+    the [masc-keeper-] prefix invariant. The result is opaque to the
+    parser; downstream consumers that need the prefix invariant must
+    re-validate. *)
+val parse_line : string -> Docker_response.ps_record option
+
+(** [parse_output stdout] splits stdout by ['\n'] and parses each
+    line via {!parse_line}, dropping [None] results. The cumulative
+    silent-drop count is *not* reported — observability is the
+    consumer's responsibility (see RFC §3.3 follow-up note re:
+    [masc_docker_ps_parse_drop_total] counter, if it becomes
+    operationally noisy). *)
+val parse_output : string -> Docker_response.ps_record list

--- a/lib/keeper/keeper_container_name.ml
+++ b/lib/keeper/keeper_container_name.ml
@@ -24,6 +24,8 @@ let derive ~algo ~turn_id ~attempt ~suffix =
 
 let to_string t = t
 
+let of_external_string s = s
+
 let equal = String.equal
 
 let pp ppf t = Format.pp_print_string ppf t

--- a/lib/keeper/keeper_container_name.mli
+++ b/lib/keeper/keeper_container_name.mli
@@ -40,6 +40,21 @@ val derive
     to [docker run --name <to_string t> ...]. *)
 val to_string : t -> string
 
+(** [of_external_string s] wraps an arbitrary [string] as a
+    {!t} *without validation*. Intended for parsing output emitted by
+    an external source (e.g. [docker ps] [Names] field) where the
+    consumer treats the value as opaque and never decomposes the
+    format. **Not** suitable for callers that construct names — they
+    must use {!derive} so the format invariant is enforced.
+
+    The unchecked wrap is acceptable here because:
+    - Phase 3b-iv.2.4 reads docker's container [Names] field and the
+      caller (cleanup / quarantine) only round-trips the value back
+      into [docker rm <name>] without parsing.
+    - Wrapping at the type-system level still segregates "name from
+      docker" from "arbitrary string" in caller code. *)
+val of_external_string : string -> t
+
 (** [equal] / [pp] for property tests and dashboards. *)
 val equal : t -> t -> bool
 

--- a/test/dune
+++ b/test/dune
@@ -596,6 +596,7 @@
         test_docker_response
         test_docker_client_mock
         test_docker_client_real
+        test_docker_ps_parser
         test_sandbox_executor
         test_keeper_backoff_policy
         test_worker_runtime
@@ -813,6 +814,7 @@
         test_docker_response
         test_docker_client_mock
         test_docker_client_real
+        test_docker_ps_parser
         test_sandbox_executor
         test_keeper_backoff_policy
         test_worker_runtime

--- a/test/test_docker_client_real.ml
+++ b/test/test_docker_client_real.ml
@@ -86,10 +86,25 @@ let test_exec_returns_typed_result () =
   | Error Docker_client.Probe_format_drift ->
     fail "exec should only surface Ok exec_result or Error Daemon_unreachable"
 
-let test_ps_query_placeholder () =
-  match Docker_client_real.ps_query ~labels:[] with
-  | Error Docker_client.Cleanup_failed -> ()
-  | _ -> fail "expected Cleanup_failed placeholder"
+(* Phase 3b-iv.2.4 — ps_query is no longer a placeholder. It spawns
+   [docker ps -a --format '{{json .}}' --filter ...] and parses each
+   line. The test environment may or may not have a docker daemon, so
+   we only assert the *typed* contract:
+   - Ok records (daemon present; list may be empty)
+   - Error Daemon_unreachable (daemon / CLI missing)
+   - Error Probe_format_drift (docker ps exit non-zero without daemon
+     signal — unusual but defined)
+   Other sandbox_error variants must NOT surface. *)
+let test_ps_query_returns_typed_result () =
+  match Docker_client_real.ps_query ~labels:[ "masc.keeper.test", "alice" ] with
+  | Ok _ -> ()
+  | Error Docker_client.Daemon_unreachable -> ()
+  | Error Docker_client.Probe_format_drift -> ()
+  | Error Docker_client.Cleanup_failed
+  | Error Docker_client.Image_pull_failed
+  | Error Docker_client.Container_oom
+  | Error Docker_client.Exec_timeout ->
+    fail "ps_query should only surface Ok | Daemon_unreachable | Probe_format_drift"
 
 (* Phase 3b-iv.2.1 — rm is no longer a placeholder; it spawns
    [docker rm -f <name>]. The test environment may or may not have a
@@ -122,7 +137,7 @@ let test_executor_with_real_returns_typed_result () =
     fail "executor with Real should only surface Ok or Daemon_unreachable"
 
 let () =
-  run "Docker_client_real (Phase 3b-iv.2.3)"
+  run "Docker_client_real (Phase 3b-iv.2.4 — all 4 functions wired)"
     [
       ( "S placeholder",
         [
@@ -132,7 +147,9 @@ let () =
           test_case "exec → Ok exec_result | Error Daemon_unreachable"
             `Quick
             test_exec_returns_typed_result;
-          test_case "ps_query → Cleanup_failed" `Quick test_ps_query_placeholder;
+          test_case "ps_query → Ok records | Daemon_unreachable | Probe_format_drift"
+            `Quick
+            test_ps_query_returns_typed_result;
           test_case "rm → typed error (Daemon_unreachable | Cleanup_failed)"
             `Quick
             test_rm_returns_typed_error;

--- a/test/test_docker_client_real.ml
+++ b/test/test_docker_client_real.ml
@@ -59,12 +59,12 @@ let test_run_returns_typed_result () =
   match Docker_client_real.run (sample_plan ()) with
   | Ok _ -> ()                                     (* daemon present *)
   | Error Docker_client.Daemon_unreachable -> ()   (* daemon / CLI missing *)
+  | Error Docker_client.Exec_timeout -> ()         (* WEXITED 124 — Process_eio timeout *)
   | Error Docker_client.Cleanup_failed
   | Error Docker_client.Image_pull_failed
   | Error Docker_client.Container_oom
-  | Error Docker_client.Exec_timeout
   | Error Docker_client.Probe_format_drift ->
-    fail "run should only surface Ok exec_result or Error Daemon_unreachable"
+    fail "run should only surface Ok | Daemon_unreachable | Exec_timeout"
 
 (* Phase 3b-iv.2.2 — exec is no longer a placeholder. It spawns
    [docker exec <container> sh -lc <cmd>]. The test environment may
@@ -79,12 +79,12 @@ let test_exec_returns_typed_result () =
   with
   | Ok _ -> ()                                    (* daemon present *)
   | Error Docker_client.Daemon_unreachable -> ()  (* daemon / CLI missing *)
+  | Error Docker_client.Exec_timeout -> ()        (* WEXITED 124 — Process_eio timeout *)
   | Error Docker_client.Cleanup_failed
   | Error Docker_client.Image_pull_failed
   | Error Docker_client.Container_oom
-  | Error Docker_client.Exec_timeout
   | Error Docker_client.Probe_format_drift ->
-    fail "exec should only surface Ok exec_result or Error Daemon_unreachable"
+    fail "exec should only surface Ok | Daemon_unreachable | Exec_timeout"
 
 (* Phase 3b-iv.2.4 — ps_query is no longer a placeholder. It spawns
    [docker ps -a --format '{{json .}}' --filter ...] and parses each
@@ -100,11 +100,11 @@ let test_ps_query_returns_typed_result () =
   | Ok _ -> ()
   | Error Docker_client.Daemon_unreachable -> ()
   | Error Docker_client.Probe_format_drift -> ()
+  | Error Docker_client.Exec_timeout -> ()  (* WEXITED 124 — Process_eio timeout *)
   | Error Docker_client.Cleanup_failed
   | Error Docker_client.Image_pull_failed
-  | Error Docker_client.Container_oom
-  | Error Docker_client.Exec_timeout ->
-    fail "ps_query should only surface Ok | Daemon_unreachable | Probe_format_drift"
+  | Error Docker_client.Container_oom ->
+    fail "ps_query should only surface Ok | Daemon_unreachable | Probe_format_drift | Exec_timeout"
 
 (* Phase 3b-iv.2.1 — rm is no longer a placeholder; it spawns
    [docker rm -f <name>]. The test environment may or may not have a
@@ -114,12 +114,12 @@ let test_rm_returns_typed_error () =
   match Docker_client_real.rm (sample_container ()) with
   | Error Docker_client.Daemon_unreachable
   | Error Docker_client.Cleanup_failed -> ()  (* env-dependent path *)
+  | Error Docker_client.Exec_timeout -> ()    (* WEXITED 124 — Process_eio timeout *)
   | Ok () -> fail "unexpected Ok — derived container name should not exist on host"
   | Error Docker_client.Image_pull_failed
   | Error Docker_client.Container_oom
-  | Error Docker_client.Exec_timeout
   | Error Docker_client.Probe_format_drift ->
-    fail "rm should only surface Daemon_unreachable or Cleanup_failed"
+    fail "rm should only surface Daemon_unreachable | Cleanup_failed | Exec_timeout"
 
 (* ── Functor instantiation works with Real ───────────────────── *)
 
@@ -129,28 +129,28 @@ let test_executor_with_real_returns_typed_result () =
   match Real_executor.execute_plan (sample_plan ()) with
   | Ok _ -> ()
   | Error Docker_client.Daemon_unreachable -> ()
+  | Error Docker_client.Exec_timeout -> ()
   | Error Docker_client.Cleanup_failed
   | Error Docker_client.Image_pull_failed
   | Error Docker_client.Container_oom
-  | Error Docker_client.Exec_timeout
   | Error Docker_client.Probe_format_drift ->
-    fail "executor with Real should only surface Ok or Daemon_unreachable"
+    fail "executor with Real should only surface Ok | Daemon_unreachable | Exec_timeout"
 
 let () =
   run "Docker_client_real (Phase 3b-iv.2.4 — all 4 functions wired)"
     [
       ( "S placeholder",
         [
-          test_case "run → Ok exec_result | Error Daemon_unreachable"
+          test_case "run → Ok | Daemon_unreachable | Exec_timeout"
             `Quick
             test_run_returns_typed_result;
-          test_case "exec → Ok exec_result | Error Daemon_unreachable"
+          test_case "exec → Ok | Daemon_unreachable | Exec_timeout"
             `Quick
             test_exec_returns_typed_result;
-          test_case "ps_query → Ok records | Daemon_unreachable | Probe_format_drift"
+          test_case "ps_query → Ok | Daemon_unreachable | Probe_format_drift | Exec_timeout"
             `Quick
             test_ps_query_returns_typed_result;
-          test_case "rm → typed error (Daemon_unreachable | Cleanup_failed)"
+          test_case "rm → Daemon_unreachable | Cleanup_failed | Exec_timeout"
             `Quick
             test_rm_returns_typed_error;
         ] );

--- a/test/test_docker_ps_parser.ml
+++ b/test/test_docker_ps_parser.ml
@@ -1,0 +1,272 @@
+(** RFC-0070 Phase 3b-iv.2.5 — unit tests for {!Docker_ps_parser}.
+
+    Each of the 4 enumerated silent-drop paths
+    (empty / Yojson.Json_error / schema-mismatch / unknown State) is
+    exercised individually with synthetic JSON fixtures so the parser
+    contract is pinned independently of docker daemon state. *)
+
+open Alcotest
+open Masc_mcp
+
+(* Synthetic line that matches docker's [--format '{{json .}}']
+   emission shape closely enough for the parser: required fields
+   (ID, Names, State, Labels) plus a few unknown fields that the
+   [strict = false] yojson derivation must tolerate. *)
+let happy_line ~name ~state ~labels =
+  Printf.sprintf
+    {|{"ID":"abc123","Names":"%s","State":"%s","Labels":"%s","CreatedAt":"2026-05-12 09:00:00 +0900 KST","Status":"Up 5 minutes","Ports":""}|}
+    name
+    state
+    labels
+;;
+
+(* ── parse_labels ────────────────────────────────────────────── *)
+
+let test_parse_labels_empty () =
+  let actual = Docker_ps_parser.parse_labels "" in
+  check (list (pair string string)) "empty → []" [] actual
+;;
+
+let test_parse_labels_single () =
+  let actual = Docker_ps_parser.parse_labels "k=v" in
+  check (list (pair string string)) "single pair" [ "k", "v" ] actual
+;;
+
+let test_parse_labels_multi_preserves_order () =
+  let actual = Docker_ps_parser.parse_labels "z=last,a=first,m=mid" in
+  (* Order-preserving per .mli contract — caller must canonicalise
+     if comparing via Docker_response.equal_ps_record. *)
+  check
+    (list (pair string string))
+    "docker emission order preserved"
+    [ "z", "last"; "a", "first"; "m", "mid" ]
+    actual
+;;
+
+let test_parse_labels_drops_no_equals_token () =
+  let actual = Docker_ps_parser.parse_labels "good=ok,malformed,also=fine" in
+  (* "malformed" has no '=' — dropped silently. NOT mapped to
+     ("malformed", "") which would be a permissive default. *)
+  check
+    (list (pair string string))
+    "tokens without '=' dropped, not given empty-value default"
+    [ "good", "ok"; "also", "fine" ]
+    actual
+;;
+
+let test_parse_labels_empty_value_allowed () =
+  let actual = Docker_ps_parser.parse_labels "key=" in
+  (* '=' present but value empty — that IS a valid (key, "") pair.
+     Distinct from the "no =" drop case above. *)
+  check (list (pair string string)) "trailing '=' → empty value" [ "key", "" ] actual
+;;
+
+let test_parse_labels_value_contains_equals () =
+  let actual = Docker_ps_parser.parse_labels "url=https://x.com/?a=b" in
+  (* Only the FIRST '=' splits — subsequent '=' chars stay in value.
+     This matches docker's behaviour and protects label values that
+     happen to contain '='. *)
+  check
+    (list (pair string string))
+    "split on first '=' only"
+    [ "url", "https://x.com/?a=b" ]
+    actual
+;;
+
+(* ── parse_line — 4 enumerated silent-drop paths ─────────────── *)
+
+let test_parse_line_drop_empty () =
+  check (option (of_pp Fmt.nop)) "empty line → None" None (Docker_ps_parser.parse_line "");
+  check
+    (option (of_pp Fmt.nop))
+    "whitespace-only line → None"
+    None
+    (Docker_ps_parser.parse_line "   \t  ")
+;;
+
+let test_parse_line_drop_malformed_json () =
+  (* Drop path 2: Yojson.Json_error. Caught and converted to None. *)
+  check
+    (option (of_pp Fmt.nop))
+    "non-JSON line → None"
+    None
+    (Docker_ps_parser.parse_line "not a json line at all");
+  check
+    (option (of_pp Fmt.nop))
+    "truncated JSON → None"
+    None
+    (Docker_ps_parser.parse_line "{\"ID\":\"abc\"")
+;;
+
+let test_parse_line_drop_schema_mismatch () =
+  (* Drop path 3: valid JSON but missing required fields. *)
+  check
+    (option (of_pp Fmt.nop))
+    "JSON without required keys → None"
+    None
+    (Docker_ps_parser.parse_line {|{"foo":"bar"}|});
+  check
+    (option (of_pp Fmt.nop))
+    "JSON missing one required key (Labels) → None"
+    None
+    (Docker_ps_parser.parse_line {|{"ID":"x","Names":"n","State":"running"}|})
+;;
+
+let test_parse_line_drop_unknown_state () =
+  (* Drop path 4: schema-valid but State not in {Created, Running,
+     Paused, Restarting, Exited, Dead}. *)
+  check
+    (option (of_pp Fmt.nop))
+    "unknown State → None"
+    None
+    (Docker_ps_parser.parse_line (happy_line ~name:"x" ~state:"zombie" ~labels:""))
+;;
+
+(* ── parse_line — happy path ─────────────────────────────────── *)
+
+let test_parse_line_happy_running () =
+  match
+    Docker_ps_parser.parse_line
+      (happy_line ~name:"masc-keeper-abc" ~state:"running" ~labels:"k=v")
+  with
+  | None -> fail "expected Some on well-formed input"
+  | Some record ->
+    check string "id preserved" "abc123" record.Docker_response.id;
+    check
+      string
+      "name unsafe-wrapped from external string"
+      "masc-keeper-abc"
+      (Keeper_container_name.to_string record.Docker_response.name);
+    check
+      bool
+      "state parsed to typed variant Running"
+      true
+      Docker_response.(equal_ps_status record.status Running);
+    check (list (pair string string)) "labels parsed" [ "k", "v" ] record.labels
+;;
+
+let test_parse_line_happy_all_states () =
+  (* Each of the 6 valid State tokens accepted by Docker_response.parse_state
+     must round-trip through parse_line. *)
+  let cases =
+    [ "created", Docker_response.Created
+    ; "running", Docker_response.Running
+    ; "paused", Docker_response.Paused
+    ; "restarting", Docker_response.Restarting
+    ; "exited", Docker_response.Exited
+    ; "dead", Docker_response.Dead
+    ]
+  in
+  List.iter
+    (fun (token, expected) ->
+       match
+         Docker_ps_parser.parse_line (happy_line ~name:"x" ~state:token ~labels:"")
+       with
+       | None -> failf "state token %S unexpectedly dropped" token
+       | Some r ->
+         check
+           bool
+           (Printf.sprintf "state %S → typed" token)
+           true
+           (Docker_response.equal_ps_status r.status expected))
+    cases
+;;
+
+let test_parse_line_unknown_fields_tolerated () =
+  (* [@@deriving yojson { strict = false }] should accept lines with
+     fields not in the required-subset schema (CreatedAt, Status,
+     Ports, Image, Command, ...) without dropping. *)
+  let line =
+    {|{"ID":"x","Names":"n","State":"running","Labels":"","CreatedAt":"now","Status":"Up","Ports":"","Image":"alpine","Command":"sh","Mounts":"","Networks":"bridge","Size":"0B","RunningFor":"1m","LocalVolumes":"0","LogStatus":"none"}|}
+  in
+  match Docker_ps_parser.parse_line line with
+  | None -> fail "unknown fields should be tolerated by strict=false"
+  | Some _ -> ()
+;;
+
+(* ── parse_output ────────────────────────────────────────────── *)
+
+let test_parse_output_empty () =
+  check int "empty stdout → []" 0 (List.length (Docker_ps_parser.parse_output ""));
+  check
+    int
+    "whitespace-only stdout → []"
+    0
+    (List.length (Docker_ps_parser.parse_output "\n\n  \n"))
+;;
+
+let test_parse_output_mixed () =
+  (* Realistic stress: 2 happy lines + 1 of each drop type. *)
+  let stdout =
+    String.concat
+      "\n"
+      [ happy_line ~name:"k1" ~state:"running" ~labels:"app=keeper"
+      ; "" (* drop: empty *)
+      ; "not json" (* drop: Yojson error *)
+      ; {|{"foo":"bar"}|} (* drop: schema *)
+      ; happy_line ~name:"k2" ~state:"alien" ~labels:"" (* drop: unknown state *)
+      ; happy_line ~name:"k3" ~state:"exited" ~labels:""
+      ]
+  in
+  let records = Docker_ps_parser.parse_output stdout in
+  check int "2 happy + 4 drops → 2 records" 2 (List.length records);
+  match records with
+  | [ r1; r2 ] ->
+    check
+      string
+      "first record name"
+      "k1"
+      (Keeper_container_name.to_string r1.Docker_response.name);
+    check
+      string
+      "second record name (skipping all 4 drops)"
+      "k3"
+      (Keeper_container_name.to_string r2.Docker_response.name)
+  | _ -> fail "expected exactly 2 records"
+;;
+
+(* ── Suite ───────────────────────────────────────────────────── *)
+
+let () =
+  run
+    "Docker_ps_parser (Phase 3b-iv.2.5)"
+    [ ( "parse_labels"
+      , [ test_case "empty → []" `Quick test_parse_labels_empty
+        ; test_case "single k=v" `Quick test_parse_labels_single
+        ; test_case
+            "preserves docker emission order"
+            `Quick
+            test_parse_labels_multi_preserves_order
+        ; test_case
+            "drops tokens without '='"
+            `Quick
+            test_parse_labels_drops_no_equals_token
+        ; test_case
+            "trailing '=' → empty value"
+            `Quick
+            test_parse_labels_empty_value_allowed
+        ; test_case
+            "splits on first '=' only"
+            `Quick
+            test_parse_labels_value_contains_equals
+        ] )
+    ; ( "parse_line silent-drop paths"
+      , [ test_case "drop 1: empty line" `Quick test_parse_line_drop_empty
+        ; test_case "drop 2: malformed JSON" `Quick test_parse_line_drop_malformed_json
+        ; test_case "drop 3: schema mismatch" `Quick test_parse_line_drop_schema_mismatch
+        ; test_case "drop 4: unknown State" `Quick test_parse_line_drop_unknown_state
+        ] )
+    ; ( "parse_line happy paths"
+      , [ test_case "running state + labels" `Quick test_parse_line_happy_running
+        ; test_case "all 6 valid State tokens" `Quick test_parse_line_happy_all_states
+        ; test_case
+            "strict=false tolerates unknown fields"
+            `Quick
+            test_parse_line_unknown_fields_tolerated
+        ] )
+    ; ( "parse_output"
+      , [ test_case "empty / whitespace-only stdout" `Quick test_parse_output_empty
+        ; test_case "mixed happy + all 4 drops" `Quick test_parse_output_mixed
+        ] )
+    ]
+;;


### PR DESCRIPTION
## 목표 — RFC-0070 §3.2/§3.3 Phase 3b-iv.2.4 (final)

**Real `ps_query` + JSON parser**. Phase 3b-iv.2 series **closes here** — Real Docker_client의 4 functions 모두 production-wired.

## RFC 인용

| RFC | 관계 |
|-----|------|
| **RFC-0070** | §3.2 ps_query S impl + §3.3 ps_record JSON parser |
| RFC-0006 | cite-only |
| RFC-0036 | cite-only |

## Phase 3b-iv.2 진행 (series closure)

| Sub-phase | function | PR | 상태 |
|-----------|----------|----|----|
| 3b-iv.2.0 | skeleton (4 placeholders) | #14838 | ✅ |
| 3b-iv.2.1 | rm | #14844 | ✅ |
| 3b-iv.2.2 | exec | #14854 | ✅ |
| 3b-iv.2.3 | run | #14862 | ✅ |
| **3b-iv.2.4** | **ps_query + JSON parser** | 본 PR | ◀ **series final** |

## 새 추가

### 1. `Keeper_container_name.of_external_string` (mli + ml)

```ocaml
val of_external_string : string -> t
(** *Unsafe* wrap — docker output 등 external source에서 받은 string을
    typed로. format 검증 없음. derive와 contrast: derive는 *생성*+enforced,
    of_external_string은 *ingestion*+unchecked. *)
```

design 의도: ps_query가 docker stdout의 [Names] field를 *typed Keeper_container_name.t*로 wrap 필요. *external source 도래* — `derive`로 reconstruct 불가능. unsafe wrap이 유일한 path.

### 2. `Docker_client_real.ps_query` wire

```ocaml
let ps_query ~labels =
  let argv = [
    "docker"; "ps"; "-a"; "--format"; "{{json .}}"
  ] @ labels_to_filter_args labels in
  let status, stdout, _stderr = Process_eio.run_argv_with_status_split argv in
  match status with
  | WEXITED 0 → Ok (parse_ps_output stdout)
  | WEXITED 125 | 127 | signal/stopped → Error Daemon_unreachable
  | WEXITED other → Error Probe_format_drift
```

### 3. JSON 파싱 helpers (private in `.ml`)

```ocaml
parse_labels : string -> (string * string) list
  (* "k1=v1,k2=v2" → [("k1","v1"); ("k2","v2")]. 빈 input → []. '=' 없는 토큰 drop *)

raw_ps_record [@@deriving yojson { strict = false }]
  (* docker의 추가 fields (CreatedAt, Status, ...) tolerated *)

parse_ps_line : string -> ps_record option
  (* empty / JSON decode fail / schema mismatch / unknown State → None (silent drop) *)

parse_ps_output : string -> ps_record list
  (* split by '\n' + filter_map parse_ps_line *)
```

## Silent drop 명시 (RFC §3.3 trade-off)

`parse_ps_line` returns `None`은 *not catch-all* — 명시적 4 case:
1. empty line
2. Yojson.Json_error (malformed JSON)
3. raw_ps_record_of_yojson Error (schema mismatch)
4. Docker_response.parse_state Error (unknown State)

운영 trade-off 명시: *stray non-JSON line from docker should NOT collapse fleet listing for cleanup loop*. RFC §3.3 "no permissive default" + operational resilience 사이.

## 변경

```
lib/keeper/keeper_container_name.mli   +18 (of_external_string + docstring)
lib/keeper/keeper_container_name.ml    +2 (impl: identity)
lib/keeper/docker_client_real.mli      ±25 (Phase 3b-iv.2.3 → 2.4, ps_query semantics)
lib/keeper/docker_client_real.ml       +85 (JSON parsing helpers + ps_query impl)
test/test_docker_client_real.ml        ±15 (ps_query test 재구성)
```

## Test 갱신

```ocaml
let test_ps_query_returns_typed_result () =
  match Docker_client_real.ps_query ~labels:[("masc.keeper.test", "alice")] with
  | Ok _ -> ()                                       (* daemon present *)
  | Error Daemon_unreachable -> ()                   (* daemon / CLI missing *)
  | Error Probe_format_drift -> ()                   (* docker ps unusual non-zero *)
  | Error <other 4 variants> -> fail "..."
```

## Workaround Rejection Bar self-check (시리즈 closure)

| 시그니처 | 본 PR 해당? |
|---------|------------|
| Counter-as-fix | N/A |
| **String 분류기** | **명시적 retained at one site**: docker의 [Labels] field IS comma-joined string (docker wire format). `parse_labels`는 *그 format을 typed로 변환* — §2 anti-pattern (typed variant 가능 자리에 substring) 와 *반대 방향*. 이 site 제거하려면 *docker 자체*가 wire format 바꿔야 |
| **N-of-M** | **series closes here**. 4/4 S functions wired. *acknowledged enumeration fully consumed*. *unbounded sprawl* 없음 |
| Cap/cooldown/dedup/repair | N/A |
| **Test backdoor** | **deferred to Phase 3b-iv.2.5** (future cleanup): parser helpers는 *private*. unit test 위해 `Docker_ps_parser` 별도 모듈 split 권장. 본 PR은 *set_*_for_test* 우회 hack 사용 안 함 |
| **Catch-all `_ ->`** | N/A — `parse_ps_line`의 모든 failure path는 explicit (Yojson.Json_error, ofyojson Error, parse_state Error, empty line) |

## 미검증

- *Parser unit tests* — Phase 3b-iv.2.5 cleanup PR에서 `Docker_ps_parser` module split + 정밀 unit test
- *Real docker integration test* — 별도 integration track (docker compose 등)

## Phase 3b-iv.2 series closure 의미

13 PRs 머지 + 1 final draft. Real Docker_client.S 완전 구현. Mock + Real 모두 *swap-in-able functor instance*. 다음 RFC-0070 Phase 단계:

- **Phase 3c.2** (cleanup quarantine state machine) — RFC-0036 cleanup_hook main merge 의존, 미해소
- **Phase 4** (caller cutover) — 기존 `keeper_sandbox_runtime.ml` 등이 Sandbox_executor.Make 사용으로 전환

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
