### PR TITLE
fix(test): unbreak main — Alcotest.result shadowing in test_keeper_sandbox_plan.ml

### DIFF
--- a/test/test_keeper_sandbox_plan.ml
+++ b/test/test_keeper_sandbox_plan.ml
@@ -25,24 +25,24 @@ let plan_error_t = testable plan_error_pp plan_error_eq
 (* ── Validation: empty inputs rejected ────────────────────────── *)
 
 let test_empty_meta_rejected () =
-  let result =
+  let actual =
     Keeper_sandbox_plan.of_request ~turn_id:1 ~attempt:0 ~meta_name:"" ~cmd:"ls"
   in
   check
     (result plan_t plan_error_t)
     "empty meta → Invalid_meta"
     (Error (Keeper_sandbox_plan.Invalid_meta ""))
-    result
+    actual
 
 let test_empty_cmd_rejected () =
-  let result =
+  let actual =
     Keeper_sandbox_plan.of_request ~turn_id:1 ~attempt:0 ~meta_name:"k" ~cmd:""
   in
   check
     (result plan_t plan_error_t)
     "empty cmd → Invalid_command"
     (Error (Keeper_sandbox_plan.Invalid_command ""))
-    result
+    actual
 
 (* ── Payload semantics: error carries offending value (Phase 3b-iii contract) ── *)
 


### PR DESCRIPTION
## Summary

**Main 빌드 회복**. `test/test_keeper_sandbox_plan.ml` (PR #14781 RFC-0070 Phase 3b-iii) 가 `Alcotest.result` 를 local `let result = ...` 로 shadowing 한 채 `(result plan_t plan_error_t)` 로 함수 호출 시도. `dune build @check` 에서 main 실패:

```
File "test/test_keeper_sandbox_plan.ml", line 32, characters 5-11:
32 |     (result plan_t plan_error_t)
          ^^^^^^
Error: This expression has type
    (Keeper_sandbox_plan.t, Keeper_sandbox_plan.plan_error) result
    This is not a function; it cannot be applied.
```

## 수정

`test_empty_meta_rejected` + `test_empty_cmd_rejected` 의 local `result` → `actual` rename. `Alcotest.result` 가 다시 자유롭게 해석됨. 나머지 테스트는 영향 없음 (이미 local `result` 를 즉시 `match` 로 소비).

## Test plan

- [x] `dune build --root . @check`: PASS (이전 실패)
- [x] `dune exec test/test_keeper_sandbox_plan.exe`: **11/11 PASS**

## 영향 / Why now

이 빌드 실패가 같은 origin/main 베이스로 작업하는 모든 PR 의 `dune @check` 를 막음. 사용자 직접 보고 ("Main 아직 빌드 안됨") 로 발견. CI 가 이 실패를 빨리 잡지 못한 이유는 별도 조사 필요 (test/dune 등록은 됨 — line 595, 812).

RFC-WAIVED: emergency build fix, 4 라인 rename.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
