### PR TITLE
feat(jsonl): extend Fs_compat.fold_jsonl_lines streaming to 11 hot read sites

### DIFF
--- a/lib/autoresearch_knowledge.ml
+++ b/lib/autoresearch_knowledge.ml
@@ -127,13 +127,16 @@ let load_all_findings ~base_path () : finding list =
   let path = findings_file ~base_path in
   if not (Sys.file_exists path) then []
   else
-    Fs_compat.load_jsonl path
-    |> List.filter_map (fun json ->
-         match finding_of_yojson json with
-         | Ok f -> Some f
-         | Error msg ->
-           Log.Keeper.warn "Skipping malformed finding: %s" msg;
-           None)
+    Fs_compat.fold_jsonl_lines
+      ~init:[]
+      ~f:(fun acc ~line_no:_ json ->
+        match finding_of_yojson json with
+        | Ok f -> f :: acc
+        | Error msg ->
+          Log.Keeper.warn "Skipping malformed finding: %s" msg;
+          acc)
+      path
+    |> List.rev
 
 (* Empty needle preserves the legacy "matches all" semantic; non-empty
    matching delegates to [String_util.contains_substring_ci]. The

--- a/lib/drift_guard.ml
+++ b/lib/drift_guard.ml
@@ -281,36 +281,41 @@ let get_drift_stats config ~days =
     let cutoff =
       Time_compat.now () -. (float_of_int (max 0 days) *. 24.0 *. 3600.0)
     in
-    let rows = Fs_compat.load_jsonl path in
+    (* Streaming aggregation — total / drift_count / similarity_sum
+       fold over the JSONL without materialising the row list. The
+       cutoff predicate also rejects most pre-window rows on long
+       histories. *)
     let total = ref 0 in
     let drift_count = ref 0 in
     let similarity_sum = ref 0.0 in
-    List.iter (fun row ->
-      match row with
-      | `Assoc fields -> (
-          let timestamp =
-            match List.assoc_opt "timestamp" fields with
-            | Some (`Float value) -> value
-            | Some (`Int value) -> float_of_int value
-            | _ -> 0.0
-          in
-          if timestamp >= cutoff then (
-            match List.assoc_opt "result" fields with
-            | Some (`Assoc result_fields) ->
-                let similarity =
-                  match List.assoc_opt "similarity" result_fields with
-                  | Some (`Float value) -> value
-                  | Some (`Int value) -> float_of_int value
-                  | _ -> 0.0
-                in
-                incr total;
-                similarity_sum := !similarity_sum +. similarity;
-                (match List.assoc_opt "passed" result_fields with
-                | Some (`Bool false) -> incr drift_count
-                | Some (`Bool true) | Some _ | None -> ())
-            | None | Some _ -> ()))
-      | `List _ | `String _ | `Int _ | `Intlit _ | `Float _ | `Bool _ | `Null -> ()
-    ) rows;
+    Fs_compat.fold_jsonl_lines
+      ~init:()
+      ~f:(fun () ~line_no:_ row ->
+        match row with
+        | `Assoc fields -> (
+            let timestamp =
+              match List.assoc_opt "timestamp" fields with
+              | Some (`Float value) -> value
+              | Some (`Int value) -> float_of_int value
+              | _ -> 0.0
+            in
+            if timestamp >= cutoff then (
+              match List.assoc_opt "result" fields with
+              | Some (`Assoc result_fields) ->
+                  let similarity =
+                    match List.assoc_opt "similarity" result_fields with
+                    | Some (`Float value) -> value
+                    | Some (`Int value) -> float_of_int value
+                    | _ -> 0.0
+                  in
+                  incr total;
+                  similarity_sum := !similarity_sum +. similarity;
+                  (match List.assoc_opt "passed" result_fields with
+                  | Some (`Bool false) -> incr drift_count
+                  | Some (`Bool true) | Some _ | None -> ())
+              | None | Some _ -> ()))
+        | `List _ | `String _ | `Int _ | `Intlit _ | `Float _ | `Bool _ | `Null -> ())
+      path;
     let avg_similarity =
       if !total = 0 then 0.0 else !similarity_sum /. float_of_int !total
     in

--- a/lib/ide/ide_annotations.ml
+++ b/lib/ide/ide_annotations.ml
@@ -57,15 +57,20 @@ let load_all ~base_dir =
   let path = annotations_file ~base_dir in
   if not (Sys.file_exists path)
   then []
-  else (
-    let lines = Fs_compat.load_jsonl path in
-    let non_tombstones = List.filter (fun j -> not (is_tombstone j)) lines in
-    List.filter_map
-      (fun j ->
-         match annotation_of_json j with
-         | Ok a -> Some a
-         | Error _ -> None)
-      non_tombstones)
+  else
+    (* Streaming filter + decode — tombstone rejection happens during the
+       fold so the full JSONL list never lands in memory at once. *)
+    Fs_compat.fold_jsonl_lines
+      ~init:[]
+      ~f:(fun acc ~line_no:_ j ->
+        if is_tombstone j
+        then acc
+        else (
+          match annotation_of_json j with
+          | Ok a -> a :: acc
+          | Error _ -> acc))
+      path
+    |> List.rev
 ;;
 
 let write_all ~base_dir annotations =
@@ -175,12 +180,18 @@ let delete ~base_dir ~id ~keeper_id =
     let ts = now_ms () in
     let store = Dated_jsonl.create ~base_dir:(store_path ~base_dir) () in
     Dated_jsonl.append store (tombstone_json id keeper_id ts);
-    let raw_lines = Fs_compat.load_jsonl (annotations_file ~base_dir) in
-    let tombstones = List.filter is_tombstone raw_lines in
-    let total = List.length all + List.length tombstones in
+    (* Streaming count — we only need cardinalities to compute the
+       compaction ratio, not the row list itself. *)
+    let tombstone_count =
+      Fs_compat.fold_jsonl_lines
+        ~init:0
+        ~f:(fun acc ~line_no:_ j -> if is_tombstone j then acc + 1 else acc)
+        (annotations_file ~base_dir)
+    in
+    let total = List.length all + tombstone_count in
     if
       total > 0
-      && float_of_int (List.length tombstones) /. float_of_int total >= compact_threshold
+      && float_of_int tombstone_count /. float_of_int total >= compact_threshold
     then compact ~base_dir;
     Ok ()
 ;;

--- a/lib/institution_eio.ml
+++ b/lib/institution_eio.ml
@@ -786,30 +786,32 @@ let record_episode_jsonl ~event_type ~summary ~participants ~outcome ~learnings 
   episode
 ;;
 
-(** Load recent episodes from JSONL (last N entries). *)
+(** Load recent episodes from JSONL (last N entries) via a bounded
+    [Queue] ring — O(limit) resident memory regardless of file size,
+    one pass over the JSONL via [Fs_compat.fold_jsonl_lines]. *)
 let load_recent_episodes_jsonl ~limit : episode list =
   let path = episodes_jsonl_path () in
-  let jsons = Fs_compat.load_jsonl path in
-  let all =
-    List.filter_map
-      (fun json ->
-         try Some (episode_of_json json) with
-         | Yojson.Safe.Util.Type_error _ -> None
-         | exn ->
-           Log.Institution.warn "episode parse failed: %s" (Printexc.to_string exn);
-           None)
-      jsons
-  in
-  let total = List.length all in
-  if total <= limit
-  then all
+  if limit <= 0
+  then []
   else (
-    let rec drop n = function
-      | [] -> []
-      | remaining when n <= 0 -> remaining
-      | _ :: rest -> drop (n - 1) rest
-    in
-    drop (total - limit) all)
+    let buf : episode Queue.t = Queue.create () in
+    Fs_compat.fold_jsonl_lines
+      ~init:()
+      ~f:(fun () ~line_no:_ json ->
+        let parsed =
+          try Some (episode_of_json json) with
+          | Yojson.Safe.Util.Type_error _ -> None
+          | exn ->
+            Log.Institution.warn "episode parse failed: %s" (Printexc.to_string exn);
+            None
+        in
+        match parsed with
+        | None -> ()
+        | Some ep ->
+          Queue.add ep buf;
+          if Queue.length buf > limit then ignore (Queue.pop buf))
+      path;
+    List.of_seq (Queue.to_seq buf))
 ;;
 
 (** Cap episodes JSONL to at most [max_lines] by keeping the most recent ones.
@@ -824,27 +826,32 @@ let cap_episodes_jsonl ?(max_lines = episodes_jsonl_default_cap) () : int =
   if not (Sys.file_exists path)
   then 0
   else (
-    let lines = Fs_compat.load_jsonl path in
-    let total = List.length lines in
+    (* Bounded ring + total counter — O(max_lines) memory regardless
+       of input size. The ring holds the trailing [max_lines] parsed
+       JSON values that survive into the rewrite. *)
+    let buf : Yojson.Safe.t Queue.t = Queue.create () in
+    let total_ref = ref 0 in
+    Fs_compat.fold_jsonl_lines
+      ~init:()
+      ~f:(fun () ~line_no:_ json ->
+        incr total_ref;
+        Queue.add json buf;
+        if Queue.length buf > max_lines then ignore (Queue.pop buf))
+      path;
+    let total = !total_ref in
     if total <= max_lines
     then 0
     else (
-      let rec drop n = function
-        | [] -> []
-        | rest when n <= 0 -> rest
-        | _ :: rest -> drop (n - 1) rest
-      in
-      let keep = drop (total - max_lines) lines in
       let tmp_path = path ^ ".tmp" in
       let oc = open_out tmp_path in
       Eio_guard.protect
         ~finally:(fun () -> close_out_noerr oc)
         (fun () ->
-           List.iter
+           Queue.iter
              (fun line ->
                 output_string oc (Yojson.Safe.to_string line);
                 output_char oc '\n')
-             keep);
+             buf);
       Sys.rename tmp_path path;
       total - max_lines))
 ;;

--- a/lib/operator/operator_control_snapshot.ml
+++ b/lib/operator/operator_control_snapshot.ml
@@ -308,12 +308,16 @@ let recent_actions_json config =
   if not (Sys.file_exists path)
   then `List []
   else (
-    let all = Fs_compat.load_jsonl path in
-    let len = List.length all in
-    let tail =
-      if len <= 20 then all else all |> List.to_seq |> Seq.drop (len - 20) |> List.of_seq
-    in
-    `List tail)
+    (* Bounded ring — keep the trailing 20 entries via [Queue.t] so the
+       action log JSONL does not need to materialise as a full list. *)
+    let buf : Yojson.Safe.t Queue.t = Queue.create () in
+    Fs_compat.fold_jsonl_lines
+      ~init:()
+      ~f:(fun () ~line_no:_ json ->
+        Queue.add json buf;
+        if Queue.length buf > 20 then ignore (Queue.pop buf))
+      path;
+    `List (List.of_seq (Queue.to_seq buf)))
 ;;
 
 let recent_messages_json config =

--- a/lib/operator/operator_judgment.ml
+++ b/lib/operator/operator_judgment.ml
@@ -158,15 +158,18 @@ let is_fresh ?(now = Unix.gettimeofday ()) value =
 
 let load_all config =
   let path = judgments_path config in
-  Fs_compat.load_jsonl path
-  |> List.filter_map (fun json ->
-         try
-           match of_yojson json with
-           | Ok value -> Some value
-           | Error _ -> None
-         with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
-           Log.Governance.warn "operator judgment parse: %s" (Printexc.to_string exn);
-           None)
+  Fs_compat.fold_jsonl_lines
+    ~init:[]
+    ~f:(fun acc ~line_no:_ json ->
+      try
+        match of_yojson json with
+        | Ok value -> value :: acc
+        | Error _ -> acc
+      with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
+        Log.Governance.warn "operator judgment parse: %s" (Printexc.to_string exn);
+        acc)
+    path
+  |> List.rev
 
 let append config values =
   ensure_dir (operator_dir config);

--- a/lib/run_eio.ml
+++ b/lib/run_eio.ml
@@ -215,8 +215,14 @@ let read_logs config ~task_id ?limit () : log_entry list =
   if not (Sys.file_exists file) then []
   else
     let entries =
-      Fs_compat.load_jsonl file
-      |> List.filter_map log_entry_of_json
+      Fs_compat.fold_jsonl_lines
+        ~init:[]
+        ~f:(fun acc ~line_no:_ j ->
+          match log_entry_of_json j with
+          | Some e -> e :: acc
+          | None -> acc)
+        file
+      |> List.rev
     in
     match limit with
     | None -> entries

--- a/lib/server/server_dashboard_http_keeper_api.ml
+++ b/lib/server/server_dashboard_http_keeper_api.ml
@@ -82,8 +82,17 @@ let internal_history_json_to_trajectory_line (json : Yojson.Safe.t)
 let read_internal_history_lines ~(config : Coord.config) ~(trace_id : string)
     : Trajectory.trajectory_line list =
   let path = Keeper_types.keeper_internal_history_path config trace_id in
-  Fs_compat.load_jsonl path
-  |> List.filter_map internal_history_json_to_trajectory_line
+  (* Streaming filter — avoid materialising the full JSONL list when
+     only a subset of lines decode to [trajectory_line]. Output is built
+     in reverse and reversed once, matching List.filter_map ordering. *)
+  Fs_compat.fold_jsonl_lines
+    ~init:[]
+    ~f:(fun acc ~line_no:_ json ->
+      match internal_history_json_to_trajectory_line json with
+      | Some line -> line :: acc
+      | None -> acc)
+    path
+  |> List.rev
 
 let merge_keeper_trace_lines ~(config : Coord.config) ~(trace_id : string)
     (trajectory_lines : Trajectory.trajectory_line list)

--- a/lib/server/server_ide_http.ml
+++ b/lib/server/server_ide_http.ml
@@ -249,14 +249,18 @@ let add_routes router =
          in
          let store_dir = Filename.concat base ".masc-ide" in
          let path = Filename.concat store_dir "regions.jsonl" in
-         let raw = if not (Sys.file_exists path) then [] else Fs_compat.load_jsonl path in
+         (* Streaming filter — file_path filter usually drops most lines,
+            and regions.jsonl grows append-only. fold_jsonl_lines avoids
+            the full-list materialisation that List.filter_map needed. *)
          let regions =
-           List.filter_map
-             (fun j ->
-                match Ide_annotation_types.region_of_json j with
-                | Ok r when file_path = "" || r.file_path = file_path -> Some r
-                | _ -> None)
-             raw
+           Fs_compat.fold_jsonl_lines
+             ~init:[]
+             ~f:(fun acc ~line_no:_ j ->
+               match Ide_annotation_types.region_of_json j with
+               | Ok r when file_path = "" || r.file_path = file_path -> r :: acc
+               | _ -> acc)
+             path
+           |> List.rev
          in
          let json = `List (List.map Ide_annotation_types.region_to_json regions) in
          Http.Response.json

--- a/lib/telemetry_unified.ml
+++ b/lib/telemetry_unified.ml
@@ -793,8 +793,19 @@ let read_goal_events ~masc_root ?since_ts ?until_ts ~n () : Yojson.Safe.t list =
     let entries =
       protect_source_read Goal_event ~site:"read_goal_events" ~default:[]
         (fun () ->
-        Fs_compat.load_jsonl path
-        |> List.filter (within_requested_window ?since_ts ?until_ts))
+          (* Streaming filter — the time-window predicate drops most
+             entries on the typical {since_ts,until_ts} request shape,
+             so folding lets us hold only the survivors instead of the
+             full goal_events.jsonl content. The subsequent sort still
+             needs the filtered set in memory; that part can't stream. *)
+          Fs_compat.fold_jsonl_lines
+            ~init:[]
+            ~f:(fun acc ~line_no:_ json ->
+              if within_requested_window ?since_ts ?until_ts json
+              then json :: acc
+              else acc)
+            path
+          |> List.rev)
     in
     let entries = sort_newest_first entries in
     let entries = if n <= 0 then entries else take_first n entries in


### PR DESCRIPTION
## Summary

PR #14706 의 `Fs_compat.fold_jsonl_lines` streaming API 를 **11 hot site** 에 확장. 모두 기존엔 `Fs_compat.load_jsonl` (전체 list 적재) 였음.

### Batch 1 — pure filter/aggregation (4)
| 사이트 | 이득 |
|---|---|
| `server/server_dashboard_http_keeper_api.ml:85` `read_internal_history_lines` | HTTP keeper trajectory render — O(N)→O(survivors) |
| `server/server_ide_http.ml:252` `GET /api/v1/ide/regions` | file_path filter — append-only regions.jsonl |
| `telemetry_unified.ml:790` `read_goal_events` | time-window filter streaming (sort 는 in-mem 잔존) |
| `drift_guard.ml:284` similarity drift summary | pure aggregation — 가장 큰 절감 |

### Batch 2 — filter_map + count (5)
| 사이트 | 이득 |
|---|---|
| `ide/ide_annotations.ml:56` `load_all` | tombstone filter + decode 동시 |
| `ide/ide_annotations.ml:178` compaction trigger | count 만 필요 → 더 큰 절감 |
| `run_eio.ml:213` `read_logs` filter_map | limit 는 post-fold |
| `operator/operator_judgment.ml:159` `load_all` | filter_map |
| `autoresearch_knowledge.ml:126` `load_all_findings` | filter_map |

### Batch 3 — ring buffer (3, O(N)→O(limit))
| 사이트 | 이득 |
|---|---|
| `institution_eio.ml:790` `load_recent_episodes_jsonl` | `Queue.t` bounded ring, last N episodes — file size 와 무관 O(limit) |
| `institution_eio.ml:822` `cap_episodes_jsonl` | ring + total counter, write-back rewrites only the ring — O(max_lines) memory |
| `operator/operator_control_snapshot.ml:311` `recent_actions_json` | tail-20 ring 일반화 |

### Skip (의도)
- `thompson_sampling.ml:284` — batch install under `ts_mu` 락 안에서 full list 필요

## 패턴

- **filter_map → fold + List.rev**: order 보존
- **aggregation → fold init:() + ref**: associative, rev 불필요
- **tail-N (ring) → fold init:() + Queue.t**: O(limit) memory, write-back 도 ring 재사용

## Test plan

- [x] `dune build --root . @check`: PASS
- [x] `dune exec test/test_drift_guard_core.exe`: 5/5 PASS
- [x] `dune exec test/test_telemetry_unified.exe`: 33/33 PASS
- [x] `dune exec test/test_autoresearch_knowledge.exe`: 9/9 PASS
- [x] `dune exec test/test_institution_episodes_failure_learnings_10325.exe`: 6/6 PASS
- [x] `dune exec test/test_run_eio_coverage.exe`: 33/33 PASS

## Stacking

Base 는 #14872 (`fix/keeper-sandbox-plan-result-shadow`) — 그 PR 머지 후 rebase 자연 클린.

RFC-WAIVED: JSONL 읽기 패턴 메모리 최적화. credential / sandbox / operator_control lifecycle 변경 없음 — 본 PR 의 operator_control_snapshot 변경은 *읽기 패턴* 만.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
