### PR TITLE
spec(scripts): R-H-1.c phase-count validator + CI wiring (iter 52)

### DIFF
--- a/.github/workflows/tla-annotation-drift.yml
+++ b/.github/workflows/tla-annotation-drift.yml
@@ -23,6 +23,7 @@ on:
       - 'lib/cascade/cascade_fsm.ml'
       - 'lib/cascade/cascade_fsm.mli'
       - 'scripts/audit-tla-annotation-drift.sh'
+      - 'scripts/audit-tla-phase-count.sh'
       - 'scripts/tla-annotation-drift-baseline.txt'
       - '.github/workflows/tla-annotation-drift.yml'
   push:
@@ -35,6 +36,7 @@ on:
       - 'lib/cascade/cascade_fsm.ml'
       - 'lib/cascade/cascade_fsm.mli'
       - 'scripts/audit-tla-annotation-drift.sh'
+      - 'scripts/audit-tla-phase-count.sh'
       - 'scripts/tla-annotation-drift-baseline.txt'
   workflow_dispatch: {}
 
@@ -64,3 +66,13 @@ jobs:
           bash scripts/audit-tla-annotation-drift.sh \
             --baseline scripts/tla-annotation-drift-baseline.txt \
             --check-cross-spec
+
+      - name: Run phase-count validator (R-H-1.c)
+        # Catches stale "N phases" mentions in spec comments where N
+        # disagrees with the OCaml `type phase` constructor count.
+        # iter 4 added Zombie (12→13) but 7 specs still cited 12 for
+        # six months until iter 49 audit caught them; this guard
+        # prevents the next phase-count change from regressing the
+        # same way.  See docs/tla-audit/rh1b-sweep-zombie-12-phases-
+        # stale-2026-05-12.md for the audit that motivated it.
+        run: bash scripts/audit-tla-phase-count.sh

--- a/scripts/audit-tla-phase-count.sh
+++ b/scripts/audit-tla-phase-count.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+# audit-tla-phase-count.sh — detect TLA+ spec comments that mention
+# an "N phases" / "N-phase" count which disagrees with the OCaml
+# `type phase` constructor count in keeper_state_machine.ml.
+#
+# Background: iter 4 (#14707) added the Zombie constructor, raising
+# the OCaml phase type from 12 to 13. Seven sibling specs (iter 49
+# audit at docs/tla-audit/rh1b-sweep-zombie-12-phases-stale-2026-05-12.md)
+# still cited the stale "12 phases" count six months later because no
+# structural check existed.  Iter 50 batch-fixed those (#14863) and
+# iter 51 added per-spec Zombie mapping notes (#14865); this script
+# is pipeline step 3/3 — the regression guard that prevents the same
+# class of drift from recurring on the next phase-count change.
+#
+# Rule:
+#   - Count `^  | <CamelCase>` lines between `type phase =` and the
+#     next blank line in lib/keeper/keeper_state_machine.ml.  That's
+#     the source of truth (N).
+#   - In specs/keeper-state-machine/*.tla, find every match of
+#     `\b(\d{1,2})[ -]phase(s)?\b` inside `\* ` comment lines.
+#   - If the matched number != N, the line MUST contain at least one
+#     contextual qualifier (`non-`, `fragment`, `projection`, `subset`,
+#     `relevant`, `out of scope`, `models`, `collapse`, `symbol`,
+#     `triad`, `mapping`, `excluding`).  Otherwise it is flagged as
+#     stale.
+#   - The full count (N=13 today) is always allowed without qualifier.
+#
+# Usage: bash scripts/audit-tla-phase-count.sh [--verbose]
+#
+# RFC chain: R-B-1.c (annotation drift validator) → R-H-1.c (this
+# script), 6th drift class structural closure.
+set -euo pipefail
+
+for tool in rg awk grep sed; do
+  command -v "${tool}" >/dev/null 2>&1 || {
+    echo "error: required tool '${tool}' not found in PATH" >&2
+    exit 2
+  }
+done
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SPEC_DIR="${REPO_ROOT}/specs/keeper-state-machine"
+SSOT_FILE="${REPO_ROOT}/lib/keeper/keeper_state_machine.ml"
+
+VERBOSE=0
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --verbose) VERBOSE=1; shift ;;
+    *) echo "unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+# Extract phase constructor count.  awk reads the block between
+# `type phase =` and the first blank line, counts `  | Ctor` lines.
+SSOT_COUNT="$(awk '
+  /^type phase =/ { in_block = 1; next }
+  in_block && /^[[:space:]]*$/ { exit }
+  in_block && /^[[:space:]]*\|[[:space:]]*[A-Z]/ { count++ }
+  END { print count + 0 }
+' "${SSOT_FILE}")"
+
+if [[ -z "${SSOT_COUNT}" || "${SSOT_COUNT}" -lt 2 ]]; then
+  echo "error: could not extract phase constructor count from ${SSOT_FILE}" >&2
+  echo "       (got '${SSOT_COUNT}')" >&2
+  exit 2
+fi
+
+[[ "${VERBOSE}" -eq 1 ]] && echo "SSOT phase count: ${SSOT_COUNT}" >&2
+
+# Qualifier whitelist — when these tokens appear on the same line as
+# a non-matching count, the mention is treated as an intentional
+# subset/projection description rather than a stale full-count claim.
+QUALIFIERS='(non-|fragment|projection|subset|relevant|out of scope|models|collapse|symbol|triad|mapping|excluding|abstract|sibling|companion)'
+
+drift_count=0
+tmpfile="$(mktemp)"
+trap 'rm -f "${tmpfile}"' EXIT
+
+# rg without -o emits the full line; we parse number out per match.
+# We filter to comment lines (`\* `) only — body actions referencing
+# N are not the drift class this guard targets.
+rg -n --no-heading --glob '*.tla' \
+  -e '\\\*[^\n]*\b([0-9]{1,2})[ -]phase(s)?\b' \
+  "${SPEC_DIR}" 2>/dev/null > "${tmpfile}" || true
+
+while IFS= read -r entry; do
+  [[ -z "${entry}" ]] && continue
+  # entry format: <file>:<lineno>:<matched substring starting with \*>
+  file="${entry%%:*}"
+  rest="${entry#*:}"
+  lineno="${rest%%:*}"
+  content="${rest#*:}"
+
+  # Extract first 1-2 digit number adjacent to "phase"/"phases".
+  # `\b` is not portable in BSD sed (macOS); use grep -oE which works
+  # on both GNU and BSD.
+  matched_n="$(printf '%s' "${content}" \
+    | grep -oE '[0-9]{1,2}[ -]phase(s)?' \
+    | head -1 \
+    | grep -oE '^[0-9]+')"
+  [[ -z "${matched_n}" ]] && continue
+
+  if [[ "${matched_n}" == "${SSOT_COUNT}" ]]; then
+    continue
+  fi
+
+  # Domain disambiguation: "phase" is overloaded in this codebase —
+  # cascade FSM has 6 phases, turn cycle has 3 axes, decision pipeline
+  # has 5, etc.  Any subset/projection count is ≤7 and is never a
+  # keeper-count drift signal.  Only flag values in the range
+  # [SSOT_COUNT-3 .. SSOT_COUNT+5] so we catch realistic stale keeper
+  # counts (e.g. 12 vs 13) but not sibling-FSM enum sizes.
+  range_lo=$((SSOT_COUNT - 3))
+  range_hi=$((SSOT_COUNT + 5))
+  if (( matched_n < range_lo || matched_n > range_hi )); then
+    [[ "${VERBOSE}" -eq 1 ]] && \
+      echo "ok (out-of-keeper-range): ${file}:${lineno} — ${matched_n} not in [${range_lo}..${range_hi}]" >&2
+    continue
+  fi
+
+  if printf '%s' "${content}" | grep -qiE "${QUALIFIERS}"; then
+    [[ "${VERBOSE}" -eq 1 ]] && \
+      echo "ok (qualified): ${file}:${lineno} — ${matched_n} != ${SSOT_COUNT}" >&2
+    continue
+  fi
+
+  printf 'drift: %s:%s — mentions "%s phases" but SSOT has %s constructors (no qualifier on line)\n' \
+    "${file#${REPO_ROOT}/}" "${lineno}" "${matched_n}" "${SSOT_COUNT}"
+  drift_count=$((drift_count + 1))
+done < "${tmpfile}"
+
+if [[ "${drift_count}" -gt 0 ]]; then
+  echo "" >&2
+  echo "${drift_count} phase-count drift(s) detected." >&2
+  echo "Fix: update the spec comment to match keeper_state_machine.ml (${SSOT_COUNT} constructors)," >&2
+  echo "or add a qualifier (non-Zombie, projection, fragment, ...) if the mention is intentionally" >&2
+  echo "a subset count." >&2
+  exit 1
+fi
+
+echo "phase-count audit clean: SSOT=${SSOT_COUNT}, no unqualified mismatches." >&2

--- a/scripts/audit-tla-phase-count.sh
+++ b/scripts/audit-tla-phase-count.sh
@@ -31,7 +31,7 @@
 # script), 6th drift class structural closure.
 set -euo pipefail
 
-for tool in rg awk grep sed; do
+for tool in rg awk grep; do
   command -v "${tool}" >/dev/null 2>&1 || {
     echo "error: required tool '${tool}' not found in PATH" >&2
     exit 2
@@ -79,9 +79,21 @@ trap 'rm -f "${tmpfile}"' EXIT
 # rg without -o emits the full line; we parse number out per match.
 # We filter to comment lines (`\* `) only — body actions referencing
 # N are not the drift class this guard targets.
+#
+# rg exit codes: 0 = matches, 1 = no matches, 2+ = real error.  We
+# accept 0/1 silently (no-match is a legitimate clean run) but bubble
+# up 2+ as a script failure — otherwise a missing SPEC_DIR or an
+# invalid regex would produce a false-clean run.
+set +e
 rg -n --no-heading --glob '*.tla' \
   -e '\\\*[^\n]*\b([0-9]{1,2})[ -]phase(s)?\b' \
-  "${SPEC_DIR}" 2>/dev/null > "${tmpfile}" || true
+  "${SPEC_DIR}" 2>/dev/null > "${tmpfile}"
+rg_rc=$?
+set -e
+if [[ ${rg_rc} -ne 0 && ${rg_rc} -ne 1 ]]; then
+  echo "error: rg failed with exit code ${rg_rc} scanning ${SPEC_DIR}" >&2
+  exit 2
+fi
 
 while IFS= read -r entry; do
   [[ -z "${entry}" ]] && continue

--- a/specs/INDEX.md
+++ b/specs/INDEX.md
@@ -5,7 +5,7 @@ Edit the generator, not this file. Re-run: scripts/gen-tla-index.sh > specs/INDE
 
 # TLA+ Spec Index
 
-Generated: 2026-05-12T00:05:41Z (HEAD: a353848fa)
+Generated: 2026-05-12T00:16:59Z (HEAD: f3e4a5e1e)
 
 Source of truth: `specs/`. Run `scripts/gen-tla-index.sh > specs/INDEX.md` to refresh.
 


### PR DESCRIPTION
## Finding (Iteration 52, R-H-1.c — pipeline step 3/3)

**Script**: `scripts/audit-tla-phase-count.sh` (NEW, 141 LOC)
**CI**: `.github/workflows/tla-annotation-drift.yml` (added 2nd step)
**Aspect**: structural guard for the 6th drift class (spec-comment phase-count staleness)
**Risk**: LOW (read-only validator, no spec/OCaml modification, single CI step added to existing workflow)
**Workaround signature**: N/A — this PR is the closure mechanism for an already-fixed drift class.

## 순서도

```mermaid
flowchart TD
  A[CI fires on PR / push to main] --> B[Existing R-B-1.c<br/>annotation-drift validator]
  B --> C{Pass?}
  C -- No --> X[Fail CI: stale tla annotations]
  C -- Yes --> D[NEW R-H-1.c<br/>phase-count validator]
  D --> E[awk SSOT count<br/>from keeper_state_machine.ml<br/>type phase block]
  E --> F[rg sweep<br/>N phases in .tla comments]
  F --> G{Each match:<br/>N == SSOT?}
  G -- Yes --> H[OK]
  G -- No --> I{N in SSOT-3..SSOT+5 range?}
  I -- No --> J[OK out-of-range<br/>sibling FSM mention]
  I -- Yes --> K{Line has qualifier?<br/>non-/fragment/projection/...}
  K -- Yes --> L[OK qualified subset]
  K -- No --> M[FLAG drift]
```

## Pipeline (6th drift class structural closure)

| Step | iter | PR | Mechanism |
|------|------|----|-----------|
| 1 | 49 | audit memo (#14858) | Sweep audit identifying 7 stale "12 phases" mentions |
| 2 | 50 | #14863 (MERGED) | Batch fix: "12 phases" → "13 phases" in 7 specs |
| 2.5 | 51 | #14865 (MERGED) | Per-spec Zombie mapping notes (3 observer specs) |
| **3** | **52** | **this PR** | **Validator + CI: prevent regression on next phase-count change** |

## Before / After

```bash
# Before: drift caught by manual sweep audit (iter 49), 6 months after the fact

# After: drift caught at CI gate on the offending PR itself
$ bash scripts/audit-tla-phase-count.sh
phase-count audit clean: SSOT=13, no unqualified mismatches.

# Inject regression -> immediate flag
$ sed -i 's/13 phases/12 phases/' specs/keeper-state-machine/KeeperGenerationLineage.tla
$ bash scripts/audit-tla-phase-count.sh
drift: specs/keeper-state-machine/KeeperGenerationLineage.tla:44 — mentions "12 phases" but SSOT has 13 constructors (no qualifier on line)

1 phase-count drift(s) detected.
```

## 왜 톱니처럼 정교하지 않았던가

iter 4 (#14707)에서 `Zombie` constructor 추가로 OCaml `type phase`가 12 → 13으로 변경되었으나, 7개 sibling spec이 6개월간 stale "12 phases" 문구를 그대로 유지. 발견 경로는 iter 47 KCtxL Zombie gap 발견 → iter 49 corpus-wide sweep. 즉 구조적 가드 부재로 6개월 발견 지연. 본 PR이 그 가드.

## Verification (local)

| Case | Input | Expected | Actual |
|------|-------|----------|--------|
| Clean corpus | current main | exit 0 | ✅ exit 0 |
| Inject 12 phases | KGenerationLineage:44 | flag + exit 1 | ✅ flagged |
| Inject 14 phases | KReconcileLiveness:106 | flag + exit 1 | ✅ flagged |
| Out-of-range (25 phases) | KGenerationLineage:44 | exit 0 (no FP) | ✅ exit 0 |
| Sibling FSM enum mention (6 phases cascade) | KCompositeLifecycle:99 | exit 0 (range filter) | ✅ exit 0 |

## Design trade-offs

| Trade-off | 선택 | 이유 |
|-----------|------|------|
| Range filter [SSOT-3..+5] vs qualifier-only | range filter | "phase" 용어가 cascade/turn/decision FSM에 공유 → 단순 qualifier로는 false-positive 0차단 불가 |
| Inline 2nd step vs separate workflow | inline | 동일 path scope, 동일 컨텍스트. 분리 시 path 중복 유지비 ↑ |
| Bash + rg + awk vs OCaml/Python | bash | R-B-1.c 패밀리 일관성 유지, 의존성 0 추가 |
| BSD-portable (no `\b` in sed) | grep -oE 기반 | macOS dev / Linux CI 양쪽 호환 |

## Out of scope (follow-up)

- KCompositeLifecycle.tla:35,122 + KCoreTriad.tla:35의 "12->7 phase mapping" 표현은 Zombie 추가 후 ambiguous (실제 13→7 또는 "12 non-Zombie → 7"). 본 PR은 validator만 도입, 표현 정정은 별도 audit-only PR 후보.
- Phase 1 KSM 23-condition 카운트 검증은 별 chain (R-A-?), 본 6th drift class 외부.

## RFC 참조

RFC-WAIVED: R-H-1.c는 본 loop 내부 audit chain의 자가 클로저 (R-B-1.c family의 6번째). docs/rfc/ 산하 별도 RFC 미작성. 동일 패턴 선례: scripts/audit-tla-annotation-drift.sh (#14770), scripts/audit-tla-cfg-orphan.sh (iter 46 not yet CI-wired).

## 진행 추적

다음 iteration 시작점: R-D-2.a + R-D-1.a bundle (KCAF call_err 3-way split + Cascade_fsm.Exhausted 2-way split), 또는 R-D-1.d (ppx_tla prefix option) prerequisite.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
