### PR TITLE
style: apply ocamlformat to 12 recently merged files

### DIFF
--- a/lib/coord/coord_task_classify.ml
+++ b/lib/coord/coord_task_classify.ml
@@ -209,9 +209,7 @@ let missing_required_tools ~allowed required =
      pre-traversal (Hashtbl grows automatically). *)
   let allowed_set = Hashtbl.create 32 in
   List.iter (fun name -> Hashtbl.replace allowed_set name ()) allowed;
-  List.filter
-    (fun required_name -> not (Hashtbl.mem allowed_set required_name))
-    required
+  List.filter (fun required_name -> not (Hashtbl.mem allowed_set required_name)) required
 ;;
 
 let required_tool_claim_guard config ~agent_name ?agent_tool_names task =

--- a/lib/coord/coord_task_schedule.ml
+++ b/lib/coord/coord_task_schedule.ml
@@ -21,72 +21,74 @@ let task_status_label (status : Masc_domain.task_status) : string =
   | AwaitingVerification _ -> "awaiting_verification"
   | Done _ -> "done"
   | Cancelled _ -> "cancelled"
+;;
 
 let task_is_claim_pool_candidate (task : Masc_domain.task) =
   match task.task_status with
   | Todo ->
-      Option.is_none
-        (Coord_task.do_not_reclaim_reason_blocks_claim task.do_not_reclaim_reason)
-  | Claimed _ | InProgress _ | AwaitingVerification _ | Done _ | Cancelled _ ->
-      false
+    Option.is_none
+      (Coord_task.do_not_reclaim_reason_blocks_claim task.do_not_reclaim_reason)
+  | Claimed _ | InProgress _ | AwaitingVerification _ | Done _ | Cancelled _ -> false
+;;
 
 let task_is_primary_claim_pool_candidate (task : Masc_domain.task) =
   match task.task_status with
   | Todo -> Option.is_none task.do_not_reclaim_reason
-  | Claimed _ | InProgress _ | AwaitingVerification _ | Done _ | Cancelled _ ->
-      false
+  | Claimed _ | InProgress _ | AwaitingVerification _ | Done _ | Cancelled _ -> false
+;;
 
 let task_is_soft_reclaim_candidate (task : Masc_domain.task) =
   match task.task_status, task.do_not_reclaim_reason with
   | Todo, Some reason ->
-      Option.is_none (Coord_task.do_not_reclaim_reason_blocks_claim (Some reason))
+    Option.is_none (Coord_task.do_not_reclaim_reason_blocks_claim (Some reason))
   | Todo, None
   | Claimed _, _
   | InProgress _, _
   | AwaitingVerification _, _
   | Done _, _
-  | Cancelled _, _ ->
-      false
+  | Cancelled _, _ -> false
+;;
 
 type verification_claim_state =
-  [ `Pending | `Assigned | `Passed | `Rejected ]
+  [ `Pending
+  | `Assigned
+  | `Passed
+  | `Rejected
+  ]
 
-let verification_claim_state_of_status
-    (status : Coord_verification_store.request_status) =
+let verification_claim_state_of_status (status : Coord_verification_store.request_status) =
   match status with
   | `Pending -> `Pending
   | `Assigned _ -> `Assigned
   | `Completed `Pass -> `Passed
-  | `Completed (`Fail _ | `Partial _) ->
-      `Rejected
+  | `Completed (`Fail _ | `Partial _) -> `Rejected
+;;
 
 let latest_verification_status_by_task config =
   let latest = Hashtbl.create 16 in
   Coord_verification_store.list_request_headers config.base_path
   |> List.iter (fun (req : Coord_verification_store.request_header) ->
-         let state = verification_claim_state_of_status req.status in
-         match Hashtbl.find_opt latest req.task_id with
-         | Some (latest_created_at, _) when latest_created_at >= req.created_at ->
-             ()
-         | Some _ | None ->
-             Hashtbl.replace latest req.task_id (req.created_at, state));
+    let state = verification_claim_state_of_status req.status in
+    match Hashtbl.find_opt latest req.task_id with
+    | Some (latest_created_at, _) when latest_created_at >= req.created_at -> ()
+    | Some _ | None -> Hashtbl.replace latest req.task_id (req.created_at, state));
   latest
+;;
 
 let verification_blocks_claim latest_status_by_task (task : Masc_domain.task) =
   match Hashtbl.find_opt latest_status_by_task task.id with
-  | Some (_, `Pending)
-  | Some (_, `Assigned) -> true
+  | Some (_, `Pending) | Some (_, `Assigned) -> true
   | Some (_, `Rejected) -> false
-  | Some (_, `Passed)
-  | None -> false
+  | Some (_, `Passed) | None -> false
+;;
 
 let task_required_tools (task : Masc_domain.task) =
   match task.contract with
   | Some contract -> contract.required_tools
   | None -> []
+;;
 
-let string_list_contains all value =
-  List.exists (String.equal value) all
+let string_list_contains all value = List.exists (String.equal value) all
 
 (* Build [allowed] as a [(name, unit) Hashtbl.t] once.  Constant
    initial bucket size avoids the [List.length allowed] pre-traversal
@@ -96,22 +98,22 @@ let build_allowed_set allowed =
   let set = Hashtbl.create 32 in
   List.iter (fun name -> Hashtbl.replace set name ()) allowed;
   set
+;;
 
 let make_required_tools_predicate ?agent_tool_names () =
   match agent_tool_names with
   | None ->
-      (* Without an explicit surface, the surface is open: all required
+    (* Without an explicit surface, the surface is open: all required
          tools are considered allowed.  Empty [required] also short-
          circuits to [true] below. *)
-      fun _required_tools -> true
+    fun _required_tools -> true
   | Some allowed ->
-      let allowed_set = build_allowed_set allowed in
-      fun required_tools ->
-        match required_tools with
-        | [] -> true
-        | _ ->
-            List.for_all (fun name -> Hashtbl.mem allowed_set name)
-              required_tools
+    let allowed_set = build_allowed_set allowed in
+    fun required_tools ->
+      (match required_tools with
+       | [] -> true
+       | _ -> List.for_all (fun name -> Hashtbl.mem allowed_set name) required_tools)
+;;
 
 let required_tools_allowed ?agent_tool_names required_tools =
   (* Single-shot caller convenience.  Per-candidate loops should hoist
@@ -119,12 +121,23 @@ let required_tools_allowed ?agent_tool_names required_tools =
      is built once per claim cycle instead of once per candidate. *)
   let pred = make_required_tools_predicate ?agent_tool_names () in
   pred required_tools
+;;
 
 let underscore_name name =
-  String.map (function '-' -> '_' | c -> c) name
+  String.map
+    (function
+      | '-' -> '_'
+      | c -> c)
+    name
+;;
 
 let hyphen_name name =
-  String.map (function '_' -> '-' | c -> c) name
+  String.map
+    (function
+      | '_' -> '-'
+      | c -> c)
+    name
+;;
 
 let keeper_name_from_agent_name agent_name =
   let trimmed = String.trim agent_name in
@@ -136,18 +149,21 @@ let keeper_name_from_agent_name agent_name =
   else if String.ends_with ~suffix:"-agent" trimmed && String.length trimmed > 6
   then Some (String.sub trimmed 0 (String.length trimmed - 6))
   else None
+;;
 
 let agent_record_keeper_name config ~agent_name =
   let agent_file =
     Filename.concat (agents_dir config) (safe_filename agent_name ^ ".json")
   in
-  if path_exists config agent_file then
+  if path_exists config agent_file
+  then (
     match read_agent_with_repair config agent_file with
     | Ok { meta = Some { keeper_name = Some name; _ }; _ } ->
-        let name = String.trim name in
-        if name = "" then None else Some name
-    | Ok _ | Error _ -> None
+      let name = String.trim name in
+      if name = "" then None else Some name
+    | Ok _ | Error _ -> None)
   else None
+;;
 
 let keeper_receipt_candidate_names config ~agent_name =
   let base =
@@ -159,29 +175,36 @@ let keeper_receipt_candidate_names config ~agent_name =
   in
   base
   |> List.concat_map (fun name ->
-       let trimmed = String.trim name in
-       if trimmed = "" then []
-       else
-         [ trimmed; safe_filename trimmed; underscore_name trimmed; hyphen_name trimmed ])
+    let trimmed = String.trim name in
+    if trimmed = ""
+    then []
+    else [ trimmed; safe_filename trimmed; underscore_name trimmed; hyphen_name trimmed ])
   |> List.sort_uniq String.compare
+;;
 
 let directory_exists path =
-  try Sys.file_exists path && Sys.is_directory path with Sys_error _ -> false
+  try Sys.file_exists path && Sys.is_directory path with
+  | Sys_error _ -> false
+;;
 
 let directory_entries path =
-  try Sys.readdir path |> Array.to_list with Sys_error _ -> []
+  try Sys.readdir path |> Array.to_list with
+  | Sys_error _ -> []
+;;
 
 let jsonl_files_under base_dir =
-  if not (directory_exists base_dir) then []
+  if not (directory_exists base_dir)
+  then []
   else
     directory_entries base_dir
     |> List.filter_map (fun month ->
-         let month_dir = Filename.concat base_dir month in
-         if directory_exists month_dir then Some month_dir else None)
+      let month_dir = Filename.concat base_dir month in
+      if directory_exists month_dir then Some month_dir else None)
     |> List.concat_map (fun month_dir ->
-         directory_entries month_dir
-         |> List.filter (String.ends_with ~suffix:".jsonl")
-         |> List.map (Filename.concat month_dir))
+      directory_entries month_dir
+      |> List.filter (String.ends_with ~suffix:".jsonl")
+      |> List.map (Filename.concat month_dir))
+;;
 
 let last_nonempty_line path =
   try
@@ -192,220 +215,247 @@ let last_nonempty_line path =
          let rec loop last =
            match input_line input with
            | line ->
-               let trimmed = String.trim line in
-               loop (if trimmed = "" then last else Some trimmed)
+             let trimmed = String.trim line in
+             loop (if trimmed = "" then last else Some trimmed)
            | exception End_of_file -> last
          in
          loop None)
   with
   | Eio.Cancel.Cancelled _ as e -> raise e
   | Sys_error _ -> None
+;;
 
 let latest_json_in_receipt_dir base_dir =
   jsonl_files_under base_dir
   |> List.sort (fun a b -> compare b a)
   |> List.find_map (fun path ->
-       match last_nonempty_line path with
-       | None -> None
-       | Some line -> (
-           try Some (Yojson.Safe.from_string line)
-           with Yojson.Json_error _ -> None))
+    match last_nonempty_line path with
+    | None -> None
+    | Some line ->
+      (try Some (Yojson.Safe.from_string line) with
+       | Yojson.Json_error _ -> None))
+;;
 
 let json_member_path path json =
-  List.fold_left
-    (fun current key -> Yojson.Safe.Util.member key current)
-    json
-    path
+  List.fold_left (fun current key -> Yojson.Safe.Util.member key current) json path
+;;
 
 let json_raw_string_path path json =
   match json_member_path path json with
   | `String value -> Some (String.trim value)
   | _ -> None
+;;
 
 let json_string_path path json =
-  json_raw_string_path path json
-  |> Option.map String.lowercase_ascii
+  json_raw_string_path path json |> Option.map String.lowercase_ascii
+;;
 
 let receipt_sort_key json =
   match json_raw_string_path [ "recorded_at" ] json with
   | Some value -> value
-  | None ->
-      Option.value ~default:"" (json_raw_string_path [ "ended_at" ] json)
+  | None -> Option.value ~default:"" (json_raw_string_path [ "ended_at" ] json)
+;;
 
 let latest_execution_receipt_json config ~agent_name =
   let keeper_root = Filename.concat (masc_root_dir config) "keepers" in
   keeper_receipt_candidate_names config ~agent_name
   |> List.filter_map (fun keeper_name ->
-       let base_dir =
-         Filename.concat
-           (Filename.concat keeper_root keeper_name)
-           "execution-receipts"
-       in
-       latest_json_in_receipt_dir base_dir)
+    let base_dir =
+      Filename.concat (Filename.concat keeper_root keeper_name) "execution-receipts"
+    in
+    latest_json_in_receipt_dir base_dir)
   |> List.sort (fun a b -> compare (receipt_sort_key b) (receipt_sort_key a))
   |> List.find_opt (fun _ -> true)
+;;
 
 let json_string_list key json =
   match Yojson.Safe.Util.member key json with
   | `List items ->
-      List.filter_map
-        (function
-          | `String value ->
-              let trimmed = String.trim value in
-              if trimmed = "" then None else Some trimmed
-          | _ -> None)
-        items
+    List.filter_map
+      (function
+        | `String value ->
+          let trimmed = String.trim value in
+          if trimmed = "" then None else Some trimmed
+        | _ -> None)
+      items
   | _ -> []
+;;
 
 let latest_receipt_blocks_required_tool_claim config ~agent_name ~required_tools =
   match latest_execution_receipt_json config ~agent_name with
   | None -> false
   | Some receipt ->
-      let operator_reason =
-        json_string_path [ "operator_disposition_reason" ] receipt
-      in
-      let tool_contract_result =
-        json_string_path [ "tool_contract_result" ] receipt
-      in
-      let tool_requirement =
-        json_string_path [ "tool_surface"; "tool_requirement" ] receipt
-      in
-      let tools_used = json_string_list "tools_used" receipt in
-      let degraded_contract =
-        match tool_contract_result with
-        | Some
-            ( "violated"
-            | "unknown"
-            | "satisfied_by_deterministic_fallback"
-            | "needs_execution_progress"
-            | "missing_required_tool_use"
-            | "passive_only"
-            | "claim_only_after_owned_task"
-            | "tool_surface_mismatch"
-            | "no_tool_capable_provider" ) ->
-            true
-        | Some _ | None -> false
-      in
-      let visible_tools =
-        json_string_list "requested_tools" receipt
-        @ json_string_list "canonical_tools" receipt
-        @ tools_used
-      in
-      let required_tool_visible =
-        List.exists
-          (fun required_tool -> string_list_contains visible_tools required_tool)
-          required_tools
-      in
-      (operator_reason = Some "tool_required_no_tools"
-       || degraded_contract
-       || (tool_requirement = Some "required" && tools_used = []))
-      && not required_tool_visible
+    let operator_reason = json_string_path [ "operator_disposition_reason" ] receipt in
+    let tool_contract_result = json_string_path [ "tool_contract_result" ] receipt in
+    let tool_requirement =
+      json_string_path [ "tool_surface"; "tool_requirement" ] receipt
+    in
+    let tools_used = json_string_list "tools_used" receipt in
+    let degraded_contract =
+      match tool_contract_result with
+      | Some
+          ( "violated"
+          | "unknown"
+          | "satisfied_by_deterministic_fallback"
+          | "needs_execution_progress"
+          | "missing_required_tool_use"
+          | "passive_only"
+          | "claim_only_after_owned_task"
+          | "tool_surface_mismatch"
+          | "no_tool_capable_provider" ) -> true
+      | Some _ | None -> false
+    in
+    let visible_tools =
+      json_string_list "requested_tools" receipt
+      @ json_string_list "canonical_tools" receipt
+      @ tools_used
+    in
+    let required_tool_visible =
+      List.exists
+        (fun required_tool -> string_list_contains visible_tools required_tool)
+        required_tools
+    in
+    (operator_reason = Some "tool_required_no_tools"
+     || degraded_contract
+     || (tool_requirement = Some "required" && tools_used = []))
+    && not required_tool_visible
+;;
 
 let active_task_assignees_by_task_id backlog =
   let table = Hashtbl.create (List.length backlog.tasks) in
   List.iter
     (fun (task : Masc_domain.task) ->
-      match task.task_status with
-      | Claimed { assignee; _ } | InProgress { assignee; _ } ->
-          Hashtbl.replace table task.id assignee
-      | Todo | AwaitingVerification _ | Done _ | Cancelled _ -> ())
+       match task.task_status with
+       | Claimed { assignee; _ } | InProgress { assignee; _ } ->
+         Hashtbl.replace table task.id assignee
+       | Todo | AwaitingVerification _ | Done _ | Cancelled _ -> ())
     backlog.tasks;
   table
+;;
 
-let agent_current_task_matches_assignments active_task_assignees ~agent_name
-    task_id =
+let agent_current_task_matches_assignments active_task_assignees ~agent_name task_id =
   match Hashtbl.find_opt active_task_assignees task_id with
   | Some assignee -> String.equal assignee agent_name
   | None -> false
+;;
 
 let agent_current_task_matches_backlog backlog ~agent_name task_id =
   let active_task_assignees = active_task_assignees_by_task_id backlog in
-  agent_current_task_matches_assignments active_task_assignees ~agent_name
-    task_id
+  agent_current_task_matches_assignments active_task_assignees ~agent_name task_id
+;;
 
-let reconcile_agent_current_task_record config ?(touch_last_seen = true)
-    ~agent_file ~(agent : Masc_domain.agent) active_task_assignees =
+let reconcile_agent_current_task_record
+      config
+      ?(touch_last_seen = true)
+      ~agent_file
+      ~(agent : Masc_domain.agent)
+      active_task_assignees
+  =
   match agent.current_task with
   | Some task_id
     when not
-           (agent_current_task_matches_assignments active_task_assignees
-              ~agent_name:agent.name task_id)
-    ->
-      let updated_status =
-        match agent.status with
-        | Inactive -> Inactive
-        | Active | Busy | Listening -> Active
-      in
-      let updated =
-        {
-          agent with
-          status = updated_status;
-          current_task = None;
-          last_seen =
-            (if touch_last_seen then now_iso () else agent.last_seen);
-        }
-      in
-      write_json config agent_file (agent_to_yojson updated);
-      log_event config (`Assoc [
-           ("type", `String "agent_current_task_reconciled");
-           ("agent", `String agent.name);
-           ("stale_task", `String task_id);
-           ("ts", `String (now_iso ()));
-         ])
+           (agent_current_task_matches_assignments
+              active_task_assignees
+              ~agent_name:agent.name
+              task_id) ->
+    let updated_status =
+      match agent.status with
+      | Inactive -> Inactive
+      | Active | Busy | Listening -> Active
+    in
+    let updated =
+      { agent with
+        status = updated_status
+      ; current_task = None
+      ; last_seen = (if touch_last_seen then now_iso () else agent.last_seen)
+      }
+    in
+    write_json config agent_file (agent_to_yojson updated);
+    log_event
+      config
+      (`Assoc
+          [ "type", `String "agent_current_task_reconciled"
+          ; "agent", `String agent.name
+          ; "stale_task", `String task_id
+          ; "ts", `String (now_iso ())
+          ])
   | Some _ | None -> ()
+;;
 
-let reconcile_agent_current_task_with_assignments config ?(touch_last_seen = true)
-    ~agent_name active_task_assignees =
+let reconcile_agent_current_task_with_assignments
+      config
+      ?(touch_last_seen = true)
+      ~agent_name
+      active_task_assignees
+  =
   let agent_file =
     Filename.concat (agents_dir config) (safe_filename agent_name ^ ".json")
   in
-  if path_exists config agent_file then
+  if path_exists config agent_file
+  then
     with_file_lock config agent_file (fun () ->
       match read_agent_with_repair config agent_file with
       | Ok agent ->
-          reconcile_agent_current_task_record config ~touch_last_seen ~agent_file
-            ~agent active_task_assignees
-      | Error msg ->
-          Log.Misc.error "agent state reconcile failed: %s" msg)
+        reconcile_agent_current_task_record
+          config
+          ~touch_last_seen
+          ~agent_file
+          ~agent
+          active_task_assignees
+      | Error msg -> Log.Misc.error "agent state reconcile failed: %s" msg)
+;;
 
-let reconcile_agent_current_task_with_backlog config ?(touch_last_seen = true)
-    ~agent_name backlog =
+let reconcile_agent_current_task_with_backlog
+      config
+      ?(touch_last_seen = true)
+      ~agent_name
+      backlog
+  =
   let active_task_assignees = active_task_assignees_by_task_id backlog in
-  reconcile_agent_current_task_with_assignments config ~touch_last_seen
-    ~agent_name active_task_assignees
+  reconcile_agent_current_task_with_assignments
+    config
+    ~touch_last_seen
+    ~agent_name
+    active_task_assignees
+;;
 
-let reconcile_all_agent_current_tasks_with_backlog config
-    ?(touch_last_seen = true) backlog =
+let reconcile_all_agent_current_tasks_with_backlog
+      config
+      ?(touch_last_seen = true)
+      backlog
+  =
   let agents_path = agents_dir config in
   try
-    if Sys.file_exists agents_path then (
+    if Sys.file_exists agents_path
+    then (
       let active_task_assignees = active_task_assignees_by_task_id backlog in
       Sys.readdir agents_path
       |> Array.to_list
       |> List.filter (fun name -> Filename.check_suffix name ".json")
       |> List.iter (fun name ->
-           Coord_query.safe_yield ();
-           let path = Filename.concat agents_path name in
-           with_file_lock config path (fun () ->
-             match read_agent_with_repair config path with
-             | Ok (agent : Masc_domain.agent) ->
-                 reconcile_agent_current_task_record config ~touch_last_seen
-                   ~agent_file:path ~agent active_task_assignees
-             | Error msg ->
-                 Log.Misc.error "agent state reconcile failed for %s: %s" name
-                   msg)))
+        Coord_query.safe_yield ();
+        let path = Filename.concat agents_path name in
+        with_file_lock config path (fun () ->
+          match read_agent_with_repair config path with
+          | Ok (agent : Masc_domain.agent) ->
+            reconcile_agent_current_task_record
+              config
+              ~touch_last_seen
+              ~agent_file:path
+              ~agent
+              active_task_assignees
+          | Error msg -> Log.Misc.error "agent state reconcile failed for %s: %s" name msg)))
   with
-  | Sys_error msg ->
-      Log.Misc.error "agent state reconcile scan failed: %s" msg
+  | Sys_error msg -> Log.Misc.error "agent state reconcile scan failed: %s" msg
+;;
 
-let reconcile_all_agent_current_tasks_with_fresh_backlog
-    ?(touch_last_seen = true) config =
+let reconcile_all_agent_current_tasks_with_fresh_backlog ?(touch_last_seen = true) config =
   let backlog_path = Filename.concat (tasks_dir config) ".backlog" in
   with_file_lock config backlog_path (fun () ->
     let backlog = read_backlog config in
-    reconcile_all_agent_current_tasks_with_backlog config ~touch_last_seen
-      backlog;
+    reconcile_all_agent_current_tasks_with_backlog config ~touch_last_seen backlog;
     backlog)
+;;
 
 (** Claim next highest priority unclaimed task.
     Optional [exclude_task_ids] prevents re-claiming known bad tasks in the
@@ -427,366 +477,412 @@ let claim_next_r
   =
   let exception Existing_claim of claim_next_result in
   ensure_initialized config;
-
   let backlog_path = Filename.concat (tasks_dir config) ".backlog" in
   let claim_under_lock () =
     try
       match read_backlog_r config with
       | Error msg -> Claim_next_error msg
       | Ok backlog ->
-      reconcile_agent_current_task_with_backlog config ~agent_name backlog;
-
-      (* #10421: If this agent already holds a Claimed or InProgress task,
+        reconcile_agent_current_task_with_backlog config ~agent_name backlog;
+        (* #10421: If this agent already holds a Claimed or InProgress task,
          return that task instead of implicitly releasing it.  Automatic
          release caused keeper hot-potato loops: a repeated claim_next call
          could drop InProgress work back to Todo and let another keeper steal
          it before the original owner had a chance to finish.  AwaitingVerification
          is still excluded: it is no longer active implementation work for
          the claimant. *)
-      let previous_claim = List.find_opt (fun (t : Masc_domain.task) ->
-        match t.task_status with
-        | Claimed { assignee; _ } | InProgress { assignee; _ } ->
-            String.equal assignee agent_name
-        | Todo | AwaitingVerification _ | Done _ | Cancelled _ -> false
-      ) backlog.tasks in
-      (match previous_claim with
-       | None -> ()
-       | Some prev ->
+        let previous_claim =
+          List.find_opt
+            (fun (t : Masc_domain.task) ->
+               match t.task_status with
+               | Claimed { assignee; _ } | InProgress { assignee; _ } ->
+                 String.equal assignee agent_name
+               | Todo | AwaitingVerification _ | Done _ | Cancelled _ -> false)
+            backlog.tasks
+        in
+        (match previous_claim with
+         | None -> ()
+         | Some prev ->
            let from_status = task_status_label prev.task_status in
-           log_event config (`Assoc [
-             ("type", `String "task_claim_next_existing_task");
-             ("agent", `String agent_name);
-             ("task", `String prev.id);
-             ("from_status", `String from_status);
-             ("reason", `String "existing_claim_preserved");
-             ("ts", `String (now_iso ()));
-           ]);
+           log_event
+             config
+             (`Assoc
+                 [ "type", `String "task_claim_next_existing_task"
+                 ; "agent", `String agent_name
+                 ; "task", `String prev.id
+                 ; "from_status", `String from_status
+                 ; "reason", `String "existing_claim_preserved"
+                 ; "ts", `String (now_iso ())
+                 ]);
            Log.RoomTask.info
-             "task_claim_next preserved existing task: agent=%s task=%s \
-              from_status=%s — finish or explicitly release before claiming \
-              different work (#10421)"
-             agent_name prev.id from_status;
+             "task_claim_next preserved existing task: agent=%s task=%s from_status=%s — \
+              finish or explicitly release before claiming different work (#10421)"
+             agent_name
+             prev.id
+             from_status;
            Coord_task.update_local_agent_state config ~agent_name (fun agent ->
              { agent with status = Busy; current_task = Some prev.id });
            let message =
              Printf.sprintf
-               "%s already holds [P%d] %s: %s. ACTION: Resume this task; \
-                do not call claim_next again until it is done or explicitly \
-                released."
-               agent_name prev.priority prev.id prev.title
+               "%s already holds [P%d] %s: %s. ACTION: Resume this task; do not call \
+                claim_next again until it is done or explicitly released."
+               agent_name
+               prev.priority
+               prev.id
+               prev.title
            in
            raise
              (Existing_claim
                 (Claim_next_claimed
-                   {
-                     task_id = prev.id;
-                     title = prev.title;
-                     priority = prev.priority;
-                     released_task_id = None;
-                     message;
+                   { task_id = prev.id
+                   ; title = prev.title
+                   ; priority = prev.priority
+                   ; released_task_id = None
+                   ; message
                    })));
-      let observe_legacy_release () =
-        ()
-      in
-      let released_task_id, working_tasks = None, backlog.tasks in
-
-      (* Starvation prevention: Calculate effective priority
+        let observe_legacy_release () = () in
+        let released_task_id, working_tasks = None, backlog.tasks in
+        (* Starvation prevention: Calculate effective priority
          Tasks waiting >24h get priority boost (-1 per 24h, min 1) *)
-      let now = Time_compat.now () in
-      (* Reuse canonical UTC parser from Types_core *)
-      let parse_time = Types_core.parse_iso8601_opt in
-      let effective_priority (task : Masc_domain.task) =
-        let age_hours =
-          match parse_time task.created_at with
-          | Some created -> (now -. created) /. 3600.0
-          | None -> 0.0
+        let now = Time_compat.now () in
+        (* Reuse canonical UTC parser from Types_core *)
+        let parse_time = Types_core.parse_iso8601_opt in
+        let effective_priority (task : Masc_domain.task) =
+          let age_hours =
+            match parse_time task.created_at with
+            | Some created -> (now -. created) /. 3600.0
+            | None -> 0.0
+          in
+          let boost = Float.to_int (Float.round (age_hours /. 24.0)) in
+          max 1 (task.priority - boost)
         in
-        let boost = Float.to_int (Float.round (age_hours /. 24.0)) in
-        max 1 (task.priority - boost)
-      in
-
-      (* Find highest priority (lowest number) unclaimed task
+        (* Find highest priority (lowest number) unclaimed task
          Within same priority, prefer older tasks (FIFO) *)
-      let sorted = List.sort (fun a b ->
-        let priority_cmp = compare (effective_priority a) (effective_priority b) in
-        if priority_cmp <> 0 then priority_cmp
-        else compare a.created_at b.created_at
-      ) working_tasks in
-      (* Identify blocked Todo tasks for observability *)
-      let all_todo = List.filter (fun (t : Masc_domain.task) ->
-        t.task_status = Masc_domain.Todo
-      ) sorted in
-      let blocked_todo = List.filter (fun (t : Masc_domain.task) ->
-        Option.is_some
-          (Coord_task.do_not_reclaim_reason_blocks_claim t.do_not_reclaim_reason)
-      ) all_todo in
-      let latest_verification_status = latest_verification_status_by_task config in
-      let verification_blocked_todo =
-        List.filter (verification_blocks_claim latest_verification_status) all_todo
-      in
-      if blocked_todo <> [] then
-        log_event config
-          (`Assoc [
-             ("type", `String "task_claim_next_skip_blocked");
-             ("agent", `String agent_name);
-             ("blocked", `Int (List.length blocked_todo));
-             ("ts", `String (now_iso ()));
-           ]);
-      if verification_blocked_todo <> [] then
-        log_event config
-          (`Assoc [
-             ("type", `String "task_claim_next_skip_verification");
-             ("agent", `String agent_name);
-             ("blocked", `Int (List.length verification_blocked_todo));
-             ("ts", `String (now_iso ()));
-           ]);
-
-      let primary_unclaimed =
-        List.filter task_is_primary_claim_pool_candidate sorted
-      in
-      let soft_unclaimed =
-        List.filter task_is_soft_reclaim_candidate sorted
-      in
-      let unclaimed =
-        List.filter task_is_claim_pool_candidate sorted
-      in
-      (* Also exclude the just-released task: the agent is moving on,
+        let sorted =
+          List.sort
+            (fun a b ->
+               let priority_cmp = compare (effective_priority a) (effective_priority b) in
+               if priority_cmp <> 0
+               then priority_cmp
+               else compare a.created_at b.created_at)
+            working_tasks
+        in
+        (* Identify blocked Todo tasks for observability *)
+        let all_todo =
+          List.filter
+            (fun (t : Masc_domain.task) -> t.task_status = Masc_domain.Todo)
+            sorted
+        in
+        let blocked_todo =
+          List.filter
+            (fun (t : Masc_domain.task) ->
+               Option.is_some
+                 (Coord_task.do_not_reclaim_reason_blocks_claim t.do_not_reclaim_reason))
+            all_todo
+        in
+        let latest_verification_status = latest_verification_status_by_task config in
+        let verification_blocked_todo =
+          List.filter (verification_blocks_claim latest_verification_status) all_todo
+        in
+        if blocked_todo <> []
+        then
+          log_event
+            config
+            (`Assoc
+                [ "type", `String "task_claim_next_skip_blocked"
+                ; "agent", `String agent_name
+                ; "blocked", `Int (List.length blocked_todo)
+                ; "ts", `String (now_iso ())
+                ]);
+        if verification_blocked_todo <> []
+        then
+          log_event
+            config
+            (`Assoc
+                [ "type", `String "task_claim_next_skip_verification"
+                ; "agent", `String agent_name
+                ; "blocked", `Int (List.length verification_blocked_todo)
+                ; "ts", `String (now_iso ())
+                ]);
+        let primary_unclaimed = List.filter task_is_primary_claim_pool_candidate sorted in
+        let soft_unclaimed = List.filter task_is_soft_reclaim_candidate sorted in
+        let unclaimed = List.filter task_is_claim_pool_candidate sorted in
+        (* Also exclude the just-released task: the agent is moving on,
          re-claiming the same task would be a no-op loop. *)
-      let blocked_ids =
-        List.map (fun (t : Masc_domain.task) -> t.id) blocked_todo
-        @ List.map (fun (t : Masc_domain.task) -> t.id) verification_blocked_todo
-        |> List.sort_uniq String.compare
-      in
-      let all_excluded = match released_task_id with
-        | Some rid -> rid :: (blocked_ids @ exclude_task_ids)
-        | None -> blocked_ids @ exclude_task_ids
-      in
-      let receipt_blocks_task (task : task) =
-        match agent_tool_names with
-        | Some _ -> false
-        | None ->
-          let required_tools = task_required_tools task in
-          required_tools <> []
-          && latest_receipt_blocks_required_tool_claim config ~agent_name
-               ~required_tools
-      in
-      if Option.is_none agent_tool_names
-         && List.exists (fun task -> task_required_tools task <> []) unclaimed
-      then
-        log_event config
-          (`Assoc [
-             ("type", `String "task_claim_next_required_tools_unknown_surface");
-             ("agent", `String agent_name);
-             ("candidate_count", `Int (List.length
-                (List.filter (fun task -> task_required_tools task <> []) unclaimed)));
-             ("ts", `String (now_iso ()));
-           ]);
-      (* Hoist allowed-set materialisation above the per-candidate
+        let blocked_ids =
+          List.map (fun (t : Masc_domain.task) -> t.id) blocked_todo
+          @ List.map (fun (t : Masc_domain.task) -> t.id) verification_blocked_todo
+          |> List.sort_uniq String.compare
+        in
+        let all_excluded =
+          match released_task_id with
+          | Some rid -> rid :: (blocked_ids @ exclude_task_ids)
+          | None -> blocked_ids @ exclude_task_ids
+        in
+        let receipt_blocks_task (task : task) =
+          match agent_tool_names with
+          | Some _ -> false
+          | None ->
+            let required_tools = task_required_tools task in
+            required_tools <> []
+            && latest_receipt_blocks_required_tool_claim
+                 config
+                 ~agent_name
+                 ~required_tools
+        in
+        if
+          Option.is_none agent_tool_names
+          && List.exists (fun task -> task_required_tools task <> []) unclaimed
+        then
+          log_event
+            config
+            (`Assoc
+                [ "type", `String "task_claim_next_required_tools_unknown_surface"
+                ; "agent", `String agent_name
+                ; ( "candidate_count"
+                  , `Int
+                      (List.length
+                         (List.filter
+                            (fun task -> task_required_tools task <> [])
+                            unclaimed)) )
+                ; "ts", `String (now_iso ())
+                ]);
+        (* Hoist allowed-set materialisation above the per-candidate
          filter so we pay O(A) once instead of O(R*A).  Restores the
          O(R+A) win that this PR's title advertises. *)
-      let required_tools_allowed_for_agent =
-        make_required_tools_predicate ?agent_tool_names ()
-      in
-      let required_tool_claim_allowed (task : task) =
-        let required_tools = task_required_tools task in
-        required_tools_allowed_for_agent required_tools
-        && not (receipt_blocks_task task)
-      in
-      let required_tool_excluded =
-        List.filter
-          (fun (t : task) ->
-             (not (List.mem t.id all_excluded))
-             && task_filter t
-             && not (required_tool_claim_allowed t))
-          unclaimed
-      in
-      if required_tool_excluded <> [] then
-        log_event config (`Assoc [
-          ("type", `String "task_claim_next_skip_required_tools");
-          ("agent", `String agent_name);
-          ("blocked", `Int (List.length required_tool_excluded));
-          ("receipt_blocked", `Bool (List.exists receipt_blocks_task required_tool_excluded));
-          ("agent_tool_names_known", `Bool (Option.is_some agent_tool_names));
-          ("ts", `String (now_iso ()));
-        ]);
-      let effective_task_filter task =
-        task_filter task && required_tool_claim_allowed task
-      in
-      let task_filter_excluded =
-        List.filter
-          (fun (t : task) -> (not (List.mem t.id all_excluded)) && not (task_filter t))
-          unclaimed
-      in
-      let eligible_from candidates =
-        List.filter
-          (fun (t : task) ->
-             (not (List.mem t.id all_excluded)) && effective_task_filter t)
-          candidates
-      in
-      let primary_eligible = eligible_from primary_unclaimed in
-      let eligible =
-        match primary_eligible with
-        | _ :: _ -> primary_eligible
-        | [] -> eligible_from soft_unclaimed
-      in
-
-      (* Helper: clear agent current_task and reset status after a legacy
+        let required_tools_allowed_for_agent =
+          make_required_tools_predicate ?agent_tool_names ()
+        in
+        let required_tool_claim_allowed (task : task) =
+          let required_tools = task_required_tools task in
+          required_tools_allowed_for_agent required_tools
+          && not (receipt_blocks_task task)
+        in
+        let required_tool_excluded =
+          List.filter
+            (fun (t : task) ->
+               (not (List.mem t.id all_excluded))
+               && task_filter t
+               && not (required_tool_claim_allowed t))
+            unclaimed
+        in
+        if required_tool_excluded <> []
+        then
+          log_event
+            config
+            (`Assoc
+                [ "type", `String "task_claim_next_skip_required_tools"
+                ; "agent", `String agent_name
+                ; "blocked", `Int (List.length required_tool_excluded)
+                ; ( "receipt_blocked"
+                  , `Bool (List.exists receipt_blocks_task required_tool_excluded) )
+                ; "agent_tool_names_known", `Bool (Option.is_some agent_tool_names)
+                ; "ts", `String (now_iso ())
+                ]);
+        let effective_task_filter task =
+          task_filter task && required_tool_claim_allowed task
+        in
+        let task_filter_excluded =
+          List.filter
+            (fun (t : task) -> (not (List.mem t.id all_excluded)) && not (task_filter t))
+            unclaimed
+        in
+        let eligible_from candidates =
+          List.filter
+            (fun (t : task) ->
+               (not (List.mem t.id all_excluded)) && effective_task_filter t)
+            candidates
+        in
+        let primary_eligible = eligible_from primary_unclaimed in
+        let eligible =
+          match primary_eligible with
+          | _ :: _ -> primary_eligible
+          | [] -> eligible_from soft_unclaimed
+        in
+        (* Helper: clear agent current_task and reset status after a legacy
          released_task_id path when no replacement task can be claimed. Delegates to
          [Coord_task.update_local_agent_state] so the agent-file write
          holds [with_file_lock] on the agent file itself, matching the
          discipline used by [Coord_task] transitions (PR #6634). *)
-      let clear_agent_state_after_release () =
-        match released_task_id with
-        | Some _ ->
+        let clear_agent_state_after_release () =
+          match released_task_id with
+          | Some _ ->
             Coord_task.update_local_agent_state config ~agent_name (fun agent ->
               { agent with status = Active; current_task = None })
-        | None -> ()
-      in
-
-      match all_todo, eligible with
-      | [], _ ->
-          (* Even if we released a task, there may be nothing else to claim.
+          | None -> ()
+        in
+        (match all_todo, eligible with
+         | [], _ ->
+           (* Even if we released a task, there may be nothing else to claim.
              Write the release if it happened. *)
-          (match released_task_id with
-           | Some _ ->
-               let new_backlog = {
-                 tasks = working_tasks;
-                 last_updated = now_iso ();
-                 version = backlog.version + 1;
-               } in
-               write_backlog config new_backlog;
-               observe_legacy_release ()
-           | None -> ());
-          clear_agent_state_after_release ();
-          Claim_next_no_unclaimed
-      | _ :: _, [] ->
-          (match released_task_id with
-           | Some _ ->
-               let new_backlog = {
-                 tasks = working_tasks;
-                 last_updated = now_iso ();
-                 version = backlog.version + 1;
-               } in
-               write_backlog config new_backlog;
-               observe_legacy_release ()
-           | None -> ());
-          clear_agent_state_after_release ();
-          Claim_next_no_eligible
-            {
-              excluded_count =
-                List.length all_excluded
-                + List.length task_filter_excluded
-                + List.length required_tool_excluded;
-            }
-      | _ :: _, task :: _ ->
-          (* Claim this task *)
-          let new_tasks = List.map (fun (t : task) ->
-            if t.id = task.id then
-              let t =
-                t
-                |> Coord_task.clear_soft_do_not_reclaim_reason
-                |> Coord_task.clear_stale_worktree_binding
+           (match released_task_id with
+            | Some _ ->
+              let new_backlog =
+                { tasks = working_tasks
+                ; last_updated = now_iso ()
+                ; version = backlog.version + 1
+                }
               in
-              {
-                t with
-                task_status =
-                  Claimed { assignee = agent_name; claimed_at = now_iso () };
-              }
-            else t
-          ) working_tasks in
-
-          let new_backlog = {
-            tasks = new_tasks;
-            last_updated = now_iso ();
-            version = backlog.version + 1;
-          } in
-          write_backlog config new_backlog;
-
-          (* Update agent status — takes [with_file_lock] on the
+              write_backlog config new_backlog;
+              observe_legacy_release ()
+            | None -> ());
+           clear_agent_state_after_release ();
+           Claim_next_no_unclaimed
+         | _ :: _, [] ->
+           (match released_task_id with
+            | Some _ ->
+              let new_backlog =
+                { tasks = working_tasks
+                ; last_updated = now_iso ()
+                ; version = backlog.version + 1
+                }
+              in
+              write_backlog config new_backlog;
+              observe_legacy_release ()
+            | None -> ());
+           clear_agent_state_after_release ();
+           Claim_next_no_eligible
+             { excluded_count =
+                 List.length all_excluded
+                 + List.length task_filter_excluded
+                 + List.length required_tool_excluded
+             }
+         | _ :: _, task :: _ ->
+           (* Claim this task *)
+           let new_tasks =
+             List.map
+               (fun (t : task) ->
+                  if t.id = task.id
+                  then (
+                    let t =
+                      t
+                      |> Coord_task.clear_soft_do_not_reclaim_reason
+                      |> Coord_task.clear_stale_worktree_binding
+                    in
+                    { t with
+                      task_status =
+                        Claimed { assignee = agent_name; claimed_at = now_iso () }
+                    })
+                  else t)
+               working_tasks
+           in
+           let new_backlog =
+             { tasks = new_tasks
+             ; last_updated = now_iso ()
+             ; version = backlog.version + 1
+             }
+           in
+           write_backlog config new_backlog;
+           (* Update agent status — takes [with_file_lock] on the
              agent file via [Coord_task.update_local_agent_state] to
              keep the record consistent with concurrent
              [Coord_agent.update_agent_r] or other task transitions
              that hold the agent-file lock (PR #6634). *)
-          Coord_task.update_local_agent_state config ~agent_name (fun agent ->
-            { agent with status = Busy; current_task = Some task.id });
-
-          (* No broadcast — log_event + emit_task_activity below are sufficient. *)
-          (match released_task_id with
-           | Some rid ->
-               Coord_task.emit_task_activity config ~agent_name ~task_id:rid
-                 ~kind:(Event_kind.Task.to_string Event_kind.Task.Released)
-                 ~payload:(`Assoc [ ("task_id", `String rid) ]);
-               observe_legacy_release ()
-           | None -> ());
-          Coord_task.emit_task_activity config ~agent_name ~task_id:task.id
-            ~kind:(Event_kind.Task.to_string Event_kind.Task.Claimed)
-            ~payload:
-              (`Assoc
-                [
-                  ("task_id", `String task.id);
-                  ("title", `String task.title);
-                  ("priority", `Int task.priority);
-                ]);
-
-          log_event config (`Assoc [
-            ("type", `String "task_claim_next");
-            ("agent", `String agent_name);
-            ("task", `String task.id);
-            ("priority", `Int task.priority);
-            ("ts", `String (now_iso ()));
-          ]);
-          Coord_task.observe_task_transition config ~agent_name ~task_id:task.id
-            ~transition:Masc_domain.Claim
-            ~details:
-              (Coord_task.task_transition_details ~from_status:Masc_domain.Todo
-                 ~to_status:
-                   (Masc_domain.Claimed
-                      { assignee = agent_name; claimed_at = now_iso () })
-                 ());
-          (try
-             (Atomic.get Coord_hooks.claim_post_provision_fn) config ~agent_name
-               ~task_id:task.id
-           with
-           | Eio.Cancel.Cancelled _ as e -> raise e
-           | exn ->
-               Coord_hooks.observe_claim_post_provision_failure
-                 ~site:"claim_next" ~agent_name ~task_id:task.id exn);
-
-          let message = match released_task_id with
+           Coord_task.update_local_agent_state config ~agent_name (fun agent ->
+             { agent with status = Busy; current_task = Some task.id });
+           (* No broadcast — log_event + emit_task_activity below are sufficient. *)
+           (match released_task_id with
             | Some rid ->
-                Printf.sprintf "%s released %s, then claimed [P%d] %s: %s"
-                  agent_name rid task.priority task.id task.title
-            | None ->
-                Printf.sprintf "%s auto-claimed [P%d] %s: %s"
-                  agent_name task.priority task.id task.title
-          in
-          Claim_next_claimed {
-            task_id = task.id;
-            title = task.title;
-            priority = task.priority;
-            released_task_id;
-            message;
-          }
+              Coord_task.emit_task_activity
+                config
+                ~agent_name
+                ~task_id:rid
+                ~kind:(Event_kind.Task.to_string Event_kind.Task.Released)
+                ~payload:(`Assoc [ "task_id", `String rid ]);
+              observe_legacy_release ()
+            | None -> ());
+           Coord_task.emit_task_activity
+             config
+             ~agent_name
+             ~task_id:task.id
+             ~kind:(Event_kind.Task.to_string Event_kind.Task.Claimed)
+             ~payload:
+               (`Assoc
+                   [ "task_id", `String task.id
+                   ; "title", `String task.title
+                   ; "priority", `Int task.priority
+                   ]);
+           log_event
+             config
+             (`Assoc
+                 [ "type", `String "task_claim_next"
+                 ; "agent", `String agent_name
+                 ; "task", `String task.id
+                 ; "priority", `Int task.priority
+                 ; "ts", `String (now_iso ())
+                 ]);
+           Coord_task.observe_task_transition
+             config
+             ~agent_name
+             ~task_id:task.id
+             ~transition:Masc_domain.Claim
+             ~details:
+               (Coord_task.task_transition_details
+                  ~from_status:Masc_domain.Todo
+                  ~to_status:
+                    (Masc_domain.Claimed
+                       { assignee = agent_name; claimed_at = now_iso () })
+                  ());
+           (try
+              (Atomic.get Coord_hooks.claim_post_provision_fn)
+                config
+                ~agent_name
+                ~task_id:task.id
+            with
+            | Eio.Cancel.Cancelled _ as e -> raise e
+            | exn ->
+              Coord_hooks.observe_claim_post_provision_failure
+                ~site:"claim_next"
+                ~agent_name
+                ~task_id:task.id
+                exn);
+           let message =
+             match released_task_id with
+             | Some rid ->
+               Printf.sprintf
+                 "%s released %s, then claimed [P%d] %s: %s"
+                 agent_name
+                 rid
+                 task.priority
+                 task.id
+                 task.title
+             | None ->
+               Printf.sprintf
+                 "%s auto-claimed [P%d] %s: %s"
+                 agent_name
+                 task.priority
+                 task.id
+                 task.title
+           in
+           Claim_next_claimed
+             { task_id = task.id
+             ; title = task.title
+             ; priority = task.priority
+             ; released_task_id
+             ; message
+             })
     with
     | Existing_claim result -> result
     | Eio.Cancel.Cancelled _ as e -> raise e
-    | e ->
-      Claim_next_error (Printexc.to_string e)
+    | e -> Claim_next_error (Printexc.to_string e)
   in
   match with_file_lock_r config backlog_path claim_under_lock with
   | Ok result -> result
   | Error err -> Claim_next_error (Masc_domain.masc_error_to_string err)
+;;
 
 (** Claim next highest priority unclaimed task (legacy string API). *)
 let claim_next config ~agent_name =
   match claim_next_r config ~agent_name () with
   | Claim_next_claimed { message; _ } -> message
-  | Claim_next_no_unclaimed -> "No unclaimed tasks. ACTION: Stop task-checking — nothing to claim."
+  | Claim_next_no_unclaimed ->
+    "No unclaimed tasks. ACTION: Stop task-checking — nothing to claim."
   | Claim_next_no_eligible { excluded_count } ->
-      Printf.sprintf
-        "No eligible unclaimed tasks. ACTION: Stop task-checking — blocked/excluded=%d."
-        excluded_count
+    Printf.sprintf
+      "No eligible unclaimed tasks. ACTION: Stop task-checking — blocked/excluded=%d."
+      excluded_count
   | Claim_next_error e -> Printf.sprintf "Error: %s" e
+;;
 
 (** Release stale task claims older than [ttl_seconds].
     A Claimed or InProgress task whose assignee has no recent heartbeat
@@ -798,86 +894,95 @@ let release_stale_claims config ~ttl_seconds =
   let release_under_lock () =
     match read_backlog_r config with
     | Error msg ->
-        Log.Orchestrator.error
-          "[stale-claims] skipping backlog mutation due to read failure: %s"
-          msg;
-        []
+      Log.Orchestrator.error
+        "[stale-claims] skipping backlog mutation due to read failure: %s"
+        msg;
+      []
     | Ok backlog ->
-        let now_str = now_iso () in
-        let now_f = Time_compat.now () in
-        let age_seconds_json ts =
-          `Float (max 0.0 (now_f -. ts))
-        in
-        let stale_tasks = ref [] in
-        (* RFC-0034.d: clear assignee's [current_task] mirror when we
+      let now_str = now_iso () in
+      let now_f = Time_compat.now () in
+      let age_seconds_json ts = `Float (max 0.0 (now_f -. ts)) in
+      let stale_tasks = ref [] in
+      (* RFC-0034.d: clear assignee's [current_task] mirror when we
            release a stale Claimed/InProgress task.  Best-effort — agent
            file lock is a different file/identity from the backlog lock,
            and on failure we keep the backlog mutation (the source of
            truth) and only log the agent-side miss.  Eio.Cancel.Cancelled
            is re-raised to match surrounding cancel semantics. *)
-        let clear_assignee_current_task ~assignee ~task_id =
-          try
-            Coord_task.update_local_agent_state config ~agent_name:assignee
-              (fun agent ->
-                if agent.current_task = Some task_id
-                then { agent with current_task = None }
-                else agent)
-          with
-          | Eio.Cancel.Cancelled _ as e -> raise e
-          | exn ->
-              Log.Orchestrator.warn
-                "[stale-claims] agent state clear failed for %s task=%s: %s"
-                assignee task_id (Printexc.to_string exn)
+      let clear_assignee_current_task ~assignee ~task_id =
+        try
+          Coord_task.update_local_agent_state config ~agent_name:assignee (fun agent ->
+            if agent.current_task = Some task_id
+            then { agent with current_task = None }
+            else agent)
+        with
+        | Eio.Cancel.Cancelled _ as e -> raise e
+        | exn ->
+          Log.Orchestrator.warn
+            "[stale-claims] agent state clear failed for %s task=%s: %s"
+            assignee
+            task_id
+            (Printexc.to_string exn)
+      in
+      let updated_tasks =
+        List.map
+          (fun (task : task) ->
+             match task.task_status with
+             | Claimed { assignee; claimed_at } ->
+               let ts =
+                 parse_iso8601 ~default_time:(now_f -. ttl_seconds -. 1.0) claimed_at
+               in
+               if now_f -. ts > ttl_seconds
+               then (
+                 stale_tasks := (task.id, assignee) :: !stale_tasks;
+                 log_event
+                   config
+                   (`Assoc
+                       [ "type", `String "stale_claim_released"
+                       ; "task_id", `String task.id
+                       ; "assignee", `String assignee
+                       ; "age_s", age_seconds_json ts
+                       ; "ts", `String now_str
+                       ]);
+                 clear_assignee_current_task ~assignee ~task_id:task.id;
+                 { task with task_status = Todo; worktree = None })
+               else task
+             | InProgress { assignee; started_at } ->
+               let ts =
+                 parse_iso8601 ~default_time:(now_f -. ttl_seconds -. 1.0) started_at
+               in
+               if now_f -. ts > ttl_seconds
+               then (
+                 stale_tasks := (task.id, assignee) :: !stale_tasks;
+                 log_event
+                   config
+                   (`Assoc
+                       [ "type", `String "stale_inprogress_released"
+                       ; "task_id", `String task.id
+                       ; "assignee", `String assignee
+                       ; "age_s", age_seconds_json ts
+                       ; "ts", `String now_str
+                       ]);
+                 clear_assignee_current_task ~assignee ~task_id:task.id;
+                 { task with task_status = Todo; worktree = None })
+               else task
+             | AwaitingVerification _ -> task (* leave alone; awaiting verifier *)
+             | Todo | Done _ | Cancelled _ -> task)
+          backlog.tasks
+      in
+      if !stale_tasks <> []
+      then (
+        let updated_backlog =
+          { tasks = updated_tasks; last_updated = now_str; version = backlog.version + 1 }
         in
-        let updated_tasks = List.map (fun (task : task) ->
-          match task.task_status with
-          | Claimed { assignee; claimed_at } ->
-              let ts = parse_iso8601 ~default_time:(now_f -. ttl_seconds -. 1.0) claimed_at in
-              if now_f -. ts > ttl_seconds then begin
-                stale_tasks := (task.id, assignee) :: !stale_tasks;
-                log_event config (`Assoc [
-                  ("type", `String "stale_claim_released");
-                  ("task_id", `String task.id);
-                  ("assignee", `String assignee);
-                  ("age_s", age_seconds_json ts);
-                  ("ts", `String now_str);
-                ]);
-                clear_assignee_current_task ~assignee ~task_id:task.id;
-                { task with
-                  task_status = Todo;
-                  worktree = None;
-                }
-              end else task
-          | InProgress { assignee; started_at } ->
-              let ts = parse_iso8601 ~default_time:(now_f -. ttl_seconds -. 1.0) started_at in
-              if now_f -. ts > ttl_seconds then begin
-                stale_tasks := (task.id, assignee) :: !stale_tasks;
-                log_event config (`Assoc [
-                  ("type", `String "stale_inprogress_released");
-                  ("task_id", `String task.id);
-                  ("assignee", `String assignee);
-                  ("age_s", age_seconds_json ts);
-                  ("ts", `String now_str);
-                ]);
-                clear_assignee_current_task ~assignee ~task_id:task.id;
-                { task with
-                  task_status = Todo;
-                  worktree = None;
-                }
-              end else task
-          | AwaitingVerification _ -> task  (* leave alone; awaiting verifier *)
-        | Todo | Done _ | Cancelled _ -> task
-      ) backlog.tasks in
-        if !stale_tasks <> [] then begin
-          let updated_backlog = { tasks = updated_tasks; last_updated = now_str; version = backlog.version + 1 } in
-          write_backlog config updated_backlog
-        end;
-        List.rev !stale_tasks
+        write_backlog config updated_backlog);
+      List.rev !stale_tasks
   in
   match with_file_lock_r config backlog_path release_under_lock with
   | Ok released -> released
   | Error err ->
-      Log.Orchestrator.warn
-        "[stale-claims] skipping backlog mutation due to lock failure: %s"
-        (Masc_domain.masc_error_to_string err);
-      []
+    Log.Orchestrator.warn
+      "[stale-claims] skipping backlog mutation due to lock failure: %s"
+      (Masc_domain.masc_error_to_string err);
+    []
+;;

--- a/lib/coord/coord_task_schedule.mli
+++ b/lib/coord/coord_task_schedule.mli
@@ -8,28 +8,33 @@ include module type of Coord_state
 (** Lifecycle state of a verification request, used by the claim
     gate to decide whether a task can be reclaimed. *)
 type verification_claim_state =
-  [ `Pending | `Assigned | `Passed | `Rejected ]
+  [ `Pending
+  | `Assigned
+  | `Passed
+  | `Rejected
+  ]
 
 val task_status_label : Masc_domain.task_status -> string
 val task_is_claim_pool_candidate : Masc_domain.task -> bool
 val task_is_primary_claim_pool_candidate : Masc_domain.task -> bool
 val task_is_soft_reclaim_candidate : Masc_domain.task -> bool
 
-val verification_claim_state_of_status :
-  Coord_verification_store.request_status -> verification_claim_state
+val verification_claim_state_of_status
+  :  Coord_verification_store.request_status
+  -> verification_claim_state
 
-val latest_verification_status_by_task :
-  config -> (string, float * verification_claim_state) Hashtbl.t
+val latest_verification_status_by_task
+  :  config
+  -> (string, float * verification_claim_state) Hashtbl.t
 
-val verification_blocks_claim :
-  (string, 'a * verification_claim_state) Hashtbl.t ->
-  Masc_domain.task -> bool
+val verification_blocks_claim
+  :  (string, 'a * verification_claim_state) Hashtbl.t
+  -> Masc_domain.task
+  -> bool
 
 val task_required_tools : Masc_domain.task -> string list
 val string_list_contains : string list -> string -> bool
-
-val required_tools_allowed :
-  ?agent_tool_names:string list -> string list -> bool
+val required_tools_allowed : ?agent_tool_names:string list -> string list -> bool
 
 (** [make_required_tools_predicate ?agent_tool_names ()] returns a
     closure that checks whether a given [required_tools] list is
@@ -37,67 +42,75 @@ val required_tools_allowed :
     once at call time and reused across every invocation of the
     returned closure — call this {b outside} per-candidate loops to
     avoid rebuilding the set per task. *)
-val make_required_tools_predicate :
-  ?agent_tool_names:string list -> unit -> (string list -> bool)
+val make_required_tools_predicate
+  :  ?agent_tool_names:string list
+  -> unit
+  -> string list
+  -> bool
 
 val underscore_name : string -> string
 val hyphen_name : string -> string
 val keeper_name_from_agent_name : string -> string option
-
-val agent_record_keeper_name :
-  config -> agent_name:string -> string option
-
-val keeper_receipt_candidate_names :
-  config -> agent_name:string -> string list
-
+val agent_record_keeper_name : config -> agent_name:string -> string option
+val keeper_receipt_candidate_names : config -> agent_name:string -> string list
 val directory_exists : string -> bool
 val directory_entries : string -> string list
 val jsonl_files_under : string -> string list
 val last_nonempty_line : string -> string option
-
 val latest_json_in_receipt_dir : string -> Yojson.Safe.t option
-
 val json_member_path : string list -> Yojson.Safe.t -> Yojson.Safe.t
 val json_raw_string_path : string list -> Yojson.Safe.t -> string option
 val json_string_path : string list -> Yojson.Safe.t -> string option
 val receipt_sort_key : Yojson.Safe.t -> string
-
-val latest_execution_receipt_json :
-  config -> agent_name:string -> Yojson.Safe.t option
-
+val latest_execution_receipt_json : config -> agent_name:string -> Yojson.Safe.t option
 val json_string_list : string -> Yojson.Safe.t -> string list
 
-val latest_receipt_blocks_required_tool_claim :
-  config -> agent_name:string -> required_tools:string list -> bool
+val latest_receipt_blocks_required_tool_claim
+  :  config
+  -> agent_name:string
+  -> required_tools:string list
+  -> bool
 
-val active_task_assignees_by_task_id :
-  Masc_domain.backlog -> (string, string) Hashtbl.t
+val active_task_assignees_by_task_id : Masc_domain.backlog -> (string, string) Hashtbl.t
 
-val agent_current_task_matches_assignments :
-  (string, string) Hashtbl.t -> agent_name:string -> string -> bool
+val agent_current_task_matches_assignments
+  :  (string, string) Hashtbl.t
+  -> agent_name:string
+  -> string
+  -> bool
 
-val agent_current_task_matches_backlog :
-  Masc_domain.backlog -> agent_name:string -> string -> bool
+val agent_current_task_matches_backlog
+  :  Masc_domain.backlog
+  -> agent_name:string
+  -> string
+  -> bool
 
-val reconcile_agent_current_task_with_backlog :
-  config -> ?touch_last_seen:bool -> agent_name:string -> Masc_domain.backlog -> unit
+val reconcile_agent_current_task_with_backlog
+  :  config
+  -> ?touch_last_seen:bool
+  -> agent_name:string
+  -> Masc_domain.backlog
+  -> unit
 
-val reconcile_all_agent_current_tasks_with_backlog :
-  config -> ?touch_last_seen:bool -> Masc_domain.backlog -> unit
+val reconcile_all_agent_current_tasks_with_backlog
+  :  config
+  -> ?touch_last_seen:bool
+  -> Masc_domain.backlog
+  -> unit
 
-val reconcile_all_agent_current_tasks_with_fresh_backlog :
-  ?touch_last_seen:bool -> config -> Masc_domain.backlog
+val reconcile_all_agent_current_tasks_with_fresh_backlog
+  :  ?touch_last_seen:bool
+  -> config
+  -> Masc_domain.backlog
 
-val claim_next_r :
-  config ->
-  agent_name:string ->
-  ?agent_tool_names:string list ->
-  ?exclude_task_ids:string list ->
-  ?task_filter:(Masc_domain.task -> bool) ->
-  unit ->
-  Masc_domain.claim_next_result
+val claim_next_r
+  :  config
+  -> agent_name:string
+  -> ?agent_tool_names:string list
+  -> ?exclude_task_ids:string list
+  -> ?task_filter:(Masc_domain.task -> bool)
+  -> unit
+  -> Masc_domain.claim_next_result
 
 val claim_next : config -> agent_name:string -> string
-
-val release_stale_claims :
-  config -> ttl_seconds:float -> (string * string) list
+val release_stale_claims : config -> ttl_seconds:float -> (string * string) list

--- a/lib/keeper/docker_client_real.ml
+++ b/lib/keeper/docker_client_real.ml
@@ -27,6 +27,7 @@ let map_exit_status_for_rm (status : Unix.process_status) =
   | Unix.WEXITED 127 -> Error Docker_client.Daemon_unreachable
   | Unix.WEXITED _ -> Error Docker_client.Cleanup_failed
   | Unix.WSIGNALED _ | Unix.WSTOPPED _ -> Error Docker_client.Daemon_unreachable
+;;
 
 (* Docker CLI exit code semantics for [docker exec] AND [docker run]:
    both return the executed *command's* exit code on success; only
@@ -39,16 +40,13 @@ let map_exit_status_for_rm (status : Unix.process_status) =
    docker CLI, and its [WEXITED n] reflects what docker reported about
    the containerized command. *)
 let map_status_to_exec_result
-    ((status, stdout, stderr) :
-      Unix.process_status * string * string)
+      ((status, stdout, stderr) : Unix.process_status * string * string)
   =
   match status with
-  | Unix.WEXITED 125 | Unix.WEXITED 127 ->
-    Error Docker_client.Daemon_unreachable
-  | Unix.WEXITED code ->
-    Ok Docker_response.{ exit_code = code; stdout; stderr }
-  | Unix.WSIGNALED _ | Unix.WSTOPPED _ ->
-    Error Docker_client.Daemon_unreachable
+  | Unix.WEXITED 125 | Unix.WEXITED 127 -> Error Docker_client.Daemon_unreachable
+  | Unix.WEXITED code -> Ok Docker_response.{ exit_code = code; stdout; stderr }
+  | Unix.WSIGNALED _ | Unix.WSTOPPED _ -> Error Docker_client.Daemon_unreachable
+;;
 
 (* ── Functions ───────────────────────────────────────────────── *)
 
@@ -56,18 +54,13 @@ let ps_query ~labels:_ = placeholder
 
 let exec ~container ~cmd =
   let argv =
-    [ "docker"
-    ; "exec"
-    ; Keeper_container_name.to_string container
-    ; "sh"
-    ; "-lc"
-    ; cmd
-    ]
+    [ "docker"; "exec"; Keeper_container_name.to_string container; "sh"; "-lc"; cmd ]
   in
   (* [Process_eio.run_argv_with_status_split] returns
      [(status, stdout, stderr)]; on spawn failure the status is
      synthesized as [WEXITED 127] (see 3b-iv.2.1 commit on rm). *)
   map_status_to_exec_result (Process_eio.run_argv_with_status_split argv)
+;;
 
 let run plan =
   let container_name =
@@ -83,23 +76,13 @@ let run plan =
      so caller-passed [cmd] strings work identically across both
      functions. *)
   let argv =
-    [ "docker"
-    ; "run"
-    ; "--rm"
-    ; "--name"
-    ; container_name
-    ; image
-    ; "sh"
-    ; "-lc"
-    ; command
-    ]
+    [ "docker"; "run"; "--rm"; "--name"; container_name; image; "sh"; "-lc"; command ]
   in
-  map_status_to_exec_result
-    (Process_eio.run_argv_with_status_split ~timeout_sec argv)
+  map_status_to_exec_result (Process_eio.run_argv_with_status_split ~timeout_sec argv)
+;;
 
 let rm container =
-  let argv =
-    [ "docker"; "rm"; "-f"; Keeper_container_name.to_string container ]
-  in
+  let argv = [ "docker"; "rm"; "-f"; Keeper_container_name.to_string container ] in
   let status, _stdout = Process_eio.run_argv_with_status argv in
   map_exit_status_for_rm status
+;;

--- a/lib/keeper/keeper_backoff_policy.ml
+++ b/lib/keeper/keeper_backoff_policy.ml
@@ -6,20 +6,21 @@ type t =
   }
 
 let make ~max_attempts ~retryable_errors =
-  if max_attempts < 1 then
+  if max_attempts < 1
+  then
     invalid_arg
       (Printf.sprintf
          "Keeper_backoff_policy.make: max_attempts must be >= 1 (got %d)"
          max_attempts);
   { max_attempts; retryable_errors }
+;;
 
 let default_for_sandbox =
   { max_attempts = 3
   ; retryable_errors =
-      [ Docker_client.Daemon_unreachable
-      ; Docker_client.Image_pull_failed
-      ]
+      [ Docker_client.Daemon_unreachable; Docker_client.Image_pull_failed ]
   }
+;;
 
 let max_attempts t = t.max_attempts
 
@@ -27,7 +28,10 @@ let max_attempts t = t.max_attempts
    classified. Adding a new variant to [Docker_client.sandbox_error]
    forces this match to compile-error until the new arm is classified
    as retryable or not. *)
-let sandbox_error_equal (a : Docker_client.sandbox_error) (b : Docker_client.sandbox_error) =
+let sandbox_error_equal
+      (a : Docker_client.sandbox_error)
+      (b : Docker_client.sandbox_error)
+  =
   match a, b with
   | Daemon_unreachable, Daemon_unreachable -> true
   | Image_pull_failed, Image_pull_failed -> true
@@ -41,5 +45,6 @@ let sandbox_error_equal (a : Docker_client.sandbox_error) (b : Docker_client.san
   | Exec_timeout, _
   | Probe_format_drift, _
   | Cleanup_failed, _ -> false
+;;
 
 let should_retry t err = List.exists (sandbox_error_equal err) t.retryable_errors

--- a/lib/keeper/keeper_backoff_policy.mli
+++ b/lib/keeper/keeper_backoff_policy.mli
@@ -23,10 +23,7 @@ type t
     [retryable_errors] enumerates exactly the {!Docker_client.sandbox_error}
     arms that warrant a retry — *no catch-all*, the caller must
     enumerate every retryable variant. *)
-val make
-  :  max_attempts:int
-  -> retryable_errors:Docker_client.sandbox_error list
-  -> t
+val make : max_attempts:int -> retryable_errors:Docker_client.sandbox_error list -> t
 
 (** [default_for_sandbox] is the canonical policy for Sandbox_executor:
     - [max_attempts = 3]

--- a/lib/keeper/keeper_exec_board.ml
+++ b/lib/keeper/keeper_exec_board.ml
@@ -3,6 +3,7 @@ open Keeper_exec_shared
 
 let assoc_replace key value fields =
   (key, value) :: List.filter (fun (name, _) -> name <> key) fields
+;;
 
 let keeper_board_meta ?quantitative_evidence ~source meta =
   let base =
@@ -16,16 +17,19 @@ let keeper_board_meta ?quantitative_evidence ~source meta =
     | None -> base
   in
   `Assoc fields
+;;
 
 let assoc_value_opt key = function
   | `Assoc fields -> List.assoc_opt key fields
   | _ -> None
+;;
 
 let usable_evidence_json = function
   | `String value when String.trim value <> "" -> Some (`String value)
   | `Assoc fields when fields <> [] -> Some (`Assoc fields)
   | `List values when values <> [] -> Some (`List values)
   | _ -> None
+;;
 
 let quantitative_evidence_arg args =
   let meta_evidence () =
@@ -37,29 +41,34 @@ let quantitative_evidence_arg args =
     | None -> None
   in
   match assoc_value_opt "quantitative_evidence" args with
-  | Some value -> (
-      match usable_evidence_json value with
-      | Some _ as evidence -> evidence
-      | None -> meta_evidence ())
+  | Some value ->
+    (match usable_evidence_json value with
+     | Some _ as evidence -> evidence
+     | None -> meta_evidence ())
   | None -> meta_evidence ()
+;;
 
 let string_arg key = function
-  | `Assoc fields -> (
-      match List.assoc_opt key fields with
-      | Some (`String value) -> Some value
-      | _ -> None)
+  | `Assoc fields ->
+    (match List.assoc_opt key fields with
+     | Some (`String value) -> Some value
+     | _ -> None)
   | _ -> None
+;;
 
 let post_content_arg args =
   match string_arg "body" args with
   | Some body when String.trim body <> "" -> body
   | _ -> Option.value (string_arg "content" args) ~default:""
+;;
 
 let re_matches pattern text =
   try
     ignore (Str.search_forward (Str.regexp_case_fold pattern) text 0);
     true
-  with Not_found -> false
+  with
+  | Not_found -> false
+;;
 
 (* Precompile the static patterns used by [content_has_risky_quantitative_claim]
    so each board-post check reuses the same DFA instead of rebuilding it
@@ -74,15 +83,16 @@ let re_matches pattern text =
    groups, so the global state is not observed. Migrate to [Re] if
    match-group access is ever needed on this hot path. *)
 let re_line_ref_short = Str.regexp_case_fold "[Ll][0-9][0-9]*"
-let re_line_ref_file =
-  Str.regexp_case_fold "[A-Za-z0-9_./-]+\\.[A-Za-z0-9_]+:[0-9][0-9]*"
+let re_line_ref_file = Str.regexp_case_fold "[A-Za-z0-9_./-]+\\.[A-Za-z0-9_]+:[0-9][0-9]*"
 let re_percent = Str.regexp_case_fold "[0-9][0-9]*%"
 
 let re_matches_compiled re text =
   try
     ignore (Str.search_forward re text 0);
     true
-  with Not_found -> false
+  with
+  | Not_found -> false
+;;
 
 let contains_substring haystack needle =
   let len_haystack = String.length haystack in
@@ -91,26 +101,39 @@ let contains_substring haystack needle =
   ||
   let rec loop idx =
     idx + len_needle <= len_haystack
-    &&
-    (String.sub haystack idx len_needle = needle || loop (idx + 1))
+    && (String.sub haystack idx len_needle = needle || loop (idx + 1))
   in
   loop 0
+;;
 
 let content_has_inline_quantitative_evidence content =
   let lower = String.lowercase_ascii content in
   List.exists
     (contains_substring lower)
-    [ "command: rg -n"; "command: grep -n"; "command: git grep -n";
-      "command: wc -l"; "$ rg -n"; "$ grep -n"; "$ git grep -n";
-      "$ wc -l"; "`rg -n"; "`grep -n"; "`git grep -n"; "`wc -l" ]
+    [ "command: rg -n"
+    ; "command: grep -n"
+    ; "command: git grep -n"
+    ; "command: wc -l"
+    ; "$ rg -n"
+    ; "$ grep -n"
+    ; "$ git grep -n"
+    ; "$ wc -l"
+    ; "`rg -n"
+    ; "`grep -n"
+    ; "`git grep -n"
+    ; "`wc -l"
+    ]
+;;
 
 let is_digit = function
   | '0' .. '9' -> true
   | _ -> false
+;;
 
 let is_numeric_claim_boundary = function
   | 'a' .. 'z' | 'A' .. 'Z' | '0' .. '9' | '_' | ':' -> false
   | _ -> true
+;;
 
 let content_has_standalone_count content =
   let len = String.length content in
@@ -118,37 +141,40 @@ let content_has_standalone_count content =
     if idx < len && is_digit content.[idx] then skip_digits (idx + 1) else idx
   in
   let rec loop idx =
-    if idx >= len then false
-    else if is_digit content.[idx] then
+    if idx >= len
+    then false
+    else if is_digit content.[idx]
+    then (
       let next_idx = skip_digits idx in
-      let before_ok =
-        idx = 0 || is_numeric_claim_boundary content.[idx - 1]
-      in
-      let after_ok =
-        next_idx = len || is_numeric_claim_boundary content.[next_idx]
-      in
-      (before_ok && after_ok) || loop next_idx
+      let before_ok = idx = 0 || is_numeric_claim_boundary content.[idx - 1] in
+      let after_ok = next_idx = len || is_numeric_claim_boundary content.[next_idx] in
+      (before_ok && after_ok) || loop next_idx)
     else loop (idx + 1)
   in
   loop 0
+;;
 
 let is_word_char = function
   | 'a' .. 'z' | '0' .. '9' | '_' -> true
   | _ -> false
+;;
 
 let contains_word lower word =
   let len_text = String.length lower in
   let len_word = String.length word in
   let rec loop idx =
-    if idx + len_word > len_text then false
-    else if String.sub lower idx len_word = word then
+    if idx + len_word > len_text
+    then false
+    else if String.sub lower idx len_word = word
+    then (
       let before_ok = idx = 0 || not (is_word_char lower.[idx - 1]) in
       let after_idx = idx + len_word in
       let after_ok = after_idx = len_text || not (is_word_char lower.[after_idx]) in
-      (before_ok && after_ok) || loop (idx + 1)
+      (before_ok && after_ok) || loop (idx + 1))
     else loop (idx + 1)
   in
   len_word > 0 && loop 0
+;;
 
 let content_has_risky_quantitative_claim content =
   let has_line_ref =
@@ -159,20 +185,34 @@ let content_has_risky_quantitative_claim content =
   let has_quantifier =
     List.exists
       (contains_word lower)
-      [ "site"; "sites"; "hit"; "hits"; "line"; "lines"; "occurrence";
-        "occurrences"; "pattern"; "patterns"; "instance"; "instances";
-        "accuracy" ]
+      [ "site"
+      ; "sites"
+      ; "hit"
+      ; "hits"
+      ; "line"
+      ; "lines"
+      ; "occurrence"
+      ; "occurrences"
+      ; "pattern"
+      ; "patterns"
+      ; "instance"
+      ; "instances"
+      ; "accuracy"
+      ]
     || re_matches_compiled re_percent content
     || content_has_standalone_count content
   in
   has_line_ref && has_quantifier
+;;
 
 let quantitative_claim_rejection_reason ~content ~quantitative_evidence =
-  if content_has_risky_quantitative_claim content
-     && Option.is_none quantitative_evidence
-     && not (content_has_inline_quantitative_evidence content)
+  if
+    content_has_risky_quantitative_claim content
+    && Option.is_none quantitative_evidence
+    && not (content_has_inline_quantitative_evidence content)
   then Some "missing_quantitative_evidence"
   else None
+;;
 
 let ensure_keeper_board_post_args ?quantitative_evidence ~author ~source = function
   | `Assoc fields ->
@@ -184,10 +224,10 @@ let ensure_keeper_board_post_args ?quantitative_evidence ~author ~source = funct
     let fields =
       List.filter
         (fun (k, _) ->
-          k <> "author"
-          && k <> "post_kind"
-          && k <> "meta"
-          && k <> "quantitative_evidence")
+           k <> "author"
+           && k <> "post_kind"
+           && k <> "meta"
+           && k <> "quantitative_evidence")
         fields
     in
     let has_hearth =
@@ -207,11 +247,11 @@ let ensure_keeper_board_post_args ?quantitative_evidence ~author ~source = funct
     in
     `Assoc
       ([ "author", `String author
-       (* Variant SSOT: bind the literal to the Variant constructor so a
+         (* Variant SSOT: bind the literal to the Variant constructor so a
           rename of [Automation_post] forces this site to update too.
           Same pattern family as #8354 / #8392. *)
-       ; "post_kind", `String
-           (Board_core_classify.post_kind_to_string Board_types.Automation_post)
+       ; ( "post_kind"
+         , `String (Board_core_classify.post_kind_to_string Board_types.Automation_post) )
        ; "meta", keeper_board_meta ?quantitative_evidence ~source raw_meta
        ]
        @ fields)
@@ -257,7 +297,8 @@ let handle_keeper_board_tool
          ();
        error_json
          ~fields:[ "keeper", `String author; "reason", `String reason ]
-         "keeper_board_post rejected: quantitative code claims with line/count references require quantitative_evidence metadata or inline rg/grep evidence"
+         "keeper_board_post rejected: quantitative code claims with line/count \
+          references require quantitative_evidence metadata or inline rg/grep evidence"
      | None ->
        let board_args =
          ensure_keeper_board_post_args
@@ -268,7 +309,9 @@ let handle_keeper_board_tool
        in
        Log.Keeper.debug "board_args: %s" (Yojson.Safe.to_string board_args);
        let result =
-         Tool_board.handle_tool (Tool_name.Masc.to_string Tool_name.Masc.Board_post) board_args
+         Tool_board.handle_tool
+           (Tool_name.Masc.to_string Tool_name.Masc.Board_post)
+           board_args
        in
        let ok = result.success in
        let msg = Tool_result.message result in
@@ -277,35 +320,30 @@ let handle_keeper_board_tool
          ok
          (String_util.utf8_safe ~max_bytes:203 ~suffix:"..." msg |> String_util.to_string);
        tool_result_or_error result)
-  | Some Tool_name.Keeper.Board_list ->
-    dispatch_board Tool_name.Masc.Board_list args
-  | Some Tool_name.Keeper.Board_get ->
-    dispatch_board Tool_name.Masc.Board_get args
+  | Some Tool_name.Keeper.Board_list -> dispatch_board Tool_name.Masc.Board_list args
+  | Some Tool_name.Keeper.Board_get -> dispatch_board Tool_name.Masc.Board_get args
   | Some Tool_name.Keeper.Board_comment ->
     dispatch_board
       Tool_name.Masc.Board_comment
       (assoc_override_string "author" meta.name args)
   | Some Tool_name.Keeper.Board_vote ->
-    dispatch_board Tool_name.Masc.Board_vote (assoc_override_string "voter" meta.name args)
+    dispatch_board
+      Tool_name.Masc.Board_vote
+      (assoc_override_string "voter" meta.name args)
   | Some Tool_name.Keeper.Board_comment_vote ->
     dispatch_board
       Tool_name.Masc.Board_comment_vote
       (assoc_override_string "voter" meta.name args)
-  | Some Tool_name.Keeper.Board_stats ->
-    dispatch_board Tool_name.Masc.Board_stats args
-  | Some Tool_name.Keeper.Board_search ->
-    dispatch_board Tool_name.Masc.Board_search args
+  | Some Tool_name.Keeper.Board_stats -> dispatch_board Tool_name.Masc.Board_stats args
+  | Some Tool_name.Keeper.Board_search -> dispatch_board Tool_name.Masc.Board_search args
   | Some Tool_name.Keeper.Board_curation_read ->
     dispatch_board Tool_name.Masc.Board_curation_read args
   | Some Tool_name.Keeper.Board_curation_submit ->
     dispatch_board
       Tool_name.Masc.Board_curation_submit
       (assoc_override_string "submitted_by" meta.name args)
-  | Some Tool_name.Keeper.Board_delete ->
-    dispatch_board Tool_name.Masc.Board_delete args
+  | Some Tool_name.Keeper.Board_delete -> dispatch_board Tool_name.Masc.Board_delete args
   | Some Tool_name.Keeper.Board_cleanup ->
     dispatch_board Tool_name.Masc.Board_cleanup args
-  | Some _
-  | None ->
-    error_json ~fields:[ "tool", `String name ] "unknown_board_tool"
+  | Some _ | None -> error_json ~fields:[ "tool", `String name ] "unknown_board_tool"
 ;;

--- a/lib/keeper/keeper_registry.ml
+++ b/lib/keeper/keeper_registry.ml
@@ -18,7 +18,6 @@
     visibility); persistent [StringMap] behind a single [ref]. *)
 
 open Keeper_types
-
 module StringMap = Map.Make (String)
 
 (** Structured failure reason for cohort detection in self-preservation.
@@ -27,54 +26,62 @@ type ambiguous_partial_commit_kind =
   | Post_commit_timeout
   | Post_commit_failure
 
-type ambiguous_partial_commit = {
-  kind : ambiguous_partial_commit_kind;
-  detail : string;
-}
+type ambiguous_partial_commit =
+  { kind : ambiguous_partial_commit_kind
+  ; detail : string
+  }
 
 (** Phase B PR-6 (2026-04-28): typed sub-class of stale-watchdog kills.
     See keeper_registry.mli for rationale. *)
 type stale_kill_class =
   | Idle_turn of { stall_seconds : float }
-  | In_turn_hung of {
-      active_seconds : float;
-      timeout_threshold : float;
-    }
+  | In_turn_hung of
+      { active_seconds : float
+      ; timeout_threshold : float
+      }
   | Noop_failure_loop of { noop_count : int }
 
 let stale_kill_class_to_string = function
-  | Idle_turn { stall_seconds } ->
-      Printf.sprintf "idle_turn(%.0fs)" stall_seconds
+  | Idle_turn { stall_seconds } -> Printf.sprintf "idle_turn(%.0fs)" stall_seconds
   | In_turn_hung { active_seconds; timeout_threshold } ->
-      Printf.sprintf "in_turn_hung(active=%.0fs threshold=%.0fs)"
-        active_seconds timeout_threshold
+    Printf.sprintf
+      "in_turn_hung(active=%.0fs threshold=%.0fs)"
+      active_seconds
+      timeout_threshold
   | Noop_failure_loop { noop_count } ->
-      Printf.sprintf "noop_failure_loop(noop=%d)" noop_count
+    Printf.sprintf "noop_failure_loop(noop=%d)" noop_count
+;;
 
 type failure_reason =
   | Heartbeat_consecutive_failures of int
   | Turn_consecutive_failures of int
   | Stale_turn_timeout of stale_kill_class
   | Stale_termination_storm of { count : int }
-      (** #10765 Phase 2: latched when [record_stale_termination] returns a
+  (** #10765 Phase 2: latched when [record_stale_termination] returns a
           window count >= [escalation_threshold]. The supervisor's
           [`Crashed] branch checks this variant and skips [to_restart],
           persisting [meta.paused = true] instead so an operator must
           investigate the underlying cascade/provider/fd issue before
           resuming the keeper. *)
   | Stale_fleet_batch of { distinct_count : int }
-      (** Latched when the stale watchdog observes several distinct keepers
+  (** Latched when the stale watchdog observes several distinct keepers
           terminating inside the fleet batch window. This is a systemic
           cascade/provider/runtime signal, so the supervisor pauses affected
           keepers with auto-resume backoff instead of restarting each keeper
           independently into the same failure mode. *)
   | Oas_timeout_budget_loop of { count : int }
-      (** Latched when the same keeper exhausts the OAS turn budget on
+  (** Latched when the same keeper exhausts the OAS turn budget on
           consecutive cycles. This is a provider/cascade/runtime throughput
           failure, so the supervisor pauses instead of restarting into the
           same slow model and burning another multi-minute budget. *)
-  | Provider_runtime_error of { code : string; detail : string }
-  | Tool_required_unsatisfied of { code : string; detail : string }
+  | Provider_runtime_error of
+      { code : string
+      ; detail : string
+      }
+  | Tool_required_unsatisfied of
+      { code : string
+      ; detail : string
+      }
   | Ambiguous_partial_commit of ambiguous_partial_commit
   | Fiber_unresolved
   | Exception of string
@@ -82,31 +89,32 @@ type failure_reason =
 let ambiguous_partial_commit_kind_to_string = function
   | Post_commit_timeout -> "post_commit_timeout"
   | Post_commit_failure -> "post_commit_failure"
+;;
 
 let failure_reason_to_string = function
   | Heartbeat_consecutive_failures n ->
-      Printf.sprintf "heartbeat_consecutive_failures(%d)" n
-  | Turn_consecutive_failures n ->
-      Printf.sprintf "turn_consecutive_failures(%d)" n
+    Printf.sprintf "heartbeat_consecutive_failures(%d)" n
+  | Turn_consecutive_failures n -> Printf.sprintf "turn_consecutive_failures(%d)" n
   | Stale_turn_timeout cls ->
-      Printf.sprintf "stale_turn_timeout(%s)"
-        (stale_kill_class_to_string cls)
+    Printf.sprintf "stale_turn_timeout(%s)" (stale_kill_class_to_string cls)
   | Stale_termination_storm { count } ->
-      Printf.sprintf "stale_termination_storm(count=%d)" count
+    Printf.sprintf "stale_termination_storm(count=%d)" count
   | Stale_fleet_batch { distinct_count } ->
-      Printf.sprintf "stale_fleet_batch(distinct_count=%d)" distinct_count
+    Printf.sprintf "stale_fleet_batch(distinct_count=%d)" distinct_count
   | Oas_timeout_budget_loop { count } ->
-      Printf.sprintf "oas_timeout_budget_loop(count=%d)" count
+    Printf.sprintf "oas_timeout_budget_loop(count=%d)" count
   | Provider_runtime_error { code; detail } ->
-      Printf.sprintf "provider_runtime_error(%s:%s)" code detail
+    Printf.sprintf "provider_runtime_error(%s:%s)" code detail
   | Tool_required_unsatisfied { code; detail } ->
-      Printf.sprintf "tool_required_unsatisfied(%s:%s)" code detail
+    Printf.sprintf "tool_required_unsatisfied(%s:%s)" code detail
   | Ambiguous_partial_commit { kind; detail } ->
-      Printf.sprintf "ambiguous_partial_commit(%s:%s)"
-        (ambiguous_partial_commit_kind_to_string kind)
-        detail
+    Printf.sprintf
+      "ambiguous_partial_commit(%s:%s)"
+      (ambiguous_partial_commit_kind_to_string kind)
+      detail
   | Fiber_unresolved -> "fiber_unresolved"
   | Exception s -> Printf.sprintf "exception(%s)" s
+;;
 
 (** #10584: cohort key for grouping failures by variant, ignoring
     parameters (e.g. failure count, timeout seconds).  Lives next to
@@ -130,6 +138,7 @@ let failure_reason_cohort_key = function
   | Some Fiber_unresolved -> "fiber_unresolved"
   | Some (Exception _) -> "exception"
   | None -> "unknown"
+;;
 
 let stale_watchdog_failure_reason ~prior ~kill_class =
   match prior with
@@ -140,15 +149,14 @@ let stale_watchdog_failure_reason ~prior ~kill_class =
       | Ambiguous_partial_commit _
       | Turn_consecutive_failures _
       | Heartbeat_consecutive_failures _
-      | Exception _ ) ->
-      prior
+      | Exception _ ) -> prior
   | Some
       ( Stale_termination_storm _
       | Stale_fleet_batch _
       | Stale_turn_timeout _
       | Fiber_unresolved )
-  | None ->
-      Some (Stale_turn_timeout kill_class)
+  | None -> Some (Stale_turn_timeout kill_class)
+;;
 
 (** Pure control-flow signal for immediate fiber termination (RFC-0002).
     Carries no state — failure reason must be pre-stored via
@@ -187,8 +195,7 @@ type 'a turn_phase_witness =
   | Turn_finalizing : turn_finalizing turn_phase_witness
   | Turn_exhausted : turn_exhausted turn_phase_witness
 
-type packed_turn_phase =
-  | Packed : 'a turn_phase_witness -> packed_turn_phase
+type packed_turn_phase = Packed : 'a turn_phase_witness -> packed_turn_phase
 
 let turn_phase_to_witness : turn_phase -> packed_turn_phase = function
   | Turn_idle -> Packed Turn_idle
@@ -198,6 +205,7 @@ let turn_phase_to_witness : turn_phase -> packed_turn_phase = function
   | Turn_compacting -> Packed Turn_compacting
   | Turn_finalizing -> Packed Turn_finalizing
   | Turn_exhausted -> Packed Turn_exhausted
+;;
 
 let witness_to_turn_phase : packed_turn_phase -> turn_phase = function
   | Packed Turn_idle -> Turn_idle
@@ -207,6 +215,7 @@ let witness_to_turn_phase : packed_turn_phase -> turn_phase = function
   | Packed Turn_compacting -> Turn_compacting
   | Packed Turn_finalizing -> Turn_finalizing
   | Packed Turn_exhausted -> Turn_exhausted
+;;
 
 (* Diagnostic label for invalid-transition error messages.  Must stay in
    sync with the [turn_phase] variant — adding a constructor will fail
@@ -220,6 +229,7 @@ let packed_turn_phase_label : packed_turn_phase -> string = function
   | Packed Turn_compacting -> "Turn_compacting"
   | Packed Turn_finalizing -> "Turn_finalizing"
   | Packed Turn_exhausted -> "Turn_exhausted"
+;;
 
 module Turn_phase_transition = struct
   (* Mirrors [validate_turn_phase_transition] (below): every constructor
@@ -290,6 +300,7 @@ module Turn_phase_transition = struct
     | Exhausted_to_routing -> "exhausted->routing"
     | Exhausted_to_executing -> "exhausted->executing"
     | Exhausted_to_exhausted -> "exhausted->exhausted"
+  ;;
 end
 
 type decision_stage =
@@ -317,12 +328,14 @@ let witness_to_stage : type a. a decision_stage_witness -> decision_stage = func
   | Decision_guard_ok -> Decision_guard_ok
   | Decision_gate_rejected -> Decision_gate_rejected
   | Decision_tool_policy_selected -> Decision_tool_policy_selected
+;;
 
 let stage_to_witness : decision_stage -> packed_decision_stage = function
   | Decision_undecided -> Packed Decision_undecided
   | Decision_guard_ok -> Packed Decision_guard_ok
   | Decision_gate_rejected -> Packed Decision_gate_rejected
   | Decision_tool_policy_selected -> Packed Decision_tool_policy_selected
+;;
 
 (* Diagnostic label for invalid-transition error messages.  Mirrors
    [decision_stage]; constructor changes will fail compilation here. *)
@@ -331,18 +344,24 @@ let packed_decision_stage_label : packed_decision_stage -> string = function
   | Packed Decision_guard_ok -> "Decision_guard_ok"
   | Packed Decision_gate_rejected -> "Decision_gate_rejected"
   | Packed Decision_tool_policy_selected -> "Decision_tool_policy_selected"
+;;
 
 module Decision_transition = struct
   type ('from, 'to_) t =
     | Undecided_to_guard_ok : (decision_undecided, decision_guard_ok) t
     | Undecided_to_gate_rejected : (decision_undecided, decision_gate_rejected) t
-    | Undecided_to_tool_policy_selected : (decision_undecided, decision_tool_policy_selected) t
+    | Undecided_to_tool_policy_selected :
+        (decision_undecided, decision_tool_policy_selected) t
     | Guard_ok_to_gate_rejected : (decision_guard_ok, decision_gate_rejected) t
-    | Guard_ok_to_tool_policy_selected : (decision_guard_ok, decision_tool_policy_selected) t
+    | Guard_ok_to_tool_policy_selected :
+        (decision_guard_ok, decision_tool_policy_selected) t
     | Gate_rejected_to_guard_ok : (decision_gate_rejected, decision_guard_ok) t
-    | Gate_rejected_to_tool_policy_selected : (decision_gate_rejected, decision_tool_policy_selected) t
-    | Tool_policy_selected_to_guard_ok : (decision_tool_policy_selected, decision_guard_ok) t
-    | Tool_policy_selected_to_gate_rejected : (decision_tool_policy_selected, decision_gate_rejected) t
+    | Gate_rejected_to_tool_policy_selected :
+        (decision_gate_rejected, decision_tool_policy_selected) t
+    | Tool_policy_selected_to_guard_ok :
+        (decision_tool_policy_selected, decision_guard_ok) t
+    | Tool_policy_selected_to_gate_rejected :
+        (decision_tool_policy_selected, decision_gate_rejected) t
 
   let to_tag : type a b. (a, b) t -> string = function
     | Undecided_to_guard_ok -> "undecided->guard_ok"
@@ -354,6 +373,7 @@ module Decision_transition = struct
     | Gate_rejected_to_tool_policy_selected -> "gate_rejected->tool_policy_selected"
     | Tool_policy_selected_to_guard_ok -> "tool_policy_selected->guard_ok"
     | Tool_policy_selected_to_gate_rejected -> "tool_policy_selected->gate_rejected"
+  ;;
 end
 
 let validate_decision_transition ~from ~to_ =
@@ -376,11 +396,12 @@ let validate_decision_transition ~from ~to_ =
   | Packed Decision_guard_ok, Packed Decision_undecided
   | Packed Decision_gate_rejected, Packed Decision_undecided
   | Packed Decision_tool_policy_selected, Packed Decision_undecided ->
-      invalid_arg
-        (Printf.sprintf
-           "validate_decision_transition: invalid transition %s -> %s"
-           (packed_decision_stage_label from_packed)
-           (packed_decision_stage_label to_packed))
+    invalid_arg
+      (Printf.sprintf
+         "validate_decision_transition: invalid transition %s -> %s"
+         (packed_decision_stage_label from_packed)
+         (packed_decision_stage_label to_packed))
+;;
 
 type cascade_state =
   | Cascade_idle [@tla.idle]
@@ -404,8 +425,7 @@ type 'a cascade_state_witness =
   | Cascade_done : cascade_done cascade_state_witness
   | Cascade_exhausted : cascade_exhausted cascade_state_witness
 
-type packed_cascade_state =
-  | Packed : 'a cascade_state_witness -> packed_cascade_state
+type packed_cascade_state = Packed : 'a cascade_state_witness -> packed_cascade_state
 
 let cascade_state_to_witness : cascade_state -> packed_cascade_state = function
   | Cascade_idle -> Packed Cascade_idle
@@ -413,6 +433,7 @@ let cascade_state_to_witness : cascade_state -> packed_cascade_state = function
   | Cascade_trying -> Packed Cascade_trying
   | Cascade_done -> Packed Cascade_done
   | Cascade_exhausted -> Packed Cascade_exhausted
+;;
 
 let witness_to_cascade_state : packed_cascade_state -> cascade_state = function
   | Packed Cascade_idle -> Cascade_idle
@@ -420,6 +441,7 @@ let witness_to_cascade_state : packed_cascade_state -> cascade_state = function
   | Packed Cascade_trying -> Cascade_trying
   | Packed Cascade_done -> Cascade_done
   | Packed Cascade_exhausted -> Cascade_exhausted
+;;
 
 (* Diagnostic label for invalid-transition error messages.  Mirrors
    [cascade_state]; constructor changes will fail compilation here. *)
@@ -429,6 +451,7 @@ let packed_cascade_state_label : packed_cascade_state -> string = function
   | Packed Cascade_trying -> "Cascade_trying"
   | Packed Cascade_done -> "Cascade_done"
   | Packed Cascade_exhausted -> "Cascade_exhausted"
+;;
 
 type compaction_stage =
   | Compaction_accumulating [@tla.idle]
@@ -453,78 +476,77 @@ let compaction_stage_to_witness : compaction_stage -> packed_compaction_stage = 
   | Compaction_accumulating -> Packed Compaction_accumulating
   | Compaction_compacting -> Packed Compaction_compacting
   | Compaction_done -> Packed Compaction_done
+;;
 
 let witness_to_compaction_stage : packed_compaction_stage -> compaction_stage = function
   | Packed Compaction_accumulating -> Compaction_accumulating
   | Packed Compaction_compacting -> Compaction_compacting
   | Packed Compaction_done -> Compaction_done
+;;
 
-type turn_measurement = {
-  tm_captured_at : float;
-  tm_auto_rules : Keeper_state_machine.auto_rule_summary;
-}
+type turn_measurement =
+  { tm_captured_at : float
+  ; tm_auto_rules : Keeper_state_machine.auto_rule_summary
+  }
 
-type registry_entry = {
-  base_path : string;
-  name : string;
-  meta : keeper_meta;
-  (** Keeper lifecycle phase (RFC-0002 11-state machine). *)
-  phase : Keeper_state_machine.phase;
-  (** Observable conditions that derive [phase]. *)
-  conditions : Keeper_state_machine.conditions;
-  fiber_stop : bool Atomic.t;
-  fiber_wakeup : bool Atomic.t;
-  event_queue : Keeper_event_queue.t Atomic.t;
-  started_at : float;
-  grpc_close : (unit -> unit) option Atomic.t;
-  done_p : [ `Stopped | `Crashed of string ] Eio.Promise.t;
-  done_r : [ `Stopped | `Crashed of string ] Eio.Promise.u;
-  restart_count : int;
-  last_restart_ts : float;
-  dead_since_ts : float option;
-  crash_log : (float * string) list;
-  last_error : string option;
-  last_failure_reason : failure_reason option;
-  turn_consecutive_failures : int;
-  last_agent_count : int;
-  board_wakeups : float StringMap.t;
-  board_cursor_ts : float;
-  board_cursor_post_id : string option;
-  tool_usage : tool_call_entry StringMap.t;
-  transition_seq : int;
-  waiting_for_inference : bool Atomic.t;
-      (** Ephemeral flag: true when keeper is blocked in admission queue.
+type registry_entry =
+  { base_path : string
+  ; name : string
+  ; meta : keeper_meta (** Keeper lifecycle phase (RFC-0002 11-state machine). *)
+  ; phase : Keeper_state_machine.phase (** Observable conditions that derive [phase]. *)
+  ; conditions : Keeper_state_machine.conditions
+  ; fiber_stop : bool Atomic.t
+  ; fiber_wakeup : bool Atomic.t
+  ; event_queue : Keeper_event_queue.t Atomic.t
+  ; started_at : float
+  ; grpc_close : (unit -> unit) option Atomic.t
+  ; done_p : [ `Stopped | `Crashed of string ] Eio.Promise.t
+  ; done_r : [ `Stopped | `Crashed of string ] Eio.Promise.u
+  ; restart_count : int
+  ; last_restart_ts : float
+  ; dead_since_ts : float option
+  ; crash_log : (float * string) list
+  ; last_error : string option
+  ; last_failure_reason : failure_reason option
+  ; turn_consecutive_failures : int
+  ; last_agent_count : int
+  ; board_wakeups : float StringMap.t
+  ; board_cursor_ts : float
+  ; board_cursor_post_id : string option
+  ; tool_usage : tool_call_entry StringMap.t
+  ; transition_seq : int
+  ; waiting_for_inference : bool Atomic.t
+    (** Ephemeral flag: true when keeper is blocked in admission queue.
           Set/cleared around [Admission_queue.with_permit].
           Does not affect state machine phase derivation. *)
-  last_auto_rules :
-    (float * Keeper_state_machine.auto_rule_summary) option;
-  last_event_bus_correlation : string option;
-  pending_turn_measurement : turn_measurement option;
-  current_turn_observation : turn_observation option;
-  last_completed_turn : completed_turn_observation option;
-  last_skip_observation : (float * string list) option;
-  compaction_stage : packed_compaction_stage;
-}
+  ; last_auto_rules : (float * Keeper_state_machine.auto_rule_summary) option
+  ; last_event_bus_correlation : string option
+  ; pending_turn_measurement : turn_measurement option
+  ; current_turn_observation : turn_observation option
+  ; last_completed_turn : completed_turn_observation option
+  ; last_skip_observation : (float * string list) option
+  ; compaction_stage : packed_compaction_stage
+  }
 
-and turn_observation = {
-  turn_id : int;
-  started_at : float;
-  turn_phase : packed_turn_phase;
-  decision_stage : packed_decision_stage;
-  cascade_state : packed_cascade_state;
-  measurement : turn_measurement option;
-  measurement_bind_count : int;
-  selected_model : string option;
-}
+and turn_observation =
+  { turn_id : int
+  ; started_at : float
+  ; turn_phase : packed_turn_phase
+  ; decision_stage : packed_decision_stage
+  ; cascade_state : packed_cascade_state
+  ; measurement : turn_measurement option
+  ; measurement_bind_count : int
+  ; selected_model : string option
+  }
 
-and completed_turn_observation = {
-  ct_turn_id : int;
-  ct_started_at : float;
-  ct_ended_at : float;
-  ct_decision_stage : packed_decision_stage;
-  ct_cascade_state : packed_cascade_state;
-  ct_selected_model : string option;
-}
+and completed_turn_observation =
+  { ct_turn_id : int
+  ; ct_started_at : float
+  ; ct_ended_at : float
+  ; ct_decision_stage : packed_decision_stage
+  ; ct_cascade_state : packed_cascade_state
+  ; ct_selected_model : string option
+  }
 
 let try_resolve_done entry value =
   match Eio.Promise.peek entry.done_p with
@@ -550,6 +572,7 @@ let decr_running_count_clamped () =
     if not (Atomic.compare_and_set running_count_atomic cur next) then loop ()
   in
   loop ()
+;;
 
 (** Serializes every writer path into [registry] via lock-free CAS.
     Concurrent [update_entry]/[put_entry]/[unregister] retry until they
@@ -566,9 +589,10 @@ let decr_running_count_clamped () =
     Pattern follows #7011 (executor_pool) and #7013 (runtime_state). *)
 
 let registry_key ~base_path name =
-  if String.contains name '\x1f' then
-    invalid_arg (Printf.sprintf "keeper name contains unit separator: %s" name);
+  if String.contains name '\x1f'
+  then invalid_arg (Printf.sprintf "keeper name contains unit separator: %s" name);
   base_path ^ "\x1f" ^ name
+;;
 
 let put_entry key entry =
   let rec loop () =
@@ -577,6 +601,7 @@ let put_entry key entry =
     if not (Atomic.compare_and_set registry current updated) then loop ()
   in
   loop ()
+;;
 
 (* P0-2 (2026-05-07): orphan turn-loop observability.
 
@@ -604,9 +629,7 @@ let put_entry key entry =
    that requires unregister-time fiber cancel and is RFC-level. *)
 let orphan_drop_threshold = 5
 let orphan_drop_window_sec = 60.0
-
-let orphan_drop_state : (int * float) StringMap.t Atomic.t =
-  Atomic.make StringMap.empty
+let orphan_drop_state : (int * float) StringMap.t Atomic.t = Atomic.make StringMap.empty
 
 (* Returns [(count, breached_now)]. [breached_now] is [true] exactly
    on the transition from below-threshold to at-threshold within an
@@ -620,34 +643,34 @@ let record_orphan_drop ~base_path name =
       match StringMap.find_opt key current with
       | Some (prev_count, prev_first_at)
         when now -. prev_first_at <= orphan_drop_window_sec ->
-          let new_count = prev_count + 1 in
-          let breached =
-            prev_count < orphan_drop_threshold
-            && new_count >= orphan_drop_threshold
-          in
-          (new_count, prev_first_at, breached)
+        let new_count = prev_count + 1 in
+        let breached =
+          prev_count < orphan_drop_threshold && new_count >= orphan_drop_threshold
+        in
+        new_count, prev_first_at, breached
       | _ ->
-          (* Fresh window (no prior state, or prior window expired). *)
-          (1, now, false)
+        (* Fresh window (no prior state, or prior window expired). *)
+        1, now, false
     in
     let updated = StringMap.add key (count, first_at) current in
-    if Atomic.compare_and_set orphan_drop_state current updated then
-      (count, breached_now)
+    if Atomic.compare_and_set orphan_drop_state current updated
+    then count, breached_now
     else loop ()
   in
   loop ()
+;;
 
 let clear_orphan_drop ~base_path name =
   let key = registry_key ~base_path name in
   let rec loop () =
     let current = Atomic.get orphan_drop_state in
-    if StringMap.mem key current then begin
+    if StringMap.mem key current
+    then (
       let updated = StringMap.remove key current in
-      if not (Atomic.compare_and_set orphan_drop_state current updated)
-      then loop ()
-    end
+      if not (Atomic.compare_and_set orphan_drop_state current updated) then loop ())
   in
   loop ()
+;;
 
 (** Apply [f entry] and write back.  No-op if key absent.
 
@@ -660,110 +683,132 @@ let update_entry ~base_path name f =
     let current = Atomic.get registry in
     match StringMap.find_opt key current with
     | None ->
-        let count, breached = record_orphan_drop ~base_path name in
+      let count, breached = record_orphan_drop ~base_path name in
+      Prometheus.inc_counter
+        Keeper_metrics.metric_keeper_registry_update_dropped
+        ~labels:[ "name", name ]
+        ();
+      if breached
+      then (
         Prometheus.inc_counter
-          Keeper_metrics.metric_keeper_registry_update_dropped
-          ~labels:[("name", name)]
+          Keeper_metrics.metric_keeper_registry_orphan_threshold_breached
+          ~labels:[ "name", name ]
           ();
-        if breached then begin
-          Prometheus.inc_counter
-            Keeper_metrics.metric_keeper_registry_orphan_threshold_breached
-            ~labels:[("name", name)]
-            ();
-          Log.Keeper.error
-            "registry: orphan threshold breached name=%s base_path=%s \
-             drops=%d window=%.0fs — turn fiber may be racing \
-             post-deregistration; check masc_keeper_status and watchdog"
-            name base_path count orphan_drop_window_sec
-        end else
-          Log.Keeper.warn
-            "registry: update_entry name=%s base_path=%s: entry not \
-             found, update dropped (count=%d)"
-            name base_path count
+        Log.Keeper.error
+          "registry: orphan threshold breached name=%s base_path=%s drops=%d \
+           window=%.0fs — turn fiber may be racing post-deregistration; check \
+           masc_keeper_status and watchdog"
+          name
+          base_path
+          count
+          orphan_drop_window_sec)
+      else
+        Log.Keeper.warn
+          "registry: update_entry name=%s base_path=%s: entry not found, update dropped \
+           (count=%d)"
+          name
+          base_path
+          count
     | Some entry ->
-        let updated = StringMap.add key (f entry) current in
-        if not (Atomic.compare_and_set registry current updated) then loop ()
-        else clear_orphan_drop ~base_path name
+      let updated = StringMap.add key (f entry) current in
+      if not (Atomic.compare_and_set registry current updated)
+      then loop ()
+      else clear_orphan_drop ~base_path name
   in
   loop ()
+;;
 
 let max_crash_log_entries = 5
 
-let register_with_state ~base_path name meta
-    ~(phase : Keeper_state_machine.phase)
-    ~(conditions : Keeper_state_machine.conditions) =
-  Log.Keeper.info "registry: registering keeper name=%s base_path=%s phase=%s"
-    name base_path (Keeper_state_machine.phase_to_string phase);
+let register_with_state
+      ~base_path
+      name
+      meta
+      ~(phase : Keeper_state_machine.phase)
+      ~(conditions : Keeper_state_machine.conditions)
+  =
+  Log.Keeper.info
+    "registry: registering keeper name=%s base_path=%s phase=%s"
+    name
+    base_path
+    (Keeper_state_machine.phase_to_string phase);
   let done_p, done_r = Eio.Promise.create () in
   let key = registry_key ~base_path name in
   (match StringMap.find_opt key (Atomic.get registry) with
    | Some entry when entry.phase = Running ->
-       Prometheus.inc_counter
-        Keeper_metrics.metric_keeper_lifecycle_dispatch_rejections
-        ~labels:[("keeper", name); ("event", "register_overwrite_running")]
-        ();
-      Log.Keeper.warn "registry: overwriting running keeper during register name=%s" name;
-       decr_running_count_clamped ()
+     Prometheus.inc_counter
+       Keeper_metrics.metric_keeper_lifecycle_dispatch_rejections
+       ~labels:[ "keeper", name; "event", "register_overwrite_running" ]
+       ();
+     Log.Keeper.warn "registry: overwriting running keeper during register name=%s" name;
+     decr_running_count_clamped ()
    | _ -> ());
-  let entry = {
-    base_path;
-    name;
-    meta;
-    phase;
-    conditions;
-    fiber_stop = Atomic.make false;
-    fiber_wakeup = Atomic.make false;
-    event_queue = Atomic.make Keeper_event_queue.empty;
-    started_at = Time_compat.now ();
-    grpc_close = Atomic.make None;
-    done_p;
-    done_r;
-    restart_count = 0;
-    last_restart_ts = 0.0;
-    dead_since_ts = None;
-    crash_log = [];
-    last_error = None;
-    last_failure_reason = None;
-    turn_consecutive_failures = 0;
-    last_agent_count = 0;
-    board_wakeups = StringMap.empty;
-    board_cursor_ts = 0.0;
-    board_cursor_post_id = None;
-    tool_usage = StringMap.empty;
-    transition_seq = 0;
-    waiting_for_inference = Atomic.make false;
-    last_auto_rules = None;
-    last_event_bus_correlation = None;
-    pending_turn_measurement = None;
-    current_turn_observation = None;
-    last_completed_turn = None;
-    last_skip_observation = None;
-    compaction_stage = Packed Compaction_accumulating;
-  } in
+  let entry =
+    { base_path
+    ; name
+    ; meta
+    ; phase
+    ; conditions
+    ; fiber_stop = Atomic.make false
+    ; fiber_wakeup = Atomic.make false
+    ; event_queue = Atomic.make Keeper_event_queue.empty
+    ; started_at = Time_compat.now ()
+    ; grpc_close = Atomic.make None
+    ; done_p
+    ; done_r
+    ; restart_count = 0
+    ; last_restart_ts = 0.0
+    ; dead_since_ts = None
+    ; crash_log = []
+    ; last_error = None
+    ; last_failure_reason = None
+    ; turn_consecutive_failures = 0
+    ; last_agent_count = 0
+    ; board_wakeups = StringMap.empty
+    ; board_cursor_ts = 0.0
+    ; board_cursor_post_id = None
+    ; tool_usage = StringMap.empty
+    ; transition_seq = 0
+    ; waiting_for_inference = Atomic.make false
+    ; last_auto_rules = None
+    ; last_event_bus_correlation = None
+    ; pending_turn_measurement = None
+    ; current_turn_observation = None
+    ; last_completed_turn = None
+    ; last_skip_observation = None
+    ; compaction_stage = Packed Compaction_accumulating
+    }
+  in
   put_entry key entry;
-  if phase = Running then
-    Atomic.incr running_count_atomic;
-  Log.Keeper.debug "registry: keeper registered name=%s running_count=%d"
-    name (Atomic.get running_count_atomic);
+  if phase = Running then Atomic.incr running_count_atomic;
+  Log.Keeper.debug
+    "registry: keeper registered name=%s running_count=%d"
+    name
+    (Atomic.get running_count_atomic);
   entry
+;;
 
 let register ~base_path name meta =
-  let conditions = {
-    Keeper_state_machine.default_conditions with
-    fiber_alive = true;
-    restart_budget_remaining = true;
-  } in
+  let conditions =
+    { Keeper_state_machine.default_conditions with
+      fiber_alive = true
+    ; restart_budget_remaining = true
+    }
+  in
   let phase = Keeper_state_machine.derive_phase conditions in
   register_with_state ~base_path name meta ~phase ~conditions
+;;
 
 let register_offline ~base_path name meta =
-  let conditions = {
-    Keeper_state_machine.default_conditions with
-    launch_pending = true;
-    restart_budget_remaining = true;
-  } in
+  let conditions =
+    { Keeper_state_machine.default_conditions with
+      launch_pending = true
+    ; restart_budget_remaining = true
+    }
+  in
   let phase = Keeper_state_machine.derive_phase conditions in
   register_with_state ~base_path name meta ~phase ~conditions
+;;
 
 (** R-A-6.a — refuse to revive a keeper whose restart_budget was previously
     exhausted.  Pairs with TLA+ §S3 BudgetNeverRevives:
@@ -777,53 +822,59 @@ let register_offline ~base_path name meta =
     documented in `docs/tla-audit/ksm-a6-budget-never-revives-2026-05-12.md`
     (iter 14 audit memo).  This refusal turns those silent corruptions
     into a typed error the caller must handle. *)
-type register_restarting_error =
-  | Budget_already_exhausted of { name : string }
+type register_restarting_error = Budget_already_exhausted of { name : string }
 
 let register_restarting ~base_path name meta
   : (registry_entry, register_restarting_error) result
   =
   let key = registry_key ~base_path name in
-  let conditions = {
-    Keeper_state_machine.default_conditions with
-    restart_budget_remaining = true;
-    backoff_elapsed = true;
-  } in
+  let conditions =
+    { Keeper_state_machine.default_conditions with
+      restart_budget_remaining = true
+    ; backoff_elapsed = true
+    }
+  in
   let phase = Keeper_state_machine.derive_phase conditions in
   (* Build fresh entry once — its per-fiber atomics (fiber_stop,
      event_queue, etc.) are independent of registry contents, so a
      CAS retry can re-use the same record without re-allocating. *)
   let done_p, done_r = Eio.Promise.create () in
-  let new_entry = {
-    base_path; name; meta; phase; conditions;
-    fiber_stop = Atomic.make false;
-    fiber_wakeup = Atomic.make false;
-    event_queue = Atomic.make Keeper_event_queue.empty;
-    started_at = Time_compat.now ();
-    grpc_close = Atomic.make None;
-    done_p; done_r;
-    restart_count = 0;
-    last_restart_ts = 0.0;
-    dead_since_ts = None;
-    crash_log = [];
-    last_error = None;
-    last_failure_reason = None;
-    turn_consecutive_failures = 0;
-    last_agent_count = 0;
-    board_wakeups = StringMap.empty;
-    board_cursor_ts = 0.0;
-    board_cursor_post_id = None;
-    tool_usage = StringMap.empty;
-    transition_seq = 0;
-    waiting_for_inference = Atomic.make false;
-    last_auto_rules = None;
-    last_event_bus_correlation = None;
-    pending_turn_measurement = None;
-    current_turn_observation = None;
-    last_completed_turn = None;
-    last_skip_observation = None;
-    compaction_stage = Packed Compaction_accumulating;
-  } in
+  let new_entry =
+    { base_path
+    ; name
+    ; meta
+    ; phase
+    ; conditions
+    ; fiber_stop = Atomic.make false
+    ; fiber_wakeup = Atomic.make false
+    ; event_queue = Atomic.make Keeper_event_queue.empty
+    ; started_at = Time_compat.now ()
+    ; grpc_close = Atomic.make None
+    ; done_p
+    ; done_r
+    ; restart_count = 0
+    ; last_restart_ts = 0.0
+    ; dead_since_ts = None
+    ; crash_log = []
+    ; last_error = None
+    ; last_failure_reason = None
+    ; turn_consecutive_failures = 0
+    ; last_agent_count = 0
+    ; board_wakeups = StringMap.empty
+    ; board_cursor_ts = 0.0
+    ; board_cursor_post_id = None
+    ; tool_usage = StringMap.empty
+    ; transition_seq = 0
+    ; waiting_for_inference = Atomic.make false
+    ; last_auto_rules = None
+    ; last_event_bus_correlation = None
+    ; pending_turn_measurement = None
+    ; current_turn_observation = None
+    ; last_completed_turn = None
+    ; last_skip_observation = None
+    ; compaction_stage = Packed Compaction_accumulating
+    }
+  in
   (* Guard + write in a single CAS loop so a concurrent budget-exhaust
      update between our read and write cannot be overwritten back to
      [restart_budget_remaining = true].  Without this loop, two threads
@@ -837,14 +888,18 @@ let register_restarting ~base_path name meta
       Error (Budget_already_exhausted { name })
     | _ ->
       let updated = StringMap.add key new_entry current in
-      if Atomic.compare_and_set registry current updated then begin
+      if Atomic.compare_and_set registry current updated
+      then (
         Log.Keeper.info
           "registry: registering keeper name=%s base_path=%s phase=%s"
-          name base_path (Keeper_state_machine.phase_to_string phase);
-        Ok new_entry
-      end else loop ()
+          name
+          base_path
+          (Keeper_state_machine.phase_to_string phase);
+        Ok new_entry)
+      else loop ()
   in
   loop ()
+;;
 
 let unregister ~base_path name =
   Log.Keeper.info "registry: unregistering keeper name=%s base_path=%s" name base_path;
@@ -853,19 +908,23 @@ let unregister ~base_path name =
     let current = Atomic.get registry in
     let before = StringMap.find_opt key current in
     let updated = StringMap.remove key current in
-    if not (Atomic.compare_and_set registry current updated) then loop ()
-    else before
+    if not (Atomic.compare_and_set registry current updated) then loop () else before
   in
-  (match loop () with
-   | Some entry when entry.phase = Running ->
-       decr_running_count_clamped ();
-       Log.Keeper.debug "registry: unregistered running keeper name=%s running_count=%d"
-         name (Atomic.get running_count_atomic)
-   | Some entry ->
-       Log.Keeper.debug "registry: unregistered non-running keeper name=%s state=%s"
-         name (Keeper_state_machine.phase_to_string entry.phase)
-   | None ->
-       Log.Keeper.warn "registry: attempted to unregister non-existent keeper name=%s" name)
+  match loop () with
+  | Some entry when entry.phase = Running ->
+    decr_running_count_clamped ();
+    Log.Keeper.debug
+      "registry: unregistered running keeper name=%s running_count=%d"
+      name
+      (Atomic.get running_count_atomic)
+  | Some entry ->
+    Log.Keeper.debug
+      "registry: unregistered non-running keeper name=%s state=%s"
+      name
+      (Keeper_state_machine.phase_to_string entry.phase)
+  | None ->
+    Log.Keeper.warn "registry: attempted to unregister non-existent keeper name=%s" name
+;;
 
 let get ~base_path name =
   let result = StringMap.find_opt (registry_key ~base_path name) (Atomic.get registry) in
@@ -873,30 +932,36 @@ let get ~base_path name =
    | None -> Log.Keeper.debug "registry: lookup miss name=%s base_path=%s" name base_path
    | Some _ -> ());
   result
+;;
 
 let all ?base_path () =
   StringMap.fold
     (fun _k v acc ->
-      match base_path with
-      | Some expected when not (String.equal expected v.base_path) -> acc
-      | _ -> v :: acc)
-    (Atomic.get registry) []
+       match base_path with
+       | Some expected when not (String.equal expected v.base_path) -> acc
+       | _ -> v :: acc)
+    (Atomic.get registry)
+    []
+;;
 
 let update_meta ~base_path name meta =
   update_entry ~base_path name (fun e -> { e with meta })
+;;
 
 let () =
   register_runtime_meta_write_sync (fun config meta ->
-      update_meta ~base_path:config.base_path meta.name meta)
+    update_meta ~base_path:config.base_path meta.name meta)
+;;
 
 let mark_dead ~base_path name ~at =
   Prometheus.inc_counter
     Keeper_metrics.metric_keeper_lifecycle_transitions
-    ~labels:[("keeper", name); ("from_phase", "direct"); ("to_phase", "Dead")]
+    ~labels:[ "keeper", name; "from_phase", "direct"; "to_phase", "Dead" ]
     ();
   Log.Keeper.error "registry: marking keeper dead name=%s at=%.0f" name at;
   update_entry ~base_path name (fun entry ->
-    if entry.phase <> Dead then begin
+    if entry.phase <> Dead
+    then (
       (* Enumerate every phase so the compiler flags any new variant.
          Only the Running phase contributes to [running_count_atomic];
          all other phases were never counted, so transitioning to
@@ -904,40 +969,53 @@ let mark_dead ~base_path name ~at =
          anti-pattern as PR #14857 (this file's [is_running]). *)
       (match entry.phase with
        | Running -> decr_running_count_clamped ()
-       | Offline | Failing | Overflowed | Compacting | HandingOff
-       | Draining | Paused | Stopped | Crashed | Restarting | Dead
+       | Offline
+       | Failing
+       | Overflowed
+       | Compacting
+       | HandingOff
+       | Draining
+       | Paused
+       | Stopped
+       | Crashed
+       | Restarting
+       | Dead
        | Zombie -> ());
       let conditions =
         { Keeper_state_machine.default_conditions with
-          launch_pending = false;
-          fiber_alive = false;
-          restart_budget_remaining = false;
+          launch_pending = false
+        ; fiber_alive = false
+        ; restart_budget_remaining = false
         }
       in
       let phase = Keeper_state_machine.derive_phase conditions in
-      { entry with dead_since_ts = Some at; phase; conditions }
-    end else
+      { entry with dead_since_ts = Some at; phase; conditions })
+    else
       { entry with dead_since_ts = Some (Option.value ~default:at entry.dead_since_ts) })
+;;
 
 let record_restart ~base_path name =
   Log.Keeper.warn "registry: recording restart name=%s" name;
   update_entry ~base_path name (fun e ->
-    { e with restart_count = e.restart_count + 1;
-             last_restart_ts = Time_compat.now () })
+    { e with restart_count = e.restart_count + 1; last_restart_ts = Time_compat.now () })
+;;
 
 let record_error ~base_path name err =
   Log.Keeper.error "registry: recording error name=%s error=%s" name err;
   update_entry ~base_path name (fun e -> { e with last_error = Some err })
+;;
 
 let clear_error ~base_path name =
   update_entry ~base_path name (fun e -> { e with last_error = None })
+;;
 
 let set_failure_reason ~base_path name reason =
   update_entry ~base_path name (fun e -> { e with last_failure_reason = reason })
+;;
 
 let set_last_correlation_id ~base_path name cid =
-  update_entry ~base_path name (fun e ->
-    { e with last_event_bus_correlation = Some cid })
+  update_entry ~base_path name (fun e -> { e with last_event_bus_correlation = Some cid })
+;;
 
 let turn_phase_of_cascade_state (s : packed_cascade_state) : packed_turn_phase =
   match s with
@@ -946,22 +1024,23 @@ let turn_phase_of_cascade_state (s : packed_cascade_state) : packed_turn_phase =
   | Packed Cascade_trying -> Packed Turn_executing
   | Packed Cascade_done -> Packed Turn_finalizing
   | Packed Cascade_exhausted -> Packed Turn_exhausted
+;;
 
 let broadcast_composite_changed ~name ~ts_unix =
   try
     let json =
-      `Assoc [
-        "type", `String "keeper_composite_changed";
-        "name", `String name;
-        "ts_unix", `Float ts_unix;
-      ]
+      `Assoc
+        [ "type", `String "keeper_composite_changed"
+        ; "name", `String name
+        ; "ts_unix", `Float ts_unix
+        ]
     in
     Sse.broadcast json;
     Sse.broadcast_presence json
   with
   | Eio.Cancel.Cancelled _ as e -> raise e
   | exn ->
-      (* P2 silent-failure fix: previously this discarded the exception
+    (* P2 silent-failure fix: previously this discarded the exception
          silently, hiding the case where the SSE broadcast pipe is dead
          (subscriber cleanup race, transport tear-down).  Operators
          investigating "dashboard stopped updating" had no signal that
@@ -970,25 +1049,30 @@ let broadcast_composite_changed ~name ~ts_unix =
          inside broadcast_impl — exceptions thrown out of
          Sse.broadcast itself bypass that counter.  Logging here
          makes the exception visible at the call site. *)
-      Prometheus.inc_counter
-        Keeper_metrics.metric_keeper_lifecycle_dispatch_rejections
-        ~labels:[("keeper", name); ("event", "broadcast_composite_failed")]
-        ();
-      Log.Keeper.warn
-        "registry: broadcast_composite_changed name=%s failed: %s"
-        name (Printexc.to_string exn)
+    Prometheus.inc_counter
+      Keeper_metrics.metric_keeper_lifecycle_dispatch_rejections
+      ~labels:[ "keeper", name; "event", "broadcast_composite_failed" ]
+      ();
+    Log.Keeper.warn
+      "registry: broadcast_composite_changed name=%s failed: %s"
+      name
+      (Printexc.to_string exn)
+;;
 
 let record_phase_broadcast_failure ~name exn =
   Prometheus.inc_counter
     Keeper_metrics.metric_keeper_sse_broadcast_failures
-    ~labels:[("keeper", name); ("site", "phase_changed")]
+    ~labels:[ "keeper", name; "site", "phase_changed" ]
     ();
   Log.Keeper.warn
     "registry: keeper_phase_changed broadcast failed name=%s err=%s"
-    name (Printexc.to_string exn)
+    name
+    (Printexc.to_string exn)
+;;
 
-let completed_turn_outcome_of_observation
-    (obs : turn_observation) : Keeper_transition_audit.completed_turn_outcome =
+let completed_turn_outcome_of_observation (obs : turn_observation)
+  : Keeper_transition_audit.completed_turn_outcome
+  =
   (* P1 silent-failure fix: the previous wildcard `| _ -> Turn_failed`
      meant that adding a new variant to either ADT (decision_stage or
      cascade_state) would silently fall through to Turn_failed without
@@ -997,12 +1081,13 @@ let completed_turn_outcome_of_observation
   match obs.decision_stage with
   | Packed Decision_gate_rejected -> Keeper_transition_audit.Turn_gate_rejected
   | Packed (Decision_undecided | Decision_guard_ok | Decision_tool_policy_selected) ->
-      (match obs.cascade_state with
-       | Packed Cascade_done -> Keeper_transition_audit.Turn_substantive
-       | Packed Cascade_idle
-       | Packed Cascade_selecting
-       | Packed Cascade_trying
-       | Packed Cascade_exhausted -> Keeper_transition_audit.Turn_failed)
+    (match obs.cascade_state with
+     | Packed Cascade_done -> Keeper_transition_audit.Turn_substantive
+     | Packed Cascade_idle
+     | Packed Cascade_selecting
+     | Packed Cascade_trying
+     | Packed Cascade_exhausted -> Keeper_transition_audit.Turn_failed)
+;;
 
 let update_current_turn e f =
   let current_turn_observation =
@@ -1011,28 +1096,31 @@ let update_current_turn e f =
     | Some obs -> Some (f obs)
   in
   { e with current_turn_observation }
+;;
 
 let mark_turn_started ~base_path name =
   let changed = ref false in
   let now = Time_compat.now () in
   update_entry ~base_path name (fun e ->
     let turn_id = e.meta.runtime.usage.total_turns + 1 in
-    let obs = {
-      turn_id;
-      started_at = now;
-      turn_phase = Packed Turn_prompting;
-      decision_stage = Packed Decision_undecided;
-      cascade_state = Packed Cascade_idle;
-      measurement = None;
-      measurement_bind_count = 0;
-      selected_model = None;
-    } in
+    let obs =
+      { turn_id
+      ; started_at = now
+      ; turn_phase = Packed Turn_prompting
+      ; decision_stage = Packed Decision_undecided
+      ; cascade_state = Packed Cascade_idle
+      ; measurement = None
+      ; measurement_bind_count = 0
+      ; selected_model = None
+      }
+    in
     changed := true;
     { e with
-      current_turn_observation = Some obs;
-      compaction_stage = Packed Compaction_accumulating;
+      current_turn_observation = Some obs
+    ; compaction_stage = Packed Compaction_accumulating
     });
   if !changed then broadcast_composite_changed ~name ~ts_unix:now
+;;
 
 (* RFC-0045: SDK-turn boundary reset.  Resets in-turn FSM fields without
    touching keeper-turn-scoped data ([turn_id], [started_at],
@@ -1050,20 +1138,23 @@ let mark_sdk_turn_started ~base_path name =
     match e.current_turn_observation with
     | None -> e
     | Some obs ->
-      if obs.turn_phase = Packed Turn_prompting
-         && obs.cascade_state = Packed Cascade_idle
-         && obs.decision_stage = Packed Decision_undecided
+      if
+        obs.turn_phase = Packed Turn_prompting
+        && obs.cascade_state = Packed Cascade_idle
+        && obs.decision_stage = Packed Decision_undecided
       then e
       else (
         changed := true;
-        let new_obs = {
-          obs with
-          turn_phase = Packed Turn_prompting;
-          cascade_state = Packed Cascade_idle;
-          decision_stage = Packed Decision_undecided;
-        } in
+        let new_obs =
+          { obs with
+            turn_phase = Packed Turn_prompting
+          ; cascade_state = Packed Cascade_idle
+          ; decision_stage = Packed Decision_undecided
+          }
+        in
         { e with current_turn_observation = Some new_obs }));
   if !changed then broadcast_composite_changed ~name ~ts_unix:now
+;;
 
 let mark_turn_measurement ~base_path name =
   let changed = ref false in
@@ -1072,50 +1163,61 @@ let mark_turn_measurement ~base_path name =
     match e.current_turn_observation, e.pending_turn_measurement with
     | Some obs, Some measurement ->
       changed := true;
-      {
-        e with
+      { e with
         current_turn_observation =
-          Some {
-            obs with
-            measurement = Some measurement;
-            measurement_bind_count = obs.measurement_bind_count + 1;
-          };
-        pending_turn_measurement = None;
+          Some
+            { obs with
+              measurement = Some measurement
+            ; measurement_bind_count = obs.measurement_bind_count + 1
+            }
+      ; pending_turn_measurement = None
       }
     | _ -> e);
   if !changed then broadcast_composite_changed ~name ~ts_unix:now
+;;
 
 let validate_cascade_transition ~from ~to_ =
   let (_ : packed_cascade_state) = from in
   let (_ : packed_cascade_state) = to_ in
   match from, to_ with
   | Packed Cascade_idle, Packed Cascade_idle -> ()
-  | Packed Cascade_idle, Packed Cascade_selecting -> ()  (* via set_turn_cascade_state *)
-  | Packed Cascade_selecting, Packed Cascade_idle -> ()  (* via prepare_turn_retry_after_compaction *)
+  | Packed Cascade_idle, Packed Cascade_selecting -> () (* via set_turn_cascade_state *)
+  | Packed Cascade_selecting, Packed Cascade_idle ->
+    () (* via prepare_turn_retry_after_compaction *)
   | Packed Cascade_selecting, Packed Cascade_selecting -> ()
-  | Packed Cascade_selecting, Packed Cascade_trying -> ()  (* via set_turn_cascade_state *)
-  | Packed Cascade_trying, Packed Cascade_idle -> ()  (* via prepare_turn_retry_after_compaction *)
-  | Packed Cascade_trying, Packed Cascade_selecting -> ()  (* via set_turn_cascade_state: retry re-entry *)
+  | Packed Cascade_selecting, Packed Cascade_trying -> () (* via set_turn_cascade_state *)
+  | Packed Cascade_trying, Packed Cascade_idle ->
+    () (* via prepare_turn_retry_after_compaction *)
+  | Packed Cascade_trying, Packed Cascade_selecting ->
+    () (* via set_turn_cascade_state: retry re-entry *)
   | Packed Cascade_trying, Packed Cascade_trying -> ()
-  | Packed Cascade_trying, Packed Cascade_done -> ()  (* via set_turn_cascade_state *)
-  | Packed Cascade_trying, Packed Cascade_exhausted -> ()  (* via set_turn_cascade_state *)
-  | Packed Cascade_done, Packed Cascade_idle -> ()  (* via prepare_turn_retry_after_compaction *)
-  | Packed Cascade_done, Packed Cascade_selecting -> ()  (* via prepare_turn_retry_after_compaction *)
-  | Packed Cascade_done, Packed Cascade_trying -> ()  (* via prepare_turn_retry_after_compaction *)
+  | Packed Cascade_trying, Packed Cascade_done -> () (* via set_turn_cascade_state *)
+  | Packed Cascade_trying, Packed Cascade_exhausted -> () (* via set_turn_cascade_state *)
+  | Packed Cascade_done, Packed Cascade_idle ->
+    () (* via prepare_turn_retry_after_compaction *)
+  | Packed Cascade_done, Packed Cascade_selecting ->
+    () (* via prepare_turn_retry_after_compaction *)
+  | Packed Cascade_done, Packed Cascade_trying ->
+    () (* via prepare_turn_retry_after_compaction *)
   | Packed Cascade_done, Packed Cascade_done -> ()
-  | Packed Cascade_exhausted, Packed Cascade_idle -> ()  (* via prepare_turn_retry_after_compaction *)
-  | Packed Cascade_exhausted, Packed Cascade_selecting -> ()  (* via prepare_turn_retry_after_compaction *)
-  | Packed Cascade_exhausted, Packed Cascade_trying -> ()  (* via prepare_turn_retry_after_compaction *)
+  | Packed Cascade_exhausted, Packed Cascade_idle ->
+    () (* via prepare_turn_retry_after_compaction *)
+  | Packed Cascade_exhausted, Packed Cascade_selecting ->
+    () (* via prepare_turn_retry_after_compaction *)
+  | Packed Cascade_exhausted, Packed Cascade_trying ->
+    () (* via prepare_turn_retry_after_compaction *)
   | Packed Cascade_exhausted, Packed Cascade_exhausted -> ()
-  | Packed Cascade_idle, (Packed Cascade_trying | Packed Cascade_done | Packed Cascade_exhausted)
+  | ( Packed Cascade_idle
+    , (Packed Cascade_trying | Packed Cascade_done | Packed Cascade_exhausted) )
   | Packed Cascade_selecting, (Packed Cascade_done | Packed Cascade_exhausted)
   | Packed Cascade_done, Packed Cascade_exhausted
   | Packed Cascade_exhausted, Packed Cascade_done ->
-      invalid_arg
-        (Printf.sprintf
-           "validate_cascade_transition: invalid transition %s -> %s"
-           (packed_cascade_state_label from)
-           (packed_cascade_state_label to_))
+    invalid_arg
+      (Printf.sprintf
+         "validate_cascade_transition: invalid transition %s -> %s"
+         (packed_cascade_state_label from)
+         (packed_cascade_state_label to_))
+;;
 
 let validate_turn_phase_transition ~from ~to_ =
   let (_ : packed_turn_phase) = from in
@@ -1128,67 +1230,95 @@ let validate_turn_phase_transition ~from ~to_ =
          match from, to_ with
          (* from Turn_idle *)
          | Packed Turn_idle, Packed Turn_idle -> true
-         | Packed Turn_idle, Packed Turn_prompting -> true  (* via turn init / prepare_turn_retry_after_compaction *)
+         | Packed Turn_idle, Packed Turn_prompting ->
+           true (* via turn init / prepare_turn_retry_after_compaction *)
          | Packed Turn_idle, Packed Turn_routing -> false
          | Packed Turn_idle, Packed Turn_executing -> false
          | Packed Turn_idle, Packed Turn_compacting -> false
          | Packed Turn_idle, Packed Turn_finalizing -> false
          | Packed Turn_idle, Packed Turn_exhausted -> false
          (* from Turn_prompting *)
-         | Packed Turn_prompting, Packed Turn_idle -> false  (* new turn init is reset, not transition *)
+         | Packed Turn_prompting, Packed Turn_idle ->
+           false (* new turn init is reset, not transition *)
          | Packed Turn_prompting, Packed Turn_prompting -> true
-         | Packed Turn_prompting, Packed Turn_routing -> true  (* via set_turn_cascade_state: Cascade_selecting *)
-         | Packed Turn_prompting, Packed Turn_executing -> true  (* via set_turn_phase *)
+         | Packed Turn_prompting, Packed Turn_routing ->
+           true (* via set_turn_cascade_state: Cascade_selecting *)
+         | Packed Turn_prompting, Packed Turn_executing -> true (* via set_turn_phase *)
          | Packed Turn_prompting, Packed Turn_compacting -> false
-         | Packed Turn_prompting, Packed Turn_finalizing -> true  (* via mark_turn_gate_rejected_by_name *)
-         | Packed Turn_prompting, Packed Turn_exhausted -> true  (* via set_turn_cascade_state: Cascade_exhausted before any cascade attempt (e.g. all candidates filtered out at admission) *)
+         | Packed Turn_prompting, Packed Turn_finalizing ->
+           true (* via mark_turn_gate_rejected_by_name *)
+         | Packed Turn_prompting, Packed Turn_exhausted -> true
+         (* via set_turn_cascade_state: Cascade_exhausted before any cascade attempt (e.g. all candidates filtered out at admission) *)
          (* from Turn_routing *)
-         | Packed Turn_routing, Packed Turn_idle -> false  (* new turn init is reset, not transition *)
-         | Packed Turn_routing, Packed Turn_prompting -> true  (* via set_turn_cascade_state: Cascade_idle on retry *)
+         | Packed Turn_routing, Packed Turn_idle ->
+           false (* new turn init is reset, not transition *)
+         | Packed Turn_routing, Packed Turn_prompting ->
+           true (* via set_turn_cascade_state: Cascade_idle on retry *)
          | Packed Turn_routing, Packed Turn_routing -> true
-         | Packed Turn_routing, Packed Turn_executing -> true  (* via set_turn_cascade_state: Cascade_trying *)
+         | Packed Turn_routing, Packed Turn_executing ->
+           true (* via set_turn_cascade_state: Cascade_trying *)
          | Packed Turn_routing, Packed Turn_compacting -> false
          | Packed Turn_routing, Packed Turn_finalizing -> false
-         | Packed Turn_routing, Packed Turn_exhausted -> true  (* via set_turn_cascade_state: Cascade_exhausted during model selection (cascade-fallback exhausted before Cascade_trying) *)
+         | Packed Turn_routing, Packed Turn_exhausted -> true
+         (* via set_turn_cascade_state: Cascade_exhausted during model selection (cascade-fallback exhausted before Cascade_trying) *)
          (* from Turn_executing *)
-         | Packed Turn_executing, Packed Turn_idle -> false  (* new turn init is reset, not transition *)
-         | Packed Turn_executing, Packed Turn_prompting -> true  (* via set_turn_cascade_state: Cascade_idle retry *)
-         | Packed Turn_executing, Packed Turn_routing -> true  (* via set_turn_cascade_state: Cascade_selecting retry *)
+         | Packed Turn_executing, Packed Turn_idle ->
+           false (* new turn init is reset, not transition *)
+         | Packed Turn_executing, Packed Turn_prompting ->
+           true (* via set_turn_cascade_state: Cascade_idle retry *)
+         | Packed Turn_executing, Packed Turn_routing ->
+           true (* via set_turn_cascade_state: Cascade_selecting retry *)
          | Packed Turn_executing, Packed Turn_executing -> true
-         | Packed Turn_executing, Packed Turn_compacting -> true  (* via set_turn_phase: retry plan *)
-         | Packed Turn_executing, Packed Turn_finalizing -> true  (* via set_turn_cascade_state: Cascade_done *)
-         | Packed Turn_executing, Packed Turn_exhausted -> true  (* via set_turn_cascade_state: Cascade_exhausted *)
+         | Packed Turn_executing, Packed Turn_compacting ->
+           true (* via set_turn_phase: retry plan *)
+         | Packed Turn_executing, Packed Turn_finalizing ->
+           true (* via set_turn_cascade_state: Cascade_done *)
+         | Packed Turn_executing, Packed Turn_exhausted ->
+           true (* via set_turn_cascade_state: Cascade_exhausted *)
          (* from Turn_compacting *)
-         | Packed Turn_compacting, Packed Turn_idle -> false  (* new turn init is reset, not transition *)
-         | Packed Turn_compacting, Packed Turn_prompting -> true  (* via prepare_turn_retry_after_compaction *)
+         | Packed Turn_compacting, Packed Turn_idle ->
+           false (* new turn init is reset, not transition *)
+         | Packed Turn_compacting, Packed Turn_prompting ->
+           true (* via prepare_turn_retry_after_compaction *)
          | Packed Turn_compacting, Packed Turn_routing -> false
          | Packed Turn_compacting, Packed Turn_executing -> false
          | Packed Turn_compacting, Packed Turn_compacting -> true
-         | Packed Turn_compacting, Packed Turn_finalizing -> true  (* via set_turn_phase: compaction failure *)
-         | Packed Turn_compacting, Packed Turn_exhausted -> true  (* via set_turn_cascade_state: Cascade_exhausted on terminal error *)
+         | Packed Turn_compacting, Packed Turn_finalizing ->
+           true (* via set_turn_phase: compaction failure *)
+         | Packed Turn_compacting, Packed Turn_exhausted ->
+           true (* via set_turn_cascade_state: Cascade_exhausted on terminal error *)
          (* from Turn_finalizing *)
-         | Packed Turn_finalizing, Packed Turn_idle -> false  (* new turn is reset *)
-         | Packed Turn_finalizing, Packed Turn_prompting -> true  (* via set_turn_cascade_state: degraded retry Cascade_idle *)
-         | Packed Turn_finalizing, Packed Turn_routing -> true  (* via set_turn_cascade_state: degraded retry Cascade_selecting *)
-         | Packed Turn_finalizing, Packed Turn_executing -> true  (* via set_turn_cascade_state: degraded retry Cascade_trying *)
+         | Packed Turn_finalizing, Packed Turn_idle -> false (* new turn is reset *)
+         | Packed Turn_finalizing, Packed Turn_prompting ->
+           true (* via set_turn_cascade_state: degraded retry Cascade_idle *)
+         | Packed Turn_finalizing, Packed Turn_routing ->
+           true (* via set_turn_cascade_state: degraded retry Cascade_selecting *)
+         | Packed Turn_finalizing, Packed Turn_executing ->
+           true (* via set_turn_cascade_state: degraded retry Cascade_trying *)
          | Packed Turn_finalizing, Packed Turn_compacting -> false
          | Packed Turn_finalizing, Packed Turn_finalizing -> true
-         | Packed Turn_finalizing, Packed Turn_exhausted -> true  (* via set_turn_cascade_state: Cascade_exhausted on terminal error *)
+         | Packed Turn_finalizing, Packed Turn_exhausted ->
+           true (* via set_turn_cascade_state: Cascade_exhausted on terminal error *)
          (* from Turn_exhausted *)
-         | Packed Turn_exhausted, Packed Turn_idle -> false  (* new turn is reset *)
-         | Packed Turn_exhausted, Packed Turn_prompting -> true  (* via prepare_turn_retry_after_compaction: Cascade_idle *)
-         | Packed Turn_exhausted, Packed Turn_routing -> true  (* via set_turn_cascade_state: retry Cascade_selecting *)
-         | Packed Turn_exhausted, Packed Turn_executing -> true  (* via set_turn_cascade_state: retry Cascade_trying *)
+         | Packed Turn_exhausted, Packed Turn_idle -> false (* new turn is reset *)
+         | Packed Turn_exhausted, Packed Turn_prompting ->
+           true (* via prepare_turn_retry_after_compaction: Cascade_idle *)
+         | Packed Turn_exhausted, Packed Turn_routing ->
+           true (* via set_turn_cascade_state: retry Cascade_selecting *)
+         | Packed Turn_exhausted, Packed Turn_executing ->
+           true (* via set_turn_cascade_state: retry Cascade_trying *)
          | Packed Turn_exhausted, Packed Turn_compacting -> false
          | Packed Turn_exhausted, Packed Turn_finalizing -> false
          | Packed Turn_exhausted, Packed Turn_exhausted -> true
        in
-       if not valid then
+       if not valid
+       then
          invalid_arg
            (Printf.sprintf
               "validate_turn_phase_transition: invalid transition %s -> %s"
               (packed_turn_phase_label from)
               (packed_turn_phase_label to_)))
+;;
 
 let set_turn_decision_stage ~base_path name decision_stage =
   let target_packed = stage_to_witness decision_stage in
@@ -1199,33 +1329,41 @@ let set_turn_decision_stage ~base_path name decision_stage =
       match obs.decision_stage, target_packed with
       | Packed Decision_undecided, Packed Decision_undecided -> obs
       | Packed Decision_undecided, Packed Decision_guard_ok ->
-          changed := true; { obs with decision_stage = target_packed }
+        changed := true;
+        { obs with decision_stage = target_packed }
       | Packed Decision_undecided, Packed Decision_gate_rejected ->
-          changed := true; { obs with decision_stage = target_packed }
+        changed := true;
+        { obs with decision_stage = target_packed }
       | Packed Decision_undecided, Packed Decision_tool_policy_selected ->
-          changed := true; { obs with decision_stage = target_packed }
+        changed := true;
+        { obs with decision_stage = target_packed }
       | Packed Decision_guard_ok, Packed Decision_guard_ok -> obs
       | Packed Decision_guard_ok, Packed Decision_gate_rejected ->
-          changed := true; { obs with decision_stage = target_packed }
+        changed := true;
+        { obs with decision_stage = target_packed }
       | Packed Decision_guard_ok, Packed Decision_tool_policy_selected ->
-          changed := true; { obs with decision_stage = target_packed }
+        changed := true;
+        { obs with decision_stage = target_packed }
       | Packed Decision_gate_rejected, Packed Decision_gate_rejected -> obs
       | Packed Decision_gate_rejected, Packed Decision_guard_ok ->
-          changed := true; { obs with decision_stage = target_packed }
+        changed := true;
+        { obs with decision_stage = target_packed }
       | Packed Decision_gate_rejected, Packed Decision_tool_policy_selected ->
-          changed := true; { obs with decision_stage = target_packed }
-      | Packed Decision_tool_policy_selected, Packed Decision_tool_policy_selected ->
-          obs
+        changed := true;
+        { obs with decision_stage = target_packed }
+      | Packed Decision_tool_policy_selected, Packed Decision_tool_policy_selected -> obs
       | Packed Decision_tool_policy_selected, Packed Decision_guard_ok ->
-          changed := true; { obs with decision_stage = target_packed }
+        changed := true;
+        { obs with decision_stage = target_packed }
       | Packed Decision_tool_policy_selected, Packed Decision_gate_rejected ->
-          changed := true; { obs with decision_stage = target_packed }
+        changed := true;
+        { obs with decision_stage = target_packed }
       | Packed Decision_guard_ok, Packed Decision_undecided
       | Packed Decision_gate_rejected, Packed Decision_undecided
       | Packed Decision_tool_policy_selected, Packed Decision_undecided ->
-          invalid_arg "decision_stage transition to undecided is not valid within a turn"
-    ));
+        invalid_arg "decision_stage transition to undecided is not valid within a turn"));
   if !changed then broadcast_composite_changed ~name ~ts_unix:now
+;;
 
 let set_turn_cascade_state ~base_path name (cascade_state : packed_cascade_state) =
   let changed = ref false in
@@ -1233,17 +1371,12 @@ let set_turn_cascade_state ~base_path name (cascade_state : packed_cascade_state
   update_entry ~base_path name (fun e ->
     update_current_turn e (fun obs ->
       let new_turn_phase = turn_phase_of_cascade_state cascade_state in
-      validate_cascade_transition
-        ~from:obs.cascade_state
-        ~to_:cascade_state;
+      validate_cascade_transition ~from:obs.cascade_state ~to_:cascade_state;
       validate_turn_phase_transition ~from:obs.turn_phase ~to_:new_turn_phase;
       changed := true;
-      {
-        obs with
-        cascade_state;
-        turn_phase = new_turn_phase;
-      }));
+      { obs with cascade_state; turn_phase = new_turn_phase }));
   if !changed then broadcast_composite_changed ~name ~ts_unix:now
+;;
 
 let set_turn_phase ~base_path name (turn_phase : packed_turn_phase) =
   let changed = ref false in
@@ -1254,6 +1387,7 @@ let set_turn_phase ~base_path name (turn_phase : packed_turn_phase) =
       changed := true;
       { obs with turn_phase }));
   if !changed then broadcast_composite_changed ~name ~ts_unix:now
+;;
 
 let set_turn_selected_model ~base_path name selected_model =
   let changed = ref false in
@@ -1263,6 +1397,7 @@ let set_turn_selected_model ~base_path name selected_model =
       changed := true;
       { obs with selected_model }));
   if !changed then broadcast_composite_changed ~name ~ts_unix:now
+;;
 
 let prepare_turn_retry_after_compaction ~base_path name =
   let changed = ref false in
@@ -1274,39 +1409,40 @@ let prepare_turn_retry_after_compaction ~base_path name =
         ~to_:(Packed Cascade_idle : packed_cascade_state);
       validate_turn_phase_transition ~from:obs.turn_phase ~to_:(Packed Turn_prompting);
       changed := true;
-      {
-        obs with
-        turn_phase = Packed Turn_prompting;
-        decision_stage = Packed Decision_guard_ok;
-        cascade_state = Packed Cascade_idle;
-        selected_model = None;
+      { obs with
+        turn_phase = Packed Turn_prompting
+      ; decision_stage = Packed Decision_guard_ok
+      ; cascade_state = Packed Cascade_idle
+      ; selected_model = None
       }));
   if !changed then broadcast_composite_changed ~name ~ts_unix:now
+;;
 
 let mark_turn_gate_rejected_by_name name =
   let target =
     StringMap.fold
       (fun _k v acc ->
-        match acc with
-        | Some _ -> acc
-        | None -> if String.equal v.name name then Some v else None)
-      (Atomic.get registry) None
+         match acc with
+         | Some _ -> acc
+         | None -> if String.equal v.name name then Some v else None)
+      (Atomic.get registry)
+      None
   in
   match target with
   | None -> ()
   | Some entry ->
-      let changed = ref false in
-      let now = Time_compat.now () in
-      update_entry ~base_path:entry.base_path name (fun e ->
-        update_current_turn e (fun obs ->
-          validate_turn_phase_transition ~from:obs.turn_phase ~to_:(Packed Turn_finalizing);
-          changed := true;
-          {
-            obs with
-            decision_stage = Packed Decision_gate_rejected;
-            turn_phase = Packed Turn_finalizing;
-          }));
-      if !changed then broadcast_composite_changed ~name ~ts_unix:now
+    let changed = ref false in
+    let now = Time_compat.now () in
+    update_entry ~base_path:entry.base_path name (fun e ->
+      update_current_turn e (fun obs ->
+        validate_turn_phase_transition ~from:obs.turn_phase ~to_:(Packed Turn_finalizing);
+        changed := true;
+        { obs with
+          decision_stage = Packed Decision_gate_rejected
+        ; turn_phase = Packed Turn_finalizing
+        }));
+    if !changed then broadcast_composite_changed ~name ~ts_unix:now
+;;
 
 let mark_turn_finished ~base_path name =
   let completed_turn_to_record = ref None in
@@ -1321,44 +1457,37 @@ let mark_turn_finished ~base_path name =
     let last_completed_turn =
       match e.current_turn_observation with
       | Some obs ->
-          let ended_at = now in
-          changed := true;
-          completed_turn_to_record :=
-            Some
-              {
-                Keeper_transition_audit.turn_id = obs.turn_id;
-                started_at = obs.started_at;
-                ended_at;
-                outcome = completed_turn_outcome_of_observation obs;
-              };
-          Some
-            {
-              ct_turn_id = obs.turn_id;
-              ct_started_at = obs.started_at;
-              ct_ended_at = ended_at;
-              ct_decision_stage = obs.decision_stage;
-              ct_cascade_state = obs.cascade_state;
-              ct_selected_model = obs.selected_model;
-            }
-      | None -> e.last_completed_turn  (* no live turn → preserve previous *)
+        let ended_at = now in
+        changed := true;
+        completed_turn_to_record
+        := Some
+             { Keeper_transition_audit.turn_id = obs.turn_id
+             ; started_at = obs.started_at
+             ; ended_at
+             ; outcome = completed_turn_outcome_of_observation obs
+             };
+        Some
+          { ct_turn_id = obs.turn_id
+          ; ct_started_at = obs.started_at
+          ; ct_ended_at = ended_at
+          ; ct_decision_stage = obs.decision_stage
+          ; ct_cascade_state = obs.cascade_state
+          ; ct_selected_model = obs.selected_model
+          }
+      | None -> e.last_completed_turn (* no live turn → preserve previous *)
     in
     let meta =
-      if had_live_turn then
-        {
-          e.meta with
+      if had_live_turn
+      then
+        { e.meta with
           runtime =
-            {
-              e.meta.runtime with
-              usage =
-                { e.meta.runtime.usage with last_turn_ts = now };
-            };
+            { e.meta.runtime with
+              usage = { e.meta.runtime.usage with last_turn_ts = now }
+            }
         }
       else e.meta
     in
-    { e with
-      meta;
-      current_turn_observation = None;
-      last_completed_turn });
+    { e with meta; current_turn_observation = None; last_completed_turn });
   Option.iter
     (Keeper_transition_audit.record_completed_turn ~keeper_name:name)
     !completed_turn_to_record;
@@ -1371,16 +1500,18 @@ let mark_turn_finished ~base_path name =
    | Some entry -> Atomic.set entry.fiber_wakeup false
    | None -> ());
   if !changed then broadcast_composite_changed ~name ~ts_unix:now
+;;
 
 let record_skip_reasons ~base_path name ~reasons =
   (* Only stamp when there's at least one reason — empty lists from a
      [Run] verdict path would otherwise overwrite the last legitimate
      skip stamp with a no-op. *)
-  if reasons <> [] then begin
+  if reasons <> []
+  then (
     let now = Time_compat.now () in
     update_entry ~base_path name (fun e ->
-      { e with last_skip_observation = Some (now, reasons) })
-  end
+      { e with last_skip_observation = Some (now, reasons) }))
+;;
 
 let touch_last_turn_ts ~base_path name =
   let now = Time_compat.now () in
@@ -1390,25 +1521,25 @@ let touch_last_turn_ts ~base_path name =
     { e with
       meta =
         { e.meta with
-          runtime =
-            { runtime with
-              usage = { usage with last_turn_ts = now }
-            }
+          runtime = { runtime with usage = { usage with last_turn_ts = now } }
         }
     })
+;;
 
 let increment_turn_failures ~base_path name =
   update_entry ~base_path name (fun e ->
     { e with turn_consecutive_failures = e.turn_consecutive_failures + 1 })
+;;
 
 let reset_turn_failures ~base_path name =
-  update_entry ~base_path name (fun e ->
-    { e with turn_consecutive_failures = 0 })
+  update_entry ~base_path name (fun e -> { e with turn_consecutive_failures = 0 })
+;;
 
 let get_turn_failures ~base_path name =
   match get ~base_path name with
   | Some e -> e.turn_consecutive_failures
   | None -> 0
+;;
 
 let is_running ~base_path name =
   (* Enumerate every [Keeper_state_machine.phase] variant so the
@@ -1435,148 +1566,172 @@ let is_running ~base_path name =
   | Some { phase = Running; _ } -> true
   | Some
       { phase =
-          ( Offline | Failing | Overflowed | Compacting | HandingOff
-          | Draining | Paused | Stopped | Crashed | Restarting | Dead
+          ( Offline
+          | Failing
+          | Overflowed
+          | Compacting
+          | HandingOff
+          | Draining
+          | Paused
+          | Stopped
+          | Crashed
+          | Restarting
+          | Dead
           | Zombie )
       ; _
       } -> false
   | None -> false
+;;
 
 (** True if the keeper has ANY registry entry (regardless of state).
     Used by reconcile to avoid re-launching Crashed/Dead keepers. *)
-let is_registered ~base_path name =
-  Option.is_some (get ~base_path name)
+let is_registered ~base_path name = Option.is_some (get ~base_path name)
 
 let count_running ?base_path () =
   match base_path with
   | None -> Atomic.get running_count_atomic
   | Some expected ->
-      StringMap.fold
-        (fun _k v acc ->
-          if String.equal expected v.base_path && v.phase = Running then acc + 1
-          else acc)
-        (Atomic.get registry) 0
+    StringMap.fold
+      (fun _k v acc ->
+         if String.equal expected v.base_path && v.phase = Running then acc + 1 else acc)
+      (Atomic.get registry)
+      0
+;;
 
 let record_crash ~base_path name ts msg =
   Log.Keeper.error "registry: recording crash name=%s msg=%s" name msg;
   update_entry ~base_path name (fun e ->
-    { e with crash_log =
-        List.filteri (fun i _ -> i < max_crash_log_entries)
-          ((ts, msg) :: e.crash_log) })
+    { e with
+      crash_log =
+        List.filteri (fun i _ -> i < max_crash_log_entries) ((ts, msg) :: e.crash_log)
+    })
+;;
 
 let set_grpc_close ~base_path name close_fn =
   match StringMap.find_opt (registry_key ~base_path name) (Atomic.get registry) with
   | Some entry -> Atomic.set entry.grpc_close close_fn
   | None -> ()
+;;
 
 let started_at ~base_path name =
   match get ~base_path name with
   | Some entry -> Some entry.started_at
   | None -> None
+;;
 
 let set_started_at_for_test ~base_path name started_at =
   update_entry ~base_path name (fun entry -> { entry with started_at })
+;;
 
 let spawn_slots_available () =
   let max_keepers = Keeper_runtime_resolved.bootstrap_max_active_keepers () in
-  max_keepers <= 0
-  || Atomic.get running_count_atomic < max_keepers
+  max_keepers <= 0 || Atomic.get running_count_atomic < max_keepers
+;;
 
 let wakeup ~base_path name =
   match StringMap.find_opt (registry_key ~base_path name) (Atomic.get registry) with
   (* tla-lint: allow-mutation: fiber signal — public wakeup API for a single keeper *)
   | Some entry -> Atomic.set entry.fiber_wakeup true
   | None -> ()
+;;
 
 let wakeup_all ?base_path () =
-  StringMap.iter (fun _k entry ->
-    (match base_path with
-     | Some expected when not (String.equal expected entry.base_path) -> ()
-     (* tla-lint: allow-mutation: fiber signal — bulk wakeup for Running keepers under base_path filter *)
-     | _ -> if entry.phase = Running then Atomic.set entry.fiber_wakeup true)
-  ) (Atomic.get registry)
+  StringMap.iter
+    (fun _k entry ->
+       match base_path with
+       | Some expected when not (String.equal expected entry.base_path) -> ()
+       (* tla-lint: allow-mutation: fiber signal — bulk wakeup for Running keepers under base_path filter *)
+       | _ -> if entry.phase = Running then Atomic.set entry.fiber_wakeup true)
+    (Atomic.get registry)
+;;
 
 let fiber_health_of ~base_path name =
   match StringMap.find_opt (registry_key ~base_path name) (Atomic.get registry) with
   | None -> Fiber_unknown
-  | Some entry -> (
-      match entry.phase with
-      | Dead | Zombie -> Fiber_dead
-      | Crashed | Restarting ->
+  | Some entry ->
+    (match entry.phase with
+     | Dead | Zombie -> Fiber_dead
+     | Crashed | Restarting ->
+       let max_restarts =
+         Runtime_params.get Governance_registry.keeper_supervisor_max_restarts
+       in
+       if entry.restart_count >= max_restarts then Fiber_dead else Fiber_zombie
+     | Stopped | Offline -> Fiber_unknown
+     | Running | Paused | Failing | Overflowed | Compacting | HandingOff | Draining ->
+       (match Eio.Promise.peek entry.done_p with
+        | None -> Fiber_alive
+        | Some `Stopped -> Fiber_unknown
+        | Some (`Crashed _) ->
           let max_restarts =
             Runtime_params.get Governance_registry.keeper_supervisor_max_restarts
           in
-          if entry.restart_count >= max_restarts then Fiber_dead else Fiber_zombie
-      | Stopped | Offline -> Fiber_unknown
-      | Running | Paused | Failing | Overflowed | Compacting | HandingOff | Draining -> (
-          match Eio.Promise.peek entry.done_p with
-          | None -> Fiber_alive
-          | Some `Stopped -> Fiber_unknown
-          | Some (`Crashed _) ->
-              let max_restarts =
-                Runtime_params.get Governance_registry.keeper_supervisor_max_restarts
-              in
-              if entry.restart_count >= max_restarts
-              then Fiber_dead
-              else Fiber_zombie))
+          if entry.restart_count >= max_restarts then Fiber_dead else Fiber_zombie))
+;;
 
 let crash_log_of ~base_path name =
   match get ~base_path name with
   | Some entry -> entry.crash_log
   | None -> []
+;;
 
-let restore_supervisor_state ~base_path name ~restart_count ~last_restart_ts
-    ~crash_log =
+let restore_supervisor_state ~base_path name ~restart_count ~last_restart_ts ~crash_log =
   update_entry ~base_path name (fun e ->
-    {
-      e with
-      restart_count;
-      last_restart_ts;
-      dead_since_ts = None;
-      crash_log;
-      last_failure_reason = None;
+    { e with
+      restart_count
+    ; last_restart_ts
+    ; dead_since_ts = None
+    ; crash_log
+    ; last_failure_reason = None
     })
+;;
 
 let get_last_agent_count ~base_path name =
   match StringMap.find_opt (registry_key ~base_path name) (Atomic.get registry) with
   | Some entry -> entry.last_agent_count
   | None -> 0
+;;
 
 let set_last_agent_count ~base_path name count =
   update_entry ~base_path name (fun e -> { e with last_agent_count = count })
+;;
 
 let board_wakeup_allowed ~base_path name ~post_id ~debounce_sec =
   match StringMap.find_opt (registry_key ~base_path name) (Atomic.get registry) with
   | None -> true
   | Some entry ->
-      let now_ts = Time_compat.now () in
-      match StringMap.find_opt post_id entry.board_wakeups with
-      | Some last_ts when now_ts -. last_ts < debounce_sec -> false
-      | _ ->
-          update_entry ~base_path name (fun e ->
-            { e with board_wakeups = StringMap.add post_id now_ts e.board_wakeups });
-          true
+    let now_ts = Time_compat.now () in
+    (match StringMap.find_opt post_id entry.board_wakeups with
+     | Some last_ts when now_ts -. last_ts < debounce_sec -> false
+     | _ ->
+       update_entry ~base_path name (fun e ->
+         { e with board_wakeups = StringMap.add post_id now_ts e.board_wakeups });
+       true)
+;;
 
 let clear_board_wakeups ~base_path name =
   update_entry ~base_path name (fun e -> { e with board_wakeups = StringMap.empty })
+;;
 
 let cleanup_tracking ~base_path name =
   let key = registry_key ~base_path name in
   match StringMap.find_opt key (Atomic.get registry) with
   | Some entry ->
-      put_entry key
-        { entry with
-          board_wakeups = StringMap.empty;
-          tool_usage = StringMap.empty;
-          last_agent_count = 0;
-          board_cursor_ts = 0.0;
-          board_cursor_post_id = None;
-        }
+    put_entry
+      key
+      { entry with
+        board_wakeups = StringMap.empty
+      ; tool_usage = StringMap.empty
+      ; last_agent_count = 0
+      ; board_cursor_ts = 0.0
+      ; board_cursor_post_id = None
+      }
   | None -> ()
+;;
 
 let clear () =
   Atomic.set registry StringMap.empty;
   Atomic.set running_count_atomic 0
+;;
 
 (* -- Board cursor -------------------------------------------------- *)
 
@@ -1584,23 +1739,26 @@ let get_board_cursor_ts ~base_path name =
   match StringMap.find_opt (registry_key ~base_path name) (Atomic.get registry) with
   | Some entry -> entry.board_cursor_ts
   | None -> 0.0
+;;
 
 let set_board_cursor_ts ~base_path name ts =
   update_entry ~base_path name (fun e ->
     let board_cursor_post_id =
-      if Float.compare ts e.board_cursor_ts = 0 then e.board_cursor_post_id
-      else None
+      if Float.compare ts e.board_cursor_ts = 0 then e.board_cursor_post_id else None
     in
     { e with board_cursor_ts = ts; board_cursor_post_id })
+;;
 
 let get_board_cursor ~base_path name =
   match StringMap.find_opt (registry_key ~base_path name) (Atomic.get registry) with
-  | Some entry -> (entry.board_cursor_ts, entry.board_cursor_post_id)
-  | None -> (0.0, None)
+  | Some entry -> entry.board_cursor_ts, entry.board_cursor_post_id
+  | None -> 0.0, None
+;;
 
 let set_board_cursor ~base_path name ts post_id =
   update_entry ~base_path name (fun e ->
     { e with board_cursor_ts = ts; board_cursor_post_id = post_id })
+;;
 
 (* -- Tool usage tracking ------------------------------------------- *)
 
@@ -1622,6 +1780,7 @@ let record_tool_use ~base_path name ~tool_name ~success =
       }
     in
     { entry with tool_usage = StringMap.add tool_name updated entry.tool_usage })
+;;
 
 let tool_usage_of ~base_path name =
   match StringMap.find_opt (registry_key ~base_path name) (Atomic.get registry) with
@@ -1629,35 +1788,41 @@ let tool_usage_of ~base_path name =
   | Some entry ->
     StringMap.fold (fun n e acc -> (n, e) :: acc) entry.tool_usage []
     |> List.sort (fun (_, a) (_, b) -> Int.compare b.count a.count)
+;;
 
 (** Look up a keeper by name across all base_paths (O(n) scan). *)
 let find_by_name name =
   StringMap.fold
     (fun _k v acc ->
-      match acc with
-      | Some _ -> acc
-      | None -> if String.equal v.name name then Some v else None)
-    (Atomic.get registry) None
+       match acc with
+       | Some _ -> acc
+       | None -> if String.equal v.name name then Some v else None)
+    (Atomic.get registry)
+    None
+;;
 
 let find_by_agent_name agent_name =
   StringMap.fold
     (fun _k v acc ->
-      match acc with
-      | Some _ -> acc
-      | None ->
-        if String.equal v.meta.agent_name agent_name then Some v else None)
-    (Atomic.get registry) None
+       match acc with
+       | Some _ -> acc
+       | None -> if String.equal v.meta.agent_name agent_name then Some v else None)
+    (Atomic.get registry)
+    None
+;;
 
 let find_by_id (uid : Keeper_id.Uid.t) =
   StringMap.fold
     (fun _k v acc ->
-      match acc with
-      | Some _ -> acc
-      | None ->
-        (match v.meta.keeper_id with
-         | Some id when Keeper_id.Uid.equal id uid -> Some v
-         | _ -> None))
-    (Atomic.get registry) None
+       match acc with
+       | Some _ -> acc
+       | None ->
+         (match v.meta.keeper_id with
+          | Some id when Keeper_id.Uid.equal id uid -> Some v
+          | _ -> None))
+    (Atomic.get registry)
+    None
+;;
 
 let tool_usage_of_by_name name =
   match find_by_name name with
@@ -1665,117 +1830,138 @@ let tool_usage_of_by_name name =
   | Some entry ->
     StringMap.fold (fun n e acc -> (n, e) :: acc) entry.tool_usage []
     |> List.sort (fun (_, a) (_, b) -> Int.compare b.count a.count)
+;;
 
 (* -- Config resolution --------------------------------------------- *)
 
 let resolve_config (config : Coord_utils_backend_setup.config) keeper_name
-    : Coord_utils_backend_setup.config =
-  if keeper_name = "" then config
-  else
+  : Coord_utils_backend_setup.config
+  =
+  if keeper_name = ""
+  then config
+  else (
     (* Keeper config resolution is scoped to the caller's current base_path.
        Do not retarget requests across other base_path registries. *)
     match get ~base_path:config.base_path keeper_name with
-    | Some _ | None -> config
+    | Some _ | None -> config)
+;;
 
 (* -- Tool usage persistence ---------------------------------------- *)
 
 let tool_usage_path ~base_path name =
-  let dir = Filename.concat (Common.masc_dir_from_base_path ~base_path) "keepers/tool_usage" in
+  let dir =
+    Filename.concat (Common.masc_dir_from_base_path ~base_path) "keepers/tool_usage"
+  in
   Filename.concat dir (name ^ ".json")
+;;
 
 let flush_tool_usage ~base_path name =
   match StringMap.find_opt (registry_key ~base_path name) (Atomic.get registry) with
   | None -> ()
   | Some entry ->
     let items =
-      StringMap.fold (fun tool_name (e : tool_call_entry) acc ->
-        `Assoc [
-          ("tool", `String tool_name);
-          ("count", `Int e.count);
-          ("successes", `Int e.successes);
-          ("failures", `Int e.failures);
-          ("last_used_at", `Float e.last_used_at);
-        ] :: acc
-      ) entry.tool_usage []
+      StringMap.fold
+        (fun tool_name (e : tool_call_entry) acc ->
+           `Assoc
+             [ "tool", `String tool_name
+             ; "count", `Int e.count
+             ; "successes", `Int e.successes
+             ; "failures", `Int e.failures
+             ; "last_used_at", `Float e.last_used_at
+             ]
+           :: acc)
+        entry.tool_usage
+        []
     in
-    let json = `Assoc [
-      ("keeper", `String name);
-      ("flushed_at", `Float (Time_compat.now ()));
-      ("tools", `List items);
-    ] in
+    let json =
+      `Assoc
+        [ "keeper", `String name
+        ; "flushed_at", `Float (Time_compat.now ())
+        ; "tools", `List items
+        ]
+    in
     let path = tool_usage_path ~base_path name in
     (try
        Fs_compat.mkdir_p (Filename.dirname path);
        Fs_compat.save_file path (Yojson.Safe.to_string json ^ "\n")
-     with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
-       Prometheus.inc_counter Keeper_metrics.metric_keeper_tool_usage_flush_failures
-         ~labels:[("keeper", name)]
+     with
+     | Eio.Cancel.Cancelled _ as e -> raise e
+     | exn ->
+       Prometheus.inc_counter
+         Keeper_metrics.metric_keeper_tool_usage_flush_failures
+         ~labels:[ "keeper", name ]
          ();
        Log.Keeper.error "flush_tool_usage %s: %s" name (Printexc.to_string exn))
+;;
 
 let restore_tool_usage ~base_path name =
   let path = tool_usage_path ~base_path name in
-  if not (Fs_compat.file_exists path) then ()
-  else
+  if not (Fs_compat.file_exists path)
+  then ()
+  else (
     match StringMap.find_opt (registry_key ~base_path name) (Atomic.get registry) with
     | None -> ()
     | Some _entry ->
       (try
          let content = Fs_compat.load_file path in
          let json = Yojson.Safe.from_string content in
-         let tools = match json with
+         let tools =
+           match json with
            | `Assoc fields ->
              (match List.assoc_opt "tools" fields with
               | Some (`List items) -> items
               | _ -> [])
            | _ -> []
          in
-         List.iter (fun item ->
-           match
-             ( Safe_ops.json_string_opt "tool" item,
-               Safe_ops.json_int_opt "count" item,
-               Safe_ops.json_int_opt "successes" item,
-               Safe_ops.json_int_opt "failures" item,
-               Safe_ops.json_float_opt "last_used_at" item )
-           with
-           | Some tool_name, Some count, Some successes, Some failures, Some last_used_at
-             when tool_name <> "" ->
-             let e = {
-               count;
-               successes;
-               failures;
-               last_used_at;
-             } in
-             update_entry ~base_path name (fun ent ->
-               { ent with tool_usage = StringMap.add tool_name e ent.tool_usage })
-           | _ -> ()
-         ) tools
+         List.iter
+           (fun item ->
+              match
+                ( Safe_ops.json_string_opt "tool" item
+                , Safe_ops.json_int_opt "count" item
+                , Safe_ops.json_int_opt "successes" item
+                , Safe_ops.json_int_opt "failures" item
+                , Safe_ops.json_float_opt "last_used_at" item )
+              with
+              | ( Some tool_name
+                , Some count
+                , Some successes
+                , Some failures
+                , Some last_used_at )
+                when tool_name <> "" ->
+                let e = { count; successes; failures; last_used_at } in
+                update_entry ~base_path name (fun ent ->
+                  { ent with tool_usage = StringMap.add tool_name e ent.tool_usage })
+              | _ -> ())
+           tools
        with
        | Eio.Cancel.Cancelled _ as e -> raise e
        | exn ->
-           Prometheus.inc_counter
-          Keeper_metrics.metric_keeper_checkpoint_failures
-          ~labels:[("keeper", name); ("site", "restore_tool_usage")]
-          ();
-       Log.Keeper.warn "restore_tool_usage %s: %s" name (Printexc.to_string exn))
+         Prometheus.inc_counter
+           Keeper_metrics.metric_keeper_checkpoint_failures
+           ~labels:[ "keeper", name; "site", "restore_tool_usage" ]
+           ();
+         Log.Keeper.warn "restore_tool_usage %s: %s" name (Printexc.to_string exn)))
+;;
 
 (* ── RFC-0002 Event Dispatch ───────────────────────────── *)
 
 let execute_entry_action_observability
-    ~(name : string)
-    ~(phase : Keeper_state_machine.phase)
-    ~(ts_unix : float)
-    (action : Keeper_state_machine.entry_action) : unit =
+      ~(name : string)
+      ~(phase : Keeper_state_machine.phase)
+      ~(ts_unix : float)
+      (action : Keeper_state_machine.entry_action)
+  : unit
+  =
   match action with
   | Keeper_state_machine.Publish_lifecycle { event_name; detail } ->
-      Log.Keeper.info
-        "registry: lifecycle name=%s phase=%s event=%s detail=%s"
-        name
-        (Keeper_state_machine.phase_to_string phase)
-        event_name
-        detail;
-      let (_ignore_ts : float) = ts_unix in
-      ()
+    Log.Keeper.info
+      "registry: lifecycle name=%s phase=%s event=%s detail=%s"
+      name
+      (Keeper_state_machine.phase_to_string phase)
+      event_name
+      detail;
+    let (_ignore_ts : float) = ts_unix in
+    ()
   | Start_compaction
   | Start_handoff
   | Start_drain
@@ -1784,45 +1970,47 @@ let execute_entry_action_observability
   | Mark_zombie_tombstone
   | Cleanup_and_unregister
   | Trigger_immediate_cleanup
-  | Cancel_pending_oas ->
-      ()
+  | Cancel_pending_oas -> ()
+;;
 
 let followup_event_of_entry_action
-    ~(phase : Keeper_state_machine.phase)
-    (action : Keeper_state_machine.entry_action)
-  : Keeper_state_machine.event option =
+      ~(phase : Keeper_state_machine.phase)
+      (action : Keeper_state_machine.entry_action)
+  : Keeper_state_machine.event option
+  =
   match phase, action with
   | Keeper_state_machine.Overflowed, Start_compaction ->
-      Prometheus.inc_counter Keeper_metrics.metric_keeper_fsm_edge_transitions
-        ~labels:[("edge", "ksm_to_kmc_compact_trigger")] ();
-      Some Keeper_state_machine.Auto_compact_triggered
-  | _ ->
-      None
+    Prometheus.inc_counter
+      Keeper_metrics.metric_keeper_fsm_edge_transitions
+      ~labels:[ "edge", "ksm_to_kmc_compact_trigger" ]
+      ();
+    Some Keeper_state_machine.Auto_compact_triggered
+  | _ -> None
+;;
 
 let record_followup_dispatch_rejection event =
   Prometheus.inc_counter
     Keeper_metrics.metric_keeper_lifecycle_dispatch_rejections
-    ~labels:[ ("event", Keeper_state_machine.event_to_string event) ]
+    ~labels:[ "event", Keeper_state_machine.event_to_string event ]
     ()
+;;
 
 let pending_measurement_after_event now entry event =
   match event with
   | Keeper_state_machine.Context_measured { auto_rules; _ } ->
-    Some {
-      tm_captured_at = now;
-      tm_auto_rules = auto_rules;
-    }
+    Some { tm_captured_at = now; tm_auto_rules = auto_rules }
   | _ -> entry.pending_turn_measurement
+;;
 
 let compaction_stage_of_event entry event =
   match event with
   | Keeper_state_machine.Compaction_started
   | Keeper_state_machine.Auto_compact_triggered
-  | Keeper_state_machine.Operator_compact_requested ->
-    Packed Compaction_compacting
+  | Keeper_state_machine.Operator_compact_requested -> Packed Compaction_compacting
   | Keeper_state_machine.Compaction_completed _ -> Packed Compaction_done
   | Keeper_state_machine.Compaction_failed _ -> Packed Compaction_accumulating
   | _ -> entry.compaction_stage
+;;
 
 let validate_compaction_transition ~from ~to_ =
   Keeper_fsm_guard_runtime.wrap_unit
@@ -1830,47 +2018,53 @@ let validate_compaction_transition ~from ~to_ =
     ~stage:"guard"
     (fun () ->
        assert (
-         match (from, to_) with
+         match from, to_ with
          (* from Compaction_accumulating *)
-         | (Packed Compaction_accumulating, Packed Compaction_accumulating) -> true
-         | (Packed Compaction_accumulating, Packed Compaction_compacting) -> true  (* via set_compaction_stage *)
-         | (Packed Compaction_accumulating, Packed Compaction_done) -> false
+         | Packed Compaction_accumulating, Packed Compaction_accumulating -> true
+         | Packed Compaction_accumulating, Packed Compaction_compacting ->
+           true (* via set_compaction_stage *)
+         | Packed Compaction_accumulating, Packed Compaction_done -> false
          (* from Compaction_compacting *)
-         | (Packed Compaction_compacting, Packed Compaction_accumulating) -> true  (* via set_compaction_stage: retry *)
-         | (Packed Compaction_compacting, Packed Compaction_compacting) -> true
-         | (Packed Compaction_compacting, Packed Compaction_done) -> true  (* via set_compaction_stage *)
+         | Packed Compaction_compacting, Packed Compaction_accumulating ->
+           true (* via set_compaction_stage: retry *)
+         | Packed Compaction_compacting, Packed Compaction_compacting -> true
+         | Packed Compaction_compacting, Packed Compaction_done ->
+           true (* via set_compaction_stage *)
          (* from Compaction_done — terminal *)
-         | (Packed Compaction_done, Packed Compaction_accumulating) -> false  (* terminal; new compaction is reset *)
-         | (Packed Compaction_done, Packed Compaction_compacting) -> false  (* terminal *)
-         | (Packed Compaction_done, Packed Compaction_done) -> true
-       ))
+         | Packed Compaction_done, Packed Compaction_accumulating ->
+           false (* terminal; new compaction is reset *)
+         | Packed Compaction_done, Packed Compaction_compacting -> false (* terminal *)
+         | Packed Compaction_done, Packed Compaction_done -> true))
+;;
 
 let compaction_stage_after_event entry event =
   let old_stage = entry.compaction_stage in
   let new_stage = compaction_stage_of_event entry event in
   validate_compaction_transition ~from:old_stage ~to_:new_stage;
   new_stage
+;;
 
 (** Registry mutation is still non-yielding (StringMap lookup + put,
     Atomic.set). Entry actions run only after [put_entry], so any
     observability or follow-up state transitions happen after the registry
     state is consistent. *)
 let rec dispatch_event_with_audit
-    ~base_path
-    ?snapshot
-    ?events_fired
-    ?selected_event
-    name
-    (event : Keeper_state_machine.event)
+          ~base_path
+          ?snapshot
+          ?events_fired
+          ?selected_event
+          name
+          (event : Keeper_state_machine.event)
   =
   let key = registry_key ~base_path name in
   match StringMap.find_opt key (Atomic.get registry) with
   | None ->
-    Error (Keeper_state_machine.Invalid_transition {
-      from_phase = Keeper_state_machine.Offline;
-      to_phase = Keeper_state_machine.Offline;
-      reason = Printf.sprintf "keeper %s not registered" name;
-    })
+    Error
+      (Keeper_state_machine.Invalid_transition
+         { from_phase = Keeper_state_machine.Offline
+         ; to_phase = Keeper_state_machine.Offline
+         ; reason = Printf.sprintf "keeper %s not registered" name
+         })
   | Some entry ->
     let now = Time_compat.now () in
     (* Retain the last auto-rule summary emitted with a [Context_measured]
@@ -1879,16 +2073,11 @@ let rec dispatch_event_with_audit
        events leave the field untouched. *)
     let last_auto_rules =
       match event with
-      | Keeper_state_machine.Context_measured { auto_rules; _ } ->
-        Some (now, auto_rules)
+      | Keeper_state_machine.Context_measured { auto_rules; _ } -> Some (now, auto_rules)
       | _ -> entry.last_auto_rules
     in
-    let pending_turn_measurement =
-      pending_measurement_after_event now entry event
-    in
-    let compaction_stage =
-      compaction_stage_after_event entry event
-    in
+    let pending_turn_measurement = pending_measurement_after_event now entry event in
+    let compaction_stage = compaction_stage_after_event entry event in
     let result =
       Keeper_state_machine.apply_event
         ~current_phase:entry.phase
@@ -1900,103 +2089,114 @@ let rec dispatch_event_with_audit
       (Keeper_state_machine.attribution_of_transition ~event result);
     (match result with
      | Ok tr when tr.new_phase <> tr.prev_phase ->
-       Log.Keeper.info "registry: phase transition name=%s old=%s new=%s event=%s"
+       Log.Keeper.info
+         "registry: phase transition name=%s old=%s new=%s event=%s"
          name
          (Keeper_state_machine.phase_to_string tr.prev_phase)
          (Keeper_state_machine.phase_to_string tr.new_phase)
          (Keeper_state_machine.event_to_string event);
        (* Record transition in audit ring buffer for dashboard API *)
-       Keeper_transition_audit.record_transition ~keeper_name:name {
-         snapshot;
-         events_fired = Option.value events_fired ~default:[event];
-         selected_event = Option.value selected_event ~default:event;
-         prev_phase = tr.prev_phase;
-         new_phase = tr.new_phase;
-         transition_outcome = "applied";
-         wall_clock_at_decision = now;
-       };
+       Keeper_transition_audit.record_transition
+         ~keeper_name:name
+         { snapshot
+         ; events_fired = Option.value events_fired ~default:[ event ]
+         ; selected_event = Option.value selected_event ~default:event
+         ; prev_phase = tr.prev_phase
+         ; new_phase = tr.new_phase
+         ; transition_outcome = "applied"
+         ; wall_clock_at_decision = now
+         };
        (* Broadcast phase transition to SSE subscribers *)
        (try
           Sse.broadcast
-            (`Assoc [
-               "type", `String "keeper_phase_changed";
-               "name", `String name;
-               "prev_phase", `String (Keeper_state_machine.phase_to_string tr.prev_phase);
-               "new_phase", `String (Keeper_state_machine.phase_to_string tr.new_phase);
-               "event", `String (Keeper_state_machine.event_to_string event);
-               "ts_unix", `Float now;
-             ])
+            (`Assoc
+                [ "type", `String "keeper_phase_changed"
+                ; "name", `String name
+                ; ( "prev_phase"
+                  , `String (Keeper_state_machine.phase_to_string tr.prev_phase) )
+                ; "new_phase", `String (Keeper_state_machine.phase_to_string tr.new_phase)
+                ; "event", `String (Keeper_state_machine.event_to_string event)
+                ; "ts_unix", `Float now
+                ])
         with
         | Eio.Cancel.Cancelled _ as e -> raise e
         | exn -> record_phase_broadcast_failure ~name exn);
        (* Update running count based on phase transition *)
        (match tr.prev_phase, tr.new_phase with
-        | Running, phase when phase <> Running ->
-          decr_running_count_clamped ()
-        | phase, Running when phase <> Running ->
-          Atomic.incr running_count_atomic
+        | Running, phase when phase <> Running -> decr_running_count_clamped ()
+        | phase, Running when phase <> Running -> Atomic.incr running_count_atomic
         | _ -> ());
-       Prometheus.inc_counter Keeper_metrics.metric_keeper_lifecycle_transitions
-         ~labels:[
-           ("keeper", name);
-           ("from_phase", Keeper_state_machine.phase_to_string tr.prev_phase);
-           ("to_phase", Keeper_state_machine.phase_to_string tr.new_phase);
-         ] ();
+       Prometheus.inc_counter
+         Keeper_metrics.metric_keeper_lifecycle_transitions
+         ~labels:
+           [ "keeper", name
+           ; "from_phase", Keeper_state_machine.phase_to_string tr.prev_phase
+           ; "to_phase", Keeper_state_machine.phase_to_string tr.new_phase
+           ]
+         ();
        (* Update dead_since_ts: always set to now on Dead transition *)
-       let dead_since_ts = match tr.new_phase with
+       let dead_since_ts =
+         match tr.new_phase with
          | Keeper_state_machine.Dead -> Some now
          | _ -> None
        in
        let new_seq = entry.transition_seq + 1 in
        (* TLA+ trace emission (MASC_TLA_TRACE=1) *)
-       if Keeper_trace_emit.enabled () then
+       if Keeper_trace_emit.enabled ()
+       then
          Keeper_trace_emit.emit_transition
-           ~keeper_name:name ~base_path
-           ~seq:new_seq ~event
-           ~prev_phase:tr.prev_phase ~new_phase:tr.new_phase
+           ~keeper_name:name
+           ~base_path
+           ~seq:new_seq
+           ~event
+           ~prev_phase:tr.prev_phase
+           ~new_phase:tr.new_phase
            ~conditions_after:tr.updated_conditions
            ~restart_count:entry.restart_count;
-       put_entry key {
-         entry with
-         phase = tr.new_phase;
-         conditions = tr.updated_conditions;
-         dead_since_ts;
-         transition_seq = new_seq;
-         last_auto_rules;
-         pending_turn_measurement;
-         compaction_stage;
-       };
+       put_entry
+         key
+         { entry with
+           phase = tr.new_phase
+         ; conditions = tr.updated_conditions
+         ; dead_since_ts
+         ; transition_seq = new_seq
+         ; last_auto_rules
+         ; pending_turn_measurement
+         ; compaction_stage
+         };
        List.iter
-         (execute_entry_action_observability
-            ~name
-            ~phase:tr.new_phase
-            ~ts_unix:now)
+         (execute_entry_action_observability ~name ~phase:tr.new_phase ~ts_unix:now)
          tr.entry_actions;
        List.iter
          (fun followup_event ->
             match dispatch_event_with_audit ~base_path name followup_event with
             | Ok _ -> ()
-            | Error (Keeper_state_machine.Invalid_transition { from_phase; to_phase; reason }) ->
-                record_followup_dispatch_rejection followup_event;
-                Log.Keeper.error
-                  "registry(%s): followup dispatch failed: %s -> %s (%s)"
-                  name
-                  (Keeper_state_machine.phase_to_string from_phase)
-                  (Keeper_state_machine.phase_to_string to_phase)
-                  reason
+            | Error
+                (Keeper_state_machine.Invalid_transition { from_phase; to_phase; reason })
+              ->
+              record_followup_dispatch_rejection followup_event;
+              Log.Keeper.error
+                "registry(%s): followup dispatch failed: %s -> %s (%s)"
+                name
+                (Keeper_state_machine.phase_to_string from_phase)
+                (Keeper_state_machine.phase_to_string to_phase)
+                reason
             | Error (Keeper_state_machine.Terminal_state { current; attempted_event }) ->
-                record_followup_dispatch_rejection followup_event;
-                Log.Keeper.warn
-                  "registry(%s): followup skipped, already terminal: %s (event: %s)"
-                  name
-                  (Keeper_state_machine.phase_to_string current)
-                  attempted_event
-            | Error (Keeper_state_machine.Precondition_violation { event = ev; reason }) ->
-                record_followup_dispatch_rejection followup_event;
-                Log.Keeper.warn
-                  "registry(%s): followup skipped, precondition violated: %s (%s)"
-                  name ev reason)
-       (List.filter_map
+              record_followup_dispatch_rejection followup_event;
+              Log.Keeper.warn
+                "registry(%s): followup skipped, already terminal: %s (event: %s)"
+                name
+                (Keeper_state_machine.phase_to_string current)
+                attempted_event
+            | Error (Keeper_state_machine.Precondition_violation { event = ev; reason })
+              ->
+              record_followup_dispatch_rejection followup_event;
+              Log.Keeper.warn
+                "registry(%s): followup skipped, precondition violated: %s (%s)"
+                name
+                ev
+                reason)
+         (List.filter_map
             (followup_event_of_entry_action ~phase:tr.new_phase)
             tr.entry_actions);
        (* Composite-lifecycle SSE envelope — RFC-0003 §6.
@@ -2009,34 +2209,41 @@ let rec dispatch_event_with_audit
      | Ok tr ->
        (* No phase change — still update conditions *)
        let new_seq = entry.transition_seq + 1 in
-       if Keeper_trace_emit.enabled () then
+       if Keeper_trace_emit.enabled ()
+       then
          Keeper_trace_emit.emit_transition
-           ~keeper_name:name ~base_path
-           ~seq:new_seq ~event
-           ~prev_phase:tr.prev_phase ~new_phase:tr.new_phase
+           ~keeper_name:name
+           ~base_path
+           ~seq:new_seq
+           ~event
+           ~prev_phase:tr.prev_phase
+           ~new_phase:tr.new_phase
            ~conditions_after:tr.updated_conditions
            ~restart_count:entry.restart_count;
-       put_entry key {
-         entry with
-         conditions = tr.updated_conditions;
-         transition_seq = new_seq;
-         last_auto_rules;
-         pending_turn_measurement;
-         compaction_stage;
-       };
+       put_entry
+         key
+         { entry with
+           conditions = tr.updated_conditions
+         ; transition_seq = new_seq
+         ; last_auto_rules
+         ; pending_turn_measurement
+         ; compaction_stage
+         };
        broadcast_composite_changed ~name ~ts_unix:now;
        Ok tr
      | Error e ->
        Prometheus.inc_counter
          Keeper_metrics.metric_keeper_lifecycle_dispatch_rejections
-         ~labels:[("event", Keeper_state_machine.event_to_string event)]
+         ~labels:[ "event", Keeper_state_machine.event_to_string event ]
          ();
-       Log.Keeper.warn "registry: dispatch_event rejected name=%s error=%s"
-         name (Keeper_state_machine.transition_error_to_string e);
+       Log.Keeper.warn
+         "registry: dispatch_event rejected name=%s error=%s"
+         name
+         (Keeper_state_machine.transition_error_to_string e);
        Error e)
+;;
 
-let dispatch_event ~base_path name event =
-  dispatch_event_with_audit ~base_path name event
+let dispatch_event ~base_path name event = dispatch_event_with_audit ~base_path name event
 
 let dispatch_event_and_log ~base_path name event =
   match dispatch_event ~base_path name event with
@@ -2050,18 +2257,38 @@ let dispatch_event_and_log ~base_path name event =
     in
     Prometheus.inc_counter
       Keeper_metrics.metric_keeper_dispatch_event_failures
-      ~labels:[("keeper", name); ("reason", reason_label)]
+      ~labels:[ "keeper", name; "reason", reason_label ]
       ();
     Error e
+;;
 
 let dispatch_event_unit ~base_path name event =
   match dispatch_event_and_log ~base_path name event with
   | Ok _ -> ()
   | Error e ->
-    Log.Keeper.warn "%s: dispatch_event failed: %s" name
+    Log.Keeper.warn
+      "%s: dispatch_event failed: %s"
+      name
       (Keeper_state_machine.transition_error_to_string e)
-let dispatch_event_with_audit_and_log ~base_path ?snapshot ?events_fired ?selected_event name event =
-  match dispatch_event_with_audit ~base_path ?snapshot ?events_fired ?selected_event name event with
+;;
+
+let dispatch_event_with_audit_and_log
+      ~base_path
+      ?snapshot
+      ?events_fired
+      ?selected_event
+      name
+      event
+  =
+  match
+    dispatch_event_with_audit
+      ~base_path
+      ?snapshot
+      ?events_fired
+      ?selected_event
+      name
+      event
+  with
   | Ok tr -> Ok tr
   | Error e ->
     let reason_label =
@@ -2072,82 +2299,90 @@ let dispatch_event_with_audit_and_log ~base_path ?snapshot ?events_fired ?select
     in
     Prometheus.inc_counter
       Keeper_metrics.metric_keeper_dispatch_event_failures
-      ~labels:[("keeper", name); ("reason", reason_label)]
+      ~labels:[ "keeper", name; "reason", reason_label ]
       ();
     Error e
+;;
 
 let prepare_fiber_launch ~base_path name =
   (match get ~base_path name with
    | Some entry ->
-       (* tla-lint: allow-mutation: fiber signal — initialise per-fiber Atomic flags before keeper launch *)
-       Atomic.set entry.fiber_stop false;
-       Atomic.set entry.fiber_wakeup false;
-       Atomic.set entry.waiting_for_inference false
+     (* tla-lint: allow-mutation: fiber signal — initialise per-fiber Atomic flags before keeper launch *)
+     Atomic.set entry.fiber_stop false;
+     Atomic.set entry.fiber_wakeup false;
+     Atomic.set entry.waiting_for_inference false
    | None ->
-       (* P3 cleanup: previously this was a silent no-op when the
+     (* P3 cleanup: previously this was a silent no-op when the
           keeper was not yet registered.  The dispatch_event call
           below still fires even in this case, which can leave a
           Fiber_started event with no corresponding atomic-flag
           reset.  Log so the race is at least visible — caller
           (server_runtime_bootstrap.ml) is responsible for ensuring
           register_with_state has happened before this point. *)
-       Log.Keeper.warn
-         "registry: prepare_fiber_launch name=%s base_path=%s: entry not registered, skipping flag reset"
-         name base_path);
+     Log.Keeper.warn
+       "registry: prepare_fiber_launch name=%s base_path=%s: entry not registered, \
+        skipping flag reset"
+       name
+       base_path);
   dispatch_event ~base_path name Keeper_state_machine.Fiber_started
+;;
 
 let get_phase ~base_path name =
   match get ~base_path name with
   | Some entry -> Some entry.phase
   | None -> None
+;;
 
 let get_conditions ~base_path name =
   match get ~base_path name with
   | Some entry -> Some entry.conditions
   | None -> None
+;;
 
 let enqueue_event ~base_path name stimulus =
   match get ~base_path name with
   | None ->
-      Log.Keeper.warn
-        "registry: enqueue_event name=%s base_path=%s: keeper not registered"
-        name base_path
+    Log.Keeper.warn
+      "registry: enqueue_event name=%s base_path=%s: keeper not registered"
+      name
+      base_path
   | Some entry ->
-      let rec loop () =
-        let cur = Atomic.get entry.event_queue in
-        let next = Keeper_event_queue.enqueue cur stimulus in
-        if not (Atomic.compare_and_set entry.event_queue cur next) then loop ()
-      in
-      loop ()
+    let rec loop () =
+      let cur = Atomic.get entry.event_queue in
+      let next = Keeper_event_queue.enqueue cur stimulus in
+      if not (Atomic.compare_and_set entry.event_queue cur next) then loop ()
+    in
+    loop ()
+;;
 
 let event_queue_snapshot ~base_path name =
   match get ~base_path name with
   | None -> Keeper_event_queue.empty
   | Some entry -> Atomic.get entry.event_queue
+;;
 
 let dequeue_event ~base_path name =
   match get ~base_path name with
   | None -> None
   | Some entry ->
-      let rec loop () =
-        let cur = Atomic.get entry.event_queue in
-        match Keeper_event_queue.dequeue cur with
-        | None -> None
-        | Some (stim, rest) ->
-            if Atomic.compare_and_set entry.event_queue cur rest
-            then Some stim
-            else loop ()
-      in
-      loop ()
+    let rec loop () =
+      let cur = Atomic.get entry.event_queue in
+      match Keeper_event_queue.dequeue cur with
+      | None -> None
+      | Some (stim, rest) ->
+        if Atomic.compare_and_set entry.event_queue cur rest then Some stim else loop ()
+    in
+    loop ()
+;;
 
 let drain_board_events ?window_sec ~base_path name =
   match get ~base_path name with
   | None -> []
   | Some entry ->
-      let rec loop () =
-        let cur = Atomic.get entry.event_queue in
-        let board, rest = Keeper_event_queue.drain_board_window ?window_sec cur in
-        if Atomic.compare_and_set entry.event_queue cur rest then board
-        else loop ()
-      in
-      loop ()
+    let rec loop () =
+      let cur = Atomic.get entry.event_queue in
+      let board, rest = Keeper_event_queue.drain_board_window ?window_sec cur in
+      if Atomic.compare_and_set entry.event_queue cur rest then board else loop ()
+    in
+    loop ()
+;;

--- a/lib/keeper/keeper_world_observation.ml
+++ b/lib/keeper/keeper_world_observation.ml
@@ -9,42 +9,42 @@ open Keeper_types
 open Keeper_memory
 open Keeper_exec_context
 
-type pending_board_event = {
-  post_id : string;
-  author : string;
-  title : string;
-  preview : string;
-  hearth : string option;
-  post_kind : Board.post_kind;
-  updated_at : float;
-  explicit_mention : bool;
-  matched_targets : string list;
-  self_commented : bool;
-  new_external_since : int;
-  latest_external_author : string option;
-  latest_external_preview : string option;
-}
+type pending_board_event =
+  { post_id : string
+  ; author : string
+  ; title : string
+  ; preview : string
+  ; hearth : string option
+  ; post_kind : Board.post_kind
+  ; updated_at : float
+  ; explicit_mention : bool
+  ; matched_targets : string list
+  ; self_commented : bool
+  ; new_external_since : int
+  ; latest_external_author : string option
+  ; latest_external_preview : string option
+  }
 
-type world_observation = {
-  pending_mentions : (string * string) list;
-  pending_board_events : pending_board_event list;
-  pending_scope_messages : (string * string) list;
-  message_cursor_updates : (string * int) list;
-  idle_seconds : int;
-  active_goals : string list;
-  continuity_summary : string;
-  worktree_change_summary : string option;
-  context_ratio : float;
-  economic_pressure : Agent_economy.pressure_mode;
-  unclaimed_task_count : int;
-  claimable_task_count : int;
-  failed_task_count : int;
-  pending_verification_count : int;
-  backlog_updated_since_last_scheduled_autonomous : bool;
-  active_agent_count : int;
-  last_turn_budget : (int * int) option;
-  work_discovery_due : bool;
-}
+type world_observation =
+  { pending_mentions : (string * string) list
+  ; pending_board_events : pending_board_event list
+  ; pending_scope_messages : (string * string) list
+  ; message_cursor_updates : (string * int) list
+  ; idle_seconds : int
+  ; active_goals : string list
+  ; continuity_summary : string
+  ; worktree_change_summary : string option
+  ; context_ratio : float
+  ; economic_pressure : Agent_economy.pressure_mode
+  ; unclaimed_task_count : int
+  ; claimable_task_count : int
+  ; failed_task_count : int
+  ; pending_verification_count : int
+  ; backlog_updated_since_last_scheduled_autonomous : bool
+  ; active_agent_count : int
+  ; last_turn_budget : (int * int) option
+  ; work_discovery_due : bool
+  }
 
 type keeper_cycle_channel =
   | Reactive
@@ -57,9 +57,15 @@ type turn_reason =
   | Board_event_pending
   | Scope_message_pending
   | Scheduled_autonomous_turn
-  | Idle_cooldown_elapsed of { idle_sec : int; cooldown : int }
+  | Idle_cooldown_elapsed of
+      { idle_sec : int
+      ; cooldown : int
+      }
   | Cooldown_elapsed
-  | Task_backlog of { unclaimed : int; failed : int }
+  | Task_backlog of
+      { unclaimed : int
+      ; failed : int
+      }
   | Task_reactive_cooldown_elapsed
   | Never_started
   | Min_interval_elapsed
@@ -90,6 +96,7 @@ let turn_reason_to_string = function
   | Never_started -> "never_started"
   | Min_interval_elapsed -> "min_interval_elapsed"
   | Entropic_oscillation -> "entropic_oscillation"
+;;
 
 let skip_reason_to_string = function
   | Keeper_paused -> "keeper_paused"
@@ -99,66 +106,71 @@ let skip_reason_to_string = function
   | Idle_gate_pending _ -> "idle_gate_pending"
   | Cooldown_pending _ -> "cooldown_pending"
   | No_signal -> "no_signal"
+;;
 
 let channel_to_string = function
   | Reactive -> "reactive"
   | Scheduled_autonomous -> "scheduled_autonomous"
+;;
 
 let is_autonomous_channel (channel : string) : bool =
-  String.equal channel "scheduled_autonomous"
-  || String.equal channel "proactive"
+  String.equal channel "scheduled_autonomous" || String.equal channel "proactive"
+;;
 
 let verdict_reasons_to_strings = function
-  | Run { reasons = (first, rest) } ->
-      List.map turn_reason_to_string (first :: rest)
-  | Skip { reasons = (first, rest) } ->
-      List.map skip_reason_to_string (first :: rest)
-type keeper_cycle_decision = {
-  should_run : bool;
-  channel : keeper_cycle_channel;
-  verdict : turn_verdict;
-  since_last_scheduled_autonomous : int option;
-  effective_cooldown : int option;
-  task_reactive_cooldown : int option;
-  idle_gate_sec : int option;
-}
+  | Run { reasons = first, rest } -> List.map turn_reason_to_string (first :: rest)
+  | Skip { reasons = first, rest } -> List.map skip_reason_to_string (first :: rest)
+;;
+
+type keeper_cycle_decision =
+  { should_run : bool
+  ; channel : keeper_cycle_channel
+  ; verdict : turn_verdict
+  ; since_last_scheduled_autonomous : int option
+  ; effective_cooldown : int option
+  ; task_reactive_cooldown : int option
+  ; idle_gate_sec : int option
+  }
 
 type unified_turn_decision = keeper_cycle_decision
 
-type board_signal_match = {
-  explicit_mention : bool;
-  matched_targets : string list;
-  score : int;
-}
+type board_signal_match =
+  { explicit_mention : bool
+  ; matched_targets : string list
+  ; score : int
+  }
 
 let scope_message_feed_enabled (meta : keeper_meta) : bool =
   meta.room_signal_prompt_enabled
+;;
 
 let message_feed_targets (meta : keeper_meta) =
   if meta.mention_targets <> [] then meta.mention_targets else [ meta.name ]
+;;
 
 let normalized_identity_token value =
   let trimmed = String.lowercase_ascii (String.trim value) in
   if trimmed = "" then None else Some trimmed
+;;
 
 let identity_tokens_of_value value =
   let trimmed = String.trim value in
-  [
-    normalized_identity_token trimmed;
-    Option.bind
+  [ normalized_identity_token trimmed
+  ; Option.bind
       (Keeper_identity.canonical_keeper_name_from_agent_name trimmed)
-      normalized_identity_token;
-    Option.bind (Keeper_identity.canonical_keeper_name trimmed)
-      normalized_identity_token;
+      normalized_identity_token
+  ; Option.bind (Keeper_identity.canonical_keeper_name trimmed) normalized_identity_token
   ]
   |> List.filter_map (fun value -> value)
   |> List.sort_uniq String.compare
+;;
 
 let self_identity_tokens (meta : keeper_meta) =
   [ meta.name; meta.agent_name ]
   |> List.map identity_tokens_of_value
   |> List.flatten
   |> List.sort_uniq String.compare
+;;
 
 (* Single source of truth for "is this author one of us?".  Two inline
    copies of this predicate used to live in [collect_message_scope] and
@@ -167,113 +179,138 @@ let self_identity_tokens (meta : keeper_meta) =
 let is_self_author ~self_tokens (author : string) : bool =
   identity_tokens_of_value author
   |> List.exists (fun author_token -> List.mem author_token self_tokens)
+;;
 
 let is_keeper_authored_message author =
   Option.is_some (Keeper_identity.canonical_keeper_name_from_agent_name author)
+;;
 
-let collect_message_scope ~(config : Coord.config) ~(meta : keeper_meta) :
-    ((string * string) list * (string * string) list * (string * int) list) =
+let collect_message_scope ~(config : Coord.config) ~(meta : keeper_meta)
+  : (string * string) list * (string * string) list * (string * int) list
+  =
   let targets = message_feed_targets meta in
   let broad_scope = scope_message_feed_enabled meta in
   let self_tokens = self_identity_tokens meta in
   let batch_limit = Keeper_config.keeper_batch_limit () in
-  let rec consume_room_messages remaining last_processed mentions scope_messages =
-    function
-    | [] -> (`Done, remaining, last_processed, List.rev mentions, List.rev scope_messages)
+  let rec consume_room_messages remaining last_processed mentions scope_messages
+    = function
+    | [] -> `Done, remaining, last_processed, List.rev mentions, List.rev scope_messages
     | (msg : Masc_domain.message) :: rest ->
-        let author = String.trim msg.from_agent in
-        if author = "" || is_self_author ~self_tokens author then
-          consume_room_messages remaining msg.seq mentions scope_messages rest
-        else if
-          Coord_task_cache_invariant.stale_active_task_signal_present
-            ~config
-            ~from_agent:author
-            ~module_name:"keeper_world_observation"
-            ~content:msg.content
+      let author = String.trim msg.from_agent in
+      if author = "" || is_self_author ~self_tokens author
+      then consume_room_messages remaining msg.seq mentions scope_messages rest
+      else if
+        Coord_task_cache_invariant.stale_active_task_signal_present
+          ~config
+          ~from_agent:author
+          ~module_name:"keeper_world_observation"
+          ~content:msg.content
+      then consume_room_messages remaining msg.seq mentions scope_messages rest
+      else if exact_direct_mention_present ~targets msg.content
+      then
+        if remaining <= 0
         then
-          consume_room_messages remaining msg.seq mentions scope_messages rest
-        else if exact_direct_mention_present ~targets msg.content then
-          if remaining <= 0 then
-            (`Saturated, remaining, last_processed, List.rev mentions, List.rev scope_messages)
-          else
-            consume_room_messages
-              (remaining - 1)
-              msg.seq
-              ((msg.from_agent, msg.content) :: mentions)
-              scope_messages
-              rest
-        else if broad_scope then
-          (* Broad room scope is for operator/human context; direct mentions
-             above still allow explicit keeper-to-keeper handoff. *)
-          if is_keeper_authored_message author then
-            consume_room_messages remaining msg.seq mentions scope_messages rest
-          else if remaining <= 0 then
-            (`Saturated, remaining, last_processed, List.rev mentions, List.rev scope_messages)
-          else
-            consume_room_messages
-              (remaining - 1)
-              msg.seq
-              mentions
-              ((msg.from_agent, msg.content) :: scope_messages)
-              rest
+          ( `Saturated
+          , remaining
+          , last_processed
+          , List.rev mentions
+          , List.rev scope_messages )
         else
-          consume_room_messages remaining msg.seq mentions scope_messages rest
+          consume_room_messages
+            (remaining - 1)
+            msg.seq
+            ((msg.from_agent, msg.content) :: mentions)
+            scope_messages
+            rest
+      else if broad_scope
+      then
+        (* Broad room scope is for operator/human context; direct mentions
+             above still allow explicit keeper-to-keeper handoff. *)
+        if is_keeper_authored_message author
+        then consume_room_messages remaining msg.seq mentions scope_messages rest
+        else if remaining <= 0
+        then
+          ( `Saturated
+          , remaining
+          , last_processed
+          , List.rev mentions
+          , List.rev scope_messages )
+        else
+          consume_room_messages
+            (remaining - 1)
+            msg.seq
+            mentions
+            ((msg.from_agent, msg.content) :: scope_messages)
+            rest
+      else consume_room_messages remaining msg.seq mentions scope_messages rest
   in
   let rec consume_rooms remaining mentions_acc scope_acc cursor_acc = function
-    | [] -> (mentions_acc, scope_acc, List.rev cursor_acc)
-    | _ when remaining <= 0 -> (mentions_acc, scope_acc, List.rev cursor_acc)
+    | [] -> mentions_acc, scope_acc, List.rev cursor_acc
+    | _ when remaining <= 0 -> mentions_acc, scope_acc, List.rev cursor_acc
     | room_id :: rest ->
-        let since_seq = room_cursor_for meta room_id in
-        let messages =
-          try
-            Coord.get_all_messages_raw config ~since_seq
-          with
-          | Eio.Cancel.Cancelled _ as e -> raise e
-          | _ -> []
-        in
-        let status, remaining, last_processed, room_mentions, scoped_messages =
-          consume_room_messages remaining since_seq [] [] messages
-        in
-        let cursor_acc =
-          if last_processed > since_seq then (room_id, last_processed) :: cursor_acc
-          else cursor_acc
-        in
-        let mentions_acc = mentions_acc @ room_mentions in
-        let scope_acc = scope_acc @ scoped_messages in
-        match status with
-        | `Done -> consume_rooms remaining mentions_acc scope_acc cursor_acc rest
-        | `Saturated -> (mentions_acc, scope_acc, List.rev cursor_acc)
+      let since_seq = room_cursor_for meta room_id in
+      let messages =
+        try Coord.get_all_messages_raw config ~since_seq with
+        | Eio.Cancel.Cancelled _ as e -> raise e
+        | _ -> []
+      in
+      let status, remaining, last_processed, room_mentions, scoped_messages =
+        consume_room_messages remaining since_seq [] [] messages
+      in
+      let cursor_acc =
+        if last_processed > since_seq
+        then (room_id, last_processed) :: cursor_acc
+        else cursor_acc
+      in
+      let mentions_acc = mentions_acc @ room_mentions in
+      let scope_acc = scope_acc @ scoped_messages in
+      (match status with
+       | `Done -> consume_rooms remaining mentions_acc scope_acc cursor_acc rest
+       | `Saturated -> mentions_acc, scope_acc, List.rev cursor_acc)
   in
   consume_rooms batch_limit [] [] [] meta.joined_room_ids
+;;
 
-let apply_message_cursor_updates (meta : keeper_meta)
-    (updates : (string * int) list) : keeper_meta =
-  List.fold_left
-    (fun acc (room_id, seq) -> set_room_cursor acc room_id seq)
-    meta updates
+let apply_message_cursor_updates (meta : keeper_meta) (updates : (string * int) list)
+  : keeper_meta
+  =
+  List.fold_left (fun acc (room_id, seq) -> set_room_cursor acc room_id seq) meta updates
+;;
 
 let backlog_updated_since_last_scheduled_autonomous
-    ~(meta : keeper_meta)
-    ~(backlog : Masc_domain.backlog) : bool =
+      ~(meta : keeper_meta)
+      ~(backlog : Masc_domain.backlog)
+  : bool
+  =
   let last_ts = meta.runtime.proactive_rt.last_ts in
-  if last_ts <= 0.0 then backlog.tasks <> []
-  else
+  if last_ts <= 0.0
+  then backlog.tasks <> []
+  else (
     match Coord_resilience.Time.parse_iso8601_opt backlog.last_updated with
     | Some updated_at -> updated_at > last_ts
-    | None -> false
+    | None -> false)
+;;
 
-let claim_goal_scope_filter ?agent_tool_names ~(config : Coord.config)
-    ~(meta : keeper_meta) () =
+let claim_goal_scope_filter
+      ?agent_tool_names
+      ~(config : Coord.config)
+      ~(meta : keeper_meta)
+      ()
+  =
   let scope =
     Keeper_runtime_contract.resolve_observation_claim_goal_scope
-      ?agent_tool_names ~config ~meta ()
+      ?agent_tool_names
+      ~config
+      ~meta
+      ()
   in
   scope.task_filter
+;;
 
 (** Read room backlog counts. *)
-let read_backlog_counts ~allowed_tool_names ~(config : Coord.config)
-    ~(meta : keeper_meta) :
-    int * int * int * int * bool =
+let read_backlog_counts ~allowed_tool_names ~(config : Coord.config) ~(meta : keeper_meta)
+  : int * int * int * int * bool
+  =
   try
     let backlog = Coord.read_backlog config in
     let unclaimed_tasks =
@@ -283,11 +320,7 @@ let read_backlog_counts ~allowed_tool_names ~(config : Coord.config)
     in
     let unclaimed = List.length unclaimed_tasks in
     let claim_scope_filter =
-      claim_goal_scope_filter
-        ?agent_tool_names:allowed_tool_names
-        ~config
-        ~meta
-        ()
+      claim_goal_scope_filter ?agent_tool_names:allowed_tool_names ~config ~meta ()
     in
     (* Build the allowed-set once and reuse across all candidates in
        the [unclaimed_tasks] filter below — see PR #14826 for the
@@ -301,88 +334,91 @@ let read_backlog_counts ~allowed_tool_names ~(config : Coord.config)
       List.length
         (List.filter
            (fun task ->
-             Coord_task_schedule.task_is_claim_pool_candidate task
-             && claim_scope_filter task
-             && required_tools_allowed
-                  (Coord_task_schedule.task_required_tools task))
+              Coord_task_schedule.task_is_claim_pool_candidate task
+              && claim_scope_filter task
+              && required_tools_allowed (Coord_task_schedule.task_required_tools task))
            unclaimed_tasks)
     in
     let failed =
       List.length
         (List.filter
            (fun (t : Masc_domain.task) ->
-             match t.task_status with
-             | Masc_domain.Cancelled _ -> true
-             | Masc_domain.Todo | Masc_domain.Claimed _ | Masc_domain.InProgress _
-             | Masc_domain.AwaitingVerification _ | Masc_domain.Done _ -> false)
+              match t.task_status with
+              | Masc_domain.Cancelled _ -> true
+              | Masc_domain.Todo
+              | Masc_domain.Claimed _
+              | Masc_domain.InProgress _
+              | Masc_domain.AwaitingVerification _
+              | Masc_domain.Done _ -> false)
            backlog.tasks)
     in
     let pending_verification =
       List.length
         (List.filter
            (fun (t : Masc_domain.task) ->
-             match t.task_status with
-             | Masc_domain.AwaitingVerification _ -> true
-             | Masc_domain.Todo | Masc_domain.Claimed _ | Masc_domain.InProgress _
-             | Masc_domain.Done _ | Masc_domain.Cancelled _ -> false)
+              match t.task_status with
+              | Masc_domain.AwaitingVerification _ -> true
+              | Masc_domain.Todo
+              | Masc_domain.Claimed _
+              | Masc_domain.InProgress _
+              | Masc_domain.Done _
+              | Masc_domain.Cancelled _ -> false)
            backlog.tasks)
     in
     let backlog_updated_since_last_scheduled_autonomous =
       backlog_updated_since_last_scheduled_autonomous ~meta ~backlog
     in
-    ( unclaimed,
-      claimable,
-      failed,
-      pending_verification,
-      backlog_updated_since_last_scheduled_autonomous )
+    ( unclaimed
+    , claimable
+    , failed
+    , pending_verification
+    , backlog_updated_since_last_scheduled_autonomous )
   with
   | Eio.Cancel.Cancelled _ as e -> raise e
   | ex ->
-      Prometheus.inc_counter
-        Keeper_metrics.metric_keeper_observation_query_failures
-        ~labels:[("operation", Observation_query_operation.(to_label Read_backlog_counts))]
-        ();
-      Log.Keeper.warn "read_backlog_counts failed: %s" (Printexc.to_string ex);
-      (0, 0, 0, 0, false)
+    Prometheus.inc_counter
+      Keeper_metrics.metric_keeper_observation_query_failures
+      ~labels:
+        [ ("operation", Observation_query_operation.(to_label Read_backlog_counts)) ]
+      ();
+    Log.Keeper.warn "read_backlog_counts failed: %s" (Printexc.to_string ex);
+    0, 0, 0, 0, false
+;;
 
 (** Count active agents in room. *)
 let count_active_agents ~(config : Coord.config) : int =
-  try List.length (Coord.get_agents_raw config)
-  with
+  try List.length (Coord.get_agents_raw config) with
   | Eio.Cancel.Cancelled _ as e -> raise e
   | ex ->
-      Prometheus.inc_counter
-        Keeper_metrics.metric_keeper_observation_query_failures
-        ~labels:[("operation", Observation_query_operation.(to_label Count_active_agents))]
-        ();
-      Log.Keeper.warn "count_active_agents failed: %s" (Printexc.to_string ex);
-      0
+    Prometheus.inc_counter
+      Keeper_metrics.metric_keeper_observation_query_failures
+      ~labels:
+        [ ("operation", Observation_query_operation.(to_label Count_active_agents)) ]
+      ();
+    Log.Keeper.warn "count_active_agents failed: %s" (Printexc.to_string ex);
+    0
+;;
 
 (** Compute idle seconds from keeper timestamps. *)
 let compute_idle_seconds ~(meta : keeper_meta) : int =
   let now_ts = Time_compat.now () in
   let created_ts =
-    Coord_resilience.Time.parse_iso8601_opt meta.created_at
-    |> Option.value ~default:0.0
+    Coord_resilience.Time.parse_iso8601_opt meta.created_at |> Option.value ~default:0.0
   in
-  let activity_ts =
-    List.fold_left max created_ts
-      [
-        meta.runtime.proactive_rt.last_ts;
-      ]
-  in
-  if activity_ts <= 0.0 then 0
-  else int_of_float (max 0.0 (now_ts -. activity_ts))
+  let activity_ts = List.fold_left max created_ts [ meta.runtime.proactive_rt.last_ts ] in
+  if activity_ts <= 0.0 then 0 else int_of_float (max 0.0 (now_ts -. activity_ts))
+;;
 
-let board_post_id_string (post : Board.post) =
-  Board.Post_id.to_string post.id
+let board_post_id_string (post : Board.post) = Board.Post_id.to_string post.id
 
 let compare_board_cursor_token (ts_a, post_id_a) (ts_b, post_id_b) =
   let cmp = Float.compare ts_a ts_b in
   if cmp <> 0 then cmp else String.compare post_id_a post_id_b
+;;
 
 let board_cursor_token_of_post (post : Board.post) =
-  (post.updated_at, board_post_id_string post)
+  post.updated_at, board_post_id_string post
+;;
 
 let list_board_posts_after_cursor (cursor_ts, cursor_post_id) =
   let cursor_post_id = Option.value ~default:"" cursor_post_id in
@@ -395,27 +431,34 @@ let list_board_posts_after_cursor (cursor_ts, cursor_post_id) =
   Board_dispatch.list_posts ~sort_by:Board_dispatch.Updated ~limit:max_int ()
   |> List.filter is_after_cursor
   |> List.sort (fun (a : Board.post) (b : Board.post) ->
-       compare_board_cursor_token
-         (board_cursor_token_of_post a)
-         (board_cursor_token_of_post b))
+    compare_board_cursor_token
+      (board_cursor_token_of_post a)
+      (board_cursor_token_of_post b))
+;;
 
 let board_signal_text (signal : Board_dispatch.keeper_board_signal) =
-  String.concat "\n"
-    (List.filter (fun part -> String.trim part <> "")
-       [
-         signal.title;
-         signal.content;
-         (match signal.hearth with Some hearth -> hearth | None -> "");
+  String.concat
+    "\n"
+    (List.filter
+       (fun part -> String.trim part <> "")
+       [ signal.title
+       ; signal.content
+       ; (match signal.hearth with
+          | Some hearth -> hearth
+          | None -> "")
        ])
+;;
 
 let board_signal_match
-    ~continuity_summary:(_ : string)
-    ~(meta : keeper_meta)
-    ~(signal : Board_dispatch.keeper_board_signal) : board_signal_match =
+      ~continuity_summary:(_ : string)
+      ~(meta : keeper_meta)
+      ~(signal : Board_dispatch.keeper_board_signal)
+  : board_signal_match
+  =
   let self_tokens = self_identity_tokens meta in
-  if is_self_author ~self_tokens signal.author then
-    { explicit_mention = false; matched_targets = []; score = 0 }
-  else
+  if is_self_author ~self_tokens signal.author
+  then { explicit_mention = false; matched_targets = []; score = 0 }
+  else (
     let targets =
       if meta.mention_targets <> [] then meta.mention_targets else [ meta.name ]
     in
@@ -423,20 +466,18 @@ let board_signal_match
     let matched_targets =
       targets
       |> List.filter (fun target ->
-             let needle = "@" ^ String.lowercase_ascii (String.trim target) in
-             needle <> "@"
-             && String_util.contains_substring haystack needle)
+        let needle = "@" ^ String.lowercase_ascii (String.trim target) in
+        needle <> "@" && String_util.contains_substring haystack needle)
     in
-    if matched_targets <> [] then
-      { explicit_mention = true; matched_targets; score = 100 }
-    else { explicit_mention = false; matched_targets = []; score = 0 }
+    if matched_targets <> []
+    then { explicit_mention = true; matched_targets; score = 100 }
+    else { explicit_mention = false; matched_targets = []; score = 0 })
+;;
 
 (** Read context ratio from checkpoint if available. *)
 let read_context_ratio ~(config : Coord.config) ~(meta : keeper_meta) : float =
   try
-    let cascade_models =
-      Keeper_model_labels.configured_model_labels_of_meta meta
-    in
+    let cascade_models = Keeper_model_labels.configured_model_labels_of_meta meta in
     let primary_max_context =
       let resolution =
         Keeper_exec_context.resolve_max_context_resolution
@@ -450,7 +491,8 @@ let read_context_ratio ~(config : Coord.config) ~(meta : keeper_meta) : float =
       load_context_from_checkpoint
         ~max_checkpoint_messages:meta.compaction.max_checkpoint_messages
         ~trace_id:(Keeper_id.Trace_id.to_string meta.runtime.trace_id)
-        ~primary_model_max_tokens:primary_max_context ~base_dir
+        ~primary_model_max_tokens:primary_max_context
+        ~base_dir
     in
     match ctx_opt with
     | Some c -> Keeper_exec_context.context_ratio c
@@ -458,70 +500,69 @@ let read_context_ratio ~(config : Coord.config) ~(meta : keeper_meta) : float =
   with
   | Eio.Cancel.Cancelled _ as e -> raise e
   | _ -> 0.0
+;;
 
 (** Read continuity summary from checkpoint messages or meta fallback. *)
-let read_continuity_summary ~(config : Coord.config) ~(meta : keeper_meta)
-    : string =
+let read_continuity_summary ~(config : Coord.config) ~(meta : keeper_meta) : string =
   try
     match Keeper_memory_policy.read_progress_snapshot ~config ~name:meta.name with
-    | Some snapshot ->
-        keeper_state_snapshot_to_summary_text snapshot
+    | Some snapshot -> keeper_state_snapshot_to_summary_text snapshot
     | None ->
-    let cascade_models =
-      Keeper_model_labels.configured_model_labels_of_meta meta
-    in
-    let primary_max_context =
-      let resolution =
-        Keeper_exec_context.resolve_max_context_resolution
-          ~requested_override:meta.max_context_override
-          cascade_models
+      let cascade_models = Keeper_model_labels.configured_model_labels_of_meta meta in
+      let primary_max_context =
+        let resolution =
+          Keeper_exec_context.resolve_max_context_resolution
+            ~requested_override:meta.max_context_override
+            cascade_models
+        in
+        resolution.effective_budget
       in
-      resolution.effective_budget
-    in
-    let base_dir = session_base_dir config in
-    let trace_id = Keeper_id.Trace_id.to_string meta.runtime.trace_id in
-    let session, ctx_opt =
-      load_context_from_checkpoint
-        ~max_checkpoint_messages:meta.compaction.max_checkpoint_messages
-        ~trace_id
-        ~primary_model_max_tokens:primary_max_context ~base_dir
-    in
-      match ctx_opt with
-      | Some c ->
-          let structured_snapshot =
-            match
-              Keeper_checkpoint_store.load_oas
-                ~session_dir:session.session_dir ~session_id:trace_id
-            with
-            | Ok cp ->
-                (match cp.Agent_sdk.Checkpoint.working_context with
-                 | Some json ->
-                     Keeper_memory_policy
-                     .snapshot_of_structured_working_context json
-                 | None -> None)
-            | Error _ -> None
-          in
-          let snapshot =
-            match latest_state_snapshot_from_messages (messages_of_context c) with
-            | Some _ as snapshot -> snapshot
-            | None -> structured_snapshot
-          in
-          (match snapshot with
-           | Some s -> keeper_state_snapshot_to_summary_text s
-           | None ->
-               continuity_fallback_summary_text
-                 ~continuity_summary:meta.continuity_summary
-                 ~last_continuity_update_ts:meta.runtime.last_continuity_update_ts)
-      | None ->
-          continuity_fallback_summary_text
-            ~continuity_summary:meta.continuity_summary
-            ~last_continuity_update_ts:meta.runtime.last_continuity_update_ts
+      let base_dir = session_base_dir config in
+      let trace_id = Keeper_id.Trace_id.to_string meta.runtime.trace_id in
+      let session, ctx_opt =
+        load_context_from_checkpoint
+          ~max_checkpoint_messages:meta.compaction.max_checkpoint_messages
+          ~trace_id
+          ~primary_model_max_tokens:primary_max_context
+          ~base_dir
+      in
+      (match ctx_opt with
+       | Some c ->
+         let structured_snapshot =
+           match
+             Keeper_checkpoint_store.load_oas
+               ~session_dir:session.session_dir
+               ~session_id:trace_id
+           with
+           | Ok cp ->
+             (match cp.Agent_sdk.Checkpoint.working_context with
+              | Some json ->
+                Keeper_memory_policy.snapshot_of_structured_working_context json
+              | None -> None)
+           | Error _ -> None
+         in
+         let snapshot =
+           match latest_state_snapshot_from_messages (messages_of_context c) with
+           | Some _ as snapshot -> snapshot
+           | None -> structured_snapshot
+         in
+         (match snapshot with
+          | Some s -> keeper_state_snapshot_to_summary_text s
+          | None ->
+            continuity_fallback_summary_text
+              ~continuity_summary:meta.continuity_summary
+              ~last_continuity_update_ts:meta.runtime.last_continuity_update_ts)
+       | None ->
+         continuity_fallback_summary_text
+           ~continuity_summary:meta.continuity_summary
+           ~last_continuity_update_ts:meta.runtime.last_continuity_update_ts)
   with
   | Eio.Cancel.Cancelled _ as e -> raise e
   | _ ->
-      continuity_fallback_summary_text
-        ~continuity_summary:meta.continuity_summary
-        ~last_continuity_update_ts:meta.runtime.last_continuity_update_ts
+    continuity_fallback_summary_text
+      ~continuity_summary:meta.continuity_summary
+      ~last_continuity_update_ts:meta.runtime.last_continuity_update_ts
+;;
 
 (** Board event cursor bootstrap window (seconds). *)
 let bootstrap_window_sec = Env_config.InternalTimers.bootstrap_window_sec
@@ -532,137 +573,157 @@ let bootstrap_window_sec = Env_config.InternalTimers.bootstrap_window_sec
     or updated_at). Based on BDI commitment reconsideration: a committed
     response is only re-evaluated when new external beliefs arrive. *)
 let check_self_comment_status ~self_tokens ~(post_id : string)
-    : [ `Never | `No_new_external | `New_external of int * string * string ] =
+  : [ `Never | `No_new_external | `New_external of int * string * string ]
+  =
   match Board_dispatch.get_comments ~post_id with
   | Error _ -> `Never
   | Ok comments ->
-      let my_comments =
+    let my_comments =
+      List.filter
+        (fun (c : Board.comment) ->
+           is_self_author ~self_tokens (Board.Agent_id.to_string c.author))
+        comments
+    in
+    if my_comments = []
+    then `Never
+    else (
+      let my_latest_ts =
+        List.fold_left
+          (fun acc (c : Board.comment) -> max acc c.created_at)
+          0.0
+          my_comments
+      in
+      let external_after =
         List.filter
           (fun (c : Board.comment) ->
-            is_self_author ~self_tokens (Board.Agent_id.to_string c.author))
+             (not (is_self_author ~self_tokens (Board.Agent_id.to_string c.author)))
+             && c.created_at > my_latest_ts)
           comments
       in
-      if my_comments = [] then `Never
-      else
-        let my_latest_ts =
+      match external_after with
+      | [] -> `No_new_external
+      | hd :: tl ->
+        let latest =
           List.fold_left
-            (fun acc (c : Board.comment) -> max acc c.created_at)
-            0.0 my_comments
+            (fun (acc : Board.comment) (c : Board.comment) ->
+               if c.created_at > acc.created_at then c else acc)
+            hd
+            tl
         in
-        let external_after =
-          List.filter
-            (fun (c : Board.comment) ->
-              not (is_self_author ~self_tokens (Board.Agent_id.to_string c.author))
-              && c.created_at > my_latest_ts)
-            comments
-        in
-        match external_after with
-        | [] -> `No_new_external
-        | hd :: tl ->
-          let latest =
-            List.fold_left
-              (fun (acc : Board.comment) (c : Board.comment) ->
-                if c.created_at > acc.created_at then c else acc)
-              hd tl
-          in
-          `New_external
-            ( List.length external_after,
-              Board.Agent_id.to_string latest.author,
-              short_preview ~max_len:60 latest.content )
+        `New_external
+          ( List.length external_after
+          , Board.Agent_id.to_string latest.author
+          , short_preview ~max_len:60 latest.content ))
+;;
 
 type stigmergy_match_result = { overall_score : int }
 
-let stigmergy_match ~(meta : keeper_meta)
-    ~(signal : Board_dispatch.keeper_board_signal) : stigmergy_match_result =
+let stigmergy_match ~(meta : keeper_meta) ~(signal : Board_dispatch.keeper_board_signal)
+  : stigmergy_match_result
+  =
   let signal_text = String.lowercase_ascii (board_signal_text signal) in
   let goal_keywords =
     [ meta.goal; meta.short_goal; meta.mid_goal; meta.long_goal ]
     |> List.filter (fun s -> String.trim s <> "")
     |> List.concat_map (fun g ->
-         String.split_on_char ' ' (String.lowercase_ascii g)
-         |> List.map String.trim
-         |> List.filter (fun s -> String.length s > 3))
+      String.split_on_char ' ' (String.lowercase_ascii g)
+      |> List.map String.trim
+      |> List.filter (fun s -> String.length s > 3))
     |> List.sort_uniq String.compare
   in
   let score =
     List.fold_left
       (fun acc kw ->
-        if String_util.contains_substring signal_text kw then acc + 5 else acc)
-      0 goal_keywords
+         if String_util.contains_substring signal_text kw then acc + 5 else acc)
+      0
+      goal_keywords
   in
   { overall_score = min score 50 }
+;;
 
 let board_signal_wake_reason
-    ~continuity_summary
-    ~(meta : keeper_meta)
-    ~(signal : Board_dispatch.keeper_board_signal) : string option =
+      ~continuity_summary
+      ~(meta : keeper_meta)
+      ~(signal : Board_dispatch.keeper_board_signal)
+  : string option
+  =
   let matched = board_signal_match ~continuity_summary ~meta ~signal in
-  if matched.explicit_mention then
-    Some "explicit_mention"
-  else if scope_message_feed_enabled meta then
-    Some "board_activity"
-  else
+  if matched.explicit_mention
+  then Some "explicit_mention"
+  else if scope_message_feed_enabled meta
+  then Some "board_activity"
+  else (
     let stigmergy = stigmergy_match ~meta ~signal in
-    if stigmergy.overall_score > 0 then
-      Some ("stigmergy: score=" ^ string_of_int stigmergy.overall_score)
-    else
+    if stigmergy.overall_score > 0
+    then Some ("stigmergy: score=" ^ string_of_int stigmergy.overall_score)
+    else (
       let self_tokens = self_identity_tokens meta in
       match signal.kind with
       | Board_dispatch.Board_comment_added ->
-          (match check_self_comment_status ~self_tokens ~post_id:signal.post_id with
-           | `New_external _ -> Some "thread_reply_after_self_comment"
-           | `Never | `No_new_external -> None)
-      | Board_dispatch.Board_post_created -> None
+        (match check_self_comment_status ~self_tokens ~post_id:signal.post_id with
+         | `New_external _ -> Some "thread_reply_after_self_comment"
+         | `Never | `No_new_external -> None)
+      | Board_dispatch.Board_post_created -> None))
+;;
 
 let json_string_member name fields =
   match List.assoc_opt name fields with
   | Some (`String value) -> Some value
   | _ -> None
+;;
 
 let json_string_null_member name fields =
   match List.assoc_opt name fields with
   | Some (`String value) -> Some value
   | Some `Null | None -> None
   | _ -> None
+;;
 
 let board_signal_kind_of_string = function
   | "post_created" | "post" -> Some Board_dispatch.Board_post_created
   | "comment_added" | "comment" -> Some Board_dispatch.Board_comment_added
   | _ -> None
+;;
 
 let board_signal_of_stimulus_payload payload =
   try
     match Yojson.Safe.from_string payload with
     | `Assoc fields
-      when Option.equal String.equal
+      when Option.equal
+             String.equal
              (json_string_member "source" fields)
              (Some "board_signal") ->
-        (match
-           ( json_string_member "kind" fields,
-             json_string_member "post_id" fields,
-             json_string_member "author" fields,
-             json_string_member "title" fields,
-             json_string_member "content" fields )
-         with
-         | Some kind, Some post_id, Some author, Some title, Some content ->
-             Option.map
-               (fun kind ->
-                 {
-                   Board_dispatch.kind;
-                   post_id;
-                   author;
-                   title;
-                   content;
-                   hearth = json_string_null_member "hearth" fields;
-                 })
-               (board_signal_kind_of_string kind)
-         | _ -> None)
+      (match
+         ( json_string_member "kind" fields
+         , json_string_member "post_id" fields
+         , json_string_member "author" fields
+         , json_string_member "title" fields
+         , json_string_member "content" fields )
+       with
+       | Some kind, Some post_id, Some author, Some title, Some content ->
+         Option.map
+           (fun kind ->
+              { Board_dispatch.kind
+              ; post_id
+              ; author
+              ; title
+              ; content
+              ; hearth = json_string_null_member "hearth" fields
+              })
+           (board_signal_kind_of_string kind)
+       | _ -> None)
     | _ -> None
-  with Yojson.Json_error _ -> None
+  with
+  | Yojson.Json_error _ -> None
+;;
 
-let pending_board_event_of_board_signal ~continuity_summary ~(meta : keeper_meta)
-    ~(arrived_at : float) (signal : Board_dispatch.keeper_board_signal) :
-    pending_board_event =
+let pending_board_event_of_board_signal
+      ~continuity_summary
+      ~(meta : keeper_meta)
+      ~(arrived_at : float)
+      (signal : Board_dispatch.keeper_board_signal)
+  : pending_board_event
+  =
   let self_tokens = self_identity_tokens meta in
   let matched = board_signal_match ~continuity_summary ~meta ~signal in
   let post_snapshot =
@@ -673,59 +734,58 @@ let pending_board_event_of_board_signal ~continuity_summary ~(meta : keeper_meta
   let title, preview, hearth, post_kind, updated_at =
     match post_snapshot with
     | Some (post : Board.post) ->
-        ( post.title,
-          short_preview ~max_len:80 post.content,
-          post.hearth,
-          post.post_kind,
-          post.updated_at )
+      ( post.title
+      , short_preview ~max_len:80 post.content
+      , post.hearth
+      , post.post_kind
+      , post.updated_at )
     | None ->
-        ( signal.title,
-          short_preview ~max_len:80 signal.content,
-          signal.hearth,
-          Board.Human_post,
-          arrived_at )
+      ( signal.title
+      , short_preview ~max_len:80 signal.content
+      , signal.hearth
+      , Board.Human_post
+      , arrived_at )
   in
-  let self_commented, new_external_since, latest_external_author,
-      latest_external_preview =
+  let self_commented, new_external_since, latest_external_author, latest_external_preview =
     match signal.kind with
-    | Board_dispatch.Board_post_created -> (false, 0, None, None)
+    | Board_dispatch.Board_post_created -> false, 0, None, None
     | Board_dispatch.Board_comment_added ->
-        (match check_self_comment_status ~self_tokens ~post_id:signal.post_id with
-         | `New_external (count, author, preview) ->
-             (true, count, Some author, Some preview)
-         | `No_new_external ->
-             ( true,
-               0,
-               Some signal.author,
-               Some (short_preview ~max_len:60 signal.content) )
-         | `Never ->
-             ( false,
-               1,
-               Some signal.author,
-               Some (short_preview ~max_len:60 signal.content) ))
+      (match check_self_comment_status ~self_tokens ~post_id:signal.post_id with
+       | `New_external (count, author, preview) -> true, count, Some author, Some preview
+       | `No_new_external ->
+         true, 0, Some signal.author, Some (short_preview ~max_len:60 signal.content)
+       | `Never ->
+         false, 1, Some signal.author, Some (short_preview ~max_len:60 signal.content))
   in
-  {
-    post_id = signal.post_id;
-    author = signal.author;
-    title;
-    preview;
-    hearth;
-    post_kind;
-    updated_at;
-    explicit_mention = matched.explicit_mention;
-    matched_targets = matched.matched_targets;
-    self_commented;
-    new_external_since;
-    latest_external_author;
-    latest_external_preview;
+  { post_id = signal.post_id
+  ; author = signal.author
+  ; title
+  ; preview
+  ; hearth
+  ; post_kind
+  ; updated_at
+  ; explicit_mention = matched.explicit_mention
+  ; matched_targets = matched.matched_targets
+  ; self_commented
+  ; new_external_since
+  ; latest_external_author
+  ; latest_external_preview
   }
+;;
 
-let pending_board_event_of_stimulus ~continuity_summary ~(meta : keeper_meta)
-    (stimulus : Keeper_event_queue.stimulus) : pending_board_event option =
+let pending_board_event_of_stimulus
+      ~continuity_summary
+      ~(meta : keeper_meta)
+      (stimulus : Keeper_event_queue.stimulus)
+  : pending_board_event option
+  =
   board_signal_of_stimulus_payload stimulus.payload
   |> Option.map
-       (pending_board_event_of_board_signal ~continuity_summary ~meta
+       (pending_board_event_of_board_signal
+          ~continuity_summary
+          ~meta
           ~arrived_at:stimulus.arrived_at)
+;;
 
 (** Collect recent board activity using cursor-based tracking.
     Cursor state lives in Keeper_registry as [(updated_at, post_id)].
@@ -736,199 +796,219 @@ let pending_board_event_of_stimulus ~continuity_summary ~(meta : keeper_meta)
     Posts where the keeper has already commented and no new external
     replies have arrived are excluded. This prevents duplicate reactive
     comments while allowing legitimate follow-ups. *)
-let collect_board_events_with_cursor_policy ~advance_cursor ~(base_path : string)
-    ~(continuity_summary : string) ~(meta : keeper_meta) :
-    pending_board_event list * int * int =
+let collect_board_events_with_cursor_policy
+      ~advance_cursor
+      ~(base_path : string)
+      ~(continuity_summary : string)
+      ~(meta : keeper_meta)
+  : pending_board_event list * int * int
+  =
   try
     let broad_scope = scope_message_feed_enabled meta in
     let cursor_ts, cursor_post_id =
       Keeper_registry.get_board_cursor ~base_path meta.name
     in
     let base_cursor =
-      if cursor_ts > 0.0 then
-        (cursor_ts, cursor_post_id)
-      else
-        (Time_compat.now () -. bootstrap_window_sec, None)
+      if cursor_ts > 0.0
+      then cursor_ts, cursor_post_id
+      else Time_compat.now () -. bootstrap_window_sec, None
     in
     let posts = list_board_posts_after_cursor base_cursor in
     let self_tokens = self_identity_tokens meta in
     let recent =
       List.filter
         (fun (p : Board.post) ->
-          not (is_self_author ~self_tokens
-                 (Board.Agent_id.to_string p.author)))
+           not (is_self_author ~self_tokens (Board.Agent_id.to_string p.author)))
         posts
     in
     let new_count = List.length recent in
     let targets =
-      if meta.mention_targets <> [] then meta.mention_targets
-      else [ meta.name ]
+      if meta.mention_targets <> [] then meta.mention_targets else [ meta.name ]
     in
     let mention_count =
       List.length
         (List.filter
            (fun (p : Board.post) ->
-             let haystack =
-               String.lowercase_ascii (p.title ^ " " ^ p.body ^ " " ^ p.content)
-             in
-             List.exists
-               (fun target ->
-                 let needle = "@" ^ String.lowercase_ascii target in
-                 String_util.contains_substring haystack needle)
-               targets)
+              let haystack =
+                String.lowercase_ascii (p.title ^ " " ^ p.body ^ " " ^ p.content)
+              in
+              List.exists
+                (fun target ->
+                   let needle = "@" ^ String.lowercase_ascii target in
+                   String_util.contains_substring haystack needle)
+                targets)
            recent)
     in
     let event_limit = Keeper_config.keeper_board_event_limit () in
     let rec consume_posts remaining last_cursor acc = function
-      | [] -> (List.rev acc, last_cursor)
+      | [] -> List.rev acc, last_cursor
       | (p : Board.post) :: rest ->
-          let post_id = Board.Post_id.to_string p.id in
-          let next_cursor = board_cursor_token_of_post p in
-          let comment_status = check_self_comment_status ~self_tokens ~post_id in
-          match comment_status with
-          | `No_new_external ->
-              Log.Keeper.debug
-                "board dedup: skipping post_id=%s (no new external since my comment)"
-                post_id;
-              consume_posts remaining (Some next_cursor) acc rest
-          | `Never ->
-              let signal : Board_dispatch.keeper_board_signal =
-                {
-                  kind = Board_dispatch.Board_post_created;
-                  post_id;
-                  author = Board.Agent_id.to_string p.author;
-                  title = p.title;
-                  content = p.content;
-                  hearth = p.hearth;
+        let post_id = Board.Post_id.to_string p.id in
+        let next_cursor = board_cursor_token_of_post p in
+        let comment_status = check_self_comment_status ~self_tokens ~post_id in
+        (match comment_status with
+         | `No_new_external ->
+           Log.Keeper.debug
+             "board dedup: skipping post_id=%s (no new external since my comment)"
+             post_id;
+           consume_posts remaining (Some next_cursor) acc rest
+         | `Never ->
+           let signal : Board_dispatch.keeper_board_signal =
+             { kind = Board_dispatch.Board_post_created
+             ; post_id
+             ; author = Board.Agent_id.to_string p.author
+             ; title = p.title
+             ; content = p.content
+             ; hearth = p.hearth
+             }
+           in
+           let matched = board_signal_match ~continuity_summary ~meta ~signal in
+           if not (matched.explicit_mention || broad_scope)
+           then (
+             Log.Keeper.debug
+               "board dedup: skipping post_id=%s (no mention and no prior keeper \
+                participation)"
+               post_id;
+             consume_posts remaining (Some next_cursor) acc rest)
+           else if remaining <= 0
+           then List.rev acc, last_cursor
+           else
+             consume_posts
+               (remaining - 1)
+               (Some next_cursor)
+               ({ post_id
+                ; author = Board.Agent_id.to_string p.author
+                ; title = p.title
+                ; preview = short_preview ~max_len:80 p.content
+                ; hearth = p.hearth
+                ; post_kind = p.post_kind
+                ; updated_at = p.updated_at
+                ; explicit_mention = matched.explicit_mention
+                ; matched_targets = matched.matched_targets
+                ; self_commented = false
+                ; new_external_since = 0
+                ; latest_external_author = None
+                ; latest_external_preview = None
                 }
-              in
-              let matched = board_signal_match ~continuity_summary ~meta ~signal in
-              if not (matched.explicit_mention || broad_scope) then (
-                Log.Keeper.debug
-                  "board dedup: skipping post_id=%s (no mention and no prior keeper participation)"
-                  post_id;
-                consume_posts remaining (Some next_cursor) acc rest)
-              else if remaining <= 0 then
-                (List.rev acc, last_cursor)
-              else
-                consume_posts
-                  (remaining - 1)
-                  (Some next_cursor)
-                  ({
-                     post_id;
-                     author = Board.Agent_id.to_string p.author;
-                     title = p.title;
-                     preview = short_preview ~max_len:80 p.content;
-                     hearth = p.hearth;
-                     post_kind = p.post_kind;
-                     updated_at = p.updated_at;
-                     explicit_mention = matched.explicit_mention;
-                     matched_targets = matched.matched_targets;
-                     self_commented = false;
-                     new_external_since = 0;
-                     latest_external_author = None;
-                     latest_external_preview = None;
-                   }
-                   :: acc)
-                  rest
-          | `New_external (count, ext_author, ext_preview) ->
-              if remaining <= 0 then
-                (List.rev acc, last_cursor)
-              else
-                let signal : Board_dispatch.keeper_board_signal =
-                  {
-                    kind = Board_dispatch.Board_post_created;
-                    post_id;
-                    author = Board.Agent_id.to_string p.author;
-                    title = p.title;
-                    content = p.content;
-                    hearth = p.hearth;
-                  }
-                in
-                let matched = board_signal_match ~continuity_summary ~meta ~signal in
-                consume_posts
-                  (remaining - 1)
-                  (Some next_cursor)
-                  ({
-                     post_id;
-                     author = Board.Agent_id.to_string p.author;
-                     title = p.title;
-                     preview = short_preview ~max_len:80 p.content;
-                     hearth = p.hearth;
-                     post_kind = p.post_kind;
-                     updated_at = p.updated_at;
-                     explicit_mention = matched.explicit_mention;
-                     matched_targets = matched.matched_targets;
-                     self_commented = true;
-                     new_external_since = count;
-                     latest_external_author = Some ext_author;
-                     latest_external_preview = Some ext_preview;
-                   }
-                   :: acc)
-                  rest
+                :: acc)
+               rest
+         | `New_external (count, ext_author, ext_preview) ->
+           if remaining <= 0
+           then List.rev acc, last_cursor
+           else (
+             let signal : Board_dispatch.keeper_board_signal =
+               { kind = Board_dispatch.Board_post_created
+               ; post_id
+               ; author = Board.Agent_id.to_string p.author
+               ; title = p.title
+               ; content = p.content
+               ; hearth = p.hearth
+               }
+             in
+             let matched = board_signal_match ~continuity_summary ~meta ~signal in
+             consume_posts
+               (remaining - 1)
+               (Some next_cursor)
+               ({ post_id
+                ; author = Board.Agent_id.to_string p.author
+                ; title = p.title
+                ; preview = short_preview ~max_len:80 p.content
+                ; hearth = p.hearth
+                ; post_kind = p.post_kind
+                ; updated_at = p.updated_at
+                ; explicit_mention = matched.explicit_mention
+                ; matched_targets = matched.matched_targets
+                ; self_commented = true
+                ; new_external_since = count
+                ; latest_external_author = Some ext_author
+                ; latest_external_preview = Some ext_preview
+                }
+                :: acc)
+               rest))
     in
-    let final_events, last_cursor =
-      consume_posts event_limit None [] recent
-    in
-    if advance_cursor then (
+    let final_events, last_cursor = consume_posts event_limit None [] recent in
+    if advance_cursor
+    then (
       match last_cursor with
       | Some (ts, post_id)
         when compare_board_cursor_token
                (ts, post_id)
                (fst base_cursor, Option.value ~default:"" (snd base_cursor))
              > 0 ->
-          Keeper_registry.set_board_cursor ~base_path meta.name ts (Some post_id)
+        Keeper_registry.set_board_cursor ~base_path meta.name ts (Some post_id)
       | Some (ts, post_id) ->
         Log.Keeper.debug
           "board cursor not advanced for %s: new=(%f, %s) not greater than base=(%f, %s)"
-          meta.name ts post_id (fst base_cursor)
+          meta.name
+          ts
+          post_id
+          (fst base_cursor)
           (Option.value ~default:"" (snd base_cursor))
       | None ->
-        if final_events <> [] then begin
+        if final_events <> []
+        then (
           Prometheus.inc_counter
             Keeper_metrics.metric_keeper_observation_query_failures
-            ~labels:[("operation", Observation_query_operation.(to_label Cursor_stale))]
+            ~labels:[ ("operation", Observation_query_operation.(to_label Cursor_stale)) ]
             ();
           Log.Keeper.warn
             "board cursor not updated for %s despite %d events processed"
-            meta.name (List.length final_events)
-        end);
-    (final_events, new_count, mention_count)
+            meta.name
+            (List.length final_events)));
+    final_events, new_count, mention_count
   with
   | Eio.Cancel.Cancelled _ as e -> raise e
   | exn ->
     Prometheus.inc_counter
       Keeper_metrics.metric_keeper_observation_query_failures
-      ~labels:[("operation", Observation_query_operation.(to_label Board_events))]
+      ~labels:[ ("operation", Observation_query_operation.(to_label Board_events)) ]
       ();
-    Log.Keeper.warn "board event collection failed: %s"
-      (Printexc.to_string exn);
-    ([], 0, 0)
+    Log.Keeper.warn "board event collection failed: %s" (Printexc.to_string exn);
+    [], 0, 0
+;;
 
-let collect_board_events ~(base_path : string) ~(continuity_summary : string)
-    ~(meta : keeper_meta) : pending_board_event list * int * int =
-  collect_board_events_with_cursor_policy ~advance_cursor:true ~base_path
-    ~continuity_summary ~meta
+let collect_board_events
+      ~(base_path : string)
+      ~(continuity_summary : string)
+      ~(meta : keeper_meta)
+  : pending_board_event list * int * int
+  =
+  collect_board_events_with_cursor_policy
+    ~advance_cursor:true
+    ~base_path
+    ~continuity_summary
+    ~meta
+;;
 
-let collect_board_events_without_advancing_cursor ~(base_path : string)
-    ~(continuity_summary : string) ~(meta : keeper_meta) :
-    pending_board_event list * int * int =
-  collect_board_events_with_cursor_policy ~advance_cursor:false ~base_path
-    ~continuity_summary ~meta
+let collect_board_events_without_advancing_cursor
+      ~(base_path : string)
+      ~(continuity_summary : string)
+      ~(meta : keeper_meta)
+  : pending_board_event list * int * int
+  =
+  collect_board_events_with_cursor_policy
+    ~advance_cursor:false
+    ~base_path
+    ~continuity_summary
+    ~meta
+;;
 
-let observe ~allowed_tool_names
-    ~(pending_board_events : pending_board_event list option)
-    ~(config : Coord.config)
-    ~(meta : keeper_meta) :
-    world_observation =
+let observe
+      ~allowed_tool_names
+      ~(pending_board_events : pending_board_event list option)
+      ~(config : Coord.config)
+      ~(meta : keeper_meta)
+  : world_observation
+  =
   let pending_mentions, pending_scope_messages, message_cursor_updates =
     collect_message_scope ~config ~meta
   in
-  let ( unclaimed_task_count,
-        claimable_task_count,
-        failed_task_count,
-        pending_verification_count,
-        backlog_updated_since_last_scheduled_autonomous ) =
+  let ( unclaimed_task_count
+      , claimable_task_count
+      , failed_task_count
+      , pending_verification_count
+      , backlog_updated_since_last_scheduled_autonomous )
+    =
     read_backlog_counts ~allowed_tool_names ~config ~meta
   in
   let active_agent_count = count_active_agents ~config in
@@ -937,20 +1017,20 @@ let observe ~allowed_tool_names
   let continuity_summary = read_continuity_summary ~config ~meta in
   let worktree_change_summary =
     Worktree_live_context.capture_change_block
-      ~base_path:config.base_path ~actor_key:meta.name
+      ~base_path:config.base_path
+      ~actor_key:meta.name
   in
   let economic_pressure =
-    Agent_economy.economic_pressure ~base_path:config.base_path
-      ~agent_name:meta.name
+    Agent_economy.economic_pressure ~base_path:config.base_path ~agent_name:meta.name
   in
   let pending_board_events =
     match pending_board_events with
     | Some events -> events
     | None ->
-        let events, _board_new_count, _board_mention_count =
-          collect_board_events ~base_path:config.base_path ~meta ~continuity_summary
-        in
-        events
+      let events, _board_new_count, _board_mention_count =
+        collect_board_events ~base_path:config.base_path ~meta ~continuity_summary
+      in
+      events
   in
   (* Work Discovery: check if scan interval has elapsed.
      None means "not explicitly configured" — default to enabled so
@@ -962,66 +1042,68 @@ let observe ~allowed_tool_names
     match meta.work_discovery_enabled with
     | Some false -> false
     | _ ->
-      let interval =
-        Option.value ~default:600 meta.work_discovery_interval_sec
-      in
+      let interval = Option.value ~default:600 meta.work_discovery_interval_sec in
       let since_last =
         Time_compat.now () -. meta.runtime.proactive_rt.last_work_discovery_ts
       in
       since_last >= float_of_int interval
   in
-  {
-    pending_mentions;
-    pending_board_events;
-    pending_scope_messages;
-    message_cursor_updates;
-    idle_seconds;
-    active_goals = meta.active_goal_ids;
-    continuity_summary;
-    worktree_change_summary;
-    context_ratio;
-    economic_pressure;
-    unclaimed_task_count;
-    claimable_task_count;
-    failed_task_count;
-    pending_verification_count;
-    backlog_updated_since_last_scheduled_autonomous;
-    active_agent_count;
-    last_turn_budget = None;
-    work_discovery_due;
+  { pending_mentions
+  ; pending_board_events
+  ; pending_scope_messages
+  ; message_cursor_updates
+  ; idle_seconds
+  ; active_goals = meta.active_goal_ids
+  ; continuity_summary
+  ; worktree_change_summary
+  ; context_ratio
+  ; economic_pressure
+  ; unclaimed_task_count
+  ; claimable_task_count
+  ; failed_task_count
+  ; pending_verification_count
+  ; backlog_updated_since_last_scheduled_autonomous
+  ; active_agent_count
+  ; last_turn_budget = None
+  ; work_discovery_due
   }
+;;
 
-let durable_signal_present ~allowed_tool_names ~pending_board_events
-    ~(config : Coord.config) ~(meta : keeper_meta) : bool =
+let durable_signal_present
+      ~allowed_tool_names
+      ~pending_board_events
+      ~(config : Coord.config)
+      ~(meta : keeper_meta)
+  : bool
+  =
   let pending_mentions, pending_scope_messages, _message_cursor_updates =
     collect_message_scope ~config ~meta
   in
-  let ( _unclaimed_task_count,
-        claimable_task_count,
-        failed_task_count,
-        pending_verification_count,
-        _backlog_updated_since_last_scheduled_autonomous ) =
+  let ( _unclaimed_task_count
+      , claimable_task_count
+      , failed_task_count
+      , pending_verification_count
+      , _backlog_updated_since_last_scheduled_autonomous )
+    =
     read_backlog_counts ~allowed_tool_names ~config ~meta
   in
   let pending_board_events =
     match pending_board_events with
     | Some events -> events
     | None ->
-        let events, _board_new_count, _board_mention_count =
-          collect_board_events_without_advancing_cursor
-            ~base_path:config.base_path
-            ~meta
-            ~continuity_summary:meta.continuity_summary
-        in
-        events
+      let events, _board_new_count, _board_mention_count =
+        collect_board_events_without_advancing_cursor
+          ~base_path:config.base_path
+          ~meta
+          ~continuity_summary:meta.continuity_summary
+      in
+      events
   in
   let work_discovery_due =
     match meta.work_discovery_enabled with
     | Some false -> false
     | _ ->
-      let interval =
-        Option.value ~default:600 meta.work_discovery_interval_sec
-      in
+      let interval = Option.value ~default:600 meta.work_discovery_interval_sec in
       Time_compat.now () -. meta.runtime.proactive_rt.last_work_discovery_ts
       >= float_of_int interval
   in
@@ -1032,6 +1114,7 @@ let durable_signal_present ~allowed_tool_names ~pending_board_events
   || failed_task_count > 0
   || pending_verification_count > 0
   || work_discovery_due
+;;
 
 let actionable_signal_present (observation : world_observation) =
   observation.pending_mentions <> []
@@ -1042,47 +1125,52 @@ let actionable_signal_present (observation : world_observation) =
   || observation.failed_task_count > 0
   || observation.pending_verification_count > 0
   || observation.work_discovery_due
+;;
 
-let proactive_work_signal_present ~(meta : keeper_meta)
-    (observation : world_observation) =
-  actionable_signal_present observation
-  || Option.is_some meta.current_task_id
+let proactive_work_signal_present ~(meta : keeper_meta) (observation : world_observation) =
+  actionable_signal_present observation || Option.is_some meta.current_task_id
+;;
 
 (** Compute effective scheduled autonomous cooldown with idle decay.
     After extended idle (> base cooldown), halve the cooldown each
     additional period, down to a configurable floor.  This prevents
     permanent silence when no external events arrive. *)
 let effective_scheduled_autonomous_cooldown
-    ~(base_cooldown : int) ~(since_last : int)
-    ?(consecutive_noop_count = 0) () : int =
+      ~(base_cooldown : int)
+      ~(since_last : int)
+      ?(consecutive_noop_count = 0)
+      ()
+  : int
+  =
   (* Noop backoff: consecutive observation-only cycles multiply the base
      cooldown by 2^min(n, 3), capping at 8x. This prevents token waste when
      the keeper repeatedly reads board_list without taking action. *)
   let noop_multiplier =
-    if consecutive_noop_count <= 0 then 1
-    else 1 lsl (min consecutive_noop_count 3)  (* 1, 2, 4, 8 *)
+    if consecutive_noop_count <= 0 then 1 else 1 lsl min consecutive_noop_count 3
+    (* 1, 2, 4, 8 *)
   in
   let effective_base = base_cooldown * noop_multiplier in
   let min_cooldown = Keeper_config.keeper_proactive_min_cooldown_sec () in
   (* Floor must not exceed the effective base cooldown — otherwise decay would
      paradoxically increase a short cooldown. *)
   let floor = min min_cooldown effective_base in
-  if since_last <= effective_base then effective_base
-  else
-    let decay_periods = (since_last - effective_base) / (max 1 effective_base) in
+  if since_last <= effective_base
+  then effective_base
+  else (
+    let decay_periods = (since_last - effective_base) / max 1 effective_base in
     let capped_periods = min decay_periods 4 in
-    let factor = 1.0 /. (Float.pow 2.0 (float_of_int capped_periods)) in
-    max floor (int_of_float (float_of_int effective_base *. factor))
+    let factor = 1.0 /. Float.pow 2.0 (float_of_int capped_periods) in
+    max floor (int_of_float (float_of_int effective_base *. factor)))
+;;
 
-let effective_proactive_cooldown =
-  effective_scheduled_autonomous_cooldown
+let effective_proactive_cooldown = effective_scheduled_autonomous_cooldown
 
 let fallback_cascade_for_provider_cooldown
-    ~(base_cascade : string)
-    ~(effective_cascade : string) : string option =
-  let normalized_base =
-    Keeper_cascade_profile.normalize_declared_name base_cascade
-  in
+      ~(base_cascade : string)
+      ~(effective_cascade : string)
+  : string option
+  =
+  let normalized_base = Keeper_cascade_profile.normalize_declared_name base_cascade in
   let normalized_effective =
     Keeper_cascade_profile.normalize_declared_name effective_cascade
   in
@@ -1093,65 +1181,71 @@ let fallback_cascade_for_provider_cooldown
     || String.equal normalized_effective (Keeper_config.default_cascade_name ())
   then None
   else Some (Keeper_config.default_cascade_name ())
+;;
 
 let provider_cooldown_remaining_sec_for_cascade
-    ~(cascade_name : Keeper_cascade_profile.runtime_name) : int option =
+      ~(cascade_name : Keeper_cascade_profile.runtime_name)
+  : int option
+  =
   let model_ids =
-    Cascade_runtime.models_of_cascade_name
-      cascade_name
+    Cascade_runtime.models_of_cascade_name cascade_name
     |> Cascade_config.parse_model_strings
-    |> List.map (fun (cfg : Llm_provider.Provider_config.t) ->
-           String.trim cfg.model_id)
+    |> List.map (fun (cfg : Llm_provider.Provider_config.t) -> String.trim cfg.model_id)
     |> List.filter (fun model_id -> model_id <> "")
     |> List.sort_uniq String.compare
   in
   match model_ids with
   | [] -> None
   | _ ->
-      let provider_infos =
-        List.map
-          (fun provider_key ->
-             Cascade_health_tracker.provider_info
-               Cascade_health_tracker.global ~provider_key)
-          model_ids
-      in
-      if not (List.for_all Option.is_some provider_infos) then None
-      else
-        let provider_infos = List.filter_map Fun.id provider_infos in
-        if not (List.for_all (fun info -> info.Cascade_health_tracker.in_cooldown) provider_infos)
-        then None
-        else
-          let now = Time_compat.now () in
-          provider_infos
-          |> List.filter_map
-               (fun info -> info.Cascade_health_tracker.cooldown_expires_at)
-          |> List.map (fun expires_at ->
-                 int_of_float
-                   (Float.max 0.0 (Float.ceil (expires_at -. now))))
-          |> function
-          | [] -> Some 0
-          | first :: rest -> Some (List.fold_left min first rest)
+    let provider_infos =
+      List.map
+        (fun provider_key ->
+           Cascade_health_tracker.provider_info
+             Cascade_health_tracker.global
+             ~provider_key)
+        model_ids
+    in
+    if not (List.for_all Option.is_some provider_infos)
+    then None
+    else (
+      let provider_infos = List.filter_map Fun.id provider_infos in
+      if
+        not
+          (List.for_all
+             (fun info -> info.Cascade_health_tracker.in_cooldown)
+             provider_infos)
+      then None
+      else (
+        let now = Time_compat.now () in
+        provider_infos
+        |> List.filter_map (fun info -> info.Cascade_health_tracker.cooldown_expires_at)
+        |> List.map (fun expires_at ->
+          int_of_float (Float.max 0.0 (Float.ceil (expires_at -. now))))
+        |> function
+        | [] -> Some 0
+        | first :: rest -> Some (List.fold_left min first rest)))
+;;
 
 let entropic_oscillation_interval_sec = 600
-
 let entropic_oscillation_probability_percent = 5
 
-let should_inject_entropic_oscillation
-    ~since_last_scheduled_autonomous ~draw_percent =
+let should_inject_entropic_oscillation ~since_last_scheduled_autonomous ~draw_percent =
   since_last_scheduled_autonomous >= entropic_oscillation_interval_sec
   && draw_percent >= 0
   && draw_percent < entropic_oscillation_probability_percent
+;;
 
 let keeper_cycle_decision
-    ?(provider_cooldown_remaining_sec =
-        provider_cooldown_remaining_sec_for_cascade)
-    ~(meta : keeper_meta)
-    (observation : world_observation) =
+      ?(provider_cooldown_remaining_sec = provider_cooldown_remaining_sec_for_cascade)
+      ~(meta : keeper_meta)
+      (observation : world_observation)
+  =
   let reactive_triggers =
-    [
-      (if observation.pending_mentions <> [] then Some Mention_pending else None);
-      (if observation.pending_board_events <> [] then Some Board_event_pending else None);
-      (if observation.pending_scope_messages <> [] then Some Scope_message_pending else None);
+    [ (if observation.pending_mentions <> [] then Some Mention_pending else None)
+    ; (if observation.pending_board_events <> [] then Some Board_event_pending else None)
+    ; (if observation.pending_scope_messages <> []
+       then Some Scope_message_pending
+       else None)
     ]
     |> List.filter_map Fun.id
   in
@@ -1161,50 +1255,49 @@ let keeper_cycle_decision
     | [] -> Scheduled_autonomous
   in
   let blocked reason =
-    {
-      should_run = false;
-      channel = blocked_channel;
-      verdict = Skip { reasons = (reason, []) };
-      since_last_scheduled_autonomous = None;
-      effective_cooldown = None;
-      task_reactive_cooldown = None;
-      idle_gate_sec = None;
+    { should_run = false
+    ; channel = blocked_channel
+    ; verdict = Skip { reasons = reason, [] }
+    ; since_last_scheduled_autonomous = None
+    ; effective_cooldown = None
+    ; task_reactive_cooldown = None
+    ; idle_gate_sec = None
     }
   in
-  if meta.paused then
-    blocked Keeper_paused
-  else if Keeper_approval_queue.has_pending_for_keeper ~keeper_name:meta.name then
-    blocked Approval_pending
-  else
-  match reactive_triggers with
-  | first :: rest ->
-      {
-        should_run = true;
-        channel = Reactive;
-        verdict = Run { reasons = (first, rest) };
-        since_last_scheduled_autonomous = None;
-        effective_cooldown = None;
-        task_reactive_cooldown = None;
-        idle_gate_sec = None;
+  if meta.paused
+  then blocked Keeper_paused
+  else if Keeper_approval_queue.has_pending_for_keeper ~keeper_name:meta.name
+  then blocked Approval_pending
+  else (
+    match reactive_triggers with
+    | first :: rest ->
+      { should_run = true
+      ; channel = Reactive
+      ; verdict = Run { reasons = first, rest }
+      ; since_last_scheduled_autonomous = None
+      ; effective_cooldown = None
+      ; task_reactive_cooldown = None
+      ; idle_gate_sec = None
       }
-  | [] ->
+    | [] ->
       let since_last_scheduled_autonomous =
-        if meta.runtime.proactive_rt.last_ts <= 0.0 then max_int
+        if meta.runtime.proactive_rt.last_ts <= 0.0
+        then max_int
         else
           int_of_float (max 0.0 (Time_compat.now () -. meta.runtime.proactive_rt.last_ts))
       in
       let idle_gate_sec = meta.proactive.idle_sec in
-      if not meta.proactive.enabled then
-        {
-          should_run = false;
-          channel = Scheduled_autonomous;
-          verdict = Skip { reasons = (Scheduled_autonomous_disabled, []) };
-          since_last_scheduled_autonomous = Some since_last_scheduled_autonomous;
-          effective_cooldown = None;
-          task_reactive_cooldown = None;
-          idle_gate_sec = Some idle_gate_sec;
+      if not meta.proactive.enabled
+      then
+        { should_run = false
+        ; channel = Scheduled_autonomous
+        ; verdict = Skip { reasons = Scheduled_autonomous_disabled, [] }
+        ; since_last_scheduled_autonomous = Some since_last_scheduled_autonomous
+        ; effective_cooldown = None
+        ; task_reactive_cooldown = None
+        ; idle_gate_sec = Some idle_gate_sec
         }
-      else
+      else (
         let effective_cooldown =
           effective_scheduled_autonomous_cooldown
             ~base_cooldown:meta.proactive.cooldown_sec
@@ -1219,16 +1312,13 @@ let keeper_cycle_decision
           Keeper_config.keeper_proactive_task_min_cooldown_sec ()
         in
         let task_reactive_cooldown =
-          max task_cooldown_floor
-            (effective_cooldown / max 1 task_cooldown_divisor)
+          max task_cooldown_floor (effective_cooldown / max 1 task_cooldown_divisor)
         in
         let has_actionable_tasks =
           observation.claimable_task_count > 0 || observation.failed_task_count > 0
         in
         let idle_gate_elapsed = observation.idle_seconds >= idle_gate_sec in
-        let cooldown_elapsed =
-          since_last_scheduled_autonomous >= effective_cooldown
-        in
+        let cooldown_elapsed = since_last_scheduled_autonomous >= effective_cooldown in
         let backlog_elapsed =
           has_actionable_tasks
           && since_last_scheduled_autonomous >= task_reactive_cooldown
@@ -1237,9 +1327,7 @@ let keeper_cycle_decision
           has_actionable_tasks
           && observation.backlog_updated_since_last_scheduled_autonomous
         in
-        let proactive_work_ready =
-          proactive_work_signal_present ~meta observation
-        in
+        let proactive_work_ready = proactive_work_signal_present ~meta observation in
         (* Phase 1 — Bootstrap bypass: keeper has never completed a scheduled
            autonomous turn (last_ts <= 0.0, so since_last = max_int). Fire
            immediately without requiring work signals or time gates, so a
@@ -1262,7 +1350,7 @@ let keeper_cycle_decision
              min_interval_elapsed here would also set Min_interval_elapsed on a
              bootstrap turn, which is misleading — the two paths are mutually
              exclusive by design. *)
-          not is_bootstrap
+          (not is_bootstrap)
           && since_last_scheduled_autonomous >= proactive_min_interval_sec
         in
         (* Backlog bypass: when actionable tasks exist and task_reactive_cooldown
@@ -1297,9 +1385,9 @@ let keeper_cycle_decision
         let provider_cooldown_fail_open =
           match provider_cooldown_remaining_sec with
           | Some _ ->
-              fallback_cascade_for_provider_cooldown
-                ~base_cascade:cascade_name
-                ~effective_cascade:cascade_name
+            fallback_cascade_for_provider_cooldown
+              ~base_cascade:cascade_name
+              ~effective_cascade:cascade_name
           | None -> None
         in
         let verdict =
@@ -1307,34 +1395,41 @@ let keeper_cycle_decision
             Option.is_some provider_cooldown_remaining_sec
             && Option.is_none provider_cooldown_fail_open
           then
-            Skip {
-              reasons = (
-                Provider_cooldown_pending {
-                  remaining_sec =
-                    Option.value ~default:0 provider_cooldown_remaining_sec;
-                },
-                [] );
-            }
-          else if should_run then
+            Skip
+              { reasons =
+                  ( Provider_cooldown_pending
+                      { remaining_sec =
+                          Option.value ~default:0 provider_cooldown_remaining_sec
+                      }
+                  , [] )
+              }
+          else if should_run
+          then (
             let run_reasons =
-              [
-                Some Scheduled_autonomous_turn;
-                (if should_oscillate then Some Entropic_oscillation else None);
-                (if is_bootstrap
-                 then Some Never_started else None);
-                (if min_interval_elapsed
-                 then Some Min_interval_elapsed else None);
-                (if idle_gate_elapsed
-                 then Some (Idle_cooldown_elapsed
-                              { idle_sec = observation.idle_seconds;
-                                cooldown = effective_cooldown }) else None);
-                (if cooldown_elapsed then Some Cooldown_elapsed else None);
-                (if has_actionable_tasks
-                 then Some (Task_backlog
-                              { unclaimed = observation.claimable_task_count;
-                                failed = observation.failed_task_count }) else None);
-                (if backlog_fresh || backlog_elapsed
-                 then Some Task_reactive_cooldown_elapsed else None);
+              [ Some Scheduled_autonomous_turn
+              ; (if should_oscillate then Some Entropic_oscillation else None)
+              ; (if is_bootstrap then Some Never_started else None)
+              ; (if min_interval_elapsed then Some Min_interval_elapsed else None)
+              ; (if idle_gate_elapsed
+                 then
+                   Some
+                     (Idle_cooldown_elapsed
+                        { idle_sec = observation.idle_seconds
+                        ; cooldown = effective_cooldown
+                        })
+                 else None)
+              ; (if cooldown_elapsed then Some Cooldown_elapsed else None)
+              ; (if has_actionable_tasks
+                 then
+                   Some
+                     (Task_backlog
+                        { unclaimed = observation.claimable_task_count
+                        ; failed = observation.failed_task_count
+                        })
+                 else None)
+              ; (if backlog_fresh || backlog_elapsed
+                 then Some Task_reactive_cooldown_elapsed
+                 else None)
               ]
               |> List.filter_map Fun.id
             in
@@ -1342,62 +1437,66 @@ let keeper_cycle_decision
                Scheduled_autonomous_turn tag first, so the reason list
                cannot be empty even if future edits change the payload list. *)
             match run_reasons with
-            | first :: rest ->
-                Run { reasons = (first, rest) }
+            | first :: rest -> Run { reasons = first, rest }
             | [] ->
-                (* Structurally unreachable: the synthetic Scheduled_autonomous_turn
+              (* Structurally unreachable: the synthetic Scheduled_autonomous_turn
                    tag is always added first, so the list is never empty.
                    Defensive: log warning and fall through to skip so that
                    should_run (derived below) stays consistent with verdict. *)
-                Prometheus.inc_counter
-                  Keeper_metrics.metric_keeper_observation_query_failures
-                  ~labels:[("operation", Observation_query_operation.(to_label Empty_run_reasons))]
-                  ();
-                Log.Keeper.warn
-                  "unreachable: should_run=true but run_reasons is empty";
-                Skip { reasons = (No_signal, []) }
-          else
+              Prometheus.inc_counter
+                Keeper_metrics.metric_keeper_observation_query_failures
+                ~labels:
+                  [ ("operation", Observation_query_operation.(to_label Empty_run_reasons))
+                  ]
+                ();
+              Log.Keeper.warn "unreachable: should_run=true but run_reasons is empty";
+              Skip { reasons = No_signal, [] })
+          else (
             let skip_reasons =
-              [
-                (if not proactive_work_ready then Some No_signal else None);
-                (if not idle_gate_elapsed
-                 then Some (Idle_gate_pending
-                              { remaining_sec =
-                                  idle_gate_sec - observation.idle_seconds })
-                 else None);
-                (if idle_gate_elapsed && not cooldown_elapsed
-                 then Some (Cooldown_pending
-                              { remaining_sec =
-                                  effective_cooldown - since_last_scheduled_autonomous })
-                 else None);
+              [ (if not proactive_work_ready then Some No_signal else None)
+              ; (if not idle_gate_elapsed
+                 then
+                   Some
+                     (Idle_gate_pending
+                        { remaining_sec = idle_gate_sec - observation.idle_seconds })
+                 else None)
+              ; (if idle_gate_elapsed && not cooldown_elapsed
+                 then
+                   Some
+                     (Cooldown_pending
+                        { remaining_sec =
+                            effective_cooldown - since_last_scheduled_autonomous
+                        })
+                 else None)
               ]
               |> List.filter_map Fun.id
             in
             match skip_reasons with
-            | first :: rest ->
-                Skip { reasons = (first, rest) }
-            | [] ->
-                Skip { reasons = (No_signal, []) }
+            | first :: rest -> Skip { reasons = first, rest }
+            | [] -> Skip { reasons = No_signal, [] })
         in
         (* Derive should_run from verdict to guarantee consistency.
            The earlier [let should_run] is an intent signal; verdict is
            authoritative after the reason-list construction. *)
         let should_run =
-          match verdict with Run _ -> true | Skip _ -> false
+          match verdict with
+          | Run _ -> true
+          | Skip _ -> false
         in
-        {
-          should_run;
-          channel = Scheduled_autonomous;
-          verdict;
-          since_last_scheduled_autonomous = Some since_last_scheduled_autonomous;
-          effective_cooldown = Some effective_cooldown;
-          task_reactive_cooldown = Some task_reactive_cooldown;
-          idle_gate_sec = Some idle_gate_sec;
-        }
+        { should_run
+        ; channel = Scheduled_autonomous
+        ; verdict
+        ; since_last_scheduled_autonomous = Some since_last_scheduled_autonomous
+        ; effective_cooldown = Some effective_cooldown
+        ; task_reactive_cooldown = Some task_reactive_cooldown
+        ; idle_gate_sec = Some idle_gate_sec
+        }))
+;;
 
 let unified_turn_decision = keeper_cycle_decision
 
 let should_run_keeper_cycle ~(meta : keeper_meta) (observation : world_observation) =
   (keeper_cycle_decision ~meta observation).should_run
+;;
 
 let should_run_unified_turn = should_run_keeper_cycle

--- a/lib/tool_prefilter.ml
+++ b/lib/tool_prefilter.ml
@@ -14,7 +14,6 @@ module String = Stdlib.String
 module Char = Stdlib.Char
 module Int = Stdlib.Int
 module Float = Stdlib.Float
-
 module StringMap = Map.Make (String)
 module StringSet = Set.Make (String)
 
@@ -36,222 +35,427 @@ module StringSet = Set.Make (String)
     might use but don't appear in the tool's name or description.
     Derived from Python benchmark data (data/tool-calling-benchmark). *)
 let synonyms : (string * string list) list =
-  [
-    ("masc_dashboard",
-     [ "happening"; "activity"; "overview"; "summary"; "monitor"; "big picture" ]);
-    ("masc_broadcast",
-     [ "notify"; "announce"; "tell"; "inform"; "alert"; "everyone"; "let know" ]);
-    ("masc_claim_next",
-     [ "claim next task"; "pick up task"; "assign me"; "next task"; "give me work"; "take task" ]);
-    ("masc_add_task",
-     [ "create task"; "new task"; "make task"; "register task" ]);
-    ("masc_leave",
-     [ "disconnect"; "go offline"; "exit room"; "sign off"; "leave room" ]);
-    ("masc_messages",
-     [ "chat"; "conversation"; "history"; "log"; "what was said" ]);
-    ("masc_agents",
-     [ "who is working"; "team members"; "workers"; "collaborators" ]);
-    ("masc_status",
-     [ "how are things"; "state"; "health"; "situation" ]);
-    ("keeper_fs_read",
-     [ "contents"; "file contents"; "read file"; "file read"; "source code";
-       "open file"; "show file"; "cat file"; "view file"; "file content" ]);
-    ("keeper_fs_edit",
-     [ "write file"; "create file"; "edit file"; "save file"; "new file";
-       "make file"; "update file"; "overwrite"; "append to file" ]);
-    ("keeper_shell",
-     [ "run command"; "shell read only"; "safe command"; "grep"; "rg search";
-       "list files"; "directory listing"; "git status"; "find file";
-       "pull request"; "issue"; "pr"; "github"; "gh cli"; "create pr";
-       "open draft pr"; "submit pr"; "push and pr";
-       "open issue"; "ci status"; "repository" ]);
-    ("keeper_bash",
-     [ "run shell"; "execute command"; "build"; "test"; "compile"; "dune build";
-       "npm"; "cargo"; "shell command"; "bash command" ]);
-    ("keeper_board_get",
-     [ "read post"; "view post"; "get post"; "board post detail";
-       "show post"; "inspect post" ]);
-    ("keeper_board_post",
-     [ "create post"; "new post"; "share finding"; "write post";
-       "publish post"; "board write" ]);
-    ("keeper_board_list",
-     [ "list posts"; "browse board"; "recent posts"; "forum"; "feed";
-       "board posts"; "discussion list" ]);
-    ("keeper_board_comment",
-     [ "reply"; "add comment"; "respond"; "comment on post"; "feedback" ]);
-    ("keeper_board_vote",
-     [ "upvote"; "downvote"; "rate"; "like"; "agree disagree"; "vote on" ]);
-    ("keeper_board_search",
-     [ "search board"; "find post"; "search discussion"; "keyword search board" ]);
-    ("keeper_board_delete",
-     [ "delete post"; "remove post"; "trash post" ]);
-    ("keeper_board_stats",
-     [ "board statistics"; "activity stats"; "engagement"; "post count" ]);
-    ("keeper_tasks_list",
-     [ "backlog"; "todo list"; "task list"; "available tasks"; "task board";
-       "work items"; "assignee" ]);
-    ("keeper_task_create",
-     [ "create task"; "new task"; "add task"; "make task"; "propose work";
-       "found work"; "needs doing"; "backlog item"; "discovered issue" ]);
-    ("keeper_task_claim",
-     [ "claim task"; "pick up task"; "assign me task"; "take task";
-       "next task"; "give me work" ]);
-    ("keeper_task_done",
-     [ "complete task"; "finish task"; "mark done"; "task completed";
-       "task finished"; "done with task" ]);
-    ("keeper_task_submit_for_verification",
-     [ "submit for verification"; "request verification"; "ready for review";
-       "send to verification"; "handoff to verifier" ]);
-    ("keeper_task_force_release",
-     [ "release task"; "unassign task"; "free task"; "orphaned task";
-       "stuck task"; "unclaim task" ]);
-    ("keeper_task_force_done",
-     [ "force complete"; "mark task done by force"; "force finish task" ]);
-    ("keeper_memory_search",
-     [ "remember"; "recall"; "memory"; "past conversation"; "what was said";
-       "search memory"; "find memory"; "previous discussion" ]);
-    ("keeper_library_search",
-     [ "knowledge library"; "docs"; "documentation"; "lookup docs";
-       "search docs"; "reference"; "knowledge base"; "wiki" ]);
-    ("keeper_library_read",
-     [ "read document"; "read docs"; "library topic"; "full document";
-       "knowledge article" ]);
-    ("keeper_tools_list",
-     [ "what can you do"; "capabilities"; "available tools"; "my tools";
-       "list capabilities"; "tool list"; "discover tools" ]);
-    ("keeper_context_status",
-     [ "context window"; "token usage"; "how much space"; "remaining context";
-       "context usage"; "memory status"; "session state" ]);
-    ("keeper_time_now",
-     [ "current time"; "what time"; "timestamp"; "date now"; "clock";
-       "server time"; "time now" ]);
-    ("keeper_broadcast",
-     [ "broadcast"; "announce to all"; "tell everyone"; "notify all";
-       "send message all" ]);
-    ("keeper_voice_speak",
-     [ "speak"; "say out loud"; "talk"; "voice output"; "text to speech";
-       "tts"; "say something" ]);
-    ("keeper_voice_listen",
-     [ "listen"; "microphone"; "speech to text"; "transcribe"; "hear";
-       "voice input"; "record speech" ]);
-    ("keeper_tool_search",
-     [ "find tool"; "discover tool"; "search tools"; "what tool";
-       "tool for"; "which tool" ]);
-    ("keeper_stay_silent",
-     [ "do nothing"; "skip turn"; "no action"; "stay quiet"; "no response";
-       "silent"; "침묵"; "대기"; "아무것도 안함" ]);
-    ("keeper_tasks_audit",
-     [ "audit tasks"; "orphaned tasks"; "stale tasks"; "zombie tasks";
-       "task cleanup"; "find abandoned"; "고아 태스크"; "방치 태스크"; "태스크 감사" ]);
-    ("keeper_voice_agent",
-     [ "voice settings"; "speech config"; "tts config"; "voice configure";
-       "음성 설정"; "보이스 구성"; "TTS 설정" ]);
-    ("keeper_voice_session_start",
-     [ "start voice session"; "begin voice call"; "open voice channel";
-       "음성 세션 시작"; "보이스 통화 시작" ]);
-    ("keeper_voice_session_end",
-     [ "end voice session"; "close voice call"; "stop voice channel";
-       "음성 세션 종료"; "보이스 통화 종료" ]);
-    ("keeper_voice_sessions",
-     [ "list voice sessions"; "voice session history"; "active calls";
-       "음성 세션 목록"; "보이스 세션" ]);
-    ("keeper_write",
-     [ "write file"; "create file"; "save file"; "new file";
-       "파일 작성"; "파일 저장"; "새 파일" ]);
-    (* masc_code_* — code manipulation tools *)
-    ("masc_code_search",
-     [ "search code"; "find code"; "code lookup"; "grep code"; "find symbol";
-       "search source"; "codebase search"; "code query" ]);
-    ("masc_code_read",
-     [ "read code"; "view code"; "source file"; "open source"; "code contents";
-       "read source"; "show code" ]);
-    ("masc_code_edit",
-     [ "edit code"; "modify code"; "change code"; "update code"; "patch code";
-       "code change" ]);
-    ("masc_code_write",
-     [ "write code"; "create code"; "new file code"; "generate code";
-       "code creation" ]);
-    ("masc_code_symbols",
-     [ "code symbols"; "function list"; "class definitions"; "symbol overview";
-       "navigate code"; "code structure" ]);
-    ("masc_code_shell",
-     [ "code shell"; "run code command"; "execute in code"; "code exec" ]);
-    ("masc_code_git",
-     [ "code git"; "git in code"; "code commit"; "code branch"; "code log" ]);
-    (* masc_autoresearch_* — automated research *)
-    ("masc_autoresearch_start",
-     [ "start research"; "begin research"; "auto research"; "autoresearch start" ]);
-    ("masc_autoresearch_status",
-     [ "research status"; "autoresearch status"; "research progress" ]);
-    ("masc_autoresearch_stop",
-     [ "stop research"; "cancel research"; "end autoresearch" ]);
-    ("masc_autoresearch_cycle",
-     [ "research cycle"; "run cycle"; "autoresearch cycle"; "execute research" ]);
-    (* masc_plan_* — project planning *)
-    ("masc_plan_get",
-     [ "get plan"; "view plan"; "show plan"; "current plan"; "roadmap" ]);
-    ("masc_plan_init",
-     [ "init plan"; "create plan"; "new plan"; "setup plan"; "plan setup" ]);
-    ("masc_plan_update",
-     [ "update plan"; "modify plan"; "change plan"; "edit plan"; "revise plan" ]);
-    ("masc_plan_set_task",
-     [ "set task in plan"; "assign plan task"; "plan task set"; "current task plan" ]);
-    ("masc_plan_get_task",
-     [ "get task from plan"; "plan task"; "current plan task" ]);
-    ("masc_plan_clear_task",
-     [ "clear plan task"; "remove plan task"; "unassign plan task" ]);
-    (* masc_worktree_* — git worktree management *)
-    ("masc_worktree_create",
-     [ "create worktree"; "new worktree"; "isolated branch"; "git worktree add" ]);
-    ("masc_worktree_list",
-     [ "list worktrees"; "show worktrees"; "worktree status" ]);
-    ("masc_worktree_remove",
-     [ "remove worktree"; "delete worktree"; "cleanup worktree" ]);
-    (* masc_agent_* — agent management *)
-    ("masc_agent_card",
-     [ "agent card"; "agent profile"; "agent info"; "who is agent" ]);
-    ("masc_agent_update",
-     [ "update agent"; "change agent"; "agent modify"; "agent settings" ]);
-    ("masc_agent_fitness",
-     [ "agent fitness"; "agent evaluation"; "agent score"; "rate agent" ]);
-    (* masc web search + fetch *)
-    ("masc_web_search",
-     [ "web search"; "search internet"; "search online"; "google" ]);
-    ("masc_web_fetch",
-     [ "web fetch"; "fetch page"; "read url"; "download page" ]);
-    (* masc keeper management — tools available via BM25 but missing from TF-IDF *)
-    ("masc_keeper_up",
-     [ "start keeper"; "launch keeper"; "spawn keeper"; "keeper create" ]);
-    ("masc_keeper_down",
-     [ "stop keeper"; "shutdown keeper"; "kill keeper"; "keeper terminate" ]);
-    ("masc_keeper_list",
-     [ "list keepers"; "show keepers"; "keeper status all"; "active keepers" ]);
-    ("masc_keeper_persona_audit",
-     [ "keeper persona audit"; "persona keeper check"; "keeper toml persona"; "autoboot keepalive audit" ]);
-    ("masc_keeper_msg",
-     [ "send keeper message"; "talk to keeper"; "message keeper"; "keeper chat" ]);
-    ("masc_keeper_status",
-     [ "keeper health"; "keeper state"; "keeper check"; "keeper info" ]);
-    ("masc_keeper_compact",
-     [ "compact keeper"; "shrink context"; "reduce context"; "context overflow fix" ]);
-    ("masc_keeper_clear",
-     [ "clear keeper"; "reset keeper context"; "wipe keeper history"; "emergency clear" ]);
+  [ ( "masc_dashboard"
+    , [ "happening"; "activity"; "overview"; "summary"; "monitor"; "big picture" ] )
+  ; ( "masc_broadcast"
+    , [ "notify"; "announce"; "tell"; "inform"; "alert"; "everyone"; "let know" ] )
+  ; ( "masc_claim_next"
+    , [ "claim next task"
+      ; "pick up task"
+      ; "assign me"
+      ; "next task"
+      ; "give me work"
+      ; "take task"
+      ] )
+  ; "masc_add_task", [ "create task"; "new task"; "make task"; "register task" ]
+  ; "masc_leave", [ "disconnect"; "go offline"; "exit room"; "sign off"; "leave room" ]
+  ; "masc_messages", [ "chat"; "conversation"; "history"; "log"; "what was said" ]
+  ; "masc_agents", [ "who is working"; "team members"; "workers"; "collaborators" ]
+  ; "masc_status", [ "how are things"; "state"; "health"; "situation" ]
+  ; ( "keeper_fs_read"
+    , [ "contents"
+      ; "file contents"
+      ; "read file"
+      ; "file read"
+      ; "source code"
+      ; "open file"
+      ; "show file"
+      ; "cat file"
+      ; "view file"
+      ; "file content"
+      ] )
+  ; ( "keeper_fs_edit"
+    , [ "write file"
+      ; "create file"
+      ; "edit file"
+      ; "save file"
+      ; "new file"
+      ; "make file"
+      ; "update file"
+      ; "overwrite"
+      ; "append to file"
+      ] )
+  ; ( "keeper_shell"
+    , [ "run command"
+      ; "shell read only"
+      ; "safe command"
+      ; "grep"
+      ; "rg search"
+      ; "list files"
+      ; "directory listing"
+      ; "git status"
+      ; "find file"
+      ; "pull request"
+      ; "issue"
+      ; "pr"
+      ; "github"
+      ; "gh cli"
+      ; "create pr"
+      ; "open draft pr"
+      ; "submit pr"
+      ; "push and pr"
+      ; "open issue"
+      ; "ci status"
+      ; "repository"
+      ] )
+  ; ( "keeper_bash"
+    , [ "run shell"
+      ; "execute command"
+      ; "build"
+      ; "test"
+      ; "compile"
+      ; "dune build"
+      ; "npm"
+      ; "cargo"
+      ; "shell command"
+      ; "bash command"
+      ] )
+  ; ( "keeper_board_get"
+    , [ "read post"
+      ; "view post"
+      ; "get post"
+      ; "board post detail"
+      ; "show post"
+      ; "inspect post"
+      ] )
+  ; ( "keeper_board_post"
+    , [ "create post"
+      ; "new post"
+      ; "share finding"
+      ; "write post"
+      ; "publish post"
+      ; "board write"
+      ] )
+  ; ( "keeper_board_list"
+    , [ "list posts"
+      ; "browse board"
+      ; "recent posts"
+      ; "forum"
+      ; "feed"
+      ; "board posts"
+      ; "discussion list"
+      ] )
+  ; ( "keeper_board_comment"
+    , [ "reply"; "add comment"; "respond"; "comment on post"; "feedback" ] )
+  ; ( "keeper_board_vote"
+    , [ "upvote"; "downvote"; "rate"; "like"; "agree disagree"; "vote on" ] )
+  ; ( "keeper_board_search"
+    , [ "search board"; "find post"; "search discussion"; "keyword search board" ] )
+  ; "keeper_board_delete", [ "delete post"; "remove post"; "trash post" ]
+  ; ( "keeper_board_stats"
+    , [ "board statistics"; "activity stats"; "engagement"; "post count" ] )
+  ; ( "keeper_tasks_list"
+    , [ "backlog"
+      ; "todo list"
+      ; "task list"
+      ; "available tasks"
+      ; "task board"
+      ; "work items"
+      ; "assignee"
+      ] )
+  ; ( "keeper_task_create"
+    , [ "create task"
+      ; "new task"
+      ; "add task"
+      ; "make task"
+      ; "propose work"
+      ; "found work"
+      ; "needs doing"
+      ; "backlog item"
+      ; "discovered issue"
+      ] )
+  ; ( "keeper_task_claim"
+    , [ "claim task"
+      ; "pick up task"
+      ; "assign me task"
+      ; "take task"
+      ; "next task"
+      ; "give me work"
+      ] )
+  ; ( "keeper_task_done"
+    , [ "complete task"
+      ; "finish task"
+      ; "mark done"
+      ; "task completed"
+      ; "task finished"
+      ; "done with task"
+      ] )
+  ; ( "keeper_task_submit_for_verification"
+    , [ "submit for verification"
+      ; "request verification"
+      ; "ready for review"
+      ; "send to verification"
+      ; "handoff to verifier"
+      ] )
+  ; ( "keeper_task_force_release"
+    , [ "release task"
+      ; "unassign task"
+      ; "free task"
+      ; "orphaned task"
+      ; "stuck task"
+      ; "unclaim task"
+      ] )
+  ; ( "keeper_task_force_done"
+    , [ "force complete"; "mark task done by force"; "force finish task" ] )
+  ; ( "keeper_memory_search"
+    , [ "remember"
+      ; "recall"
+      ; "memory"
+      ; "past conversation"
+      ; "what was said"
+      ; "search memory"
+      ; "find memory"
+      ; "previous discussion"
+      ] )
+  ; ( "keeper_library_search"
+    , [ "knowledge library"
+      ; "docs"
+      ; "documentation"
+      ; "lookup docs"
+      ; "search docs"
+      ; "reference"
+      ; "knowledge base"
+      ; "wiki"
+      ] )
+  ; ( "keeper_library_read"
+    , [ "read document"
+      ; "read docs"
+      ; "library topic"
+      ; "full document"
+      ; "knowledge article"
+      ] )
+  ; ( "keeper_tools_list"
+    , [ "what can you do"
+      ; "capabilities"
+      ; "available tools"
+      ; "my tools"
+      ; "list capabilities"
+      ; "tool list"
+      ; "discover tools"
+      ] )
+  ; ( "keeper_context_status"
+    , [ "context window"
+      ; "token usage"
+      ; "how much space"
+      ; "remaining context"
+      ; "context usage"
+      ; "memory status"
+      ; "session state"
+      ] )
+  ; ( "keeper_time_now"
+    , [ "current time"
+      ; "what time"
+      ; "timestamp"
+      ; "date now"
+      ; "clock"
+      ; "server time"
+      ; "time now"
+      ] )
+  ; ( "keeper_broadcast"
+    , [ "broadcast"
+      ; "announce to all"
+      ; "tell everyone"
+      ; "notify all"
+      ; "send message all"
+      ] )
+  ; ( "keeper_voice_speak"
+    , [ "speak"
+      ; "say out loud"
+      ; "talk"
+      ; "voice output"
+      ; "text to speech"
+      ; "tts"
+      ; "say something"
+      ] )
+  ; ( "keeper_voice_listen"
+    , [ "listen"
+      ; "microphone"
+      ; "speech to text"
+      ; "transcribe"
+      ; "hear"
+      ; "voice input"
+      ; "record speech"
+      ] )
+  ; ( "keeper_tool_search"
+    , [ "find tool"
+      ; "discover tool"
+      ; "search tools"
+      ; "what tool"
+      ; "tool for"
+      ; "which tool"
+      ] )
+  ; ( "keeper_stay_silent"
+    , [ "do nothing"
+      ; "skip turn"
+      ; "no action"
+      ; "stay quiet"
+      ; "no response"
+      ; "silent"
+      ; "침묵"
+      ; "대기"
+      ; "아무것도 안함"
+      ] )
+  ; ( "keeper_tasks_audit"
+    , [ "audit tasks"
+      ; "orphaned tasks"
+      ; "stale tasks"
+      ; "zombie tasks"
+      ; "task cleanup"
+      ; "find abandoned"
+      ; "고아 태스크"
+      ; "방치 태스크"
+      ; "태스크 감사"
+      ] )
+  ; ( "keeper_voice_agent"
+    , [ "voice settings"
+      ; "speech config"
+      ; "tts config"
+      ; "voice configure"
+      ; "음성 설정"
+      ; "보이스 구성"
+      ; "TTS 설정"
+      ] )
+  ; ( "keeper_voice_session_start"
+    , [ "start voice session"
+      ; "begin voice call"
+      ; "open voice channel"
+      ; "음성 세션 시작"
+      ; "보이스 통화 시작"
+      ] )
+  ; ( "keeper_voice_session_end"
+    , [ "end voice session"
+      ; "close voice call"
+      ; "stop voice channel"
+      ; "음성 세션 종료"
+      ; "보이스 통화 종료"
+      ] )
+  ; ( "keeper_voice_sessions"
+    , [ "list voice sessions"
+      ; "voice session history"
+      ; "active calls"
+      ; "음성 세션 목록"
+      ; "보이스 세션"
+      ] )
+  ; ( "keeper_write"
+    , [ "write file"; "create file"; "save file"; "new file"; "파일 작성"; "파일 저장"; "새 파일" ] )
+  ; (* masc_code_* — code manipulation tools *)
+    ( "masc_code_search"
+    , [ "search code"
+      ; "find code"
+      ; "code lookup"
+      ; "grep code"
+      ; "find symbol"
+      ; "search source"
+      ; "codebase search"
+      ; "code query"
+      ] )
+  ; ( "masc_code_read"
+    , [ "read code"
+      ; "view code"
+      ; "source file"
+      ; "open source"
+      ; "code contents"
+      ; "read source"
+      ; "show code"
+      ] )
+  ; ( "masc_code_edit"
+    , [ "edit code"
+      ; "modify code"
+      ; "change code"
+      ; "update code"
+      ; "patch code"
+      ; "code change"
+      ] )
+  ; ( "masc_code_write"
+    , [ "write code"; "create code"; "new file code"; "generate code"; "code creation" ] )
+  ; ( "masc_code_symbols"
+    , [ "code symbols"
+      ; "function list"
+      ; "class definitions"
+      ; "symbol overview"
+      ; "navigate code"
+      ; "code structure"
+      ] )
+  ; ( "masc_code_shell"
+    , [ "code shell"; "run code command"; "execute in code"; "code exec" ] )
+  ; ( "masc_code_git"
+    , [ "code git"; "git in code"; "code commit"; "code branch"; "code log" ] )
+  ; (* masc_autoresearch_* — automated research *)
+    ( "masc_autoresearch_start"
+    , [ "start research"; "begin research"; "auto research"; "autoresearch start" ] )
+  ; ( "masc_autoresearch_status"
+    , [ "research status"; "autoresearch status"; "research progress" ] )
+  ; "masc_autoresearch_stop", [ "stop research"; "cancel research"; "end autoresearch" ]
+  ; ( "masc_autoresearch_cycle"
+    , [ "research cycle"; "run cycle"; "autoresearch cycle"; "execute research" ] )
+  ; (* masc_plan_* — project planning *)
+    "masc_plan_get", [ "get plan"; "view plan"; "show plan"; "current plan"; "roadmap" ]
+  ; ( "masc_plan_init"
+    , [ "init plan"; "create plan"; "new plan"; "setup plan"; "plan setup" ] )
+  ; ( "masc_plan_update"
+    , [ "update plan"; "modify plan"; "change plan"; "edit plan"; "revise plan" ] )
+  ; ( "masc_plan_set_task"
+    , [ "set task in plan"; "assign plan task"; "plan task set"; "current task plan" ] )
+  ; "masc_plan_get_task", [ "get task from plan"; "plan task"; "current plan task" ]
+  ; ( "masc_plan_clear_task"
+    , [ "clear plan task"; "remove plan task"; "unassign plan task" ] )
+  ; (* masc_worktree_* — git worktree management *)
+    ( "masc_worktree_create"
+    , [ "create worktree"; "new worktree"; "isolated branch"; "git worktree add" ] )
+  ; "masc_worktree_list", [ "list worktrees"; "show worktrees"; "worktree status" ]
+  ; "masc_worktree_remove", [ "remove worktree"; "delete worktree"; "cleanup worktree" ]
+  ; (* masc_agent_* — agent management *)
+    "masc_agent_card", [ "agent card"; "agent profile"; "agent info"; "who is agent" ]
+  ; ( "masc_agent_update"
+    , [ "update agent"; "change agent"; "agent modify"; "agent settings" ] )
+  ; ( "masc_agent_fitness"
+    , [ "agent fitness"; "agent evaluation"; "agent score"; "rate agent" ] )
+  ; (* masc web search + fetch *)
+    "masc_web_search", [ "web search"; "search internet"; "search online"; "google" ]
+  ; "masc_web_fetch", [ "web fetch"; "fetch page"; "read url"; "download page" ]
+  ; (* masc keeper management — tools available via BM25 but missing from TF-IDF *)
+    "masc_keeper_up", [ "start keeper"; "launch keeper"; "spawn keeper"; "keeper create" ]
+  ; ( "masc_keeper_down"
+    , [ "stop keeper"; "shutdown keeper"; "kill keeper"; "keeper terminate" ] )
+  ; ( "masc_keeper_list"
+    , [ "list keepers"; "show keepers"; "keeper status all"; "active keepers" ] )
+  ; ( "masc_keeper_persona_audit"
+    , [ "keeper persona audit"
+      ; "persona keeper check"
+      ; "keeper toml persona"
+      ; "autoboot keepalive audit"
+      ] )
+  ; ( "masc_keeper_msg"
+    , [ "send keeper message"; "talk to keeper"; "message keeper"; "keeper chat" ] )
+  ; ( "masc_keeper_status"
+    , [ "keeper health"; "keeper state"; "keeper check"; "keeper info" ] )
+  ; ( "masc_keeper_compact"
+    , [ "compact keeper"; "shrink context"; "reduce context"; "context overflow fix" ] )
+  ; ( "masc_keeper_clear"
+    , [ "clear keeper"; "reset keeper context"; "wipe keeper history"; "emergency clear" ]
+    )
   ]
+;;
 
 let synonym_lookup : string list StringMap.t =
   List.fold_left (fun m (name, kws) -> StringMap.add name kws m) StringMap.empty synonyms
+;;
 
 let synonym_text name =
   match StringMap.find_opt name synonym_lookup with
   | Some kws -> String.concat " " kws
   | None -> ""
+;;
 
 (* ================================================================ *)
 (* Tokenizer                                                        *)
 (* ================================================================ *)
 
 let is_alnum c =
-  (match c with 'a'..'z' | '0'..'9' -> true | _ -> false)
+  match c with
+  | 'a' .. 'z' | '0' .. '9' -> true
+  | _ -> false
+;;
 
 (** Tokenize text into lowercase alphanumeric words. *)
 let tokenize (text : string) : string list =
@@ -261,18 +465,16 @@ let tokenize (text : string) : string list =
   let tokens = ref [] in
   for i = 0 to len - 1 do
     let c = String.get s i in
-    if is_alnum c then
-      Buffer.add_char buf c
-    else begin
-      if Buffer.length buf > 0 then begin
-        tokens := Buffer.contents buf :: !tokens;
-        Buffer.clear buf
-      end
-    end
+    if is_alnum c
+    then Buffer.add_char buf c
+    else if Buffer.length buf > 0
+    then (
+      tokens := Buffer.contents buf :: !tokens;
+      Buffer.clear buf)
   done;
-  if Buffer.length buf > 0 then
-    tokens := Buffer.contents buf :: !tokens;
+  if Buffer.length buf > 0 then tokens := Buffer.contents buf :: !tokens;
   List.rev !tokens
+;;
 
 (* ================================================================ *)
 (* TF-IDF engine                                                    *)
@@ -286,7 +488,7 @@ let build_document (schema : Masc_domain.tool_schema) : string list =
   let name_words =
     schema.name
     |> String.split_on_char '_'
-    |> List.filter (fun w -> not (String.equal w "masc") && not (String.equal w ""))
+    |> List.filter (fun w -> (not (String.equal w "masc")) && not (String.equal w ""))
   in
   let desc_tokens = tokenize schema.description in
   let param_tokens =
@@ -294,18 +496,19 @@ let build_document (schema : Masc_domain.tool_schema) : string list =
     | `Assoc fields ->
       (match List.assoc_opt "properties" fields with
        | Some (`Assoc props) ->
-         List.concat_map (fun (key, value) ->
-           let key_parts = String.split_on_char '_' key in
-           let desc_parts =
-             match value with
-             | `Assoc vf ->
-               (match List.assoc_opt "description" vf with
-                | Some (`String d) -> tokenize d
-                | _ -> [])
-             | _ -> []
-           in
-           key_parts @ desc_parts
-         ) props
+         List.concat_map
+           (fun (key, value) ->
+              let key_parts = String.split_on_char '_' key in
+              let desc_parts =
+                match value with
+                | `Assoc vf ->
+                  (match List.assoc_opt "description" vf with
+                   | Some (`String d) -> tokenize d
+                   | _ -> [])
+                | _ -> []
+              in
+              key_parts @ desc_parts)
+           props
        | _ -> [])
     | _ -> []
   in
@@ -315,64 +518,101 @@ let build_document (schema : Masc_domain.tool_schema) : string list =
     | None -> []
   in
   name_words @ desc_tokens @ param_tokens @ syn_tokens
+;;
 
 (** Count term frequency in a token list. *)
 let term_freq (tokens : string list) : int StringMap.t =
-  List.fold_left (fun m t ->
-    let prev = match StringMap.find_opt t m with Some n -> n | None -> 0 in
-    StringMap.add t (prev + 1) m
-  ) StringMap.empty tokens
+  List.fold_left
+    (fun m t ->
+       let prev =
+         match StringMap.find_opt t m with
+         | Some n -> n
+         | None -> 0
+       in
+       StringMap.add t (prev + 1) m)
+    StringMap.empty
+    tokens
+;;
 
 (** Compute IDF values from a collection of documents. *)
 let compute_idf (docs : string list list) : float StringMap.t =
   let n = List.length docs in
-  let df = List.fold_left (fun df doc ->
-    let seen = List.fold_left (fun seen t ->
-      if not (StringSet.mem t seen) then
-        StringSet.add t seen
-      else
-        seen
-    ) StringSet.empty doc in
-    StringSet.fold (fun t acc ->
-      let prev = match StringMap.find_opt t acc with Some v -> v | None -> 0 in
-      StringMap.add t (prev + 1) acc
-    ) seen df
-  ) StringMap.empty docs in
-  StringMap.map (fun doc_freq ->
-    Stdlib.log (Stdlib.Float.of_int (n + 1) /. Stdlib.Float.of_int (doc_freq + 1)) +. 1.0
-  ) df
+  let df =
+    List.fold_left
+      (fun df doc ->
+         let seen =
+           List.fold_left
+             (fun seen t ->
+                if not (StringSet.mem t seen) then StringSet.add t seen else seen)
+             StringSet.empty
+             doc
+         in
+         StringSet.fold
+           (fun t acc ->
+              let prev =
+                match StringMap.find_opt t acc with
+                | Some v -> v
+                | None -> 0
+              in
+              StringMap.add t (prev + 1) acc)
+           seen
+           df)
+      StringMap.empty
+      docs
+  in
+  StringMap.map
+    (fun doc_freq ->
+       Stdlib.log (Stdlib.Float.of_int (n + 1) /. Stdlib.Float.of_int (doc_freq + 1))
+       +. 1.0)
+    df
+;;
 
 (** Build TF-IDF sparse vector for a document given IDF table. *)
 let tfidf_vector (tokens : string list) (idf : float StringMap.t) : sparse_vec =
   let tf = term_freq tokens in
   let doc_len = max (List.length tokens) 1 in
-  StringMap.fold (fun term count acc ->
-    let tf_val = Stdlib.Float.of_int count /. Stdlib.Float.of_int doc_len in
-    let idf_val = match StringMap.find_opt term idf with Some v -> v | None -> 1.0 in
-    (term, tf_val *. idf_val) :: acc
-  ) tf []
+  StringMap.fold
+    (fun term count acc ->
+       let tf_val = Stdlib.Float.of_int count /. Stdlib.Float.of_int doc_len in
+       let idf_val =
+         match StringMap.find_opt term idf with
+         | Some v -> v
+         | None -> 1.0
+       in
+       (term, tf_val *. idf_val) :: acc)
+    tf
+    []
+;;
 
 let sparse_vec_norm (v : sparse_vec) : float =
-  Stdlib.Float.sqrt
-    (List.fold_left (fun acc (_, w) -> acc +. (w *. w)) 0.0 v)
+  Stdlib.Float.sqrt (List.fold_left (fun acc (_, w) -> acc +. (w *. w)) 0.0 v)
+;;
 
 let sparse_vec_to_map (v : sparse_vec) : float StringMap.t =
   List.fold_left (fun m (t, w) -> StringMap.add t w m) StringMap.empty v
+;;
 
 (** Cosine similarity between two sparse vectors. *)
 let cosine (a : sparse_vec) (b : sparse_vec) : float =
   let b_tbl = sparse_vec_to_map b in
-  let dot = List.fold_left (fun acc (t, wa) ->
-    match StringMap.find_opt t b_tbl with
-    | Some wb -> acc +. (wa *. wb)
-    | None -> acc
-  ) 0.0 a in
-  if Stdlib.Float.compare dot 0.0 = 0 then 0.0
-  else
+  let dot =
+    List.fold_left
+      (fun acc (t, wa) ->
+         match StringMap.find_opt t b_tbl with
+         | Some wb -> acc +. (wa *. wb)
+         | None -> acc)
+      0.0
+      a
+  in
+  if Stdlib.Float.compare dot 0.0 = 0
+  then 0.0
+  else (
     let na = sparse_vec_norm a in
     let nb = sparse_vec_norm b in
-    if Stdlib.Float.compare na 0.0 = 0 || Stdlib.Float.compare nb 0.0 = 0 then 0.0
-    else dot /. (na *. nb)
+    if Stdlib.Float.compare na 0.0 = 0 || Stdlib.Float.compare nb 0.0 = 0
+    then 0.0
+    else dot /. (na *. nb))
+;;
 
 (** Cosine similarity where the reference (query) vector's [StringMap]
     and norm are pre-computed.  [filter_with_scores] scores N tools
@@ -385,36 +625,46 @@ let cosine (a : sparse_vec) (b : sparse_vec) : float =
     the dot product and the tool-side sum-of-squares in a single pass
     so [other] is traversed only once instead of twice. *)
 let cosine_with_precomp
-    ~(ref_map : float StringMap.t)
-    ~(ref_norm : float)
-    (other : sparse_vec) : float =
+      ~(ref_map : float StringMap.t)
+      ~(ref_norm : float)
+      (other : sparse_vec)
+  : float
+  =
   let dot, other_sq =
-    List.fold_left (fun (dot_acc, sq_acc) (t, w) ->
-      let dot_acc =
-        match StringMap.find_opt t ref_map with
-        | Some rw -> dot_acc +. (rw *. w)
-        | None -> dot_acc
-      in
-      dot_acc, sq_acc +. (w *. w)
-    ) (0.0, 0.0) other
+    List.fold_left
+      (fun (dot_acc, sq_acc) (t, w) ->
+         let dot_acc =
+           match StringMap.find_opt t ref_map with
+           | Some rw -> dot_acc +. (rw *. w)
+           | None -> dot_acc
+         in
+         dot_acc, sq_acc +. (w *. w))
+      (0.0, 0.0)
+      other
   in
-  if Stdlib.Float.compare dot 0.0 = 0 then 0.0
-  else
+  if Stdlib.Float.compare dot 0.0 = 0
+  then 0.0
+  else (
     let other_norm = Stdlib.Float.sqrt other_sq in
-    if Stdlib.Float.compare ref_norm 0.0 = 0
-       || Stdlib.Float.compare other_norm 0.0 = 0
+    if Stdlib.Float.compare ref_norm 0.0 = 0 || Stdlib.Float.compare other_norm 0.0 = 0
     then 0.0
-    else dot /. (ref_norm *. other_norm)
+    else dot /. (ref_norm *. other_norm))
+;;
 
 (* ================================================================ *)
 (* Public API                                                       *)
 (* ================================================================ *)
 
-let filter_with_scores ~(tools : Masc_domain.tool_schema list) ~(query : string)
-    ~(k : int) : (Masc_domain.tool_schema * float) list =
+let filter_with_scores
+      ~(tools : Masc_domain.tool_schema list)
+      ~(query : string)
+      ~(k : int)
+  : (Masc_domain.tool_schema * float) list
+  =
   let query_tokens = tokenize query in
-  if Stdlib.List.length query_tokens = 0 then []
-  else
+  if Stdlib.List.length query_tokens = 0
+  then []
+  else (
     let docs = List.map build_document tools in
     let idf = compute_idf (query_tokens :: docs) in
     let query_vec = tfidf_vector query_tokens idf in
@@ -423,26 +673,33 @@ let filter_with_scores ~(tools : Masc_domain.tool_schema list) ~(query : string)
     let query_vec_map = sparse_vec_to_map query_vec in
     let query_norm = sparse_vec_norm query_vec in
     let tool_vecs = List.map (fun doc -> tfidf_vector doc idf) docs in
-    let scored = List.map2 (fun schema vec ->
-      let score =
-        cosine_with_precomp ~ref_map:query_vec_map ~ref_norm:query_norm vec
-      in
-      (schema, score)
-    ) tools tool_vecs in
+    let scored =
+      List.map2
+        (fun schema vec ->
+           let score =
+             cosine_with_precomp ~ref_map:query_vec_map ~ref_norm:query_norm vec
+           in
+           schema, score)
+        tools
+        tool_vecs
+    in
     (* Filter zero-score results *)
     let nonzero = List.filter (fun (_, s) -> Stdlib.Float.compare s 0.0 > 0) scored in
-    if Stdlib.List.length nonzero = 0 then []
-    else
+    if Stdlib.List.length nonzero = 0
+    then []
+    else (
       let sorted = List.sort (fun (_, a) (_, b) -> Float.compare b a) nonzero in
       let rec take n = function
         | [] -> []
         | x :: rest -> if n <= 0 then [] else x :: take (n - 1) rest
       in
-      take k sorted
+      take k sorted))
+;;
 
 let filter ~(tools : Masc_domain.tool_schema list) ~(query : string) ~(k : int)
-    : Masc_domain.tool_schema list =
-  filter_with_scores ~tools ~query ~k
-  |> List.map fst
+  : Masc_domain.tool_schema list
+  =
+  filter_with_scores ~tools ~query ~k |> List.map fst
+;;
 
 let synonym_keys = List.map fst synonyms

--- a/test/test_docker_client_real.ml
+++ b/test/test_docker_client_real.ml
@@ -22,14 +22,11 @@ module Real_executor = Sandbox_executor.Make (Docker_client_real)
 
 let sample_plan () =
   match
-    Keeper_sandbox_plan.of_request
-      ~turn_id:1
-      ~attempt:0
-      ~meta_name:"alice"
-      ~cmd:"echo hi"
+    Keeper_sandbox_plan.of_request ~turn_id:1 ~attempt:0 ~meta_name:"alice" ~cmd:"echo hi"
   with
   | Ok p -> p
   | Error _ -> failwith "test fixture"
+;;
 
 (* Container-name derivation is deterministic in [(turn_id, attempt,
    suffix)], so a literal suffix like ["alice"] could collide with a
@@ -47,6 +44,7 @@ let sample_container () =
     ~turn_id:1
     ~attempt:0
     ~suffix:(Printf.sprintf "test-pid%d-%d" pid nonce)
+;;
 
 (* ── Each S function returns the typed placeholder ──────────── *)
 
@@ -57,14 +55,15 @@ let sample_container () =
    [sandbox_error] variant is semantically valid for [run]. *)
 let test_run_returns_typed_result () =
   match Docker_client_real.run (sample_plan ()) with
-  | Ok _ -> ()                                     (* daemon present *)
-  | Error Docker_client.Daemon_unreachable -> ()   (* daemon / CLI missing *)
+  | Ok _ -> () (* daemon present *)
+  | Error Docker_client.Daemon_unreachable -> () (* daemon / CLI missing *)
   | Error Docker_client.Cleanup_failed
   | Error Docker_client.Image_pull_failed
   | Error Docker_client.Container_oom
   | Error Docker_client.Exec_timeout
   | Error Docker_client.Probe_format_drift ->
     fail "run should only surface Ok exec_result or Error Daemon_unreachable"
+;;
 
 (* Phase 3b-iv.2.2 — exec is no longer a placeholder. It spawns
    [docker exec <container> sh -lc <cmd>]. The test environment may
@@ -74,22 +73,22 @@ let test_run_returns_typed_result () =
    (no daemon / CLI missing). Other [sandbox_error] variants are
    semantically out of scope for [exec] and must NOT surface. *)
 let test_exec_returns_typed_result () =
-  match
-    Docker_client_real.exec ~container:(sample_container ()) ~cmd:"echo hi"
-  with
-  | Ok _ -> ()                                    (* daemon present *)
-  | Error Docker_client.Daemon_unreachable -> ()  (* daemon / CLI missing *)
+  match Docker_client_real.exec ~container:(sample_container ()) ~cmd:"echo hi" with
+  | Ok _ -> () (* daemon present *)
+  | Error Docker_client.Daemon_unreachable -> () (* daemon / CLI missing *)
   | Error Docker_client.Cleanup_failed
   | Error Docker_client.Image_pull_failed
   | Error Docker_client.Container_oom
   | Error Docker_client.Exec_timeout
   | Error Docker_client.Probe_format_drift ->
     fail "exec should only surface Ok exec_result or Error Daemon_unreachable"
+;;
 
 let test_ps_query_placeholder () =
   match Docker_client_real.ps_query ~labels:[] with
   | Error Docker_client.Cleanup_failed -> ()
   | _ -> fail "expected Cleanup_failed placeholder"
+;;
 
 (* Phase 3b-iv.2.1 — rm is no longer a placeholder; it spawns
    [docker rm -f <name>]. The test environment may or may not have a
@@ -97,14 +96,15 @@ let test_ps_query_placeholder () =
    are surfaced (no exception leakage, no silent success). *)
 let test_rm_returns_typed_error () =
   match Docker_client_real.rm (sample_container ()) with
-  | Error Docker_client.Daemon_unreachable
-  | Error Docker_client.Cleanup_failed -> ()  (* env-dependent path *)
+  | Error Docker_client.Daemon_unreachable | Error Docker_client.Cleanup_failed ->
+    () (* env-dependent path *)
   | Ok () -> fail "unexpected Ok — derived container name should not exist on host"
   | Error Docker_client.Image_pull_failed
   | Error Docker_client.Container_oom
   | Error Docker_client.Exec_timeout
   | Error Docker_client.Probe_format_drift ->
     fail "rm should only surface Daemon_unreachable or Cleanup_failed"
+;;
 
 (* ── Functor instantiation works with Real ───────────────────── *)
 
@@ -120,27 +120,31 @@ let test_executor_with_real_returns_typed_result () =
   | Error Docker_client.Exec_timeout
   | Error Docker_client.Probe_format_drift ->
     fail "executor with Real should only surface Ok or Daemon_unreachable"
+;;
 
 let () =
-  run "Docker_client_real (Phase 3b-iv.2.3)"
-    [
-      ( "S placeholder",
-        [
-          test_case "run → Ok exec_result | Error Daemon_unreachable"
+  run
+    "Docker_client_real (Phase 3b-iv.2.3)"
+    [ ( "S placeholder"
+      , [ test_case
+            "run → Ok exec_result | Error Daemon_unreachable"
             `Quick
-            test_run_returns_typed_result;
-          test_case "exec → Ok exec_result | Error Daemon_unreachable"
+            test_run_returns_typed_result
+        ; test_case
+            "exec → Ok exec_result | Error Daemon_unreachable"
             `Quick
-            test_exec_returns_typed_result;
-          test_case "ps_query → Cleanup_failed" `Quick test_ps_query_placeholder;
-          test_case "rm → typed error (Daemon_unreachable | Cleanup_failed)"
+            test_exec_returns_typed_result
+        ; test_case "ps_query → Cleanup_failed" `Quick test_ps_query_placeholder
+        ; test_case
+            "rm → typed error (Daemon_unreachable | Cleanup_failed)"
             `Quick
-            test_rm_returns_typed_error;
-        ] );
-      ( "Functor composition",
-        [
-          test_case "Sandbox_executor.Make (Real) instantiates + forwards placeholder"
+            test_rm_returns_typed_error
+        ] )
+    ; ( "Functor composition"
+      , [ test_case
+            "Sandbox_executor.Make (Real) instantiates + forwards placeholder"
             `Quick
-            test_executor_with_real_returns_typed_result;
-        ] );
+            test_executor_with_real_returns_typed_result
+        ] )
     ]
+;;

--- a/test/test_keeper_backoff_policy.ml
+++ b/test/test_keeper_backoff_policy.ml
@@ -8,45 +8,72 @@ open Alcotest
 open Masc_mcp
 
 let test_default_for_sandbox_max_attempts () =
-  check int "default max_attempts = 3" 3
-    (Keeper_backoff_policy.max_attempts
-       Keeper_backoff_policy.default_for_sandbox)
+  check
+    int
+    "default max_attempts = 3"
+    3
+    (Keeper_backoff_policy.max_attempts Keeper_backoff_policy.default_for_sandbox)
+;;
 
 let test_default_retries_daemon_unreachable () =
-  check bool "Daemon_unreachable retryable" true
+  check
+    bool
+    "Daemon_unreachable retryable"
+    true
     (Keeper_backoff_policy.should_retry
        Keeper_backoff_policy.default_for_sandbox
        Docker_client.Daemon_unreachable)
+;;
 
 let test_default_retries_image_pull_failed () =
-  check bool "Image_pull_failed retryable" true
+  check
+    bool
+    "Image_pull_failed retryable"
+    true
     (Keeper_backoff_policy.should_retry
        Keeper_backoff_policy.default_for_sandbox
        Docker_client.Image_pull_failed)
+;;
 
 let test_default_does_not_retry_oom () =
-  check bool "Container_oom non-retryable" false
+  check
+    bool
+    "Container_oom non-retryable"
+    false
     (Keeper_backoff_policy.should_retry
        Keeper_backoff_policy.default_for_sandbox
        Docker_client.Container_oom)
+;;
 
 let test_default_does_not_retry_exec_timeout () =
-  check bool "Exec_timeout non-retryable" false
+  check
+    bool
+    "Exec_timeout non-retryable"
+    false
     (Keeper_backoff_policy.should_retry
        Keeper_backoff_policy.default_for_sandbox
        Docker_client.Exec_timeout)
+;;
 
 let test_default_does_not_retry_format_drift () =
-  check bool "Probe_format_drift non-retryable" false
+  check
+    bool
+    "Probe_format_drift non-retryable"
+    false
     (Keeper_backoff_policy.should_retry
        Keeper_backoff_policy.default_for_sandbox
        Docker_client.Probe_format_drift)
+;;
 
 let test_default_does_not_retry_cleanup_failed () =
-  check bool "Cleanup_failed non-retryable" false
+  check
+    bool
+    "Cleanup_failed non-retryable"
+    false
     (Keeper_backoff_policy.should_retry
        Keeper_backoff_policy.default_for_sandbox
        Docker_client.Cleanup_failed)
+;;
 
 let test_custom_policy () =
   let p =
@@ -55,66 +82,95 @@ let test_custom_policy () =
       ~retryable_errors:[ Docker_client.Container_oom ]
   in
   check int "custom max_attempts" 5 (Keeper_backoff_policy.max_attempts p);
-  check bool "custom retryable: oom" true
+  check
+    bool
+    "custom retryable: oom"
+    true
     (Keeper_backoff_policy.should_retry p Docker_client.Container_oom);
-  check bool "non-listed: daemon_unreachable" false
+  check
+    bool
+    "non-listed: daemon_unreachable"
+    false
     (Keeper_backoff_policy.should_retry p Docker_client.Daemon_unreachable)
+;;
 
 let test_disable_retry () =
   let p = Keeper_backoff_policy.make ~max_attempts:1 ~retryable_errors:[] in
-  check int "max_attempts = 1 (no retry)" 1
-    (Keeper_backoff_policy.max_attempts p);
-  check bool "empty retryable list rejects every variant" false
+  check int "max_attempts = 1 (no retry)" 1 (Keeper_backoff_policy.max_attempts p);
+  check
+    bool
+    "empty retryable list rejects every variant"
+    false
     (Keeper_backoff_policy.should_retry p Docker_client.Daemon_unreachable)
+;;
 
 (* ── Precondition enforcement (Copilot review T20/T21) ──────── *)
 
 let test_make_rejects_zero_attempts () =
-  check_raises "max_attempts=0 raises Invalid_argument"
-    (Invalid_argument
-       "Keeper_backoff_policy.make: max_attempts must be >= 1 (got 0)")
+  check_raises
+    "max_attempts=0 raises Invalid_argument"
+    (Invalid_argument "Keeper_backoff_policy.make: max_attempts must be >= 1 (got 0)")
     (fun () ->
-      let _ : Keeper_backoff_policy.t =
-        Keeper_backoff_policy.make ~max_attempts:0 ~retryable_errors:[]
-      in
-      ())
+       let _ : Keeper_backoff_policy.t =
+         Keeper_backoff_policy.make ~max_attempts:0 ~retryable_errors:[]
+       in
+       ())
+;;
 
 let test_make_rejects_negative_attempts () =
-  check_raises "max_attempts=-3 raises Invalid_argument"
-    (Invalid_argument
-       "Keeper_backoff_policy.make: max_attempts must be >= 1 (got -3)")
+  check_raises
+    "max_attempts=-3 raises Invalid_argument"
+    (Invalid_argument "Keeper_backoff_policy.make: max_attempts must be >= 1 (got -3)")
     (fun () ->
-      let _ : Keeper_backoff_policy.t =
-        Keeper_backoff_policy.make ~max_attempts:(-3) ~retryable_errors:[]
-      in
-      ())
+       let _ : Keeper_backoff_policy.t =
+         Keeper_backoff_policy.make ~max_attempts:(-3) ~retryable_errors:[]
+       in
+       ())
+;;
 
 let test_make_accepts_minimum_one () =
   let p = Keeper_backoff_policy.make ~max_attempts:1 ~retryable_errors:[] in
   check int "min boundary 1 accepted" 1 (Keeper_backoff_policy.max_attempts p)
+;;
 
 let () =
-  run "Keeper_backoff_policy"
-    [
-      ( "default policy",
-        [
-          test_case "max_attempts = 3" `Quick test_default_for_sandbox_max_attempts;
-          test_case "retries Daemon_unreachable" `Quick test_default_retries_daemon_unreachable;
-          test_case "retries Image_pull_failed" `Quick test_default_retries_image_pull_failed;
-          test_case "does not retry Container_oom" `Quick test_default_does_not_retry_oom;
-          test_case "does not retry Exec_timeout" `Quick test_default_does_not_retry_exec_timeout;
-          test_case "does not retry Probe_format_drift" `Quick test_default_does_not_retry_format_drift;
-          test_case "does not retry Cleanup_failed" `Quick test_default_does_not_retry_cleanup_failed;
-        ] );
-      ( "custom policy",
-        [
-          test_case "custom max_attempts + retryable list" `Quick test_custom_policy;
-          test_case "max_attempts=1 + empty list disables retry" `Quick test_disable_retry;
-        ] );
-      ( "precondition enforcement",
-        [
-          test_case "make rejects max_attempts=0" `Quick test_make_rejects_zero_attempts;
-          test_case "make rejects negative max_attempts" `Quick test_make_rejects_negative_attempts;
-          test_case "make accepts minimum 1" `Quick test_make_accepts_minimum_one;
-        ] );
+  run
+    "Keeper_backoff_policy"
+    [ ( "default policy"
+      , [ test_case "max_attempts = 3" `Quick test_default_for_sandbox_max_attempts
+        ; test_case
+            "retries Daemon_unreachable"
+            `Quick
+            test_default_retries_daemon_unreachable
+        ; test_case
+            "retries Image_pull_failed"
+            `Quick
+            test_default_retries_image_pull_failed
+        ; test_case "does not retry Container_oom" `Quick test_default_does_not_retry_oom
+        ; test_case
+            "does not retry Exec_timeout"
+            `Quick
+            test_default_does_not_retry_exec_timeout
+        ; test_case
+            "does not retry Probe_format_drift"
+            `Quick
+            test_default_does_not_retry_format_drift
+        ; test_case
+            "does not retry Cleanup_failed"
+            `Quick
+            test_default_does_not_retry_cleanup_failed
+        ] )
+    ; ( "custom policy"
+      , [ test_case "custom max_attempts + retryable list" `Quick test_custom_policy
+        ; test_case "max_attempts=1 + empty list disables retry" `Quick test_disable_retry
+        ] )
+    ; ( "precondition enforcement"
+      , [ test_case "make rejects max_attempts=0" `Quick test_make_rejects_zero_attempts
+        ; test_case
+            "make rejects negative max_attempts"
+            `Quick
+            test_make_rejects_negative_attempts
+        ; test_case "make accepts minimum 1" `Quick test_make_accepts_minimum_one
+        ] )
     ]
+;;


### PR DESCRIPTION
## Summary

Follow-up to admin-merge fast-track of #14826, #14832, #14837, #14844, #14845, #14857, #14860 — all merged with ocamlformat-check failing under the established advisory pattern. This PR brings main back into ocamlformat 0.29.0 (profile=janestreet) compliance so subsequent PRs touching these files don't carry stale-format diff noise.

## Files (12)

| File | Reason for inclusion |
|------|---------------------|
| lib/coord/coord_task_classify.ml | from #14826 |
| lib/coord/coord_task_schedule.{ml,mli} | from #14826 |
| lib/keeper/keeper_world_observation.ml | from #14826, #14860 |
| lib/tool_prefilter.ml | from #14837 |
| lib/keeper/keeper_exec_board.ml | from #14845 |
| lib/keeper/docker_client_real.ml + test | from #14844 |
| lib/keeper/keeper_registry.ml | from #14857 |
| lib/keeper/keeper_backoff_policy.{ml,mli} + test | from #14832 (parent stack) |

## Verification

- `ocamlformat --check` clean on all 12 files locally (ocamlformat 0.29.0).
- `MASC_SKIP_PIN_CHECK=1 dune build --root . @check` green.

## Test plan

- [x] Local `ocamlformat --check` per file
- [x] Local `dune build --root . @check`
- [ ] CI ocamlformat-check green
- [ ] CI Build and Test green

Pure reformat — no behavior change.