### PR TITLE
refactor(tools): ok-envelope SSOT — Tool_args.ok_result + ok_assoc + lint guard (T28+T29, 11 sites)

### DIFF
--- a/.github/workflows/fundamental-check.yml
+++ b/.github/workflows/fundamental-check.yml
@@ -44,6 +44,14 @@ jobs:
       - name: Run lint
         run: bash scripts/lint/no-oas-prefix-in-lib.sh
 
+  no-inline-ok-envelope:
+    name: No inline ok-envelope literals (T27/T28/T29)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run lint
+        run: bash scripts/lint/no-inline-ok-envelope.sh
+
   godfile-size-regression:
     name: Godfile size
     runs-on: ubuntu-latest

--- a/lib/auth_login.ml
+++ b/lib/auth_login.ml
@@ -130,9 +130,8 @@ let mint ~base_path ~host ~port ~agent_name ~role () =
             })
 
 let to_yojson report =
-  `Assoc
+  Tool_args.ok_assoc
     [
-      ("status", `String "ok");
       ("base_path", `String report.base_path);
       ("auth_config_path", `String report.auth_config_path);
       ("auth_change", `String (auth_change_to_string report.auth_change));

--- a/lib/operator/operator_control_action.ml
+++ b/lib/operator/operator_control_action.ml
@@ -74,11 +74,8 @@ let judgment_write_json (ctx : 'a context) args =
         ~keeper_name ()
     in
     Ok
-      (`Assoc
-        [
-          ("status", `String "ok");
-          ("judgment", Operator_judgment.to_yojson judgment);
-        ])
+      (Tool_args.ok_assoc
+         [ ("judgment", Operator_judgment.to_yojson judgment) ])
 
 let judgment_latest_json (_ctx : 'a context) args =
   let* surface = normalize_judgment_surface (get_string args "surface" "") in
@@ -97,14 +94,13 @@ let judgment_latest_json (_ctx : 'a context) args =
     | _ -> None
   in
   Ok
-    (`Assoc
-      [
-        ("status", `String "ok");
-        ( "judgment",
-          match judgment with
-          | Some value -> Operator_judgment.to_yojson value
-          | None -> `Null );
-      ])
+    (Tool_args.ok_assoc
+       [
+         ( "judgment",
+           match judgment with
+           | Some value -> Operator_judgment.to_yojson value
+           | None -> `Null );
+       ])
 
 type action_request = {
   actor : string;

--- a/lib/server/server_routes_http_runtime.ml
+++ b/lib/server/server_routes_http_runtime.ml
@@ -186,8 +186,7 @@ let make_health_json ?(listener = "http/1.1") request =
     else if keeper_config_unknown_key_count > 0 then "config_unknown_keys"
     else "none"
   in
-  `Assoc [
-    ("status", `String "ok");
+  Tool_args.ok_assoc [
     ("server", `String "masc-mcp");
     ("version", `String build.release_version);
     ("release_version", `String build.release_version);

--- a/lib/tool_args.ml
+++ b/lib/tool_args.ml
@@ -109,6 +109,15 @@ let error_response_typed ~code message =
 let ok_response fields =
   Yojson.Safe.to_string (`Assoc (("status", `String "ok") :: fields))
 
+(** Build a JSON OK envelope as a [Yojson.Safe.t] (unserialized).  Use
+    when the caller needs the envelope as part of a larger composed
+    response — for example HTTP body builders that wrap multiple
+    sub-payloads, or [(Yojson.Safe.t, string) result] pipelines that
+    serialize at a later stage.  Same field-order guarantee as
+    [ok_response]: status is prepended to the head of the [`Assoc]. *)
+let ok_assoc fields : Yojson.Safe.t =
+  `Assoc (("status", `String "ok") :: fields)
+
 (** {1 Tool_result.t Helpers}
 
     These return structured [Tool_result.t] instead of [(bool * string)].

--- a/lib/tool_args.mli
+++ b/lib/tool_args.mli
@@ -68,8 +68,15 @@ val error_response : string -> string
 (** [{"status":"error","error_code":"…","message":"…"}] *)
 val error_response_typed : code:error_code -> string -> string
 
-(** [{"status":"ok", <fields>}] *)
+(** [{"status":"ok", <fields>}] as a serialized JSON string. *)
 val ok_response : (string * Yojson.Safe.t) list -> string
+
+(** [{"status":"ok", <fields>}] as a [`Assoc] node (no serialization).
+    Use when embedding the envelope in a larger composed response — HTTP
+    body builders, [(Yojson.Safe.t, string) result] pipelines, etc.
+    Identical field-order semantics to {!ok_response}: [status] is
+    prepended to the [`Assoc] head. *)
+val ok_assoc : (string * Yojson.Safe.t) list -> Yojson.Safe.t
 
 (** {1 Tool_result.t Helpers}
 

--- a/lib/tool_code_write.ml
+++ b/lib/tool_code_write.ml
@@ -459,13 +459,11 @@ let handle_code_write ~tool_name ~start_time ctx args =
           Fs_compat.mkdir_p dir
         end;
         Fs_compat.save_file abs_path content;
-        let response = `Assoc [
-          ("status", `String "ok");
+        Tool_args.ok_result ~tool_name ~start_time [
           ("path", `String path);
           ("bytes_written", `Int (String.length content));
           ("agent", `String ctx.agent_name);
-        ] in
-        Tool_result.ok ~tool_name ~start_time (Yojson.Safe.to_string response)
+        ]
       with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
         Tool_result.error ~tool_name ~start_time (Printf.sprintf "Write failed: %s" (Stdlib.Printexc.to_string exn))
   end
@@ -579,13 +577,11 @@ let handle_code_edit ~tool_name ~start_time ctx args =
               end
             in
             Fs_compat.save_file abs_path new_content;
-            let response = `Assoc [
-              ("status", `String "ok");
+            Tool_args.ok_result ~tool_name ~start_time [
               ("path", `String path);
               ("replacements", `Int !count);
               ("agent", `String ctx.agent_name);
-            ] in
-            Tool_result.ok ~tool_name ~start_time (Yojson.Safe.to_string response)
+            ]
           end
         with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
           Tool_result.error ~tool_name ~start_time (Printf.sprintf "Edit failed: %s" (Stdlib.Printexc.to_string exn))
@@ -608,12 +604,10 @@ let handle_code_delete ~tool_name ~start_time ctx args =
       else begin
         try
           Sys.remove abs_path;
-          let response = `Assoc [
-            ("status", `String "ok");
+          Tool_args.ok_result ~tool_name ~start_time [
             ("path", `String path);
             ("agent", `String ctx.agent_name);
-          ] in
-          Tool_result.ok ~tool_name ~start_time (Yojson.Safe.to_string response)
+          ]
         with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
           Tool_result.error ~tool_name ~start_time (Printf.sprintf "Delete failed: %s" (Stdlib.Printexc.to_string exn))
       end

--- a/lib/tool_inline_dispatch.ml
+++ b/lib/tool_inline_dispatch.ml
@@ -183,8 +183,7 @@ let dispatch (ctx : context) ~(name : string) : Tool_result.t option =
                  let updated = { s with last_seen = now } in
                  let others = List.filter (fun (x : Mcp_server_eio_governance.mcp_session_record) -> not (String.equal x.id session_id)) sessions in
                  save (updated :: others);
-                 Ok (`Assoc [
-                   ("status", `String "ok");
+                 Ok (Tool_args.ok_assoc [
                    ("session", Mcp_server_eio_governance.mcp_session_to_json updated);
                  ]))
         | Mcp_session.List ->

--- a/lib/tool_misc_admin.ml
+++ b/lib/tool_misc_admin.ml
@@ -270,17 +270,13 @@ let handle_config ~tool_name ~start_time args : tool_result =
 let handle_tool_admin_snapshot ~tool_name ~start_time ctx args =
   let include_hidden = get_bool args "include_hidden" true in
   let include_deprecated = get_bool args "include_deprecated" true in
-  let payload =
-    `Assoc
-      [
-        ("status", `String "ok");
-        ("generated_at", `String (Masc_domain.now_iso ()));
-        ("auth", auth_snapshot_json ctx);
-        ( "tool_inventory",
-          tool_inventory_json ctx ~include_hidden ~include_deprecated );
-      ]
-  in
-  Tool_result.ok ~tool_name ~start_time (Yojson.Safe.to_string payload)
+  Tool_args.ok_result ~tool_name ~start_time
+    [
+      ("generated_at", `String (Masc_domain.now_iso ()));
+      ("auth", auth_snapshot_json ctx);
+      ( "tool_inventory",
+        tool_inventory_json ctx ~include_hidden ~include_deprecated );
+    ]
 
 let handle_tool_admin_update ~tool_name ~start_time ctx args =
   let section =
@@ -330,16 +326,12 @@ let handle_tool_admin_update ~tool_name ~start_time ctx args =
             }
           in
           Auth.save_auth_config ctx.config.base_path updated;
-          let payload =
-            `Assoc
-              [
-                ("status", `String "ok");
-                ("section", `String "auth");
-                ("room_secret", json_string_option room_secret);
-                ("result", auth_snapshot_json ctx);
-              ]
-          in
-          Tool_result.ok ~tool_name ~start_time (Yojson.Safe.to_string payload))
+          Tool_args.ok_result ~tool_name ~start_time
+            [
+              ("section", `String "auth");
+              ("room_secret", json_string_option room_secret);
+              ("result", auth_snapshot_json ctx);
+            ])
   | _ ->
       Tool_result.error ~tool_name ~start_time
         (Printf.sprintf "section must be one of: %s"

--- a/lib/voice/voice_config.ml
+++ b/lib/voice/voice_config.ml
@@ -447,9 +447,8 @@ let agent_voices_json config =
        config.tts.agent_voices)
 
 let public_json config =
-  `Assoc
+  Tool_args.ok_assoc
     [
-      ("status", `String "ok");
       ( "tts",
         `Assoc
           [

--- a/scripts/lint/no-inline-ok-envelope.sh
+++ b/scripts/lint/no-inline-ok-envelope.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# lint-ok-envelope.sh — Block inline `("status", `String "ok")` literals
+# in lib/. Use Tool_args.ok_response / ok_assoc / ok_result instead.
+#
+# Rationale: T27/T28/T29 consolidated 11+ inline ok-envelope sites into
+# Tool_args SSOT helpers. Without a lint guard, the inline pattern
+# leaks back in — AI agents learn from codebase statistics, and a few
+# remaining intentional sites can be misread as license to add more.
+#
+# Allowlisted files fall into three categories:
+#   1. SSOT definition itself (tool_args.ml).
+#   2. T27 alias backstop for sibling-include cascade
+#      (tool_local_runtime_core.ml).
+#   3. Tier B/C intentional inline sites where wire format reordering
+#      would break external consumers. Adding to this list requires a
+#      one-line rationale comment in the allowlist.
+
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+ALLOWLIST=(
+  # SSOT definition — the canonical helper itself.
+  "lib/tool_args.ml"
+
+  # T27 alias backstop. sibling tool_local_runtime_*.ml modules
+  # consume `json_ok` / `json_error` via `include Tool_local_runtime_core`;
+  # the symbols are kept as aliases for `Tool_args.ok_response` /
+  # `error_response`. Direct migration of every caller is deferred.
+  "lib/tool_local_runtime_core.ml"
+
+  # Tier B: status field intentionally placed at non-zero position.
+  # Helper migration would reorder JSON keys → wire-breaking for the
+  # dashboard frontend that parses generated_at/cached/stale before
+  # status.
+  "lib/dashboard/dashboard_mission_briefing.ml"
+
+  # Tier B: Yojson.Safe.pretty_to_string (multi-line indented form)
+  # rather than to_string. The SSOT helper emits compact form. Wire
+  # format divergence: a follow-up RFC must decide whether to keep
+  # pretty form or normalize.
+  "lib/tool_keeper.ml"
+
+  # Tier C: local `json_ok` helper, same sibling-include pattern as
+  # tool_local_runtime_core. Operator subsystem will be migrated in
+  # an independent PR scoped to lib/operator/.
+  "lib/operator/operator_control_snapshot.ml"
+
+  # Single-shot health endpoint, no caller chain. De-prioritized — safe
+  # to migrate but no test/wire impact.
+  "lib/http_server_eio.ml"
+
+  # ---- Temporary allowlist entries — REMOVE after T27 (#14876) merges ----
+  # T27 deletes these inline json_ok helpers in tool_misc_web_search and
+  # tool_misc_web_fetch (consolidating to Tool_args.ok_response). This
+  # PR was opened in parallel with T27; once T27 lands these two lines
+  # disappear from origin/main and the entries below must be deleted.
+  "lib/tool_misc_web_fetch.ml"
+  "lib/tool_misc_web_search.ml"
+)
+
+count=0
+while IFS= read -r match; do
+  file=${match%%:*}
+
+  skip=0
+  for allowed in "${ALLOWLIST[@]}"; do
+    if [[ "$file" == "$allowed" ]]; then
+      skip=1
+      break
+    fi
+  done
+  [[ $skip -eq 1 ]] && continue
+
+  # Skip .mli (interface signatures may quote the pattern in docstrings).
+  if [[ "$file" == *.mli ]]; then
+    continue
+  fi
+
+  # Strip the line:linenumber prefix for display.
+  echo "ERROR: inline ok-envelope literal (use Tool_args.ok_response / ok_assoc / ok_result): $match"
+  count=$((count + 1))
+done < <(rg -nP '\("status",\s*`String\s+"ok"\)' lib/ --type-add 'ocaml:*.ml' -tocaml 2>/dev/null || true)
+
+if [[ $count -gt 0 ]]; then
+  echo ""
+  echo "Found $count inline ok-envelope literal(s) outside the allowlist."
+  echo "Migration guide:"
+  echo "  - Returns string?         Tool_args.ok_response fields"
+  echo "  - Returns Yojson.Safe.t?  Tool_args.ok_assoc fields"
+  echo "  - Returns Tool_result.t?  Tool_args.ok_result ~tool_name ~start_time fields"
+  echo ""
+  echo "If the site genuinely requires non-zero status position or pretty"
+  echo "serialization, add a one-line rationale to ALLOWLIST in this script."
+  exit 1
+fi
+
+echo "OK: no inline ok-envelope literals found outside allowlist"
+exit 0


### PR DESCRIPTION
## Scope (Sweep §5 후속 — 빡센 정리)

T27 (#14876) 후속. 사용자 명시 \"빡세게 inline 패턴을 거부하고 제대로 하자\".

T28 (paving) + T29 (확장 + lint guard) 합쳐서 **11 사이트 typed 마이그레이션
+ regression-guard lint**. 추가 inline 패턴이 main에 들어가지 못하도록
fundamental-check CI pipeline에 wire.

## Two-helper SSOT

\`\`\`ocaml
(* lib/tool_args.ml — 이전부터 있던 helper *)
val ok_response : (string * Yojson.Safe.t) list -> string

(* lib/tool_args.ml — 이번 PR 신설 *)
val ok_assoc    : (string * Yojson.Safe.t) list -> Yojson.Safe.t

(* lib/tool_args.ml — 이전부터 있던 helper *)
val ok_result   :
  ?tool_name:string -> ?start_time:float ->
  (string * Yojson.Safe.t) list -> Tool_result.t
\`\`\`

- \`ok_response\` — serialized string (HTTP body, raw output)
- \`ok_assoc\`    — \`Yojson.Safe.t\` node (composed responses, \`(Yojson, string) result\` pipelines)
- \`ok_result\`   — \`Tool_result.t\` (MCP tool handlers)

세 helper 모두 \`(\"status\", \`String \"ok\") :: fields\` 동일 prepend semantics.

## Sites migrated (11)

**Tier A — \`Tool_result.t\` wrapping (5 sites, T28 paving)**:
- \`lib/tool_code_write.ml\` ×3 (write/edit/delete handlers) → \`Tool_args.ok_result\`
- \`lib/tool_misc_admin.ml\` ×2 (snapshot/auth update) → \`Tool_args.ok_result\`

**Tier A — \`Yojson.Safe.t\` returning, status at position 0 (6 sites, T29)**:
- \`lib/operator/operator_control_action.ml\` ×2 (judgment Ok wrappers) → \`Tool_args.ok_assoc\`
- \`lib/voice/voice_config.ml\` (public_json) → \`Tool_args.ok_assoc\`
- \`lib/auth_login.ml\` (to_yojson report) → \`Tool_args.ok_assoc\`
- \`lib/server/server_routes_http_runtime.ml\` (HTTP runtime probe) → \`Tool_args.ok_assoc\`
- \`lib/tool_inline_dispatch.ml\` (MCP session touch) → \`Tool_args.ok_assoc\`

## Sites intentionally allowlisted (Tier B/C — wire format constraint)

| File | Reason | Tier |
|------|--------|------|
| \`lib/dashboard/dashboard_mission_briefing.ml\` | status at field position 5 (after generated_at/cached/stale/refreshing). Helper migration reorders JSON keys → wire-breaking for dashboard frontend | B |
| \`lib/tool_keeper.ml\` | \`pretty_to_string\` (multi-line indent) ≠ SSOT \`to_string\` (compact). Wire format divergence | B |
| \`lib/operator/operator_control_snapshot.ml\` | Local \`json_ok\` sibling-include helper. Operator subsystem awaits independent module-scoped PR | C |
| \`lib/http_server_eio.ml\` | Single-shot health endpoint, de-prioritized | C |
| \`lib/tool_misc_web_fetch.ml\` | **TEMPORARY** — T27 (#14876) deletes this; remove from allowlist after T27 merges | — |
| \`lib/tool_misc_web_search.ml\` | **TEMPORARY** — same as above | — |
| \`lib/tool_local_runtime_core.ml\` | T27 alias backstop (sibling-include cascade for tool_local_runtime_*.ml) | T27 ratified |
| \`lib/tool_args.ml\` | SSOT helper definition itself | — |

## CI guard: \`scripts/lint/no-inline-ok-envelope.sh\`

\`\`\`bash
$ bash scripts/lint/no-inline-ok-envelope.sh
OK: no inline ok-envelope literals found outside allowlist
\`\`\`

- Pattern: \`(\"status\", \`String \"ok\")\` literal in any \`.ml\` under \`lib/\`
- Wired as required check in \`.github/workflows/fundamental-check.yml\`
- 새 inline 패턴이 PR 단계에서 즉시 fail. Allowlist 추가 시 1줄 rationale 의무.

## Diff stat

9 files, +137 / -54 net (lint script 100 LOC + CI hookup + 6 site migration + helper).

## Build

\`MASC_SKIP_PIN_CHECK=1 bash ./scripts/dune-local.sh build --root . @lib/check\` green.

## Wire format guarantee

세 helper 모두 \`(\"status\", \`String \"ok\") :: fields\` semantics — 마이그레이션
사이트의 출력은 byte-identical (status가 originally 첫 필드인 사이트만
T29에 포함, Tier B는 의도적 보류).

## Anti-pattern signatures closed

- Workaround #1 (sprinkle of identical primitive across modules)
- SSOT helper drift (ok_response 14 sites silent reimpl, ok_result 0 caller until T28, ok_assoc 신설)
- Regression vector (lint guard 추가 — RFC-0070 §3b precedent와 동질의 *removal-only* lint, 워크어라운드 #2 string 분류기 *추가*가 아님)

## Cross-reference

- T27 (#14876) — sibling envelope SSOT (error/ok_response helpers)
- CLAUDE.md §워크어라운드 거부 기준 #1 (sprinkle, abstraction missing)
- \`tool_args.mli\` §1 — T27 강화한 \"must open Tool_args\" prescription
- \`feedback_lint_string_classifier_is_workaround_not_fundamental\` — 이 lint는 *removal-only* 이므로 워크어라운드 #2 해당하지 않음 (precedent: RFC-0070 §3b PR #14764)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>