### PR TITLE
refactor(core): extract Set_util for Hashtbl-set saturation

### DIFF
--- a/lib/core/dune
+++ b/lib/core/dune
@@ -9,5 +9,5 @@
  ; existing code but locks in the type-level guarantee for any future closed
  ; concrete variant. Smallest justifiable scope to prove Phase 5 end-to-end.
  (flags (:standard -w +4))
- (modules json_util safe_ops common validation circuit_breaker eio_guard executor_pool_ref masc_runtime_events provider_error text_similarity string_util list_util read_drop_reason actor_types actor_mailbox domain_pool)
+ (modules json_util safe_ops common validation circuit_breaker eio_guard executor_pool_ref masc_runtime_events provider_error text_similarity string_util list_util set_util read_drop_reason actor_types actor_mailbox domain_pool)
  (libraries yojson unix re re.pcre eio eio.unix time_compat fs_compat masc_log runtime_events))

--- a/lib/core/set_util.ml
+++ b/lib/core/set_util.ml
@@ -1,0 +1,36 @@
+(** Hashtbl-as-set membership kernels. See [set_util.mli] for design rationale
+    (Hashtbl over Set.Make: polymorphic key, single-edit future swap). *)
+
+let default_capacity = 16
+
+let of_list_with (key : 'a -> 'b) (xs : 'a list) : ('b, unit) Hashtbl.t =
+  let tbl = Hashtbl.create default_capacity in
+  List.iter (fun x -> Hashtbl.replace tbl (key x) ()) xs;
+  tbl
+
+let count_distinct (key : 'a -> 'b option) (xs : 'a list) : int =
+  let seen : ('b, unit) Hashtbl.t = Hashtbl.create default_capacity in
+  List.iter
+    (fun x ->
+      match key x with
+      | Some k -> Hashtbl.replace seen k ()
+      | None -> ())
+    xs;
+  Hashtbl.length seen
+
+let count_difference (xs : 'a list)
+    ~(present : 'a -> 'b option) ~(absent : 'a -> 'b option) : int =
+  let absent_set : ('b, unit) Hashtbl.t = Hashtbl.create default_capacity in
+  let present_set : ('b, unit) Hashtbl.t = Hashtbl.create default_capacity in
+  List.iter
+    (fun x ->
+      (match absent x with
+       | Some id -> Hashtbl.replace absent_set id ()
+       | None -> ());
+      match present x with
+      | Some id -> Hashtbl.replace present_set id ()
+      | None -> ())
+    xs;
+  Hashtbl.fold
+    (fun id () acc -> if Hashtbl.mem absent_set id then acc else acc + 1)
+    present_set 0

--- a/lib/core/set_util.ml
+++ b/lib/core/set_util.ml
@@ -1,5 +1,7 @@
 (** Hashtbl-as-set membership kernels. See [set_util.mli] for design rationale
-    (Hashtbl over Set.Make: polymorphic key, single-edit future swap). *)
+    (Hashtbl over Set.Make: polymorphic key; [Hashtbl.t] is exposed
+    concretely, so a future [Set.Make] swap would be an API change, not a
+    single-module edit). *)
 
 let default_capacity = 16
 
@@ -7,30 +9,38 @@ let of_list_with (key : 'a -> 'b) (xs : 'a list) : ('b, unit) Hashtbl.t =
   let tbl = Hashtbl.create default_capacity in
   List.iter (fun x -> Hashtbl.replace tbl (key x) ()) xs;
   tbl
+;;
 
 let count_distinct (key : 'a -> 'b option) (xs : 'a list) : int =
   let seen : ('b, unit) Hashtbl.t = Hashtbl.create default_capacity in
   List.iter
     (fun x ->
-      match key x with
-      | Some k -> Hashtbl.replace seen k ()
-      | None -> ())
+       match key x with
+       | Some k -> Hashtbl.replace seen k ()
+       | None -> ())
     xs;
   Hashtbl.length seen
+;;
 
-let count_difference (xs : 'a list)
-    ~(present : 'a -> 'b option) ~(absent : 'a -> 'b option) : int =
+let count_difference
+      (xs : 'a list)
+      ~(present : 'a -> 'b option)
+      ~(absent : 'a -> 'b option)
+  : int
+  =
   let absent_set : ('b, unit) Hashtbl.t = Hashtbl.create default_capacity in
   let present_set : ('b, unit) Hashtbl.t = Hashtbl.create default_capacity in
   List.iter
     (fun x ->
-      (match absent x with
-       | Some id -> Hashtbl.replace absent_set id ()
-       | None -> ());
-      match present x with
-      | Some id -> Hashtbl.replace present_set id ()
-      | None -> ())
+       (match absent x with
+        | Some id -> Hashtbl.replace absent_set id ()
+        | None -> ());
+       match present x with
+       | Some id -> Hashtbl.replace present_set id ()
+       | None -> ())
     xs;
   Hashtbl.fold
     (fun id () acc -> if Hashtbl.mem absent_set id then acc else acc + 1)
-    present_set 0
+    present_set
+    0
+;;

--- a/lib/core/set_util.mli
+++ b/lib/core/set_util.mli
@@ -1,0 +1,31 @@
+(** Set utilities — SSOT for the Hashtbl-as-set membership / set-difference
+    pattern that saturated across perf PRs (telemetry, dedupe, distinct
+    counters).
+
+    Each helper is a one-pass [Hashtbl] kernel. We keep [Hashtbl.t] over
+    [Set.Make(Key)] because (a) callers already pass arbitrary key types
+    (strings, ints, tuples) without a functor instance, and (b) the linear
+    O(N) bucket model matches the existing call sites' allocation profile.
+    A future swap to [Set.Make] is a single-module edit. *)
+
+val of_list_with : ('a -> 'b) -> 'a list -> ('b, unit) Hashtbl.t
+(** [of_list_with key xs] builds a membership set keyed by [key x] for each
+    [x] in [xs]. Duplicates collapse via [Hashtbl.replace]. One linear pass.
+    Default capacity 16 (matches existing call sites). *)
+
+val count_distinct : ('a -> 'b option) -> 'a list -> int
+(** [count_distinct key xs] counts the number of distinct [Some k] values
+    produced by [key] across [xs]. Elements where [key x = None] are
+    ignored. Two-pass equivalent of [List.filter_map key xs |> List.sort_uniq
+    compare |> List.length] but in O(N) time with no intermediate list. *)
+
+val count_difference :
+  'a list ->
+  present:('a -> 'b option) ->
+  absent:('a -> 'b option) ->
+  int
+(** [count_difference xs ~present ~absent] counts distinct keys produced by
+    [present] that are NOT also produced by [absent], in one walk of [xs].
+    Used to model [joined \ left] (active agents) or [started \ completed]
+    (in-progress tasks) over a flat event stream. Replaces O(N x M)
+    [List.filter ... List.mem] pipelines with two linear passes. *)

--- a/lib/core/set_util.mli
+++ b/lib/core/set_util.mli
@@ -6,26 +6,34 @@
     [Set.Make(Key)] because (a) callers already pass arbitrary key types
     (strings, ints, tuples) without a functor instance, and (b) the linear
     O(N) bucket model matches the existing call sites' allocation profile.
-    A future swap to [Set.Make] is a single-module edit. *)
 
-val of_list_with : ('a -> 'b) -> 'a list -> ('b, unit) Hashtbl.t
+    Note: [Hashtbl.t] is exposed concretely in the return type of
+    [of_list_with], so a future swap to [Set.Make] is NOT a single-module
+    edit — it would break callers that hold the table directly. If the
+    backing representation needs to change, hide it behind an abstract
+    type [`'k t`] in this interface first. *)
+
 (** [of_list_with key xs] builds a membership set keyed by [key x] for each
     [x] in [xs]. Duplicates collapse via [Hashtbl.replace]. One linear pass.
     Default capacity 16 (matches existing call sites). *)
+val of_list_with : ('a -> 'b) -> 'a list -> ('b, unit) Hashtbl.t
 
-val count_distinct : ('a -> 'b option) -> 'a list -> int
 (** [count_distinct key xs] counts the number of distinct [Some k] values
     produced by [key] across [xs]. Elements where [key x = None] are
     ignored. Two-pass equivalent of [List.filter_map key xs |> List.sort_uniq
     compare |> List.length] but in O(N) time with no intermediate list. *)
+val count_distinct : ('a -> 'b option) -> 'a list -> int
 
-val count_difference :
-  'a list ->
-  present:('a -> 'b option) ->
-  absent:('a -> 'b option) ->
-  int
 (** [count_difference xs ~present ~absent] counts distinct keys produced by
-    [present] that are NOT also produced by [absent], in one walk of [xs].
-    Used to model [joined \ left] (active agents) or [started \ completed]
-    (in-progress tasks) over a flat event stream. Replaces O(N x M)
-    [List.filter ... List.mem] pipelines with two linear passes. *)
+    [present] that are NOT also produced by [absent]. Implementation: one
+    pass over [xs] populates both the [absent_set] and [present_set]
+    tables, followed by a single [Hashtbl.fold] over [present_set] that
+    skips keys also in [absent_set]. Used to model [joined \ left] (active
+    agents) or [started \ completed] (in-progress tasks) over a flat event
+    stream. Replaces O(N x M) [List.filter ... List.mem] pipelines with
+    O(N) work. *)
+val count_difference
+  :  'a list
+  -> present:('a -> 'b option)
+  -> absent:('a -> 'b option)
+  -> int

--- a/lib/telemetry_eio.ml
+++ b/lib/telemetry_eio.ml
@@ -304,34 +304,11 @@ let read_events_since ?fs config ~since : event_record list =
 
 (** Metrics calculation functions (pure) *)
 
-(* Count distinct elements in [present_set] that are not in [absent_set] —
-   shared kernel for [count_active_agents] (joined \ left) and
-   [count_tasks_in_progress] (started \ completed).  Each event list is
-   walked once into a Hashtbl, then the second pass filters and counts.
-   Replaces the previous O(N x M) [List.filter ... List.mem] + O(N log N)
-   [List.sort_uniq] pipeline with two linear passes. *)
-let count_distinct_set_difference
-    (events : event_record list)
-    ~(present : event_record -> string option)
-    ~(absent : event_record -> string option)
-    : int =
-  let absent_set : (string, unit) Hashtbl.t = Hashtbl.create 16 in
-  let present_set : (string, unit) Hashtbl.t = Hashtbl.create 16 in
-  List.iter (fun r ->
-    (match absent r with
-     | Some id -> Hashtbl.replace absent_set id ()
-     | None -> ());
-    match present r with
-    | Some id -> Hashtbl.replace present_set id ()
-    | None -> ()
-  ) events;
-  Hashtbl.fold
-    (fun id () acc -> if Hashtbl.mem absent_set id then acc else acc + 1)
-    present_set
-    0
-
+(* [count_active_agents] = joined \ left,
+   [count_tasks_in_progress] = started \ completed.
+   Kernel lives in [Set_util.count_difference] (lib/core/set_util.ml). *)
 let count_active_agents events =
-  count_distinct_set_difference events
+  Set_util.count_difference events
     ~present:(fun r ->
       match r.event with
       | Agent_joined { agent_id; _ } -> Some agent_id
@@ -344,7 +321,7 @@ let count_active_agents events =
       | Error_occurred _ | Tool_called _ | Tool_assigned _ -> None)
 
 let count_tasks_in_progress events =
-  count_distinct_set_difference events
+  Set_util.count_difference events
     ~present:(fun r ->
       match r.event with
       | Task_started { task_id; _ } -> Some task_id

--- a/test/dune
+++ b/test/dune
@@ -758,6 +758,7 @@
         test_goal_store
         test_goal_verification
         test_string_util
+        test_set_util
         test_board_core_payload
         test_board_attachment_meta
         test_board_moderation
@@ -974,6 +975,7 @@
         test_goal_store
         test_goal_verification
         test_string_util
+        test_set_util
         test_board_core_payload
         test_board_attachment_meta
         test_board_moderation

--- a/test/test_set_util.ml
+++ b/test/test_set_util.ml
@@ -1,4 +1,5 @@
-(** Tests for Masc_core.Set_util — Hashtbl-as-set kernels. *)
+(** Tests for [Set_util] (lib/core, [masc_core] is [(wrapped false)]) —
+    Hashtbl-as-set kernels. *)
 
 open Alcotest
 module S = Set_util
@@ -8,6 +9,7 @@ module S = Set_util
 let test_of_list_with_empty () =
   let tbl = S.of_list_with Fun.id [] in
   check int "empty" 0 (Hashtbl.length tbl)
+;;
 
 let test_of_list_with_dedupes () =
   let tbl = S.of_list_with Fun.id [ "a"; "b"; "a"; "c"; "b" ] in
@@ -16,90 +18,112 @@ let test_of_list_with_dedupes () =
   check bool "b present" true (Hashtbl.mem tbl "b");
   check bool "c present" true (Hashtbl.mem tbl "c");
   check bool "z absent" false (Hashtbl.mem tbl "z")
+;;
 
 let test_of_list_with_key_projection () =
-  let tbl = S.of_list_with fst [ (1, "x"); (2, "y"); (1, "z") ] in
+  let tbl = S.of_list_with fst [ 1, "x"; 2, "y"; 1, "z" ] in
   check int "distinct ints" 2 (Hashtbl.length tbl);
   check bool "1 present" true (Hashtbl.mem tbl 1);
   check bool "2 present" true (Hashtbl.mem tbl 2)
+;;
 
 (* ---------- count_distinct ---------- *)
 
 let test_count_distinct_empty () =
   check int "empty" 0 (S.count_distinct (fun _ -> Some 0) [])
+;;
 
 let test_count_distinct_all_some () =
-  check int "all distinct" 3
-    (S.count_distinct (fun x -> Some x) [ 1; 2; 3 ])
+  check int "all distinct" 3 (S.count_distinct (fun x -> Some x) [ 1; 2; 3 ])
+;;
 
 let test_count_distinct_duplicates_counted_once () =
-  check int "dup collapsed" 2
-    (S.count_distinct (fun x -> Some x) [ "a"; "b"; "a"; "a" ])
+  check int "dup collapsed" 2 (S.count_distinct (fun x -> Some x) [ "a"; "b"; "a"; "a" ])
+;;
 
 let test_count_distinct_none_skipped () =
-  check int "None skipped" 2
-    (S.count_distinct
-       (fun x -> if x mod 2 = 0 then Some x else None)
-       [ 1; 2; 3; 4; 5 ])
+  check
+    int
+    "None skipped"
+    2
+    (S.count_distinct (fun x -> if x mod 2 = 0 then Some x else None) [ 1; 2; 3; 4; 5 ])
+;;
 
 (* ---------- count_difference ---------- *)
 
 (* Mini event model isomorphic to telemetry_eio's joined/left flow. *)
-type ev = Joined of string | Left of string | Other
+type ev =
+  | Joined of string
+  | Left of string
+  | Other
 
-let present = function Joined id -> Some id | Left _ | Other -> None
-let absent = function Left id -> Some id | Joined _ | Other -> None
+let present = function
+  | Joined id -> Some id
+  | Left _ | Other -> None
+;;
+
+let absent = function
+  | Left id -> Some id
+  | Joined _ | Other -> None
+;;
 
 let test_count_difference_empty () =
   check int "empty" 0 (S.count_difference [] ~present ~absent)
+;;
 
 let test_count_difference_all_present_no_absent () =
   let events = [ Joined "a"; Joined "b"; Joined "c" ] in
   check int "all present" 3 (S.count_difference events ~present ~absent)
+;;
 
 let test_count_difference_some_absent () =
   (* a joined+left, b joined, c joined+left, d joined → diff = {b, d} = 2 *)
-  let events =
-    [ Joined "a"; Joined "b"; Left "a"; Joined "c"; Left "c"; Joined "d" ]
-  in
+  let events = [ Joined "a"; Joined "b"; Left "a"; Joined "c"; Left "c"; Joined "d" ] in
   check int "joined \\ left" 2 (S.count_difference events ~present ~absent)
+;;
 
 let test_count_difference_duplicate_present () =
   (* a joined twice, never left → still 1 *)
   let events = [ Joined "a"; Joined "a"; Joined "a" ] in
-  check int "dup present collapsed" 1
-    (S.count_difference events ~present ~absent)
+  check int "dup present collapsed" 1 (S.count_difference events ~present ~absent)
+;;
 
 let test_count_difference_present_after_absent () =
   (* absent recorded first; if present key matches, still excluded.
      Models a late-join after Left was emitted. Set-difference is
      order-independent over the full event list. *)
   let events = [ Left "a"; Joined "a" ] in
-  check int "absent dominates" 0
-    (S.count_difference events ~present ~absent)
+  check int "absent dominates" 0 (S.count_difference events ~present ~absent)
+;;
 
 (* ---------- Test runner ---------- *)
 
 let () =
-  run "set_util"
-    [ ( "of_list_with",
-        [ test_case "empty" `Quick test_of_list_with_empty;
-          test_case "dedupes" `Quick test_of_list_with_dedupes;
-          test_case "key projection" `Quick test_of_list_with_key_projection
-        ] );
-      ( "count_distinct",
-        [ test_case "empty" `Quick test_count_distinct_empty;
-          test_case "all some" `Quick test_count_distinct_all_some;
-          test_case "duplicates counted once" `Quick
-            test_count_distinct_duplicates_counted_once;
-          test_case "None skipped" `Quick test_count_distinct_none_skipped ]
-      );
-      ( "count_difference",
-        [ test_case "empty" `Quick test_count_difference_empty;
-          test_case "all present no absent" `Quick
-            test_count_difference_all_present_no_absent;
-          test_case "some absent" `Quick test_count_difference_some_absent;
-          test_case "duplicate present" `Quick
-            test_count_difference_duplicate_present;
-          test_case "absent dominates" `Quick
-            test_count_difference_present_after_absent ] ) ]
+  run
+    "set_util"
+    [ ( "of_list_with"
+      , [ test_case "empty" `Quick test_of_list_with_empty
+        ; test_case "dedupes" `Quick test_of_list_with_dedupes
+        ; test_case "key projection" `Quick test_of_list_with_key_projection
+        ] )
+    ; ( "count_distinct"
+      , [ test_case "empty" `Quick test_count_distinct_empty
+        ; test_case "all some" `Quick test_count_distinct_all_some
+        ; test_case
+            "duplicates counted once"
+            `Quick
+            test_count_distinct_duplicates_counted_once
+        ; test_case "None skipped" `Quick test_count_distinct_none_skipped
+        ] )
+    ; ( "count_difference"
+      , [ test_case "empty" `Quick test_count_difference_empty
+        ; test_case
+            "all present no absent"
+            `Quick
+            test_count_difference_all_present_no_absent
+        ; test_case "some absent" `Quick test_count_difference_some_absent
+        ; test_case "duplicate present" `Quick test_count_difference_duplicate_present
+        ; test_case "absent dominates" `Quick test_count_difference_present_after_absent
+        ] )
+    ]
+;;

--- a/test/test_set_util.ml
+++ b/test/test_set_util.ml
@@ -1,0 +1,105 @@
+(** Tests for Masc_core.Set_util — Hashtbl-as-set kernels. *)
+
+open Alcotest
+module S = Set_util
+
+(* ---------- of_list_with ---------- *)
+
+let test_of_list_with_empty () =
+  let tbl = S.of_list_with Fun.id [] in
+  check int "empty" 0 (Hashtbl.length tbl)
+
+let test_of_list_with_dedupes () =
+  let tbl = S.of_list_with Fun.id [ "a"; "b"; "a"; "c"; "b" ] in
+  check int "distinct keys" 3 (Hashtbl.length tbl);
+  check bool "a present" true (Hashtbl.mem tbl "a");
+  check bool "b present" true (Hashtbl.mem tbl "b");
+  check bool "c present" true (Hashtbl.mem tbl "c");
+  check bool "z absent" false (Hashtbl.mem tbl "z")
+
+let test_of_list_with_key_projection () =
+  let tbl = S.of_list_with fst [ (1, "x"); (2, "y"); (1, "z") ] in
+  check int "distinct ints" 2 (Hashtbl.length tbl);
+  check bool "1 present" true (Hashtbl.mem tbl 1);
+  check bool "2 present" true (Hashtbl.mem tbl 2)
+
+(* ---------- count_distinct ---------- *)
+
+let test_count_distinct_empty () =
+  check int "empty" 0 (S.count_distinct (fun _ -> Some 0) [])
+
+let test_count_distinct_all_some () =
+  check int "all distinct" 3
+    (S.count_distinct (fun x -> Some x) [ 1; 2; 3 ])
+
+let test_count_distinct_duplicates_counted_once () =
+  check int "dup collapsed" 2
+    (S.count_distinct (fun x -> Some x) [ "a"; "b"; "a"; "a" ])
+
+let test_count_distinct_none_skipped () =
+  check int "None skipped" 2
+    (S.count_distinct
+       (fun x -> if x mod 2 = 0 then Some x else None)
+       [ 1; 2; 3; 4; 5 ])
+
+(* ---------- count_difference ---------- *)
+
+(* Mini event model isomorphic to telemetry_eio's joined/left flow. *)
+type ev = Joined of string | Left of string | Other
+
+let present = function Joined id -> Some id | Left _ | Other -> None
+let absent = function Left id -> Some id | Joined _ | Other -> None
+
+let test_count_difference_empty () =
+  check int "empty" 0 (S.count_difference [] ~present ~absent)
+
+let test_count_difference_all_present_no_absent () =
+  let events = [ Joined "a"; Joined "b"; Joined "c" ] in
+  check int "all present" 3 (S.count_difference events ~present ~absent)
+
+let test_count_difference_some_absent () =
+  (* a joined+left, b joined, c joined+left, d joined → diff = {b, d} = 2 *)
+  let events =
+    [ Joined "a"; Joined "b"; Left "a"; Joined "c"; Left "c"; Joined "d" ]
+  in
+  check int "joined \\ left" 2 (S.count_difference events ~present ~absent)
+
+let test_count_difference_duplicate_present () =
+  (* a joined twice, never left → still 1 *)
+  let events = [ Joined "a"; Joined "a"; Joined "a" ] in
+  check int "dup present collapsed" 1
+    (S.count_difference events ~present ~absent)
+
+let test_count_difference_present_after_absent () =
+  (* absent recorded first; if present key matches, still excluded.
+     Models a late-join after Left was emitted. Set-difference is
+     order-independent over the full event list. *)
+  let events = [ Left "a"; Joined "a" ] in
+  check int "absent dominates" 0
+    (S.count_difference events ~present ~absent)
+
+(* ---------- Test runner ---------- *)
+
+let () =
+  run "set_util"
+    [ ( "of_list_with",
+        [ test_case "empty" `Quick test_of_list_with_empty;
+          test_case "dedupes" `Quick test_of_list_with_dedupes;
+          test_case "key projection" `Quick test_of_list_with_key_projection
+        ] );
+      ( "count_distinct",
+        [ test_case "empty" `Quick test_count_distinct_empty;
+          test_case "all some" `Quick test_count_distinct_all_some;
+          test_case "duplicates counted once" `Quick
+            test_count_distinct_duplicates_counted_once;
+          test_case "None skipped" `Quick test_count_distinct_none_skipped ]
+      );
+      ( "count_difference",
+        [ test_case "empty" `Quick test_count_difference_empty;
+          test_case "all present no absent" `Quick
+            test_count_difference_all_present_no_absent;
+          test_case "some absent" `Quick test_count_difference_some_absent;
+          test_case "duplicate present" `Quick
+            test_count_difference_duplicate_present;
+          test_case "absent dominates" `Quick
+            test_count_difference_present_after_absent ] ) ]


### PR DESCRIPTION
## 배경

지난 23 perf PR 중 13건이 동일한 Hashtbl-as-set 패턴을 inline으로 반복했다:

```ocaml
let seen = Hashtbl.create N in
List.iter (fun x -> Hashtbl.replace seen (key x) ()) xs;
... Hashtbl.mem seen y ...
```

또는 twin Hashtbl set-difference (`present \ absent`). `Hashtbl.t`가 `Set.Make(String).t` / `Set.Make(Int).t`처럼 쓰이는 것. self-evaluation에서 P1 break-out 누락으로 플래그됨.

## 변경

### 1. `lib/core/set_util.{ml,mli}` 신설

`lib/core/`는 이미 `list_util`, `string_util`, `json_util` 등 util 모듈의 home — `masc_core` (wrapped=false) 안에 `set_util` 추가.

API:

```ocaml
val of_list_with : ('a -> 'b) -> 'a list -> ('b, unit) Hashtbl.t
val count_distinct : ('a -> 'b option) -> 'a list -> int
val count_difference :
  'a list ->
  present:('a -> 'b option) ->
  absent:('a -> 'b option) ->
  int
```

- Polymorphic key, no provider/domain assumption
- `Hashtbl.create 16` default (matches saturated call sites)
- mli에 `Set.Make` 미선택 사유 명시 (polymorphic key, future single-edit swap)

### 2. Migration (surgical, 시그니처 보존)

`lib/telemetry_eio.ml`:
- 로컬 `count_distinct_set_difference` 제거
- `count_active_agents` (joined \\ left), `count_tasks_in_progress` (started \\ completed) 두 call site가 `Set_util.count_difference`를 직접 호출
- public 시그니처 (`event_record list -> int`) 변경 없음

### 3. Tests

`test/test_set_util.ml`: 12 case
- `of_list_with`: empty / dedupes / key projection
- `count_distinct`: empty / all some / dup once / None skip
- `count_difference`: empty / all present / some absent / dup / absent dominates

`test/dune`의 2개 stanza에 `test_set_util` 등록 (다른 test_* 모듈과 동일 패턴).

## 검증

```bash
$ dune build --root .             # clean
$ ./_build/default/test/test_set_util.exe
Test Successful in 0.002s. 12 tests run.
$ ./_build/default/test/test_telemetry_eio_coverage.exe
Test Successful in 0.014s. 38 tests run.
# (count_active_agents 4건 + count_tasks_in_progress 3건 = 7건 영향 모두 green)
```

## Diff stat

```
 lib/core/dune        |  2 +-
 lib/core/set_util.ml | 36 ++++++++++++++++++
 lib/core/set_util.mli| 33 ++++++++++++++++
 lib/telemetry_eio.ml | 33 +++++----------------------------
 test/dune            |  2 ++
 test/test_set_util.ml| 103 ++++++++++++++++++++++++++++++
 6 files changed, 180 insertions(+), 29 deletions(-)
```

## 향후

추가 saturated site (`lib/coord/coord_task_schedule.ml::build_allowed_set`, `lib/coord/coord_task_classify.ml::allowed_set`, `lib/tool_catalog.ml::public_mcp_set` 등)은 별도 PR에서 1-line으로 마이그레이션 가능.

## Workaround Rejection Bar self-check

이 PR은 워크어라운드 시그니처 3종 어느 것도 해당하지 않음:
- 텔레메트리-as-fix 아님 (구조적 SSOT 추출)
- string/substring 분류기 아님 (타입 보존)
- N-of-M 패치 아님 (kernel을 하나의 모듈로 통합, 향후 sites는 동일 helper 사용)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>