### PR TITLE
refactor(cascade-transport): capability-driven bridged runtime MCP policy — RFC-0058 §2.4 leak fix

### DIFF
--- a/lib/cascade/cascade_transport.ml
+++ b/lib/cascade/cascade_transport.ml
@@ -398,31 +398,32 @@ let codex_cli_can_auth_keeper_bound_runtime_mcp ~agent_name policy =
   && Option.is_some (per_keeper_authorization_header ~agent_name)
 ;;
 
-(* RFC-0058 §2.4 capability-driven projection: dispatch by [tool_policy]
-   flags, never by provider name.  When the adapter cannot carry arbitrary
-   per-request HTTP headers ([supports_runtime_mcp_http_headers = false]),
-   strip every header and re-inject only the non-secret MASC identity
-   headers plus the per-keeper [Authorization: Bearer ...] derived from
-   [bearer_token_env_var].  When the adapter does support per-request
-   headers, the inbound policy is preserved aside from the authorization
-   replacement.  Codex CLI is currently the only adapter whose tool_policy
-   reaches this function, but the body has zero codex-specific references
-   so a future bridging-required adapter inherits the same projection
-   automatically. *)
-let bridged_runtime_mcp_policy_for_agent
-      ~(supports_runtime_mcp_http_headers : bool)
-      ~agent_name
-      (policy : Llm_provider.Llm_transport.runtime_mcp_policy)
-  : Llm_provider.Llm_transport.runtime_mcp_policy
-  =
-  let projected =
-    if supports_runtime_mcp_http_headers
-    then policy
-    else
-      runtime_mcp_policy_without_http_headers policy
-      |> runtime_mcp_policy_with_masc_agent_name
-           ~include_internal_token:false
-           ~agent_name
+(* RFC-0058 §2.4 capability-driven projection.  Strip the inbound
+   policy's HTTP headers and re-inject only the non-secret MASC identity
+   headers, then attach the per-keeper [Authorization] header sourced
+   from [Auth.load_raw_token] via [per_keeper_authorization_header] when
+   the inbound policy uses bound-actor tools, otherwise the existing
+   authorization header from the policy.
+
+   Invariant: this function is only reached from the dispatch site when
+   [Provider_adapter.requires_per_keeper_bridging_for_bound_actor_tools_
+   for_config = true], i.e. the adapter cannot carry arbitrary per-
+   request HTTP headers.  Body is intentionally identical in semantics
+   to the prior [codex_runtime_mcp_policy_for_agent] — the rename
+   removes the provider-name leak from the dispatch site without
+   altering behavior.
+
+   A future adapter with [requires_per_keeper_bridging = true] but
+   different transport semantics (e.g. native per-keeper header
+   injection) should be handled by an explicit dispatch arm at the
+   call site, not by adding a new flag parameter here — adding such
+   a flag now would introduce a code path no current provider exercises
+   and risks a silent header-preservation regression (see Copilot
+   review of PR #14885). *)
+let bridged_runtime_mcp_policy_for_agent ~agent_name policy =
+  let stripped =
+    runtime_mcp_policy_without_http_headers policy
+    |> runtime_mcp_policy_with_masc_agent_name ~include_internal_token:false ~agent_name
   in
   let authorization_header =
     if runtime_mcp_policy_uses_bound_actor_tools policy
@@ -430,8 +431,8 @@ let bridged_runtime_mcp_policy_for_agent
     else authorization_header_from_policy policy
   in
   match authorization_header with
-  | Some header -> add_masc_authorization_header header projected
-  | None -> projected
+  | Some header -> add_masc_authorization_header header stripped
+  | None -> stripped
 ;;
 
 let runtime_mcp_policy_for_provider
@@ -443,30 +444,21 @@ let runtime_mcp_policy_for_provider
     let trimmed = String.trim agent_name in
     if String.equal trimmed "" then None else Some trimmed
   in
-  (* Dispatch by capability flags from [Provider_adapter.tool_policy], not
+  (* Dispatch by capability flag from [Provider_adapter.tool_policy], not
      by provider name (RFC-0058 §2.4).  [requires_per_keeper_bridging]
      gates the strip-and-bridge path; Codex CLI is currently the only
-     adapter that returns [true], but the projection generalises to any
-     future provider whose CLI cannot carry per-request HTTP headers. *)
+     adapter that returns [true]. *)
   let requires_per_keeper_bridging =
     Provider_adapter
     .requires_per_keeper_bridging_for_bound_actor_tools_for_config
       provider_cfg
   in
-  let supports_runtime_mcp_http_headers =
-    Provider_adapter.supports_runtime_mcp_http_headers_for_config provider_cfg
-  in
   match policy_opt, requires_per_keeper_bridging, agent_name with
   | Some policy, true, Some agent_name ->
-    (* Per-request HTTP headers are projected out (when the adapter cannot
-         carry them) and only MASC identity headers plus the per-keeper
-         [Authorization: Bearer ...] survive — so runtime MCP tools still
-         authenticate without leaking secrets via argv. *)
-    Some
-      (bridged_runtime_mcp_policy_for_agent
-         ~supports_runtime_mcp_http_headers
-         ~agent_name
-         policy)
+    (* Per-request HTTP headers are stripped and only MASC identity headers
+         plus the per-keeper [Authorization] header survive — so runtime MCP
+         tools still authenticate without leaking secrets via argv. *)
+    Some (bridged_runtime_mcp_policy_for_agent ~agent_name policy)
   | Some policy, true, None ->
     (* No agent_name to inject — preserve the legacy strip-all behavior. *)
     Some (runtime_mcp_policy_without_http_headers policy)

--- a/lib/cascade/cascade_transport.ml
+++ b/lib/cascade/cascade_transport.ml
@@ -398,12 +398,27 @@ let codex_cli_can_auth_keeper_bound_runtime_mcp ~agent_name policy =
   && Option.is_some (per_keeper_authorization_header ~agent_name)
 ;;
 
-(* RFC-0058 §2.4 capability-driven projection.  Strip the inbound
-   policy's HTTP headers and re-inject only the non-secret MASC identity
-   headers, then attach the per-keeper [Authorization] header sourced
-   from [Auth.load_raw_token] via [per_keeper_authorization_header] when
-   the inbound policy uses bound-actor tools, otherwise the existing
-   authorization header from the policy.
+(* RFC-0058 §2.4 capability-driven projection.
+
+   Header lifecycle (in this order, no early exits):
+   1. [runtime_mcp_policy_without_http_headers] strips ALL HTTP headers
+      from every [Http_server] in the policy. This step is
+      unconditional — any inbound [Authorization] is gone before any
+      decision below.
+   2. [runtime_mcp_policy_with_masc_agent_name] re-injects only the
+      non-secret MASC identity headers.
+   3. The [Authorization] header is then sourced from one of two
+      branches:
+        - if [runtime_mcp_policy_uses_bound_actor_tools policy = true],
+          from [Auth.load_raw_token] via
+          [per_keeper_authorization_header ~agent_name];
+        - else, read from the *inbound* policy's [name = "masc"]
+          [Http_server] entry via [authorization_header_from_policy]
+          (which reads [policy.servers], not [stripped.servers], so it
+          recovers the MASC bearer that the caller provided).
+      When either branch yields [None], the returned policy carries no
+      [Authorization] header — there is no fall-through to the inbound
+      policy's non-masc headers, which were removed in step 1.
 
    Invariant: this function is only reached from the dispatch site when
    [Provider_adapter.requires_per_keeper_bridging_for_bound_actor_tools_

--- a/lib/cascade/cascade_transport.ml
+++ b/lib/cascade/cascade_transport.ml
@@ -398,10 +398,31 @@ let codex_cli_can_auth_keeper_bound_runtime_mcp ~agent_name policy =
   && Option.is_some (per_keeper_authorization_header ~agent_name)
 ;;
 
-let codex_runtime_mcp_policy_for_agent ~agent_name policy =
-  let stripped =
-    runtime_mcp_policy_without_http_headers policy
-    |> runtime_mcp_policy_with_masc_agent_name ~include_internal_token:false ~agent_name
+(* RFC-0058 §2.4 capability-driven projection: dispatch by [tool_policy]
+   flags, never by provider name.  When the adapter cannot carry arbitrary
+   per-request HTTP headers ([supports_runtime_mcp_http_headers = false]),
+   strip every header and re-inject only the non-secret MASC identity
+   headers plus the per-keeper [Authorization: Bearer ...] derived from
+   [bearer_token_env_var].  When the adapter does support per-request
+   headers, the inbound policy is preserved aside from the authorization
+   replacement.  Codex CLI is currently the only adapter whose tool_policy
+   reaches this function, but the body has zero codex-specific references
+   so a future bridging-required adapter inherits the same projection
+   automatically. *)
+let bridged_runtime_mcp_policy_for_agent
+      ~(supports_runtime_mcp_http_headers : bool)
+      ~agent_name
+      (policy : Llm_provider.Llm_transport.runtime_mcp_policy)
+  : Llm_provider.Llm_transport.runtime_mcp_policy
+  =
+  let projected =
+    if supports_runtime_mcp_http_headers
+    then policy
+    else
+      runtime_mcp_policy_without_http_headers policy
+      |> runtime_mcp_policy_with_masc_agent_name
+           ~include_internal_token:false
+           ~agent_name
   in
   let authorization_header =
     if runtime_mcp_policy_uses_bound_actor_tools policy
@@ -409,8 +430,8 @@ let codex_runtime_mcp_policy_for_agent ~agent_name policy =
     else authorization_header_from_policy policy
   in
   match authorization_header with
-  | Some header -> add_masc_authorization_header header stripped
-  | None -> stripped
+  | Some header -> add_masc_authorization_header header projected
+  | None -> projected
 ;;
 
 let runtime_mcp_policy_for_provider
@@ -422,22 +443,30 @@ let runtime_mcp_policy_for_provider
     let trimmed = String.trim agent_name in
     if String.equal trimmed "" then None else Some trimmed
   in
-  (* Codex CLI's [requires_per_keeper_bridging_for_bound_actor_tools = true]
-     is the capability flag that gates the legacy strip-and-bridge path; see
-     [Provider_adapter.codex_cli_tool_policy].  Other providers either carry
-     headers natively or do not need bridging. *)
+  (* Dispatch by capability flags from [Provider_adapter.tool_policy], not
+     by provider name (RFC-0058 §2.4).  [requires_per_keeper_bridging]
+     gates the strip-and-bridge path; Codex CLI is currently the only
+     adapter that returns [true], but the projection generalises to any
+     future provider whose CLI cannot carry per-request HTTP headers. *)
   let requires_per_keeper_bridging =
     Provider_adapter
     .requires_per_keeper_bridging_for_bound_actor_tools_for_config
       provider_cfg
   in
+  let supports_runtime_mcp_http_headers =
+    Provider_adapter.supports_runtime_mcp_http_headers_for_config provider_cfg
+  in
   match policy_opt, requires_per_keeper_bridging, agent_name with
   | Some policy, true, Some agent_name ->
-    (* Codex CLI still cannot carry arbitrary per-request headers, but OAS
-         routes [Authorization: Bearer ...] through [bearer_token_env_var].
-         Keep only that auth path plus non-secret identity headers so Codex can
-         pre-approve runtime MCP tools without leaking tokens through argv. *)
-    Some (codex_runtime_mcp_policy_for_agent ~agent_name policy)
+    (* Per-request HTTP headers are projected out (when the adapter cannot
+         carry them) and only MASC identity headers plus the per-keeper
+         [Authorization: Bearer ...] survive — so runtime MCP tools still
+         authenticate without leaking secrets via argv. *)
+    Some
+      (bridged_runtime_mcp_policy_for_agent
+         ~supports_runtime_mcp_http_headers
+         ~agent_name
+         policy)
   | Some policy, true, None ->
     (* No agent_name to inject — preserve the legacy strip-all behavior. *)
     Some (runtime_mcp_policy_without_http_headers policy)


### PR DESCRIPTION
## Why

R440 of PR #14867 review surfaced that `cascade_transport.ml` still calls `codex_runtime_mcp_policy_for_agent` from a *generic, capability-driven* dispatch site:

```ocaml
let requires_per_keeper_bridging =
  Provider_adapter.requires_per_keeper_bridging_for_bound_actor_tools_for_config provider_cfg
in
match policy_opt, requires_per_keeper_bridging, agent_name with
| Some policy, true, Some agent_name ->
    Some (codex_runtime_mcp_policy_for_agent ~agent_name policy)  (* ← leaky *)
```

The capability flag is generic but the projection function name asserts a specific vendor. RFC-0058 §2.4 states *"Code dispatches by `api_format`, never by provider name"* — the function body had zero codex-specific logic, so the leak is in the *name*, not the behavior.

## What (final, after review iteration)

- Rename `codex_runtime_mcp_policy_for_agent` → `bridged_runtime_mcp_policy_for_agent`.
- Body kept *identical in semantics* to the prior function: **unconditional** strip of all HTTP headers → re-inject only MASC identity headers → set `Authorization` from `per_keeper_authorization_header` (bound-actor path, via `Auth.load_raw_token`) or from `authorization_header_from_policy` (non-bound-actor path, reads the inbound policy's `name = "masc"` slot).
- Dispatch site still gates only on `requires_per_keeper_bridging_for_bound_actor_tools_for_config` — `supports_runtime_mcp_http_headers_for_config` is **not** consulted at the dispatch site. The first revision of this PR added that lookup alongside a flag-driven body, but Yagni revert in `21a6708f3` removed both, since:
  - No current adapter has `requires_per_keeper_bridging = true && supports_runtime_mcp_http_headers = true` (Codex CLI is `false`/`true`); a flag gating a branch that no provider exercises is premature generalization.
  - A future adapter with different transport semantics belongs in a *separate dispatch arm* at the call site, not a new flag parameter on the projection function (see `bridged_runtime_mcp_policy_for_agent` docstring after `83e4c5fe5`).
- Body has zero `codex` references — name, comment, string, or otherwise.

## Semantics preservation

Codex CLI's `tool_policy` (`supports_runtime_mcp_http_headers = false`, `requires_per_keeper_bridging = true`) reaches the dispatch arm and the projection body produces *identical output* to the prior `codex_runtime_mcp_policy_for_agent`.  No behavior change.

## Commit lineage

| Commit | Role |
|---|---|
| `aef4d731d` | Initial rename + flag-driven body (Yagni-violating; superseded) |
| `21a6708f3` | Drop `~supports_runtime_mcp_http_headers` flag, unconditional strip restored |
| `83e4c5fe5` | Docstring rewritten to enumerate three-step header lifecycle; invariant made explicit. Addresses Copilot review threads 1+2 (false positives in retrospect once the Yagni revert was in place) |

## Scope

Internal helper only — function is not exported via `.mli`, so no public API change. Sibling `codex_cli_*` functions remain in this PR:

| Function | Scope | Why deferred |
|---|---|---|
| `codex_cli_can_auth_keeper_bound_runtime_mcp` | 3 callers (`cascade_runner`, `cascade_oas_runner`, `test_per_keeper_token_fallback`) | Cross-module rename — separate PR |
| `codex_cli_cannot_carry_keeper_bound_runtime_mcp` | `cascade_oas_runner` only | Sibling generalisation — separate PR |

## Verification

```
dune build lib/ bin/                            → clean
test_per_keeper_token_fallback (5 tests)        → all pass
test_oas_worker                                 → 10 pre-existing failures unchanged
                                                  (MASC_CONFIG_DIR fixture, not transport-related)
ocamlformat-check                               → fail on pre-existing in-file violations
                                                  (lines 32-33, 452-453, 697-700, 1745-1750
                                                   from commits 29b1b2d1e/9faabfadf; not
                                                   introduced by this PR; advisory per
                                                   masc-mcp policy)
```

## Relation to PR #14867

PR #14867 (cascade observability + hardening, 50 commits) is now merged. This PR is the surgical follow-up requested at review on R440 of #14867. Branched from `origin/main`; no rebase needed.

## RFC reference

- RFC-0058 §2.4 — capability-driven dispatch
- RFC-0058 Phase 5 (erase provider variant) — same spirit; this PR closes a leak the Phase 5 audit did not enumerate

🤖 Generated with [Claude Code](https://claude.com/claude-code)