### PR TITLE
docs(keeper): R-H-1.e OCaml docstring 12→13 phase count + history (iter 54)

### DIFF
--- a/lib/keeper/keeper_composite_observer.ml
+++ b/lib/keeper/keeper_composite_observer.ml
@@ -254,9 +254,10 @@ let invariant_key_of_string = function
 
 (* Derivation from registry entry *)
 
-(* Exhaustive on [Keeper_state_machine.phase]: maps the raw 12-state
-   keeper phase to the turn phase projection when no live turn
-   observation exists.  Spelling each branch out turns a future phase
+(* Exhaustive on [Keeper_state_machine.phase]: maps the raw 13-state
+   keeper phase (post-Zombie #14707) to the turn phase projection when
+   no live turn observation exists.  Spelling each branch out turns a
+   future phase
    addition into a compile error. *)
 let live_turn_phase (entry : Keeper_registry.registry_entry) =
   match entry.current_turn_observation with

--- a/lib/keeper/keeper_composite_observer.mli
+++ b/lib/keeper/keeper_composite_observer.mli
@@ -175,10 +175,10 @@ type snapshot = {
   run_id : string;
   ts : float;
   phase : Keeper_state_machine.phase;
-      (** Full 12-state keeper phase (RFC-0002). Previously collapsed to
-          a collapsed projection (7 states) for dashboard brevity; now exposed raw
-          so the fleet matrix renders every state with its own chip colour.
-          The 12-state alphabet matches
+      (** Full 13-state keeper phase (RFC-0002, post-Zombie #14707). Previously
+          collapsed to a 7-state projection for dashboard brevity; now exposed
+          raw so the fleet matrix renders every state with its own chip colour.
+          The 13-state alphabet matches
           [specs/keeper-state-machine/KeeperStateMachine.tla] exactly. *)
   ktc_turn_phase : Keeper_registry.packed_turn_phase;
   kdp_decision : Keeper_registry.packed_decision_stage;

--- a/lib/keeper/keeper_exec_status.ml
+++ b/lib/keeper/keeper_exec_status.ml
@@ -590,7 +590,7 @@ let keeper_diagnostic_json
     ]
 
 (** Derive pipeline stage directly from the 13-state phase (RFC-0002,
-    post-Zombie #14707).  Deterministic mapping — no 30s recency heuristic. *)
+    post-Zombie #14707). Deterministic mapping — no 30s recency heuristic. *)
 let pipeline_stage_of_phase (phase : Keeper_state_machine.phase) : string =
   match phase with
   | Keeper_state_machine.Offline -> "offline"

--- a/lib/keeper/keeper_exec_status.ml
+++ b/lib/keeper/keeper_exec_status.ml
@@ -589,8 +589,8 @@ let keeper_diagnostic_json
       ("next_eligible_at_s", keeper_next_eligible_at_s ~meta ~quiet_reason ~now_ts);
     ]
 
-(** Derive pipeline stage directly from the 12-state phase (RFC-0002).
-    Deterministic mapping — no 30s recency heuristic. *)
+(** Derive pipeline stage directly from the 13-state phase (RFC-0002,
+    post-Zombie #14707).  Deterministic mapping — no 30s recency heuristic. *)
 let pipeline_stage_of_phase (phase : Keeper_state_machine.phase) : string =
   match phase with
   | Keeper_state_machine.Offline -> "offline"

--- a/lib/keeper/keeper_state_machine.mli
+++ b/lib/keeper/keeper_state_machine.mli
@@ -7,7 +7,8 @@
       - 11 phases at RFC-0002 Phase 1 introduction (#5229, 2026-04-05)
       - +1 → 12 when [Overflowed] was added (MASC-1, 2026-04)
       - +1 → 13 when [Zombie] was added (#14707, /loop iter 4)
-    SSOT is the [type phase] declaration below; spec doc counts are
+    Single Source of Truth (SSOT) is the [type phase] declaration below;
+    spec doc counts are
     cross-checked by [scripts/audit-tla-phase-count.sh] (R-H-1.c #14874).
 
     Architecture:

--- a/lib/keeper/keeper_state_machine.mli
+++ b/lib/keeper/keeper_state_machine.mli
@@ -1,7 +1,14 @@
 (** Keeper State Machine — Deterministic Core (RFC-0002).
 
-    This module defines the 12-state keeper lifecycle as a pure state machine.
+    This module defines the 13-state keeper lifecycle as a pure state machine.
     All functions are deterministic: no I/O, no clock reads, no mutable state.
+
+    Phase count history:
+      - 11 phases at RFC-0002 Phase 1 introduction (#5229, 2026-04-05)
+      - +1 → 12 when [Overflowed] was added (MASC-1, 2026-04)
+      - +1 → 13 when [Zombie] was added (#14707, /loop iter 4)
+    SSOT is the [type phase] declaration below; spec doc counts are
+    cross-checked by [scripts/audit-tla-phase-count.sh] (R-H-1.c #14874).
 
     Architecture:
     - Layer 3 (NonDet Shell): measurements captured via [Keeper_measurement]


### PR DESCRIPTION
## Finding (Iteration 54, R-H-1.e — OCaml docstring side of 6th drift class)

**Files**: `lib/keeper/keeper_state_machine.mli`, `keeper_composite_observer.{ml,mli}`, `keeper_exec_status.ml`
**Aspect**: 6th drift class has an **OCaml docstring twin** that iter 49-53's TLA+-side sweep missed
**Risk**: LOW (docstring/comment only, no semantic change, no build impact)
**Workaround signature**: N/A — closure follow-up.

## 순서도

```mermaid
flowchart LR
  A[iter 4 #14707<br/>type phase += Zombie<br/>12 → 13 constructors] --> B{Doc sites<br/>updated?}
  B -- 'mli {1 Phase} header' --> C[✓ line 14 updated to 13-State Enum]
  B -- 'mli module summary' --> D[✗ line 3 left as 12-state]
  B -- 'composite_observer.mli phase comment' --> E[✗ line 178+181 left as 12-state]
  B -- 'composite_observer.ml mapping comment' --> F[✗ line 257 left as 12-state]
  B -- 'exec_status.ml docstring' --> G[✗ line 592 left as 12-state]
  B -- 'runtime.ml exhaustive comment' --> H[✓ line 779 'other 12 phases' coincidentally correct - 13-1=12]
  D & E & F & G --> I[iter 54 this PR: fix 4 sites + history line]
```

## Why this exists

iter 49 audit (`docs/tla-audit/rh1b-sweep-zombie-12-phases-stale-2026-05-12.md`) and the iter 49-53 fix chain swept *specs/* only. The same Zombie addition (#14707, /loop iter 4) leaves an OCaml-side analogue:

| Site | State | Reason |
|------|-------|--------|
| `keeper_state_machine.mli:3` | stale "12-state" | Module summary leftover; line 14 `{1 Phase (13-State Enum)}` was updated but line 3 wasn't |
| `keeper_state_machine.mli` (new) | history line added | "11 (#5229) → 12 (Overflowed MASC-1 2026-04) → 13 (Zombie #14707)" with SSOT cross-ref to `audit-tla-phase-count.sh` |
| `keeper_composite_observer.mli:178,181` | stale "Full 12-state" / "12-state alphabet" | Field docstring describing `phase : Keeper_state_machine.phase` |
| `keeper_composite_observer.ml:257` | stale "raw 12-state" | Mapping comment in `live_turn_phase` |
| `keeper_exec_status.ml:592` | stale "12-state phase" | `pipeline_stage_of_phase` docstring |

Intentionally not touched: `keeper_runtime.ml:779` — `"the other 12 phases must skip ..."` is contextually correct (excludes Running; 13 − 1 = 12 with the enumeration on surrounding lines listing exactly 12 non-Running constructors).

## Pipeline relationship to 6th drift class

| Step | iter | PR | Side |
|------|------|----|------|
| 1 (audit) | 49 | #14858 ✅ | TLA+ spec |
| 2 (batch) | 50 | #14863 ✅ | TLA+ spec |
| 2.5 (per-spec) | 51 | #14865 ✅ | TLA+ spec |
| 3 (validator) | 52 | #14874 Draft | TLA+ spec (CI guard) |
| 3.5 (disambig) | 53 | #14877 Draft | TLA+ spec |
| **4 (OCaml side)** | **54** | **this PR** | **OCaml docstring** |

Cross-language audit script (sweep `lib/keeper/*.{ml,mli}` against the same SSOT count) is a candidate follow-up but **not in scope** here — would expand `audit-tla-phase-count.sh` beyond its name implies, or warrant a separate script. Out of scope to keep this PR's blast radius minimal.

## Verification

```bash
$ rg "12[ -]state|12[ -]phase|12 phases" lib/keeper/
lib/keeper/keeper_runtime.ml:779:                 12 phases must skip (a Stopped/Crashed/Dead/Zombie

# Only the intentional runtime.ml mention remains.
```

No semantic change. dune build NOT re-run (8-datapoint honest-doc precedent: iter 27/35/37/39/48/50/51/53). Build impact = 0 since these are `(** ... *)` and `(* ... *)` blocks only.

## Phase count history line (new)

Added to `keeper_state_machine.mli` module docstring:

```ocaml
    Phase count history:
      - 11 phases at RFC-0002 Phase 1 introduction (#5229, 2026-04-05)
      - +1 → 12 when [Overflowed] was added (MASC-1, 2026-04)
      - +1 → 13 when [Zombie] was added (#14707, /loop iter 4)
    SSOT is the [type phase] declaration below; spec doc counts are
    cross-checked by [scripts/audit-tla-phase-count.sh] (R-H-1.c #14874).
```

Rationale: phase count evolution is otherwise only reconstructable via `git log -S 'type phase ='` archaeology. Embedding the brief history in the .mli docstring puts it where future readers naturally look. SSOT cross-reference points at the iter 52 validator so the history line and the structural guard stay aligned.

Discovery anchor: the original RFC-0002 Phase 1 commit message was `feat(keeper): 10-state machine with det/nondet boundary` — but the code actually introduced **11** constructors. That commit-message-vs-code drift is the original instance of the 6th drift class (predates Zombie addition). The history line embeds the truth.

## RFC 참조

RFC-WAIVED: docstring-only, no semantics change. 9th honest-doc datapoint, first one crossing OCaml/TLA+ language boundary.

## 진행 추적

6th drift class fully closed across both sides:
- TLA+ spec: iter 49-53 (5 PRs)
- OCaml docstring: iter 54 (this PR)
- Cross-language audit script: out of scope (defer)

다음 iteration 시작점: **R-D-2.a + R-D-1.a bundle** (biggest pending, MID ~150-300 LOC) OR **R-D-1.d** (ppx_tla prefix prerequisite) OR **R-B-2.a/b** (KTC RoutingStart + TLC dry-run).

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
