### PR TITLE
fix(keeper_registry): make set_turn_decision_stage's forbidden _to_undecided unrepresentable

### DIFF
--- a/lib/keeper/keeper_registry.ml
+++ b/lib/keeper/keeper_registry.ml
@@ -337,6 +337,25 @@ let stage_to_witness : decision_stage -> packed_decision_stage = function
   | Decision_tool_policy_selected -> Packed Decision_tool_policy_selected
 ;;
 
+(* Decision stages valid as ADVANCE targets within a turn.
+   Excludes [Decision_undecided] (the initial state, set only by
+   [mark_turn_started] / [mark_sdk_turn_started]).  The 3 spec-forbidden
+   [<active>_to_undecided] transitions are unrepresentable through this
+   type, replacing the prior runtime [invalid_arg] inside
+   [set_turn_decision_stage]. *)
+type decision_stage_active =
+  | Decision_active_guard_ok
+  | Decision_active_gate_rejected
+  | Decision_active_tool_policy_selected
+
+let decision_stage_active_to_packed
+    : decision_stage_active -> packed_decision_stage
+  = function
+  | Decision_active_guard_ok -> Packed Decision_guard_ok
+  | Decision_active_gate_rejected -> Packed Decision_gate_rejected
+  | Decision_active_tool_policy_selected -> Packed Decision_tool_policy_selected
+;;
+
 (* Diagnostic label for invalid-transition error messages.  Mirrors
    [decision_stage]; constructor changes will fail compilation here. *)
 let packed_decision_stage_label : packed_decision_stage -> string = function
@@ -1320,48 +1339,27 @@ let validate_turn_phase_transition ~from ~to_ =
               (packed_turn_phase_label to_)))
 ;;
 
-let set_turn_decision_stage ~base_path name decision_stage =
-  let target_packed = stage_to_witness decision_stage in
+let set_turn_decision_stage ~base_path name (decision_stage : decision_stage_active) =
+  (* Spec invariant: the 3 [<active>_to_undecided] transitions are forbidden
+     within a turn.  Previously enforced at runtime via [invalid_arg] inside
+     a 16-pair match; now unrepresentable through the [decision_stage_active]
+     input type, so the matrix collapses to a simple equality check.  All
+     12 remaining (from, to) pairs (4 from-states × 3 non-Undecided targets)
+     share identical action: idempotent on equality, otherwise replace.
+     [Decision_transition] (module above) enumerates the 9 valid cross-state
+     transitions; the GADT remains available for future per-transition
+     dispatch but is not needed here since this setter has no per-pair
+     side effects. *)
+  let target_packed = decision_stage_active_to_packed decision_stage in
   let changed = ref false in
   let now = Time_compat.now () in
   update_entry ~base_path name (fun e ->
     update_current_turn e (fun obs ->
-      match obs.decision_stage, target_packed with
-      | Packed Decision_undecided, Packed Decision_undecided -> obs
-      | Packed Decision_undecided, Packed Decision_guard_ok ->
+      if obs.decision_stage = target_packed
+      then obs
+      else (
         changed := true;
-        { obs with decision_stage = target_packed }
-      | Packed Decision_undecided, Packed Decision_gate_rejected ->
-        changed := true;
-        { obs with decision_stage = target_packed }
-      | Packed Decision_undecided, Packed Decision_tool_policy_selected ->
-        changed := true;
-        { obs with decision_stage = target_packed }
-      | Packed Decision_guard_ok, Packed Decision_guard_ok -> obs
-      | Packed Decision_guard_ok, Packed Decision_gate_rejected ->
-        changed := true;
-        { obs with decision_stage = target_packed }
-      | Packed Decision_guard_ok, Packed Decision_tool_policy_selected ->
-        changed := true;
-        { obs with decision_stage = target_packed }
-      | Packed Decision_gate_rejected, Packed Decision_gate_rejected -> obs
-      | Packed Decision_gate_rejected, Packed Decision_guard_ok ->
-        changed := true;
-        { obs with decision_stage = target_packed }
-      | Packed Decision_gate_rejected, Packed Decision_tool_policy_selected ->
-        changed := true;
-        { obs with decision_stage = target_packed }
-      | Packed Decision_tool_policy_selected, Packed Decision_tool_policy_selected -> obs
-      | Packed Decision_tool_policy_selected, Packed Decision_guard_ok ->
-        changed := true;
-        { obs with decision_stage = target_packed }
-      | Packed Decision_tool_policy_selected, Packed Decision_gate_rejected ->
-        changed := true;
-        { obs with decision_stage = target_packed }
-      | Packed Decision_guard_ok, Packed Decision_undecided
-      | Packed Decision_gate_rejected, Packed Decision_undecided
-      | Packed Decision_tool_policy_selected, Packed Decision_undecided ->
-        invalid_arg "decision_stage transition to undecided is not valid within a turn"));
+        { obs with decision_stage = target_packed })));
   if !changed then broadcast_composite_changed ~name ~ts_unix:now
 ;;
 

--- a/lib/keeper/keeper_registry.mli
+++ b/lib/keeper/keeper_registry.mli
@@ -213,6 +213,20 @@ type packed_decision_stage = Packed : 'a decision_stage_witness -> packed_decisi
 val witness_to_stage : 'a decision_stage_witness -> decision_stage
 val stage_to_witness : decision_stage -> packed_decision_stage
 
+(** Decision stages valid as ADVANCE targets within a turn.  Excludes
+    [Decision_undecided] (the initial state set only by [mark_turn_started]
+    / [mark_sdk_turn_started]).  The 3 spec-forbidden [<active>_to_undecided]
+    transitions are unrepresentable through this type, replacing the prior
+    runtime [invalid_arg] inside [set_turn_decision_stage]. *)
+type decision_stage_active =
+  | Decision_active_guard_ok
+  | Decision_active_gate_rejected
+  | Decision_active_tool_policy_selected
+
+val decision_stage_active_to_packed
+  :  decision_stage_active
+  -> packed_decision_stage
+
 (** Diagnostic label using the constructor name (e.g.
     ["Decision_guard_ok"]).  Used by [validate_decision_transition] for
     [Invalid_argument] messages. *)
@@ -516,9 +530,12 @@ val mark_sdk_turn_started : base_path:string -> string -> unit
     No-op if no turn is active or no pending measurement exists. *)
 val mark_turn_measurement : base_path:string -> string -> unit
 
-(** Advance the live turn's projected decision stage. No-op if idle. *)
+(** Advance the live turn's projected decision stage. No-op if idle.
+    Input type [decision_stage_active] excludes [Decision_undecided];
+    the 3 spec-forbidden [<active>_to_undecided] transitions are therefore
+    unrepresentable at the call site (replaces prior runtime [invalid_arg]). *)
 val set_turn_decision_stage :
-  base_path:string -> string -> decision_stage -> unit
+  base_path:string -> string -> decision_stage_active -> unit
 
 (** Advance the live turn's projected cascade state. No-op if idle.
     Sets [turn_phase] to [Turn_executing] for [Cascade_trying] and to

--- a/lib/keeper/keeper_run_tools.ml
+++ b/lib/keeper/keeper_run_tools.ml
@@ -1559,7 +1559,7 @@ let prepare_agent_setup
                  Keeper_registry.set_turn_decision_stage
                    ~base_path:config.base_path
                    meta.name
-                   Keeper_registry.Decision_tool_policy_selected;
+                   Keeper_registry.Decision_active_tool_policy_selected;
                  Keeper_registry.set_turn_cascade_state
                    ~base_path:config.base_path
                    meta.name

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -942,7 +942,7 @@ let run_keeper_cycle
                   Keeper_registry.set_turn_decision_stage
                     ~base_path:config.base_path
                     meta.name
-                    Keeper_registry.Decision_guard_ok
+                    Keeper_registry.Decision_active_guard_ok
                 | _ -> ());
                let last_execution = ref initial_execution in
                let last_timeout_budget : oas_timeout_budget_resolution option ref =

--- a/test/test_dashboard_harness_health.ml
+++ b/test/test_dashboard_harness_health.ml
@@ -359,18 +359,18 @@ let test_outcomes_rollup_counts_gate_rejected_from_completed_turns () =
   ignore (Reg.register ~base_path:config.base_path keeper_name meta);
   Reg.mark_turn_started ~base_path:config.base_path keeper_name;
   Reg.set_turn_decision_stage
-    ~base_path:config.base_path keeper_name Reg.Decision_tool_policy_selected;
+    ~base_path:config.base_path keeper_name Reg.Decision_active_tool_policy_selected;
   Reg.mark_turn_gate_rejected_by_name keeper_name;
   Reg.mark_turn_finished ~base_path:config.base_path keeper_name;
   Reg.mark_turn_started ~base_path:config.base_path keeper_name;
   Reg.set_turn_decision_stage
-    ~base_path:config.base_path keeper_name Reg.Decision_tool_policy_selected;
+    ~base_path:config.base_path keeper_name Reg.Decision_active_tool_policy_selected;
   Reg.set_turn_cascade_state
     ~base_path:config.base_path keeper_name (Reg.Packed Reg.Cascade_done);
   Reg.mark_turn_finished ~base_path:config.base_path keeper_name;
   Reg.mark_turn_started ~base_path:config.base_path keeper_name;
   Reg.set_turn_decision_stage
-    ~base_path:config.base_path keeper_name Reg.Decision_tool_policy_selected;
+    ~base_path:config.base_path keeper_name Reg.Decision_active_tool_policy_selected;
   Reg.set_turn_cascade_state
     ~base_path:config.base_path keeper_name (Reg.Packed Reg.Cascade_exhausted);
   Reg.mark_turn_finished ~base_path:config.base_path keeper_name;

--- a/test/test_decision_pipeline_observer.ml
+++ b/test/test_decision_pipeline_observer.ml
@@ -203,7 +203,7 @@ let test_observer_gate_rejected_finalizes_turn () =
   let _ = Reg.register ~base_path:test_obs_bp name (make_obs_meta name) in
   Reg.mark_turn_started ~base_path:test_obs_bp name;
   Reg.set_turn_decision_stage
-    ~base_path:test_obs_bp name Reg.Decision_tool_policy_selected;
+    ~base_path:test_obs_bp name Reg.Decision_active_tool_policy_selected;
   Reg.set_turn_cascade_state ~base_path:test_obs_bp name (Reg.Packed Reg.Cascade_trying);
   Reg.mark_turn_gate_rejected_by_name name;
   match Reg.get ~base_path:test_obs_bp name with
@@ -261,7 +261,7 @@ let test_observer_last_outcome_populated_after_turn () =
   dispatch_obs_measurement name;
   Reg.mark_turn_measurement ~base_path:test_obs_bp name;
   Reg.set_turn_decision_stage
-    ~base_path:test_obs_bp name Reg.Decision_tool_policy_selected;
+    ~base_path:test_obs_bp name Reg.Decision_active_tool_policy_selected;
   Reg.set_turn_cascade_state ~base_path:test_obs_bp name (Reg.Packed Reg.Cascade_done);
   Reg.set_turn_selected_model ~base_path:test_obs_bp name (Some "glm-4.5");
   Reg.mark_turn_finished ~base_path:test_obs_bp name;
@@ -312,7 +312,7 @@ let test_observer_json_includes_terminal_fields () =
   dispatch_obs_measurement name;
   Reg.mark_turn_measurement ~base_path:test_obs_bp name;
   Reg.set_turn_decision_stage
-    ~base_path:test_obs_bp name Reg.Decision_tool_policy_selected;
+    ~base_path:test_obs_bp name Reg.Decision_active_tool_policy_selected;
   Reg.set_turn_cascade_state ~base_path:test_obs_bp name (Reg.Packed Reg.Cascade_done);
   Reg.set_turn_selected_model ~base_path:test_obs_bp name (Some "glm-4.5");
   Reg.mark_turn_finished ~base_path:test_obs_bp name;
@@ -355,7 +355,7 @@ let test_turn_retry_after_compaction_resets_cascade_attempt () =
   dispatch_obs_measurement name;
   Reg.mark_turn_measurement ~base_path:test_obs_bp name;
   Reg.set_turn_decision_stage
-    ~base_path:test_obs_bp name Reg.Decision_tool_policy_selected;
+    ~base_path:test_obs_bp name Reg.Decision_active_tool_policy_selected;
   Reg.set_turn_cascade_state ~base_path:test_obs_bp name (Reg.Packed Reg.Cascade_trying);
   Reg.set_turn_selected_model ~base_path:test_obs_bp name (Some "glm-4.5");
   Reg.set_turn_phase ~base_path:test_obs_bp name Reg.(Packed Turn_compacting);

--- a/test/test_keeper_registry.ml
+++ b/test/test_keeper_registry.ml
@@ -339,7 +339,7 @@ let test_mark_turn_finished_records_completed_turn_outcome_once () =
   ignore (R.register ~base_path:bp keeper_name (make_meta keeper_name));
   R.mark_turn_started ~base_path:bp keeper_name;
   R.set_turn_decision_stage
-    ~base_path:bp keeper_name R.Decision_tool_policy_selected;
+    ~base_path:bp keeper_name R.Decision_active_tool_policy_selected;
   R.mark_turn_gate_rejected_by_name keeper_name;
   R.mark_turn_finished ~base_path:bp keeper_name;
   R.mark_turn_finished ~base_path:bp keeper_name;
@@ -1392,7 +1392,7 @@ let test_effective_keepalive_meta_prefers_registry_when_disk_unchanged () =
 let drive_turn_to_finalizing keeper_name =
   R.mark_turn_started ~base_path:bp keeper_name;
   R.set_turn_decision_stage
-    ~base_path:bp keeper_name R.Decision_tool_policy_selected;
+    ~base_path:bp keeper_name R.Decision_active_tool_policy_selected;
   R.set_turn_cascade_state ~base_path:bp keeper_name (R.Packed R.Cascade_selecting);
   R.set_turn_cascade_state ~base_path:bp keeper_name (R.Packed R.Cascade_trying);
   R.set_turn_cascade_state ~base_path:bp keeper_name (R.Packed R.Cascade_done)
@@ -1462,7 +1462,7 @@ let test_two_sdk_turn_boundaries_no_assert () =
   (* Second SDK turn arrives via before_turn_params hook. *)
   R.mark_sdk_turn_started ~base_path:bp keeper_name;
   R.set_turn_decision_stage
-    ~base_path:bp keeper_name R.Decision_tool_policy_selected;
+    ~base_path:bp keeper_name R.Decision_active_tool_policy_selected;
   R.set_turn_cascade_state ~base_path:bp keeper_name (R.Packed R.Cascade_selecting);
   match R.get ~base_path:bp keeper_name with
   | Some { current_turn_observation = Some obs; _ } ->


### PR DESCRIPTION
## Why

`set_turn_decision_stage` (lib/keeper/keeper_registry.ml:1226 pre-PR) enforced the spec invariant "decision_stage transition to undecided is not valid within a turn" at **runtime** via `invalid_arg`:

```ocaml
| Packed Decision_guard_ok, Packed Decision_undecided
| Packed Decision_gate_rejected, Packed Decision_undecided
| Packed Decision_tool_policy_selected, Packed Decision_undecided ->
    invalid_arg "decision_stage transition to undecided is not valid within a turn"
```

This is a runtime FSM exception in the keeper lifecycle critical path — the same class as the keeper_registry.ml:721 incident (2026-05-08), which raised `Assert_failure` from a sparse FSM transition match.

The 16-pair `(from, to)` matrix enumerated 13 valid pairs (4 idempotent + 9 cross-state) and 3 forbidden `_to_undecided` arms. All 13 valid arms shared identical action (idempotent on equality, otherwise replace); the 3 forbidden arms existed solely to raise.

Plan inventory item #4 calls this out: "FSM `invalid_arg` → typed `Result.t`". This PR takes the **alternate, smaller path**: input refinement (Alexis King "Parse, don't validate" per CLAUDE.md `software-development.md`) instead of `Result.t` propagation.

## What

Refine the input type so the forbidden case is **unrepresentable**:

```ocaml
type decision_stage_active =
  | Decision_active_guard_ok
  | Decision_active_gate_rejected
  | Decision_active_tool_policy_selected

val set_turn_decision_stage :
  base_path:string -> string -> decision_stage_active -> unit
```

`Decision_undecided` has no constructor in `decision_stage_active`, so passing it produces a **compile error** at the call site, not a runtime exception. The 16-pair match collapses to a simple equality check:

```ocaml
update_current_turn e (fun obs ->
  if obs.decision_stage = target_packed
  then obs
  else (changed := true; { obs with decision_stage = target_packed }))
```

`Decision_undecided` continues to be set **only** by:
- `mark_turn_started` (keeper_registry.ml:1024) — turn initialization
- `mark_sdk_turn_started` (keeper_registry.ml:1055) — SDK-turn reset

Both bypass `set_turn_decision_stage` entirely via direct field assignment, so removing the runtime check at the validator is safe.

## Caller migration (12 sites, `Decision_<X>` → `Decision_active_<X>`)

| File | Sites | Target |
|---|---|---|
| `lib/keeper/keeper_run_tools.ml` | 1 (line 1562) | `Decision_active_tool_policy_selected` (SelectToolPolicy atomic group) |
| `lib/keeper/keeper_unified_turn.ml` | 1 (line 945) | `Decision_active_guard_ok` (after `mark_turn_measurement`) |
| `test/test_keeper_registry.ml` | 3 | `Decision_active_tool_policy_selected` |
| `test/test_decision_pipeline_observer.ml` | 4 | `Decision_active_tool_policy_selected` |
| `test/test_dashboard_harness_health.ml` | 3 | `Decision_active_tool_policy_selected` |

Zero callers passed `Decision_undecided` — refinement is naturally compatible.

## Why not `Decision_transition` GADT?

`lib/keeper/keeper_registry.ml:349` defines `Decision_transition` GADT with all 9 valid cross-state transitions enumerated. It is currently used by 0 production sites.

Activating it for `set_turn_decision_stage` would force callers to track *from-state*; the current caller pattern (target-only) doesn't carry it (e.g., `keeper_unified_turn.ml:945` after `mark_turn_measurement` knows the logical state but doesn't read `obs.decision_stage`). Forcing callers to read state + dispatch would add complexity without semantic gain — `set_turn_decision_stage` has no per-pair side effects.

GADT activation is a separate followup (e.g., per-transition metric emission, audit trail with typed transition values) and deserves its own RFC.

## Followup sites (out of scope)

3 other `invalid_arg` sites in keeper_registry.ml remain:
- line 418 `validate_decision_transition` — separate validator function with test contract (`test_keeper_sub_fsm_guards.ml` uses `capture_invalid_arg`)
- line 1234 `validate_cascade_transition` — different scrutinee (5-variant `cascade_state`, 25 pairs)
- line 1335 `validate_turn_phase_transition` — different scrutinee (8-variant `turn_phase`, 60+ pairs)

Each has different shape and test surface — folding 3+ into one PR would violate Workaround Rejection Bar §3 (N-of-M). Pilot site (1226) closes the smallest, most surgical surface.

## Behavior change

Only the **raising** of `Invalid_argument` from `set_turn_decision_stage` is removed. The 12 admitted `(from, to)` pairs behave identically. `validate_decision_transition` (line 418, separate function) retains its runtime contract — `test_keeper_sub_fsm_guards.ml` unaffected.

## Self-check (CLAUDE.md Workaround Rejection Bar)

| # | Check | Result |
|---|---|---|
| 1 | telemetry-as-fix? | no — removes runtime exception, not adds counter |
| 2 | string classifier? | no — typed sum refinement |
| 3 | N-of-M? | no — site 1226 fully closed; sites 418/1234/1335 are different validators deferred to followups |
| 4 | catch-all added? | no — match collapsed to `if/else`, no `_ ->` arm |
| 5 | cap/cooldown/dedup? | no |
| 6 | test backdoor? | no |
| 7 | typo N sites? | no — single type definition + single-site refactor |

## Principle reference

Alexis King "Parse, don't validate" (CLAUDE.md `software-development.md` §Coding Principle, `.claude/role/user-core.xml` "make illegal states unrepresentable"): refine the input type so the validator becomes unnecessary at the type-system level. The forbidden case is not "rejected at runtime" — it is "not expressible at all".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
