### PR TITLE
feat(core): enable warning 4 on masc_core (RFC-0071 §3.4 bootstrap)

### DIFF
--- a/lib/core/circuit_breaker.ml
+++ b/lib/core/circuit_breaker.ml
@@ -265,7 +265,8 @@ let cleanup t ~older_than_seconds =
       StringMap.fold (fun agent_id breaker (n, m) ->
         match breaker.state with
         | Closed when breaker.last_check < threshold -> (n + 1, m)
-        | _ -> (n, StringMap.add agent_id breaker m)
+        | Closed | Open _ | HalfOpen ->
+            (n, StringMap.add agent_id breaker m)
       ) t.breakers (0, StringMap.empty)
     in
     t.breakers <- kept;

--- a/lib/core/dune
+++ b/lib/core/dune
@@ -3,5 +3,11 @@
  (name masc_core)
  (public_name masc_mcp.masc_core)
  (wrapped false)
+ ; RFC-0071 §3.4 Phase 5 bootstrap: warning 4 (fragile pattern match) on.
+ ; All 13 catch-all sites in this sublib match Yojson.Safe.t (poly variant),
+ ; which warning 4 ignores by design — so flipping +4 here is a no-op for
+ ; existing code but locks in the type-level guarantee for any future closed
+ ; concrete variant. Smallest justifiable scope to prove Phase 5 end-to-end.
+ (flags (:standard -w +4))
  (modules json_util safe_ops common validation circuit_breaker eio_guard executor_pool_ref masc_runtime_events provider_error text_similarity string_util list_util read_drop_reason actor_types actor_mailbox domain_pool)
  (libraries yojson unix re re.pcre eio eio.unix time_compat fs_compat masc_log runtime_events))


### PR DESCRIPTION
## 목적

RFC-0071 §3.4 Phase 5 bootstrap. **컴파일러 빌트인 fragile-match warning (`-w +4`) 을 한 sublib 에서 활성화** 하여, RFC 가 주장한 enforcement 패스가 end-to-end 로 작동함을 실증.

## 변경

- `lib/core/dune`: `(flags (:standard -w +4))` 추가.
- `lib/core/circuit_breaker.ml`: warning 4 가 잡은 단 1건의 fragile site closure.
  - Before: `match breaker.state with Closed when ... -> ... | _ -> ...`
  - After: `match breaker.state with Closed when ... -> ... | Closed | Open _ | HalfOpen -> ...`

## 왜 lib/core 가 첫 타겟인가

RFC-0071 inventory 분석:
- `lib/core` 13 catch-all sites: `json_util.ml` 7 + `safe_ops.ml` 6.
- **13 사이트 전부 `Yojson.Safe.t` (polymorphic variant)** 위에서 매칭.
- Warning 4 는 *closed concrete variant* 에만 fire — poly variant 무시.
- 따라서 `-w +4` 활성화 = 기존 코드 *no-op*, 미래 closed-variant 도입 시 *컴파일러가 즉시 강제*.

이게 RFC 의 핵심 주장 (\"warning 4 가 일급 enforcement, custom lint 는 백업\") 의 가장 작은 증명.

## 검증

- `dune build --root . lib/core` clean
- `dune build --root .` 전체 clean
- `dune runtest test/test_circuit_breaker.ml` — 27/27 green

## RFC-0071 와의 관계

- Phase 5 의 핵심 액션 (`lib/dune` 에 `(flags (:standard -w +4))` 추가) 을 **sublib 수준에서 먼저 실증**.
- Phase 3 (codemod) 가 아직 구현 전이지만, lib/core 는 codemod 불필요 (이미 clean).
- 다음 후속: 다른 clean sublib 도 동일 방식으로 활성화 → Phase 3 codemod 가 cleanup 한 sublib 도 같은 패턴으로 lockdown.

## Out of scope

- Phase 2 codemod 구현
- 다른 sublib (`lib/keeper/`, `lib/cascade/` 등) warning 4 활성화 — 각각 별도 cleanup 필요