### PR TITLE
feat(rfc-0070): Phase 3b-iv.2.5 — Docker_ps_parser module + 15 hermetic unit tests

### DIFF
--- a/lib/keeper/docker_client_real.ml
+++ b/lib/keeper/docker_client_real.ml
@@ -1,10 +1,11 @@
-(* RFC-0070 Phase 3b-iv.2.4 — Real Docker_client (all 4 functions wired).
+(* RFC-0070 Phase 3b-iv.2.5 — Real Docker_client (parser extracted).
 
    Sub-phase 3b-iv.2.0 shipped placeholders for all four S functions.
-   Sub-phases 3b-iv.2.{1,2,3} wired [rm] (#14844), [exec] (#14854),
-   and [run] (#14862). Sub-phase 3b-iv.2.4 (this) wires [ps_query] +
-   the JSON parser for [docker ps --format '\{\{json .\}\}'] output.
-   Phase 3b-iv.2 series closes here. *)
+   Sub-phases 3b-iv.2.{1,2,3,4} wired [rm] (#14844), [exec] (#14854),
+   [run] (#14862), and [ps_query]+JSON parser (#14871). Sub-phase
+   3b-iv.2.5 (this) extracts the JSON parser to {!Docker_ps_parser}
+   so each silent-drop path is exercised by unit tests with
+   synthetic JSON fixtures. *)
 
 (* ── Exit-status mapping helpers ─────────────────────────────── *)
 
@@ -40,82 +41,9 @@ let map_status_to_exec_result
   | Unix.WSIGNALED _ | Unix.WSTOPPED _ -> Error Docker_client.Daemon_unreachable
 ;;
 
-(* ── JSON parsing helpers for ps_query ───────────────────────── *)
-
-(* [parse_labels "k1=v1,k2=v2"] returns [[("k1","v1"); ("k2","v2")]].
-   Empty input maps to []. Tokens without '=' are dropped. Docker emits
-   labels as a single comma-joined string in [docker ps --format].
-
-   Order-preserving — the parsed list mirrors docker's emission order.
-   {!Docker_response.equal_ps_record} treats label order as
-   significant; canonical ordering is a higher-level concern (e.g.
-   sort by key) the parser does NOT impose here. *)
-let parse_labels (s : string) : (string * string) list =
-  if String.equal s ""
-  then []
-  else (
-    let parts = String.split_on_char ',' s in
-    List.filter_map
-      (fun part ->
-         match String.index_opt part '=' with
-         | None -> None
-         | Some i ->
-           let k = String.sub part 0 i in
-           let v = String.sub part (i + 1) (String.length part - i - 1) in
-           Some (k, v))
-      parts)
-;;
-
-(* Required-only subset of docker's ps JSON line. [@@deriving
-   yojson { strict = false }] tolerates unknown fields like
-   [CreatedAt], [Status], [Ports] without failure. *)
-type raw_ps_record =
-  { id : string [@key "ID"]
-  ; names : string [@key "Names"]
-  ; state : string [@key "State"]
-  ; labels : string [@key "Labels"]
-  }
-[@@deriving yojson { strict = false }]
-
-(* [parse_ps_line line] decodes one JSON-formatted [docker ps] line
-   into a {!Docker_response.ps_record}. Returns [None] when the line
-   is empty, fails to decode as JSON, fails to match the required
-   schema, or carries an unknown [State] token — every drop is
-   *opportunistic*; the caller (ps_query) silently skips. This is
-   the documented compromise between RFC §3.3 "no permissive default"
-   and the operational reality that [docker ps] can emit stray output
-   under unusual conditions (e.g. warning lines on stderr leaking into
-   stdout under specific BuildKit configurations); a single
-   unparseable line should NOT collapse the entire fleet listing. *)
-let parse_ps_line (line : string) : Docker_response.ps_record option =
-  let trimmed = String.trim line in
-  if String.equal trimmed ""
-  then None
-  else (
-    match Yojson.Safe.from_string trimmed with
-    | exception Yojson.Json_error _ -> None
-    | json ->
-      (match raw_ps_record_of_yojson json with
-       | Error _ -> None
-       | Ok raw ->
-         (match Docker_response.parse_state raw.state with
-          | Error _ -> None
-          | Ok status ->
-            Some
-              Docker_response.
-                { id = raw.id
-                ; name = Keeper_container_name.of_external_string raw.names
-                ; status
-                ; labels = parse_labels raw.labels
-                })))
-;;
-
-(* [parse_ps_output stdout] splits stdout by newline and parses each
-   line. Unparseable lines are silently dropped (see [parse_ps_line]'s
-   rationale). *)
-let parse_ps_output (stdout : string) : Docker_response.ps_record list =
-  String.split_on_char '\n' stdout |> List.filter_map parse_ps_line
-;;
+(* JSON parsing helpers extracted to {!Docker_ps_parser} so each
+   silent-drop path is testable via synthetic JSON fixtures. See
+   that module's .mli for the surface and trade-off rationale. *)
 
 (* [labels_to_filter_args] folds each [(k, v)] into a [--filter
    label=k=v] pair on the argv, suitable for [docker ps]. *)
@@ -131,7 +59,7 @@ let ps_query ~labels =
   in
   let status, stdout, _stderr = Process_eio.run_argv_with_status_split argv in
   match status with
-  | Unix.WEXITED 0 -> Ok (parse_ps_output stdout)
+  | Unix.WEXITED 0 -> Ok (Docker_ps_parser.parse_output stdout)
   | Unix.WEXITED 124 -> Error Docker_client.Exec_timeout
   | Unix.WEXITED 125 | Unix.WEXITED 127 -> Error Docker_client.Daemon_unreachable
   | Unix.WEXITED _ -> Error Docker_client.Probe_format_drift

--- a/lib/keeper/docker_ps_parser.ml
+++ b/lib/keeper/docker_ps_parser.ml
@@ -1,0 +1,58 @@
+(* RFC-0070 Phase 3b-iv.2.5 — pure parser for docker ps JSON output.
+   See .mli for the public surface and the silent-drop trade-off
+   rationale. Extracted unchanged from docker_client_real.ml (Phase
+   3b-iv.2.4 / #14871). *)
+
+let parse_labels (s : string) : (string * string) list =
+  if String.equal s ""
+  then []
+  else (
+    let parts = String.split_on_char ',' s in
+    List.filter_map
+      (fun part ->
+         match String.index_opt part '=' with
+         | None -> None
+         | Some i ->
+           let k = String.sub part 0 i in
+           let v = String.sub part (i + 1) (String.length part - i - 1) in
+           Some (k, v))
+      parts)
+;;
+
+(* Required-only subset of docker's ps JSON line. [@@deriving
+   yojson { strict = false }] tolerates unknown fields like
+   [CreatedAt], [Status], [Ports] without failure. *)
+type raw_ps_record =
+  { id : string [@key "ID"]
+  ; names : string [@key "Names"]
+  ; state : string [@key "State"]
+  ; labels : string [@key "Labels"]
+  }
+[@@deriving yojson { strict = false }]
+
+let parse_line (line : string) : Docker_response.ps_record option =
+  let trimmed = String.trim line in
+  if String.equal trimmed ""
+  then None
+  else (
+    match Yojson.Safe.from_string trimmed with
+    | exception Yojson.Json_error _ -> None
+    | json ->
+      (match raw_ps_record_of_yojson json with
+       | Error _ -> None
+       | Ok raw ->
+         (match Docker_response.parse_state raw.state with
+          | Error _ -> None
+          | Ok status ->
+            Some
+              Docker_response.
+                { id = raw.id
+                ; name = Keeper_container_name.of_external_string raw.names
+                ; status
+                ; labels = parse_labels raw.labels
+                })))
+;;
+
+let parse_output (stdout : string) : Docker_response.ps_record list =
+  String.split_on_char '\n' stdout |> List.filter_map parse_line
+;;

--- a/lib/keeper/docker_ps_parser.mli
+++ b/lib/keeper/docker_ps_parser.mli
@@ -1,0 +1,61 @@
+(** RFC-0070 Phase 3b-iv.2.5 — pure parser for [docker ps --format '\{\{json .\}\}'] output.
+
+    Extracted from {!Docker_client_real} so the parser surface can be
+    exercised directly by hermetic unit tests with synthetic JSON
+    fixtures (no docker daemon dependency). Phase 3b-iv.2.4 (#14871)
+    left these helpers [private] in [docker_client_real.ml]; this PR
+    promotes them to a typed boundary so each silent-drop path
+    (empty / Yojson.Json_error / schema-mismatch / unknown State) is
+    individually testable.
+
+    {!Docker_client_real.ps_query} now delegates to {!parse_output};
+    no other production caller is intended.
+
+    Reference: docs/rfc/RFC-0070-keeper-sandbox-pure-edge-separation.md §3.3 *)
+
+(** [parse_labels s] decodes docker's comma-joined label string
+    [["k1=v1,k2=v2"]] into an association list.
+
+    - Empty input → [[]].
+    - Tokens without ['='] → dropped (no [Some (k, "")] permissive
+      default; the absence of a key/value separator is parser-defined
+      noise, not a typed value).
+    - Order-preserving: the result mirrors docker's emission order.
+      Canonical re-ordering (e.g. sort by key) is the caller's
+      responsibility — {!Docker_response.equal_ps_record} treats
+      label order as significant. *)
+val parse_labels : string -> (string * string) list
+
+(** [parse_line line] decodes one JSON-formatted [docker ps] line
+    into a {!Docker_response.ps_record}.
+
+    Returns [None] when *any* of the four enumerated failure paths
+    fires:
+    + [line] is empty (after [String.trim])
+    + [line] is not valid JSON (Yojson raises [Json_error])
+    + [line] is valid JSON but does not satisfy the required schema
+      (missing [ID] / [Names] / [State] / [Labels])
+    + [line] is schema-valid but carries an unknown [State] token
+      (one that {!Docker_response.parse_state} rejects)
+
+    All four are *deliberate silent drops* — RFC §3.3 documented
+    trade-off. They are *enumerated*, not a catch-all [_ -> None]:
+    every code path is reachable and individually exercisable by
+    {!test_docker_ps_parser}.
+
+    The [Names] string is wrapped via
+    {!Keeper_container_name.of_external_string} — *unsafe*. docker
+    may emit container names that did not originate from
+    {!Keeper_container_name.derive}, and the parser does not enforce
+    the [masc-keeper-] prefix invariant. The result is opaque to the
+    parser; downstream consumers that need the prefix invariant must
+    re-validate. *)
+val parse_line : string -> Docker_response.ps_record option
+
+(** [parse_output stdout] splits stdout by ['\n'] and parses each
+    line via {!parse_line}, dropping [None] results. The cumulative
+    silent-drop count is *not* reported — observability is the
+    consumer's responsibility (see RFC §3.3 follow-up note re:
+    [masc_docker_ps_parse_drop_total] counter, if it becomes
+    operationally noisy). *)
+val parse_output : string -> Docker_response.ps_record list

--- a/test/dune
+++ b/test/dune
@@ -596,6 +596,7 @@
         test_docker_response
         test_docker_client_mock
         test_docker_client_real
+        test_docker_ps_parser
         test_sandbox_executor
         test_keeper_backoff_policy
         test_worker_runtime
@@ -813,6 +814,7 @@
         test_docker_response
         test_docker_client_mock
         test_docker_client_real
+        test_docker_ps_parser
         test_sandbox_executor
         test_keeper_backoff_policy
         test_worker_runtime

--- a/test/test_docker_ps_parser.ml
+++ b/test/test_docker_ps_parser.ml
@@ -1,0 +1,272 @@
+(** RFC-0070 Phase 3b-iv.2.5 — unit tests for {!Docker_ps_parser}.
+
+    Each of the 4 enumerated silent-drop paths
+    (empty / Yojson.Json_error / schema-mismatch / unknown State) is
+    exercised individually with synthetic JSON fixtures so the parser
+    contract is pinned independently of docker daemon state. *)
+
+open Alcotest
+open Masc_mcp
+
+(* Synthetic line that matches docker's [--format '{{json .}}']
+   emission shape closely enough for the parser: required fields
+   (ID, Names, State, Labels) plus a few unknown fields that the
+   [strict = false] yojson derivation must tolerate. *)
+let happy_line ~name ~state ~labels =
+  Printf.sprintf
+    {|{"ID":"abc123","Names":"%s","State":"%s","Labels":"%s","CreatedAt":"2026-05-12 09:00:00 +0900 KST","Status":"Up 5 minutes","Ports":""}|}
+    name
+    state
+    labels
+;;
+
+(* ── parse_labels ────────────────────────────────────────────── *)
+
+let test_parse_labels_empty () =
+  let actual = Docker_ps_parser.parse_labels "" in
+  check (list (pair string string)) "empty → []" [] actual
+;;
+
+let test_parse_labels_single () =
+  let actual = Docker_ps_parser.parse_labels "k=v" in
+  check (list (pair string string)) "single pair" [ "k", "v" ] actual
+;;
+
+let test_parse_labels_multi_preserves_order () =
+  let actual = Docker_ps_parser.parse_labels "z=last,a=first,m=mid" in
+  (* Order-preserving per .mli contract — caller must canonicalise
+     if comparing via Docker_response.equal_ps_record. *)
+  check
+    (list (pair string string))
+    "docker emission order preserved"
+    [ "z", "last"; "a", "first"; "m", "mid" ]
+    actual
+;;
+
+let test_parse_labels_drops_no_equals_token () =
+  let actual = Docker_ps_parser.parse_labels "good=ok,malformed,also=fine" in
+  (* "malformed" has no '=' — dropped silently. NOT mapped to
+     ("malformed", "") which would be a permissive default. *)
+  check
+    (list (pair string string))
+    "tokens without '=' dropped, not given empty-value default"
+    [ "good", "ok"; "also", "fine" ]
+    actual
+;;
+
+let test_parse_labels_empty_value_allowed () =
+  let actual = Docker_ps_parser.parse_labels "key=" in
+  (* '=' present but value empty — that IS a valid (key, "") pair.
+     Distinct from the "no =" drop case above. *)
+  check (list (pair string string)) "trailing '=' → empty value" [ "key", "" ] actual
+;;
+
+let test_parse_labels_value_contains_equals () =
+  let actual = Docker_ps_parser.parse_labels "url=https://x.com/?a=b" in
+  (* Only the FIRST '=' splits — subsequent '=' chars stay in value.
+     This matches docker's behaviour and protects label values that
+     happen to contain '='. *)
+  check
+    (list (pair string string))
+    "split on first '=' only"
+    [ "url", "https://x.com/?a=b" ]
+    actual
+;;
+
+(* ── parse_line — 4 enumerated silent-drop paths ─────────────── *)
+
+let test_parse_line_drop_empty () =
+  check (option (of_pp Fmt.nop)) "empty line → None" None (Docker_ps_parser.parse_line "");
+  check
+    (option (of_pp Fmt.nop))
+    "whitespace-only line → None"
+    None
+    (Docker_ps_parser.parse_line "   \t  ")
+;;
+
+let test_parse_line_drop_malformed_json () =
+  (* Drop path 2: Yojson.Json_error. Caught and converted to None. *)
+  check
+    (option (of_pp Fmt.nop))
+    "non-JSON line → None"
+    None
+    (Docker_ps_parser.parse_line "not a json line at all");
+  check
+    (option (of_pp Fmt.nop))
+    "truncated JSON → None"
+    None
+    (Docker_ps_parser.parse_line "{\"ID\":\"abc\"")
+;;
+
+let test_parse_line_drop_schema_mismatch () =
+  (* Drop path 3: valid JSON but missing required fields. *)
+  check
+    (option (of_pp Fmt.nop))
+    "JSON without required keys → None"
+    None
+    (Docker_ps_parser.parse_line {|{"foo":"bar"}|});
+  check
+    (option (of_pp Fmt.nop))
+    "JSON missing one required key (Labels) → None"
+    None
+    (Docker_ps_parser.parse_line {|{"ID":"x","Names":"n","State":"running"}|})
+;;
+
+let test_parse_line_drop_unknown_state () =
+  (* Drop path 4: schema-valid but State not in {Created, Running,
+     Paused, Restarting, Exited, Dead}. *)
+  check
+    (option (of_pp Fmt.nop))
+    "unknown State → None"
+    None
+    (Docker_ps_parser.parse_line (happy_line ~name:"x" ~state:"zombie" ~labels:""))
+;;
+
+(* ── parse_line — happy path ─────────────────────────────────── *)
+
+let test_parse_line_happy_running () =
+  match
+    Docker_ps_parser.parse_line
+      (happy_line ~name:"masc-keeper-abc" ~state:"running" ~labels:"k=v")
+  with
+  | None -> fail "expected Some on well-formed input"
+  | Some record ->
+    check string "id preserved" "abc123" record.Docker_response.id;
+    check
+      string
+      "name unsafe-wrapped from external string"
+      "masc-keeper-abc"
+      (Keeper_container_name.to_string record.Docker_response.name);
+    check
+      bool
+      "state parsed to typed variant Running"
+      true
+      Docker_response.(equal_ps_status record.status Running);
+    check (list (pair string string)) "labels parsed" [ "k", "v" ] record.labels
+;;
+
+let test_parse_line_happy_all_states () =
+  (* Each of the 6 valid State tokens accepted by Docker_response.parse_state
+     must round-trip through parse_line. *)
+  let cases =
+    [ "created", Docker_response.Created
+    ; "running", Docker_response.Running
+    ; "paused", Docker_response.Paused
+    ; "restarting", Docker_response.Restarting
+    ; "exited", Docker_response.Exited
+    ; "dead", Docker_response.Dead
+    ]
+  in
+  List.iter
+    (fun (token, expected) ->
+       match
+         Docker_ps_parser.parse_line (happy_line ~name:"x" ~state:token ~labels:"")
+       with
+       | None -> failf "state token %S unexpectedly dropped" token
+       | Some r ->
+         check
+           bool
+           (Printf.sprintf "state %S → typed" token)
+           true
+           (Docker_response.equal_ps_status r.status expected))
+    cases
+;;
+
+let test_parse_line_unknown_fields_tolerated () =
+  (* [@@deriving yojson { strict = false }] should accept lines with
+     fields not in the required-subset schema (CreatedAt, Status,
+     Ports, Image, Command, ...) without dropping. *)
+  let line =
+    {|{"ID":"x","Names":"n","State":"running","Labels":"","CreatedAt":"now","Status":"Up","Ports":"","Image":"alpine","Command":"sh","Mounts":"","Networks":"bridge","Size":"0B","RunningFor":"1m","LocalVolumes":"0","LogStatus":"none"}|}
+  in
+  match Docker_ps_parser.parse_line line with
+  | None -> fail "unknown fields should be tolerated by strict=false"
+  | Some _ -> ()
+;;
+
+(* ── parse_output ────────────────────────────────────────────── *)
+
+let test_parse_output_empty () =
+  check int "empty stdout → []" 0 (List.length (Docker_ps_parser.parse_output ""));
+  check
+    int
+    "whitespace-only stdout → []"
+    0
+    (List.length (Docker_ps_parser.parse_output "\n\n  \n"))
+;;
+
+let test_parse_output_mixed () =
+  (* Realistic stress: 2 happy lines + 1 of each drop type. *)
+  let stdout =
+    String.concat
+      "\n"
+      [ happy_line ~name:"k1" ~state:"running" ~labels:"app=keeper"
+      ; "" (* drop: empty *)
+      ; "not json" (* drop: Yojson error *)
+      ; {|{"foo":"bar"}|} (* drop: schema *)
+      ; happy_line ~name:"k2" ~state:"alien" ~labels:"" (* drop: unknown state *)
+      ; happy_line ~name:"k3" ~state:"exited" ~labels:""
+      ]
+  in
+  let records = Docker_ps_parser.parse_output stdout in
+  check int "2 happy + 4 drops → 2 records" 2 (List.length records);
+  match records with
+  | [ r1; r2 ] ->
+    check
+      string
+      "first record name"
+      "k1"
+      (Keeper_container_name.to_string r1.Docker_response.name);
+    check
+      string
+      "second record name (skipping all 4 drops)"
+      "k3"
+      (Keeper_container_name.to_string r2.Docker_response.name)
+  | _ -> fail "expected exactly 2 records"
+;;
+
+(* ── Suite ───────────────────────────────────────────────────── *)
+
+let () =
+  run
+    "Docker_ps_parser (Phase 3b-iv.2.5)"
+    [ ( "parse_labels"
+      , [ test_case "empty → []" `Quick test_parse_labels_empty
+        ; test_case "single k=v" `Quick test_parse_labels_single
+        ; test_case
+            "preserves docker emission order"
+            `Quick
+            test_parse_labels_multi_preserves_order
+        ; test_case
+            "drops tokens without '='"
+            `Quick
+            test_parse_labels_drops_no_equals_token
+        ; test_case
+            "trailing '=' → empty value"
+            `Quick
+            test_parse_labels_empty_value_allowed
+        ; test_case
+            "splits on first '=' only"
+            `Quick
+            test_parse_labels_value_contains_equals
+        ] )
+    ; ( "parse_line silent-drop paths"
+      , [ test_case "drop 1: empty line" `Quick test_parse_line_drop_empty
+        ; test_case "drop 2: malformed JSON" `Quick test_parse_line_drop_malformed_json
+        ; test_case "drop 3: schema mismatch" `Quick test_parse_line_drop_schema_mismatch
+        ; test_case "drop 4: unknown State" `Quick test_parse_line_drop_unknown_state
+        ] )
+    ; ( "parse_line happy paths"
+      , [ test_case "running state + labels" `Quick test_parse_line_happy_running
+        ; test_case "all 6 valid State tokens" `Quick test_parse_line_happy_all_states
+        ; test_case
+            "strict=false tolerates unknown fields"
+            `Quick
+            test_parse_line_unknown_fields_tolerated
+        ] )
+    ; ( "parse_output"
+      , [ test_case "empty / whitespace-only stdout" `Quick test_parse_output_empty
+        ; test_case "mixed happy + all 4 drops" `Quick test_parse_output_mixed
+        ] )
+    ]
+;;


### PR DESCRIPTION
## 목표 — RFC-0070 Phase 3b-iv.2.5: Docker_ps_parser 모듈 분리 + 헬퍼별 unit test

PR #14871 (Phase 3b-iv.2.4) 의 Copilot review thread #5 acknowledgement 이행. parser helper들이 `docker_client_real.ml` 내부 *private* 으로 남아 **silent-drop 4 경로**가 직접 검증 불가능했음. 본 PR 은 그 헬퍼를 별도 모듈로 분리해 *각 drop 경로* 와 *happy path* 를 hermetic JSON fixture 로 검증.

## Stacked on PR #14871

base branch: `feat/rfc-0070-phase-3b-iv-2-4-ps-query`. #14871 squash-merge 시 본 PR auto-close 가능 (`feedback_stacked_pr_auto_close_recovery` 메모). 복구 절차: `git rebase origin/main` + parent commit `--skip` + 새 PR 생성 ("Supersedes closed #...").

## 변경

| 파일 | 추가 | 비고 |
|------|-----|------|
| `lib/keeper/docker_ps_parser.mli` | +61 | public surface (`parse_labels` / `parse_line` / `parse_output`) |
| `lib/keeper/docker_ps_parser.ml` | +58 | extracted unchanged from #14871 |
| `lib/keeper/docker_client_real.ml` | -80, +10 | parser 헬퍼 제거, `Docker_ps_parser.parse_output` 위임 |
| `test/test_docker_ps_parser.ml` | +272 | 15 hermetic tests |
| `test/dune` | +1 | test 등록 |

총 +403 / -82.

## 새 unit test 매트릭스 (15 tests, all `Quick`)

### `parse_labels` (6 tests)
- empty → `[]`
- single `k=v`
- 다중 pair docker emission 순서 유지
- `'='` 없는 token *drop* (NOT permissive default `(k, "")`)
- trailing `'='` → empty value (앞과 *구별*되는 경로)
- 첫 번째 `'='` 에서만 split (value 가 `'='` 포함 가능)

### `parse_line` silent-drop paths (4 tests, **drop 경로별 1개**)
- drop 1: empty / whitespace-only line
- drop 2: malformed / truncated JSON (`Yojson.Json_error`)
- drop 3: schema mismatch (필수 키 누락)
- drop 4: unknown State token

### `parse_line` happy paths (3 tests)
- running + labels round-trip
- 6 valid State tokens 전수 (`created`/`running`/`paused`/`restarting`/`exited`/`dead`)
- `strict=false` 가 unknown fields tolerate (CreatedAt, Image, Mounts, ...)

### `parse_output` (2 tests)
- empty / whitespace stdout → `[]`
- mixed 2 happy + 4 drops → 2 records, emission 순서 보존

## RFC §3.3 silent-drop trade-off 의 *실증*

`parse_ps_line` 의 4-path drop은 *catch-all 이 아닌 enumerated drops*. 본 PR 의 test suite 가 그 사실을 *executable evidence* 로 pin:
- 4 drop paths 각각 *reachable* (test 로 트리거 가능)
- 4 drop paths 각각 *exhaustive* (5th path 가 있다면 별도 test 필요)
- happy path 는 6 State variant × 7+ JSON 필드 tolerated

→ "opaque garbage-in/garbage-out" 라는 claim 을 *증거로 반박*. RFC-0070 §3.3 의 trade-off 는 **deliberate, enumerated, tested**.

## 검증

```
$ dune build lib/keeper test/test_docker_ps_parser.exe test/test_docker_client_real.exe
exit=0

$ _build/default/test/test_docker_ps_parser.exe
15 tests run, all PASS

$ _build/default/test/test_docker_client_real.exe
5 tests run, all PASS (회귀 없음)
```

ocamlformat 적용 완료 (Janestreet profile).

## 미검증

- *Real docker daemon integration test* — 별도 integration track (사실은 매 sub-phase 와 동일 미해결)
- *Parser performance under realistic fleet size* — 100+ container line 입력 시 List.filter_map의 O(N) 동작 측정 (현실적으로 fleet ≤ 16, 의미 없음)

## Workaround Rejection Bar self-check

| 시그니처 | 본 PR 해당? |
|---------|------------|
| Counter-as-fix | N/A — typed boundary 추가, metric 추가 아님 |
| String 분류기 | N/A — *wire format → typed value* 정방향 (정확히 RFC-0042 패턴의 *해소*) |
| N-of-M | **N/A** — extraction 완료. parser helper *전부* 분리 (no residual private helpers) |
| Cap/cooldown/dedup/repair | N/A |
| Test backdoor | N/A — parser 는 *production public API*, test 가 그것을 *direct* 호출 |
| Catch-all `_ ->` | N/A — 4 drop paths *enumerated*, exhaustive match |
| Hardcoded phrase | N/A |

## Out of scope

- `masc_docker_ps_parse_drop_total` Prometheus counter (RFC §3.3 follow-up note) — operational noise 가 *실측* 되면 추가
- `keeper_sandbox_runtime.ml` / `keeper_shell_docker.ml` caller cutover — Phase 4 영토
- `keeper_sandbox_control.ml` 8개 `try ... with _ -> None` catch-all 제거 — Phase 5 영토

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
