### PR TITLE
feat(keeper): RFC-0059 PR-7 soak observability + Lockfree_atomic adoption

### DIFF
--- a/lib/cache_eio.ml
+++ b/lib/cache_eio.ml
@@ -160,15 +160,12 @@ let cached_entry_count = Atomic.make (-1)
 let reset_cached_entry_count () = Atomic.set cached_entry_count (-1)
 
 let decrement_cached_entry_count () =
-  let rec loop () =
-    let current = Atomic.get cached_entry_count in
-    if current < 0
-    then ()
-    else (
-      let next = max 0 (current - 1) in
-      if not (Atomic.compare_and_set cached_entry_count current next) then loop ())
-  in
-  loop ()
+  (* Hand-rolled CAS loop replaced by [Lockfree_atomic.update].  The
+     transform is intentionally a no-op when the counter sits at the
+     "unknown" sentinel (-1) so a stale decrement during cache reset
+     does not push the cached count into bogus negative territory. *)
+  Lockfree_atomic.update cached_entry_count (fun current ->
+    if current < 0 then current else max 0 (current - 1))
 ;;
 
 let maybe_migrate_legacy_entry config ~key entry =

--- a/lib/keeper/keeper_metrics.ml
+++ b/lib/keeper/keeper_metrics.ml
@@ -42,6 +42,7 @@ type t =
   | TurnQueueDepth
   | SupervisorSweepStarts
   | SupervisorLastSweepUnixtime
+  | DomainPoolFork
   | SemaphoreWaitTimeout
   | TurnSlotBookkeepingFailures
   | SemaphoreWaitSeconds
@@ -238,6 +239,7 @@ let to_string = function
   | TurnQueueDepth -> "masc_keeper_turn_queue_depth"
   | SupervisorSweepStarts -> "masc_keeper_supervisor_sweep_starts_total"
   | SupervisorLastSweepUnixtime -> "masc_keeper_supervisor_last_sweep_unixtime"
+  | DomainPoolFork -> "masc_keeper_domain_pool_fork_total"
   | SemaphoreWaitTimeout -> "masc_keeper_semaphore_wait_timeout_total"
   | TurnSlotBookkeepingFailures -> "masc_keeper_turn_slot_bookkeeping_failures_total"
   | SemaphoreWaitSeconds -> "masc_keeper_semaphore_wait_seconds"
@@ -456,6 +458,17 @@ let metric_keeper_supervisor_sweep_starts = "masc_keeper_supervisor_sweep_starts
 let metric_keeper_supervisor_last_sweep_unixtime =
   "masc_keeper_supervisor_last_sweep_unixtime"
 ;;
+
+(* RFC-0059 PR-7 soak observability.  Each per-keeper supervised launch
+   increments this counter with one of four outcome labels:
+   - "pool"            flag ON + [Executor_pool_ref] returned a pool,
+                       body submitted to a worker Domain.
+   - "inline_no_pool"  flag ON but [Executor_pool_ref] was [None]
+                       (boot-order or misconfig); body ran inline.
+   - "inline_disabled" flag OFF (default); body ran inline on [ctx.sw].
+   - "submit_failed"   pool submit raised a non-cancellation exception;
+                       body ran inline via the fallback path. *)
+let metric_keeper_domain_pool_fork = to_string DomainPoolFork
 
 let metric_keeper_semaphore_wait_timeout = "masc_keeper_semaphore_wait_timeout_total"
 

--- a/lib/keeper/keeper_metrics.ml
+++ b/lib/keeper/keeper_metrics.ml
@@ -460,14 +460,23 @@ let metric_keeper_supervisor_last_sweep_unixtime =
 ;;
 
 (* RFC-0059 PR-7 soak observability.  Each per-keeper supervised launch
-   increments this counter with one of four outcome labels:
+   emits at least one increment of this counter, tagged with one of:
    - "pool"            flag ON + [Executor_pool_ref] returned a pool,
                        body submitted to a worker Domain.
    - "inline_no_pool"  flag ON but [Executor_pool_ref] was [None]
                        (boot-order or misconfig); body ran inline.
    - "inline_disabled" flag OFF (default); body ran inline on [ctx.sw].
    - "submit_failed"   pool submit raised a non-cancellation exception;
-                       body ran inline via the fallback path. *)
+                       body ran inline via the fallback path.
+
+   The launch path is **not** mutually exclusive over a single launch:
+   when an [outcome=pool] increment is followed by a worker-Domain
+   submit failure, the fallback path emits an additional
+   [outcome=submit_failed] increment for the same launch.  Aggregation
+   queries that count "supervised launches" should therefore sum only
+   over the launch-attempt outcomes [pool | inline_no_pool |
+   inline_disabled] and treat [submit_failed] as a failure-ratio
+   numerator over [outcome=pool] only. *)
 let metric_keeper_domain_pool_fork = to_string DomainPoolFork
 let metric_keeper_semaphore_wait_timeout = "masc_keeper_semaphore_wait_timeout_total"
 

--- a/lib/keeper/keeper_metrics.ml
+++ b/lib/keeper/keeper_metrics.ml
@@ -469,7 +469,6 @@ let metric_keeper_supervisor_last_sweep_unixtime =
    - "submit_failed"   pool submit raised a non-cancellation exception;
                        body ran inline via the fallback path. *)
 let metric_keeper_domain_pool_fork = to_string DomainPoolFork
-
 let metric_keeper_semaphore_wait_timeout = "masc_keeper_semaphore_wait_timeout_total"
 
 let metric_keeper_turn_slot_bookkeeping_failures =

--- a/lib/keeper/keeper_metrics.mli
+++ b/lib/keeper/keeper_metrics.mli
@@ -34,6 +34,7 @@ type t =
   | TurnQueueDepth
   | SupervisorSweepStarts
   | SupervisorLastSweepUnixtime
+  | DomainPoolFork
   | SemaphoreWaitTimeout
   | TurnSlotBookkeepingFailures
   | SemaphoreWaitSeconds
@@ -227,6 +228,12 @@ val metric_keeper_provider_block_duration_sec : string
 val metric_keeper_turn_queue_depth : string
 val metric_keeper_supervisor_sweep_starts : string
 val metric_keeper_supervisor_last_sweep_unixtime : string
+
+(** RFC-0059 PR-7 soak observability counter; labels: [outcome]
+    in {"pool" | "inline_no_pool" | "inline_disabled" | "submit_failed"},
+    [keeper] = keeper name. *)
+val metric_keeper_domain_pool_fork : string
+
 val metric_keeper_semaphore_wait_timeout : string
 val metric_keeper_turn_slot_bookkeeping_failures : string
 val metric_keeper_semaphore_wait_seconds : string

--- a/lib/keeper/keeper_metrics.mli
+++ b/lib/keeper/keeper_metrics.mli
@@ -229,9 +229,17 @@ val metric_keeper_turn_queue_depth : string
 val metric_keeper_supervisor_sweep_starts : string
 val metric_keeper_supervisor_last_sweep_unixtime : string
 
-(** RFC-0059 PR-7 soak observability counter; labels: [outcome]
-    in {"pool" | "inline_no_pool" | "inline_disabled" | "submit_failed"},
-    [keeper] = keeper name. *)
+(** RFC-0059 PR-7 soak observability counter.
+
+    Labels: [keeper] (keeper name, first), [outcome] in
+    {"pool" | "inline_no_pool" | "inline_disabled" | "submit_failed"}.
+
+    [outcome=submit_failed] is emitted in addition to a prior
+    [outcome=pool] increment on the same launch when the worker-Domain
+    submit raises a non-cancellation exception; the total counter can
+    therefore exceed the number of supervised launches.  Aggregations
+    that need launch counts should sum over [pool | inline_no_pool |
+    inline_disabled] only. *)
 val metric_keeper_domain_pool_fork : string
 
 val metric_keeper_semaphore_wait_timeout : string

--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -243,7 +243,10 @@ let launch_supervised_fiber
        (Keeper_state_machine.transition_error_to_string err);
      Prometheus.inc_counter
        Keeper_metrics.metric_keeper_supervisor_cleanup_failures
-       ~labels:[ "keeper", meta.name; "site", Supervisor_cleanup_failure_site.(to_label Fiber_start_rejected) ]
+       ~labels:
+         [ "keeper", meta.name
+         ; ("site", Supervisor_cleanup_failure_site.(to_label Fiber_start_rejected))
+         ]
        ());
   if restart_launch_noop_enabled_for_test ()
   then ()
@@ -276,9 +279,7 @@ let launch_supervised_fiber
        [run_heartbeat_loop] is the open architectural question this
        pilot exists to validate; see RFC-0059 §10 risks. *)
     let domain_pool_flag = Env_config.KeeperSupervisor.domain_pool_enabled in
-    let pool_for_keeper =
-      if domain_pool_flag then Executor_pool_ref.get () else None
-    in
+    let pool_for_keeper = if domain_pool_flag then Executor_pool_ref.get () else None in
     let bump_fork_outcome outcome =
       Prometheus.inc_counter
         Keeper_metrics.metric_keeper_domain_pool_fork
@@ -313,8 +314,7 @@ let launch_supervised_fiber
                the original "pool" launch attempt. *)
             bump_fork_outcome "submit_failed";
             Log.Keeper.warn
-              "keeper supervise pool submit failed, running inline: \
-               keeper=%s err=%s"
+              "keeper supervise pool submit failed, running inline: keeper=%s err=%s"
               meta.name
               (Printexc.to_string exn);
             body ())
@@ -859,7 +859,11 @@ let restore_reconcile_continue_gate (ctx : _ context) (meta : keeper_meta) =
             reason;
           Prometheus.inc_counter
             Keeper_metrics.metric_keeper_supervisor_cleanup_failures
-            ~labels:[ "keeper", meta.name; "site", Supervisor_cleanup_failure_site.(to_label Reconcile_gate_rejected) ]
+            ~labels:
+              [ "keeper", meta.name
+              ; ( "site"
+                , Supervisor_cleanup_failure_site.(to_label Reconcile_gate_rejected) )
+              ]
             ())
       ()
   in
@@ -927,7 +931,9 @@ let reconcile_keepalive_keepers (ctx : _ context) =
         | Error err ->
           Prometheus.inc_counter
             Keeper_metrics.metric_keeper_observation_query_failures
-            ~labels:[ "operation", Observation_query_operation.(to_label Reconcile_read_meta) ]
+            ~labels:
+              [ ("operation", Observation_query_operation.(to_label Reconcile_read_meta))
+              ]
             ();
           Log.Keeper.warn "reconcile: read_meta failed for %s: %s" name err);
        Eio_guard.yield_step reconcile_ym)
@@ -1004,7 +1010,10 @@ let cleanup_dead_tombstone (ctx : _ context) (entry : Keeper_registry.registry_e
         entry.name;
       Prometheus.inc_counter
         Keeper_metrics.metric_keeper_supervisor_cleanup_failures
-        ~labels:[ "keeper", entry.name; "site", Supervisor_cleanup_failure_site.(to_label Dead_tombstone_meta_write) ]
+        ~labels:
+          [ "keeper", entry.name
+          ; ("site", Supervisor_cleanup_failure_site.(to_label Dead_tombstone_meta_write))
+          ]
         ())
   | Ok None ->
     Keeper_registry.unregister ~base_path:ctx.config.base_path entry.name;
@@ -1019,7 +1028,10 @@ let cleanup_dead_tombstone (ctx : _ context) (entry : Keeper_registry.registry_e
     Log.Keeper.warn "%s: dead tombstone unregistered (meta missing)" entry.name;
     Prometheus.inc_counter
       Keeper_metrics.metric_keeper_supervisor_cleanup_failures
-      ~labels:[ "keeper", entry.name; "site", Supervisor_cleanup_failure_site.(to_label Dead_tombstone_meta_missing) ]
+      ~labels:
+        [ "keeper", entry.name
+        ; ("site", Supervisor_cleanup_failure_site.(to_label Dead_tombstone_meta_missing))
+        ]
       ()
   | Error err ->
     Keeper_registry.unregister ~base_path:ctx.config.base_path entry.name;
@@ -1034,7 +1046,10 @@ let cleanup_dead_tombstone (ctx : _ context) (entry : Keeper_registry.registry_e
     Log.Keeper.warn "%s: dead tombstone unregistered (meta error: %s)" entry.name err;
     Prometheus.inc_counter
       Keeper_metrics.metric_keeper_supervisor_cleanup_failures
-      ~labels:[ "keeper", entry.name; "site", Supervisor_cleanup_failure_site.(to_label Dead_tombstone_meta_error) ]
+      ~labels:
+        [ "keeper", entry.name
+        ; ("site", Supervisor_cleanup_failure_site.(to_label Dead_tombstone_meta_error))
+        ]
       ()
 ;;
 
@@ -1506,8 +1521,7 @@ let sweep_and_recover (ctx : _ context) =
        List.iter
          (fun (v : Keeper_invariant_check.violation) ->
             Log.Keeper.warn
-              "keeper_invariant_violation: keeper=%s phase=%s property=%s \
-               detail=%s"
+              "keeper_invariant_violation: keeper=%s phase=%s property=%s detail=%s"
               entry.name
               (Keeper_state_machine.phase_to_string entry.phase)
               v.property
@@ -1647,7 +1661,10 @@ let sweep_and_recover (ctx : _ context) =
       msg;
     Prometheus.inc_counter
       Keeper_metrics.metric_keeper_supervisor_cleanup_failures
-      ~labels:[ "keeper", entry.name; "site", Supervisor_cleanup_failure_site.(to_label Force_watchdog_crash) ]
+      ~labels:
+        [ "keeper", entry.name
+        ; ("site", Supervisor_cleanup_failure_site.(to_label Force_watchdog_crash))
+        ]
       ();
     (* 2026-05-05 fleet-stuck cycle: when a keeper fiber is stuck inside
        an LLM subprocess that does not honour [Eio.Cancel.Cancelled],
@@ -1826,9 +1843,7 @@ let sweep_and_recover (ctx : _ context) =
             exhausted keepers to [to_mark_dead], not [to_restart].  A
             refusal here means some out-of-band path cleared the budget
             (one of the three vectors documented in iter 14 audit memo). *)
-         (match
-            Keeper_registry.register_restarting ~base_path old_entry.name meta
-          with
+         (match Keeper_registry.register_restarting ~base_path old_entry.name meta with
           | Error (Keeper_registry.Budget_already_exhausted _) ->
             (* Route to mark_dead instead of merely skipping: a keeper that
                trips the BudgetNeverRevives guard should reach a stable
@@ -1942,7 +1957,10 @@ let sweep_and_recover (ctx : _ context) =
              (Printexc.to_string exn);
            Prometheus.inc_counter
              Keeper_metrics.metric_keeper_supervisor_cleanup_failures
-             ~labels:[ "keeper", name; "site", Supervisor_cleanup_failure_site.(to_label Paused_meta_prune) ]
+             ~labels:
+               [ "keeper", name
+               ; ("site", Supervisor_cleanup_failure_site.(to_label Paused_meta_prune))
+               ]
              ())
       | _ -> ());
     Eio_guard.yield_step sweep_names_ym);

--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -281,9 +281,14 @@ let launch_supervised_fiber
     let domain_pool_flag = Env_config.KeeperSupervisor.domain_pool_enabled in
     let pool_for_keeper = if domain_pool_flag then Executor_pool_ref.get () else None in
     let bump_fork_outcome outcome =
+      (* Label order mirrors the other [keeper_supervisor.ml] inc_counter
+         call sites ([keeper] first, then the discriminator).  Prometheus
+         label-set keys are order-sensitive, so a single per-metric
+         convention prevents accidental time-series splitting when new
+         call sites add the same labels in a different order. *)
       Prometheus.inc_counter
         Keeper_metrics.metric_keeper_domain_pool_fork
-        ~labels:[ "outcome", outcome; "keeper", meta.name ]
+        ~labels:[ "keeper", meta.name; "outcome", outcome ]
         ()
     in
     (* IO-bound weight: 0.05 mirrors [Domain_pool.weight_io] (the

--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -275,10 +275,15 @@ let launch_supervised_fiber
        Cross-domain switch / fiber-local-state safety inside
        [run_heartbeat_loop] is the open architectural question this
        pilot exists to validate; see RFC-0059 §10 risks. *)
+    let domain_pool_flag = Env_config.KeeperSupervisor.domain_pool_enabled in
     let pool_for_keeper =
-      if Env_config.KeeperSupervisor.domain_pool_enabled
-      then Executor_pool_ref.get ()
-      else None
+      if domain_pool_flag then Executor_pool_ref.get () else None
+    in
+    let bump_fork_outcome outcome =
+      Prometheus.inc_counter
+        Keeper_metrics.metric_keeper_domain_pool_fork
+        ~labels:[ "outcome", outcome; "keeper", meta.name ]
+        ()
     in
     (* IO-bound weight: 0.05 mirrors [Domain_pool.weight_io] (the
        canonical IO weight from [lib/core/domain_pool.ml:9]).  The
@@ -292,6 +297,7 @@ let launch_supervised_fiber
     let fork_body body =
       match pool_for_keeper with
       | Some pool ->
+        bump_fork_outcome "pool";
         Eio.Fiber.fork ~sw:ctx.sw (fun () ->
           try Eio.Executor_pool.submit_exn pool ~weight:keeper_io_weight body with
           | Eio.Cancel.Cancelled _ as e -> raise e
@@ -301,14 +307,21 @@ let launch_supervised_fiber
                itself fails (rather than the body raising on
                cancellation), warn-log and fall back inline so a
                misconfigured pool does not bring down the supervisor
-               by surfacing the exception to [ctx.sw]. *)
+               by surfacing the exception to [ctx.sw].  We emit a
+               second counter increment with [outcome=submit_failed]
+               so dashboards can see the failure ratio without losing
+               the original "pool" launch attempt. *)
+            bump_fork_outcome "submit_failed";
             Log.Keeper.warn
               "keeper supervise pool submit failed, running inline: \
                keeper=%s err=%s"
               meta.name
               (Printexc.to_string exn);
             body ())
-      | None -> Eio.Fiber.fork ~sw:ctx.sw body
+      | None ->
+        bump_fork_outcome
+          (if domain_pool_flag then "inline_no_pool" else "inline_disabled");
+        Eio.Fiber.fork ~sw:ctx.sw body
     in
     fork_body (fun () ->
       let resolved = ref false in


### PR DESCRIPTION
## Summary

Follow-up to #14718 (Domain pool pilot, now merged).  Adds two distinct OCaml 5.x wins.

### 1. Domain pool fork outcome counter (soak readiness)

#14718 ships the flag-gated fork but has **no observability** for the soak phase. This PR closes that.

New variant: `Keeper_metrics.DomainPoolFork` → `masc_keeper_domain_pool_fork_total{outcome, keeper}` with four outcomes:

| outcome           | meaning                                                        | soak signal             |
|-------------------|----------------------------------------------------------------|-------------------------|
| `pool`            | flag ON + pool present, body submitted to worker Domain        | target under flag=true  |
| `inline_no_pool`  | flag ON but `Executor_pool_ref` was `None` (boot order issue) | indicates misconfig     |
| `inline_disabled` | flag OFF (default), body ran inline on `ctx.sw`                | expected today          |
| `submit_failed`   | pool submit raised non-cancellation exception                  | pages on any nonzero    |

The counter is independent of the flag — under default (flag=OFF) every launch emits `outcome=inline_disabled`, which already gives dashboards a baseline keeper-launch rate to compare against once the flag is flipped per-keeper.

### 2. Replace hand-rolled CAS loop with `Lockfree_atomic.update`

`cache_eio.decrement_cached_entry_count` had a stray hand-rolled `Atomic.get` + `Atomic.compare_and_set` retry loop. `Lockfree_atomic` (already consolidating the CAS pattern across `agent_registry_eio` / `sse` / `tool_registry`) is the canonical helper. Identical semantics — the `-1` sentinel for ""unknown"" is still passed through — but intent is explicit and the loop body cannot drift from the surrounding accessor pattern.

### Soak procedure (next step, separate PR-7b)

Once this lands, the soak rollout is:

1. Stage env: `MASC_KEEPER_DOMAIN_POOL_ENABLED=true` on 1–2 keepers
2. Dashboards: watch `masc_keeper_domain_pool_fork_total` outcome split. Expected: ~100% `pool`, 0% `submit_failed`.
3. Latency: compare `masc_keeper_turn_latency_bucket` p95/p99 vs. baseline (flag=false fleet)
4. Watchdog: monitor `masc_keeper_stale_turn_timeout`, `masc_keeper_provider_runtime_error` for elevation
5. If clean for 24h: extend to full fleet via PR-7b that flips default ON

## Test plan

- [x] `dune build --root . @check`: PASS
- [x] `dune exec --root . test/test_keeper_supervisor.exe`: **70/70 PASS** (no regression on flag default OFF)
- [x] `dune exec --root . test/test_cache_eio.exe`: **16/16 PASS**
- [x] `dune exec --root . test/test_cache_eio_coverage.exe`: **11/11 PASS**

## RFC reference

RFC-0059 §10 (Tier A Integration) — closes observability gap that the PR-7-pilot left open by design. Not a new pattern, just instrumentation around the existing merged pilot. Adoption of `Lockfree_atomic` extends existing in-repo infrastructure (no new dependencies).

🤖 Generated with [Claude Code](https://claude.com/claude-code)