### PR TITLE
spec(scripts): R-H-1.f OCaml docstring phase-count validator + 2 new sites (iter 55)

### DIFF
--- a/.github/workflows/tla-annotation-drift.yml
+++ b/.github/workflows/tla-annotation-drift.yml
@@ -24,6 +24,10 @@ on:
       - 'lib/cascade/cascade_fsm.mli'
       - 'scripts/audit-tla-annotation-drift.sh'
       - 'scripts/audit-tla-phase-count.sh'
+      - 'scripts/audit-ocaml-phase-count.sh'
+      - 'scripts/ocaml-phase-count-baseline.txt'
+      - 'lib/keeper/**/*.ml'
+      - 'lib/keeper/**/*.mli'
       - 'scripts/tla-annotation-drift-baseline.txt'
       - '.github/workflows/tla-annotation-drift.yml'
   push:
@@ -37,6 +41,10 @@ on:
       - 'lib/cascade/cascade_fsm.mli'
       - 'scripts/audit-tla-annotation-drift.sh'
       - 'scripts/audit-tla-phase-count.sh'
+      - 'scripts/audit-ocaml-phase-count.sh'
+      - 'scripts/ocaml-phase-count-baseline.txt'
+      - 'lib/keeper/**/*.ml'
+      - 'lib/keeper/**/*.mli'
       - 'scripts/tla-annotation-drift-baseline.txt'
   workflow_dispatch: {}
 
@@ -76,3 +84,16 @@ jobs:
         # same way.  See docs/tla-audit/rh1b-sweep-zombie-12-phases-
         # stale-2026-05-12.md for the audit that motivated it.
         run: bash scripts/audit-tla-phase-count.sh
+
+      - name: Run OCaml phase-count validator (R-H-1.f)
+        # OCaml-side twin of R-H-1.c.  Iter 54 (#14886) discovered the
+        # same 12→13 stale-count drift class in lib/keeper/*.{ml,mli}
+        # docstrings — six sites, two of them ("11-state" in
+        # keeper_registry) predating even Zombie addition.  Baseline
+        # file grandfathers the four sites still pending fix from PR
+        # #14886; once that PR merges, the corresponding baseline lines
+        # must be removed in a follow-up so future regressions are
+        # caught.
+        run: |
+          bash scripts/audit-ocaml-phase-count.sh \
+            --baseline scripts/ocaml-phase-count-baseline.txt

--- a/lib/keeper/keeper_registry.ml
+++ b/lib/keeper/keeper_registry.ml
@@ -492,9 +492,11 @@ type turn_measurement =
 type registry_entry =
   { base_path : string
   ; name : string
-  ; meta : keeper_meta (** Keeper lifecycle phase (RFC-0002 13-state machine; 11 at #5229 → 12 Overflowed (MASC-1) → 13 Zombie #14707). *)
-  ; phase : Keeper_state_machine.phase (** Observable conditions that derive [phase]. *)
+  ; meta : keeper_meta
+  ; phase : Keeper_state_machine.phase
+    (** Keeper lifecycle phase (RFC-0002 13-state machine; 11 at #5229 → 12 Overflowed (MASC-1) → 13 Zombie #14707). *)
   ; conditions : Keeper_state_machine.conditions
+    (** Observable conditions that derive [phase]. *)
   ; fiber_stop : bool Atomic.t
   ; fiber_wakeup : bool Atomic.t
   ; event_queue : Keeper_event_queue.t Atomic.t

--- a/lib/keeper/keeper_registry.ml
+++ b/lib/keeper/keeper_registry.ml
@@ -492,7 +492,7 @@ type turn_measurement =
 type registry_entry =
   { base_path : string
   ; name : string
-  ; meta : keeper_meta (** Keeper lifecycle phase (RFC-0002 11-state machine). *)
+  ; meta : keeper_meta (** Keeper lifecycle phase (RFC-0002 13-state machine; 11 at #5229 → 12 Overflowed (MASC-1) → 13 Zombie #14707). *)
   ; phase : Keeper_state_machine.phase (** Observable conditions that derive [phase]. *)
   ; conditions : Keeper_state_machine.conditions
   ; fiber_stop : bool Atomic.t

--- a/lib/keeper/keeper_registry.mli
+++ b/lib/keeper/keeper_registry.mli
@@ -304,7 +304,8 @@ type registry_entry = {
   name : string;
   meta : keeper_meta;
   phase : Keeper_state_machine.phase;
-      (** Keeper lifecycle phase (RFC-0002 11-state machine). *)
+      (** Keeper lifecycle phase (RFC-0002 13-state machine; 11 at #5229
+          → 12 with Overflowed (MASC-1) → 13 with Zombie #14707). *)
   conditions : Keeper_state_machine.conditions;
       (** Observable conditions that derive [phase]. *)
   fiber_stop : bool Atomic.t;

--- a/scripts/audit-ocaml-phase-count.sh
+++ b/scripts/audit-ocaml-phase-count.sh
@@ -103,11 +103,13 @@ fi
 
 [[ "${VERBOSE}" -eq 1 ]] && echo "SSOT phase count: ${SSOT_COUNT}" >&2
 
-# Qualifier whitelist.  Adds `must skip`, `excludes`, `other` on top of
-# the TLA+ variant: these idioms appear in OCaml exhaustive-match
-# comments like "the other N phases must skip ..." where N = SSOT - 1
-# (e.g. keeper_runtime.ml:779 with N=12 when SSOT=13).
-QUALIFIERS='(non-|fragment|projection|subset|relevant|out of scope|models|collapse|symbol|triad|mapping|excluding|abstract|sibling|companion|must skip|excludes|other)'
+# Qualifier whitelist.  Adds `must skip`, `excludes`, "other N phases"
+# / "the other N phases" on top of the TLA+ variant: these idioms appear
+# in OCaml exhaustive-match comments like "the other N phases must
+# skip ..." where N = SSOT - 1 (e.g. keeper_runtime.ml:779 with N=12 when
+# SSOT=13).  `other` is anchored to "other N phases" so bare uses of the
+# word "other" do not silently exempt real drifts.
+QUALIFIERS='(non-|fragment|projection|subset|relevant|out of scope|models|collapse|symbol|triad|mapping|excluding|abstract|sibling|companion|must skip|excludes|(the )?other [0-9]+ phases?)'
 
 drift_count=0
 tmpfile="$(mktemp)"
@@ -116,9 +118,15 @@ trap 'rm -f "${tmpfile}"' EXIT
 # rg over OCaml comment-bearing lines.  We match both `N-state` and
 # `N[ -]phase(s)?` patterns since OCaml docstrings use both
 # ("13-state keeper lifecycle", "13-phase enum", "13 phases").
+rg_exit=0
 rg -n --no-heading --glob '*.ml' --glob '*.mli' \
   -e '\b([0-9]{1,2})[ -](state|phase(s)?)\b' \
-  "${KEEPER_DIR}" 2>/dev/null > "${tmpfile}" || true
+  "${KEEPER_DIR}" > "${tmpfile}" 2>/dev/null || rg_exit=$?
+# rg exit 1 = no matches (treat as clean); exit 2+ = error (regex / I/O / glob).
+if [[ "${rg_exit}" -ge 2 ]]; then
+  echo "ERROR: ripgrep failed with exit ${rg_exit} while scanning ${KEEPER_DIR}" >&2
+  exit "${rg_exit}"
+fi
 
 while IFS= read -r entry; do
   [[ -z "${entry}" ]] && continue
@@ -127,23 +135,26 @@ while IFS= read -r entry; do
   lineno="${rest%%:*}"
   content="${rest#*:}"
 
-  # Restrict to lines that are inside a comment.  OCaml has two
-  # comment syntaxes: `(* ... *)` and `(** ... *)`.  Continuation
-  # lines of a comment block do not start with `(*` so we use a more
-  # permissive rule: a line is treated as "comment context" if it does
-  # NOT contain `let`, `type`, `match`, `function` keywords at column 0
-  # (rough proxy for code vs prose).  This avoids flagging variant
-  # names or pattern-match arms that happen to contain the pattern.
-  if printf '%s' "${content}" | grep -qE '^(let|type|match|function|val|and|in|module)[[:space:]]'; then
-    continue
-  fi
-  # Additionally skip lines that look like type signatures with phase
-  # arity (e.g. `phase : Keeper_state_machine.phase`) by requiring the
-  # surrounding context to look like prose.  The simplest filter: the
-  # numeric pattern must be preceded by something looking like prose
-  # (letter or space), not by `=` or `;`.
-  case "${content}" in
-    *"="*|*";"*[0-9]*"-state"*|*";"*[0-9]*"-phase"*) :;;
+  # Restrict to lines that look like OCaml comment / docstring context.
+  # OCaml comment syntaxes: `(* ... *)` and `(** ... *)`.  Heuristic
+  # (the script intentionally avoids a full OCaml comment-span parser):
+  # require the line, after stripping leading whitespace, to either
+  # (a) start with `(*` / `(**` / `*` (in-comment continuation) — i.e.
+  # clearly inside a comment block, or (b) contain `*)` (comment closer
+  # on the same line).  Code lines like `let foo = ...`, `type t = ...`,
+  # variant arms etc. are rejected because they neither start with
+  # `(*` / `*` nor contain `*)`.  This is more reliable than the prior
+  # left-anchored keyword filter, which let prefixed-whitespace code
+  # through and could flag string literals.
+  stripped="${content#"${content%%[![:space:]]*}"}"
+  case "${stripped}" in
+    '(*'*|'(**'*|'*'*) : ;;          # comment open or continuation
+    *)
+      case "${content}" in
+        *'*)'*) : ;;                 # contains comment closer
+        *) continue ;;
+      esac
+      ;;
   esac
 
   matched_n="$(printf '%s' "${content}" \

--- a/scripts/audit-ocaml-phase-count.sh
+++ b/scripts/audit-ocaml-phase-count.sh
@@ -1,0 +1,198 @@
+#!/usr/bin/env bash
+# audit-ocaml-phase-count.sh — detect OCaml docstring/comment mentions
+# of "N-state" / "N-phase" / "N phases" in lib/keeper/*.{ml,mli} that
+# disagree with the `type phase` constructor count in
+# keeper_state_machine.ml.
+#
+# Background: iter 49-53 closed the 6th drift class on the TLA+ spec
+# side via `scripts/audit-tla-phase-count.sh` (R-H-1.c, #14874).  Iter
+# 54 (R-H-1.e, #14886) discovered the same class lurking in OCaml
+# docstrings: four sites still cited "12-state" even though the
+# canonical type declaration had 13 constructors after Zombie
+# (#14707, /loop iter 4) was added.  This script is the OCaml-side
+# regression guard so the next phase-count change cannot quietly
+# leave docstrings stale.
+#
+# Rule (mirrors audit-tla-phase-count.sh, OCaml comment syntax):
+#   - SSOT: count `  | <CamelCase>` constructors between `type phase =`
+#     and the next blank line in lib/keeper/keeper_state_machine.ml.
+#   - Sweep `lib/keeper/*.{ml,mli}` for `\b(\d{1,2})[ -]state\b` and
+#     `\b(\d{1,2})[ -]phase(s)?\b` inside comment lines (`(*`/`(**` or
+#     continuation lines of a comment block).
+#   - Range filter [SSOT-3 .. SSOT+5]: out-of-range numbers refer to
+#     sibling FSMs (cascade=6, decision=5, turn-phase=7, etc.) and
+#     are intentionally not flagged.
+#   - Qualifier whitelist: if the line contains `non-`, `fragment`,
+#     `projection`, `subset`, `relevant`, `out of scope`, `models`,
+#     `collapse`, `symbol`, `triad`, `mapping`, `excluding`, `must skip`,
+#     `excludes`, `other`, the mention is treated as an intentional
+#     subset description.  `must skip` and `other` cover the
+#     `keeper_runtime.ml:779`-style "the other N phases must skip"
+#     comments where N = SSOT - 1.
+#
+# Usage: bash scripts/audit-ocaml-phase-count.sh [--verbose]
+#
+# RFC chain: R-B-1.c → R-H-1.c (TLA+ side #14874) → R-H-1.f (this
+# script, OCaml side).
+set -euo pipefail
+
+for tool in rg awk grep; do
+  command -v "${tool}" >/dev/null 2>&1 || {
+    echo "error: required tool '${tool}' not found in PATH" >&2
+    exit 2
+  }
+done
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+KEEPER_DIR="${REPO_ROOT}/lib/keeper"
+SSOT_FILE="${REPO_ROOT}/lib/keeper/keeper_state_machine.ml"
+
+VERBOSE=0
+BASELINE_FILE=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --verbose) VERBOSE=1; shift ;;
+    --baseline) BASELINE_FILE="$2"; shift 2 ;;
+    --baseline=*) BASELINE_FILE="${1#*=}"; shift ;;
+    *) echo "unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+# Baseline file format: one entry per line, "<repo-relative-path>:<lineno>",
+# blank lines and lines starting with '#' are comments.  These entries
+# are pre-existing drifts being fixed in flight by other PRs; the
+# validator skips them so CI doesn't false-fail during the merge
+# window.  Baseline entries MUST be removed once the corresponding fix
+# PR lands.
+declare -a BASELINE_KEYS=()
+if [[ -n "${BASELINE_FILE}" ]]; then
+  if [[ ! -f "${BASELINE_FILE}" ]]; then
+    echo "error: baseline file not found: ${BASELINE_FILE}" >&2
+    exit 2
+  fi
+  while IFS= read -r raw; do
+    [[ -z "${raw}" ]] && continue
+    case "${raw}" in '#'*) continue;; esac
+    BASELINE_KEYS+=("${raw}")
+  done < "${BASELINE_FILE}"
+  [[ "${VERBOSE}" -eq 1 ]] && \
+    echo "loaded ${#BASELINE_KEYS[@]} baseline entries" >&2
+fi
+
+in_baseline() {
+  local key="$1"
+  local b
+  for b in "${BASELINE_KEYS[@]:-}"; do
+    [[ "${b}" == "${key}" ]] && return 0
+  done
+  return 1
+}
+
+SSOT_COUNT="$(awk '
+  /^type phase =/ { in_block = 1; next }
+  in_block && /^[[:space:]]*$/ { exit }
+  in_block && /^[[:space:]]*\|[[:space:]]*[A-Z]/ { count++ }
+  END { print count + 0 }
+' "${SSOT_FILE}")"
+
+if [[ -z "${SSOT_COUNT}" || "${SSOT_COUNT}" -lt 2 ]]; then
+  echo "error: could not extract phase constructor count from ${SSOT_FILE}" >&2
+  echo "       (got '${SSOT_COUNT}')" >&2
+  exit 2
+fi
+
+[[ "${VERBOSE}" -eq 1 ]] && echo "SSOT phase count: ${SSOT_COUNT}" >&2
+
+# Qualifier whitelist.  Adds `must skip`, `excludes`, `other` on top of
+# the TLA+ variant: these idioms appear in OCaml exhaustive-match
+# comments like "the other N phases must skip ..." where N = SSOT - 1
+# (e.g. keeper_runtime.ml:779 with N=12 when SSOT=13).
+QUALIFIERS='(non-|fragment|projection|subset|relevant|out of scope|models|collapse|symbol|triad|mapping|excluding|abstract|sibling|companion|must skip|excludes|other)'
+
+drift_count=0
+tmpfile="$(mktemp)"
+trap 'rm -f "${tmpfile}"' EXIT
+
+# rg over OCaml comment-bearing lines.  We match both `N-state` and
+# `N[ -]phase(s)?` patterns since OCaml docstrings use both
+# ("13-state keeper lifecycle", "13-phase enum", "13 phases").
+rg -n --no-heading --glob '*.ml' --glob '*.mli' \
+  -e '\b([0-9]{1,2})[ -](state|phase(s)?)\b' \
+  "${KEEPER_DIR}" 2>/dev/null > "${tmpfile}" || true
+
+while IFS= read -r entry; do
+  [[ -z "${entry}" ]] && continue
+  file="${entry%%:*}"
+  rest="${entry#*:}"
+  lineno="${rest%%:*}"
+  content="${rest#*:}"
+
+  # Restrict to lines that are inside a comment.  OCaml has two
+  # comment syntaxes: `(* ... *)` and `(** ... *)`.  Continuation
+  # lines of a comment block do not start with `(*` so we use a more
+  # permissive rule: a line is treated as "comment context" if it does
+  # NOT contain `let`, `type`, `match`, `function` keywords at column 0
+  # (rough proxy for code vs prose).  This avoids flagging variant
+  # names or pattern-match arms that happen to contain the pattern.
+  if printf '%s' "${content}" | grep -qE '^(let|type|match|function|val|and|in|module)[[:space:]]'; then
+    continue
+  fi
+  # Additionally skip lines that look like type signatures with phase
+  # arity (e.g. `phase : Keeper_state_machine.phase`) by requiring the
+  # surrounding context to look like prose.  The simplest filter: the
+  # numeric pattern must be preceded by something looking like prose
+  # (letter or space), not by `=` or `;`.
+  case "${content}" in
+    *"="*|*";"*[0-9]*"-state"*|*";"*[0-9]*"-phase"*) :;;
+  esac
+
+  matched_n="$(printf '%s' "${content}" \
+    | grep -oE '[0-9]{1,2}[ -](state|phase)' \
+    | head -1 \
+    | grep -oE '^[0-9]+')"
+  [[ -z "${matched_n}" ]] && continue
+
+  if [[ "${matched_n}" == "${SSOT_COUNT}" ]]; then
+    continue
+  fi
+
+  # Range filter — sibling FSMs (cascade=6, decision=5, turn=7, etc.)
+  # use the same "N-state" / "N-phase" idiom and are intentionally not
+  # the keeper-count drift class.
+  range_lo=$((SSOT_COUNT - 3))
+  range_hi=$((SSOT_COUNT + 5))
+  if (( matched_n < range_lo || matched_n > range_hi )); then
+    [[ "${VERBOSE}" -eq 1 ]] && \
+      echo "ok (out-of-keeper-range): ${file}:${lineno} — ${matched_n} not in [${range_lo}..${range_hi}]" >&2
+    continue
+  fi
+
+  if printf '%s' "${content}" | grep -qiE "${QUALIFIERS}"; then
+    [[ "${VERBOSE}" -eq 1 ]] && \
+      echo "ok (qualified): ${file}:${lineno} — ${matched_n} != ${SSOT_COUNT}" >&2
+    continue
+  fi
+
+  rel_path="${file#${REPO_ROOT}/}"
+  key="${rel_path}:${lineno}"
+  if in_baseline "${key}"; then
+    [[ "${VERBOSE}" -eq 1 ]] && \
+      echo "ok (baseline): ${key} — ${matched_n} != ${SSOT_COUNT} (pending fix-PR)" >&2
+    continue
+  fi
+
+  printf 'drift: %s — mentions "%s" but SSOT (lib/keeper/keeper_state_machine.ml type phase) has %s constructors\n' \
+    "${key}" "${matched_n}-state/phase" "${SSOT_COUNT}"
+  drift_count=$((drift_count + 1))
+done < "${tmpfile}"
+
+if [[ "${drift_count}" -gt 0 ]]; then
+  echo "" >&2
+  echo "${drift_count} OCaml docstring phase-count drift(s) detected." >&2
+  echo "Fix: update the docstring/comment to match keeper_state_machine.ml" >&2
+  echo "(${SSOT_COUNT} constructors), or add a qualifier (non-Zombie, projection," >&2
+  echo "fragment, must skip, ...) if the mention is intentionally a subset count." >&2
+  exit 1
+fi
+
+echo "OCaml phase-count audit clean: SSOT=${SSOT_COUNT}, no unqualified mismatches." >&2

--- a/scripts/ocaml-phase-count-baseline.txt
+++ b/scripts/ocaml-phase-count-baseline.txt
@@ -1,0 +1,17 @@
+# OCaml phase-count baseline — pre-existing drifts grandfathered while
+# their fix PR is in flight.  Each line: "<repo-relative-path>:<lineno>".
+#
+# Iter 54 R-H-1.e (#14886) fixes the four "12-state" sites below.
+# Once that PR merges, remove the corresponding lines in a follow-up.
+# The CI step that runs this validator will then enforce zero drift.
+#
+# Why baseline rather than fix-in-place: iter 55 R-H-1.f (this PR) is
+# strictly the *validator* + the two NEW sites the validator surfaced
+# (keeper_registry.{ml,mli} "11-state" mentions predating both
+# Overflowed (MASC-1) and Zombie (#14707) additions).  Folding iter 54's
+# already-reviewed fixes here would create a stack with #14886.
+
+lib/keeper/keeper_state_machine.mli:3
+lib/keeper/keeper_composite_observer.mli:181
+lib/keeper/keeper_composite_observer.ml:257
+lib/keeper/keeper_exec_status.ml:592


### PR DESCRIPTION
## Finding (Iteration 55, R-H-1.f — OCaml-side structural guard + 2 new sites)

**Script**: `scripts/audit-ocaml-phase-count.sh` (NEW, ~150 LOC) + baseline file
**CI**: `.github/workflows/tla-annotation-drift.yml` (3rd step added)
**Fixes**: 2 new "11-state" mentions in `keeper_registry.{ml,mli}` predating Zombie addition
**Risk**: LOW (validator + 2-line docstring fix, no semantic change, no build impact)
**Workaround signature**: N/A — closure-by-construction for OCaml side of 6th drift class.

## 순서도

```mermaid
flowchart TD
  A[iter 49-53: TLA+ corpus closed] --> B[iter 54 #14886: manual sweep finds 4 'sites' in lib/keeper/]
  B --> C{iter 55: structural validator}
  C --> D[Sweep all lib/keeper/*.ml,mli for N-state/N-phase]
  D --> E[Range filter SSOT±range]
  E --> F[Qualifier whitelist]
  F --> G{6 drifts found}
  G --> H[4 sites in iter 54 scope - baselined]
  G --> I[2 NEW sites '11-state' in keeper_registry]
  I --> J[Fixed in this PR]
  H --> K[Cleanup follow-up after #14886 merge]
  D --> L[CI: validator activates on lib/keeper/** changes]
```

## Discovery: 2 new "11-state" sites

The validator found two mentions iter 54's manual `rg "12[ -]state"` missed:

```ocaml
(* keeper_registry.mli:307 *)
  phase : Keeper_state_machine.phase;
      (** Keeper lifecycle phase (RFC-0002 11-state machine). *)
                                       ^^^^^^^^^^^^^^^^^^^^^^^
                                       Predates both Overflowed (+1 → 12)
                                       AND Zombie (+1 → 13).  This docstring
                                       was added at the original RFC-0002
                                       Phase 1 commit (#5229, 2026-04-05)
                                       and never updated through two
                                       phase-count bumps.
```

Both sites updated to `"RFC-0002 13-state machine; 11 at #5229 → 12 Overflowed (MASC-1) → 13 Zombie #14707"`, consistent with the iter 54 history line in `keeper_state_machine.mli`.

## Validator architecture

Mirrors `audit-tla-phase-count.sh` (#14874) but for OCaml corpus:

| Aspect | TLA+ validator (#14874) | OCaml validator (this PR) |
|--------|-------------------------|---------------------------|
| Corpus | `specs/keeper-state-machine/*.tla` | `lib/keeper/*.{ml,mli}` |
| SSOT extraction | awk `type phase =` block | (same) |
| Pattern | `\* ... N[ -]phases?` | `\b N[ -](state\|phase(s)?)\b` |
| Range filter | `[SSOT-3..SSOT+5]` | (same) |
| Qualifier whitelist | `non-/fragment/projection/...` | (same) + `must skip`, `excludes`, `other` for `runtime.ml:779`-style idioms |
| Baseline mechanism | none (no in-flight fixes) | `--baseline FILE` (4 in-flight sites from #14886) |

## CI behavior matrix

| Pre-state | Post-#14886 + this PR merge | Action required |
|-----------|----------------------------|-----------------|
| origin/main today: 4 stale + 2 stale | This PR fixes 2, #14886 fixes 4 | After both merge: remove baseline lines |
| Only this PR merges first | 4 baselined drifts still present, validator silent on them | None — CI green |
| Only #14886 merges first | 4 sites fixed but baseline still cites them as "expected" | None — validator skips, but baseline becomes stale |
| Both merged + baseline cleared | 0 drifts, validator enforces zero | Future regression caught at CI gate |

## Verification (local)

```bash
$ bash scripts/audit-ocaml-phase-count.sh --baseline scripts/ocaml-phase-count-baseline.txt --verbose
loaded 4 baseline entries
SSOT phase count: 13
ok (out-of-keeper-range): lib/keeper/oas_execution_error_phase.mli:4 — 7 not in [10..18]
ok (qualified): lib/keeper/keeper_composite_observer.mli:178 — 12 != 13
ok (baseline): lib/keeper/keeper_composite_observer.mli:181 — 12 != 13 (pending fix-PR)
ok (baseline): lib/keeper/keeper_exec_status.ml:592 — 12 != 13 (pending fix-PR)
ok (out-of-keeper-range): lib/keeper/keeper_lifecycle_events.ml:88 — 4 not in [10..18]
ok (qualified): lib/keeper/keeper_runtime.ml:779 — 12 != 13
ok (baseline): lib/keeper/keeper_composite_observer.ml:257 — 12 != 13 (pending fix-PR)
ok (baseline): lib/keeper/keeper_state_machine.mli:3 — 12 != 13 (pending fix-PR)
ok (out-of-keeper-range): lib/keeper/keeper_registry.ml:177 — 7 not in [10..18]
ok (out-of-keeper-range): lib/keeper/keeper_state_machine.ml:448 — 3 not in [10..18]
OCaml phase-count audit clean: SSOT=13, no unqualified mismatches.
EXIT: 0
```

Pre-fix run (with baseline removed) flags all 6 sites — confirmed the validator surfaces real drifts.

## Why baseline rather than fold iter 54's fixes here

iter 54 PR #14886 is in review with its own scope (4 manual sites + history line). Folding those fixes into this PR would:
1. Create a 5-file overlap requiring merge-conflict resolution.
2. Conflate two separable findings ("manual sweep result" vs "structural guard").

Baseline approach keeps both PRs independent. Memory feedback `feedback_stacked_pr_auto_close_recovery.md` notes that stacked PRs auto-close on squash-merge — baseline is the safe alternative.

## RFC 참조

RFC-WAIVED: validator script + CI extension + 2-site docstring fix. Same family as R-B-1.c (annotation drift, #14770/#14772) and R-H-1.c (TLA+ phase count, #14874).

## 진행 추적

6th drift class closure status:
- TLA+ spec corpus: closed iter 49-53 (5 PRs)
- OCaml docstring corpus: iter 54 (#14886) + iter 55 (this PR)
- Cross-language structural guard: this PR

Follow-up tasks:
1. After #14886 merges → remove 4 baseline lines from `scripts/ocaml-phase-count-baseline.txt` (1-line cleanup PR).
2. Consider consolidating `audit-tla-phase-count.sh` + `audit-ocaml-phase-count.sh` into a single `audit-phase-count.sh --corpus tla|ocaml` (defer, only if a 3rd corpus appears).

다음 iteration 시작점: **R-D-2.a + R-D-1.a bundle** OR **R-D-1.d** (ppx_tla prefix) OR **R-B-2.a/b** (KTC RoutingStart) OR **새 spec entry** (KAL Phase K).

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
