### PR TITLE
refactor(tools): error-envelope SSOT — error_assoc + error_response_with + lint guard (T30, 7 sites)

### DIFF
--- a/.github/workflows/fundamental-check.yml
+++ b/.github/workflows/fundamental-check.yml
@@ -52,6 +52,14 @@ jobs:
       - name: Run lint
         run: bash scripts/lint/no-inline-ok-envelope.sh
 
+  no-inline-error-envelope:
+    name: No inline error-envelope literals (T30)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run lint
+        run: bash scripts/lint/no-inline-error-envelope.sh
+
   godfile-size-regression:
     name: Godfile size
     runs-on: ubuntu-latest

--- a/lib/keeper/keeper_exec_voice.ml
+++ b/lib/keeper/keeper_exec_voice.ml
@@ -40,12 +40,10 @@ let handle_keeper_voice_tool
          with
          | Ok json -> Yojson.Safe.to_string json
          | Error err ->
-           Yojson.Safe.to_string
-             (`Assoc
-                 [ "status", `String "error"
-                 ; "agent_id", `String meta.name
-                 ; "message", `String err
-                 ]))
+           Tool_args.error_response_with
+             [ "agent_id", `String meta.name
+             ; "message", `String err
+             ])
       | _ ->
         Yojson.Safe.to_string (keeper_text_fallback_json ~agent_id:meta.name ~message))
   | "keeper_voice_listen" ->
@@ -60,22 +58,18 @@ let handle_keeper_voice_tool
      with
      | Ok json -> Yojson.Safe.to_string json
      | Error err ->
-       Yojson.Safe.to_string
-         (`Assoc
-             [ "status", `String "error"
-             ; "error", `String err
-             ; "agent_id", `String meta.name
-             ]))
+       Tool_args.error_response_with
+         [ "error", `String err
+         ; "agent_id", `String meta.name
+         ])
   | "keeper_voice_agent" ->
     (match Voice_bridge.get_agent_voice ~agent_id:meta.name with
      | Ok json -> Yojson.Safe.to_string json
      | Error err ->
-       Yojson.Safe.to_string
-         (`Assoc
-             [ "status", `String "error"
-             ; "agent_id", `String meta.name
-             ; "message", `String err
-             ]))
+       Tool_args.error_response_with
+         [ "agent_id", `String meta.name
+         ; "message", `String err
+         ])
   | "keeper_voice_sessions" ->
     let mgr = Keeper_voice_local.get_session_manager () in
     let sessions = Voice_session_manager.list_sessions mgr in

--- a/lib/server/server_dashboard_http.ml
+++ b/lib/server/server_dashboard_http.ml
@@ -1140,7 +1140,7 @@ let operator_confirm_http_json ~state ~sw ~clock request ~args =
 ;;
 
 let operator_error_json message =
-  `Assoc [ "status", `String "error"; "message", `String message ]
+  Tool_args.error_assoc [ "message", `String message ]
 ;;
 
 (* Cold-start bootstrap aggregator.

--- a/lib/tool_args.ml
+++ b/lib/tool_args.ml
@@ -90,20 +90,32 @@ let error_code_to_string = function
     These produce plain JSON strings without [Tool_result.t] wrapping.
     Used by [get_string_required] error paths and legacy callers. *)
 
+(** Build a JSON error envelope as a [Yojson.Safe.t] node (unserialized).
+    Mirrors [ok_assoc] for the error variant.  Use when the envelope is
+    composed into a larger structure or returned as
+    [(Yojson.Safe.t, _) result]. *)
+let error_assoc fields : Yojson.Safe.t =
+  `Assoc (("status", `String "error") :: fields)
+
 (** Build a JSON error response string: [\{"status":"error","message":"..."\}] *)
 let error_response message =
-  Yojson.Safe.to_string
-    (`Assoc [ ("status", `String "error"); ("message", `String message) ])
+  Yojson.Safe.to_string (error_assoc [ ("message", `String message) ])
+
+(** Build a JSON error response string with caller-supplied fields.
+    Use when the error payload needs more than just [message] (e.g.
+    [error]/[agent_id]/[config_path] context).  Field-order semantics:
+    [status] is prepended to the head of the [`Assoc]. *)
+let error_response_with fields =
+  Yojson.Safe.to_string (error_assoc fields)
 
 (** Build a JSON error response string with machine-readable error code:
     [\{"status":"error","error_code":"validation_error","message":"..."\}] *)
 let error_response_typed ~code message =
-  Yojson.Safe.to_string
-    (`Assoc [
-      ("status", `String "error");
+  error_response_with
+    [
       ("error_code", `String (error_code_to_string code));
       ("message", `String message);
-    ])
+    ]
 
 (** Build a JSON OK response string with additional fields. *)
 let ok_response fields =
@@ -236,13 +248,12 @@ let field_error_to_yojson (e : field_error) : Yojson.Safe.t =
     "field_errors":[...],"message":"N field error(s)"\}] *)
 let validation_error_response (errors : field_error list) : string =
   let field_errors = List.map field_error_to_yojson errors in
-  Yojson.Safe.to_string
-    (`Assoc [
-      ("status", `String "error");
+  error_response_with
+    [
       ("error_code", `String "validation_error");
       ("field_errors", `List field_errors);
       ("message", `String (Printf.sprintf "%d field error(s)" (List.length errors)));
-    ])
+    ]
 
 (** Convenience: [Tool_result.t] validation error. *)
 let validation_error_result ?tool_name ?start_time errors =

--- a/lib/tool_args.ml
+++ b/lib/tool_args.ml
@@ -91,7 +91,8 @@ let error_code_to_string = function
     Used by [get_string_required] error paths and legacy callers. *)
 
 (** Build a JSON error envelope as a [Yojson.Safe.t] node (unserialized).
-    Mirrors [ok_assoc] for the error variant.  Use when the envelope is
+    Counterpart to {!ok_response} / {!ok_result} on the success side,
+    but returning the unserialized [Yojson.Safe.t] node so it can be
     composed into a larger structure or returned as
     [(Yojson.Safe.t, _) result]. *)
 let error_assoc fields : Yojson.Safe.t =

--- a/lib/tool_args.mli
+++ b/lib/tool_args.mli
@@ -62,10 +62,10 @@ val error_code_to_string : error_code -> string
     These produce plain JSON strings without [Tool_result.t] wrapping.
     Used by [get_string_required] error paths and other low-level callers. *)
 
-(** [{"status":"error", <fields>}] as a [`Assoc] node.  Mirrors
-    {!ok_assoc} for the error variant — use when the envelope must be
-    embedded in a larger response or returned via
-    [(Yojson.Safe.t, _) result]. *)
+(** [{"status":"error", <fields>}] as a [`Assoc] node.  Counterpart to
+    {!ok_response} / {!ok_result} on the success side, but returns the
+    *unserialized* [Yojson.Safe.t] for embedding in a larger response
+    or returning via [(Yojson.Safe.t, _) result]. *)
 val error_assoc : (string * Yojson.Safe.t) list -> Yojson.Safe.t
 
 (** [{"status":"error","message":"…"}] as a serialized JSON string. *)

--- a/lib/tool_args.mli
+++ b/lib/tool_args.mli
@@ -62,8 +62,19 @@ val error_code_to_string : error_code -> string
     These produce plain JSON strings without [Tool_result.t] wrapping.
     Used by [get_string_required] error paths and other low-level callers. *)
 
-(** [{"status":"error","message":"…"}] *)
+(** [{"status":"error", <fields>}] as a [`Assoc] node.  Mirrors
+    {!ok_assoc} for the error variant — use when the envelope must be
+    embedded in a larger response or returned via
+    [(Yojson.Safe.t, _) result]. *)
+val error_assoc : (string * Yojson.Safe.t) list -> Yojson.Safe.t
+
+(** [{"status":"error","message":"…"}] as a serialized JSON string. *)
 val error_response : string -> string
+
+(** [{"status":"error", <fields>}] as a serialized JSON string with
+    caller-supplied fields.  Use when the payload needs more than just
+    [message] (e.g. [error]/[agent_id]/[config_path] context). *)
+val error_response_with : (string * Yojson.Safe.t) list -> string
 
 (** [{"status":"error","error_code":"…","message":"…"}] *)
 val error_response_typed : code:error_code -> string -> string

--- a/lib/tool_shard.ml
+++ b/lib/tool_shard.ml
@@ -2102,13 +2102,12 @@ let execute (tool_name : string) (arguments : Yojson.Safe.t) : bool * Yojson.Saf
               ; "shard", `String shard_name
               ; "active_shards", `List (List.map (fun s -> `String s) next_shards)
               ] )
-        | Error msg -> false, `Assoc [ "status", `String "error"; "message", `String msg ])
+        | Error msg ->
+          false, Tool_args.error_assoc [ "message", `String msg ])
      | _ ->
        ( false
-       , `Assoc
-           [ "status", `String "error"
-           ; "message", `String "agent_name and shard_name are required"
-           ] ))
+       , Tool_args.error_assoc
+           [ "message", `String "agent_name and shard_name are required" ] ))
   | _ -> false, `String "Unknown tool"
 ;;
 

--- a/lib/voice/voice_bridge.ml
+++ b/lib/voice/voice_bridge.ml
@@ -246,11 +246,10 @@ let public_config_json () =
   | Ok config -> Ok (Voice_config.public_json config)
   | Error message ->
     Error
-      (`Assoc
-          [ "status", `String "error"
-          ; "message", `String message
-          ; "config_path", `String (Voice_config.config_path ())
-          ])
+      (Tool_args.error_assoc
+         [ "message", `String message
+         ; "config_path", `String (Voice_config.config_path ())
+         ])
 ;;
 
 let tts_preview_bytes_from_request_json json =

--- a/scripts/lint/no-inline-error-envelope.sh
+++ b/scripts/lint/no-inline-error-envelope.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# lint-no-inline-error-envelope — block inline `("status", `String "error")`
+# in lib/. Mirrors no-inline-ok-envelope. Use Tool_args.error_response /
+# error_response_with / error_assoc / error_result instead.
+
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+ALLOWLIST=(
+  # SSOT definition — canonical helpers themselves.
+  "lib/tool_args.ml"
+
+  # T27 alias backstop (sibling-include cascade for tool_local_runtime_*.ml).
+  "lib/tool_local_runtime_core.ml"
+
+  # ---- Temporary allowlist — REMOVE after T27 (#14876) merges ----
+  # T27 deletes these inline json_error helpers in tool_misc_web_search,
+  # tool_misc_web_fetch, and inlines the envelope in tool_operator.
+  "lib/tool_misc_web_fetch.ml"
+  "lib/tool_misc_web_search.ml"
+  "lib/tool_operator.ml"
+)
+
+count=0
+while IFS= read -r match; do
+  file=${match%%:*}
+
+  skip=0
+  for allowed in "${ALLOWLIST[@]}"; do
+    if [[ "$file" == "$allowed" ]]; then
+      skip=1
+      break
+    fi
+  done
+  [[ $skip -eq 1 ]] && continue
+
+  if [[ "$file" == *.mli ]]; then
+    continue
+  fi
+
+  echo "ERROR: inline error-envelope literal (use Tool_args.error_response / error_response_with / error_assoc / error_result): $match"
+  count=$((count + 1))
+done < <(rg -nP '"status",\s*`String\s+"error"' lib/ --type-add 'ocaml:*.ml' -tocaml 2>/dev/null || true)
+
+if [[ $count -gt 0 ]]; then
+  echo ""
+  echo "Found $count inline error-envelope literal(s) outside the allowlist."
+  echo "Migration guide:"
+  echo "  - Returns string (msg only)?  Tool_args.error_response msg"
+  echo "  - Returns string (+ fields)?  Tool_args.error_response_with fields"
+  echo "  - Returns Yojson.Safe.t?      Tool_args.error_assoc fields"
+  echo "  - Returns Tool_result.t?      Tool_args.error_result ~tool_name ~start_time msg"
+  exit 1
+fi
+
+echo "OK: no inline error-envelope literals found outside allowlist"
+exit 0


### PR DESCRIPTION
## Scope

T27/T28/T29 의 ok 영역 sweep을 error 영역에 mirror. 동일 anti-pattern,
동일 fix shape — 7 사이트가 `(\"status\", \`String \"error\")` envelope 을
inline 재구성. 기존 \`Tool_args.error_response\`는 \`msg: string\` 단일
인자라 *추가 필드* (agent_id, config_path 등)가 필요한 사이트에는
부족해서 SSOT 활용 0 → 모든 호출자가 inline reimpl.

## Helper 4-축 완성

| Returns | Variant | Helper |
|---------|---------|--------|
| \`string\` | ok | \`Tool_args.ok_response fields\` |
| \`string\` | error (msg only) | \`Tool_args.error_response msg\` |
| \`string\` | error (custom fields) | **new**: \`Tool_args.error_response_with fields\` |
| \`Yojson.Safe.t\` | ok | \`Tool_args.ok_assoc fields\` (T28+T29) |
| \`Yojson.Safe.t\` | error | **new**: \`Tool_args.error_assoc fields\` |
| \`Tool_result.t\` | ok | \`Tool_args.ok_result ~tool_name ~start_time fields\` |
| \`Tool_result.t\` | error | \`Tool_args.error_result ~tool_name ~start_time msg\` |

기존 \`error_response\` / \`error_response_typed\` / \`validation_error_response\`
는 모두 \`error_assoc\` 위에 delegate (single source of truth).

## Sites migrated (7)

| File:Line | Returns | Shape |
|-----------|---------|-------|
| \`lib/tool_shard.ml:2105\` | \`(bool * Yojson)\` | shard Error branch |
| \`lib/tool_shard.ml:2109\` | \`(bool * Yojson)\` | required-args guard |
| \`lib/server/server_dashboard_http.ml:1143\` | \`Yojson\` | operator_error_json helper |
| \`lib/voice/voice_bridge.ml:250\` | \`Yojson\` (Error) | public_config_json Error branch |
| \`lib/keeper/keeper_exec_voice.ml:45\` | \`string\` | voice speak error |
| \`lib/keeper/keeper_exec_voice.ml:65\` | \`string\` | voice listen error |
| \`lib/keeper/keeper_exec_voice.ml:75\` | \`string\` | voice agent error |

## CI regression guard

\`scripts/lint/no-inline-error-envelope.sh\` (mirrors no-inline-ok-envelope):

\`\`\`
$ bash scripts/lint/no-inline-error-envelope.sh
OK: no inline error-envelope literals found outside allowlist
\`\`\`

Wired as required check in \`.github/workflows/fundamental-check.yml\`.

**Allowlist**:
- \`lib/tool_args.ml\` — SSOT definitions
- \`lib/tool_local_runtime_core.ml\` — T27 alias backstop (sibling-include cascade)
- \`lib/tool_misc_web_{fetch,search}.ml\` + \`lib/tool_operator.ml\` —
  **TEMPORARY** (T27 #14876 deletes these; remove after T27 merges)

## Wire format guarantee

\`\`\`ocaml
let error_assoc fields = `Assoc ((\"status\", \`String \"error\") :: fields)
let error_response msg = Yojson.Safe.to_string (error_assoc [(\"message\", \`String msg)])
let error_response_with fields = Yojson.Safe.to_string (error_assoc fields)
\`\`\`

모든 마이그레이션 사이트는 status가 *first field* 인 케이스만 포함.
byte-identical wire format 보장.

## Diff stat

8 files, +120 / -40 net.

## Build

\`MASC_SKIP_PIN_CHECK=1 bash ./scripts/dune-local.sh build --root . @lib/check\` green.

## Anti-pattern signatures closed

- Workaround #1 (sprinkle across modules — 7 사이트 동일 envelope shape 0 abstraction)
- Helper signature gap (\`error_response\`가 \`msg\` 단일 인자로 제한되어 *추가 필드 케이스*에선 callers가 inline 으로 fallback)

## Cross-reference

- T27 (#14876) — sibling ok/error envelope helpers (\`json_error\`/\`json_ok\` consolidation)
- T28+T29 (#14882) — ok_assoc/ok_result + ok-envelope lint guard
- CLAUDE.md §워크어라운드 거부 기준 #1 (sprinkle, abstraction missing)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>