### PR TITLE
refactor(keeper_registry): make validate_decision_transition compile-time enforced

### DIFF
--- a/lib/keeper/keeper_registry.ml
+++ b/lib/keeper/keeper_registry.ml
@@ -395,11 +395,21 @@ module Decision_transition = struct
   ;;
 end
 
-let validate_decision_transition ~from ~to_ =
+(* Living-matrix documentation of the decision-stage transition relation.
+   Forbidden [<active>_to_undecided] pairs are unrepresentable through the
+   [decision_stage_active] target type (PR #14887 made [set_turn_decision_stage]
+   reject them at compile time; this validator now mirrors that invariant
+   at the test surface).  Each branch is the explicit type-level acknowledgement
+   that the pair is admitted by the spec — adding a new [decision_stage] or
+   [decision_stage_active] constructor will fail Warning 8 here, forcing
+   the maintainer to decide whether the new variant participates. *)
+let validate_decision_transition
+    ~(from : decision_stage)
+    ~(to_ : decision_stage_active)
+  =
   let from_packed = stage_to_witness from in
-  let to_packed = stage_to_witness to_ in
+  let to_packed = decision_stage_active_to_packed to_ in
   match from_packed, to_packed with
-  | Packed Decision_undecided, Packed Decision_undecided -> ()
   | Packed Decision_undecided, Packed Decision_guard_ok -> ()
   | Packed Decision_undecided, Packed Decision_gate_rejected -> ()
   | Packed Decision_undecided, Packed Decision_tool_policy_selected -> ()
@@ -412,14 +422,6 @@ let validate_decision_transition ~from ~to_ =
   | Packed Decision_tool_policy_selected, Packed Decision_tool_policy_selected -> ()
   | Packed Decision_tool_policy_selected, Packed Decision_guard_ok -> ()
   | Packed Decision_tool_policy_selected, Packed Decision_gate_rejected -> ()
-  | Packed Decision_guard_ok, Packed Decision_undecided
-  | Packed Decision_gate_rejected, Packed Decision_undecided
-  | Packed Decision_tool_policy_selected, Packed Decision_undecided ->
-    invalid_arg
-      (Printf.sprintf
-         "validate_decision_transition: invalid transition %s -> %s"
-         (packed_decision_stage_label from_packed)
-         (packed_decision_stage_label to_packed))
 ;;
 
 type cascade_state =

--- a/lib/keeper/keeper_registry.mli
+++ b/lib/keeper/keeper_registry.mli
@@ -228,11 +228,20 @@ val decision_stage_active_to_packed
   -> packed_decision_stage
 
 (** Diagnostic label using the constructor name (e.g.
-    ["Decision_guard_ok"]).  Used by [validate_decision_transition] for
-    [Invalid_argument] messages. *)
+    ["Decision_guard_ok"]).  Used by [validate_cascade_transition] /
+    [validate_turn_phase_transition] for [Invalid_argument] messages. *)
 val packed_decision_stage_label : packed_decision_stage -> string
 
-val validate_decision_transition : from:decision_stage -> to_:decision_stage -> unit
+(** Living-matrix documentation of the decision-stage transition relation.
+    Forbidden [<active>_to_undecided] pairs are unrepresentable through the
+    [decision_stage_active] target type, so this validator no longer raises;
+    it exists as a compile-time fixture that enumerates every admitted pair.
+    Adding a new variant to either side will trigger Warning 8 here, forcing
+    the maintainer to classify the new pair. *)
+val validate_decision_transition
+  :  from:decision_stage
+  -> to_:decision_stage_active
+  -> unit
 
 module Decision_transition : sig
   type ('from, 'to_) t =

--- a/test/test_keeper_sub_fsm_guards.ml
+++ b/test/test_keeper_sub_fsm_guards.ml
@@ -110,25 +110,33 @@ let test_invalid_turn_phase_transitions () =
 
 (* ── KDP: decision_stage ────────────────────────────────── *)
 
+(* PR #14887 + this PR moved decision_stage forbidden transitions into the
+   type system via [decision_stage_active] as the [to_] argument:
+   [<active>_to_undecided] pairs are unrepresentable, so the prior
+   [test_invalid_decision_transitions] and [test_decision_message_includes_labels]
+   cases are gone (their contracts are now compile-time invariants — the only
+   "test" that can fail is the build itself).  This remaining valid-transitions
+   case enumerates the 12 admitted [(from, to_active)] pairs so that adding a
+   new [decision_stage] / [decision_stage_active] constructor will fail
+   compilation here, forcing a deliberate classification. *)
 let test_valid_decision_transitions () =
-  let cases : (decision_stage * decision_stage) list =
+  let cases : (decision_stage * decision_stage_active) list =
     [ (* from Decision_undecided *)
-      Decision_undecided, Decision_undecided
-    ; Decision_undecided, Decision_guard_ok
-    ; Decision_undecided, Decision_gate_rejected
-    ; Decision_undecided, Decision_tool_policy_selected
+      Decision_undecided, Decision_active_guard_ok
+    ; Decision_undecided, Decision_active_gate_rejected
+    ; Decision_undecided, Decision_active_tool_policy_selected
       (* from Decision_guard_ok *)
-    ; Decision_guard_ok, Decision_guard_ok
-    ; Decision_guard_ok, Decision_gate_rejected
-    ; Decision_guard_ok, Decision_tool_policy_selected
+    ; Decision_guard_ok, Decision_active_guard_ok
+    ; Decision_guard_ok, Decision_active_gate_rejected
+    ; Decision_guard_ok, Decision_active_tool_policy_selected
       (* from Decision_gate_rejected *)
-    ; Decision_gate_rejected, Decision_guard_ok
-    ; Decision_gate_rejected, Decision_gate_rejected
-    ; Decision_gate_rejected, Decision_tool_policy_selected
+    ; Decision_gate_rejected, Decision_active_guard_ok
+    ; Decision_gate_rejected, Decision_active_gate_rejected
+    ; Decision_gate_rejected, Decision_active_tool_policy_selected
       (* from Decision_tool_policy_selected *)
-    ; Decision_tool_policy_selected, Decision_guard_ok
-    ; Decision_tool_policy_selected, Decision_gate_rejected
-    ; Decision_tool_policy_selected, Decision_tool_policy_selected
+    ; Decision_tool_policy_selected, Decision_active_guard_ok
+    ; Decision_tool_policy_selected, Decision_active_gate_rejected
+    ; Decision_tool_policy_selected, Decision_active_tool_policy_selected
     ]
   in
   List.iter
@@ -137,31 +145,8 @@ let test_valid_decision_transitions () =
        | (Assert_failure _ | Invalid_argument _) ->
          Alcotest.fail
            (Printf.sprintf
-              "valid decision %s -> %s rejected"
-              (Obs.decision_stage_to_string (stage_to_witness from))
-              (Obs.decision_stage_to_string (stage_to_witness to_))))
-    cases
-;;
-
-let test_invalid_decision_transitions () =
-  let cases : (decision_stage * decision_stage) list =
-    [ (* Only _ -> undecided is invalid (reset, not transition) *)
-      Decision_guard_ok, Decision_undecided
-    ; Decision_gate_rejected, Decision_undecided
-    ; Decision_tool_policy_selected, Decision_undecided
-    ]
-  in
-  List.iter
-    (fun (from, to_) ->
-       try
-         validate_decision_transition ~from ~to_;
-         Alcotest.fail
-           (Printf.sprintf
-              "invalid decision %s -> %s should raise"
-              (Obs.decision_stage_to_string (stage_to_witness from))
-              (Obs.decision_stage_to_string (stage_to_witness to_)))
-       with
-       | Invalid_argument _ -> ())
+              "valid decision %s rejected"
+              (Obs.decision_stage_to_string (stage_to_witness from))))
     cases
 ;;
 
@@ -384,22 +369,11 @@ let test_turn_phase_message_includes_labels () =
     assert_msg_contains ~msg ~needle:(packed_turn_phase_label to_)
 ;;
 
-let test_decision_message_includes_labels () =
-  let from : decision_stage = Decision_guard_ok in
-  let to_ : decision_stage = Decision_undecided in
-  match
-    capture_invalid_arg (fun () -> validate_decision_transition ~from ~to_)
-  with
-  | None -> Alcotest.fail "validator should have raised Invalid_argument"
-  | Some msg ->
-    assert_msg_contains ~msg ~needle:"validate_decision_transition";
-    assert_msg_contains
-      ~msg
-      ~needle:(packed_decision_stage_label (stage_to_witness from));
-    assert_msg_contains
-      ~msg
-      ~needle:(packed_decision_stage_label (stage_to_witness to_))
-;;
+(* test_decision_message_includes_labels removed: validate_decision_transition
+   no longer raises Invalid_argument (the forbidden [<active>_to_undecided]
+   pairs are unrepresentable through the [decision_stage_active] [to_] type).
+   The contract that "rejection messages include the typed labels" is now a
+   compile-time absence-of-rejection — there is no message to assert on. *)
 
 let test_cascade_message_includes_labels () =
   let from : packed_cascade_state = Packed Cascade_idle in
@@ -434,10 +408,10 @@ let () =
             "valid transitions"
             `Quick
             test_valid_decision_transitions
-        ; Alcotest.test_case
-            "invalid transitions"
-            `Quick
-            test_invalid_decision_transitions
+          (* "invalid transitions" case removed: forbidden
+             [<active>_to_undecided] pairs are unrepresentable through the
+             [decision_stage_active] [to_] type — the test would not
+             compile.  Compile-time enforcement supersedes runtime test. *)
         ] )
     ; ( "cascade_state"
       , [ Alcotest.test_case
@@ -474,10 +448,9 @@ let () =
             "turn_phase rejection includes from/to labels"
             `Quick
             test_turn_phase_message_includes_labels
-        ; Alcotest.test_case
-            "decision rejection includes from/to labels"
-            `Quick
-            test_decision_message_includes_labels
+          (* "decision rejection includes from/to labels" removed:
+             validate_decision_transition no longer raises (the forbidden
+             pairs are unrepresentable, see runner note above). *)
         ; Alcotest.test_case
             "cascade rejection includes from/to labels"
             `Quick


### PR DESCRIPTION
## Why

`validate_decision_transition` (`lib/keeper/keeper_registry.ml:398`, post-#14887 line) was a 16-pair match returning `unit` on 13 valid pairs and raising `invalid_arg` on 3 forbidden `<active>_to_undecided` transitions. It exists **only for the test surface** — no production path in `lib/` calls it (the production caller is `set_turn_decision_stage`, which #14887 already made type-safe).

PR #14887 introduced `decision_stage_active` (3-variant sum excluding `Decision_undecided`) and used it as the input type for `set_turn_decision_stage`, making the forbidden case unrepresentable. This PR applies the **same type refinement** to the validator's `to_` argument — closing the 2nd of 4 keeper FSM `invalid_arg` sites identified in the plan inventory item #4.

## What

```ocaml
(* Before *)
val validate_decision_transition : from:decision_stage -> to_:decision_stage -> unit
(* body: 16 pairs, 3 forbidden arms -> invalid_arg *)

(* After *)
val validate_decision_transition
  :  from:decision_stage
  -> to_:decision_stage_active
  -> unit
(* body: 12 pairs, all -> () *)
```

`Decision_undecided` as `to_` is **unrepresentable** through `decision_stage_active`, so the 3 forbidden arms are removed. The function becomes pure "living-matrix documentation":

```ocaml
match from_packed, to_packed with
| Packed Decision_undecided, Packed Decision_guard_ok -> ()
| Packed Decision_undecided, Packed Decision_gate_rejected -> ()
| Packed Decision_undecided, Packed Decision_tool_policy_selected -> ()
| Packed Decision_guard_ok, Packed Decision_guard_ok -> ()
(* ... 12 explicit pairs ... *)
| Packed Decision_tool_policy_selected, Packed Decision_gate_rejected -> ()
```

No `_ ->` arm. Adding a new variant to either `decision_stage` or `decision_stage_active` triggers Warning 8 here, forcing the maintainer to classify the new pair.

## Test surface changes

Two tests deleted (their contracts became compile-time invariants):

| Deleted test | Original purpose | Why removed |
|---|---|---|
| `test_invalid_decision_transitions` (line 146) | Verify 3 forbidden `_to_undecided` pairs raise `Invalid_argument` | Forbidden pairs cannot be constructed against new signature — *compile error* replaces runtime check |
| `test_decision_message_includes_labels` (line 372) | Verify rejection message contains typed `from`/`to` labels | Validator no longer raises — no message to assert on |

One test migrated:

`test_valid_decision_transitions` (line 113) retained. Cases list type changes from `(decision_stage * decision_stage) list` to `(decision_stage * decision_stage_active) list`. Pairs reduced from 13 → 12 (the prior `(Decision_undecided, Decision_undecided)` self-loop was idempotent no-op now ruled out by the type system; no production caller relied on it).

Alcotest runner entries for the 2 deleted tests are removed from the `decision_stage` and `diagnostic_messages` sections with explanatory comments at each site.

## Plan inventory progress (item #4 — FSM invalid_arg → typed enforcement)

| Site | Function | Status |
|---|---|---|
| 1226 (pre-#14887) | `set_turn_decision_stage` | **CLOSED** by PR #14887 (input refinement) |
| 418 (pre-#14887) → 398 (this PR) | `validate_decision_transition` | **CLOSED** by this PR (same input refinement + test compile-time enforcement) |
| 1234 | `validate_cascade_transition` | Open — 5-variant scrutinee, 25 pairs, separate followup |
| 1335 | `validate_turn_phase_transition` | Open — 8+ variant scrutinee, 60+ pairs, separate followup |
| 612 | keeper name unit separator | Open — input boundary validation, different category |

## Self-check (CLAUDE.md Workaround Rejection Bar)

| # | Check | Result |
|---|---|---|
| 1 | telemetry-as-fix? | no — removes runtime exception entirely; no counter introduced |
| 2 | string classifier? | no — typed sum refinement, not string match |
| 3 | N-of-M? | no — followup to #14887 in the same surface; sites 1234/1335 are different validators with different scrutinee shapes, separate PRs |
| 4 | catch-all added? | no — 12 explicit arms, no `_ ->` |
| 5 | cap/cooldown/dedup? | no |
| 6 | test backdoor? | no — test deletions are because the contracts *moved to the type system*, not skipped; documentation comments at each deletion site explain |
| 7 | typo N sites? | no |

## Principle reference

Same as #14887: Alexis King "Parse, don't validate" (`software-development.md` Coding Principle, `.claude/role/user-core.xml` "make illegal states unrepresentable"). PR #14887 applied it at the mutator boundary; this PR applies it at the validator boundary. The pattern is now consistent across both decision-stage entry points.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
