### PR TITLE
feat(sublibs): enable warning 4 on 5 leaf util sublibs (RFC-0071 §3.4 ratchet)

### DIFF
--- a/lib/eio_context/dune
+++ b/lib/eio_context/dune
@@ -4,4 +4,6 @@
  (public_name masc_mcp.masc_eio_context)
  (wrapped false)
  (modules eio_context)
+ ; RFC-0071 §3.4 Phase 5 ratchet: warning 4 enabled. Leaf util sublib.
+ (flags (:standard -w +4))
  (libraries eio uri masc_log ca-certs tls tls-eio domain-name))

--- a/lib/oas_compat/dune
+++ b/lib/oas_compat/dune
@@ -5,4 +5,6 @@
  (public_name masc_mcp.oas_compat)
  (modules oas_compat)
  (wrapped false)
+ ; RFC-0071 §3.4 Phase 5 ratchet: warning 4 enabled. Leaf util sublib.
+ (flags (:standard -w +4))
  (libraries agent_sdk agent_sdk.llm_provider yojson))

--- a/lib/random_id/dune
+++ b/lib/random_id/dune
@@ -4,6 +4,8 @@
  (public_name masc_mcp.masc_random_id)
  (wrapped false)
  (modules random_id)
+ ; RFC-0071 §3.4 Phase 5 ratchet: warning 4 enabled. Leaf util sublib.
+ (flags (:standard -w +4))
  (libraries
    mirage-crypto
    mirage-crypto-rng))

--- a/lib/time_compat/dune
+++ b/lib/time_compat/dune
@@ -3,4 +3,6 @@
  (name time_compat)
  (public_name masc_mcp.time_compat)
  (modules time_compat)
+ ; RFC-0071 §3.4 Phase 5 ratchet: warning 4 enabled. Leaf util sublib.
+ (flags (:standard -w +4))
  (libraries eio unix mcp_protocol.eio))

--- a/lib/tool_schemas_specs/dune
+++ b/lib/tool_schemas_specs/dune
@@ -3,5 +3,7 @@
 (library
  (name tool_schemas_specs)
  (wrapped false)
+ ; RFC-0071 §3.4 Phase 5 ratchet: warning 4 enabled. Leaf util sublib.
+ (flags (:standard -w +4))
  (libraries yojson)
  (modules tool_schemas_specs_types))


### PR DESCRIPTION
## 목적

RFC-0071 §3.4 Phase 5 **ratchet 2단계**. #14888 (lib/core) 후속.

## 변경

5개 leaf utility/compat sublib 의 `dune` 에 `(flags (:standard -w +4))` 추가:

| Sublib | 역할 |
|--------|------|
| `lib/time_compat` | Unix/Eio 시간 wrapper |
| `lib/random_id` | mirage-crypto 기반 ID 생성 |
| `lib/eio_context` | TLS/Eio 컨텍스트 |
| `lib/oas_compat` | OAS agent_sdk compat |
| `lib/tool_schemas_specs` | tool schema 타입 |

## 왜 이 5개인가

직접 grep 측정:
\`\`\`
rg -c '\| _ -> (false|None|\(\))' lib/<sublib>/ → 0
\`\`\`

5개 모두 closed-variant catch-all 0건. \`-w +4\` 활성화 = 기존 코드 *no-op*, 미래 closed variant 도입 시 *컴파일러가 강제*.

## 검증

- \`dune build --root . lib/time_compat lib/random_id lib/eio_context lib/oas_compat lib/tool_schemas_specs\` clean
- \`dune build --root .\` 전체 clean
- Warning 4 violation 0건

## Diff stat

5 files, +10/-0. 각 sublib 당 1줄 \`(flags ...)\` + 주석 1줄.

## RFC-0071 와의 관계

- §3.4 \"compiler-builtin enforcement\" 의 sublib-by-sublib 활성화.
- §4 Phase 5 의 점진 적용 패턴.
- #14888 이 시작, 본 PR 이 ratchet 1턴.

## Out of scope

- closed-variant catch-all 보유 sublib (예: `lib/keeper/`, `lib/cascade/`) — Phase 3 codemod 필요.
- `lib/dated_jsonl` — 기존 \`-w -32\` flag 가 있어 별도 PR 로 merge.

## 다음 ratchet 후보

남은 zero-count sublibs: ag_ui, board_types, compression, dashboard_api_types, masc_http_client, pulse, response, shared_audit, shared_types, tool_blob_store, tool_schemas. 각각 동일 패턴.