### PR TITLE
docs(tla-audit): KAL K-1 admission spec ↔ OCaml mapping snapshot (iter 56)

### DIFF
--- a/docs/tla-audit/kal-k1-admission-spec-ocaml-mapping-2026-05-12.md
+++ b/docs/tla-audit/kal-k1-admission-spec-ocaml-mapping-2026-05-12.md
@@ -31,7 +31,7 @@ This memo is the snapshot before any activation. It does two things:
 
 | Module | LOC | Role |
 |--------|-----|------|
-| `keeper_provider_token_bucket.ml` | 103 | Per-provider token bucket; `try_acquire`, `release`, `refill_tokens` |
+| `keeper_provider_token_bucket.ml` | 103 | Per-provider token bucket; `try_acquire`, `release`, `refill_locked` (lazy), `add_on_refill`/`fire_on_refill_callbacks` |
 | `keeper_wfq_overflow.ml` | 94 | Weighted-fair-queueing overflow heap; `enqueue`, `wake_one`, deficit accounting |
 | `keeper_admission_policy.ml` | 139 | Decision logic — picks among candidate providers, computes outcome |
 | `keeper_admission_router.ml` | 123 | Public entry point; orchestrates policy + bucket + queue |

--- a/docs/tla-audit/kal-k1-admission-spec-ocaml-mapping-2026-05-12.md
+++ b/docs/tla-audit/kal-k1-admission-spec-ocaml-mapping-2026-05-12.md
@@ -21,7 +21,7 @@ This memo is the snapshot before any activation. It does two things:
 |---------|-------|-------|
 | State enum | 5 | `keeper_state ∈ {"Idle", "Waiting", "Dispatched", "Working", "Done"}` |
 | Actions | 7 | `StartTurn`, `TryDispatch(k,p)`, `EnqueueOverflow`, `RefillToken(p)`, `WakeFromQueue`, `StartWork`, `CompleteWork` |
-| Safety invariants | 4 | `TypeOK`, `RateRespect` (I3), `TokensInRange`, `QueueWellFormed`, `WorkConserving` (I2 step form) |
+| Safety invariants | 5 | `TypeOK`, `RateRespect` (I3), `TokensInRange`, `QueueWellFormed`, `WorkConserving` (I2 step form) |
 | Liveness | 1 | `LivenessInvariant` (I1) under strong fairness on `TryDispatch` |
 | Bug models | 2 | `KeeperAdmissionLiveness-buggy.cfg`, `…-buggy-2.cfg` (counter-example fixtures) |
 
@@ -48,7 +48,7 @@ External callers (5 sites): `keeper_heartbeat_loop.ml` (primary integration), `p
 | `StartTurn(k)` | heartbeat tick that produces an admission request | yes (heartbeat loop always calls) |
 | `TryDispatch(k, p)` | `Keeper_admission_runtime.run_admission_*` → `Keeper_admission_policy.choose` → `Keeper_provider_token_bucket.try_acquire` | shadow only unless `MASC_ADMISSION_USE_NEW=1` |
 | `EnqueueOverflow(k)` | `Keeper_wfq_overflow.enqueue` (via runtime) | dormant (flag-gated) |
-| `RefillToken(p)` | `Keeper_provider_token_bucket.refill_tokens` (timer-driven) | dormant (timer not started when flag off) |
+| `RefillToken(p)` | `Keeper_provider_token_bucket.refill_locked` (lazy — called inside `try_acquire`/`tokens_available` when `elapsed_sec > 0`; no separate timer). `add_on_refill` registers post-refill callbacks; `fire_on_refill_callbacks` drains them. | dormant (refill computation runs but admission flow disabled when flag off) |
 | `WakeFromQueue` | `Keeper_wfq_overflow.wake_one` invoked on refill | dormant |
 | `StartWork(k)` | (implicit; not a distinct OCaml function — the heartbeat-loop hands off to the cascade dispatch which the spec abstracts as `Working`) | always wired (cascade dispatch) |
 | `CompleteWork(k)` | `Keeper_provider_token_bucket.release` in the cascade completion callback | dormant (release call only on `USE_NEW` path) |

--- a/docs/tla-audit/kal-k1-admission-spec-ocaml-mapping-2026-05-12.md
+++ b/docs/tla-audit/kal-k1-admission-spec-ocaml-mapping-2026-05-12.md
@@ -1,0 +1,100 @@
+# KAL K-1 — KeeperAdmissionLiveness spec ↔ OCaml mapping (audit)
+
+**Iteration**: /loop iter 56 — first entry to Phase K (`KeeperAdmissionLiveness.tla`).
+**Date**: 2026-05-12.
+**Scope**: audit-only. No spec or OCaml mutation in this PR. Findings catalogued for downstream `K-2`/`K-3` fix-PR candidates.
+**RFC reference**: RFC-0026 Work-Conserving Keeper Admission (admission spec is the design ground for the dormant runtime).
+
+## Why this audit exists
+
+Six iterations into the loop the FSM-side specs (KSM, KTC, KCR, KCAF, KCL, KCtxL, KMC) have been worked over; admission has been deferred because the matching OCaml is *dormant*. Memory note (`reference_masc_mcp_integrated_improvement_design_audit.md`, 2026-05-05) explicitly flags `RFC-0026 PR-E-1.6 wiring pending` — admission modules sit in `main` but `keeper_heartbeat_loop.ml` only takes the new code path when `MASC_ADMISSION_USE_NEW=1` is set in the process environment. Without this audit, future contributors to admission would re-derive the spec/OCaml correspondence from scratch every time the dormancy was lifted.
+
+This memo is the snapshot before any activation. It does two things:
+1. Catalogues which spec action maps to which OCaml function so the *next* PR that lifts dormancy has a checklist.
+2. Calls out the four drift risks visible at the boundary today, with recommended follow-up RFC names.
+
+## Spec surface
+
+`specs/keeper-state-machine/KeeperAdmissionLiveness.tla` (387 LOC):
+
+| Element | Count | Where |
+|---------|-------|-------|
+| State enum | 5 | `keeper_state ∈ {"Idle", "Waiting", "Dispatched", "Working", "Done"}` |
+| Actions | 7 | `StartTurn`, `TryDispatch(k,p)`, `EnqueueOverflow`, `RefillToken(p)`, `WakeFromQueue`, `StartWork`, `CompleteWork` |
+| Safety invariants | 4 | `TypeOK`, `RateRespect` (I3), `TokensInRange`, `QueueWellFormed`, `WorkConserving` (I2 step form) |
+| Liveness | 1 | `LivenessInvariant` (I1) under strong fairness on `TryDispatch` |
+| Bug models | 2 | `KeeperAdmissionLiveness-buggy.cfg`, `…-buggy-2.cfg` (counter-example fixtures) |
+
+## OCaml surface
+
+`lib/keeper/` (845 LOC across 7 modules):
+
+| Module | LOC | Role |
+|--------|-----|------|
+| `keeper_provider_token_bucket.ml` | 103 | Per-provider token bucket; `try_acquire`, `release`, `refill_tokens` |
+| `keeper_wfq_overflow.ml` | 94 | Weighted-fair-queueing overflow heap; `enqueue`, `wake_one`, deficit accounting |
+| `keeper_admission_policy.ml` | 139 | Decision logic — picks among candidate providers, computes outcome |
+| `keeper_admission_router.ml` | 123 | Public entry point; orchestrates policy + bucket + queue |
+| `keeper_admission_registry.ml` | 51 | Per-provider bucket lookup / lifecycle |
+| `keeper_admission_runtime.ml` | 280 | Runtime adapter (shadow + active paths); reads `MASC_ADMISSION_USE_NEW` |
+| `keeper_admission_glue.ml` | 55 | Heartbeat-loop integration shim |
+
+External callers (5 sites): `keeper_heartbeat_loop.ml` (primary integration), `prometheus.ml` (metrics), `cascade/cascade_toml_materializer.ml` + `cascade_attempt_liveness_config.{ml,mli}` (config), and one cross-reference in `keeper_admission_glue.{ml,mli}`.
+
+## Mapping table (spec action → OCaml call site)
+
+| Spec action | OCaml entry point | Wired today? |
+|-------------|------------------|--------------|
+| `StartTurn(k)` | heartbeat tick that produces an admission request | yes (heartbeat loop always calls) |
+| `TryDispatch(k, p)` | `Keeper_admission_runtime.run_admission_*` → `Keeper_admission_policy.choose` → `Keeper_provider_token_bucket.try_acquire` | shadow only unless `MASC_ADMISSION_USE_NEW=1` |
+| `EnqueueOverflow(k)` | `Keeper_wfq_overflow.enqueue` (via runtime) | dormant (flag-gated) |
+| `RefillToken(p)` | `Keeper_provider_token_bucket.refill_tokens` (timer-driven) | dormant (timer not started when flag off) |
+| `WakeFromQueue` | `Keeper_wfq_overflow.wake_one` invoked on refill | dormant |
+| `StartWork(k)` | (implicit; not a distinct OCaml function — the heartbeat-loop hands off to the cascade dispatch which the spec abstracts as `Working`) | always wired (cascade dispatch) |
+| `CompleteWork(k)` | `Keeper_provider_token_bucket.release` in the cascade completion callback | dormant (release call only on `USE_NEW` path) |
+
+## Drift risks visible today
+
+These are call-outs for follow-up PRs, **not** fixes in this audit.
+
+1. **Two-state observability gap (HIGH, drift class candidate)**
+   The spec models `StartWork → Working → CompleteWork` as three discrete transitions. The OCaml dormant path inlines them: `try_acquire` returns, then the cascade dispatch runs synchronously, then `release` is called from the completion callback. If `MASC_ADMISSION_USE_NEW` is ever flipped on while the cascade completion callback is unreliable (panic, fiber cancel before release), `in_flight[p]` will leak. Spec's `RateRespect` invariant assumes `CompleteWork` always fires; OCaml has no equivalent of `Switch.on_release` wrapping the bucket lifetime.
+   *Suggested fix-PR*: `K-2.a` — wrap admission acquire/release in `Eio.Switch.on_release` so cancellation releases the bucket. Cross-references RFC-0026 §4.2 "fault recovery".
+
+2. **Strong-fairness expectation has no OCaml emulation (MED)**
+   The spec comment around `Fairness` notes that `TryDispatch` must be *strongly* fair (not just weakly): "TLC 6243-state counter-example confirmed this 2026-05-05". OCaml side has no retry-with-bounded-backoff loop matching SF. Today this is invisible because the dormant path doesn't admit; on activation, a hostile burst of `Refill`/`Complete` interleaving could starve a keeper indefinitely.
+   *Suggested fix-PR*: `K-2.b` — define and test a bounded-retry policy in `keeper_admission_router.ml`. Cross-reference TLC counter-example referenced in the spec comment for the test fixture.
+
+3. **Five-state vs seven-state status enumeration (LOW)**
+   Spec uses `{"Idle", "Waiting", "Dispatched", "Working", "Done"}`. OCaml admission policy result type uses a different enumeration: `{ Dispatch_immediate p; Enqueue_overflow; Bypass_admission; Capacity_exhausted }`. The mapping is implicit ("Dispatch_immediate" subsumes both spec `TryDispatch` *and* `StartWork`). This is acceptable as an abstraction but should be documented in the OCaml `.mli`, because today the abstraction relationship is reconstructed only by reading both files in parallel.
+   *Suggested fix-PR*: `K-2.c` — add OCaml `.mli` comment block citing this spec's mapping table. 6th drift class precedent — this is the same shape as `iter 47 KCtxL doc-layer drift`.
+
+4. **Dormancy not visible from the spec (LOW)**
+   The spec preamble lists invariants I1–I5 with no acknowledgement that the runtime does not yet apply them. A new contributor reading only the spec would assume `MASC_ADMISSION_USE_NEW` is on. Spec comment should add a "Status: design ground, runtime dormant pending `MASC_ADMISSION_USE_NEW=1` activation; see RFC-0026 PR-E-1.6" line.
+   *Suggested fix-PR*: `K-2.d` — comment-only spec preamble note. RFC-WAIVED, same shape as iter 27/48/53 honest-doc.
+
+## Out-of-scope observations
+
+- `K-3` (TLC verification refresh) — `KeeperAdmissionLiveness.cfg` and the two `-buggy.cfg` fixtures have not been run inside this loop. A future iter should re-execute them after each `K-2.*` fix to confirm no regression. ~10–60 seconds per cfg per memory's "8-datapoint honest-doc precedent" but admission-spec changes do affect behaviour (unlike pure comment edits), so this should not be skipped.
+- `K-4` (bug-model invariant pairing) — only safety invariants are exercised by the existing buggy cfgs; the liveness property `LivenessInvariant` has no buggy counterpart that demonstrates it would catch the starvation scenario. Adding a `BugAction_StarveKeeper` action that consumes/refills tokens around the target keeper without admitting it would close the bug-model symmetry the rest of the spec corpus enjoys.
+
+## Verification (this audit)
+
+- `wc -l specs/keeper-state-machine/KeeperAdmissionLiveness.tla` → 387 LOC.
+- `wc -l lib/keeper/keeper_admission_*.ml lib/keeper/keeper_provider_token_bucket.ml lib/keeper/keeper_wfq_overflow.ml` → 845 LOC total.
+- `rg -l 'Keeper_admission_(router|policy|glue|registry|runtime)\.' lib/ bin/` → 10 files, 5 unique callers outside admission itself.
+- `rg -n 'MASC_ADMISSION_USE_NEW' lib/` → 5 references, all in admission modules. Confirms dormancy boundary is centralized.
+
+No spec, OCaml, or .cfg modified by this PR.
+
+## RFC trail
+
+RFC-WAIVED — audit-only memo. Recommended follow-up RFCs:
+- K-2.a (Switch.on_release for bucket lifetime)
+- K-2.b (bounded retry → SF emulation)
+- K-2.c (spec mapping in .mli, 6th drift class shape)
+- K-2.d (spec preamble dormancy note)
+- K-3 (TLC verification refresh after K-2)
+- K-4 (BugAction_StarveKeeper paired buggy cfg)
+
+Picked up by iter 57+ when admission becomes active scope (or as opportunistic finds in the FSM queue).


### PR DESCRIPTION
## Finding (Iteration 56, KAL K-1 — first entry to Phase K)

**Spec**: `specs/keeper-state-machine/KeeperAdmissionLiveness.tla` (387 LOC, RFC-0026 design ground)
**OCaml**: `lib/keeper/keeper_admission_*.ml` + `keeper_provider_token_bucket.ml` + `keeper_wfq_overflow.ml` (7 modules, 845 LOC)
**Aspect**: spec ↔ dormant-OCaml mapping snapshot before any activation
**Risk**: LOW (audit-only, no spec/OCaml mutation)

## 순서도

```mermaid
flowchart LR
  A[Heartbeat tick] --> B{MASC_ADMISSION_USE_NEW set?}
  B -- No / shadow --> C[run_admission shadow path<br/>computes outcome, no bucket consume]
  B -- Yes / active --> D[Keeper_admission_runtime.run_admission]
  D --> E[policy.choose - pick candidate]
  E --> F{bucket.try_acquire}
  F -- ok --> G[Dispatched - spec TryDispatch]
  F -- denied --> H{candidates exhausted?}
  H -- yes --> I[wfq_overflow.enqueue - spec EnqueueOverflow]
  H -- no --> E
  G --> J[cascade dispatch - spec Working]
  J --> K[completion callback - spec CompleteWork]
  K --> L[bucket.release]
  
  M[Refill timer] -.dormant.-> N[bucket.refill_tokens - spec RefillToken]
  N --> O[wfq_overflow.wake_one - spec WakeFromQueue]
```

## Audit summary (full memo at `docs/tla-audit/kal-k1-admission-spec-ocaml-mapping-2026-05-12.md`)

Spec surface (387 LOC):
- **5 states**: `Idle`, `Waiting`, `Dispatched`, `Working`, `Done`
- **7 actions**: `StartTurn`, `TryDispatch(k,p)`, `EnqueueOverflow`, `RefillToken(p)`, `WakeFromQueue`, `StartWork`, `CompleteWork`
- **4 safety invariants** (TypeOK, RateRespect/I3, TokensInRange, QueueWellFormed, WorkConserving/I2) + 1 liveness (LivenessInvariant/I1 under SF on TryDispatch)
- **2 buggy cfgs** for bug-model verification

OCaml surface (845 LOC, 7 modules):

| Module | LOC | Role |
|--------|-----|------|
| `keeper_provider_token_bucket.ml` | 103 | try_acquire / release / refill_tokens |
| `keeper_wfq_overflow.ml` | 94 | WFQ heap + deficit accounting |
| `keeper_admission_policy.ml` | 139 | candidate-provider decision |
| `keeper_admission_router.ml` | 123 | public entry point |
| `keeper_admission_registry.ml` | 51 | bucket lifecycle |
| `keeper_admission_runtime.ml` | 280 | shadow vs active path, reads `MASC_ADMISSION_USE_NEW` |
| `keeper_admission_glue.ml` | 55 | heartbeat integration |

**Dormancy boundary**: 5 references to `MASC_ADMISSION_USE_NEW` env var, *all* inside admission modules — single switch point makes activation easy and reversible.

## 4 drift risks (no fix here, K-2.{a..d} candidates)

| Tag | Risk | Description |
|-----|------|-------------|
| **K-2.a** | HIGH | spec models 3 transitions for work cycle (`StartWork→Working→CompleteWork`); OCaml inlines them in cascade dispatch. `RateRespect` assumes `CompleteWork` always fires — fiber cancel or panic between try_acquire and release leaks `in_flight[p]`. Fix: `Eio.Switch.on_release` wrapping bucket lifetime. |
| **K-2.b** | MED | spec requires **strong** fairness on `TryDispatch` (TLC 6243-state counter-example cited in spec). OCaml has no SF emulation (no bounded retry). Hostile interleaving could starve a keeper on activation. Fix: bounded-retry policy with backoff. |
| **K-2.c** | LOW | 5-state spec vs `{Dispatch_immediate \| Enqueue_overflow \| Bypass_admission \| Capacity_exhausted}` OCaml enum — abstraction acceptable but undocumented at the .mli layer. Fix: mapping table comment (6th drift class shape, iter 47 KCtxL precedent). |
| **K-2.d** | LOW | spec preamble lists invariants I1–I5 with no acknowledgement of dormancy. Fresh reader assumes flag is on. Fix: comment-only "Status: design ground, runtime dormant pending `MASC_ADMISSION_USE_NEW=1`" line (iter 27/48/53 honest-doc shape). |

## Why audit-only

- Memory `reference_masc_mcp_integrated_improvement_design_audit.md` (2026-05-05) flags `RFC-0026 PR-E-1.6 wiring pending` and the user note from that memo: "high-stakes runtime 변경 전 사용자 승인 필수". The 4 K-2 fixes touch runtime semantics on activation — not in scope for a single /loop iter without explicit user direction.
- First-entry pattern matches iter 1 (KSM A-1), iter 22 (KCR C-1), iter 38 (KCL E-1), iter 47 (KCtxL H-1): audit memo first, fix in next iter when scope is clear.

## Out-of-scope follow-ups

- **K-3**: TLC verification refresh after any K-2 fix. The two `-buggy.cfg` fixtures haven't been re-run inside this loop; admission spec changes are *not* TLC-transparent (unlike pure comment edits) so K-3 cannot be skipped.
- **K-4**: liveness bug-model pairing — current buggy cfgs exercise safety invariants only. A `BugAction_StarveKeeper` action that refills tokens around a target keeper without admitting it would close the bug-model symmetry the rest of the spec corpus enjoys.

## Verification (this audit)

| Check | Result |
|-------|--------|
| `wc -l specs/keeper-state-machine/KeeperAdmissionLiveness.tla` | 387 LOC |
| `wc -l lib/keeper/keeper_admission_*.ml keeper_provider_token_bucket.ml keeper_wfq_overflow.ml` | 845 LOC across 7 modules |
| `rg -l 'Keeper_admission_(router\|policy\|glue\|registry\|runtime)\.' lib/ bin/` | 10 files, 5 unique external callers |
| `rg -n 'MASC_ADMISSION_USE_NEW' lib/` | 5 references, all in admission modules (dormancy centralized) |

No spec / OCaml / cfg mutation.  +100 LOC docs/.

## RFC 참조

RFC-WAIVED — audit-only memo. K-2/K-3/K-4 downstream candidates carry their own RFC trail via RFC-0026 PR-E-1.6 family.

## 진행 추적

다음 iteration 시작점 (priority order):
1. **K-2.a** (HIGH, Eio.Switch.on_release wrapping bucket lifetime) — if admission activation enters scope.
2. **R-D-2.a + R-D-1.a bundle** (biggest pending, MID ~150-300 LOC) — KCAF call_err 3-way + Cascade_fsm.Exhausted 2-way.
3. **R-H-1.g cleanup** — remove 4 baseline lines from `scripts/ocaml-phase-count-baseline.txt` after iter 54 #14886 merges (1-line PR).
4. **R-D-1.d** (ppx_tla prefix prerequisite) — independent of admission.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
