### PR TITLE
spec(kal): K-2.d preamble dormancy note (iter 57)

### DIFF
--- a/specs/keeper-state-machine/KeeperAdmissionLiveness.tla
+++ b/specs/keeper-state-machine/KeeperAdmissionLiveness.tla
@@ -4,6 +4,22 @@
 \* to dispatch on a provider, enqueue on the WFQ overflow queue, or
 \* surface a capacity-exhausted event.
 \*
+\* Runtime status (2026-05-12, iter 57 K-2.d):
+\*   The OCaml implementation (lib/keeper/keeper_admission_*.ml +
+\*   keeper_provider_token_bucket.ml + keeper_wfq_overflow.ml, ~845 LOC
+\*   across 7 modules) lives in main but is DORMANT.  keeper_heartbeat_loop
+\*   only exercises the active path when the process environment sets
+\*   MASC_ADMISSION_USE_NEW=1; with the flag unset (the default), the
+\*   shadow path computes admission outcomes but does NOT consume bucket
+\*   tokens or enqueue the WFQ.  RFC-0026 PR-E-1.6 is the activation
+\*   wiring step (memory:reference_masc_mcp_integrated_improvement_design_audit
+\*   2026-05-05).  Until PR-E-1.6 lands, the invariants below describe
+\*   the intended behaviour, not the running behaviour.
+\*
+\*   The spec/OCaml mapping table and four open drift risks (K-2.a..d)
+\*   are catalogued in docs/tla-audit/kal-k1-admission-spec-ocaml-mapping-
+\*   2026-05-12.md (iter 56 #14895).
+\*
 \* This spec is the design ground for PR-A (#12904 keeper_provider_token_bucket)
 \* and the planned PR-B/PR-C/PR-E series. It does NOT model:
 \*   - in-attempt streaming liveness (RFC-0022)


### PR DESCRIPTION
## Finding (Iteration 57, K-2.d — KAL preamble dormancy note)

**Spec**: `specs/keeper-state-machine/KeeperAdmissionLiveness.tla` (1 edit, +16/-0 LOC)
**Aspect**: spec preamble now documents that the matching OCaml is dormant
**Risk**: LOW (comment-only, TLC structurally transparent, no spec semantics change)
**Workaround signature**: N/A — honest-doc shape, 10th datapoint.

## 순서도

```mermaid
flowchart LR
  A[iter 56 #14895: audit memo names K-2.a..d 4 risks] --> B{Pick safest first}
  B -- HIGH/MED runtime changes --> C[K-2.a/K-2.b: deferred until user approval]
  B -- LOW doc only --> D[K-2.d: spec preamble dormancy note iter 57]
  B -- LOW mli mapping doc --> E[K-2.c: deferred — touches OCaml]
  D --> F[Fresh reader now sees runtime status before invariants]
  F --> G[Cross-refs RFC-0026 PR-E-1.6 + audit memo + memory ref]
```

## What was added

A "Runtime status" block sits between the opening line and the existing scope summary:

```tla
\* Runtime status (2026-05-12, iter 57 K-2.d):
\*   The OCaml implementation (lib/keeper/keeper_admission_*.ml +
\*   keeper_provider_token_bucket.ml + keeper_wfq_overflow.ml, ~845 LOC
\*   across 7 modules) lives in main but is DORMANT.  keeper_heartbeat_loop
\*   only exercises the active path when the process environment sets
\*   MASC_ADMISSION_USE_NEW=1; with the flag unset (the default), the
\*   shadow path computes admission outcomes but does NOT consume bucket
\*   tokens or enqueue the WFQ.  RFC-0026 PR-E-1.6 is the activation
\*   wiring step (memory:reference_masc_mcp_integrated_improvement_design_audit
\*   2026-05-05).  Until PR-E-1.6 lands, the invariants below describe
\*   the intended behaviour, not the running behaviour.
\*
\*   The spec/OCaml mapping table and four open drift risks (K-2.a..d)
\*   are catalogued in docs/tla-audit/kal-k1-admission-spec-ocaml-mapping-
\*   2026-05-12.md (iter 56 #14895).
```

## Why this matters

iter 56 audit observed a real risk: a fresh reader (LLM or human) landing on `KeeperAdmissionLiveness.tla` without prior context would read the invariants (`RateRespect`, `WorkConserving`, `LivenessInvariant`) and **assume they hold in production right now**. They do not — the runtime is gated by `MASC_ADMISSION_USE_NEW=1` and the default is unset.

Concrete failure mode this note prevents:
- During incident triage, an operator searches for "admission token bucket overflow" → finds `RateRespect` invariant → concludes "the gate is enforcing" → wastes time looking for a bucket-leak bug that cannot occur because no acquire is happening.

The cross-reference to `docs/tla-audit/kal-k1-admission-spec-ocaml-mapping-2026-05-12.md` gives the reader a path to the full 100-LOC mapping table and the four open drift risks. No information is duplicated between the spec preamble and the audit memo — only a pointer.

## Pipeline relationship

| Step | iter | PR | Action |
|------|------|----|--------|
| 1 audit | 56 | #14895 Draft | KAL K-1 — spec/OCaml mapping snapshot, 4 K-2 risks ranked |
| **2 apply LOW** | **57** | **this PR** | **K-2.d — preamble dormancy note** |
| 3 apply LOW | (later) | TBD | K-2.c — .mli mapping doc (touches OCaml, 6th drift class shape) |
| 4 apply MED | (gated) | TBD | K-2.b — bounded retry / SF emulation (runtime change) |
| 5 apply HIGH | (gated) | TBD | K-2.a — Switch.on_release bucket lifetime (runtime change) |

K-2.a/K-2.b are deferred per memory `reference_masc_mcp_integrated_improvement_design_audit.md`: "high-stakes runtime 변경 전 사용자 승인 필수". K-2.c is deferred because OCaml .mli edits accumulate ocamlformat-check pressure with iter 54 PR #14886 still open.

## Verification

```bash
$ bash scripts/audit-tla-annotation-drift.sh --baseline ... --check-cross-spec
tla-annotation-drift summary: 20 constructors checked across 4 type/set pairs,
  0 new drift(s), 1 baseline-known drift(s); 3 cross-spec set(s) checked,
  0 cross-spec drifts

$ bash scripts/audit-tla-phase-count.sh
phase-count audit clean: SSOT=13, no unqualified mismatches.

$ git diff --stat
specs/keeper-state-machine/KeeperAdmissionLiveness.tla | 16 ++++++++++++++++
1 file changed, 16 insertions(+)
```

TLC NOT re-run — 9-datapoint honest-doc precedent (iter 27/35/37/39/48/50/51/53/54). This is the **10th honest-doc datapoint**, and the first to cite *runtime dormancy* rather than count/symbol/mapping drift.

## RFC 참조

RFC-WAIVED — spec doc-only. K-2.a/K-2.b runtime changes require explicit user approval per the production-blocking-only rule.

## 진행 추적

다음 iteration 시작점:
1. **R-H-1.g cleanup** (blocked on #14886 merge; 1-line baseline removal)
2. **R-D queue** (R-D-2.a + R-D-1.a bundle, biggest pending)
3. **K-2.c** (LOW, .mli mapping doc — defer until #14886 settles)
4. **새 spec entry** (KRL Phase L, KOAS, KWP)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
