### PR TITLE
feat(sublibs): enable warning 4 on 15 leaf util sublibs (RFC-0071 §3.4 ratchet batch 2)

### DIFF
--- a/lib/ag_ui/dune
+++ b/lib/ag_ui/dune
@@ -5,5 +5,7 @@
  (public_name masc_mcp.ag_ui)
  (modules ag_ui)
  (wrapped false)
+ ; RFC-0071 §3.4 Phase 5 ratchet (warning 4)
+ (flags (:standard -w +4))
  (libraries time_compat yojson masc_core)
  (preprocess (pps ppx_deriving.show ppx_deriving.eq)))

--- a/lib/board_types/dune
+++ b/lib/board_types/dune
@@ -4,6 +4,8 @@
  (public_name masc_mcp.masc_board)
  (wrapped false)
  (modules board_types)
+ ; RFC-0071 §3.4 Phase 5 ratchet (warning 4)
+ (flags (:standard -w +4))
  (libraries
    yojson
    re

--- a/lib/compression/dune
+++ b/lib/compression/dune
@@ -5,6 +5,8 @@
  (wrapped false)
  (modules
   compression_codec)
+ ; RFC-0071 §3.4 Phase 5 ratchet (warning 4)
+ (flags (:standard -w +4))
  (libraries
   masc_log
   zstd))

--- a/lib/dashboard_api_types/dune
+++ b/lib/dashboard_api_types/dune
@@ -3,5 +3,7 @@
  (name masc_dashboard_api_types)
  (public_name masc_mcp.masc_dashboard_api_types)
  (modules keepers)
+ ; RFC-0071 §3.4 Phase 5 ratchet (warning 4)
+ (flags (:standard -w +4))
  (libraries yojson)
  (preprocess (pps ppx_deriving_yojson)))

--- a/lib/dashboard_utils/dune
+++ b/lib/dashboard_utils/dune
@@ -5,4 +5,6 @@
  (public_name masc_mcp.dashboard_utils)
  (modules dashboard_utils)
  (wrapped false)
+ ; RFC-0071 §3.4 Phase 5 ratchet (warning 4)
+ (flags (:standard -w +4))
  (libraries masc_types masc_core unix yojson))

--- a/lib/fs_compat/dune
+++ b/lib/fs_compat/dune
@@ -3,4 +3,6 @@
  (name fs_compat)
  (public_name masc_mcp.fs_compat)
  (modules fs_compat)
+ ; RFC-0071 §3.4 Phase 5 ratchet (warning 4)
+ (flags (:standard -w +4))
  (libraries eio eio.unix unix yojson optint))

--- a/lib/masc_http_client/dune
+++ b/lib/masc_http_client/dune
@@ -2,4 +2,6 @@
 (library
  (name masc_http_client)
  (public_name masc_mcp.http_client)
+ ; RFC-0071 §3.4 Phase 5 ratchet (warning 4)
+ (flags (:standard -w +4))
  (libraries eio eio.unix cstruct cohttp cohttp-eio uri))

--- a/lib/mcp_session/dune
+++ b/lib/mcp_session/dune
@@ -5,4 +5,6 @@
  (public_name masc_mcp.mcp_session)
  (modules mcp_session)
  (wrapped false)
+ ; RFC-0071 §3.4 Phase 5 ratchet (warning 4)
+ (flags (:standard -w +4))
  (libraries time_compat unix))

--- a/lib/prompt_registry/dune
+++ b/lib/prompt_registry/dune
@@ -8,6 +8,8 @@
    prompt_registry_store
    prompt_registry)
  (wrapped false)
+ ; RFC-0071 §3.4 Phase 5 ratchet (warning 4)
+ (flags (:standard -w +4))
  (libraries
    masc_core
    masc_log

--- a/lib/pulse/dune
+++ b/lib/pulse/dune
@@ -5,6 +5,8 @@
  (public_name masc_mcp.pulse)
  (wrapped false)
  (modules pulse)
+ ; RFC-0071 §3.4 Phase 5 ratchet (warning 4)
+ (flags (:standard -w +4))
  (libraries
    eio
    eio.unix

--- a/lib/response/dune
+++ b/lib/response/dune
@@ -5,4 +5,6 @@
  (public_name masc_mcp.response)
  (modules response)
  (wrapped false)
+ ; RFC-0071 §3.4 Phase 5 ratchet (warning 4)
+ (flags (:standard -w +4))
  (libraries yojson time_compat masc_types))

--- a/lib/shared_audit/dune
+++ b/lib/shared_audit/dune
@@ -3,4 +3,6 @@
 (library
  (name shared_audit)
  (public_name masc_mcp.shared_audit)
+ ; RFC-0071 §3.4 Phase 5 ratchet (warning 4)
+ (flags (:standard -w +4))
  (libraries unix yojson digestif digestif.c))

--- a/lib/shared_types/dune
+++ b/lib/shared_types/dune
@@ -3,4 +3,6 @@
 (library
  (name shared_types)
  (public_name masc_mcp.shared_types)
+ ; RFC-0071 §3.4 Phase 5 ratchet (warning 4)
+ (flags (:standard -w +4))
  (libraries unix yojson))

--- a/lib/tool_blob_store/dune
+++ b/lib/tool_blob_store/dune
@@ -12,6 +12,8 @@
  (public_name masc_mcp.masc_tool_blob_store)
  (wrapped false)
  (modules tool_blob_store tool_output)
+ ; RFC-0071 §3.4 Phase 5 ratchet (warning 4)
+ (flags (:standard -w +4))
  (libraries
    digestif
    digestif.c

--- a/lib/tool_schemas/dune
+++ b/lib/tool_schemas/dune
@@ -25,6 +25,8 @@
    ;; Masc_tool_schemas.Tool_descriptors_gen.
    tool_descriptors_gen)
  (wrapped false)
+ ; RFC-0071 §3.4 Phase 5 ratchet (warning 4)
+ (flags (:standard -w +4))
  (libraries masc_types))
 
 ;; RFC-0057 Phase 0 — capture bin/gen_tool_descriptors.exe stdout into


### PR DESCRIPTION
## 목적

RFC-0071 §3.4 Phase 5 **ratchet 3단계**. #14888 (lib/core) + #14894 (5 sublibs) 후속.

## 변경

15개 leaf util sublib 의 `dune` 에 `(flags (:standard -w +4))` 추가:

| 그룹 | Sublibs |
|------|---------|
| Type/Schema | `ag_ui`, `board_types`, `dashboard_api_types`, `shared_types`, `tool_schemas` |
| Util/Compat | `compression`, `pulse`, `fs_compat`, `dashboard_utils` |
| HTTP/Session | `masc_http_client`, `mcp_session`, `response` |
| Storage/Audit | `tool_blob_store`, `shared_audit` |
| Registry | `prompt_registry` |

## 검증

| Sublib | catch-alls | warning 4 fires | Build clean |
|--------|------------|-----------------|-------------|
| 11 (zero-count) | 0 | 0 | ✅ |
| mcp_session | 1 (string) | 0 (string scrutinee) | ✅ |
| prompt_registry | 2 (char + option-when) | 0 | ✅ |
| fs_compat | 1 (Unix.stats record) | 0 | ✅ |
| dashboard_utils | 2 (option + Yojson) | 0 | ✅ |

\`dune build --root . lib/<sublib>\` clean for all 15.

## 핵심 발견

기존 catch-all 6건 (mcp_session/prompt_registry/fs_compat/dashboard_utils) 전부 *non-closed-concrete-variant* scrutinee 위에서 매칭. 즉:
- string, char: warning 4 fire 안 함 (infinite type)
- Yojson.Safe.t: poly variant — fire 안 함
- option (`when` guard 와 함께): closed concrete 지만 fire 안 함 (이미 fully-exhaustive 가 guard 로 보장)

→ **17개 sublib 가 코드 변경 0건으로 ratchet 완료**.

## 누적 보호 sublib

| PR | Sublibs |
|----|---------|
| #14888 | 1 (lib/core, +1 fix) |
| #14894 | 5 (time_compat, random_id, eio_context, oas_compat, tool_schemas_specs) |
| **본 PR** | **15** |
| **누계** | **21** |

## Pre-existing build issue

\`lib/keeper/keeper_registry.ml:412-424\` 에 warning 8 (partial-match) 에러가 origin/main 에 존재. 본 PR 과 무관. 별도 fix 필요.

## RFC-0071 와의 관계

§3.4 \"compiler-builtin enforcement\" 의 ratchet 패턴. §4 Phase 5 점진 적용.

## 다음 ratchet 후보

- \`dated_jsonl\` (기존 \`-w -32\` 와 merge 필요)
- catch-all 보유 sublibs (\`exec\`, \`gate\`, \`autonomous\`, \`backend\`, \`config\` 각 4건) — closed-variant 여부에 따라 cleanup 필요할 수 있음
- Phase 3 codemod 본진 (\`lib/keeper/\` 256, \`lib/cascade*/\` 63)