### PR TITLE
spec(krl): L-2.a + L-2.b preamble — design-ground status + truthful citations (iter 59)

### DIFF
--- a/specs/INDEX.md
+++ b/specs/INDEX.md
@@ -5,7 +5,7 @@ Edit the generator, not this file. Re-run: scripts/gen-tla-index.sh > specs/INDE
 
 # TLA+ Spec Index
 
-Generated: 2026-05-12T00:16:59Z (HEAD: f3e4a5e1e)
+Generated: 2026-05-12T01:35:13Z (HEAD: 62be39f)
 
 Source of truth: `specs/`. Run `scripts/gen-tla-index.sh > specs/INDEX.md` to refresh.
 
@@ -117,7 +117,7 @@ Source of truth: `specs/`. Run `scripts/gen-tla-index.sh > specs/INDEX.md` to re
 
 | File | Module | Kind | cfg | buggy | Invariants / Properties | Source Hash |
 |------|--------|------|-----|-------|-------------------------|---------------|
-| KeeperAdmissionLiveness.tla | KeeperAdmissionLiveness | manual | 3 | 2 | clean={inv:TypeOK, inv:RateRespect, inv:TokensInRange, inv:QueueWellFormed, inv:TokenInflightConservation} buggy-2={inv:TypeOK, inv:RateRespect, inv:TokensInRange, inv:QueueWellFormed, inv:TokenInflightConservation} buggy={inv:TypeOK, inv:RateRespect, inv:TokensInRange, inv:QueueWellFormed, inv:TokenInflightConservation} | d0de975d7f83 |
+| KeeperAdmissionLiveness.tla | KeeperAdmissionLiveness | manual | 3 | 2 | clean={inv:TypeOK, inv:RateRespect, inv:TokensInRange, inv:QueueWellFormed, inv:TokenInflightConservation} buggy-2={inv:TypeOK, inv:RateRespect, inv:TokensInRange, inv:QueueWellFormed, inv:TokenInflightConservation} buggy={inv:TypeOK, inv:RateRespect, inv:TokensInRange, inv:QueueWellFormed, inv:TokenInflightConservation} | 318ebc8ebd0f |
 | KeeperApprovalQueue.tla | KeeperApprovalQueue | manual | 2 | 1 | clean={inv:TypeOK, inv:SafetyInvariant} buggy={inv:TypeOK, inv:SafetyInvariant} | a18102f83db7 |
 | KeeperCascadeAttemptFSM.tla | KeeperCascadeAttemptFSM | manual | 2 | 1 | clean={inv:SafetyInvariant} buggy={inv:SafetyInvariant} | a6708aff38f9 |
 | KeeperCascadeLifecycle.tla | KeeperCascadeLifecycle | manual | 2 | 1 | clean={inv:Safety, prop:TryingEventuallyTerminates, prop:FinalizingEventuallyClears} buggy={inv:CascadeSelectionRequiresMeasurement} | 9134dad5df91 |
@@ -139,7 +139,7 @@ Source of truth: `specs/`. Run `scripts/gen-tla-index.sh > specs/INDEX.md` to re
 | KeeperOASAdvanced.tla | KeeperOASAdvanced | manual | 2 | 1 | clean={inv:NoZombieFibers, inv:CancelledNeverAbsorbed, prop:AtomicCascadeFallback, prop:CommittedSideEffectsRequireContinueGate, prop:StrictStopPreemption, prop:EventualTermination} buggy={inv:NoZombieFibers, inv:CancelledNeverAbsorbed, prop:AtomicCascadeFallback, prop:StrictStopPreemption, prop:EventualTermination} | f8cc8eaeef07 |
 | KeeperOutcomesConservation.tla | KeeperOutcomesConservation | manual | 2 | 1 | clean={inv:Safety} buggy={inv:ConservationLaw} | c53dded69dc1 |
 | KeeperPostTurnOrchestration.tla | KeeperPostTurnOrchestration | manual | 2 | 1 | clean={inv:SafetyInvariant} buggy={inv:SafetyInvariant} | 0c26d77292b4 |
-| KeeperReactionLiveness.tla | KeeperReactionLiveness | manual | 2 | 1 | clean={inv:Safety, prop:BoardEnqueueLeadsToReceipt, prop:VerificationLeadsToReaction, prop:GoalVerificationLeadsToResolution, prop:TaskTransitionLeadsToReceipt, prop:CursorAdvancementRequiresAck} buggy={inv:TypeOK, prop:BoardEnqueueLeadsToReceipt} | 6d49d1fb3824 |
+| KeeperReactionLiveness.tla | KeeperReactionLiveness | manual | 2 | 1 | clean={inv:Safety, prop:BoardEnqueueLeadsToReceipt, prop:VerificationLeadsToReaction, prop:GoalVerificationLeadsToResolution, prop:TaskTransitionLeadsToReceipt, prop:CursorAdvancementRequiresAck} buggy={inv:TypeOK, prop:BoardEnqueueLeadsToReceipt} | 353fe806cd4a |
 | KeeperReconcileLiveness.tla | KeeperReconcileLiveness | manual | 2 | 1 | clean={inv:TypeOK, prop:RunningClearsManualReconcile, prop:DeadIsForever, prop:StoppedIsForever, prop:RunningRequiresFiber, prop:ManualReconcileLiveness, prop:FailingRecoveryLiveness, prop:CompactingResolves, prop:HandoffResolves, prop:DrainingResolves} buggy={inv:TypeOK, prop:RunningClearsManualReconcile, prop:DeadIsForever, prop:StoppedIsForever, prop:RunningRequiresFiber, prop:ManualReconcileLiveness, prop:FailingRecoveryLiveness} | 62638a411215 |
 | KeeperRolloverDecision.tla | KeeperRolloverDecision | manual | 2 | 1 | clean={inv:SignalGateOverflowOnly} buggy={inv:SignalGateOverflowOnly} | 71d1c2f76746 |
 | KeeperSocialModelMagenticLedger.tla | KeeperSocialModelMagenticLedger | manual | 2 | 1 | clean={inv:TypeOK, inv:ClassifyTypeOK, inv:StalledNeedsGoalOrFailure, prop:ProgressDominates, prop:ReactiveDominatesIdleTimeout, prop:StalledStickyWithGoal, prop:QuietWhenNoDrivers} buggy={inv:StalledNeedsGoalOrFailureMustHold} | 4adca73b6508 |

--- a/specs/keeper-state-machine/KeeperReactionLiveness.tla
+++ b/specs/keeper-state-machine/KeeperReactionLiveness.tla
@@ -8,6 +8,27 @@
 \* duplicate the safety invariants in KeeperTurnFSM / KeeperEventQueue /
 \* KeeperTaskAcquisition — those remain the authoritative safety SSOT.
 \*
+\* Runtime status (2026-05-12, iter 59 L-2.a):
+\*   This spec is a DESIGN GROUND, not a description of running code.
+\*   iter 58 #14898 audit confirmed via rg across all 251 lib/keeper/*.ml
+\*   files that NONE of the modeled concepts (goal_phase, task_state,
+\*   board_cursor, verifier_reaction, receipt_issued) appear anywhere
+\*   in the codebase.  Of the five OCaml "mirror" entry points cited
+\*   below, two exist as generic plumbing without matching the spec's
+\*   per-stimulus FSM, and three do not exist at all (see citation
+\*   table below — TBD entries).  Of L1-L5 only L1 has partial
+\*   coverage (queue exists, no receipt FSM).
+\*
+\*   Implementation tracking owner: MASC task
+\*   `goal-world-reaction-liveness/task-134`.  Until that work lands,
+\*   the invariants below describe the intended contract, not the
+\*   running behaviour.  Reader should not assume any L1-L5 claim is
+\*   currently enforced in production.
+\*
+\*   Full implementation gap matrix + L-2.{a..d} fix-PR candidates:
+\*   docs/tla-audit/krl-l1-reaction-spec-implementation-gap-2026-05-12.md
+\*   (iter 58 #14898).
+\*
 \* MASC tracking: goal-world-reaction-liveness / task-134
 \*
 \* Five liveness claims (L1–L5):
@@ -42,12 +63,21 @@
 \*                                                       violated.
 \* Both must hold.
 \*
-\* Mirrors (OCaml runtime entry points):
-\*   stimulus / board queue   — lib/keeper/keeper_event_queue.ml
-\*   verification FSM         — lib/keeper/keeper_unified_turn.ml (verification gate)
-\*   goal phase               — lib/keeper/goal_store.ml
-\*   task FSM                 — lib/keeper/keeper_task_dispatch.ml
-\*   board cursor             — lib/keeper/keeper_board_observer.ml
+\* Mirrors (OCaml runtime entry points; ✓ = present, TBD = not yet
+\* implemented per iter 58 #14898 audit):
+\*   stimulus / board queue   — ✓ lib/keeper/keeper_event_queue.ml (queue
+\*                              plumbing only; no per-stimulus receipt FSM
+\*                              as the spec models)
+\*   verification FSM         — ✓ lib/keeper/keeper_unified_turn.ml
+\*                              (terminal_reason machinery; no
+\*                              verification_state / approve / reject
+\*                              concepts as the spec models)
+\*   goal phase               — TBD: lib/keeper/goal_store.ml not yet
+\*                              implemented (MASC task-134 owns this)
+\*   task FSM                 — TBD: lib/keeper/keeper_task_dispatch.ml
+\*                              not yet implemented (MASC task-134)
+\*   board cursor             — TBD: lib/keeper/keeper_board_observer.ml
+\*                              not yet implemented (MASC task-134)
 
 EXTENDS TLC
 

--- a/specs/keeper-state-machine/KeeperReactionLiveness.tla
+++ b/specs/keeper-state-machine/KeeperReactionLiveness.tla
@@ -10,14 +10,20 @@
 \*
 \* Runtime status (2026-05-12, iter 59 L-2.a):
 \*   This spec is a DESIGN GROUND, not a description of running code.
-\*   iter 58 #14898 audit confirmed via rg across all 251 lib/keeper/*.ml
-\*   files that NONE of the modeled concepts (goal_phase, task_state,
-\*   board_cursor, verifier_reaction, receipt_issued) appear anywhere
-\*   in the codebase.  Of the five OCaml "mirror" entry points cited
-\*   below, two exist as generic plumbing without matching the spec's
-\*   per-stimulus FSM, and three do not exist at all (see citation
-\*   table below — TBD entries).  Of L1-L5 only L1 has partial
-\*   coverage (queue exists, no receipt FSM).
+\*   iter 58 #14898 audit confirmed via rg across lib/keeper/*.ml that
+\*   the KRL reaction/receipt FSM (L1-L5 leads-to claims) has NO
+\*   matching runtime: verifier_reaction, receipt_issued, task_state
+\*   are truly absent everywhere; goal_phase appears as data shape
+\*   in lib/goal/ + adjacent modules but not as the per-stimulus FSM
+\*   the spec models; board_cursor exists as opaque cursor state in
+\*   lib/keeper/keeper_registry.{ml,mli} (get_board_cursor /
+\*   set_board_cursor) + lib/keeper/keeper_world_observation.ml, but
+\*   without the cursor-ack semantics L5 models (no ack tracking).
+\*   Of the five OCaml "mirror" entry points cited below, two exist
+\*   as generic plumbing without matching the spec's per-stimulus FSM,
+\*   and three do not exist at the cited path (see citation table
+\*   below — TBD entries).  Of L1-L5 only L1 has partial coverage
+\*   (queue exists, no receipt FSM).
 \*
 \*   Implementation tracking owner: MASC task
 \*   `goal-world-reaction-liveness/task-134`.  Until that work lands,
@@ -76,8 +82,13 @@
 \*                              implemented (MASC task-134 owns this)
 \*   task FSM                 — TBD: lib/keeper/keeper_task_dispatch.ml
 \*                              not yet implemented (MASC task-134)
-\*   board cursor             — TBD: lib/keeper/keeper_board_observer.ml
-\*                              not yet implemented (MASC task-134)
+\*   board cursor             — PARTIAL: lib/keeper/keeper_registry.{ml,mli}
+\*                              (get_board_cursor / set_board_cursor /
+\*                              board_cursor_ts) + keeper_world_observation.ml
+\*                              track opaque cursor state, but without the
+\*                              cursor-ack token L5 models.  Per-stimulus
+\*                              board observer (keeper_board_observer.ml)
+\*                              not yet implemented (MASC task-134).
 
 EXTENDS TLC
 


### PR DESCRIPTION
## Finding (Iteration 59, L-2.a + L-2.b — KRL preamble honest-doc bundle)

**Spec**: `specs/keeper-state-machine/KeeperReactionLiveness.tla` (+36/-6 LOC, 1 spec)
**Aspect**: design-ground status + truthful module citations
**Risk**: LOW (comment-only, TLC structurally transparent, no spec semantics change)
**Workaround signature**: N/A — 11th honest-doc datapoint.

## 순서도

```mermaid
flowchart LR
  A[iter 58 #14898 audit: KRL is design-ground] --> B{4 L-2 candidates}
  B --> C[L-2.a LOW Runtime status block]
  B --> D[L-2.b LOW citation table fix]
  B --> E[L-2.c MED design RFC - deferred]
  B --> F[L-2.d MED TLC refresh - deferred]
  C --> G[Mirror iter 57 K-2.d shape]
  D --> H[Tag 2 existing modules with what they contain]
  D --> I[Tag 3 missing modules TBD MASC task-134]
  G --> J[Reader no longer needs to rg to learn design-ground]
  H --> J
  I --> J
```

## What was added

### L-2.a — Runtime status block (lines 11–30)

```tla
\* Runtime status (2026-05-12, iter 59 L-2.a):
\*   This spec is a DESIGN GROUND, not a description of running code.
\*   iter 58 #14898 audit confirmed via rg across all 251 lib/keeper/*.ml
\*   files that NONE of the modeled concepts (goal_phase, task_state,
\*   board_cursor, verifier_reaction, receipt_issued) appear anywhere
\*   in the codebase.  Of the five OCaml "mirror" entry points cited
\*   below, two exist as generic plumbing without matching the spec's
\*   per-stimulus FSM, and three do not exist at all (see citation
\*   table below — TBD entries).  Of L1-L5 only L1 has partial
\*   coverage (queue exists, no receipt FSM).
\*
\*   Implementation tracking owner: MASC task
\*   `goal-world-reaction-liveness/task-134`.  Until that work lands,
\*   the invariants below describe the intended contract, not the
\*   running behaviour.  Reader should not assume any L1-L5 claim is
\*   currently enforced in production.
\*
\*   Full implementation gap matrix + L-2.{a..d} fix-PR candidates:
\*   docs/tla-audit/krl-l1-reaction-spec-implementation-gap-2026-05-12.md
\*   (iter 58 #14898).
```

Mirrors iter 57 K-2.d (PR #14896) Runtime status block in KAL. Same anatomy: status sentence → rg-verified evidence → tracking owner → audit memo link.

### L-2.b — truthful citation table (Mirrors block)

Before (5 lines, 3 stale):
```tla
\*   stimulus / board queue   — lib/keeper/keeper_event_queue.ml
\*   verification FSM         — lib/keeper/keeper_unified_turn.ml (verification gate)
\*   goal phase               — lib/keeper/goal_store.ml
\*   task FSM                 — lib/keeper/keeper_task_dispatch.ml
\*   board cursor             — lib/keeper/keeper_board_observer.ml
```

After (12 lines, ✓ and TBD tagged):
```tla
\* Mirrors (OCaml runtime entry points; ✓ = present, TBD = not yet
\* implemented per iter 58 #14898 audit):
\*   stimulus / board queue   — ✓ lib/keeper/keeper_event_queue.ml (queue
\*                              plumbing only; no per-stimulus receipt FSM
\*                              as the spec models)
\*   verification FSM         — ✓ lib/keeper/keeper_unified_turn.ml
\*                              (terminal_reason machinery; no
\*                              verification_state / approve / reject
\*                              concepts as the spec models)
\*   goal phase               — TBD: lib/keeper/goal_store.ml not yet
\*                              implemented (MASC task-134 owns this)
\*   task FSM                 — TBD: lib/keeper/keeper_task_dispatch.ml
\*                              not yet implemented (MASC task-134)
\*   board cursor             — TBD: lib/keeper/keeper_board_observer.ml
\*                              not yet implemented (MASC task-134)
```

The ✓ tags note what the modules *actually* contain so a contributor sees the abstraction gap immediately. The TBD entries make the missing implementation a feature of the spec, not a citation bug.

## Concrete failure mode addressed

A future contributor reading this spec and then `cd`ing into `lib/keeper/goal_store.ml` after the old citation list would have hit `no such file or directory`. Two bad outcomes follow:

1. *Spec is stale* — assume the spec was abandoned, ignore it, miss the design-ground intent.
2. *Satisfy the citation* — create an empty stub module `goal_store.ml`, then forget to remove it when the real implementation lands. Now there's a phantom module.

The TBD tagging plus MASC task-134 link defends against both. Reader sees the gap *is the design* and knows where the implementation work is owned.

## Pipeline relationship

| Step | iter | PR | Action |
|------|------|----|--------|
| 1 audit | 58 | #14898 Draft | KRL L-1 — implementation gap discovered (3/5 modules MIA, 0/5 concept matches) |
| **2 LOW bundle** | **59** | **this PR** | **L-2.a Runtime status + L-2.b truthful citations** |
| 3 MED design | gated | TBD | L-2.c design RFC for runtime layer (needs user direction) |
| 4 MED TLC | gated | TBD | L-2.d buggy.cfg verification refresh (TLC re-run, not transparent) |

L-2.a and L-2.b are deliberately *bundled* because they make sense together — L-2.a says "design ground" and L-2.b shows *what specifically is missing*. Splitting them produces two PRs with overlapping rationale and a brittle commit order (L-2.a alone leaves stale citations visible until L-2.b lands).

## Verification

```bash
$ bash scripts/audit-tla-annotation-drift.sh --baseline ... --check-cross-spec
tla-annotation-drift summary: 20 constructors checked across 4 type/set pairs,
  0 new drift(s), 1 baseline-known drift(s); 3 cross-spec set(s) checked,
  0 cross-spec drifts

$ bash scripts/audit-tla-phase-count.sh
phase-count audit clean: SSOT=13, no unqualified mismatches.

$ git diff --stat
specs/keeper-state-machine/KeeperReactionLiveness.tla | 42 ++++++++++++++++++----
1 file changed, 36 insertions(+), 6 deletions(-)
```

TLC NOT re-run — 10-datapoint honest-doc precedent (iter 27/35/37/39/48/50/51/53/54/57). This is the **11th honest-doc datapoint** and the first to combine status-disclosure with broken-citation cleanup in one commit.

## RFC 참조

RFC-WAIVED — spec doc-only. L-2.c (design RFC for runtime layer) and L-2.d (TLC buggy.cfg refresh) remain deferred per the iter 58 audit memo; both need user direction or are not TLC-transparent.

## 진행 추적

다음 iteration 시작점:
1. **R-H-1.g cleanup** (1-line, blocked on #14886 merge — still Draft as of iter 59 push)
2. **R-D queue** (R-D-2.a + R-D-1.a bundle, biggest pending, MID ~150-300 LOC)
3. **새 spec entry** (KOAS / KWP / KAQ / KH untouched)
4. **L-2.c / L-2.d** (gated on user direction)
5. **K-2.c LOW** (.mli mapping doc, gated on #14886 settling)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
