### PR TITLE
refactor(tool_plan): Plan_action_outcome closed sum — 6 verb statuses (T31)

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -3,6 +3,7 @@
  (name masc_mcp)
  (public_name masc_mcp)
 (private_modules
+ plan_action_outcome
  error_event_type
  dashboard_http_keeper_metrics
  dashboard_http_keeper_detail

--- a/lib/plan_action_outcome.ml
+++ b/lib/plan_action_outcome.ml
@@ -1,0 +1,20 @@
+type t =
+  | Initialized
+  | Updated
+  | Added
+  | Delivered
+  | Set
+  | Cleared
+
+let to_label = function
+  | Initialized -> "initialized"
+  | Updated -> "updated"
+  | Added -> "added"
+  | Delivered -> "delivered"
+  | Set -> "set"
+  | Cleared -> "cleared"
+;;
+
+let status_field outcome : string * Yojson.Safe.t =
+  ("status", `String (to_label outcome))
+;;

--- a/lib/plan_action_outcome.mli
+++ b/lib/plan_action_outcome.mli
@@ -1,0 +1,32 @@
+(** Plan_action_outcome — closed sum for the [status] field emitted by
+    the [masc_plan_*] / [masc_note_add] / [masc_deliver] handlers in
+    {!Tool_plan}.  Replaces 6 inline [`String "initialized"]-style
+    literals; adding a new handler now forces compiler-checked variant
+    enumeration. *)
+
+type t =
+  | Initialized
+  (** Emitted by [handle_plan_init] after a fresh planning context is
+      created via {!Planning_eio.init}. *)
+  | Updated
+  (** Emitted by [handle_plan_update] after a successful
+      {!Planning_eio.update_plan}. *)
+  | Added
+  (** Emitted by [handle_note_add] after a note is appended via
+      {!Planning_eio.add_note}. *)
+  | Delivered
+  (** Emitted by [handle_deliver] after a deliverable is recorded via
+      {!Planning_eio.set_deliverable}. *)
+  | Set
+  (** Emitted by [handle_plan_set_task] after [current_task] is
+      reassigned. *)
+  | Cleared
+  (** Emitted by [handle_plan_clear_task] after [current_task] is
+      cleared. *)
+
+val to_label : t -> string
+(** Wire-format label, byte-identical to the original inline literals. *)
+
+val status_field : t -> string * Yojson.Safe.t
+(** Pair [("status", `String (to_label outcome))] — convenience for the
+    common envelope shape [`Assoc \[ status_field outcome; ...other \]]. *)

--- a/lib/tool_plan.ml
+++ b/lib/tool_plan.ml
@@ -37,7 +37,7 @@ let handle_plan_init ~tool_name ~start_time ctx args =
   match result with
   | Ok _ctx ->
       let response = `Assoc [
-        ("status", `String "initialized");
+        Plan_action_outcome.status_field Initialized;
         ("task_id", `String task_id);
         ("message", `String (Printf.sprintf "Planning context created for %s" task_id));
       ] in
@@ -52,7 +52,7 @@ let handle_plan_update ~tool_name ~start_time ctx args =
   match result with
   | Ok plan_ctx ->
       let response = `Assoc [
-        ("status", `String "updated");
+        Plan_action_outcome.status_field Updated;
         ("task_id", `String task_id);
         ("updated_at", `String plan_ctx.Planning_eio.updated_at);
       ] in
@@ -67,7 +67,7 @@ let handle_note_add ~tool_name ~start_time ctx args =
   match result with
   | Ok plan_ctx ->
       let response = `Assoc [
-        ("status", `String "added");
+        Plan_action_outcome.status_field Added;
         ("task_id", `String task_id);
         ("note_count", `Int (List.length plan_ctx.Planning_eio.notes));
       ] in
@@ -88,7 +88,7 @@ let handle_deliver ~tool_name ~start_time ctx args =
   match result with
   | Ok plan_ctx ->
       let response = `Assoc [
-        ("status", `String "delivered");
+        Plan_action_outcome.status_field Delivered;
         ("task_id", `String task_id);
         ("updated_at", `String plan_ctx.Planning_eio.updated_at);
       ] in
@@ -121,7 +121,7 @@ let handle_plan_set_task ~tool_name ~start_time ctx args =
   else begin
     Planning_eio.set_current_task ctx.config ~task_id;
     let response = `Assoc [
-      ("status", `String "set");
+      Plan_action_outcome.status_field Set;
       ("current_task", `String task_id);
     ] in
     Tool_result.ok ~tool_name ~start_time (Yojson.Safe.to_string response)
@@ -144,7 +144,7 @@ let handle_plan_get_task ~tool_name ~start_time ctx _args =
 let handle_plan_clear_task ~tool_name ~start_time ctx _args =
   Planning_eio.clear_current_task ctx.config;
   let response = `Assoc [
-    ("status", `String "cleared");
+    Plan_action_outcome.status_field Cleared;
     ("message", `String "Current task cleared");
   ] in
   Tool_result.ok ~tool_name ~start_time (Yojson.Safe.to_string response)

--- a/lib/tool_plan.ml
+++ b/lib/tool_plan.ml
@@ -37,7 +37,7 @@ let handle_plan_init ~tool_name ~start_time ctx args =
   match result with
   | Ok _ctx ->
       let response = `Assoc [
-        Plan_action_outcome.status_field Initialized;
+        Plan_action_outcome.(status_field Initialized);
         ("task_id", `String task_id);
         ("message", `String (Printf.sprintf "Planning context created for %s" task_id));
       ] in
@@ -52,7 +52,7 @@ let handle_plan_update ~tool_name ~start_time ctx args =
   match result with
   | Ok plan_ctx ->
       let response = `Assoc [
-        Plan_action_outcome.status_field Updated;
+        Plan_action_outcome.(status_field Updated);
         ("task_id", `String task_id);
         ("updated_at", `String plan_ctx.Planning_eio.updated_at);
       ] in
@@ -67,7 +67,7 @@ let handle_note_add ~tool_name ~start_time ctx args =
   match result with
   | Ok plan_ctx ->
       let response = `Assoc [
-        Plan_action_outcome.status_field Added;
+        Plan_action_outcome.(status_field Added);
         ("task_id", `String task_id);
         ("note_count", `Int (List.length plan_ctx.Planning_eio.notes));
       ] in
@@ -88,7 +88,7 @@ let handle_deliver ~tool_name ~start_time ctx args =
   match result with
   | Ok plan_ctx ->
       let response = `Assoc [
-        Plan_action_outcome.status_field Delivered;
+        Plan_action_outcome.(status_field Delivered);
         ("task_id", `String task_id);
         ("updated_at", `String plan_ctx.Planning_eio.updated_at);
       ] in
@@ -121,7 +121,7 @@ let handle_plan_set_task ~tool_name ~start_time ctx args =
   else begin
     Planning_eio.set_current_task ctx.config ~task_id;
     let response = `Assoc [
-      Plan_action_outcome.status_field Set;
+      Plan_action_outcome.(status_field Set);
       ("current_task", `String task_id);
     ] in
     Tool_result.ok ~tool_name ~start_time (Yojson.Safe.to_string response)
@@ -144,7 +144,7 @@ let handle_plan_get_task ~tool_name ~start_time ctx _args =
 let handle_plan_clear_task ~tool_name ~start_time ctx _args =
   Planning_eio.clear_current_task ctx.config;
   let response = `Assoc [
-    Plan_action_outcome.status_field Cleared;
+    Plan_action_outcome.(status_field Cleared);
     ("message", `String "Current task cleared");
   ] in
   Tool_result.ok ~tool_name ~start_time (Yojson.Safe.to_string response)


### PR DESCRIPTION
## Scope

T27/T28+T29/T30 의 envelope SSOT sweep 후속. 사용자 명시 \"빡세게\":
6 handler-specific verb status (\`initialized\` / \`updated\` / \`added\` /
\`delivered\` / \`set\` / \`cleared\`) 가 \`tool_plan.ml\` 안에 inline raw
\`\`String\`로 흩어져 있음 — closed sum 부재로 새 handler 추가 시 wire
vocabulary 가 *조용히* 확장됨.

## 새 모듈

\`lib/plan_action_outcome.ml(.mli)\`:

\`\`\`ocaml
type t =
  | Initialized
  | Updated
  | Added
  | Delivered
  | Set
  | Cleared

val to_label : t -> string
val status_field : t -> string * Yojson.Safe.t
\`\`\`

\`status_field outcome\` 가 \`(\"status\", \`String (to_label outcome))\`
pair 를 반환 — call site 가:

\`\`\`ocaml
let response = \`Assoc [
  Plan_action_outcome.status_field Initialized;
  (\"task_id\", \`String task_id);
  ...
]
\`\`\`

으로 단순화.

## 마이그레이션 (6 사이트, single file)

| Handler | Variant | Line |
|---------|---------|------|
| \`handle_plan_init\` | \`Initialized\` | 40 |
| \`handle_plan_update\` | \`Updated\` | 55 |
| \`handle_note_add\` | \`Added\` | 70 |
| \`handle_deliver\` | \`Delivered\` | 91 |
| \`handle_plan_set_task\` | \`Set\` | 124 |
| \`handle_plan_clear_task\` | \`Cleared\` | 147 |

## Wire format

byte-identical. \`to_label\` 는 기존 literal 과 정확히 동일 (\"initialized\"
/ \"updated\" / \"added\" / \"delivered\" / \"set\" / \"cleared\").

## 컴파일러 강제

새 handler 가 \`status: \"X\"\` 를 추가하려면 (1) variant 추가 + (2)
\`to_label\` arm 추가 두 곳 모두 컴파일러가 enforce. 침묵 확장 불가능.

## Diff stat

3 files, +58 / -6 (signed 새 모듈 2 + tool_plan.ml 6 사이트).

## 빌드 노트

origin/main 에 pre-existing partial-match error 가 있음
(\`lib/keeper/keeper_registry.ml\`, commit [8d1130687](https://github.com/jeong-sik/masc-mcp/commit/8d1130687) PR #14893).
\`@lib/check\` 가 그 지점에서 abort. T31 의 새 모듈과 tool_plan.ml 변경은
\`ocamlfind ocamlc -c\` 격리 typecheck 로 검증 — 클린. keeper_registry
warning 은 별도 PR로 정리될 영역 (Decision_undecided self-loop 매핑
누락이 진실, T31 무관).

## Anti-pattern signature closed

- Workaround #2 (string vocabulary expansion without typed gate)
- inline literal sprinkle within single file (6 사이트, 같은 패턴, abstraction 부재)

## Cross-reference

- T27 (#14876) — json_error/json_ok envelope helpers
- T28+T29 (#14882) — ok_assoc/ok_result + ok lint guard
- T30 (#14892) — error_assoc/error_response_with + error lint guard
- CLAUDE.md §워크어라운드 거부 기준 #2 (string/substring classifier)

## 후속 후보 (T32+)

다른 *verb status* 사이트들 — 단일 file 단위로 grouping 가능 시 typed sum:
- \`tool_misc_admin.ml\`: \`conditional\` / \`enforced\` / \`advisory_only\` (admin policy state, 7 사이트)
- \`tool_control.ml\`: \`paused\` / \`running\` / \`initializing\` (keeper lifecycle, 3 사이트 — 단 이미 다른 file의 Keeper_state 와 의미 중복일 가능성, audit 필요)

이미 closed sum 으로 covered:
- \`lib/types/types_core.ml\` task lifecycle (todo/claimed/in_progress/done/awaiting_verification/cancelled) — Task_status variant 의 \`to_yojson\`
- \`lib/audit_log.ml\` Success/Failure
- \`lib/verification.ml\` Pending/Assigned/Completed

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>