### PR TITLE
feat(keeper_registry): RFC-0072 Phase 1 — Cascade_transition GADT + resolver

### DIFF
--- a/lib/keeper/keeper_registry.ml
+++ b/lib/keeper/keeper_registry.ml
@@ -474,6 +474,173 @@ let packed_cascade_state_label : packed_cascade_state -> string = function
   | Packed Cascade_exhausted -> "Cascade_exhausted"
 ;;
 
+(* RFC-0072 Phase 1: GADT-encoded cascade transitions.
+
+   Enumerates the 13 valid cross-state transitions of the 5-variant
+   [cascade_state] FSM.  Idempotent (self-loop) transitions are
+   intentionally not represented — mirrors [Decision_transition] —
+   because they correspond to no-op writes at the mutator boundary.
+
+   The 7 forbidden pairs ([Idle -> Trying/Done/Exhausted],
+   [Selecting -> Done/Exhausted], [Done <-> Exhausted]) have no
+   constructor and are therefore type-unrepresentable.  Adding a new
+   [cascade_state] variant will trigger Warning 8 in [to_tag] and in
+   any future per-transition dispatcher.
+
+   Phase 1 (this PR) introduces the module additively — no caller is
+   wired yet.  Phase 2 routes [set_turn_cascade_state] through
+   [resolve_cascade_transition] for internal dispatch.  Phase 3
+   converts [validate_cascade_transition] into a compile-time
+   fixture (mirroring PR #14893 for decision). *)
+module Cascade_transition = struct
+  type ('from, 'to_) t =
+    (* Boot dispatch (Idle -> Selecting). *)
+    | Idle_to_selecting : (cascade_idle, cascade_selecting) t
+    (* Selecting -> {Idle, Trying} (retry-back or forward dispatch). *)
+    | Selecting_to_idle : (cascade_selecting, cascade_idle) t
+    | Selecting_to_trying : (cascade_selecting, cascade_trying) t
+    (* Trying -> {Idle, Selecting, Done, Exhausted}: retry-back,
+       re-entry, completion, exhaustion. *)
+    | Trying_to_idle : (cascade_trying, cascade_idle) t
+    | Trying_to_selecting : (cascade_trying, cascade_selecting) t
+    | Trying_to_done : (cascade_trying, cascade_done) t
+    | Trying_to_exhausted : (cascade_trying, cascade_exhausted) t
+    (* Compaction-driven retry from terminal states.
+       prepare_turn_retry_after_compaction lifts Done/Exhausted back
+       into Idle/Selecting/Trying. *)
+    | Done_to_idle : (cascade_done, cascade_idle) t
+    | Done_to_selecting : (cascade_done, cascade_selecting) t
+    | Done_to_trying : (cascade_done, cascade_trying) t
+    | Exhausted_to_idle : (cascade_exhausted, cascade_idle) t
+    | Exhausted_to_selecting : (cascade_exhausted, cascade_selecting) t
+    | Exhausted_to_trying : (cascade_exhausted, cascade_trying) t
+
+  type packed = Packed_transition : ('a, 'b) t -> packed
+
+  let to_tag : type a b. (a, b) t -> string = function
+    | Idle_to_selecting -> "idle->selecting"
+    | Selecting_to_idle -> "selecting->idle"
+    | Selecting_to_trying -> "selecting->trying"
+    | Trying_to_idle -> "trying->idle"
+    | Trying_to_selecting -> "trying->selecting"
+    | Trying_to_done -> "trying->done"
+    | Trying_to_exhausted -> "trying->exhausted"
+    | Done_to_idle -> "done->idle"
+    | Done_to_selecting -> "done->selecting"
+    | Done_to_trying -> "done->trying"
+    | Exhausted_to_idle -> "exhausted->idle"
+    | Exhausted_to_selecting -> "exhausted->selecting"
+    | Exhausted_to_trying -> "exhausted->trying"
+  ;;
+end
+
+(* RFC-0072 Phase 1: typed error for cascade transition spec violations.
+
+   Replaces the prior string-formatted [Invalid_argument] message at
+   [validate_cascade_transition].  Each forbidden pair has its own
+   constructor — adding a future forbidden pair (or downgrading an
+   admitted pair to forbidden) is a deliberate type-level commit, not
+   a substring of an error message.  Idempotent self-loops are
+   classified [Idempotent_no_op] (admitted by the mutator boundary
+   but not a Cascade_transition.t value). *)
+type cascade_transition_spec_violation =
+  | Idle_to_trying
+  | Idle_to_done
+  | Idle_to_exhausted
+  | Selecting_to_done
+  | Selecting_to_exhausted
+  | Done_to_exhausted
+  | Exhausted_to_done
+
+let cascade_transition_spec_violation_to_tag = function
+  | Idle_to_trying -> "idle->trying"
+  | Idle_to_done -> "idle->done"
+  | Idle_to_exhausted -> "idle->exhausted"
+  | Selecting_to_done -> "selecting->done"
+  | Selecting_to_exhausted -> "selecting->exhausted"
+  | Done_to_exhausted -> "done->exhausted"
+  | Exhausted_to_done -> "exhausted->done"
+;;
+
+(* RFC-0072 Phase 1: resolve a (from, target) packed pair to a typed
+   transition value.
+
+   - [Ok (Packed_transition t)] when the pair matches a Cascade_transition.t
+     constructor (13 valid cross-state pairs).
+   - [Ok Packed_transition Idle_to_selecting] etc do NOT cover idempotent
+     self-loops — those return [Error] with no spec violation (they are a
+     mutator-boundary concern, not a transition).  Callers that need
+     idempotent handling should check [from = target] before calling.
+   - [Error spec_violation] for the 7 forbidden cross-state pairs.
+
+   Self-loops are deliberately not in the GADT.  This function distinguishes
+   them via a separate [`Idempotent] return tag below to keep Result.t
+   semantically clean (Ok = transition value exists, Error = spec violation).
+
+   Phase 2 will use this to replace the [validate_cascade_transition] call
+   inside [set_turn_cascade_state]. *)
+type cascade_resolve_outcome =
+  | Resolved_transition of Cascade_transition.packed
+  | Resolved_idempotent
+  | Resolved_violation of cascade_transition_spec_violation
+
+let resolve_cascade_transition
+    ~(from : packed_cascade_state)
+    ~(target : packed_cascade_state)
+  : cascade_resolve_outcome
+  =
+  match from, target with
+  (* Idempotent self-loops (5). *)
+  | Packed Cascade_idle, Packed Cascade_idle
+  | Packed Cascade_selecting, Packed Cascade_selecting
+  | Packed Cascade_trying, Packed Cascade_trying
+  | Packed Cascade_done, Packed Cascade_done
+  | Packed Cascade_exhausted, Packed Cascade_exhausted ->
+    Resolved_idempotent
+  (* Valid cross-state transitions (13). *)
+  | Packed Cascade_idle, Packed Cascade_selecting ->
+    Resolved_transition (Cascade_transition.Packed_transition Idle_to_selecting)
+  | Packed Cascade_selecting, Packed Cascade_idle ->
+    Resolved_transition (Cascade_transition.Packed_transition Selecting_to_idle)
+  | Packed Cascade_selecting, Packed Cascade_trying ->
+    Resolved_transition (Cascade_transition.Packed_transition Selecting_to_trying)
+  | Packed Cascade_trying, Packed Cascade_idle ->
+    Resolved_transition (Cascade_transition.Packed_transition Trying_to_idle)
+  | Packed Cascade_trying, Packed Cascade_selecting ->
+    Resolved_transition (Cascade_transition.Packed_transition Trying_to_selecting)
+  | Packed Cascade_trying, Packed Cascade_done ->
+    Resolved_transition (Cascade_transition.Packed_transition Trying_to_done)
+  | Packed Cascade_trying, Packed Cascade_exhausted ->
+    Resolved_transition (Cascade_transition.Packed_transition Trying_to_exhausted)
+  | Packed Cascade_done, Packed Cascade_idle ->
+    Resolved_transition (Cascade_transition.Packed_transition Done_to_idle)
+  | Packed Cascade_done, Packed Cascade_selecting ->
+    Resolved_transition (Cascade_transition.Packed_transition Done_to_selecting)
+  | Packed Cascade_done, Packed Cascade_trying ->
+    Resolved_transition (Cascade_transition.Packed_transition Done_to_trying)
+  | Packed Cascade_exhausted, Packed Cascade_idle ->
+    Resolved_transition (Cascade_transition.Packed_transition Exhausted_to_idle)
+  | Packed Cascade_exhausted, Packed Cascade_selecting ->
+    Resolved_transition (Cascade_transition.Packed_transition Exhausted_to_selecting)
+  | Packed Cascade_exhausted, Packed Cascade_trying ->
+    Resolved_transition (Cascade_transition.Packed_transition Exhausted_to_trying)
+  (* Spec violations (7). *)
+  | Packed Cascade_idle, Packed Cascade_trying ->
+    Resolved_violation Idle_to_trying
+  | Packed Cascade_idle, Packed Cascade_done ->
+    Resolved_violation Idle_to_done
+  | Packed Cascade_idle, Packed Cascade_exhausted ->
+    Resolved_violation Idle_to_exhausted
+  | Packed Cascade_selecting, Packed Cascade_done ->
+    Resolved_violation Selecting_to_done
+  | Packed Cascade_selecting, Packed Cascade_exhausted ->
+    Resolved_violation Selecting_to_exhausted
+  | Packed Cascade_done, Packed Cascade_exhausted ->
+    Resolved_violation Done_to_exhausted
+  | Packed Cascade_exhausted, Packed Cascade_done ->
+    Resolved_violation Exhausted_to_done
+;;
+
 type compaction_stage =
   | Compaction_accumulating [@tla.idle]
   | Compaction_compacting [@tla.active]

--- a/lib/keeper/keeper_registry.mli
+++ b/lib/keeper/keeper_registry.mli
@@ -294,6 +294,64 @@ val packed_cascade_state_label : packed_cascade_state -> string
 
 val validate_cascade_transition : from:packed_cascade_state -> to_:packed_cascade_state -> unit
 
+(** RFC-0072 Phase 1: GADT-encoded cascade transitions.
+
+    Enumerates the 13 valid cross-state transitions of the 5-variant
+    [cascade_state] FSM.  The 7 forbidden pairs ([Idle -> Trying/Done/
+    Exhausted], [Selecting -> Done/Exhausted], [Done <-> Exhausted]) have
+    no constructor and are therefore type-unrepresentable.  Idempotent
+    self-loops are not represented (they are mutator-boundary no-ops). *)
+module Cascade_transition : sig
+  type ('from, 'to_) t =
+    | Idle_to_selecting : (cascade_idle, cascade_selecting) t
+    | Selecting_to_idle : (cascade_selecting, cascade_idle) t
+    | Selecting_to_trying : (cascade_selecting, cascade_trying) t
+    | Trying_to_idle : (cascade_trying, cascade_idle) t
+    | Trying_to_selecting : (cascade_trying, cascade_selecting) t
+    | Trying_to_done : (cascade_trying, cascade_done) t
+    | Trying_to_exhausted : (cascade_trying, cascade_exhausted) t
+    | Done_to_idle : (cascade_done, cascade_idle) t
+    | Done_to_selecting : (cascade_done, cascade_selecting) t
+    | Done_to_trying : (cascade_done, cascade_trying) t
+    | Exhausted_to_idle : (cascade_exhausted, cascade_idle) t
+    | Exhausted_to_selecting : (cascade_exhausted, cascade_selecting) t
+    | Exhausted_to_trying : (cascade_exhausted, cascade_trying) t
+
+  type packed = Packed_transition : ('a, 'b) t -> packed
+
+  val to_tag : ('a, 'b) t -> string
+end
+
+(** RFC-0072 Phase 1: typed error for cascade transition spec violations.
+    Each forbidden pair has its own constructor; replaces the prior
+    string-formatted [Invalid_argument] payload at the validator. *)
+type cascade_transition_spec_violation =
+  | Idle_to_trying
+  | Idle_to_done
+  | Idle_to_exhausted
+  | Selecting_to_done
+  | Selecting_to_exhausted
+  | Done_to_exhausted
+  | Exhausted_to_done
+
+val cascade_transition_spec_violation_to_tag
+  :  cascade_transition_spec_violation
+  -> string
+
+(** RFC-0072 Phase 1: resolve a (from, target) packed pair to one of
+    three outcomes: a typed transition value, an idempotent no-op, or a
+    typed spec violation.  Phase 2 will route [set_turn_cascade_state]
+    through this resolver. *)
+type cascade_resolve_outcome =
+  | Resolved_transition of Cascade_transition.packed
+  | Resolved_idempotent
+  | Resolved_violation of cascade_transition_spec_violation
+
+val resolve_cascade_transition
+  :  from:packed_cascade_state
+  -> target:packed_cascade_state
+  -> cascade_resolve_outcome
+
 type compaction_stage =
   | Compaction_accumulating [@tla.idle]
   | Compaction_compacting [@tla.active]


### PR DESCRIPTION
## What

RFC-0072 Phase 1 implementation: **additive** GADT module + typed spec violation + resolver function for cascade-state transitions. No existing caller is wired; no behavior change.

Builds on the precedent module `Decision_transition` (lib/keeper/keeper_registry.ml:368) which was previously unused and now serves as the reference template.

## Three new constructs (all in `lib/keeper/keeper_registry.{ml,mli}`)

### 1. `module Cascade_transition` (GADT)

13 valid cross-state transitions of the 5-variant `cascade_state` FSM:

```ocaml
module Cascade_transition : sig
  type ('from, 'to_) t =
    | Idle_to_selecting : (cascade_idle, cascade_selecting) t
    | Selecting_to_idle : (cascade_selecting, cascade_idle) t
    | Selecting_to_trying : (cascade_selecting, cascade_trying) t
    | Trying_to_idle : (cascade_trying, cascade_idle) t
    | Trying_to_selecting : (cascade_trying, cascade_selecting) t
    | Trying_to_done : (cascade_trying, cascade_done) t
    | Trying_to_exhausted : (cascade_trying, cascade_exhausted) t
    | Done_to_idle : (cascade_done, cascade_idle) t
    | Done_to_selecting : (cascade_done, cascade_selecting) t
    | Done_to_trying : (cascade_done, cascade_trying) t
    | Exhausted_to_idle : (cascade_exhausted, cascade_idle) t
    | Exhausted_to_selecting : (cascade_exhausted, cascade_selecting) t
    | Exhausted_to_trying : (cascade_exhausted, cascade_trying) t

  type packed = Packed_transition : ('a, 'b) t -> packed
  val to_tag : ('a, 'b) t -> string
end
```

The 7 forbidden pairs (`Idle -> Trying/Done/Exhausted`, `Selecting -> Done/Exhausted`, `Done <-> Exhausted`) have **no constructor** and are type-unrepresentable. Idempotent self-loops are not represented (mutator-boundary no-ops).

### 2. `cascade_transition_spec_violation` (typed sum)

```ocaml
type cascade_transition_spec_violation =
  | Idle_to_trying
  | Idle_to_done
  | Idle_to_exhausted
  | Selecting_to_done
  | Selecting_to_exhausted
  | Done_to_exhausted
  | Exhausted_to_done
```

One constructor per forbidden pair (7 cases). Replaces the prior string-formatted `Invalid_argument` message at `validate_cascade_transition` (Phase 2/3 will activate this). Future code paths can match exhaustively — adding a new forbidden pair or downgrading an admitted pair is a deliberate type-level commit.

### 3. `resolve_cascade_transition` (function)

```ocaml
type cascade_resolve_outcome =
  | Resolved_transition of Cascade_transition.packed
  | Resolved_idempotent
  | Resolved_violation of cascade_transition_spec_violation

val resolve_cascade_transition
  :  from:packed_cascade_state
  -> target:packed_cascade_state
  -> cascade_resolve_outcome
```

The 25-pair (5×5) match enumerates **all admitted variant combinations**: 5 idempotent + 13 valid + 7 violation. If `cascade_state` gains a 6th variant, this match (plus the 2 `to_tag` matches) fails compilation — forced classification.

## Tests

**Compile-time exhaustivity** per RFC-0072 §5.1 (Phase 1 acceptance). The 3 match expressions inside the new module collectively cover all variant combinations:

| Match | Arms | What it verifies |
|---|---|---|
| `Cascade_transition.to_tag` | 13 | All valid cross-state transitions have labels |
| `cascade_transition_spec_violation_to_tag` | 7 | All forbidden pairs have labels |
| `resolve_cascade_transition` | 25 | Complete (from, target) coverage |

No runtime tests added in this PR. Phase 2 (when callers are wired) will exercise the resolver against `set_turn_cascade_state` semantics.

## LOC honesty

| File | + | - | Net |
|---|---|---|---|
| `lib/keeper/keeper_registry.ml` | 167 | 0 | +167 |
| `lib/keeper/keeper_registry.mli` | 58 | 0 | +58 |
| **Total** | **225** | **0** | **+225** |

**RFC-0072 §5.1 estimated ~80 LOC for Phase 1**; actual is 225. The higher count comes from enumerating spec_violation constructors (7) and the full 25-arm resolver (RFC mentioned only the GADT module). Both spec-essential and mechanical. No deletions, no logic change to existing code.

If reviewer prefers splitting into:
- **Phase 1a**: `Cascade_transition` GADT module only (~70 LOC impl + 25 LOC mli)
- **Phase 1b**: `cascade_transition_spec_violation` + `resolve_cascade_transition` (~95 LOC impl + 30 LOC mli)

happy to extract. The combined PR keeps the 3 constructs together because:
1. `spec_violation` has no purpose without `resolve_cascade_transition`
2. `resolve_cascade_transition` has no purpose without the `Cascade_transition` GADT
3. None of the 3 are called yet — all dead code until Phase 2

## Next phases (per RFC-0072 §5)

- **Phase 2**: `set_turn_cascade_state` internal dispatch via `resolve_cascade_transition` (~50 LOC, medium risk)
- **Phase 3**: `validate_cascade_transition` → compile-time fixture (~70 LOC, mirrors PR #14893)
- **Phase 4**: `Turn_phase_transition` GADT (parallel structure for turn_phase axis)

## Self-check (Workaround Rejection Bar)

| # | Check | Result |
|---|---|---|
| 1 | telemetry-as-fix? | no — type-level invariant, not a counter |
| 2 | string classifier? | no — typed GADT + typed violation sum |
| 3 | N-of-M? | no — Phase 1 of multi-phase RFC, each phase self-contained; sites 1234/1335 are different axes (separate phases per RFC) |
| 4 | catch-all added? | no — all 3 matches exhaustive, no `_ ->` arms |
| 5 | cap/cooldown/dedup? | no |
| 6 | test backdoor? | no — compile-time exhaustivity IS the test |
| 7 | typo N sites? | no |

## References

- **RFC-0072** (`docs/rfc/RFC-0072-keeper-sub-fsm-transitions-typed.md`) — design SSOT for this PR series.
- **PR #14887**: decision-axis input refinement precedent.
- **PR #14893**: decision-axis validator → compile-time fixture precedent.
- **`Decision_transition` GADT** (`keeper_registry.ml:368`) — template pattern this PR mirrors for cascade.
- **CLAUDE.md `software-development.md` §AI 코드 생성 안티패턴 §4**: FSM Sparse Match anti-pattern.
- **Alexis King "Parse, don't validate"**: make illegal states unrepresentable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
