### PR TITLE
feat(cascade): RFC-0058 Phase 5.2b — liveness caller migration + validator R13

### DIFF
--- a/lib/cascade/cascade_attempt_liveness_config.ml
+++ b/lib/cascade/cascade_attempt_liveness_config.ml
@@ -1,9 +1,10 @@
 (* See cascade_attempt_liveness_config.mli for documentation.
 
-   RFC-0022 PR-2/4 §2 — tri-state env flag + per-label budget map.
-   RFC-0058 Phase 5.2b — provider→budget routing reads
-   [Cascade_declarative_types.cascade_provider.liveness_class] declared
-   in [config/cascade.toml]. The hardcoded
+   RFC-0022 PR-2/4 §2 — tri-state env flag + per-liveness-class budget map.
+   RFC-0058 Phase 5.2b — provider→budget routing now reads each provider's
+   [Cascade_declarative_types.cascade_provider.liveness_class] declared in
+   [config/cascade.toml] (the budget itself is still keyed by liveness
+   class via [budget_of_class]); the prior hardcoded
    [match provider_id with "codex_cli" | "claude_code" | …] block is
    deleted (RFC-0058 §4 Phase 5.2b acceptance). *)
 

--- a/lib/cascade/cascade_attempt_liveness_config.ml
+++ b/lib/cascade/cascade_attempt_liveness_config.ml
@@ -1,6 +1,11 @@
 (* See cascade_attempt_liveness_config.mli for documentation.
 
-   RFC-0022 PR-2/4 §2 — tri-state env flag + per-label budget map. *)
+   RFC-0022 PR-2/4 §2 — tri-state env flag + per-label budget map.
+   RFC-0058 Phase 5.2b — provider→budget routing reads
+   [Cascade_declarative_types.cascade_provider.liveness_class] declared
+   in [config/cascade.toml]. The hardcoded
+   [match provider_id with "codex_cli" | "claude_code" | …] block is
+   deleted (RFC-0058 §4 Phase 5.2b acceptance). *)
 
 type mode =
   | Off
@@ -11,6 +16,7 @@ let mode_label = function
   | Off -> "off"
   | Observe -> "observe"
   | Enforce -> "enforce"
+;;
 
 let env_var_name = "MASC_CASCADE_ATTEMPT_LIVENESS"
 
@@ -20,6 +26,7 @@ let parse_mode raw =
   | "enforce" | "kill" | "on_kill" -> Enforce
   | "" | "observe" | "default" | "1" | "true" | "shadow" -> Observe
   | _ -> Observe (* unknown values default to Observe — never silently Off *)
+;;
 
 (* Cached after first read. Mirrors Keeper_admission_glue.use_new_admission. *)
 let mode_cache : mode option ref = ref None
@@ -28,51 +35,113 @@ let current_mode () =
   match !mode_cache with
   | Some m -> m
   | None ->
-      let m =
-        match Sys.getenv_opt env_var_name with
-        | None -> Enforce
-        | Some raw -> parse_mode raw
-      in
-      mode_cache := Some m;
-      m
+    let m =
+      match Sys.getenv_opt env_var_name with
+      | None -> Enforce
+      | Some raw -> parse_mode raw
+    in
+    mode_cache := Some m;
+    m
+;;
 
-let reset_cache_for_test () = mode_cache := None
+(* RFC-0058 Phase 5.2b — lazy declarative-config cache.
 
-(* Per-label budget catalog — RFC-0022 PR-2 §2.
+   The active cascade_config is read once from
+   [Config_dir_resolver.cascade_path_candidate], cached, and reused for
+   every subsequent provider→budget lookup. A failed parse (missing
+   file, pre-5-layer schema, invalid TOML) caches as [None] — callers
+   fall back to [cloud_fast], the same conservative default the
+   deleted hardcoded match used for unknown ids. *)
+let cfg_cache : Cascade_declarative_types.cascade_config option ref = ref None
+let cfg_loaded : bool ref = ref false
 
-   Cloud streaming providers (codex_cli, claude_code, gemini_cli) use
-   [cloud_fast] as a TTFT-strict budget that matches their typical short
-   answer latency. Adaptive-reasoning models (glm-coding which streams
-   thinking deltas, kimi-for-coding) get [cloud_thinking].
+let load_active_cfg () : Cascade_declarative_types.cascade_config option =
+  if !cfg_loaded
+  then !cfg_cache
+  else (
+    let path = Config_dir_resolver.cascade_path_candidate () in
+    let parsed =
+      match Cascade_declarative_parser.parse_file path with
+      | Error _ -> None
+      | Ok cfg -> Some cfg
+    in
+    cfg_cache := parsed;
+    cfg_loaded := true;
+    parsed)
+;;
 
-   Local providers stay on the larger [local_27b] / [local_70b_plus]
-   budgets to avoid killing slow local models. *)
+let reset_cache_for_test () =
+  mode_cache := None;
+  cfg_cache := None;
+  cfg_loaded := false
+;;
 
-let budget_for_provider_id ~(provider_id : string) :
-    Cascade_attempt_liveness.budget =
+let budget_of_class
+  : Cascade_declarative_types.cascade_liveness_class -> Cascade_attempt_liveness.budget
+  = function
+  | Cloud_fast -> Cascade_attempt_liveness.cloud_fast
+  | Cloud_thinking -> Cascade_attempt_liveness.cloud_thinking
+  | Local_27b -> Cascade_attempt_liveness.local_27b
+  | Local_70b_plus -> Cascade_attempt_liveness.local_70b_plus
+;;
+
+let liveness_class_for_provider_id
+      ~(cfg : Cascade_declarative_types.cascade_config option)
+      ~(provider_id : string)
+  : Cascade_declarative_types.cascade_liveness_class option
+  =
   let canon = String.lowercase_ascii (String.trim provider_id) in
-  match canon with
-  | "codex_cli" | "claude_code" | "claude" | "gemini_cli" | "gemini" ->
-      Cascade_attempt_liveness.cloud_fast
-  | "glm-coding" | "glm_coding" | "glm" | "kimi_cli" | "kimi-for-coding"
-  | "kimi" ->
-      Cascade_attempt_liveness.cloud_thinking
-  | "ollama_only" | "llama-server" | "llama_server" ->
-      Cascade_attempt_liveness.local_27b
-  | "local_70b" | "local_70b_plus" | "ollama_70b" ->
-      Cascade_attempt_liveness.local_70b_plus
-  | _ -> Cascade_attempt_liveness.cloud_fast
+  let active_cfg =
+    match cfg with
+    | Some _ as explicit -> explicit
+    | None -> load_active_cfg ()
+  in
+  match active_cfg with
+  | None -> None
+  | Some c ->
+    (* Try exact match first; fall back to case-folded scan so a
+         caller passing an upper-cased provider_id still resolves
+         against the lower-cased TOML keys. *)
+    (match Cascade_declarative_types.provider_of_id c provider_id with
+     | Some p -> p.liveness_class
+     | None ->
+       let normalized =
+         List.find_opt
+           (fun (p : Cascade_declarative_types.cascade_provider) ->
+              String.lowercase_ascii p.id = canon)
+           c.providers
+       in
+       Option.bind normalized (fun p -> p.liveness_class))
+;;
+
+let budget_for_provider_id
+      ?(cfg : Cascade_declarative_types.cascade_config option)
+      ~(provider_id : string)
+      ()
+  : Cascade_attempt_liveness.budget
+  =
+  match liveness_class_for_provider_id ~cfg ~provider_id with
+  | Some c -> budget_of_class c
+  | None ->
+    (* RFC-0058 Phase 5.2b: cascade.toml is the SSOT. An unknown
+         provider_id (not declared, or the cascade config failed to
+         parse) falls back to [cloud_fast] — the conservative default
+         the deleted hardcoded match used. The validator R-rule for
+         [liveness.class] (Phase 5.2b) ensures every shipped provider
+         in [config/cascade.toml] declares its class, so this fallback
+         only fires for ad-hoc / custom integrations, not for the
+         in-tree provider set. *)
+    Cascade_attempt_liveness.cloud_fast
+;;
 
 (* RFC-0022 §1 — see .mli for contract. *)
-let outer_wall_for_attempt
-    ~mode ~observer_attached ~per_provider_timeout_s ~provider_id =
+let outer_wall_for_attempt ~mode ~observer_attached ~per_provider_timeout_s ~provider_id =
   match mode, observer_attached with
   | Enforce, true -> None
   | _, true ->
-      let budget_wall =
-        (budget_for_provider_id ~provider_id).Cascade_attempt_liveness.attempt_wall_max
-      in
-      Option.map
-        (fun t -> Float.max t budget_wall)
-        per_provider_timeout_s
+    let budget_wall =
+      (budget_for_provider_id ~provider_id ()).Cascade_attempt_liveness.attempt_wall_max
+    in
+    Option.map (fun t -> Float.max t budget_wall) per_provider_timeout_s
   | _, false -> per_provider_timeout_s
+;;

--- a/lib/cascade/cascade_attempt_liveness_config.ml
+++ b/lib/cascade/cascade_attempt_liveness_config.ml
@@ -37,7 +37,10 @@ let current_mode () =
   | None ->
     let m =
       match Sys.getenv_opt env_var_name with
-      | None -> Enforce
+      (* Truly-unset env var → [Observe], matching the .mli contract and
+         [parse_mode ""]. The module's stance is "default to Observe,
+         never silently Off, only Enforce when explicitly requested". *)
+      | None -> Observe
       | Some raw -> parse_mode raw
     in
     mode_cache := Some m;
@@ -46,34 +49,34 @@ let current_mode () =
 
 (* RFC-0058 Phase 5.2b — lazy declarative-config cache.
 
-   The active cascade_config is read once from
-   [Config_dir_resolver.cascade_path_candidate], cached, and reused for
-   every subsequent provider→budget lookup. A failed parse (missing
-   file, pre-5-layer schema, invalid TOML) caches as [None] — callers
-   fall back to [cloud_fast], the same conservative default the
-   deleted hardcoded match used for unknown ids. *)
+   A *successful* parse of [Config_dir_resolver.cascade_path_candidate]
+   is cached and reused for every subsequent provider→budget lookup. A
+   *failed* parse (missing file during a boot race, transient permission
+   error, half-written TOML mid-deploy, pre-5-layer schema) is NOT
+   cached — the next call re-attempts so a recovered config takes effect
+   without a restart. Until a parse succeeds, [budget_for_provider_id]
+   falls back to [cloud_fast] (the conservative default the deleted
+   hardcoded match used for unknown ids). Cost of the no-cache-on-error
+   policy: one TOML parse per [budget_for_provider_id] call during an
+   outage window — acceptable, as these calls are per-attempt (not
+   per-token) and most callers thread an explicit [?cfg] anyway. *)
 let cfg_cache : Cascade_declarative_types.cascade_config option ref = ref None
-let cfg_loaded : bool ref = ref false
 
 let load_active_cfg () : Cascade_declarative_types.cascade_config option =
-  if !cfg_loaded
-  then !cfg_cache
-  else (
+  match !cfg_cache with
+  | Some _ as cached -> cached
+  | None ->
     let path = Config_dir_resolver.cascade_path_candidate () in
-    let parsed =
-      match Cascade_declarative_parser.parse_file path with
-      | Error _ -> None
-      | Ok cfg -> Some cfg
-    in
-    cfg_cache := parsed;
-    cfg_loaded := true;
-    parsed)
+    (match Cascade_declarative_parser.parse_file path with
+     | Ok cfg ->
+       cfg_cache := Some cfg;
+       Some cfg
+     | Error _ -> None)
 ;;
 
 let reset_cache_for_test () =
   mode_cache := None;
-  cfg_cache := None;
-  cfg_loaded := false
+  cfg_cache := None
 ;;
 
 let budget_of_class

--- a/lib/cascade/cascade_attempt_liveness_config.mli
+++ b/lib/cascade/cascade_attempt_liveness_config.mli
@@ -18,7 +18,11 @@
 
     [budget_for_provider_id] resolves the per-provider liveness budget
     by reading [\[providers.<id>.liveness\] class] from
-    [config/cascade.toml]. The cascade config is parsed once and cached.
+    [config/cascade.toml]. A *successful* parse is cached; a *failed*
+    parse is not cached and is re-attempted on the next call, so a
+    config that becomes available (or is repaired) after boot takes
+    effect without a restart. Until a parse succeeds the fallback is
+    [cloud_fast].
 
     Phase 5.2b deleted the hardcoded
     [match provider_id with "codex_cli" | "claude_code" | …] block that

--- a/lib/cascade/cascade_attempt_liveness_config.mli
+++ b/lib/cascade/cascade_attempt_liveness_config.mli
@@ -1,5 +1,5 @@
-(** Tri-state env flag + per-label budget lookup for the cascade
-    attempt-liveness gate (RFC-0022 PR-2/4 §2).
+(** Tri-state env flag + per-provider budget lookup for the cascade
+    attempt-liveness gate (RFC-0022 PR-2/4 §2 + RFC-0058 Phase 5.2b).
 
     The flag [MASC_CASCADE_ATTEMPT_LIVENESS] selects one of three modes:
 
@@ -14,6 +14,18 @@
     [Keeper_admission_glue.use_new_admission]) so that mid-attempt env
     edits do not split-brain the observer.
 
+    {2 RFC-0058 Phase 5.2b}
+
+    [budget_for_provider_id] resolves the per-provider liveness budget
+    by reading [\[providers.<id>.liveness\] class] from
+    [config/cascade.toml]. The cascade config is parsed once and cached.
+
+    Phase 5.2b deleted the hardcoded
+    [match provider_id with "codex_cli" | "claude_code" | …] block that
+    previously routed cascade prefixes to liveness classes. The
+    cascade-config SSOT (RFC-0058 §2.4) is now the only source for the
+    provider → class mapping.
+
     @stability Evolving
     @since 0.190.0 *)
 
@@ -22,42 +34,50 @@ type mode =
   | Observe
   | Enforce
 
-val current_mode : unit -> mode
 (** Cached env-flag read. First call reads
     [MASC_CASCADE_ATTEMPT_LIVENESS] and caches the result. Subsequent
     calls return the cached value. Default when unset / unparseable is
     {!Observe}. *)
+val current_mode : unit -> mode
 
-val mode_label : mode -> string
 (** Stable label for telemetry / Prometheus counter values. One of
     [off | observe | enforce]. *)
+val mode_label : mode -> string
 
-val budget_for_provider_id :
-  provider_id:string -> Cascade_attempt_liveness.budget
 (** Map a cascade [provider_id] (e.g. [codex_cli], [claude_code],
-    [gemini_cli], [glm-coding], [ollama_only], [llama-server]) to a
-    per-profile budget.
+    [gemini_cli], [glm-coding], [ollama]) to a per-class budget.
 
     The argument is the {b provider} dispatch key — not a model id.
     Callers should pass the value from
     [Provider_adapter.provider_label_of_config provider_cfg] or an
     equivalent provider-level identifier.
 
-    Unknown provider ids fall back to
-    {!Cascade_attempt_liveness.cloud_fast} which is the conservative
-    cloud-streaming default. *)
+    [?cfg] override (test-only): bypass the cached active cascade
+    config and resolve against an explicit one. Production callers
+    omit [?cfg] and rely on the cached load from
+    [Config_dir_resolver.cascade_path_candidate]. The trailing [()]
+    is required so OCaml can erase the optional argument
+    (warning 16 — see RFC-0058 Phase 5.2b).
 
-val reset_cache_for_test : unit -> unit
-(** Test-only: reset the cached flag read so a new value of
-    [MASC_CASCADE_ATTEMPT_LIVENESS] takes effect. Production callers
-    must not invoke this. *)
-
-val outer_wall_for_attempt
-  :  mode:mode
-  -> observer_attached:bool
-  -> per_provider_timeout_s:float option
+    Unknown provider ids — id not declared in cascade.toml, or
+    cascade.toml failed to parse — fall back to
+    {!Cascade_attempt_liveness.cloud_fast}, matching the conservative
+    default the deleted hardcoded match used. The validator R-rule for
+    [liveness.class] (Phase 5.2b) ensures every shipped provider
+    declares its class, so this fallback only fires for ad-hoc / custom
+    integrations. *)
+val budget_for_provider_id
+  :  ?cfg:Cascade_declarative_types.cascade_config
   -> provider_id:string
-  -> float option
+  -> unit
+  -> Cascade_attempt_liveness.budget
+
+(** Test-only: reset the cached env-flag and declarative-config caches
+    so the next call re-reads [MASC_CASCADE_ATTEMPT_LIVENESS] and
+    re-parses [config/cascade.toml]. Production callers must not
+    invoke this. *)
+val reset_cache_for_test : unit -> unit
+
 (** RFC-0022 §1 — backstop wall for the legacy [per_provider_timeout_s]
     knob.
 
@@ -70,7 +90,7 @@ val outer_wall_for_attempt
       attempt wall budget breach. The legacy outer wall must not
       pre-empt it.
     - [Off] / [Observe] + observer attached: returns
-      [Some (max t (budget_for_provider_id ~provider_id).attempt_wall_max)]
+      [Some (max t (budget_for_provider_id ~provider_id ()).attempt_wall_max)]
       when [per_provider_timeout_s = Some t]. Slow-but-legitimate
       streams (local Ollama 27B / 70B+) get the profile's attempt wall
       so the legacy 120s knob cannot prematurely fall back the cascade.
@@ -81,3 +101,9 @@ val outer_wall_for_attempt
       returns [None] (no outer wall).
 
     @since 0.20.0 *)
+val outer_wall_for_attempt
+  :  mode:mode
+  -> observer_attached:bool
+  -> per_provider_timeout_s:float option
+  -> provider_id:string
+  -> float option

--- a/lib/cascade_decl/cascade_declarative_validator.ml
+++ b/lib/cascade_decl/cascade_declarative_validator.ml
@@ -12,7 +12,8 @@
     R9: At most one is-default=true per provider
     R10: Strategy-specific fields match the declared strategy
     R11: Binding max-concurrent required and positive (RFC-0058 §3.4)
-    R12: Protocol ↔ transport consistency (RFC-0058 §2.1) *)
+    R12: Protocol ↔ transport consistency (RFC-0058 §2.1)
+    R13: Every provider declares liveness.class (RFC-0058 §4 Phase 5.2b) *)
 
 open Cascade_declarative_types
 
@@ -69,6 +70,7 @@ let name_set (names : string list) : (string, unit) Hashtbl.t =
   let tbl = Hashtbl.create (List.length names) in
   List.iter (fun name -> Hashtbl.replace tbl name ()) names;
   tbl
+;;
 
 let err (rule : string) (path : string) (message : string) : validation_error list =
   [ { rule; path; message } ]
@@ -203,9 +205,7 @@ let validate_tier_group_refs (cfg : cascade_config) : validation_error list =
 
 let validate_route_targets (cfg : cascade_config) : validation_error list =
   let all_targets_set =
-    name_set
-      (tier_group_names cfg @ tier_names cfg
-      @ binding_keys cfg @ alias_keys cfg)
+    name_set (tier_group_names cfg @ tier_names cfg @ binding_keys cfg @ alias_keys cfg)
   in
   List.filter_map
     (fun (r : cascade_route) ->
@@ -331,11 +331,13 @@ let validate_protocol_transport (cfg : cascade_config) : validation_error list =
     (fun (p : cascade_provider) ->
        let path = Printf.sprintf "providers.%s.protocol" p.id in
        let expected_transport =
-         if String.length p.protocol >= 4
-            && String.sub p.protocol (String.length p.protocol - 4) 4 = "-cli"
+         if
+           String.length p.protocol >= 4
+           && String.sub p.protocol (String.length p.protocol - 4) 4 = "-cli"
          then Some "Cli"
-         else if String.length p.protocol >= 5
-                 && String.sub p.protocol (String.length p.protocol - 5) 5 = "-http"
+         else if
+           String.length p.protocol >= 5
+           && String.sub p.protocol (String.length p.protocol - 5) 5 = "-http"
          then Some "Http"
          else None
        in
@@ -363,6 +365,38 @@ let validate_protocol_transport (cfg : cascade_config) : validation_error list =
                     "protocol %S implies Cli transport, but transport is Http"
                     p.protocol
               }))
+    cfg.providers
+;;
+
+(* --- R13: Every provider declares [liveness.class] (RFC-0058 Phase 5.2b)
+
+   The parser tolerates a missing [\[providers.<id>.liveness\] class]
+   sub-table for backward compatibility (Phase 5.2a, schema-only). The
+   caller-cutover in Phase 5.2b makes
+   [Cascade_attempt_liveness_config.budget_for_provider_id] read the
+   class via [Cascade_declarative_types.provider_of_id]; an absent
+   class silently falls back to [cloud_fast].
+
+   Promoting the missing-class tolerance into a validator R-rule is the
+   only thing that prevents a future provider entry from regressing to
+   that silent fallback (RFC-0058 §4 Phase 5.2b "validator R-rule"). *)
+
+let validate_provider_liveness_class (cfg : cascade_config) : validation_error list =
+  List.filter_map
+    (fun (p : cascade_provider) ->
+       match p.liveness_class with
+       | Some _ -> None
+       | None ->
+         Some
+           { rule = "R13"
+           ; path = Printf.sprintf "providers.%s.liveness.class" p.id
+           ; message =
+               "every shipped provider must declare a `liveness.class` (one of \
+                `cloud_fast`, `cloud_thinking`, `local_27b`, `local_70b_plus`); RFC-0058 \
+                Phase 5.2b promotes the parser's missing-class tolerance to a validator \
+                rule so the `budget_for_provider_id` cloud_fast fallback only fires for \
+                ad-hoc integrations, not for `config/cascade.toml` entries"
+           })
     cfg.providers
 ;;
 
@@ -397,4 +431,5 @@ let validate (cfg : cascade_config) : validation_error list =
   @ validate_strategy_fields cfg
   @ validate_binding_capacity cfg
   @ validate_protocol_transport cfg
+  @ validate_provider_liveness_class cfg
 ;;

--- a/lib/cascade_decl/cascade_declarative_validator.mli
+++ b/lib/cascade_decl/cascade_declarative_validator.mli
@@ -1,11 +1,14 @@
 (** Declarative cascade config cross-reference validator (RFC-0058 v2).
 
-    [validate] checks all 12 load-time invariants (R1–R12) on a parsed
+    [validate] checks all 13 load-time invariants (R1–R13) on a parsed
     [cascade_config] and returns every error found rather than stopping
     at the first. R11 (binding max-concurrent required & positive,
     RFC-0058 §3.4) is enforced unconditionally. R12 (protocol ↔ transport
     consistency, RFC-0058 §2.1) checks that protocol suffixes like "-cli"
-    and "-http" match the declared transport type. *)
+    and "-http" match the declared transport type. R13 (every provider
+    declares [liveness.class], RFC-0058 §4 Phase 5.2b) is the structural
+    counterpart to deleting the hardcoded vendor match in
+    [Cascade_attempt_liveness_config]. *)
 
 type validation_error =
   { rule : string

--- a/lib/keeper/keeper_turn_driver_try_provider.ml
+++ b/lib/keeper/keeper_turn_driver_try_provider.ml
@@ -187,7 +187,7 @@ let run_try_provider
       | Cascade_attempt_liveness_config.Observe | Cascade_attempt_liveness_config.Enforce
         ->
         let budget =
-          Cascade_attempt_liveness_config.budget_for_provider_id ~provider_id
+          Cascade_attempt_liveness_config.budget_for_provider_id ~provider_id ()
         in
         let obs =
           Cascade_attempt_liveness_observer.create

--- a/test/test_cascade_attempt_liveness_config.ml
+++ b/test/test_cascade_attempt_liveness_config.ml
@@ -1,11 +1,14 @@
-(** Tests for [Cascade_attempt_liveness_config] (RFC-0022 PR-2/4 §2).
+(** Tests for [Cascade_attempt_liveness_config] (RFC-0022 PR-2/4 §2 +
+    RFC-0058 Phase 5.2b).
 
     Covers: env-flag parsing (default Observe, all aliases),
-    cache invalidation via reset_cache_for_test, label→budget mapping. *)
+    cache invalidation via reset_cache_for_test, and the cascade-config-
+    driven [budget_for_provider_id] lookup (Phase 5.2b). *)
 
 open Masc_mcp
 module Cfg = Cascade_attempt_liveness_config
 module L = Cascade_attempt_liveness
+module Decl = Cascade_declarative_types
 
 let env_var = "MASC_CASCADE_ATTEMPT_LIVENESS"
 
@@ -22,13 +25,19 @@ let with_env value f =
     Cfg.reset_cache_for_test ()
   in
   match f () with
-  | x -> restore (); x
-  | exception e -> restore (); raise e
+  | x ->
+    restore ();
+    x
+  | exception e ->
+    restore ();
+    raise e
+;;
 
 let mode_label = Cfg.mode_label
 
 let check_mode label expected actual =
   Alcotest.(check string) label (mode_label expected) (mode_label actual)
+;;
 
 (* -- mode parsing --------------------------------------------------- *)
 
@@ -36,146 +45,238 @@ let test_default_unset () =
   let prior = Sys.getenv_opt env_var in
   Unix.putenv env_var "";
   Cfg.reset_cache_for_test ();
-  (* Empty string parses as Observe by parse_mode contract. *)
   let m = Cfg.current_mode () in
   (match prior with
    | None -> Unix.putenv env_var ""
    | Some v -> Unix.putenv env_var v);
   Cfg.reset_cache_for_test ();
   check_mode "empty string -> Observe" Observe m
+;;
 
 let test_observe_alias () =
-  with_env (Some "observe") (fun () ->
-      check_mode "observe" Observe (Cfg.current_mode ()))
+  with_env (Some "observe") (fun () -> check_mode "observe" Observe (Cfg.current_mode ()))
+;;
 
 let test_off_alias () =
-  with_env (Some "off") (fun () ->
-      check_mode "off" Off (Cfg.current_mode ()))
+  with_env (Some "off") (fun () -> check_mode "off" Off (Cfg.current_mode ()))
+;;
 
 let test_off_zero () =
-  with_env (Some "0") (fun () ->
-      check_mode "0 -> Off" Off (Cfg.current_mode ()))
+  with_env (Some "0") (fun () -> check_mode "0 -> Off" Off (Cfg.current_mode ()))
+;;
 
 let test_enforce_alias () =
-  with_env (Some "enforce") (fun () ->
-      check_mode "enforce" Enforce (Cfg.current_mode ()))
+  with_env (Some "enforce") (fun () -> check_mode "enforce" Enforce (Cfg.current_mode ()))
+;;
 
 let test_enforce_kill () =
   with_env (Some "kill") (fun () ->
-      check_mode "kill -> Enforce" Enforce (Cfg.current_mode ()))
+    check_mode "kill -> Enforce" Enforce (Cfg.current_mode ()))
+;;
 
 let test_unknown_defaults_observe () =
-  with_env (Some "garbage") (fun () ->
-      check_mode "garbage -> Observe" Observe (Cfg.current_mode ()))
+  with_env (Some "bogus") (fun () ->
+    check_mode "unknown -> Observe" Observe (Cfg.current_mode ()))
+;;
 
 let test_case_insensitive () =
-  with_env (Some "OFF") (fun () ->
-      check_mode "OFF -> Off" Off (Cfg.current_mode ()))
+  with_env (Some "OBSERVE") (fun () ->
+    check_mode "OBSERVE upper -> Observe" Observe (Cfg.current_mode ()))
+;;
 
-(* -- cache contract ------------------------------------------------- *)
+(* -- cache --------------------------------------------------------- *)
 
 let test_cache_first_read () =
   with_env (Some "off") (fun () ->
-      let m1 = Cfg.current_mode () in
-      (* Mutate env after first read; cached value should persist. *)
-      Unix.putenv env_var "enforce";
-      let m2 = Cfg.current_mode () in
-      check_mode "first read" Off m1;
-      check_mode "cached, ignores mutation" Off m2)
+    let m1 = Cfg.current_mode () in
+    Unix.putenv env_var "enforce";
+    let m2 = Cfg.current_mode () in
+    check_mode "cached Off" Off m1;
+    check_mode "still Off after env change without reset" Off m2)
+;;
 
 let test_reset_cache () =
   with_env (Some "off") (fun () ->
-      let _ = Cfg.current_mode () in
-      Unix.putenv env_var "enforce";
-      Cfg.reset_cache_for_test ();
-      check_mode "after reset, sees enforce" Enforce (Cfg.current_mode ()))
-
-(* -- mode_label round-trip ----------------------------------------- *)
+    let m1 = Cfg.current_mode () in
+    Unix.putenv env_var "enforce";
+    Cfg.reset_cache_for_test ();
+    let m2 = Cfg.current_mode () in
+    check_mode "first read Off" Off m1;
+    check_mode "after reset Enforce" Enforce m2)
+;;
 
 let test_mode_labels () =
   Alcotest.(check string) "off" "off" (mode_label Off);
   Alcotest.(check string) "observe" "observe" (mode_label Observe);
   Alcotest.(check string) "enforce" "enforce" (mode_label Enforce)
+;;
 
-(* -- budget_for_provider_id ---------------------------------------- *)
+(* -- budget_for_provider_id (Phase 5.2b — cascade-config-driven) --- *)
 
 let budget_eq (a : L.budget) (b : L.budget) =
   Float.equal a.ttft_max b.ttft_max
   && Float.equal a.inter_chunk_max b.inter_chunk_max
   && Float.equal a.attempt_wall_max b.attempt_wall_max
+;;
 
 let check_budget label expected actual =
   Alcotest.(check bool) label true (budget_eq expected actual)
+;;
 
-let test_budget_codex_cli () =
-  check_budget "codex_cli -> cloud_fast" L.cloud_fast
-    (Cfg.budget_for_provider_id ~provider_id:"codex_cli")
+(* Test helpers — synthesize a minimal cascade_config so the lookup
+   path can be exercised without touching disk. *)
+let make_provider ~id ~liveness_class : Decl.cascade_provider =
+  { id
+  ; display_name = id
+  ; protocol = "anthropic-cli"
+  ; api_format = Decl.Messages_api
+  ; transport = Decl.Cli "test"
+  ; is_non_interactive = true
+  ; credentials = None
+  ; liveness_class
+  ; capabilities = None
+  ; headers = None
+  }
+;;
 
-let test_budget_claude_code () =
-  check_budget "claude_code -> cloud_fast" L.cloud_fast
-    (Cfg.budget_for_provider_id ~provider_id:"claude_code")
+let make_cfg (providers : Decl.cascade_provider list) : Decl.cascade_config =
+  { providers
+  ; models = []
+  ; bindings = []
+  ; aliases = []
+  ; tiers = []
+  ; tier_groups = []
+  ; routes = []
+  ; system_targets = []
+  }
+;;
 
-let test_budget_glm_coding () =
-  check_budget "glm-coding -> cloud_thinking" L.cloud_thinking
-    (Cfg.budget_for_provider_id ~provider_id:"glm-coding")
+(* The five in-tree provider classes from config/cascade.toml live here
+   as canonical fixtures; each row exercises one [liveness_class]. *)
+let fixture_cfg =
+  make_cfg
+    [ make_provider ~id:"codex_cli" ~liveness_class:(Some Cloud_fast)
+    ; make_provider ~id:"claude_code" ~liveness_class:(Some Cloud_fast)
+    ; make_provider ~id:"gemini_cli" ~liveness_class:(Some Cloud_fast)
+    ; make_provider ~id:"kimi_cli" ~liveness_class:(Some Cloud_thinking)
+    ; make_provider ~id:"glm-coding" ~liveness_class:(Some Cloud_thinking)
+    ; make_provider ~id:"ollama" ~liveness_class:(Some Local_27b)
+    ; make_provider ~id:"big-local" ~liveness_class:(Some Local_70b_plus)
+    ; make_provider ~id:"no-class" ~liveness_class:None
+    ]
+;;
 
-let test_budget_kimi () =
-  check_budget "kimi-for-coding -> cloud_thinking" L.cloud_thinking
-    (Cfg.budget_for_provider_id ~provider_id:"kimi-for-coding")
+let budget_of cfg pid = Cfg.budget_for_provider_id ~cfg ~provider_id:pid ()
 
-let test_budget_local () =
-  check_budget "ollama_only -> local_27b" L.local_27b
-    (Cfg.budget_for_provider_id ~provider_id:"ollama_only");
-  check_budget "llama-server -> local_27b" L.local_27b
-    (Cfg.budget_for_provider_id ~provider_id:"llama-server")
+let test_budget_cloud_fast () =
+  check_budget "codex_cli -> cloud_fast" L.cloud_fast (budget_of fixture_cfg "codex_cli");
+  check_budget
+    "claude_code -> cloud_fast"
+    L.cloud_fast
+    (budget_of fixture_cfg "claude_code");
+  check_budget
+    "gemini_cli -> cloud_fast"
+    L.cloud_fast
+    (budget_of fixture_cfg "gemini_cli")
+;;
 
-let test_budget_local_70b () =
-  check_budget "local_70b_plus -> local_70b_plus" L.local_70b_plus
-    (Cfg.budget_for_provider_id ~provider_id:"local_70b_plus")
+let test_budget_cloud_thinking () =
+  check_budget
+    "kimi_cli -> cloud_thinking"
+    L.cloud_thinking
+    (budget_of fixture_cfg "kimi_cli");
+  check_budget
+    "glm-coding -> cloud_thinking"
+    L.cloud_thinking
+    (budget_of fixture_cfg "glm-coding")
+;;
 
-let test_budget_unknown_default () =
-  check_budget "unknown -> cloud_fast" L.cloud_fast
-    (Cfg.budget_for_provider_id ~provider_id:"weird_provider_xyz")
+let test_budget_local_27b () =
+  check_budget "ollama -> local_27b" L.local_27b (budget_of fixture_cfg "ollama")
+;;
+
+let test_budget_local_70b_plus () =
+  check_budget
+    "big-local -> local_70b_plus"
+    L.local_70b_plus
+    (budget_of fixture_cfg "big-local")
+;;
+
+let test_budget_missing_class_fallback () =
+  (* Provider exists but has no liveness_class — falls back to cloud_fast. *)
+  check_budget "no-class -> cloud_fast" L.cloud_fast (budget_of fixture_cfg "no-class")
+;;
+
+let test_budget_unknown_provider () =
+  (* Provider id not in cascade config — falls back to cloud_fast. *)
+  check_budget
+    "weird_provider_xyz -> cloud_fast"
+    L.cloud_fast
+    (budget_of fixture_cfg "weird_provider_xyz")
+;;
 
 let test_budget_case_insensitive () =
-  check_budget "GLM-CODING -> cloud_thinking" L.cloud_thinking
-    (Cfg.budget_for_provider_id ~provider_id:"GLM-CODING")
+  check_budget
+    "GLM-CODING -> cloud_thinking"
+    L.cloud_thinking
+    (budget_of fixture_cfg "GLM-CODING");
+  check_budget "Codex_Cli -> cloud_fast" L.cloud_fast (budget_of fixture_cfg "Codex_Cli")
+;;
+
+let test_budget_whitespace_trim () =
+  check_budget
+    "  codex_cli  -> cloud_fast"
+    L.cloud_fast
+    (budget_of fixture_cfg "  codex_cli  ")
+;;
+
+(* Sanity: omitting [?cfg] uses the lazy disk-loaded cache (or returns
+   cloud_fast when the disk config does not parse). We don't pin the
+   in-tree config/cascade.toml contents here — the assertion is purely
+   that the call shape works without an explicit [~cfg]. *)
+let test_budget_no_explicit_cfg () =
+  Cfg.reset_cache_for_test ();
+  let b = Cfg.budget_for_provider_id ~provider_id:"weird_provider_xyz" () in
+  Alcotest.(check bool) "fallback returns a valid budget" true (budget_eq L.cloud_fast b)
+;;
 
 let () =
-  Alcotest.run "cascade_attempt_liveness_config"
-    [
-      ( "mode parsing",
-        [
-          Alcotest.test_case "default unset -> observe" `Quick
-            test_default_unset;
-          Alcotest.test_case "observe" `Quick test_observe_alias;
-          Alcotest.test_case "off" `Quick test_off_alias;
-          Alcotest.test_case "off via 0" `Quick test_off_zero;
-          Alcotest.test_case "enforce" `Quick test_enforce_alias;
-          Alcotest.test_case "enforce via kill" `Quick test_enforce_kill;
-          Alcotest.test_case "unknown -> observe" `Quick
-            test_unknown_defaults_observe;
-          Alcotest.test_case "case insensitive" `Quick test_case_insensitive;
-        ] );
-      ( "cache",
-        [
-          Alcotest.test_case "first read cached" `Quick test_cache_first_read;
-          Alcotest.test_case "reset_cache_for_test re-reads" `Quick
-            test_reset_cache;
-        ] );
-      ( "mode_label",
-        [ Alcotest.test_case "stable labels" `Quick test_mode_labels ] );
-      ( "budget_for_provider_id",
-        [
-          Alcotest.test_case "codex_cli" `Quick test_budget_codex_cli;
-          Alcotest.test_case "claude_code" `Quick test_budget_claude_code;
-          Alcotest.test_case "glm-coding" `Quick test_budget_glm_coding;
-          Alcotest.test_case "kimi-for-coding" `Quick test_budget_kimi;
-          Alcotest.test_case "local 27b" `Quick test_budget_local;
-          Alcotest.test_case "local 70b plus" `Quick test_budget_local_70b;
-          Alcotest.test_case "unknown -> cloud_fast" `Quick
-            test_budget_unknown_default;
-          Alcotest.test_case "case insensitive" `Quick
-            test_budget_case_insensitive;
-        ] );
+  Alcotest.run
+    "cascade_attempt_liveness_config"
+    [ ( "mode parsing"
+      , [ Alcotest.test_case "default unset -> observe" `Quick test_default_unset
+        ; Alcotest.test_case "observe" `Quick test_observe_alias
+        ; Alcotest.test_case "off" `Quick test_off_alias
+        ; Alcotest.test_case "off via 0" `Quick test_off_zero
+        ; Alcotest.test_case "enforce" `Quick test_enforce_alias
+        ; Alcotest.test_case "enforce via kill" `Quick test_enforce_kill
+        ; Alcotest.test_case "unknown -> observe" `Quick test_unknown_defaults_observe
+        ; Alcotest.test_case "case insensitive" `Quick test_case_insensitive
+        ] )
+    ; ( "cache"
+      , [ Alcotest.test_case "first read cached" `Quick test_cache_first_read
+        ; Alcotest.test_case "reset_cache_for_test re-reads" `Quick test_reset_cache
+        ] )
+    ; "mode_label", [ Alcotest.test_case "stable labels" `Quick test_mode_labels ]
+    ; ( "budget_for_provider_id (Phase 5.2b)"
+      , [ Alcotest.test_case "cloud_fast providers" `Quick test_budget_cloud_fast
+        ; Alcotest.test_case "cloud_thinking providers" `Quick test_budget_cloud_thinking
+        ; Alcotest.test_case "local_27b provider" `Quick test_budget_local_27b
+        ; Alcotest.test_case "local_70b_plus provider" `Quick test_budget_local_70b_plus
+        ; Alcotest.test_case
+            "provider without class -> cloud_fast"
+            `Quick
+            test_budget_missing_class_fallback
+        ; Alcotest.test_case
+            "unknown provider -> cloud_fast"
+            `Quick
+            test_budget_unknown_provider
+        ; Alcotest.test_case "case insensitive" `Quick test_budget_case_insensitive
+        ; Alcotest.test_case "whitespace trim" `Quick test_budget_whitespace_trim
+        ; Alcotest.test_case
+            "no explicit ?cfg uses disk cache fallback"
+            `Quick
+            test_budget_no_explicit_cfg
+        ] )
     ]
+;;

--- a/test/test_cascade_attempt_liveness_config.ml
+++ b/test/test_cascade_attempt_liveness_config.ml
@@ -41,6 +41,15 @@ let check_mode label expected actual =
 
 (* -- mode parsing --------------------------------------------------- *)
 
+(* Covers the empty-string env value, which is the closest a pure-OCaml
+   test can get to "unset": the stdlib [Unix] module has [putenv] but no
+   [unsetenv], so we can't actually remove the variable here. That's
+   acceptable: [current_mode] maps both the truly-unset case
+   ([Sys.getenv_opt = None] -> [Observe]) and the empty-string case
+   ([parse_mode ""] -> [Observe]) to the same result, so the observable
+   behavior this asserts is identical for both. The only regression this
+   can't catch is a future change to the [None] arm alone — guard that
+   by keeping the arm and [parse_mode ""] in sync. *)
 let test_default_unset () =
   let prior = Sys.getenv_opt env_var in
   Unix.putenv env_var "";
@@ -155,13 +164,13 @@ let make_cfg (providers : Decl.cascade_provider list) : Decl.cascade_config =
    as canonical fixtures; each row exercises one [liveness_class]. *)
 let fixture_cfg =
   make_cfg
-    [ make_provider ~id:"codex_cli" ~liveness_class:(Some Cloud_fast)
-    ; make_provider ~id:"claude_code" ~liveness_class:(Some Cloud_fast)
-    ; make_provider ~id:"gemini_cli" ~liveness_class:(Some Cloud_fast)
-    ; make_provider ~id:"kimi_cli" ~liveness_class:(Some Cloud_thinking)
-    ; make_provider ~id:"glm-coding" ~liveness_class:(Some Cloud_thinking)
-    ; make_provider ~id:"ollama" ~liveness_class:(Some Local_27b)
-    ; make_provider ~id:"big-local" ~liveness_class:(Some Local_70b_plus)
+    [ make_provider ~id:"codex_cli" ~liveness_class:(Some Decl.Cloud_fast)
+    ; make_provider ~id:"claude_code" ~liveness_class:(Some Decl.Cloud_fast)
+    ; make_provider ~id:"gemini_cli" ~liveness_class:(Some Decl.Cloud_fast)
+    ; make_provider ~id:"kimi_cli" ~liveness_class:(Some Decl.Cloud_thinking)
+    ; make_provider ~id:"glm-coding" ~liveness_class:(Some Decl.Cloud_thinking)
+    ; make_provider ~id:"ollama" ~liveness_class:(Some Decl.Local_27b)
+    ; make_provider ~id:"big-local" ~liveness_class:(Some Decl.Local_70b_plus)
     ; make_provider ~id:"no-class" ~liveness_class:None
     ]
 ;;

--- a/test/test_cascade_declarative_validator.ml
+++ b/test/test_cascade_declarative_validator.ml
@@ -12,40 +12,58 @@ open Cascade_declarative_validator
 (* --- Helpers --- *)
 
 let has_rule (rule : string) (errs : validation_error list) =
-  check bool
-    ("has rule " ^ rule)
-    true
-    (List.exists (fun e -> e.rule = rule) errs)
+  check bool ("has rule " ^ rule) true (List.exists (fun e -> e.rule = rule) errs)
+;;
 
 let has_rule_at (rule : string) (path : string) (errs : validation_error list) =
-  check bool
+  check
+    bool
     (Printf.sprintf "has rule %s at %s" rule path)
     true
     (List.exists (fun e -> e.rule = rule && e.path = path) errs)
+;;
 
+(* R13 (every provider declares liveness.class) is exercised explicitly by
+   its own tests. Other rule-specific fixtures do not bother to declare a
+   liveness class, so this helper ignores R13 to keep those tests focused
+   on the rule under exam. The dedicated [test_r13_*] tests pin both the
+   error and the no-error cases. *)
 let no_errors (errs : validation_error list) =
-  check int "no errors" 0 (List.length errs)
+  let non_r13 = List.filter (fun (e : validation_error) -> e.rule <> "R13") errs in
+  check int "no errors (R13 excluded — see dedicated R13 tests)" 0 (List.length non_r13)
+;;
 
 let validate_toml (toml : string) : validation_error list =
   match parse_string toml with
   | Ok cfg -> validate cfg
   | Error (errs : parse_error list) ->
     failwith
-      (Printf.sprintf "parse failed: %s"
-         (String.concat "; "
-            (List.map (fun (e : parse_error) ->
-              Printf.sprintf "%s: %s" e.path e.message) errs)))
+      (Printf.sprintf
+         "parse failed: %s"
+         (String.concat
+            "; "
+            (List.map
+               (fun (e : parse_error) -> Printf.sprintf "%s: %s" e.path e.message)
+               errs)))
+;;
 
 (* --- Valid config: 0 errors --- *)
 
-let valid_toml = {|
+let valid_toml =
+  {|
 [providers.claude-code]
 protocol = "anthropic-cli"
 command = "claude"
 
+[providers.claude-code.liveness]
+class = "cloud_fast"
+
 [providers.ollama]
 protocol = "ollama-http"
 endpoint = "http://localhost:11434"
+
+[providers.ollama.liveness]
+class = "local_27b"
 
 [models.haiku]
 max-context = 200000
@@ -94,15 +112,21 @@ target = "tier-group.big-three"
 [system.governance]
 target = "claude-code.haiku.for-tool-rerank"
 |}
+;;
 
 let test_valid_config () =
   let errs = validate_toml valid_toml in
-  no_errors errs
+  (* valid_toml declares [liveness.class] on every provider, so even
+     R13 must pass. We assert on the full error set here, not the
+     R13-excluded helper. *)
+  check int "no errors (including R13)" 0 (List.length errs)
+;;
 
 (* --- R1: Binding → unknown provider --- *)
 
 let test_r1_unknown_provider () =
-  let toml = {|
+  let toml =
+    {|
 [providers.good]
 protocol = "anthropic-cli"
 command = "claude"
@@ -112,14 +136,17 @@ max-context = 200000
 
 [bad-provider.haiku]
 is-default = true
-|} in
+|}
+  in
   let errs = validate_toml toml in
   has_rule_at "R1" "bad-provider.haiku" errs
+;;
 
 (* --- R2: Binding → unknown model --- *)
 
 let test_r2_unknown_model () =
-  let toml = {|
+  let toml =
+    {|
 [providers.claude-code]
 protocol = "anthropic-cli"
 command = "claude"
@@ -129,9 +156,11 @@ max-context = 200000
 
 [claude-code.nonexistent-model]
 is-default = true
-|} in
+|}
+  in
   let errs = validate_toml toml in
   has_rule_at "R2" "claude-code.nonexistent-model" errs
+;;
 
 (* --- R3: Alias → unknown binding --- *)
 (* Parser synthesizes a parent binding when [p.m.a] exists without [p.m],
@@ -140,32 +169,36 @@ is-default = true
    by constructing the config directly (bypassing parser synthesis). *)
 
 let test_r3_unknown_binding () =
-  let cfg = {
-    Cascade_declarative_types.providers = [];
-    models = [];
-    bindings = [];
-    aliases = [{
-      Cascade_declarative_types.provider_id = "x";
-      model_id = "y";
-      name = "z";
-      max_input = None;
-      max_output = None;
-      temperature = None;
-      thinking_enabled = None;
-      thinking_budget = None;
-    }];
-    tiers = [];
-    tier_groups = [];
-    routes = [];
-    system_targets = [];
-  } in
+  let cfg =
+    { Cascade_declarative_types.providers = []
+    ; models = []
+    ; bindings = []
+    ; aliases =
+        [ { Cascade_declarative_types.provider_id = "x"
+          ; model_id = "y"
+          ; name = "z"
+          ; max_input = None
+          ; max_output = None
+          ; temperature = None
+          ; thinking_enabled = None
+          ; thinking_budget = None
+          }
+        ]
+    ; tiers = []
+    ; tier_groups = []
+    ; routes = []
+    ; system_targets = []
+    }
+  in
   let errs = Cascade_declarative_validator.validate cfg in
   has_rule "R3" errs
+;;
 
 (* --- R4: Alias max-input > model max-context --- *)
 
 let test_r4_max_input_exceeds () =
-  let toml = {|
+  let toml =
+    {|
 [providers.claude-code]
 protocol = "anthropic-cli"
 command = "claude"
@@ -178,12 +211,15 @@ is-default = true
 
 [claude-code.haiku.too-big]
 max-input = 999999
-|} in
+|}
+  in
   let errs = validate_toml toml in
   has_rule "R4" errs
+;;
 
 let test_r4_max_input_ok () =
-  let toml = {|
+  let toml =
+    {|
 [providers.claude-code]
 protocol = "anthropic-cli"
 command = "claude"
@@ -197,14 +233,17 @@ max-concurrent = 1
 
 [claude-code.haiku.ok-alias]
 max-input = 4096
-|} in
+|}
+  in
   let errs = validate_toml toml in
   no_errors errs
+;;
 
 (* --- R5: Tier member does not resolve --- *)
 
 let test_r5_unknown_tier_member () =
-  let toml = {|
+  let toml =
+    {|
 [providers.claude-code]
 protocol = "anthropic-cli"
 command = "claude"
@@ -218,12 +257,15 @@ is-default = true
 [tier.bad-tier]
 members = ["claude-code.haiku", "nonexistent.binding"]
 strategy = "failover"
-|} in
+|}
+  in
   let errs = validate_toml toml in
   has_rule "R5" errs
+;;
 
 let test_r5_alias_member_ok () =
-  let toml = {|
+  let toml =
+    {|
 [providers.claude-code]
 protocol = "anthropic-cli"
 command = "claude"
@@ -241,14 +283,17 @@ max-input = 4096
 [tier.t]
 members = ["claude-code.haiku.alias-a"]
 strategy = "failover"
-|} in
+|}
+  in
   let errs = validate_toml toml in
   no_errors errs
+;;
 
 (* --- R6: Tier-group references unknown tier --- *)
 
 let test_r6_unknown_tier () =
-  let toml = {|
+  let toml =
+    {|
 [providers.claude-code]
 protocol = "anthropic-cli"
 command = "claude"
@@ -266,14 +311,17 @@ strategy = "failover"
 [tier-group.broken]
 tiers = ["real", "phantom"]
 strategy = "failover"
-|} in
+|}
+  in
   let errs = validate_toml toml in
   has_rule "R6" errs
+;;
 
 (* --- R7: Route target does not resolve --- *)
 
 let test_r7_unknown_route_target () =
-  let toml = {|
+  let toml =
+    {|
 [providers.claude-code]
 protocol = "anthropic-cli"
 command = "claude"
@@ -286,12 +334,15 @@ is-default = true
 
 [routes.dead-end]
 target = "tier-group.nowhere"
-|} in
+|}
+  in
   let errs = validate_toml toml in
   has_rule "R7" errs
+;;
 
 let test_r7_route_to_binding () =
-  let toml = {|
+  let toml =
+    {|
 [providers.claude-code]
 protocol = "anthropic-cli"
 command = "claude"
@@ -305,12 +356,15 @@ max-concurrent = 1
 
 [routes.direct]
 target = "claude-code.haiku"
-|} in
+|}
+  in
   let errs = validate_toml toml in
   no_errors errs
+;;
 
 let test_r7_route_to_tier () =
-  let toml = {|
+  let toml =
+    {|
 [providers.claude-code]
 protocol = "anthropic-cli"
 command = "claude"
@@ -328,14 +382,17 @@ strategy = "failover"
 
 [routes.via-tier]
 target = "tier.primary"
-|} in
+|}
+  in
   let errs = validate_toml toml in
   no_errors errs
+;;
 
 (* --- R8: System target does not resolve --- *)
 
 let test_r8_unknown_system_target () =
-  let toml = {|
+  let toml =
+    {|
 [providers.claude-code]
 protocol = "anthropic-cli"
 command = "claude"
@@ -348,12 +405,15 @@ is-default = true
 
 [system.broken]
 target = "nonexistent.binding"
-|} in
+|}
+  in
   let errs = validate_toml toml in
   has_rule "R8" errs
+;;
 
 let test_r8_system_to_alias () =
-  let toml = {|
+  let toml =
+    {|
 [providers.claude-code]
 protocol = "anthropic-cli"
 command = "claude"
@@ -370,14 +430,17 @@ max-input = 8192
 
 [system.governance]
 target = "claude-code.haiku.gov"
-|} in
+|}
+  in
   let errs = validate_toml toml in
   no_errors errs
+;;
 
 (* --- R9: Multiple is-default per provider --- *)
 
 let test_r9_multiple_defaults () =
-  let toml = {|
+  let toml =
+    {|
 [providers.claude-code]
 protocol = "anthropic-cli"
 command = "claude"
@@ -393,12 +456,15 @@ is-default = true
 
 [claude-code.sonnet]
 is-default = true
-|} in
+|}
+  in
   let errs = validate_toml toml in
   has_rule "R9" errs
+;;
 
 let test_r9_single_default_ok () =
-  let toml = {|
+  let toml =
+    {|
 [providers.claude-code]
 protocol = "anthropic-cli"
 command = "claude"
@@ -415,14 +481,17 @@ max-concurrent = 1
 
 [claude-code.sonnet]
 max-concurrent = 1
-|} in
+|}
+  in
   let errs = validate_toml toml in
   no_errors errs
+;;
 
 (* --- Multiple errors at once --- *)
 
 let test_multiple_errors () =
-  let toml = {|
+  let toml =
+    {|
 [providers.good]
 protocol = "anthropic-cli"
 command = "claude"
@@ -438,17 +507,20 @@ is-default = true
 
 [system.broken]
 target = "no.such.binding"
-|} in
+|}
+  in
   let errs = validate_toml toml in
   has_rule "R1" errs;
   has_rule "R2" errs;
   has_rule "R8" errs;
   check bool "multiple errors" true (List.length errs >= 3)
+;;
 
 (* --- R10: Strategy-field consistency --- *)
 
 let test_r10_cycle_policy_on_wrong_strategy () =
-  let toml = {|
+  let toml =
+    {|
 [providers.p]
 protocol = "anthropic-cli"
 command = "c"
@@ -465,12 +537,15 @@ strategy = "failover"
 max-cycles = 3
 backoff-base-ms = 500
 backoff-cap-ms = 10000
-|} in
+|}
+  in
   let errs = validate_toml toml in
   has_rule_at "R10" "tier.t.cycle-policy" errs
+;;
 
 let test_r10_cycle_policy_on_correct_strategy () =
-  let toml = {|
+  let toml =
+    {|
 [providers.p]
 protocol = "anthropic-cli"
 command = "c"
@@ -487,12 +562,15 @@ strategy = "circuit_breaker_cycling"
 max-cycles = 3
 backoff-base-ms = 500
 backoff-cap-ms = 10000
-|} in
+|}
+  in
   let errs = validate_toml toml in
   no_errors errs
+;;
 
 let test_r10_sticky_ttl_on_wrong_strategy () =
-  let toml = {|
+  let toml =
+    {|
 [providers.p]
 protocol = "anthropic-cli"
 command = "c"
@@ -507,12 +585,15 @@ max-concurrent = 1
 members = ["p.m"]
 strategy = "failover"
 sticky-ttl-ms = 600000
-|} in
+|}
+  in
   let errs = validate_toml toml in
   has_rule_at "R10" "tier.t.sticky-ttl-ms" errs
+;;
 
 let test_r10_sticky_ttl_on_correct_strategy () =
-  let toml = {|
+  let toml =
+    {|
 [providers.p]
 protocol = "anthropic-cli"
 command = "c"
@@ -527,12 +608,15 @@ max-concurrent = 1
 members = ["p.m"]
 strategy = "sticky"
 sticky-ttl-ms = 600000
-|} in
+|}
+  in
   let errs = validate_toml toml in
   no_errors errs
+;;
 
 let test_r10_scoring_on_wrong_strategy () =
-  let toml = {|
+  let toml =
+    {|
 [providers.p]
 protocol = "anthropic-cli"
 command = "c"
@@ -553,12 +637,15 @@ rate-limit-skip-after = 3
 server-error-recency-window-s = 120.0
 server-error-decay-base = 0.3
 server-error-skip-after = 5
-|} in
+|}
+  in
   let errs = validate_toml toml in
   has_rule_at "R10" "tier.t.scoring-params" errs
+;;
 
 let test_r10_scoring_on_correct_strategy () =
-  let toml = {|
+  let toml =
+    {|
 [providers.p]
 protocol = "anthropic-cli"
 command = "c"
@@ -579,12 +666,15 @@ rate-limit-skip-after = 3
 server-error-recency-window-s = 120.0
 server-error-decay-base = 0.3
 server-error-skip-after = 5
-|} in
+|}
+  in
   let errs = validate_toml toml in
   no_errors errs
+;;
 
 let test_r10_no_strategy_fields_is_ok () =
-  let toml = {|
+  let toml =
+    {|
 [providers.p]
 protocol = "anthropic-cli"
 command = "c"
@@ -598,12 +688,15 @@ max-concurrent = 1
 [tier.t]
 members = ["p.m"]
 strategy = "failover"
-|} in
+|}
+  in
   let errs = validate_toml toml in
   no_errors errs
+;;
 
 let test_r10_multiple_mismatches () =
-  let toml = {|
+  let toml =
+    {|
 [providers.p]
 protocol = "anthropic-cli"
 command = "c"
@@ -621,18 +714,24 @@ max-cycles = 3
 backoff-base-ms = 500
 backoff-cap-ms = 10000
 sticky-ttl-ms = 600000
-|} in
+|}
+  in
   let errs = validate_toml toml in
   has_rule "R10" errs;
-  check bool "multiple R10 errors" true
+  check
+    bool
+    "multiple R10 errors"
+    true
     (List.length (List.filter (fun e -> e.rule = "R10") errs) >= 2)
+;;
 
 (* --- Test suite --- *)
 
 (* --- R12: Protocol ↔ transport consistency --- *)
 
 let test_r12_cli_protocol_with_cli_transport () =
-  let toml = {|
+  let toml =
+    {|
 [providers.claude-code]
 protocol = "anthropic-cli"
 command = "claude"
@@ -643,13 +742,19 @@ max-context = 200000
 [claude-code.haiku]
 is-default = true
 max-concurrent = 1
-|} in
+|}
+  in
   let errs = validate_toml toml in
-  check bool "no R12 errors" false
+  check
+    bool
+    "no R12 errors"
+    false
     (List.exists (fun (e : validation_error) -> e.rule = "R12") errs)
+;;
 
 let test_r12_http_protocol_with_http_transport () =
-  let toml = {|
+  let toml =
+    {|
 [providers.ollama]
 protocol = "ollama-http"
 endpoint = "http://localhost:11434"
@@ -659,13 +764,19 @@ max-context = 32768
 
 [ollama.qwen3]
 max-concurrent = 1
-|} in
+|}
+  in
   let errs = validate_toml toml in
-  check bool "no R12 errors" false
+  check
+    bool
+    "no R12 errors"
+    false
     (List.exists (fun (e : validation_error) -> e.rule = "R12") errs)
+;;
 
 let test_r12_cli_protocol_with_http_transport () =
-  let toml = {|
+  let toml =
+    {|
 [providers.bad]
 protocol = "anthropic-cli"
 endpoint = "http://localhost:8080"
@@ -675,12 +786,15 @@ max-context = 4096
 
 [bad.m]
 max-concurrent = 1
-|} in
+|}
+  in
   let errs = validate_toml toml in
   has_rule_at "R12" "providers.bad.protocol" errs
+;;
 
 let test_r12_http_protocol_with_cli_transport () =
-  let toml = {|
+  let toml =
+    {|
 [providers.bad]
 protocol = "openai-http"
 command = "my-cli"
@@ -690,65 +804,177 @@ max-context = 4096
 
 [bad.m]
 max-concurrent = 1
-|} in
+|}
+  in
   let errs = validate_toml toml in
   has_rule_at "R12" "providers.bad.protocol" errs
+;;
+
+(* --- R13: Provider liveness.class required (RFC-0058 Phase 5.2b) --- *)
+
+let test_r13_missing_liveness_class () =
+  let toml =
+    {|
+[providers.no-class]
+protocol = "anthropic-cli"
+command = "test"
+
+[models.m]
+max-context = 4096
+
+[no-class.m]
+max-concurrent = 1
+|}
+  in
+  let errs = validate_toml toml in
+  has_rule_at "R13" "providers.no-class.liveness.class" errs
+;;
+
+let test_r13_with_liveness_class_no_error () =
+  let toml =
+    {|
+[providers.with-class]
+protocol = "anthropic-cli"
+command = "test"
+
+[providers.with-class.liveness]
+class = "cloud_fast"
+
+[models.m]
+max-context = 4096
+
+[with-class.m]
+max-concurrent = 1
+|}
+  in
+  let errs = validate_toml toml in
+  check
+    bool
+    "no R13 errors when class declared"
+    false
+    (List.exists (fun (e : validation_error) -> e.rule = "R13") errs)
+;;
+
+let test_r13_one_error_per_missing_provider () =
+  let toml =
+    {|
+[providers.a]
+protocol = "anthropic-cli"
+command = "a"
+
+[providers.b]
+protocol = "anthropic-cli"
+command = "b"
+
+[providers.b.liveness]
+class = "cloud_fast"
+
+[providers.c]
+protocol = "anthropic-cli"
+command = "c"
+
+[models.m]
+max-context = 4096
+
+[a.m]
+max-concurrent = 1
+
+[b.m]
+max-concurrent = 1
+
+[c.m]
+max-concurrent = 1
+|}
+  in
+  let errs = validate_toml toml in
+  let r13s = List.filter (fun (e : validation_error) -> e.rule = "R13") errs in
+  check int "R13 error count" 2 (List.length r13s);
+  has_rule_at "R13" "providers.a.liveness.class" errs;
+  has_rule_at "R13" "providers.c.liveness.class" errs
+;;
 
 let () =
-  run "RFC-0058 Declarative Validator"
-    [ "valid", [
-        test_case "full valid config" `Quick test_valid_config;
-      ];
-      "R1_binding_provider", [
-        test_case "unknown provider" `Quick test_r1_unknown_provider;
-      ];
-      "R2_binding_model", [
-        test_case "unknown model" `Quick test_r2_unknown_model;
-      ];
-      "R3_alias_binding", [
-        test_case "unknown binding" `Quick test_r3_unknown_binding;
-      ];
-      "R4_alias_max_input", [
-        test_case "max-input exceeds max-context" `Quick test_r4_max_input_exceeds;
-        test_case "max-input within max-context" `Quick test_r4_max_input_ok;
-      ];
-      "R5_tier_members", [
-        test_case "unknown tier member" `Quick test_r5_unknown_tier_member;
-        test_case "alias as tier member" `Quick test_r5_alias_member_ok;
-      ];
-      "R6_tier_group_refs", [
-        test_case "unknown tier in group" `Quick test_r6_unknown_tier;
-      ];
-      "R7_route_targets", [
-        test_case "unknown route target" `Quick test_r7_unknown_route_target;
-        test_case "route to binding" `Quick test_r7_route_to_binding;
-        test_case "route to tier" `Quick test_r7_route_to_tier;
-      ];
-      "R8_system_targets", [
-        test_case "unknown system target" `Quick test_r8_unknown_system_target;
-        test_case "system to alias" `Quick test_r8_system_to_alias;
-      ];
-      "R9_single_default", [
-        test_case "multiple defaults per provider" `Quick test_r9_multiple_defaults;
-        test_case "single default ok" `Quick test_r9_single_default_ok;
-      ];
-      "multi", [
-        test_case "multiple errors at once" `Quick test_multiple_errors;
-      ];
-      "R10_strategy_fields", [
-        test_case "cycle_policy on wrong strategy" `Quick test_r10_cycle_policy_on_wrong_strategy;
-        test_case "cycle_policy on correct strategy" `Quick test_r10_cycle_policy_on_correct_strategy;
-        test_case "sticky_ttl on wrong strategy" `Quick test_r10_sticky_ttl_on_wrong_strategy;
-        test_case "sticky_ttl on correct strategy" `Quick test_r10_sticky_ttl_on_correct_strategy;
-        test_case "scoring on wrong strategy" `Quick test_r10_scoring_on_wrong_strategy;
-        test_case "scoring on correct strategy" `Quick test_r10_scoring_on_correct_strategy;
-        test_case "no strategy fields is ok" `Quick test_r10_no_strategy_fields_is_ok;
-        test_case "multiple mismatches" `Quick test_r10_multiple_mismatches;
-      ];
-      "R12_protocol_transport", [
-        test_case "cli protocol with cli transport ok" `Quick test_r12_cli_protocol_with_cli_transport;
-        test_case "http protocol with http transport ok" `Quick test_r12_http_protocol_with_http_transport;
-        test_case "cli protocol with http transport mismatch" `Quick test_r12_cli_protocol_with_http_transport;
-        test_case "http protocol with cli transport mismatch" `Quick test_r12_http_protocol_with_cli_transport;
-      ];
+  run
+    "RFC-0058 Declarative Validator"
+    [ "valid", [ test_case "full valid config" `Quick test_valid_config ]
+    ; ( "R1_binding_provider"
+      , [ test_case "unknown provider" `Quick test_r1_unknown_provider ] )
+    ; "R2_binding_model", [ test_case "unknown model" `Quick test_r2_unknown_model ]
+    ; "R3_alias_binding", [ test_case "unknown binding" `Quick test_r3_unknown_binding ]
+    ; ( "R4_alias_max_input"
+      , [ test_case "max-input exceeds max-context" `Quick test_r4_max_input_exceeds
+        ; test_case "max-input within max-context" `Quick test_r4_max_input_ok
+        ] )
+    ; ( "R5_tier_members"
+      , [ test_case "unknown tier member" `Quick test_r5_unknown_tier_member
+        ; test_case "alias as tier member" `Quick test_r5_alias_member_ok
+        ] )
+    ; ( "R6_tier_group_refs"
+      , [ test_case "unknown tier in group" `Quick test_r6_unknown_tier ] )
+    ; ( "R7_route_targets"
+      , [ test_case "unknown route target" `Quick test_r7_unknown_route_target
+        ; test_case "route to binding" `Quick test_r7_route_to_binding
+        ; test_case "route to tier" `Quick test_r7_route_to_tier
+        ] )
+    ; ( "R8_system_targets"
+      , [ test_case "unknown system target" `Quick test_r8_unknown_system_target
+        ; test_case "system to alias" `Quick test_r8_system_to_alias
+        ] )
+    ; ( "R9_single_default"
+      , [ test_case "multiple defaults per provider" `Quick test_r9_multiple_defaults
+        ; test_case "single default ok" `Quick test_r9_single_default_ok
+        ] )
+    ; "multi", [ test_case "multiple errors at once" `Quick test_multiple_errors ]
+    ; ( "R10_strategy_fields"
+      , [ test_case
+            "cycle_policy on wrong strategy"
+            `Quick
+            test_r10_cycle_policy_on_wrong_strategy
+        ; test_case
+            "cycle_policy on correct strategy"
+            `Quick
+            test_r10_cycle_policy_on_correct_strategy
+        ; test_case
+            "sticky_ttl on wrong strategy"
+            `Quick
+            test_r10_sticky_ttl_on_wrong_strategy
+        ; test_case
+            "sticky_ttl on correct strategy"
+            `Quick
+            test_r10_sticky_ttl_on_correct_strategy
+        ; test_case "scoring on wrong strategy" `Quick test_r10_scoring_on_wrong_strategy
+        ; test_case
+            "scoring on correct strategy"
+            `Quick
+            test_r10_scoring_on_correct_strategy
+        ; test_case "no strategy fields is ok" `Quick test_r10_no_strategy_fields_is_ok
+        ; test_case "multiple mismatches" `Quick test_r10_multiple_mismatches
+        ] )
+    ; ( "R12_protocol_transport"
+      , [ test_case
+            "cli protocol with cli transport ok"
+            `Quick
+            test_r12_cli_protocol_with_cli_transport
+        ; test_case
+            "http protocol with http transport ok"
+            `Quick
+            test_r12_http_protocol_with_http_transport
+        ; test_case
+            "cli protocol with http transport mismatch"
+            `Quick
+            test_r12_cli_protocol_with_http_transport
+        ; test_case
+            "http protocol with cli transport mismatch"
+            `Quick
+            test_r12_http_protocol_with_cli_transport
+        ] )
+    ; ( "R13_provider_liveness_class"
+      , [ test_case "missing class flagged" `Quick test_r13_missing_liveness_class
+        ; test_case "class declared passes" `Quick test_r13_with_liveness_class_no_error
+        ; test_case
+            "one error per missing provider"
+            `Quick
+            test_r13_one_error_per_missing_provider
+        ] )
     ]
+;;

--- a/test/test_cascade_declarative_validator.ml
+++ b/test/test_cascade_declarative_validator.ml
@@ -24,11 +24,13 @@ let has_rule_at (rule : string) (path : string) (errs : validation_error list) =
 ;;
 
 (* R13 (every provider declares liveness.class) is exercised explicitly by
-   its own tests. Other rule-specific fixtures do not bother to declare a
-   liveness class, so this helper ignores R13 to keep those tests focused
-   on the rule under exam. The dedicated [test_r13_*] tests pin both the
-   error and the no-error cases. *)
-let no_errors (errs : validation_error list) =
+   its own [test_r13_*] tests, which pin both the error and the no-error
+   cases. Other rule-specific fixtures do not declare a liveness class, so
+   this helper filters R13 out before asserting "no errors" — the
+   [_except_r13] suffix is deliberate so a future test that needs the full
+   error set (R13 included) reaches for an inline [check int ... errs]
+   instead of accidentally masking an unexpected R13 failure. *)
+let no_errors_except_r13 (errs : validation_error list) =
   let non_r13 = List.filter (fun (e : validation_error) -> e.rule <> "R13") errs in
   check int "no errors (R13 excluded — see dedicated R13 tests)" 0 (List.length non_r13)
 ;;
@@ -236,7 +238,7 @@ max-input = 4096
 |}
   in
   let errs = validate_toml toml in
-  no_errors errs
+  no_errors_except_r13 errs
 ;;
 
 (* --- R5: Tier member does not resolve --- *)
@@ -286,7 +288,7 @@ strategy = "failover"
 |}
   in
   let errs = validate_toml toml in
-  no_errors errs
+  no_errors_except_r13 errs
 ;;
 
 (* --- R6: Tier-group references unknown tier --- *)
@@ -359,7 +361,7 @@ target = "claude-code.haiku"
 |}
   in
   let errs = validate_toml toml in
-  no_errors errs
+  no_errors_except_r13 errs
 ;;
 
 let test_r7_route_to_tier () =
@@ -385,7 +387,7 @@ target = "tier.primary"
 |}
   in
   let errs = validate_toml toml in
-  no_errors errs
+  no_errors_except_r13 errs
 ;;
 
 (* --- R8: System target does not resolve --- *)
@@ -433,7 +435,7 @@ target = "claude-code.haiku.gov"
 |}
   in
   let errs = validate_toml toml in
-  no_errors errs
+  no_errors_except_r13 errs
 ;;
 
 (* --- R9: Multiple is-default per provider --- *)
@@ -484,7 +486,7 @@ max-concurrent = 1
 |}
   in
   let errs = validate_toml toml in
-  no_errors errs
+  no_errors_except_r13 errs
 ;;
 
 (* --- Multiple errors at once --- *)
@@ -565,7 +567,7 @@ backoff-cap-ms = 10000
 |}
   in
   let errs = validate_toml toml in
-  no_errors errs
+  no_errors_except_r13 errs
 ;;
 
 let test_r10_sticky_ttl_on_wrong_strategy () =
@@ -611,7 +613,7 @@ sticky-ttl-ms = 600000
 |}
   in
   let errs = validate_toml toml in
-  no_errors errs
+  no_errors_except_r13 errs
 ;;
 
 let test_r10_scoring_on_wrong_strategy () =
@@ -669,7 +671,7 @@ server-error-skip-after = 5
 |}
   in
   let errs = validate_toml toml in
-  no_errors errs
+  no_errors_except_r13 errs
 ;;
 
 let test_r10_no_strategy_fields_is_ok () =
@@ -691,7 +693,7 @@ strategy = "failover"
 |}
   in
   let errs = validate_toml toml in
-  no_errors errs
+  no_errors_except_r13 errs
 ;;
 
 let test_r10_multiple_mismatches () =

--- a/test/test_oas_worker_named_liveness_integration.ml
+++ b/test/test_oas_worker_named_liveness_integration.ml
@@ -84,7 +84,7 @@ let test_e2e_observe_finalize_emits_observed_total () =
       let cascade = "integ_observe_cascade" in
       let provider = "integ_observe_provider" in
       let mode = Cfg.current_mode () in
-      let budget = Cfg.budget_for_provider_id ~provider_id:provider in
+      let budget = Cfg.budget_for_provider_id ~provider_id:provider () in
       let obs =
         Obs.create ~mode ~budget ~cascade_label:cascade
           ~provider_label:provider ~started_at:0.0
@@ -106,7 +106,7 @@ let test_e2e_off_no_observed_total () =
       let cascade = "integ_off_cascade" in
       let provider = "integ_off_provider" in
       let mode = Cfg.current_mode () in
-      let budget = Cfg.budget_for_provider_id ~provider_id:provider in
+      let budget = Cfg.budget_for_provider_id ~provider_id:provider () in
       let obs =
         Obs.create ~mode ~budget ~cascade_label:cascade
           ~provider_label:provider ~started_at:0.0
@@ -126,7 +126,7 @@ let test_enforce_registered_switch_kills_attempt_without_tick_clock () =
           try
             Eio.Switch.run (fun attempt_sw ->
                 let mode = Cfg.current_mode () in
-                let budget = Cfg.budget_for_provider_id ~provider_id:provider in
+                let budget = Cfg.budget_for_provider_id ~provider_id:provider () in
                 let obs =
                   Obs.create ~mode ~budget ~cascade_label:cascade
                     ~provider_label:provider ~started_at:0.0

--- a/test/test_oas_worker_named_liveness_integration.ml
+++ b/test/test_oas_worker_named_liveness_integration.ml
@@ -40,134 +40,151 @@ let with_env value f =
     Cfg.reset_cache_for_test ()
   in
   match f () with
-  | x -> restore (); x
-  | exception e -> restore (); raise e
+  | x ->
+    restore ();
+    x
+  | exception e ->
+    restore ();
+    raise e
+;;
 
 (* -- env-flag bridge contract ------------------------------------- *)
 
 let test_env_off_short_circuits () =
   with_env (Some "off") (fun () ->
-      Alcotest.(check string)
-        "MASC_CASCADE_ATTEMPT_LIVENESS=off -> Off mode"
-        "off"
-        (Cfg.mode_label (Cfg.current_mode ())))
+    Alcotest.(check string)
+      "MASC_CASCADE_ATTEMPT_LIVENESS=off -> Off mode"
+      "off"
+      (Cfg.mode_label (Cfg.current_mode ())))
+;;
 
 let test_env_observe_default () =
   with_env None (fun () ->
-      Alcotest.(check string)
-        "default -> Observe (RFC §9 Phase A)"
-        "observe"
-        (Cfg.mode_label (Cfg.current_mode ())))
+    Alcotest.(check string)
+      "default -> Observe (RFC §9 Phase A)"
+      "observe"
+      (Cfg.mode_label (Cfg.current_mode ())))
+;;
 
 let test_env_enforce () =
   with_env (Some "enforce") (fun () ->
-      Alcotest.(check string)
-        "MASC_CASCADE_ATTEMPT_LIVENESS=enforce -> Enforce mode"
-        "enforce"
-        (Cfg.mode_label (Cfg.current_mode ())))
+    Alcotest.(check string)
+      "MASC_CASCADE_ATTEMPT_LIVENESS=enforce -> Enforce mode"
+      "enforce"
+      (Cfg.mode_label (Cfg.current_mode ())))
+;;
 
 (* -- end-to-end finalize emits observed_total -------------------- *)
 
 let observed_value cascade provider outcome =
   Prometheus.metric_value_or_zero
     Prometheus.metric_cascade_attempt_liveness_observed
-    ~labels:
-      [
-        ("cascade", cascade);
-        ("provider", provider);
-        ("outcome", outcome);
-      ]
+    ~labels:[ "cascade", cascade; "provider", provider; "outcome", outcome ]
     ()
+;;
 
 let test_e2e_observe_finalize_emits_observed_total () =
   with_env (Some "observe") (fun () ->
-      let cascade = "integ_observe_cascade" in
-      let provider = "integ_observe_provider" in
-      let mode = Cfg.current_mode () in
-      let budget = Cfg.budget_for_provider_id ~provider_id:provider () in
-      let obs =
-        Obs.create ~mode ~budget ~cascade_label:cascade
-          ~provider_label:provider ~started_at:0.0
-      in
-      (* Simulate: provider streamed Done before any chunk -> Success. *)
-      let wrapped = Obs.wrap_on_event obs None in
-      (match wrapped with
-       | Some f -> f Agent_sdk.Types.MessageStop
-       | None -> Alcotest.fail "Observe should wrap");
-      let before = observed_value cascade provider "success" in
-      Obs.finalize obs;
-      let after = observed_value cascade provider "success" in
-      Alcotest.(check (float 1e-6))
-        "observed_total{outcome=success} incremented"
-        (before +. 1.0) after)
+    let cascade = "integ_observe_cascade" in
+    let provider = "integ_observe_provider" in
+    let mode = Cfg.current_mode () in
+    let budget = Cfg.budget_for_provider_id ~provider_id:provider () in
+    let obs =
+      Obs.create
+        ~mode
+        ~budget
+        ~cascade_label:cascade
+        ~provider_label:provider
+        ~started_at:0.0
+    in
+    (* Simulate: provider streamed Done before any chunk -> Success. *)
+    let wrapped = Obs.wrap_on_event obs None in
+    (match wrapped with
+     | Some f -> f Agent_sdk.Types.MessageStop
+     | None -> Alcotest.fail "Observe should wrap");
+    let before = observed_value cascade provider "success" in
+    Obs.finalize obs;
+    let after = observed_value cascade provider "success" in
+    Alcotest.(check (float 1e-6))
+      "observed_total{outcome=success} incremented"
+      (before +. 1.0)
+      after)
+;;
 
 let test_e2e_off_no_observed_total () =
   with_env (Some "off") (fun () ->
-      let cascade = "integ_off_cascade" in
-      let provider = "integ_off_provider" in
-      let mode = Cfg.current_mode () in
-      let budget = Cfg.budget_for_provider_id ~provider_id:provider () in
-      let obs =
-        Obs.create ~mode ~budget ~cascade_label:cascade
-          ~provider_label:provider ~started_at:0.0
-      in
-      let before = observed_value cascade provider "wire_error" in
-      Obs.finalize obs;
-      let after = observed_value cascade provider "wire_error" in
-      Alcotest.(check (float 1e-6))
-        "Off finalize emits no observed counter" before after)
+    let cascade = "integ_off_cascade" in
+    let provider = "integ_off_provider" in
+    let mode = Cfg.current_mode () in
+    let budget = Cfg.budget_for_provider_id ~provider_id:provider () in
+    let obs =
+      Obs.create
+        ~mode
+        ~budget
+        ~cascade_label:cascade
+        ~provider_label:provider
+        ~started_at:0.0
+    in
+    let before = observed_value cascade provider "wire_error" in
+    Obs.finalize obs;
+    let after = observed_value cascade provider "wire_error" in
+    Alcotest.(check (float 1e-6)) "Off finalize emits no observed counter" before after)
+;;
 
 let test_enforce_registered_switch_kills_attempt_without_tick_clock () =
   let cascade = "integ_enforce_cascade" in
   let provider = "integ_enforce_provider" in
   let raised = ref None in
   with_env (Some "enforce") (fun () ->
-      Eio_main.run (fun _env ->
-          try
-            Eio.Switch.run (fun attempt_sw ->
-                let mode = Cfg.current_mode () in
-                let budget = Cfg.budget_for_provider_id ~provider_id:provider () in
-                let obs =
-                  Obs.create ~mode ~budget ~cascade_label:cascade
-                    ~provider_label:provider ~started_at:0.0
-                in
-                Obs.register_attempt_switch obs ~sw:attempt_sw;
-                let wrapped = Obs.wrap_on_event obs None in
-                (match wrapped with
-                 | Some f -> f (Agent_sdk.Types.SSEError "wire boom")
-                 | None -> Alcotest.fail "Enforce should wrap");
-                Eio.Fiber.yield ())
-          with
-          | Obs.Liveness_kill failure ->
-              raised := Some (Cascade_attempt_liveness.failure_kind_label failure)
-          | exn ->
-              Alcotest.failf "unexpected exception: %s" (Printexc.to_string exn)));
+    Eio_main.run (fun _env ->
+      try
+        Eio.Switch.run (fun attempt_sw ->
+          let mode = Cfg.current_mode () in
+          let budget = Cfg.budget_for_provider_id ~provider_id:provider () in
+          let obs =
+            Obs.create
+              ~mode
+              ~budget
+              ~cascade_label:cascade
+              ~provider_label:provider
+              ~started_at:0.0
+          in
+          Obs.register_attempt_switch obs ~sw:attempt_sw;
+          let wrapped = Obs.wrap_on_event obs None in
+          (match wrapped with
+           | Some f -> f (Agent_sdk.Types.SSEError "wire boom")
+           | None -> Alcotest.fail "Enforce should wrap");
+          Eio.Fiber.yield ())
+      with
+      | Obs.Liveness_kill failure ->
+        raised := Some (Cascade_attempt_liveness.failure_kind_label failure)
+      | exn -> Alcotest.failf "unexpected exception: %s" (Printexc.to_string exn)));
   Alcotest.(check (option string))
     "registered attempt switch receives enforce kill without tick fiber"
     (Some "provider_error")
     !raised
+;;
 
 let () =
-  Alcotest.run "oas_worker_named_liveness_integration"
-    [
-      ( "env flag bridge",
-        [
-          Alcotest.test_case "off short-circuits" `Quick
-            test_env_off_short_circuits;
-          Alcotest.test_case "default observe" `Quick test_env_observe_default;
-          Alcotest.test_case "enforce alias" `Quick test_env_enforce;
-        ] );
-      ( "end to end",
-        [
-          Alcotest.test_case "Observe e2e finalize emits observed_total"
-            `Quick test_e2e_observe_finalize_emits_observed_total;
-          Alcotest.test_case "Off e2e emits nothing" `Quick
-            test_e2e_off_no_observed_total;
-        ] );
-      ( "source contract",
-        [
-          Alcotest.test_case
-            "enforce kill is scoped without clock tick fiber" `Quick
-            test_enforce_registered_switch_kills_attempt_without_tick_clock;
-        ] );
+  Alcotest.run
+    "oas_worker_named_liveness_integration"
+    [ ( "env flag bridge"
+      , [ Alcotest.test_case "off short-circuits" `Quick test_env_off_short_circuits
+        ; Alcotest.test_case "default observe" `Quick test_env_observe_default
+        ; Alcotest.test_case "enforce alias" `Quick test_env_enforce
+        ] )
+    ; ( "end to end"
+      , [ Alcotest.test_case
+            "Observe e2e finalize emits observed_total"
+            `Quick
+            test_e2e_observe_finalize_emits_observed_total
+        ; Alcotest.test_case "Off e2e emits nothing" `Quick test_e2e_off_no_observed_total
+        ] )
+    ; ( "source contract"
+      , [ Alcotest.test_case
+            "enforce kill is scoped without clock tick fiber"
+            `Quick
+            test_enforce_registered_switch_kills_attempt_without_tick_clock
+        ] )
     ]
+;;


### PR DESCRIPTION
## Summary

RFC-0058 Phase 5.2b "liveness caller migration" — `Cascade_attempt_liveness_config.budget_for_provider_id`
now resolves the per-provider liveness class from the cascade.toml SSOT via
`Cascade_declarative_types.provider_of_id`. The hardcoded vendor match block
in `lib/cascade/cascade_attempt_liveness_config.ml` is **deleted**, completing
the §4 Phase 5.2b acceptance.

Companion change: new validator rule **R13** — every shipped provider must
declare `[providers.<id>.liveness] class`. Promotes the parser's missing-class
tolerance into a structural guard so the caller-side `cloud_fast` fallback can
only fire for ad-hoc integrations, not for in-tree providers.

## What changed

| File | Change |
|------|--------|
| `lib/cascade/cascade_attempt_liveness_config.ml` | hardcoded vendor match deleted; lazy declarative-config cache; `?cfg`/trailing-unit signature; `budget_of_class` mapping |
| `lib/cascade/cascade_attempt_liveness_config.mli` | doc rewrite for Phase 5.2b semantics |
| `lib/cascade_decl/cascade_declarative_validator.ml` | new `validate_provider_liveness_class` (R13) wired into `validate` |
| `lib/cascade_decl/cascade_declarative_validator.mli` | doc bump R1–R12 → R1–R13 |
| `lib/keeper/keeper_turn_driver_try_provider.ml` | caller updated for trailing `()` |
| `test/test_cascade_attempt_liveness_config.ml` | 9 new declarative-driven budget tests (replaces hardcoded-string tests) |
| `test/test_cascade_declarative_validator.ml` | `valid_toml` declares `liveness.class` on both providers; 3 new R13 cases |
| `test/test_oas_worker_named_liveness_integration.ml` | trailing `()` |

## Verification

```
$ MASC_SKIP_PIN_CHECK=1 scripts/dune-local.sh build --root . @check
(silent — pass)

$ _build/default/test/test_cascade_attempt_liveness_config.exe
Test Successful in 0.007s. 20 tests run.

$ _build/default/test/test_cascade_declarative_validator.exe
Test Successful in 0.005s. 32 tests run.

$ _build/default/test/test_oas_worker_named_liveness_integration.exe
Test Successful in 0.013s. 6 tests run.
```

`config/cascade.toml` already declares `liveness.class` on every shipped
provider (`claude_code`, `codex_cli`, `gemini_cli`, `kimi_cli`, `glm-coding`,
`ollama`), so production routing is unchanged. R13 ensures future provider
entries cannot silently regress to `cloud_fast`.

## RFC reference

- RFC-0058 §2.4 (Code never knows provider names)
- RFC-0058 §3.2.1 (provider liveness class)
- RFC-0058 §4 Phase 5.2b (`budget_for_label` replaced by `budget_for_provider_id ~cfg`; hardcoded match block deleted; parser's missing-class tolerance promoted to validator R-rule)

## Notes

- The `?cfg` named optional argument needs a trailing `unit` so OCaml can
  erase it (warning 16). All call sites updated.
- `provider_label_of_config` returns `cascade_prefix`, which is 1:1 with
  cascade.toml `[providers.<id>]` keys for the in-tree provider set — verified
  against `lib/provider_adapter.ml` before deleting the hardcoded match.
- **History note**: this branch was rebuilt cleanly on top of `origin/main`.
  An earlier interleaved `git pull --rebase` had picked up 45 duplicate main
  commits into the branch (which surfaced as the failing `ocamlformat-check`
  and a `mergeStateStatus: UNKNOWN`). The change set is identical to the
  original Phase 5.2b PR (+381/-90 across 8 files), plus the ocamlformat pass
  that CI flagged — now a single squashed commit on a clean base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
