### PR TITLE
docs(keeper_admission): K-2.c spec ↔ OCaml mapping table in .mli (iter 60)

### DIFF
--- a/lib/keeper/keeper_admission_router.mli
+++ b/lib/keeper/keeper_admission_router.mli
@@ -23,7 +23,48 @@
 
       I5 (Drift Observability): every [Dispatch] decision exposes
       [preferred_provider] and [actual_provider] (which may differ);
-      callers log this pair to the dispatch counter. *)
+      callers log this pair to the dispatch counter.
+
+    Spec ↔ OCaml mapping (KeeperAdmissionLiveness.tla, iter 60 K-2.c):
+
+      The TLA+ spec models five FSM phases for a single keeper
+      [{Idle, Waiting, Dispatched, Working, Done}].  This OCaml
+      module's [type decision] is the result of one [schedule] call,
+      not an FSM — three discrete outcomes, not five.  The mapping
+      is therefore "spec transition" ↔ "OCaml call result", spread
+      across one [schedule] call and one paired [release_bucket]
+      callback.  Reader who expects 5↔5 will be confused; the
+      correspondence is:
+
+        spec phase             | OCaml call / outcome
+        -----------------------+---------------------------------------------
+        Idle                   | (pre-state; no admission call yet)
+        Idle -> Waiting        | caller invokes [schedule]
+        Waiting -> Dispatched  | [schedule] returns [Dispatch _]
+        Waiting -> Waiting     | [schedule] returns [Wait] (caller enqueues)
+        Waiting -> Surface     | [schedule] returns [Surface _] (operator alert)
+        Dispatched -> Working  | (caller's LLM call; opaque to this module)
+        Working -> Done        | caller invokes [release_bucket]
+
+      The five spec states are the caller's *external* FSM; this
+      module is a stateless oracle that drives one transition per
+      call.  K-2.a (HIGH, not yet applied) is the proposal to wrap
+      the [Dispatch -> release_bucket] window in
+      [Eio.Switch.on_release] so that a cancelled or panicking
+      caller cannot leak the bucket in flight; without that, the
+      spec's [RateRespect] invariant
+      ([in_flight[p] <= Capacity[p]]) is only enforced on the
+      happy path.
+
+      Full audit and the four follow-up risks (K-2.a..d):
+      [docs/tla-audit/kal-k1-admission-spec-ocaml-mapping-
+      2026-05-12.md] (iter 56 #14895).
+
+      Note: iter 56 audit memo line ~80 cited the OCaml outcome
+      as a "4-variant policy enum"; that was speculative.  The
+      verified count is three: [Dispatch | Wait | Surface].  A
+      follow-up amendment of the audit memo will correct that line
+      after iter 60 lands (gh issue tracked as K-2.c.1). *)
 
 (** {1 Decision type} *)
 

--- a/lib/keeper/keeper_admission_router.mli
+++ b/lib/keeper/keeper_admission_router.mli
@@ -32,7 +32,7 @@
       module's [type decision] is the result of one [schedule] call,
       not an FSM — three discrete outcomes, not five.  The mapping
       is therefore "spec transition" ↔ "OCaml call result", spread
-      across one [schedule] call and one paired [release_bucket]
+      across one [schedule] call and one paired [Keeper_admission_runtime.release_bucket]
       callback.  Reader who expects 5↔5 will be confused; the
       correspondence is:
 
@@ -44,7 +44,7 @@
         Waiting -> Waiting     | [schedule] returns [Wait] (caller enqueues)
         Waiting -> Surface     | [schedule] returns [Surface _] (operator alert)
         Dispatched -> Working  | (caller's LLM call; opaque to this module)
-        Working -> Done        | caller invokes [release_bucket]
+        Working -> Done        | caller invokes [Keeper_admission_runtime.release_bucket]
 
       The five spec states are the caller's *external* FSM; this
       module is a stateless oracle that drives one transition per


### PR DESCRIPTION
## Finding (Iteration 60, K-2.c — KAL spec ↔ OCaml mapping table in .mli)

**File**: `lib/keeper/keeper_admission_router.mli` (+42/-1 LOC)
**Aspect**: explicit mapping table from KAL spec phases to admission router outcomes; corrects iter 56 audit's speculative variant count
**Risk**: LOW (docstring-only, no semantics change, dune build untouched)
**Workaround signature**: N/A — 12th honest-doc datapoint.

## 순서도

```mermaid
flowchart TD
  A[iter 56 #14895 audit: K-2.c LOW .mli mapping doc] --> B{iter 54 #14886 merged?}
  B -- yes --> C[ocamlformat-check pressure cleared]
  C --> D[Verify actual OCaml type — type decision]
  D --> E{Variant count}
  E -- iter 56 audit claimed 4 --> F[FACTUALLY WRONG]
  E -- rg verified --> G[3 - Dispatch | Wait | Surface]
  G --> H[Add mapping table with correct count]
  H --> I[Spec FSM phases ≠ OCaml call result]
  I --> J[Map spec transitions ↔ call + release_bucket events]
```

## What was added

A `Spec ↔ OCaml mapping (KeeperAdmissionLiveness.tla, iter 60 K-2.c)` block sits inside the existing top docstring of `keeper_admission_router.mli`, right after the `I5 (Drift Observability)` invariant note and before the `(** {1 Decision type} *)` section header:

```ocaml
    Spec ↔ OCaml mapping (KeeperAdmissionLiveness.tla, iter 60 K-2.c):

      The TLA+ spec models five FSM phases for a single keeper
      [{Idle, Waiting, Dispatched, Working, Done}].  This OCaml
      module's [type decision] is the result of one [schedule] call,
      not an FSM — three discrete outcomes, not five.  The mapping
      is therefore "spec transition" ↔ "OCaml call result", spread
      across one [schedule] call and one paired [release_bucket]
      callback.  Reader who expects 5↔5 will be confused; the
      correspondence is:

        spec phase             | OCaml call / outcome
        -----------------------+---------------------------------------------
        Idle                   | (pre-state; no admission call yet)
        Idle -> Waiting        | caller invokes [schedule]
        Waiting -> Dispatched  | [schedule] returns [Dispatch _]
        Waiting -> Waiting     | [schedule] returns [Wait] (caller enqueues)
        Waiting -> Surface     | [schedule] returns [Surface _] (operator alert)
        Dispatched -> Working  | (caller's LLM call; opaque to this module)
        Working -> Done        | caller invokes [release_bucket]
```

The block also restates K-2.a (HIGH) in context — the `Dispatched → Working → Done` arc is exactly the window where missing `Eio.Switch.on_release` lets a cancelled caller leak `in_flight[p]`, breaking `RateRespect` in production-only (TLC can't see it because TLC's `CompleteWork` is unconditional).

## Correction of iter 56 audit memo

iter 56 audit (#14895 Draft) claimed in K-2.c's description "5-state spec ↔ **4-variant** OCaml policy enum". Verification via `rg` over `type decision` in `keeper_admission_router.mli`:

```ocaml
type decision =
  | Dispatch of { candidate; drift }
  | Wait
  | Surface of surface_reason
```

**3 variants, not 4**.  iter 56 audit was speculative — exactly the pattern memory `feedback_adversarial_reviewer_fabricates_line_refs.md` warned against (line/field/metric fabrication). Caught here by reading the actual `.mli` before writing the mapping.

The mapping block in this PR uses the verified count. A follow-up amendment of #14895 (tracked as K-2.c.1) will correct the audit memo line. Sequencing this way avoids overwriting the still-Draft #14895 while the truth lives in main via this `.mli`.

## Why this matters

Without the mapping block, a reader landing on either side of the boundary has to read the other to learn what the correspondence is. Three concrete failure modes:

1. **Spec reader expects 5 OCaml states**. The five spec phases look symmetric; without the block, the reader searches the `.mli` for matching constructors and finds three. Two interpretations follow: (a) the spec is over-modeled and the OCaml is "missing" `Idle/Working/Done`, or (b) there's a hidden second module owning the other phases. Both wrong. The truth is the spec is an FSM and the OCaml is a stateless oracle.

2. **.mli reader thinks `Wait` is final**. Without the block linking `Wait` to spec's `Waiting -> Waiting` self-loop and the caller's enqueue obligation, `Wait` looks like a terminal failure rather than a "try again after WFQ wake".

3. **K-2.a HIGH stays buried**. The `Dispatched → Working → Done` arc is the most safety-critical thing the spec models and the most fragile thing the OCaml stack ships. Without the explicit map, the link between `RateRespect` and `release_bucket` is hidden.

## Pipeline status

| Step | iter | PR | Action | Status |
|------|------|----|--------|--------|
| 1 audit | 56 | #14895 | K-1 mapping snapshot, K-2.{a..d} ranked | Draft |
| 2 LOW dormancy | 57 | #14896 | K-2.d preamble Runtime status block | ✅ MERGED |
| **3 LOW mapping** | **60** | **this PR** | **K-2.c .mli mapping table** | Draft |
| 4 audit cleanup | TBD | K-2.c.1 | correct iter 56 memo "4-variant" → "3-variant" | gated on #14895 merge or supersede |
| 5 MED SF | gated | TBD | K-2.b bounded-retry / SF emulation | runtime change — user approval |
| 6 HIGH leak guard | gated | TBD | K-2.a Eio.Switch.on_release | runtime change — user approval |

K-2.d (#14896) merged earlier today; this is the second K-2 candidate to land. K-2.a/K-2.b remain deferred per the audit memo's user-approval rule.

## Verification

```bash
$ bash scripts/audit-tla-annotation-drift.sh --baseline ... --check-cross-spec
tla-annotation-drift summary: 20 constructors checked across 4 type/set pairs,
  0 new drift(s), 1 baseline-known drift(s); 3 cross-spec set(s) checked,
  0 cross-spec drifts

$ bash scripts/audit-tla-phase-count.sh
phase-count audit clean: SSOT=13, no unqualified mismatches.

$ git diff --stat
lib/keeper/keeper_admission_router.mli | 43 +++++++++++++++++++++++++++++++++-
1 file changed, 42 insertions(+), 1 deletion(-)
```

dune build NOT re-run — 11-datapoint honest-doc precedent (iter 27/35/37/39/48/50/51/53/54/57/59). This is the **12th honest-doc datapoint** and the first to bridge the boundary in the direction TLA+ → OCaml (the previous 11 corrected the spec to match OCaml; this PR corrects the OCaml docstring to map back to the spec).

## RFC 참조

RFC-WAIVED — .mli docstring only. K-2.a/K-2.b runtime changes require explicit user approval per memory `reference_masc_mcp_integrated_improvement_design_audit.md` "high-stakes runtime 변경 전 사용자 승인 필수".

## 진행 추적

다음 iteration 시작점:
1. **R-H-1.g cleanup** (1-line baseline cleanup, blocked on iter 55 #14891 merge)
2. **R-D-2.a + R-D-1.a bundle** (MID ~150-300 LOC, biggest pending)
3. **K-2.c.1** (audit memo "4-variant" correction — gated on #14895 merge or supersede)
4. **새 spec entry** (KOAS / KWP / KAQ / KH untouched)
5. **R-D-1.d** (ppx_tla prefix prerequisite for R-D-1.c chain)
6. **R-B-2.a/b** (KTC RoutingStart + TLC dry-run)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
