### PR TITLE
refactor(tool_misc_admin): Enforcement_status closed sum + typed rows (T32, 7 sites)

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -171,6 +171,7 @@
   tool_catalog_surfaces
   tool_misc_transport
   tool_misc_admin
+  enforcement_status
   tool_misc_web_search
   tool_misc_web_fetch
   meta_cognition_types

--- a/lib/enforcement_status.ml
+++ b/lib/enforcement_status.ml
@@ -1,0 +1,10 @@
+type t =
+  | Conditional
+  | Enforced
+  | Advisory_only
+
+let to_label = function
+  | Conditional -> "conditional"
+  | Enforced -> "enforced"
+  | Advisory_only -> "advisory_only"
+;;

--- a/lib/enforcement_status.mli
+++ b/lib/enforcement_status.mli
@@ -1,0 +1,26 @@
+(** Enforcement_status — closed sum for the [status] field of admin
+    surface-enforcement rows emitted by {!Tool_misc_admin}'s
+    [enforcement_summary_json].
+
+    Each value reflects the runtime relationship between a configured
+    policy surface and the dispatcher that consumes it:
+
+    {ul
+    {- [Conditional]: enforced only under a runtime gate (e.g. room
+       auth enabled).}
+    {- [Enforced]: unconditionally applied at the relevant dispatch
+       site.}
+    {- [Advisory_only]: stored in configuration but not wired into a
+       runtime check (informational; deprecation-track candidate).}}
+
+    Adding a new enforcement tier now forces the [to_label] match arm
+    to be added, preventing silent vocabulary drift in the surface
+    inventory wire format. *)
+
+type t =
+  | Conditional
+  | Enforced
+  | Advisory_only
+
+val to_label : t -> string
+(** Wire-format label, byte-identical to the prior inline literals. *)

--- a/lib/tool_misc_admin.ml
+++ b/lib/tool_misc_admin.ml
@@ -167,66 +167,71 @@ let tool_inventory_json _ctx ~include_hidden ~include_deprecated =
        Capability_registry.surface_snapshot_json Config.raw_all_tool_schemas);
     ]
 
-let enforcement_summary_json () =
-  `List
+(** Single row in the surface-enforcement inventory. *)
+type enforcement_row = {
+  surface : string;
+  status : Enforcement_status.t;
+  reason : string;
+}
+
+let enforcement_row_to_yojson (r : enforcement_row) : Yojson.Safe.t =
+  `Assoc
     [
-      `Assoc
-        [
-          ("surface", `String "room.auth.permission_map");
-          ("status", `String "conditional");
-          ("reason",
-           `String
-             "Auth permission checks are enforced only when room auth is enabled.");
-        ];
-      `Assoc
-        [
-          ("surface", `String "tool_catalog.visibility");
-          ("status", `String "enforced");
-          ("reason",
-           `String
-             "Hidden tools are removed from default discovery and may be direct-call blocked.");
-        ];
-      `Assoc
-        [
-          ("surface", `String "keeper.eval_gate.allowed_tools");
-          ("status", `String "enforced");
-          ("reason",
-           `String
-             "Keeper uses Eval_gate allow/deny lists at tool-call time.");
-        ];
-      `Assoc
-        [
-          ("surface", `String "unit.policy.kill_switch");
-          ("status", `String "enforced");
-          ("reason",
-           `String
-             "Command-plane assignment blocks operations targeting units with kill-switch enabled.");
-        ];
-      `Assoc
-        [
-          ("surface", `String "unit.policy.frozen");
-          ("status", `String "enforced");
-          ("reason",
-           `String
-             "Command-plane assignment blocks operations targeting frozen units.");
-        ];
-      `Assoc
-        [
-          ("surface", `String "unit.policy.tool_allowlist");
-          ("status", `String "advisory_only");
-          ("reason",
-           `String
-             "Stored in CPv2 topology/policy JSON but not wired into runtime tool dispatch on main.");
-        ];
-      `Assoc
-        [
-          ("surface", `String "unit.policy.model_allowlist");
-          ("status", `String "advisory_only");
-          ("reason",
-           `String
-             "Stored in CPv2 topology/policy JSON but not wired into runtime model selection on main.");
-        ];
+      ("surface", `String r.surface);
+      ("status", `String (Enforcement_status.to_label r.status));
+      ("reason", `String r.reason);
     ]
+;;
+
+let enforcement_summary_rows : enforcement_row list =
+  [
+    {
+      surface = "room.auth.permission_map";
+      status = Conditional;
+      reason =
+        "Auth permission checks are enforced only when room auth is enabled.";
+    };
+    {
+      surface = "tool_catalog.visibility";
+      status = Enforced;
+      reason =
+        "Hidden tools are removed from default discovery and may be direct-call blocked.";
+    };
+    {
+      surface = "keeper.eval_gate.allowed_tools";
+      status = Enforced;
+      reason = "Keeper uses Eval_gate allow/deny lists at tool-call time.";
+    };
+    {
+      surface = "unit.policy.kill_switch";
+      status = Enforced;
+      reason =
+        "Command-plane assignment blocks operations targeting units with kill-switch enabled.";
+    };
+    {
+      surface = "unit.policy.frozen";
+      status = Enforced;
+      reason =
+        "Command-plane assignment blocks operations targeting frozen units.";
+    };
+    {
+      surface = "unit.policy.tool_allowlist";
+      status = Advisory_only;
+      reason =
+        "Stored in CPv2 topology/policy JSON but not wired into runtime tool dispatch on main.";
+    };
+    {
+      surface = "unit.policy.model_allowlist";
+      status = Advisory_only;
+      reason =
+        "Stored in CPv2 topology/policy JSON but not wired into runtime model selection on main.";
+    };
+  ]
+;;
+
+let enforcement_summary_json () =
+  `List (List.map enforcement_row_to_yojson enforcement_summary_rows)
+;;
 
 (* ================================================================ *)
 (* Handlers                                                         *)


### PR DESCRIPTION
## Scope

T31 sibling. \`tool_misc_admin.ml\` 의 \`enforcement_summary_json\` 가
7 inline rows 를 \`(surface, status, reason)\` triple shape 으로 중복.
status 가 raw \`\`String\`로 직접 표현되어 새 policy tier 가 wire 에
silently 추가 가능 — typed gate 부재.

## 새 모듈

\`lib/enforcement_status.ml(.mli)\`:

\`\`\`ocaml
type t =
  | Conditional        (* runtime-gated enforcement *)
  | Enforced           (* unconditional dispatcher check *)
  | Advisory_only      (* configured but not wired — deprecation track *)

val to_label : t -> string
\`\`\`

## File-local 정리

\`tool_misc_admin.ml\` 안에:

\`\`\`ocaml
type enforcement_row = {
  surface : string;
  status : Enforcement_status.t;
  reason : string;
}

let enforcement_row_to_yojson r : Yojson.Safe.t = `Assoc [...]

let enforcement_summary_rows : enforcement_row list = [
  { surface = \"room.auth.permission_map\"; status = Conditional;
    reason = \"...\" };
  { surface = \"tool_catalog.visibility\"; status = Enforced;
    reason = \"...\" };
  ... (5 more)
]

let enforcement_summary_json () =
  `List (List.map enforcement_row_to_yojson enforcement_summary_rows)
\`\`\`

## Diff stat

3 files, +99 / -58 (record literal 이 \`Assoc shape 중복보다 조금 더 길지만,
새 행 추가 시 shape divergence 차단).

## Wire format

byte-identical:
- \`to_label\` Conditional=\"conditional\" / Enforced=\"enforced\" / Advisory_only=\"advisory_only\"
- Field order surface → status → reason 유지

## 컴파일러 강제

새 policy tier 추가 시:
1. \`Enforcement_status.t\` variant 확장 (1 곳)
2. \`to_label\` arm 추가 (1 곳)

exhaustiveness check 가 silent vocabulary drift 차단.

새 row 추가 시:
- \`{ surface; status; reason }\` 필드 강제 — \"reason\" 누락 등 shape
  divergence 컴파일 타임 차단.

## Build

\`MASC_SKIP_PIN_CHECK=1 bash ./scripts/dune-local.sh build --root . @lib/check\` green.

## Anti-pattern signature closed

- Workaround #2 (verb vocabulary expansion without typed gate, T31 와 동일 shape)
- Shape duplication across 7 rows (typed record 가 inline \`Assoc 중복 대체)

## Cross-reference

- T31 #14902 — Plan_action_outcome (sibling verb-status closed sum)
- T27 #14876, T28+T29 #14882, T30 #14892 — envelope SSOT family
- CLAUDE.md §워크어라운드 거부 기준 #2

## 후속 후보 (T33+)

verb status 사이트 남은 영역:
- \`lib/tool_control.ml\` paused/running/initializing (3 sites) — keeper lifecycle, 다른 file Keeper_state 와 의미 audit 필요
- \`lib/tool_keeper.ml:484\` queued (1 site) — Tier B (pretty_to_string 등)
- single-site verb sites (operator/control \"removed\", server/* \"initializing\"/\"active\") — typed sum 만들 가치 낮음

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>