### PR TITLE
refactor(keeper_registry): RFC-0072 Phase 2+3 — cascade dispatch via resolver

### DIFF
--- a/lib/keeper/keeper_registry.ml
+++ b/lib/keeper/keeper_registry.ml
@@ -1364,47 +1364,28 @@ let mark_turn_measurement ~base_path name =
   if !changed then broadcast_composite_changed ~name ~ts_unix:now
 ;;
 
+(* RFC-0072 Phase 3: collapse 25-pair matrix onto [resolve_cascade_transition]
+   (PR #14903).  The transition matrix is now a single source of truth in the
+   resolver — this validator becomes a thin compatibility shim that preserves
+   the prior [Invalid_argument]-raising contract for the test surface
+   ([test_keeper_sub_fsm_guards.ml] uses [capture_invalid_arg]).  Adding a new
+   [cascade_state] variant only requires updating [resolve_cascade_transition];
+   this function reflects the change automatically.
+
+   The typed [cascade_transition_spec_violation] tag is included in the error
+   message for diagnostic clarity, matching the pattern adopted by
+   [set_turn_cascade_state] in Phase 2. *)
 let validate_cascade_transition ~from ~to_ =
-  let (_ : packed_cascade_state) = from in
-  let (_ : packed_cascade_state) = to_ in
-  match from, to_ with
-  | Packed Cascade_idle, Packed Cascade_idle -> ()
-  | Packed Cascade_idle, Packed Cascade_selecting -> () (* via set_turn_cascade_state *)
-  | Packed Cascade_selecting, Packed Cascade_idle ->
-    () (* via prepare_turn_retry_after_compaction *)
-  | Packed Cascade_selecting, Packed Cascade_selecting -> ()
-  | Packed Cascade_selecting, Packed Cascade_trying -> () (* via set_turn_cascade_state *)
-  | Packed Cascade_trying, Packed Cascade_idle ->
-    () (* via prepare_turn_retry_after_compaction *)
-  | Packed Cascade_trying, Packed Cascade_selecting ->
-    () (* via set_turn_cascade_state: retry re-entry *)
-  | Packed Cascade_trying, Packed Cascade_trying -> ()
-  | Packed Cascade_trying, Packed Cascade_done -> () (* via set_turn_cascade_state *)
-  | Packed Cascade_trying, Packed Cascade_exhausted -> () (* via set_turn_cascade_state *)
-  | Packed Cascade_done, Packed Cascade_idle ->
-    () (* via prepare_turn_retry_after_compaction *)
-  | Packed Cascade_done, Packed Cascade_selecting ->
-    () (* via prepare_turn_retry_after_compaction *)
-  | Packed Cascade_done, Packed Cascade_trying ->
-    () (* via prepare_turn_retry_after_compaction *)
-  | Packed Cascade_done, Packed Cascade_done -> ()
-  | Packed Cascade_exhausted, Packed Cascade_idle ->
-    () (* via prepare_turn_retry_after_compaction *)
-  | Packed Cascade_exhausted, Packed Cascade_selecting ->
-    () (* via prepare_turn_retry_after_compaction *)
-  | Packed Cascade_exhausted, Packed Cascade_trying ->
-    () (* via prepare_turn_retry_after_compaction *)
-  | Packed Cascade_exhausted, Packed Cascade_exhausted -> ()
-  | ( Packed Cascade_idle
-    , (Packed Cascade_trying | Packed Cascade_done | Packed Cascade_exhausted) )
-  | Packed Cascade_selecting, (Packed Cascade_done | Packed Cascade_exhausted)
-  | Packed Cascade_done, Packed Cascade_exhausted
-  | Packed Cascade_exhausted, Packed Cascade_done ->
+  match resolve_cascade_transition ~from ~target:to_ with
+  | Resolved_idempotent | Resolved_transition _ -> ()
+  | Resolved_violation v ->
     invalid_arg
       (Printf.sprintf
-         "validate_cascade_transition: invalid transition %s -> %s"
+         "validate_cascade_transition: invalid transition %s -> %s \
+          (spec_violation=%s)"
          (packed_cascade_state_label from)
-         (packed_cascade_state_label to_))
+         (packed_cascade_state_label to_)
+         (cascade_transition_spec_violation_to_tag v))
 ;;
 
 let validate_turn_phase_transition ~from ~to_ =
@@ -1533,15 +1514,44 @@ let set_turn_decision_stage ~base_path name (decision_stage : decision_stage_act
 ;;
 
 let set_turn_cascade_state ~base_path name (cascade_state : packed_cascade_state) =
+  (* RFC-0072 Phase 2: dispatch via [resolve_cascade_transition] (PR #14903)
+     instead of the standalone [validate_cascade_transition].  Behavior
+     deltas vs the pre-RFC-0072 path:
+
+     - Idempotent self-loop (e.g. Selecting -> Selecting) no longer flips
+       [changed] or emits a broadcast.  The prior matrix in
+       [validate_cascade_transition] admitted self-loops but the setter
+       unconditionally set [changed := true], producing spurious
+       [broadcast_composite_changed] events.  This is a small efficiency
+       fix bundled with the Phase-2 wiring.
+
+     - Forbidden transitions (7 pairs) still raise [Invalid_argument] —
+       the typed [cascade_transition_spec_violation] tag is folded into
+       the message for diagnostic clarity.  A future RFC-0072 phase may
+       swap to a typed exception variant.
+
+     [validate_turn_phase_transition] is preserved here because the
+     turn_phase axis remains runtime-validated; Phase 4 of RFC-0072 will
+     extend the resolver pattern to that axis. *)
   let changed = ref false in
   let now = Time_compat.now () in
   update_entry ~base_path name (fun e ->
     update_current_turn e (fun obs ->
       let new_turn_phase = turn_phase_of_cascade_state cascade_state in
-      validate_cascade_transition ~from:obs.cascade_state ~to_:cascade_state;
-      validate_turn_phase_transition ~from:obs.turn_phase ~to_:new_turn_phase;
-      changed := true;
-      { obs with cascade_state; turn_phase = new_turn_phase }));
+      match resolve_cascade_transition ~from:obs.cascade_state ~target:cascade_state with
+      | Resolved_idempotent -> obs
+      | Resolved_transition _ ->
+        validate_turn_phase_transition ~from:obs.turn_phase ~to_:new_turn_phase;
+        changed := true;
+        { obs with cascade_state; turn_phase = new_turn_phase }
+      | Resolved_violation v ->
+        invalid_arg
+          (Printf.sprintf
+             "set_turn_cascade_state: forbidden transition %s -> %s \
+              (spec_violation=%s)"
+             (packed_cascade_state_label obs.cascade_state)
+             (packed_cascade_state_label cascade_state)
+             (cascade_transition_spec_violation_to_tag v))));
   if !changed then broadcast_composite_changed ~name ~ts_unix:now
 ;;
 


### PR DESCRIPTION
## What

RFC-0072 **Phase 2 + Phase 3** combined: route both `set_turn_cascade_state` (Phase 2) and `validate_cascade_transition` (Phase 3) through the `resolve_cascade_transition` helper introduced in PR #14903. The 25-arm transition matrix collapses to a single source of truth (the resolver).

| Before | After |
|---|---|
| `set_turn_cascade_state` called `validate_cascade_transition` directly | calls `resolve_cascade_transition`, dispatches on `cascade_resolve_outcome` |
| `validate_cascade_transition` body = 25-arm match (18 valid → `()`, 7 forbidden → `invalid_arg`) | thin shim calling `resolve_cascade_transition`, raising on `Resolved_violation v` only |
| Idempotent self-loop unconditionally set `changed := true` → spurious broadcast | `Resolved_idempotent` returns unchanged `obs`, no broadcast |
| Error message string-formatted | Message includes typed `cascade_transition_spec_violation` tag (`spec_violation=<tag>`) |

## Behavior deltas

### 1. Spurious-broadcast efficiency fix

Pre-PR `set_turn_cascade_state` called `validate_cascade_transition` (which `()`-returned on self-loops) and *then* unconditionally `changed := true`. Any `Cascade_X -> Cascade_X` call (rare but admitted) emitted `broadcast_composite_changed`. The matrix admitted self-loops only as a documentation device; the setter treated them as state advances. Phase 2 now matches `Resolved_idempotent -> obs` and skips the changed-flip.

### 2. Forbidden-pair message format

Both call sites now include the typed tag:
```
set_turn_cascade_state: forbidden transition Cascade_idle -> Cascade_trying (spec_violation=idle->trying)
validate_cascade_transition: invalid transition Cascade_idle -> Cascade_trying (spec_violation=idle->trying)
```

The existing `test_invalid_cascade_transitions` and `test_cascade_message_includes_labels` in `test_keeper_sub_fsm_guards.ml` use `capture_invalid_arg` + `assert_msg_contains` against the function-name and label needles, all of which are preserved.

### 3. Transition matrix has one SoT

Adding a new `cascade_state` variant only requires editing `resolve_cascade_transition` (PR #14903). Both `validate_*` and `set_turn_*` automatically reflect the change because they delegate to the resolver. The compiler triggers Warning 8 at the resolver if a new variant is omitted.

## R-1 status

RFC-0072 §7 R-1 ("cascade axis has 0 `invalid_arg` sites in `lib/`") is **NOT YET satisfied** by this PR. Two `invalid_arg` call sites remain:

- `lib/keeper/keeper_registry.ml:1382` — `validate_cascade_transition` shim
- `lib/keeper/keeper_registry.ml:1548` — `set_turn_cascade_state` violation path

Both now carry typed `cascade_transition_spec_violation` payload in their message, which is the structural prerequisite for migrating to a typed exception variant in a future phase. This PR closes the spec-violation diagnostic gap and routes all cascade transitions through the typed resolver; the exception-type swap (`Invalid_argument` → `Cascade_transition_violation of spec_violation`) is deferred to keep the test contract intact while the typed-error infrastructure stabilises.

## Why Phase 2 + Phase 3 folded into one PR

| Workaround Bar #3 check | Detail |
|---|---|
| N-of-M? | **No, justified fold** |
| Same surface? | Yes — `cascade_state` axis only |
| Same fix shape? | Yes — both functions delegate to `resolve_cascade_transition` |
| Same SoT? | Yes — the resolver |

Splitting Phase 2 from Phase 3 would temporarily leave `validate_cascade_transition`'s 25-arm matrix in place while `set_turn_cascade_state` already routed via the resolver — *two parallel sources of truth for the matrix*. That is exactly the anti-pattern the RFC's "single SoT" goal targets. Folding into one PR ensures the matrix unification happens atomically.

## What's NOT changed in this PR

- `validate_turn_phase_transition` — Phase 4 of RFC-0072 will extend the resolver pattern to that axis (separate PR, larger surface: 8+ variants × 60+ pairs).
- The `Invalid_argument` exception type — preserved for backward compatibility; future phase introduces typed exception variant.
- Test surface — `test_keeper_sub_fsm_guards.ml` cascade tests unchanged; message-keyword assertions pass against the new tagged format.

## Diff

| File | + | - | Net |
|---|---|---|---|
| `lib/keeper/keeper_registry.ml` | 51 | 41 | +10 |

Single-file change. Net +10 LOC despite combining 2 RFC phases — because the 25-arm matrix collapses substantially (compare to the +225 LOC Phase 1 addition; this phase is a net-saving consolidation).

## Self-check (Workaround Rejection Bar)

| # | Check | Result |
|---|---|---|
| 1 | telemetry-as-fix? | no — typed error, not a counter |
| 2 | string classifier? | no — typed GADT outcome + typed violation sum |
| 3 | N-of-M? | Phase 2 + 3 folded **with justification** — same surface, same fix shape, same SoT (resolver). Splitting would yield 2 parallel matrix copies temporarily. |
| 4 | catch-all added? | no |
| 5 | cap/cooldown/dedup? | no |
| 6 | test backdoor? | no — message-keyword check preserved |
| 7 | typo N sites? | no |

## References

- **RFC-0072** (`docs/rfc/RFC-0072-keeper-sub-fsm-transitions-typed.md`)
- **PR #14903**: Phase 1 — `Cascade_transition` GADT + `resolve_cascade_transition`
- **PR #14887**: decision-axis input refinement precedent
- **PR #14893**: decision-axis validator → compile-time fixture precedent

🤖 Generated with [Claude Code](https://claude.com/claude-code)
