### PR TITLE
fix(keeper_registry): restore exhaustiveness on validate_decision_transition (unblocks main test builds)

### DIFF
--- a/lib/keeper/keeper_registry.ml
+++ b/lib/keeper/keeper_registry.ml
@@ -396,32 +396,43 @@ module Decision_transition = struct
 end
 
 (* Living-matrix documentation of the decision-stage transition relation.
-   Forbidden [<active>_to_undecided] pairs are unrepresentable through the
-   [decision_stage_active] target type (PR #14887 made [set_turn_decision_stage]
-   reject them at compile time; this validator now mirrors that invariant
-   at the test surface).  Each branch is the explicit type-level acknowledgement
-   that the pair is admitted by the spec — adding a new [decision_stage] or
-   [decision_stage_active] constructor will fail Warning 8 here, forcing
-   the maintainer to decide whether the new variant participates. *)
+   Forbidden [<active>_to_undecided] pairs are unrepresentable through
+   the [decision_stage_active] target type (PR #14887 made
+   [set_turn_decision_stage] reject them at compile time; this
+   validator mirrors that invariant at the test surface).
+
+   We pattern-match on the raw [decision_stage] / [decision_stage_active]
+   variants — *not* on the packed GADT witnesses returned by
+   [stage_to_witness] / [decision_stage_active_to_packed].  The packed
+   wrappers existentially quantify away the witness phantom, after
+   which the compiler can no longer see that [decision_stage_active]
+   has no [Decision_active_undecided] constructor; Warning 8 then
+   spuriously demands the unreachable [(Packed Decision_undecided,
+   Packed Decision_undecided)] case (regression introduced by #14893).
+
+   By matching directly on the source variants the exhaustiveness
+   check ranges over the *actual* input domain: 4 [decision_stage]
+   sources × 3 [decision_stage_active] targets = 12 admitted pairs,
+   no false-positive cases.  Adding a new [decision_stage] or
+   [decision_stage_active] constructor still fails Warning 8 here,
+   preserving the original tripwire intent. *)
 let validate_decision_transition
     ~(from : decision_stage)
     ~(to_ : decision_stage_active)
   =
-  let from_packed = stage_to_witness from in
-  let to_packed = decision_stage_active_to_packed to_ in
-  match from_packed, to_packed with
-  | Packed Decision_undecided, Packed Decision_guard_ok -> ()
-  | Packed Decision_undecided, Packed Decision_gate_rejected -> ()
-  | Packed Decision_undecided, Packed Decision_tool_policy_selected -> ()
-  | Packed Decision_guard_ok, Packed Decision_guard_ok -> ()
-  | Packed Decision_guard_ok, Packed Decision_gate_rejected -> ()
-  | Packed Decision_guard_ok, Packed Decision_tool_policy_selected -> ()
-  | Packed Decision_gate_rejected, Packed Decision_gate_rejected -> ()
-  | Packed Decision_gate_rejected, Packed Decision_guard_ok -> ()
-  | Packed Decision_gate_rejected, Packed Decision_tool_policy_selected -> ()
-  | Packed Decision_tool_policy_selected, Packed Decision_tool_policy_selected -> ()
-  | Packed Decision_tool_policy_selected, Packed Decision_guard_ok -> ()
-  | Packed Decision_tool_policy_selected, Packed Decision_gate_rejected -> ()
+  match from, to_ with
+  | Decision_undecided, Decision_active_guard_ok -> ()
+  | Decision_undecided, Decision_active_gate_rejected -> ()
+  | Decision_undecided, Decision_active_tool_policy_selected -> ()
+  | Decision_guard_ok, Decision_active_guard_ok -> ()
+  | Decision_guard_ok, Decision_active_gate_rejected -> ()
+  | Decision_guard_ok, Decision_active_tool_policy_selected -> ()
+  | Decision_gate_rejected, Decision_active_guard_ok -> ()
+  | Decision_gate_rejected, Decision_active_gate_rejected -> ()
+  | Decision_gate_rejected, Decision_active_tool_policy_selected -> ()
+  | Decision_tool_policy_selected, Decision_active_guard_ok -> ()
+  | Decision_tool_policy_selected, Decision_active_gate_rejected -> ()
+  | Decision_tool_policy_selected, Decision_active_tool_policy_selected -> ()
 ;;
 
 type cascade_state =


### PR DESCRIPTION
## Summary

**Main-blocker fix.** PR #14893 introduced `validate_decision_transition` as a Warning-8 tripwire over admitted `(decision_stage * decision_stage_active)` pairs, but pattern-matched through `stage_to_witness` / `decision_stage_active_to_packed`, which existentially quantify the GADT witness phantom away.

After the `Packed : 'a witness -> packed` wrap the compiler can no longer see that `decision_stage_active` omits the `Decision_active_undecided` constructor; Warning 8 then spuriously demands the unreachable case

```ocaml
| Packed Decision_undecided, Packed Decision_undecided -> ()
```

which under the test-build's warn-error promotion turns into a fatal compile error. **Every test binary that links the main `masc_mcp` library currently fails to produce a `.exe` on origin/main** — verified locally with `test_misc_coverage.exe` (silently absent).

## Fix

Pattern-match on the raw `decision_stage` / `decision_stage_active` variants directly. The exhaustiveness check now ranges over the **actual** input domain (4 `decision_stage` sources × 3 `decision_stage_active` targets = 12 admitted pairs, no false-positive case). Adding a new `decision_stage` or `decision_stage_active` constructor still fails Warning 8 here, preserving:

1. The original tripwire intent of #14893
2. The type-level "`<active>_to_undecided` unrepresentable" guarantee from #14887

The `stage_to_witness` / `decision_stage_active_to_packed` helpers are still used elsewhere (`keeper_registry.ml:1533` for stored-state packed storage, `test_keeper_sub_fsm_guards.ml:149` for diagnostic label printing) so they remain exported.

## Why this matters (general principle)

This is a textbook **type+arm shape** miss documented in our local memory `feedback_exhaustive_match_sweep_type_plus_arm.md`. The author's intent was correct (make forbidden pairs *unrepresentable*), but the GADT pack wrapper inserted between the input value and the match destroyed the type-narrowing the compiler needs to verify exhaustiveness. The lesson: when type-level enforcement of a partial relation is the goal, **don't existentially quantify the witness immediately before pattern-matching it** — match on the narrower input variant directly.

## Test plan

- [x] `dune build --root . @check`: clean (was: warning 8 fatal in test scope)
- [x] `dune build --root . test/test_misc_coverage.exe`: builds (was: silently fails to produce `.exe`)
- [x] `_build/default/test/test_misc_coverage.exe`: **32/32 PASS**
- [x] `_build/default/test/test_keeper_sub_fsm_guards.exe`: 10/11 PASS — the remaining `diagnostic_messages 0 — turn_phase rejection includes from/to labels` failure is **unrelated** (the test asserts `validate_turn_phase_transition` rejects `Turn_routing -> Turn_exhausted`, but the current rule at line 1461 admits that pair as `true`; that drift is a separate pre-existing main issue, out of scope for this PR)

## Out-of-scope follow-up

The `turn_phase rejection` test failure is a separate code/test drift introduced by an earlier PR that flipped `Turn_routing -> Turn_exhausted` from rejected to admitted without updating the test. Suggest a follow-up to either restore the rejection rule or update the test to the new admitted-pair semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)