### PR TITLE
fix(keeper_registry): unblock main — exhaust validate_decision_transition

### DIFF
--- a/lib/keeper/keeper_registry.ml
+++ b/lib/keeper/keeper_registry.ml
@@ -422,6 +422,17 @@ let validate_decision_transition
   | Packed Decision_tool_policy_selected, Packed Decision_tool_policy_selected -> ()
   | Packed Decision_tool_policy_selected, Packed Decision_guard_ok -> ()
   | Packed Decision_tool_policy_selected, Packed Decision_gate_rejected -> ()
+  (* GADT existential erasure: [to_packed] is built from
+     [decision_stage_active_to_packed to_] where [to_ : decision_stage_active]
+     excludes [Decision_undecided] at the type level. After packing the
+     witness type is erased, so the compiler must see the
+     [<x>, Decision_undecided] arms explicitly. Reaching any of these is
+     a type-system violation, not a runtime case. *)
+  | Packed Decision_undecided, Packed Decision_undecided
+  | Packed Decision_guard_ok, Packed Decision_undecided
+  | Packed Decision_gate_rejected, Packed Decision_undecided
+  | Packed Decision_tool_policy_selected, Packed Decision_undecided ->
+      assert false
 ;;
 
 type cascade_state =


### PR DESCRIPTION
## 목적

origin/main 의 \`dune build --root .\` 가 깨져 있는 상태를 해소. RFC-0072 Phase 1 (#14903, commit \`b2b126e90\`) 이후 \`lib/keeper/keeper_registry.ml:412-424\` 에 warning 8 (partial-match) 에러가 존재.

## 영향

이 에러는 *전체 빌드*를 막아 다음 PR 들의 CI red 의 원인:
- #14878 (keeper_unified_turn audit)
- #14879 (TLA correspondence smoke)
- #14880 (RFC-0072 provider_adapter)
- #14881 (RFC-0071 codemod RFC)
- #14884 (Set_util)

각 PR 의 *진짜* 변경분은 clean 빌드되나, main baseline 이 broken 이라 CI 가 downstream failure 표시.

## 원인

\`validate_decision_transition\` 의 match:

\`\`\`ocaml
let validate_decision_transition
    ~(from : decision_stage)
    ~(to_ : decision_stage_active)
  =
  let from_packed = stage_to_witness from in
  let to_packed = decision_stage_active_to_packed to_ in
  match from_packed, to_packed with
  | Packed Decision_undecided, Packed Decision_guard_ok -> ()
  ...
\`\`\`

\`to_ : decision_stage_active\` 는 *타입 레벨에서* \`Decision_undecided\` 를 배제. 그러나 \`decision_stage_active_to_packed\` 가 \`packed_decision_stage\` 로 wrap 하는 순간 GADT existential 의 타입 정보가 소거됨. 컴파일러는 packed level 에서 \`(_, Packed Decision_undecided)\` 가 가능하다고 보고 warning 8 발화.

## Fix

4개 unreachable arm 명시 (`<x>, Packed Decision_undecided` × 4):

\`\`\`ocaml
| Packed Decision_undecided, Packed Decision_undecided
| Packed Decision_guard_ok, Packed Decision_undecided
| Packed Decision_gate_rejected, Packed Decision_undecided
| Packed Decision_tool_policy_selected, Packed Decision_undecided ->
    assert false
\`\`\`

주석으로 GADT erasure 메커니즘 설명. 이 arm 에 도달 = 타입 시스템 위반 (런타임 케이스 아님).

## 검증

| 명령 | Before | After |
|------|--------|-------|
| \`dune build --root .\` | warning 8 error | clean |
| \`dune runtest test/test_keeper_registry.ml\` | (빌드 실패로 미실행) | 77/77 green |

## Diff

1 파일, +11/-0. 변경 없음 (assert false 4 arms + 6 lines 주석).