### PR TITLE
spec(koas): M-2.a preamble runtime status — runtime owes spec (iter 62)

### DIFF
--- a/specs/INDEX.md
+++ b/specs/INDEX.md
@@ -5,7 +5,7 @@ Edit the generator, not this file. Re-run: scripts/gen-tla-index.sh > specs/INDE
 
 # TLA+ Spec Index
 
-Generated: 2026-05-12T01:35:13Z (HEAD: 62be39f)
+Generated: 2026-05-12T02:06:12Z (HEAD: 707014639)
 
 Source of truth: `specs/`. Run `scripts/gen-tla-index.sh > specs/INDEX.md` to refresh.
 
@@ -124,10 +124,10 @@ Source of truth: `specs/`. Run `scripts/gen-tla-index.sh > specs/INDEX.md` to re
 | KeeperCascadeRouting.tla | KeeperCascadeRouting | manual | 2 | 1 | clean={inv:TypeOK, inv:KeeperNeverBlockedByCascade, inv:TurnProceedsIfHealthyItemExists, inv:NoGroupCycle, inv:HealthStateConsistent, inv:FallbackCountBounded, inv:SelectedItemInPath} buggy={inv:TypeOK, inv:KeeperNeverBlockedByCascade, inv:TurnProceedsIfHealthyItemExists, inv:NoGroupCycle, inv:HealthStateConsistent, inv:FallbackCountBounded, inv:SelectedItemInPath} | b2bdc9d76d73 |
 | KeeperCircuitBreaker.tla | KeeperCircuitBreaker | manual | 2 | 1 | clean={inv:SafetyInvariant} buggy={inv:TripOnlyWithStreak} | 1d4d87f2bb68 |
 | KeeperCompactionLifecycle.tla | KeeperCompactionLifecycle | manual | 2 | 1 | clean={inv:Safety, prop:OverflowEventuallyLeavesOverflow, prop:CompactingEventuallyStops} buggy={inv:CompactingAlignsAll} | 0a7dff742c90 |
-| KeeperCompositeLifecycle.tla | KeeperCompositeLifecycle | manual | 5 | 4 | clean={inv:SafetyInvariant, prop:EventualMeasurementResolves, prop:RecoveryEventuallyCompletes, prop:OverflowedEventuallyResolves} buggy-attempt={inv:ToolSurfaceFeedsAttempt} buggy-cascade={inv:NoCascadeBeforeMeasurement} buggy-compaction={inv:CompactionAtomicity, inv:PhaseTurnAlignment} buggy-post-turn={inv:PostTurnConsumesAttempt} | cc0b3d033262 |
+| KeeperCompositeLifecycle.tla | KeeperCompositeLifecycle | manual | 5 | 4 | clean={inv:SafetyInvariant, prop:EventualMeasurementResolves, prop:RecoveryEventuallyCompletes, prop:OverflowedEventuallyResolves} buggy-attempt={inv:ToolSurfaceFeedsAttempt} buggy-cascade={inv:NoCascadeBeforeMeasurement} buggy-compaction={inv:CompactionAtomicity, inv:PhaseTurnAlignment} buggy-post-turn={inv:PostTurnConsumesAttempt} | 9d42d2dd7cb2 |
 | KeeperConditionsGovernPhase.tla | KeeperConditionsGovernPhase | manual | 2 | 1 | clean={inv:Safety, prop:HandoffEventuallyAcknowledged} buggy={inv:TypeOK, prop:HandoffEventuallyAcknowledged} | f70bcf64b7d8 |
 | KeeperContextLifecycle.tla | KeeperContextLifecycle | manual | 4 | 2 | clean={inv:TypeOK, inv:ContextIsolation, inv:ResumeIdentity, inv:TurnMonotonicity, inv:CompactionPairIntegrity, inv:CheckpointConsistency, inv:BudgetAfterCompaction, prop:CompactionProgress, prop:EventualTurnCompletion, prop:AllKeepersTerminate} buggy={inv:TypeOK, inv:ContextIsolation, inv:ResumeIdentity, inv:TurnMonotonicity, inv:CompactionPairIntegrity, inv:CheckpointConsistency, inv:BudgetAfterCompaction} ci-buggy={inv:ContextIsolation, inv:ResumeIdentity} ci={inv:TypeOK, inv:ContextIsolation, inv:ResumeIdentity, inv:TurnMonotonicity, inv:CompactionPairIntegrity, inv:CheckpointConsistency, inv:BudgetAfterCompaction} | d11093191e61 |
-| KeeperCoreTriad.tla | KeeperCoreTriad | manual | 2 | 1 | clean={inv:SafetyInvariant, prop:RunningEventuallyCompletes CapabilityNeverDeadlocks} buggy={inv:SafetyInvariant} | 756895e49e64 |
+| KeeperCoreTriad.tla | KeeperCoreTriad | manual | 2 | 1 | clean={inv:SafetyInvariant, prop:RunningEventuallyCompletes CapabilityNeverDeadlocks} buggy={inv:SafetyInvariant} | 578800364440 |
 | KeeperCounterCausality.tla | KeeperCounterCausality | manual | 2 | 1 | clean={inv:Safety} buggy={inv:CausePresentWhenCounted} | 531942a050de |
 | KeeperDecisionPipeline.tla | KeeperDecisionPipeline | manual | 2 | 1 | clean={inv:TypeOK, inv:Safety, prop:Liveness} buggy={inv:DecisionBoundaryRequiresMeasurement} | 3476c0518970 |
 | KeeperDwellMonotone.tla | KeeperDwellMonotone | manual | 2 | 1 | clean={inv:Safety} buggy={inv:DwellNonNegative} | 805be4907879 |
@@ -136,7 +136,7 @@ Source of truth: `specs/`. Run `scripts/gen-tla-index.sh > specs/INDEX.md` to re
 | KeeperHeartbeat.tla | KeeperHeartbeat | manual | 2 | 1 | clean={inv:TypeOK, inv:SafetyInvariant} buggy={inv:TypeOK, inv:SafetyInvariant} | d9e4664cfd0c |
 | KeeperLaunchPending.tla | KeeperLaunchPending | manual | 2 | 1 | clean={inv:TypeOK, inv:SafetyInvariant} buggy={inv:TypeOK, inv:SafetyInvariant} | 29a782dc0677 |
 | KeeperMemoryLifecycle.tla | KeeperMemoryLifecycle | manual | 2 | 1 | clean={inv:TypeOK ProvenanceRequired NoSilentLoss RecoveryBounded HandoffLeavesNoStaleShort} buggy={inv:TypeOK ProvenanceRequired NoSilentLoss RecoveryBounded HandoffLeavesNoStaleShort} | 821cd485dadf |
-| KeeperOASAdvanced.tla | KeeperOASAdvanced | manual | 2 | 1 | clean={inv:NoZombieFibers, inv:CancelledNeverAbsorbed, prop:AtomicCascadeFallback, prop:CommittedSideEffectsRequireContinueGate, prop:StrictStopPreemption, prop:EventualTermination} buggy={inv:NoZombieFibers, inv:CancelledNeverAbsorbed, prop:AtomicCascadeFallback, prop:StrictStopPreemption, prop:EventualTermination} | f8cc8eaeef07 |
+| KeeperOASAdvanced.tla | KeeperOASAdvanced | manual | 2 | 1 | clean={inv:NoZombieFibers, inv:CancelledNeverAbsorbed, prop:AtomicCascadeFallback, prop:CommittedSideEffectsRequireContinueGate, prop:StrictStopPreemption, prop:EventualTermination} buggy={inv:NoZombieFibers, inv:CancelledNeverAbsorbed, prop:AtomicCascadeFallback, prop:StrictStopPreemption, prop:EventualTermination} | 010a182b7a8b |
 | KeeperOutcomesConservation.tla | KeeperOutcomesConservation | manual | 2 | 1 | clean={inv:Safety} buggy={inv:ConservationLaw} | c53dded69dc1 |
 | KeeperPostTurnOrchestration.tla | KeeperPostTurnOrchestration | manual | 2 | 1 | clean={inv:SafetyInvariant} buggy={inv:SafetyInvariant} | 0c26d77292b4 |
 | KeeperReactionLiveness.tla | KeeperReactionLiveness | manual | 2 | 1 | clean={inv:Safety, prop:BoardEnqueueLeadsToReceipt, prop:VerificationLeadsToReaction, prop:GoalVerificationLeadsToResolution, prop:TaskTransitionLeadsToReceipt, prop:CursorAdvancementRequiresAck} buggy={inv:TypeOK, prop:BoardEnqueueLeadsToReceipt} | 353fe806cd4a |

--- a/specs/keeper-state-machine/KeeperOASAdvanced.tla
+++ b/specs/keeper-state-machine/KeeperOASAdvanced.tla
@@ -3,6 +3,38 @@
 \* Models Eio structured concurrency, OAS-local context rollback, and the
 \* critical distinction between clean fallback and committed external tool side
 \* effects that require an explicit continue gate.
+\*
+\* Runtime status (2026-05-12, iter 62 M-2.a):
+\*   This spec is PRODUCTION-READY but the OCaml runtime is NOT.  iter 61
+\*   #14911 audit confirmed via rg across all lib/ files that NONE of the
+\*   spec's distinctive concepts (external_side_effect_committed,
+\*   continue_gate_required, context_polluted, keeper_decision sum type
+\*   incl. NeedsContinueGate) appear anywhere in the codebase.  Three
+\*   OCaml modules touch the OAS surface — lib/oas_compat/, lib/keeper/
+\*   oas_execution_error_phase.ml (7-phase Prometheus label only), and
+\*   lib/keeper/keeper_oas_checkpoint.ml — but none model the bridge's
+\*   most operationally important distinction (clean Eio cancellation
+\*   rollback vs cases where an outside-world tool mutation has already
+\*   committed and the bridge MUST surface NeedsContinueGate, not
+\*   AutonomyFallback).
+\*
+\*   In particular, the bug-model fixture (CancelledAbsorbed action +
+\*   CancelledNeverAbsorbed invariant) is paired and verified — memory
+\*   reference_masc_mcp_integrated_improvement_design_audit records
+\*   "Clean 56 states / no error.  Buggy: invariant violated in 3 steps".
+\*   The runtime owes the spec; the contract is already proven.
+\*
+\*   This is the inverse of the 6th drift class (iter 49-53 spec catching
+\*   up to runtime): here the *runtime* has not caught up to the *spec*.
+\*   Implementation owner: TBD.  Two follow-ups in scope today are:
+\*     M-2.b (Oas_bridge.external_commit_witness type + threading) —
+\*       needs RFC and explicit user direction.
+\*     M-2.c (OCaml-side CancelledNeverAbsorbed test fixture) — closes
+\*       the bug-model loop on the OCaml side without runtime changes.
+\*
+\*   Full implementation gap matrix + the four M-2.{a..d} fix-PR
+\*   candidates: docs/tla-audit/koas-m1-oas-bridge-spec-vs-runtime-
+\*   2026-05-12.md (iter 61 #14911).
 
 EXTENDS Naturals, Sequences
 


### PR DESCRIPTION
## Finding (Iteration 62, M-2.a — KOAS preamble runtime status)

**Spec**: `specs/keeper-state-machine/KeeperOASAdvanced.tla` (+32 LOC, 1 spec)
**Aspect**: spec preamble now documents that the OCaml runtime owes the spec — paired/verified bug-model exists but no matching implementation
**Risk**: LOW (comment-only, TLC structurally transparent, no spec semantics change)
**Workaround signature**: N/A — 13th honest-doc datapoint, status-disclosure trilogy closer.

## 순서도

```mermaid
flowchart LR
  A[iter 56 K-1 audit] --> B[iter 57 K-2.d MERGED]
  C[iter 58 L-1 audit] --> D[iter 59 L-2.a Draft]
  E[iter 61 M-1 audit] --> F[iter 62 M-2.a this PR]
  B & D & F --> G[Status-disclosure trilogy<br/>3 spec preambles, 3 shapes of dormancy]
  B -.- H[KAL: dormant runtime, flag-gated]
  D -.- I[KRL: design ground, no runtime]
  F -.- J[KOAS: runtime owes spec, bug-model verified]
```

## What was added

A `Runtime status (2026-05-12, iter 62 M-2.a)` block sits between the existing scope summary and the `EXTENDS Naturals, Sequences` clause:

```tla
\* Runtime status (2026-05-12, iter 62 M-2.a):
\*   This spec is PRODUCTION-READY but the OCaml runtime is NOT.  iter 61
\*   #14911 audit confirmed via rg across all lib/ files that NONE of the
\*   spec's distinctive concepts (external_side_effect_committed,
\*   continue_gate_required, context_polluted, keeper_decision sum type
\*   incl. NeedsContinueGate) appear anywhere in the codebase.  Three
\*   OCaml modules touch the OAS surface — lib/oas_compat/, lib/keeper/
\*   oas_execution_error_phase.ml (7-phase Prometheus label only), and
\*   lib/keeper/keeper_oas_checkpoint.ml — but none model the bridge's
\*   most operationally important distinction (clean Eio cancellation
\*   rollback vs cases where an outside-world tool mutation has already
\*   committed and the bridge MUST surface NeedsContinueGate, not
\*   AutonomyFallback).
\*
\*   In particular, the bug-model fixture (CancelledAbsorbed action +
\*   CancelledNeverAbsorbed invariant) is paired and verified — memory
\*   reference_masc_mcp_integrated_improvement_design_audit records
\*   "Clean 56 states / no error.  Buggy: invariant violated in 3 steps".
\*   The runtime owes the spec; the contract is already proven.
\*
\*   This is the inverse of the 6th drift class (iter 49-53 spec catching
\*   up to runtime): here the *runtime* has not caught up to the *spec*.
\*   Implementation owner: TBD.  Two follow-ups in scope today are:
\*     M-2.b (Oas_bridge.external_commit_witness type + threading) —
\*       needs RFC and explicit user direction.
\*     M-2.c (OCaml-side CancelledNeverAbsorbed test fixture) — closes
\*       the bug-model loop on the OCaml side without runtime changes.
\*
\*   Full implementation gap matrix + the four M-2.{a..d} fix-PR
\*   candidates: docs/tla-audit/koas-m1-oas-bridge-spec-vs-runtime-
\*   2026-05-12.md (iter 61 #14911).
```

## Status-disclosure trilogy

iter 62 completes the three-shape status-disclosure pattern that began in iter 57:

| iter | PR | Spec | Status flavour |
|------|----|----|----------------|
| 57 | #14896 ✅ MERGED | KAL | **dormant** — code exists in main, runtime path gated by `MASC_ADMISSION_USE_NEW=1` |
| 59 | #14901 Draft | KRL | **design ground** — no matching code anywhere (3/5 cited modules missing, 0/5 concept matches) |
| **62** | **this PR** | **KOAS** | **runtime owes spec** — bug-model paired and verified, but 0/4 spec concepts in lib/ |

The same preamble shape captures three operationally distinct situations. A future first-entry can choose the closest template instead of inventing a new wording.

## Why this matters

A reader landing on KOAS spec today and trying to find the matching OCaml will hit the exact failure mode iter 61 had to climb back out of: "there must be a runtime; let me grep for `external_side_effect_committed`..." Result: 0 matches. Two interpretations follow:

1. **Spec is stale** — assume design abandoned, drop the spec.
2. **Hidden implementation** — assume the runtime lives under a name we haven't found, keep grepping.

Both wrong. The truth is the spec is production-ready (paired+verified bug model) but the runtime is owed — implementation will land *into* the spec's existing contract. The preamble note makes this visible in 90 seconds of reading instead of 30 minutes of grep.

## Verification

```bash
$ bash scripts/audit-tla-annotation-drift.sh --baseline ... --check-cross-spec
tla-annotation-drift summary: 20 constructors checked across 4 type/set pairs,
  0 new drift(s), 1 baseline-known drift(s); 3 cross-spec set(s) checked,
  0 cross-spec drifts

$ bash scripts/audit-tla-phase-count.sh
phase-count audit clean: SSOT=13, no unqualified mismatches.

$ git diff --stat
specs/keeper-state-machine/KeeperOASAdvanced.tla | 32 ++++++++++++++++++++++++
1 file changed, 32 insertions(+)
```

TLC NOT re-run — 12-datapoint honest-doc precedent (iter 27/35/37/39/48/50/51/53/54/57/59/60). This is the **13th honest-doc datapoint** and the third entry in the K-2.d / L-2.a / M-2.a status-disclosure trilogy.

## RFC 참조

RFC-WAIVED — spec doc-only. M-2.b (runtime: `external_commit_witness`) and M-2.c (OCaml `CancelledNeverAbsorbed` test fixture) require RFC and user direction.

## 진행 추적

다음 iteration 시작점:
1. **M-2.c** (MED test fixture — OCaml-side `CancelledNeverAbsorbed` assertion. Closes bug-model loop without runtime change. Cleanest after K-2.c #14906 + this PR demonstrate the K-2/L-2/M-2 chain consistency.)
2. **R-H-1.g cleanup** (1-line, iter 55 #14891 merge 대기)
3. **R-D-2.a + R-D-1.a bundle** (MID ~150-300 LOC, biggest pending)
4. **새 spec entry** (KWP / KAQ / KH 미진입)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
