### PR TITLE
feat(cascade): RFC-0058 Phase 5.3a — drop 4 hardcoded provider-name thin wrappers

### DIFF
--- a/lib/cascade/cascade_model_resolve.ml
+++ b/lib/cascade/cascade_model_resolve.ml
@@ -91,22 +91,6 @@ let default_resolution ?getenv provider_name ~requested_model_id =
 let glm_auto_models = Llm_provider.Zai_catalog.glm_auto_models
 let glm_coding_auto_models = Llm_provider.Zai_catalog.glm_coding_auto_models
 
-let gemini_cli_auto_models () =
-  Provider_adapter.auto_models_for_cascade_prefix "gemini_cli"
-  |> Option.value ~default:[]
-
-let codex_cli_auto_models () =
-  Provider_adapter.auto_models_for_cascade_prefix "codex_cli"
-  |> Option.value ~default:[]
-
-let claude_code_auto_models () =
-  Provider_adapter.auto_models_for_cascade_prefix "claude_code"
-  |> Option.value ~default:[]
-
-let kimi_cli_auto_models () =
-  Provider_adapter.auto_models_for_cascade_prefix "kimi_cli"
-  |> Option.value ~default:[]
-
 let resolve_glm_model ?getenv selector =
   let model_id = match selector with Concrete s -> s | Auto -> "auto" in
   let default_model = default_resolution ?getenv "glm" ~requested_model_id:model_id in

--- a/lib/cascade/cascade_model_resolve.mli
+++ b/lib/cascade/cascade_model_resolve.mli
@@ -14,28 +14,17 @@
 val glm_auto_models : unit -> string list
 val glm_coding_auto_models : unit -> string list
 
-(** Ordered Gemini CLI candidates for [gemini_cli:auto].
-    Configurable via [MASC_GEMINI_CLI_AUTO_MODELS] (comma-separated).
-    When unset, [GEMINI_DEFAULT_MODEL] narrows the list to that single
-    model for backward-compatible explicit override semantics. *)
-val gemini_cli_auto_models : unit -> string list
+(** {2 Removed in RFC-0058 Phase 5.3a}
 
-(** Ordered Codex CLI candidates for [codex_cli:auto].
-    Configurable via [MASC_CODEX_CLI_AUTO_MODELS] (comma-separated).
-    Defaults to a light-to-heavy generation order (5.1 -> 5.4),
-    including mini/spark variants. *)
-val codex_cli_auto_models : unit -> string list
-
-(** Ordered Claude Code candidates for [claude_code:auto].
-    Configurable via [MASC_CLAUDE_CODE_AUTO_MODELS] (comma-separated).
-    Defaults to [["auto"]] so the user's Claude Code default remains in
-    control unless an operator opts into model rotation. *)
-val claude_code_auto_models : unit -> string list
-
-(** Ordered Kimi CLI candidates for [kimi_cli:auto].
-    Configurable via [MASC_KIMI_CLI_AUTO_MODELS] (comma-separated).
-    Defaults to [["kimi-for-coding"]]. *)
-val kimi_cli_auto_models : unit -> string list
+    The per-provider [gemini_cli_auto_models], [codex_cli_auto_models],
+    [claude_code_auto_models], and [kimi_cli_auto_models] thin wrappers
+    have been deleted. They were unused in production — every routing
+    call went through {!Provider_adapter.auto_models_for_cascade_prefix}
+    directly. Hardcoded provider names were a §2.4 "code knows provider
+    names" violation. Callers that need a specific provider's auto list
+    use the generic API; per-provider env-override behaviour
+    ([MASC_<PROVIDER>_AUTO_MODELS]) remains intact and is now exercised
+    against the generic path in [test/test_cascade_model_resolve.ml]. *)
 
 type model_selector = Concrete of string | Auto
 

--- a/test/test_cascade_model_resolve.ml
+++ b/test/test_cascade_model_resolve.ml
@@ -12,6 +12,15 @@ module R = Masc_mcp.Cascade_model_resolve
 module C = Masc_mcp.Cascade_config
 module State = Masc_mcp.Cascade_state
 module H = Masc_mcp.Cascade_health_tracker
+module PA = Masc_mcp.Provider_adapter
+
+(* RFC-0058 Phase 5.3a — the per-provider thin wrappers
+   ([gemini_cli_auto_models], etc.) were deleted because they were unused
+   in production. Tests now exercise the generic
+   [Provider_adapter.auto_models_for_cascade_prefix] entry point directly;
+   the provider id is the test's pin, not a production literal. *)
+let auto_models_for pid =
+  PA.auto_models_for_cascade_prefix pid |> Option.value ~default:[]
 
 let unset_env k =
   try Unix.putenv k "" with _ -> ()
@@ -88,12 +97,12 @@ let test_gemini_cli_auto_models_default_rotation_order () =
         "gemini-3.1-flash-lite-preview";
         "gemini-3.1-pro-preview";
       ]
-      (R.gemini_cli_auto_models ()))
+      (auto_models_for "gemini_cli"))
 
 let test_gemini_cli_auto_models_env_override () =
   Unix.putenv "MASC_GEMINI_CLI_AUTO_MODELS"
     "gemini-a, gemini-b,, gemini-c ";
-  let models = R.gemini_cli_auto_models () in
+  let models = auto_models_for "gemini_cli" in
   Unix.putenv "MASC_GEMINI_CLI_AUTO_MODELS" "";
   check (list string) "operator override trims blanks"
     [ "gemini-a"; "gemini-b"; "gemini-c" ] models
@@ -109,13 +118,13 @@ let test_codex_and_claude_cli_auto_models_env_override () =
         "gpt-5.4";
         "gpt-5.5";
       ]
-      (R.codex_cli_auto_models ());
+      (auto_models_for "codex_cli");
     check (list string) "claude default delegates to CLI"
-      [ "auto" ] (R.claude_code_auto_models ());
+      [ "auto" ] (auto_models_for "claude_code");
     Unix.putenv "MASC_CODEX_CLI_AUTO_MODELS" "gpt-a,gpt-b";
     Unix.putenv "MASC_CLAUDE_CODE_AUTO_MODELS" "sonnet,opus";
-    let codex = R.codex_cli_auto_models () in
-    let claude = R.claude_code_auto_models () in
+    let codex = auto_models_for "codex_cli" in
+    let claude = auto_models_for "claude_code" in
     Unix.putenv "MASC_CODEX_CLI_AUTO_MODELS" "";
     Unix.putenv "MASC_CLAUDE_CODE_AUTO_MODELS" "";
     check (list string) "codex operator rotation"
@@ -130,9 +139,9 @@ let test_kimi_cli_auto_model_policy () =
       (R.resolve_auto_model_id "kimi_cli" "auto");
     check (list string) "kimi_cli:auto expands to declared default"
       [ "kimi-for-coding" ]
-      (R.kimi_cli_auto_models ());
+      (auto_models_for "kimi_cli");
     Unix.putenv "MASC_KIMI_CLI_AUTO_MODELS" "kimi-a,kimi-b";
-    let models = R.kimi_cli_auto_models () in
+    let models = auto_models_for "kimi_cli" in
     Unix.putenv "MASC_KIMI_CLI_AUTO_MODELS" "";
     check (list string) "kimi cli operator rotation"
       [ "kimi-a"; "kimi-b" ] models)


### PR DESCRIPTION
## Summary

RFC-0058 Phase 5.3a — drop the 4 hardcoded provider-name thin wrappers in
`lib/cascade/cascade_model_resolve.{ml,mli}`. They existed only as test
fixtures (zero production callers, verified with `rg`); their env-override
behaviour lives in `Provider_adapter.auto_models_for_cascade_prefix`, not in
the wrappers. Removing them changes no runtime behaviour and shrinks the §2.4
"code knows provider names" surface monotonically.

Smallest possible first step of Phase 5.3. The larger work (per-provider
record list in `provider_adapter.ml`, the `cascade_prefix` field itself)
lands in 5.3b... — those PRs touch 56 callers and need separate sequencing.

## What changed

| File | Change |
|------|--------|
| `lib/cascade/cascade_model_resolve.ml` | Delete 4 thin wrappers (`gemini_cli_auto_models`, `codex_cli_auto_models`, `claude_code_auto_models`, `kimi_cli_auto_models`) |
| `lib/cascade/cascade_model_resolve.mli` | Drop 4 `val`s; replace doc block with a "Removed in Phase 5.3a" note pointing readers at the generic API |
| `test/test_cascade_model_resolve.ml` | Add `auto_models_for pid` helper that calls `Provider_adapter.auto_models_for_cascade_prefix`; 4 call sites updated. Provider id is the test's pin, not a production literal |

## G2 (RFC §5) — monotonic shrink

```
$ git show origin/main:lib/cascade/cascade_model_resolve.ml \
    | rg '"claude_code"|"codex_cli"|"kimi_cli"|"gemini_cli"|"glm-coding"' | wc -l
5

$ rg '"claude_code"|"codex_cli"|"kimi_cli"|"gemini_cli"|"glm-coding"' \
    lib/cascade/cascade_model_resolve.ml | wc -l
1
```

The remaining `1` is `resolve_kimi_model`'s `"kimi-for-coding"` literal,
which is a model-id alias (not a provider name) — out of scope for §2.4.

## Verification

```
$ MASC_SKIP_PIN_CHECK=1 scripts/dune-local.sh build --root . @check
(silent — pass)

$ _build/default/test/test_cascade_model_resolve.exe
1 failure! in 0.003s. 18 tests run.
```

The one failure is `test_order_weighted_entries_rotation_scope_rotates_top_level_providers`
— **pre-existing on `origin/main`**, verified by stashing this PR's changes
and re-running on a clean baseline (same failure). Unrelated to provider-name
erasure and out of scope.

## RFC reference

- RFC-0058 §2.4 (code never knows provider names)
- RFC-0058 Phase 5 §4.3 ("Erase `cascade_prefix` literals from `provider_adapter`")
- Phase 5.3 acceptance G2 ("zero hardcoded provider-name literals under `lib/` once 5.3 lands")

## Notes

- `Provider_adapter.auto_models_for_cascade_prefix` still takes a string
  provider id — that's the signature 5.3b will tackle. Surfacing it in the
  tests (which must pin to specific providers anyway) makes the boundary
  explicit instead of buried inside `cascade_model_resolve.ml`.
- An earlier revision of this branch carried a `keeper_registry.ml` warning-8
  fix; it has been rebased away — `#14912` (RFC-0072 Phase 4a) already landed
  the same fix upstream. This PR is now scoped purely to the four wrappers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
