### PR TITLE
fix(run_eio): bound read_logs ~limit to O(n) memory via Queue ring buffer

### DIFF
--- a/lib/run_eio.ml
+++ b/lib/run_eio.ml
@@ -209,12 +209,26 @@ let set_deliverable config ~task_id ~content : (run_record, string) result =
   | Eio.Cancel.Cancelled _ as e -> raise e
   | e -> Error (Printexc.to_string e)
 
-(** Read logs (optionally tail N) *)
+(** Read logs (optionally tail N).
+
+    When [limit] is given the fold drives a bounded [Queue.t] sized to
+    [n] (drop-oldest on overflow), so peak live memory is O(n) instead
+    of O(file_line_count) and the post-fold [List.length] / [mapi] /
+    [filter] / [map snd] trim chain is gone.
+
+    Same ring-buffer pattern as
+    [institution_eio.load_recent_episodes_jsonl] (PR #14873) and
+    [Log.Ring.load_from_file] (PR #14904 after Copilot review): for
+    tail-N over an unbounded append-only JSONL the streaming fold
+    should *also* be the trim, otherwise the win from
+    [Fs_compat.fold_jsonl_lines] is canceled by a downstream list
+    materialisation. *)
 let read_logs config ~task_id ?limit () : log_entry list =
   let file = log_path config task_id in
   if not (Sys.file_exists file) then []
   else
-    let entries =
+    match limit with
+    | None ->
       Fs_compat.fold_jsonl_lines
         ~init:[]
         ~f:(fun acc ~line_no:_ j ->
@@ -223,15 +237,19 @@ let read_logs config ~task_id ?limit () : log_entry list =
           | None -> acc)
         file
       |> List.rev
-    in
-    match limit with
-    | None -> entries
+    | Some n when n <= 0 -> []
     | Some n ->
-        let total = List.length entries in
-        if total <= n then entries else
-          let start = total - n in
-          entries |> List.mapi (fun i e -> (i, e)) |> List.filter (fun (i, _) -> i >= start)
-          |> List.map snd
+      let ring : log_entry Queue.t = Queue.create () in
+      Fs_compat.fold_jsonl_lines
+        ~init:()
+        ~f:(fun () ~line_no:_ j ->
+          match log_entry_of_json j with
+          | None -> ()
+          | Some e ->
+            Queue.add e ring;
+            if Queue.length ring > n then ignore (Queue.pop ring))
+        file;
+      List.of_seq (Queue.to_seq ring)
 
 (** Get run details *)
 let get config ~task_id : (Yojson.Safe.t, string) result =


### PR DESCRIPTION
## Summary

Apply the same fix Copilot caught in #14904 (`masc_log/log.ml:361`) to `lib/run_eio.ml:read_logs ~limit`.

### Before

Streaming fold into a full list, then post-fold trim via `List.length` / `List.mapi` / `List.filter` / `List.map snd`. **Peak memory O(file_line_count)** even when `limit=10`. The win from `Fs_compat.fold_jsonl_lines` was canceled by the downstream list materialisation.

```ocaml
let entries = fold_jsonl_lines ... |> List.rev in
match limit with
| None -> entries
| Some n ->
    let total = List.length entries in
    if total <= n then entries
    else
      let start = total - n in
      entries |> List.mapi ... |> List.filter ... |> List.map snd
```

### After

When `limit` is given, drive the fold directly into a bounded `Queue.t` sized to `n` (drop-oldest on overflow). **Peak memory O(n)**.

```ocaml
| Some n ->
  let ring : log_entry Queue.t = Queue.create () in
  Fs_compat.fold_jsonl_lines ~init:() ~f:(fun () ~line_no:_ j ->
    match log_entry_of_json j with
    | None -> ()
    | Some e ->
      Queue.add e ring;
      if Queue.length ring > n then ignore (Queue.pop ring))
    file;
  List.of_seq (Queue.to_seq ring)
```

### General principle

Codified by the Copilot review on #14904: **for tail-N over an unbounded append-only JSONL, the streaming fold should *also* be the trim** — otherwise the win from `Fs_compat.fold_jsonl_lines` is canceled by a downstream list materialisation.

This is the 5th adoption of the ring-buffer-as-fold pattern in the codebase:

| # | Site | PR |
|---|---|---|
| 1 | `institution_eio.load_recent_episodes_jsonl` | #14873 |
| 2 | `institution_eio.cap_episodes_jsonl` | #14873 |
| 3 | `operator_control_snapshot.recent_actions_json` | #14873 |
| 4 | `masc_log.Log.Ring.load_from_file` | #14904 |
| 5 | `run_eio.read_logs ~limit` | **this PR** |

### Edge case

Added `Some n when n <= 0 -> []` short-circuit before opening the file. Previously a `limit:0` call would run the full fold then return an empty filter result, doing the IO for nothing.

## Test plan

- [x] `dune build --root . @check`: clean
- [x] `_build/default/test/test_run_eio_coverage.exe`: **33/33 PASS**
  - `eio_logs 0-3` (append / read / read-multiple / **read-limit**): PASS
  - `json_edge_cases 2-3` (missing field / invalid JSON): PASS
  - `error_paths 2` (read logs nonexistent): PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)