### PR TITLE
refactor(operator): json_ok → Tool_args.ok_assoc alias (T33, Tier C closeout)

### DIFF
--- a/lib/operator/operator_control_snapshot.ml
+++ b/lib/operator/operator_control_snapshot.ml
@@ -190,7 +190,7 @@ type action_log_entry =
   ; created_at : string
   }
 
-let json_ok fields = `Assoc (("status", `String "ok") :: fields)
+let json_ok = Tool_args.ok_assoc
 
 let get_payload args =
   match U.member "payload" args with

--- a/lib/operator/operator_control_snapshot.mli
+++ b/lib/operator/operator_control_snapshot.mli
@@ -195,10 +195,10 @@ val append_action_log :
     cascade-include of this module. *)
 
 val json_ok : (string * Yojson.Safe.t) list -> Yojson.Safe.t
-(** Builds [`Assoc] envelope with a leading
-    [("status", "ok")] field followed by [fields].  Pinned
-    because {!Operator_control} reaches it via the
-    cascade-include of this module. *)
+(** Alias for {!Tool_args.ok_assoc}.  Kept here because
+    {!Operator_control} consumes it via the cascade-include of this
+    module; new code in [lib/operator/] should call
+    {!Tool_args.ok_assoc} directly. *)
 
 val remote_client_type_of_context : 'a context -> string
 (** Classifies the [mcp_session_id] of an operator

--- a/scripts/lint/no-inline-ok-envelope.sh
+++ b/scripts/lint/no-inline-ok-envelope.sh
@@ -41,11 +41,6 @@ ALLOWLIST=(
   # pretty form or normalize.
   "lib/tool_keeper.ml"
 
-  # Tier C: local `json_ok` helper, same sibling-include pattern as
-  # tool_local_runtime_core. Operator subsystem will be migrated in
-  # an independent PR scoped to lib/operator/.
-  "lib/operator/operator_control_snapshot.ml"
-
   # Single-shot health endpoint, no caller chain. De-prioritized — safe
   # to migrate but no test/wire impact.
   "lib/http_server_eio.ml"


### PR DESCRIPTION
## Scope

Sweep §5 envelope SSOT family Tier C closeout. \`operator_control_snapshot.ml\`
의 file-local \`json_ok\` 가 byte-identical 로 \`Tool_args.ok_assoc\` 동작
— T28+T29 (#14882) 이후 SSOT 위에 alias 로 합칠 수 있음.

## 변경

\`\`\`ocaml
(* lib/operator/operator_control_snapshot.ml *)
- let json_ok fields = `Assoc ((\"status\", `String \"ok\") :: fields)
+ let json_ok = Tool_args.ok_assoc
\`\`\`

\`json_ok\` symbol 은 \`.mli\` 에 노출된 채로 유지 — 4 caller
(\`operator_control.ml:675, 703, 795, 836\`) 가 cascade-include 또는
직접 호출하므로 export 신호 보존 필요. T27 의 \`Tool_local_runtime_core\`
alias 패턴과 동일.

\`.mli\` docstring 도 갱신:
- 기존: \"Builds [\`Assoc] envelope with a leading [...] field\"
- 변경: \"Alias for {!Tool_args.ok_assoc}. ... new code in
  [lib/operator/] should call {!Tool_args.ok_assoc} directly.\"

## Lint guard 정리

\`scripts/lint/no-inline-ok-envelope.sh\` 의 Tier C allowlist 엔트리
(\`lib/operator/operator_control_snapshot.ml\`) 삭제. helper 가 alias 로
변환되어 inline literal 가 더 이상 존재하지 않음 — lint 가 자동 통과.

## Wire format

\`Tool_args.ok_assoc fields = \`Assoc ((\"status\", \`String \"ok\") :: fields)\`
- 이전 inline 정의와 정확히 동일 — byte-identical.

## Diff

3 files, +5 / -10 (alias 1줄, mli docstring 5줄, lint 5줄 삭제).

## Build

\`MASC_SKIP_PIN_CHECK=1 bash ./scripts/dune-local.sh build --root . @lib/check\` green.
\`scripts/lint/no-inline-ok-envelope.sh\` green (allowlist 1줄 삭제 후).

## 후속 후보 (T34+)

남은 Tier B/C/temporary allowlist:
- **Tier B (wire-breaking)**: \`dashboard_mission_briefing.ml\` (status 5th field), \`tool_keeper.ml\` (pretty_to_string)
- **Tier C (single-shot)**: \`http_server_eio.ml\` health endpoint
- **Temporary**: \`tool_misc_web_fetch.ml\`, \`tool_misc_web_search.ml\` — T27 (#14876) 머지 후 자동 정리

## Cross-reference

- T27 #14876 — sibling-include alias pattern precedent (\`Tool_local_runtime_core\`)
- T28+T29 #14882 — \`Tool_args.ok_assoc\` SSOT 도입
- CLAUDE.md §워크어라운드 거부 기준 #1 (sprinkle abstraction admit)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>